### PR TITLE
fix: 수식 렌더링 개선 — TAC 높이 반영 + 한글 이탤릭 제거 (#174, #175)

### DIFF
--- a/src/renderer/equation/canvas_render.rs
+++ b/src/renderer/equation/canvas_render.rs
@@ -41,7 +41,10 @@ fn render_box(
         }
         LayoutKind::Text(text) => {
             let fi = font_size_from_box(lb, fs);
-            set_font(ctx, fi, true, bold);
+            let has_cjk = text.chars().any(|c| matches!(c,
+                '\u{3000}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}' | '\u{AC00}'..='\u{D7AF}'
+            ));
+            set_font(ctx, fi, !has_cjk, bold);
             ctx.set_fill_style_str(color);
             let _ = ctx.fill_text(text, x, y + lb.baseline);
         }

--- a/src/renderer/equation/layout.rs
+++ b/src/renderer/equation/layout.rs
@@ -1019,19 +1019,30 @@ mod tests {
         assert!(lb.width > 0.0, "CASES width should be positive");
         assert!(lb.height > 0.0, "CASES height should be positive");
 
-        // CASES는 Paren{ body: Row[ row1, row2 ] } 구조
-        if let LayoutKind::Paren { body, .. } = &lb.kind {
-            if let LayoutKind::Row(rows) = &body.kind {
-                assert!(rows.len() >= 2, "CASES should have at least 2 rows");
-                let row1 = &rows[0];
-                let row2 = &rows[1];
-                let row1_bottom = row1.y + row1.height;
-                let row2_top = row2.y;
-                assert!(row2_top >= row1_bottom,
-                    "CASES rows should not overlap: row1 bottom={:.1}, row2 top={:.1}",
-                    row1_bottom, row2_top);
-            }
-        }
+        // 전체 수식 a_{n+1} = {cases{...}} 는 Row[subscript, =, Paren{cases}]
+        let top_children = match &lb.kind {
+            LayoutKind::Row(children) => children,
+            other => panic!("Top-level should be Row, got {:?}", other),
+        };
+        let cases_paren = top_children.iter()
+            .find(|c| matches!(&c.kind, LayoutKind::Paren { .. }))
+            .expect("Should contain a Paren (CASES) element");
+        let cases_body = match &cases_paren.kind {
+            LayoutKind::Paren { body, .. } => body,
+            _ => unreachable!(),
+        };
+        let rows = match &cases_body.kind {
+            LayoutKind::Row(rows) => rows,
+            other => panic!("CASES body should be Row, got {:?}", other),
+        };
+        assert!(rows.len() >= 2, "CASES should have at least 2 rows");
+        let row1 = &rows[0];
+        let row2 = &rows[1];
+        let row1_bottom = row1.y + row1.height;
+        let row2_top = row2.y;
+        assert!(row2_top >= row1_bottom,
+            "CASES rows should not overlap: row1 bottom={:.1}, row2 top={:.1}",
+            row1_bottom, row2_top);
     }
 
     #[test]

--- a/src/renderer/equation/layout.rs
+++ b/src/renderer/equation/layout.rs
@@ -223,7 +223,11 @@ impl EqLayout {
     }
 
     fn layout_text(&self, text: &str, fs: f64) -> LayoutBox {
-        let w = estimate_text_width(text, fs, true);
+        // CJK/한글 텍스트는 이탤릭이 아니므로 italic 보정 제외
+        let has_cjk = text.chars().any(|c| matches!(c,
+            '\u{3000}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}' | '\u{AC00}'..='\u{D7AF}'
+        ));
+        let w = estimate_text_width(text, fs, !has_cjk);
         LayoutBox {
             x: 0.0, y: 0.0, width: w, height: fs,
             baseline: fs * 0.8,
@@ -1003,5 +1007,41 @@ mod tests {
         );
         assert!(lb.width > 100.0);
         assert!(lb.height > 0.0);
+    }
+
+    #[test]
+    fn test_cases_korean_no_overlap() {
+        // exam_math.hwp p177 CASES 수식 — 한글 혼합
+        let lb = parse_and_layout(
+            "a _{n+1} = {cases{``a _{n} -3&&LEFT ( LEFT |` a _{n} `RIGHT | 이~홀수인~경우 RIGHT )#``{1} over {2} a _{n}&&LEFT ( a _{n} =0~또는~ LEFT |` a _{n} `RIGHT | 이~짝수인~경우 RIGHT )}}",
+            14.67,
+        );
+        assert!(lb.width > 0.0, "CASES width should be positive");
+        assert!(lb.height > 0.0, "CASES height should be positive");
+
+        // CASES는 Paren{ body: Row[ row1, row2 ] } 구조
+        if let LayoutKind::Paren { body, .. } = &lb.kind {
+            if let LayoutKind::Row(rows) = &body.kind {
+                assert!(rows.len() >= 2, "CASES should have at least 2 rows");
+                let row1 = &rows[0];
+                let row2 = &rows[1];
+                let row1_bottom = row1.y + row1.height;
+                let row2_top = row2.y;
+                assert!(row2_top >= row1_bottom,
+                    "CASES rows should not overlap: row1 bottom={:.1}, row2 top={:.1}",
+                    row1_bottom, row2_top);
+            }
+        }
+    }
+
+    #[test]
+    fn test_korean_text_width_not_italic() {
+        // 한글 텍스트는 이탤릭 보정 없이 폭 산출
+        let korean = parse_and_layout("홀수인~경우", 20.0);
+        let latin = parse_and_layout("abcdef", 20.0);
+        // 한글 6자(전각 1.0×) > 라틴 6자(~0.55×)
+        assert!(korean.width > latin.width,
+            "Korean text width ({:.1}) should be larger than Latin ({:.1})",
+            korean.width, latin.width);
     }
 }

--- a/src/renderer/equation/svg_render.rs
+++ b/src/renderer/equation/svg_render.rs
@@ -43,9 +43,14 @@ fn render_box(
             let text_y = y + lb.baseline;
             let esc = escape_xml(text);
             let fi = fs;
+            // CJK/한글 텍스트는 이탤릭 없이 렌더링 (수학 변수명만 이탤릭)
+            let has_cjk = text.chars().any(|c| matches!(c,
+                '\u{3000}'..='\u{9FFF}' | '\u{F900}'..='\u{FAFF}' | '\u{AC00}'..='\u{D7AF}'
+            ));
+            let style = if has_cjk { "" } else { " font-style=\"italic\"" };
             svg.push_str(&format!(
-                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"{:.2}\" fill=\"{}\" font-style=\"italic\"{}>{}</text>\n",
-                text_x, text_y, fi, color, EQ_FONT_FAMILY, esc,
+                "<text x=\"{:.2}\" y=\"{:.2}\" font-size=\"{:.2}\" fill=\"{}\"{}{}>{}</text>\n",
+                text_x, text_y, fi, color, style, EQ_FONT_FAMILY, esc,
             ));
         }
         LayoutKind::Number(text) => {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1733,9 +1733,17 @@ impl LayoutEngine {
                                 let svg_content = crate::renderer::equation::svg_render::render_equation_svg(
                                     &layout_box, &color_str, font_size_px,
                                 );
-                                let eq_h = layout_box.height;
+                                // HWP 저장 높이를 우선 사용 (한컴 조판 결과 기준)
+                                let hwp_eq_h = hwpunit_to_px(eq.common.height as i32, self.dpi);
+                                let eq_h = if hwp_eq_h > 0.0 { hwp_eq_h } else { layout_box.height };
                                 // 수식 baseline을 텍스트 baseline에 맞춤
-                                let eq_y = (y + baseline - layout_box.baseline).max(y);
+                                // HWP 높이와 레이아웃 높이가 다르면 baseline도 비례 조정
+                                let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
+                                    let scale = hwp_eq_h / layout_box.height;
+                                    (y + baseline - layout_box.baseline * scale).max(y)
+                                } else {
+                                    (y + baseline - layout_box.baseline).max(y)
+                                };
                                 let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                     (Some(ctx.path[0].cell_index), Some(ctx.path[0].cell_para_index))
                                 } else {
@@ -2098,8 +2106,14 @@ impl LayoutEngine {
                             let svg_content = crate::renderer::equation::svg_render::render_equation_svg(
                                 &layout_box, &color_str, font_size_px,
                             );
-                            let eq_h = layout_box.height;
-                            let eq_y = (y + baseline - layout_box.baseline).max(y);
+                            let hwp_eq_h = hwpunit_to_px(eq.common.height as i32, self.dpi);
+                            let eq_h = if hwp_eq_h > 0.0 { hwp_eq_h } else { layout_box.height };
+                            let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
+                                let scale = hwp_eq_h / layout_box.height;
+                                (y + baseline - layout_box.baseline * scale).max(y)
+                            } else {
+                                (y + baseline - layout_box.baseline).max(y)
+                            };
                             let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                 (Some(ctx.path[0].cell_index), Some(ctx.path[0].cell_para_index))
                             } else {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -329,10 +329,16 @@ impl SvgRenderer {
                 } else {
                     1.0
                 };
-                if (scale_x - 1.0).abs() > 0.01 {
+                let scale_y = if eq.layout_box.height > 0.0 && node.bbox.height > 0.0 {
+                    node.bbox.height / eq.layout_box.height
+                } else {
+                    1.0
+                };
+                let needs_scale = (scale_x - 1.0).abs() > 0.01 || (scale_y - 1.0).abs() > 0.01;
+                if needs_scale {
                     self.output.push_str(&format!(
-                        "<g transform=\"translate({},{}) scale({:.4},1)\">\n",
-                        node.bbox.x, node.bbox.y, scale_x,
+                        "<g transform=\"translate({},{}) scale({:.4},{:.4})\">\n",
+                        node.bbox.x, node.bbox.y, scale_x, scale_y,
                     ));
                 } else {
                     self.output.push_str(&format!(


### PR DESCRIPTION
## 요약

기존 PR #388 을 `devel` 기반으로 재작업한 PR 입니다. `main` 으로 직접 올린 점 죄송합니다.

### 1. TAC 높이에 HWP 권위값 사용 (#174)
- 인라인 수식 높이를 `eq.common.height` (HWP 저장 값) 기준으로 설정
- X/Y 스케일링 동시 적용으로 수식 bbox 정확도 향상
- 큰 수식이 인접 행과 겹치는 문제 해결

### 2. 한글(CJK) 이탤릭 제거 (#175)
- 수식 내 CJK 문자에 이탤릭 스타일링 및 너비 보정 비적용
- CASES 표현식에서 한글 행이 겹치는 문제 해결
- 회귀 테스트 추가 (CASES overlap / width)

## 변경 파일 (4개)

- `src/renderer/svg.rs` — 수식 SVG 배치 시 Y축 스케일링 추가
- `src/renderer/layout/paragraph_layout.rs` — HWP 수식 높이 우선 + 베이스라인 스케일 조정
- `src/renderer/equation/svg_render.rs` — CJK 수식 텍스트 이탤릭 제거
- `src/renderer/equation/layout.rs` — CJK 이탤릭 너비 보정 제외 + 회귀 테스트

## 테스트

- `cargo test` — 전체 통과
- `cargo clippy -- -D warnings` — 경고 0

Closes #174, #175