### PR TITLE
fix: iframe postMessage race condition — wasm 초기화 대기 (#522)

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -650,7 +650,7 @@ function showLoadError(error: unknown): void {
   });
 }
 
-initialize();
+const initPromise = initialize();
 
 // ── iframe 연동 API (postMessage) ──
 // 부모 페이지에서 postMessage로 에디터를 제어할 수 있다.
@@ -663,6 +663,7 @@ window.addEventListener('message', async (e) => {
   // 기존 hwpctl-load 호환
   if (msg.type === 'hwpctl-load' && msg.data) {
     try {
+      await initPromise;
       const bytes = new Uint8Array(msg.data);
       const docInfo = wasm.loadDocument(bytes, msg.fileName || 'document.hwp');
       await initializeDocument(docInfo, `${msg.fileName || 'document'} — ${docInfo.pageCount}페이지`);
@@ -682,7 +683,13 @@ window.addEventListener('message', async (e) => {
 
   try {
     switch (method) {
+      case 'ready':
+        // wasm 초기화 완료 후에만 true 응답 — race condition 방지 (#522)
+        await initPromise;
+        reply(true);
+        break;
       case 'loadFile': {
+        await initPromise;
         const bytes = new Uint8Array(params.data);
         const docInfo = wasm.loadDocument(bytes, params.fileName || 'document.hwp');
         await initializeDocument(docInfo, `${params.fileName || 'document'} — ${docInfo.pageCount}페이지`);
@@ -690,16 +697,16 @@ window.addEventListener('message', async (e) => {
         break;
       }
       case 'pageCount':
+        await initPromise;
         reply(wasm.pageCount);
         break;
       case 'getPageSvg':
+        await initPromise;
         reply(wasm.renderPageSvg(params.page ?? 0));
         break;
       case 'exportHwp':
+        await initPromise;
         reply(Array.from(wasm.exportHwp()));
-        break;
-      case 'ready':
-        reply(true);
         break;
       default:
         reply(undefined, `Unknown method: ${method}`);


### PR DESCRIPTION
## 문제

`@rhwp/editor` wrapper의 `_waitReady()` → `loadFile` 호출 시:
1. `__wbindgen_malloc undefined` 즉시 실패
2. `Request timeout: loadFile` (10초 후)

두 패턴이 무작위로 발생. 원인: `rhwp-studio/src/main.ts`의 message handler가
`initialize()` 완료 여부와 무관하게 즉시 등록되고, `'ready'` 메서드가 wasm 상태
확인 없이 `reply(true)` 반환.

## 원인 분석

```
initialize() (async, 5-15s)
  ├─ loadWebFonts
  └─ wasm.initialize() ← 시간 소요

window.addEventListener('message', ...) ← 즉시 등록, initialize 대기 X
  case 'ready': reply(true)  ← wasm 미초기화 상태에서도 true
  case 'loadFile': wasm.loadDocument(...) ← throw
```

## 해결

`initialize()` 반환 Promise를 `initPromise`로 캡처하고, 모든 RPC 메서드에서
`await initPromise` 후 응답:

- `ready`: 초기화 완료 후에만 `true` 응답
- `loadFile`, `pageCount`, `getPageSvg`, `exportHwp`: 초기화 대기 후 실행
- 레거시 `hwpctl-load`: 동일 가드 추가

## 검증

- `npx tsc --noEmit` — 기존 `@types/chrome` 누락 1건 외 에러 없음 (기존)
- `cargo test` + `cargo clippy -- -D warnings` 통과

Closes #522