### PR TITLE
fix: 그룹 내 그림(Picture) 직렬화 구현 + 라운드트립 테스트

### DIFF
--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1273,8 +1273,19 @@ fn serialize_group_child(
                 serialize_group_child(nested_child, comp_level + 1, comp_level + 2, records);
             }
         }
-        ShapeObject::Picture(_pic) => {
-            // TODO: 그룹 내 그림 직렬화
+        ShapeObject::Picture(pic) => {
+            records.push(Record {
+                tag_id: tags::HWPTAG_SHAPE_COMPONENT,
+                level: comp_level,
+                size: 0,
+                data: serialize_shape_component(tags::SHAPE_PICTURE_ID, &pic.shape_attr, false),
+            });
+            records.push(Record {
+                tag_id: tags::HWPTAG_SHAPE_COMPONENT_PICTURE,
+                level: type_level,
+                size: 0,
+                data: serialize_picture_data(pic),
+            });
         }
         ShapeObject::Chart(chart) => {
             // Task #195 단계 2: 그룹 내 차트는 raw_chart_data로 라운드트립

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -398,3 +398,82 @@ fn test_roundtrip_header() {
         panic!("Expected Header control");
     }
 }
+
+/// 그룹 내 Picture 자식 라운드트립 (#428 후속)
+#[test]
+fn test_roundtrip_group_picture_child() {
+    use crate::model::image::Picture;
+    use crate::model::shape::{
+        CommonObjAttr, GroupShape, ShapeComponentAttr, ShapeObject,
+    };
+
+    let pic = Picture {
+        common: CommonObjAttr::default(),
+        shape_attr: ShapeComponentAttr {
+            group_level: 1,
+            original_width: 5000,
+            original_height: 3000,
+            current_width: 5000,
+            current_height: 3000,
+            ..Default::default()
+        },
+        image_attr: crate::model::image::ImageAttr {
+            bin_data_id: 7,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let group = GroupShape {
+        common: CommonObjAttr {
+            width: 10000,
+            height: 8000,
+            ..Default::default()
+        },
+        shape_attr: ShapeComponentAttr {
+            original_width: 10000,
+            original_height: 8000,
+            current_width: 10000,
+            current_height: 8000,
+            ..Default::default()
+        },
+        children: vec![ShapeObject::Picture(Box::new(pic))],
+        caption: None,
+    };
+
+    let para = Paragraph {
+        char_count: 2,
+        text: "".to_string(),
+        char_offsets: vec![],
+        controls: vec![Control::Shape(Box::new(ShapeObject::Group(group)))],
+        ..Default::default()
+    };
+
+    let section = Section {
+        paragraphs: vec![para],
+        raw_stream: None,
+        ..Default::default()
+    };
+
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+
+    assert_eq!(parsed.paragraphs.len(), 1);
+    let ctrl = &parsed.paragraphs[0].controls[0];
+    if let Control::Shape(shape) = ctrl {
+        if let ShapeObject::Group(g) = shape.as_ref() {
+            assert_eq!(g.children.len(), 1, "Group should have 1 child");
+            if let ShapeObject::Picture(p) = &g.children[0] {
+                assert_eq!(p.image_attr.bin_data_id, 7, "bin_data_id should survive roundtrip");
+                assert_eq!(p.shape_attr.original_width, 5000);
+                assert_eq!(p.shape_attr.original_height, 3000);
+            } else {
+                panic!("Expected Picture child, got {:?}", g.children[0]);
+            }
+        } else {
+            panic!("Expected Group shape");
+        }
+    } else {
+        panic!("Expected Shape control");
+    }
+}


### PR DESCRIPTION
## 배경

이전 PR #428에서 동일 수정을 제출했으나, Copilot 리뷰에서 라운드트립
테스트 부재를 지적받아 close됨. 이번 PR은 해당 피드백을 반영.

## 문제

`serialize_group_child()`의 `ShapeObject::Picture` 분기가 TODO로 빈 상태:
```rust
ShapeObject::Picture(_pic) => {
    // TODO: 그룹 내 그림 직렬화
}
```

그룹 도형에 포함된 그림이 저장 시 누락됨.

## 해결

기존 단독 Picture 직렬화(`serialize_picture_control`)와 동일한 패턴으로
그룹 자식 경로에 레코드 2개 생성:

1. `HWPTAG_SHAPE_COMPONENT` (comp_level) — `serialize_shape_component(SHAPE_PICTURE_ID, ...)`
2. `HWPTAG_SHAPE_COMPONENT_PICTURE` (type_level) — `serialize_picture_data(pic)`

다른 그룹 자식(Line, Rectangle, Ellipse, Chart, OLE)과 동일한 구조.

## 검증

라운드트립 테스트 `test_roundtrip_group_picture_child`:
- Group{children: [Picture{bin_data_id=7, size=5000x3000}]} 구성
- `serialize_section` → `parse_body_text_section`
- Picture 자식 존재, `bin_data_id`, `original_width/height` 보존 확인

- `cargo test` 전체 통과
- `cargo clippy -- -D warnings` 경고 0

이전 PR: #428 (closed)