### PR TITLE
fix(rhwp-chrome): 썸네일 로딩 스피너 정리 + options CSP 호환

### DIFF
--- a/rhwp-chrome/build.mjs
+++ b/rhwp-chrome/build.mjs
@@ -60,6 +60,7 @@ copy(resolve(__dirname, 'content-script.css'), resolve(DIST, 'content-script.css
 copy(resolve(__dirname, 'dev-tools-inject.js'), resolve(DIST, 'dev-tools-inject.js'));
 copy(resolve(__dirname, 'sw'), resolve(DIST, 'sw'));
 copy(resolve(__dirname, 'options.html'), resolve(DIST, 'options.html'));
+copy(resolve(__dirname, 'options.js'), resolve(DIST, 'options.js'));
 
 // 아이콘
 mkdirSync(resolve(DIST, 'icons'), { recursive: true });

--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -67,6 +67,7 @@
     img.src = new URL(dataUri).href;
     img.alt = '미리보기';
     img.referrerPolicy = 'no-referrer';
+    thumbDiv.textContent = '';
     thumbDiv.className = 'rhwp-hover-thumb';
     thumbDiv.appendChild(img);
   }

--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -27,9 +27,9 @@
 
   // 확장 존재 알림
   document.documentElement.setAttribute('data-hwp-extension', 'rhwp');
-  document.documentElement.setAttribute('data-hwp-extension-version', '0.1.0');
+  document.documentElement.setAttribute('data-hwp-extension-version', '0.1.1');
   window.dispatchEvent(new CustomEvent('hwp-extension-ready', {
-    detail: { name: 'rhwp', version: '0.1.0', capabilities: ['preview', 'edit', 'print'] }
+    detail: { name: 'rhwp', version: '0.1.1', capabilities: ['preview', 'edit', 'print'] }
   }));
 
   // 개발자 도구 주입 (페이지 컨텍스트에 rhwpDev 노출)

--- a/rhwp-chrome/dev-tools-inject.js
+++ b/rhwp-chrome/dev-tools-inject.js
@@ -4,7 +4,7 @@
   'use strict';
   if (window.rhwpDev) return;
 
-  const VERSION = '0.1.0';
+  const VERSION = '0.1.1';
 
   window.rhwpDev = {
     inspect() {
@@ -127,7 +127,7 @@
    data-hwp="true"
    data-hwp-title="전입신고서"
    data-hwp-pages="2"
-   data-hwp-thumbnail="/thumbs/preview.webp"
+   data-hwp-thumbnail="https://example.com/thumbs/preview.webp"
    data-hwp-category="민원서식"
    data-hwp-form-fields="true">전입신고서</a>
 

--- a/rhwp-chrome/options.html
+++ b/rhwp-chrome/options.html
@@ -40,41 +40,6 @@
     <span id="privacy"></span>
   </p>
 
-  <script>
-    // i18n 적용
-    document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
-    document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
-    document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
-    document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
-    document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
-    document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
-
-    const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
-
-    // 설정 로드
-    chrome.storage.sync.get(
-      { autoOpen: true, showBadges: true, hoverPreview: true },
-      (settings) => {
-        for (const id of inputs) {
-          document.getElementById(id).checked = settings[id];
-        }
-      }
-    );
-
-    // 설정 저장
-    for (const id of inputs) {
-      document.getElementById(id).addEventListener('change', () => {
-        const settings = {};
-        for (const id2 of inputs) {
-          settings[id2] = document.getElementById(id2).checked;
-        }
-        chrome.storage.sync.set(settings, () => {
-          const saved = document.getElementById('saved');
-          saved.classList.add('show');
-          setTimeout(() => saved.classList.remove('show'), 1500);
-        });
-      });
-    }
-  </script>
+  <script src="options.js"></script>
 </body>
 </html>

--- a/rhwp-chrome/options.html
+++ b/rhwp-chrome/options.html
@@ -36,7 +36,7 @@
 
   <hr>
   <p class="info">
-    rhwp v0.1.0 — MIT<br>
+    rhwp v<span id="version">-</span> — MIT<br>
     <span id="privacy"></span>
   </p>
 

--- a/rhwp-chrome/options.js
+++ b/rhwp-chrome/options.js
@@ -1,0 +1,34 @@
+// i18n 적용
+document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
+document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
+document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
+document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
+document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
+document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
+
+const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+
+// 설정 로드
+chrome.storage.sync.get(
+  { autoOpen: true, showBadges: true, hoverPreview: true },
+  (settings) => {
+    for (const id of inputs) {
+      document.getElementById(id).checked = settings[id];
+    }
+  }
+);
+
+// 설정 저장
+for (const id of inputs) {
+  document.getElementById(id).addEventListener('change', () => {
+    const settings = {};
+    for (const id2 of inputs) {
+      settings[id2] = document.getElementById(id2).checked;
+    }
+    chrome.storage.sync.set(settings, () => {
+      const saved = document.getElementById('saved');
+      saved.classList.add('show');
+      setTimeout(() => saved.classList.remove('show'), 1500);
+    });
+  });
+}

--- a/rhwp-chrome/options.js
+++ b/rhwp-chrome/options.js
@@ -1,34 +1,38 @@
-// i18n 적용
-document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
-document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
-document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
-document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
-document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
-document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
+(function () {
+  'use strict';
 
-const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+  // i18n 적용
+  document.getElementById('title').textContent = chrome.i18n.getMessage('optionsTitle');
+  document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
+  document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
+  document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
+  document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
+  document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
 
-// 설정 로드
-chrome.storage.sync.get(
-  { autoOpen: true, showBadges: true, hoverPreview: true },
-  (settings) => {
-    for (const id of inputs) {
-      document.getElementById(id).checked = settings[id];
+  const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+
+  // 설정 로드
+  chrome.storage.sync.get(
+    { autoOpen: true, showBadges: true, hoverPreview: true },
+    (settings) => {
+      for (const id of inputs) {
+        document.getElementById(id).checked = settings[id];
+      }
     }
-  }
-);
+  );
 
-// 설정 저장
-for (const id of inputs) {
-  document.getElementById(id).addEventListener('change', () => {
-    const settings = {};
-    for (const id2 of inputs) {
-      settings[id2] = document.getElementById(id2).checked;
-    }
-    chrome.storage.sync.set(settings, () => {
-      const saved = document.getElementById('saved');
-      saved.classList.add('show');
-      setTimeout(() => saved.classList.remove('show'), 1500);
+  // 설정 저장
+  for (const id of inputs) {
+    document.getElementById(id).addEventListener('change', () => {
+      const settings = {};
+      for (const id2 of inputs) {
+        settings[id2] = document.getElementById(id2).checked;
+      }
+      chrome.storage.sync.set(settings, () => {
+        const saved = document.getElementById('saved');
+        saved.classList.add('show');
+        setTimeout(() => saved.classList.remove('show'), 1500);
+      });
     });
-  });
-}
+  }
+})();

--- a/rhwp-chrome/options.js
+++ b/rhwp-chrome/options.js
@@ -8,6 +8,7 @@
   document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
   document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
   document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
+  document.getElementById('version').textContent = chrome.runtime.getManifest().version;
 
   const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
 

--- a/rhwp-chrome/sw/thumbnail-extractor.js
+++ b/rhwp-chrome/sw/thumbnail-extractor.js
@@ -24,7 +24,6 @@ export async function extractThumbnailFromUrl(url) {
     const data = new Uint8Array(buffer);
 
     // HWP(CFB) 또는 HWPX(ZIP) 감지
-    // HWP(CFB) 또는 HWPX(ZIP) 감지
     const isZip = data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B;
     const result = isZip
       ? await extractPrvImageFromZipAsync(data)


### PR DESCRIPTION
## 변경 요약

Chrome 확장에서 두 가지 사용자 체감 이슈를 수정했습니다.

1. 썸네일 로딩 완료 후에도 모래시계(⏳)가 남아 보이던 문제를 수정했습니다.
   - `rhwp-chrome/content-script.js`
   - `insertThumbnailImg()`에서 이미지 삽입 전에 `thumbDiv.textContent = ''`로 로딩 플레이스홀더를 제거
2. 옵션 페이지가 비어 보이던 CSP 문제를 수정했습니다.
   - `rhwp-chrome/options.html` 인라인 스크립트를 제거하고 `options.js`로 분리
   - `rhwp-chrome/options.js`는 다른 non-module 스크립트(`content-script.js`, `dev-tools-inject.js`)와 동일하게 IIFE + `'use strict'` 패턴 적용
   - `rhwp-chrome/build.mjs`에서 `options.js`를 `dist/`로 복사하도록 반영

변경 파일:
- `rhwp-chrome/content-script.js`
- `rhwp-chrome/options.html`
- `rhwp-chrome/options.js` (신규)
- `rhwp-chrome/build.mjs`

> 본 PR은 #167을 대체합니다. (close/reopen 흔적 정리 + Copilot 리뷰 반영 커밋 포함)

## 관련 이슈

closes #86
closes #166

## 테스트

본 PR 변경 범위는 `rhwp-chrome/` 내 JS·HTML·빌드 스크립트에 한정됩니다. Rust 코어(파서/렌더러/WASM)에는 변경이 없으므로 Rust 측 항목은 무관(N/A)이지만 회귀 확인 차원에서 cargo 명령은 실제 실행했습니다.

- [x] `cargo test` 통과 — 785 passed, 0 failed (회귀 확인용 실행, 본 PR 변경과 직접 관련 없음)
- [x] `cargo clippy -- -D warnings` 통과 — 라이브러리 타겟 깨끗 통과 (회귀 확인용 실행, 본 PR 변경과 직접 관련 없음)
- [ ] ~~관련 샘플 파일로 SVG 내보내기 확인~~ — **N/A**: Rust 렌더러 무변경 (Chrome 확장 JS만 수정)
- [ ] ~~웹(WASM) 렌더링 확인~~ — **N/A**: Rust→WASM 빌드 무변경 (Chrome 확장 JS만 수정)
- [x] `cd rhwp-chrome && npm run build` 실행
- [x] Chrome 개발자 모드에서 `rhwp-chrome/dist` 로드 후 옵션 페이지/썸네일 동작 수동 확인

## 스크린샷

- 옵션 페이지: 인라인 스크립트 차단으로 텍스트가 비던 상태에서 정상 텍스트 표시 상태로 개선

| 변경 전 | 변경 후 |
| :---: | :---: |
|<img width="100%" alt="스크린샷 2026-04-16 22 14 13" src="https://github.com/user-attachments/assets/014bb9cb-856d-4d1f-a9aa-a0633aa20964" />|<img width="100%" alt="스크린샷 2026-04-17 02 55 10" src="https://github.com/user-attachments/assets/ada4e0c6-003b-465e-9d4e-a6c1e61a6ab8" />|


- 썸네일 호버: 로딩 완료 후 스피너 제거되고 썸네일만 표시
 (이상하게 배포버전에서 썸네일이 안 보입니다.)

| 변경 전 | 변경 후 |
| :---: | :---: |
|<img width="100%" height="982" alt="스크린샷 2026-04-17 03 07 59" src="https://github.com/user-attachments/assets/febb0d46-0ace-447f-978b-fca9c792599d" />|<img width="100%" height="982" alt="스크린샷 2026-04-17 03 06 45" src="https://github.com/user-attachments/assets/ae3df0b6-242c-46a7-b8a0-14ce72277348" />|
