### PR TITLE
fix(rhwp-chrome): 썸네일 로딩 스피너 정리 + options CSP 호환

### DIFF
--- a/rhwp-chrome/build.mjs
+++ b/rhwp-chrome/build.mjs
@@ -60,6 +60,7 @@ copy(resolve(__dirname, 'content-script.css'), resolve(DIST, 'content-script.css
 copy(resolve(__dirname, 'dev-tools-inject.js'), resolve(DIST, 'dev-tools-inject.js'));
 copy(resolve(__dirname, 'sw'), resolve(DIST, 'sw'));
 copy(resolve(__dirname, 'options.html'), resolve(DIST, 'options.html'));
+copy(resolve(__dirname, 'options.js'), resolve(DIST, 'options.js'));
 
 // 아이콘
 mkdirSync(resolve(DIST, 'icons'), { recursive: true });

--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -67,6 +67,7 @@
     img.src = new URL(dataUri).href;
     img.alt = '미리보기';
     img.referrerPolicy = 'no-referrer';
+    thumbDiv.textContent = '';
     thumbDiv.className = 'rhwp-hover-thumb';
     thumbDiv.appendChild(img);
   }

--- a/rhwp-chrome/options.html
+++ b/rhwp-chrome/options.html
@@ -40,41 +40,6 @@
     <span id="privacy"></span>
   </p>
 
-  <script>
-    // i18n 적용
-    document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
-    document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
-    document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
-    document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
-    document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
-    document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
-
-    const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
-
-    // 설정 로드
-    chrome.storage.sync.get(
-      { autoOpen: true, showBadges: true, hoverPreview: true },
-      (settings) => {
-        for (const id of inputs) {
-          document.getElementById(id).checked = settings[id];
-        }
-      }
-    );
-
-    // 설정 저장
-    for (const id of inputs) {
-      document.getElementById(id).addEventListener('change', () => {
-        const settings = {};
-        for (const id2 of inputs) {
-          settings[id2] = document.getElementById(id2).checked;
-        }
-        chrome.storage.sync.set(settings, () => {
-          const saved = document.getElementById('saved');
-          saved.classList.add('show');
-          setTimeout(() => saved.classList.remove('show'), 1500);
-        });
-      });
-    }
-  </script>
+  <script src="options.js"></script>
 </body>
 </html>

--- a/rhwp-chrome/options.js
+++ b/rhwp-chrome/options.js
@@ -1,0 +1,34 @@
+// i18n 적용
+document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
+document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
+document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
+document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
+document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
+document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
+
+const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+
+// 설정 로드
+chrome.storage.sync.get(
+  { autoOpen: true, showBadges: true, hoverPreview: true },
+  (settings) => {
+    for (const id of inputs) {
+      document.getElementById(id).checked = settings[id];
+    }
+  }
+);
+
+// 설정 저장
+for (const id of inputs) {
+  document.getElementById(id).addEventListener('change', () => {
+    const settings = {};
+    for (const id2 of inputs) {
+      settings[id2] = document.getElementById(id2).checked;
+    }
+    chrome.storage.sync.set(settings, () => {
+      const saved = document.getElementById('saved');
+      saved.classList.add('show');
+      setTimeout(() => saved.classList.remove('show'), 1500);
+    });
+  });
+}


### PR DESCRIPTION
## 변경 요약

Chrome 확장에서 두 가지 사용자 체감 이슈를 수정했습니다.

1. 썸네일 로딩 완료 후에도 모래시계(⏳)가 남아 보이던 문제를 수정했습니다.
   - `rhwp-chrome/content-script.js`
   - `insertThumbnailImg()`에서 이미지 삽입 전에 `thumbDiv.textContent = ''`로 로딩 플레이스홀더를 제거
2. 옵션 페이지가 비어 보이던 CSP 문제를 수정했습니다.
   - `rhwp-chrome/options.html` 인라인 스크립트를 제거하고 `options.js`로 분리
   - `rhwp-chrome/build.mjs`에서 `options.js`를 `dist/`로 복사하도록 반영

변경 파일:
- `rhwp-chrome/content-script.js`
- `rhwp-chrome/options.html`
- `rhwp-chrome/options.js` (신규)
- `rhwp-chrome/build.mjs`

## 관련 이슈

closes #86
closes #166

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (N/A: rhwp-chrome 변경 범위 외)
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)  (N/A: rhwp-chrome 변경 범위 외)
- [x] `cd rhwp-chrome && npm run build` 실행
- [x] Chrome 개발자 모드에서 `rhwp-chrome/dist` 로드 후 옵션 페이지/썸네일 동작 수동 확인

## 스크린샷

- 옵션 페이지: 인라인 스크립트 차단으로 텍스트가 비던 상태에서 정상 텍스트 표시 상태로 개선
- 썸네일 호버: 로딩 완료 후 스피너 제거되고 썸네일만 표시
