### PR TITLE
fix: add undo history for non-text resize operations

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -799,6 +799,60 @@ export class MoveShapeCommand implements EditCommand {
   }
 }
 
+
+// ─── 개체 크기/위치 속성 변경 명령 ─────────────────────
+
+export type ObjectResizeTarget = {
+  sec: number;
+  ppi: number;
+  ci: number;
+  type: string;
+  before: Record<string, unknown>;
+  after: Record<string, unknown>;
+};
+
+/**
+ * 그림/도형 리사이즈처럼 드래그 중 WASM에 이미 반영된 속성 변경을
+ * Undo/Redo 스택에 기록하기 위한 명령.
+ */
+export class ResizeObjectCommand implements EditCommand {
+  readonly type = 'resizeObject';
+  readonly timestamp: number;
+
+  constructor(
+    private targets: ObjectResizeTarget[],
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  private setProps(wasm: WasmBridge, target: ObjectResizeTarget, props: Record<string, unknown>): void {
+    if (target.type === 'shape' || target.type === 'line' || target.type === 'group') {
+      wasm.setShapeProperties(target.sec, target.ppi, target.ci, props);
+    } else {
+      wasm.setPictureProperties(target.sec, target.ppi, target.ci, props);
+    }
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    for (const target of this.targets) {
+      this.setProps(wasm, target, target.after);
+    }
+    const first = this.targets[0];
+    return { sectionIndex: first?.sec ?? 0, paragraphIndex: first?.ppi ?? 0, charOffset: 0 };
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    for (const target of this.targets) {
+      this.setProps(wasm, target, target.before);
+    }
+    const first = this.targets[0];
+    return { sectionIndex: first?.sec ?? 0, paragraphIndex: first?.ppi ?? 0, charOffset: 0 };
+  }
+
+  mergeWith(): null { return null; }
+}
+
 // ─── 스냅샷 기반 명령 (복잡한 작업의 Undo/Redo) ─────
 
 /**

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -323,6 +323,8 @@ export function onClick(this: any, e: MouseEvent): void {
                 ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
                 origWidth: props.width,
                 origHeight: props.height,
+                origHorzOffset: props.horzOffset,
+                origVertOffset: props.vertOffset,
                 rotationAngle: (props.rotationAngle ?? 0) as number,
                 startClientX: e.clientX,
                 startClientY: e.clientY,

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -1,7 +1,7 @@
 /** input-handler picture/shape methods — extracted from InputHandler class */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { MovePictureCommand, MoveShapeCommand } from './command';
+import { MovePictureCommand, MoveShapeCommand, ResizeObjectCommand } from './command';
 
 /** 클릭 좌표에서 그림, 글상자, 수식 개체를 찾는다. */
 /** 점과 선분 사이 최소 거리 (px) */
@@ -418,6 +418,7 @@ export function finishPictureResizeDrag(this: any, e: MouseEvent): void {
     const isCorner = ['nw', 'ne', 'sw', 'se'].includes(state.dir);
 
     try {
+      const historyTargets = [];
       for (const r of state.multiRefs) {
         const relX = r.bboxX - origX;
         const relY = r.bboxY - origY;
@@ -430,9 +431,22 @@ export function finishPictureResizeDrag(this: any, e: MouseEvent): void {
         const newW = Math.max(Math.round(r.origWidth * sx), MIN_SIZE_HWP);
         const newH = Math.max(Math.round(r.origHeight * sy), MIN_SIZE_HWP);
         const updated: Record<string, unknown> = { width: newW, height: newH };
-        if (deltaH !== 0) updated['horzOffset'] = ((r.origHorzOffset + deltaH) >>> 0);
-        if (deltaV !== 0) updated['vertOffset'] = ((r.origVertOffset + deltaV) >>> 0);
+        const before: Record<string, unknown> = { width: r.origWidth, height: r.origHeight };
+        if (deltaH !== 0) {
+          updated['horzOffset'] = ((r.origHorzOffset + deltaH) >>> 0);
+          before['horzOffset'] = r.origHorzOffset;
+        }
+        if (deltaV !== 0) {
+          updated['vertOffset'] = ((r.origVertOffset + deltaV) >>> 0);
+          before['vertOffset'] = r.origVertOffset;
+        }
+        const changed = Object.keys(updated).some(key => updated[key] !== before[key]);
+        if (!changed) continue;
         setObjectProperties.call(this, r, updated);
+        historyTargets.push({ sec: r.sec, ppi: r.ppi, ci: r.ci, type: r.type, before, after: updated });
+      }
+      if (historyTargets.length > 0) {
+        this.executeOperation({ kind: 'record', command: new ResizeObjectCommand(historyTargets) });
       }
       this.eventBus.emit('document-changed');
     } catch (err) {
@@ -454,12 +468,31 @@ export function finishPictureResizeDrag(this: any, e: MouseEvent): void {
 
   try {
     const updated: Record<string, unknown> = {};
-    if (newW !== state.origWidth) updated['width'] = newW;
-    if (newH !== state.origHeight) updated['height'] = newH;
-    if (newHorzOffset !== origHorzOffset) updated['horzOffset'] = (newHorzOffset >>> 0);
-    if (newVertOffset !== origVertOffset) updated['vertOffset'] = (newVertOffset >>> 0);
+    const before: Record<string, unknown> = {};
+    if (newW !== state.origWidth) {
+      updated['width'] = newW;
+      before['width'] = state.origWidth;
+    }
+    if (newH !== state.origHeight) {
+      updated['height'] = newH;
+      before['height'] = state.origHeight;
+    }
+    const beforeHorzOffset = state.origHorzOffset ?? origHorzOffset;
+    const beforeVertOffset = state.origVertOffset ?? origVertOffset;
+    if (newHorzOffset !== origHorzOffset) {
+      updated['horzOffset'] = (newHorzOffset >>> 0);
+      before['horzOffset'] = beforeHorzOffset;
+    }
+    if (newVertOffset !== origVertOffset) {
+      updated['vertOffset'] = (newVertOffset >>> 0);
+      before['vertOffset'] = beforeVertOffset;
+    }
     if (Object.keys(updated).length > 0) {
       setObjectProperties.call(this, state.ref, updated);
+      this.executeOperation({
+        kind: 'record',
+        command: new ResizeObjectCommand([{ sec: state.ref.sec, ppi: state.ref.ppi, ci: state.ref.ci, type: state.ref.type, before, after: updated }]),
+      });
       this.eventBus.emit('document-changed');
     }
   } catch (err) {

--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -183,15 +183,21 @@ export function finishResizeDrag(this: any, e: MouseEvent): void {
     });
   }
 
-  // WASM 배치 API 호출
+  // WASM 배치 API 호출 (복합 셀 보상 변경은 스냅샷으로 Undo 기록)
   try {
-    this.wasm.resizeTableCells(
-      state.tableRef.sec,
-      state.tableRef.ppi,
-      state.tableRef.ci,
-      updates,
-    );
-    this.eventBus.emit('document-changed');
+    this.executeOperation({
+      kind: 'snapshot',
+      operationType: 'resizeTableCells',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(
+          state.tableRef.sec,
+          state.tableRef.ppi,
+          state.tableRef.ci,
+          updates,
+        );
+        return this.cursor.getPosition();
+      },
+    });
     if (inCellSel) this.updateCellSelection();
   } catch (err) {
     console.warn('[InputHandler] resizeTableCells 실패:', err);
@@ -493,8 +499,14 @@ export function resizeCellByKeyboard(this: any, key: 'ArrowUp' | 'ArrowDown' | '
   }
 
   try {
-    this.wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
-    this.eventBus.emit('document-changed');
+    this.executeOperation({
+      kind: 'snapshot',
+      operationType: 'resizeCellByKeyboard',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+        return this.cursor.getPosition();
+      },
+    });
     this.updateCellSelection();
   } catch (err) {
     console.warn('[InputHandler] resizeCellByKeyboard 실패:', err);
@@ -525,8 +537,14 @@ export function resizeTableProportional(this: any, key: 'ArrowUp' | 'ArrowDown' 
       }
     }
 
-    this.wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
-    this.eventBus.emit('document-changed');
+    this.executeOperation({
+      kind: 'snapshot',
+      operationType: 'resizeTableProportional',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+        return this.cursor.getPosition();
+      },
+    });
     this.updateCellSelection();
   } catch (err) {
     console.warn('[InputHandler] resizeTableProportional 실패:', err);

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -166,6 +166,8 @@ export class InputHandler {
     ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' };
     origWidth: number;
     origHeight: number;
+    origHorzOffset?: number;
+    origVertOffset?: number;
     startClientX: number;
     startClientY: number;
     pageIndex: number;


### PR DESCRIPTION
변경 요약

rhwp-studio에서 텍스트 이외 편집 작업의 undo 누락 문제(#458) 를 해결했습니다.

기존에는 일부 표 크기 조절 및 그림/도형 크기 조절 경로가 CommandHistory를 통하지 않고 WASM mutation만 직접 호출하고 있어, Ctrl+Z / Ctrl+Y가 동작하지 않았습니다.

이번 PR에서는:

• 표 리사이즈 경로를 snapshot 기반 undo 기록으로 감쌌고
• 그림/도형 리사이즈 경로에 ResizeObjectCommand 를 추가하여
• 리사이즈 후 non-text 편집도 undo/redo 스택에 정상 반영되도록 수정했습니다.

범위는 최소 수정으로 제한했으며:

• 텍스트 undo 경로는 변경하지 않았고
• 표/개체 이동 undo 경로도 기존 동작을 유지했습니다.

관련 이슈

closes #458

테스트

☑ cargo test 통과
☑ cargo clippy -- -D warnings 통과
☐ 관련 샘플 파일로 SVG 내보내기 확인
☑ 웹(WASM) 렌더링 확인 (해당하는 경우)

추가 확인:

• docker compose --env-file .env.docker run --rm wasm
• cd rhwp-studio && npm run build
• git diff --check

