### PR TITLE
Task #613: export-png VLM 프리셋 확장 (GPT-4V / Gemini / Qwen-VL / LLaVA)

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -260,13 +260,21 @@ pub struct PngExportOptions {
 }
 
 /// VLM (Vision-Language Model) 입력 사양 프리셋.
-///
-/// 본 사이클은 Claude Vision 만 지원. 다른 provider 는 이슈 #613 후속 task.
 #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum VlmTarget {
     /// Claude Vision (Anthropic): longest edge ≤1568 px, ≤1.15 MP.
     Claude,
+    /// GPT-4V low detail (OpenAI): 512×512 고정.
+    Gpt4vLow,
+    /// GPT-4V high detail (OpenAI): 768×2000 tile 기반.
+    Gpt4vHigh,
+    /// Gemini (Google): longest edge ≤3072 px.
+    Gemini,
+    /// Qwen-VL (Alibaba): longest edge ≤2240 px, 28×28 patch 기반.
+    QwenVl,
+    /// LLaVA / 기타 OSS (CLIP backbone): longest edge ≤672 px.
+    Llava,
 }
 
 #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
@@ -275,15 +283,29 @@ impl VlmTarget {
     pub fn constraints(&self) -> (i32, u64) {
         match self {
             VlmTarget::Claude => (1568, 1_150_000),
+            VlmTarget::Gpt4vLow => (512, 262_144),
+            VlmTarget::Gpt4vHigh => (2000, 1_536_000),
+            VlmTarget::Gemini => (3072, 9_437_184),
+            VlmTarget::QwenVl => (2240, 5_017_600),
+            VlmTarget::Llava => (672, 451_584),
         }
     }
 
     /// CLI 옵션 문자열 → VlmTarget 변환.
     pub fn from_str(s: &str) -> Option<Self> {
-        match s.to_lowercase().as_str() {
+        match s.to_lowercase().replace('-', "_").as_str() {
             "claude" => Some(VlmTarget::Claude),
+            "gpt4v_low" | "gpt4v-low" => Some(VlmTarget::Gpt4vLow),
+            "gpt4v_high" | "gpt4v-high" | "gpt4v" => Some(VlmTarget::Gpt4vHigh),
+            "gemini" => Some(VlmTarget::Gemini),
+            "qwen_vl" | "qwen-vl" | "qwen" => Some(VlmTarget::QwenVl),
+            "llava" => Some(VlmTarget::Llava),
             _ => None,
         }
+    }
+
+    pub fn all_names() -> &'static str {
+        "claude, gpt4v-low, gpt4v-high, gemini, qwen-vl, llava"
     }
 }
 
@@ -2329,5 +2351,40 @@ mod tests {
         assert_eq!(core.get_bin_data(0), Some(&[0x01, 0x02, 0x03][..]));
         assert_eq!(core.get_bin_data(1), Some(&[0xAA, 0xBB][..]));
         assert_eq!(core.get_bin_data(2), None);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    #[test]
+    fn vlm_target_from_str_all_variants() {
+        use super::VlmTarget;
+        assert_eq!(VlmTarget::from_str("claude"), Some(VlmTarget::Claude));
+        assert_eq!(VlmTarget::from_str("gpt4v-low"), Some(VlmTarget::Gpt4vLow));
+        assert_eq!(VlmTarget::from_str("gpt4v_low"), Some(VlmTarget::Gpt4vLow));
+        assert_eq!(VlmTarget::from_str("gpt4v-high"), Some(VlmTarget::Gpt4vHigh));
+        assert_eq!(VlmTarget::from_str("gpt4v"), Some(VlmTarget::Gpt4vHigh));
+        assert_eq!(VlmTarget::from_str("gemini"), Some(VlmTarget::Gemini));
+        assert_eq!(VlmTarget::from_str("qwen-vl"), Some(VlmTarget::QwenVl));
+        assert_eq!(VlmTarget::from_str("qwen_vl"), Some(VlmTarget::QwenVl));
+        assert_eq!(VlmTarget::from_str("qwen"), Some(VlmTarget::QwenVl));
+        assert_eq!(VlmTarget::from_str("llava"), Some(VlmTarget::Llava));
+        assert_eq!(VlmTarget::from_str("CLAUDE"), Some(VlmTarget::Claude));
+        assert_eq!(VlmTarget::from_str("unknown"), None);
+    }
+
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    #[test]
+    fn vlm_target_constraints_are_sane() {
+        use super::VlmTarget;
+        let targets = [
+            VlmTarget::Claude, VlmTarget::Gpt4vLow, VlmTarget::Gpt4vHigh,
+            VlmTarget::Gemini, VlmTarget::QwenVl, VlmTarget::Llava,
+        ];
+        for t in &targets {
+            let (edge, pixels) = t.constraints();
+            assert!(edge > 0, "{:?} edge should be positive", t);
+            assert!(pixels > 0, "{:?} pixels should be positive", t);
+            assert!((edge as u64) * (edge as u64) >= pixels,
+                "{:?} max_pixels should be reachable within edge", t);
+        }
     }
 }

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -292,20 +292,21 @@ impl VlmTarget {
     }
 
     /// CLI 옵션 문자열 → VlmTarget 변환.
+    /// 하이픈/밑줄 정규화 후 매칭. `gpt4v`/`qwen` 등 축약 별칭도 허용.
     pub fn from_str(s: &str) -> Option<Self> {
         match s.to_lowercase().replace('-', "_").as_str() {
             "claude" => Some(VlmTarget::Claude),
-            "gpt4v_low" | "gpt4v-low" => Some(VlmTarget::Gpt4vLow),
-            "gpt4v_high" | "gpt4v-high" | "gpt4v" => Some(VlmTarget::Gpt4vHigh),
+            "gpt4v_low" => Some(VlmTarget::Gpt4vLow),
+            "gpt4v_high" | "gpt4v" => Some(VlmTarget::Gpt4vHigh),
             "gemini" => Some(VlmTarget::Gemini),
-            "qwen_vl" | "qwen-vl" | "qwen" => Some(VlmTarget::QwenVl),
+            "qwen_vl" | "qwen" => Some(VlmTarget::QwenVl),
             "llava" => Some(VlmTarget::Llava),
             _ => None,
         }
     }
 
     pub fn all_names() -> &'static str {
-        "claude, gpt4v-low, gpt4v-high, gemini, qwen-vl, llava"
+        "claude, gpt4v-low, gpt4v-high (또는 gpt4v), gemini, qwen-vl (또는 qwen), llava"
     }
 }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,9 +66,13 @@ fn print_help() {
     println!("      --scale <배율>          렌더링 배율 (기본: 1.0)");
     println!("      --max-dimension <픽셀>  한 변 최대 픽셀 (longest edge). VLM 입력 한도용.");
     println!("                              명시 --scale 이 없으면 자동 scale 계산 (페이지 → 한도 안)");
-    println!("      --vlm-target <프리셋>   VLM 입력 프리셋 (현재: claude)");
-    println!("                              claude: 1568 px / 1.15 MP (Claude Vision 정합)");
-    println!("                              다른 VLM (gpt4v/gemini/qwen-vl/llava) 은 이슈 #613 후속");
+    println!("      --vlm-target <프리셋>   VLM 입력 프리셋:");
+    println!("                              claude:     1568 px / 1.15 MP (Claude Vision)");
+    println!("                              gpt4v-low:  512 px (GPT-4V low detail)");
+    println!("                              gpt4v-high: 2000 px / 1.54 MP (GPT-4V high detail)");
+    println!("                              gemini:     3072 px (Google Gemini)");
+    println!("                              qwen-vl:    2240 px (Qwen-VL)");
+    println!("                              llava:      672 px (LLaVA / OSS CLIP)");
     println!();
     println!("  export-text <파일.hwp> [옵션]");
     println!("      페이지별 텍스트를 TXT로 내보내기");
@@ -477,8 +481,10 @@ fn export_png(args: &[String]) {
                     match VlmTarget::from_str(&args[i + 1]) {
                         Some(t) => vlm_target = Some(t),
                         None => {
-                            eprintln!("오류: --vlm-target 값이 올바르지 않습니다 (지원: claude).");
-                            eprintln!("       다른 VLM 프리셋 (gpt4v / gemini / qwen-vl / llava) 은 이슈 #613 후속 task.");
+                            eprintln!(
+                                "오류: --vlm-target 값이 올바르지 않습니다 (지원: {}).",
+                                VlmTarget::all_names()
+                            );
                             return;
                         }
                     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,12 +66,12 @@ fn print_help() {
     println!("      --scale <배율>          렌더링 배율 (기본: 1.0)");
     println!("      --max-dimension <픽셀>  한 변 최대 픽셀 (longest edge). VLM 입력 한도용.");
     println!("                              명시 --scale 이 없으면 자동 scale 계산 (페이지 → 한도 안)");
-    println!("      --vlm-target <프리셋>   VLM 입력 프리셋:");
+    println!("      --vlm-target <프리셋>   VLM 입력 프리셋 (하이픈/밑줄 모두 허용):");
     println!("                              claude:     1568 px / 1.15 MP (Claude Vision)");
     println!("                              gpt4v-low:  512 px (GPT-4V low detail)");
-    println!("                              gpt4v-high: 2000 px / 1.54 MP (GPT-4V high detail)");
+    println!("                              gpt4v-high: 2000 px / 1.54 MP (GPT-4V high, 별칭: gpt4v)");
     println!("                              gemini:     3072 px (Google Gemini)");
-    println!("                              qwen-vl:    2240 px (Qwen-VL)");
+    println!("                              qwen-vl:    2240 px (Qwen-VL, 별칭: qwen)");
     println!("                              llava:      672 px (LLaVA / OSS CLIP)");
     println!();
     println!("  export-text <파일.hwp> [옵션]");


### PR DESCRIPTION
## 요약

`export-png --vlm-target` 옵션을 6종 VLM provider 프리셋으로 확장합니다.

## 추가된 프리셋

| 프리셋 | 한 변 한도 | 최대 픽셀 | 비고 |
|--------|-----------|----------|------|
| `claude` | 1568 px | 1.15 MP | 기존 (변경 없음) |
| `gpt4v-low` | 512 px | 262K px | GPT-4V low detail |
| `gpt4v-high` | 2000 px | 1.54 MP | GPT-4V high detail (tile 기반) |
| `gemini` | 3072 px | 9.44 MP | Google Gemini |
| `qwen-vl` | 2240 px | 5.02 MP | Qwen-VL (28×28 patch) |
| `llava` | 672 px | 452K px | LLaVA / CLIP backbone OSS |

## 변경 사항

- `VlmTarget` enum 확장 (1 → 6 variants)
- `constraints()` 메서드에 각 provider 별 한도 추가
- `from_str()` 에 대소문자/하이픈/밑줄 유연 매칭
- CLI 도움말 갱신 (각 프리셋 한 줄 설명)
- 단위 테스트: from_str 전 변형 파싱 + constraints 정합성 검증

## 사용 예시

```bash
rhwp export-png input.hwp --vlm-target gemini
rhwp export-png input.hwp --vlm-target gpt4v-high
rhwp export-png input.hwp --vlm-target llava
```

## 테스트

```bash
cargo test && cargo clippy -- -D warnings  # 0 failed, 0 warnings
```

Closes #613

감사합니다.