### PR TITLE
feat(rhwp-studio): 문서 비교·이력(compare + history) 및 diff-engine 정합

### DIFF
--- a/rhwp-studio/index.html
+++ b/rhwp-studio/index.html
@@ -43,6 +43,8 @@
           <div class="md-item disabled" data-cmd="edit:select-all"><span class="md-icon icon-select-all"></span><span class="md-label">모두 선택</span><span class="md-shortcut">Ctrl+A</span></div>
           <div class="md-sep"></div>
           <div class="md-item" data-cmd="edit:find"><span class="md-icon icon-find"></span><span class="md-label">찾기(F)</span><span class="md-shortcut">Ctrl+F</span></div>
+          <div class="md-item" data-cmd="edit:compare-documents"><span class="md-icon"></span><span class="md-label">문서 비교</span><span class="md-shortcut">Alt+Shift+V</span></div>
+          <div class="md-item" data-cmd="edit:document-history"><span class="md-icon"></span><span class="md-label">문서 이력 관리</span><span class="md-shortcut">Ctrl+Shift+H</span></div>
           <div class="md-item" data-cmd="edit:find-replace"><span class="md-icon icon-find-replace"></span><span class="md-label">찾아 바꾸기(E)</span><span class="md-shortcut">Ctrl+F2</span></div>
           <div class="md-item" data-cmd="edit:find-again"><span class="md-icon"></span><span class="md-label">다시 찾기(X)</span><span class="md-shortcut">Ctrl+L</span></div>
           <div class="md-item" data-cmd="edit:goto"><span class="md-icon"></span><span class="md-label">찾아가기(G)</span><span class="md-shortcut">Alt+G</span></div>
@@ -434,12 +436,16 @@
           <button class="tb-btn tb-split-arrow" title="찾기 메뉴"><span class="tb-arrow-icon">▾</span></button>
           <div class="tb-split-menu">
             <div class="tb-split-item" data-cmd="edit:find">찾기(F) <span class="tb-split-shortcut">Ctrl+F</span></div>
+            <div class="tb-split-item" data-cmd="edit:compare-documents">문서 비교 <span class="tb-split-shortcut">Alt+Shift+V</span></div>
+            <div class="tb-split-item" data-cmd="edit:document-history">문서 이력 관리 <span class="tb-split-shortcut">Ctrl+Shift+H</span></div>
             <div class="tb-split-item" data-cmd="edit:find-replace">찾아 바꾸기(E) <span class="tb-split-shortcut">Ctrl+F2</span></div>
             <div class="tb-split-item" data-cmd="edit:find-again">다시 찾기(X) <span class="tb-split-shortcut">Ctrl+L</span></div>
             <div class="tb-split-sep"></div>
             <div class="tb-split-item" data-cmd="edit:goto">찾아가기(G) <span class="tb-split-shortcut">Alt+G</span></div>
           </div>
         </div>
+        <button class="tb-btn" data-cmd="edit:document-history" title="문서 이력 관리 (Ctrl+Shift+H)"><span class="tb-icon-text">⧉</span><span class="tb-label">이력<br/>관리</span></button>
+        <button class="tb-btn" data-cmd="edit:compare-documents" title="문서 비교 (Alt+Shift+V)"><span class="tb-icon-text">≍</span><span class="tb-label">문서<br/>비교</span></button>
       </div>
       <!-- 머리말/꼬리말 편집 모드 전용 도구상자 (숨김) -->
       <div class="tb-group tb-headerfooter-group" style="display:none">

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-studio",
-  "version": "0.7.8",
+  "version": "0.7.9",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.7.8",
+      "version": "0.7.9",
       "license": "MIT",
       "devDependencies": {
         "@types/chrome": "^0.1.40",

--- a/rhwp-studio/src/command/commands/edit.ts
+++ b/rhwp-studio/src/command/commands/edit.ts
@@ -2,9 +2,18 @@ import type { CommandDef } from '../types';
 import { FieldEditDialog } from '@/ui/field-edit-dialog';
 import { FindDialog } from '@/ui/find-dialog';
 import { GotoDialog } from '@/ui/goto-dialog';
+import { HistoryDialog } from '@/ui/history-dialog';
+import { CompareDialog } from '@/ui/compare-dialog';
+import { CompareSessionStore } from '@/compare/session';
 
 /** 검색 대화상자 싱글톤 — 열려 있으면 재사용 */
 let findDialogInstance: FindDialog | null = null;
+/** 싱글톤: 문서 이력 관리 대화상자 */
+let historyDialogInstance: HistoryDialog | null = null;
+/** 싱글톤: 두 파일 문서 비교 대화상자 */
+let compareDialogInstance: CompareDialog | null = null;
+/** 비교/이력 공용 세션 스토어 */
+let compareSessionStore: CompareSessionStore | null = null;
 
 export const editCommands: CommandDef[] = [
   {
@@ -149,6 +158,38 @@ export const editCommands: CommandDef[] = [
           (ih as any).updateCaret?.();
         }
       }
+    },
+  },
+  {
+    id: 'edit:compare-documents',
+    label: '문서 비교',
+    shortcutLabel: 'Alt+Shift+V',
+    canExecute: () => true,
+    execute(services) {
+      if (!compareSessionStore) {
+        compareSessionStore = new CompareSessionStore(services.eventBus);
+      }
+      if (historyDialogInstance?.isOpen()) historyDialogInstance.hide();
+      if (compareDialogInstance && compareDialogInstance.isOpen()) return;
+      compareDialogInstance = new CompareDialog(services, compareSessionStore);
+      compareDialogInstance.show();
+    },
+  },
+  {
+    id: 'edit:document-history',
+    label: '문서 이력 관리',
+    shortcutLabel: 'Ctrl+Shift+H',
+    canExecute: () => true,
+    execute(services) {
+      if (!compareSessionStore) {
+        compareSessionStore = new CompareSessionStore(services.eventBus);
+      }
+      if (compareDialogInstance?.isOpen()) compareDialogInstance.hide();
+      if (historyDialogInstance && historyDialogInstance.isOpen()) {
+        return;
+      }
+      historyDialogInstance = new HistoryDialog(services, compareSessionStore);
+      historyDialogInstance.show();
     },
   },
   {

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -47,6 +47,8 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   [{ key: 'f', ctrl: true }, 'edit:find'],
   [{ key: 'f2', ctrl: true }, 'edit:find-replace'],
   [{ key: 'l', ctrl: true }, 'edit:find-again'],
+  [{ key: 'v', alt: true, shift: true }, 'edit:compare-documents'],
+  [{ key: 'h', ctrl: true, shift: true }, 'edit:document-history'],
   [{ key: 'g', alt: true }, 'edit:goto'],
   [{ key: 'ㅎ', alt: true }, 'edit:goto'],
 

--- a/rhwp-studio/src/compare/compare-debug.ts
+++ b/rhwp-studio/src/compare/compare-debug.ts
@@ -1,0 +1,28 @@
+/**
+ * 문서 비교 디버그 (밀림 / ID / 폴백 원인 추적).
+ *
+ * 켜는 방법(택일):
+ * - `localStorage.setItem('rhwp:compareDebug', '1')` 후 페이지 새로고침
+ * - URL에 `?compareDebug=1`
+ * - 콘솔에서 `globalThis.__RHWP_COMPARE_DEBUG__ = true`
+ */
+
+export function isCompareDebugEnabled(): boolean {
+  try {
+    if (typeof globalThis !== 'undefined' && (globalThis as unknown as { __RHWP_COMPARE_DEBUG__?: boolean }).__RHWP_COMPARE_DEBUG__) {
+      return true;
+    }
+    if (typeof window !== 'undefined') {
+      if (new URLSearchParams(window.location.search).get('compareDebug') === '1') return true;
+      if (window.localStorage?.getItem('rhwp:compareDebug') === '1') return true;
+    }
+  } catch {
+    /* localStorage 접근 불가 */
+  }
+  return false;
+}
+
+export function compareDbg(...args: unknown[]): void {
+  if (!isCompareDebugEnabled()) return;
+  console.log('[rhwp:compare]', ...args);
+}

--- a/rhwp-studio/src/compare/diff-engine-readme.md
+++ b/rhwp-studio/src/compare/diff-engine-readme.md
@@ -1,0 +1,471 @@
+# diff-engine.ts 구조 설명
+
+이 문서는 `diff-engine.ts`의 **현재 구현**을 기준으로, **이력 관리(동일 세션·stable_id)** 와 **문서 비교(외부 파일·다른 혈통)** 경로를 나누어 설명합니다.
+
+**줄 번호**는 모두 `rhwp/rhwp-studio/src/compare/diff-engine.ts` 기준(함수 **선언이 시작되는 줄**). 편집 후에는 `rg "^function |^export "` 등으로 다시 맞추면 됩니다.
+
+---
+
+## 목차
+
+0. [함수·라인 색인](#0-함수라인-색인)
+1. [한눈에 보기](#1-한눈에-보기)
+2. [이력 관리 경로](#2-이력-관리-경로)
+3. [문서 비교(alignment) 경로](#3-문서-비교alignment-경로)
+4. [양 경로가 공유하는 부분](#4-양-경로가-공유하는-부분)
+5. [튜닝 상수와 의존 관계](#5-튜닝-상수와-의존-관계)
+6. [UI에서의 호출](#6-ui에서의-호출)
+7. [디버그 로그 ①②③](#7-디버그-로그-①②③)
+8. [문서 유지보수 시 구상](#8-문서-유지보수-시-구상)
+9. [왜 이 로직이 추가됐는가](#9-왜-이-로직이-추가됐는가-문제--대응)
+
+---
+
+## 0. 함수·라인 색인
+
+### 0.1 공개 API
+
+| 함수 | 줄 |
+|------|-----:|
+| `buildSnapshotFromBytes` | 1021 |
+| `buildSnapshotFromWasm` | 1033 |
+| `compareSnapshots` | 2392 |
+| `compareDocuments` | 2495 |
+
+### 0.2 스냅샷·문단·컨트롤 수집
+
+| 함수 | 줄 |
+|------|-----:|
+| `fillSnapshotFromWasm` | 707 |
+| `compactParaShapeForAnchor` | 688 |
+| `resolveAnchorTuning` | 156 |
+| `resolvePerformanceTuning` | 166 |
+| `shannonEntropy` | 173 |
+| `isAnchorTextQualityOk` | 190 |
+| `normalizeText` | 385 |
+| `simpleHash` | 391 |
+| `simpleHashBytes` | 401 |
+| `buildTableSummary` | 474 |
+| `mapControlKind` | 423 |
+| `canonicalControlKey` | 435 |
+| `controlSnapshotQuality` | 448 |
+
+### 0.3 컨트롤 diff 세부
+
+| 함수 | 줄 |
+|------|-----:|
+| `buildGranularControlDiffs` | 609 |
+| `extractControlIndexFromKey` | 560 |
+| `parseSummaryKV` | 567 |
+| `countChangedCellsByHash` | 580 |
+
+### 0.4 이력(identity)·전략·후처리
+
+| 함수 | 줄 |
+|------|-----:|
+| `buildStableIdMap` | 1046 |
+| `buildIdentityTextDiffs` | 1069 |
+| `resolveTextCompareStrategy` | 1183 |
+| `isParagraphMoveMeta` | 1194 |
+| `suppressPureReflowMoves` | 1202 |
+| `preferRightPath` | 1276 |
+
+### 0.5 alignment — 앵커·정렬
+
+| 함수 | 줄 |
+|------|-----:|
+| `buildUniqueSigPairsInSlices` | 1290 |
+| `buildAnchorPairs` | 1329 |
+| `charBigramSimilarity` | 1363 |
+| `textSimilarity` | 1377 |
+| `isNearStructure` | 1413 |
+| `isNearStructureLongPair` | 1423 |
+| `softSimilarityThresholdForPair` | 1433 |
+| `getEffectiveSimilarity` | 1441 |
+| `matchCost` | 1452 |
+| `matchSegmentWithInternalAnchors` | 1467 |
+| `matchSegment` | 1530 |
+| `matchSegmentDp` | 1580 |
+| `scorePairGreedy` | 1659 |
+| `matchWindowedGreedy` | 1675 |
+
+### 0.6 alignment — `buildTextDiffs` 보정 헬퍼
+
+| 함수 | 줄 |
+|------|-----:|
+| `isLeftParagraphSplitIntoTwoRightParas` | 1745 |
+| `shouldPromoteEmptyTextEdit` | 1767 |
+| `shouldMergeRemovedAddedAsModify` | 1830 |
+| `buildTextDiffs` | 2067 |
+
+### 0.7 컨트롤 diff 병합·쪽번호·유틸
+
+| 함수 | 줄 |
+|------|-----:|
+| `kindLabel` | 461 |
+| `mkDiffId` | 411 |
+| `extractTablePatiencePins` | 2114 |
+| `buildControlDiffs` | 2178 |
+| `pairControlsFallback` | 2252 |
+| `scoreControlFallback` | 2283 |
+| `annotateDiffSectionPages` | 2318 |
+| `myersCharDiffSummary` | 364 |
+
+### 0.8 성능 가드·타입·기본 옵션
+
+| 항목 | 줄 |
+|------|-----:|
+| `CompareRuntimeGuard` 타입 | 148 |
+| `activeRuntimeGuard` | 153 |
+| `shouldBailToGreedy` | 202 |
+| `AlignedPair` 타입 | 1264 |
+| `ControlPair` 타입 | 1270 |
+| `DEFAULT_COMPARE_OPTIONS` | 2163 |
+| `activeCompareOptions` | 2170 |
+| 튜닝 `const` 블록 시작 | 95 |
+| 문자 diff 상한 `CHAR_DIFF_*` | 130–135 |
+
+---
+
+## 1. 한눈에 보기
+
+### 1.1 파일이 하는 일
+
+- WASM/IR에서 **`CompareDocumentSnapshot`**(문단·컨트롤·메타)을 채우고,
+- 좌·우 스냅샷을 **`CompareSession`**(`diffItems` 등)으로 줄입니다.
+- **본문 텍스트** 비교는 `options.strategy`와 **stable_id 맵 구성 가능 여부**에 따라
+  - **`identity`**: `stable_id`로 1:1 매칭 (이력에 유리) — `buildIdentityTextDiffs` (**1069**)
+  - **`alignment`**: 앵커 + 구간 DP/그리디 — `buildTextDiffs` (**2067**)
+
+### 1.2 전체 플로우 (요약 다이어그램)
+
+```mermaid
+flowchart TB
+  subgraph snap [스냅샷 생성]
+    BBytes["buildSnapshotFromBytes\n별도 WASM · 1021"]
+    BWasm["buildSnapshotFromWasm\n편집기 WASM · 1033"]
+    Fill["fillSnapshotFromWasm · 707"]
+    BBytes --> Fill
+    BWasm --> Fill
+  end
+
+  subgraph cmp [compareSnapshots · 2392]
+    Strat["resolveTextCompareStrategy · 1183"]
+    Id["buildIdentityTextDiffs · 1069"]
+    Al["buildTextDiffs · 2067"]
+    Ctrl["buildControlDiffs · 2178"]
+    Sup["suppressPureReflowMoves · 1202"]
+    Ann["annotateDiffSectionPages · 2318"]
+    Strat -->|identity| Id
+    Strat -->|alignment| Al
+    Id --> Merge
+    Al --> Merge
+    Merge["병합 + kinds 필터"]
+    Ctrl --> Merge
+    Merge --> Sup
+    Sup --> Ann
+  end
+
+  Fill --> cmp
+
+  subgraph doc [compareDocuments · 2495]
+    L["buildSnapshotFromBytes 좌"]
+    R["buildSnapshotFromBytes 우"]
+    L --> cmp2["compareSnapshots"]
+    R --> cmp2
+  end
+```
+
+---
+
+## 2. 이력 관리 경로
+
+“이력”은 **같은 편집 세션·같은 WASM 인스턴스 혈통**에서 `stable_id`가 문단 정체성으로 유지된다는 전제에 가장 잘 맞습니다.
+
+### 2.1 스냅샷: `buildSnapshotFromWasm` (**1033**)
+
+편집기에 올라온 문서를 **현재 `WasmBridge` 그대로** 스냅샷합니다. 내부에서 `getDocumentInfo` 후 **`fillSnapshotFromWasm` (707)** 로 위임합니다.
+
+### 2.2 공통 채움: `fillSnapshotFromWasm` (**707**)
+
+문단마다 `text`, `normalizedText`, `signature`(정규화 텍스트·컨트롤 개수·`getParaPropertiesAt` 기반 문단모양 digest), `stableId`, `globalIndex`, `anchor`, `isAnchorCandidate` 등을 채웁니다. 앵커 후보 판별에는 **`resolveAnchorTuning` (156)**, **`isAnchorTextQualityOk` (190)** 가 쓰입니다. 컨트롤은 레이아웃·문단 순회로 수집 후 **`canonicalControlKey` (435)** / **`controlSnapshotQuality` (448)** 로 중복 제거·품질 선택합니다.
+
+### 2.3 비교 진입: `compareSnapshots` (**2392**) + 전략
+
+이미 만든 스냅샷 두 개를 비교합니다. 전략 결정은 **`resolveTextCompareStrategy` (1183)** : `strategy === 'identity'` 이고 양쪽 **`buildStableIdMap` (1046)** 가 성공할 때만 identity, 아니면 alignment 폴백.
+
+본문 diff 분기는 **`compareSnapshots` (2446–2450)** 근처: `textMode === 'identity'` 이면 `buildIdentityTextDiffs`, 아니면 `buildTextDiffs`.
+
+### 2.4 Identity 본문: `buildStableIdMap` (**1046**) + `buildIdentityTextDiffs` (**1069**)
+
+- `stableId`가 비어 있는 문단이 있으면 맵이 `null` → identity 불가.
+- 중복 `stableId`는 등장 순서로 `#` 접미 키 정규화 (**1046** 주석과 구현 참고).
+
+`buildIdentityTextDiffs`에서 합집합 키 순회로 removed / added / modified(`myersCharDiffSummary` **364**) / paragraphMeta(이동·컨트롤 수)를 생성합니다.
+
+### 2.4.1 이력(Identity) 알고리즘 상세
+
+아래 순서는 `buildIdentityTextDiffs`에서 실제로 diff를 만드는 핵심 절차입니다.
+
+1. **양쪽 stable_id 맵 구성** — `buildStableIdMap` (**1046**)  
+   - 실패 조건: 문단 하나라도 `stableId` 없음 → `null` 반환  
+   - 보정: 중복 id는 `#occurrence`를 붙여 키 충돌 방지
+2. **키 합집합 생성 + 정렬** — `buildIdentityTextDiffs` (**1069**)  
+   - `keys = set(leftKeys ∪ rightKeys)`  
+   - 정렬 기준: `(section, paragraph)` 우선 (좌/우 중 존재하는 좌표 사용)
+3. **키 단위 분기**  
+   - `l && !r` → `removed`  
+   - `!l && r` → `added`  
+   - `l && r` → 텍스트/메타 비교 단계로 진입
+4. **텍스트 변경 판정**  
+   - `l.normalizedText !== r.normalizedText`면 `modified`  
+   - 사용자용 요약은 `myersCharDiffSummary` (**364**, Hirschberg·`CHAR_DIFF_*` 상한)로 별도 생성
+5. **문단 메타 변경 판정 (`paragraphMeta` 포함 시)**  
+   - 이동: `l.signature === r.signature` && `|l.globalIndex-r.globalIndex| > MOVE_DISTANCE_THRESHOLD(3)`  
+   - 개체 수: `l.controlCount !== r.controlCount`
+
+핵심 포인트: identity 경로는 **문단 짝짓기 자체를 sid로 확정**하고, 그 후 “무엇이 바뀌었는가”만 계산합니다. 그래서 alignment보다 짝짓기 불확실성이 낮고, 계산량도 키 수에 비례하는 형태입니다.
+
+### 2.5 이동 노이즈 제거: `suppressPureReflowMoves` (**1202**)
+
+보조로 **`isParagraphMoveMeta` (1194)**. 삽입·삭제로 인덱스만 밀린 경우와 순서 변경을 구분합니다.
+
+### 2.5.1 `suppressPureReflowMoves` 판정 규칙 요약
+
+`moved`를 모두 제거하지 않고, “진짜 이동”만 남기기 위해 다음을 검사합니다.
+
+1. **공유 sid 상대순서 보존 검사**  
+   - `rankLeft[sid] === rankRight[sid]` 이면 상대순서는 유지된 상태
+2. **밀림량 설명 가능성 검사**  
+   - `delta > 0`(오른쪽에서 뒤로 밀림): 오른쪽 prefix의 “오른쪽 전용 문단 개수”와 `delta` 일치 시 reflow로 간주  
+   - `delta < 0`(앞으로 당겨짐): 왼쪽 prefix의 “왼쪽 전용 문단 개수”와 `-delta` 일치 시 reflow로 간주
+3. 위 두 조건을 만족하면 `moved` 제거, 아니면 유지
+
+즉, 이 함수는 “순서 변경” 이벤트를 **삽입/삭제에 의한 위치 재배치**와 분리하는 후처리 필터입니다.
+
+### 2.6 이력 경로 플로우 (정리)
+
+```mermaid
+sequenceDiagram
+  participant UI as history-dialog
+  participant WASM as WasmBridge
+  participant Snap as buildSnapshotFromWasm ·1033
+  participant Cmp as compareSnapshots ·2392
+  participant Id as buildIdentityTextDiffs ·1069
+
+  UI->>WASM: 편집 문서
+  UI->>Snap: 시점 A 스냅샷
+  UI->>Snap: 시점 B 스냅샷
+  UI->>Cmp: strategy identity (권장)
+  Cmp->>Cmp: resolveTextCompareStrategy ·1183
+  alt maps OK
+    Cmp->>Id: 텍스트 diff O(N) 키 순회
+  else 폴백
+    Cmp->>buildTextDiffs: alignment ·2067
+  end
+  Cmp->>buildControlDiffs: 표/도형 등 ·2178
+  Cmp->>suppressPureReflowMoves ·1202
+```
+
+---
+
+## 3. 문서 비교(alignment) 경로
+
+서로 다른 파일을 각각 **새 WASM**으로 열면 `stable_id` 세션이 달라 공유 sid가 거의 없습니다. 이 경우 **문단 정렬(alignment)** 이 본문 비교의 중심입니다.
+
+### 3.1 진입: `compareDocuments` (**2495**)
+
+좌·우 **`buildSnapshotFromBytes` (1021)** 후 **`compareSnapshots` (2392)**.
+
+호출부에서 `strategy: 'alignment'`(또는 기본)이면 **`resolveTextCompareStrategy` (1183)** 가 alignment를 고릅니다.
+
+### 3.2 단계 A — 글로벌 앵커: `buildAnchorPairs` (**1329**)
+
+`isAnchorCandidate` 및 시그니처 유일성, `ri` 단조 조건으로 앵커 쌍을 만듭니다.
+
+### 3.3 단계 B — 구간 정렬: `matchSegment` 계열
+
+| 함수 | 줄 | 역할 요약 |
+|------|-----:|-----------|
+| `matchSegment` | 1530 | 구간 진입·DP/그리디/내부앵커 분기 |
+| `matchSegmentWithInternalAnchors` | 1467 | 유일 시그니처로 쪼개 재귀 |
+| `matchSegmentDp` | 1580 | 2차원 DP, `matchCost` 치환 |
+| `matchWindowedGreedy` | 1675 | 윈도 그리디, `scorePairGreedy` |
+| `shouldBailToGreedy` | 202 | 타임버짓 시 조기 그리디 |
+
+```mermaid
+flowchart LR
+  subgraph seg [matchSegment ·1530]
+    Bail["shouldBailToGreedy ·202"]
+    Intra["matchSegmentWithInternalAnchors ·1467"]
+    DP["matchSegmentDp ·1580"]
+    Greedy["matchWindowedGreedy ·1675"]
+  end
+  Bail --> Greedy
+  Intra --> DP
+  Intra --> Greedy
+  DP --> Greedy
+```
+
+유사도·비용 체인: **`textSimilarity` (1377)** → **`getEffectiveSimilarity` (1441)** → **`matchCost` (1452)**; 구조 플래그는 **`isNearStructure` (1413)**, **`isNearStructureLongPair` (1423)**, **`softSimilarityThresholdForPair` (1433)**. 그리디 점수는 **`scorePairGreedy` (1659)**.
+
+### 3.3.1 alignment 정렬 알고리즘 상세
+
+`buildTextDiffs`(**2067**)는 먼저 앵커로 구간을 나누고, 각 구간에 아래 정렬기를 적용합니다.
+
+1. **구간 선택기** — `matchSegment` (**1530**)  
+   - base case: 좌/우 길이 0이면 남은 쪽을 added/removed 페어로 반환  
+   - 성능 가드: `shouldBailToGreedy` (**202**) true면 즉시 그리디  
+   - 셀 수 조건: `n*m`이 임계 이상이면 내부 앵커 분할 또는 그리디
+2. **내부 앵커 분할** — `matchSegmentWithInternalAnchors` (**1467**)  
+   - `buildUniqueSigPairsInSlices` (**1290**)로 구간 내 “유일 시그니처” 페어를 찾고  
+   - 경계 사이를 재귀적으로 다시 `matchSegment` 처리
+3. **DP 정렬** — `matchSegmentDp` (**1580**)  
+   - 점화식: `dp[i][j] = min(match, del, ins)`  
+   - 삭제/삽입 비용은 고정(1.05), 치환은 `matchCost` (**1452**)  
+   - 백트래킹 우선순위: `match > delete > insert` (동률 시 시각적 밀림 완화)
+4. **그리디 정렬** — `matchWindowedGreedy` (**1675**)  
+   - 오른쪽 문단 순회하며 왼쪽 후보를 윈도에서 검색  
+   - 점수: `scorePairGreedy` (**1659**)  
+   - `minScore(3.45)` 미달/동률(ambiguous)면 unmatched 처리  
+   - 단, 1위가 `isNearStructure`면 ambiguous 검사 생략
+
+핵심 포인트: alignment는 “완전 매칭”이 아니라 **구조 제약 + 비용 최소화**로 가장 그럴듯한 1:1 정렬을 만든 뒤, 이후 단계에서 라벨을 보정하는 2단계 구조입니다.
+
+### 3.4 단계 C — 정렬 스트림 → Diff: `buildTextDiffs` (**2067**)
+
+1. **`buildAnchorPairs` (1329)** 로 경계·앵커 쌍 반영 후 구간마다 **`matchSegment` (1530)**.
+2. 순차 스캔에서 **`shouldPromoteEmptyTextEdit` (1767)**, **`shouldMergeRemovedAddedAsModify` (1830)**, **`isLeftParagraphSplitIntoTwoRightParas` (1745)** 등으로 라벨 보정.
+3. 일반 `(L,R)`는 텍스트·이동·컨트롤 수 메타 (**`cleanupParagraphAlignStepsToDiffItems` 1865–2065** 메인 루프).
+
+### 3.4.1 `buildTextDiffs` 라벨 보정 규칙(우선순위)
+
+정렬 결과 `aligned[]`를 앞에서부터 읽을 때, 아래 규칙을 **위에서 아래 순서로** 적용합니다.
+
+1. **빈 문단 편집 승격** — `shouldPromoteEmptyTextEdit` (**1767**)  
+   - `(L,null)(null,R)` 또는 반대 패턴에서 구조 신호가 맞으면 “삭제+추가” 대신 1건의 `modified`
+2. **삭제+추가 병합 승격** — `shouldMergeRemovedAddedAsModify` (**1830**)  
+   - 같은 섹션/유사 거리/유사도 조건 만족 시 `modified-merged`
+3. **문단 쪼개기 라벨 교정** — `isLeftParagraphSplitIntoTwoRightParas` (**1745**)  
+   - `(null,R앞)(L,R뒤)` 패턴이면 `R앞=modified`, `R뒤=added`로 재배열
+4. **기본 라벨 처리**  
+   - 단일 `(null,R)` → `added`, `(L,null)` → `removed`, `(L,R)` → 필요 시 `modified`
+5. **메타 추가**  
+   - 서명 동일 + 이동 임계 초과 시 `paragraphMeta:moved`  
+   - `controlCount` 불일치 시 `paragraphMeta:ctrlcount`
+
+핵심 포인트: 이 단계는 정렬기를 바꾸지 않고도 사용자 체감 오류(삭제+추가 오탐, 분할 라벨 역전)를 줄이기 위한 **결과 재해석 레이어**입니다.
+
+---
+
+## 4. 양 경로가 공유하는 부분
+
+| 영역 | 함수 | 줄 | 설명 |
+|------|------|-----:|------|
+| 스냅샷 채움 | `fillSnapshotFromWasm` | 707 | 이력·문서 비교 동일 형식; `signature`에 문단모양(ps) 포함 |
+| 정규화 | `normalizeText` | 385 | 공백/대소문자 옵션 |
+| 문자 요약 | `myersCharDiffSummary` | 364 | identity `inlineTextDiff`; 접두·접미·Hirschberg·`CHAR_DIFF_*` (**130–135**) |
+| 컨트롤 diff | `buildControlDiffs` | 2178 | key 매칭 → `extractTablePatiencePins` → 폴백 |
+| 표 patience 핀 | `extractTablePatiencePins` | 2114 | 요약 키 양쪽 유일 1:1 표만 선매칭 |
+| 폴백 매칭 | `pairControlsFallback` | 2252 | |
+| 폴백 점수 | `scoreControlFallback` | 2283 | |
+| 세분 diff | `buildGranularControlDiffs` | 609 | |
+| 쪽번호 | `annotateDiffSectionPages` | 2318 | UI 표시 |
+| 성능 가드 | `shouldBailToGreedy` | 202 | `activeRuntimeGuard` **153** |
+| 이동 필터 | `suppressPureReflowMoves` | 1202 | 최종 단계 공통 |
+
+`compareSnapshots` 후반 처리 순서(같은 파일 **2452–2473** 근처): `buildControlDiffs` 병합 → `kinds` 필터 → `suppressPureReflowMoves` → `annotateDiffSectionPages` → 구역·문단 정렬.
+
+---
+
+## 5. 튜닝 상수와 의존 관계
+
+**`const` 블록**은 파일 **95**행부터 (`WINDOW_SIZE`, `ANCHOR_*`, `SEGMENT_DP_MAX`, `MATCH_*`, `NEAR_STRUCTURE_*`, `GREEDY_*`, `REMOVED_ADDED_*`, `CHAR_DIFF_*` 등).
+
+의존 요약:
+
+- **`isNearStructure` (1413)** 가 true일 때 NEAR_STRUCTURE 계열이 강하게 작동.
+- `globalIndex` 밀림으로 구조 근접이 깨지면 **`shouldMergeRemovedAddedAsModify` (1830)** 등이 보완층.
+
+---
+
+## 6. UI에서의 호출
+
+| 파일 | import | 용도 |
+|------|----------|------|
+| `src/ui/history-dialog.ts` | `buildSnapshotFromWasm`, `compareSnapshots`, `compareDocuments` | 편집 문서 스냅샷 + 이력/비교 |
+| `src/ui/compare-dialog.ts` | `compareDocuments` | 외부 두 파일 비교 |
+
+---
+
+## 7. 디버그 로그 ①②③
+
+`isCompareDebugEnabled()`일 때 **`compareSnapshots` (2392)** 내부:
+
+- **①** `stable_id` 품질·문단 헤더 — **2425–2442**
+- **②** `textMode`, 공유 sid — **2443–2452**
+- **③** alignment 시 앵커 로그 — **`buildTextDiffs` (2067)** 내 **`compareDbg` 블록 (2072–2085)**
+
+---
+
+## 8. 문서 유지보수 시 구상
+
+1. **§0 색인표**: `export` / 핵심 `function` 선언 줄을 PR마다 또는 큰 편집 후 한 번 갱신.
+2. **전략**: `CompareOptions.strategy` + **`resolveTextCompareStrategy` (1183)** 조건.
+3. **Mermaid**: 분기나 함수 이름이 바뀌면 다이어그램 라벨만 맞춤.
+4. **본문 내 줄 범위**: `compareSnapshots`·`buildTextDiffs`처럼 긴 함수는 절차만 범위로 적었으면, 진입점은 **§0**의 함수 시작 줄을 기준으로 IDE에서 이동.
+5. **컨트롤 kind 확장 동기화**: `DiffKind`가 확장되면(`image` 등) `mapControlKind`, `DEFAULT_KINDS`(history/compare), UI `kindLabel`을 같이 갱신.
+6. **표 텍스트 표시 계약 유지**: table 요약의 `cprev/csha/txt/props` 포맷 변경 시 `parseCellPreviewMap`/`formatCellPreviewDiff`를 같이 수정.
+7. **표 카드 fallback 정책**: 셀 미리보기 한계가 있어도 “변경 셀 수” 또는 “속성 해시 전/후”를 표시해 빈 카드가 나오지 않게 유지.
+8. **검증 루틴**: `npx tsc --noEmit` + UI 스모크(이력/문서 비교 둘 다) + 대표 시나리오(H-07, D-07) 재확인.
+
+새 동작은 **이력 전용 / alignment 전용 / 공통**을 먼저 나눈 뒤 §2·§3·§4에 반영하면 읽는 흐름이 유지됩니다.
+
+---
+
+## 9. 왜 이 로직이 추가됐는가 (문제 → 대응)
+
+아래는 실제 운영/디버깅에서 자주 보인 문제 패턴과, 이를 완화하기 위해 들어간 핵심 로직의 대응 관계입니다.
+
+### 9.1 이력(identity) 경로
+
+| 문제 상황 | 증상 | 대응 로직(함수/줄) |
+|---|---|---|
+| 동일 문서 이력인데도 sid 누락/중복으로 identity 실패 | 기대는 빠른 1:1인데 alignment 폴백으로 변동성 증가 | `buildStableIdMap` (1046): sid 누락 시 실패 감지, 중복 sid `#occurrence` 정규화 |
+| 삽입/삭제 때문에 `moved`가 과검출 | 실제 순서 변경이 아닌데 이동 알림 다수 | `suppressPureReflowMoves` (1202): 상대순서 + prefix 삽입/삭제량으로 reflow 필터링 |
+| 수정량이 큰 문단에서 “무엇이 바뀌었는지” 읽기 어려움 | modified는 뜨지만 변경 밀도 파악 어려움 | `myersCharDiffSummary` (364): 편집거리·패턴 요약(Hirschberg·`CHAR_DIFF_*`) |
+
+### 9.2 alignment(문서 비교) 경로
+
+| 문제 상황 | 증상 | 대응 로직(함수/줄) |
+|---|---|---|
+| 반복 문구/짧은 문단이 앵커로 잡혀 정렬 전체가 밀림 | 뒤 구간이 연쇄적으로 added/removed 오탐 | `isAnchorTextQualityOk` (190), `buildAnchorPairs` (1329): 길이/중복/품질 필터로 앵커 오염 억제 |
+| 대구간에서 DP 비용 폭발/브라우저 정지 | 비교 시간이 급증하거나 UI 프리징 | `matchSegment` (1530), `shouldBailToGreedy` (202), `matchWindowedGreedy` (1675): 셀 수/시간 기반 fallback |
+| 의역/미세 수정 문단이 서명 불일치로 매칭 탈락 | 삭제+추가로 쪼개져 사용자 체감 품질 저하 | `textSimilarity` (1377), `getEffectiveSimilarity` (1441), `matchCost` (1452), `scorePairGreedy` (1659): 구조근접 기반 비용/점수 보정 |
+| 윈도 그리디에서 1·2위 점수차가 작아 둘 다 버림 | 맞는 후보가 있어도 unmatched 증가 | `matchWindowedGreedy` (1675): 1위가 `isNearStructure`면 ambiguous 검사 생략 |
+| 정렬 결과가 (삭제+추가)로만 나와 수정 의도가 사라짐 | 실제는 수정인데 added/removed 2건으로 보임 | `shouldMergeRemovedAddedAsModify` (1830): 유사도/거리 조건으로 modified 병합 |
+| 빈 문단 편집(빈→텍스트/반대)이 삭제+추가로 표시 | 사용자는 단순 입력/삭제인데 과한 diff | `shouldPromoteEmptyTextEdit` (1767): 구조 신호 맞으면 modified 승격 |
+| 문단 분할 케이스에서 라벨 순서가 어색 | `(null,R앞)(L,R뒤)`가 추가+수정 순으로 역전 | `isLeftParagraphSplitIntoTwoRightParas` (1745): 변경+추가로 재라벨 |
+
+### 9.3 컨트롤(표/도형/이미지/차트) 추적
+
+| 문제 상황 | 증상 | 대응 로직(함수/줄) |
+|---|---|---|
+| 레이아웃/문단 번호 밀림으로 같은 개체를 다른 개체로 인식 | modified 대신 removed+added 다발 | `canonicalControlKey` (435): `sid:` 우선 stem 정규화로 동일 개체 추적 |
+| 같은 키 후보가 여러 번 수집될 때 품질 불균형 | 저품질 요약이 채택돼 diff 품질 저하 | `controlSnapshotQuality` (448): 텍스트/픽셀/bbox 정보가 풍부한 스냅샷 우선 |
+| key가 변한 컨트롤을 전부 신규/삭제로 처리 | 작은 위치 변화에도 추적 단절 | `extractTablePatiencePins` (2114) 후 `pairControlsFallback` (2252), `scoreControlFallback` (2283): 표 유일 키 선매칭 + 타입/요약/위치 근접 |
+| 표 내부 변경이 “표 변경” 한 줄로만 보임 | 어떤 셀이 바뀌었는지 불명확 | `buildTableSummary` (474), `buildGranularControlDiffs` (609), `countChangedCellsByHash` (580): 셀 요약/해시 기반 세분화 |
+| 이미지가 도형으로 묶여 표시됨 | 결과 카드 의미가 모호 | `DiffKind`에 `image` 추가 + `mapControlKind`/UI `kindLabel` 동기화 |
+| 표 텍스트 카드가 인코딩/빈값처럼 보임 | 행/열별 값 확인 어려움 | `cprev` 포맷 고정 + UI `parseCellPreviewMap`(`&amp;` 정규화/URL decode) + 구조변경 union-key 렌더 |
+| 표 속성 변경 카드의 근거 부족 | “속성 값 변경”만 보임 | 값 행이 없을 때 `props` 전/후 fallback 표시 |
+
+### 9.4 운영 관점 공통 대응
+
+| 문제 상황 | 증상 | 대응 로직(함수/줄) |
+|---|---|---|
+| kinds가 많아 결과 노이즈 증가 | 사용자가 핵심 변경을 놓침 | `compareSnapshots` (2392): `options.kinds` 필터 후 최종 반환 |
+| 메타 diff에서 쪽번호 탐색 불편 | 좌/우 페이지 점프 어려움 | `annotateDiffSectionPages` (2318): 문단/anchor 기반 sectionPage 주석 |
+
+---
+
+*기준: `diff-engine.ts` — 본 README의 줄 번호는 편집 시 어긋날 수 있으니 §0을 소스와 함께 갱신할 것.*

--- a/rhwp-studio/src/compare/diff-engine.ts
+++ b/rhwp-studio/src/compare/diff-engine.ts
@@ -1,0 +1,2851 @@
+/**
+ * HWP 문서 비교 엔진 — 문단 정렬(alignment), 문자 단위 diff, 표·도형·그림 등 컨트롤 diff를 한 모듈에서 처리한다.
+ *
+ * ── [용어] “밀림(shift)”
+ * 한쪽에 문단·표가 삽입되면 이후 문단의 `section`/`paragraph`/`globalIndex`가 통째로 밀린다.
+ * 텍스트는 내용 기반 정렬로 상쇄할 수 있으나, 컨트롤 키에 물리 위치가 남으면 표/도형이 “삭제+추가”로
+ * 쪼개져 보이는 문제가 생긴다. 이 파일은 (A) 문단 쪽 밀림 완화 (B) 정렬 결과를 컨트롤에 전달 두 축으로 대응한다.
+ *
+ * ── [도메인 분리: identity vs alignment]
+ * - **이력(같은 혈통)**: `stable_id`가 양쪽에 공유되면 `identity` 경로로 문단 1:1을 직접 잡는다(O(N) 수준).
+ * - **외부 문서(다른 혈통)**: 공유 sid가 없으므로 `alignment`만 사용한다. 유일·긴 문단과 섹션 제목류를
+ *   **글로벌 앵커**로 써 문서를 구간으로 쪼개고, 구간 안은 DP/그리디로 채운다.
+ *
+ * ── [문단 밀림 완화 — alignment 내부 계층]
+ * 1. **글로벌 앵커** (`buildAnchorPairs`, `fillSnapshotFromWasm`의 `isAnchorCandidate`)
+ *    - 시그니처가 좌·우 각각 한 번만 등장하는 문단만 앵커 후보.
+ *    - 길이·엔트로피 등 `isAnchorTextQualityOk`로 짧은 반복 문장을 걸러 오염 앵커를 막는다.
+ *    - `[테스트 N: …]` 같은 짧은 제목은 `isStructuralBlockTitleLine` 등으로 후보로 올리되,
+ *      `buildBothSidesUniqueTrimNorm`으로 **trim 본문이 양쪽 문서에서 정확히 한 번씩**일 때만 글로벌 앵커로 승인.
+ * 2. **구간 정렬** (`matchSegment` 재귀 트리)
+ *    - `buildUniqueSigPairsInSlices`: 구간 안에서만 시그니처 빈도를 세 **내부 Patience 핀**으로 쪼갠다.
+ *    - `tryMatchByNormHashPins`: 서명 핀이 없을 때 `normalizedText` 해시 토큰으로 거시 핀(DMP line-mode 유사).
+ *    - `matchSegmentDp` / `findLongestEqualSignatureRun` / `matchWindowedGreedy`: 셀 수·시간 한도에 따라 선택.
+ * 3. **상대 구조 근접** (`SegmentAnchorBoundary` + `runWithSegmentStructBase` + `isNearStructure`)
+ *    - 구간마다 직전 글로벌 앵커 쌍의 `globalIndex`를 베이스로 잡고, `|Δleft - Δright| ≤ 2`로 본다.
+ *    - 문서 맨 앞 구간은 베이스가 구간 **첫 문단**이다. 절대 인덱스만 보면 큰 밀림 직후 이웃 문단이
+ *      구조적으로 가깝다고 인정받지 못하는 문제를 줄인다.
+ * 4. **DP 비용** (`matchCost`, `getEffectiveSimilarity`, `softSimilarityThresholdForPair`)
+ *    - 유사도는 “전역 라벨”이 아니라 치환 비용·약매칭 방지용 가중치로만 쓴다.
+ *
+ * ── [컨트롤 밀림 완화]
+ * - 1차: `kind::key` 정확 일치(`sid:…` 우선).
+ * - 2차: **`buildRightToLeftParaMapFromAligned`** — `buildTextDiffs`가 만든 문단 정렬 `AlignedPair[]`에서
+ *   오른쪽 `section:paragraph` → 짝 왼쪽 문단 맵을 구축해 `buildControlDiffs`에 전달한다.
+ * - 3차: **`pairAlignmentSlotControls`** — 키가 어긋린 뒤에도, 오른쪽 컨트롤의 부모 문단이 맵상으로
+ *   어느 왼쪽 문단과 짝인지 알면 **그 왼쪽 문단에 붙은 미매칭 컨트롤만** 후보로 삼고
+ *   `scoreControlFallback + ALIGNMENT_CONTROL_SLOT_BONUS`로 짝을 찾는다(절대 y 밀림 보정).
+ * - 4차: `extractTablePatiencePins`(표 요약 유일 키) → `pairControlsFallback`(전역 탐욕, 임계 2.75).
+ *
+ * ── [단계적 비교(성능)]
+ * - 전 문단×문단 유사도 행렬 같은 O(N²) 전역 최적화는 하지 않는다.
+ * - 짝이 맞은 문단에만 `myersCharDiffSummary`(접두·접미 제거, Hirschberg, `CHAR_DIFF_*` 상한)를 적용한다.
+ *
+ * ── [튜닝 상수 — `// ─── 튜닝 상수` 블록]
+ * - 앵커·구간: ANCHOR_*, INTRA_UNIQUE_SIG_*, SEGMENT_DP_MAX, NORM_HASH_PIN_MIN_TOTAL_PARAS, HARD_SEGMENT_CELL_LIMIT,
+ *   ALIGNMENT_MAX_COMPUTE_MS, MAX_SEGMENT_RECURSION
+ * - 구조 근접·비용: NEAR_STRUCTURE_*, MATCH_SOFT_SIM_MIN, MATCH_COST_WEAK, WINDOW_SIZE, GREEDY_AMBIGUOUS_GAP
+ * - 컨트롤 슬롯: ALIGNMENT_CONTROL_SLOT_BONUS, ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE
+ * - 후처리: PARA_SPLIT_JOIN_SIM_MIN, REMOVED_ADDED_*
+ * - 문자 요약: CHAR_DIFF_FULL_DP_MAX, CHAR_DIFF_TOTAL_MAX, CHAR_DIFF_CELL_HARD
+ *
+ * ── [입력 경로]
+ * - `buildSnapshotFromBytes`: 외부 파일 비교.
+ * - `buildSnapshotFromWasm`: 편집기 IR — 같은 세션 이력에서 sid 보존에 유리.
+ *
+ * ── [공개 진입점]
+ * - `compareSnapshots`: 전략 선택 → 본문 diff → 컨트롤 diff(맵 전달) → 필터·쪽번호·정렬.
+ * - `compareDocuments`: bytes 두 개를 스냅샷으로 만든 뒤 위와 동일.
+ *
+ * ── [유지보수]
+ * - 품질 이슈 시 compare-debug 로그 ① stable_id ② 전략 ③ 앵커를 함께 본다.
+ * - 본 파일은 `// ───` 섹션 구분으로 점프 검색이 가능하다.
+ */
+import { WasmBridge } from '@/core/wasm-bridge';
+import type { DocumentInfo, ParaProperties } from '@/core/types';
+import { compareDbg, isCompareDebugEnabled } from './compare-debug';
+import type {
+  CompareAnchorTuning,
+  CompareControlSnapshot,
+  CompareDocumentSnapshot,
+  CompareOptions,
+  CompareParaSnapshot,
+  ComparePerformanceTuning,
+  CompareSession,
+  CompareStrategy,
+  DiffAnchor,
+  DiffItem,
+  DiffKind,
+} from './types';
+
+// ═══ 튜닝·런타임 가드 ═══════════════════════════════════════════════════════
+// alignment·컨트롤 슬롯 매칭의 비용/품질은 아래 상수에 강하게 묶여 있다.
+// 튜닝 변경 후에는 통합 테스트용 HWP(앵커·표 삽입·밀림)으로 회귀 확인하는 것을 권장한다.
+// 파일 맨 위 블록 주석(용어·파이프라인)과 이 표를 같이 읽으면 의도가 정리된다.
+
+// ─── 튜닝 상수 (값 변경 시 대표 문서로 회귀 확인 권장) ─────────────────
+// 상호 의존:
+// - NEAR_STRUCTURE_* 는 `isNearStructure`가 true일 때만 DP/그리디에 반영된다.
+// - 큰 밀림 직후에도 구간 베이스(`SegmentAnchorBoundary`)가 맞으면 isNear가 true가 되기 쉬워져
+//   치환 비용 할인·유사도 완화가 켜진다.
+// - 그래도 (L,null)(null,R) 패턴으로 남는 구간은 REMOVED_ADDED_* 로 “한 슬롯 수정”으로 승격할 수 있다.
+/** alignment 경로: 오른쪽 문단마다 왼쪽에서 고를 때의 탐색 반경(문단 개수) */
+const WINDOW_SIZE = 32;
+/** `buildAnchorPairs`: 시그니처가 같아도 너무 짧은 문단은 앵커 후보에서 제외(오탐 앵커 방지) */
+const ANCHOR_MIN_TEXT_LEN = 20;
+/** `[테스트 N: …]` 등 짧은 블록 제목을 앵커로 쓸 때 최소 글자 수(공백 제거 `trim` 기준) */
+const STRUCTURAL_ANCHOR_MIN_LEN = 5;
+/** 최상위 구간 `buildUniqueSigPairsInSlices` 최소 문단 길이 */
+const INTRA_UNIQUE_SIG_MIN_TOP = 10;
+/** 글로벌 앵커로 이미 자른 하위 구간에서 내부 유일 시그니처 핀의 최소 길이 */
+const INTRA_UNIQUE_SIG_MIN_NESTED = 4;
+/** 동일 서명 문단 쌍의 globalIndex 차가 이 값보다 크면 "문단 이동" 메타 후보로 본다 */
+const MOVE_DISTANCE_THRESHOLD = 3;
+/** 정렬이 (null,R앞)(L,R뒤)로 나온 쪼개기만: L≈R앞+R뒤일 때 R앞=변경·R뒤=추가로 재라벨 */
+const PARA_SPLIT_JOIN_SIM_MIN = 0.86;
+/** 구간 내 DP 직접 적용 최대 한 변 길이 (n*m <= MAX^2) */
+const SEGMENT_DP_MAX = 150;
+/** DP에서 약한 유사도끼리 붙는 것 방지 (치환 비용 하한으로 del+ins보다 불리하게) */
+const MATCH_SOFT_SIM_MIN = 0.7;
+/** `matchCost`: 유사도가 너무 낮으면 치환 대신 삽입+삭제 쪽으로 유도하는 비용 상한 */
+const MATCH_COST_WEAK = 4;
+/** `isNearStructure`이고 문단이 충분히 길 때, `textSimilarity` 결과를 DP/그리디 평가용으로만 끌어올리는 하한 */
+const NEAR_STRUCTURE_SIM_BOOST = 0.4;
+/** 위 부스트를 받기 위한 최소 raw 유사도(무연관 짧은 문단·우연 일치 완화) */
+const NEAR_STRUCTURE_MIN_SIM = 0.12;
+/** 구조 근접 시 치환 비용(`1-sim`)에서 깎는 할인 — `getEffectiveSimilarity`와 별개 튜닝 */
+const NEAR_STRUCTURE_COST_DISCOUNT = 0.4;
+/** 그리디 `scorePairGreedy`: `isNearStructure`일 때 `minScore`(의역·서명 불일치) 통과용 가산 */
+const NEAR_STRUCTURE_GREEDY_BONUS = 1.5;
+/** 그리디: 1·2위 점수 차가 이 값 미만이면 동률로 보고 매칭 포기(1위가 구조 근접이면 검사 생략) */
+const GREEDY_AMBIGUOUS_GAP = 0.35;
+/** (L,null)(null,R) 등 삭제+추가로만 남았지만 동일 슬롯 수정으로 승격할 최소 textSimilarity */
+const REMOVED_ADDED_MERGE_SIM_MIN = 0.28;
+/** 위 승격: 같은 구역에서 허용하는 문단 번호·globalIndex 최대 간격(위쪽 삽입으로 밀린 경우) */
+const REMOVED_ADDED_MAX_PARA_GAP = 12;
+const REMOVED_ADDED_MAX_GLOBAL_GAP = 24;
+/** 문자 diff: 이 이하의 n×m만 전역 DP 역추적(Hirschberg 잎) */
+const CHAR_DIFF_FULL_DP_MAX = 280_000;
+/** 좌+우 길이 합 상한 — 그 이상은 요약 생략(메인 스레드 보호) */
+const CHAR_DIFF_TOTAL_MAX = 96_000;
+/** n×m 셀 상한 — 평균 케이스에서도 과도한 O(nm) 방지 */
+const CHAR_DIFF_CELL_HARD = 14_000_000;
+/** 앵커 품질 기본 가드레일: 공백 비율 상한 */
+const ANCHOR_MAX_WHITESPACE_RATIO = 0.62;
+/** 앵커 품질 기본 가드레일: 최소 고유 문자 수 */
+const ANCHOR_MIN_UNIQUE_CHARS = 6;
+/** 앵커 품질 기본 가드레일: 최소 엔트로피 */
+const ANCHOR_MIN_ENTROPY = 1.9;
+/** 브라우저 프리징 방지: 구간 셀 수 하드캡(초과 시 DP 금지) */
+const HARD_SEGMENT_CELL_LIMIT = 180_000;
+/** 브라우저 프리징 방지: alignment 타임버짓 기본값(ms) */
+const ALIGNMENT_MAX_COMPUTE_MS = 2600;
+/** `matchSegment` 재귀(내부 앵커·half-match) 최대 깊이 */
+const MAX_SEGMENT_RECURSION = 96;
+/** half-match 전수 탐색 시 n×m 상한(초과 시 half-match 생략) */
+const HALF_MATCH_MAX_PRODUCT = 450_000;
+/**
+ * `tryMatchByNormHashPins`: 서명 유일 핀이 없을 때 `normalizedText` trim을 해시 토큰으로 바꿔
+ * 구간 내 유일 쌍을 찾는 **거시** 단계. 좌·우 문단 수 합이 이 값 미만이면 오버헤드만 커져 생략한다.
+ */
+const NORM_HASH_PIN_MIN_TOTAL_PARAS = 48;
+/**
+ * `pairAlignmentSlotControls`: 문단 정렬로 이미 “같은 논리 문단”으로 묶인 표·도형에 대해
+ * `scoreControlFallback` 원점수에 더하는 보너스. 위쪽 삽입으로 앵커 y가 크게 달라져도
+ * 원점수가 2.75 근처에서 막히는 현상을 완화한다.
+ */
+const ALIGNMENT_CONTROL_SLOT_BONUS = 2.35;
+/**
+ * 슬롯 단계에서 채택하는 최소 점수 = `scoreControlFallback(l,r) + ALIGNMENT_CONTROL_SLOT_BONUS`.
+ * 너무 낮추면 다른 문단 개체와 오매칭, 너무 높이면 슬롯이 거의 동작하지 않는다.
+ */
+const ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE = 4.38;
+
+/** `compareSnapshots` 한 번 호출 동안만 유효. `ALIGNMENT_MAX_COMPUTE_MS` 경과 시 greedy 쪽으로 이탈한다. */
+type CompareRuntimeGuard = {
+  deadline: number;
+  bailedOut: boolean;
+};
+
+let activeRuntimeGuard: CompareRuntimeGuard | null = null;
+
+/**
+ * `isNearStructure`가 쓰는 좌·우 `globalIndex` 베이스(한 쌍의 절대 인덱스).
+ * `matchSegment` 재귀 전체에서 동일 베이스를 쓰면, “구간 전체가 위에서 k칸 밀렸다”를
+ * `dL = lp.globalIndex - leftBaseGi`, `dR = rp.globalIndex - rightBaseGi`로 보고 `|dL-dR|≤2`만 검사한다.
+ */
+type SegmentStructBase = { leftBaseGi: number; rightBaseGi: number };
+/**
+ * 글로벌 앵커 한 쌍의 globalIndex. `buildTextDiffs`가 앵커 사이 슬라이스를 `matchSegment`에 넘길 때
+ * 직전 경계 앵커 `(a.li,a.ri)`가 있으면 그 문단의 인덱스를 베이스로 넣고, 문서 맨 앞 구간은 null이라
+ * 베이스가 구간의 **첫 문단** 쌍으로 대체된다(`matchSegment` 내부에서 산출).
+ */
+type SegmentAnchorBoundary = { leftAnchorGi: number; rightAnchorGi: number };
+/** `matchSegment`/`matchSegmentDp`/`matchCost` 호출 동안만 세팅. 중첩 재귀 시 스택처럼 복구한다. */
+let activeSegmentStructBase: SegmentStructBase | null = null;
+
+/** `fn` 실행 동안 `isNearStructure`가 `base` 기준 상대 오프셋을 보도록 한다. */
+function runWithSegmentStructBase<T>(base: SegmentStructBase, fn: () => T): T {
+  const prev = activeSegmentStructBase;
+  activeSegmentStructBase = base;
+  try {
+    return fn();
+  } finally {
+    activeSegmentStructBase = prev;
+  }
+}
+
+/** `CompareOptions.anchorTuning`이 있으면 그걸 쓰고, 없으면 파일 상단 기본 앵커 가드레일을 쓴다. */
+function resolveAnchorTuning(options: CompareOptions): Required<CompareAnchorTuning> {
+  return {
+    minTextLen: options.anchorTuning?.minTextLen ?? ANCHOR_MIN_TEXT_LEN,
+    minUniqueChars: options.anchorTuning?.minUniqueChars ?? ANCHOR_MIN_UNIQUE_CHARS,
+    maxWhitespaceRatio: options.anchorTuning?.maxWhitespaceRatio ?? ANCHOR_MAX_WHITESPACE_RATIO,
+    minEntropy: options.anchorTuning?.minEntropy ?? ANCHOR_MIN_ENTROPY,
+  };
+}
+
+/** `hardSegmentCells` / `maxComputeMs` — 큰 문서에서 DP 테이블·이중 루프가 메인 스레드를 막지 않게 상한을 둔다. */
+function resolvePerformanceTuning(options: CompareOptions): Required<ComparePerformanceTuning> {
+  return {
+    maxComputeMs: options.performanceTuning?.maxComputeMs ?? ALIGNMENT_MAX_COMPUTE_MS,
+    hardSegmentCells: options.performanceTuning?.hardSegmentCells ?? HARD_SEGMENT_CELL_LIMIT,
+  };
+}
+
+function shannonEntropy(text: string): number {
+  if (!text) return 0;
+  const freq = new Map<string, number>();
+  for (const ch of text) freq.set(ch, (freq.get(ch) ?? 0) + 1);
+  let entropy = 0;
+  for (const c of freq.values()) {
+    const p = c / text.length;
+    entropy -= p * Math.log2(p);
+  }
+  return entropy;
+}
+
+/**
+ * 글로벌 앵커 후보 문단의 "텍스트 품질" 검사(엔트로피·공백 비율·고유 문자 수).
+ *
+ * 너무 짧거나 반복적인 줄을 앵커로 쓰면 뒤따르는 모든 구간 정렬이 한 번에 틀어질 수 있어 기본은 배제한다.
+ * 다만 `[테스트 N: …]`·`1. …` 같이 **구조적 한 줄 제목**으로 보이는 패턴(`isStructuralBlockTitleLine`)은
+ * 길이가 `STRUCTURAL_ANCHOR_MIN_LEN` 이상·`minTextLen` 미만이면 엔트로피 검사 없이 후보로 통과시킨다.
+ * 짧은 줄의 **전역 유일성**(양쪽 문서에서 trim 본문이 각각 한 번)은 `buildAnchorPairs`에서 별도로 걸러진다.
+ */
+function isAnchorTextQualityOk(text: string, tuning: Required<CompareAnchorTuning>): boolean {
+  const trimmed = text.trim();
+  if (
+    trimmed.length >= STRUCTURAL_ANCHOR_MIN_LEN &&
+    trimmed.length < tuning.minTextLen &&
+    isStructuralBlockTitleLine(trimmed)
+  ) {
+    return true;
+  }
+  if (text.length < tuning.minTextLen) return false;
+  const whitespaceCount = (text.match(/\s/g) ?? []).length;
+  if (whitespaceCount / Math.max(1, text.length) > tuning.maxWhitespaceRatio) return false;
+  if (new Set(text).size < tuning.minUniqueChars) return false;
+  return shannonEntropy(text) >= tuning.minEntropy;
+}
+
+/**
+ * `[테스트 N: …]`·`[제목]`·`1. 소제목` 같이 짧아도 블록 경계로 쓸 만한 한 줄 제목.
+ * 글로벌 앵커 후보는 `signature` 중복 여부로 별도 차단한다.
+ */
+function isStructuralBlockTitleLine(trimmedOneLine: string): boolean {
+  if (!trimmedOneLine) return false;
+  if (/^\[[^\]]+\]$/.test(trimmedOneLine)) return true;
+  if (/^\[[^\]]+:[^\]]+\]$/.test(trimmedOneLine)) return true;
+  if (/^\d+\.\s+/.test(trimmedOneLine)) return true;
+  return false;
+}
+
+/**
+ * alignment 중 시간이 `maxComputeMs`를 넘기면 true로 고정되며, 이후 DP 진입을 막고 그리디로만 처리한다.
+ * DP 이중 루프 안에서는 `i % 12` 등으로 가끔만 호출해 오버헤드를 제한한다.
+ */
+function shouldBailToGreedy(): boolean {
+  if (!activeRuntimeGuard) return false;
+  if (activeRuntimeGuard.bailedOut) return true;
+  if (Date.now() <= activeRuntimeGuard.deadline) return false;
+  activeRuntimeGuard.bailedOut = true;
+  return true;
+}
+
+// ─── 문자 diff 요약 (`myersCharDiffSummary`): 접두·접미, 전역 DP 잎, Hirschberg ─
+
+/** 공통 접두·접미를 제거해 Levenshtein/Hirschberg 입력을 줄인다. */
+function stripCommonAffixChars(left: string, right: string): { a: string; b: string } {
+  let lo = 0;
+  const minLen = Math.min(left.length, right.length);
+  while (lo < minLen && left.charCodeAt(lo) === right.charCodeAt(lo)) lo += 1;
+  let suf = 0;
+  while (
+    suf < left.length - lo &&
+    suf < right.length - lo &&
+    left.charCodeAt(left.length - 1 - suf) === right.charCodeAt(right.length - 1 - suf)
+  )
+    suf += 1;
+  return { a: left.slice(lo, left.length - suf), b: right.slice(lo, right.length - suf) };
+}
+
+function levenshteinDistanceTwoRow(a: string, b: string): number {
+  const n = a.length;
+  const m = b.length;
+  if (n === 0) return m;
+  if (m === 0) return n;
+  let prev = new Array<number>(m + 1);
+  let cur = new Array<number>(m + 1);
+  for (let j = 0; j <= m; j += 1) prev[j] = j;
+  for (let i = 1; i <= n; i += 1) {
+    cur[0] = i;
+    const cAi = a.charCodeAt(i - 1);
+    for (let j = 1; j <= m; j += 1) {
+      const eq = cAi === b.charCodeAt(j - 1) ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + eq);
+    }
+    const t = prev;
+    prev = cur;
+    cur = t;
+  }
+  return prev[m];
+}
+
+/** `a[0..nrow)` vs `b` — 마지막 행 비용만 (Hirschberg 전반). `nrow===0`이면 삽입만. */
+function levenshteinLastRowPrefix(a: string, nrow: number, b: string): number[] {
+  const m = b.length;
+  if (nrow <= 0) {
+    const row = new Array<number>(m + 1);
+    for (let j = 0; j <= m; j += 1) row[j] = j;
+    return row;
+  }
+  let prev = new Array<number>(m + 1);
+  let cur = new Array<number>(m + 1);
+  for (let j = 0; j <= m; j += 1) prev[j] = j;
+  for (let i = 1; i <= nrow; i += 1) {
+    cur[0] = i;
+    const cAi = a.charCodeAt(i - 1);
+    for (let j = 1; j <= m; j += 1) {
+      const eq = cAi === b.charCodeAt(j - 1) ? 0 : 1;
+      cur[j] = Math.min(prev[j] + 1, cur[j - 1] + 1, prev[j - 1] + eq);
+    }
+    const t = prev;
+    prev = cur;
+    cur = t;
+  }
+  return prev;
+}
+
+/** `D[i][j]` = ed(`a[i..n)`, `b[j..m)`). `i === mid`인 행만 필요할 때 아래로 채운다. */
+function levenshteinSuffixRowAt(a: string, mid: number, b: string): number[] {
+  const n = a.length;
+  const m = b.length;
+  let cur = new Array<number>(m + 1);
+  for (let j = 0; j <= m; j += 1) cur[j] = m - j;
+  for (let i = n - 1; i >= mid; i -= 1) {
+    const next = new Array<number>(m + 1);
+    next[m] = n - i;
+    const ca = a.charCodeAt(i);
+    for (let j = m - 1; j >= 0; j -= 1) {
+      const eq = ca === b.charCodeAt(j) ? 0 : 1;
+      next[j] = Math.min(cur[j] + 1, next[j + 1] + 1, cur[j + 1] + eq);
+    }
+    cur = next;
+  }
+  return cur;
+}
+
+/** 전체 `dp` 역추적 — `n*m`이 작을 때만 호출. */
+function charEditOpsFullDp(left: string, right: string): string {
+  const n = left.length;
+  const m = right.length;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(0));
+  for (let i = 0; i <= n; i += 1) dp[i][0] = i;
+  for (let j = 0; j <= m; j += 1) dp[0][j] = j;
+  for (let i = 1; i <= n; i += 1) {
+    for (let j = 1; j <= m; j += 1) {
+      const eq = left.charCodeAt(i - 1) === right.charCodeAt(j - 1) ? 0 : 1;
+      dp[i][j] = Math.min(dp[i - 1][j] + 1, dp[i][j - 1] + 1, dp[i - 1][j - 1] + eq);
+    }
+  }
+  let i = n;
+  let j = m;
+  const ops: string[] = [];
+  while (i > 0 || j > 0) {
+    if (i > 0 && j > 0 && left.charCodeAt(i - 1) === right.charCodeAt(j - 1)) {
+      ops.push('=');
+      i -= 1;
+      j -= 1;
+    } else if (i > 0 && dp[i][j] === dp[i - 1][j] + 1) {
+      ops.push('-');
+      i -= 1;
+    } else if (j > 0 && dp[i][j] === dp[i][j - 1] + 1) {
+      ops.push('+');
+      j -= 1;
+    } else if (i > 0 && j > 0) {
+      ops.push('×');
+      i -= 1;
+      j -= 1;
+    } else if (i > 0) {
+      ops.push('-');
+      i -= 1;
+    } else {
+      ops.push('+');
+      j -= 1;
+    }
+  }
+  ops.reverse();
+  return ops.join('');
+}
+
+function charEditOpsHirschberg(a: string, b: string): string {
+  const n = a.length;
+  const m = b.length;
+  if (n === 0) return '+'.repeat(m);
+  if (m === 0) return '-'.repeat(n);
+  if (n * m <= CHAR_DIFF_FULL_DP_MAX) {
+    return charEditOpsFullDp(a, b);
+  }
+  const mid = Math.max(1, Math.floor(n / 2));
+  const f = levenshteinLastRowPrefix(a, mid, b);
+  const suf = levenshteinSuffixRowAt(a, mid, b);
+  let bestJ = 0;
+  let best = Infinity;
+  for (let j = 0; j <= m; j += 1) {
+    const s = f[j] + suf[j];
+    if (s < best || (s === best && j < bestJ)) {
+      best = s;
+      bestJ = j;
+    }
+  }
+  return (
+    charEditOpsHirschberg(a.slice(0, mid), b.slice(0, bestJ)) +
+    charEditOpsHirschberg(a.slice(mid), b.slice(bestJ))
+  );
+}
+
+/**
+ * 동일 stable_id 문단의 문자 단위 편집 거리·간단 패턴 요약 (2-depth diff).
+ * 공통 접두·접미 제거 후, 작은 구간은 전역 DP, 큰 구간은 Hirschberg로 선형 메모리에 가깝게 처리한다.
+ */
+function myersCharDiffSummary(left: string, right: string): string {
+  if (left.length === 0 && right.length === 0) return '';
+  if (left.length + right.length > CHAR_DIFF_TOTAL_MAX) {
+    return `문자 diff 요약 생략(길이: ${left.length}+${right.length})`;
+  }
+  const { a, b } = stripCommonAffixChars(left, right);
+  const n = a.length;
+  const m = b.length;
+  if (n === 0 && m === 0) return '';
+  if (n * m > CHAR_DIFF_CELL_HARD) {
+    return `문자 diff 요약 생략(과대: ${n}×${m})`;
+  }
+  const dist = levenshteinDistanceTwoRow(a, b);
+  const opStr = charEditOpsHirschberg(a, b);
+  const pat = opStr.replace(/=+/g, '·').slice(0, 100);
+  return `편집거리 ${dist} · ${pat}`;
+}
+
+// ─── 정규화·해시·Diff ID (문단 시그니처·컨트롤 요약에 공통 사용) ───────────────
+
+/** 비교 옵션에 따른 문단 텍스트 정규화. `ignoreWhitespace`/`caseSensitive`는 여기서만 일괄 적용된다. */
+function normalizeText(text: string, options: CompareOptions): string {
+  const base = options.ignoreWhitespace ? text.replace(/\s+/g, ' ').trim() : text;
+  return options.caseSensitive ? base : base.toLowerCase();
+}
+
+/** 짧은 FNV-1a digest — 문단 시그니처·표 텍스트 digest 등 충돌 가능성은 있으나 비교용으론 충분 */
+function simpleHash(input: string): string {
+  let h = 2166136261;
+  for (let i = 0; i < input.length; i += 1) {
+    h ^= input.charCodeAt(i);
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/** 바이너리(이미지 픽셀 등)용 FNV-1a 계열 해시 — 짧은 digest 문자열로 요약 비교에 사용 */
+function simpleHashBytes(bytes: Uint8Array): string {
+  let h = 2166136261;
+  for (let i = 0; i < bytes.length; i += 1) {
+    h ^= bytes[i];
+    h = Math.imul(h, 16777619);
+  }
+  return (h >>> 0).toString(16);
+}
+
+/** DiffItem.id — kind와 고유 키를 합쳐 UI 목록·로그·reflow 필터(`id-moved:` 등)에서 항목을 식별 */
+function mkDiffId(kind: DiffKind, key: string): string {
+  return `${kind}:${key}`;
+}
+
+/**
+ * WASM `item.type` + 요약 문자열을 DiffKind로 정규화.
+ * chart는 summary 키워드로 shape/group과 구분한다(도형 안 차트 등).
+ */
+function mapControlKind(type: string, summary: string): DiffKind {
+  if (type === 'table') return 'table';
+  if (type === 'image') return 'image';
+  if (type === 'shape' || type === 'group') {
+    if (summary.toLowerCase().includes('chart')) return 'chart';
+    return 'shape';
+  }
+  if (summary.toLowerCase().includes('chart')) return 'chart';
+  return 'paragraphMeta';
+}
+
+/**
+ * 동일 실개체가 `group`↔`shape`처럼 타입만 바뀌며 중복 수집되는 경우를 한 키로 묶는다.
+ * 매칭/중복 제거(`uniqueControls`)의 기준이 되므로 stem(`sid:…` 또는 `loc:…`) 추출 규칙을 바꿀 때는
+ * 레이아웃 경로·문단 직접 경로 양쪽의 key 포맷을 함께 점검해야 한다.
+ */
+function canonicalControlKey(c: CompareControlSnapshot): string {
+  const m = c.key.match(/^(sid:[^:]+:\d+|loc:-?\d+:-?\d+:\d+):[^:]+$/);
+  if (!m) return `${c.kind}::${c.key}`;
+  const stem = m[1];
+  // 요소별 변경 추적 안정화:
+  // - 동일 anchor(control index)인데 type만 group/shape로 달라지는 중복을 하나로 합친다.
+  // - 매칭 단계에서는 canonical key를 기준으로 "같은 개체"를 판정한다.
+  if (c.kind === 'shape' || c.kind === 'chart') return `${c.kind}::${stem}:shape`;
+  if (c.kind === 'table') return `${c.kind}::${stem}:table`;
+  return `${c.kind}::${stem}:image`;
+}
+
+/** 동일 canonical 키로 여러 스냅샷이 들어왔을 때, UI에 더 유의미한 요약을 남기기 위한 휴리스틱 점수 */
+function controlSnapshotQuality(c: CompareControlSnapshot): number {
+  let score = 0;
+  // 요소별 변경 추적 품질 점수:
+  // - 텍스트/픽셀해시/유효 bbox가 있는 스냅샷을 우선 채택해
+  //   동일 key 중 더 "정보가 풍부한" 항목을 남긴다.  
+  if (c.summary.includes('text="') && !c.summary.includes('text="(없음)"')) score += 4;
+  if (!c.summary.includes('pix=nopix')) score += 2;
+  if (!c.summary.includes('nobox')) score += 1;
+  if (c.type === 'shape') score += 1; // group보다 shape 상세값이 많은 편
+  return score;
+}
+
+/** DiffKind → 짧은 한글 제목(컨트롤 추가/삭제 카드 등). UI `kindLabel`과 문구를 맞출 때 동기화 */
+function kindLabel(kind: DiffKind): string {
+  if (kind === 'table') return '표';
+  if (kind === 'shape') return '도형';
+  if (kind === 'image') return '이미지';
+  if (kind === 'chart') return '그래프';
+  if (kind === 'text') return '텍스트';
+  return '메타';
+}
+
+/**
+ * 표 셀 텍스트·속성을 요약한 짧은 문자열 — 컨트롤 diff에서 "같은 표인지" 판별용.
+ * WASM에 `getTableSignature`가 있으면 그걸 우선(정확·빠름), 없으면 셀 순회 폴백.
+ */
+function buildTableSummary(
+  wasm: WasmBridge,
+  options: CompareOptions,
+  sec: number,
+  para: number,
+  ci: number,
+): string {
+  let sigDigest = 'nosig';
+  try {
+    const sigJson = wasm.getTableSignature(sec, para, ci);
+    sigDigest = simpleHash(sigJson);
+  } catch {
+    // 신/구 WASM 호환: 시그니처 API가 없으면 기존 JS 조합 경로 사용
+  }
+
+  const dim = wasm.getTableDimensions(sec, para, ci);
+  const cellCount = Math.max(0, dim.rowCount * dim.colCount);
+  const cellSnippets: string[] = [];
+  const cellPreviewPairs: string[] = [];
+  const cellHashPairs: string[] = [];
+  for (let cellIdx = 0; cellIdx < cellCount; cellIdx += 1) {
+    let paraCount = 0;
+    try {
+      paraCount = wasm.getCellParagraphCount(sec, para, ci, cellIdx);
+    } catch {
+      paraCount = 0;
+    }
+    const paraTexts: string[] = [];
+    for (let cpi = 0; cpi < paraCount; cpi += 1) {
+      try {
+        const plen = wasm.getCellParagraphLength(sec, para, ci, cellIdx, cpi);
+        const t = plen > 0 ? wasm.getTextInCell(sec, para, ci, cellIdx, cpi, 0, plen) : '';
+        if (t) paraTexts.push(normalizeText(t, options));
+      } catch {
+        // 일부 셀 접근 실패 시 해당 문단만 스킵
+      }
+    }
+    const joined = paraTexts.join('|');
+    cellSnippets.push(joined);
+    if (joined && cellPreviewPairs.length < 240) {
+      // 요소별 변경 추적(표 텍스트):
+      // - cprev: UI 표시용(사람이 읽는 셀 미리보기)
+      // - csha : 긴 문장/여러 줄에서 잘림이 있어도 변경 감지를 유지하기 위한 셀 단위 해시
+      const compact = joined
+        .replaceAll('"', "'")
+        .replaceAll('\r\n', '\n')
+        .replaceAll('\n', ' ↵ ')
+        .replace(/\s{2,}/g, ' ')
+        .trim()
+        .slice(0, 180);
+      const row = dim.colCount > 0 ? Math.floor(cellIdx / dim.colCount) + 1 : 1;
+      const col = dim.colCount > 0 ? (cellIdx % dim.colCount) + 1 : (cellIdx + 1);
+      const key = `r${row}c${col}`;
+      cellPreviewPairs.push(`${key}=${encodeURIComponent(compact)}`);
+      cellHashPairs.push(`${key}=${simpleHash(joined)}`);
+    }
+  }
+  const textDigest = simpleHash(cellSnippets.join('||'));
+  const textPreview = cellSnippets
+    .filter(Boolean)
+    .slice(0, 2)
+    .map((s) => s.replaceAll('"', "'").replace(/\s+/g, ' ').trim())
+    .join(' | ')
+    .slice(0, 80);
+  let propsDigest = '';
+  try {
+    const props = wasm.getTableProperties(sec, para, ci);
+    propsDigest = simpleHash(JSON.stringify(props));
+  } catch {
+    propsDigest = 'noprops';
+  }
+  let bboxDigest = 'nobox';
+  try {
+    const bbox = wasm.getTableBBox(sec, para, ci);
+    bboxDigest = `${Math.round(bbox.width)}x${Math.round(bbox.height)}`;
+  } catch {
+    bboxDigest = 'nobox';
+  }
+  const cellPreview = cellPreviewPairs.join('&');
+  const cellHash = cellHashPairs.join('&');
+  return `table r=${dim.rowCount} c=${dim.colCount} tprev="${textPreview || '(없음)'}" cprev="${cellPreview || '(없음)'}" csha="${cellHash || '(없음)'}" txt=${textDigest} props=${propsDigest} box=${bboxDigest} sig=${sigDigest}`;
+}
+
+// ─── 표 요약 파싱·셀 단위 변경 집계 (buildGranularControlDiffs에서 사용) ───────
+
+/** `sid:…:ci:type` / `loc:…:ci:type` 형태에서 컨트롤 인덱스 `ci`만 뽑아 폴백 점수에 사용 */
+function extractControlIndexFromKey(key: string): number | null {
+  const m = key.match(/:(\d+):[^:]+$/);
+  if (!m) return null;
+  return Number.isFinite(Number(m[1])) ? Number(m[1]) : null;
+}
+
+/** 스냅샷 문단·컨트롤의 `section`+`paragraph`를 하나의 맵 키로 묶을 때 사용한다. */
+function paraPosKey(p: { section: number; paragraph: number }): string {
+  return `${p.section}:${p.paragraph}`;
+}
+
+/**
+ * 문단 정렬 결과(`AlignedPair[]`, cleanup 이전)에서 오른쪽 문단 위치 → 짝 왼쪽 문단을 추출한다.
+ * - 키: `paraPosKey(right)` (오른쪽 HWP 좌표계).
+ * - 값: DP/그리디가 같은 논리 슬롯으로 판단한 `left` 문단.
+ * `(null, right)`·`(left, null)` 삽입/삭제 축은 맵에 넣지 않는다 → 해당 문단의 컨트롤은 슬롯 매칭 대상에서 제외되고
+ * 이후 `extractTablePatiencePins` / `pairControlsFallback` / added·removed로 처리된다.
+ */
+function buildRightToLeftParaMapFromAligned(aligned: AlignedPair[]): Map<string, CompareParaSnapshot> {
+  const m = new Map<string, CompareParaSnapshot>();
+  for (const { left, right } of aligned) {
+    if (!left || !right) continue;
+    m.set(paraPosKey(right), left);
+  }
+  return m;
+}
+
+/** `buildTableSummary` 등이 만든 `key=value` 나열을 Record로 파싱. 값에 따옴표가 있으면 제거한다. */
+function parseSummaryKV(summary: string): Record<string, string> {
+  const out: Record<string, string> = {};
+  for (const m of summary.matchAll(/([a-z]+)=("([^"]*)"|[^\s]+)/g)) {
+    const raw = m[2] ?? '';
+    out[m[1]] = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+  }
+  return out;
+}
+
+/**
+ * `csha="r1c1=…&r2c2=…"` 형태(셀별 해시)를 키 단위로 비교해 변경된 셀 개수를 센다.
+ * 행/열 구조가 바뀌어 키 집합이 달라져도 union 키 기준으로 added/removed 셀을 모두 잡는다.
+ */
+function countChangedCellsByHash(leftHash: string, rightHash: string): number {
+  const parse = (v: string): Map<string, string> => {
+    const out = new Map<string, string>();
+    if (!v || v === '(없음)') return out;
+    for (const pair of v.split('&')) {
+      const i = pair.indexOf('=');
+      if (i <= 0) continue;
+      const key = pair.slice(0, i);
+      const value = pair.slice(i + 1);
+      out.set(key, value);
+    }
+    return out;
+  };
+  const l = parse(leftHash);
+  const r = parse(rightHash);
+  const keys = new Set<string>([...l.keys(), ...r.keys()]);
+  let changed = 0;
+  for (const k of keys) {
+    if ((l.get(k) ?? '') !== (r.get(k) ?? '')) changed += 1;
+  }
+  return changed;
+}
+
+/**
+ * 동일 컨트롤 쌍(l,r)에 대해 가능한 한 잘게 쪼갠 DiffItem[]을 만든다.
+ * - 표: 행/열·크기·셀 텍스트(cprev/csha)·속성(props)을 분리해 카드가 비지 않게 한다.
+ * - 이미지/도형: 크기·텍스트·자르기·효과 등 필드별 push.
+ * - `push` 내부에서 좌우 문자열이 같으면(강제 제외 아닌 이상) 항목을 생략한다.
+ */
+function buildGranularControlDiffs(
+  l: CompareControlSnapshot,
+  r: CompareControlSnapshot,
+  idStem: string,
+): DiffItem[] {
+  const lk = parseSummaryKV(l.summary);
+  const rk = parseSummaryKV(r.summary);
+  const items: DiffItem[] = [];
+  const label = kindLabel(l.kind);
+  const push = (suffix: string, title: string, leftPreview: string, rightPreview: string, force = false) => {
+    if (!force && leftPreview === rightPreview) return;
+    items.push({
+      id: mkDiffId(l.kind, `${idStem}:${suffix}`),
+      kind: l.kind,
+      severity: 'modified',
+      path: { section: r.section, paragraph: r.paragraph, controlKey: r.key },
+      title,
+      leftPreview,
+      rightPreview,
+      leftAnchor: l.anchor,
+      rightAnchor: r.anchor,
+    });
+  };
+
+  if (l.type === 'table' && r.type === 'table') {
+    const hasCellText =
+      (lk.cprev && lk.cprev !== '(없음)') ||
+      (rk.cprev && rk.cprev !== '(없음)') ||
+      (lk.tprev && lk.tprev !== '(없음)') ||
+      (rk.tprev && rk.tprev !== '(없음)');
+    const tableLabel = hasCellText ? '표' : '테이블';
+    const rowsColsChanged = (lk.r ?? '') !== (rk.r ?? '') || (lk.c ?? '') !== (rk.c ?? '');
+    push('rows-cols', `${tableLabel} 행/열 변경`, `r=${lk.r ?? '(없음)'} c=${lk.c ?? '(없음)'}`, `r=${rk.r ?? '(없음)'} c=${rk.c ?? '(없음)'}`);
+    push('size', `${tableLabel} 크기 변경`, `box=${lk.box ?? '(없음)'}`, `box=${rk.box ?? '(없음)'}`);
+    // UI의 행/열별 셀 비교는 cprev(r1c1=...&r1c2=...) 포맷을 기준으로 동작한다.
+    // cprev가 없을 때만 tprev로 폴백한다.
+    const lText = `cprev="${lk.cprev ?? lk.tprev ?? '(없음)'}"`;
+    const rText = `cprev="${rk.cprev ?? rk.tprev ?? '(없음)'}"`;
+    const tableTextChanged = (lk.txt ?? '') !== (rk.txt ?? '') || lText !== rText;
+    const changedCells = countChangedCellsByHash(lk.csha ?? '', rk.csha ?? '');
+    const textTitle = rowsColsChanged
+      ? `${tableLabel} 텍스트 변경(구조변경 동반${changedCells > 0 ? `, ${changedCells}셀` : ''})`
+      : `${tableLabel} 텍스트 변경${changedCells > 0 ? `(${changedCells}셀)` : ''}`;
+    push('text', textTitle, lText, rText, tableTextChanged);
+    push('style', `${tableLabel} 속성 변경`, `props=${lk.props ?? '(없음)'}`, `props=${rk.props ?? '(없음)'}`);
+    return items;
+  }
+
+  if (l.type === 'image' && r.type === 'image') {
+    push('size', '그림 크기 변경', `box=${lk.box ?? '(없음)'}`, `box=${rk.box ?? '(없음)'}`);
+    const imageTextChanged = (lk.text ?? '') !== (rk.text ?? '') || ((lk.pix ?? '') !== (rk.pix ?? '') && (lk.text ?? '') === (rk.text ?? ''));
+    push('text', '그림 텍스트 변경', `text="${lk.text ?? '(없음)'}" pix=${lk.pix ?? '(없음)'}`, `text="${rk.text ?? '(없음)'}" pix=${rk.pix ?? '(없음)'}`, imageTextChanged);
+    push('crop', '그림 자르기 변경', `crop=${lk.crop ?? '(없음)'}`, `crop=${rk.crop ?? '(없음)'}`);
+    push('effect', '그림 효과 변경', `effect=${lk.effect ?? '(없음)'} bc=${lk.bc ?? '(없음)'}`, `effect=${rk.effect ?? '(없음)'} bc=${rk.bc ?? '(없음)'}`);
+    return items;
+  }
+
+  if ((l.type === 'shape' || l.type === 'group') && (r.type === 'shape' || r.type === 'group')) {
+    push('size', `${label} 크기 변경`, `box=${lk.box ?? '(없음)'}`, `box=${rk.box ?? '(없음)'}`);
+    const shapeTextChanged = (lk.text ?? '') !== (rk.text ?? '') || ((lk.pix ?? '') !== (rk.pix ?? '') && (lk.text ?? '') === (rk.text ?? ''));
+    push('text', `${label} 텍스트 변경`, `text="${lk.text ?? '(없음)'}" pix=${lk.pix ?? '(없음)'}`, `text="${rk.text ?? '(없음)'}" pix=${rk.pix ?? '(없음)'}`, shapeTextChanged);
+    push('rotate', `${label} 회전/대칭 변경`, `rot=${lk.rot ?? '(없음)'} flip=${lk.flip ?? '(없음)'}`, `rot=${rk.rot ?? '(없음)'} flip=${rk.flip ?? '(없음)'}`);
+    push('layout', `${label} 배치 변경`, `wrap=${lk.wrap ?? '(없음)'} rel=${lk.rel ?? '(없음)'}`, `wrap=${rk.wrap ?? '(없음)'} rel=${rk.rel ?? '(없음)'}`);
+    return items;
+  }
+
+  push('generic', `${label} 속성 변경`, l.summary, r.summary);
+  return items;
+}
+
+// ─── 스냅샷 수집: WASM 단일 문서 → CompareDocumentSnapshot ─────────────────────
+
+/** 앵커용 문단 모양 요약 — 텍스트만 같고 번호/정렬이 다른 문단을 구분한다. */
+function compactParaShapeForAnchor(pp: ParaProperties): string {
+  const q = (v: number | undefined) => (v == null || Number.isNaN(v) ? 0 : Math.round(v / 2) * 2);
+  return JSON.stringify({
+    a: pp.alignment ?? '',
+    h: pp.headType ?? '',
+    lv: pp.paraLevel ?? 0,
+    n: pp.numberingId ?? 0,
+    i: q(pp.indent),
+    ml: q(pp.marginLeft),
+  });
+}
+
+/**
+ * WASM이 열린 단일 문서에서 비교용 스냅샷을 만든다.
+ * - 문단: 텍스트, 정규화 텍스트, stable_id, 레이아웃 앵커(커서 rect 기반), 구역 내 쪽번호,
+ *   `signature`(정규화 텍스트·컨트롤 개수 + `getParaPropertiesAt` 기반 문단모양 요약 `ps:`)
+ * - 개체: 페이지 레이아웃 + 문단별 table 순회를 합쳐 키를 `sid:` 우선으로 통일
+ * - 마지막에 `canonicalControlKey`로 중복을 합치고 `controlSnapshotQuality`로 더 나은 요약을 남긴다.
+ */
+function fillSnapshotFromWasm(
+  wasm: WasmBridge,
+  info: DocumentInfo,
+  displayName: string,
+  options: CompareOptions,
+): CompareDocumentSnapshot {
+  // 비교 스냅샷 직전에 강제 재조판하여 폰트/도형 반영 지연으로 인한 페이지 밀림을 줄인다.
+  wasm.refreshLayout();
+
+  const displayedPageByGlobalPage = new Map<number, number>();
+  for (let page = 0; page < info.pageCount; page += 1) {
+    try {
+      const pi = wasm.getPageInfo(page);
+      displayedPageByGlobalPage.set(page, pi.pageNumber ?? (page + 1));
+    } catch {
+      // page info 조회 실패 시 후속 fallback 사용
+    }
+  }
+
+  const paragraphs: CompareParaSnapshot[] = [];
+  /** 구역·문단별: 글머리/번호/개요 등 HWP `headType`이 Outline·Number인지(짧은 제목 앵커 후보용) */
+  const paraHeadOutlineOrNumber = new Map<string, boolean>();
+  let globalIndex = 0;
+  for (let sec = 0; sec < info.sectionCount; sec += 1) {
+    const paraCount = wasm.getParagraphCount(sec);
+    for (let para = 0; para < paraCount; para += 1) {
+      const length = wasm.getParagraphLength(sec, para);
+      const text = length > 0 ? wasm.getTextRange(sec, para, 0, length) : '';
+      const controls = wasm.getControlTextPositions(sec, para);
+      const normalizedText = normalizeText(text, options);
+      let shapeDigest = '';
+      try {
+        const pp = wasm.getParaPropertiesAt(sec, para);
+        shapeDigest = simpleHash(compactParaShapeForAnchor(pp));
+        const ht = pp.headType ?? 'None';
+        paraHeadOutlineOrNumber.set(`${sec}:${para}`, ht === 'Outline' || ht === 'Number');
+      } catch {
+        shapeDigest = '';
+        paraHeadOutlineOrNumber.set(`${sec}:${para}`, false);
+      }
+      // 문단 "내용+컨트롤 개수+문단모양" 지문 — alignment에서 앵커/유일쌍 찾기에 사용
+      const signature = simpleHash(
+        `${normalizedText}|cc:${controls.length}${shapeDigest ? `|ps:${shapeDigest}` : ''}`,
+      );
+      const stableId = wasm.getParagraphStableId(sec, para);
+      const anchor = (() => {
+        try {
+          const rect = wasm.getCursorRect(sec, para, 0);
+          return {
+            pageIndex: rect.pageIndex,
+            x: rect.x,
+            y: rect.y,
+            // 문단 시작 위치 기준 넓은 박스: UI 하이라이트·hitTest에 쓰기 위함(정밀 bbox는 아님)
+            width: 320,
+            height: Math.max(18, rect.height || 18),
+          };
+        } catch {
+          return undefined;
+        }
+      })();
+      const sectionPage = (() => {
+        if (!anchor) return 1;
+        return displayedPageByGlobalPage.get(anchor.pageIndex) ?? (anchor.pageIndex + 1);
+      })();
+      paragraphs.push({
+        section: sec,
+        paragraph: para,
+        sectionPage,
+        globalIndex,
+        stableId,
+        text,
+        normalizedText,
+        controlCount: controls.length,
+        signature,
+        isAnchorCandidate: false,
+        anchor,
+      });
+      globalIndex += 1;
+    }
+  }
+
+  // 글로벌 앵커 후보(`isAnchorCandidate`): 시그니처 중복은 즉시 탈락. 그 다음
+  // - 길이·엔트로피 등으로 “긴” 문단은 `isAnchorTextQualityOk`
+  // - 짧은 제목 줄은 `[…]` / 번호 목록 패턴(`isStructuralBlockTitleLine`) 또는 HWP Outline/Number 머리
+  // `buildAnchorPairs` 단계에서 짧은 후보는 `buildBothSidesUniqueTrimNorm`으로 양쪽 각 1회만 추가 검증.
+  const anchorTuning = resolveAnchorTuning(options);
+  const sigCount = new Map<string, number>();
+  for (const p of paragraphs) {
+    sigCount.set(p.signature, (sigCount.get(p.signature) ?? 0) + 1);
+  }
+  for (const p of paragraphs) {
+    const isDuplicate = (sigCount.get(p.signature) ?? 0) > 1;
+    if (isDuplicate) {
+      p.isAnchorCandidate = false;
+      continue;
+    }
+    const t = p.normalizedText.trim();
+    const headOutlineOrNumber = paraHeadOutlineOrNumber.get(`${p.section}:${p.paragraph}`) ?? false;
+    const structBracket =
+      t.length >= STRUCTURAL_ANCHOR_MIN_LEN &&
+      t.length < anchorTuning.minTextLen &&
+      isStructuralBlockTitleLine(t);
+    const structHeading =
+      headOutlineOrNumber && t.length >= 3 && t.length < anchorTuning.minTextLen;
+    const okNormal = isAnchorTextQualityOk(p.normalizedText, anchorTuning);
+    p.isAnchorCandidate = okNormal || structBracket || structHeading;
+  }
+  const paraStableByPos = new Map<string, string>();
+  const paraTextByPos = new Map<string, string>();
+  for (const p of paragraphs) {
+    paraStableByPos.set(`${p.section}:${p.paragraph}`, p.stableId);
+    paraTextByPos.set(`${p.section}:${p.paragraph}`, p.normalizedText.slice(0, 48));
+  }
+
+  const controls: CompareControlSnapshot[] = [];
+  const shapeDebugRows: Array<{
+    source: 'layout' | 'direct';
+    sec: number;
+    para: number;
+    ci: number;
+    type: string;
+    shapeTextLen: number;
+    usedDescription: boolean;
+    usedParaFallback: boolean;
+    hasPix: boolean;
+  }> = [];
+  for (let page = 0; page < info.pageCount; page += 1) {
+    const layout = wasm.getPageControlLayout(page);
+    for (const item of layout.controls) {
+      const sec = item.secIdx ?? -1;
+      const para = item.paraIdx ?? -1;
+      const ci = item.controlIdx ?? -1;
+      const paraStableId = sec >= 0 && para >= 0 ? paraStableByPos.get(`${sec}:${para}`) : undefined;
+      const key = paraStableId
+        ? `sid:${paraStableId}:${ci}:${item.type}`
+        : `loc:${sec}:${para}:${ci}:${item.type}`;
+      let summary = `${item.type} ${Math.round(item.w)}x${Math.round(item.h)}`;
+
+      try {
+        if (item.type === 'table' && sec >= 0 && para >= 0 && ci >= 0) {
+          summary = buildTableSummary(wasm, options, sec, para, ci);
+        } else if (item.type === 'image' && sec >= 0 && para >= 0 && ci >= 0) {
+          const pic = wasm.getPictureProperties(sec, para, ci);
+          const w = Math.round(pic.width);
+          const h = Math.round(pic.height);
+          const crop = [pic.cropLeft, pic.cropTop, pic.cropRight, pic.cropBottom].map((v) => Math.round(v)).join(',');
+          const effect = `${pic.effect}:${pic.rotationAngle ?? 0}`;
+          const bc = `${pic.brightness ?? 0}/${pic.contrast ?? 0}`;
+          const paraText = paraTextByPos.get(`${sec}:${para}`) ?? '';
+          const desc = ((pic.description ?? '').trim() || paraText).replaceAll('"', "'").slice(0, 48);
+          let pix = 'nopix';
+          try {
+            const raw = wasm.getControlImageData(sec, para, ci);
+            pix = simpleHashBytes(raw);
+          } catch {
+            pix = 'nopix';
+          }
+          summary = `image box=${w}x${h} crop=${crop} effect=${effect} bc=${bc} text="${desc || '(없음)'}" pix=${pix}`;
+        } else if ((item.type === 'shape' || item.type === 'group') && sec >= 0 && para >= 0 && ci >= 0) {
+          const props = wasm.getShapeProperties(sec, para, ci);
+          const box = `${Math.round(props.width)}x${Math.round(props.height)}`;
+          const rot = Math.round(props.rotationAngle ?? 0);
+          const flip = `${props.horzFlip ? 1 : 0}${props.vertFlip ? 1 : 0}`;
+          const wrap = props.textWrap ?? 'none';
+          const rel = `${props.horzRelTo ?? '-'}:${props.vertRelTo ?? '-'}`;
+          const paraText = paraTextByPos.get(`${sec}:${para}`) ?? '';
+          let shapeText = '';
+          try {
+            const st = wasm.getShapeText(sec, para, ci);
+            if (st.ok && st.text) shapeText = st.text;
+          } catch {
+            shapeText = '';
+          }
+          const desc = (shapeText.trim() || (props.description ?? '').trim() || paraText).replaceAll('"', "'").slice(0, 120);
+          const usedDescription = !shapeText.trim() && Boolean((props.description ?? '').trim());
+          const usedParaFallback = !shapeText.trim() && !(props.description ?? '').trim() && Boolean(paraText.trim());
+          let pix = 'nopix';
+          try {
+            const raw = wasm.getControlImageData(sec, para, ci);
+            pix = simpleHashBytes(raw);
+          } catch {
+            pix = 'nopix';
+          }
+          summary = `shape box=${box} rot=${rot} flip=${flip} wrap=${wrap} rel=${rel} text="${desc || '(없음)'}" pix=${pix}`;
+          shapeDebugRows.push({
+            source: 'layout',
+            sec,
+            para,
+            ci,
+            type: item.type,
+            shapeTextLen: shapeText.trim().length,
+            usedDescription,
+            usedParaFallback,
+            hasPix: pix !== 'nopix',
+          });
+        }
+      } catch {
+        // 일부 개체 타입은 속성 조회 API가 제한될 수 있다.
+      }
+
+      controls.push({
+        key,
+        type: item.type,
+        section: sec,
+        paragraph: para,
+        summary,
+        kind: mapControlKind(item.type, summary),
+        anchor: {
+          pageIndex: page,
+          x: item.x,
+          y: item.y,
+          width: Math.max(12, item.w),
+          height: Math.max(12, item.h),
+        },
+      });
+    }
+  }
+
+  // RTMS 계열에서 유효했던 방식과 동일한 취지:
+  // 페이지 레이아웃 매핑(item.secIdx/paraIdx)에만 의존하지 말고,
+  // 문단의 컨트롤 인덱스를 직접 순회하며 table/shape/image를 식별/요약한다.
+  for (const p of paragraphs) {
+    const controlCount = wasm.getControlTextPositions(p.section, p.paragraph).length;
+    for (let ci = 0; ci < controlCount; ci += 1) {
+      try {
+        const summary = buildTableSummary(wasm, options, p.section, p.paragraph, ci);
+        const key = p.stableId
+          ? `sid:${p.stableId}:${ci}:table`
+          : `loc:${p.section}:${p.paragraph}:${ci}:table`;
+        let anchor = p.anchor ?? { pageIndex: 0, x: 0, y: 0, width: 12, height: 12 };
+        try {
+          const bbox = wasm.getTableBBox(p.section, p.paragraph, ci);
+          anchor = {
+            pageIndex: bbox.pageIndex,
+            x: bbox.x,
+            y: bbox.y,
+            width: Math.max(12, bbox.width),
+            height: Math.max(12, bbox.height),
+          };
+        } catch {
+          // bbox 조회 실패 시 문단 anchor 유지
+        }
+        controls.push({
+          key,
+          type: 'table',
+          section: p.section,
+          paragraph: p.paragraph,
+          summary,
+          kind: 'table',
+          anchor,
+        });
+      } catch {
+        // getTableDimensions 실패 => table이 아닌 컨트롤
+      }
+
+      // 요소별 변경 추적 정책(도형/그림):
+      // - shape/image는 layout 경로만 사용해 오매핑을 최소화한다.
+      // - direct 경로는 table 전용으로 제한한다.
+    }
+  }
+
+  const uniqueControls = new Map<string, CompareControlSnapshot>();
+  for (const c of controls) {
+    const ck = canonicalControlKey(c);
+    const prev = uniqueControls.get(ck);
+    if (!prev) {
+      uniqueControls.set(ck, c);
+      continue;
+    }
+    // 같은 개체로 판정되면 더 품질 높은 스냅샷으로 교체
+    if (controlSnapshotQuality(c) > controlSnapshotQuality(prev)) {
+      uniqueControls.set(ck, c);
+    }
+  }
+
+  if (isCompareDebugEnabled()) {
+    const rows = shapeDebugRows;
+    const bySource = {
+      layout: rows.filter((r) => r.source === 'layout').length,
+      direct: rows.filter((r) => r.source === 'direct').length,
+    };
+    const withShapeText = rows.filter((r) => r.shapeTextLen > 0).length;
+    const withDescription = rows.filter((r) => r.usedDescription).length;
+    const withParaFallback = rows.filter((r) => r.usedParaFallback).length;
+    const withPix = rows.filter((r) => r.hasPix).length;
+    compareDbg('[shape-text-debug] 수집 요약', {
+      total: rows.length,
+      bySource,
+      withShapeText,
+      withDescription,
+      withParaFallback,
+      withPix,
+    });
+    compareDbg(
+      '[shape-text-debug] 샘플(최대 20)',
+      rows.slice(0, 20).map((r) => ({
+        src: r.source,
+        sec: r.sec,
+        para: r.para,
+        ci: r.ci,
+        type: r.type,
+        shapeTextLen: r.shapeTextLen,
+        desc: r.usedDescription,
+        paraFallback: r.usedParaFallback,
+        pix: r.hasPix,
+      })),
+    );
+    compareDbg(
+      '[shape-text-debug] 미추출 대상(shapeTextLen=0)',
+      rows
+        .filter((r) => r.shapeTextLen === 0)
+        .map((r) => ({
+          src: r.source,
+          sec: r.sec,
+          para: r.para,
+          ci: r.ci,
+          type: r.type,
+          desc: r.usedDescription,
+          paraFallback: r.usedParaFallback,
+          pix: r.hasPix,
+        })),
+    );
+  }
+
+  return {
+    meta: {
+      name: displayName,
+      sectionCount: info.sectionCount,
+      pageCount: info.pageCount,
+      pageDisplayNumbers: Array.from({ length: info.pageCount }, (_, pageIndex) =>
+        displayedPageByGlobalPage.get(pageIndex) ?? (pageIndex + 1),
+      ),
+    },
+    paragraphs,
+    controls: [...uniqueControls.values()],
+  };
+}
+
+// ─── 스냅샷 빌더 export (bytes vs 편집기 WASM) ─────────────────────────────────
+
+/** 디스크/외부 바이트 → 별도 WASM 인스턴스로 파싱 (stable_id는 이 인스턴스 세션 기준) */
+export async function buildSnapshotFromBytes(
+  bytes: Uint8Array,
+  fileName: string,
+  options: CompareOptions,
+): Promise<CompareDocumentSnapshot> {
+  const wasm = new WasmBridge();
+  await wasm.initialize();
+  const info = wasm.loadDocument(bytes, fileName);
+  return fillSnapshotFromWasm(wasm, info, fileName, options);
+}
+
+/** 편집기에 올라온 문서 그대로 스냅샷 — 이력 비교 시 stable_id 유지 */
+export function buildSnapshotFromWasm(
+  wasm: WasmBridge,
+  displayName: string,
+  options: CompareOptions,
+): CompareDocumentSnapshot {
+  const info = wasm.getDocumentInfo();
+  return fillSnapshotFromWasm(wasm, info, displayName, options);
+}
+
+/**
+ * IR `stable_id` → 문단 스냅샷. 값이 비어 있으면 identity 경로를 쓸 수 없어 null.
+ * 동일 stable_id가 여러 번 나오면 `#0,#1,…` occurrence suffix로 키를 유일화한다(빈 문단 다수 문서).
+ */
+function buildStableIdMap(snap: CompareDocumentSnapshot): Map<string, CompareParaSnapshot> | null {
+  const m = new Map<string, CompareParaSnapshot>();
+  const seen = new Map<string, number>();
+  for (const p of snap.paragraphs) {
+    if (!p.stableId) return null;
+    // fallback stable_id가 중복되는 문서(빈 문단 다수 등)도 identity를 사용하기 위해
+    // 등장 순서 기반 suffix로 키를 정규화한다.
+    const occ = seen.get(p.stableId) ?? 0;
+    seen.set(p.stableId, occ + 1);
+    const key = occ === 0 ? p.stableId : `${p.stableId}#${occ}`;
+    m.set(key, p);
+  }
+  return m;
+}
+
+// ─── identity 경로: 이력(동일 혈통)에서 stable_id 기준 O(N) 근사 텍스트 diff ───
+
+/**
+ * identity 텍스트 비교: stable_id 정규화 키로 좌/우 문단을 1:1 매칭.
+ * - 양쪽 중 한쪽에만 있으면 added/removed
+ * - 둘 다 있으면 normalizedText 불일치 시 modified + 문자 요약
+ * - kinds에 paragraphMeta가 있으면 이동/컨트롤 수 변화도 별도 항목으로 낸다
+ */
+function buildIdentityTextDiffs(left: CompareDocumentSnapshot, right: CompareDocumentSnapshot, kinds: DiffKind[]): DiffItem[] {
+  const lmap = buildStableIdMap(left);
+  const rmap = buildStableIdMap(right);
+  if (!lmap || !rmap) return [];
+
+  // 양쪽 Map의 key(stableId)를 합집합으로 만든다.
+  // -> 어떤 id든 최소 1회는 순회되므로 "한쪽만 존재(추가/삭제)"도 놓치지 않는다.
+  const keys = [...new Set([...lmap.keys(), ...rmap.keys()])];
+  keys.sort((a, b) => {
+    const la = lmap.get(a);
+    const lb = lmap.get(b);
+    const ra = rmap.get(a);
+    const rb = rmap.get(b);
+    const sa = la?.section ?? ra?.section ?? 0;
+    const sb = lb?.section ?? rb?.section ?? 0;
+    if (sa !== sb) return sa - sb;
+    const pa = la?.paragraph ?? ra?.paragraph ?? 0;
+    const pb = lb?.paragraph ?? rb?.paragraph ?? 0;
+    return pa - pb;
+  });
+
+  const diffs: DiffItem[] = [];
+  for (const id of keys) {
+    // 동일 id를 좌/우 Map에서 각각 조회:
+    // - l만 있으면: 기준 문서에는 있었는데 비교 문서에는 없음 => removed
+    // - r만 있으면: 비교 문서에 새로 생김 => added
+    // - 둘 다 있으면: 내용(normalizedText) 비교로 modified 여부 판단
+    // 조회 자체는 Map#get 이라 평균 O(1), 전체는 key 개수에 비례해 O(N)으로 동작한다.
+    const l = lmap.get(id);
+    const r = rmap.get(id);
+    if (l && !r) {
+      diffs.push({
+        id: mkDiffId('text', `id-removed:${id}`),
+        kind: 'text',
+        severity: 'removed',
+        path: { section: l.section, paragraph: l.paragraph },
+        title: '문단 삭제',
+        leftPreview: l.text,
+        rightPreview: '',
+        leftAnchor: l.anchor,
+      });
+      continue;
+    }
+    if (!l && r) {
+      diffs.push({
+        id: mkDiffId('text', `id-added:${id}`),
+        kind: 'text',
+        severity: 'added',
+        path: { section: r.section, paragraph: r.paragraph },
+        title: '문단 추가',
+        leftPreview: '',
+        rightPreview: r.text,
+        rightAnchor: r.anchor,
+      });
+      continue;
+    }
+    if (!l || !r) continue;
+
+    if (l.normalizedText !== r.normalizedText) {
+      diffs.push({
+        id: mkDiffId('text', `id-modified:${id}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(l, r),
+        title: '텍스트 변경',
+        leftPreview: l.text,
+        rightPreview: r.text,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+        inlineTextDiff: myersCharDiffSummary(l.text, r.text),
+      });
+    }
+
+    if (
+      kinds.includes('paragraphMeta') &&
+      l.signature === r.signature &&
+      Math.abs(l.globalIndex - r.globalIndex) > MOVE_DISTANCE_THRESHOLD
+    ) {
+      diffs.push({
+        id: mkDiffId('paragraphMeta', `id-moved:${id}`),
+        kind: 'paragraphMeta',
+        severity: 'modified',
+        path: preferRightPath(l, r),
+        title: '문단 순서 이동',
+        leftPreview: `A idx=${l.globalIndex}`,
+        rightPreview: `B idx=${r.globalIndex}`,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+      });
+    }
+
+    if (kinds.includes('paragraphMeta') && l.controlCount !== r.controlCount) {
+      diffs.push({
+        id: mkDiffId('paragraphMeta', `id-ctrlcount:${id}`),
+        kind: 'paragraphMeta',
+        severity: 'modified',
+        path: preferRightPath(l, r),
+        title: '문단 개체 수 변경',
+        leftPreview: `controls=${l.controlCount}`,
+        rightPreview: `controls=${r.controlCount}`,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+      });
+    }
+  }
+  return diffs;
+}
+
+// ─── 전략 선택·순수 reflow 에 대한 moved 메타 제거 ───────────────────────────
+
+/**
+ * 호출부 `options.strategy`와 실제 가능 여부를 교차 검사한다.
+ * `identity`를 요청해도 양쪽 `buildStableIdMap`이 null이면 alignment로 내려가 변동성이 커질 수 있다.
+ */
+function resolveTextCompareStrategy(
+  strategy: CompareStrategy,
+  left: CompareDocumentSnapshot,
+  right: CompareDocumentSnapshot,
+): 'identity' | 'alignment' {
+  const canId = Boolean(buildStableIdMap(left) && buildStableIdMap(right));
+  if (strategy === 'identity') return canId ? 'identity' : 'alignment';
+  return 'alignment';
+}
+
+/** `suppressPureReflowMoves`가 제거 대상으로 삼는 paragraphMeta 이동 항목만 true */
+function isParagraphMoveMeta(diff: DiffItem): boolean {
+  return diff.kind === 'paragraphMeta' && (diff.id.includes('moved:') || diff.id.includes('id-moved:'));
+}
+
+/**
+ * 삽입/삭제로 globalIndex만 밀린 것과 "진짜 순서 바뀜"을 구분해 moved 노이즈를 제거한다.
+ * (공유 sid의 상대 순서가 유지되고, 밀림량이 앞쪽 순수 추가/삭제 개수와 일치하면 제외)
+ */
+function suppressPureReflowMoves(
+  diffs: DiffItem[],
+  left: CompareDocumentSnapshot,
+  right: CompareDocumentSnapshot,
+): DiffItem[] {
+  const lmap = buildStableIdMap(left);
+  const rmap = buildStableIdMap(right);
+  if (!lmap || !rmap) return diffs;
+
+  const sharedLeftIds = left.paragraphs.map((p) => p.stableId).filter((id) => id && rmap.has(id));
+  const sharedRightIds = right.paragraphs.map((p) => p.stableId).filter((id) => id && lmap.has(id));
+  const rankLeft = new Map<string, number>();
+  const rankRight = new Map<string, number>();
+  sharedLeftIds.forEach((id, i) => rankLeft.set(id, i));
+  sharedRightIds.forEach((id, i) => rankRight.set(id, i));
+
+  const rightOnlyPrefixCount: number[] = Array(right.paragraphs.length + 1).fill(0);
+  for (let i = 0; i < right.paragraphs.length; i += 1) {
+    rightOnlyPrefixCount[i + 1] = rightOnlyPrefixCount[i] + (lmap.has(right.paragraphs[i].stableId) ? 0 : 1);
+  }
+  const leftOnlyPrefixCount: number[] = Array(left.paragraphs.length + 1).fill(0);
+  for (let i = 0; i < left.paragraphs.length; i += 1) {
+    leftOnlyPrefixCount[i + 1] = leftOnlyPrefixCount[i] + (rmap.has(left.paragraphs[i].stableId) ? 0 : 1);
+  }
+
+  return diffs.filter((d) => {
+    if (!isParagraphMoveMeta(d)) return true;
+    let l: CompareParaSnapshot | undefined;
+    let r: CompareParaSnapshot | undefined;
+
+    // identity 경로: id는 "paragraphMeta:id-moved:<stableId>"
+    const sid = d.id.includes('id-moved:') ? d.id.split('id-moved:')[1] : '';
+    if (sid) {
+      l = lmap.get(sid);
+      r = rmap.get(sid);
+    } else {
+      // alignment 경로: path가 좌측 기준으로 내려오는 moved:<sec>:<para>
+      l = left.paragraphs.find((p) => p.section === d.path.section && p.paragraph === d.path.paragraph);
+      r = l ? rmap.get(l.stableId) : undefined;
+    }
+    if (!l || !r) return true;
+
+    const delta = r.globalIndex - l.globalIndex;
+    if (delta === 0) return false;
+
+    const sameRelativeOrder = rankLeft.get(l.stableId) === rankRight.get(l.stableId);
+    if (!sameRelativeOrder) return true;
+
+    if (delta > 0) {
+      const addedBefore = rightOnlyPrefixCount[r.globalIndex];
+      if (delta === addedBefore) return false;
+    } else {
+      const removedBefore = leftOnlyPrefixCount[l.globalIndex];
+      if (-delta === removedBefore) return false;
+    }
+    return true;
+  });
+}
+
+// ─── alignment 중간 표현: 정렬 결과 한 줄(좌만·우만·양쪽) ─────────────────────
+// `AlignedPair[]`는 `buildTextDiffs`가 앵커 경계마다 `matchSegment`를 호출해 쌓은 뒤,
+// `buildParagraphAlignStepsFromAligned` → `cleanupParagraphAlignStepsToDiffItems`로 소비된다.
+// 컨트롤 슬롯 매칭은 cleanup **이전**의 동일 배열에서 `buildRightToLeftParaMapFromAligned`로 맵만 뽑는다.
+
+/** `matchSegment*`의 출력 원소. null 쪽은 해당 문서에 문단이 없음(삽입/삭제 축). */
+type AlignedPair = {
+  left: CompareParaSnapshot | null;
+  right: CompareParaSnapshot | null;
+};
+
+/** 컨트롤 폴백 매칭 단계에서 확정된 (좌, 우) 쌍 */
+type ControlPair = {
+  left: CompareControlSnapshot;
+  right: CompareControlSnapshot;
+};
+
+/** diff의 path는 보통 "변경 후" 좌표를 우선하지만, 우측이 없으면 좌측을 쓴다. */
+function preferRightPath(
+  left: { section: number; paragraph: number } | null,
+  right: { section: number; paragraph: number } | null,
+): { section: number; paragraph: number } {
+  if (right) return { section: right.section, paragraph: right.paragraph };
+  if (left) return { section: left.section, paragraph: left.paragraph };
+  return { section: 0, paragraph: 0 };
+}
+
+/**
+ * **구간 한정** 유일 시그니처 앵커(Patience / LCS 스타일).
+ *
+ * `leftSeg`·`rightSeg` **안에서만** 시그니처 빈도를 세므로, 전역적으로는 중복이어도 구간 안에서만 유일하면 핀이 된다.
+ * 양쪽에서 정확히 1번씩만 나오는 시그니처끼리 `ri`를 잡되, `ri`가 단조 증가하도록만 쌍을 채택해 교차 매칭을 막는다.
+ * `minTextLen`: 상위 구간은 `INTRA_UNIQUE_SIG_MIN_TOP`, 깊은 재귀는 `INTRA_UNIQUE_SIG_MIN_NESTED`로
+ * 짧은 줄의 우연 유일 핀을 줄인다. `tryMatchByNormHashPins`는 `minTextLen=0`으로 같은 로직을 재사용한다.
+ */
+function buildUniqueSigPairsInSlices(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+  minTextLen: number,
+): Array<{ li: number; ri: number }> {
+  const countL = new Map<string, number>();
+  const countR = new Map<string, number>();
+  for (const p of leftSeg) countL.set(p.signature, (countL.get(p.signature) ?? 0) + 1);
+  for (const p of rightSeg) countR.set(p.signature, (countR.get(p.signature) ?? 0) + 1);
+
+  const rightBySig = new Map<string, number[]>();
+  for (let ri = 0; ri < rightSeg.length; ri += 1) {
+    const p = rightSeg[ri];
+    if ((countR.get(p.signature) ?? 0) !== 1) continue;
+    if (p.normalizedText.length < minTextLen) continue;
+    if (!rightBySig.has(p.signature)) rightBySig.set(p.signature, []);
+    rightBySig.get(p.signature)!.push(ri);
+  }
+
+  const pairs: Array<{ li: number; ri: number }> = [];
+  let lastRi = -1;
+  for (let li = 0; li < leftSeg.length; li += 1) {
+    const lp = leftSeg[li];
+    if ((countL.get(lp.signature) ?? 0) !== 1) continue;
+    if (lp.normalizedText.length < minTextLen) continue;
+    const candidates = rightBySig.get(lp.signature);
+    if (!candidates || candidates.length !== 1) continue;
+    const ri = candidates[0];
+    if (ri <= lastRi) continue;
+    pairs.push({ li, ri });
+    lastRi = ri;
+  }
+  return pairs;
+}
+
+/** 문서 전체에서 `normalizedText.trim()` 문자열이 몇 번 나오는지 센다(빈 문자열 제외). */
+function countTrimNormText(paras: CompareParaSnapshot[]): Map<string, number> {
+  const m = new Map<string, number>();
+  for (const p of paras) {
+    const k = p.normalizedText.trim();
+    if (!k) continue;
+    m.set(k, (m.get(k) ?? 0) + 1);
+  }
+  return m;
+}
+
+/**
+ * trim `normalizedText` 가 왼쪽·오른쪽 문서에서 각각 정확히 한 번만 등장하는 문자열(교집합).
+ * 짧은 구조 앵커 후보가 전역적으로 우연 중복이 아닌지 확인할 때 사용한다.
+ */
+function buildBothSidesUniqueTrimNorm(left: CompareParaSnapshot[], right: CompareParaSnapshot[]): Set<string> {
+  const cl = countTrimNormText(left);
+  const cr = countTrimNormText(right);
+  const out = new Set<string>();
+  for (const [k, v] of cl) {
+    if (v !== 1) continue;
+    if (cr.get(k) === 1) out.add(k);
+  }
+  return out;
+}
+
+/**
+ * 전역 문단 배열에서 유일한 동일 시그니처 쌍을 단조 증가하는 `ri`로만 잡아 alignment 구간 경계를 만든다.
+ * 후보는 `fillSnapshotFromWasm`에서 `isAnchorCandidate`로 거른다(기본은 길이·엔트로피, 예외는 짧은 블록 제목·Outline/Number).
+ * `minTextLen` 미만인 후보는 trim 본문이 양쪽 문서에서 각각 한 번만 나올 때만 앵커로 승인한다.
+ */
+function buildAnchorPairs(
+  left: CompareParaSnapshot[],
+  right: CompareParaSnapshot[],
+  anchorTuning: Required<CompareAnchorTuning>,
+): Array<{ li: number; ri: number }> {
+  const shortOkTrim = buildBothSidesUniqueTrimNorm(left, right);
+  const rightBySig = new Map<string, number[]>();
+  for (let i = 0; i < right.length; i += 1) {
+    const p = right[i];
+    if (!p.isAnchorCandidate) continue;
+    if (!rightBySig.has(p.signature)) rightBySig.set(p.signature, []);
+    rightBySig.get(p.signature)!.push(i);
+  }
+
+  const pairs: Array<{ li: number; ri: number }> = [];
+  let lastRi = -1;
+  for (let li = 0; li < left.length; li += 1) {
+    const lp = left[li];
+    if (!lp.isAnchorCandidate) continue;
+    const t = lp.normalizedText.trim();
+    if (t.length < anchorTuning.minTextLen && !shortOkTrim.has(t)) continue;
+    const candidates = rightBySig.get(lp.signature);
+    if (!candidates || candidates.length !== 1) continue; // 앵커 오염 방지: 단일 매치만 앵커로 인정
+    const ri = candidates[0];
+    if (ri <= lastRi) continue;
+    pairs.push({ li, ri });
+    lastRi = ri;
+  }
+  return pairs;
+}
+
+// ─── 문단 정렬: 유사도·구조·비용 (DP / 그리디 공통) ─────────────────────────────
+// `textSimilarity`: 스냅샷의 normalizedText 기준. 정렬 외 일부 휴리스틱에서도 호출된다.
+// `isNearStructure` / `getEffectiveSimilarity` / `matchCost` / `scorePairGreedy` 는 문단 쌍 정렬 전용.
+
+/** 문자 2-gram Dice 계수. 공백 제거 문자열에 사용해 형태소 단위 토큰이 없을 때도 신호를 남긴다. */
+function charBigramSimilarity(a: string, b: string): number {
+  const aa = Array.from(a);
+  const bb = Array.from(b);
+  if (aa.length < 2 || bb.length < 2) return 0;
+  const gramsA = new Set<string>();
+  const gramsB = new Set<string>();
+  for (let i = 0; i < aa.length - 1; i += 1) gramsA.add(`${aa[i]}${aa[i + 1]}`);
+  for (let i = 0; i < bb.length - 1; i += 1) gramsB.add(`${bb[i]}${bb[i + 1]}`);
+  if (gramsA.size === 0 || gramsB.size === 0) return 0;
+  let inter = 0;
+  for (const g of gramsA) if (gramsB.has(g)) inter += 1;
+  return (2 * inter) / (gramsA.size + gramsB.size);
+}
+
+/**
+ * 토큰(공백 분리) + 문자 바이그램 혼합 유사도.
+ * 한국어는 조사/어미만 바뀌어도 토큰 집합이 크게 달라질 수 있어 `charSim`에 0.8 가중.
+ * `containsBoost`는 짧은 문자열이 긴 쪽에 거의 그대로 포함되는 경우(번호 접미 등)를 보정.
+ */
+function textSimilarity(a: string, b: string): number {
+  if (!a && !b) return 1;
+  if (!a || !b) return 0;
+  if (a === b) return 1;
+
+  const sa = new Set(a.split(/\s+/).filter(Boolean));
+  const sb = new Set(b.split(/\s+/).filter(Boolean));
+  const tokenSim =
+    sa.size === 0 || sb.size === 0
+      ? 0
+      : (() => {
+          let inter = 0;
+          for (const t of sa) if (sb.has(t)) inter += 1;
+          return (2 * inter) / (sa.size + sb.size);
+        })();
+
+  // 문자 유사도는 공백 변형 영향을 줄이기 위해 공백 제거본으로 계산한다.
+  const aNoWs = a.replace(/\s+/g, '');
+  const bNoWs = b.replace(/\s+/g, '');
+  const charSim = charBigramSimilarity(aNoWs, bNoWs);
+
+  // 한쪽이 다른 쪽을 거의 포함하면(예: "맛있다" -> "맛있다2") 동일 문단 가능성이 높다.
+  const shorter = a.length <= b.length ? a : b;
+  const longer = a.length <= b.length ? b : a;
+  const containsBoost = shorter.length >= 4 && longer.includes(shorter) ? 0.96 : 0;
+
+  // 문단 정렬: 한국어는 조사·어미만 바뀌어도 공백 토큰이 크게 달라지므로 바이그램 쪽 비중을 둔다.
+  const mixed = tokenSim * 0.2 + charSim * 0.8;
+  return Math.max(mixed, containsBoost);
+}
+
+/**
+ * 구역·문단 번호·(상대)globalIndex·컨트롤 수가 "같은 슬롯의 이웃"으로 볼 만한 쌍.
+ * - `matchSegment` 안에서는 `activeSegmentStructBase` 기준으로 베이스 대비 오프셋 차만 본다(베이스는 직전
+ *   글로벌 앵커 쌍이 있으면 그 `globalIndex`, 없으면 구간 첫 문단).
+ * - 그 밖(후처리 등)에서는 전역 `globalIndex` 차 ≤2를 그대로 사용한다.
+ */
+function isNearStructure(lp: CompareParaSnapshot, rp: CompareParaSnapshot): boolean {
+  if (lp.section !== rp.section) return false;
+  if (Math.abs(lp.paragraph - rp.paragraph) > 1) return false;
+  if (lp.controlCount !== rp.controlCount) return false;
+  if (activeSegmentStructBase) {
+    const dL = lp.globalIndex - activeSegmentStructBase.leftBaseGi;
+    const dR = rp.globalIndex - activeSegmentStructBase.rightBaseGi;
+    return Math.abs(dL - dR) <= 2;
+  }
+  return Math.abs(lp.globalIndex - rp.globalIndex) <= 2;
+}
+
+/** 공백 제거 기준 양쪽 문단이 충분히 길 때만 임계/부스트 완화(짧은 문단 노이즈 억제) */
+function isNearStructureLongPair(lp: CompareParaSnapshot, rp: CompareParaSnapshot): boolean {
+  const lenL = lp.normalizedText.replace(/\s+/g, '').length;
+  const lenR = rp.normalizedText.replace(/\s+/g, '').length;
+  return lenL > 15 && lenR > 15;
+}
+
+/**
+ * textSimilarity 통과 하한: 전역은 엄격, 구조 근접 시만 완화(짧은 문단은 우연 일치 억제).
+ * `textSimilarity` 자체는 수정하지 않고, DP/그리디의 `matchCost`·`scorePairGreedy`에서만 사용한다.
+ */
+function softSimilarityThresholdForPair(lp: CompareParaSnapshot, rp: CompareParaSnapshot): number {
+  if (!isNearStructure(lp, rp)) return MATCH_SOFT_SIM_MIN;
+  return isNearStructureLongPair(lp, rp) ? 0.25 : 0.45;
+}
+
+/**
+ * DP/그리디 평가 전용 유사도. `textSimilarity`는 순수 값으로 두고, 구조 근접·긴 문단일 때만 보정한다.
+ */
+function getEffectiveSimilarity(lp: CompareParaSnapshot, rp: CompareParaSnapshot): number {
+  const rawSim = textSimilarity(lp.normalizedText, rp.normalizedText);
+  if (!isNearStructure(lp, rp)) return rawSim;
+  if (!isNearStructureLongPair(lp, rp)) return rawSim;
+  if (rawSim > NEAR_STRUCTURE_MIN_SIM) {
+    return Math.max(rawSim, NEAR_STRUCTURE_SIM_BOOST);
+  }
+  return rawSim;
+}
+
+/** 매칭 비용: 낮을수록 좋음 (0 = 완전 일치). 서명 불일치 + 낮은 유사도는 치환 경로를 막아 이웃 문단 오매칭을 줄인다. */
+function matchCost(lp: CompareParaSnapshot, rp: CompareParaSnapshot): number {
+  if (lp.signature === rp.signature) return 0;
+  const sim = getEffectiveSimilarity(lp, rp);
+  const threshold = softSimilarityThresholdForPair(lp, rp);
+  if (sim < threshold) return MATCH_COST_WEAK;
+  let c = 1 - sim;
+  if (lp.controlCount !== rp.controlCount) c += 0.35;
+  if (isNearStructure(lp, rp)) c = Math.max(0, c - NEAR_STRUCTURE_COST_DISCOUNT);
+  return c;
+}
+
+/** 원본 문단을 복제하되 `signature`만 `nh:<hash(trim)>`로 바꿔, 유일 시그니처 핀 로직을 재사용한다. */
+function paraWithNormHashSig(p: CompareParaSnapshot): CompareParaSnapshot {
+  const key = p.normalizedText.trim();
+  const h = key ? simpleHash(key) : 'empty';
+  return { ...p, signature: `nh:${h}` };
+}
+
+/**
+ * DMP `diff_lineMode_`와 비슷한 **2단계 중 거시**: 구간 문단을 줄 단위 해시 토큰으로 본 뒤
+ * `buildUniqueSigPairsInSlices(..., minTextLen=0)`로 구간 내 양쪽 유일 쌍을 핀으로 세운다.
+ * 원문 시그니처만으로는 유일 핀이 없을 때(대량 삽입으로 서명이 겹칠 때) 큰 덩어리를 가른다.
+ * `NORM_HASH_PIN_MIN_TOTAL_PARAS` 미만이면 호출하지 않는다.
+ */
+function tryMatchByNormHashPins(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+  depth: number,
+  anchorBoundary: SegmentAnchorBoundary | null,
+): AlignedPair[] | null {
+  const n = leftSeg.length;
+  const m = rightSeg.length;
+  if (n + m < NORM_HASH_PIN_MIN_TOTAL_PARAS) return null;
+  const lh = leftSeg.map(paraWithNormHashSig);
+  const rh = rightSeg.map(paraWithNormHashSig);
+  const intra0 = buildUniqueSigPairsInSlices(lh, rh, 0);
+  if (intra0.length === 0) return null;
+  return runInternalAnchorBoundaries(leftSeg, rightSeg, intra0, depth, anchorBoundary);
+}
+
+/**
+ * 내부 핀(`intra`)을 경계로 삼아 슬라이스를 나누고, 각 조각에 `matchSegment`를 재귀한다.
+ * `intra`는 시그니처 기반(`matchSegmentWithInternalAnchors`)이든 해시 기반(`tryMatchByNormHashPins`)이든 동일.
+ */
+function runInternalAnchorBoundaries(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+  intra: Array<{ li: number; ri: number }>,
+  depth: number,
+  anchorBoundary: SegmentAnchorBoundary | null,
+): AlignedPair[] {
+  const boundaries = [{ li: -1, ri: -1 }, ...intra, { li: leftSeg.length, ri: rightSeg.length }];
+  const out: AlignedPair[] = [];
+  for (let i = 0; i < boundaries.length - 1; i += 1) {
+    const a = boundaries[i];
+    const b = boundaries[i + 1];
+    if (a.li >= 0 && a.ri >= 0) {
+      out.push({ left: leftSeg[a.li], right: rightSeg[a.ri] });
+    }
+    const ls = leftSeg.slice(a.li + 1, b.li);
+    const rs = rightSeg.slice(a.ri + 1, b.ri);
+    if (ls.length === 0 && rs.length === 0) continue;
+    out.push(...matchSegment(ls, rs, depth + 1, anchorBoundary));
+  }
+  return out;
+}
+
+/**
+ * 구간 내부 유일 시그니처 앵커로 쪼개 각 조각에 `matchSegment` 재귀.
+ * Git patience와 유사: DP에 넘기기 전 구간을 최대한 잘게 나눈다.
+ */
+function matchSegmentWithInternalAnchors(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+  depth: number,
+  anchorBoundary: SegmentAnchorBoundary | null,
+): AlignedPair[] {
+  const intraMin = depth >= 1 ? INTRA_UNIQUE_SIG_MIN_NESTED : INTRA_UNIQUE_SIG_MIN_TOP;
+  const intra = buildUniqueSigPairsInSlices(leftSeg, rightSeg, intraMin);
+  if (intra.length === 0) return [];
+  return runInternalAnchorBoundaries(leftSeg, rightSeg, intra, depth, anchorBoundary);
+}
+
+/**
+ * 문단 시그니처가 **연속으로** 동일한 최장 구간(시작 인덱스 포함).
+ * DMP half-match 유사: 그리디 직전 큰 구간을 한 번 가른다.
+ */
+function findLongestEqualSignatureRun(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+): { li0: number; ri0: number; len: number } | null {
+  const n = leftSeg.length;
+  const m = rightSeg.length;
+  if (n === 0 || m === 0) return null;
+  if (n * m > HALF_MATCH_MAX_PRODUCT) return null;
+  let bestLen = 0;
+  let bestI = 0;
+  let bestJ = 0;
+  for (let i = 0; i < n; i += 1) {
+    for (let j = 0; j < m; j += 1) {
+      if (leftSeg[i].signature !== rightSeg[j].signature) continue;
+      let k = 0;
+      while (i + k < n && j + k < m && leftSeg[i + k].signature === rightSeg[j + k].signature) k += 1;
+      if (k > bestLen) {
+        bestLen = k;
+        bestI = i;
+        bestJ = j;
+      }
+    }
+  }
+  if (bestLen < 1) return null;
+  const touchesAll = bestI === 0 && bestJ === 0 && bestLen === n && bestLen === m;
+  if (touchesAll) return null;
+  const hasLeftover = bestI > 0 || bestJ > 0 || bestI + bestLen < n || bestJ + bestLen < m;
+  if (!hasLeftover) return null;
+  if (bestLen < 2 && n + m < 12) return null;
+  return { li0: bestI, ri0: bestJ, len: bestLen };
+}
+
+/**
+ * 앵커 사이(또는 재귀 하위) 한 구간의 좌·우 문단 슬라이스를 `AlignedPair[]`로 정렬한다.
+ *
+ * 순서(대략):
+ * 1. `runWithSegmentStructBase`: `anchorBoundary`가 있으면 그 앵커의 globalIndex를 구조 베이스로,
+ *    없으면 슬라이스 첫 문단 쌍을 베이스로 `isNearStructure`가 동작하게 한다.
+ * 2. 시간 가드(`shouldBailToGreedy`) → 그리디 조기 종료.
+ * 3. `buildUniqueSigPairsInSlices`로 내부 유일 시그니처 핀이 있으면 `matchSegmentWithInternalAnchors`.
+ * 4. 없으면 `tryMatchByNormHashPins`(큰 구간만).
+ * 5. 셀 수 한도 내면 `matchSegmentDp`, 아니면 `findLongestEqualSignatureRun`으로 한 번 가르고 재귀,
+ *    그것도 어렵면 `matchWindowedGreedy`.
+ */
+function matchSegment(
+  leftSeg: CompareParaSnapshot[],
+  rightSeg: CompareParaSnapshot[],
+  depth = 0,
+  anchorBoundary: SegmentAnchorBoundary | null = null,
+): AlignedPair[] {
+  const n = leftSeg.length;
+  const m = rightSeg.length;
+  const perf = resolvePerformanceTuning(activeCompareOptions ?? DEFAULT_COMPARE_OPTIONS);
+  if (n === 0 && m === 0) return [];
+  if (n === 0) return rightSeg.map((rp) => ({ left: null, right: rp }));
+  if (m === 0) return leftSeg.map((lp) => ({ left: lp, right: null }));
+
+  const structBase: SegmentStructBase = anchorBoundary
+    ? { leftBaseGi: anchorBoundary.leftAnchorGi, rightBaseGi: anchorBoundary.rightAnchorGi }
+    : { leftBaseGi: leftSeg[0].globalIndex, rightBaseGi: rightSeg[0].globalIndex };
+
+  return runWithSegmentStructBase(structBase, () => {
+    if (shouldBailToGreedy()) return matchWindowedGreedy(leftSeg, rightSeg);
+
+    if (depth >= MAX_SEGMENT_RECURSION) {
+      if (n * m <= SEGMENT_DP_MAX * SEGMENT_DP_MAX && n * m <= perf.hardSegmentCells) {
+        return matchSegmentDp(leftSeg, rightSeg);
+      }
+      return matchWindowedGreedy(leftSeg, rightSeg);
+    }
+
+    const intraMin = depth >= 1 ? INTRA_UNIQUE_SIG_MIN_NESTED : INTRA_UNIQUE_SIG_MIN_TOP;
+    const intra = buildUniqueSigPairsInSlices(leftSeg, rightSeg, intraMin);
+    if (intra.length > 0) {
+      return matchSegmentWithInternalAnchors(leftSeg, rightSeg, depth, anchorBoundary);
+    }
+
+    const hashPinned = tryMatchByNormHashPins(leftSeg, rightSeg, depth, anchorBoundary);
+    if (hashPinned) return hashPinned;
+
+    if (n * m <= SEGMENT_DP_MAX * SEGMENT_DP_MAX && n * m <= perf.hardSegmentCells) {
+      return matchSegmentDp(leftSeg, rightSeg);
+    }
+
+    const run = findLongestEqualSignatureRun(leftSeg, rightSeg);
+    if (run && depth + 1 < MAX_SEGMENT_RECURSION) {
+      const { li0, ri0, len } = run;
+      const out: AlignedPair[] = [];
+      out.push(...matchSegment(leftSeg.slice(0, li0), rightSeg.slice(0, ri0), depth + 1, anchorBoundary));
+      for (let k = 0; k < len; k += 1) {
+        out.push({ left: leftSeg[li0 + k], right: rightSeg[ri0 + k] });
+      }
+      out.push(...matchSegment(leftSeg.slice(li0 + len), rightSeg.slice(ri0 + len), depth + 1, anchorBoundary));
+      return out;
+    }
+
+    return matchWindowedGreedy(leftSeg, rightSeg);
+  });
+}
+
+/**
+ * 표준 2문자열 편집 DP를 "문단 시퀀스"에 적용한 것. `dp[i][j]` = 왼쪽 i개·오른쪽 j개까지 최소 비용.
+ * - 치환 비용은 `matchCost`(0~수렴)이고 삽입/삭제는 고정 `del`/`ins`(1.05)로 스무딩한다.
+ * - 백트래킹 동률 시 `match > delete > insert` 순으로 분기해, 삽입으로만 밀린 것처럼 보이는 경향을 줄인다.
+ * - 연속한 `matchCost===0`(시그니처 일치 등) 대각선은 한 번에 소비(snake)해 백트래킹 루프 비용을 줄인다.
+ */
+function matchSegmentDp(leftSeg: CompareParaSnapshot[], rightSeg: CompareParaSnapshot[]): AlignedPair[] {
+  if (shouldBailToGreedy()) return matchWindowedGreedy(leftSeg, rightSeg);
+  const n = leftSeg.length;
+  const m = rightSeg.length;
+  const inf = 1e9;
+  /** 문단 한 줄 삽입/삭제 비용. 1.0보다 약간 크게 두어 무의미한 치환 남발을 억제 */
+  const del = 1.05;
+  const ins = 1.05;
+  const dp: number[][] = Array.from({ length: n + 1 }, () => Array(m + 1).fill(inf));
+  dp[0][0] = 0;
+  for (let i = 1; i <= n; i += 1) dp[i][0] = dp[i - 1][0] + del;
+  for (let j = 1; j <= m; j += 1) dp[0][j] = dp[0][j - 1] + ins;
+
+  for (let i = 1; i <= n; i += 1) {
+    if (i % 12 === 0 && shouldBailToGreedy()) return matchWindowedGreedy(leftSeg, rightSeg);
+    for (let j = 1; j <= m; j += 1) {
+      const mc = matchCost(leftSeg[i - 1], rightSeg[j - 1]);
+      dp[i][j] = Math.min(dp[i - 1][j - 1] + mc, dp[i - 1][j] + del, dp[i][j - 1] + ins);
+    }
+  }
+
+  const eps = 1e-5;
+  const out: AlignedPair[] = [];
+  let i = n;
+  let j = m;
+  while (i > 0 || j > 0) {
+    const candMatch =
+      i > 0 && j > 0
+        ? dp[i - 1][j - 1] + matchCost(leftSeg[i - 1], rightSeg[j - 1])
+        : inf;
+    const candDel = i > 0 ? dp[i - 1][j] + del : inf;
+    const candIns = j > 0 ? dp[i][j - 1] + ins : inf;
+    const target = dp[i][j];
+    if (i > 0 && j > 0 && Math.abs(candMatch - target) < eps) {
+      out.push({ left: leftSeg[i - 1], right: rightSeg[j - 1] });
+      i -= 1;
+      j -= 1;
+      // Snake: 이후 `matchCost===0`이고 대각선이 최적을 유지하는 동안 연속 소비.
+      while (i > 0 && j > 0) {
+        const lp = leftSeg[i - 1];
+        const rp = rightSeg[j - 1];
+        if (matchCost(lp, rp) !== 0) break;
+        if (Math.abs(dp[i][j] - dp[i - 1][j - 1]) >= eps) break;
+        const delC = dp[i - 1][j] + del;
+        const insC = dp[i][j - 1] + ins;
+        if (delC < dp[i][j] - eps || insC < dp[i][j] - eps) break;
+        out.push({ left: lp, right: rp });
+        i -= 1;
+        j -= 1;
+      }
+      continue;
+    } else if (i > 0 && Math.abs(candDel - target) < eps) {
+      out.push({ left: leftSeg[i - 1], right: null });
+      i -= 1;
+    } else if (j > 0 && Math.abs(candIns - target) < eps) {
+      out.push({ left: null, right: rightSeg[j - 1] });
+      j -= 1;
+    } else {
+      if (i > 0 && j > 0) {
+        out.push({ left: leftSeg[i - 1], right: rightSeg[j - 1] });
+        i -= 1;
+        j -= 1;
+      } else if (i > 0) {
+        out.push({ left: leftSeg[i - 1], right: null });
+        i -= 1;
+      } else {
+        out.push({ left: null, right: rightSeg[j - 1] });
+        j -= 1;
+      }
+    }
+  }
+  out.reverse();
+  return out;
+}
+
+/**
+ * 윈도 그리디 전용 점수. 음수면 후보에서 제외(`sim`이 쌍별 임계 미만 등).
+ * 서명 일치(+5)·컨트롤 수 일치(+1)·구조 근접(`NEAR_STRUCTURE_GREEDY_BONUS`)에 `sim*3`을 더해 스케일을 맞춘다.
+ */
+function scorePairGreedy(lp: CompareParaSnapshot, rp: CompareParaSnapshot): number {
+  const sim = getEffectiveSimilarity(lp, rp);
+  if (lp.signature !== rp.signature && sim < softSimilarityThresholdForPair(lp, rp)) return -1;
+  let score = 0;
+  if (lp.signature === rp.signature) score += 5;
+  if (lp.controlCount === rp.controlCount) score += 1;
+  if (isNearStructure(lp, rp)) score += NEAR_STRUCTURE_GREEDY_BONUS;
+  return score + sim * 3;
+}
+
+/**
+ * 대구간 폴백: 오른쪽 문단 순서대로 왼쪽 후보를 윈도 안에서 고른 뒤, 점수로 매칭.
+ * - `minScore`: 서명이 다른 의역 문단은 sim*3+보너스로도 낮게 나올 수 있어 NEAR_STRUCTURE_GREEDY_BONUS 로 보완.
+ * - `ambiguous`: 1·2위 점수 차가 GREEDY_AMBIGUOUS_GAP 미만이면 매칭 포기. 단 1위가 `isNearStructure`이면
+ *   동률 검사 생략(의역 쌍이 엉뚱한 2위와 0.2점 차로 동반 탈락하는 것 방지).
+ */
+function matchWindowedGreedy(leftSeg: CompareParaSnapshot[], rightSeg: CompareParaSnapshot[]): AlignedPair[] {
+  const aligned: AlignedPair[] = [];
+  const usedLeft = new Set<number>();
+  let leftCursor = 0;
+  /** 후보 거절 임계. 튜닝 시 `scorePairGreedy` 최솟값(서명 불일치·의역)과 함께 맞출 것 */
+  const minScore = 3.45;
+
+  const pickBestInRange = (rp: CompareParaSnapshot, start: number, end: number) => {
+    let bestLi = -1;
+    let bestScore = -1;
+    let secondScore = -1;
+    const lo = Math.max(0, start);
+    const hi = Math.min(leftSeg.length - 1, end);
+    for (let li = lo; li <= hi; li += 1) {
+      if (usedLeft.has(li)) continue;
+      const s = scorePairGreedy(leftSeg[li], rp);
+      if (s < 0) continue;
+      if (s > bestScore) {
+        secondScore = bestScore;
+        bestScore = s;
+        bestLi = li;
+      } else if (s > secondScore) {
+        secondScore = s;
+      }
+    }
+    return { bestLi, bestScore, secondScore };
+  };
+
+  for (let ri = 0; ri < rightSeg.length; ri += 1) {
+    if (ri % 32 === 0 && shouldBailToGreedy()) {
+      for (let rj = ri; rj < rightSeg.length; rj += 1) aligned.push({ left: null, right: rightSeg[rj] });
+      for (let li = 0; li < leftSeg.length; li += 1) {
+        if (!usedLeft.has(li)) aligned.push({ left: leftSeg[li], right: null });
+      }
+      return aligned;
+    }
+    const rp = rightSeg[ri];
+    // 이전 매칭 위치 근처를 먼저 본 뒤, 실패 시 전 구간 재탐색(의역으로 인덱스가 크게 어긋난 경우).
+    const start = Math.max(leftCursor, 0);
+    const end = Math.min(leftSeg.length - 1, leftCursor + WINDOW_SIZE + WINDOW_SIZE);
+    let { bestLi, bestScore, secondScore } = pickBestInRange(rp, start, end);
+
+    if (bestLi < 0 || bestScore < minScore) {
+      const full = pickBestInRange(rp, 0, leftSeg.length - 1);
+      if (full.bestScore > bestScore) {
+        bestLi = full.bestLi;
+        bestScore = full.bestScore;
+        secondScore = full.secondScore;
+      }
+    }
+
+    const isBestNear = bestLi >= 0 && isNearStructure(leftSeg[bestLi], rp);
+    const ambiguous =
+      !isBestNear && bestLi >= 0 && secondScore >= 0 && bestScore - secondScore < GREEDY_AMBIGUOUS_GAP;
+    if (bestLi >= 0 && bestScore >= minScore && !ambiguous) {
+      usedLeft.add(bestLi);
+      aligned.push({ left: leftSeg[bestLi], right: rp });
+      leftCursor = bestLi;
+    } else {
+      aligned.push({ left: null, right: rp });
+    }
+  }
+
+  for (let li = 0; li < leftSeg.length; li += 1) {
+    if (!usedLeft.has(li)) aligned.push({ left: leftSeg[li], right: null });
+  }
+  return aligned;
+}
+
+/** 왼쪽 한 문단이 오른쪽 연속 두 문단으로만 쪼개진 경우(순서: 앞·뒤) */
+function isLeftParagraphSplitIntoTwoRightParas(
+  left: CompareParaSnapshot,
+  rightHead: CompareParaSnapshot,
+  rightTail: CompareParaSnapshot,
+): boolean {
+  const joined = `${rightHead.normalizedText} ${rightTail.normalizedText}`.trim();
+  if (!joined) return false;
+  const leftN = left.normalizedText.replace(/\s+/g, ' ').trim();
+  const joinedN = joined.replace(/\s+/g, ' ').trim();
+  if (!leftN) return false;
+  // 중간 삽입으로 밀린 경우: R앞에 원문에 없던 긴 텍스트가 끼면 이어붙인 길이가 원문보다 커진다.
+  // textSimilarity의 contains 부스트만으로는 이 경우도 '분할'로 오인할 수 있어 길이로 한 번 걸러낸다.
+  const maxExtra = Math.max(2, Math.ceil(leftN.length * 0.06));
+  if (joinedN.length > leftN.length + maxExtra) return false;
+  return textSimilarity(left.normalizedText, joined) >= PARA_SPLIT_JOIN_SIM_MIN;
+}
+
+/**
+ * 유사도만으로는 잡기 어려운 케이스 보정:
+ * - 기존 빈 문단에 텍스트를 입력한 경우(sim=0에 가까움)도
+ *   구조 신호(구역/문단 위치/컨트롤 수)가 일치하면 "텍스트 변경"으로 본다.
+ */
+function shouldPromoteEmptyTextEdit(
+  left: CompareParaSnapshot,
+  right: CompareParaSnapshot,
+  leftParas: CompareParaSnapshot[],
+  rightParas: CompareParaSnapshot[],
+): boolean {
+  if (left.section !== right.section) return false;
+  // 문서 비교(alignment)에서는 앞쪽 삽입/삭제로 인덱스가 쉽게 밀리므로
+  // 빈문단 편집 승격은 근접 허용폭을 약간 넓힌다.
+  if (Math.abs(left.paragraph - right.paragraph) > 2) return false;
+  if (Math.abs(left.globalIndex - right.globalIndex) > 4) return false;
+  if (left.controlCount !== right.controlCount) return false;
+  const lEmpty = left.normalizedText.length === 0;
+  const rEmpty = right.normalizedText.length === 0;
+  if (lEmpty === rEmpty) return false;
+  const leftByGlobal = new Map<number, CompareParaSnapshot>(leftParas.map((p) => [p.globalIndex, p] as const));
+  const rightByGlobal = new Map<number, CompareParaSnapshot>(rightParas.map((p) => [p.globalIndex, p] as const));
+
+  const leftPrev = leftByGlobal.get(left.globalIndex - 1) ?? null;
+  const leftNext = leftByGlobal.get(left.globalIndex + 1) ?? null;
+  const rightPrev = rightByGlobal.get(right.globalIndex - 1) ?? null;
+  const rightNext = rightByGlobal.get(right.globalIndex + 1) ?? null;
+
+  const isEmptyPara = (p: CompareParaSnapshot | null) => !!p && p.normalizedText.length === 0;
+
+  // 연속 빈 문단 구간은 원래 보수적으로 차단했지만,
+  // 실제 문서에서는 "빈 문단 -> 텍스트 입력" 케이스가 여기에 걸려 added/removed로 남는 경우가 잦다.
+  // 슬롯 근접(문단/전역 인덱스)일 때는 빈 이웃이 있어도 승격을 허용한다.
+  const hasAdjacentEmpty =
+    isEmptyPara(leftPrev) || isEmptyPara(leftNext) || isEmptyPara(rightPrev) || isEmptyPara(rightNext);
+  if (hasAdjacentEmpty) {
+    const nearSlot =
+      Math.abs(left.paragraph - right.paragraph) <= 2 &&
+      Math.abs(left.globalIndex - right.globalIndex) <= 4;
+    if (!nearSlot) return false;
+  }
+
+  // 양옆 문맥 정합성: 바로 위/아래 문단 중 하나 이상은 시그니처가 유지되어야 한다.
+  const prevStable =
+    !!leftPrev &&
+    !!rightPrev &&
+    leftPrev.section === rightPrev.section &&
+    leftPrev.signature === rightPrev.signature;
+  const nextStable =
+    !!leftNext &&
+    !!rightNext &&
+    leftNext.section === rightNext.section &&
+    leftNext.signature === rightNext.signature;
+  if (!prevStable && !nextStable) {
+    // 양옆 시그니처가 모두 흔들린 케이스에서도,
+    // 같은 슬롯 근처(문단/전역 인덱스가 충분히 가까운 경우)면 빈문단 편집으로 본다.
+    const nearSlot =
+      Math.abs(left.paragraph - right.paragraph) <= 2 &&
+      Math.abs(left.globalIndex - right.globalIndex) <= 4;
+    if (!nearSlot) return false;
+  }
+
+  return true;
+}
+
+/**
+ * 정렬이 (삭제, 추가)로 쪼개졌지만 텍스트는 같은 문단의 수정에 가깝다고 볼 때(밀림·globalIndex 한계 보정).
+ */
+function shouldMergeRemovedAddedAsModify(lp: CompareParaSnapshot, rp: CompareParaSnapshot): boolean {
+  if (lp.section !== rp.section) return false;
+  if (lp.controlCount !== rp.controlCount) return false;
+  if (Math.abs(lp.paragraph - rp.paragraph) > REMOVED_ADDED_MAX_PARA_GAP) return false;
+  if (Math.abs(lp.globalIndex - rp.globalIndex) > REMOVED_ADDED_MAX_GLOBAL_GAP) return false;
+  return textSimilarity(lp.normalizedText, rp.normalizedText) >= REMOVED_ADDED_MERGE_SIM_MIN;
+}
+
+// ─── alignment 본문: 앵커 → 구간 정렬 → 단계 스트림 → cleanup ─────────────────
+
+/**
+ * `AlignedPair`를 한 칸씩 전진하는 스트림으로 바꾼다(DMP cleanup 전 단계).
+ * lookahead 없이 `cleanupParagraphAlignStepsToDiffItems`에서만 2칸 패턴을 처리한다.
+ */
+type ParagraphAlignStep =
+  | { kind: 'lr'; l: CompareParaSnapshot; r: CompareParaSnapshot }
+  | { kind: 'l'; l: CompareParaSnapshot }
+  | { kind: 'r'; r: CompareParaSnapshot };
+
+function buildParagraphAlignStepsFromAligned(aligned: AlignedPair[]): ParagraphAlignStep[] {
+  const steps: ParagraphAlignStep[] = [];
+  for (const pair of aligned) {
+    const { left: l, right: r } = pair;
+    if (!l && !r) continue;
+    if (l && !r) steps.push({ kind: 'l', l });
+    else if (!l && r) steps.push({ kind: 'r', r });
+    else steps.push({ kind: 'lr', l: l!, r: r! });
+  }
+  return steps;
+}
+
+/**
+ * 정렬 스트림을 `DiffItem[]`로 바꾼다. DMP `diff_cleanupSemantic`과 같이
+ * “기계적 변환 + 고정 순서 cleanup”을 한곳에 모은다.
+ */
+function cleanupParagraphAlignStepsToDiffItems(
+  steps: ParagraphAlignStep[],
+  lps: CompareParaSnapshot[],
+  rps: CompareParaSnapshot[],
+): DiffItem[] {
+  const diffs: DiffItem[] = [];
+  let i = 0;
+  while (i < steps.length) {
+    const s0 = steps[i];
+    const s1 = i + 1 < steps.length ? steps[i + 1] : null;
+
+    if (s0.kind === 'l' && s1?.kind === 'r' && shouldPromoteEmptyTextEdit(s0.l, s1.r, lps, rps)) {
+      diffs.push({
+        id: mkDiffId('text', `modified-empty-edit:${s0.l.section}:${s0.l.paragraph}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(s0.l, s1.r),
+        title: `텍스트 변경 (${s0.l.section}.${s0.l.paragraph})`,
+        leftPreview: s0.l.text,
+        rightPreview: s1.r.text,
+        leftAnchor: s0.l.anchor,
+        rightAnchor: s1.r.anchor,
+      });
+      i += 2;
+      continue;
+    }
+    if (s0.kind === 'r' && s1?.kind === 'l' && shouldPromoteEmptyTextEdit(s1.l, s0.r, lps, rps)) {
+      diffs.push({
+        id: mkDiffId('text', `modified-empty-edit:${s1.l.section}:${s1.l.paragraph}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(s1.l, s0.r),
+        title: `텍스트 변경 (${s1.l.section}.${s1.l.paragraph})`,
+        leftPreview: s1.l.text,
+        rightPreview: s0.r.text,
+        leftAnchor: s1.l.anchor,
+        rightAnchor: s0.r.anchor,
+      });
+      i += 2;
+      continue;
+    }
+
+    if (s0.kind === 'l' && s1?.kind === 'r' && shouldMergeRemovedAddedAsModify(s0.l, s1.r)) {
+      const r2 = s1.r;
+      diffs.push({
+        id: mkDiffId('text', `modified-merged:${s0.l.section}:${s0.l.paragraph}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(s0.l, r2),
+        title: `텍스트 변경 (${r2.section}.${r2.paragraph})`,
+        leftPreview: s0.l.text,
+        rightPreview: r2.text,
+        leftAnchor: s0.l.anchor,
+        rightAnchor: r2.anchor,
+        leftSectionPage: s0.l.sectionPage,
+        rightSectionPage: r2.sectionPage,
+      });
+      i += 2;
+      continue;
+    }
+    if (s0.kind === 'r' && s1?.kind === 'l' && shouldMergeRemovedAddedAsModify(s1.l, s0.r)) {
+      const l2 = s1.l;
+      diffs.push({
+        id: mkDiffId('text', `modified-merged:${l2.section}:${l2.paragraph}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(l2, s0.r),
+        title: `텍스트 변경 (${s0.r.section}.${s0.r.paragraph})`,
+        leftPreview: l2.text,
+        rightPreview: s0.r.text,
+        leftAnchor: l2.anchor,
+        rightAnchor: s0.r.anchor,
+        leftSectionPage: l2.sectionPage,
+        rightSectionPage: s0.r.sectionPage,
+      });
+      i += 2;
+      continue;
+    }
+
+    if (s0.kind === 'r' && s1?.kind === 'lr' && isLeftParagraphSplitIntoTwoRightParas(s1.l, s0.r, s1.r)) {
+      const L = s1.l;
+      const rHead = s0.r;
+      const rTail = s1.r;
+      diffs.push(
+        {
+          id: mkDiffId('text', `modified:${L.section}:${L.paragraph}`),
+          kind: 'text',
+          severity: 'modified',
+          path: preferRightPath(L, rHead),
+          title: `텍스트 변경 (${rHead.section}.${rHead.paragraph})`,
+          leftPreview: L.text,
+          rightPreview: rHead.text,
+          leftAnchor: L.anchor,
+          rightAnchor: rHead.anchor,
+          leftSectionPage: L.sectionPage,
+          rightSectionPage: rHead.sectionPage,
+        },
+        {
+          id: mkDiffId('text', `added:${rTail.section}:${rTail.paragraph}`),
+          kind: 'text',
+          severity: 'added',
+          path: { section: rTail.section, paragraph: rTail.paragraph },
+          title: `문단 추가 (${rTail.section}.${rTail.paragraph})`,
+          leftPreview: '',
+          rightPreview: rTail.text,
+          rightAnchor: rTail.anchor,
+          rightSectionPage: rTail.sectionPage,
+        },
+      );
+      i += 2;
+      continue;
+    }
+
+    if (s0.kind === 'r') {
+      const r = s0.r;
+      diffs.push({
+        id: mkDiffId('text', `added:${r.section}:${r.paragraph}`),
+        kind: 'text',
+        severity: 'added',
+        path: { section: r.section, paragraph: r.paragraph },
+        title: `문단 추가 (${r.section}.${r.paragraph})`,
+        leftPreview: '',
+        rightPreview: r.text,
+        rightAnchor: r.anchor,
+        rightSectionPage: r.sectionPage,
+      });
+      i += 1;
+      continue;
+    }
+    if (s0.kind === 'l') {
+      const l = s0.l;
+      diffs.push({
+        id: mkDiffId('text', `removed:${l.section}:${l.paragraph}`),
+        kind: 'text',
+        severity: 'removed',
+        path: preferRightPath(l, null),
+        title: `문단 삭제 (${l.section}.${l.paragraph})`,
+        leftPreview: l.text,
+        rightPreview: '',
+        leftAnchor: l.anchor,
+        leftSectionPage: l.sectionPage,
+      });
+      i += 1;
+      continue;
+    }
+
+    const l = s0.l;
+    const r = s0.r;
+    if (l.normalizedText !== r.normalizedText) {
+      diffs.push({
+        id: mkDiffId('text', `modified:${l.section}:${l.paragraph}`),
+        kind: 'text',
+        severity: 'modified',
+        path: preferRightPath(l, r),
+        title: `텍스트 변경 (${l.section}.${l.paragraph})`,
+        leftPreview: l.text,
+        rightPreview: r.text,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+      });
+    }
+
+    if (l.signature === r.signature && Math.abs(l.globalIndex - r.globalIndex) > MOVE_DISTANCE_THRESHOLD) {
+      diffs.push({
+        id: mkDiffId('paragraphMeta', `moved:${l.section}:${l.paragraph}`),
+        kind: 'paragraphMeta',
+        severity: 'modified',
+        path: { section: l.section, paragraph: l.paragraph },
+        title: `문단 이동 감지 (${l.section}.${l.paragraph})`,
+        leftPreview: `A idx=${l.globalIndex}`,
+        rightPreview: `B idx=${r.globalIndex}`,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+      });
+    }
+
+    if (l.controlCount !== r.controlCount) {
+      diffs.push({
+        id: mkDiffId('paragraphMeta', `ctrlcount:${l.section}:${l.paragraph}`),
+        kind: 'paragraphMeta',
+        severity: 'modified',
+        path: { section: l.section, paragraph: l.paragraph },
+        title: `문단 개체 수 변경 (${l.section}.${l.paragraph})`,
+        leftPreview: `controls=${l.controlCount}`,
+        rightPreview: `controls=${r.controlCount}`,
+        leftAnchor: l.anchor,
+        rightAnchor: r.anchor,
+      });
+    }
+
+    i += 1;
+  }
+  return diffs;
+}
+
+/**
+ * 문서 대 문서(alignment) 텍스트 diff + 컨트롤 매칭용 문단 맵.
+ *
+ * 1. `buildAnchorPairs`: 글로벌 앵커(단조 `ri`, 시그니처 유일, 짧은 줄은 trim 양쪽 1회).
+ * 2. 앵커 경계마다 `matchSegment(..., anchorBoundary)`로 `AlignedPair[]` 누적.
+ * 3. `buildRightToLeftParaMapFromAligned(aligned)`: 오른쪽 문단 좌표 → 짝 왼쪽 문단(양쪽 non-null만).
+ * 4. `buildParagraphAlignStepsFromAligned` → `cleanupParagraphAlignStepsToDiffItems`로 `DiffItem[]` 생성.
+ *
+ * 반환의 `rightToLeftPara`는 cleanup 이전 `aligned`와 일치한다. 컨트롤 단계는 이 맵으로
+ * 물리 `paragraph`가 달라도 같은 논리 문단의 개체를 다시 붙인다(`buildControlDiffs`).
+ */
+function buildTextDiffs(left: CompareDocumentSnapshot, right: CompareDocumentSnapshot): {
+  diffs: DiffItem[];
+  rightToLeftPara: Map<string, CompareParaSnapshot>;
+} {
+  const lps = left.paragraphs;
+  const rps = right.paragraphs;
+  const anchorTuning = resolveAnchorTuning(activeCompareOptions ?? DEFAULT_COMPARE_OPTIONS);
+  const anchors = buildAnchorPairs(lps, rps, anchorTuning);
+  if (isCompareDebugEnabled()) {
+    compareDbg(
+      '[③ 앵커] 시그니처 유일 + 품질필터(길이/공백비율/엔트로피). 빈 줄·패턴 문장이 많으면 구간이 어긋날 수 있음.',
+      `앵커 ${anchors.length}쌍 (앞 20개)`,
+      anchors.slice(0, 20).map(({ li, ri }) => ({
+        li,
+        ri,
+        left: lps[li].text.slice(0, 44),
+        right: rps[ri].text.slice(0, 44),
+        normLenL: lps[li].normalizedText.length,
+        normLenR: rps[ri].normalizedText.length,
+        anchorMinLen: anchorTuning.minTextLen,
+      })),
+    );
+  }
+  // 경계: (문서 시작) — 앵커1 — … — 앵커N — (문서 끝). 각 앵커 쌍 자체는 1:1 고정 매칭.
+  const boundaries = [{ li: -1, ri: -1 }, ...anchors, { li: lps.length, ri: rps.length }];
+
+  const aligned: AlignedPair[] = [];
+  for (let i = 0; i < boundaries.length - 1; i += 1) {
+    const a = boundaries[i];
+    const b = boundaries[i + 1];
+
+    if (a.li >= 0 && a.ri >= 0) {
+      aligned.push({ left: lps[a.li], right: rps[a.ri] });
+    }
+
+    // 앵커 (a)와 (b) "사이"의 문단만 DP/그리디에 넘긴다. 앵커 문단 본인은 위에서 이미 짝을 맞춤.
+    const leftSeg = lps.slice(a.li + 1, b.li);
+    const rightSeg = rps.slice(a.ri + 1, b.ri);
+    if (leftSeg.length === 0 && rightSeg.length === 0) continue;
+    const anchorBoundary: SegmentAnchorBoundary | null =
+      a.li >= 0 && a.ri >= 0
+        ? { leftAnchorGi: lps[a.li].globalIndex, rightAnchorGi: rps[a.ri].globalIndex }
+        : null;
+    aligned.push(...matchSegment(leftSeg, rightSeg, 0, anchorBoundary));
+  }
+
+  const rightToLeftPara = buildRightToLeftParaMapFromAligned(aligned);
+  const steps = buildParagraphAlignStepsFromAligned(aligned);
+  const diffs = cleanupParagraphAlignStepsToDiffItems(steps, lps, rps);
+  return { diffs, rightToLeftPara };
+}
+
+/**
+ * 키가 달라진 뒤에도 **표(table)** 만 모아, 요약 문자열에서 뽑은 키(`txt` / `sig` / 해시) 기준으로
+ * 양쪽 문서에서 각각 **정확히 한 개**뿐인 표끼리 1:1 고정한다(Git Patience 유사).
+ *
+ * 문단 슬롯(`pairAlignmentSlotControls`)이 먼저 돌기 때문에, 동일 표가 이미 짝지어졌으면 여기까지 내려오지 않는다.
+ * 이 단계는 표 요약이 충분히 구별될 때만 효과가 있다.
+ */
+function extractTablePatiencePins(
+  left: CompareControlSnapshot[],
+  right: CompareControlSnapshot[],
+): { pins: ControlPair[]; restLeft: CompareControlSnapshot[]; restRight: CompareControlSnapshot[] } {
+  const pins: ControlPair[] = [];
+  const lTables = left.filter((c) => c.type === 'table');
+  const rTables = right.filter((c) => c.type === 'table');
+  if (lTables.length === 0 || rTables.length === 0) {
+    return { pins: [], restLeft: left, restRight: right };
+  }
+  const keyOf = (c: CompareControlSnapshot): string => {
+    const kv = parseSummaryKV(c.summary);
+    const t = (kv.txt ?? '').trim();
+    if (t) return `t:${t}`;
+    const sg = (kv.sig ?? '').trim();
+    if (sg) return `s:${sg}`;
+    return `h:${simpleHash(c.summary)}`;
+  };
+  const lByKey = new Map<string, CompareControlSnapshot[]>();
+  const rByKey = new Map<string, CompareControlSnapshot[]>();
+  for (const c of lTables) {
+    const k = keyOf(c);
+    const arr = lByKey.get(k);
+    if (arr) arr.push(c);
+    else lByKey.set(k, [c]);
+  }
+  for (const c of rTables) {
+    const k = keyOf(c);
+    const arr = rByKey.get(k);
+    if (arr) arr.push(c);
+    else rByKey.set(k, [c]);
+  }
+  const usedL = new Set<CompareControlSnapshot>();
+  const usedR = new Set<CompareControlSnapshot>();
+  for (const [k, ls] of lByKey) {
+    const rs = rByKey.get(k);
+    if (!rs || ls.length !== 1 || rs.length !== 1) continue;
+    pins.push({ left: ls[0], right: rs[0] });
+    usedL.add(ls[0]);
+    usedR.add(rs[0]);
+  }
+  return {
+    pins,
+    restLeft: left.filter((c) => !usedL.has(c)),
+    restRight: right.filter((c) => !usedR.has(c)),
+  };
+}
+
+/**
+ * 문단 정렬 맵(`rightToLeftPara`)을 이용한 컨트롤 **슬롯** 매칭.
+ *
+ * 전제: `kind::key` 1차 매칭에서 빠진 표·도형·그림이 있다. 오른쪽 컨트롤 `r`의 부모 문단이
+ * 맵에서 왼쪽 문단 `L`로 짝지어져 있으면, 후보는 **같은 문단 좌표(`paraPosKey(L)`)에 남아 있는
+ * 왼쪽 미매칭 컨트롤**으로 한정한다. 이렇게 하면 위쪽에 표가 삽입되어 y·para 인덱스만 밀린 경우에도
+ * “테스트 7 표 vs 테스트 7 표”처럼 짝을 다시 찾을 수 있다.
+ *
+ * 알고리즘: 오른쪽을 (section, paragraph, controlIdx)순으로 정렬한 뒤, 각 `r`에 대해 버킷 내에서
+ * `scoreControlFallback` 최대 + `ALIGNMENT_CONTROL_SLOT_BONUS`가 `ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE`
+ * 이상인 쌍만 채택(탐욕, 한 왼쪽 개체는 한 번만 사용).
+ */
+function pairAlignmentSlotControls(
+  unmatchedLeft: CompareControlSnapshot[],
+  unmatchedRight: CompareControlSnapshot[],
+  rightToLeftPara: Map<string, CompareParaSnapshot>,
+): { pairs: ControlPair[]; restLeft: CompareControlSnapshot[]; restRight: CompareControlSnapshot[] } {
+  if (rightToLeftPara.size === 0) {
+    return { pairs: [], restLeft: unmatchedLeft, restRight: unmatchedRight };
+  }
+  const leftByPara = new Map<string, CompareControlSnapshot[]>();
+  for (const c of unmatchedLeft) {
+    const k = paraPosKey(c);
+    if (!leftByPara.has(k)) leftByPara.set(k, []);
+    leftByPara.get(k)!.push(c);
+  }
+  for (const arr of leftByPara.values()) {
+    arr.sort((a, b) => (extractControlIndexFromKey(a.key) ?? 0) - (extractControlIndexFromKey(b.key) ?? 0));
+  }
+
+  const sortedR = [...unmatchedRight].sort((a, b) => {
+    if (a.section !== b.section) return a.section - b.section;
+    if (a.paragraph !== b.paragraph) return a.paragraph - b.paragraph;
+    return (extractControlIndexFromKey(a.key) ?? 0) - (extractControlIndexFromKey(b.key) ?? 0);
+  });
+
+  const usedL = new Set<CompareControlSnapshot>();
+  const usedR = new Set<CompareControlSnapshot>();
+  const pairs: ControlPair[] = [];
+
+  for (const r of sortedR) {
+    const lp = rightToLeftPara.get(paraPosKey(r));
+    if (!lp) continue;
+    const bucket = leftByPara.get(paraPosKey(lp));
+    if (!bucket?.length) continue;
+    let best: CompareControlSnapshot | null = null;
+    let bestAdj = -1;
+    for (const l of bucket) {
+      if (usedL.has(l)) continue;
+      const raw = scoreControlFallback(l, r);
+      if (raw < 0) continue;
+      const adj = raw + ALIGNMENT_CONTROL_SLOT_BONUS;
+      if (adj > bestAdj) {
+        bestAdj = adj;
+        best = l;
+      }
+    }
+    if (best && bestAdj >= ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE) {
+      usedL.add(best);
+      usedR.add(r);
+      pairs.push({ left: best, right: r });
+    }
+  }
+
+  return {
+    pairs,
+    restLeft: unmatchedLeft.filter((c) => !usedL.has(c)),
+    restRight: unmatchedRight.filter((c) => !usedR.has(c)),
+  };
+}
+
+/** compareSnapshots 등에서 options 일부가 빠졌을 때의 기본값. kinds는 UI 노이즈를 줄이기 위해 화이트리스트 형태 */
+const DEFAULT_COMPARE_OPTIONS: CompareOptions = {
+  caseSensitive: false,
+  ignoreWhitespace: true,
+  kinds: ['text', 'table', 'shape', 'image', 'chart', 'paragraphMeta'],
+};
+
+/** compareSnapshots 실행 중 `matchCost`/`resolveAnchorTuning` 등이 읽는 전역(스레드 안전은 요구하지 않음) */
+let activeCompareOptions: CompareOptions | null = null;
+
+// ─── 컨트롤 diff: 키 매칭 → 정렬 슬롯 → 표 patience 핀 → 폴백 → added/removed ───
+
+/**
+ * 표·도형·그림 등 컨트롤 diff. 단계:
+ *
+ * 1. **키 정확 매칭** — `kind::key`(우선 `sid:paraStableId:ci:type`). 좌우 동시 존재하면 내용 비교 후
+ *    `buildGranularControlDiffs` 또는 동일 시 생략. 한쪽만 있으면 unmatched 버퍼.
+ * 2. **정렬 슬롯**(`rightToLeftPara`가 비어 있지 않을 때) — `pairAlignmentSlotControls`.
+ *    짝이 맞고 요약·종류까지 같으면 diff 생략(순수 밀림), 다르면 `align-slot:` 스템으로 상세 diff.
+ * 3. **표 Patience** — `extractTablePatiencePins`(요약에서 뽑은 키가 양쪽 유일할 때).
+ * 4. **전역 폴백** — `pairControlsFallback`(임계 2.75). 동일 요약·타입이면 생략.
+ * 5. 남은 항목은 added / removed.
+ *
+ * `identity` 전략에서는 맵이 비어 2단계가 no-op이 된다.
+ */
+function buildControlDiffs(
+  left: CompareDocumentSnapshot,
+  right: CompareDocumentSnapshot,
+  rightToLeftPara?: Map<string, CompareParaSnapshot>,
+): DiffItem[] {
+  const diffs: DiffItem[] = [];
+  const lmap = new Map(left.controls.map((c) => [`${c.kind}::${c.key}`, c] as const));
+  const rmap = new Map(right.controls.map((c) => [`${c.kind}::${c.key}`, c] as const));
+  const unmatchedLeft: CompareControlSnapshot[] = [];
+  const unmatchedRight: CompareControlSnapshot[] = [];
+
+  // 1차: key 기반 정확 매칭
+  const keys = new Set([...lmap.keys(), ...rmap.keys()]);
+  for (const key of keys) {
+    const l = lmap.get(key);
+    const r = rmap.get(key);
+    if (l && r) {
+      if (l.summary !== r.summary || l.kind !== r.kind) {
+        diffs.push(...buildGranularControlDiffs(l, r, `modified:${key}`));
+      }
+      continue;
+    }
+    if (l) unmatchedLeft.push(l);
+    if (r) unmatchedRight.push(r);
+  }
+
+  let slotRestL = unmatchedLeft;
+  let slotRestR = unmatchedRight;
+  if (rightToLeftPara && rightToLeftPara.size > 0) {
+    const slot = pairAlignmentSlotControls(unmatchedLeft, unmatchedRight, rightToLeftPara);
+    for (const { left: l, right: r } of slot.pairs) {
+      if (l.summary !== r.summary || l.kind !== r.kind) {
+        diffs.push(...buildGranularControlDiffs(l, r, `align-slot:${l.key}=>${r.key}`));
+      }
+    }
+    slotRestL = slot.restLeft;
+    slotRestR = slot.restRight;
+  }
+
+  const { pins, restLeft, restRight } = extractTablePatiencePins(slotRestL, slotRestR);
+  for (const { left: l, right: r } of pins) {
+    if (l.summary !== r.summary || l.kind !== r.kind) {
+      diffs.push(...buildGranularControlDiffs(l, r, `table-pin:${l.key}=>${r.key}`));
+    }
+  }
+
+  // 2차: key가 달라진 컨트롤(특히 표/이미지)의 폴백 매칭
+  const fallbackPairs = pairControlsFallback(restLeft, restRight);
+  const pairedL = new Set(fallbackPairs.map((p) => p.left));
+  const pairedR = new Set(fallbackPairs.map((p) => p.right));
+  for (const { left: l, right: r } of fallbackPairs) {
+    // 매칭 키만 달라지고 내용/속성이 동일하면 "밀림 보정" 성격의 재매칭이므로 결과에서 제외한다.
+    if (l.summary === r.summary && l.type === r.type && l.kind === r.kind) continue;
+    diffs.push(...buildGranularControlDiffs(l, r, `fallback-modified:${l.key}=>${r.key}`));
+  }
+
+  for (const r of restRight) {
+    if (pairedR.has(r)) continue;
+    const key = `${r.kind}::${r.key}`;
+    diffs.push({
+      id: mkDiffId(r.kind, `added:${key}`),
+      kind: r.kind,
+      severity: 'added',
+      path: { section: r.section, paragraph: r.paragraph, controlKey: key },
+      title: `${kindLabel(r.kind)} 추가`,
+      leftPreview: '',
+      rightPreview: r.summary,
+      rightAnchor: r.anchor,
+    });
+  }
+  for (const l of restLeft) {
+    if (pairedL.has(l)) continue;
+    const key = `${l.kind}::${l.key}`;
+    diffs.push({
+      id: mkDiffId(l.kind, `removed:${key}`),
+      kind: l.kind,
+      severity: 'removed',
+      path: { section: l.section, paragraph: l.paragraph, controlKey: key },
+      title: `${kindLabel(l.kind)} 삭제`,
+      leftPreview: l.summary,
+      rightPreview: '',
+      leftAnchor: l.anchor,
+    });
+  }
+  return diffs;
+}
+
+/**
+ * 키·슬롯·표 핀 이후에도 남은 좌·우 컨트롤을 **전역 탐욕**으로 짝지음(오른쪽 각각에 대해 왼쪽 후보 중 최고점).
+ *
+ * `bestScore >= 2.75` 미만이면 매칭하지 않는다 — 절대 좌표·요약 유사도만으로 오매칭하면 added/removed 노이즈가 커지기 때문.
+ * 문단 정렬이 신뢰되는 경우에는 먼저 `pairAlignmentSlotControls`가 같은 논리 문단 안에서 점수 보너스를 준다.
+ */
+function pairControlsFallback(
+  left: CompareControlSnapshot[],
+  right: CompareControlSnapshot[],
+): ControlPair[] {
+  const pairs: ControlPair[] = [];
+  const usedL = new Set<number>();
+  for (let ri = 0; ri < right.length; ri += 1) {
+    const r = right[ri];
+    let bestLi = -1;
+    let bestScore = -1;
+    for (let li = 0; li < left.length; li += 1) {
+      if (usedL.has(li)) continue;
+      const l = left[li];
+      const score = scoreControlFallback(l, r);
+      if (score > bestScore) {
+        bestScore = score;
+        bestLi = li;
+      }
+    }
+    if (bestLi >= 0 && bestScore >= 2.75) {
+      usedL.add(bestLi);
+      pairs.push({ left: left[bestLi], right: r });
+    }
+  }
+  return pairs;
+}
+
+/**
+ * `pairControlsFallback` / `pairAlignmentSlotControls` 공통 점수 함수.
+ *
+ * - kind 불일치 → -1 (즉시 탈락).
+ * - 동일 `type`, 동일 `summary`에 큰 가중(표·도형은 요약 문자열에 구조·텍스트 요약이 들어 있음).
+ * - 그다음 `sid`/`loc` 키에서 뽑은 **control index** 일치, 같은 section, 페이지 간격, 앵커 박스 x/y/wh 근접.
+ *
+ * 문단 삽입으로 y가 크게 밀리면 위치 항만으로는 2.75에 못 미칠 수 있어, alignment 맵이 있을 때는
+ * 슬롯 단계에서 보너스를 더해 같은 문제를 완화한다.
+ */
+function scoreControlFallback(l: CompareControlSnapshot, r: CompareControlSnapshot): number {
+  if (l.kind !== r.kind) return -1;
+  let score = 0;
+  if (l.type === r.type) score += 1.2;
+  if (l.summary === r.summary) score += 2.6;
+  else {
+    const ld = l.summary.toLowerCase();
+    const rd = r.summary.toLowerCase();
+    if (ld.includes('table') && rd.includes('table')) score += 1.0;
+    if (ld.includes('shape') && rd.includes('shape')) score += 0.8;
+  }
+  const lci = extractControlIndexFromKey(l.key);
+  const rci = extractControlIndexFromKey(r.key);
+  if (lci != null && rci != null && lci === rci) score += 1.15;
+  if (l.section === r.section) score += 0.45;
+  const pageGap = Math.abs(l.anchor.pageIndex - r.anchor.pageIndex);
+  if (pageGap === 0) score += 0.9;
+  else if (pageGap === 1) score += 0.45;
+  const xGap = Math.abs(l.anchor.x - r.anchor.x);
+  const yGap = Math.abs(l.anchor.y - r.anchor.y);
+  const wGap = Math.abs(l.anchor.width - r.anchor.width);
+  const hGap = Math.abs(l.anchor.height - r.anchor.height);
+  if (xGap < 120) score += 0.35;
+  else if (xGap < 260) score += 0.18;
+  if (yGap < 80) score += 0.6;
+  else if (yGap < 180) score += 0.3;
+  if (wGap < 45 && hGap < 45) score += 0.45;
+  else if (wGap < 120 && hGap < 120) score += 0.22;
+  return score;
+}
+
+/**
+ * 각 DiffItem에 구역 내 "사람이 읽는" 쪽번호(`sectionPage`)를 붙인다.
+ * identity id 패턴·path·controlKey 내 sid를 역추적해 문단을 찾고, 실패 시 anchor의 전역 pageDisplayNumbers로 보완.
+ */
+function annotateDiffSectionPages(
+  diffs: DiffItem[],
+  left: CompareDocumentSnapshot,
+  right: CompareDocumentSnapshot,
+): void {
+  const lByPos = new Map<string, CompareParaSnapshot>();
+  const rByPos = new Map<string, CompareParaSnapshot>();
+  const lByStable = new Map<string, CompareParaSnapshot>();
+  const rByStable = new Map<string, CompareParaSnapshot>();
+  for (const p of left.paragraphs) {
+    lByPos.set(`${p.section}:${p.paragraph}`, p);
+    lByStable.set(p.stableId, p);
+  }
+  for (const p of right.paragraphs) {
+    rByPos.set(`${p.section}:${p.paragraph}`, p);
+    rByStable.set(p.stableId, p);
+  }
+
+  for (const d of diffs) {
+    let lp: CompareParaSnapshot | undefined;
+    let rp: CompareParaSnapshot | undefined;
+
+    const sidMatch = d.id.match(/id-(?:added|removed|modified|moved|ctrlcount):(.+)$/);
+    if (sidMatch) {
+      const sid = sidMatch[1];
+      lp = lByStable.get(sid);
+      rp = rByStable.get(sid);
+    } else {
+      const key = `${d.path.section}:${d.path.paragraph ?? -1}`;
+      if (d.severity === 'removed') {
+        lp = lByPos.get(key);
+      } else if (d.severity === 'added') {
+        rp = rByPos.get(key);
+      } else {
+        lp = lByPos.get(key);
+        rp = rByPos.get(key);
+      }
+    }
+
+    // 컨트롤 diff는 controlKey에 부모 문단 stable_id가 포함될 수 있다.
+    // path 기반 문단 매핑이 어긋난 경우 sid로 좌/우 문단을 재식별해 쪽번호를 고정한다.
+    if ((!lp || !rp) && d.path.controlKey) {
+      const sidMatch = d.path.controlKey.match(/sid:([^:]+):\d+:/);
+      if (sidMatch) {
+        const sid = sidMatch[1];
+        if (!lp) lp = lByStable.get(sid);
+        if (!rp) rp = rByStable.get(sid);
+      }
+    }
+
+    if (lp) d.leftSectionPage = lp.sectionPage;
+    if (rp) d.rightSectionPage = rp.sectionPage;
+
+    // 문단 매핑 실패(특히 컨트롤/일부 메타) 시에도 렌더 엔진이 계산한 표시 쪽번호를 사용.
+    if (!d.leftSectionPage && d.leftAnchor) {
+      const pn = left.meta.pageDisplayNumbers?.[d.leftAnchor.pageIndex];
+      if (pn && pn > 0) d.leftSectionPage = pn;
+    }
+    if (!d.rightSectionPage && d.rightAnchor) {
+      const pn = right.meta.pageDisplayNumbers?.[d.rightAnchor.pageIndex];
+      if (pn && pn > 0) d.rightSectionPage = pn;
+    }
+  }
+}
+
+// ─── 공개 진입점: 스냅샷 비교 세션 생성 ───────────────────────────────────────
+
+/**
+ * 이미 파싱된 스냅샷 두 개를 비교해 `CompareSession`을 만든다.
+ *
+ * 흐름:
+ * - `resolveTextCompareStrategy`: 공유 stable_id가 신뢰되면 `identity`, 아니면 `alignment`.
+ * - **본문**: `buildIdentityTextDiffs` 또는 `buildTextDiffs`(후자는 `{ diffs, rightToLeftPara }`).
+ * - **컨트롤**: `buildControlDiffs(left, right, rightToLeftPara)` — 문단 밀림 보정을 위해 alignment 맵 전달.
+ * - **후처리**: `options.kinds` 필터 → `suppressPureReflowMoves` → `annotateDiffSectionPages` →
+ *   구역·문단 순 정렬.
+ *
+ * 성능: `activeRuntimeGuard`로 wall-clock 상한. 초과 시 `matchSegment` 쪽이 그리디 위주로 이탈할 수 있다.
+ */
+export function compareSnapshots(
+  left: CompareDocumentSnapshot,
+  right: CompareDocumentSnapshot,
+  options: CompareOptions,
+): CompareSession {
+  activeCompareOptions = options;
+  const strategy: CompareStrategy = options.strategy ?? 'alignment';
+  const perf = resolvePerformanceTuning(options);
+  activeRuntimeGuard = {
+    deadline: Date.now() + perf.maxComputeMs,
+    bailedOut: false,
+  };
+  const textMode = resolveTextCompareStrategy(strategy, left, right);
+
+  // compare-debug 켜진 빌드에서만: stable_id 품질(①) → 전략(②) → alignment는 ③ 앵커 로그 참고
+  if (isCompareDebugEnabled()) {
+    const lmap = buildStableIdMap(left);
+    const rmap = buildStableIdMap(right);
+    let sharedStable = 0;
+    if (lmap && rmap) {
+      for (const id of lmap.keys()) {
+        if (rmap.has(id)) sharedStable += 1;
+      }
+    }
+    compareDbg('[① stable_id] 스냅샷 요약', {
+      left: left.meta.name,
+      right: right.meta.name,
+      leftParas: left.paragraphs.length,
+      rightParas: right.paragraphs.length,
+      leftHead: left.paragraphs.slice(0, 10).map((p) => ({
+        sec: p.section,
+        para: p.paragraph,
+        id: p.stableId ? `${p.stableId.slice(0, 14)}…` : '(빈)',
+        t: p.text.slice(0, 32),
+      })),
+      rightHead: right.paragraphs.slice(0, 10).map((p) => ({
+        sec: p.section,
+        para: p.paragraph,
+        id: p.stableId ? `${p.stableId.slice(0, 14)}…` : '(빈)',
+        t: p.text.slice(0, 32),
+      })),
+    });
+    compareDbg('[② 전략·폴백]', {
+      optionsStrategy: strategy,
+      textMode,
+      mapsBuildOk: Boolean(lmap && rmap),
+      sharedStableIdCount: lmap && rmap ? sharedStable : null,
+      path:
+        textMode === 'identity'
+          ? 'buildIdentityTextDiffs (Map<stableId>, 인덱스 1:1 아님)'
+          : 'buildTextDiffs (앵커 + 구간 DP/그리디 — ③ 로그 참고)',
+    });
+  }
+
+  // 1) 본문: identity면 sid 집합 비교, 아니면 앵커+구간 정렬
+  const textBundle =
+    textMode === 'identity'
+      ? { diffs: buildIdentityTextDiffs(left, right, options.kinds), rightToLeftPara: new Map<string, CompareParaSnapshot>() }
+      : buildTextDiffs(left, right);
+  const textDiffs = textBundle.diffs;
+
+  // 2) 개체(표/도형 등) 병합 — 문단 정렬 맵으로 밀린 문단 좌표의 표·그림을 같은 슬롯에서 재짝짓기
+  const all = [...textDiffs, ...buildControlDiffs(left, right, textBundle.rightToLeftPara)];
+
+  // 3) kinds 필터 + 순수 리플로우 이동 노이즈 제거 후, UI용 쪽번호 주석
+  const filtered = suppressPureReflowMoves(
+    all.filter((d) => options.kinds.includes(d.kind)),
+    left,
+    right,
+  );
+  annotateDiffSectionPages(filtered, left, right);
+  if (isCompareDebugEnabled() && activeRuntimeGuard?.bailedOut) {
+    compareDbg('[성능 가드레일] 타임버짓 초과로 일부 구간을 greedy/fallback으로 처리했습니다.');
+  }
+  // 목록 정렬: 구역 → 문단 순으로 탐색하기 쉽게
+  filtered.sort((a, b) => {
+    const sa = a.path.section ?? 0;
+    const sb = b.path.section ?? 0;
+    if (sa !== sb) return sa - sb;
+    const pa = a.path.paragraph ?? 0;
+    const pb = b.path.paragraph ?? 0;
+    return pa - pb;
+  });
+
+  try {
+    return {
+      left: left.meta,
+      right: right.meta,
+      options,
+      diffItems: filtered,
+      currentDiffIndex: filtered.length > 0 ? 0 : -1,
+      generatedAt: Date.now(),
+      textCompareStrategyUsed: textMode,
+    };
+  } finally {
+    activeRuntimeGuard = null;
+    activeCompareOptions = null;
+  }
+}
+
+/**
+ * 외부 두 파일(bytes): 각각 별도 WASM으로 스냅샷을 만든 뒤 `compareSnapshots`와 동일 파이프라인.
+ * 좌·우 stable_id 집합이 보통 겹치지 않아 alignment가 기본이 된다.
+ */
+export async function compareDocuments(
+  leftBytes: Uint8Array,
+  leftName: string,
+  rightBytes: Uint8Array,
+  rightName: string,
+  options: CompareOptions,
+): Promise<CompareSession> {
+  const left = await buildSnapshotFromBytes(leftBytes, leftName, options);
+  const right = await buildSnapshotFromBytes(rightBytes, rightName, options);
+  return compareSnapshots(left, right, options);
+}

--- a/rhwp-studio/src/compare/diff-engine.ts
+++ b/rhwp-studio/src/compare/diff-engine.ts
@@ -32,10 +32,10 @@
  * - 1차: `kind::key` 정확 일치(`sid:…` 우선).
  * - 2차: **`buildRightToLeftParaMapFromAligned`** — `buildTextDiffs`가 만든 문단 정렬 `AlignedPair[]`에서
  *   오른쪽 `section:paragraph` → 짝 왼쪽 문단 맵을 구축해 `buildControlDiffs`에 전달한다.
- * - 3차: **`pairAlignmentSlotControls`** — 키가 어긋린 뒤에도, 오른쪽 컨트롤의 부모 문단이 맵상으로
- *   어느 왼쪽 문단과 짝인지 알면 **그 왼쪽 문단에 붙은 미매칭 컨트롤만** 후보로 삼고
- *   `scoreControlFallback + ALIGNMENT_CONTROL_SLOT_BONUS`로 짝을 찾는다(절대 y 밀림 보정).
- * - 4차: `extractTablePatiencePins`(표 요약 유일 키) → `pairControlsFallback`(전역 탐욕, 임계 2.75).
+ * - 3차: **`extractTablePatiencePins`** — 요약 키가 양쪽에서 각각 유일한 표를 슬롯보다 먼저 고정한다.
+ * - 4차: **`pairAlignmentSlotControls`** — 남은 컨트롤에 대해, 오른쪽 부모 문단의 맵상 짝 왼쪽 문단에 붙은
+ *   미매칭 컨트롤만 후보로 `scoreControlFallback + ALIGNMENT_CONTROL_SLOT_BONUS`로 짝을 찾는다.
+ * - 5차: `pairControlsFallback`(전역 탐욕, 임계 2.75).
  *
  * ── [단계적 비교(성능)]
  * - 전 문단×문단 유사도 행렬 같은 O(N²) 전역 최적화는 하지 않는다.
@@ -45,7 +45,8 @@
  * - 앵커·구간: ANCHOR_*, INTRA_UNIQUE_SIG_*, SEGMENT_DP_MAX, NORM_HASH_PIN_MIN_TOTAL_PARAS, HARD_SEGMENT_CELL_LIMIT,
  *   ALIGNMENT_MAX_COMPUTE_MS, MAX_SEGMENT_RECURSION
  * - 구조 근접·비용: NEAR_STRUCTURE_*, MATCH_SOFT_SIM_MIN, MATCH_COST_WEAK, WINDOW_SIZE, GREEDY_AMBIGUOUS_GAP
- * - 컨트롤 슬롯: ALIGNMENT_CONTROL_SLOT_BONUS, ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE
+ * - 컨트롤 슬롯: ALIGNMENT_CONTROL_SLOT_BONUS, ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE,
+ *   TABLE_SUMMARY_MISMATCH_PENALTY, TABLE_PAIR_SIM_NO_PENALTY, TABLE_PAIR_SIM_FULL_PENALTY
  * - 후처리: PARA_SPLIT_JOIN_SIM_MIN, REMOVED_ADDED_*
  * - 문자 요약: CHAR_DIFF_FULL_DP_MAX, CHAR_DIFF_TOTAL_MAX, CHAR_DIFF_CELL_HARD
  *
@@ -62,7 +63,7 @@
  * - 본 파일은 `// ───` 섹션 구분으로 점프 검색이 가능하다.
  */
 import { WasmBridge } from '@/core/wasm-bridge';
-import type { DocumentInfo, ParaProperties } from '@/core/types';
+import type { ControlLayoutItem, DocumentInfo, ParaProperties } from '@/core/types';
 import { compareDbg, isCompareDebugEnabled } from './compare-debug';
 import type {
   CompareAnchorTuning,
@@ -160,6 +161,16 @@ const ALIGNMENT_CONTROL_SLOT_BONUS = 2.35;
  * 너무 낮추면 다른 문단 개체와 오매칭, 너무 높이면 슬롯이 거의 동작하지 않는다.
  */
 const ALIGNMENT_CONTROL_MIN_ADJUSTED_SCORE = 4.38;
+/**
+ * `scoreControlFallback`: 표 요약(`summary`)이 다를 때 부과하는 **최대** 감점.
+ * `tableControlPairContentSimilarity`가 높으면(같은 행·열 그리드에서 셀만 수정) 감점 비율을 0에 가깝게 줄여
+ * `buildGranularControlDiffs`로 “표 수정”이 나가게 한다. 유사도가 낮으면(다른 표) 전액 감점한다.
+ */
+const TABLE_SUMMARY_MISMATCH_PENALTY = 4.25;
+/** 이 이상이면 표 요약 불일치 감점을 적용하지 않는다(한 셀 수정 등). */
+const TABLE_PAIR_SIM_NO_PENALTY = 0.74;
+/** 이 이하이면 표 감점을 전액 적용한다(내용이 다른 표). */
+const TABLE_PAIR_SIM_FULL_PENALTY = 0.36;
 
 /** `compareSnapshots` 한 번 호출 동안만 유효. `ALIGNMENT_MAX_COMPUTE_MS` 경과 시 greedy 쪽으로 이탈한다. */
 type CompareRuntimeGuard = {
@@ -641,7 +652,7 @@ function paraPosKey(p: { section: number; paragraph: number }): string {
  * - 키: `paraPosKey(right)` (오른쪽 HWP 좌표계).
  * - 값: DP/그리디가 같은 논리 슬롯으로 판단한 `left` 문단.
  * `(null, right)`·`(left, null)` 삽입/삭제 축은 맵에 넣지 않는다 → 해당 문단의 컨트롤은 슬롯 매칭 대상에서 제외되고
- * 이후 `extractTablePatiencePins` / `pairControlsFallback` / added·removed로 처리된다.
+ * 이후 `extractTablePatiencePins`(선행) → `pairAlignmentSlotControls` → `pairControlsFallback` / added·removed로 처리된다.
  */
 function buildRightToLeftParaMapFromAligned(aligned: AlignedPair[]): Map<string, CompareParaSnapshot> {
   const m = new Map<string, CompareParaSnapshot>();
@@ -739,7 +750,7 @@ function buildGranularControlDiffs(
       ? `${tableLabel} 텍스트 변경(구조변경 동반${changedCells > 0 ? `, ${changedCells}셀` : ''})`
       : `${tableLabel} 텍스트 변경${changedCells > 0 ? `(${changedCells}셀)` : ''}`;
     push('text', textTitle, lText, rText, tableTextChanged);
-    push('style', `${tableLabel} 속성 변경`, `props=${lk.props ?? '(없음)'}`, `props=${rk.props ?? '(없음)'}`);
+    // props= 는 `getTableProperties` 전체 JSON 해시라 조판·저장 경로만 달라도 달라져 노이즈가 크다. UI에는 내리지 않는다.
     return items;
   }
 
@@ -781,8 +792,136 @@ function compactParaShapeForAnchor(pp: ParaProperties): string {
 }
 
 /**
+ * `getCursorRect(sec,para,0)`이 실패하는 문단(표 셀 내부·빈 줄 등)에 대해 오프셋을 바꿔 재시도한다.
+ */
+function tryResolveCompareParaAnchorFromCursor(
+  wasm: WasmBridge,
+  sec: number,
+  para: number,
+  textLength: number,
+): DiffAnchor | undefined {
+  const offsets = new Set<number>([0]);
+  if (textLength > 0) {
+    offsets.add(1);
+    offsets.add(Math.max(0, textLength - 1));
+    if (textLength > 2) offsets.add(Math.floor(textLength / 2));
+  }
+  for (const off of offsets) {
+    try {
+      const rect = wasm.getCursorRect(sec, para, off);
+      if (rect && typeof rect.pageIndex === 'number' && Number.isFinite(rect.x) && Number.isFinite(rect.y)) {
+        return {
+          pageIndex: rect.pageIndex,
+          x: rect.x,
+          y: rect.y,
+          width: 320,
+          height: Math.max(18, rect.height || 18),
+        };
+      }
+    } catch {
+      /* 다음 오프셋 */
+    }
+  }
+  return undefined;
+}
+
+/**
+ * 커서 rect를 못 얻은 문단에 대해, 해당 문단에 붙은 첫 레이아웃 개체 박스로 앵커를 채운다(비교 상세 캔버스용).
+ */
+function fillMissingParaAnchorsFromPageLayout(
+  wasm: WasmBridge,
+  info: DocumentInfo,
+  paragraphs: CompareParaSnapshot[],
+  displayedPageByGlobalPage: Map<number, number>,
+): void {
+  const firstBoxByPara = new Map<string, DiffAnchor>();
+  for (let page = 0; page < info.pageCount; page += 1) {
+    let controls: ControlLayoutItem[];
+    try {
+      controls = wasm.getPageControlLayout(page).controls;
+    } catch {
+      continue;
+    }
+    for (const item of controls) {
+      const sec = item.secIdx;
+      const pIdx = item.paraIdx;
+      if (sec == null || pIdx == null || sec < 0 || pIdx < 0) continue;
+      const key = `${sec}:${pIdx}`;
+      if (firstBoxByPara.has(key)) continue;
+      firstBoxByPara.set(key, {
+        pageIndex: page,
+        x: item.x,
+        y: item.y,
+        width: Math.max(48, Math.round(item.w)),
+        height: Math.max(18, Math.round(item.h)),
+      });
+    }
+  }
+  for (const p of paragraphs) {
+    if (p.anchor) continue;
+    const fb = firstBoxByPara.get(`${p.section}:${p.paragraph}`);
+    if (!fb) continue;
+    p.anchor = fb;
+    p.sectionPage = displayedPageByGlobalPage.get(fb.pageIndex) ?? (fb.pageIndex + 1);
+  }
+}
+
+/**
+ * 레이아웃에도 없으면 같은 구역에서 가장 가까운 앵커가 있는 문단 좌표를 복사한다.
+ * 이전 문단 앵커를 **그대로** 쓰면(표가 있는 문단 등) 비교 상세 마커가 표 위에 겹쳐 “문단 추가 = 표”로 보이므로 세로로 한 칸 밀어 구분한다.
+ */
+function fillMissingParaAnchorsFromNeighbors(
+  paragraphs: CompareParaSnapshot[],
+  displayedPageByGlobalPage: Map<number, number>,
+): void {
+  for (const p of paragraphs) {
+    if (p.anchor) continue;
+    let nbr: DiffAnchor | undefined;
+    let fromPreviousPara = false;
+    for (let gi = p.globalIndex - 1; gi >= 0; gi -= 1) {
+      const q = paragraphs[gi];
+      if (q.section !== p.section) break;
+      if (q.anchor) {
+        nbr = q.anchor;
+        fromPreviousPara = true;
+        break;
+      }
+    }
+    if (!nbr) {
+      for (let gi = p.globalIndex + 1; gi < paragraphs.length; gi += 1) {
+        const q = paragraphs[gi];
+        if (q.section !== p.section) break;
+        if (q.anchor) {
+          nbr = q.anchor;
+          fromPreviousPara = false;
+          break;
+        }
+      }
+    }
+    if (!nbr) continue;
+    if (fromPreviousPara) {
+      const dy = Math.min(200, Math.max(28, Math.round(nbr.height) + 10));
+      p.anchor = {
+        ...nbr,
+        y: nbr.y + dy,
+        width: nbr.width,
+        height: Math.max(18, nbr.height),
+      };
+    } else {
+      p.anchor = {
+        ...nbr,
+        y: Math.max(0, nbr.y - 28),
+        width: nbr.width,
+        height: Math.max(18, nbr.height),
+      };
+    }
+    p.sectionPage = displayedPageByGlobalPage.get(nbr.pageIndex) ?? (nbr.pageIndex + 1);
+  }
+}
+
+/**
  * WASM이 열린 단일 문서에서 비교용 스냅샷을 만든다.
- * - 문단: 텍스트, 정규화 텍스트, stable_id, 레이아웃 앵커(커서 rect 기반), 구역 내 쪽번호,
+ * - 문단: 텍스트, 정규화 텍스트, stable_id, 레이아웃 앵커(커서 rect·다중 오프셋 → 페이지 개체 박스 → 이웃 문단), 구역 내 쪽번호,
  *   `signature`(정규화 텍스트·컨트롤 개수 + `getParaPropertiesAt` 기반 문단모양 요약 `ps:`)
  * - 개체: 페이지 레이아웃 + 문단별 table 순회를 합쳐 키를 `sid:` 우선으로 통일
  * - 마지막에 `canonicalControlKey`로 중복을 합치고 `controlSnapshotQuality`로 더 나은 요약을 남긴다.
@@ -832,21 +971,7 @@ function fillSnapshotFromWasm(
         `${normalizedText}|cc:${controls.length}${shapeDigest ? `|ps:${shapeDigest}` : ''}`,
       );
       const stableId = wasm.getParagraphStableId(sec, para);
-      const anchor = (() => {
-        try {
-          const rect = wasm.getCursorRect(sec, para, 0);
-          return {
-            pageIndex: rect.pageIndex,
-            x: rect.x,
-            y: rect.y,
-            // 문단 시작 위치 기준 넓은 박스: UI 하이라이트·hitTest에 쓰기 위함(정밀 bbox는 아님)
-            width: 320,
-            height: Math.max(18, rect.height || 18),
-          };
-        } catch {
-          return undefined;
-        }
-      })();
+      const anchor = tryResolveCompareParaAnchorFromCursor(wasm, sec, para, length);
       const sectionPage = (() => {
         if (!anchor) return 1;
         return displayedPageByGlobalPage.get(anchor.pageIndex) ?? (anchor.pageIndex + 1);
@@ -867,6 +992,9 @@ function fillSnapshotFromWasm(
       globalIndex += 1;
     }
   }
+
+  fillMissingParaAnchorsFromPageLayout(wasm, info, paragraphs, displayedPageByGlobalPage);
+  fillMissingParaAnchorsFromNeighbors(paragraphs, displayedPageByGlobalPage);
 
   // 글로벌 앵커 후보(`isAnchorCandidate`): 시그니처 중복은 즉시 탈락. 그 다음
   // - 길이·엔트로피 등으로 “긴” 문단은 `isAnchorTextQualityOk`
@@ -1168,6 +1296,34 @@ function buildStableIdMap(snap: CompareDocumentSnapshot): Map<string, ComparePar
   return m;
 }
 
+/** ZWSP·NBSP 등만 남은 문단도 “빈 문단”으로 본다. */
+function isEffectivelyEmptyParaNormalized(normalizedText: string): boolean {
+  const t = normalizedText
+    .replace(/[\u200b-\u200d\ufeff]/g, '')
+    .replace(/\u00a0/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+  return t.length === 0;
+}
+
+/** 텍스트·개체 없는 문단: 정렬/스냅샷 노이즈로 추가·삭제만 남는 경우 diff에서 생략한다. */
+function shouldSuppressNoiseParagraphOnly(p: CompareParaSnapshot): boolean {
+  return p.controlCount === 0 && isEffectivelyEmptyParaNormalized(p.normalizedText);
+}
+
+/** 정렬 스텝에서 빈 고아 문단만 제거해 cleanup 2글자 패턴이 깨지지 않게 한다. */
+function stripNoiseOnlyParagraphAlignSteps(steps: ParagraphAlignStep[]): ParagraphAlignStep[] {
+  return steps.filter((s) => {
+    if (s.kind === 'r') return !shouldSuppressNoiseParagraphOnly(s.r);
+    if (s.kind === 'l') return !shouldSuppressNoiseParagraphOnly(s.l);
+    return true;
+  });
+}
+
+function formatParaLocTitle(p: { section: number; paragraph: number }): string {
+  return `구역 ${p.section}, 문단 ${p.paragraph}`;
+}
+
 // ─── identity 경로: 이력(동일 혈통)에서 stable_id 기준 O(N) 근사 텍스트 diff ───
 
 /**
@@ -1207,29 +1363,33 @@ function buildIdentityTextDiffs(left: CompareDocumentSnapshot, right: CompareDoc
     const l = lmap.get(id);
     const r = rmap.get(id);
     if (l && !r) {
-      diffs.push({
-        id: mkDiffId('text', `id-removed:${id}`),
-        kind: 'text',
-        severity: 'removed',
-        path: { section: l.section, paragraph: l.paragraph },
-        title: '문단 삭제',
-        leftPreview: l.text,
-        rightPreview: '',
-        leftAnchor: l.anchor,
-      });
+      if (!shouldSuppressNoiseParagraphOnly(l)) {
+        diffs.push({
+          id: mkDiffId('text', `id-removed:${id}`),
+          kind: 'text',
+          severity: 'removed',
+          path: { section: l.section, paragraph: l.paragraph },
+          title: '문단 삭제',
+          leftPreview: l.text,
+          rightPreview: '',
+          leftAnchor: l.anchor,
+        });
+      }
       continue;
     }
     if (!l && r) {
-      diffs.push({
-        id: mkDiffId('text', `id-added:${id}`),
-        kind: 'text',
-        severity: 'added',
-        path: { section: r.section, paragraph: r.paragraph },
-        title: '문단 추가',
-        leftPreview: '',
-        rightPreview: r.text,
-        rightAnchor: r.anchor,
-      });
+      if (!shouldSuppressNoiseParagraphOnly(r)) {
+        diffs.push({
+          id: mkDiffId('text', `id-added:${id}`),
+          kind: 'text',
+          severity: 'added',
+          path: { section: r.section, paragraph: r.paragraph },
+          title: '문단 추가',
+          leftPreview: '',
+          rightPreview: r.text,
+          rightAnchor: r.anchor,
+        });
+      }
       continue;
     }
     if (!l || !r) continue;
@@ -2098,7 +2258,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'text',
         severity: 'modified',
         path: preferRightPath(s0.l, s1.r),
-        title: `텍스트 변경 (${s0.l.section}.${s0.l.paragraph})`,
+        title: `텍스트 변경 (${formatParaLocTitle(s0.l)})`,
         leftPreview: s0.l.text,
         rightPreview: s1.r.text,
         leftAnchor: s0.l.anchor,
@@ -2113,7 +2273,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'text',
         severity: 'modified',
         path: preferRightPath(s1.l, s0.r),
-        title: `텍스트 변경 (${s1.l.section}.${s1.l.paragraph})`,
+        title: `텍스트 변경 (${formatParaLocTitle(s1.l)})`,
         leftPreview: s1.l.text,
         rightPreview: s0.r.text,
         leftAnchor: s1.l.anchor,
@@ -2130,7 +2290,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'text',
         severity: 'modified',
         path: preferRightPath(s0.l, r2),
-        title: `텍스트 변경 (${r2.section}.${r2.paragraph})`,
+        title: `텍스트 변경 (${formatParaLocTitle(r2)})`,
         leftPreview: s0.l.text,
         rightPreview: r2.text,
         leftAnchor: s0.l.anchor,
@@ -2148,7 +2308,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'text',
         severity: 'modified',
         path: preferRightPath(l2, s0.r),
-        title: `텍스트 변경 (${s0.r.section}.${s0.r.paragraph})`,
+        title: `텍스트 변경 (${formatParaLocTitle(s0.r)})`,
         leftPreview: l2.text,
         rightPreview: s0.r.text,
         leftAnchor: l2.anchor,
@@ -2170,7 +2330,7 @@ function cleanupParagraphAlignStepsToDiffItems(
           kind: 'text',
           severity: 'modified',
           path: preferRightPath(L, rHead),
-          title: `텍스트 변경 (${rHead.section}.${rHead.paragraph})`,
+          title: `텍스트 변경 (${formatParaLocTitle(rHead)})`,
           leftPreview: L.text,
           rightPreview: rHead.text,
           leftAnchor: L.anchor,
@@ -2178,17 +2338,21 @@ function cleanupParagraphAlignStepsToDiffItems(
           leftSectionPage: L.sectionPage,
           rightSectionPage: rHead.sectionPage,
         },
-        {
-          id: mkDiffId('text', `added:${rTail.section}:${rTail.paragraph}`),
-          kind: 'text',
-          severity: 'added',
-          path: { section: rTail.section, paragraph: rTail.paragraph },
-          title: `문단 추가 (${rTail.section}.${rTail.paragraph})`,
-          leftPreview: '',
-          rightPreview: rTail.text,
-          rightAnchor: rTail.anchor,
-          rightSectionPage: rTail.sectionPage,
-        },
+        ...(shouldSuppressNoiseParagraphOnly(rTail)
+          ? []
+          : [
+              {
+                id: mkDiffId('text', `added:${rTail.section}:${rTail.paragraph}`),
+                kind: 'text' as const,
+                severity: 'added' as const,
+                path: { section: rTail.section, paragraph: rTail.paragraph },
+                title: `문단 추가 (${formatParaLocTitle(rTail)})`,
+                leftPreview: '',
+                rightPreview: rTail.text,
+                rightAnchor: rTail.anchor,
+                rightSectionPage: rTail.sectionPage,
+              },
+            ]),
       );
       i += 2;
       continue;
@@ -2196,33 +2360,37 @@ function cleanupParagraphAlignStepsToDiffItems(
 
     if (s0.kind === 'r') {
       const r = s0.r;
-      diffs.push({
-        id: mkDiffId('text', `added:${r.section}:${r.paragraph}`),
-        kind: 'text',
-        severity: 'added',
-        path: { section: r.section, paragraph: r.paragraph },
-        title: `문단 추가 (${r.section}.${r.paragraph})`,
-        leftPreview: '',
-        rightPreview: r.text,
-        rightAnchor: r.anchor,
-        rightSectionPage: r.sectionPage,
-      });
+      if (!shouldSuppressNoiseParagraphOnly(r)) {
+        diffs.push({
+          id: mkDiffId('text', `added:${r.section}:${r.paragraph}`),
+          kind: 'text',
+          severity: 'added',
+          path: { section: r.section, paragraph: r.paragraph },
+          title: `문단 추가 (${formatParaLocTitle(r)})`,
+          leftPreview: '',
+          rightPreview: r.text,
+          rightAnchor: r.anchor,
+          rightSectionPage: r.sectionPage,
+        });
+      }
       i += 1;
       continue;
     }
     if (s0.kind === 'l') {
       const l = s0.l;
-      diffs.push({
-        id: mkDiffId('text', `removed:${l.section}:${l.paragraph}`),
-        kind: 'text',
-        severity: 'removed',
-        path: preferRightPath(l, null),
-        title: `문단 삭제 (${l.section}.${l.paragraph})`,
-        leftPreview: l.text,
-        rightPreview: '',
-        leftAnchor: l.anchor,
-        leftSectionPage: l.sectionPage,
-      });
+      if (!shouldSuppressNoiseParagraphOnly(l)) {
+        diffs.push({
+          id: mkDiffId('text', `removed:${l.section}:${l.paragraph}`),
+          kind: 'text',
+          severity: 'removed',
+          path: preferRightPath(l, null),
+          title: `문단 삭제 (${formatParaLocTitle(l)})`,
+          leftPreview: l.text,
+          rightPreview: '',
+          leftAnchor: l.anchor,
+          leftSectionPage: l.sectionPage,
+        });
+      }
       i += 1;
       continue;
     }
@@ -2235,7 +2403,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'text',
         severity: 'modified',
         path: preferRightPath(l, r),
-        title: `텍스트 변경 (${l.section}.${l.paragraph})`,
+        title: `텍스트 변경 (${formatParaLocTitle(l)})`,
         leftPreview: l.text,
         rightPreview: r.text,
         leftAnchor: l.anchor,
@@ -2249,7 +2417,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'paragraphMeta',
         severity: 'modified',
         path: { section: l.section, paragraph: l.paragraph },
-        title: `문단 이동 감지 (${l.section}.${l.paragraph})`,
+        title: `문단 이동 감지 (${formatParaLocTitle(l)})`,
         leftPreview: `A idx=${l.globalIndex}`,
         rightPreview: `B idx=${r.globalIndex}`,
         leftAnchor: l.anchor,
@@ -2263,7 +2431,7 @@ function cleanupParagraphAlignStepsToDiffItems(
         kind: 'paragraphMeta',
         severity: 'modified',
         path: { section: l.section, paragraph: l.paragraph },
-        title: `문단 개체 수 변경 (${l.section}.${l.paragraph})`,
+        title: `문단 개체 수 변경 (${formatParaLocTitle(l)})`,
         leftPreview: `controls=${l.controlCount}`,
         rightPreview: `controls=${r.controlCount}`,
         leftAnchor: l.anchor,
@@ -2334,7 +2502,7 @@ function buildTextDiffs(left: CompareDocumentSnapshot, right: CompareDocumentSna
   }
 
   const rightToLeftPara = buildRightToLeftParaMapFromAligned(aligned);
-  const steps = buildParagraphAlignStepsFromAligned(aligned);
+  const steps = stripNoiseOnlyParagraphAlignSteps(buildParagraphAlignStepsFromAligned(aligned));
   const diffs = cleanupParagraphAlignStepsToDiffItems(steps, lps, rps);
   return { diffs, rightToLeftPara };
 }
@@ -2343,7 +2511,8 @@ function buildTextDiffs(left: CompareDocumentSnapshot, right: CompareDocumentSna
  * 키가 달라진 뒤에도 **표(table)** 만 모아, 요약 문자열에서 뽑은 키(`txt` / `sig` / 해시) 기준으로
  * 양쪽 문서에서 각각 **정확히 한 개**뿐인 표끼리 1:1 고정한다(Git Patience 유사).
  *
- * 문단 슬롯(`pairAlignmentSlotControls`)이 먼저 돌기 때문에, 동일 표가 이미 짝지어졌으면 여기까지 내려오지 않는다.
+ * `buildControlDiffs`에서는 **정렬 슬롯보다 먼저** 호출한다. 삽입으로 키가 어긋져도 요약이 유일하게 대응되면
+ * 같은 내용의 표가 먼저 짝지어져, 슬롯이 위치만 보고 엉뚱한 표를 가져가는 일을 줄인다.
  * 이 단계는 표 요약이 충분히 구별될 때만 효과가 있다.
  */
 function extractTablePatiencePins(
@@ -2467,7 +2636,7 @@ function pairAlignmentSlotControls(
 
 /** compareSnapshots 등에서 options 일부가 빠졌을 때의 기본값. kinds는 UI 노이즈를 줄이기 위해 화이트리스트 형태 */
 const DEFAULT_COMPARE_OPTIONS: CompareOptions = {
-  caseSensitive: false,
+  caseSensitive: true,
   ignoreWhitespace: true,
   kinds: ['text', 'table', 'shape', 'image', 'chart', 'paragraphMeta'],
 };
@@ -2475,20 +2644,20 @@ const DEFAULT_COMPARE_OPTIONS: CompareOptions = {
 /** compareSnapshots 실행 중 `matchCost`/`resolveAnchorTuning` 등이 읽는 전역(스레드 안전은 요구하지 않음) */
 let activeCompareOptions: CompareOptions | null = null;
 
-// ─── 컨트롤 diff: 키 매칭 → 정렬 슬롯 → 표 patience 핀 → 폴백 → added/removed ───
+// ─── 컨트롤 diff: 키 매칭 → 표 patience 핀 → 정렬 슬롯 → 폴백 → added/removed ───
 
 /**
  * 표·도형·그림 등 컨트롤 diff. 단계:
  *
  * 1. **키 정확 매칭** — `kind::key`(우선 `sid:paraStableId:ci:type`). 좌우 동시 존재하면 내용 비교 후
  *    `buildGranularControlDiffs` 또는 동일 시 생략. 한쪽만 있으면 unmatched 버퍼.
- * 2. **정렬 슬롯**(`rightToLeftPara`가 비어 있지 않을 때) — `pairAlignmentSlotControls`.
+ * 2. **표 Patience(선행)** — `extractTablePatiencePins`(요약 키가 양쪽에서 각각 유일할 때).
+ * 3. **정렬 슬롯**(`rightToLeftPara`가 비어 있지 않을 때) — `pairAlignmentSlotControls`.
  *    짝이 맞고 요약·종류까지 같으면 diff 생략(순수 밀림), 다르면 `align-slot:` 스템으로 상세 diff.
- * 3. **표 Patience** — `extractTablePatiencePins`(요약에서 뽑은 키가 양쪽 유일할 때).
  * 4. **전역 폴백** — `pairControlsFallback`(임계 2.75). 동일 요약·타입이면 생략.
  * 5. 남은 항목은 added / removed.
  *
- * `identity` 전략에서는 맵이 비어 2단계가 no-op이 된다.
+ * `identity` 전략에서는 `rightToLeftPara`가 비어 3단계 슬롯만 no-op이며, 2단계 Patience는 그대로 적용된다.
  */
 function buildControlDiffs(
   left: CompareDocumentSnapshot,
@@ -2516,10 +2685,21 @@ function buildControlDiffs(
     if (r) unmatchedRight.push(r);
   }
 
-  let slotRestL = unmatchedLeft;
-  let slotRestR = unmatchedRight;
+  const {
+    pins: tablePins,
+    restLeft: afterPatienceL,
+    restRight: afterPatienceR,
+  } = extractTablePatiencePins(unmatchedLeft, unmatchedRight);
+  for (const { left: l, right: r } of tablePins) {
+    if (l.summary !== r.summary || l.kind !== r.kind) {
+      diffs.push(...buildGranularControlDiffs(l, r, `table-pin:${l.key}=>${r.key}`));
+    }
+  }
+
+  let slotRestL = afterPatienceL;
+  let slotRestR = afterPatienceR;
   if (rightToLeftPara && rightToLeftPara.size > 0) {
-    const slot = pairAlignmentSlotControls(unmatchedLeft, unmatchedRight, rightToLeftPara);
+    const slot = pairAlignmentSlotControls(afterPatienceL, afterPatienceR, rightToLeftPara);
     for (const { left: l, right: r } of slot.pairs) {
       if (l.summary !== r.summary || l.kind !== r.kind) {
         diffs.push(...buildGranularControlDiffs(l, r, `align-slot:${l.key}=>${r.key}`));
@@ -2529,15 +2709,8 @@ function buildControlDiffs(
     slotRestR = slot.restRight;
   }
 
-  const { pins, restLeft, restRight } = extractTablePatiencePins(slotRestL, slotRestR);
-  for (const { left: l, right: r } of pins) {
-    if (l.summary !== r.summary || l.kind !== r.kind) {
-      diffs.push(...buildGranularControlDiffs(l, r, `table-pin:${l.key}=>${r.key}`));
-    }
-  }
-
   // 2차: key가 달라진 컨트롤(특히 표/이미지)의 폴백 매칭
-  const fallbackPairs = pairControlsFallback(restLeft, restRight);
+  const fallbackPairs = pairControlsFallback(slotRestL, slotRestR);
   const pairedL = new Set(fallbackPairs.map((p) => p.left));
   const pairedR = new Set(fallbackPairs.map((p) => p.right));
   for (const { left: l, right: r } of fallbackPairs) {
@@ -2546,7 +2719,7 @@ function buildControlDiffs(
     diffs.push(...buildGranularControlDiffs(l, r, `fallback-modified:${l.key}=>${r.key}`));
   }
 
-  for (const r of restRight) {
+  for (const r of slotRestR) {
     if (pairedR.has(r)) continue;
     const key = `${r.kind}::${r.key}`;
     diffs.push({
@@ -2560,7 +2733,7 @@ function buildControlDiffs(
       rightAnchor: r.anchor,
     });
   }
-  for (const l of restLeft) {
+  for (const l of slotRestL) {
     if (pairedL.has(l)) continue;
     const key = `${l.kind}::${l.key}`;
     diffs.push({
@@ -2578,10 +2751,10 @@ function buildControlDiffs(
 }
 
 /**
- * 키·슬롯·표 핀 이후에도 남은 좌·우 컨트롤을 **전역 탐욕**으로 짝지음(오른쪽 각각에 대해 왼쪽 후보 중 최고점).
+ * 키·표 Patience·슬롯 이후에도 남은 좌·우 컨트롤을 **전역 탐욕**으로 짝지음(오른쪽 각각에 대해 왼쪽 후보 중 최고점).
  *
  * `bestScore >= 2.75` 미만이면 매칭하지 않는다 — 절대 좌표·요약 유사도만으로 오매칭하면 added/removed 노이즈가 커지기 때문.
- * 문단 정렬이 신뢰되는 경우에는 먼저 `pairAlignmentSlotControls`가 같은 논리 문단 안에서 점수 보너스를 준다.
+ * 문단 정렬이 신뢰되는 경우에는 `pairAlignmentSlotControls`가 같은 논리 문단 안에서 점수 보너스를 준다.
  */
 function pairControlsFallback(
   left: CompareControlSnapshot[],
@@ -2611,10 +2784,45 @@ function pairControlsFallback(
 }
 
 /**
+ * 표 한 쌍의 “같은 표에서 셀만 바뀜” 정도를 0~1로 본다. 행·열(r/c)이 다르면 낮게 나와 전액 감점된다.
+ */
+function tableControlPairContentSimilarity(l: CompareControlSnapshot, r: CompareControlSnapshot): number {
+  const lk = parseSummaryKV(l.summary);
+  const rk = parseSummaryKV(r.summary);
+  const sameGrid = (lk.r ?? '') === (rk.r ?? '') && (lk.c ?? '') === (rk.c ?? '');
+  if (!sameGrid) return 0.08;
+
+  const pickCells = (kv: Record<string, string>) => {
+    const cp = kv.cprev;
+    if (cp && cp !== '(없음)') return cp;
+    const tp = kv.tprev;
+    if (tp && tp !== '(없음)') return tp;
+    return kv.txt ?? '';
+  };
+  const a = pickCells(lk);
+  const b = pickCells(rk);
+  if (a || b) return textSimilarity(a, b);
+
+  const shaL = lk.csha ?? '';
+  const shaR = rk.csha ?? '';
+  if (shaL && shaR && shaL === shaR) return 1;
+
+  return textSimilarity(l.summary.replace(/\s+/g, ' '), r.summary.replace(/\s+/g, ' '));
+}
+
+function tableSummaryMismatchPenaltyFactor(l: CompareControlSnapshot, r: CompareControlSnapshot): number {
+  const sim = tableControlPairContentSimilarity(l, r);
+  if (sim >= TABLE_PAIR_SIM_NO_PENALTY) return 0;
+  if (sim <= TABLE_PAIR_SIM_FULL_PENALTY) return 1;
+  return (TABLE_PAIR_SIM_NO_PENALTY - sim) / (TABLE_PAIR_SIM_NO_PENALTY - TABLE_PAIR_SIM_FULL_PENALTY);
+}
+
+/**
  * `pairControlsFallback` / `pairAlignmentSlotControls` 공통 점수 함수.
  *
  * - kind 불일치 → -1 (즉시 탈락).
  * - 동일 `type`, 동일 `summary`에 큰 가중(표·도형은 요약 문자열에 구조·텍스트 요약이 들어 있음).
+ * - **표끼리 요약이 다르면** `TABLE_SUMMARY_MISMATCH_PENALTY`를 **내용 유사도에 비례해** 감점(같은 그리드·거의 같은 셀 문자열이면 감점 없음).
  * - 그다음 `sid`/`loc` 키에서 뽑은 **control index** 일치, 같은 section, 페이지 간격, 앵커 박스 x/y/wh 근접.
  *
  * 문단 삽입으로 y가 크게 밀리면 위치 항만으로는 2.75에 못 미칠 수 있어, alignment 맵이 있을 때는
@@ -2648,6 +2856,10 @@ function scoreControlFallback(l: CompareControlSnapshot, r: CompareControlSnapsh
   else if (yGap < 180) score += 0.3;
   if (wGap < 45 && hGap < 45) score += 0.45;
   else if (wGap < 120 && hGap < 120) score += 0.22;
+  if (l.kind === 'table' && r.kind === 'table' && l.summary !== r.summary) {
+    const factor = tableSummaryMismatchPenaltyFactor(l, r);
+    score -= TABLE_SUMMARY_MISMATCH_PENALTY * factor;
+  }
   return score;
 }
 

--- a/rhwp-studio/src/compare/session.ts
+++ b/rhwp-studio/src/compare/session.ts
@@ -1,0 +1,49 @@
+import type { EventBus } from '@/core/event-bus';
+import type { CompareSession, DiffItem } from './types';
+
+export class CompareSessionStore {
+  private session: CompareSession | null = null;
+
+  constructor(private readonly eventBus: EventBus) {}
+
+  set(session: CompareSession): void {
+    this.session = session;
+    this.eventBus.emit('compare:session-changed', session);
+  }
+
+  clear(): void {
+    this.session = null;
+    this.eventBus.emit('compare:session-cleared');
+  }
+
+  get(): CompareSession | null {
+    return this.session;
+  }
+
+  nextDiff(): DiffItem | null {
+    if (!this.session || this.session.diffItems.length === 0) return null;
+    const next = Math.min(this.session.currentDiffIndex + 1, this.session.diffItems.length - 1);
+    this.session.currentDiffIndex = next;
+    const item = this.session.diffItems[next];
+    this.eventBus.emit('compare:navigate-diff', item, next, this.session.diffItems.length);
+    return item;
+  }
+
+  prevDiff(): DiffItem | null {
+    if (!this.session || this.session.diffItems.length === 0) return null;
+    const prev = Math.max(this.session.currentDiffIndex - 1, 0);
+    this.session.currentDiffIndex = prev;
+    const item = this.session.diffItems[prev];
+    this.eventBus.emit('compare:navigate-diff', item, prev, this.session.diffItems.length);
+    return item;
+  }
+
+  gotoDiff(index: number): DiffItem | null {
+    if (!this.session || this.session.diffItems.length === 0) return null;
+    if (index < 0 || index >= this.session.diffItems.length) return null;
+    this.session.currentDiffIndex = index;
+    const item = this.session.diffItems[index];
+    this.eventBus.emit('compare:navigate-diff', item, index, this.session.diffItems.length);
+    return item;
+  }
+}

--- a/rhwp-studio/src/compare/types.ts
+++ b/rhwp-studio/src/compare/types.ts
@@ -1,0 +1,118 @@
+export type DiffKind = 'text' | 'table' | 'shape' | 'image' | 'chart' | 'paragraphMeta';
+export type DiffSeverity = 'added' | 'removed' | 'modified';
+
+/** 이력 비교(identity) / 문서 비교(alignment) 호출부에서 명시적으로 선택 */
+export type CompareStrategy = 'identity' | 'alignment';
+
+export interface CompareAnchorTuning {
+  /** 앵커 후보 최소 정규화 길이 */
+  minTextLen?: number;
+  /** 앵커 후보 최소 고유 문자 수 */
+  minUniqueChars?: number;
+  /** 공백 비율이 이 값을 넘으면 앵커에서 제외 */
+  maxWhitespaceRatio?: number;
+  /** Shannon entropy(문자 분포) 하한 */
+  minEntropy?: number;
+}
+
+export interface ComparePerformanceTuning {
+  /** alignment 계산 타임버짓(ms). 초과 시 그리디 폴백 비중을 높인다. */
+  maxComputeMs?: number;
+  /** 구간 셀 개수(n*m)가 이 값 초과면 DP를 금지한다. */
+  hardSegmentCells?: number;
+}
+
+export interface CompareOptions {
+  caseSensitive: boolean;
+  ignoreWhitespace: boolean;
+  kinds: DiffKind[];
+  /** 호출부 정책에 맞는 비교 전략을 명시적으로 지정 */
+  strategy?: CompareStrategy;
+  /** 외부 문서 비교용 앵커 튜닝 */
+  anchorTuning?: CompareAnchorTuning;
+  /** 브라우저 프리징 방지용 계산 가드레일 */
+  performanceTuning?: ComparePerformanceTuning;
+}
+
+export interface CompareDocMeta {
+  name: string;
+  sectionCount: number;
+  pageCount: number;
+  /** pageIndex(0-base) -> 문서 표시 쪽번호(1-base) */
+  pageDisplayNumbers?: number[];
+}
+
+/** `buildSnapshotFromWasm` / JSON 이력 저장용 — 문단 `stable_id` 포함 (바이너리 .hwp에는 비영속) */
+export interface CompareParaSnapshot {
+  section: number;
+  paragraph: number;
+  /** 구역 내 쪽 번호 (1-base) */
+  sectionPage: number;
+  globalIndex: number;
+  stableId: string;
+  text: string;
+  normalizedText: string;
+  controlCount: number;
+  /** 정규화 텍스트·컨트롤 개수·(WASM 가능 시)문단 모양 `ParaProperties` 요약을 묶은 digest — 앵커·유일 시그니처 매칭용 */
+  signature: string;
+  isAnchorCandidate: boolean;
+  anchor?: DiffAnchor;
+}
+
+export interface CompareControlSnapshot {
+  key: string;
+  type: string;
+  section: number;
+  paragraph: number;
+  summary: string;
+  kind: DiffKind;
+  anchor: DiffAnchor;
+}
+
+export interface CompareDocumentSnapshot {
+  meta: CompareDocMeta;
+  paragraphs: CompareParaSnapshot[];
+  controls: CompareControlSnapshot[];
+}
+
+export interface ComparePath {
+  section: number;
+  paragraph?: number;
+  controlKey?: string;
+}
+
+export interface DiffAnchor {
+  pageIndex: number;
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface DiffItem {
+  id: string;
+  kind: DiffKind;
+  severity: DiffSeverity;
+  path: ComparePath;
+  title: string;
+  leftPreview: string;
+  rightPreview: string;
+  leftAnchor?: DiffAnchor;
+  rightAnchor?: DiffAnchor;
+  /** 좌/우 문서 기준 구역 내 쪽 번호 (1-base) */
+  leftSectionPage?: number;
+  rightSectionPage?: number;
+  /** 정체성 매칭 후 문단 내부 문자 단위 요약(`myersCharDiffSummary`: Levenshtein·Hirschberg·`CHAR_DIFF_*` 상한) */
+  inlineTextDiff?: string;
+}
+
+export interface CompareSession {
+  left: CompareDocMeta;
+  right: CompareDocMeta;
+  options: CompareOptions;
+  diffItems: DiffItem[];
+  currentDiffIndex: number;
+  generatedAt: number;
+  /** 실제 적용된 본문 텍스트 비교 방식 */
+  textCompareStrategyUsed?: 'identity' | 'alignment';
+}

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -11,6 +11,8 @@ export interface DocumentInfo {
 /** WASM getPageInfo() 반환 타입 */
 export interface PageInfo {
   pageIndex: number;
+  /** 조판 기준으로 계산된 표시용 쪽 번호(구역 설정 반영) */
+  pageNumber?: number;
   width: number;
   height: number;
   sectionIndex: number;

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -76,6 +76,22 @@ export class WasmBridge {
     };
   }
 
+  /**
+   * 문서 IR만 해제한다. WASM 모듈 초기화 상태는 유지한다.
+   * 비교 상세 창 등 보조 WasmBridge 인스턴스에서 반복 로드 시 메모리 누수를 줄이기 위해 사용한다.
+   */
+  releaseDocument(): void {
+    if (this.doc) {
+      try {
+        this.doc.free();
+      } catch {
+        /* noop */
+      }
+      this.doc = null;
+    }
+    this._currentFileHandle = null;
+  }
+
   loadDocument(data: Uint8Array, fileName?: string): DocumentInfo {
     if (this.doc) {
       this.doc.free();
@@ -84,10 +100,16 @@ export class WasmBridge {
     this._currentFileHandle = null;
     this.doc = new HwpDocument(data);
     this.doc.convertToEditable();
+    this.ensureParagraphStableIds();
     this.doc.setFileName(this._fileName);
     const info: DocumentInfo = JSON.parse(this.doc.getDocumentInfo());
     console.log(`[WasmBridge] 문서 로드: ${info.pageCount}페이지`);
     return info;
+  }
+
+  /** 메인 뷰에 문서가 올라와 있는지(비교 보조 WasmBridge 등과 구분). */
+  hasLoadedDocument(): boolean {
+    return this.doc != null;
   }
 
   createNewDocument(): DocumentInfo {
@@ -96,6 +118,7 @@ export class WasmBridge {
       this.doc = HwpDocument.createEmpty();
     }
     const info: DocumentInfo = JSON.parse(this.doc.createBlankDocument());
+    this.ensureParagraphStableIds();
     this._fileName = '새 문서.hwp';
     this._currentFileHandle = null;
     this.doc.setFileName(this._fileName);
@@ -170,6 +193,20 @@ export class WasmBridge {
     return JSON.parse(this.doc.getPageInfo(pageNum));
   }
 
+  refreshLayout(): void {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    try {
+      (this.doc as any).refreshLayout?.();
+    } catch (e) {
+      console.warn('[WasmBridge] refreshLayout failed:', e);
+    }
+  }
+
+  getDocumentInfo(): DocumentInfo {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse(this.doc.getDocumentInfo());
+  }
+
   getPageDef(sectionIdx: number): PageDef {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.getPageDef(sectionIdx));
@@ -213,7 +250,15 @@ export class WasmBridge {
     layerKind: 'all' | 'flow' | 'behind' | 'front',
   ): void {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    this.doc.renderPageToCanvasFiltered(pageNum, canvas, scale, layerKind);
+    const d = this.doc as unknown as {
+      renderPageToCanvasFiltered?: (p: number, c: HTMLCanvasElement, s: number, k: string) => void;
+    };
+    if (typeof d.renderPageToCanvasFiltered === 'function') {
+      d.renderPageToCanvasFiltered(pageNum, canvas, scale, layerKind);
+      return;
+    }
+    // 구버전 WASM(public/rhwp.js 등): 레이어 필터 API 없음 → 전체 캔버스 렌더로 폴백
+    this.doc.renderPageToCanvas(pageNum, canvas, scale);
   }
 
   /**
@@ -223,7 +268,11 @@ export class WasmBridge {
    */
   getPageLayerTree(pageNum: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    return this.doc.getPageLayerTree(pageNum);
+    const d = this.doc as unknown as { getPageLayerTree?: (p: number) => string };
+    if (typeof d.getPageLayerTree === 'function') {
+      return d.getPageLayerTree(pageNum);
+    }
+    return '{"layers":[]}';
   }
 
   renderPageSvg(pageNum: number): string {
@@ -299,6 +348,34 @@ export class WasmBridge {
   getParagraphCount(sec: number): number {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.getParagraphCount(sec);
+  }
+
+  getParagraphStableId(sec: number, para: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getParagraphStableId?: (a: number, b: number) => string };
+    if (typeof d.getParagraphStableId !== 'function') return '';
+    return d.getParagraphStableId(sec, para) ?? '';
+  }
+
+  /** 비교/스냅샷 생성 직전에만 stable_id를 보정한다(문서 로드 시 자동 호출 금지). */
+  ensureParagraphStableIds(): void {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { ensureParagraphStableIds?: () => void };
+    if (typeof d.ensureParagraphStableIds === 'function') {
+      try {
+        d.ensureParagraphStableIds();
+      } catch (e) {
+        console.warn('[WasmBridge] ensureParagraphStableIds skipped:', e);
+      }
+    }
+  }
+
+  /** 디버그: `JSON.parse(bridge.debugDumpStableIds(0,0,12))` 등 분할 직후 등 stable_id 확인 */
+  debugDumpStableIds(sec: number, startPara: number, count: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { debugDumpStableIds?: (a: number, b: number, c: number) => string };
+    if (typeof d.debugDumpStableIds !== 'function') return '[]';
+    return d.debugDumpStableIds(sec, startPara, count) ?? '[]';
   }
 
   /** 문단에 텍스트박스 Shape 컨트롤이 있으면 control_index, 없으면 -1 */
@@ -490,6 +567,15 @@ export class WasmBridge {
     return JSON.parse(this.doc.getTableProperties(sec, parentPara, controlIdx));
   }
 
+  getTableSignature(sec: number, parentPara: number, controlIdx: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as { getTableSignature?: (a: number, b: number, c: number) => string };
+    if (typeof d.getTableSignature !== 'function') {
+      throw new Error('getTableSignature API unavailable');
+    }
+    return d.getTableSignature(sec, parentPara, controlIdx);
+  }
+
   setTableProperties(sec: number, parentPara: number, controlIdx: number, props: Partial<TableProperties>): { ok: boolean } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.setTableProperties(sec, parentPara, controlIdx, JSON.stringify(props)));
@@ -610,6 +696,11 @@ export class WasmBridge {
   getShapeProperties(sec: number, para: number, ci: number): import('./types').ShapeProperties {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.getShapeProperties(sec, para, ci));
+  }
+
+  getShapeText(sec: number, para: number, ci: number): { ok: boolean; text: string } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse((this.doc as any).getShapeText(sec, para, ci));
   }
 
   setShapeProperties(sec: number, para: number, ci: number, props: Record<string, unknown>): { ok: boolean } {

--- a/rhwp-studio/src/history/idb-store.ts
+++ b/rhwp-studio/src/history/idb-store.ts
@@ -1,0 +1,217 @@
+/**
+ * 문서 이력 — IndexedDB + 메모리 폴백.
+ * - 신규: IR 스냅샷 JSON(`CompareDocumentSnapshot`)으로 stable_id 보존.
+ * - 레거시: HWP 바이트만 있던 항목은 비교 시 `compareDocuments`(alignment)로 폴백.
+ */
+
+import type { CompareDocumentSnapshot } from '@/compare/types';
+import type { DocHistoryEntryMeta } from './types';
+
+const DB_NAME = 'rhwpStudioDocHistory';
+const DB_VER = 1;
+const META = 'historyMeta';
+const BLOBS = 'historyBlobs';
+const MAX_SNAPSHOTS = 24;
+
+type MetaRow = DocHistoryEntryMeta;
+
+type MemEntry = {
+  meta: MetaRow;
+  irSnapshot?: CompareDocumentSnapshot;
+  legacyBytes?: Uint8Array;
+};
+
+const memory = new Map<string, MemEntry>();
+
+export type HistoryPayload =
+  | { kind: 'ir'; snapshot: CompareDocumentSnapshot }
+  | { kind: 'legacy'; bytes: Uint8Array };
+
+function idbAvailable(): boolean {
+  return typeof indexedDB !== 'undefined';
+}
+
+function openDb(): Promise<IDBDatabase | null> {
+  if (!idbAvailable()) return Promise.resolve(null);
+  return new Promise((resolve) => {
+    const req = indexedDB.open(DB_NAME, DB_VER);
+    req.onerror = () => resolve(null);
+    req.onsuccess = () => resolve(req.result);
+    req.onupgradeneeded = () => {
+      const db = req.result;
+      if (!db.objectStoreNames.contains(META)) db.createObjectStore(META, { keyPath: 'id' });
+      if (!db.objectStoreNames.contains(BLOBS)) db.createObjectStore(BLOBS, { keyPath: 'id' });
+    };
+  });
+}
+
+async function withDb<T>(fn: (db: IDBDatabase) => Promise<T>, fallback: () => Promise<T>): Promise<T> {
+  const db = await openDb();
+  if (!db) return fallback();
+  try {
+    return await fn(db);
+  } finally {
+    db.close();
+  }
+}
+
+async function listMetaMemory(): Promise<MetaRow[]> {
+  return [...memory.values()]
+    .map((e) => e.meta)
+    .sort((a, b) => b.createdAt - a.createdAt);
+}
+
+export async function listHistoryMeta(): Promise<MetaRow[]> {
+  return withDb(
+    async (db) =>
+      new Promise((resolve, reject) => {
+        const tx = db.transaction(META, 'readonly');
+        const req = tx.objectStore(META).getAll();
+        req.onsuccess = () => {
+          const rows = (req.result as MetaRow[]) ?? [];
+          resolve(rows.sort((a, b) => b.createdAt - a.createdAt));
+        };
+        req.onerror = () => reject(req.error);
+      }),
+    listMetaMemory,
+  );
+}
+
+type BlobRow = { id: string; snapshotJson?: string; data?: ArrayBuffer };
+
+export async function getHistoryPayload(id: string): Promise<HistoryPayload | null> {
+  const mem = memory.get(id);
+  if (mem) {
+    if (mem.irSnapshot) return { kind: 'ir', snapshot: mem.irSnapshot };
+    if (mem.legacyBytes) return { kind: 'legacy', bytes: mem.legacyBytes };
+    return null;
+  }
+  return withDb(
+    async (db) =>
+      new Promise<HistoryPayload | null>((resolve, reject) => {
+        const tx = db.transaction(BLOBS, 'readonly');
+        const req = tx.objectStore(BLOBS).get(id);
+        req.onsuccess = () => {
+          const v = req.result as BlobRow | undefined;
+          if (!v) {
+            resolve(null);
+            return;
+          }
+          if (typeof v.snapshotJson === 'string' && v.snapshotJson.length > 0) {
+            try {
+              resolve({ kind: 'ir', snapshot: JSON.parse(v.snapshotJson) as CompareDocumentSnapshot });
+            } catch {
+              resolve(null);
+            }
+            return;
+          }
+          if (v.data) {
+            resolve({ kind: 'legacy', bytes: new Uint8Array(v.data) });
+            return;
+          }
+          resolve(null);
+        };
+        req.onerror = () => reject(req.error);
+      }),
+    async () => null,
+  );
+}
+
+async function deleteOldestIfOverLimit(db: IDBDatabase): Promise<void> {
+  const meta: MetaRow[] = await new Promise((resolve, reject) => {
+    const tx = db.transaction(META, 'readonly');
+    const req = tx.objectStore(META).getAll();
+    req.onsuccess = () => resolve((req.result as MetaRow[]) ?? []);
+    req.onerror = () => reject(req.error);
+  });
+  if (meta.length < MAX_SNAPSHOTS) return;
+  meta.sort((a, b) => a.createdAt - b.createdAt);
+  const remove = meta.slice(0, meta.length - MAX_SNAPSHOTS + 1);
+  for (const m of remove) {
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([META, BLOBS], 'readwrite');
+      tx.objectStore(META).delete(m.id);
+      tx.objectStore(BLOBS).delete(m.id);
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+  }
+}
+
+function cloneSnapshot(s: CompareDocumentSnapshot): CompareDocumentSnapshot {
+  return JSON.parse(JSON.stringify(s)) as CompareDocumentSnapshot;
+}
+
+/** IR 스냅샷 저장 — 문단 stable_id가 JSON에 포함되어 이력 비교 시 identity 모드에 적합 */
+export async function saveHistoryIrSnapshot(
+  label: string,
+  sourceFileName: string,
+  snapshot: CompareDocumentSnapshot,
+): Promise<DocHistoryEntryMeta> {
+  const id = globalThis.crypto?.randomUUID?.() ?? `h_${Date.now()}_${Math.random().toString(36).slice(2, 9)}`;
+  const createdAt = Date.now();
+  const json = JSON.stringify(snapshot);
+  const byteLength = new TextEncoder().encode(json).length;
+  const meta: MetaRow = {
+    id,
+    label: label.trim() || `스냅샷 ${new Date(createdAt).toLocaleString('ko-KR')}`,
+    createdAt,
+    sourceFileName,
+    byteLength,
+    storageKind: 'ir',
+  };
+
+  const db = await openDb();
+  if (!db) {
+    while (memory.size >= MAX_SNAPSHOTS) {
+      const oldest = [...memory.entries()].sort((a, b) => a[1].meta.createdAt - b[1].meta.createdAt)[0];
+      if (oldest) memory.delete(oldest[0]);
+    }
+    memory.set(id, { meta, irSnapshot: cloneSnapshot(snapshot) });
+    return meta;
+  }
+
+  try {
+    await deleteOldestIfOverLimit(db);
+    await new Promise<void>((resolve, reject) => {
+      const tx = db.transaction([META, BLOBS], 'readwrite');
+      tx.objectStore(META).put(meta);
+      tx.objectStore(BLOBS).put({ id, snapshotJson: json });
+      tx.oncomplete = () => resolve();
+      tx.onerror = () => reject(tx.error);
+    });
+    return meta;
+  } finally {
+    db.close();
+  }
+}
+
+export async function deleteHistorySnapshot(id: string): Promise<void> {
+  memory.delete(id);
+  await withDb(
+    async (db) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction([META, BLOBS], 'readwrite');
+        tx.objectStore(META).delete(id);
+        tx.objectStore(BLOBS).delete(id);
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      }),
+    async () => {},
+  );
+}
+
+export async function clearHistory(): Promise<void> {
+  memory.clear();
+  await withDb(
+    async (db) =>
+      new Promise<void>((resolve, reject) => {
+        const tx = db.transaction([META, BLOBS], 'readwrite');
+        tx.objectStore(META).clear();
+        tx.objectStore(BLOBS).clear();
+        tx.oncomplete = () => resolve();
+        tx.onerror = () => reject(tx.error);
+      }),
+    async () => {},
+  );
+}

--- a/rhwp-studio/src/history/types.ts
+++ b/rhwp-studio/src/history/types.ts
@@ -1,0 +1,11 @@
+/** 메타만 목록용 (페이로드는 별도 store) */
+export interface DocHistoryEntryMeta {
+  id: string;
+  label: string;
+  createdAt: number;
+  sourceFileName: string;
+  /** IR JSON UTF-8 길이 또는 구버전 HWP 바이트 길이 */
+  byteLength: number;
+  /** `ir`: stable_id 보존 스냅샷 JSON. `legacy`: 구 HWP 바이트만 저장된 항목 */
+  storageKind?: 'ir' | 'legacy';
+}

--- a/rhwp-studio/src/ui/compare-dialog.ts
+++ b/rhwp-studio/src/ui/compare-dialog.ts
@@ -1,0 +1,573 @@
+import type { CommandServices } from '@/command/types';
+import { compareDocuments } from '@/compare/diff-engine';
+import type { CompareSessionStore } from '@/compare/session';
+import type { CompareOptions, DiffItem, DiffKind } from '@/compare/types';
+import { CompareResultWindow } from './compare-result-window';
+
+const DEFAULT_KINDS: DiffKind[] = ['text', 'table', 'shape', 'image', 'chart'];
+const DEFAULT_COMPARE_OPTS: CompareOptions = {
+  caseSensitive: true,
+  ignoreWhitespace: true,
+  kinds: DEFAULT_KINDS,
+  // 외부 문서 비교는 stable_id 공유를 가정하지 않고 정렬 기반으로 고정.
+  strategy: 'alignment',
+  anchorTuning: {
+    // 문서 비교 전용 프리셋: 앵커 품질을 높여 오정렬 연쇄를 줄인다.
+    minTextLen: 22,
+    minUniqueChars: 7,
+    maxWhitespaceRatio: 0.58,
+    minEntropy: 2.05,
+  },
+  performanceTuning: {
+    // UI 프리징 방지: 타임버짓 이후 greedy/fallback 비중을 높인다.
+    maxComputeMs: 2200,
+    hardSegmentCells: 160000,
+  },
+};
+
+type CompareFile = {
+  bytes: Uint8Array;
+  fileName: string;
+};
+
+export class CompareDialog {
+  private readonly services: CommandServices;
+  private readonly compareSessionStore: CompareSessionStore;
+  private _open = false;
+  private running = false;
+
+  private wrap!: HTMLDivElement;
+  private leftFileNameEl!: HTMLSpanElement;
+  private rightFileNameEl!: HTMLSpanElement;
+  private runBtn!: HTMLButtonElement;
+  private openTwoPaneBtn!: HTMLButtonElement;
+  private caseSensitiveCheck!: HTMLInputElement;
+  private resultMetaEl!: HTMLSpanElement;
+  private resultListEl!: HTMLUListElement;
+
+  private leftFile: CompareFile | null = null;
+  private rightFile: CompareFile | null = null;
+  private resultWindow: CompareResultWindow | null = null;
+
+  constructor(services: CommandServices, compareSessionStore: CompareSessionStore) {
+    this.services = services;
+    this.compareSessionStore = compareSessionStore;
+  }
+
+  isOpen(): boolean {
+    return this._open;
+  }
+
+  show(): void {
+    if (this._open) return;
+    this._open = true;
+    this.build();
+    document.body.appendChild(this.wrap);
+  }
+
+  hide(): void {
+    this._open = false;
+    this.wrap?.remove();
+  }
+
+  private build(): void {
+    this.wrap = document.createElement('div');
+    this.wrap.className = 'compare-dialog doc-compare-dialog';
+
+    const title = document.createElement('div');
+    title.className = 'compare-dialog-title';
+    title.innerHTML = '<span>문서 비교</span>';
+    const close = document.createElement('button');
+    close.className = 'dialog-close';
+    close.textContent = '\u00D7';
+    close.addEventListener('click', () => this.hide());
+    title.appendChild(close);
+    this.wrap.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'compare-dialog-body';
+
+    const hint = document.createElement('p');
+    hint.className = 'history-hint';
+    hint.textContent =
+      '두 문서를 업로드해 차이를 계산합니다. 결과를 클릭하면 좌/우 상세창에서 변경된 부분이 하이라이트되며 변경 구간 중심으로 표시됩니다.';
+    body.appendChild(hint);
+
+    const leftRow = document.createElement('div');
+    leftRow.className = 'compare-row';
+    const leftLabel = document.createElement('span');
+    leftLabel.className = 'compare-label';
+    leftLabel.textContent = '왼쪽 문서';
+    const leftBtn = document.createElement('button');
+    leftBtn.className = 'dialog-btn';
+    leftBtn.textContent = '파일 선택';
+    this.leftFileNameEl = document.createElement('span');
+    this.leftFileNameEl.className = 'compare-file';
+    this.leftFileNameEl.textContent = '(선택 안 됨)';
+    leftBtn.addEventListener('click', () => void this.pickFile('left'));
+    leftRow.append(leftLabel, leftBtn, this.leftFileNameEl);
+    body.appendChild(leftRow);
+
+    const rightRow = document.createElement('div');
+    rightRow.className = 'compare-row';
+    const rightLabel = document.createElement('span');
+    rightLabel.className = 'compare-label';
+    rightLabel.textContent = '오른쪽 문서';
+    const rightBtn = document.createElement('button');
+    rightBtn.className = 'dialog-btn';
+    rightBtn.textContent = '파일 선택';
+    this.rightFileNameEl = document.createElement('span');
+    this.rightFileNameEl.className = 'compare-file';
+    this.rightFileNameEl.textContent = '(선택 안 됨)';
+    rightBtn.addEventListener('click', () => void this.pickFile('right'));
+    rightRow.append(rightLabel, rightBtn, this.rightFileNameEl);
+    body.appendChild(rightRow);
+
+    const optWrap = document.createElement('div');
+    optWrap.className = 'compare-options';
+    const optRow = document.createElement('div');
+    optRow.className = 'compare-strategy-row';
+    const caseLabel = document.createElement('label');
+    caseLabel.className = 'compare-checkbox';
+    this.caseSensitiveCheck = document.createElement('input');
+    this.caseSensitiveCheck.type = 'checkbox';
+    this.caseSensitiveCheck.id = 'doc-compare-case-sensitive';
+    this.caseSensitiveCheck.checked = DEFAULT_COMPARE_OPTS.caseSensitive;
+    const caseSpan = document.createElement('span');
+    caseSpan.textContent = '영문 대소문자 구분';
+    caseLabel.append(this.caseSensitiveCheck, caseSpan);
+    optRow.appendChild(caseLabel);
+    optWrap.appendChild(optRow);
+    body.appendChild(optWrap);
+
+    const actions = document.createElement('div');
+    actions.className = 'compare-actions';
+    this.runBtn = document.createElement('button');
+    this.runBtn.className = 'dialog-btn';
+    this.runBtn.textContent = '문서 비교 실행';
+    this.runBtn.addEventListener('click', () => void this.onRunCompare());
+    this.openTwoPaneBtn = document.createElement('button');
+    this.openTwoPaneBtn.className = 'dialog-btn';
+    this.openTwoPaneBtn.textContent = '2개 창 띄우기';
+    this.openTwoPaneBtn.disabled = true;
+    this.openTwoPaneBtn.addEventListener('click', () => this.openResultWindow());
+    actions.append(this.runBtn, this.openTwoPaneBtn);
+    body.appendChild(actions);
+
+    const resultTitle = document.createElement('div');
+    resultTitle.className = 'compare-kinds-title';
+    resultTitle.textContent = '비교 결과';
+    body.appendChild(resultTitle);
+
+    this.resultMetaEl = document.createElement('span');
+    this.resultMetaEl.className = 'compare-result-meta';
+    this.resultMetaEl.textContent = '비교 실행 전';
+    this.resultListEl = document.createElement('ul');
+    this.resultListEl.className = 'compare-result-list';
+    body.appendChild(this.resultMetaEl);
+    body.appendChild(this.resultListEl);
+
+    this.wrap.appendChild(body);
+    this.prefillRightFromCurrentDocument();
+  }
+
+  /** 에디터에 열린 문서를 오른쪽 비교 대상으로 기본 설정한다. */
+  private prefillRightFromCurrentDocument(): void {
+    if (this.rightFile) return;
+    const wasm = this.services.wasm;
+    if (!wasm.hasLoadedDocument()) return;
+    try {
+      const fmt = wasm.getSourceFormat();
+      const raw = fmt === 'hwpx' ? wasm.exportHwpx() : wasm.exportHwp();
+      const bytes = new Uint8Array(raw);
+      this.rightFile = { bytes, fileName: wasm.fileName };
+      this.rightFileNameEl.textContent = wasm.fileName;
+    } catch {
+      /* 미로드·보내기 실패 시 무시 */
+    }
+  }
+
+  private async pickFile(side: 'left' | 'right'): Promise<void> {
+    const input = document.createElement('input');
+    input.type = 'file';
+    input.accept = '.hwp,.hwpx';
+    input.style.display = 'none';
+    document.body.appendChild(input);
+    input.click();
+    const selected = await new Promise<File | null>((resolve) => {
+      input.onchange = () => resolve(input.files?.[0] ?? null);
+    });
+    input.remove();
+    if (!selected) return;
+    const name = selected.name.toLowerCase();
+    if (!name.endsWith('.hwp') && !name.endsWith('.hwpx')) {
+      this.resultMetaEl.textContent = 'HWP/HWPX 파일만 선택할 수 있습니다.';
+      return;
+    }
+    const bytes = new Uint8Array(await selected.arrayBuffer());
+    const picked: CompareFile = { bytes, fileName: selected.name };
+    if (side === 'left') {
+      this.leftFile = picked;
+      this.leftFileNameEl.textContent = selected.name;
+    } else {
+      this.rightFile = picked;
+      this.rightFileNameEl.textContent = selected.name;
+    }
+  }
+
+  private async onRunCompare(): Promise<void> {
+    if (this.running) return;
+    if (!this.leftFile || !this.rightFile) {
+      this.resultMetaEl.textContent = '왼쪽/오른쪽 문서를 모두 선택하세요.';
+      return;
+    }
+
+    const ctx = this.services.getContext();
+    if (ctx.hasDocument) {
+      const detail = ctx.canUndo
+        ? '저장하지 않은 변경이 있으면 잃을 수 있습니다.'
+        : '현재 편집 중인 문서가 오른쪽과 다르면 에디터 내용이 오른쪽 파일로 바뀝니다.';
+      const ok = window.confirm(
+        `비교를 실행한 뒤 오른쪽 문서를 에디터에 불러옵니다.\n${detail}\n계속할까요?`,
+      );
+      if (!ok) return;
+    }
+
+    this.running = true;
+    this.runBtn.disabled = true;
+    this.openTwoPaneBtn.disabled = true;
+    this.runBtn.textContent = '비교 중...';
+    this.resultMetaEl.textContent = '비교 계산 중...';
+    this.resultListEl.replaceChildren();
+
+    try {
+      const session = await compareDocuments(
+        this.leftFile.bytes,
+        this.leftFile.fileName,
+        this.rightFile.bytes,
+        this.rightFile.fileName,
+        { ...DEFAULT_COMPARE_OPTS, caseSensitive: this.caseSensitiveCheck.checked },
+      );
+
+      await this.loadRightDocumentToEditor(this.rightFile);
+      this.compareSessionStore.set(session);
+      this.services.eventBus.emit('compare:mode-changed', true);
+
+      const mode =
+        session.textCompareStrategyUsed === 'identity' ? '본문=id(Map)' : '본문=정렬(alignment)';
+      this.resultMetaEl.textContent =
+        `${session.diffItems.length}개 차이 · ${mode} · "${this.leftFile.fileName}" vs "${this.rightFile.fileName}"`;
+      this.renderDiffList(session.diffItems);
+      this.openTwoPaneBtn.disabled = session.diffItems.length === 0;
+      if (session.diffItems.length > 0) {
+        this.compareSessionStore.gotoDiff(0);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.resultMetaEl.textContent = `비교 실패: ${msg}`;
+    } finally {
+      this.running = false;
+      this.runBtn.disabled = false;
+      this.runBtn.textContent = '문서 비교 실행';
+    }
+  }
+
+  private openResultWindow(): void {
+    const sess = this.compareSessionStore.get();
+    if (!sess || sess.diffItems.length === 0) {
+      this.resultMetaEl.textContent = '먼저 문서 비교를 실행해 결과를 생성하세요.';
+      return;
+    }
+    const idx = Math.max(0, sess.currentDiffIndex);
+    this.resultWindow ??= new CompareResultWindow();
+    if (!this.leftFile || !this.rightFile) return;
+    this.resultWindow.show(sess, this.compareSessionStore, idx, {
+      left: this.leftFile,
+      right: this.rightFile,
+    });
+  }
+
+  private async loadRightDocumentToEditor(file: CompareFile): Promise<void> {
+    const requestId = `cmp_${Date.now()}_${Math.random().toString(36).slice(2, 8)}`;
+    const done = new Promise<void>((resolve, reject) => {
+      const off = this.services.eventBus.on('open-document-bytes:done', (payload) => {
+        const p = payload as { requestId?: string; ok: boolean; error?: string };
+        if (p.requestId !== requestId) return;
+        off();
+        if (p.ok) resolve();
+        else reject(new Error(p.error || '오른쪽 문서 로드 실패'));
+      });
+      setTimeout(() => {
+        off();
+        reject(new Error('오른쪽 문서 로드 타임아웃'));
+      }, 15000);
+    });
+    this.services.eventBus.emit('open-document-bytes', {
+      bytes: new Uint8Array(file.bytes),
+      fileName: file.fileName,
+      fileHandle: null,
+      requestId,
+    });
+    await done;
+  }
+
+  private renderDiffList(items: DiffItem[]): void {
+    this.resultListEl.replaceChildren();
+    for (const [idx, item] of items.entries()) {
+      const li = document.createElement('li');
+      li.className = 'compare-result-item';
+      li.dataset.diffId = item.id;
+      const location = this.formatLocation(item);
+      const valueDiff = this.renderValueDiff(item);
+      const leftPreview = this.formatPreviewText(this.sanitizeControlPreview(item.leftPreview));
+      const rightPreview = this.formatPreviewText(this.sanitizeControlPreview(item.rightPreview));
+      const previewLine = (item.kind === 'text' || item.severity !== 'modified')
+        ? `<div class="compare-result-preview">L: ${this.escape(leftPreview)} / R: ${this.escape(rightPreview)}</div>`
+        : '';
+      li.innerHTML = `<strong>[${this.escape(this.kindLabel(item.kind))}] ${this.escape(item.title)}${location ? ` <span class="compare-result-location">(${this.escape(location)})</span>` : ''}</strong>${previewLine}${valueDiff}`;
+      li.addEventListener('click', () => {
+        this.compareSessionStore.gotoDiff(idx);
+        const sess = this.compareSessionStore.get();
+        if (sess) {
+          this.resultWindow ??= new CompareResultWindow();
+          if (this.leftFile && this.rightFile) {
+            this.resultWindow.show(sess, this.compareSessionStore, idx, {
+              left: this.leftFile,
+              right: this.rightFile,
+            });
+          } else {
+            this.resultWindow.show(sess, this.compareSessionStore, idx);
+          }
+        }
+        this.resultListEl.querySelectorAll('.compare-result-item.active').forEach((el) => el.classList.remove('active'));
+        li.classList.add('active');
+        li.scrollIntoView({ block: 'nearest' });
+      });
+      this.resultListEl.appendChild(li);
+    }
+  }
+
+  private formatLocation(item: DiffItem): string | null {
+    const sec = item.path.section;
+    if (sec < 0) return null;
+    const sectionPage =
+      item.severity === 'removed'
+        ? item.leftSectionPage
+        : (item.rightSectionPage ?? item.leftSectionPage);
+    if (sectionPage && sectionPage > 0) return `제 ${sec + 1}구역, ${sectionPage}쪽`;
+    const anchor = item.severity === 'removed' ? item.leftAnchor : (item.rightAnchor ?? item.leftAnchor);
+    if (!anchor) return `제 ${sec + 1}구역`;
+    return `제 ${sec + 1}구역, ${anchor.pageIndex + 1}쪽`;
+  }
+
+  private formatPreviewText(text: string): string {
+    const t = text.trim().replaceAll('\r\n', '\n').replaceAll('\n', ' ↵ ').replace(/\s{2,}/g, ' ');
+    if (!t) return '(없음)';
+    if (t.length <= 140) return t;
+    return `${t.slice(0, 139)}…`;
+  }
+
+  private renderValueDiff(item: DiffItem): string {
+    if (item.severity !== 'modified') return '';
+    if (item.kind === 'text') {
+      const l = this.formatPreviewText(item.leftPreview);
+      const r = this.formatPreviewText(item.rightPreview);
+      if (l === r) return '';
+      return `<div class="compare-result-kv compare-result-kv-text"><div class="compare-result-kv-head">텍스트 변경</div><div class="compare-result-kv-line"><span class="k">기존</span><span class="v">${this.escape(l)}</span></div><div class="compare-result-kv-line"><span class="k">변경</span><span class="v">${this.escape(r)}</span></div></div>`;
+    }
+    const left = this.parseKvSummary(item.leftPreview);
+    const right = this.parseKvSummary(item.rightPreview);
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    if (keys.size === 0) return '';
+
+    const labels: Record<string, string> = {
+      r: '행',
+      c: '열',
+      tprev: '텍스트',
+      cprev: '셀 텍스트',
+      txt: '텍스트 해시',
+      props: '속성 해시',
+      box: '크기',
+      sig: '시그니처',
+      crop: '자르기',
+      effect: '효과',
+      bc: '밝기/대비',
+      rot: '회전',
+      flip: '대칭',
+      wrap: '본문배치',
+      rel: '기준',
+      pix: '시각 내용',
+    };
+
+    const rows: string[] = [];
+    for (const k of keys) {
+      if (k === 'txt' || k === 'sig' || k === 'csha') continue;
+      const lv = left[k] ?? '(없음)';
+      const rv = right[k] ?? '(없음)';
+      if (lv === rv) continue;
+      if (k === 'cprev') {
+        const cellDiff = this.formatCellPreviewDiff(lv, rv, left.csha, right.csha);
+        if (cellDiff) rows.push(`${labels[k] ?? k}: ${cellDiff}`);
+        else rows.push(`${labels[k] ?? k}: ${this.formatFieldValue(k, lv)} → ${this.formatFieldValue(k, rv)}`);
+        continue;
+      }
+      rows.push(`${labels[k] ?? k}: ${this.formatFieldValue(k, lv)} → ${this.formatFieldValue(k, rv)}`);
+    }
+    if (rows.length === 0) {
+      if (item.title.includes('텍스트 변경')) {
+        const changedCells = this.countChangedCellsFromHash(left.csha, right.csha);
+        if (changedCells > 0) {
+          return `<div class="compare-result-kv">변경값:<br/>변경 셀 ${changedCells}개 (셀 미리보기 범위를 벗어나거나 텍스트가 길어 일부 생략됨)</div>`;
+        }
+      }
+      if (item.title.includes('속성 변경')) {
+        const lp = left.props ?? '(없음)';
+        const rp = right.props ?? '(없음)';
+        if (lp !== rp) {
+          return `<div class="compare-result-kv">변경값:<br/>속성 해시: ${this.escape(lp)} → ${this.escape(rp)}</div>`;
+        }
+        return '<div class="compare-result-kv">변경값:<br/>속성 값 변경</div>';
+      }
+      return '';
+    }
+    const body = rows.slice(0, 4).map((r) => this.escape(r)).join('<br/>');
+    return `<div class="compare-result-kv">변경값:<br/>${body}</div>`;
+  }
+
+  private parseKvSummary(summary: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const m of summary.matchAll(/([a-z]+)=("([^"]*)"|[^\s]+)/g)) {
+      const raw = m[2] ?? '';
+      out[m[1]] = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+    }
+    return out;
+  }
+
+  private sanitizeControlPreview(text: string): string {
+    return text
+      .replace(/\s(?:txt|props|sig|cprev|csha|pix)=\"[^\"]*\"/g, '')
+      .replace(/\s(?:sig|txt|props)=[^\s]+/g, '')
+      .replace(/(?:^|\s)(sig|txt|props|csha|pix)=[^\s]+/g, '')
+      .trim();
+  }
+
+  private formatFieldValue(key: string, value: string): string {
+    if (value === '(없음)') return value;
+    if (key === 'box') {
+      const m = value.match(/^(-?\d+)x(-?\d+)$/);
+      if (m) return `${m[1]}px × ${m[2]}px`;
+    }
+    if (key === 'crop') {
+      const nums = value.split(',');
+      if (nums.length === 4) return `좌${nums[0]}, 상${nums[1]}, 우${nums[2]}, 하${nums[3]}`;
+    }
+    if (key === 'cprev') {
+      const map = this.parseCellPreviewMap(value);
+      if (map.size > 0) {
+        return [...map.entries()]
+          .slice(0, 2)
+          .map(([cell, text]) => `${cell}=${text}`)
+          .join(' | ');
+      }
+      const normalized = value.replaceAll('&amp;', '&');
+      return normalized || '(없음)';
+    }
+    if (key === 'rot') return `${value}도`;
+    if (key === 'bc') {
+      const [b, c] = value.split('/');
+      if (b != null && c != null) return `밝기 ${b}, 대비 ${c}`;
+    }
+    if (key === 'flip') {
+      if (value === '10') return '가로';
+      if (value === '01') return '세로';
+      if (value === '11') return '가로+세로';
+      if (value === '00') return '없음';
+    }
+    return value;
+  }
+
+  private parseCellPreviewMap(value: string): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!value || value === '(없음)') return map;
+    const normalized = value.replaceAll('&amp;', '&');
+    const parts = normalized.includes('&') ? normalized.split('&') : normalized.split(';');
+    for (const part of parts) {
+      const p = part.trim();
+      if (!p) continue;
+      const idx = p.includes('=') ? p.indexOf('=') : p.indexOf(':');
+      if (idx <= 0) continue;
+      const cell = p.slice(0, idx).trim();
+      const raw = p.slice(idx + 1).trim();
+      let text = raw;
+      try {
+        text = decodeURIComponent(raw);
+      } catch {
+        text = raw;
+      }
+      if (!cell) continue;
+      map.set(cell, text || '(빈값)');
+    }
+    return map;
+  }
+
+  private parseCellHashMap(value: string): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!value || value === '(없음)') return map;
+    const normalized = value.replaceAll('&amp;', '&');
+    const parts = normalized.includes('&') ? normalized.split('&') : normalized.split(';');
+    for (const part of parts) {
+      const p = part.trim();
+      if (!p) continue;
+      const idx = p.includes('=') ? p.indexOf('=') : p.indexOf(':');
+      if (idx <= 0) continue;
+      map.set(p.slice(0, idx).trim(), p.slice(idx + 1).trim());
+    }
+    return map;
+  }
+
+  private formatCellPreviewDiff(left: string, right: string, leftHashRaw?: string, rightHashRaw?: string): string {
+    const lmap = this.parseCellPreviewMap(left);
+    const rmap = this.parseCellPreviewMap(right);
+    const lh = this.parseCellHashMap(leftHashRaw ?? '');
+    const rh = this.parseCellHashMap(rightHashRaw ?? '');
+    const unionKeys = [...new Set([...lmap.keys(), ...rmap.keys(), ...lh.keys(), ...rh.keys()])];
+    const hashChangedKeys = unionKeys.filter((k) => (lh.get(k) ?? '') !== (rh.get(k) ?? ''));
+    const keys = hashChangedKeys.length > 0 ? hashChangedKeys : unionKeys;
+    const changes: string[] = [];
+    for (const key of keys) {
+      const lv = lmap.get(key) ?? '(없음)';
+      const rv = rmap.get(key) ?? '(없음)';
+      if (lv === rv) continue;
+      const prettyKey = key.replace(/^r(\d+)c(\d+)$/i, '$1행$2열');
+      changes.push(`${prettyKey} ${lv} → ${rv}`);
+      if (changes.length >= 3) break;
+    }
+    if (changes.length === 0) return '';
+    return changes.join(' / ');
+  }
+
+  private countChangedCellsFromHash(leftHashRaw?: string, rightHashRaw?: string): number {
+    const lh = this.parseCellHashMap(leftHashRaw ?? '');
+    const rh = this.parseCellHashMap(rightHashRaw ?? '');
+    const keys = new Set<string>([...lh.keys(), ...rh.keys()]);
+    let changed = 0;
+    for (const key of keys) {
+      if ((lh.get(key) ?? '') !== (rh.get(key) ?? '')) changed += 1;
+    }
+    return changed;
+  }
+
+  private escape(text: string): string {
+    return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  }
+
+  private kindLabel(kind: DiffItem['kind']): string {
+    if (kind === 'table') return '표';
+    if (kind === 'shape') return '도형';
+    if (kind === 'image') return '이미지';
+    if (kind === 'chart') return '그래프';
+    if (kind === 'text') return '텍스트';
+    return '메타';
+  }
+}
+

--- a/rhwp-studio/src/ui/compare-result-window.ts
+++ b/rhwp-studio/src/ui/compare-result-window.ts
@@ -1,0 +1,500 @@
+import type { CompareSessionStore } from '@/compare/session';
+import type { CompareSession, DiffItem } from '@/compare/types';
+import { WasmBridge } from '@/core/wasm-bridge';
+
+type CompareSourceDocument = {
+  bytes: Uint8Array;
+  fileName: string;
+};
+
+export class CompareResultWindow {
+  private _open = false;
+  private wrap!: HTMLDivElement;
+  private titleEl!: HTMLSpanElement;
+  private leftPane!: HTMLDivElement;
+  private rightPane!: HTMLDivElement;
+  private metaEl!: HTMLDivElement;
+  private session: CompareSession | null = null;
+  private store: CompareSessionStore | null = null;
+  private leftTitleEl!: HTMLHeadingElement;
+  private rightTitleEl!: HTMLHeadingElement;
+  private leftCanvas!: HTMLCanvasElement;
+  private rightCanvas!: HTMLCanvasElement;
+  private leftMarker!: HTMLDivElement;
+  private rightMarker!: HTMLDivElement;
+  private leftCanvasWrap!: HTMLDivElement;
+  private rightCanvasWrap!: HTMLDivElement;
+  private leftStatusEl!: HTMLDivElement;
+  private rightStatusEl!: HTMLDivElement;
+  private leftWasm: WasmBridge | null = null;
+  private rightWasm: WasmBridge | null = null;
+  private leftDocKey = '';
+  private rightDocKey = '';
+  private leftSource: CompareSourceDocument | null = null;
+  private rightSource: CompareSourceDocument | null = null;
+  private loadingToken = 0;
+
+  isOpen(): boolean {
+    return this._open;
+  }
+
+  show(
+    session: CompareSession,
+    store: CompareSessionStore,
+    initialIndex = 0,
+    docs?: { left: CompareSourceDocument; right: CompareSourceDocument },
+  ): void {
+    this.session = session;
+    this.store = store;
+    if (docs) {
+      this.leftSource = docs.left;
+      this.rightSource = docs.right;
+    }
+    if (!this._open) {
+      this._open = true;
+      this.build();
+      document.body.appendChild(this.wrap);
+    }
+    this.titleEl.textContent = `문서 비교 상세 · ${session.left.name} ↔ ${session.right.name}`;
+    this.leftTitleEl.textContent = '왼쪽 문서';
+    this.rightTitleEl.textContent = '오른쪽 문서';
+    void this.focusDiff(initialIndex);
+  }
+
+  hide(): void {
+    this._open = false;
+    this.wrap?.remove();
+    try {
+      this.leftWasm?.releaseDocument();
+      this.rightWasm?.releaseDocument();
+    } catch {
+      /* noop */
+    }
+    this.leftWasm = null;
+    this.rightWasm = null;
+    this.leftDocKey = '';
+    this.rightDocKey = '';
+    this.leftSource = null;
+    this.rightSource = null;
+    this.session = null;
+    this.store = null;
+  }
+
+  async focusDiff(index: number): Promise<void> {
+    if (!this.session) return;
+    const item = this.session.diffItems[index];
+    if (!item) return;
+    await this.ensureCompareDocumentsLoaded();
+    this.metaEl.textContent = `[${item.kind}] ${item.title}`;
+    this.leftPane.innerHTML = this.highlightPreview(item, 'left');
+    this.rightPane.innerHTML = this.highlightPreview(item, 'right');
+    this.renderRealDocumentPreview(item);
+  }
+
+  private build(): void {
+    this.wrap = document.createElement('div');
+    this.wrap.className = 'compare-inspector-window';
+
+    const head = document.createElement('div');
+    head.className = 'compare-inspector-head';
+    this.titleEl = document.createElement('span');
+    this.titleEl.textContent = '문서 비교 상세';
+    const close = document.createElement('button');
+    close.className = 'dialog-close';
+    close.textContent = '\u00D7';
+    close.addEventListener('click', () => this.hide());
+    head.append(this.titleEl, close);
+
+    const body = document.createElement('div');
+    body.className = 'compare-inspector-body';
+    this.metaEl = document.createElement('div');
+    this.metaEl.className = 'compare-inspector-meta';
+    this.metaEl.style.whiteSpace = 'pre-line';
+
+    const panes = document.createElement('div');
+    panes.className = 'compare-inspector-panes';
+    const leftWrap = document.createElement('div');
+    leftWrap.className = 'compare-inspector-pane';
+    this.leftTitleEl = document.createElement('h4');
+    this.leftTitleEl.textContent = '왼쪽 문서';
+    this.leftStatusEl = document.createElement('div');
+    this.leftStatusEl.className = 'compare-inspector-page-status';
+    this.leftStatusEl.textContent = '페이지 준비 중...';
+    this.leftCanvasWrap = document.createElement('div');
+    this.leftCanvasWrap.className = 'compare-inspector-canvas-wrap';
+    this.leftCanvas = document.createElement('canvas');
+    this.leftCanvas.className = 'compare-inspector-canvas';
+    this.leftMarker = document.createElement('div');
+    this.leftMarker.className = 'compare-inspector-anchor-marker';
+    this.leftCanvasWrap.append(this.leftCanvas, this.leftMarker);
+    this.leftPane = document.createElement('div');
+    this.leftPane.className = 'compare-inspector-content';
+    leftWrap.append(this.leftTitleEl, this.leftStatusEl, this.leftCanvasWrap, this.leftPane);
+
+    const rightWrap = document.createElement('div');
+    rightWrap.className = 'compare-inspector-pane';
+    this.rightTitleEl = document.createElement('h4');
+    this.rightTitleEl.textContent = '오른쪽 문서';
+    this.rightStatusEl = document.createElement('div');
+    this.rightStatusEl.className = 'compare-inspector-page-status';
+    this.rightStatusEl.textContent = '페이지 준비 중...';
+    this.rightCanvasWrap = document.createElement('div');
+    this.rightCanvasWrap.className = 'compare-inspector-canvas-wrap';
+    this.rightCanvas = document.createElement('canvas');
+    this.rightCanvas.className = 'compare-inspector-canvas';
+    this.rightMarker = document.createElement('div');
+    this.rightMarker.className = 'compare-inspector-anchor-marker';
+    this.rightCanvasWrap.append(this.rightCanvas, this.rightMarker);
+    this.rightPane = document.createElement('div');
+    this.rightPane.className = 'compare-inspector-content';
+    rightWrap.append(this.rightTitleEl, this.rightStatusEl, this.rightCanvasWrap, this.rightPane);
+    panes.append(leftWrap, rightWrap);
+
+    const nav = document.createElement('div');
+    nav.className = 'compare-inspector-nav';
+    const prev = document.createElement('button');
+    prev.className = 'dialog-btn';
+    prev.textContent = '이전 차이';
+    prev.addEventListener('click', () => {
+      const item = this.store?.prevDiff();
+      if (!item || !this.session) return;
+      void this.focusDiff(this.session.currentDiffIndex);
+    });
+    const next = document.createElement('button');
+    next.className = 'dialog-btn';
+    next.textContent = '다음 차이';
+    next.addEventListener('click', () => {
+      const item = this.store?.nextDiff();
+      if (!item || !this.session) return;
+      void this.focusDiff(this.session.currentDiffIndex);
+    });
+    nav.append(prev, next);
+
+    body.append(this.metaEl, panes, nav);
+    this.wrap.append(head, body);
+  }
+
+  /**
+   * 한쪽 문서 기준 구역·쪽(`annotateDiffSectionPages`가 채운 구역 내 쪽번호 우선, 없으면 앵커 글로벌 쪽).
+   */
+  private formatDiffLocationForSide(item: DiffItem, side: 'left' | 'right'): string | null {
+    const sec = item.path.section;
+    if (sec < 0) return null;
+    if (side === 'left' && item.severity === 'added') return null;
+    if (side === 'right' && item.severity === 'removed') return null;
+
+    const sectionPage = side === 'left' ? item.leftSectionPage : item.rightSectionPage;
+    if (sectionPage && sectionPage > 0) return `제 ${sec + 1}구역, ${sectionPage}쪽`;
+    const anchor = side === 'left' ? item.leftAnchor : item.rightAnchor;
+    if (anchor) return `제 ${sec + 1}구역, ${anchor.pageIndex + 1}쪽`;
+    return `제 ${sec + 1}구역`;
+  }
+
+  private highlightPreview(item: DiffItem, side: 'left' | 'right'): string {
+    const severity = item.severity;
+    let leftText: string;
+    let rightText: string;
+    if (item.kind === 'table' && severity === 'modified') {
+      const narrowed = this.formatTableCprevChangedCellsOnly(
+        item.leftPreview || '',
+        item.rightPreview || '',
+      );
+      if (narrowed) {
+        leftText = narrowed.left;
+        rightText = narrowed.right;
+      } else {
+        leftText = this.formatInspectorText(item.leftPreview || '(없음)');
+        rightText = this.formatInspectorText(item.rightPreview || '(없음)');
+      }
+    } else {
+      leftText = this.formatInspectorText(item.leftPreview || '(없음)');
+      rightText = this.formatInspectorText(item.rightPreview || '(없음)');
+    }
+    const text = side === 'left' ? leftText : rightText;
+    if (severity === 'added' && side === 'right') {
+      return `<pre><mark>${this.escape(text)}</mark></pre>`;
+    }
+    if (severity === 'removed' && side === 'left') {
+      return `<pre><mark>${this.escape(text)}</mark></pre>`;
+    }
+    if (severity !== 'modified') return `<pre>${this.escape(text)}</pre>`;
+
+    const a = leftText;
+    const b = rightText;
+    let start = 0;
+    const minLen = Math.min(a.length, b.length);
+    while (start < minLen && a.charCodeAt(start) === b.charCodeAt(start)) start += 1;
+    let enda = a.length - 1;
+    let endb = b.length - 1;
+    while (enda >= start && endb >= start && a.charCodeAt(enda) === b.charCodeAt(endb)) {
+      enda -= 1;
+      endb -= 1;
+    }
+    const source = side === 'left' ? a : b;
+    const end = side === 'left' ? enda : endb;
+    const before = source.slice(0, start);
+    const changed = source.slice(start, end + 1);
+    const after = source.slice(end + 1);
+    if (!changed) return `<pre>${this.escape(source)}</pre>`;
+    return this.renderFocusedDiff(before, changed, after);
+  }
+
+  /**
+   * 표 텍스트 변경: `cprev`/`tprev` 셀 맵을 비교해 **값이 달라진 셀만** 좌·우 각각 한 줄씩 만든다.
+   * (기존 `formatInspectorText`는 앞 5셀만 잘라 노이즈가 컸음.)
+   */
+  private formatTableCprevChangedCellsOnly(
+    leftRaw: string,
+    rightRaw: string,
+  ): { left: string; right: string } | null {
+    const lk = this.parseKvSummary(leftRaw);
+    const rk = this.parseKvSummary(rightRaw);
+    const pick = (kv: Record<string, string>) => {
+      const cp = kv.cprev;
+      if (cp && cp !== '(없음)') return cp;
+      const tp = kv.tprev;
+      if (tp && tp !== '(없음)') return tp;
+      return '';
+    };
+    const lc = pick(lk);
+    const rc = pick(rk);
+    if (!lc && !rc) return null;
+    const Lm = this.parseCellPreviewToMap(lc);
+    const Rm = this.parseCellPreviewToMap(rc);
+    if (Lm.size === 0 && Rm.size === 0) return null;
+    const keys = new Set<string>([...Lm.keys(), ...Rm.keys()]);
+    const changed: string[] = [];
+    for (const k of keys) {
+      if ((Lm.get(k) ?? '') !== (Rm.get(k) ?? '')) changed.push(k);
+    }
+    changed.sort((ka, kb) => {
+      const ma = ka.match(/^r(\d+)c(\d+)$/i);
+      const mb = kb.match(/^r(\d+)c(\d+)$/i);
+      if (!ma || !mb) return ka.localeCompare(kb);
+      const ra = Number(ma[1]);
+      const ca = Number(ma[2]);
+      const rb = Number(mb[1]);
+      const cb = Number(mb[2]);
+      return ra !== rb ? ra - rb : ca - cb;
+    });
+    if (changed.length === 0) return { left: '(셀 텍스트 동일)', right: '(셀 텍스트 동일)' };
+    const cellLabel = (k: string) => k.replace(/^r(\d+)c(\d+)$/i, '$1행$2열');
+    const left = changed.map((k) => `${cellLabel(k)}: ${Lm.get(k) ?? '(없음)'}`).join('\n');
+    const right = changed.map((k) => `${cellLabel(k)}: ${Rm.get(k) ?? '(없음)'}`).join('\n');
+    return { left, right };
+  }
+
+  private parseCellPreviewToMap(raw: string): Map<string, string> {
+    const m = new Map<string, string>();
+    for (const [k, v] of this.parseCellPreview(raw)) m.set(k, v);
+    return m;
+  }
+
+  private formatInspectorText(raw: string): string {
+    if (!raw) return '(없음)';
+    if (!raw.includes('=')) return raw;
+
+    const kv = this.parseKvSummary(raw);
+    if (Object.keys(kv).length === 0) return raw;
+
+    const lines: string[] = [];
+    const push = (label: string, value?: string) => {
+      if (!value || value === '(없음)' || value === 'nopix' || value === 'nobox') return;
+      lines.push(`${label}: ${value}`);
+    };
+
+    const cprev = kv.cprev;
+    if (cprev && cprev !== '(없음)') {
+      const cells = this.parseCellPreview(cprev);
+      if (cells.length > 0) {
+        for (const [cell, text] of cells.slice(0, 5)) {
+          lines.push(`${cell.replace(/^r(\d+)c(\d+)$/i, '$1행$2열')}: ${text}`);
+        }
+        if (cells.length > 5) lines.push(`... 외 ${cells.length - 5}개 셀`);
+      } else {
+        push('셀 텍스트', cprev);
+      }
+    }
+
+    push('행', kv.r);
+    push('열', kv.c);
+    push('크기', kv.box?.replace(/^(-?\d+)x(-?\d+)$/, '$1px × $2px'));
+    push('텍스트', kv.text);
+    push('자르기', kv.crop);
+    push('효과', kv.effect);
+    push('밝기/대비', kv.bc);
+    push('회전', kv.rot ? `${kv.rot}도` : undefined);
+    push('대칭', kv.flip);
+    push('배치', kv.wrap);
+    push('기준', kv.rel);
+
+    if (lines.length === 0) return raw;
+    return lines.join('\n');
+  }
+
+  private parseKvSummary(summary: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const m of summary.matchAll(/([a-z]+)=("([^"]*)"|[^\s]+)/g)) {
+      const raw = m[2] ?? '';
+      const unquoted = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+      out[m[1]] = unquoted;
+    }
+    return out;
+  }
+
+  private parseCellPreview(raw: string): Array<[string, string]> {
+    const out: Array<[string, string]> = [];
+    const parts = raw.includes('&') ? raw.split('&') : raw.split(';');
+    for (const p of parts) {
+      const part = p.trim();
+      if (!part) continue;
+      const idx = part.indexOf('=');
+      const legacyIdx = part.indexOf(':');
+      const cut = idx > 0 ? idx : legacyIdx;
+      if (cut <= 0) continue;
+      const key = part.slice(0, cut).trim();
+      const valRaw = part.slice(cut + 1).trim();
+      let val = valRaw;
+      try { val = decodeURIComponent(valRaw); } catch { val = valRaw; }
+      out.push([key, val]);
+    }
+    return out;
+  }
+
+  private renderFocusedDiff(before: string, changed: string, after: string): string {
+    const sideContext = 90;
+    const hasBeforeTrim = before.length > sideContext;
+    const hasAfterTrim = after.length > sideContext;
+    const beforeSlice = hasBeforeTrim ? before.slice(before.length - sideContext) : before;
+    const afterSlice = hasAfterTrim ? after.slice(0, sideContext) : after;
+    const lead = hasBeforeTrim ? '…' : '';
+    const tail = hasAfterTrim ? '…' : '';
+    return `<pre>${this.escape(lead + beforeSlice)}<mark>${this.escape(changed)}</mark>${this.escape(afterSlice + tail)}</pre>`;
+  }
+
+  private escape(text: string): string {
+    return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  }
+
+  private async ensureCompareDocumentsLoaded(): Promise<void> {
+    if (!this.leftSource || !this.rightSource) return;
+    const token = ++this.loadingToken;
+    this.leftStatusEl.textContent = '왼쪽 문서 로딩 중...';
+    this.rightStatusEl.textContent = '오른쪽 문서 로딩 중...';
+    try {
+      const leftKey = `${this.leftSource.fileName}:${this.leftSource.bytes.byteLength}`;
+      const rightKey = `${this.rightSource.fileName}:${this.rightSource.bytes.byteLength}`;
+
+      if (!this.leftWasm) {
+        this.leftWasm = new WasmBridge();
+        await this.leftWasm.initialize();
+      }
+      if (!this.rightWasm) {
+        this.rightWasm = new WasmBridge();
+        await this.rightWasm.initialize();
+      }
+      if (this.loadingToken !== token) return;
+
+      if (this.leftDocKey !== leftKey) {
+        this.leftWasm.loadDocument(this.leftSource.bytes, this.leftSource.fileName);
+        this.leftDocKey = leftKey;
+      }
+      if (this.rightDocKey !== rightKey) {
+        this.rightWasm.loadDocument(this.rightSource.bytes, this.rightSource.fileName);
+        this.rightDocKey = rightKey;
+      }
+      if (this.loadingToken !== token) return;
+      try {
+        this.leftWasm.refreshLayout();
+      } catch {
+        /* noop */
+      }
+      try {
+        this.rightWasm.refreshLayout();
+      } catch {
+        /* noop */
+      }
+      if (this.loadingToken !== token) return;
+      this.leftStatusEl.textContent = '왼쪽 문서 페이지 준비 완료';
+      this.rightStatusEl.textContent = '오른쪽 문서 페이지 준비 완료';
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.leftStatusEl.textContent = `페이지 로드 실패: ${msg}`;
+      this.rightStatusEl.textContent = `페이지 로드 실패: ${msg}`;
+    }
+  }
+
+  private renderRealDocumentPreview(item: DiffItem): void {
+    this.renderSidePage('left', this.leftWasm, this.leftCanvas, this.leftMarker, this.leftStatusEl, item);
+    this.renderSidePage('right', this.rightWasm, this.rightCanvas, this.rightMarker, this.rightStatusEl, item);
+  }
+
+  private renderSidePage(
+    side: 'left' | 'right',
+    wasm: WasmBridge | null,
+    canvas: HTMLCanvasElement,
+    marker: HTMLDivElement,
+    statusEl: HTMLDivElement,
+    item: DiffItem,
+  ): void {
+    const anchor = side === 'left' ? item.leftAnchor : item.rightAnchor;
+    const oppositeAnchor = side === 'left' ? item.rightAnchor : item.leftAnchor;
+    if (!wasm) {
+      statusEl.textContent = '문서가 아직 로드되지 않았습니다.';
+      marker.style.display = 'none';
+      return;
+    }
+    const effectiveAnchor = anchor ?? oppositeAnchor;
+    if (!effectiveAnchor) {
+      const locShort = this.formatDiffLocationForSide(item, side);
+      const base = side === 'left' ? '왼쪽 문서에 해당 위치가 없습니다.' : '오른쪽 문서에 해당 위치가 없습니다.';
+      statusEl.textContent = locShort ? `${locShort} · ${base}` : base;
+      const ctx = canvas.getContext('2d');
+      if (ctx) ctx.clearRect(0, 0, canvas.width, canvas.height);
+      marker.style.display = 'none';
+      return;
+    }
+    try {
+      const info = wasm.getPageInfo(effectiveAnchor.pageIndex);
+      const wrap = side === 'left' ? this.leftCanvasWrap : this.rightCanvasWrap;
+      const maxWidth = Math.max(260, wrap.clientWidth - 10);
+      const scale = Math.max(0.25, Math.min(1.25, maxWidth / Math.max(1, info.width)));
+      const pageIdx = effectiveAnchor.pageIndex;
+      const draw = (): void => {
+        try {
+          canvas.width = Math.max(1, Math.floor(info.width * scale));
+          canvas.height = Math.max(1, Math.floor(info.height * scale));
+          // 본 편집기는 flow+overlay 분리이나, 비교 상세는 단일 캔버스이므로 전 레이어('all')로 통일
+          wasm.renderPageToCanvasFiltered(pageIdx, canvas, scale, 'all');
+          const locShort = this.formatDiffLocationForSide(item, side);
+          const pageLine = anchor
+            ? `${effectiveAnchor.pageIndex + 1}쪽 실제 화면`
+            : `${effectiveAnchor.pageIndex + 1}쪽 대응 페이지(반대 문서 기준)`;
+          if (anchor) {
+            marker.style.display = 'block';
+            marker.style.left = `${Math.max(0, Math.floor(anchor.x * scale))}px`;
+            marker.style.top = `${Math.max(0, Math.floor(anchor.y * scale))}px`;
+            marker.style.width = `${Math.max(14, Math.floor(anchor.width * scale))}px`;
+            marker.style.height = `${Math.max(14, Math.floor(anchor.height * scale))}px`;
+          } else {
+            marker.style.display = 'none';
+          }
+          statusEl.textContent = locShort ? `${locShort} · ${pageLine}` : pageLine;
+        } catch (err) {
+          const msg = err instanceof Error ? err.message : String(err);
+          statusEl.textContent = `페이지 렌더 실패: ${msg}`;
+          marker.style.display = 'none';
+        }
+      };
+      requestAnimationFrame(() => {
+        requestAnimationFrame(draw);
+      });
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      statusEl.textContent = `페이지 렌더 실패: ${msg}`;
+      marker.style.display = 'none';
+    }
+  }
+
+}
+

--- a/rhwp-studio/src/ui/history-dialog.ts
+++ b/rhwp-studio/src/ui/history-dialog.ts
@@ -1,0 +1,542 @@
+/**
+ * 원본 오픈소스 대비 이력관리 UI 확장 (상세)
+ *
+ * [역할]
+ * - 단순 비교 호출 UI가 아니라, "버전 스냅샷 저장소" 프론트 게이트 역할을 한다.
+ * - 사용자 기준 액션: 저장 / 목록 조회 / 삭제 / 전체 비우기 / 선택 버전 vs 현재 비교.
+ *
+ * [저장 정책]
+ * - 우선 저장 포맷: IR 스냅샷(JSON)
+ *   -> 문단 stable_id를 보존하여 같은 문서의 시계열 비교에서 identity 모드를 유도한다.
+ * - 레거시 포맷(bytes)도 읽을 수 있게 유지
+ *   -> 기존 사용자 데이터 유실 방지(하위호환).
+ *
+ * [비교 실행 정책]
+ * - IR 항목: `compareSnapshots(leftSnap, rightSnap, opts)` 사용
+ * - legacy bytes 항목: `compareDocuments(...)`로 폴백
+ * - 결과는 `CompareSessionStore.set(session)` 후 `gotoDiff(0)`로 즉시 탐색 가능하게 연결한다.
+ *
+ * [UI/탐색 연결]
+ * - 이 다이얼로그는 자체 스크롤/렌더 목록만 담당하고,
+ *   실제 문서 이동/하이라이트는 `compare:navigate-diff` 체인(main.ts)으로 위임한다.
+ *
+ * [유지보수 포인트]
+ * - 결과 리스트 포맷(미리보기/위치 표기)은 사용성 이슈가 가장 잦다.
+ * - 위치 표기는 `leftSectionPage/rightSectionPage` 우선, 없으면 anchor.pageIndex 폴백 순서 유지.
+ */
+import type { CommandServices } from '@/command/types';
+import { buildSnapshotFromWasm, compareDocuments, compareSnapshots } from '@/compare/diff-engine';
+import type { CompareSessionStore } from '@/compare/session';
+import type { CompareOptions, DiffItem, DiffKind } from '@/compare/types';
+import { clearHistory, deleteHistorySnapshot, getHistoryPayload, listHistoryMeta, saveHistoryIrSnapshot } from '@/history/idb-store';
+import type { DocHistoryEntryMeta } from '@/history/types';
+
+const DEFAULT_KINDS: DiffKind[] = ['text', 'table', 'shape', 'image', 'chart', 'paragraphMeta'];
+
+const HISTORY_COMPARE_OPTS: CompareOptions = {
+  caseSensitive: true,
+  ignoreWhitespace: true,
+  kinds: DEFAULT_KINDS,
+  // 이력 관리는 같은 문서 계통 비교가 목적이므로 stable_id(identity) 고정.
+  strategy: 'identity',
+  performanceTuning: {
+    // identity는 O(N) 성격이므로 타임버짓을 넉넉히 유지(실질 영향 작음).
+    maxComputeMs: 3000,
+  },
+};
+
+export class HistoryDialog {
+  private readonly services: CommandServices;
+  private readonly compareSessionStore: CompareSessionStore;
+  private _open = false;
+
+  private wrap!: HTMLDivElement;
+  private labelInput!: HTMLInputElement;
+  private listEl!: HTMLUListElement;
+  private resultMetaEl!: HTMLSpanElement;
+  private resultListEl!: HTMLUListElement;
+  private selectedId: string | null = null;
+  private entries: DocHistoryEntryMeta[] = [];
+
+  constructor(services: CommandServices, compareSessionStore: CompareSessionStore) {
+    this.services = services;
+    this.compareSessionStore = compareSessionStore;
+  }
+
+  isOpen(): boolean {
+    return this._open;
+  }
+
+  show(): void {
+    if (this._open) return;
+    this._open = true;
+    this.build();
+    document.body.appendChild(this.wrap);
+    void this.refreshList();
+  }
+
+  hide(): void {
+    this._open = false;
+    this.wrap?.remove();
+  }
+
+  private build(): void {
+    this.wrap = document.createElement('div');
+    this.wrap.className = 'compare-dialog history-dialog';
+
+    const title = document.createElement('div');
+    title.className = 'compare-dialog-title';
+    title.innerHTML = '<span>문서 이력 관리</span>';
+    const close = document.createElement('button');
+    close.className = 'dialog-close';
+    close.textContent = '\u00D7';
+    close.addEventListener('click', () => this.hide());
+    title.appendChild(close);
+    this.wrap.appendChild(title);
+
+    const body = document.createElement('div');
+    body.className = 'compare-dialog-body';
+
+    const hint = document.createElement('p');
+    hint.className = 'history-hint';
+    hint.textContent =
+      '이력은 문단 stable_id가 보존된 IR 스냅샷(JSON)으로 저장됩니다. "선택과 현재 비교"는 같은 편집 세션에서 identity(Map) 비교가 됩니다. 예전에 HWP 바이트만 저장된 항목(legacy)은 비교 시 정렬(alignment)로 폴백됩니다.';
+    body.appendChild(hint);
+
+    const saveRow = document.createElement('div');
+    saveRow.className = 'compare-row';
+    const lab = document.createElement('label');
+    lab.className = 'compare-label';
+    lab.textContent = '스냅샷';
+    lab.htmlFor = 'history-snap-label';
+    this.labelInput = document.createElement('input');
+    this.labelInput.id = 'history-snap-label';
+    this.labelInput.type = 'text';
+    this.labelInput.className = 'history-label-input';
+    this.labelInput.placeholder = '메모 (비우면 시각 기본값)';
+    this.labelInput.value = '';
+    const saveBtn = document.createElement('button');
+    saveBtn.className = 'dialog-btn';
+    saveBtn.textContent = '현재 문서 저장';
+    saveBtn.addEventListener('click', () => void this.onSaveSnapshot());
+    saveRow.append(lab, this.labelInput, saveBtn);
+    body.appendChild(saveRow);
+
+    const listTitle = document.createElement('div');
+    listTitle.className = 'compare-kinds-title';
+    listTitle.textContent = '저장된 이력 (클릭하여 선택)';
+    body.appendChild(listTitle);
+    this.listEl = document.createElement('ul');
+    this.listEl.className = 'history-list';
+    body.appendChild(this.listEl);
+
+    const actions = document.createElement('div');
+    actions.className = 'compare-actions';
+    const delBtn = document.createElement('button');
+    delBtn.className = 'dialog-btn';
+    delBtn.textContent = '선택 삭제';
+    delBtn.addEventListener('click', () => void this.onDeleteSelected());
+    const clrBtn = document.createElement('button');
+    clrBtn.className = 'dialog-btn';
+    clrBtn.textContent = '전체 비우기';
+    clrBtn.addEventListener('click', () => void this.onClearAll());
+    const cmpBtn = document.createElement('button');
+    cmpBtn.className = 'dialog-btn';
+    cmpBtn.textContent = '선택과 현재 문서 비교';
+    cmpBtn.addEventListener('click', () => void this.onCompareWithCurrent());
+    actions.append(delBtn, clrBtn, cmpBtn);
+    body.appendChild(actions);
+
+    const resTitle = document.createElement('div');
+    resTitle.className = 'compare-kinds-title';
+    resTitle.textContent = '비교 결과';
+    body.appendChild(resTitle);
+    this.resultMetaEl = document.createElement('span');
+    this.resultMetaEl.className = 'compare-result-meta';
+    this.resultMetaEl.textContent = '비교 실행 전';
+    this.resultListEl = document.createElement('ul');
+    this.resultListEl.className = 'compare-result-list';
+    body.appendChild(this.resultMetaEl);
+    body.appendChild(this.resultListEl);
+
+    this.wrap.appendChild(body);
+  }
+
+  private async refreshList(): Promise<void> {
+    this.entries = await listHistoryMeta();
+    this.listEl.replaceChildren();
+    for (const e of this.entries) {
+      const li = document.createElement('li');
+      li.className = 'history-entry';
+      if (e.id === this.selectedId) li.classList.add('selected');
+      li.dataset.id = e.id;
+      const dt = new Date(e.createdAt).toLocaleString('ko-KR');
+      const kindNote = e.storageKind === 'legacy' ? ' · 구바이트' : '';
+      li.innerHTML = `<strong>${this.escape(e.label)}</strong><div class="history-entry-meta">${this.escape(e.sourceFileName)} · ${(e.byteLength / 1024).toFixed(1)} KB${kindNote} · ${dt}</div>`;
+      li.addEventListener('click', () => {
+        this.selectedId = e.id;
+        this.listEl.querySelectorAll('.history-entry').forEach((el) => el.classList.remove('selected'));
+        li.classList.add('selected');
+      });
+      this.listEl.appendChild(li);
+    }
+    if (!this.entries.find((x) => x.id === this.selectedId)) this.selectedId = null;
+  }
+
+  private async onSaveSnapshot(): Promise<void> {
+    const { wasm } = this.services;
+    try {
+      const label = this.labelInput.value.trim() || new Date().toLocaleString('ko-KR');
+      const snap = buildSnapshotFromWasm(wasm, label, HISTORY_COMPARE_OPTS);
+      await saveHistoryIrSnapshot(label, wasm.fileName, snap);
+      this.labelInput.value = '';
+      await this.refreshList();
+      this.resultMetaEl.textContent = '스냅샷을 저장했습니다.';
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      this.resultMetaEl.textContent = `저장 실패: ${msg}`;
+    }
+  }
+
+  private async onDeleteSelected(): Promise<void> {
+    if (!this.selectedId) {
+      this.resultMetaEl.textContent = '삭제할 항목을 목록에서 먼저 선택하세요.';
+      return;
+    }
+    await deleteHistorySnapshot(this.selectedId);
+    this.selectedId = null;
+    await this.refreshList();
+    this.resultMetaEl.textContent = '삭제했습니다.';
+    this.resultListEl.replaceChildren();
+  }
+
+  private async onClearAll(): Promise<void> {
+    if (!window.confirm('저장된 문서 이력을 모두 지울까요?')) return;
+    await clearHistory();
+    this.selectedId = null;
+    await this.refreshList();
+    this.resultMetaEl.textContent = '이력을 비웠습니다.';
+    this.resultListEl.replaceChildren();
+  }
+
+  private async onCompareWithCurrent(): Promise<void> {
+    const { wasm } = this.services;
+    if (!this.selectedId) {
+      this.resultMetaEl.textContent = '비교할 스냅샷을 목록에서 선택하세요.';
+      return;
+    }
+    const payload = await getHistoryPayload(this.selectedId);
+    if (!payload) {
+      this.resultMetaEl.textContent = '스냅샷 데이터를 읽을 수 없습니다.';
+      return;
+    }
+    const meta = this.entries.find((x) => x.id === this.selectedId);
+    const leftName = meta?.label ?? '이력 스냅샷';
+    const rightName = wasm.fileName || '현재 문서.hwp';
+    this.resultMetaEl.textContent = '비교 중...';
+    this.resultListEl.replaceChildren();
+    try {
+      let session;
+      if (payload.kind === 'ir') {
+        const rightSnap = buildSnapshotFromWasm(wasm, rightName, HISTORY_COMPARE_OPTS);
+        session = compareSnapshots(payload.snapshot, rightSnap, HISTORY_COMPARE_OPTS);
+      } else {
+        let cur: Uint8Array;
+        try {
+          cur = wasm.exportHwp();
+        } catch {
+          this.resultMetaEl.textContent = '현재 문서가 없습니다. 문서를 연 뒤 다시 시도하세요.';
+          return;
+        }
+        session = await compareDocuments(payload.bytes, leftName, cur, rightName, HISTORY_COMPARE_OPTS);
+      }
+      console.log('[rhwp:history] 최종 Diff 배열', session.diffItems);
+      this.compareSessionStore.set(session);
+      const mode =
+        session.textCompareStrategyUsed === 'identity' ? '본문=id(Map)' : '본문=정렬(alignment)';
+      this.resultMetaEl.textContent = `${session.diffItems.length}개 차이 · ${mode} · "${leftName}" vs "${rightName}"`;
+      this.renderDiffList(session.diffItems);
+      this.services.eventBus.emit('compare:mode-changed', true);
+      if (session.diffItems.length > 0) {
+        this.compareSessionStore.gotoDiff(0);
+      }
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : String(e);
+      this.resultMetaEl.textContent = `비교 실패: ${msg}`;
+    }
+  }
+
+  private renderDiffList(items: DiffItem[]): void {
+    this.resultListEl.replaceChildren();
+    for (const [idx, item] of items.entries()) {
+      const li = document.createElement('li');
+      li.className = 'compare-result-item';
+      li.dataset.diffId = item.id;
+      const location = this.formatLocation(item);
+      const leftText = this.formatPreviewText(this.sanitizeControlPreview(item.leftPreview));
+      const rightText = this.formatPreviewText(this.sanitizeControlPreview(item.rightPreview));
+      const previewLine = (item.kind === 'text' || item.severity !== 'modified')
+        ? `<div class="compare-result-preview">L: ${this.escape(leftText)} / R: ${this.escape(rightText)}</div>`
+        : '';
+      const inline =
+        item.inlineTextDiff !== undefined && item.inlineTextDiff !== ''
+          ? `<div class="compare-result-inline-diff">${this.escape(this.formatInlineDiffText(item.inlineTextDiff))}</div>`
+          : '';
+      const valueDiff = this.renderValueDiff(item);
+      li.innerHTML = `<strong>[${this.escape(this.kindLabel(item.kind))}] ${this.escape(item.title)}${location ? ` <span class="compare-result-location">(${this.escape(location)})</span>` : ''}</strong>${previewLine}${valueDiff}${inline}`;
+      li.addEventListener('click', () => {
+        this.compareSessionStore.gotoDiff(idx);
+        this.resultListEl.querySelectorAll('.compare-result-item.active').forEach((el) => el.classList.remove('active'));
+        li.classList.add('active');
+        li.scrollIntoView({ block: 'nearest' });
+      });
+      this.resultListEl.appendChild(li);
+    }
+  }
+
+  private escape(text: string): string {
+    return text.replaceAll('&', '&amp;').replaceAll('<', '&lt;').replaceAll('>', '&gt;');
+  }
+
+  private formatPreviewText(text: string): string {
+    const trimmed = text.trim();
+    if (!trimmed) return '(없음)';
+    const visible = this.makeWhitespaceVisible(trimmed);
+    return this.truncateText(visible, 140);
+  }
+
+  private formatInlineDiffText(text: string): string {
+    const compact = text
+      .replaceAll('\r\n', '\n')
+      .split('\n')
+      .map((line) => this.makeWhitespaceVisible(line).trimEnd())
+      .filter((line, idx, arr) => !(line === '' && idx > 0 && arr[idx - 1] === ''))
+      .join('\n');
+    return this.truncateText(compact, 500);
+  }
+
+  private makeWhitespaceVisible(text: string): string {
+    return text
+      .replaceAll('\t', '⇥ ')
+      .replaceAll('\r\n', '\n')
+      .replaceAll('\n', ' ↵ ')
+      .replace(/\s{2,}/g, ' ');
+  }
+
+  private truncateText(text: string, maxLen: number): string {
+    if (text.length <= maxLen) return text;
+    return `${text.slice(0, maxLen - 1)}…`;
+  }
+
+  private renderValueDiff(item: DiffItem): string {
+    if (item.severity !== 'modified') return '';
+    if (item.kind === 'text') {
+      const l = this.formatPreviewText(item.leftPreview);
+      const r = this.formatPreviewText(item.rightPreview);
+      if (l === r) return '';
+      return `<div class="compare-result-kv compare-result-kv-text"><div class="compare-result-kv-head">텍스트 변경</div><div class="compare-result-kv-line"><span class="k">기존</span><span class="v">${this.escape(l)}</span></div><div class="compare-result-kv-line"><span class="k">변경</span><span class="v">${this.escape(r)}</span></div></div>`;
+    }
+    const left = this.parseKvSummary(item.leftPreview);
+    const right = this.parseKvSummary(item.rightPreview);
+    const keys = new Set([...Object.keys(left), ...Object.keys(right)]);
+    if (keys.size === 0) return '';
+
+    const labels: Record<string, string> = {
+      r: '행',
+      c: '열',
+      tprev: '텍스트',
+      cprev: '셀 텍스트',
+      txt: '텍스트 해시',
+      props: '속성 해시',
+      box: '크기',
+      sig: '시그니처',
+      crop: '자르기',
+      effect: '효과',
+      bc: '밝기/대비',
+      rot: '회전',
+      flip: '대칭',
+      wrap: '본문배치',
+      rel: '기준',
+      pix: '시각 내용',
+    };
+
+    const rows: string[] = [];
+    for (const k of keys) {
+      if (k === 'txt' || k === 'sig' || k === 'csha') continue;
+      const lv = left[k] ?? '(없음)';
+      const rv = right[k] ?? '(없음)';
+      if (lv === rv) continue;
+      if (k === 'cprev') {
+        const cellDiff = this.formatCellPreviewDiff(lv, rv, left.csha, right.csha);
+        if (cellDiff) rows.push(`${labels[k] ?? k}: ${cellDiff}`);
+        else rows.push(`${labels[k] ?? k}: ${this.formatFieldValue(k, lv)} → ${this.formatFieldValue(k, rv)}`);
+        continue;
+      }
+      rows.push(`${labels[k] ?? k}: ${this.formatFieldValue(k, lv)} → ${this.formatFieldValue(k, rv)}`);
+    }
+    if (rows.length === 0) {
+      if (item.title.includes('텍스트 변경')) {
+        const changedCells = this.countChangedCellsFromHash(left.csha, right.csha);
+        if (changedCells > 0) {
+          return `<div class="compare-result-kv">변경값:<br/>변경 셀 ${changedCells}개 (셀 미리보기 범위를 벗어나거나 텍스트가 길어 일부 생략됨)</div>`;
+        }
+      }
+      if (item.title.includes('속성 변경')) {
+        const lp = left.props ?? '(없음)';
+        const rp = right.props ?? '(없음)';
+        if (lp !== rp) {
+          return `<div class="compare-result-kv">변경값:<br/>속성 해시: ${this.escape(lp)} → ${this.escape(rp)}</div>`;
+        }
+        return '<div class="compare-result-kv">변경값:<br/>속성 값 변경</div>';
+      }
+      return '';
+    }
+    const body = rows.slice(0, 4).map((r) => this.escape(r)).join('<br/>');
+    return `<div class="compare-result-kv">변경값:<br/>${body}</div>`;
+  }
+
+  private parseKvSummary(summary: string): Record<string, string> {
+    const out: Record<string, string> = {};
+    for (const m of summary.matchAll(/([a-z]+)=("([^"]*)"|[^\s]+)/g)) {
+      const raw = m[2] ?? '';
+      out[m[1]] = raw.startsWith('"') && raw.endsWith('"') ? raw.slice(1, -1) : raw;
+    }
+    return out;
+  }
+
+  private sanitizeControlPreview(text: string): string {
+    return text
+      .replace(/\s(?:txt|props|sig|cprev|csha|pix)=\"[^\"]*\"/g, '')
+      .replace(/\s(?:sig|txt|props)=[^\s]+/g, '')
+      .replace(/(?:^|\s)(sig|txt|props|csha|pix)=[^\s]+/g, '')
+      .trim();
+  }
+
+  private formatFieldValue(key: string, value: string): string {
+    if (value === '(없음)') return value;
+    if (key === 'box') {
+      const m = value.match(/^(-?\d+)x(-?\d+)$/);
+      if (m) return `${m[1]}px × ${m[2]}px`;
+    }
+    if (key === 'crop') {
+      const nums = value.split(',');
+      if (nums.length === 4) return `좌${nums[0]}, 상${nums[1]}, 우${nums[2]}, 하${nums[3]}`;
+    }
+    if (key === 'cprev') {
+      const map = this.parseCellPreviewMap(value);
+      if (map.size > 0) {
+        return [...map.entries()]
+          .slice(0, 2)
+          .map(([cell, text]) => `${cell}=${text}`)
+          .join(' | ');
+      }
+      const normalized = value.replaceAll('&amp;', '&');
+      return normalized || '(없음)';
+    }
+    if (key === 'rot') return `${value}도`;
+    if (key === 'bc') {
+      const [b, c] = value.split('/');
+      if (b != null && c != null) return `밝기 ${b}, 대비 ${c}`;
+    }
+    if (key === 'flip') {
+      if (value === '10') return '가로';
+      if (value === '01') return '세로';
+      if (value === '11') return '가로+세로';
+      if (value === '00') return '없음';
+    }
+    return value;
+  }
+
+  private parseCellPreviewMap(value: string): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!value || value === '(없음)') return map;
+    const normalized = value.replaceAll('&amp;', '&');
+    const parts = normalized.includes('&') ? normalized.split('&') : normalized.split(';');
+    for (const part of parts) {
+      const p = part.trim();
+      if (!p) continue;
+      const idx = p.includes('=') ? p.indexOf('=') : p.indexOf(':');
+      if (idx <= 0) continue;
+      const cell = p.slice(0, idx).trim();
+      const raw = p.slice(idx + 1).trim();
+      let text = raw;
+      try {
+        text = decodeURIComponent(raw);
+      } catch {
+        text = raw;
+      }
+      if (!cell) continue;
+      map.set(cell, text || '(빈값)');
+    }
+    return map;
+  }
+
+  private parseCellHashMap(value: string): Map<string, string> {
+    const map = new Map<string, string>();
+    if (!value || value === '(없음)') return map;
+    const normalized = value.replaceAll('&amp;', '&');
+    const parts = normalized.includes('&') ? normalized.split('&') : normalized.split(';');
+    for (const part of parts) {
+      const p = part.trim();
+      if (!p) continue;
+      const idx = p.includes('=') ? p.indexOf('=') : p.indexOf(':');
+      if (idx <= 0) continue;
+      map.set(p.slice(0, idx).trim(), p.slice(idx + 1).trim());
+    }
+    return map;
+  }
+
+  private formatCellPreviewDiff(left: string, right: string, leftHashRaw?: string, rightHashRaw?: string): string {
+    const lmap = this.parseCellPreviewMap(left);
+    const rmap = this.parseCellPreviewMap(right);
+    const lh = this.parseCellHashMap(leftHashRaw ?? '');
+    const rh = this.parseCellHashMap(rightHashRaw ?? '');
+    const unionKeys = [...new Set([...lmap.keys(), ...rmap.keys(), ...lh.keys(), ...rh.keys()])];
+    const hashChangedKeys = unionKeys.filter((k) => (lh.get(k) ?? '') !== (rh.get(k) ?? ''));
+    const keys = hashChangedKeys.length > 0 ? hashChangedKeys : unionKeys;
+    const changes: string[] = [];
+    for (const key of keys) {
+      const lv = lmap.get(key) ?? '(없음)';
+      const rv = rmap.get(key) ?? '(없음)';
+      if (lv === rv) continue;
+      const prettyKey = key.replace(/^r(\d+)c(\d+)$/i, '$1행$2열');
+      changes.push(`${prettyKey} ${lv} → ${rv}`);
+      if (changes.length >= 3) break;
+    }
+    if (changes.length === 0) return '';
+    return changes.join(' / ');
+  }
+
+  private countChangedCellsFromHash(leftHashRaw?: string, rightHashRaw?: string): number {
+    const lh = this.parseCellHashMap(leftHashRaw ?? '');
+    const rh = this.parseCellHashMap(rightHashRaw ?? '');
+    const keys = new Set<string>([...lh.keys(), ...rh.keys()]);
+    let changed = 0;
+    for (const key of keys) {
+      if ((lh.get(key) ?? '') !== (rh.get(key) ?? '')) changed += 1;
+    }
+    return changed;
+  }
+
+  private formatLocation(item: DiffItem): string | null {
+    const sec = item.path.section;
+    if (sec < 0) return null;
+    const sectionPage =
+      item.severity === 'removed'
+        ? item.leftSectionPage
+        : (item.rightSectionPage ?? item.leftSectionPage);
+    if (sectionPage && sectionPage > 0) return `제 ${sec + 1}구역, ${sectionPage}쪽`;
+    const anchor = item.severity === 'removed' ? item.leftAnchor : (item.rightAnchor ?? item.leftAnchor);
+    if (!anchor) return `제 ${sec + 1}구역`;
+    return `제 ${sec + 1}구역, ${anchor.pageIndex + 1}쪽`;
+  }
+
+  private kindLabel(kind: DiffItem['kind']): string {
+    if (kind === 'table') return '표';
+    if (kind === 'shape') return '도형';
+    if (kind === 'image') return '이미지';
+    if (kind === 'chart') return '그래프';
+    if (kind === 'text') return '텍스트';
+    return '메타';
+  }
+}


### PR DESCRIPTION
## 변경 요약
- Base Skew 해결: `upstream/devel` 최신 커밋으로 fast-forward 동기화 후 분기하여, 이전 PR에서 우려되었던 본질 정정(revert) 충돌 문제를 해결했습니다.
- 분리 PR (1/3 - 프론트엔드 TS/UI 본질): 메인테이너님의 권장 가이드에 따라, 시각 판정 게이트가 필요한 Rust 렌더링 변경 및 파서 `stable_id` 연동 작업은 2, 3번 PR로 완전히 분리하고 본 PR에는 순수 프론트엔드 로직만 담았습니다.

[주요 구현 내용]
- 비교/이력 UI 및 엔진: `rhwp-studio`에 문서 비교 및 이력 관리 다이얼로그를 추가하고, `diff-engine` 기반의 정렬/비교 로직을 반영했습니다.
- 진입점 연결: 메뉴, 툴바, 단축키(`Alt+Shift+V` 문서 비교, `Ctrl+Shift+H` 이력) 및 `edit.ts` 커맨드 등록을 통해 UI 진입 경로를 연결했습니다.
- WasmBridge API 명세 추가: 프론트엔드 비교 로직에서 요구하는 보조 API(`hasLoadedDocument`, `refreshLayout`, `getParagraphStableId`, `getTableSignature` 등) 인터페이스를 정의하고 `PageInfo.pageNumber` 타입을 동기화했습니다.
- **보조 모듈 통합:** 업스트림 `devel`에 존재하지 않던 `compare/session`, `compare-debug`, `history`(IndexedDB 연동) 등의 모듈을 본 PR 범위에 포함했습니다.
## 관련 이슈

closes #571

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷

