### PR TITLE
fix: HWPX ColorRef 상위 바이트 보존

### DIFF
--- a/src/parser/hwpx/utils.rs
+++ b/src/parser/hwpx/utils.rs
@@ -51,7 +51,7 @@ pub fn parse_i32(attr: &quick_xml::events::attributes::Attribute) -> i32 {
     attr_str(attr).parse().unwrap_or(0)
 }
 
-/// "#RRGGBB" 또는 "#AARRGGBB" 형식의 색상을 HWP ColorRef(0x00BBGGRR)로 변환
+/// "#RRGGBB" 또는 "#AARRGGBB" 형식의 색상을 HWP ColorRef로 변환
 pub fn parse_color(attr: &quick_xml::events::attributes::Attribute) -> u32 {
     let s = attr_str(attr);
     parse_color_str(&s)
@@ -72,12 +72,14 @@ pub fn parse_color_str(s: &str) -> u32 {
             return b << 16 | g << 8 | r;
         }
     } else if hex.len() == 8 {
-        // AARRGGBB → 0x00BBGGRR (alpha 무시)
+        // AARRGGBB → 0xAABBGGRR
+        // 상위 바이트는 HWP ColorRef의 확장/특수값 판별에 쓰이므로 보존한다.
         if let Ok(v) = u32::from_str_radix(hex, 16) {
+            let a = (v >> 24) & 0xFF;
             let r = (v >> 16) & 0xFF;
             let g = (v >> 8) & 0xFF;
             let b = v & 0xFF;
-            return b << 16 | g << 8 | r;
+            return a << 24 | b << 16 | g << 8 | r;
         }
     }
     0x00000000 // 검정
@@ -135,7 +137,9 @@ mod tests {
 
     #[test]
     fn test_parse_color_str_with_alpha() {
-        // AARRGGBB — alpha 무시
-        assert_eq!(parse_color_str("#80FF0000"), 0x000000FF);
+        // AARRGGBB — RGB는 BGR로 바꾸되 상위 바이트는 보존
+        assert_eq!(parse_color_str("#80FF0000"), 0x800000FF);
+        assert_eq!(parse_color_str("#FF000000"), 0xFF000000);
+        assert_eq!(parse_color_str("#FFFFFFFF"), 0xFFFFFFFF);
     }
 }


### PR DESCRIPTION
## 변경 요약

HWPX 색상 문자열 `#AARRGGBB`를 HWP `ColorRef`로 변환할 때 상위 바이트를 버리지 않고 보존하도록 수정했습니다.

이번 문제에서는 `faceColor="#FF000000"` / `alpha="0"` 조합이 들어간 표 배경이 검정색으로 렌더링되고 있었습니다. 기존 파서는 `#FF000000`을 `0x00000000`으로 바꿨고, 이 값이 뒤쪽 렌더링 단계에서 일반 검정 채우기로 처리되었습니다.

`style_resolver` 쪽에는 이미 `ColorRef`의 상위 바이트가 0이 아닌 경우 특수값 또는 확장값으로 보고 채우기 없음으로 처리하는 로직이 있으므로, 파서에서 `#AARRGGBB`를 `0xAABBGGRR` 형태로 보존하게 바꾸는 것이 가장 작은 수정 범위라고 판단했습니다.

추가로 `parse_color_str` 단위 테스트에서 `#FF000000`, `#FFFFFFFF`, 반투명 예시의 상위 바이트 보존을 검증하도록 기대값을 갱신했습니다.

## 관련 이슈

closes #606

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인
  - `123kb.hwp` 2페이지: `rect fill="#000000"` 65개 → 0개
  - `74kb.hwp` 1페이지: `rect fill="#000000"` 31개 → 0개
- [ ] 웹(WASM) 렌더링 확인 (이번 검증은 CLI `export-svg` / `export-pdf` 경로에서 수행했습니다)

추가로 실행한 검증:

- `cargo test --lib`
- `cargo test --test svg_snapshot`
- `cargo build --release --bin rhwp`
- `target/release/rhwp export-pdf`로 두 샘플 PDF 재생성 후 비교

## 스크린샷

### 123kb.hwp 2페이지

![123kb.hwp page 2 before/after](https://raw.githubusercontent.com/dicebattle/rhwp/issue-assets/hwpx-colorref-alpha-byte/hwpx-colorref-alpha-byte/123kb-page2-before-after.png)

### 74kb.hwp 1페이지

![74kb.hwp page 1 before/after](https://raw.githubusercontent.com/dicebattle/rhwp/issue-assets/hwpx-colorref-alpha-byte/hwpx-colorref-alpha-byte/74kb-page1-before-after.png)

---

이 PR의 코드 변경과 본문 작성에는 AI 도구(Codex)가 사용되었습니다.
