### PR TITLE
Hotfix v0.2.1 (확장): 매뉴얼 §5.1 누락 버전 보강

### DIFF
--- a/mydocs/manual/MEMORY.md
+++ b/mydocs/manual/MEMORY.md
@@ -1,20 +1,22 @@
-- [작업 시간 제한 금지](memory/feedback_no_time_limits.md) — 클로드가 임의로 작업 종료 제안 금지, 작업지시자가 결정
-- [한컴 LINE_SEG 자동 재계산](memory/project_hancom_lineseg_behavior.md) — LINE_SEG가 비어있어도 한컴이 자체 재계산. 역공학 샘플 전략의 기반
-- [타스크 번호는 GitHub Issues로 채번](memory/feedback_task_numbering.md) — gh issue create로 자동 채번, 수동 번호 할당 금지
-- [마일스톤 표기 규칙](memory/feedback_milestone_notation.md) — v1.0.0→M100, v0.5.x→M05x. 오늘할일에서 M100 #1 형식 사용
-- [안드로이드 IME 미구현](memory/project_android_ime_pending.md) — 기기 미보유로 미테스트. iOS는 contentEditable+디바운스로 해결. 기기 확보 시 구현 필요
-- [Discord 커뮤니티](memory/reference_discord.md) — Rust Discord에 프로젝트 소개 (2026-04-04)
-- [타스크 프로세스 반드시 준수](memory/feedback_process_must_follow.md) — 이슈→브랜치→할일→계획서→구현 순서 절대 생략 금지. #61에서 위반 발생
-- [이슈 클로즈는 작업지시자 승인 필수](memory/feedback_no_close_without_approval.md) — 미해결 상태 임의 클로즈 금지. #62에서 위반 발생
-- [로컬 폰트 경로](memory/reference_font_path.md) — TTF 폰트는 /home/edward/mygithub/ttfs에 프로젝트 외부 분리
-- [작업 문서 네이밍 규칙](memory/feedback_working_doc_naming.md) — task_m100_{번호}_stage{단계}.md 패턴 필수
-- [최종 보고서 위치 규칙](memory/feedback_report_location.md) — 최종 보고서는 mydocs/report/, 단계별 보고서는 mydocs/working/
-- [보고서는 타스크 브랜치에서 커밋](memory/feedback_commit_reports_in_branch.md) — 보고서·오늘할일 갱신은 타스크 브랜치에서 소스와 함께 커밋. merge 전 git status 필수
-- [오늘할일 문서 작업일지 갱신 필수](memory/feedback_update_daily_orders.md) — 작업한 내용은 반드시 mydocs/orders/yyyymmdd.md에 기록. 세션 종료 전 커밋
-- [알한글 iOS 프로젝트](memory/project_alhangeul_ios.md) — iPad HWP 학습 도구, 맥북 전용(ios/devel), 리눅스에서 빌드 불가. 현재 환경에서 작업 불가
-- [output 폴더 서브폴더 구조](memory/project_output_folder_structure.md) — output/re/(재현검증), output/svg/(SVG), output/debug/(디버그) 용도별 분리. 새 출력 코드는 반드시 서브폴더에 저장
-- [수식 컨트롤은 항상 TAC](memory/project_equation_always_tac.md) — 한컴 수식은 모두 treat_as_char. paragraph_layout 인라인 배치가 핵심 경로
-- [rhwp 자기 검증 ≠ 한컴 호환](memory/feedback_self_verification_not_hancom.md) — 자기 라운드트립 통과해도 한컴 거부 가능. HWP 저장 작업은 한컴2020 수동 검증 게이트 필수
-- [트러블슈팅 폴더 사전 검색 의무](memory/feedback_search_troubleshootings_first.md) — 직렬화·한컴 호환·파일 손상 작업 시작 전 mydocs/troubleshootings/ 전수 검색
-- [HWPX→HWP 단순 어댑터의 한계](memory/project_hwpx_to_hwp_adapter_limit.md) — 단순 어댑터로 한컴 호환 불가. 다음 시도는 "완전 변환기" 정체성 필요
-- [hwp2hwpx Java 라이브러리](memory/reference_hwp2hwpx_library.md) — HWP↔HWPX 변환 매핑 권위 자료. /home/edward/vsworks/hwp2hwpx (Apache 2.0)
+- [작업 시간 제한 금지](feedback_no_time_limits.md) — 클로드가 임의로 작업 종료 제안 금지, 작업지시자가 결정
+- [한컴 LINE_SEG 자동 재계산](project_hancom_lineseg_behavior.md) — LINE_SEG가 비어있어도 한컴이 자체 재계산. 역공학 샘플 전략의 기반
+- [타스크 번호는 GitHub Issues로 채번](feedback_task_numbering.md) — gh issue create로 자동 채번, 수동 번호 할당 금지
+- [마일스톤 표기 규칙](feedback_milestone_notation.md) — v1.0.0→M100, v0.5.x→M05x. 오늘할일에서 M100 #1 형식 사용
+- [안드로이드 IME 미구현](project_android_ime_pending.md) — 기기 미보유로 미테스트. iOS는 contentEditable+디바운스로 해결. 기기 확보 시 구현 필요
+- [Discord 커뮤니티](reference_discord.md) — Rust Discord에 프로젝트 소개 (2026-04-04)
+- [타스크 프로세스 반드시 준수](feedback_process_must_follow.md) — 이슈→브랜치→할일→계획서→구현 순서 절대 생략 금지. #61에서 위반 발생
+- [이슈 클로즈는 작업지시자 승인 필수](feedback_no_close_without_approval.md) — 미해결 상태 임의 클로즈 금지. #62에서 위반 발생
+- [로컬 폰트 경로](reference_font_path.md) — TTF 폰트는 /home/edward/mygithub/ttfs에 프로젝트 외부 분리
+- [작업 문서 네이밍 규칙](feedback_working_doc_naming.md) — task_m100_{번호}_stage{단계}.md 패턴 필수
+- [최종 보고서 위치 규칙](feedback_report_location.md) — 최종 보고서는 mydocs/report/, 단계별 보고서는 mydocs/working/
+- [보고서는 타스크 브랜치에서 커밋](feedback_commit_reports_in_branch.md) — 보고서·오늘할일 갱신은 타스크 브랜치에서 소스와 함께 커밋. merge 전 git status 필수
+- [오늘할일 문서 작업일지 갱신 필수](feedback_update_daily_orders.md) — 작업한 내용은 반드시 mydocs/orders/yyyymmdd.md에 기록. 세션 종료 전 커밋
+- [알한글 iOS 프로젝트](project_alhangeul_ios.md) — iPad HWP 학습 도구, 맥북 전용(ios/devel), 리눅스에서 빌드 불가. 현재 환경에서 작업 불가
+- [output 폴더 서브폴더 구조](project_output_folder_structure.md) — output/re/(재현검증), output/svg/(SVG), output/debug/(디버그) 용도별 분리. 새 출력 코드는 반드시 서브폴더에 저장
+- [수식 컨트롤은 항상 TAC](project_equation_always_tac.md) — 한컴 수식은 모두 treat_as_char. paragraph_layout 인라인 배치가 핵심 경로
+- [rhwp 자기 검증 ≠ 한컴 호환](feedback_self_verification_not_hancom.md) — 자기 라운드트립 통과해도 한컴 거부 가능. HWP 저장 작업은 한컴2020 수동 검증 게이트 필수
+- [트러블슈팅 폴더 사전 검색 의무](feedback_search_troubleshootings_first.md) — 직렬화·한컴 호환·파일 손상 작업 시작 전 mydocs/troubleshootings/ 전수 검색
+- [HWPX→HWP 단순 어댑터의 한계](project_hwpx_to_hwp_adapter_limit.md) — 단순 어댑터로 한컴 호환 불가. 다음 시도는 "완전 변환기" 정체성 필요
+- [hwp2hwpx Java 라이브러리](reference_hwp2hwpx_library.md) — HWP↔HWPX 변환 매핑 권위 자료. /home/edward/vsworks/hwp2hwpx (Apache 2.0)
+- [릴리즈 작업 전 main 동기화 점검 필수](feedback_release_sync_check.md) — devel→main 머지/태그 작업 시작 전 git pull --ff-only origin main. 분기 발견 시 즉시 중단
+- [릴리즈/배포 작업 시 매뉴얼 정독 필수](feedback_release_manual_required.md) — mydocs/manual/ 관련 매뉴얼 전체 정독. 부분 검색 금지. 매뉴얼 체크리스트와 1:1 대조

--- a/mydocs/manual/memory/feedback_release_manual_required.md
+++ b/mydocs/manual/memory/feedback_release_manual_required.md
@@ -1,0 +1,22 @@
+---
+name: 릴리즈/배포 작업 시 매뉴얼 정독 필수
+description: 빌드/배포/버전 갱신 작업 시작 시 mydocs/manual/ 의 관련 매뉴얼 전체 정독 필수. 부분 검색만으로 진행 금지
+type: feedback
+originSessionId: 67d1cb8f-86d4-4672-b831-a8d028a1cfcf
+---
+빌드/배포/버전 갱신 등 매뉴얼이 존재하는 영역의 작업은 **시작 시 관련 매뉴얼 전체 정독** 필수.
+
+**Why**: 2026-04-19 v0.2.0 (확장) 배포 작업 시 `mydocs/manual/chrome_edge_extension_build_deploy.md` 의 §5.1 (버전 변경 대상 4개 파일) 을 정독하지 않고 부분 검색 (`manifest.json`, `package.json` 만) 으로 진행. 결과적으로 `dev-tools-inject.js` 의 `VERSION` 상수와 `content-script.js` 의 `data-hwp-extension-version` 2개 파일 갱신 누락 → 사용자 console / DOM attribute 에서 0.1.1 표시 → hotfix v0.2.1 발생.
+
+**How to apply**:
+- 작업 시작 첫 단계로 `Read` 도구로 매뉴얼 **전체 정독** (Glob/Grep 부분 검색 X)
+- 매뉴얼의 체크리스트 항목 (예: §5.1 의 4개 파일) 모두 작업 항목으로 옮김
+- 각 항목 처리 후 매뉴얼과 대조하여 누락 검증
+- 작업 완료 보고 시 매뉴얼 명시 항목과 1:1 대조 표 첨부
+
+관련 매뉴얼 (현재 시점):
+- `mydocs/manual/chrome_edge_extension_build_deploy.md` (Chrome/Edge 확장)
+- `mydocs/manual/browser_extension_dev_guide.md` (확장 개발 일반)
+- `mydocs/manual/dev_environment_guide.md` (개발 환경)
+- `mydocs/manual/onboarding_guide.md` (신규 온보딩)
+- 기타 `mydocs/manual/*.md`

--- a/mydocs/manual/memory/feedback_release_sync_check.md
+++ b/mydocs/manual/memory/feedback_release_sync_check.md
@@ -1,0 +1,21 @@
+---
+name: 릴리즈 작업 전 main 동기화 점검 필수
+description: devel→main 머지/태그/릴리즈 작업 시작 전 반드시 로컬 main 을 origin/main 과 동기화 점검. 분기 발견 시 즉시 보고
+type: feedback
+originSessionId: 67d1cb8f-86d4-4672-b831-a8d028a1cfcf
+---
+devel → main 머지, 태그 생성, 릴리즈 노트 작성 등 릴리즈 작업 시작 직전에 다음 절차를 반드시 수행:
+
+```bash
+git checkout main
+git fetch origin main
+git pull --ff-only origin main   # 또는 분기 발견 시 멈춤
+```
+
+**Why**: 2026-04-19 v0.7.3 릴리즈 작업 시 본 점검을 누락하고 PR 머지 → 태그 생성을 진행. 결과적으로 `git pull --ff-only` 가 fast-forward 불가로 실패했으나 그 시점에는 이미 `gh pr merge` 가 완료된 후였음. 우연히 origin 기준으로는 정상 (`c2e8a34` 위치에 태그 생성) 이었지만, 만약 로컬 main 의 분기된 커밋이 의미 있는 변경이었다면 잃을 뻔함. 절차 누락이 운으로 해결된 케이스.
+
+**How to apply**:
+- 릴리즈 관련 작업 시작 시 첫 단계로 main 동기화 점검 명시
+- `git pull --ff-only` 실패 시 즉시 작업 중단 + 작업지시자에게 분기 원인 보고
+- 분기된 로컬 커밋이 발견되면 (a) 폐기 (`reset --hard origin/main`), (b) cherry-pick 으로 devel 거쳐 재머지, (c) 다른 처리 — 작업지시자 결정 후 진행
+- 분기 정리 전에는 PR 머지 / 태그 생성 / push 등 릴리즈 액션 금지

--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -27,9 +27,9 @@
 
   // 확장 존재 알림
   document.documentElement.setAttribute('data-hwp-extension', 'rhwp');
-  document.documentElement.setAttribute('data-hwp-extension-version', '0.1.1');
+  document.documentElement.setAttribute('data-hwp-extension-version', '0.2.1');
   window.dispatchEvent(new CustomEvent('hwp-extension-ready', {
-    detail: { name: 'rhwp', version: '0.1.1', capabilities: ['preview', 'edit', 'print'] }
+    detail: { name: 'rhwp', version: '0.2.1', capabilities: ['preview', 'edit', 'print'] }
   }));
 
   // 개발자 도구 주입 (페이지 컨텍스트에 rhwpDev 노출)

--- a/rhwp-chrome/dev-tools-inject.js
+++ b/rhwp-chrome/dev-tools-inject.js
@@ -4,7 +4,7 @@
   'use strict';
   if (window.rhwpDev) return;
 
-  const VERSION = '0.1.1';
+  const VERSION = '0.2.1';
 
   window.rhwpDev = {
     inspect() {

--- a/rhwp-chrome/manifest.json
+++ b/rhwp-chrome/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "__MSG_extDescription__",
   "default_locale": "ko",
   "icons": {

--- a/rhwp-chrome/package.json
+++ b/rhwp-chrome/package.json
@@ -1,6 +1,6 @@
 {
   "name": "rhwp-chrome",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "rhwp HWP 뷰어 & 에디터 — Chrome/Edge 확장 프로그램",
   "license": "MIT",
   "private": true,

--- a/rhwp-safari/src/manifest.json
+++ b/rhwp-safari/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "__MSG_extDescription__",
   "default_locale": "ko",
   "icons": {


### PR DESCRIPTION
## Summary

- v0.2.0 배포 시 매뉴얼의 §5.1 (버전 변경 대상 4개 파일) 중 2개 파일 누락 발견 → 핫픽스
- \`dev-tools-inject.js\` VERSION 상수, \`content-script.js\` DOM attribute / CustomEvent 의 0.1.1 → 0.2.1
- 라이브러리 버전 (0.7.3) 변경 없음

## Affected files

- rhwp-chrome/manifest.json: 0.2.0 → 0.2.1
- rhwp-chrome/package.json: 0.2.0 → 0.2.1
- rhwp-chrome/dev-tools-inject.js (VERSION 상수)
- rhwp-chrome/content-script.js (data-hwp-extension-version + CustomEvent detail)
- rhwp-safari/src/manifest.json (확장 동일 버전)

## Test plan

- [x] dist 재빌드 통과
- [x] 5곳 모두 0.2.1 통일 확인

## 메모리 등록

- feedback_release_manual_required.md: 매뉴얼 정독 필수
- feedback_release_sync_check.md: main 동기화 점검 필수

🤖 Generated with [Claude Code](https://claude.com/claude-code)