### PR TITLE
fix(rhwp-firefox): vite.config.ts __APP_VERSION__ define 주입 (#205)

### DIFF
--- a/rhwp-firefox/vite.config.ts
+++ b/rhwp-firefox/vite.config.ts
@@ -1,11 +1,22 @@
 import { defineConfig } from 'vite';
 import { resolve } from 'path';
+import { readFileSync } from 'fs';
 
 // rhwp-studio를 Firefox 확장용으로 빌드
 // 산출물: rhwp-firefox/dist/ → viewer.html + JS/CSS + WASM + 폰트
+
+// rhwp-studio 의 package.json 버전을 __APP_VERSION__ 으로 주입
+// (rhwp-studio/vite.config.ts 와 동일 패턴 — about-dialog 가 ReferenceError 나지 않도록)
+const studioPkg = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'rhwp-studio', 'package.json'), 'utf-8'),
+);
+
 export default defineConfig({
   root: resolve(__dirname, '..', 'rhwp-studio'),
   publicDir: false, // public/ 폴더 제외 (samples, images 등 불필요)
+  define: {
+    __APP_VERSION__: JSON.stringify(studioPkg.version),
+  },
   resolve: {
     alias: {
       '@': resolve(__dirname, '..', 'rhwp-studio', 'src'),


### PR DESCRIPTION
## 요약

Firefox 확장에서 메뉴 → 도움말 → 제품 정보 클릭 시 `ReferenceError: __APP_VERSION__ is not defined` 발생.

[`rhwp-firefox/vite.config.ts`](rhwp-firefox/vite.config.ts) 에 `define: { __APP_VERSION__: ... }` 누락이 원인. rhwp-chrome (#196) 과 동일 패턴으로 `readFileSync` + `studioPkg` 로딩 + `define` 추가.

## 변경 내용

- `readFileSync` import 추가
- `rhwp-studio/package.json` 로딩
- `define.__APP_VERSION__` 에 studio 버전 주입

## 검증

- [x] `cd rhwp-firefox && npm run build` 성공
- [x] 산출물 `viewer-*.js` 에 `__APP_VERSION__` 잔존 0회, `"0.7.3"` 치환 확인
- [x] Firefox `about:debugging` 재로드 → 메뉴 → 도움말 → 제품 정보 → 콘솔 에러 없음 + 버전 표시 정상 (작업지시자 수동 확인 완료)

### 동작 확인 스크린샷

<img width="2000" height="1298" alt="image" src="https://github.com/user-attachments/assets/046272c1-eca2-42fe-ad0a-0ddbe5688eca" />

## 관련

- closes #205
- 동일 패턴: #196 (rhwp-chrome)
- 원인 PR: #169 (Firefox 포팅 시점에 rhwp-chrome define 수정 전 상태를 기준으로 포팅됨)