### PR TITLE
Task #676: 통합재정통계 trailing empty paragraph 페이지 분리 정정

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -629,7 +629,8 @@ impl TypesetEngine {
             if !has_table {
                 // --- 핵심: format → fits → place/split ---
                 let formatted = self.format_paragraph(para, composed.get(para_idx), styles);
-                self.typeset_paragraph(&mut st, para_idx, para, &formatted);
+                let is_last_in_section = para_idx + 1 == paragraphs.len();
+                self.typeset_paragraph(&mut st, para_idx, para, &formatted, is_last_in_section);
             } else {
                 // 표 문단: Phase 2에서 전환 예정. 현재는 기존 방식 호환용 stub.
                 self.typeset_table_paragraph(
@@ -894,6 +895,7 @@ impl TypesetEngine {
         para_idx: usize,
         para: &Paragraph,
         fmt: &FormattedParagraph,
+        is_last_in_section: bool,
     ) {
         // Task #332 Stage 4a: layout drift 안전 마진.
         // typeset 의 fit 추정과 layout 의 실측 진행은 폰트 메트릭/표 측정 다중성 등으로
@@ -1000,6 +1002,29 @@ impl TypesetEngine {
                     para_index: para_idx,
                 });
                 return;
+            }
+        }
+
+        // [Task #676] trailing empty paragraph 가드 (단단 전용):
+        // 섹션 마지막 빈 paragraph 가 LAYOUT_DRIFT_SAFETY_PX(10px) 영역 내 미세 overflow 로
+        // fit 실패 시 height=0 흡수 — 단독 빈 페이지 차단. 한컴2022 정합 시멘틱.
+        // (통합재정통계 2010.11/2011.10: pi=14 cur_h=751.0 + 16.0 = 767.0 > avail 766.2,
+        //  overflow=0.8px ≤ safety_margin 10px → 흡수.)
+        // hide_empty_line (Task #362) 분기와 달리 SectionDef bit 무관, 섹션 마지막 1개만 흡수.
+        if is_last_in_section
+            && st.col_count == 1
+            && !st.current_items.is_empty()
+        {
+            let trimmed = para.text.replace(|c: char| c.is_control(), "");
+            let is_empty_para = trimmed.trim().is_empty() && para.controls.is_empty();
+            if is_empty_para {
+                let total_h = st.current_height + fmt.height_for_fit;
+                let fit_fail_within_safety =
+                    total_h > available && total_h <= available + LAYOUT_DRIFT_SAFETY_PX;
+                if fit_fail_within_safety {
+                    st.current_items.push(PageItem::FullParagraph { para_index: para_idx });
+                    return;
+                }
             }
         }
 

--- a/tests/issue_676_trailing_empty_para.rs
+++ b/tests/issue_676_trailing_empty_para.rs
@@ -1,0 +1,60 @@
+//! Issue #676: 통합재정통계 2010.11/2011.10 — 본문 끝 trailing 빈 줄이
+//! `LAYOUT_DRIFT_SAFETY_PX = 10.0` (typeset.rs) 영역 내 미세 overflow 로 fit 실패하여
+//! 단독 빈 페이지 (페이지 2) 발생.
+//!
+//! 정정: `typeset_paragraph` 에 trailing empty paragraph 가드 추가 — 섹션 마지막
+//! 빈 paragraph + 단단(col_count==1) + 페이지 첫 항목 아님 + overflow ≤ safety_margin
+//! 시 height=0 흡수.
+//!
+//! 1단계 trace 진단:
+//!   pi=14 cur_h=751.0 + h_for_fit=16.0 = 767.0 > avail 766.2 (= 776.2 - 10 safety),
+//!   overflow=0.8px ≤ safety_margin 10px → 흡수 대상.
+//!
+//! 한컴2022 정합: 두 문서 모두 1페이지 출력.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn issue_676_t재정통계_2010_11_single_page() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/통합재정통계(2010.11월).hwp");
+    let bytes = fs::read(&hwp_path).expect("read 통합재정통계(2010.11월).hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .expect("parse 통합재정통계(2010.11월).hwp");
+
+    // 한컴2022 정합 정답지: 1 페이지
+    // 회귀 시: 2 페이지 (pi=14 trailing 빈 줄이 단독 페이지 발생)
+    assert_eq!(
+        doc.page_count(),
+        1,
+        "통합재정통계(2010.11월).hwp 는 1 페이지여야 함 (Task #676 trailing empty para 가드 회귀 시 2)"
+    );
+}
+
+#[test]
+fn issue_676_t재정통계_2011_10_single_page() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/통합재정통계(2011.10월).hwp");
+    let bytes = fs::read(&hwp_path).expect("read 통합재정통계(2011.10월).hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .expect("parse 통합재정통계(2011.10월).hwp");
+
+    // 한컴2022 정합 정답지: 1 페이지 (2010.11 과 동일 패턴)
+    assert_eq!(
+        doc.page_count(),
+        1,
+        "통합재정통계(2011.10월).hwp 는 1 페이지여야 함 (Task #676 trailing empty para 가드 회귀 시 2)"
+    );
+}
+
+#[test]
+fn issue_676_t재정통계_2014_08_no_regression() {
+    // 2014.8 은 본 결함 미발현 (rhwp 1p, PDF 1p 일치) — 가드 도입 후 무회귀 검증.
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/통합재정통계(2014.8월).hwp");
+    let bytes = fs::read(&hwp_path).expect("read 통합재정통계(2014.8월).hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .expect("parse 통합재정통계(2014.8월).hwp");
+    assert_eq!(doc.page_count(), 1);
+}


### PR DESCRIPTION
## 요약

본문 끝 빈 paragraph (h=16px) 가 `LAYOUT_DRIFT_SAFETY_PX = 10.0` 안전마진 영역 내 미세 overflow (0.8px) 로 fit 실패하여 단독 빈 페이지를 발생시키던 결함 정정.

| 문서 | rhwp BEFORE | rhwp AFTER | 한글2022 PDF |
|------|------:|------:|------:|
| `samples/통합재정통계(2010.11월).hwp` | 2p ❌ | **1p ✅** | 1p |
| `samples/통합재정통계(2011.10월).hwp` | 2p ❌ | **1p ✅** | 1p |
| `samples/통합재정통계(2014.8월).hwp` | 1p | **1p ✅** | 1p (참고, 무회귀) |

## 원인 분석 (`DBG_T676` 환경변수 trace)

```
pi=14 cur_h=751.0 + h_for_fit=16.0 = 767.0 > avail 766.2  → FIT FAIL
       (available_height 776.2 - safety 10 = 766.2)
overflow = 0.8px (≈ 0.27mm) ≤ safety_margin 10px
```

`src/renderer/typeset.rs::typeset_paragraph` 의 `LAYOUT_DRIFT_SAFETY_PX = 10.0` 안전마진 (Task #321/#359/#361 영역의 LAYOUT_OVERFLOW 사전 차단 의도) 이 trailing 빈 줄의 fit 판정을 0.8px 차이로 실패시켜 split 분기로 진입, 페이지 2 단독 push.

`hide_empty_line` 분기 (Task #362) 는 `SectionDef bit 19` 미설정으로 미진입.

## 정정 — trailing empty paragraph 가드 (단단 전용)

`typeset_paragraph` 시그니처에 `is_last_in_section: bool` 인자 추가 + `hide_empty_line` 분기 다음 가드 추가. **5 조건 AND** 로 영향 영역 좁힘:

| # | 조건 | 의도 |
|---|------|------|
| A | `is_last_in_section` | trailing 만 흡수 (중간 빈 줄 의도 보존) |
| B | `is_empty_para` (text trim empty + no controls) | hide_empty_line 분기와 동일 시멘틱 |
| C | `!st.current_items.is_empty()` | 단독 항목 페이지 자기참조 회피 |
| D | `st.col_count == 1` | 다단의 단 끝 분리는 의도적일 수 있음 |
| E | `total_h > available && total_h <= available + LAYOUT_DRIFT_SAFETY_PX` | 안전마진 영역 내 미세 overflow 만, 실 overflow 는 분리 유지 |

기존 `LAYOUT_DRIFT_SAFETY_PX` 상수 그대로 활용 — **신규 휴리스틱/허용오차 0**.

## 회귀 차단 가드

`tests/issue_676_trailing_empty_para.rs` (3 통합 테스트):
- `issue_676_t재정통계_2010_11_single_page` — 1p 검증
- `issue_676_t재정통계_2011_10_single_page` — 1p 검증
- `issue_676_t재정통계_2014_08_no_regression` — 무회귀 검증

## 검증

| 항목 | 결과 |
|------|------|
| `cargo test --release --lib` | ✅ **1155 passed**, 0 failed (회귀 0) |
| `cargo test --release` (통합) | ✅ all GREEN |
| `issue_676` 회귀 차단 가드 | ✅ 3/3 |
| `cargo build --release` | ✅ 통과 (경고 없음) |
| clippy | ⚠️ 2 사전 존재 에러 (`table_ops.rs:1007` + `object_ops.rs:298`) — `upstream/devel d58217be` baseline 직접 비교 동일, **본 PR 무관** |

### 광범위 페이지네이션 sweep (`samples/` 187 fixture, BEFORE=upstream/devel d58217be)

```
$ diff /tmp/sweep_before.txt /tmp/sweep_after.txt
148c148
< samples/table-ipc.hwp|13
---
> samples/table-ipc.hwp|11
160,161c160,161
< samples/통합재정통계(2010.11월).hwp|2
< samples/통합재정통계(2011.10월).hwp|2
---
> samples/통합재정통계(2010.11월).hwp|1
> samples/통합재정통계(2011.10월).hwp|1
```

| 영역 | 결과 |
|------|------|
| 의도된 정정 | 2 fixture (통합재정통계 2010.11/2011.10) |
| 의도된 부수 진전 | 1 fixture (`table-ipc.hwp` 13p → 11p, 한글2022 PDF 정답지 10p 방향 진전) |
| 무변동 | 184 fixture |
| **회귀** | **0** |

#### `table-ipc.hwp` 부수 진전 분석

각 섹션마다 `[Table + trailing 빈 paragraph]` 패턴 반복 구조. 본 가드가 일부 섹션의 trailing 빈 paragraph 를 흡수하여 단독 빈 페이지 2건 제거 → 한글2022 PDF 정답지 (10p) 방향 진전. 잔존 1p 차이는 별도 task 영역 (작업지시자 PAGE_MISMATCH 목록 19건 중 다른 항목).

## 시각 영향

`dump-pages` 결과:
- 페이지 1 items: 14 → **15** (pi=14 흡수)
- used: 751.0px **불변** (height=0 흡수, pi=0~13 영역 동일)
- 시각 회귀 없음

## 회귀 위험 영역 점검

| Task 영역 | 회귀 가능성 | sweep 결과 |
|---------|----------|-----------|
| Task #321 (vpos-reset) | 매우 낮음 | ✅ 무회귀 |
| Task #359 (next-vpos-reset) | 매우 낮음 | ✅ 무회귀 |
| Task #361 (PartialTable) | 매우 낮음 | ✅ 무회귀 |
| Task #362 (hide_empty_line) | 없음 (분기 다음 가드) | ✅ 무회귀 |
| Task #391 (다단/단단) | 없음 (D 조건 차단) | ✅ 무회귀 |
| Task #404 (heading-orphan) | 매우 낮음 | ✅ 무회귀 |
| kps-ai p67~70 | 없음 | ✅ 무회귀 |
| k-water-rfp p3 | 없음 | ✅ 무회귀 |
| hwp-multi-001 (다단) | 없음 | ✅ 무회귀 |

## 후속 영역

본 PR 도입 가드로 작업지시자 PAGE_MISMATCH 19건 중 진전:
- ✅ 2건 완전 정정 (통합재정통계 2010.11/2011.10)
- 🔄 1건 부분 진전 (table-ipc 13p→11p, 정답지 10p)
- 🔄 잔존 16건 (별도 task 영역)

## Test plan

- [x] `cargo test --release --lib` (1155 passed)
- [x] `cargo test --release --test issue_676_trailing_empty_para` (3/3)
- [x] `cargo build --release`
- [x] `samples/` 187 fixture 페이지 카운트 sweep (회귀 0)
- [ ] 메인테이너 시각 판정 (rhwp-studio web editor 또는 SVG 출력)

Closes #676

🤖 Generated with [Claude Code](https://claude.com/claude-code)