### PR TITLE
Task #222: Safari showBadges init 게이팅 분리

### DIFF
--- a/rhwp-safari/src/content-script.js
+++ b/rhwp-safari/src/content-script.js
@@ -22,7 +22,8 @@
   });
 
   function init() {
-    if (settings.showBadges) {
+    const shouldProcess = settings.showBadges || settings.hoverPreview || settings.autoOpen;
+    if (shouldProcess) {
       processLinks();
       observeDynamicContent();
     }


### PR DESCRIPTION
## 요약

#222 해결. `rhwp-safari/src/content-script.js`의 `init()`가 `settings.showBadges` 단일 조건으로 `processLinks()`/`observeDynamicContent()` 실행을 게이트하고 있어, `showBadges=false`이면서 `hoverPreview=true` 또는 `autoOpen=true`인 조합에서도 링크 바인딩이 아예 수행되지 않았다.

전략: `init()`의 실행 게이트를 `showBadges || hoverPreview || autoOpen` 기능 기반 OR 조건으로 분리. 배지 렌더링 분기(`processLinks()` 내부 `if (settings.showBadges)`)는 기존 위치와 동작을 그대로 유지하여, 배지 토글이 배지 DOM에만 영향하도록 한다.

## 변경 내역

- **Stage 1** ([51246c5](https://github.com/edwardkim/rhwp/pull/224/commits/51246c57a421d86ef44908678489ebdc7bfdfdda)): `rhwp-safari/src/content-script.js` — `init()`의 실행 조건을 `settings.showBadges` 단일 조건에서 `settings.showBadges || settings.hoverPreview || settings.autoOpen` OR 조건으로 분리. 배지 렌더링 분기(`processLinks()` 내부 `if (settings.showBadges)`)는 유지. `observeDynamicContent()`도 동일 조건으로 정렬.

### 변경 전/후

```diff
 function init() {
-  if (settings.showBadges) {
+  const shouldProcess = settings.showBadges || settings.hoverPreview || settings.autoOpen;
+  if (shouldProcess) {
     processLinks();
     observeDynamicContent();
   }
 }
```

## 변경 파일

- `rhwp-safari/src/content-script.js` — init 게이트 조건 분리 (단일 파일)

## 동작 정렬 (핵심 시나리오)

| # | 옵션 조합 | 배지 | hover/click | 비고 |
|---|---|---|---|---|
| 1 | `showBadges=false, hoverPreview=true, autoOpen=true` | 미표시 | ✅ 동작 | **#222 핵심 수정** |
| 2 | `showBadges=true, hoverPreview=false, autoOpen=false` | ✅ 표시 | 비활성 | 기존 동작 유지 |
| 3 | `showBadges=false, hoverPreview=false, autoOpen=false` | 미표시 | 비활성 | 기존 비활성 유지 |
| 4 | 동적 삽입 링크 | 위 1~3과 동일 | 위 1~3과 동일 | `observeDynamicContent` 동일 조건 |

## 검증

- [x] `node --check rhwp-safari/src/content-script.js` — 문법 오류 없음
- [x] 옵션 조합별 분기 경로 회귀 점검 (위 4개 시나리오 통과)
  - `showBadges=false, hoverPreview=true, autoOpen=true` → `shouldProcess=true`, 배지 미삽입, `interceptHwpClick`/`attachHoverEvents` 바인딩 동작
  - `showBadges=true, hoverPreview=false, autoOpen=false` → 배지 삽입, `interceptHwpClick` 내부 `autoOpen=false` 즉시 return, `attachHoverEvents` 내부 `hoverPreview=false` 즉시 return
  - `showBadges=false, hoverPreview=false, autoOpen=false` → `shouldProcess=false`, 초기 스캔/동적 관찰 미실행
  - 동적 링크 경로: `observeDynamicContent()` → `processLinks(node)` 호출 → 위와 동일 분기 적용
- [x] Safari 로컬 수동 테스트 완료

### 변경 전

https://github.com/user-attachments/assets/61d655db-29c5-49e6-bad9-b7d0148737ff

### 변경 후

 https://github.com/user-attachments/assets/ba9d05f4-2386-49d4-a910-21bac55d6c37





## 영향 범위

- Safari content-script 초기화 조건 분기만 변경 (단일 파일)
- background/sw/manifest 및 타 브라우저 확장 코드는 변경 없음

## 관련

- Closes #222
- 동일 패턴: `processLinks()` 내부 배지/인터셉트/호버 바인딩이 각 설정의 자체 게이트를 가지고 있으므로, `init()` 진입 조건만 분리하면 충분
