### PR TITLE
fix: 그룹 내 그림(Picture) 직렬화 구현

### DIFF
--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1017,7 +1017,7 @@ fn serialize_shape_control(shape: &ShapeObject, level: u16, ctrl_data_record: Op
                         ShapeObject::Polygon(_) => tags::SHAPE_POLYGON_ID,
                         ShapeObject::Curve(_) => tags::SHAPE_CURVE_ID,
                         ShapeObject::Group(_) => tags::CTRL_GEN_SHAPE,
-                        ShapeObject::Picture(_) => 0x24706963, // '$pic'
+                        ShapeObject::Picture(_) => tags::SHAPE_PICTURE_ID,
                         ShapeObject::Chart(c) => c.drawing.shape_attr.ctrl_id,
                         ShapeObject::Ole(o) => o.drawing.shape_attr.ctrl_id,
                     };
@@ -1273,8 +1273,19 @@ fn serialize_group_child(
                 serialize_group_child(nested_child, comp_level + 1, comp_level + 2, records);
             }
         }
-        ShapeObject::Picture(_pic) => {
-            // TODO: 그룹 내 그림 직렬화
+        ShapeObject::Picture(pic) => {
+            records.push(Record {
+                tag_id: tags::HWPTAG_SHAPE_COMPONENT,
+                level: comp_level,
+                size: 0,
+                data: serialize_shape_component(tags::SHAPE_PICTURE_ID, &pic.shape_attr, false),
+            });
+            records.push(Record {
+                tag_id: tags::HWPTAG_SHAPE_COMPONENT_PICTURE,
+                level: type_level,
+                size: 0,
+                data: serialize_picture_data(pic),
+            });
         }
         ShapeObject::Chart(chart) => {
             // Task #195 단계 2: 그룹 내 차트는 raw_chart_data로 라운드트립


### PR DESCRIPTION
## 요약

`serialize_group_child()`에서 `ShapeObject::Picture` 분기가 비어 있던 TODO를 구현합니다.

## 변경 내용

- 그룹 도형 내 중첩 그림 개체 직렬화: `SHAPE_COMPONENT` + `SHAPE_COMPONENT_PICTURE` 레코드 추가
- Chart/OLE 자식과 동일한 패턴 적용
- ctrl_id 매직넘버 `0x24706963` → `tags::SHAPE_PICTURE_ID` 상수 사용으로 가독성 개선

## 테스트

- `cargo test` 891+ 테스트 전체 통과
- `cargo clippy -- -D warnings` 경고 0

## 참고

그룹 내 그림이 포함된 HWP 파일을 열고 저장할 때 그림 데이터가 유실되는 문제를 해결합니다. 기존에는 `serialize_group_child`의 Picture 분기가 빈 구현이어서 저장 시 그룹 내 그림이 누락되었습니다.