### PR TITLE
수식 ATOP 파싱 및 렌더링 보정

### DIFF
--- a/src/renderer/equation/canvas_render.rs
+++ b/src/renderer/equation/canvas_render.rs
@@ -87,6 +87,10 @@ fn render_box(
             ctx.stroke();
             render_box(ctx, denom, x, y, color, fs, italic, bold);
         }
+        LayoutKind::Atop { top, bottom } => {
+            render_box(ctx, top, x, y, color, fs, italic, bold);
+            render_box(ctx, bottom, x, y, color, fs, italic, bold);
+        }
         LayoutKind::Sqrt { index, body } => {
             let sign_h = lb.height;
             let body_left = x + body.x - fs * 0.1;

--- a/src/renderer/equation/layout.rs
+++ b/src/renderer/equation/layout.rs
@@ -42,6 +42,11 @@ pub enum LayoutKind {
         numer: Box<LayoutBox>,
         denom: Box<LayoutBox>,
     },
+    /// 위아래 배치 (분수선 없음)
+    Atop {
+        top: Box<LayoutBox>,
+        bottom: Box<LayoutBox>,
+    },
     /// 제곱근
     Sqrt {
         index: Option<Box<LayoutBox>>,
@@ -153,7 +158,7 @@ impl EqLayout {
             EqNode::Function(s) => self.layout_function(s, fs),
             EqNode::Quoted(s) => self.layout_number(s, fs),
             EqNode::Fraction { numer, denom } => self.layout_fraction(numer, denom, fs),
-            EqNode::Atop { top, bottom } => self.layout_fraction(top, bottom, fs),
+            EqNode::Atop { top, bottom } => self.layout_atop(top, bottom, fs),
             EqNode::Sqrt { index, body } => self.layout_sqrt(index, body, fs),
             EqNode::Superscript { base, sup } => self.layout_superscript(base, sup, fs),
             EqNode::Subscript { base, sub } => self.layout_subscript(base, sub, fs),
@@ -319,6 +324,36 @@ impl EqLayout {
             kind: LayoutKind::Fraction {
                 numer: Box::new(n_box),
                 denom: Box::new(d_box),
+            },
+        }
+    }
+
+    fn layout_atop(&self, top: &EqNode, bottom: &EqNode, fs: f64) -> LayoutBox {
+        let t = self.layout_node(top, fs);
+        let b = self.layout_node(bottom, fs);
+
+        let pad = fs * FRAC_LINE_PAD;
+        let axis = fs * AXIS_HEIGHT;
+        let w = t.width.max(b.width) + pad * 2.0;
+
+        let top_h = t.height + pad;
+        let bottom_h = b.height + pad;
+        let baseline = top_h + axis;
+        let total_h = top_h + bottom_h;
+
+        let mut top_box = t;
+        top_box.x = (w - top_box.width) / 2.0;
+        top_box.y = pad;
+
+        let mut bottom_box = b;
+        bottom_box.x = (w - bottom_box.width) / 2.0;
+        bottom_box.y = top_h;
+
+        LayoutBox {
+            x: 0.0, y: 0.0, width: w, height: total_h, baseline,
+            kind: LayoutKind::Atop {
+                top: Box::new(top_box),
+                bottom: Box::new(bottom_box),
             },
         }
     }

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -88,7 +88,7 @@ impl EqParser {
     }
 
     /// 표현식 파싱 (중단 조건 없이 끝까지)
-    /// OVER를 중위 연산자로 처리: 바로 앞 요소가 분자, 바로 뒤 요소가 분모
+    /// OVER/ATOP을 중위 연산자로 처리: 바로 앞/뒤 요소를 위아래로 배치
     fn parse_expression(&mut self) -> EqNode {
         let mut children = Vec::new();
         while !self.at_end() {
@@ -101,16 +101,25 @@ impl EqParser {
             {
                 break;
             }
-            // OVER 중위 연산자: 직전 요소를 분자, 직후 요소를 분모로 결합
+            // OVER/ATOP 중위 연산자: 직전/직후 요소를 위아래로 결합
             if self.current_type() == TokenType::Command
-                && Self::cmd_eq(self.current_value(), "OVER")
+                && (Self::cmd_eq(self.current_value(), "OVER")
+                    || Self::cmd_eq(self.current_value(), "ATOP"))
             {
-                self.pos += 1; // OVER 건너뛰기
-                let numer = children.pop().unwrap_or(EqNode::Empty);
-                let denom = self.parse_element();
-                children.push(EqNode::Fraction {
-                    numer: Box::new(numer),
-                    denom: Box::new(denom),
+                let is_atop = Self::cmd_eq(self.current_value(), "ATOP");
+                self.pos += 1; // 연산자 건너뛰기
+                let top = children.pop().unwrap_or(EqNode::Empty);
+                let bottom = self.parse_element();
+                children.push(if is_atop {
+                    EqNode::Atop {
+                        top: Box::new(top),
+                        bottom: Box::new(bottom),
+                    }
+                } else {
+                    EqNode::Fraction {
+                        numer: Box::new(top),
+                        denom: Box::new(bottom),
+                    }
                 });
                 continue;
             }
@@ -189,13 +198,13 @@ impl EqParser {
         let cmd_upper = cmd.to_ascii_uppercase();
         let cu = cmd_upper.as_str();
 
-        // OVER는 parse_fraction에서 처리됨 (단독 발생 시)
+        // OVER/ATOP은 parse_expression에서 처리됨 (단독 발생 시)
         if cu == "OVER" {
             return EqNode::Empty;
         }
 
         if cu == "ATOP" {
-            return EqNode::Empty; // ATOP도 parse_atop에서 처리
+            return EqNode::Empty;
         }
 
         // 제곱근
@@ -444,16 +453,25 @@ impl EqParser {
             if self.current_type() == TokenType::RBrace {
                 break;
             }
-            // OVER 중위 연산자: 그룹 내에서도 동일하게 처리
+            // OVER/ATOP 중위 연산자: 그룹 내에서도 동일하게 처리
             if self.current_type() == TokenType::Command
-                && Self::cmd_eq(self.current_value(), "OVER")
+                && (Self::cmd_eq(self.current_value(), "OVER")
+                    || Self::cmd_eq(self.current_value(), "ATOP"))
             {
+                let is_atop = Self::cmd_eq(self.current_value(), "ATOP");
                 self.pos += 1;
-                let numer = children.pop().unwrap_or(EqNode::Empty);
-                let denom = self.parse_element();
-                children.push(EqNode::Fraction {
-                    numer: Box::new(numer),
-                    denom: Box::new(denom),
+                let top = children.pop().unwrap_or(EqNode::Empty);
+                let bottom = self.parse_element();
+                children.push(if is_atop {
+                    EqNode::Atop {
+                        top: Box::new(top),
+                        bottom: Box::new(bottom),
+                    }
+                } else {
+                    EqNode::Fraction {
+                        numer: Box::new(top),
+                        denom: Box::new(bottom),
+                    }
                 });
                 continue;
             }
@@ -1180,6 +1198,18 @@ mod tests {
                 assert!(matches!(denom.as_ref(), EqNode::Number(n) if n == "2"));
             }
             _ => panic!("Expected Fraction, got {:?}", ast),
+        }
+    }
+
+    #[test]
+    fn test_atop() {
+        let ast = parse("a atop b");
+        match &ast {
+            EqNode::Atop { top, bottom } => {
+                assert!(matches!(top.as_ref(), EqNode::Text(t) if t == "a"));
+                assert!(matches!(bottom.as_ref(), EqNode::Text(t) if t == "b"));
+            }
+            _ => panic!("Expected Atop, got {:?}", ast),
         }
     }
 

--- a/src/renderer/equation/svg_render.rs
+++ b/src/renderer/equation/svg_render.rs
@@ -110,6 +110,10 @@ fn render_box(
             // 분모
             render_box(svg, denom, x, y, color, fs, italic, bold);
         }
+        LayoutKind::Atop { top, bottom } => {
+            render_box(svg, top, x, y, color, fs, italic, bold);
+            render_box(svg, bottom, x, y, color, fs, italic, bold);
+        }
         LayoutKind::Sqrt { index, body } => {
             // √ 기호
             let sign_h = lb.height;
@@ -523,6 +527,29 @@ mod tests {
         let svg = render_eq("a over b");
         assert!(svg.contains("<text")); // 분자/분모 텍스트
         assert!(svg.contains("<line")); // 분수선
+    }
+
+    #[test]
+    fn test_atop_svg_has_no_fraction_line() {
+        let svg = render_eq("a atop b");
+        assert!(svg.contains("<text"));
+        assert!(!svg.contains("<line"));
+        let y_values: Vec<&str> = svg
+            .lines()
+            .filter_map(|line| line.split(" y=\"").nth(1))
+            .filter_map(|rest| rest.split('"').next())
+            .collect();
+        assert_eq!(
+            y_values.len(),
+            2,
+            "ATOP은 위/아래 텍스트 2개를 렌더링해야 함: {}",
+            svg
+        );
+        assert_ne!(
+            y_values[0], y_values[1],
+            "ATOP은 두 항을 세로로 배치해야 함: {}",
+            svg
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

- 한컴 수식 `a ATOP b`를 `EqNode::Atop`으로 파싱하도록 보정
- `Atop` 레이아웃을 `Fraction`과 분리해 분수선 없이 위/아래 항만 배치하도록 구현
- SVG/Canvas 렌더러가 `LayoutKind::Atop`을 별도 처리하도록 추가
- 파서 단위 테스트와 SVG 렌더링 회귀 테스트를 추가

## 배경

한컴 수식 문법에서 `ATOP`은 `OVER`와 비슷하게 두 항을 위아래로 배치하지만, `OVER`와 달리 가운데 분수선을 그리지 않는다.

예:

```text
a ATOP b
```

기대 렌더링은 `a`가 위, `b`가 아래에 배치되는 형태이며, `a OVER b`처럼 분수선이 들어가면 안 된다.

## 현상

기존 코드에는 이미 `EqNode::Atop { top, bottom }` AST 타입이 있었지만 실제 파싱·레이아웃·렌더링 흐름이 완성되어 있지 않았다.

그 결과 `a ATOP b` 입력 시:

- 파서가 `ATOP` 명령을 독립 명령으로 만나면 빈 노드로 처리
- 중위 연산자 형태의 `a ATOP b`를 위/아래 구조로 결합하지 못함
- `EqNode::Atop`이 만들어져도 레이아웃 단계에서 `Fraction` 레이아웃으로 대체되어 분수선이 생길 수 있음
- SVG/Canvas 렌더러에는 `LayoutKind::Atop` 처리 분기가 없었음

## 근본 원인

`OVER`는 `parse_expression()`과 그룹 파싱 내부에서 중위 연산자로 처리되어 직전 요소를 분자, 직후 요소를 분모로 결합한다.

반면 `ATOP`은 문법적으로 같은 중위 연산자 계열임에도 해당 처리 흐름에 포함되어 있지 않았다.

또한 레이아웃 단계에서 `EqNode::Atop`을 `layout_fraction()`으로 넘기고 있었기 때문에, `Atop`의 의미인 “분수선 없는 위/아래 배치”가 유지되지 않았다.

## 해결책

### 1. ATOP 중위 연산자 파싱

`src/renderer/equation/parser.rs`에서 `OVER` 처리 경로에 `ATOP`을 함께 포함했다.

- `a OVER b` → `EqNode::Fraction { numer, denom }`
- `a ATOP b` → `EqNode::Atop { top, bottom }`

동일한 처리를 최상위 표현식과 `{ ... }` 그룹 내부 파싱 양쪽에 적용했다.

### 2. Atop 전용 레이아웃 추가

`src/renderer/equation/layout.rs`에 `LayoutKind::Atop`과 `layout_atop()`을 추가했다.

`layout_atop()`은 `layout_fraction()`과 유사하게 위/아래 항을 중앙 정렬하지만, 분수선 영역을 만들거나 렌더러에 선을 요구하지 않는다.

핵심 차이:

- `Fraction`: 위/아래 항 + 분수선
- `Atop`: 위/아래 항만 배치, 분수선 없음

### 3. SVG/Canvas 렌더링 분기 추가

`src/renderer/equation/svg_render.rs`와 `src/renderer/equation/canvas_render.rs`에 `LayoutKind::Atop` 분기를 추가했다.

렌더러는 이미 계산된 `top`, `bottom` 위치에 각각 텍스트/수식 박스를 렌더링하며, 별도의 `<line>` 또는 Canvas line stroke를 만들지 않는다.

## 검증

### 신규 회귀 테스트

`src/renderer/equation/parser.rs`:

- `test_atop`
  - `a atop b`가 `EqNode::Atop`으로 파싱되는지 확인
  - 위 항이 `a`, 아래 항이 `b`로 보존되는지 확인

`src/renderer/equation/svg_render.rs`:

- `test_atop_svg_has_no_fraction_line`
  - `a atop b` SVG에 `<text>`가 출력되는지 확인
  - SVG에 `<line>`이 없어 분수선이 그려지지 않는지 확인
  - 두 텍스트의 y 좌표가 달라 위/아래 배치가 되었는지 확인

기존 회귀 확인:

- `test_fraction_svg`
  - `OVER` 수식은 기존처럼 분수선을 유지하는지 확인

### 테스트 실행 결과

- `cargo test renderer::equation::parser::tests::test_atop` 통과
- `cargo test renderer::equation::svg_render::tests::test_atop_svg_has_no_fraction_line` 통과
- `cargo test renderer::equation::svg_render::tests::test_fraction_svg` 통과
- `cargo test` 통과
  - lib 1018 passed, 1 ignored
  - 통합 테스트 및 문서 테스트 통과
- `git diff --check` 통과
- `cargo clippy -- -D warnings`는 기존 코드의 `clippy::uninlined_format_args` 716건으로 실패
- 기존 lint만 제외한 `cargo clippy -- -D warnings -A clippy::uninlined_format_args` 통과

## 의도된 동작 변경

`ATOP` 수식이 더 이상 빈 노드로 사라지거나 분수선 있는 분수처럼 렌더링되지 않는다.

앞으로:

- `a OVER b`는 분수선 있는 분수로 렌더링
- `a ATOP b`는 분수선 없는 위/아래 배치로 렌더링

이는 한컴 수식 문법의 의미에 맞는 동작 변경이다.

## 변경 파일

| 파일 | 변경 |
| --- | --- |
| `src/renderer/equation/parser.rs` | `ATOP`을 `OVER`와 같은 중위 연산자 흐름으로 파싱, `EqNode::Atop` 생성, 파서 테스트 추가 |
| `src/renderer/equation/layout.rs` | `LayoutKind::Atop` 추가, 분수선 없는 `layout_atop()` 구현 |
| `src/renderer/equation/svg_render.rs` | `LayoutKind::Atop` SVG 렌더링 분기 추가, 분수선 없음 회귀 테스트 추가 |
| `src/renderer/equation/canvas_render.rs` | `LayoutKind::Atop` Canvas 렌더링 분기 추가 |

## Test plan

- [x] `cargo test renderer::equation::parser::tests::test_atop`
- [x] `cargo test renderer::equation::svg_render::tests::test_atop_svg_has_no_fraction_line`
- [x] `cargo test renderer::equation::svg_render::tests::test_fraction_svg`
- [x] `cargo test`
- [x] `git diff --check`
- [x] `cargo clippy -- -D warnings -A clippy::uninlined_format_args`

## 메타

- **Base 브랜치**: `devel`
- **Head 브랜치**: `cskwork:fix/atop-equation-parser`
- **커밋**: `d212857` — `fix: 수식 ATOP 파싱 및 렌더링 보정`