### PR TITLE
pua_oldhangul U+F53A 매핑 제거 — hwpspec '매핑 표 외' 정합

### DIFF
--- a/src/renderer/pua_oldhangul.rs
+++ b/src/renderer/pua_oldhangul.rs
@@ -25,7 +25,7 @@
 //! 5,660 매핑 (U+E0BC ~ U+F8F7), 출력 자모는 Hangul Jamo (U+1100-11FF)
 //! + Extended-A (U+A960-A97F) + Extended-B (U+D7B0-D7FF).
 
-/// 매핑 표 크기: 5660 entries.
+/// 매핑 표 크기: 5659 entries.
 ///
 /// (PUA 코드포인트, 자모 시퀀스) 정렬된 정적 배열. 이진 검색으로 룩업.
 static PUA_OLDHANGUL_MAP: &[(u32, &[char])] = &[
@@ -5019,7 +5019,7 @@ static PUA_OLDHANGUL_MAP: &[(u32, &[char])] = &[
     (0xF537, &['\u{1112}', '\u{119E}']),
     (0xF538, &['\u{1112}', '\u{119E}', '\u{11A8}']),
     (0xF539, &['\u{1112}', '\u{119E}', '\u{11C3}']),
-    (0xF53A, &['\u{1112}', '\u{119E}', '\u{11AB}']),
+    // 0xF53A 제거: hwpspec 매핑 표 "Basic-out (매핑 표 외)" — 한컴 정답지와 정합 (#615)
     (0xF53B, &['\u{1112}', '\u{119E}', '\u{11AE}']),
     (0xF53C, &['\u{1112}', '\u{119E}', '\u{11AF}']),
     (0xF53D, &['\u{1112}', '\u{119E}', '\u{11B0}']),
@@ -5713,7 +5713,7 @@ mod tests {
 
     #[test]
     fn test_map_size() {
-        assert_eq!(PUA_OLDHANGUL_MAP.len(), 5660);
+        assert_eq!(PUA_OLDHANGUL_MAP.len(), 5659);
     }
 
     #[test]
@@ -5765,6 +5765,24 @@ mod tests {
                 assert!(
                     !is_pua_old_hangul(ch),
                     "Task #509 bullet U+{:04X} 가 PUA 옛한글 매핑 표에 충돌",
+                    cp
+                );
+            }
+        }
+    }
+
+    #[test]
+    fn test_hwpspec_unmapped_codepoints_not_in_table() {
+        // hwpspec "매핑 표 외" (Basic-out) 코드포인트는 pua_oldhangul 매핑에 없어야 함.
+        // 한컴 정답지가 매핑 미지원인 영역을 임의 변환하면 시각 정합 불일치 발생 (#615).
+        let unmapped_basic_out: &[u32] = &[
+            0xF53A, // Basic-out, hwpspec, (매핑 표 외)
+        ];
+        for &cp in unmapped_basic_out {
+            if let Some(ch) = char::from_u32(cp) {
+                assert!(
+                    map_pua_old_hangul(ch).is_none(),
+                    "hwpspec '매핑 표 외' U+{:04X} 가 pua_oldhangul 매핑 표에 존재 — 제거 필요",
                     cp
                 );
             }

--- a/src/renderer/pua_oldhangul.rs
+++ b/src/renderer/pua_oldhangul.rs
@@ -1,4 +1,6 @@
 // 자동 생성 — scripts/gen_pua_oldhangul_rs.py 로 재생성
+// 주의: hwpspec "매핑 표 외" 코드포인트(0xF53A 등)는 수동 제거됨 (#615).
+// 재생성 시 test_hwpspec_unmapped_codepoints_not_in_table 테스트가 재삽입을 감지함.
 // 원본 데이터: KTUG HanyangPuaTableProject (Public Domain)
 // https://github.com/mete0r/hypua2jamo/blob/master/data/hypua2jamocomposed.txt
 
@@ -22,7 +24,7 @@
 //! [KTUG (Korean TeX Users Group) HanyangPuaTableProject]
 //! (http://faq.ktug.or.kr/mywiki/HanyangPuaTableProject) — Public Domain.
 //!
-//! 5,660 매핑 (U+E0BC ~ U+F8F7), 출력 자모는 Hangul Jamo (U+1100-11FF)
+//! 5,659 매핑 (U+E0BC ~ U+F8F7), 출력 자모는 Hangul Jamo (U+1100-11FF)
 //! + Extended-A (U+A960-A97F) + Extended-B (U+D7B0-D7FF).
 
 /// 매핑 표 크기: 5659 entries.


### PR DESCRIPTION
## 변경 사항

`pua_oldhangul.rs`에서 U+F53A 항목을 제거합니다.

- hwpspec 매핑 표에서 U+F53A는 `Basic-out, (매핑 표 외)`로 명시되어 한컴 정답지가 매핑을 지원하지 않는 코드포인트
- 기존 코드는 자모 시퀀스 `ᄒᆞᆫ`으로 임의 변환하여 한컴 정답지(빈 공백)와 시각 정합 불일치 발생
- 매핑 제거 후 한컴 정답지와 동일하게 빈 공백 출력으로 정합

## 옵션 A + B 모두 반영

- **옵션A**: U+F53A 항목 제거 (단일 정합)
- **옵션B**: hwpspec "매핑 표 외" 코드포인트 교차 검증 테스트 추가 — BMP PUA 범위에서는 U+F53A가 유일한 "매핑 표 외" 항목으로 확인됨

## 테스트

- `cargo test --lib -- pua`: 13 passed (신규 테스트 포함)
- `cargo clippy -- -D warnings`: 경고 없음
- 신규 테스트 `test_hwpspec_unmapped_codepoints_not_in_table`: hwpspec "매핑 표 외" 코드포인트가 매핑 표에 없는지 검증 (재발 방지)

Closes #615

감사합니다.