### PR TITLE
feat: 그림 밝기/대비 효과 SVG 반영 (#150)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -2572,6 +2572,8 @@ impl LayoutEngine {
                                     control_index: Some(control_index),
                                     crop,
                                     effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                                     ..ImageNode::new(bin_data_id, image_data)
                                 }),
                                 BoundingBox::new(pic_x, pic_y, pic_w, pic_h),

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1702,6 +1702,8 @@ impl LayoutEngine {
                                             para_index: Some(para_index),
                                             control_index: Some(tac_ci),
                                             effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -1952,6 +1954,8 @@ impl LayoutEngine {
                                         para_index: Some(para_index),
                                         control_index: Some(tac_ci),
                                         effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                                         ..ImageNode::new(bin_data_id, image_data)
                                     }),
                                     BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -2035,6 +2039,8 @@ impl LayoutEngine {
                                             para_index: Some(para_index),
                                             control_index: Some(tac_ci),
                                             effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(img_x, img_y, tac_w, pic_h),

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -101,6 +101,8 @@ impl LayoutEngine {
                 control_index,
                 crop,
                 effect: picture.image_attr.effect,
+                brightness: picture.image_attr.brightness,
+                contrast: picture.image_attr.contrast,
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(pic_x, pic_y, pic_width, pic_height),
@@ -298,6 +300,8 @@ impl LayoutEngine {
                 control_index: Some(control_index),
                 crop,
                 effect: picture.image_attr.effect,
+                brightness: picture.image_attr.brightness,
+                contrast: picture.image_attr.contrast,
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -959,6 +959,8 @@ impl LayoutEngine {
                     RenderNodeType::Image(ImageNode {
                         transform,
                         effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                         ..ImageNode::new(bin_data_id, image_data)
                     }),
                     BoundingBox::new(render_x, render_y, render_w, render_h),

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -643,6 +643,8 @@ impl LayoutEngine {
                                     transform: ShapeTransform::default(),
                                     crop: None,
                                     effect: pic.image_attr.effect,
+                                    brightness: pic.image_attr.brightness,
+                                    contrast: pic.image_attr.contrast,
                                 }),
                                 BoundingBox::new(pic_x, pic_y, fit_w, fit_h),
                             );

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -635,6 +635,10 @@ pub struct ImageNode {
     pub crop: Option<(i32, i32, i32, i32)>,
     /// 그림 효과 (실사/그레이스케일/흑백/패턴)
     pub effect: ImageEffect,
+    /// 밝기 (-100 ~ +100)
+    pub brightness: i8,
+    /// 명암(대비) (-100 ~ +100)
+    pub contrast: i8,
 }
 
 impl ImageNode {
@@ -646,6 +650,8 @@ impl ImageNode {
             transform: ShapeTransform::default(),
             crop: None,
             effect: ImageEffect::RealPic,
+            brightness: 0,
+            contrast: 0,
         }
     }
 }

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -1061,6 +1061,11 @@ impl SvgRenderer {
         if let Some(ref fid) = effect_filter_id {
             self.output.push_str(&format!("<g filter=\"url(#{})\">\n", fid));
         }
+        // 밝기/대비 → SVG 필터 래핑
+        let bc_filter_id = self.ensure_brightness_contrast_filter(img.brightness, img.contrast);
+        if let Some(ref fid) = bc_filter_id {
+            self.output.push_str(&format!("<g filter=\"url(#{})\">\n", fid));
+        }
 
         let mime_type = detect_image_mime_type(data);
 
@@ -1158,6 +1163,9 @@ impl SvgRenderer {
             }
         }
 
+        if bc_filter_id.is_some() {
+            self.output.push_str("</g>\n");
+        }
         if effect_filter_id.is_some() {
             self.output.push_str("</g>\n");
         }
@@ -1207,6 +1215,37 @@ impl SvgRenderer {
             self.defs.push(def_str);
         }
         Some(id.to_string())
+    }
+
+    /// 밝기/대비 조정용 SVG 필터를 defs에 보장하고 ID를 반환한다.
+    /// 둘 다 0이면 필터 불필요 → None 반환.
+    fn ensure_brightness_contrast_filter(&mut self, brightness: i8, contrast: i8) -> Option<String> {
+        if brightness == 0 && contrast == 0 {
+            return None;
+        }
+
+        let id = format!("rhwp-img-bc-b{}c{}", brightness, contrast);
+
+        // 밝기: intercept 오프셋으로 구현 (slope=1, intercept=brightness/100)
+        // 대비: slope 조정으로 구현 (slope=(100+contrast)/100, intercept=0.5-0.5*slope)
+        // 둘을 합성: slope=contrast_slope, intercept=contrast_intercept + brightness_offset
+        let b = brightness as f64 / 100.0;
+        let slope = (100.0 + contrast as f64) / 100.0;
+        let intercept = (0.5 - 0.5 * slope) + b;
+
+        let def = format!(
+            "<filter id=\"{id}\">\
+                <feComponentTransfer>\
+                    <feFuncR type=\"linear\" slope=\"{slope:.4}\" intercept=\"{intercept:.4}\"/>\
+                    <feFuncG type=\"linear\" slope=\"{slope:.4}\" intercept=\"{intercept:.4}\"/>\
+                    <feFuncB type=\"linear\" slope=\"{slope:.4}\" intercept=\"{intercept:.4}\"/>\
+                </feComponentTransfer>\
+            </filter>\n"
+        );
+        if !self.defs.iter().any(|d| d == &def) {
+            self.defs.push(def);
+        }
+        Some(id)
     }
 
     /// 이미지를 원래 크기로 지정 위치에 배치 (배치 모드)


### PR DESCRIPTION
## 배경

PR #149에서 그레이스케일/흑백 효과가 구현되었으나, 밝기(brightness)와 대비(contrast) 속성은 파싱만 되고 SVG 출력에 반영되지 않았습니다.

## 변경 사항

- `ImageNode`에 `brightness: i8`, `contrast: i8` 필드 추가
- 8개 ImageNode 생성 지점에서 `pic.image_attr.brightness/contrast` 전달
- SVG `<feComponentTransfer>` 필터로 밝기/대비 조정 구현
- 기존 효과 필터(그레이스케일/흑백)와 중첩 `<g filter>` 래핑으로 조합

## 필터 수식

```
slope = (100 + contrast) / 100
intercept = (0.5 - 0.5 × slope) + brightness / 100
```

## 테스트

- `cargo test`: 1008 통과
- `cargo clippy -- -D warnings`: 경고 0건
- SVG 스냅샷 테스트 6건 모두 통과 (회귀 없음)

Closes #150