### PR TITLE
Task #420: 문서 전환 시 글꼴 드롭다운 초기화 — 이전 문서 폰트 잔존 정정

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -422,7 +422,8 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
     canvasView?.loadDocument();
     console.log('[initDoc] 5. toolbar setEnabled');
     toolbar?.setEnabled(true);
-    console.log('[initDoc] 6. toolbar initStyleDropdown');
+    console.log('[initDoc] 6. toolbar initFontDropdown + initStyleDropdown');
+    toolbar?.initFontDropdown(docInfo.fontsUsed);
     toolbar?.initStyleDropdown();
     console.log('[initDoc] 7. inputHandler activateWithCaretPosition');
     inputHandler?.activateWithCaretPosition();

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -476,6 +476,32 @@ export class Toolbar {
     });
   }
 
+  /** 문서 로드 시 글꼴 드롭다운을 초기화한다 (기본 글꼴 + 문서 글꼴 + 대표/로컬) */
+  initFontDropdown(docFonts?: string[]): void {
+    const BASE_FONTS = ['함초롬바탕', '함초롬돋움', '맑은 고딕', '나눔고딕', '바탕', '돋움', '궁서'];
+    this.fontName.replaceChildren();
+    for (const name of BASE_FONTS) {
+      const opt = document.createElement('option');
+      opt.value = name;
+      opt.textContent = name;
+      this.fontName.appendChild(opt);
+    }
+    if (docFonts?.length) {
+      const seen = new Set(BASE_FONTS);
+      for (const name of docFonts) {
+        if (!seen.has(name)) {
+          const opt = document.createElement('option');
+          opt.value = name;
+          opt.textContent = name;
+          this.fontName.appendChild(opt);
+          seen.add(name);
+        }
+      }
+    }
+    this.populateFontSetOptions();
+    this.populateLocalFontOptions();
+  }
+
   /** 문서 로드 시 스타일 목록으로 드롭다운을 채운다 */
   initStyleDropdown(): void {
     try {


### PR DESCRIPTION
## 문제

문서를 열고 텍스트를 복사한 뒤 새 문서를 생성하면, 이전 문서에서 사용하던 폰트(예: HY헤드라인M)가 새 문서의 글꼴 드롭다운에 잔존합니다. 스타일 드롭다운은 `initStyleDropdown()`으로 문서 전환 시 초기화되지만, 글꼴 드롭다운에는 대응하는 초기화 메서드가 없어 폰트 옵션이 누적됩니다.

## 수정 내용

- `Toolbar.initFontDropdown(docFonts?: string[])` 메서드 추가
  - `#font-name` select 요소를 `replaceChildren()`으로 완전 초기화
  - 기본 7개 글꼴(함초롬바탕/돋움, 맑은 고딕, 나눔고딕, 바탕, 돋움, 궁서) 재등록
  - 현재 문서의 `fontsUsed` 배열에서 중복 없이 문서 고유 폰트 추가
  - `populateFontSetOptions()` + `populateLocalFontOptions()` 재호출로 대표/로컬 글꼴 복원
- `initializeDocument()`에서 `initStyleDropdown()` 직전에 `initFontDropdown(docInfo.fontsUsed)` 호출

## 테스트

- `cargo test` 전체 통과
- `cargo clippy -- -D warnings` 경고 없음

Closes #420

감사합니다.