### PR TITLE
feat: insertParagraph WASM API 추가

### DIFF
--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -959,6 +959,61 @@ impl DocumentCore {
         Ok(super::super::helpers::json_ok_with(&format!("\"paraIdx\":{},\"charOffset\":{}", prev_idx, merge_point)))
     }
 
+    /// 빈 문단 삽입 (네이티브 에러 타입)
+    ///
+    /// `para_idx == paragraphs.len()` 이면 구역 끝에 추가(append).
+    pub fn insert_paragraph_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+    ) -> Result<String, HwpError> {
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!(
+                "구역 인덱스 {} 범위 초과 (총 {}개)", section_idx, self.document.sections.len()
+            )));
+        }
+        let para_count = self.document.sections[section_idx].paragraphs.len();
+        if para_idx > para_count {
+            return Err(HwpError::RenderError(format!(
+                "문단 인덱스 {} 범위 초과 (총 {}개, 최대 {})", para_idx, para_count, para_count
+            )));
+        }
+
+        self.document.sections[section_idx].raw_stream = None;
+
+        let new_para = Paragraph::new_empty();
+        self.document.sections[section_idx].paragraphs.insert(para_idx, new_para);
+
+        let reflow_target = if para_idx > 0 { para_idx - 1 } else { para_idx };
+        let old_col = self.para_column_map.get(section_idx)
+            .and_then(|m| m.get(reflow_target)).copied().unwrap_or(0);
+        self.reflow_paragraph(section_idx, para_idx);
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs, reflow_target,
+        );
+        self.insert_composed_paragraph(section_idx, para_idx);
+        self.paginate_if_needed();
+
+        for _ in 0..2 {
+            let new_col = self.para_column_map.get(section_idx)
+                .and_then(|m| m.get(reflow_target)).copied().unwrap_or(0);
+            if new_col == old_col { break; }
+            self.reflow_paragraph(section_idx, para_idx);
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs, reflow_target,
+            );
+            self.recompose_paragraph(section_idx, para_idx);
+            self.paginate_if_needed();
+        }
+
+        let new_count = self.document.sections[section_idx].paragraphs.len();
+        self.event_log.push(DocumentEvent::ParagraphInserted { section: section_idx, para: para_idx });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"paraIdx\":{},\"newParagraphCount\":{}",
+            para_idx, new_count
+        )))
+    }
+
     /// 셀 내부 문단 분할 (네이티브 에러 타입)
     pub fn split_paragraph_in_cell_native(
         &mut self,

--- a/src/model/event.rs
+++ b/src/model/event.rs
@@ -11,6 +11,7 @@ pub enum DocumentEvent {
     TextDeleted { section: usize, para: usize, offset: usize, count: usize },
     ParagraphSplit { section: usize, para: usize, offset: usize },
     ParagraphMerged { section: usize, para: usize },
+    ParagraphInserted { section: usize, para: usize },
 
     // ── 서식 변경 ──
     CharFormatChanged { section: usize, para: usize, start: usize, end: usize },
@@ -49,6 +50,8 @@ impl DocumentEvent {
                 format!(r#"{{"type":"ParagraphSplit","section":{},"para":{},"offset":{}}}"#, section, para, offset),
             DocumentEvent::ParagraphMerged { section, para } =>
                 format!(r#"{{"type":"ParagraphMerged","section":{},"para":{}}}"#, section, para),
+            DocumentEvent::ParagraphInserted { section, para } =>
+                format!(r#"{{"type":"ParagraphInserted","section":{},"para":{}}}"#, section, para),
 
             // 서식 변경
             DocumentEvent::CharFormatChanged { section, para, start, end } =>

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1088,6 +1088,12 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = insertParagraph)]
+    pub fn insert_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue> {
+        self.insert_paragraph_native(section_idx as usize, para_idx as usize)
+            .map_err(|e| e.into())
+    }
+
     // ─── Phase 1: 기본 편집 보조 API ───────────────────────────
 
     /// 구역(Section) 수를 반환한다.


### PR DESCRIPTION
Closes #269

## 문제

구역 끝에 새 문단을 추가(append)하는 WASM API가 없습니다. `splitParagraph`는 기존 문단을 분리할 뿐이라, `paraIdx == paragraphCount`를 "범위 초과"로 거부합니다.

다운스트림(MCP/CLI/Swift)에서는 "insert before last"로 degrade하여 문단 순서가 뒤바뀌는 문제가 발생합니다.

## 변경 사항

`insertParagraph(section, paraIdx)` API를 추가합니다.

### API

```ts
doc.insertParagraph(section: number, paraIdx: number)
// → { ok: true, paraIdx: number, newParagraphCount: number }
```

- `paraIdx` 범위: `0..=paragraphCount(section)`
- `paraIdx == paragraphCount` 이면 구역 끝에 append
- `Paragraph::new_empty()` 기반 (HWP 기본 LineSeg 포함)

### 내부 구현

- `insert_paragraph_native` (`text_editing.rs`): `split_paragraph_native`와 동일한 리플로우/재구성/재페이지네이션 패턴
- `ParagraphInserted` 이벤트 (`event.rs`)
- `insertParagraph` WASM 바인딩 (`wasm_api.rs`)

### `splitParagraph`와의 차이

| | `splitParagraph` | `insertParagraph` |
|--|---|---|
| 입력 | 기존 문단 + char offset | 삽입 위치 (0..=count) |
| 결과 | 기존 문단 분리 | 새 빈 문단 추가 |
| append | 불가 | `paraIdx == count`로 가능 |

## 검증

```bash
cargo test    # 1,117 passed, 0 failed
cargo clippy --lib -- -D warnings  # 0 warnings
```