### PR TITLE
수식 신규 입력: insertEquation WASM API + 입력 메뉴 항목

### DIFF
--- a/rhwp-studio/index.html
+++ b/rhwp-studio/index.html
@@ -94,6 +94,7 @@
           <div class="md-sep"></div>
           <div class="md-item" data-cmd="insert:image"><span class="md-icon icon-image"></span><span class="md-label">그림</span></div>
           <div class="md-item" data-cmd="insert:textbox"><span class="md-icon icon-textbox"></span><span class="md-label">글상자</span></div>
+          <div class="md-item" data-cmd="insert:equation"><span class="md-icon"></span><span class="md-label">수식</span><span class="md-shortcut">Ctrl+N,M</span></div>
           <div class="md-sep"></div>
           <div class="md-item disabled" data-cmd="insert:field"><span class="md-icon"></span><span class="md-label">필드 입력</span><span class="md-shortcut">Ctrl+K+E</span></div>
           <div class="md-sep"></div>

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -82,11 +82,13 @@ export const insertCommands: CommandDef[] = [
     id: 'insert:equation',
     label: '수식',
     shortcutLabel: 'Ctrl+N,M',
-    canExecute: (ctx) => ctx.hasDocument,
+    canExecute: (ctx) => ctx.hasDocument && !ctx.inTableCellEditing,
     execute(services) {
       const ih = services.getInputHandler();
       if (!ih) return;
       const pos = ih.getPosition();
+      // 본문 전용 — 표 셀 내부에서는 실행하지 않음
+      if ((pos as any).cellIndex !== undefined && (pos as any).cellIndex >= 0) return;
       try {
         const defaultFontSize = 1000; // 10pt → HWPUNIT
         const defaultColor = 0x00000000; // 검정

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -78,6 +78,34 @@ export const insertCommands: CommandDef[] = [
       ih.enterTextboxPlacementMode();
     },
   },
+  {
+    id: 'insert:equation',
+    label: '수식',
+    shortcutLabel: 'Ctrl+N,M',
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const pos = ih.getPosition();
+      try {
+        const defaultFontSize = 1000; // 10pt → HWPUNIT
+        const defaultColor = 0x00000000; // 검정
+        const result = services.wasm.insertEquation(
+          pos.sectionIndex, pos.paragraphIndex, pos.charOffset,
+          '', defaultFontSize, defaultColor
+        );
+        if (result.ok) {
+          services.eventBus.emit('document-changed');
+          if (!equationEditorDialog) {
+            equationEditorDialog = new EquationEditorDialog(services.wasm, services.eventBus);
+          }
+          equationEditorDialog.open(pos.sectionIndex, result.paraIdx, result.controlIdx);
+        }
+      } catch (err) {
+        console.warn('[insert:equation] 수식 삽입 실패:', err);
+      }
+    },
+  },
   stub('insert:field', '필드 입력', undefined, 'Ctrl+K+E'),
   stub('insert:caption-top', '캡션 - 위'),
   stub('insert:caption-lt', '캡션 - 왼쪽 위'),

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -640,6 +640,11 @@ export class WasmBridge {
     return JSON.parse((this.doc as any).groupShapes(json));
   }
 
+  insertEquation(sec: number, para: number, charOffset: number, script: string, fontSizeHwpunit: number, color: number): { ok: boolean; paraIdx: number; controlIdx: number } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse((this.doc as any).insertEquation(sec, para, charOffset, script, fontSizeHwpunit, color));
+  }
+
   insertFootnote(sec: number, para: number, charOffset: number): { ok: boolean; paraIdx: number; controlIdx: number; footnoteNumber: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse((this.doc as any).insertFootnote(sec, para, charOffset));

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -3641,7 +3641,7 @@ impl DocumentCore {
         Ok(format!("{{\"ok\":true,\"paraIdx\":{},\"controlIdx\":{},\"footnoteNumber\":{}}}", para_idx, insert_idx, footnote_number))
     }
 
-    /// 수식을 삽입한다.
+    /// 본문 문단에 수식을 삽입한다 (표 셀/글상자 내부는 미지원).
     /// 커서 위치에 수식 컨트롤을 추가한다.
     /// 반환: JSON `{"ok":true, "paraIdx":N, "controlIdx":N}`
     pub fn insert_equation_native(
@@ -3655,6 +3655,7 @@ impl DocumentCore {
     ) -> Result<String, HwpError> {
         use crate::model::control::Equation;
         use crate::model::shape::CommonObjAttr;
+        use crate::parser::tags::CTRL_EQUATION;
 
         if section_idx >= self.document.sections.len() {
             return Err(HwpError::RenderError(format!("구역 인덱스 {} 범위 초과", section_idx)));
@@ -3665,7 +3666,7 @@ impl DocumentCore {
 
         let equation = Equation {
             common: CommonObjAttr {
-                ctrl_id: 0x65716564, // 'eqed'
+                ctrl_id: CTRL_EQUATION,
                 treat_as_char: true,
                 width: 0,
                 height: 0,
@@ -3704,6 +3705,7 @@ impl DocumentCore {
             }
         }
         paragraph.char_count += 8;
+        paragraph.control_mask |= 1u32 << 11;
         paragraph.has_para_text = true;
 
         // 본문 문단 리플로우

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -3640,6 +3640,98 @@ impl DocumentCore {
         self.event_log.push(DocumentEvent::PictureInserted { section: section_idx, para: para_idx });
         Ok(format!("{{\"ok\":true,\"paraIdx\":{},\"controlIdx\":{},\"footnoteNumber\":{}}}", para_idx, insert_idx, footnote_number))
     }
+
+    /// 수식을 삽입한다.
+    /// 커서 위치에 수식 컨트롤을 추가한다.
+    /// 반환: JSON `{"ok":true, "paraIdx":N, "controlIdx":N}`
+    pub fn insert_equation_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        char_offset: usize,
+        script: &str,
+        font_size: u32,
+        color: u32,
+    ) -> Result<String, HwpError> {
+        use crate::model::control::Equation;
+        use crate::model::shape::CommonObjAttr;
+
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!("구역 인덱스 {} 범위 초과", section_idx)));
+        }
+        if para_idx >= self.document.sections[section_idx].paragraphs.len() {
+            return Err(HwpError::RenderError(format!("문단 인덱스 {} 범위 초과", para_idx)));
+        }
+
+        let equation = Equation {
+            common: CommonObjAttr {
+                ctrl_id: 0x65716564, // 'eqed'
+                treat_as_char: true,
+                width: 0,
+                height: 0,
+                ..Default::default()
+            },
+            script: script.to_string(),
+            font_size,
+            color,
+            font_name: "HYhwpEQ".to_string(),
+            ..Default::default()
+        };
+
+        self.document.sections[section_idx].raw_stream = None;
+        let paragraph = &mut self.document.sections[section_idx].paragraphs[para_idx];
+
+        let insert_idx = {
+            let positions = crate::document_core::helpers::find_control_text_positions(paragraph);
+            let mut idx = paragraph.controls.len();
+            for (i, &pos) in positions.iter().enumerate() {
+                if pos > char_offset {
+                    idx = i;
+                    break;
+                }
+            }
+            idx
+        };
+
+        paragraph.controls.insert(insert_idx, Control::Equation(Box::new(equation)));
+        paragraph.ctrl_data_records.insert(insert_idx, None);
+
+        if !paragraph.char_offsets.is_empty() {
+            let text_len = paragraph.text.chars().count();
+            let safe_offset = char_offset.min(text_len);
+            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
+                *co += 8;
+            }
+        }
+        paragraph.char_count += 8;
+        paragraph.has_para_text = true;
+
+        // 본문 문단 리플로우
+        {
+            use crate::renderer::hwpunit_to_px;
+            use crate::renderer::composer::reflow_line_segs;
+            let page_def = &self.document.sections[section_idx].section_def.page_def;
+            let text_width = page_def.width as i32
+                - page_def.margin_left as i32
+                - page_def.margin_right as i32;
+            let available_width = hwpunit_to_px(text_width, self.dpi);
+            let para_style = self.styles.para_styles.get(
+                self.document.sections[section_idx].paragraphs[para_idx].para_shape_id as usize
+            );
+            let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
+            let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
+            let final_width = (available_width - margin_left - margin_right).max(0.0);
+            let body_para = &mut self.document.sections[section_idx].paragraphs[para_idx];
+            reflow_line_segs(body_para, final_width, &self.styles, self.dpi);
+        }
+
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+        self.invalidate_page_tree_cache();
+
+        self.event_log.push(DocumentEvent::PictureInserted { section: section_idx, para: para_idx });
+        Ok(format!("{{\"ok\":true,\"paraIdx\":{},\"controlIdx\":{}}}", para_idx, insert_idx))
+    }
 }
 
 #[cfg(test)]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2509,6 +2509,28 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    /// 수식을 삽입한다.
+    #[wasm_bindgen(js_name = insertEquation)]
+    pub fn insert_equation(
+        &mut self,
+        section_idx: u32,
+        para_idx: u32,
+        char_offset: u32,
+        script: &str,
+        font_size: u32,
+        color: u32,
+    ) -> Result<String, JsValue> {
+        self.insert_equation_native(
+            section_idx as usize,
+            para_idx as usize,
+            char_offset as usize,
+            script,
+            font_size,
+            color,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 각주 정보를 조회한다.
     #[wasm_bindgen(js_name = getFootnoteInfo)]
     pub fn get_footnote_info(


### PR DESCRIPTION
## 변경 사항

본문 캐럿 위치에 새 수식 객체를 삽입하는 기능을 구현합니다.

### Rust (백엔드)
- `insert_equation_native()`: 캐럿 위치에 `Control::Equation` 컨트롤 삽입
  - `treat_as_char: true` (글자처럼 취급)
  - `char_offsets` 8바이트 갭 생성 + 리플로우 + 재조판
  - `insertFootnote` 패턴과 동일한 삽입 로직
- WASM 바인딩: `insertEquation(sec, para, charOffset, script, fontSize, color)`

### TypeScript (프론트엔드)
- `wasm-bridge.ts`: `insertEquation()` 메서드 추가
- `insert.ts`: `insert:equation` 명령 — 빈 수식 삽입 후 수식 편집 대화상자 자동 진입
- `index.html`: 입력 메뉴에 "수식 (Ctrl+N,M)" 항목 추가

### 기존 인프라 활용
- `renderEquationPreview`, `getEquationProperties`, `setEquationProperties` 기존 API 보존
- `EquationEditorDialog` 기존 편집 대화상자 재사용

## 테스트
- `cargo test`: 전체 통과
- `cargo clippy -- -D warnings`: 경고 없음
- `npx tsc --noEmit`: 에러 없음 (WASM 모듈 제외)

Closes #731

감사합니다.