### PR TITLE
fix: Visual Diff 기반 렌더링 호환성 개선 — PUA 심볼 + 문단 테두리 + 표 외곽 테두리 (#249)

### DIFF
--- a/mydocs/plans/task_m100_249.md
+++ b/mydocs/plans/task_m100_249.md
@@ -1,0 +1,58 @@
+# Task #249: Visual Diff 기반 렌더링 호환성 개선 — PUA 심볼 + 문단 테두리 + 표 외곽 테두리
+
+> 수행계획서 | 2026-04-22
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+> Milestone: v1.0.0
+
+---
+
+## 1. 목표
+
+Visual Diff 파이프라인(한컴 PDF ↔ rhwp SVG 페이지별 픽셀 비교)을 구축하고, 이를 통해 발견한 렌더링 불일치 3건을 수정한다.
+
+| 지표 | 목표 |
+|------|------|
+| PUA 심볼 문자 정상 표시 | SVG/Canvas/HTML 세 렌더러 |
+| 문단 테두리 위치 일치 | margin_left/right 반영 |
+| 표 외곽 테두리 표시 | 셀 미커버 영역 기준 fallback |
+
+## 2. 현황 분석
+
+### 발견 경위
+
+Visual Diff 파이프라인으로 실제 문서(KTX.hwp 등)를 한컴 렌더링과 페이지별 비교하는 과정에서 아래 3건 발견.
+
+### 문제 1: PUA 심볼 문자 렌더링 오류
+- Wingdings 등 심볼 폰트의 PUA 영역(U+F000~F0FF) 문자가 □(두부 문자)로 표시됨
+- 영향 범위: SVG, Canvas, HTML 세 렌더러 모두
+
+### 문제 2: 문단 테두리/배경 여백 미반영
+- `border_fill` 렌더링 시 문단의 `margin_left`/`margin_right`를 무시
+- 테두리 박스가 텍스트 영역보다 넓게 그려짐
+
+### 문제 3: 표 외곽 테두리 누락
+- `table.border_fill_id`가 설정된 경우 외곽 테두리를 그리지 않음
+- 셀로 커버되지 않는 영역에 fallback 적용 필요
+- clip_rect가 body_area로 고정되어 표 외곽 테두리가 잘리는 문제 동반
+
+## 3. 구현 계획 (3단계)
+
+### 단계 1: PUA 심볼 문자 렌더링
+
+`map_pua_bullet_char()` 함수로 U+F000~F0FF 범위 문자를 유니코드 표준 문자로 변환.
+세 렌더러(SVG, Canvas, HTML)에 일관 적용.
+
+### 단계 2: 문단 border_fill margin 반영
+
+`paragraph_layout.rs`에서 border_fill rect 계산 시 `margin_left`/`margin_right` 적용.
+
+### 단계 3: 표 외곽 테두리 fallback + clip_rect 개선
+
+- `table_layout.rs`: border_fill_id 설정 시 외곽 테두리 그리기, 셀 커버 영역 제외 처리
+- `layout.rs`: clip_rect를 콘텐츠 레이아웃 후 확정하여 표 외곽 테두리가 잘리지 않도록 수정
+
+## 4. 검증 계획
+
+1. `cargo test` — 전체 테스트 통과
+2. Visual Diff 파이프라인으로 한컴 렌더링과 페이지별 비교
+3. Regression 없음 확인 (기존 검증 페이지)

--- a/mydocs/plans/task_m100_249_impl.md
+++ b/mydocs/plans/task_m100_249_impl.md
@@ -1,0 +1,96 @@
+# Task #249: 구현계획서
+
+> 구현계획서 | 2026-04-22
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+
+---
+
+## 단계 1: PUA 심볼 문자 렌더링
+
+### 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/svg.rs` | `draw_text`에 `map_pua_bullet_char()` 호출 추가 |
+| `src/renderer/web_canvas.rs` | `draw_text`에 `map_pua_bullet_char()` 호출 추가 |
+| `src/renderer/html.rs` | 텍스트 렌더링에 `map_pua_bullet_char()` 호출 추가 |
+
+### 구현 내용
+
+```rust
+// 각 렌더러 draw_text 내
+let ch = map_pua_bullet_char(ch);  // PUA → 유니코드 표준 문자 변환
+```
+
+PUA 변환 매핑 (Wingdings 기준):
+- U+F028~F02F: ⇩⇧⇦⇨ 등 화살표
+- U+F0A7: ● 도형
+- U+F0FC: ✔ 체크마크
+- 기타 U+F000~F0FF 범위
+
+### 완료 기준
+- 793개 테스트 전체 통과
+- Visual Diff: PUA 문자가 포함된 페이지에서 □ → 정상 심볼 표시
+
+---
+
+## 단계 2: 문단 border_fill margin 반영
+
+### 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout/paragraph_layout.rs` | border_fill rect에 margin 적용 |
+
+### 구현 내용
+
+```rust
+// paragraph_layout.rs: border_fill rect 계산
+let border_rect = Rect {
+    x: para_x + margin_left,
+    y: border_y,
+    width: para_width - margin_left - margin_right,
+    height: border_height,
+};
+```
+
+### 완료 기준
+- 793개 테스트 전체 통과
+- Visual Diff: 문단 테두리 박스가 텍스트 영역과 일치
+
+---
+
+## 단계 3: 표 외곽 테두리 fallback + clip_rect 개선
+
+### 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout/table_layout.rs` | border_fill_id fallback 로직 추가, 셀 커버 영역 제외 |
+| `src/renderer/layout.rs` | clip_rect를 콘텐츠 레이아웃 후 확정 |
+
+### 구현 내용
+
+**table_layout.rs:**
+```rust
+// border_fill_id가 설정된 경우 외곽 테두리 그리기
+if let Some(border_fill_id) = table.border_fill_id {
+    // 셀로 커버된 영역을 제외한 외곽 영역에만 fallback 적용
+    draw_table_outer_border(border_fill_id, uncovered_rects);
+}
+```
+
+**layout.rs:**
+```rust
+// clip_rect: 콘텐츠 레이아웃 후 자식 노드 bbox를 반영하여 확정
+if self.clip_enabled.get() {
+    let mut clip = body_bbox;
+    expand_clip(&mut clip, &body_node);  // 자식 노드 bbox 재귀 반영
+    body_node.set_clip_rect(Some(clip));
+}
+```
+
+### 완료 기준
+- 793개 테스트 전체 통과
+- Visual Diff: 표 외곽 테두리가 한컴 렌더링과 일치
+- 표 외곽 테두리가 body_area clip으로 잘리지 않음

--- a/mydocs/plans/task_m100_250.md
+++ b/mydocs/plans/task_m100_250.md
@@ -1,0 +1,90 @@
+# Task #250: Right Tab 정렬 수정 — 목차 페이지 번호 선행 공백 처리
+
+> 수행계획서 | 2026-04-22
+> Issue: [#250](https://github.com/edwardkim/rhwp/issues/250)
+> Milestone: v1.0.0
+
+---
+
+## 1. 목표
+
+목차(TOC)에서 페이지 번호의 right tab 정렬이 문단 구조에 따라 달라지는 문제를 수정한다.
+
+| 현상 | 목표 |
+|------|------|
+| 소제목 페이지 번호 9.33px 왼쪽 밀림 | 장제목과 동일 x좌표 |
+| 3경로(run 내/교차 추정/교차 렌더) 공백 처리 불일치 | 세 경로 동일 규칙 |
+
+## 2. 현황 분석
+
+### 재현 파일
+
+KTX.hwp 2페이지 목차 (`셀[10]` 내)
+
+### 문단 구조 차이
+
+| 문단 | run 구조 | seg_w | 결과 |
+|------|---------|-------|------|
+| p[0] 장제목 (Ⅰ...) | ctrls=2, 탭이 run 끝 | 0.00 | 올바름 |
+| p[1] 소제목 (1. ...) | ctrls=0, 탭이 run 중간 | 9.33 (공백 포함) | 9.33px 밀림 |
+
+### 원인
+
+`compute_char_positions()` right tab 처리 경로가 3가지로 분기됨:
+
+1. **같은 run 내 탭** → `seg_w`에 탭 직후 선행 공백 폭(≈9.33px) 포함
+2. **교차 run 탭 (추정 패스)** → `pending_right_tab_est` 별도 처리
+3. **교차 run 탭 (렌더 패스)** → `pending_right_tab_render` 별도 처리
+
+한컴 동작: right tab 정렬 시 탭 직후 선행 공백을 무시하고 실질 텍스트 기준 정렬.
+세 경로의 공백 처리 불일치 → 정렬 오차 발생.
+
+### 이전 시도 (2026-04-22, revert됨)
+
+| 시도 | 결과 |
+|------|------|
+| 방안 B: `measure_segment_from`에서 선행 공백 skip | 소제목 경로 개선, 장제목 경로 미적용 → 불일치 |
+| 교차 run에 `trim_start()` 적용 | 장제목이 오히려 오른쪽으로 더 밀림 (악화) |
+| `available_width → col_area.width - margin_right` | 모든 tab_pos 변동 → revert |
+
+**핵심 교훈**: 단일 경로만 수정 시 나머지 경로와 불일치 발생 → 세 경로 동시 적용 필요.
+
+## 3. 구현 계획 (3단계)
+
+### 단계 1: 재현 샘플 생성 + 기준값 확정
+
+- 목차 구조를 재현하는 제어 샘플 생성 (장제목/소제목 혼합)
+- 한컴에서 정확한 x좌표 캡처 → 목표값 확정
+
+### 단계 2: 3경로 통일 구현
+
+```rust
+// compute_char_positions(): right tab 분기 (경로 1)
+let trimmed_start = (i+1..chars.len())
+    .find(|&j| chars[j] != ' ')
+    .unwrap_or(chars.len());
+let trimmed_seg_w = measure_segment_from(&chars, &cluster_len, trimmed_start, &char_width);
+x = (rel_tab - trimmed_seg_w).max(x);
+
+// pending_right_tab 처리 (경로 2, 3)에도 동일한 trim_start 적용
+```
+
+center tab은 기존 동작 유지 (right tab 전용 적용).
+
+### 단계 3: 검증
+
+1. `cargo test` — 793개 전체 통과
+2. KTX.hwp 2페이지 목차 — 장제목/소제목 페이지 번호 동일 x좌표
+3. Visual Diff 기존 검증 페이지 — regression 없음
+4. 추가 목차 문서 교차 검증 (hwpspec.hwp 등)
+
+## 4. 수정 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout/text_measurement.rs` | `compute_char_positions()` right tab 3경로에 선행 공백 trim |
+
+## 5. 참고
+
+- 관련 이슈: #249 (Visual Diff 파이프라인 — 동일 파이프라인으로 검증)
+- Task 403의 제어 샘플 생성 프레임워크 활용 권장

--- a/mydocs/report/task_m100_249_report.md
+++ b/mydocs/report/task_m100_249_report.md
@@ -1,0 +1,57 @@
+# Task #249: 최종 결과보고서 — Visual Diff 기반 렌더링 호환성 개선
+
+> 최종 보고서 | 2026-04-22
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+
+---
+
+## 1. 작업 요약
+
+Visual Diff 파이프라인을 구축하여 한컴 렌더링과 페이지별 비교 검증 체계를 확립하고, 이를 통해 발견한 렌더링 불일치 3건을 수정했다.
+
+## 2. 구현 결과
+
+### 단계 1: PUA 심볼 문자 렌더링 ✅ 완료
+
+- `map_pua_bullet_char()` 함수로 U+F000~F0FF 문자를 유니코드 표준 문자로 변환
+- SVG, Canvas, HTML 세 렌더러에 일관 적용
+- Wingdings 체크마크, 화살표, 도형 심볼이 정상 표시됨
+
+### 단계 2: 문단 border_fill margin 반영 ✅ 완료
+
+- `paragraph_layout.rs`에서 border_fill rect 계산 시 `margin_left`/`margin_right` 반영
+- 테두리 박스 위치·폭이 텍스트 영역과 정확히 일치
+
+### 단계 3: 표 외곽 테두리 fallback + clip_rect 개선 ✅ 완료
+
+- `table_layout.rs`: `border_fill_id` fallback 로직 추가, 셀 커버 영역 제외 처리
+- `layout.rs`: clip_rect를 콘텐츠 레이아웃 후 확정하여 표 외곽 테두리 클리핑 방지
+
+## 3. 검증 결과
+
+| 항목 | 결과 |
+|------|------|
+| cargo test | 793개 전체 통과, 0 실패 |
+| Visual Diff (PUA 페이지) | □ 두부 문자 → 정상 심볼 |
+| Visual Diff (문단 테두리) | 테두리 박스 텍스트 영역 일치 |
+| Visual Diff (표 외곽 테두리) | 한컴 렌더링과 일치 |
+| Regression (p1, p5, p6, p10) | 없음 |
+
+## 4. 부록: Visual Diff 파이프라인
+
+한컴 PDF를 페이지별 PNG로 캡처(Ground Truth)하고, rhwp SVG를 resvg로 PNG 변환한 후 pixelmatch + SSIM으로 페이지별 픽셀 비교하는 체계를 구축했다.
+
+- 파이프라인 위치: `visual-diff/`
+- 성공 기준: SSIM ≥ 95%, 페이지 수 100% 일치
+- 이 파이프라인은 #249 이후에도 계속 활용 예정 (#250 Right Tab 수정 검증 등)
+
+## 5. 수정 파일 목록
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/renderer/svg.rs` | PUA 변환 적용 |
+| `src/renderer/web_canvas.rs` | PUA 변환 적용 |
+| `src/renderer/html.rs` | PUA 변환 적용 |
+| `src/renderer/layout/paragraph_layout.rs` | border_fill margin 반영 |
+| `src/renderer/layout/table_layout.rs` | 표 외곽 테두리 fallback |
+| `src/renderer/layout.rs` | clip_rect 콘텐츠 레이아웃 후 확정 |

--- a/mydocs/working/task_m100_249_stage1.md
+++ b/mydocs/working/task_m100_249_stage1.md
@@ -1,0 +1,29 @@
+# Task #249 단계별 완료보고서: 단계 1 — PUA 심볼 문자 렌더링
+
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+> 완료일: 2026-04-22
+
+---
+
+## 구현 내용
+
+Wingdings 등 심볼 폰트의 PUA 영역(U+F000~F0FF) 문자를 `map_pua_bullet_char()`로 유니코드 표준 문자로 변환. SVG, Canvas, HTML 세 렌더러에 일관 적용.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/renderer/svg.rs` | `draw_text` 내 `map_pua_bullet_char()` 호출 추가 |
+| `src/renderer/web_canvas.rs` | `draw_text` 내 `map_pua_bullet_char()` 호출 추가 |
+| `src/renderer/html.rs` | 텍스트 렌더링 내 `map_pua_bullet_char()` 호출 추가 |
+
+## 주요 구현 사항
+
+- U+F000~F0FF 범위 문자를 유니코드 표준 문자로 변환
+  - ⇩⇧⇦⇨ 등 화살표, ●■◆ 등 도형, ✔☑ 등 체크마크
+- 세 렌더러 경로에 동일한 변환 함수 적용 → 렌더러 간 일관성 확보
+
+## 검증
+
+- `cargo test`: 793개 통과, 0 실패
+- Visual Diff: PUA 문자 포함 페이지에서 □(두부 문자) → 정상 심볼 표시 확인

--- a/mydocs/working/task_m100_249_stage2.md
+++ b/mydocs/working/task_m100_249_stage2.md
@@ -1,0 +1,27 @@
+# Task #249 단계별 완료보고서: 단계 2 — 문단 border_fill margin 반영
+
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+> 완료일: 2026-04-22
+
+---
+
+## 구현 내용
+
+`border_fill` 렌더링 시 문단의 `margin_left`/`margin_right`를 반영하여 테두리 박스 위치·폭이 텍스트 영역과 정확히 일치하도록 수정.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/renderer/layout/paragraph_layout.rs` | border_fill rect 계산에 `margin_left`/`margin_right` 적용 |
+
+## 주요 구현 사항
+
+- 기존: border_fill rect가 문단 전체 폭(여백 무시)으로 계산됨
+- 수정: `rect.x += margin_left`, `rect.width -= margin_left + margin_right` 적용
+- 텍스트 영역과 테두리 박스의 좌/우 경계가 정확히 일치
+
+## 검증
+
+- `cargo test`: 793개 통과, 0 실패
+- Visual Diff: 문단 테두리가 한컴 렌더링과 일치 확인

--- a/mydocs/working/task_m100_249_stage3.md
+++ b/mydocs/working/task_m100_249_stage3.md
@@ -1,0 +1,33 @@
+# Task #249 단계별 완료보고서: 단계 3 — 표 외곽 테두리 fallback + clip_rect 개선
+
+> Issue: [#249](https://github.com/edwardkim/rhwp/issues/249)
+> 완료일: 2026-04-22
+
+---
+
+## 구현 내용
+
+`table.border_fill_id` 설정 시 표 외곽 테두리를 그리도록 fallback 로직을 추가하고, 셀로 커버되지 않는 영역에만 한정 적용. 또한 clip_rect를 콘텐츠 레이아웃 후 확정하여 표 외곽 테두리가 잘리지 않도록 수정.
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|------|-----------|
+| `src/renderer/layout/table_layout.rs` | `border_fill_id` fallback 로직 + 셀 커버 영역 제외 처리 |
+| `src/renderer/layout.rs` | clip_rect를 콘텐츠 레이아웃 후 자식 노드 bbox 반영하여 확정 |
+
+## 주요 구현 사항
+
+**table_layout.rs:**
+- `table.border_fill_id`가 있을 때 외곽 테두리 영역 계산
+- 셀 bbox 합집합을 구하여 커버된 영역을 제외한 나머지에만 fallback 테두리 적용
+- 과도한 fallback으로 인한 이중 테두리 방지
+
+**layout.rs:**
+- `clip_rect`를 `body_area`로 즉시 고정하던 방식에서, 콘텐츠 레이아웃 완료 후 자식 노드 bbox를 재귀 반영하여 확정하는 방식으로 변경
+- 표 외곽 테두리가 `body_area` clip 경계에서 잘리는 문제 해결
+
+## 검증
+
+- `cargo test`: 793개 통과, 0 실패
+- Visual Diff: 표 외곽 테두리가 한컴 렌더링과 일치, 기존 페이지 regression 없음

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -248,6 +248,11 @@ impl Renderer for HtmlRenderer {
     }
 
     fn draw_text(&mut self, text: &str, x: f64, y: f64, style: &TextStyle) {
+        // PUA 문자(U+F000~F0FF, Wingdings 등 심볼 폰트)를 유니코드 표준 문자로 변환
+        let text = &text.chars().map(|ch| {
+            crate::renderer::layout::map_pua_bullet_char(ch)
+        }).collect::<String>();
+
         let font_size = if style.font_size > 0.0 { style.font_size } else { 12.0 };
         let color = color_to_css(style.color);
         let font_family = if style.font_family.is_empty() {

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -405,18 +405,15 @@ impl LayoutEngine {
             self.build_header(&mut tree, page_content, header_paragraphs, composed, styles, layout, bin_data_content);
         }
 
-        // 본문 영역 노드
+        // 본문 영역 노드 (clip_rect은 콘텐츠 레이아웃 후 확정)
         let body_id = tree.next_id();
+        let body_bbox = layout_rect_to_bbox(&layout.body_area);
         let mut body_node = RenderNode::new(
             body_id,
             RenderNodeType::Body {
-                clip_rect: if self.clip_enabled.get() {
-                    Some(layout_rect_to_bbox(&layout.body_area))
-                } else {
-                    None
-                },
+                clip_rect: None, // 레이아웃 후 설정
             },
-            layout_rect_to_bbox(&layout.body_area),
+            body_bbox,
         );
 
         // 단별 콘텐츠 레이아웃
@@ -430,6 +427,43 @@ impl LayoutEngine {
 
         // 단 구분선
         self.build_column_separators(&mut tree, &mut body_node, layout);
+
+        // 콘텐츠 레이아웃 후 clip_rect 확정:
+        // 자식 노드(표 등)의 실제 바운딩 박스를 재귀적으로 반영하여
+        // body_area보다 큰 콘텐츠(표 외곽 테두리 등)가 잘리지 않도록 함
+        if self.clip_enabled.get() {
+            let mut clip = body_bbox;
+            fn expand_clip(clip: &mut BoundingBox, node: &RenderNode) {
+                let cb = &node.bbox;
+                let child_bottom = cb.y + cb.height;
+                let child_right = cb.x + cb.width;
+                let clip_bottom = clip.y + clip.height;
+                let clip_right = clip.x + clip.width;
+                if child_bottom > clip_bottom {
+                    clip.height = child_bottom - clip.y;
+                }
+                if child_right > clip_right {
+                    clip.width = child_right - clip.x;
+                }
+                if cb.x < clip.x {
+                    clip.width += clip.x - cb.x;
+                    clip.x = cb.x;
+                }
+                if cb.y < clip.y {
+                    clip.height += clip.y - cb.y;
+                    clip.y = cb.y;
+                }
+                for child in &node.children {
+                    expand_clip(clip, child);
+                }
+            }
+            for child in &body_node.children {
+                expand_clip(&mut clip, child);
+            }
+            body_node.node_type = RenderNodeType::Body {
+                clip_rect: Some(clip),
+            };
+        }
 
         // 용지 기준 이미지: body clip 바깥에 배치 (배경 이미지 등)
         for img_node in paper_images {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -2223,11 +2223,13 @@ impl LayoutEngine {
         }
 
         // 문단 테두리/배경 범위 수집 (build_single_column에서 연속 그룹으로 병합 렌더링)
+        // margin_left/margin_right를 반영하여 박스 위치·폭 조정
         if para_border_fill_id > 0 {
             let bg_height = y - bg_y_start;
             if bg_height > 0.0 {
+                // margin_left/margin_right는 이미 px 단위 (style_resolver에서 변환됨)
                 self.para_border_ranges.borrow_mut().push(
-                    (para_border_fill_id, col_area.x, bg_y_start, col_area.width, y)
+                    (para_border_fill_id, col_area.x + margin_left, bg_y_start, col_area.width - margin_left - margin_right, y)
                 );
             }
         }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -332,6 +332,67 @@ impl LayoutEngine {
             split_row_range, row_y_shift,
         );
 
+
+        // ── 5-1. 표 전체 외곽 테두리 보충 ──
+        // 셀 테두리만으로는 표 외곽이 비어있을 수 있음.
+        // 셀이 해당 외곽 엣지를 커버하지 않는 곳에만 table.border_fill_id fallback 적용.
+        // (셀이 존재하지만 의도적으로 테두리를 없앤 곳에는 적용하지 않음)
+        if table.border_fill_id > 0 {
+            let tbl_idx = (table.border_fill_id as usize).saturating_sub(1);
+            if let Some(tbl_bs) = styles.border_styles.get(tbl_idx) {
+                let borders = &tbl_bs.borders; // [left, right, top, bottom]
+
+                // 셀이 커버하는 외곽 엣지 맵 구축
+                let mut h_covered = vec![vec![false; col_count]; row_count + 1];
+                let mut v_covered = vec![vec![false; row_count]; col_count + 1];
+                for cell in &table.cells {
+                    let c = cell.col as usize;
+                    let r = cell.row as usize;
+                    if c >= col_count || r >= row_count { continue; }
+                    let ec = (c + cell.col_span as usize).min(col_count);
+                    let er = (r + cell.row_span as usize).min(row_count);
+                    // 상단
+                    if r == 0 { for cc in c..ec { h_covered[0][cc] = true; } }
+                    // 하단
+                    if er == row_count { for cc in c..ec { h_covered[row_count][cc] = true; } }
+                    // 좌측
+                    if c == 0 { for rr in r..er { v_covered[0][rr] = true; } }
+                    // 우측
+                    if ec == col_count { for rr in r..er { v_covered[col_count][rr] = true; } }
+                }
+
+                // 셀이 커버하지 않는 외곽 엣지에만 fallback 적용
+                for c in 0..col_count {
+                    if h_edges[0][c].is_none() && !h_covered[0][c] {
+                        let b = &borders[2];
+                        if !matches!(b.line_type, crate::model::style::BorderLineType::None) && b.width > 0 {
+                            h_edges[0][c] = Some(*b);
+                        }
+                    }
+                    if h_edges[row_count][c].is_none() && !h_covered[row_count][c] {
+                        let b = &borders[3];
+                        if !matches!(b.line_type, crate::model::style::BorderLineType::None) && b.width > 0 {
+                            h_edges[row_count][c] = Some(*b);
+                        }
+                    }
+                }
+                for r in 0..row_count {
+                    if v_edges[0][r].is_none() && !v_covered[0][r] {
+                        let b = &borders[0];
+                        if !matches!(b.line_type, crate::model::style::BorderLineType::None) && b.width > 0 {
+                            v_edges[0][r] = Some(*b);
+                        }
+                    }
+                    if v_edges[col_count][r].is_none() && !v_covered[col_count][r] {
+                        let b = &borders[1];
+                        if !matches!(b.line_type, crate::model::style::BorderLineType::None) && b.width > 0 {
+                            v_edges[col_count][r] = Some(*b);
+                        }
+                    }
+                }
+            }
+        }
+
         // ── 6. 테두리 렌더링 ──
         table_node.children.extend(render_edge_borders(
             tree, &h_edges, &v_edges, &row_col_x, &row_y, table_x, table_y,

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -1761,6 +1761,11 @@ impl Renderer for SvgRenderer {
     }
 
     fn draw_text(&mut self, text: &str, x: f64, y: f64, style: &TextStyle) {
+        // PUA 문자(U+F000~F0FF, Wingdings 등 심볼 폰트)를 유니코드 표준 문자로 변환
+        let text = &text.chars().map(|ch| {
+            crate::renderer::layout::map_pua_bullet_char(ch)
+        }).collect::<String>();
+
         let color = color_to_svg(style.color);
         let font_size = if style.font_size > 0.0 { style.font_size } else { 12.0 };
         let font_family = if style.font_family.is_empty() {

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -1166,6 +1166,11 @@ impl Renderer for WebCanvasRenderer {
     }
 
     fn draw_text(&mut self, text: &str, x: f64, y: f64, style: &TextStyle) {
+        // PUA 문자(U+F000~F0FF, Wingdings 등 심볼 폰트)를 유니코드 표준 문자로 변환
+        let text = &text.chars().map(|ch| {
+            crate::renderer::layout::map_pua_bullet_char(ch)
+        }).collect::<String>();
+
         // 글꼴 설정
         let font_weight = if style.bold { "bold " } else { "" };
         let font_style = if style.italic { "italic " } else { "" };


### PR DESCRIPTION
## 개요

Issue: #249

Visual Diff 파이프라인(한컴 PDF ↔ rhwp SVG 페이지별 픽셀 비교)을 통해 발견한 렌더링 불일치 3건 수정.

## 변경 사항

### 1. PUA 심볼 문자 렌더링 (`8e5183c`)

Wingdings 등 심볼 폰트의 PUA 영역(U+F000~F0FF) 문자를 유니코드 표준 문자로 변환.
SVG, Canvas, HTML 세 렌더러에 `map_pua_bullet_char()` 일관 적용.

### 2. 문단 border_fill margin 반영 (`7e2c6eb`)

border_fill rect 계산 시 `margin_left`/`margin_right` 적용.
테두리 박스 위치·폭이 텍스트 영역과 정확히 일치.

### 3. 표 외곽 테두리 fallback + clip_rect 개선 (`3f0538d`)

- `border_fill_id` 설정 시 외곽 테두리 그리기, 셀 커버 영역 제외 처리
- clip_rect를 콘텐츠 레이아웃 후 확정하여 표 외곽 테두리 클리핑 방지

## 검증

- `cargo test`: 793개 전체 통과, 0 실패
- Visual Diff 파이프라인으로 한컴 렌더링과 페이지별 비교 검증

## 문서

- `mydocs/plans/task_m100_249.md` — 수행계획서
- `mydocs/plans/task_m100_249_impl.md` — 구현계획서
- `mydocs/report/task_m100_249_report.md` — 최종 결과보고서
- `mydocs/plans/task_m100_250.md` — #250 Right Tab 수행계획서 (이 PR에 코드 미포함)

## 비포함 사항

- Right Tab 정렬 수정: 별도 Issue #250 + PR로 진행 예정
- Cargo.toml 버전 bump / CHANGELOG: 메인테이너 릴리즈 시점에 처리