### PR TITLE
fix: hit_test_header_footer 영역이 본문 침범 정정 (closes #595)

### DIFF
--- a/examples/inspect_595.rs
+++ b/examples/inspect_595.rs
@@ -1,0 +1,174 @@
+//! Issue #595 진단 — exam_math.hwp page 별 hit_test_header_footer 영역 검증
+//!
+//! 본질 가설: page 2 (0-based 1) 의 본문 좌표 (654.5, 209.7) 가
+//! `wasm.hitTestHeaderFooter` 에서 머리말 hit 으로 인식됨.
+//!
+//! 본 진단은 다음을 확인한다:
+//! 1. 각 페이지의 Header / Footer 렌더 노드 bbox 직접 dump
+//! 2. y 좌표 sweep 으로 머리말로 hit 되는 y 범위 식별
+//!
+//! 실행: cargo run --release --example inspect_595
+
+use std::fs;
+
+fn main() {
+    let path = "samples/exam_math.hwp";
+    let data = fs::read(path).unwrap_or_else(|e| panic!("read {} failed: {}", path, e));
+    let core = rhwp::document_core::DocumentCore::from_bytes(&data).expect("parse");
+
+    println!("=== exam_math.hwp 의 hitTestHeaderFooter 영역 진단 ===\n");
+
+    // 페이지 0~3 의 Header / Footer hit 영역 sweep
+    for page in 0..4u32 {
+        println!("--- page {} (1-based={}) ---", page, page + 1);
+
+        // x 는 페이지 중앙 514 고정, y 를 50 단위로 sweep (페이지 높이 1489.1)
+        // Header 영역, 본문 영역, Footer 영역 모두 커버
+        let x = 514.0;
+        let mut header_hits: Vec<f64> = Vec::new();
+        let mut footer_hits: Vec<f64> = Vec::new();
+        for ystep in 0..30 {
+            let y = (ystep as f64) * 50.0;
+            match core.hit_test_header_footer_native(page, x, y) {
+                Ok(json) => {
+                    if json.contains("\"hit\":true") {
+                        if json.contains("\"isHeader\":true") {
+                            header_hits.push(y);
+                        } else {
+                            footer_hits.push(y);
+                        }
+                    }
+                }
+                Err(_) => {}
+            }
+        }
+        if !header_hits.is_empty() {
+            let min = header_hits.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max = header_hits.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            println!("  Header hit y 범위: {:.1} ~ {:.1}  (50px sweep)", min, max);
+            println!("    hit y 좌표: {:?}", header_hits);
+        } else {
+            println!("  Header hit 없음");
+        }
+        if !footer_hits.is_empty() {
+            let min = footer_hits.iter().cloned().fold(f64::INFINITY, f64::min);
+            let max = footer_hits.iter().cloned().fold(f64::NEG_INFINITY, f64::max);
+            println!("  Footer hit y 범위: {:.1} ~ {:.1}  (50px sweep)", min, max);
+        }
+
+        // 이슈 명세 좌표 직접 검증
+        if page == 1 {
+            // Page 2 (0-based 1) — paraIdx=65 ci=0 수식 영역 (589.5+65, 191.7+18) = (654.5, 209.7)
+            let r = core.hit_test_header_footer_native(page, 654.5, 209.7);
+            println!("  [이슈 명세 좌표] page {} (654.5, 209.7) -> {:?}", page, r);
+        }
+        if page == 0 {
+            // Page 1 (0-based 0) — paraIdx=18 ci=0 수식 영역 (180.8, 826.3)
+            let r = core.hit_test_header_footer_native(page, 180.8, 826.3);
+            println!("  [이슈 명세 좌표] page {} (180.8, 826.3) -> {:?}", page, r);
+        }
+        println!();
+    }
+
+    // Header / Footer 영역 정밀 sweep — 더 작은 step (10px) 으로 범위 좁히기
+    println!("\n=== Header hit y 범위 정밀 sweep (step=5px, x=514) ===");
+    for page in 0..4u32 {
+        let x = 514.0;
+        let mut header_min: Option<f64> = None;
+        let mut header_max: Option<f64> = None;
+        for ystep in 0..300 {
+            let y = (ystep as f64) * 5.0;
+            if let Ok(json) = core.hit_test_header_footer_native(page, x, y) {
+                if json.contains("\"hit\":true") && json.contains("\"isHeader\":true") {
+                    if header_min.is_none() { header_min = Some(y); }
+                    header_max = Some(y);
+                }
+            }
+        }
+        match (header_min, header_max) {
+            (Some(min), Some(max)) => {
+                println!("  page {}: Header hit y={:.1} ~ {:.1}  (실제 머리말 영역: 0~147)", page, min, max);
+            }
+            _ => println!("  page {}: Header hit 없음", page),
+        }
+    }
+
+    // x 도 sweep — page 1 (이슈 발현) 에 대해 (x, y=209.7) 으로 가로 sweep
+    println!("\n=== page 1 (0-based, 이슈 발현) y=209.7 가로 sweep (step=50px) ===");
+    let page = 1u32;
+    for xstep in 0..21 {
+        let x = (xstep as f64) * 50.0;
+        if let Ok(json) = core.hit_test_header_footer_native(page, x, 209.7) {
+            let mark = if json.contains("\"hit\":true") {
+                if json.contains("\"isHeader\":true") { " ← Header HIT" } else { " ← Footer HIT" }
+            } else { "" };
+            println!("  x={:5.1} y=209.7 → {}{}", x, json, mark);
+        }
+    }
+
+    // 광범위 sweep — samples/ 전체에서 머리말 본문 침범 페이지 식별
+    println!("\n=== 광범위 sweep — samples/ 전체에서 본문 영역까지 머리말 hit 되는 fixture/페이지 ===");
+    use std::path::Path;
+    let samples_dir = Path::new("samples");
+    let mut total_fixtures = 0usize;
+    let mut affected_fixtures = 0usize;
+    let mut total_pages = 0u32;
+    let mut affected_pages = 0u32;
+    let mut affected_summaries: Vec<String> = Vec::new();
+
+    let entries: Vec<_> = match fs::read_dir(samples_dir) {
+        Ok(rd) => rd.flatten().collect(),
+        Err(e) => { eprintln!("read_dir fail: {:?}", e); return; }
+    };
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for ent in entries {
+        let p = ent.path();
+        if p.is_file() {
+            let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext == "hwp" || ext == "hwpx" {
+                paths.push(p);
+            }
+        }
+    }
+    paths.sort();
+
+    for path in &paths {
+        let bytes = match fs::read(path) { Ok(b) => b, Err(_) => continue };
+        let core_r = rhwp::document_core::DocumentCore::from_bytes(&bytes);
+        let core_local = match core_r { Ok(c) => c, Err(_) => continue };
+        total_fixtures += 1;
+        // 각 페이지 하한 영역 (y=200, 800) 가 머리말 hit 인지 확인
+        let pc = core_local.page_count();
+        let mut fixture_affected_pages: Vec<u32> = Vec::new();
+        for page in 0..pc {
+            total_pages += 1;
+            let r1 = core_local.hit_test_header_footer_native(page, 514.0, 800.0);
+            if let Ok(j) = r1 {
+                if j.contains("\"hit\":true") && j.contains("\"isHeader\":true") {
+                    fixture_affected_pages.push(page);
+                    affected_pages += 1;
+                }
+            }
+        }
+        if !fixture_affected_pages.is_empty() {
+            affected_fixtures += 1;
+            let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("?");
+            let pages_str = if fixture_affected_pages.len() <= 5 {
+                format!("{:?}", fixture_affected_pages)
+            } else {
+                format!("[{}, ..., {}] ({}건)", fixture_affected_pages[0],
+                    fixture_affected_pages[fixture_affected_pages.len()-1],
+                    fixture_affected_pages.len())
+            };
+            affected_summaries.push(format!("  {} ({}/{}p): {}", name, fixture_affected_pages.len(), pc, pages_str));
+        }
+    }
+
+    println!("\n총 {} fixture / {} 페이지 점검", total_fixtures, total_pages);
+    println!("머리말 hit 본문 침범 fixture: {} / {} ({:.1}%)", affected_fixtures, total_fixtures, 100.0 * affected_fixtures as f64 / total_fixtures as f64);
+    println!("머리말 hit 본문 침범 페이지: {} / {} ({:.1}%)", affected_pages, total_pages, 100.0 * affected_pages as f64 / total_pages as f64);
+    println!("\n발현 fixture 목록:");
+    for line in &affected_summaries {
+        println!("{}", line);
+    }
+}

--- a/examples/inspect_595_regression.rs
+++ b/examples/inspect_595_regression.rs
@@ -1,0 +1,183 @@
+//! Issue #595 회귀 sweep — 정정 전/후 hit_test_header_footer 결과 비교
+//!
+//! 각 fixture / 각 페이지에서 다음 영역의 hit 결과를 측정:
+//! - **머리말 영역 중앙** — hit:true Header 보장 (기존 동작 보존)
+//! - **꼬리말 영역 중앙** — hit:true Footer 보장 (기존 동작 보존)
+//! - **본문 영역 중앙** — hit:false 보장 (정정 전 결함 → 정정 후 정상)
+//!
+//! 페이지의 머리말/꼬리말/본문 영역 좌표는 `getPageInfo` JSON 의 margin 정보로 계산.
+//!
+//! 실행:
+//!   cargo run --release --example inspect_595_regression > /tmp/595_after.txt
+//!   git stash -- src/document_core/queries/cursor_rect.rs
+//!   cargo run --release --example inspect_595_regression > /tmp/595_before.txt
+//!   git stash pop
+//!   diff /tmp/595_before.txt /tmp/595_after.txt
+
+use std::fs;
+
+#[derive(Default, Debug)]
+struct PageMargins {
+    page_width: f64,
+    page_height: f64,
+    margin_left: f64,
+    margin_right: f64,
+    margin_top: f64,
+    margin_bottom: f64,
+    margin_header: f64,
+    margin_footer: f64,
+}
+
+fn parse_f64(json: &str, key: &str) -> Option<f64> {
+    let needle = format!("\"{}\":", key);
+    let pos = json.find(&needle)?;
+    let after = &json[pos + needle.len()..];
+    let end = after.find(|c: char| c == ',' || c == '}')?;
+    after[..end].trim().parse::<f64>().ok()
+}
+
+fn parse_margins(json: &str) -> Option<PageMargins> {
+    Some(PageMargins {
+        page_width: parse_f64(json, "width")?,
+        page_height: parse_f64(json, "height")?,
+        margin_left: parse_f64(json, "marginLeft")?,
+        margin_right: parse_f64(json, "marginRight")?,
+        margin_top: parse_f64(json, "marginTop")?,
+        margin_bottom: parse_f64(json, "marginBottom")?,
+        margin_header: parse_f64(json, "marginHeader")?,
+        margin_footer: parse_f64(json, "marginFooter")?,
+    })
+}
+
+#[derive(Default)]
+struct Stats {
+    pages: u32,
+    header_hit_pass: u32,
+    header_hit_fail: u32,
+    footer_hit_pass: u32,
+    footer_hit_fail: u32,
+    body_no_hit_pass: u32,
+    body_no_hit_fail: u32,
+    failures: Vec<String>,
+}
+
+fn main() {
+    let samples_dir = std::path::Path::new("samples");
+    let entries: Vec<_> = match fs::read_dir(samples_dir) {
+        Ok(rd) => rd.flatten().collect(),
+        Err(e) => { eprintln!("read_dir fail: {:?}", e); return; }
+    };
+    let mut paths: Vec<std::path::PathBuf> = Vec::new();
+    for ent in entries {
+        let p = ent.path();
+        if p.is_file() {
+            let ext = p.extension().and_then(|e| e.to_str()).unwrap_or("");
+            if ext == "hwp" || ext == "hwpx" {
+                paths.push(p);
+            }
+        }
+    }
+    paths.sort();
+
+    let mut stats = Stats::default();
+    let mut total_fixtures = 0usize;
+
+    for path in &paths {
+        let bytes = match fs::read(path) { Ok(b) => b, Err(_) => continue };
+        let core = match rhwp::document_core::DocumentCore::from_bytes(&bytes) {
+            Ok(c) => c, Err(_) => continue
+        };
+        total_fixtures += 1;
+        let name = path.file_name().and_then(|s| s.to_str()).unwrap_or("?").to_string();
+
+        let pc = core.page_count();
+        for page in 0..pc {
+            stats.pages += 1;
+            let info_json = match core.get_page_info_native(page) { Ok(j) => j, Err(_) => continue };
+            let m = match parse_margins(&info_json) { Some(m) => m, None => continue };
+
+            // 머리말 영역 중앙: x=중앙, y=margin_top + margin_header/2
+            let header_x = m.page_width / 2.0;
+            let header_y = m.margin_top + m.margin_header / 2.0;
+
+            // 꼬리말 영역 중앙: x=중앙, y=page_height - margin_bottom - margin_footer/2
+            let footer_x = m.page_width / 2.0;
+            let footer_y = m.page_height - m.margin_bottom - m.margin_footer / 2.0;
+
+            // 본문 중앙: 페이지 정중앙 (확실히 본문 영역 안)
+            let body_x = m.page_width / 2.0;
+            let body_y = m.page_height / 2.0;
+
+            // 머리말 영역 hit 검증 (margin_header > 0 인 페이지만 — 정의된 머리말이 있는 경우)
+            if m.margin_header > 0.0 {
+                if let Ok(r) = core.hit_test_header_footer_native(page, header_x, header_y) {
+                    let hit = r.contains("\"hit\":true") && r.contains("\"isHeader\":true");
+                    if hit { stats.header_hit_pass += 1; }
+                    else {
+                        stats.header_hit_fail += 1;
+                        if stats.failures.len() < 30 {
+                            stats.failures.push(format!(
+                                "  [HEADER MISS] {} page {} ({:.1},{:.1}) margin_header={:.1}: {}",
+                                name, page, header_x, header_y, m.margin_header, r
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // 꼬리말 영역 hit 검증 (margin_footer > 0 인 페이지만)
+            if m.margin_footer > 0.0 {
+                if let Ok(r) = core.hit_test_header_footer_native(page, footer_x, footer_y) {
+                    let hit = r.contains("\"hit\":true") && r.contains("\"isHeader\":false");
+                    if hit { stats.footer_hit_pass += 1; }
+                    else {
+                        stats.footer_hit_fail += 1;
+                        if stats.failures.len() < 30 {
+                            stats.failures.push(format!(
+                                "  [FOOTER MISS] {} page {} ({:.1},{:.1}) margin_footer={:.1}: {}",
+                                name, page, footer_x, footer_y, m.margin_footer, r
+                            ));
+                        }
+                    }
+                }
+            }
+
+            // 본문 영역 hit 안 됨 검증
+            if let Ok(r) = core.hit_test_header_footer_native(page, body_x, body_y) {
+                let no_hit = r.contains("\"hit\":false");
+                if no_hit { stats.body_no_hit_pass += 1; }
+                else {
+                    stats.body_no_hit_fail += 1;
+                    if stats.failures.len() < 30 {
+                        stats.failures.push(format!(
+                            "  [BODY HIT — FALSE POSITIVE] {} page {} ({:.1},{:.1}): {}",
+                            name, page, body_x, body_y, r
+                        ));
+                    }
+                }
+            }
+        }
+    }
+
+    println!("=== Issue #595 회귀 sweep 결과 ===");
+    println!("총 fixture: {} / 총 페이지: {}", total_fixtures, stats.pages);
+    println!();
+    println!("[1] 머리말 영역 중앙 hit:true 보장 (기존 동작 보존)");
+    println!("    pass: {} / fail: {}", stats.header_hit_pass, stats.header_hit_fail);
+    println!();
+    println!("[2] 꼬리말 영역 중앙 hit:true 보장 (기존 동작 보존)");
+    println!("    pass: {} / fail: {}", stats.footer_hit_pass, stats.footer_hit_fail);
+    println!();
+    println!("[3] 본문 중앙 hit:false 보장 (Issue #595 결함 정정)");
+    println!("    pass: {} / fail: {}", stats.body_no_hit_pass, stats.body_no_hit_fail);
+    println!();
+
+    if !stats.failures.is_empty() {
+        println!("=== 실패 케이스 (최대 30건) ===");
+        for line in &stats.failures {
+            println!("{}", line);
+        }
+    } else {
+        println!("=== 모든 케이스 통과 ===");
+    }
+}

--- a/mydocs/plans/task_m100_595.md
+++ b/mydocs/plans/task_m100_595.md
@@ -1,0 +1,127 @@
+# Task #595 수행 계획서
+
+**Issue**: [#595](https://github.com/edwardkim/rhwp/issues/595) — exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작 — 1페이지만 정상
+**Milestone**: M100 (v1.0.0)
+**브랜치**: `local/task595`
+**진행자**: Claude (작업지시자: edwardkim)
+
+---
+
+## 1. 본질 (이슈 요약)
+
+`samples/exam_math.hwp` 의 수식 객체를 더블클릭했을 때 **1페이지(0-based 0)만 정상 동작**, **2페이지(0-based 1)부터 오동작**.
+
+오동작 시 `findPictureAtClick` 이 수식을 hit 으로 인식하지 못 하여 일반 텍스트 hitTest fallback 으로 진입 → 의도하지 않은 위치로 캐럿 이동.
+
+## 2. 정적 분석 결과 (사전 진단)
+
+### 2.1 Rust 측 정합 — `examples/inspect_595.rs` 결과
+
+```
+모든 페이지: width=1028.0, height=1489.1 (동일)
+모든 페이지의 머리말 표 y=1359.4 (동일)
+2페이지 paraIdx=65 ci=0 수식: bbox (589.5, 191.7) 131.7×37.3  ← 이슈 명세 정합
+```
+
+**결론**: `getPageControlLayout` 좌표는 페이지 내부 좌표 (0..1489.1) 이며 모든 페이지 일관 — Rust 측 데이터 무결.
+
+### 2.2 TS 측 좌표 변환식 — 이론상 정합
+
+```ts
+const pageIdx = virtualScroll.getPageAtY(contentY);
+const pageOffset = virtualScroll.getPageOffset(pageIdx);
+const pageX = (contentX - pageLeft) / zoom;
+const pageY = (contentY - pageOffset) / zoom;
+```
+
+`pageOffsets[i]` 는 zoom 적용 누적 (`pageGap=10 + Σ(pageHeights[j] * zoom + pageGap)`).
+`canvas.style.top = pageOffsets[i]` 로 동일 배열 사용 — 자체적으론 정합.
+
+### 2.3 정적 분석 한계
+
+- `findPictureAtClick` 본체는 단순 bbox 매칭 — equation 의 wrap 미존재로 behindCtrls 분기 비해당
+- 단 구분선 (line w=0.0) 도 distance 검사로만 hit, 클릭 좌표 거리 충분히 멀어 무관
+- 그러므로 **동적 환경에서만 발현되는 좌표 오차** 또는 **간접 진단 미커버 영역** 가능성
+
+## 3. 수행 목표
+
+본 task 의 1차 목표는 **본질 원인 정확 식별**. 정정 패치는 본질 확정 후 별도 task 또는 본 task의 후속 단계로 진행.
+
+진단 수단으로 **Puppeteer e2e 테스트 + 콘솔 캡처** 사용 (옵션 B).
+
+## 4. 진단 e2e 테스트 설계 (`rhwp-studio/e2e/issue-595.test.mjs`)
+
+### 4.1 시나리오
+
+1. `samples/exam_math.hwp` 로드
+2. **page 1 (0-based 0)** 의 수식 영역 클릭 — 정상 동작 baseline (수식 paraIdx=18 ci=0 또는 ci=1, x=130.8 y=818.3 / x=307.8 y=811.3 등 사용)
+3. **page 2 (0-based 1)** 의 수식 영역 클릭 — 결함 재현 (paraIdx=65 ci=0, x=589.5 y=191.7 w=131.7 h=37.3)
+4. 각 클릭 직후 다음을 콘솔/페이지 상태로 캡처:
+   - `pageIdx`, `pageX`, `pageY`, `pageOffset`, `contentY`, `zoom`
+   - `wasm.getPageControlLayout(pageIdx).controls.length` + 첫 5개 ctrl bbox 요약
+   - `findPictureAtClick(pageIdx, pageX, pageY)` 직접 호출 결과
+   - `cursor.isInPictureObjectSelection()` 상태
+5. 두 케이스의 데이터를 비교하여 **page 1 정상 / page 2 fail 의 분기점** 식별
+
+### 4.2 진단 hook 설계 (TS 코드 영구 수정 없음)
+
+본질 정정 전 단계이므로 TS 측에 **임시 디버그 콘솔 로그를 영구 삽입하지 않는다**.
+
+대신 e2e 테스트 내부에서 `page.evaluate()` 로 다음을 직접 호출:
+
+```js
+const diag = await page.evaluate(({ contentX, contentY }) => {
+  const inputHandler = window.__inputHandler;
+  const virtualScroll = window.__canvasView.virtualScroll;  // expose 필요할 수 있음
+  const wasm = window.__wasm;
+  const zoom = window.__viewportManager.getZoom();
+  const sc = document.querySelector('#scroll-content');
+  const cr = sc.getBoundingClientRect();
+  const cy = contentY - cr.top;
+  const cx = contentX - cr.left;
+  const pageIdx = virtualScroll.getPageAtY(cy);
+  const pageOffset = virtualScroll.getPageOffset(pageIdx);
+  const pageDisplayWidth = virtualScroll.getPageWidth(pageIdx);
+  const pageLeft = (sc.clientWidth - pageDisplayWidth) / 2;
+  const pageX = (cx - pageLeft) / zoom;
+  const pageY = (cy - pageOffset) / zoom;
+  const layout = JSON.parse(wasm.getPageControlLayout(pageIdx));
+  const picHit = inputHandler.findPictureAtClick(pageIdx, pageX, pageY);
+  return { pageIdx, pageX, pageY, pageOffset, cx, cy, zoom, controlsCount: layout.controls.length, picHit, sampleCtrls: layout.controls.slice(0, 5) };
+}, { contentX, contentY });
+```
+
+만약 `window.__canvasView.virtualScroll` 가 expose 안 되어 있으면 진단 hook 노출이 필요할 수 있음 — 그 영역은 진단 후 결정.
+
+### 4.3 결과 포맷
+
+콘솔 출력 + screenshots 으로 두 케이스 비교 결과 요약. 콘솔/스크린샷은 `mydocs/working/task_m100_595_stage1.md` 에 첨부.
+
+## 5. 단계 분해 (구현 계획서는 별도)
+
+| 단계 | 내용 |
+|------|------|
+| Stage 1 | e2e 진단 테스트 작성 + 실행 + 콘솔 캡처 + 1차 본질 가설 정립 |
+| Stage 2 | (필요 시) 진단 hook 노출 또는 추가 데이터 수집 |
+| Stage 3 | 본질 정정 (별도 구현 계획서 작성 후 승인 — 본 task 또는 후속) |
+
+본질 진단이 명확해지면 단계 수가 줄어들 수 있음. 정정 영역의 위험도에 따라 추가 단계 필요할 수 있음.
+
+## 6. 검증
+
+- e2e 진단 테스트 실행 결과 (page 1 vs page 2 비교) 명확
+- 본질 가설이 데이터로 뒷받침
+- 회귀 위험 — 진단 단계는 기존 코드 수정 없음 (e2e 신규 1 파일만 추가)
+
+## 7. 외부 영역
+
+- `examples/inspect_595.rs` — 사전 정적 분석용 임시 진단. 본 task 종료 시 보존 여부 결정 (역사 기록 vs 정리).
+- 본 task 는 PR 처리 사이클이 아님 — 내부 task. CLAUDE.md `pr/` 폴더와 무관.
+
+## 8. 작업지시자 승인 요청 사항
+
+1. **방향 승인**: e2e 기반 진단 (옵션 B) 진행 — 이미 답변 받음 ✓
+2. **본 수행 계획서 승인**: Stage 1 부터 진행 가능 여부
+3. **`examples/inspect_595.rs` 보존**: 정적 분석 dump 결과를 기록으로 보존할지 (보존 → stage1 보고서에 인용 / 삭제 → 진단 정리)
+
+승인 후 구현 계획서 (`task_m100_595_impl.md`) 작성 → 승인 후 Stage 1 진행.

--- a/mydocs/plans/task_m100_595_impl.md
+++ b/mydocs/plans/task_m100_595_impl.md
@@ -1,0 +1,78 @@
+# Task #595 구현 계획서
+
+**Issue**: #595 — exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작
+**브랜치**: `local/task595`
+**상위 계획서**: `task_m100_595.md`
+
+---
+
+## 단계 분해 (3 단계)
+
+### Stage 1 — e2e 진단 테스트 작성 + 실행 + 본질 가설 정립
+
+**산출물**: `rhwp-studio/e2e/issue-595.test.mjs`
+
+**시나리오 (단일 테스트)**:
+
+1. `samples/exam_math.hwp` 로드 (helpers `loadHwpFile`)
+2. **page 1 (0-based 0) 의 수식 클릭**:
+   - 대상: paraIdx=18 ci=0 ("2.함수 ..." 본문 수식, x=130.8 y=818.3 w=108.0 h=17.5)
+   - 클릭 좌표: 페이지 내부 (130.8 + 50, 818.3 + 8) ≈ (180.8, 826.3) 페이지 px
+   - DOM 좌표 변환: contentX = pageLeft + 180.8 * zoom, contentY = pageOffsets[0] + 826.3 * zoom
+3. **page 2 (0-based 1) 의 수식 클릭**:
+   - 대상: paraIdx=65 ci=0 (이슈 명세 수식, x=589.5 y=191.7 w=131.7 h=37.3)
+   - 클릭 좌표: 페이지 내부 (589.5 + 65, 191.7 + 18) ≈ (654.5, 209.7) 페이지 px
+   - DOM 좌표 변환: contentX = pageLeft + 654.5 * zoom, contentY = pageOffsets[1] + 209.7 * zoom
+4. **각 클릭 직전/직후 진단 데이터 캡처** (page.evaluate):
+   - `pageIdx`, `pageX`, `pageY`, `pageOffset`, `cx`, `cy`, `zoom`, `pageHeights[]`, `pageOffsets[]`
+   - `wasm.getPageControlLayout(pageIdx)` controls 배열의 type=equation 항목 list
+   - `inputHandler.findPictureAtClick(pageIdx, pageX, pageY)` 직접 호출 결과
+   - 클릭 후 `cursor.isInPictureObjectSelection()` 상태
+5. **결과 비교 + 본질 가설 정립**
+
+**기존 코드 변경**: 없음 (e2e 신규 1 파일만 추가)
+
+**진단 hook 노출 필요 시**: stage 종료 후 revert
+
+**완료 기준**:
+- e2e 테스트 실행 성공 (host 또는 headless 모드)
+- 진단 데이터 캡처 완료
+- 본질 가설 1개 이상 데이터로 뒷받침
+- `mydocs/working/task_m100_595_stage1.md` 작성
+
+### Stage 2 — (조건부) 본질 정정 또는 추가 진단
+
+**진입 조건**: Stage 1 본질 가설이 명확 + 정정 영역 식별
+
+**케이스 분기**:
+- **케이스 A**: 본질 명확 + 영향도 낮음 → 본질 정정 + 회귀 테스트
+- **케이스 B**: 본질 추정만 가능 → 추가 진단 hook 또는 다른 fixture 비교
+- **케이스 C**: Rust 측 결함 발견 → 별도 task 분리 검토
+
+**완료 기준**:
+- 케이스별 산출물 + 검증 통과 + Stage2 보고서
+
+### Stage 3 — 회귀 테스트 + 최종 보고서
+
+**산출물**:
+- `mydocs/report/task_m100_595_report.md`
+- 회귀 sweep 결과 (cargo test, clippy, build, e2e 회귀 0)
+- `mydocs/orders/20260506.md` 갱신
+
+---
+
+## 위험도 영역
+
+| 영역 | 위험도 | 대응 |
+|------|--------|------|
+| e2e host/headless 환경 | 낮음 | 둘 다 시도 (helpers 지원) |
+| inputHandler.findPictureAtClick private | 낮음 | JS 런타임 접근 가능 (TS private은 컴파일 시만) |
+| 진단 hook 노출 시 prod 영향 | 매우 낮음 | `import.meta.env.DEV` 가드 (현재 `__inputHandler` 와 동일 영역) |
+| 본질 정정 회귀 | 중 | Stage 2 진입 시 영역 식별 후 회귀 sweep 사전 정의 |
+
+## 5. 작업지시자 승인 요청
+
+- 본 구현 계획서 (3단계) 승인
+- Stage 1 진행 가능 여부
+
+승인 후 Stage 1 e2e 테스트 작성 시작.

--- a/mydocs/report/task_m100_595_report.md
+++ b/mydocs/report/task_m100_595_report.md
@@ -1,0 +1,125 @@
+# Task #595 최종 결과 보고서
+
+**Issue**: [#595](https://github.com/edwardkim/rhwp/issues/595) — exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작 — 1페이지만 정상
+**Milestone**: M100 (v1.0.0)
+**브랜치**: `local/task595` → `local/devel` 머지 영역
+**완료일**: 2026-05-07
+
+---
+
+## 1. 본질 요약
+
+`samples/exam_math.hwp` 의 수식 객체를 더블클릭했을 때 1페이지만 정상 동작, **2페이지부터 수식 편집기가 안 나타남 + 캐럿이 머리말 영역으로 이동**. 사용자 보고 단서 "hover 시 손바닥 표시는 뜨는데 클릭 반응 없음" 으로 본질 영역 확정.
+
+**본질 결함 위치**: `src/renderer/layout.rs::build_header` ([line 928](../../src/renderer/layout.rs#L928)) 의 `expand_bbox_to_children` 호출이 머리말 자식 (단 구분선 line `paraIdx=0 ci=2`, h≈1227px) 의 bbox 까지 Header 영역으로 확장 → `hit_test_header_footer_native` 가 본문 좌표를 머리말 hit 으로 잘못 인식 → `onDblClick` 의 머리말 분기가 picture selection 분기보다 먼저 실행되어 수식 편집기 진입 차단.
+
+**page 0 vs page 1+ 차이**: page 0 의 단 구분선은 ci=5 로 Body 자식, page 1+ 부터 ci=2 로 Header 자식 → page 0 만 정상.
+
+## 2. 정정 영역 (옵션 A)
+
+**파일**: `src/document_core/queries/cursor_rect.rs`
+**함수**: `hit_test_header_footer_native`
+**LOC**: +20 / -13 (단일 함수)
+
+`build_page_tree` 의 Header/Footer 노드 bbox (자식 노드 까지 확장됨) 대신 **`layout.header_area` / `layout.footer_area`** (PageDef margin 으로 계산된 정확한 영역) 로 hit 판정. `expand_bbox_to_children` 은 무수정 — 머리말 표 셀 내 Shape 클리핑 방지 의도 보존.
+
+**부수 효과**: `build_page_tree` 호출 제거 → mousedown 마다 호출되던 비싼 트리 빌드 비용 제거.
+
+**정합 영역**: HWP IR 표준 직접 사용 (`feedback_rule_not_heuristic` 정합), 회귀 위험 영역 좁힘 (단일 함수, 렌더링 무영향), 본질 정정 (우회 패치 아님).
+
+## 3. 검증 결과 (정량)
+
+| 검증 항목 | 정정 전 | 정정 후 |
+|-----------|---------|---------|
+| `tests/issue_595.rs` (5 케이스) | 3 fail / 2 pass | **5 pass** |
+| 본문 hit:false sweep (164 fixture / 1684p) | 1652p / 32 fail | **1684 / 0 fail** (+32 본질 정정) |
+| 머리말 hit (margin_header > 0, 1356p) | 1329 / 27 fail | **1356 / 0 fail** (+27 부수 개선) |
+| 꼬리말 hit (margin_footer > 0) | 1383 / 16 fail | 1383 / 16 fail (회귀 0, 별도 영역) |
+| `cargo test --lib --release` | (baseline) | **1140 pass** (회귀 0) |
+| `cargo clippy --release` (lib) | (baseline) | clean |
+| `cargo build --release` | (baseline) | clean |
+| `cargo test --release --test issue_516/530/546/554/595` | (baseline) | 30 pass (회귀 0) |
+| WASM 빌드 (Docker) | (baseline) | **4,531,883 bytes** clean |
+| 작업지시자 시각 판정 ★ | 결함 재현 | **정상 동작** ★ |
+
+## 4. 회귀 위험성 점검
+
+**관련 이슈** (CLOSED):
+
+| 이슈 | 영역 | 회귀 위험 |
+|------|------|----------|
+| #236 | `PageAreas::from_page_def` 머리말/본문 영역 공식 | **0** — 본 정정이 #236 정정의 영역을 일관 활용 (정확성 강화) |
+| #42 | 머리말/꼬리말 내 Picture 렌더링 | **0** — 렌더링 무영향 |
+| #36 | 머리말 표 셀 안 이미지 미렌더링 | **0** — 렌더링 무영향 |
+| #340 | exam_math 13페이지 머리말 누출 | **0** — typeset 무영향 |
+
+**관련 함수**:
+
+| 함수 | 정정 영향 | 회귀 위험 |
+|------|----------|----------|
+| `hit_test_in_header_footer_native` (편집 모드 텍스트 hit) | 무수정 | **0** — 본 정정 영역 안에서 정상 동작 |
+| `get_active_hf_info` / `find_section_for_page` | 무수정 (본 정정에서 호출) | **0** |
+| `build_page_tree` | 호출 제거 | 0 — 다른 호출처 무영향 |
+
+**TS 측 호출처**: `hitTestHeaderFooter` 호출은 `input-handler-mouse.ts` 단 2곳만:
+- L494 onMouseDown 머리말 모드 탈출 — **개선** (hit:false 정확)
+- L784 onDblClick 본질 영역 — **정정**
+
+## 5. 단계별 진행
+
+| Stage | 산출물 | commit |
+|-------|--------|--------|
+| Stage 1 | 본질 진단 + 재현 단위 테스트 (5 케이스) + 광범위 sweep + 정정 영역 후보 분석 | [`54c0af2`](#) |
+| Stage 2 | hit_test_header_footer 영역 정정 + 회귀 sweep 도구 + 정정 효과 광범위 검증 | [`0d20917`](#) |
+| Stage 3 | 최종 보고서 + 회귀 위험성 점검 + 별도 task 등록 | (본 commit) |
+
+## 6. 산출물 목록
+
+**소스 코드**:
+- `src/document_core/queries/cursor_rect.rs` — 본질 정정 (+20 / -13 LOC)
+
+**단위 테스트** (영구 보존, 회귀 차단 가드):
+- `tests/issue_595.rs` — 5 케이스 (정정 전 3 fail / 2 pass → 정정 후 5 pass)
+
+**검증 도구** (영구 보존, 향후 재사용):
+- `examples/inspect_595.rs` — Header bbox / 머리말 hit y 범위 sweep
+- `examples/inspect_595_regression.rs` — 머리말/꼬리말/본문 영역 광범위 회귀 sweep
+
+**문서**:
+- `mydocs/plans/task_m100_595.md` — 수행 계획서
+- `mydocs/plans/task_m100_595_impl.md` — 구현 계획서
+- `mydocs/working/task_m100_595_stage1.md` — Stage 1 보고서
+- `mydocs/working/task_m100_595_stage2.md` — Stage 2 보고서
+- `mydocs/report/task_m100_595_report.md` — 본 최종 보고서
+
+**e2e 진단** (비-회귀, 향후 다른 이슈에서 패턴 재사용):
+- `rhwp-studio/e2e/issue-595.test.mjs` — 1365×1018 사용자 환경 모사 + zoom 변동 시나리오
+
+**임시 파일 정리**:
+- `rhwp-studio/public/samples/exam_math.hwp` — Stage 3 정리 시 제거 완료
+
+## 7. 보조 메모 — 본 task 분리 영역 (참고만)
+
+광범위 sweep / e2e 진단 중 발견된 본 이슈 #595 와 본질이 다른 영역. 본 task 정정과 무관 (회귀 0 확인됨), 사용자 시각 검증 안 됨, 한컴 호환 진단 필요 → **별도 이슈 등록 보류**. 본 보고서에는 참고 기록만 보존하고 본 task 정리 영역에서 분리.
+
+| 영역 | 본질 (추정) | 정정 전후 | 사용자 검증 |
+|------|-------------|-----------|-------------|
+| 그리드 모드 (zoom ≤ 0.5) hit 좌표 | TS 측 `pageLeft` 단일 컬럼 가정 vs 그리드 `pageLefts[i]` 불일치 | 동일 | 안 함 |
+| hwpctl_Action_Table 꼬리말 hit:false | landscape + `marginBottom=0` 양식의 `PageAreas::from_page_def` `footer_area.height = 0` | 동일 | 안 함 (정정 전후 동일 확인) |
+
+향후 사용자 시각 검증 또는 한컴 호환 비교로 결함 확정 시 별도 task 진입.
+
+## 8. 본 사이클 정합
+
+- **하이퍼-워터폴 절차 정합** — 이슈 → 브랜치 → 수행 계획서 → 구현 계획서 → 단계별 진행 → 단계별 보고서 → 최종 보고서 모두 정상 진행. 작업지시자 단계별 승인 + 시각 판정 통과.
+- **광범위 회귀 sweep 패턴** (`feedback_wide_regression_sweep` 정합) — 164 fixture / 1684p 광범위 측정으로 정정 안전성 입증.
+- **본질 정정 영역 좁힘** (`feedback_root_cause_only` 정합) — 단일 함수 정정, 렌더링 무영향, expand 의도 보존.
+- **이슈 본문 정오표 갱신** (`feedback_full_disclosure` 정합) — 이슈 작성자의 초기 진단 (a)/(b)/(c) 가 본질 영역 밖이었음을 코멘트로 명시.
+- **회귀 위험성 영역 점검** — 관련 이슈 (#236, #42, #36, #340) + 관련 함수 + 호출처 모두 점검.
+- **단위 테스트 영구 가드** — `tests/issue_595.rs` 5 케이스 회귀 차단 영구 보존.
+
+## 9. 본 task 종결
+
+본 task 는 **Issue #595 완전 해결** + 회귀 0 + 부수 개선 +27p + 별도 task 영역 식별로 완료. `local/devel` merge → `devel` push → main release 영역은 작업지시자 결정.
+
+**Issue #595 close 영역**: 본 보고서 + 정정 코드 + 검증 데이터를 코멘트로 등록 후 close.

--- a/mydocs/troubleshootings/body_outside_click_fallback.md
+++ b/mydocs/troubleshootings/body_outside_click_fallback.md
@@ -1,0 +1,142 @@
+# rhwp-studio 본문 외곽 클릭 fallback 한컴 mismatch 결함
+
+## 본질
+
+`samples/hwpctl_Action_Table__v1.1.hwp` (16p, landscape, `margin_bottom=0`, `footer_area.height=0`) 의 페이지 16 꼬리말 영역 클릭 시 한컴과 RHWP 동작 mismatch.
+
+| 환경 | 동작 |
+|------|------|
+| 한컴 | 문서 마지막 `}` 문자에 캐럿 배치 (= 본문 외곽 → 가장 가까운 본문 캐럿 fallback) |
+| RHWP | **페이지 2, 3 으로 뷰 점프** + 캐럿 / 선택 상태 부정합 |
+
+## 사전 정합 사실
+
+- `PageAreas::from_page_def` 의 `footer_area.height = margin_bottom` 수식은 HWP spec 정합 (한컴도 동일).
+- `margin_bottom=0` → footer_area.height=0 → `hit_test_header_footer = false` 는 한컴과 정합 (양쪽 모두 그 영역을 꼬리말로 인식 안 함).
+- 결함은 **`hit_test_header_footer = false` 이후 onMouseDown fallback 분기** 에 한정.
+
+## 코드 경로 trace
+
+[input-handler-mouse.ts:onMouseDown](../../rhwp-studio/src/engine/input-handler-mouse.ts#L460-L781) 의 흐름 (page 16 꼬리말 영역 click 시 점진적 분기):
+
+1. (line 470-479) `pageX/pageY` 계산 — 정상.
+2. (line 482-491) `tableResizeRenderer` 표 경계 hit — `cachedCellBboxes` 없음 → skip.
+3. (line 494-516) `cursor.isInHeaderFooter()` — 첫 클릭이라 false → skip.
+4. (line 519-540) `cursor.isInFootnote()` — false → skip.
+5. (line 543-595) 각주 마커 / 영역 hit — 없음 → skip.
+6. (line 597) **`hit = wasm.hitTest(pageIdx=15, pageX, pageY)`** — 핵심 분기점.
+7. (line 601) `paragraphIndex >= 0xFFFFFF00` (머리말/꼬리말 sentinel) → `textarea.focus()` + return. **scroll 변화 없음.** footer_area.height=0 이므로 sentinel 반환 가능성 낮음.
+8. (line 607-622) 표 내부 + 표 경계 click → 표 객체 선택 + return.
+9. (line 625-640) `findTableByOuterClick` (표 외곽 click 휴리스틱) → 표 객체 선택 + return.
+10. (line 643-657) **`hit.isTextBox === true` → `cursor.moveTo(hit)` + `this.updateCaret()` + 드래그 시작.** `updateCaret` 은 [input-handler.ts:1505](../../rhwp-studio/src/engine/input-handler.ts#L1505) 에서 `scrollCaretIntoView(rect)` 호출 → **여기서 페이지 점프 발생 가능.**
+11. (line 660-732) `findPictureAtClick` (그림/글상자/수식) → 객체 선택 + return.
+12. (line 736-742) form object → handler + return.
+13. (line 754-781) **일반 click fallback** — `cursor.moveTo(hit)` + `caret.show(rect, zoom)` + isDragging=true. **`scrollCaretIntoView` 호출 안 함**, `caret.show` 만 — scroll 변화는 없어야 정상.
+
+## 후보 (a/b/c) 좁히기 — **e2e 측정으로 (b) 확정 (2026-05-07)**
+
+| 후보 | 가설 | e2e 측정 결과 |
+|------|------|---------------|
+| (a) cursor.moveTo({sec:0, para:0, ...}) invalid fallback | hit 결과 invalid → 기본값 fallback | **부정** — wasm.hitTest 가 valid hit 반환 (cursorRect.pageIndex=15 정상) |
+| **(b) 바탕쪽 (master page) 글상자 hit → isTextBox=true 분기** | line 643-657 분기 → `updateCaret` → `scrollCaretIntoView` 발생 | **확정 — dblclick 시 정확히 재현** (delta=−11288, page 0~1 jump) |
+| (c) 본문 paragraph hit 휴리스틱이 잘못된 paragraphIndex 반환 | hit.paragraphIndex 가 다른 페이지로 매핑 | **부정** — hit.paragraphIndex 정상, cursorRect.pageIndex=15 (click 페이지) 정상 |
+
+### 결정적 측정 데이터 (2026-05-07)
+
+`rhwp-studio/e2e/body-outside-click-fallback.test.mjs` 변종 + 정밀 측정 (페이지 번호 textbox 정확한 위치 click) 결과:
+
+**Step 1 — Layout dump (page 15 의 control 위치)**:
+```json
+{ "controls": [
+    {"type": "shape", "x": 113.4, "y": 740, "w": 75.6, "h": 21.5, "secIdx": 0, "paraIdx": 0, "controlIdx": 0},  // ← 자동번호 글상자
+    {"type": "image", "x": 1752.9, "y": 1480.5, ...},  // off-page
+    {"type": "shape", "x": 113.4, "y": 736.8, "w": 895.7, "h": 4, ...}  // 단 구분선
+]}
+```
+
+자동번호 글상자: `secIdx=0, paraIdx=0, controlIdx=0` — section 0 의 paragraph 0 (= master page) 에 anchored.
+
+**Step 2 — 글상자 정확한 위치 (151.2, 750.75 = bbox 중앙) 단일 click**:
+```
+scroll: 12023 → 12023 (delta=0)
+pos = {sec:0, para:0, char:0}
+isInPictureObjectSelection=true
+selectedPicRef = {sec:0, ppi:0, ci:0, type:'shape'}
+```
+→ shape 객체 선택. **scroll 변화 없음.** 선택 상태로만 진입.
+
+**Step 3 — 같은 위치 더블 click (사용자 정확한 시나리오)**:
+```
+scroll: 12023 → 735 (delta=−11288)
+pos = {sec:0, para:0, char:0, ppi:0, ci:0, cellIdx:0}
+isInTextBox=true  ★
+rectPg=0  ★
+visible pages after dblclick: [0, 1]  ★
+```
+
+→ **isInTextBox=true 분기 진입**, cursor 가 sec 0 paragraph 0 의 control 0 cell 0 (= master page 글상자 안) 으로 이동, **`cursor.getRect().pageIndex = 0`** (master page 가 first-attached 된 page 0 의 좌표 반환), `scrollCaretIntoView` 가 page 0 으로 스크롤 → **사용자 보고와 정확히 일치 (페이지 1, 2 visible)**.
+
+**확정된 결함 본질**:
+1. dblclick 분기는 [input-handler-mouse.ts:onDblClick](../../rhwp-studio/src/engine/input-handler-mouse.ts#L784) 직접 처리가 아닌, mousedown 의 textbox 분기 ([input-handler-mouse.ts:643-657](../../rhwp-studio/src/engine/input-handler-mouse.ts#L643-L657)) 안의 **`isInTextBox` 가 이미 true** 인 상태에서 두 번째 mousedown.
+2. master page 의 자동번호 글상자는 `secIdx=0, paraIdx=0` 으로 attached → `cursor.moveTo(hit)` 후 `getRect()` 가 paraIdx=0 이 first 정의된 위치 (= page 0) 의 rect 를 반환.
+3. `scrollCaretIntoView(rect)` 가 rect.pageIndex=0 의 좌표를 viewport 안으로 스크롤 → 마지막 페이지 → 첫 페이지로 점프.
+
+**한컴 정합 정정 방향**: master page 글상자 (특히 paraIdx=0 으로 anchored 된 control) 는:
+- A) `findPictureAtClick` 에서 마스터 페이지 출처 글상자는 hit 결과에서 제외 → 일반 본문 fallback 진행
+- B) hit 의 cursorRect.pageIndex 가 click 페이지 (`pageIdx`) 와 다르면 fallback
+- 한컴은 master page 위 dblclick 시 본문 가장 가까운 caret 으로 떨어짐 — 본 환경도 동일하게.
+
+## 한컴 정합 fallback 동작
+
+한컴은 **master page 위 click 을 textbox edit 으로 처리하지 않고**, 본문 영역 외곽 click 으로 인식 → 가장 가까운 본문 paragraph 캐럿 (이 fixture 의 경우 문서 마지막 `}` 문자) 으로 떨어짐.
+
+본 환경 정합 정정 방향 (가설):
+- A) `findPictureAtClick` / `isTextBox` 분기에서 **master page (바탕쪽) 출처의 글상자는 제외**하고 본문 fallback 으로 진행.
+- B) hit 결과의 `cursor.getRect().pageIndex` 가 click 페이지 (`pageIdx`) 와 다르면 본문 fallback 으로 우회.
+- 한컴 정합은 A 가 더 자연스러움 (의미적으로 master page 위 click은 본문 click).
+
+## e2e 계측 (정정 task 에서 수행)
+
+1. `cd rhwp-studio && npx vite --host 0.0.0.0 --port 7700 &`
+2. `samples/hwpctl_Action_Table__v1.1.hwp` 로드.
+3. 페이지 16 페이지 하단 (꼬리말 위치) 클릭.
+4. `console.log` 또는 e2e 계측: `hit` 객체 (`sectionIndex`, `paragraphIndex`, `parentParaIndex`, `controlIndex`, `cellIndex`, `isTextBox`), `cursor.getPosition()`, `cursor.getRect().pageIndex`, click 직후 `scrollContainer.scrollTop` 변화.
+5. 후보 (b) 확정: `hit.isTextBox === true` + `parentParaIndex` 가 master page 글상자 ppi.
+
+## 우선순위
+
+- **Medium**: 단일 fixture (`hwpctl_Action_Table__v1.1.hwp`) 에서만 재현. 다른 일반 문서는 footer_area.height > 0 이라 hit_test_header_footer = true 분기로 진입.
+- 그러나 본질 (master page 글상자 위 본문 외곽 click) 은 **다른 양식** (페이지 양식 / 표지 양식 등) 에서도 잠재적 재현 가능. 등록 가치 있음.
+
+## fixture
+
+- `samples/hwpctl_Action_Table__v1.1.hwp`
+  - 16 페이지, landscape (가로)
+  - `margin_left=30, margin_right=30, margin_top=0, margin_bottom=0, margin_header=15, margin_footer=15` (mm)
+  - 바탕쪽 2개 (Both, 자동번호 Page 글상자 포함)
+  - section 0 dump: `cargo run --release --bin rhwp -- dump samples/hwpctl_Action_Table__v1.1.hwp`
+
+## 우선 처리 후순위 (정정 task 진입 전)
+
+1. e2e 계측으로 후보 (b) 확정 (5-10 분).
+2. 정정 방향 (A vs B) 결정.
+3. 한컴 정합 시각 검증 매뉴얼 준비.
+
+## 등록 전 보류 (사용자 결정, 2026-05-07) → **e2e 확정으로 등록 가능**
+
+작업지시자: "**모든 이슈 파악을 완벽하게 하고 이슈를 올리는게 좋을것 같음**". 본 노트는 진단 보강 단계로 간주하고 issue 등록 보류 → **2026-05-07 e2e 측정으로 가설 (b) 확정 + 정량 데이터 확보 → 등록 가능 상태**.
+
+남은 횡적 검증 (선택):
+- master page 구조 변환 (예: section 다중 + 표지 양식) 에서 동일 결함 재현되는지 — 본 fixture 외 추가 fixture 측정.
+- 한컴 정합 정정 방향 (A vs B) 결정 — 회귀 영역 (정상 글상자 click 시나리오) 명시 후 정정.
+
+## 사용자 측정 vs e2e 측정 정합
+
+| 측정 항목 | 사용자 직접 (host browser) | e2e (headless) |
+|-----------|----------------------------|-----------------|
+| 페이지 번호 위치 | "16" 텍스트 | shape #1 bbox (113.4, 740, 75.6×21.5) |
+| 동작 | 더블클릭 | mouse.click({clickCount:2, delay:80}) |
+| 결과 (사용자) | "페이지 2, 3 으로 이동" | scroll delta=−11288, visible pages [0, 1] (= 1, 2 페이지) |
+| 한컴 동작 | "문서 마지막 `}` 캐럿" | (e2e 미측정 — 한컴 자동화 불가) |
+
+→ **본질 정합** (사용자 보고 "2, 3 페이지" 와 e2e "1, 2 페이지" 차이는 viewport 크기 / 첫 화면에 보이는 페이지 수 차이일 뿐, **첫 페이지 부근으로 점프** 라는 본질은 동일).

--- a/mydocs/troubleshootings/grid_mode_click_coord.md
+++ b/mydocs/troubleshootings/grid_mode_click_coord.md
@@ -1,0 +1,153 @@
+# rhwp-studio 그리드 모드 (zoom ≤ 0.5) click 좌표 단일 컬럼 가정 결함
+
+## 본질
+
+[rhwp-studio/src/view/virtual-scroll.ts](../../rhwp-studio/src/view/virtual-scroll.ts)는 줌 ≤ 0.5일 때 **다중 열 그리드 배치**로 분기 (`gridMode = zoom <= 0.5 && viewportWidth > 0 && pages.length > 1`). 그리드 활성 시 각 페이지의 X 좌표는 `pageLefts[i] = marginLeft + col * (pw + gap)` 로 열별 분리 저장되며, [getPageLeft(pageIdx)](../../rhwp-studio/src/view/virtual-scroll.ts#L155) 로 노출된다.
+
+그러나 [rhwp-studio/src/engine/input-handler-mouse.ts](../../rhwp-studio/src/engine/input-handler-mouse.ts)는 `getPageLeft` 를 **단 한 곳도 호출하지 않고** 14개 분기 모두 단일 컬럼 가정 공식 사용:
+
+```ts
+const pageLeft = (scrollContent.clientWidth - pageDisplayWidth) / 2;
+const pageX = (contentX - pageLeft) / zoom;
+```
+
+그리드 모드에서 페이지가 좌/우 열에 분산 배치되므로 위 공식의 `pageLeft` 는 모든 페이지를 "중앙 정렬" 로 가정 → `pageX` 가 실제 페이지 내 좌표와 어긋남 → 모든 마우스 인터랙션 어긋남.
+
+## 영향 분기 (14곳)
+
+| Line | 함수 | 트리거 | 영향 |
+|------|------|--------|------|
+| 23 | onConnectorMouseDown | 연결선 모드 click | 연결선 시작/끝 좌표 |
+| 129 | onMouseDown (표 객체 선택 중) | 선택된 표 click | 표 이동 드래그 시작 hit |
+| 176 | onMouseDown (다중 그림 선택) | multi-picture handle click | 합산 BBOX 좌표 |
+| 279 | onMouseDown (직선 끝점 드래그) | line endpoint handle click | drag init coord |
+| 296 | onMouseDown (회전 드래그) | rotate handle click | rotate center coord |
+| 357 | onMouseDown (단일 그림 선택) | 선택된 그림 본체 click | move drag init |
+| 431 | onMouseDown (표 리사이즈) | 표 border click | resize drag hit |
+| **475** | **onMouseDown (일반 click)** | **left mousedown 전반** | **메인 click 좌표 (cursor.moveTo)** |
+| **811** | **onDblClick** | **left dblclick** | **dblclick hit (머리말/꼬리말)** |
+| **889** | **onContextMenu** | **right click** | **context menu 표 셀 판정** |
+| 931 | onMouseMove (연결선 모드) | connector drawing mousemove | preview 좌표 |
+| 1146 | onMouseMove (그림 hover) | mousemove during picture hover | hover cursor |
+| 1196 | onMouseMove (표 hover) | mousemove during table hover | hover cursor |
+| 1243 | handleResizeHover | 표 border mousemove | hover cursor |
+
+핵심 영향 (사용자 직접 인지): **475 / 811 / 889** — 일반 click / dblclick / context menu 모두 그리드 모드에서 엉뚱한 위치 처리.
+
+## 트리거 조건
+
+`virtual-scroll.ts:29`:
+```ts
+this.gridMode = zoom <= GRID_ZOOM_THRESHOLD && viewportWidth > 0 && pages.length > 1;
+```
+
+- `GRID_ZOOM_THRESHOLD = 0.5`
+- 페이지 수 > 1
+- 뷰포트 폭 > 0
+
+→ 줌 25%/50% (실제 사용자 시나리오: "전체 보기" 또는 "다중 페이지 미리보기") 에서 활성.
+
+## 영향 범위 (사용자 직접 측정, 2026-05-07)
+
+**한컴**: 그리드 모드 / 일반 모드 모두 정상 클릭 동작.
+
+**RHWP 그리드 모드 (zoom ≤ 0.5)**: **모든 열에서 click 어긋남** (좌측 열 + 가운데 열 + 우측 열 전부). 일반 모드 (zoom > 0.5) 는 정상.
+
+원인: 페이지 element 의 실제 left 좌표는 `pageLefts[i]` ([canvas-view.ts:156-163](../../rhwp-studio/src/view/canvas-view.ts#L156-L163) 에서 `style.left = ${pageLeft}px`) 인데, input-handler-mouse 의 14곳 모두 `(clientWidth - pageDisplayWidth) / 2` 단일 컬럼 가정. 그리드 모드에서는 모든 열의 페이지가 슬롯 좌표에 배치되므로 단일 컬럼 가정 공식과 어긋남 (좌/우 방향 + 정도가 열별로 다름).
+
+## 정정 범위
+
+**`getPageLeft(pageIdx)` 호출로 14개 분기 일괄 정정**. 단, 단일 컬럼 모드에서 `getPageLeft = -1` 반환 (CSS 중앙 정렬 sentinel) 이므로 fallback 처리 필요.
+
+권장 패턴:
+```ts
+const pl = virtualScroll.getPageLeft(pi);
+const pageLeft = pl >= 0 ? pl : (scrollContent.clientWidth - pageDisplayWidth) / 2;
+```
+
+또는 `virtual-scroll.ts` 에 단일 헬퍼 추가:
+```ts
+getPageLeftResolved(pageIdx: number, containerWidth: number): number {
+  const pl = this.pageLefts[pageIdx] ?? -1;
+  if (pl >= 0) return pl;
+  const pw = this.pageWidths[pageIdx] ?? 0;
+  return (containerWidth - pw) / 2;
+}
+```
+
+→ `input-handler-mouse.ts` 14곳 모두 `virtualScroll.getPageLeftResolved(pageIdx, sc.clientWidth)` 한 줄로 치환.
+
+## 회귀 영역
+
+- 단일 컬럼 모드 (zoom > 0.5) → `pageLefts[i] = -1` → 기존 `(clientWidth - pw) / 2` 공식 그대로 적용 → 무회귀
+- 그리드 모드 → 새 공식 적용 → 사용자 시각 검증 필요 (e2e 줌 25%/50% 클릭 시 cursor 위치 정확)
+
+## 재현 절차
+
+1. `cd rhwp-studio && npx vite --host 0.0.0.0 --port 7700 &`
+2. 다중 페이지 HWP 파일 (예: `samples/exam_kor.hwp`) 열기.
+3. 줌 25% 또는 50% 로 변경 → 그리드 활성 (좌/우 열 페이지 다중 배치).
+4. **2열째 페이지** 본문 텍스트 클릭 → 커서가 엉뚱한 위치 (1열째 페이지 영역 처럼 처리됨) 에 떨어지는지 확인.
+5. 또는 머리말 영역 dblclick → 머리말 편집기 미진입 (좌표 어긋남으로 hit_test_header_footer = false 반환).
+
+## 한컴 호환 무관성
+
+한컴 오피스는 그리드 모드 (다중 열 페이지 배치) 자체가 없음. 본 결함은 RHWP 자체 결함이며 한컴 호환 진단 불필요.
+
+## 우선순위
+
+- **High** (UX-blocking): 줌 25%/50% 사용 시 모든 열의 마우스 동작이 어긋남 (사용자 직접 측정 확인).
+- 정정 범위는 file 1개 (input-handler-mouse.ts) + 1개 헬퍼 추가 → 작업량 작음.
+- 시각 검증은 e2e (Vite dev server + 줌 변경) 으로 빠르게 가능.
+
+## 등록 전 추가 검증 권장
+
+본 노트의 본질 (단일 컬럼 가정 공식 vs 그리드 pageLefts 불일치) 은 코드 + CSS evidence 로 확정. 다만 등록 전 다음 사항 보강 가능:
+
+1. **수치 정량화**: 줌 50% + columns=2 환경에서 좌측 열 click X 좌표 어긋남 정도 (예: ~px 단위) e2e 계측.
+2. **다른 input 경로 확인**: keyboard 입력 / IME / textarea 좌표 변환에 동일 결함 영향 있는지 (현 진단은 mouse 만).
+3. **Touch / 펜 입력**: touch 이벤트도 같은 14개 분기 사용하는지 별도 확인 (touch handler 별도 가능).
+
+## 정량 측정 결과 (e2e, 2026-05-07)
+
+`rhwp-studio/e2e/grid-mode-click-coord.test.mjs` 실행 결과 (`samples/exam_kor.hwp` 20p, viewport 1600x1000, headless Chrome).
+
+### zoom=0.5 (columns=2)
+
+| page | col | pw | correct (pageLefts[i]) | buggy (단일 컬럼 공식) | delta_px |
+|------|-----|-----|------------------------|------------------------|----------|
+| 0 | 0 | 561.3 | 223.8 | 509.4 | **+285.6** |
+| 1 | 1 | 561.3 | 795.0 | 509.4 | **−285.6** |
+| 2 | 0 | 561.3 | 223.8 | 509.4 | +285.6 |
+| 3 | 1 | 561.3 | 795.0 | 509.4 | −285.6 |
+| ... | ... | ... | ... | ... | ... |
+
+→ 좌측 열 (col 0) 모두 +285.6px, 우측 열 (col 1) 모두 −285.6px 어긋남.
+
+### zoom=0.25 (columns=5)
+
+| page | col | pw | correct | buggy | delta_px |
+|------|-----|-----|---------|-------|----------|
+| 0 | 0 | 280.6 | 68.4 | 649.7 | **+581.3** |
+| 1 | 1 | 280.6 | 359.1 | 649.7 | **+290.6** |
+| 2 | 2 | 280.6 | 649.7 | 649.7 | **0.0** |
+| 3 | 3 | 280.6 | 940.3 | 649.7 | **−290.6** |
+| 4 | 4 | 280.6 | 1230.9 | 649.7 | **−581.3** |
+
+→ 가운데 열 (col 2) 만 우연히 0px 정합. 양 끝 열은 ±581.3px 어긋남.
+
+### zoom=1.0 (단일 컬럼, baseline)
+
+| page | col | pw | correct | buggy | delta_px |
+|------|-----|-----|---------|-------|----------|
+| 모두 | 0 | 1122.5 | −1.0 | 20.3 | **0.0** |
+
+→ 단일 컬럼 모드는 정합 (correct=−1 sentinel → fallback 공식 = buggy 공식 결과).
+
+### 실제 click 동작 검증
+
+zoom=0.5, page 1 (col 1) 에서 hwpX=100 좌표를 의도한 click:
+- CORRECT click @(865.0, 242.0) → cursor.pos = `{sec:0, para:39, char:70}` (정상)
+- BUGGY click @(579.4, 242.0) → cursor.pos = `{sec:0, para:31, char:0}` (page 0 의 영역으로 잘못 떨어짐)
+
+**결론**: 그리드 모드에서 input-handler-mouse 의 14개 분기는 모든 페이지에서 ±수백 px 단위로 click 좌표를 어긋나게 만듬. 가운데 열 (홀수 columns 일 때 mid-col) 만 우연히 정합.

--- a/mydocs/troubleshootings/grid_mode_click_coord.md
+++ b/mydocs/troubleshootings/grid_mode_click_coord.md
@@ -49,9 +49,11 @@ this.gridMode = zoom <= GRID_ZOOM_THRESHOLD && viewportWidth > 0 && pages.length
 
 ## 영향 범위 (사용자 직접 측정, 2026-05-07)
 
-**한컴**: 그리드 모드 / 일반 모드 모두 정상 클릭 동작.
+**한컴**: 그리드 모드 / 일반 모드 모두 **정상 클릭 동작**. ※ 한컴 오피스도 다중 페이지 그리드 모드 (여러 페이지 동시 보기) 가 존재하며, 거기서도 click 좌표는 정확히 처리됨.
 
 **RHWP 그리드 모드 (zoom ≤ 0.5)**: **모든 열에서 click 어긋남** (좌측 열 + 가운데 열 + 우측 열 전부). 일반 모드 (zoom > 0.5) 는 정상.
+
+→ **한컴 호환 결함** (한컴은 정상, RHWP만 어긋남).
 
 원인: 페이지 element 의 실제 left 좌표는 `pageLefts[i]` ([canvas-view.ts:156-163](../../rhwp-studio/src/view/canvas-view.ts#L156-L163) 에서 `style.left = ${pageLeft}px`) 인데, input-handler-mouse 의 14곳 모두 `(clientWidth - pageDisplayWidth) / 2` 단일 컬럼 가정. 그리드 모드에서는 모든 열의 페이지가 슬롯 좌표에 배치되므로 단일 컬럼 가정 공식과 어긋남 (좌/우 방향 + 정도가 열별로 다름).
 
@@ -90,9 +92,11 @@ getPageLeftResolved(pageIdx: number, containerWidth: number): number {
 4. **2열째 페이지** 본문 텍스트 클릭 → 커서가 엉뚱한 위치 (1열째 페이지 영역 처럼 처리됨) 에 떨어지는지 확인.
 5. 또는 머리말 영역 dblclick → 머리말 편집기 미진입 (좌표 어긋남으로 hit_test_header_footer = false 반환).
 
-## 한컴 호환 무관성
+## 한컴 호환 결함
 
-한컴 오피스는 그리드 모드 (다중 열 페이지 배치) 자체가 없음. 본 결함은 RHWP 자체 결함이며 한컴 호환 진단 불필요.
+한컴 오피스는 다중 페이지 그리드 모드 (여러 페이지 동시 보기) 가 존재하며, 그 모드에서 click 좌표는 정확히 처리됨 (사용자 직접 시연 확인, 2026-05-07). RHWP 만 그리드 모드에서 click 좌표 어긋남 → **한컴 호환 결함**.
+
+본 정정의 기대 동작: 한컴 그리드 모드와 동일하게 클릭 → 클릭한 페이지 안의 정확한 위치에 cursor 배치.
 
 ## 우선순위
 

--- a/mydocs/working/task_m100_595_stage1.md
+++ b/mydocs/working/task_m100_595_stage1.md
@@ -1,0 +1,143 @@
+# Task #595 Stage 1 완료 보고서
+
+**Issue**: #595 — exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작
+**브랜치**: `local/task595`
+**Stage**: 1 — 본질 진단 + 재현 단위 테스트 + 광범위 sweep
+**날짜**: 2026-05-07
+
+---
+
+## 1. Stage 1 산출물
+
+| 항목 | 위치 | 상태 |
+|------|------|------|
+| 정적 분석 진단 도구 | `examples/inspect_595.rs` | 작성 ✓ |
+| e2e 진단 테스트 | `rhwp-studio/e2e/issue-595.test.mjs` | 작성 + 실행 ✓ |
+| 재현 단위 테스트 | `tests/issue_595.rs` (5 케이스) | 작성 + 실행 ✓ (3 fail / 2 pass) |
+| 임시 자료 | `rhwp-studio/public/samples/exam_math.hwp` | 진단용 임시 (Stage 종료 시 정리) |
+
+## 2. 본질 결함 위치 정확 식별
+
+**함수**: `src/renderer/layout.rs::build_header` ([line 888-931](../../src/renderer/layout.rs#L888))
+
+**결함 라인**: [layout.rs:928](../../src/renderer/layout.rs#L928)
+```rust
+// Header bbox를 자식 노드 범위까지 확장 + 셀 클리핑 해제
+// (머리말 표 셀 내 Shape가 header_area 밖에 배치될 수 있음)
+Self::expand_bbox_to_children(&mut header_node);
+```
+
+**메커니즘**:
+1. Header 노드 초기 bbox = `layout_rect_to_bbox(&layout.header_area)` — 정상 머리말 영역 (예: y=0~147)
+2. 머리말 내부 컨텐츠 (문단, 셀, Shape, line 등) 추가
+3. **`expand_bbox_to_children`** 가 자식 모두의 bbox 합집합으로 Header bbox 확장
+4. 자식 중 본문 끝까지 늘어진 객체 (단 구분선 line `paraIdx=0 ci=2`, h≈1227px) 가 있으면 Header bbox 가 본문 영역까지 침범
+
+**의도 (주석)**: 머리말 표 셀 내 Shape 가 머리말 영역 외부 배치 시 클리핑 방지.
+**부작용**: 페이지 전체 길이로 늘어진 자식 객체에 대해서는 hit test 영역까지 본문 침범.
+
+## 3. 페이지별 발현
+
+`examples/inspect_595.rs` 결과 (5px sweep, x=514):
+
+| 페이지 | Header hit y 범위 | 실제 머리말 영역 | 판정 |
+|--------|------------------|------------------|------|
+| page 0 (1p) | **60.0 ~ 145.0** | 0 ~ 147 | **정상** ✓ |
+| page 1 (2p) | **60.0 ~ 1355.0** | 0 ~ 147 | **결함** ✗ |
+| page 2 (3p) | 60.0 ~ 1355.0 | 0 ~ 147 | 결함 ✗ |
+| page 3 (4p) | 60.0 ~ 1355.0 | 0 ~ 147 | 결함 ✗ |
+
+**page 0 vs page 1+ 차이**:
+- page 0: 단 구분선 line `paraIdx=0 ci=5 y=224.6 h=1133.9` — Body 자식
+- page 1+: 단 구분선 line `paraIdx=0 ci=2 y=132.3 h=1226.8` — Header 자식 (controlIdx 차이)
+
+## 4. 재현 단위 테스트 (`tests/issue_595.rs`)
+
+```
+running 5 tests
+test issue_595_page1_equation_coord_not_header ... FAILED            ← 정정 전 fail
+test issue_595_page1_header_area_still_hits ... ok                    ← 정상 가드
+test issue_595_page1_body_coord_not_header_regression_guard ... FAILED ← 정정 전 fail
+test issue_595_page0_body_coord_not_header ... ok                     ← 정상 baseline
+test issue_595_page1_body_center_not_header ... FAILED               ← 정정 전 fail
+
+test result: FAILED. 2 passed; 3 failed; 0 ignored; 0 measured
+```
+
+**Fail 메시지 정합**:
+- `(514, 200)` → `{"hit":true,"isHeader":true,"sectionIndex":0,"applyTo":1}` ← 본문 좌표 머리말 hit
+- `(654.5, 209.7)` → 동일 (이슈 명세 수식 좌표)
+- `(514, 800)` → 동일 (본문 중앙)
+
+→ 결함 재현 정합. 정정 후 5 케이스 모두 pass 가 stage 2 검증 기준.
+
+## 5. 광범위 sweep — 영향 영역 정량
+
+`samples/` 전체 164 fixture / 1684 페이지 점검 (x=514, y=800 본문 좌표 기준):
+
+| 항목 | 측정값 |
+|------|--------|
+| 머리말 hit 본문 침범 fixture | **2 / 164 (1.2%)** |
+| 머리말 hit 본문 침범 페이지 | **32 / 1684 (1.9%)** |
+
+**발현 fixture**:
+- `exam_math.hwp` — 20p 중 16p (page 0 제외 모든 페이지)
+- `exam_math_no.hwp` — 동일 양식 (16/20p)
+
+**해석**: 매우 특수한 양식 (머리말에 단 구분선 line 이 자식으로 포함된 경우) — 회귀 위험 매우 낮음.
+
+## 6. 이슈 본문 정오표
+
+이슈에서 "Rust 측 점검 결과 — 정합" 으로 결론 지었으나 **점검 범위가 부분적**:
+
+| 점검 영역 | 이슈에서 점검 | 본 stage 점검 |
+|-----------|---------------|----------------|
+| `getPageControlLayout` controls 배열 (수식 bbox) | ✓ 정합 확인 | ✓ 정합 재확인 |
+| **`hitTestHeaderFooter`** | ✗ 점검 안 함 | **✗ page 1+ 결함 발견** |
+| `build_page_tree` 의 Header 노드 bbox | ✗ 점검 안 함 | **✗ build_header 의 expand_bbox_to_children 결함** |
+
+이슈에서 후속 진단 후보로 제시한 (a)/(b)/(c) 가 모두 TS 측 좌표 변환 영역 — Rust 측 hit test 영역은 의심 후보 밖.
+
+**놓친 단서 (사용자 추가 보고 시 명확화)**:
+- "hover 시 손바닥 표시는 뜨는데 클릭 반응 없음" → `findPictureAtClick` 자체는 정상 hit, dblclick 흐름의 별도 분기 (머리말 검사) 가 가로채는 중
+
+## 7. e2e 진단 결과 (참고)
+
+`rhwp-studio/e2e/issue-595.test.mjs` (1365×1018 사용자 환경 모사):
+
+| 시나리오 | findPictureAtClick | hfHit | dblclick 결과 |
+|----------|-------------------|--------|---------------|
+| zoom=1 page 0 paraIdx=18 ci=0 | hit ✓ | false | picSel=true ✓ |
+| zoom=1 page 1 paraIdx=65 ci=0 | hit ✓ | **true** | picSel=true (e2e mock 한계) |
+| zoom=0.5 그리드 모드 | null ✗ | false | picSel=false |
+
+**별도 결함 발견**: zoom ≤ 0.5 그리드 모드에서 `pageLeft = (sc.clientWidth - pageDisplayWidth) / 2` 단일 컬럼 가정으로 hit 좌표 계산 결함. 본 이슈 (#595) 와 별개 영역 — 별도 task 분리 검토.
+
+## 8. Stage 2 정정 영역 후보
+
+| 옵션 | 영향 영역 | 안전도 | 비고 |
+|------|----------|--------|------|
+| **A. `hit_test_header_footer_native` 에서 `layout.header_area` 로 hit 판정** | 단일 함수 | 높음 | bbox 확장과 무관하게 정확한 머리말 영역만 hit. 렌더링 동작 무영향. |
+| **B. `expand_bbox_to_children` 후 `layout.header_area` 로 max-clip** | `build_header` | 중 | bbox 자체를 보정. 단 구분선 line 의 클리핑 동작에 영향 가능. |
+| **C. 단 구분선 line 을 Header 자식이 아니라 별도 분류** | layout 분류 영역 | 낮음 | 영향 영역 광범위 — 회귀 위험 ↑ |
+
+**권장**: **옵션 A** — 영향 영역 좁고 본 결함 정정에 충분. 회귀 위험 최소.
+
+## 9. 다음 단계 (Stage 2)
+
+1. 정정 옵션 (A 권장) 작업지시자 승인
+2. `cursor_rect.rs::hit_test_header_footer_native` 에서 `layout.header_area` 사용으로 정정
+3. 단위 테스트 5 케이스 모두 pass 확인
+4. 광범위 sweep 재실행 — 회귀 0 확인
+5. e2e 정정 후 재시도 — 사용자 환경 정합 확인
+6. Stage 2 보고서 작성
+
+## 10. Stage 1 정리 항목
+
+- `examples/inspect_595.rs` — 보존 (정정 후 회귀 검증용으로 재사용 가능)
+- `rhwp-studio/public/samples/exam_math.hwp` — Stage 2 e2e 검증 후 제거
+- `tests/issue_595.rs` — 영구 보존 (회귀 차단 가드)
+
+---
+
+**Stage 1 완료 — Stage 2 진입 승인 요청**

--- a/mydocs/working/task_m100_595_stage2.md
+++ b/mydocs/working/task_m100_595_stage2.md
@@ -1,0 +1,162 @@
+# Task #595 Stage 2 완료 보고서
+
+**Issue**: #595 — exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작
+**브랜치**: `local/task595`
+**Stage**: 2 — 본질 정정 + 회귀 검증
+**날짜**: 2026-05-07
+
+---
+
+## 1. 정정 영역
+
+**파일**: `src/document_core/queries/cursor_rect.rs`
+**함수**: `hit_test_header_footer_native`
+
+**옵션 A 적용** — Header/Footer 노드의 bbox (자식 노드 까지 확장) 가 아닌, layout 의 정확한 `header_area` / `footer_area` 로 hit 판정.
+
+### 정정 전 (Stage 1 진단 결과)
+
+```rust
+let tree = self.build_page_tree(page_num)?;
+for child in &tree.root.children {
+    let is_header = matches!(child.node_type, RenderNodeType::Header);
+    let is_footer = matches!(child.node_type, RenderNodeType::Footer);
+    if !is_header && !is_footer { continue; }
+    if x >= child.bbox.x && x <= child.bbox.x + child.bbox.width
+        && y >= child.bbox.y && y <= child.bbox.y + child.bbox.height
+    {
+        // ... hit ...
+    }
+}
+```
+
+`child.bbox` 가 `expand_bbox_to_children` 으로 자식 (단 구분선 line) 까지 확장되어 본문 영역 침범.
+
+### 정정 후
+
+```rust
+let (page_content, _, _) = self.find_page(page_num)?;
+let layout = &page_content.layout;
+
+// 머리말 영역 hit 판정 (layout.header_area — 정확한 머리말 범위)
+let h = &layout.header_area;
+if x >= h.x && x <= h.x + h.width && y >= h.y && y <= h.y + h.height {
+    // ... hit ...
+}
+
+// 꼬리말 영역 hit 판정 (layout.footer_area)
+let f = &layout.footer_area;
+if x >= f.x && x <= f.x + f.width && y >= f.y && y <= f.y + f.height {
+    // ... hit ...
+}
+```
+
+`layout.header_area` / `layout.footer_area` 는 PageDef 의 margin 정보로 계산된 정확한 영역. bbox 확장과 무관.
+
+**부수 효과**: `build_page_tree` 호출 제거 → 효율 ↑ (mousedown / dblclick 마다 호출되던 비싼 트리 빌드 제거).
+
+## 2. 검증 결과
+
+### 2.1 재현 단위 테스트 (`tests/issue_595.rs`)
+
+```
+running 5 tests
+test issue_595_page1_header_area_still_hits ... ok                    ← 정상 가드
+test issue_595_page1_body_center_not_header ... ok                    ← Stage 1 fail → 정정 후 pass
+test issue_595_page0_body_coord_not_header ... ok                     ← 정상 baseline
+test issue_595_page1_body_coord_not_header_regression_guard ... ok   ← Stage 1 fail → 정정 후 pass
+test issue_595_page1_equation_coord_not_header ... ok                 ← Stage 1 fail → 정정 후 pass
+
+test result: ok. 5 passed; 0 failed
+```
+
+### 2.2 페이지별 hit y 범위 정상화 (`inspect_595.rs`)
+
+| 페이지 | 정정 전 | 정정 후 |
+|--------|---------|---------|
+| page 0 (1p) | 60.0 ~ 145.0 | **60.0 ~ 145.0** (정상 보존) |
+| page 1 (2p) | **60.0 ~ 1355.0** | **60.0 ~ 145.0** (정상화) |
+| page 2 (3p) | 60.0 ~ 1355.0 | 60.0 ~ 145.0 (정상화) |
+| page 3 (4p) | 60.0 ~ 1355.0 | 60.0 ~ 145.0 (정상화) |
+
+### 2.3 광범위 sweep (`samples/` 전체 164 fixture / 1684 페이지)
+
+| 항목 | 정정 전 | 정정 후 |
+|------|---------|---------|
+| 머리말 hit 본문 침범 fixture | 2 / 164 (1.2%) | **0 / 164 (0.0%)** |
+| 머리말 hit 본문 침범 페이지 | 32 / 1684 (1.9%) | **0 / 1684 (0.0%)** |
+
+### 2.4 회귀 sweep
+
+| 검증 | 결과 |
+|------|------|
+| `cargo test --lib --release` | **1140 passed** (회귀 0) |
+| `cargo clippy --release` (lib) | warning/error 0 (회귀 0) |
+| `cargo build --release` | clean |
+| `cargo test --release --test issue_516/530/546/554/595` | **30 passed** (회귀 0) |
+
+### 2.5 광범위 머리말/꼬리말/본문 영역 hit sweep (`inspect_595_regression`)
+
+164 fixture / 1684 페이지에서 정정 전 vs 정정 후 비교 (작업지시자 요청 — "비슷한 상황에서 기존 잘 되는 동작이 안 되는 것까지 신경 써달라"):
+
+| 항목 | 정정 전 | 정정 후 | 변화 |
+|------|---------|---------|------|
+| **머리말 영역 중앙 hit:true** (margin_header > 0) | 1329 pass / 27 fail | **1356 pass / 0 fail** | **+27 부수 개선** |
+| **꼬리말 영역 중앙 hit:true** (margin_footer > 0) | 1383 pass / 16 fail | 1383 pass / 16 fail | **동일 (회귀 0)** |
+| **본문 중앙 hit:false** (Issue #595 결함 영역) | 1652 pass / 32 fail | **1684 pass / 0 fail** | **+32 본질 정정** |
+
+**해석**:
+
+- **회귀 0** — 정정 후 fail 케이스 (꼬리말 16개) 는 정정 전에도 동일 fail. 본 정정과 무관.
+- **본질 정정** — 본문 영역 false-positive 32 페이지 (exam_math.hwp / exam_math_no.hwp) 완전 제거 → Issue #595 완전 해결.
+- **부수 개선** — 머리말 영역 hit 정확화 27 페이지. 정정 전에는 expand_bbox_to_children 결과가 자식 노드에 종속되어 머리말 영역 자체도 일부 hit 안 됐는데, 정정 후 layout.header_area 직접 사용으로 정확한 영역만 hit.
+- **별도 영역** — 꼬리말 16 페이지 fail (`hwpctl_Action_Table__v1.1.hwp` 한 fixture). 정정 전후 동일 → 본 task 무관, 별도 task 영역 후보.
+
+**검증 도구 `inspect_595_regression.rs`** — 영구 보존. 향후 hit_test_header_footer 영역 회귀 차단 가드로 재사용 가능.
+
+## 3. 정정 영향 영역
+
+| 영역 | 영향 |
+|------|------|
+| `hit_test_header_footer_native` 자체 | 본질 정정 — bbox 사용 → layout.area 사용 |
+| `build_page_tree` 호출 | **제거** — 효율 ↑ |
+| `expand_bbox_to_children` (`build_header`) | **무수정** — 렌더링 동작 보존 |
+| 머리말 표 셀 내 Shape 클리핑 | **무영향** — `expand_bbox_to_children` 의 의도 (클리핑 방지) 보존 |
+| 다른 hit_test 함수 (`hit_test_in_header_footer_native` 등) | **무영향** — 본 정정 함수 한정 |
+
+## 4. dblclick 흐름 정합 확인
+
+정정 후 `onDblClick` 흐름 ([rhwp-studio/src/engine/input-handler-mouse.ts:769-825](../../rhwp-studio/src/engine/input-handler-mouse.ts#L769)):
+
+1. `wasm.hitTestHeaderFooter(pageIdx, pageX, pageY)` — page 1+ 본문 좌표에서 `hit:false` 정상 반환
+2. 머리말 분기 미진입 → `if (this.cursor.isInPictureObjectSelection())` 분기 도달
+3. `ref.type === 'equation'` 확인 → `equation-edit-request` 이벤트 emit
+4. **수식 편집기 정상 진입** ✓
+
+## 5. 별도 발견 — 본 task 범위 밖
+
+Stage 1 e2e 진단에서 추가 발견 — **그리드 모드 (zoom ≤ 0.5) 좌표 결함**:
+
+`rhwp-studio/src/engine/input-handler-mouse.ts` 의 mouse hit 좌표 계산이 단일 컬럼 가정 (`pageLeft = (sc.clientWidth - pageDisplayWidth) / 2`). 그리드 모드에서 페이지가 다중 열 배치될 때 hit 좌표 계산 어긋남. 본 이슈 (#595) 와 별개 영역 — **별도 issue/task 분리 등록 권장** (Stage 3 정리 단계에서 처리).
+
+## 6. 다음 단계 (Stage 3)
+
+1. ~~e2e 정정 후 재검증~~ — WASM 재빌드 (Docker) 가 별도 단계라 본 stage 종료 후 작업지시자 직접 검증 영역 (또는 별도 단계)
+2. **이슈 #595 본문 정오표 코멘트 등록** — Stage 1 진단 + Stage 2 정정 + 검증 데이터 첨부
+3. **Stage 3 최종 보고서 + 오늘할일 갱신**
+4. `local/devel` merge → `devel` push 영역은 작업지시자 결정
+
+## 7. Stage 2 산출물
+
+- `src/document_core/queries/cursor_rect.rs::hit_test_header_footer_native` 정정 (단일 함수, +20/-13 LOC)
+- `mydocs/working/task_m100_595_stage2.md` (본 보고서)
+
+## 8. 정합 영역
+
+- **HWP IR 표준 직접 사용** — `layout.header_area` / `layout.footer_area` 는 PageDef margin 으로 계산된 정확한 머리말/꼬리말 영역. 휴리스틱 미도입 (`feedback_rule_not_heuristic` 정합).
+- **회귀 위험 영역 좁힘** — bbox 사용 → layout area 사용 으로 단일 함수만 정정. 렌더링 동작 무영향. `expand_bbox_to_children` 의 의도 (셀 내 Shape 클리핑 방지) 보존.
+- **본질 정정** — 우회/패치 아닌 정확한 영역 사용 (`feedback_root_cause_only` 정합).
+
+---
+
+**Stage 2 완료 — Stage 3 진입 (이슈 정오표 등록 + 최종 보고서) 승인 요청**

--- a/rhwp-studio/.gitignore
+++ b/rhwp-studio/.gitignore
@@ -1,3 +1,7 @@
 node_modules/
 dist/
 *.local
+
+# 측정용 샘플 심볼릭 링크 (e2e 로컬 실행 시 추가, 환경별 setup)
+public/samples/exam_kor.hwp
+public/samples/hwpctl_Action_Table__v1.1.hwp

--- a/rhwp-studio/e2e/body-outside-click-fallback.test.mjs
+++ b/rhwp-studio/e2e/body-outside-click-fallback.test.mjs
@@ -1,0 +1,197 @@
+/**
+ * 보류 ② 본문 외곽 클릭 fallback 결함 — 가설 (b) master page 글상자 hit 확정 e2e
+ *
+ * 본질: samples/hwpctl_Action_Table__v1.1.hwp (16p, landscape, margin_bottom=0)
+ * 의 page 16 꼬리말 영역 (footer_area.height=0) 클릭 시:
+ *   - 한컴: 문서 마지막 `}` 캐럿 배치 (본문 외곽 fallback)
+ *   - RHWP: 페이지 2, 3 으로 뷰 점프 (본질 결함)
+ *
+ * 본 측정은 input-handler-mouse onMouseDown 내부에서 호출되는 wasm.hitTest
+ * 결과를 직접 캡쳐하여 다음을 확인:
+ *   (a) cursor.moveTo(invalid) fallback?
+ *   (b) hit.isTextBox === true (master page 글상자 hit)?
+ *   (c) 일반 paragraph hit 인데 cursor.getRect() 의 pageIndex 가 click 페이지와 다름?
+ *
+ * 측정 항목:
+ *   - hit object 전체
+ *   - cursor.getPosition() / getRect() (click 후)
+ *   - scrollContainer.scrollTop (click 전후)
+ *   - 한컴 정합 동작 (마지막 `}` 캐럿) 비교 가능 여부
+ *
+ * 실행:
+ *   cd rhwp-studio
+ *   npx vite --host 0.0.0.0 --port 7700 &
+ *   node e2e/body-outside-click-fallback.test.mjs --mode=headless
+ */
+import { runTest, loadHwpFile, screenshot } from './helpers.mjs';
+
+async function probeFooterClick(page, label, pageIdx, hwpX, hwpY) {
+  console.log(`\n=== ${label} (page ${pageIdx}, hwpX=${hwpX}, hwpY=${hwpY}) ===`);
+
+  // 사전: page 정보 + scroll 안정화
+  const setup = await page.evaluate(({ pageIdx, hwpX, hwpY }) => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const wasm = window.__wasm;
+    const zoom = vm.getZoom();
+    const pw = vs.getPageWidth(pageIdx);
+    const ph = vs.getPageHeight(pageIdx);
+    const po = vs.getPageOffset(pageIdx);
+    const pl = vs.getPageLeft(pageIdx);
+    const plDOM = pl >= 0 ? pl : (sc.clientWidth - pw) / 2;
+    const docX = plDOM + hwpX * zoom;
+    const docY = po + hwpY * zoom;
+
+    const scroller = sc.parentElement;
+    const targetScrollY = Math.max(0, docY - 300);
+    scroller.scrollTop = targetScrollY;
+
+    return { zoom, pw, ph, po, pl, plDOM, docX, docY, targetScrollY };
+  }, { pageIdx, hwpX, hwpY });
+
+  await page.evaluate(() => new Promise(r => setTimeout(r, 500)));
+
+  // click 직전 hit 결과 + scrollTop 측정
+  const beforeClick = await page.evaluate(({ docX, docY, pageIdx }) => {
+    const sc = document.querySelector('#scroll-content');
+    const scroller = sc.parentElement;
+    const cr = sc.getBoundingClientRect();
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const wasm = window.__wasm;
+    const zoom = vm.getZoom();
+    const cx = docX;
+    const cy = docY;
+    const pageDisplayWidth = vs.getPageWidth(pageIdx);
+    const buggyLeft = (sc.clientWidth - pageDisplayWidth) / 2;
+    const correctLeft = vs.getPageLeft(pageIdx);
+    const correctLeftDOM = correctLeft >= 0 ? correctLeft : buggyLeft;
+    const buggyPageX = (cx - buggyLeft) / zoom;
+    const correctPageX = (cx - correctLeftDOM) / zoom;
+    const pageY = (cy - vs.getPageOffset(pageIdx)) / zoom;
+
+    // wasm hit 시리즈 (input-handler-mouse onMouseDown 흐름 모사 — buggy 좌표 사용)
+    let hit = null, hfHit = null, fnHit = null;
+    try { hit = wasm.hitTest(pageIdx, buggyPageX, pageY); } catch (e) { hit = { error: e?.message || String(e) }; }
+    try { hfHit = wasm.hitTestHeaderFooter(pageIdx, buggyPageX, pageY); } catch (e) {}
+    try { fnHit = wasm.hitTestFootnote(pageIdx, buggyPageX, pageY); } catch (e) {}
+
+    // findPictureAtClick (buggy 좌표 기준)
+    let picHit = null;
+    try { picHit = ih.findPictureAtClick(pageIdx, buggyPageX, pageY); } catch (e) { picHit = { error: e?.message || String(e) }; }
+
+    return {
+      scrollTop: scroller.scrollTop,
+      clientX: cr.left + docX,
+      clientY: cr.top + docY,
+      buggyPageX, correctPageX, pageY, buggyLeft, correctLeftDOM,
+      hit, hfHit, fnHit, picHit,
+    };
+  }, { docX: setup.docX, docY: setup.docY, pageIdx });
+
+  console.log(`  scroll.before = ${beforeClick.scrollTop.toFixed(1)}`);
+  console.log(`  click @(${beforeClick.clientX.toFixed(1)}, ${beforeClick.clientY.toFixed(1)})`);
+  console.log(`  buggyPageX=${beforeClick.buggyPageX.toFixed(1)} correctPageX=${beforeClick.correctPageX.toFixed(1)} pageY=${beforeClick.pageY.toFixed(1)}`);
+  console.log(`  buggyLeft=${beforeClick.buggyLeft.toFixed(1)} correctLeftDOM=${beforeClick.correctLeftDOM.toFixed(1)}`);
+  console.log(`  hit = ${JSON.stringify(beforeClick.hit)}`);
+  console.log(`  hfHit = ${JSON.stringify(beforeClick.hfHit)}`);
+  console.log(`  fnHit = ${JSON.stringify(beforeClick.fnHit)}`);
+  console.log(`  picHit = ${JSON.stringify(beforeClick.picHit)}`);
+
+  // 실제 click 발생
+  await page.mouse.click(beforeClick.clientX, beforeClick.clientY);
+  await page.evaluate(() => new Promise(r => setTimeout(r, 400)));
+
+  // click 후 cursor + scroll 상태
+  const afterClick = await page.evaluate(() => {
+    const sc = document.querySelector('#scroll-content');
+    const scroller = sc.parentElement;
+    const ih = window.__inputHandler;
+    const cur = ih?.cursor;
+    const pos = cur?.getPosition?.();
+    const rect = cur?.getRect?.();
+    return {
+      scrollTop: scroller.scrollTop,
+      pos: pos ? { sec: pos.sectionIndex, para: pos.paragraphIndex, char: pos.charOffset, parentParaIndex: pos.parentParaIndex, controlIndex: pos.controlIndex } : null,
+      rect: rect ? { pageIdx: rect.pageIndex, x: rect.x, y: rect.y, height: rect.height } : null,
+      isInTextBox: !!cur?.isInTextBox?.(),
+      isInPictureObjectSelection: !!cur?.isInPictureObjectSelection?.(),
+      isInTableObjectSelection: !!cur?.isInTableObjectSelection?.(),
+      isInHeaderFooter: !!cur?.isInHeaderFooter?.(),
+    };
+  });
+
+  console.log(`  scroll.after = ${afterClick.scrollTop.toFixed(1)}  (delta = ${(afterClick.scrollTop - beforeClick.scrollTop).toFixed(1)})`);
+  console.log(`  cursor.pos = ${JSON.stringify(afterClick.pos)}`);
+  console.log(`  cursor.rect = ${JSON.stringify(afterClick.rect)}`);
+  console.log(`  isInTextBox=${afterClick.isInTextBox} isInPictureObjectSelection=${afterClick.isInPictureObjectSelection} isInTableObjectSelection=${afterClick.isInTableObjectSelection} isInHeaderFooter=${afterClick.isInHeaderFooter}`);
+
+  // 가설 (b) 확정 조건 점검
+  const hypothesisB = beforeClick.hit?.isTextBox === true;
+  const hypothesisA = !beforeClick.hit || beforeClick.hit.error;
+  const scrollJumped = Math.abs(afterClick.scrollTop - beforeClick.scrollTop) > 50;
+  const rectPageMismatch = afterClick.rect && afterClick.rect.pageIdx !== pageIdx;
+
+  console.log(`\n  >>> 가설 (a) hit invalid: ${hypothesisA ? 'YES' : 'no'}`);
+  console.log(`  >>> 가설 (b) isTextBox=true: ${hypothesisB ? 'YES (master page 글상자 hit)' : 'no'}`);
+  console.log(`  >>> 가설 (c) rect.pageIdx mismatch: ${rectPageMismatch ? 'YES (click=' + pageIdx + ' rect=' + afterClick.rect?.pageIdx + ')' : 'no'}`);
+  console.log(`  >>> scroll 점프 발생: ${scrollJumped ? 'YES' : 'no'}`);
+
+  return { setup, beforeClick, afterClick, hypothesisA, hypothesisB, hypothesisC: rectPageMismatch, scrollJumped };
+}
+
+runTest('보류 ② 본문 외곽 fallback — hwpctl_Action_Table__v1.1.hwp 16p 꼬리말 click 가설 확정', async ({ page }) => {
+  await page.setViewport({ width: 1600, height: 1000 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 200)));
+
+  console.log('[1] hwpctl_Action_Table__v1.1.hwp 로드');
+  const info = await loadHwpFile(page, 'hwpctl_Action_Table__v1.1.hwp');
+  console.log(`  pageCount=${info.pageCount}`);
+  await screenshot(page, 'body-outside-01-loaded');
+
+  // zoom=1.0 (단일 컬럼) — 그리드 모드 결함 배제
+  await page.evaluate(() => window.__inputHandler.viewportManager.setZoom(1.0));
+  await page.evaluate(() => new Promise(r => setTimeout(r, 500)));
+
+  // page 정보 dump
+  const pageDump = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const wasm = window.__wasm;
+    const list = [];
+    for (let i = 0; i < vs.pageCount; i++) {
+      list.push({ i, w: vs.getPageWidth(i), h: vs.getPageHeight(i), o: vs.getPageOffset(i) });
+    }
+    return list;
+  });
+  console.log(`\n페이지 정보 (총 ${pageDump.length} 페이지):`);
+  for (const p of pageDump.slice(0, 4)) console.log(`  page ${p.i}: w=${p.w.toFixed(1)} h=${p.h.toFixed(1)} o=${p.o.toFixed(1)}`);
+  if (pageDump.length > 4) console.log(`  ...`);
+  for (const p of pageDump.slice(Math.max(0, pageDump.length - 3))) console.log(`  page ${p.i}: w=${p.w.toFixed(1)} h=${p.h.toFixed(1)} o=${p.o.toFixed(1)}`);
+
+  // page 16 (0-based 15) 꼬리말 영역 click — pageHeight 의 95% 위치
+  // landscape 297x210mm → pageHeight ≈ 793px (75 DPI 가정)
+  const targetPageIdx = Math.min(15, pageDump.length - 1);
+  const targetPage = pageDump[targetPageIdx];
+  const footerY = targetPage.h * 0.96;  // 페이지 하단 4% (꼬리말 영역)
+  const footerX = targetPage.w * 0.5;    // 페이지 가운데
+
+  console.log(`\n[2] page ${targetPageIdx} 꼬리말 영역 click 시뮬레이션`);
+  await probeFooterClick(page, `page ${targetPageIdx} 꼬리말 영역`, targetPageIdx, footerX, footerY);
+  await screenshot(page, 'body-outside-02-page16-footer-click');
+
+  // 비교 baseline: page 1 (0-based 0) 본문 영역 click — 정상 동작 확인
+  console.log(`\n[3] page 0 본문 click (정상 baseline)`);
+  await probeFooterClick(page, 'page 0 본문 영역', 0, pageDump[0].w * 0.5, pageDump[0].h * 0.5);
+  await screenshot(page, 'body-outside-03-page0-body-click');
+
+  // 비교: page 1 (0-based 1) 꼬리말 영역 click — 본 결함 재현 여부 (master page 영향 가설)
+  if (pageDump.length > 1) {
+    console.log(`\n[4] page 1 꼬리말 영역 click (master page 영향 비교)`);
+    await probeFooterClick(page, 'page 1 꼬리말 영역', 1, pageDump[1].w * 0.5, pageDump[1].h * 0.96);
+    await screenshot(page, 'body-outside-04-page1-footer-click');
+  }
+});

--- a/rhwp-studio/e2e/grid-mode-click-coord.test.mjs
+++ b/rhwp-studio/e2e/grid-mode-click-coord.test.mjs
@@ -1,0 +1,216 @@
+/**
+ * 보류 ① 그리드 좌표 결함 — 정량 e2e 측정
+ *
+ * 본질: zoom ≤ 0.5 그리드 모드에서 input-handler-mouse.ts 의 14곳이
+ * `pageLeft = (scrollContent.clientWidth - pageDisplayWidth) / 2` 단일 컬럼 가정 사용.
+ * 실제 페이지 element 의 left 는 `pageLefts[i]` (canvas-view.ts:158).
+ * 두 값의 차이가 click 좌표 어긋남 정도.
+ *
+ * 본 측정은:
+ *   1. 그리드 모드 활성 여부 확인 (zoom=0.5, multi-page)
+ *   2. 각 페이지 (col 0/1/2/...) 의 correct vs buggy pageLeft 값 비교
+ *   3. delta_px (CSS px 단위) 정량화
+ *   4. 실제 click 시 cursor 위치 어긋남 검증 (correct 좌표로 click → 정상, buggy 좌표로 click → 어긋남)
+ *
+ * 실행:
+ *   cd rhwp-studio
+ *   npx vite --host 0.0.0.0 --port 7700 &
+ *   node e2e/grid-mode-click-coord.test.mjs --mode=headless
+ */
+import { runTest, loadHwpFile, screenshot } from './helpers.mjs';
+
+async function dumpGridState(page, label) {
+  console.log(`\n=== ${label} ===`);
+  const state = await page.evaluate(() => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const zoom = vm.getZoom();
+    const isGrid = vs.isGridMode();
+    const columns = vs.getColumns();
+    const pageCount = vs.pageCount;
+    const clientWidth = sc.clientWidth;
+    const rows = [];
+    for (let i = 0; i < pageCount; i++) {
+      const correct = vs.getPageLeft(i);
+      const pw = vs.getPageWidth(i);
+      const buggy = (clientWidth - pw) / 2;
+      const col = i % Math.max(columns, 1);
+      const delta = correct >= 0 ? (buggy - correct) : 0;
+      rows.push({ i, col, pw, correct, buggy, delta });
+    }
+    return { zoom, isGrid, columns, pageCount, clientWidth, rows };
+  });
+
+  console.log(`  zoom=${state.zoom}  grid=${state.isGrid}  columns=${state.columns}  pageCount=${state.pageCount}  clientWidth=${state.clientWidth}`);
+  console.log(`  | i  | col | pw     | correct(pageLefts[i]) | buggy(formula) | delta_px |`);
+  console.log(`  |----|-----|--------|-----------------------|----------------|----------|`);
+  for (const r of state.rows.slice(0, 8)) {  // 첫 8 페이지만 출력
+    console.log(`  | ${String(r.i).padEnd(2)} | ${String(r.col).padEnd(3)} | ${r.pw.toFixed(1).padEnd(6)} | ${r.correct.toFixed(1).padEnd(21)} | ${r.buggy.toFixed(1).padEnd(14)} | ${r.delta.toFixed(1).padEnd(8)} |`);
+  }
+  return state;
+}
+
+async function probeClickAtPage(page, label, pageIdx, hwpX, hwpY) {
+  console.log(`\n--- ${label} (page ${pageIdx}, hwpX=${hwpX}, hwpY=${hwpY}) ---`);
+
+  // correct 좌표 + buggy 좌표 둘 다 계산
+  const probe = await page.evaluate(({ pageIdx, hwpX, hwpY }) => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const zoom = vm.getZoom();
+    const pw = vs.getPageWidth(pageIdx);
+    const po = vs.getPageOffset(pageIdx);
+
+    // CORRECT: pageLefts[i] 사용 (실제 페이지 element 위치)
+    const correctLeft = vs.getPageLeft(pageIdx);
+    const correctLeftDOM = correctLeft >= 0 ? correctLeft : (sc.clientWidth - pw) / 2;
+    const correctDocX = correctLeftDOM + hwpX * zoom;
+    const correctDocY = po + hwpY * zoom;
+
+    // BUGGY: (clientWidth - pageDisplayWidth) / 2 (input-handler-mouse 의 가정)
+    const buggyLeft = (sc.clientWidth - pw) / 2;
+    const buggyDocX = buggyLeft + hwpX * zoom;
+    const buggyDocY = po + hwpY * zoom;
+
+    // 스크롤 안정화
+    const scroller = sc.parentElement;
+    scroller.scrollTop = Math.max(0, correctDocY - 200);
+
+    return {
+      zoom, pw, po, correctLeft, correctLeftDOM, buggyLeft,
+      correctDocX, correctDocY, buggyDocX, buggyDocY,
+      delta_x: buggyDocX - correctDocX,
+    };
+  }, { pageIdx, hwpX, hwpY });
+
+  await page.evaluate(() => new Promise(r => setTimeout(r, 400)));
+
+  // CORRECT 좌표로 click 후 cursor 위치 확인
+  const correctClick = await page.evaluate(({ correctDocX, correctDocY }) => {
+    const sc = document.querySelector('#scroll-content');
+    const cr = sc.getBoundingClientRect();
+    return { clientX: cr.left + correctDocX, clientY: cr.top + correctDocY };
+  }, probe);
+
+  await page.mouse.click(correctClick.clientX, correctClick.clientY);
+  await page.evaluate(() => new Promise(r => setTimeout(r, 250)));
+
+  const afterCorrectClick = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const cur = ih?.cursor;
+    const pos = cur?.getPosition?.();
+    const rect = cur?.getRect?.();
+    return {
+      pos: pos ? { sec: pos.sectionIndex, para: pos.paragraphIndex, char: pos.charOffset } : null,
+      rectPageIdx: rect?.pageIndex ?? null,
+      rectX: rect?.x ?? null,
+      rectY: rect?.y ?? null,
+    };
+  });
+
+  // BUGGY 좌표로 click 후 cursor 위치 확인 (input-handler-mouse 의 현재 동작 모사)
+  await page.mouse.click(correctClick.clientX + probe.delta_x, correctClick.clientY);
+  await page.evaluate(() => new Promise(r => setTimeout(r, 250)));
+
+  const afterBuggyClick = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const cur = ih?.cursor;
+    const pos = cur?.getPosition?.();
+    const rect = cur?.getRect?.();
+    return {
+      pos: pos ? { sec: pos.sectionIndex, para: pos.paragraphIndex, char: pos.charOffset } : null,
+      rectPageIdx: rect?.pageIndex ?? null,
+      rectX: rect?.x ?? null,
+      rectY: rect?.y ?? null,
+    };
+  });
+
+  console.log(`  zoom=${probe.zoom} pw=${probe.pw.toFixed(1)} po=${probe.po.toFixed(1)}`);
+  console.log(`  correctLeft=${probe.correctLeft} correctLeftDOM=${probe.correctLeftDOM.toFixed(1)} buggyLeft=${probe.buggyLeft.toFixed(1)}`);
+  console.log(`  delta_x = ${probe.delta_x.toFixed(1)} px (CSS px, click 어긋남 정도)`);
+  console.log(`  CORRECT click @(${correctClick.clientX.toFixed(1)}, ${correctClick.clientY.toFixed(1)}) → pos=${JSON.stringify(afterCorrectClick.pos)} rectPage=${afterCorrectClick.rectPageIdx}`);
+  console.log(`  BUGGY  click @(${(correctClick.clientX + probe.delta_x).toFixed(1)}, ${correctClick.clientY.toFixed(1)}) → pos=${JSON.stringify(afterBuggyClick.pos)} rectPage=${afterBuggyClick.rectPageIdx}`);
+
+  return { probe, correctClick, afterCorrectClick, afterBuggyClick };
+}
+
+runTest('보류 ① 그리드 좌표 결함 — exam_kor.hwp zoom=0.5 정량 측정', async ({ page }) => {
+  // 충분히 큰 viewport 로 columns >= 2 보장
+  await page.setViewport({ width: 1600, height: 1000 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 200)));
+
+  console.log('[1] exam_kor.hwp 로드');
+  const info = await loadHwpFile(page, 'exam_kor.hwp');
+  console.log(`  pageCount=${info.pageCount}`);
+
+  await screenshot(page, 'grid-coord-01-loaded');
+
+  // [2] zoom=0.5 → 그리드 모드 활성
+  console.log('\n[2] zoom=0.5 변경');
+  await page.evaluate(() => {
+    window.__inputHandler.viewportManager.setZoom(0.5);
+  });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+  await screenshot(page, 'grid-coord-02-zoom05');
+
+  const stateZ05 = await dumpGridState(page, 'zoom=0.5 그리드 상태');
+
+  // [3] zoom=0.25 → columns 더 많음
+  console.log('\n[3] zoom=0.25 변경');
+  await page.evaluate(() => {
+    window.__inputHandler.viewportManager.setZoom(0.25);
+  });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+  await screenshot(page, 'grid-coord-03-zoom025');
+
+  const stateZ025 = await dumpGridState(page, 'zoom=0.25 그리드 상태');
+
+  // [4] zoom=1.0 (단일 컬럼) - 비교 baseline
+  console.log('\n[4] zoom=1.0 변경 (단일 컬럼)');
+  await page.evaluate(() => {
+    window.__inputHandler.viewportManager.setZoom(1.0);
+  });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+
+  const stateZ10 = await dumpGridState(page, 'zoom=1.0 단일 컬럼 (정상 baseline)');
+
+  // [5] zoom=0.5 + 실제 click 측정 — col 0/1 페이지 비교
+  console.log('\n[5] zoom=0.5 실제 click 측정');
+  await page.evaluate(() => {
+    window.__inputHandler.viewportManager.setZoom(0.5);
+  });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+
+  // page 0 (col 0) — 임의 좌표 (페이지 좌측 상단)
+  await probeClickAtPage(page, 'page 0 (col 0)', 0, 100, 200);
+  await screenshot(page, 'grid-coord-04-page0-click');
+
+  // page 1 (col 1) — 동일 페이지 내 좌표
+  await probeClickAtPage(page, 'page 1 (col 1)', 1, 100, 200);
+  await screenshot(page, 'grid-coord-05-page1-click');
+
+  // page 2 (col 0 if columns=2, col 2 if columns >=3) — 가운데 열 가능성
+  if (stateZ05.pageCount >= 3) {
+    await probeClickAtPage(page, 'page 2 (col=2 % columns)', 2, 100, 200);
+    await screenshot(page, 'grid-coord-06-page2-click');
+  }
+
+  // 결과 요약
+  console.log('\n=== 측정 결과 요약 ===');
+  console.log(`zoom=0.5: columns=${stateZ05.columns}, delta 분포 (page 0..7):`);
+  for (const r of stateZ05.rows.slice(0, 8)) {
+    console.log(`  page ${r.i} (col ${r.col}): delta_px = ${r.delta.toFixed(1)}`);
+  }
+  console.log(`zoom=0.25: columns=${stateZ025.columns}, delta 분포 (page 0..7):`);
+  for (const r of stateZ025.rows.slice(0, 8)) {
+    console.log(`  page ${r.i} (col ${r.col}): delta_px = ${r.delta.toFixed(1)}`);
+  }
+  console.log(`zoom=1.0 (baseline): columns=${stateZ10.columns}, delta 분포 (page 0..3):`);
+  for (const r of stateZ10.rows.slice(0, 4)) {
+    console.log(`  page ${r.i} (col ${r.col}): delta_px = ${r.delta.toFixed(1)}`);
+  }
+});

--- a/rhwp-studio/e2e/issue-595.test.mjs
+++ b/rhwp-studio/e2e/issue-595.test.mjs
@@ -1,0 +1,309 @@
+/**
+ * Issue #595 진단 e2e
+ *
+ * 본질: exam_math.hwp 의 수식을 더블클릭했을 때 1페이지(0-based 0) 만 정상,
+ * 2페이지(0-based 1) 부터 findPictureAtClick 이 hit 으로 인식하지 못 함.
+ *
+ * 본 e2e 는 정정 패치 전 단계로, page 1 vs page 2 의 좌표/매칭 결과를
+ * 직접 비교하여 본질 가설을 데이터로 검증한다.
+ *
+ * 실행:
+ *   cd rhwp-studio
+ *   npx vite --host 0.0.0.0 --port 7700 &
+ *   node e2e/issue-595.test.mjs --mode=headless
+ *
+ * 또는:
+ *   node e2e/issue-595.test.mjs --mode=host
+ */
+import { runTest, loadHwpFile, screenshot } from './helpers.mjs';
+
+// 진단 유틸 — page.evaluate 안에서 좌표 변환 + bbox 매칭 직접 호출
+async function probe(page, label, target) {
+  console.log(`\n=== ${label} ===`);
+  console.log(`  target: paraIdx=${target.paraIdx} ci=${target.ci}, pageInside=(${target.pageX}, ${target.pageY})`);
+
+  // 1) 좌표 변환 + 진단 데이터 캡처 (클릭 전)
+  const beforeClick = await page.evaluate((t) => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const cv = window.__canvasView;
+    if (!sc || !ih || !cv) {
+      return { error: `missing globals: sc=${!!sc} ih=${!!ih} cv=${!!cv}` };
+    }
+    // private 접근 (TS private 은 컴파일 시만 — JS 런타임 접근 가능)
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const wasm = window.__wasm;
+    const zoom = vm.getZoom();
+    const pageWidth = vs.getPageWidth(t.targetPageIdx);
+    const pageHeight = vs.getPageHeight(t.targetPageIdx);
+    const pageOffset = vs.getPageOffset(t.targetPageIdx);
+    const pageLefts = [];
+    const pageOffsets = [];
+    const pageHeights = [];
+    for (let i = 0; i < vs.pageCount; i++) {
+      pageLefts.push(vs.getPageLeft(i));
+      pageOffsets.push(vs.getPageOffset(i));
+      pageHeights.push(vs.getPageHeight(i));
+    }
+
+    // 페이지 내부 좌표 (HWP layout 단위) → DOM 좌표
+    // canvas style.left 가 -1 이면 CSS 중앙 정렬 사용
+    const pageLeftRaw = vs.getPageLeft(t.targetPageIdx);
+    const pageLeftDOM = pageLeftRaw >= 0 ? pageLeftRaw : (sc.clientWidth - pageWidth) / 2;
+    const docX = pageLeftDOM + t.pageX * zoom;
+    const docY = pageOffset + t.pageY * zoom;
+
+    // 스크롤하여 클릭 좌표가 화면 안에 들어오게
+    const scroller = sc.parentElement;
+    const targetScrollY = Math.max(0, docY - 200);
+    scroller.scrollTop = targetScrollY;
+
+    return {
+      zoom,
+      pageWidth,
+      pageHeight,
+      pageOffset,
+      pageLeftRaw,
+      pageLeftDOM,
+      docX,
+      docY,
+      targetScrollY,
+      scrollContentClientWidth: sc.clientWidth,
+      scrollerScrollTop: scroller.scrollTop,
+      pageOffsets,
+      pageHeights,
+      pageLefts,
+      pageCount: vs.pageCount,
+    };
+  }, { ...target });
+
+  if (beforeClick.error) throw new Error(`probe failed: ${beforeClick.error}`);
+
+  // 스크롤 안정화 대기
+  await page.evaluate(() => new Promise(r => setTimeout(r, 400)));
+
+  // 2) clientX/clientY 계산 (스크롤 후 contentRect 기준)
+  const clickPoint = await page.evaluate((d) => {
+    const sc = document.querySelector('#scroll-content');
+    const cr = sc.getBoundingClientRect();
+    const clientX = cr.left + d.docX;
+    const clientY = cr.top + d.docY;
+    // 안전: clientY 가 viewport 안에 있는지 확인 (스크롤 안정화 후)
+    const vph = window.innerHeight;
+    return {
+      clientX, clientY, crLeft: cr.left, crTop: cr.top,
+      viewportHeight: vph,
+      inViewport: clientY >= 0 && clientY < vph,
+    };
+  }, { docX: beforeClick.docX, docY: beforeClick.docY });
+
+  // 3) 클릭 직전 inputHandler.findPictureAtClick 직접 호출 + 좌표 재계산 (클릭 모사)
+  const probeResult = await page.evaluate((cp) => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const vm = ih.viewportManager;
+    const vs = ih.virtualScroll;
+    const wasm = window.__wasm;
+    const zoom = vm.getZoom();
+    const cr = sc.getBoundingClientRect();
+    // 마우스 핸들러와 동일한 식
+    const cx = cp.clientX - cr.left;
+    const cy = cp.clientY - cr.top;
+    const pageIdx = vs.getPageAtY(cy);
+    const pageOffset = vs.getPageOffset(pageIdx);
+    const pageDisplayWidth = vs.getPageWidth(pageIdx);
+    const pageLeft = (sc.clientWidth - pageDisplayWidth) / 2;
+    const pageX = (cx - pageLeft) / zoom;
+    const pageY = (cy - pageOffset) / zoom;
+
+    // layout.controls 중 type=equation 만 추출 (개수만)
+    let layoutSummary = null;
+    try {
+      const json = wasm.getPageControlLayout(pageIdx);
+      const layout = JSON.parse(json);
+      const eqs = (layout.controls || []).filter(c => c.type === 'equation');
+      layoutSummary = {
+        total: (layout.controls || []).length,
+        equationCount: eqs.length,
+      };
+    } catch (e) {
+      layoutSummary = { error: e?.message || String(e) };
+    }
+
+    // wasm.hitTest 결과 (mousedown 흐름 모사)
+    let hitResult = null;
+    try {
+      hitResult = wasm.hitTest(pageIdx, pageX, pageY);
+    } catch (e) {
+      hitResult = { error: e?.message || String(e) };
+    }
+
+    // 머리말/꼬리말 hit
+    let hfHit = null, fnHit = null, formHit = null;
+    try { hfHit = wasm.hitTestHeaderFooter(pageIdx, pageX, pageY); } catch (e) {}
+    try { fnHit = wasm.hitTestFootnote(pageIdx, pageX, pageY); } catch (e) {}
+    try { formHit = wasm.getFormObjectAt(pageIdx, pageX, pageY); } catch (e) {}
+
+    // findPictureAtClick 직접 호출
+    let picHit = null;
+    try {
+      picHit = ih.findPictureAtClick(pageIdx, pageX, pageY);
+    } catch (e) {
+      picHit = { error: e?.message || String(e) };
+    }
+    return { cx, cy, pageIdx, pageOffset, pageDisplayWidth, pageLeft, pageX, pageY,
+             picHit, layoutSummary, hitResult, hfHit, fnHit, formHit };
+  }, clickPoint);
+
+  // 4) 실제 클릭 이벤트 발생
+  await page.mouse.click(clickPoint.clientX, clickPoint.clientY);
+  await page.evaluate(() => new Promise(r => setTimeout(r, 300)));
+
+  // 5) 클릭 결과 — cursor 상태 확인
+  const afterClick = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const cur = ih?.cursor;
+    return {
+      isInPictureObjectSelection: !!cur?.isInPictureObjectSelection?.(),
+      isInTextBox: !!cur?.isInTextBox?.(),
+      pos: cur?.getPosition?.() ? {
+        sectionIndex: cur.getPosition().sectionIndex,
+        paragraphIndex: cur.getPosition().paragraphIndex,
+        charOffset: cur.getPosition().charOffset,
+      } : null,
+      selectedPictureRef: cur?.getSelectedPictureRef?.() ?? null,
+    };
+  });
+
+  console.log(`  zoom=${beforeClick.zoom}  pageOffsets[0..3]=${beforeClick.pageOffsets.slice(0,4).map(v => v.toFixed(1)).join(', ')}`);
+  console.log(`  pageHeight=${beforeClick.pageHeight.toFixed(1)}  pageWidth=${beforeClick.pageWidth.toFixed(1)}  pageLeftRaw=${beforeClick.pageLeftRaw}  pageLeftDOM=${beforeClick.pageLeftDOM.toFixed(1)}`);
+  console.log(`  docX=${beforeClick.docX.toFixed(1)} docY=${beforeClick.docY.toFixed(1)} → scrollTop=${beforeClick.targetScrollY.toFixed(1)}`);
+  console.log(`  clientX=${clickPoint.clientX.toFixed(1)} clientY=${clickPoint.clientY.toFixed(1)} cr=(${clickPoint.crLeft.toFixed(1)}, ${clickPoint.crTop.toFixed(1)}) inVp=${clickPoint.inViewport}`);
+  console.log(`  [PROBE 좌표 역계산] cx=${probeResult.cx.toFixed(1)} cy=${probeResult.cy.toFixed(1)} → pageIdx=${probeResult.pageIdx} pageOffset=${probeResult.pageOffset.toFixed(1)} pageX=${probeResult.pageX.toFixed(1)} pageY=${probeResult.pageY.toFixed(1)}`);
+  console.log(`  [PROBE layout] page ${probeResult.pageIdx} controls=${probeResult.layoutSummary?.total} equations=${probeResult.layoutSummary?.equationCount}`);
+  console.log(`  [PROBE wasm.hitTest] ${JSON.stringify(probeResult.hitResult)}`);
+  console.log(`  [PROBE hf/fn/form] hf=${JSON.stringify(probeResult.hfHit)} fn=${JSON.stringify(probeResult.fnHit)} form=${JSON.stringify(probeResult.formHit)}`);
+  console.log(`  [PROBE findPictureAtClick] ${JSON.stringify(probeResult.picHit)}`);
+  console.log(`  [AFTER CLICK] picSel=${afterClick.isInPictureObjectSelection} textBox=${afterClick.isInTextBox} pos=${JSON.stringify(afterClick.pos)} selRef=${JSON.stringify(afterClick.selectedPictureRef)}`);
+
+  return { beforeClick, clickPoint, probeResult, afterClick };
+}
+
+runTest('Issue #595 — exam_math.hwp page 1 vs page 2 수식 hitTest 비교 (1365x1018 사용자 환경)', async ({ page }) => {
+  // 사용자 환경: 1365x1018, zoom=100%
+  await page.setViewport({ width: 1365, height: 1018 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 200)));
+
+  console.log('[1] exam_math.hwp 로드');
+  const info = await loadHwpFile(page, 'exam_math.hwp');
+  console.log(`  pageCount=${info.pageCount}`);
+
+  // 환경 정보
+  const env = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const vs = ih?.virtualScroll;
+    return {
+      windowInner: { w: window.innerWidth, h: window.innerHeight },
+      dpr: window.devicePixelRatio,
+      zoom: ih?.viewportManager?.getZoom?.(),
+      gridMode: vs?.isGridMode?.(),
+      columns: vs?.getColumns?.(),
+      pageCount: vs?.pageCount,
+    };
+  });
+  console.log(`  env: window=${env.windowInner.w}x${env.windowInner.h} dpr=${env.dpr} zoom=${env.zoom} grid=${env.gridMode} cols=${env.columns} pageCount=${env.pageCount}`);
+  await screenshot(page, 'issue595-01-loaded');
+
+  // page 1 (0-based 0) — paraIdx=18 ci=0 수식 (x=130.8 y=818.3 w=108.0 h=17.5)
+  const r1 = await probe(page, 'page 1 (0-based 0) — paraIdx=18 ci=0 수식 [zoom=1]', {
+    targetPageIdx: 0,
+    paraIdx: 18, ci: 0,
+    pageX: 130.8 + 50, // bbox 중앙 근처
+    pageY: 818.3 + 8,
+  });
+  await screenshot(page, 'issue595-02-page1-clicked');
+
+  // page 2 (0-based 1) — paraIdx=65 ci=0 수식 (x=589.5 y=191.7 w=131.7 h=37.3) — 이슈 명세
+  const r2 = await probe(page, 'page 2 (0-based 1) — paraIdx=65 ci=0 수식 [zoom=1]', {
+    targetPageIdx: 1,
+    paraIdx: 65, ci: 0,
+    pageX: 589.5 + 65,
+    pageY: 191.7 + 18,
+  });
+  await screenshot(page, 'issue595-03-page2-clicked');
+
+  // ─── 추가 시나리오: 다양한 zoom 에서 page 2 수식 클릭 ───
+  // 사용자 환경에서 발현 가능성: 모바일 fit-to-width (zoom < 1) / Hi-DPI 확대 (zoom > 1)
+  for (const z of [0.5, 0.75, 1.5, 2.0]) {
+    console.log(`\n>>> zoom=${z} 로 변경 후 page 2 수식 재시도`);
+    await page.evaluate((zoom) => {
+      window.__inputHandler.viewportManager.setZoom(zoom);
+    }, z);
+    await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+    const rZ = await probe(page, `page 2 (0-based 1) — paraIdx=65 ci=0 수식 [zoom=${z}]`, {
+      targetPageIdx: 1,
+      paraIdx: 65, ci: 0,
+      pageX: 589.5 + 65,
+      pageY: 191.7 + 18,
+    });
+    await screenshot(page, `issue595-zoom-${z}`.replace('.', '_'));
+  }
+
+  // 원래 zoom 으로 복귀
+  await page.evaluate(() => window.__inputHandler.viewportManager.setZoom(1.0));
+  await page.evaluate(() => new Promise(r => setTimeout(r, 400)));
+
+  // ─── 더블클릭 시뮬레이션 ───
+  console.log('\n>>> page 2 수식 더블클릭 (실제 사용자 동작 모사)');
+  const dblTarget = await page.evaluate(() => {
+    const sc = document.querySelector('#scroll-content');
+    const ih = window.__inputHandler;
+    const vs = ih.virtualScroll;
+    const vm = ih.viewportManager;
+    const zoom = vm.getZoom();
+    const pageIdx = 1;
+    const pageW = vs.getPageWidth(pageIdx);
+    const pageOffset = vs.getPageOffset(pageIdx);
+    const pageLeftDOM = (sc.clientWidth - pageW) / 2;
+    const pageX = 589.5 + 65, pageY = 191.7 + 18;
+    const docX = pageLeftDOM + pageX * zoom;
+    const docY = pageOffset + pageY * zoom;
+    sc.parentElement.scrollTop = Math.max(0, docY - 200);
+    return new Promise(r => requestAnimationFrame(() => {
+      const cr = sc.getBoundingClientRect();
+      r({ clientX: cr.left + docX, clientY: cr.top + docY });
+    }));
+  });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 400)));
+  // 두 번 빠르게 클릭 (Puppeteer 더블클릭)
+  await page.mouse.click(dblTarget.clientX, dblTarget.clientY, { clickCount: 2, delay: 50 });
+  await page.evaluate(() => new Promise(r => setTimeout(r, 600)));
+  const afterDbl = await page.evaluate(() => {
+    const ih = window.__inputHandler;
+    const cur = ih?.cursor;
+    return {
+      isInPictureObjectSelection: !!cur?.isInPictureObjectSelection?.(),
+      selectedPictureRef: cur?.getSelectedPictureRef?.() ?? null,
+    };
+  });
+  console.log(`  더블클릭 후: picSel=${afterDbl.isInPictureObjectSelection} selRef=${JSON.stringify(afterDbl.selectedPictureRef)}`);
+  await screenshot(page, 'issue595-04-dblclick');
+
+  // 비교 요약
+  console.log('\n=== 비교 요약 ===');
+  console.log(`page 1: picHit=${JSON.stringify(r1.probeResult.picHit)} → afterClick.picSel=${r1.afterClick.isInPictureObjectSelection}`);
+  console.log(`page 2: picHit=${JSON.stringify(r2.probeResult.picHit)} → afterClick.picSel=${r2.afterClick.isInPictureObjectSelection}`);
+
+  // 검증: page 1 정상, page 2 fail 가설 확인
+  const page1Ok = r1.probeResult.picHit && !r1.probeResult.picHit.error;
+  const page2Ok = r2.probeResult.picHit && !r2.probeResult.picHit.error;
+  console.log(`\n[가설 검증] page1 picture hit OK=${!!page1Ok}  /  page2 picture hit OK=${!!page2Ok}`);
+  if (page1Ok && !page2Ok) {
+    console.log('  → 이슈 재현 ✓ (page 1 정상 / page 2 fail)');
+  } else if (page1Ok && page2Ok) {
+    console.log('  → 이슈 재현 실패 — 두 페이지 모두 정상 (좌표 모델 불일치 가능성)');
+  } else {
+    console.log(`  → 예상 외 결과: page1=${!!page1Ok}, page2=${!!page2Ok}`);
+  }
+});

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -1776,40 +1776,53 @@ impl DocumentCore {
     /// 페이지 좌표가 머리말 또는 꼬리말 영역에 해당하는지 판별.
     /// 반환: JSON `{"hit":true,"isHeader":bool,"sectionIndex":N,"applyTo":N}`
     /// 또는 `{"hit":false}`
+    ///
+    /// Issue #595: Header/Footer 노드의 bbox 는 `expand_bbox_to_children` 으로
+    /// 자식 (예: 단 구분선 line) 까지 확장되어 본문 영역을 침범할 수 있음.
+    /// hit 판정은 layout 의 정확한 `header_area` / `footer_area` 로 수행하여
+    /// bbox 확장과 무관하게 본질 영역만 hit.
     pub fn hit_test_header_footer_native(
         &self,
         page_num: u32,
         x: f64,
         y: f64,
     ) -> Result<String, HwpError> {
-        use crate::renderer::render_tree::RenderNodeType;
+        let (page_content, _, _) = self.find_page(page_num)?;
+        let layout = &page_content.layout;
 
-        let tree = self.build_page_tree(page_num)?;
-
-        for child in &tree.root.children {
-            let is_header = matches!(child.node_type, RenderNodeType::Header);
-            let is_footer = matches!(child.node_type, RenderNodeType::Footer);
-            if !is_header && !is_footer { continue; }
-
-            if x >= child.bbox.x && x <= child.bbox.x + child.bbox.width
-                && y >= child.bbox.y && y <= child.bbox.y + child.bbox.height
-            {
-                // active header/footer에서 source_section_index와 apply_to 추출
-                // 머리말/꼬리말은 이전 구역에서 상속될 수 있으므로
-                // 페이지 소속 구역이 아닌 source_section_index를 반환해야 함
-                if let Some((source_sec, apply_to)) = self.get_active_hf_info(page_num, is_header) {
-                    return Ok(format!(
-                        "{{\"hit\":true,\"isHeader\":{},\"sectionIndex\":{},\"applyTo\":{}}}",
-                        is_header, source_sec, apply_to
-                    ));
-                }
-                // active 정보가 없는 경우 fallback
-                let (section_idx, _) = self.find_section_for_page(page_num);
+        // 머리말 영역 hit 판정 (layout.header_area — 정확한 머리말 범위)
+        let h = &layout.header_area;
+        if x >= h.x && x <= h.x + h.width && y >= h.y && y <= h.y + h.height {
+            // active header에서 source_section_index와 apply_to 추출
+            // 머리말은 이전 구역에서 상속될 수 있으므로 source_section_index 우선
+            if let Some((source_sec, apply_to)) = self.get_active_hf_info(page_num, true) {
                 return Ok(format!(
-                    "{{\"hit\":true,\"isHeader\":{},\"sectionIndex\":{},\"applyTo\":0}}",
-                    is_header, section_idx
+                    "{{\"hit\":true,\"isHeader\":true,\"sectionIndex\":{},\"applyTo\":{}}}",
+                    source_sec, apply_to
                 ));
             }
+            // active 정보가 없는 경우 fallback (빈 머리말 영역 — 신규 생성 대상)
+            let (section_idx, _) = self.find_section_for_page(page_num);
+            return Ok(format!(
+                "{{\"hit\":true,\"isHeader\":true,\"sectionIndex\":{},\"applyTo\":0}}",
+                section_idx
+            ));
+        }
+
+        // 꼬리말 영역 hit 판정 (layout.footer_area)
+        let f = &layout.footer_area;
+        if x >= f.x && x <= f.x + f.width && y >= f.y && y <= f.y + f.height {
+            if let Some((source_sec, apply_to)) = self.get_active_hf_info(page_num, false) {
+                return Ok(format!(
+                    "{{\"hit\":true,\"isHeader\":false,\"sectionIndex\":{},\"applyTo\":{}}}",
+                    source_sec, apply_to
+                ));
+            }
+            let (section_idx, _) = self.find_section_for_page(page_num);
+            return Ok(format!(
+                "{{\"hit\":true,\"isHeader\":false,\"sectionIndex\":{},\"applyTo\":0}}",
+                section_idx
+            ));
         }
 
         Ok("{\"hit\":false}".to_string())

--- a/tests/issue_595.rs
+++ b/tests/issue_595.rs
@@ -1,0 +1,87 @@
+//! Issue #595: exam_math.hwp 2페이지부터 수식 더블클릭 hitTest 오동작.
+//!
+//! 본질: `src/renderer/layout.rs::build_header` 의 `expand_bbox_to_children`
+//! 호출이 머리말 자식 노드 (특히 단 구분선 line `paraIdx=0 ci=2`, h≈1227px) 의
+//! bbox 까지 Header 영역으로 확장 → `hit_test_header_footer_native` 가 본문 좌표를
+//! 머리말 hit 으로 잘못 인식 → `onDblClick` 의 머리말 분기가 picture selection
+//! 분기보다 먼저 실행되어 수식 편집기 진입 차단.
+//!
+//! 발현: page 0 (1p) 정상 / page 1+ (2p~) 결함.
+//!
+//! 본 테스트는 정정 전 fail / 정정 후 pass — 회귀 차단 영구 가드.
+
+use std::fs;
+use std::path::Path;
+
+fn load_exam_math() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/exam_math.hwp");
+    let bytes = fs::read(&hwp_path).expect("read exam_math.hwp");
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse exam_math.hwp")
+}
+
+/// page 0 (1-based 1) 의 본문 좌표 (514, 200) 는 머리말 hit 이 아니어야 한다.
+/// 정상 머리말 영역은 y=0~147 정도. 본 테스트는 baseline (정정 전에도 통과 예상).
+#[test]
+fn issue_595_page0_body_coord_not_header() {
+    let doc = load_exam_math();
+    let r = doc.hit_test_header_footer_native(0, 514.0, 200.0).unwrap();
+    assert!(
+        r.contains("\"hit\":false"),
+        "page 0 본문 좌표 (514, 200) 가 머리말 hit 으로 잘못 인식됨: {}",
+        r
+    );
+}
+
+/// page 1 (1-based 2) 의 본문 좌표 (514, 200) 는 머리말 hit 이 아니어야 한다.
+/// 정정 전: hit:true (Header bbox 가 본문 영역 60~1355 까지 침범)
+/// 정정 후: hit:false (정상 머리말 영역 60~145 로 제한)
+#[test]
+fn issue_595_page1_body_coord_not_header_regression_guard() {
+    let doc = load_exam_math();
+    let r = doc.hit_test_header_footer_native(1, 514.0, 200.0).unwrap();
+    assert!(
+        r.contains("\"hit\":false"),
+        "page 1 본문 좌표 (514, 200) 가 머리말 hit 으로 잘못 인식됨 (Issue #595 회귀): {}",
+        r
+    );
+}
+
+/// 이슈 명세 정확 좌표 — page 1 의 paraIdx=65 ci=0 수식 영역 (654.5, 209.7).
+/// 이 좌표는 본문 영역의 수식 객체 위치이며 머리말 hit 이 아니어야 한다.
+#[test]
+fn issue_595_page1_equation_coord_not_header() {
+    let doc = load_exam_math();
+    let r = doc.hit_test_header_footer_native(1, 654.5, 209.7).unwrap();
+    assert!(
+        r.contains("\"hit\":false"),
+        "page 1 수식 좌표 (654.5, 209.7) 가 머리말 hit 으로 잘못 인식됨 (Issue #595): {}",
+        r
+    );
+}
+
+/// page 1 의 페이지 중앙 본문 영역 (514, 800) 도 머리말 hit 이 아니어야 한다.
+/// 본문 한가운데 — 명백히 머리말 영역 밖.
+#[test]
+fn issue_595_page1_body_center_not_header() {
+    let doc = load_exam_math();
+    let r = doc.hit_test_header_footer_native(1, 514.0, 800.0).unwrap();
+    assert!(
+        r.contains("\"hit\":false"),
+        "page 1 본문 중앙 (514, 800) 이 머리말 hit 으로 잘못 인식됨 (Issue #595): {}",
+        r
+    );
+}
+
+/// page 1 의 머리말 영역 좌표 (514, 100) 은 정상적으로 머리말 hit 이어야 한다.
+/// 정정으로 인해 머리말 영역 자체의 hit 이 사라지지 않아야 함을 보장.
+#[test]
+fn issue_595_page1_header_area_still_hits() {
+    let doc = load_exam_math();
+    let r = doc.hit_test_header_footer_native(1, 514.0, 100.0).unwrap();
+    assert!(
+        r.contains("\"hit\":true") && r.contains("\"isHeader\":true"),
+        "page 1 머리말 영역 (514, 100) 이 머리말 hit 으로 인식되어야 함 (정정 회귀 가드): {}",
+        r
+    );
+}


### PR DESCRIPTION
## Summary

`exam_math.hwp` 의 수식을 더블클릭했을 때 **1페이지만 정상**, **2페이지부터 오동작** ([Issue #595](https://github.com/edwardkim/rhwp/issues/595)). 본질은 `hit_test_header_footer_native` 가 사용하는 Header 노드 bbox 가 자식 (단 구분선 line) 까지 확장되어 본문 영역을 머리말로 잘못 인식 → `onDblClick` 의 머리말 분기가 picture selection 분기보다 먼저 실행되어 수식 편집기 진입 차단.

**옵션 A 정정** — `cursor_rect.rs::hit_test_header_footer_native` 가 build_page_tree 의 Header/Footer 노드 bbox 대신 `layout.header_area` / `layout.footer_area` (PageDef margin 으로 계산된 정확한 영역) 로 hit 판정. **단일 함수 (+20/-13 LOC), 렌더링 동작 무영향, `expand_bbox_to_children` 의도 보존**.

## 본질 결함 위치

`src/renderer/layout.rs::build_header` (line 928) 의 `expand_bbox_to_children` 호출이 머리말 자식 노드 — 특히 단 구분선 line `paraIdx=0 ci=2` (h≈1227px) — 의 bbox 까지 Header 영역으로 확장:

| 페이지 | 정정 전 Header hit y 범위 | 실제 머리말 영역 |
|--------|--------------------------|------------------|
| page 0 (1p) | 60.0 ~ 145.0 | 0 ~ 147 (정상) |
| page 1 (2p) | **60.0 ~ 1355.0** | 0 ~ 147 (본문 80% 침범) |
| page 2~ | 60.0 ~ 1355.0 | 0 ~ 147 |

**page 0 vs page 1+ 차이**: page 0 의 단 구분선은 `ci=5` 로 Body 자식, page 1+ 부터 `ci=2` 로 Header 자식 → page 0 만 정상.

## 정정 영역

`src/document_core/queries/cursor_rect.rs::hit_test_header_footer_native` 단일 함수.

```diff
- let tree = self.build_page_tree(page_num)?;
- for child in &tree.root.children {
-     let is_header = matches!(child.node_type, RenderNodeType::Header);
-     ...
-     if x >= child.bbox.x && x <= child.bbox.x + child.bbox.width
-         && y >= child.bbox.y && y <= child.bbox.y + child.bbox.height
-     { ... }
- }

+ let (page_content, _, _) = self.find_page(page_num)?;
+ let layout = &page_content.layout;
+ let h = &layout.header_area;
+ if x >= h.x && x <= h.x + h.width && y >= h.y && y <= h.y + h.height {
+     // ... hit ...
+ }
+ let f = &layout.footer_area;
+ if x >= f.x && x <= f.x + f.width && y >= f.y && y <= f.y + f.height {
+     // ... hit ...
+ }
```

**부수 효과**: `build_page_tree` 호출 제거 → mousedown 마다 호출되던 트리 빌드 비용 제거.

**의도 보존**: `expand_bbox_to_children` 은 무수정 — 머리말 표 셀 내 Shape 클리핑 방지 의도 (#42 영역) 보존.

## 검증 (정정 전 → 정정 후)

| 검증 | 정정 전 | 정정 후 |
|------|---------|---------|
| `tests/issue_595.rs` (5 케이스, 신규) | 3 fail / 2 pass | **5 pass** |
| 본문 hit:false sweep (164 fixture / 1684p) | 1652 / **32 fail** | **1684 / 0 fail** (+32 본질 정정) |
| 머리말 hit (margin_header > 0, 1356p) | 1329 / 27 fail | 1356 / **0 fail** (+27 부수 개선) |
| 꼬리말 hit (margin_footer > 0) | 1383 / 16 fail | 1383 / 16 fail (회귀 0, 별도 영역) |
| `cargo test --lib --release` | (baseline) | **1141 passed** (회귀 0) |
| `cargo clippy --release` (lib) | (baseline) | clean |
| `cargo build --release` | (baseline) | clean |
| WASM 빌드 (Docker) | (baseline) | **4,531,883 bytes** clean |

**메인테이너 시각 판정 영역**: 작업지시자 직접 환경 (1365×1018, zoom=1.0) 에서 정정 전 결함 재현 (page 2 본문 빈 공간 더블클릭 → 머리말 편집 모드 진입) + 정정 후 정상 동작 (수식 더블클릭 → 수식 편집기 진입) 모두 ★ 통과 확인. 진행 환경: macOS + Chrome.

## 회귀 위험성 점검

**관련 이슈** (CLOSED):

| 이슈 | 영역 | 회귀 위험 |
|------|------|----------|
| [#236](https://github.com/edwardkim/rhwp/issues/236) | `PageAreas::from_page_def` 머리말/본문 영역 공식 | **0** — 본 정정이 #236 정정의 영역을 일관 활용 (정확성 강화) |
| [#42](https://github.com/edwardkim/rhwp/issues/42) | 머리말/꼬리말 내 Picture 렌더링 | **0** — 렌더링 무영향 |
| [#36](https://github.com/edwardkim/rhwp/issues/36) | 머리말 표 셀 안 이미지 미렌더링 | **0** — `expand_bbox_to_children` 의도 보존 |
| [#340](https://github.com/edwardkim/rhwp/issues/340) | exam_math 13페이지 머리말 누출 | **0** — typeset 무영향 |

**관련 함수**: `hit_test_in_header_footer_native` (편집 모드 텍스트 hit), `get_active_hf_info`, `find_section_for_page` 무수정 — 회귀 위험 0.

**TS 측 호출처** (`hitTestHeaderFooter` 호출 단 2곳):
- `input-handler-mouse.ts:494` (onMouseDown 머리말 모드 탈출용) — 정정 후 hit:false 정확 → 모드 탈출 정확 (개선)
- `input-handler-mouse.ts:784` (onDblClick 모드 진입용) — 본 정정 본질 영역

## 광범위 회귀 sweep 정량

`samples/` 전체 167 fixture / 1687 페이지 (PR #642 기준 baseline) 정정 전후 비교:

- **머리말 영역 hit:true (margin_header > 0)**: 27 fail → **0 fail** (+27 부수 개선)
- **꼬리말 영역 hit:true (margin_footer > 0)**: 동일 (16 fail, 1 fixture `hwpctl_Action_Table` 한정 — 별도 영역, 본 정정과 무관)
- **본문 중앙 hit:false**: 32 fail → **0 fail** (+32 본질 정정 — exam_math.hwp / exam_math_no.hwp)

검증 도구는 `examples/inspect_595_regression.rs` 로 영구 보존 (향후 hit_test_header_footer 영역 회귀 차단 가드).

## 단계별 진행 (Hyper-Waterfall 정합)

| Stage | 산출물 | 본 PR commit |
|-------|--------|---------------|
| **Stage 1** | 본질 진단 + `tests/issue_595.rs` (5 케이스) + 광범위 sweep + 정정 영역 후보 분석 | `24a267d` |
| **Stage 2** | 본질 정정 (`cursor_rect.rs`) + 회귀 sweep 도구 (`inspect_595_regression.rs`) + WASM 빌드 + 시각 판정 ★ 통과 | `33fc7ac` |
| **Stage 3** | 최종 보고서 + 회귀 위험성 점검 (관련 이슈/함수/호출처) | `938631f` |

각 단계는 작업지시자 단계별 승인 + 시각 판정 후 진행. 단계별 보고서는 `mydocs/working/task_m100_595_stage{1,2}.md` + `mydocs/report/task_m100_595_report.md` 참조.

## 별도 발견 (참고만, 본 PR 영역 아님)

광범위 sweep / e2e 진단 중 발견된 본 이슈와 본질이 다른 영역. 정정 전후 동일 (회귀 0), 사용자 시각 검증 안 됨, 한컴 호환 진단 필요 → **이슈 등록 보류**:

- **그리드 모드 (zoom ≤ 0.5) 좌표 결함** — `input-handler-mouse.ts` 의 `pageLeft` 단일 컬럼 가정 vs 그리드 `pageLefts[i]` 불일치
- **`hwpctl_Action_Table__v1.1.hwp` 꼬리말 hit:false** — landscape + `marginBottom=0` 양식의 `PageAreas::from_page_def` `footer_area.height = 0`

## Test plan

- [x] `cargo test --lib --release` (1141 passed, 회귀 0)
- [x] `cargo clippy --release` (clean)
- [x] `cargo build --release` (clean)
- [x] `cargo test --release --test issue_595` (5 passed)
- [x] WASM 빌드 (Docker, 4,531,883 bytes)
- [x] 작업지시자 시각 판정 ★ 통과 (1365×1018, zoom=1.0, macOS + Chrome — 정정 전 결함 재현 + 정정 후 정상 모두 확인)
- [ ] (메인테이너) 본 환경 재검증 + e2e (`rhwp-studio/e2e/issue-595.test.mjs`) 시각 판정

## 본 PR 영역

- `src/document_core/queries/cursor_rect.rs` — 본질 정정 (+20/-13 LOC)
- `tests/issue_595.rs` — 회귀 차단 가드 (5 케이스, 신규)
- `examples/inspect_595.rs` / `examples/inspect_595_regression.rs` — 진단/회귀 sweep 도구 (영구 보존)
- `rhwp-studio/e2e/issue-595.test.mjs` — e2e 진단 (1365×1018 사용자 환경 모사 + zoom 변동 시나리오)
- `mydocs/plans/task_m100_595{,_impl}.md` — 수행/구현 계획서
- `mydocs/working/task_m100_595_stage{1,2}.md` — 단계별 보고서
- `mydocs/report/task_m100_595_report.md` — 최종 보고서

closes #595
