### PR TITLE
fix: 문자 컨트롤 0x18/0x1E 매핑 swap (하이픈 ↔ 묶음 빈칸)

### DIFF
--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -327,22 +327,22 @@ fn parse_para_text(data: &[u8]) -> (String, Vec<u32>, Vec<FieldRange>, Vec<[u16;
             match ch {
                 0x0018 => {
                     char_offsets.push(code_unit_pos);
-                    text.push('\u{00A0}'); // 묶음 빈칸
+                    text.push('-'); // 하이픈 (HWP 5.0 표 7: 코드 24)
                     char_count += 1;
                 }
                 0x0019 => {
                     char_offsets.push(code_unit_pos);
-                    text.push(' '); // 고정폭 빈칸
+                    text.push(' '); // 예약 (코드 25-29) — 호환성 위해 공백 유지
                     char_count += 1;
                 }
                 0x001E => {
                     char_offsets.push(code_unit_pos);
-                    text.push('-'); // 하이픈
+                    text.push('\u{00A0}'); // 묶음 빈칸 (HWP 5.0 표 7: 코드 30, NO-BREAK SPACE)
                     char_count += 1;
                 }
                 0x001F => {
                     char_offsets.push(code_unit_pos);
-                    text.push('\u{2007}'); // 고정폭 빈칸 (FIGURE SPACE)
+                    text.push('\u{2007}'); // 고정폭 빈칸 (HWP 5.0 표 7: 코드 31, FIGURE SPACE)
                     char_count += 1;
                 }
                 _ => {}

--- a/src/parser/tags.rs
+++ b/src/parser/tags.rs
@@ -125,13 +125,13 @@ pub const CHAR_EXTENDED_CTRL: u16 = 0x000B;
 pub const CHAR_LINE_BREAK: u16 = 0x000A;
 /// 문단 나눔
 pub const CHAR_PARA_BREAK: u16 = 0x000D;
-/// 하이픈
-pub const CHAR_HYPHEN: u16 = 0x001E;
-/// 고정폭 공백
-pub const CHAR_NBSPACE: u16 = 0x0018;
-/// 고정폭 하이픈
+/// 하이픈 (HWP 5.0 표 7: 코드 24)
+pub const CHAR_HYPHEN: u16 = 0x0018;
+/// 묶음 빈칸 / NO-BREAK SPACE (HWP 5.0 표 7: 코드 30)
+pub const CHAR_NBSPACE: u16 = 0x001E;
+/// 예약 (스펙 코드 25)
 pub const CHAR_FIXED_WIDTH_SPACE: u16 = 0x0019;
-/// 고정폭 빈칸 (스펙 코드 31)
+/// 고정폭 빈칸 / FIGURE SPACE (HWP 5.0 표 7: 코드 31)
 pub const CHAR_FIXED_WIDTH_SPACE_31: u16 = 0x001F;
 
 // ============================================================


### PR DESCRIPTION
## 요약

HWP 5.0 스펙 **표 7 (문자 컨트롤)** 과 반대로 매핑되어 있던 두 코드를 정정합니다.

| 코드   | 스펙 (표 7)         | 수정 전          | 수정 후          |
|--------|---------------------|------------------|------------------|
| 0x18   | 하이픈              | `U+00A0` (nbsp)  | `-` (hyphen)     |
| 0x1E   | 묶음 빈칸           | `-` (hyphen)     | `U+00A0` (nbsp)  |

자체 테스트 (`src/parser/body_text/tests.rs:117,120`) 의 주석은 이미 정답을 가리키고 있었습니다 — 구현만 swap 되어 있던 상태입니다.

## 증상

`samples/exam_eng.hwp`, `samples/exam_kor.hwp` 등 시험지 문서에서 문제 번호 다음에 하이픈이 잘못 표시되었습니다. 한컴 PDF (`samples/exam_eng.pdf` 등) 와 비교 시 확인 가능합니다.

```
수정 전: "1.- 다음을 듣고, 여자가 하는 말의 목적으로 가장 적절한 것을 고르시오."
수정 후: "1.\u{a0} 다음을 듣고, 여자가 하는 말의 목적으로 가장 적절한 것을 고르시오."
```

`rhwp dump samples/exam_eng.hwp -s 0 -p 2` 로 확인.

## 회귀 검증

`export-svg` 결과의 `>-</text>` 글리프 출현 횟수 비교:

| 샘플          | 수정 전 | 수정 후 | 제거된 잘못된 '-' |
|---------------|---------|---------|-------------------|
| exam_eng      | 366     | 39      | 327               |
| exam_kor      | 444     | 33      | 411               |
| exam_science  | 37      | 18      | 19                |
| exam_math     | 42      | 42      | 0                 |
| exam_social   | 2       | 2       | 0                 |

수정 후 남은 `-` 글리프는 영어 단어 내 실제 하이픈, 표 구분자 등 정상 케이스입니다. exam_math / exam_social 은 해당 코드를 미사용하는 문서라 변화 없음.

## 변경 파일

- `src/parser/body_text.rs:328-348` — 0x18 ↔ 0x1E 매핑 swap (`parse_para_text`)
- `src/parser/tags.rs:128-131` — `CHAR_HYPHEN` / `CHAR_NBSPACE` 상수 swap (외부 참조 없음)

## 테스트 계획

- [x] `cargo test --release --lib` 1125 passed
- [x] `cargo test --release --lib parser::body_text` 22 passed
- [x] `rhwp dump samples/exam_eng.hwp -s 0 -p 2` 결과 확인
- [x] exam_eng / exam_kor / exam_math / exam_science / exam_social SVG 회귀 비교

🤖 Generated with [Claude Code](https://claude.com/claude-code)