### PR TITLE
feat: add replaceOne API for query-based single replacement

### DIFF
--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -575,6 +575,15 @@ export interface ReplaceResult {
   newLength?: number;
 }
 
+/** 단일 치환 (검색어 기반) 결과 */
+export interface ReplaceOneResult {
+  ok: boolean;
+  sec?: number;
+  para?: number;
+  charOffset?: number;
+  newLength?: number;
+}
+
 /** 전체 치환 결과 */
 export interface ReplaceAllResult {
   ok: boolean;

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1279,6 +1279,11 @@ export class WasmBridge {
     return JSON.parse((this.doc as any).replaceText(sec, para, charOffset, length, newText));
   }
 
+  replaceOne(query: string, newText: string, caseSensitive: boolean): import('./types').ReplaceOneResult {
+    if (!this.doc || typeof (this.doc as any).replaceOne !== 'function') return { ok: false };
+    return JSON.parse((this.doc as any).replaceOne(query, newText, caseSensitive));
+  }
+
   replaceAll(query: string, newText: string, caseSensitive: boolean): import('./types').ReplaceAllResult {
     if (!this.doc || typeof (this.doc as any).replaceAll !== 'function') return { ok: false };
     return JSON.parse((this.doc as any).replaceAll(query, newText, caseSensitive));

--- a/src/document_core/queries/search_query.rs
+++ b/src/document_core/queries/search_query.rs
@@ -50,6 +50,25 @@ fn find_in_text(text: &str, query: &str, case_sensitive: bool) -> Vec<usize> {
     results
 }
 
+/// 문서 본문에서 query의 첫 번째 매치만 반환 (표/글상자 내부 제외, early-exit)
+fn search_first_body(doc: &DocumentCore, query: &str, case_sensitive: bool) -> Option<SearchHit> {
+    let qlen = query.chars().count();
+    for (sec_idx, section) in doc.document.sections.iter().enumerate() {
+        for (para_idx, para) in section.paragraphs.iter().enumerate() {
+            if let Some(&offset) = find_in_text(&para.text, query, case_sensitive).first() {
+                return Some(SearchHit {
+                    sec: sec_idx,
+                    para: para_idx,
+                    char_offset: offset,
+                    length: qlen,
+                    cell_context: None,
+                });
+            }
+        }
+    }
+    None
+}
+
 /// 문서 전체를 순회하며 query와 일치하는 모든 위치를 반환
 fn search_all(doc: &DocumentCore, query: &str, case_sensitive: bool) -> Vec<SearchHit> {
     let mut results = vec![];
@@ -190,7 +209,8 @@ impl DocumentCore {
 
     /// 단일 치환 (검색어 기반)
     ///
-    /// 문서에서 query의 첫 번째 매치를 new_text로 교체한다.
+    /// 문서 본문에서 query의 첫 번째 매치를 new_text로 교체한다.
+    /// 표/글상자 내부는 대상에서 제외 (search_text_native와 동일 범위).
     /// 반환: JSON `{"ok":true,"sec":N,"para":N,"charOffset":N,"newLength":N}` 또는 `{"ok":false}`
     pub fn replace_one_native(
         &mut self,
@@ -202,44 +222,14 @@ impl DocumentCore {
             return Ok(r#"{"ok":false}"#.to_string());
         }
 
-        let all_hits = search_all(self, query, case_sensitive);
-        let hit = match all_hits.first() {
+        let hit = match search_first_body(self, query, case_sensitive) {
             Some(h) => h,
             None => return Ok(r#"{"ok":false}"#.to_string()),
         };
 
         let new_len = new_text.chars().count();
-        let sec_idx = hit.sec;
-
-        if let Some((parent_para, ctrl_idx, cell_idx, cell_para_idx)) = hit.cell_context {
-            let section = self.document.sections.get_mut(hit.sec)
-                .ok_or_else(|| HwpError::RenderError("구역 범위 초과".into()))?;
-            let para = section.paragraphs.get_mut(parent_para)
-                .ok_or_else(|| HwpError::RenderError("문단 범위 초과".into()))?;
-
-            let cell_para = match para.controls.get_mut(ctrl_idx) {
-                Some(Control::Table(table)) => {
-                    let cell = table.cells.get_mut(cell_idx)
-                        .ok_or_else(|| HwpError::RenderError("셀 범위 초과".into()))?;
-                    cell.paragraphs.get_mut(cell_para_idx)
-                        .ok_or_else(|| HwpError::RenderError("셀 문단 범위 초과".into()))?
-                }
-                Some(Control::Shape(shape)) => {
-                    let tb = crate::document_core::helpers::get_textbox_from_shape_mut(shape)
-                        .ok_or_else(|| HwpError::RenderError("글상자 없음".into()))?;
-                    tb.paragraphs.get_mut(cell_para_idx)
-                        .ok_or_else(|| HwpError::RenderError("글상자 문단 범위 초과".into()))?
-                }
-                _ => return Ok(r#"{"ok":false}"#.to_string()),
-            };
-            cell_para.delete_text_at(hit.char_offset, hit.length);
-            cell_para.insert_text_at(hit.char_offset, new_text);
-        } else {
-            self.delete_text_native(hit.sec, hit.para, hit.char_offset, hit.length)?;
-            self.insert_text_native(hit.sec, hit.para, hit.char_offset, new_text)?;
-        }
-
-        self.recompose_section(sec_idx);
+        self.delete_text_native(hit.sec, hit.para, hit.char_offset, hit.length)?;
+        self.insert_text_native(hit.sec, hit.para, hit.char_offset, new_text)?;
 
         Ok(format!(
             "{{\"ok\":true,\"sec\":{},\"para\":{},\"charOffset\":{},\"newLength\":{}}}",

--- a/src/document_core/queries/search_query.rs
+++ b/src/document_core/queries/search_query.rs
@@ -188,6 +188,65 @@ impl DocumentCore {
         ))
     }
 
+    /// 단일 치환 (검색어 기반)
+    ///
+    /// 문서에서 query의 첫 번째 매치를 new_text로 교체한다.
+    /// 반환: JSON `{"ok":true,"sec":N,"para":N,"charOffset":N,"newLength":N}` 또는 `{"ok":false}`
+    pub fn replace_one_native(
+        &mut self,
+        query: &str,
+        new_text: &str,
+        case_sensitive: bool,
+    ) -> Result<String, HwpError> {
+        if query.is_empty() {
+            return Ok(r#"{"ok":false}"#.to_string());
+        }
+
+        let all_hits = search_all(self, query, case_sensitive);
+        let hit = match all_hits.first() {
+            Some(h) => h,
+            None => return Ok(r#"{"ok":false}"#.to_string()),
+        };
+
+        let new_len = new_text.chars().count();
+        let sec_idx = hit.sec;
+
+        if let Some((parent_para, ctrl_idx, cell_idx, cell_para_idx)) = hit.cell_context {
+            let section = self.document.sections.get_mut(hit.sec)
+                .ok_or_else(|| HwpError::RenderError("구역 범위 초과".into()))?;
+            let para = section.paragraphs.get_mut(parent_para)
+                .ok_or_else(|| HwpError::RenderError("문단 범위 초과".into()))?;
+
+            let cell_para = match para.controls.get_mut(ctrl_idx) {
+                Some(Control::Table(table)) => {
+                    let cell = table.cells.get_mut(cell_idx)
+                        .ok_or_else(|| HwpError::RenderError("셀 범위 초과".into()))?;
+                    cell.paragraphs.get_mut(cell_para_idx)
+                        .ok_or_else(|| HwpError::RenderError("셀 문단 범위 초과".into()))?
+                }
+                Some(Control::Shape(shape)) => {
+                    let tb = crate::document_core::helpers::get_textbox_from_shape_mut(shape)
+                        .ok_or_else(|| HwpError::RenderError("글상자 없음".into()))?;
+                    tb.paragraphs.get_mut(cell_para_idx)
+                        .ok_or_else(|| HwpError::RenderError("글상자 문단 범위 초과".into()))?
+                }
+                _ => return Ok(r#"{"ok":false}"#.to_string()),
+            };
+            cell_para.delete_text_at(hit.char_offset, hit.length);
+            cell_para.insert_text_at(hit.char_offset, new_text);
+        } else {
+            self.delete_text_native(hit.sec, hit.para, hit.char_offset, hit.length)?;
+            self.insert_text_native(hit.sec, hit.para, hit.char_offset, new_text)?;
+        }
+
+        self.recompose_section(sec_idx);
+
+        Ok(format!(
+            "{{\"ok\":true,\"sec\":{},\"para\":{},\"charOffset\":{},\"newLength\":{}}}",
+            hit.sec, hit.para, hit.char_offset, new_len
+        ))
+    }
+
     /// 전체 치환
     ///
     /// 문서 전체에서 query를 new_text로 모두 교체한다.
@@ -319,4 +378,38 @@ fn format_search_hit(hit: &SearchHit, wrapped: bool) -> String {
         "{{\"found\":true,\"wrapped\":{},\"sec\":{},\"para\":{},\"charOffset\":{},\"length\":{}{}}}",
         wrapped, hit.sec, hit.para, hit.char_offset, hit.length, cell_ctx
     )
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn find_in_text_case_sensitive() {
+        assert_eq!(find_in_text("hello world", "world", true), vec![6]);
+        assert_eq!(find_in_text("hello world", "World", true), vec![]);
+    }
+
+    #[test]
+    fn find_in_text_case_insensitive() {
+        assert_eq!(find_in_text("Hello World", "hello", false), vec![0]);
+        assert_eq!(find_in_text("Hello World", "WORLD", false), vec![6]);
+    }
+
+    #[test]
+    fn find_in_text_multiple_matches() {
+        assert_eq!(find_in_text("abcabc", "abc", true), vec![0, 3]);
+    }
+
+    #[test]
+    fn find_in_text_empty_inputs() {
+        assert_eq!(find_in_text("", "abc", true), vec![]);
+        assert_eq!(find_in_text("abc", "", true), vec![]);
+    }
+
+    #[test]
+    fn find_in_text_korean() {
+        assert_eq!(find_in_text("안녕하세요 세계", "세계", true), vec![6]);
+        assert_eq!(find_in_text("가나가나", "가나", true), vec![0, 2]);
+    }
 }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2261,6 +2261,18 @@ impl HwpDocument {
         ).map_err(|e| e.into())
     }
 
+    /// 단일 치환 (검색어 기반) — 첫 번째 매치만 교체
+    #[wasm_bindgen(js_name = replaceOne)]
+    pub fn replace_one(
+        &mut self,
+        query: &str,
+        new_text: &str,
+        case_sensitive: bool,
+    ) -> Result<String, JsValue> {
+        self.core.replace_one_native(query, new_text, case_sensitive)
+            .map_err(|e| e.into())
+    }
+
     /// 전체 치환
     #[wasm_bindgen(js_name = replaceAll)]
     pub fn replace_all(


### PR DESCRIPTION
## 변경 요약

Fixes #268. `replaceText(find, replace, caseSensitive)` 호출 시 JS crash 해결.

기존 `replaceText` WASM API는 위치 기반 파라미터 `(sec, para, charOffset, length, newText)`를 기대하지만, 사용자가 검색어 기반 `(query, newText, caseSensitive)`으로 호출하면 5번째 인자가 undefined가 되어 wasm_bindgen에서 `.length` 접근 시 crash가 발생합니다.

`replaceAll`과 동일한 시그니처의 `replaceOne(query, newText, caseSensitive)` API를 추가하여 첫 번째 매치만 교체하는 기능을 제공합니다. 기존 `replaceText` API는 변경 없이 유지됩니다.

### 변경 파일
- `src/document_core/queries/search_query.rs` — `replace_one_native` + 5 unit tests
- `src/wasm_api.rs` — `replaceOne` WASM binding
- `rhwp-studio/src/core/types.ts` — `ReplaceOneResult` type
- `rhwp-studio/src/core/wasm-bridge.ts` — `replaceOne` bridge method

## 관련 이슈

closes #268

## 테스트

- [x] `cargo test` 통과 (942 tests, 0 failures)
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — API 전용 변경)
- [ ] 웹(WASM) 렌더링 확인 (WASM 빌드는 Docker 필요, 로컬 cargo test로 검증)