### PR TITLE
feat: 표 셀 높이/너비 균등화 커맨드 구현

### DIFF
--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -362,26 +362,25 @@ export const tableCommands: CommandDef[] = [
       const sec = pos.sectionIndex, ppi = pos.parentParaIndex, ci = pos.controlIndex;
       try {
         const dims = services.wasm.getTableDimensions(sec, ppi, ci);
+        const cells: Array<{ idx: number; row: number; height: number }> = [];
         const rowHeights = new Map<number, { sum: number; count: number }>();
         for (let i = 0; i < dims.cellCount; i++) {
           const info = services.wasm.getCellInfo(sec, ppi, ci, i);
           if (info.rowSpan > 1) continue;
-          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const h = services.wasm.getCellProperties(sec, ppi, ci, i).height;
+          cells.push({ idx: i, row: info.row, height: h });
           const entry = rowHeights.get(info.row);
-          if (entry) { entry.sum += props.height; entry.count++; }
-          else rowHeights.set(info.row, { sum: props.height, count: 1 });
+          if (entry) { entry.sum += h; entry.count++; }
+          else rowHeights.set(info.row, { sum: h, count: 1 });
         }
         if (rowHeights.size < 2) return;
         let totalHeight = 0;
         for (const v of rowHeights.values()) totalHeight += v.sum / v.count;
         const avgHeight = Math.round(totalHeight / rowHeights.size);
         const updates: Array<{ cellIdx: number; heightDelta: number }> = [];
-        for (let i = 0; i < dims.cellCount; i++) {
-          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
-          if (info.rowSpan > 1) continue;
-          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
-          const delta = avgHeight - props.height;
-          if (delta !== 0) updates.push({ cellIdx: i, heightDelta: delta });
+        for (const c of cells) {
+          const delta = avgHeight - c.height;
+          if (delta !== 0) updates.push({ cellIdx: c.idx, heightDelta: delta });
         }
         if (updates.length === 0) return;
         services.wasm.resizeTableCells(sec, ppi, ci, updates);
@@ -404,26 +403,25 @@ export const tableCommands: CommandDef[] = [
       const sec = pos.sectionIndex, ppi = pos.parentParaIndex, ci = pos.controlIndex;
       try {
         const dims = services.wasm.getTableDimensions(sec, ppi, ci);
+        const cells: Array<{ idx: number; col: number; width: number }> = [];
         const colWidths = new Map<number, { sum: number; count: number }>();
         for (let i = 0; i < dims.cellCount; i++) {
           const info = services.wasm.getCellInfo(sec, ppi, ci, i);
           if (info.colSpan > 1) continue;
-          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const w = services.wasm.getCellProperties(sec, ppi, ci, i).width;
+          cells.push({ idx: i, col: info.col, width: w });
           const entry = colWidths.get(info.col);
-          if (entry) { entry.sum += props.width; entry.count++; }
-          else colWidths.set(info.col, { sum: props.width, count: 1 });
+          if (entry) { entry.sum += w; entry.count++; }
+          else colWidths.set(info.col, { sum: w, count: 1 });
         }
         if (colWidths.size < 2) return;
         let totalWidth = 0;
         for (const v of colWidths.values()) totalWidth += v.sum / v.count;
         const avgWidth = Math.round(totalWidth / colWidths.size);
         const updates: Array<{ cellIdx: number; widthDelta: number }> = [];
-        for (let i = 0; i < dims.cellCount; i++) {
-          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
-          if (info.colSpan > 1) continue;
-          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
-          const delta = avgWidth - props.width;
-          if (delta !== 0) updates.push({ cellIdx: i, widthDelta: delta });
+        for (const c of cells) {
+          const delta = avgWidth - c.width;
+          if (delta !== 0) updates.push({ cellIdx: c.idx, widthDelta: delta });
         }
         if (updates.length === 0) return;
         services.wasm.resizeTableCells(sec, ppi, ci, updates);

--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -349,8 +349,90 @@ export const tableCommands: CommandDef[] = [
       ih.enterTableCaptionEditing(sec, ppi, ci, charOffset);
     },
   },
-  stub('table:cell-height-equal', '셀 높이를 같게', undefined, 'H'),
-  stub('table:cell-width-equal', '셀 너비를 같게', undefined, 'W'),
+  {
+    id: 'table:cell-height-equal',
+    label: '셀 높이를 같게',
+    shortcutLabel: 'H',
+    canExecute: inTable,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const pos = ih.getCursorPosition();
+      if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
+      const sec = pos.sectionIndex, ppi = pos.parentParaIndex, ci = pos.controlIndex;
+      try {
+        const dims = services.wasm.getTableDimensions(sec, ppi, ci);
+        const rowHeights = new Map<number, { sum: number; count: number }>();
+        for (let i = 0; i < dims.cellCount; i++) {
+          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
+          if (info.rowSpan > 1) continue;
+          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const entry = rowHeights.get(info.row);
+          if (entry) { entry.sum += props.height; entry.count++; }
+          else rowHeights.set(info.row, { sum: props.height, count: 1 });
+        }
+        if (rowHeights.size < 2) return;
+        let totalHeight = 0;
+        for (const v of rowHeights.values()) totalHeight += v.sum / v.count;
+        const avgHeight = Math.round(totalHeight / rowHeights.size);
+        const updates: Array<{ cellIdx: number; heightDelta: number }> = [];
+        for (let i = 0; i < dims.cellCount; i++) {
+          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
+          if (info.rowSpan > 1) continue;
+          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const delta = avgHeight - props.height;
+          if (delta !== 0) updates.push({ cellIdx: i, heightDelta: delta });
+        }
+        if (updates.length === 0) return;
+        services.wasm.resizeTableCells(sec, ppi, ci, updates);
+        services.eventBus.emit('document-changed');
+      } catch (err) {
+        console.warn('[table:cell-height-equal] 높이 균등화 실패:', err);
+      }
+    },
+  },
+  {
+    id: 'table:cell-width-equal',
+    label: '셀 너비를 같게',
+    shortcutLabel: 'W',
+    canExecute: inTable,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const pos = ih.getCursorPosition();
+      if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
+      const sec = pos.sectionIndex, ppi = pos.parentParaIndex, ci = pos.controlIndex;
+      try {
+        const dims = services.wasm.getTableDimensions(sec, ppi, ci);
+        const colWidths = new Map<number, { sum: number; count: number }>();
+        for (let i = 0; i < dims.cellCount; i++) {
+          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
+          if (info.colSpan > 1) continue;
+          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const entry = colWidths.get(info.col);
+          if (entry) { entry.sum += props.width; entry.count++; }
+          else colWidths.set(info.col, { sum: props.width, count: 1 });
+        }
+        if (colWidths.size < 2) return;
+        let totalWidth = 0;
+        for (const v of colWidths.values()) totalWidth += v.sum / v.count;
+        const avgWidth = Math.round(totalWidth / colWidths.size);
+        const updates: Array<{ cellIdx: number; widthDelta: number }> = [];
+        for (let i = 0; i < dims.cellCount; i++) {
+          const info = services.wasm.getCellInfo(sec, ppi, ci, i);
+          if (info.colSpan > 1) continue;
+          const props = services.wasm.getCellProperties(sec, ppi, ci, i);
+          const delta = avgWidth - props.width;
+          if (delta !== 0) updates.push({ cellIdx: i, widthDelta: delta });
+        }
+        if (updates.length === 0) return;
+        services.wasm.resizeTableCells(sec, ppi, ci, updates);
+        services.eventBus.emit('document-changed');
+      } catch (err) {
+        console.warn('[table:cell-width-equal] 너비 균등화 실패:', err);
+      }
+    },
+  },
   {
     id: 'table:formula',
     label: '계산식(F)...',


### PR DESCRIPTION
## 변경 내용

`table:cell-height-equal` (단축키 H)과 `table:cell-width-equal` (단축키 W) 스텁 커맨드를 실제 동작하도록 구현했습니다.

### table:cell-height-equal (셀 높이를 같게)
- 표 내 모든 행의 높이를 평균값으로 균등화
- `getCellProperties`로 각 셀의 HWPUNIT 높이를 조회
- `resizeTableCells`로 delta 값을 전달하여 리사이즈
- `rowSpan > 1`인 병합 셀은 건너뜀

### table:cell-width-equal (셀 너비를 같게)
- 표 내 모든 열의 너비를 평균값으로 균등화
- 동일한 방식으로 `getCellProperties` + `resizeTableCells` 사용
- `colSpan > 1`인 병합 셀은 건너뜀

## 구현 방식

1. `getTableDimensions`로 셀 개수 조회
2. 전체 셀을 순회하며 `getCellInfo`로 행/열 위치, `getCellProperties`로 현재 크기 조회
3. 행(또는 열)별 평균 크기 계산
4. 전체 평균 산출 후 각 셀의 delta를 `resizeTableCells` API로 일괄 적용

## 테스트

- `cargo test` 전체 통과
- `cargo clippy -- -D warnings` 경고 없음

감사합니다.