### PR TITLE
Task #674: paragraph_layout 측정 corrected_line_height 보정 — 마지막 줄 시각 클립 정정 (closes #674)

### DIFF
--- a/mydocs/orders/20260507.md
+++ b/mydocs/orders/20260507.md
@@ -70,3 +70,11 @@ v0.7.10 (5/6) 후 PATCH 회전 운영 패턴 (`feedback_small_batch_release_stra
 - 이슈 #485 GitHub 코멘트 추가 (페이지 20·21 검증 케이스 + 정정 영역 + close 권고)
 - `local/task485` → `local/devel` merge
 - 후속 작업 이슈 #656 등록 (typeset/layout 모델 통일)
+
+## M100 — 신규 결함 정정 (Task #671 ~ #674 시리즈)
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **Task #671** | 표 셀 내부 paragraph 줄바꿈 시 다중 LINE_SEG 줄 겹침 (closes #671) | **머지 완료 (PR #673)** | `samples/계획서.hwp` 1페이지 표 셀 [13]/[21]에서 단일 paragraph가 셀 너비에 맞춰 다중 줄로 줄바꿈될 때 두 줄이 같은 y 좌표에 겹쳐 그려지던 결함 정정. `composer.rs` 신규 함수 `recompose_for_cell_width` (3 중 가드) + 호출 위치 6 곳. 메인테이너 머지 (`a6645ed`) + 추가 정정 (`4d354d2`, 자동보정 모드 영역 셀 폭 정정 — `document.rs:270/425` reflow_line_segs cell_inner_width 적용). |
+| **Task #672** | TAC 표 비례 축소 시 셀 콘텐츠 클립 (closes #672) | **머지 완료 (PR #675)** | Task #671 본질 정정 후 노출된 별개 결함. `height_measurer.rs:805-822` 임계값 가드 (TAC_SHRINK_THRESHOLD_RATIO = 0.02). 작은 차이 (≤2%) 면제 → row_heights 측정값 보존. 메인테이너 머지 (`877e020`). |
+| **Task #674** | paragraph_layout 줄 위치 vs row_heights 정합 — calc_para_lines_height corrected_line_height 누락 (closes #674) | **PR #678 OPEN** | Task #672 본질 정정 후 노출된 별개 결함. `table_layout.rs:746` `calc_para_lines_height` 시그니처에 `styles` 추가 + `corrected_line_height` 보정 적용. 시각 판정 ★ 통과 (셀 [21] 3줄 모두 표시 + 셀 [52] 3 paragraph 모두 표시). 의존성: 선행 Task #672 (머지 완료). |

--- a/mydocs/plans/task_m100_674.md
+++ b/mydocs/plans/task_m100_674.md
@@ -1,0 +1,114 @@
+# Task #674 수행 계획서
+
+## 1. 이슈 요약
+
+**Issue #674**: paragraph_layout 줄 위치 vs row_heights 정합 — line_segs 부재 paragraph 마지막 줄 시각 클립
+
+**증상**: Task #672 (TAC 표 비례 축소 면제) 정정 후에도 line_segs 부재 셀 paragraph 의 마지막 줄이 SVG cell-clip 영역을 초과하여 시각적으로 클립됨.
+
+## 2. 본질 식별 (사전 진단)
+
+### 2.1 SVG clipPath 영역
+
+`samples/계획서.hwp` 셀 [21] (r=5, c=1, cs=14):
+
+```
+<clipPath id="cell-clip-81">
+  <rect x="164.05" y="353.49" width="564.32" height="67.76"/>
+</clipPath>
+```
+
+- clipPath 영역: y = 353.49 ~ 421.25 (height=67.76, row_heights[5] 정합)
+
+### 2.2 paragraph_layout 줄 위치
+
+```
+col_area.y = 379.37
+줄 0 y = 379.37 (clip 안)
+줄 1 y = 400.71 (clip 안)
+줄 2 y = 422.04 (clip 끝 421.25 **초과**)
+```
+
+### 2.3 본질 결함
+
+`col_area.y` (379.37) 가 `cell_y + pad_top` (이론: 353.49 + 1.88 = 355.37) 보다 **25.88 px 큼**. 이로 인해 paragraph layout 시작 위치가 cell-clip 영역 상단보다 아래로 밀림 → 마지막 줄이 clip 끝 초과.
+
+## 3. 25.88px 오프셋 원인 후보
+
+`src/renderer/layout/table_layout.rs:1374-1388` `text_y_start` 결정 로직:
+
+```rust
+let text_y_start = if !has_nested_table && first_line_vpos.filter(|&v| v > 0.0).is_some() {
+    cell_y + pad_top + first_line_vpos.unwrap()
+} else {
+    match effective_valign {
+        VerticalAlign::Top => cell_y + pad_top,
+        VerticalAlign::Center => {
+            let mechanical_offset = (inner_height - total_content_height).max(0.0) / 2.0;
+            cell_y + pad_top + mechanical_offset
+        }
+        VerticalAlign::Bottom => {
+            cell_y + pad_top + (inner_height - total_content_height).max(0.0)
+        }
+    }
+};
+```
+
+가설:
+- (a) `first_line_vpos > 0.0` 분기 진입 — line_segs 비어있어 first_line_vpos = None 이어야. 하지만 다른 paragraph (예: 본문 첫 paragraph) 의 vpos 가 영향?
+- (b) `effective_valign` 이 Center 또는 Bottom — Stage 1 에서 정확히 식별
+- (c) total_content_height 가 inner_height 보다 작아 mechanical_offset 발생
+
+## 4. Stage 1: 본질 진단
+
+- 셀 [21] 의 effective_valign 식별
+- `first_line_vpos` 값 식별 (line_segs 부재 시 None 이어야 정상)
+- text_y_start 분기 식별
+- 25.88 px 오프셋의 정확한 본질 위치
+
+## 5. Stage 2: 본질 정정
+
+Stage 1 결과에 따라 정정 방향 결정:
+
+### 옵션 A: text_y_start 결정 로직 정정
+
+`first_line_vpos.is_some()` 분기 또는 mechanical_offset 계산이 line_segs 부재 paragraph 에서 잘못 계산되는 영역 정정.
+
+### 옵션 B: cell-clip 영역 확장
+
+cell BoundingBox 의 clip 영역을 layout end 까지 확장. (`cell_h` 가 layout 결과 끝까지 커지도록)
+
+### 옵션 C: 양방향 — 정확한 시작 위치 + clip 영역 정합
+
+paragraph layout 시작 위치 = cell_y + pad_top (정확) + clip 영역 = cell_h (정확). 두 영역 간 정합.
+
+권장: 옵션 A — 본질 정정 + 회귀 위험 좁힘.
+
+## 6. Stage 3: 광범위 회귀 sweep + 시각 판정
+
+- 187 fixture 회귀 0 검증
+- `samples/계획서.hwp` 시각 판정 (셀 [21] / [52] 마지막 줄 표시)
+- 다른 셀 영역 회귀 0
+
+## 7. 마일스톤
+
+M100 (v1.0.0) — 조판 엔진 정합성
+
+## 8. 권위 자료
+
+- `samples/계획서.hwp` — 권위 재현 영역 (Task #671/#672 와 공유)
+
+## 9. 회귀 위험 영역 좁힘 원칙
+
+- `text_y_start` 결정 로직은 모든 셀 paragraph 에 영향 → 정정 시 case 가드 명시
+- 본 case (line_segs 부재) 만 영향, 정상 line_segs 인코딩 paragraph 무영향
+- 광범위 sweep 차이 0 보장
+
+## 10. 의존성
+
+- **선행 의존**: Task #671 + #672 정정 코드 (`local/task672` 브랜치)
+- **후행 의존**: 없음 — `samples/계획서.hwp` 시각 결함 완전 해소
+
+## 11. 승인 요청
+
+본 수행계획서 + Stage 1 본질 진단 (25.88 px 오프셋 정확 원인 식별) 진행 승인 요청.

--- a/mydocs/plans/task_m100_674_impl.md
+++ b/mydocs/plans/task_m100_674_impl.md
@@ -1,0 +1,145 @@
+# Task #674 구현 계획서
+
+## 개요
+
+Issue #674 "paragraph_layout 줄 위치 vs row_heights 정합 — line_segs 부재 paragraph 마지막 줄 시각 클립" 정정 구현. 3 단계 진행.
+
+## Stage 1: 본질 진단 — 25.88px 오프셋 원인 식별
+
+### 목표
+
+`samples/계획서.hwp` 셀 [21] 의 `text_y_start = 379.37` 결정 경로 정확 식별. 25.88px 오프셋의 정확한 위치 (text_y_start 분기 또는 추가 보정) 진단.
+
+### 진단 절차
+
+1. **text_y_start 디버그 추가**
+   - `src/renderer/layout/table_layout.rs:1374-1388` 에 환경변수 기반 디버그 출력
+   - 셀 [21] (cell_idx=21, r=5,c=1) 의 분기 결과 + first_line_vpos + effective_valign + inner_height + total_content_height + mechanical_offset 출력
+
+2. **분기 식별**
+   - 어느 분기 (first_line_vpos / Top / Center / Bottom) 진입
+   - mechanical_offset 또는 추가 offset 영역
+
+3. **다른 셀 비교**
+   - 정상 표시되는 셀 (예: 셀 [13]) 의 text_y_start 분기 비교
+   - 차이 영역 식별
+
+### 진단 산출물
+
+`mydocs/working/task_m100_674_stage1.md` — 본질 진단 결과 + Stage 2 정정 방향 결정.
+
+### 승인 요청
+
+Stage 1 진단 결과 + Stage 2 정정 방향 승인 요청.
+
+## Stage 2: 본질 정정
+
+### 목표
+
+Stage 1 진단 결과에 따라 `text_y_start` 결정 로직 또는 관련 영역 정정. paragraph layout 시작 위치 = `cell_y + pad_top` (Top 정렬, line_segs 부재 케이스).
+
+### 정정 원칙
+
+- **케이스 가드 명시**: line_segs 부재 paragraph 만 영향. 정상 인코딩된 paragraph 무영향.
+- **회귀 위험 좁힘**: 다른 셀 / 다른 fixture 의 text_y_start 결정 로직에 영향 없음.
+- **본질 룰**: 25.88px 오프셋의 본질 원인 정확히 정정 (휴리스틱 금지).
+
+### 정정 위치 후보
+
+`src/renderer/layout/table_layout.rs:1374-1388`:
+
+```rust
+let text_y_start = if !has_nested_table && first_line_vpos.filter(|&v| v > 0.0).is_some() {
+    cell_y + pad_top + first_line_vpos.unwrap()
+} else {
+    match effective_valign {
+        VerticalAlign::Top => cell_y + pad_top,
+        VerticalAlign::Center => { ... }
+        VerticalAlign::Bottom => { ... }
+    }
+};
+```
+
+Stage 1 진단에 따른 정정 후보:
+
+#### A. first_line_vpos 분기 잘못 진입 시
+
+- line_segs.is_empty() 인 paragraph 에서 first_line_vpos 가 다른 값 (예: 다른 paragraph 의 vpos) 으로 결정되는 경우
+- 가드: `cell.paragraphs.first().filter(|p| !p.line_segs.is_empty()).and_then(...)`
+
+#### B. effective_valign 이 Center 시
+
+- 셀 [21] 의 vertical_align 이 Center 로 잘못 인식
+- 또는 mechanical_offset 계산 오류 (inner_height vs total_content_height)
+
+#### C. mechanical_offset 계산 오류
+
+- total_content_height 가 inner_height 보다 작게 측정 → 비례 offset 발생
+- recompose_for_cell_width 로 줄 수 변경 시 total_content_height 재계산 필요
+
+### 검증 절차
+
+1. **결정적 검증**
+   - cargo test --lib --release 회귀 0 (1155+ passed)
+   - svg_snapshot 6/6 + issue_546 1/1 + issue_554 12/12
+   - cargo clippy --release 신규 경고 0
+2. **시각 검증**
+   - `samples/계획서.hwp` 셀 [21] 3 줄 / [52] 3 paragraph 정상 표시 (PNG 변환)
+3. **광범위 sweep**
+   - 187 fixture 페이지 수 차이 0 (Stage 3)
+
+### 정정 산출물
+
+- 영향 코드 변경 (`src/renderer/layout/table_layout.rs` 등)
+- `mydocs/working/task_m100_674_stage2.md` 단계별 보고서
+
+### 승인 요청
+
+Stage 2 정정 결과 + 시각 판정 통과 → Stage 3 진행 승인.
+
+## Stage 3: 광범위 회귀 sweep + 최종 검증
+
+### 목표
+
+광범위 페이지네이션 회귀 sweep + 시각 판정 게이트웨이 통과. `samples/계획서.hwp` 1 페이지 표 시각 결함 완전 해소.
+
+### 검증 절차
+
+1. **광범위 페이지네이션 회귀 sweep**
+   - 187 fixture BEFORE/AFTER 페이지 수 차이 0
+2. **결정적 검증 (release 모드)**
+   - cargo test --lib --release 1155+ passed
+   - cargo test --release 전체 GREEN
+   - cargo clippy --release 신규 경고 0
+3. **시각 판정 게이트웨이 (작업지시자)**
+   - `samples/계획서.hwp` 1 페이지 시각 판정 (PNG)
+   - 셀 [21] 3 줄 모두 표시 + 셀 [52] 3 paragraph 모두 표시 확인
+   - 다른 셀 영역 회귀 0 확인
+
+### 산출물
+
+- `mydocs/report/task_m100_674_report.md` 최종 보고서
+- `mydocs/orders/20260507.md` Task #674 상태 갱신
+
+### 승인 요청
+
+최종 보고서 + 시각 판정 게이트웨이 통과 후 작업지시자 승인 → fork push + PR 생성 영역.
+
+## 회귀 위험 영역 좁힘 원칙
+
+- **수정 영역 명시**: text_y_start 결정 로직 또는 관련 영역만
+- **케이스 가드**: line_segs 부재 paragraph + 본 결함 발현 영역만 정정 영향
+- **광범위 sweep 검증**: 187 fixture 페이지 수 차이 0
+- **다른 영역 영향**: cell-clip 영역, paragraph_layout y 누적 등 무영향
+
+## 의존성
+
+- **선행 의존**: Task #671 + #672 정정 코드 (`local/task672` 브랜치) — 본 task 는 그 위에서 분기
+- **후행 의존**: 없음 — `samples/계획서.hwp` 시각 결함 완전 해소
+
+## 최종 결과 영역
+
+본 task 완료 후:
+- Issue #674 close (closes #674 키워드)
+- `samples/계획서.hwp` 1 페이지 표 시각 결함 (Task #671/#672/#674) 완전 해소
+- Task #671~#674 시리즈 완료

--- a/mydocs/report/task_m100_674_report.md
+++ b/mydocs/report/task_m100_674_report.md
@@ -1,0 +1,177 @@
+# Task #674 최종 결과 보고서
+
+## 1. 요약
+
+**Issue #674**: paragraph_layout 줄 위치 vs row_heights 정합 — line_segs 부재 paragraph 마지막 줄 시각 클립
+
+**결과**: `calc_para_lines_height` 의 `corrected_line_height` 보정 누락이 본질 결함으로 식별. 시그니처에 `styles` 추가 + 보정 적용으로 **본질 정정 완료**. 회귀 0. 시각 판정 ★ 통과.
+
+**Task #671 ~ #674 시리즈 완성** — `samples/계획서.hwp` 1페이지 표 시각 결함 완전 해소.
+
+## 2. 본질 진단 (Stage 1)
+
+### 2.1 25.88 px 오프셋 본질 식별
+
+`samples/계획서.hwp` 셀 [21] (r=5, c=1) 의 paragraph layout 시작 위치 계산:
+
+```
+[T674] cell[5,1] cell_y=353.49 pad_top=1.88 pad_bottom=1.88
+[T674]   has_nested=false first_line_vpos=None effective_valign=Center
+[T674]   inner_height=64.00 total_content_height=16.00
+[T674]   text_y_start=379.37 (cell_y+pad_top=355.37, diff=+24.00)
+```
+
+### 2.2 본질 결함 메커니즘
+
+```
+calc_composed_paras_content_height
+  ↓
+calc_para_lines_height (corrected_line_height 누락!)
+  → line.line_height (raw 5.33 px) 그대로 사용
+  → 3줄 × 5.33 = 16.00 (잘못된 측정)
+  ↓
+total_content_height = 16.00
+  ↓
+mechanical_offset = (inner_height 64 - total 16) / 2 = 24.00 (Center 정렬)
+  ↓
+text_y_start = cell_y + pad_top + 24.00 = 379.37 (24px 위로 밀림)
+  ↓
+paragraph_layout 줄 layout 시작 위치 잘못 → 마지막 줄 cell-clip 영역 초과
+  ↓
+SVG cell-clip-81 (y=353.49, h=67.76, end=421.25) 안에 줄 0,1 만 들어감
+줄 2 (y=422.04) clip 영역 초과 → 시각 클립
+```
+
+## 3. 본질 정정 (Stage 2)
+
+### 3.1 정정 위치
+
+`src/renderer/layout/table_layout.rs:746-781` `calc_para_lines_height`:
+
+```rust
+fn calc_para_lines_height(
+    &self,
+    lines: &[crate::renderer::composer::ComposedLine],
+    pidx: usize,
+    total_para_count: usize,
+    para_style: Option<&crate::renderer::style_resolver::ResolvedParaStyle>,
+    styles: &ResolvedStyleSet,  // [Task #674] 신규
+) -> f64 {
+    ...
+    let cell_ls_val = para_style.map(|s| s.line_spacing).unwrap_or(160.0);
+    let cell_ls_type = para_style.map(|s| s.line_spacing_type)
+        .unwrap_or(crate::model::style::LineSpacingType::Percent);
+    let lines_total: f64 = lines.iter()
+        .enumerate()
+        .map(|(i, line)| {
+            let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
+            let max_fs = line.runs.iter()
+                .map(|r| styles.char_styles.get(r.char_style_id as usize)
+                    .map(|cs| cs.font_size).unwrap_or(0.0))
+                .fold(0.0f64, f64::max);
+            let h = crate::renderer::corrected_line_height(
+                raw_lh, max_fs, cell_ls_type, cell_ls_val);
+            ...
+        })
+        .sum();
+    ...
+}
+```
+
+`height_measurer.rs:570-587` 와 동일 로직 — 측정/layout 일관성 정합.
+
+### 3.2 호출자 시그니처 정정
+
+| 파일:줄 | 함수 | 변경 |
+|---------|------|------|
+| `table_layout.rs:710` | calc_cell_paragraphs_content_height | calc_para_lines_height 호출 시 styles 추가 |
+| `table_layout.rs:728` | calc_composed_paras_content_height | calc_para_lines_height 호출 시 styles 추가 |
+
+### 3.3 정정 효과
+
+| 항목 | BEFORE | AFTER |
+|------|--------|-------|
+| line_height 보정 | 없음 (raw 5.33) | corrected (21.33) ✅ |
+| total_content_height (3줄) | 16.00 | **64.00** ✅ |
+| mechanical_offset (Center) | 24.00 | **0.00** ✅ |
+| text_y_start | 379.37 | **355.37** ✅ |
+| 줄 2 y | 422.04 (clip 초과) | **397.71 (clip 안)** ✅ |
+
+## 4. 결정적 검증
+
+| 검증 영역 | 결과 |
+|----------|------|
+| `cargo build --release` | ✅ |
+| `cargo test --lib --release` | ✅ **1155 passed** (회귀 0) |
+| `cargo test --release --test svg_snapshot` | ✅ **6/6** |
+| `cargo test --release --test issue_546` | ✅ **1/1** |
+| `cargo test --release --test issue_554` | ✅ **12/12** |
+| `cargo clippy --release` | ✅ 0 warnings |
+
+## 5. 광범위 페이지네이션 회귀 sweep (Stage 3)
+
+| 영역 | 결과 |
+|------|------|
+| BEFORE (task672) | 187 fixtures / 2013 pages |
+| AFTER (task674) | 187 fixtures / **2013 pages** |
+| **차이** | **0** ✅ |
+
+회귀 위험 영역 완전 좁힘.
+
+## 6. 시각 판정 게이트웨이 ★ 통과
+
+`samples/계획서.hwp` 1페이지 표:
+
+| 셀 | BEFORE (task672) | AFTER (task674) |
+|----|-----------------|-----------------|
+| [13] "탈레스 HSM 관리 시스템 및 REST API" | 2줄 정상 | 2줄 정상 (회귀 0) ✅ |
+| [21] "목적" | 2줄 (마지막 줄 클립) | **3줄 모두 표시** ✅ |
+| [52] "특허 취득" | 2 paragraph (◦특허의뢰 누락) | **3 paragraph 모두 표시** ✅ |
+| 다른 셀 | — | 회귀 0 ✅ |
+
+## 7. Task #671 ~ #674 시리즈 본질 영역 정합 정리
+
+| Task | 본질 영역 | 정정 위치 |
+|------|----------|-----------|
+| #671 | 셀 paragraph line_segs 부재 → compose_lines 단일 ComposedLine 압축 | composer.rs (recompose_for_cell_width) + 6개 호출 위치 |
+| #672 | TAC 표 비례 축소 (작은 차이도 발동) | height_measurer.rs:822 임계값 가드 |
+| #674 | calc_para_lines_height corrected_line_height 누락 | table_layout.rs:746 시그니처 + 보정 |
+
+3 task 시리즈 정합 — `samples/계획서.hwp` 시각 결함 완전 해소.
+
+## 8. 회귀 위험 영역 좁힘 원칙
+
+- **수정 영역 명시**: `calc_para_lines_height` 시그니처 + 보정 적용 (단일 함수)
+- **본질 룰**: height_measurer 와 동일 로직 (측정/layout 일관성)
+- **광범위 sweep 검증**: 187 fixture 페이지 수 차이 0
+- **다른 영역 영향**: 정상 line_segs 인코딩된 paragraph 영향 미미 (보정 결과가 raw 값과 비슷)
+
+## 9. 권위 자료
+
+- `samples/계획서.hwp` — Task #671/#672/#674 권위 재현 영역 (이미 git tracked)
+
+## 10. 최종 산출물
+
+| 영역 | 파일 |
+|------|------|
+| 코드 정정 | `src/renderer/layout/table_layout.rs` (calc_para_lines_height + 호출자) |
+| 수행계획서 | `mydocs/plans/task_m100_674.md` |
+| 구현계획서 | `mydocs/plans/task_m100_674_impl.md` |
+| 단계별 보고서 | `mydocs/working/task_m100_674_stage1.md`, `_stage2.md`, `_stage3.md` |
+| 최종 보고서 | `mydocs/report/task_m100_674_report.md` (본 문서) |
+
+## 11. 의존성
+
+- **선행 의존**: Task #671 (PR #673), Task #672 (PR #675) — `local/task674` ← `local/task672` 분기
+
+## 12. 정합 패턴 정리
+
+- `feedback_rule_not_heuristic`: 본질 정정 (height_measurer 와 동일 로직)
+- `feedback_hancom_compat_specific_over_general`: 측정/layout 일관성 정합
+- `feedback_visual_judgment_authority`: 시각 판정 ★ 통과
+- `feedback_close_issue_verify_merged`: Issue close 시 정정 코드 devel 머지 검증
+- `project_dtp_identity`: 조판 엔진 정합성 강화
+
+## 13. 후속 영역
+
+Task #671 ~ #674 시리즈 완성. `samples/계획서.hwp` 의 본질적 시각 결함 모두 해소.

--- a/mydocs/working/task_m100_674_stage1.md
+++ b/mydocs/working/task_m100_674_stage1.md
@@ -1,0 +1,120 @@
+# Task #674 Stage 1 단계별 보고서 — 본질 진단
+
+## 진단 결과 요약
+
+`samples/계획서.hwp` 셀 [21] paragraph layout 시작 위치 (`text_y_start = 379.37`) 가 이론값 (`cell_y + pad_top = 355.37`) 보다 **24.00 px** 큼. 본질 위치 식별 완료.
+
+## 1. 디버그 출력 결과
+
+`src/renderer/layout/table_layout.rs:1374-1388` 환경변수 디버그:
+
+```
+[T674] cell[5,1] cell_y=353.49 pad_top=1.88 pad_bottom=1.88
+[T674]   has_nested=false first_line_vpos=None effective_valign=Center
+[T674]   inner_height=64.00 total_content_height=16.00
+[T674]   text_y_start=379.37 (cell_y+pad_top=355.37, diff=+24.00)
+```
+
+## 2. 본질 식별
+
+| 항목 | 값 | 분석 |
+|------|------|------|
+| has_nested_table | false | 중첩 표 없음 (정상) |
+| first_line_vpos | None | line_segs 부재 (정상) |
+| effective_valign | **Center** | 셀 vertical_align = Center |
+| inner_height | 64.00 | (정확) cell_h - pad |
+| total_content_height | **16.00** | **잘못된 값 (3줄인데 16!)** |
+| mechanical_offset | (64-16)/2 = **24.00** | 잘못된 큰 offset |
+| text_y_start | 355.37 + 24 = **379.37** | mechanical_offset 영향 |
+
+## 3. 본질 결함
+
+### 3.1 `total_content_height = 16.00` 의 본질
+
+`calc_composed_paras_content_height` → `calc_para_lines_height` 호출:
+
+```rust
+fn calc_para_lines_height(...) -> f64 {
+    ...
+    let lines_total: f64 = lines.iter()
+        .map(|(i, line)| {
+            let h = hwpunit_to_px(line.line_height, self.dpi);  // raw line_height만 사용!
+            ...
+        })
+        .sum();
+    ...
+}
+```
+
+**`line.line_height` 그대로 사용** — `corrected_line_height` 보정 누락. line_segs 부재 paragraph 의 fallback `line_height = 400 HU = 5.33 px` 그대로 사용.
+
+→ 3줄 × 5.33 = **16 px** 잘못된 측정.
+
+### 3.2 paragraph_layout vs measurement 불일치
+
+| 영역 | line_height | 3줄 합 |
+|------|-------------|---------|
+| `calc_para_lines_height` (측정) | 5.33 (raw) | **16.00** ❌ |
+| `paragraph_layout::layout_composed_paragraph` (실제) | 21.33 (corrected) | **64.00** ✅ |
+| `height_measurer` (row_heights 결정) | 21.33 (corrected) | **64.00** ✅ |
+
+→ table_layout 의 `calc_para_lines_height` 만 corrected_line_height 보정 누락. height_measurer 와 paragraph_layout 은 정상.
+
+### 3.3 결함 발현 흐름
+
+```
+table_layout.rs::layout_table:
+  composed_paras = compose_paragraph(p)
+  recompose_for_cell_width(comp, p, inner_width, styles)
+  ↓
+  total_content_height = calc_composed_paras_content_height(...)
+                       → calc_para_lines_height (corrected_line_height 누락)
+                       → 16.00 (잘못된 측정)
+  ↓
+  effective_valign = Center
+  mechanical_offset = (64.00 - 16.00) / 2 = 24.00 (잘못된 큰 offset)
+  ↓
+  text_y_start = cell_y + pad_top + 24.00 = 379.37 (24px 위로 밀림)
+  ↓
+  paragraph_layout 줄 위치:
+    줄 0 y = 379.37
+    줄 1 y = 400.71
+    줄 2 y = 422.04 (cell-clip 끝 421.25 초과 → 클립)
+```
+
+## 4. 다른 호출 위치 영향 평가
+
+`calc_para_lines_height` 호출자:
+
+| 파일:줄 | 함수 | 용도 |
+|---------|------|------|
+| `table_layout.rs:710` | calc_cell_paragraphs_content_height | 셀 높이 측정 (resolve_row_heights) |
+| `table_layout.rs:728` | calc_composed_paras_content_height | total_content_height 계산 (text_y_start) |
+
+두 함수 모두 영향. 정정 시 모두 corrected_line_height 적용 필요.
+
+## 5. Stage 2 정정 방향
+
+### 5.1 정정 위치
+
+`src/renderer/layout/table_layout.rs:746-781` `calc_para_lines_height`:
+
+- 시그니처에 `styles: &ResolvedStyleSet` 추가
+- `corrected_line_height` 보정 적용 (height_measurer.rs:570-587 와 동일 로직)
+- `cell_ls_val` / `cell_ls_type` ParaShape 기반 결정
+- max_fs (line.runs 의 max font_size) 측정
+
+### 5.2 회귀 위험 영역 좁힘
+
+- **본질 정정** — 모든 호출 위치에 보정 적용 (height_measurer 와 일관성)
+- 정상 line_segs 인코딩 paragraph: line.line_height 가 corrected 값과 비슷 → 영향 미미
+- 본 case (line_segs 부재) 만 큰 영향 (5.33 → 21.33 보정)
+- 광범위 sweep 차이 0 보장
+
+## 6. Stage 1 산출물
+
+본 단계별 보고서 — `text_y_start = 379.37` 의 24.00 px 오프셋 본질 (corrected_line_height 누락) 식별.
+
+## 7. Stage 2 진행 승인 요청
+
+본 진단 결과 + Stage 2 정정 방향 (calc_para_lines_height 시그니처 변경 + corrected_line_height 적용) 승인 요청.

--- a/mydocs/working/task_m100_674_stage2.md
+++ b/mydocs/working/task_m100_674_stage2.md
@@ -1,0 +1,106 @@
+# Task #674 Stage 2 단계별 보고서 — 본질 정정
+
+## 1. 정정 위치
+
+`src/renderer/layout/table_layout.rs:746-781` — `calc_para_lines_height` 함수.
+
+### 시그니처 변경
+
+```rust
+fn calc_para_lines_height(
+    &self,
+    lines: &[crate::renderer::composer::ComposedLine],
+    pidx: usize,
+    total_para_count: usize,
+    para_style: Option<&crate::renderer::style_resolver::ResolvedParaStyle>,
+    styles: &ResolvedStyleSet,  // [Task #674] 신규
+) -> f64
+```
+
+### 본질 정정
+
+```rust
+let cell_ls_val = para_style.map(|s| s.line_spacing).unwrap_or(160.0);
+let cell_ls_type = para_style.map(|s| s.line_spacing_type)
+    .unwrap_or(crate::model::style::LineSpacingType::Percent);
+let lines_total: f64 = lines.iter()
+    .enumerate()
+    .map(|(i, line)| {
+        let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
+        let max_fs = line.runs.iter()
+            .map(|r| styles.char_styles.get(r.char_style_id as usize)
+                .map(|cs| cs.font_size).unwrap_or(0.0))
+            .fold(0.0f64, f64::max);
+        let h = crate::renderer::corrected_line_height(
+            raw_lh, max_fs, cell_ls_type, cell_ls_val);
+        let is_cell_last_line = is_last_para && i + 1 == line_count;
+        if !is_cell_last_line {
+            h + hwpunit_to_px(line.line_spacing, self.dpi)
+        } else {
+            h
+        }
+    })
+    .sum();
+```
+
+`height_measurer.rs:570-587` 와 동일 로직 — 측정/layout 일관성 정합.
+
+## 2. 호출자 시그니처 정정
+
+| 파일:줄 | 함수 | 변경 |
+|---------|------|------|
+| `table_layout.rs:710` | calc_cell_paragraphs_content_height → calc_para_lines_height | styles 추가 |
+| `table_layout.rs:728` | calc_composed_paras_content_height → calc_para_lines_height | styles 추가 |
+
+## 3. 결정적 검증
+
+| 검증 영역 | 결과 |
+|----------|------|
+| `cargo build --release` | ✅ |
+| `cargo test --lib --release` | ✅ **1155 passed** (회귀 0) |
+| `cargo test --release --test svg_snapshot` | ✅ **6/6** |
+| `cargo test --release --test issue_546` | ✅ **1/1** |
+| `cargo test --release --test issue_554` | ✅ **12/12** |
+| `cargo clippy --release` | ✅ 0 warnings |
+
+## 4. 본 정정 효과
+
+### total_content_height 정합
+
+| 영역 | BEFORE | AFTER |
+|------|--------|-------|
+| `calc_para_lines_height` line_height 보정 | 없음 (raw 5.33) | **corrected (21.33)** ✅ |
+| total_content_height (3줄) | 16.00 | **64.00** ✅ |
+| mechanical_offset (Center) | (64-16)/2 = 24.00 | **(64-64)/2 = 0.00** ✅ |
+| text_y_start | 379.37 (24px 위로 밀림) | **355.37 (정확)** ✅ |
+| 마지막 줄 y (줄 2) | 422.04 (clip 끝 초과) | **397.71 (clip 안)** ✅ |
+
+### 시각 판정 (PNG)
+
+`samples/계획서.hwp` 1페이지:
+
+| 셀 | BEFORE | AFTER |
+|----|--------|-------|
+| [21] "목적" 행 | 2줄 표시 (마지막 줄 클립) | **3줄 모두 표시** ✅ |
+| [52] "특허 취득" 행 | 2개 paragraph (◦특허의뢰 누락) | **3개 paragraph 모두 표시** ✅ |
+| 다른 셀 | — | 회귀 0 ✅ |
+
+## 5. 회귀 위험 영역 좁힘
+
+`corrected_line_height` 적용 영역:
+
+- 정상 인코딩 paragraph: `line.line_height` (corrected 값과 비슷) → 보정 후 동일 또는 약간 큼 → 영향 미미
+- line_segs 부재 paragraph: 큰 보정 (5.33 → 21.33) → 본 case 정정
+
+광범위 sweep 차이 0 입증 (Stage 3).
+
+## 6. Stage 3 진행 영역
+
+- 광범위 페이지네이션 회귀 sweep (187 fixture)
+- 결정적 검증 (cargo test, clippy)
+- 시각 판정 게이트웨이 (작업지시자)
+- 최종 보고서 작성
+
+## 7. Stage 3 진행 승인 요청
+
+본 Stage 2 결과 + 결정적 검증 + 시각 판정 통과 영역 입증 후 Stage 3 진행.

--- a/mydocs/working/task_m100_674_stage3.md
+++ b/mydocs/working/task_m100_674_stage3.md
@@ -1,0 +1,49 @@
+# Task #674 Stage 3 단계별 보고서 — 광범위 회귀 sweep + 최종 검증
+
+## 1. 광범위 페이지네이션 회귀 sweep
+
+`samples/` 폴더 전체 187 fixture 페이지 수 BEFORE/AFTER 비교:
+
+| 영역 | 결과 |
+|------|------|
+| BEFORE (task672) | 187 fixtures / **2013 pages** |
+| AFTER (task674) | 187 fixtures / **2013 pages** |
+| **차이** | **0** ✅ |
+
+**회귀 위험 영역 완전 좁힘** — 본 task 정정 (calc_para_lines_height 의 corrected_line_height 적용) 이 다른 fixture 페이지네이션에 영향 0.
+
+## 2. 결정적 검증
+
+| 검증 영역 | 결과 |
+|----------|------|
+| `cargo build --release` | ✅ |
+| `cargo test --lib --release` | ✅ **1155 passed** (회귀 0) |
+| `cargo test --release --test svg_snapshot` | ✅ **6/6** |
+| `cargo test --release --test issue_546` | ✅ **1/1** |
+| `cargo test --release --test issue_554` | ✅ **12/12** |
+| `cargo clippy --release` | ✅ 0 warnings |
+
+## 3. 시각 판정 게이트웨이 통과
+
+`samples/계획서.hwp` 1페이지 표 (PNG 시각 확인, rsvg-convert -z 4):
+
+| 셀 | BEFORE (task672) | AFTER (task674) |
+|----|-----------------|-----------------|
+| [13] r=3,c=1 "탈레스 HSM 관리 시스템 및 REST API" | 2줄 정상 | 2줄 정상 (회귀 0) ✅ |
+| [21] r=5,c=1 "목적" | 2줄 (마지막 줄 클립) | **3줄 모두 표시** ✅ |
+| [52] r=13,c=3 "특허 취득" | 2 paragraph | **3 paragraph 모두 표시** ✅ |
+| 다른 셀 | — | 회귀 0 ✅ |
+
+**Task #671/#672/#674 시리즈 정정 완료** — `samples/계획서.hwp` 1페이지 표 시각 결함 완전 해소.
+
+## 4. Task #671 ~ #674 시리즈 본질 영역 정합
+
+| Task | 본질 영역 | 정정 위치 |
+|------|----------|-----------|
+| #671 | 셀 paragraph line_segs 부재 → compose_lines 단일 ComposedLine 압축 | composer.rs (recompose_for_cell_width) + 6개 호출 위치 |
+| #672 | TAC 표 비례 축소 (작은 차이도 발동) | height_measurer.rs:822 임계값 가드 |
+| #674 | calc_para_lines_height corrected_line_height 누락 | table_layout.rs:746 시그니처 + 보정 |
+
+## 5. Stage 3 완료 — 최종 보고서 작성 영역 진입
+
+본 단계별 보고서 + 결정적 검증 + 광범위 sweep 회귀 0 + 시각 판정 ★ 통과 → **최종 결과 보고서** (`mydocs/report/task_m100_674_report.md`) 작성 진입.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -719,7 +719,7 @@ impl LayoutEngine {
                     &mut comp, p, cell_inner_width_px, styles,
                 );
                 self.calc_para_lines_height(&comp.lines, pidx, cell_para_count,
-                    styles.para_styles.get(p.para_shape_id as usize))
+                    styles.para_styles.get(p.para_shape_id as usize), styles)
             })
             .sum()
     }
@@ -737,18 +737,24 @@ impl LayoutEngine {
             .enumerate()
             .map(|(pidx, (comp, para))| {
                 self.calc_para_lines_height(&comp.lines, pidx, cell_para_count,
-                    styles.para_styles.get(para.para_shape_id as usize))
+                    styles.para_styles.get(para.para_shape_id as usize), styles)
             })
             .sum()
     }
 
     /// 단일 문단의 줄 높이 합산 (공통 로직)
+    ///
+    /// [Task #674] line_height 측정에 corrected_line_height 보정 적용.
+    /// line_segs 부재 paragraph 의 fallback line_height (400 HU = 5.33 px) 가
+    /// max_fs 보다 작은 경우 ParaShape 의 line_spacing_type + line_spacing 으로
+    /// 보정. height_measurer.rs:570-587 와 동일 로직 — 측정/layout 일관성 보장.
     fn calc_para_lines_height(
         &self,
         lines: &[crate::renderer::composer::ComposedLine],
         pidx: usize,
         total_para_count: usize,
         para_style: Option<&crate::renderer::style_resolver::ResolvedParaStyle>,
+        styles: &ResolvedStyleSet,
     ) -> f64 {
         let is_last_para = pidx + 1 == total_para_count;
         let spacing_before = if pidx > 0 {
@@ -764,11 +770,20 @@ impl LayoutEngine {
         if lines.is_empty() {
             spacing_before + hwpunit_to_px(400, self.dpi) + spacing_after
         } else {
+            let cell_ls_val = para_style.map(|s| s.line_spacing).unwrap_or(160.0);
+            let cell_ls_type = para_style.map(|s| s.line_spacing_type)
+                .unwrap_or(crate::model::style::LineSpacingType::Percent);
             let line_count = lines.len();
             let lines_total: f64 = lines.iter()
                 .enumerate()
                 .map(|(i, line)| {
-                    let h = hwpunit_to_px(line.line_height, self.dpi);
+                    let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
+                    let max_fs = line.runs.iter()
+                        .map(|r| styles.char_styles.get(r.char_style_id as usize)
+                            .map(|cs| cs.font_size).unwrap_or(0.0))
+                        .fold(0.0f64, f64::max);
+                    let h = crate::renderer::corrected_line_height(
+                        raw_lh, max_fs, cell_ls_type, cell_ls_val);
                     let is_cell_last_line = is_last_para && i + 1 == line_count;
                     if !is_cell_last_line {
                         h + hwpunit_to_px(line.line_spacing, self.dpi)


### PR DESCRIPTION
## 요약

`calc_para_lines_height` 의 `corrected_line_height` 보정 누락이 본질 결함. line_segs 부재 셀 paragraph 의 fallback line_height (5.33 px) 가 폰트 보정 (21.33 px) 안 받아 mechanical_offset 잘못 계산 → text_y_start 24 px 위로 밀림 → 마지막 줄 cell-clip 영역 초과 → 시각 클립.

closes #674

## ⚠️ 의존성 — PR #673 (Task #671) + PR #675 (Task #672) 선행 머지 권장

본 PR 은 Task #671 + #672 정정 위에서 분기. 두 PR 머지 후 본 PR 의 diff 가 Task #674 단일 분기 정정으로 자동 축약.

## 본질 진단

`samples/계획서.hwp` 셀 [21] (r=5, c=1) text_y_start 결정:

```
[T674] cell[5,1] cell_y=353.49 pad_top=1.88 pad_bottom=1.88
[T674]   has_nested=false first_line_vpos=None effective_valign=Center
[T674]   inner_height=64.00 total_content_height=16.00
[T674]   text_y_start=379.37 (cell_y+pad_top=355.37, diff=+24.00)
```

### 결함 메커니즘

```
calc_composed_paras_content_height
  ↓
calc_para_lines_height (corrected_line_height 누락!)
  → line.line_height (raw 5.33 px) 그대로 사용
  → 3줄 × 5.33 = 16.00 (잘못된 측정)
  ↓
total_content_height = 16.00
  ↓
mechanical_offset = (inner_height 64 - total 16) / 2 = 24.00 (Center 정렬)
  ↓
text_y_start = cell_y + pad_top + 24.00 = 379.37 (24 px 위로 밀림)
  ↓
줄 2 y = 422.04 (cell-clip-81 끝 421.25 초과 → SVG 클립)
```

## 본질 정정

`src/renderer/layout/table_layout.rs:746` `calc_para_lines_height` 시그니처에 `styles` 추가 + `corrected_line_height` 보정 적용 (height_measurer.rs:570-587 와 동일 로직).

```rust
let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
let max_fs = line.runs.iter()
    .map(|r| styles.char_styles.get(r.char_style_id as usize)
        .map(|cs| cs.font_size).unwrap_or(0.0))
    .fold(0.0f64, f64::max);
let h = crate::renderer::corrected_line_height(
    raw_lh, max_fs, cell_ls_type, cell_ls_val);
```

호출자 시그니처 정정:
- `calc_cell_paragraphs_content_height` → calc_para_lines_height(styles 추가)
- `calc_composed_paras_content_height` → calc_para_lines_height(styles 추가)

### 정정 효과

| 항목 | BEFORE | AFTER |
|------|--------|-------|
| line_height 보정 | 없음 (raw 5.33) | corrected (21.33) ✅ |
| total_content_height (3줄) | 16.00 | **64.00** ✅ |
| mechanical_offset (Center) | 24.00 | **0.00** ✅ |
| text_y_start | 379.37 | **355.37** ✅ |
| 줄 2 y | 422.04 (clip 초과) | **397.71 (clip 안)** ✅ |

## 회귀 위험 영역 좁힘

- 단일 함수 (`calc_para_lines_height`) 보정 적용
- height_measurer 와 동일 로직 — 측정/layout 일관성 정합
- 정상 line_segs 인코딩 paragraph: corrected 결과가 raw 와 비슷 → 영향 미미
- 광범위 sweep 차이 0 입증

## 검증

| 검증 영역 | 결과 |
|----------|------|
| `cargo build --release` | ✅ |
| `cargo test --lib --release` | ✅ **1155 passed** (회귀 0) |
| `cargo test --release --test svg_snapshot` | ✅ **6/6** |
| `cargo test --release --test issue_546` | ✅ **1/1** |
| `cargo test --release --test issue_554` | ✅ **12/12** |
| `cargo clippy --release` | ✅ 0 warnings |

## 광범위 페이지네이션 회귀 sweep

| 영역 | 결과 |
|------|------|
| BEFORE | 187 fixtures / 2013 pages |
| AFTER | 187 fixtures / 2013 pages |
| **차이** | **0** ✅ |

## 시각 판정 ★ 통과

`samples/계획서.hwp` 1페이지 표:

| 셀 | BEFORE (task672) | AFTER (task674) |
|----|-----------------|-----------------|
| [13] "탈레스 HSM 관리 시스템 및 REST API" | 2줄 정상 | 2줄 정상 (회귀 0) ✅ |
| [21] "목적" | 2줄 (마지막 줄 클립) | **3줄 모두 표시** ✅ |
| [52] "특허 취득" | 2 paragraph (◦특허의뢰 누락) | **3 paragraph 모두 표시** ✅ |
| 다른 셀 | — | 회귀 0 ✅ |

## Task #671 ~ #674 시리즈 완성

| Task | 본질 영역 | 정정 위치 |
|------|----------|-----------|
| #671 | 셀 paragraph line_segs 부재 → compose_lines 단일 ComposedLine 압축 | composer.rs (recompose_for_cell_width) + 6개 호출 위치 |
| #672 | TAC 표 비례 축소 (작은 차이도 발동) | height_measurer.rs:822 임계값 가드 |
| #674 | calc_para_lines_height corrected_line_height 누락 | table_layout.rs:746 시그니처 + 보정 |

3 task 시리즈 완성 — `samples/계획서.hwp` 시각 결함 완전 해소.

## 산출물

| 영역 | 파일 |
|------|------|
| 코드 정정 | `src/renderer/layout/table_layout.rs` (calc_para_lines_height + 호출자) |
| 거버넌스 산출물 | `mydocs/plans/task_m100_674{,_impl}.md`, `mydocs/working/task_m100_674_stage{1,2,3}.md`, `mydocs/report/task_m100_674_report.md` |

## 커밋 시퀀스 (3 단계)

- Stage 1: 본질 진단 — 24 px 오프셋 식별
- Stage 2: 본질 정정 — calc_para_lines_height 시그니처 + corrected_line_height 보정
- Stage 3: 광범위 회귀 sweep + 최종 보고서 + orders 갱신