### PR TITLE
fix: 문단 정렬 Alt+Shift 단축키 한국어 IME 매핑 추가

### DIFF
--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -81,8 +81,11 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   // Ctrl+Shift+C: 브라우저 요소검사 충돌 → Alt+Shift+C로 재매핑
   // Ctrl+Shift+T: 브라우저 탭복원 충돌 → Alt+Shift+T로 재매핑
   [{ key: 'h', alt: true, shift: true }, 'format:align-right'],   // 오른쪽 정렬 (재매핑, H=rigHt)
+  [{ key: 'ㅗ', alt: true, shift: true }, 'format:align-right'],
   [{ key: 'c', alt: true, shift: true }, 'format:align-center'],  // 가운데 정렬 (재매핑)
+  [{ key: 'ㅊ', alt: true, shift: true }, 'format:align-center'],
   [{ key: 'd', alt: true, shift: true }, 'format:align-distribute'], // 배분 정렬 (재매핑)
+  [{ key: 'ㅇ', alt: true, shift: true }, 'format:align-distribute'],
 
   // 표
   [{ key: 'insert', alt: true }, 'table:insert-col-left'],


### PR DESCRIPTION
## 문제

문단 정렬 단축키(Alt+Shift+H/C/D)에 한국어 IME 자모 매핑이 누락되어, 한글 입력 상태에서 오른쪽/가운데/배분 정렬 단축키가 동작하지 않습니다.

기존 줄간격(Alt+Shift+A→ㅁ, Z→ㅋ), 글꼴 크기(E→ㄷ, R→ㄱ) 단축키에는 이미 한국어 매핑이 있으나 정렬 단축키 3개만 빠져 있었습니다.

## 수정 내용

| 단축키 | 기능 | 추가된 매핑 |
|--------|------|------------|
| Alt+Shift+H | 오른쪽 정렬 | `ㅗ` |
| Alt+Shift+C | 가운데 정렬 | `ㅊ` |
| Alt+Shift+D | 배분 정렬 | `ㅇ` |

## 테스트

- `cargo test` 통과
- `cargo clippy -- -D warnings` 경고 없음

Closes #223 (부분)

감사합니다.