### PR TITLE
Task #530: TAC Top caption 표 머리행 겹침 정정

### DIFF
--- a/mydocs/orders/20260502.md
+++ b/mydocs/orders/20260502.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| **M100 #530** | treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정 | **진행중** | Stage 3 완료보고 승인 대기 |
+| **M100 #530** | treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정 | **진행중** | Stage 4 완료보고 승인 대기 |
 | **M100 #509** | PUA (Private Use Area) 글머리표 글리프 회귀 — KTX/synam-001/kps-ai 등 14 샘플의 글머리표가 ☰ (폰트 폴백 결함) 또는 잘못된 글리프로 출력 | **완료 (Stage 6/6)** | **본질**: PR #251 (외부 컨트리뷰터, 2026-04 영역) 의 일반 텍스트 PUA 변환 도입 후 매핑 표 정확성 영역 회귀. **진단 영역**: Stage 1 — 광범위 PUA 사용 영역 정합 (14 샘플 / 18 codepoint / 111 회). Stage 2 — `mydocs/manual/hwp/Help/extracted/hwpbase/hncpuaconverter.htm` 정독, KS X 1026-1:2007 표준 정합 (별도 task #512 등록). Stage 3~4 — 4개 옵션 (A/B/C/F) 점검, **Option F 확정** (PR #251 draw_text 영역 보존 + 매핑 표 한컴 PDF 정답지 정확화). **작업지시자 통찰**: *"한컴의 경우 PUA 는 폰트지정과 상관없이 처리해야 할 것 같습니다. 지정된 폰트에 없는 경우 현재 문제가 되는 것으로 판단됩니다."* → rhwp 도 한컴과 동일하게 PUA 자체 변환 발행. **검증 도구**: `gen-pua` 서브명령 추가 — 18 종 PUA 코드포인트 영역 검증용 HWP 생성. samples/pua-test.hwp + 한컴 2022 출력 PDF 캡처 → 정답지 영역 정합. **정정 매핑 (2개)**: U+0F0A0 ▪ U+25AA → · U+00B7 (Middle dot, synam-001 9회), U+0F0E8 ➤ U+27A4 → ➔ U+2794 (Heavy wide-headed arrow, kps-ai 4회). **신규 매핑 (10개)**: Supplementary PUA-A (U+F02B0~F02FF) — U+F02B1~B9 → ① ~ ⑨ (mel-001/kps-ai), U+F02EF → · (KTX). **검증 게이트**: cargo build (lib) + pua_mapping 5/5 + svg_snapshot 6/6 회귀 0 + WASM 4.18MB 빌드 + rhwp-studio 배포. **작업지시자 시각 검증** — KTX p10 + samples/pua-test.hwp 정상 출력 ★. **별도 결함 (본 task 너머)**: Supplementary PUA-A 의 SVG 출력 누락 — 함수 매핑 정확하나 SVG 렌더링 영역에서 누락 (UTF-16 surrogate pair 처리 결함 추정), 별도 task 분리 권장 |
 
 ## 외부 PR 처리

--- a/mydocs/orders/20260502.md
+++ b/mydocs/orders/20260502.md
@@ -10,7 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| **M100 #530** | treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정 | **진행중** | Stage 4 완료보고 승인 대기 |
+| **M100 #530** | treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정 | **완료 (Stage 5/5)** | 최종 보고 완료: 15:50, 이슈 close 승인 대기 |
 | **M100 #509** | PUA (Private Use Area) 글머리표 글리프 회귀 — KTX/synam-001/kps-ai 등 14 샘플의 글머리표가 ☰ (폰트 폴백 결함) 또는 잘못된 글리프로 출력 | **완료 (Stage 6/6)** | **본질**: PR #251 (외부 컨트리뷰터, 2026-04 영역) 의 일반 텍스트 PUA 변환 도입 후 매핑 표 정확성 영역 회귀. **진단 영역**: Stage 1 — 광범위 PUA 사용 영역 정합 (14 샘플 / 18 codepoint / 111 회). Stage 2 — `mydocs/manual/hwp/Help/extracted/hwpbase/hncpuaconverter.htm` 정독, KS X 1026-1:2007 표준 정합 (별도 task #512 등록). Stage 3~4 — 4개 옵션 (A/B/C/F) 점검, **Option F 확정** (PR #251 draw_text 영역 보존 + 매핑 표 한컴 PDF 정답지 정확화). **작업지시자 통찰**: *"한컴의 경우 PUA 는 폰트지정과 상관없이 처리해야 할 것 같습니다. 지정된 폰트에 없는 경우 현재 문제가 되는 것으로 판단됩니다."* → rhwp 도 한컴과 동일하게 PUA 자체 변환 발행. **검증 도구**: `gen-pua` 서브명령 추가 — 18 종 PUA 코드포인트 영역 검증용 HWP 생성. samples/pua-test.hwp + 한컴 2022 출력 PDF 캡처 → 정답지 영역 정합. **정정 매핑 (2개)**: U+0F0A0 ▪ U+25AA → · U+00B7 (Middle dot, synam-001 9회), U+0F0E8 ➤ U+27A4 → ➔ U+2794 (Heavy wide-headed arrow, kps-ai 4회). **신규 매핑 (10개)**: Supplementary PUA-A (U+F02B0~F02FF) — U+F02B1~B9 → ① ~ ⑨ (mel-001/kps-ai), U+F02EF → · (KTX). **검증 게이트**: cargo build (lib) + pua_mapping 5/5 + svg_snapshot 6/6 회귀 0 + WASM 4.18MB 빌드 + rhwp-studio 배포. **작업지시자 시각 검증** — KTX p10 + samples/pua-test.hwp 정상 출력 ★. **별도 결함 (본 task 너머)**: Supplementary PUA-A 의 SVG 출력 누락 — 함수 매핑 정확하나 SVG 렌더링 영역에서 누락 (UTF-16 surrogate pair 처리 결함 추정), 별도 task 분리 권장 |
 
 ## 외부 PR 처리

--- a/mydocs/orders/20260502.md
+++ b/mydocs/orders/20260502.md
@@ -10,6 +10,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
+| **M100 #530** | treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정 | **진행중** | Stage 3 완료보고 승인 대기 |
 | **M100 #509** | PUA (Private Use Area) 글머리표 글리프 회귀 — KTX/synam-001/kps-ai 등 14 샘플의 글머리표가 ☰ (폰트 폴백 결함) 또는 잘못된 글리프로 출력 | **완료 (Stage 6/6)** | **본질**: PR #251 (외부 컨트리뷰터, 2026-04 영역) 의 일반 텍스트 PUA 변환 도입 후 매핑 표 정확성 영역 회귀. **진단 영역**: Stage 1 — 광범위 PUA 사용 영역 정합 (14 샘플 / 18 codepoint / 111 회). Stage 2 — `mydocs/manual/hwp/Help/extracted/hwpbase/hncpuaconverter.htm` 정독, KS X 1026-1:2007 표준 정합 (별도 task #512 등록). Stage 3~4 — 4개 옵션 (A/B/C/F) 점검, **Option F 확정** (PR #251 draw_text 영역 보존 + 매핑 표 한컴 PDF 정답지 정확화). **작업지시자 통찰**: *"한컴의 경우 PUA 는 폰트지정과 상관없이 처리해야 할 것 같습니다. 지정된 폰트에 없는 경우 현재 문제가 되는 것으로 판단됩니다."* → rhwp 도 한컴과 동일하게 PUA 자체 변환 발행. **검증 도구**: `gen-pua` 서브명령 추가 — 18 종 PUA 코드포인트 영역 검증용 HWP 생성. samples/pua-test.hwp + 한컴 2022 출력 PDF 캡처 → 정답지 영역 정합. **정정 매핑 (2개)**: U+0F0A0 ▪ U+25AA → · U+00B7 (Middle dot, synam-001 9회), U+0F0E8 ➤ U+27A4 → ➔ U+2794 (Heavy wide-headed arrow, kps-ai 4회). **신규 매핑 (10개)**: Supplementary PUA-A (U+F02B0~F02FF) — U+F02B1~B9 → ① ~ ⑨ (mel-001/kps-ai), U+F02EF → · (KTX). **검증 게이트**: cargo build (lib) + pua_mapping 5/5 + svg_snapshot 6/6 회귀 0 + WASM 4.18MB 빌드 + rhwp-studio 배포. **작업지시자 시각 검증** — KTX p10 + samples/pua-test.hwp 정상 출력 ★. **별도 결함 (본 task 너머)**: Supplementary PUA-A 의 SVG 출력 누락 — 함수 매핑 정확하나 SVG 렌더링 영역에서 누락 (UTF-16 surrogate pair 처리 결함 추정), 별도 task 분리 권장 |
 
 ## 외부 PR 처리

--- a/mydocs/plans/task_m100_530.md
+++ b/mydocs/plans/task_m100_530.md
@@ -1,0 +1,174 @@
+# Task #530 수행 계획서 — treatise sample.hwp 5페이지 TAC 표 Top caption 머리행 겹침 정정
+
+## 이슈 정합
+
+- **Issue**: [#530](https://github.com/edwardkim/rhwp/issues/530) — treatise sample.hwp 5페이지 표 머리행 텍스트 겹침
+- **마일스톤**: M100 — v1.0.0 조판 엔진
+- **작업 브랜치**: `local/task530`
+- **기준 커밋**: `upstream/devel` `ce98bf5`
+- **대표 샘플**: `samples/basic/treatise sample.hwp`
+- **문제 위치**: page=5, global_idx=4, section=0, column=1, `Table pi=60 ci=0`
+- **표 속성**: 3행×3열, 283.9×61.7px, `wrap=TopAndBottom`, `treat_as_char=true`
+
+## 본질 (사전 분석)
+
+이슈 설명은 작은 행 높이에서 머리행 셀 내부 텍스트가 중첩되는 것으로 보이지만, 현재 SVG 재현 결과의 핵심은 **Top caption 이 표 본문 머리행 위에 겹쳐 렌더링되는 문제**로 판단된다.
+
+`export-svg --debug-overlay` 로 생성한 SVG 좌표에서 머리행 셀 내부 두 줄은 서로 다른 y 좌표를 가진다.
+
+```text
+머리행 셀 텍스트 1줄: y≈537.57
+머리행 셀 텍스트 2줄: y≈551.97
+```
+
+반면 같은 표의 Top caption 두 줄이 거의 같은 영역에 렌더링된다.
+
+```text
+표 1. CGA 생성시간: y≈535.69
+Table 1. Generation times of CGA: y≈551.32
+```
+
+따라서 1차 결론은 다음과 같다.
+
+- 셀 내부 paragraph y advance 자체는 붕괴하지 않았다.
+- caption 과 표 본문이 같은 시작 y 영역을 공유한다.
+- 그 결과 caption 텍스트가 머리행 텍스트 위에 덮여 보인다.
+
+## 의심 코드 영역
+
+### 1. `src/renderer/layout/table_layout.rs`
+
+`layout_table` 에서 `inline_x_override.is_some()` 인 경우 `table_y = y_start` 로 바로 결정한다.
+
+이 경로는 `compute_table_y_position()` 이 일반 Top caption 표에 적용하는 `caption_height + caption_spacing` 오프셋을 건너뛴다. 그러나 Top caption 렌더링은 여전히 `y_start` 에 수행되므로, TAC 표에서는 caption 과 표 본문이 같은 y 기준점을 공유할 수 있다.
+
+### 2. `src/renderer/layout.rs`
+
+`treat_as_char=true` 표는 paragraph layout 단계에서 inline shape position 을 얻고, `layout_table` 호출 시 `inline_x_override` 를 전달한다. 이 때문에 #530 표는 일반 표 경로가 아니라 inline/TAC 표 경로로 들어간다.
+
+### 3. 비교 선례
+
+- `src/renderer/layout/table_partial.rs`: Top caption 을 렌더링할 때 표 본문 y 를 `caption_height + caption_spacing` 만큼 내리는 선례가 있다.
+- `src/renderer/layout/picture_footnote.rs`, `src/renderer/layout/shape_layout.rs`: Top caption 이 있는 객체 본문을 caption 아래로 내리는 유사 선례가 있다.
+
+## 작업 목표
+
+`samples/basic/treatise sample.hwp` 의 page 5 `pi=60 ci=0` TAC 표에서 Top caption 이 머리행 셀 텍스트와 겹치지 않도록 정정한다.
+
+정정 후 기대 상태:
+
+- Top caption 은 표 본문 위에 별도 영역으로 렌더링된다.
+- 표 본문 시작 y 는 caption 높이와 간격만큼 아래로 이동한다.
+- 기존 non-TAC Top caption 표, Bottom caption 표, caption 없는 표의 배치가 회귀하지 않는다.
+- 페이지네이션 반환 y / used height 계산이 기존 의도와 정합해야 한다.
+
+## 범위
+
+### 포함
+
+- TAC 표의 Top caption y 오프셋 누락 진단 확정
+- `layout_table` 의 inline/TAC 경로에서 Top caption 오프셋 적용
+- #530 전용 회귀 테스트 추가
+- `export-svg --debug-overlay`, `dump-pages`, `dump` 기반 재현/정정 검증
+- 기존 표 회귀 테스트와 SVG snapshot 회귀 확인
+
+### 제외
+
+- #501 의 cell padding 방어 로직 재설계
+- #229 의 표 셀 텍스트 겹침 일반 문제 재조사
+- 표 행 높이 산출 알고리즘 전면 재작성
+- rhwp-studio UI 자체 수정
+
+## 단계 분리 (5 stages)
+
+### Stage 1 — 진단 확정
+
+- `dump-pages "samples/basic/treatise sample.hwp" -p 4` 로 문제 표 위치와 TAC 속성 확인
+- `dump "samples/basic/treatise sample.hwp" -s 0 -p 60` 로 셀 paragraph line segment 확인
+- `export-svg --debug-overlay` 출력에서 caption y 와 머리행 텍스트 y 가 같은 영역에 있는지 재확인
+- `table_layout.rs` 의 inline/TAC y 결정 경로와 Top caption offset 누락 확정
+
+**산출물**: `mydocs/working/task_m100_530_stage1.md`
+
+### Stage 2 — 구현 계획서 작성
+
+- Stage 1 결과를 기반으로 정정 방식 결정
+- 후보 정정:
+  - `inline_x_override` 경로에서도 Top caption offset 을 표 본문 y 에 적용
+  - 또는 `compute_table_y_position()` 호출 범위를 조정하되 inline x/y 기준의 중복 offset 을 방지
+- 회귀 테스트 방식 확정
+- 위험 영역과 검증 게이트 확정
+
+**산출물**: `mydocs/plans/task_m100_530_impl.md`
+
+### Stage 3 — 정정 구현 + 집중 테스트
+
+- 승인된 구현 계획에 따라 table layout 경로 수정
+- #530 회귀 테스트 추가
+- 대상 샘플 SVG 에서 caption 과 머리행 텍스트 overlap 해소 확인
+
+**산출물**: `mydocs/working/task_m100_530_stage3.md`
+
+### Stage 4 — 회귀 검증
+
+- `cargo test --lib`
+- `cargo test --test issue_501`
+- `cargo test --test issue_418`
+- `cargo test --test svg_snapshot`
+- 신규 #530 테스트
+- `cargo clippy --lib -- -D warnings`
+- 필요 시 `cargo build --release`
+
+**산출물**: `mydocs/working/task_m100_530_stage4.md`
+
+### Stage 5 — 시각 판정 + 최종 보고
+
+- 정정 전/후 `export-svg --debug-overlay` 결과 비교
+- 작업지시자 시각 판정
+- 최종 보고서 작성: `mydocs/report/task_m100_530_report.md`
+- 오늘 할일 문서 완료 상태 갱신
+- 이슈 #530 close 승인 요청
+
+**산출물**: `mydocs/report/task_m100_530_report.md` + `mydocs/orders/20260502.md` 갱신
+
+## 검증 게이트
+
+| 검증 | 기준 |
+|------|------|
+| `dump-pages -p 4` | `pi=60 ci=0` 표 위치와 크기 정합 |
+| `dump -s 0 -p 60` | 머리행 paragraph line segment 정합 |
+| `export-svg --debug-overlay` | caption 과 머리행 텍스트가 같은 y 영역에 겹치지 않음 |
+| 신규 #530 테스트 | TAC Top caption offset 회귀 방지 |
+| `cargo test --lib` | 회귀 0 |
+| `cargo test --test issue_501` | 기존 cell padding 방어 회귀 0 |
+| `cargo test --test svg_snapshot` | 기존 SVG snapshot 회귀 0 |
+| `cargo clippy --lib -- -D warnings` | warning 0 |
+
+## 위험 영역
+
+| 위험 | 가능성 | 회피책 |
+|------|--------|--------|
+| TAC 표 y 기준에 Top caption offset 을 중복 적용 | 중간 | Stage 1 에서 inline anchor y 의 의미를 확정하고 Stage 3 에서 대상 SVG 좌표 검증 |
+| 페이지네이션 used height 와 실제 paint y 불일치 | 중간 | 반환 y 계산이 `table_height + caption_extra` 와 계속 정합하는지 검증 |
+| non-TAC Top caption 표 회귀 | 낮음~중간 | 기존 `compute_table_y_position()` 경로 변경 최소화 |
+| Bottom/Left/Right caption 회귀 | 낮음 | Top caption 방향에만 조건부 적용 |
+| 분할 표 partial caption 경로와 충돌 | 낮음 | `table_partial.rs` 는 별도 경로로 보존 |
+
+## 처리 정합
+
+- 코드 수정은 수행계획서와 구현 계획서 승인 후 진행한다.
+- 단계별 완료보고서는 해당 단계 변경과 함께 task 브랜치에서 커밋한다.
+- 최종 보고서와 오늘 할일 갱신도 task 브랜치에서 커밋한다.
+- 이슈 close 는 작업지시자 승인 후에만 수행한다.
+
+## 승인 게이트
+
+1. 본 수행계획서 승인 → Stage 1 진단 확정 진행
+2. Stage 1 완료보고서 승인 → 구현 계획서 작성
+3. 구현 계획서 승인 → Stage 3 정정 구현 시작
+4. Stage 3/4 완료보고서 승인 → Stage 5 시각 판정
+5. 최종 보고서 승인 → 머지/이슈 close 절차 진행
+
+## 다음 단계
+
+작업지시자 승인 후 Stage 1 진단 확정 진행.

--- a/mydocs/plans/task_m100_530_impl.md
+++ b/mydocs/plans/task_m100_530_impl.md
@@ -1,0 +1,185 @@
+# Task #530 구현 계획서 — TAC Top caption 표 본문 y 오프셋 적용
+
+## 전제
+
+Stage 1 에서 #530 의 원인을 다음과 같이 확정했다.
+
+- 문제 표는 `samples/basic/treatise sample.hwp` page 5 의 `pi=60 ci=0` TAC 표이다.
+- 셀 내부 두 문단의 line segment 는 `vpos=0`, `vpos=1080` 으로 정상 분리되어 있다.
+- 실제 SVG 에서는 Top caption 두 줄이 머리행 두 줄과 같은 y 영역에 렌더링된다.
+- 원인은 `layout_table` 의 `inline_x_override.is_some()` 경로가 Top caption offset 을 표 본문 y 에 적용하지 않는 것이다.
+
+## 구현 원칙
+
+1. 정정 범위는 `src/renderer/layout/table_layout.rs` 로 제한한다.
+2. `inline_x_override` 의 x 좌표 의미는 유지한다.
+3. inline/TAC 경로에서도 Top caption 이 있으면 표 본문 y 만 `caption_height + caption_spacing` 만큼 아래로 이동한다.
+4. caption 자체의 y 는 기존처럼 `y_start` 로 유지한다.
+5. Bottom/Left/Right caption 과 caption 없는 표에는 영향을 주지 않는다.
+6. 반환 y 계산은 기존 `table_height + caption_extra` 정책과 정합하도록 유지한다.
+
+## 구현 상세
+
+### 변경 파일
+
+- `src/renderer/layout/table_layout.rs`
+- `tests/issue_530.rs` 신규
+
+### `table_layout.rs` 정정 방향
+
+현재 코드:
+
+```rust
+// inline_x_override가 있으면 외부에서 이미 위치를 계산했으므로 y_start 그대로 사용
+let table_y = if inline_x_override.is_some() {
+    y_start
+} else {
+    self.compute_table_y_position(...)
+};
+```
+
+정정 방향:
+
+```rust
+let inline_top_caption_offset = if inline_x_override.is_some() && depth == 0 {
+    table.caption.as_ref()
+        .filter(|caption| matches!(caption.direction, CaptionDirection::Top))
+        .map(|_| caption_height + caption_spacing)
+        .unwrap_or(0.0)
+} else {
+    0.0
+};
+
+let table_y = if inline_x_override.is_some() {
+    y_start + inline_top_caption_offset
+} else {
+    self.compute_table_y_position(...)
+};
+```
+
+주의:
+
+- `caption_height + caption_spacing` 은 현재 `compute_table_y_position()` 의 `treat_as_char=true` Top caption 분기와 동일한 계산이다.
+- `v_offset` 은 여기서 추가하지 않는다. `inline_x_override` 경로의 y 는 paragraph layout 이 이미 inline 흐름 좌표로 계산한 값이므로, 이번 정정은 누락된 Top caption body offset 만 추가한다.
+- non-inline Top caption 표는 기존 `compute_table_y_position()` 경로를 계속 사용한다.
+
+## 회귀 테스트 설계
+
+### 신규 테스트
+
+파일: `tests/issue_530.rs`
+
+테스트명:
+
+```rust
+issue_530_tac_top_caption_does_not_overlap_header_row
+```
+
+절차:
+
+1. `samples/basic/treatise sample.hwp` 를 `HwpDocument::from_bytes` 로 로드한다.
+2. page index 4 를 `render_page_svg_native(4)` 로 SVG 렌더링한다.
+3. 문제 표의 첫 머리행 cell clip rect 를 찾는다.
+   - x: `431.97333333333336`
+   - width: `88.33333333333333`
+   - height: `30.16`
+4. 같은 x 에서 Top caption 둘째 줄 시작 글자 `T` 의 baseline y 를 찾는다.
+5. 다음 조건을 검증한다.
+
+```text
+header_cell_top_y > caption_second_line_baseline_y
+```
+
+현재 회귀 상태:
+
+```text
+header_cell_top_y = 525.49
+caption_second_line_baseline_y = 551.32
+```
+
+따라서 현재 코드는 실패해야 한다.
+
+정정 후 기대:
+
+```text
+header_cell_top_y > 551.32
+```
+
+즉, 표 머리행이 Top caption 아래에서 시작해야 한다.
+
+### 보조 검증
+
+테스트 안에서 다음도 같이 확인한다.
+
+- SVG 에 `"cell-clip"` 이 존재한다.
+- caption 시작 글자 `T` 를 찾지 못하면 명확한 panic 메시지를 낸다.
+- 머리행 top y 와 caption baseline y 를 `println!` 으로 남겨 실패 시 좌표 판단이 가능하게 한다.
+
+## 단계 분리 (3 stages)
+
+### Stage 3 — Red 테스트 + 정정 구현
+
+- `tests/issue_530.rs` 추가
+- 수정 전 신규 테스트가 실패하는지 확인
+- `src/renderer/layout/table_layout.rs` 에 inline Top caption offset 적용
+- 신규 테스트 통과 확인
+- 대상 SVG 재생성 후 머리행 y 가 caption 아래로 이동했는지 확인
+
+**산출물**: `mydocs/working/task_m100_530_stage3.md`
+
+### Stage 4 — 회귀 검증
+
+실행 게이트:
+
+```bash
+cargo test --test issue_530
+cargo test --test issue_501
+cargo test --test issue_418
+cargo test --test svg_snapshot
+cargo test --lib
+cargo clippy --lib -- -D warnings
+```
+
+검증 기준:
+
+- #530 신규 테스트 통과
+- #501 cell padding 방어 회귀 없음
+- #418 / svg_snapshot 회귀 없음
+- lib 테스트 회귀 없음
+- clippy warning 0
+
+**산출물**: `mydocs/working/task_m100_530_stage4.md`
+
+### Stage 5 — 시각 검증 + 최종 보고
+
+- 정정 전/후 `output/debug/treatise sample_005.svg` 좌표 비교
+- 작업지시자 시각 판정 요청
+- 최종 보고서 작성: `mydocs/report/task_m100_530_report.md`
+- 오늘 할일 문서 완료 상태 갱신
+- 이슈 #530 close 승인 요청
+
+**산출물**: `mydocs/report/task_m100_530_report.md` + `mydocs/orders/20260502.md` 갱신
+
+## 예상 변경 영향
+
+| 영역 | 영향 |
+|------|------|
+| TAC + Top caption 표 | 표 본문 y 가 caption 아래로 이동 |
+| TAC + Bottom caption 표 | 변경 없음 |
+| TAC + Left/Right caption 표 | 변경 없음 |
+| non-TAC Top caption 표 | 기존 `compute_table_y_position()` 경로 유지 |
+| partial table caption | 별도 `table_partial.rs` 경로 유지 |
+| 페이지네이션 반환 y | 기존 `caption_extra` 기반 반환 유지 |
+
+## 위험과 대응
+
+| 위험 | 대응 |
+|------|------|
+| 표 본문 y 만 내려가고 반환 y 가 어긋남 | 반환 계산은 변경하지 않는다. 기존 `y_start + table_height + caption_extra` 와 본문 이동량이 같은지 Stage 3 에서 좌표 확인 |
+| inline position 이 이미 caption 을 포함한 경우 중복 이동 | Stage 1 SVG 증거상 현재 inline position 은 표 본문 기준 y 이므로 caption 미포함. 신규 테스트로 회귀 방지 |
+| SVG 좌표 기반 테스트가 지나치게 fixture-specific | 본 결함은 특정 TAC Top caption fixture 의 회귀이므로 issue test 로 한정한다. 광범위 회귀는 `svg_snapshot` 과 기존 issue tests 로 보완 |
+| Bottom/Left/Right caption 회귀 | `CaptionDirection::Top` 조건만 적용 |
+
+## 승인 게이트
+
+본 구현 계획서 승인 후 Stage 3 을 진행한다.

--- a/mydocs/report/task_m100_530_report.md
+++ b/mydocs/report/task_m100_530_report.md
@@ -1,0 +1,110 @@
+# Task #530 최종 보고서 — treatise sample.hwp TAC 표 Top caption 머리행 겹침 정정
+
+## 대상
+
+- **Issue**: [#530](https://github.com/edwardkim/rhwp/issues/530)
+- **브랜치**: `local/task530`
+- **대표 샘플**: `samples/basic/treatise sample.hwp`
+- **문제 위치**: page=5, global_idx=4, section=0, column=1, `Table pi=60 ci=0`
+- **표 속성**: 3행×3열, `wrap=TopAndBottom`, `treat_as_char=true`
+
+## 본질
+
+이슈의 시각 증상은 머리행 셀 내부 두 문단의 line advance 붕괴가 아니라, **Top caption 이 TAC 표 본문 위에 겹쳐 렌더링되는 문제**였다.
+
+Stage 1 진단에서 확인한 정정 전 좌표:
+
+```text
+머리행 top: y=525.49
+caption 2줄 baseline: y=551.32
+```
+
+caption 둘째 줄이 머리행 영역 내부에 들어와 텍스트가 겹쳐 보였다.
+
+## 원인
+
+`src/renderer/layout/table_layout.rs` 의 `layout_table` 에서 `inline_x_override.is_some()` 인 경우 표 본문 y 를 `y_start` 로 그대로 사용했다.
+
+일반 표 경로의 `compute_table_y_position()` 은 Top caption 일 때 표 본문 y 에 `caption_height + caption_spacing` 을 적용하지만, TAC inline 경로는 이 처리를 우회했다.
+
+결과적으로 TAC Top caption 표에서는 다음 배치가 발생했다.
+
+| 요소 | 기존 y 기준 |
+|------|-------------|
+| Top caption | `y_start` |
+| 표 본문 | `y_start` |
+
+## 구현
+
+`inline_x_override` 경로에서도 Top caption 인 경우 표 본문 y 에 `caption_height + caption_spacing` 을 적용했다.
+
+수정 파일:
+
+- `src/renderer/layout/table_layout.rs`
+- `tests/issue_530.rs`
+
+정책:
+
+- caption 자체는 기존처럼 `y_start` 에 렌더링한다.
+- 표 본문만 caption 아래로 이동한다.
+- Bottom/Left/Right caption 과 caption 없는 표는 변경하지 않는다.
+- non-TAC 표는 기존 `compute_table_y_position()` 경로를 유지한다.
+
+## 시각 검증 자료
+
+사용자 직접 PR 본문 이미지 삽입용으로 전/후 비교 자료를 생성했다.
+
+```text
+output/debug/task530_compare/index.html
+output/debug/task530_compare/before/treatise sample_005.svg
+output/debug/task530_compare/after/treatise sample_005.svg
+```
+
+정정 후 좌표:
+
+```text
+머리행 top: y=560.83
+caption 2줄 baseline: y=551.32
+```
+
+비교:
+
+| 항목 | 정정 전 | 정정 후 |
+|------|---------|---------|
+| 머리행 top | 525.49 | 560.83 |
+| caption 2줄 baseline | 551.32 | 551.32 |
+| 판정 | 겹침 | 분리 |
+
+## 검증
+
+Stage 4 검증 결과:
+
+```bash
+cargo test --test issue_530 --test issue_501 --test issue_418 --test svg_snapshot
+cargo test --lib
+cargo clippy --lib -- -D warnings
+```
+
+결과:
+
+- `issue_530`: 1 passed
+- `issue_501`: 1 passed
+- `issue_418`: 1 passed
+- `svg_snapshot`: 6 passed
+- `cargo test --lib`: 1110 passed, 0 failed, 1 ignored
+- `cargo clippy --lib -- -D warnings`: 통과
+
+`cargo test --lib` 중 기존 테스트 코드 warning 4건이 출력되었으나 이번 변경 파일과 무관하며 테스트는 통과했다.
+
+## 커밋
+
+```text
+ac298d4 Task #530 Stage 3: TAC Top caption 표 본문 y 오프셋 정정
+104b4f7 Task #530 Stage 4: 회귀 검증
+```
+
+## 결론
+
+Task #530 정정은 구현, 신규 회귀 테스트, 기존 회귀 검증, 시각 검증 자료 준비까지 완료되었다.
+
+이슈 close 는 작업지시자 승인 후 수행한다.

--- a/mydocs/working/task_m100_530_stage1.md
+++ b/mydocs/working/task_m100_530_stage1.md
@@ -1,0 +1,175 @@
+# Task #530 Stage 1 완료보고서 — TAC 표 Top caption 겹침 원인 확정
+
+## 대상
+
+- **Issue**: [#530](https://github.com/edwardkim/rhwp/issues/530)
+- **브랜치**: `local/task530`
+- **기준 커밋**: `ce98bf5`
+- **샘플**: `samples/basic/treatise sample.hwp`
+- **문제 위치**: page=5, global_idx=4, section=0, column=1, `Table pi=60 ci=0`
+
+## 실행 명령
+
+```bash
+cargo run --quiet --bin rhwp -- dump-pages "samples/basic/treatise sample.hwp" -p 4
+cargo run --quiet --bin rhwp -- dump "samples/basic/treatise sample.hwp" -s 0 -p 60
+cargo run --quiet --bin rhwp -- export-svg "samples/basic/treatise sample.hwp" -p 4 --debug-overlay -o output/debug
+```
+
+## 재현 결과
+
+`dump-pages` 에서 이슈와 동일한 표 위치를 확인했다.
+
+```text
+Table pi=60 ci=0  3x3  283.9x61.7px  wrap=TopAndBottom tac=true  vpos=27708
+```
+
+`dump` 에서 머리행 셀은 2개 문단을 가지고 있으며, 두 문단의 line segment 위치가 서로 다르다.
+
+```text
+셀[0] text="시스템|SecParam"
+  p[0] vpos=0    lh=900 ls=180
+  p[1] vpos=1080 lh=900 ls=180
+
+셀[1] text="라우터 시스템|(P3-870MHz)"
+  p[0] vpos=0    lh=900 ls=180
+  p[1] vpos=1080 lh=900 ls=180
+
+셀[2] text="일반노드 시스템1|(P3-696MHz)"
+  p[0] vpos=0    lh=900 ls=180
+  p[1] vpos=1080 lh=900 ls=180
+```
+
+따라서 셀 내부 두 문단의 y advance 자체가 0 으로 붕괴한 상태는 아니다.
+
+## SVG 좌표 증거
+
+생성 파일:
+
+```text
+output/debug/treatise sample_005.svg
+```
+
+첫 번째 머리행 셀 clip rect:
+
+```text
+x=431.97333333333336
+y=525.4933333333336
+w=88.33333333333333
+h=30.16
+```
+
+첫 번째 머리행 셀 텍스트:
+
+```text
+시스템   y=537.5733333333336
+SecParam y=551.9733333333336
+```
+
+같은 표의 Top caption:
+
+```text
+표 1. CGA 생성시간              y=535.6933333333336
+Table 1. Generation times...   y=551.3200000000003
+```
+
+caption 두 줄이 머리행 두 줄과 거의 같은 y 영역에 렌더링된다. 즉, 시각 증상은 **머리행 셀 텍스트끼리의 중첩**이 아니라 **Top caption 이 머리행 위에 덮여 그려지는 중첩**이다.
+
+## 코드 경로 확인
+
+### `src/renderer/layout.rs`
+
+`treat_as_char=true` 표는 `tree.get_inline_shape_position(...)` 에서 paragraph layout 이 계산한 inline position 을 가져온다. 해당 position 이 있으면 `layout_table(...)` 호출 시 `inline_x_override` 가 전달되고, `y_start` 도 inline position 의 y 값으로 들어간다.
+
+관련 경로:
+
+```rust
+let inline_pos = if is_tac {
+    tree.get_inline_shape_position(page_content.section_index, para_index, control_index)
+} else {
+    None
+};
+
+let tbl_inline_x = if let Some((ix, _)) = inline_pos {
+    Some(ix)
+...
+let table_y_start = if let Some((_, iy)) = inline_pos { iy } else { y_offset };
+y_offset = self.layout_table(... table_y_start, ... tbl_inline_x, ...);
+```
+
+### `src/renderer/layout/paragraph_layout.rs`
+
+paragraph layout 은 TAC 표의 inline 좌표를 계산하고 별도 `PageItem::Table` 중복 렌더링을 막기 위해 위치를 등록한다.
+
+```rust
+let table_y = (y + baseline + om_bottom - table_h).max(y);
+self.layout_table(... table_y, ... Some(x), ...);
+tree.set_inline_shape_position(section_index, para_index, tac_ci, x, table_y);
+```
+
+이 `table_y` 는 표 본문 자체의 기준 y 로 계산되며, Top caption 높이만큼 표 본문을 아래로 내리는 처리가 없다.
+
+### `src/renderer/layout/table_layout.rs`
+
+`layout_table` 은 `inline_x_override.is_some()` 인 경우 y 위치 계산을 우회한다.
+
+```rust
+// inline_x_override가 있으면 외부에서 이미 위치를 계산했으므로 y_start 그대로 사용
+let table_y = if inline_x_override.is_some() {
+    y_start
+} else {
+    self.compute_table_y_position(...)
+};
+```
+
+반면 일반 경로의 `compute_table_y_position()` 은 Top caption 일 때 표 본문 y 에 caption offset 을 적용한다.
+
+```rust
+if matches!(caption.direction, CaptionDirection::Top) {
+    y_start + caption_height + caption_spacing + v_offset
+}
+```
+
+caption 자체는 Top caption 일 때 `y_start` 에 렌더링된다.
+
+```rust
+CaptionDirection::Top => (table_x, table_width, y_start)
+```
+
+결과적으로 TAC 표 + Top caption 조합에서는 다음 상태가 된다.
+
+| 요소 | 현재 y 기준 |
+|------|-------------|
+| Top caption | `y_start` |
+| 표 본문 | `y_start` |
+
+이 때문에 caption 과 머리행이 같은 y 영역에 겹친다.
+
+## 비교 선례
+
+`src/renderer/layout/table_partial.rs` 의 partial table 경로는 Top caption 이 있을 때 표 본문 y 를 명시적으로 내린다.
+
+```rust
+let table_y = if render_top_caption {
+    y_start + caption_height + caption_spacing
+} else {
+    y_start
+};
+```
+
+그림/도형 caption 경로도 Top caption 이 있는 객체 본문을 caption 아래로 내리는 구조를 사용한다. 따라서 #530 의 정정 방향은 기존 코드베이스 선례와도 일치한다.
+
+## Stage 1 결론
+
+원인은 **TAC 표의 inline 경로에서 Top caption offset 을 표 본문 y 에 적용하지 않는 것**으로 확정한다.
+
+정정 방향은 다음 단계에서 구현 계획서로 확정한다.
+
+1. `inline_x_override.is_some()` 경로에서도 Top caption 일 때 `caption_height + caption_spacing` 을 표 본문 y 에 적용한다.
+2. caption 렌더링 y 는 기존처럼 `y_start` 로 유지한다.
+3. 반환 y 는 기존 `table_height + caption_extra` 기반과 정합하도록 유지한다.
+4. 회귀 테스트는 `samples/basic/treatise sample.hwp` page 5 표에서 caption y 와 표 본문/header y 가 같은 영역에 겹치지 않는지 확인하는 방식으로 추가한다.
+
+## 다음 단계
+
+작업지시자 승인 후 `mydocs/plans/task_m100_530_impl.md` 구현 계획서를 작성한다.

--- a/mydocs/working/task_m100_530_stage3.md
+++ b/mydocs/working/task_m100_530_stage3.md
@@ -1,0 +1,127 @@
+# Task #530 Stage 3 완료보고서 — TAC Top caption 표 본문 y 오프셋 정정
+
+## 대상
+
+- **Issue**: [#530](https://github.com/edwardkim/rhwp/issues/530)
+- **브랜치**: `local/task530`
+- **수정 범위**:
+  - `src/renderer/layout/table_layout.rs`
+  - `tests/issue_530.rs`
+
+## Red 테스트
+
+신규 회귀 테스트를 먼저 추가했다.
+
+```bash
+cargo test --test issue_530
+```
+
+수정 전 실패:
+
+```text
+issue #530 table_top=525.49, max_caption_baseline=551.32
+TAC Top caption 이 표 머리행 위에 겹침
+```
+
+이는 Stage 1 분석과 동일하게 표 본문 top 이 caption 둘째 줄 baseline 보다 위에 있음을 증명한다.
+
+## 구현 내용
+
+`layout_table` 의 `inline_x_override.is_some()` 경로에서 Top caption offset 을 표 본문 y 에 반영했다.
+
+기존:
+
+```rust
+let table_y = if inline_x_override.is_some() {
+    y_start
+} else {
+    self.compute_table_y_position(...)
+};
+```
+
+정정:
+
+```rust
+let inline_top_caption_offset = if inline_x_override.is_some() && depth == 0 {
+    if let Some(ref caption) = table.caption {
+        use crate::model::shape::CaptionDirection;
+        if matches!(caption.direction, CaptionDirection::Top) {
+            caption_height + caption_spacing
+        } else {
+            0.0
+        }
+    } else {
+        0.0
+    }
+} else {
+    0.0
+};
+
+let table_y = if inline_x_override.is_some() {
+    y_start + inline_top_caption_offset
+} else {
+    self.compute_table_y_position(...)
+};
+```
+
+정책:
+
+- `inline_x_override` 의 x/y anchor 의미는 유지한다.
+- Top caption 이 있는 경우에만 표 본문 y 를 아래로 내린다.
+- caption 자체는 기존처럼 `y_start` 에 렌더링한다.
+- Bottom/Left/Right caption 과 caption 없는 표는 변경하지 않는다.
+- 반환 y 계산은 기존 `table_height + caption_extra` 정책을 유지한다.
+
+## Green 테스트
+
+```bash
+cargo test --test issue_530 -- --nocapture
+```
+
+결과:
+
+```text
+test issue_530_tac_top_caption_does_not_overlap_header_row ... ok
+
+issue #530 table_top=560.83, max_caption_baseline=551.32
+```
+
+정정 후 표 본문 top 이 caption 둘째 줄 baseline 아래로 이동했다.
+
+## SVG 좌표 확인
+
+명령:
+
+```bash
+cargo run --quiet --bin rhwp -- export-svg "samples/basic/treatise sample.hwp" -p 4 --debug-overlay -o output/debug
+```
+
+생성 파일:
+
+```text
+output/debug/treatise sample_005.svg
+```
+
+정정 후 좌표:
+
+```text
+cell-clip-233 rect y=560.8266666666669
+Top caption 1줄 "표" y=535.6933333333336
+Top caption 2줄 "T"  y=551.3200000000003
+```
+
+정정 전/후 비교:
+
+| 항목 | 정정 전 | 정정 후 |
+|------|---------|---------|
+| 표 머리행 top | 525.49 | 560.83 |
+| caption 둘째 줄 baseline | 551.32 | 551.32 |
+| 판정 | 겹침 | 분리 |
+
+## Stage 3 결론
+
+TAC Top caption 표에서 caption 이 머리행 위에 덮이는 직접 원인을 정정했다. 신규 회귀 테스트는 Red → Green 으로 전환되었고, SVG 좌표에서도 caption 과 표 본문이 분리됨을 확인했다.
+
+## 다음 단계
+
+작업지시자 승인 후 Stage 4 회귀 검증을 진행한다.

--- a/mydocs/working/task_m100_530_stage4.md
+++ b/mydocs/working/task_m100_530_stage4.md
@@ -1,0 +1,86 @@
+# Task #530 Stage 4 완료보고서 — 회귀 검증
+
+## 대상
+
+- **Issue**: [#530](https://github.com/edwardkim/rhwp/issues/530)
+- **브랜치**: `local/task530`
+- **대상 커밋**: `ac298d4` — Task #530 Stage 3 정정 커밋
+
+## 검증 결과 요약
+
+| 검증 | 결과 | 비고 |
+|------|------|------|
+| `cargo test --test issue_530 --test issue_501 --test issue_418 --test svg_snapshot` | 통과 | targeted 회귀 9건 통과 |
+| `cargo test --lib` | 통과 | 1110 passed, 0 failed, 1 ignored |
+| `cargo clippy --lib -- -D warnings` | 통과 | warning 0 |
+
+## targeted tests
+
+명령:
+
+```bash
+cargo test --test issue_530 --test issue_501 --test issue_418 --test svg_snapshot
+```
+
+결과:
+
+```text
+issue_418: 1 passed
+issue_501: 1 passed
+issue_530: 1 passed
+svg_snapshot: 6 passed
+```
+
+판정:
+
+- #530 신규 회귀 테스트 통과
+- #501 cell padding 방어 회귀 없음
+- #418 이미지 중복 emit 회귀 없음
+- 기존 SVG snapshot 6건 회귀 없음
+
+## lib 전체 테스트
+
+명령:
+
+```bash
+cargo test --lib
+```
+
+결과:
+
+```text
+test result: ok. 1110 passed; 0 failed; 1 ignored; 0 measured; 0 filtered out
+```
+
+컴파일 중 기존 테스트 코드 warning 4건이 출력되었다.
+
+```text
+non_snake_case: footnote_emits_autoNum
+non_snake_case: test_merge_then_control_layout_has_colSpan
+unused Result: doc.insert_text_native(...)
+unused Result: doc.convert_to_editable_native()
+```
+
+해당 warning 은 이번 변경 파일이 아닌 기존 테스트 코드에서 발생하며, 테스트 결과는 통과했다.
+
+## clippy
+
+명령:
+
+```bash
+cargo clippy --lib -- -D warnings
+```
+
+결과:
+
+```text
+Finished `dev` profile
+```
+
+판정: 통과. `-D warnings` 조건에서 에러 없음.
+
+## Stage 4 결론
+
+Task #530 정정은 신규 회귀 테스트와 기존 표/스냅샷 회귀 테스트, lib 전체 테스트, clippy 검증을 모두 통과했다.
+
+다음 단계는 Stage 5 시각 판정과 최종 보고서 작성이다.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -232,9 +232,25 @@ impl LayoutEngine {
         }
 
         let table_text_wrap = if depth == 0 { table.common.text_wrap } else { crate::model::shape::TextWrap::Square };
-        // inline_x_override가 있으면 외부에서 이미 위치를 계산했으므로 y_start 그대로 사용
+        let inline_top_caption_offset = if inline_x_override.is_some() && depth == 0 {
+            if let Some(ref caption) = table.caption {
+                use crate::model::shape::CaptionDirection;
+                if matches!(caption.direction, CaptionDirection::Top) {
+                    caption_height + caption_spacing
+                } else {
+                    0.0
+                }
+            } else {
+                0.0
+            }
+        } else {
+            0.0
+        };
+
+        // inline_x_override가 있으면 외부에서 inline 위치를 계산했으므로 x/y 기준은 유지한다.
+        // 단, Top 캡션은 표 본문 위의 별도 영역이므로 표 본문 y 에 캡션 높이만큼 반영한다.
         let table_y = if inline_x_override.is_some() {
-            y_start
+            y_start + inline_top_caption_offset
         } else {
             self.compute_table_y_position(
                 table, table_height, y_start, col_area, depth, caption_height, caption_spacing,

--- a/tests/issue_530.rs
+++ b/tests/issue_530.rs
@@ -1,0 +1,99 @@
+//! Issue #530: treatise sample.hwp 5페이지 TAC 표 Top caption 이 머리행 위에 겹치는 회귀.
+//!
+//! 본질: `treat_as_char=true` 표가 inline 위치로 렌더링될 때 Top caption 높이가
+//! 표 본문 y 에 반영되지 않아 caption 과 머리행이 같은 y 영역에 렌더링됨.
+
+use std::cmp::Ordering;
+use std::fs;
+use std::path::Path;
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+#[test]
+fn issue_530_tac_top_caption_does_not_overlap_header_row() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/basic/treatise sample.hwp");
+    let bytes =
+        fs::read(&hwp_path).unwrap_or_else(|e| panic!("read {}: {}", hwp_path.display(), e));
+
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse treatise sample.hwp");
+
+    // page=5, global_idx=4
+    let tree = doc
+        .build_page_render_tree(4)
+        .expect("render treatise sample.hwp page 5");
+
+    let mut issue_tables = Vec::new();
+    collect_issue_530_tables(&tree.root, &mut issue_tables);
+    assert!(
+        !issue_tables.is_empty(),
+        "section=0 pi=60 ci=0 표 노드를 찾지 못함"
+    );
+
+    let table = issue_tables
+        .into_iter()
+        .min_by(|a, b| a.bbox.y.partial_cmp(&b.bbox.y).unwrap_or(Ordering::Equal))
+        .expect("issue #530 표 노드 선택 실패");
+
+    let mut caption_baselines = Vec::new();
+    collect_issue_530_caption_baselines(&tree.root, &mut caption_baselines);
+    assert!(
+        caption_baselines.len() >= 2,
+        "issue #530 표 caption TextRun 을 충분히 찾지 못함: {:?}",
+        caption_baselines
+    );
+
+    let max_caption_baseline = caption_baselines
+        .iter()
+        .map(|(_, baseline)| *baseline)
+        .fold(f64::NEG_INFINITY, f64::max);
+
+    println!(
+        "issue #530 table_top={:.2}, max_caption_baseline={:.2}, caption_runs={:?}",
+        table.bbox.y, max_caption_baseline, caption_baselines
+    );
+
+    assert!(
+        table.bbox.y > max_caption_baseline + 0.1,
+        "TAC Top caption 이 표 머리행 위에 겹침: table_top={:.2}, \
+         max_caption_baseline={:.2}, caption_runs={:?}",
+        table.bbox.y,
+        max_caption_baseline,
+        caption_baselines
+    );
+}
+
+fn collect_issue_530_tables<'a>(node: &'a RenderNode, out: &mut Vec<&'a RenderNode>) {
+    if let RenderNodeType::Table(table) = &node.node_type {
+        if table.section_index == Some(0)
+            && table.para_index == Some(60)
+            && table.control_index == Some(0)
+        {
+            out.push(node);
+        }
+    }
+
+    for child in &node.children {
+        collect_issue_530_tables(child, out);
+    }
+}
+
+fn collect_issue_530_caption_baselines(node: &RenderNode, out: &mut Vec<(String, f64)>) {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        if let Some(ctx) = &run.cell_context {
+            if ctx.parent_para_index == 60
+                && ctx
+                    .path
+                    .first()
+                    .map(|entry| entry.control_index == 0 && entry.cell_index == 65534)
+                    .unwrap_or(false)
+            {
+                out.push((run.text.clone(), node.bbox.y + run.baseline));
+            }
+        }
+    }
+
+    for child in &node.children {
+        collect_issue_530_caption_baselines(child, out);
+    }
+}


### PR DESCRIPTION
## 개요

`task_m100_530`은 `samples/basic/treatise sample.hwp` 5페이지 우측 단의 TAC 표에서 Top caption이 머리행 위에 겹쳐 보이는 렌더링 결함을 정정합니다.

Refs #530

## 문제

- 위치: page=5, global_idx=4, section=0, `Table pi=60 ci=0`
- 표 속성: 3행x3열, `wrap=TopAndBottom`, `treat_as_char=true`
- 증상: Top caption 두 줄이 표 머리행 텍스트와 같은 y 영역에 렌더링되어 겹쳐 보임

## 원인

`layout_table`에서 `inline_x_override.is_some()`인 TAC inline 경로가 `table_y = y_start`를 그대로 사용해, 일반 Top caption 경로가 적용하는 `caption_height + caption_spacing` 오프셋을 건너뛰었습니다. 따라서 Top caption과 표 본문이 같은 y 기준점을 공유했습니다.

## 변경 사항

- `src/renderer/layout/table_layout.rs`
  - inline/TAC 경로에서도 Top caption인 경우 표 본문 y에 `caption_height + caption_spacing` 반영
  - caption 자체의 y는 기존처럼 `y_start` 유지
  - Bottom/Left/Right caption, non-TAC 표 경로는 변경하지 않음
- `tests/issue_530.rs`
  - `treatise sample.hwp` page index 4에서 caption baseline보다 table top이 아래인지 검증

## 시각 검증

시각 검증 환경:

- 로컬 macOS 환경
- `rhwp export-svg` 디버그 오버레이 출력 기준
- 비교 대상: 수정 전 `ce98bf5`, 수정 후 현재 PR 브랜치

좌표 기준:

| 항목 | 변경 전 (`ce98bf5`) | 변경 후 |
| --- | --- | --- |
| 머리행 top | `y=525.49` | `y=560.83` |
| caption 2줄 baseline | `y=551.32` | `y=551.32` |
| 판정 | 겹침 | 분리 |
| SVG |<img width="100%" alt="treatise sample_005" src="https://github.com/user-attachments/assets/5240c15c-78e1-4a07-801f-0d0b481d2c51" />|<img width="100%" alt="treatise sample_005" src="https://github.com/user-attachments/assets/0f80cb8c-ca5b-4102-a228-623c40c41354" />|

## 자동 검증

```bash
cargo test --test issue_530 --test issue_501 --test issue_418 --test svg_snapshot
cargo test --lib
cargo clippy --lib -- -D warnings
```

결과:

- `issue_530`: 1 passed
- `issue_501`: 1 passed
- `issue_418`: 1 passed
- `svg_snapshot`: 6 passed
- `cargo test --lib`: 1110 passed, 0 failed, 1 ignored
- `cargo clippy --lib -- -D warnings`: passed

`cargo test --lib` 중 기존 테스트 코드 warning 4건이 출력되었으나 이번 변경 파일과 무관합니다.

## 문서

- `mydocs/plans/task_m100_530.md`
- `mydocs/plans/task_m100_530_impl.md`
- `mydocs/working/task_m100_530_stage1.md`
- `mydocs/working/task_m100_530_stage3.md`
- `mydocs/working/task_m100_530_stage4.md`
- `mydocs/report/task_m100_530_report.md`

## 영향 범위

- TAC + Top caption 표: 표 본문이 caption 아래로 이동
- TAC + Bottom/Left/Right caption: 변경 없음
- non-TAC 표: 기존 경로 유지
- partial table caption: 별도 `table_partial.rs` 경로 유지
