### PR TITLE
Task #204: 표 편집 Undo/Redo — 스냅샷 기반 이력 등록

### DIFF
--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -7,6 +7,10 @@ import { FormulaDialog } from '@/ui/formula-dialog';
 
 const inTable = (ctx: EditorContext) => ctx.inTable;
 
+function safeTableOp(fn: () => void, label: string): void {
+  try { fn(); } catch (e) { console.error(`[table] ${label} 실패:`, e); }
+}
+
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
   return {
     id,
@@ -30,7 +34,7 @@ export const tableCommands: CommandDef[] = [
       dialog.onApply = (rows, cols) => {
         const ih2 = services.getInputHandler();
         if (!ih2) return;
-        ih2.executeOperation({
+        safeTableOp(() => ih2.executeOperation({
           kind: 'snapshot',
           operationType: 'createTable',
           operation: (wasm) => {
@@ -41,14 +45,14 @@ export const tableCommands: CommandDef[] = [
                 paragraphIndex: 0,
                 charOffset: 0,
                 parentParaIndex: result.paraIdx,
-                controlIndex: 0,
+                controlIndex: result.controlIdx,
                 cellIndex: 0,
                 cellParaIndex: 0,
               };
             }
             return pos;
           },
-        });
+        }), '표 만들기');
       };
       dialog.show(params?.anchorEl as HTMLElement | undefined);
     },
@@ -107,14 +111,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'insertTableRow',
         operation: (wasm) => {
           wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row, false);
           return pos;
         },
-      });
+      }), '줄 추가');
     },
   },
   {
@@ -127,14 +131,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'insertTableRow',
         operation: (wasm) => {
           wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row, true);
           return pos;
         },
-      });
+      }), '줄 추가');
     },
   },
   {
@@ -148,14 +152,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'insertTableColumn',
         operation: (wasm) => {
           wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col, false);
           return pos;
         },
-      });
+      }), '칸 추가');
     },
   },
   {
@@ -168,14 +172,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'insertTableColumn',
         operation: (wasm) => {
           wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col, true);
           return pos;
         },
-      });
+      }), '칸 추가');
     },
   },
   {
@@ -188,14 +192,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'deleteTableRow',
         operation: (wasm) => {
           wasm.deleteTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row);
           return pos;
         },
-      });
+      }), '줄 지우기');
     },
   },
   {
@@ -209,14 +213,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'deleteTableColumn',
         operation: (wasm) => {
           wasm.deleteTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col);
           return pos;
         },
-      });
+      }), '칸 지우기');
     },
   },
   {
@@ -243,7 +247,7 @@ export const tableCommands: CommandDef[] = [
       dialog.onApply = (nRows, mCols, equalHeight, mergeFirst) => {
         const ih2 = services.getInputHandler();
         if (!ih2) return;
-        ih2.executeOperation({
+        safeTableOp(() => ih2.executeOperation({
           kind: 'snapshot',
           operationType: 'splitTableCell',
           operation: (wasm) => {
@@ -262,7 +266,7 @@ export const tableCommands: CommandDef[] = [
             }
             return pos;
           },
-        });
+        }), '셀 나누기');
         if (isMultiCell) ih2.exitCellSelectionMode?.();
       };
       dialog.show();
@@ -280,14 +284,14 @@ export const tableCommands: CommandDef[] = [
       const tableCtx = ih.getCellTableContext();
       if (!range || !tableCtx) return;
       if (range.startRow === range.endRow && range.startCol === range.endCol) return;
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'mergeTableCells',
         operation: (wasm) => {
           wasm.mergeTableCells(tableCtx.sec, tableCtx.ppi, tableCtx.ci, range.startRow, range.startCol, range.endRow, range.endCol);
           return ih.getCursorPosition();
         },
-      });
+      }), '셀 합치기');
       ih.exitCellSelectionMode();
     },
   },
@@ -300,26 +304,26 @@ export const tableCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedTableRef();
       if (ref) {
-        ih.executeOperation({
+        safeTableOp(() => ih.executeOperation({
           kind: 'snapshot',
           operationType: 'deleteTable',
           operation: (wasm) => {
             wasm.deleteTableControl(ref.sec, ref.ppi, ref.ci);
             return { sectionIndex: ref.sec, paragraphIndex: ref.ppi, charOffset: 0 };
           },
-        });
+        }), '표 지우기');
         return;
       }
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined) return;
-      ih.executeOperation({
+      safeTableOp(() => ih.executeOperation({
         kind: 'snapshot',
         operationType: 'deleteTable',
         operation: (wasm) => {
           wasm.deleteTableControl(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!);
           return { sectionIndex: pos.sectionIndex, paragraphIndex: pos.parentParaIndex!, charOffset: 0 };
         },
-      });
+      }), '표 지우기');
     },
   },
   {
@@ -345,7 +349,7 @@ export const tableCommands: CommandDef[] = [
       if (!props) return;
       let charOffset = 0;
       if (!props.hasCaption) {
-        ih.executeOperation({
+        safeTableOp(() => ih.executeOperation({
           kind: 'snapshot',
           operationType: 'toggleTableCaption',
           operation: (wasm) => {
@@ -353,7 +357,7 @@ export const tableCommands: CommandDef[] = [
             charOffset = result?.captionCharOffset ?? 3;
             return { sectionIndex: sec, paragraphIndex: ppi, charOffset: 0 };
           },
-        });
+        }), '캡션 넣기');
       } else {
         try {
           const len = services.wasm.getCellParagraphLength(sec, ppi, ci, 65534, 0);

--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -25,21 +25,18 @@ export const tableCommands: CommandDef[] = [
       const ih = services.getInputHandler();
       if (!ih) return;
       const pos = ih.getCursorPosition();
-      // 셀 내부에서는 사용 불가 (canExecute에서 걸리지만 방어)
       if (pos.parentParaIndex !== undefined) return;
       const dialog = new TableCreateDialog();
       dialog.onApply = (rows, cols) => {
-        try {
-          const result = services.wasm.createTable(
-            pos.sectionIndex, pos.paragraphIndex, pos.charOffset,
-            rows, cols,
-          );
-          if (result.ok) {
-            services.eventBus.emit('document-changed');
-            // 표 생성 후 첫 번째 셀로 커서 이동
-            const ih = services.getInputHandler();
-            if (ih) {
-              ih.moveCursorTo({
+        const ih2 = services.getInputHandler();
+        if (!ih2) return;
+        ih2.executeOperation({
+          kind: 'snapshot',
+          operationType: 'createTable',
+          operation: (wasm) => {
+            const result = wasm.createTable(pos.sectionIndex, pos.paragraphIndex, pos.charOffset, rows, cols);
+            if (result.ok) {
+              return {
                 sectionIndex: pos.sectionIndex,
                 paragraphIndex: 0,
                 charOffset: 0,
@@ -47,12 +44,11 @@ export const tableCommands: CommandDef[] = [
                 controlIndex: 0,
                 cellIndex: 0,
                 cellParaIndex: 0,
-              });
+              };
             }
-          }
-        } catch (e) {
-          console.error('표 만들기 실패:', e);
-        }
+            return pos;
+          },
+        });
       };
       dialog.show(params?.anchorEl as HTMLElement | undefined);
     },
@@ -111,12 +107,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.row, false);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('줄 추가 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'insertTableRow',
+        operation: (wasm) => {
+          wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row, false);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -129,12 +127,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.row, true);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('줄 추가 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'insertTableRow',
+        operation: (wasm) => {
+          wasm.insertTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row, true);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -148,12 +148,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.col, false);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('칸 추가 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'insertTableColumn',
+        operation: (wasm) => {
+          wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col, false);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -166,12 +168,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.col, true);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('칸 추가 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'insertTableColumn',
+        operation: (wasm) => {
+          wasm.insertTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col, true);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -184,12 +188,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.deleteTableRow(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.row);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('줄 지우기 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'deleteTableRow',
+        operation: (wasm) => {
+          wasm.deleteTableRow(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.row);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -203,12 +209,14 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const cellInfo = services.wasm.getCellInfo(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, pos.cellIndex);
-      try {
-        services.wasm.deleteTableColumn(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, cellInfo.col);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('칸 지우기 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'deleteTableColumn',
+        operation: (wasm) => {
+          wasm.deleteTableColumn(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, cellInfo.col);
+          return pos;
+        },
+      });
     },
   },
   {
@@ -233,27 +241,29 @@ export const tableCommands: CommandDef[] = [
 
       const dialog = new CellSplitDialog(isMerged);
       dialog.onApply = (nRows, mCols, equalHeight, mergeFirst) => {
-        try {
-          if (isMultiCell && range && tableCtx) {
-            // 다중 셀: 범위 내 각 셀을 개별 분할
-            services.wasm.splitTableCellsInRange(
-              tableCtx.sec, tableCtx.ppi, tableCtx.ci,
-              range.startRow, range.startCol, range.endRow, range.endCol,
-              nRows, mCols, equalHeight,
-            );
-            ih.exitCellSelectionMode?.();
-          } else {
-            // 단일 셀 분할
-            services.wasm.splitTableCellInto(
-              pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!,
-              cellInfo.row, cellInfo.col,
-              nRows, mCols, equalHeight, mergeFirst,
-            );
-          }
-          services.eventBus.emit('document-changed');
-        } catch (e) {
-          console.error('셀 나누기 실패:', e);
-        }
+        const ih2 = services.getInputHandler();
+        if (!ih2) return;
+        ih2.executeOperation({
+          kind: 'snapshot',
+          operationType: 'splitTableCell',
+          operation: (wasm) => {
+            if (isMultiCell && range && tableCtx) {
+              wasm.splitTableCellsInRange(
+                tableCtx.sec, tableCtx.ppi, tableCtx.ci,
+                range.startRow, range.startCol, range.endRow, range.endCol,
+                nRows, mCols, equalHeight,
+              );
+            } else {
+              wasm.splitTableCellInto(
+                pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!,
+                cellInfo.row, cellInfo.col,
+                nRows, mCols, equalHeight, mergeFirst,
+              );
+            }
+            return pos;
+          },
+        });
+        if (isMultiCell) ih2.exitCellSelectionMode?.();
       };
       dialog.show();
     },
@@ -270,13 +280,15 @@ export const tableCommands: CommandDef[] = [
       const tableCtx = ih.getCellTableContext();
       if (!range || !tableCtx) return;
       if (range.startRow === range.endRow && range.startCol === range.endCol) return;
-      try {
-        services.wasm.mergeTableCells(tableCtx.sec, tableCtx.ppi, tableCtx.ci, range.startRow, range.startCol, range.endRow, range.endCol);
-        ih.exitCellSelectionMode();
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('셀 합치기 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'mergeTableCells',
+        operation: (wasm) => {
+          wasm.mergeTableCells(tableCtx.sec, tableCtx.ppi, tableCtx.ci, range.startRow, range.startCol, range.endRow, range.endCol);
+          return ih.getCursorPosition();
+        },
+      });
+      ih.exitCellSelectionMode();
     },
   },
   {
@@ -286,26 +298,28 @@ export const tableCommands: CommandDef[] = [
     execute(services) {
       const ih = services.getInputHandler();
       if (!ih) return;
-      // 표 객체 선택 모드면 선택된 표 참조 사용
       const ref = ih.getSelectedTableRef();
       if (ref) {
-        try {
-          services.wasm.deleteTableControl(ref.sec, ref.ppi, ref.ci);
-          services.eventBus.emit('document-changed');
-        } catch (e) {
-          console.error('표 지우기 실패:', e);
-        }
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'deleteTable',
+          operation: (wasm) => {
+            wasm.deleteTableControl(ref.sec, ref.ppi, ref.ci);
+            return { sectionIndex: ref.sec, paragraphIndex: ref.ppi, charOffset: 0 };
+          },
+        });
         return;
       }
-      // 셀 내부에서 커맨드 실행
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined) return;
-      try {
-        services.wasm.deleteTableControl(pos.sectionIndex, pos.parentParaIndex, pos.controlIndex);
-        services.eventBus.emit('document-changed');
-      } catch (e) {
-        console.error('표 지우기 실패:', e);
-      }
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'deleteTable',
+        operation: (wasm) => {
+          wasm.deleteTableControl(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!);
+          return { sectionIndex: pos.sectionIndex, paragraphIndex: pos.parentParaIndex!, charOffset: 0 };
+        },
+      });
     },
   },
   {
@@ -331,11 +345,15 @@ export const tableCommands: CommandDef[] = [
       if (!props) return;
       let charOffset = 0;
       if (!props.hasCaption) {
-        try {
-          const result: any = services.wasm.setTableProperties(sec, ppi, ci, { hasCaption: true });
-          charOffset = result?.captionCharOffset ?? 3;
-          services.eventBus.emit('document-changed');
-        } catch (e) { console.error('표 캡션 생성 실패:', e); return; }
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'toggleTableCaption',
+          operation: (wasm) => {
+            const result: any = wasm.setTableProperties(sec, ppi, ci, { hasCaption: true });
+            charOffset = result?.captionCharOffset ?? 3;
+            return { sectionIndex: sec, paragraphIndex: ppi, charOffset: 0 };
+          },
+        });
       } else {
         try {
           const len = services.wasm.getCellParagraphLength(sec, ppi, ci, 65534, 0);


### PR DESCRIPTION
## 요약

표 관련 커맨드(생성/삭제/행열 삽입·삭제/셀 분할·병합/캡션)가 WASM을 직접 호출하여 히스토리를 우회하던 문제를 수정합니다.

기존 `SnapshotCommand` + `executeOperation` 인프라를 활용하여 모든 표 편집 작업에 스냅샷 기반 Undo/Redo를 적용했습니다.

## 접근 방식

이슈 #204 의 **B안 (스냅샷 + SnapshotCommand 일괄 래핑)** 을 채택했습니다.

- 각 표 편집 작업을 `ih.executeOperation({ kind: 'snapshot', ... })` 로 래핑
- 작업 전후 Document 스냅샷을 자동 저장 (`saveSnapshot` / `restoreSnapshot`)
- Undo: before 스냅샷 복원, Redo: after 스냅샷 복원
- 기존 텍스트 편집 Undo/Redo 스택과 자연스럽게 통합
- `document-changed` 이벤트는 `executeOperation` → `afterEdit()` 에서 자동 발행되므로 수동 호출 제거

## 대상 커맨드 (10건 + 캡션 1건)

| 커맨드 | 작업 |
|--------|------|
| `table:create` | 표 생성 (대화상자 콜백) |
| `table:insert-row-above` | 위쪽에 줄 추가 |
| `table:insert-row-below` | 아래쪽에 줄 추가 |
| `table:insert-col-left` | 왼쪽에 칸 추가 |
| `table:insert-col-right` | 오른쪽에 칸 추가 |
| `table:delete-row` | 줄 지우기 |
| `table:delete-col` | 칸 지우기 |
| `table:cell-split` | 셀 나누기 (대화상자 콜백) |
| `table:cell-merge` | 셀 합치기 |
| `table:delete` | 표 지우기 |
| `table:caption-toggle` | 캡션 넣기 |

## 범위 외

- **HwpCtrl(hwpctl) API 경로** (`hwpctl/actions/table-edit.ts`): HwpCtrl은 InputHandler의 히스토리에 접근하지 않으므로, HwpCtrl 경로의 Undo/Redo는 아키텍처 변경이 필요합니다 (별도 이슈).

## 검증

- `cargo test` — 전체 통과
- `cargo clippy -- -D warnings` — 경고 0건
- `tsc --noEmit` — 기존 WASM 모듈 타입 오류 외 신규 오류 없음

감사합니다.