### PR TITLE
fix(hwpx): cap ZIP entry decompression to defeat zip bombs

### DIFF
--- a/src/parser/hwpx/reader.rs
+++ b/src/parser/hwpx/reader.rs
@@ -1,11 +1,49 @@
 //! HWPX ZIP 컨테이너 읽기
 //!
 //! HWPX 파일은 ZIP 아카이브이다. 내부 파일을 읽는 래퍼를 제공한다.
+//!
+//! ## 압축 해제 폭탄 방어
+//!
+//! ZIP은 높은 압축률을 허용하므로, 수 KB짜리 HWPX가 수 GB로 팽창하는
+//! "zip bomb"을 만들 수 있다. 단일 `.xml` 엔트리가 무제한으로 `read_to_end`
+//! 되면 호스트 프로세스를 OOM으로 몰 수 있다.
+//!
+//! [`MAX_XML_SIZE`] / [`MAX_BINDATA_SIZE`] 상한을 적용해 이를 차단한다.
+//! 실제 한국 법령/보도자료 HWPX는 충분히 이 한도 아래에 있다.
 
-use std::io::{Cursor, Read};
+use std::io::{self, Cursor, Read};
 use zip::ZipArchive;
 
 use super::HwpxError;
+
+/// XML 엔트리(section, header, content.hpf 등) 엔트리당 압축 해제 상한.
+///
+/// 실제 정부 보도자료·법령 HWPX에서도 section.xml이 이 한도를 넘는 경우는
+/// 없다. 초과 시 압축 해제 폭탄으로 판단해 차단한다.
+pub const MAX_XML_SIZE: usize = 32 * 1024 * 1024; // 32 MB
+
+/// BinData(이미지·폰트 등) 엔트리당 압축 해제 상한.
+pub const MAX_BINDATA_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+
+/// `reader`에서 최대 `max` 바이트까지 읽는다. 초과 시 `InvalidData` 에러.
+///
+/// `Read::take(max + 1)`을 사용해 오버플로를 감지하되, 버퍼는 실제 읽은
+/// 크기 + 1 이상으로 자라지 않는다.
+fn read_limited<R: Read>(reader: &mut R, max: usize) -> io::Result<Vec<u8>> {
+    let mut buf = Vec::new();
+    let cap = (max as u64).saturating_add(1);
+    reader.take(cap).read_to_end(&mut buf)?;
+    if buf.len() > max {
+        return Err(io::Error::new(
+            io::ErrorKind::InvalidData,
+            format!(
+                "HWPX entry exceeds {} byte limit (possible decompression bomb)",
+                max
+            ),
+        ));
+    }
+    Ok(buf)
+}
 
 /// HWPX ZIP 컨테이너 리더
 pub struct HwpxReader {
@@ -21,27 +59,30 @@ impl HwpxReader {
     }
 
     /// 지정한 경로의 파일을 UTF-8 문자열로 읽는다.
+    ///
+    /// 엔트리 압축 해제 크기는 [`MAX_XML_SIZE`]로 제한된다.
     pub fn read_file(&mut self, path: &str) -> Result<String, HwpxError> {
         let mut file = self.archive.by_name(path).map_err(|e| {
             HwpxError::MissingFile(format!("{}: {}", path, e))
         })?;
-        let mut buf = String::new();
-        file.read_to_string(&mut buf).map_err(|e| {
+        let bytes = read_limited(&mut file, MAX_XML_SIZE).map_err(|e| {
             HwpxError::ZipError(format!("{} 읽기 실패: {}", path, e))
         })?;
-        Ok(buf)
+        String::from_utf8(bytes).map_err(|e| {
+            HwpxError::ZipError(format!("{} UTF-8 변환 실패: {}", path, e))
+        })
     }
 
     /// 지정한 경로의 파일을 바이트 배열로 읽는다.
+    ///
+    /// 엔트리 압축 해제 크기는 [`MAX_BINDATA_SIZE`]로 제한된다.
     pub fn read_file_bytes(&mut self, path: &str) -> Result<Vec<u8>, HwpxError> {
         let mut file = self.archive.by_name(path).map_err(|e| {
             HwpxError::MissingFile(format!("{}: {}", path, e))
         })?;
-        let mut buf = Vec::new();
-        file.read_to_end(&mut buf).map_err(|e| {
+        read_limited(&mut file, MAX_BINDATA_SIZE).map_err(|e| {
             HwpxError::ZipError(format!("{} 읽기 실패: {}", path, e))
-        })?;
-        Ok(buf)
+        })
     }
 
     /// 아카이브 내 파일 목록을 반환한다.
@@ -58,5 +99,73 @@ mod tests {
     fn test_open_invalid_zip() {
         let result = HwpxReader::open(&[0u8; 100]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_read_limited_under_cap() {
+        let data = vec![0u8; 1000];
+        let mut cursor = Cursor::new(data.clone());
+        let result = read_limited(&mut cursor, 2000).unwrap();
+        assert_eq!(result.len(), 1000);
+    }
+
+    #[test]
+    fn test_read_limited_at_cap() {
+        let data = vec![0u8; 1000];
+        let mut cursor = Cursor::new(data.clone());
+        let result = read_limited(&mut cursor, 1000).unwrap();
+        assert_eq!(result.len(), 1000);
+    }
+
+    #[test]
+    fn test_read_limited_over_cap() {
+        let data = vec![0u8; 1001];
+        let mut cursor = Cursor::new(data);
+        let result = read_limited(&mut cursor, 1000);
+        assert!(result.is_err());
+        let err = result.unwrap_err();
+        assert_eq!(err.kind(), io::ErrorKind::InvalidData);
+    }
+
+    /// 해제 시 상한을 넘는 엔트리가 포함된 ZIP은 `ZipError`로 거부되어야 한다.
+    ///
+    /// 실제 "zip bomb"을 흉내내기 위해 고압축 가능한(반복 패턴) 데이터
+    /// `MAX_XML_SIZE + 1` 바이트를 deflate로 압축한 뒤 `.xml` 엔트리로
+    /// 넣는다. 압축 결과물은 수십 KB지만, 압축 해제 시도는 상한에
+    /// 걸려 실패해야 한다.
+    #[test]
+    fn test_zip_bomb_xml_entry_rejected() {
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let mut out = Cursor::new(Vec::<u8>::new());
+        {
+            let mut zip = ZipWriter::new(&mut out);
+            let opts = SimpleFileOptions::default()
+                .compression_method(zip::CompressionMethod::Deflated);
+            zip.start_file("Contents/bomb.xml", opts).unwrap();
+            // 상한 + 1 바이트짜리 반복 패턴 — 매우 높은 압축률
+            let payload = vec![b'A'; MAX_XML_SIZE + 1];
+            zip.write_all(&payload).unwrap();
+            zip.finish().unwrap();
+        }
+        let bytes = out.into_inner();
+        // 압축본은 실제로 수십 KB에 불과
+        assert!(bytes.len() < 1024 * 1024, "bomb compressed too large: {}", bytes.len());
+
+        let mut reader = HwpxReader::open(&bytes).unwrap();
+        let result = reader.read_file("Contents/bomb.xml");
+        assert!(result.is_err(), "bomb entry should be rejected");
+        match result.unwrap_err() {
+            HwpxError::ZipError(msg) => {
+                assert!(
+                    msg.contains("decompression bomb") || msg.contains("limit"),
+                    "unexpected error message: {}",
+                    msg
+                );
+            }
+            other => panic!("expected ZipError, got {:?}", other),
+        }
     }
 }


### PR DESCRIPTION
## 요약

HWPX 파서의 `HwpxReader`가 ZIP 엔트리를 읽을 때 크기 제한 없이 `read_to_string` / `read_to_end`를 호출합니다. ZIP은 압축률이 매우 높을 수 있어 수 KB짜리 악성 HWPX가 단일 `section.xml` 엔트리만으로 수 GB까지 팽창 — 호스트 프로세스를 OOM으로 몰 수 있습니다 (decompression bomb).

영향 경로: `parse_hwpx` → `HwpxReader::read_file*`
영향 범위: CLI (`rhwp export-svg` 등), WASM, Chrome/Safari 확장, VS Code 확장, rhwp-studio 모두.

## 변경

`src/parser/hwpx/reader.rs`에 작은 유틸 `read_limited(reader, max)`를 추가하고, `read_file` / `read_file_bytes`가 이를 통해 읽도록 전환했습니다.

| 엔트리 종류 | 상한 | 상수 |
|---|---|---|
| XML (section / header / content.hpf 등) | 32 MB | `MAX_XML_SIZE` |
| BinData (이미지·폰트 등) | 64 MB | `MAX_BINDATA_SIZE` |

`Read::take(max + 1)`을 사용해 오버플로를 감지하되, 버퍼는 실제 읽은 크기 + 1 이상으로 자라지 않습니다. 상한 초과 시 `HwpxError::ZipError("... decompression bomb ...")`로 surface.

## 임계값 근거

실제 정부 보도자료·판례·법령 HWPX에서 section.xml이 32 MB를 넘는 사례를 본 적 없습니다. 이미지도 64 MB 단일 파일을 넘는 경우는 없습니다 (대부분 개별 이미지는 수 MB 이하).

저희 쪽 [MDM (markdown-media)](https://github.com/seunghan91/markdown-media) 파서는 이 32/64 MB 임계값을 ~500개 실제 HWPX 픽스처 (MOIS 보도자료 전량 + 법원 판결문 샘플) 에서 돌려왔고 false positive는 0건입니다. 원본 패턴은 MDM commit `a94b459` 에서 HWP/HWPX/PDF 세 파서 경로에 함께 적용했습니다.

## 공개 API 영향

- `HwpxError` 변형 추가 없음 — 초과는 기존 `ZipError`에 실림
- 메서드 시그니처 변경 없음
- `MAX_XML_SIZE` / `MAX_BINDATA_SIZE`는 `pub const`로 노출 (통합자가 현재 상한을 읽을 수 있음). 필요하면 후속 PR에서 `open_with_limits()` 생성자도 추가 가능.

## 테스트

`parser::hwpx::reader` 5개 유닛 테스트 추가:

- `test_read_limited_under_cap` — 상한 미만
- `test_read_limited_at_cap` — 상한과 정확히 같은 크기
- `test_read_limited_over_cap` — 1 바이트 초과 → `InvalidData`
- `test_zip_bomb_xml_entry_rejected` — `MAX_XML_SIZE + 1` 바이트의 반복 패턴을 deflate 압축하면 결과물이 1 MB 미만이지만, 실제 해제 시도는 상한에 걸려 `ZipError`로 거부됨
- `test_open_invalid_zip` (기존)

전체: `cargo test --lib` → 789 passed, 0 failed (기존 784 + 신규 5).

## 관련 맥락

- MDM 프로젝트는 HWP/HWPX → Markdown 추출 엔진입니다. rhwp와 파싱 층에서 상호보완적이므로, 저희가 운영 중에 발견·수정한 보안·파싱 이슈를 역으로 기여하고 있습니다. 이게 첫 PR이고, 추후 `shape="3D"` strikeout 화이트리스트 PR도 보낼 예정입니다.
- `cfb_lenient.rs`가 rhwp `src/parser/cfb_reader.rs::LenientCfbReader`에서 MDM으로 포팅된 것이어서, 이번에는 반대 방향으로 기여합니다.

🙇 감사합니다!