### PR TITLE
Task #634: 첫 NewNumber Page 발화 전 쪽번호 미표시 — 한컴 호환

### DIFF
--- a/src/renderer/page_number.rs
+++ b/src/renderer/page_number.rs
@@ -19,6 +19,9 @@ pub(crate) struct PageNumberAssigner<'a> {
     new_page_numbers: &'a [(usize, u16)],
     consumed: HashSet<usize>,
     counter: u32,
+    /// NewNumber 컨트롤이 1건 이상 소비되었는지 여부.
+    /// 한컴 호환: NewNumber가 존재하면 첫 발화 전 페이지에는 쪽번호 미표시.
+    numbering_started: bool,
 }
 
 impl<'a> PageNumberAssigner<'a> {
@@ -28,6 +31,7 @@ impl<'a> PageNumberAssigner<'a> {
             new_page_numbers,
             consumed: HashSet::new(),
             counter: initial,
+            numbering_started: false,
         }
     }
 
@@ -43,8 +47,7 @@ impl<'a> PageNumberAssigner<'a> {
             if Self::para_first_appears(page, nn_pi) {
                 self.counter = nn_num as u32;
                 self.consumed.insert(idx);
-                // break 하지 않고 계속 — 한 페이지 안에 여러 NewNumber 가 모두 처음 등장하면
-                // 마지막 것이 적용된다 (현실적으로 거의 발생하지 않음).
+                self.numbering_started = true;
             }
         }
         let assigned = self.counter;
@@ -55,6 +58,12 @@ impl<'a> PageNumberAssigner<'a> {
     /// 다음 페이지에 적용될 카운터 값 (구역 carry 용).
     pub fn next_counter(&self) -> u32 {
         self.counter
+    }
+
+    /// NewNumber가 존재하지만 아직 발화되지 않은 상태인지 판별한다.
+    /// true이면 이 페이지에 쪽번호를 표시하지 않아야 한다 (한컴 호환).
+    pub fn should_hide_page_number(&self) -> bool {
+        !self.new_page_numbers.is_empty() && !self.numbering_started
     }
 
     fn para_first_appears(page: &PageContent, target_pi: usize) -> bool {

--- a/src/renderer/page_number.rs
+++ b/src/renderer/page_number.rs
@@ -237,6 +237,31 @@ mod tests {
     }
 
     #[test]
+    fn should_hide_before_first_new_number() {
+        let nns = vec![(5usize, 1u16)];
+        let mut a = PageNumberAssigner::new(&nns, 1);
+        assert!(a.should_hide_page_number(), "NewNumber 존재 + 미발화 → 숨김");
+
+        let p1 = mk_page(vec![PageItem::FullParagraph { para_index: 0 }]);
+        a.assign(&p1);
+        assert!(a.should_hide_page_number(), "아직 NewNumber 미트리거 → 숨김");
+
+        let p2 = mk_page(vec![PageItem::FullParagraph { para_index: 5 }]);
+        a.assign(&p2);
+        assert!(!a.should_hide_page_number(), "NewNumber 발화 후 → 표시");
+
+        let p3 = mk_page(vec![PageItem::FullParagraph { para_index: 6 }]);
+        a.assign(&p3);
+        assert!(!a.should_hide_page_number(), "이후에도 계속 표시");
+    }
+
+    #[test]
+    fn should_not_hide_when_no_new_numbers() {
+        let a = PageNumberAssigner::new(&[], 1);
+        assert!(!a.should_hide_page_number(), "NewNumber 없으면 항상 표시");
+    }
+
+    #[test]
     fn multiple_new_numbers_each_consumed_once() {
         // 별첨 시작 시점에 NewNumber=1 이 또 한번 등장하는 케이스
         let nns = vec![(5usize, 1u16), (20usize, 1u16)];

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -1899,7 +1899,9 @@ impl Paginator {
                 footer_even.clone().or_else(|| footer_both.clone())
             };
 
-            page.page_number_pos = page_number_pos.clone();
+            if !assigner.should_hide_page_number() {
+                page.page_number_pos = page_number_pos.clone();
+            }
             // PageHide: 해당 문단이 이 페이지에서 **처음** 시작하는 경우만 적용
             // (문단이 여러 페이지에 걸치면 첫 페이지에서만 감추기 적용)
             for (ph_para, ph) in page_hides {

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2069,7 +2069,9 @@ impl TypesetEngine {
             page.page_number = page_num;
             page.active_header = current_header.clone();
             page.active_footer = current_footer.clone();
-            page.page_number_pos = page_number_pos.clone();
+            if !assigner.should_hide_page_number() {
+                page.page_number_pos = page_number_pos.clone();
+            }
 
             // PageHide: 해당 문단이 이 페이지에서 **처음** 시작하는 경우만 적용
             // (engine.rs 의 동일 로직과 일치 — 머리말/꼬리말/바탕쪽/페이지번호 감추기)


### PR DESCRIPTION
## 문제

`PageNumberPos` 컨트롤이 등록된 시점부터 모든 페이지에 쪽번호가 표시됩니다. 한컴오피스는 첫 `NewNumber Page` 컨트롤이 발화한 페이지부터만 쪽번호를 표시합니다.

결과: 표지/요약문/목차 페이지에서 한컴과 시각 차이 발생.

## 수정 내용

- `PageNumberAssigner`에 `numbering_started: bool` 플래그 추가
- `assign()` 호출 시 첫 NewNumber 소비 시점에 `true`로 전환
- `should_hide_page_number()` 메서드 추가: NewNumber가 존재하지만 아직 미발화 시 `true`
- `finalize_pages()`에서 `page_number_pos` 할당을 `should_hide_page_number()` 가드로 게이트

NewNumber 컨트롤이 없는 문서(기존 대부분 문서)는 `new_page_numbers`가 빈 벡터이므로 `should_hide_page_number()`가 항상 `false` — 기존 동작과 동일합니다.

## 검증

- `cargo test` — 전체 통과
- `cargo clippy -- -D warnings` — 경고 0건
- `samples/aift.hwp`:
  - 페이지 1~6 (표지/목차): 쪽번호 미출력 (한컴 동일)
  - 페이지 7 (NewNumber Page=1 발화): "- 1 -" 정상 출력

Closes #634

감사합니다.