### PR TITLE
fix: Supplementary PUA-A (U+F02B1~F02C4) SVG 출력 정정 (closes #513)

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -935,10 +935,10 @@ pub fn effective_text_for_metrics(run: &ComposedTextRun) -> &str {
     run.display_text.as_deref().unwrap_or(&run.text)
 }
 
-/// PUA Supplementary 영역(U+F0000~) 문자가 사각형/원형 테두리 숫자인지 판별한다.
+/// PUA Supplementary 영역(U+F0000~) 문자가 테두리 숫자인지 판별한다.
 ///
 /// HWP 특수문자표에서 표준 Unicode가 없는 테두리 숫자를 PUA로 인코딩한다.
-/// - U+F02B1~U+F02C4: 사각형 안의 숫자 1~20 (border_type=3)
+/// - U+F02B1~U+F02C4: map_pua_bullet_char 에서 ①~⑳ 으로 매핑 (CharOverlap 제외)
 /// - U+F02CE~U+F02E1: 반전 사각형 안의 숫자 1~20 (border_type=4)
 ///
 /// 반환: Some(border_type) 또는 None
@@ -987,10 +987,7 @@ pub fn decode_pua_overlap_number(chars: &[char]) -> Option<String> {
 
 fn pua_enclosed_border_type(ch: char) -> Option<u8> {
     let cp = ch as u32;
-    // 사각형 안의 숫자: U+F02B1(1) ~ U+F02C4(20)
-    if (0xF02B1..=0xF02C4).contains(&cp) {
-        return Some(3); // border_type=3: 사각형
-    }
+    // U+F02B1~F02C4 (①~⑳): map_pua_bullet_char 에서 표준 원문자로 매핑 — CharOverlap 제외
     // 반전 사각형 안의 숫자: U+F02CE(1) ~ U+F02E1(20)
     if (0xF02CE..=0xF02E1).contains(&cp) {
         return Some(4); // border_type=4: 반전 사각형
@@ -1003,11 +1000,7 @@ fn pua_enclosed_border_type(ch: char) -> Option<u8> {
 /// draw_char_overlap()에서 호출하여, 실제 렌더링 시에만 변환한다.
 pub fn pua_to_display_text(ch: char) -> Option<String> {
     let cp = ch as u32;
-    // 사각형 안의 숫자: U+F02B1(1) ~ U+F02C4(20)
-    if (0xF02B1..=0xF02C4).contains(&cp) {
-        let num = cp - 0xF02B0;
-        return Some(format!("{}", num));
-    }
+    // U+F02B1~F02C4 는 map_pua_bullet_char 에서 ①~⑳ 으로 매핑 — 여기 도달 불가
     // 반전 사각형 안의 숫자: U+F02CE(1) ~ U+F02E1(20)
     if (0xF02CE..=0xF02E1).contains(&cp) {
         let num = cp - 0xF02CD;

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -188,7 +188,7 @@ impl LayoutEngine {
                     .find(|cs| cs.start_pos <= utf16_pos)
                     .map(|cs| cs.char_shape_id as u32)
                     .unwrap_or(char_style_id);
-                let ch = text_chars[ch_idx];
+                let ch = map_pua_bullet_char(text_chars[ch_idx]);
                 let lang = super::super::style_resolver::detect_lang_category(ch);
                 let ts = resolved_to_text_style(styles, cs_id, lang);
                 total += estimate_text_width(&ch.to_string(), &ts);
@@ -2902,7 +2902,7 @@ impl LayoutEngine {
 ///   HWP 글머리표는 Wingdings 폰트 문자를 PUA(0xF000+code)로 저장.
 ///
 /// **Supplementary PUA-A (0xF02B0~0xF02FF)** — 한컴 자체 PUA 영역.
-///   원문자 (①~⑨, U+2460~U+2468) 와 별 (★ U+2605) 등을 본 영역에 저장.
+///   원문자 (①~⑳, U+2460~U+2473) 와 · (U+00B7) 등을 본 영역에 저장.
 ///   Task #509 의 한컴 PDF 정답지 시각 검증으로 매핑 확정.
 pub(crate) fn map_pua_bullet_char(ch: char) -> char {
     let code = ch as u32;
@@ -3034,7 +3034,7 @@ mod pua_mapping_tests {
 
     #[test]
     fn supplementary_pua_a_maps_circled_digits() {
-        // [Task #509] U+F02B1~F02B9 → U+2460~U+2468 (원문자 ①~⑨)
+        // U+F02B1~F02C4 → U+2460~U+2473 (원문자 ①~⑳)
         assert_eq!(map_pua_bullet_char('\u{F02B1}'), '\u{2460}', "①");
         assert_eq!(map_pua_bullet_char('\u{F02B2}'), '\u{2461}', "②");
         assert_eq!(map_pua_bullet_char('\u{F02B3}'), '\u{2462}', "③");
@@ -3044,6 +3044,17 @@ mod pua_mapping_tests {
         assert_eq!(map_pua_bullet_char('\u{F02B7}'), '\u{2466}', "⑦");
         assert_eq!(map_pua_bullet_char('\u{F02B8}'), '\u{2467}', "⑧");
         assert_eq!(map_pua_bullet_char('\u{F02B9}'), '\u{2468}', "⑨");
+        assert_eq!(map_pua_bullet_char('\u{F02BA}'), '\u{2469}', "⑩");
+        assert_eq!(map_pua_bullet_char('\u{F02BB}'), '\u{246A}', "⑪");
+        assert_eq!(map_pua_bullet_char('\u{F02BC}'), '\u{246B}', "⑫");
+        assert_eq!(map_pua_bullet_char('\u{F02BD}'), '\u{246C}', "⑬");
+        assert_eq!(map_pua_bullet_char('\u{F02BE}'), '\u{246D}', "⑭");
+        assert_eq!(map_pua_bullet_char('\u{F02BF}'), '\u{246E}', "⑮");
+        assert_eq!(map_pua_bullet_char('\u{F02C0}'), '\u{246F}', "⑯");
+        assert_eq!(map_pua_bullet_char('\u{F02C1}'), '\u{2470}', "⑰");
+        assert_eq!(map_pua_bullet_char('\u{F02C2}'), '\u{2471}', "⑱");
+        assert_eq!(map_pua_bullet_char('\u{F02C3}'), '\u{2472}', "⑲");
+        assert_eq!(map_pua_bullet_char('\u{F02C4}'), '\u{2473}', "⑳");
     }
 
     #[test]

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -2910,7 +2910,7 @@ pub(crate) fn map_pua_bullet_char(ch: char) -> char {
     // Supplementary PUA-A — 한컴 자체 영역 (Task #509 한컴 정답지 정합)
     if (0xF02B0..=0xF02FF).contains(&code) {
         return match code {
-            // 원문자 ①~⑨ (mel-001 / kps-ai 사용 영역, 한컴 PDF 시각 검증)
+            // 원문자 ①~⑳ (mel-001 / kps-ai 사용 영역, 한컴 PDF 시각 검증)
             0xF02B1 => '\u{2460}', // ①
             0xF02B2 => '\u{2461}', // ②
             0xF02B3 => '\u{2462}', // ③
@@ -2920,6 +2920,17 @@ pub(crate) fn map_pua_bullet_char(ch: char) -> char {
             0xF02B7 => '\u{2466}', // ⑦
             0xF02B8 => '\u{2467}', // ⑧
             0xF02B9 => '\u{2468}', // ⑨
+            0xF02BA => '\u{2469}', // ⑩
+            0xF02BB => '\u{246A}', // ⑪
+            0xF02BC => '\u{246B}', // ⑫
+            0xF02BD => '\u{246C}', // ⑬
+            0xF02BE => '\u{246D}', // ⑭
+            0xF02BF => '\u{246E}', // ⑮
+            0xF02C0 => '\u{246F}', // ⑯
+            0xF02C1 => '\u{2470}', // ⑰
+            0xF02C2 => '\u{2471}', // ⑱
+            0xF02C3 => '\u{2472}', // ⑲
+            0xF02C4 => '\u{2473}', // ⑳
             // KTX 회귀 origin — 한컴 PDF 시각 = · (Middle dot), ★ 아님
             // (작업지시자 정정 — 이전 ★ U+2605 매핑은 잘못)
             0xF02EF => '\u{00B7}', // · Middle dot


### PR DESCRIPTION
## 문제

Task #509 에서 `map_pua_bullet_char` 에 Supplementary PUA-A (U+F02B1~F02B9 → ①~⑨) 매핑을 추가했으나, `convert_pua_enclosed_numbers` (composer) 가 동일 범위를 CharOverlap(border_type=3, 사각형 안의 숫자) 으로 먼저 변환하여 매핑이 도달하지 못했습니다.

결과: SVG 에 ① 대신 "1" (사각형 박스) 이 렌더링됨.

## 수정 내용

1. **`pua_enclosed_border_type`**: F02B1~F02C4 범위 제거 — CharOverlap 대상에서 제외
2. **`map_pua_bullet_char`**: F02BA~F02C4 (⑩~⑳) 매핑 추가 — 전체 20자 완성
3. **반전 사각형** (F02CE~F02E1): CharOverlap 유지 (표준 Unicode 대응 문자 부재)

## 검증

```bash
cargo test   # 전체 통과
cargo clippy -- -D warnings   # 경고 없음
```

- `samples/mel-001.hwp` p2: ①②③ `<text>` 요소 정상 출력 (기존: "1" "2" "3" CharOverlap)
- `samples/pua-test.hwp`: ①~⑨ 총 9개 SVG text 확인 (기존: 0개)

## 영향 범위

| 샘플 | 사용 codepoint | 변경 전 | 변경 후 |
|------|----------------|---------|---------|
| mel-001 | F02B1~F02B3 | "1" "2" "3" 박스 | ① ② ③ |
| kps-ai | F02B1, F02B2 | "1" "2" 박스 | ① ② |
| KTX | F02EF | · (circle) | · (circle, 변경 없음) |

---
*이 변경이 프로젝트 방향과 맞지 않으면 피드백 부탁드립니다.*