### PR TITLE
Task #721: 중첩 표 내 필드 값 설정 — nested_path 전체 탐색으로 field_range 인덱스 초과 수정

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -215,22 +215,25 @@ impl DocumentCore {
         }
 
         // 마지막 항목: 셀의 첫 문단 텍스트를 교체
+        let last_idx = location.nested_path.len() - 1;
         let last = location.nested_path.last().unwrap();
         match last {
             NestedEntry::TableCell { control_index, cell_index, .. } => {
                 let ctrl = para.controls.get_mut(*control_index)
-                    .ok_or_else(|| HwpError::InvalidField("컨트롤이 표가 아님".into()))?;
+                    .ok_or_else(|| HwpError::InvalidField(
+                        format!("경로[{}]: 컨트롤 인덱스 {} 초과", last_idx, control_index)))?;
                 if let Control::Table(ref mut table) = ctrl {
                     let cell = table.cells.get_mut(*cell_index)
-                        .ok_or_else(|| HwpError::InvalidField("셀 인덱스 초과".into()))?;
+                        .ok_or_else(|| HwpError::InvalidField(
+                            format!("경로[{}]: 셀 인덱스 {} 초과", last_idx, cell_index)))?;
                     if let Some(cell_para) = cell.paragraphs.first_mut() {
                         cell_para.text = value.to_string();
-                        let new_len = value.chars().count();
-                        cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+                        rebuild_char_offsets(cell_para);
                     }
                     Ok(())
                 } else {
-                    Err(HwpError::InvalidField("컨트롤이 표가 아님".into()))
+                    Err(HwpError::InvalidField(
+                        format!("경로[{}]: controls[{}]가 Table이 아님", last_idx, control_index)))
                 }
             }
             _ => Err(HwpError::InvalidField("셀 필드가 아닌 위치".into())),

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -163,31 +163,75 @@ impl DocumentCore {
     }
 
     /// 셀 필드의 텍스트를 교체한다 (셀의 첫 문단 텍스트를 value로 대체).
+    /// 중첩 표를 재귀적으로 탐색하여 임의 깊이를 지원한다.
     fn set_cell_field_text(&mut self, location: &FieldLocation, value: &str) -> Result<(), HwpError> {
         if location.nested_path.is_empty() {
             return Err(HwpError::InvalidField("셀 필드 위치에 중첩 경로 없음".into()));
         }
-        let entry = &location.nested_path[0];
-        match entry {
-            NestedEntry::TableCell { control_index, cell_index, .. } => {
-                let sec = self.document.sections.get_mut(location.section_index)
-                    .ok_or_else(|| HwpError::InvalidField("구역 초과".into()))?;
-                let para = sec.paragraphs.get_mut(location.para_index)
-                    .ok_or_else(|| HwpError::InvalidField("문단 초과".into()))?;
-                let table = match para.controls.get_mut(*control_index) {
-                    Some(Control::Table(t)) => t,
-                    _ => return Err(HwpError::InvalidField("컨트롤이 표가 아님".into())),
-                };
-                let cell = table.cells.get_mut(*cell_index)
-                    .ok_or_else(|| HwpError::InvalidField("셀 인덱스 초과".into()))?;
-                // 첫 문단의 텍스트를 교체
-                if let Some(cell_para) = cell.paragraphs.first_mut() {
-                    cell_para.text = value.to_string();
-                    // char_offsets 재생성
-                    let new_len = value.chars().count();
-                    cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+        let sec = self.document.sections.get_mut(location.section_index)
+            .ok_or_else(|| HwpError::InvalidField("구역 초과".into()))?;
+        let mut para: &mut Paragraph = sec.paragraphs.get_mut(location.para_index)
+            .ok_or_else(|| HwpError::InvalidField("문단 초과".into()))?;
+
+        // 마지막 항목 직전까지 중첩 탐색
+        for (i, entry) in location.nested_path[..location.nested_path.len() - 1].iter().enumerate() {
+            para = match entry {
+                NestedEntry::TableCell { control_index, cell_index, para_index } => {
+                    let ctrl = para.controls.get_mut(*control_index)
+                        .ok_or_else(|| HwpError::InvalidField(
+                            format!("경로[{}]: 컨트롤 인덱스 {} 초과", i, control_index)))?;
+                    if let Control::Table(ref mut table) = ctrl {
+                        let cell = table.cells.get_mut(*cell_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 셀 인덱스 {} 초과", i, cell_index)))?;
+                        cell.paragraphs.get_mut(*para_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 셀 문단 인덱스 {} 초과", i, para_index)))?
+                    } else {
+                        return Err(HwpError::InvalidField(
+                            format!("경로[{}]: controls[{}]가 Table이 아님", i, control_index)));
+                    }
                 }
-                Ok(())
+                NestedEntry::TextBox { control_index, para_index } => {
+                    let ctrl = para.controls.get_mut(*control_index)
+                        .ok_or_else(|| HwpError::InvalidField(
+                            format!("경로[{}]: 컨트롤 인덱스 {} 초과", i, control_index)))?;
+                    if let Control::Shape(ref mut shape) = ctrl {
+                        let drawing = shape.drawing_mut()
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: Shape에 DrawingObjAttr 없음", i)))?;
+                        let tb = drawing.text_box.as_mut()
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: Shape에 TextBox 없음", i)))?;
+                        tb.paragraphs.get_mut(*para_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 글상자 문단 인덱스 {} 초과", i, para_index)))?
+                    } else {
+                        return Err(HwpError::InvalidField(
+                            format!("경로[{}]: controls[{}]가 Shape가 아님", i, control_index)));
+                    }
+                }
+            };
+        }
+
+        // 마지막 항목: 셀의 첫 문단 텍스트를 교체
+        let last = location.nested_path.last().unwrap();
+        match last {
+            NestedEntry::TableCell { control_index, cell_index, .. } => {
+                let ctrl = para.controls.get_mut(*control_index)
+                    .ok_or_else(|| HwpError::InvalidField("컨트롤이 표가 아님".into()))?;
+                if let Control::Table(ref mut table) = ctrl {
+                    let cell = table.cells.get_mut(*cell_index)
+                        .ok_or_else(|| HwpError::InvalidField("셀 인덱스 초과".into()))?;
+                    if let Some(cell_para) = cell.paragraphs.first_mut() {
+                        cell_para.text = value.to_string();
+                        let new_len = value.chars().count();
+                        cell_para.char_offsets = (0..new_len).map(|i| i as u32).collect();
+                    }
+                    Ok(())
+                } else {
+                    Err(HwpError::InvalidField("컨트롤이 표가 아님".into()))
+                }
             }
             _ => Err(HwpError::InvalidField("셀 필드가 아닌 위치".into())),
         }
@@ -238,47 +282,54 @@ impl DocumentCore {
 
     /// FieldLocation에 해당하는 Paragraph의 가변 참조를 반환한다.
     ///
-    /// 중첩 경로는 1단계만 지원 (표 셀 또는 글상자 내 문단).
+    /// 중첩 표/글상자를 재귀적으로 탐색하여 임의 깊이를 지원한다.
     fn get_para_mut_at_location(&mut self, location: &FieldLocation) -> Result<&mut Paragraph, HwpError> {
         let sec = self.document.sections.get_mut(location.section_index)
             .ok_or_else(|| HwpError::InvalidField("구역 인덱스 초과".into()))?;
-        let host_para = sec.paragraphs.get_mut(location.para_index)
+        let mut para = sec.paragraphs.get_mut(location.para_index)
             .ok_or_else(|| HwpError::InvalidField("문단 인덱스 초과".into()))?;
 
-        if location.nested_path.is_empty() {
-            return Ok(host_para);
+        for (i, entry) in location.nested_path.iter().enumerate() {
+            para = match entry {
+                NestedEntry::TableCell { control_index, cell_index, para_index } => {
+                    let ctrl = para.controls.get_mut(*control_index)
+                        .ok_or_else(|| HwpError::InvalidField(
+                            format!("경로[{}]: 컨트롤 인덱스 {} 초과", i, control_index)))?;
+                    if let Control::Table(ref mut table) = ctrl {
+                        let cell = table.cells.get_mut(*cell_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 셀 인덱스 {} 초과", i, cell_index)))?;
+                        cell.paragraphs.get_mut(*para_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 셀 문단 인덱스 {} 초과", i, para_index)))?
+                    } else {
+                        return Err(HwpError::InvalidField(
+                            format!("경로[{}]: controls[{}]가 Table이 아님", i, control_index)));
+                    }
+                }
+                NestedEntry::TextBox { control_index, para_index } => {
+                    let ctrl = para.controls.get_mut(*control_index)
+                        .ok_or_else(|| HwpError::InvalidField(
+                            format!("경로[{}]: 컨트롤 인덱스 {} 초과", i, control_index)))?;
+                    if let Control::Shape(ref mut shape) = ctrl {
+                        let drawing = shape.drawing_mut()
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: Shape에 DrawingObjAttr 없음", i)))?;
+                        let tb = drawing.text_box.as_mut()
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: Shape에 TextBox 없음", i)))?;
+                        tb.paragraphs.get_mut(*para_index)
+                            .ok_or_else(|| HwpError::InvalidField(
+                                format!("경로[{}]: 글상자 문단 인덱스 {} 초과", i, para_index)))?
+                    } else {
+                        return Err(HwpError::InvalidField(
+                            format!("경로[{}]: controls[{}]가 Shape가 아님", i, control_index)));
+                    }
+                }
+            };
         }
 
-        // 1단계 중첩만 처리
-        let entry = &location.nested_path[0];
-        match entry {
-            NestedEntry::TableCell { control_index, cell_index, para_index } => {
-                let ctrl = host_para.controls.get_mut(*control_index)
-                    .ok_or_else(|| HwpError::InvalidField("컨트롤 인덱스 초과".into()))?;
-                if let Control::Table(ref mut table) = ctrl {
-                    let cell = table.cells.get_mut(*cell_index)
-                        .ok_or_else(|| HwpError::InvalidField("셀 인덱스 초과".into()))?;
-                    cell.paragraphs.get_mut(*para_index)
-                        .ok_or_else(|| HwpError::InvalidField("셀 문단 인덱스 초과".into()))
-                } else {
-                    Err(HwpError::InvalidField("예상된 Table 컨트롤이 아님".into()))
-                }
-            }
-            NestedEntry::TextBox { control_index, para_index } => {
-                let ctrl = host_para.controls.get_mut(*control_index)
-                    .ok_or_else(|| HwpError::InvalidField("컨트롤 인덱스 초과".into()))?;
-                if let Control::Shape(ref mut shape) = ctrl {
-                    let drawing = shape.drawing_mut()
-                        .ok_or_else(|| HwpError::InvalidField("Shape에 DrawingObjAttr 없음".into()))?;
-                    let tb = drawing.text_box.as_mut()
-                        .ok_or_else(|| HwpError::InvalidField("Shape에 TextBox 없음".into()))?;
-                    tb.paragraphs.get_mut(*para_index)
-                        .ok_or_else(|| HwpError::InvalidField("글상자 문단 인덱스 초과".into()))
-                } else {
-                    Err(HwpError::InvalidField("예상된 Shape 컨트롤이 아님".into()))
-                }
-            }
-        }
+        Ok(para)
     }
 
     /// 본문 문단의 커서 위치에서 필드를 제거한다 (텍스트 유지, 필드 마커만 삭제).


### PR DESCRIPTION
## 문제

`setFieldValueByName` / `setFieldValue`를 호출할 때, **중첩 표** (표 안의 표) 내부에 있는 ClickHere 필드에서 `field_range 인덱스 초과` 에러가 발생합니다.

### 근본 원인

`get_para_mut_at_location`이 `nested_path[0]`만 처리하여, 2단계 이상 중첩된 표/글상자 내 필드에 접근 시 외부 표의 문단을 반환합니다. 이 문단에는 내부 필드의 `field_range`가 존재하지 않으므로 인덱스 초과가 발생합니다.

`collect_fields_from_paragraph`는 재귀적으로 중첩 구조를 탐색하여 `nested_path`에 여러 항목을 추가하지만, `get_para_mut_at_location`은 첫 항목만 사용합니다.

동일한 문제가 `set_cell_field_text`에도 존재합니다.

## 수정 내용

- `get_para_mut_at_location`: `nested_path[0]` 고정 접근을 `for` 루프로 변경하여 전체 `nested_path`를 순회. 임의 깊이의 중첩 표/글상자를 지원.
- `set_cell_field_text`: 동일하게 전체 `nested_path`를 순회하도록 수정. 마지막 항목 직전까지 중첩 탐색 후, 마지막 항목에서 셀의 첫 문단 텍스트를 교체.
- 에러 메시지에 경로 인덱스를 포함하여 디버깅 편의성 향상.

## 검증

- `cargo test` — 전체 통과 (1067 lib + 9 integration)
- `cargo clippy -- -D warnings` — 경고 0건

Closes #721

감사합니다.