### PR TITLE
[api] Paragraph::utf16_pos_to_char_idx 추가 (옵션 A, #484)

### DIFF
--- a/mydocs/plans/task_m100_484.md
+++ b/mydocs/plans/task_m100_484.md
@@ -1,0 +1,50 @@
+# Task #484: `utf16_pos_to_char_idx` 외부 crate 노출 — 수행 계획서
+
+## 수행 목표
+
+`document_core::helpers::utf16_pos_to_char_idx(char_offsets: &[u32], utf16_pos: u32) -> usize` 의 contract 를 외부 Rust crate (PyO3 / napi / JNI 등 third-party binding 레이어) 에서 호출 가능하도록 안정적으로 노출한다.
+
+## 배경
+
+- 이슈 #484 — 외부 binding (`rhwp-python`) 의 IR / RAG character run 정규화 hot path 에서 `char_shape.start_pos` (UTF-16 단위) 를 codepoint 인덱스로 변환할 helper 필요
+- 함수는 `v0.5.0` initial commit 부터 helpers 모듈에 존재해 온 helper 로 prod 사용 중 (`cursor_nav.rs:8, 112, 159` / `clipboard.rs:11, 845` 의 import + 호출 5 회) — contract 안정
+- `src/document_core/mod.rs:6` 의 `pub(crate) mod helpers;` 가시성 때문에 외부 crate 에서 접근 불가
+- 외부 자체 알고리즘 복사는 boundary fallback (`unwrap_or(...)` 의 의미) 미묘한 차이로 silent drift 위험. helper 의 fallback 은 `char_offsets.len()` 인데 inline 5 군데는 호출자 컨텍스트별로 `text_len` / `text_end` / `0` / `inserted_chars` 로 상이
+
+## 접근 결정
+
+이슈 본문에서 두 옵션 제시:
+- **옵션 A** — `Paragraph::utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize` 인스턴스 메서드 캡슐화
+- **옵션 B** — `helpers::utf16_pos_to_char_idx` 함수 자체 `pub` 승격
+
+**옵션 A 선택 사유**:
+- Task #390 / PR #405 의 `Paragraph::control_text_positions()` 와 같은 결 — helpers 모듈에 갇힌 helper 의 외부 노출
+- 외부 API surface 를 좁게 — `Paragraph` 메서드 한 개만 노출
+- 의미 응집 — `Paragraph` 가 `char_offsets` 를 자체 필드로 보유하므로 `&self` 메서드가 자연
+- 옵션 B 채택 시 helpers 의 다른 비공개 함수 (`logical_to_text_offset`, `navigable_text_len` 등) 까지 외부 진화 부담
+
+## 의존성 고려
+
+`model` ← `parser` ← `document_core` 단방향 의존 구조. 옵션 A 채택 시 두 가지 변형이 가능:
+
+- **변형 A1 (PR #405 패턴)** — 본체를 `impl Paragraph` 로 이동 + helpers free function 을 thin wrapper 로 위임
+- **변형 A2** — `impl Paragraph` 에 메서드 본체 자체 보유 + helpers free function 변경 없음
+
+PR #405 의 `find_control_text_positions(para: &Paragraph) -> Vec<usize>` 는 시그니처가 이미 `&Paragraph` 라 wrapper 가 자연 (`para.control_text_positions()` 한 줄로 위임). 본 helper 는 `(char_offsets: &[u32], utf16_pos: u32)` — `Paragraph` 인스턴스 없이 raw slice 받으므로 wrapper 변환을 위해선 시그니처 변경 + caller 5+ 라인 수정 필요. **변형 A2 채택** — 본 PR scope 를 외부 노출에 한정, caller 정리는 별도 후속 PR.
+
+**SSOT 우려**: 변형 A2 는 본체가 두 곳 (helpers free function + Paragraph 메서드) 에 존재한다. 알고리즘이 1줄 (`iter().position(...).unwrap_or(...)`) 짜리 trivial scan 이라 silent drift 위험은 무시 가능. 문서화로 사유 명시 (Paragraph 메서드의 docstring 안에 helpers 와의 관계 기술).
+
+## 범위
+
+- `src/model/paragraph.rs` — `pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize` 추가 (`control_text_positions` 메서드 다음)
+- `src/model/paragraph/tests.rs` — 단위 테스트 6건 추가 (boundary 검증)
+- `src/document_core/helpers.rs` — 변경 없음 (기존 caller 호환 유지)
+- 알고리즘 / 동작 변경 없음 — semver MINOR
+
+## 비범위
+
+- helpers 의 `utf16_pos_to_char_idx` free function 시그니처 / 가시성 변경 (caller 5+ 라인 변경 강제 — 별도 cleanup PR 으로 분리 가능)
+- `cursor_rect.rs:8` 의 dead import 제거 (옵션 A 와 무관한 cleanup — 별도 PR)
+- 다른 helpers 내부 함수 (`logical_to_text_offset`, `navigable_text_len` 등) 노출 없음
+- 본 PR base (`upstream/devel`) 의 기존 lint / fmt warning 정정 (우리 변경 무관, 별도)
+- `Paragraph::utf16_pos_to_char_idx` 의 caller 점진 전환 (cursor_nav, clipboard 가 helpers free function 대신 메서드 직접 호출하도록) — 별도 PR

--- a/mydocs/plans/task_m100_484_impl.md
+++ b/mydocs/plans/task_m100_484_impl.md
@@ -1,0 +1,64 @@
+# Task #484: 구현 계획서
+
+## 1단계: `Paragraph::utf16_pos_to_char_idx` 메서드 신설
+
+### 목표
+
+`src/model/paragraph.rs` 의 `impl Paragraph` 블록에 UTF-16 단위 위치를 codepoint 인덱스로 정규화하는 인스턴스 메서드를 추가한다.
+
+### 작업 내용
+
+1. `impl Paragraph` 블록 내 `control_text_positions` (PR #390 으로 추가, line 802 닫는 brace) 다음에 메서드 삽입
+2. 시그니처: `pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize`
+3. 본체: `self.char_offsets.iter().position(|&off| off >= utf16_pos).unwrap_or(self.char_offsets.len())` — helpers 의 free function 과 동일 알고리즘
+4. docstring — 사용 의도 (`char_shapes[i].start_pos` / `line_segs[i].text_start` 정규화), 알고리즘 본체 자체 보유 사유 (시그니처 호환성), `# Returns` 섹션
+
+### 산출물
+
+- `cargo build --tests` 성공
+- 새로운 외부 가시 메서드 `Paragraph::utf16_pos_to_char_idx` 노출
+
+## 2단계: 단위 테스트 추가
+
+### 목표
+
+`src/model/paragraph/tests.rs` 에 `Paragraph::utf16_pos_to_char_idx` 의 boundary 케이스를 검증하는 테스트 6건을 추가한다.
+
+### 작업 내용
+
+1. `test_utf16_pos_to_char_idx_empty_offsets` — `char_offsets.is_empty()` → `unwrap_or(0)` 분기
+2. `test_utf16_pos_to_char_idx_zero_returns_first` — `utf16_pos = 0`, `offsets[0] = 0 >= 0` → 인덱스 0
+3. `test_utf16_pos_to_char_idx_exact_match` — `offsets` 안의 정확한 값일 때 해당 인덱스
+4. `test_utf16_pos_to_char_idx_between_offsets` — `offsets` 사이 값일 때 첫 entry >= 인덱스 (SMP `🎉` 가 들어간 `[0, 1, 3]` 케이스)
+5. `test_utf16_pos_to_char_idx_beyond_end_returns_len` — `utf16_pos > 모든 entry` → `char_offsets.len()` fallback
+6. `test_utf16_pos_to_char_idx_surrogate_pair_midpoint` — surrogate pair 의 low half 위치를 다음 codepoint 시작 위치로 정규화 (`"🎉A"`, offsets `[0, 2]`)
+
+### 산출물
+
+- `cargo test --lib model::paragraph::tests` 통과 (PR #390 6건 + 본 PR 6건 = 신규 12건 누적, 회귀 39건 + 신규 6건 = 45건 통과)
+
+## 3단계: 품질 검증
+
+### 작업 내용
+
+```bash
+cargo fmt -- --check src/model/paragraph.rs src/model/paragraph/tests.rs    # 변경 파일만
+cargo test --lib    # 회귀 + 신규
+cargo clippy --all-targets 2>&1 | grep "src/model/paragraph"    # 우리 변경 파일만
+```
+
+### 통과 기준
+
+- 변경 파일 (`src/model/paragraph.rs`, `src/model/paragraph/tests.rs`) rustfmt / clippy 깨끗
+- 신규 6건 테스트 모두 통과 + 회귀 통과
+- base branch (`upstream/devel`) 의 기존 lint / fmt warning (총 43건, `emf/tests.rs` / `serializer/hwpx/field.rs` / `wasm_api/tests.rs`) 은 별도 — 우리 변경 무관
+
+## 변경 파일 요약
+
+| 파일 | 변경 형태 | 라인 수 (대략) |
+|---|---|---|
+| `src/model/paragraph.rs` | 새 메서드 추가 (`impl Paragraph` 내) | +24 |
+| `src/model/paragraph/tests.rs` | 신규 단위 테스트 6건 | +75 |
+| `src/document_core/helpers.rs` | 변경 없음 | 0 |
+
+순 알고리즘 라인 수 변동: +1 (1줄짜리 알고리즘이 model 메서드로 추가, helpers free function 그대로). 코드 중복은 1줄 — silent drift 위험 trivial.

--- a/mydocs/report/task_m100_484_report.md
+++ b/mydocs/report/task_m100_484_report.md
@@ -1,0 +1,55 @@
+# Task #484: 최종 결과보고서
+
+## 완료 사항
+
+이슈 #484 — `utf16_pos_to_char_idx` 외부 crate 노출. 옵션 A (`Paragraph::utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize` 인스턴스 메서드 캡슐화) 로 구현 완료.
+
+## 변경 내역
+
+### 코드
+
+- `src/model/paragraph.rs` — `pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize` 추가 (impl Paragraph 블록 내, `control_text_positions` 다음). 본체 1 줄 (`self.char_offsets.iter().position(|&off| off >= utf16_pos).unwrap_or(self.char_offsets.len())`) 자체 보유.
+- `src/document_core/helpers.rs` — 변경 없음. free function 시그니처 (`(char_offsets: &[u32], utf16_pos: u32)`) 가 `Paragraph` 인스턴스를 받지 않아 PR #405 패턴 (본체 이동 + thin wrapper) 적용 불가. caller (cursor_nav, clipboard 5+ 라인) 변경 회피로 본 PR scope 외.
+
+### 테스트
+
+- `src/model/paragraph/tests.rs` — 신규 단위 테스트 6 건:
+  - `test_utf16_pos_to_char_idx_empty_offsets` — `char_offsets.is_empty()` → `unwrap_or(0)` 분기
+  - `test_utf16_pos_to_char_idx_zero_returns_first` — `utf16_pos = 0` → 첫 entry 인덱스
+  - `test_utf16_pos_to_char_idx_exact_match` — offsets 정확값 매칭
+  - `test_utf16_pos_to_char_idx_between_offsets` — offsets 사이 값 (SMP `"A🎉"`, offsets `[0, 1, 3]`)
+  - `test_utf16_pos_to_char_idx_beyond_end_returns_len` — `utf16_pos > 모든 entry` → `char_offsets.len()` fallback
+  - `test_utf16_pos_to_char_idx_surrogate_pair_midpoint` — surrogate pair low half 위치를 다음 codepoint 시작 위치로 정규화
+
+### 문서 (`mydocs/`)
+
+- `plans/task_m100_484.md` — 수행 계획서 (배경, 옵션 결정, 의존성 고려, 범위/비범위)
+- `plans/task_m100_484_impl.md` — 구현 계획서 (3 단계)
+- `report/task_m100_484_report.md` — 본 문서
+
+## 검증 결과
+
+| 검증 항목 | 결과 |
+|---|---|
+| `cargo build --tests` | 성공 |
+| `cargo clippy --all-targets` (변경 파일 한정) | warning 0 건 |
+| `cargo test --lib` | 1081 passed / 0 failed / 1 ignored (baseline `upstream/devel @ 109bb04` = 1075, +6 신규 테스트로 일치) |
+| `Paragraph::utf16_pos_to_char_idx` 신규 단위 테스트 | 6 / 6 통과 |
+| helpers 의 기존 caller (cursor_nav, clipboard) 회귀 | 없음 (helpers free function 미변경) |
+
+## 동작 보장
+
+- helpers 의 `utf16_pos_to_char_idx` free function 알고리즘과 동치 (`iter().position(...).unwrap_or(...)` 1줄)
+- 외부 가시성: 새 `pub fn Paragraph::utf16_pos_to_char_idx` 만 추가. helpers / free function 가시성 변경 없음 (`pub(crate)` 유지)
+- semver: MINOR (신규 public API 추가, 기존 contract 보존)
+
+## 검증 범위
+
+- 변경 파일 한정 rustfmt / clippy 통과
+- 저장소 전체 fmt / clippy 는 본 PR 범위 외 — base branch `upstream/devel @ 109bb04` 의 기존 lint warning 43 건 (`emf/tests.rs`, `serializer/hwpx/field.rs`, `wasm_api/tests.rs`) 별도 cleanup 필요
+
+## 다음 단계
+
+- 메인테이너 리뷰 후 PR 머지 (대상 브랜치: `devel`)
+- PR 본문에 `closes #484` 명시
+- 머지 후 외부 binding (`rhwp-python` 등) 에서 `Paragraph::utf16_pos_to_char_idx()` 직접 호출 가능 → 외부의 자체 알고리즘 복사 (`utf16_to_cp` 등) 제거 가능

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -800,6 +800,28 @@ impl Paragraph {
         positions
     }
 
+    /// `char_offsets` 중 UTF-16 위치 `utf16_pos` 이상인 첫 번째 codepoint 의
+    /// 인덱스를 반환한다. 모든 entry 가 작으면 `char_offsets.len()` (텍스트 끝).
+    ///
+    /// `char_shapes[i].start_pos` 와 `line_segs[i].text_start` 같은 UTF-16
+    /// 단위 위치 필드를 codepoint 인덱스로 정규화할 때 사용한다.
+    ///
+    /// 본 메서드는 `document_core::helpers::utf16_pos_to_char_idx` 와 동일
+    /// 알고리즘이나, 시그니처 호환성 (raw `&[u32]` vs `&self`) 때문에 본체를
+    /// 자체 보유한다 — 의존성 방향 (model ← document_core) 보존. 알고리즘이
+    /// 1줄 (`iter().position`) 이라 silent drift 위험은 무시 가능.
+    ///
+    /// # Returns
+    ///
+    /// `char_offsets` 첫 entry 가 `utf16_pos` 이상인 인덱스. 모든 entry 가
+    /// 작으면 `char_offsets.len()`.
+    pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize {
+        self.char_offsets
+            .iter()
+            .position(|&off| off >= utf16_pos)
+            .unwrap_or(self.char_offsets.len())
+    }
+
     /// [start_char_offset, end_char_offset) 범위에 new_char_shape_id를 적용한다.
     ///
     /// CharShapeRef 배열을 분할/교체하여 지정 범위만 새 ID로 변경한다.

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -775,3 +775,75 @@ fn test_control_text_positions_no_offsets_non_inline_skipped() {
     };
     assert_eq!(para.control_text_positions(), vec![0, 0, 1]);
 }
+
+#[test]
+fn test_utf16_pos_to_char_idx_empty_offsets() {
+    // char_offsets 가 비어있으면 unwrap_or(char_offsets.len()) = 0 반환.
+    let para = Paragraph::default();
+    assert_eq!(para.utf16_pos_to_char_idx(0), 0);
+    assert_eq!(para.utf16_pos_to_char_idx(100), 0);
+}
+
+#[test]
+fn test_utf16_pos_to_char_idx_zero_returns_first() {
+    // utf16_pos = 0 → 첫 entry (offsets[0] = 0 >= 0) 의 인덱스 0.
+    let para = Paragraph {
+        text: "ABC".to_string(),
+        char_offsets: vec![0, 1, 2],
+        ..Default::default()
+    };
+    assert_eq!(para.utf16_pos_to_char_idx(0), 0);
+}
+
+#[test]
+fn test_utf16_pos_to_char_idx_exact_match() {
+    // offsets 안의 정확한 값일 때 해당 인덱스 반환.
+    let para = Paragraph {
+        text: "ABC".to_string(),
+        char_offsets: vec![0, 1, 2],
+        ..Default::default()
+    };
+    assert_eq!(para.utf16_pos_to_char_idx(1), 1);
+    assert_eq!(para.utf16_pos_to_char_idx(2), 2);
+}
+
+#[test]
+fn test_utf16_pos_to_char_idx_between_offsets() {
+    // offsets 사이 값일 때 첫 entry >= utf16_pos 인 인덱스 반환.
+    // offsets = [0, 1, 3] (2번째 codepoint 는 SMP) → utf16_pos=2 는 첫
+    // entry >=2 인 3 의 인덱스 2.
+    let para = Paragraph {
+        text: "A🎉".to_string(),
+        char_offsets: vec![0, 1, 3],
+        ..Default::default()
+    };
+    assert_eq!(para.utf16_pos_to_char_idx(2), 2);
+}
+
+#[test]
+fn test_utf16_pos_to_char_idx_beyond_end_returns_len() {
+    // utf16_pos 가 모든 entry 보다 크면 char_offsets.len() (텍스트 끝).
+    let para = Paragraph {
+        text: "ABC".to_string(),
+        char_offsets: vec![0, 1, 2],
+        ..Default::default()
+    };
+    assert_eq!(para.utf16_pos_to_char_idx(3), 3);
+    assert_eq!(para.utf16_pos_to_char_idx(100), 3);
+}
+
+#[test]
+fn test_utf16_pos_to_char_idx_surrogate_pair_midpoint() {
+    // text = "🎉A" → offsets = [0, 2] (🎉 가 UTF-16 width=2). utf16_pos=1
+    // (surrogate pair 의 low half) 도 첫 entry >=1 인 2 의 인덱스 1 반환 —
+    // 다음 codepoint 시작 위치로 정규화.
+    let para = Paragraph {
+        text: "🎉A".to_string(),
+        char_offsets: vec![0, 2],
+        ..Default::default()
+    };
+    assert_eq!(para.utf16_pos_to_char_idx(0), 0);
+    assert_eq!(para.utf16_pos_to_char_idx(1), 1);
+    assert_eq!(para.utf16_pos_to_char_idx(2), 1);
+    assert_eq!(para.utf16_pos_to_char_idx(3), 2); // beyond end
+}


### PR DESCRIPTION
## 변경 요약

이슈 #484 옵션 A 채택. `helpers::utf16_pos_to_char_idx` 와 동일 알고리즘을 `Paragraph::utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize` 인스턴스 메서드로 추가하여 외부 crate (third-party PyO3 / napi / JNI 등 binding) 에서 호출 가능하게 합니다.

PR #405 (`Paragraph::control_text_positions`) 와 같은 결의 외부 노출입니다. 다만 본 helper 는 free function 시그니처 (`char_offsets: &[u32], utf16_pos: u32`) 가 `Paragraph` 인스턴스를 받지 않아 본체 이동 + thin wrapper 패턴 적용 불가 — `helpers::utf16_pos_to_char_idx` 는 변경 없이 그대로 두고 (caller 5+ 라인 호환 유지), 메서드 본체만 자체 보유합니다. 알고리즘이 1줄 (`iter().position(...).unwrap_or(...)`) 짜리라 코드 중복으로 인한 silent drift 위험은 무시 가능합니다.

## 관련 이슈

closes #484

## 테스트

- [x] `cargo test --lib` 1081 passed / 0 failed / 1 ignored (baseline upstream/devel @ 109bb04 = 1075, +6 신규)
- [x] `cargo clippy --all-targets` 변경 파일 (`paragraph.rs`, `paragraph/tests.rs`) warning 0
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 (해당 없음 — model 메서드 추가만, 렌더링 / 출력 변경 없음)
- [ ] 웹(WASM) 렌더링 확인 (해당 없음 — WASM API 변경 없음)

## 스크린샷

해당 없음 (API 노출, 시각적 변경 없음).
