### PR TITLE
fix: set_field 후 저장/재오픈 시 필드 값 유실 수정

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -707,8 +707,17 @@ fn rebuild_char_offsets(para: &mut Paragraph) {
     let ctrls_before_text = if !para.char_offsets.is_empty() {
         para.char_offsets[0] as usize / 8
     } else {
-        para.controls.len() // fallback: 모든 컨트롤이 텍스트 앞
+        para.controls.len()
     };
+
+    // FIELD_BEGIN: control_idx >= ctrls_before_text이고 start > 0인 필드의 시작 위치에 갭 필요
+    let mut field_begin_at: Vec<usize> = vec![0; text_len + 1];
+    for fr in &para.field_ranges {
+        if fr.control_idx >= ctrls_before_text && fr.start_char_idx > 0 {
+            let idx = fr.start_char_idx.min(text_len);
+            field_begin_at[idx] += 1;
+        }
+    }
 
     // FIELD_END 수: field_ranges에서 end가 텍스트 범위 내인 것
     let mut field_end_at: Vec<usize> = vec![0; text_len + 1];
@@ -721,12 +730,13 @@ fn rebuild_char_offsets(para: &mut Paragraph) {
     let mut new_offsets = Vec::with_capacity(text_len);
 
     for (i, ch) in text_chars.iter().enumerate() {
-        // 이 문자 앞에 FIELD_END 삽입
+        // 이 문자 앞에 FIELD_BEGIN 컨트롤 갭 삽입
+        offset += field_begin_at[i] as u32 * 8;
+        // 이 문자 앞에 FIELD_END 마커 갭 삽입
         offset += field_end_at[i] as u32 * 8;
 
         new_offsets.push(offset);
 
-        // 현재 문자의 크기
         let char_size = match *ch {
             '\t' => 8,
             '\n' | '\u{00A0}' => 1,
@@ -759,4 +769,98 @@ fn json_escape(s: &str) -> String {
     }
     result.push('"');
     result
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::control::{Control, Field, FieldType};
+    use crate::model::paragraph::{FieldRange, Paragraph};
+
+    fn make_field_control(ctrl_id: u32) -> Control {
+        Control::Field(Field {
+            field_type: FieldType::ClickHere,
+            command: String::new(),
+            properties: 0,
+            extra_properties: 0,
+            field_id: ctrl_id,
+            ctrl_id,
+            ctrl_data_name: None,
+            memo_index: 0,
+        })
+    }
+
+    #[test]
+    fn rebuild_preserves_mid_text_field_begin_gap() {
+        // Stream: [ColumnDef 8B] A(1) B(1) C(1) [FIELD_BEGIN 8B] X(1) Y(1) [FIELD_END 8B]
+        let mut para = Paragraph {
+            text: "ABCXY".into(),
+            controls: vec![
+                Control::ColumnDef(Default::default()),
+                make_field_control(100),
+            ],
+            field_ranges: vec![FieldRange {
+                start_char_idx: 3,
+                end_char_idx: 5,
+                control_idx: 1,
+            }],
+            char_offsets: vec![8, 9, 10, 19, 20],
+            ..Default::default()
+        };
+
+        rebuild_char_offsets(&mut para);
+
+        // A=8(+1) B=9(+1) C=10(+1) → gap 8 for FIELD_BEGIN → X=19(+1) Y=20
+        assert_eq!(para.char_offsets, vec![8, 9, 10, 19, 20]);
+    }
+
+    #[test]
+    fn rebuild_field_at_start_no_double_count() {
+        // FIELD_BEGIN is pre-text control (control_idx=0 < ctrls_before_text=1)
+        let mut para = Paragraph {
+            text: "XY".into(),
+            controls: vec![make_field_control(100)],
+            field_ranges: vec![FieldRange {
+                start_char_idx: 0,
+                end_char_idx: 2,
+                control_idx: 0,
+            }],
+            char_offsets: vec![8, 9],
+            ..Default::default()
+        };
+
+        rebuild_char_offsets(&mut para);
+
+        assert_eq!(para.char_offsets, vec![8, 9]);
+    }
+
+    #[test]
+    fn rebuild_after_set_field_creates_serializable_gap() {
+        // After set_field: "라벨: " [FIELD_BEGIN] "NEW" [FIELD_END]
+        let mut para = Paragraph {
+            text: "라벨: NEW".into(), // 7 chars: 라 벨 : ' ' N E W
+            controls: vec![
+                Control::ColumnDef(Default::default()),
+                make_field_control(200),
+            ],
+            field_ranges: vec![FieldRange {
+                start_char_idx: 4,
+                end_char_idx: 7,
+                control_idx: 1,
+            }],
+            // 원본 offsets (stale after text change, but char_offsets[0] still valid for ctrls_before_text)
+            char_offsets: vec![8, 9, 10, 11, 20, 21, 22],
+            ..Default::default()
+        };
+
+        rebuild_char_offsets(&mut para);
+
+        // ctrls_before_text = 8/8 = 1
+        // 라=8(+1) 벨=9(+1) :=10(+1) ' '=11(+1) → field_begin gap +8 → N=20(+1) E=21(+1) W=22
+        assert_eq!(para.char_offsets[0], 8);  // 라
+        assert_eq!(para.char_offsets[3], 11); // ' '
+        assert_eq!(para.char_offsets[4], 20); // N — 8-byte gap after ' ' for FIELD_BEGIN
+        let gap = para.char_offsets[4] as i64 - (para.char_offsets[3] as i64 + 1);
+        assert_eq!(gap, 8); // serializer needs exactly 8 code units for FIELD_BEGIN
+    }
 }


### PR DESCRIPTION
Closes #270

## 문제

`set_field("필드명", "값")` 후 `exportHwp()` → 재오픈하면 필드 값이 빈 문자열로 유실됩니다. In-memory에���는 정상 동작합니다.

## 근본 원인

`rebuild_char_offsets()`가 FIELD_END(0x04) 마커 갭만 생성하고 **FIELD_BEGIN(0x03) 컨트롤 갭을 누락**합니다.

중간 위치(start_char_idx > 0) 필드의 경우:
1. `rebuild_char_offsets`가 FIELD_BEGIN 위치에 8바이트 갭을 생성하지 않음
2. `serialize_para_text`가 갭이 없어 FIELD_BEGIN을 텍스트 뒤로 밀어냄
3. 재오픈 시 FIELD_BEGIN~FIELD_END 사이에 텍스트가 없으므로 빈 필드로 파싱

```
// 변경 ��� (잘못된 직렬화)
TEXT("라벨: PERSIST_TEST") | FIELD_BEGIN | FIELD_END | PARA_END

// 변경 후 (올바른 직렬화)
TEXT("라벨: ") | FIELD_BEGIN | TEXT("PERSIST_TEST") | FIELD_END | PARA_END
```

## 수정 내용

`field_begin_at` 배열을 추가하여 `start_char_idx` 위치에 8바이트 갭을 생성합니다. 이중 계산 방지를 위해 `control_idx >= ctrls_before_text && start_char_idx > 0` 조���으로 필터링합니다.

## 테스트

회귀 테스트 3건 추가:
- `rebuild_preserves_mid_text_field_begin_gap` — 중간 위치 필드 갭 보존
- `rebuild_field_at_start_no_double_count` — 문단 시작 필드 이중 계산 방지
- `rebuild_after_set_field_creates_serializable_gap` — set_field 후 직렬화 가능한 갭 생성

```bash
cargo test --lib field_query::tests  # 3 passed
cargo test                           # 1,120 passed, 0 failed
cargo clippy --lib -- -D warnings    # 0 warnings
```