### PR TITLE
Task #223: Ctrl/Cmd+O 파일 열기 단축키 추가

### DIFF
--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -19,6 +19,7 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   // 파일
   [{ key: 'n', alt: true }, 'file:new-doc'],
   [{ key: 'ㅜ', alt: true }, 'file:new-doc'],
+  [{ key: 'o', ctrl: true }, 'file:open'],
   [{ key: 's', ctrl: true }, 'file:save'],
   [{ key: 'p', ctrl: true }, 'file:print'],
 

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -20,6 +20,7 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   [{ key: 'n', alt: true }, 'file:new-doc'],
   [{ key: 'ㅜ', alt: true }, 'file:new-doc'],
   [{ key: 'o', ctrl: true }, 'file:open'],
+  [{ key: 'ㅐ', ctrl: true }, 'file:open'],
   [{ key: 's', ctrl: true }, 'file:save'],
   [{ key: 'p', ctrl: true }, 'file:print'],
 

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -215,6 +215,14 @@ function setupGlobalShortcuts(): void {
         return;
       }
     }
+    // Ctrl/Cmd+O → 열기 (문서 미로드 상태에서도 동작)
+    if (ctrlOrMeta && !e.altKey && !e.shiftKey) {
+      if (e.key === 'o' || e.key === 'O' || e.key === 'ㅐ') {
+        e.preventDefault();
+        dispatcher.dispatch('file:open');
+        return;
+      }
+    }
   }, false);
 }
 


### PR DESCRIPTION
## 문제

Ctrl+O (Windows) / Cmd+O (macOS) 단축키로 파일 열기가 지원되지 않습니다. 대부분의 문서 편집기에서 기본 제공하는 단축키입니다.

## 수정 내용

- `shortcut-map.ts`: `Ctrl+O → file:open` 매핑 추가
- `main.ts` `setupGlobalShortcuts`: 문서 미로드 상태에서도 `Ctrl/Cmd+O`로 파일 열기 대화상자 호출
- 한글 IME 상태(`ㅐ`)도 처리

## 범위

이 PR은 #223의 일부로, 파일 열기 단축키만 구현합니다.

## 검증

- TypeScript 타입 체크 통과

감사합니다.