### PR TITLE
feat: page:new-page-num (새 번호로 시작) 커맨드 구현

### DIFF
--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -276,7 +276,9 @@ export const pageCommands: CommandDef[] = [
       const ih = services.getInputHandler();
       if (!ih) return;
       const pos = ih.getPosition();
-      const dlg = new NumberingRestartDialog(1, (startNum) => {
+      const cursor = (ih as any).cursor;
+      const currentPage = (cursor?.rect?.pageIndex ?? 0) + 1;
+      const dlg = new NumberingRestartDialog(currentPage, (startNum) => {
         try {
           services.wasm.setNumberingRestart(pos.sectionIndex, pos.paragraphIndex, 2, startNum);
           services.eventBus.emit('document-changed');

--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from '../types';
 import { PageSetupDialog } from '@/ui/page-setup-dialog';
 import { SectionSettingsDialog } from '@/ui/section-settings-dialog';
+import { NumberingRestartDialog } from '@/ui/numbering-restart-dialog';
 
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
   return {
@@ -267,7 +268,25 @@ export const pageCommands: CommandDef[] = [
       navigateHeaderFooter(services, 1);
     },
   },
-  stub('page:new-page-num', '새 번호로 시작'),
+  {
+    id: 'page:new-page-num',
+    label: '새 번호로 시작',
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const pos = ih.getPosition();
+      const dlg = new NumberingRestartDialog(1, (startNum) => {
+        try {
+          services.wasm.setNumberingRestart(pos.sectionIndex, pos.paragraphIndex, 2, startNum);
+          services.eventBus.emit('document-changed');
+        } catch (err) {
+          console.warn('[page:new-page-num] 새 번호 설정 실패:', err);
+        }
+      });
+      dlg.show();
+    },
+  },
   // ─── 머리말/꼬리말 현재 쪽 감추기 ──────────────
   {
     id: 'page:hide-headerfooter',

--- a/rhwp-studio/src/ui/numbering-restart-dialog.ts
+++ b/rhwp-studio/src/ui/numbering-restart-dialog.ts
@@ -3,14 +3,13 @@ import { ModalDialog } from './dialog';
 export class NumberingRestartDialog extends ModalDialog {
   private input!: HTMLInputElement;
   private callback: (startNum: number) => void;
+  private defaultValue: number;
 
-  constructor(currentPage: number, callback: (startNum: number) => void) {
+  constructor(defaultStartNum: number, callback: (startNum: number) => void) {
     super('새 번호로 시작', 300);
     this.callback = callback;
-    this.defaultValue = currentPage;
+    this.defaultValue = defaultStartNum;
   }
-
-  private defaultValue: number;
 
   protected createBody(): HTMLElement {
     const body = document.createElement('div');
@@ -35,10 +34,14 @@ export class NumberingRestartDialog extends ModalDialog {
     this.input.select();
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): boolean {
     const num = parseInt(this.input.value, 10);
-    if (num >= 1) {
-      this.callback(num);
+    if (isNaN(num) || num < 1) {
+      this.input.style.outline = '2px solid red';
+      this.input.focus();
+      return false;
     }
+    this.callback(num);
+    return true;
   }
 }

--- a/rhwp-studio/src/ui/numbering-restart-dialog.ts
+++ b/rhwp-studio/src/ui/numbering-restart-dialog.ts
@@ -1,0 +1,44 @@
+import { ModalDialog } from './dialog';
+
+export class NumberingRestartDialog extends ModalDialog {
+  private input!: HTMLInputElement;
+  private callback: (startNum: number) => void;
+
+  constructor(currentPage: number, callback: (startNum: number) => void) {
+    super('새 번호로 시작', 300);
+    this.callback = callback;
+    this.defaultValue = currentPage;
+  }
+
+  private defaultValue: number;
+
+  protected createBody(): HTMLElement {
+    const body = document.createElement('div');
+    const row = document.createElement('div');
+    row.style.cssText = 'display:flex;align-items:center;gap:8px;margin-bottom:10px;';
+    const lbl = document.createElement('label');
+    lbl.textContent = '시작 번호';
+    lbl.style.cssText = 'min-width:70px;font-size:13px;';
+    this.input = document.createElement('input');
+    this.input.type = 'number';
+    this.input.min = '1';
+    this.input.value = String(this.defaultValue);
+    this.input.style.cssText = 'width:80px;padding:4px 6px;font-size:13px;';
+    row.appendChild(lbl);
+    row.appendChild(this.input);
+    body.appendChild(row);
+    return body;
+  }
+
+  show(): void {
+    super.show();
+    this.input.select();
+  }
+
+  protected onConfirm(): void {
+    const num = parseInt(this.input.value, 10);
+    if (num >= 1) {
+      this.callback(num);
+    }
+  }
+}


### PR DESCRIPTION
## 문제

쪽 > 새 번호로 시작 (page:new-page-num) 커맨드가 스텁으로 남아 있어 메뉴에서 비활성 상태입니다.

## 수정 내용

### NumberingRestartDialog

시작 번호를 입력받는 간단한 대화상자입니다. ModalDialog 패턴을 따릅니다.

### 커맨드 구현

1. 현재 커서 위치의 섹션/문단 인덱스를 확인
2. NumberingRestartDialog에서 시작 번호 입력
3. `setNumberingRestart(sec, para, mode=2, startNum)` WASM API 호출
   - mode=2: NewStart (새 번호로 시작)
4. document-changed 이벤트 발행

## 테스트

- `cargo test` 통과
- `cargo clippy -- -D warnings` 경고 없음

감사합니다.