### PR TITLE
fix(parser): Windows 환경의 CFB 경로 구분자 오류 수정

### DIFF
--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -163,7 +163,7 @@ impl CfbReader {
         let mut names = Vec::new();
         // cfb 크레이트의 walk API로 BinData 하위 항목 탐색
         for entry in self.compound.walk() {
-            let path = entry.path().to_string_lossy().to_string();
+            let path = entry.path().to_string_lossy().replace('\\', "/");
             if path.starts_with("/BinData/") && entry.is_stream() {
                 if let Some(name) = path.strip_prefix("/BinData/") {
                     names.push(name.to_string());
@@ -178,7 +178,7 @@ impl CfbReader {
         let mut paths = Vec::new();
         for entry in self.compound.walk() {
             if entry.is_stream() {
-                paths.push(entry.path().to_string_lossy().to_string());
+                paths.push(entry.path().to_string_lossy().replace('\\', "/"));
             }
         }
         paths
@@ -188,7 +188,7 @@ impl CfbReader {
     pub fn list_all_entries(&self) -> Vec<(String, u64, bool)> {
         let mut entries = Vec::new();
         for entry in self.compound.walk() {
-            let path = entry.path().to_string_lossy().to_string();
+            let path = entry.path().to_string_lossy().replace('\\', "/");
             let size = entry.len();
             let is_stream = entry.is_stream();
             entries.push((path, size, is_stream));


### PR DESCRIPTION
Windows 환경에서 cfb 크레이트 동작 시 발생하는 역슬래시(\) 경로 구분자 문제를 슬래시(/) 단위로 일일이 변경하여 모든 OS 환경에서 일관된 경로를 보장하도록 함.

## 변경 요약

이 PR이 해결하는 문제와 변경 내용을 간결하게 설명해주세요.

## 관련 이슈

closes #

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷

변경 전후 비교가 필요한 경우 첨부해주세요.
