### PR TITLE
feat(renderer): 페이지네이션 그림 높이 예약 + 조판 부유 전용 빈 문단 높이 정규화(PR2)

### DIFF
--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -546,6 +546,37 @@ impl Paginator {
         (hf_entries, page_number_pos, page_hides, new_page_numbers)
     }
 
+    /// 비-TAC 그림이 column `used_height`에 높이를 예약해야 하는지.
+    ///
+    /// [PR #571 분리 — 시각 게이트 대상] 한컴 정합을 위해 예약 규칙을 세분화한다.
+    /// - `Square`(어울림)·`InFront`·`Behind`: 본문 흐름 높이를 소비하지 않는다 (layout 어울림·부유와 동일 계열).
+    /// - `TopAndBottom` + `vert_rel_to == Paper`: 머리말 밴드(`header_area`) 안에서는 예약 생략.
+    fn should_reserve_picture_height(
+        &self,
+        common: &crate::model::shape::CommonObjAttr,
+        st: &PaginationState,
+    ) -> bool {
+        use crate::model::shape::{TextWrap, VertRelTo};
+        if common.treat_as_char {
+            return false;
+        }
+        match common.text_wrap {
+            TextWrap::InFrontOfText | TextWrap::BehindText => false,
+            TextWrap::Square => false,
+            TextWrap::TopAndBottom => {
+                if common.vert_rel_to == VertRelTo::Paper {
+                    let header_band = st.layout.header_area.height;
+                    let y = st.current_zone_y_offset + st.current_height;
+                    if y < header_band - 0.5 {
+                        return false;
+                    }
+                }
+                true
+            }
+            TextWrap::Tight | TextWrap::Through => false,
+        }
+    }
+
     /// 다단 나누기 처리
     fn process_multicolumn_break(
         &self,
@@ -1068,12 +1099,8 @@ impl Paginator {
                         para_index: para_idx,
                         control_index: ctrl_idx,
                     });
-                    // 비-TAC 그림: 본문 공간을 차지하는 배치이면 높이 추가 (Task #10)
-                    if !pic.common.treat_as_char
-                        && matches!(pic.common.text_wrap,
-                            crate::model::shape::TextWrap::Square
-                            | crate::model::shape::TextWrap::TopAndBottom)
-                    {
+                    // 비-TAC 그림: 자리차지·본문 밀림 등에만 used_height 예약 (`should_reserve_picture_height`).
+                    if self.should_reserve_picture_height(&pic.common, st) {
                         let pic_h = crate::renderer::hwpunit_to_px(pic.common.height as i32, self.dpi);
                         let margin_top = crate::renderer::hwpunit_to_px(pic.common.margin.top as i32, self.dpi);
                         let margin_bottom = crate::renderer::hwpunit_to_px(pic.common.margin.bottom as i32, self.dpi);

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -9,7 +9,7 @@
 //! MS Word/OOXML의 cantSplit/tblHeader를 참고.
 
 use crate::model::control::Control;
-use crate::model::shape::CaptionDirection;
+use crate::model::shape::{CaptionDirection, ShapeObject, TextWrap};
 use crate::model::header_footer::HeaderFooterApply;
 use crate::model::paragraph::{Paragraph, ColumnBreakType};
 use crate::model::page::{PageDef, ColumnDef};
@@ -597,6 +597,7 @@ impl TypesetEngine {
             if !has_table {
                 // --- 핵심: format → fits → place/split ---
                 let formatted = self.format_paragraph(para, composed.get(para_idx), styles);
+                let formatted = self.normalize_floating_only_paragraph_height(para, formatted);
                 self.typeset_paragraph(&mut st, para_idx, para, &formatted);
             } else {
                 // 표 문단: Phase 2에서 전환 예정. 현재는 기존 방식 호환용 stub.
@@ -848,6 +849,56 @@ impl TypesetEngine {
             spacing_after,
             height_for_fit,
         }
+    }
+
+    /// 텍스트가 비어 있고 비-TAC **부유**(글 앞/글 뒤) 그림만 있는 문단의 조판 높이를 0으로 맞춘다.
+    ///
+    /// [PR #571 분리 — 시각 게이트 대상] Square·표·TAC 개체가 섞이면 적용하지 않는다.
+    fn normalize_floating_only_paragraph_height(
+        &self,
+        para: &Paragraph,
+        mut fmt: FormattedParagraph,
+    ) -> FormattedParagraph {
+        let trimmed = para.text.replace(|c: char| c.is_control(), "");
+        if !trimmed.trim().is_empty() || para.controls.is_empty() {
+            return fmt;
+        }
+        let only_float_pictures = para.controls.iter().all(|c| match c {
+            Control::Picture(p) => {
+                !p.common.treat_as_char
+                    && matches!(
+                        p.common.text_wrap,
+                        TextWrap::InFrontOfText | TextWrap::BehindText,
+                    )
+            }
+            Control::Shape(s) => {
+                if s.common().treat_as_char {
+                    return false;
+                }
+                matches!(
+                    s.as_ref(),
+                    ShapeObject::Picture(p) if matches!(
+                        p.common.text_wrap,
+                        TextWrap::InFrontOfText | TextWrap::BehindText,
+                    ),
+                )
+            }
+            _ => false,
+        });
+        if !only_float_pictures {
+            return fmt;
+        }
+        fmt.total_height = 0.0;
+        fmt.height_for_fit = 0.0;
+        fmt.spacing_before = 0.0;
+        fmt.spacing_after = 0.0;
+        for h in &mut fmt.line_heights {
+            *h = 0.0;
+        }
+        for s in &mut fmt.line_spacings {
+            *s = 0.0;
+        }
+        fmt
     }
 
     // ========================================================


### PR DESCRIPTION
## 변경 요약
[반영 사항]
- 분리 PR (2/3 - Rust 렌더링 본질): 메인테이너님의 PR #571 리뷰 피드백("Rust 쪽으로만 분리")에 따라, 시각 판정 게이트가 필요한 `pagination` 및 `typeset` 변경 사항만을 독립된 PR로 분리하여 제출합니다.
- `rhwp-studio` 로직(1번 PR 제출 완료) 및 `stable_id`/WASM 통합(3번 PR 예정), 미추적 산출물(`.actual.svg`)은 본 PR에 포함되지 않았습니다.

[주요 구현 내용]
1. 페이지 나눔 (Pagination) - `src/renderer/pagination/engine.rs`
- 비-TAC `Picture`의 column `used_height` 예약 조건을 결정하는 `should_reserve_picture_height` 함수를 신설 및 세분화했습니다.
  - `Square` / `InFrontOfText` / `BehindText`: 본문 흐름 높이와 분리하여 예약하지 않음.
  - `TopAndBottom`: 세로 기준이 `Paper`이고 현재 누적 세로가 머리말 밴드 안일 경우 예약하지 않음. 그 외의 경우는 기존처럼 예약함.
  - `Tight` / `Through`: 예약하지 않음.

2. 조판 (Typeset) - `src/renderer/typeset.rs`
- `format_paragraph` 와 `typeset_paragraph` 사이에 `normalize_floating_only_paragraph_height` 단계를 추가했습니다.
- 텍스트가 비어있고, 포함된 컨트롤이 모두 비-TAC이면서 `InFrontOfText` / `BehindText` 속성의 그림만 있는 문단의 경우, 해당 `FormattedParagraph`의 총 높이(줄 높이, 줄간격, spacing 등)를 **0으로 강제 맞춤** 처리합니다. (표, Square, TAC 등 다른 개체가 하나라도 섞여 있으면 변경하지 않음)


## 관련 이슈

closes #571 

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷
