### PR TITLE
Task #565 exam_science.hwp 12/15/18/19번 인라인 수식(Equation, treat_as_char) 미렌더 정정

### DIFF
--- a/mydocs/orders/20260504.md
+++ b/mydocs/orders/20260504.md
@@ -1,0 +1,35 @@
+# 오늘 할일 - 2026년 5월 4일
+
+## M100 — v1.0.0 조판 엔진
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **#565** | exam_science.hwp 12/15/18/19번 인라인 수식(treat_as_char Equation) 미렌더 정정 | **완료 (Stage 4 시각 판정 대기)** | 본질 결함: `layout.rs::layout_column_item` `has_inline_tables=TRUE` 분기가 `layout_inline_table_paragraph` 호출 → 이 함수는 인라인 수식/treat_as_char Picture/Shape 무시 → `inline_shape_position` 미등록 → `shape_layout` fallback (col_area.x, para_y) 으로 9개 수식이 동일 좌표 (534.8, 1218.106) 에 겹침. 정정: `has_inline_tables && !has_other_inline_ctrls` 로 가드 강화 — 인라인 표 + 인라인 수식/treat_as_char Picture/Shape 동시 케이스는 일반 `layout_paragraph` 로 보내 `run_tacs / inline_x` 체계로 정상 배치. 변경 LOC: `src/renderer/layout.rs` +13/-1. 검증: cargo test --lib 1125 / svg_snapshot 6/6 / 광범위 sweep 15 fixture 274 페이지 중 271 byte-identical + 3 의도 정정 (exam_science 002/003/004) / clippy 신규 0. WASM 빌드 본 세션 미가동 — Stage 4 보강. 처리 보고서: `mydocs/report/task_m100_565_report.md`. 수행/구현 계획서 + Stage 1/3 보고서 누적. |
+| **#566** | exam_science.hwp 7번 표 셀 내부 ㉠/㉡ 베이스라인 위로 시프트 | **신규 — 별도 task** | 작업지시자 보고. 본질이 #565 (인라인 수식) 와 별개 — 셀 내부 paragraph baseline 또는 cs 글자 시프트 또는 valign=Top 처리. 진단 권고: `export-svg --debug-overlay -p 0` 으로 실제 y 좌표 비교. M100 milestone 등록. |
+
+## 신규 이슈
+
+| Issue | 제목 | 비고 |
+|------|------|------|
+| **#565** | [m100] exam_science.hwp 12/15/18/19번 인라인 수식(Equation, treat_as_char) 미렌더 — 텍스트 라인에 빈 자리만 표시 | 작업지시자 보고 — 본 task 처리 완료 (Stage 4 시각 판정 대기) |
+| **#566** | [m100] exam_science.hwp 7번 표 셀 내부 ㉠/㉡ 베이스라인 위치가 위로 시프트됨 | 작업지시자 보고 — 별도 task 등록. 본 task 와 메커니즘 다름 (셀 베이스라인) |
+
+## 사전 결함 (별도 정정 권고)
+
+- `cargo clippy --release` 변경 전후 동일 발생 — 본 task 와 무관:
+  - `src/document_core/commands/table_ops.rs:1007` `panicking_unwrap`
+  - `src/document_core/commands/object_ops.rs:298` `panicking_unwrap`
+  → 별도 issue 등록 + 정정 권고
+
+## 작업 메모
+
+- 본 task 시작 전 `local/task565` 분기 (`local/devel` 기준)
+- 디버그 진단: 임시 `eprintln!` 추가 후 본질 식별 → 모두 제거 (git diff src/renderer/layout.rs +13/-1 만 잔존)
+- WASM 빌드는 Docker 가동 환경에서 별도 검증 필요 (`docker compose --env-file .env.docker run --rm wasm`)
+
+## 작업지시자 검토 사항
+
+1. **시각 판정 (#565)**: `output/exam_science_001..004.svg` — 12/15/18/19번 본문 인라인 수식 정상 표시 + 회귀 없음 확인
+2. **rhwp-studio web Canvas 시각 판정**: WASM 빌드 후 browser 에서 동일 문서 검증
+3. **이슈 #565 close + local/devel merge**: 시각 판정 통과 시 작업지시자 승인 필요
+4. **이슈 #566 (7번 ㉠ 위치)** 진행 결정: 후속 처리 일정/순위

--- a/mydocs/plans/task_m100_565.md
+++ b/mydocs/plans/task_m100_565.md
@@ -1,0 +1,86 @@
+# Task #565 수행 계획서 — exam_science.hwp 인라인 수식(Equation, treat_as_char) 미렌더 정정
+
+- **마일스톤**: v1.0.0 (M100)
+- **이슈**: [#565](https://github.com/edwardkim/rhwp/issues/565)
+- **브랜치**: `local/task565` (분기점: `local/devel`)
+- **작성일**: 2026-05-04
+
+## 1. 배경 / 증상
+
+`samples/exam_science.hwp` 페이지 2 의 12·15·18·19 번 문제 본문에서 인라인 수식 자리(원소 기호 `A/B/C/D/X`, 원자량 `m-4/m-2/m+2/m+4` 등)가 **빈 자리만 표시**되고 글자가 보이지 않음. PDF (한컴독스 출력) 에는 정상.
+
+## 2. 1차 조사 결과 (코드/덤프 기반 — 코드 무수정)
+
+### 2.1 IR 측 — 수식 컨트롤은 정상 보존됨
+
+`rhwp dump samples/exam_science.hwp` 결과 (예: 문단 0.61 — 12번 문제):
+
+- text_len=56, controls=10
+- 컨트롤 구성: 표 1 + **수식 9** (모두 `treat_as_char=true`, `font="Equation Version 60"`, `font_size=1100`)
+  - `rmX`(X), `rmA`(A), `rmB`(B), `rmC`(C), `rmD`(D), `m-4`, `m-2`, `m+2`, `m+4`
+
+→ **파서/IR 단계에는 결함 없음**. EQ-script 가 정상적으로 추출됨.
+
+### 2.2 SVG 출력 — 수식들이 본문 위치가 아닌 페이지 끝에 응축
+
+`rhwp export-svg samples/exam_science.hwp -p 1` → `output/exam_science_002.svg` 의 텍스트만 추출하여 점검:
+
+- 12번 본문 자리: `"...단,는임의의원소기호이고,,,,의원자량은각각,,,이다.)..."` — 빈자리 그대로
+- SVG 마지막 부분: `"XABCDm-4m-2m+2m+4"` — **누락된 9개 수식이 한 줄에 모두 모여 등장**
+
+→ EquationNode 자체는 생성되고 SVG 에 그려짐. **다만 좌표 (x, y) 가 본문 라인 위치가 아니라 페이지 마지막 영역에 잘못 배치됨**.
+
+### 2.3 코드 분기 — 두 갈래 인라인 수식 렌더 경로
+
+`src/renderer/layout/paragraph_layout.rs` 에 인라인 `Control::Equation` 처리가 **2 개 경로**로 분기:
+
+| 경로 | 위치 | 좌표 변수 | 비고 |
+|------|------|-----------|------|
+| A | L1830-1885 | `x` (선두 char x) | line 시작 시점 처리 |
+| B | L2274-2325 | `inline_x = effective_col_x + effective_margin_left + align_offset` | 정렬(align) 보정 후 처리 |
+
+두 경로 모두 동일한 `RenderNodeType::Equation` 노드를 만들고 `line_node.children` 에 push. **하나의 수식이 두 경로 모두에서 처리되거나, 한 경로에서만 처리되면서 좌표가 다른 컨텍스트(예: align 미보정 좌표) 를 사용**할 수 있음. 12번 문제는 좁은 줄에 9개 수식이 inline 으로 들어가는 케이스로, 정렬 보정 또는 줄 분할 경로에 결함이 있을 가능성이 높음.
+
+## 3. 목표
+
+본문 라인 정확한 좌표에 인라인 수식이 그려지도록 정정. 회귀 0 (다른 인라인 수식 사용 문서 페이지의 byte-identical 보존).
+
+## 4. 단계 개요 (3-5 단계)
+
+### Stage 1 — 정밀 진단 (코드 무수정)
+- 12번 문단(0.61) 의 line_segs 구조 (`ts`/`vpos`/`segment_width`) 및 `tac_controls` 좌표 산출 결과 정밀 추적
+- 두 EquationNode 생성 경로 (L1830, L2274) 각각의 분기 조건과 활성 케이스 매트릭스 작성
+- "수식들이 페이지 끝에 응축" 의 실제 SVG 좌표 추출 (x, y) — 어느 라인의 어느 좌표 체계인지 확정
+- 11번 문제(정상)와 12번 문제의 line/seg/control 차이 비교 (대조 진단)
+- **산출**: `mydocs/working/task_m100_565_stage1.md` (진단 보고서) → 승인 요청
+
+### Stage 2 — 구현 계획 수립
+- Stage 1 진단 결과로 본질 정정 방향 1-3 안 비교 (분기 통합 / 조건 정정 / 좌표 재계산 등)
+- 회귀 위험 평가 (TAC 수식 사용 다른 fixture 식별)
+- **산출**: `mydocs/plans/task_m100_565_impl.md` → 승인 요청
+
+### Stage 3 — 구현 + 검증
+- Stage 2 승인 안 적용 (`paragraph_layout.rs` + 필요 시 `composer.rs`)
+- 검증: `cargo test --lib`, `cargo clippy`, `svg_snapshot` 6/6, 광범위 fixture sweep (인라인 수식 보유 샘플 식별 후 byte-identical 확인 + 의도된 정정만 diff)
+- **산출**: `mydocs/working/task_m100_565_stage3.md` → 승인 요청
+
+### Stage 4 — 시각 판정 + 최종 보고
+- 작업지시자 SVG 시각 판정 (12/15/18/19번 본문 인라인 수식 정상 표시 + 7번 ㉠ 위치 비회귀)
+- rhwp-studio web Canvas 시각 판정
+- **산출**: `mydocs/report/task_m100_565_report.md` + `orders/20260504.md` 갱신
+
+## 5. 회귀 검증 범위
+
+- **필수**: `exam_science.hwp` 4 페이지 byte-identical (의도된 12/15/18/19번 본문 정정 외)
+- **필수**: 인라인 수식이 사용되는 다른 샘플 식별 후 byte-identical (Stage 1 에서 후보 목록 확정)
+- **필수**: `cargo test --lib` 전체 통과, `clippy` 0, `svg_snapshot` 6/6
+- **권고**: 한컴 2010/2020 환경 PDF 비교 (메모리 `feedback_pdf_not_authoritative` 정합 — 보조 ref)
+
+## 6. 위험 요소
+
+- **두 경로(A/B) 통합 시 다른 paragraph 의 수식 좌표 회귀** 가능 — 메모리 `feedback_essential_fix_regression_risk` 정합. Stage 1 에서 두 경로의 케이스 매트릭스를 명확히 한 뒤에만 정정.
+- **다단/분할 paragraph 와의 상호작용** — 12번이 다단인지/줄 분할이 발생하는지 Stage 1 에서 확인.
+
+## 7. 승인 요청
+
+본 수행 계획대로 Stage 1 (정밀 진단) 진입을 승인 요청합니다.

--- a/mydocs/plans/task_m100_565_impl.md
+++ b/mydocs/plans/task_m100_565_impl.md
@@ -1,0 +1,159 @@
+# Task #565 구현 계획서 — `layout_inline_table_paragraph` 인라인 수식 미처리 정정
+
+- **이슈**: [#565](https://github.com/edwardkim/rhwp/issues/565)
+- **단계**: Stage 2 (구현 계획서, **본질 결함 식별 완료**)
+- **작성일**: 2026-05-04
+
+## 1. 본질 결함 (Stage 2 디버그 결과)
+
+### 1.1 결함 위치
+
+`src/renderer/layout.rs::layout_column_item` (L2056) 의 `PageItem::FullParagraph` 분기에서:
+
+```rust
+let has_inline_tables = para.controls.iter()
+    .any(|c| matches!(c, Control::Table(t) if t.common.treat_as_char
+        && is_tac_table_inline(t, seg_width, &para.text, &para.controls)));
+
+if has_inline_tables {
+    // → layout_inline_table_paragraph 호출 (인라인 표 + 텍스트 세그먼트만 처리)
+} else {
+    // → 일반 layout_paragraph (인라인 수식/그림/글상자 정상 처리)
+}
+```
+
+### 1.2 결함 메커니즘
+
+`layout_inline_table_paragraph` (`paragraph_layout.rs:88`) 는 **인라인 표(treat_as_char Table) + 텍스트 세그먼트만 배치**하고, **다른 인라인 컨트롤(Equation/Picture/Shape)은 처리하지 않음**.
+
+12번 본문(0.61) 의 controls = `[표 1, 수식 9]` (모두 treat_as_char). 따라서:
+
+1. `has_inline_tables = TRUE` → `layout_inline_table_paragraph` 진입
+2. 9 개 인라인 수식은 무시 → `tree.set_inline_shape_position` 등록 안 됨
+3. paginator 가 `PageItem::Shape pi=61 ci=1..9 (수식)` 을 별도로 등록함
+4. `shape_layout::layout_shape_item` 진입 시 `inline_pos.is_none()` → fallback 경로 (L140-181):
+   - `eq_x = col_area.x` (정렬=Justify 이지만 좌측 fallback)
+   - `eq_y = para_y` (paragraph 시작 y)
+5. 9 개 수식 모두 동일 좌표 (534.8, 1218.106) 에 겹쳐 그려짐 (실제 SVG 결과와 일치)
+
+### 1.3 디버그 로그 증거 (제거됨)
+
+```
+[T565-DISPATCH] FullParagraph pi=60 y_offset=1040.19
+[T565-DISPATCH]   pi=60 no special table → plain layout_paragraph
+[T565-A] line=0 ci=1 script="rmA SIM D" x=656.80 ...   ← 정상 분산
+...
+[T565-DISPATCH] FullParagraph pi=61 y_offset=1130.32
+[T565-DISPATCH]   pi=61 has_inline_tables=TRUE → layout_inline_table_paragraph
+                                              ← 인라인 수식 처리 누락 (T565-A/B 둘 다 안 찍힘)
+```
+
+대조: 0.60 (12번 그림 문단, 인라인 표 없음) 은 plain layout_paragraph 정상 동작.
+
+## 2. 정정 방향 비교 (3 안)
+
+### 안 A — `has_inline_tables` 조건 강화 (분기 전환)
+
+```rust
+// 인라인 표 + 다른 인라인 컨트롤 (Equation/Picture/Shape) 가 같이 있으면
+// 일반 layout_paragraph 로 보낸다 (인라인 표는 layout_paragraph 의 TAC 표
+// 인라인 경로 L1888-1906 가 처리).
+let has_inline_tables = para.controls.iter()
+    .any(|c| matches!(c, Control::Table(t) if t.common.treat_as_char
+        && is_tac_table_inline(...)));
+let has_other_inline_ctrls = para.controls.iter()
+    .any(|c| matches!(c,
+        Control::Equation(_)
+        | Control::Picture(p) if p.common.treat_as_char
+        | Control::Shape(s) if s.common().treat_as_char
+    ));
+
+if has_inline_tables && !has_other_inline_ctrls {
+    // 기존 specialized 경로
+} else {
+    // 일반 layout_paragraph
+}
+```
+
+- **장점**: 정정 위치 한 곳, 영향 범위 명확.
+- **위험**: 일반 layout_paragraph 의 인라인 표 처리 (L1886-1906) 가 기존 `layout_inline_table_paragraph` 와 동등한 출력을 내는지 확인 필요. 12번 표 (2x1 TAC) 는 한컴 정답지 대비 정정되어야 하지만, `layout_inline_table_paragraph` 가 처리하던 다른 케이스 (Task #517 등) 와 동등 출력 보장 필요.
+- **대안**: 인라인 수식 + 인라인 표 동시 케이스 한정으로 우회 분기.
+
+### 안 B — `layout_inline_table_paragraph` 에 인라인 수식 처리 추가
+
+`layout_inline_table_paragraph` 의 segment 배치 루프 안에서, 표 사이 갭 위치에 등장하는 `Control::Equation` (treat_as_char) 도 함께 처리.
+
+- **장점**: 기존 분기 구조 유지, specialized 경로 강화.
+- **위험**: `layout_inline_table_paragraph` 의 char_offsets 갭 분석 + 표/텍스트 배치 로직과 인라인 수식 배치를 통합해야 함. 코드 복잡도 ↑. char_offsets 와 controls 의 매칭 로직이 layout_composed_paragraph 의 `tac_offsets_px` 와 다르므로 별도 산출 필요.
+- **회귀 위험**: 기존 layout_inline_table_paragraph 사용 케이스 (Task #517 등) 의 byte-identical 보장 까다로움.
+
+### 안 C — `shape_layout` fallback 좌표 정정
+
+shape_layout fallback 경로 (`shape_layout.rs:140-181`) 가 9 개 수식이 같은 좌표를 받지 않도록 하단의 inline 위치를 추정하여 분산.
+
+- **장점**: `layout.rs` 분기와 `layout_inline_table_paragraph` 무수정.
+- **위험**: 추정 좌표는 실제 paragraph layout 결과와 다를 수밖에 없음. 본질 정정이 아님 (shape_layout 의 fallback 자체가 본 케이스 처리용으로 설계되지 않음). **메모리 `feedback_rule_not_heuristic` 에 정합 — 휴리스틱 fallback 회피**.
+
+### 권장: 안 A
+
+1. 본질 정정 (분기 조건의 정확한 케이스 분리).
+2. 변경 범위 한 곳 (`layout.rs::layout_column_item` 의 `has_inline_tables` 가드).
+3. `layout_paragraph` 의 인라인 표 처리 (L1886-1906) 와 인라인 수식 처리 (L1830-1885) 가 같은 줄/위치 체계 (run_tacs / inline_x) 를 공유하므로 자연스러운 통합.
+
+**조건**: 안 A 적용 전 광범위 fixture sweep 으로 일반 layout_paragraph 의 인라인 표 처리가 기존 `layout_inline_table_paragraph` 사용 케이스와 동등 출력을 내는지 확인. **다르면 안 B 로 전환**.
+
+## 3. 단계별 구현 (Stage 3 세부 단계)
+
+### Stage 3-1 — 안 A 적용 가능성 검증 (no-op 변경 사전 확인)
+
+1. `has_other_inline_ctrls` 조건 추가 후, 안 A 를 12번 본문 한정으로 강제 적용 (예: `para_index == 61`).
+2. 12번 본문 SVG 산출 → 9 개 수식 정상 분산 + 인라인 표 위치 정상 + 표 셀 내부 텍스트 정상 표시 확인.
+3. **표 위치/셀 내부 텍스트가 회귀하면 → 안 A 부적합 → Stage 3-2 안 B 로 전환**.
+
+### Stage 3-2 — 정정 적용 (안 A 채택 시)
+
+1. `layout.rs::layout_column_item` 의 `has_inline_tables` 가드를 `has_inline_tables && !has_other_inline_ctrls` 로 변경.
+2. `has_other_inline_ctrls` 정의 (Equation + treat_as_char Picture/Shape).
+3. (안 B 채택 시) `layout_inline_table_paragraph` 에 인라인 수식 + Picture/Shape 처리 통합.
+
+### Stage 3-3 — 검증 (필수)
+
+광범위 fixture sweep (인라인 수식 + 인라인 표 동시 사용 페이지 식별):
+
+1. `cargo test --lib` 1113 통과 (현재 baseline)
+2. `cargo clippy` 0 경고
+3. `svg_snapshot` 6/6
+4. `samples/exam_science.hwp` 4 페이지 — 12/15/18/19 번 본문 의도 정정 + 그 외 byte-identical
+5. 다른 sample 들 byte-identical 확인:
+   - `samples/exam_kor*.hwp`, `samples/issue-505-equations.hwp`
+   - `samples/aift.hwp`, `samples/treatise sample.hwp`, `samples/2010-01-06.hwp` 등 포함
+6. WASM 빌드 성공 + 크기 확인
+
+### Stage 3-4 — 단계별 보고서 작성 + 승인 요청
+
+`mydocs/working/task_m100_565_stage3.md` — 적용 안, 변경 LOC, 검증 결과, 회귀 0 입증.
+
+### Stage 4 — 시각 판정 + 최종 보고
+
+작업지시자 시각 판정 (SVG + rhwp-studio web Canvas) → `task_m100_565_report.md` + `orders/20260504.md` 갱신.
+
+## 4. 회귀 위험 요소 (재정리)
+
+| 위험 | 완화 |
+|------|------|
+| `layout_paragraph` 의 인라인 표 처리 vs `layout_inline_table_paragraph` 의 출력 차이 | Stage 3-1 사전 검증 + 광범위 fixture sweep |
+| 인라인 표 + 인라인 그림/글상자 동시 케이스 (다른 fixture 가능) | `has_other_inline_ctrls` 에 모든 treat_as_char 컨트롤 포함 — 동일 분기로 통일 |
+| Task #287 (display equation as own LINE_SEG) 회귀 | layout_paragraph 의 L2245 분기는 그대로 유지 |
+| 다단/페이지 분할 회귀 | 안 A 는 분기 조건만 변경 — y/x 계산 변경 없음 |
+
+## 5. 변경 LOC 추정
+
+- 안 A: `layout.rs` ~5 LOC 추가 (조건절 1 곳)
+- 안 B: `paragraph_layout.rs::layout_inline_table_paragraph` ~50 LOC 추가
+- 안 C: 회피 (휴리스틱)
+
+## 6. 승인 요청
+
+본 구현 계획대로 **Stage 3 (구현 + 검증) 진입**을 승인 요청합니다.
+
+진입 시점에 **Stage 3-1 (안 A 적용 가능성 사전 검증)** 부터 시작하며, 12번 본문에서 안 A 가 부적합으로 판명되면 안 B 로 전환합니다. 어느 안을 채택했는지는 Stage 3 완료 보고서에 명기합니다.

--- a/mydocs/report/task_m100_565_report.md
+++ b/mydocs/report/task_m100_565_report.md
@@ -1,0 +1,138 @@
+# Task #565 최종 결과 보고서 — exam_science.hwp 인라인 수식(treat_as_char) 미렌더 정정
+
+- **이슈**: [#565](https://github.com/edwardkim/rhwp/issues/565)
+- **마일스톤**: v1.0.0 (M100)
+- **브랜치**: `local/task565` (분기: `local/devel`)
+- **작성일**: 2026-05-04
+- **상태**: **완료 (시각 판정 대기)**
+
+## 1. 결함 요약
+
+`samples/exam_science.hwp` 페이지 2 의 12·15·18·19번 문제 본문 인라인 수식 (원소 기호 `A/B/C/D/X` + 원자량 `m-4/m-2/m+2/m+4` 등) 이 모두 빈 자리만 표시되고 글자가 누락. 한컴 PDF 정답에는 정상 표시.
+
+## 2. 본질 원인
+
+`src/renderer/layout.rs::layout_column_item` 의 `PageItem::FullParagraph` 분기에서:
+
+- `has_inline_tables = TRUE` 인 문단은 `paragraph_layout::layout_inline_table_paragraph` 가 호출됨
+- 이 함수는 인라인 표 + 텍스트 세그먼트만 처리하고 **인라인 수식·treat_as_char Picture/Shape 는 무시**
+- 결과: `inline_shape_position` 미등록 → paginator 가 등록한 `PageItem::Shape (수식)` 들이 `shape_layout` 에 도달했을 때 `inline_pos.is_none()` → fallback 경로 (`shape_layout.rs:140-181`) 가 모두 동일 좌표 `(col_area.x, para_y)` = SVG `(534.8, 1218.106)` 에 9개 수식을 겹쳐 그림
+
+`paragraph_layout::layout_composed_paragraph` 의 인라인 수식 처리 경로 (run_tacs / inline_x) 자체는 정상 — 0.60 (12번 그림 문단, 인라인 표 없음) 의 8개 수식은 정상 분산되었으며, 0.61 (12번 본문, 인라인 표 + 수식 9) 만 잘못된 분기로 떨어진 것.
+
+## 3. 본질 정정
+
+`src/renderer/layout.rs` (+13 / -1 LOC):
+
+```rust
+// [Task #565] 인라인 표 + 다른 인라인 컨트롤(수식/treat_as_char Picture/Shape)
+// 이 같이 있는 문단은 layout_inline_table_paragraph 가 인라인 수식 등을
+// 처리하지 않아 shape_layout fallback (col_area.x, para_y) 으로 9개 수식이
+// 동일 좌표에 겹친다 (exam_science.hwp 12/15/18/19번). 일반
+// layout_paragraph 로 보내 인라인 표 + 인라인 수식이 같은 line/x 체계
+// (run_tacs / inline_x) 로 정상 배치되도록 한다.
+let has_other_inline_ctrls = para.controls.iter().any(|c| match c {
+    Control::Equation(_) => true,
+    Control::Picture(p) => p.common.treat_as_char,
+    Control::Shape(s) => s.common().treat_as_char,
+    _ => false,
+});
+
+if has_inline_tables && !has_other_inline_ctrls {
+    // 기존 layout_inline_table_paragraph 경로
+} else {
+    // 일반 layout_paragraph 경로 — 인라인 표 + 인라인 수식 정상 처리
+}
+```
+
+## 4. 검증 결과
+
+| 항목 | 결과 | 비고 |
+|------|------|------|
+| `cargo test --lib` | ✅ **1125 통과 / 0 실패** | 변경 전 1125 ↔ 변경 후 1125 동일 |
+| `cargo test --release --test svg_snapshot` | ✅ **6/6 통과** | issue_147/157/267, form_002, table_text, render_is_deterministic |
+| 광범위 sweep (15 fixture, 274 페이지) | ✅ **271 byte-identical, 3 의도 정정** | 회귀 0 |
+| `cargo clippy --release` (본 변경) | ✅ **신규 경고/오류 0** | 사전 결함 2건 변경 전후 동일 (별도 정정 권고) |
+| WASM 빌드 | ⏳ Docker 미가동 — 미검증 | Stage 4 보강 (별도 환경) |
+
+### 4.1 광범위 sweep 대상 fixture (15개)
+
+```
+exam_science.hwp, exam_kor.hwp, exam_math.hwp, exam_eng.hwp, exam_social.hwp,
+aift.hwp, issue-505-equations.hwp, eq-01.hwp, equation-lim.hwp,
+atop-equation-01.hwp, 21_언어_기출_편집가능본.hwp, 2010-01-06.hwp,
+biz_plan.hwp, k-water-rfp.hwp, kps-ai.hwp
+```
+
+### 4.2 의도된 정정 3 페이지
+
+- `exam_science_002.svg` — 12번 본문 9개 수식 (X/A/B/C/D + m-4/m-2/m+2/m+4) 정상 분산
+- `exam_science_003.svg` — 15번 본문 W~Y, X~Z 정상 표시
+- `exam_science_004.svg` — 18/19번 본문 인라인 수식 정상 표시
+
+### 4.3 SVG 텍스트 검증 (의도 정정 영역)
+
+```
+[페이지 2 12번] (단,X는임의의원소기호이고,A,B,C,D의원자량은각각m-4,m-2,m+2,m+4이다.)
+[페이지 3 15번] 15.-그림(가)는원자WsimY의를,(나)는원자이온반지름이온의전하XsimZ의을…
+[페이지 4 18번] 18.-표는2xMHA(aq),xMH2B(aq),yMNaOH(aq)의부피를…
+[페이지 4 19번] 19.-다음은A(g)로부터B(g)와C(g)가생성되는반응의화학반응식이다.
+[페이지 4 19번] (단,XsimZ는임의의원소기호이다.)
+```
+
+→ 인라인 수식 누락 0 건.
+
+### 4.4 변경 전후 좌표 비교 (12번 본문)
+
+| 변경 전 | 변경 후 |
+|---|---|
+| 9개 수식 모두 (534.8, 1218.106) — 동일 좌표 겹침 | 첫 줄 y=1174.91: X(606.87), A(887.87), B(934.87) |
+|  | 둘째 줄 y=1196.37: C(549.87), D(569.87), m-4(698.87), m-2(743.97), m+2(789.08), m+4(834.19) |
+
+## 5. 회귀 위험 검증
+
+| 케이스 | 검증 결과 |
+|--------|----------|
+| 인라인 표만 사용 paragraph (12번 보기 셀 등) | ✅ 정상 분산 (좌표 분산됨) — 본 정정의 가드 조건 외 |
+| 인라인 표 + 인라인 그림 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 일반 layout_paragraph 처리 |
+| 인라인 표 + 인라인 글상자 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 일반 layout_paragraph 처리 |
+| Task #287 (display equation as own LINE_SEG) | ✅ `paragraph_layout` L2245 분기 무수정 — 회귀 영역 외 |
+| 광범위 sweep | ✅ 271/274 byte-identical (3건 = 의도 정정) |
+
+## 6. 변경 요약
+
+| 파일 | +/- | 비고 |
+|------|-----|------|
+| `src/renderer/layout.rs` | **+13 / -1** | `has_inline_tables` 가드 강화 |
+| `mydocs/plans/task_m100_565.md` | 신규 | 수행 계획서 |
+| `mydocs/plans/task_m100_565_impl.md` | 신규 | 구현 계획서 |
+| `mydocs/working/task_m100_565_stage1.md` | 신규 | Stage 1 정밀 진단 |
+| `mydocs/working/task_m100_565_stage3.md` | 신규 | Stage 3 적용 + 검증 |
+| `mydocs/report/task_m100_565_report.md` | 신규 | 본 최종 보고서 |
+
+## 7. 시각 판정 안내 (작업지시자)
+
+검증용 SVG 4개 파일이 `output/` 에 생성됨:
+
+- `output/exam_science_001.svg` — 페이지 1 (회귀 검증, byte-identical)
+- `output/exam_science_002.svg` — 페이지 2 (12번 본문 정정, 11번도 비교 가능)
+- `output/exam_science_003.svg` — 페이지 3 (15번 본문 정정)
+- `output/exam_science_004.svg` — 페이지 4 (18/19번 본문 정정)
+
+추가 검증 권고:
+
+1. **rhwp-studio web Canvas 시각 판정**: WASM 빌드 후 brwoser 에서 동일 문서 렌더 결과 검증
+2. **WASM 빌드**: Docker 가동 환경에서 `docker compose --env-file .env.docker run --rm wasm` 후 크기 확인
+
+## 8. 후속 / 잔존 사항
+
+- **이슈 #566 (7번 ㉠ 위치)**: 본 정정과 별개 결함 (셀 베이스라인). 별도 task 로 후속 처리 (이미 등록).
+- **clippy 사전 결함 2건** (`document_core/commands/{table_ops.rs:1007, object_ops.rs:298}` `panicking_unwrap`): 본 task 범위 외 — 별도 issue 등록 권고.
+- **이슈 close**: 작업지시자 승인 후 `gh issue close 565` 수행.
+- **local/devel merge**: 작업지시자 승인 후 `git checkout local/devel && git merge local/task565 --no-ff` 수행.
+
+## 9. 메모리 정합
+
+- `feedback_essential_fix_regression_risk` ✅ 광범위 sweep + cargo test 1125 + svg_snapshot 6/6 으로 회귀 0 입증
+- `feedback_rule_not_heuristic` ✅ 본질 정정 — 분기 조건 정확화 (휴리스틱 fallback 회피)
+- `feedback_pdf_not_authoritative` ✅ PDF 는 보조 ref. SVG 텍스트 추출로 인라인 수식 표시 검증

--- a/mydocs/working/task_m100_565_stage1.md
+++ b/mydocs/working/task_m100_565_stage1.md
@@ -1,0 +1,112 @@
+# Task #565 Stage 1 — 정밀 진단 보고서
+
+- **이슈**: [#565](https://github.com/edwardkim/rhwp/issues/565)
+- **단계**: Stage 1 (정밀 진단, **코드 무수정**)
+- **작성일**: 2026-05-04
+
+## 1. 진단 절차
+
+1. `samples/exam_science.hwp` 페이지 2 SVG 출력 (`rhwp export-svg samples/exam_science.hwp -p 1`)
+2. 12번 문제(문단 0.61) IR 덤프 (`rhwp dump`)
+3. SVG 파일 내 모든 `<g transform="translate(x,y)">` 좌표 추출 + 인라인 수식 텍스트 매칭
+4. `paragraph_layout.rs` 의 인라인 수식 처리 경로 코드 정독
+
+## 2. 핵심 발견 — 9개 수식이 동일 좌표에 겹쳐 그려짐
+
+12번 문제 본문의 9개 인라인 수식이 SVG에서 모두 **정확히 동일한 (x, y) = (534.8, 1218.106)** 좌표에 그려짐:
+
+```
+translate(534.8,1218.106666666667)  → "X"
+translate(534.8,1218.106666666667)  → "A"
+translate(534.8,1218.106666666667)  → "B"
+translate(534.8,1218.106666666667)  → "C"
+translate(534.8,1218.106666666667)  → "D"
+translate(534.8,1218.106666666667)  → "m-4"
+translate(534.8,1218.106666666667)  → "m-2"
+translate(534.8,1218.106666666667)  → "m+2"
+translate(534.8,1218.106666666667)  → "m+4"
+```
+
+**대조**: 같은 페이지 다른 문제의 인라인 수식들은 정상 분산:
+
+```
+translate(774.8,152.586) → "A"   translate(802.8,152.586) → "B"   (x 28 px 분리)
+translate(570.89,1232.54) → "67"   translate(653.27,1232.54) → "78"   (보기 표 셀 내부 — 정상)
+```
+
+→ **EquationNode 자체는 생성되지만, 9개 모두 동일한 시작 좌표를 받음**. SVG 렌더 코드(`svg.rs:341-368`) 는 `node.bbox.x/y` 를 그대로 `<g transform="translate(...)">` 로 사용하므로 결함은 **`paragraph_layout.rs` 단계의 BoundingBox 좌표 산출**에 있음.
+
+## 3. IR 정상 확인
+
+`rhwp dump samples/exam_science.hwp -s 0 -p 61` 결과:
+
+- 문단 0.61: cc=137, text_len=56, controls=10 (표 1 + 수식 9)
+- ls[0] ts=0, vpos=74118, lh=2864 (큰 lh — 인라인 TAC 표 포함)
+- ls[1] ts=13, vpos=77442, lh=1150
+- ls[2] ts=60, vpos=79052, lh=1150
+- 수식 컨트롤 모두 정상:
+  - [1] rmX 675x1125, [2] rmA 825x1125, [3] rmB 675x1125, [4] rmC 675x1125, [5] rmD 750x1125
+  - [6] m-4, [7] m-2, [8] m+2, [9] m+4 모두 2558x1125
+
+→ **IR 단계 결함 없음**. 좌표 산출 결함만 남음.
+
+## 4. 코드 분기 — 인라인 수식 처리 경로 매트릭스
+
+`src/renderer/layout/paragraph_layout.rs` 에 인라인 `Control::Equation` 처리가 **2 경로** 존재:
+
+### 경로 A — L1830-1885 (`run_tacs` 루프 내부)
+
+위치: `for &(tac_rel, tac_w, tac_ci) in &run_tacs` 루프 내 (L1734~1941).
+
+좌표:
+- `BoundingBox::new(x, eq_y, tac_w, eq_h)` (L1879)
+- `x` 는 sub-segment 텍스트 폭 (`x += seg_w`, L1773) 과 tac 폭 (`x += tac_w`, L1939) 으로 누적
+- 누적 정상
+
+활성 조건: 해당 run 안에 1개 이상의 tac 가 있고 (`!run_tacs.is_empty()`), 그 tac 가 `Control::Equation` 인 경우.
+
+### 경로 B — L2274-2323 (`comp_line.runs.is_empty()` 가드)
+
+위치: L2245 `if comp_line.runs.is_empty() && !tac_offsets_px.is_empty()` 분기 내.
+
+좌표:
+- `BoundingBox::new(inline_x, eq_y, tac_w, eq_h)` (L2318)
+- `inline_x = effective_col_x + effective_margin_left + align_offset` (L2268, line 시작)
+- 각 수식 처리 후 `inline_x += tac_w` (L2322)
+- 누적 정상
+
+활성 조건: 해당 line 의 `comp_line.runs` 가 비어있고 (텍스트 run 없음) tac만 있는 경우. Task #287 케이스 (디스플레이 수식이 자체 LINE_SEG 가질 때).
+
+### 두 경로 모두 누적 코드는 정상으로 보임
+
+코드 정독 기준 두 경로 모두 좌표 누적은 정상. 그럼에도 SVG 결과는 9개 동일 좌표 → **두 경로 중 어느 게 실제 활성인지 / 활성 경로가 어떤 변수 전달 단계에서 좌표 누적을 잃는지** 디버그 로그(임시)로 정밀 추적 필요.
+
+## 5. 추가 의심 시나리오
+
+| # | 가설 | 검증 방법 |
+|---|------|----------|
+| H1 | 12번 문제의 line 분할에서 각 수식이 **별도 ComposedLine** 으로 분리 → 9개 line_node 모두 동일 시작 inline_x 사용 | 디버그 로그로 `comp_line` 개수와 각 line 의 `runs.is_empty()` / tac_offsets_px 분포 확인 |
+| H2 | composer.rs `find_control_text_positions` 가 9개 수식의 텍스트 위치를 모두 동일 pos 로 산출 → run_tacs/tac_offsets_px 누적 안 됨 | 디버그 로그로 tac_controls 의 (pos, width) 출력 |
+| H3 | run 분할 결과 `run_tacs` 가 9개 모두 같은 run 에 들어가지 못하고 별도 run 에서 처리됨 → 매 run 시작마다 `x` 가 리셋(=line 시작 x)되는데 sub-segment 텍스트 폭이 누적되지 않음 | 디버그 로그로 run 개수와 `run_tacs` 분포, 각 run 시작 시점의 x 값 확인 |
+
+## 6. 회귀 위험 후보 영역 (Stage 3 sweep 대상)
+
+- 인라인 수식 사용 다른 샘플:
+  - `samples/exam_kor*.hwp`, `samples/exam_science.hwp` 다른 문제, `samples/issue-505-equations.hwp`
+- 표 셀 내부 인라인 수식 (12번 표의 ① m+/m- 셀들 — 현재 SVG 정상 분산 확인됨)
+- 디스플레이 수식이 자체 LINE_SEG 갖는 케이스 (Task #287 회귀 방지)
+
+## 7. Stage 2 진입 권고 — 디버그 로그 임시 추가
+
+본질 정정 방향(분기 통합 / 경로별 조건 정정 / 좌표 산출 보강) 결정 전에 **임시 디버그 로그(`eprintln!`)** 를 두 경로에 추가하여:
+
+1. 12번 문단(0.61) 의 `comp_line` 개수와 각 line 의 `runs.len()`, `tac_offsets_px.len()` 출력
+2. 경로 A 활성 시: 매 tac 처리 시점의 `(x, tac_w, tac_ci)` 출력
+3. 경로 B 활성 시: 매 tac 처리 시점의 `(inline_x, tac_w, tac_ci)` 출력
+4. 결과로 어느 경로가 활성이며 좌표 누적이 어디서 깨지는지 정확히 식별
+
+확정 후 디버그 로그 제거 + 본질 정정 안 1-3개 비교하여 `task_m100_565_impl.md` 작성.
+
+## 8. 승인 요청
+
+본 진단 보고대로 **Stage 2 (구현 계획서 작성) 진입을 승인 요청**합니다. 시작 시점에 디버그 로그 임시 추가가 포함되며, 본질 정정 방향 확정 후 디버그 코드는 모두 제거합니다.

--- a/mydocs/working/task_m100_565_stage3.md
+++ b/mydocs/working/task_m100_565_stage3.md
@@ -1,0 +1,147 @@
+# Task #565 Stage 3 — 본질 정정 적용 + 검증 보고서
+
+- **이슈**: [#565](https://github.com/edwardkim/rhwp/issues/565)
+- **단계**: Stage 3 (구현 + 검증)
+- **작성일**: 2026-05-04
+- **채택 안**: **안 A** (사전 검증 통과)
+
+## 1. Stage 3-1 — 안 A 사전 검증 (12번 본문 한정 강제 적용)
+
+`force_plain_t565 = section==0 && para_index==61` 가드를 임시로 추가하여 12번 본문만 일반 `layout_paragraph` 로 강제 전환.
+
+### 결과 (12번 본문 9개 수식 좌표)
+
+| 변경 전 (Stage 1/2) | 변경 후 (Stage 3-1) |
+|---|---|
+| 9개 모두 (534.8, 1218.106) — 겹침 | 첫 줄 y=1174.91: X(606.87), A(887.87), B(934.87) |
+| | 둘째 줄 y=1196.37: C(549.87), D(569.87), m-4(698.87), m-2(743.97), m+2(789.08), m+4(834.19) |
+
+→ **9개 수식 모두 정상 분산. 안 A 본질 정정 동작 확인**.
+
+표 위치 / 본문 레이아웃 회귀 없음 (Stage 3-3 광범위 sweep 으로 재검증).
+
+## 2. Stage 3-2 — 본 정정 적용
+
+`src/renderer/layout.rs` (+13 / -1 LOC):
+
+```rust
+// [Task #565] 인라인 표 + 다른 인라인 컨트롤(수식/treat_as_char Picture/Shape)
+// 이 같이 있는 문단은 layout_inline_table_paragraph 가 인라인 수식 등을
+// 처리하지 않아 shape_layout fallback (col_area.x, para_y) 으로 9개 수식이
+// 동일 좌표에 겹친다 (exam_science.hwp 12/15/18/19번). 일반
+// layout_paragraph 로 보내 인라인 표 + 인라인 수식이 같은 line/x 체계
+// (run_tacs / inline_x) 로 정상 배치되도록 한다.
+let has_other_inline_ctrls = para.controls.iter().any(|c| match c {
+    Control::Equation(_) => true,
+    Control::Picture(p) => p.common.treat_as_char,
+    Control::Shape(s) => s.common().treat_as_char,
+    _ => false,
+});
+
+if has_inline_tables && !has_other_inline_ctrls {
+    // (기존 layout_inline_table_paragraph 경로)
+} else {
+    // 일반 layout_paragraph 경로 — 인라인 표 + 인라인 수식 정상 처리
+}
+```
+
+## 3. Stage 3-3 — 광범위 sweep 검증
+
+### 3.1 `cargo test --lib`
+
+```
+test result: ok. 1125 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out; finished in 71.87s
+```
+
+→ **1125 통과, 0 실패** (변경 전 1125 ↔ 변경 후 1125 동일).
+
+### 3.2 `cargo test --release --test svg_snapshot`
+
+```
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.14s
+```
+
+→ **6/6 통과** (issue_147 aift, issue_157, issue_267 ktx, form_002, table_text, render_is_deterministic).
+
+### 3.3 광범위 fixture sweep (15 sample / 274 페이지)
+
+대상 fixture (인라인 수식/표 가능성 높은 것 + 회귀 위험 fixture 종합):
+
+```
+exam_science.hwp, exam_kor.hwp, exam_math.hwp, exam_eng.hwp, exam_social.hwp,
+aift.hwp, issue-505-equations.hwp, eq-01.hwp, equation-lim.hwp,
+atop-equation-01.hwp, 21_언어_기출_편집가능본.hwp, 2010-01-06.hwp,
+biz_plan.hwp, k-water-rfp.hwp, kps-ai.hwp
+```
+
+baseline (Stage 2 commit) vs after-fix SVG byte-compare:
+
+```
+총 274 SVG: identical=271, diff=3
+
+diff 파일:
+  exam_science_002.svg   ← 12번 본문 정정 (9개 수식 정상 분산)
+  exam_science_003.svg   ← 15번 본문 정정 (수식 정상 표시)
+  exam_science_004.svg   ← 18/19번 본문 정정 (수식 정상 표시)
+```
+
+→ **271 페이지 byte-identical (회귀 0)**. 의도된 정정 3 페이지 (exam_science 페이지 2/3/4) 모두 12/15/18/19번 본문 인라인 수식 정상 표시.
+
+### 3.4 의도된 정정 SVG 텍스트 검증
+
+```
+[페이지 2 12번] (단,X는임의의원소기호이고,A,B,C,D의원자량은각각m-4,m-2,m+2,m+4이다.)
+[페이지 2 11번] (단,X와Y는임의의원소기호이고,Y2는물과반응하지않는다.)        ← 이전부터 정상
+[페이지 3 15번] 15.-그림(가)는원자WsimY의를,(나)는원자이온반지름이온의전하XsimZ의을…
+[페이지 4 18번] 18.-표는2xMHA(aq),xMH2B(aq),yMNaOH(aq)의부피를달리하여혼합한…
+[페이지 4 19번] 19.-다음은A(g)로부터B(g)와C(g)가생성되는반응의화학반응식이다.
+[페이지 4 19번 단서] (단,XsimZ는임의의원소기호이다.)
+```
+
+→ 인라인 수식 모두 정상 표시. 누락 0.
+
+### 3.5 `cargo clippy --release`
+
+`src/document_core/commands/{table_ops.rs:1007, object_ops.rs:298}` 의 `panicking_unwrap` 2 건 — **변경 전 baseline 에서도 동일 발생**. 본 변경과 무관 (사전 결함). 별도 정정 권고 (본 task 범위 외).
+
+본 변경(`layout.rs` +13/-1)에 의한 신규 clippy 경고/오류 **0**.
+
+### 3.6 WASM 빌드
+
+본 세션 환경의 Docker daemon 미가동 (`Cannot connect to the Docker daemon`). WASM 빌드는 별도 머신/세션에서 검증 필요. 다만:
+
+- 변경 코드는 `Control` enum match + boolean 가드 (WASM 비호환 API 미사용)
+- 동일 `Control::Picture/Shape/Equation` match 패턴은 동일 파일 다른 곳에서 이미 사용 중 (예: `layout.rs:1991`)
+
+→ WASM 빌드 회귀 가능성 매우 낮음. **시각 판정 단계(Stage 4) 또는 별도 환경에서 보강 검증 필요**.
+
+## 4. 변경 LOC
+
+| 파일 | +/- | 비고 |
+|------|-----|------|
+| `src/renderer/layout.rs` | **+13 / -1** | `has_other_inline_ctrls` 정의 + `has_inline_tables` 가드 강화 |
+
+본 task 의 본질 정정 한 곳. 디버그 로그 모두 제거 확인됨 (`git diff` 12 LOC 추가만 표시).
+
+## 5. 회귀 위험 검증 결과
+
+| 항목 | 결과 |
+|------|------|
+| `cargo test --lib` 1125 | ✅ 0 회귀 |
+| `svg_snapshot` 6/6 | ✅ 0 회귀 |
+| 274 페이지 byte-identical | ✅ 271/274 (3건 = 의도된 정정) |
+| 인라인 표만 사용 paragraph (12번 셀 내 수식 등) | ✅ 정상 분산 (좌표 분산됨) |
+| 인라인 표 + 인라인 그림 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 동일 분기 |
+| 인라인 표 + 인라인 글상자 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 동일 분기 |
+| Task #287 (display equation as own LINE_SEG) | ✅ `paragraph_layout::layout_composed_paragraph` L2245 분기 무수정 — 회귀 영역 외 |
+
+## 6. 잔존 사항 / Stage 4 진행 항목
+
+1. **시각 판정**: 작업지시자 SVG 시각 판정 (12/15/18/19번 본문 인라인 수식 정상 표시 + 회귀 없음).
+2. **rhwp-studio web Canvas 시각 판정**: 동일 문서 brwoser 렌더 결과 검증.
+3. **WASM 빌드 검증**: Docker 가동 환경에서 별도 확인 후 결과 회신.
+4. **이슈 #566 (7번 ㉠ 위치)** 와의 양립성: 본 정정은 7번 셀 내부 ㉠/㉡ 위치 변동 영향 없음 (셀 베이스라인 계산 미변경) — 별도 task 로 후속 처리.
+
+## 7. 승인 요청
+
+본 Stage 3 결과로 **Stage 4 (시각 판정 + 최종 보고서) 진입**을 승인 요청합니다. 시각 판정 통과 시 `task_m100_565_report.md` 작성 + `orders/20260504.md` 갱신 후 본 task 종료.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1968,7 +1968,20 @@ impl LayoutEngine {
                         .any(|c| matches!(c, Control::Table(t) if t.common.treat_as_char
                             && crate::renderer::height_measurer::is_tac_table_inline(t, seg_width, &para.text, &para.controls)));
 
-                    if has_inline_tables {
+                    // [Task #565] 인라인 표 + 다른 인라인 컨트롤(수식/treat_as_char Picture/Shape)
+                    // 이 같이 있는 문단은 layout_inline_table_paragraph 가 인라인 수식 등을
+                    // 처리하지 않아 shape_layout fallback (col_area.x, para_y) 으로 9개 수식이
+                    // 동일 좌표에 겹친다 (exam_science.hwp 12/15/18/19번). 일반
+                    // layout_paragraph 로 보내 인라인 표 + 인라인 수식이 같은 line/x 체계
+                    // (run_tacs / inline_x) 로 정상 배치되도록 한다.
+                    let has_other_inline_ctrls = para.controls.iter().any(|c| match c {
+                        Control::Equation(_) => true,
+                        Control::Picture(p) => p.common.treat_as_char,
+                        Control::Shape(s) => s.common().treat_as_char,
+                        _ => false,
+                    });
+
+                    if has_inline_tables && !has_other_inline_ctrls {
                         // 인라인 표 문단도 번호 카운터 전진 필요
                         self.apply_paragraph_numbering(
                             composed.get(*para_index), para, styles, outline_numbering_id,


### PR DESCRIPTION
## Summary

- **본질**: `src/renderer/layout.rs::layout_column_item` 의 `has_inline_tables=TRUE` 분기가 `paragraph_layout::layout_inline_table_paragraph` (인라인 표 + 텍스트 세그먼트만 처리, 인라인 수식/treat_as_char Picture/Shape 는 무시) 를 호출 → `inline_shape_position` 미등록 → `shape_layout::layout_shape_item` fallback (`col_area.x`, `para_y`) 으로 9개 인라인 수식이 동일 좌표 (534.8, 1218.106) 에 겹쳐 그려짐 (`samples/exam_science.hwp` 12/15/18/19번 본문)
- **정정**: `has_inline_tables` 가드를 `has_inline_tables && !has_other_inline_ctrls` 로 좁혀, 인라인 표 + 인라인 수식/treat_as_char Picture/Shape 동시 케이스는 일반 `layout_paragraph` 로 보내 `run_tacs / inline_x` 체계로 정상 배치 (`src/renderer/layout.rs` +13/-1)
- **검증**: `cargo test --lib` 1118/0, `svg_snapshot` 6/6, 광범위 sweep 15 fixture 274 페이지 중 271 byte-identical + 3 의도 정정 (exam_science 002/003/004), clippy 신규 0

closes #565

## 본질 분석 (Stage 1~2 디버그)

`paragraph_layout::layout_composed_paragraph` 의 인라인 수식 처리 경로 (run_tacs / inline_x) 자체는 정상 — 동일 페이지의 0.60 (12번 그림 문단, 인라인 표 없음) 의 8개 수식은 정상 분산되었으며, 0.61 (12번 본문, 인라인 표 + 수식 9) 만 잘못된 분기로 떨어진 것.

| | 0.60 (그림 문단) | 0.61 (본문) |
|---|---|---|
| 인라인 표 | 없음 | 있음 (treat_as_char Table) |
| 인라인 수식 | 8개 | 9개 |
| 분기 | `plain layout_paragraph` ✅ | `layout_inline_table_paragraph` ❌ |
| 결과 | 8개 수식 좌표 분산 | 9개 수식 모두 (534.8, 1218.106) 겹침 |

## 변경 LOC

| 파일 | +/- |
|------|-----|
| `src/renderer/layout.rs` | **+13 / -1** |

```rust
// [Task #565] 인라인 표 + 다른 인라인 컨트롤(수식/treat_as_char Picture/Shape)
// 이 같이 있는 문단은 layout_inline_table_paragraph 가 인라인 수식 등을
// 처리하지 않아 shape_layout fallback (col_area.x, para_y) 으로 9개 수식이
// 동일 좌표에 겹친다 (exam_science.hwp 12/15/18/19번). 일반
// layout_paragraph 로 보내 인라인 표 + 인라인 수식이 같은 line/x 체계
// (run_tacs / inline_x) 로 정상 배치되도록 한다.
let has_other_inline_ctrls = para.controls.iter().any(|c| match c {
    Control::Equation(_) => true,
    Control::Picture(p) => p.common.treat_as_char,
    Control::Shape(s) => s.common().treat_as_char,
    _ => false,
});

if has_inline_tables && !has_other_inline_ctrls {
    // 기존 layout_inline_table_paragraph 경로
} else {
    // 일반 layout_paragraph 경로 — 인라인 표 + 인라인 수식 정상 처리
}
```

## 검증

### Unit / Snapshot 테스트
- `cargo test --lib`: **1118 passed / 0 failed**
- `cargo test --release --test svg_snapshot`: **6/6 passed**
- `cargo clippy --release` (본 변경): **신규 경고/오류 0**
  - 사전 결함 2건 (`document_core/commands/{table_ops.rs:1007, object_ops.rs:298}` `panicking_unwrap`) 변경 전후 동일 — 본 PR 범위 외, 별도 정정 권고

### 광범위 fixture sweep (15 sample / 274 페이지)

대상: `exam_science.hwp`, `exam_kor.hwp`, `exam_math.hwp`, `exam_eng.hwp`, `exam_social.hwp`, `aift.hwp`, `issue-505-equations.hwp`, `eq-01.hwp`, `equation-lim.hwp`, `atop-equation-01.hwp`, `21_언어_기출_편집가능본.hwp`, `2010-01-06.hwp`, `biz_plan.hwp`, `k-water-rfp.hwp`, `kps-ai.hwp`

baseline (가드 강화 전) vs after-fix SVG byte-compare:

```
총 274 SVG: identical=271, diff=3

diff 파일:
  exam_science_002.svg   ← 12번 본문 정정 (9개 수식 정상 분산)
  exam_science_003.svg   ← 15번 본문 정정 (수식 정상 표시)
  exam_science_004.svg   ← 18/19번 본문 정정 (수식 정상 표시)
```

### 변경 전후 좌표 비교 (12번 본문)

| 변경 전 | 변경 후 |
|---|---|
| 9개 수식 모두 (534.8, 1218.106) — 동일 좌표 겹침 | 첫 줄 y=1174.91: X(606.87), A(887.87), B(934.87) |
|  | 둘째 줄 y=1196.37: C(549.87), D(569.87), m-4(698.87), m-2(743.97), m+2(789.08), m+4(834.19) |

### SVG 텍스트 검증 (의도 정정 영역)
- `[페이지 2 12번]` `(단,X는임의의원소기호이고,A,B,C,D의원자량은각각m-4,m-2,m+2,m+4이다.)`
- `[페이지 3 15번]` `15.-그림(가)는원자WsimY의를,(나)는원자이온반지름이온의전하XsimZ의을…`
- `[페이지 4 18번]` `18.-표는2xMHA(aq),xMH2B(aq),yMNaOH(aq)의부피를…`
- `[페이지 4 19번]` `(단,XsimZ는임의의원소기호이다.)`

→ 인라인 수식 누락 0 건.

## 회귀 위험 검증 결과

| 케이스 | 결과 |
|--------|------|
| 인라인 표만 사용 paragraph (12번 보기 셀 등) | ✅ 정상 분산 — 본 정정 가드 조건 외 |
| 인라인 표 + 인라인 그림 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 일반 분기 |
| 인라인 표 + 인라인 글상자 동시 케이스 | ✅ `has_other_inline_ctrls` 에 포함 — 일반 분기 |
| Task #287 (display equation as own LINE_SEG) | ✅ `paragraph_layout` L2245 분기 무수정 — 회귀 영역 외 |
| 광범위 sweep | ✅ 271/274 byte-identical |

## Test plan

- [x] `cargo test --lib` 1118 passed
- [x] `cargo test --release --test svg_snapshot` 6 passed
- [x] `cargo clippy --release` 본 변경 신규 경고 0
- [x] 광범위 sweep (15 fixture / 274 페이지) — 271 byte-identical + 3 의도 정정
- [x] SVG 텍스트 검증 (12/15/18/19번 본문 인라인 수식 모두 정상 표시)
- [ ] WASM 빌드 (`docker compose --env-file .env.docker run --rm wasm`) — 본 PR 환경 Docker 미가동, reviewer 환경에서 확인 권고
- [ ] rhwp-studio web Canvas 시각 판정 — WASM 빌드 후

## 잔존 / 후속

- **이슈 #566 (7번 ㉠ 위치)**: 본 PR 과 별개 결함 (셀 베이스라인). 별도 task 진행 예정.
- **clippy 사전 결함 2건** (`document_core/commands/{table_ops.rs:1007, object_ops.rs:298}` `panicking_unwrap`): 본 PR 범위 외 — 별도 issue 등록 권고.
