### PR TITLE
Task #606: HWPX ColorRef 상위 바이트(alpha) 보존 — 표 배경 검정 렌더링 수정

### DIFF
--- a/src/parser/hwpx/utils.rs
+++ b/src/parser/hwpx/utils.rs
@@ -72,12 +72,13 @@ pub fn parse_color_str(s: &str) -> u32 {
             return b << 16 | g << 8 | r;
         }
     } else if hex.len() == 8 {
-        // AARRGGBB → 0x00BBGGRR (alpha 무시)
+        // AARRGGBB → 0xAABBGGRR (alpha 보존)
         if let Ok(v) = u32::from_str_radix(hex, 16) {
+            let a = (v >> 24) & 0xFF;
             let r = (v >> 16) & 0xFF;
             let g = (v >> 8) & 0xFF;
             let b = v & 0xFF;
-            return b << 16 | g << 8 | r;
+            return a << 24 | b << 16 | g << 8 | r;
         }
     }
     0x00000000 // 검정
@@ -135,7 +136,9 @@ mod tests {
 
     #[test]
     fn test_parse_color_str_with_alpha() {
-        // AARRGGBB — alpha 무시
-        assert_eq!(parse_color_str("#80FF0000"), 0x000000FF);
+        // AARRGGBB → 0xAABBGGRR (alpha 보존)
+        assert_eq!(parse_color_str("#80FF0000"), 0x800000FF);
+        assert_eq!(parse_color_str("#FF000000"), 0xFF000000); // 상위 바이트 비제로 → 채우기 없음
+        assert_eq!(parse_color_str("#00FF0000"), 0x000000FF); // alpha=00 → 동일
     }
 }

--- a/src/parser/hwpx/utils.rs
+++ b/src/parser/hwpx/utils.rs
@@ -51,7 +51,7 @@ pub fn parse_i32(attr: &quick_xml::events::attributes::Attribute) -> i32 {
     attr_str(attr).parse().unwrap_or(0)
 }
 
-/// "#RRGGBB" 또는 "#AARRGGBB" 형식의 색상을 HWP ColorRef(0x00BBGGRR)로 변환
+/// "#RRGGBB" → 0x00BBGGRR, "#AARRGGBB" → 0xAABBGGRR (alpha 보존)
 pub fn parse_color(attr: &quick_xml::events::attributes::Attribute) -> u32 {
     let s = attr_str(attr);
     parse_color_str(&s)

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -308,7 +308,12 @@ fn border_width_mm(w: u8) -> &'static str {
 }
 
 fn color_hex(c: ColorRef) -> String {
-    // ColorRef = u32. HWP는 0xAABBGGRR 저장. HWPX는 "#RRGGBB" 또는 "#AARRGGBB".
+    // ColorRef = u32. HWP 내부 저장: 상위 바이트가 비투명 플래그(0이면 유효 색상).
+    // 0xFFFFFFFF = 투명/없음 센티넬 → "none"
+    if c == 0xFFFFFFFF {
+        return "none".to_string();
+    }
+    // HWPX는 "#RRGGBB" 또는 "#AARRGGBB".
     let a = ((c >> 24) & 0xFF) as u8;
     let r = (c & 0xFF) as u8;
     let g = ((c >> 8) & 0xFF) as u8;

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -308,11 +308,16 @@ fn border_width_mm(w: u8) -> &'static str {
 }
 
 fn color_hex(c: ColorRef) -> String {
-    // ColorRef = u32. HWP는 BGR 저장. HWPX는 RGB "#RRGGBB".
+    // ColorRef = u32. HWP는 0xAABBGGRR 저장. HWPX는 "#RRGGBB" 또는 "#AARRGGBB".
+    let a = ((c >> 24) & 0xFF) as u8;
     let r = (c & 0xFF) as u8;
     let g = ((c >> 8) & 0xFF) as u8;
     let b = ((c >> 16) & 0xFF) as u8;
-    format!("#{:02X}{:02X}{:02X}", r, g, b)
+    if a == 0 {
+        format!("#{:02X}{:02X}{:02X}", r, g, b)
+    } else {
+        format!("#{:02X}{:02X}{:02X}{:02X}", a, r, g, b)
+    }
 }
 
 // =====================================================================

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -335,10 +335,15 @@ fn color_ref_to_hwpx(color: u32) -> String {
         return "none".to_string();
     }
 
+    let a = (color >> 24) & 0xFF;
     let r = color & 0xFF;
     let g = (color >> 8) & 0xFF;
     let b = (color >> 16) & 0xFF;
-    format!("#{r:02X}{g:02X}{b:02X}")
+    if a == 0 {
+        format!("#{r:02X}{g:02X}{b:02X}")
+    } else {
+        format!("#{a:02X}{r:02X}{g:02X}{b:02X}")
+    }
 }
 
 fn text_wrap_to_hwpx(wrap: TextWrap) -> &'static str {


### PR DESCRIPTION
## 문제

HWPX 문서의 `faceColor="#FF000000"` (alpha=0xFF, 채우기 없음)이 `0x00000000` (검정)으로 파싱되어 표 배경이 검정색으로 렌더링됩니다.

### 근본 원인

`parse_color_str`이 `#AARRGGBB` 8자리 입력에서 상위 alpha 바이트를 버리고 `0x00BBGGRR`로 변환합니다. `style_resolver`는 ColorRef 상위 바이트가 비제로이면 "채우기 없음"으로 처리하는 로직이 이미 있으나, alpha가 소실되어 이 분기에 도달하지 못합니다.

## 수정 내용

- `src/parser/hwpx/utils.rs` — `parse_color_str`: `#AARRGGBB` → `0xAABBGGRR` (alpha 보존)
- `src/serializer/hwpx/header.rs` — `color_hex`: alpha 비제로 시 `#AARRGGBB` 출력
- `src/serializer/hwpx/section.rs` — `color_ref_to_hwpx`: 동일하게 alpha 보존 출력
- 기존 테스트 `test_parse_color_str_with_alpha` 수정 및 케이스 추가

## 검증

- `cargo test` — 전체 통과
- `cargo clippy -- -D warnings` — 경고 0건

Closes #606

감사합니다.