### PR TITLE
render: harden PageLayerTree schema and resource keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cfb = "0.14"
 flate2 = "1.0"
 byteorder = "1.5"
 base64 = "0.22"
+blake3 = "1"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 quick-xml = "0.39"
 codepage = "0.1.2"

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -8,8 +8,7 @@ use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
-    RenderProfile, PAGE_LAYER_TREE_COORDINATE_SYSTEM, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-    PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
+    RenderProfile, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
@@ -25,10 +24,10 @@ impl PageLayerTree {
         let _ = write!(
             buf,
             "\"schemaVersion\":{},\"resourceTableVersion\":{},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
-            PAGE_LAYER_TREE_SCHEMA_VERSION,
-            PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-            json_escape(PAGE_LAYER_TREE_UNIT),
-            json_escape(PAGE_LAYER_TREE_COORDINATE_SYSTEM),
+            LAYER_TREE_SCHEMA.schema_version,
+            LAYER_TREE_SCHEMA.resource_table_version,
+            json_escape(LAYER_TREE_SCHEMA.unit),
+            json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
             self.output_options.show_paragraph_marks,
             self.output_options.show_control_codes,

--- a/src/paint/layer_tree.rs
+++ b/src/paint/layer_tree.rs
@@ -5,14 +5,6 @@ use crate::renderer::render_tree::{
     BoundingBox, GroupNode, NodeId, TableCellNode, TableNode, TextLineNode,
 };
 
-/// JSON schema version for `PageLayerTree` exports.
-///
-/// Increment this when the exported node/op shape changes incompatibly.
-pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = 1;
-pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = 1;
-pub const PAGE_LAYER_TREE_UNIT: &str = "px";
-pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = "page-top-left";
-
 /// 한 페이지의 visual layer tree.
 #[derive(Debug, Clone)]
 pub struct PageLayerTree {

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -8,13 +8,19 @@ pub mod layer_tree;
 pub mod paint_op;
 pub mod profile;
 pub mod resources;
+pub mod schema;
 
 pub use builder::LayerBuilder;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
-    PAGE_LAYER_TREE_COORDINATE_SYSTEM, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-    PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
 };
 pub use paint_op::PaintOp;
 pub use profile::RenderProfile;
-pub use resources::ResourceArena;
+pub use resources::{
+    image_resource_key, resource_digest_hex, svg_resource_key, ResourceArena,
+    RESOURCE_KEY_ALGORITHM,
+};
+pub use schema::{
+    LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,
+    PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION, PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
+};

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -1,6 +1,46 @@
+pub const RESOURCE_KEY_ALGORITHM: &str = "blake3";
+
 /// 추후 이미지/패스/셰이프 캐시 공유를 위한 arena placeholder.
 ///
 /// 레이어드 렌더러 전환 1차에서는 leaf payload를 직접 보관하되,
 /// IR 상에 arena 자리를 먼저 확보해 이후 Skia/CanvasKit 자원 공유로 확장한다.
 #[derive(Debug, Clone, Default)]
 pub struct ResourceArena;
+
+pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String {
+    blake3::hash(bytes.as_ref()).to_hex().to_string()
+}
+
+pub fn image_resource_key(byte_len: usize, digest: &str) -> String {
+    resource_key("img", byte_len, digest)
+}
+
+pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {
+    resource_key("svg", byte_len, digest)
+}
+
+fn resource_key(kind: &str, byte_len: usize, digest: &str) -> String {
+    format!("{kind}:{RESOURCE_KEY_ALGORITHM}:{byte_len}:{digest}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{image_resource_key, resource_digest_hex, svg_resource_key};
+
+    #[test]
+    fn resource_digest_is_stable_and_content_dependent() {
+        let digest = resource_digest_hex([1, 2, 3, 4]);
+        assert_eq!(digest.len(), 64);
+        assert_eq!(digest, resource_digest_hex([1, 2, 3, 4]));
+        assert_ne!(digest, resource_digest_hex([1, 2, 3, 5]));
+    }
+
+    #[test]
+    fn resource_keys_include_kind_algorithm_length_and_digest() {
+        assert_eq!(image_resource_key(4, "abcd"), "img:blake3:4:abcd");
+        assert_eq!(
+            svg_resource_key(6, "0123456789abcdef"),
+            "svg:blake3:6:0123456789abcdef"
+        );
+    }
+}

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -1,0 +1,33 @@
+/// Versioned root metadata for PageLayerTree JSON exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerTreeSchema {
+    pub schema_version: u32,
+    pub resource_table_version: u32,
+    pub unit: &'static str,
+    pub coordinate_system: &'static str,
+}
+
+pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
+    schema_version: 1,
+    resource_table_version: 1,
+    unit: "px",
+    coordinate_system: "page-top-left",
+};
+
+pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version;
+pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version;
+pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit;
+pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_tree_schema_contract_is_stable() {
+        assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
+        assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left");
+    }
+}

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -213,6 +213,9 @@ impl SvgLayerRenderer {
 
 impl LayerRenderer for SvgLayerRenderer {
     fn render_page(&mut self, tree: &PageLayerTree) -> LayerRenderResult<()> {
+        self.renderer.show_paragraph_marks = tree.output_options.show_paragraph_marks;
+        self.renderer.show_control_codes = tree.output_options.show_control_codes;
+        self.renderer.debug_overlay = tree.output_options.debug_overlay;
         let render_tree = self.build_render_tree(tree);
         self.renderer.render_tree(&render_tree);
         Ok(())
@@ -222,7 +225,7 @@ impl LayerRenderer for SvgLayerRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paint::{LayerBuilder, RenderProfile};
+    use crate::paint::{LayerBuilder, LayerOutputOptions, RenderProfile};
     use crate::renderer::render_tree::{
         PageNode, PlaceholderNode, RawSvgNode, RectangleNode, TextRunNode,
     };
@@ -331,5 +334,61 @@ mod tests {
         layer.render_page(&layer_tree).unwrap();
 
         assert_eq!(layer.output(), legacy.output());
+    }
+
+    #[test]
+    fn render_page_consumes_layer_output_options() {
+        let mut render_tree = PageRenderTree::new(0, 80.0, 60.0);
+        render_tree.root.node_type = RenderNodeType::Page(PageNode {
+            page_index: 0,
+            width: 80.0,
+            height: 60.0,
+            section_index: 0,
+        });
+        render_tree.root.children.push(RenderNode::new(
+            31,
+            RenderNodeType::TextRun(TextRunNode {
+                text: "a b".to_string(),
+                style: TextStyle {
+                    font_size: 14.0,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: true,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 16.0,
+                field_marker: Default::default(),
+            }),
+            BoundingBox::new(10.0, 15.0, 40.0, 20.0),
+        ));
+
+        let mut builder =
+            LayerBuilder::new(RenderProfile::Screen).with_output_options(LayerOutputOptions {
+                show_paragraph_marks: true,
+                show_control_codes: true,
+                ..Default::default()
+            });
+        let layer_tree = builder.build(&render_tree);
+        let mut layer = SvgLayerRenderer::new();
+        layer.render_page(&layer_tree).unwrap();
+
+        let output = layer.output();
+        assert!(
+            output.contains("\u{2228}"),
+            "layer output options should enable visible space marks:\n{output}"
+        );
+        assert!(
+            output.contains("\u{21b5}"),
+            "layer output options should enable paragraph end marks:\n{output}"
+        );
     }
 }

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -265,6 +265,8 @@ impl WebCanvasRenderer {
 
     /// 레이어 트리를 Canvas에 렌더링
     pub fn render_layer_tree(&mut self, tree: &PageLayerTree) {
+        self.show_paragraph_marks = tree.output_options.show_paragraph_marks;
+        self.show_control_codes = tree.output_options.show_control_codes;
         self.begin_page(tree.page_width, tree.page_height);
         self.render_layer_node(&tree.root);
     }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -44,6 +44,51 @@ impl From<HwpError> for JsValue {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+const MAX_CANVAS_DIMENSION: f64 = 16_384.0;
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn normalize_canvas_scale(
+    page_width: f64,
+    page_height: f64,
+    requested_scale: f64,
+) -> Result<f64, &'static str> {
+    if !page_width.is_finite()
+        || !page_height.is_finite()
+        || page_width <= 0.0
+        || page_height <= 0.0
+    {
+        return Err("invalid page dimensions");
+    }
+
+    let scale = if requested_scale <= 0.0 || !requested_scale.is_finite() {
+        1.0
+    } else {
+        requested_scale.clamp(0.25, 12.0)
+    };
+
+    let scaled_width = page_width * scale;
+    let scaled_height = page_height * scale;
+    if !scaled_width.is_finite() || !scaled_height.is_finite() {
+        return Ok((MAX_CANVAS_DIMENSION / page_width)
+            .min(MAX_CANVAS_DIMENSION / page_height)
+            .min(scale));
+    }
+
+    if scaled_width > MAX_CANVAS_DIMENSION || scaled_height > MAX_CANVAS_DIMENSION {
+        Ok((MAX_CANVAS_DIMENSION / page_width)
+            .min(MAX_CANVAS_DIMENSION / page_height)
+            .min(scale))
+    } else {
+        Ok(scale)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn scaled_canvas_extent(page_extent: f64, scale: f64) -> u32 {
+    (page_extent * scale).max(1.0).min(MAX_CANVAS_DIMENSION) as u32
+}
+
 /// WASM에서 사용할 HWP 문서 래퍼
 ///
 /// 도메인 로직은 `DocumentCore`에 구현되어 있으며,
@@ -216,27 +261,12 @@ impl HwpDocument {
 
         let tree = self.build_page_layer_tree(page_num).map_err(JsValue::from)?;
 
-        // scale 정규화: 0 이하 또는 NaN이면 1.0, 최소 0.25 최대 12.0
-        // (zoom 3.0 × DPR 4.0 = 12.0 지원)
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-
-        // 최대 캔버스 크기 가드 (16384px)
-        let max_dim = 16384.0;
-        let scale = if tree.page_width * scale > max_dim || tree.page_height * scale > max_dim {
-            (max_dim / tree.page_width)
-                .min(max_dim / tree.page_height)
-                .min(scale)
-        } else {
-            scale
-        };
+        let scale = normalize_canvas_scale(tree.page_width, tree.page_height, scale)
+            .map_err(JsValue::from_str)?;
 
         // 캔버스 크기 = 페이지 크기 × scale
-        canvas.set_width((tree.page_width * scale) as u32);
-        canvas.set_height((tree.page_height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.page_width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.page_height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;
@@ -280,22 +310,11 @@ impl HwpDocument {
 
         let tree = self.build_page_layer_tree(page_num).map_err(JsValue::from)?;
 
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-        let max_dim = 16384.0;
-        let scale = if tree.page_width * scale > max_dim || tree.page_height * scale > max_dim {
-            (max_dim / tree.page_width)
-                .min(max_dim / tree.page_height)
-                .min(scale)
-        } else {
-            scale
-        };
+        let scale = normalize_canvas_scale(tree.page_width, tree.page_height, scale)
+            .map_err(JsValue::from_str)?;
 
-        canvas.set_width((tree.page_width * scale) as u32);
-        canvas.set_height((tree.page_height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.page_width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.page_height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;
@@ -321,28 +340,12 @@ impl HwpDocument {
             .build_page_tree_cached(page_num)
             .map_err(|e| JsValue::from(e))?;
 
-        // scale 정규화: 0 이하 또는 NaN이면 1.0, 최소 0.25 최대 12.0
-        // (zoom 3.0 × DPR 4.0 = 12.0 지원)
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-
-        // 최대 캔버스 크기 가드 (16384px)
-        let max_dim = 16384.0;
-        let scale =
-            if tree.root.bbox.width * scale > max_dim || tree.root.bbox.height * scale > max_dim {
-                (max_dim / tree.root.bbox.width)
-                    .min(max_dim / tree.root.bbox.height)
-                    .min(scale)
-            } else {
-                scale
-            };
+        let scale = normalize_canvas_scale(tree.root.bbox.width, tree.root.bbox.height, scale)
+            .map_err(JsValue::from_str)?;
 
         // 캔버스 크기 = 페이지 크기 × scale
-        canvas.set_width((tree.root.bbox.width * scale) as u32);
-        canvas.set_height((tree.root.bbox.height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.root.bbox.width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.root.bbox.height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -1,6 +1,7 @@
     use super::*;
     use crate::model::document::{Document, Section};
     use crate::model::paragraph::{Paragraph, LineSeg};
+    use crate::paint::LAYER_TREE_SCHEMA;
 
     #[test]
     fn test_create_empty_document() {
@@ -44,6 +45,82 @@
             HwpError::PageOutOfRange(n) => assert_eq!(n, 999),
             _ => panic!("Expected PageOutOfRange error"),
         }
+    }
+
+    #[test]
+    fn test_page_layer_tree_export_uses_schema_contract() {
+        let doc = HwpDocument::create_empty();
+        let json = doc
+            .get_page_layer_tree_native(0)
+            .expect("empty document layer tree should export");
+
+        assert!(json.contains(&format!(
+            "\"schemaVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_version
+        )));
+        assert!(json.contains(&format!(
+            "\"resourceTableVersion\":{}",
+            LAYER_TREE_SCHEMA.resource_table_version
+        )));
+        assert!(json.contains(&format!("\"unit\":\"{}\"", LAYER_TREE_SCHEMA.unit)));
+        assert!(json.contains(&format!(
+            "\"coordinateSystem\":\"{}\"",
+            LAYER_TREE_SCHEMA.coordinate_system
+        )));
+        assert!(json.contains("\"profile\":\"screen\""));
+        assert!(json.contains("\"outputOptions\":{"));
+    }
+
+    #[test]
+    fn test_page_layer_tree_export_preserves_output_options() {
+        let mut doc = HwpDocument::create_empty();
+        doc.set_show_paragraph_marks(true);
+        doc.set_show_control_codes(true);
+        doc.set_show_transparent_borders(true);
+        doc.set_clip_enabled(false);
+        doc.set_debug_overlay(true);
+
+        let json = doc
+            .get_page_layer_tree_native(0)
+            .expect("layer tree should export output options");
+
+        assert!(json.contains("\"showParagraphMarks\":true"));
+        assert!(json.contains("\"showControlCodes\":true"));
+        assert!(json.contains("\"showTransparentBorders\":true"));
+        assert!(json.contains("\"clipEnabled\":false"));
+        assert!(json.contains("\"debugOverlay\":true"));
+    }
+
+    #[test]
+    fn test_normalize_canvas_scale_rejects_invalid_page_dimensions() {
+        for (width, height) in [
+            (0.0, 100.0),
+            (100.0, 0.0),
+            (-1.0, 100.0),
+            (100.0, -1.0),
+            (f64::NAN, 100.0),
+            (100.0, f64::NAN),
+            (f64::INFINITY, 100.0),
+            (100.0, f64::INFINITY),
+        ] {
+            assert!(
+                normalize_canvas_scale(width, height, 1.0).is_err(),
+                "invalid page dimensions must fail: {width} x {height}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_canvas_scale_clamps_request_and_canvas_extent() {
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 0.0), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, f64::NAN), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, f64::INFINITY), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 0.1), Ok(0.25));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 20.0), Ok(12.0));
+
+        let scale = normalize_canvas_scale(20_000.0, 10_000.0, 1.0)
+            .expect("large finite page should be scaled down");
+        assert!((scale - (16_384.0 / 20_000.0)).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -15680,4 +15757,3 @@
         let count = doc.reflow_linesegs();
         assert_eq!(count, 0);
     }
-


### PR DESCRIPTION
## What

P8은 이후 text/image/cache 작업이 기대게 될 Layer IR contract를 먼저 단단하게 잡는 PR입니다.

- `paint/schema.rs`를 추가해서 `PageLayerTree` JSON schema metadata를 한 곳에서 관리합니다.
- resource key helper를 `blake3` digest 기반으로 고정하고, key에 kind/algorithm/byte length/digest가 모두 들어가게 했습니다.
- `SvgLayerRenderer`와 `WebCanvasRenderer`가 renderer 직접 호출에서도 `LayerOutputOptions`를 소비하도록 보강했습니다.
- WASM canvas scale guard를 공통 helper로 빼서 invalid page dimension과 oversized canvas를 명시적으로 막습니다.
- schema/resource/output option/canvas scale contract 테스트를 추가했습니다.

## Why

`skia` 브랜치의 다음 큰 묶음은 text replay, image effect, cache/diagnostics로 커지기 쉽습니다. 그 전에 schema version, resource key, output option 전달 규칙을 먼저 고정해 두는 편이 이후 PR에서 diff 원인을 좁히기 좋습니다.

이 PR은 렌더링 결과를 크게 바꾸는 단계라기보다는, 이후 backend 작업이 같은 contract 위에 올라가게 만드는 정리 단계입니다.

## Non-goals

- 실제 binary resource interning/public resource table transport까지 구현하지 않습니다.
- native Skia text/image/cache replay 변경은 넣지 않습니다.
- CanvasKit이나 rhwp-studio 쪽 resource transport는 후속 PR로 봅니다.

## Tests

- `cargo test --lib resource_`
- `cargo test --lib layer_tree_schema_contract_is_stable`
- `cargo test --lib page_layer_tree_export`
- `cargo test --lib normalize_canvas_scale`
- `cargo test --lib render_page_consumes_layer_output_options`
- `cargo clippy --lib -- -D warnings`
- `cargo check --target wasm32-unknown-unknown --lib`

Refs #536
