### PR TITLE
Task #260: Ctrl/Cmd+Arrow 커서 이동 — 줄/문서 시작·끝

### DIFF
--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -892,7 +892,7 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
     return;
   }
 
-  // 커맨드 시스템에 없는 직접 처리 (Ctrl+Home/End 등 커서 이동)
+  // 커맨드 시스템에 없는 직접 처리 (Ctrl+Home/End, Ctrl/Cmd+Arrow 등 커서 이동)
   switch (e.key.toLowerCase()) {
     case 'home': {
       e.preventDefault();
@@ -916,6 +916,42 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
         this.cursor.moveToDocumentEnd();
       }
       this.updateCaret();
+      break;
+    }
+    case 'arrowleft': {
+      e.preventDefault();
+      if (e.shiftKey) this.cursor.setAnchor();
+      else this.cursor.clearSelection();
+      this.cursor.moveToLineStart();
+      this.updateCaret();
+      if (e.shiftKey) this.updateSelection();
+      break;
+    }
+    case 'arrowright': {
+      e.preventDefault();
+      if (e.shiftKey) this.cursor.setAnchor();
+      else this.cursor.clearSelection();
+      this.cursor.moveToLineEnd();
+      this.updateCaret();
+      if (e.shiftKey) this.updateSelection();
+      break;
+    }
+    case 'arrowup': {
+      e.preventDefault();
+      if (e.shiftKey) this.cursor.setAnchor();
+      else this.cursor.clearSelection();
+      this.cursor.moveToDocumentStart();
+      this.updateCaret();
+      if (e.shiftKey) this.updateSelection();
+      break;
+    }
+    case 'arrowdown': {
+      e.preventDefault();
+      if (e.shiftKey) this.cursor.setAnchor();
+      else this.cursor.clearSelection();
+      this.cursor.moveToDocumentEnd();
+      this.updateCaret();
+      if (e.shiftKey) this.updateSelection();
       break;
     }
     // 그 외 Ctrl 조합 (줌 등)은 브라우저 기본 동작 허용

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -924,7 +924,6 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
       else this.cursor.clearSelection();
       this.cursor.moveToLineStart();
       this.updateCaret();
-      if (e.shiftKey) this.updateSelection();
       break;
     }
     case 'arrowright': {
@@ -933,7 +932,6 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
       else this.cursor.clearSelection();
       this.cursor.moveToLineEnd();
       this.updateCaret();
-      if (e.shiftKey) this.updateSelection();
       break;
     }
     case 'arrowup': {
@@ -942,7 +940,6 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
       else this.cursor.clearSelection();
       this.cursor.moveToDocumentStart();
       this.updateCaret();
-      if (e.shiftKey) this.updateSelection();
       break;
     }
     case 'arrowdown': {
@@ -951,7 +948,6 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
       else this.cursor.clearSelection();
       this.cursor.moveToDocumentEnd();
       this.updateCaret();
-      if (e.shiftKey) this.updateSelection();
       break;
     }
     // 그 외 Ctrl 조합 (줌 등)은 브라우저 기본 동작 허용


### PR DESCRIPTION
## 문제

macOS에서 `Cmd+Arrow` 조합이 처리되지 않아 줄 시작/끝, 문서 시작/끝으로 이동할 수 없습니다. Windows의 `Ctrl+Arrow`도 마찬가지입니다.

## 수정 내용

`handleCtrlKey()`에 Arrow 키 처리 추가:

| 키 조합 | 동작 | 기존 대응 키 |
|---------|------|-------------|
| Ctrl/Cmd + ← | 줄 시작 | Home |
| Ctrl/Cmd + → | 줄 끝 | End |
| Ctrl/Cmd + ↑ | 문서 시작 | Ctrl+Home |
| Ctrl/Cmd + ↓ | 문서 끝 | Ctrl+End |

모든 방향에 `Shift` 조합으로 선택 범위 확장을 지원합니다.

## 범위

- 이 PR은 #260의 첫 단계로, Ctrl/Cmd+Arrow 방향키에 대한 커서 이동만 구현합니다.
- Option+Arrow (단어 단위 이동)은 단어 경계 감지 로직이 필요하여 후속 작업으로 남겨둡니다.

## 검증

- TypeScript 타입 체크 통과 (WASM 모듈 import 제외)
- `cargo test` — 전체 통과

감사합니다.