### PR TITLE
Task #680: nested 1x1 wrapper 표 외곽 테두리 누락 정정

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -158,13 +158,79 @@ impl LayoutEngine {
                     .flat_map(|p| p.controls.iter())
                     .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
                 {
-                    return self.layout_table(
+                    // [Task: nested-table-border] 자료 박스 외곽 테두리 추가:
+                    // 외부 1x1 표가 wrapper 라도 padding + border_fill 에 테두리선이
+                    // 정의된 경우 (자료 박스 외곽), 외곽 4개 라인을 별도 추가하여 시각 정합.
+                    // 외곽 박스의 size 는 nested layout 의 실제 결과 (y_end - y_start) 와
+                    // nested 표의 측정 width 를 사용하여 내부 표 영역과 정확히 정합.
+                    // (exam_social.hwp pi=15 4번 자료 박스: 외부 1x1 padding=(850,850,850,850)
+                    //  border_fill_id=6, 내부 6x3 대화체 셀.)
+                    let outer_y = y_start;
+                    let outer_x_for_box;
+                    let outer_w_for_box;
+                    let outer_border_meta = if depth == 0 {
+                        let has_outer_padding = cell.padding.left != 0
+                            || cell.padding.right != 0
+                            || cell.padding.top != 0
+                            || cell.padding.bottom != 0;
+                        if has_outer_padding {
+                            if let Some(bs) = styles.border_styles.get(cell.border_fill_id as usize) {
+                                let any_border = bs.borders.iter()
+                                    .any(|b| b.line_type != crate::model::style::BorderLineType::None);
+                                if any_border {
+                                    Some(bs.borders)
+                                } else { None }
+                            } else { None }
+                        } else { None }
+                    } else { None };
+
+                    // nested 표 위치/size 미리 결정 (nested layout 의 위치 결정 logic 동일)
+                    let pw_now = self.current_paper_width.get();
+                    let paper_w = if pw_now > 0.0 { Some(pw_now) } else { None };
+                    let nested_w = hwpunit_to_px(nested.common.width as i32, self.dpi);
+                    outer_w_for_box = nested_w;
+                    outer_x_for_box = self.compute_table_x_position(
+                        nested, nested_w, col_area, depth, host_alignment,
+                        host_margin_left, host_margin_right, inline_x_override, paper_w,
+                    );
+
+                    let y_end = self.layout_table(
                         tree, col_node, nested,
                         section_index, styles, col_area, y_start,
                         bin_data_content, None, depth,
                         table_meta, host_alignment, enclosing_cell_ctx, host_margin_left,
                         host_margin_right, inline_x_override, nested_split, para_y,
                     );
+
+                    if let Some(bs_borders) = outer_border_meta {
+                        let outer_h_actual = (y_end - outer_y).max(0.0);
+                        if outer_h_actual > 0.0 {
+                            use super::border_rendering::create_border_line_nodes;
+                            // 좌
+                            col_node.children.extend(create_border_line_nodes(
+                                tree, &bs_borders[0],
+                                outer_x_for_box, outer_y, outer_x_for_box, outer_y + outer_h_actual,
+                            ));
+                            // 우
+                            col_node.children.extend(create_border_line_nodes(
+                                tree, &bs_borders[1],
+                                outer_x_for_box + outer_w_for_box, outer_y,
+                                outer_x_for_box + outer_w_for_box, outer_y + outer_h_actual,
+                            ));
+                            // 상
+                            col_node.children.extend(create_border_line_nodes(
+                                tree, &bs_borders[2],
+                                outer_x_for_box, outer_y, outer_x_for_box + outer_w_for_box, outer_y,
+                            ));
+                            // 하
+                            col_node.children.extend(create_border_line_nodes(
+                                tree, &bs_borders[3],
+                                outer_x_for_box, outer_y + outer_h_actual,
+                                outer_x_for_box + outer_w_for_box, outer_y + outer_h_actual,
+                            ));
+                        }
+                    }
+                    return y_end;
                 }
             }
         }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -166,8 +166,6 @@ impl LayoutEngine {
                     // (exam_social.hwp pi=15 4번 자료 박스: 외부 1x1 padding=(850,850,850,850)
                     //  border_fill_id=6, 내부 6x3 대화체 셀.)
                     let outer_y = y_start;
-                    let outer_x_for_box;
-                    let outer_w_for_box;
                     let outer_border_meta = if depth == 0 {
                         let has_outer_padding = cell.padding.left != 0
                             || cell.padding.right != 0
@@ -188,8 +186,8 @@ impl LayoutEngine {
                     let pw_now = self.current_paper_width.get();
                     let paper_w = if pw_now > 0.0 { Some(pw_now) } else { None };
                     let nested_w = hwpunit_to_px(nested.common.width as i32, self.dpi);
-                    outer_w_for_box = nested_w;
-                    outer_x_for_box = self.compute_table_x_position(
+                    let outer_w_for_box = nested_w;
+                    let outer_x_for_box = self.compute_table_x_position(
                         nested, nested_w, col_area, depth, host_alignment,
                         host_margin_left, host_margin_right, inline_x_override, paper_w,
                     );

--- a/tests/issue_nested_table_border.rs
+++ b/tests/issue_nested_table_border.rs
@@ -1,0 +1,50 @@
+//! Nested table 외부 1x1 wrapper 표 외곽 테두리 누락 정정 (exam_social.hwp p1 4번).
+//!
+//! `src/renderer/layout/table_layout.rs::layout_table` 의 1x1 wrapper 분기는
+//! 외부 표를 무시하고 내부 표만 직접 layout 한다. 외부 표가 padding 과
+//! border line 을 가진 자료 박스 외곽 테두리 역할인 경우 외곽선이 누락되었다.
+//!
+//! 정정: wrapper 분기 진입 시 외부 셀의 padding != 0 + border_fill 의 borders
+//! 중 하나라도 None 아닌 경우, 외부 표의 size + border_fill 정보로 외곽 4개
+//! 라인을 col_node 에 추가한다.
+//!
+//! 권위 자료: pi=15 4번 자료 박스 (외부 1x1 padding=850 + 내부 6x3 대화체).
+//! 한컴2022 PDF (`pdf/exam_social-2022.pdf`) p1 우측 4번 영역 외곽 박스 시각 정합.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn nested_table_border_exam_social_p1_q4_outline_present() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/exam_social.hwp");
+    let bytes = fs::read(&hwp_path).expect("read exam_social.hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse exam_social.hwp");
+
+    // 4 페이지 (PDF 정합)
+    assert_eq!(doc.page_count(), 4, "exam_social.hwp 는 4 페이지");
+
+    // 페이지 1 SVG 출력
+    let svg = doc.render_page_svg(0).expect("render_page_svg");
+
+    // 4번 자료 박스 외곽 4개 라인이 SVG 에 존재해야 한다.
+    // 박스 size: nested 6x3 표 측정 결과 — width=390.65 (nested.common.width),
+    // height=343.88 (nested layout 의 y_end - y_start).
+    // 위치: x=549.88~940.53, y=331.53~675.41
+    // (외부 표 IR size 411.92×370.32 사용 시 5번 박스와 위치 부정합 발생.)
+    let has_top_line = svg.contains("y1=\"331.53333333333336\"")
+        && svg.contains("x1=\"549.8800000000001\"")
+        && svg.contains("x2=\"940.5333333333334\"");
+    let has_bottom_line = svg.contains("y1=\"675.4133333333334\"")
+        && svg.contains("y2=\"675.4133333333334\"");
+    let has_left_line = svg.contains("x1=\"549.8800000000001\"")
+        && svg.contains("x2=\"549.8800000000001\"")
+        && svg.contains("y2=\"675.4133333333334\"");
+    let has_right_line = svg.contains("x1=\"940.5333333333334\"")
+        && svg.contains("x2=\"940.5333333333334\"");
+
+    assert!(has_top_line, "4번 박스 상단 외곽선 누락");
+    assert!(has_bottom_line, "4번 박스 하단 외곽선 누락");
+    assert!(has_left_line, "4번 박스 좌측 외곽선 누락");
+    assert!(has_right_line, "4번 박스 우측 외곽선 누락");
+}


### PR DESCRIPTION
## 요약

`src/renderer/layout/table_layout.rs::layout_table` 의 1x1 wrapper 분기가 외부 1x1 표를 무시하고 내부 nested 표만 직접 layout 하면서, **외부 1x1 표가 자료 박스 외곽 테두리 역할 (padding + border_fill 정의)** 인 경우 외곽선이 SVG 출력에서 누락되던 결함 정정.

## 권위 자료

`samples/exam_social.hwp` 페이지 1 단 1 의 **4번 자료 박스 (대화체)**:

- 외부 1x1: `padding=(850,850,850,850)` (3mm), `border_fill_id=6`
- 내부 6x3: 대화체 셀 16개 (그림 6개 포함, `bin_id=1~6`)
- 한컴2022 PDF (`pdf/exam_social-2022.pdf`) 에서 외곽 박스 시각 정합

### SVG 검증 (devel baseline `d58217be`)

`grep -E '<rect [^/]*411\.92[^/]*' exam_social_001.svg` 결과 width=411.92 rect 3개 — nested wrapper pi=15 외곽선 누락 확인:

| pi | 구조 | SVG 외곽 rect (BEFORE) |
|---|------|----|
| 1, 5 (단 0), 21 (단 1) | simple 1x1 | ✅ 출력 |
| **15** (단 1) | **nested 1x1+6x3** | ❌ **누락** |

## 정정 — wrapper 분기에 외곽선 추가

`table_layout.rs:152` wrapper 분기 진입 시 **3 조건 AND** 만족 시 외곽 4개 라인 (좌/우/상/하) 을 `col_node` 에 추가:

| # | 조건 | 의도 |
|---|------|------|
| A | `depth == 0` | top-level 표만 |
| B | 외부 셀 `padding != 0` (4 방향 OR) | 자료 박스 의미 있음 |
| C | `border_fill.borders` 중 하나라도 `BorderLineType::None` 이 아님 | 테두리 정의 |

3 조건 모두 충족 시에만 외곽선 추가 → 회귀 영역 좁힘.

### 외곽 박스 size — nested layout 결과 사용

```rust
// width: nested 표 측정 너비
let nested_w = hwpunit_to_px(nested.common.width as i32, dpi);
// height: nested layout 실제 결과 (y_end - y_start)
let outer_h_actual = (y_end - outer_y).max(0.0);
```

외부 표 IR size (411.92×370.32) 가 아닌 **nested 측정 결과 (390.65×343.88)** 사용 → 내부 표 영역과 정확히 정합. 외부 표 IR size 사용 시 5번 박스 (y=935.83) 와 위치 부정합 발생.

### 4번 박스 외곽 SVG (AFTER)

```
좌: x=549.88, y=331.53 → 675.41  stroke=#000000 width=0.75
우: x=940.53, y=331.53 → 675.41
상: y=331.53, x=549.88 → 940.53
하: y=675.41, x=549.88 → 940.53
```

5번 박스 (y=935.83~1198.76) 와 ~260px 갭 — 겹침 없음.

## 회귀 차단 가드

`tests/issue_nested_table_border.rs` (1 통합 테스트):
- `nested_table_border_exam_social_p1_q4_outline_present` — 페이지 카운트 4 + 4번 박스 외곽 4개 라인 좌표 검증

## 검증

| 항목 | 결과 |
|------|------|
| `cargo build --release` | ✅ 통과 |
| `cargo test --release --lib` | ✅ **1155 passed**, 0 failed (회귀 0) |
| `cargo test --release` (통합) | ✅ all GREEN |
| `issue_nested_table_border` | ✅ 1/1 |
| 광범위 sweep (`samples/` 187 fixture) | ✅ **페이지 카운트 변동 0** (외곽 박스만 추가, 페이지 분할 로직 무관) |

## 시각 영향

- **4번 박스 외곽 4개 라인** (stroke=#000000, width=0.75) 출력
- **내부 6×3 셀들은 wrapper 분기 그대로** → 시각 위치 변경 없음
- **다른 nested 표 케이스**: 외부 셀 padding=0 또는 border_fill borders 모두 None 인 경우 (pure wrapper) 가드 미발동, 기존 동작 유지

## 주의 사항 (정합 한계)

본 정정은 **외곽 박스만 추가**. 외부 셀 padding (3mm) 영역 적용은 미포함 — 내부 표가 외곽 박스 가장자리까지 닿음. 한컴2022 PDF 는 padding 안쪽으로 내부 표 inset.

padding 정합은 별도 후속 영역 (wrapper 분기 본질 정정 또는 nested padding inset). 본 PR 은 **"박스가 안 보임" 결함의 1차 정정** — 박스 외곽이 시각상 표시되는 영역 충족.

## Test plan

- [x] `cargo test --release --lib` (1155 passed)
- [x] `cargo test --release --test issue_nested_table_border` (1/1)
- [x] `cargo build --release`
- [x] `samples/` 187 fixture 페이지 카운트 sweep (회귀 0)
- [x] `grep` 으로 4번 박스 외곽 4개 라인 좌표 검증 (390.65×343.88, x=549.88~940.53, y=331.53~675.41)
- [ ] 메인테이너 시각 판정 (rhwp-studio web editor 또는 SVG 출력)

Closes #680

🤖 Generated with [Claude Code](https://claude.com/claude-code)