### PR TITLE
fix: 수식 렌더링 개선 — TAC 높이 반영 + 한글 이탤릭 제거 (#174, #175)

### DIFF
--- a/src/renderer/equation/layout.rs
+++ b/src/renderer/equation/layout.rs
@@ -223,7 +223,11 @@ impl EqLayout {
     }
 
     fn layout_text(&self, text: &str, fs: f64) -> LayoutBox {
-        let w = estimate_text_width(text, fs, true);
+        // CJK/한글 텍스트는 이탤릭이 아니므로 italic 보정 제외
+        let has_cjk = text.chars().any(|c| matches!(c,
+            '\u{3000}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}' | '\u{AC00}'..='\u{D7AF}'
+        ));
+        let w = estimate_text_width(text, fs, !has_cjk);
         LayoutBox {
             x: 0.0, y: 0.0, width: w, height: fs,
             baseline: fs * 0.8,
@@ -1003,5 +1007,41 @@ mod tests {
         );
         assert!(lb.width > 100.0);
         assert!(lb.height > 0.0);
+    }
+
+    #[test]
+    fn test_cases_korean_no_overlap() {
+        // exam_math.hwp p177 CASES 수식 — 한글 혼합
+        let lb = parse_and_layout(
+            "a _{n+1} = {cases{``a _{n} -3&&LEFT ( LEFT |` a _{n} `RIGHT | 이~홀수인~경우 RIGHT )#``{1} over {2} a _{n}&&LEFT ( a _{n} =0~또는~ LEFT |` a _{n} `RIGHT | 이~짝수인~경우 RIGHT )}}",
+            14.67,
+        );
+        assert!(lb.width > 0.0, "CASES width should be positive");
+        assert!(lb.height > 0.0, "CASES height should be positive");
+
+        // CASES는 Paren{ body: Row[ row1, row2 ] } 구조
+        if let LayoutKind::Paren { body, .. } = &lb.kind {
+            if let LayoutKind::Row(rows) = &body.kind {
+                assert!(rows.len() >= 2, "CASES should have at least 2 rows");
+                let row1 = &rows[0];
+                let row2 = &rows[1];
+                let row1_bottom = row1.y + row1.height;
+                let row2_top = row2.y;
+                assert!(row2_top >= row1_bottom,
+                    "CASES rows should not overlap: row1 bottom={:.1}, row2 top={:.1}",
+                    row1_bottom, row2_top);
+            }
+        }
+    }
+
+    #[test]
+    fn test_korean_text_width_not_italic() {
+        // 한글 텍스트는 이탤릭 보정 없이 폭 산출
+        let korean = parse_and_layout("홀수인~경우", 20.0);
+        let latin = parse_and_layout("abcdef", 20.0);
+        // 한글 6자(전각 1.0×) > 라틴 6자(~0.55×)
+        assert!(korean.width > latin.width,
+            "Korean text width ({:.1}) should be larger than Latin ({:.1})",
+            korean.width, latin.width);
     }
 }

--- a/src/renderer/equation/svg_render.rs
+++ b/src/renderer/equation/svg_render.rs
@@ -43,9 +43,14 @@ fn render_box(
             let text_y = y + lb.baseline;
             let esc = escape_xml(text);
             let fi = fs;
+            // CJK/한글 텍스트는 이탤릭 없이 렌더링 (수학 변수명만 이탤릭)
+            let has_cjk = text.chars().any(|c| matches!(c,
+                '\u{3000}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}' | '\u{AC00}'..='\u{D7AF}'
+            ));
+            let style = if has_cjk { "" } else { " font-style=\"italic\"" };
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"{:.2}\" fill=\"{}\" font-style=\"italic\"{}>{}</text>\n",
-                text_x, text_y, fi, color, EQ_FONT_FAMILY, esc,
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"{:.2}\" fill=\"{}\"{}{}>{}</text>\n",
+                text_x, text_y, fi, color, style, EQ_FONT_FAMILY, esc,
             ));
         }
         LayoutKind::Number(text) => {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1733,9 +1733,17 @@ impl LayoutEngine {
                                 let svg_content = crate::renderer::equation::svg_render::render_equation_svg(
                                     &layout_box, &color_str, font_size_px,
                                 );
-                                let eq_h = layout_box.height;
+                                // HWP 저장 높이를 우선 사용 (한컴 조판 결과 기준)
+                                let hwp_eq_h = hwpunit_to_px(eq.common.height as i32, self.dpi);
+                                let eq_h = if hwp_eq_h > 0.0 { hwp_eq_h } else { layout_box.height };
                                 // 수식 baseline을 텍스트 baseline에 맞춤
-                                let eq_y = (y + baseline - layout_box.baseline).max(y);
+                                // HWP 높이와 레이아웃 높이가 다르면 baseline도 비례 조정
+                                let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
+                                    let scale = hwp_eq_h / layout_box.height;
+                                    (y + baseline - layout_box.baseline * scale).max(y)
+                                } else {
+                                    (y + baseline - layout_box.baseline).max(y)
+                                };
                                 let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                     (Some(ctx.path[0].cell_index), Some(ctx.path[0].cell_para_index))
                                 } else {
@@ -2098,8 +2106,14 @@ impl LayoutEngine {
                             let svg_content = crate::renderer::equation::svg_render::render_equation_svg(
                                 &layout_box, &color_str, font_size_px,
                             );
-                            let eq_h = layout_box.height;
-                            let eq_y = (y + baseline - layout_box.baseline).max(y);
+                            let hwp_eq_h = hwpunit_to_px(eq.common.height as i32, self.dpi);
+                            let eq_h = if hwp_eq_h > 0.0 { hwp_eq_h } else { layout_box.height };
+                            let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
+                                let scale = hwp_eq_h / layout_box.height;
+                                (y + baseline - layout_box.baseline * scale).max(y)
+                            } else {
+                                (y + baseline - layout_box.baseline).max(y)
+                            };
                             let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                 (Some(ctx.path[0].cell_index), Some(ctx.path[0].cell_para_index))
                             } else {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -329,10 +329,16 @@ impl SvgRenderer {
                 } else {
                     1.0
                 };
-                if (scale_x - 1.0).abs() > 0.01 {
+                let scale_y = if eq.layout_box.height > 0.0 && node.bbox.height > 0.0 {
+                    node.bbox.height / eq.layout_box.height
+                } else {
+                    1.0
+                };
+                let needs_scale = (scale_x - 1.0).abs() > 0.01 || (scale_y - 1.0).abs() > 0.01;
+                if needs_scale {
                     self.output.push_str(&format!(
-                        "<g transform=\"translate({},{}) scale({:.4},1)\">\n",
-                        node.bbox.x, node.bbox.y, scale_x,
+                        "<g transform=\"translate({},{}) scale({:.4},{:.4})\">\n",
+                        node.bbox.x, node.bbox.y, scale_x, scale_y,
                     ));
                 } else {
                     self.output.push_str(&format!(


### PR DESCRIPTION
## 배경

수식 렌더링에서 두 가지 문제가 있었습니다:
1. **#174**: 큰 수식(∑, 분수, lim 등)이 포함된 줄과 인접 줄이 겹침
2. **#175**: CASES 수식 내 한글+수학 혼합 텍스트가 이탤릭으로 렌더링됨

## 변경 사항

### 수식 TAC 높이 (#174)

- 인라인 수식의 BoundingBox 높이를 레이아웃 엔진 산출값 대신 HWP 저장 높이(`eq.common.height`)를 우선 사용
- SVG 렌더러에서 `scale(x, y)` 변환 적용 — 기존에는 x축만 스케일링하고 y는 `1`로 고정
- HWP 높이와 레이아웃 높이 차이에 비례하여 baseline도 조정

### 한글 수식 텍스트 (#175)

- 수식 내 CJK 텍스트(한글 등)에 `font-style="italic"` 제거
  - 수학 변수명(`x`, `n`)만 이탤릭, 한글 설명 텍스트("홀수인 경우")는 정체(upright)
- 한글 텍스트 폭 산출 시 이탤릭 1.05배 보정 제외
- CASES 행 겹침 방지 검증 테스트 추가

## 테스트

- `cargo test`: 1010 통과 (신규 2건 포함)
- `cargo clippy -- -D warnings`: 경고 0건
- SVG 스냅샷 테스트 6건 통과 (회귀 없음)

Addresses #174, #175