### PR TITLE
render: add native Skia PNG raster backend

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,17 @@ jobs:
       - name: Check WASM target
         run: cargo check --target wasm32-unknown-unknown --lib
 
+      - name: Install native Skia runtime packages
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fonts-dejavu-core \
+            libfontconfig1-dev \
+            libfreetype6-dev
+
+      - name: Native Skia tests
+        run: cargo test --features native-skia skia --lib --verbose
+
       - name: Run tests
         run: cargo test --verbose
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,6 +41,7 @@ console_error_panic_hook = { version = "0.1", optional = true }
 
 [features]
 default = ["console_error_panic_hook"]
+native-skia = ["dep:skia-safe"]
 
 # PDF 내보내기 (네이티브 전용, Task #21)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
@@ -49,6 +50,7 @@ usvg = "0.45"
 pdf-writer = "0.12"
 subsetter = "0.2"
 ttf-parser = "0.25"
+skia-safe = { version = "0.93.1", optional = true, default-features = false, features = ["binary-cache", "embed-icudtl", "pdf", "textlayout"] }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 web-sys = { version = "0.3", features = [

--- a/README.md
+++ b/README.md
@@ -216,7 +216,8 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - Legacy Canvas remains available through `renderPageCanvasLegacy` / `renderPageToCanvasLegacy` for parity checks.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
-- Native Skia PNG export is available only on native targets with `--features native-skia`.
+- P4 adds native-only `DocumentCore::render_page_png_native(page)` behind `--features native-skia`; it renders `PageLayerTree` to encoded PNG through `SkiaLayerRenderer`.
+- CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
 - The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.

--- a/README.md
+++ b/README.md
@@ -217,6 +217,7 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - Native Skia PNG export is available only on native targets with `--features native-skia`.
+- The initial native Skia path is a PNG raster backend smoke path; CanvasKit, resource interning/cache, complex text shaping, full image crop/tile parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README.md
+++ b/README.md
@@ -216,9 +216,10 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - Legacy Canvas remains available through `renderPageCanvasLegacy` / `renderPageToCanvasLegacy` for parity checks.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
+- Native Skia PNG export is available only on native targets with `--features native-skia`.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
-- This phase establishes the frontend/backend boundary for later CanvasKit and native Skia backends.
+- This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.
 
 ### Web Editor (웹 에디터)
 - Text editing (insert, delete, undo/redo)

--- a/README.md
+++ b/README.md
@@ -217,7 +217,7 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - Native Skia PNG export is available only on native targets with `--features native-skia`.
-- The initial native Skia path is a PNG raster backend smoke path; CanvasKit, resource interning/cache, complex text shaping, full image crop/tile parity, and native equation/raw-svg/form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README_EN.md
+++ b/README_EN.md
@@ -209,6 +209,7 @@ See the [roadmap document](mydocs/eng/report/rhwp-milestone.md) for details.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - Native Skia PNG export is available only on native targets with `--features native-skia`.
+- The initial native Skia path is a PNG raster backend smoke path; CanvasKit, resource interning/cache, complex text shaping, full image crop/tile parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README_EN.md
+++ b/README_EN.md
@@ -208,7 +208,8 @@ See the [roadmap document](mydocs/eng/report/rhwp-milestone.md) for details.
 - Legacy Canvas remains available through `renderPageCanvasLegacy` / `renderPageToCanvasLegacy` for parity checks.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
-- Native Skia PNG export is available only on native targets with `--features native-skia`.
+- P4 adds native-only `DocumentCore::render_page_png_native(page)` behind `--features native-skia`; it renders `PageLayerTree` to encoded PNG through `SkiaLayerRenderer`.
+- CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
 - The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.

--- a/README_EN.md
+++ b/README_EN.md
@@ -209,7 +209,7 @@ See the [roadmap document](mydocs/eng/report/rhwp-milestone.md) for details.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - Native Skia PNG export is available only on native targets with `--features native-skia`.
-- The initial native Skia path is a PNG raster backend smoke path; CanvasKit, resource interning/cache, complex text shaping, full image crop/tile parity, and native equation/raw-svg/form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README_EN.md
+++ b/README_EN.md
@@ -208,9 +208,10 @@ See the [roadmap document](mydocs/eng/report/rhwp-milestone.md) for details.
 - Legacy Canvas remains available through `renderPageCanvasLegacy` / `renderPageToCanvasLegacy` for parity checks.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
+- Native Skia PNG export is available only on native targets with `--features native-skia`.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
-- This phase establishes the frontend/backend boundary for later CanvasKit and native Skia backends.
+- This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.
 
 ### Web Editor
 - Text editing (insert, delete, undo/redo)

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2140,6 +2140,46 @@ mod tests {
         }
     }
 
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    #[test]
+    fn render_page_png_native_uses_document_core_skia_layer_path() {
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        let mut document = Document::default();
+        document.sections.push(Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![Paragraph::default()],
+            raw_stream: None,
+        });
+
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+
+        let png = core
+            .render_page_png_native(0)
+            .expect("empty document should render through native Skia");
+
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+        let decoded = image::load_from_memory(&png).expect("decode native Skia PNG");
+        assert!(decoded.width() > 0);
+        assert!(decoded.height() > 0);
+    }
+
     #[test]
     fn get_bin_data_returns_zero_based_content_slice() {
         let mut core = DocumentCore::new_empty();

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -147,6 +147,15 @@ impl DocumentCore {
         Ok(renderer.command_count() as u32)
     }
 
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_page_png_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError> {
+        use crate::renderer::layer_renderer::LayerRasterRenderer;
+        use crate::renderer::skia::SkiaLayerRenderer;
+
+        let layer_tree = self.build_page_layer_tree(page_num)?;
+        SkiaLayerRenderer::new().render_png(&layer_tree)
+    }
+
     pub fn get_page_layer_tree_native(&self, page_num: u32) -> Result<String, HwpError> {
         Ok(self.build_page_layer_tree(page_num)?.to_json())
     }

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -12,6 +12,7 @@ pub trait LayerRenderer {
 #[derive(Debug, Clone, Copy, PartialEq)]
 pub struct RasterRenderOptions {
     pub max_dimension: i32,
+    pub max_pixels: u64,
     pub scale: f64,
     pub dpi: Option<f64>,
     pub transparent: bool,
@@ -24,6 +25,7 @@ impl Default for RasterRenderOptions {
     fn default() -> Self {
         Self {
             max_dimension: 16_384,
+            max_pixels: 67_108_864,
             scale: 1.0,
             dpi: None,
             transparent: true,

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -1,4 +1,5 @@
 use crate::error::HwpError;
+use crate::model::ColorRef;
 use crate::paint::PageLayerTree;
 
 pub type LayerRenderResult<T> = Result<T, HwpError>;
@@ -6,4 +7,73 @@ pub type LayerRenderResult<T> = Result<T, HwpError>;
 /// visual layer tree를 backend 출력으로 재생한다.
 pub trait LayerRenderer {
     fn render_page(&mut self, tree: &PageLayerTree) -> LayerRenderResult<()>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct RasterRenderOptions {
+    pub max_dimension: i32,
+    pub scale: f64,
+    pub dpi: Option<f64>,
+    pub transparent: bool,
+    pub background_color: Option<ColorRef>,
+    pub color_space: RasterColorSpace,
+    pub format: RasterOutputFormat,
+}
+
+impl Default for RasterRenderOptions {
+    fn default() -> Self {
+        Self {
+            max_dimension: 16_384,
+            scale: 1.0,
+            dpi: None,
+            transparent: true,
+            background_color: None,
+            color_space: RasterColorSpace::Srgb,
+            format: RasterOutputFormat::Png,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RasterColorSpace {
+    Srgb,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RasterOutputFormat {
+    Png,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct RasterRenderOutput {
+    pub bytes: Vec<u8>,
+    pub format: RasterOutputFormat,
+    pub width: i32,
+    pub height: i32,
+    pub dpi: Option<f64>,
+    pub color_space: RasterColorSpace,
+}
+
+/// visual layer tree를 raster 결과로 직접 내보내는 backend 계약.
+pub trait LayerRasterRenderer {
+    fn render_png(&self, tree: &PageLayerTree) -> LayerRenderResult<Vec<u8>> {
+        self.render_png_with_options(tree, RasterRenderOptions::default())
+    }
+
+    fn render_png_with_options(
+        &self,
+        tree: &PageLayerTree,
+        options: RasterRenderOptions,
+    ) -> LayerRenderResult<Vec<u8>> {
+        let mut png_options = options;
+        png_options.format = RasterOutputFormat::Png;
+        self.render_raster(tree, png_options)
+            .map(|output| output.bytes)
+    }
+
+    fn render_raster(
+        &self,
+        tree: &PageLayerTree,
+        options: RasterRenderOptions,
+    ) -> LayerRenderResult<RasterRenderOutput>;
 }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -27,6 +27,8 @@ pub mod svg_fragment;
 pub mod svg_layer;
 #[cfg(not(target_arch = "wasm32"))]
 pub mod pdf;
+#[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+pub mod skia;
 pub mod typeset;
 #[cfg(target_arch = "wasm32")]
 pub mod web_canvas;

--- a/src/renderer/skia/image_conv.rs
+++ b/src/renderer/skia/image_conv.rs
@@ -1,0 +1,288 @@
+use skia_safe::{
+    canvas::SrcRectConstraint, color_filters, image::RequiredProperties, Color, Data, FilterMode,
+    IRect, Image, Matrix, MipmapMode, Paint, Rect, SamplingOptions, TileMode,
+};
+
+use crate::model::image::ImageEffect;
+use crate::model::style::ImageFillMode;
+
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub struct ImageSampling {
+    filter_mode: FilterMode,
+    mipmap_mode: MipmapMode,
+}
+
+impl ImageSampling {
+    pub fn linear() -> Self {
+        Self {
+            filter_mode: FilterMode::Linear,
+            mipmap_mode: MipmapMode::None,
+        }
+    }
+
+    fn options(self) -> SamplingOptions {
+        SamplingOptions::new(self.filter_mode, self.mipmap_mode)
+    }
+}
+
+pub fn draw_image_bytes(
+    canvas: &skia_safe::Canvas,
+    bytes: &[u8],
+    x: f32,
+    y: f32,
+    width: f32,
+    height: f32,
+    fill_mode: Option<ImageFillMode>,
+    original_size: Option<(f64, f64)>,
+    crop: Option<(i32, i32, i32, i32)>,
+    effect: ImageEffect,
+    sampling: ImageSampling,
+) {
+    let is_valid_destination_rect = |x: f32, y: f32, width: f32, height: f32| {
+        x.is_finite()
+            && y.is_finite()
+            && width.is_finite()
+            && height.is_finite()
+            && width > 0.0
+            && height > 0.0
+    };
+    let is_valid_image_size = |width: f32, height: f32| {
+        width.is_finite() && height.is_finite() && width > 0.0 && height > 0.0
+    };
+    let grayscale_filter = |scale: f32, translate: f32| {
+        let r = 0.299 * scale;
+        let g = 0.587 * scale;
+        let b = 0.114 * scale;
+        color_filters::matrix_row_major(
+            &[
+                r, g, b, 0.0, translate, r, g, b, 0.0, translate, r, g, b, 0.0, translate, 0.0,
+                0.0, 0.0, 1.0, 0.0,
+            ],
+            None,
+        )
+    };
+    let image_effect_filter = |effect: ImageEffect| match effect {
+        ImageEffect::RealPic => None,
+        ImageEffect::GrayScale => Some(grayscale_filter(1.0, 0.0)),
+        ImageEffect::BlackWhite => Some(grayscale_filter(255.0, -127.5)),
+        ImageEffect::Pattern8x8 => Some(grayscale_filter(1.0, 0.0)),
+    };
+    let resolve_image_placement = |fill_mode: ImageFillMode,
+                                   x: f32,
+                                   y: f32,
+                                   width: f32,
+                                   height: f32,
+                                   image_width: f32,
+                                   image_height: f32| {
+        match fill_mode {
+            ImageFillMode::LeftTop => (x, y),
+            ImageFillMode::CenterTop => (x + (width - image_width) / 2.0, y),
+            ImageFillMode::RightTop => (x + width - image_width, y),
+            ImageFillMode::LeftCenter => (x, y + (height - image_height) / 2.0),
+            ImageFillMode::Center => (
+                x + (width - image_width) / 2.0,
+                y + (height - image_height) / 2.0,
+            ),
+            ImageFillMode::RightCenter => {
+                (x + width - image_width, y + (height - image_height) / 2.0)
+            }
+            ImageFillMode::LeftBottom => (x, y + height - image_height),
+            ImageFillMode::CenterBottom => {
+                (x + (width - image_width) / 2.0, y + height - image_height)
+            }
+            ImageFillMode::RightBottom => (x + width - image_width, y + height - image_height),
+            _ => (x, y),
+        }
+    };
+    let draw_missing_image_placeholder = |x: f32, y: f32, width: f32, height: f32| {
+        let rect = Rect::from_xywh(x, y, width, height);
+        let mut fill = Paint::default();
+        fill.set_anti_alias(true);
+        fill.set_style(skia_safe::paint::Style::Fill);
+        fill.set_color(Color::from_argb(48, 96, 96, 96));
+        canvas.draw_rect(rect, &fill);
+
+        let mut stroke = Paint::default();
+        stroke.set_anti_alias(true);
+        stroke.set_style(skia_safe::paint::Style::Stroke);
+        stroke.set_stroke_width(1.0);
+        stroke.set_color(Color::from_argb(160, 96, 96, 96));
+        canvas.draw_rect(rect, &stroke);
+    };
+
+    if !is_valid_destination_rect(x, y, width, height) {
+        return;
+    }
+    let Some(image) = Image::from_encoded(Data::new_copy(bytes)) else {
+        draw_missing_image_placeholder(x, y, width, height);
+        return;
+    };
+
+    let dst = Rect::from_xywh(x, y, width, height);
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    if let Some(color_filter) = image_effect_filter(effect) {
+        paint.set_color_filter(color_filter);
+    }
+
+    let mode = fill_mode.unwrap_or(ImageFillMode::FitToSize);
+    let decoded_width = image.width() as f32;
+    let decoded_height = image.height() as f32;
+    let crop_src = crop.and_then(|(left, top, right, bottom)| {
+        if decoded_width <= 0.0 || decoded_height <= 0.0 {
+            return None;
+        }
+        let scale_x = right as f32 / decoded_width;
+        let scale_y = bottom as f32 / decoded_height;
+        if scale_x <= 0.0 || scale_y <= 0.0 {
+            return None;
+        }
+        let src_x = left as f32 / scale_x;
+        let src_y = top as f32 / scale_y;
+        let src_w = (right - left) as f32 / scale_x;
+        let src_h = (bottom - top) as f32 / scale_y;
+        let is_cropped = src_x > 0.5
+            || src_y > 0.5
+            || (src_w - decoded_width).abs() > 1.0
+            || (src_h - decoded_height).abs() > 1.0;
+        if is_cropped && src_w > 0.0 && src_h > 0.0 {
+            Some(Rect::from_xywh(src_x, src_y, src_w, src_h))
+        } else {
+            None
+        }
+    });
+
+    let draw_image_rect = |src: Option<Rect>, dst: Rect| {
+        if let Some(src) = src.as_ref() {
+            canvas.draw_image_rect_with_sampling_options(
+                &image,
+                Some((src, SrcRectConstraint::Strict)),
+                dst,
+                sampling.options(),
+                &paint,
+            );
+        } else {
+            canvas.draw_image_rect_with_sampling_options(
+                &image,
+                None,
+                dst,
+                sampling.options(),
+                &paint,
+            );
+        }
+    };
+
+    if matches!(mode, ImageFillMode::FitToSize | ImageFillMode::None) {
+        draw_image_rect(crop_src, dst);
+        return;
+    }
+
+    let image_width = original_size
+        .map(|(width, _)| width as f32)
+        .unwrap_or_else(|| image.width() as f32);
+    let image_height = original_size
+        .map(|(_, height)| height as f32)
+        .unwrap_or_else(|| image.height() as f32);
+    if !is_valid_image_size(image_width, image_height) {
+        draw_missing_image_placeholder(x, y, width, height);
+        return;
+    }
+
+    canvas.save();
+    canvas.clip_rect(dst, None, Some(true));
+
+    if matches!(
+        mode,
+        ImageFillMode::TileAll
+            | ImageFillMode::TileHorzTop
+            | ImageFillMode::TileHorzBottom
+            | ImageFillMode::TileVertLeft
+            | ImageFillMode::TileVertRight
+    ) {
+        let shader_image = crop_src
+            .and_then(|src| {
+                let left = src.left.floor().max(0.0) as i32;
+                let top = src.top.floor().max(0.0) as i32;
+                let right = src.right.ceil().min(decoded_width) as i32;
+                let bottom = src.bottom.ceil().min(decoded_height) as i32;
+                if right <= left || bottom <= top {
+                    return None;
+                }
+                image.make_subset(
+                    None,
+                    IRect::from_xywh(left, top, right - left, bottom - top),
+                    RequiredProperties::default(),
+                )
+            })
+            .unwrap_or_else(|| image.clone());
+        let shader_source_width = shader_image.width() as f32;
+        let shader_source_height = shader_image.height() as f32;
+        let draw_tiled_shader = |tile_rect: Rect, origin_x: f32, origin_y: f32| -> bool {
+            if shader_source_width <= 0.0 || shader_source_height <= 0.0 {
+                return false;
+            }
+            let scale_x = shader_source_width / image_width;
+            let scale_y = shader_source_height / image_height;
+            if !scale_x.is_finite() || !scale_y.is_finite() || scale_x <= 0.0 || scale_y <= 0.0 {
+                return false;
+            }
+            let local_matrix = Matrix::scale_translate(
+                (scale_x, scale_y),
+                (-origin_x * scale_x, -origin_y * scale_y),
+            );
+            let Some(shader) = shader_image.to_shader(
+                Some((TileMode::Repeat, TileMode::Repeat)),
+                sampling.options(),
+                Some(&local_matrix),
+            ) else {
+                return false;
+            };
+            let mut shader_paint = paint.clone();
+            shader_paint.set_shader(shader);
+            canvas.draw_rect(tile_rect, &shader_paint);
+            true
+        };
+
+        if matches!(mode, ImageFillMode::TileAll) && draw_tiled_shader(dst, x, y) {
+            canvas.restore();
+            return;
+        }
+        if matches!(
+            mode,
+            ImageFillMode::TileHorzTop | ImageFillMode::TileHorzBottom
+        ) {
+            let tile_y = if matches!(mode, ImageFillMode::TileHorzTop) {
+                y
+            } else {
+                y + height - image_height
+            };
+            if draw_tiled_shader(Rect::from_xywh(x, tile_y, width, image_height), x, tile_y) {
+                canvas.restore();
+                return;
+            }
+        }
+        if matches!(
+            mode,
+            ImageFillMode::TileVertLeft | ImageFillMode::TileVertRight
+        ) {
+            let tile_x = if matches!(mode, ImageFillMode::TileVertLeft) {
+                x
+            } else {
+                x + width - image_width
+            };
+            if draw_tiled_shader(Rect::from_xywh(tile_x, y, image_width, height), tile_x, y) {
+                canvas.restore();
+                return;
+            }
+        }
+    } else {
+        let (image_x, image_y) =
+            resolve_image_placement(mode, x, y, width, height, image_width, image_height);
+        draw_image_rect(
+            crop_src,
+            Rect::from_xywh(image_x, image_y, image_width, image_height),
+        );
+    }
+
+    canvas.restore();
+}

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is available only with the `native-skia` feature.
 
+mod image_conv;
 mod renderer;
 
 pub use renderer::SkiaLayerRenderer;

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -1,0 +1,7 @@
+//! Native Skia layer renderer.
+//!
+//! This module is available only with the `native-skia` feature.
+
+mod renderer;
+
+pub use renderer::SkiaLayerRenderer;

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -598,13 +598,41 @@ fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paint::{LayerNode, LayerOutputOptions};
-    use crate::renderer::render_tree::{BoundingBox, RectangleNode};
+    use crate::model::control::FormType;
+    use crate::model::style::ImageFillMode;
+    use crate::paint::{CacheHint, GroupKind, LayerNode, LayerOutputOptions};
+    use crate::renderer::render_tree::{
+        BoundingBox, FootnoteMarkerNode, FormObjectNode, ImageNode, PageBackgroundImage,
+        PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode, TextRunNode,
+    };
+    use crate::renderer::{GradientFillInfo, PatternFillInfo, TextStyle};
+    use image::{ImageFormat, Rgba, RgbaImage};
+    use std::io::Cursor;
 
     fn decode_rgba(bytes: &[u8]) -> image::RgbaImage {
         image::load_from_memory(bytes)
             .expect("decode png")
             .to_rgba8()
+    }
+
+    fn assert_channel(pixel: image::Rgba<u8>, channel: usize, min: u8, max: u8) {
+        assert!(
+            pixel[channel] >= min && pixel[channel] <= max,
+            "pixel={pixel:?}, channel={channel}, expected {min}..={max}"
+        );
+    }
+
+    fn count_ink(image: &image::RgbaImage) -> usize {
+        image.pixels().filter(|pixel| pixel[3] > 0).count()
+    }
+
+    fn solid_png(color: [u8; 4]) -> Vec<u8> {
+        let image = RgbaImage::from_pixel(2, 2, Rgba(color));
+        let mut cursor = Cursor::new(Vec::new());
+        image
+            .write_to(&mut cursor, ImageFormat::Png)
+            .expect("encode png");
+        cursor.into_inner()
     }
 
     fn solid_rect_tree(
@@ -796,5 +824,468 @@ mod tests {
             },
         );
         assert!(oversized.is_err());
+    }
+
+    #[test]
+    fn raster_output_preserves_metadata_and_background_color() {
+        let tree = PageLayerTree::new(
+            3.0,
+            2.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 3.0, 2.0), None, vec![]),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(
+                &tree,
+                RasterRenderOptions {
+                    dpi: Some(144.0),
+                    background_color: Some(0x0000ff00),
+                    ..Default::default()
+                },
+            )
+            .expect("render with metadata");
+        let image = decode_rgba(&output.bytes);
+        let pixel = *image.get_pixel(0, 0);
+
+        assert_eq!(output.dpi, Some(144.0));
+        assert_eq!(
+            output.color_space,
+            crate::renderer::layer_renderer::RasterColorSpace::Srgb
+        );
+        assert_channel(pixel, 0, 0, 16);
+        assert_channel(pixel, 1, 220, 255);
+        assert_channel(pixel, 2, 0, 16);
+        assert_eq!(pixel[3], 255);
+    }
+
+    #[test]
+    fn rejects_invalid_page_dimensions() {
+        let renderer = SkiaLayerRenderer::new();
+        let zero_width = PageLayerTree::new(
+            0.0,
+            10.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 0.0, 10.0), None, vec![]),
+        );
+        let nan_height = PageLayerTree::new(
+            10.0,
+            f64::NAN,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 10.0, 10.0), None, vec![]),
+        );
+
+        assert!(renderer
+            .render_raster_with_options(&zero_width, RasterRenderOptions::default())
+            .is_err());
+        assert!(renderer
+            .render_raster_with_options(&nan_height, RasterRenderOptions::default())
+            .is_err());
+    }
+
+    #[test]
+    fn renders_page_background_fill_border_and_image() {
+        let tree = PageLayerTree::new(
+            8.0,
+            8.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                None,
+                vec![PaintOp::PageBackground {
+                    bbox: BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                    background: PageBackgroundNode {
+                        background_color: Some(0x0000ff00),
+                        border_color: Some(0x00ff0000),
+                        border_width: 2.0,
+                        gradient: None,
+                        image: None,
+                    },
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render background");
+        let image = decode_rgba(&output.bytes);
+        let fill = *image.get_pixel(4, 4);
+        let border = *image.get_pixel(0, 0);
+
+        assert_channel(fill, 0, 0, 32);
+        assert_channel(fill, 1, 180, 255);
+        assert_channel(fill, 2, 0, 32);
+        assert_eq!(fill[3], 255);
+        assert_channel(border, 0, 0, 64);
+        assert_channel(border, 1, 0, 64);
+        assert_channel(border, 2, 180, 255);
+        assert_eq!(border[3], 255);
+
+        let tree = PageLayerTree::new(
+            8.0,
+            8.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                None,
+                vec![PaintOp::PageBackground {
+                    bbox: BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                    background: PageBackgroundNode {
+                        background_color: None,
+                        border_color: None,
+                        border_width: 0.0,
+                        gradient: None,
+                        image: Some(PageBackgroundImage {
+                            data: solid_png([0, 0, 255, 255]),
+                            fill_mode: ImageFillMode::FitToSize,
+                        }),
+                    },
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render background image");
+        let image = decode_rgba(&output.bytes);
+        let pixel = *image.get_pixel(4, 4);
+
+        assert_channel(pixel, 0, 0, 32);
+        assert_channel(pixel, 1, 0, 32);
+        assert_channel(pixel, 2, 220, 255);
+        assert_eq!(pixel[3], 255);
+    }
+
+    #[test]
+    fn renders_shape_fallback_fills_for_gradient_pattern_ellipse_path_and_line() {
+        let gradient = GradientFillInfo {
+            gradient_type: 1,
+            angle: 0,
+            center_x: 0,
+            center_y: 0,
+            colors: vec![0x00ff0000, 0x000000ff],
+            positions: vec![0.0, 1.0],
+        };
+        let gradient_rect = RectangleNode::new(
+            0.0,
+            ShapeStyle {
+                fill_color: Some(0x000000ff),
+                ..Default::default()
+            },
+            Some(Box::new(gradient)),
+        );
+        let pattern_rect = RectangleNode::new(
+            0.0,
+            ShapeStyle {
+                pattern: Some(PatternFillInfo {
+                    pattern_type: 1,
+                    pattern_color: 0x000000ff,
+                    background_color: 0x0000ff00,
+                }),
+                ..Default::default()
+            },
+            None,
+        );
+        let ellipse = crate::renderer::render_tree::EllipseNode::new(
+            ShapeStyle {
+                fill_color: Some(0x000000ff),
+                ..Default::default()
+            },
+            None,
+        );
+        let path = PathNode::new(
+            vec![
+                PathCommand::MoveTo(2.0, 24.0),
+                PathCommand::LineTo(12.0, 24.0),
+                PathCommand::LineTo(12.0, 34.0),
+                PathCommand::LineTo(2.0, 34.0),
+                PathCommand::ClosePath,
+            ],
+            ShapeStyle {
+                fill_color: Some(0x00ff0000),
+                ..Default::default()
+            },
+            None,
+        );
+        let line = crate::renderer::render_tree::LineNode::new(
+            18.0,
+            30.0,
+            34.0,
+            30.0,
+            LineStyle {
+                color: 0x000000ff,
+                width: 3.0,
+                ..Default::default()
+            },
+        );
+        let tree = PageLayerTree::new(
+            40.0,
+            40.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 40.0, 40.0),
+                None,
+                vec![
+                    PaintOp::Rectangle {
+                        bbox: BoundingBox::new(2.0, 2.0, 10.0, 8.0),
+                        rect: gradient_rect,
+                    },
+                    PaintOp::Rectangle {
+                        bbox: BoundingBox::new(16.0, 2.0, 10.0, 8.0),
+                        rect: pattern_rect,
+                    },
+                    PaintOp::Ellipse {
+                        bbox: BoundingBox::new(2.0, 12.0, 10.0, 10.0),
+                        ellipse,
+                    },
+                    PaintOp::Path {
+                        bbox: BoundingBox::new(2.0, 24.0, 10.0, 10.0),
+                        path,
+                    },
+                    PaintOp::Line {
+                        bbox: BoundingBox::new(18.0, 28.0, 16.0, 4.0),
+                        line,
+                    },
+                ],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render shapes");
+        let image = decode_rgba(&output.bytes);
+        let gradient_pixel = *image.get_pixel(4, 4);
+        let pattern_pixel = *image.get_pixel(18, 4);
+        let ellipse_pixel = *image.get_pixel(7, 17);
+        let path_pixel = *image.get_pixel(7, 29);
+        let line_pixel = *image.get_pixel(24, 30);
+
+        assert_channel(gradient_pixel, 2, 180, 255);
+        assert_channel(pattern_pixel, 1, 180, 255);
+        assert_channel(ellipse_pixel, 0, 180, 255);
+        assert_channel(path_pixel, 2, 180, 255);
+        assert_channel(line_pixel, 0, 180, 255);
+    }
+
+    #[test]
+    fn renders_arc_path_segments_as_ink() {
+        let path = PathNode::new(
+            vec![
+                PathCommand::MoveTo(4.0, 12.0),
+                PathCommand::ArcTo(8.0, 8.0, 0.0, false, true, 20.0, 12.0),
+            ],
+            ShapeStyle {
+                stroke_color: Some(0x000000ff),
+                stroke_width: 2.0,
+                ..Default::default()
+            },
+            None,
+        );
+        let tree = PageLayerTree::new(
+            24.0,
+            18.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 24.0, 18.0),
+                None,
+                vec![PaintOp::Path {
+                    bbox: BoundingBox::new(4.0, 4.0, 16.0, 12.0),
+                    path,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render arc path");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 8);
+    }
+
+    #[test]
+    fn renders_valid_images_and_invalid_image_placeholders() {
+        let tree = PageLayerTree::new(
+            20.0,
+            10.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 20.0, 10.0),
+                None,
+                vec![
+                    PaintOp::Image {
+                        bbox: BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                        image: ImageNode::new(1, Some(solid_png([0, 0, 255, 255]))),
+                    },
+                    PaintOp::Image {
+                        bbox: BoundingBox::new(10.0, 0.0, 8.0, 8.0),
+                        image: ImageNode::new(2, Some(vec![1, 2, 3, 4])),
+                    },
+                ],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render images");
+        let image = decode_rgba(&output.bytes);
+        let valid = *image.get_pixel(4, 4);
+        let invalid_placeholder = *image.get_pixel(12, 4);
+
+        assert_channel(valid, 2, 220, 255);
+        assert!(invalid_placeholder[3] > 0);
+    }
+
+    #[test]
+    fn renders_text_and_footnote_marker_as_ink() {
+        let run = TextRunNode {
+            text: "A".to_string(),
+            style: TextStyle {
+                font_size: 18.0,
+                color: 0x00000000,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 20.0,
+            field_marker: Default::default(),
+        };
+        let marker = FootnoteMarkerNode {
+            number: 1,
+            text: "1)".to_string(),
+            base_font_size: 18.0,
+            font_family: String::new(),
+            color: 0x00000000,
+            section_index: 0,
+            para_index: 0,
+            control_index: 0,
+        };
+        let tree = PageLayerTree::new(
+            64.0,
+            32.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 64.0, 32.0),
+                None,
+                vec![
+                    PaintOp::TextRun {
+                        bbox: BoundingBox::new(4.0, 4.0, 24.0, 24.0),
+                        run,
+                    },
+                    PaintOp::FootnoteMarker {
+                        bbox: BoundingBox::new(32.0, 4.0, 24.0, 24.0),
+                        marker,
+                    },
+                ],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render text");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_placeholder_style_ops_as_ink() {
+        let form = FormObjectNode {
+            form_type: FormType::PushButton,
+            caption: "OK".to_string(),
+            text: String::new(),
+            fore_color: "#000000".to_string(),
+            back_color: "#ffffff".to_string(),
+            value: 0,
+            enabled: true,
+            section_index: 0,
+            para_index: 0,
+            control_index: 0,
+            name: "button".to_string(),
+            cell_location: None,
+        };
+        let tree = PageLayerTree::new(
+            48.0,
+            16.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 48.0, 16.0),
+                None,
+                vec![
+                    PaintOp::Placeholder {
+                        bbox: BoundingBox::new(0.0, 0.0, 14.0, 14.0),
+                        placeholder: PlaceholderNode {
+                            fill_color: 0,
+                            stroke_color: 0,
+                            label: "ph".to_string(),
+                        },
+                    },
+                    PaintOp::RawSvg {
+                        bbox: BoundingBox::new(16.0, 0.0, 14.0, 14.0),
+                        raw: RawSvgNode {
+                            svg: "<rect/>".to_string(),
+                        },
+                    },
+                    PaintOp::FormObject {
+                        bbox: BoundingBox::new(32.0, 0.0, 14.0, 14.0),
+                        form,
+                    },
+                ],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render placeholders");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 40);
+    }
+
+    #[test]
+    fn group_children_replay_in_order() {
+        let red = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 12.0, 12.0),
+            None,
+            vec![PaintOp::Rectangle {
+                bbox: BoundingBox::new(0.0, 0.0, 12.0, 12.0),
+                rect: RectangleNode::new(
+                    0.0,
+                    ShapeStyle {
+                        fill_color: Some(0x000000ff),
+                        ..Default::default()
+                    },
+                    None,
+                ),
+            }],
+        );
+        let blue = LayerNode::leaf(
+            BoundingBox::new(3.0, 3.0, 6.0, 6.0),
+            None,
+            vec![PaintOp::Rectangle {
+                bbox: BoundingBox::new(3.0, 3.0, 6.0, 6.0),
+                rect: RectangleNode::new(
+                    0.0,
+                    ShapeStyle {
+                        fill_color: Some(0x00ff0000),
+                        ..Default::default()
+                    },
+                    None,
+                ),
+            }],
+        );
+        let tree = PageLayerTree::new(
+            12.0,
+            12.0,
+            LayerNode::group(
+                BoundingBox::new(0.0, 0.0, 12.0, 12.0),
+                None,
+                vec![red, blue],
+                CacheHint::None,
+                GroupKind::Generic,
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render group");
+        let image = decode_rgba(&output.bytes);
+        let center = *image.get_pixel(6, 6);
+
+        assert_channel(center, 0, 0, 64);
+        assert_channel(center, 1, 0, 64);
+        assert_channel(center, 2, 180, 255);
+        assert_eq!(center[3], 255);
     }
 }

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,0 +1,631 @@
+use skia_safe::{
+    paint, surfaces, Canvas, Color, Data, EncodedImageFormat, FilterMode, Font, Image, MipmapMode,
+    Paint, PathBuilder, PathEffect, Rect, SamplingOptions,
+};
+
+use crate::error::HwpError;
+use crate::model::ColorRef;
+use crate::paint::{LayerNode, LayerNodeKind, PageLayerTree, PaintOp};
+use crate::renderer::layer_renderer::{
+    LayerRasterRenderer, LayerRenderResult, RasterOutputFormat, RasterRenderOptions,
+    RasterRenderOutput,
+};
+use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
+
+pub struct SkiaLayerRenderer;
+
+impl SkiaLayerRenderer {
+    pub fn new() -> Self {
+        Self
+    }
+
+    pub fn render_raster_with_options(
+        &self,
+        tree: &PageLayerTree,
+        options: RasterRenderOptions,
+    ) -> LayerRenderResult<RasterRenderOutput> {
+        if let Some(dpi) = options.dpi {
+            if !dpi.is_finite() || dpi <= 0.0 {
+                return Err(HwpError::RenderError(format!("invalid raster dpi: {dpi}")));
+            }
+        }
+        if options.format != RasterOutputFormat::Png {
+            return Err(HwpError::RenderError(
+                "Skia raster renderer currently supports PNG output".to_string(),
+            ));
+        }
+
+        let raster_dimension = |value: f64, label: &str| -> LayerRenderResult<i32> {
+            if !value.is_finite() || value <= 0.0 {
+                return Err(HwpError::RenderError(format!(
+                    "invalid page {label}: {value}"
+                )));
+            }
+            if !options.scale.is_finite() || options.scale <= 0.0 {
+                return Err(HwpError::RenderError(format!(
+                    "invalid raster scale: {}",
+                    options.scale
+                )));
+            }
+            if options.max_dimension <= 0 {
+                return Err(HwpError::RenderError(format!(
+                    "invalid raster max dimension: {}",
+                    options.max_dimension
+                )));
+            }
+            let scaled = (value * options.scale).ceil();
+            if !scaled.is_finite() || scaled <= 0.0 || scaled > options.max_dimension as f64 {
+                return Err(HwpError::RenderError(format!(
+                    "raster {label} out of range: {scaled}"
+                )));
+            }
+            Ok(scaled as i32)
+        };
+        let width = raster_dimension(tree.page_width, "width")?;
+        let height = raster_dimension(tree.page_height, "height")?;
+
+        let mut surface = surfaces::raster_n32_premul((width, height))
+            .ok_or_else(|| HwpError::RenderError("Skia raster surface 생성 실패".to_string()))?;
+        let canvas = surface.canvas();
+        let clear_color = if let Some(color) = options.background_color {
+            colorref_to_skia(color, 1.0)
+        } else if options.transparent {
+            Color::from_argb(0, 0, 0, 0)
+        } else {
+            Color::WHITE
+        };
+        canvas.clear(clear_color);
+        if options.scale != 1.0 {
+            canvas.scale((options.scale as f32, options.scale as f32));
+        }
+        self.render_node(canvas, &tree.root, tree.output_options.clip_enabled);
+
+        let image = surface.image_snapshot();
+        let data = image
+            .encode(None, EncodedImageFormat::PNG, None)
+            .ok_or_else(|| HwpError::RenderError("Skia PNG 인코딩 실패".to_string()))?;
+        Ok(RasterRenderOutput {
+            bytes: data.as_bytes().to_vec(),
+            format: RasterOutputFormat::Png,
+            width,
+            height,
+            dpi: options.dpi,
+            color_space: options.color_space,
+        })
+    }
+
+    fn render_node(&self, canvas: &Canvas, node: &LayerNode, clip_enabled: bool) {
+        let apply_dash = |paint: &mut Paint, dash: StrokeDash| {
+            let base_width = paint.stroke_width().max(1.0);
+            let intervals: Option<[f32; 6]> = match dash {
+                StrokeDash::Solid => None,
+                StrokeDash::Dash => Some([6.0, 3.0, 0.0, 0.0, 0.0, 0.0]),
+                StrokeDash::Dot => Some([2.0, 2.0, 0.0, 0.0, 0.0, 0.0]),
+                StrokeDash::DashDot => Some([6.0, 3.0, 2.0, 3.0, 0.0, 0.0]),
+                StrokeDash::DashDotDot => Some([6.0, 3.0, 2.0, 3.0, 2.0, 3.0]),
+            };
+            if let Some(intervals) = intervals {
+                let intervals = intervals
+                    .into_iter()
+                    .filter(|value| *value > 0.0)
+                    .map(|value| value * base_width)
+                    .collect::<Vec<_>>();
+                if let Some(effect) = PathEffect::dash(&intervals, 0.0) {
+                    paint.set_path_effect(effect);
+                }
+            }
+        };
+        let make_fill_paint = |style: &ShapeStyle| -> Option<Paint> {
+            let color = style
+                .pattern
+                .map(|pattern| pattern.background_color)
+                .or(style.fill_color)?;
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_style(paint::Style::Fill);
+            paint.set_color(colorref_to_skia(color, style.opacity as f32));
+            Some(paint)
+        };
+        let make_stroke_paint = |style: &ShapeStyle| -> Option<Paint> {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_style(paint::Style::Stroke);
+            paint.set_stroke_width(if style.stroke_width > 0.0 {
+                style.stroke_width as f32
+            } else {
+                1.0
+            });
+            paint.set_color(colorref_to_skia(style.stroke_color?, style.opacity as f32));
+            apply_dash(&mut paint, style.stroke_dash);
+            Some(paint)
+        };
+        let make_line_paint = |style: &LineStyle| {
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_style(paint::Style::Stroke);
+            paint.set_stroke_width(if style.width > 0.0 {
+                style.width as f32
+            } else {
+                1.0
+            });
+            paint.set_color(colorref_to_skia(style.color, 1.0));
+            apply_dash(&mut paint, style.dash);
+            paint
+        };
+        let draw_placeholder = |bbox: crate::renderer::render_tree::BoundingBox, label: &str| {
+            if bbox.width <= 0.0 || bbox.height <= 0.0 {
+                return;
+            }
+            let rect = Rect::from_xywh(
+                bbox.x as f32,
+                bbox.y as f32,
+                bbox.width as f32,
+                bbox.height as f32,
+            );
+            let mut fill = Paint::default();
+            fill.set_anti_alias(true);
+            fill.set_style(paint::Style::Fill);
+            fill.set_color(Color::from_argb(48, 96, 96, 96));
+            canvas.draw_rect(rect, &fill);
+            let mut stroke = Paint::default();
+            stroke.set_anti_alias(true);
+            stroke.set_style(paint::Style::Stroke);
+            stroke.set_stroke_width(1.0);
+            stroke.set_color(Color::from_argb(160, 96, 96, 96));
+            canvas.draw_rect(rect, &stroke);
+            let mut font = Font::default();
+            font.set_size(10.0);
+            let mut text = Paint::default();
+            text.set_anti_alias(true);
+            text.set_color(Color::from_argb(220, 64, 64, 64));
+            canvas.draw_str(
+                label,
+                (bbox.x as f32 + 4.0, (bbox.y + bbox.height / 2.0) as f32),
+                &font,
+                &text,
+            );
+        };
+        let draw_image = |data: &[u8], bbox: crate::renderer::render_tree::BoundingBox| {
+            if bbox.width <= 0.0 || bbox.height <= 0.0 {
+                return;
+            }
+            if let Some(image) = Image::from_encoded(Data::new_copy(data)) {
+                let dst = Rect::from_xywh(
+                    bbox.x as f32,
+                    bbox.y as f32,
+                    bbox.width as f32,
+                    bbox.height as f32,
+                );
+                let paint = Paint::default();
+                canvas.draw_image_rect_with_sampling_options(
+                    &image,
+                    None,
+                    dst,
+                    SamplingOptions::new(FilterMode::Linear, MipmapMode::None),
+                    &paint,
+                );
+            } else {
+                draw_placeholder(bbox, "image");
+            }
+        };
+        let draw_text = |text: &str,
+                         bbox: crate::renderer::render_tree::BoundingBox,
+                         style: &crate::renderer::TextStyle,
+                         baseline: f64,
+                         rotation: f64| {
+            if text.is_empty() {
+                return;
+            }
+            let mut font = Font::default();
+            font.set_size(if style.font_size > 0.0 {
+                style.font_size as f32
+            } else {
+                12.0
+            });
+            let mut paint = Paint::default();
+            paint.set_anti_alias(true);
+            paint.set_color(colorref_to_skia(style.color, 1.0));
+            let y = if baseline > 0.0 {
+                bbox.y + baseline
+            } else {
+                bbox.y + bbox.height
+            };
+            if rotation != 0.0 {
+                canvas.save();
+                canvas.rotate(
+                    rotation as f32,
+                    Some(
+                        (
+                            (bbox.x + bbox.width / 2.0) as f32,
+                            (bbox.y + bbox.height / 2.0) as f32,
+                        )
+                            .into(),
+                    ),
+                );
+                canvas.draw_str(text, (bbox.x as f32, y as f32), &font, &paint);
+                canvas.restore();
+            } else {
+                canvas.draw_str(text, (bbox.x as f32, y as f32), &font, &paint);
+            }
+        };
+        let open_shape_transform =
+            |transform: crate::renderer::render_tree::ShapeTransform,
+             bbox: &crate::renderer::render_tree::BoundingBox| {
+                canvas.save();
+                let cx = (bbox.x + bbox.width / 2.0) as f32;
+                let cy = (bbox.y + bbox.height / 2.0) as f32;
+                if transform.horz_flip {
+                    canvas.translate((cx * 2.0, 0.0));
+                    canvas.scale((-1.0, 1.0));
+                }
+                if transform.vert_flip {
+                    canvas.translate((0.0, cy * 2.0));
+                    canvas.scale((1.0, -1.0));
+                }
+                if transform.rotation != 0.0 {
+                    canvas.rotate(transform.rotation as f32, Some((cx, cy).into()));
+                }
+            };
+
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    self.render_node(canvas, child, clip_enabled);
+                }
+            }
+            LayerNodeKind::ClipRect { clip, child, .. } => {
+                if !clip_enabled {
+                    self.render_node(canvas, child, clip_enabled);
+                    return;
+                }
+                canvas.save();
+                canvas.clip_rect(
+                    Rect::from_xywh(
+                        clip.x as f32,
+                        clip.y as f32,
+                        clip.width as f32,
+                        clip.height as f32,
+                    ),
+                    None,
+                    Some(true),
+                );
+                self.render_node(canvas, child, clip_enabled);
+                canvas.restore();
+            }
+            LayerNodeKind::Leaf { ops } => {
+                for op in ops {
+                    match op {
+                        PaintOp::PageBackground { bbox, background } => {
+                            let rect = Rect::from_xywh(
+                                bbox.x as f32,
+                                bbox.y as f32,
+                                bbox.width as f32,
+                                bbox.height as f32,
+                            );
+                            if let Some(color) = background
+                                .gradient
+                                .as_ref()
+                                .and_then(|gradient| gradient.colors.first().copied())
+                                .or(background.background_color)
+                            {
+                                let mut paint = Paint::default();
+                                paint.set_anti_alias(true);
+                                paint.set_style(paint::Style::Fill);
+                                paint.set_color(colorref_to_skia(color, 1.0));
+                                canvas.draw_rect(rect, &paint);
+                            }
+                            if let Some(image) = &background.image {
+                                draw_image(&image.data, *bbox);
+                            }
+                            if let Some(color) = background.border_color {
+                                let mut paint = Paint::default();
+                                paint.set_anti_alias(true);
+                                paint.set_style(paint::Style::Stroke);
+                                paint.set_stroke_width(if background.border_width > 0.0 {
+                                    background.border_width as f32
+                                } else {
+                                    1.0
+                                });
+                                paint.set_color(colorref_to_skia(color, 1.0));
+                                canvas.draw_rect(rect, &paint);
+                            }
+                        }
+                        PaintOp::TextRun { bbox, run } => {
+                            draw_text(&run.text, *bbox, &run.style, run.baseline, run.rotation);
+                        }
+                        PaintOp::FootnoteMarker { bbox, marker } => {
+                            let style = crate::renderer::TextStyle {
+                                font_family: marker.font_family.clone(),
+                                font_size: (marker.base_font_size * 0.55).max(7.0),
+                                color: marker.color,
+                                ..Default::default()
+                            };
+                            draw_text(&marker.text, *bbox, &style, bbox.height * 0.4, 0.0);
+                        }
+                        PaintOp::Line { bbox, line } => {
+                            if line.transform.has_transform() {
+                                open_shape_transform(line.transform, bbox);
+                            }
+                            canvas.draw_line(
+                                (line.x1 as f32, line.y1 as f32),
+                                (line.x2 as f32, line.y2 as f32),
+                                &make_line_paint(&line.style),
+                            );
+                            if line.transform.has_transform() {
+                                canvas.restore();
+                            }
+                        }
+                        PaintOp::Rectangle { bbox, rect } => {
+                            if rect.transform.has_transform() {
+                                open_shape_transform(rect.transform, bbox);
+                            }
+                            let sk_rect = Rect::from_xywh(
+                                bbox.x as f32,
+                                bbox.y as f32,
+                                bbox.width as f32,
+                                bbox.height as f32,
+                            );
+                            if let Some(fill) = rect
+                                .gradient
+                                .as_ref()
+                                .and_then(|gradient| gradient.colors.first().copied())
+                                .map(|color| {
+                                    let mut paint = Paint::default();
+                                    paint.set_anti_alias(true);
+                                    paint.set_style(paint::Style::Fill);
+                                    paint.set_color(colorref_to_skia(
+                                        color,
+                                        rect.style.opacity as f32,
+                                    ));
+                                    paint
+                                })
+                                .or_else(|| make_fill_paint(&rect.style))
+                            {
+                                if rect.corner_radius > 0.0 {
+                                    canvas.draw_round_rect(
+                                        sk_rect,
+                                        rect.corner_radius as f32,
+                                        rect.corner_radius as f32,
+                                        &fill,
+                                    );
+                                } else {
+                                    canvas.draw_rect(sk_rect, &fill);
+                                }
+                            }
+                            if let Some(stroke) = make_stroke_paint(&rect.style) {
+                                if rect.corner_radius > 0.0 {
+                                    canvas.draw_round_rect(
+                                        sk_rect,
+                                        rect.corner_radius as f32,
+                                        rect.corner_radius as f32,
+                                        &stroke,
+                                    );
+                                } else {
+                                    canvas.draw_rect(sk_rect, &stroke);
+                                }
+                            }
+                            if rect.transform.has_transform() {
+                                canvas.restore();
+                            }
+                        }
+                        PaintOp::Ellipse { bbox, ellipse } => {
+                            if ellipse.transform.has_transform() {
+                                open_shape_transform(ellipse.transform, bbox);
+                            }
+                            let oval = Rect::from_xywh(
+                                bbox.x as f32,
+                                bbox.y as f32,
+                                bbox.width as f32,
+                                bbox.height as f32,
+                            );
+                            if let Some(fill) = ellipse
+                                .gradient
+                                .as_ref()
+                                .and_then(|gradient| gradient.colors.first().copied())
+                                .map(|color| {
+                                    let mut paint = Paint::default();
+                                    paint.set_anti_alias(true);
+                                    paint.set_style(paint::Style::Fill);
+                                    paint.set_color(colorref_to_skia(
+                                        color,
+                                        ellipse.style.opacity as f32,
+                                    ));
+                                    paint
+                                })
+                                .or_else(|| make_fill_paint(&ellipse.style))
+                            {
+                                canvas.draw_oval(oval, &fill);
+                            }
+                            if let Some(stroke) = make_stroke_paint(&ellipse.style) {
+                                canvas.draw_oval(oval, &stroke);
+                            }
+                            if ellipse.transform.has_transform() {
+                                canvas.restore();
+                            }
+                        }
+                        PaintOp::Path { bbox, path } => {
+                            if path.transform.has_transform() {
+                                open_shape_transform(path.transform, bbox);
+                            }
+                            let mut builder = PathBuilder::new();
+                            let mut current = (0.0, 0.0);
+                            for command in &path.commands {
+                                match *command {
+                                    PathCommand::MoveTo(x, y) => {
+                                        builder.move_to((x as f32, y as f32));
+                                        current = (x, y);
+                                    }
+                                    PathCommand::LineTo(x, y) => {
+                                        builder.line_to((x as f32, y as f32));
+                                        current = (x, y);
+                                    }
+                                    PathCommand::CurveTo(x1, y1, x2, y2, x, y) => {
+                                        builder.cubic_to(
+                                            (x1 as f32, y1 as f32),
+                                            (x2 as f32, y2 as f32),
+                                            (x as f32, y as f32),
+                                        );
+                                        current = (x, y);
+                                    }
+                                    PathCommand::ArcTo(
+                                        rx,
+                                        ry,
+                                        rotation,
+                                        large_arc,
+                                        sweep,
+                                        x,
+                                        y,
+                                    ) => {
+                                        for segment in svg_arc_to_beziers(
+                                            current.0, current.1, rx, ry, rotation, large_arc,
+                                            sweep, x, y,
+                                        ) {
+                                            if let PathCommand::CurveTo(x1, y1, x2, y2, ex, ey) =
+                                                segment
+                                            {
+                                                builder.cubic_to(
+                                                    (x1 as f32, y1 as f32),
+                                                    (x2 as f32, y2 as f32),
+                                                    (ex as f32, ey as f32),
+                                                );
+                                                current = (ex, ey);
+                                            }
+                                        }
+                                    }
+                                    PathCommand::ClosePath => {
+                                        builder.close();
+                                    }
+                                }
+                            }
+                            let sk_path = builder.detach();
+                            if let Some(fill) = path
+                                .gradient
+                                .as_ref()
+                                .and_then(|gradient| gradient.colors.first().copied())
+                                .map(|color| {
+                                    let mut paint = Paint::default();
+                                    paint.set_anti_alias(true);
+                                    paint.set_style(paint::Style::Fill);
+                                    paint.set_color(colorref_to_skia(
+                                        color,
+                                        path.style.opacity as f32,
+                                    ));
+                                    paint
+                                })
+                                .or_else(|| make_fill_paint(&path.style))
+                            {
+                                canvas.draw_path(&sk_path, &fill);
+                            }
+                            if let Some(stroke) = make_stroke_paint(&path.style) {
+                                canvas.draw_path(&sk_path, &stroke);
+                            }
+                            if path.transform.has_transform() {
+                                canvas.restore();
+                            }
+                        }
+                        PaintOp::Image { bbox, image } => {
+                            if image.transform.has_transform() {
+                                open_shape_transform(image.transform, bbox);
+                            }
+                            if let Some(data) = image.data.as_deref() {
+                                draw_image(data, *bbox);
+                            } else {
+                                draw_placeholder(*bbox, "image");
+                            }
+                            if image.transform.has_transform() {
+                                canvas.restore();
+                            }
+                        }
+                        PaintOp::Equation { bbox, .. } => draw_placeholder(*bbox, "equation"),
+                        PaintOp::FormObject { bbox, form } => {
+                            draw_placeholder(*bbox, form.caption.as_str());
+                        }
+                        PaintOp::Placeholder { bbox, placeholder } => {
+                            draw_placeholder(*bbox, placeholder.label.as_str());
+                        }
+                        PaintOp::RawSvg { bbox, .. } => draw_placeholder(*bbox, "svg"),
+                    }
+                }
+            }
+        }
+    }
+}
+
+impl LayerRasterRenderer for SkiaLayerRenderer {
+    fn render_raster(
+        &self,
+        tree: &PageLayerTree,
+        options: RasterRenderOptions,
+    ) -> LayerRenderResult<RasterRenderOutput> {
+        self.render_raster_with_options(tree, options)
+    }
+}
+
+fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
+    let b = ((color >> 16) & 0xFF) as u8;
+    let g = ((color >> 8) & 0xFF) as u8;
+    let r = (color & 0xFF) as u8;
+    let a = (255.0 * alpha_scale.clamp(0.0, 1.0)).round() as u8;
+    Color::from_argb(a, r, g, b)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::LayerNode;
+    use crate::renderer::render_tree::{BoundingBox, RectangleNode};
+
+    #[test]
+    fn renders_png_for_basic_layer_tree() {
+        let style = ShapeStyle {
+            fill_color: Some(0x000000ff),
+            ..Default::default()
+        };
+        let tree = PageLayerTree::new(
+            32.0,
+            24.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 32.0, 24.0),
+                None,
+                vec![PaintOp::Rectangle {
+                    bbox: BoundingBox::new(4.0, 4.0, 16.0, 12.0),
+                    rect: RectangleNode::new(0.0, style, None),
+                }],
+            ),
+        );
+
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render png");
+
+        assert_eq!(output.format, RasterOutputFormat::Png);
+        assert_eq!(output.width, 32);
+        assert_eq!(output.height, 24);
+        assert_eq!(&output.bytes[..8], b"\x89PNG\r\n\x1a\n");
+        let decoded = image::load_from_memory(&output.bytes).expect("decode png");
+        assert_eq!(decoded.width(), 32);
+        assert_eq!(decoded.height(), 24);
+    }
+
+    #[test]
+    fn raster_options_scale_output_size() {
+        let tree = PageLayerTree::new(
+            10.0,
+            12.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 10.0, 12.0), None, vec![]),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(
+                &tree,
+                RasterRenderOptions {
+                    scale: 2.0,
+                    transparent: false,
+                    ..Default::default()
+                },
+            )
+            .expect("render scaled png");
+
+        assert_eq!(output.width, 20);
+        assert_eq!(output.height, 24);
+    }
+}

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,6 +1,6 @@
 use skia_safe::{
-    paint, surfaces, Canvas, Color, Data, EncodedImageFormat, FilterMode, Font, Image, MipmapMode,
-    Paint, PathBuilder, PathEffect, Rect, SamplingOptions,
+    font, paint, surfaces, Canvas, Color, Data, EncodedImageFormat, FilterMode, Font, FontMgr,
+    FontStyle, Image, MipmapMode, Paint, PathBuilder, PathEffect, Rect, SamplingOptions,
 };
 
 use crate::error::HwpError;
@@ -12,11 +12,15 @@ use crate::renderer::layer_renderer::{
 };
 use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
 
-pub struct SkiaLayerRenderer;
+pub struct SkiaLayerRenderer {
+    font_mgr: FontMgr,
+}
 
 impl SkiaLayerRenderer {
     pub fn new() -> Self {
-        Self
+        Self {
+            font_mgr: FontMgr::default(),
+        }
     }
 
     pub fn render_raster_with_options(
@@ -216,12 +220,34 @@ impl SkiaLayerRenderer {
             if text.is_empty() {
                 return;
             }
-            let mut font = Font::default();
-            font.set_size(if style.font_size > 0.0 {
+            let font_size = if style.font_size > 0.0 {
                 style.font_size as f32
             } else {
                 12.0
-            });
+            };
+            let font_style = match (style.bold, style.italic) {
+                (true, true) => FontStyle::bold_italic(),
+                (true, false) => FontStyle::bold(),
+                (false, true) => FontStyle::italic(),
+                (false, false) => FontStyle::normal(),
+            };
+            let mut families = Vec::new();
+            if !style.font_family.trim().is_empty() {
+                families.push(style.font_family.as_str());
+            }
+            families.extend(["DejaVu Sans", "Arial", "sans-serif"]);
+            let typeface = families
+                .into_iter()
+                .find_map(|family| self.font_mgr.match_family_style(family, font_style))
+                .or_else(|| self.font_mgr.legacy_make_typeface(None::<&str>, font_style));
+            let mut font = if let Some(typeface) = typeface {
+                Font::new(typeface, font_size)
+            } else {
+                let mut font = Font::default();
+                font.set_size(font_size);
+                font
+            };
+            font.set_edging(font::Edging::AntiAlias);
             let mut paint = Paint::default();
             paint.set_anti_alias(true);
             paint.set_color(colorref_to_skia(style.color, 1.0));

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,9 +1,10 @@
 use skia_safe::{
-    font, paint, surfaces, Canvas, Color, Data, EncodedImageFormat, FilterMode, Font, FontMgr,
-    FontStyle, Image, MipmapMode, Paint, PathBuilder, PathEffect, Rect, SamplingOptions,
+    font, paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Paint,
+    PathBuilder, PathEffect, Rect,
 };
 
 use crate::error::HwpError;
+use crate::model::image::ImageEffect;
 use crate::model::ColorRef;
 use crate::paint::{LayerNode, LayerNodeKind, PageLayerTree, PaintOp};
 use crate::renderer::layer_renderer::{
@@ -11,6 +12,8 @@ use crate::renderer::layer_renderer::{
     RasterRenderOutput,
 };
 use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
+
+use super::image_conv::{draw_image_bytes, ImageSampling};
 
 pub struct SkiaLayerRenderer {
     font_mgr: FontMgr,
@@ -189,28 +192,25 @@ impl SkiaLayerRenderer {
                 &text,
             );
         };
-        let draw_image = |data: &[u8], bbox: crate::renderer::render_tree::BoundingBox| {
-            if bbox.width <= 0.0 || bbox.height <= 0.0 {
-                return;
-            }
-            if let Some(image) = Image::from_encoded(Data::new_copy(data)) {
-                let dst = Rect::from_xywh(
-                    bbox.x as f32,
-                    bbox.y as f32,
-                    bbox.width as f32,
-                    bbox.height as f32,
-                );
-                let paint = Paint::default();
-                canvas.draw_image_rect_with_sampling_options(
-                    &image,
-                    None,
-                    dst,
-                    SamplingOptions::new(FilterMode::Linear, MipmapMode::None),
-                    &paint,
-                );
-            } else {
-                draw_placeholder(bbox, "image");
-            }
+        let draw_image = |data: &[u8],
+                          bbox: crate::renderer::render_tree::BoundingBox,
+                          fill_mode,
+                          original_size,
+                          crop,
+                          effect| {
+            draw_image_bytes(
+                canvas,
+                data,
+                bbox.x as f32,
+                bbox.y as f32,
+                bbox.width as f32,
+                bbox.height as f32,
+                fill_mode,
+                original_size,
+                crop,
+                effect,
+                ImageSampling::linear(),
+            );
         };
         let draw_text = |text: &str,
                          bbox: crate::renderer::render_tree::BoundingBox,
@@ -341,7 +341,14 @@ impl SkiaLayerRenderer {
                                 canvas.draw_rect(rect, &paint);
                             }
                             if let Some(image) = &background.image {
-                                draw_image(&image.data, *bbox);
+                                draw_image(
+                                    &image.data,
+                                    *bbox,
+                                    Some(image.fill_mode),
+                                    None,
+                                    None,
+                                    ImageEffect::RealPic,
+                                );
                             }
                             if let Some(color) = background.border_color {
                                 let mut paint = Paint::default();
@@ -554,7 +561,14 @@ impl SkiaLayerRenderer {
                                 open_shape_transform(image.transform, bbox);
                             }
                             if let Some(data) = image.data.as_deref() {
-                                draw_image(data, *bbox);
+                                draw_image(
+                                    data,
+                                    *bbox,
+                                    image.fill_mode,
+                                    image.original_size,
+                                    image.crop,
+                                    image.effect,
+                                );
                             } else {
                                 draw_placeholder(*bbox, "image");
                             }
@@ -628,6 +642,33 @@ mod tests {
 
     fn solid_png(color: [u8; 4]) -> Vec<u8> {
         let image = RgbaImage::from_pixel(2, 2, Rgba(color));
+        let mut cursor = Cursor::new(Vec::new());
+        image
+            .write_to(&mut cursor, ImageFormat::Png)
+            .expect("encode png");
+        cursor.into_inner()
+    }
+
+    fn split_png(
+        width: u32,
+        height: u32,
+        first: [u8; 4],
+        second: [u8; 4],
+        vertical: bool,
+    ) -> Vec<u8> {
+        let mut image = RgbaImage::from_pixel(width, height, Rgba(first));
+        for y in 0..height {
+            for x in 0..width {
+                let second_half = if vertical {
+                    y >= height / 2
+                } else {
+                    x >= width / 2
+                };
+                if second_half {
+                    image.put_pixel(x, y, Rgba(second));
+                }
+            }
+        }
         let mut cursor = Cursor::new(Vec::new());
         image
             .write_to(&mut cursor, ImageFormat::Png)
@@ -1120,6 +1161,120 @@ mod tests {
 
         assert_channel(valid, 2, 220, 255);
         assert!(invalid_placeholder[3] > 0);
+    }
+
+    #[test]
+    fn renders_cropped_image_source_rects() {
+        let mut node = ImageNode::new(
+            1,
+            Some(split_png(4, 4, [255, 0, 0, 255], [0, 0, 255, 255], true)),
+        );
+        node.crop = Some((0, 2, 4, 4));
+        let tree = PageLayerTree::new(
+            8.0,
+            8.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                None,
+                vec![PaintOp::Image {
+                    bbox: BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                    image: node,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render cropped image");
+        let image = decode_rgba(&output.bytes);
+        let pixel = *image.get_pixel(4, 4);
+
+        assert_channel(pixel, 0, 0, 48);
+        assert_channel(pixel, 2, 180, 255);
+    }
+
+    #[test]
+    fn renders_tiled_images_using_original_size() {
+        let mut node = ImageNode::new(
+            1,
+            Some(split_png(8, 4, [255, 0, 0, 255], [0, 255, 0, 255], false)),
+        );
+        node.fill_mode = Some(ImageFillMode::TileAll);
+        node.original_size = Some((8.0, 4.0));
+        let tree = PageLayerTree::new(
+            16.0,
+            4.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 16.0, 4.0),
+                None,
+                vec![PaintOp::Image {
+                    bbox: BoundingBox::new(0.0, 0.0, 16.0, 4.0),
+                    image: node,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render tiled image");
+        let image = decode_rgba(&output.bytes);
+        let first_tile_left = *image.get_pixel(2, 2);
+        let second_tile_left = *image.get_pixel(10, 2);
+        let first_tile_right = *image.get_pixel(6, 2);
+        let second_tile_right = *image.get_pixel(14, 2);
+
+        assert_channel(first_tile_left, 0, 180, 255);
+        assert_channel(second_tile_left, 0, 180, 255);
+        assert_channel(first_tile_right, 1, 180, 255);
+        assert_channel(second_tile_right, 1, 180, 255);
+    }
+
+    #[test]
+    fn applies_grayscale_image_effect() {
+        let mut node = ImageNode::new(1, Some(solid_png([255, 0, 0, 255])));
+        node.effect = ImageEffect::GrayScale;
+        let tree = PageLayerTree::new(
+            8.0,
+            8.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                None,
+                vec![PaintOp::Image {
+                    bbox: BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                    image: node,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render grayscale image");
+        let pixel = *decode_rgba(&output.bytes).get_pixel(4, 4);
+        let max_channel = pixel[0].max(pixel[1]).max(pixel[2]);
+        let min_channel = pixel[0].min(pixel[1]).min(pixel[2]);
+
+        assert!(max_channel.abs_diff(min_channel) <= 2, "pixel={pixel:?}");
+        assert!(pixel[0] > 40 && pixel[0] < 140, "pixel={pixel:?}");
+        assert_eq!(pixel[3], 255);
+    }
+
+    #[test]
+    fn ignores_invalid_image_rects() {
+        let tree = PageLayerTree::new(
+            8.0,
+            8.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 8.0, 8.0),
+                None,
+                vec![PaintOp::Image {
+                    bbox: BoundingBox::new(f64::NAN, 0.0, 8.0, 8.0),
+                    image: ImageNode::new(1, Some(solid_png([255, 0, 0, 255]))),
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render invalid image rect");
+        let image = decode_rgba(&output.bytes);
+
+        assert_eq!(count_ink(&image), 0);
     }
 
     #[test]

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -70,6 +70,19 @@ impl SkiaLayerRenderer {
         };
         let width = raster_dimension(tree.page_width, "width")?;
         let height = raster_dimension(tree.page_height, "height")?;
+        if options.max_pixels == 0 {
+            return Err(HwpError::RenderError(
+                "invalid raster max pixel count: 0".to_string(),
+            ));
+        }
+        let pixel_count = (width as u64).checked_mul(height as u64).ok_or_else(|| {
+            HwpError::RenderError("raster pixel count overflow".to_string())
+        })?;
+        if pixel_count > options.max_pixels {
+            return Err(HwpError::RenderError(format!(
+                "raster pixel count out of range: {pixel_count}"
+            )));
+        }
 
         let mut surface = surfaces::raster_n32_premul((width, height))
             .ok_or_else(|| HwpError::RenderError("Skia raster surface 생성 실패".to_string()))?;
@@ -865,6 +878,24 @@ mod tests {
             },
         );
         assert!(oversized.is_err());
+
+        let too_many_pixels = renderer.render_raster_with_options(
+            &tree,
+            RasterRenderOptions {
+                max_pixels: 99,
+                ..Default::default()
+            },
+        );
+        assert!(too_many_pixels.is_err());
+
+        let invalid_pixel_budget = renderer.render_raster_with_options(
+            &tree,
+            RasterRenderOptions {
+                max_pixels: 0,
+                ..Default::default()
+            },
+        );
+        assert!(invalid_pixel_budget.is_err());
     }
 
     #[test]

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -572,26 +572,46 @@ fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paint::LayerNode;
+    use crate::paint::{LayerNode, LayerOutputOptions};
     use crate::renderer::render_tree::{BoundingBox, RectangleNode};
 
-    #[test]
-    fn renders_png_for_basic_layer_tree() {
+    fn decode_rgba(bytes: &[u8]) -> image::RgbaImage {
+        image::load_from_memory(bytes)
+            .expect("decode png")
+            .to_rgba8()
+    }
+
+    fn solid_rect_tree(
+        page_width: f64,
+        page_height: f64,
+        bbox: BoundingBox,
+        fill_color: ColorRef,
+    ) -> PageLayerTree {
         let style = ShapeStyle {
-            fill_color: Some(0x000000ff),
+            fill_color: Some(fill_color),
             ..Default::default()
         };
-        let tree = PageLayerTree::new(
-            32.0,
-            24.0,
+        PageLayerTree::new(
+            page_width,
+            page_height,
             LayerNode::leaf(
-                BoundingBox::new(0.0, 0.0, 32.0, 24.0),
+                BoundingBox::new(0.0, 0.0, page_width, page_height),
                 None,
                 vec![PaintOp::Rectangle {
-                    bbox: BoundingBox::new(4.0, 4.0, 16.0, 12.0),
+                    bbox,
                     rect: RectangleNode::new(0.0, style, None),
                 }],
             ),
+        )
+    }
+
+    #[test]
+    fn renders_png_for_basic_layer_tree() {
+        let tree = solid_rect_tree(
+            32.0,
+            24.0,
+            BoundingBox::new(4.0, 4.0, 16.0, 12.0),
+            0x000000ff,
         );
 
         let output = SkiaLayerRenderer::new()
@@ -627,5 +647,128 @@ mod tests {
 
         assert_eq!(output.width, 20);
         assert_eq!(output.height, 24);
+    }
+
+    #[test]
+    fn preserves_colorref_channel_order_in_pixels() {
+        let tree = solid_rect_tree(12.0, 12.0, BoundingBox::new(2.0, 2.0, 8.0, 8.0), 0x000000ff);
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render red rect");
+        let image = decode_rgba(&output.bytes);
+        let pixel = image.get_pixel(4, 4);
+
+        assert!(pixel[0] > 220, "red channel should be high: {pixel:?}");
+        assert!(pixel[1] < 32, "green channel should be low: {pixel:?}");
+        assert!(pixel[2] < 32, "blue channel should be low: {pixel:?}");
+        assert_eq!(pixel[3], 255);
+    }
+
+    #[test]
+    fn clears_transparent_by_default_and_opaque_when_requested() {
+        let tree = PageLayerTree::new(
+            4.0,
+            4.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 4.0, 4.0), None, vec![]),
+        );
+        let renderer = SkiaLayerRenderer::new();
+        let transparent = renderer
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render transparent");
+        let opaque = renderer
+            .render_raster_with_options(
+                &tree,
+                RasterRenderOptions {
+                    transparent: false,
+                    ..Default::default()
+                },
+            )
+            .expect("render opaque");
+
+        assert_eq!(decode_rgba(&transparent.bytes).get_pixel(0, 0)[3], 0);
+        assert_eq!(
+            decode_rgba(&opaque.bytes).get_pixel(0, 0).0,
+            [255, 255, 255, 255]
+        );
+    }
+
+    #[test]
+    fn output_options_control_clip_rect_replay() {
+        let style = ShapeStyle {
+            fill_color: Some(0x000000ff),
+            ..Default::default()
+        };
+        let child = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            None,
+            vec![PaintOp::Rectangle {
+                bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                rect: RectangleNode::new(0.0, style, None),
+            }],
+        );
+        let clipped = PageLayerTree::new(
+            20.0,
+            20.0,
+            LayerNode::clip_rect(
+                BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                None,
+                BoundingBox::new(0.0, 0.0, 10.0, 10.0),
+                child.clone(),
+                crate::paint::ClipKind::Generic,
+            ),
+        );
+        let unclipped = clipped.clone().with_output_options(LayerOutputOptions {
+            clip_enabled: false,
+            ..Default::default()
+        });
+        let renderer = SkiaLayerRenderer::new();
+        let clipped_png = renderer
+            .render_raster_with_options(&clipped, RasterRenderOptions::default())
+            .expect("render clipped");
+        let unclipped_png = renderer
+            .render_raster_with_options(&unclipped, RasterRenderOptions::default())
+            .expect("render unclipped");
+        let clipped = decode_rgba(&clipped_png.bytes);
+        let unclipped = decode_rgba(&unclipped_png.bytes);
+
+        assert_eq!(clipped.get_pixel(15, 15)[3], 0);
+        assert_eq!(unclipped.get_pixel(15, 15)[3], 255);
+    }
+
+    #[test]
+    fn rejects_invalid_raster_options_before_surface_creation() {
+        let tree = PageLayerTree::new(
+            10.0,
+            10.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 10.0, 10.0), None, vec![]),
+        );
+        let renderer = SkiaLayerRenderer::new();
+
+        let invalid_scale = renderer.render_raster_with_options(
+            &tree,
+            RasterRenderOptions {
+                scale: 0.0,
+                ..Default::default()
+            },
+        );
+        assert!(invalid_scale.is_err());
+
+        let invalid_dpi = renderer.render_raster_with_options(
+            &tree,
+            RasterRenderOptions {
+                dpi: Some(0.0),
+                ..Default::default()
+            },
+        );
+        assert!(invalid_dpi.is_err());
+
+        let oversized = renderer.render_raster_with_options(
+            &tree,
+            RasterRenderOptions {
+                max_dimension: 8,
+                ..Default::default()
+            },
+        );
+        assert!(oversized.is_err());
     }
 }


### PR DESCRIPTION
## 변경 요약

이번 PR은 render P4 단계로, `PageLayerTree`를 native Skia로 replay해서 PNG를 만들 수 있는 첫 raster backend를 추가합니다.

P1에서 `PageLayerTree` 경계를 만들고, P2/P3에서 Canvas layer path와 diff 테스트를 붙였고, 이번에는 그 IR을 native backend에서도 실제로 replay할 수 있는지 확인하는 단계입니다.

주요 변경은 아래와 같습니다.

- `LayerRasterRenderer`, `RasterRenderOptions`, `RasterRenderOutput` 추가
- `native-skia` feature 추가
- native-only `SkiaLayerRenderer` 추가
- `DocumentCore::render_page_png_native(page)` 추가
- `PageLayerTree` 기반 PNG encode 경로 추가
- page background, clip/group, text/footnote marker, line/path/shape, image replay 처리
- image crop / tile / basic effect replay 처리
- invalid image, placeholder, raw-svg, equation, form object에 대한 fallback replay 처리
- raster size guard 추가
  - invalid page dimension reject
  - invalid scale / dpi reject
  - max dimension / max pixel count 제한
- CI에서 native Skia 테스트를 돌리도록 추가
- README / README_EN에 native Skia 경로와 비목표 정리

이 PR의 Skia 경로는 아직 완성형 renderer라기보다는 `PageLayerTree`가 native raster backend까지 갈 수 있는지 검증하는 초기 backend입니다. 그래서 기본 SVG/Canvas 출력은 그대로 두고, native feature를 켰을 때만 PNG export API를 사용할 수 있게 했습니다.

## 관련 이슈

refs #536

## 범위

이번 PR에 포함한 범위는 아래 정도입니다.

- native-only Skia PNG backend
- `PageLayerTree` replay 기반 raster output
- feature-gated `native-skia`
- 기본 이미지 replay
- raster 생성 안정성 guard
- native Skia unit/smoke test
- CI native Skia test step

## 비목표

아래는 일부러 이번 PR에 넣지 않았습니다.

- CanvasKit renderer
- browser/WASM public API 변경
- C ABI / CLI PNG export
- resource interning/cache
- complex text shaping parity
- 완전한 equation/raw-svg/form native replay
- Skia visual regression fixture pipeline

특히 equation/raw-svg/form은 이번 PR에서는 placeholder/fallback replay 수준입니다. 실제 native replay는 후속 PR에서 따로 보는 게 맞습니다.

## 테스트

- [x] `git diff --check upstream/devel...origin/render-p4`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo check --target wasm32-unknown-unknown --lib`
- [x] `cargo test --features native-skia skia --lib`

SVG 샘플 내보내기와 웹 렌더링 확인은 이번 PR의 직접 범위가 아닙니다. P4는 native-only Skia PNG backend 추가이고, wasm 쪽은 `cargo check --target wasm32-unknown-unknown --lib`로 native Skia 의존성이 새지 않는지만 확인했습니다.

## 스크린샷

없음.

이번 PR은 UI 변경이 아니라 native PNG raster backend 추가입니다. 대신 Skia 테스트에서 PNG decode, pixel sampling, clip, image crop/tile/effect, placeholder fallback, raster option guard를 확인합니다.