### PR TITLE
fix: 복수 제목행 반복 시 2행 이상 출력 정정 (closes #594)

### DIFF
--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -150,17 +150,24 @@ impl LayoutEngine {
         );
 
         // ── 4. 렌더링할 행 목록 구성 ──
-        // is_continuation && repeat_header → 제목행(0)에 제목 셀(is_header)이 있으면 반복
-        let render_header = is_continuation && table.repeat_header && start_row > 0
-            && table.cells.iter()
-                .filter(|c| c.row == 0)
-                .any(|c| c.is_header);
-        let mut render_rows: Vec<usize> = Vec::new();
-        if render_header {
-            render_rows.push(0); // 제목행
+        // is_continuation && repeat_header → is_header 셀이 있는 모든 행을 반복
+        let mut header_rows: Vec<usize> = Vec::new();
+        if is_continuation && table.repeat_header && start_row > 0 {
+            let mut seen = vec![false; row_count];
+            for c in &table.cells {
+                if c.is_header && (c.row as usize) < row_count && !seen[c.row as usize] {
+                    seen[c.row as usize] = true;
+                    header_rows.push(c.row as usize);
+                }
+            }
+            header_rows.sort_unstable();
         }
+        let mut render_rows: Vec<usize> = Vec::new();
+        render_rows.extend_from_slice(&header_rows);
         for r in start_row..end_row.min(row_count) {
-            render_rows.push(r);
+            if !header_rows.contains(&r) {
+                render_rows.push(r);
+            }
         }
 
         // 렌더링 영역의 행별 y 위치 계산 (0부터 시작)
@@ -255,16 +262,20 @@ impl LayoutEngine {
 
             // 이 셀이 렌더링 범위에 포함되는지 확인
             let cell_end_row = cell_row + cell.row_span as usize;
-            let render_range_start = if render_header { 0 } else { start_row };
+            let render_range_start = if !header_rows.is_empty() {
+                *header_rows.first().unwrap()
+            } else {
+                start_row
+            };
             let render_range_end = end_row.min(row_count);
 
             // 제목행 반복으로 렌더링되는 셀인지 판별
-            // (원래 범위 밖이지만 render_header 때문에 포함되는 행0 셀)
-            let is_repeated_header_cell = render_header && cell_row == 0 && cell_end_row <= start_row;
+            let is_repeated_header_cell = !header_rows.is_empty()
+                && header_rows.contains(&cell_row)
+                && cell_end_row <= start_row;
 
             // 셀이 렌더링 범위와 겹치는지 확인
             if cell_row >= render_range_end || cell_end_row <= render_range_start {
-                // 제목행 렌더링 시 행0 셀은 포함
                 if !is_repeated_header_cell {
                     continue;
                 }

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -150,14 +150,15 @@ impl LayoutEngine {
         );
 
         // ── 4. 렌더링할 행 목록 구성 ──
-        // is_continuation && repeat_header → is_header 셀이 있는 모든 행을 반복
+        // is_continuation && repeat_header → start_row 이전의 is_header 행만 반복
         let mut header_rows: Vec<usize> = Vec::new();
         if is_continuation && table.repeat_header && start_row > 0 {
             let mut seen = vec![false; row_count];
             for c in &table.cells {
-                if c.is_header && (c.row as usize) < row_count && !seen[c.row as usize] {
-                    seen[c.row as usize] = true;
-                    header_rows.push(c.row as usize);
+                let r = c.row as usize;
+                if c.is_header && r < start_row && r < row_count && !seen[r] {
+                    seen[r] = true;
+                    header_rows.push(r);
                 }
             }
             header_rows.sort_unstable();
@@ -165,9 +166,7 @@ impl LayoutEngine {
         let mut render_rows: Vec<usize> = Vec::new();
         render_rows.extend_from_slice(&header_rows);
         for r in start_row..end_row.min(row_count) {
-            if !header_rows.contains(&r) {
-                render_rows.push(r);
-            }
+            render_rows.push(r);
         }
 
         // 렌더링 영역의 행별 y 위치 계산 (0부터 시작)


### PR DESCRIPTION
## 문제

페이지를 넘어가는 표에서 제목행 반복이 적용될 때, 제목행이 2개 이상 행으로 구성된 경우 첫 번째 제목행만 반복되고 나머지는 누락됩니다.

원인: `table_partial.rs` 에서 `render_rows.push(0)` 으로 행 0만 하드코딩.

## 수정 내용

- `is_header` 셀이 있는 모든 행을 수집하여 `header_rows` 벡터 구성
- 연속 페이지에서 모든 제목행을 반복 렌더링
- 셀 범위 판별 로직도 다중 제목행을 인식하도록 업데이트

## 검증

```bash
cargo test   # 전체 통과
cargo clippy -- -D warnings   # 경고 없음
```

- `samples/synam-001.hwp` p15 (분할 표): 정상 렌더링 확인
- `samples/aift.hwp` (41 페이지, 대형 표 다수): export-pdf 에러 없음

참고: 첨부된 테스트.hwp 는 로컬에 없어 직접 검증하지 못했으나, 코드 변경은 리포터가 지적한 `table_partial.rs:154` 의 단일 행 하드코딩을 정확히 수정합니다.

---
*피드백 있으시면 말씀해주세요.*