### PR TITLE
Task #307: 이미지 파일 드래그 앤 드롭 삽입

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -251,11 +251,22 @@ function setupFileInput(): void {
     const file = e.dataTransfer?.files[0];
     if (!file) return;
     const dropName = file.name.toLowerCase();
-    if (!dropName.endsWith('.hwp') && !dropName.endsWith('.hwpx')) {
-      alert('HWP/HWPX 파일만 지원합니다.');
+    if (dropName.endsWith('.hwp') || dropName.endsWith('.hwpx')) {
+      await loadFile(file);
       return;
     }
-    await loadFile(file);
+    const imageExts = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
+    if (imageExts.some(ext => dropName.endsWith(ext)) && inputHandler && wasm.pageCount > 0) {
+      const data = new Uint8Array(await file.arrayBuffer());
+      const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
+      const img = new Image();
+      img.src = URL.createObjectURL(file);
+      await new Promise<void>(r => { img.onload = () => r(); });
+      URL.revokeObjectURL(img.src);
+      inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      return;
+    }
+    alert('HWP/HWPX 또는 이미지 파일만 지원합니다.');
   });
 }
 

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -256,14 +256,27 @@ function setupFileInput(): void {
       return;
     }
     const imageExts = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
-    if (imageExts.some(ext => dropName.endsWith(ext)) && inputHandler && wasm.pageCount > 0) {
+    if (imageExts.some(ext => dropName.endsWith(ext))) {
+      if (!inputHandler || wasm.pageCount === 0) {
+        alert('문서를 먼저 열어주세요.');
+        return;
+      }
       const data = new Uint8Array(await file.arrayBuffer());
       const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
       const img = new Image();
-      img.src = URL.createObjectURL(file);
-      await new Promise<void>(r => { img.onload = () => r(); });
-      URL.revokeObjectURL(img.src);
-      inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      const objectUrl = URL.createObjectURL(file);
+      try {
+        await new Promise<void>((resolve, reject) => {
+          img.onload = () => resolve();
+          img.onerror = () => reject(new Error('이미지 로드 실패'));
+          img.src = objectUrl;
+        });
+        inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      } catch {
+        alert('이미지 파일을 읽을 수 없습니다.');
+      } finally {
+        URL.revokeObjectURL(objectUrl);
+      }
       return;
     }
     alert('HWP/HWPX 또는 이미지 파일만 지원합니다.');


### PR DESCRIPTION
## 문제

편집 영역에 이미지 파일을 드래그 앤 드롭하면 "HWP/HWPX 파일만 지원합니다" 에러가 표시됩니다. 한글 등 다른 워드프로세서에서는 이미지를 드래그 앤 드롭으로 삽입할 수 있습니다.

## 수정 내용

편집 영역 drop 이벤트 핸들러에 이미지 파일 처리 추가:
- PNG/JPEG/GIF/BMP/WebP 확장자 감지
- 문서가 열려있고 inputHandler가 존재할 때만 동작
- 기존 `insert:image` 커맨드와 동일한 `enterImagePlacementMode` 호출
- HWP/HWPX 드롭은 기존 동작 유지
- 미지원 파일 드롭 시 에러 메시지 한국어화

## 검증

- TypeScript 타입 체크 통과
- `cargo test` — 전체 통과

Closes #307

감사합니다.