### PR TITLE
render: replay equations in native Skia PNG output

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,8 +217,10 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - P4 adds native-only `DocumentCore::render_page_png_native(page)` behind `--features native-skia`; it renders `PageLayerTree` to encoded PNG through `SkiaLayerRenderer`.
+- P5 adds native Skia equation replay from `EquationNode.layout_box`, so equations are no longer placeholder boxes in the PNG path.
+- P5 replays the existing equation layout tree directly; it does not add SVG fragment rasterization, CanvasKit equation replay, or native raw-svg/form replay.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
-- The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image/equation replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README_EN.md
+++ b/README_EN.md
@@ -209,8 +209,10 @@ See the [roadmap document](mydocs/eng/report/rhwp-milestone.md) for details.
 - P3 visual regression coverage runs `npm run e2e:render-diff:ci` in `rhwp-studio` to compare legacy Canvas and layer Canvas in Chromium; CI uploads render-diff artifacts and writes a summary.
 - The default render-diff fixtures cover basic text/table output, business-document layout, and treat-as-char object placement; override with `RHWP_RENDER_DIFF_FILES`, `RHWP_RENDER_DIFF_MAX_PAGES`, or `RHWP_RENDER_DIFF_ALL=1`.
 - P4 adds native-only `DocumentCore::render_page_png_native(page)` behind `--features native-skia`; it renders `PageLayerTree` to encoded PNG through `SkiaLayerRenderer`.
+- P5 adds native Skia equation replay from `EquationNode.layout_box`, so equations are no longer placeholder boxes in the PNG path.
+- P5 replays the existing equation layout tree directly; it does not add SVG fragment rasterization, CanvasKit equation replay, or native raw-svg/form replay.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
-- The initial native Skia path is a PNG raster backend with core image replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native equation/raw-svg/form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image/equation replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native raw-svg/form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/src/renderer/skia/equation_conv.rs
+++ b/src/renderer/skia/equation_conv.rs
@@ -1,0 +1,713 @@
+use skia_safe::{font, paint, Canvas, Color, Font, FontMgr, FontStyle, Paint, PathBuilder};
+
+use crate::renderer::equation::ast::MatrixStyle;
+use crate::renderer::equation::layout::{
+    is_integral_symbol, LayoutBox, LayoutKind, AXIS_HEIGHT, BIG_OP_SCALE, SCRIPT_SCALE,
+};
+use crate::renderer::equation::symbols::{DecoKind, FontStyleKind};
+
+const EQ_FONT_FAMILY: &str =
+    "Latin Modern Math, STIX Two Math, Cambria Math, DejaVu Sans, Times New Roman, serif";
+
+pub fn render_equation(
+    canvas: &Canvas,
+    font_mgr: &FontMgr,
+    layout: &LayoutBox,
+    origin_x: f64,
+    origin_y: f64,
+    color: u32,
+    base_font_size: f64,
+) {
+    render_box(
+        canvas,
+        font_mgr,
+        layout,
+        origin_x,
+        origin_y,
+        colorref_to_skia(color, 1.0),
+        base_font_size,
+        false,
+        false,
+    );
+}
+
+fn render_box(
+    canvas: &Canvas,
+    font_mgr: &FontMgr,
+    lb: &LayoutBox,
+    parent_x: f64,
+    parent_y: f64,
+    color: Color,
+    fs: f64,
+    italic: bool,
+    bold: bool,
+) {
+    let x = parent_x + lb.x;
+    let y = parent_y + lb.y;
+
+    match &lb.kind {
+        LayoutKind::Row(children) => {
+            for child in children {
+                render_box(canvas, font_mgr, child, x, y, color, fs, italic, bold);
+            }
+        }
+        LayoutKind::Text(text) => {
+            draw_text(
+                canvas,
+                font_mgr,
+                text,
+                x,
+                y + lb.baseline,
+                font_size_from_box(lb, fs),
+                true,
+                bold,
+                color,
+                false,
+            );
+        }
+        LayoutKind::Number(text) => {
+            draw_text(
+                canvas,
+                font_mgr,
+                text,
+                x,
+                y + lb.baseline,
+                font_size_from_box(lb, fs),
+                false,
+                bold,
+                color,
+                false,
+            );
+        }
+        LayoutKind::Symbol(text) => {
+            draw_text(
+                canvas,
+                font_mgr,
+                text,
+                x + lb.width / 2.0,
+                y + lb.baseline,
+                font_size_from_box(lb, fs),
+                false,
+                false,
+                color,
+                true,
+            );
+        }
+        LayoutKind::MathSymbol(text) => {
+            let font_size = if is_integral_symbol(text) {
+                lb.height
+            } else {
+                font_size_from_box(lb, fs)
+            };
+            draw_text(
+                canvas,
+                font_mgr,
+                text,
+                x,
+                y + lb.baseline,
+                font_size,
+                false,
+                false,
+                color,
+                false,
+            );
+        }
+        LayoutKind::Function(name) => {
+            draw_text(
+                canvas,
+                font_mgr,
+                name,
+                x,
+                y + lb.baseline,
+                font_size_from_box(lb, fs),
+                false,
+                false,
+                color,
+                false,
+            );
+        }
+        LayoutKind::Fraction { numer, denom } => {
+            render_box(canvas, font_mgr, numer, x, y, color, fs, italic, bold);
+            let line_y = y + lb.baseline - fs * AXIS_HEIGHT;
+            canvas.draw_line(
+                ((x + fs * 0.05) as f32, line_y as f32),
+                ((x + lb.width - fs * 0.05) as f32, line_y as f32),
+                &stroke_paint(color, fs * 0.04),
+            );
+            render_box(canvas, font_mgr, denom, x, y, color, fs, italic, bold);
+        }
+        LayoutKind::Sqrt { index, body } => {
+            let sign_h = lb.height;
+            let body_left = x + body.x - fs * 0.1;
+            let sign_x = x;
+            let v_top = y;
+            let v_mid_x = body_left - fs * 0.15;
+            let v_mid_y = y + sign_h;
+            let v_start_x = v_mid_x - fs * 0.3;
+            let v_start_y = y + sign_h * 0.6;
+            let tick_x = v_start_x - fs * 0.1;
+            let tick_y = v_start_y - fs * 0.05;
+
+            let mut path = PathBuilder::new();
+            path.move_to((tick_x as f32, tick_y as f32));
+            path.line_to((v_start_x as f32, v_start_y as f32));
+            path.line_to((v_mid_x as f32, v_mid_y as f32));
+            path.line_to((body_left as f32, v_top as f32));
+            path.line_to(((x + lb.width) as f32, v_top as f32));
+            canvas.draw_path(&path.detach(), &stroke_paint(color, fs * 0.04));
+
+            if let Some(index) = index {
+                render_box(
+                    canvas,
+                    font_mgr,
+                    index,
+                    sign_x,
+                    y,
+                    color,
+                    fs * SCRIPT_SCALE,
+                    false,
+                    false,
+                );
+            }
+            render_box(canvas, font_mgr, body, x, y, color, fs, italic, bold);
+        }
+        LayoutKind::Superscript { base, sup } => {
+            render_box(canvas, font_mgr, base, x, y, color, fs, italic, bold);
+            render_box(
+                canvas,
+                font_mgr,
+                sup,
+                x,
+                y,
+                color,
+                fs * SCRIPT_SCALE,
+                italic,
+                bold,
+            );
+        }
+        LayoutKind::Subscript { base, sub } => {
+            render_box(canvas, font_mgr, base, x, y, color, fs, italic, bold);
+            render_box(
+                canvas,
+                font_mgr,
+                sub,
+                x,
+                y,
+                color,
+                fs * SCRIPT_SCALE,
+                italic,
+                bold,
+            );
+        }
+        LayoutKind::SubSup { base, sub, sup } => {
+            render_box(canvas, font_mgr, base, x, y, color, fs, italic, bold);
+            render_box(
+                canvas,
+                font_mgr,
+                sub,
+                x,
+                y,
+                color,
+                fs * SCRIPT_SCALE,
+                italic,
+                bold,
+            );
+            render_box(
+                canvas,
+                font_mgr,
+                sup,
+                x,
+                y,
+                color,
+                fs * SCRIPT_SCALE,
+                italic,
+                bold,
+            );
+        }
+        LayoutKind::BigOp { symbol, sub, sup } => {
+            let op_fs = fs * BIG_OP_SCALE;
+            let (op_x, op_y) = if is_integral_symbol(symbol) {
+                (x, y + op_fs * 0.8)
+            } else {
+                let sup_h = sup.as_ref().map(|b| b.height + fs * 0.05).unwrap_or(0.0);
+                (
+                    x + (lb.width - estimate_op_width(symbol, op_fs)) / 2.0,
+                    y + sup_h + op_fs * 0.8,
+                )
+            };
+            draw_text(
+                canvas, font_mgr, symbol, op_x, op_y, op_fs, false, false, color, false,
+            );
+            if let Some(sup) = sup {
+                render_box(
+                    canvas,
+                    font_mgr,
+                    sup,
+                    x,
+                    y,
+                    color,
+                    fs * SCRIPT_SCALE,
+                    false,
+                    false,
+                );
+            }
+            if let Some(sub) = sub {
+                render_box(
+                    canvas,
+                    font_mgr,
+                    sub,
+                    x,
+                    y,
+                    color,
+                    fs * SCRIPT_SCALE,
+                    false,
+                    false,
+                );
+            }
+        }
+        LayoutKind::Limit { is_upper, sub } => {
+            let name = if *is_upper { "Lim" } else { "lim" };
+            draw_text(
+                canvas,
+                font_mgr,
+                name,
+                x,
+                y + fs * 0.8,
+                fs,
+                false,
+                false,
+                color,
+                false,
+            );
+            if let Some(sub) = sub {
+                render_box(
+                    canvas,
+                    font_mgr,
+                    sub,
+                    x,
+                    y,
+                    color,
+                    fs * SCRIPT_SCALE,
+                    false,
+                    false,
+                );
+            }
+        }
+        LayoutKind::Matrix { cells, style } => {
+            let bracket_chars = match style {
+                MatrixStyle::Paren => ("(", ")"),
+                MatrixStyle::Bracket => ("[", "]"),
+                MatrixStyle::Vert => ("|", "|"),
+                MatrixStyle::Plain => ("", ""),
+            };
+            if !bracket_chars.0.is_empty() {
+                draw_stretch_bracket(
+                    canvas,
+                    font_mgr,
+                    bracket_chars.0,
+                    x,
+                    y,
+                    fs * 0.3,
+                    lb.height,
+                    color,
+                    fs,
+                );
+                draw_stretch_bracket(
+                    canvas,
+                    font_mgr,
+                    bracket_chars.1,
+                    x + lb.width - fs * 0.3,
+                    y,
+                    fs * 0.3,
+                    lb.height,
+                    color,
+                    fs,
+                );
+            }
+            for row in cells {
+                for cell in row {
+                    render_box(canvas, font_mgr, cell, x, y, color, fs, italic, bold);
+                }
+            }
+        }
+        LayoutKind::Rel { arrow, over, under } => {
+            render_box(canvas, font_mgr, over, x, y, color, fs, italic, bold);
+            render_box(canvas, font_mgr, arrow, x, y, color, fs, italic, bold);
+            if let Some(under) = under {
+                render_box(canvas, font_mgr, under, x, y, color, fs, italic, bold);
+            }
+        }
+        LayoutKind::EqAlign { rows } => {
+            for (left, right) in rows {
+                render_box(canvas, font_mgr, left, x, y, color, fs, italic, bold);
+                render_box(canvas, font_mgr, right, x, y, color, fs, italic, bold);
+            }
+        }
+        LayoutKind::Paren { left, right, body } => {
+            let paren_w = fs * 0.333;
+            let use_glyph = lb.height <= fs * 1.2;
+            if !left.is_empty() {
+                if use_glyph && (left == "(" || left == ")") {
+                    draw_text(
+                        canvas,
+                        font_mgr,
+                        left,
+                        x,
+                        y + lb.baseline,
+                        fs,
+                        false,
+                        false,
+                        color,
+                        false,
+                    );
+                } else {
+                    draw_stretch_bracket(
+                        canvas, font_mgr, left, x, y, paren_w, lb.height, color, fs,
+                    );
+                }
+            }
+            render_box(canvas, font_mgr, body, x, y, color, fs, italic, bold);
+            if !right.is_empty() {
+                let right_x = x + lb.width - paren_w;
+                if use_glyph && (right == "(" || right == ")") {
+                    draw_text(
+                        canvas,
+                        font_mgr,
+                        right,
+                        right_x,
+                        y + lb.baseline,
+                        fs,
+                        false,
+                        false,
+                        color,
+                        false,
+                    );
+                } else {
+                    draw_stretch_bracket(
+                        canvas, font_mgr, right, right_x, y, paren_w, lb.height, color, fs,
+                    );
+                }
+            }
+        }
+        LayoutKind::Decoration { kind, body } => {
+            render_box(canvas, font_mgr, body, x, y, color, fs, italic, bold);
+            let deco_y = y + fs * 0.05;
+            let mid_x = x + body.x + body.width / 2.0;
+            draw_decoration(canvas, *kind, mid_x, deco_y, body.width, color, fs);
+        }
+        LayoutKind::FontStyle { style, body } => {
+            let (new_italic, new_bold) = match style {
+                FontStyleKind::Roman => (false, false),
+                FontStyleKind::Italic => (true, bold),
+                FontStyleKind::Bold => (italic, true),
+            };
+            render_box(
+                canvas, font_mgr, body, x, y, color, fs, new_italic, new_bold,
+            );
+        }
+        LayoutKind::Space(_) | LayoutKind::Newline | LayoutKind::Empty => {}
+    }
+}
+
+fn draw_text(
+    canvas: &Canvas,
+    font_mgr: &FontMgr,
+    text: &str,
+    x: f64,
+    baseline_y: f64,
+    font_size: f64,
+    italic: bool,
+    bold: bool,
+    color: Color,
+    centered: bool,
+) {
+    if text.is_empty() {
+        return;
+    }
+    let font_style = match (bold, italic) {
+        (true, true) => FontStyle::bold_italic(),
+        (true, false) => FontStyle::bold(),
+        (false, true) => FontStyle::italic(),
+        (false, false) => FontStyle::normal(),
+    };
+    let typeface = EQ_FONT_FAMILY
+        .split(',')
+        .map(str::trim)
+        .filter(|family| !family.is_empty())
+        .find_map(|family| font_mgr.match_family_style(family, font_style))
+        .or_else(|| font_mgr.legacy_make_typeface(None::<&str>, font_style));
+    let mut font = if let Some(typeface) = typeface {
+        Font::new(typeface, font_size as f32)
+    } else {
+        let mut font = Font::default();
+        font.set_size(font_size as f32);
+        font
+    };
+    font.set_edging(font::Edging::AntiAlias);
+
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_style(paint::Style::Fill);
+    paint.set_color(color);
+
+    let draw_x = if centered {
+        let (width, _) = font.measure_str(text, Some(&paint));
+        x - f64::from(width) / 2.0
+    } else {
+        x
+    };
+    canvas.draw_str(text, (draw_x as f32, baseline_y as f32), &font, &paint);
+}
+
+fn draw_stretch_bracket(
+    canvas: &Canvas,
+    font_mgr: &FontMgr,
+    bracket: &str,
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+    color: Color,
+    fs: f64,
+) {
+    let mid_x = x + w / 2.0;
+    let paint = stroke_paint(color, fs * 0.04);
+
+    match bracket {
+        "(" => {
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x + w * 0.2) as f32, y as f32));
+            path.quad_to(
+                (x as f32, (y + h / 2.0) as f32),
+                ((mid_x + w * 0.2) as f32, (y + h) as f32),
+            );
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        ")" => {
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x - w * 0.2) as f32, y as f32));
+            path.quad_to(
+                ((x + w) as f32, (y + h / 2.0) as f32),
+                ((mid_x - w * 0.2) as f32, (y + h) as f32),
+            );
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        "[" => {
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x + w * 0.2) as f32, y as f32));
+            path.line_to(((mid_x - w * 0.2) as f32, y as f32));
+            path.line_to(((mid_x - w * 0.2) as f32, (y + h) as f32));
+            path.line_to(((mid_x + w * 0.2) as f32, (y + h) as f32));
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        "]" => {
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x - w * 0.2) as f32, y as f32));
+            path.line_to(((mid_x + w * 0.2) as f32, y as f32));
+            path.line_to(((mid_x + w * 0.2) as f32, (y + h) as f32));
+            path.line_to(((mid_x - w * 0.2) as f32, (y + h) as f32));
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        "{" => {
+            let qh = h / 4.0;
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x + w * 0.2) as f32, y as f32));
+            path.quad_to(
+                ((mid_x - w * 0.1) as f32, y as f32),
+                ((mid_x - w * 0.1) as f32, (y + qh) as f32),
+            );
+            path.quad_to(
+                ((mid_x - w * 0.1) as f32, (y + qh * 2.0) as f32),
+                ((mid_x - w * 0.3) as f32, (y + qh * 2.0) as f32),
+            );
+            path.quad_to(
+                ((mid_x - w * 0.1) as f32, (y + qh * 2.0) as f32),
+                ((mid_x - w * 0.1) as f32, (y + qh * 3.0) as f32),
+            );
+            path.quad_to(
+                ((mid_x - w * 0.1) as f32, (y + h) as f32),
+                ((mid_x + w * 0.2) as f32, (y + h) as f32),
+            );
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        "}" => {
+            let qh = h / 4.0;
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x - w * 0.2) as f32, y as f32));
+            path.quad_to(
+                ((mid_x + w * 0.1) as f32, y as f32),
+                ((mid_x + w * 0.1) as f32, (y + qh) as f32),
+            );
+            path.quad_to(
+                ((mid_x + w * 0.1) as f32, (y + qh * 2.0) as f32),
+                ((mid_x + w * 0.3) as f32, (y + qh * 2.0) as f32),
+            );
+            path.quad_to(
+                ((mid_x + w * 0.1) as f32, (y + qh * 2.0) as f32),
+                ((mid_x + w * 0.1) as f32, (y + qh * 3.0) as f32),
+            );
+            path.quad_to(
+                ((mid_x + w * 0.1) as f32, (y + h) as f32),
+                ((mid_x - w * 0.2) as f32, (y + h) as f32),
+            );
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        "|" => {
+            canvas.draw_line(
+                (mid_x as f32, y as f32),
+                (mid_x as f32, (y + h) as f32),
+                &paint,
+            );
+        }
+        _ => {
+            draw_text(
+                canvas,
+                font_mgr,
+                bracket,
+                mid_x,
+                y + h * 0.7,
+                h,
+                false,
+                false,
+                color,
+                true,
+            );
+        }
+    }
+}
+
+fn draw_decoration(
+    canvas: &Canvas,
+    kind: DecoKind,
+    mid_x: f64,
+    y: f64,
+    width: f64,
+    color: Color,
+    fs: f64,
+) {
+    let half_w = width / 2.0;
+    let paint = stroke_paint(color, fs * 0.03);
+
+    match kind {
+        DecoKind::Hat => {
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x - half_w * 0.6) as f32, (y + fs * 0.15) as f32));
+            path.line_to((mid_x as f32, y as f32));
+            path.line_to(((mid_x + half_w * 0.6) as f32, (y + fs * 0.15) as f32));
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        DecoKind::Bar | DecoKind::Overline => {
+            canvas.draw_line(
+                ((mid_x - half_w) as f32, (y + fs * 0.05) as f32),
+                ((mid_x + half_w) as f32, (y + fs * 0.05) as f32),
+                &paint,
+            );
+        }
+        DecoKind::Vec => {
+            let arrow_y = y + fs * 0.05;
+            canvas.draw_line(
+                ((mid_x - half_w) as f32, arrow_y as f32),
+                ((mid_x + half_w) as f32, arrow_y as f32),
+                &paint,
+            );
+            let mut head = PathBuilder::new();
+            head.move_to((
+                (mid_x + half_w - fs * 0.1) as f32,
+                (arrow_y - fs * 0.06) as f32,
+            ));
+            head.line_to(((mid_x + half_w) as f32, arrow_y as f32));
+            head.line_to((
+                (mid_x + half_w - fs * 0.1) as f32,
+                (arrow_y + fs * 0.06) as f32,
+            ));
+            canvas.draw_path(&head.detach(), &paint);
+        }
+        DecoKind::Tilde => {
+            let ty = y + fs * 0.08;
+            let mut path = PathBuilder::new();
+            path.move_to(((mid_x - half_w * 0.6) as f32, ty as f32));
+            path.quad_to(
+                ((mid_x - half_w * 0.2) as f32, (ty - fs * 0.08) as f32),
+                (mid_x as f32, ty as f32),
+            );
+            path.quad_to(
+                ((mid_x + half_w * 0.2) as f32, (ty + fs * 0.08) as f32),
+                ((mid_x + half_w * 0.6) as f32, ty as f32),
+            );
+            canvas.draw_path(&path.detach(), &paint);
+        }
+        DecoKind::Dot => {
+            canvas.draw_circle(
+                (mid_x as f32, (y + fs * 0.06) as f32),
+                (fs * 0.03) as f32,
+                &fill_paint(color),
+            );
+        }
+        DecoKind::DDot => {
+            let gap = fs * 0.1;
+            let fill = fill_paint(color);
+            canvas.draw_circle(
+                ((mid_x - gap) as f32, (y + fs * 0.06) as f32),
+                (fs * 0.03) as f32,
+                &fill,
+            );
+            canvas.draw_circle(
+                ((mid_x + gap) as f32, (y + fs * 0.06) as f32),
+                (fs * 0.03) as f32,
+                &fill,
+            );
+        }
+        DecoKind::Underline | DecoKind::Under => {
+            let underline_y = y + fs * 1.1;
+            canvas.draw_line(
+                ((mid_x - half_w) as f32, underline_y as f32),
+                ((mid_x + half_w) as f32, underline_y as f32),
+                &paint,
+            );
+        }
+        _ => {
+            canvas.draw_line(
+                ((mid_x - half_w * 0.5) as f32, (y + fs * 0.1) as f32),
+                ((mid_x + half_w * 0.5) as f32, (y + fs * 0.1) as f32),
+                &paint,
+            );
+        }
+    }
+}
+
+fn font_size_from_box(lb: &LayoutBox, base_fs: f64) -> f64 {
+    if lb.height > 0.0 {
+        lb.height
+    } else {
+        base_fs
+    }
+}
+
+fn estimate_op_width(text: &str, fs: f64) -> f64 {
+    text.chars().count() as f64 * fs * 0.6
+}
+
+fn fill_paint(color: Color) -> Paint {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_style(paint::Style::Fill);
+    paint.set_color(color);
+    paint
+}
+
+fn stroke_paint(color: Color, width: f64) -> Paint {
+    let mut paint = Paint::default();
+    paint.set_anti_alias(true);
+    paint.set_style(paint::Style::Stroke);
+    paint.set_stroke_width(width.max(0.5) as f32);
+    paint.set_color(color);
+    paint
+}
+
+fn colorref_to_skia(color: u32, alpha_scale: f32) -> Color {
+    let b = ((color >> 16) & 0xFF) as u8;
+    let g = ((color >> 8) & 0xFF) as u8;
+    let r = (color & 0xFF) as u8;
+    let a = (255.0 * alpha_scale.clamp(0.0, 1.0)).round() as u8;
+    Color::from_argb(a, r, g, b)
+}

--- a/src/renderer/skia/equation_conv.rs
+++ b/src/renderer/skia/equation_conv.rs
@@ -136,6 +136,10 @@ fn render_box(
             );
             render_box(canvas, font_mgr, denom, x, y, color, fs, italic, bold);
         }
+        LayoutKind::Atop { top, bottom } => {
+            render_box(canvas, font_mgr, top, x, y, color, fs, italic, bold);
+            render_box(canvas, font_mgr, bottom, x, y, color, fs, italic, bold);
+        }
         LayoutKind::Sqrt { index, body } => {
             let sign_h = lb.height;
             let body_left = x + body.x - fs * 0.1;

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! This module is available only with the `native-skia` feature.
 
+mod equation_conv;
 mod image_conv;
 mod renderer;
 

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -14,6 +14,7 @@ use crate::renderer::layer_renderer::{
 };
 use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
 
+use super::equation_conv::render_equation;
 use super::image_conv::{draw_image_bytes, ImageSampling};
 
 pub struct SkiaLayerRenderer {
@@ -721,7 +722,38 @@ impl SkiaLayerRenderer {
                                 canvas.restore();
                             }
                         }
-                        PaintOp::Equation { bbox, .. } => draw_placeholder(*bbox, "equation"),
+                        PaintOp::Equation { bbox, equation } => {
+                            canvas.save();
+                            let scale_x = if equation.layout_box.width > 0.0 && bbox.width > 0.0 {
+                                bbox.width / equation.layout_box.width
+                            } else {
+                                1.0
+                            };
+                            if (scale_x - 1.0).abs() > 0.01 {
+                                canvas.translate((bbox.x as f32, bbox.y as f32));
+                                canvas.scale((scale_x as f32, 1.0));
+                                render_equation(
+                                    canvas,
+                                    &self.font_mgr,
+                                    &equation.layout_box,
+                                    0.0,
+                                    0.0,
+                                    equation.color,
+                                    equation.font_size,
+                                );
+                            } else {
+                                render_equation(
+                                    canvas,
+                                    &self.font_mgr,
+                                    &equation.layout_box,
+                                    bbox.x,
+                                    bbox.y,
+                                    equation.color,
+                                    equation.font_size,
+                                );
+                            }
+                            canvas.restore();
+                        }
                         PaintOp::FormObject { bbox, form } => {
                             draw_placeholder(*bbox, form.caption.as_str());
                         }
@@ -760,9 +792,12 @@ mod tests {
     use crate::model::control::FormType;
     use crate::model::style::ImageFillMode;
     use crate::paint::{CacheHint, GroupKind, LayerNode, LayerOutputOptions};
+    use crate::renderer::equation::ast::EqNode;
+    use crate::renderer::equation::layout::EqLayout;
     use crate::renderer::render_tree::{
-        BoundingBox, FootnoteMarkerNode, FormObjectNode, ImageNode, PageBackgroundImage,
-        PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode, TextRunNode,
+        BoundingBox, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
+        PageBackgroundImage, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode,
+        RectangleNode, TextRunNode,
     };
     use crate::renderer::{GradientFillInfo, PatternFillInfo, TextStyle};
     use image::{ImageFormat, Rgba, RgbaImage};
@@ -1498,6 +1533,52 @@ mod tests {
         let image = decode_rgba(&output.bytes);
 
         assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_equation_layout_as_colored_ink() {
+        let font_size = 18.0;
+        let layout_box = EqLayout::new(font_size).layout(&EqNode::Fraction {
+            numer: Box::new(EqNode::Text("a".to_string())),
+            denom: Box::new(EqNode::Text("b".to_string())),
+        });
+        let equation = EquationNode {
+            svg_content: String::new(),
+            layout_box,
+            color_str: "#ff0000".to_string(),
+            color: 0x000000ff,
+            font_size,
+            section_index: Some(0),
+            para_index: Some(0),
+            control_index: Some(0),
+            cell_index: None,
+            cell_para_index: None,
+        };
+        let tree = PageLayerTree::new(
+            64.0,
+            48.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 64.0, 48.0),
+                None,
+                vec![PaintOp::Equation {
+                    bbox: BoundingBox::new(6.0, 6.0, 44.0, 32.0),
+                    equation,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render equation");
+        let image = decode_rgba(&output.bytes);
+        let red_ink = image
+            .pixels()
+            .filter(|pixel| pixel[0] > 160 && pixel[1] < 96 && pixel[2] < 96 && pixel[3] > 0)
+            .count();
+
+        assert!(
+            red_ink > 0,
+            "equation should render using its configured color"
+        );
     }
 
     #[test]

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1582,6 +1582,52 @@ mod tests {
     }
 
     #[test]
+    fn renders_atop_equation_layout_as_colored_ink() {
+        let font_size = 18.0;
+        let layout_box = EqLayout::new(font_size).layout(&EqNode::Atop {
+            top: Box::new(EqNode::Text("a".to_string())),
+            bottom: Box::new(EqNode::Text("b".to_string())),
+        });
+        let equation = EquationNode {
+            svg_content: String::new(),
+            layout_box,
+            color_str: "#00aa00".to_string(),
+            color: 0x0000aa00,
+            font_size,
+            section_index: Some(0),
+            para_index: Some(0),
+            control_index: Some(0),
+            cell_index: None,
+            cell_para_index: None,
+        };
+        let tree = PageLayerTree::new(
+            64.0,
+            48.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 64.0, 48.0),
+                None,
+                vec![PaintOp::Equation {
+                    bbox: BoundingBox::new(6.0, 6.0, 44.0, 32.0),
+                    equation,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render atop equation");
+        let image = decode_rgba(&output.bytes);
+        let green_ink = image
+            .pixels()
+            .filter(|pixel| pixel[0] < 96 && pixel[1] > 96 && pixel[2] < 96 && pixel[3] > 0)
+            .count();
+
+        assert!(
+            green_ink > 0,
+            "atop equation should render using its configured color"
+        );
+    }
+
+    #[test]
     fn renders_placeholder_style_ops_as_ink() {
         let form = FormObjectNode {
             form_type: FormType::PushButton,


### PR DESCRIPTION
## 변경 요약

이번 PR은 P4에서 들어간 native Skia PNG 렌더링 경로에 수식 replay를 추가합니다.

P4까지는 `PaintOp::Equation`이 native Skia 경로에서 placeholder 박스로만 그려졌는데, 이 PR에서는 기존 equation layout tree(`EquationNode.layout_box`)를 Skia canvas에 직접 replay하도록 바꿉니다. 그래서 `render_page_png_native`나 `export-png`처럼 native Skia PNG 경로를 타는 출력에서 수식이 빈 박스처럼 빠지지 않습니다.

구현 범위는 일부러 좁게 잡았습니다.

- `src/renderer/skia/equation_conv.rs`를 추가해서 equation layout node를 Skia draw call로 변환합니다.
- fraction, atop, sqrt, superscript/subscript, matrix, limit, bracket/paren, decoration, font style 등 현재 equation layout tree가 표현하는 주요 노드를 replay합니다.
- `PaintOp::Equation` 처리에서 `EquationNode.layout_box`를 사용하고, bbox 폭 차이가 있을 때는 x축 scale로 맞춥니다.
- 수식 색상과 기본 font size를 native Skia 출력에 반영합니다.
- README에는 P5가 “native Skia equation replay” 단계라는 점과 아직 raw-svg/form/native CanvasKit replay는 후속이라는 점을 명시했습니다.

#599에서 `export-png`와 VLM/Vision 쪽 사용 흐름이 들어왔기 때문에, 이 PR은 그 PNG 출력 품질을 바로 보강하는 성격입니다. 다만 #613 같은 VLM preset 확장이나 #614 DPI metadata는 이 PR 범위에 넣지 않습니다.

## 관련 이슈

- Follow-up to #599
- VLM/Vision preset 확장과 PNG DPI metadata는 별도 후속 이슈로 둡니다: #613, #614

## 테스트

- [x] `cargo test --features native-skia skia --lib` 통과
- [x] `cargo clippy --features native-skia --lib -- -D warnings` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] `cargo check --target wasm32-unknown-unknown --lib` 통과
- [x] `cargo test` 통과

## 스크린샷

없음.

이 PR은 native Skia raster backend 내부 replay 보강이고, 테스트는 수식이 placeholder가 아니라 실제 colored ink로 렌더링되는지 확인하는 방식으로 추가했습니다.