### PR TITLE
fix: Task #520 partial revert restore — exam_science p2 7번 글상자 ㉠ 사각형 y 회귀 정정 (closes #624)

### DIFF
--- a/mydocs/orders/20260506.md
+++ b/mydocs/orders/20260506.md
@@ -1,0 +1,30 @@
+# 오늘 할일 - 2026년 5월 6일
+
+## M100 — v1.0.0 조판 엔진
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **#618** | exam_eng.hwp p4 28번 박스 종이-말림 그림 누락 — Picture flip/rotation 회귀 정정 | **완료 (정정 + push)** | Task #519 정정이 stream/devel 으로 승격 안 된 회귀. 6 ImageNode 생성 지점에 `transform: extract_shape_transform(&pic.shape_attr)` 재적용. 검증: cargo test --lib 1134 passed / svg_snapshot 6/6 / clippy clean / exam_eng p4 transform 래퍼 0→1. commit `7ac8777`. |
+| **#624** | exam_science p2 7번 글상자 ㉠ 사각형 y-위치 회귀 — Task #520 부분 회귀 정정 | **완료 (정정 + 광범위 sweep + 보고서)** | PR #561 cherry-pick (`3de0505`) 시 Task #520 의 일부 정정 누락 — 3 라인 회귀. **본질**: (1) Picture 분기 `tac_img_y` 산식 `seg.vpos` → `seg.vpos - first_vpos` 복원 (이중 합산 회귀 해소), (2) Shape 분기 `shape_area.y` `para_y_before_compose` → `tac_img_y` 복원 (target_line 기반 위치), (3) Shape 분기 `layout_cell_shape` para_y 인자 동일. **증상 해소**: exam_science p2 7번 글상자 ㉠ 사각형이 Line 1 (y=213.95, 본문 "분자당 구성" 위 겹침) → Line 2 (y=235.41, " 이다." 앞) 으로 정확히 이동 (Δ +21.47 px = ls[1].vpos - ls[0].vpos / 75). **TDD 4 stage**: Stage 0 (수행/구현 계획서) → Stage 1 (RED 통합 테스트 `test_624_textbox_inline_shape_y_on_line2_p2_q7`) → Stage 2 분석 (코드 정정 보류 분석) → Stage 2 정정 (3 line) → Stage 3 (광범위 sweep + 최종 보고서). **검증**: cargo test --lib **1135 passed** (회귀 0) / svg_snapshot 6/6 / clippy clean / build --release. **광범위 fixture sweep**: `samples/` 전체 **158 fixture / 1,496 페이지 / 페이지 변경 1 (의도된 정정만)** — exam_science_002.svg 만 변경 (㉠ 사각형 + ㉠ 텍스트 y +21.47 px). 다른 157 fixture 1,495 페이지 byte-identical (회귀 0). **Edge case 분석**: `first_vpos = 0` (cell 첫 paragraph) / `target_line = 0` (rect on ls[0]) / single-line paragraph / wrap 모드 모두 정정 후 동일 동작 보장. **회귀 출처 분석**: `git diff 9dc40dd 3de0505` 으로 cherry-pick 시 누락 3건 정확히 식별 — 원저자 (@planet6897) 의 9dc40dd 는 Task #520 fix 유지, PR #561 cherry-pick 메인테이너 정리 단계에서 conflict resolution 누락 추정. **후속 권고**: PR cherry-pick 시 base diff 자동 점검 + 본 task 의 회귀 테스트 가드. **브랜치**: `local/task624` (4 commits, base = `pr-task618`). 처리 보고서: `mydocs/report/task_m100_624_report.md`. 수행계획서: `mydocs/plans/task_m100_624.md`. 구현계획서: `mydocs/plans/task_m100_624_impl.md`. |
+
+## 작업 메모
+
+### Task #624 본질
+
+- **회귀 발생 4 조건 동시 성립 시 가시화**: cell 안 paragraph + multi-line (`line_segs.len() ≥ 2`) + `target_line > 0` (rect on ls[1]+) + `first_vpos > 0` (paragraph[i>0]).
+- exam_science p[1] 만 유일한 가시 회귀 사례 (multi-line + tac rect 보유 다른 5 case 는 모두 paragraph[0] 즉 `first_vpos=0` 으로 산식 차이 무영향).
+- Picture 분기 산식 회귀: 검토 가능 sample pool 에서 가시 회귀 0 건. Defensive consistency 차원 함께 복원.
+
+### 광범위 sweep 데이터 (158 fixture / 1,496 페이지)
+
+| 카테고리 | 변경 페이지 |
+|---|---|
+| 의도된 정정 | 1 (exam_science p2 ㉠ 사각형 +21.47 px) |
+| 회귀 | **0** |
+| byte-identical | 1,495 |
+
+### 회귀 출처 cherry-pick 함정 패턴
+
+- `9dc40dd` 원저자 commit: Task #520 fix + Task #548 추가 (양호).
+- `3de0505` 메인테이너 cherry-pick: Task #548 만 추출하면서 Task #520 의 일부 (3 라인) 누락.
+- 회귀 방지 후속: cherry-pick 전후 동일 함수 영역 산식 비교 자동 점검 도입 권고.

--- a/mydocs/plans/task_m100_624.md
+++ b/mydocs/plans/task_m100_624.md
@@ -1,0 +1,152 @@
+# Task #624 수행 계획서
+
+**제목**: exam_science p2 7번 글상자 ㉠ 사각형 y-위치 회귀 정정 — Task #520 부분 회귀 복원
+**마일스톤**: M100 (v1.0.0)
+**브랜치**: `local/task624`
+**이슈**: https://github.com/edwardkim/rhwp/issues/624
+**선행 task**: #520 (`313e65d`), #548 cherry-pick (PR #561, `3de0505`)
+
+---
+
+## 1. 문제 정의
+
+`samples/exam_science.hwp` page 2 의 7번 문제 글상자 (pi=33 ci=0, 1x1 Table, tac=true) 안 p[1] 단락의 **㉠ 사각형 (Control::Shape, treat_as_char=true, ls[1] 위치)** 이 Line 1 영역 (y≈213.95 px) 에 잘못 그려져 본문 텍스트 "분자당 구성 …" 위에 겹침.
+
+- 기대: ㉠ 사각형이 Line 2 (y≈235.65 px) 에서 " 이다." 앞에 위치
+- 현재: ㉠ 사각형 (x=117.07, y=213.95) — Line 1 의 y 영역, Line 2 의 x 영역
+- " 이다." 자체는 x=180.05, y=247.68 (Line 2) 로 사각형 다음 위치에 정상
+
+## 2. 사전 분석 결과 (Stage 0 — 이슈 본문에 기록)
+
+### 2.1 회귀 출처 확정
+
+| 시점 | 커밋 | Picture branch tac_img_y | Shape branch tac_img_y | shape_area.y | layout_cell_shape para_y |
+|---|---|---|---|---|---|
+| Task #520 | `313e65d` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
+| Task #544 v2 Stage 3 (원저자 @planet6897) | `9dc40dd` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
+| **Task #548 cherry-pick (PR #561)** | **`3de0505`** | **`seg.vpos` ✗ (회귀)** | `seg.vpos - first_vpos` ✓ | **`para_y_before_compose` ✗ (회귀)** | **`para_y_before_compose` ✗ (회귀)** |
+| 현재 HEAD (`local/devel`) | `e9f3562` | 회귀 유지 | 정상 | 회귀 유지 | 회귀 유지 |
+
+`git diff 9dc40dd 3de0505 -- src/renderer/layout/table_layout.rs` 으로 누락 3 건 확정.
+
+### 2.2 코드 모순
+
+현재 HEAD 의 Shape 분기는 `tac_img_y` 를 Task #520 산식 그대로 정확히 계산 (line 1714 근처) 하지만, `shape_area` 와 `layout_cell_shape` 호출 (line 1810, 1815) 에서는 `para_y_before_compose` 를 사용 → 계산된 `tac_img_y` 가 **소비되지 않는** 상태.
+
+Picture 분기는 `tac_img_y` 를 사용하지만 산식이 `seg.vpos` 만 (없는 `- first_vpos`) 이라 ls[0].vpos > 0 인 셀의 두 번째+ paragraph 에서 이중 합산 회귀.
+
+### 2.3 영향 범위 추정
+
+- **직접 영향**: Multi-line paragraph 안에 inline TAC Shape (사각형 등) 이 있는 케이스 (exam_science 7번 등)
+- **Picture 분기 산식 회귀**: `tac_img_y` 가 ls[0].vpos 누적 위에 다시 vpos 절대값을 더해 한 줄 아래로 밀림. 영향 케이스: ls[0].vpos > 0 인 셀의 paragraph[i>0] 안 inline TAC Picture
+- **추정 광범위 영향**: 보기 박스, 자료 박스, 탐구 박스 등 textbox 안 multi-line paragraph + inline 도형/그림 케이스 전반
+
+## 3. 수정 방향
+
+원저자 9dc40dd 의 의도 그대로 복원 — 3 라인 정정.
+
+### 3.1 Picture 분기 (`src/renderer/layout/table_layout.rs:1606`)
+
+**Before** (현재 HEAD):
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+}
+```
+
+**After**:
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    // [Task #520] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+    // para_y_before_compose 에는 이미 ls[0].vpos 가 누적되어 있으므로
+    // 상대 오프셋(seg.vpos - ls[0].vpos)만 더해야 이중 합산을 피한다.
+    let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+    tac_img_y = para_y_before_compose
+        + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
+}
+```
+
+### 3.2 Shape 분기 `shape_area.y` (`src/renderer/layout/table_layout.rs:1811`)
+
+**Before**:
+```rust
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: para_y_before_compose,
+    width: shape_w,
+    height: inner_area.height,
+};
+```
+
+**After**:
+```rust
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: tac_img_y,
+    width: shape_w,
+    height: inner_area.height,
+};
+```
+
+### 3.3 Shape 분기 `layout_cell_shape` para_y 인자 (`src/renderer/layout/table_layout.rs:1815`)
+
+**Before**:
+```rust
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, para_y_before_compose, Alignment::Left, styles, bin_data_content);
+```
+
+**After**:
+```rust
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, tac_img_y, Alignment::Left, styles, bin_data_content);
+```
+
+## 4. 단계 분할
+
+- **Stage 0** (현재 완료): 사전 진단 + 회귀 출처 확정 + 누락 3 건 식별 (이슈 본문 + 본 수행계획서)
+- **Stage 1**: 구현 계획서 작성 (TDD 우선) — RED 통합 테스트 작성 + 정정 영역 LOC 확정
+- **Stage 2**: 정정 적용 (3 line fix) → RED → GREEN 전환 + 단위 테스트 회귀 확인
+- **Stage 3**: 광범위 회귀 검증 (164 fixture sweep) + 시각 판정 sample (exam_science p2 + 인접 케이스) + 최종 보고서
+
+## 5. 검증 전략
+
+### 5.1 단위 / 통합 테스트
+- `cargo test --lib` — 회귀 0
+- `cargo test --test svg_snapshot` — 6/6 통과
+- 신규 통합 테스트 (Stage 1 TDD): `test_624_textbox_inline_shape_y_on_line2_p2_q7` (exam_science p2 7번 글상자 ㉠ 사각형 y 좌표 검증)
+
+### 5.2 회귀 검증 샘플
+- `samples/exam_science.hwp` (직접 대상 — p2 7번 + p3 인접 케이스)
+- `samples/exam_math.hwp`, `samples/exam_eng.hwp`, `samples/exam_kor.hwp` (보기/자료 박스)
+- `samples/synam-001.hwp` (음수 ls 광범위 — 무관해야 함)
+- `samples/21_언어_기출_편집가능본.hwp` (passage 박스)
+
+### 5.3 광범위 sweep
+- 164 fixture × 평균 10 페이지 = ~1,614 페이지 SVG diff
+- 의도된 변경 (exam_science 7번 + 인접) 외 회귀 0 확인
+
+### 5.4 clippy
+- `cargo clippy --lib -- -D warnings` clean
+
+## 6. 위험 및 완화
+
+| 위험 | 영향 | 완화 |
+|------|------|------|
+| Task #548 효과 (cell inline TAC Shape margin_left + indent) 회귀 | 큼 | Task #548 의 `effective_margin_left_line` 호출 + `inline_x` 산출은 그대로 유지, `tac_img_y` 사용처만 정정 |
+| Picture 분기 산식 변경의 다른 케이스 영향 | 중간 | 광범위 sweep + 의도된 정정 vs 회귀 구분 |
+| ls[0].vpos = 0 케이스에서 동작 변화 | 낮음 | first_vpos = 0 일 때 `seg.vpos - 0 = seg.vpos` 로 기존 동작 그대로 |
+
+## 7. 산출물
+
+- 코드: `src/renderer/layout/table_layout.rs` (3 라인 정정)
+- 단위 테스트: `src/renderer/layout/integration_tests.rs` 또는 별도 테스트 (Stage 1 TDD)
+- 문서:
+  - `mydocs/plans/task_m100_624.md` (본 문서)
+  - `mydocs/plans/task_m100_624_impl.md` (Stage 1 작성)
+  - `mydocs/working/task_m100_624_stage{1,2,3}.md`
+  - `mydocs/report/task_m100_624_report.md`
+
+---
+
+## 8. 진행 승인 요청
+
+본 수행 계획서 검토 후 Stage 1 (구현 계획서 + RED TDD) 진입 승인 요청합니다.

--- a/mydocs/plans/task_m100_624_impl.md
+++ b/mydocs/plans/task_m100_624_impl.md
@@ -1,0 +1,172 @@
+# Task #624 구현 계획서
+
+**제목**: exam_science p2 7번 글상자 ㉠ 사각형 y-위치 회귀 정정 — 3 line fix
+**브랜치**: `local/task624`
+**이슈**: https://github.com/edwardkim/rhwp/issues/624
+
+---
+
+## 1. 구현 대상 LOC 확정
+
+`src/renderer/layout/table_layout.rs` (3 라인 정정).
+
+### 1.1 Picture 분기 — `tac_img_y` 산식 (Task #520 복원)
+
+위치: `Control::Picture(pic)` arm 안 `if pic.common.treat_as_char` 분기 — `target_line > current_tac_line` 블록 안.
+
+현재 (HEAD `e9f3562`):
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+}
+```
+
+정정:
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    // [Task #520 복원] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+    // para_y_before_compose 에 이미 ls[0].vpos 가 누적되어 있어
+    // 상대 오프셋만 더해야 한다 (Shape 분기와 동일).
+    let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+    tac_img_y = para_y_before_compose
+        + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
+}
+```
+
+### 1.2 Shape 분기 — `shape_area.y` (Task #520 복원)
+
+위치: `Control::Shape(shape)` arm 안 `if shape.common().treat_as_char` 분기 — text_before 발행 직후, layout_cell_shape 호출 전.
+
+현재:
+```rust
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: para_y_before_compose,
+    width: shape_w,
+    height: inner_area.height,
+};
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, para_y_before_compose, Alignment::Left, styles, bin_data_content);
+```
+
+정정:
+```rust
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: tac_img_y,
+    width: shape_w,
+    height: inner_area.height,
+};
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, tac_img_y, Alignment::Left, styles, bin_data_content);
+```
+
+## 2. TDD — Stage 1 RED 테스트
+
+### 2.1 신규 통합 테스트 추가
+
+`src/renderer/layout/integration_tests.rs` 끝에 `test_624_textbox_inline_shape_y_on_line2_p2_q7` 추가 — exam_science.hwp p2 7번 글상자의 ㉠ 사각형 y 좌표 검증.
+
+```rust
+#[test]
+fn test_624_textbox_inline_shape_y_on_line2_p2_q7() {
+    // exam_science.hwp p2 7번 글상자 (pi=33 ci=0) 안 p[1] 단락의
+    // ㉠ 사각형 (treat_as_char + ls[1] 위치) y 좌표가 Line 2 영역에 와야 한다.
+    // 회귀 (Task #520 부분 회귀) 시 사각형이 Line 1 (y≈213) 에 떨어져
+    // 본문 텍스트 "분자당 구성" 위에 겹친다.
+
+    let path = std::path::Path::new("samples/exam_science.hwp");
+    let doc = crate::Document::load(path).expect("load");
+    let tree = render_page_to_tree(&doc, 1 /* page index 0-based */);
+
+    // ㉠ 사각형: Shape 노드 중 p[1] (pi=33 ci=0 cell paragraph[1])
+    // 의 Rectangle ctrl 인 것을 식별
+    let rect_y = find_inline_shape_y_in_textbox(&tree, /* section */ 0, /* paragraph */ 33);
+
+    // Line 2 baseline ≈ 247.68, line top ≈ 235.65, sheet 22.88
+    // 정상 범위: y ∈ [230, 240] (line 2 영역)
+    // 회귀 범위: y ∈ [212, 218] (line 1 영역)
+    assert!(rect_y >= 230.0 && rect_y <= 240.0,
+        "rect y={} expected ~235.65 (Line 2), got Line 1 area (회귀)", rect_y);
+}
+```
+
+> 테스트 헬퍼는 기존 패턴 (`render_page_to_tree`, `find_inline_shape_y_*`) 재사용. 헬퍼 부재 시 Stage 2 에서 SVG 텍스트 grep 으로 대체 측정.
+
+대안: SVG snapshot 비교 방식 (`output/svg/exam_science_002.svg` 의 `<rect ... y="..."` 패턴 grep).
+
+### 2.2 RED 확인
+
+본 정정 적용 전 cargo test 실행 → 신규 테스트 RED.
+
+## 3. 단계별 진행
+
+### Stage 1 (현재): 구현 계획서 + RED TDD
+1. 본 문서 작성 (완료)
+2. TDD 통합 테스트 추가 → cargo test --lib RED 확인
+3. Stage 1 보고서 (`task_m100_624_stage1.md`) 작성
+
+### Stage 2: 정정 적용 (3 라인)
+1. `src/renderer/layout/table_layout.rs` 3 라인 정정
+2. cargo test --lib → RED → GREEN 전환 확인
+3. cargo test --test svg_snapshot 6/6 통과
+4. cargo clippy --lib -- -D warnings clean
+5. 시각 판정 — `output/svg/exam_science_002.svg` 의 ㉠ 사각형 y 좌표 측정 (≈235.65)
+6. Stage 2 보고서 (`task_m100_624_stage2.md`) 작성
+
+### Stage 3: 광범위 회귀 검증 + 최종 보고
+1. 광범위 fixture sweep — 164 fixture × ~10 페이지 SVG 생성 + 기존 baseline 대비 diff
+2. 의도된 변경 (exam_science 7번 + 인접) vs 회귀 분리
+3. exam_math/exam_eng/exam_kor/synam-001/21_언어 무회귀 확인
+4. 최종 보고서 (`mydocs/report/task_m100_624_report.md`) 작성
+5. orders 갱신
+
+### Stage 4 (옵션): merge
+- local/task624 → local/devel merge
+- 작업지시자 승인 후 진행
+
+## 4. 단위 테스트 매핑
+
+기존 테스트 영향 없음으로 추정 (`tac_img_y` 산식은 `seg.vpos - first_vpos` 로 첫 paragraph (first_vpos=0) 케이스에서는 동일). 단:
+
+- `test_544_passage_box_coords_match_pdf_p4`: 무관 (paragraph border 좌표)
+- `test_547_passage_text_inset_match_pdf_p4`: 무관 (텍스트 inset)
+- `test_548_cell_inline_shape_first_line_indent_p8`: **잠재 영향** — 셀 안 inline TAC Shape 위치
+  - first-line 케이스이므로 first_vpos = ls[0].vpos = ls[0].vpos → `seg.vpos - first_vpos = 0` (line 0 그대로) → 영향 없을 것
+- `test_552_passage_box_top_gap_p2_4_6`: 무관 (border push)
+
+## 5. 회귀 위험 정밀 평가
+
+### 5.1 Picture 분기 산식 변경
+
+영향 케이스: `target_line > 0` 인 inline TAC Picture (multi-line paragraph 안 ls[1]+ 위치 picture).
+
+- **변경 전**: `tac_img_y = para_y_before_compose + seg.vpos` (절대값 더함)
+- **변경 후**: `tac_img_y = para_y_before_compose + (seg.vpos - first_vpos)` (상대 오프셋만)
+- **첫 paragraph (first_vpos = 0)**: 동일 동작
+- **두 번째+ paragraph (first_vpos > 0)**: ls[0].vpos 만큼 위로 이동 (이중 합산 해소)
+
+회귀 가능 케이스: 셀 안 첫 paragraph 의 multi-line 인라인 picture — 거의 없음 (대부분 `target_line=0`).
+
+### 5.2 Shape 분기 `shape_area.y` 변경
+
+영향 케이스: 셀 안 multi-line paragraph + inline TAC Shape (사각형/원 등) — exam_science 7번이 대표.
+
+- **변경 전**: `y = para_y_before_compose` (Line 0 위치)
+- **변경 후**: `y = tac_img_y` (target_line 기반 위치)
+- **target_line = 0** 케이스: `tac_img_y = para_y_before_compose` 로 동일 동작
+- **target_line > 0** 케이스: 정상 line 위치로 이동 (회귀 해소)
+
+## 6. 검증 체크리스트
+
+- [ ] Stage 1: TDD 테스트 RED 확인
+- [ ] Stage 2: 정정 적용 후 RED → GREEN
+- [ ] Stage 2: cargo test --lib 회귀 0
+- [ ] Stage 2: svg_snapshot 6/6 GREEN
+- [ ] Stage 2: clippy clean
+- [ ] Stage 2: exam_science p2 7번 ㉠ 사각형 y 좌표 시각 측정
+- [ ] Stage 3: 164 fixture sweep — 의도된 변경 외 회귀 0
+- [ ] Stage 3: exam_math/exam_eng/exam_kor/synam-001/21_언어 무회귀
+- [ ] Stage 3: 최종 보고서 + orders 갱신
+
+---
+
+승인 시 Stage 1 (TDD RED 테스트 추가) 진행.

--- a/mydocs/report/task_m100_624_report.md
+++ b/mydocs/report/task_m100_624_report.md
@@ -1,0 +1,173 @@
+# Task #624 최종 보고서
+
+**제목**: exam_science p2 7번 글상자 ㉠ 사각형 y-위치 회귀 정정 — Task #520 부분 회귀 복원
+**마일스톤**: M100 (v1.0.0)
+**브랜치**: `local/task624` (base: `pr-task618`)
+**이슈**: https://github.com/edwardkim/rhwp/issues/624
+**선행 task**: #520 (`313e65d`), #548 cherry-pick PR #561 (`3de0505`)
+
+---
+
+## 1. 요약
+
+PR #561 cherry-pick (`3de0505`) 시 Task #520 정정 일부 (3 라인) 누락 회귀를 정정. exam_science p2 7번 글상자 ㉠ 사각형이 Line 1 영역 (y=213.95, 본문 "분자당 구성" 위 겹침) 에서 Line 2 영역 (y=235.41, " 이다." 앞) 으로 정확히 이동.
+
+코드 변경: `src/renderer/layout/table_layout.rs` +9/-2 (3 라인 본질 + 주석).
+검증: cargo test --lib 1135 passed (회귀 0) / 광범위 fixture sweep 158 fixture 1,496 페이지 / 1 페이지 의도된 정정 / 회귀 0.
+
+## 2. 문제 정의
+
+### 2.1 증상
+
+`samples/exam_science.hwp` page 2 의 7번 문제 글상자 (pi=33 ci=0, 1x1 Table) 안 p[1] 단락의 ㉠ 사각형 (`Control::Shape`, `treat_as_char=true`, ls[1] 위치) 이 Line 1 영역 (y≈213.95 px) 에 잘못 그려져 본문 텍스트 "분자당 구성 …" 위에 겹쳐 보임.
+
+기대: ㉠ 사각형이 Line 2 (y≈235.65 px) 에서 " 이다." 앞에 위치.
+
+### 2.2 회귀 출처
+
+| 시점 | 커밋 | Picture branch tac_img_y | Shape branch tac_img_y | shape_area.y | layout_cell_shape para_y |
+|---|---|---|---|---|---|
+| Task #520 | `313e65d` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
+| Task #544 v2 Stage 3 (원저자 @planet6897) | `9dc40dd` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
+| **Task #548 cherry-pick (PR #561)** | **`3de0505`** | **`seg.vpos` ✗ (회귀)** | `seg.vpos - first_vpos` ✓ | **`para_y_before_compose` ✗ (회귀)** | **`para_y_before_compose` ✗ (회귀)** |
+
+`git diff 9dc40dd 3de0505 -- src/renderer/layout/table_layout.rs` 으로 누락 3 건 정확히 식별.
+
+## 3. 정정 내용
+
+### 3.1 Picture 분기 `tac_img_y` 산식 (`src/renderer/layout/table_layout.rs:1605~1607`)
+
+```rust
+// Before
+if let Some(seg) = para.line_segs.get(target_line) {
+    tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+}
+
+// After
+if let Some(seg) = para.line_segs.get(target_line) {
+    let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+    tac_img_y = para_y_before_compose
+        + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
+}
+```
+
+### 3.2 Shape 분기 `shape_area.y` (`src/renderer/layout/table_layout.rs:1814~1820`)
+
+```rust
+// Before
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: para_y_before_compose,
+    ...
+};
+self.layout_cell_shape(..., para_y_before_compose, ...);
+
+// After
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: tac_img_y,
+    ...
+};
+self.layout_cell_shape(..., tac_img_y, ...);
+```
+
+## 4. 검증 결과
+
+### 4.1 단위 / 통합 테스트
+
+| 테스트 | 결과 |
+|---|---|
+| `test_624_textbox_inline_shape_y_on_line2_p2_q7` | RED → **GREEN** |
+| `cargo test --lib` (전체) | **1135 passed / 0 failed / 2 ignored** |
+| `cargo test --test svg_snapshot` | **6/6 passed** |
+| `cargo clippy --lib -- -D warnings` | **clean** |
+
+### 4.2 광범위 fixture sweep
+
+158 sample × 평균 ~9.5 페이지 = **1,496 페이지** sweep:
+
+| 카테고리 | 페이지 수 | 비고 |
+|---|---|---|
+| 의도된 정정 | **1** | exam_science_002.svg ㉠ 사각형 + ㉠ 텍스트 y +21.47 px |
+| 회귀 | **0** | 다른 157 fixture 1,495 페이지 byte-identical |
+
+### 4.3 정정 효과 (exam_science p2 7번 글상자 ㉠)
+
+```diff
+-<rect x="117.066" y="213.946" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
+-<text x="141.56"  y="229.986" ...>㉠</text>
++<rect x="117.066" y="235.413" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
++<text x="141.56"  y="251.453" ...>㉠</text>
+```
+
+- `<rect>` y: **213.95 → 235.41** (Δ +21.47 px = (3220 - 1610)/75 = ls[1].vpos - ls[0].vpos 정확)
+- `<text>㉠` y: **229.99 → 251.45** (Δ +21.47 px)
+
+→ ㉠ 사각형 + 그 안 ㉠ 텍스트가 Line 2 영역으로 정확히 이동. 본문 "분자당 구성" 침범 해소.
+
+## 5. 안전성 분석 (edge cases)
+
+| 케이스 | 정정 후 동작 | 사유 |
+|---|---|---|
+| `first_vpos = 0` (cell 첫 paragraph) | 동일 동작 보장 | `seg.vpos - 0 = seg.vpos`, 산식 결과 동일 |
+| `target_line = 0` (rect on ls[0]) | 동일 동작 보장 | `target_line > current_tac_line` 가드로 if 블록 미진입, `tac_img_y == para_y_before_compose` 초기값 유지 |
+| `line_segs.len() = 1` (single-line) | 동일 동작 보장 | `composed.lines.len() = 1` 이면 `target_line = 0` 으로 위와 동일 |
+| `wrap = Square / InFrontOfText / TopAndBottom` | 본 분기 영향 없음 | `treat_as_char=true` 만 처리, wrap 모드는 IR 보존만 |
+
+→ 정정의 부수 효과 없음 — 정확히 회귀 사례만 해소.
+
+## 6. 회귀 발생 4 조건 분석
+
+`Control::Shape(shape) if shape.common().treat_as_char` 분기에서 다음 4 조건 모두 성립 시 회귀 가시화:
+
+| 조건 | exam_science p[1] | exam_kor p[0] | synam-001 p[6/0/8] | 21_언어 p[0] | k-water p[0] |
+|---|---|---|---|---|---|
+| (a) cell 안 paragraph | ✓ | ✓ | ✓ | ✓ | ✓ |
+| (b) multi-line (`line_segs.len() ≥ 2`) | ✓ (2) | ✓ (4) | ✓ (2/3/3) | ✓ (10) | ✓ (2) |
+| (c) `target_line > 0` (rect on ls[1]+) | ✓ | ? | ? | ? | ? |
+| (d) `first_vpos > 0` (paragraph[i>0]) | **✓ (1610)** | ✗ (0) | ✗/✗/✗ | ✗ (0) | ✗ (0) |
+| **회귀 가시화** | **YES** | NO | NO | NO | NO |
+
+→ exam_science p[1] 만이 (c) AND (d) 동시 성립 — 광범위 sweep 결과 (1/1496) 와 정확히 부합.
+
+## 7. 후속 권고
+
+1. **PR cherry-pick 시 base diff 자동 점검**: 본 결함은 `9dc40dd → 3de0505` 비교만으로 즉시 식별 가능. 동일 함수 영역의 산식이 base 와 cherry-pick 후 차이 발생 시 경고 도입.
+2. **회귀 테스트 가드**: 본 task 의 `test_624_textbox_inline_shape_y_on_line2_p2_q7` 가 RED → GREEN 가드 역할. 추가 cherry-pick 시 본 테스트 RED 발생하면 즉시 차단.
+3. **`local/devel` ↔ `devel` 동기화 점검**: 173 commit 차이의 다른 영역에도 유사 회귀 가능. `local/devel` ahead 인 fix 들 (Task #520 외) 도 `devel` 에 정확히 반영되어 있는지 검증 권고.
+
+## 8. 산출물
+
+### 8.1 코드 변경
+
+| 파일 | LOC | 비고 |
+|---|---|---|
+| `src/renderer/layout/table_layout.rs` | +9 / -2 | Picture 산식 + Shape 위치 (3 라인 본질 + 주석) |
+| `src/renderer/layout/integration_tests.rs` | +59 | Stage 1 RED 테스트 |
+
+### 8.2 문서
+
+| 문서 | 단계 |
+|---|---|
+| `mydocs/plans/task_m100_624.md` | Stage 0 — 수행 계획서 |
+| `mydocs/plans/task_m100_624_impl.md` | Stage 0 — 구현 계획서 |
+| `mydocs/working/task_m100_624_stage1.md` | Stage 1 — TDD RED |
+| `mydocs/working/task_m100_624_stage2_analysis.md` | Stage 2 (분석) |
+| `mydocs/working/task_m100_624_stage2.md` | Stage 2 (정정) |
+| `mydocs/report/task_m100_624_report.md` | Stage 3 — 본 보고서 |
+| `mydocs/orders/20260506.md` | 오늘 할일 갱신 |
+
+### 8.3 commit chain (`local/task624`)
+
+```
+4b094b6 Task #624 Stage 2: Task #520 부분 회귀 정정 (3 line)
+aee08d6 Task #624 Stage 2 분석 보고서 (코드 정정 보류)
+bdb6671 Task #624 Stage 1: TDD RED 통합 테스트
+1237a78 Task #624 Stage 0: 수행 계획서 + 구현 계획서
+```
+
+## 9. 결론
+
+PR #561 cherry-pick 시 Task #520 의 일부 정정 누락 회귀 (3 라인) 를 복원. 광범위 1,496 페이지 sweep 으로 회귀 0건 확인. 정정 안전성 (edge case 4종) 정합 — 의도된 1 페이지만 변경, 다른 1,495 페이지 byte-identical.
+
+`closes #624`.

--- a/mydocs/working/task_m100_624_stage1.md
+++ b/mydocs/working/task_m100_624_stage1.md
@@ -1,0 +1,42 @@
+# Task #624 Stage 1 보고서
+
+## 목적
+
+회귀 재현 TDD 통합 테스트 추가 → RED 확인.
+
+## 적용 변경
+
+### `src/renderer/layout/integration_tests.rs`
+
+`test_624_textbox_inline_shape_y_on_line2_p2_q7` 추가 (+58 LOC).
+
+**테스트 로직**:
+1. `samples/exam_science.hwp` page 2 (index 1) SVG 렌더
+2. ㉠ 사각형 식별: `<rect width≈63 height≈22.88 fill="#ffffff" stroke="#000000"/>`
+3. y 좌표 검증: 정상 범위 [230, 240] (Line 2 영역)
+   - 회귀 시: y≈213.95 (Line 1 영역)
+   - 정상 시: y≈235.65 (Line 2 영역)
+
+## RED 확인
+
+```
+test test_624_textbox_inline_shape_y_on_line2_p2_q7 ... FAILED
+
+Task #624: ㉠ 사각형 y=213.95 가 Line 2 영역 [230, 240] 에 있어야 함.
+회귀 (Task #520 부분 회귀): y≈213.95 (Line 1 영역, 본문 '분자당 구성' 위 겹침).
+정정 (3 line fix): y≈235.65 (Line 2 영역, ' 이다.' 앞).
+```
+
+측정값 y=213.95 가 회귀 범위와 정확히 일치. 회귀 재현 완료.
+
+## 베이스 브랜치 정정
+
+수행계획서/구현계획서 작성 중 base 브랜치 오설정 (`local/devel`) 발견:
+- `local/devel`: Task #520 fix **이미 보존** (회귀 없음)
+- `pr-task618` / `devel`: Task #520 회귀 존재 (PR #561 cherry-pick `3de0505`)
+
+`local/task624` 를 `pr-task618` 에서 재분기. Stage 0 plan commit 은 그대로 유지 (`git am` 으로 재적용).
+
+## 다음 단계
+
+Stage 2: `src/renderer/layout/table_layout.rs` 3 라인 정정 적용 → RED → GREEN 전환 + 광범위 cargo test --lib 회귀 확인.

--- a/mydocs/working/task_m100_624_stage2.md
+++ b/mydocs/working/task_m100_624_stage2.md
@@ -1,0 +1,111 @@
+# Task #624 Stage 2 보고서
+
+## 목적
+
+Task #520 부분 회귀 정정 — Picture 산식 + Shape `shape_area.y` + Shape `layout_cell_shape` para_y 인자 3 라인 복원.
+
+## 적용 변경
+
+`src/renderer/layout/table_layout.rs` 3 영역 정정.
+
+### 1. Picture 분기 `tac_img_y` 산식 복원 (line 1605~1607)
+
+**Before**:
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+}
+```
+
+**After**:
+```rust
+if let Some(seg) = para.line_segs.get(target_line) {
+    // [Task #520 / #624 복원] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+    // para_y_before_compose 에 이미 ls[0].vpos 가 누적되어 있어
+    // 상대 오프셋(seg.vpos - ls[0].vpos)만 더해야 이중 합산을 피한다.
+    let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+    tac_img_y = para_y_before_compose
+        + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
+}
+```
+
+### 2. Shape 분기 `shape_area.y` + `layout_cell_shape` para_y 인자 (line 1814~1820)
+
+**Before**:
+```rust
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: para_y_before_compose,
+    width: shape_w,
+    height: inner_area.height,
+};
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, para_y_before_compose, Alignment::Left, styles, bin_data_content);
+```
+
+**After**:
+```rust
+// [Task #520 / #624 복원] target_line 기반 tac_img_y 사용 (Picture 분기와 동일).
+// para_y_before_compose 사용 시 multi-line paragraph 의 ls[1]+ inline TAC Shape 가
+// 항상 line 0 좌표에 떨어져 본문 텍스트와 겹친다 (exam_science p2 7번 글상자 ㉠).
+let shape_area = LayoutRect {
+    x: inline_x,
+    y: tac_img_y,
+    width: shape_w,
+    height: inner_area.height,
+};
+self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, tac_img_y, Alignment::Left, styles, bin_data_content);
+```
+
+## 검증
+
+### 단위 / 통합 테스트
+
+| 테스트 | 결과 |
+|---|---|
+| `cargo test --lib test_624_textbox_inline_shape_y_on_line2_p2_q7` | **GREEN** (RED → GREEN) |
+| `cargo test --lib` (전체) | **1135 passed / 0 failed / 2 ignored** |
+| `cargo test --test svg_snapshot` | **6/6 passed** |
+| `cargo clippy --lib -- -D warnings` | **clean** |
+
+### 광범위 회귀 sweep (12 fixture, 102 페이지)
+
+| 샘플 | 페이지 | 변경 | 비고 |
+|---|---|---|---|
+| `exam_science.hwp` | 4 | **1** | 의도된 정정 (page 2 ㉠) |
+| `exam_kor.hwp` | 20 | 0 | 무회귀 |
+| `exam_math.hwp` | 20 | 0 | 무회귀 |
+| `exam_eng.hwp` | 8 | 0 | 무회귀 |
+| `synam-001.hwp` | 35 | 0 | 무회귀 (multi-line + tac rect 3 case 무영향) |
+| `21_언어_기출_편집가능본.hwp` | 15 | 0 | 무회귀 |
+| **합계** | **102** | **1 (의도)** | **회귀 0** |
+
+추가 sweep 권고 (158 sample 전체 fixture) 는 Stage 3 에서 수행.
+
+### 정정 효과 (exam_science p2 7번 글상자 ㉠ 사각형)
+
+```diff
+-<rect x="117.066" y="213.946" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
+-<text x="141.56"  y="229.986" ...>㉠</text>
++<rect x="117.066" y="235.413" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
++<text x="141.56"  y="251.453" ...>㉠</text>
+```
+
+- `<rect>` y: 213.95 → 235.41 (Δ +21.47 px = ls[1].vpos − ls[0].vpos / 75 정확)
+- `<text>㉠` y: 229.99 → 251.45 (Δ +21.47 px)
+
+→ ㉠ 사각형이 Line 1 영역 (본문 "분자당 구성" 위 겹침) 에서 Line 2 영역 (" 이다." 앞) 으로 정확히 이동.
+
+## 코드 영향
+
+| 파일 | 변경 LOC |
+|---|---|
+| `src/renderer/layout/table_layout.rs` | +9 / -2 (Picture 산식 + Shape 위치) |
+| `src/renderer/layout/integration_tests.rs` | +59 (Stage 1 RED 테스트 — 이미 commit) |
+
+## 잔존
+
+- Stage 3: 158 sample 전체 fixture sweep (광범위 회귀 검증) + 최종 보고서 작성
+
+## 다음 단계
+
+Stage 3 진입 — 광범위 fixture sweep + orders 갱신 + 최종 보고서 작성.

--- a/mydocs/working/task_m100_624_stage2_analysis.md
+++ b/mydocs/working/task_m100_624_stage2_analysis.md
@@ -1,0 +1,150 @@
+# Task #624 Stage 2 분석 보고서 (코드 수정 미진입)
+
+> 사용자 지시: "분석만 계속 진행" — Stage 2 정정 적용 보류, 영향 범위·edge case·후속 진단 분석으로 전환.
+
+---
+
+## 1. 광범위 sweep 결과 (정정 시뮬레이션)
+
+이전 stash/pop 기반 sweep (정정 미커밋 상태에서 빌드 → SVG 생성 → revert) 의 실측 데이터:
+
+| 샘플 | 페이지 | 변경 페이지 | 비고 |
+|---|---|---|---|
+| `exam_science.hwp` | 4 | **1** (page 2) | ㉠ 사각형 + ㉠ 텍스트 y +21.47 px |
+| `exam_kor.hwp` | 20 | 0 | (multi-line + tac rect 있으나 변경 없음) |
+| `exam_math.hwp` | 20 | 0 | |
+| `exam_eng.hwp` | 8 | 0 | |
+| `synam-001.hwp` | 35 | 0 | (multi-line + tac rect 3 개 있으나 변경 없음) |
+| `21_언어_기출_편집가능본.hwp` | 15 | 0 | |
+| **합계** | **102** | **1** | 0.98% — 매우 좁은 회귀 |
+
+### 1.1 exam_science_002.svg 의 정확한 변경
+
+```diff
+-<rect x="117.066" y="213.946" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
+-<text x="141.56"  y="229.986" ...>㉠</text>
++<rect x="117.066" y="235.413" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
++<text x="141.56"  y="251.453" ...>㉠</text>
+```
+
+- `<rect>` y: 213.95 → 235.41, Δ = +21.47 px
+- `<text>㉠` y: 229.99 → 251.45, Δ = +21.47 px
+- Δ 21.47 px = (3220 - 1610) HU / 75 = exact ls[1].vpos − ls[0].vpos.
+
+→ 정정 효과는 ㉠ 사각형 + 그 안 ㉠ 텍스트가 line 2 영역으로 정확히 이동.
+
+## 2. 회귀 발생 조건 (3 항 모두 충족 시)
+
+`table_layout.rs` 의 `Control::Shape(shape) if shape.common().treat_as_char` 분기 (line 1671~1820) 에서:
+
+| 조건 | exam_science p[1] | exam_kor p[0] | synam-001 p[6/0/8] | 21_언어 p[0] | k-water p[0] |
+|---|---|---|---|---|---|
+| (a) cell 안 paragraph | ✓ | ✓ | ✓ | ✓ | ✓ |
+| (b) `line_segs.len() ≥ 2` (multi-line) | ✓ (2) | ✓ (4) | ✓ (2/3/3) | ✓ (10) | ✓ (2) |
+| (c) `target_line > 0` (rect on ls[1]+) | ✓ | ? | ? | ? | ? |
+| (d) `first_vpos > 0` (paragraph[i>0]) | **✓ (1610)** | ✗ (0) | ✗/✗/✗ | ✗ (0) | ✗ (0) |
+| **회귀 가시화** | **YES** | NO | NO | NO | NO |
+
+→ 본 회귀는 **(c) AND (d)** 두 조건이 동시 성립해야 가시화.
+→ exam_science p[1] 만이 유일한 가시 회귀 사례 — `first_vpos = 1610 HU` 로 paragraph[1]+ 위치이며 rect 가 ls[1] 에 있음.
+
+### 2.1 다른 multi-line + tac rect 케이스 무회귀 사유
+
+- `exam_kor` p[0] (paragraph 0, first_vpos=0): rect 의 target_line 무관, first_vpos=0 으로 산식 영향 없음. shape_area.y 차이는 ls[0] 와 ls[1] 모두 같은 para_y_before_compose 일 때만 동일 (즉 target_line=0 이면 tac_img_y == para_y_before_compose, target_line=1 이어도 ls[0].vpos=0 인 경우 첫 line 시작 = paragraph 시작이라 일치).
+- `synam-001` p[6/p[0]/p[8]: wrap=InFrontOfText / Square — 본 분기는 `treat_as_char=true` 만 처리, wrap 모드 무관 (단지 IR 표기). 실제 표시 위치는 inline 룰 적용. 그러나 first_vpos=0 케이스로 산식 차이 무관.
+- `21_언어` p[0] / `k-water` p[0]: 동일 — first_vpos=0.
+
+## 3. 정정의 안전성 (edge case)
+
+### 3.1 첫 paragraph (`first_vpos = 0`) 무회귀
+
+```
+seg.vpos - first_vpos = seg.vpos - 0 = seg.vpos
+```
+→ 산식 변경 후도 동일 동작. cell 첫 paragraph 의 모든 케이스에서 무회귀.
+
+### 3.2 첫 줄 (`target_line = 0`) 무회귀
+
+```
+target_line > current_tac_line 가드 (line 1693)
+```
+→ target_line == 0 (current_tac_line 도 0) 이면 if 블록 진입 안 함, tac_img_y 갱신 없음, 초기값 = para_y_before_compose 유지. 즉 shape_area.y = tac_img_y == para_y_before_compose 로 정정 후도 동일 동작.
+
+### 3.3 단일 줄 paragraph (`line_segs.len() == 1`) 무회귀
+
+target_line 산출 시 `composed.lines` 가 1 줄이면 `target_line = 0`. 동일 가드로 무회귀.
+
+### 3.4 wrap=Square / InFrontOfText / TopAndBottom
+
+본 분기는 `treat_as_char=true` 만 처리. wrap 모드는 IR 보존만 하고 inline 배치 룰 자체에는 영향 없음 (다른 분기가 wrap 모드 사용). 즉 본 정정의 wrap 모드별 영향 차이 없음.
+
+## 4. Picture 분기 산식 회귀의 별도 영향
+
+### 4.1 패턴 검색 결과
+
+`Picture(pic) if pic.common.treat_as_char` 분기 안 paragraph[i>0] (`first_vpos > 0`) + multi-line + ls[1]+ 위치 picture:
+
+```
+scan: 0 hits (158 sample × 평균 dump LOC)
+```
+
+→ 검토 가능한 sample 풀에서 가시 회귀 0 건. Picture 산식 회귀는 **이론적 결함**으로만 존재 (defensive consistency 차원).
+
+### 4.2 정정 권고 (Picture 산식)
+
+Shape 분기와의 **일관성** 차원에서 함께 복원 권고. Task #520 의 본질이 "Picture/Shape 양 분기 동일 산식" 임을 commit message 에서 명시 (`313e65d`).
+
+## 5. 회귀 출처의 본질 — PR cherry-pick 의 함정
+
+`git diff 9dc40dd 3de0505 -- src/renderer/layout/table_layout.rs`:
+
+원저자 `9dc40dd` (2026-05-04) 는 Task #544 v2 Stage 3 에서 Phase C (#548) 만 추가하면서 Task #520 의 산식 복원을 **유지**. 그러나 PR #561 cherry-pick 의 메인테이너 정리 단계에서 conflict resolution 또는 cherry-pick base 차이로 인해 Task #520 의 일부가 누락되어 `3de0505` 로 commit.
+
+### 5.1 정정 경로의 분기 상태
+
+| 브랜치 | shape_area.y | Picture tac_img_y | Shape tac_img_y |
+|---|---|---|---|
+| `local/devel` (e9f3562) | `tac_img_y` ✓ | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ |
+| `pr-task618` (7ac8777) | `para_y_before_compose` ✗ | `seg.vpos` ✗ | `seg.vpos - first_vpos` ✓ |
+| `devel` (9b49063) | `para_y_before_compose` ✗ | `seg.vpos` ✗ | `seg.vpos - first_vpos` ✓ |
+
+→ `local/devel` 은 회귀 없음. `devel`/`pr-task618` 은 회귀.
+→ `local/devel..devel` 사이 173 commit 분기 — `local/devel` 이 먼저 나뉘어 origin/devel 로 진행, 이후 cherry-pick 들이 `devel` 에 누적되며 회귀 유입.
+
+### 5.2 후속 권고
+
+1. **PR cherry-pick 시 base diff 자동 점검**: 동일 함수 영역의 산식이 base 와 cherry-pick 후 차이 발생 시 경고. 본 결함은 `9dc40dd → 3de0505` 비교만으로 즉시 식별 가능.
+2. **Task #520 회귀 방지 회귀 테스트**: 본 task 의 `test_624_textbox_inline_shape_y_on_line2_p2_q7` 가 RED → GREEN 가드 역할. 추가 cherry-pick 시 본 테스트 RED 발생하면 즉시 차단.
+3. **`local/devel` ↔ `devel` 동기화 점검**: 173 commit 차이의 다른 영역에도 유사 회귀 가능. `local/devel` ahead 인 영역의 fix 들 (Task #520 외) 도 `devel` 에 정확히 반영되어 있는지 검증.
+
+## 6. 정정 적용 보류 결정 (분석 모드)
+
+본 보고서는 분석에 집중하며 Stage 2 코드 정정은 **보류**. 작업지시자 승인 후 진행.
+
+### 6.1 정정 시 체크리스트 (참고)
+
+- [ ] `src/renderer/layout/table_layout.rs:1606` Picture tac_img_y 산식 (3 line 추가)
+- [ ] `src/renderer/layout/table_layout.rs:1816` Shape `shape_area.y` (1 line)
+- [ ] `src/renderer/layout/table_layout.rs:1820` Shape `layout_cell_shape` para_y arg (1 line)
+- [ ] `cargo test --lib test_624_textbox_inline_shape_y_on_line2_p2_q7` GREEN 전환
+- [ ] `cargo test --lib` 1135 passed (회귀 0)
+- [ ] `cargo test --test svg_snapshot` 6/6 GREEN
+- [ ] `cargo clippy --lib -- -D warnings` clean
+- [ ] 광범위 sweep 102 페이지 (현재 데이터) — 1/102 변경 (의도된 정정), 회귀 0
+- [ ] 추가 sweep 권고: 158 sample 전체 fixture 회귀 0 확인
+
+### 6.2 정정 미진행 사유
+
+작업지시자 명시 — "분석만 계속 진행". 정정 적용은 후속 명시 승인 후.
+
+---
+
+## 7. 핵심 결론
+
+1. **본질**: PR #561 cherry-pick (`3de0505`) 시 Task #520 의 일부 정정 누락 — 3 라인 회귀.
+2. **가시 영향**: `samples/exam_science.hwp` page 2 7번 글상자 ㉠ 사각형 1 건 (102 sweep 페이지 중 1).
+3. **정정 안전성**: `first_vpos = 0` AND `target_line = 0` 케이스 모두 동일 동작 보장 — edge case 회귀 0.
+4. **Picture 산식 회귀**: 가시 영향 0 건이나 Shape 와의 산식 일관성 차원에서 복원 권고.
+5. **방지책**: cherry-pick base diff 자동 점검 + 본 task 의 회귀 테스트 가드 도입.
+
+분석 완료. 후속 명시 승인 시 Stage 2 코드 정정 진행 가능.

--- a/mydocs/working/task_m100_624_stage3.md
+++ b/mydocs/working/task_m100_624_stage3.md
@@ -1,0 +1,66 @@
+# Task #624 Stage 3 보고서
+
+## 목적
+
+광범위 fixture sweep 으로 회귀 0 검증 + 최종 보고서 + orders 갱신.
+
+## 광범위 sweep 결과
+
+`samples/` 폴더 전체 **158 fixture / 1,496 페이지** sweep:
+
+| 카테고리 | 페이지 수 | 비율 |
+|---|---|---|
+| 의도된 정정 | 1 | 0.067% |
+| 회귀 | **0** | **0%** |
+| byte-identical | 1,495 | 99.933% |
+
+### 의도된 정정 (1 건)
+
+`/tmp/sweep_all_before/exam_science/exam_science_002.svg` ↔ `/tmp/sweep_all_after/exam_science/exam_science_002.svg`:
+
+```diff
+-<rect x="117.066" y="213.946" width="62.986" height="22.880" fill="#ffffff" stroke="#000000"/>
+-<text x="141.56"  y="229.986" ...>㉠</text>
++<rect x="117.066" y="235.413" width="62.986" height="22.880" fill="#ffffff" stroke="#000000"/>
++<text x="141.56"  y="251.453" ...>㉠</text>
+```
+
+- ㉠ 사각형 y: 213.95 → 235.41 (Δ +21.47 px)
+- ㉠ 텍스트 y: 229.99 → 251.45 (Δ +21.47 px)
+- Δ = (3220 - 1610) HU / 75 = ls[1].vpos - ls[0].vpos / px-conversion 정확
+
+### 회귀 0 검증
+
+| 샘플 카테고리 | 페이지 수 | 변경 페이지 |
+|---|---|---|
+| `exam_*.hwp` (5 files) | 64 | 1 (의도된 정정) |
+| `synam-001.hwp` | 35 | 0 |
+| `21_언어_*.hwp` | 15 | 0 |
+| `통합재정통계*.hwp` (3 files) | ~30 | 0 |
+| `hwpspec-w.hwp` | ~170 | 0 |
+| `aift.hwp` / `biz_plan.hwp` / `kps-ai.hwp` | ~60 | 0 |
+| 기타 fixture (~140 files) | ~1,120 | 0 |
+| **합계** | **1,496** | **1** |
+
+## 최종 검증 체크리스트
+
+- [x] Stage 1 TDD 테스트 RED 확인 (y=213.95 측정)
+- [x] Stage 2 정정 적용 후 RED → GREEN
+- [x] Stage 2 cargo test --lib 회귀 0 (1135 passed)
+- [x] Stage 2 svg_snapshot 6/6 GREEN
+- [x] Stage 2 clippy clean
+- [x] Stage 2 exam_science p2 ㉠ 사각형 y 시각 측정 (235.41 ≈ 235.65)
+- [x] Stage 3 158 fixture sweep — 의도된 변경 외 회귀 0
+- [x] Stage 3 exam_math/exam_eng/exam_kor/synam-001/21_언어 무회귀
+- [x] Stage 3 최종 보고서 + orders 갱신
+
+## 산출물
+
+- `mydocs/report/task_m100_624_report.md` — 최종 보고서
+- `mydocs/orders/20260506.md` — 오늘 할일 갱신 (Task #624 항목 추가)
+- `mydocs/working/task_m100_624_stage3.md` — 본 보고서
+
+## 다음 단계
+
+- 작업지시자 승인 후 `local/devel` merge → `devel` 푸시 → Issue #624 close
+- 회귀 방지 후속 (선택): cherry-pick base diff 자동 점검 도입 task 제안

--- a/src/renderer/layout/integration_tests.rs
+++ b/src/renderer/layout/integration_tests.rs
@@ -1219,4 +1219,62 @@ mod tests {
              SVG 요소를 찾지 못함 — 식별 가드 갱신 필요"
         );
     }
+
+    /// Task #624: exam_science p2 7번 글상자 (pi=33 ci=0) 안 p[1] 의
+    /// ㉠ 사각형 (Control::Shape, treat_as_char=true, ls[1] 위치) y 좌표 검증.
+    ///
+    /// 회귀 (Task #520 부분 회귀, PR #561 cherry-pick `3de0505`) 시 사각형이
+    /// Line 1 영역 (y≈213.95) 에 떨어져 본문 텍스트 "분자당 구성" 위에 겹친다.
+    /// 정정 후: Line 2 영역 (y≈235.65) 으로 이동해 " 이다." 앞에 위치.
+    ///
+    /// 사각형 식별: width≈63 (62.99) AND height≈22.88 의 흰색 fill + 검정 stroke.
+    #[test]
+    fn test_624_textbox_inline_shape_y_on_line2_p2_q7() {
+        let Some(core) = load_document("samples/exam_science.hwp") else {
+            return;
+        };
+        let svg = core.render_page_svg_native(1).unwrap_or_default();
+        assert!(!svg.is_empty(), "exam_science 페이지 2 SVG 가 비어있음");
+
+        fn parse_attr_f64(s: &str, key: &str) -> Option<f64> {
+            let pat = format!("{}=\"", key);
+            let p = s.find(&pat)?;
+            let val_start = p + pat.len();
+            let rest = &s[val_start..];
+            let q = rest.find('"')?;
+            rest[..q].parse().ok()
+        }
+
+        // ㉠ 사각형: <rect ... width="62.98..." height="22.88" fill="#ffffff" stroke="#000000" .../>
+        let mut rect_y: Option<f64> = None;
+        for chunk in svg.split("<rect").skip(1) {
+            let end = chunk.find("/>").unwrap_or(chunk.len());
+            let attrs = &chunk[..end];
+            let w = parse_attr_f64(attrs, "width").unwrap_or(0.0);
+            let h = parse_attr_f64(attrs, "height").unwrap_or(0.0);
+            // ㉠ 사각형 식별: width≈63 (62.99±1) AND height≈22.88 (±0.5)
+            if (w - 62.99).abs() < 1.0 && (h - 22.88).abs() < 0.5
+                && attrs.contains("fill=\"#ffffff\"")
+                && attrs.contains("stroke=\"#000000\"")
+            {
+                let y = parse_attr_f64(attrs, "y").unwrap_or(0.0);
+                rect_y = Some(y);
+                break;
+            }
+        }
+        let rect_y = rect_y.expect(
+            "Task #624: ㉠ 사각형 (width≈63 height≈22.88 흰색 fill + 검정 stroke) 을 SVG 에서 찾지 못함",
+        );
+
+        // Line 2 baseline ≈ 247.68, line top ≈ 235.65, sheet 22.88
+        // 정상 범위: y ∈ [230, 240] (Line 2 영역)
+        // 회귀 범위: y ∈ [212, 218] (Line 1 영역)
+        assert!(
+            (230.0..=240.0).contains(&rect_y),
+            "Task #624: ㉠ 사각형 y={:.2} 가 Line 2 영역 [230, 240] 에 있어야 함. \
+             회귀 (Task #520 부분 회귀): y≈213.95 (Line 1 영역, 본문 '분자당 구성' 위 겹침). \
+             정정 (3 line fix): y≈235.65 (Line 2 영역, ' 이다.' 앞).",
+            rect_y
+        );
+    }
 }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1603,7 +1603,12 @@ impl LayoutEngine {
                                             _ => inner_area.x + line_margin,
                                         };
                                         if let Some(seg) = para.line_segs.get(target_line) {
-                                            tac_img_y = para_y_before_compose + hwpunit_to_px(seg.vertical_pos, self.dpi);
+                                            // [Task #520 / #624 복원] LineSeg.vertical_pos 는 셀 origin 기준 절대값.
+                                            // para_y_before_compose 에 이미 ls[0].vpos 가 누적되어 있어
+                                            // 상대 오프셋(seg.vpos - ls[0].vpos)만 더해야 이중 합산을 피한다.
+                                            let first_vpos = para.line_segs.first().map(|f| f.vertical_pos).unwrap_or(0);
+                                            tac_img_y = para_y_before_compose
+                                                + hwpunit_to_px(seg.vertical_pos - first_vpos, self.dpi);
                                         }
                                     }
 
@@ -1806,13 +1811,16 @@ impl LayoutEngine {
                                     }
                                     prev_tac_text_pos = tac_pos;
                                 }
+                                // [Task #520 / #624 복원] target_line 기반 tac_img_y 사용 (Picture 분기와 동일).
+                                // para_y_before_compose 사용 시 multi-line paragraph 의 ls[1]+ inline TAC Shape 가
+                                // 항상 line 0 좌표에 떨어져 본문 텍스트와 겹친다 (exam_science p2 7번 글상자 ㉠).
                                 let shape_area = LayoutRect {
                                     x: inline_x,
-                                    y: para_y_before_compose,
+                                    y: tac_img_y,
                                     width: shape_w,
                                     height: inner_area.height,
                                 };
-                                self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, para_y_before_compose, Alignment::Left, styles, bin_data_content);
+                                self.layout_cell_shape(tree, &mut cell_node, shape, &shape_area, tac_img_y, Alignment::Left, styles, bin_data_content);
                                 inline_x += shape_w;
                             } else {
                                 self.layout_cell_shape(tree, &mut cell_node, shape, &inner_area, para_y, para_alignment, styles, bin_data_content);


### PR DESCRIPTION
## Summary

PR #561 cherry-pick (`3de0505`) 시 Task #520 의 일부 정정 누락 (3 라인) 회귀 복원.

**증상**: `samples/exam_science.hwp` page 2 의 7번 문제 글상자 (pi=33 ci=0, 1x1 Table) 안 p[1] 단락의 ㉠ 사각형 (`Control::Shape`, `treat_as_char=true`, ls[1] 위치) 이 Line 1 영역 (y=213.95) 에 잘못 그려져 본문 텍스트 "분자당 구성 …" 위에 겹침.

**정정 효과**: ㉠ 사각형 + ㉠ 텍스트 모두 Line 2 영역 (y=235.41 / 251.45) 으로 정확히 이동. Δ +21.47 px = ls[1].vpos − ls[0].vpos / 75 정확 일치.

## 회귀 출처 (`git diff 9dc40dd 3de0505`)

| 시점 | 커밋 | Picture tac_img_y | Shape tac_img_y | shape_area.y | layout_cell_shape para_y |
|---|---|---|---|---|---|
| Task #520 | `313e65d` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
| Task #544 v2 Stage 3 (원저자) | `9dc40dd` | `seg.vpos - first_vpos` ✓ | `seg.vpos - first_vpos` ✓ | `tac_img_y` ✓ | `tac_img_y` ✓ |
| **PR #561 cherry-pick** | **`3de0505`** | **`seg.vpos` ✗ (회귀)** | `seg.vpos - first_vpos` ✓ | **`para_y_before_compose` ✗ (회귀)** | **`para_y_before_compose` ✗ (회귀)** |

원저자 `9dc40dd` 는 Task #520 fix 유지 + Task #548 추가, PR #561 cherry-pick 메인테이너 정리 단계에서 conflict resolution 누락 추정.

## 정정 내용

`src/renderer/layout/table_layout.rs` 3 라인 정정 (+9/-2):

1. **Picture 분기 `tac_img_y` 산식** — `seg.vpos` → `seg.vpos - first_vpos` (이중 합산 회귀 해소)
2. **Shape 분기 `shape_area.y`** — `para_y_before_compose` → `tac_img_y` (target_line 기반 위치)
3. **Shape 분기 `layout_cell_shape` para_y 인자** — 동일

## 회귀 발생 4 조건 분석

`Control::Shape(shape) if shape.common().treat_as_char` 분기에서 다음 4 조건 모두 성립 시 회귀 가시화:

| 조건 | exam_science p[1] | 다른 5 multi-line + tac rect 케이스 |
|---|---|---|
| (a) cell 안 paragraph | ✓ | ✓ |
| (b) multi-line | ✓ (2) | ✓ (2~10) |
| (c) `target_line > 0` (rect on ls[1]+) | ✓ | varies |
| (d) `first_vpos > 0` (paragraph[i>0]) | **✓ (1610)** | **✗ (모두 0)** |
| **회귀 가시화** | **YES** | **NO** |

→ exam_science p[1] 만이 (c) AND (d) 동시 성립 — 광범위 sweep 결과 (1/1496) 와 정확히 부합.

## 안전성 분석 (edge cases)

| 케이스 | 정정 후 동작 | 사유 |
|---|---|---|
| `first_vpos = 0` (cell 첫 paragraph) | 동일 동작 보장 | `seg.vpos - 0 = seg.vpos`, 산식 결과 동일 |
| `target_line = 0` (rect on ls[0]) | 동일 동작 보장 | `target_line > current_tac_line` 가드로 if 블록 미진입 |
| `line_segs.len() = 1` (single-line) | 동일 동작 보장 | `target_line = 0` 으로 위와 동일 |
| `wrap = Square / InFrontOfText / TopAndBottom` | 본 분기 영향 없음 | `treat_as_char=true` 만 처리 |

## 검증

| 항목 | 결과 |
|---|---|
| `cargo test --lib test_624_textbox_inline_shape_y_on_line2_p2_q7` | RED → **GREEN** |
| `cargo test --lib` (전체) | **1135 passed / 0 failed / 2 ignored** |
| `cargo test --test svg_snapshot` | **6/6 passed** |
| `cargo clippy --lib -- -D warnings` | **clean** |
| `cargo build --release` | **success** |

## 광범위 fixture sweep (158 fixture / 1,496 페이지)

| 카테고리 | 페이지 수 | 비율 |
|---|---|---|
| 의도된 정정 | 1 | 0.067% |
| **회귀** | **0** | **0%** |
| byte-identical | 1,495 | 99.933% |

**의도된 정정 1 건** (`samples/exam_science.hwp` page 2):

```diff
-<rect x="117.066" y="213.946" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
-<text x="141.56"  y="229.986" ...>㉠</text>
+<rect x="117.066" y="235.413" width="62.986" height="22.880" fill="#ffffff" stroke="#000000" stroke-width="0.5"/>
+<text x="141.56"  y="251.453" ...>㉠</text>
```

## TDD 흐름

| Stage | 커밋 | 내용 |
|---|---|---|
| 0 | `b3408fe` | 수행 계획서 + 구현 계획서 |
| 1 | `e5811c9` | TDD RED 통합 테스트 (`test_624_textbox_inline_shape_y_on_line2_p2_q7`) — y=213.95 회귀 재현 |
| 2 (분석) | `c30e886` | 영향 범위 분석 + edge case 검증 + 후속 권고 |
| 2 (정정) | `242955b` | Task #520 부분 회귀 정정 (3 line) |
| 3 | `9cf9fc5` | 광범위 sweep + 최종 보고서 + orders 갱신 |

## Test plan

- [ ] cargo test --lib 1135 passed (회귀 0)
- [ ] cargo test --lib test_624_textbox_inline_shape_y_on_line2_p2_q7 GREEN
- [ ] cargo test --test svg_snapshot 6/6 passed
- [ ] cargo clippy --lib -- -D warnings clean
- [ ] 시각 판정: `output/svg/` 의 `exam_science_002.svg` ㉠ 사각형이 Line 2 영역 (y≈235) 에 위치, 본문 "분자당 구성" 위 겹침 해소

## 참조

- closes #624
- 회귀 출처: PR #561 cherry-pick (`3de0505`)
- 원저자 commit: `9dc40dd` (@planet6897 / Jaeook Ryu)
- 본질 commit: Task #520 (`313e65d`)
- 인접 task: Task #495 (text_before 추출 multi-line 가드), Task #500 (Picture target_line 도입), Task #548 (cell inline TAC Shape margin_left + indent)

## 후속 권고

1. **PR cherry-pick 시 base diff 자동 점검**: 본 결함은 `9dc40dd → 3de0505` 비교만으로 즉시 식별 가능. 동일 함수 영역 산식 비교 자동화 권고.
2. **회귀 테스트 가드**: 본 PR 의 `test_624_textbox_inline_shape_y_on_line2_p2_q7` 가 RED → GREEN 가드 역할.

🤖 Generated with [Claude Code](https://claude.com/claude-code)