### PR TITLE
다단 paragraph 내 vpos-reset 미처리 정정 (closes #619)

### DIFF
--- a/mydocs/orders/20260506.md
+++ b/mydocs/orders/20260506.md
@@ -1,0 +1,34 @@
+# 오늘 할일 - 2026년 5월 6일
+
+## M100 — v1.0.0 조판 엔진
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **#619** | 다단 paragraph 내 vpos-reset 미처리 — TypesetEngine partial-split 에서 line.vertical_pos==0 무시 | **완료** | 작업지시자 보고: `samples/21_언어_기출_편집가능본.hwp` 페이지 8 우측 단 마지막 줄(pi=181 line 8) overflow 17.1 px → 절반 잘림. 분석: pi=181 `line_segs[8].vertical_pos=0` 은 HWP 의 vpos-reset 신호 (다음 단 최상단 배치). 활성 `TypesetEngine` (`src/renderer/typeset.rs`) 의 partial-split 루프가 이를 무시 → line 8 이 col_bottom 너머에 그려짐. 정정: partial-split 의 inner fit 루프에 다단 한정 (`col_count > 1`) `line_segs[li].vertical_pos == 0 && li > cursor_line` forced break 추가. 변경 LOC: `src/renderer/typeset.rs` +9. 검증: 페이지 8 단 1 lines 0..9 → 0..8, 페이지 9 단 0 lines 9..13 → 8..13, LAYOUT_OVERFLOW_DRAW 미발생. 한컴 2020 PDF 정확 일치 (8줄 분할). cargo test 통과 / clippy 통과 / 회귀 가드 샘플 10개 + 광역 4개 모두 변경 전후 byte-equivalent (overflow + 페이지 분포). 처리 보고서: `mydocs/report/task_m100_619_report.md`. |
+
+## 신규 이슈
+
+| Issue | 제목 | 비고 |
+|------|------|------|
+| **#619** | [m100] 다단 paragraph 내 vpos-reset 미처리 — TypesetEngine partial-split 에서 line.vertical_pos == 0 무시 | 작업지시자 보고 — 본 task 처리 완료 (PR 생성) |
+
+## 작업 메모
+
+### Task #619
+- 본 task 시작 전 `local/task619` 분기 (`local/devel` 기준)
+- 분석: `dump-pages` → `LAYOUT_OVERFLOW_DRAW` 메시지 → `dump -s 0 -p 181` → 활성 엔진 식별 (TypesetEngine vs Paginator) → 한컴 2010/2020 PDF 비교 (`pdftotext -layout`) 로 본 정정 방향 (한컴 2020 정합) 확인
+- 회귀 검증: HEAD~1 의 `typeset.rs` 만 임시 빌드 → 결과 저장 → 원복 → 변경 후 결과 비교. 모든 가드 샘플 byte-equivalent
+- PR: `planet6897:pr-task619` → `edwardkim:devel` 별도 fork branch (메모리 룰 `feedback_per_task_pr_branch.md` 정합)
+
+## 메모리 정합
+
+- `feedback_pr_target_devel` — PR base 는 `devel`. main 은 릴리즈 전용
+- `feedback_per_task_pr_branch` — 각 PR 은 별도 fork branch (`planet6897:pr-task619`)
+- `feedback_pdf_not_authoritative` — 한컴 2010 vs 2020 환경 차이 함께 점검 (본 정정은 2020 정합 방향)
+- `feedback_essential_fix_regression_risk` — 다단 한정 (col_count > 1) + 회귀 가드 광범위 검증
+- `feedback_rule_not_heuristic` — HWP 인코딩 신호 (vpos-reset) 존중 단일 룰. 분기/허용오차 없음
+
+## 작업지시자 검토 사항
+
+1. **시각 판정**: `output/svg/p21_after/21_언어_기출_편집가능본_008.svg`, `_009.svg` — 페이지 8 우측 단 line 8 overflow 해소 + 페이지 9 좌측 단 첫 줄 = "토속 신앙의 영향을…" 정상 표시 확인
+2. **PR 검토**: GitHub PR `planet6897:pr-task619` → `edwardkim:devel`

--- a/mydocs/plans/task_m100_619.md
+++ b/mydocs/plans/task_m100_619.md
@@ -1,0 +1,86 @@
+# 수행계획서 — Task #619
+
+다단 paragraph 내 vpos-reset 미처리 — TypesetEngine partial-split 에서 `line.vertical_pos == 0` 무시
+
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+
+## 1. 배경
+
+`samples/21_언어_기출_편집가능본.hwp` 페이지 8 우측 단(단 1) 마지막 줄(pi=181 line 8) 이 본문 영역 하단을 17.1px 초과한 위치에 그려져 라인 절반 이상이 꼬리말 영역으로 빠져 보임.
+
+```
+LAYOUT_OVERFLOW_DRAW: section=0 pi=181 line=8 y=1453.2 col_bottom=1436.2 overflow=17.1px
+```
+
+`pi=181 line_segs[8].vertical_pos = 0` (line>0 인데 vpos=0) 은 HWP 가 line 8 을 다음 단 최상단에서 시작하도록 인코딩한 vpos-reset 신호다. HWP 의도는:
+- 페이지 8 단 1: pi=181 line 0..7 (8줄)
+- 페이지 9 단 0: pi=181 line 8..12 (5줄)
+
+현 동작:
+- 페이지 8 단 1: pi=181 line 0..8 (line 8 이 col_bottom 너머에 그려짐)
+- 페이지 9 단 0: pi=181 line 9..12
+
+## 2. 원인
+
+`TypesetEngine` (`src/renderer/typeset.rs`) 의 partial-split 루프 (line 1060–1132) 가 문단 *내부* `line.vertical_pos == 0` 신호를 인식하지 않는다. 문단 *간* vpos-reset 만 `next_will_vpos_reset` (line 444) 으로 처리.
+
+별도 `Paginator` 엔진 (`src/renderer/pagination/engine.rs::paginate_with_forced_breaks`) 에 `respect_vpos_reset` 옵션 기반 처리가 있으나 기본 미사용 (`RHWP_USE_PAGINATOR=1` 필요).
+
+## 3. 수정 방향 (A 안 — 가장 보수적)
+
+`TypesetEngine` partial-split 루프 안에 다단 (`col_count > 1`) 한정으로 `line_segs[li].vertical_pos == 0 && li > 0` forced break 처리를 추가한다.
+
+### 적용 조건
+- `st.col_count > 1` (다단 섹션) — 단일 단의 partial-table split / 회귀 차단
+- `li > 0 && para.line_segs[li].vertical_pos == 0` — vpos-reset 신호 검출
+
+### 동작
+1. partial-split 의 inner fit 루프 (`for li in cursor_line..line_count`) 에서 vpos-reset 위치를 만나면, 해당 line 직전에서 break.
+2. 결과: cursor_line..end_line 가 vpos-reset 직전 line 까지만 포함 → PartialParagraph 로 푸시.
+3. 다음 iteration 에서 `cursor_line = end_line` 으로 vpos-reset line 부터 시작. 이때 `advance_column_or_new_page()` 로 다음 단/페이지 진행 후 배치.
+
+### 회귀 차단
+- 단일 단 (col_count==1) 미적용 → exam_kor 등 partial-table 회귀 차단.
+- 표 분할 경로 (table split) 는 별도 함수 (1135 이후) 라 영향 없음.
+- 문단 간 vpos-reset (`next_will_vpos_reset`) 은 변경하지 않음.
+- `paginate_with_forced_breaks` (Paginator 경로) 와 동일한 시멘틱 → 옵션 활성화 시 일관성 확보.
+
+## 4. 검증 항목
+
+### 정합성
+1. 대상 파일: `samples/21_언어_기출_편집가능본.hwp` 페이지 8/9 정상 렌더링 (line 8 이 페이지 9 단 0 첫 줄로 이동, LAYOUT_OVERFLOW_DRAW 미발생).
+2. 한컴 2010/2020 PDF 비교 — 페이지 8/9 경계 일치 (`feedback_pdf_not_authoritative.md` 룰: 두 환경 모두 점검).
+
+### 회귀
+3. 기존 다단 회귀 가드 샘플:
+   - `samples/exam_eng_*.hwp` 8p 단 채움
+   - `samples/exam_kor_*.hwp` partial-table split (issue #418 가드)
+   - `samples/kps-ai*.hwp` pi=778 (Task #362 가드)
+   - `samples/hwp-multi-001*.hwp` 정상 쪽나누기 (Task #470 가드)
+4. `cargo test` 전체 통과.
+5. `cargo clippy --all-targets -- -D warnings` 통과.
+
+### 측정
+6. `rhwp dump-pages -p 7` 결과: 단 1 의 PartialParagraph lines=0..8 (현 0..9), 페이지 9 단 0 의 PartialParagraph lines=8..13 (현 9..13).
+7. `rhwp export-svg -p 7` 결과: LAYOUT_OVERFLOW_DRAW 미발생.
+
+## 5. 단계 (구현계획서에서 상세화)
+
+대략 3 단계 예상:
+- Stage 1: TypesetEngine partial-split 루프에 vpos-reset forced break 로직 추가 (다단 한정).
+- Stage 2: 회귀 검증 (위 6개 샘플 + cargo test + clippy).
+- Stage 3: 한컴 PDF 정합성 비교 + 최종 보고서.
+
+상세 단계는 승인 후 구현계획서 (`task_m100_619_impl.md`) 에 작성한다.
+
+## 6. 위험 / 미해결 질문
+
+- **다단 한정 조건의 충분성**: 단일 단에서도 vpos-reset 이 의미를 가질 수 있는지 (현 한계 주석 `paragraph_layout.rs:1733` 은 "다단" 한정 표현 없음). 단일 단은 본 변경 범위 외 — 추가 발견 시 별도 이슈로 분리.
+- **Inline Shape 처리**: pi=181 line 0 의 inline shape (마흐디) 는 같은 vpos=77316 에 anchor. forced break 시 shape 가 어느 페이지로 이동하는지 검증 필요. 현재 dump 상 Shape 도 PartialParagraph 와 함께 단 1 에 배치 → forced break 적용 시 shape 는 line 0..7 와 함께 단 1 에 남아야 함 (vpos 기준).
+- **ls[2] lh=1417** (다른 줄 1100): 인라인 컨트롤 영향 가능성. fit 계산에 영향 있는지 검증 필요.
+
+## 7. 승인 요청
+
+본 수행계획서 검토 후 승인 부탁드립니다. 승인 후 구현계획서 작성 단계로 진행합니다.

--- a/mydocs/plans/task_m100_619_impl.md
+++ b/mydocs/plans/task_m100_619_impl.md
@@ -1,0 +1,134 @@
+# 구현계획서 — Task #619
+
+다단 paragraph 내 vpos-reset 미처리 — TypesetEngine partial-split 에서 `line.vertical_pos == 0` 무시
+
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+- 수행계획서: `mydocs/plans/task_m100_619.md`
+
+## 1. 단계 구성 (4 단계)
+
+### Stage 1 — vpos-reset forced break 로직 추가 (다단 한정)
+
+**대상**: `src/renderer/typeset.rs::typeset_paragraph` 의 partial-split 루프 (line 1057–1132).
+
+**수정 내용**:
+1. 줄 단위 분할 루프 (`while cursor_line < line_count`) 의 inner fit 루프 (`for li in cursor_line..line_count`) 에 vpos-reset 검출 추가.
+2. 적용 조건:
+   - `st.col_count > 1` (다단 섹션 한정)
+   - `li > cursor_line` (현 세그먼트 첫 줄 제외)
+   - `para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)` (vpos-reset 신호)
+3. 검출 시: `break` 로 inner 루프 종료 → `end_line = li` 로 forced split.
+4. 외부 루프에서 `cursor_line = end_line` 으로 다음 iteration 진입 → `advance_column_or_new_page()` 후 vpos-reset line 부터 재배치.
+
+**수정 위치 의사코드**:
+```rust
+for li in cursor_line..line_count {
+    // [Task #619] 다단 paragraph 내 vpos-reset 강제 분리.
+    // line_segs[li].vertical_pos == 0 (li>0) 은 HWP 가 해당 line 을
+    // 다음 단/페이지 최상단에 배치하도록 인코딩한 신호. 다단 한정 적용
+    // (단일 단은 partial-table split 회귀 차단 위해 미적용).
+    if st.col_count > 1
+        && li > cursor_line
+        && para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)
+    {
+        break;
+    }
+    let content_h = fmt.line_heights[li];
+    if cumulative + content_h > avail_for_lines && li > cursor_line {
+        break;
+    }
+    cumulative += fmt.line_advance(li);
+    end_line = li + 1;
+}
+```
+
+**커밋 메시지**: `Task #619: TypesetEngine partial-split 에 다단 vpos-reset forced break 추가`
+
+**완료 조건**:
+- `cargo build --release` 성공.
+- 코드 변경에 주석으로 의도 명시 (Task #619 참조).
+
+### Stage 2 — 대상 파일 수정 검증
+
+**검증 항목**:
+1. `rhwp dump-pages "samples/21_언어_기출_편집가능본.hwp" -p 7` 결과:
+   - 단 1: `PartialParagraph pi=181 lines=0..8` (변경 전: `0..9`)
+2. `rhwp dump-pages "samples/21_언어_기출_편집가능본.hwp" -p 8` 결과:
+   - 단 0: `PartialParagraph pi=181 lines=8..13` (변경 전: `9..13`)
+3. `rhwp export-svg "samples/21_언어_기출_편집가능본.hwp" -p 7 -o output/svg/p21_after/`:
+   - `LAYOUT_OVERFLOW_DRAW: pi=181 line=8` 미발생.
+4. `rhwp export-svg "samples/21_언어_기출_편집가능본.hwp" -p 8 -o output/svg/p21_after/`:
+   - 페이지 9 단 0 첫 줄 = pi=181 line 8 의 텍스트 ("거나, 이러한 능력을…").
+
+**한컴 PDF 비교**:
+5. `samples/21_언어_기출_편집가능본-2010.pdf` 페이지 8/9 vs SVG: 라인 분포 일치.
+6. `samples/21_언어_기출_편집가능본-2020.pdf` 페이지 8/9 vs SVG: 라인 분포 일치.
+
+**완료 조건**:
+- 위 1–4 통과.
+- 5–6 비교 결과 본문 (단계별 보고서) 에 기록.
+
+### Stage 3 — 회귀 검증
+
+**테스트 항목**:
+1. `cargo test --release` 전체 통과.
+2. `cargo clippy --all-targets --release -- -D warnings` 통과.
+3. 기존 회귀 가드 샘플 SVG 비교 (변경 전/후):
+   - `samples/exam_eng*.hwp` (8p 단 채움, Task #470 가드)
+   - `samples/exam_kor*.hwp` (partial-table split, issue #418 가드)
+   - `samples/kps-ai*.hwp` 또는 유사 다단 샘플 (Task #362 가드)
+   - `samples/k-water-rfp*.hwp` p3, p15 (Task #391 / Task #361 가드)
+   - 기타 다단 샘플 (samples/ 폴더의 다단 케이스 5–10 개 무작위 검증)
+4. 검증 방식:
+   - 각 샘플 전 페이지 SVG 생성 (변경 전 백업 → 변경 후 비교).
+   - `LAYOUT_OVERFLOW_DRAW` 또는 `LAYOUT_OVERFLOW` 메시지 신규 발생 여부 확인.
+   - 페이지 수, 페이지별 단 분포 (`dump-pages`) 변경 여부 비교.
+
+**완료 조건**:
+- 1, 2 통과.
+- 3 의 회귀 가드 샘플에서 페이지 분포 변화 없음 (또는 변화가 본 변경 의도와 일치하는 합리적 변화임을 단계별 보고서에 명시).
+
+### Stage 4 — 최종 보고서 + 머지
+
+**작업 항목**:
+1. 최종 결과 보고서 작성: `mydocs/report/task_m100_619_report.md`.
+   - 변경 전/후 dump-pages 출력 비교
+   - LAYOUT_OVERFLOW_DRAW 제거 증거
+   - 한컴 PDF 비교 스크린샷/요약
+   - 회귀 검증 결과 요약
+2. `mydocs/orders/{yyyymmdd}.md` 갱신 (Task #619 완료 항목 추가).
+3. 단계별 보고서 (`task_m100_619_stage{1,2,3}.md`) 와 최종 보고서를 task 브랜치에 커밋.
+4. 작업지시자 승인 후 `local/devel` 머지 진행 (이슈 closes #619).
+
+**완료 조건**:
+- 보고서 작성 + 승인.
+- task 브랜치에 모든 변경 (소스 + 문서) 커밋 완료.
+- `git status` clean 확인 후 머지 준비.
+
+## 2. 변경 파일 목록 (예상)
+
+| 파일 | 변경 사유 |
+|------|----------|
+| `src/renderer/typeset.rs` | partial-split 루프에 vpos-reset forced break 추가 |
+| `mydocs/plans/task_m100_619.md` | 수행계획서 (작성 완료) |
+| `mydocs/plans/task_m100_619_impl.md` | 구현계획서 (이 문서) |
+| `mydocs/working/task_m100_619_stage1.md` | Stage 1 완료 보고서 |
+| `mydocs/working/task_m100_619_stage2.md` | Stage 2 완료 보고서 |
+| `mydocs/working/task_m100_619_stage3.md` | Stage 3 완료 보고서 |
+| `mydocs/report/task_m100_619_report.md` | 최종 결과 보고서 |
+| `mydocs/orders/{날짜}.md` | 오늘 할일 갱신 |
+
+## 3. 위험 요소 및 완화
+
+| 위험 | 영향 | 완화 |
+|------|------|------|
+| 다단에서 vpos-reset 가 의도와 다른 위치에서 발생하는 케이스 (예: 빈 줄, 표 분할 후 line_segs 잔재) | 페이지 분포 의도와 다르게 변경 | 다단 한정 적용 + Stage 3 회귀 검증으로 차단 |
+| Inline shape (pi=181 ci=0 마흐디) 가 forced break 로 잘못된 페이지로 이동 | shape 페이지 누락 / 중복 | Stage 2 SVG 검증 시 shape 위치 확인 |
+| 표 분할 + vpos-reset 동시 케이스 | partial-table split 회귀 | 표 분할 경로 (`fn typeset_paragraph` 의 다른 분기) 미수정 → 영향 없음. Stage 3 exam_kor 가드로 검증 |
+| `next_will_vpos_reset` (문단 간) 와 충돌 | safety_margin 이중 동작 | 문단 *간* vpos-reset 처리 코드 미수정. 본 변경은 문단 *내부* 만. |
+
+## 4. 승인 요청
+
+본 구현계획서 검토 후 승인 부탁드립니다. 승인 후 Stage 1 부터 순차 진행합니다.

--- a/mydocs/report/task_m100_619_report.md
+++ b/mydocs/report/task_m100_619_report.md
@@ -1,0 +1,130 @@
+# 최종 결과 보고서 — Task #619
+
+다단 paragraph 내 vpos-reset 미처리 — TypesetEngine partial-split 에서 `line.vertical_pos == 0` 무시
+
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task619` → fork `planet6897:pr-task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+- 처리 일자: 2026-05-06
+
+## 1. 증상
+
+`samples/21_언어_기출_편집가능본.hwp` 페이지 8 우측 단(단 1) 마지막 줄(pi=181 line 8) 이 본문 영역 하단을 17.1 px 초과한 위치에 그려져 라인 절반 이상이 꼬리말 영역으로 빠져 보임.
+
+```
+LAYOUT_OVERFLOW_DRAW: section=0 pi=181 line=8 y=1453.2 col_bottom=1436.2 overflow=17.1px
+```
+
+## 2. 원인
+
+`pi=181 line_segs[8].vertical_pos = 0` (line>0 인데 vpos=0) 은 HWP 가 line 8 을 다음 단/페이지 최상단에서 시작하도록 인코딩한 vpos-reset 신호다. 한컴 2020 PDF 도 이 신호에 따라 page 8 단 1 = pi=181 line 0..8 (8줄), page 9 단 0 = line 8..13 분포로 렌더.
+
+활성 페이지네이션 엔진 `TypesetEngine` (`src/renderer/typeset.rs`) 의 partial-split 루프 (line 1077–1093) 가 문단 *내부* `line.vertical_pos == 0` 신호를 인식하지 않음. 문단 *간* vpos-reset 만 `next_will_vpos_reset` (line 444) 으로 처리.
+
+`paragraph_layout.rs:1733` 의 주석에서 한계 명시:
+> *"vpos-reset 미지원으로 paragraph 가 col_bottom 너머에 layout 될 수 있는데…"*
+
+## 3. 정정 (A 안 — 가장 보수적)
+
+`TypesetEngine::typeset_paragraph` 의 partial-split 루프 (`src/renderer/typeset.rs:1077-1093`) 의 inner fit 루프에 vpos-reset forced break 검출을 추가.
+
+```rust
+for li in cursor_line..line_count {
+    // [Task #619] 다단 paragraph 내 vpos-reset 강제 분리.
+    // line_segs[li].vertical_pos == 0 (li>0) 은 HWP 가 해당 line 을
+    // 다음 단/페이지 최상단에 배치하도록 인코딩한 신호.
+    // 다단 한정 적용 — 단일 단은 partial-table split 회귀 (issue #418) 차단 위해 미적용.
+    if st.col_count > 1
+        && li > cursor_line
+        && para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)
+    {
+        break;
+    }
+    let content_h = fmt.line_heights[li];
+    if cumulative + content_h > avail_for_lines && li > cursor_line {
+        break;
+    }
+    cumulative += fmt.line_advance(li);
+    end_line = li + 1;
+}
+```
+
+**변경 LOC**: +9 / -0.
+
+### 3.1 적용 범위
+
+| 조건 | 의도 |
+|------|------|
+| `st.col_count > 1` | 다단 섹션 한정. 단일 단은 partial-table split (issue #418) 회귀 차단 |
+| `li > cursor_line` | 세그먼트 첫 줄 제외 (forced break 후 cursor 가 vpos-reset line 부터 시작 시 무한 루프 방지) |
+| `vertical_pos == 0` | HWP vpos-reset 신호 |
+
+## 4. 검증
+
+### 4.1 대상 파일 정합
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| 페이지 8 단 1 pi=181 | `lines=0..9` | **`lines=0..8`** ✓ |
+| 페이지 9 단 0 pi=181 | `lines=9..13` | **`lines=8..13`** ✓ |
+| LAYOUT_OVERFLOW_DRAW (텍스트) | 17.1 px | **사라짐** ✓ |
+| LAYOUT_OVERFLOW (PartialParagraph bbox) | 26.6 px | 2.4 px (잔여, 별도 이슈 후보) |
+| LAYOUT_OVERFLOW (Shape bbox) | 26.6 px | 2.4 px |
+
+### 4.2 한컴 PDF 정합
+
+| 환경 | pi=181 페이지 8 줄 수 | 페이지 9 첫 줄 |
+|------|----------------------|---------------|
+| 한컴 **2010** PDF | 5줄 (line 0..5) | "인도하고…" |
+| 한컴 **2020** PDF | **8줄 (line 0..8)** | "토속 신앙의…" |
+| **변경 후 rhwp** | **8줄 (line 0..8)** ✓ | "토속 신앙의…" ✓ |
+
+→ 변경 후 결과는 **한컴 2020 PDF 와 정확히 일치**. HWP `vpos-reset` 인코딩 의도 = 한컴 2020 분포.
+
+메모리 노트 `feedback_pdf_not_authoritative` 룰 ("PDF 200dpi 는 보조 ref. 한컴 2010/2020 환경 차이 함께 점검") 정합.
+
+### 4.3 회귀 검증
+
+- `cargo test --release --lib` 통과.
+- `cargo clippy --release --all-targets -- -D warnings` 통과 (신규 warning 0).
+- 회귀 가드 샘플 10개 (HEAD~1 빌드 vs 변경 후 빌드 자동 비교):
+
+| 샘플 | LAYOUT_OVERFLOW (전/후) | 페이지 분포 |
+|------|------------------------|-------------|
+| `exam_eng.hwp` (Task #470 가드) | 3 / 3 동일 | 동일 |
+| `exam_kor.hwp` (issue #418 가드) | 1 / 1 동일 | 동일 |
+| `exam_science.hwp` (Task #568 가드) | 1 / 1 동일 | 동일 |
+| `exam_math.hwp` | 0 / 0 동일 | 동일 |
+| `exam_social.hwp` | 0 / 0 동일 | 동일 |
+| `hwp-multi-001.hwp` (Task #470 가드) | 1 / 1 동일 | 동일 |
+| `hwp-multi-002.hwp` | 0 / 0 동일 | 동일 |
+| `k-water-rfp.hwp` (Task #361 가드) | 2 / 2 동일 | 동일 |
+| `kps-ai.hwp` (Task #362 가드) | 7 / 7 동일 | 동일 |
+| `aift.hwp` (77p 다단) | 8 / 8 동일 | 동일 |
+
+→ **모든 회귀 가드 샘플의 overflow + 페이지 분포 변경 전후 완전 동일**.
+
+## 5. 잔여 사항
+
+- **PartialParagraph/Shape bbox 2.4 px overflow**: 텍스트 글리프는 단 안 (`LAYOUT_OVERFLOW_DRAW` 미발생). bbox 가 line_spacing trail 까지 포함하는 기하학적 잔여. 본 Task 핵심 증상과 무관 — 별도 이슈 분리 후보.
+
+## 6. 메모리 정합
+
+- `feedback_pr_target_devel` — PR base 는 `devel`. main 은 릴리즈 전용
+- `feedback_per_task_pr_branch` — 각 PR 은 별도 fork branch (`planet6897:pr-task619`)
+- `feedback_pdf_not_authoritative` — 한컴 2010 vs 2020 환경 차이 함께 점검 (본 정정은 2020 정합 방향)
+- `feedback_essential_fix_regression_risk` — 다단 한정 + 광범위 회귀 가드 검증
+- `feedback_rule_not_heuristic` — HWP 인코딩 신호 (vpos-reset) 존중 단일 룰. 분기/허용오차 없음
+
+## 7. 변경 파일 목록
+
+| 파일 | LOC |
+|------|-----|
+| `src/renderer/typeset.rs` | +9 |
+| `mydocs/plans/task_m100_619.md` | 신규 |
+| `mydocs/plans/task_m100_619_impl.md` | 신규 |
+| `mydocs/working/task_m100_619_stage1.md` | 신규 |
+| `mydocs/working/task_m100_619_stage2.md` | 신규 |
+| `mydocs/working/task_m100_619_stage3.md` | 신규 |
+| `mydocs/report/task_m100_619_report.md` | 신규 |
+| `mydocs/orders/20260506.md` | 신규 |

--- a/mydocs/working/task_m100_619_stage1.md
+++ b/mydocs/working/task_m100_619_stage1.md
@@ -1,0 +1,103 @@
+# Stage 1 단계별 보고서 — Task #619
+
+TypesetEngine partial-split 에 다단 vpos-reset forced break 추가
+
+- 브랜치: `local/task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+
+## 1. 변경 내용
+
+`src/renderer/typeset.rs::typeset_paragraph` 의 partial-split 루프 (line 1077–1093) 의 inner fit 루프에 vpos-reset forced break 검출을 추가했다.
+
+```rust
+for li in cursor_line..line_count {
+    // [Task #619] 다단 paragraph 내 vpos-reset 강제 분리.
+    // line_segs[li].vertical_pos == 0 (li>0) 은 HWP 가 해당 line 을
+    // 다음 단/페이지 최상단에 배치하도록 인코딩한 신호.
+    // 다단 한정 적용 — 단일 단은 partial-table split 회귀 (issue #418) 차단 위해 미적용.
+    if st.col_count > 1
+        && li > cursor_line
+        && para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)
+    {
+        break;
+    }
+    let content_h = fmt.line_heights[li];
+    if cumulative + content_h > avail_for_lines && li > cursor_line {
+        break;
+    }
+    cumulative += fmt.line_advance(li);
+    end_line = li + 1;
+}
+```
+
+## 2. 적용 범위 및 회귀 차단 설계
+
+| 조건 | 의도 |
+|------|------|
+| `st.col_count > 1` | 다단 섹션 한정. 단일 단은 partial-table split (issue #418) 회귀 차단 |
+| `li > cursor_line` | 세그먼트 첫 줄 제외. forced break 후 cursor 가 vpos-reset line 부터 시작할 때 즉시 break 되어 무한 루프되는 것 방지 |
+| `vertical_pos == 0` | HWP vpos-reset 신호. 다음 단/페이지 최상단 배치 의도 |
+
+## 3. 빌드 검증
+
+```
+$ cargo build --release
+   Compiling rhwp v0.7.9 (/Users/planet/rhwp)
+    Finished `release` profile [optimized] target(s) in 1m 05s
+```
+
+## 4. 즉시 검증 — 대상 파일
+
+### 4.1 페이지네이션 결과 변화
+
+```
+$ rhwp dump-pages samples/21_언어_기출_편집가능본.hwp -p 7
+변경 전: 단 1: PartialParagraph pi=181 lines=0..9  vpos=77316..1816 [vpos-reset@line8]
+변경 후: 단 1: PartialParagraph pi=181 lines=0..8  vpos=77316..0    [vpos-reset@line8]
+```
+
+```
+$ rhwp dump-pages samples/21_언어_기출_편집가능본.hwp -p 8
+변경 전: 단 0: PartialParagraph pi=181 lines=9..13 vpos=1816..7264
+변경 후: 단 0: PartialParagraph pi=181 lines=8..13 vpos=0..7264 [vpos-reset@line8]
+```
+
+line 8 (vpos-reset 위치) 이 페이지 9 단 0 으로 이동.
+
+### 4.2 LAYOUT_OVERFLOW_DRAW 제거
+
+```
+$ rhwp export-svg samples/21_언어_기출_편집가능본.hwp -p 7
+변경 전:
+  LAYOUT_OVERFLOW_DRAW: section=0 pi=181 line=8 y=1453.2 col_bottom=1436.2 overflow=17.1px
+  LAYOUT_OVERFLOW: page=7, col=1, para=181, type=PartialParagraph, overflow=26.6px
+  LAYOUT_OVERFLOW: page=7, col=1, para=181, type=Shape,            overflow=26.6px
+
+변경 후:
+  (LAYOUT_OVERFLOW_DRAW 미발생)
+  LAYOUT_OVERFLOW: page=7, col=1, para=181, type=PartialParagraph, overflow=2.4px
+  LAYOUT_OVERFLOW: page=7, col=1, para=181, type=Shape,            overflow=2.4px
+```
+
+- **`LAYOUT_OVERFLOW_DRAW`** (실제 텍스트 글리프 그리기 기준 오버플로) — **사라짐**. 본 Task 의 핵심 증상 "반쯤 안 보임" 해결.
+- **`LAYOUT_OVERFLOW`** (PartialParagraph/Shape bbox 기준) — 26.6px → 2.4px 로 크게 감소. 잔여 2.4px 는 line_spacing trail 까지 포함한 bbox 기하학 차이로, 텍스트 글리프 자체는 단 안에 들어감 (별도 검토 사항).
+
+### 4.3 페이지 9 첫 줄 검증
+
+```
+$ grep -oE 'translate\([0-9]+\.[0-9]+,2[0-9][0-9]\.[0-9]+\)' output/svg/p21_after/21_언어_기출_편집가능본_009.svg | sort -u | head -5
+translate(128.53333333333336,222.2266666666667)  ← 페이지 9 단 0 첫 줄 (line 8)
+translate(128.53333333333336,246.44000000000003)
+translate(128.53333333333336,270.6533333333333)
+translate(128.53333333333336,294.8666666666666)
+```
+
+페이지 9 본문 영역 상단 (col_top=209.8, baseline 반영 ~222) 에 line 8 텍스트가 정확히 배치됨.
+
+## 5. 잔여 사항
+
+- **PartialParagraph/Shape bbox 잔여 2.4px**: 본 Task 범위 외. 별도 이슈 분리 후보. Stage 3 회귀 검증에서 동일 패턴이 다른 샘플에도 있는지 확인.
+
+## 6. 다음 단계
+
+Stage 2 (한컴 PDF 비교 + 전체 회귀 가드 샘플 점검) 진행 승인 요청.

--- a/mydocs/working/task_m100_619_stage2.md
+++ b/mydocs/working/task_m100_619_stage2.md
@@ -1,0 +1,71 @@
+# Stage 2 단계별 보고서 — Task #619
+
+대상 파일 수정 검증 + 한컴 PDF 비교
+
+- 브랜치: `local/task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+
+## 1. 대상 파일 검증 — `samples/21_언어_기출_편집가능본.hwp`
+
+### 1.1 페이지네이션 변화
+
+```
+$ rhwp dump-pages samples/21_언어_기출_편집가능본.hwp -p 7
+변경 전: 단 1: PartialParagraph pi=181 lines=0..9  vpos=77316..1816 [vpos-reset@line8]
+변경 후: 단 1: PartialParagraph pi=181 lines=0..8  vpos=77316..0    [vpos-reset@line8]
+
+$ rhwp dump-pages samples/21_언어_기출_편집가능본.hwp -p 8
+변경 전: 단 0: PartialParagraph pi=181 lines=9..13 vpos=1816..7264
+변경 후: 단 0: PartialParagraph pi=181 lines=8..13 vpos=0..7264 [vpos-reset@line8]
+```
+
+### 1.2 LAYOUT_OVERFLOW_DRAW 제거
+
+```
+변경 전: LAYOUT_OVERFLOW_DRAW: pi=181 line=8 overflow=17.1px  ← 텍스트 글리프 자체 오버플로
+         LAYOUT_OVERFLOW (PartialParagraph) overflow=26.6px
+         LAYOUT_OVERFLOW (Shape)            overflow=26.6px
+
+변경 후: (LAYOUT_OVERFLOW_DRAW 미발생)                          ← 핵심 증상 해결
+         LAYOUT_OVERFLOW (PartialParagraph) overflow=2.4px    ← bbox 잔여 (텍스트는 단 안)
+         LAYOUT_OVERFLOW (Shape)            overflow=2.4px
+```
+
+### 1.3 페이지 9 첫 줄 정상 배치
+
+```
+$ grep 'translate(128.5..,2[0-9][0-9]\.\.)' output/svg/p21_after/21_언어_기출_편집가능본_009.svg
+translate(128.5,222.2)  ← 페이지 9 단 0 첫 줄 (line 8) — col_top=209.8 + baseline ≈ 222
+translate(128.5,246.4)
+translate(128.5,270.6)
+```
+
+페이지 9 단 0 첫 줄에 line 8 텍스트가 정상 배치됨.
+
+## 2. 한컴 PDF 비교
+
+`pdftotext -layout` 으로 한컴 2010 / 2020 PDF 페이지 8/9 텍스트 추출 후 비교.
+
+### 2.1 페이지 8 단 1 의 pi=181 부분 줄 수
+
+| 환경 | pi=181 줄 수 | 페이지 9 첫 줄 |
+|------|--------------|---------------|
+| 한컴 **2010** PDF | 5줄 (line 0..5) | "인도하고…" (line 5) |
+| 한컴 **2020** PDF | **8줄 (line 0..8)** | "토속 신앙의 영향을…" (line 8) |
+| **변경 전 (rhwp)** | 9줄 (line 0..9, **overflow 17.1px**) | "로 쉽게…" (line 9) |
+| **변경 후 (rhwp)** | **8줄 (line 0..8)** ✓ | "토속 신앙의 영향을…" (line 8) ✓ |
+
+### 2.2 결론
+
+- 변경 후 결과는 **한컴 2020 PDF 와 정확히 일치**.
+- HWP 파일의 `pi=181 line_segs[8].vertical_pos = 0` 인코딩 의도는 한컴 2020 의 분포와 동일하다 (line 8 부터 다음 단 시작).
+- 한컴 2010 PDF 는 다른 알고리즘 (line 5 에서 분할) 을 사용하지만, **HWP 인코딩 신호 (vpos-reset) 를 존중하는 본 변경의 방향은 한컴 2020 정합성 향상**.
+- 메모리 노트 `feedback_pdf_not_authoritative.md` 룰 ("PDF 200dpi 는 보조 ref. 한컴 2010/2020 환경 차이 함께 점검") 에 따라 두 환경 모두 점검 완료.
+
+## 3. 잔여 사항
+
+- **PartialParagraph/Shape bbox 2.4px overflow**: 텍스트 글리프는 단 안 (LAYOUT_OVERFLOW_DRAW 미발생). bbox 가 line_spacing trail 까지 포함하는 기하학적 잔여. 본 Task 의 핵심 증상과 무관 — 별도 이슈로 분리 후보.
+
+## 4. 다음 단계
+
+Stage 3 (회귀 검증 — cargo test, clippy, 다단 가드 샘플) 진행.

--- a/mydocs/working/task_m100_619_stage3.md
+++ b/mydocs/working/task_m100_619_stage3.md
@@ -1,0 +1,84 @@
+# Stage 3 단계별 보고서 — Task #619
+
+회귀 검증
+
+- 브랜치: `local/task619`
+- 이슈: https://github.com/edwardkim/rhwp/issues/619
+
+## 1. cargo test / clippy
+
+```
+$ cargo test --release --lib
+... (전체 통과)
+exit code 0
+
+$ cargo clippy --release --all-targets -- -D warnings
+... (warning 없음)
+exit code 0
+```
+
+## 2. 회귀 가드 샘플 SVG 비교
+
+변경 전 (HEAD~1 의 typeset.rs 만 빌드) vs 변경 후 (`local/task619`) 의 결과를 자동 비교.
+
+### 2.1 LAYOUT_OVERFLOW 메시지 비교
+
+```
+$ for sample in 가드샘플들; do diff before/after_${sample}_overflow.txt; done
+```
+
+| 샘플 | overflow 메시지 (before / after) | 결과 |
+|------|--------------------------------|------|
+| `exam_eng.hwp` (Task #470 가드) | 3 / 3 | 동일 ✓ |
+| `exam_kor.hwp` (issue #418 가드) | 1 / 1 | 동일 ✓ |
+| `exam_science.hwp` (Task #568 가드) | 1 / 1 | 동일 ✓ |
+| `exam_math.hwp` | 0 / 0 | 동일 ✓ |
+| `exam_social.hwp` | 0 / 0 | 동일 ✓ |
+| `hwp-multi-001.hwp` (Task #470 가드) | 1 / 1 | 동일 ✓ |
+| `hwp-multi-002.hwp` | 0 / 0 | 동일 ✓ |
+| `k-water-rfp.hwp` (Task #361 가드) | 2 / 2 | 동일 ✓ |
+| `kps-ai.hwp` (Task #362 가드) | 7 / 7 | 동일 ✓ |
+| `aift.hwp` (77p 다단 샘플) | 8 / 8 | 동일 ✓ |
+
+→ **모든 회귀 가드 샘플의 overflow 메시지가 변경 전후 완전히 동일**. 본 변경에 의한 새로운 overflow 발생 없음.
+
+### 2.2 페이지 분포 비교
+
+```
+$ for sample in 가드샘플들; do diff before/after_${sample}_pages.txt; done
+```
+
+| 샘플 | 페이지/단 분포 |
+|------|------|
+| `exam_eng.hwp` | 동일 ✓ |
+| `exam_kor.hwp` | 동일 ✓ |
+| `exam_science.hwp` | 동일 ✓ |
+| `exam_math.hwp` | 동일 ✓ |
+| `exam_social.hwp` | 동일 ✓ |
+| `hwp-multi-001.hwp` | 동일 ✓ |
+| `hwp-multi-002.hwp` | 동일 ✓ |
+| `k-water-rfp.hwp` | 동일 ✓ |
+| `kps-ai.hwp` | 동일 ✓ |
+
+→ **모든 회귀 가드 샘플의 페이지/단 분포 완전 동일**. 본 변경은 다단 paragraph 내부 vpos-reset (line>0 + vertical_pos==0) 케이스 한정으로 동작하며, 가드 샘플들에는 해당 패턴이 없거나 영향 없음.
+
+### 2.3 광역 다단 샘플
+
+| 샘플 | pages | overflow |
+|------|-------|----------|
+| `2010-01-06.hwp` | 6 | 0 |
+| `biz_plan.hwp` | 6 | 0 |
+| `atop-equation-01.hwp` | 1 | 0 |
+| `aift.hwp` | 77 | 8 (변경 전과 동일) |
+
+추가 회귀 없음.
+
+## 3. 결론
+
+- cargo test / clippy 통과.
+- 회귀 가드 샘플 10개 + 광역 샘플 4개 모두 변경 전후 동일한 결과.
+- 본 변경의 영향 범위는 **다단 + 문단 내부 line.vertical_pos==0 케이스** 한정으로 검증됨.
+
+## 4. 다음 단계
+
+Stage 4 (최종 결과 보고서 + orders 갱신 + 머지 준비) 진행.

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -1079,6 +1079,16 @@ impl TypesetEngine {
             let mut cumulative = 0.0;
             let mut end_line = cursor_line;
             for li in cursor_line..line_count {
+                // [Task #619] 다단 paragraph 내 vpos-reset 강제 분리.
+                // line_segs[li].vertical_pos == 0 (li>0) 은 HWP 가 해당 line 을
+                // 다음 단/페이지 최상단에 배치하도록 인코딩한 신호.
+                // 다단 한정 적용 — 단일 단은 partial-table split 회귀 (issue #418) 차단 위해 미적용.
+                if st.col_count > 1
+                    && li > cursor_line
+                    && para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)
+                {
+                    break;
+                }
                 let content_h = fmt.line_heights[li];
                 if cumulative + content_h > avail_for_lines && li > cursor_line {
                     break;


### PR DESCRIPTION
## Summary

- 다단 paragraph 내부 `line.vertical_pos == 0` (vpos-reset) 신호를 `TypesetEngine` partial-split 루프가 인식하도록 정정
- `samples/21_언어_기출_편집가능본.hwp` 페이지 8 우측 단 마지막 줄(pi=181 line 8) 17.1 px overflow 해소
- 한컴 2020 PDF 와 정확히 일치 (8줄 분할)

closes #619

## Background

`pi=181 line_segs[8].vertical_pos = 0` (line>0 인데 vpos=0) 은 HWP 가 line 8 을 다음 단/페이지 최상단에서 시작하도록 인코딩한 vpos-reset 신호. 활성 `TypesetEngine` 의 partial-split 루프가 이를 무시 → line 8 이 col_bottom 너머에 그려짐.

`paragraph_layout.rs:1733` 주석이 한계를 명시:
> *"vpos-reset 미지원으로 paragraph 가 col_bottom 너머에 layout 될 수 있는데…"*

## Change

`TypesetEngine::typeset_paragraph` partial-split 루프 (`src/renderer/typeset.rs:1077-1093`) 의 inner fit 루프에 vpos-reset forced break 추가.

```rust
for li in cursor_line..line_count {
    // [Task #619] 다단 paragraph 내 vpos-reset 강제 분리.
    if st.col_count > 1
        && li > cursor_line
        && para.line_segs.get(li).map(|s| s.vertical_pos == 0).unwrap_or(false)
    {
        break;
    }
    // ... 기존 fit 로직
}
```

| 조건 | 의도 |
|------|------|
| `st.col_count > 1` | 다단 한정. 단일 단의 partial-table split (issue #418) 회귀 차단 |
| `li > cursor_line` | 세그먼트 첫 줄 제외 (forced break 후 재진입 시 무한 루프 방지) |
| `vertical_pos == 0` | HWP vpos-reset 신호 |

## Verification

### 대상 파일

| 항목 | 변경 전 | 변경 후 |
|------|---------|---------|
| 페이지 8 단 1 pi=181 | `lines=0..9` | `lines=0..8` |
| 페이지 9 단 0 pi=181 | `lines=9..13` | `lines=8..13` |
| LAYOUT_OVERFLOW_DRAW (텍스트) | 17.1 px | 사라짐 |

### 한컴 2010 / 2020 PDF 비교

| 환경 | pi=181 페이지 8 줄 수 |
|------|----------------------|
| 한컴 2010 | 5줄 |
| **한컴 2020** | **8줄** |
| 변경 후 rhwp | **8줄** ✓ (한컴 2020 정확 일치) |

HWP `vpos-reset` 인코딩 의도 = 한컴 2020 분포.

### 회귀 가드 샘플 (HEAD~1 vs 변경 후 자동 비교)

| 샘플 | LAYOUT_OVERFLOW (전/후) | 페이지 분포 |
|------|------------------------|-------------|
| `exam_eng.hwp` (Task #470) | 3 / 3 동일 | 동일 |
| `exam_kor.hwp` (issue #418) | 1 / 1 동일 | 동일 |
| `exam_science.hwp` (Task #568) | 1 / 1 동일 | 동일 |
| `exam_math.hwp` | 0 / 0 동일 | 동일 |
| `exam_social.hwp` | 0 / 0 동일 | 동일 |
| `hwp-multi-001.hwp` (Task #470) | 1 / 1 동일 | 동일 |
| `hwp-multi-002.hwp` | 0 / 0 동일 | 동일 |
| `k-water-rfp.hwp` (Task #361) | 2 / 2 동일 | 동일 |
| `kps-ai.hwp` (Task #362) | 7 / 7 동일 | 동일 |
| `aift.hwp` (77p) | 8 / 8 동일 | 동일 |

→ 모든 회귀 가드 샘플의 overflow + 페이지 분포 변경 전후 완전 동일.

## Test plan

- [x] `cargo build --release` 통과
- [x] `cargo test --release --lib` 통과
- [x] `cargo clippy --release --all-targets -- -D warnings` 통과
- [x] 대상 파일 (`samples/21_언어_기출_편집가능본.hwp`) 페이지 8 단 1 lines=0..8, 페이지 9 단 0 lines=8..13 확인
- [x] 한컴 2020 PDF 분포 일치
- [x] 회귀 가드 샘플 10개 byte-equivalent 확인

## Remaining

PartialParagraph/Shape bbox 잔여 2.4 px overflow (텍스트 자체는 단 안). 별도 이슈 분리 후보.

## Files changed

- `src/renderer/typeset.rs` (+9 LOC)
- `mydocs/{plans,working,report,orders}/` (신규 보고서/계획서)