### PR TITLE
Add Firefox Extension

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@ Cargo.lock
 .DS_Store
 Thumbs.db
 
+# Node
+node_modules/
+
 # 폰트 (저작권 보호)
 /ttfs/hwp/
 /ttfs/windows/
@@ -77,3 +80,6 @@ rhwp-chrome/dist/
 rhwp-safari/dist/
 rhwp-safari/HWP Viewer/
 rhwp-safari/.DS_Store
+
+# rhwp-firefox 빌드 산출물
+rhwp-firefox/dist/

--- a/rhwp-firefox/README.md
+++ b/rhwp-firefox/README.md
@@ -1,0 +1,38 @@
+# rhwp Firefox Extension
+
+Firefox WebExtension build of rhwp's HWP/HWPX viewer and editor.
+
+## Build
+
+The Firefox package reuses the rhwp-studio viewer and copies Firefox-specific
+extension files into `rhwp-firefox/dist`.
+
+```bash
+cd rhwp-firefox
+npm install
+npm run build
+```
+
+The repository must already have the Rust/WASM package in `pkg/`. If `pkg/` is
+missing, build it from the repository root first:
+
+```bash
+cp .env.docker.example .env.docker
+docker compose --env-file .env.docker run --rm wasm
+```
+
+## Load Temporarily
+
+1. Open `about:debugging#/runtime/this-firefox` in Firefox.
+2. Click "Load Temporary Add-on...".
+3. Select `rhwp-firefox/dist/manifest.json`.
+
+## Firefox Notes
+
+Chrome uses `background.service_worker` for Manifest V3. Firefox does not
+support extension background service workers yet, so this build uses
+`background.scripts` with ES modules.
+
+Firefox also does not support Chrome's `downloads.onDeterminingFilename` event.
+This build opens detected HWP/HWPX downloads with `downloads.onCreated` where
+available and intercepts direct HWP/HWPX link clicks from the content script.

--- a/rhwp-firefox/background.js
+++ b/rhwp-firefox/background.js
@@ -1,0 +1,23 @@
+import { openViewer } from './sw/viewer-launcher.js';
+import { setupContextMenus } from './sw/context-menus.js';
+import { setupDownloadObserver } from './sw/download-observer.js';
+import { setupMessageRouter } from './sw/message-router.js';
+
+browser.runtime.onInstalled.addListener((details) => {
+  setupContextMenus();
+
+  if (details.reason === 'install') {
+    browser.storage.sync.set({
+      autoOpen: true,
+      showBadges: true,
+      hoverPreview: true,
+    });
+  }
+});
+
+browser.action.onClicked.addListener(() => {
+  openViewer();
+});
+
+setupDownloadObserver();
+setupMessageRouter();

--- a/rhwp-firefox/build.mjs
+++ b/rhwp-firefox/build.mjs
@@ -1,0 +1,114 @@
+#!/usr/bin/env node
+
+import { execFileSync } from 'child_process';
+import {
+  cpSync,
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  renameSync,
+  writeFileSync,
+} from 'fs';
+import { dirname, resolve } from 'path';
+import { fileURLToPath } from 'url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, '..');
+const DIST = resolve(__dirname, 'dist');
+
+function run(file, args, cwd = __dirname) {
+  console.log(`> ${file} ${args.join(' ')}`);
+  execFileSync(file, args, {
+    stdio: 'inherit',
+    cwd,
+  });
+}
+
+function copy(src, dest, options = {}) {
+  if (!existsSync(src)) {
+    console.warn(`  SKIP: ${src}`);
+    return;
+  }
+  cpSync(src, dest, { recursive: true, ...options });
+  console.log(`  COPY: ${src} -> ${dest}`);
+}
+
+const EXCLUDE_FROM_DIST = /\.(test|spec)\.[mc]?[jt]sx?$/i;
+const viteCli = resolve(__dirname, 'node_modules', 'vite', 'bin', 'vite.js');
+
+console.log('=== rhwp-firefox build start ===\n');
+
+console.log('[1/4] Building viewer with Vite...');
+const studioDir = resolve(ROOT, 'rhwp-studio');
+run(process.execPath, [viteCli, 'build', '--config', resolve(__dirname, 'vite.config.ts')], studioDir);
+
+const indexHtml = resolve(DIST, 'index.html');
+const viewerHtml = resolve(DIST, 'viewer.html');
+if (existsSync(indexHtml)) {
+  renameSync(indexHtml, viewerHtml);
+  console.log('  RENAME: index.html -> viewer.html');
+}
+
+if (existsSync(viewerHtml)) {
+  const viewerContent = readFileSync(viewerHtml, 'utf-8');
+  writeFileSync(viewerHtml, viewerContent.replace(
+    '</head>',
+    '  <script src="/firefox-compat.js"></script>\n  <script src="/dev-tools-inject.js"></script>\n</head>',
+  ));
+  console.log('  INJECT: firefox-compat.js + dev-tools-inject.js');
+}
+
+console.log('\n[2/4] Copying extension files...');
+copy(resolve(__dirname, 'manifest.json'), resolve(DIST, 'manifest.json'));
+copy(resolve(__dirname, 'background.js'), resolve(DIST, 'background.js'));
+copy(resolve(__dirname, 'content-script.js'), resolve(DIST, 'content-script.js'));
+copy(resolve(ROOT, 'rhwp-chrome', 'content-script.css'), resolve(DIST, 'content-script.css'));
+copy(resolve(ROOT, 'rhwp-chrome', 'dev-tools-inject.js'), resolve(DIST, 'dev-tools-inject.js'));
+copy(resolve(__dirname, 'firefox-compat.js'), resolve(DIST, 'firefox-compat.js'));
+copy(resolve(__dirname, 'sw'), resolve(DIST, 'sw'), {
+  filter: (src) => !EXCLUDE_FROM_DIST.test(src),
+});
+copy(resolve(__dirname, 'options.js'), resolve(DIST, 'options.js'));
+copy(resolve(ROOT, 'rhwp-chrome', 'options.html'), resolve(DIST, 'options.html'));
+copy(resolve(ROOT, 'rhwp-chrome', 'icons'), resolve(DIST, 'icons'));
+copy(resolve(ROOT, 'rhwp-chrome', '_locales'), resolve(DIST, '_locales'));
+
+mkdirSync(resolve(DIST, 'images'), { recursive: true });
+copy(
+  resolve(ROOT, 'rhwp-studio', 'public', 'images', 'icon_small_ko.svg'),
+  resolve(DIST, 'images', 'icon_small_ko.svg'),
+);
+copy(resolve(ROOT, 'rhwp-studio', 'public', 'favicon.ico'), resolve(DIST, 'favicon.ico'));
+
+console.log('\n[3/4] Copying WASM package...');
+mkdirSync(resolve(DIST, 'wasm'), { recursive: true });
+copy(resolve(ROOT, 'pkg', 'rhwp.js'), resolve(DIST, 'wasm', 'rhwp.js'));
+copy(resolve(ROOT, 'pkg', 'rhwp.d.ts'), resolve(DIST, 'wasm', 'rhwp.d.ts'));
+copy(resolve(ROOT, 'pkg', 'rhwp_bg.wasm'), resolve(DIST, 'wasm', 'rhwp_bg.wasm'));
+copy(resolve(ROOT, 'pkg', 'rhwp_bg.wasm.d.ts'), resolve(DIST, 'wasm', 'rhwp_bg.wasm.d.ts'));
+
+console.log('\n[4/4] Copying fonts...');
+mkdirSync(resolve(DIST, 'fonts'), { recursive: true });
+const essentialFonts = [
+  'Pretendard-Regular.woff2',
+  'Pretendard-Bold.woff2',
+  'NotoSansKR-Regular.woff2',
+  'NotoSansKR-Bold.woff2',
+  'NotoSerifKR-Regular.woff2',
+  'NotoSerifKR-Bold.woff2',
+  'GowunBatang-Regular.woff2',
+  'GowunBatang-Bold.woff2',
+  'GowunDodum-Regular.woff2',
+  'NanumGothic-Regular.woff2',
+  'NanumGothic-Bold.woff2',
+  'NanumMyeongjo-Regular.woff2',
+  'NanumMyeongjo-Bold.woff2',
+  'D2Coding-Regular.woff2',
+];
+
+for (const font of essentialFonts) {
+  copy(resolve(ROOT, 'web', 'fonts', font), resolve(DIST, 'fonts', font));
+}
+
+console.log('\n=== rhwp-firefox build complete ===');
+console.log(`Output: ${DIST}`);

--- a/rhwp-firefox/content-script.js
+++ b/rhwp-firefox/content-script.js
@@ -1,7 +1,7 @@
 (function () {
   'use strict';
 
-  const VERSION = '0.2.1';
+  const VERSION = (browser.runtime.getManifest() && browser.runtime.getManifest().version) || '';
   const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';

--- a/rhwp-firefox/content-script.js
+++ b/rhwp-firefox/content-script.js
@@ -1,0 +1,375 @@
+(function () {
+  'use strict';
+
+  const VERSION = '0.2.1';
+  const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
+  const BADGE_CLASS = 'rhwp-badge';
+  const HOVER_CLASS = 'rhwp-hover-card';
+  const PROCESSED_ATTR = 'data-rhwp-processed';
+  const PREFETCH_CONCURRENCY = 3;
+
+  let settings = { autoOpen: true, showBadges: true, hoverPreview: true };
+  let activeCard = null;
+  let hoverTimeout = null;
+  let prefetchQueue = [];
+  let prefetchActive = 0;
+  const thumbnailCache = new Map();
+
+  browser.runtime.sendMessage({ type: 'get-settings' })
+    .then((result) => {
+      if (result) settings = { ...settings, ...result };
+    })
+    .catch(() => {})
+    .finally(init);
+
+  function init() {
+    announceExtension();
+    injectDevTools();
+
+    if (settings.showBadges) {
+      processLinks();
+      observeDynamicContent();
+    } else if (settings.autoOpen || settings.hoverPreview) {
+      processLinks();
+      observeDynamicContent();
+    }
+
+    if (settings.hoverPreview) {
+      prefetchThumbnails();
+    }
+  }
+
+  function announceExtension() {
+    document.documentElement.setAttribute('data-hwp-extension', 'rhwp');
+    document.documentElement.setAttribute('data-hwp-extension-version', VERSION);
+    window.dispatchEvent(new CustomEvent('hwp-extension-ready', {
+      detail: { name: 'rhwp', version: VERSION, capabilities: ['preview', 'edit', 'print'] },
+    }));
+  }
+
+  function injectDevTools() {
+    const devScript = document.createElement('script');
+    devScript.src = browser.runtime.getURL('dev-tools-inject.js');
+    (document.head || document.documentElement).appendChild(devScript);
+    devScript.onload = () => devScript.remove();
+  }
+
+  function createEl(tag, className, text) {
+    const el = document.createElement(tag);
+    if (className) el.className = className;
+    if (text != null) el.textContent = text;
+    return el;
+  }
+
+  function truncate(str, max) {
+    if (!str) return '';
+    return str.length > max ? `${str.slice(0, max)}...` : str;
+  }
+
+  function formatSize(bytes) {
+    if (!Number.isFinite(bytes)) return '';
+    if (bytes < 1024) return `${bytes}B`;
+    if (bytes < 1024 * 1024) return `${Math.round(bytes / 1024)}KB`;
+    return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+  }
+
+  function isHwpLink(anchor) {
+    if (!anchor.href) return false;
+    if (anchor.getAttribute('data-hwp') === 'true') return true;
+    return HWP_EXTENSIONS.test(anchor.href);
+  }
+
+  function filenameFromAnchor(anchor) {
+    try {
+      const url = new URL(anchor.href);
+      const name = decodeURIComponent(url.pathname.split('/').pop() || '');
+      if (name) return name;
+    } catch {
+      // Fall through to text fallback.
+    }
+    return anchor.textContent.trim() || 'document.hwp';
+  }
+
+  function isSafeImageUrl(url) {
+    try {
+      const parsed = new URL(url);
+      return parsed.protocol === 'https:' || parsed.protocol === 'http:';
+    } catch {
+      return false;
+    }
+  }
+
+  function openHwp(anchor) {
+    return browser.runtime.sendMessage({
+      type: 'open-hwp',
+      url: anchor.href,
+      filename: filenameFromAnchor(anchor),
+    });
+  }
+
+  function createBadge(anchor) {
+    const badge = document.createElement('span');
+    badge.className = BADGE_CLASS;
+
+    const title = anchor.getAttribute('data-hwp-title');
+    const pages = anchor.getAttribute('data-hwp-pages');
+    const size = anchor.getAttribute('data-hwp-size');
+
+    if (title && pages && size) {
+      badge.title = browser.i18n.getMessage(
+        'badgeTooltipWithInfo',
+        [title, pages, formatSize(Number(size))],
+      );
+    } else {
+      badge.title = title || browser.i18n.getMessage('badgeTooltip') || 'Open with rhwp';
+    }
+
+    badge.addEventListener('click', (event) => {
+      event.preventDefault();
+      event.stopPropagation();
+      openHwp(anchor).catch(() => {});
+    });
+
+    return badge;
+  }
+
+  function attachClickInterceptor(anchor) {
+    if (!settings.autoOpen) return;
+
+    anchor.addEventListener('click', (event) => {
+      if (event.defaultPrevented) return;
+      if (event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) return;
+
+      event.preventDefault();
+      openHwp(anchor).catch(() => {
+        window.location.href = anchor.href;
+      });
+    });
+  }
+
+  function insertThumbnailImg(thumbDiv, dataUri) {
+    const img = document.createElement('img');
+    img.src = new URL(dataUri).href;
+    img.alt = 'Preview';
+    img.referrerPolicy = 'no-referrer';
+    thumbDiv.textContent = '';
+    thumbDiv.className = 'rhwp-hover-thumb';
+    thumbDiv.appendChild(img);
+  }
+
+  function showHoverCard(anchor) {
+    if (!settings.hoverPreview) return;
+
+    hideHoverCard();
+
+    const card = document.createElement('div');
+    card.className = HOVER_CLASS;
+
+    const thumbnail = anchor.getAttribute('data-hwp-thumbnail');
+    const thumbContainer = document.createElement('div');
+    if (thumbnail && isSafeImageUrl(thumbnail)) {
+      insertThumbnailImg(thumbContainer, thumbnail);
+    } else {
+      thumbContainer.className = 'rhwp-hover-thumb rhwp-thumb-loading';
+      thumbContainer.appendChild(createEl('span', 'rhwp-thumb-spinner', '...'));
+    }
+    card.appendChild(thumbContainer);
+
+    const title = anchor.getAttribute('data-hwp-title') || filenameFromAnchor(anchor);
+    card.appendChild(createEl('div', 'rhwp-hover-title', truncate(title, 200)));
+
+    const meta = [];
+    const format = anchor.getAttribute('data-hwp-format');
+    const pages = anchor.getAttribute('data-hwp-pages');
+    const size = anchor.getAttribute('data-hwp-size');
+    if (format) meta.push(truncate(format.toUpperCase(), 10));
+    if (pages && !Number.isNaN(Number(pages))) meta.push(`${pages} pages`);
+    if (size && !Number.isNaN(Number(size))) meta.push(formatSize(Number(size)));
+    if (meta.length > 0) {
+      card.appendChild(createEl('div', 'rhwp-hover-meta', meta.join(' \u00B7 ')));
+    }
+
+    const author = anchor.getAttribute('data-hwp-author');
+    const date = anchor.getAttribute('data-hwp-date');
+    if (author || date) {
+      const info = [];
+      if (author) info.push(truncate(author, 100));
+      if (date) info.push(truncate(date, 20));
+      card.appendChild(createEl('div', 'rhwp-hover-info', info.join(' \u00B7 ')));
+    }
+
+    const category = anchor.getAttribute('data-hwp-category');
+    if (category) {
+      card.appendChild(createEl('div', 'rhwp-hover-category', truncate(category, 50)));
+    }
+
+    const description = anchor.getAttribute('data-hwp-description');
+    if (description) {
+      card.appendChild(createEl('div', 'rhwp-hover-desc', truncate(description, 500)));
+    }
+
+    const footer = document.createElement('div');
+    footer.className = 'rhwp-hover-action';
+    footer.appendChild(createEl('span', 'rhwp-hover-action-label', 'Open with rhwp'));
+    footer.appendChild(createEl('span', 'rhwp-hover-action-arrow', '>'));
+    card.appendChild(footer);
+
+    card.addEventListener('click', () => {
+      openHwp(anchor).catch(() => {});
+      hideHoverCard();
+    });
+
+    const rect = anchor.getBoundingClientRect();
+    document.body.appendChild(card);
+    activeCard = card;
+
+    const cardHeight = card.offsetHeight;
+    const spaceBelow = window.innerHeight - rect.bottom;
+    const spaceAbove = rect.top;
+
+    let left = rect.left + window.scrollX;
+    let top;
+
+    if (spaceBelow >= cardHeight + 8) {
+      top = rect.bottom + window.scrollY + 4;
+    } else if (spaceAbove >= cardHeight + 8) {
+      top = rect.top + window.scrollY - cardHeight - 4;
+    } else {
+      top = window.scrollY + window.innerHeight - cardHeight - 8;
+    }
+
+    const cardWidth = card.offsetWidth;
+    if (left + cardWidth > window.scrollX + window.innerWidth - 8) {
+      left = window.scrollX + window.innerWidth - cardWidth - 8;
+    }
+    if (left < window.scrollX + 8) left = window.scrollX + 8;
+
+    card.style.left = `${left}px`;
+    card.style.top = `${top}px`;
+
+    card.addEventListener('mouseenter', () => clearTimeout(hoverTimeout));
+    card.addEventListener('mouseleave', () => hideHoverCard());
+
+    loadThumbnail(anchor, card, thumbnail);
+  }
+
+  function loadThumbnail(anchor, card, thumbnail) {
+    if (thumbnail || !anchor.href) return;
+
+    const cached = thumbnailCache.get(anchor.href);
+    if (cached) {
+      const thumbDiv = card.querySelector('.rhwp-thumb-loading');
+      if (thumbDiv) insertThumbnailImg(thumbDiv, cached.dataUri);
+      return;
+    }
+
+    if (cached === null) {
+      const thumbDiv = card.querySelector('.rhwp-thumb-loading');
+      if (thumbDiv) thumbDiv.remove();
+      return;
+    }
+
+    browser.runtime.sendMessage({ type: 'extract-thumbnail', url: anchor.href })
+      .then((response) => {
+        if (response?.dataUri) {
+          thumbnailCache.set(anchor.href, response);
+          if (activeCard === card) {
+            const thumbDiv = card.querySelector('.rhwp-thumb-loading');
+            if (thumbDiv) insertThumbnailImg(thumbDiv, response.dataUri);
+          }
+        } else {
+          thumbnailCache.set(anchor.href, null);
+          if (activeCard === card) {
+            const thumbDiv = card.querySelector('.rhwp-thumb-loading');
+            if (thumbDiv) thumbDiv.remove();
+          }
+        }
+      })
+      .catch(() => thumbnailCache.set(anchor.href, null));
+  }
+
+  function hideHoverCard() {
+    if (activeCard) {
+      activeCard.remove();
+      activeCard = null;
+    }
+    clearTimeout(hoverTimeout);
+  }
+
+  function attachHoverEvents(anchor) {
+    if (!settings.hoverPreview) return;
+
+    anchor.addEventListener('mouseenter', () => {
+      clearTimeout(hoverTimeout);
+      hideHoverCard();
+      hoverTimeout = setTimeout(() => showHoverCard(anchor), 300);
+    });
+    anchor.addEventListener('mouseleave', () => {
+      hoverTimeout = setTimeout(() => hideHoverCard(), 200);
+    });
+  }
+
+  function prefetchThumbnails() {
+    setTimeout(() => {
+      const anchors = document.querySelectorAll('a[href]');
+      for (const anchor of anchors) {
+        if (!isHwpLink(anchor)) continue;
+        if (anchor.getAttribute('data-hwp-thumbnail')) continue;
+        if (thumbnailCache.has(anchor.href)) continue;
+        prefetchQueue.push(anchor.href);
+      }
+      prefetchQueue = [...new Set(prefetchQueue)];
+      drainPrefetchQueue();
+    }, 1000);
+  }
+
+  function drainPrefetchQueue() {
+    while (prefetchActive < PREFETCH_CONCURRENCY && prefetchQueue.length > 0) {
+      const url = prefetchQueue.shift();
+      if (thumbnailCache.has(url)) continue;
+
+      prefetchActive++;
+      browser.runtime.sendMessage({ type: 'extract-thumbnail', url })
+        .then((response) => {
+          thumbnailCache.set(url, response?.dataUri ? response : null);
+        })
+        .catch(() => thumbnailCache.set(url, null))
+        .finally(() => {
+          prefetchActive--;
+          drainPrefetchQueue();
+        });
+    }
+  }
+
+  function processLinks(root = document) {
+    const anchors = root.querySelectorAll('a[href]');
+    for (const anchor of anchors) {
+      if (anchor.hasAttribute(PROCESSED_ATTR)) continue;
+      if (!isHwpLink(anchor)) continue;
+
+      anchor.setAttribute(PROCESSED_ATTR, 'true');
+
+      if (settings.showBadges) {
+        const badge = createBadge(anchor);
+        anchor.style.position = anchor.style.position || 'relative';
+        anchor.insertAdjacentElement('afterend', badge);
+      }
+
+      attachClickInterceptor(anchor);
+      attachHoverEvents(anchor);
+    }
+  }
+
+  function observeDynamicContent() {
+    const observer = new MutationObserver((mutations) => {
+      for (const mutation of mutations) {
+        for (const node of mutation.addedNodes) {
+          if (node.nodeType === Node.ELEMENT_NODE) {
+            processLinks(node);
+          }
+        }
+      }
+    });
+    observer.observe(document.body, { childList: true, subtree: true });
+  }
+})();

--- a/rhwp-firefox/firefox-compat.js
+++ b/rhwp-firefox/firefox-compat.js
@@ -1,0 +1,18 @@
+(function () {
+  'use strict';
+
+  if (typeof browser === 'undefined') return;
+
+  try {
+    globalThis.chrome = browser;
+  } catch {
+    try {
+      Object.defineProperty(globalThis, 'chrome', {
+        value: browser,
+        configurable: true,
+      });
+    } catch {
+      // Ignore. Firefox normally exposes chrome for compatibility already.
+    }
+  }
+})();

--- a/rhwp-firefox/manifest.json
+++ b/rhwp-firefox/manifest.json
@@ -1,0 +1,60 @@
+{
+  "manifest_version": 3,
+  "name": "__MSG_extName__",
+  "version": "0.2.1",
+  "description": "__MSG_extDescription__",
+  "default_locale": "ko",
+  "icons": {
+    "16": "icons/icon-16.png",
+    "32": "icons/icon-32.png",
+    "48": "icons/icon-48.png",
+    "128": "icons/icon-128.png"
+  },
+  "action": {
+    "default_icon": {
+      "16": "icons/icon-16.png",
+      "32": "icons/icon-32.png"
+    },
+    "default_title": "__MSG_actionTitle__"
+  },
+  "background": {
+    "scripts": ["background.js"],
+    "type": "module"
+  },
+  "content_scripts": [
+    {
+      "matches": ["<all_urls>"],
+      "js": ["content-script.js"],
+      "css": ["content-script.css"],
+      "run_at": "document_idle"
+    }
+  ],
+  "permissions": [
+    "activeTab",
+    "downloads",
+    "contextMenus",
+    "clipboardWrite",
+    "storage"
+  ],
+  "host_permissions": [
+    "<all_urls>"
+  ],
+  "content_security_policy": {
+    "extension_pages": "script-src 'self' 'wasm-unsafe-eval'; object-src 'self'"
+  },
+  "web_accessible_resources": [
+    {
+      "resources": ["wasm/*", "fonts/*", "icons/*", "dev-tools-inject.js"],
+      "matches": ["<all_urls>"]
+    }
+  ],
+  "options_ui": {
+    "page": "options.html",
+    "open_in_tab": true
+  },
+  "browser_specific_settings": {
+    "gecko": {
+      "strict_min_version": "109.0"
+    }
+  }
+}

--- a/rhwp-firefox/options.js
+++ b/rhwp-firefox/options.js
@@ -1,0 +1,36 @@
+(function () {
+  'use strict';
+
+  const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+
+  document.getElementById('title').textContent = browser.i18n.getMessage('optionsTitle');
+  document.getElementById('labelAutoOpen').textContent = browser.i18n.getMessage('optionsAutoOpen');
+  document.getElementById('labelShowBadges').textContent = browser.i18n.getMessage('optionsShowBadges');
+  document.getElementById('labelHoverPreview').textContent = browser.i18n.getMessage('optionsHoverPreview');
+  document.getElementById('saved').textContent = browser.i18n.getMessage('optionsSaved');
+  document.getElementById('privacy').textContent = browser.i18n.getMessage('optionsPrivacy');
+  document.getElementById('version').textContent = browser.runtime.getManifest().version;
+
+  browser.storage.sync.get(
+    { autoOpen: true, showBadges: true, hoverPreview: true },
+  ).then((settings) => {
+    for (const id of inputs) {
+      document.getElementById(id).checked = settings[id];
+    }
+  });
+
+  for (const id of inputs) {
+    document.getElementById(id).addEventListener('change', () => {
+      const settings = {};
+      for (const id2 of inputs) {
+        settings[id2] = document.getElementById(id2).checked;
+      }
+
+      browser.storage.sync.set(settings).then(() => {
+        const saved = document.getElementById('saved');
+        saved.classList.add('show');
+        setTimeout(() => saved.classList.remove('show'), 1500);
+      });
+    });
+  }
+})();

--- a/rhwp-firefox/package-lock.json
+++ b/rhwp-firefox/package-lock.json
@@ -1,0 +1,1120 @@
+{
+  "name": "rhwp-firefox",
+  "version": "0.2.1",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "rhwp-firefox",
+      "version": "0.2.1",
+      "license": "MIT",
+      "devDependencies": {
+        "typescript": "^5.7.0",
+        "vite": "^6.1.0"
+      }
+    },
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.25.12.tgz",
+      "integrity": "sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.25.12.tgz",
+      "integrity": "sha512-VJ+sKvNA/GE7Ccacc9Cha7bpS8nyzVv0jdVgwNDaR4gDMC/2TTRc33Ip8qrNYUcpkOHUT5OZ0bUcNNVZQ9RLlg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.25.12.tgz",
+      "integrity": "sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/android-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.25.12.tgz",
+      "integrity": "sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.25.12.tgz",
+      "integrity": "sha512-N3zl+lxHCifgIlcMUP5016ESkeQjLj/959RxxNYIthIg+CQHInujFuXeWbWMgnTo4cp5XVHqFPmpyu9J65C1Yg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/darwin-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.25.12.tgz",
+      "integrity": "sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-gA0Bx759+7Jve03K1S0vkOu5Lg/85dou3EseOGUes8flVOGxbhDDh/iZaoek11Y8mtyKPGF3vP8XhnkDEAmzeg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/freebsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.25.12.tgz",
+      "integrity": "sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.25.12.tgz",
+      "integrity": "sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.25.12.tgz",
+      "integrity": "sha512-8bwX7a8FghIgrupcxb4aUmYDLp8pX06rGh5HqDT7bB+8Rdells6mHvrFHHW2JAOPZUbnjUpKTLg6ECyzvas2AQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.25.12.tgz",
+      "integrity": "sha512-0y9KrdVnbMM2/vG8KfU0byhUN+EFCny9+8g202gYqSSVMonbsCfLjUO+rCci7pM0WBEtz+oK/PIwHkzxkyharA==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-loong64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.25.12.tgz",
+      "integrity": "sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-mips64el": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.25.12.tgz",
+      "integrity": "sha512-iyRrM1Pzy9GFMDLsXn1iHUm18nhKnNMWscjmp4+hpafcZjrr2WbT//d20xaGljXDBYHqRcl8HnxbX6uaA/eGVw==",
+      "cpu": [
+        "mips64el"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-ppc64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.25.12.tgz",
+      "integrity": "sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-riscv64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.25.12.tgz",
+      "integrity": "sha512-Zr7KR4hgKUpWAwb1f3o5ygT04MzqVrGEGXGLnj15YQDJErYu/BGg+wmFlIDOdJp0PmB0lLvxFIOXZgFRrdjR0w==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-s390x": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.25.12.tgz",
+      "integrity": "sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/linux-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.25.12.tgz",
+      "integrity": "sha512-uqZMTLr/zR/ed4jIGnwSLkaHmPjOjJvnm6TVVitAa08SLS9Z0VM8wIRx7gWbJB5/J54YuIMInDquWyYvQLZkgw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-Ld5pTlzPy3YwGec4OuHh1aCVCRvOXdH8DgRjfDy/oumVovmuSzWfnSJg+VtakB9Cm0gxNO9BzWkj6mtO1FMXkQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.25.12.tgz",
+      "integrity": "sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.25.12.tgz",
+      "integrity": "sha512-MZyXUkZHjQxUvzK7rN8DJ3SRmrVrke8ZyRusHlP+kuwqTcfWLyqMOE3sScPPyeIXN/mDJIfGXvcMqCgYKekoQw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.25.12.tgz",
+      "integrity": "sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/sunos-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.25.12.tgz",
+      "integrity": "sha512-3wGSCDyuTHQUzt0nV7bocDy72r2lI33QL3gkDNGkod22EsYl04sMf0qLb8luNKTOmgF/eDEDP5BFNwoBKH441w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "sunos"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-arm64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.25.12.tgz",
+      "integrity": "sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-ia32": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.25.12.tgz",
+      "integrity": "sha512-HkqnmmBoCbCwxUKKNPBixiWDGCpQGVsrQfJoVGYLPT41XWF8lHuE5N6WhVia2n4o5QK5M4tYr21827fNhi4byQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/win32-x64": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.25.12.tgz",
+      "integrity": "sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@rollup/rollup-android-arm-eabi": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.2.tgz",
+      "integrity": "sha512-dnlp69efPPg6Uaw2dVqzWRfAWRnYVb1XJ8CyyhIbZeaq4CA5/mLeZ1IEt9QqQxmbdvagjLIm2ZL8BxXv5lH4Yw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-android-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.2.tgz",
+      "integrity": "sha512-OqZTwDRDchGRHHm/hwLOL7uVPB9aUvI0am/eQuWMNyFHf5PSEQmyEeYYheA0EPPKUO/l0uigCp+iaTjoLjVoHg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.2.tgz",
+      "integrity": "sha512-UwRE7CGpvSVEQS8gUMBe1uADWjNnVgP3Iusyda1nSRwNDCsRjnGc7w6El6WLQsXmZTbLZx9cecegumcitNfpmA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-darwin-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.2.tgz",
+      "integrity": "sha512-gjEtURKLCC5VXm1I+2i1u9OhxFsKAQJKTVB8WvDAHF+oZlq0GTVFOlTlO1q3AlCTE/DF32c16ESvfgqR7343/g==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.2.tgz",
+      "integrity": "sha512-Bcl6CYDeAgE70cqZaMojOi/eK63h5Me97ZqAQoh77VPjMysA/4ORQBRGo3rRy45x4MzVlU9uZxs8Uwy7ZaKnBw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-freebsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.2.tgz",
+      "integrity": "sha512-LU+TPda3mAE2QB0/Hp5VyeKJivpC6+tlOXd1VMoXV/YFMvk/MNk5iXeBfB4MQGRWyOYVJ01625vjkr0Az98OJQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.2.tgz",
+      "integrity": "sha512-2QxQrM+KQ7DAW4o22j+XZ6RKdxjLD7BOWTP0Bv0tmjdyhXSsr2Ul1oJDQqh9Zf5qOwTuTc7Ek83mOFaKnodPjg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.2.tgz",
+      "integrity": "sha512-TbziEu2DVsTEOPif2mKWkMeDMLoYjx95oESa9fkQQK7r/Orta0gnkcDpzwufEcAO2BLBsD7mZkXGFqEdMRRwfw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.2.tgz",
+      "integrity": "sha512-bO/rVDiDUuM2YfuCUwZ1t1cP+/yqjqz+Xf2VtkdppefuOFS2OSeAfgafaHNkFn0t02hEyXngZkxtGqXcXwO8Rg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-arm64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.2.tgz",
+      "integrity": "sha512-hr26p7e93Rl0Za+JwW7EAnwAvKkehh12BU1Llm9Ykiibg4uIr2rbpxG9WCf56GuvidlTG9KiiQT/TXT1yAWxTA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.2.tgz",
+      "integrity": "sha512-pOjB/uSIyDt+ow3k/RcLvUAOGpysT2phDn7TTUB3n75SlIgZzM6NKAqlErPhoFU+npgY3/n+2HYIQVbF70P9/A==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-loong64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.2.tgz",
+      "integrity": "sha512-2/w+q8jszv9Ww1c+6uJT3OwqhdmGP2/4T17cu8WuwyUuuaCDDJ2ojdyYwZzCxx0GcsZBhzi3HmH+J5pZNXnd+Q==",
+      "cpu": [
+        "loong64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.2.tgz",
+      "integrity": "sha512-11+aL5vKheYgczxtPVVRhdptAM2H7fcDR5Gw4/bTcteuZBlH4oP9f5s9zYO9aGZvoGeBpqXI/9TZZihZ609wKw==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-ppc64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.2.tgz",
+      "integrity": "sha512-i16fokAGK46IVZuV8LIIwMdtqhin9hfYkCh8pf8iC3QU3LpwL+1FSFGej+O7l3E/AoknL6Dclh2oTdnRMpTzFQ==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.2.tgz",
+      "integrity": "sha512-49FkKS6RGQoriDSK/6E2GkAsAuU5kETFCh7pG4yD/ylj9rKhTmO3elsnmBvRD4PgJPds5W2PkhC82aVwmUcJ7A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-riscv64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.2.tgz",
+      "integrity": "sha512-mjYNkHPfGpUR00DuM1ZZIgs64Hpf4bWcz9Z41+4Q+pgDx73UwWdAYyf6EG/lRFldmdHHzgrYyge5akFUW0D3mQ==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-s390x-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.2.tgz",
+      "integrity": "sha512-ALyvJz965BQk8E9Al/JDKKDLH2kfKFLTGMlgkAbbYtZuJt9LU8DW3ZoDMCtQpXAltZxwBHevXz5u+gf0yA0YoA==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-UQjrkIdWrKI626Du8lCQ6MJp/6V1LAo2bOK9OTu4mSn8GGXIkPXk/Vsp4bLHCd9Z9Iz2OTEaokUE90VweJgIYQ==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-linux-x64-musl": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.2.tgz",
+      "integrity": "sha512-bTsRGj6VlSdn/XD4CGyzMnzaBs9bsRxy79eTqTCBsA8TMIEky7qg48aPkvJvFe1HyzQ5oMZdg7AnVlWQSKLTnw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rollup/rollup-openbsd-x64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.2.tgz",
+      "integrity": "sha512-6d4Z3534xitaA1FcMWP7mQPq5zGwBmGbhphh2DwaA1aNIXUu3KTOfwrWpbwI4/Gr0uANo7NTtaykFyO2hPuFLg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ]
+    },
+    "node_modules/@rollup/rollup-openharmony-arm64": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.2.tgz",
+      "integrity": "sha512-NetAg5iO2uN7eB8zE5qrZ3CSil+7IJt4WDFLcC75Ymywq1VZVD6qJ6EvNLjZ3rEm6gB7XW5JdT60c6MN35Z85Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-arm64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.2.tgz",
+      "integrity": "sha512-NCYhOotpgWZ5kdxCZsv6Iudx0wX8980Q/oW4pNFNihpBKsDbEA1zpkfxJGC0yugsUuyDZ7gL37dbzwhR0VI7pQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-ia32-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.2.tgz",
+      "integrity": "sha512-RXsaOqXxfoUBQoOgvmmijVxJnW2IGB0eoMO7F8FAjaj0UTywUO/luSqimWBJn04WNgUkeNhh7fs7pESXajWmkg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-gnu": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.2.tgz",
+      "integrity": "sha512-qdAzEULD+/hzObedtmV6iBpdL5TIbKVztGiK7O3/KYSf+HIzU257+MX1EXJcyIiDbMAqmbwaufcYPvyRryeZtA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rollup/rollup-win32-x64-msvc": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.2.tgz",
+      "integrity": "sha512-Nd/SgG27WoA9e+/TdK74KnHz852TLa94ovOYySo/yMPuTmpckK/jIF2jSwS3g7ELSKXK13/cVdmg1Z/DaCWKxA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@types/estree": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
+      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/esbuild": {
+      "version": "0.25.12",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.25.12.tgz",
+      "integrity": "sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "bin": {
+        "esbuild": "bin/esbuild"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@esbuild/aix-ppc64": "0.25.12",
+        "@esbuild/android-arm": "0.25.12",
+        "@esbuild/android-arm64": "0.25.12",
+        "@esbuild/android-x64": "0.25.12",
+        "@esbuild/darwin-arm64": "0.25.12",
+        "@esbuild/darwin-x64": "0.25.12",
+        "@esbuild/freebsd-arm64": "0.25.12",
+        "@esbuild/freebsd-x64": "0.25.12",
+        "@esbuild/linux-arm": "0.25.12",
+        "@esbuild/linux-arm64": "0.25.12",
+        "@esbuild/linux-ia32": "0.25.12",
+        "@esbuild/linux-loong64": "0.25.12",
+        "@esbuild/linux-mips64el": "0.25.12",
+        "@esbuild/linux-ppc64": "0.25.12",
+        "@esbuild/linux-riscv64": "0.25.12",
+        "@esbuild/linux-s390x": "0.25.12",
+        "@esbuild/linux-x64": "0.25.12",
+        "@esbuild/netbsd-arm64": "0.25.12",
+        "@esbuild/netbsd-x64": "0.25.12",
+        "@esbuild/openbsd-arm64": "0.25.12",
+        "@esbuild/openbsd-x64": "0.25.12",
+        "@esbuild/openharmony-arm64": "0.25.12",
+        "@esbuild/sunos-x64": "0.25.12",
+        "@esbuild/win32-arm64": "0.25.12",
+        "@esbuild/win32-ia32": "0.25.12",
+        "@esbuild/win32-x64": "0.25.12"
+      }
+    },
+    "node_modules/fdir": {
+      "version": "6.5.0",
+      "resolved": "https://registry.npmjs.org/fdir/-/fdir-6.5.0.tgz",
+      "integrity": "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "peerDependencies": {
+        "picomatch": "^3 || ^4"
+      },
+      "peerDependenciesMeta": {
+        "picomatch": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/fsevents": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.3.tgz",
+      "integrity": "sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
+      }
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.11",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
+      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/picomatch": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.4.tgz",
+      "integrity": "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/postcss": {
+      "version": "8.5.10",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.10.tgz",
+      "integrity": "sha512-pMMHxBOZKFU6HgAZ4eyGnwXF/EvPGGqUr0MnZ5+99485wwW41kW91A4LOGxSHhgugZmSChL5AlElNdwlNgcnLQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.11",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/rollup": {
+      "version": "4.60.2",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.2.tgz",
+      "integrity": "sha512-J9qZyW++QK/09NyN/zeO0dG/1GdGfyp9lV8ajHnRVLfo/uFsbji5mHnDgn/qYdUHyCkM2N+8VyspgZclfAh0eQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "1.0.8"
+      },
+      "bin": {
+        "rollup": "dist/bin/rollup"
+      },
+      "engines": {
+        "node": ">=18.0.0",
+        "npm": ">=8.0.0"
+      },
+      "optionalDependencies": {
+        "@rollup/rollup-android-arm-eabi": "4.60.2",
+        "@rollup/rollup-android-arm64": "4.60.2",
+        "@rollup/rollup-darwin-arm64": "4.60.2",
+        "@rollup/rollup-darwin-x64": "4.60.2",
+        "@rollup/rollup-freebsd-arm64": "4.60.2",
+        "@rollup/rollup-freebsd-x64": "4.60.2",
+        "@rollup/rollup-linux-arm-gnueabihf": "4.60.2",
+        "@rollup/rollup-linux-arm-musleabihf": "4.60.2",
+        "@rollup/rollup-linux-arm64-gnu": "4.60.2",
+        "@rollup/rollup-linux-arm64-musl": "4.60.2",
+        "@rollup/rollup-linux-loong64-gnu": "4.60.2",
+        "@rollup/rollup-linux-loong64-musl": "4.60.2",
+        "@rollup/rollup-linux-ppc64-gnu": "4.60.2",
+        "@rollup/rollup-linux-ppc64-musl": "4.60.2",
+        "@rollup/rollup-linux-riscv64-gnu": "4.60.2",
+        "@rollup/rollup-linux-riscv64-musl": "4.60.2",
+        "@rollup/rollup-linux-s390x-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-gnu": "4.60.2",
+        "@rollup/rollup-linux-x64-musl": "4.60.2",
+        "@rollup/rollup-openbsd-x64": "4.60.2",
+        "@rollup/rollup-openharmony-arm64": "4.60.2",
+        "@rollup/rollup-win32-arm64-msvc": "4.60.2",
+        "@rollup/rollup-win32-ia32-msvc": "4.60.2",
+        "@rollup/rollup-win32-x64-gnu": "4.60.2",
+        "@rollup/rollup-win32-x64-msvc": "4.60.2",
+        "fsevents": "~2.3.2"
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/tinyglobby": {
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "fdir": "^6.5.0",
+        "picomatch": "^4.0.4"
+      },
+      "engines": {
+        "node": ">=12.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/typescript": {
+      "version": "5.9.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
+      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/vite": {
+      "version": "6.4.2",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
+      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "esbuild": "^0.25.0",
+        "fdir": "^6.4.4",
+        "picomatch": "^4.0.2",
+        "postcss": "^8.5.3",
+        "rollup": "^4.34.9",
+        "tinyglobby": "^0.2.13"
+      },
+      "bin": {
+        "vite": "bin/vite.js"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/vitejs/vite?sponsor=1"
+      },
+      "optionalDependencies": {
+        "fsevents": "~2.3.3"
+      },
+      "peerDependencies": {
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "jiti": ">=1.21.0",
+        "less": "*",
+        "lightningcss": "^1.21.0",
+        "sass": "*",
+        "sass-embedded": "*",
+        "stylus": "*",
+        "sugarss": "*",
+        "terser": "^5.16.0",
+        "tsx": "^4.8.1",
+        "yaml": "^2.4.2"
+      },
+      "peerDependenciesMeta": {
+        "@types/node": {
+          "optional": true
+        },
+        "jiti": {
+          "optional": true
+        },
+        "less": {
+          "optional": true
+        },
+        "lightningcss": {
+          "optional": true
+        },
+        "sass": {
+          "optional": true
+        },
+        "sass-embedded": {
+          "optional": true
+        },
+        "stylus": {
+          "optional": true
+        },
+        "sugarss": {
+          "optional": true
+        },
+        "terser": {
+          "optional": true
+        },
+        "tsx": {
+          "optional": true
+        },
+        "yaml": {
+          "optional": true
+        }
+      }
+    }
+  }
+}

--- a/rhwp-firefox/package.json
+++ b/rhwp-firefox/package.json
@@ -7,7 +7,7 @@
   "type": "module",
   "scripts": {
     "build": "node build.mjs",
-    "check": "node --check background.js && node --check content-script.js && node --check options.js && node --check firefox-compat.js && node --check sw/viewer-launcher.js && node --check sw/context-menus.js && node --check sw/download-observer.js && node --check sw/message-router.js",
+    "check": "node --check background.js && node --check content-script.js && node --check options.js && node --check firefox-compat.js && node --check sw/viewer-launcher.js && node --check sw/context-menus.js && node --check sw/download-observer.js && node --check sw/message-router.js && node --check sw/thumbnail-extractor.js",
     "clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\""
   },
   "devDependencies": {

--- a/rhwp-firefox/package.json
+++ b/rhwp-firefox/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "rhwp-firefox",
+  "version": "0.2.1",
+  "description": "rhwp HWP viewer and editor Firefox extension",
+  "license": "MIT",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "node build.mjs",
+    "check": "node --check background.js && node --check content-script.js && node --check options.js && node --check firefox-compat.js && node --check sw/viewer-launcher.js && node --check sw/context-menus.js && node --check sw/download-observer.js && node --check sw/message-router.js",
+    "clean": "node -e \"import('node:fs').then(fs => fs.rmSync('dist', { recursive: true, force: true }))\""
+  },
+  "devDependencies": {
+    "typescript": "^5.7.0",
+    "vite": "^6.1.0"
+  }
+}

--- a/rhwp-firefox/sw/context-menus.js
+++ b/rhwp-firefox/sw/context-menus.js
@@ -1,0 +1,33 @@
+import { openViewer } from './viewer-launcher.js';
+
+const MENU_ID = 'rhwp-open-link';
+
+export async function setupContextMenus() {
+  try {
+    await browser.contextMenus.removeAll();
+  } catch {
+    // Continue with create. Firefox may reject during extension shutdown/reload.
+  }
+
+  browser.contextMenus.create({
+    id: MENU_ID,
+    title: browser.i18n.getMessage('contextMenuOpen') || 'Open with rhwp',
+    contexts: ['link'],
+    targetUrlPatterns: [
+      '*://*/*.hwp',
+      '*://*/*.hwp?*',
+      '*://*/*.hwpx',
+      '*://*/*.hwpx?*',
+    ],
+  });
+
+  if (!browser.contextMenus.onClicked.hasListener(handleMenuClick)) {
+    browser.contextMenus.onClicked.addListener(handleMenuClick);
+  }
+}
+
+function handleMenuClick(info) {
+  if (info.menuItemId === MENU_ID && info.linkUrl) {
+    openViewer({ url: info.linkUrl });
+  }
+}

--- a/rhwp-firefox/sw/download-observer.js
+++ b/rhwp-firefox/sw/download-observer.js
@@ -1,0 +1,51 @@
+import { openViewer } from './viewer-launcher.js';
+
+const HWP_EXTENSION_RE = /\.(hwp|hwpx)(\?|$)/i;
+const HWP_MIME_HINTS = ['haansoft', 'x-hwp', 'hwp+zip'];
+const NON_REFETCHABLE_PATTERNS = [
+  /\/dext5handler\.[a-z0-9]+/i,
+];
+
+export function shouldOpenDownload(item) {
+  if (!item) return false;
+
+  const url = item.url || '';
+  const referrer = item.referrer || '';
+  if (NON_REFETCHABLE_PATTERNS.some((re) => re.test(url) || re.test(referrer))) {
+    return false;
+  }
+
+  const filename = item.filename || '';
+  if (HWP_EXTENSION_RE.test(filename)) return true;
+  if (HWP_EXTENSION_RE.test(url)) return true;
+
+  const finalUrl = item.finalUrl || '';
+  if (finalUrl !== url && HWP_EXTENSION_RE.test(finalUrl)) return true;
+
+  const mime = (item.mime || '').toLowerCase();
+  return HWP_MIME_HINTS.some((hint) => mime.includes(hint));
+}
+
+export function setupDownloadObserver() {
+  if (!browser.downloads?.onCreated) return;
+
+  browser.downloads.onCreated.addListener((item) => {
+    if (shouldOpenDownload(item)) {
+      handleHwpDownload(item);
+    }
+  });
+}
+
+async function handleHwpDownload(item) {
+  try {
+    const settings = await browser.storage.sync.get({ autoOpen: true });
+    if (!settings.autoOpen) return;
+
+    openViewer({
+      url: item.finalUrl || item.url,
+      filename: item.filename,
+    });
+  } catch (err) {
+    console.error('[rhwp] Firefox download observer failed:', err);
+  }
+}

--- a/rhwp-firefox/sw/message-router.js
+++ b/rhwp-firefox/sw/message-router.js
@@ -1,0 +1,40 @@
+import { openViewer } from './viewer-launcher.js';
+import { extractThumbnailFromUrl } from './thumbnail-extractor.js';
+
+export function setupMessageRouter() {
+  browser.runtime.onMessage.addListener((message, sender) => {
+    const handler = messageHandlers[message?.type];
+    if (!handler) return undefined;
+
+    return Promise.resolve(handler(message, sender))
+      .catch((err) => ({ error: err.message || String(err) }));
+  });
+}
+
+const messageHandlers = {
+  'open-hwp': (message) => {
+    openViewer({ url: message.url, filename: message.filename });
+    return { ok: true };
+  },
+
+  'fetch-file': async (message) => {
+    const response = await fetch(message.url);
+    if (!response.ok) {
+      return { error: `HTTP ${response.status}: ${response.statusText}` };
+    }
+
+    const buffer = await response.arrayBuffer();
+    return { data: Array.from(new Uint8Array(buffer)) };
+  },
+
+  'extract-thumbnail': async (message) => {
+    const result = await extractThumbnailFromUrl(message.url);
+    return result || { error: 'PrvImage not found' };
+  },
+
+  'get-settings': async () => browser.storage.sync.get({
+    autoOpen: true,
+    showBadges: true,
+    hoverPreview: true,
+  }),
+};

--- a/rhwp-firefox/sw/thumbnail-extractor.js
+++ b/rhwp-firefox/sw/thumbnail-extractor.js
@@ -1,0 +1,385 @@
+// HWP 파일에서 PrvImage 썸네일을 경량 추출 (WASM 불필요)
+//
+// CFB(OLE2 Compound File) 컨테이너에서 /PrvImage 스트림만 추출한다.
+// 전체 HWP 파싱 없이 썸네일만 빠르게 얻을 수 있다.
+
+const THUMBNAIL_CACHE = new Map();
+const CACHE_MAX_SIZE = 100;
+
+/**
+ * URL에서 HWP 파일을 fetch하여 PrvImage 썸네일을 추출한다.
+ * @param {string} url - HWP 파일 URL
+ * @returns {Promise<{dataUri: string, width: number, height: number} | null>}
+ */
+export async function extractThumbnailFromUrl(url) {
+  // 캐시 확인
+  if (THUMBNAIL_CACHE.has(url)) {
+    return THUMBNAIL_CACHE.get(url);
+  }
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) return null;
+    const buffer = await response.arrayBuffer();
+    const data = new Uint8Array(buffer);
+
+    // HWP(CFB) 또는 HWPX(ZIP) 감지
+    const isZip = data.length >= 4 && data[0] === 0x50 && data[1] === 0x4B;
+    const result = isZip
+      ? await extractPrvImageFromZipAsync(data)
+      : extractPrvImage(data);
+    if (result) {
+      // 캐시 저장 (LRU)
+      if (THUMBNAIL_CACHE.size >= CACHE_MAX_SIZE) {
+        const firstKey = THUMBNAIL_CACHE.keys().next().value;
+        THUMBNAIL_CACHE.delete(firstKey);
+      }
+      THUMBNAIL_CACHE.set(url, result);
+    }
+    return result;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * CFB 바이너리에서 /PrvImage 스트림을 추출한다.
+ *
+ * CFB 구조:
+ * - 헤더 512바이트 (매직: D0 CF 11 E0 A1 B1 1A E1)
+ * - 디렉토리 엔트리에서 "PrvImage" 이름을 찾아 스트림 위치/크기 파악
+ * - 해당 섹터 체인을 따라 데이터 읽기
+ *
+ * 디렉토리 섹터도 FAT 체인으로 연결될 수 있으므로 체인 전체를 순회한다.
+ */
+function extractPrvImage(data) {
+  // CFB 매직 넘버 확인
+  if (data.length < 512) return null;
+  if (data[0] !== 0xD0 || data[1] !== 0xCF || data[2] !== 0x11 || data[3] !== 0xE0) return null;
+
+  // CFB 헤더에서 섹터 크기 읽기
+  const sectorSizePow = data[30] | (data[31] << 8);
+  const sectorSize = 1 << sectorSizePow; // 보통 512
+
+  const miniSectorSizePow = data[32] | (data[33] << 8);
+  const miniSectorSize = 1 << miniSectorSizePow; // 보통 64
+
+  const miniStreamCutoff = readU32LE(data, 56); // 보통 4096
+  const miniFatStart     = readU32LE(data, 60);
+
+  // FAT 테이블 구성
+  const fatEntries = buildFatTable(data, sectorSize);
+
+  // Root Entry에서 Mini Stream 위치/크기 읽기 (offset 48: dirStartSector)
+  const dirStartSector = readU32LE(data, 48);
+  const rootOffset = (dirStartSector + 1) * sectorSize;
+  const miniStreamStart = readU32LE(data, rootOffset + 116);
+  const miniStreamSize  = readU32LE(data, rootOffset + 120);
+
+  // Mini FAT 구성
+  const miniFatEntries = buildMiniFatTable(data, sectorSize, miniFatStart, fatEntries);
+
+  // Mini Stream 데이터 (Root Entry FAT 체인)
+  const miniStreamData = readStreamFromFAT(data, miniStreamStart, miniStreamSize, sectorSize, fatEntries);
+
+  // 디렉토리 섹터 FAT 체인을 따라 전체 순회
+  const entriesPerSector = sectorSize / 128;
+  let dirSector = dirStartSector;
+
+  while (dirSector < 0xFFFFFFFE) {
+    const dirOffset = (dirSector + 1) * sectorSize;
+
+    for (let i = 0; i < entriesPerSector; i++) {
+      const entryOffset = dirOffset + i * 128;
+      if (entryOffset + 128 > data.length) break;
+
+      // 엔트리 이름 읽기 (UTF-16LE)
+      const nameLen = readU16LE(data, entryOffset + 64);
+      if (nameLen === 0 || nameLen > 64) continue;
+
+      const name = readUTF16LE(data, entryOffset, nameLen);
+      if (name !== 'PrvImage') continue;
+
+      const startSector = readU32LE(data, entryOffset + 116);
+      const streamSize  = readU32LE(data, entryOffset + 120);
+
+      if (streamSize === 0 || streamSize > 10 * 1024 * 1024) continue;
+
+      let streamData;
+      if (streamSize < miniStreamCutoff && miniStreamData) {
+        // Mini Stream에서 읽기
+        streamData = readStreamFromMini(miniStreamData, startSector, streamSize, miniSectorSize, miniFatEntries);
+      } else {
+        // 일반 FAT 체인에서 읽기
+        streamData = readStreamFromFAT(data, startSector, streamSize, sectorSize, fatEntries);
+      }
+      if (!streamData) continue;
+
+      return parseImageData(streamData);
+    }
+
+    // 다음 디렉토리 섹터로 이동
+    dirSector = dirSector < fatEntries.length ? fatEntries[dirSector] : 0xFFFFFFFE;
+  }
+
+  return null;
+}
+
+/**
+ * CFB Mini FAT 테이블을 구성하여 반환한다.
+ *
+ * Mini FAT 섹터들은 일반 FAT 체인으로 연결된다.
+ */
+function buildMiniFatTable(data, sectorSize, miniFatStart, fatEntries) {
+  const miniFatEntries = [];
+  let sector = miniFatStart;
+  for (let safety = 0; safety < 10000; safety++) {
+    if (sector >= 0xFFFFFFFE) break;
+    const offset = (sector + 1) * sectorSize;
+    const entriesPerSector = sectorSize / 4;
+    for (let j = 0; j < entriesPerSector; j++) {
+      const off = offset + j * 4;
+      if (off + 4 > data.length) break;
+      miniFatEntries.push(readU32LE(data, off));
+    }
+    sector = sector < fatEntries.length ? fatEntries[sector] : 0xFFFFFFFE;
+  }
+  return miniFatEntries;
+}
+
+/**
+ * Mini Stream에서 Mini FAT 체인을 따라 데이터를 읽는다.
+ *
+ * @param {Uint8Array} miniStream - Root Entry의 Mini Stream 전체 데이터
+ * @param {number} startSector - Mini Stream 내 시작 미니 섹터 번호
+ * @param {number} streamSize - 읽을 바이트 수
+ * @param {number} miniSectorSize - 미니 섹터 크기 (보통 64)
+ * @param {number[]} miniFatEntries - Mini FAT 테이블
+ */
+function readStreamFromMini(miniStream, startSector, streamSize, miniSectorSize, miniFatEntries) {
+  const result = new Uint8Array(streamSize);
+  let sector = startSector;
+  let bytesRead = 0;
+
+  for (let safety = 0; safety < 10000 && bytesRead < streamSize; safety++) {
+    if (sector >= 0xFFFFFFFE) break;
+    const offset = sector * miniSectorSize;
+    const copyLen = Math.min(miniSectorSize, streamSize - bytesRead);
+    if (offset + copyLen > miniStream.length) break;
+    result.set(miniStream.subarray(offset, offset + copyLen), bytesRead);
+    bytesRead += copyLen;
+    sector = sector < miniFatEntries.length ? miniFatEntries[sector] : 0xFFFFFFFE;
+  }
+
+  return bytesRead >= streamSize ? result : null;
+}
+
+/**
+ * CFB FAT 테이블을 구성하여 반환한다.
+ *
+ * 헤더 offset 76~507의 DIFAT 엔트리(최대 109개)에서 FAT 섹터 목록을 읽고,
+ * 각 FAT 섹터를 순회하여 sector → nextSector 매핑 배열을 반환한다.
+ */
+function buildFatTable(data, sectorSize) {
+  const fatEntries = [];
+  for (let i = 0; i < 109; i++) {
+    const fatSect = readU32LE(data, 76 + i * 4);
+    if (fatSect === 0xFFFFFFFE || fatSect === 0xFFFFFFFF) break;
+    const fatOffset = (fatSect + 1) * sectorSize;
+    const entriesPerSector = sectorSize / 4;
+    for (let j = 0; j < entriesPerSector; j++) {
+      const off = fatOffset + j * 4;
+      if (off + 4 > data.length) break;
+      fatEntries.push(readU32LE(data, off));
+    }
+  }
+  return fatEntries;
+}
+
+/**
+ * FAT 체인을 따라 스트림 데이터를 읽는다.
+ *
+ * @param {Uint8Array} data - CFB 전체 바이너리
+ * @param {number} startSector - 스트림 시작 섹터 번호
+ * @param {number} streamSize - 읽을 바이트 수
+ * @param {number} sectorSize - 섹터 크기 (바이트)
+ * @param {number[]} [fatEntries] - 미리 구성된 FAT 테이블 (없으면 내부 구성)
+ */
+function readStreamFromFAT(data, startSector, streamSize, sectorSize, fatEntries) {
+  if (!fatEntries) {
+    fatEntries = buildFatTable(data, sectorSize);
+  }
+
+  // 섹터 체인을 따라 데이터 수집
+  const result = new Uint8Array(streamSize);
+  let sector = startSector;
+  let bytesRead = 0;
+
+  for (let safety = 0; safety < 10000 && bytesRead < streamSize; safety++) {
+    if (sector >= 0xFFFFFFFE) break;
+    const offset = (sector + 1) * sectorSize;
+    const copyLen = Math.min(sectorSize, streamSize - bytesRead);
+    if (offset + copyLen > data.length) break;
+    result.set(data.subarray(offset, offset + copyLen), bytesRead);
+    bytesRead += copyLen;
+
+    // 다음 섹터
+    if (sector < fatEntries.length) {
+      sector = fatEntries[sector];
+    } else {
+      break;
+    }
+  }
+
+  return bytesRead >= streamSize ? result : null;
+}
+
+/**
+ * 이미지 데이터에서 포맷 감지 + dataUri 생성
+ */
+function parseImageData(data) {
+  let mime, width = 0, height = 0;
+
+  if (data.length >= 8 && data[0] === 0x89 && data[1] === 0x50 && data[2] === 0x4E && data[3] === 0x47) {
+    // PNG
+    mime = 'image/png';
+    if (data.length >= 24) {
+      width = (data[16] << 24) | (data[17] << 16) | (data[18] << 8) | data[19];
+      height = (data[20] << 24) | (data[21] << 16) | (data[22] << 8) | data[23];
+    }
+  } else if (data.length >= 2 && data[0] === 0x42 && data[1] === 0x4D) {
+    // BMP
+    mime = 'image/bmp';
+    if (data.length >= 26) {
+      width = readU32LE(data, 18);
+      height = Math.abs(readI32LE(data, 22));
+    }
+  } else if (data.length >= 3 && data[0] === 0x47 && data[1] === 0x49 && data[2] === 0x46) {
+    // GIF
+    mime = 'image/gif';
+    if (data.length >= 10) {
+      width = readU16LE(data, 6);
+      height = readU16LE(data, 8);
+    }
+  } else {
+    return null;
+  }
+
+  // Base64 인코딩
+  let binary = '';
+  for (let i = 0; i < data.length; i++) {
+    binary += String.fromCharCode(data[i]);
+  }
+  const base64 = btoa(binary);
+  const dataUri = `data:${mime};base64,${base64}`;
+
+  return { dataUri, width, height, mime };
+}
+
+/**
+ * HWPX(ZIP) 컨테이너에서 Preview/PrvImage.* 추출
+ *
+ * ZIP End of Central Directory → Central Directory → 로컬 파일 헤더 → 데이터
+ */
+async function extractPrvImageFromZipAsync(data) {
+  // End of Central Directory 찾기 (ZIP 파일 끝에서 역방향 탐색)
+  let eocdOffset = -1;
+  for (let i = data.length - 22; i >= 0 && i >= data.length - 65558; i--) {
+    if (data[i] === 0x50 && data[i+1] === 0x4B && data[i+2] === 0x05 && data[i+3] === 0x06) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset < 0) return null;
+
+  const cdOffset = readU32LE(data, eocdOffset + 16);
+  const cdEntries = readU16LE(data, eocdOffset + 10);
+
+  // Central Directory 순회
+  let offset = cdOffset;
+  for (let i = 0; i < cdEntries && offset + 46 < data.length; i++) {
+    // Central Directory 시그니처 확인
+    if (data[offset] !== 0x50 || data[offset+1] !== 0x4B || data[offset+2] !== 0x01 || data[offset+3] !== 0x02) break;
+
+    const compMethod = readU16LE(data, offset + 10);
+    const compSize = readU32LE(data, offset + 20);
+    const uncompSize = readU32LE(data, offset + 24);
+    const nameLen = readU16LE(data, offset + 28);
+    const extraLen = readU16LE(data, offset + 30);
+    const commentLen = readU16LE(data, offset + 32);
+    const localHeaderOffset = readU32LE(data, offset + 42);
+
+    // 파일 이름 읽기
+    const nameBytes = data.subarray(offset + 46, offset + 46 + nameLen);
+    const name = new TextDecoder().decode(nameBytes);
+
+    // Preview/PrvImage 확인
+    if (name.startsWith('Preview/PrvImage')) {
+      // 로컬 파일 헤더에서 실제 데이터 위치 계산
+      if (localHeaderOffset + 30 >= data.length) break;
+      const localNameLen = readU16LE(data, localHeaderOffset + 26);
+      const localExtraLen = readU16LE(data, localHeaderOffset + 28);
+      const dataStart = localHeaderOffset + 30 + localNameLen + localExtraLen;
+
+      if (compMethod === 0) {
+        // 비압축 (stored)
+        const imageData = data.subarray(dataStart, dataStart + uncompSize);
+        return parseImageData(imageData);
+      } else if (compMethod === 8) {
+        // deflate 압축 — DecompressionStream (비동기)
+        try {
+          const compressed = data.slice(dataStart, dataStart + compSize);
+          const ds = new DecompressionStream('raw');
+          const writer = ds.writable.getWriter();
+          writer.write(compressed);
+          writer.close();
+          const reader = ds.readable.getReader();
+          const chunks = [];
+          while (true) {
+            const { done, value } = await reader.read();
+            if (done) break;
+            chunks.push(value);
+          }
+          const totalLen = chunks.reduce((s, c) => s + c.length, 0);
+          const decompressed = new Uint8Array(totalLen);
+          let offset = 0;
+          for (const chunk of chunks) {
+            decompressed.set(chunk, offset);
+            offset += chunk.length;
+          }
+          return parseImageData(decompressed);
+        } catch {
+          return null;
+        }
+      }
+    }
+
+    offset += 46 + nameLen + extraLen + commentLen;
+  }
+
+  return null;
+}
+
+// ─── 바이너리 헬퍼 ───
+
+function readU16LE(data, offset) {
+  return data[offset] | (data[offset + 1] << 8);
+}
+
+function readU32LE(data, offset) {
+  return (data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24)) >>> 0;
+}
+
+function readI32LE(data, offset) {
+  return data[offset] | (data[offset + 1] << 8) | (data[offset + 2] << 16) | (data[offset + 3] << 24);
+}
+
+function readUTF16LE(data, offset, byteLen) {
+  let str = '';
+  for (let i = 0; i < byteLen - 2; i += 2) {
+    const code = data[offset + i] | (data[offset + i + 1] << 8);
+    if (code === 0) break;
+    str += String.fromCharCode(code);
+  }
+  return str;
+}

--- a/rhwp-firefox/sw/thumbnail-extractor.js
+++ b/rhwp-firefox/sw/thumbnail-extractor.js
@@ -9,7 +9,7 @@ const CACHE_MAX_SIZE = 100;
 /**
  * URL에서 HWP 파일을 fetch하여 PrvImage 썸네일을 추출한다.
  * @param {string} url - HWP 파일 URL
- * @returns {Promise<{dataUri: string, width: number, height: number} | null>}
+ * @returns {Promise<{dataUri: string, mime: string, width: number, height: number} | null>}
  */
 export async function extractThumbnailFromUrl(url) {
   // 캐시 확인

--- a/rhwp-firefox/sw/viewer-launcher.js
+++ b/rhwp-firefox/sw/viewer-launcher.js
@@ -1,0 +1,31 @@
+export function openViewer(options = {}) {
+  const viewerBase = browser.runtime.getURL('viewer.html');
+  const params = new URLSearchParams();
+
+  if (options.url) params.set('url', options.url);
+  if (options.filename) params.set('filename', options.filename);
+
+  const query = params.toString();
+  const fullUrl = query ? `${viewerBase}?${query}` : viewerBase;
+
+  return browser.tabs.create({ url: fullUrl });
+}
+
+export async function openViewerOrReuse(options = {}) {
+  const viewerBase = browser.runtime.getURL('viewer.html');
+  const tabs = await browser.tabs.query({ url: `${viewerBase}*` });
+  const emptyTab = tabs.find((tab) => tab.url === viewerBase);
+
+  if (!emptyTab) {
+    return openViewer(options);
+  }
+
+  const params = new URLSearchParams();
+  if (options.url) params.set('url', options.url);
+  if (options.filename) params.set('filename', options.filename);
+
+  return browser.tabs.update(emptyTab.id, {
+    url: `${viewerBase}?${params.toString()}`,
+    active: true,
+  });
+}

--- a/rhwp-firefox/vite.config.ts
+++ b/rhwp-firefox/vite.config.ts
@@ -1,0 +1,38 @@
+import { defineConfig } from 'vite';
+import { resolve } from 'path';
+import { readFileSync } from 'fs';
+
+const studioPkg = JSON.parse(
+  readFileSync(resolve(__dirname, '..', 'rhwp-studio', 'package.json'), 'utf-8'),
+);
+
+export default defineConfig({
+  root: resolve(__dirname, '..', 'rhwp-studio'),
+  publicDir: false,
+  define: {
+    __APP_VERSION__: JSON.stringify(studioPkg.version),
+  },
+  resolve: {
+    alias: {
+      '@': resolve(__dirname, '..', 'rhwp-studio', 'src'),
+      '@wasm': resolve(__dirname, '..', 'pkg'),
+    },
+  },
+  build: {
+    outDir: resolve(__dirname, 'dist'),
+    emptyOutDir: true,
+    rollupOptions: {
+      input: {
+        viewer: resolve(__dirname, '..', 'rhwp-studio', 'index.html'),
+      },
+    },
+    assetsInlineLimit: 0,
+  },
+  server: {
+    host: '0.0.0.0',
+    port: 7702,
+    fs: {
+      allow: ['..'],
+    },
+  },
+});


### PR DESCRIPTION
﻿## Summary

- Add a Firefox WebExtension package under `rhwp-firefox`.
- Use Firefox-compatible Manifest V3 background scripts instead of Chrome service workers.
- Add Firefox-specific build wiring, content script behavior, options script, and README.
- Ignore Firefox build output and Node dependency directories.

## Validation

- `npm run check` in `rhwp-firefox`
- `npm run build` in `rhwp-firefox`
