### PR TITLE
[m100] exam_eng.hwp p7 #40 글상자 사이 화살표 누락 — PUA U+F003B → ↓ 매핑 추가 (closes #588)

### DIFF
--- a/mydocs/plans/task_m100_588.md
+++ b/mydocs/plans/task_m100_588.md
@@ -1,0 +1,142 @@
+# Task #588 수행 계획서 — exam_eng.hwp 7페이지 #40 글상자 사이 PUA U+F003B 화살표 매핑 누락
+
+## 이슈 정합
+
+- **Issue**: [#588](https://github.com/edwardkim/rhwp/issues/588) — bug, milestone v1.0.0 (M100)
+- **본질**: HWP SPUA-A (`0xF0000~0xF02AF`) 영역 코드포인트 U+F003B 가 `map_pua_bullet_char` 매핑 표 밖에 있어 SVG 에 두부(□)로 렌더
+- **연관 사이클**: Task #509 (PUA 매핑 표 골격) / Task #528 (옛한글 PUA + 책괄호 hotfix)
+
+## 본 사이클 조사 결과
+
+### 증상 위치 (확정)
+
+| 항목 | 값 |
+|------|-----|
+| 파일 | `samples/exam_eng.hwp` |
+| 페이지 | 7 (global_idx=6, section=0) |
+| 단 | 1 (우측 단) |
+| 문단 | pi=278 (단일 문자) |
+| 컨텍스트 | pi=277 (첫 글상자) ── pi=278 (↓ 자리) ── pi=279 (둘째 글상자) |
+| 글자 | U+F003B (UTF-8 `f3 b0 80 bb`) |
+| CharShape | id=20, 폰트 HY신명조, 15pt, ratio 130%, spacing -5%, align Center |
+
+### 매핑 영역 점검
+
+`src/renderer/layout/paragraph_layout.rs:2907` `map_pua_bullet_char` 의 현재 분기:
+
+| 영역 | 범위 | 용도 |
+|------|------|------|
+| Wingdings | `0xF020..=0xF0FF` | 글머리표 / 화살표 / 도형 (Task #509 정합) |
+| 원문자 | `0xF02B0..=0xF02FF` | ①~⑨, · (Task #509 정합) |
+| 책괄호 / 예시 | `0xF00D0..=0xF09FF` | 《》, ▸ (Task #528 hotfix) |
+
+**U+F003B (=`0xF0000 + 0x3B`) 는 `0xF0000..=0xF00CF` 미커버 영역**.
+
+### 시각 정답지 확정 필요
+
+요약형 문항(2010 수능 영어 40번 패턴) 의 표준 패턴:
+```
+[원문 passage]
+       ↓
+[요약 (A) … (B) …]
+```
+
+후보 글리프 (확정 필요):
+- ↓ U+2193 DOWNWARDS ARROW
+- ⇩ U+21E9 DOWNWARDS WHITE ARROW (기존 `0xF0F2` 와 같은 영역, Wingdings 분기 선례)
+- ⬇ U+2B07 DOWNWARDS BLACK ARROW
+- ⇓ U+21D3 DOWNWARDS DOUBLE ARROW
+
+판정 권위: `samples/exam_eng.pdf` 7쪽 한컴 PDF (메모리 룰 `reference_authoritative_hancom`).
+
+### 정정 방향 — 옵션 A (권장)
+
+**SPUA-A 분기 신설 (`0xF0000..=0xF00CF`) + U+F003B 1건 매핑 추가**
+
+근거:
+1. 기존 분기 영역과 충돌 없음 (디스조인트)
+2. 최소 fix — 단일 코드포인트 매핑, 광범위 영향 0
+3. 메모리 룰 `feedback_hancom_compat_specific_over_general` 정합 (특정 영역 한정)
+4. 향후 같은 영역의 다른 미매핑 코드포인트 발견 시 본 분기에 추가만 하면 됨
+
+옵션 B (기각): 기존 `0xF02B0..=0xF02FF` 영역을 `0xF0000..=0xF02FF` 로 확장 — 영역 의미 혼합으로 향후 가독성 저하.
+
+## 단계 분리 (4 stages)
+
+### Stage 1 — 한컴 PDF 시각 정답지 확정 + 광범위 PUA 점검
+
+- `samples/exam_eng.pdf` 7쪽 시각 확인 → 정확한 화살표 글리프 형태 확정 (작업지시자 판정)
+- 14 fixture 샘플 (exam_kor / exam_science / exam_eng / 21_언어_기출 / synam-001 / k-water-rfp / aift / mel-001 / hwpspec / hwp3-sample / mathpresso / kps-ai / synap-001 / kshs-001) 의 SPUA-A `0xF0000..=0xF00CF` 영역 코드포인트 전수 통계
+  - 같은 영역의 추가 미매핑 글자 발견 시 본 사이클 일괄 처리 후보로 정리 (별도 task 분리 가능)
+- 본 사이클 정정 영역이 회귀 차단 정합인지 점검 (다른 의도된 PUA 사용 회피)
+
+**산출물**: `mydocs/working/task_m100_588_stage1.md`
+
+### Stage 2 — Red 테스트 + 매핑 구현
+
+- 단위 테스트 추가 (`paragraph_layout.rs::pua_mapping_tests` 모듈 안):
+  - `supplementary_pua_a_low_range_maps_down_arrow` — U+F003B → 확정 코드포인트
+  - `supplementary_pua_a_low_range_unmapped_returns_original` — 같은 영역 매핑 표 외는 원본 유지
+- `map_pua_bullet_char` 에 SPUA-A 저영역 분기 신설:
+  ```rust
+  if (0xF0000..=0xF00CF).contains(&code) {
+      return match code {
+          0xF003B => '\u{XXXX}', // 확정 화살표
+          _ => ch,
+      };
+  }
+  ```
+  분기 위치: 기존 `0xF02B0..=0xF02FF` 분기 직전 (코드포인트 오름차순 정합)
+- Red → Green 전환
+
+**산출물**: `paragraph_layout.rs` 변경 + 단위 테스트 +2 GREEN
+
+### Stage 3 — 광범위 회귀 점검
+
+- `cargo test --lib` (baseline 회귀 0)
+- `cargo test --test svg_snapshot` 6/6
+- `cargo clippy --lib -- -D warnings` 0건 신규
+- WASM 빌드 정합
+- 14 fixture 광범위 byte sweep — 의도된 변경 (exam_eng p7 only) 외 회귀 0
+  - 의도된 변경: pi=278 SVG `<text>` 내용 U+F003B → ↓ (또는 확정 글리프)
+- 기존 PUA 매핑 영역 (Task #509 / #528) 회귀 0 확인
+
+**산출물**: `mydocs/working/task_m100_588_stage3.md`
+
+### Stage 4 — 작업지시자 시각 검증 + 최종 보고서
+
+- exam_eng.hwp p7 SVG 시각 비교 (한컴 PDF 정답지 정합)
+- 글상자 사이 화살표 정합 표시 확인
+- 다른 페이지 (회귀 영역) 시각 정합 보존
+- 최종 보고서 작성 + 오늘할일 갱신
+- 이슈 #588 close 승인 요청
+
+**산출물**: `mydocs/report/task_m100_588_report.md`
+
+## 검증 게이트 (각 Stage 공통)
+
+| 검증 | 기준 |
+|------|------|
+| cargo test --lib | 회귀 0 (baseline 1123+) |
+| cargo test --test svg_snapshot | 6/6 |
+| cargo clippy --lib -- -D warnings | 0건 신규 |
+| WASM 빌드 | 정합 |
+| 14 fixture 광범위 byte sweep | 의도된 변경 외 회귀 0 |
+| **작업지시자 시각 검증** | 한컴 PDF 정답지 정합 (Stage 4 게이트) |
+
+## 위험 영역
+
+- **글리프 형태 오판** — ↓ / ⇩ / ⬇ / ⇓ 중 한컴 PDF 정답지로 정확한 형태 확정 필요. 작업지시자 시각 판정 권위.
+- **광범위 영역 매핑 충동** — SPUA-A 저영역 (`0xF0000..=0xF00CF`) 의 다른 코드포인트 사용 케이스 회귀. Stage 1 의 광범위 통계로 차단.
+- **분기 순서 영향** — 기존 분기 `0xF00D0..=0xF09FF` 가 신설 분기와 인접. 분기 작성 순서 명확히 (오름차순).
+
+## 처리 정합 (메모리 룰)
+
+- `feedback_hancom_compat_specific_over_general` — 단일 코드포인트 한정 매핑 (광범위 영역 일괄 매핑 회피)
+- `reference_authoritative_hancom` — 한컴 PDF 시각 정답지 권위
+- `feedback_visual_regression_grows` — 작업지시자 시각 판정 게이트 정합 (Stage 4)
+- `feedback_search_troubleshootings_first` — Stage 1 시작 전 troubleshootings/ 전수 검색
+
+## 다음 단계
+
+작업지시자 승인 후 Stage 1 (한컴 PDF 정답지 확정 + 광범위 통계) 진행.

--- a/mydocs/report/task_m100_588_report.md
+++ b/mydocs/report/task_m100_588_report.md
@@ -1,0 +1,134 @@
+# Task #588 최종 결과 보고서 — exam_eng.hwp p7 #40 글상자 사이 화살표 누락 (PUA U+F003B 매핑 추가)
+
+## 요약
+
+- **이슈**: [#588](https://github.com/edwardkim/rhwp/issues/588) (M100, v1.0.0)
+- **본질**: HWP SPUA-A 저영역 (`0xF0000~0xF00CF`) 코드포인트 U+F003B 가 `map_pua_bullet_char` 매핑 표 밖이어서 SVG 에 두부(□) 표시
+- **정정**: SPUA-A 저영역 분기 신설 + U+F003B → ↓ U+2193 (DOWNWARDS ARROW) 매핑 추가
+- **결과**: exam_eng.hwp p7 #40 요약형 문항 글상자 사이 화살표 정합 표시. 광범위 회귀 0 (582/583 byte-identical).
+
+## 변경 영역
+
+### 1. `src/renderer/layout/paragraph_layout.rs`
+
+#### 1.1 `map_pua_bullet_char` SPUA-A 저영역 분기 신설
+
+```rust
+// Supplementary PUA-A 저영역 — 한컴 자체 영역 (Task #588 한컴 정답지 정합)
+if (0xF0000..=0xF00CF).contains(&code) {
+    return match code {
+        // exam_eng.hwp p7 #40 요약형 문항 글상자 사이 화살표.
+        // 한컴 PDF (HCRBatang 임베디드 폰트) 글리프 외곽 분석:
+        //   stem 35% × arrowhead 100% × solid filled (1 contour, 7 pts) → ↓
+        0xF003B => '\u{2193}', // ↓ DOWNWARDS ARROW
+        _ => ch,
+    };
+}
+```
+
+#### 1.2 docstring 갱신
+
+기존 "두 영역 분기" → 세 영역 (Basic / SPUA-A 저영역 / SPUA-A 일반) 으로 정합 갱신.
+
+#### 1.3 단위 테스트 +2
+
+- `supplementary_pua_a_low_range_maps_down_arrow` (U+F003B → U+2193)
+- `supplementary_pua_a_low_range_unmapped_returns_original` (F0000/F0090/F00CF default)
+
+## 단계 요약
+
+| 단계 | 산출물 | 핵심 결과 |
+|------|--------|----------|
+| Stage 1 | `mydocs/working/task_m100_588_stage1.md` | PDF 임베디드 폰트 글리프 외곽 분석 (↓ 형태 확정) + 159 샘플 광범위 통계 (target 영역 U+F003B 1건 + U+F0090 1건) |
+| Stage 2 | `paragraph_layout.rs` + `_stage2.md` | 분기 신설 + 매핑 + 단위 테스트 +2 (7/7 GREEN) |
+| Stage 3 | `_stage3.md` | 광범위 회귀 점검: 583 SVG → 582 byte-identical, 1 의도된 변경 (exam_eng/p7), 회귀 0 |
+| Stage 4 | 본 보고서 | 작업지시자 시각 판정 + 이슈 close |
+
+## 결정적 검증 게이트 (Stage 3 통과)
+
+| 게이트 | 결과 |
+|--------|------|
+| cargo test --lib | **1126 passed** (3 ignored, 0 failed; baseline 1124 + 신규 2) |
+| cargo test --test svg_snapshot | **6/6 GREEN** |
+| 통합 테스트 (issue_*, exam_eng_multicolumn) | **모두 통과** (issue_418/501/505/514/516/530/546 + exam_eng_multicolumn) |
+| cargo clippy --lib -- -D warnings | **0 신규** |
+| WASM 빌드 | **4,529,640 bytes** 정합 |
+| 14 fixture 광범위 byte sweep | **582/583 byte-identical** (회귀 0) |
+
+## 시각 변경 (작업지시자 판정 게이트)
+
+`exam_eng.hwp` 7페이지 → 단 1 → 40번 문제:
+
+**변경 전**:
+```
+[원문 passage 글상자 (pi=277)]
+       □                       ← 두부 (U+F003B 글리프 미보유)
+[요약 (A) … (B) … 글상자 (pi=279)]
+```
+
+**변경 후**:
+```
+[원문 passage 글상자 (pi=277)]
+       ↓                       ← U+2193 DOWNWARDS ARROW (모든 폰트에서 글리프 보유)
+[요약 (A) … (B) … 글상자 (pi=279)]
+```
+
+**작업지시자 시각 판정 권위** (메모리 룰 `reference_authoritative_hancom`).
+
+## 회귀 차단 설계
+
+신설 분기 (`0xF0000..=0xF00CF`) 는 기존 분기 영역과 **완전 디스조인트**:
+
+| 영역 | 범위 | 차이 |
+|------|------|------|
+| 본 사이클 (Task #588) | `0xF0000..=0xF00CF` | (신규) |
+| Task #528 (책괄호/예시) | `0xF00D0..=0xF09FF` | 0xF00D0 직전에서 종료 |
+| Task #509 (원문자) | `0xF02B0..=0xF02FF` | 영역 분리 |
+| Wingdings (Task #509) | `0xF020..=0xF0FF` | BMP PUA, SPUA-A 와 무중첩 |
+
+설계 검증: 583 SVG sweep 에서 582 byte-identical → 디스조인트 설계 결정적 확인.
+
+## 잔존 영역 (별도 task 후보)
+
+Stage 1 광범위 통계로 확인된 동일 영역 미매핑 코드포인트:
+
+| 코드포인트 | 분포 | 비고 |
+|---|---|---|
+| U+F0090 | img-start-001.hwp 1건 | 본 task 영역 (`0xF0000~0xF00CF`) — 시각 판정 후 별도 이슈 |
+| U+F012B | 복학원서.hwp 1건 | Task #528 영역 default |
+| U+F081C | 복학원서.hwp 2건 | Task #528 영역 default |
+| U+F02BA, F02C3~F02C5 | mel-001.hwp | Task #509 영역 default |
+| U+F02CE~F02D0 | k-water-rfp.hwp | Task #509 영역 default |
+| U+F02FC | pic-in-head/table 22건 | Task #509 영역 default |
+
+작업지시자 결정 대기 — 일괄 이슈 등록 후 별도 task 사이클로 처리 가능.
+
+## 다음 단계
+
+1. 작업지시자 시각 판정:
+   - `output/svg/exam_eng_p7_after/exam_eng_007.svg` 7쪽 40번 문제 글상자 사이 ↓ 표시 정합 확인
+   - (선택) `samples/exam_eng.pdf` 7쪽과 시각 비교
+2. 시각 판정 통과 시 이슈 #588 close + `local/task588` → `local/devel` merge
+3. 오늘할일 (`mydocs/orders/20260504.md`) 갱신
+
+## 메모리 룰 정합
+
+- `feedback_hancom_compat_specific_over_general` — 단일 코드포인트 한정 매핑 (광범위 영역 일괄 매핑 회피)
+- `reference_authoritative_hancom` — 한컴 PDF 시각 정답지 권위 (Stage 1 분석)
+- `feedback_visual_regression_grows` — 광범위 byte sweep + 시각 판정 게이트
+- `feedback_essential_fix_regression_risk` — 분기 디스조인트 설계로 회귀 위험 차단
+- `feedback_no_pr_accumulation` — 같은 영역 다른 코드포인트는 별도 task
+
+## 산출물 목록
+
+```
+mydocs/plans/task_m100_588.md                  — 수행 계획서
+mydocs/working/task_m100_588_stage1.md         — Stage 1 (PDF 분석 + 통계)
+mydocs/working/task_m100_588_stage2.md         — Stage 2 (구현)
+mydocs/working/task_m100_588_stage3.md         — Stage 3 (회귀 점검)
+mydocs/report/task_m100_588_report.md          — 최종 보고서 (본 문서)
+
+src/renderer/layout/paragraph_layout.rs        — 분기 신설 + 단위 테스트 +2 (32 lines added)
+
+output/svg/exam_eng_p7_after/exam_eng_007.svg  — Stage 2 후 SVG (시각 판정 대상)
+```

--- a/mydocs/working/task_m100_588_stage1.md
+++ b/mydocs/working/task_m100_588_stage1.md
@@ -1,0 +1,142 @@
+# Task #588 Stage 1 — 한컴 PDF 정답지 글리프 확정 + 광범위 PUA 통계
+
+## 목표
+
+1. `samples/exam_eng.pdf` 7쪽의 U+F003B 글리프 시각 형태 확정
+2. 14 fixture (전체 159 샘플) 의 SPUA-A 저영역 (`0xF0000~0xF00CF`) 코드포인트 전수 통계
+3. 회귀 차단 정합 점검
+
+## 1. 글리프 형태 — 한컴 PDF 정답지 분석
+
+### 1.1 PDF 구조 분석
+
+`samples/exam_eng.pdf` 7쪽은 임베디드 서브셋 폰트 `AAAAAL+HCRBatang` (HWP의 HY신명조 등가) 를 사용하며, U+F003B 위치:
+```
+x=593.6, y=275.2, font=AAAAAL+HCRBatang, size=11.5pt
+```
+
+ToUnicode CMap 미설정 → PDF 텍스트 추출에서 U+F003B 가 그대로 보존 (pdfminer 검증).
+
+### 1.2 임베디드 폰트 글리프 분석
+
+`AAAAAL+HCRBatang` 의 `uF003B` 글리프 (1 contour, 7 points):
+
+| Point | Coordinate | 의미 |
+|-------|-----------|------|
+| 0 | (661, 799) | 상부 우측 (stem top-right) |
+| 1 | (661, 255) | stem 우측 하단 |
+| 2 | (882, 255) | 화살촉 우측 끝 |
+| 3 | (486, -141) | **화살촉 끝 (tip, 하단)** |
+| 4 | (87, 255) | 화살촉 좌측 끝 |
+| 5 | (308, 255) | stem 좌측 하단 |
+| 6 | (308, 799) | 상부 좌측 (stem top-left) |
+
+bbox: (87, -141, 882, 799), units/em = 1000
+
+ASCII 렌더링:
+```
+       ████████████
+       ████████████   ← stem (sturdy/thick rectangular shaft)
+       ████████████
+       ████████████
+       ████████████
+       ████████████
+   ████████████████████  ← arrowhead (full-width horizontal)
+    ██████████████████
+     ████████████████
+      ██████████████
+       ████████████
+         ████████
+          ██████
+           ████
+            ██     ← tip
+```
+
+**확정 형태**: solid filled (단일 contour 폐다각형 → fill 영역) **down arrow**.
+
+### 1.3 후보 매핑 비교
+
+| 후보 | 이름 | 유닉스 글리프 | 정합 |
+|------|-----|---|------|
+| ↓ U+2193 | DOWNWARDS ARROW | 단순 (수능 표준) | **권장** |
+| ⇩ U+21E9 | DOWNWARDS WHITE ARROW | 외곽선/속빈 | 형태 불일치 (속빈) |
+| ⬇ U+2B07 | DOWNWARDS BLACK ARROW | 두꺼운 검정 | 형태 정합 |
+| ⇓ U+21D3 | DOWNWARDS DOUBLE ARROW | 두 줄 | 형태 불일치 |
+
+**근거**:
+- 글리프 외곽 (stem 35% / arrowhead 100% / 단일 fill) = solid black arrow
+- 한국 수능 출제 표준: ↓ U+2193 (한국교육과정평가원 + EBS 출제 폰트 정합)
+- 해당 fixture 자체가 **수능 영어 기출** 문서 (40번 요약형 문항)
+
+**최종 권장**: **↓ U+2193 DOWNWARDS ARROW**
+
+대안 (⬇ U+2B07): 일반 폰트의 ↓ (U+2193) 글리프가 본 HCRBatang 글리프보다 얇게 그려지는 폰트가 다수 → 본 글리프의 두꺼운 시각과 더 정합. 단, Unicode 표준 의도는 다름 (U+2B07 은 명시적 "검정 화살표").
+
+작업지시자 시각 판정 권위 (메모리 룰 `reference_authoritative_hancom`).
+
+## 2. 14 fixture 광범위 PUA 통계
+
+### 2.1 Task #588 target range (`0xF0000..=0xF00CF`)
+
+전체 159 샘플 (HWP / HWPX) 의 export-text 출력 전수 스캔 결과:
+
+| 코드포인트 | 합계 | 분포 |
+|---|---|---|
+| **U+F003B** | 1 | exam_eng.hwp(1) — **본 task target** |
+| U+F0090 | 1 | img-start-001.hwp(1) — 별도 task 후보 |
+
+**확정**: 본 사이클 정정 영역 = U+F003B 1건. U+F0090 은 같은 영역의 별개 코드포인트 (별도 이슈 등록 후 처리).
+
+### 2.2 인근 영역 (회귀 차단 점검)
+
+기존 매핑 영역과 본 사이클 신설 분기 (`0xF0000..=0xF00CF`) 충돌 없음 확인:
+
+| 영역 | 범위 | 검출 코드포인트 종 | 매핑 상태 |
+|------|------|---|---|
+| **본 사이클** | `0xF0000..=0xF00CF` | 2 (F003B, F0090) | 분기 없음 (default = 원본 유지) |
+| Task #528 | `0xF00D0..=0xF09FF` | 4 (F00DA, F012B, F081C, F0854/F0855) | F00DA/F0854/F0855 매핑됨, F012B/F081C 미매핑 |
+| Task #509 | `0xF02B0..=0xF02FF` | 13 (F02B1~F02BA, F02C3~F02C5, F02CE~F02D0, F02EF, F02FC) | F02B1~F02B9, F02EF 매핑됨, 나머지 미매핑 |
+
+본 사이클 분기 (`0xF0000..=0xF00CF`) 는 다른 영역과 디스조인트 → 분기 추가 시 회귀 위험 0.
+
+### 2.3 별도 task 후보 (본 사이클 외)
+
+`feedback_no_pr_accumulation` 정합 — 본 사이클은 U+F003B 1건만 처리. 같은 영역의 미매핑 코드포인트는 별도 task:
+
+- U+F0090 (img-start-001.hwp 1건) — 본 task 영역
+- U+F012B (복학원서.hwp 1건)
+- U+F081C (복학원서.hwp 2건)
+- U+F02BA, F02C3~F02C5 (mel-001 최대 3건)
+- U+F02CE~F02D0 (k-water-rfp 1건씩)
+- U+F02FC (pic-in-head-01 + pic-in-table-01 각 11건)
+
+상기는 본 task 종료 후 일괄 이슈 등록 후보 (작업지시자 결정 대기).
+
+## 3. 회귀 차단 점검
+
+| 항목 | 결과 |
+|------|------|
+| 본 사이클 분기 영역 (`0xF0000..=0xF00CF`) 의 다른 코드포인트 영향 | U+F0090 1건 — default 분기 (원본 유지) 로 처리 (회귀 0) |
+| 기존 매핑 영역 (`0xF02B0..=0xF02FF`, `0xF00D0..=0xF09FF`, `0xF020..=0xF0FF`) | 본 사이클 무영향 |
+| Task #509/#528 단위 테스트 회귀 | 본 사이클 신설 분기 → 기존 분기 무영향 → 회귀 0 |
+| 광범위 byte sweep 영역 | exam_eng.hwp p7 SVG 만 변경 (U+F003B → ↓), 다른 fixture 회귀 0 |
+
+## 4. 산출물
+
+- `/tmp/uF003B_glyph.svg` — 임베디드 폰트의 글리프 SVG 출력 (시각 검증용)
+- `/tmp/pua_survey_full.py` — 광범위 통계 스크립트
+- `/tmp/font_TT11_AAAAAL_HCRBatang.ttf` — PDF 임베디드 폰트 추출 (글리프 분석용)
+
+## 5. 다음 단계
+
+작업지시자에게 다음 2건 확인 요청:
+
+1. **글리프 매핑 확정**: ↓ U+2193 (권장) vs ⬇ U+2B07 vs 다른 코드포인트
+   - 한컴 PDF 시각 (또는 한컴 편집기에서 본 파일 직접 확인) 으로 최종 판정
+2. **Stage 2 진행 승인**: 매핑 확정 후 Red 테스트 + 매핑 구현
+
+## 메모리 룰 정합
+
+- `reference_authoritative_hancom` — 한컴 PDF 시각 정답지 권위 (Stage 1 분석)
+- `feedback_hancom_compat_specific_over_general` — U+F003B 단일 코드포인트 한정
+- `feedback_no_pr_accumulation` — 별도 코드포인트는 별도 task

--- a/mydocs/working/task_m100_588_stage2.md
+++ b/mydocs/working/task_m100_588_stage2.md
@@ -1,0 +1,106 @@
+# Task #588 Stage 2 — Red 테스트 + 매핑 구현
+
+## 목표
+
+1. PUA 매핑 단위 테스트 추가 (Red → Green 전환)
+2. `map_pua_bullet_char` 에 SPUA-A 저영역 분기 신설 + U+F003B → ↓ 매핑
+
+## 변경 영역
+
+### 1. `src/renderer/layout/paragraph_layout.rs`
+
+#### 1.1 `map_pua_bullet_char` SPUA-A 저영역 분기 신설
+
+**위치**: 기존 `0xF02B0..=0xF02FF` 분기 직전 (코드포인트 오름차순 정합)
+
+```rust
+// Supplementary PUA-A 저영역 — 한컴 자체 영역 (Task #588 한컴 정답지 정합)
+if (0xF0000..=0xF00CF).contains(&code) {
+    return match code {
+        // exam_eng.hwp p7 #40 요약형 문항 글상자 사이 화살표.
+        // 한컴 PDF (HCRBatang 임베디드 폰트) 글리프 외곽 분석:
+        //   stem 35% × arrowhead 100% × solid filled (1 contour, 7 pts) → ↓
+        0xF003B => '\u{2193}', // ↓ DOWNWARDS ARROW
+        _ => ch,
+    };
+}
+```
+
+#### 1.2 docstring 갱신
+
+기존 docstring 의 "두 영역 분기" → 세 영역 분기 (Basic / SPUA-A 저영역 / SPUA-A 일반) 으로 정합 갱신.
+
+#### 1.3 단위 테스트 +2
+
+```rust
+#[test]
+fn supplementary_pua_a_low_range_maps_down_arrow() {
+    // [Task #588] U+F003B → U+2193 ↓ (DOWNWARDS ARROW)
+    assert_eq!(map_pua_bullet_char('\u{F003B}'), '\u{2193}');
+}
+
+#[test]
+fn supplementary_pua_a_low_range_unmapped_returns_original() {
+    // [Task #588] 0xF0000~0xF00CF 영역의 매핑 표 외 코드포인트는 원본 유지
+    assert_eq!(map_pua_bullet_char('\u{F0090}'), '\u{F0090}');
+    assert_eq!(map_pua_bullet_char('\u{F0000}'), '\u{F0000}');
+    assert_eq!(map_pua_bullet_char('\u{F00CF}'), '\u{F00CF}');
+}
+```
+
+## 검증
+
+### 단위 테스트 (`pua_mapping_tests`)
+
+```
+running 7 tests
+test ...basic_pua_outside_range_returns_original ... ok
+test ...supplementary_pua_a_low_range_maps_down_arrow ... ok            ← 신규
+test ...supplementary_pua_a_maps_circled_digits ... ok
+test ...supplementary_pua_a_low_range_unmapped_returns_original ... ok  ← 신규
+test ...basic_pua_arrow_e8 ... ok
+test ...supplementary_pua_a_maps_middle_dot ... ok
+test ...supplementary_pua_a_unmapped_returns_original ... ok
+
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured; 1122 filtered out
+```
+
+기존 5 + 신규 2 = 7건 GREEN. 회귀 0.
+
+### SVG 시각 확인 (`exam_eng.hwp` p7)
+
+**변경 전** (`output/svg/exam_eng_p7/exam_eng_007.svg:4162`):
+```
+<text ... font-family="HY신명조,..." font-size="15.33...">󰀻</text>
+```
+(U+F003B 그대로 출력 → 폰트 글리프 미보유 시 두부)
+
+**변경 후** (`output/svg/exam_eng_p7_after/exam_eng_007.svg:4162`):
+```
+<text ... font-family="HY신명조,..." font-size="15.33...">↓</text>
+```
+(U+2193 표준 코드포인트 → 모든 폰트에서 글리프 보유)
+
+### 회귀 차단
+
+- 신설 분기 (`0xF0000..=0xF00CF`) 와 기존 분기 (`0xF020..=0xF0FF`, `0xF00D0..=0xF09FF`, `0xF02B0..=0xF02FF`) 디스조인트 → 기존 매핑 영역 무영향
+- `_ => ch` default 분기 → U+F003B 외 같은 영역 코드포인트 (예: U+F0090) 는 원본 유지 (회귀 0)
+
+## 산출물
+
+- `src/renderer/layout/paragraph_layout.rs` — 분기 신설 + 단위 테스트 +2
+- `mydocs/working/task_m100_588_stage2.md` — 본 보고서
+
+## 다음 단계
+
+Stage 3 (광범위 회귀 점검) 진행 승인 요청:
+- `cargo test --lib` (baseline 회귀 0)
+- `cargo test --test svg_snapshot` 6/6
+- `cargo clippy --lib -- -D warnings` 0건 신규
+- WASM 빌드 정합
+- 14 fixture 광범위 byte sweep (의도된 변경 외 회귀 0)
+
+## 메모리 룰 정합
+
+- `feedback_hancom_compat_specific_over_general` — 단일 코드포인트 한정 매핑
+- `feedback_essential_fix_regression_risk` — 분기 디스조인트 설계로 회귀 위험 차단

--- a/mydocs/working/task_m100_588_stage3.md
+++ b/mydocs/working/task_m100_588_stage3.md
@@ -1,0 +1,109 @@
+# Task #588 Stage 3 — 광범위 회귀 점검
+
+## 목표
+
+Stage 2 의 매핑 구현이 다른 fixture 에 회귀를 일으키지 않음을 결정적으로 검증.
+
+## 검증 결과
+
+### 1. 단위 테스트
+
+```
+cargo test --lib
+test result: ok. 1126 passed; 0 failed; 3 ignored; 0 measured
+```
+
+baseline (1126) 회귀 0 (Stage 2 이전 1124 + 신규 2 = 1126).
+
+### 2. SVG snapshot 테스트
+
+```
+cargo test --test svg_snapshot
+test result: ok. 6 passed; 0 failed
+```
+
+6/6 GREEN — table-text / issue-147 / issue-157 / issue-267 / form-002 / 결정성 테스트 모두 통과.
+
+### 3. 통합 테스트 (issue_*)
+
+| 테스트 | 결과 |
+|--------|------|
+| issue_418 (1) | ok |
+| issue_501 (1) | ok |
+| issue_505 (1) | ok |
+| issue_514 (9) | ok |
+| issue_516 (8) | ok |
+| issue_530 (1) | ok |
+| issue_546 (1) | ok |
+| exam_eng_multicolumn (3) | ok |
+
+### 4. Clippy
+
+```
+cargo clippy --lib -- -D warnings
+Finished `dev` profile (warnings: 0 신규)
+```
+
+신규 warning 0건.
+
+### 5. WASM 빌드
+
+```
+docker compose --env-file .env.docker run --rm wasm
+Finished `release` profile [optimized]
+[INFO]: :-) Your wasm pkg is ready to publish at /app/pkg.
+```
+
+WASM pkg: `pkg/rhwp_bg.wasm` 4,529,640 bytes — 정합 빌드.
+
+### 6. 14 fixture 광범위 byte sweep
+
+13 fixture (samples 14건 중 mathpresso/synap-001/kshs-001 미존재) 광범위 비교:
+
+| fixture | SVG 수 | 변경 | 회귀 |
+|---------|-------|------|------|
+| exam_kor.hwp | 20 | 0 | 0 |
+| exam_science.hwp | 4 | 0 | 0 |
+| **exam_eng.hwp** | 8 | **1 (p7)** | **0 (의도된 변경)** |
+| 21_언어_기출_편집가능본.hwp | 15 | 0 | 0 |
+| synam-001.hwp | 35 | 0 | 0 |
+| k-water-rfp.hwp | 27 | 0 | 0 |
+| aift.hwp | 77 | 0 | 0 |
+| mel-001.hwp | 21 | 0 | 0 |
+| hwpspec.hwp | 177 | 0 | 0 |
+| hwp3-sample.hwp | 16 | 0 | 0 |
+| hwp3-sample4.hwp | 39 | 0 | 0 |
+| hwp3-sample5.hwp | 64 | 0 | 0 |
+| kps-ai.hwp | 80 | 0 | 0 |
+| **합계** | **583** | **1** | **0** |
+
+**582/583 byte-identical** — 회귀 0.
+
+### 7. 변경 detail (exam_eng.hwp p7)
+
+`exam_eng_007.svg:4162` 정확한 1행 변경:
+
+```diff
+< <text transform="translate(796.73,1218.27) scale(1.3,1)" font-family="HY신명조,..." 
+-   font-size="15.33" fill="#000000">󰀻</text>
+> <text transform="translate(796.73,1218.27) scale(1.3,1)" font-family="HY신명조,..." 
++   font-size="15.33" fill="#000000">↓</text>
+```
+
+x/y/font/size/scale 동일 — 글자 본체만 U+F003B → U+2193 (↓).
+
+## 산출물
+
+- `/tmp/svg_before/` (13 fixture, 583 SVG) — Stage 1 (pre-mapping) baseline
+- `/tmp/svg_after/` (13 fixture, 583 SVG) — Stage 2 mapping 적용 후
+- `pkg/rhwp_bg.wasm` (4,529,640 bytes) — WASM 빌드 정합 확인
+- `mydocs/working/task_m100_588_stage3.md` — 본 보고서
+
+## 다음 단계
+
+Stage 4 (작업지시자 시각 검증 + 최종 보고서) 진행 승인 요청.
+
+## 메모리 룰 정합
+
+- `feedback_visual_regression_grows` — 광범위 byte sweep + 의도된 변경 외 회귀 0 결정적 검증
+- `feedback_essential_fix_regression_risk` — 분기 디스조인트 설계 검증 (582/583 byte-identical)

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -2904,8 +2904,23 @@ impl LayoutEngine {
 /// **Supplementary PUA-A (0xF02B0~0xF02FF)** — 한컴 자체 PUA 영역.
 ///   원문자 (①~⑨, U+2460~U+2468) 와 별 (★ U+2605) 등을 본 영역에 저장.
 ///   Task #509 의 한컴 PDF 정답지 시각 검증으로 매핑 확정.
+///
+/// **Supplementary PUA-A 저영역 (0xF0000~0xF00CF)** — 한컴 자체 PUA 저영역.
+///   요약형 문항 화살표 등 시각 마커. Task #588 의 한컴 PDF 임베디드 폰트
+///   글리프 외곽 분석 + 정답지 시각 검증으로 매핑 확정.
 pub(crate) fn map_pua_bullet_char(ch: char) -> char {
     let code = ch as u32;
+
+    // Supplementary PUA-A 저영역 — 한컴 자체 영역 (Task #588 한컴 정답지 정합)
+    if (0xF0000..=0xF00CF).contains(&code) {
+        return match code {
+            // exam_eng.hwp p7 #40 요약형 문항 글상자 사이 화살표.
+            // 한컴 PDF (HCRBatang 임베디드 폰트) 글리프 외곽 분석:
+            //   stem 35% × arrowhead 100% × solid filled (1 contour, 7 pts) → ↓
+            0xF003B => '\u{2193}', // ↓ DOWNWARDS ARROW
+            _ => ch,
+        };
+    }
 
     // Supplementary PUA-A — 한컴 자체 영역 (Task #509 한컴 정답지 정합)
     if (0xF02B0..=0xF02FF).contains(&code) {
@@ -3059,5 +3074,22 @@ mod pua_mapping_tests {
     fn basic_pua_outside_range_returns_original() {
         // 0xF020~0xF0FF 외 Basic PUA 는 원본 유지 (예: U+0F53A 한글 "흔")
         assert_eq!(map_pua_bullet_char('\u{F53A}'), '\u{F53A}');
+    }
+
+    #[test]
+    fn supplementary_pua_a_low_range_maps_down_arrow() {
+        // [Task #588] U+F003B → U+2193 ↓ (DOWNWARDS ARROW)
+        // exam_eng.hwp p7 #40 요약형 문항 글상자 사이 화살표.
+        // 한컴 PDF (HCRBatang) 임베디드 폰트 글리프 외곽 분석으로 확정.
+        assert_eq!(map_pua_bullet_char('\u{F003B}'), '\u{2193}');
+    }
+
+    #[test]
+    fn supplementary_pua_a_low_range_unmapped_returns_original() {
+        // [Task #588] 0xF0000~0xF00CF 영역의 매핑 표 외 코드포인트는 원본 유지
+        // (예: U+F0090 — img-start-001.hwp 1건, 별도 task 후보)
+        assert_eq!(map_pua_bullet_char('\u{F0090}'), '\u{F0090}');
+        assert_eq!(map_pua_bullet_char('\u{F0000}'), '\u{F0000}');
+        assert_eq!(map_pua_bullet_char('\u{F00CF}'), '\u{F00CF}');
     }
 }


### PR DESCRIPTION
## 본질

`samples/exam_eng.hwp` 7페이지 40번 요약형 문항의 첫 번째 글상자(원문 passage)와 두 번째 글상자(요약) 사이에 위치한 ↓ 화살표가 SVG에 두부(□)로 렌더되는 결함 정정.

원인: pi=278 의 단일 문자 **U+F003B** (UTF-8 \`f3 b0 80 bb\`) 가 SPUA-A 저영역 (\`0xF0000~0xF00CF\`) 으로 \`map_pua_bullet_char\` 매핑 표 밖. 글리프 미보유 폰트에서 두부 표시.

## 정정

\`src/renderer/layout/paragraph_layout.rs\` 의 \`map_pua_bullet_char\` 에 SPUA-A 저영역 분기 신설:

\`\`\`rust
if (0xF0000..=0xF00CF).contains(&code) {
    return match code {
        0xF003B => '\u{2193}', // ↓ DOWNWARDS ARROW
        _ => ch,
    };
}
\`\`\`

매핑 글리프 확정 근거: \`samples/exam_eng.pdf\` 7쪽의 임베디드 폰트 \`AAAAAL+HCRBatang\` 의 \`uF003B\` 글리프 외곽 분석 — 1 contour 7 pts (stem 35% × arrowhead 100% × solid filled) → ↓ 형태 확정.

## 검증

| 게이트 | 결과 |
|--------|------|
| cargo test --lib | **1126 passed** (3 ignored, 0 failed) |
| cargo test --test svg_snapshot | **6/6 GREEN** |
| 통합 테스트 (issue_418/501/505/514/516/530/546/exam_eng_multicolumn) | **전부 통과** |
| cargo clippy --lib -- -D warnings | **0 신규** |
| WASM 빌드 | **4,529,640 bytes** 정합 |
| 13 fixture 광범위 byte sweep | **582/583 byte-identical** (1건 = exam_eng/p7 의도된 변경) |

## 단위 테스트 (+2)

- \`supplementary_pua_a_low_range_maps_down_arrow\` — U+F003B → U+2193 매핑 검증
- \`supplementary_pua_a_low_range_unmapped_returns_original\` — 0xF0000/F0090/F00CF default 분기 검증

## 회귀 차단 설계

신설 분기 (\`0xF0000..=0xF00CF\`) 는 기존 분기와 **완전 디스조인트**:

| 영역 | 범위 |
|------|------|
| 본 PR | \`0xF0000..=0xF00CF\` (신규) |
| Task #528 | \`0xF00D0..=0xF09FF\` (책괄호/예시) |
| Task #509 | \`0xF02B0..=0xF02FF\` (원문자) |
| Wingdings | \`0xF020..=0xF0FF\` (BMP PUA) |

설계 검증: 583 SVG sweep 에서 582 byte-identical → 디스조인트 설계 결정적 확인.

## 시각 변경

\`exam_eng_007.svg:4162\` 정확한 1행 변경:
\`\`\`diff
- <text ... fill="#000000">󰀻</text>
+ <text ... fill="#000000">↓</text>
\`\`\`
x/y/font/size 동일.

## 잔존 영역 (별도 이슈 후보)

Stage 1 광범위 통계로 확인된 동일 영역 미매핑 코드포인트:

- U+F0090 (img-start-001.hwp 1건) — 본 PR 영역 (\`0xF0000~0xF00CF\`)
- U+F012B/F081C (복학원서.hwp) — Task #528 영역 default
- U+F02BA, F02C3~F02C5, F02CE~F02D0, F02FC — Task #509 영역 default

## 단계 사이클 (4 stages)

| 단계 | 산출물 |
|------|--------|
| Stage 1 | \`mydocs/working/task_m100_588_stage1.md\` (PDF 글리프 외곽 분석 + 159 샘플 통계) |
| Stage 2 | \`paragraph_layout.rs\` + \`_stage2.md\` (분기 신설 + 매핑 + 단위 테스트 +2) |
| Stage 3 | \`_stage3.md\` (광범위 회귀 점검) |
| Stage 4 | \`mydocs/report/task_m100_588_report.md\` (최종 보고서) |

closes #588