### PR TITLE
Task #340: typeset 경로의 PageHide/Shape/중복 emit 결함 수정

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -330,8 +330,8 @@ impl TypesetEngine {
             footnote_separator_overhead, footnote_safety_margin,
         );
 
-        // 머리말/꼬리말/쪽 번호/새 번호 컨트롤 수집
-        let (hf_entries, page_number_pos, new_page_numbers) =
+        // 머리말/꼬리말/쪽 번호/새 번호/감추기 컨트롤 수집
+        let (hf_entries, page_number_pos, new_page_numbers, page_hides) =
             Self::collect_header_footer_controls(paragraphs, section_index);
 
         for (para_idx, para) in paragraphs.iter().enumerate() {
@@ -412,7 +412,7 @@ impl TypesetEngine {
         // 페이지 번호 + 머리말/꼬리말 할당
         Self::finalize_pages(
             &mut st.pages, &hf_entries, &page_number_pos,
-            &new_page_numbers, section_index,
+            &new_page_numbers, &page_hides, section_index,
         );
 
         PaginationResult { pages: st.pages, wrap_around_paras: Vec::new(), hidden_empty_paras: std::collections::HashSet::new() }
@@ -843,7 +843,9 @@ impl TypesetEngine {
                         }
                     }
                 }
-                Control::Picture(_) | Control::Equation(_) => {
+                Control::Shape(_) | Control::Picture(_) | Control::Equation(_) => {
+                    // 사각형/직선/타원 등 Shape 컨트롤도 PageItem::Shape 로 등록
+                    // (둥근사각형 글상자 "제 2 교시" 등이 누락되는 문제 차단)
                     st.current_items.push(PageItem::Shape {
                         para_index: para_idx,
                         control_index: ctrl_idx,
@@ -990,7 +992,14 @@ impl TypesetEngine {
         } else {
             pre_table_end_line
         };
-        let should_add_post_text = is_last_table && tac_table_count <= 1 && !para.text.is_empty() && total_lines > post_table_start;
+        // 중복 방지: 이전 표가 이미 같은 문단의 pre-text(start_line=0)를 추가했으면 건너뜀
+        // (engine.rs:1418-1421 와 동일한 가드 — 다중 TopAndBottom 표 문단에서
+        //  같은 line 범위가 두 번 emit되어 본문이 두 번 렌더되는 문제 차단)
+        let pre_text_exists = post_table_start == 0 && st.current_items.iter().any(|item| {
+            matches!(item, PageItem::PartialParagraph { para_index, start_line, .. }
+                if *para_index == para_idx && *start_line == 0)
+        });
+        let should_add_post_text = is_last_table && tac_table_count <= 1 && !para.text.is_empty() && total_lines > post_table_start && !pre_text_exists;
         if should_add_post_text {
             let post_height: f64 = fmt.line_advances_sum(post_table_start..total_lines);
             st.current_items.push(PageItem::PartialParagraph {
@@ -1451,10 +1460,12 @@ impl TypesetEngine {
         Vec<(usize, HeaderFooterRef, bool, HeaderFooterApply)>,
         Option<crate::model::control::PageNumberPos>,
         Vec<(usize, u16)>,
+        Vec<(usize, crate::model::control::PageHide)>,
     ) {
         let mut hf_entries = Vec::new();
         let mut page_number_pos = None;
         let mut new_page_numbers = Vec::new();
+        let mut page_hides: Vec<(usize, crate::model::control::PageHide)> = Vec::new();
 
         for (pi, para) in paragraphs.iter().enumerate() {
             for (ci, ctrl) in para.controls.iter().enumerate() {
@@ -1483,12 +1494,15 @@ impl TypesetEngine {
                             new_page_numbers.push((pi, nn.number));
                         }
                     }
+                    Control::PageHide(ph) => {
+                        page_hides.push((pi, ph.clone()));
+                    }
                     _ => {}
                 }
             }
         }
 
-        (hf_entries, page_number_pos, new_page_numbers)
+        (hf_entries, page_number_pos, new_page_numbers, page_hides)
     }
 
     /// 페이지 번호 + 머리말/꼬리말 최종 할당 (기존 Paginator::finalize_pages와 동일)
@@ -1497,6 +1511,7 @@ impl TypesetEngine {
         hf_entries: &[(usize, HeaderFooterRef, bool, HeaderFooterApply)],
         page_number_pos: &Option<crate::model::control::PageNumberPos>,
         new_page_numbers: &[(usize, u16)],
+        page_hides: &[(usize, crate::model::control::PageHide)],
         _section_index: usize,
     ) {
         // 기존 Paginator::finalize_pages 로직을 그대로 재사용
@@ -1561,6 +1576,25 @@ impl TypesetEngine {
             page.active_header = current_header.clone();
             page.active_footer = current_footer.clone();
             page.page_number_pos = page_number_pos.clone();
+
+            // PageHide: 해당 문단이 이 페이지에서 **처음** 시작하는 경우만 적용
+            // (engine.rs 의 동일 로직과 일치 — 머리말/꼬리말/바탕쪽/페이지번호 감추기)
+            for (ph_para, ph) in page_hides {
+                let starts = page.column_contents.iter().any(|col| {
+                    col.items.iter().any(|item| match item {
+                        PageItem::FullParagraph { para_index } => *para_index == *ph_para,
+                        PageItem::PartialParagraph { para_index, start_line, .. } =>
+                            *para_index == *ph_para && *start_line == 0,
+                        PageItem::Table { para_index, .. } => *para_index == *ph_para,
+                        PageItem::PartialTable { para_index, .. } => *para_index == *ph_para,
+                        PageItem::Shape { para_index, .. } => *para_index == *ph_para,
+                    })
+                });
+                if starts {
+                    page.page_hide = Some(ph.clone());
+                    break;
+                }
+            }
 
             page_num += 1;
         }

--- a/tests/golden_svg/issue-147/aift-page3.svg
+++ b/tests/golden_svg/issue-147/aift-page3.svg
@@ -666,7 +666,4 @@
 <text x="705" y="979.9066666666668" font-family="돋움체,&apos;Malgun Gothic&apos;,&apos;맑은 고딕&apos;,&apos;Apple SD Gothic Neo&apos;,&apos;Noto Sans KR&apos;,&apos;Pretendard&apos;,sans-serif" font-size="17.333333333333332" font-weight="bold" fill="#000000">)</text>
 <line x1="309.92" y1="973.84" x2="596.3333333333334" y2="973.84" stroke="#000000" stroke-width="1.0" stroke-dasharray="0.1 3" stroke-linecap="round"/>
 </g>
-<text x="387.85333333333335" y="1079.16" font-family="바탕,&apos;Batang&apos;,&apos;바탕&apos;,&apos;AppleMyungjo&apos;,&apos;Noto Serif KR&apos;,serif" font-size="10" fill="#000000">-</text>
-<text x="394.09333333333336" y="1079.16" font-family="바탕,&apos;Batang&apos;,&apos;바탕&apos;,&apos;AppleMyungjo&apos;,&apos;Noto Serif KR&apos;,serif" font-size="10" fill="#000000">1</text>
-<text x="400.04" y="1079.16" font-family="바탕,&apos;Batang&apos;,&apos;바탕&apos;,&apos;AppleMyungjo&apos;,&apos;Noto Serif KR&apos;,serif" font-size="10" fill="#000000">-</text>
 </svg>


### PR DESCRIPTION
closes #340

세 가지 결함이 typeset.rs 의 누락에서 동일하게 비롯됨. engine.rs 에 이미 존재하는 동일 로직을 typeset 측으로 정합한다.

1. collect_header_footer_controls / finalize_pages
   - Control::PageHide 수집과 page.page_hide 할당 추가
   - 누락으로 인해 pi=34 의 [감추기] header=true 가 무시되어 섹션 1 시작 머리말("수학 영역(확률과 통계)") 이 미적분 페이지까지 잔존

2. place_table_with_text
   - 마지막 표 post-text emit 직전에 pre_text_exists 가드 추가
   - 다중 TopAndBottom 표 문단의 본문 라인이 두 번 등록되는 문제 차단
   - engine.rs:1418-1421 와 동일

3. typeset_table_paragraph 인라인 컨트롤 등록
   - Picture | Equation 만 PageItem::Shape 로 등록하던 것을 Shape | Picture | Equation 로 확장
   - pi=34 ctrl[3] 둥근사각형 글상자("제 2 교시") 누락 해결

검증: samples/exam_math.hwp 페이지 9, 13 SVG 가 PDF 와 일치. cargo test --release --lib → 992 passed, 0 failed.