### PR TITLE
Task #628: nested cell inline_shape_positions 키 충돌 정정 — 글상자 안 이미지 미렌더링

### DIFF
--- a/mydocs/orders/20260506.md
+++ b/mydocs/orders/20260506.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 5월 6일
+
+## M100 — v1.0.0 조판 엔진 (버그 픽스)
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **#628** | exam_science.hwp 20번 글상자 안 이미지 미렌더링 — `inline_shape_positions` 키 충돌 (셀 경로 미반영) | **진행 중 (PR 등록)** | 작업지시자 보고 "exam_science.hwp 20번 문제 글상자 안 이미지 안보임". 분석 결과 `PageRenderTree.inline_shape_positions` 의 키 `(section, para, control)` 가 (1) 섹션 단위 paragraph 인덱스 (2) 셀 내부 paragraph 인덱스(`cp_idx`) 두 컨텍스트에서 동일 namespace 공유 → stale value 가 `already_rendered_inline=true` 오판 → `table_layout.rs:1900` 분기에서 `layout_table` 재귀 호출 스킵 → double-nested 표(외부 1x1 → 내부 2x3) 안의 그림 `bin_id=2` 미렌더. 19번(단일 nesting) 정상 / 20번(이중 nesting) 누락 비대칭으로 confirmed. **근본 수정**: 키에 `cell_path: Vec<(ctrl_idx, cell_idx, cell_para_idx)>` 추가, 섹션 단위는 빈 Vec, 셀 단위는 nesting 경로 전체. `set/get_inline_shape_position` 시그니처에 `cell_ctx: Option<&CellContext>` 추가. 호출처 13곳 일괄 패치. 검증: page 4 — 4개 이미지 모두 렌더 (이전 3개) / exam_eng·math·kor·social SVG **byte-identical** (회귀 0) / `cargo test --release` 1134 GREEN. base = upstream/devel. 수행계획서: `mydocs/plans/task_m100_628.md`. |

--- a/mydocs/plans/task_m100_628.md
+++ b/mydocs/plans/task_m100_628.md
@@ -1,0 +1,44 @@
+# Task #628: 글상자 안 이미지 미렌더링 — `inline_shape_positions` 키 충돌 정정 — 수행계획서
+
+## 배경
+
+작업지시자 보고: `samples/exam_science.hwp` 페이지 4 (20번 문항) 글상자 내부 실린더 이미지가 SVG 출력에서 보이지 않음.
+
+같은 페이지 19번 문항의 동일 형태 이미지(`bin_id=1`)는 정상 렌더링되며, **표 nesting 깊이 차이**가 비대칭의 원인으로 의심.
+
+| 문항 | 표 nesting | 이미지 |
+|---|---|---|
+| 19번 (pi=119) | 2x3 표 → 셀 → 그림 (1단) | ✅ 렌더 |
+| 20번 (pi=127) | **1x1 → 셀 → 2x3 → 셀 → 그림 (2단)** | ❌ 누락 |
+
+## 목표
+
+double-nested 표 안의 floating 이미지가 정상 렌더링되도록 근본 정정.
+
+## 본질
+
+`PageRenderTree.inline_shape_positions` 의 키가 `(section, para, control)` 인데, `para` 가 두 가지 의미로 혼용됨:
+
+1. `paragraph_layout` 호출 시 → 섹션 단위 paragraph 인덱스
+2. `layout_table` → 셀 paragraph 호출 시 → 셀 내부 paragraph 인덱스 (`cp_idx`)
+
+서로 다른 셀 컨텍스트가 동일 키 `(0, 0, 1)` 등을 공유하여 stale value 가 `already_rendered_inline=true` 오판을 유발 → `table_layout.rs:1900` 분기에서 `layout_table` 재귀 호출이 스킵 → 내부 표 + 그 안의 그림 미렌더.
+
+## 단계
+
+1. **분석** — IR dump + SVG 비교 + 트레이스로 키 충돌 확인
+2. **수정** — `inline_shape_positions` 키에 `cell_path` 추가, 호출처 13곳 패치
+3. **검증** — 타겟 샘플 + 4개 시험지 회귀 sweep + 단위 테스트
+
+## 검증 게이트
+
+- exam_science page 4: 이미지 4개 모두 렌더 (이전 3개)
+- exam_eng·math·kor·social: SVG byte-identical (회귀 0)
+- `cargo test --release`: 1134+ 전체 GREEN
+- clippy 신규 경고 0 (기존 `table_ops.rs`/`object_ops.rs` 의 panic-on-unwrap 경고 2건은 사전 존재, 본 변경과 무관)
+
+## 브랜치
+
+- base: `upstream/devel` (`9b490634`)
+- task: `local/task628`
+- PR: `pr-task628` (fork branch, base=devel)

--- a/mydocs/plans/task_m100_628_impl.md
+++ b/mydocs/plans/task_m100_628_impl.md
@@ -1,0 +1,79 @@
+# Task #628: 구현계획서
+
+## 키 타입 변경
+
+```rust
+// 기존
+inline_shape_positions: HashMap<(usize, usize, usize), (f64, f64)>
+
+// 신규
+pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
+//                          section, para, control, cell_path
+inline_shape_positions: HashMap<InlineShapeKey, (f64, f64)>
+```
+
+`cell_path` 는 외→내 nesting 순서로 `(control_index, cell_index, cell_para_index)` 튜플 목록. 섹션 단위 호출은 빈 Vec.
+
+## API 변경
+
+```rust
+pub fn set_inline_shape_position(
+    &mut self,
+    sec: usize, para: usize, ctrl: usize,
+    cell_ctx: Option<&CellContext>,    // ← 신규
+    x: f64, y: f64,
+)
+
+pub fn get_inline_shape_position(
+    &self,
+    sec: usize, para: usize, ctrl: usize,
+    cell_ctx: Option<&CellContext>,    // ← 신규
+) -> Option<(f64, f64)>
+```
+
+내부에서 `cell_ctx.path` → `Vec<(ctrl_idx, cell_idx, cell_para_idx)>` 로 변환하여 키 구성.
+
+## 호출처 패치 (13곳)
+
+### 셀 컨텍스트 (`cell_context` / `cell_ctx` 전달)
+
+| 파일 | 라인 | 호출 |
+|---|---|---|
+| `paragraph_layout.rs` | 1849 | set Shape inline (run_tacs 경로) |
+| `paragraph_layout.rs` | 1906 | set Equation inline (run_tacs 경로) |
+| `paragraph_layout.rs` | 1926 | set Table inline (run_tacs 경로) |
+| `paragraph_layout.rs` | 2183 | set Shape inline (empty-runs 경로) |
+| `paragraph_layout.rs` | 2225 | set Picture inline (empty-runs 경로) |
+| `paragraph_layout.rs` | 2342 | set Equation inline (Task #287 분기) |
+| `table_layout.rs` | 1831 | get Equation dedup |
+| `table_layout.rs` | 1897 | get Table dedup ← **본 결함 진입점** |
+| `table_partial.rs` | 768 | get Equation dedup (분할 표 경로) |
+
+### 섹션 단위 (`None` 전달)
+
+| 파일 | 라인 | 호출 |
+|---|---|---|
+| `layout.rs` | 2292 | get Table inline (paginator) |
+| `layout.rs` | 2538 | get Table inline (paragraph 흐름) |
+| `layout.rs` | 2825 | get Picture dedup |
+| `layout.rs` | 2877 | set Picture inline |
+| `shape_layout.rs` | 135 | get Equation dedup |
+| `shape_layout.rs` | 219 | get Shape inline |
+| `cursor_rect.rs` | 180 | get hit-test |
+
+### hit-test 루프 (`cursor_rect.rs:532`)
+
+`inline_shape_positions()` iterate 시 `cell_path.is_empty()` 가드 추가 — 셀 내부 inline shape 은 hit-test 에서 별외 (섹션 단위만 검사).
+
+## 검증
+
+1. exam_science page 4 SVG 재생성 → 이미지 4개 확인
+2. exam_eng/math/kor/social 4개 샘플 sweep → byte-identical
+3. `cargo test --release` 전체 통과
+4. clippy 신규 경고 없음
+
+## 회귀 위험 평가
+
+- **낮음**: 키 namespace 분리만 수행 (값/계산 로직 무변경)
+- 섹션 단위 호출(`None` 전달)은 기존 `(sec, para, ctrl, [])` 와 동등 → 기존 동작 유지
+- 셀 단위 호출(`Some(ctx)` 전달)은 기존 stale-key 충돌 차단 → 의도된 변화만

--- a/mydocs/report/task_m100_628_report.md
+++ b/mydocs/report/task_m100_628_report.md
@@ -1,0 +1,97 @@
+# Task #628 최종 보고서: 글상자 안 이미지 미렌더링 — `inline_shape_positions` 키 충돌 정정
+
+## 결함
+
+`samples/exam_science.hwp` 페이지 4 (20번 문항) 글상자 안 실린더 이미지 (`bin_id=2`, 99.7×26.9mm) 가 SVG 출력에서 누락. 같은 페이지 19번 문항의 동일 형태 이미지 (`bin_id=1`) 는 정상 렌더링.
+
+## 근본 원인
+
+`PageRenderTree.inline_shape_positions` 의 키 `(section, para, control)` 에서 `para` 가 **두 가지 의미로 혼용**:
+
+1. `paragraph_layout` 호출 시 → 섹션 단위 paragraph 인덱스
+2. `layout_table` → 셀 paragraph 호출 시 → 셀 내부 paragraph 인덱스 (`cp_idx`)
+
+서로 다른 셀 컨텍스트가 동일 키 namespace 를 공유하여 `(0, 0, 1)` 등의 키가 충돌. 다른 paragraph 의 double-nested 셀 처리가 `(0, 0, 1)` 을 점유 → 20번 외부 1x1 표 처리 시 stale 값을 보고 `already_rendered_inline=true` 오판 → `table_layout.rs:1900` 분기에서 내부 2x3 표의 `layout_table` 재귀 호출이 스킵 → 그 안의 그림 미렌더.
+
+19번(단일 nesting)은 영향 없음, 20번(이중 nesting)만 발현.
+
+## 수정
+
+`inline_shape_positions` 키에 `cell_path` 추가:
+
+```rust
+pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
+//                          section, para, control, cell_path
+```
+
+`cell_path` = 외→내 nesting 순서의 `(control_index, cell_index, cell_para_index)` 튜플 목록. 섹션 단위 호출은 빈 Vec, 셀 단위 호출은 `CellContext.path` 전체를 변환.
+
+`set/get_inline_shape_position` 시그니처에 `cell_ctx: Option<&CellContext>` 추가, 호출처 13곳 일괄 패치:
+
+| 컨텍스트 | 호출 수 | 파일 |
+|---|---|---|
+| 셀 단위 (`cell_ctx` 전달) | 9 | paragraph_layout.rs (6) + table_layout.rs (2) + table_partial.rs (1) |
+| 섹션 단위 (`None` 전달) | 7 | layout.rs (4) + shape_layout.rs (2) + cursor_rect.rs (1) |
+
+`cursor_rect.rs:532` 의 hit-test 루프는 `cell_path.is_empty()` 가드 추가 (셀 내부 inline shape 은 별도 처리, 섹션 단위만 검사).
+
+## 변경 통계
+
+```
+ src/document_core/queries/cursor_rect.rs |  6 ++--
+ src/renderer/layout.rs                   |  8 ++---
+ src/renderer/layout/paragraph_layout.rs  | 12 +++----
+ src/renderer/layout/shape_layout.rs      |  4 +--
+ src/renderer/layout/table_layout.rs      |  4 +--
+ src/renderer/layout/table_partial.rs     |  2 +-
+ src/renderer/render_tree.rs              | 54 ++++++++++++++++++++++++-------
+ 7 files changed, 62 insertions(+), 28 deletions(-)
+```
+
+## 검증
+
+### 타겟 결함 해결
+
+| 페이지 | 이전 | 수정 후 |
+|---|---|---|
+| exam_science page 4 | 3 images | **4 images** ✓ |
+
+20번 이미지 위치 검증:
+- `x=568, y=783.92` (외부 1x1 표 영역 y=770.71~1071.91 내부)
+- `width=376.65 height=101.81` = 99.7×26.9mm (HWPUNIT IR 정확 매칭)
+
+### 회귀 sweep (5 샘플 56 페이지)
+
+| 샘플 | 페이지 | 이미지 수 | SVG diff |
+|---|---|---|---|
+| exam_eng | 8 | 14 | byte-identical |
+| exam_math | 20 | 9 | byte-identical |
+| exam_kor | 20 | 49 | byte-identical |
+| exam_social | 4 | 7 | byte-identical |
+| exam_science page 1-3 | 3 | 16 | byte-identical |
+| exam_science page 4 | 1 | **3 → 4** | 의도된 +1 |
+
+회귀 0건.
+
+### 단위 테스트
+
+```
+cargo test --release: 1134+ passed, 0 failed
+```
+
+### Clippy
+
+신규 경고 0. 사전 존재 경고 2건 (`table_ops.rs:1007`, `object_ops.rs:298` 의 panic-on-unwrap) 은 base branch 에서 동일 발생, 본 변경 영향 없음.
+
+## 회귀 위험 평가
+
+- **낮음** — 키 namespace 분리만 수행, 값/계산 로직 무변경
+- 섹션 단위 호출은 기존 `(sec, para, ctrl, [])` 와 동등 → 기존 동작 유지
+- 셀 단위 호출은 stale-key 충돌 차단 → 의도된 변화만 (20번 이미지 +1)
+- 5 샘플 56 페이지 byte-identical 결과로 잠재 회귀 영역 부재 확인
+
+## 브랜치 / PR
+
+- base: `upstream/devel` (`9b490634`)
+- task: `local/task628`
+- PR: 등록 예정 (`pr-task628`, base=devel)

--- a/mydocs/working/task_m100_628_stage1.md
+++ b/mydocs/working/task_m100_628_stage1.md
@@ -1,0 +1,113 @@
+# Task #628 Stage 1: 분석
+
+## IR 구조 비교
+
+### 19번 문항 (pi=119, 정상)
+
+```
+--- 문단 0.119 --- ctrls=1
+[0] 표: 2행×3열 treat_as_char=true
+    셀[0] (rs=1, cs=3) paras=1
+      p[0] ctrls=1
+        ctrl[0] 그림: bin_id=1, w=28300 h=5872 (99.8×20.7mm), tac=false, wrap=TopAndBottom
+```
+
+표 nesting: **1단** (paragraph → 2x3 표 → 셀 → 그림)
+
+### 20번 문항 (pi=127, 결함)
+
+```
+--- 문단 0.127 --- ctrls=1
+[0] 표: 1행×1열 treat_as_char=true     ← 외부 글상자 1x1 wrapper
+    셀[0] paras=4
+      p[0] ctrls=2
+        ctrl[0] (Other)
+        ctrl[1] 표: 2행×3열 tac=true   ← 내부 표
+          셀[0] (rs=1, cs=3) paras=1
+            p[0] ctrls=1
+              ctrl[0] 그림: bin_id=2, w=28249 h=7636 (99.7×26.9mm), tac=false, wrap=TopAndBottom
+      p[1] "◦ 의 질량은 (가)에서가 (다)에서의 배이다."
+      p[2] "◦ 실린더 속 기체의 단위 부피당 원자 수는 (나)에서"
+      p[3] "◦ 전체 원자 수는 (가)에서가 (다)에서의 배이다."
+```
+
+표 nesting: **2단** (paragraph → 1x1 → 셀 → 2x3 → 셀 → 그림)
+
+→ 외부 1x1 wrapper 가 **글상자** 역할 (이미지 + 캡션 (가)/(나)/(다) + 관찰 bullet 통합 박스)
+
+## SVG 출력 비교 (수정 전)
+
+```
+<image x=279.68 y=1003.39 width=57.28  height=56.32  ...>  ← 작은 인라인 1
+<image x=426.59 y=1003.39 width=59.52  height=57.6   ...>  ← 작은 인라인 2
+<image x=560.45 y=415.48  width=377.33 height=78.29  ...>  ← bin_id=1 (19번)
+                                                             ← bin_id=2 누락!
+```
+
+높이 78.29 px = 20.7 mm × 96/25.4 → 19번(`bin_id=1`) 매칭. 20번(`bin_id=2`, 26.9mm = 101.8 px) 은 SVG 에 없음.
+
+## 트레이스로 confirm
+
+`Control::Picture` 매치 진입 트레이스 (`depth, cp_idx, ctrl_idx, bin_id`):
+
+```
+[TRACE_PIC] depth=0 cp_idx=0 ctrl_idx=0 bin_id=3       ← 작은 1
+[TRACE_PIC] depth=0 cp_idx=0 ctrl_idx=0 bin_id=4       ← 작은 2
+[TRACE_PIC] depth=0 cp_idx=0 ctrl_idx=0 bin_id=1       ← 19번 ✓
+                                                         ← 20번 (bin_id=2) 누락!
+```
+
+20번 그림은 Picture 처리 분기에 **도달조차 못함** → 그 위에 있는 내부 2x3 표 자체가 미렌더 의심.
+
+## `layout_table` 호출 트레이스
+
+```
+[TRACE_TBL] enter depth=0 table=2x3 tac=true y_start=413.60   ← 19번 내부 표
+[TRACE_PIC] depth=0 cp_idx=0 ctrl_idx=0 bin_id=1               ← 19번 그림 ✓
+
+[TRACE_TBL] enter depth=0 table=1x1 tac=true y_start=770.71   ← 20번 외부 1x1
+                                                                 ← 내부 2x3 호출 누락!
+[TRACE_TBL] enter depth=0 table=1x10 tac=true y_start=1119.11 ← 다음 paragraph (pi=129)
+```
+
+20번 외부 1x1 → 내부 2x3 의 `layout_table(depth=1)` 재귀 호출이 발생하지 않음.
+
+## `Control::Table(nested_table)` 분기 트레이스
+
+`table_layout.rs:1893` 의 `already_rendered_inline` 체크:
+
+```
+[TRACE_NESTED] depth=0 cp_idx=15 ctrl_idx=0 is_tac=true already_rendered_inline=false  table=2x3   ← 19번 ✓
+[TRACE_NESTED] depth=0 cp_idx=0  ctrl_idx=1 is_tac=true already_rendered_inline=true   table=2x3   ← 20번 ✗
+```
+
+→ 20번은 `already_rendered_inline=true` 로 판정되어 `layout_table` 호출이 스킵됨 (`inline_x += tac_w` 만 수행).
+
+## `set_inline_shape_position(0, 0, 1, ...)` 백트레이스
+
+`already_rendered_inline=true` 의 원인은 **누가 `(sec=0, para=0, ctrl=1)` 키를 미리 등록**했기 때문. 백트레이스 캡처:
+
+```
+[TRACE_SETINL] sec=0 para=0 ctrl=1 x=269.11 y=633.62
+   2: PageRenderTree::set_inline_shape_position
+   3: layout_composed_paragraph         ← inner cell paragraph 의 inline TAC 표 등록
+   4: layout_table_cells                 ← inner table 처리
+   5: layout_table                        ← inner table (depth=1)
+   6: layout_table_cells                 ← outer table 처리
+   7: layout_table                        ← outer table (depth=0)
+```
+
+다른 paragraph 의 double-nested 셀 처리가 `(0, 0, 1)` 키를 점유 → 20번 외부 1x1 처리 시 stale 값을 보고 오판.
+
+## 근본 원인
+
+`PageRenderTree.inline_shape_positions` 의 키 `(section, para, control)` 에서 `para` 가 **두 가지 의미로 혼용**:
+
+1. `paragraph_layout` 호출 시 → 섹션 단위 paragraph 인덱스 (예: 119, 127)
+2. `layout_table` → 셀 paragraph 호출 시 → 셀 내부 paragraph 인덱스 (`cp_idx`, 보통 0)
+
+→ 서로 다른 셀 컨텍스트가 동일 키 namespace 를 공유하여 충돌.
+
+## 결론
+
+키에 `cell_path` 를 추가해 namespace 분리해야 함.

--- a/mydocs/working/task_m100_628_stage2.md
+++ b/mydocs/working/task_m100_628_stage2.md
@@ -1,0 +1,130 @@
+# Task #628 Stage 2: 수정 + 검증
+
+## 수정 내용
+
+### `src/renderer/render_tree.rs`
+
+키 타입 신설:
+
+```rust
+pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
+//                          section, para, control, cell_path
+```
+
+`cell_path` 는 외→내 nesting 순서로 `(control_index, cell_index, cell_para_index)` 튜플 목록. 섹션 단위는 빈 Vec.
+
+`set/get_inline_shape_position` 시그니처에 `cell_ctx: Option<&CellContext>` 추가, 내부에서 `cell_ctx.path` → `cell_path` 변환:
+
+```rust
+fn cell_path_from_ctx(cell_ctx: Option<&CellContext>) -> Vec<(usize, usize, usize)> {
+    cell_ctx.map(|ctx| {
+        ctx.path.iter()
+            .map(|e| (e.control_index, e.cell_index, e.cell_para_index))
+            .collect()
+    }).unwrap_or_default()
+}
+```
+
+### 호출처 패치 (13곳)
+
+**셀 컨텍스트 (`cell_context` / `cell_ctx` 전달, 9곳)**:
+
+- `paragraph_layout.rs:1849, 1906, 1926, 2183, 2225, 2342` (set 6곳, run_tacs / empty-runs / Task #287 분기)
+- `table_layout.rs:1831, 1897` (get 2곳, dedup 체크)
+- `table_partial.rs:768` (get 1곳, 분할 표 경로)
+
+**섹션 단위 (`None` 전달, 4곳)**:
+
+- `layout.rs:2292, 2538, 2825, 2877` (paginator + 본문 흐름)
+- `shape_layout.rs:135, 219` (Equation/Shape dedup)
+- `cursor_rect.rs:180` (hit-test 단건 조회)
+
+**hit-test 루프 (`cursor_rect.rs:532`)**:
+
+```rust
+for (key, &(sx, sy)) in tree.inline_shape_positions() {
+    let (si, pi, ci, ref cell_path) = *key;
+    // 셀 내부 inline shape 은 cursor hit-test 에서 별도 처리 — 섹션 단위만 검사
+    if !cell_path.is_empty() { continue; }
+    ...
+}
+```
+
+## 검증
+
+### 타겟 결함 해결
+
+`./target/release/rhwp export-svg samples/exam_science.hwp -p 3` (page 4):
+
+```
+수정 전: 3 images
+<image x=279.68 y=1003.39 width=57.28  ...>
+<image x=426.59 y=1003.39 width=59.52  ...>
+<image x=560.45 y=415.48  width=377.33 ...>  ← 19번
+
+수정 후: 4 images
+<image x=279.68 y=1003.39 width=57.28  ...>
+<image x=426.59 y=1003.39 width=59.52  ...>
+<image x=560.45 y=415.48  width=377.33 height=78.29  ...>   ← 19번
+<image x=568.00 y=783.92  width=376.65 height=101.81 ...>   ← 20번 ✓ NEW
+```
+
+20번 이미지 위치 검증:
+- y=783.92 → 외부 1x1 표 영역 (y=770.71 ~ 1071.91) 내부 ✓
+- height=101.81 px = 26.9 mm × 96/25.4 ✓
+- width=376.65 px ≈ 99.7 mm × 96/25.4 ≈ 376.95 ✓
+
+### 회귀 sweep (4 시험지 샘플)
+
+수정 전후 SVG 직접 비교:
+
+```
+exam_eng:    8p 14imgs  diff_files=0   (byte-identical)
+exam_math:  20p  9imgs  diff_files=0   (byte-identical)
+exam_kor:   20p 49imgs  diff_files=0   (byte-identical)
+exam_social: 4p  7imgs  diff_files=0   (byte-identical)
+```
+
+### exam_science 페이지 1-3
+
+byte-identical (page 4 만 의도된 변화).
+
+### 단위 테스트
+
+```
+$ cargo test --release --lib
+test result: ok. 1134 passed; 0 failed; 2 ignored
+```
+
+전체 cargo test (workspace):
+```
+test result: ok. 1134 passed; ...
+test result: ok. 14 passed; ...
+test result: ok. 25 passed; ...
+... (다수)
+```
+
+모두 GREEN, failure 0.
+
+### Clippy
+
+```
+$ cargo clippy --release --lib
+error: this call to `unwrap()` will always panic
+    --> src/document_core/commands/table_ops.rs:1007
+error: this call to `unwrap()` will always panic
+    --> src/document_core/commands/object_ops.rs:298
+```
+
+**사전 존재 경고 2건** (base branch `upstream/devel` 에서 동일 발생, `git stash` + clippy 재실행으로 확인). 본 변경은 신규 경고 0.
+
+## 회귀 위험 평가
+
+- **낮음** — 키 namespace 분리만 수행, 값/계산 로직 무변경
+- 섹션 단위 호출(`None` 전달)은 기존 `(sec, para, ctrl, [])` 와 동등 → 기존 동작 유지
+- 셀 단위 호출(`Some(ctx)` 전달)은 기존 stale-key 충돌 차단 → 의도된 변화만 (20번 이미지 +1)
+- 4 샘플 byte-identical 결과로 잠재 회귀 영역 부재 확인
+
+## 다음 단계
+
+최종 보고서 작성 → 브랜치 push → PR 등록.

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -177,7 +177,7 @@ impl DocumentCore {
                         // inline_shape_positions에서 Shape 좌표 조회
                         let first_page = pages[0];
                         let tree = self.build_page_tree(first_page)?;
-                        if let Some((sx, sy)) = tree.get_inline_shape_position(section_idx, para_idx, ci) {
+                        if let Some((sx, sy)) = tree.get_inline_shape_position(section_idx, para_idx, ci, None) {
                             let shape_h = if let Some(Control::Shape(s)) = para.controls.get(ci) {
                                 crate::renderer::hwpunit_to_px(s.common().height as i32, crate::renderer::DEFAULT_DPI)
                             } else if let Some(Control::Picture(p)) = para.controls.get(ci) {
@@ -530,7 +530,9 @@ impl DocumentCore {
         // inline_shape_positions에 등록된 Shape의 bbox를 검사하여
         // 클릭 시 해당 Shape의 텍스트 위치(char_offset)를 반환
         for (key, &(sx, sy)) in tree.inline_shape_positions() {
-            let (si, pi, ci) = *key;
+            let (si, pi, ci, ref cell_path) = *key;
+            // 셀 내부 inline shape 은 cursor hit-test 에서 별도 처리 — 섹션 단위만 검사
+            if !cell_path.is_empty() { continue; }
             if let Some(section) = self.document.sections.get(si) {
                 if let Some(para) = section.paragraphs.get(pi) {
                     if let Some(ctrl) = para.controls.get(ci) {

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -2289,7 +2289,7 @@ impl LayoutEngine {
                 let tbl_is_square = matches!(t.common.text_wrap, crate::model::shape::TextWrap::Square);
                 // インラインTAC表: paragraph_layoutで計算された位置を使用
                 let inline_pos = if is_tac {
-                    tree.get_inline_shape_position(page_content.section_index, para_index, control_index)
+                    tree.get_inline_shape_position(page_content.section_index, para_index, control_index, None)
                 } else {
                     None
                 };
@@ -2536,7 +2536,7 @@ impl LayoutEngine {
                                 .unwrap_or(Alignment::Left);
                             // paragraph_layout에서 계산된 인라인 좌표 사용
                             let inline_pos = tree.get_inline_shape_position(
-                                page_content.section_index, para_index, ci);
+                                page_content.section_index, para_index, ci, None);
                             let (inline_x, inline_y) = if let Some((ix, iy)) = inline_pos {
                                 (Some(ix), iy)
                             } else {
@@ -2823,7 +2823,7 @@ impl LayoutEngine {
                         // 여기서 또 push 하면 이중 emit 이 된다. 등록된 경우 push 를 스킵하고
                         // result_y 만 갱신한다.
                         let already_registered = tree.get_inline_shape_position(
-                            page_content.section_index, para_index, control_index,
+                            page_content.section_index, para_index, control_index, None,
                         ).is_some();
                         if !has_real_text && !already_registered {
                             let bin_data_id = pic.image_attr.bin_data_id;
@@ -2875,7 +2875,7 @@ impl LayoutEngine {
                             }
                             // 후속 InFrontOfText 객체의 para_y 기준이 되도록 위치 등록
                             tree.set_inline_shape_position(
-                                page_content.section_index, para_index, control_index, pic_x, pic_y,
+                                page_content.section_index, para_index, control_index, None, pic_x, pic_y,
                             );
                             // [Task #462] LINE_SEG 의 lh+ls 를 advance 로 사용 — 이미지 박스
                             // 높이만 사용하면 leading + line_spacing 이 누락되어 다음 문단이

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1846,7 +1846,7 @@ impl LayoutEngine {
                                 let shape_h = hwpunit_to_px(common.height as i32, self.dpi);
                                 let shape_y = (y + baseline - shape_h).max(y);
                                 // 인라인 좌표 등록 → shape_layout.rs에서 이 Shape를 스킵
-                                tree.set_inline_shape_position(section_index, para_index, tac_ci, x, shape_y);
+                                tree.set_inline_shape_position(section_index, para_index, tac_ci, cell_ctx.as_ref(), x, shape_y);
                             }
                         }
                         // 인라인 수식: 직접 EquationNode로 렌더링
@@ -1903,7 +1903,7 @@ impl LayoutEngine {
                                 );
                                 line_node.children.push(eq_node);
                                 // 인라인 좌표 등록 → shape_layout에서 이 수식을 스킵
-                                tree.set_inline_shape_position(section_index, para_index, tac_ci, x, eq_y);
+                                tree.set_inline_shape_position(section_index, para_index, tac_ci, cell_ctx.as_ref(), x, eq_y);
                             }
                         }
                         // 인라인 TAC 표: 텍스트 흐름 위치에 직접 렌더링
@@ -1923,7 +1923,7 @@ impl LayoutEngine {
                                         Some(x), None, None,
                                     );
                                     // 스킵 마커 등록 (별도 Table PageItem에서 중복 렌더 방지)
-                                    tree.set_inline_shape_position(section_index, para_index, tac_ci, x, table_y);
+                                    tree.set_inline_shape_position(section_index, para_index, tac_ci, cell_ctx.as_ref(), x, table_y);
                                 }
                             }
                         }
@@ -2180,7 +2180,7 @@ impl LayoutEngine {
                                     let common = shape.common();
                                     let shape_h = hwpunit_to_px(common.height as i32, self.dpi);
                                     let shape_y = (y + baseline - shape_h).max(y);
-                                    tree.set_inline_shape_position(section_index, para_index, tac_ci, img_x, shape_y);
+                                    tree.set_inline_shape_position(section_index, para_index, tac_ci, cell_ctx.as_ref(), img_x, shape_y);
                                     img_x += tac_w;
                                     continue;
                                 }
@@ -2223,7 +2223,7 @@ impl LayoutEngine {
                                     // TAC Picture 직접 emit) 와 이중 렌더링되지 않도록 인라인 위치를
                                     // 등록한다. layout_shape_item 은 등록된 경우 push 를 스킵한다.
                                     tree.set_inline_shape_position(
-                                        section_index, para_index, tac_ci, img_x, img_y,
+                                        section_index, para_index, tac_ci, cell_ctx.as_ref(), img_x, img_y,
                                     );
                                     img_x += tac_w;
                                 }
@@ -2339,7 +2339,7 @@ impl LayoutEngine {
                                 BoundingBox::new(inline_x, eq_y, tac_w, eq_h),
                             );
                             line_node.children.push(eq_node);
-                            tree.set_inline_shape_position(section_index, para_index, tac_ci, inline_x, eq_y);
+                            tree.set_inline_shape_position(section_index, para_index, tac_ci, cell_ctx.as_ref(), inline_x, eq_y);
                             inline_x += tac_w;
                         }
                     }

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -132,7 +132,7 @@ impl LayoutEngine {
         // 수식 컨트롤 처리
         if let Control::Equation(eq) = ctrl {
             // 인라인 좌표가 등록되어 있으면 paragraph_layout에서 이미 렌더링됨 → 스킵
-            let inline_pos = tree.get_inline_shape_position(section_index, para_index, control_index);
+            let inline_pos = tree.get_inline_shape_position(section_index, para_index, control_index, None);
             if inline_pos.is_some() {
                 return;
             }
@@ -216,7 +216,7 @@ impl LayoutEngine {
 
         // 인라인 Shape: paragraph_layout에서 계산된 좌표가 있으면 사용
         let inline_pos = if common.treat_as_char {
-            tree.get_inline_shape_position(section_index, para_index, control_index)
+            tree.get_inline_shape_position(section_index, para_index, control_index, None)
         } else {
             None
         };

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1828,7 +1828,7 @@ impl LayoutEngine {
                             // 빈 runs 셀 + TAC 수식: paragraph_layout(Task #287 경로)이 이미
                             // 렌더 후 set_inline_shape_position 호출. 중복 emit 방지(Issue #301).
                             let already_rendered_inline = tree
-                                .get_inline_shape_position(section_index, cp_idx, ctrl_idx)
+                                .get_inline_shape_position(section_index, cp_idx, ctrl_idx, cell_context.as_ref())
                                 .is_some();
                             if has_text_in_para || already_rendered_inline {
                                 // paragraph_layout 경로에서 이미 렌더됨
@@ -1894,7 +1894,7 @@ impl LayoutEngine {
                                 // 인라인 TAC 표를 이미 렌더하고 set_inline_shape_position
                                 // 등록했다면 중복 emit 방지 (Equation 의 L1800 가드와 동일 패턴).
                                 let already_rendered_inline = tree
-                                    .get_inline_shape_position(section_index, cp_idx, ctrl_idx)
+                                    .get_inline_shape_position(section_index, cp_idx, ctrl_idx, cell_context.as_ref())
                                     .is_some();
                                 let tac_w = hwpunit_to_px(nested_table.common.width as i32, self.dpi);
                                 if already_rendered_inline {

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -765,7 +765,7 @@ impl LayoutEngine {
                                 // set_inline_shape_position 호출. 중복 emit 방지
                                 // (Issue #301 의 분할 표 경로 보강 — Task #318).
                                 let already_rendered_inline = tree
-                                    .get_inline_shape_position(section_index, cp_idx, ctrl_idx)
+                                    .get_inline_shape_position(section_index, cp_idx, ctrl_idx, cell_context_opt.as_ref())
                                     .is_some();
                                 if already_rendered_inline {
                                     inline_x += eq_w;

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -708,6 +708,13 @@ pub struct EquationNode {
     pub cell_para_index: Option<usize>,
 }
 
+/// 인라인 Shape 좌표 맵 키. 섹션 단위 + 셀 경로로 셀 내 paragraph/control
+/// 인덱스 충돌(예: 서로 다른 셀이 cp_idx=0 + ctrl_idx=N 동일)을 방지한다.
+///
+/// `cell_path` 는 외→내 nesting 순서로 `(control_index, cell_index, cell_para_index)`
+/// 튜플 목록. 섹션 단위(셀 외부)는 빈 Vec.
+pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
+
 /// 한 페이지의 렌더 트리
 #[derive(Debug, Clone, Serialize)]
 pub struct PageRenderTree {
@@ -716,9 +723,9 @@ pub struct PageRenderTree {
     /// 다음 노드 ID 카운터
     #[serde(skip)]
     next_id: NodeId,
-    /// 인라인 Shape 좌표 맵: (section, para, control) → (x, y)
+    /// 인라인 Shape 좌표 맵: (section, para, control, cell_path) → (x, y)
     #[serde(skip)]
-    inline_shape_positions: std::collections::HashMap<(usize, usize, usize), (f64, f64)>,
+    inline_shape_positions: std::collections::HashMap<InlineShapeKey, (f64, f64)>,
 }
 
 impl PageRenderTree {
@@ -737,18 +744,43 @@ impl PageRenderTree {
         Self { root, next_id: 1, inline_shape_positions: std::collections::HashMap::new() }
     }
 
-    /// 인라인 Shape 좌표 등록
-    pub fn set_inline_shape_position(&mut self, sec: usize, para: usize, ctrl: usize, x: f64, y: f64) {
-        self.inline_shape_positions.insert((sec, para, ctrl), (x, y));
+    /// `CellContext` 를 InlineShapeKey 의 cell_path 부분으로 변환.
+    fn cell_path_from_ctx(cell_ctx: Option<&crate::renderer::layout::CellContext>) -> Vec<(usize, usize, usize)> {
+        cell_ctx.map(|ctx| {
+            ctx.path.iter()
+                .map(|e| (e.control_index, e.cell_index, e.cell_para_index))
+                .collect()
+        }).unwrap_or_default()
     }
 
-    /// 인라인 Shape 좌표 조회
-    pub fn get_inline_shape_position(&self, sec: usize, para: usize, ctrl: usize) -> Option<(f64, f64)> {
-        self.inline_shape_positions.get(&(sec, para, ctrl)).copied()
+    /// 인라인 Shape 좌표 등록 (셀 컨텍스트 포함)
+    pub fn set_inline_shape_position(
+        &mut self,
+        sec: usize,
+        para: usize,
+        ctrl: usize,
+        cell_ctx: Option<&crate::renderer::layout::CellContext>,
+        x: f64,
+        y: f64,
+    ) {
+        let cell_path = Self::cell_path_from_ctx(cell_ctx);
+        self.inline_shape_positions.insert((sec, para, ctrl, cell_path), (x, y));
+    }
+
+    /// 인라인 Shape 좌표 조회 (셀 컨텍스트 포함)
+    pub fn get_inline_shape_position(
+        &self,
+        sec: usize,
+        para: usize,
+        ctrl: usize,
+        cell_ctx: Option<&crate::renderer::layout::CellContext>,
+    ) -> Option<(f64, f64)> {
+        let cell_path = Self::cell_path_from_ctx(cell_ctx);
+        self.inline_shape_positions.get(&(sec, para, ctrl, cell_path)).copied()
     }
 
     /// 인라인 Shape 좌표 전체 참조 (hitTest용)
-    pub fn inline_shape_positions(&self) -> &std::collections::HashMap<(usize, usize, usize), (f64, f64)> {
+    pub fn inline_shape_positions(&self) -> &std::collections::HashMap<InlineShapeKey, (f64, f64)> {
         &self.inline_shape_positions
     }
 


### PR DESCRIPTION
## Summary

- `samples/exam_science.hwp` 페이지 4 (20번 문항) 글상자 안 실린더 이미지(`bin_id=2`, 99.7×26.9mm) 미렌더링 결함 정정. 19번 (단일 nesting) 정상 / 20번 (이중 nesting: 외부 1x1 글상자 → 내부 2x3 표 → 셀 → 그림) 만 발현하던 비대칭의 근본 원인을 fix.
- `PageRenderTree.inline_shape_positions` 의 키 `(section, para, control)` 에 `cell_path` 차원을 추가하여 섹션 단위 vs 셀 단위 paragraph 인덱스 namespace 충돌 차단.

## 근본 원인

키의 `para` 가 두 가지 의미로 혼용됨:

1. `paragraph_layout` 호출 시 → 섹션 단위 paragraph 인덱스 (예: 119, 127)
2. `layout_table` → 셀 paragraph 호출 시 → 셀 내부 paragraph 인덱스 (`cp_idx`, 보통 0)

서로 다른 셀 컨텍스트가 동일 키 `(0, 0, 1)` 등을 공유 → 다른 paragraph 의 double-nested 셀 처리가 키를 미리 점유 → 20번 외부 1x1 표 처리 시 `already_rendered_inline=true` 오판 → `table_layout.rs:1900` 분기에서 내부 2x3 표의 `layout_table` 재귀 호출 스킵 → 그 안의 그림 미렌더.

## 수정

```rust
// 기존
inline_shape_positions: HashMap<(usize, usize, usize), (f64, f64)>

// 신규
pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>);
//                          section, para, control, cell_path
inline_shape_positions: HashMap<InlineShapeKey, (f64, f64)>
```

`cell_path` = 외→내 nesting 순서의 `(control_index, cell_index, cell_para_index)` 튜플 목록. 섹션 단위는 빈 Vec, 셀 단위는 `CellContext.path` 전체.

`set/get_inline_shape_position` 시그니처에 `cell_ctx: Option<&CellContext>` 추가, 호출처 13곳 일괄 패치 (셀 단위 9 + 섹션 단위 4). `cursor_rect.rs:532` 의 hit-test 루프에 `cell_path.is_empty()` 가드 추가.

## 변경 통계

```
 src/document_core/queries/cursor_rect.rs |  6 ++--
 src/renderer/layout.rs                   |  8 ++---
 src/renderer/layout/paragraph_layout.rs  | 12 +++----
 src/renderer/layout/shape_layout.rs      |  4 +--
 src/renderer/layout/table_layout.rs      |  4 +--
 src/renderer/layout/table_partial.rs     |  2 +-
 src/renderer/render_tree.rs              | 54 ++++++++++++++++++++++++-------
 7 files changed, 62 insertions(+), 28 deletions(-)
```

## 회귀 위험 평가

- **낮음** — 키 namespace 분리만 수행, 값/계산 로직 무변경
- 섹션 단위 호출(`None` 전달)은 기존 `(sec, para, ctrl, [])` 와 동등 → 기존 동작 유지
- 셀 단위 호출(`Some(ctx)` 전달)은 stale-key 충돌 차단 → 의도된 변화만 (20번 이미지 +1)

## Test plan

- [x] **타겟 결함 해결** — exam_science page 4: 3 → 4 images (20번 이미지 정상 위치 `x=568 y=783.92 width=376.65 height=101.81` = 99.7×26.9mm IR 정확 매칭)
- [x] **회귀 sweep 5 샘플 56 페이지** — exam_eng/math/kor/social + exam_science page 1-3: SVG byte-identical (회귀 0)
- [x] `cargo test --release --lib`: 1134 passed, 0 failed
- [x] `cargo test --release` (전체 workspace): 모두 GREEN
- [x] `cargo clippy --release --lib`: 신규 경고 0 (사전 존재 경고 2건 — `table_ops.rs:1007`, `object_ops.rs:298` 의 panic-on-unwrap — 은 base branch 동일 발생, 본 변경 무관)

closes #628

🤖 Generated with [Claude Code](https://claude.com/claude-code)