### PR TITLE
feat: ir-diff 표 속성 / 컨트롤 식별 비교 추가 (closes #653)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -201,7 +201,8 @@ rhwp ir-diff sample.hwpx sample.hwp 2>&1 | grep "\[PS " # ParaShape 차이만
 rhwp ir-diff sample.hwpx sample.hwp 2>&1 | tail -1      # 차이 건수만
 ```
 
-비교 항목: text, char_count, char_offsets, char_shapes, line_segs, controls, tab_extended, ParaShape(여백/줄간격/탭), TabDef(위치/종류/채움).
+비교 항목: text, char_count, char_offsets, char_shapes, line_segs, controls(타입+속성), tab_extended, ParaShape(여백/줄간격/탭), TabDef(위치/종류/채움).
+표/그림/도형 컨트롤: treat_as_char, wrap, size, offset, page_break, outer_margin 등 개별 속성 비교.
 
 상세 매뉴얼: `mydocs/manual/ir_diff_command.md`
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -202,7 +202,8 @@ rhwp ir-diff sample.hwpx sample.hwp 2>&1 | tail -1      # 차이 건수만
 ```
 
 비교 항목: text, char_count, char_offsets, char_shapes, line_segs, controls(타입+속성), tab_extended, ParaShape(여백/줄간격/탭), TabDef(위치/종류/채움).
-표/그림/도형 컨트롤: treat_as_char, wrap, size, offset, page_break, outer_margin 등 개별 속성 비교.
+표: page_break, outer_margin, treat_as_char, wrap, size, v_offset/h_offset 비교.
+그림/도형: treat_as_char, wrap, size, v_offset/h_offset, vert_rel/horz_rel 비교.
 
 상세 매뉴얼: `mydocs/manual/ir_diff_command.md`
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -81,6 +81,9 @@ fn print_help() {
     println!();
     println!("  ir-diff <파일A.hwpx> <파일B.hwp> [-s <구역>] [-p <문단>]");
     println!("      두 파일의 IR(중간표현) 비교 (HWPX↔HWP 불일치 검출)");
+    println!("      비교 항목: text, char_count, char_offsets, char_shapes, line_segs,");
+    println!("                 controls(타입+속성), tab_extended, ParaShape, TabDef");
+    println!("      표/그림/도형 컨트롤: treat_as_char, wrap, size, offset, page_break 등");
     println!();
     println!("  thumbnail <파일.hwp> [옵션]");
     println!("      HWP 파일에서 썸네일(PrvImage) 추출");
@@ -2325,6 +2328,103 @@ fn test_field_roundtrip(args: &[String]) {
     }
 }
 
+fn control_tag(c: &rhwp::model::control::Control) -> &'static str {
+    use rhwp::model::control::Control;
+    match c {
+        Control::SectionDef(_) => "secd",
+        Control::ColumnDef(_) => "cold",
+        Control::Table(_) => "tbl",
+        Control::Shape(_) => "shape",
+        Control::Picture(_) => "pic",
+        Control::Header(_) => "head",
+        Control::Footer(_) => "foot",
+        Control::Footnote(_) => "fn",
+        Control::Endnote(_) => "en",
+        Control::AutoNumber(_) => "atno",
+        Control::NewNumber(_) => "nwno",
+        Control::PageNumberPos(_) => "pgnp",
+        Control::Bookmark(_) => "bokm",
+        Control::Hyperlink(_) => "hlk",
+        Control::Ruby(_) => "ruby",
+        Control::CharOverlap(_) => "tcps",
+        Control::PageHide(_) => "pghd",
+        Control::HiddenComment(_) => "tcmt",
+        Control::Equation(_) => "eqed",
+        Control::Field(_) => "field",
+        Control::Form(_) => "form",
+        Control::Unknown(_) => "unknown",
+    }
+}
+
+fn diff_table(
+    diffs: &mut Vec<String>,
+    ci: usize,
+    a: &rhwp::model::table::Table,
+    b: &rhwp::model::table::Table,
+) {
+    if a.row_count != b.row_count {
+        diffs.push(format!("ctrl[{}] tbl rows: A={} vs B={}", ci, a.row_count, b.row_count));
+    }
+    if a.col_count != b.col_count {
+        diffs.push(format!("ctrl[{}] tbl cols: A={} vs B={}", ci, a.col_count, b.col_count));
+    }
+    if a.page_break != b.page_break {
+        diffs.push(format!("ctrl[{}] tbl page_break: A={:?} vs B={:?}", ci, a.page_break, b.page_break));
+    }
+    if a.repeat_header != b.repeat_header {
+        diffs.push(format!("ctrl[{}] tbl repeat_header: A={} vs B={}", ci, a.repeat_header, b.repeat_header));
+    }
+    if a.cell_spacing != b.cell_spacing {
+        diffs.push(format!("ctrl[{}] tbl cell_spacing: A={} vs B={}", ci, a.cell_spacing, b.cell_spacing));
+    }
+    if a.border_fill_id != b.border_fill_id {
+        diffs.push(format!("ctrl[{}] tbl border_fill: A={} vs B={}", ci, a.border_fill_id, b.border_fill_id));
+    }
+    if a.outer_margin_left != b.outer_margin_left
+        || a.outer_margin_right != b.outer_margin_right
+        || a.outer_margin_top != b.outer_margin_top
+        || a.outer_margin_bottom != b.outer_margin_bottom
+    {
+        diffs.push(format!(
+            "ctrl[{}] tbl outer_margin: A=({},{},{},{}) vs B=({},{},{},{})",
+            ci,
+            a.outer_margin_left, a.outer_margin_top, a.outer_margin_right, a.outer_margin_bottom,
+            b.outer_margin_left, b.outer_margin_top, b.outer_margin_right, b.outer_margin_bottom,
+        ));
+    }
+    diff_common_obj(diffs, ci, "tbl", &a.common, &b.common);
+}
+
+fn diff_common_obj(
+    diffs: &mut Vec<String>,
+    ci: usize,
+    tag: &str,
+    a: &rhwp::model::shape::CommonObjAttr,
+    b: &rhwp::model::shape::CommonObjAttr,
+) {
+    if a.treat_as_char != b.treat_as_char {
+        diffs.push(format!("ctrl[{}] {} tac: A={} vs B={}", ci, tag, a.treat_as_char, b.treat_as_char));
+    }
+    if a.text_wrap != b.text_wrap {
+        diffs.push(format!("ctrl[{}] {} wrap: A={:?} vs B={:?}", ci, tag, a.text_wrap, b.text_wrap));
+    }
+    if a.width != b.width || a.height != b.height {
+        diffs.push(format!("ctrl[{}] {} size: A={}x{} vs B={}x{}", ci, tag, a.width, a.height, b.width, b.height));
+    }
+    if a.vertical_offset != b.vertical_offset {
+        diffs.push(format!("ctrl[{}] {} voff: A={} vs B={}", ci, tag, a.vertical_offset, b.vertical_offset));
+    }
+    if a.horizontal_offset != b.horizontal_offset {
+        diffs.push(format!("ctrl[{}] {} hoff: A={} vs B={}", ci, tag, a.horizontal_offset, b.horizontal_offset));
+    }
+    if a.vert_rel_to != b.vert_rel_to {
+        diffs.push(format!("ctrl[{}] {} vert_rel: A={:?} vs B={:?}", ci, tag, a.vert_rel_to, b.vert_rel_to));
+    }
+    if a.horz_rel_to != b.horz_rel_to {
+        diffs.push(format!("ctrl[{}] {} horz_rel: A={:?} vs B={:?}", ci, tag, a.horz_rel_to, b.horz_rel_to));
+    }
+}
+
 fn ir_diff(args: &[String]) {
     if args.len() < 2 {
         eprintln!("사용법: rhwp ir-diff <파일A> <파일B> [-s <구역>] [-p <문단>]");
@@ -2466,9 +2566,32 @@ fn ir_diff(args: &[String]) {
                 }
             }
 
-            // 컨트롤 수 비교
+            // 컨트롤 식별 비교
             if pa.controls.len() != pb.controls.len() {
-                diffs.push(format!("controls: A={} vs B={}", pa.controls.len(), pb.controls.len()));
+                diffs.push(format!("controls count: A={} vs B={}", pa.controls.len(), pb.controls.len()));
+            }
+            {
+                use rhwp::model::control::Control;
+                let ctrl_count = pa.controls.len().min(pb.controls.len());
+                for ci in 0..ctrl_count {
+                    let ca = &pa.controls[ci];
+                    let cb = &pb.controls[ci];
+                    let tag_a = control_tag(ca);
+                    let tag_b = control_tag(cb);
+                    if tag_a != tag_b {
+                        diffs.push(format!("ctrl[{}] type: A={} vs B={}", ci, tag_a, tag_b));
+                        continue;
+                    }
+                    if let (Control::Table(ta), Control::Table(tb)) = (ca, cb) {
+                        diff_table(&mut diffs, ci, ta, tb);
+                    }
+                    if let (Control::Picture(pic_a), Control::Picture(pic_b)) = (ca, cb) {
+                        diff_common_obj(&mut diffs, ci, "pic", &pic_a.common, &pic_b.common);
+                    }
+                    if let (Control::Shape(sa), Control::Shape(sb)) = (ca, cb) {
+                        diff_common_obj(&mut diffs, ci, "shape", sa.common(), sb.common());
+                    }
+                }
             }
 
             // char_shapes 비교

--- a/src/main.rs
+++ b/src/main.rs
@@ -2557,8 +2557,23 @@ fn ir_diff(args: &[String]) {
                     if la.text_start != lb.text_start {
                         diffs.push(format!("ls[{}].ts: A={} vs B={}", li, la.text_start, lb.text_start));
                     }
+                    if la.vertical_pos != lb.vertical_pos {
+                        diffs.push(format!("ls[{}].vpos: A={} vs B={}", li, la.vertical_pos, lb.vertical_pos));
+                    }
                     if la.line_height != lb.line_height {
                         diffs.push(format!("ls[{}].lh: A={} vs B={}", li, la.line_height, lb.line_height));
+                    }
+                    if la.text_height != lb.text_height {
+                        diffs.push(format!("ls[{}].th: A={} vs B={}", li, la.text_height, lb.text_height));
+                    }
+                    if la.baseline_distance != lb.baseline_distance {
+                        diffs.push(format!("ls[{}].bl: A={} vs B={}", li, la.baseline_distance, lb.baseline_distance));
+                    }
+                    if la.line_spacing != lb.line_spacing {
+                        diffs.push(format!("ls[{}].ls: A={} vs B={}", li, la.line_spacing, lb.line_spacing));
+                    }
+                    if la.column_start != lb.column_start {
+                        diffs.push(format!("ls[{}].cs: A={} vs B={}", li, la.column_start, lb.column_start));
                     }
                     if la.segment_width != lb.segment_width {
                         diffs.push(format!("ls[{}].sw: A={} vs B={}", li, la.segment_width, lb.segment_width));

--- a/src/main.rs
+++ b/src/main.rs
@@ -83,7 +83,8 @@ fn print_help() {
     println!("      두 파일의 IR(중간표현) 비교 (HWPX↔HWP 불일치 검출)");
     println!("      비교 항목: text, char_count, char_offsets, char_shapes, line_segs,");
     println!("                 controls(타입+속성), tab_extended, ParaShape, TabDef");
-    println!("      표/그림/도형 컨트롤: treat_as_char, wrap, size, offset, page_break 등");
+    println!("      표: page_break, outer_margin, treat_as_char, wrap, size, v_offset/h_offset");
+    println!("      그림/도형: treat_as_char, wrap, size, v_offset/h_offset, vert_rel/horz_rel");
     println!();
     println!("  thumbnail <파일.hwp> [옵션]");
     println!("      HWP 파일에서 썸네일(PrvImage) 추출");
@@ -2378,7 +2379,7 @@ fn diff_table(
         diffs.push(format!("ctrl[{}] tbl cell_spacing: A={} vs B={}", ci, a.cell_spacing, b.cell_spacing));
     }
     if a.border_fill_id != b.border_fill_id {
-        diffs.push(format!("ctrl[{}] tbl border_fill: A={} vs B={}", ci, a.border_fill_id, b.border_fill_id));
+        diffs.push(format!("ctrl[{}] tbl border_fill_id: A={} vs B={}", ci, a.border_fill_id, b.border_fill_id));
     }
     if a.outer_margin_left != b.outer_margin_left
         || a.outer_margin_right != b.outer_margin_right
@@ -2412,10 +2413,10 @@ fn diff_common_obj(
         diffs.push(format!("ctrl[{}] {} size: A={}x{} vs B={}x{}", ci, tag, a.width, a.height, b.width, b.height));
     }
     if a.vertical_offset != b.vertical_offset {
-        diffs.push(format!("ctrl[{}] {} voff: A={} vs B={}", ci, tag, a.vertical_offset, b.vertical_offset));
+        diffs.push(format!("ctrl[{}] {} v_offset: A={} vs B={}", ci, tag, a.vertical_offset, b.vertical_offset));
     }
     if a.horizontal_offset != b.horizontal_offset {
-        diffs.push(format!("ctrl[{}] {} hoff: A={} vs B={}", ci, tag, a.horizontal_offset, b.horizontal_offset));
+        diffs.push(format!("ctrl[{}] {} h_offset: A={} vs B={}", ci, tag, a.horizontal_offset, b.horizontal_offset));
     }
     if a.vert_rel_to != b.vert_rel_to {
         diffs.push(format!("ctrl[{}] {} vert_rel: A={:?} vs B={:?}", ci, tag, a.vert_rel_to, b.vert_rel_to));
@@ -2591,20 +2592,20 @@ fn ir_diff(args: &[String]) {
                 for ci in 0..ctrl_count {
                     let ca = &pa.controls[ci];
                     let cb = &pb.controls[ci];
-                    let tag_a = control_tag(ca);
-                    let tag_b = control_tag(cb);
-                    if tag_a != tag_b {
-                        diffs.push(format!("ctrl[{}] type: A={} vs B={}", ci, tag_a, tag_b));
-                        continue;
-                    }
-                    if let (Control::Table(ta), Control::Table(tb)) = (ca, cb) {
-                        diff_table(&mut diffs, ci, ta, tb);
-                    }
-                    if let (Control::Picture(pic_a), Control::Picture(pic_b)) = (ca, cb) {
-                        diff_common_obj(&mut diffs, ci, "pic", &pic_a.common, &pic_b.common);
-                    }
-                    if let (Control::Shape(sa), Control::Shape(sb)) = (ca, cb) {
-                        diff_common_obj(&mut diffs, ci, "shape", sa.common(), sb.common());
+                    match (ca, cb) {
+                        (Control::Table(ta), Control::Table(tb)) => {
+                            diff_table(&mut diffs, ci, ta, tb);
+                        }
+                        (Control::Picture(pic_a), Control::Picture(pic_b)) => {
+                            diff_common_obj(&mut diffs, ci, "pic", &pic_a.common, &pic_b.common);
+                        }
+                        (Control::Shape(sa), Control::Shape(sb)) => {
+                            diff_common_obj(&mut diffs, ci, "shape", sa.common(), sb.common());
+                        }
+                        _ if control_tag(ca) != control_tag(cb) => {
+                            diffs.push(format!("ctrl[{}] type: A={} vs B={}", ci, control_tag(ca), control_tag(cb)));
+                        }
+                        _ => {}
                     }
                 }
             }


### PR DESCRIPTION
## 변경 요약

ir-diff 명령의 컨트롤 비교를 **수(count)만 비교** → **타입 + 속성 식별 비교**로 확장합니다.

### 추가된 비교 항목

**컨트롤 타입 식별**: 같은 위치의 컨트롤이 다른 타입(tbl vs pic 등)이면 `ctrl[N] type: A=tbl vs B=pic` 으로 보고

**표 (Table) 속성 비교**:
- `row_count`, `col_count`
- `page_break` (None / CellBreak / RowBreak)
- `repeat_header`
- `cell_spacing`, `border_fill_id`
- `outer_margin` (좌/상/우/하)
- CommonObjAttr: `treat_as_char`, `text_wrap`, `size`, `offset`, `vert_rel`, `horz_rel`

**그림/도형 CommonObjAttr 비교**: 표와 동일한 공통 속성 비교

### 출력 예시

```
--- 문단 0.45 --- ""
  [차이] ctrl[0] tbl page_break: A=None vs B=CellBreak
  [차이] ctrl[0] tbl tac: A=false vs B=true
  [차이] ctrl[0] tbl wrap: A=TopAndBottom vs B=Square
  [차이] ctrl[0] tbl size: A=35280x14400 vs B=35280x14520
```

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과