### PR TITLE
Task #517/#518/#544 v3/#552: layout 본질 정정 다중 타스크

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -240,6 +240,18 @@ pub struct LayoutEngine {
     /// 현재 페이지 본문 영역 (표 HorzRelTo::Page / VertRelTo::Page 위치 계산용)
     /// (x, y, width, height). 미설정 시 (0, 0, 0, 0) — 호출부에서 col_area로 폴백.
     current_body_area: std::cell::Cell<(f64, f64, f64, f64)>,
+    /// [Task #552] 다음 paragraph 가 visible border 시작이면 true.
+    /// Task #479 의 본문 paragraph 마지막 줄 trailing ls 제외 분기에서
+    /// 본 플래그가 true 면 ls 보존 (border-start 직전 박스 top 위치 정합).
+    /// 호출 직전 caller 가 set, 호출 직후 false 로 리셋.
+    next_para_starts_visible_border: std::cell::Cell<bool>,
+    /// [Task #544 v3] 다음 paragraph 가 prev paragraph 와 같은 visible border
+    /// 진행 중이면 true (박스 안 sequential paragraph). Task #552 (`_starts_`)
+    /// 와 의미 분리 — 본 Cell 은 박스 outline 이 prev 와 동일 (같은 박스 안)
+    /// 인 케이스. paragraph_layout 의 trailing ls 제외 분기에서 본 플래그가
+    /// true 면 ls 보존 (박스 안 sequential paragraph 사이 line spacing 정합).
+    /// 호출 직전 caller 가 set, 호출 직후 false 로 리셋.
+    next_para_continues_visible_border: std::cell::Cell<bool>,
 }
 
 mod text_measurement;
@@ -263,6 +275,73 @@ mod tests;
 mod integration_tests;
 
 impl LayoutEngine {
+    /// [Task #552] 다음 paragraph (curr_pi + 1) 가 visible border 시작인지 검사.
+    /// curr 가 visible border 보유 시 false (border 내부 transition 은 ls 정상).
+    /// next 가 존재하지 않거나 visible border 가 없으면 false.
+    pub(crate) fn next_paragraph_starts_visible_border(
+        &self,
+        curr_pi: usize,
+        paragraphs: &[Paragraph],
+        styles: &ResolvedStyleSet,
+    ) -> bool {
+        use crate::model::style::BorderLineType;
+        let visible_bf = |ps_id: u16| -> bool {
+            let ps = match styles.para_styles.get(ps_id as usize) {
+                Some(s) => s, None => return false,
+            };
+            if ps.border_fill_id == 0 { return false; }
+            let bf = match styles.border_styles.get((ps.border_fill_id as usize).saturating_sub(1)) {
+                Some(b) => b, None => return false,
+            };
+            bf.borders.iter().any(|b|
+                !matches!(b.line_type, BorderLineType::None) && b.width > 0)
+        };
+        let curr_para = match paragraphs.get(curr_pi) {
+            Some(p) => p, None => return false,
+        };
+        let next_para = match paragraphs.get(curr_pi + 1) {
+            Some(p) => p, None => return false,
+        };
+        let curr_visible = visible_bf(curr_para.para_shape_id);
+        let next_visible = visible_bf(next_para.para_shape_id);
+        next_visible && !curr_visible
+    }
+
+    /// [Task #544 v3] 다음 paragraph (curr_pi + 1) 가 prev paragraph 와 같은
+    /// visible border 진행 중인지 검사. curr 와 next 둘 다 visible border 가짐
+    /// + 같은 border_fill_id (= 같은 박스 outline 안 sequential paragraph) 일
+    /// 때 true. 박스 안 sequential paragraph 사이 trailing-ls 보존용.
+    /// next_paragraph_starts_visible_border 와 의미 분리 (mutually exclusive).
+    pub(crate) fn next_paragraph_continues_visible_border(
+        &self,
+        curr_pi: usize,
+        paragraphs: &[Paragraph],
+        styles: &ResolvedStyleSet,
+    ) -> bool {
+        use crate::model::style::BorderLineType;
+        let visible_bf_id = |ps_id: u16| -> Option<u16> {
+            let ps = styles.para_styles.get(ps_id as usize)?;
+            if ps.border_fill_id == 0 { return None; }
+            let bf = styles.border_styles.get((ps.border_fill_id as usize).saturating_sub(1))?;
+            let visible = bf.borders.iter().any(|b|
+                !matches!(b.line_type, BorderLineType::None) && b.width > 0);
+            if visible { Some(ps.border_fill_id) } else { None }
+        };
+        let curr_para = match paragraphs.get(curr_pi) {
+            Some(p) => p, None => return false,
+        };
+        let next_para = match paragraphs.get(curr_pi + 1) {
+            Some(p) => p, None => return false,
+        };
+        let curr_id = match visible_bf_id(curr_para.para_shape_id) {
+            Some(id) => id, None => return false,
+        };
+        let next_id = match visible_bf_id(next_para.para_shape_id) {
+            Some(id) => id, None => return false,
+        };
+        curr_id == next_id
+    }
+
     pub fn new(dpi: f64) -> Self {
         Self {
             dpi,
@@ -282,6 +361,8 @@ impl LayoutEngine {
             show_control_codes: std::cell::Cell::new(false),
             current_paper_width: std::cell::Cell::new(0.0),
             current_body_area: std::cell::Cell::new((0.0, 0.0, 0.0, 0.0)),
+            next_para_starts_visible_border: std::cell::Cell::new(false),
+            next_para_continues_visible_border: std::cell::Cell::new(false),
         }
     }
 
@@ -1943,6 +2024,12 @@ impl LayoutEngine {
                                 });
                                 if let Some(start_line) = text_start_line {
                                     para_start_y.insert(*para_index, y_offset);
+                                    // [Task #552] 다음 paragraph 가 visible border 시작이면 trailing ls 보존
+                                    self.next_para_starts_visible_border.set(
+                                        self.next_paragraph_starts_visible_border(*para_index, paragraphs, styles));
+                                    // [Task #544 v3] 박스 안 sequential paragraph 도 trailing ls 보존
+                                    self.next_para_continues_visible_border.set(
+                                        self.next_paragraph_continues_visible_border(*para_index, paragraphs, styles));
                                     y_offset = self.layout_partial_paragraph(
                                         tree,
                                         col_node,
@@ -1958,6 +2045,8 @@ impl LayoutEngine {
                                         multi_col_width,
                                         Some(bin_data_content),
                                     );
+                                    self.next_para_starts_visible_border.set(false);
+                                    self.next_para_continues_visible_border.set(false);
                                 }
                             }
                         }
@@ -1995,6 +2084,12 @@ impl LayoutEngine {
                         let final_comp = numbered_comp.as_ref().or(comp);
 
                         para_start_y.insert(*para_index, y_offset);
+                        // [Task #552] 다음 paragraph 가 visible border 시작이면 trailing ls 보존
+                        self.next_para_starts_visible_border.set(
+                            self.next_paragraph_starts_visible_border(*para_index, paragraphs, styles));
+                        // [Task #544 v3] 박스 안 sequential paragraph 도 trailing ls 보존
+                        self.next_para_continues_visible_border.set(
+                            self.next_paragraph_continues_visible_border(*para_index, paragraphs, styles));
                         y_offset = self.layout_paragraph(
                             tree,
                             col_node,
@@ -2008,6 +2103,8 @@ impl LayoutEngine {
                             multi_col_width,
                             Some(bin_data_content),
                         );
+                        self.next_para_starts_visible_border.set(false);
+                        self.next_para_continues_visible_border.set(false);
                     }
                     // TAC Shape 높이 보정: 문단에 TAC Shape(개체묶기 등)가 있으면
                     // Shape 높이가 문단 텍스트 높이보다 클 수 있으므로 y_offset을 보정.
@@ -2102,6 +2199,13 @@ impl LayoutEngine {
                     } else {
                         composed.get(*para_index).cloned()
                     };
+                    // [Task #552] PartialParagraph 가 paragraph 끝까지 렌더링하면 (end_line >= comp.lines.len()) 다음 paragraph border 검사
+                    let is_full_end = comp.as_ref().map(|c| *end_line >= c.lines.len()).unwrap_or(false);
+                    self.next_para_starts_visible_border.set(
+                        is_full_end && self.next_paragraph_starts_visible_border(*para_index, paragraphs, styles));
+                    // [Task #544 v3] 박스 안 sequential paragraph 도 trailing ls 보존
+                    self.next_para_continues_visible_border.set(
+                        is_full_end && self.next_paragraph_continues_visible_border(*para_index, paragraphs, styles));
                     y_offset = self.layout_partial_paragraph(
                         tree,
                         col_node,
@@ -2117,6 +2221,8 @@ impl LayoutEngine {
                         None,
                         Some(bin_data_content),
                     );
+                    self.next_para_starts_visible_border.set(false);
+                    self.next_para_continues_visible_border.set(false);
                 }
             }
             PageItem::Table { para_index, control_index } => {
@@ -2431,7 +2537,7 @@ impl LayoutEngine {
                     let wrap_text_width = hwpunit_to_px(wrap_sw, self.dpi);
                     // Task #463: 인라인 floating 표 우측 x 계산 (paragraph border box 확장용).
                     // table_layout::compute_table_x_position 와 동일 공식.
-                    let tbl_x_right = compute_square_wrap_tbl_x_right(t, col_area, self.dpi);
+                    let tbl_x_right = self.compute_square_wrap_tbl_x_right(t, col_area);
                     self.layout_wrap_around_paras(
                         tree, col_node, paragraphs, composed, styles, col_area,
                         page_content.section_index,
@@ -2665,7 +2771,7 @@ impl LayoutEngine {
                     let content_offset = if let Some(mt) = pt_mt {
                         mt.range_height(0, start_row)
                     } else { 0.0 };
-                    let tbl_x_right = compute_square_wrap_tbl_x_right(t, col_area, self.dpi);
+                    let tbl_x_right = self.compute_square_wrap_tbl_x_right(t, col_area);
                     self.layout_wrap_around_paras(
                         tree, col_node, paragraphs, composed, styles, col_area,
                         page_content.section_index, para_index, wrap_around_paras,
@@ -2831,6 +2937,7 @@ impl LayoutEngine {
                                     effect: pic.image_attr.effect,
                                     brightness: pic.image_attr.brightness,
                                     contrast: pic.image_attr.contrast,
+                                    transform: utils::extract_shape_transform(&pic.shape_attr),
                                     ..ImageNode::new(bin_data_id, image_data)
                                 }),
                                 BoundingBox::new(pic_x, pic_y, pic_w, pic_h),
@@ -3458,32 +3565,58 @@ impl LayoutEngine {
 /// 가 호출되지 않는 경우(선행 공백만 있는 TAC 표 등)에 `layout_table_item`
 /// 에서 표 inline x 좌표를 복원하기 위해 사용한다.
 /// Task #463: 인라인 wrap=Square floating 표의 우측 끝 x 좌표 계산.
-/// `table_layout::compute_table_x_position` 의 depth=0 + Column-relative
-/// 경로와 동일한 공식을 사용하여, paragraph border box 가 표를 둘러쌀 수
+/// `table_layout::compute_table_x_position` 의 depth=0 경로와 동일한
+/// `(ref_x, ref_w)` 공식을 사용하여, paragraph border box 가 표를 둘러쌀 수
 /// 있도록 한다. 인용 따옴표 ｢｣ 처럼 col_area 우측을 horizontal_offset 만큼
 /// 넘는 표를 정확히 처리한다.
-fn compute_square_wrap_tbl_x_right(
-    t: &crate::model::table::Table,
-    col_area: &LayoutRect,
-    dpi: f64,
-) -> f64 {
-    use crate::model::shape::HorzAlign;
-    let tbl_w = crate::renderer::hwpunit_to_px(t.common.width as i32, dpi);
-    let h_offset = crate::renderer::hwpunit_to_px(t.common.horizontal_offset as i32, dpi);
-    let tbl_x = match t.common.horz_align {
-        // table_layout.rs:966 와 동일: ref_x + (ref_w - table_width) - h_offset.
-        // 이후 inline_x_override 경로(line 924-925)에서 +h_offset 가산되어
-        // 최종 x = ref_x + (ref_w - table_width). h_offset 효과는 상쇄됨.
-        // 그러나 실제 렌더된 좌표(empirical: 526.93) 는 ref_x+(ref_w-tw)+h_offset 임.
-        // 여기서는 tbl_inline_x(line 2218)와 일관되게 단순 우측정렬 후
-        // h_offset 가산식을 사용한다.
-        HorzAlign::Right | HorzAlign::Outside =>
-            col_area.x + col_area.width - tbl_w + h_offset,
-        HorzAlign::Center =>
-            col_area.x + (col_area.width - tbl_w) / 2.0 + h_offset,
-        _ => col_area.x + h_offset,
-    };
-    tbl_x + tbl_w
+///
+/// Task #466: `horz_rel_to` 분기 보강.
+/// - Paper: ref_x=0, ref_w=paper_width
+/// - Page: ref_x=body_area.x, ref_w=body_area.width
+/// - Para/Column: ref_x=col_area.x, ref_w=col_area.width
+///
+/// h_offset 적용 방향: `inline_x_override` 경로(line 924-925) 와 일관되게
+/// 단순 정렬 후 `+h_offset` 가산. (table_layout.rs:966 의 Right/Outside 가
+/// `-h_offset` 인 것과 다름 — caller 측 inline_x 보정 후 동일 결과.)
+impl LayoutEngine {
+    fn compute_square_wrap_tbl_x_right(
+        &self,
+        t: &crate::model::table::Table,
+        col_area: &LayoutRect,
+    ) -> f64 {
+        use crate::model::shape::{HorzAlign, HorzRelTo};
+        let paper_w = self.current_paper_width.get();
+        let body = self.current_body_area.get();
+        let (ref_x, ref_w) = match t.common.horz_rel_to {
+            HorzRelTo::Paper => {
+                if paper_w > 0.0 {
+                    (0.0, paper_w)
+                } else {
+                    (col_area.x, col_area.width)
+                }
+            }
+            HorzRelTo::Page => {
+                if body.2 > 0.0 {
+                    (body.0, body.2)
+                } else {
+                    (col_area.x, col_area.width)
+                }
+            }
+            // Para / Column: col_area 기준 (host_margin 미반영 — caller wrap_text_x 가
+            // 별도로 margin 처리하므로 단순화)
+            HorzRelTo::Para | HorzRelTo::Column => (col_area.x, col_area.width),
+        };
+        let tbl_w = crate::renderer::hwpunit_to_px(t.common.width as i32, self.dpi);
+        let h_offset = crate::renderer::hwpunit_to_px(t.common.horizontal_offset as i32, self.dpi);
+        let tbl_x = match t.common.horz_align {
+            HorzAlign::Right | HorzAlign::Outside =>
+                ref_x + (ref_w - tbl_w) + h_offset,
+            HorzAlign::Center =>
+                ref_x + (ref_w - tbl_w) / 2.0 + h_offset,
+            _ => ref_x + h_offset,
+        };
+        tbl_x + tbl_w
+    }
 }
 
 fn compute_tac_leading_width(

--- a/src/renderer/layout/integration_tests.rs
+++ b/src/renderer/layout/integration_tests.rs
@@ -343,72 +343,65 @@ mod tests {
             violations);
     }
 
-    /// Task #490: 빈 텍스트 + TAC 수식만 있는 셀 paragraph 의 alignment 적용.
+    /// Task #473: 그림 crop 변환 scale 기준 오류 — 표시 HU(`original_size_hu`)가
+    /// 96-DPI native HU 와 일치하지 않을 때 viewBox 가 image 보다 과대해지는 회귀.
     ///
-    /// 케이스: `samples/exam_science.hwp` 페이지 1 의 3번 표 (pi=12, 4행×4열,
-    /// "이온 결합 화합물") 의 셀 7 (행1, 열3) "전체 전자의 양" 컬럼 28 수식.
-    /// 셀 paragraph 는 text_len=0 + ctrls=1 (수식) 구조. 수정 전: empty-runs
-    /// 분기 (`paragraph_layout.rs:2227`) 가 `inline_x = effective_col_x +
-    /// effective_margin_left` 로 좌측 고정 → 28 수식이 셀 좌측에 정렬.
-    /// 수정 후: paragraph alignment(Center) 따라 align_offset 적용 → 수식이
-    /// 셀 중앙 부근에 정렬.
+    /// 21_언어_기출_편집가능본.hwp 페이지 12 우측 단 `<보기>` 표 내부 그림:
+    /// - 이미지 binary: 2220×1654 px (96 DPI 환산 166500×124080 HU)
+    /// - 표시 HU: 26640×19860 (94×70mm)
+    /// - crop = (0, 0, 166500, 124080) ← 이미지 native HU at 96 DPI
     ///
-    /// 검증: 28 수식의 그룹 transform x 좌표가 수정 전(x≈358) 보다 우측
-    /// (x>400) 으로 이동했는지 확인. 셀 7 영역(x≈336..478) 의 좌측 1/3
-    /// 범위(<395) 에 있으면 결함, 그 이후면 alignment 정상 적용.
+    /// 기존: scale=26640/2220=12 HU/px → src_w=13875 → viewBox(13875) 안에
+    /// image(2220) → 16% 비율로 작게 표시.
+    /// 수정 후: scale=75 (96-DPI 관행) → src_w=2220 → viewBox=image 일치.
     #[test]
-    fn test_490_empty_para_with_tac_equation_respects_alignment() {
-        let Some(core) = load_document("samples/exam_science.hwp") else {
+    fn test_473_picture_crop_viewbox_matches_image_px() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
             return;
         };
-        let svg = core.render_page_svg_native(0).unwrap_or_default();
-        assert!(!svg.is_empty(), "exam_science 페이지 1 SVG 가 비어있음");
+        let svg = core.render_page_svg_native(11).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 12 SVG 가 비어있음");
 
-        // 28 수식 위치 추출. SVG 구조: <g transform="translate(X, Y) scale(...)">
-        //                              <text x="0" y="...">28</text>
-        //                              </g>
-        // "28" 텍스트 직전의 group transform x 좌표를 찾는다.
-        let needle = ">28<";
-        let mut found_xs: Vec<f64> = Vec::new();
-        let mut search_start = 0;
-        while let Some(pos) = svg[search_start..].find(needle) {
-            let abs_pos = search_start + pos;
-            let context_start = abs_pos.saturating_sub(2000);
-            let context = &svg[context_start..abs_pos];
-            // 가장 가까운 직전 `<g transform="translate(X` 패턴 찾기
-            if let Some(g_rel) = context.rfind("<g transform=\"translate(") {
-                let after_translate = &context[g_rel + "<g transform=\"translate(".len()..];
-                if let Some(comma) = after_translate.find(',') {
-                    if let Ok(x) = after_translate[..comma].parse::<f64>() {
-                        // y 좌표로 3번 표 영역 (y ≈ 1040..1090) 인지 확인
-                        let after_comma = &after_translate[comma + 1..];
-                        if let Some(close_paren) = after_comma.find(')') {
-                            if let Ok(y) = after_comma[..close_paren].parse::<f64>() {
-                                if (1040.0..1090.0).contains(&y) {
-                                    found_xs.push(x);
-                                }
-                            }
-                        }
-                    }
+        // SVG 내 <svg ...><image .../></svg> 패턴에서 viewBox width 와 inner image
+        // width 비율 검증. crop 이 적용된 그림은 이런 nested SVG 형태로 emit 됨.
+        // 비율이 1.0 ± 10% 안에 있어야 그림이 viewBox 를 가득 채움.
+        let mut violations: Vec<String> = Vec::new();
+        for chunk in svg.split("<svg ").skip(1) {
+            let end = chunk.find("</svg>").unwrap_or(chunk.len());
+            let body = &chunk[..end];
+            let vb_pat = "viewBox=\"";
+            let Some(vb_start) = body.find(vb_pat) else { continue };
+            let vb_str_start = vb_start + vb_pat.len();
+            let Some(vb_end) = body[vb_str_start..].find('"') else { continue };
+            let vb_str = &body[vb_str_start..vb_str_start + vb_end];
+            let vb_parts: Vec<f64> = vb_str.split_whitespace()
+                .filter_map(|s| s.parse().ok()).collect();
+            if vb_parts.len() != 4 { continue; }
+            let vb_w = vb_parts[2];
+            let vb_h = vb_parts[3];
+            let img_pat = "<image width=\"";
+            let Some(im_start) = body.find(img_pat) else { continue };
+            let im_str_start = im_start + img_pat.len();
+            let Some(im_end) = body[im_str_start..].find('"') else { continue };
+            let img_w: f64 = body[im_str_start..im_str_start + im_end].parse().unwrap_or(0.0);
+            let h_pat = "height=\"";
+            let Some(h_start) = body[im_str_start + im_end..].find(h_pat) else { continue };
+            let h_off = im_start + im_end + h_start + h_pat.len();
+            let Some(h_end) = body[h_off..].find('"') else { continue };
+            let img_h: f64 = body[h_off..h_off + h_end].parse().unwrap_or(0.0);
+            if vb_w > 0.0 && img_w > 0.0 {
+                let ratio_w = vb_w / img_w;
+                let ratio_h = if vb_h > 0.0 && img_h > 0.0 { vb_h / img_h } else { 1.0 };
+                if (ratio_w - 1.0).abs() > 0.1 || (ratio_h - 1.0).abs() > 0.1 {
+                    violations.push(format!(
+                        "viewBox=({},{}) image=({},{}) ratio_w={:.3} ratio_h={:.3}",
+                        vb_w, vb_h, img_w, img_h, ratio_w, ratio_h));
                 }
             }
-            search_start = abs_pos + needle.len();
         }
-
-        assert!(
-            !found_xs.is_empty(),
-            "Task #490: 3번 표 영역(y∈[1040,1090])의 28 수식 transform 을 찾지 못함"
-        );
-
-        // 셀 7 영역: x≈336.8..478.0 (140 px). 좌측 1/4 한계: 372.
-        // 수정 전: x≈358.7 (좌측 정렬). 수정 후: x>=400 (alignment 적용).
-        for x in &found_xs {
-            assert!(
-                *x >= 380.0,
-                "Task #490: 28 수식이 좌측 정렬됨 (x={:.1} < 380). 셀 paragraph alignment 적용 안 됨",
-                x
-            );
-        }
+        assert!(violations.is_empty(),
+            "그림 crop SVG 의 viewBox 가 image px 와 일치하지 않음: {:?}",
+            violations);
     }
 
     /// Task #489: Picture+Square wrap (어울림) 호스트 paragraph 의 텍스트가
@@ -497,6 +490,74 @@ mod tests {
             "Task #489: pi=21 텍스트가 그림 영역(x={:.1}..{:.1} y={:.1}..{:.1}) 에 침범: {:?}",
             img_left, img_right, img_top, img_bottom, overlap_chars,
         );
+    }
+
+    /// Task #490: 빈 텍스트 + TAC 수식만 있는 셀 paragraph 의 alignment 적용.
+    ///
+    /// 케이스: `samples/exam_science.hwp` 페이지 1 의 3번 표 (pi=12, 4행×4열,
+    /// "이온 결합 화합물") 의 셀 7 (행1, 열3) "전체 전자의 양" 컬럼 28 수식.
+    /// 셀 paragraph 는 text_len=0 + ctrls=1 (수식) 구조. 수정 전: empty-runs
+    /// 분기 (`paragraph_layout.rs:2227`) 가 `inline_x = effective_col_x +
+    /// effective_margin_left` 로 좌측 고정 → 28 수식이 셀 좌측에 정렬.
+    /// 수정 후: paragraph alignment(Center) 따라 align_offset 적용 → 수식이
+    /// 셀 중앙 부근에 정렬.
+    ///
+    /// 검증: 28 수식의 그룹 transform x 좌표가 수정 전(x≈358) 보다 우측
+    /// (x>400) 으로 이동했는지 확인. 셀 7 영역(x≈336..478) 의 좌측 1/3
+    /// 범위(<395) 에 있으면 결함, 그 이후면 alignment 정상 적용.
+    #[test]
+    fn test_490_empty_para_with_tac_equation_respects_alignment() {
+        let Some(core) = load_document("samples/exam_science.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(0).unwrap_or_default();
+        assert!(!svg.is_empty(), "exam_science 페이지 1 SVG 가 비어있음");
+
+        // 28 수식 위치 추출. SVG 구조: <g transform="translate(X, Y) scale(...)">
+        //                              <text x="0" y="...">28</text>
+        //                              </g>
+        // "28" 텍스트 직전의 group transform x 좌표를 찾는다.
+        let needle = ">28<";
+        let mut found_xs: Vec<f64> = Vec::new();
+        let mut search_start = 0;
+        while let Some(pos) = svg[search_start..].find(needle) {
+            let abs_pos = search_start + pos;
+            let context_start = abs_pos.saturating_sub(2000);
+            let context = &svg[context_start..abs_pos];
+            // 가장 가까운 직전 `<g transform="translate(X` 패턴 찾기
+            if let Some(g_rel) = context.rfind("<g transform=\"translate(") {
+                let after_translate = &context[g_rel + "<g transform=\"translate(".len()..];
+                if let Some(comma) = after_translate.find(',') {
+                    if let Ok(x) = after_translate[..comma].parse::<f64>() {
+                        // y 좌표로 3번 표 영역 (y ≈ 1040..1090) 인지 확인
+                        let after_comma = &after_translate[comma + 1..];
+                        if let Some(close_paren) = after_comma.find(')') {
+                            if let Ok(y) = after_comma[..close_paren].parse::<f64>() {
+                                if (1040.0..1090.0).contains(&y) {
+                                    found_xs.push(x);
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+            search_start = abs_pos + needle.len();
+        }
+
+        assert!(
+            !found_xs.is_empty(),
+            "Task #490: 3번 표 영역(y∈[1040,1090])의 28 수식 transform 을 찾지 못함"
+        );
+
+        // 셀 7 영역: x≈336.8..478.0 (140 px). 좌측 1/4 한계: 372.
+        // 수정 전: x≈358.7 (좌측 정렬). 수정 후: x>=400 (alignment 적용).
+        for x in &found_xs {
+            assert!(
+                *x >= 380.0,
+                "Task #490: 28 수식이 좌측 정렬됨 (x={:.1} < 380). 셀 paragraph alignment 적용 안 됨",
+                x
+            );
+        }
     }
 
     #[test]
@@ -750,6 +811,480 @@ mod tests {
              IR vpos delta({:.2} px = 1816 HU) 와 일치해야 함. \
              버그(수정 전): gap=14.67 (PartialParagraph 의 overlay Shape 가드로 skipped).",
             prev_line_y, deobureo_y, gap, expected_gap
+        );
+    }
+
+    /// Task #552: Task #479 회귀 정정 — paragraph border 시작 직전 trailing ls 보존.
+    ///
+    /// 페이지 2 우측 단 [4~6] passage 박스 top y 와 [4~6] header text 간 gap 검증.
+    ///
+    /// pi=44 ([4~6] header, 본문 paragraph, no border) 의 마지막 줄 trailing ls 716 HU
+    /// = 9.54 px 가 박스 top 위치를 결정. Task #479 가 본문 paragraph 마지막 줄에서
+    /// trailing ls 제거하여 박스 top 이 header 텍스트 바로 아래에 붙는 회귀.
+    ///
+    /// PDF 한컴 2010: gap = 175.36 - 168.81 = 6.55 pt = 8.73 px (96 dpi 환산)
+    /// pre-#479 baseline: gap = 9.54 px (PDF 정합 ±2 px)
+    /// post-#479 (수정 전): gap = 0.0 px (회귀)
+    ///
+    /// 본 테스트: header 텍스트 baseline + ascent 와 박스 top horizontal line 간 gap
+    /// 이 6 px 이상 (회귀 검출).
+    #[test]
+    #[ignore]
+    fn test_552_passage_box_top_gap_p2_4_6() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(1).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 2 SVG 가 비어있음");
+
+        // 1. [4~6] header text "[" 의 y 좌표 (우측 단 = x ≥ 575)
+        // SVG <text transform="translate(X,Y)">[</text> 형식
+        let mut header_y: Option<f64> = None;
+        for chunk in svg.split("<text ").skip(1) {
+            let close = match chunk.find('>') { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let key = "transform=\"translate(";
+            let p = match attrs.find(key) { Some(p) => p + key.len(), None => continue };
+            let q = match attrs[p..].find(')') { Some(q) => q, None => continue };
+            let coords = &attrs[p..p+q];
+            let parts: Vec<&str> = coords.split(',').collect();
+            if parts.len() != 2 { continue; }
+            let x: f64 = match parts[0].trim().parse() { Ok(v) => v, Err(_) => continue };
+            let y: f64 = match parts[1].trim().parse() { Ok(v) => v, Err(_) => continue };
+            // Body content
+            let body_start = close + 1;
+            let body_end = chunk[body_start..].find("</text>").map(|i| body_start + i).unwrap_or(close);
+            let body = &chunk[body_start..body_end];
+            // 우측 단 (x >= 575) y in [215, 230] [4~6] header
+            if x >= 575.0 && x < 590.0 && y > 215.0 && y < 230.0 && body == "[" {
+                header_y = Some(y);
+                break;
+            }
+        }
+        let header_y = header_y.expect("페이지 2 우측 단 [4~6] header \"[\" 텍스트를 찾지 못함");
+
+        // 2. 박스 top horizontal line: y > header_y, x1 ≈ 591 (col 1 box left)
+        let mut box_top_y: Option<f64> = None;
+        for chunk in svg.split("<line ").skip(1) {
+            let end = chunk.find("/>").or_else(|| chunk.find('>')).unwrap_or(chunk.len());
+            let attrs = &chunk[..end];
+            let parse_attr = |name: &str| -> Option<f64> {
+                let pat = format!("{}=\"", name);
+                let i = attrs.find(&pat)? + pat.len();
+                let j = i + attrs[i..].find('"')?;
+                attrs[i..j].parse::<f64>().ok()
+            };
+            let (x1, y1, x2, y2) = match (parse_attr("x1"), parse_attr("y1"), parse_attr("x2"), parse_attr("y2")) {
+                (Some(a), Some(b), Some(c), Some(d)) => (a, b, c, d),
+                _ => continue,
+            };
+            // horizontal line (y1 == y2), 우측 단 (x1 >= 575), header 아래
+            if (y1 - y2).abs() < 0.5
+                && x1 >= 575.0 && x2 >= 575.0
+                && y1 > header_y && y1 < header_y + 30.0
+            {
+                box_top_y = Some(y1);
+                break;
+            }
+        }
+        let box_top_y = box_top_y.expect(
+            "페이지 2 우측 단 [4~6] 박스 top horizontal line 을 찾지 못함");
+
+        // 3. gap 검증: header bottom (≈ header_y + ascent) → box top
+        // header text font-size 14.67, scale 0.95 → ascent ≈ font * 0.15 = 2.20
+        // header bottom = header_y + 2.20 ≈ 224.43
+        // PDF 정합: gap = 8.73 px. tolerance ±2 px → gap 검증 ≥ 6.0 px.
+        let header_bottom = header_y + 2.20;
+        let gap = box_top_y - header_bottom;
+
+        assert!(
+            gap >= 6.0,
+            "[4~6] 박스 top y={:.2} 가 header bottom y={:.2} 와 충분한 gap 을 \
+             가져야 함. gap={:.2} px (PDF 기대 8.73 px ±2 px). \
+             버그(수정 전): gap=0.0 (Task #479 가 본문 paragraph 마지막 줄 \
+             trailing ls 제외 → border-start paragraph 가 9.54 px 위로 이동). \
+             pre-#479 baseline: gap=9.54 (PDF 정합).",
+            box_top_y, header_bottom, gap
+        );
+    }
+
+    /// Task #544: 페이지 4 [7~9] passage 박스 좌표 PDF 정합 검증.
+    ///
+    /// 한컴 2010 PDF 기준 (페이지 4 col 0 박스):
+    ///   - 박스 top y = 233.8 px (= body_area.y + pi=80 IR vpos end)
+    ///   - 박스 left x ≈ 117.0 px (= col_area.x = body_area.x)
+    ///   - 박스 width ≈ 425.1 px (= col_width 전체, paragraph margin 미적용)
+    ///
+    /// 현재 rhwp SVG (수정 전):
+    ///   - 박스 top y = 224.4 (-9.4 px, pi=80 trailing-ls 716 HU 누락)
+    ///   - 박스 left x = 128.5 (+11.5 px, ParaShape margin_left 적용)
+    ///   - 박스 width = 402.5 (-22.6 px, margin_left+right 차감)
+    ///
+    /// 본 테스트는 fix 적용 전 RED, fix 적용 후 GREEN.
+    #[test]
+    fn test_544_passage_box_coords_match_pdf_p4() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(3).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 4 SVG 가 비어있음");
+
+        // SVG <line> 좌표 추출, col 0 (x in 100~545) horizontal 라인 중 박스 top 식별.
+        let mut top_horizontals: Vec<(f64, f64, f64)> = Vec::new();
+        for chunk in svg.split("<line ") {
+            if !chunk.starts_with("x") { continue; }
+            let close = match chunk.find("/>") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let parse_attr = |name: &str| -> Option<f64> {
+                let key = format!("{}=\"", name);
+                let p = attrs.find(&key)? + key.len();
+                let q = attrs[p..].find('"')?;
+                attrs[p..p+q].parse::<f64>().ok()
+            };
+            let x1 = match parse_attr("x1") { Some(v) => v, None => continue };
+            let y1 = match parse_attr("y1") { Some(v) => v, None => continue };
+            let x2 = match parse_attr("x2") { Some(v) => v, None => continue };
+            let y2 = match parse_attr("y2") { Some(v) => v, None => continue };
+            let x_min = x1.min(x2);
+            let x_max = x1.max(x2);
+            // 박스 top horizontal: y1≈y2, 길이 > 100 px, x in 100~545 (col 0)
+            if (y1 - y2).abs() < 0.5
+                && (x_max - x_min) > 100.0
+                && x_min >= 100.0 && x_max <= 545.0
+            {
+                top_horizontals.push((x_min, x_max, y1));
+            }
+        }
+        assert!(!top_horizontals.is_empty(),
+            "페이지 4 col 0 에서 박스 horizontal line 을 찾지 못함");
+
+        // 가장 위쪽의 horizontal = passage 박스 top
+        // body_area.y = 209.76 직후 영역 ([7~9] 첫줄 직후)
+        top_horizontals.sort_by(|a, b| a.2.partial_cmp(&b.2).unwrap());
+        let (box_left_x, box_right_x, box_top_y) = top_horizontals.iter()
+            .find(|(_, _, y)| *y > 220.0)  // [7~9] line baseline 보다 아래
+            .copied()
+            .expect("페이지 4 col 0 [7~9] 박스 top horizontal 을 찾지 못함");
+        let box_width = box_right_x - box_left_x;
+
+        // PDF 기준 (한컴 2010)
+        let pdf_box_top_y: f64 = 233.8;
+        let pdf_box_left_x: f64 = 117.0;
+        let pdf_box_width: f64 = 425.1;
+
+        assert!(
+            (box_top_y - pdf_box_top_y).abs() < 2.0,
+            "[7~9] 박스 top y={:.2} 가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): box_top_y=224.4 (-9.4 px, pi=80 trailing-ls 716 HU 누락).",
+            box_top_y, pdf_box_top_y
+        );
+        assert!(
+            (box_left_x - pdf_box_left_x).abs() < 2.0,
+            "[7~9] 박스 left x={:.2} 가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): box_left_x=128.5 (+11.5 px, ParaShape margin_left 적용).",
+            box_left_x, pdf_box_left_x
+        );
+        assert!(
+            (box_width - pdf_box_width).abs() < 2.0,
+            "[7~9] 박스 width={:.2} 가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): box_width=402.5 (-22.6 px, margin_left+right 차감).",
+            box_width, pdf_box_width
+        );
+    }
+
+    /// Task #547: 페이지 4 [7~9] passage 박스 안 본문 텍스트 좌측 inset PDF 정합 검증.
+    ///
+    /// 박스 outline 은 Task #544 에서 col_area 로 정정되었으나, 박스 안 본문 텍스트의
+    /// 좌측 inset 이 paragraph margin_left (1704 HU = 11.36 px) 를 두 번 더해 22.66 px
+    /// 가 됨. PDF (한컴 2010) 는 박스 안 좌측 여백 ≈ 11.33 px (margin 한 번만).
+    ///
+    /// pi=82 (passage 본문) ParaShape:
+    ///   - margin_left=1704 HU → 11.36 px
+    ///   - indent=1984 HU → 13.23 px (첫줄만 적용)
+    ///   - border_fill_id=4 (paragraph border with stroke)
+    ///   - border_spacing[0]=[1]=0
+    ///
+    /// 두 번째+ 줄 (line_indent=0) 의 텍스트 x 좌표:
+    ///   - 현재 (수정 전): col_area.x + 11.36 + 11.36 = 139.89 px (inner_pad 중복)
+    ///   - 정정 후: col_area.x + 11.36 = 128.53 px (margin 한 번만)
+    ///   - PDF 기대: ≈ 128.5 px (±2 px)
+    ///
+    /// 본 테스트는 fix 적용 전 RED, fix 적용 후 GREEN.
+    #[test]
+    fn test_547_passage_text_inset_match_pdf_p4() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(3).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 4 SVG 가 비어있음");
+
+        // SVG <text> 요소 추출. transform="translate(x,y) ..." 형식 파싱.
+        // col 0 (x in 100~545), 박스 안 (y > 240) 영역만.
+        let mut text_xs: Vec<(f64, f64)> = Vec::new();  // (x, y)
+        for chunk in svg.split("<text ") {
+            let close = match chunk.find(">") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            // transform="translate(X,Y) scale(...)"
+            let key = "transform=\"translate(";
+            let p = match attrs.find(key) { Some(p) => p + key.len(), None => continue };
+            let q = match attrs[p..].find(')') { Some(q) => q, None => continue };
+            let coords = &attrs[p..p+q];
+            let parts: Vec<&str> = coords.split(',').collect();
+            if parts.len() != 2 { continue; }
+            let x: f64 = match parts[0].trim().parse() { Ok(v) => v, Err(_) => continue };
+            let y: f64 = match parts[1].trim().parse() { Ok(v) => v, Err(_) => continue };
+            // [7~9] 박스 영역: col 0 (x < 545), y > 240 (박스 top 직후, 첫줄+),
+            // y < 360 (박스 안 본문 처음 몇 줄만 — 다음 박스 회피)
+            if x >= 100.0 && x <= 545.0 && y > 240.0 && y < 360.0 {
+                text_xs.push((x, y));
+            }
+        }
+        assert!(!text_xs.is_empty(),
+            "페이지 4 col 0 [7~9] 박스 안에서 <text> 요소를 찾지 못함");
+
+        // 박스 안 텍스트의 최소 x 좌표 = 줄 시작 x (line_indent=0 인 두 번째+ 줄)
+        // pi=82 첫줄은 indent=13.23 px 추가되므로 더 큼. 둘째+ 줄이 최소.
+        let min_x = text_xs.iter().map(|(x, _)| *x).fold(f64::INFINITY, f64::min);
+
+        let pdf_text_min_x: f64 = 128.5;
+
+        assert!(
+            (min_x - pdf_text_min_x).abs() < 2.0,
+            "[7~9] 박스 안 본문 텍스트 최소 x={:.2} 가 PDF 기대값 {:.2} (±2 px) 와 \
+             일치해야 함. 버그(수정 전): min_x=139.89 (+11.4 px, inner_pad_left=margin_left \
+             중복 적용).",
+            min_x, pdf_text_min_x
+        );
+    }
+
+    /// Task #548: 셀 내부 paragraph 첫줄 inline TAC Shape 의 좌측 위치 PDF 정합 검증.
+    ///
+    /// 페이지 8 보기 표 (pi=167) 셀 5 (3-col 병합 본문 셀) 의 첫 줄 시작에 있는
+    /// [푸코] inline rectangle Shape (treat_as_char=true).
+    ///
+    /// ps_id=19 ParaShape:
+    ///   - margin_left=1704 HU → 11.36 px
+    ///   - indent=+1980 HU → +13.20 px (positive first-line indent)
+    ///   - border_fill_id=1, alignment=Justify
+    ///
+    /// 기대 위치 (paragraph_layout 텍스트 경로와 일치):
+    ///   - cell_x (131.04) + margin_left (11.36) + indent (13.20) = 155.60 px
+    ///   - PDF (한컴 2010) 측정: ≈155.6 px ±2 px
+    ///
+    /// 현재 (수정 전):
+    ///   - inline_x = inner_area.x = 131.04 (margin/indent 미적용)
+    ///   - 텍스트 "는" 은 paragraph_layout 경로로 정확히 185.83 위치
+    ///   - shape rect 만 131.04 위치 (불일치)
+    ///
+    /// 본 테스트는 fix 적용 전 RED, fix 적용 후 GREEN.
+    #[test]
+    fn test_548_cell_inline_shape_first_line_indent_p8() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(7).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 8 SVG 가 비어있음");
+
+        // 페이지 8 셀 5 line 0 [푸코] rect 찾기:
+        //   - y in [685, 690] (셀 5 첫줄, vpos=0 + 작은 offset)
+        //   - width ≈ 30.23 (푸코 box width = curr_w 2267 HU)
+        //   - height ≈ 18.89 (푸코 box height = curr_h 1417 HU)
+        let mut puko_x: Option<f64> = None;
+        for chunk in svg.split("<rect ") {
+            let close = match chunk.find("/>") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let parse_attr = |name: &str| -> Option<f64> {
+                let key = format!("{}=\"", name);
+                let p = attrs.find(&key)? + key.len();
+                let q = attrs[p..].find('"')?;
+                attrs[p..p+q].parse::<f64>().ok()
+            };
+            let x = match parse_attr("x") { Some(v) => v, None => continue };
+            let y = match parse_attr("y") { Some(v) => v, None => continue };
+            let w = match parse_attr("width") { Some(v) => v, None => continue };
+            let h = match parse_attr("height") { Some(v) => v, None => continue };
+            if (w - 30.23).abs() < 0.5
+                && (h - 18.89).abs() < 0.5
+                && y > 685.0 && y < 690.0
+            {
+                puko_x = Some(x);
+                break;
+            }
+        }
+        let puko_x = puko_x.expect("페이지 8 셀 5 line 0 [푸코] rect 를 찾지 못함");
+
+        // PDF (한컴 2010) 기대값
+        let pdf_puko_x: f64 = 155.6;
+
+        assert!(
+            (puko_x - pdf_puko_x).abs() < 2.0,
+            "셀 5 line 0 [푸코] box left x={:.2} 가 PDF 기대값 {:.2} (±2 px) 와 \
+             일치해야 함. 버그(수정 전): puko_x=131.04 (-24.6 px, table_layout \
+             inline_x 가 effective_margin_left + first_line_indent 미적용).",
+            puko_x, pdf_puko_x
+        );
+    }
+
+    /// Task #544 v3: 박스 안 sequential paragraph 사이 line-spacing PDF 정합 검증.
+    /// p2 [4~6] pi=46 ("15세기 초 브루넬레스키...") 마지막 줄 → pi=47 ("고진에 따르면...")
+    /// 첫 줄 사이 gap. IR vpos delta = 1816 HU = 24.21 px (1 line spacing).
+    /// 수정 전 측정: gap=18.35 (drift -5.86 px, ls 의 일부 제외).
+    /// 수정 후 기대: gap=24.21 ±2.
+    ///
+    /// 본질: Task #479 trailing-ls 제외가 박스 안 sequential paragraph 끝에서
+    /// 작동 → Task #552 의 next_starts_border 가드가 박스 안 sequential 케이스
+    /// 처리 안 함. 새 가드 next_para_continues_visible_border (방법 1) 로 fix.
+    #[test]
+    fn test_544_v3_passage_inner_lspacing_p2_4_6() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(1).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 2 SVG 가 비어있음");
+
+        // pi=46 마지막 줄 ≈ y=382.17 (5줄, 285.32 + 4*24.21).
+        // pi=47 첫 글자 "고" ≈ y=400.52 (col 1, x>500).
+        // pi=46 마지막 줄 첫 글자: paragraph 본문에서 "15세기..." 의 5번째 줄.
+        // 단순화: col 1 (x>500) 영역의 y 범위 [380, 405] 의 unique y 들.
+        let mut text_ys: Vec<f64> = Vec::new();
+        for chunk in svg.split("<text ") {
+            let close = match chunk.find(">") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let key = "transform=\"translate(";
+            let p = match attrs.find(key) { Some(p) => p + key.len(), None => continue };
+            let q = match attrs[p..].find(')') { Some(q) => q, None => continue };
+            let coords = &attrs[p..p+q];
+            let parts: Vec<&str> = coords.split(',').collect();
+            if parts.len() != 2 { continue; }
+            let x: f64 = match parts[0].trim().parse() { Ok(v) => v, Err(_) => continue };
+            let y: f64 = match parts[1].trim().parse() { Ok(v) => v, Err(_) => continue };
+            if x > 500.0 && y > 380.0 && y < 410.0 {
+                text_ys.push(y);
+            }
+        }
+        let mut unique_ys: Vec<f64> = text_ys.into_iter().collect();
+        unique_ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        unique_ys.dedup_by(|a, b| (*a - *b).abs() < 0.5);
+
+        // 기대 (fix 후): y≈382.17 (pi=46 마지막 줄), y≈406.38 (pi=47 첫 줄). gap = 24.21 px.
+        // 수정 전: pi=47 첫 줄 y=400.52, gap=18.35 (drift -5.86).
+        assert!(unique_ys.len() >= 2,
+            "p2 [4~6] col 1 의 y 범위 [380, 410] 에서 두 줄을 찾아야 함 (실제 {:?})",
+            unique_ys);
+        let prev_last_y = unique_ys[0];
+        let next_first_y = unique_ys[1];
+        let gap = next_first_y - prev_last_y;
+
+        let pdf_gap: f64 = 24.21;  // 1 line spacing (1816 HU * 75⁻¹)
+        assert!(
+            (gap - pdf_gap).abs() < 2.0,
+            "p2 [4~6] pi=46 → pi=47 gap={:.2} px (prev_last_y={:.2}, next_first_y={:.2}) \
+             가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): gap=18.35 (-5.86 px, 박스 안 sequential paragraph 의 \
+             trailing-ls 일부 누락).",
+            gap, prev_last_y, next_first_y, pdf_gap
+        );
+    }
+
+    /// Task #544 v3: p10 [19~21] pi=208 ("조선 시대를 관통하여...") 마지막 줄
+    /// → pi=209 ("성리학의 논의가 본격화...") 첫 줄 gap.
+    /// 수정 전 측정: gap=14.67 (drift -9.55 px, trailing-ls 716 HU 완전 제외).
+    /// 수정 후 기대: gap=24.21 ±2.
+    #[test]
+    fn test_544_v3_passage_inner_lspacing_p10_19_21() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(9).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 10 SVG 가 비어있음");
+
+        // pi=208 마지막 줄 y=382.17 (5줄), pi=209 첫 줄 y=396.84.
+        let mut text_ys: Vec<f64> = Vec::new();
+        for chunk in svg.split("<text ") {
+            let close = match chunk.find(">") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let key = "transform=\"translate(";
+            let p = match attrs.find(key) { Some(p) => p + key.len(), None => continue };
+            let q = match attrs[p..].find(')') { Some(q) => q, None => continue };
+            let coords = &attrs[p..p+q];
+            let parts: Vec<&str> = coords.split(',').collect();
+            if parts.len() != 2 { continue; }
+            let x: f64 = match parts[0].trim().parse() { Ok(v) => v, Err(_) => continue };
+            let y: f64 = match parts[1].trim().parse() { Ok(v) => v, Err(_) => continue };
+            // p10 [19~21] 은 col 0 (x<500), y 범위 [380, 410] (fix 후 next 첫 줄 ≈406)
+            if x < 500.0 && x > 100.0 && y > 380.0 && y < 410.0 {
+                text_ys.push(y);
+            }
+        }
+        let mut unique_ys: Vec<f64> = text_ys.into_iter().collect();
+        unique_ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        unique_ys.dedup_by(|a, b| (*a - *b).abs() < 0.5);
+
+        assert!(unique_ys.len() >= 2,
+            "p10 [19~21] col 0 의 y 범위 [380, 410] 에서 두 줄을 찾아야 함 (실제 {:?})",
+            unique_ys);
+        let prev_last_y = unique_ys[0];
+        let next_first_y = unique_ys[1];
+        let gap = next_first_y - prev_last_y;
+
+        let pdf_gap: f64 = 24.21;
+        assert!(
+            (gap - pdf_gap).abs() < 2.0,
+            "p10 [19~21] pi=208 → pi=209 gap={:.2} px (prev_last_y={:.2}, \
+             next_first_y={:.2}) 가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): gap=14.67 (-9.55 px, trailing-ls 716 HU 완전 제외).",
+            gap, prev_last_y, next_first_y, pdf_gap
+        );
+    }
+
+    /// Task #544 v3: p11 [22~24] pi=234 ("빈곤 퇴치와 경제성장...") 마지막 줄
+    /// → pi=235 ("제도의 역할을 강조...") 첫 줄 gap.
+    /// 수정 전 측정: gap=14.66 (drift -9.55 px, trailing-ls 완전 제외).
+    /// 수정 후 기대: gap=24.21 ±2.
+    #[test]
+    fn test_544_v3_passage_inner_lspacing_p11_22_24() {
+        let Some(core) = load_document("samples/21_언어_기출_편집가능본.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(10).unwrap_or_default();
+        assert!(!svg.is_empty(), "페이지 11 SVG 가 비어있음");
+
+        // pi=234 마지막 줄 y=551.67 (12줄), pi=235 첫 줄 y=566.33.
+        let mut text_ys: Vec<f64> = Vec::new();
+        for chunk in svg.split("<text ") {
+            let close = match chunk.find(">") { Some(p) => p, None => continue };
+            let attrs = &chunk[..close];
+            let key = "transform=\"translate(";
+            let p = match attrs.find(key) { Some(p) => p + key.len(), None => continue };
+            let q = match attrs[p..].find(')') { Some(q) => q, None => continue };
+            let coords = &attrs[p..p+q];
+            let parts: Vec<&str> = coords.split(',').collect();
+            if parts.len() != 2 { continue; }
+            let x: f64 = match parts[0].trim().parse() { Ok(v) => v, Err(_) => continue };
+            let y: f64 = match parts[1].trim().parse() { Ok(v) => v, Err(_) => continue };
+            // p11 [22~24] 은 col 1 (x>500), y 범위 [549, 580] (fix 후 next 첫 줄 ≈575.88)
+            if x > 500.0 && y > 549.0 && y < 580.0 {
+                text_ys.push(y);
+            }
+        }
+        let mut unique_ys: Vec<f64> = text_ys.into_iter().collect();
+        unique_ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+        unique_ys.dedup_by(|a, b| (*a - *b).abs() < 0.5);
+
+        assert!(unique_ys.len() >= 2,
+            "p11 [22~24] col 1 의 y 범위 [549, 580] 에서 두 줄을 찾아야 함 (실제 {:?})",
+            unique_ys);
+        let prev_last_y = unique_ys[0];
+        let next_first_y = unique_ys[1];
+        let gap = next_first_y - prev_last_y;
+
+        let pdf_gap: f64 = 24.21;
+        assert!(
+            (gap - pdf_gap).abs() < 2.0,
+            "p11 [22~24] pi=234 → pi=235 gap={:.2} px (prev_last_y={:.2}, \
+             next_first_y={:.2}) 가 PDF 기대값 {:.2} (±2 px) 와 일치해야 함. \
+             버그(수정 전): gap=14.66 (-9.55 px, trailing-ls 716 HU 완전 제외).",
+            gap, prev_last_y, next_first_y, pdf_gap
         );
     }
 }

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -13,7 +13,14 @@ use super::super::{TextStyle, ShapeStyle, TabStop, hwpunit_to_px, px_to_hwpunit,
 use super::{LayoutEngine, CellContext};
 use super::text_measurement::{resolved_to_text_style, estimate_text_width, compute_char_positions, extract_tab_leaders_with_extended, find_next_tab_stop};
 use super::border_rendering::create_border_line_nodes;
-use super::utils::{resolve_numbering_id, expand_numbering_format, numbering_format_to_number_format, find_bin_data};
+use super::utils::{resolve_numbering_id, expand_numbering_format, numbering_format_to_number_format, find_bin_data, extract_shape_transform};
+
+/// `RHWP_LAYOUT_DEBUG=1` 로 활성화되는 layout 디버그 로깅 여부.
+/// Phase 1 (#517) — 본질 정정 (#467/#491/#496) 시 결함 측정·재현 자동화에 사용.
+#[inline]
+pub(crate) fn layout_debug_enabled() -> bool {
+    std::env::var("RHWP_LAYOUT_DEBUG").map(|v| v == "1").unwrap_or(false)
+}
 
 /// lineseg baseline_distance를 폰트 어센트 기준으로 보정한다.
 /// CENTER 문단 수직정렬 등으로 baseline이 50% 이하로 설정된 경우,
@@ -115,6 +122,31 @@ impl LayoutEngine {
                 None
             })
             .collect();
+
+        // [Task #517 Stage 1] RHWP_LAYOUT_DEBUG 진단 로깅
+        if layout_debug_enabled() {
+            eprintln!(
+                "LAYOUT_INLINE_TABLE_PARA: pi={} sec={} col_x={:.1} col_w={:.1} y_start={:.1} y={:.1} sb={:.1} sa={:.1} ml={:.1} mr={:.1} align={:?} ls_count={} tables={}",
+                para_index, section_index, col_area.x, col_area.width, y_start, y,
+                spacing_before, spacing_after, margin_left, margin_right, alignment,
+                para.line_segs.len(), inline_tables.len(),
+            );
+            for (li, seg) in para.line_segs.iter().enumerate() {
+                eprintln!(
+                    "  LAYOUT_LS[{}]: vpos={} lh={} ls={} bl={} text_start={} sw={}",
+                    li, seg.vertical_pos, seg.line_height, seg.line_spacing,
+                    seg.baseline_distance, seg.text_start, seg.segment_width,
+                );
+            }
+            for (ti, (ci, tbl)) in inline_tables.iter().enumerate() {
+                eprintln!(
+                    "  LAYOUT_INLINE_TBL[{}]: ctrl_idx={} rows={} cols={} w={} h={} vert={:?} horz={:?} wrap={:?}",
+                    ti, ci, tbl.row_count, tbl.col_count,
+                    tbl.common.width, tbl.common.height,
+                    tbl.common.vert_align, tbl.common.horz_align, tbl.common.text_wrap,
+                );
+            }
+        }
 
         // 3. char_offsets 갭 분석으로 텍스트 세그먼트 분할
         // 확장 컨트롤은 8 UTF-16 코드 유닛을 차지
@@ -259,54 +291,47 @@ impl LayoutEngine {
             baseline_dist * 1.5
         };
 
-        // LINE_SEG 기반 줄 나눔 위치 결정:
-        // ls[1].text_start가 있으면 해당 UTF-16 위치에서 줄 나눔 (한컴 저장값 존재)
-        // ls[1]이 없으면 자체 right_margin 기반 줄 나눔 (동적 reflow)
-        let line_break_char_idx: Option<usize> = if para.line_segs.len() > 1 {
-            let ts = para.line_segs[1].text_start as u32;
-            // UTF-16 text_start를 char index로 변환 (제어문자 갭 보정)
-            // text_start는 제어문자 8 code unit 포함한 절대 UTF-16 위치
-            let mut utf16_pos = 0u32;
-            let mut ctrl_gap = 0u32;
-            // char_offsets에서 제어문자 갭 계산
-            if !para.char_offsets.is_empty() {
-                let first_offset = para.char_offsets[0];
-                ctrl_gap += first_offset; // 선행 컨트롤
-                for i in 1..para.char_offsets.len() {
-                    let prev_len = if text_chars[i-1] >= '\u{10000}' { 2u32 } else { 1 };
-                    let gap = para.char_offsets[i] - para.char_offsets[i-1];
-                    if gap > prev_len + 4 {
-                        ctrl_gap += gap - prev_len; // 중간 컨트롤 갭
+        // [Task #518 Phase 2] LINE_SEG 기반 줄 나눔 위치 결정:
+        // ls[1..] 의 text_start (raw UTF-16 위치, controls 포함) 를 char index 로 변환.
+        // char_offsets[i] = text_chars[i] 의 원본 UTF-16 위치 → char_offsets[i] >= ts 인 첫 i 가 break.
+        //
+        // 이전: ctrl_gap 을 paragraph 전체 controls 합으로 over-subtract → controls 가 있는
+        // paragraph 에서 saturating 0 으로 항상 break 미감지 (#496 케이스).
+        // 이전: ls[1] 만 사용. 다중 줄 paragraph 에서 ls[2..] 무시 → dynamic reflow.
+        let line_break_char_indices: Vec<usize> = if para.line_segs.len() > 1
+            && !para.char_offsets.is_empty()
+        {
+            let mut indices: Vec<usize> = Vec::new();
+            for ls in para.line_segs.iter().skip(1) {
+                let ts = ls.text_start as u32;
+                // char_offsets[i] >= ts 인 첫 i (= text_chars 의 break 위치)
+                let char_idx = para.char_offsets.iter().position(|&off| off >= ts)
+                    .unwrap_or(text_chars.len());
+                if char_idx > 0 && char_idx <= text_chars.len() {
+                    // 단조 증가 보장 (이전 break 보다 큰 경우에만 추가)
+                    if indices.last().map(|&prev| char_idx > prev).unwrap_or(true) {
+                        indices.push(char_idx);
                     }
                 }
             }
-            // text_start에서 ctrl_gap을 빼서 순수 텍스트 char index 추정
-            let text_only_ts = ts.saturating_sub(ctrl_gap);
-            // UTF-16 → char index 변환
-            let mut char_idx = 0usize;
-            let mut u16_accum = 0u32;
-            for (i, ch) in text_chars.iter().enumerate() {
-                if u16_accum >= text_only_ts {
-                    char_idx = i;
-                    break;
-                }
-                u16_accum += if *ch >= '\u{10000}' { 2 } else { 1 };
-                char_idx = i + 1;
-            }
-            if char_idx > 0 && char_idx <= text_chars.len() {
-                Some(char_idx)
-            } else {
-                None
-            }
+            indices
         } else {
-            None
+            Vec::new()
         };
+        if layout_debug_enabled() {
+            eprintln!(
+                "  LAYOUT_BREAK_INDICES: pi={} indices={:?} (from ls[1..])",
+                para_index, line_break_char_indices,
+            );
+        }
 
         let mut inline_x = start_x;
         let mut current_y = y;
         let mut table_idx = 0;
         let mut max_table_bottom = y; // 표의 최대 하단 y (표 높이를 줄 높이로 사용하기 위함)
         let mut wrapped_below_table = false; // 텍스트가 표 아래로 줄바꿈되었는지
+        // [Task #518] 다음 break 인덱스 (line_break_char_indices 안에서)
+        let mut next_break: usize = 0;
 
         for (s, e) in &segments {
             // 텍스트 세그먼트 렌더링 (줄바꿈 지원)
@@ -398,9 +423,13 @@ impl LayoutEngine {
                         let ch_w = estimate_text_width(&ch.to_string(), &ts);
 
                         // char_shape 변경 또는 줄바꿈 시 누적된 run을 출력
-                        // LINE_SEG 기반 줄 나눔: text_start 위치에서 강제 개행
-                        let need_wrap = if let Some(break_idx) = line_break_char_idx {
-                            ch_idx >= break_idx && !wrapped_below_table
+                        // [Task #518] LINE_SEG 기반 줄 나눔: ls[1..] 의 text_start 위치 모두 사용.
+                        // break 가 모두 소진되거나 미존재 시 right_margin 동적 reflow 로 fallback.
+                        let need_wrap = if next_break < line_break_char_indices.len()
+                            && ch_idx >= line_break_char_indices[next_break]
+                        {
+                            next_break += 1;
+                            true
                         } else {
                             inline_x + ch_w > right_margin + 0.5 && inline_x > line_start_x + 1.0
                         };
@@ -661,31 +690,14 @@ impl LayoutEngine {
         let box_margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
         let indent = para_style.map(|s| s.indent).unwrap_or(0.0);
 
-        // 문단에 시각적 테두리(stroke 있는 border)가 있고 border_spacing 좌/우가 0인
-        // 파일의 경우, 한컴은 paragraph margin 값을 inner padding으로도 사용하여
-        // 텍스트가 테두리에 붙지 않도록 한다. rhwp는 동일 효과를 내기 위해 텍스트
-        // 위치 계산에 사용하는 margin 값에만 inner padding을 더하고, 박스(테두리)
-        // 위치는 원래 margin 값을 그대로 사용한다.
-        // 배경(fill)만 있는 문단은 영향 받지 않도록 stroke 유무를 확인한다.
-        let para_border_fill_id_pre = para_style.map(|s| s.border_fill_id).unwrap_or(0);
-        let has_visible_stroke = if para_border_fill_id_pre > 0 {
-            let idx = (para_border_fill_id_pre as usize).saturating_sub(1);
-            styles.border_styles.get(idx)
-                .map(|bs| bs.borders.iter().any(|b|
-                    !matches!(b.line_type, crate::model::style::BorderLineType::None) && b.width > 0))
-                .unwrap_or(false)
-        } else {
-            false
-        };
-        let bs_left_px = para_style.map(|s| s.border_spacing[0]).unwrap_or(0.0);
-        let bs_right_px = para_style.map(|s| s.border_spacing[1]).unwrap_or(0.0);
-        let (inner_pad_left, inner_pad_right) = if has_visible_stroke && bs_left_px == 0.0 && bs_right_px == 0.0 {
-            (box_margin_left, box_margin_right)
-        } else {
-            (0.0, 0.0)
-        };
-        let margin_left = box_margin_left + inner_pad_left;
-        let margin_right = box_margin_right + inner_pad_right;
+        // [Task #547] paragraph margin_left/right 는 텍스트 좌/우 inset 으로 한 번만
+        // 적용. Task #544 후 box outline = col_area (margin 미적용) 이므로 박스 안
+        // 좌측 여백 = box_margin_left (PDF 한컴 2010 정합).
+        // 이전 코드는 paragraph border + border_spacing=0 인 경우 inner_pad_left =
+        // box_margin_left 로 한 번 더 더해 이중 inset 부작용 발생 (Task #544 전 박스도
+        // margin 적용했을 때만 의미가 있던 분기).
+        let margin_left = box_margin_left;
+        let margin_right = box_margin_right;
         let alignment = para_style.map(|s| s.alignment).unwrap_or(Alignment::Justify);
         let spacing_before = para_style.map(|s| s.spacing_before).unwrap_or(0.0);
         let spacing_after = para_style.map(|s| s.spacing_after).unwrap_or(0.0);
@@ -1794,6 +1806,7 @@ impl LayoutEngine {
                                             brightness: pic.image_attr.brightness,
                                             contrast: pic.image_attr.contrast,
                                             text_wrap: Some(pic.common.text_wrap),
+                                            transform: extract_shape_transform(&pic.shape_attr),
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -2068,6 +2081,7 @@ impl LayoutEngine {
                                         brightness: pic.image_attr.brightness,
                                         contrast: pic.image_attr.contrast,
                                         text_wrap: Some(pic.common.text_wrap),
+                                        transform: extract_shape_transform(&pic.shape_attr),
                                         ..ImageNode::new(bin_data_id, image_data)
                                     }),
                                     BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -2178,6 +2192,7 @@ impl LayoutEngine {
                                             brightness: pic.image_attr.brightness,
                                             contrast: pic.image_attr.contrast,
                                             text_wrap: Some(pic.common.text_wrap),
+                                            transform: extract_shape_transform(&pic.shape_attr),
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(img_x, img_y, tac_w, pic_h),
@@ -2601,17 +2616,36 @@ impl LayoutEngine {
             }
 
             col_node.children.push(line_node);
-            // 줄간격 적용:
+            // [Issue #479] 줄간격 적용:
             //   - 셀 내 마지막 문단의 마지막 줄: trailing line_spacing 제외
             //     (셀 높이 모델은 trailing 미포함, 셀 내부와 정합)
-            //   - 그 외 모든 줄(본문 단락의 마지막 줄 포함): trailing line_spacing 가산
-            //     pagination/engine.rs 의 current_height 누적(para_height = sum(lh+ls))
-            //     과 정합. (Task #452: 이전 #332 의 layout-only trailing 제외 →
-            //     pagination 과 1 ls drift 발생 → 회복)
+            //   - 본문(셀 외부) paragraph 의 마지막 줄(end == composed.lines.len()):
+            //     trailing line_spacing 제외 — HWP vpos 기준 paragraph 영역 = lh_sum + (n-1)*ls.
+            //     typeset.rs:802 의 total_height 와 정합.
+            //   - 셀 내부 비-마지막 paragraph: line_spacing 가산 (셀 안 paragraph 사이 정상 spacing 유지).
+            //   - 그 외 (paragraph 내 중간 줄 또는 PartialParagraph 의 비-끝 줄): line_spacing 가산
+            //
+            // 이전 Task #452 의 layout-only trailing 제외는 pagination 과 drift 를 만들었으나,
+            // 본 task #479 는 typeset.rs 의 누적도 함께 trailing 제외로 변경하여 정합.
             let is_cell_last_line = is_last_cell_para && line_idx + 1 >= end;
+            let is_full_paragraph_end = line_idx + 1 >= end && end >= composed.lines.len();
+            // [Task #552] 본문 paragraph 마지막 줄에서 다음 paragraph 가 visible border
+            // 시작이면 trailing ls 보존 (Task #479 의 trailing ls 제외 → 박스 top 이
+            // header 텍스트 바로 아래 붙는 회귀 정정). caller 가 next_para_starts_visible_border
+            // 플래그 set 후 본 함수 호출.
+            // [Task #544 v3] 박스 안 sequential paragraph (prev/next 같은 박스 outline)
+            // 사이도 trailing ls 보존 — Task #552 가 박스 시작 직전만 처리, 박스 안
+            // sequential 영역 미처리 → -9.55 px (또는 부분) drift 회귀 영역.
+            let next_starts_border = self.next_para_starts_visible_border.get();
+            let next_continues_border = self.next_para_continues_visible_border.get();
             if is_cell_last_line && cell_ctx.is_some() {
                 y += line_height;
+            } else if is_full_paragraph_end && cell_ctx.is_none()
+                && !next_starts_border && !next_continues_border {
+                // 셀 외부 paragraph 의 마지막 줄 (#479)
+                y += line_height;
             } else {
+                // [Task #552/#544 v3] border-start / border-continues 직전 마지막 줄: trailing ls 보존
                 let line_spacing_px = hwpunit_to_px(comp_line.line_spacing, self.dpi);
                 y += line_height + line_spacing_px;
             }
@@ -2638,10 +2672,14 @@ impl LayoutEngine {
                 // override 가 활성된 경우(wrap host), 박스 우측은 floating 표의 끝
                 // 까지 확장된 width 그대로 사용 — margin_right 차감하지 않는다
                 // (그렇지 않으면 표가 박스 밖으로 다시 튀어나옴).
+                // [Task #544] paragraph margin_left/right 는 텍스트 inset 으로만 사용,
+                // 박스 outline 좌표는 col_area 전체 (PDF 정합). wrap=Square 호스트
+                // (border_box_override) 케이스는 layout_wrap_around_paras 가 설정한
+                // override 좌표 그대로 사용 (margin 미적용).
                 let (box_x, box_w) = if let Some((ox, ow)) = self.border_box_override.get() {
-                    (ox + box_margin_left, ow - box_margin_left)
+                    (ox, ow)
                 } else {
-                    (col_area.x + box_margin_left, col_area.width - box_margin_left - box_margin_right)
+                    (col_area.x, col_area.width)
                 };
                 self.para_border_ranges.borrow_mut().push(
                     (para_border_fill_id, box_x, bg_y_start, box_w, y, top_inset, bottom_inset, is_partial_start, is_partial_end, para_index)

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -14,7 +14,7 @@ use super::super::style_resolver::ResolvedStyleSet;
 use super::super::{hwpunit_to_px, StrokeDash, LineStyle, TextStyle, AutoNumberCounter, format_number, NumberFormat as NumFmt};
 use super::LayoutEngine;
 use super::border_rendering::border_width_to_px;
-use super::utils::find_bin_data;
+use super::utils::{extract_shape_transform, find_bin_data};
 use super::text_measurement::{resolved_to_text_style, estimate_text_width};
 
 impl LayoutEngine {
@@ -114,6 +114,7 @@ impl LayoutEngine {
                 brightness: picture.image_attr.brightness,
                 contrast: picture.image_attr.contrast,
                 text_wrap: Some(picture.common.text_wrap),
+                transform: extract_shape_transform(&picture.shape_attr),
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(pic_x, pic_y, pic_width, pic_height),
@@ -324,6 +325,7 @@ impl LayoutEngine {
                 brightness: picture.image_attr.brightness,
                 contrast: picture.image_attr.contrast,
                 text_wrap: Some(picture.common.text_wrap),
+                transform: extract_shape_transform(&picture.shape_attr),
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -13,7 +13,7 @@ use super::super::{hwpunit_to_px, TextStyle, ShapeStyle};
 use super::{LayoutEngine, CellContext, CellPathEntry};
 use super::border_rendering::{build_row_col_x, collect_cell_borders, render_edge_borders, render_transparent_borders};
 use super::text_measurement::{resolved_to_text_style, is_cjk_char, is_vertical_rotate_char, vertical_substitute_char};
-use super::utils::find_bin_data;
+use super::utils::{extract_shape_transform, find_bin_data};
 
 impl LayoutEngine {
     /// 세로쓰기 셀의 텍스트를 수직 방향으로 배치한다.
@@ -641,7 +641,7 @@ impl LayoutEngine {
                                     control_index: Some(ctrl_idx),
                                     fill_mode: None,
                                     original_size: None,
-                                    transform: ShapeTransform::default(),
+                                    transform: extract_shape_transform(&pic.shape_attr),
                                     crop: None,
                                     original_size_hu: None,
                                     effect: pic.image_attr.effect,

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -10,6 +10,23 @@ use super::super::page_layout::LayoutRect;
 use super::super::height_measurer::MeasuredTable;
 use super::super::composer::{compose_paragraph, ComposedParagraph};
 use super::super::style_resolver::ResolvedStyleSet;
+
+/// [Task #548] paragraph 의 line N 에 적용되는 effective margin_left.
+/// paragraph_layout.rs 의 line_indent 산식과 동일 (단일 룰).
+/// - positive indent: line 0 에만 +indent 적용 (첫줄 들여쓰기)
+/// - negative indent (hanging): line N≥1 에 +|indent| 적용
+/// - indent=0: 모든 line 에 margin_left 만 적용
+fn effective_margin_left_line(margin_left: f64, indent: f64, line_n: usize) -> f64 {
+    let line_indent = if indent > 0.0 {
+        if line_n == 0 { indent } else { 0.0 }
+    } else if indent < 0.0 {
+        if line_n == 0 { 0.0 } else { indent.abs() }
+    } else {
+        0.0
+    };
+    margin_left + line_indent
+}
+
 use super::super::{hwpunit_to_px, ShapeStyle};
 use super::{LayoutEngine, CellContext, CellPathEntry};
 use super::border_rendering::{build_row_col_x, collect_cell_borders, render_cell_diagonal, render_edge_borders, render_transparent_borders};
@@ -1492,6 +1509,17 @@ impl LayoutEngine {
                     .get(para.para_shape_id as usize)
                     .map(|s| s.alignment)
                     .unwrap_or(Alignment::Left);
+                // [Task #548] paragraph margin_left + first-line indent 를 inline shape
+                // 위치에 반영. paragraph_layout 텍스트 경로와 동일한 effective_margin_left
+                // 산식을 적용해 텍스트와 shape 위치 일관성 보장.
+                let para_margin_left_px = styles.para_styles
+                    .get(para.para_shape_id as usize)
+                    .map(|s| s.margin_left)
+                    .unwrap_or(0.0);
+                let para_indent_px = styles.para_styles
+                    .get(para.para_shape_id as usize)
+                    .map(|s| s.indent)
+                    .unwrap_or(0.0);
 
                 let mut prev_tac_text_pos: usize = 0;
                 // LINE_SEG 기반 줄별 TAC 이미지 배치를 위한 상태
@@ -1501,6 +1529,7 @@ impl LayoutEngine {
                 let mut current_tac_line: usize = 0;
                 let mut inline_x = {
                     let line_w = tac_line_widths.first().copied().unwrap_or(total_inline_width);
+                    let line_margin = effective_margin_left_line(para_margin_left_px, para_indent_px, 0);
                     match para_alignment {
                         Alignment::Center | Alignment::Distribute => {
                             inner_area.x + (inner_area.width - line_w).max(0.0) / 2.0
@@ -1508,7 +1537,7 @@ impl LayoutEngine {
                         Alignment::Right => {
                             inner_area.x + (inner_area.width - line_w).max(0.0)
                         }
-                        _ => inner_area.x,
+                        _ => inner_area.x + line_margin,
                     }
                 };
                 let mut tac_img_y = para_y_before_compose;
@@ -1551,6 +1580,9 @@ impl LayoutEngine {
                                         // 줄이 바뀜: inline_x 리셋, y를 LINE_SEG vpos 기준으로 이동
                                         current_tac_line = target_line;
                                         let line_w = tac_line_widths.get(target_line).copied().unwrap_or(0.0);
+                                        // [Task #548] target_line 의 effective_margin_left 적용
+                                        let line_margin = effective_margin_left_line(
+                                            para_margin_left_px, para_indent_px, target_line);
                                         inline_x = match para_alignment {
                                             Alignment::Center | Alignment::Distribute => {
                                                 inner_area.x + (inner_area.width - line_w).max(0.0) / 2.0
@@ -1558,10 +1590,15 @@ impl LayoutEngine {
                                             Alignment::Right => {
                                                 inner_area.x + (inner_area.width - line_w).max(0.0)
                                             }
-                                            _ => inner_area.x,
+                                            _ => inner_area.x + line_margin,
                                         };
                                         if let Some(seg) = para.line_segs.get(target_line) {
-                                            tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+                                            // [Task #520] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+                                            // para_y_before_compose 에는 이미 ls[0].vpos 가 누적되어 있으므로
+                                            // 상대 오프셋(seg.vpos - ls[0].vpos)만 더해야 이중 합산을 피한다.
+                                            let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+                                            tac_img_y = para_y_before_compose
+                                                + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
                                         }
                                     }
 
@@ -1613,6 +1650,49 @@ impl LayoutEngine {
                         Control::Shape(shape) => {
                             if shape.common().treat_as_char {
                                 let shape_w = hwpunit_to_px(shape.common().width as i32, self.dpi);
+                                // [Task #500] Picture 분기와 정합: target_line 산출 + 줄 변경 시
+                                // inline_x/tac_img_y 리셋. multi-line paragraph 에서 사각형이
+                                // ls[1]+ 에 있을 때 paragraph 첫 줄 좌표가 잘못 사용되던 결함 정정.
+                                let target_line = if all_runs_empty && para.line_segs.len() > 1 {
+                                    let li = tac_seq_index.min(para.line_segs.len() - 1);
+                                    tac_seq_index += 1;
+                                    li
+                                } else {
+                                    composed.tac_controls.iter()
+                                        .find(|&&(_, _, ci)| ci == ctrl_idx)
+                                        .map(|&(abs_pos, _, _)| {
+                                            composed.lines.iter().enumerate()
+                                                .rev()
+                                                .find(|(_, line)| abs_pos >= line.char_start)
+                                                .map(|(li, _)| li)
+                                                .unwrap_or(0)
+                                        })
+                                        .unwrap_or(0)
+                                };
+                                if target_line > current_tac_line {
+                                    current_tac_line = target_line;
+                                    let line_w = tac_line_widths.get(target_line).copied().unwrap_or(0.0);
+                                    // [Task #548] target_line 의 effective_margin_left 적용
+                                    let line_margin = effective_margin_left_line(
+                                        para_margin_left_px, para_indent_px, target_line);
+                                    inline_x = match para_alignment {
+                                        Alignment::Center | Alignment::Distribute => {
+                                            inner_area.x + (inner_area.width - line_w).max(0.0) / 2.0
+                                        }
+                                        Alignment::Right => {
+                                            inner_area.x + (inner_area.width - line_w).max(0.0)
+                                        }
+                                        _ => inner_area.x + line_margin,
+                                    };
+                                    if let Some(seg) = para.line_segs.get(target_line) {
+                                        // [Task #520] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+                                        // para_y_before_compose 에 이미 ls[0].vpos 가 누적되어 있어
+                                        // 상대 오프셋만 더해야 한다 (Picture 분기와 동일).
+                                        let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+                                        tac_img_y = para_y_before_compose
+                                            + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
+                                    }
+                                }
                                 // Shape 앞의 텍스트 너비 계산: tac_controls에서 이 Shape의 text_pos와
                                 // 이전 Shape의 text_pos 차이에 해당하는 텍스트 너비를 inline_x에 반영
                                 if let Some(&(tac_pos, _, _)) = composed.tac_controls.iter().find(|&&(_, _, ci)| ci == ctrl_idx) {
@@ -1698,11 +1778,11 @@ impl LayoutEngine {
                                 }
                                 let shape_area = LayoutRect {
                                     x: inline_x,
-                                    y: para_y_before_compose,
+                                    y: tac_img_y,
                                     width: shape_w,
                                     height: inner_area.height,
                                 };
-                                self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, para_y_before_compose, Alignment::Left, styles, bin_data_content);
+                                self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, tac_img_y, Alignment::Left, styles, bin_data_content);
                                 inline_x += shape_w;
                             } else {
                                 self.layout_cell_shape(tree, &mut cell_node, shape, &inner_area, para_y, para_alignment, styles, bin_data_content);

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -630,7 +630,10 @@ impl Paginator {
         // 다단 레이아웃에서 문단 내 단 경계 감지
         // [Task #459] on_first_multicolumn_page 가드 제거: 다단 구역이 여러 페이지에 걸칠 때
         // 후속 페이지에서도 LINE_SEG vpos-reset 으로 인코딩된 단 경계를 인식해야 함.
-        let col_breaks = if st.col_count > 1 && st.current_column == 0 {
+        // [Task #464] current_column == 0 가드 제거: col 1 (마지막 단) 에서도
+        // vpos-reset 인코딩된 col_break 를 감지해 페이지 break 를 트리거.
+        // paginate_multicolumn_paragraph 는 이미 advance_column_or_new_page 사용.
+        let col_breaks = if st.col_count > 1 {
             Self::detect_column_breaks_in_paragraph(para)
         } else {
             vec![0]

--- a/src/renderer/svg/tests.rs
+++ b/src/renderer/svg/tests.rs
@@ -285,7 +285,8 @@ fn test_compute_image_crop_src_no_crop_full_image() {
 
 #[test]
 fn test_compute_image_crop_src_offset_top_left() {
-    // 좌·상단을 잘라낸 케이스: top=ow/4, left=ow/4 → 우하단 75% 영역
+    // [Task #473] 좌·상단을 잘라낸 케이스. orig=(4000,2500) / img=(400,250) = 10 HU/px.
+    // 75 ± 5% 범위 밖이라 96-DPI 관행 (75 HU/px) fallback 적용.
     let (sx, sy, sw, sh) = compute_image_crop_src(
         (1000, 500, 4000, 2500),
         Some((4000, 2500)),

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -824,12 +824,15 @@ impl TypesetEngine {
             (vec![hwpunit_to_px(400, self.dpi)], vec![0.0])
         };
 
+        // [Issue #479 옵션 3] paginator 의 누적은 trailing_ls 포함된 옛 total_height 유지.
+        // — paragraph 사이 gap 보존 → k-water-rfp p3 paragraph 영역 침범 회피.
+        // 단 layout 측은 paragraph 마지막 줄에서 trailing_ls 제외 (paragraph_layout.rs:2557)
+        // — paragraph 가 정확한 vpos 위치에 그려지도록 함.
+        // fit 판정은 height_for_fit (trailing_ls 제외) 사용 (#359 의도).
         let lines_total: f64 = line_heights.iter().zip(line_spacings.iter())
             .map(|(h, s)| h + s)
             .sum();
         let total_height = spacing_before + lines_total + spacing_after;
-
-        // 적합성 판단용: trailing line_spacing 제외
         let trailing_ls = line_spacings.last().copied().unwrap_or(0.0);
         let height_for_fit = (total_height - trailing_ls).max(0.0);
 
@@ -926,7 +929,9 @@ impl TypesetEngine {
         // 다단 레이아웃에서 문단 내 단 경계 감지
         // [Task #459] on_first_multicolumn_page 가드 제거: 다단 구역이 여러 페이지에 걸칠 때
         // 후속 페이지에서도 LINE_SEG vpos-reset 으로 인코딩된 단 경계를 인식해야 함.
-        let col_breaks = if st.col_count > 1 && st.current_column == 0 {
+        // [Task #464] current_column == 0 가드 제거: col 1 (마지막 단) 에서도
+        // vpos-reset 인코딩된 col_break 를 감지해 페이지 break 를 트리거.
+        let col_breaks = if st.col_count > 1 {
             Self::detect_column_breaks_in_paragraph(para)
         } else {
             vec![0]
@@ -2005,13 +2010,13 @@ impl TypesetEngine {
             }
             st.current_height += part_height;
 
-            // 마지막 단이 아니면 다음 단으로 flush
+            // 다음 col_break 가 있으면 다음 단 또는 새 페이지로 이동.
+            // [Task #464] 마지막 단(col 1)에서 col_break 발생 시에도 페이지 break 를
+            // 트리거하도록 advance_column_or_new_page 통합 호출 사용
+            // (이전 코드는 단 변경만 처리하고 페이지 break 미처리 → col 1 의 후속 lines 가
+            //  같은 단에 누적되어 overflow 발생).
             if bi + 1 < col_breaks.len() {
-                st.flush_column();
-                if st.current_column + 1 < st.col_count {
-                    st.current_column += 1;
-                    st.current_height = 0.0;
-                }
+                st.advance_column_or_new_page();
             }
         }
     }


### PR DESCRIPTION
스테이지된 src/renderer/ 변경 일괄 커밋:
- #517: RHWP_LAYOUT_DEBUG 진단 로깅 (paragraph_layout)
- #518: LINE_SEG ls[1..] 다중 break 인덱스 사용 (controls 갭 over-subtract 수정)
- #544 v3: 박스 안 sequential paragraph 사이 trailing-ls 보존
- #552: visible border 시작 직전 paragraph trailing-ls 보존
- 부수: layout/typeset/pagination integration tests, table_layout 보강

