### PR TITLE
refactor(hwpx): whitelist strikeout shapes instead of blacklist

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -12,6 +12,50 @@ use crate::model::style::*;
 use super::HwpxError;
 use super::utils::{local_name, attr_str, parse_u8, parse_i8, parse_u16, parse_i16, parse_u32, parse_i32, parse_color, parse_bool};
 
+/// `<hh:strikeout shape="..."/>` 의 shape 값이 실제 렌더링되는 취소선인지
+/// 판정한다 (화이트리스트).
+///
+/// ## 배경
+///
+/// 한컴오피스 HWPX 익스포터는 본문 charPr 정의에 `<hh:strikeout shape="3D"/>`
+/// 를 placeholder 기본값으로 넣어두는 경우가 많다. "3D"는 OWPML 스펙상
+/// 유효한 취소선 모양이 아니며, 한컴 뷰어에서도 취소선으로 그리지 않는다.
+/// 따라서 이를 진짜 strikethrough로 해석하면 정상 본문 전체가 취소선으로
+/// 렌더링되는 버그가 생긴다.
+///
+/// 또한 한컴이 향후 다른 placeholder 값("Ghost", "4D" 등)을 추가할 가능성이
+/// 있으므로, 블랙리스트(\"NONE\" | \"3D\" 제외)보다는 화이트리스트가 더
+/// 안전하다. 알 수 없는 값은 fail-closed로 no-strike 처리한다.
+///
+/// ## 허용 값
+///
+/// 본 함수가 `true`를 반환하는 값은 OWPML `LineSym2` 열거(표 27 선 종류)와
+/// shape.rs 의 `strike_shape` 매핑 표에서 모두 실제 선으로 인정되는 13종:
+///
+/// `SOLID`, `DASH`, `DOT`, `DASH_DOT`, `DASH_DOT_DOT`, `LONG_DASH`,
+/// `CIRCLE`, `DOUBLE_SLIM`, `SLIM_THICK`, `THICK_SLIM`, `SLIM_THICK_SLIM`,
+/// `WAVE`, `DOUBLE_WAVE`.
+///
+/// `NONE`, `3D`, 기타 모든 값은 `false` (취소선 없음).
+pub(crate) fn is_real_strike_shape(shape: &str) -> bool {
+    matches!(
+        shape,
+        "SOLID"
+            | "DASH"
+            | "DOT"
+            | "DASH_DOT"
+            | "DASH_DOT_DOT"
+            | "LONG_DASH"
+            | "CIRCLE"
+            | "DOUBLE_SLIM"
+            | "SLIM_THICK"
+            | "THICK_SLIM"
+            | "SLIM_THICK_SLIM"
+            | "WAVE"
+            | "DOUBLE_WAVE"
+    )
+}
+
 /// header.xml을 파싱하여 DocInfo와 DocProperties를 생성한다.
 pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxError> {
     let mut doc_info = DocInfo::default();
@@ -289,8 +333,12 @@ fn parse_char_shape(
                                 match attr.key.as_ref() {
                                     b"shape" => {
                                         let val = attr_str(&attr);
-                                        // 유효한 취소선: NONE/3D 이외의 선 스타일
-                                        cs.strikethrough = !matches!(val.as_str(), "NONE" | "3D");
+                                        // 화이트리스트 방식: 한컴이 실제 렌더링하는
+                                        // OWPML LineSym2 값만 취소선으로 인정한다.
+                                        // "NONE", "3D" 같은 placeholder 및 알 수 없는
+                                        // 값은 fail-closed로 no-strike 처리.
+                                        // is_real_strike_shape() 독스트링 참고.
+                                        cs.strikethrough = is_real_strike_shape(&val);
                                         cs.strike_shape = match val.as_str() {
                                             "SOLID" => 0,
                                             "DASH" => 1,
@@ -1142,5 +1190,52 @@ mod tests {
                 }
             }
         }
+    }
+
+    #[test]
+    fn test_is_real_strike_shape_valid_shapes() {
+        // OWPML LineSym2 전체 — 모두 true
+        for shape in &[
+            "SOLID",
+            "DASH",
+            "DOT",
+            "DASH_DOT",
+            "DASH_DOT_DOT",
+            "LONG_DASH",
+            "CIRCLE",
+            "DOUBLE_SLIM",
+            "SLIM_THICK",
+            "THICK_SLIM",
+            "SLIM_THICK_SLIM",
+            "WAVE",
+            "DOUBLE_WAVE",
+        ] {
+            assert!(
+                is_real_strike_shape(shape),
+                "{} should be a real strike shape",
+                shape
+            );
+        }
+    }
+
+    #[test]
+    fn test_is_real_strike_shape_placeholder_none() {
+        assert!(!is_real_strike_shape("NONE"));
+    }
+
+    #[test]
+    fn test_is_real_strike_shape_placeholder_3d() {
+        // 한컴 익스포터의 대표 placeholder — 본문 전체가 취소선으로 찍히던 버그
+        assert!(!is_real_strike_shape("3D"));
+    }
+
+    #[test]
+    fn test_is_real_strike_shape_unknown_fail_closed() {
+        // 미래에 한컴이 추가할 수 있는 placeholder. 블랙리스트였다면 true로
+        // 오인식되어 본문에 취소선이 그려질 것이다. 화이트리스트는 false.
+        assert!(!is_real_strike_shape("4D"));
+        assert!(!is_real_strike_shape("Ghost"));
+        assert!(!is_real_strike_shape(""));
+        assert!(!is_real_strike_shape("solid")); // 대소문자 구분
     }
 }


### PR DESCRIPTION
## 요약

`parser/hwpx/header.rs:293`의 strikeout 판정 로직을 **블랙리스트 → 화이트리스트**로 전환합니다.

```rust
// before
cs.strikethrough = !matches!(val.as_str(), "NONE" | "3D");

// after
cs.strikethrough = is_real_strike_shape(&val);
```

## 문제

현재 코드는 "shape가 NONE/3D 외이면 모두 취소선"으로 가정합니다. 지금 한컴이 내보내는 placeholder(`shape="3D"`)는 처리하지만, **fails open**입니다:

- 한컴이 향후 다른 placeholder (예: `4D`, `Ghost`, 내부 실험 값) 를 추가하면 다시 본문 전체가 취소선으로 렌더링됩니다.
- 새 placeholder가 나올 때마다 블랙리스트를 쫓아가야 합니다.

## 수정

`is_real_strike_shape(&str) -> bool`을 `pub(crate)` 헬퍼로 추출. OWPML `LineSym2` 열거 — `shape.rs`의 `strike_shape` 매핑에 이미 있는 13종(`SOLID`, `DASH`, `DOT`, `DASH_DOT`, `DASH_DOT_DOT`, `LONG_DASH`, `CIRCLE`, `DOUBLE_SLIM`, `SLIM_THICK`, `THICK_SLIM`, `SLIM_THICK_SLIM`, `WAVE`, `DOUBLE_WAVE`) — 만 `true`. `NONE`/`3D`/미지 값은 모두 **fail-closed**로 `false` (no-strike).

**기존 파일에 대한 동작 변화는 없습니다.** `shape.rs`가 알고 있는 값에 대해서는 블랙리스트와 화이트리스트가 동일한 결과를 냅니다. 달라지는 건 오직 "알 수 없는 값 처리": 이전엔 strike=true, 이제는 strike=false.

## 근거

저희 쪽 [MDM (markdown-media)](https://github.com/seunghan91/markdown-media) 파서도 같은 버그를 먼저 겪었습니다. 한컴 HWPX 익스포터는 본문 charPr 기본값으로 `<hh:strikeout shape=\"3D\"/>`를 뿌리는데, "NONE 아니면 전부 취소선" 로직 때문에 보도자료 본문 전체가 `~~...~~`로 감싸졌습니다.

MDM commit `ae15dd8`에서 동일한 화이트리스트 방식으로 고쳤고, 21개 MOIS HWPX 픽스처에서 false strike가 0건임을 확인했습니다. 로직이 작고 rhwp 구조에 그대로 맞아 역기여합니다.

## 테스트

`parser::hwpx::header::tests`에 5개 유닛 테스트 추가:

- `test_is_real_strike_shape_valid_shapes` — 13종 OWPML 값 모두 `true`
- `test_is_real_strike_shape_placeholder_none` — `\"NONE\"` → `false`
- `test_is_real_strike_shape_placeholder_3d` — `\"3D\"` → `false` (원 버그)
- `test_is_real_strike_shape_unknown_fail_closed` — `\"4D\"`, `\"Ghost\"`, `\"\"`, `\"solid\"`(대소문자) → 모두 `false`

전체: `cargo test --lib` → **789 passed, 0 failed** (기존 784 + 신규 5).

## 참고

- 이 PR은 [#153 (ZIP bomb 방어)](https://github.com/edwardkim/rhwp/pull/153) 다음 두 번째 기여입니다. 독립적이어서 merge 순서는 상관없습니다.
- `underline` 블록(바로 위, header.rs:264-282)도 같은 구조의 코드지만 블랙리스트가 없어 이번 PR 범위에서 제외했습니다. 필요하시면 후속 PR로 헬퍼 이름/위치를 맞출 수 있습니다.

🙇 감사합니다!