### PR TITLE
Task #158: 표 크기 조절 Undo/Redo — SnapshotCommand 적용

### DIFF
--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -188,14 +188,17 @@ export function finishResizeDrag(this: any, e: MouseEvent): void {
   const ppi = state.tableRef.ppi;
   const ci = state.tableRef.ci;
   const pos = this.cursor.getPosition();
-  this.executeOperation({
-    kind: 'snapshot', operationType: 'resizeTable',
-    operation: (wasm: any) => {
-      wasm.resizeTableCells(sec, ppi, ci, updates);
-      return pos;
-    },
-  });
-  this.eventBus.emit('document-changed');
+  try {
+    this.executeOperation({
+      kind: 'snapshot', operationType: 'resizeTable',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(sec, ppi, ci, updates);
+        return pos;
+      },
+    });
+  } catch (err) {
+    console.warn('[InputHandler] finishResizeDrag 실패:', err);
+  }
   if (inCellSel) this.updateCellSelection();
 
   this.cleanupResizeDrag();
@@ -494,14 +497,17 @@ export function resizeCellByKeyboard(this: any, key: 'ArrowUp' | 'ArrowDown' | '
   }
 
   const pos = this.cursor.getPosition();
-  this.executeOperation({
-    kind: 'snapshot', operationType: 'resizeCell',
-    operation: (wasm: any) => {
-      wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
-      return pos;
-    },
-  });
-  this.eventBus.emit('document-changed');
+  try {
+    this.executeOperation({
+      kind: 'snapshot', operationType: 'resizeCell',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+        return pos;
+      },
+    });
+  } catch (err) {
+    console.warn('[InputHandler] resizeCellByKeyboard 실패:', err);
+  }
   this.updateCellSelection();
 }
 
@@ -537,7 +543,6 @@ export function resizeTableProportional(this: any, key: 'ArrowUp' | 'ArrowDown' 
         return pos;
       },
     });
-    this.eventBus.emit('document-changed');
     this.updateCellSelection();
   } catch (err) {
     console.warn('[InputHandler] resizeTableProportional 실패:', err);

--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -183,19 +183,20 @@ export function finishResizeDrag(this: any, e: MouseEvent): void {
     });
   }
 
-  // WASM 배치 API 호출
-  try {
-    this.wasm.resizeTableCells(
-      state.tableRef.sec,
-      state.tableRef.ppi,
-      state.tableRef.ci,
-      updates,
-    );
-    this.eventBus.emit('document-changed');
-    if (inCellSel) this.updateCellSelection();
-  } catch (err) {
-    console.warn('[InputHandler] resizeTableCells 실패:', err);
-  }
+  // Undo 이력 등록 + WASM 배치 API 호출
+  const sec = state.tableRef.sec;
+  const ppi = state.tableRef.ppi;
+  const ci = state.tableRef.ci;
+  const pos = this.cursor.getPosition();
+  this.executeOperation({
+    kind: 'snapshot', operationType: 'resizeTable',
+    operation: (wasm: any) => {
+      wasm.resizeTableCells(sec, ppi, ci, updates);
+      return pos;
+    },
+  });
+  this.eventBus.emit('document-changed');
+  if (inCellSel) this.updateCellSelection();
 
   this.cleanupResizeDrag();
 }
@@ -492,13 +493,16 @@ export function resizeCellByKeyboard(this: any, key: 'ArrowUp' | 'ArrowDown' | '
     }
   }
 
-  try {
-    this.wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
-    this.eventBus.emit('document-changed');
-    this.updateCellSelection();
-  } catch (err) {
-    console.warn('[InputHandler] resizeCellByKeyboard 실패:', err);
-  }
+  const pos = this.cursor.getPosition();
+  this.executeOperation({
+    kind: 'snapshot', operationType: 'resizeCell',
+    operation: (wasm: any) => {
+      wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+      return pos;
+    },
+  });
+  this.eventBus.emit('document-changed');
+  this.updateCellSelection();
 }
 
 /** 전체 표 비율 리사이즈 (phase 3, Ctrl+방향키) */
@@ -525,7 +529,14 @@ export function resizeTableProportional(this: any, key: 'ArrowUp' | 'ArrowDown' 
       }
     }
 
-    this.wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+    const pos = this.cursor.getPosition();
+    this.executeOperation({
+      kind: 'snapshot', operationType: 'resizeTableProportional',
+      operation: (wasm: any) => {
+        wasm.resizeTableCells(ctx.sec, ctx.ppi, ctx.ci, updates);
+        return pos;
+      },
+    });
     this.eventBus.emit('document-changed');
     this.updateCellSelection();
   } catch (err) {


### PR DESCRIPTION
## 문제

표 크기 조절(마우스 드래그, 키보드, Ctrl+방향키 비율 리사이즈) 후 Ctrl+Z로 되돌릴 수 없습니다. `resizeTableCells` WASM API가 Undo 이력 없이 직접 호출되어 변경 내역이 기록되지 않습니다.

## 수정 내용

세 가지 크기 조절 경로 모두 `executeOperation({ kind: 'snapshot' })` 경유로 변경:

1. **마우스 드래그 리사이즈** (`finishResizeDrag`): `operationType: 'resizeTable'`
2. **키보드 셀 리사이즈** (`resizeCellByKeyboard`): `operationType: 'resizeCell'`
3. **Ctrl+방향키 비율 리사이즈** (`resizeTableProportional`): `operationType: 'resizeTableProportional'`

기존 `SnapshotCommand` 인프라를 그대로 활용하여 before/after 문서 스냅샷을 자동 관리합니다.

## 검증

- TypeScript 타입 체크 통과
- `cargo test` — 전체 통과

Closes #158

감사합니다.