### PR TITLE
수식 편집 UI 개선: 듀얼 모드, 자동완성, 탭 기반 템플릿

### DIFF
--- a/rhwp-studio/src/styles/dialogs.css
+++ b/rhwp-studio/src/styles/dialogs.css
@@ -458,12 +458,54 @@
 
 /* ── 수식 편집 대화상자 ────────────────────────── */
 .eq-dialog {
-  width: 520px;
+  width: 560px;
 }
 .eq-body {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+/* 모드 토글 */
+.eq-mode-btn {
+  margin-left: auto;
+  margin-right: 8px;
+  padding: 2px 10px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  background: var(--color-accent-bg);
+  cursor: pointer;
+  font-size: 11px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+}
+.eq-mode-btn:hover {
+  background: var(--color-primary);
+  color: #fff;
+}
+/* 탭 */
+.eq-tabs {
+  display: flex;
+  gap: 1px;
+  border-bottom: 1px solid var(--color-border-lighter);
+}
+.eq-tab {
+  padding: 4px 10px;
+  border: 1px solid transparent;
+  border-bottom: none;
+  border-radius: 3px 3px 0 0;
+  background: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  color: var(--color-text-secondary);
+}
+.eq-tab:hover {
+  background: var(--color-accent-bg);
+}
+.eq-tab-active {
+  background: var(--color-surface);
+  border-color: var(--color-border-lighter);
+  color: var(--color-text);
+  font-weight: 600;
 }
 /* 도구 모음 */
 .eq-toolbar {
@@ -473,7 +515,9 @@
   padding: 4px;
   background: var(--color-bg);
   border: 1px solid var(--color-border-lighter);
-  border-radius: 3px;
+  border-top: none;
+  border-radius: 0 0 3px 3px;
+  min-height: 30px;
 }
 .eq-toolbar-btn {
   min-width: 28px;
@@ -490,10 +534,71 @@
   background: var(--color-accent-bg);
   border-color: var(--color-primary);
 }
-.eq-toolbar-sep {
-  width: 1px;
-  margin: 2px 3px;
-  background: #c0c0c0;
+/* 기호 검색 */
+.eq-search-row {
+  position: relative;
+}
+.eq-search-input {
+  width: 100%;
+  padding: 4px 8px;
+  border: 1px solid var(--color-border);
+  border-radius: 3px;
+  font-size: var(--font-size-sm);
+  box-sizing: border-box;
+}
+.eq-search-input:focus {
+  border-color: var(--color-primary);
+  outline: none;
+}
+.eq-search-results {
+  position: absolute;
+  top: 100%;
+  left: 0;
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 0 0 3px 3px;
+  max-height: 160px;
+  overflow-y: auto;
+  z-index: 10;
+}
+.eq-search-result-btn {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  width: 100%;
+  padding: 4px 8px;
+  border: none;
+  background: none;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+  text-align: left;
+}
+.eq-search-result-btn:hover {
+  background: var(--color-accent-bg);
+}
+.eq-sr-display {
+  font-size: 16px;
+  min-width: 20px;
+  text-align: center;
+}
+.eq-sr-name {
+  color: var(--color-text-secondary);
+  font-family: 'Consolas', monospace;
+  font-size: 11px;
+}
+/* LaTeX 전환 힌트 */
+.eq-latex-hint {
+  padding: 4px 8px;
+  background: #fffbea;
+  border: 1px solid #f0d060;
+  border-radius: 3px;
+  font-size: var(--font-size-sm);
+  color: #7a6200;
+}
+.eq-latex-hint a {
+  color: #2563eb;
+  text-decoration: underline;
 }
 /* 미리보기 */
 .eq-preview {
@@ -521,7 +626,10 @@
 .eq-preview-error {
   color: #c44;
 }
-/* 스크립트 입력 */
+/* 스크립트 입력 + 자동완성 */
+.eq-script-wrap {
+  position: relative;
+}
 .eq-script {
   width: 100%;
   min-height: 72px;
@@ -536,6 +644,45 @@
 .eq-script:focus {
   border-color: var(--color-primary);
   outline: none;
+}
+.eq-autocomplete {
+  position: absolute;
+  bottom: 100%;
+  left: 0;
+  right: 0;
+  background: var(--color-surface);
+  border: 1px solid var(--color-border-dark);
+  border-radius: 3px 3px 0 0;
+  max-height: 180px;
+  overflow-y: auto;
+  z-index: 10;
+  box-shadow: 0 -2px 8px rgba(0,0,0,0.12);
+}
+.eq-ac-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 4px 8px;
+  cursor: pointer;
+  font-size: var(--font-size-sm);
+}
+.eq-ac-item:hover,
+.eq-ac-selected {
+  background: var(--color-accent-bg);
+}
+.eq-ac-display {
+  font-size: 15px;
+  min-width: 20px;
+  text-align: center;
+}
+.eq-ac-name {
+  font-family: 'Consolas', monospace;
+  font-size: 12px;
+}
+.eq-ac-group {
+  margin-left: auto;
+  color: var(--color-text-placeholder);
+  font-size: 10px;
 }
 /* 속성 행 */
 .eq-props-row {

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -17,7 +17,7 @@ type InputMode = 'hwp' | 'latex';
 interface TemplateEntry { label: string; hwp: string; latex: string }
 interface TemplateGroup { id: string; name: string; items: TemplateEntry[] }
 
-interface CommandEntry { name: string; display: string; insert: string; group: string }
+interface CommandEntry { name: string; display: string; hwpInsert: string; latexInsert: string; group: string }
 
 const TEMPLATE_GROUPS: TemplateGroup[] = [
   { id: 'struct', name: '구조', items: [
@@ -182,7 +182,9 @@ function buildCommandList(): CommandEntry[] {
   const cmds: CommandEntry[] = [];
   for (const grp of TEMPLATE_GROUPS) {
     for (const t of grp.items) {
-      cmds.push({ name: t.hwp.split(/[\s{}_^]/)[0], display: t.label, insert: t.hwp, group: grp.name });
+      const parts = t.hwp.split(/[\s{}_^]/);
+      const name = parts.find(p => p.length > 0) || t.label;
+      cmds.push({ name, display: t.label, hwpInsert: t.hwp, latexInsert: t.latex, group: grp.name });
     }
   }
   return cmds;
@@ -540,10 +542,10 @@ export class EquationEditorDialog {
     const pos = ta.selectionStart;
     const text = ta.value;
     const before = text.substring(0, pos);
-    const match = before.match(/([a-zA-Z]+)$/);
+    const match = before.match(/(\\?[a-zA-Z]+)$/);
     if (!match) return;
     const wordStart = pos - match[1].length;
-    const script = this.mode === 'hwp' ? cmd.insert : (cmd.insert.startsWith('\\') ? cmd.insert : '\\' + cmd.insert);
+    const script = this.mode === 'hwp' ? cmd.hwpInsert : cmd.latexInsert;
     ta.value = text.substring(0, wordStart) + script + text.substring(pos);
     const newPos = wordStart + script.length;
     ta.selectionStart = newPos;
@@ -603,7 +605,7 @@ export class EquationEditorDialog {
       btn.className = 'eq-search-result-btn';
       btn.innerHTML = `<span class="eq-sr-display">${cmd.display}</span><span class="eq-sr-name">${cmd.name}</span>`;
       btn.addEventListener('click', () => {
-        const script = this.mode === 'hwp' ? cmd.insert : (cmd.insert.startsWith('\\') ? cmd.insert : '\\' + cmd.insert);
+        const script = this.mode === 'hwp' ? cmd.hwpInsert : cmd.latexInsert;
         this.insertTemplate(script);
         this.searchInput.value = '';
         this.searchResults.style.display = 'none';

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -5,48 +5,190 @@ import { appendSvgMarkup } from './dom-utils';
 
 /**
  * 수식 편집 대화상자
- * - textarea로 수식 스크립트 편집
- * - WASM renderEquationPreview()로 실시간 SVG 미리보기
- * - 도구 모음 버튼으로 템플릿 삽입
+ * - 듀얼 모드: HWP 네이티브 ↔ LaTeX 입력
+ * - 명령어 자동완성 드롭다운
+ * - 탭 기반 템플릿 (구조, 그리스, 연산자, 화살표, 함수, 장식, 괄호)
+ * - 기호 검색 (이름/유니코드)
  * - PicturePropsDialog 패턴 (ModalDialog 미상속, 자체 overlay/DOM/keyboard 관리)
  */
 
-/** 도구 모음 템플릿 정의 */
-const TEMPLATES: { label: string; script: string; group?: string }[] = [
-  // ── 구조 ──
-  { label: '분수', script: '{} over {}', group: 'struct' },
-  { label: 'x²', script: '{}^{}', group: 'struct' },
-  { label: 'x₂', script: '{}_{}', group: 'struct' },
-  { label: '√', script: 'sqrt {}', group: 'struct' },
-  { label: 'Σ', script: 'sum _{}^{}', group: 'struct' },
-  { label: '∫', script: 'int _{}^{}', group: 'struct' },
-  { label: '()', script: 'LEFT ( {} RIGHT )', group: 'struct' },
-  { label: '[]', script: 'LEFT [ {} RIGHT ]', group: 'struct' },
-  { label: '행렬', script: 'matrix { {} # {} ; {} # {} }', group: 'struct' },
-  { label: 'hat', script: 'hat {}', group: 'struct' },
-  { label: 'bar', script: 'bar {}', group: 'struct' },
-  // ── 그리스 문자 ──
-  { label: 'α', script: 'alpha', group: 'greek' },
-  { label: 'β', script: 'beta', group: 'greek' },
-  { label: 'γ', script: 'gamma', group: 'greek' },
-  { label: 'δ', script: 'delta', group: 'greek' },
-  { label: 'θ', script: 'theta', group: 'greek' },
-  { label: 'π', script: 'pi', group: 'greek' },
-  { label: 'σ', script: 'sigma', group: 'greek' },
-  { label: 'λ', script: 'lambda', group: 'greek' },
-  { label: 'ω', script: 'omega', group: 'greek' },
-  // ── 연산자/기호 ──
-  { label: '±', script: 'pm', group: 'op' },
-  { label: '×', script: 'times', group: 'op' },
-  { label: '÷', script: 'div', group: 'op' },
-  { label: '≠', script: 'neq', group: 'op' },
-  { label: '≤', script: 'leq', group: 'op' },
-  { label: '≥', script: 'geq', group: 'op' },
-  { label: '∞', script: 'inf', group: 'op' },
-  { label: '→', script: 'rarrow', group: 'op' },
-  { label: '∈', script: 'in', group: 'op' },
-  { label: '⊂', script: 'subset', group: 'op' },
+type InputMode = 'hwp' | 'latex';
+
+interface TemplateEntry { label: string; hwp: string; latex: string }
+interface TemplateGroup { id: string; name: string; items: TemplateEntry[] }
+
+interface CommandEntry { name: string; display: string; insert: string; group: string }
+
+const TEMPLATE_GROUPS: TemplateGroup[] = [
+  { id: 'struct', name: '구조', items: [
+    { label: '분수', hwp: '{} over {}', latex: '\\frac{}{}'  },
+    { label: 'x²', hwp: '{}^{}', latex: '{}^{}' },
+    { label: 'x₂', hwp: '{}_{}', latex: '{}_{}' },
+    { label: '√', hwp: 'sqrt {}', latex: '\\sqrt{}' },
+    { label: '³√', hwp: 'root 3 of {}', latex: '\\sqrt[3]{}' },
+    { label: 'Σ', hwp: 'sum _{}^{}', latex: '\\sum_{}^{}' },
+    { label: '∫', hwp: 'int _{}^{}', latex: '\\int_{}^{}' },
+    { label: '∬', hwp: 'dint _{}^{}', latex: '\\iint_{}^{}' },
+    { label: '∮', hwp: 'oint _{}^{}', latex: '\\oint_{}^{}' },
+    { label: '∏', hwp: 'prod _{}^{}', latex: '\\prod_{}^{}' },
+    { label: '()', hwp: 'LEFT ( {} RIGHT )', latex: '\\left( {} \\right)' },
+    { label: '[]', hwp: 'LEFT [ {} RIGHT ]', latex: '\\left[ {} \\right]' },
+    { label: '{}', hwp: 'LEFT lbrace {} RIGHT rbrace', latex: '\\left\\{ {} \\right\\}' },
+    { label: '⌈⌉', hwp: 'LEFT lceil {} RIGHT rceil', latex: '\\left\\lceil {} \\right\\rceil' },
+    { label: '⌊⌋', hwp: 'LEFT lfloor {} RIGHT rfloor', latex: '\\left\\lfloor {} \\right\\rfloor' },
+    { label: '||', hwp: 'LEFT | {} RIGHT |', latex: '\\left| {} \\right|' },
+    { label: '행렬', hwp: 'matrix { {} # {} ; {} # {} }', latex: '\\begin{matrix} {} & {} \\\\ {} & {} \\end{matrix}' },
+    { label: 'cases', hwp: 'cases { {} ; {} }', latex: '\\begin{cases} {} \\\\ {} \\end{cases}' },
+    { label: 'lim', hwp: 'lim _{} {}', latex: '\\lim_{} {}' },
+  ] },
+  { id: 'greek', name: '그리스', items: [
+    { label: 'α', hwp: 'alpha', latex: '\\alpha' },
+    { label: 'β', hwp: 'beta', latex: '\\beta' },
+    { label: 'γ', hwp: 'gamma', latex: '\\gamma' },
+    { label: 'δ', hwp: 'delta', latex: '\\delta' },
+    { label: 'ε', hwp: 'epsilon', latex: '\\epsilon' },
+    { label: 'ζ', hwp: 'zeta', latex: '\\zeta' },
+    { label: 'η', hwp: 'eta', latex: '\\eta' },
+    { label: 'θ', hwp: 'theta', latex: '\\theta' },
+    { label: 'ι', hwp: 'iota', latex: '\\iota' },
+    { label: 'κ', hwp: 'kappa', latex: '\\kappa' },
+    { label: 'λ', hwp: 'lambda', latex: '\\lambda' },
+    { label: 'μ', hwp: 'mu', latex: '\\mu' },
+    { label: 'ν', hwp: 'nu', latex: '\\nu' },
+    { label: 'ξ', hwp: 'xi', latex: '\\xi' },
+    { label: 'π', hwp: 'pi', latex: '\\pi' },
+    { label: 'ρ', hwp: 'rho', latex: '\\rho' },
+    { label: 'σ', hwp: 'sigma', latex: '\\sigma' },
+    { label: 'τ', hwp: 'tau', latex: '\\tau' },
+    { label: 'υ', hwp: 'upsilon', latex: '\\upsilon' },
+    { label: 'φ', hwp: 'phi', latex: '\\phi' },
+    { label: 'χ', hwp: 'chi', latex: '\\chi' },
+    { label: 'ψ', hwp: 'psi', latex: '\\psi' },
+    { label: 'ω', hwp: 'omega', latex: '\\omega' },
+    { label: 'Γ', hwp: 'Gamma', latex: '\\Gamma' },
+    { label: 'Δ', hwp: 'Delta', latex: '\\Delta' },
+    { label: 'Θ', hwp: 'Theta', latex: '\\Theta' },
+    { label: 'Λ', hwp: 'Lambda', latex: '\\Lambda' },
+    { label: 'Ξ', hwp: 'Xi', latex: '\\Xi' },
+    { label: 'Π', hwp: 'Pi', latex: '\\Pi' },
+    { label: 'Σ', hwp: 'Sigma', latex: '\\Sigma' },
+    { label: 'Φ', hwp: 'Phi', latex: '\\Phi' },
+    { label: 'Ψ', hwp: 'Psi', latex: '\\Psi' },
+    { label: 'Ω', hwp: 'Omega', latex: '\\Omega' },
+  ] },
+  { id: 'op', name: '연산자', items: [
+    { label: '±', hwp: 'pm', latex: '\\pm' },
+    { label: '∓', hwp: 'mp', latex: '\\mp' },
+    { label: '×', hwp: 'times', latex: '\\times' },
+    { label: '÷', hwp: 'div', latex: '\\div' },
+    { label: '·', hwp: 'cdot', latex: '\\cdot' },
+    { label: '≠', hwp: 'neq', latex: '\\neq' },
+    { label: '≤', hwp: 'leq', latex: '\\leq' },
+    { label: '≥', hwp: 'geq', latex: '\\geq' },
+    { label: '≈', hwp: 'approx', latex: '\\approx' },
+    { label: '≡', hwp: 'equiv', latex: '\\equiv' },
+    { label: '∼', hwp: 'sim', latex: '\\sim' },
+    { label: '≅', hwp: 'cong', latex: '\\cong' },
+    { label: '∝', hwp: 'propto', latex: '\\propto' },
+    { label: '∞', hwp: 'inf', latex: '\\infty' },
+    { label: '∂', hwp: 'partial', latex: '\\partial' },
+    { label: '∅', hwp: 'emptyset', latex: '\\emptyset' },
+    { label: '∈', hwp: 'in', latex: '\\in' },
+    { label: '∉', hwp: 'notin', latex: '\\notin' },
+    { label: '⊂', hwp: 'subset', latex: '\\subset' },
+    { label: '⊃', hwp: 'superset', latex: '\\supset' },
+    { label: '⊆', hwp: 'subseteq', latex: '\\subseteq' },
+    { label: '⊇', hwp: 'supseteq', latex: '\\supseteq' },
+    { label: '∪', hwp: 'union', latex: '\\cup' },
+    { label: '∩', hwp: 'inter', latex: '\\cap' },
+    { label: '∀', hwp: 'forall', latex: '\\forall' },
+    { label: '∃', hwp: 'exist', latex: '\\exists' },
+    { label: '¬', hwp: 'lnot', latex: '\\neg' },
+    { label: '∧', hwp: 'wedge', latex: '\\wedge' },
+    { label: '∨', hwp: 'vee', latex: '\\vee' },
+    { label: '⊕', hwp: 'oplus', latex: '\\oplus' },
+    { label: '⊗', hwp: 'otimes', latex: '\\otimes' },
+    { label: '∴', hwp: 'therefore', latex: '\\therefore' },
+    { label: '∵', hwp: 'because', latex: '\\because' },
+  ] },
+  { id: 'arrow', name: '화살표', items: [
+    { label: '←', hwp: 'larrow', latex: '\\leftarrow' },
+    { label: '→', hwp: 'rarrow', latex: '\\rightarrow' },
+    { label: '↑', hwp: 'uparrow', latex: '\\uparrow' },
+    { label: '↓', hwp: 'downarrow', latex: '\\downarrow' },
+    { label: '↔', hwp: 'lrarrow', latex: '\\leftrightarrow' },
+    { label: '⇐', hwp: 'LARROW', latex: '\\Leftarrow' },
+    { label: '⇒', hwp: 'RARROW', latex: '\\Rightarrow' },
+    { label: '⇔', hwp: 'LRARROW', latex: '\\Leftrightarrow' },
+    { label: '↦', hwp: 'mapsto', latex: '\\mapsto' },
+    { label: '↗', hwp: 'nearrow', latex: '\\nearrow' },
+    { label: '↘', hwp: 'searrow', latex: '\\searrow' },
+  ] },
+  { id: 'func', name: '함수', items: [
+    { label: 'sin', hwp: 'sin', latex: '\\sin' },
+    { label: 'cos', hwp: 'cos', latex: '\\cos' },
+    { label: 'tan', hwp: 'tan', latex: '\\tan' },
+    { label: 'cot', hwp: 'cot', latex: '\\cot' },
+    { label: 'sec', hwp: 'sec', latex: '\\sec' },
+    { label: 'csc', hwp: 'csc', latex: '\\csc' },
+    { label: 'arcsin', hwp: 'arcsin', latex: '\\arcsin' },
+    { label: 'arccos', hwp: 'arccos', latex: '\\arccos' },
+    { label: 'arctan', hwp: 'arctan', latex: '\\arctan' },
+    { label: 'sinh', hwp: 'sinh', latex: '\\sinh' },
+    { label: 'cosh', hwp: 'cosh', latex: '\\cosh' },
+    { label: 'tanh', hwp: 'tanh', latex: '\\tanh' },
+    { label: 'log', hwp: 'log', latex: '\\log' },
+    { label: 'ln', hwp: 'ln', latex: '\\ln' },
+    { label: 'exp', hwp: 'exp', latex: '\\exp' },
+    { label: 'det', hwp: 'det', latex: '\\det' },
+    { label: 'max', hwp: 'max', latex: '\\max' },
+    { label: 'min', hwp: 'min', latex: '\\min' },
+    { label: 'gcd', hwp: 'gcd', latex: '\\gcd' },
+    { label: 'mod', hwp: 'mod', latex: '\\mod' },
+  ] },
+  { id: 'deco', name: '장식', items: [
+    { label: 'â', hwp: 'hat {}', latex: '\\hat{}' },
+    { label: 'ā', hwp: 'bar {}', latex: '\\bar{}' },
+    { label: 'ã', hwp: 'tilde {}', latex: '\\tilde{}' },
+    { label: 'à', hwp: 'grave {}', latex: '\\grave{}' },
+    { label: 'á', hwp: 'acute {}', latex: '\\acute{}' },
+    { label: 'ȧ', hwp: 'dot {}', latex: '\\dot{}' },
+    { label: 'ä', hwp: 'ddot {}', latex: '\\ddot{}' },
+    { label: 'a⃗', hwp: 'vec {}', latex: '\\vec{}' },
+    { label: 'a̲', hwp: 'UNDERLINE {}', latex: '\\underline{}' },
+    { label: 'a̅', hwp: 'OVERLINE {}', latex: '\\overline{}' },
+  ] },
+  { id: 'special', name: '특수', items: [
+    { label: 'ℓ', hwp: 'ell', latex: '\\ell' },
+    { label: 'ℏ', hwp: 'hbar', latex: '\\hbar' },
+    { label: 'ℵ', hwp: 'aleph', latex: '\\aleph' },
+    { label: '⋯', hwp: 'cdots', latex: '\\cdots' },
+    { label: '…', hwp: 'ldots', latex: '\\ldots' },
+    { label: '⋮', hwp: 'vdots', latex: '\\vdots' },
+    { label: '⋱', hwp: 'ddots', latex: '\\ddots' },
+    { label: '△', hwp: 'triangle', latex: '\\triangle' },
+    { label: '∠', hwp: 'angle', latex: '\\angle' },
+    { label: '⊥', hwp: 'bot', latex: '\\bot' },
+    { label: '°', hwp: 'deg', latex: '^{\\circ}' },
+    { label: '†', hwp: 'dagger', latex: '\\dagger' },
+    { label: '‡', hwp: 'ddagger', latex: '\\ddagger' },
+    { label: '★', hwp: 'star', latex: '\\star' },
+    { label: '℃', hwp: 'CENTIGRADE', latex: '^{\\circ}\\text{C}' },
+    { label: '′', hwp: 'prime', latex: "'" },
+  ] },
 ];
+
+function buildCommandList(): CommandEntry[] {
+  const cmds: CommandEntry[] = [];
+  for (const grp of TEMPLATE_GROUPS) {
+    for (const t of grp.items) {
+      cmds.push({ name: t.hwp.split(/[\s{}_^]/)[0], display: t.label, insert: t.hwp, group: grp.name });
+    }
+  }
+  return cmds;
+}
+
+const ALL_COMMANDS = buildCommandList();
 
 export class EquationEditorDialog {
   private wasm: WasmBridge;
@@ -60,6 +202,26 @@ export class EquationEditorDialog {
   private fontSizeInput!: HTMLInputElement;
   private colorInput!: HTMLInputElement;
   private built = false;
+
+  // 모드
+  private mode: InputMode = 'hwp';
+  private modeBtn!: HTMLButtonElement;
+  private latexHint!: HTMLDivElement;
+
+  // 탭 UI
+  private tabContainer!: HTMLDivElement;
+  private toolbarContent!: HTMLDivElement;
+  private activeTabId = 'struct';
+
+  // 자동완성
+  private acDropdown!: HTMLDivElement;
+  private acItems: CommandEntry[] = [];
+  private acSelectedIdx = -1;
+  private acVisible = false;
+
+  // 기호 검색
+  private searchInput!: HTMLInputElement;
+  private searchResults!: HTMLDivElement;
 
   // 현재 편집 대상 좌표
   private sec = 0;
@@ -88,7 +250,6 @@ export class EquationEditorDialog {
     this.cellIdx = cellIdx;
     this.cellParaIdx = cellParaIdx;
 
-    // WASM에서 수식 속성 가져오기
     try {
       this.origProps = this.wasm.getEquationProperties(sec, para, ci, cellIdx, cellParaIdx);
     } catch (err) {
@@ -96,12 +257,17 @@ export class EquationEditorDialog {
       return;
     }
 
-    // UI에 값 채우기
     this.scriptArea.value = this.origProps.script || '';
-    this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100)); // HWPUNIT→pt
+    this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100));
     this.colorInput.value = colorRefToHex(this.origProps.color);
 
-    // 대화상자 표시
+    // 기존 스크립트에 \ 가 있으면 LaTeX 모드로 시작
+    if (this.origProps.script && /\\[a-zA-Z]/.test(this.origProps.script)) {
+      this.setMode('latex');
+    } else {
+      this.setMode('hwp');
+    }
+
     document.body.appendChild(this.overlay);
     setTimeout(() => {
       this.scriptArea.focus();
@@ -115,6 +281,7 @@ export class EquationEditorDialog {
       clearTimeout(this.previewTimer);
       this.previewTimer = null;
     }
+    this.hideAutocomplete();
     this.overlay?.remove();
   }
 
@@ -123,46 +290,91 @@ export class EquationEditorDialog {
     if (this.built) return;
     this.built = true;
 
-    // 오버레이
     this.overlay = document.createElement('div');
     this.overlay.className = 'modal-overlay';
 
-    // 대화상자 컨테이너
     this.dialog = document.createElement('div');
     this.dialog.className = 'dialog-wrap eq-dialog';
 
     // 타이틀바
     const titleBar = document.createElement('div');
     titleBar.className = 'dialog-title';
-    titleBar.textContent = '수식 편집';
+
+    const titleText = document.createElement('span');
+    titleText.textContent = '수식 편집';
+
+    // 모드 토글 버튼
+    this.modeBtn = document.createElement('button');
+    this.modeBtn.className = 'eq-mode-btn';
+    this.modeBtn.addEventListener('click', () => this.toggleMode());
+
     const closeBtn = document.createElement('button');
     closeBtn.className = 'dialog-close';
-    closeBtn.textContent = '\u00D7';
+    closeBtn.textContent = '×';
     closeBtn.addEventListener('click', () => this.hide());
-    titleBar.appendChild(closeBtn);
+    titleBar.append(titleText, this.modeBtn, closeBtn);
 
     // 본문
     const body = document.createElement('div');
     body.className = 'dialog-body eq-body';
 
-    // 1) 도구 모음
-    const toolbar = this.buildToolbar();
-    body.appendChild(toolbar);
+    // 1) 탭 + 도구 모음
+    this.tabContainer = document.createElement('div');
+    this.tabContainer.className = 'eq-tabs';
+    this.toolbarContent = document.createElement('div');
+    this.toolbarContent.className = 'eq-toolbar';
+    this.buildTabs();
+    body.append(this.tabContainer, this.toolbarContent);
 
-    // 2) 미리보기 영역
+    // 2) 기호 검색
+    const searchRow = document.createElement('div');
+    searchRow.className = 'eq-search-row';
+    this.searchInput = document.createElement('input');
+    this.searchInput.type = 'text';
+    this.searchInput.className = 'eq-search-input';
+    this.searchInput.placeholder = '기호 검색 (이름 또는 유니코드)';
+    this.searchInput.addEventListener('input', () => this.onSearchInput());
+    this.searchResults = document.createElement('div');
+    this.searchResults.className = 'eq-search-results';
+    this.searchResults.style.display = 'none';
+    searchRow.append(this.searchInput, this.searchResults);
+    body.appendChild(searchRow);
+
+    // 3) LaTeX 전환 힌트
+    this.latexHint = document.createElement('div');
+    this.latexHint.className = 'eq-latex-hint';
+    this.latexHint.style.display = 'none';
+    this.latexHint.innerHTML = '<span>💡 백슬래시(\\) 명령어가 감지됨 — </span>';
+    const hintLink = document.createElement('a');
+    hintLink.href = '#';
+    hintLink.textContent = 'LaTeX 모드로 전환';
+    hintLink.addEventListener('click', (e) => { e.preventDefault(); this.setMode('latex'); });
+    this.latexHint.appendChild(hintLink);
+    body.appendChild(this.latexHint);
+
+    // 4) 미리보기 영역
     this.previewContainer = document.createElement('div');
     this.previewContainer.className = 'eq-preview';
     body.appendChild(this.previewContainer);
 
-    // 3) 텍스트 입력 영역
+    // 5) 텍스트 입력 영역 (자동완성 포함)
+    const scriptWrap = document.createElement('div');
+    scriptWrap.className = 'eq-script-wrap';
     this.scriptArea = document.createElement('textarea');
     this.scriptArea.className = 'eq-script';
     this.scriptArea.rows = 4;
     this.scriptArea.spellcheck = false;
-    this.scriptArea.addEventListener('input', () => this.schedulePreview());
-    body.appendChild(this.scriptArea);
+    this.scriptArea.addEventListener('input', () => { this.schedulePreview(); this.onScriptInput(); });
+    this.scriptArea.addEventListener('keydown', (e) => this.onScriptKeydown(e));
 
-    // 4) 속성 행 (글자 크기 + 색상)
+    this.acDropdown = document.createElement('div');
+    this.acDropdown.className = 'eq-autocomplete';
+    this.acDropdown.style.display = 'none';
+
+    scriptWrap.append(this.scriptArea, this.acDropdown);
+    body.appendChild(scriptWrap);
+
+    // 6) 속성 행
     const propsRow = document.createElement('div');
     propsRow.className = 'dialog-row eq-props-row';
 
@@ -191,7 +403,7 @@ export class EquationEditorDialog {
     propsRow.append(sizeLabel, this.fontSizeInput, sizeUnit, colorLabel, this.colorInput);
     body.appendChild(propsRow);
 
-    // 5) 버튼 영역
+    // 7) 버튼 영역
     const footer = document.createElement('div');
     footer.className = 'dialog-footer';
     const okBtn = document.createElement('button');
@@ -204,62 +416,205 @@ export class EquationEditorDialog {
     cancelBtn.addEventListener('click', () => this.hide());
     footer.append(okBtn, cancelBtn);
 
-    // 조립
     this.dialog.append(titleBar, body, footer);
     this.overlay.appendChild(this.dialog);
 
-    // 키보드 핸들링
+    // 키보드
     this.overlay.addEventListener('keydown', (e) => {
       if (e.key === 'Escape') {
+        if (this.acVisible) { this.hideAutocomplete(); e.stopPropagation(); return; }
         e.stopPropagation();
         this.hide();
       }
-      // Enter 키(Ctrl+Enter)로 확인
       if (e.key === 'Enter' && e.ctrlKey) {
         e.preventDefault();
         e.stopPropagation();
         this.handleOk();
       }
-      // 대화상자 내부 이벤트가 편집기로 전파되지 않도록
       e.stopPropagation();
     });
 
-    // 오버레이 클릭으로 닫기
     this.overlay.addEventListener('mousedown', (e) => {
       if (e.target === this.overlay) this.hide();
     });
 
-    // 드래그 지원
     this.enableDrag(titleBar);
   }
 
-  /** 도구 모음 빌드 */
-  private buildToolbar(): HTMLDivElement {
-    const toolbar = document.createElement('div');
-    toolbar.className = 'eq-toolbar';
+  // ── 모드 ──────────────────────────────────────
 
-    let currentGroup = '';
-    for (const tmpl of TEMPLATES) {
-      // 그룹 구분선
-      if (tmpl.group && tmpl.group !== currentGroup && currentGroup !== '') {
-        const sep = document.createElement('span');
-        sep.className = 'eq-toolbar-sep';
-        toolbar.appendChild(sep);
-      }
-      currentGroup = tmpl.group || '';
+  private setMode(m: InputMode): void {
+    this.mode = m;
+    this.modeBtn.textContent = m === 'hwp' ? 'HWP' : 'LaTeX';
+    this.modeBtn.title = m === 'hwp' ? 'LaTeX 모드로 전환' : 'HWP 모드로 전환';
+    this.latexHint.style.display = 'none';
+    this.refreshToolbar();
+  }
 
+  private toggleMode(): void {
+    this.setMode(this.mode === 'hwp' ? 'latex' : 'hwp');
+  }
+
+  // ── 탭 ────────────────────────────────────────
+
+  private buildTabs(): void {
+    this.tabContainer.replaceChildren();
+    for (const grp of TEMPLATE_GROUPS) {
+      const tab = document.createElement('button');
+      tab.className = 'eq-tab' + (grp.id === this.activeTabId ? ' eq-tab-active' : '');
+      tab.textContent = grp.name;
+      tab.dataset.tabId = grp.id;
+      tab.addEventListener('click', () => {
+        this.activeTabId = grp.id;
+        this.tabContainer.querySelectorAll('.eq-tab').forEach(t => t.classList.remove('eq-tab-active'));
+        tab.classList.add('eq-tab-active');
+        this.refreshToolbar();
+      });
+      this.tabContainer.appendChild(tab);
+    }
+    this.refreshToolbar();
+  }
+
+  private refreshToolbar(): void {
+    this.toolbarContent.replaceChildren();
+    const grp = TEMPLATE_GROUPS.find(g => g.id === this.activeTabId);
+    if (!grp) return;
+    for (const tmpl of grp.items) {
       const btn = document.createElement('button');
       btn.className = 'eq-toolbar-btn';
       btn.textContent = tmpl.label;
-      btn.title = tmpl.script;
-      btn.addEventListener('click', () => this.insertTemplate(tmpl.script));
-      toolbar.appendChild(btn);
+      const script = this.mode === 'hwp' ? tmpl.hwp : tmpl.latex;
+      btn.title = script;
+      btn.addEventListener('click', () => this.insertTemplate(script));
+      this.toolbarContent.appendChild(btn);
     }
-
-    return toolbar;
   }
 
-  /** textarea 커서 위치에 템플릿 삽입 */
+  // ── 자동완성 ──────────────────────────────────
+
+  private onScriptInput(): void {
+    const ta = this.scriptArea;
+    const pos = ta.selectionStart;
+    const text = ta.value.substring(0, pos);
+
+    // HWP 모드: 백슬래시 감지 시 힌트
+    if (this.mode === 'hwp' && /\\[a-zA-Z]/.test(text)) {
+      this.latexHint.style.display = '';
+    } else {
+      this.latexHint.style.display = 'none';
+    }
+
+    // 현재 입력 중인 단어 추출
+    const wordMatch = text.match(/([a-zA-Z]{2,})$/);
+    if (!wordMatch) { this.hideAutocomplete(); return; }
+    const word = wordMatch[1].toLowerCase();
+
+    const matches = ALL_COMMANDS.filter(c =>
+      c.name.toLowerCase().startsWith(word) || c.display.includes(word)
+    ).slice(0, 8);
+
+    if (matches.length === 0) { this.hideAutocomplete(); return; }
+
+    this.acItems = matches;
+    this.acSelectedIdx = 0;
+    this.renderAutocomplete();
+  }
+
+  private renderAutocomplete(): void {
+    this.acDropdown.replaceChildren();
+    this.acItems.forEach((cmd, i) => {
+      const row = document.createElement('div');
+      row.className = 'eq-ac-item' + (i === this.acSelectedIdx ? ' eq-ac-selected' : '');
+      row.innerHTML = `<span class="eq-ac-display">${cmd.display}</span> <span class="eq-ac-name">${cmd.name}</span> <span class="eq-ac-group">${cmd.group}</span>`;
+      row.addEventListener('mousedown', (e) => { e.preventDefault(); this.acceptAutocomplete(i); });
+      this.acDropdown.appendChild(row);
+    });
+    this.acDropdown.style.display = '';
+    this.acVisible = true;
+  }
+
+  private acceptAutocomplete(idx: number): void {
+    const cmd = this.acItems[idx];
+    if (!cmd) return;
+    const ta = this.scriptArea;
+    const pos = ta.selectionStart;
+    const text = ta.value;
+    const before = text.substring(0, pos);
+    const match = before.match(/([a-zA-Z]+)$/);
+    if (!match) return;
+    const wordStart = pos - match[1].length;
+    const script = this.mode === 'hwp' ? cmd.insert : (cmd.insert.startsWith('\\') ? cmd.insert : '\\' + cmd.insert);
+    ta.value = text.substring(0, wordStart) + script + text.substring(pos);
+    const newPos = wordStart + script.length;
+    ta.selectionStart = newPos;
+    ta.selectionEnd = newPos;
+    ta.focus();
+    this.hideAutocomplete();
+    this.schedulePreview();
+  }
+
+  private hideAutocomplete(): void {
+    this.acDropdown.style.display = 'none';
+    this.acVisible = false;
+    this.acItems = [];
+    this.acSelectedIdx = -1;
+  }
+
+  private onScriptKeydown(e: KeyboardEvent): void {
+    if (!this.acVisible) return;
+    if (e.key === 'ArrowDown') {
+      e.preventDefault();
+      this.acSelectedIdx = Math.min(this.acSelectedIdx + 1, this.acItems.length - 1);
+      this.renderAutocomplete();
+    } else if (e.key === 'ArrowUp') {
+      e.preventDefault();
+      this.acSelectedIdx = Math.max(this.acSelectedIdx - 1, 0);
+      this.renderAutocomplete();
+    } else if (e.key === 'Tab' || e.key === 'Enter') {
+      if (this.acSelectedIdx >= 0) {
+        e.preventDefault();
+        this.acceptAutocomplete(this.acSelectedIdx);
+      }
+    } else if (e.key === 'Escape') {
+      this.hideAutocomplete();
+    }
+  }
+
+  // ── 기호 검색 ─────────────────────────────────
+
+  private onSearchInput(): void {
+    const q = this.searchInput.value.trim().toLowerCase();
+    if (q.length < 1) { this.searchResults.style.display = 'none'; return; }
+
+    const matches = ALL_COMMANDS.filter(c =>
+      c.name.toLowerCase().includes(q) ||
+      c.display.includes(q) ||
+      c.group.toLowerCase().includes(q)
+    ).slice(0, 12);
+
+    if (matches.length === 0) {
+      this.searchResults.style.display = 'none';
+      return;
+    }
+
+    this.searchResults.replaceChildren();
+    for (const cmd of matches) {
+      const btn = document.createElement('button');
+      btn.className = 'eq-search-result-btn';
+      btn.innerHTML = `<span class="eq-sr-display">${cmd.display}</span><span class="eq-sr-name">${cmd.name}</span>`;
+      btn.addEventListener('click', () => {
+        const script = this.mode === 'hwp' ? cmd.insert : (cmd.insert.startsWith('\\') ? cmd.insert : '\\' + cmd.insert);
+        this.insertTemplate(script);
+        this.searchInput.value = '';
+        this.searchResults.style.display = 'none';
+      });
+      this.searchResults.appendChild(btn);
+    }
+    this.searchResults.style.display = '';
+  }
+
+  // ── 템플릿 삽입 ───────────────────────────────
+
   private insertTemplate(script: string): void {
     const ta = this.scriptArea;
     const start = ta.selectionStart;
@@ -267,14 +622,12 @@ export class EquationEditorDialog {
     const before = ta.value.substring(0, start);
     const after = ta.value.substring(end);
 
-    // 앞에 공백 추가 (이전 문자가 공백/빈 문자열이 아닌 경우)
     const needSpaceBefore = before.length > 0 && !/\s$/.test(before);
     const needSpaceAfter = after.length > 0 && !/^\s/.test(after);
     const insertion = (needSpaceBefore ? ' ' : '') + script + (needSpaceAfter ? ' ' : '');
 
     ta.value = before + insertion + after;
 
-    // {} 안에 커서 배치
     const bracePos = (before + insertion).indexOf('{}', start);
     if (bracePos >= 0) {
       ta.selectionStart = bracePos + 1;
@@ -289,13 +642,13 @@ export class EquationEditorDialog {
     this.schedulePreview();
   }
 
-  /** 디바운스된 미리보기 갱신 예약 */
+  // ── 미리보기 ──────────────────────────────────
+
   private schedulePreview(): void {
     if (this.previewTimer) clearTimeout(this.previewTimer);
     this.previewTimer = setTimeout(() => this.updatePreview(), 300);
   }
 
-  /** WASM으로 SVG 미리보기 갱신 */
   private updatePreview(): void {
     const script = this.scriptArea.value.trim();
     if (!script) {
@@ -304,7 +657,7 @@ export class EquationEditorDialog {
     }
 
     const fontSizePt = parseInt(this.fontSizeInput.value, 10) || 10;
-    const fontSizeHwpunit = fontSizePt * 100; // pt → HWPUNIT
+    const fontSizeHwpunit = fontSizePt * 100;
     const color = hexToColorRef(this.colorInput.value);
 
     try {
@@ -324,7 +677,8 @@ export class EquationEditorDialog {
     this.previewContainer.replaceChildren(span);
   }
 
-  /** 확인 버튼 핸들러 */
+  // ── 확인 ──────────────────────────────────────
+
   private handleOk(): void {
     if (!this.origProps) return;
 
@@ -333,7 +687,6 @@ export class EquationEditorDialog {
     const fontSizeHwpunit = fontSizePt * 100;
     const color = hexToColorRef(this.colorInput.value);
 
-    // 변경된 속성만 전송
     const updated: Record<string, unknown> = {};
     if (script !== this.origProps.script) updated.script = script;
     if (fontSizeHwpunit !== this.origProps.fontSize) updated.fontSize = fontSizeHwpunit;
@@ -351,11 +704,12 @@ export class EquationEditorDialog {
     this.hide();
   }
 
-  /** 타이틀바 드래그 */
+  // ── 드래그 ────────────────────────────────────
+
   private enableDrag(titleEl: HTMLElement): void {
     let offsetX = 0, offsetY = 0, isDragging = false;
     titleEl.addEventListener('mousedown', (e) => {
-      if ((e.target as HTMLElement).closest('.dialog-close')) return;
+      if ((e.target as HTMLElement).closest('.dialog-close, .eq-mode-btn')) return;
       isDragging = true;
       const rect = this.dialog.getBoundingClientRect();
       offsetX = e.clientX - rect.left;


### PR DESCRIPTION
## 변경 사항

수식 편집 대화상자(`equation-editor-dialog.ts`)를 전면 개선합니다.

### 1. HWP ↔ LaTeX 듀얼 입력 모드
- 타이틀바에 모드 토글 버튼 (HWP/LaTeX)
- 모드에 따라 템플릿 스크립트가 HWP 또는 LaTeX 구문으로 전환
- 기존 스크립트에 `\명령어` 존재 시 LaTeX 모드로 자동 시작
- Rust 수식 파서가 이미 양 구문을 처리하므로 백엔드 변경 불필요

### 2. 탭 기반 확장 템플릿
- 기존 30개 → 130+ 항목으로 확장
- 7개 탭: 구조, 그리스, 연산자, 화살표, 함수, 장식, 특수
- `symbols.rs` 명령어 체계와 정합

### 3. 명령어 자동완성
- 2자 이상 입력 시 자동완성 드롭다운 활성화
- ↑↓ 키로 선택, Tab/Enter로 확정, Esc로 닫기
- 기호 미리보기(α), 명령어 이름(alpha), 그룹명(그리스) 동시 표시

### 4. 기호 검색
- 이름 또는 유니코드 문자로 전체 명령어 검색
- 검색 결과 클릭 시 커서 위치에 삽입

### 5. LaTeX 전환 힌트
- HWP 모드에서 `\` + 영문자 입력 감지 시 LaTeX 전환 안내 배너 표시

## 의존성
- #143 (LaTeX 파서 확장) PR과 시너지 — LaTeX 명령어 호환 범위 확장 반영

## 테스트
- `npx tsc --noEmit`: 에러 없음 (WASM 모듈 제외)
- `cargo test`: 전체 통과
- `cargo clippy -- -D warnings`: 경고 없음

Closes #144

감사합니다.