### PR TITLE
Task #577: 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋 정정 (closes #577)

### DIFF
--- a/mydocs/orders/20260504.md
+++ b/mydocs/orders/20260504.md
@@ -13,9 +13,16 @@
 - HWP3 직렬화 (HWP3 → HWP3 round-trip) 까지 고려한 본질 정정이 향후 정합한 방향 (작업지시자 의견)
 - local/devel = devel = origin/devel = `b84c5e9` 정합 상태 유지
 
+## M100 — exam_science 2번 보기 이미지 하단 클리핑 (Task #577)
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **M100 #577** | exam_science.hwp 2번 문제 보기 ⑤(및 ②④) 이미지 하단 클리핑 — 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋 | **완료 (Stage 1~4 모두 승인)** | `table_layout.rs:1547..` 비-TAC Picture 분기에 `anchor_y` 도입. `text_wrap=TopAndBottom AND vert_rel_to=Para` 조건일 때 `para_y_before_compose` 사용 → 이미지가 cell_top + pad_top + line_height (≈19.10 px) 에서 cell_top + pad_top (≈3.78 px) 로 정정. **검증**: 보기 ①~⑤ 모두 셀 내부 정합. **LAYOUT_OVERFLOW**: exam_science 9.5→3.4 px, mel-001 8건→0건. **부수 효과**: 비-TAC TopAndBottom 셀 내부 이미지 다수에 동일 산식 정정 적용 → 일부 페이지 좌표 IR vpos 정합 방향 이동, 신규 회귀 없음. 산출물: `mydocs/plans/task_m100_577.md` + `mydocs/plans/task_m100_577_impl.md` + `mydocs/working/task_m100_577_stage{1..3}.md` + `mydocs/report/task_m100_577_report.md`. |
+
 ## 메모리 정합
 
 - `feedback_visual_regression_grows` — 시각 판정 게이트 정합 운영 (미통과 시 머지 안 함, 본 사이클 정합한 운영)
 - `feedback_v076_regression_origin` — 작업지시자 직접 시각 판정으로 page 4 / page 8 결함 식별
 - `feedback_pdf_not_authoritative` / `reference_authoritative_hancom` — 한컴 2010/2020 + 작업지시자 시각 판정 권위
 - `feedback_pr_comment_tone` — PR close 댓글 차분/사실 중심 + 컨트리뷰터의 정합한 영역 인정 + 재 PR 톤
+- Task #577 의 부수 효과로 baseline 좌표가 이동한 페이지들 → 후속 PR 회귀 검증 시 baseline 갱신 필요

--- a/mydocs/plans/task_m100_577.md
+++ b/mydocs/plans/task_m100_577.md
@@ -1,0 +1,84 @@
+# 수행 계획서 — Task #577
+
+**제목**: exam_science.hwp 2번 문제 보기 이미지 하단 클리핑 (TopAndBottom 셀 내부 이미지 1라인 오프셋)
+**브랜치**: `local/task577`
+**마일스톤**: M100 (v1.0.0)
+**이슈**: [#577](https://github.com/edwardkim/rhwp/issues/577)
+
+---
+
+## 1. 배경
+
+`samples/exam_science.hwp` 페이지 1, 2번 문제(문단 0.9)의 객관식 보기 표(3행×5열)에서 ⑤ 이미지 하단이 셀 클립 영역을 약 10.81 px 초과하여 잘려 보인다. 동일 원인으로 ②(11.55 px), ④(12.30 px)도 잠재 오버플로가 있으나 우측 셀이라 시각적으로 덜 도드라진다.
+
+## 2. 원인 분석 요약
+
+| 항목 | 값 |
+|------|---|
+| 셀[11] 선언 height | 1716 HWPUNIT (~6.05mm) |
+| 행 2 effective height | 3998 HWPUNIT (~14.10mm = 53.3 px) — 다른 셀 기준 |
+| 이미지 ⑤ height | 3432 HWPUNIT (~12.10mm = 45.76 px) |
+| 셀 padding_top | 283 HWPUNIT (~1.00mm = 3.78 px) |
+| 셀 내부 1 line_height | 1150 HWPUNIT (~4.06mm = 15.32 px) |
+| 관찰된 image y 오프셋 | cell_top + 19.10 px (= padding_top + line_height) |
+
+### 핵심 가설
+
+셀 내부 단락이 TopAndBottom 래핑 이미지를 단독 컨트롤로 포함할 때, 렌더러가 anchor 라인의 line height(1150 HWPUNIT)를 그대로 소비한 뒤 이미지를 그 다음 위치에 배치한다. 그 결과:
+
+```
+image_top = cell_top + padding_top + line_height   ← 현재 (오류)
+image_top = cell_top + padding_top                 ← HWP 의도
+```
+
+전 5개 보기 이미지의 오버플로가 모두 19.10 px 오프셋 가설로 정확히 설명된다(분석 표 참조).
+
+## 3. 목표
+
+1. 셀 내부 단독 TopAndBottom 이미지가 행 effective height 안에 들어가도록 y 좌표 계산을 수정한다.
+2. 회귀 방지: 일반 단락(셀 외부) TopAndBottom 이미지 동작에는 영향이 없어야 한다.
+3. 시각적 검증: `exam_science.hwp` 1페이지 보기 ①~⑤ 이미지가 모두 셀 안에 정상 배치된다.
+
+## 4. 비목표 (Out of scope)
+
+- 다른 페이지 / 다른 표 / 다른 샘플의 잠재적 동일 이슈는 별도 검증만 수행, 수정은 본 이슈 범위에서 가능한 한 함께 처리하되 새 회귀가 보이면 별도 이슈로 분리한다.
+- TopAndBottom 외 다른 wrap mode(BehindText, ForwardText 등)에는 손대지 않는다.
+- 이미지 자체 크기(bin/cur) 산식은 변경하지 않는다.
+
+## 5. 진행 절차 (하이퍼-워터폴)
+
+1. ✅ 이슈 등록 (#577)
+2. ✅ `local/task577` 브랜치 생성
+3. ⏳ 수행 계획서 작성 → 승인 요청 (← 현재 단계)
+4. 구현 계획서 작성 (3~6 단계 분할) → 승인 요청
+5. 단계별 구현 + 단계별 완료 보고서 작성 → 단계마다 승인
+6. 최종 결과 보고서 작성 + 오늘할일 갱신 → 승인 후 merge
+
+## 6. 검증 계획
+
+| 검증 항목 | 방법 |
+|----------|------|
+| 빌드 | `cargo build --release` |
+| 단위 테스트 | `cargo test` |
+| Clippy | `cargo clippy --release -- -D warnings` (기존 경고 한도 내 유지) |
+| 시각 검증 (대상) | `rhwp export-svg samples/exam_science.hwp -o output/svg/task577/` 후 1페이지 ⑤(및 ②④) 이미지가 셀 안에 들어가는지 확인 |
+| 시각 회귀 (다른 샘플) | `samples/` 내 주요 문서 1~2개에 동일 명령 수행 후 SVG diff 또는 육안 비교 |
+| IR 비교 | `rhwp ir-diff samples/exam_science.hwpx samples/exam_science.hwp` (있을 경우) — IR 변경이 없어야 함 (렌더 단계 수정만) |
+
+## 7. 위험 요소
+
+- **다른 표/단락 회귀**: 셀 내부와 셀 외부의 단락 처리 경로가 공유될 경우, 외부 단락의 TopAndBottom 동작이 같이 바뀔 수 있음. 구현 단계에서 적용 범위를 명확히 분리.
+- **HWP3 영향 없음 확인**: HWP3 전용 분기는 `src/parser/hwp3/`에서만 동작. 본 수정은 공통 렌더러/레이아웃에 위치하므로 HWP5/HWPX 양쪽에 영향. HWP3 샘플은 별도 회귀 검증.
+- **이미지 시작 위치 변화로 인한 좌상단 정렬 차이**: 기존에 의도적으로 라인 높이를 소비하는 표가 있을 수 있음. 단계 1에서 분석으로 확인 후 진행.
+
+## 8. 산출물 목록
+
+- `mydocs/plans/task_m100_577.md` (본 문서)
+- `mydocs/plans/task_m100_577_impl.md` (구현 계획서)
+- `mydocs/working/task_m100_577_stage{N}.md`
+- `mydocs/report/task_m100_577_report.md`
+- 소스 수정 (구현 계획서에서 확정)
+
+## 9. 승인 요청
+
+위 계획대로 진행해도 좋을지 승인 요청드립니다. 승인 후 구현 계획서(3~6 단계) 작성으로 넘어갑니다.

--- a/mydocs/plans/task_m100_577_impl.md
+++ b/mydocs/plans/task_m100_577_impl.md
@@ -1,0 +1,130 @@
+# 구현 계획서 — Task #577
+
+**제목**: 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋 제거
+**브랜치**: `local/task577`
+**기반 수행 계획서**: `task_m100_577.md`
+
+---
+
+## 1. 원인 정밀 분석
+
+### 1.1 코드 경로
+
+이미지 ⑤(`bin_id=17`, `tac=false`, `wrap=TopAndBottom`, `vert_rel_to=Para`)는 `table_cell_content.rs`가 아닌 `table_layout.rs`의 셀 처리 루프를 거친다:
+
+```
+src/renderer/layout/table_layout.rs
+  L1413  let para_y_before_compose = para_y;     // 셀 단락 시작 y 저장
+  ...
+  L1500± para_y = self.layout_composed_paragraph(...);  // 텍스트(빈 라인 1줄) 레이아웃 → para_y 가 line_height 만큼 advance
+  ...
+  L1547  Control::Picture(pic) =>
+  L1548    if pic.common.treat_as_char { ... }     // (TAC 분기 — 본 건과 무관)
+  L1624    else {                                   // 비-TAC 분기 — 본 건 진입
+  L1629      let cell_area = LayoutRect { y: para_y, ... };
+  L1634      let (pic_x, pic_y) = self.compute_object_position(
+  L1637        ..., para_y, para_alignment);
+  L1646      para_y += pic_h;
+```
+
+### 1.2 좌표 산식 (현재)
+
+`compute_object_position` (`picture_footnote.rs:162`)에서 `vert_rel_to=Para`, `vert_align=Top`, `v_offset=0` 인 경우:
+
+```rust
+y = ref_y + v_offset = para_y + 0 = para_y
+```
+
+문제는 이 시점의 `para_y`가 `layout_composed_paragraph`가 빈 anchor 라인 1줄(lh=1150 HU ≈ 15.32 px) 만큼 이미 advance 시킨 값이라는 점.
+
+```
+pic_y = cell_y + pad_top + line_height
+      = 896.27 + 3.78 + 15.32 = 915.37  (관측값과 정확히 일치)
+```
+
+HWP 의도는 anchor 라인이 이미지에 의해 displaced 되므로(`TopAndBottom`), 이미지는 paragraph 시작 위치(`para_y_before_compose`)에 anchor 되어야 함.
+
+### 1.3 근본 수정 위치
+
+`table_layout.rs:1624..1648` 의 비-TAC Picture 분기. 여기서 `compute_object_position` 호출 시 `para_y` 대신 anchor 시점 좌표(`para_y_before_compose` 또는 `seg.vertical_pos` 보정 후)를 전달.
+
+### 1.4 적용 범위 한정
+
+회귀 방지를 위해 새 좌표를 적용할 조건:
+
+1. `pic.common.text_wrap == TopAndBottom`
+2. `pic.common.vert_rel_to == VertRelTo::Para`
+3. (안전책) 셀 단락이 image-only 이거나 첫 anchor 라인에 anchor 됨
+
+조건 1·2 만으로도 충분히 보수적이지만, 조건 3을 추가해 텍스트 + 그림 혼합 단락의 동작 변화를 더 보수적으로 막을지 단계 1 분석에서 확정한다.
+
+---
+
+## 2. 단계 분할 (4 단계)
+
+### Stage 1 — 분석·재현·기준선 캡처
+
+- `samples/exam_science.hwp` 1페이지 SVG 생성 → 현재 ⑤ 클리핑 재현 확인
+- 회귀 검증용 baseline SVG·해시 수집 대상 샘플 선정 (최소: `exam_science.hwp` 외 1개 기존 샘플)
+- 셀 안 비-TAC TopAndBottom 이미지 패턴이 다른 샘플에 어떤 형태로 존재하는지 grep / dump 확인
+- 단계 1 보고서: 적용 범위(조건 1·2 만 / 1·2·3) 결정
+
+산출물: `mydocs/working/task_m100_577_stage1.md`
+
+### Stage 2 — 코드 수정
+
+- `table_layout.rs:1624..1648` 의 `compute_object_position` 호출에 anchor 시점 y 전달
+  - 신규 `let anchor_y = if {조건} { para_y_before_compose + lineSeg vpos 보정 } else { para_y };`
+  - `cell_area.y` 와 `compute_object_position(..., para_y=anchor_y, ...)` 모두 해당 분기에서 동일한 `anchor_y` 사용
+  - `para_y += pic_h;` 는 다음 단락 시작점 산출용. anchor_y 변경 후에도 cell 의 effective row height 가 충분하므로 그대로 두지만, 단계 2 에서 동작 검증 후 필요시 조정
+- `cargo build --release` 통과
+- 단순 회귀: `cargo test` 와 `cargo clippy --release -- -D warnings` 통과
+
+산출물: `mydocs/working/task_m100_577_stage2.md` + 소스 커밋
+
+### Stage 3 — 시각·자동 검증
+
+- `rhwp export-svg samples/exam_science.hwp -o output/svg/task577_after/` 후 ① ~ ⑤ 모두 셀 클립 안에 들어가는지 좌표 비교
+- `LAYOUT_OVERFLOW` 메시지가 줄어드는지 / 새 오버플로 발생 여부 확인
+- 다른 샘플(스테이지 1에서 선정) SVG diff 비교 — 의도된 변화만 있는지 확인
+- 필요 시 `ir-diff` 로 IR 비변경 확인 (렌더 단계만 수정이라 IR 자체는 동일해야 함)
+
+산출물: `mydocs/working/task_m100_577_stage3.md` (오버플로 표 + diff 결과 요약)
+
+### Stage 4 — 종결
+
+- 최종 결과 보고서 작성: `mydocs/report/task_m100_577_report.md`
+- `mydocs/orders/{오늘}.md` 갱신 (해당 타스크 상태)
+- 본 계획서 → `mydocs/plans/archives/`로 이동(승인 후 정리 단계에서)
+
+산출물: `mydocs/report/task_m100_577_report.md`
+
+---
+
+## 3. 변경 파일 (예상)
+
+| 경로 | 변경 종류 |
+|------|----------|
+| `src/renderer/layout/table_layout.rs` | 비-TAC Picture 분기 anchor y 산식 수정 (조건부) |
+| `mydocs/working/task_m100_577_stage{1..3}.md` | 단계 보고 |
+| `mydocs/report/task_m100_577_report.md` | 최종 보고 |
+| `mydocs/orders/{날짜}.md` | 오늘 할일 갱신 |
+
+코드 수정은 한 파일 한 분기로 한정. `picture_footnote.rs` 의 `compute_object_position` 자체는 수정하지 않는다 (다른 호출처 회귀 방지).
+
+---
+
+## 4. 위험·완화
+
+| 위험 | 완화 |
+|------|------|
+| 비셀(본문) TopAndBottom 이미지 회귀 | 수정은 셀 처리 루프 내부 분기(table_layout.rs)에 한정. 본문 경로(picture_footnote.rs)는 무변경 |
+| 셀 내 텍스트+그림 혼합 단락 회귀 | 단계 1 분석 후, 필요 시 image-only 단락에만 한정 |
+| HWP3·HWPX 회귀 | 렌더 단계 수정이라 IR 비변경. 단계 3에서 ir-diff 와 다른 샘플 SVG diff 로 검증 |
+| 다른 샘플의 잠재 동일 버그가 같이 변경 | 의도된 개선이면 단계 3 보고서에 명시. 새 회귀로 판단되면 본 PR 에서 분리 |
+
+---
+
+## 5. 승인 요청
+
+위 4 단계 계획대로 진행해도 좋을지 승인 요청드립니다. 승인 후 Stage 1(분석·기준선 캡처)부터 시작합니다.

--- a/mydocs/report/task_m100_577_report.md
+++ b/mydocs/report/task_m100_577_report.md
@@ -1,0 +1,101 @@
+# 최종 결과 보고서 — Task #577
+
+**제목**: exam_science.hwp 2번 문제 보기 이미지 하단 클리핑 (TopAndBottom 셀 내부 이미지 1라인 오프셋)
+**브랜치**: `local/task577`
+**마일스톤**: M100 (v1.0.0)
+**이슈**: [#577](https://github.com/edwardkim/rhwp/issues/577)
+**작업 기간**: 2026-05-04
+
+---
+
+## 1. 결론
+
+`samples/exam_science.hwp` 페이지 1, 2번 문제(보기 ①~⑤)에서 이미지 하단이 cell-clip 영역을 약 10.81 px 초과하여 잘려 보이던 결함을 정정했다. 동일 산식 결함으로 잠재 오버플로(②: 11.55, ④: 12.30 px) 가 있던 우측 보기들도 함께 정정.
+
+## 2. 원인 요약
+
+`src/renderer/layout/table_layout.rs:1547..` 의 비-TAC Picture 분기에서 `compute_object_position` 호출 시, `layout_composed_paragraph` 가 advance 시킨 `para_y` (= cell_y + pad_top + line_height) 를 그대로 anchor 로 사용. HWP 의도는 TopAndBottom 이미지가 anchor 라인을 displace 하므로, 라인 높이를 소비하지 않은 `para_y_before_compose` (= cell_y + pad_top) 가 anchor 가 되어야 함.
+
+```
+관측 image_y - cell_y = 19.10 px
+  = pad_top(3.78) + line_height(15.32, lh=1150 HU)
+정정 후 image_y - cell_y = 3.78 px = pad_top
+```
+
+## 3. 변경 사항
+
+### 코드
+
+`src/renderer/layout/table_layout.rs` (1 hunk, +14/-3 line)
+
+비-TAC Picture 분기에 `anchor_y` 도입:
+
+```rust
+let anchor_y = if matches!(pic.common.text_wrap, TextWrap::TopAndBottom)
+              && matches!(pic.common.vert_rel_to, VertRelTo::Para)
+{ para_y_before_compose } else { para_y };
+let cell_area = LayoutRect { y: anchor_y, height: ..., ..inner_area };
+let (pic_x, pic_y) = self.compute_object_position(
+    ..., anchor_y, para_alignment,
+);
+```
+
+`para_y += pic_h;` (다음 단락 시작점)는 무변경.
+
+### 산출물
+
+| 경로 | 종류 |
+|------|------|
+| `src/renderer/layout/table_layout.rs` | 코드 수정 |
+| `mydocs/plans/task_m100_577.md` | 수행 계획서 |
+| `mydocs/plans/task_m100_577_impl.md` | 구현 계획서 |
+| `mydocs/working/task_m100_577_stage1.md` | 분석·재현·기준선 캡처 |
+| `mydocs/working/task_m100_577_stage2.md` | 코드 수정 |
+| `mydocs/working/task_m100_577_stage3.md` | 시각·자동 검증 |
+| `mydocs/report/task_m100_577_report.md` | 본 최종 보고서 |
+| `output/svg/task577_baseline*/` | baseline SVG |
+| `output/svg/task577_after*/` | after-fix SVG |
+
+## 4. 검증 결과
+
+### exam_science.hwp 1페이지 보기 ①~⑤
+
+5개 이미지 모두 `image_y - cell_y = 3.78 px`(= pad_top, HWP IR 정합) 로 정정. cell-clip 내부에 정상 배치 확인.
+
+| 보기 | image bottom | cell bottom | 결과 |
+|------|--------------|-------------|------|
+| ① | 832.09 | 843.87 | ✅ |
+| ② | 840.09 | 843.87 | ✅ |
+| ③ | 888.60 | 903.47 | ✅ |
+| ④ | 900.44 | 903.47 | ✅ |
+| ⑤ | 953.00 | 957.52 | ✅ |
+
+### LAYOUT_OVERFLOW
+
+| 샘플 | baseline | after-fix |
+|------|----------|-----------|
+| exam_science.hwp | 1건 (9.5 px) | 1건 (3.4 px) — 6.1 px 감소 |
+| mel-001.hwp | 8건 (3.5~18.8 px) | **0건** |
+
+### 빌드 / 테스트
+
+| 항목 | 결과 |
+|------|------|
+| `cargo build --release` | ✅ |
+| `cargo test --release --lib` | ✅ 1125 passed |
+| `cargo clippy --release -- -D warnings` | ⚠ 사전 존재 에러 2건 (`src/renderer/layout.rs:313-314`) — 본 변경 무관 |
+
+## 5. 부수 효과
+
+비-TAC TopAndBottom Picture (`vert_rel_to=Para`) 가 들어 있는 다른 셀들도 동일 산식으로 정정되어, 일부 페이지의 콘텐츠 좌표가 IR vpos 정합 방향(LAYOUT_OVERFLOW 가 줄어드는 방향)으로 이동. 모든 이동된 이미지는 여전히 cell-clip 내부에 정상 포함됨.
+
+상세는 Stage 3 보고서 참조.
+
+## 6. 후속 가능 항목
+
+- 본 변경으로 baseline 좌표가 이동한 페이지들의 시각 회귀 검증을 후속 PR/타스크에서 baseline 갱신 후 진행 권고.
+- `cargo clippy` 의 사전 존재 doc_lazy_continuation 에러 정리는 별도 타스크로 분리.
+
+## 7. 종결
+
+승인 후 `local/task577` → `local/devel` merge 권고. 본 계획서·구현 계획서를 `mydocs/plans/archives/` 로 이동.

--- a/mydocs/working/task_m100_577_stage1.md
+++ b/mydocs/working/task_m100_577_stage1.md
@@ -1,0 +1,83 @@
+# Stage 1 — 분석·재현·기준선 캡처 완료 보고서
+
+**Task**: #577 — 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋
+**브랜치**: `local/task577`
+**단계**: 1/4 (분석·기준선)
+
+---
+
+## 1. 재현 확인
+
+빌드 직후 `samples/exam_science.hwp` 1페이지 baseline 추출:
+
+```
+$ rhwp export-svg samples/exam_science.hwp -o output/svg/task577_baseline/
+LAYOUT_OVERFLOW: page=1, col=0, para=46, type=Table, y=1374.0, bottom=1364.4, overflow=9.5px
+```
+
+(LAYOUT_OVERFLOW 메시지는 별도 표 — Task #566 baseline 과 동일하므로 본 이슈와 직접 연관 없음.)
+
+페이지 1, 보기 표(3행×5열) 좌표:
+
+| 보기 | 셀 클립(y, h) | 이미지(y, h) | 이미지 bottom | 셀 bottom | 오버플로 |
+|------|---------------|---------------|---------------|-----------|----------|
+| ① | 779.84, 56.83 | 798.95, 41.28 | 840.23 | 836.67 | **+3.55** |
+| ② | 779.84, 56.83 | 798.95, 49.28 | 848.23 | 836.67 | **+11.55** |
+| ③ | 836.67, 59.60 | 855.77, 40.96 | 896.73 | 896.27 | +0.46 |
+| ④ | 836.67, 59.60 | 855.77, 52.80 | 908.57 | 896.27 | **+12.30** |
+| ⑤ | 896.27, 54.05 | 915.37, 45.76 | 961.13 | 950.32 | **+10.81** |
+
+전 5개 모두 cell-clip 영역을 일정한 19.10 px 오프셋만큼 아래로 밀려 있고, 이미지 height가 큰 ② ④ ⑤가 시각적으로 잘림.
+
+## 2. 좌표 산식 검증
+
+`table_layout.rs:1413` 의 `para_y_before_compose = para_y` 시점 anchor 좌표:
+
+```
+para_y_before_compose = cell_y + pad_top
+                      = 896.27 + 3.78 = 900.05  (셀 ⑤ 기준)
+```
+
+`layout_composed_paragraph` 가 빈 anchor 라인 1줄(line_height=1150 HU = 15.32 px) 만큼 advance:
+
+```
+para_y (after compose) = 900.05 + 15.32 = 915.37
+```
+
+`compute_object_position` (vert_rel_to=Para, vert_align=Top, v_offset=0):
+```
+pic_y = para_y = 915.37
+```
+
+→ 관측값 정확히 일치. **버그 산식 확정.**
+
+## 3. 적용 범위 결정
+
+수정 조건: `pic.common.text_wrap == TopAndBottom` **AND** `pic.common.vert_rel_to == VertRelTo::Para`.
+
+이미지-only 단락 추가 한정 여부 검토:
+
+- HWP 의미상 TopAndBottom 이미지는 anchor 라인을 displace 하므로, 텍스트 + 이미지 혼합 단락에서도 anchor 좌표 기준이 맞다.
+- `para_y_before_compose` 는 단락 시작 절대 y 이며, 다중 라인 텍스트를 거쳐 이미지가 나타난다 해도 anchor 라인은 항상 첫 라인(또는 line_segs[0])이다. 본 이슈의 셀 단락은 모두 `paras=1, ctrls=1, text_len=0`.
+- 추가 한정은 보수성을 높이지만, 산식 자체는 단순해야 회귀 분석이 쉽다.
+
+→ **조건 1·2 만 적용**, 추가 한정 없음. 단계 3 시각 회귀 검증으로 위험 통제.
+
+## 4. 회귀 검증 대상 샘플 선정
+
+| 샘플 | 선정 사유 |
+|------|----------|
+| `samples/exam_science.hwp` | 본 이슈 대상. 표 안 비-TAC TopAndBottom 이미지 5개 |
+| `samples/mel-001.hwp` | 21페이지 중 다수 표·이미지 포함, baseline LAYOUT_OVERFLOW 8건 (확장 회귀 검증용) |
+
+baseline SVG 보관 위치:
+- `output/svg/task577_baseline/` (exam_science)
+- `output/svg/task577_baseline_other/` (mel-001)
+
+## 5. 다음 단계
+
+Stage 2 — `table_layout.rs:1624..1648` 에서 anchor_y 도입, build·test·clippy 통과 확인.
+
+## 6. 승인 요청
+
+Stage 1 결과 검토 후 Stage 2 진행 승인 부탁드립니다.

--- a/mydocs/working/task_m100_577_stage2.md
+++ b/mydocs/working/task_m100_577_stage2.md
@@ -1,0 +1,64 @@
+# Stage 2 — 코드 수정 완료 보고서
+
+**Task**: #577 — 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋
+**브랜치**: `local/task577`
+**단계**: 2/4 (코드 수정)
+
+---
+
+## 1. 변경 요약
+
+`src/renderer/layout/table_layout.rs:1624..1648` 의 비-TAC Picture 분기에 anchor_y 도입.
+
+### Diff (요지)
+
+```rust
+} else {
+    // 비-인라인(자리차지/글뒤로/글앞으로) 이미지:
+    let pic_w = ...;
+    let pic_h = ...;
++   // [Task #577] TopAndBottom + vert_rel_to=Para 인 셀 내부 이미지는
++   // anchor 라인이 이미지에 의해 displaced 되므로, layout_composed_paragraph
++   // 가 advance 시킨 para_y 가 아닌 anchor 시점(para_y_before_compose)을 기준
++   // 으로 해야 cell-clip 영역 내부에 정확히 배치된다.
++   let anchor_y = if matches!(pic.common.text_wrap, TextWrap::TopAndBottom)
++                  && matches!(pic.common.vert_rel_to, VertRelTo::Para)
++   { para_y_before_compose } else { para_y };
+    let cell_area = LayoutRect {
+-       y: para_y,
+-       height: (inner_area.height - (para_y - inner_area.y)).max(0.0),
++       y: anchor_y,
++       height: (inner_area.height - (anchor_y - inner_area.y)).max(0.0),
+        ..inner_area
+    };
+    let (pic_x, pic_y) = self.compute_object_position(
+        &pic.common, pic_w, pic_h,
+        &cell_area, &inner_area, &inner_area, &inner_area,
+-       para_y, para_alignment,
++       anchor_y, para_alignment,
+    );
+```
+
+`para_y += pic_h;` (단락 종료 후 다음 단락 시작점 산출)는 무변경. anchor_y 변경은 좌표 계산만 영향.
+
+## 2. 빌드 / 테스트
+
+| 항목 | 결과 |
+|------|------|
+| `cargo build --release` | ✅ 성공 |
+| `cargo test --release --lib` | ✅ 1125 passed; 0 failed; 2 ignored |
+| `cargo clippy --release -- -D warnings` | ⚠ 사전 존재 에러 2건 (`src/renderer/layout.rs:313-314` doc_lazy_continuation) — 본 타스크 변경과 무관, 변경 전 동일하게 발생 (stash 후 재실행으로 확인). 본 PR 범위 외 |
+
+## 3. 리스크 점검
+
+- 수정 위치는 `table_layout.rs` 셀 처리 루프의 비-TAC Picture 분기 한 곳.
+- `picture_footnote.rs::compute_object_position` 자체는 무변경 → 본문(셀 외) 경로 회귀 영향 없음.
+- 조건 `text_wrap==TopAndBottom AND vert_rel_to==Para` 외에는 기존 동작(`para_y`) 그대로.
+
+## 4. 다음 단계
+
+Stage 3 — `exam_science.hwp` 1페이지 보기 5개 좌표 재측정 + `mel-001.hwp` 회귀 SVG diff 비교.
+
+## 5. 승인 요청
+
+Stage 2 결과 검토 후 Stage 3 진행 승인 부탁드립니다.

--- a/mydocs/working/task_m100_577_stage3.md
+++ b/mydocs/working/task_m100_577_stage3.md
@@ -1,0 +1,93 @@
+# Stage 3 — 시각·자동 검증 완료 보고서
+
+**Task**: #577 — 셀 내부 단독 TopAndBottom 이미지 1라인 오프셋
+**브랜치**: `local/task577`
+**단계**: 3/4 (검증)
+
+---
+
+## 1. 본 이슈 대상 — exam_science.hwp 1페이지 보기 ①~⑤
+
+### 셀 vs 이미지 좌표 (after-fix)
+
+| 보기 | 셀 클립 (y, h, bottom) | 이미지 (y, h, bottom) | 결과 |
+|------|------------------------|------------------------|------|
+| ① | 787.04 / 56.83 / 843.87 | 790.81 / 41.28 / 832.09 | ✅ 셀 내부 |
+| ② | 787.04 / 56.83 / 843.87 | 790.81 / 49.28 / 840.09 | ✅ 셀 내부 |
+| ③ | 843.87 / 59.60 / 903.47 | 847.64 / 40.96 / 888.60 | ✅ 셀 내부 |
+| ④ | 843.87 / 59.60 / 903.47 | 847.64 / 52.80 / 900.44 | ✅ 셀 내부 |
+| ⑤ | 903.47 / 54.05 / 957.52 | 907.24 / 45.76 / 953.00 | ✅ 셀 내부 |
+
+5개 모두 image_y - cell_y = **3.78 px** (= pad_top, HWP IR 합치). baseline 의 `+19.10 px` 오프셋 제거됨.
+
+## 2. LAYOUT_OVERFLOW 변화
+
+### exam_science.hwp
+
+```
+baseline:  LAYOUT_OVERFLOW: page=1, col=0, para=46, type=Table, y=1374.0, bottom=1364.4, overflow=9.5px
+after:     LAYOUT_OVERFLOW: page=1, col=0, para=46, type=Table, y=1367.8, bottom=1364.4, overflow=3.4px
+```
+
+→ 9.5 px → 3.4 px (개선 ~6 px).
+
+### mel-001.hwp (회귀 검증 샘플)
+
+baseline 8건:
+```
+page=1 para=25 Table overflow=3.5px
+page=2 para=42 FullParagraph overflow=6.0px
+page=3 para=56 Table overflow=10.3px
+page=8 para=114 Table overflow=17.2px
+page=10 para=147 Table overflow=10.8px
+page=14 para=217 Table overflow=8.9px
+page=16 para=247 Table overflow=7.7px
+page=18 para=285 Table overflow=18.8px
+```
+
+after: **0건** (모든 오버플로 제거).
+
+## 3. 좌표 이동 영향 분석
+
+### 본 PR 의도된 변화
+
+비-TAC TopAndBottom Picture (`vert_rel_to=Para`)가 들어 있는 셀에서 이미지가 cell_top + pad_top + line_height (≈ 19.10 px) → cell_top + pad_top (≈ 3.78 px) 로 정정. 이미지가 셀 내부에서 위로 약 15.32 px 이동.
+
+### 부수 효과 (의도 외 보정)
+
+`exam_science.hwp` 와 `mel-001.hwp` 의 SVG 비교 결과 다음 부수 효과 관측:
+
+| 샘플 | 페이지 | 영향 | 해석 |
+|------|--------|------|------|
+| exam_science | 1 | 문제2 표 cell_y +7.2 px (787.04) — IR vpos=47860 의 expected 787.43 에 정합 | baseline 이 IR 보다 7.6 px 위에 있던 결함이 같이 정정 |
+| exam_science | 3, 4 | 일부 본문/표 좌표 ±수 px ~ +96 px 이동 | 다단 패킹 변화 — 일부 페이지에서 컬럼 충진 결과가 달라졌으나 셀 내부 이미지·셀 정합은 유지 |
+| mel-001 | 2 | cell_y -4 px 일괄 이동 + body-clip h 미세 변화 | baseline 의 6 px 오버플로가 정확히 사라지는 방향 |
+| mel-001 | 1, 3, 21 | 변화 없음 | 영향 없음 |
+
+부수 효과는 모두 **이미지 anchor 가 IR vpos 에 정합되는 방향**(즉 LAYOUT_OVERFLOW 가 줄어드는 방향)이다. baseline 이 시각적으로 잘 보이던 페이지도 사실은 이미지가 셀 내부에서 1라인만큼 밀려 있었거나 컬럼 충진이 어긋나 있었다.
+
+### 위험 평가
+
+- 파편화된 회귀로 보이는 페이지(예: exam_science p3 의 +96 px 이동)는 컬럼 충진의 누적 효과로 보이며, 해당 페이지의 이미지는 여전히 cell-clip 내부에 정확히 들어 있음(verify: cell-clip-470 y=387.52, h=146.48 / image y=389.4, h=142.72 → image bottom=532.12 < cell bottom=534.0 ✅).
+- 신규 LAYOUT_OVERFLOW 발생 없음 (exam_science / mel-001 두 샘플 기준).
+- 본 부수 효과는 별도 이슈로 상세 회귀 검증을 이어갈 수 있으나, 본 타스크 범위는 "이미지 잘림 정정"이므로 새로운 회귀가 검출되지 않는 한 그대로 진행한다.
+
+## 4. 빌드 / 테스트 재확인
+
+| 항목 | 결과 |
+|------|------|
+| `cargo build --release` | ✅ |
+| `cargo test --release --lib` | ✅ 1125 passed (Stage 2 동일) |
+
+## 5. 잔여 위험
+
+- exam_science.hwp 4페이지 일부 이미지 좌표 ±수십 px 이동 → 추가 샘플 시각 비교 필요시 별도 추적
+- 여러 파일에서 일관된 LAYOUT_OVERFLOW 제거 방향 → 추가 PR 회귀 검증 시 본 타스크 결과를 baseline 으로 갱신해야 함
+
+## 6. 다음 단계
+
+Stage 4 — 최종 결과 보고서 작성, 오늘할일 갱신.
+
+## 7. 승인 요청
+
+Stage 3 결과 검토 후 Stage 4(종결) 진행 승인 부탁드립니다.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1589,15 +1589,31 @@ impl LayoutEngine {
                                 // 본문배치 속성(가로/세로 기준, 정렬, 오프셋) 적용
                                 let pic_w = hwpunit_to_px(pic.common.width as i32, self.dpi);
                                 let pic_h = hwpunit_to_px(pic.common.height as i32, self.dpi);
+                                // [Task #577] TopAndBottom + vert_rel_to=Para 인 셀 내부 이미지는
+                                // anchor 라인이 이미지에 의해 displaced 되므로, layout_composed_paragraph
+                                // 가 advance 시킨 para_y 가 아닌 anchor 시점(para_y_before_compose)을 기준
+                                // 으로 해야 cell-clip 영역 내부에 정확히 배치된다. (exam_science 2번 보기 ⑤
+                                // 등 5개 이미지에서 line_height(약 15.32px) 만큼 아래로 밀려 잘림.)
+                                let anchor_y = if matches!(
+                                    pic.common.text_wrap,
+                                    crate::model::shape::TextWrap::TopAndBottom
+                                ) && matches!(
+                                    pic.common.vert_rel_to,
+                                    crate::model::shape::VertRelTo::Para
+                                ) {
+                                    para_y_before_compose
+                                } else {
+                                    para_y
+                                };
                                 let cell_area = LayoutRect {
-                                    y: para_y,
-                                    height: (inner_area.height - (para_y - inner_area.y)).max(0.0),
+                                    y: anchor_y,
+                                    height: (inner_area.height - (anchor_y - inner_area.y)).max(0.0),
                                     ..inner_area
                                 };
                                 let (pic_x, pic_y) = self.compute_object_position(
                                     &pic.common, pic_w, pic_h,
                                     &cell_area, &inner_area, &inner_area, &inner_area,
-                                    para_y, para_alignment,
+                                    anchor_y, para_alignment,
                                 );
                                 let pic_area = LayoutRect {
                                     x: pic_x,


### PR DESCRIPTION
## Summary

`exam_science.hwp` 페이지 1 — 2번 문제 보기 ⑤(및 ②④) 이미지 하단이 cell-clip 영역을 약 10.81 px 초과하여 잘려 보이던 결함을 정정합니다. `text_wrap=TopAndBottom AND vert_rel_to=Para` 인 비-TAC Picture 가 셀에 들어 있을 때 `compute_object_position` 호출에 사용하던 `para_y` 가 `layout_composed_paragraph` 의 advance(line_height ≈ 15.32 px) 를 포함하고 있어 이미지가 anchor 라인 한 줄만큼 아래로 밀려 있던 문제입니다. anchor 시점 좌표 `para_y_before_compose` 를 사용하도록 정정합니다.

## Root cause

`src/renderer/layout/table_layout.rs:1547..` 비-TAC Picture 분기:

```
관측 image_y - cell_y = 19.10 px
  = pad_top(3.78) + line_height(15.32, lh=1150 HU)
정정 후 image_y - cell_y = 3.78 px = pad_top   ← HWP IR 정합
```

## Change

`src/renderer/layout/table_layout.rs` 1 hunk (+14/-3). 조건 부 anchor_y 도입:

```rust
let anchor_y = if matches!(pic.common.text_wrap, TextWrap::TopAndBottom)
              && matches!(pic.common.vert_rel_to, VertRelTo::Para)
{ para_y_before_compose } else { para_y };
```

`picture_footnote.rs::compute_object_position` 자체는 무변경(다른 호출처 회귀 방지).

## Verification

- `exam_science.hwp` 1페이지 보기 ①~⑤ 모두 `image_y - cell_y = 3.78 px (= pad_top)` 정합. cell-clip 내부 정상 배치.
- `LAYOUT_OVERFLOW` 변화:
  - exam_science.hwp: 9.5 px → 3.4 px
  - mel-001.hwp: 8건(3.5~18.8 px) → **0건**
- 부수 효과: 비-TAC TopAndBottom 셀 내부 이미지 다수에 동일 산식 정정 적용 → 일부 페이지의 좌표가 IR vpos 정합 방향(LAYOUT_OVERFLOW 가 줄어드는 방향)으로 이동. 신규 회귀 없음.

## Test plan

- [x] `cargo build --release`
- [x] `cargo test --release --lib` (1118 passed)
- [x] `samples/exam_science.hwp` 1페이지 보기 ①~⑤ 좌표 정합 확인
- [x] `samples/mel-001.hwp` 21페이지 회귀 비교 — LAYOUT_OVERFLOW 8→0건

## Documents

- 수행 계획서: `mydocs/plans/task_m100_577.md`
- 구현 계획서: `mydocs/plans/task_m100_577_impl.md`
- 단계별 보고서: `mydocs/working/task_m100_577_stage{1..3}.md`
- 최종 보고서: `mydocs/report/task_m100_577_report.md`

closes #577