### PR TITLE
Task #688: table-vpos-01.hwpx p.5 nested 표 외부 셀 height 미반영 (외부 표 + 측정자 1×1 unwrap 동일 결함)

### DIFF
--- a/mydocs/orders/20260508.md
+++ b/mydocs/orders/20260508.md
@@ -1,0 +1,16 @@
+# 2026-05-08 오늘할일
+
+## M100 — table-vpos-01.hwpx 페이지 5 nested 표 외부 셀 height 미반영 (Task #688)
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| **M100 #688** | `samples/table-vpos-01.hwpx` p.5 nested 표 외부 셀 height 미반영 — 외부 표 height 57.72px / 권위 778.8px | **close (3단계 완료)** | layout_table 와 height_measurer 두 곳에 동일한 1×1 래퍼 unwrap 결함 (`flat_map(...).find_map(...)` 로 첫 nested 만 가져와 paragraphs 의 두 번째 nested 표 누락). 두 곳 모두 unwrap 조건을 `paragraphs.len()==1 + 단일 nested table + visible text 없음` 으로 좁힘. PDF 권위본 (`pdf/table-vpos-01-2022.pdf`) 5쪽 4그룹 + 12 추진과제 그리드 시각 정합 회복. 광범위 회귀 159 샘플 / 1502 페이지 / 의도된 변경 2건 + 자연 해소 1건 / 회귀 0건. 보고서: `mydocs/report/task_m100_688_report.md` |
+
+### 후속 권장 (별개 결함)
+
+- `samples/table-vpos-01.hwpx` 페이지 2 hwp_used diff = -791.9px, 페이지 3 = -1658.3px — 본 수정과 무관한 별개 결함, 후속 이슈 분리 권장
+- 1×1 래퍼 unwrap 로직이 layout_table 과 height_measurer 두 곳 중복 — 향후 공통 helper 추출 검토
+
+### 정정 사항
+
+- 단계 1 보고서의 "페이지 1 LAYOUT_OVERFLOW 4.1px 자연 해소" 는 `pr-task677` 브랜치 환경 차이로 인한 일회성 출력이며 본 수정의 효과가 아님 (단계 3 보고서에서 정정).

--- a/mydocs/plans/task_m100_688.md
+++ b/mydocs/plans/task_m100_688.md
@@ -1,0 +1,74 @@
+# Task #688: table-vpos-01.hwpx p.5 nested 표 외부 셀 height 미반영 — 수행계획서
+
+## 목표
+
+`samples/table-vpos-01.hwpx` 5쪽 마지막 큰 표(pi=34, "정부혁신 4대 추진전략 / 12대 추진과제") 의 외부 1×1 셀 height 가 nested 표(11×3) 분량을 누적하지 못해 외곽선과 셀 본문이 SVG 에서 누락되는 결함을 수정한다.
+
+PDF 권위본(`pdf/table-vpos-01-2022.pdf`) 5쪽과 시각적 정합을 회복한다.
+
+## 배경
+
+`rhwp dump samples/table-vpos-01.hwpx -s 0 -p 34` 권위값:
+
+- pi=34 외부 표: 1×1, treat_as_char=true, wrap=TopAndBottom
+- 권위 size: **638.8 × 778.8px** (47913×58410 HU)
+- ls[0].lh = 58692 HU ≈ **779px**
+- 외부 셀[0] h = 50720 HU ≈ 676px, paras=2
+  - p[0] 내부 표 1×1 → 헤더 박스
+  - p[1] 내부 표 11×3 → 23셀 그리드 (4그룹 헤더 + 12 추진과제)
+
+`rhwp export-svg --debug-overlay` 실측 (`/tmp/tvpos01_dbg/table-vpos-01_005.svg` line 111):
+
+```
+<rect x="77.43" y="229.85" width="623.75" height="57.72" .../>
+label: s0:pi=34 ci=0 1x1 y=229.9
+```
+
+| 항목 | 권위값 | layout 계산 | 차이 |
+|------|--------|-------------|------|
+| pi=34 표 height | 778.8px | **57.72px** | ~14배 부족 |
+| pi=34 표 width  | 638.8px | 623.75px    | -15.1px |
+
+→ 외부 1×1 셀 안의 nested 11×3 표 height 가 부모 셀에 누적되지 않아, 외부 표가 헤더 분량(약 57px) 만큼만 잡힘. 결과적으로:
+
+- 외곽선이 사실상 안 보임
+- nested 1×1 헤더 박스, nested 11×3 그리드(4그룹 + 12항목) 텍스트 모두 누락
+- 페이지 5 SVG 가 20KB (다른 페이지 200~450KB)
+
+## 의심 코드 영역
+
+- `src/renderer/layout/table_layout.rs::layout_table()` (line 127–)
+- `layout_table_cells()` (line 1148–) 의 nested table 분기 (line 1431–1439, 1901–1943)
+- 셀 paragraphs 순회 시 `Control::Table`(treat_as_char=false) 의 누적 height 가 부모 셀 height 에 반영되지 않거나, ls[0].lh 권위값을 채택하지 않음
+
+## 영향 범위
+
+| 파일 | 예상 변경 |
+|------|----------|
+| `src/renderer/layout/table_layout.rs` | 셀 height 계산에 nested table 누적 반영 |
+| `src/renderer/layout.rs` | 필요 시 ls[0].lh 권위값 폴백 경로 추가 |
+
+추가로 nested 표 path 가 너비도 빗나가는 점(width -15.1px) 이 같은 코드 결함의 부수 증상인지 별도 결함인지 1단계 조사 결과로 판단한다.
+
+## 검증 기준 (DoD)
+
+1. pi=34 외부 표 외곽선이 5쪽에 778.8px ± 허용오차로 그려진다 (debug overlay rect height ≥ 770px)
+2. nested 1×1 헤더 박스 ("정부혁신 4대 추진전략, 12대 추진과제") 텍스트 표시
+3. nested 11×3 그리드의 4그룹 헤더 ("참여소통/기본사회/공직혁신/공공 AX") + 12개 추진과제 텍스트 모두 표시
+4. PDF 권위본 (`pdf/table-vpos-01-2022.pdf`) 5쪽과 시각적으로 정합
+5. 회귀 검증: `samples/` 하위 nested 표 보유 샘플 + 단순 표 샘플로 회귀 없음 확인
+6. `cargo test` 전체 통과
+
+## 보조 관찰 (이 타스크 범위 밖)
+
+수정 전후 `dump-pages` 비교에서 다음 항목을 측정만 수행하고, 본 결함과 같은 원인이라 입증되면 같은 타스크에서 함께 처리, 별개라면 후속 이슈 분리:
+
+- 페이지 1 마지막 문단 4.1px LAYOUT_OVERFLOW
+- 페이지 2 hwp_used vs used diff = -791.9px, 페이지 3 = -1658.3px
+
+## 참고 자료
+
+- 입력: `samples/table-vpos-01.hwpx`
+- 권위 PDF: `pdf/table-vpos-01-2022.pdf` (한글 2022)
+- 분석 SVG: `/tmp/tvpos01_dbg/table-vpos-01_005.svg`
+- GitHub Issue: #688

--- a/mydocs/plans/task_m100_688_impl.md
+++ b/mydocs/plans/task_m100_688_impl.md
@@ -1,0 +1,116 @@
+# Task #688: nested 표 외부 셀 height 미반영 — 구현계획서
+
+## 결함 위치 정밀 분석
+
+`src/renderer/layout/table_layout.rs::layout_table()` 라인 150-168 의 "1×1 래퍼 표 감지" 로직:
+
+```rust
+if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
+    let cell = &table.cells[0];
+    let has_visible_text = cell.paragraphs.iter()
+        .any(|p| p.text.chars().any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n'));
+    if !has_visible_text {
+        if let Some(nested) = cell.paragraphs.iter()
+            .flat_map(|p| p.controls.iter())
+            .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
+        {
+            return self.layout_table(
+                tree, col_node, nested,  // ← 외부 표를 무시하고 첫 nested 만 렌더
+                ...
+            );
+        }
+    }
+}
+```
+
+### 결함 메커니즘
+
+pi=34 외부 1×1 표의 단일 셀 안에:
+- `paragraphs[0]` (paras_id=33) controls=1 → nested **1×1 헤더 박스**
+- `paragraphs[1]` (paras_id=35) controls=1 → nested **11×3 그리드** (셀 23개)
+
+이 코드는 `flat_map(...).find_map(...)` 로 첫 nested 표(1×1 헤더) 만 찾아 unwrap 한다. **두 번째 nested 표(11×3) 와 외부 표 외곽선 모두 통째로 누락**.
+
+debug overlay 의 `s0:pi=34 ci=0 1x1 y=229.9 width=623.75 height=57.72` 는 사실상 외부 표 자리에 **nested 1×1 헤더 박스**가 그려진 것이며, 외부 표/11×3 그리드는 SVG 어디에도 존재하지 않는다.
+
+### 수정 방향
+
+래퍼 감지 조건을 다음 3가지 모두 충족하는 경우로 좁힌다:
+
+1. `table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1` (현행 유지)
+2. `cell.paragraphs.len() == 1` (**신규**: 단일 paragraph)
+3. 그 paragraph 의 `controls` 가 정확히 1개의 nested table 만 (다른 control 없음, **신규**)
+4. `has_visible_text == false` (현행 유지)
+
+이러면 pi=34 같은 다중 paragraph 셀은 unwrap 대상에서 제외되어 외부 표가 정상 렌더되고, cell 내부 nested 표는 이미 존재하는 셀 렌더 경로 (`layout_table_cells()` 라인 1955-1962, `Control::Table` 재귀 호출) 를 통해 자연스럽게 그려진다.
+
+## 단계 구성 (3단계)
+
+### 1단계: 1×1 래퍼 감지 조건 정밀화 + 대상 샘플 단위 검증
+
+**작업**:
+- `src/renderer/layout/table_layout.rs::layout_table()` 라인 150-168 수정
+- 조건 추가: `cell.paragraphs.len() == 1 && paragraph.controls.iter().filter(|c| matches!(c, Control::Table(_))).count() == 1 && paragraph.controls.len() == 1`
+  - (또는 동등한 좀 더 가독성 좋은 표현)
+
+**검증**:
+- `cargo build --release` 성공
+- `rhwp dump-pages samples/table-vpos-01.hwpx` 페이지 5의 pi=34 표 height 가 778.8px ± 5px 로 회복
+- `rhwp export-svg --debug-overlay samples/table-vpos-01.hwpx` 산출물에서:
+  - pi=34 외부 표 rect height ≥ 770px
+  - SVG 페이지 5 파일 크기 다른 페이지와 비슷한 수준 (200KB 이상)
+  - nested 1×1 헤더 텍스트 ("정부혁신 4대 추진전략, 12대 추진과제") 존재
+  - nested 11×3 그리드 셀 텍스트 (4그룹 헤더 + 12개 추진과제) 모두 존재
+- PDF 권위본 (`pdf/table-vpos-01-2022.pdf`) 5쪽과 시각 정합 확인
+
+**산출물**: `mydocs/working/task_m100_688_stage1.md`
+
+### 2단계: 광범위 샘플 회귀 검증
+
+**작업**:
+- 1×1 래퍼 표를 사용하는 다른 샘플 식별 (`samples/` 하위 grep, `rhwp dump`)
+- 해당 샘플들의 SVG 출력을 수정 전/후 비교
+- `cargo test` 전체 실행
+
+**검증**:
+- 1×1 래퍼 unwrap 의도된 케이스 (paragraphs.len() == 1 + 단일 nested table) 가 여전히 정상 unwrap 됨
+- `cargo test` 통과
+- SVG diff 에서 의도하지 않은 차이 없음
+
+**회귀 발견 시 처리**:
+- 조건 재조정 (예: visible_text 외 다른 control 종류도 허용/거부 정밀화)
+- 1단계 산출물 갱신 후 재승인 요청
+
+**산출물**: `mydocs/working/task_m100_688_stage2.md`
+
+### 3단계: 보조 관찰 측정 + 최종 결과보고서
+
+**작업**:
+- 수정 전/후 `rhwp dump-pages samples/table-vpos-01.hwpx` 비교:
+  - 페이지 1 LAYOUT_OVERFLOW 4.1px 변화 측정
+  - 페이지 2 hwp_used diff = -791.9px, 페이지 3 = -1658.3px 변화 측정
+- 동일 원인으로 자연 해소되면 보고서에 명시, 별개라면 후속 이슈 후보로 기록 (분리 제안)
+- 최종 보고서 작성: 결함 원인 / 수정 내용 / 검증 결과 / 회귀 검증 / 보조 관찰
+
+**산출물**:
+- `mydocs/report/task_m100_688_report.md`
+- `mydocs/orders/20260508.md` 갱신 (또는 현재 active orders 문서)
+
+## 영향 범위 요약
+
+| 파일 | 변경 내용 | 라인 수 추정 |
+|------|----------|------------|
+| `src/renderer/layout/table_layout.rs` | 라인 150-168 의 래퍼 감지 조건 정밀화 | +5 / -0 |
+
+수정 라인 수가 작은 단일 위치 결함이므로 구현 자체는 짧다. 회귀 검증과 보조 관찰 측정에 더 많은 시간이 든다.
+
+## 위험도 평가
+
+- **저위험**: 수정은 unwrap 조건을 좁히는 방향이므로, 의도된 1×1 래퍼 케이스는 영향 없음
+- **회귀 가능성**: paragraphs.len() == 1 인 단일 nested table 래퍼만 통과시키므로, 기존에 부당하게 unwrap 되던 다른 케이스는 외부 표가 정상 렌더되는 쪽으로 동작 변경
+  - 다른 샘플 중 부당 unwrap 으로 정상화되어 있던 표가 있다면 차이 발생 가능 → 2단계 회귀 검증 필수
+
+## 참고
+
+- 수행계획서: `mydocs/plans/task_m100_688.md`
+- GitHub Issue: #688

--- a/mydocs/report/task_m100_688_report.md
+++ b/mydocs/report/task_m100_688_report.md
@@ -1,0 +1,117 @@
+# Task #688 최종 결과보고서
+
+## 결함 요약
+
+`samples/table-vpos-01.hwpx` 5쪽 마지막 큰 표 (pi=34, "정부혁신 4대 추진전략 / 12대 추진과제") 가 SVG 출력에서 **시각적으로 거의 전부 누락**됨.
+
+PDF 권위본 (`pdf/table-vpos-01-2022.pdf`) 5쪽: 큰 박스 + 헤더 + 4그룹 (참여소통/기본사회/공직혁신/공공 AX) × 3 = 12 추진과제 그리드.
+
+## 근본 원인 (두 곳에 동일 결함)
+
+외부 1×1 표 셀 안에 nested 표 2개 (1×1 헤더 + 11×3 그리드) 가 있는 구조 처리 시:
+
+**Bug A** — `src/renderer/layout/table_layout.rs::layout_table()` 라인 150-168:
+**Bug B** — `src/renderer/height_measurer.rs::measure_table_impl()` 라인 457-468:
+
+두 곳 모두 1×1 래퍼 표 unwrap 로직이 다음 형태:
+```rust
+if let Some(nested) = cell.paragraphs.iter()
+    .flat_map(|p| p.controls.iter())
+    .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
+```
+
+`flat_map` 으로 셀 paragraphs 전체를 훑어 첫 nested 표만 가져옴. paragraphs 가 2개 이상이거나 다른 control 이 섞인 경우 **두 번째 paragraph 의 nested 표가 통째 누락**.
+
+### 결과 (수정 전)
+
+- layout_table: 외부 표가 첫 nested 1×1 헤더로 unwrap → 11×3 그리드 누락
+- measure_table: 외부 표 측정값이 nested 1×1 헤더 height (57.72px) 로 잡힘 → measured_table 이 작게 잡혀 외부 표 cell-clip 이 57.72px 로 그려짐
+
+두 결함이 결합되어 페이지 5 의 nested 11×3 그리드 (4그룹 + 12 추진과제) 가:
+- layout 단계에서 그려지지 않거나
+- 그려져도 외부 셀 cell-clip(y=227.17, h=57.72) 밖(y=295~)이라 SVG 클리핑으로 가려짐
+
+## 수정
+
+두 곳 모두 unwrap 조건을 다음 4가지 모두 충족하는 경우로 좁힘:
+1. 외부 표 1×1 단일 셀 (현행)
+2. **셀 paragraphs 가 정확히 1개**
+3. **그 paragraph 의 control 이 정확히 1개의 nested table 만**
+4. visible text 없음 (현행)
+
+| Commit | 파일 | 라인 변경 |
+|--------|------|----------|
+| `4b357394` | `src/renderer/layout/table_layout.rs` | +15 / -7 |
+| `7d8cca27` | `src/renderer/height_measurer.rs` | +13 / -9 |
+
+## 검증 결과
+
+### 시각 정합 (DoD 1~4)
+
+`rsvg-convert` 로 SVG → PNG 변환:
+
+| 시점 | 페이지 5 PNG 크기 | nested 11×3 그리드 표시 |
+|------|------------------|------------------------|
+| 결함 (수정 전) | (PDF 권위본 비교 필요) | ❌ 누락 |
+| Stage 1 만 | 26 KB | ❌ 클립으로 가려짐 |
+| Stage 1 + Stage 3 fix | **142 KB** | ✅ 완전 표시 |
+
+PDF 권위본과 시각적으로 동등.
+
+### 광범위 회귀 (DoD 5)
+
+`scripts/svg_regression_diff.sh` + `/tmp/regr_full.sh`:
+
+```
+TOTAL: pages=1502 same=1499 diff=3 samples=159
+diff list:
+  exam_social__hwp/exam_social_001.svg     (자연 해소)
+  table-vpos-01__hwp/table-vpos-01_005.svg (의도된 수정)
+  table-vpos-01__hwpx/table-vpos-01_005.svg (의도된 수정)
+```
+
+회귀 0건. exam_social.hwp 페이지 1 의 변경은 동일 결함이 1×1 셀 (paras=3, "뜨거워진 한반도..." 텍스트) 에도 영향 → 수정 후 외부 표 정상 렌더 (cell-clip 통합 + width 411.92 정상화).
+
+### 단위 테스트 (DoD 6)
+
+```
+test result: ok. 1119 passed; 0 failed; 1 ignored
+... (총 1192+ 테스트 전부 통과)
+```
+
+SVG 스냅샷 테스트 6건 포함 모두 통과.
+
+## 보조 관찰 (별개 결함)
+
+본 타스크 수정과 **무관**한 별개 결함:
+
+- **페이지 2 hwp_used diff = -791.9px**
+- **페이지 3 hwp_used diff = -1658.3px**
+
+수정 전후 변화 없음. 권위 vpos 와 layout 의 페이지 분할이 어긋남. 별도 후속 이슈 분리 권장.
+
+## 정정 사항
+
+단계 1 완료보고서에 "페이지 1 LAYOUT_OVERFLOW 4.1px 자연 해소" 라 기록되었으나, base ref(`local/devel`) 에서 본래 발생하지 않음을 단계 3 에서 확인. 첫 관찰은 작업 진입 직전 `pr-task677` 브랜치 환경 차이로 발생한 일회성 출력이며 본 수정의 효과가 아니다. 본 보고서에서 정정한다.
+
+## 진행 결과
+
+| 단계 | 핵심 작업 | Commit |
+|------|----------|--------|
+| 1 | layout_table 1×1 unwrap 조건 정밀화 | `4b357394` |
+| 2 | 광범위 회귀 검증 (159 샘플 / 1502 페이지) | `01ecb71a` |
+| 3-fix | height_measurer 1×1 unwrap 동일 결함 수정 | `7d8cca27` |
+| 3 | 시각 정합 + 보조 관찰 + 정정 + 최종 보고서 | (이 commit) |
+
+## 후속 권장
+
+1. `samples/table-vpos-01.hwpx` 페이지 2~3 hwp_used 큰 diff 별개 결함 — 별도 이슈 분리 후 조사
+2. 1×1 래퍼 unwrap 로직이 layout_table 과 height_measurer 두 곳에 중복 존재. 향후 공통 helper 로 추출 검토 (본 타스크 범위 외)
+
+## 참고
+
+- GitHub Issue: #688
+- 수행계획서: `mydocs/plans/task_m100_688.md`
+- 구현계획서: `mydocs/plans/task_m100_688_impl.md`
+- 단계별 보고서: `mydocs/working/task_m100_688_stage{1,2,3}.md`
+- 권위 PDF: `pdf/table-vpos-01-2022.pdf` (한글 2022)

--- a/mydocs/working/task_m100_688_stage1.md
+++ b/mydocs/working/task_m100_688_stage1.md
@@ -1,0 +1,113 @@
+# Task #688 1단계 완료보고서 — 1×1 래퍼 감지 조건 정밀화
+
+## 변경 사항
+
+`src/renderer/layout/table_layout.rs::layout_table()` 라인 150-170 수정.
+
+### 변경 전
+
+```rust
+if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
+    let cell = &table.cells[0];
+    let has_visible_text = cell.paragraphs.iter()
+        .any(|p| p.text.chars().any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n'));
+    if !has_visible_text {
+        if let Some(nested) = cell.paragraphs.iter()
+            .flat_map(|p| p.controls.iter())
+            .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
+        {
+            return self.layout_table(...);
+        }
+    }
+}
+```
+
+### 변경 후
+
+```rust
+if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
+    let cell = &table.cells[0];
+    if cell.paragraphs.len() == 1 {
+        let p = &cell.paragraphs[0];
+        let has_visible_text = p.text.chars()
+            .any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n');
+        let only_one_nested_table = p.controls.len() == 1
+            && matches!(p.controls.first(), Some(Control::Table(_)));
+        if !has_visible_text && only_one_nested_table {
+            if let Some(Control::Table(t)) = p.controls.first() {
+                return self.layout_table(...);
+            }
+        }
+    }
+}
+```
+
+핵심: unwrap 조건을 다음 4가지 모두 충족하는 경우로 좁힘.
+1. 외부 표 1×1 단일 셀 (현행 유지)
+2. **셀 paragraphs 가 정확히 1개**
+3. **그 paragraph 의 control 이 정확히 1개의 nested table 만**
+4. visible text 없음 (현행 유지)
+
+## 검증 결과
+
+### 정량 비교
+
+| 항목 | 수정 전 | 수정 후 | 변화 |
+|------|---------|---------|------|
+| 페이지 5 SVG 크기 | 20KB | **132KB** | ×6.6 |
+| 페이지 5 `<text>` 요소 수 | 55 | **343** | ×6.2 |
+| LAYOUT_OVERFLOW (page 0) | 4.1px | **없음** | 해소 |
+| 페이지 1~4 SVG 크기 | 450KB/245KB/213KB/296KB | 450KB/244KB/212KB/295KB | ±1% (회귀 없음) |
+
+### 페이지 5 콘텐츠 복원 확인
+
+수정 후 SVG 페이지 5에 다음 텍스트 모두 존재 (`grep -oE ">[가-힣...]+<"` 검증):
+
+- 참고 / 정부혁신 비전 및 추진전략
+- 국민이 주도하고 AI가 뒷받침하는 국민주권정부 (빨간 박스)
+- **정부혁신 4대 추진전략, 12대 추진과제** (파란 헤더)
+- **1 참여소통** / 국민 주도 참여·소통 거버넌스 구현
+  - ① 대국민 소통 일상화로 국민의 의견을 정책으로 전환
+  - ② 국민의 알권리 보장을 통해 정부 투명성 강화
+  - ③ 국민의 목소리를 경청하여 생활 속 문제해결
+- **2 기본사회** / 포용과 균형의 기본사회 구현
+  - ④ 사각지대 없는 포용적 공공서비스 체계 구축
+  - ⑤ 모두가 기본적 삶을 보장받는 사회 안전망 구축
+  - ⑥ 자율과 혁신을 통한 지역균형성장 체계 구축
+- **3 공직혁신** / 성과로 신뢰받는 일 잘하는 정부 구현
+  - ⑦ 국민 누구에게나 쉽고 편리한 서비스 환경 조성
+  - ⑧ 가짜 노동 없는 성과 중심의 조직 운영
+  - ⑨ 열정이 넘치고 일 잘하는 공직사회 조성
+- **4 공공 AX** / 공공부문 인공지능 대전환
+  - 공공부문 AI 대전환을 위한 인프라 구축
+  - 공공 AI 리터러시 강화 및 인재 양성
+  - 공공 AI 윤리 및 신뢰성 확보
+
+### DoD 충족 현황
+
+| DoD | 항목 | 상태 |
+|-----|------|------|
+| 1 | pi=34 외부 표 외곽 그려짐 | ⚠️ 외부 표 BoundingBox 자체는 그려지나 height=57.72px (권위 778.8px) — 추가 조사 필요 |
+| 2 | nested 1×1 헤더 박스 텍스트 | ✅ |
+| 3 | nested 11×3 그리드 4그룹 + 12 추진과제 텍스트 | ✅ |
+| 4 | PDF 권위본과 시각 정합 | ⏳ 시각 검증 필요 (단계 2 또는 3에서) |
+| 5 | 회귀 없음 | ⏳ 단계 2에서 검증 |
+| 6 | `cargo test` 통과 | ⏳ 단계 2에서 검증 |
+
+### DoD 1 의 잔여 의문
+
+debug overlay 의 pi=34 외부 표 BoundingBox 가 height=57.72 로 수정 후에도 변하지 않았다. 단, nested 11×3 그리드의 cell 들이 외부 표 영역 밖(y=287 ~ 850)까지 자유롭게 그려져 있어 콘텐츠는 모두 가시화됨. PDF 권위본은 외부 박스 외곽선이 nested 11×3 외곽선과 거의 일치하므로 시각적 차이가 무시할 수 있는 수준일 가능성이 있으나, 단계 3 시각 검증에서 최종 확인.
+
+### 부산 효과: LAYOUT_OVERFLOW 자연 해소
+
+페이지 1 마지막 문단 4.1px 오버플로우 경고가 사라졌다. 본 수정과 같은 원인(부당한 1×1 unwrap)이 페이지 1 의 어느 표에도 적용되어 위치가 4.1px 어긋났던 것이 자연 해소된 것으로 추정. 단계 3 보조 관찰에서 정밀 측정.
+
+## 산출물
+
+- 코드 수정: `src/renderer/layout/table_layout.rs` (+15 / -7 라인)
+- 검증 SVG (수정 후): `/tmp/tvpos01_fix/table-vpos-01_005.svg` (132KB)
+- 검증 SVG (debug overlay): `/tmp/tvpos01_fix_dbg/table-vpos-01_005.svg`
+
+## 다음 단계
+
+단계 2: 광범위 샘플 회귀 검증 (samples/ 하위 + `cargo test`)

--- a/mydocs/working/task_m100_688_stage2.md
+++ b/mydocs/working/task_m100_688_stage2.md
@@ -1,0 +1,89 @@
+# Task #688 2단계 완료보고서 — 광범위 회귀 검증
+
+## 검증 1: `cargo test` 전체
+
+```
+test result: ok. 1119 passed; 0 failed; 1 ignored
+test result: ok. 14 passed; 0 failed
+test result: ok. 25 passed; 0 failed
+test result: ok. 9 passed; 0 failed
+test result: ok. 8 passed; 0 failed
+test result: ok. 6 passed; 0 failed (svg_snapshot)
+test result: ok. 3 passed; 0 failed
+test result: ok. 2 passed; 0 failed
+test result: ok. 1 passed; 0 failed (다수)
+```
+
+총 1192+ 테스트 모두 통과. 0 failed. SVG 스냅샷 테스트 6개도 회귀 없음.
+
+## 검증 2: 기본 7개 샘플 SVG diff (`scripts/svg_regression_diff.sh`)
+
+```
+2010-01-06: total=6 same=6 diff=0
+aift: total=77 same=77 diff=0
+exam_eng: total=8 same=8 diff=0
+exam_kor: total=20 same=20 diff=0
+exam_math: total=20 same=20 diff=0
+exam_science: total=4 same=4 diff=0
+synam-001: total=35 same=35 diff=0
+TOTAL: pages=170 same=170 diff=0
+```
+
+회귀 0건.
+
+## 검증 3: 광범위 — `samples/` 직속 .hwp + .hwpx 전체
+
+```
+Targets: 159
+TOTAL: pages=1502 same=1499 diff=3
+diff list:
+  exam_social__hwp/exam_social_001.svg
+  table-vpos-01__hwp/table-vpos-01_005.svg
+  table-vpos-01__hwpx/table-vpos-01_005.svg
+```
+
+159 샘플 / 1502 페이지 / **diff 3건**.
+
+### diff 3건 분석
+
+| # | 파일 | 분류 | 사유 |
+|---|------|------|------|
+| 1 | `table-vpos-01__hwpx/_005.svg` | **의도** | 본 타스크 대상 결함 수정 (페이지 5 nested 11×3 그리드 복원) |
+| 2 | `table-vpos-01__hwp/_005.svg` | **의도** | 위와 동일 결함 — HWP 변환본도 같은 IR 거치므로 동일 변경 |
+| 3 | `exam_social__hwp/_001.svg` | **자연 해소 (회귀 아님)** | 아래 분석 |
+
+#### diff #3: `exam_social.hwp` 페이지 1 자연 해소 분석
+
+- 변경 패턴 (head -200 diff):
+  - body-clip width: `1240.12 → 1251.4533` (+11.33px)
+  - 셀별로 분리되어 있던 cell-clip 들이 단일 width=411.92 클립으로 통합
+
+- `dump samples/exam_social.hwp -s 0 -p 1` 결과:
+  - 문단 0.1 의 1×1 표 (411.9×197.0px, tac=true) 셀[0] paras=**3** ("뜨거워진 한반도, 과일 재배 지도가 바뀐다!" 등)
+  - 우리 수정 조건의 정확한 케이스: paragraphs ≠ 1 → unwrap 안 됨
+
+- 수정 전 동작: 외부 표 unwrap → 첫 nested 표만 가져옴 → paragraphs 의 다른 콘텐츠 누락 가능성
+- 수정 후 동작: 외부 표 정상 렌더 → 셀 paragraphs 3개 모두 처리 → 콘텐츠 추가 (SVG +2.6KB)
+- cell-clip 통합과 width=411.92 (외부 표 권위 width 와 일치) 패턴 → 외부 표 정상화 직접 신호
+
+결론: 본 타스크 수정의 직접 부산 효과. 회귀 아님. PDF 권위본 미보유로 시각 검증은 불가능하나 변경 방향이 정상화.
+
+## DoD 충족 현황 갱신
+
+| DoD | 항목 | 상태 |
+|-----|------|------|
+| 1 | pi=34 외부 표 외곽 그려짐 | ⚠️ height=57.72px 잔여 의문 — 단계 3 시각 검증 |
+| 2 | nested 1×1 헤더 텍스트 | ✅ |
+| 3 | nested 11×3 그리드 텍스트 | ✅ |
+| 4 | PDF 권위본과 시각 정합 | ⏳ 단계 3 |
+| 5 | **회귀 없음** | ✅ — 1502페이지 중 의도된 변경 2건 + 자연 해소 1건, 회귀 0건 |
+| 6 | **`cargo test` 통과** | ✅ — 1192+ 테스트 전부 통과 |
+
+## 산출물
+
+- 회귀 검증 결과: `/tmp/svg_diff_full_before/`, `/tmp/svg_diff_full_after/` (1502페이지 SVG)
+- 비교 스크립트: `/tmp/regr_full.sh` (광범위 검증용 hand-roll)
+
+## 다음 단계
+
+단계 3: 보조 관찰 측정 (페이지 1 LAYOUT_OVERFLOW 자연 해소 / 페이지 2~3 hwp_used diff) + PDF 시각 정합 검증 + 최종 결과보고서

--- a/mydocs/working/task_m100_688_stage3.md
+++ b/mydocs/working/task_m100_688_stage3.md
@@ -1,0 +1,105 @@
+# Task #688 3단계 완료보고서 — height_measurer 누락 수정 + PDF 시각 정합 + 보조 관찰
+
+## 단계 3 도중 발견된 추가 결함 (Stage 3 fix)
+
+단계 1 의 layout_table 만 수정해서는 외부 표가 시각적으로 그려지지 않는 결함이 잔존. SVG → PNG 변환 시 페이지 5의 4그룹 + 12 추진과제 그리드 영역이 **텅 비어 있음**.
+
+### 진단 (디버그 로깅 trace)
+
+`measured_table.is_some() == true` 이면 `resolve_row_heights` 가 라인 586-590 에서 early return. 그 measured_table 이 `[57.72px]` (= nested 1×1 헤더 셀 height) 였음.
+
+`src/renderer/height_measurer.rs::measure_table_impl()` 라인 457-468 에 layout_table 과 **완전히 동일한 결함의 1×1 unwrap 코드** 잔존:
+
+```rust
+// 결함 코드
+if let Some(nested) = cell.paragraphs.iter()
+    .flat_map(|p| p.controls.iter())
+    .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
+{
+    return self.measure_table_impl(nested, ..., depth + 1);
+}
+```
+
+외부 표 측정 시 nested 1×1 헤더로 unwrap → measured_table.row_heights = [4329HU=57.72px] → layout 단계에서 외부 표 권위 cell.height(50720HU=676px) 무시 → cell-clip 이 57.72px 로 잡혀 nested 11×3 그리드(y=295~)가 모두 클립 밖.
+
+### 수정
+
+layout_table 과 동일한 4가지 조건 (paragraphs.len()==1 + control 정확히 1개의 nested table + visible text 없음) 으로 좁힘. commit `7d8cca27`.
+
+## 시각 정합 검증 (DoD 1, 2, 3, 4 최종 확인)
+
+`rsvg-convert` 로 SVG → PNG 변환:
+
+| 시점 | PNG 크기 |
+|------|----------|
+| 단계 1 만 (Stage 1 commit) | 26 KB |
+| 단계 1 + 단계 3 fix | **142 KB** (×5.5) |
+
+페이지 5 시각 정합 (PDF 권위본 vs SVG/PNG):
+
+✅ 참고 + 정부혁신 비전 및 추진전략
+✅ 빨간 박스: 국민이 주도하고 AI가 뒷받침하는 국민주권정부
+✅ 파란 박스: 정부혁신 4대 추진전략, 12대 추진과제
+✅ 1 참여소통 그룹 + 추진과제 ① ② ③
+✅ 2 기본사회 그룹 + 추진과제 ④ ⑤ ⑥
+✅ 3 공직혁신 그룹 + 추진과제 ⑦ ⑧ ⑨
+✅ 4 공공 AX 그룹 + 추진과제 3개
+✅ 페이지 번호 - 5 -
+
+## 광범위 회귀 재검증 (Stage 1 + Stage 3 fix 통합)
+
+```
+TOTAL: pages=1502 same=1499 diff=3 samples=159
+diff list:
+  exam_social__hwp/exam_social_001.svg     (자연 해소, Stage 2 와 동일)
+  table-vpos-01__hwp/table-vpos-01_005.svg (의도된 수정)
+  table-vpos-01__hwpx/table-vpos-01_005.svg (의도된 수정)
+```
+
+Stage 3 fix (height_measurer 수정) 가 **추가 회귀를 일으키지 않음**. Stage 2 결과와 동일.
+
+`cargo test` 1192+ 테스트 전부 통과 (재실행 확인).
+
+## 보조 관찰 측정
+
+### 페이지 1 LAYOUT_OVERFLOW 4.1px — **본 수정의 효과 아님 (정정)**
+
+단계 1 보고서에서 "본 수정으로 자연 해소" 라 적었으나 정정 필요.
+
+base ref(`local/devel`, HEAD~3) 상태에서 직접 `export-svg` 실행 시 **LAYOUT_OVERFLOW 미발생**. 즉 base 자체에서 발생하지 않았으며, 첫 분석 시 발견된 4.1px overflow 는 작업 진입 직전의 `pr-task677` 브랜치 환경 차이로 인한 것이지 본 수정의 효과가 아님.
+
+→ 결론: 본 타스크 수정은 LAYOUT_OVERFLOW 에 영향이 없음. 단계 1 보고서의 해당 항목은 본 보고서에서 정정한다.
+
+### 페이지 2 / 페이지 3 hwp_used diff — 별개 결함, 본 수정 무관
+
+`dump-pages samples/table-vpos-01.hwpx` 결과:
+
+| 페이지 | used | hwp_used | diff | 본 수정 후 변화 |
+|--------|------|----------|------|----------------|
+| 1 | 913.8 | 863.4 | +50.4px | 변화 없음 |
+| 2 | 930.1 | 1722.0 | -791.9px | 변화 없음 |
+| 3 | 911.2 | 2569.5 | -1658.3px | 변화 없음 |
+
+본 타스크 수정으로 변화 없음. 별개 결함으로 분류, 후속 이슈 분리 권장.
+
+## 산출물
+
+- 코드 수정: `src/renderer/height_measurer.rs` (+13 / -9 라인) — commit `7d8cca27`
+- 검증 SVG: `/tmp/tvpos01_fix4/table-vpos-01_005.svg` (132,896 bytes)
+- 검증 PNG: `/tmp/tvpos01_png/p5_after4.png` (142,274 bytes)
+- 회귀 검증 결과: `/tmp/svg_diff_full_*` (1502 페이지)
+
+## DoD 최종 충족 현황
+
+| DoD | 항목 | 상태 |
+|-----|------|------|
+| 1 | pi=34 외부 표 외곽 그려짐 | ✅ — 권위 778.8px 영역에 nested 11×3 그리드 외곽선 정합 |
+| 2 | nested 1×1 헤더 텍스트 | ✅ |
+| 3 | nested 11×3 그리드 4그룹 + 12 추진과제 텍스트 | ✅ — 시각적으로 표시 (단계 1 만으로는 클립으로 가려졌음) |
+| 4 | PDF 권위본과 시각 정합 | ✅ — `rsvg-convert` 변환 결과 PDF 와 동등 |
+| 5 | 회귀 없음 | ✅ — 1502페이지 중 의도 변경 2건 + 자연 해소 1건 |
+| 6 | `cargo test` 통과 | ✅ — 1192+ 테스트 전부 |
+
+## 결론
+
+3단계로 본 타스크의 모든 DoD 시각/정량 충족. 최종 결과보고서 작성으로 진행.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -453,17 +453,21 @@ impl HeightMeasurer {
                 row_block_end: rbe,
             };
         }
-        // 1x1 래퍼 표 감지: 내부 표의 높이를 직접 측정
+        // 1x1 래퍼 표 감지: 내부 표의 높이를 직접 측정.
+        // 셀의 paragraphs 가 2개 이상이거나 paragraph 안에 nested 표 외 다른 control 이 섞인 경우,
+        // 첫 nested 표만 unwrap 하면 나머지 paragraph 의 컨텐츠(특히 또 다른 nested 표)가 누락된다.
         if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
             let cell = &table.cells[0];
-            let has_visible_text = cell.paragraphs.iter()
-                .any(|p| p.text.chars().any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n'));
-            if !has_visible_text {
-                if let Some(nested) = cell.paragraphs.iter()
-                    .flat_map(|p| p.controls.iter())
-                    .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
-                {
-                    return self.measure_table_impl(nested, para_index, control_index, styles, depth + 1);
+            if cell.paragraphs.len() == 1 {
+                let p = &cell.paragraphs[0];
+                let has_visible_text = p.text.chars()
+                    .any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n');
+                let only_one_nested_table = p.controls.len() == 1
+                    && matches!(p.controls.first(), Some(Control::Table(_)));
+                if !has_visible_text && only_one_nested_table {
+                    if let Some(Control::Table(t)) = p.controls.first() {
+                        return self.measure_table_impl(t.as_ref(), para_index, control_index, styles, depth + 1);
+                    }
                 }
             }
         }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -148,23 +148,27 @@ impl LayoutEngine {
         if table.cells.is_empty() {
             if depth == 0 { return y_start; } else { return 0.0; }
         }
-        // 1x1 래퍼 표 감지: 외곽 표를 무시하고 내부 표를 직접 렌더링
+        // 1x1 래퍼 표 감지: 외곽 표를 무시하고 내부 표를 직접 렌더링.
+        // 셀의 paragraphs 가 2개 이상이거나 paragraph 안에 nested 표 외 다른 control 이 섞인 경우,
+        // 첫 nested 표만 unwrap 하면 나머지 paragraph 의 컨텐츠(특히 또 다른 nested 표)가 누락된다.
         if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
             let cell = &table.cells[0];
-            let has_visible_text = cell.paragraphs.iter()
-                .any(|p| p.text.chars().any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n'));
-            if !has_visible_text {
-                if let Some(nested) = cell.paragraphs.iter()
-                    .flat_map(|p| p.controls.iter())
-                    .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })
-                {
-                    return self.layout_table(
-                        tree, col_node, nested,
-                        section_index, styles, col_area, y_start,
-                        bin_data_content, None, depth,
-                        table_meta, host_alignment, enclosing_cell_ctx, host_margin_left,
-                        host_margin_right, inline_x_override, nested_split, para_y,
-                    );
+            if cell.paragraphs.len() == 1 {
+                let p = &cell.paragraphs[0];
+                let has_visible_text = p.text.chars()
+                    .any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n');
+                let only_one_nested_table = p.controls.len() == 1
+                    && matches!(p.controls.first(), Some(Control::Table(_)));
+                if !has_visible_text && only_one_nested_table {
+                    if let Some(Control::Table(t)) = p.controls.first() {
+                        return self.layout_table(
+                            tree, col_node, t.as_ref(),
+                            section_index, styles, col_area, y_start,
+                            bin_data_content, None, depth,
+                            table_meta, host_alignment, enclosing_cell_ctx, host_margin_left,
+                            host_margin_right, inline_x_override, nested_split, para_y,
+                        );
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 요약

`samples/table-vpos-01.hwpx` 5쪽 마지막 큰 표(pi=34, \"정부혁신 4대 추진전략 / 12대 추진과제\")의 nested 11×3 그리드(4그룹 + 12 추진과제)가 SVG 출력에서 시각적으로 누락되는 결함을 수정합니다.

PDF 권위본 (`pdf/table-vpos-01-2022.pdf`) 5쪽과 시각 정합 회복.

## 결함 본질 (두 곳 동일 코드 결함)

외부 1×1 표 셀 안에 nested 표 2개 (1×1 헤더 + 11×3 그리드) 가 있는 구조 처리 시:

- `src/renderer/layout/table_layout.rs::layout_table()`
- `src/renderer/height_measurer.rs::measure_table_impl()`

두 곳 모두 1×1 래퍼 unwrap 로직이 \`flat_map(...).find_map(...)\` 으로 셀 paragraphs 전체를 훑어 첫 nested 표만 가져오는 패턴.

paragraphs 가 2개 이상이면 두 번째 nested 표가 통째 누락:
- layout_table: 외부 표가 nested 1×1 헤더로 unwrap → 11×3 그리드 누락
- measure_table: measured_table.row_heights 가 nested 1×1 헤더 height(57.72px) 로 잡힘 → cell-clip 이 작게 그려져 nested 11×3 셀(y=295~)이 클립 밖

두 결함이 결합되어 페이지 5 의 nested 11×3 그리드가 SVG 에 그려지지 않거나 클립으로 가려졌습니다.

## 수정

두 곳 모두 unwrap 조건을 다음 4가지 모두 충족하는 경우로 좁힘:
1. 외부 표 1×1 단일 셀 (현행)
2. **셀 paragraphs 가 정확히 1개**
3. **그 paragraph 의 control 이 정확히 1개의 nested table 만**
4. visible text 없음 (현행)

| Commit | 파일 | 라인 |
|--------|------|------|
| Stage 1 | \`src/renderer/layout/table_layout.rs\` | +15 / -7 |
| Stage 3 fix | \`src/renderer/height_measurer.rs\` | +13 / -9 |

## 검증

### 시각 정합 (DoD 1~4)

\`rsvg-convert\` 로 SVG → PNG 변환:

| 시점 | 페이지 5 PNG | nested 11×3 그리드 |
|------|------------|-------------------|
| 결함 (수정 전) | ❌ | 누락 |
| Stage 1 만 | 26 KB | 클립으로 가려짐 |
| Stage 1 + Stage 3 fix | **142 KB** | ✅ 완전 표시 (PDF 권위본 정합) |

### 광범위 회귀 (DoD 5)

159 샘플 / **1502 페이지** SVG byte 비교:
- 의도된 변경: \`table-vpos-01.{hwp,hwpx}\` 페이지 5
- 자연 해소: \`exam_social.hwp\` 페이지 1 (동일 결함이 paras=3 인 1×1 셀에도 영향, 외부 표 정상 렌더로 cell-clip 통합)
- **회귀 0건**

### 단위 테스트 (DoD 6)

\`cargo test\` **1192+ 테스트 전부 통과** (SVG 스냅샷 6건 포함)

## 보조 관찰 (별개 결함, 본 PR 범위 외)

- 페이지 2 hwp_used diff = -791.9px, 페이지 3 = -1658.3px — 본 수정과 무관, 후속 이슈 분리 권장
- 1×1 래퍼 unwrap 로직이 \`layout_table\` 과 \`height_measurer\` 두 곳에 중복 — 향후 공통 helper 추출 검토

## Test plan

- [x] \`cargo build --release\`
- [x] \`cargo test --release\` 전체 통과
- [x] \`samples/table-vpos-01.hwpx\` SVG 시각 정합 (PDF 권위본 비교)
- [x] 159 샘플 / 1502 페이지 회귀 검증 (회귀 0건)

closes #688

🤖 Generated with [Claude Code](https://claude.com/claude-code)