### PR TITLE
Add editor exportHwp API

### DIFF
--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -101,6 +101,22 @@ const count = await editor.pageCount();
 const svg = await editor.getPageSvg(0); // 첫 페이지
 ```
 
+### editor.exportHwp()
+
+현재 편집 중인 문서를 HWP 바이너리로 내보냅니다.
+
+```javascript
+const bytes = await editor.exportHwp();
+const blob = new Blob([bytes], { type: 'application/x-hwp' });
+
+const url = URL.createObjectURL(blob);
+const a = document.createElement('a');
+a.href = url;
+a.download = 'document.hwp';
+a.click();
+URL.revokeObjectURL(url);
+```
+
 ### editor.destroy()
 
 에디터를 제거합니다.

--- a/npm/editor/index.d.ts
+++ b/npm/editor/index.d.ts
@@ -22,6 +22,8 @@ export declare class RhwpEditor {
   pageCount(): Promise<number>;
   /** 특정 페이지를 SVG 문자열로 렌더링합니다 */
   getPageSvg(page?: number): Promise<string>;
+  /** 현재 문서를 HWP 바이너리로 내보냅니다 */
+  exportHwp(): Promise<Uint8Array>;
   /** iframe 엘리먼트를 반환합니다 */
   readonly element: HTMLIFrameElement;
   /** 에디터를 제거합니다 */

--- a/npm/editor/index.js
+++ b/npm/editor/index.js
@@ -158,6 +158,15 @@ class RhwpEditor {
   }
 
   /**
+   * 현재 문서를 HWP 바이너리로 내보냅니다.
+   * @returns {Promise<Uint8Array>} HWP 파일 bytes
+   */
+  async exportHwp() {
+    const result = await this._request('exportHwp');
+    return result instanceof Uint8Array ? result : new Uint8Array(result || []);
+  }
+
+  /**
    * iframe 엘리먼트를 반환합니다.
    */
   get element() {

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -648,6 +648,9 @@ window.addEventListener('message', async (e) => {
       case 'getPageSvg':
         reply(wasm.renderPageSvg(params.page ?? 0));
         break;
+      case 'exportHwp':
+        reply(Array.from(wasm.exportHwp()));
+        break;
       case 'ready':
         reply(true);
         break;


### PR DESCRIPTION
## 변경 요약

`@rhwp/core`에는 HWP 바이너리를 내보낼 수 있는 `exportHwp()` 기능이 있지만, iframe 기반 `@rhwp/editor` wrapper 에서는 편집 중인 문서 bytes를 직접 가져올 수 있는 공개 API가 없었습니다.

이 PR은 `rhwp-studio`의 `rhwp-request` message handler에 `exportHwp` 요청을 추가하고, `@rhwp/editor`에  `editor.exportHwp(): Promise<Uint8Array>` wrapper API를 추가합니다.

주요 변경 사항

  - `rhwp-studio`에서 `wasm.exportHwp()` 결과를 message response로 반환
  - `@rhwp/editor`의 `RhwpEditor.exportHwp()` 추가
  - TypeScript declaration에 `exportHwp()` 추가
  - `npm/editor/README.md`에 HWP bytes 다운로드 예제 추가

## 관련 이슈

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

참고: `rhwp-studio`의 `npm run build`는 현재 로컬 checkout에서 생성된 WASM alias 파일 `@wasm/rhwp.js`가 없어 실행이 중단되었습니다. 변경 범위는 JS/TS wrapper 및 message handler이며, Rust core는 수정하지 않았습니다.
