### PR TITLE
Task #614: export-png --dpi 옵션 — PNG pHYs chunk 메타데이터

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -256,19 +256,22 @@ impl DocumentCore {
 /// pHYs chunk: 4-byte X ppm + 4-byte Y ppm + 1-byte unit(1=meter).
 #[cfg(not(target_arch = "wasm32"))]
 fn inject_png_phys(png: Vec<u8>, dpi: f64) -> Vec<u8> {
+    const PNG_SIGNATURE: [u8; 8] = [0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A];
+    const IHDR_DATA_LEN: usize = 13;
+
     let ppm = (dpi / 0.0254).round() as u32;
-    // PNG 구조: 8-byte signature + chunks (IHDR first, then others)
-    // 각 chunk: 4-byte length + 4-byte type + data + 4-byte CRC
-    if png.len() < 8 {
+    if png.len() < 8 || png[..8] != PNG_SIGNATURE {
         return png;
     }
-    let mut pos = 8; // signature 이후
-    // IHDR chunk 끝 위치 찾기
+    let pos = 8; // signature 이후
     if pos + 8 > png.len() {
         return png;
     }
     let ihdr_len = u32::from_be_bytes([png[pos], png[pos + 1], png[pos + 2], png[pos + 3]]) as usize;
-    let ihdr_end = pos + 4 + 4 + ihdr_len + 4; // length + type + data + CRC
+    if ihdr_len != IHDR_DATA_LEN || &png[pos + 4..pos + 8] != b"IHDR" {
+        return png;
+    }
+    let Some(ihdr_end) = pos.checked_add(4 + 4 + ihdr_len + 4) else { return png };
     if ihdr_end > png.len() {
         return png;
     }

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -201,8 +201,9 @@ impl DocumentCore {
 
         // scale 결정 우선순위:
         // 1. 명시 scale (사용자 직접 지정)
-        // 2. max_dimension + max_pixels 기반 자동 계산 (페이지가 두 한도 모두 안에 들어가도록)
-        // 3. 기본 1.0
+        // 2. max_dimension / VLM 기반 자동 계산
+        // 3. --dpi 만 지정 시 scale = dpi / 96.0 (#614)
+        // 4. 기본 1.0
         let scale = if let Some(s) = options.scale {
             s
         } else if effective_max_dim.is_some() || effective_max_pixels.is_some() {
@@ -224,11 +225,14 @@ impl DocumentCore {
             }
             // 1.0 초과 시는 페이지가 이미 충분히 작은 것이므로 1.0 으로 cap
             auto_scale.min(1.0).max(0.1)
+        } else if let Some(dpi) = options.dpi {
+            (dpi / 96.0).max(0.1)
         } else {
             1.0
         };
 
         raster_options.scale = scale;
+        raster_options.dpi = options.dpi;
         if let Some(max_dim) = effective_max_dim {
             raster_options.max_dimension = max_dim;
         }
@@ -236,10 +240,78 @@ impl DocumentCore {
             raster_options.max_pixels = max_pixels;
         }
 
-        SkiaLayerRenderer::new()
+        let png_bytes = SkiaLayerRenderer::new()
             .with_font_paths(&options.font_paths)
-            .render_png_with_options(&layer_tree, raster_options)
+            .render_png_with_options(&layer_tree, raster_options)?;
+
+        if let Some(dpi) = options.dpi {
+            Ok(inject_png_phys(png_bytes, dpi))
+        } else {
+            Ok(png_bytes)
+        }
     }
+}
+
+/// PNG 바이트에 pHYs chunk 를 삽입한다 (IHDR 직후, 첫 IDAT 직전).
+/// pHYs chunk: 4-byte X ppm + 4-byte Y ppm + 1-byte unit(1=meter).
+#[cfg(not(target_arch = "wasm32"))]
+fn inject_png_phys(png: Vec<u8>, dpi: f64) -> Vec<u8> {
+    let ppm = (dpi / 0.0254).round() as u32;
+    // PNG 구조: 8-byte signature + chunks (IHDR first, then others)
+    // 각 chunk: 4-byte length + 4-byte type + data + 4-byte CRC
+    if png.len() < 8 {
+        return png;
+    }
+    let mut pos = 8; // signature 이후
+    // IHDR chunk 끝 위치 찾기
+    if pos + 8 > png.len() {
+        return png;
+    }
+    let ihdr_len = u32::from_be_bytes([png[pos], png[pos + 1], png[pos + 2], png[pos + 3]]) as usize;
+    let ihdr_end = pos + 4 + 4 + ihdr_len + 4; // length + type + data + CRC
+    if ihdr_end > png.len() {
+        return png;
+    }
+
+    // pHYs chunk 구성 (9 bytes data)
+    let mut phys_data = Vec::with_capacity(9);
+    phys_data.extend_from_slice(&ppm.to_be_bytes()); // X pixels per unit
+    phys_data.extend_from_slice(&ppm.to_be_bytes()); // Y pixels per unit
+    phys_data.push(1); // unit = meter
+
+    let phys_type = b"pHYs";
+    let mut phys_chunk = Vec::with_capacity(4 + 4 + 9 + 4);
+    phys_chunk.extend_from_slice(&(9u32).to_be_bytes()); // length
+    phys_chunk.extend_from_slice(phys_type);
+    phys_chunk.extend_from_slice(&phys_data);
+    // CRC: type + data
+    let mut crc_input = Vec::with_capacity(4 + 9);
+    crc_input.extend_from_slice(phys_type);
+    crc_input.extend_from_slice(&phys_data);
+    let crc = png_crc32(&crc_input);
+    phys_chunk.extend_from_slice(&crc.to_be_bytes());
+
+    let mut result = Vec::with_capacity(png.len() + phys_chunk.len());
+    result.extend_from_slice(&png[..ihdr_end]);
+    result.extend_from_slice(&phys_chunk);
+    result.extend_from_slice(&png[ihdr_end..]);
+    result
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+fn png_crc32(data: &[u8]) -> u32 {
+    let mut crc: u32 = 0xFFFF_FFFF;
+    for &byte in data {
+        crc ^= byte as u32;
+        for _ in 0..8 {
+            if crc & 1 != 0 {
+                crc = (crc >> 1) ^ 0xEDB8_8320;
+            } else {
+                crc >>= 1;
+            }
+        }
+    }
+    crc ^ 0xFFFF_FFFF
 }
 
 /// PNG 내보내기 옵션 (export-png CLI / API 통합).
@@ -255,6 +327,9 @@ pub struct PngExportOptions {
     pub max_dimension: Option<i32>,
     /// VLM 프리셋. Claude / 향후 GPT-4V / Gemini / Qwen-VL / LLaVA 확장 (이슈 #613).
     pub vlm_target: Option<VlmTarget>,
+    /// DPI 메타데이터. PNG pHYs chunk 에 기록. 실제 래스터 픽셀 수에 영향 없음.
+    /// `scale` 미지정 시 `scale = dpi / 96.0` 자동 계산.
+    pub dpi: Option<f64>,
     /// 사용자 지정 폰트 디렉토리 (ttfs 등). SVG 의 `--font-path` 와 동일.
     pub font_paths: Vec<std::path::PathBuf>,
 }
@@ -2329,5 +2404,66 @@ mod tests {
         assert_eq!(core.get_bin_data(0), Some(&[0x01, 0x02, 0x03][..]));
         assert_eq!(core.get_bin_data(1), Some(&[0xAA, 0xBB][..]));
         assert_eq!(core.get_bin_data(2), None);
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn inject_png_phys_inserts_after_ihdr() {
+        // 최소 PNG: 8-byte signature + IHDR chunk (13 bytes data)
+        let mut png = Vec::new();
+        png.extend_from_slice(&[0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A]); // signature
+        // IHDR: length=13
+        png.extend_from_slice(&13u32.to_be_bytes());
+        png.extend_from_slice(b"IHDR");
+        png.extend_from_slice(&[0u8; 13]); // dummy IHDR data
+        let ihdr_crc = super::png_crc32(&{
+            let mut v = Vec::new();
+            v.extend_from_slice(b"IHDR");
+            v.extend_from_slice(&[0u8; 13]);
+            v
+        });
+        png.extend_from_slice(&ihdr_crc.to_be_bytes());
+        let ihdr_end = png.len(); // 8 + 4 + 4 + 13 + 4 = 33
+        // IDAT dummy
+        png.extend_from_slice(&4u32.to_be_bytes());
+        png.extend_from_slice(b"IDAT");
+        png.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+        let idat_crc = super::png_crc32(&{
+            let mut v = Vec::new();
+            v.extend_from_slice(b"IDAT");
+            v.extend_from_slice(&[0xDE, 0xAD, 0xBE, 0xEF]);
+            v
+        });
+        png.extend_from_slice(&idat_crc.to_be_bytes());
+
+        let result = super::inject_png_phys(png.clone(), 300.0);
+
+        // pHYs chunk 삽입 확인: IHDR 직후에 pHYs 가 위치
+        assert_eq!(&result[ihdr_end + 4..ihdr_end + 8], b"pHYs");
+        // pHYs data length = 9
+        let phys_len = u32::from_be_bytes([
+            result[ihdr_end], result[ihdr_end + 1],
+            result[ihdr_end + 2], result[ihdr_end + 3],
+        ]);
+        assert_eq!(phys_len, 9);
+        // 300 DPI → 11811 ppm (300 / 0.0254 = 11811.02...)
+        let ppm = u32::from_be_bytes([
+            result[ihdr_end + 8], result[ihdr_end + 9],
+            result[ihdr_end + 10], result[ihdr_end + 11],
+        ]);
+        assert_eq!(ppm, 11811);
+        // unit = 1 (meter)
+        assert_eq!(result[ihdr_end + 16], 1);
+        // IDAT 는 pHYs 뒤에 보존
+        let phys_chunk_size = 4 + 4 + 9 + 4; // 21
+        let idat_pos = ihdr_end + phys_chunk_size;
+        assert_eq!(&result[idat_pos + 4..idat_pos + 8], b"IDAT");
+    }
+
+    #[cfg(not(target_arch = "wasm32"))]
+    #[test]
+    fn png_crc32_known_value() {
+        let crc = super::png_crc32(b"IHDR");
+        assert_eq!(crc, 0xA8A1_AE0A);
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,8 @@ fn print_help() {
     println!("      --scale <배율>          렌더링 배율 (기본: 1.0)");
     println!("      --max-dimension <픽셀>  한 변 최대 픽셀 (longest edge). VLM 입력 한도용.");
     println!("                              명시 --scale 이 없으면 자동 scale 계산 (페이지 → 한도 안)");
+    println!("      --dpi <값>              DPI 메타데이터 (PNG pHYs chunk). 실제 픽셀 수 무관.");
+    println!("                              --scale 미지정 시 scale = dpi/96 자동 계산");
     println!("      --vlm-target <프리셋>   VLM 입력 프리셋 (현재: claude)");
     println!("                              claude: 1568 px / 1.15 MP (Claude Vision 정합)");
     println!("                              다른 VLM (gpt4v/gemini/qwen-vl/llava) 은 이슈 #613 후속");
@@ -405,6 +407,7 @@ fn export_png(args: &[String]) {
     let mut scale: Option<f64> = None;
     let mut max_dimension: Option<i32> = None;
     let mut vlm_target: Option<VlmTarget> = None;
+    let mut dpi: Option<f64> = None;
 
     let mut i = 1;
     while i < args.len() {
@@ -472,6 +475,21 @@ fn export_png(args: &[String]) {
                     return;
                 }
             }
+            "--dpi" => {
+                if i + 1 < args.len() {
+                    match args[i + 1].parse::<f64>() {
+                        Ok(d) if d.is_finite() && d > 0.0 => dpi = Some(d),
+                        _ => {
+                            eprintln!("오류: --dpi 값이 올바르지 않습니다 (양수 실수 필요).");
+                            return;
+                        }
+                    }
+                    i += 2;
+                } else {
+                    eprintln!("오류: --dpi 뒤에 DPI 값이 필요합니다.");
+                    return;
+                }
+            }
             "--vlm-target" => {
                 if i + 1 < args.len() {
                     match VlmTarget::from_str(&args[i + 1]) {
@@ -499,6 +517,7 @@ fn export_png(args: &[String]) {
         scale,
         max_dimension,
         vlm_target,
+        dpi,
         font_paths: font_paths.clone(),
     };
 
@@ -552,7 +571,8 @@ fn export_png(args: &[String]) {
     for page_num in &pages {
         let has_options = png_options.scale.is_some()
             || png_options.max_dimension.is_some()
-            || png_options.vlm_target.is_some();
+            || png_options.vlm_target.is_some()
+            || png_options.dpi.is_some();
         let result = if has_options {
             core.render_page_png_native_with_export_options(*page_num, &png_options)
         } else if !font_paths.is_empty() {


### PR DESCRIPTION
## 요약

`export-png` 명령에 `--dpi <값>` 옵션을 추가합니다.

- PNG `pHYs` chunk 에 DPI 메타데이터를 삽입하여 인쇄 워크플로우에서 크기 힌트를 제공합니다
- `--scale` 미지정 시 `scale = dpi / 96.0` 자동 계산 (예: `--dpi 300` → scale 3.125)
- 실제 래스터 픽셀 수에는 영향 없음 (메타데이터 전용)

## 변경 사항

- `PngExportOptions` 에 `dpi: Option<f64>` 필드 추가
- CLI `--dpi <값>` 옵션 파싱 + 도움말 갱신
- Skia PNG 인코딩 후 `pHYs` chunk 후처리 삽입 (IHDR 직후, PNG spec §11.3.5.3)
- CRC32 자체 구현 (외부 의존성 없음)
- 단위 테스트: pHYs 삽입 위치/PPM 값 검증, CRC32 known-value 검증

## 사용 예시

```bash
rhwp export-png input.hwp --dpi 300           # scale 3.125 자동, 300 DPI 메타데이터
rhwp export-png input.hwp --scale 2 --dpi 150 # scale 2 명시, 150 DPI 메타데이터
```

## 테스트

```bash
cargo test && cargo clippy -- -D warnings  # 0 failed, 0 warnings
```

Closes #614

감사합니다.