### PR TITLE
feat: 다단 설정 대화상자 구현 (#733)

### DIFF
--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from '../types';
 import { PageSetupDialog } from '@/ui/page-setup-dialog';
 import { SectionSettingsDialog } from '@/ui/section-settings-dialog';
+import { ColumnSettingsDialog } from '@/ui/column-settings-dialog';
 
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
   return {
@@ -438,7 +439,19 @@ export const pageCommands: CommandDef[] = [
       } catch (err) { console.warn('[page:col-right]', err); }
     },
   },
-  stub('page:col-settings', '다단 설정', undefined, 'Ctrl+Alt+Enter'),
+  {
+    id: 'page:col-settings',
+    label: '다단 설정',
+    shortcutLabel: 'Ctrl+Alt+Enter',
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const pos = ih.getPosition();
+      const dlg = new ColumnSettingsDialog(services.wasm, services.eventBus, pos.sectionIndex);
+      dlg.show();
+    },
+  },
   // ─── 구역 설정 ──────────────────────────────────
   {
     id: 'page:section-settings',

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -56,6 +56,7 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   // 쪽
   [{ key: 'enter', ctrl: true }, 'page:break'],
   [{ key: 'enter', ctrl: true, shift: true }, 'page:column-break'],
+  [{ key: 'enter', ctrl: true, alt: true }, 'page:col-settings'],
 
   // 줄간격
   [{ key: 'a', alt: true, shift: true }, 'format:line-spacing-decrease'],

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -273,6 +273,11 @@ export class WasmBridge {
     return (this.doc as any).insertColumnBreak(sec, para, charOffset);
   }
 
+  getColumnDef(sec: number): { columnCount: number; columnType: number; sameWidth: boolean; spacing: number } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse((this.doc as any).getColumnDef(sec));
+  }
+
   setColumnDef(sec: number, columnCount: number, columnType: number, sameWidth: number, spacingHu: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).setColumnDef(sec, columnCount, columnType, sameWidth, spacingHu);

--- a/rhwp-studio/src/ui/column-settings-dialog.ts
+++ b/rhwp-studio/src/ui/column-settings-dialog.ts
@@ -2,7 +2,7 @@ import { ModalDialog } from './dialog';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { EventBus } from '@/core/event-bus';
 
-const HWPUNIT_PER_MM = 283.46; // 1mm ≈ 283.46 HWPUNIT (7200/25.4)
+const HWPUNIT_PER_MM = 7200 / 25.4;
 
 function hwpunitToMm(hu: number): number {
   return Math.round(hu / HWPUNIT_PER_MM * 10) / 10;
@@ -104,17 +104,16 @@ export class ColumnSettingsDialog extends ModalDialog {
     }
   }
 
-  protected onOk(): void {
-    const count = parseInt(this.countInput.value, 10) || 1;
-    const type = parseInt(this.typeSelect.value, 10) || 0;
+  protected onConfirm(): void {
+    const count = Math.max(1, Math.min(8, parseInt(this.countInput.value, 10) || 1));
+    const type = Math.max(0, Math.min(2, parseInt(this.typeSelect.value, 10) || 0));
     const sameWidth = this.sameWidthCheck.checked ? 1 : 0;
-    const spacingHu = mmToHwpunit(parseFloat(this.spacingInput.value) || 0);
+    const spacingHu = Math.max(0, Math.min(32767, mmToHwpunit(parseFloat(this.spacingInput.value) || 0)));
     try {
       this.wasm.setColumnDef(this.sectionIdx, count, type, sameWidth, spacingHu);
       this.eventBus.emit('document-changed');
     } catch (err) {
       console.warn('[ColumnSettingsDialog] 다단 설정 실패:', err);
     }
-    this.close();
   }
 }

--- a/rhwp-studio/src/ui/column-settings-dialog.ts
+++ b/rhwp-studio/src/ui/column-settings-dialog.ts
@@ -1,0 +1,120 @@
+import { ModalDialog } from './dialog';
+import type { WasmBridge } from '@/core/wasm-bridge';
+import type { EventBus } from '@/core/event-bus';
+
+const HWPUNIT_PER_MM = 283.46; // 1mm ≈ 283.46 HWPUNIT (7200/25.4)
+
+function hwpunitToMm(hu: number): number {
+  return Math.round(hu / HWPUNIT_PER_MM * 10) / 10;
+}
+
+function mmToHwpunit(mm: number): number {
+  return Math.round(mm * HWPUNIT_PER_MM);
+}
+
+const LABEL_MIN_W = '80px';
+
+export class ColumnSettingsDialog extends ModalDialog {
+  private wasm: WasmBridge;
+  private eventBus: EventBus;
+  private sectionIdx: number;
+
+  private countInput!: HTMLInputElement;
+  private typeSelect!: HTMLSelectElement;
+  private sameWidthCheck!: HTMLInputElement;
+  private spacingInput!: HTMLInputElement;
+
+  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number) {
+    super('다단 설정', 360);
+    this.wasm = wasm;
+    this.eventBus = eventBus;
+    this.sectionIdx = sectionIdx;
+  }
+
+  show(): void {
+    super.show();
+    this.populateFields();
+  }
+
+  protected createBody(): HTMLElement {
+    const body = document.createElement('div');
+
+    const addRow = (label: string): HTMLElement => {
+      const row = document.createElement('div');
+      row.style.cssText = 'display:flex;align-items:center;margin-bottom:10px;gap:8px;';
+      const lbl = document.createElement('label');
+      lbl.textContent = label;
+      lbl.style.cssText = `min-width:${LABEL_MIN_W};font-size:13px;`;
+      row.appendChild(lbl);
+      body.appendChild(row);
+      return row;
+    };
+
+    // 단 수
+    const countRow = addRow('단 수');
+    this.countInput = document.createElement('input');
+    this.countInput.type = 'number';
+    this.countInput.min = '1';
+    this.countInput.max = '8';
+    this.countInput.style.cssText = 'width:60px;padding:4px 6px;font-size:13px;';
+    countRow.appendChild(this.countInput);
+
+    // 단 종류
+    const typeRow = addRow('종류');
+    this.typeSelect = document.createElement('select');
+    this.typeSelect.style.cssText = 'width:120px;padding:4px;font-size:13px;';
+    for (const [val, text] of [['0', '일반'], ['1', '배분'], ['2', '평행']]) {
+      const opt = document.createElement('option');
+      opt.value = val;
+      opt.textContent = text;
+      this.typeSelect.appendChild(opt);
+    }
+    typeRow.appendChild(this.typeSelect);
+
+    // 너비 동일
+    const sameRow = addRow('너비 동일');
+    this.sameWidthCheck = document.createElement('input');
+    this.sameWidthCheck.type = 'checkbox';
+    sameRow.appendChild(this.sameWidthCheck);
+
+    // 단 간격
+    const spacingRow = addRow('간격 (mm)');
+    this.spacingInput = document.createElement('input');
+    this.spacingInput.type = 'number';
+    this.spacingInput.min = '0';
+    this.spacingInput.step = '0.5';
+    this.spacingInput.style.cssText = 'width:80px;padding:4px 6px;font-size:13px;';
+    spacingRow.appendChild(this.spacingInput);
+
+    return body;
+  }
+
+  private populateFields(): void {
+    try {
+      const def = this.wasm.getColumnDef(this.sectionIdx);
+      this.countInput.value = String(Math.max(def.columnCount, 1));
+      this.typeSelect.value = String(def.columnType);
+      this.sameWidthCheck.checked = def.sameWidth;
+      this.spacingInput.value = String(hwpunitToMm(def.spacing));
+    } catch {
+      this.countInput.value = '1';
+      this.typeSelect.value = '0';
+      this.sameWidthCheck.checked = true;
+      this.spacingInput.value = '8';
+    }
+  }
+
+  protected onOk(): void {
+    const count = parseInt(this.countInput.value, 10) || 1;
+    const type = parseInt(this.typeSelect.value, 10) || 0;
+    const sameWidth = this.sameWidthCheck.checked ? 1 : 0;
+    const spacingHu = mmToHwpunit(parseFloat(this.spacingInput.value) || 0);
+    try {
+      this.wasm.setColumnDef(this.sectionIdx, count, type, sameWidth, spacingHu);
+      this.eventBus.emit('document-changed');
+    } catch (err) {
+      console.warn('[ColumnSettingsDialog] 다단 설정 실패:', err);
+    }
+    this.close();
+  }
+}

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -408,6 +408,23 @@ impl HwpDocument {
         self.set_section_def_all_native(json).map_err(|e| e.into())
     }
 
+    /// 현재 구역의 다단 설정을 JSON으로 반환한다.
+    #[wasm_bindgen(js_name = getColumnDef)]
+    pub fn get_column_def(&self, section_idx: u32) -> Result<String, JsValue> {
+        let sec = self.core.document.sections.get(section_idx as usize)
+            .ok_or_else(|| JsValue::from_str("구역 인덱스 범위 초과"))?;
+        let col_def = HwpDocument::find_initial_column_def(&sec.paragraphs);
+        let col_type = match col_def.column_type {
+            crate::model::page::ColumnType::Normal => 0,
+            crate::model::page::ColumnType::Distribute => 1,
+            crate::model::page::ColumnType::Parallel => 2,
+        };
+        Ok(format!(
+            "{{\"columnCount\":{},\"columnType\":{},\"sameWidth\":{},\"spacing\":{}}}",
+            col_def.column_count, col_type, col_def.same_width, col_def.spacing,
+        ))
+    }
+
     /// 문서 정보를 JSON 문자열로 반환한다.
     #[wasm_bindgen(js_name = getDocumentInfo)]
     pub fn get_document_info(&self) -> String {


### PR DESCRIPTION
## 변경 사항

이슈 #733 에서 요청된 다단 설정 대화상자를 구현합니다.

- **Rust (wasm_api.rs)**: `getColumnDef` WASM API 추가 — 현재 구역의 다단 설정(단 수, 종류, 너비 동일, 간격)을 JSON으로 반환
- **TS (column-settings-dialog.ts)**: `ColumnSettingsDialog` 클래스 — 기존 `SectionSettingsDialog`와 동일한 `ModalDialog` 패턴
  - 단 수 (1~8)
  - 종류 (일반/배분/평행)
  - 너비 동일 체크박스
  - 간격 (mm 단위)
- **TS (page.ts)**: `page:col-settings` 커맨드를 stub에서 실제 구현으로 대체
- **TS (shortcut-map.ts)**: `Ctrl+Alt+Enter` → `page:col-settings` 매핑 추가

## 테스트

- `cargo test` 1173개 통과
- `cargo clippy -- -D warnings` 경고 없음

Closes #733

감사합니다.