### PR TITLE
fix: Picture flip/rotation 누락 회귀 정정 (Task #519 재적용, closes #618)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -2856,6 +2856,7 @@ impl LayoutEngine {
                                     effect: pic.image_attr.effect,
                                     brightness: pic.image_attr.brightness,
                                     contrast: pic.image_attr.contrast,
+                                    transform: utils::extract_shape_transform(&pic.shape_attr),
                                     ..ImageNode::new(bin_data_id, image_data)
                                 }),
                                 BoundingBox::new(pic_x, pic_y, pic_w, pic_h),

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -13,7 +13,7 @@ use super::super::{TextStyle, ShapeStyle, TabStop, hwpunit_to_px, px_to_hwpunit,
 use super::{LayoutEngine, CellContext};
 use super::text_measurement::{resolved_to_text_style, estimate_text_width, compute_char_positions, extract_tab_leaders_with_extended, find_next_tab_stop};
 use super::border_rendering::create_border_line_nodes;
-use super::utils::{resolve_numbering_id, expand_numbering_format, numbering_format_to_number_format, find_bin_data};
+use super::utils::{resolve_numbering_id, expand_numbering_format, numbering_format_to_number_format, find_bin_data, extract_shape_transform};
 
 /// lineseg baseline_distance를 폰트 어센트 기준으로 보정한다.
 /// CENTER 문단 수직정렬 등으로 baseline이 50% 이하로 설정된 경우,
@@ -1830,6 +1830,7 @@ impl LayoutEngine {
                                             brightness: pic.image_attr.brightness,
                                             contrast: pic.image_attr.contrast,
                                             text_wrap: Some(pic.common.text_wrap),
+                                            transform: extract_shape_transform(&pic.shape_attr),
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -2104,6 +2105,7 @@ impl LayoutEngine {
                                         brightness: pic.image_attr.brightness,
                                         contrast: pic.image_attr.contrast,
                                         text_wrap: Some(pic.common.text_wrap),
+                                        transform: extract_shape_transform(&pic.shape_attr),
                                         ..ImageNode::new(bin_data_id, image_data)
                                     }),
                                     BoundingBox::new(x, img_y, tac_w, pic_h),
@@ -2214,6 +2216,7 @@ impl LayoutEngine {
                                             brightness: pic.image_attr.brightness,
                                             contrast: pic.image_attr.contrast,
                                             text_wrap: Some(pic.common.text_wrap),
+                                            transform: extract_shape_transform(&pic.shape_attr),
                                             ..ImageNode::new(bin_data_id, image_data)
                                         }),
                                         BoundingBox::new(img_x, img_y, tac_w, pic_h),

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -14,7 +14,7 @@ use super::super::style_resolver::ResolvedStyleSet;
 use super::super::{hwpunit_to_px, StrokeDash, LineStyle, TextStyle, AutoNumberCounter, format_number, NumberFormat as NumFmt};
 use super::LayoutEngine;
 use super::border_rendering::border_width_to_px;
-use super::utils::find_bin_data;
+use super::utils::{extract_shape_transform, find_bin_data};
 use super::text_measurement::{resolved_to_text_style, estimate_text_width};
 
 impl LayoutEngine {
@@ -114,6 +114,7 @@ impl LayoutEngine {
                 brightness: picture.image_attr.brightness,
                 contrast: picture.image_attr.contrast,
                 text_wrap: Some(picture.common.text_wrap),
+                transform: extract_shape_transform(&picture.shape_attr),
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(pic_x, pic_y, pic_width, pic_height),
@@ -324,6 +325,7 @@ impl LayoutEngine {
                 brightness: picture.image_attr.brightness,
                 contrast: picture.image_attr.contrast,
                 text_wrap: Some(picture.common.text_wrap),
+                transform: extract_shape_transform(&picture.shape_attr),
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -13,7 +13,7 @@ use super::super::{hwpunit_to_px, TextStyle, ShapeStyle};
 use super::{LayoutEngine, CellContext, CellPathEntry};
 use super::border_rendering::{build_row_col_x, collect_cell_borders, render_edge_borders, render_transparent_borders};
 use super::text_measurement::{resolved_to_text_style, is_cjk_char, is_vertical_rotate_char, vertical_substitute_char};
-use super::utils::find_bin_data;
+use super::utils::{extract_shape_transform, find_bin_data};
 
 impl LayoutEngine {
     /// 세로쓰기 셀의 텍스트를 수직 방향으로 배치한다.
@@ -641,7 +641,7 @@ impl LayoutEngine {
                                     control_index: Some(ctrl_idx),
                                     fill_mode: None,
                                     original_size: None,
-                                    transform: ShapeTransform::default(),
+                                    transform: extract_shape_transform(&pic.shape_attr),
                                     crop: None,
                                     original_size_hu: None,
                                     effect: pic.image_attr.effect,


### PR DESCRIPTION
## Summary

이슈 #618 정정. `samples/exam_eng.hwp` 4페이지 28번 박스 종이-말림(curl) 그림의 `horz_flip+vert_flip` 속성이 SVG 출력에 적용되지 않는 회귀를 정정.

원인: Task #519 (#519, `7ead89d`) 의 정정이 `local/devel` 에는 머지되었으나 `stream/devel` 로의 승격이 한 번도 일어나지 않음. 묶음 머지 `a7e43f9` 가 `stream/devel` 첫부모 경로에 부재.

```bash
$ git merge-base --is-ancestor 7ead89d stream/devel
NOT in stream/devel
$ git branch -a --contains 7ead89d
local/devel, local/task524..574, remotes/origin/local/devel, ...
(stream/devel / main 부재)
```

## Changes

6 ImageNode 생성 지점에 `transform: extract_shape_transform(&pic.shape_attr)` 재적용. `extract_shape_transform` 헬퍼는 `utils.rs:109` 에 그대로 살아있어 신규 단위 변환 코드 0줄.

| 파일 | 라인 | 변경 |
|------|------|------|
| `src/renderer/layout.rs` | 2851 | `transform:` 추가 (TAC Picture / col_node) |
| `src/renderer/layout/picture_footnote.rs` | 117, 328 | `transform:` 추가 + import |
| `src/renderer/layout/paragraph_layout.rs` | 1834, 2108, 2218 | `transform:` 추가 + import |
| `src/renderer/layout/table_cell_content.rs` | 644 | `ShapeTransform::default()` → `extract_shape_transform(&pic.shape_attr)` + import |

총 4 files, +10/-4.

## 검증

- `cargo test --lib`: **1134 passed** (회귀 0)
- `cargo test --test svg_snapshot`: **6/6 passed**
- `cargo clippy --lib -- -D warnings`: **clean**
- `exam_eng.hwp` 8페이지 SVG diff: 페이지 4만 2 lines 변경 (`<g transform>` 래퍼 1쌍 추가), 다른 7개 페이지 byte-identical
- export-svg p4 transform 래퍼 카운트: **0 → 1** (Q28 그림에 horz/vert flip 정상 적용)

```bash
$ ./target/debug/rhwp export-svg samples/exam_eng.hwp -p 3 -o /tmp/p4/
$ grep -c '<g transform=' /tmp/p4/exam_eng_004.svg
1
$ grep -oE '<g transform="[^"]*">' /tmp/p4/exam_eng_004.svg
<g transform="translate(1602.426666666667,0) scale(-1,1) translate(0,2217.373333333333) scale(1,-1)">
```

## Test plan

- [x] cargo test --lib (1134 passed)
- [x] cargo test --test svg_snapshot (6 passed)
- [x] cargo clippy --lib -- -D warnings (clean)
- [x] exam_eng 8페이지 광역 회귀 비교 (페이지 4만 의도된 정정, 7페이지 byte-identical)
- [ ] 메인테이너 시각 판정 (PDF 와 SVG 비교 — Q28 박스 좌상단 curl 위치)

## 회귀 방지 후속 권고

이번 회귀처럼 `local/devel` → `stream/devel` 승격 누락 사례 재발 방지를 위해, 동일 묶음 머지 `a7e43f9 (Task #517/#518/#519/#520/#521/#523/#528)` 의 다른 task 들도 `stream/devel` 누락 가능성 점검 권고 (별도 이슈로 분리 가능).

## 참고

- 원 이슈: #519 (CLOSED, Task #519 정정)
- 원 fix 커밋: `7ead89d` (Task #519 Stage 2: ImageNode.transform 채우기)
- 묶음 머지: `a7e43f9` (Merge local/devel: Task #517/#518/#519/#520/#521/#523/#528)
- 본 이슈: #618

closes #618