### PR TITLE
fix: rhwpDev 디버깅 툴킷 결함 수정 — paragraph 식별 + 다중 매치 (#449)

### DIFF
--- a/rhwp-studio/src/core/rhwp-dev.ts
+++ b/rhwp-studio/src/core/rhwp-dev.ts
@@ -42,11 +42,11 @@ export function initRhwpDev(wasm: WasmBridge): void {
       }> = [];
 
       for (let p = startPage; p < endPage; p++) {
-        let layout: string;
+        let data: any;
         try {
-          layout = (wasm as any).doc.getPageTextLayout(p);
+          const layout = (wasm as any).doc.getPageTextLayout(p);
+          data = JSON.parse(layout);
         } catch { continue; }
-        const data = JSON.parse(layout);
         if (!data || !Array.isArray(data.runs)) continue;
 
         for (const run of data.runs as TextRunInfo[]) {
@@ -103,11 +103,11 @@ export function initRhwpDev(wasm: WasmBridge): void {
       const page = pageNum ?? 0;
       if (page >= totalPages) return null;
 
-      let layout: string;
+      let data: any;
       try {
-        layout = (wasm as any).doc.getPageTextLayout(page);
+        const layout = (wasm as any).doc.getPageTextLayout(page);
+        data = JSON.parse(layout);
       } catch { return null; }
-      const data = JSON.parse(layout);
       if (!data || !Array.isArray(data.runs)) return null;
 
       let nearest: { paraIdx: number; distance: number; text: string; container: string } | null = null;

--- a/rhwp-studio/src/core/rhwp-dev.ts
+++ b/rhwp-studio/src/core/rhwp-dev.ts
@@ -1,0 +1,139 @@
+import type { WasmBridge } from './wasm-bridge';
+
+interface TextRunInfo {
+  secIdx: number;
+  paraIdx: number;
+  charStart: number;
+  x: number;
+  y: number;
+  text: string;
+  parentParaIdx?: number;
+  controlIdx?: number;
+  cellIdx?: number;
+  cellParaIdx?: number;
+}
+
+interface SearchResult {
+  found: boolean;
+  sec?: number;
+  para?: number;
+  charOffset?: number;
+  length?: number;
+}
+
+function containerKey(run: TextRunInfo): string {
+  if (run.parentParaIdx != null) {
+    return `cell[p${run.parentParaIdx},c${run.controlIdx ?? 0},i${run.cellIdx ?? 0}]`;
+  }
+  return 'body';
+}
+
+
+export function initRhwpDev(wasm: WasmBridge): void {
+  const dev = {
+    showAllIds(pageNum?: number): void {
+      const totalPages = wasm.pageCount;
+      const startPage = pageNum ?? 0;
+      const endPage = pageNum != null ? pageNum + 1 : totalPages;
+      const entries: Array<{
+        page: number; container: string;
+        secIdx: number; paraIdx: number; charStart: number;
+        x: number; y: number; text: string;
+      }> = [];
+
+      for (let p = startPage; p < endPage; p++) {
+        let layout: string;
+        try {
+          layout = (wasm as any).doc.getPageTextLayout(p);
+        } catch { continue; }
+        const data = JSON.parse(layout);
+        if (!data || !Array.isArray(data.runs)) continue;
+
+        for (const run of data.runs as TextRunInfo[]) {
+          if (run.secIdx == null || run.paraIdx == null) continue;
+          entries.push({
+            page: p,
+            container: containerKey(run),
+            secIdx: run.secIdx,
+            paraIdx: run.paraIdx,
+            charStart: run.charStart ?? 0,
+            x: run.x ?? 0,
+            y: run.y ?? 0,
+            text: (run.text ?? '').slice(0, 20),
+          });
+        }
+      }
+
+      const seen = new Set<string>();
+      const unique = entries.filter(e => {
+        const key = `${e.page}:${e.container}:${e.secIdx}:${e.paraIdx}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      console.table(unique);
+      console.log(`[rhwpDev] showAllIds: ${unique.length} unique paragraph IDs across pages ${startPage}~${endPage - 1}`);
+    },
+
+    search(text: string): SearchResult[] {
+      const results: SearchResult[] = [];
+      let sec = 0, para = 0, charOff = 0;
+
+      for (;;) {
+        const r = wasm.searchText(text, sec, para, charOff, true, false);
+        if (!r || !r.found) break;
+        results.push(r);
+        sec = r.sec!;
+        para = r.para!;
+        charOff = r.charOffset! + (r.length ?? text.length);
+      }
+
+      if (results.length === 0) {
+        console.warn(`[rhwpDev] search("${text}"): not found`);
+      } else {
+        console.log(`[rhwpDev] search("${text}"): ${results.length} match(es)`);
+        console.table(results);
+      }
+      return results;
+    },
+
+    findNearest(targetId: number, pageNum?: number): { paraIdx: number; distance: number; text: string; container: string } | null {
+      const totalPages = wasm.pageCount;
+      const page = pageNum ?? 0;
+      if (page >= totalPages) return null;
+
+      let layout: string;
+      try {
+        layout = (wasm as any).doc.getPageTextLayout(page);
+      } catch { return null; }
+      const data = JSON.parse(layout);
+      if (!data || !Array.isArray(data.runs)) return null;
+
+      let nearest: { paraIdx: number; distance: number; text: string; container: string } | null = null;
+      for (const run of data.runs as TextRunInfo[]) {
+        const id = run.paraIdx;
+        if (id == null) continue;
+        const dist = Math.abs(id - targetId);
+        if (!nearest || dist < nearest.distance) {
+          nearest = { paraIdx: id, distance: dist, text: (run.text ?? '').slice(0, 30), container: containerKey(run) };
+        }
+      }
+      if (nearest) {
+        console.log(`[rhwpDev] findNearest(${targetId}, page=${page}): closest paraIdx=${nearest.paraIdx} (${nearest.container}, distance=${nearest.distance}) "${nearest.text}"`);
+      }
+      return nearest;
+    },
+
+    help(): void {
+      console.log(`%c[rhwpDev]%c Debugging Toolkit
+  .showAllIds(page?)      — list all paragraph IDs with container context (console.table)
+  .search("text")         — find all matches: section/paragraph/offset (returns array)
+  .findNearest(id, page?) — find nearest valid paraIdx to a given ID
+  .help()                 — this message`, 'color:#2563eb;font-weight:bold', 'color:inherit');
+    },
+  };
+
+  (window as any).rhwpDev = dev;
+  console.log('%c[rhwpDev]%c Debugging toolkit loaded — rhwpDev.help() for usage', 'color:#2563eb;font-weight:bold', 'color:inherit');
+}

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -25,6 +25,7 @@ import { CellSelectionRenderer } from '@/engine/cell-selection-renderer';
 import { TableObjectRenderer } from '@/engine/table-object-renderer';
 import { TableResizeRenderer } from '@/engine/table-resize-renderer';
 import { Ruler } from '@/view/ruler';
+import { initRhwpDev } from '@/core/rhwp-dev';
 
 const wasm = new WasmBridge();
 const eventBus = new EventBus();
@@ -95,6 +96,7 @@ async function initialize(): Promise<void> {
     await loadWebFonts([]);  // CSS @font-face 등록 + CRITICAL 폰트만 로드
     msg.textContent = 'WASM 로딩 중...';
     await wasm.initialize();
+    initRhwpDev(wasm);
     msg.textContent = 'HWP 파일을 선택해주세요.';
 
     const container = document.getElementById('scroll-container')!;

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -96,7 +96,9 @@ async function initialize(): Promise<void> {
     await loadWebFonts([]);  // CSS @font-face 등록 + CRITICAL 폰트만 로드
     msg.textContent = 'WASM 로딩 중...';
     await wasm.initialize();
-    initRhwpDev(wasm);
+    if (import.meta.env.DEV) {
+      initRhwpDev(wasm);
+    }
     msg.textContent = 'HWP 파일을 선택해주세요.';
 
     const container = document.getElementById('scroll-container')!;


### PR DESCRIPTION
## 요약

PR #602 cherry-pick 후 메인테이너 시각 판정에서 식별된 결함 두 건을 수정합니다.

### 결함 #1: paragraph 식별 부정확 (본문 vs 셀 내부 충돌)

`getPageTextLayout`이 반환하는 runs의 `parentParaIdx`/`controlIdx`/`cellIdx` 필드를 활용하여 본문 paragraph와 셀 내부 paragraph를 구분합니다.

- `containerKey()`: body paragraphs → `"body"`, cell-internal → `"cell[p0,c0,i0]"` 형식
- `showAllIds()` 출력에 `container` 컬럼 추가
- 중복 제거 키에 container 포함 → `0:body:0:0` ≠ `0:cell[p0,c0,i0]:0:0`
- `findNearest()` 결과에도 container 정보 포함

**Before**: `samples/aift.hwp` paragraph 0 에서 본문 텍스트("  * 사업계획서...") 대신 셀 내부 텍스트("※ ") 표시
**After**: 본문과 셀 내부가 별도 행으로 구분됨

### 결함 #2: 다중 매치 미처리

`search(text)`가 `searchText`를 반복 호출하여 문서 전체의 모든 매치를 수집합니다.

- 반환 타입: `SearchResult` → `SearchResult[]`
- `console.table`로 전체 매치 목록 출력
- 매치 없을 때만 `console.warn`

## 변경 파일

- `rhwp-studio/src/core/rhwp-dev.ts` — 신규 (PR #602 기반 + 결함 수정)
- `rhwp-studio/src/main.ts` — `initRhwpDev(wasm)` 호출 추가

## 검증

- `cargo test --lib`: 1066 passed, 0 failed
- `cargo clippy -- -D warnings`: clean
- TypeScript: rhwp-dev.ts, main.ts 에러 없음

## 관련 이슈

fixes #449 (후속 결함 영역)

---
*PR #602 cherry-pick 이후의 후속 수정입니다.*