### PR TITLE
Task #202: 다각형 리사이즈 + 드래그 실시간 반영 + 도형 클릭시 맨 앞으로 이동

### DIFF
--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -627,8 +627,14 @@ export function onClick(this: any, e: MouseEvent): void {
     {
       const picHit = this.findPictureAtClick(pageIdx, pageX, pageY);
       if (picHit) {
-        // Shift+클릭: 다중 선택
+        // Shift+클릭: 다중 선택 + 맨 앞으로 이동
         if (e.shiftKey && this.cursor.isInPictureObjectSelection()) {
+          if (picHit.type === 'shape' || picHit.type === 'line' || picHit.type === 'group') {
+            try {
+              this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+              this.eventBus.emit('document-changed');
+            } catch { /* ignore */ }
+          }
           const selType = picHit.type === 'shape' ? 'shape' as const : picHit.type as any;
           this.cursor.togglePictureObjectSelection(picHit.sec, picHit.ppi, picHit.ci, selType);
           this.caret.hide();
@@ -640,7 +646,11 @@ export function onClick(this: any, e: MouseEvent): void {
         }
 
         if (picHit.type === 'line') {
-          // 직선 → 바로 객체 선택
+          // 직선 → 맨 앞으로 이동 후 객체 선택
+          try {
+            this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+            this.eventBus.emit('document-changed');
+          } catch { /* ignore */ }
           this.cursor.clearSelection();
           this.exitPictureObjectSelectionIfNeeded();
           this.cursor.enterPictureObjectSelectionDirect(picHit.sec, picHit.ppi, picHit.ci, 'line');
@@ -669,7 +679,11 @@ export function onClick(this: any, e: MouseEvent): void {
               return;
             }
           }
-          // 단일 클릭 → 객체 선택 (경계/내부 구분 없이)
+          // 단일 클릭 → 객체 선택 + 맨 앞으로 이동
+          try {
+            this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+            this.eventBus.emit('document-changed');
+          } catch { /* ignore */ }
           this.cursor.clearSelection();
           this.exitPictureObjectSelectionIfNeeded();
           this.cursor.enterPictureObjectSelectionDirect(picHit.sec, picHit.ppi, picHit.ci, 'shape');
@@ -681,7 +695,7 @@ export function onClick(this: any, e: MouseEvent): void {
           this.textarea.focus();
           return;
         }
-        // 이미지 → 기존 객체 선택 유지
+        // 이미지/방정식 → 객체 선택 (z-order 미지원)
         this.cursor.clearSelection();
         this.exitPictureObjectSelectionIfNeeded();
         this.cursor.enterPictureObjectSelectionDirect(picHit.sec, picHit.ppi, picHit.ci, picHit.type, picHit.cellIdx, picHit.cellParaIdx);

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -629,12 +629,7 @@ export function onClick(this: any, e: MouseEvent): void {
       if (picHit) {
         // Shift+클릭: 다중 선택 + 맨 앞으로 이동
         if (e.shiftKey && this.cursor.isInPictureObjectSelection()) {
-          if (picHit.type === 'shape' || picHit.type === 'line' || picHit.type === 'group') {
-            try {
-              this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
-              this.eventBus.emit('document-changed');
-            } catch { /* ignore */ }
-          }
+          bringShapeToFront.call(this, picHit);
           const selType = picHit.type === 'shape' ? 'shape' as const : picHit.type as any;
           this.cursor.togglePictureObjectSelection(picHit.sec, picHit.ppi, picHit.ci, selType);
           this.caret.hide();
@@ -647,10 +642,7 @@ export function onClick(this: any, e: MouseEvent): void {
 
         if (picHit.type === 'line') {
           // 직선 → 맨 앞으로 이동 후 객체 선택
-          try {
-            this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
-            this.eventBus.emit('document-changed');
-          } catch { /* ignore */ }
+          bringShapeToFront.call(this, picHit);
           this.cursor.clearSelection();
           this.exitPictureObjectSelectionIfNeeded();
           this.cursor.enterPictureObjectSelectionDirect(picHit.sec, picHit.ppi, picHit.ci, 'line');
@@ -680,10 +672,7 @@ export function onClick(this: any, e: MouseEvent): void {
             }
           }
           // 단일 클릭 → 객체 선택 + 맨 앞으로 이동
-          try {
-            this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
-            this.eventBus.emit('document-changed');
-          } catch { /* ignore */ }
+          bringShapeToFront.call(this, picHit);
           this.cursor.clearSelection();
           this.exitPictureObjectSelectionIfNeeded();
           this.cursor.enterPictureObjectSelectionDirect(picHit.sec, picHit.ppi, picHit.ci, 'shape');
@@ -1367,6 +1356,15 @@ export function onMouseUp(this: any, _e: MouseEvent): void {
  * @param dir 기본 방향 ('nw', 'n', 'ne', 'e', 'se', 's', 'sw', 'w')
  * @param angleDeg 회전각 (도)
  */
+function bringShapeToFront(this: any, picHit: any): void {
+  if (picHit.type === 'shape' || picHit.type === 'line' || picHit.type === 'group') {
+    try {
+      this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+      this.eventBus.emit('document-changed');
+    } catch { /* ignore */ }
+  }
+}
+
 function getRotatedCursor(dir: string, angleDeg: number): string {
   const dirs = ['n', 'ne', 'e', 'se', 's', 'sw', 'w', 'nw'];
   const idx = dirs.indexOf(dir);

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -381,8 +381,8 @@ export function updatePictureResizeDrag(this: any, e: MouseEvent): void {
     } catch { /* ignore */ }
   }
 
-  // 그룹 단일 선택: 드래그 중 실시간 크기 반영
-  if (!state.multiRefs && state.ref.type === 'group') {
+  // 단일 선택 (그룹/shape/image 등): 드래그 중 실시간 크기/위치 반영
+  if (!state.multiRefs && state.ref.type !== 'line') {
     const newW = Math.max(Math.round(newBbox.width * PX_TO_HWP), MIN_SIZE_HWP);
     const newH = Math.max(Math.round(newBbox.height * PX_TO_HWP), MIN_SIZE_HWP);
     const newHorzOffset = Math.round(newBbox.x * PX_TO_HWP);

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -1614,6 +1614,13 @@ impl DocumentCore {
         let new_h = super::super::helpers::json_u32(props_json, "height").map(|h| h.max(MIN_SHAPE_SIZE));
         Self::apply_common_obj_attr_from_json(c, props_json);
 
+        // Polygon/Curve: original_width/height는 생성 시 값으로 유지해야 렌더러의
+        // 스케일 팩터(sx = current/original)가 올바르게 동작한다.
+        let is_polygon_or_curve = matches!(shape,
+            crate::model::shape::ShapeObject::Polygon(_) | crate::model::shape::ShapeObject::Curve(_));
+        let saved_orig_w = if is_polygon_or_curve { shape.drawing().map(|d| d.shape_attr.original_width) } else { None };
+        let saved_orig_h = if is_polygon_or_curve { shape.drawing().map(|d| d.shape_attr.original_height) } else { None };
+
         // ShapeComponentAttr 크기/회전/채우기 동기화
         if let Some(d) = shape.drawing_mut() {
             if let Some(w) = new_w {
@@ -1765,6 +1772,12 @@ impl DocumentCore {
             let h = rect.common.height as i32;
             rect.x_coords = [0, w, w, 0];
             rect.y_coords = [0, 0, h, h];
+        }
+
+        // Polygon/Curve: original_width/height 복원 (생성 시 값 유지 → 렌더러 스케일 팩터 정상화)
+        if let Some(d) = shape.drawing_mut() {
+            if let Some(w) = saved_orig_w { d.shape_attr.original_width = w; }
+            if let Some(h) = saved_orig_h { d.shape_attr.original_height = h; }
         }
 
         // Group 리사이즈: original_width 유지, current_width만 변경 (렌더러가 스케일 적용)


### PR DESCRIPTION
## 변경 요약

- **다각형/곡선 리사이즈 버그 수정**: 렌더러의 스케일 팩터(sx =
  current/original) 정상화로 리사이즈 시 점 좌표가 올바르게 적용
- **단일 도형 드래그 중 실시간 반영**: shape 타입 선택 시 마우스 드래그
   중 크기/위치가 실시간으로 갱신
- **도형 클릭 시 맨 앞으로 이동**: shape/line/group 선택 시 z-order를
  자동으로 최상단으로 설정

## 중요한 점

- **한글과 방식이 다름**: 개인적으로 리사이징을 표현하는 방식은 한글보다 워드가 깔끔하다고 생각해서 워드의 방식대로 구현했는데 문제가 있으면 한글 방식으로 구현하겠습니다!

- 한글 
<img width="1148" height="946" alt="20260420-0431-00 6942870" src="https://github.com/user-attachments/assets/1c4fb491-aa83-4c4c-829b-f4b88625026e" />

- 워드
<img width="954" height="700" alt="20260420-0432-31 2242276" src="https://github.com/user-attachments/assets/c493b631-838d-483f-b109-66d3421749c3" />

- 수정한 rhwp
<img width="860" height="720" alt="20260420-0424-21 5718512" src="https://github.com/user-attachments/assets/a9b2f515-3363-4256-8ff6-c49a2f2d0ba4" />

## 관련 이슈
closes #202

## Files

  - `src/document_core/commands/object_ops.rs`: Polygon/Curve
  original_width/height 유지 로직
  - `rhwp-studio/src/engine/input-handler-picture.ts`: 실시간 드래그
  업데이트 범위 확대 (group → shape)
  - `rhwp-studio/src/engine/input-handler-mouse.ts`: z-order 변경 및
  document-changed 이벤트 발생

## 버그 수정 상세

  ### 다각형 리사이즈
  - **원인**: `set_shape_properties_native`에서 `current_width =
  original_width = new_w`로 설정해 렌더러의 스케일 팩터 `sx = 1.0` 초래
  - **수정**: Polygon/Curve는 `original_width/height`를 생성 시 값으로
  유지하여 `sx = current/original` 정상화

  ### 실시간 업데이트
  - **기존**: group 타입만 드래그 중 실시간 업데이트
  - **개선**: `shape` 타입도 포함하여 다각형 리사이즈 중 도형이 움직이는 모습 표시

  ### 맨 앞으로 이동
  - shape/line/group 선택 시 `changeShapeZOrder('front')` 호출

## Test

  - [x] `cargo test` 통과 (858개 테스트 완료)
  - [x] `cargo clippy -- -D warnings` 통과
  - [x] 관련 샘플 파일로 SVG 내보내기 확인
  - [x] 웹(WASM) 렌더링 확인
  - [x] 다각형 생성 후 핸들로 리사이징 시 점 좌표가 올바르게 스케일됨
  - [x] 도형 드래그 중 실시간으로 크기/위치가 반영됨
  - [x] 도형 클릭 시 자동으로 맨 앞으로 이동 (다른 도형 뒤에서 앞으로 변함)



