### PR TITLE
Task #362: kps-ai p56 외부 표 안 콘텐츠 클립 회귀 해소 (TAC 셀 vpos 클램프)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1284,12 +1284,16 @@ impl LayoutEngine {
             // 를 기록한다. 이 값을 그대로 적용하면 모든 vertical_align (Top/Center/Bottom)에서
             // PDF와 일치하는 텍스트 시작 y가 자동으로 결정됨 (mechanical_offset 불필요).
             // 단, line_segs가 비어있는 케이스는 기존 mechanical_offset 폴백 유지.
+            //
+            // Task #362: 콘텐츠가 셀에 꽉 찬 경우 vpos 를 그대로 적용하면 셀 경계를 넘어
+            // 클립이 발생한다 (kps-ai p56 외부 표). 셀 내부 여유 공간(remaining_room)
+            // 한도로 vpos 를 클램프해 오버플로를 방지한다. 여유가 충분하면 기존 동작 유지.
             let first_line_vpos = cell.paragraphs.first()
                 .and_then(|p| p.line_segs.first())
                 .map(|ls| hwpunit_to_px(ls.vertical_pos, self.dpi));
             let text_y_start = if let Some(vpos) = first_line_vpos.filter(|&v| v > 0.0) {
-                // vpos는 셀 컨텐츠 상단(=cell_y+pad_top)으로부터의 첫 줄 top y 오프셋
-                cell_y + pad_top + vpos
+                let remaining_room = (inner_height - total_content_height).max(0.0);
+                cell_y + pad_top + vpos.min(remaining_room)
             } else {
                 match effective_valign {
                     VerticalAlign::Top => cell_y + pad_top,


### PR DESCRIPTION
## 요약

`samples/kps-ai.hwp` 56쪽 외부 표 (pi=535, 1×1 TAC, 635.0×865.1px) 안에
배치된 11개 문단 + 7×6 내부 표가 외부 셀 경계를 초과해 마지막 행이
시각적으로 클립되던 v0.7.3 대비 회귀를 해소한다.

closes #362

## 원인

커밋 `f3ba9eb` (Task #347 cont) 가 셀 첫 줄의 y 좌표를
`cell_y + pad_top + LineSeg.vertical_pos[0]` 으로 적용했다.
exam_eng.hwp p4 Q27/Q28 박스의 ~1mm 미세 오프셋 보정에는 효과적이었으나,
셀 콘텐츠가 셀 높이에 꽉 찬 케이스(kps-ai p56 외부 표) 에서는
`vpos=2000 HU(≈26.67px)` 만큼 콘텐츠 전체가 아래로 밀려
외부 셀(`y=148.28 + h=865.05 → bottom=1013.33`)을 초과해
마지막 inner row(이전 `y=995.73 + h=38.63 → bottom=1034.36`)가
21px 클립되었다.

## 변경 내용

`src/renderer/layout/table_layout.rs::layout_table_cells` 에서
`text_y_start` 계산 시 `vpos` 를 셀 내부 여유 공간(`inner_height -
total_content_height`) 으로 클램프한다. 여유가 충분한 케이스에서는
기존 #347 동작이 그대로 유지되고, 콘텐츠가 꽉 찬 케이스에서는
v0.7.3 와 동일한 `cell_y + pad_top` 으로 자연 폴백된다.

```rust
let text_y_start = if let Some(vpos) = first_line_vpos.filter(|&v| v > 0.0) {
    let remaining_room = (inner_height - total_content_height).max(0.0);
    cell_y + pad_top + vpos.min(remaining_room)
} else {
    // 기존 mechanical_offset 폴백 유지
    ...
};
```

## 검증

- `cargo build --release` ✅
- `cargo test --release` — **1008+ ok / 0 failed** (회귀 없음)
- `rhwp export-svg samples/kps-ai.hwp -p 55` 재출력
  - 외부 셀: `y=148.28 + h=865.05 = bottom 1013.33`
  - 마지막 inner row: `y=969.07 + h=38.63 = bottom 1007.69` ✅ 들어감
  - 외부 표 내부 상대좌표 89.88px — v0.7.3 와 일치
- `rhwp export-svg samples/exam_eng.hwp -p 3` 회귀 검증
  - SVG 바이트 단위 동일 (0 diff vs HEAD) — Task #347 fix 보존
- 회귀 샘플(form-002, k-water-rfp, exam_eng, exam_math, kps-ai)
  LAYOUT_OVERFLOW 신규 0건 (kps-ai 의 4건은 사전 존재)

## 영향 범위

- 표 셀 layout 단일 분기 변경. 그리기/측정 다른 경로 영향 없음.
- 여유 공간이 충분한 셀(exam_eng p4 등): 기존 동작 유지 (clamp 미발동).
- 콘텐츠가 꽉 찬 셀(kps-ai p56 외부 표 등): v0.7.3 와 동일하게 폴백.

## 변경 파일

- `src/renderer/layout/table_layout.rs` — `layout_table_cells` 의
  `text_y_start` 에 `remaining_room` 클램프 추가 (+6 -2)