### PR TITLE
feat: deleteParagraph WASM API 추가

### DIFF
--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -959,6 +959,73 @@ impl DocumentCore {
         Ok(super::super::helpers::json_ok_with(&format!("\"paraIdx\":{},\"charOffset\":{}", prev_idx, merge_point)))
     }
 
+    /// 문단 삭제 (네이티브 에러 타입)
+    pub fn delete_paragraph_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Result<String, HwpError> {
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!(
+                "구역 인덱스 {} 범위 초과 (총 {}개)", section_idx, self.document.sections.len()
+            )));
+        }
+        let section = &self.document.sections[section_idx];
+        if section.paragraphs.len() <= 1 {
+            return Err(HwpError::RenderError(
+                "구역의 마지막 문단은 삭제할 수 없습니다".to_string()
+            ));
+        }
+        if para_idx >= section.paragraphs.len() {
+            return Err(HwpError::RenderError(format!(
+                "문단 인덱스 {} 범위 초과 (총 {}개)", para_idx, section.paragraphs.len()
+            )));
+        }
+
+        let removed_char_count = self.document.sections[section_idx].paragraphs[para_idx]
+            .text.chars().count();
+        self.document.sections[section_idx].raw_stream = None;
+        self.document.sections[section_idx].paragraphs.remove(para_idx);
+
+        let reflow_idx = if para_idx > 0 { para_idx - 1 } else { 0 };
+        let old_col = self.para_column_map.get(section_idx)
+            .and_then(|m| m.get(reflow_idx)).copied().unwrap_or(0);
+        self.remove_composed_paragraph(section_idx, para_idx);
+        if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
+            self.reflow_paragraph(section_idx, reflow_idx);
+        }
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs, reflow_idx,
+        );
+        if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
+            self.recompose_paragraph(section_idx, reflow_idx);
+        }
+        self.paginate_if_needed();
+
+        for _ in 0..2 {
+            let new_col = self.para_column_map.get(section_idx)
+                .and_then(|m| m.get(reflow_idx)).copied().unwrap_or(0);
+            if new_col == old_col { break; }
+            if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
+                self.reflow_paragraph(section_idx, reflow_idx);
+            }
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs, reflow_idx,
+            );
+            if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
+                self.recompose_paragraph(section_idx, reflow_idx);
+            }
+            self.paginate_if_needed();
+        }
+
+        let new_count = self.document.sections[section_idx].paragraphs.len();
+        self.event_log.push(DocumentEvent::ParagraphDeleted { section: section_idx, para: para_idx });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"removedCharCount\":{},\"newParagraphCount\":{}",
+            removed_char_count, new_count
+        )))
+    }
+
     /// 셀 내부 문단 분할 (네이티브 에러 타입)
     pub fn split_paragraph_in_cell_native(
         &mut self,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -971,19 +971,20 @@ impl DocumentCore {
             )));
         }
         let section = &self.document.sections[section_idx];
-        if section.paragraphs.len() <= 1 {
-            return Err(HwpError::RenderError(
-                "구역의 마지막 문단은 삭제할 수 없습니다".to_string()
-            ));
-        }
         if para_idx >= section.paragraphs.len() {
             return Err(HwpError::RenderError(format!(
                 "문단 인덱스 {} 범위 초과 (총 {}개)", para_idx, section.paragraphs.len()
             )));
         }
+        if section.paragraphs.len() <= 1 {
+            return Err(HwpError::RenderError(
+                "구역의 마지막 문단은 삭제할 수 없습니다".to_string()
+            ));
+        }
 
-        let removed_char_count = self.document.sections[section_idx].paragraphs[para_idx]
-            .text.chars().count();
+        let removed_char_count = super::super::helpers::logical_paragraph_length(
+            &self.document.sections[section_idx].paragraphs[para_idx],
+        );
         self.document.sections[section_idx].raw_stream = None;
         self.document.sections[section_idx].paragraphs.remove(para_idx);
 

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -11,6 +11,7 @@ pub enum DocumentEvent {
     TextDeleted { section: usize, para: usize, offset: usize, count: usize },
     ParagraphSplit { section: usize, para: usize, offset: usize },
     ParagraphMerged { section: usize, para: usize },
+    ParagraphDeleted { section: usize, para: usize },
 
     // ── 서식 변경 ──
     CharFormatChanged { section: usize, para: usize, start: usize, end: usize },
@@ -49,6 +50,8 @@ impl DocumentEvent {
                 format!(r#"{{"type":"ParagraphSplit","section":{},"para":{},"offset":{}}}"#, section, para, offset),
             DocumentEvent::ParagraphMerged { section, para } =>
                 format!(r#"{{"type":"ParagraphMerged","section":{},"para":{}}}"#, section, para),
+            DocumentEvent::ParagraphDeleted { section, para } =>
+                format!(r#"{{"type":"ParagraphDeleted","section":{},"para":{}}}"#, section, para),
 
             // 서식 변경
             DocumentEvent::CharFormatChanged { section, para, start, end } =>

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -119,6 +119,15 @@ mod tests {
     }
 
     #[test]
+    fn test_paragraph_deleted_to_json() {
+        let event = DocumentEvent::ParagraphDeleted { section: 1, para: 3 };
+        let json = event.to_json();
+        assert!(json.contains(r#""type":"ParagraphDeleted""#));
+        assert!(json.contains(r#""section":1"#));
+        assert!(json.contains(r#""para":3"#));
+    }
+
+    #[test]
     fn test_serialize_event_log_empty() {
         let result = serialize_event_log(&[]);
         assert_eq!(result, r#"{"ok":true,"events":[]}"#);

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1088,6 +1088,12 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = deleteParagraph)]
+    pub fn delete_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue> {
+        self.delete_paragraph_native(section_idx as usize, para_idx as usize)
+            .map_err(|e| e.into())
+    }
+
     // ─── Phase 1: 기본 편집 보조 API ───────────────────────────
 
     /// 구역(Section) 수를 반환한다.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1088,6 +1088,10 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 지정한 문단을 구역에서 구조적으로 삭제한다.
+    ///
+    /// 구역에 문단이 1개만 남아있으면 삭제할 수 없다.
+    /// 반환값: JSON `{"ok":true,"removedCharCount":<n>,"newParagraphCount":<n>}`
     #[wasm_bindgen(js_name = deleteParagraph)]
     pub fn delete_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue> {
         self.delete_paragraph_native(section_idx as usize, para_idx as usize)


### PR DESCRIPTION
Closes #271

## 문제

문단 구조 자체를 삭제하는 WASM API가 없습니다. `replaceAll(text, "")` 폴백으로 텍스트만 비울 수 있을 뿐, 빈 문단 구조가 남아 문서가 점점 공허해집니다.

## 변경 사항

`deleteParagraph(section, paraIdx)` API를 추가합니다.

### API

```ts
doc.deleteParagraph(section: number, paraIdx: number)
// → { ok: true, removedCharCount: number, newParagraphCount: number }
```

### 내부 구현

- `delete_paragraph_native` (`text_editing.rs`): `merge_paragraph_native`와 동일한 패턴
  1. 범위 검사 (구역 인덱스, 문단 인덱스, 마지막 문단 방지)
  2. `raw_stream` 무효화
  3. `paragraphs.remove(para_idx)`
  4. 인접 문단 리플로우 → vpos 재계산 → 재구성 → 재페이지네이션 + 다단 수렴
- `ParagraphDeleted` 이벤트 (`event.rs`)
- `deleteParagraph` WASM 바인딩 (`wasm_api.rs`)

### 범위 검사

- 구역 마지막 문단 삭제 시 에러 반환 (HWP 규약: 구역당 최소 1 문단)

## 검증

```bash
cargo test    # 1,117 passed, 0 failed
cargo clippy --lib -- -D warnings  # 0 warnings
```