### PR TITLE
HWPX 수식 직렬화 보존

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2690,6 +2690,26 @@ fn parse_equation(
                     }
                 }
             }
+            Ok(Event::GeneralRef(ref r)) => {
+                if in_script {
+                    if let Ok(Some(ch)) = r.resolve_char_ref() {
+                        script.push(ch);
+                    } else if let Ok(name) = r.decode() {
+                        match name.as_ref() {
+                            "lt" => script.push('<'),
+                            "gt" => script.push('>'),
+                            "amp" => script.push('&'),
+                            "quot" => script.push('"'),
+                            "apos" => script.push('\''),
+                            _ => {
+                                script.push('&');
+                                script.push_str(&name);
+                                script.push(';');
+                            }
+                        }
+                    }
+                }
+            }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
                 let local = local_name(eename.as_ref());

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -222,6 +222,188 @@ mod tests {
     }
 
     #[test]
+    fn equation_control_roundtrip_preserves_script() {
+        use crate::model::control::{Control, Equation};
+        use crate::model::shape::{CommonObjAttr, HorzAlign, HorzRelTo, TextWrap, VertAlign, VertRelTo};
+        use crate::model::Padding;
+
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "AB".to_string();
+        para.char_offsets = vec![0, 9];
+        para.char_count = 11;
+        para.controls.push(Control::Equation(Box::new(Equation {
+            common: CommonObjAttr {
+                instance_id: 7,
+                z_order: 3,
+                width: 2400,
+                height: 1200,
+                vertical_offset: 80,
+                horizontal_offset: 160,
+                margin: Padding { left: 10, right: 20, top: 30, bottom: 40 },
+                treat_as_char: true,
+                text_wrap: TextWrap::TopAndBottom,
+                vert_rel_to: VertRelTo::Para,
+                horz_rel_to: HorzRelTo::Para,
+                vert_align: VertAlign::Bottom,
+                horz_align: HorzAlign::Center,
+                ..Default::default()
+            },
+            script: "x < y & z".to_string(),
+            font_size: 1000,
+            color: 0x000000FF,
+            baseline: 120,
+            font_name: "HYhwpEQ".to_string(),
+            version_info: "Equation Version 60".to_string(),
+            raw_ctrl_data: Vec::new(),
+        })));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize equation");
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
+        assert!(
+            xml.contains("<hp:equation "),
+            "equation XML missing: {}",
+            xml
+        );
+        assert!(
+            xml.contains("<hp:script>x &lt; y &amp; z</hp:script>"),
+            "script XML missing: {}",
+            xml
+        );
+        drop(sec0);
+
+        let parsed = parse_hwpx(&bytes).expect("parse back");
+        let parsed_para = &parsed.sections[0].paragraphs[0];
+        assert_eq!(parsed_para.text, "AB");
+        let parsed_eq = parsed_para.controls.iter().find_map(|ctrl| match ctrl {
+            Control::Equation(eq) => Some(eq),
+            _ => None,
+        });
+        match parsed_eq {
+            Some(eq) => {
+                assert_eq!(eq.script, "x < y & z");
+                assert_eq!(eq.font_size, 1000);
+                assert_eq!(eq.color, 0x000000FF);
+                assert_eq!(eq.baseline, 120);
+                assert_eq!(eq.font_name, "HYhwpEQ");
+                assert_eq!(eq.version_info, "Equation Version 60");
+                assert!(eq.common.treat_as_char);
+                assert_eq!(eq.common.width, 2400);
+                assert_eq!(eq.common.height, 1200);
+                assert_eq!(eq.common.instance_id, 7);
+                assert_eq!(eq.common.z_order, 3);
+                assert_eq!(eq.common.vertical_offset, 80);
+                assert_eq!(eq.common.horizontal_offset, 160);
+                assert_eq!(eq.common.margin.left, 10);
+                assert_eq!(eq.common.margin.right, 20);
+                assert_eq!(eq.common.margin.top, 30);
+                assert_eq!(eq.common.margin.bottom, 40);
+                assert_eq!(eq.common.text_wrap, TextWrap::TopAndBottom);
+                assert_eq!(eq.common.vert_rel_to, VertRelTo::Para);
+                assert_eq!(eq.common.horz_rel_to, HorzRelTo::Para);
+                assert_eq!(eq.common.vert_align, VertAlign::Bottom);
+                assert_eq!(eq.common.horz_align, HorzAlign::Center);
+            }
+            None => panic!("expected equation control, got {:?}", parsed_para.controls),
+        }
+    }
+
+    #[test]
+    fn equation_control_between_text_runs_roundtrips_position() {
+        use crate::model::control::{Control, Equation};
+        use crate::model::page::ColumnDef;
+        use crate::model::shape::CommonObjAttr;
+        use crate::model::table::Table;
+
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "ACB".to_string();
+        para.char_offsets = vec![0, 9, 18];
+        para.char_count = 20;
+        para.controls.push(Control::ColumnDef(ColumnDef::default()));
+        para.controls.push(Control::Table(Box::new(Table::default())));
+        para.controls.push(Control::Equation(Box::new(Equation {
+            common: CommonObjAttr {
+                width: 1000,
+                height: 1000,
+                treat_as_char: true,
+                ..Default::default()
+            },
+            script: "a+b".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        })));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize equation");
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
+
+        let a_pos = xml.find("<hp:t>A</hp:t>").expect("A text run");
+        let c_pos = xml.find("<hp:t>C</hp:t>").expect("C text run");
+        let eq_pos = xml.find("<hp:equation ").expect("equation");
+        let b_pos = xml.find("<hp:t>B</hp:t>").expect("B text run");
+        assert!(
+            a_pos < c_pos && c_pos < eq_pos && eq_pos < b_pos,
+            "equation must stay after non-equation inline slots: {}",
+            xml
+        );
+    }
+
+    #[test]
+    fn equation_control_does_not_consume_unmapped_control_gap() {
+        use crate::model::control::{Control, Equation};
+        use crate::model::shape::CommonObjAttr;
+
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "ACB".to_string();
+        para.char_offsets = vec![0, 9, 18];
+        para.char_count = 20;
+        para.controls.push(Control::Equation(Box::new(Equation {
+            common: CommonObjAttr {
+                width: 1000,
+                height: 1000,
+                treat_as_char: true,
+                ..Default::default()
+            },
+            script: "a+b".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        })));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize equation");
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
+
+        let text_pos = xml.find("<hp:t>ACB</hp:t>").expect("text run");
+        let eq_pos = xml.find("<hp:equation ").expect("equation");
+        assert!(
+            text_pos < eq_pos,
+            "ambiguous control gap must not move equation before text: {}",
+            xml
+        );
+    }
+
+    #[test]
     fn linesegs_emitted_per_linebreak() {
         let mut doc = Document::default();
         let mut section = crate::model::document::Section::default();

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -403,6 +403,92 @@ mod tests {
         );
     }
 
+    /// 한컴 편집기가 만든 hwp 샘플(`samples/equation-lim.hwp`)의 수식 IR이
+    /// HWPX 직렬화 → 재파싱 사이클에서 의미를 잃지 않는지 검증한다.
+    ///
+    /// 자체 IR 생성 패턴(Document::default + 수동 push)을 회피하고,
+    /// 한컴 origin 데이터에서 추출한 Equation을 입력으로 사용한다.
+    #[test]
+    fn equation_roundtrip_from_hancom_origin_hwp_sample() {
+        use crate::model::control::{Control, Equation};
+        use crate::parser::parse_hwp;
+
+        let bytes = std::fs::read("samples/equation-lim.hwp")
+            .expect("samples/equation-lim.hwp must be readable");
+        let original = parse_hwp(&bytes).expect("parse hancom origin hwp");
+
+        let collect_equations = |doc: &Document| -> Vec<Equation> {
+            doc.sections
+                .iter()
+                .flat_map(|s| s.paragraphs.iter())
+                .flat_map(|p| p.controls.iter())
+                .filter_map(|c| match c {
+                    Control::Equation(eq) => Some((**eq).clone()),
+                    _ => None,
+                })
+                .collect()
+        };
+
+        let original_eqs = collect_equations(&original);
+        assert!(
+            !original_eqs.is_empty(),
+            "한컴 origin 샘플에 수식이 존재해야 회귀 비교가 의미있음"
+        );
+
+        let hwpx_bytes = serialize_hwpx(&original).expect("serialize to hwpx");
+        let reparsed = parse_hwpx(&hwpx_bytes).expect("parse hwpx back");
+        let reparsed_eqs = collect_equations(&reparsed);
+
+        assert_eq!(
+            reparsed_eqs.len(),
+            original_eqs.len(),
+            "수식 컨트롤 개수가 hwpx 라운드트립에서 유지되어야 함"
+        );
+
+        for (i, (orig, rep)) in original_eqs.iter().zip(reparsed_eqs.iter()).enumerate() {
+            assert_eq!(
+                rep.script, orig.script,
+                "[#{}] script must roundtrip through hwpx",
+                i
+            );
+            assert_eq!(
+                rep.font_size, orig.font_size,
+                "[#{}] font_size must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.baseline, orig.baseline,
+                "[#{}] baseline must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.font_name, orig.font_name,
+                "[#{}] font_name must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.color, orig.color,
+                "[#{}] color must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.common.width, orig.common.width,
+                "[#{}] common.width must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.common.height, orig.common.height,
+                "[#{}] common.height must roundtrip",
+                i
+            );
+            assert_eq!(
+                rep.common.treat_as_char, orig.common.treat_as_char,
+                "[#{}] common.treat_as_char must roundtrip",
+                i
+            );
+        }
+    }
+
     #[test]
     fn linesegs_emitted_per_linebreak() {
         let mut doc = Document::default();

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -19,8 +19,10 @@
 //!   - `paragraph.char_shapes[0].char_shape_id` → 첫 `<hp:run charPrIDRef>`
 //!   - `paragraph.line_segs[i]` → 각 `<hp:lineseg>` 속성 (6개 필드 그대로 출력)
 
+use crate::model::control::{Control, Equation};
 use crate::model::document::{Document, Section};
 use crate::model::paragraph::{ColumnBreakType, LineSeg, Paragraph};
+use crate::model::shape::{HorzAlign, HorzRelTo, TextWrap, VertAlign, VertRelTo};
 
 use super::context::SerializeContext;
 use super::utils::xml_escape;
@@ -128,7 +130,7 @@ fn first_run_char_shape_id(p: &Paragraph) -> u32 {
 /// - `para.line_segs` 가 비어있지 않으면 **IR 값 그대로 출력**
 /// - 비어있을 때만 텍스트 내 `\n` 기반으로 fallback 생성 (빈 문단·`Document::default()` 호환)
 fn render_paragraph_parts(para: &Paragraph, vert_start: u32) -> (String, String, u32) {
-    let t_xml = render_hp_t_content(&para.text);
+    let t_xml = render_run_content(para);
 
     if !para.line_segs.is_empty() {
         // IR 기반 출력 — 원본 lineseg 값 보존 (#177)
@@ -174,6 +176,217 @@ fn render_hp_t_content(text: &str) -> String {
     flush_buf(&mut t_xml, &mut buf);
     t_xml.push_str("</hp:t>");
     t_xml
+}
+
+/// Paragraph의 본문 run 콘텐츠를 `<hp:t>`와 인라인 컨트롤 XML로 직렬화한다.
+fn render_run_content(para: &Paragraph) -> String {
+    let slot_count = inferred_control_slot_count(para);
+    let slots: Vec<&Control> = if slot_count == para.controls.len() {
+        para.controls.iter().collect()
+    } else {
+        para.controls.iter()
+            .filter(|c| is_hwpx_inline_slot(c))
+            .collect()
+    };
+
+    if !slots.iter().any(|c| matches!(c, Control::Equation(_))) {
+        return render_hp_t_content(&para.text);
+    }
+
+    if slot_count != slots.len() {
+        let mut out = render_hp_t_content(&para.text);
+        for slot in slots {
+            render_control_slot(&mut out, slot);
+        }
+        return out;
+    }
+
+    let mut out = String::new();
+    let mut text_buf = String::new();
+    let mut slot_idx = 0usize;
+    let mut expected_utf16_pos = 0u32;
+
+    for (idx, c) in para.text.chars().enumerate() {
+        let char_pos = para
+            .char_offsets
+            .get(idx)
+            .copied()
+            .unwrap_or(expected_utf16_pos);
+        while slot_idx < slots.len()
+            && char_pos >= expected_utf16_pos.saturating_add(8)
+        {
+            flush_text_fragment(&mut out, &mut text_buf);
+            render_control_slot(&mut out, slots[slot_idx]);
+            slot_idx += 1;
+            expected_utf16_pos = expected_utf16_pos.saturating_add(8);
+        }
+
+        text_buf.push(c);
+        let width = char_utf16_width(c);
+        if char_pos >= expected_utf16_pos {
+            expected_utf16_pos = char_pos.saturating_add(width);
+        } else {
+            expected_utf16_pos = expected_utf16_pos.saturating_add(width);
+        }
+    }
+
+    flush_text_fragment(&mut out, &mut text_buf);
+    while slot_idx < slots.len() {
+        render_control_slot(&mut out, slots[slot_idx]);
+        slot_idx += 1;
+    }
+
+    if out.is_empty() {
+        render_hp_t_content("")
+    } else {
+        out
+    }
+}
+
+fn inferred_control_slot_count(para: &Paragraph) -> usize {
+    let text_units: u32 = para.text.chars().map(char_utf16_width).sum();
+    let from_char_count = para.char_count
+        .saturating_sub(1)
+        .saturating_sub(text_units)
+        / 8;
+
+    let mut from_offsets = 0u32;
+    let mut expected = 0u32;
+    for (idx, c) in para.text.chars().enumerate() {
+        let pos = para.char_offsets.get(idx).copied().unwrap_or(expected);
+        if pos > expected {
+            from_offsets += (pos - expected) / 8;
+        }
+        expected = pos.max(expected).saturating_add(char_utf16_width(c));
+    }
+
+    from_char_count.max(from_offsets) as usize
+}
+
+fn is_hwpx_inline_slot(control: &Control) -> bool {
+    matches!(
+        control,
+        Control::Table(_)
+            | Control::Shape(_)
+            | Control::Picture(_)
+            | Control::CharOverlap(_)
+            | Control::Ruby(_)
+            | Control::Equation(_)
+            | Control::Field(_)
+            | Control::Form(_)
+    )
+}
+
+fn flush_text_fragment(out: &mut String, text_buf: &mut String) {
+    if !text_buf.is_empty() {
+        out.push_str(&render_hp_t_content(text_buf));
+        text_buf.clear();
+    }
+}
+
+fn render_control_slot(out: &mut String, control: &Control) {
+    if let Control::Equation(eq) = control {
+        out.push_str(&render_equation(eq));
+    }
+}
+
+fn render_equation(eq: &Equation) -> String {
+    let c = &eq.common;
+    let id = c.instance_id.to_string();
+    let z_order = c.z_order.to_string();
+    let version = xml_escape(&eq.version_info);
+    let baseline = eq.baseline.to_string();
+    let text_color = color_ref_to_hwpx(eq.color);
+    let base_unit = eq.font_size.to_string();
+    let font = xml_escape(&eq.font_name);
+    let script = xml_escape(&eq.script);
+    let width = c.width.to_string();
+    let height = c.height.to_string();
+    let treat = if c.treat_as_char { "1" } else { "0" };
+    let vert_offset = c.vertical_offset.to_string();
+    let horz_offset = c.horizontal_offset.to_string();
+    let margin_left = c.margin.left.to_string();
+    let margin_right = c.margin.right.to_string();
+    let margin_top = c.margin.top.to_string();
+    let margin_bottom = c.margin.bottom.to_string();
+
+    format!(
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/></hp:equation>"#,
+        text_wrap_to_hwpx(c.text_wrap),
+        vert_rel_to_hwpx(c.vert_rel_to),
+        horz_rel_to_hwpx(c.horz_rel_to),
+        vert_align_to_hwpx(c.vert_align),
+        horz_align_to_hwpx(c.horz_align),
+    )
+}
+
+fn char_utf16_width(c: char) -> u32 {
+    if c == '\t' {
+        8
+    } else if (c as u32) > 0xFFFF {
+        2
+    } else {
+        1
+    }
+}
+
+fn color_ref_to_hwpx(color: u32) -> String {
+    if color == 0xFFFFFFFF {
+        return "none".to_string();
+    }
+
+    let r = color & 0xFF;
+    let g = (color >> 8) & 0xFF;
+    let b = (color >> 16) & 0xFF;
+    format!("#{r:02X}{g:02X}{b:02X}")
+}
+
+fn text_wrap_to_hwpx(wrap: TextWrap) -> &'static str {
+    match wrap {
+        TextWrap::Square => "SQUARE",
+        TextWrap::Tight => "TIGHT",
+        TextWrap::Through => "THROUGH",
+        TextWrap::TopAndBottom => "TOP_AND_BOTTOM",
+        TextWrap::BehindText => "BEHIND_TEXT",
+        TextWrap::InFrontOfText => "IN_FRONT_OF_TEXT",
+    }
+}
+
+fn vert_rel_to_hwpx(rel: VertRelTo) -> &'static str {
+    match rel {
+        VertRelTo::Paper => "PAPER",
+        VertRelTo::Page => "PAGE",
+        VertRelTo::Para => "PARA",
+    }
+}
+
+fn horz_rel_to_hwpx(rel: HorzRelTo) -> &'static str {
+    match rel {
+        HorzRelTo::Paper => "PAPER",
+        HorzRelTo::Page => "PAGE",
+        HorzRelTo::Column => "COLUMN",
+        HorzRelTo::Para => "PARA",
+    }
+}
+
+fn vert_align_to_hwpx(align: VertAlign) -> &'static str {
+    match align {
+        VertAlign::Top => "TOP",
+        VertAlign::Center => "CENTER",
+        VertAlign::Bottom => "BOTTOM",
+        VertAlign::Inside => "INSIDE",
+        VertAlign::Outside => "OUTSIDE",
+    }
+}
+
+fn horz_align_to_hwpx(align: HorzAlign) -> &'static str {
+    match align {
+        HorzAlign::Left => "LEFT",
+        HorzAlign::Center => "CENTER",
+        HorzAlign::Right => "RIGHT",
+        HorzAlign::Inside => "INSIDE",
+        HorzAlign::Outside => "OUTSIDE",
+    }
 }
 
 /// IR의 `line_segs` 를 그대로 XML로 직렬화 (6개 필드 전부 IR 값 사용).


### PR DESCRIPTION
## 요약

- HWPX section 직렬화에서 `Control::Equation`을 `<hp:equation>`으로 출력하도록 추가
- 수식 스크립트, 글꼴명, 글자 크기, 색상, 기준선, 기본 개체 크기·위치 속성이 `serialize_hwpx` 후 재파싱에서도 보존되도록 보강
- XML 엔티티가 포함된 수식 스크립트(`<`, `&` 등)를 HWPX 파서가 원문 의미대로 복원하도록 수정
- 수식 앞에 다른 컨트롤 슬롯이 있는 경우에도 수식 위치를 잘못 앞당기지 않도록 보수적으로 직렬화

## 배경

현재 HWP 바이너리 쪽은 `eqed` / `HWPTAG_EQEDIT` 기반 수식 파싱·직렬화 경로가 존재하고, HWPX 파서도 `<hp:equation>`과 `<hp:script>`를 `Control::Equation`으로 읽는다.

하지만 HWPX section 직렬화 경로(`src/serializer/hwpx/section.rs`)는 문단 본문을 `<hp:t>` 중심으로만 출력하고 있어, IR에 들어 있는 `Control::Equation`이 HWPX 저장 결과에 나타나지 않는다. 이 때문에 HWPX 저장/재파싱 과정에서 수식 컨트롤의 스크립트와 개체 속성이 소실될 수 있다.

## 근본 원인

`render_paragraph_parts()`가 문단 내용을 만들 때 기존에는 `render_hp_t_content(&para.text)`만 호출했다.

그 결과:

- `para.controls`에 `Control::Equation`이 있어도 `<hp:equation>` 요소를 출력하지 않음
- 수식이 문단 텍스트 사이에 있는 경우 제어 슬롯 위치를 HWPX XML에 반영할 방법이 없음
- `<hp:script>`에 XML 엔티티가 포함된 경우, 파서가 `Event::Text`만 처리하고 `Event::GeneralRef`를 무시해 `<`, `&` 같은 문자가 재파싱에서 소실됨

## 해결책

### 1. HWPX 수식 XML 출력

`src/serializer/hwpx/section.rs`에 수식 직렬화 경로를 추가했다.

`Control::Equation`을 다음 HWPX 구조로 출력한다.

```xml
<hp:equation ... version="..." baseLine="..." textColor="..." baseUnit="..." font="...">
  <hp:script>...</hp:script>
  <hp:sz .../>
  <hp:pos .../>
  <hp:outMargin .../>
</hp:equation>
```

보존 대상:

- `Equation.script`
- `Equation.font_size`
- `Equation.color`
- `Equation.baseline`
- `Equation.font_name`
- `Equation.version_info`
- `CommonObjAttr`의 기본 크기·위치·여백·정렬 속성

### 2. 문단 내 수식 위치 보존

문단의 UTF-16 위치 정보(`char_offsets`, `char_count`)를 이용해 수식 컨트롤을 텍스트 사이에 배치한다.

- 제어 슬롯 수와 컨트롤 수가 일치하는 HWP-origin 형태는 컨트롤 순서를 그대로 사용
- HWPX-origin 형태는 실제 inline slot을 만드는 컨트롤만 대상으로 사용
- `fieldEnd`처럼 텍스트 슬롯은 있으나 `Control` 엔트리가 없는 모호한 경우에는 수식을 잘못 앞당기지 않도록 텍스트 뒤에 보수적으로 출력

이 PR은 수식 출력만 추가하며, 표/그림/도형 등 다른 컨트롤의 HWPX 직렬화 범위는 확장하지 않는다.

### 3. 수식 스크립트 XML 엔티티 복원

`src/parser/hwpx/section.rs::parse_equation()`에서 `<hp:script>` 내부의 `Event::GeneralRef`를 처리하도록 보강했다.

지원 대상:

- `&lt;` → `<`
- `&gt;` → `>`
- `&amp;` → `&`
- `&quot;` → `"`
- `&apos;` → `'`
- 숫자 character reference

알 수 없는 entity는 원문 형태(`&name;`)로 보존한다.

## 검증

### 신규 회귀 테스트

`src/serializer/hwpx/mod.rs`에 수식 HWPX 직렬화 회귀 테스트 3건을 추가했다.

- `equation_control_roundtrip_preserves_script`
  - `<hp:equation>` 출력 확인
  - `x < y & z` 스크립트가 XML escape 후 재파싱에서 원문 의미로 복원되는지 확인
  - 글꼴, 크기, 색상, 기준선, 개체 크기·위치·여백·정렬 속성 보존 확인
- `equation_control_between_text_runs_roundtrips_position`
  - `ColumnDef`와 `Table` 컨트롤이 수식 앞에 있을 때 수식이 잘못 앞당겨지지 않는지 확인
- `equation_control_does_not_consume_unmapped_control_gap`
  - `fieldEnd`류처럼 슬롯은 있지만 대응 `Control`이 없는 모호한 gap에서 수식을 앞쪽 gap에 잘못 배치하지 않는지 확인

### 테스트 실행 결과

- `cargo test equation_control` 통과 (3 passed)
- `cargo test serializer::hwpx` 통과 (64 passed)
- `cargo test` 통과 (전체 테스트 exit 0)

기존 경고는 본 PR과 무관한 기존 경고다.

## 의도된 동작 변경

HWPX 저장 시 기존에는 수식 컨트롤이 section XML에 출력되지 않았지만, 이제 `Control::Equation`이 `<hp:equation>`으로 보존된다.

모호한 제어 슬롯이 있는 문단에서는 수식을 임의의 앞쪽 gap에 끼워 넣지 않고 텍스트 뒤에 보수적으로 출력한다. 이는 잘못된 위치 이동을 피하기 위한 안전한 동작이다.

## 변경 파일

| 파일 | 변경 |
| --- | --- |
| `src/serializer/hwpx/section.rs` | 문단 run 콘텐츠에 수식 컨트롤 출력 추가, 수식 XML 생성, 색상/정렬/위치 속성 매핑 |
| `src/parser/hwpx/section.rs` | `<hp:script>` 내부 XML entity / character reference 복원 |
| `src/serializer/hwpx/mod.rs` | HWPX 수식 직렬화·재파싱 회귀 테스트 추가 |

## Test plan

- [x] `cargo test equation_control`
- [x] `cargo test serializer::hwpx`
- [x] `cargo test`

## 메타

- **Base 브랜치**: `devel`
- **Head 브랜치**: `cskwork:feature/hwpx-equation-serialization`
- **관련 이슈**: #286
- **커밋**: `0bfa394` — `feat: HWPX 수식 직렬화 보존`