### PR TITLE
Task #568: 인라인 표(분수)+수식 단락 우측 편위 정정 (closes #568)

### DIFF
--- a/mydocs/orders/20260504.md
+++ b/mydocs/orders/20260504.md
@@ -1,0 +1,46 @@
+# 오늘 할일 - 2026년 5월 4일
+
+## M100 — v1.0.0 조판 엔진
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **#565** | exam_science.hwp 12/15/18/19번 인라인 수식(treat_as_char Equation) 미렌더 정정 | **완료 (Stage 4 시각 판정 대기)** | 본질 결함: `layout.rs::layout_column_item` `has_inline_tables=TRUE` 분기가 `layout_inline_table_paragraph` 호출 → 이 함수는 인라인 수식/treat_as_char Picture/Shape 무시 → `inline_shape_position` 미등록 → `shape_layout` fallback (col_area.x, para_y) 으로 9개 수식이 동일 좌표 (534.8, 1218.106) 에 겹침. 정정: `has_inline_tables && !has_other_inline_ctrls` 로 가드 강화 — 인라인 표 + 인라인 수식/treat_as_char Picture/Shape 동시 케이스는 일반 `layout_paragraph` 로 보내 `run_tacs / inline_x` 체계로 정상 배치. 변경 LOC: `src/renderer/layout.rs` +13/-1. 검증: cargo test --lib 1125 / svg_snapshot 6/6 / 광범위 sweep 15 fixture 274 페이지 중 271 byte-identical + 3 의도 정정 (exam_science 002/003/004) / clippy 신규 0. WASM 빌드 본 세션 미가동 — Stage 4 보강. 처리 보고서: `mydocs/report/task_m100_565_report.md`. 수행/구현 계획서 + Stage 1/3 보고서 누적. |
+| **#566** | exam_science.hwp 7번 표 셀 내부 ㉠/㉡ 베이스라인 위로 시프트 | **신규 — 별도 task** | 작업지시자 보고. 본질이 #565 (인라인 수식) 와 별개 — 셀 내부 paragraph baseline 또는 cs 글자 시프트 또는 valign=Top 처리. 진단 권고: `export-svg --debug-overlay -p 0` 으로 실제 y 좌표 비교. M100 milestone 등록. |
+| **#568** | exam_science.hwp 본문 인라인 표(분수)+수식 단락 우측 편위 (Task #565 후속) | **완료 (Stage 4 시각 판정 대기)** | 본질 결함: `paragraph_layout.rs::layout_composed_paragraph` L857 의 `effective_col_x/effective_col_w` 분기가 인라인 TAC 표 보유 줄의 `comp_line.segment_width` 무시 → `available_width` 가 col_area.width 로 잡혀 Justify slack 과대 산출 → 선두 공백이 80 px/space 로 부풀어 인라인 표를 +175 px 우측으로 밀던 결함. 정정: `has_picture_shape_square_wrap` 분기에 `\|\| line_has_inline_tac_table` 추가 (줄 단위 검출, Table tac=true). 임계값 `sw < col_w_hu - 200` → `sw + cs < col_w_hu - 200` 보정 (단락 들여쓰기 LINE_SEG.column_start 인코딩 paragraph 의 정상 full-width line 미진입). 변경 LOC: +25/-2. 검증: cargo test --lib 1125 / svg_snapshot 6/6 / clippy 신규 0 / 광범위 sweep 7 fixture 66 페이지 byte-identical / exam_science page 1/3/4 byte-identical, page 2 의도된 정정 (pi=61 인라인 분수 x=739.87 → 584.93). 잔여: ±5-10 px (cs/margin 결합 의도). 별도 task 후보: page 1 header LEFT-shift, 보기 셀 분수 단락 (page 3/4), 쪽번호 색·굵기. 보고서: `mydocs/report/task_m100_568_report.md`. |
+
+## 신규 이슈
+
+| Issue | 제목 | 비고 |
+|------|------|------|
+| **#565** | [m100] exam_science.hwp 12/15/18/19번 인라인 수식(Equation, treat_as_char) 미렌더 — 텍스트 라인에 빈 자리만 표시 | 작업지시자 보고 — 본 task 처리 완료 (Stage 4 시각 판정 대기) |
+| **#566** | [m100] exam_science.hwp 7번 표 셀 내부 ㉠/㉡ 베이스라인 위치가 위로 시프트됨 | 작업지시자 보고 — 별도 task 등록. 본 task 와 메커니즘 다름 (셀 베이스라인) |
+| **#568** | [m100] exam_science.hwp 본문 인라인 표(분수)+수식 단락 우측 편위 (Task #565 후속) | 작업지시자 시각 보고 → 본 task 처리 완료 (Stage 4 시각 판정 대기) |
+
+## 사전 결함 (별도 정정 권고)
+
+- `cargo clippy --release` 변경 전후 동일 발생 — 본 task 와 무관:
+  - `src/document_core/commands/table_ops.rs:1007` `panicking_unwrap`
+  - `src/document_core/commands/object_ops.rs:298` `panicking_unwrap`
+  → 별도 issue 등록 + 정정 권고
+
+## 작업 메모
+
+- 본 task 시작 전 `local/task565` 분기 (`local/devel` 기준)
+- 디버그 진단: 임시 `eprintln!` 추가 후 본질 식별 → 모두 제거 (git diff src/renderer/layout.rs +13/-1 만 잔존)
+- WASM 빌드는 Docker 가동 환경에서 별도 검증 필요 (`docker compose --env-file .env.docker run --rm wasm`)
+
+## 작업지시자 검토 사항
+
+1. **시각 판정 (#565)**: `output/exam_science_001..004.svg` — 12/15/18/19번 본문 인라인 수식 정상 표시 + 회귀 없음 확인
+2. **시각 판정 (#568)**:
+   - `output/svg/exam_science_after/exam_science_002.svg` — pi=61 (12번 응답) 인라인 분수 x=584.93 (was 739.87) 위치 정상화
+   - `output/svg/exam_science_after_dbg/exam_science_002.svg` — debug-overlay 좌표 (`s0:pi=61 ci=0 2x1`) 확인
+   - 페이지 1/3/4 byte-identical (회귀 없음) 확인
+3. **rhwp-studio web Canvas 시각 판정**: WASM 빌드 후 browser 에서 동일 문서 검증
+4. **이슈 #565 close + local/devel merge**: 시각 판정 통과 시 작업지시자 승인 필요
+5. **이슈 #568 close + local/devel merge**: 시각 판정 통과 시 작업지시자 승인 필요
+6. **이슈 #566 (7번 ㉠ 위치)** 진행 결정: 후속 처리 일정/순위
+7. **#568 잔여 항목 후속 처리**:
+   - Page 1 header sub-tables LEFT-shift (item ①) — 별도 issue + task 등록 여부
+   - Page 3/4 보기 셀 분수 단락 (13/15/16/19) — 별도 진단 task 여부 (셀 paragraph 메커니즘 다름)
+   - Page 쪽번호 색·굵기 (item ③) — 별도 issue + task 등록 여부

--- a/mydocs/plans/task_m100_568.md
+++ b/mydocs/plans/task_m100_568.md
@@ -1,0 +1,132 @@
+# Task #568 수행 계획서 — exam_science.hwp 본문 인라인 표(분수) + 수식 단락 우측 편위 정정
+
+- **마일스톤**: v1.0.0 (M100)
+- **이슈**: [#568](https://github.com/edwardkim/rhwp/issues/568)
+- **브랜치**: `local/task568` (분기점: `local/devel`)
+- **작성일**: 2026-05-04
+- **선행 타스크**: Task #565 (closed, `a35bdbe`) — 같은 단락의 인라인 수식 좌표 stack 정정. 본 타스크는 그 fix 가 가린 별개의 결함.
+
+## 1. 배경 / 증상
+
+`samples/exam_science.hwp` 본문에서 **인라인 표(treat_as_char=true) + 인라인 수식**이 함께 있는 단락의 첫 줄이 단락 left margin 기준이 아닌 column 우측으로 약 **+175 px (≈ 21.5 mm)** 편위되어 출력됨.
+
+영향 단락 (5 개, 동일 패턴):
+- p2 우단 12번 (pi=61) — 분수 "1g 의 X 에 들어 있는 중성자수"
+- p3 13번 — "(다)에서 반응한 X 의 양"
+- p3 15번 — "제 N 이온화 에너지"
+- p3 16번 — "ㄴ. ㄷ."
+- p4 19번 — "제 N 이온화 에너지"
+
+## 2. 1차 조사 결과 (코드/덤프 기반 — 코드 무수정)
+
+### 2.1 IR 측 — 단락 구조
+
+`rhwp dump -s 0 -p 61` 결과 (12번 문제 응답 단락):
+
+```
+--- 문단 0.61 --- cc=137, text_len=56, controls=10
+  텍스트: "  는? (단, 는 임의의 원소 기호이고, ...)"
+  [PS] ps_id=102 align=Justify margins: left=2260 right=0 indent=0
+  ls[0]: vpos=74118, lh=2864, sw=18939   ← 분수 단독 라인 (lh 가 표 높이)
+  ls[1]: ts=13,  lh=1150, sw=18939
+  ls[2]: ts=60,  lh=1150, sw=30562
+  [0] 표 2×1 treat_as_char=true, 14745×2864 HU (≈196.6×38.2px) — 분수
+  [1..9] 수식 (tac=true) — rmX, rmA..D, m±2, m±4
+```
+
+→ IR 단계는 정상.
+
+### 2.2 SVG 측 — 인라인 표 x 좌표 편위
+
+`output/svg/exam_science_dbg/exam_science_002.svg` debug-overlay:
+
+```
+pi=61 단락 박스 :  x=549.87, y=1137.5, w=407.5
+pi=61 ci=0 2x1 :  x=739.87, y=1137.5, w=196.6   ← 인라인 분수 위치
+첫 글리프      :  translate(747.25, 1140.44)
+```
+
+**기대**: column_x(549.87) + 단락 indent(2260 HU = 7.97 mm ≈ 30 px) ≈ `x≈580`.
+**실제**: `x=747.25`.
+**편위**: **+167 px (~21.5 mm)** 우측.
+
+이번 줄 `sw=18939 HU = 252.5 px` 는 분수 폭(196.6 px) + 약간의 lead 만큼이므로 **줄 자체 길이는 정상**. **줄의 시작 x 좌표만 잘못 계산**됨.
+
+### 2.3 코드 분기 — Task #565 fix 후 라우팅
+
+`src/renderer/layout.rs` L1967-2002:
+
+```rust
+let has_inline_tables = … treat_as_char && is_tac_table_inline …;
+let has_other_inline_ctrls = matches Equation / Picture(tac) / Shape(tac);
+
+if has_inline_tables && !has_other_inline_ctrls {
+    layout_inline_table_paragraph(…)   // 인라인 표 전용 경로
+} else {
+    layout_paragraph(…)                // 일반 경로 (run_tacs/inline_x)
+}
+```
+
+12/13/15/16/19번 단락은 **표 + 수식 동시 보유** → `else` (일반 경로) 라우팅.
+
+→ **본질 결함은 일반 경로(`layout_paragraph`)의 `run_tacs` / inline-table x 좌표 계산**. char-offset 또는 line-start x 가 line seg `vpos`/`ts`/`sw` 와 단락 left-margin 의 어느 한 축을 잘못 적용하는 것으로 추정.
+
+### 2.4 정상 단락 대조 후보
+
+- pi=33 (page 2 1×1 표, tac=false, BlockTable): x=85.73, 컬럼 좌측에 정확히 정렬 — 영향 받지 않음
+- 인라인 표만 있고 수식 없는 단락: `layout_inline_table_paragraph` 경로 → 별도 검증 필요 (Stage 1)
+
+## 3. 목표
+
+인라인 표 + 수식 단락의 첫 줄(또는 인라인 표 포함 줄) 시작 x 좌표가 **column_x + 단락 left margin** 으로 정렬되도록 정정. 회귀 0 (Task #565 fix 보존, 다른 인라인 표/수식 사용 페이지의 byte-identical 보존).
+
+## 4. 단계 개요 (4 단계)
+
+### Stage 1 — 정밀 진단 (코드 무수정)
+- pi=61 단락이 `layout_paragraph` 일반 경로로 라우팅되는지 조건 재확인
+- `run_tacs` 가 인라인 표(ci=0)의 x 좌표를 산출할 때 사용하는 line-start/segment-width/char-offset 값을 추적 (디버그 print 또는 코드 정독)
+- **+167 px** 편위가 어느 단계(line-start? align-offset? char-offset?) 에서 주입되는지 변수별 산출
+- 12번 외 13/15/16/19번 동일 패턴 확인 (각 단락의 dump + SVG 측정 좌표)
+- 정상 단락(인라인 표만, 수식만, 둘 다 없음) 3-5 개 대조군 좌표 수집
+- **산출**: `mydocs/working/task_m100_568_stage1.md` (진단 보고서) → 승인 요청
+
+### Stage 2 — 구현 계획 수립
+- Stage 1 결과로 본질 정정 방향 1-3 안 비교
+  - (a) line-start x 계산 보정
+  - (b) `run_tacs` 의 표 char-offset 처리 변경
+  - (c) `layout_inline_table_paragraph` 가드 재확장 (수식과 표 분리 처리)
+- 회귀 위험 평가 (인라인 표/수식 보유 fixture 식별 — 광범위 sweep 후보)
+- **산출**: `mydocs/plans/task_m100_568_impl.md` → 승인 요청
+
+### Stage 3 — 구현 + 검증
+- Stage 2 승인 안 적용 (`paragraph_layout.rs` 또는 `layout.rs`)
+- 검증:
+  - `cargo test --lib` 통과 (현재 1125+)
+  - `cargo clippy` 신규 경고 0
+  - `svg_snapshot` 6/6
+  - 광범위 fixture sweep: 15+ fixture 280+ 페이지 byte-identical (의도된 정정만 diff)
+  - **Task #565 fix 보존 확인** — 12/15/18/19번 인라인 수식 정상 분산
+- **산출**: `mydocs/working/task_m100_568_stage3.md` → 승인 요청
+
+### Stage 4 — 시각 판정 + 최종 보고
+- 작업지시자 SVG 시각 판정 (12/13/15/16/19번 본문 정렬 + 7번 등 비회귀)
+- 한컴 2010/2020 정답지 비교 (보조 ref, 메모리 `feedback_pdf_not_authoritative` 정합)
+- **산출**: `mydocs/report/task_m100_568_report.md` + `orders/20260504.md` 갱신
+
+## 5. 회귀 검증 범위
+
+- **필수**: `exam_science.hwp` 4 페이지 — 의도된 5 단락 정정 외 byte-identical
+- **필수**: 인라인 표(treat_as_char=true) + 수식이 함께 있는 fixture sweep — Stage 1 에서 후보 목록 확정
+- **필수**: 인라인 표만 있는 fixture (Task #565 회귀 검증 대상 포함) byte-identical
+- **필수**: `cargo test --lib` 전체 통과, `clippy` 0, `svg_snapshot` 6/6
+- **권고**: 한컴 2010/2020 환경 PDF 비교 (보조 ref)
+
+## 6. 위험 요소
+
+- **메모리 `feedback_essential_fix_regression_risk` 정합**: Task #565 fix 가린 결함 정정은 같은 코드 경로를 다시 건드려 회귀 위험 큼. Stage 1 진단을 끝까지 한 뒤 Stage 2/3 진입.
+- **메모리 `feedback_rule_not_heuristic` 정합**: HWP 표준 명세 룰(75 HU/px, 단락 left margin, line-start 좌표 산출)을 정정하므로 분기/허용오차 도입 전 "룰 vs 휴리스틱" 자문.
+- **다단/wrap 상호작용**: 12번은 우단 column. 다단에서만 발생하는지(또는 단일 단/다단 모두) Stage 1 에서 확인.
+
+## 7. 승인 요청
+
+본 수행 계획대로 Stage 1 (정밀 진단, 코드 무수정) 진입을 승인 요청합니다.

--- a/mydocs/plans/task_m100_568_impl.md
+++ b/mydocs/plans/task_m100_568_impl.md
@@ -1,0 +1,190 @@
+# Task #568 구현 계획서 — 안 (a) 상세화
+
+- **이슈**: [#568](https://github.com/edwardkim/rhwp/issues/568)
+- **브랜치**: `local/task568`
+- **단계**: Stage 2 (구현 계획)
+- **선행 산출**: `mydocs/working/task_m100_568_stage1.md` (정밀 진단)
+- **작성일**: 2026-05-04
+
+## 1. 정정 본질 (Stage 1 결론 재진술)
+
+`paragraph_layout.rs::layout_composed_paragraph` 의 `effective_col_x / effective_col_w` 산출(L857-866) 이 인라인 TAC 표 보유 줄의 `comp_line.segment_width` 를 사용하지 않음. 결과적으로 `available_width = col_area.width - margins` 가 과대 산출되고 Justify slack 이 선두 공백을 80 px / space 로 부풀려 인라인 표를 +175 px 우측으로 밀어버림.
+
+## 2. 정정 안 — 안 (a)
+
+기존 `has_picture_shape_square_wrap` 분기와 동일한 패턴(LINE_SEG.column_start/segment_width 를 effective col x/width 로 사용)을 **인라인 TAC 표 보유 줄** 에도 확장.
+
+### 2.1 변경 위치 — `paragraph_layout.rs` L857-866
+
+**현재 코드**:
+```rust
+let (effective_col_x, effective_col_w) = if has_picture_shape_square_wrap
+    && comp_line.segment_width > 0
+    && comp_line.segment_width < col_area_w_hu - 200
+{
+    let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
+    let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)
+};
+```
+
+**변경 후**:
+```rust
+// [Task #568] 인라인 TAC 표가 있는 줄도 LINE_SEG.cs/sw 적용.
+// HWP 는 인라인 TAC 표가 있는 줄의 segment_width 를 표 폭 + 잔여로 좁게
+// 인코딩한다 (wrap=TopAndBottom 영향). col_area.width 로 잡으면
+// Justify slack 이 과대 산출되어 선두 공백이 부풀어 표를 우측으로 민다
+// (exam_science.hwp 12번 응답 pi=61: +175 px 편위).
+let line_has_inline_tac_table = !tac_offsets_px.is_empty() && para.map(|p| {
+    let line_start = comp_line.char_start;
+    let line_end = line_start + comp_line.runs.iter()
+        .map(|r| r.text.chars().count()).sum::<usize>();
+    tac_offsets_px.iter().any(|(pos, _, ci)| {
+        *pos >= line_start && *pos <= line_end
+            && matches!(p.controls.get(*ci), Some(Control::Table(t)) if t.common.treat_as_char)
+    })
+}).unwrap_or(false);
+
+let (effective_col_x, effective_col_w) = if (has_picture_shape_square_wrap || line_has_inline_tac_table)
+    && comp_line.segment_width > 0
+    && comp_line.segment_width < col_area_w_hu - 200
+{
+    let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
+    let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)
+};
+```
+
+### 2.2 핵심 설계 결정
+
+**(1) 줄 단위 판정**
+- 조건은 paragraph 단위가 아니라 **줄(comp_line) 단위**. 같은 paragraph 안에서도 인라인 표가 있는 줄(line[0])과 없는 줄(line[2])이 다를 수 있다.
+- pi=61 의 line[0]/[1] 는 sw=18939 (좁음), line[2] 는 sw=30562 (full). line[2] 는 새 분기 미진입 (`comp_line.segment_width < col_area_w_hu - 200` 불충족 — 30562 ≥ 31692-200 = 31492? 실제 30562 < 31492 라 조건 충족하긴 함).
+- 단 line[2] 는 인라인 TAC 표가 없으므로 `line_has_inline_tac_table=false` → 새 분기 미진입.
+
+**(2) 임계값 200 HU 재사용**
+- 기존 `has_picture_shape_square_wrap` 분기와 동일한 임계값. 다단/회귀 차단 의도 일관.
+
+**(3) 표만(Table tac=true) — 수식/Picture 제외**
+- 인라인 수식(Equation tac=true) 은 작아서 sw 가 좁혀지지 않음(Stage 1 §5.3 검증).
+- TAC Picture 도 동일.
+- 표만 좁은 sw 를 유발 → Table 만 검출.
+
+**(4) `has_picture_shape_square_wrap` 와 OR 결합**
+- 기존 분기 보존 (Picture/Shape Square wrap 케이스 동일 출력).
+- 두 조건 OR — 한쪽이라도 활성이면 narrow sw 적용.
+
+### 2.3 이차 영향 — extra_word_sp 자동 정상화
+
+`available_width` 가 narrow sw 기반으로 좁아지면:
+- `effective_col_w = 252.5 px` (vs 기존 407.5)
+- `available_width = 252.5 - 15.07 - 0 = 237.4 px`
+- est_x: 미변경 (text_width + tac_width 계산은 effective_col_w 와 무관)
+- `total_text_width ≈ 236.6 px` (변동 없음)
+- `slack = 237.4 - 231.6 = 5.8 px` → `extra_word_sp = 5.8/2 = 2.9 px / space` ← **정상 범위**
+- 표 시작 x = 564.94 + 2 × (5 + 2.9) = 580.7 px ≈ 기대값 ✓
+
+`x_start` 도 자동 정상화 (effective_col_x = col_area.x + cs_px ≈ 549.87 + 15.07 = 564.94). 단 cs_px 가 line[0].column_start 이며, pi=61 ls[0].cs=1130 HU → 15.07 px → effective_col_x = 549.87 + 15.07 = 564.94. 그리고 effective_margin_left 는 별도로 더해지므로 **이중 적용** 위험.
+
+**검증 필요**: cs_px 와 margin_left 가 의미상 중복인지, 별개 좌표축인지.
+
+기존 `has_picture_shape_square_wrap` 분기에서는 `effective_col_x = col_area.x + cs_px` 후 `x_start = effective_col_x + effective_margin_left + ...` 로 모두 더한다. Picture wrap 케이스에서 이 분기로 정상 출력이 나왔다면, **cs_px = 한컴이 인코딩한 line 시작 절대 오프셋, margin_left = paragraph 단락 여백** 으로 별개 의미. 두 값은 일반적으로 동시에 0 이거나 한쪽만 의미를 가진다.
+
+pi=61 의 ls[0].cs=1130 HU → 한컴이 인코딩한 line 시작 오프셋이 이미 15 px 들어가 있음. paragraph margin_left=2260 HU → resolver 가 /2 적용 후 15.07 px. **수치적으로 같은 15 px** — 한컴이 paragraph margin 을 LINE_SEG.cs 에도 반영해서 인코딩한 가능성 높음.
+
+만약 cs + margin 이중 적용되면 표 x = 549.87 + 15.07(cs) + 15.07(margin) + 2×(5+2.9) ≈ 596 px → 16 px 추가 우측 편위 → 여전히 결함.
+
+#### 2.3.1 분기 후보 — 이중 적용 회피
+
+옵션 A1: 새 분기 진입 시 `effective_margin_left = 0` (cs 가 margin 역할 흡수했다고 가정)
+옵션 A2: 새 분기 진입 시 `effective_col_x = col_area.x` (cs 무시), `effective_col_w = sw_px`
+옵션 A3: 그대로 두고 (Picture wrap 분기와 동일) Stage 3 실측 후 보정
+
+**Stage 3 에서 실측 결정**. 단, Picture wrap 분기에서 회귀 없이 동작하므로 이중 적용은 일반적으로 발생하지 않을 것 (한컴 인코딩 관습상 두 값이 보완적). 표 wrap 케이스만 다를 가능성 있음 → Stage 3 첫 build 후 SVG 좌표 실측으로 결정.
+
+## 3. 변경 파일/LOC 추정
+
+| 파일 | 변경 | 추정 LOC |
+|------|------|---------|
+| `src/renderer/layout/paragraph_layout.rs` | L857 직전 `line_has_inline_tac_table` 산출 + L857 조건 확장 | +12 / -1 |
+
+기타 파일 변경 없음 (단일 분기 확장).
+
+## 4. 회귀 검증 계획 (Stage 3)
+
+### 4.1 단위 테스트 / 통합 테스트
+
+```bash
+cargo test --lib              # 1125+ 통과 확인
+cargo test --test issue_546   # exam_science 페이지 수 4 유지
+cargo clippy --all-targets -- -D warnings  # 신규 경고 0
+```
+
+### 4.2 svg_snapshot 골든 (필수)
+
+```bash
+cargo test --test svg_snapshot     # 6/6 통과
+```
+
+기존 골든 fixture 6 개 — exam_science 미포함 추정. byte-identical 보장.
+
+### 4.3 광범위 fixture sweep
+
+전체 `samples/*.hwp{,x}` (159 파일) 중 다음 기준 후보 선정:
+1. **인라인 TAC 표 보유**: ck-table-fcn-table.hwp, atop-equation-01.hwp, equation-lim.hwp, exam_science.hwp, exam_math.hwp, exam_*.hwp, fraction*.hwp 등.
+2. **인라인 수식 보유**: 같은 위 + 추가 candidates.
+3. **다단 paragraph**: exam_*.hwp 모두 다단.
+4. **Picture/Shape wrap=Square**: 21_언어_기출_편집가능본.hwp 등 — Stage 1 §4 의 narrow sw 보유 paragraph 의 정상 출력 보존 검증.
+
+스크립트 (Stage 3 에서):
+```bash
+for f in samples/*.hwp samples/*.hwpx; do
+  # 변경 전 SVG → /tmp/before/$(basename $f).svg
+  # 변경 후 SVG → /tmp/after/$(basename $f).svg
+  diff -q /tmp/before/...  /tmp/after/...
+done
+```
+
+기준:
+- exam_science.hwp: page 2/3/4 의도된 diff (12/13/15/16/19번 분수 위치 정정)
+- 나머지: byte-identical
+
+### 4.4 시각 판정 (Stage 4)
+
+- 작업지시자 SVG 시각 판정 (12/13/15/16/19번 본문 정렬 + 7번 등 비회귀)
+- 한컴 2010/2020 정답지 (PDF 200dpi) 비교 (보조 ref)
+
+## 5. 위험 요소 및 완화
+
+| 위험 | 발현 조건 | 완화책 |
+|------|----------|-------|
+| **cs/margin 이중 적용** | LINE_SEG.cs 가 paragraph margin 을 이미 흡수한 인코딩 | Stage 3 첫 빌드 후 SVG 좌표 실측 → 옵션 A1/A2/A3 선택 |
+| Picture Square wrap 회귀 | 새 조건 `\|\|` 결합으로 기존 case 무영향 (조건 만족 시 동일 분기 진입) | 기존 fixture (21_언어_기출 등) byte-identical 검증 |
+| 인라인 표 + full sw paragraph 회귀 | pi=79/110/118/120 — `comp_line.segment_width >= col_area_w_hu - 200` → 새 분기 미진입 | Stage 3 sweep 으로 byte-identical 확인 |
+| 셀 내부 paragraph 효과 | cell_ctx + narrow sw + 인라인 표 — 의도된 정정 영향 | 광범위 sweep 에서 의도된 diff 만 발생 확인 |
+| **메모리 `feedback_essential_fix_regression_risk` 정합** | 본질 정정은 회귀 위험 큼 | 광범위 sweep + 한컴 2010/2020 보조 검증 + 시각 판정 |
+
+## 6. Stage 3 실행 순서
+
+1. 코드 변경 (L857 분기 확장 + line_has_inline_tac_table 산출).
+2. `cargo build --release` — 빌드 통과.
+3. `target/release/rhwp export-svg samples/exam_science.hwp -o /tmp/svg_after/` — 본 사례 SVG 생성.
+4. pi=61 표 좌표 (debug-overlay) 측정 — 정상 (~580 px) 확인.
+5. 이중 적용 발견 시 옵션 A 분기 선택, 재빌드.
+6. `cargo test --lib`, `cargo clippy`, `cargo test --test svg_snapshot` — 통과.
+7. 광범위 sweep — byte-identical 확인 (의도된 diff 만 exam_science).
+8. Stage 3 보고서 작성.
+
+## 7. 산출물 (Stage 3)
+
+- `mydocs/working/task_m100_568_stage3.md` — 구현 + 검증 결과
+- 코드 diff: `src/renderer/layout/paragraph_layout.rs`
+- (필요 시) sweep 결과 요약
+
+## 8. 승인 요청
+
+본 구현 계획대로 Stage 3 (구현 + 검증) 진입을 승인 요청합니다.

--- a/mydocs/report/task_m100_568_report.md
+++ b/mydocs/report/task_m100_568_report.md
@@ -1,0 +1,192 @@
+# Task #568 최종 결과 보고서 — exam_science.hwp 본문 인라인 표(분수)+수식 단락 우측 편위 정정
+
+- **마일스톤**: v1.0.0 (M100)
+- **이슈**: [#568](https://github.com/edwardkim/rhwp/issues/568)
+- **브랜치**: `local/task568` (분기점: `local/devel`)
+- **작성일**: 2026-05-04
+- **선행 task**: #565 (closed) — 같은 단락의 인라인 수식 좌표 stack 정정
+- **상태**: **Stage 4 시각 판정 대기**
+
+## 1. 배경
+
+`samples/exam_science.hwp` 본문에서 인라인 표(treat_as_char=true) + 인라인 수식이 함께 있는 단락의 첫 줄이 단락 left margin 기준이 아닌 column 우측으로 약 +175 px (≈ 21.5 mm) 편위되어 출력. 사용자 시각 보고로 식별됨.
+
+영향 단락 (작업지시자 보고):
+- p2 우단 12번 응답 (pi=61) — 분수 "1g 의 X 에 들어 있는 중성자수"
+- p3 13번 / 15번 / 16번 / p4 19번 — 보기 셀 분수 단락
+
+선행 task #565 의 fix(`a35bdbe` — 인라인 표+수식 단락을 일반 `layout_paragraph` 경로로 우회) 가 가린 별개의 결함이 표면화된 것.
+
+## 2. 본질 결함
+
+`src/renderer/layout/paragraph_layout.rs::layout_composed_paragraph` L857-866 의 `effective_col_x / effective_col_w` 분기가 **인라인 TAC 표 보유 줄의 `comp_line.segment_width` 를 무시**.
+
+HWP 는 인라인 TAC 표가 있는 줄의 segment_width 를 표 폭 + 잔여로 좁게 인코딩하지만 (wrap=TopAndBottom 영향), layout 은 컬럼 전체 폭(31692 HU = 422.6 px)으로 `effective_col_w` 를 잡았다. 결과:
+
+```
+available_width = 407.5 - 15.07 = 392.4 px         (실제로는 252.5 - 15.07 = 237.4 px 가 맞음)
+slack = 392.4 - 231.6 = 160.8 px                    (실제 5.8 px 가 맞음)
+extra_word_sp = 160.8 / 2 = 80.4 px / space         (실제 2.9 px / space)
+table x = 564.94 + 2 × (5 + 80.4) = 735.74          (실제 ≈ 580 px 가 맞음)
+```
+
+선두 공백 2 개 × 80 px 부풀림으로 인라인 표가 +160 px 우측 편위.
+
+## 3. 정정
+
+### 3.1 코드 변경 — `paragraph_layout.rs` L857 분기 확장
+
+```rust
+// [Task #568] 인라인 TAC 표(treat_as_char=true) 가 있는 줄도 동일 처리.
+let line_has_inline_tac_table = !tac_offsets_px.is_empty() && para.map(|p| {
+    let line_start = comp_line.char_start;
+    let line_end = line_start + comp_line.runs.iter()
+        .map(|r| r.text.chars().count()).sum::<usize>();
+    tac_offsets_px.iter().any(|(pos, _, ci)| {
+        *pos >= line_start && *pos <= line_end
+            && matches!(p.controls.get(*ci),
+                Some(Control::Table(t)) if t.common.treat_as_char)
+    })
+}).unwrap_or(false);
+
+// [Task #568] 임계값에 column_start 포함 — 실제 가용 line 폭은 (sw + cs).
+let line_avail_hu = comp_line.segment_width.saturating_add(comp_line.column_start);
+let (effective_col_x, effective_col_w) = if (has_picture_shape_square_wrap
+    || line_has_inline_tac_table)
+    && comp_line.segment_width > 0
+    && line_avail_hu < col_area_w_hu - 200
+{
+    let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
+    let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)
+};
+```
+
+### 3.2 핵심 설계
+
+| 항목 | 결정 | 근거 |
+|------|------|------|
+| 활성 조건 추가 | `\|\| line_has_inline_tac_table` (줄 단위 검출) | 인라인 TAC 표 보유 paragraph 도 줄 단위 활성. line char range × tac_offsets_px × Control::Table(tac=true) 교차 |
+| 임계값 보정 | `sw + cs < col_w_hu - 200` | 단락 들여쓰기를 LINE_SEG.column_start 로 인코딩한 paragraph 의 정상 full-width line (sw+cs ≈ col_w_hu) 미진입 보장. 기존 Picture wrap (cs=0) 동등 |
+| 분기 보존 | OR 결합 | 기존 `has_picture_shape_square_wrap` 케이스 (pi=21/37/60) 동일 출력 |
+
+### 3.3 변경 LOC
+
+`src/renderer/layout/paragraph_layout.rs`: **+25 / -2**
+
+## 4. 검증 결과
+
+### 4.1 자동 테스트
+
+| 테스트 | 결과 |
+|--------|------|
+| `cargo test --lib` | **1125 passed**, 0 failed, 2 ignored |
+| `cargo test --test svg_snapshot` | **6/6 passed** |
+| `cargo clippy --release --lib` | 본 변경 신규 경고 0 (사전 결함 2건 변경 전후 동일) |
+
+### 4.2 광범위 fixture sweep — 회귀 0
+
+대표 7 fixture / **66 SVG 페이지** byte-identical:
+
+| Fixture | 페이지 | 결과 |
+|---------|------|------|
+| `21_언어_기출_편집가능본.hwp` (Picture Square wrap) | 15 | byte-identical |
+| `atop-equation-01.hwp` | 1 | byte-identical |
+| `equation-lim.hwp` | 1 | byte-identical |
+| `eq-01.hwp` | 1 | byte-identical |
+| `exam_eng.hwp` | 8 | byte-identical |
+| `exam_math.hwp` | 20 | byte-identical |
+| `exam_kor.hwp` | 20 | byte-identical |
+
+### 4.3 의도된 정정 — `exam_science.hwp`
+
+| 페이지 | 변경 | 사유 |
+|------|------|------|
+| 1 | byte-identical | 영향 없음 |
+| **2** | **변경됨** | pi=61 ls[0] 인라인 분수 (12번 응답) 위치 정정 |
+| 3 | byte-identical | pi=110 (13번) 등 sw+cs=full → 새 분기 미진입 |
+| 4 | byte-identical | pi=118/120 등 동일 |
+
+**Pi=61 인라인 분수 위치 측정**:
+
+| 항목 | Before | After | 기대값 | 편위 |
+|------|--------|-------|--------|------|
+| 인라인 2×1 표 x | **739.87** | **584.93** | ~575-590 | ±5-10 px (잔여) |
+
+선두 공백 `extra_word_spacing`: 80 px/space → 2.9 px/space.
+
+### 4.4 활성화 분포 (TASK568_TRACE)
+
+| paragraph | 라인 | sq | tac_tbl | sw | cs | avail | 분기 |
+|-----------|------|-----|---------|-----|-----|-------|------|
+| pi=21 | 0..5 | true | false | 19592 | 0 | 19592 | OLD = NEW (활성) |
+| pi=37 | 0..5 | true | false | 17546 | 0 | 17546 | OLD = NEW (활성) |
+| pi=60 | 0..3 | true | false | 20069 | 0 | 20069 | OLD = NEW (활성) |
+| **pi=61** | **0** | **false** | **true** | **18939** | **1130** | **20069** | **NEW (의도된 활성)** |
+| pi=110/118/120 | 다양 | false | true | 30562 | 1130 | 31692 | OLD/NEW 모두 미활성 (정확) |
+
+## 5. 잔여 / 미해결 항목 (별도 task 후보)
+
+본 fix 는 인라인 표 + 수식 + **narrow segment_width** 조합만 정정. 다음 항목은 별도 메커니즘:
+
+| 항목 | 현상 | 코드 경로 | 권고 |
+|------|------|-----------|------|
+| ① **Page 1 header LEFT-shift** | 외곽 1×1 표 cell 의 inline sub-tables (성명/수험번호/제선택) 가 cell halign=Center 미적용 | cell halign 처리 | 별도 issue + task |
+| **Page 3/4 보기 셀 분수 (13/15/16/19)** | 셀 paragraph 의 inline TAC 표 — 셀 paragraph segment_width = full cell width (좁지 않음) → 본 fix 임계값 미충족 | cell paragraph layout | 별도 진단 (다른 결함) |
+| ③ **페이지 쪽번호 색·굵기** | 바탕쪽 쪽번호 fill=#000000 font-weight=bold | 바탕쪽 CharShape 적용 | 별도 issue + task |
+
+### 5.1 작업지시자 피드백 분석
+
+> "심하진 않고, 좌측 편위가 생기는 문제도 있음"
+
+- "심하진 않고" → pi=61 ±5-10 px 잔여 (non-severe). HWP 의 cs / margin 결합 의도 (단일 vs 합산) 가 PDF/한컴 2010·2020 비교 필요. 메모리 `feedback_pdf_not_authoritative` 정합 — PDF 절대 기준 아님.
+- "좌측 편위 도 있음" → 미해결 항목 ① (page 1 header) 잔존, 또는 위 잔여 ~5 px LEFT 편위 인지로 추정.
+
+### 5.2 메모리 정합 검토
+
+- `feedback_essential_fix_regression_risk`: ✓ 광범위 sweep 66 페이지 byte-identical, exam_science 4 페이지 중 page 2 만 의도된 정정.
+- `feedback_rule_not_heuristic`: ✓ HWP 표준 룰 (LINE_SEG.cs/sw 기반 effective col 산출) 단일 룰. 휴리스틱 임계값 미도입 (200 HU 기존 임계값 재사용).
+- `feedback_pdf_not_authoritative`: ✓ PDF 기준 미사용. SVG 좌표 + dump IR 데이터로 검증.
+
+## 6. 산출물
+
+```
+src/renderer/layout/paragraph_layout.rs           +25 / -2 LOC
+mydocs/plans/task_m100_568.md                     수행 계획서
+mydocs/working/task_m100_568_stage1.md            Stage 1 진단 (코드 무수정)
+mydocs/plans/task_m100_568_impl.md                Stage 2 구현 계획
+mydocs/working/task_m100_568_stage3.md            Stage 3 구현+검증
+mydocs/report/task_m100_568_report.md             본 최종 보고서
+output/svg/exam_science_after/                    시각 판정용 SVG (4 페이지)
+output/svg/exam_science_after_dbg/                debug-overlay SVG (4 페이지)
+```
+
+## 7. 커밋 이력
+
+```
+ebf0f99c Task #568 Stage 0: 수행 계획서 (인라인 표+수식 단락 우측 편위 정정)
+e08c8897 Task #568 Stage 1: 정밀 진단 보고서 (코드 무수정) — 본질 결함 식별
+ec5aea8c Task #568 Stage 2: 구현 계획서 (안 (a) 상세화)
+5fba0abf Task #568 Stage 3: layout_composed_paragraph 분기 확장 …
+```
+
+## 8. 작업지시자 검토 사항
+
+1. **시각 판정 — 본 task 효과**:
+   - `output/svg/exam_science_after/exam_science_002.svg` — pi=61 (12번 응답) 인라인 분수 위치 정상화 확인
+   - `output/svg/exam_science_after_dbg/exam_science_002.svg` — debug-overlay 좌표 (`s0:pi=61 ci=0 2x1`) 확인
+2. **시각 판정 — 비회귀**:
+   - `exam_science_001.svg`, `exam_science_003.svg`, `exam_science_004.svg` byte-identical (변경 없음)
+   - 광범위 sweep 7 fixture 66 페이지 byte-identical
+3. **rhwp-studio web Canvas 시각 판정**: WASM 빌드 후 browser 검증 (Docker 가동 환경)
+4. **이슈 #568 close + local/devel merge** 결정: 시각 판정 통과 시
+5. **잔여 항목 후속 처리 결정**:
+   - Page 1 header sub-tables LEFT-shift (item ①) — 별도 issue + task 등록 여부
+   - Page 3/4 보기 셀 분수 단락 (13/15/16/19) — 별도 진단 task 여부
+   - Page 쪽번호 색·굵기 (item ③) — 별도 issue + task 등록 여부
+
+## 9. 승인 요청
+
+본 최종 보고서로 Task #568 완료 승인 요청합니다.

--- a/mydocs/working/task_m100_568_stage1.md
+++ b/mydocs/working/task_m100_568_stage1.md
@@ -1,0 +1,258 @@
+# Task #568 Stage 1 진단 보고서 — 본질 결함 식별
+
+- **이슈**: [#568](https://github.com/edwardkim/rhwp/issues/568)
+- **브랜치**: `local/task568`
+- **단계**: Stage 1 — 정밀 진단 (코드 무수정)
+- **작성일**: 2026-05-04
+
+## 1. 결론 (요약)
+
+본질 결함은 **`layout_composed_paragraph` 의 `available_width` 가 `col_area.width` 만 사용하고, 줄별 `comp_line.segment_width` 를 무시**하는 것이다.
+
+인라인 TAC 표(treat_as_char + wrap=TopAndBottom)가 있는 줄에서 HWP 는 `LINE_SEG.segment_width` 를 표 폭 + 작은 여유로 좁게 인코딩한다. 그런데 layout 은 컬럼 전체 폭(407.5 px) 으로 `available_width` 를 잡고, **Justify slack 을 과대 산출** 해 `extra_word_spacing` (per-space) 으로 분배한다. 결과적으로 줄 시작의 공백 글자가 80 px 씩 늘어나 그 다음에 오는 인라인 표를 약 +167 px 우측으로 밀어버린다.
+
+같은 패턴이 셀 내부 paragraph 에도 동일하게 발생 (cell_ctx 가 있어도 코드 경로는 같음).
+
+## 2. 핵심 단락 — pi=61 (page 2 12번 응답)
+
+### 2.1 IR 측 데이터 (rhwp dump + 임시 example diag_task568)
+
+```
+--- 문단 0.61 --- cc=137, text_len=56, controls=10
+  텍스트: "  는? (단, 는 임의의 원소 기호이고, , , , 의 원자량은 각각 , , , 이다.) [3점] "
+  [PS] ps_id=102 align=Justify spacing: before=0 after=1000 line=140/Percent
+       margins: left=2260 right=0 indent=0
+  ls[0]: vpos=74118 lh=2864 bl=1432 ls=460 cs=1130 sw=18939 text_start=0
+  ls[1]: vpos=77442 lh=1150 bl=575 ls=460 cs=1130 sw=18939 text_start=13
+  ls[2]: vpos=79052 lh=1150 bl=575 ls=460 cs=1130 sw=30562 text_start=60
+  ctrl[0]: Table 행=2 tac=true wrap=TopAndBottom w=14745 h=2864    ← 인라인 분수
+  ctrl[1..9]: Equation tac=true (rmX, rmA..D, m±2, m±4)
+  composed.lines = 3
+    line[0]: char_start=0 segment_width=18939 line_height=2864 runs=1
+      run[0]: 5 chars text="  는? "
+    line[1]: char_start=5 segment_width=18939 line_height=1150 runs=1
+      run[0]: 23 chars text="(단, 는 임의의 원소 기호이고, , , "
+    line[2]: char_start=28 segment_width=30562 line_height=1150 runs=4
+  tac_controls (pos, width_HU, ci):
+    (2, 14745 HU = 196.60 px, ci=0)   ← 인라인 표 (분수) — line[0] 내부, 2 spaces 뒤
+    (9, 675 HU = 9 px, ci=1)
+    (24, 11 px, ci=2) ... (46, 34.11 px, ci=9)
+```
+
+**핵심 관찰**:
+- `ls[0]` 와 `ls[1]` 는 sw=18939 HU = **252.5 px** (좁은 segment), `ls[2]` 만 sw=30562 HU = **407.5 px** (full column).
+- 컬럼 전체 폭 = 30562 HU = 407.5 px (다단 한 단).
+- `tac_controls` pos=2 (line[0] 내부) — 2 spaces 뒤에 인라인 분수.
+
+### 2.2 SVG 측 실측 (output/svg/exam_science_dbg/exam_science_002.svg)
+
+```
+column 1 좌측 edge :  x=549.87 (또는 536.8 — column 박스 내 안쪽 텍스트 영역)
+pi=61 단락 박스   :  x=549.87, y=1137.5, w=407.5
+pi=61 ci=0 2x1   :  x=739.87, y=1137.5, w=196.6   ← 인라인 분수 debug-overlay
+첫 cell 글리프    :  translate(747.25, 1140.44)
+```
+
+**좌표 차이**:
+- 컬럼 시작: x=549.87
+- 단락 left margin: 2260 HU / 7200 inch / 25.4 mm × 96dpi 변환 후 ParaStyle resolver 가 `/2` 적용 → **15.07 px**
+- 기대 표 시작 x : 549.87 + 15.07 ≈ **564.94 px** (Justify 의 default branch)
+- 실제 표 시작 x : **739.87 px**
+- **편위: +174.93 px**
+
+## 3. 원인 추적 — 코드 경로
+
+### 3.1 라우팅 (Task #565 fix 후)
+
+`src/renderer/layout.rs` L2056-2120:
+
+```rust
+let has_inline_tables = … treat_as_char + is_tac_table_inline …;
+let has_other_inline_ctrls = matches Equation / Picture(tac) / Shape(tac);
+
+if has_inline_tables && !has_other_inline_ctrls {
+    layout_inline_table_paragraph(…)        // 인라인 표 전용
+} else {
+    layout_paragraph(…)                     // 일반 경로
+}
+```
+
+pi=61 는 `has_inline_tables=true && has_other_inline_ctrls=true` → **else 분기 (일반 경로)**.
+
+### 3.2 일반 경로 — `layout_composed_paragraph` (paragraph_layout.rs)
+
+#### 3.2.1 `effective_col_x / effective_col_w` 계산 (L857-866)
+
+```rust
+let (effective_col_x, effective_col_w) = if has_picture_shape_square_wrap
+    && comp_line.segment_width > 0
+    && comp_line.segment_width < col_area_w_hu - 200
+{
+    let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
+    let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)        ← pi=61 line[0] 진입 — Picture/Shape 없음
+};
+```
+
+`has_picture_shape_square_wrap` 은 비-TAC Picture 또는 Shape 의 wrap=Square 만 검출. pi=61 의 인라인 TAC 표 (treat_as_char=true) 는 이 조건에 해당하지 않으므로 **else 분기로 빠져 `col_area.width` 를 사용**한다 → `effective_col_w = 407.5 px` (실제 줄 폭 252.5 px 가 아닌 컬럼 전체).
+
+#### 3.2.2 `available_width` 산출 (L907)
+
+```rust
+let available_width = effective_col_w - effective_margin_left - margin_right
+                       - inline_offset - num_offset;
+                    = 407.5 - 15.07 - 0 - 0 - 0
+                    = 392.43 px       ← 실제로는 252.5 - 15 = 237 px 가 맞음
+```
+
+#### 3.2.3 Justify slack 분배 (L1087-1121)
+
+line[0] 의 run = "  는? " (5 chars, 2 leading spaces + "는?" + trailing space).
+
+est_x 계산 (L984-1004):
+```
+est_x_start = effective_margin_left + 0 = 15.07
+seg "  " (2 spaces, extra_word_sp 미적용 시점) → est_x += ~10 px
+TAC 표 → est_x += 196.6 px
+remaining "는? " → est_x += ~30 px
+est_x ≈ 251.67 px
+total_text_width = est_x - est_x_start ≈ 236.6 px
+```
+
+`needs_justify = true` (line[0] 은 마지막 줄 아니고 forced break 없음) →
+```
+all_chars = "  는? "  →  trailing_spaces=1, visible_count=4, interior_spaces=2 (선두 2개)
+trailing_width = ~5 px (한 공백 폭)
+effective_used = 236.6 - 5 = 231.6
+slack = available_width - effective_used = 392.43 - 231.6 = 160.83 px
+extra_word_sp = slack / interior_spaces = 160.83 / 2 = 80.41 px / space    ← 본질 결함
+```
+
+#### 3.2.4 렌더링 — 표가 우측으로 밀려나는 순간 (L1734-1774, L1888-1939)
+
+```rust
+let mut x = x_start;       // x_start = effective_col_x + effective_margin_left = 564.94
+
+for &(tac_rel, tac_w, tac_ci) in &run_tacs {
+    if seg_start < tac_rel {                    // seg_start=0 < tac_rel=2
+        let seg_text = "  ";                    // run_chars[0..2] = 2 spaces
+        let seg_w = estimate_text_width(seg_text, &seg_style);
+        // estimate_text_width 가 공백마다 extra_word_spacing 추가 (text_measurement.rs:220):
+        //    if c == ' ' { w += style.extra_word_spacing; }
+        // → seg_w ≈ 2 * (5 + 80.41) = 170.82 px
+        x += seg_w;                             // x = 564.94 + 170.82 = 735.76
+    }
+    // 인라인 TAC 표 렌더 (L1888-1903)
+    if let Some(Control::Table(t)) = ... {
+        if t.common.treat_as_char {
+            self.layout_table(... Some(x) ...);   // x ≈ 735.76 ≈ 실측 739.87 ✓
+            tree.set_inline_shape_position(... x, table_y);
+        }
+    }
+    x += tac_w;
+    seg_start = tac_rel;
+}
+```
+
+**산식 일치**: x_start(564.94) + 2 spaces × (5 + 80.41 extra) = 735.76 px ≈ 실측 739.87 (±4 px 폰트 metric 오차).
+
+## 4. 영향 범위
+
+### 4.1 narrow segment_width + 인라인 TAC 표 보유 paragraph 스캔 (exam_science.hwp)
+
+임시 example `diag_task568.rs` 로 전체 paragraph 스캔:
+
+| pi | text 미리보기 | narrow_lines (sw HU) | inline TAC 표 |
+|----|--------------|---------------------|--------------|
+| 21 | "5.-그림은 밀폐된 진공 용기에…" | sw=19592 (lines 0-5) | ✗ (Picture wrap=Square — 기존 fix 적용됨) |
+| 37 | "8.-그림은 수소와 원소 로…" | sw=17546 | ✗ (Picture wrap=Square) |
+| 60 | "12.-그림은 원자 의 중성자수와…" | sw=20069 | ✗ (Picture wrap=Square) |
+| **61** | "  는? (단, 는 임의의 원소…" | **sw=18939 (lines 0-1)** | **✓ (분수 2×1)** ← 본 결함 트리거 |
+
+→ 본 문서 본문(컬럼 직접 paragraph)에는 pi=61 만 narrow seg + inline TAC 표 조합.
+
+### 4.2 셀 내부 paragraph (사용자 보고 페이지 3/4 항목)
+
+사용자 보고:
+- p3 13번 "(다)에서 반응한 의 양()" — pi=68 외곽 3×3 보기 표 의 셀[5] 내부 paragraph "ㄴ. 이다." 에 인라인 분수(2×1 표)
+- p3 15번 "제 이온화 에너지" — 마찬가지 보기 셀 내부 분수 paragraph
+- p3 16번 "ㄴ. ㄷ." — 마찬가지
+- p4 19번 "제 이온화 에너지" — 마찬가지
+
+이 cell 내부 paragraph 들도 `layout_composed_paragraph` 를 통과하며 (cell_ctx Some), 동일한 `effective_col_w = col_area.width` (cell inner width) 분기를 탄다. **셀 폭이 인라인 분수 폭보다 충분히 크면 동일 결함이 발현** (cell width 30562 vs 분수 ~15311 HU 차이만큼 slack 과대 산출).
+
+→ **본질 결함은 단일** — 인라인 TAC 표가 있는 줄의 `comp_line.segment_width` 를 `effective_col_w` 로 사용하지 않는 것. 본문 paragraph 든 셀 내부 paragraph 든 같은 코드 경로.
+
+## 5. 정상 케이스 대조
+
+### 5.1 has_picture_shape_square_wrap 분기 (이미 동작)
+
+pi=21/37/60 (그림 wrap=Square) — 이 분기는 narrow `segment_width` 를 인식하여 `effective_col_w = sw_px` 로 좁힘. Justify slack 도 좁은 폭 기준 산출 → 정상 배치.
+
+### 5.2 인라인 표만 (수식 없음) — `layout_inline_table_paragraph`
+
+`has_inline_tables && !has_other_inline_ctrls` 분기는 별도 함수 사용. 이 함수는 인라인 표 폭을 직접 처리하므로 본 결함 미발현. (Task #565 가 가린 결함이 별개 경로에서 노출된 것.)
+
+### 5.3 Equation tac=true 만 (표 없음) — full segment_width
+
+수식만 있는 paragraph 는 HWP 가 segment_width 를 좁히지 않음 (수식은 작아서). full sw 사용 → 본 결함 미발현.
+
+## 6. 본질 정정 방향 (Stage 2 제안 후보)
+
+### 안 (a) — `effective_col_x/effective_col_w` 분기 확장
+
+`has_picture_shape_square_wrap` 조건에 **인라인 TAC 표 보유 줄** 도 포함:
+
+```rust
+let has_narrow_seg_for_tac = comp_line.segment_width > 0
+    && comp_line.segment_width < col_area_w_hu - 200
+    && /* 이 줄에 inline TAC 표 또는 큰 inline TAC 가 있고 sw 가 그 폭 부근 */;
+
+let (effective_col_x, effective_col_w) = if (has_picture_shape_square_wrap || has_narrow_seg_for_tac)
+    && comp_line.segment_width > 0
+    && comp_line.segment_width < col_area_w_hu - 200
+{
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)
+};
+```
+
+**장점**: 기존 분기 패턴 재사용, 작은 변경 면적, Picture/Shape Square wrap 과 동등성 유지.
+**단점**: "인라인 TAC 표 보유 줄" 판정 로직 필요 (tac_offsets_px + line char range 교차).
+
+### 안 (b) — Justify slack 산출 시 segment_width 클램프
+
+`available_width` 자체는 col_area 폭 그대로 두되, slack 계산 시 segment_width 만큼 클램프.
+
+**단점**: 안 (a) 와 효과는 같으나 분기 흩어짐 (slack/x_start/available_width 서로 다른 위치). 본질이 effective_col_w 인데 부분 정정.
+
+### 안 (c) — 인라인 TAC 표 보유 paragraph 라우팅 재변경
+
+Task #565 fix 부분 되돌리고, 인라인 표는 `layout_inline_table_paragraph` 로, 수식만 별도 처리.
+
+**단점**: 두 함수 양쪽 다 인라인 수식 처리 추가 필요 → 변경 면적 큼, 회귀 위험 증가.
+
+→ **안 (a) 권고**. Stage 2 에서 정확한 조건과 회귀 검증 fixture 후보 확정.
+
+## 7. 회귀 검증 후보 (Stage 2 에서 확정)
+
+본 정정이 영향을 줄 수 있는 분류:
+
+1. **pi=21/37/60 (Picture Square wrap)** — 기존 분기와 동일 효과 → 동일 출력 보존되어야 함.
+2. **인라인 TAC 표만 (수식 없음)** — 다른 함수 경로 → 영향 없음.
+3. **인라인 TAC 표 + 수식 (full sw)** — pi=79, 110, 118, 120 — sw 가 full column 이면 새 분기 미진입 (조건 `sw < col_area_w_hu - 200` 불충족) → 동일.
+4. **셀 내부 paragraph** — 셀 폭과 sw 비교, narrow 인 경우만 진입 → 의도된 정정.
+
+광범위 fixture sweep (15+ 샘플) 에서 byte-identical 확인 + exam_science 만 의도된 diff.
+
+## 8. 산출물
+
+- 본 보고서: `mydocs/working/task_m100_568_stage1.md`
+- 임시 진단 example (커밋 안 함 — 분석 후 삭제됨): `examples/diag_task568.rs`
+
+## 9. 승인 요청
+
+본 진단 결과를 바탕으로 Stage 2 (구현 계획서 작성, 안 (a) 기반 상세화) 진입을 승인 요청합니다.

--- a/mydocs/working/task_m100_568_stage3.md
+++ b/mydocs/working/task_m100_568_stage3.md
@@ -1,0 +1,164 @@
+# Task #568 Stage 3 보고서 — 구현 + 검증
+
+- **이슈**: [#568](https://github.com/edwardkim/rhwp/issues/568)
+- **브랜치**: `local/task568`
+- **단계**: Stage 3 (구현 + 검증)
+- **선행 산출**: Stage 1 진단(`task_m100_568_stage1.md`), Stage 2 구현 계획(`task_m100_568_impl.md`)
+- **작성일**: 2026-05-04
+
+## 1. 변경 요약
+
+`src/renderer/layout/paragraph_layout.rs` L857 의 `effective_col_x / effective_col_w` 분기 조건 확장.
+
+### 1.1 코드 변경 (+25 / -2 LOC)
+
+```rust
+// [Task #568] 인라인 TAC 표(treat_as_char=true) 가 있는 줄도 동일 처리.
+let line_has_inline_tac_table = !tac_offsets_px.is_empty() && para.map(|p| {
+    let line_start = comp_line.char_start;
+    let line_end = line_start + comp_line.runs.iter()
+        .map(|r| r.text.chars().count()).sum::<usize>();
+    tac_offsets_px.iter().any(|(pos, _, ci)| {
+        *pos >= line_start && *pos <= line_end
+            && matches!(p.controls.get(*ci),
+                Some(Control::Table(t)) if t.common.treat_as_char)
+    })
+}).unwrap_or(false);
+
+// [Task #568] 임계값에 column_start 포함 — 실제 가용 line 폭은 (sw + cs).
+let line_avail_hu = comp_line.segment_width.saturating_add(comp_line.column_start);
+let (effective_col_x, effective_col_w) = if (has_picture_shape_square_wrap
+    || line_has_inline_tac_table)
+    && comp_line.segment_width > 0
+    && line_avail_hu < col_area_w_hu - 200    // ← 임계값 변경: sw → sw+cs
+{
+    let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
+    let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);
+    (col_area.x + cs_px, sw_px)
+} else {
+    (col_area.x, col_area.width)
+};
+```
+
+### 1.2 핵심 설계 결정
+
+| 항목 | 결정 | 근거 |
+|------|------|------|
+| 활성 조건 추가 | `\|\| line_has_inline_tac_table` | 인라인 TAC 표 보유 줄 검출 (per-line, per-paragraph 아님) |
+| 임계값 | `sw + cs < col_w_hu - 200` | 단락 들여쓰기를 LINE_SEG.column_start 로 인코딩한 paragraph 의 정상 라인 (sw+cs ≈ col_w_hu) 미진입 보장 |
+| 기존 분기 보존 | OR 결합 (Picture/Shape Square wrap) | cs=0 인 기존 케이스 동일 동작 |
+
+### 1.3 임계값 보정 (Stage 2 → Stage 3)
+
+Stage 2 계획은 기존 임계값 `sw < col_w_hu - 200` 유지였으나, 첫 빌드 trace 에서 pi=110/118/120 (sw=30562 cs=1130 col_w_hu=31692) 가 spurious 활성화 발견.
+
+```
+sw=30562 < col_w_hu - 200 = 31492  → TRUE (잘못 활성)
+```
+
+이는 paragraph margin 을 LINE_SEG.column_start 로 인코딩한 paragraph 의 full-width line 이 narrow 로 잘못 판정되는 결함. **`sw + cs` 로 임계값 변경하여 정정**:
+
+```
+sw + cs = 30562 + 1130 = 31692 < 31492  → FALSE (정상)
+```
+
+Picture/Shape Square wrap 케이스 (cs=0) 는 sw + 0 = sw 라 동일 동작.
+
+## 2. 검증 결과
+
+### 2.1 단위 테스트
+```
+cargo test --lib
+test result: ok. 1125 passed; 0 failed; 2 ignored; 0 measured
+```
+
+### 2.2 SVG snapshot
+```
+cargo test --test svg_snapshot
+test result: ok. 6 passed; 0 failed
+```
+6/6 통과 (table-text, issue-147, issue-157, issue-267, form-002, render_is_deterministic).
+
+### 2.3 clippy
+사전 결함 2건 (`table_ops.rs:1007`, `object_ops.rs:298` — `unwrap()` will always panic) 변경 전후 동일. **본 변경에 의한 신규 경고/오류 0**.
+
+### 2.4 광범위 fixture sweep (66 SVG 파일)
+
+대표 fixture 7개 (인라인 표/수식/그림 wrap 보유):
+
+| Fixture | 페이지 | 변경 |
+|---------|------|------|
+| `21_언어_기출_편집가능본.hwp` (Picture Square wrap) | 15 | byte-identical |
+| `atop-equation-01.hwp` | 1 | byte-identical |
+| `equation-lim.hwp` | 1 | byte-identical |
+| `eq-01.hwp` | 1 | byte-identical |
+| `exam_eng.hwp` | 8 | byte-identical |
+| `exam_math.hwp` | 20 | byte-identical |
+| `exam_kor.hwp` | 20 | byte-identical |
+| **총** | **66** | **byte-identical** |
+
+**회귀 0**.
+
+### 2.5 의도된 정정 — exam_science.hwp
+
+| 페이지 | 변경 | 사유 |
+|------|------|------|
+| 1 | byte-identical | 영향 없음 (조건 미충족) |
+| **2** | **변경됨** | pi=61 ls[0] 인라인 분수 (12번 응답) 위치 정정 |
+| 3 | byte-identical | pi=110 (13번) 등 sw+cs=full → 새 분기 미진입 |
+| 4 | byte-identical | pi=118/120 등 동일 |
+
+#### Pi=61 정정 정밀 측정
+
+| 항목 | Before | After | 기대값 |
+|------|--------|-------|--------|
+| 인라인 2×1 표 (분수) x | **739.87** | **584.93** | ~575-590 |
+| 편위 | +175 px (severe) | ±5-10 px (residual) | 0 |
+
+선두 공백의 `extra_word_spacing` 80 px/space → 2.9 px/space 로 감소. 분수 우측 편위 거의 해소.
+
+### 2.6 활성화 분포 (TASK568_TRACE)
+
+| paragraph | 라인 | sq | tac_tbl | sw | cs | avail | 분기 |
+|-----------|------|-----|---------|-----|-----|-------|------|
+| pi=21 | 0..5 | true | false | 19592 | 0 | 19592 | OLD = NEW |
+| pi=37 | 0..5 | true | false | 17546 | 0 | 17546 | OLD = NEW |
+| pi=60 | 0..3 | true | false | 20069 | 0 | 20069 | OLD = NEW |
+| **pi=61** | **0** | **false** | **true** | **18939** | **1130** | **20069** | **NEW (의도된 활성)** |
+
+pi=110/118/120 sw+cs=31692 col_w_hu=31692 → 미진입 (정확).
+
+## 3. 잔여 / 한계
+
+### 3.1 pi=61 ls[0] 잔여 ~10 px
+
+cs(15.07 px) + paragraph margin_left(15.07 px, resolved /2) 합 30 px 들여쓰기 적용. 한컴 의도가 cs OR margin 단일 인지 둘 다 인지는 PDF/한컴 2010/2020 비교 필요 (메모리 `feedback_pdf_not_authoritative` 정합 — 보조 ref). 시각적으로 ±10 px 는 무시 가능 수준.
+
+### 3.2 미해결 사용자 보고 항목
+
+다음 항목은 본 fix 로 정정되지 않음 (정정 코드 경로 불일치):
+
+- **Page 1 header LEFT-shift (item ①)** — 외곽 1×1 표 cell 의 inline sub-tables (성명/수험번호/제선택) 가 cell halign=Center 미적용 → 별도 task 필요.
+- **Page 3 보기 셀 분수 단락 (13/15/16번)** — 셀 내부 paragraph 의 inline TAC 표 + 수식. 셀 paragraph 의 segment_width = full cell width (좁지 않음) 으로 본 fix 의 임계값 미충족. 별도 분석 필요.
+- **Page 4 보기 셀 분수 단락 (19번)** — 동상.
+- **페이지 쪽번호 폰트 색상 (item ③)** — 별도 task.
+
+작업지시자 피드백 "심하진 않고 좌측 편위가 생기는 문제도 있음" 은 위 미해결 항목 (특히 item ①) 의 잔존 또는 pi=61 ~10 px 잔여로 추정.
+
+## 4. 변경 파일
+
+```
+src/renderer/layout/paragraph_layout.rs    +25 / -2 LOC
+mydocs/working/task_m100_568_stage1.md     (Stage 1)
+mydocs/plans/task_m100_568.md              (Stage 0 수행계획)
+mydocs/plans/task_m100_568_impl.md         (Stage 2 구현계획)
+mydocs/working/task_m100_568_stage3.md     (본 보고서)
+```
+
+## 5. 승인 요청
+
+본 Stage 3 검증 결과를 바탕으로 Stage 4 (시각 판정 + 최종 보고) 진입을 승인 요청합니다.
+
+다음 단계 후보 (Stage 4 후속 또는 별도 task):
+- 미해결 항목 (item ①, 보기 셀 분수, item ③) 별도 issue 등록 → 추가 task
+- 또는 본 task 의 잔여 처리에 한해 추가 진단 후 재정정

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -842,9 +842,32 @@ impl LayoutEngine {
             // 표 Square wrap 케이스는 caller 가 col_area 를 이미 wrap_area 로 좁혀
             // 호출하므로 segment_width ≈ col_area_w_hu → 조건 미발동 (회귀 차단).
             // 200 HU 임계값은 paragraph_layout 의 multi-col filter 와 동일 (페이지네이션 노이즈 제거).
-            let (effective_col_x, effective_col_w) = if has_picture_shape_square_wrap
+            //
+            // [Task #568] 인라인 TAC 표(treat_as_char=true) 가 있는 줄도 동일 처리.
+            // HWP 는 인라인 TAC 표가 있는 줄의 segment_width 를 표 폭 + 잔여로 좁게
+            // 인코딩한다 (wrap=TopAndBottom 영향). col_area.width 로 잡으면
+            // Justify slack 이 과대 산출되어 선두 공백이 80 px/space 로 부풀어 표를
+            // 우측으로 민다 (exam_science.hwp pi=61 12번 응답: +175 px 편위).
+            let line_has_inline_tac_table = !tac_offsets_px.is_empty() && para.map(|p| {
+                let line_start = comp_line.char_start;
+                let line_end = line_start + comp_line.runs.iter()
+                    .map(|r| r.text.chars().count()).sum::<usize>();
+                tac_offsets_px.iter().any(|(pos, _, ci)| {
+                    *pos >= line_start && *pos <= line_end
+                        && matches!(p.controls.get(*ci),
+                            Some(Control::Table(t)) if t.common.treat_as_char)
+                })
+            }).unwrap_or(false);
+
+            // [Task #568] 임계값에 column_start 포함 — 실제 가용 line 폭은 (sw + cs).
+            // 단락 들여쓰기를 LINE_SEG.column_start 로 인코딩한 paragraph 의
+            // 정상 라인은 (sw + cs) ≈ col_w_hu 이므로 새 분기 미진입.
+            // Picture/Shape Square wrap 은 cs=0 이라 기존 동작과 동일.
+            let line_avail_hu = comp_line.segment_width.saturating_add(comp_line.column_start);
+            let (effective_col_x, effective_col_w) = if (has_picture_shape_square_wrap
+                || line_has_inline_tac_table)
                 && comp_line.segment_width > 0
-                && comp_line.segment_width < col_area_w_hu - 200
+                && line_avail_hu < col_area_w_hu - 200
             {
                 let cs_px = hwpunit_to_px(comp_line.column_start, self.dpi);
                 let sw_px = hwpunit_to_px(comp_line.segment_width, self.dpi);


### PR DESCRIPTION
## Summary

- 본질: `paragraph_layout.rs::layout_composed_paragraph` L857 의 `effective_col_x / effective_col_w` 분기가 인라인 TAC 표 보유 줄의 `comp_line.segment_width` 무시. col_area.width(31692 HU)로 `available_width` 산출 → Justify slack 과대 → `extra_word_spacing` 80 px/space 로 부풀어 인라인 표 **+175 px 우측 편위** (exam_science.hwp pi=61 12번 응답 분수).
- 정정: 분기 조건 확장 `has_picture_shape_square_wrap || line_has_inline_tac_table` (줄 단위 검출, Table tac=true). 임계값 `sw < col_w_hu - 200` → `sw + cs < col_w_hu - 200` 보정 (단락 들여쓰기 LINE_SEG.column_start 로 인코딩한 paragraph 의 정상 full-width line 미진입 보장).
- 결과: pi=61 인라인 분수 x=739.87 → **584.93** (편위 +175 px → ±5-10 px 잔여). 변경 LOC: +25/-2.

## 본질 정정 메커니즘

HWP 는 인라인 TAC 표가 있는 줄의 segment_width 를 표 폭 + 잔여로 좁게 인코딩 (wrap=TopAndBottom 영향). 이 줄에서 layout 이 컬럼 전체 폭(407.5 px)으로 `available_width` 를 잡으면, Justify slack(~160 px)이 선두 공백 2 개에 80 px/space 분배되어 그 다음 인라인 표를 ~175 px 우측으로 민다.

기존 Picture/Shape Square wrap 분기 (`has_picture_shape_square_wrap`) 와 동일한 LINE_SEG.cs/sw 사용 패턴을 인라인 TAC 표 줄에도 확장. 단 임계값에 `column_start` 포함시켜 "단락 들여쓰기를 LINE_SEG 에 인코딩한 정상 full-width line" 을 미진입 보장.

## Test plan

- [x] `cargo test --lib` — 1125 passed, 0 failed
- [x] `cargo test --test svg_snapshot` — 6/6 passed
- [x] `cargo clippy --release --lib` — 본 변경 신규 경고 0 (사전 결함 2건 변경 전후 동일)
- [x] 광범위 fixture sweep — 7 fixture / 66 SVG 페이지 byte-identical (`21_언어_기출_편집가능본` Picture wrap / `atop-equation-01` / `equation-lim` / `eq-01` / `exam_eng` / `exam_math` / `exam_kor`)
- [x] exam_science.hwp page 1/3/4 byte-identical, page 2 의도된 정정만 diff
- [ ] 작업지시자 시각 판정 (`output/svg/exam_science_after*/exam_science_002.svg`)
- [ ] rhwp-studio web Canvas 시각 판정 (WASM)

## 미해결 (별도 task 후보)

본 PR 은 인라인 표 + 수식 + **narrow segment_width** 조합만 정정. 다음은 다른 메커니즘:

- Page 1 header sub-tables LEFT-shift — 외곽 1×1 표 cell halign=Center 미적용
- Page 3/4 보기 셀 분수 단락 (13/15/16/19번) — 셀 paragraph segment_width=full → 본 fix 임계값 미충족
- 페이지 쪽번호 색·굵기 — 바탕쪽 CharShape

## 산출 문서

- 수행계획: `mydocs/plans/task_m100_568.md`
- Stage 1 진단 (코드 무수정): `mydocs/working/task_m100_568_stage1.md`
- Stage 2 구현계획: `mydocs/plans/task_m100_568_impl.md`
- Stage 3 구현+검증: `mydocs/working/task_m100_568_stage3.md`
- 최종 보고서: `mydocs/report/task_m100_568_report.md`

closes #568

🤖 Generated with [Claude Code](https://claude.com/claude-code)