### PR TITLE
fix: Layout 리팩터링 Phase 2 line_break_char_idx 다중화 누락 회귀 정정 (Task #518 재적용, closes #648)

### DIFF
--- a/mydocs/manual/svg_regression_diff.md
+++ b/mydocs/manual/svg_regression_diff.md
@@ -1,0 +1,85 @@
+# SVG 회귀 검증 도구 — `scripts/svg_regression_diff.sh`
+
+Layout 본질 변경 (#496 / #500 등) 시 광범위 SVG 회귀 검증을 자동화한다. Phase 1 (#517) 산출물.
+
+## 사용법
+
+### Mode 1: 두 commit/branch 비교 (자동 빌드)
+
+```bash
+scripts/svg_regression_diff.sh build <BEFORE_REF> <AFTER_REF> [SAMPLES...]
+```
+
+각 ref 에서 `src/` 만 체크아웃 → release 빌드 → 7개 기본 샘플 export → byte 비교.
+
+예:
+```bash
+# devel 과 local/task500 비교 (모든 기본 샘플)
+scripts/svg_regression_diff.sh build devel local/task500
+
+# 특정 샘플만 비교
+scripts/svg_regression_diff.sh build devel HEAD exam_science exam_kor
+```
+
+작업 트리 보존: 시작 시 자동 stash, 종료 시 pop.
+
+### Mode 2: 두 디렉토리 비교 (이미 존재하는 SVG)
+
+```bash
+scripts/svg_regression_diff.sh diff <BEFORE_DIR> <AFTER_DIR>
+```
+
+각 디렉토리 구조: `<DIR>/<sample_name>/<sample_name>_NNN.svg`
+
+예:
+```bash
+scripts/svg_regression_diff.sh diff /tmp/before /tmp/after
+```
+
+## 출력 형식
+
+```
+{sample}: total={N} same={M} diff={D}  diff_pages=[페이지 목록]
+---
+TOTAL: pages={total} same={same} diff={diff}
+```
+
+`diff > 0` 인 sample 의 `diff_pages` 에서 변경된 SVG 파일을 직접 비교 (`diff /tmp/svg_diff_before/<sample>/<page> /tmp/svg_diff_after/<sample>/<page>`) 하여 변경 내용 검토.
+
+## 기본 샘플 목록
+
+(SAMPLES 미지정 시 사용)
+- `exam_kor` (20 페이지)
+- `exam_eng` (8 페이지)
+- `exam_science` (4 페이지)
+- `exam_math` (20 페이지)
+- `synam-001` (35 페이지)
+- `aift` (77 페이지)
+- `2010-01-06` (6 페이지)
+
+총 170 페이지, 다양한 layout 패턴 (다단/표/수식/각주/인라인 컨트롤) 커버.
+
+## 활용 사례
+
+### 신규 commit 의 회귀 검증
+
+```bash
+git commit -m "..."
+scripts/svg_regression_diff.sh build HEAD~1 HEAD
+```
+
+`diff > 0` 페이지가 의도된 정정인지 확인 → 의도되지 않으면 회귀.
+
+### Phase 2~4 layout 본질 변경 검증
+
+```bash
+scripts/svg_regression_diff.sh build devel local/task<N>
+```
+
+리팩터링 변경의 영향 범위를 정량 확인.
+
+## 관련
+
+- Phase 1 #517 (본 도구 추가)
+- Phase 0 로드맵: `mydocs/tech/layout_refactor_roadmap.md`
+- `RHWP_LAYOUT_DEBUG=1` env logging — 같이 사용 시 결함 측정·재현 자동화

--- a/mydocs/plans/task_m100_517.md
+++ b/mydocs/plans/task_m100_517.md
@@ -1,0 +1,53 @@
+# Task #517 수행계획서 — Layout 리팩터링 Phase 1
+
+**이슈**: #517 — Layout 리팩터링 Phase 1: 디버그 인프라 + 회귀 검증 도구
+**브랜치**: `local/task517`
+**작성일**: 2026-05-02
+
+## 1. 목적
+
+#467 / #491 / #496 본질 정정 (Phase 2~4) 의 선결 인프라 추가.
+- Layout 디버깅 도구로 결함 측정·재현 자동화
+- 회귀 검증 도구로 Phase 2~4 변경의 광범위 안전성 검증
+
+코드 변경은 인프라/도구만 추가. 본질 동작 변경 없음.
+
+## 2. 단계
+
+### Stage 1 — `RHWP_LAYOUT_DEBUG=1` env logging
+
+`layout_inline_table_paragraph` (paragraph_layout.rs:81) 에 env-var-checked eprintln 추가:
+- paragraph 메타데이터: pi, col_x, col_w, y_start, ls_count
+- line_seg 정보: vpos, lh, ls, text_start
+- 인라인 표 정보: rows, cols, w, h, vert_align
+- wrap 결정: ch_idx, current_y, reason (hwp_break / dynamic)
+- TextRun 발행: x, y, text 일부
+
+기존 `RHWP_TYPESET_DRIFT` 패턴 따름 (`src/renderer/typeset.rs:861`).
+
+### Stage 2 — 회귀 검증 도구 정형화
+
+7-sample byte-diff 비교를 정형 script 로:
+- `scripts/svg_regression_diff.sh` — before/after 디렉토리 + sample list 입력 → 페이지별 diff 출력
+- 기본 sample list: exam_kor, exam_eng, exam_science, exam_math, synam-001, aift, 2010-01-06
+- 결과 형식: `{sample}: total={N} same={M} diff={D}` + diff 파일 경로
+
+매뉴얼: `mydocs/manual/svg_regression_diff.md`
+
+## 3. 검증
+
+- Stage 1: `RHWP_LAYOUT_DEBUG=1` 로 exam_science p2 export → 로그 출력 확인. 단위 + 통합 테스트 통과
+- Stage 2: 7 샘플 before/after 비교 스크립트 실행 검증
+
+## 4. 리스크
+
+- Stage 1: env-var-checked 로깅이므로 기본 동작 변경 없음. 회귀 0
+- Stage 2: 별도 script 추가, 코드 변경 없음
+
+## 5. 산출물
+
+- `src/renderer/layout/debug.rs` (신규, 또는 paragraph_layout.rs 내 helper)
+- `scripts/svg_regression_diff.sh` (신규)
+- `mydocs/manual/svg_regression_diff.md`
+- `mydocs/working/task_m100_517_stage{1,2}.md`
+- `mydocs/report/task_m100_517_report.md`

--- a/mydocs/plans/task_m100_518.md
+++ b/mydocs/plans/task_m100_518.md
@@ -1,0 +1,99 @@
+# Task #518 수행계획서 — Layout 리팩터링 Phase 2
+
+**이슈**: #518 — line_break_char_idx 다중화 (ls[2..] break 사용)
+**브랜치**: `local/task518`
+**작성일**: 2026-05-02
+
+## 1. 목적
+
+`layout_inline_table_paragraph` 의 줄 나눔 위치 결정 정확도 향상.
+
+이전 알고리즘 결함:
+- `line_break_char_idx: Option<usize>` 가 ls[1] 만 사용
+- ctrl_gap 을 paragraph 전체 controls 합으로 over-subtract → controls 가 있는 paragraph 에서 saturating 0 으로 항상 break 미감지
+- ls[2..] 무시 → 다중 줄 본문에서 dynamic right_margin reflow 로 fallback
+
+## 2. 변경 내용
+
+`src/renderer/layout/paragraph_layout.rs` `layout_inline_table_paragraph`:
+
+### (1) line_break_char_indices: Vec<usize> 일반화
+- ls[1..] 의 text_start 들을 모두 char index 로 변환
+- 직접 char_offsets 룩업 (`char_offsets[i] >= ts` 인 첫 i)
+- 단조 증가 보장
+
+### (2) wrap 조건 변경
+```rust
+let need_wrap = if next_break < line_break_char_indices.len()
+    && ch_idx >= line_break_char_indices[next_break]
+{
+    next_break += 1;
+    true
+} else {
+    inline_x + ch_w > right_margin + 0.5 && inline_x > line_start_x + 1.0
+};
+```
+
+HWP 인코딩 break 도달 시 사용, 미존재/소진 시 dynamic reflow.
+
+### (3) 디버그 로깅 추가
+`RHWP_LAYOUT_DEBUG=1` 시 `LAYOUT_BREAK_INDICES: pi={N} indices={Vec}` 출력.
+
+## 3. 검증
+
+### 3-1. #496 재현 케이스 (exam_science p2 pi=61)
+
+```
+LAYOUT_BREAK_INDICES: pi=61 indices=[5, 28]
+```
+
+| 측정 | Before | After |
+|------|--------|-------|
+| y=1195.85 본문 | "는? (단, 는 임의의 원소 기호이고, ... [3점]" (1줄, column 폭 초과) | "는?" (2 chars, 정상) |
+| y=1227.21 | (다른 paragraph) | "(단, 는 임의의 원소 기호이고, , , ," |
+| y=1248.68 | — | ", 의 원자량은 각각 , , , 이다.) [3점]" |
+
+→ 본문이 HWP 인코딩 ls[1]/ls[2] break 위치에서 정확히 줄바꿈.
+
+### 3-2. 회귀 검증
+
+`scripts/svg_regression_diff.sh diff /tmp/test518_before /tmp/test518_after`:
+
+| 샘플 | total | same | diff | 비고 |
+|------|-------|------|------|------|
+| exam_kor | 20 | 20 | 0 | |
+| exam_eng | 8 | 8 | 0 | |
+| **exam_science** | **4** | **1** | **3** | pi=61 본질 정정 + 다른 paragraph 누적 영향 |
+| exam_math | 20 | 20 | 0 | |
+| synam-001 | 35 | 35 | 0 | |
+| aift | 77 | 77 | 0 | |
+| 2010-01-06 | 6 | 6 | 0 | |
+
+170 페이지 중 exam_science 3 페이지만 변경. 6개 다른 샘플 무영향.
+
+### 3-3. 단위/통합 테스트
+
+- `cargo test --release --lib`: **1103 passed; 0 failed**
+
+## 4. 영향 범위
+
+| 케이스 | 영향 |
+|--------|------|
+| Single line_seg paragraph | 변화 없음 (Vec.is_empty()) |
+| Multi line_seg, controls 없음 | 동일 break (이전 알고리즘과 결과 일치) |
+| **Multi line_seg + controls (#496 케이스)** | **정정** (이전 알고리즘 saturating 0 버그 해결) |
+
+exam_science 의 변경은 controls 가 있는 paragraph 의 정확도 정정.
+
+## 5. 리스크 분석
+
+- 알고리즘 정확성: 직접 char_offsets 룩업이 HWP IR 기준 정답
+- 회귀 위험: 6개 샘플 byte 동일로 contained
+- 본질 (A) baseline 정렬 정책은 미해결 (Phase 3 영역)
+
+## 6. 산출물
+
+- 본 수행계획서
+- 단계별 보고서: `mydocs/working/task_m100_518_stage1.md`
+- 최종 보고서: `mydocs/report/task_m100_518_report.md`
+- 코드 변경: `src/renderer/layout/paragraph_layout.rs` (line_break_char_indices 도입 + wrap 로직)

--- a/mydocs/report/task_m100_517_report.md
+++ b/mydocs/report/task_m100_517_report.md
@@ -1,0 +1,73 @@
+# Task #517 최종 보고서 — Layout 리팩터링 Phase 1
+
+**이슈**: #517
+**브랜치**: `local/task517`
+**Phase**: 1 (디버그 인프라 + 회귀 검증 도구)
+
+## 1. 작업 내용
+
+Phase 2~4 (본질 정정) 의 선결 인프라 추가.
+
+## 2. 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout/paragraph_layout.rs` | `layout_debug_enabled()` + `layout_inline_table_paragraph` 진단 로깅 (env-var-checked) |
+| `scripts/svg_regression_diff.sh` | 신규 (130 LOC) — build/diff 두 모드 |
+| `mydocs/manual/svg_regression_diff.md` | 사용 매뉴얼 |
+| `mydocs/plans/task_m100_517.md` | 수행계획서 |
+| `mydocs/working/task_m100_517_stage{1,2}.md` | 단계별 보고서 |
+| 본 보고서 | |
+
+## 3. 검증
+
+### 3-1. 기능 검증
+
+- Stage 1 logging: exam_science p2 pi=61 (#496 재현) 에서 `ls_count=3 tables=1 rows=2` 등 핵심 정보 출력 확인
+- Stage 2 diff: 기존 /tmp/task500_{before,after} 비교에서 의도된 1페이지 정정 정확 식별
+
+### 3-2. 회귀 검증
+
+- `cargo test --release`: **1103 passed; 0 failed; 1 ignored**
+- `scripts/svg_regression_diff.sh build devel HEAD`: **170/170 byte 동일, diff=0**
+
+env-var-checked 로깅 + 별도 script 만 추가 → 기본 동작 변경 없음.
+
+## 4. 영향 범위
+
+| 케이스 | 영향 |
+|--------|------|
+| 기본 export-svg 동작 | 변화 없음 (env var 미지정 시 logging 미동작) |
+| `RHWP_LAYOUT_DEBUG=1` 지정 시 | layout_inline_table_paragraph 진입 시 진단 로깅 출력 |
+| 단위/통합 테스트 | 영향 없음 |
+
+## 5. 활용
+
+### `RHWP_LAYOUT_DEBUG=1`
+
+```bash
+RHWP_LAYOUT_DEBUG=1 ./target/release/rhwp export-svg samples/exam_science.hwp -p 1 2>&1 | grep "LAYOUT_"
+```
+
+### `scripts/svg_regression_diff.sh`
+
+```bash
+# 두 commit 비교
+./scripts/svg_regression_diff.sh build devel local/task<N>
+
+# 두 디렉토리 비교
+./scripts/svg_regression_diff.sh diff /tmp/before /tmp/after
+```
+
+## 6. 후속
+
+Phase 2 (line_break_char_idx 다중화) 진행 시 본 인프라 사용:
+- 변경 전후 `RHWP_LAYOUT_DEBUG=1` 로 결함 케이스 baseline 측정 비교
+- `svg_regression_diff.sh build devel local/taskN` 으로 170 페이지 광범위 회귀 검증
+
+## 7. 요약
+
+- Layout 디버깅 인프라 (`RHWP_LAYOUT_DEBUG=1`) ✓
+- 회귀 검증 도구 (`scripts/svg_regression_diff.sh`) ✓
+- 회귀 0건 (170/170 byte 동일, 1103 단위 테스트 통과) ✓
+- Phase 2~4 진행을 위한 도구 기반 마련 ✓

--- a/mydocs/report/task_m100_518_report.md
+++ b/mydocs/report/task_m100_518_report.md
@@ -1,0 +1,72 @@
+# Task #518 최종 보고서 — Layout 리팩터링 Phase 2
+
+**이슈**: #518
+**브랜치**: `local/task518`
+**Phase**: 2 (line_break_char_idx 다중화)
+
+## 1. 작업 내용
+
+`layout_inline_table_paragraph` 줄 나눔 위치 결정 정확도 향상.
+
+### 변경 핵심
+1. `Option<usize>` → `Vec<usize>` 로 ls[1..] 모두 사용
+2. ctrl_gap 기반 알고리즘 → 직접 char_offsets 룩업 (간결 + 정확)
+
+### 이전 알고리즘의 결함
+
+paragraph 전체 controls 합을 ts 에서 빼는 over-subtraction 으로, controls 가 있는 paragraph 에서 saturating 0 → 항상 None 반환 → dynamic right_margin reflow 로 fallback. 하지만 dynamic reflow 도 inline_x 가 right_margin 을 초과하지 않으면 wrap 안 함 → 본문이 column 폭 너머로 늘어짐.
+
+#496 (exam_science p2 pi=61) 케이스가 정확히 이 패턴 (10 controls + 56 char text).
+
+## 2. 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout/paragraph_layout.rs` | line_break_char_indices Vec 도입 + wrap 로직 + LAYOUT_BREAK_INDICES 디버그 로깅 |
+
+## 3. 검증
+
+### 3-1. #496 재현 케이스
+
+| | Before | After |
+|---|--------|-------|
+| 본문 라인 수 | 1 (column 폭 초과) | 3 (정상 wrap) |
+| ls[1] break (char 5) | 무시 | **적용** |
+| ls[2] break (char 28) | 무시 | **적용** |
+
+### 3-2. 광범위 회귀
+
+7 샘플 170 페이지: **same=167 / diff=3** (exam_science p2/p3/p4)
+- exam_kor / exam_eng / exam_math / synam-001 / aift / 2010-01-06 byte 동일
+- exam_science 변경 = 정확도 정정
+
+### 3-3. 단위 + 통합 테스트
+
+- `cargo test --release --lib`: **1103 passed**
+
+## 4. 영향 범위
+
+| 케이스 | 영향 |
+|--------|------|
+| Single line_seg paragraph | 변화 없음 (`Vec.is_empty()` → dynamic reflow) |
+| Multi line_seg, controls 없음 | 동일 break (이전 algorithm 결과 일치) |
+| Multi line_seg + controls (#496 케이스) | 정정 (이전 saturating 0 버그 해결) |
+
+## 5. 잔여 결함 (별도 Phase)
+
+#496 는 복합 본질 (A/B/C):
+- (B) ls[2..] break 미사용 — **본 task 에서 해결 ✓**
+- (A) 본문 baseline 수직 정렬 정책 — Phase 3
+- (C) 인라인 vs 블록 정책 — Phase 4
+
+#496 이슈 본문 "줄들이 거의 같은 y 에 그려져" 는 (B) 가 주원인이었음. 본 fix 로 본문이 정상 wrap → 시각적으로 글자 안 보임 문제 해소.
+
+baseline 수직 정렬 (본문 y=1195 가 표 row 0/row 1 사이 끼임) 은 별도 Phase 3 에서 처리.
+
+## 6. 요약
+
+- ls[1..] 다중 break 사용 ✓
+- ctrl_gap over-subtraction 버그 정정 ✓
+- 회귀: 7 샘플 167/170 동일 (3건은 정확도 정정) ✓
+- 단위 1103 통과 ✓
+- #496 본질 (B) 해결 (본질 A/C 는 별도 Phase)

--- a/mydocs/working/task_m100_517_stage1.md
+++ b/mydocs/working/task_m100_517_stage1.md
@@ -1,0 +1,54 @@
+# Task #517 Stage 1 보고서 — RHWP_LAYOUT_DEBUG env logging
+
+**이슈**: #517
+**브랜치**: `local/task517`
+**Stage**: 1 / 2
+
+## 1. 변경 내용
+
+`src/renderer/layout/paragraph_layout.rs`:
+- `layout_debug_enabled()` helper 추가 (env var 체크)
+- `layout_inline_table_paragraph` 시작 부분에 진단 로깅 (env-var-checked)
+
+## 2. 출력 형식
+
+```
+LAYOUT_INLINE_TABLE_PARA: pi={N} sec={S} col_x={X} col_w={W} y_start={Y} y={Y'} sb={SB} sa={SA} ml={ML} mr={MR} align={A} ls_count={N} tables={T}
+  LAYOUT_LS[i]: vpos={V} lh={LH} ls={LS} bl={BL} text_start={TS} sw={SW}
+  LAYOUT_INLINE_TBL[i]: ctrl_idx={CI} rows={R} cols={C} w={W} h={H} vert={V} horz={H} wrap={WR}
+```
+
+## 3. 검증
+
+### 3-1. exam_science p2 pi=61 (#496 재현 케이스)
+
+```
+LAYOUT_INLINE_TABLE_PARA: pi=61 sec=0 col_x=534.8 col_w=422.6 y_start=1176.8 y=1176.8 sb=0.0 sa=6.7 ml=15.1 mr=0.0 align=Justify ls_count=3 tables=1
+  LAYOUT_LS[0]: vpos=74118 lh=2864 ls=460 bl=1432 text_start=0 sw=18939
+  LAYOUT_LS[1]: vpos=77442 lh=1150 ls=460 bl=575 text_start=13 sw=18939
+  LAYOUT_LS[2]: vpos=79052 lh=1150 ls=460 bl=575 text_start=60 sw=30562
+  LAYOUT_INLINE_TBL[0]: ctrl_idx=0 rows=2 cols=1 w=14745 h=2864 vert=Top horz=Left wrap=TopAndBottom
+```
+
+핵심 정보:
+- ls_count=3 (다중 줄 paragraph)
+- table rows=2 (다중행 인라인 표)
+- ls[2].text_start=60 (HWP 인코딩 break 위치)
+
+→ #496 결함 분석에 직접 활용 가능.
+
+### 3-2. 회귀 검증
+
+`scripts/svg_regression_diff.sh build devel HEAD` 결과:
+- TOTAL: pages=170 same=170 diff=0
+
+env-var-checked 로깅이므로 기본 동작 변경 없음. **회귀 0건**.
+
+### 3-3. 단위 + 통합 테스트
+
+- `cargo test --release --lib`: 1103 passed
+- `cargo test --release --tests`: 모든 통과
+
+## 4. 잔여
+
+Stage 2 (회귀 검증 도구 정형화) 로 진행.

--- a/mydocs/working/task_m100_517_stage2.md
+++ b/mydocs/working/task_m100_517_stage2.md
@@ -1,0 +1,77 @@
+# Task #517 Stage 2 보고서 — 회귀 검증 도구 정형화
+
+**이슈**: #517
+**브랜치**: `local/task517`
+**Stage**: 2 / 2
+
+## 1. 변경 내용
+
+- `scripts/svg_regression_diff.sh` (신규, 약 130 LOC bash)
+- `mydocs/manual/svg_regression_diff.md` (사용 매뉴얼)
+
+## 2. 기능
+
+### Mode 1: `build <BEFORE_REF> <AFTER_REF> [SAMPLES...]`
+
+- 두 commit/branch 에서 자동 빌드 → SVG 추출 → byte 비교
+- 작업 트리 자동 stash/pop
+- `/tmp/svg_diff_{before,after}/` 에 결과 보존
+
+### Mode 2: `diff <BEFORE_DIR> <AFTER_DIR>`
+
+- 이미 존재하는 두 디렉토리 비교 (재빌드 없이)
+
+## 3. 출력 형식
+
+```
+{sample}: total={N} same={M} diff={D}  diff_pages=[페이지 목록]
+---
+TOTAL: pages={total} same={same} diff={diff}
+```
+
+## 4. 검증
+
+### 4-1. Mode 2 (diff): 기존 #500 작업 dir 비교
+
+```
+$ ./scripts/svg_regression_diff.sh diff /tmp/task500_before /tmp/task500_after
+2010-01-06: total=6 same=6 diff=0
+aift: total=77 same=77 diff=0
+exam_eng: total=8 same=8 diff=0
+exam_kor: total=20 same=20 diff=0
+exam_math: total=20 same=20 diff=0
+exam_science: total=4 same=3 diff=1  diff_pages=[exam_science_002.svg]
+synam-001: total=35 same=35 diff=0
+---
+TOTAL: pages=170 same=169 diff=1
+```
+
+→ #500 fix 의 의도된 1페이지 정정 정확히 식별.
+
+### 4-2. Mode 1 (build): devel vs HEAD (Phase 1 자체)
+
+```
+$ ./scripts/svg_regression_diff.sh build devel HEAD
+TOTAL: pages=170 same=170 diff=0
+```
+
+→ Phase 1 변경 자체의 회귀 0건 검증.
+
+## 5. 활용
+
+- 신규 commit 회귀 검증
+- Phase 2~4 layout 본질 변경 광범위 회귀 검증 (170 페이지 자동 비교)
+- `RHWP_LAYOUT_DEBUG=1` 와 함께 사용 시 결함 측정·재현 자동화
+
+## 6. 기본 샘플 커버리지
+
+| 샘플 | 페이지 | 패턴 |
+|------|--------|------|
+| exam_kor | 20 | 다단, 헤더/푸터, master, 인라인 표/도형 |
+| exam_eng | 8 | 영문 문제지 |
+| exam_science | 4 | 과학 (수식/표/그림 다수) |
+| exam_math | 20 | 수학 (수식 집중) |
+| synam-001 | 35 | 일반 문서 |
+| aift | 77 | 긴 문서 (다양한 패턴) |
+| 2010-01-06 | 6 | 기본 케이스 |
+| **합계** | **170** | 광범위 layout 커버 |

--- a/mydocs/working/task_m100_518_stage1.md
+++ b/mydocs/working/task_m100_518_stage1.md
@@ -1,0 +1,85 @@
+# Task #518 Stage 1 보고서 — line_break_char_idx 다중화
+
+**이슈**: #518
+**브랜치**: `local/task518`
+**Stage**: 1 / 1 (단일 단계)
+
+## 1. 변경 내용
+
+`src/renderer/layout/paragraph_layout.rs` `layout_inline_table_paragraph`:
+
+1. `line_break_char_idx: Option<usize>` → `line_break_char_indices: Vec<usize>` 일반화 (ls[1..] 모두 사용)
+2. ctrl_gap 기반 알고리즘 → 직접 char_offsets 룩업 (단순 + 정확)
+3. wrap 조건에 `next_break` 추적 추가
+4. `RHWP_LAYOUT_DEBUG=1` 시 `LAYOUT_BREAK_INDICES` 출력
+
+## 2. 알고리즘 비교
+
+### 이전 (버그)
+```rust
+let mut ctrl_gap = 0u32;
+// paragraph 전체 controls 합 (over-subtraction)
+if !para.char_offsets.is_empty() {
+    ctrl_gap += para.char_offsets[0];
+    for i in 1..para.char_offsets.len() { ... ctrl_gap += gap - prev_len; }
+}
+let text_only_ts = ts.saturating_sub(ctrl_gap);  // saturating 0
+let mut char_idx = 0;
+let mut u16_accum = 0u32;
+for (i, ch) in text_chars.iter().enumerate() {
+    if u16_accum >= text_only_ts { char_idx = i; break; }
+    ...
+}
+if char_idx > 0 { Some(char_idx) } else { None }
+```
+
+문제: `ctrl_gap` 이 paragraph 전체 controls 합. ts 보다 큰 경우 (controls 가 많은 paragraph) saturating 0 으로 항상 None 반환.
+
+### 신규
+```rust
+let char_idx = para.char_offsets.iter().position(|&off| off >= ts)
+    .unwrap_or(text_chars.len());
+```
+
+`char_offsets[i]` 가 이미 controls 포함된 raw UTF-16 위치. `>= ts` 인 첫 i 가 break char index. 단순 + 정확.
+
+## 3. 검증
+
+### 3-1. #496 재현 (exam_science p2 pi=61)
+
+`RHWP_LAYOUT_DEBUG=1` 출력:
+```
+LAYOUT_INLINE_TABLE_PARA: pi=61 sec=0 col_x=534.8 col_w=422.6 y_start=1176.8 ... ls_count=3 tables=1
+  LAYOUT_LS[0]: vpos=74118 lh=2864 ls=460 bl=1432 text_start=0 sw=18939
+  LAYOUT_LS[1]: vpos=77442 lh=1150 ls=460 bl=575 text_start=13 sw=18939
+  LAYOUT_LS[2]: vpos=79052 lh=1150 ls=460 bl=575 text_start=60 sw=30562
+  LAYOUT_INLINE_TBL[0]: ctrl_idx=0 rows=2 cols=1 w=14745 h=2864 vert=Top horz=Left wrap=TopAndBottom
+  LAYOUT_BREAK_INDICES: pi=61 indices=[5, 28] (from ls[1..])
+```
+
+본문 baseline 분포 (column 1, y=1170~1300):
+
+| | Before | After |
+|---|--------|-------|
+| 표 row 0 | y=1191.68 | y=1191.68 |
+| **본문 라인 1** | **y=1195.85 ("는?...[3점]" 56자 1줄, column 폭 초과)** | **y=1195.85 ("는?" 2자)** |
+| 표 row 1 | y=1210.77 | y=1210.77 |
+| **본문 라인 2** | — | **y=1227.21 ("(단,는임의의원소기호이고,,," 16자)** |
+| **본문 라인 3** | — | **y=1248.68 (",의원자량은각각,,,이다.)[3점]" 19자)** |
+
+→ ls[1] (text_start=13) 과 ls[2] (text_start=60) HWP 인코딩 break 위치에서 정확히 줄바꿈.
+
+### 3-2. 회귀 검증
+
+`scripts/svg_regression_diff.sh diff /tmp/test518_before /tmp/test518_after`:
+- 7 샘플 170 페이지: **same=167 / diff=3** (exam_science p2/p3/p4)
+- 6 샘플 (exam_kor/exam_eng/exam_math/synam-001/aift/2010-01-06) byte 동일
+- exam_science 변경 = 정확도 정정 (이전 algorithm 의 ctrl_gap over-subtraction 버그)
+
+### 3-3. 단위/통합 테스트
+
+- `cargo test --release --lib`: **1103 passed; 0 failed**
+
+## 4. 잔여
+
+본 task 는 #496 의 본질 (B) ls[2..] break 미사용 만 정정. 본질 (A) baseline 정렬 + (C) 인라인 vs 블록 정책은 별도 Phase 3/4 영역.

--- a/scripts/svg_regression_diff.sh
+++ b/scripts/svg_regression_diff.sh
@@ -1,0 +1,154 @@
+#!/usr/bin/env bash
+# scripts/svg_regression_diff.sh — Layout 변경 회귀 검증 (Phase 1 #517)
+#
+# 두 commit 또는 두 디렉토리의 SVG 출력을 페이지별로 byte 비교한다.
+# Layout 본질 변경 (Phase 2~4) 시 광범위 회귀 검증에 사용.
+#
+# 사용법:
+#   scripts/svg_regression_diff.sh build <BEFORE_REF> <AFTER_REF> [SAMPLES...]
+#     — BEFORE_REF/AFTER_REF (commit/branch) 에서 빌드 → /tmp/svg_diff_{before,after}/ 에 출력 → 비교
+#   scripts/svg_regression_diff.sh diff <BEFORE_DIR> <AFTER_DIR>
+#     — 이미 존재하는 두 디렉토리만 비교
+#
+# 기본 SAMPLES (지정 안 하면 사용):
+#   exam_kor exam_eng exam_science exam_math synam-001 aift 2010-01-06
+#
+# 출력:
+#   {sample}: total={N} same={M} diff={D}
+#   diff 발생 시 페이지 목록 + diff 파일 경로
+
+set -euo pipefail
+
+DEFAULT_SAMPLES=(exam_kor exam_eng exam_science exam_math synam-001 aift 2010-01-06)
+ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+usage() {
+    sed -n '2,/^$/p' "$0" | sed 's/^# //;s/^#//'
+    exit 1
+}
+
+build_at_ref() {
+    local ref="$1"
+    local out_dir="$2"
+    shift 2
+    local samples=("$@")
+
+    pushd "$ROOT" >/dev/null
+
+    # 빌드 (현재 작업 트리 보존)
+    if ! git diff --quiet || ! git diff --cached --quiet; then
+        echo "  [build] working tree dirty, stashing..." >&2
+        git stash push -m "svg_regression_diff_$ref" >&2
+        local stashed=1
+    else
+        local stashed=0
+    fi
+
+    git checkout "$ref" -- src/ >&2
+    cargo build --release >&2
+
+    # SVG 추출
+    mkdir -p "$out_dir"
+    for s in "${samples[@]}"; do
+        local hwp="samples/${s}.hwp"
+        if [ ! -f "$hwp" ]; then
+            echo "  [build] skip $s (no $hwp)" >&2
+            continue
+        fi
+        mkdir -p "$out_dir/$s"
+        ./target/release/rhwp export-svg "$hwp" -o "$out_dir/$s/" >/dev/null 2>&1 || true
+        local n=$(ls "$out_dir/$s/" 2>/dev/null | wc -l | tr -d ' ')
+        echo "  [build:$ref] $s: $n pages" >&2
+    done
+
+    # 작업 트리 복구
+    git checkout HEAD -- src/ >&2
+    if [ "$stashed" = "1" ]; then
+        git stash pop >&2 || true
+    fi
+
+    popd >/dev/null
+}
+
+diff_dirs() {
+    local before="$1"
+    local after="$2"
+
+    local total_pages=0
+    local total_same=0
+    local total_diff=0
+
+    for d in "$before"/*/; do
+        local s=$(basename "$d")
+        local b="$before/$s"
+        local a="$after/$s"
+        [ -d "$a" ] || { echo "$s: SKIP (no $a)"; continue; }
+
+        local total=0 same=0 diff=0
+        local diff_pages=()
+        for f in "$b"/*.svg; do
+            [ -f "$f" ] || continue
+            local base=$(basename "$f")
+            total=$((total+1))
+            if [ -f "$a/$base" ] && cmp -s "$f" "$a/$base"; then
+                same=$((same+1))
+            else
+                diff=$((diff+1))
+                diff_pages+=("$base")
+            fi
+        done
+
+        printf '%s: total=%d same=%d diff=%d' "$s" "$total" "$same" "$diff"
+        if [ "$diff" -gt 0 ]; then
+            printf '  diff_pages=[%s]' "${diff_pages[*]}"
+        fi
+        echo
+
+        total_pages=$((total_pages + total))
+        total_same=$((total_same + same))
+        total_diff=$((total_diff + diff))
+    done
+
+    echo "---"
+    echo "TOTAL: pages=$total_pages same=$total_same diff=$total_diff"
+}
+
+main() {
+    [ $# -lt 1 ] && usage
+
+    local cmd="$1"
+    shift
+
+    case "$cmd" in
+        build)
+            [ $# -lt 2 ] && usage
+            local before_ref="$1"
+            local after_ref="$2"
+            shift 2
+            local samples=("$@")
+            [ ${#samples[@]} -eq 0 ] && samples=("${DEFAULT_SAMPLES[@]}")
+
+            local before_dir="/tmp/svg_diff_before"
+            local after_dir="/tmp/svg_diff_after"
+            rm -rf "$before_dir" "$after_dir"
+
+            echo "=== Building $before_ref → $before_dir ==="
+            build_at_ref "$before_ref" "$before_dir" "${samples[@]}"
+            echo
+            echo "=== Building $after_ref → $after_dir ==="
+            build_at_ref "$after_ref" "$after_dir" "${samples[@]}"
+            echo
+            echo "=== Comparing ==="
+            diff_dirs "$before_dir" "$after_dir"
+            ;;
+        diff)
+            [ $# -lt 2 ] && usage
+            diff_dirs "$1" "$2"
+            ;;
+        *)
+            usage
+            ;;
+    esac
+}
+
+main "$@"

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -15,6 +15,13 @@ use super::text_measurement::{resolved_to_text_style, estimate_text_width, compu
 use super::border_rendering::create_border_line_nodes;
 use super::utils::{resolve_numbering_id, expand_numbering_format, numbering_format_to_number_format, find_bin_data, extract_shape_transform};
 
+/// `RHWP_LAYOUT_DEBUG=1` 로 활성화되는 layout 디버그 로깅 여부.
+/// Phase 1 (#517) — 본질 정정 (#467/#491/#496) 시 결함 측정·재현 자동화에 사용.
+#[inline]
+pub(crate) fn layout_debug_enabled() -> bool {
+    std::env::var("RHWP_LAYOUT_DEBUG").map(|v| v == "1").unwrap_or(false)
+}
+
 /// lineseg baseline_distance를 폰트 어센트 기준으로 보정한다.
 /// CENTER 문단 수직정렬 등으로 baseline이 50% 이하로 설정된 경우,
 /// 텍스트 어센트(~80%)가 줄 박스 밖으로 넘치지 않도록 보장한다.
@@ -115,6 +122,31 @@ impl LayoutEngine {
                 None
             })
             .collect();
+
+        // [Task #517 Stage 1] RHWP_LAYOUT_DEBUG 진단 로깅
+        if layout_debug_enabled() {
+            eprintln!(
+                "LAYOUT_INLINE_TABLE_PARA: pi={} sec={} col_x={:.1} col_w={:.1} y_start={:.1} y={:.1} sb={:.1} sa={:.1} ml={:.1} mr={:.1} align={:?} ls_count={} tables={}",
+                para_index, section_index, col_area.x, col_area.width, y_start, y,
+                spacing_before, spacing_after, margin_left, margin_right, alignment,
+                para.line_segs.len(), inline_tables.len(),
+            );
+            for (li, seg) in para.line_segs.iter().enumerate() {
+                eprintln!(
+                    "  LAYOUT_LS[{}]: vpos={} lh={} ls={} bl={} text_start={} sw={}",
+                    li, seg.vertical_pos, seg.line_height, seg.line_spacing,
+                    seg.baseline_distance, seg.text_start, seg.segment_width,
+                );
+            }
+            for (ti, (ci, tbl)) in inline_tables.iter().enumerate() {
+                eprintln!(
+                    "  LAYOUT_INLINE_TBL[{}]: ctrl_idx={} rows={} cols={} w={} h={} vert={:?} horz={:?} wrap={:?}",
+                    ti, ci, tbl.row_count, tbl.col_count,
+                    tbl.common.width, tbl.common.height,
+                    tbl.common.vert_align, tbl.common.horz_align, tbl.common.text_wrap,
+                );
+            }
+        }
 
         // 3. char_offsets 갭 분석으로 텍스트 세그먼트 분할
         // 확장 컨트롤은 8 UTF-16 코드 유닛을 차지

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -291,54 +291,47 @@ impl LayoutEngine {
             baseline_dist * 1.5
         };
 
-        // LINE_SEG 기반 줄 나눔 위치 결정:
-        // ls[1].text_start가 있으면 해당 UTF-16 위치에서 줄 나눔 (한컴 저장값 존재)
-        // ls[1]이 없으면 자체 right_margin 기반 줄 나눔 (동적 reflow)
-        let line_break_char_idx: Option<usize> = if para.line_segs.len() > 1 {
-            let ts = para.line_segs[1].text_start as u32;
-            // UTF-16 text_start를 char index로 변환 (제어문자 갭 보정)
-            // text_start는 제어문자 8 code unit 포함한 절대 UTF-16 위치
-            let mut utf16_pos = 0u32;
-            let mut ctrl_gap = 0u32;
-            // char_offsets에서 제어문자 갭 계산
-            if !para.char_offsets.is_empty() {
-                let first_offset = para.char_offsets[0];
-                ctrl_gap += first_offset; // 선행 컨트롤
-                for i in 1..para.char_offsets.len() {
-                    let prev_len = if text_chars[i-1] >= '\u{10000}' { 2u32 } else { 1 };
-                    let gap = para.char_offsets[i] - para.char_offsets[i-1];
-                    if gap > prev_len + 4 {
-                        ctrl_gap += gap - prev_len; // 중간 컨트롤 갭
+        // [Task #518 Phase 2] LINE_SEG 기반 줄 나눔 위치 결정:
+        // ls[1..] 의 text_start (raw UTF-16 위치, controls 포함) 를 char index 로 변환.
+        // char_offsets[i] = text_chars[i] 의 원본 UTF-16 위치 → char_offsets[i] >= ts 인 첫 i 가 break.
+        //
+        // 이전: ctrl_gap 을 paragraph 전체 controls 합으로 over-subtract → controls 가 있는
+        // paragraph 에서 saturating 0 으로 항상 break 미감지 (#496 케이스).
+        // 이전: ls[1] 만 사용. 다중 줄 paragraph 에서 ls[2..] 무시 → dynamic reflow.
+        let line_break_char_indices: Vec<usize> = if para.line_segs.len() > 1
+            && !para.char_offsets.is_empty()
+        {
+            let mut indices: Vec<usize> = Vec::new();
+            for ls in para.line_segs.iter().skip(1) {
+                let ts = ls.text_start as u32;
+                // char_offsets[i] >= ts 인 첫 i (= text_chars 의 break 위치)
+                let char_idx = para.char_offsets.iter().position(|&off| off >= ts)
+                    .unwrap_or(text_chars.len());
+                if char_idx > 0 && char_idx <= text_chars.len() {
+                    // 단조 증가 보장 (이전 break 보다 큰 경우에만 추가)
+                    if indices.last().map(|&prev| char_idx > prev).unwrap_or(true) {
+                        indices.push(char_idx);
                     }
                 }
             }
-            // text_start에서 ctrl_gap을 빼서 순수 텍스트 char index 추정
-            let text_only_ts = ts.saturating_sub(ctrl_gap);
-            // UTF-16 → char index 변환
-            let mut char_idx = 0usize;
-            let mut u16_accum = 0u32;
-            for (i, ch) in text_chars.iter().enumerate() {
-                if u16_accum >= text_only_ts {
-                    char_idx = i;
-                    break;
-                }
-                u16_accum += if *ch >= '\u{10000}' { 2 } else { 1 };
-                char_idx = i + 1;
-            }
-            if char_idx > 0 && char_idx <= text_chars.len() {
-                Some(char_idx)
-            } else {
-                None
-            }
+            indices
         } else {
-            None
+            Vec::new()
         };
+        if layout_debug_enabled() {
+            eprintln!(
+                "  LAYOUT_BREAK_INDICES: pi={} indices={:?} (from ls[1..])",
+                para_index, line_break_char_indices,
+            );
+        }
 
         let mut inline_x = start_x;
         let mut current_y = y;
         let mut table_idx = 0;
         let mut max_table_bottom = y; // 표의 최대 하단 y (표 높이를 줄 높이로 사용하기 위함)
         let mut wrapped_below_table = false; // 텍스트가 표 아래로 줄바꿈되었는지
+        // [Task #518] 다음 break 인덱스 (line_break_char_indices 안에서)
+        let mut next_break: usize = 0;
 
         for (s, e) in &segments {
             // 텍스트 세그먼트 렌더링 (줄바꿈 지원)
@@ -426,9 +419,13 @@ impl LayoutEngine {
                         let ch_w = estimate_text_width(&ch.to_string(), &ts);
 
                         // char_shape 변경 또는 줄바꿈 시 누적된 run을 출력
-                        // LINE_SEG 기반 줄 나눔: text_start 위치에서 강제 개행
-                        let need_wrap = if let Some(break_idx) = line_break_char_idx {
-                            ch_idx >= break_idx && !wrapped_below_table
+                        // [Task #518] LINE_SEG 기반 줄 나눔: ls[1..] 의 text_start 위치 모두 사용.
+                        // break 가 모두 소진되거나 미존재 시 right_margin 동적 reflow 로 fallback.
+                        let need_wrap = if next_break < line_break_char_indices.len()
+                            && ch_idx >= line_break_char_indices[next_break]
+                        {
+                            next_break += 1;
+                            true
                         } else {
                             inline_x + ch_w > right_margin + 0.5 && inline_x > line_start_x + 1.0
                         };


### PR DESCRIPTION
## 개요

이슈 #648 정정. Task #518 (Layout 리팩터링 Phase 2 — `line_break_char_idx: Option<usize>` → `line_break_char_indices: Vec<usize>` 다중화) 의 원 commit `b395e8e6` 를 cherry-pick 재적용. 이슈 #496 본질 (B) `ls[2..]` break 미사용 결함 해결.

## ⚠️ 의존성 — 본 PR 은 PR #649 (Task #517) 선행 머지 필요

본 PR 의 `LAYOUT_BREAK_INDICES` 디버그 로깅은 PR #649 가 도입한 `layout_debug_enabled()` 헬퍼에 의존합니다. 따라서 PR #649 선행 머지 → 본 PR 자동 1 commit 축약 → 머지 순으로 진행 권장.

현재 본 PR 은 head=`pr-task648` (= `pr-task647` + Task #518 commit) 으로 구성되어 있어 GitHub 상에는 2 commit 으로 표시됩니다. PR #649 머지 후에는 본 PR diff 가 `b395e8e6` 단일 commit 으로 자동 축약됩니다.

## 회귀 메커니즘

이슈 #618 (Task #519) → PR #620, 이슈 #647 (Task #517) → PR #649 와 동일 패턴: 묶음 머지 `a7e43f9 (Task #517/#518/#519/#520/#521/#523/#528)` 가 `local/devel` 에는 머지되었으나 `stream/devel` 으로 승격되지 않음.

```
$ git merge-base --is-ancestor b395e8e6 stream/devel
NOT in stream/devel

$ git grep -n "line_break_char_idx" stream/devel -- src/
stream/devel:src/renderer/layout/paragraph_layout.rs:265: let line_break_char_idx: Option<usize> = ...
stream/devel:src/renderer/layout/paragraph_layout.rs:398: if let Some(break_idx) = line_break_char_idx {
```

→ Task #518 이전 단일 break 시그니처 그대로.

## 변경 내역

원 commit `b395e8e6` 를 `git cherry-pick -x` 로 그대로 적용 (충돌 없음).

핵심 변경 (`src/renderer/layout/paragraph_layout.rs` -40/+77):

| 항목 | 회귀 (이전) | 정정 |
|------|-------------|------|
| 변수 | `line_break_char_idx: Option<usize>` | `line_break_char_indices: Vec<usize>` |
| 사용 범위 | `ls[1]` 만 | `ls[1..]` 모두 |
| 알고리즘 | `ctrl_gap` 합산 (controls 많은 paragraph 에서 over-subtract → saturating 0 → 항상 None) | `char_offsets[i] >= ts` 인 첫 `i` 직접 룩업 |
| wrap 결정 | 단일 break_idx 검사 | `next_break` 추적 + 다중 break 검사 |
| 디버그 | — | `LAYOUT_BREAK_INDICES` 로깅 추가 |

## 검증

```
$ cargo build
Finished `dev` profile

$ cargo test --release --lib
test result: ok. 1141 passed; 0 failed; 2 ignored; 0 measured; 0 filtered out
```

회귀 케이스 (원 commit 보고 인용): exam_science p2 pi=61 본문 1줄 column 폭 초과 → 3줄 정상 wrap (`ls[1]` break char 5 + `ls[2]` break char 28). 7 샘플 170 페이지 중 same=167 / diff=3 (exam_science 정확도 정정).

## 참고

- 원 이슈: #518 (CLOSED)
- 회귀 이슈: #648
- 본질 이슈: #496 (B)
- 원 fix 커밋: `b395e8e6`
- 묶음 머지: `a7e43f9` (Merge local/devel: Task #517/#518/#519/#520/#521/#523/#528)
- 동일 패턴 선행 사례: PR #620 (Task #519), PR #649 (Task #517 — 의존)