### PR TITLE
render: improve Skia text replay parity

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ cfb = "0.14"
 flate2 = "1.0"
 byteorder = "1.5"
 base64 = "0.22"
+blake3 = "1"
 zip = { version = "8.5", default-features = false, features = ["deflate"] }
 quick-xml = "0.39"
 codepage = "0.1.2"

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -8,8 +8,7 @@ use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
-    RenderProfile, PAGE_LAYER_TREE_COORDINATE_SYSTEM, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-    PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
+    RenderProfile, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
@@ -25,10 +24,10 @@ impl PageLayerTree {
         let _ = write!(
             buf,
             "\"schemaVersion\":{},\"resourceTableVersion\":{},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
-            PAGE_LAYER_TREE_SCHEMA_VERSION,
-            PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-            json_escape(PAGE_LAYER_TREE_UNIT),
-            json_escape(PAGE_LAYER_TREE_COORDINATE_SYSTEM),
+            LAYER_TREE_SCHEMA.schema_version,
+            LAYER_TREE_SCHEMA.resource_table_version,
+            json_escape(LAYER_TREE_SCHEMA.unit),
+            json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
             self.output_options.show_paragraph_marks,
             self.output_options.show_control_codes,

--- a/src/paint/layer_tree.rs
+++ b/src/paint/layer_tree.rs
@@ -5,14 +5,6 @@ use crate::renderer::render_tree::{
     BoundingBox, GroupNode, NodeId, TableCellNode, TableNode, TextLineNode,
 };
 
-/// JSON schema version for `PageLayerTree` exports.
-///
-/// Increment this when the exported node/op shape changes incompatibly.
-pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = 1;
-pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = 1;
-pub const PAGE_LAYER_TREE_UNIT: &str = "px";
-pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = "page-top-left";
-
 /// 한 페이지의 visual layer tree.
 #[derive(Debug, Clone)]
 pub struct PageLayerTree {

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -8,13 +8,19 @@ pub mod layer_tree;
 pub mod paint_op;
 pub mod profile;
 pub mod resources;
+pub mod schema;
 
 pub use builder::LayerBuilder;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
-    PAGE_LAYER_TREE_COORDINATE_SYSTEM, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-    PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
 };
 pub use paint_op::PaintOp;
 pub use profile::RenderProfile;
-pub use resources::ResourceArena;
+pub use resources::{
+    image_resource_key, resource_digest_hex, svg_resource_key, ResourceArena,
+    RESOURCE_KEY_ALGORITHM,
+};
+pub use schema::{
+    LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,
+    PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION, PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
+};

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -1,6 +1,46 @@
+pub const RESOURCE_KEY_ALGORITHM: &str = "blake3";
+
 /// 추후 이미지/패스/셰이프 캐시 공유를 위한 arena placeholder.
 ///
 /// 레이어드 렌더러 전환 1차에서는 leaf payload를 직접 보관하되,
 /// IR 상에 arena 자리를 먼저 확보해 이후 Skia/CanvasKit 자원 공유로 확장한다.
 #[derive(Debug, Clone, Default)]
 pub struct ResourceArena;
+
+pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String {
+    blake3::hash(bytes.as_ref()).to_hex().to_string()
+}
+
+pub fn image_resource_key(byte_len: usize, digest: &str) -> String {
+    resource_key("img", byte_len, digest)
+}
+
+pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {
+    resource_key("svg", byte_len, digest)
+}
+
+fn resource_key(kind: &str, byte_len: usize, digest: &str) -> String {
+    format!("{kind}:{RESOURCE_KEY_ALGORITHM}:{byte_len}:{digest}")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{image_resource_key, resource_digest_hex, svg_resource_key};
+
+    #[test]
+    fn resource_digest_is_stable_and_content_dependent() {
+        let digest = resource_digest_hex([1, 2, 3, 4]);
+        assert_eq!(digest.len(), 64);
+        assert_eq!(digest, resource_digest_hex([1, 2, 3, 4]));
+        assert_ne!(digest, resource_digest_hex([1, 2, 3, 5]));
+    }
+
+    #[test]
+    fn resource_keys_include_kind_algorithm_length_and_digest() {
+        assert_eq!(image_resource_key(4, "abcd"), "img:blake3:4:abcd");
+        assert_eq!(
+            svg_resource_key(6, "0123456789abcdef"),
+            "svg:blake3:6:0123456789abcdef"
+        );
+    }
+}

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -1,0 +1,33 @@
+/// Versioned root metadata for PageLayerTree JSON exports.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct LayerTreeSchema {
+    pub schema_version: u32,
+    pub resource_table_version: u32,
+    pub unit: &'static str,
+    pub coordinate_system: &'static str,
+}
+
+pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
+    schema_version: 1,
+    resource_table_version: 1,
+    unit: "px",
+    coordinate_system: "page-top-left",
+};
+
+pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version;
+pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version;
+pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit;
+pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system;
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn layer_tree_schema_contract_is_stable() {
+        assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
+        assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left");
+    }
+}

--- a/src/renderer/skia/mod.rs
+++ b/src/renderer/skia/mod.rs
@@ -5,5 +5,6 @@
 mod equation_conv;
 mod image_conv;
 mod renderer;
+mod text_replay;
 
 pub use renderer::SkiaLayerRenderer;

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,24 +1,22 @@
 use skia_safe::{
-    font, paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Paint,
+    paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Paint,
     PathBuilder, PathEffect, RRect, Rect, Typeface,
 };
 use std::collections::HashMap;
 
 use crate::error::HwpError;
 use crate::model::image::ImageEffect;
-use crate::model::style::UnderlineType;
 use crate::model::ColorRef;
 use crate::paint::{LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree, PaintOp};
-use crate::renderer::composer::{decode_pua_overlap_number, pua_to_display_text};
 use crate::renderer::layer_renderer::{
     LayerRasterRenderer, LayerRenderResult, RasterOutputFormat, RasterRenderOptions,
     RasterRenderOutput,
 };
-use crate::renderer::layout::{compute_char_positions, split_into_clusters};
 use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
 
 use super::equation_conv::render_equation;
 use super::image_conv::{draw_image_bytes, draw_svg_fragment, ImageSampling};
+use super::text_replay::SkiaTextReplay;
 
 pub struct SkiaLayerRenderer {
     font_mgr: FontMgr,
@@ -270,692 +268,11 @@ impl SkiaLayerRenderer {
                 ImageSampling::linear(),
             );
         };
-        let draw_text =
-            |text: &str,
-             bbox: crate::renderer::render_tree::BoundingBox,
-             style: &crate::renderer::TextStyle,
-             baseline: f64,
-             rotation: f64,
-             is_vertical: bool,
-             char_overlap: Option<&crate::renderer::composer::CharOverlapInfo>| {
-                if text.is_empty() && style.tab_leaders.is_empty() {
-                    return;
-                }
-                let font_size = if style.font_size > 0.0 {
-                    style.font_size as f32
-                } else {
-                    12.0
-                };
-                let font_style = match (style.bold, style.italic) {
-                    (true, true) => FontStyle::bold_italic(),
-                    (true, false) => FontStyle::bold(),
-                    (false, true) => FontStyle::italic(),
-                    (false, false) => FontStyle::normal(),
-                };
-                let mut families = Vec::new();
-                if !style.font_family.trim().is_empty() {
-                    families.push(style.font_family.as_str());
-                }
-                // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
-                // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.
-                families.extend([
-                    "Noto Sans KR",
-                    "Noto Serif KR",
-                    "Noto Sans CJK KR",
-                    "Noto Serif CJK KR",
-                    "Nanum Gothic",
-                    "Nanum Myeongjo",
-                    "Malgun Gothic",
-                    "맑은 고딕",
-                    "Batang",
-                    "바탕",
-                    "Apple SD Gothic Neo",
-                    "AppleMyungjo",
-                    "DejaVu Sans",
-                    "Arial",
-                    "sans-serif",
-                ]);
-                // 1) 사용자 지정 폰트 (--font-path) 우선 검색
-                // 2) 시스템 FontMgr 검색 (한글 fallback chain 포함)
-                // 3) 마지막 fallback (legacy_make_typeface)
-                //
-                // 모든 후보를 chain 으로 보존 — char 단위 fallback 에 사용.
-                let typeface_chain: Vec<Typeface> = {
-                    let mut chain: Vec<Typeface> = Vec::new();
-                    let mut seen: std::collections::HashSet<String> =
-                        std::collections::HashSet::new();
-                    let mut push = |chain: &mut Vec<Typeface>,
-                                    seen: &mut std::collections::HashSet<String>,
-                                    tf: Typeface| {
-                        let key = tf.family_name();
-                        if seen.insert(key) {
-                            chain.push(tf);
-                        }
-                    };
-                    for family in &families {
-                        if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
-                            push(&mut chain, &mut seen, tf);
-                        }
-                    }
-                    for family in &families {
-                        if let Some(tf) = self.font_mgr.match_family_style(family, font_style) {
-                            push(&mut chain, &mut seen, tf);
-                        }
-                    }
-                    if let Some(tf) = self.font_mgr.legacy_make_typeface(None::<&str>, font_style) {
-                        push(&mut chain, &mut seen, tf);
-                    }
-                    chain
-                };
-                let primary_typeface = typeface_chain.first().cloned();
-                let font_for_text = |sample: &str, size: f32| -> Option<Font> {
-                    let visible_char = sample.chars().find(|ch| !ch.is_whitespace());
-                    if let Some(ch) = visible_char {
-                        let codepoint = ch as i32;
-                        if let Some(tf) = typeface_chain
-                            .iter()
-                            .find(|tf| tf.unichar_to_glyph(codepoint) != 0)
-                            .cloned()
-                        {
-                            let mut font = Font::new(tf, size);
-                            font.set_edging(font::Edging::AntiAlias);
-                            return Some(font);
-                        }
-                        return None;
-                    }
-                    if let Some(tf) = primary_typeface.clone() {
-                        let mut font = Font::new(tf, size);
-                        font.set_edging(font::Edging::AntiAlias);
-                        Some(font)
-                    } else {
-                        let mut font = Font::default();
-                        font.set_size(size);
-                        font.set_edging(font::Edging::AntiAlias);
-                        Some(font)
-                    }
-                };
-                let y = if baseline > 0.0 {
-                    bbox.y + baseline
-                } else {
-                    bbox.y + bbox.height
-                };
-                let effective_rotation = if is_vertical {
-                    rotation + 90.0
-                } else {
-                    rotation
-                };
-                if effective_rotation != 0.0 {
-                    canvas.save();
-                    canvas.rotate(
-                        effective_rotation as f32,
-                        Some(
-                            (
-                                (bbox.x + bbox.width / 2.0) as f32,
-                                (bbox.y + bbox.height / 2.0) as f32,
-                            )
-                                .into(),
-                        ),
-                    );
-                }
-
-                if let Some(overlap) = char_overlap {
-                    let chars: Vec<char> = text.chars().collect();
-                    if chars.is_empty() {
-                        if effective_rotation != 0.0 {
-                            canvas.restore();
-                        }
-                        return;
-                    }
-
-                    let size_ratio = if overlap.inner_char_size > 0 {
-                        overlap.inner_char_size as f32 / 100.0
-                    } else {
-                        1.0
-                    };
-                    let inner_size = (font_size * size_ratio).max(1.0);
-                    let box_size = font_size.max(1.0);
-                    let is_combined = decode_pua_overlap_number(&chars);
-                    let effective_border = if overlap.border_type == 0 && is_combined.is_some() {
-                        1
-                    } else {
-                        overlap.border_type
-                    };
-                    let is_reversed = effective_border == 2 || effective_border == 4;
-                    let is_circle = effective_border == 1 || effective_border == 2;
-                    let is_rect = effective_border == 3 || effective_border == 4;
-                    let fill_color = if is_reversed {
-                        Color::BLACK
-                    } else {
-                        Color::TRANSPARENT
-                    };
-                    let text_color = if is_reversed {
-                        Color::WHITE
-                    } else {
-                        colorref_to_skia(style.color, 1.0)
-                    };
-                    let stroke_color = colorref_to_skia(style.color, 1.0);
-                    let mut shape_paint = Paint::default();
-                    shape_paint.set_anti_alias(true);
-                    let mut stroke_paint = Paint::default();
-                    stroke_paint.set_anti_alias(true);
-                    stroke_paint.set_style(paint::Style::Stroke);
-                    stroke_paint.set_stroke_width(0.8);
-                    stroke_paint.set_color(stroke_color);
-                    let mut text_paint = Paint::default();
-                    text_paint.set_anti_alias(true);
-                    text_paint.set_color(text_color);
-                    let draw_overlap_text = |display: &str, cx: f32, cy: f32| {
-                        if let Some(font) = font_for_text(display, inner_size) {
-                            let width = font.measure_str(display, Some(&text_paint)).0;
-                            canvas.draw_str(
-                                display,
-                                (cx - width / 2.0, cy + inner_size * 0.35),
-                                &font,
-                                &text_paint,
-                            );
-                        }
-                    };
-                    let mut draw_overlap_box = |display: &str, cx: f32, cy: f32| {
-                        if is_circle {
-                            shape_paint.set_style(paint::Style::Fill);
-                            shape_paint.set_color(fill_color);
-                            if is_reversed {
-                                canvas.draw_circle((cx, cy), box_size / 2.0, &shape_paint);
-                            }
-                            canvas.draw_circle((cx, cy), box_size / 2.0, &stroke_paint);
-                        } else if is_rect {
-                            let rect = Rect::from_xywh(
-                                cx - box_size / 2.0,
-                                cy - box_size / 2.0,
-                                box_size,
-                                box_size,
-                            );
-                            shape_paint.set_style(paint::Style::Fill);
-                            shape_paint.set_color(fill_color);
-                            if is_reversed {
-                                canvas.draw_rect(rect, &shape_paint);
-                            }
-                            canvas.draw_rect(rect, &stroke_paint);
-                        }
-                        draw_overlap_text(display, cx, cy);
-                    };
-
-                    if let Some(number) = is_combined {
-                        draw_overlap_box(
-                            &number,
-                            (bbox.x + bbox.width / 2.0) as f32,
-                            (bbox.y + bbox.height / 2.0) as f32,
-                        );
-                    } else {
-                        let char_advance = if chars.len() > 1 {
-                            bbox.width as f32 / chars.len() as f32
-                        } else {
-                            box_size
-                        };
-                        for (index, ch) in chars.iter().enumerate() {
-                            let display = {
-                                let codepoint = *ch as u32;
-                                if (0x2460..=0x2473).contains(&codepoint) {
-                                    (codepoint - 0x2460 + 1).to_string()
-                                } else if let Some(display) = pua_to_display_text(*ch) {
-                                    display
-                                } else {
-                                    ch.to_string()
-                                }
-                            };
-                            draw_overlap_box(
-                                &display,
-                                bbox.x as f32 + index as f32 * char_advance + box_size / 2.0,
-                                (bbox.y + bbox.height / 2.0) as f32,
-                            );
-                        }
-                    }
-                    if effective_rotation != 0.0 {
-                        canvas.restore();
-                    }
-                    return;
-                }
-
-                let char_positions = compute_char_positions(text, style);
-                let clusters = split_into_clusters(text);
-                let text_width = *char_positions.last().unwrap_or(&0.0) as f32;
-                let ratio = if style.ratio > 0.0 {
-                    style.ratio as f32
-                } else {
-                    1.0
-                };
-                let has_ratio = (ratio - 1.0).abs() > 0.01;
-                let shade_rgb = style.shade_color & 0x00FF_FFFF;
-                if shade_rgb != 0x00FF_FFFF && shade_rgb != 0 && text_width > 0.0 {
-                    let mut shade = Paint::default();
-                    shade.set_anti_alias(true);
-                    shade.set_style(paint::Style::Fill);
-                    shade.set_color(colorref_to_skia(style.shade_color, 1.0));
-                    canvas.draw_rect(
-                        Rect::from_xywh(
-                            bbox.x as f32,
-                            y as f32 - font_size,
-                            text_width,
-                            font_size * 1.2,
-                        ),
-                        &shade,
-                    );
-                }
-
-                let draw_styled_line = |x1: f32,
-                                        y: f32,
-                                        x2: f32,
-                                        color: Color,
-                                        width: f32,
-                                        dash: &[f32],
-                                        round: bool| {
-                    if x2 <= x1 {
-                        return;
-                    }
-                    let mut line_paint = Paint::default();
-                    line_paint.set_anti_alias(true);
-                    line_paint.set_style(paint::Style::Stroke);
-                    line_paint.set_stroke_width(width);
-                    line_paint.set_color(color);
-                    if round {
-                        line_paint.set_stroke_cap(paint::Cap::Round);
-                    }
-                    if !dash.is_empty() {
-                        if let Some(effect) = PathEffect::dash(dash, 0.0) {
-                            line_paint.set_path_effect(effect);
-                        }
-                    }
-                    canvas.draw_line((x1, y), (x2, y), &line_paint);
-                };
-                let draw_line_shape =
-                    |x1: f32, y: f32, x2: f32, color: Color, shape: u8| match shape {
-                        7 => {
-                            draw_styled_line(x1, y - 1.0, x2, color, 0.7, &[], false);
-                            draw_styled_line(x1, y + 1.0, x2, color, 0.7, &[], false);
-                        }
-                        8 => {
-                            draw_styled_line(x1, y - 1.2, x2, color, 0.5, &[], false);
-                            draw_styled_line(x1, y + 0.8, x2, color, 1.2, &[], false);
-                        }
-                        9 => {
-                            draw_styled_line(x1, y - 0.8, x2, color, 1.2, &[], false);
-                            draw_styled_line(x1, y + 1.2, x2, color, 0.5, &[], false);
-                        }
-                        10 => {
-                            draw_styled_line(x1, y - 1.5, x2, color, 0.5, &[], false);
-                            draw_styled_line(x1, y, x2, color, 0.5, &[], false);
-                            draw_styled_line(x1, y + 1.5, x2, color, 0.5, &[], false);
-                        }
-                        1 => draw_styled_line(x1, y, x2, color, 1.0, &[3.0, 3.0], false),
-                        2 => draw_styled_line(x1, y, x2, color, 1.0, &[1.0, 2.0], false),
-                        3 => draw_styled_line(x1, y, x2, color, 1.0, &[6.0, 2.0, 1.0, 2.0], false),
-                        4 => draw_styled_line(
-                            x1,
-                            y,
-                            x2,
-                            color,
-                            1.0,
-                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
-                            false,
-                        ),
-                        5 => draw_styled_line(x1, y, x2, color, 1.0, &[8.0, 4.0], false),
-                        6 => draw_styled_line(x1, y, x2, color, 1.0, &[0.1, 2.5], true),
-                        _ => draw_styled_line(x1, y, x2, color, 1.0, &[], false),
-                    };
-
-                let suppress_dash_leader_line = !matches!(style.underline, UnderlineType::None);
-                let dash_run_groups: Vec<(usize, usize)> = {
-                    let mut groups = Vec::new();
-                    let mut run_start: Option<usize> = None;
-                    for (idx, (_, cluster)) in clusters.iter().enumerate() {
-                        if cluster == "-" {
-                            if run_start.is_none() {
-                                run_start = Some(idx);
-                            }
-                        } else if let Some(start) = run_start.take() {
-                            if idx - start >= 3 {
-                                groups.push((start, idx));
-                            }
-                        }
-                    }
-                    if let Some(start) = run_start {
-                        if clusters.len() - start >= 3 {
-                            groups.push((start, clusters.len()));
-                        }
-                    }
-                    groups
-                };
-                let cluster_in_dash_run = |cluster_idx: usize| -> Option<(f32, f32)> {
-                    for &(start, end) in &dash_run_groups {
-                        if cluster_idx == start {
-                            let start_char_idx = clusters[start].0;
-                            let last = &clusters[end - 1];
-                            let end_char_idx = last.0 + last.1.chars().count();
-                            let x1 = char_positions.get(start_char_idx).copied().unwrap_or(0.0);
-                            let x2 = char_positions
-                                .get(end_char_idx)
-                                .copied()
-                                .unwrap_or_else(|| *char_positions.last().unwrap_or(&0.0));
-                            return Some((x1 as f32, x2 as f32));
-                        }
-                        if cluster_idx > start && cluster_idx < end {
-                            return Some((f32::NAN, f32::NAN));
-                        }
-                    }
-                    None
-                };
-                let cluster_advance = |char_idx: usize, cluster: &str| -> f32 {
-                    let end = char_idx + cluster.chars().count();
-                    if end < char_positions.len() {
-                        (char_positions[end] - char_positions[char_idx]) as f32
-                    } else {
-                        0.0
-                    }
-                };
-                let is_middle_dot = |cluster: &str| cluster == "\u{00B7}";
-                let draw_text_pass = |color: Color, stroke_width: f32, dx: f32, dy: f32| {
-                    let mut text_paint = Paint::default();
-                    text_paint.set_anti_alias(true);
-                    text_paint.set_color(color);
-                    if stroke_width > 0.0 {
-                        text_paint.set_style(paint::Style::Stroke);
-                        text_paint.set_stroke_width(stroke_width);
-                    } else {
-                        text_paint.set_style(paint::Style::Fill);
-                    }
-                    for (cluster_idx, (char_idx, cluster)) in clusters.iter().enumerate() {
-                        if cluster == " " || cluster == "\t" || cluster == "\u{2007}" {
-                            continue;
-                        }
-                        if cluster.starts_with(|ch: char| {
-                            ch < '\u{0020}' && !matches!(ch, '\t' | '\n' | '\r')
-                        }) {
-                            continue;
-                        }
-                        if let Some((x1_rel, x2_rel)) = cluster_in_dash_run(cluster_idx) {
-                            if x1_rel.is_finite() && !suppress_dash_leader_line {
-                                draw_styled_line(
-                                    bbox.x as f32 + x1_rel + dx,
-                                    y as f32 - font_size * 0.32 + dy,
-                                    bbox.x as f32 + x2_rel + dx,
-                                    color,
-                                    (font_size * 0.07).max(0.5),
-                                    &[],
-                                    false,
-                                );
-                            }
-                            continue;
-                        }
-                        if is_middle_dot(cluster) {
-                            let advance = cluster_advance(*char_idx, cluster);
-                            let cx = bbox.x as f32
-                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
-                                + advance / 2.0
-                                + dx;
-                            let cy = y as f32 - font_size * 0.35 + dy;
-                            let mut dot_paint = Paint::default();
-                            dot_paint.set_anti_alias(true);
-                            dot_paint.set_style(paint::Style::Fill);
-                            dot_paint.set_color(color);
-                            canvas.draw_circle((cx, cy), font_size * 0.08, &dot_paint);
-                            continue;
-                        }
-                        if let Some(font) = font_for_text(cluster, font_size) {
-                            let char_x = bbox.x as f32
-                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
-                                + dx;
-                            let char_y = y as f32 + dy;
-                            if has_ratio {
-                                canvas.save();
-                                canvas.translate((char_x, char_y));
-                                canvas.scale((ratio, 1.0));
-                                canvas.draw_str(cluster, (0.0, 0.0), &font, &text_paint);
-                                canvas.restore();
-                            } else {
-                                canvas.draw_str(cluster, (char_x, char_y), &font, &text_paint);
-                            }
-                        }
-                    }
-                };
-
-                if style.shadow_type > 0 {
-                    draw_text_pass(
-                        colorref_to_skia(style.shadow_color, 1.0),
-                        0.0,
-                        style.shadow_offset_x as f32,
-                        style.shadow_offset_y as f32,
-                    );
-                }
-                if style.outline_type > 0 {
-                    draw_text_pass(
-                        colorref_to_skia(style.color, 1.0),
-                        (font_size * 0.08).max(0.8),
-                        0.0,
-                        0.0,
-                    );
-                }
-                if style.emboss {
-                    draw_text_pass(Color::WHITE, 0.0, -1.0, -1.0);
-                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, 1.0, 1.0);
-                } else if style.engrave {
-                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, -1.0, -1.0);
-                    draw_text_pass(Color::WHITE, 0.0, 1.0, 1.0);
-                }
-                draw_text_pass(colorref_to_skia(style.color, 1.0), 0.0, 0.0, 0.0);
-
-                if !matches!(style.underline, UnderlineType::None) && text_width > 0.0 {
-                    let color = if style.underline_color != 0 {
-                        colorref_to_skia(style.underline_color, 1.0)
-                    } else {
-                        colorref_to_skia(style.color, 1.0)
-                    };
-                    let line_y = match style.underline {
-                        UnderlineType::Top => y as f32 - font_size + 1.0,
-                        _ => y as f32 + 2.0,
-                    };
-                    draw_line_shape(
-                        bbox.x as f32,
-                        line_y,
-                        bbox.x as f32 + text_width,
-                        color,
-                        style.underline_shape,
-                    );
-                }
-                if style.strikethrough && text_width > 0.0 {
-                    let color = if style.strike_color != 0 {
-                        colorref_to_skia(style.strike_color, 1.0)
-                    } else {
-                        colorref_to_skia(style.color, 1.0)
-                    };
-                    draw_line_shape(
-                        bbox.x as f32,
-                        y as f32 - font_size * 0.3,
-                        bbox.x as f32 + text_width,
-                        color,
-                        style.strike_shape,
-                    );
-                }
-                if style.emphasis_dot > 0 {
-                    let dot = match style.emphasis_dot {
-                        1 => "●",
-                        2 => "○",
-                        3 => "ˇ",
-                        4 => "˜",
-                        5 => "･",
-                        6 => "˸",
-                        _ => "",
-                    };
-                    if !dot.is_empty() {
-                        let dot_size = font_size * 0.3;
-                        let dot_y = y as f32 - font_size * 1.05;
-                        if let Some(font) = font_for_text(dot, dot_size) {
-                            let mut dot_paint = Paint::default();
-                            dot_paint.set_anti_alias(true);
-                            dot_paint.set_color(colorref_to_skia(style.color, 1.0));
-                            for cx in &char_positions[..char_positions.len().saturating_sub(1)] {
-                                canvas.draw_str(
-                                    dot,
-                                    (bbox.x as f32 + *cx as f32 + font_size * ratio * 0.5, dot_y),
-                                    &font,
-                                    &dot_paint,
-                                );
-                            }
-                        }
-                    }
-                }
-                for leader in &style.tab_leaders {
-                    if leader.fill_type == 0 {
-                        continue;
-                    }
-                    let x1 = bbox.x as f32 + leader.start_x as f32;
-                    let x2 = bbox.x as f32 + leader.end_x as f32;
-                    let line_y = y as f32 - font_size * 0.35;
-                    let color = colorref_to_skia(style.color, 1.0);
-                    match leader.fill_type {
-                        1 => draw_styled_line(x1, line_y, x2, color, 0.5, &[], false),
-                        2 => draw_styled_line(x1, line_y, x2, color, 0.5, &[3.0, 3.0], false),
-                        3 => draw_styled_line(x1, line_y, x2, color, 1.0, &[0.1, 3.0], true),
-                        4 => draw_styled_line(
-                            x1,
-                            line_y,
-                            x2,
-                            color,
-                            0.5,
-                            &[6.0, 2.0, 1.0, 2.0],
-                            false,
-                        ),
-                        5 => draw_styled_line(
-                            x1,
-                            line_y,
-                            x2,
-                            color,
-                            0.5,
-                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
-                            false,
-                        ),
-                        6 => draw_styled_line(x1, line_y, x2, color, 0.5, &[8.0, 4.0], false),
-                        7 => draw_styled_line(x1, line_y, x2, color, 0.7, &[0.1, 2.5], true),
-                        8 => {
-                            draw_styled_line(x1, line_y - 1.0, x2, color, 0.3, &[], false);
-                            draw_styled_line(x1, line_y + 1.0, x2, color, 0.3, &[], false);
-                        }
-                        9 => {
-                            draw_styled_line(x1, line_y - 1.2, x2, color, 0.3, &[], false);
-                            draw_styled_line(x1, line_y + 0.8, x2, color, 0.8, &[], false);
-                        }
-                        10 => {
-                            draw_styled_line(x1, line_y - 0.8, x2, color, 0.8, &[], false);
-                            draw_styled_line(x1, line_y + 1.2, x2, color, 0.3, &[], false);
-                        }
-                        11 => {
-                            draw_styled_line(x1, line_y - 2.0, x2, color, 0.3, &[], false);
-                            draw_styled_line(x1, line_y, x2, color, 0.8, &[], false);
-                            draw_styled_line(x1, line_y + 2.0, x2, color, 0.3, &[], false);
-                        }
-                        _ => draw_styled_line(x1, line_y, x2, color, 0.5, &[1.0, 2.0], false),
-                    }
-                }
-                if effective_rotation != 0.0 {
-                    canvas.restore();
-                }
-            };
-        let draw_text_marks = |text: &str,
-                               bbox: crate::renderer::render_tree::BoundingBox,
-                               style: &crate::renderer::TextStyle,
-                               baseline: f64,
-                               rotation: f64,
-                               is_vertical: bool,
-                               is_marker: bool,
-                               is_para_end: bool,
-                               is_line_break_end: bool| {
-            if !output_options.show_paragraph_marks && !output_options.show_control_codes {
-                return;
-            }
-            let font_size = if style.font_size > 0.0 {
-                style.font_size as f32
-            } else {
-                12.0
-            };
-            let make_mark_font = |size: f32| {
-                let mut font = self
-                    .font_mgr
-                    .match_family_style("DejaVu Sans", FontStyle::normal())
-                    .or_else(|| {
-                        self.font_mgr
-                            .legacy_make_typeface(None::<&str>, FontStyle::normal())
-                    })
-                    .map(|tf| Font::new(tf, size))
-                    .unwrap_or_else(|| {
-                        let mut font = Font::default();
-                        font.set_size(size);
-                        font
-                    });
-                font.set_edging(font::Edging::AntiAlias);
-                font
-            };
-            let font = make_mark_font(font_size * 0.5);
-            let mut mark_paint = Paint::default();
-            mark_paint.set_anti_alias(true);
-            mark_paint.set_color(Color::from_argb(255, 74, 144, 217));
-            let y = if baseline > 0.0 {
-                bbox.y + baseline
-            } else {
-                bbox.y + bbox.height
-            };
-            let effective_rotation = if is_vertical {
-                rotation + 90.0
-            } else {
-                rotation
-            };
-            if effective_rotation != 0.0 {
-                canvas.save();
-                canvas.rotate(
-                    effective_rotation as f32,
-                    Some(
-                        (
-                            (bbox.x + bbox.width / 2.0) as f32,
-                            (bbox.y + bbox.height / 2.0) as f32,
-                        )
-                            .into(),
-                    ),
-                );
-            }
-            if !text.is_empty() && !is_marker {
-                let char_positions = compute_char_positions(text, style);
-                for (index, ch) in text.chars().enumerate() {
-                    if ch == ' ' {
-                        let x = bbox.x + char_positions.get(index).copied().unwrap_or(0.0);
-                        let next_x = if index + 1 < char_positions.len() {
-                            bbox.x + char_positions[index + 1]
-                        } else {
-                            bbox.x + bbox.width
-                        };
-                        let mark_x = ((x + next_x) / 2.0) as f32 - font_size * 0.125;
-                        canvas.draw_str("\u{2228}", (mark_x, y as f32), &font, &mark_paint);
-                    } else if ch == '\t' {
-                        let mark_x = bbox.x as f32
-                            + char_positions.get(index).copied().unwrap_or(0.0) as f32;
-                        canvas.draw_str("\u{2192}", (mark_x, y as f32), &font, &mark_paint);
-                    }
-                }
-            }
-            if is_para_end || is_line_break_end {
-                let end_font = make_mark_font(font_size);
-                let mark = if is_line_break_end {
-                    "\u{2193}"
-                } else {
-                    "\u{21B5}"
-                };
-                let mark_x = if text.is_empty() {
-                    bbox.x as f32
-                } else {
-                    (bbox.x + bbox.width) as f32
-                };
-                canvas.draw_str(mark, (mark_x, y as f32), &end_font, &mark_paint);
-            }
-            if effective_rotation != 0.0 {
-                canvas.restore();
-            }
+        let text_replay = SkiaTextReplay {
+            canvas,
+            font_mgr: &self.font_mgr,
+            custom_typefaces: &self.custom_typefaces,
+            output_options,
         };
         let open_shape_transform =
             |transform: crate::renderer::render_tree::ShapeTransform,
@@ -1047,7 +364,11 @@ impl SkiaLayerRenderer {
                             }
                         }
                         PaintOp::TextRun { bbox, run } => {
-                            draw_text(
+                            let is_marker = !matches!(
+                                run.field_marker,
+                                crate::renderer::render_tree::FieldMarkerType::None
+                            );
+                            text_replay.draw_text(
                                 &run.text,
                                 *bbox,
                                 &run.style,
@@ -1055,18 +376,6 @@ impl SkiaLayerRenderer {
                                 run.rotation,
                                 run.is_vertical,
                                 run.char_overlap.as_ref(),
-                            );
-                            let is_marker = !matches!(
-                                run.field_marker,
-                                crate::renderer::render_tree::FieldMarkerType::None
-                            );
-                            draw_text_marks(
-                                &run.text,
-                                *bbox,
-                                &run.style,
-                                run.baseline,
-                                run.rotation,
-                                run.is_vertical,
                                 is_marker,
                                 run.is_para_end,
                                 run.is_line_break_end,
@@ -1079,7 +388,7 @@ impl SkiaLayerRenderer {
                                 color: marker.color,
                                 ..Default::default()
                             };
-                            draw_text(
+                            text_replay.draw_text(
                                 &marker.text,
                                 *bbox,
                                 &style,
@@ -1087,6 +396,9 @@ impl SkiaLayerRenderer {
                                 0.0,
                                 false,
                                 None,
+                                false,
+                                false,
+                                false,
                             );
                         }
                         PaintOp::Line { bbox, line } => {
@@ -1361,7 +673,13 @@ impl LayerRasterRenderer for SkiaLayerRenderer {
 impl SkiaLayerRenderer {
     fn make_form_font(&self, size: f32) -> Font {
         let style = FontStyle::default();
-        let cjk_families = ["Malgun Gothic", "맑은 고딕", "NanumGothic", "나눔고딕", "AppleGothic"];
+        let cjk_families = [
+            "Malgun Gothic",
+            "맑은 고딕",
+            "NanumGothic",
+            "나눔고딕",
+            "AppleGothic",
+        ];
         for family in &cjk_families {
             if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
                 return Font::new(tf, size);
@@ -1400,209 +718,215 @@ impl SkiaLayerRenderer {
         let fg_color = parse_css_color(&form.fore_color).unwrap_or(Color::from_rgb(0, 0, 0));
         let border_color = Color::from_rgb(160, 160, 160);
 
-    match form.form_type {
-        FormType::PushButton => {
-            let mut fill = Paint::default();
-            fill.set_anti_alias(true);
-            fill.set_style(paint::Style::Fill);
-            fill.set_color(bg_color);
-            let rrect = RRect::new_rect_xy(rect, 3.0, 3.0);
-            canvas.draw_rrect(rrect, &fill);
+        match form.form_type {
+            FormType::PushButton => {
+                let mut fill = Paint::default();
+                fill.set_anti_alias(true);
+                fill.set_style(paint::Style::Fill);
+                fill.set_color(bg_color);
+                let rrect = RRect::new_rect_xy(rect, 3.0, 3.0);
+                canvas.draw_rrect(rrect, &fill);
 
-            let mut stroke = Paint::default();
-            stroke.set_anti_alias(true);
-            stroke.set_style(paint::Style::Stroke);
-            stroke.set_stroke_width(1.0);
-            stroke.set_color(border_color);
-            canvas.draw_rrect(rrect, &stroke);
+                let mut stroke = Paint::default();
+                stroke.set_anti_alias(true);
+                stroke.set_style(paint::Style::Stroke);
+                stroke.set_stroke_width(1.0);
+                stroke.set_color(border_color);
+                canvas.draw_rrect(rrect, &stroke);
 
-            let label = if form.caption.is_empty() { &form.name } else { &form.caption };
-            if !label.is_empty() {
-                let font = self.make_form_font((h * 0.45).clamp(8.0, 14.0));
-                let mut tp = Paint::default();
-                tp.set_anti_alias(true);
-                tp.set_color(fg_color);
-                let text_w = font.measure_str(label, Some(&tp)).0;
-                let tx = x + (w - text_w) / 2.0;
-                let ty = y + h / 2.0 + font.size() * 0.35;
-                canvas.draw_str(label, (tx, ty), &font, &tp);
+                let label = if form.caption.is_empty() {
+                    &form.name
+                } else {
+                    &form.caption
+                };
+                if !label.is_empty() {
+                    let font = self.make_form_font((h * 0.45).clamp(8.0, 14.0));
+                    let mut tp = Paint::default();
+                    tp.set_anti_alias(true);
+                    tp.set_color(fg_color);
+                    let text_w = font.measure_str(label, Some(&tp)).0;
+                    let tx = x + (w - text_w) / 2.0;
+                    let ty = y + h / 2.0 + font.size() * 0.35;
+                    canvas.draw_str(label, (tx, ty), &font, &tp);
+                }
             }
-        }
-        FormType::CheckBox => {
-            let box_size = h.min(w).min(14.0);
-            let bx = x + 2.0;
-            let by = y + (h - box_size) / 2.0;
-            let box_rect = Rect::from_xywh(bx, by, box_size, box_size);
+            FormType::CheckBox => {
+                let box_size = h.min(w).min(14.0);
+                let bx = x + 2.0;
+                let by = y + (h - box_size) / 2.0;
+                let box_rect = Rect::from_xywh(bx, by, box_size, box_size);
 
-            let mut fill = Paint::default();
-            fill.set_anti_alias(true);
-            fill.set_style(paint::Style::Fill);
-            fill.set_color(bg_color);
-            canvas.draw_rect(box_rect, &fill);
+                let mut fill = Paint::default();
+                fill.set_anti_alias(true);
+                fill.set_style(paint::Style::Fill);
+                fill.set_color(bg_color);
+                canvas.draw_rect(box_rect, &fill);
 
-            let mut stroke = Paint::default();
-            stroke.set_anti_alias(true);
-            stroke.set_style(paint::Style::Stroke);
-            stroke.set_stroke_width(1.0);
-            stroke.set_color(border_color);
-            canvas.draw_rect(box_rect, &stroke);
+                let mut stroke = Paint::default();
+                stroke.set_anti_alias(true);
+                stroke.set_style(paint::Style::Stroke);
+                stroke.set_stroke_width(1.0);
+                stroke.set_color(border_color);
+                canvas.draw_rect(box_rect, &stroke);
 
-            if form.value != 0 {
-                let mut check = Paint::default();
-                check.set_anti_alias(true);
-                check.set_style(paint::Style::Stroke);
-                check.set_stroke_width(2.0);
-                check.set_color(fg_color);
-                check.set_stroke_cap(paint::Cap::Round);
-                let cx = bx + box_size * 0.2;
-                let cy = by + box_size * 0.55;
-                let mx = bx + box_size * 0.4;
-                let my = by + box_size * 0.75;
-                let ex = bx + box_size * 0.8;
-                let ey = by + box_size * 0.25;
+                if form.value != 0 {
+                    let mut check = Paint::default();
+                    check.set_anti_alias(true);
+                    check.set_style(paint::Style::Stroke);
+                    check.set_stroke_width(2.0);
+                    check.set_color(fg_color);
+                    check.set_stroke_cap(paint::Cap::Round);
+                    let cx = bx + box_size * 0.2;
+                    let cy = by + box_size * 0.55;
+                    let mx = bx + box_size * 0.4;
+                    let my = by + box_size * 0.75;
+                    let ex = bx + box_size * 0.8;
+                    let ey = by + box_size * 0.25;
+                    let mut builder = PathBuilder::new();
+                    builder.move_to((cx, cy));
+                    builder.line_to((mx, my));
+                    builder.line_to((ex, ey));
+                    let path = builder.detach();
+                    canvas.draw_path(&path, &check);
+                }
+
+                if !form.caption.is_empty() {
+                    let font = self.make_form_font((h * 0.6).clamp(8.0, 13.0));
+                    let mut tp = Paint::default();
+                    tp.set_anti_alias(true);
+                    tp.set_color(fg_color);
+                    let tx = bx + box_size + 4.0;
+                    let ty = y + h / 2.0 + font.size() * 0.35;
+                    canvas.draw_str(&form.caption, (tx, ty), &font, &tp);
+                }
+            }
+            FormType::RadioButton => {
+                let r = h.min(w).min(14.0) / 2.0;
+                let cx = x + 2.0 + r;
+                let cy = y + h / 2.0;
+
+                let mut fill = Paint::default();
+                fill.set_anti_alias(true);
+                fill.set_style(paint::Style::Fill);
+                fill.set_color(bg_color);
+                canvas.draw_circle((cx, cy), r, &fill);
+
+                let mut stroke = Paint::default();
+                stroke.set_anti_alias(true);
+                stroke.set_style(paint::Style::Stroke);
+                stroke.set_stroke_width(1.0);
+                stroke.set_color(border_color);
+                canvas.draw_circle((cx, cy), r, &stroke);
+
+                if form.value != 0 {
+                    let mut dot = Paint::default();
+                    dot.set_anti_alias(true);
+                    dot.set_style(paint::Style::Fill);
+                    dot.set_color(fg_color);
+                    canvas.draw_circle((cx, cy), r * 0.5, &dot);
+                }
+
+                if !form.caption.is_empty() {
+                    let font = self.make_form_font((h * 0.6).clamp(8.0, 13.0));
+                    let mut tp = Paint::default();
+                    tp.set_anti_alias(true);
+                    tp.set_color(fg_color);
+                    let tx = cx + r + 4.0;
+                    let ty = y + h / 2.0 + font.size() * 0.35;
+                    canvas.draw_str(&form.caption, (tx, ty), &font, &tp);
+                }
+            }
+            FormType::ComboBox => {
+                let mut fill = Paint::default();
+                fill.set_anti_alias(true);
+                fill.set_style(paint::Style::Fill);
+                fill.set_color(bg_color);
+                canvas.draw_rect(rect, &fill);
+
+                let mut stroke = Paint::default();
+                stroke.set_anti_alias(true);
+                stroke.set_style(paint::Style::Stroke);
+                stroke.set_stroke_width(1.0);
+                stroke.set_color(border_color);
+                canvas.draw_rect(rect, &stroke);
+
+                // 드롭다운 화살표 영역
+                let arrow_w = h.min(20.0);
+                let ax = x + w - arrow_w;
+                let arrow_rect = Rect::from_xywh(ax, y, arrow_w, h);
+                let mut abg = Paint::default();
+                abg.set_anti_alias(true);
+                abg.set_style(paint::Style::Fill);
+                abg.set_color(bg_color);
+                canvas.draw_rect(arrow_rect, &abg);
+                canvas.draw_line((ax, y), (ax, y + h), &stroke);
+
+                // 화살표 삼각형
+                let mut arrow = Paint::default();
+                arrow.set_anti_alias(true);
+                arrow.set_style(paint::Style::Fill);
+                arrow.set_color(Color::from_rgb(80, 80, 80));
+                let acx = ax + arrow_w / 2.0;
+                let acy = y + h / 2.0;
+                let as_ = (arrow_w * 0.25).min(5.0);
                 let mut builder = PathBuilder::new();
-                builder.move_to((cx, cy));
-                builder.line_to((mx, my));
-                builder.line_to((ex, ey));
+                builder.move_to((acx - as_, acy - as_ * 0.5));
+                builder.line_to((acx + as_, acy - as_ * 0.5));
+                builder.line_to((acx, acy + as_ * 0.5));
+                builder.close();
                 let path = builder.detach();
-                canvas.draw_path(&path, &check);
+                canvas.draw_path(&path, &arrow);
+
+                if !form.text.is_empty() {
+                    let font = self.make_form_font((h * 0.55).clamp(8.0, 13.0));
+                    let mut tp = Paint::default();
+                    tp.set_anti_alias(true);
+                    tp.set_color(fg_color);
+                    let tx = x + 4.0;
+                    let ty = y + h / 2.0 + font.size() * 0.35;
+                    canvas.draw_str(&form.text, (tx, ty), &font, &tp);
+                }
             }
+            FormType::Edit => {
+                let mut fill = Paint::default();
+                fill.set_anti_alias(true);
+                fill.set_style(paint::Style::Fill);
+                fill.set_color(bg_color);
+                canvas.draw_rect(rect, &fill);
 
-            if !form.caption.is_empty() {
-                let font = self.make_form_font((h * 0.6).clamp(8.0, 13.0));
-                let mut tp = Paint::default();
-                tp.set_anti_alias(true);
-                tp.set_color(fg_color);
-                let tx = bx + box_size + 4.0;
-                let ty = y + h / 2.0 + font.size() * 0.35;
-                canvas.draw_str(&form.caption, (tx, ty), &font, &tp);
-            }
-        }
-        FormType::RadioButton => {
-            let r = h.min(w).min(14.0) / 2.0;
-            let cx = x + 2.0 + r;
-            let cy = y + h / 2.0;
+                let mut stroke = Paint::default();
+                stroke.set_anti_alias(true);
+                stroke.set_style(paint::Style::Stroke);
+                stroke.set_stroke_width(1.0);
+                stroke.set_color(border_color);
+                canvas.draw_rect(rect, &stroke);
 
-            let mut fill = Paint::default();
-            fill.set_anti_alias(true);
-            fill.set_style(paint::Style::Fill);
-            fill.set_color(bg_color);
-            canvas.draw_circle((cx, cy), r, &fill);
-
-            let mut stroke = Paint::default();
-            stroke.set_anti_alias(true);
-            stroke.set_style(paint::Style::Stroke);
-            stroke.set_stroke_width(1.0);
-            stroke.set_color(border_color);
-            canvas.draw_circle((cx, cy), r, &stroke);
-
-            if form.value != 0 {
-                let mut dot = Paint::default();
-                dot.set_anti_alias(true);
-                dot.set_style(paint::Style::Fill);
-                dot.set_color(fg_color);
-                canvas.draw_circle((cx, cy), r * 0.5, &dot);
-            }
-
-            if !form.caption.is_empty() {
-                let font = self.make_form_font((h * 0.6).clamp(8.0, 13.0));
-                let mut tp = Paint::default();
-                tp.set_anti_alias(true);
-                tp.set_color(fg_color);
-                let tx = cx + r + 4.0;
-                let ty = y + h / 2.0 + font.size() * 0.35;
-                canvas.draw_str(&form.caption, (tx, ty), &font, &tp);
+                if !form.text.is_empty() {
+                    let font = self.make_form_font((h * 0.55).clamp(8.0, 13.0));
+                    let mut tp = Paint::default();
+                    tp.set_anti_alias(true);
+                    tp.set_color(fg_color);
+                    let tx = x + 4.0;
+                    let ty = y + h / 2.0 + font.size() * 0.35;
+                    canvas.draw_str(&form.text, (tx, ty), &font, &tp);
+                }
             }
         }
-        FormType::ComboBox => {
-            let mut fill = Paint::default();
-            fill.set_anti_alias(true);
-            fill.set_style(paint::Style::Fill);
-            fill.set_color(bg_color);
-            canvas.draw_rect(rect, &fill);
-
-            let mut stroke = Paint::default();
-            stroke.set_anti_alias(true);
-            stroke.set_style(paint::Style::Stroke);
-            stroke.set_stroke_width(1.0);
-            stroke.set_color(border_color);
-            canvas.draw_rect(rect, &stroke);
-
-            // 드롭다운 화살표 영역
-            let arrow_w = h.min(20.0);
-            let ax = x + w - arrow_w;
-            let arrow_rect = Rect::from_xywh(ax, y, arrow_w, h);
-            let mut abg = Paint::default();
-            abg.set_anti_alias(true);
-            abg.set_style(paint::Style::Fill);
-            abg.set_color(bg_color);
-            canvas.draw_rect(arrow_rect, &abg);
-            canvas.draw_line((ax, y), (ax, y + h), &stroke);
-
-            // 화살표 삼각형
-            let mut arrow = Paint::default();
-            arrow.set_anti_alias(true);
-            arrow.set_style(paint::Style::Fill);
-            arrow.set_color(Color::from_rgb(80, 80, 80));
-            let acx = ax + arrow_w / 2.0;
-            let acy = y + h / 2.0;
-            let as_ = (arrow_w * 0.25).min(5.0);
-            let mut builder = PathBuilder::new();
-            builder.move_to((acx - as_, acy - as_ * 0.5));
-            builder.line_to((acx + as_, acy - as_ * 0.5));
-            builder.line_to((acx, acy + as_ * 0.5));
-            builder.close();
-            let path = builder.detach();
-            canvas.draw_path(&path, &arrow);
-
-            if !form.text.is_empty() {
-                let font = self.make_form_font((h * 0.55).clamp(8.0, 13.0));
-                let mut tp = Paint::default();
-                tp.set_anti_alias(true);
-                tp.set_color(fg_color);
-                let tx = x + 4.0;
-                let ty = y + h / 2.0 + font.size() * 0.35;
-                canvas.draw_str(&form.text, (tx, ty), &font, &tp);
-            }
-        }
-        FormType::Edit => {
-            let mut fill = Paint::default();
-            fill.set_anti_alias(true);
-            fill.set_style(paint::Style::Fill);
-            fill.set_color(bg_color);
-            canvas.draw_rect(rect, &fill);
-
-            let mut stroke = Paint::default();
-            stroke.set_anti_alias(true);
-            stroke.set_style(paint::Style::Stroke);
-            stroke.set_stroke_width(1.0);
-            stroke.set_color(border_color);
-            canvas.draw_rect(rect, &stroke);
-
-            if !form.text.is_empty() {
-                let font = self.make_form_font((h * 0.55).clamp(8.0, 13.0));
-                let mut tp = Paint::default();
-                tp.set_anti_alias(true);
-                tp.set_color(fg_color);
-                let tx = x + 4.0;
-                let ty = y + h / 2.0 + font.size() * 0.35;
-                canvas.draw_str(&form.text, (tx, ty), &font, &tp);
-            }
-        }
-    }
     }
 }
 
 fn parse_css_color(s: &str) -> Option<Color> {
     let s = s.trim().trim_start_matches('#');
-    if s.len() != 6 { return None; }
+    if s.len() != 6 {
+        return None;
+    }
     let r = u8::from_str_radix(&s[0..2], 16).ok()?;
     let g = u8::from_str_radix(&s[2..4], 16).ok()?;
     let b = u8::from_str_radix(&s[4..6], 16).ok()?;
     Some(Color::from_rgb(r, g, b))
 }
 
-fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
+pub(super) fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
     let b = ((color >> 16) & 0xFF) as u8;
     let g = ((color >> 8) & 0xFF) as u8;
     let r = (color & 0xFF) as u8;

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -6,12 +6,15 @@ use std::collections::HashMap;
 
 use crate::error::HwpError;
 use crate::model::image::ImageEffect;
+use crate::model::style::UnderlineType;
 use crate::model::ColorRef;
-use crate::paint::{LayerNode, LayerNodeKind, PageLayerTree, PaintOp};
+use crate::paint::{LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree, PaintOp};
+use crate::renderer::composer::{decode_pua_overlap_number, pua_to_display_text};
 use crate::renderer::layer_renderer::{
     LayerRasterRenderer, LayerRenderResult, RasterOutputFormat, RasterRenderOptions,
     RasterRenderOutput,
 };
+use crate::renderer::layout::{compute_char_positions, split_into_clusters};
 use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, StrokeDash};
 
 use super::equation_conv::render_equation;
@@ -47,7 +50,10 @@ impl SkiaLayerRenderer {
             if let Ok(entries) = std::fs::read_dir(dir) {
                 for entry in entries.flatten() {
                     let path = entry.path();
-                    let ext = path.extension().and_then(|s| s.to_str()).map(|s| s.to_lowercase());
+                    let ext = path
+                        .extension()
+                        .and_then(|s| s.to_str())
+                        .map(|s| s.to_lowercase());
                     if !matches!(ext.as_deref(), Some("ttf") | Some("otf") | Some("ttc")) {
                         continue;
                     }
@@ -136,7 +142,7 @@ impl SkiaLayerRenderer {
         if options.scale != 1.0 {
             canvas.scale((options.scale as f32, options.scale as f32));
         }
-        self.render_node(canvas, &tree.root, tree.output_options.clip_enabled);
+        self.render_node(canvas, &tree.root, &tree.output_options);
 
         let image = surface.image_snapshot();
         let data = image
@@ -152,7 +158,8 @@ impl SkiaLayerRenderer {
         })
     }
 
-    fn render_node(&self, canvas: &Canvas, node: &LayerNode, clip_enabled: bool) {
+    fn render_node(&self, canvas: &Canvas, node: &LayerNode, output_options: &LayerOutputOptions) {
+        let clip_enabled = output_options.clip_enabled;
         let apply_dash = |paint: &mut Paint, dash: StrokeDash| {
             let base_width = paint.stroke_width().max(1.0);
             let intervals: Option<[f32; 6]> = match dash {
@@ -263,12 +270,605 @@ impl SkiaLayerRenderer {
                 ImageSampling::linear(),
             );
         };
-        let draw_text = |text: &str,
-                         bbox: crate::renderer::render_tree::BoundingBox,
-                         style: &crate::renderer::TextStyle,
-                         baseline: f64,
-                         rotation: f64| {
-            if text.is_empty() {
+        let draw_text =
+            |text: &str,
+             bbox: crate::renderer::render_tree::BoundingBox,
+             style: &crate::renderer::TextStyle,
+             baseline: f64,
+             rotation: f64,
+             is_vertical: bool,
+             char_overlap: Option<&crate::renderer::composer::CharOverlapInfo>| {
+                if text.is_empty() && style.tab_leaders.is_empty() {
+                    return;
+                }
+                let font_size = if style.font_size > 0.0 {
+                    style.font_size as f32
+                } else {
+                    12.0
+                };
+                let font_style = match (style.bold, style.italic) {
+                    (true, true) => FontStyle::bold_italic(),
+                    (true, false) => FontStyle::bold(),
+                    (false, true) => FontStyle::italic(),
+                    (false, false) => FontStyle::normal(),
+                };
+                let mut families = Vec::new();
+                if !style.font_family.trim().is_empty() {
+                    families.push(style.font_family.as_str());
+                }
+                // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
+                // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.
+                families.extend([
+                    "Noto Sans KR",
+                    "Noto Serif KR",
+                    "Noto Sans CJK KR",
+                    "Noto Serif CJK KR",
+                    "Nanum Gothic",
+                    "Nanum Myeongjo",
+                    "Malgun Gothic",
+                    "맑은 고딕",
+                    "Batang",
+                    "바탕",
+                    "Apple SD Gothic Neo",
+                    "AppleMyungjo",
+                    "DejaVu Sans",
+                    "Arial",
+                    "sans-serif",
+                ]);
+                // 1) 사용자 지정 폰트 (--font-path) 우선 검색
+                // 2) 시스템 FontMgr 검색 (한글 fallback chain 포함)
+                // 3) 마지막 fallback (legacy_make_typeface)
+                //
+                // 모든 후보를 chain 으로 보존 — char 단위 fallback 에 사용.
+                let typeface_chain: Vec<Typeface> = {
+                    let mut chain: Vec<Typeface> = Vec::new();
+                    let mut seen: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    let mut push = |chain: &mut Vec<Typeface>,
+                                    seen: &mut std::collections::HashSet<String>,
+                                    tf: Typeface| {
+                        let key = tf.family_name();
+                        if seen.insert(key) {
+                            chain.push(tf);
+                        }
+                    };
+                    for family in &families {
+                        if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
+                            push(&mut chain, &mut seen, tf);
+                        }
+                    }
+                    for family in &families {
+                        if let Some(tf) = self.font_mgr.match_family_style(family, font_style) {
+                            push(&mut chain, &mut seen, tf);
+                        }
+                    }
+                    if let Some(tf) = self.font_mgr.legacy_make_typeface(None::<&str>, font_style) {
+                        push(&mut chain, &mut seen, tf);
+                    }
+                    chain
+                };
+                let primary_typeface = typeface_chain.first().cloned();
+                let font_for_text = |sample: &str, size: f32| -> Option<Font> {
+                    let visible_char = sample.chars().find(|ch| !ch.is_whitespace());
+                    if let Some(ch) = visible_char {
+                        let codepoint = ch as i32;
+                        if let Some(tf) = typeface_chain
+                            .iter()
+                            .find(|tf| tf.unichar_to_glyph(codepoint) != 0)
+                            .cloned()
+                        {
+                            let mut font = Font::new(tf, size);
+                            font.set_edging(font::Edging::AntiAlias);
+                            return Some(font);
+                        }
+                        return None;
+                    }
+                    if let Some(tf) = primary_typeface.clone() {
+                        let mut font = Font::new(tf, size);
+                        font.set_edging(font::Edging::AntiAlias);
+                        Some(font)
+                    } else {
+                        let mut font = Font::default();
+                        font.set_size(size);
+                        font.set_edging(font::Edging::AntiAlias);
+                        Some(font)
+                    }
+                };
+                let y = if baseline > 0.0 {
+                    bbox.y + baseline
+                } else {
+                    bbox.y + bbox.height
+                };
+                let effective_rotation = if is_vertical {
+                    rotation + 90.0
+                } else {
+                    rotation
+                };
+                if effective_rotation != 0.0 {
+                    canvas.save();
+                    canvas.rotate(
+                        effective_rotation as f32,
+                        Some(
+                            (
+                                (bbox.x + bbox.width / 2.0) as f32,
+                                (bbox.y + bbox.height / 2.0) as f32,
+                            )
+                                .into(),
+                        ),
+                    );
+                }
+
+                if let Some(overlap) = char_overlap {
+                    let chars: Vec<char> = text.chars().collect();
+                    if chars.is_empty() {
+                        if effective_rotation != 0.0 {
+                            canvas.restore();
+                        }
+                        return;
+                    }
+
+                    let size_ratio = if overlap.inner_char_size > 0 {
+                        overlap.inner_char_size as f32 / 100.0
+                    } else {
+                        1.0
+                    };
+                    let inner_size = (font_size * size_ratio).max(1.0);
+                    let box_size = font_size.max(1.0);
+                    let is_combined = decode_pua_overlap_number(&chars);
+                    let effective_border = if overlap.border_type == 0 && is_combined.is_some() {
+                        1
+                    } else {
+                        overlap.border_type
+                    };
+                    let is_reversed = effective_border == 2 || effective_border == 4;
+                    let is_circle = effective_border == 1 || effective_border == 2;
+                    let is_rect = effective_border == 3 || effective_border == 4;
+                    let fill_color = if is_reversed {
+                        Color::BLACK
+                    } else {
+                        Color::TRANSPARENT
+                    };
+                    let text_color = if is_reversed {
+                        Color::WHITE
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    let stroke_color = colorref_to_skia(style.color, 1.0);
+                    let mut shape_paint = Paint::default();
+                    shape_paint.set_anti_alias(true);
+                    let mut stroke_paint = Paint::default();
+                    stroke_paint.set_anti_alias(true);
+                    stroke_paint.set_style(paint::Style::Stroke);
+                    stroke_paint.set_stroke_width(0.8);
+                    stroke_paint.set_color(stroke_color);
+                    let mut text_paint = Paint::default();
+                    text_paint.set_anti_alias(true);
+                    text_paint.set_color(text_color);
+                    let draw_overlap_text = |display: &str, cx: f32, cy: f32| {
+                        if let Some(font) = font_for_text(display, inner_size) {
+                            let width = font.measure_str(display, Some(&text_paint)).0;
+                            canvas.draw_str(
+                                display,
+                                (cx - width / 2.0, cy + inner_size * 0.35),
+                                &font,
+                                &text_paint,
+                            );
+                        }
+                    };
+                    let mut draw_overlap_box = |display: &str, cx: f32, cy: f32| {
+                        if is_circle {
+                            shape_paint.set_style(paint::Style::Fill);
+                            shape_paint.set_color(fill_color);
+                            if is_reversed {
+                                canvas.draw_circle((cx, cy), box_size / 2.0, &shape_paint);
+                            }
+                            canvas.draw_circle((cx, cy), box_size / 2.0, &stroke_paint);
+                        } else if is_rect {
+                            let rect = Rect::from_xywh(
+                                cx - box_size / 2.0,
+                                cy - box_size / 2.0,
+                                box_size,
+                                box_size,
+                            );
+                            shape_paint.set_style(paint::Style::Fill);
+                            shape_paint.set_color(fill_color);
+                            if is_reversed {
+                                canvas.draw_rect(rect, &shape_paint);
+                            }
+                            canvas.draw_rect(rect, &stroke_paint);
+                        }
+                        draw_overlap_text(display, cx, cy);
+                    };
+
+                    if let Some(number) = is_combined {
+                        draw_overlap_box(
+                            &number,
+                            (bbox.x + bbox.width / 2.0) as f32,
+                            (bbox.y + bbox.height / 2.0) as f32,
+                        );
+                    } else {
+                        let char_advance = if chars.len() > 1 {
+                            bbox.width as f32 / chars.len() as f32
+                        } else {
+                            box_size
+                        };
+                        for (index, ch) in chars.iter().enumerate() {
+                            let display = {
+                                let codepoint = *ch as u32;
+                                if (0x2460..=0x2473).contains(&codepoint) {
+                                    (codepoint - 0x2460 + 1).to_string()
+                                } else if let Some(display) = pua_to_display_text(*ch) {
+                                    display
+                                } else {
+                                    ch.to_string()
+                                }
+                            };
+                            draw_overlap_box(
+                                &display,
+                                bbox.x as f32 + index as f32 * char_advance + box_size / 2.0,
+                                (bbox.y + bbox.height / 2.0) as f32,
+                            );
+                        }
+                    }
+                    if effective_rotation != 0.0 {
+                        canvas.restore();
+                    }
+                    return;
+                }
+
+                let char_positions = compute_char_positions(text, style);
+                let clusters = split_into_clusters(text);
+                let text_width = *char_positions.last().unwrap_or(&0.0) as f32;
+                let ratio = if style.ratio > 0.0 {
+                    style.ratio as f32
+                } else {
+                    1.0
+                };
+                let has_ratio = (ratio - 1.0).abs() > 0.01;
+                let shade_rgb = style.shade_color & 0x00FF_FFFF;
+                if shade_rgb != 0x00FF_FFFF && shade_rgb != 0 && text_width > 0.0 {
+                    let mut shade = Paint::default();
+                    shade.set_anti_alias(true);
+                    shade.set_style(paint::Style::Fill);
+                    shade.set_color(colorref_to_skia(style.shade_color, 1.0));
+                    canvas.draw_rect(
+                        Rect::from_xywh(
+                            bbox.x as f32,
+                            y as f32 - font_size,
+                            text_width,
+                            font_size * 1.2,
+                        ),
+                        &shade,
+                    );
+                }
+
+                let draw_styled_line = |x1: f32,
+                                        y: f32,
+                                        x2: f32,
+                                        color: Color,
+                                        width: f32,
+                                        dash: &[f32],
+                                        round: bool| {
+                    if x2 <= x1 {
+                        return;
+                    }
+                    let mut line_paint = Paint::default();
+                    line_paint.set_anti_alias(true);
+                    line_paint.set_style(paint::Style::Stroke);
+                    line_paint.set_stroke_width(width);
+                    line_paint.set_color(color);
+                    if round {
+                        line_paint.set_stroke_cap(paint::Cap::Round);
+                    }
+                    if !dash.is_empty() {
+                        if let Some(effect) = PathEffect::dash(dash, 0.0) {
+                            line_paint.set_path_effect(effect);
+                        }
+                    }
+                    canvas.draw_line((x1, y), (x2, y), &line_paint);
+                };
+                let draw_line_shape =
+                    |x1: f32, y: f32, x2: f32, color: Color, shape: u8| match shape {
+                        7 => {
+                            draw_styled_line(x1, y - 1.0, x2, color, 0.7, &[], false);
+                            draw_styled_line(x1, y + 1.0, x2, color, 0.7, &[], false);
+                        }
+                        8 => {
+                            draw_styled_line(x1, y - 1.2, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y + 0.8, x2, color, 1.2, &[], false);
+                        }
+                        9 => {
+                            draw_styled_line(x1, y - 0.8, x2, color, 1.2, &[], false);
+                            draw_styled_line(x1, y + 1.2, x2, color, 0.5, &[], false);
+                        }
+                        10 => {
+                            draw_styled_line(x1, y - 1.5, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y + 1.5, x2, color, 0.5, &[], false);
+                        }
+                        1 => draw_styled_line(x1, y, x2, color, 1.0, &[3.0, 3.0], false),
+                        2 => draw_styled_line(x1, y, x2, color, 1.0, &[1.0, 2.0], false),
+                        3 => draw_styled_line(x1, y, x2, color, 1.0, &[6.0, 2.0, 1.0, 2.0], false),
+                        4 => draw_styled_line(
+                            x1,
+                            y,
+                            x2,
+                            color,
+                            1.0,
+                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        5 => draw_styled_line(x1, y, x2, color, 1.0, &[8.0, 4.0], false),
+                        6 => draw_styled_line(x1, y, x2, color, 1.0, &[0.1, 2.5], true),
+                        _ => draw_styled_line(x1, y, x2, color, 1.0, &[], false),
+                    };
+
+                let suppress_dash_leader_line = !matches!(style.underline, UnderlineType::None);
+                let dash_run_groups: Vec<(usize, usize)> = {
+                    let mut groups = Vec::new();
+                    let mut run_start: Option<usize> = None;
+                    for (idx, (_, cluster)) in clusters.iter().enumerate() {
+                        if cluster == "-" {
+                            if run_start.is_none() {
+                                run_start = Some(idx);
+                            }
+                        } else if let Some(start) = run_start.take() {
+                            if idx - start >= 3 {
+                                groups.push((start, idx));
+                            }
+                        }
+                    }
+                    if let Some(start) = run_start {
+                        if clusters.len() - start >= 3 {
+                            groups.push((start, clusters.len()));
+                        }
+                    }
+                    groups
+                };
+                let cluster_in_dash_run = |cluster_idx: usize| -> Option<(f32, f32)> {
+                    for &(start, end) in &dash_run_groups {
+                        if cluster_idx == start {
+                            let start_char_idx = clusters[start].0;
+                            let last = &clusters[end - 1];
+                            let end_char_idx = last.0 + last.1.chars().count();
+                            let x1 = char_positions.get(start_char_idx).copied().unwrap_or(0.0);
+                            let x2 = char_positions
+                                .get(end_char_idx)
+                                .copied()
+                                .unwrap_or_else(|| *char_positions.last().unwrap_or(&0.0));
+                            return Some((x1 as f32, x2 as f32));
+                        }
+                        if cluster_idx > start && cluster_idx < end {
+                            return Some((f32::NAN, f32::NAN));
+                        }
+                    }
+                    None
+                };
+                let cluster_advance = |char_idx: usize, cluster: &str| -> f32 {
+                    let end = char_idx + cluster.chars().count();
+                    if end < char_positions.len() {
+                        (char_positions[end] - char_positions[char_idx]) as f32
+                    } else {
+                        0.0
+                    }
+                };
+                let is_middle_dot = |cluster: &str| cluster == "\u{00B7}";
+                let draw_text_pass = |color: Color, stroke_width: f32, dx: f32, dy: f32| {
+                    let mut text_paint = Paint::default();
+                    text_paint.set_anti_alias(true);
+                    text_paint.set_color(color);
+                    if stroke_width > 0.0 {
+                        text_paint.set_style(paint::Style::Stroke);
+                        text_paint.set_stroke_width(stroke_width);
+                    } else {
+                        text_paint.set_style(paint::Style::Fill);
+                    }
+                    for (cluster_idx, (char_idx, cluster)) in clusters.iter().enumerate() {
+                        if cluster == " " || cluster == "\t" || cluster == "\u{2007}" {
+                            continue;
+                        }
+                        if cluster.starts_with(|ch: char| {
+                            ch < '\u{0020}' && !matches!(ch, '\t' | '\n' | '\r')
+                        }) {
+                            continue;
+                        }
+                        if let Some((x1_rel, x2_rel)) = cluster_in_dash_run(cluster_idx) {
+                            if x1_rel.is_finite() && !suppress_dash_leader_line {
+                                draw_styled_line(
+                                    bbox.x as f32 + x1_rel + dx,
+                                    y as f32 - font_size * 0.32 + dy,
+                                    bbox.x as f32 + x2_rel + dx,
+                                    color,
+                                    (font_size * 0.07).max(0.5),
+                                    &[],
+                                    false,
+                                );
+                            }
+                            continue;
+                        }
+                        if is_middle_dot(cluster) {
+                            let advance = cluster_advance(*char_idx, cluster);
+                            let cx = bbox.x as f32
+                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
+                                + advance / 2.0
+                                + dx;
+                            let cy = y as f32 - font_size * 0.35 + dy;
+                            let mut dot_paint = Paint::default();
+                            dot_paint.set_anti_alias(true);
+                            dot_paint.set_style(paint::Style::Fill);
+                            dot_paint.set_color(color);
+                            canvas.draw_circle((cx, cy), font_size * 0.08, &dot_paint);
+                            continue;
+                        }
+                        if let Some(font) = font_for_text(cluster, font_size) {
+                            let char_x = bbox.x as f32
+                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
+                                + dx;
+                            let char_y = y as f32 + dy;
+                            if has_ratio {
+                                canvas.save();
+                                canvas.translate((char_x, char_y));
+                                canvas.scale((ratio, 1.0));
+                                canvas.draw_str(cluster, (0.0, 0.0), &font, &text_paint);
+                                canvas.restore();
+                            } else {
+                                canvas.draw_str(cluster, (char_x, char_y), &font, &text_paint);
+                            }
+                        }
+                    }
+                };
+
+                if style.shadow_type > 0 {
+                    draw_text_pass(
+                        colorref_to_skia(style.shadow_color, 1.0),
+                        0.0,
+                        style.shadow_offset_x as f32,
+                        style.shadow_offset_y as f32,
+                    );
+                }
+                if style.outline_type > 0 {
+                    draw_text_pass(
+                        colorref_to_skia(style.color, 1.0),
+                        (font_size * 0.08).max(0.8),
+                        0.0,
+                        0.0,
+                    );
+                }
+                if style.emboss {
+                    draw_text_pass(Color::WHITE, 0.0, -1.0, -1.0);
+                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, 1.0, 1.0);
+                } else if style.engrave {
+                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, -1.0, -1.0);
+                    draw_text_pass(Color::WHITE, 0.0, 1.0, 1.0);
+                }
+                draw_text_pass(colorref_to_skia(style.color, 1.0), 0.0, 0.0, 0.0);
+
+                if !matches!(style.underline, UnderlineType::None) && text_width > 0.0 {
+                    let color = if style.underline_color != 0 {
+                        colorref_to_skia(style.underline_color, 1.0)
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    let line_y = match style.underline {
+                        UnderlineType::Top => y as f32 - font_size + 1.0,
+                        _ => y as f32 + 2.0,
+                    };
+                    draw_line_shape(
+                        bbox.x as f32,
+                        line_y,
+                        bbox.x as f32 + text_width,
+                        color,
+                        style.underline_shape,
+                    );
+                }
+                if style.strikethrough && text_width > 0.0 {
+                    let color = if style.strike_color != 0 {
+                        colorref_to_skia(style.strike_color, 1.0)
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    draw_line_shape(
+                        bbox.x as f32,
+                        y as f32 - font_size * 0.3,
+                        bbox.x as f32 + text_width,
+                        color,
+                        style.strike_shape,
+                    );
+                }
+                if style.emphasis_dot > 0 {
+                    let dot = match style.emphasis_dot {
+                        1 => "●",
+                        2 => "○",
+                        3 => "ˇ",
+                        4 => "˜",
+                        5 => "･",
+                        6 => "˸",
+                        _ => "",
+                    };
+                    if !dot.is_empty() {
+                        let dot_size = font_size * 0.3;
+                        let dot_y = y as f32 - font_size * 1.05;
+                        if let Some(font) = font_for_text(dot, dot_size) {
+                            let mut dot_paint = Paint::default();
+                            dot_paint.set_anti_alias(true);
+                            dot_paint.set_color(colorref_to_skia(style.color, 1.0));
+                            for cx in &char_positions[..char_positions.len().saturating_sub(1)] {
+                                canvas.draw_str(
+                                    dot,
+                                    (bbox.x as f32 + *cx as f32 + font_size * ratio * 0.5, dot_y),
+                                    &font,
+                                    &dot_paint,
+                                );
+                            }
+                        }
+                    }
+                }
+                for leader in &style.tab_leaders {
+                    if leader.fill_type == 0 {
+                        continue;
+                    }
+                    let x1 = bbox.x as f32 + leader.start_x as f32;
+                    let x2 = bbox.x as f32 + leader.end_x as f32;
+                    let line_y = y as f32 - font_size * 0.35;
+                    let color = colorref_to_skia(style.color, 1.0);
+                    match leader.fill_type {
+                        1 => draw_styled_line(x1, line_y, x2, color, 0.5, &[], false),
+                        2 => draw_styled_line(x1, line_y, x2, color, 0.5, &[3.0, 3.0], false),
+                        3 => draw_styled_line(x1, line_y, x2, color, 1.0, &[0.1, 3.0], true),
+                        4 => draw_styled_line(
+                            x1,
+                            line_y,
+                            x2,
+                            color,
+                            0.5,
+                            &[6.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        5 => draw_styled_line(
+                            x1,
+                            line_y,
+                            x2,
+                            color,
+                            0.5,
+                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        6 => draw_styled_line(x1, line_y, x2, color, 0.5, &[8.0, 4.0], false),
+                        7 => draw_styled_line(x1, line_y, x2, color, 0.7, &[0.1, 2.5], true),
+                        8 => {
+                            draw_styled_line(x1, line_y - 1.0, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y + 1.0, x2, color, 0.3, &[], false);
+                        }
+                        9 => {
+                            draw_styled_line(x1, line_y - 1.2, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y + 0.8, x2, color, 0.8, &[], false);
+                        }
+                        10 => {
+                            draw_styled_line(x1, line_y - 0.8, x2, color, 0.8, &[], false);
+                            draw_styled_line(x1, line_y + 1.2, x2, color, 0.3, &[], false);
+                        }
+                        11 => {
+                            draw_styled_line(x1, line_y - 2.0, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y, x2, color, 0.8, &[], false);
+                            draw_styled_line(x1, line_y + 2.0, x2, color, 0.3, &[], false);
+                        }
+                        _ => draw_styled_line(x1, line_y, x2, color, 0.5, &[1.0, 2.0], false),
+                    }
+                }
+                if effective_rotation != 0.0 {
+                    canvas.restore();
+                }
+            };
+        let draw_text_marks = |text: &str,
+                               bbox: crate::renderer::render_tree::BoundingBox,
+                               style: &crate::renderer::TextStyle,
+                               baseline: f64,
+                               rotation: f64,
+                               is_vertical: bool,
+                               is_marker: bool,
+                               is_para_end: bool,
+                               is_line_break_end: bool| {
+            if !output_options.show_paragraph_marks && !output_options.show_control_codes {
                 return;
             }
             let font_size = if style.font_size > 0.0 {
@@ -276,87 +876,41 @@ impl SkiaLayerRenderer {
             } else {
                 12.0
             };
-            let font_style = match (style.bold, style.italic) {
-                (true, true) => FontStyle::bold_italic(),
-                (true, false) => FontStyle::bold(),
-                (false, true) => FontStyle::italic(),
-                (false, false) => FontStyle::normal(),
+            let make_mark_font = |size: f32| {
+                let mut font = self
+                    .font_mgr
+                    .match_family_style("DejaVu Sans", FontStyle::normal())
+                    .or_else(|| {
+                        self.font_mgr
+                            .legacy_make_typeface(None::<&str>, FontStyle::normal())
+                    })
+                    .map(|tf| Font::new(tf, size))
+                    .unwrap_or_else(|| {
+                        let mut font = Font::default();
+                        font.set_size(size);
+                        font
+                    });
+                font.set_edging(font::Edging::AntiAlias);
+                font
             };
-            let mut families = Vec::new();
-            if !style.font_family.trim().is_empty() {
-                families.push(style.font_family.as_str());
-            }
-            // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
-            // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.
-            families.extend([
-                "Noto Sans KR",
-                "Noto Serif KR",
-                "Noto Sans CJK KR",
-                "Noto Serif CJK KR",
-                "Nanum Gothic",
-                "Nanum Myeongjo",
-                "Malgun Gothic",
-                "맑은 고딕",
-                "Batang",
-                "바탕",
-                "Apple SD Gothic Neo",
-                "AppleMyungjo",
-                "DejaVu Sans",
-                "Arial",
-                "sans-serif",
-            ]);
-            // 1) 사용자 지정 폰트 (--font-path) 우선 검색
-            // 2) 시스템 FontMgr 검색 (한글 fallback chain 포함)
-            // 3) 마지막 fallback (legacy_make_typeface)
-            //
-            // 모든 후보를 chain 으로 보존 — char 단위 fallback 에 사용.
-            let typeface_chain: Vec<Typeface> = {
-                let mut chain: Vec<Typeface> = Vec::new();
-                let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
-                let mut push = |chain: &mut Vec<Typeface>,
-                                seen: &mut std::collections::HashSet<String>,
-                                tf: Typeface| {
-                    let key = tf.family_name();
-                    if seen.insert(key) {
-                        chain.push(tf);
-                    }
-                };
-                for family in &families {
-                    if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
-                        push(&mut chain, &mut seen, tf);
-                    }
-                }
-                for family in &families {
-                    if let Some(tf) = self.font_mgr.match_family_style(family, font_style) {
-                        push(&mut chain, &mut seen, tf);
-                    }
-                }
-                if let Some(tf) = self.font_mgr.legacy_make_typeface(None::<&str>, font_style) {
-                    push(&mut chain, &mut seen, tf);
-                }
-                chain
-            };
-            let primary_typeface = typeface_chain.first().cloned();
-            let mut primary_font = if let Some(ref tf) = primary_typeface {
-                Font::new(tf.clone(), font_size)
-            } else {
-                let mut f = Font::default();
-                f.set_size(font_size);
-                f
-            };
-            primary_font.set_edging(font::Edging::AntiAlias);
-            let mut paint = Paint::default();
-            paint.set_anti_alias(true);
-            paint.set_color(colorref_to_skia(style.color, 1.0));
+            let font = make_mark_font(font_size * 0.5);
+            let mut mark_paint = Paint::default();
+            mark_paint.set_anti_alias(true);
+            mark_paint.set_color(Color::from_argb(255, 74, 144, 217));
             let y = if baseline > 0.0 {
                 bbox.y + baseline
             } else {
                 bbox.y + bbox.height
             };
-            if rotation != 0.0 {
+            let effective_rotation = if is_vertical {
+                rotation + 90.0
+            } else {
+                rotation
+            };
+            if effective_rotation != 0.0 {
                 canvas.save();
                 canvas.rotate(
-                    rotation as f32,
+                    effective_rotation as f32,
                     Some(
                         (
                             (bbox.x + bbox.width / 2.0) as f32,
@@ -366,57 +920,40 @@ impl SkiaLayerRenderer {
                     ),
                 );
             }
-            // char 단위 fallback 렌더링.
-            // primary typeface 에 글리프 미보유 (unichar_to_glyph==0) 시 chain 의 다른 typeface 시도.
-            // 모두 미보유 시 visible 글리프 렌더 skip (whitespace 류 NBSP/U+2007/U+200B 등 두부 방지).
-            // primary 가 글리프 보유 시 그대로 그림 (한컴 정합).
-            let mut cursor_x = bbox.x as f32;
-            for ch in text.chars() {
-                let codepoint = ch as i32;
-                // primary typeface 의 글리프 보유 여부
-                let primary_has = primary_typeface
-                    .as_ref()
-                    .map(|tf| tf.unichar_to_glyph(codepoint) != 0)
-                    .unwrap_or(false);
-                let chosen_font = if primary_has {
-                    &primary_font
-                } else {
-                    // chain 에서 글리프 보유한 typeface 찾기
-                    let fallback = typeface_chain
-                        .iter()
-                        .skip(1)
-                        .find(|tf| tf.unichar_to_glyph(codepoint) != 0)
-                        .cloned();
-                    if let Some(tf) = fallback {
-                        let mut f = Font::new(tf, font_size);
-                        f.set_edging(font::Edging::AntiAlias);
-                        // char 단위 임시 폰트 — 그리고 cursor 진행
-                        let s = ch.to_string();
-                        canvas.draw_str(&s, (cursor_x, y as f32), &f, &paint);
-                        let advance = f.measure_str(&s, Some(&paint)).0;
-                        cursor_x += advance;
-                        continue;
-                    } else {
-                        // 모두 미보유 — whitespace 류 (NBSP/U+2007/U+200B 등) 또는 unknown.
-                        // visible 글리프 그리지 않고 advance 만 진행.
-                        // 공백류 advance 추정: 일반 공백의 너비로 대체 (또는 font_size * 0.3).
-                        let space_advance = primary_font
-                            .measure_str(" ", Some(&paint))
-                            .0;
-                        cursor_x += if space_advance > 0.0 {
-                            space_advance
+            if !text.is_empty() && !is_marker {
+                let char_positions = compute_char_positions(text, style);
+                for (index, ch) in text.chars().enumerate() {
+                    if ch == ' ' {
+                        let x = bbox.x + char_positions.get(index).copied().unwrap_or(0.0);
+                        let next_x = if index + 1 < char_positions.len() {
+                            bbox.x + char_positions[index + 1]
                         } else {
-                            font_size * 0.3
+                            bbox.x + bbox.width
                         };
-                        continue;
+                        let mark_x = ((x + next_x) / 2.0) as f32 - font_size * 0.125;
+                        canvas.draw_str("\u{2228}", (mark_x, y as f32), &font, &mark_paint);
+                    } else if ch == '\t' {
+                        let mark_x = bbox.x as f32
+                            + char_positions.get(index).copied().unwrap_or(0.0) as f32;
+                        canvas.draw_str("\u{2192}", (mark_x, y as f32), &font, &mark_paint);
                     }
-                };
-                let s = ch.to_string();
-                canvas.draw_str(&s, (cursor_x, y as f32), chosen_font, &paint);
-                let advance = chosen_font.measure_str(&s, Some(&paint)).0;
-                cursor_x += advance;
+                }
             }
-            if rotation != 0.0 {
+            if is_para_end || is_line_break_end {
+                let end_font = make_mark_font(font_size);
+                let mark = if is_line_break_end {
+                    "\u{2193}"
+                } else {
+                    "\u{21B5}"
+                };
+                let mark_x = if text.is_empty() {
+                    bbox.x as f32
+                } else {
+                    (bbox.x + bbox.width) as f32
+                };
+                canvas.draw_str(mark, (mark_x, y as f32), &end_font, &mark_paint);
+            }
+            if effective_rotation != 0.0 {
                 canvas.restore();
             }
         };
@@ -442,12 +979,12 @@ impl SkiaLayerRenderer {
         match &node.kind {
             LayerNodeKind::Group { children, .. } => {
                 for child in children {
-                    self.render_node(canvas, child, clip_enabled);
+                    self.render_node(canvas, child, output_options);
                 }
             }
             LayerNodeKind::ClipRect { clip, child, .. } => {
                 if !clip_enabled {
-                    self.render_node(canvas, child, clip_enabled);
+                    self.render_node(canvas, child, output_options);
                     return;
                 }
                 canvas.save();
@@ -461,7 +998,7 @@ impl SkiaLayerRenderer {
                     None,
                     Some(true),
                 );
-                self.render_node(canvas, child, clip_enabled);
+                self.render_node(canvas, child, output_options);
                 canvas.restore();
             }
             LayerNodeKind::Leaf { ops } => {
@@ -510,7 +1047,30 @@ impl SkiaLayerRenderer {
                             }
                         }
                         PaintOp::TextRun { bbox, run } => {
-                            draw_text(&run.text, *bbox, &run.style, run.baseline, run.rotation);
+                            draw_text(
+                                &run.text,
+                                *bbox,
+                                &run.style,
+                                run.baseline,
+                                run.rotation,
+                                run.is_vertical,
+                                run.char_overlap.as_ref(),
+                            );
+                            let is_marker = !matches!(
+                                run.field_marker,
+                                crate::renderer::render_tree::FieldMarkerType::None
+                            );
+                            draw_text_marks(
+                                &run.text,
+                                *bbox,
+                                &run.style,
+                                run.baseline,
+                                run.rotation,
+                                run.is_vertical,
+                                is_marker,
+                                run.is_para_end,
+                                run.is_line_break_end,
+                            );
                         }
                         PaintOp::FootnoteMarker { bbox, marker } => {
                             let style = crate::renderer::TextStyle {
@@ -519,7 +1079,15 @@ impl SkiaLayerRenderer {
                                 color: marker.color,
                                 ..Default::default()
                             };
-                            draw_text(&marker.text, *bbox, &style, bbox.height * 0.4, 0.0);
+                            draw_text(
+                                &marker.text,
+                                *bbox,
+                                &style,
+                                bbox.height * 0.4,
+                                0.0,
+                                false,
+                                None,
+                            );
                         }
                         PaintOp::Line { bbox, line } => {
                             if line.transform.has_transform() {
@@ -1046,8 +1614,9 @@ fn colorref_to_skia(color: ColorRef, alpha_scale: f32) -> Color {
 mod tests {
     use super::*;
     use crate::model::control::FormType;
-    use crate::model::style::ImageFillMode;
+    use crate::model::style::{ImageFillMode, UnderlineType};
     use crate::paint::{CacheHint, GroupKind, LayerNode, LayerOutputOptions};
+    use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::ast::EqNode;
     use crate::renderer::equation::layout::EqLayout;
     use crate::renderer::render_tree::{
@@ -1055,7 +1624,7 @@ mod tests {
         PageBackgroundImage, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode,
         RectangleNode, TextRunNode,
     };
-    use crate::renderer::{GradientFillInfo, PatternFillInfo, TextStyle};
+    use crate::renderer::{GradientFillInfo, PatternFillInfo, TabLeaderInfo, TextStyle};
     use image::{ImageFormat, Rgba, RgbaImage};
     use std::io::Cursor;
 
@@ -1786,6 +2355,198 @@ mod tests {
         let output = SkiaLayerRenderer::new()
             .render_raster_with_options(&tree, RasterRenderOptions::default())
             .expect("render text");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_char_overlap_text_run_as_ink() {
+        let run = TextRunNode {
+            text: "①".to_string(),
+            style: TextStyle {
+                font_size: 20.0,
+                color: 0x00000000,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: Some(CharOverlapInfo {
+                border_type: 1,
+                inner_char_size: 90,
+            }),
+            border_fill_id: 0,
+            baseline: 22.0,
+            field_marker: Default::default(),
+        };
+        let tree = PageLayerTree::new(
+            40.0,
+            40.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 40.0, 40.0),
+                None,
+                vec![PaintOp::TextRun {
+                    bbox: BoundingBox::new(8.0, 8.0, 24.0, 24.0),
+                    run,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render char overlap");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_tab_leader_for_empty_text_run() {
+        let run = TextRunNode {
+            text: String::new(),
+            style: TextStyle {
+                font_size: 18.0,
+                color: 0x00000000,
+                tab_leaders: vec![TabLeaderInfo {
+                    start_x: 8.0,
+                    end_x: 72.0,
+                    fill_type: 1,
+                }],
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 22.0,
+            field_marker: Default::default(),
+        };
+        let tree = PageLayerTree::new(
+            88.0,
+            36.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 88.0, 36.0),
+                None,
+                vec![PaintOp::TextRun {
+                    bbox: BoundingBox::new(4.0, 4.0, 80.0, 28.0),
+                    run,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render tab leader");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_output_control_marks_as_ink() {
+        let run = TextRunNode {
+            text: " \t".to_string(),
+            style: TextStyle {
+                font_size: 18.0,
+                color: 0x00000000,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: true,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 22.0,
+            field_marker: Default::default(),
+        };
+        let tree = PageLayerTree::new(
+            72.0,
+            36.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 72.0, 36.0),
+                None,
+                vec![PaintOp::TextRun {
+                    bbox: BoundingBox::new(4.0, 4.0, 60.0, 28.0),
+                    run,
+                }],
+            ),
+        )
+        .with_output_options(LayerOutputOptions {
+            show_control_codes: true,
+            ..Default::default()
+        });
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render control marks");
+        let image = decode_rgba(&output.bytes);
+
+        assert!(count_ink(&image) > 0);
+    }
+
+    #[test]
+    fn renders_decorated_text_as_ink() {
+        let run = TextRunNode {
+            text: "A".to_string(),
+            style: TextStyle {
+                font_size: 18.0,
+                color: 0x00000000,
+                underline: UnderlineType::Bottom,
+                strikethrough: true,
+                emphasis_dot: 1,
+                shade_color: 0x0000ffff,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 24.0,
+            field_marker: Default::default(),
+        };
+        let tree = PageLayerTree::new(
+            48.0,
+            40.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 48.0, 40.0),
+                None,
+                vec![PaintOp::TextRun {
+                    bbox: BoundingBox::new(8.0, 8.0, 32.0, 28.0),
+                    run,
+                }],
+            ),
+        );
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render decorated text");
         let image = decode_rgba(&output.bytes);
 
         assert!(count_ink(&image) > 0);

--- a/src/renderer/skia/text_replay.rs
+++ b/src/renderer/skia/text_replay.rs
@@ -1,0 +1,748 @@
+use std::collections::HashMap;
+
+use skia_safe::{
+    font, paint, Canvas, Color, Font, FontMgr, FontStyle, Paint, PathEffect, Rect, Typeface,
+};
+
+use crate::model::style::UnderlineType;
+use crate::paint::LayerOutputOptions;
+use crate::renderer::composer::{decode_pua_overlap_number, pua_to_display_text, CharOverlapInfo};
+use crate::renderer::layout::{compute_char_positions, split_into_clusters};
+use crate::renderer::render_tree::BoundingBox;
+use crate::renderer::TextStyle;
+
+use super::renderer::colorref_to_skia;
+
+pub(super) struct SkiaTextReplay<'a> {
+    pub(super) canvas: &'a Canvas,
+    pub(super) font_mgr: &'a FontMgr,
+    pub(super) custom_typefaces: &'a HashMap<String, Typeface>,
+    pub(super) output_options: &'a LayerOutputOptions,
+}
+
+impl SkiaTextReplay<'_> {
+    pub(super) fn draw_text(
+        &self,
+        text: &str,
+        bbox: BoundingBox,
+        style: &TextStyle,
+        baseline: f64,
+        rotation: f64,
+        is_vertical: bool,
+        char_overlap: Option<&CharOverlapInfo>,
+        is_marker: bool,
+        is_para_end: bool,
+        is_line_break_end: bool,
+    ) {
+        let canvas = self.canvas;
+        let output_options = self.output_options;
+        let draw_text =
+            |text: &str,
+             bbox: crate::renderer::render_tree::BoundingBox,
+             style: &crate::renderer::TextStyle,
+             baseline: f64,
+             rotation: f64,
+             is_vertical: bool,
+             char_overlap: Option<&crate::renderer::composer::CharOverlapInfo>| {
+                if text.is_empty() && style.tab_leaders.is_empty() {
+                    return;
+                }
+                let font_size = if style.font_size > 0.0 {
+                    style.font_size as f32
+                } else {
+                    12.0
+                };
+                let font_style = match (style.bold, style.italic) {
+                    (true, true) => FontStyle::bold_italic(),
+                    (true, false) => FontStyle::bold(),
+                    (false, true) => FontStyle::italic(),
+                    (false, false) => FontStyle::normal(),
+                };
+                let mut families = Vec::new();
+                if !style.font_family.trim().is_empty() {
+                    families.push(style.font_family.as_str());
+                }
+                // 한글 fallback (CJK glyph 미보유 폰트로 fallback 시 사각형 방지).
+                // SVG 경로의 CSS font chain 과 동일한 한글 폴백 폰트 순서.
+                families.extend([
+                    "Noto Sans KR",
+                    "Noto Serif KR",
+                    "Noto Sans CJK KR",
+                    "Noto Serif CJK KR",
+                    "Nanum Gothic",
+                    "Nanum Myeongjo",
+                    "Malgun Gothic",
+                    "맑은 고딕",
+                    "Batang",
+                    "바탕",
+                    "Apple SD Gothic Neo",
+                    "AppleMyungjo",
+                    "DejaVu Sans",
+                    "Arial",
+                    "sans-serif",
+                ]);
+                // 1) 사용자 지정 폰트 (--font-path) 우선 검색
+                // 2) 시스템 FontMgr 검색 (한글 fallback chain 포함)
+                // 3) 마지막 fallback (legacy_make_typeface)
+                //
+                // 모든 후보를 chain 으로 보존 — char 단위 fallback 에 사용.
+                let typeface_chain: Vec<Typeface> = {
+                    let mut chain: Vec<Typeface> = Vec::new();
+                    let mut seen: std::collections::HashSet<String> =
+                        std::collections::HashSet::new();
+                    let mut push = |chain: &mut Vec<Typeface>,
+                                    seen: &mut std::collections::HashSet<String>,
+                                    tf: Typeface| {
+                        let key = tf.family_name();
+                        if seen.insert(key) {
+                            chain.push(tf);
+                        }
+                    };
+                    for family in &families {
+                        if let Some(tf) = self.custom_typefaces.get(*family).cloned() {
+                            push(&mut chain, &mut seen, tf);
+                        }
+                    }
+                    for family in &families {
+                        if let Some(tf) = self.font_mgr.match_family_style(family, font_style) {
+                            push(&mut chain, &mut seen, tf);
+                        }
+                    }
+                    if let Some(tf) = self.font_mgr.legacy_make_typeface(None::<&str>, font_style) {
+                        push(&mut chain, &mut seen, tf);
+                    }
+                    chain
+                };
+                let primary_typeface = typeface_chain.first().cloned();
+                let font_for_text = |sample: &str, size: f32| -> Option<Font> {
+                    let visible_char = sample.chars().find(|ch| !ch.is_whitespace());
+                    if let Some(ch) = visible_char {
+                        let codepoint = ch as i32;
+                        if let Some(tf) = typeface_chain
+                            .iter()
+                            .find(|tf| tf.unichar_to_glyph(codepoint) != 0)
+                            .cloned()
+                        {
+                            let mut font = Font::new(tf, size);
+                            font.set_edging(font::Edging::AntiAlias);
+                            return Some(font);
+                        }
+                        return None;
+                    }
+                    if let Some(tf) = primary_typeface.clone() {
+                        let mut font = Font::new(tf, size);
+                        font.set_edging(font::Edging::AntiAlias);
+                        Some(font)
+                    } else {
+                        let mut font = Font::default();
+                        font.set_size(size);
+                        font.set_edging(font::Edging::AntiAlias);
+                        Some(font)
+                    }
+                };
+                let y = if baseline > 0.0 {
+                    bbox.y + baseline
+                } else {
+                    bbox.y + bbox.height
+                };
+                let effective_rotation = if is_vertical {
+                    rotation + 90.0
+                } else {
+                    rotation
+                };
+                if effective_rotation != 0.0 {
+                    canvas.save();
+                    canvas.rotate(
+                        effective_rotation as f32,
+                        Some(
+                            (
+                                (bbox.x + bbox.width / 2.0) as f32,
+                                (bbox.y + bbox.height / 2.0) as f32,
+                            )
+                                .into(),
+                        ),
+                    );
+                }
+
+                if let Some(overlap) = char_overlap {
+                    let chars: Vec<char> = text.chars().collect();
+                    if chars.is_empty() {
+                        if effective_rotation != 0.0 {
+                            canvas.restore();
+                        }
+                        return;
+                    }
+
+                    let size_ratio = if overlap.inner_char_size > 0 {
+                        overlap.inner_char_size as f32 / 100.0
+                    } else {
+                        1.0
+                    };
+                    let inner_size = (font_size * size_ratio).max(1.0);
+                    let box_size = font_size.max(1.0);
+                    let is_combined = decode_pua_overlap_number(&chars);
+                    let effective_border = if overlap.border_type == 0 && is_combined.is_some() {
+                        1
+                    } else {
+                        overlap.border_type
+                    };
+                    let is_reversed = effective_border == 2 || effective_border == 4;
+                    let is_circle = effective_border == 1 || effective_border == 2;
+                    let is_rect = effective_border == 3 || effective_border == 4;
+                    let fill_color = if is_reversed {
+                        Color::BLACK
+                    } else {
+                        Color::TRANSPARENT
+                    };
+                    let text_color = if is_reversed {
+                        Color::WHITE
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    let stroke_color = colorref_to_skia(style.color, 1.0);
+                    let mut shape_paint = Paint::default();
+                    shape_paint.set_anti_alias(true);
+                    let mut stroke_paint = Paint::default();
+                    stroke_paint.set_anti_alias(true);
+                    stroke_paint.set_style(paint::Style::Stroke);
+                    stroke_paint.set_stroke_width(0.8);
+                    stroke_paint.set_color(stroke_color);
+                    let mut text_paint = Paint::default();
+                    text_paint.set_anti_alias(true);
+                    text_paint.set_color(text_color);
+                    let draw_overlap_text = |display: &str, cx: f32, cy: f32| {
+                        if let Some(font) = font_for_text(display, inner_size) {
+                            let width = font.measure_str(display, Some(&text_paint)).0;
+                            canvas.draw_str(
+                                display,
+                                (cx - width / 2.0, cy + inner_size * 0.35),
+                                &font,
+                                &text_paint,
+                            );
+                        }
+                    };
+                    let mut draw_overlap_box = |display: &str, cx: f32, cy: f32| {
+                        if is_circle {
+                            shape_paint.set_style(paint::Style::Fill);
+                            shape_paint.set_color(fill_color);
+                            if is_reversed {
+                                canvas.draw_circle((cx, cy), box_size / 2.0, &shape_paint);
+                            }
+                            canvas.draw_circle((cx, cy), box_size / 2.0, &stroke_paint);
+                        } else if is_rect {
+                            let rect = Rect::from_xywh(
+                                cx - box_size / 2.0,
+                                cy - box_size / 2.0,
+                                box_size,
+                                box_size,
+                            );
+                            shape_paint.set_style(paint::Style::Fill);
+                            shape_paint.set_color(fill_color);
+                            if is_reversed {
+                                canvas.draw_rect(rect, &shape_paint);
+                            }
+                            canvas.draw_rect(rect, &stroke_paint);
+                        }
+                        draw_overlap_text(display, cx, cy);
+                    };
+
+                    if let Some(number) = is_combined {
+                        draw_overlap_box(
+                            &number,
+                            (bbox.x + bbox.width / 2.0) as f32,
+                            (bbox.y + bbox.height / 2.0) as f32,
+                        );
+                    } else {
+                        let char_advance = if chars.len() > 1 {
+                            bbox.width as f32 / chars.len() as f32
+                        } else {
+                            box_size
+                        };
+                        for (index, ch) in chars.iter().enumerate() {
+                            let display = {
+                                let codepoint = *ch as u32;
+                                if (0x2460..=0x2473).contains(&codepoint) {
+                                    (codepoint - 0x2460 + 1).to_string()
+                                } else if let Some(display) = pua_to_display_text(*ch) {
+                                    display
+                                } else {
+                                    ch.to_string()
+                                }
+                            };
+                            draw_overlap_box(
+                                &display,
+                                bbox.x as f32 + index as f32 * char_advance + box_size / 2.0,
+                                (bbox.y + bbox.height / 2.0) as f32,
+                            );
+                        }
+                    }
+                    if effective_rotation != 0.0 {
+                        canvas.restore();
+                    }
+                    return;
+                }
+
+                let char_positions = compute_char_positions(text, style);
+                let clusters = split_into_clusters(text);
+                let text_width = *char_positions.last().unwrap_or(&0.0) as f32;
+                let ratio = if style.ratio > 0.0 {
+                    style.ratio as f32
+                } else {
+                    1.0
+                };
+                let has_ratio = (ratio - 1.0).abs() > 0.01;
+                let shade_rgb = style.shade_color & 0x00FF_FFFF;
+                if shade_rgb != 0x00FF_FFFF && shade_rgb != 0 && text_width > 0.0 {
+                    let mut shade = Paint::default();
+                    shade.set_anti_alias(true);
+                    shade.set_style(paint::Style::Fill);
+                    shade.set_color(colorref_to_skia(style.shade_color, 1.0));
+                    canvas.draw_rect(
+                        Rect::from_xywh(
+                            bbox.x as f32,
+                            y as f32 - font_size,
+                            text_width,
+                            font_size * 1.2,
+                        ),
+                        &shade,
+                    );
+                }
+
+                let draw_styled_line = |x1: f32,
+                                        y: f32,
+                                        x2: f32,
+                                        color: Color,
+                                        width: f32,
+                                        dash: &[f32],
+                                        round: bool| {
+                    if x2 <= x1 {
+                        return;
+                    }
+                    let mut line_paint = Paint::default();
+                    line_paint.set_anti_alias(true);
+                    line_paint.set_style(paint::Style::Stroke);
+                    line_paint.set_stroke_width(width);
+                    line_paint.set_color(color);
+                    if round {
+                        line_paint.set_stroke_cap(paint::Cap::Round);
+                    }
+                    if !dash.is_empty() {
+                        if let Some(effect) = PathEffect::dash(dash, 0.0) {
+                            line_paint.set_path_effect(effect);
+                        }
+                    }
+                    canvas.draw_line((x1, y), (x2, y), &line_paint);
+                };
+                let draw_line_shape =
+                    |x1: f32, y: f32, x2: f32, color: Color, shape: u8| match shape {
+                        7 => {
+                            draw_styled_line(x1, y - 1.0, x2, color, 0.7, &[], false);
+                            draw_styled_line(x1, y + 1.0, x2, color, 0.7, &[], false);
+                        }
+                        8 => {
+                            draw_styled_line(x1, y - 1.2, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y + 0.8, x2, color, 1.2, &[], false);
+                        }
+                        9 => {
+                            draw_styled_line(x1, y - 0.8, x2, color, 1.2, &[], false);
+                            draw_styled_line(x1, y + 1.2, x2, color, 0.5, &[], false);
+                        }
+                        10 => {
+                            draw_styled_line(x1, y - 1.5, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y, x2, color, 0.5, &[], false);
+                            draw_styled_line(x1, y + 1.5, x2, color, 0.5, &[], false);
+                        }
+                        1 => draw_styled_line(x1, y, x2, color, 1.0, &[3.0, 3.0], false),
+                        2 => draw_styled_line(x1, y, x2, color, 1.0, &[1.0, 2.0], false),
+                        3 => draw_styled_line(x1, y, x2, color, 1.0, &[6.0, 2.0, 1.0, 2.0], false),
+                        4 => draw_styled_line(
+                            x1,
+                            y,
+                            x2,
+                            color,
+                            1.0,
+                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        5 => draw_styled_line(x1, y, x2, color, 1.0, &[8.0, 4.0], false),
+                        6 => draw_styled_line(x1, y, x2, color, 1.0, &[0.1, 2.5], true),
+                        _ => draw_styled_line(x1, y, x2, color, 1.0, &[], false),
+                    };
+
+                let suppress_dash_leader_line = !matches!(style.underline, UnderlineType::None);
+                let dash_run_groups: Vec<(usize, usize)> = {
+                    let mut groups = Vec::new();
+                    let mut run_start: Option<usize> = None;
+                    for (idx, (_, cluster)) in clusters.iter().enumerate() {
+                        if cluster == "-" {
+                            if run_start.is_none() {
+                                run_start = Some(idx);
+                            }
+                        } else if let Some(start) = run_start.take() {
+                            if idx - start >= 3 {
+                                groups.push((start, idx));
+                            }
+                        }
+                    }
+                    if let Some(start) = run_start {
+                        if clusters.len() - start >= 3 {
+                            groups.push((start, clusters.len()));
+                        }
+                    }
+                    groups
+                };
+                let cluster_in_dash_run = |cluster_idx: usize| -> Option<(f32, f32)> {
+                    for &(start, end) in &dash_run_groups {
+                        if cluster_idx == start {
+                            let start_char_idx = clusters[start].0;
+                            let last = &clusters[end - 1];
+                            let end_char_idx = last.0 + last.1.chars().count();
+                            let x1 = char_positions.get(start_char_idx).copied().unwrap_or(0.0);
+                            let x2 = char_positions
+                                .get(end_char_idx)
+                                .copied()
+                                .unwrap_or_else(|| *char_positions.last().unwrap_or(&0.0));
+                            return Some((x1 as f32, x2 as f32));
+                        }
+                        if cluster_idx > start && cluster_idx < end {
+                            return Some((f32::NAN, f32::NAN));
+                        }
+                    }
+                    None
+                };
+                let cluster_advance = |char_idx: usize, cluster: &str| -> f32 {
+                    let end = char_idx + cluster.chars().count();
+                    if end < char_positions.len() {
+                        (char_positions[end] - char_positions[char_idx]) as f32
+                    } else {
+                        0.0
+                    }
+                };
+                let is_middle_dot = |cluster: &str| cluster == "\u{00B7}";
+                let draw_text_pass = |color: Color, stroke_width: f32, dx: f32, dy: f32| {
+                    let mut text_paint = Paint::default();
+                    text_paint.set_anti_alias(true);
+                    text_paint.set_color(color);
+                    if stroke_width > 0.0 {
+                        text_paint.set_style(paint::Style::Stroke);
+                        text_paint.set_stroke_width(stroke_width);
+                    } else {
+                        text_paint.set_style(paint::Style::Fill);
+                    }
+                    for (cluster_idx, (char_idx, cluster)) in clusters.iter().enumerate() {
+                        if cluster == " " || cluster == "\t" || cluster == "\u{2007}" {
+                            continue;
+                        }
+                        if cluster.starts_with(|ch: char| {
+                            ch < '\u{0020}' && !matches!(ch, '\t' | '\n' | '\r')
+                        }) {
+                            continue;
+                        }
+                        if let Some((x1_rel, x2_rel)) = cluster_in_dash_run(cluster_idx) {
+                            if x1_rel.is_finite() && !suppress_dash_leader_line {
+                                draw_styled_line(
+                                    bbox.x as f32 + x1_rel + dx,
+                                    y as f32 - font_size * 0.32 + dy,
+                                    bbox.x as f32 + x2_rel + dx,
+                                    color,
+                                    (font_size * 0.07).max(0.5),
+                                    &[],
+                                    false,
+                                );
+                            }
+                            continue;
+                        }
+                        if is_middle_dot(cluster) {
+                            let advance = cluster_advance(*char_idx, cluster);
+                            let cx = bbox.x as f32
+                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
+                                + advance / 2.0
+                                + dx;
+                            let cy = y as f32 - font_size * 0.35 + dy;
+                            let mut dot_paint = Paint::default();
+                            dot_paint.set_anti_alias(true);
+                            dot_paint.set_style(paint::Style::Fill);
+                            dot_paint.set_color(color);
+                            canvas.draw_circle((cx, cy), font_size * 0.08, &dot_paint);
+                            continue;
+                        }
+                        if let Some(font) = font_for_text(cluster, font_size) {
+                            let char_x = bbox.x as f32
+                                + char_positions.get(*char_idx).copied().unwrap_or(0.0) as f32
+                                + dx;
+                            let char_y = y as f32 + dy;
+                            if has_ratio {
+                                canvas.save();
+                                canvas.translate((char_x, char_y));
+                                canvas.scale((ratio, 1.0));
+                                canvas.draw_str(cluster, (0.0, 0.0), &font, &text_paint);
+                                canvas.restore();
+                            } else {
+                                canvas.draw_str(cluster, (char_x, char_y), &font, &text_paint);
+                            }
+                        }
+                    }
+                };
+
+                if style.shadow_type > 0 {
+                    draw_text_pass(
+                        colorref_to_skia(style.shadow_color, 1.0),
+                        0.0,
+                        style.shadow_offset_x as f32,
+                        style.shadow_offset_y as f32,
+                    );
+                }
+                if style.outline_type > 0 {
+                    draw_text_pass(
+                        colorref_to_skia(style.color, 1.0),
+                        (font_size * 0.08).max(0.8),
+                        0.0,
+                        0.0,
+                    );
+                }
+                if style.emboss {
+                    draw_text_pass(Color::WHITE, 0.0, -1.0, -1.0);
+                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, 1.0, 1.0);
+                } else if style.engrave {
+                    draw_text_pass(Color::from_argb(255, 96, 96, 96), 0.0, -1.0, -1.0);
+                    draw_text_pass(Color::WHITE, 0.0, 1.0, 1.0);
+                }
+                draw_text_pass(colorref_to_skia(style.color, 1.0), 0.0, 0.0, 0.0);
+
+                if !matches!(style.underline, UnderlineType::None) && text_width > 0.0 {
+                    let color = if style.underline_color != 0 {
+                        colorref_to_skia(style.underline_color, 1.0)
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    let line_y = match style.underline {
+                        UnderlineType::Top => y as f32 - font_size + 1.0,
+                        _ => y as f32 + 2.0,
+                    };
+                    draw_line_shape(
+                        bbox.x as f32,
+                        line_y,
+                        bbox.x as f32 + text_width,
+                        color,
+                        style.underline_shape,
+                    );
+                }
+                if style.strikethrough && text_width > 0.0 {
+                    let color = if style.strike_color != 0 {
+                        colorref_to_skia(style.strike_color, 1.0)
+                    } else {
+                        colorref_to_skia(style.color, 1.0)
+                    };
+                    draw_line_shape(
+                        bbox.x as f32,
+                        y as f32 - font_size * 0.3,
+                        bbox.x as f32 + text_width,
+                        color,
+                        style.strike_shape,
+                    );
+                }
+                if style.emphasis_dot > 0 {
+                    let dot = match style.emphasis_dot {
+                        1 => "●",
+                        2 => "○",
+                        3 => "ˇ",
+                        4 => "˜",
+                        5 => "･",
+                        6 => "˸",
+                        _ => "",
+                    };
+                    if !dot.is_empty() {
+                        let dot_size = font_size * 0.3;
+                        let dot_y = y as f32 - font_size * 1.05;
+                        if let Some(font) = font_for_text(dot, dot_size) {
+                            let mut dot_paint = Paint::default();
+                            dot_paint.set_anti_alias(true);
+                            dot_paint.set_color(colorref_to_skia(style.color, 1.0));
+                            for cx in &char_positions[..char_positions.len().saturating_sub(1)] {
+                                canvas.draw_str(
+                                    dot,
+                                    (bbox.x as f32 + *cx as f32 + font_size * ratio * 0.5, dot_y),
+                                    &font,
+                                    &dot_paint,
+                                );
+                            }
+                        }
+                    }
+                }
+                for leader in &style.tab_leaders {
+                    if leader.fill_type == 0 {
+                        continue;
+                    }
+                    let x1 = bbox.x as f32 + leader.start_x as f32;
+                    let x2 = bbox.x as f32 + leader.end_x as f32;
+                    let line_y = y as f32 - font_size * 0.35;
+                    let color = colorref_to_skia(style.color, 1.0);
+                    match leader.fill_type {
+                        1 => draw_styled_line(x1, line_y, x2, color, 0.5, &[], false),
+                        2 => draw_styled_line(x1, line_y, x2, color, 0.5, &[3.0, 3.0], false),
+                        3 => draw_styled_line(x1, line_y, x2, color, 1.0, &[0.1, 3.0], true),
+                        4 => draw_styled_line(
+                            x1,
+                            line_y,
+                            x2,
+                            color,
+                            0.5,
+                            &[6.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        5 => draw_styled_line(
+                            x1,
+                            line_y,
+                            x2,
+                            color,
+                            0.5,
+                            &[6.0, 2.0, 1.0, 2.0, 1.0, 2.0],
+                            false,
+                        ),
+                        6 => draw_styled_line(x1, line_y, x2, color, 0.5, &[8.0, 4.0], false),
+                        7 => draw_styled_line(x1, line_y, x2, color, 0.7, &[0.1, 2.5], true),
+                        8 => {
+                            draw_styled_line(x1, line_y - 1.0, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y + 1.0, x2, color, 0.3, &[], false);
+                        }
+                        9 => {
+                            draw_styled_line(x1, line_y - 1.2, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y + 0.8, x2, color, 0.8, &[], false);
+                        }
+                        10 => {
+                            draw_styled_line(x1, line_y - 0.8, x2, color, 0.8, &[], false);
+                            draw_styled_line(x1, line_y + 1.2, x2, color, 0.3, &[], false);
+                        }
+                        11 => {
+                            draw_styled_line(x1, line_y - 2.0, x2, color, 0.3, &[], false);
+                            draw_styled_line(x1, line_y, x2, color, 0.8, &[], false);
+                            draw_styled_line(x1, line_y + 2.0, x2, color, 0.3, &[], false);
+                        }
+                        _ => draw_styled_line(x1, line_y, x2, color, 0.5, &[1.0, 2.0], false),
+                    }
+                }
+                if effective_rotation != 0.0 {
+                    canvas.restore();
+                }
+            };
+        let draw_text_marks = |text: &str,
+                               bbox: crate::renderer::render_tree::BoundingBox,
+                               style: &crate::renderer::TextStyle,
+                               baseline: f64,
+                               rotation: f64,
+                               is_vertical: bool,
+                               is_marker: bool,
+                               is_para_end: bool,
+                               is_line_break_end: bool| {
+            if !output_options.show_paragraph_marks && !output_options.show_control_codes {
+                return;
+            }
+            let font_size = if style.font_size > 0.0 {
+                style.font_size as f32
+            } else {
+                12.0
+            };
+            let make_mark_font = |size: f32| {
+                let mut font = self
+                    .font_mgr
+                    .match_family_style("DejaVu Sans", FontStyle::normal())
+                    .or_else(|| {
+                        self.font_mgr
+                            .legacy_make_typeface(None::<&str>, FontStyle::normal())
+                    })
+                    .map(|tf| Font::new(tf, size))
+                    .unwrap_or_else(|| {
+                        let mut font = Font::default();
+                        font.set_size(size);
+                        font
+                    });
+                font.set_edging(font::Edging::AntiAlias);
+                font
+            };
+            let font = make_mark_font(font_size * 0.5);
+            let mut mark_paint = Paint::default();
+            mark_paint.set_anti_alias(true);
+            mark_paint.set_color(Color::from_argb(255, 74, 144, 217));
+            let y = if baseline > 0.0 {
+                bbox.y + baseline
+            } else {
+                bbox.y + bbox.height
+            };
+            let effective_rotation = if is_vertical {
+                rotation + 90.0
+            } else {
+                rotation
+            };
+            if effective_rotation != 0.0 {
+                canvas.save();
+                canvas.rotate(
+                    effective_rotation as f32,
+                    Some(
+                        (
+                            (bbox.x + bbox.width / 2.0) as f32,
+                            (bbox.y + bbox.height / 2.0) as f32,
+                        )
+                            .into(),
+                    ),
+                );
+            }
+            if !text.is_empty() && !is_marker {
+                let char_positions = compute_char_positions(text, style);
+                for (index, ch) in text.chars().enumerate() {
+                    if ch == ' ' {
+                        let x = bbox.x + char_positions.get(index).copied().unwrap_or(0.0);
+                        let next_x = if index + 1 < char_positions.len() {
+                            bbox.x + char_positions[index + 1]
+                        } else {
+                            bbox.x + bbox.width
+                        };
+                        let mark_x = ((x + next_x) / 2.0) as f32 - font_size * 0.125;
+                        canvas.draw_str("\u{2228}", (mark_x, y as f32), &font, &mark_paint);
+                    } else if ch == '\t' {
+                        let mark_x = bbox.x as f32
+                            + char_positions.get(index).copied().unwrap_or(0.0) as f32;
+                        canvas.draw_str("\u{2192}", (mark_x, y as f32), &font, &mark_paint);
+                    }
+                }
+            }
+            if is_para_end || is_line_break_end {
+                let end_font = make_mark_font(font_size);
+                let mark = if is_line_break_end {
+                    "\u{2193}"
+                } else {
+                    "\u{21B5}"
+                };
+                let mark_x = if text.is_empty() {
+                    bbox.x as f32
+                } else {
+                    (bbox.x + bbox.width) as f32
+                };
+                canvas.draw_str(mark, (mark_x, y as f32), &end_font, &mark_paint);
+            }
+            if effective_rotation != 0.0 {
+                canvas.restore();
+            }
+        };
+
+        draw_text(
+            text,
+            bbox,
+            style,
+            baseline,
+            rotation,
+            is_vertical,
+            char_overlap,
+        );
+        draw_text_marks(
+            text,
+            bbox,
+            style,
+            baseline,
+            rotation,
+            is_vertical,
+            is_marker,
+            is_para_end,
+            is_line_break_end,
+        );
+    }
+}

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -213,6 +213,9 @@ impl SvgLayerRenderer {
 
 impl LayerRenderer for SvgLayerRenderer {
     fn render_page(&mut self, tree: &PageLayerTree) -> LayerRenderResult<()> {
+        self.renderer.show_paragraph_marks = tree.output_options.show_paragraph_marks;
+        self.renderer.show_control_codes = tree.output_options.show_control_codes;
+        self.renderer.debug_overlay = tree.output_options.debug_overlay;
         let render_tree = self.build_render_tree(tree);
         self.renderer.render_tree(&render_tree);
         Ok(())
@@ -222,7 +225,7 @@ impl LayerRenderer for SvgLayerRenderer {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paint::{LayerBuilder, RenderProfile};
+    use crate::paint::{LayerBuilder, LayerOutputOptions, RenderProfile};
     use crate::renderer::render_tree::{
         PageNode, PlaceholderNode, RawSvgNode, RectangleNode, TextRunNode,
     };
@@ -331,5 +334,61 @@ mod tests {
         layer.render_page(&layer_tree).unwrap();
 
         assert_eq!(layer.output(), legacy.output());
+    }
+
+    #[test]
+    fn render_page_consumes_layer_output_options() {
+        let mut render_tree = PageRenderTree::new(0, 80.0, 60.0);
+        render_tree.root.node_type = RenderNodeType::Page(PageNode {
+            page_index: 0,
+            width: 80.0,
+            height: 60.0,
+            section_index: 0,
+        });
+        render_tree.root.children.push(RenderNode::new(
+            31,
+            RenderNodeType::TextRun(TextRunNode {
+                text: "a b".to_string(),
+                style: TextStyle {
+                    font_size: 14.0,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: true,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 16.0,
+                field_marker: Default::default(),
+            }),
+            BoundingBox::new(10.0, 15.0, 40.0, 20.0),
+        ));
+
+        let mut builder =
+            LayerBuilder::new(RenderProfile::Screen).with_output_options(LayerOutputOptions {
+                show_paragraph_marks: true,
+                show_control_codes: true,
+                ..Default::default()
+            });
+        let layer_tree = builder.build(&render_tree);
+        let mut layer = SvgLayerRenderer::new();
+        layer.render_page(&layer_tree).unwrap();
+
+        let output = layer.output();
+        assert!(
+            output.contains("\u{2228}"),
+            "layer output options should enable visible space marks:\n{output}"
+        );
+        assert!(
+            output.contains("\u{21b5}"),
+            "layer output options should enable paragraph end marks:\n{output}"
+        );
     }
 }

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -265,6 +265,8 @@ impl WebCanvasRenderer {
 
     /// 레이어 트리를 Canvas에 렌더링
     pub fn render_layer_tree(&mut self, tree: &PageLayerTree) {
+        self.show_paragraph_marks = tree.output_options.show_paragraph_marks;
+        self.show_control_codes = tree.output_options.show_control_codes;
         self.begin_page(tree.page_width, tree.page_height);
         self.render_layer_node(&tree.root);
     }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -44,6 +44,51 @@ impl From<HwpError> for JsValue {
     }
 }
 
+#[cfg(any(target_arch = "wasm32", test))]
+const MAX_CANVAS_DIMENSION: f64 = 16_384.0;
+
+#[cfg(any(target_arch = "wasm32", test))]
+fn normalize_canvas_scale(
+    page_width: f64,
+    page_height: f64,
+    requested_scale: f64,
+) -> Result<f64, &'static str> {
+    if !page_width.is_finite()
+        || !page_height.is_finite()
+        || page_width <= 0.0
+        || page_height <= 0.0
+    {
+        return Err("invalid page dimensions");
+    }
+
+    let scale = if requested_scale <= 0.0 || !requested_scale.is_finite() {
+        1.0
+    } else {
+        requested_scale.clamp(0.25, 12.0)
+    };
+
+    let scaled_width = page_width * scale;
+    let scaled_height = page_height * scale;
+    if !scaled_width.is_finite() || !scaled_height.is_finite() {
+        return Ok((MAX_CANVAS_DIMENSION / page_width)
+            .min(MAX_CANVAS_DIMENSION / page_height)
+            .min(scale));
+    }
+
+    if scaled_width > MAX_CANVAS_DIMENSION || scaled_height > MAX_CANVAS_DIMENSION {
+        Ok((MAX_CANVAS_DIMENSION / page_width)
+            .min(MAX_CANVAS_DIMENSION / page_height)
+            .min(scale))
+    } else {
+        Ok(scale)
+    }
+}
+
+#[cfg(target_arch = "wasm32")]
+fn scaled_canvas_extent(page_extent: f64, scale: f64) -> u32 {
+    (page_extent * scale).max(1.0).min(MAX_CANVAS_DIMENSION) as u32
+}
+
 /// WASM에서 사용할 HWP 문서 래퍼
 ///
 /// 도메인 로직은 `DocumentCore`에 구현되어 있으며,
@@ -216,27 +261,12 @@ impl HwpDocument {
 
         let tree = self.build_page_layer_tree(page_num).map_err(JsValue::from)?;
 
-        // scale 정규화: 0 이하 또는 NaN이면 1.0, 최소 0.25 최대 12.0
-        // (zoom 3.0 × DPR 4.0 = 12.0 지원)
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-
-        // 최대 캔버스 크기 가드 (16384px)
-        let max_dim = 16384.0;
-        let scale = if tree.page_width * scale > max_dim || tree.page_height * scale > max_dim {
-            (max_dim / tree.page_width)
-                .min(max_dim / tree.page_height)
-                .min(scale)
-        } else {
-            scale
-        };
+        let scale = normalize_canvas_scale(tree.page_width, tree.page_height, scale)
+            .map_err(JsValue::from_str)?;
 
         // 캔버스 크기 = 페이지 크기 × scale
-        canvas.set_width((tree.page_width * scale) as u32);
-        canvas.set_height((tree.page_height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.page_width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.page_height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;
@@ -280,22 +310,11 @@ impl HwpDocument {
 
         let tree = self.build_page_layer_tree(page_num).map_err(JsValue::from)?;
 
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-        let max_dim = 16384.0;
-        let scale = if tree.page_width * scale > max_dim || tree.page_height * scale > max_dim {
-            (max_dim / tree.page_width)
-                .min(max_dim / tree.page_height)
-                .min(scale)
-        } else {
-            scale
-        };
+        let scale = normalize_canvas_scale(tree.page_width, tree.page_height, scale)
+            .map_err(JsValue::from_str)?;
 
-        canvas.set_width((tree.page_width * scale) as u32);
-        canvas.set_height((tree.page_height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.page_width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.page_height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;
@@ -321,28 +340,12 @@ impl HwpDocument {
             .build_page_tree_cached(page_num)
             .map_err(|e| JsValue::from(e))?;
 
-        // scale 정규화: 0 이하 또는 NaN이면 1.0, 최소 0.25 최대 12.0
-        // (zoom 3.0 × DPR 4.0 = 12.0 지원)
-        let scale = if scale <= 0.0 || scale.is_nan() {
-            1.0
-        } else {
-            scale.clamp(0.25, 12.0)
-        };
-
-        // 최대 캔버스 크기 가드 (16384px)
-        let max_dim = 16384.0;
-        let scale =
-            if tree.root.bbox.width * scale > max_dim || tree.root.bbox.height * scale > max_dim {
-                (max_dim / tree.root.bbox.width)
-                    .min(max_dim / tree.root.bbox.height)
-                    .min(scale)
-            } else {
-                scale
-            };
+        let scale = normalize_canvas_scale(tree.root.bbox.width, tree.root.bbox.height, scale)
+            .map_err(JsValue::from_str)?;
 
         // 캔버스 크기 = 페이지 크기 × scale
-        canvas.set_width((tree.root.bbox.width * scale) as u32);
-        canvas.set_height((tree.root.bbox.height * scale) as u32);
+        canvas.set_width(scaled_canvas_extent(tree.root.bbox.width, scale));
+        canvas.set_height(scaled_canvas_extent(tree.root.bbox.height, scale));
 
         let mut renderer = WebCanvasRenderer::new(canvas)?;
         renderer.show_paragraph_marks = self.show_paragraph_marks;

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -1,6 +1,7 @@
     use super::*;
     use crate::model::document::{Document, Section};
     use crate::model::paragraph::{Paragraph, LineSeg};
+    use crate::paint::LAYER_TREE_SCHEMA;
 
     #[test]
     fn test_create_empty_document() {
@@ -44,6 +45,82 @@
             HwpError::PageOutOfRange(n) => assert_eq!(n, 999),
             _ => panic!("Expected PageOutOfRange error"),
         }
+    }
+
+    #[test]
+    fn test_page_layer_tree_export_uses_schema_contract() {
+        let doc = HwpDocument::create_empty();
+        let json = doc
+            .get_page_layer_tree_native(0)
+            .expect("empty document layer tree should export");
+
+        assert!(json.contains(&format!(
+            "\"schemaVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_version
+        )));
+        assert!(json.contains(&format!(
+            "\"resourceTableVersion\":{}",
+            LAYER_TREE_SCHEMA.resource_table_version
+        )));
+        assert!(json.contains(&format!("\"unit\":\"{}\"", LAYER_TREE_SCHEMA.unit)));
+        assert!(json.contains(&format!(
+            "\"coordinateSystem\":\"{}\"",
+            LAYER_TREE_SCHEMA.coordinate_system
+        )));
+        assert!(json.contains("\"profile\":\"screen\""));
+        assert!(json.contains("\"outputOptions\":{"));
+    }
+
+    #[test]
+    fn test_page_layer_tree_export_preserves_output_options() {
+        let mut doc = HwpDocument::create_empty();
+        doc.set_show_paragraph_marks(true);
+        doc.set_show_control_codes(true);
+        doc.set_show_transparent_borders(true);
+        doc.set_clip_enabled(false);
+        doc.set_debug_overlay(true);
+
+        let json = doc
+            .get_page_layer_tree_native(0)
+            .expect("layer tree should export output options");
+
+        assert!(json.contains("\"showParagraphMarks\":true"));
+        assert!(json.contains("\"showControlCodes\":true"));
+        assert!(json.contains("\"showTransparentBorders\":true"));
+        assert!(json.contains("\"clipEnabled\":false"));
+        assert!(json.contains("\"debugOverlay\":true"));
+    }
+
+    #[test]
+    fn test_normalize_canvas_scale_rejects_invalid_page_dimensions() {
+        for (width, height) in [
+            (0.0, 100.0),
+            (100.0, 0.0),
+            (-1.0, 100.0),
+            (100.0, -1.0),
+            (f64::NAN, 100.0),
+            (100.0, f64::NAN),
+            (f64::INFINITY, 100.0),
+            (100.0, f64::INFINITY),
+        ] {
+            assert!(
+                normalize_canvas_scale(width, height, 1.0).is_err(),
+                "invalid page dimensions must fail: {width} x {height}"
+            );
+        }
+    }
+
+    #[test]
+    fn test_normalize_canvas_scale_clamps_request_and_canvas_extent() {
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 0.0), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, f64::NAN), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, f64::INFINITY), Ok(1.0));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 0.1), Ok(0.25));
+        assert_eq!(normalize_canvas_scale(100.0, 100.0, 20.0), Ok(12.0));
+
+        let scale = normalize_canvas_scale(20_000.0, 10_000.0, 1.0)
+            .expect("large finite page should be scaled down");
+        assert!((scale - (16_384.0 / 20_000.0)).abs() < f64::EPSILON);
     }
 
     #[test]
@@ -15680,4 +15757,3 @@
         let count = doc.reflow_linesegs();
         assert_eq!(count, 0);
     }
-


### PR DESCRIPTION
## What

P9는 native Skia text replay가 기존 `TextRunNode` payload를 더 많이 소비하도록 보강하는 PR입니다. 단순 glyph drawing만 하는 상태에서, 이미 layer payload에 들어있는 text metadata를 가능한 범위에서 replay하게 만듭니다.

- char overlap, tab leader, text decoration을 native Skia replay에 반영합니다.
- shade/shadow/outline-style effect, emphasis dot, vertical rotation을 처리합니다.
- output option에 따른 control mark replay를 보강합니다.
- char overlap, empty-text tab leader, control mark, decorated text에 대한 native Skia raster 테스트를 추가합니다.
- 커진 text replay 구현을 `src/renderer/skia/text_replay.rs`로 분리해서 `renderer.rs`가 page/layer replay orchestration에 집중하게 정리합니다.

## Why

P8에서 Layer IR schema/resource/output option contract를 먼저 고정하고, P9에서는 그 contract 위에서 실제 native Skia text parity를 올립니다. direct Skia replay를 의미 있는 backend로 보려면 기존 `TextRunNode`에 이미 있는 렌더링 정보를 조용히 무시하면 안 됩니다.

원래 P10으로 따로 빼려던 text replay module split은 순수 리팩터링에 가까워서 P9에 접었습니다. 기능 보강으로 커진 text replay 코드를 같은 PR 안에서 정리하는 편이 리뷰 흐름도 더 자연스럽습니다.

현재 draft는 #761 위에 쌓인 상태라 GitHub diff에 P8 변경이 같이 보일 수 있습니다. 의도한 P9 리뷰 범위는 `render-p8` 위의 text replay parity + text replay module split 변경입니다.

## Non-goals

- `skia` 브랜치의 full text source table / glyph-run IR 작업은 아직 넣지 않습니다.
- Skia를 기본 public render path로 전환하지 않습니다.
- targeted raster test 외의 visual/pixel regression infrastructure는 추가하지 않습니다.

## Validation

- `cargo test --features native-skia --lib skia`
- `cargo clippy --features native-skia --lib -- -D warnings`

Refs #536
