### PR TITLE
Task #775: Task #703 회귀 정정 — 다단 영역 InFrontOfText/BehindText 표 컬럼 분배 복원 (closes #775)

### DIFF
--- a/mydocs/plans/task_m100_775.md
+++ b/mydocs/plans/task_m100_775.md
@@ -1,0 +1,89 @@
+# Task #775 수행 계획서
+
+## 이슈
+
+- 이슈 번호: #775
+- 제목: Task #703 회귀 — exam_eng.hwp p4 27번 보기 그림 단 1 중반(+446.6px)으로 밀림
+- 마일스톤: v1.0.0 (M100)
+
+## 결함 요약
+
+`samples/exam_eng.hwp` page 4 (0-idx 3) 27번 문항 안내 그림 (1×1 InFrontOfText 표) 이 단 1 (우측 컬럼) 상단(정상 y≈277.08 px) 에서 단 1 중반(현재 y≈723.69 px) 으로 약 **+446.6 px** 밀림. PDF 권위 자료 (`pdf/exam_eng-2022.pdf`) 와 시각 불일치.
+
+## 회귀 진원지 (bisect 확정)
+
+**커밋 `a759a1c2`** — Task #703 / PR #707 "BehindText/InFrontOfText 표 본문 흐름 누락 정정".
+
+```
+src/renderer/typeset.rs:1403-1416 (+13)
+typeset_table_paragraph 의 Control::Table 분기에 InFrontOfText/BehindText 가드 추가
+→ 데코레이션 표를 Shape처럼 push 만 하고 cur_h 누적 건너뜀
+```
+
+## 해당 IR (pi=181 ci=1)
+
+```
+[1] 표: 1행×1열, treat_as_char=false, wrap=글앞으로(InFrontOfText)
+    size=30047×31727 HU (106.0×111.9 mm)
+    vert=문단(672 = 2.4 mm), horz=문단(280 = 1.0 mm)
+```
+
+→ Task #703 fix 의 정확한 타깃 케이스 (InFrontOfText + treat_as_char=false + 문단 기준 vert offset)
+
+## 측정 (bisect 결과)
+
+| 시점 | 커밋 | cell-clip y | 상태 |
+|------|-----|-------------|-----|
+| Pre PR#644 | `1185eb98` | 277.08 | ✅ |
+| Post PR#644 머지 | `42bb7946` | 277.08 | ✅ |
+| Pre Task#703 (RED) | `afa70578` | 277.08 | ✅ |
+| **Post Task#703 GREEN** | **`a759a1c2`** | **723.69** | ❌ **회귀** |
+| 현재 devel | `e30e52f4` | 723.69 | ❌ |
+
+## 부작용 메커니즘 (가설)
+
+InFrontOfText 표를 `current_height` 누적에서 빼면 단 0/1 컨텐츠 분배가 변경되어 27번 paragraph (pi=181) 가 단 1 상단에서 단 1 중반으로 밀림.
+
+데코레이션 표는 절대좌표 배치이므로 본문 흐름에 영향을 주지 않아야 한다는 Task #703 의 명제는 **calendar_year.hwp** (단일 컬럼) 에서는 성립했으나, **다단 + 자체 vert=문단 offset 표** 영역에서는 컬럼 분배 자체를 변경하여 회귀.
+
+## 수용 기준
+
+1. exam_eng.hwp p4 단 1 27번 보기 그림 cell-clip y ≈ 277.08 px 복원 (PDF 권위 정합)
+2. **calendar_year.hwp 단일 페이지 정합 (Task #703 본 케이스) 보존** — `tests/issue_703.rs::issue_703_calendar_year_single_page` GREEN 유지
+3. 통합재정통계 #704 영역 ignore 처리 유지
+4. 회귀 가드: exam_eng.hwp p4 cell-clip y 통합 테스트 추가
+5. 광범위 sweep — InFrontOfText/BehindText + 다단 조합 케이스 회귀 0
+6. cargo test --release: 1250+ 테스트 통과 (회귀 0)
+
+## 의심 영역
+
+`src/renderer/typeset.rs:1403-1416` 의 Task #703 가드 조건이 너무 광범위. 정밀화 후보:
+
+**옵션 A** — 가드 조건 정밀화 (단일 컬럼 + InFrontOfText 한정)
+- `paper_layout.column_count == 1` 추가 가드
+- 다단 영역에서는 종전 동작 (cur_h 누적) 유지
+
+**옵션 B** — vert_rel_to 분기
+- `vert_rel_to == VertRelTo::Page` 만 push-only
+- `vert_rel_to == VertRelTo::Para` 는 cur_h 누적 (paragraph 기준 offset 가 정상 흐름 의존)
+
+**옵션 C** — typeset 단계 fix 철회 + layout 단계 정정
+- typeset.rs:1403-1416 revert
+- layout.rs 측에서 InFrontOfText 표가 다음 paragraph y_in 누적에 영향 안 주도록 정정
+
+## 권위 자료
+
+- `pdf/exam_eng-2022.pdf` (한컴 2022 정답지)
+- `samples/calendar_year.hwp` + 한컴 2022 (Task #703 본 케이스 보존 확인)
+
+## 진행 절차
+
+1. 본 수행 계획서 승인 요청
+2. 구현 계획서 (`task_m100_775_impl.md`) 작성 → 승인 요청
+3. 단계별 구현 (Stage 1 RED → Stage 2 GREEN → Stage 3 회귀 검증 → Stage 4 광범위 sweep → Stage 5 최종 보고서)
+4. 각 단계별 보고서 작성 → 승인 요청
+5. 최종 결과 보고서 작성 → 승인 요청
+
+## 브랜치
+
+- `local/task775` (upstream/devel 기준 분기)

--- a/mydocs/plans/task_m100_775_impl.md
+++ b/mydocs/plans/task_m100_775_impl.md
@@ -1,0 +1,106 @@
+# Task #775 구현 계획서
+
+수행 계획서: [`task_m100_775.md`](./task_m100_775.md)
+
+## 옵션 비교
+
+### 옵션 A — 가드 조건 정밀화 (단일 컬럼 한정)
+
+```rust
+// src/renderer/typeset.rs:1403
+if matches!(table.common.text_wrap,
+    TextWrap::InFrontOfText | TextWrap::BehindText)
+    && self.paper_layout.column_count == 1
+{
+    st.current_items.push(PageItem::Shape { ... });
+    continue;
+}
+```
+
+- **장점**: 다단 영역 종전 동작 유지 → 본 회귀 즉시 해소
+- **단점**: 다단 + InFrontOfText 케이스에서 Task #703 의 본질 (데코레이션 표는 흐름 영향 0) 적용 불가. calendar_year.hwp 가 단일 컬럼인지 확인 필요
+
+### 옵션 B — vert_rel_to 분기
+
+```rust
+// vert_rel_to == Page 일 때만 push-only
+if matches!(table.common.text_wrap,
+    TextWrap::InFrontOfText | TextWrap::BehindText)
+    && table.common.vert_rel_to == VertRelTo::Page
+{
+    st.current_items.push(PageItem::Shape { ... });
+    continue;
+}
+```
+
+- **장점**: vert=Page (절대 좌표 데코레이션) 만 push-only, vert=Para (paragraph 흐름 의존) 는 종전 동작
+- **단점**: calendar_year.hwp 의 vert_rel_to 가 Page 이어야 본 케이스 보존 가능
+
+### 옵션 C — typeset fix 철회 + layout 단계 정정
+
+- typeset.rs:1403-1416 revert
+- layout.rs 측에서 InFrontOfText 표가 다음 paragraph y_in 누적에 영향 안 주도록 정정
+
+- **장점**: 가장 정밀한 본질 정정 가능
+- **단점**: layout 측 변경 범위 큼, calendar_year.hwp / exam_eng.hwp 양쪽 정합 별도 fix 필요
+
+## 권장: **옵션 B** (1차) → 실패 시 옵션 A → 옵션 C
+
+옵션 B 가 의미적으로 가장 정확. vert=Page 만 절대 좌표 데코레이션이고 vert=Para 는 paragraph 흐름 일부. exam_eng.hwp pi=181 ci=1 의 vert=Para(672=2.4mm) 이므로 옵션 B 적용 시 본 케이스에서 종전 동작 (cur_h 누적) 으로 복귀 → 회귀 해소.
+
+calendar_year.hwp 의 IR 검사가 옵션 B 실현가능성 결정.
+
+## 단계별 구현
+
+### Stage 1 — RED 테스트 + IR 사전 검사
+
+1. `tests/issue_775_exam_eng_p4.rs` 신규: cell-clip y ≈ 277 ± 5 px 가드
+2. `./target/release/rhwp dump samples/calendar_year.hwp` 으로 표 IR 의 vert_rel_to / column_count 확인
+3. RED 확인 (cargo test --release issue_775 → FAIL)
+
+### Stage 2 — GREEN 본질 정정 (옵션 B 우선)
+
+1. `src/renderer/typeset.rs:1403-1416` 의 가드 조건을 옵션 B 로 정밀화
+2. 본 테스트 통과 + `tests/issue_703.rs::issue_703_calendar_year_single_page` 통과 확인
+3. 옵션 B 가 calendar_year.hwp 회귀 시 옵션 A 로 fallback
+
+### Stage 3 — 라이브러리 회귀 + 단위 테스트
+
+```bash
+cargo test --release 2>&1 | grep -E "test result|FAILED"
+```
+- 1250+ 테스트 통과 (회귀 0)
+
+### Stage 4 — 광범위 sweep
+
+1. golden_svg/ 골든 SVG 회귀 검사 (issue-147, form-002 등)
+2. exam_eng.hwp 전 페이지 + samples/ 다단 + InFrontOfText/BehindText 케이스 sweep
+3. PDF 권위 자료 양쪽 정합 (calendar_year + exam_eng)
+
+### Stage 5 — 최종 보고서
+
+`mydocs/report/task_m100_775_report.md` 작성:
+- 회귀 진원지 + bisect 결과
+- 옵션 B 채택 사유
+- 양쪽 케이스 정합 입증
+- 회귀 가드 추가 + golden_svg 갱신 여부
+
+## 파일 변경 예상
+
+| 파일 | 변경 종류 | 라인 |
+|------|----------|------|
+| `src/renderer/typeset.rs` | 가드 조건 정밀화 | ~5 |
+| `tests/issue_775_exam_eng_p4.rs` | 신규 통합 테스트 | ~40 |
+| `mydocs/plans/task_m100_775.md` | 수행 계획서 | (이미 작성) |
+| `mydocs/plans/task_m100_775_impl.md` | 구현 계획서 (본 문서) | (이미 작성) |
+| `mydocs/working/task_m100_775_stage{1..4}.md` | 단계별 보고서 | ~80 each |
+| `mydocs/report/task_m100_775_report.md` | 최종 보고서 | ~150 |
+
+## 위험성
+
+- **회귀 위험**: Task #703 의 calendar_year.hwp 본 케이스가 vert=Para 라면 옵션 B 가 그대로 회귀 → 옵션 A fallback 필요
+- **광범위 영향**: typeset.rs 의 InFrontOfText 표 처리 변경은 다단 + 본문 인접 표 모두 영향. golden_svg 갱신 가능성
+
+## 진행 조건
+
+본 구현 계획서 승인 후 Stage 1 시작.

--- a/mydocs/report/task_m100_775_report.md
+++ b/mydocs/report/task_m100_775_report.md
@@ -1,0 +1,159 @@
+# Task #775 최종 결과 보고서
+
+**이슈**: [#775 — Task #703 회귀: exam_eng.hwp p4 27번 보기 그림 단 1 중반(+446.6px)으로 밀림](https://github.com/edwardkim/rhwp/issues/775)
+**브랜치**: `local/task775` (`upstream/devel` 기준)
+**마일스톤**: v1.0.0 (M100)
+
+## 1. 결함 요약
+
+`samples/exam_eng.hwp` page 4 (0-idx 3) 27번 문항 ("Adenville City Pass Card") 안내 그림
+(1×1 InFrontOfText 표) 이 다단(2단) 단 1 (우측 컬럼) 상단 (정상 y≈277.08 px) 에서
+단 1 중반 (현재 y≈723.69 px) 으로 약 **+446.6 px** 밀려 PDF 권위 자료
+(`pdf/exam_eng-2022.pdf`) 와 시각 불일치.
+
+## 2. 회귀 진원지 (bisect 확정)
+
+**커밋 `a759a1c2`** — Task #703 / PR #707 "BehindText/InFrontOfText 표 본문 흐름 누락 정정".
+
+```
+src/renderer/typeset.rs:1403-1416 (+13)
+typeset_table_paragraph 의 Control::Table 분기에 InFrontOfText/BehindText 가드 추가
+→ 데코레이션 표를 Shape처럼 push 만 하고 cur_h 누적 건너뜀
+```
+
+| 시점 | 커밋 | cell-clip y | 상태 |
+|------|-----|-------------|-----|
+| Pre PR#644 | `1185eb98` | 277.08 | ✅ |
+| Post PR#644 머지 | `42bb7946` | 277.08 | ✅ |
+| Pre Task#703 (RED) | `afa70578` | 277.08 | ✅ |
+| **Post Task#703 GREEN** | **`a759a1c2`** | **723.69** | ❌ **회귀** |
+| 현재 devel | `e30e52f4` | 723.69 | ❌ |
+
+## 3. 본질 정정
+
+### 채택 — 옵션 A (`column_count == 1` 한정 push-only)
+
+`src/renderer/typeset.rs:1553-1568` 의 가드 조건에 `&& st.col_count == 1` 추가:
+
+```diff
+                Control::Table(table) => {
+                    // [Issue #703] 글앞으로 / 글뒤로 표는 Shape처럼 취급 — 본문 흐름 공간 차지 없음.
+                    // pagination/engine.rs:976-981 와 동일 시멘틱: 데코레이션 표는 절대 좌표로 배치되며
+                    // current_height 누적에 영향을 주지 않는다.
++                   //
++                   // [Issue #775] 단일 컬럼 한정. 다단(col_count>=2) 영역에서는 InFrontOfText/BehindText
++                   // 표라도 cur_h 누적이 컬럼 분배에 필요 (exam_eng.hwp p4 27번 보기 그림 위
++                   // 데코레이션 표 회귀 차단).
+                    if matches!(
+                        table.common.text_wrap,
+                        crate::model::shape::TextWrap::InFrontOfText
+                            | crate::model::shape::TextWrap::BehindText
+-                   ) {
++                   ) && st.col_count == 1
++                   {
+                        st.current_items.push(PageItem::Shape {
+                            para_index: para_idx,
+                            control_index: ctrl_idx,
+                        });
+                        continue;
+                    }
+```
+
+### 폐기 — 옵션 B (`vert_rel_to == Page` 한정)
+
+calendar_year.hwp 의 BehindText 표가 `vert=문단(Para)` 이므로 옵션 B 적용 시 push-only 제외 →
+Task #703 본 케이스 회귀 발생. **column_count** 가 양 케이스의 결정적 차별화 요소로 확인.
+
+## 4. 메커니즘
+
+| 케이스 | column_count | text_wrap | vert_rel_to | 본 fix 동작 | 결과 |
+|--------|--------------|-----------|-------------|-------------|------|
+| calendar_year.hwp | **1** (단일 컬럼) | BehindText | Para | push-only (Task #703 fix 유지) | ✅ 1 page 유지 |
+| calendar_monthly.hwp | **1** | BehindText | Para | push-only | ✅ 1 page 유지 |
+| **exam_eng.hwp p4** | **2** (다단) | InFrontOfText | Para | cur_h 누적 (종전 동작 복귀) | ✅ y=277.08 정상 복원 |
+
+## 5. 검증
+
+### 회귀 가드 신규
+
+- `tests/issue_775.rs::issue_775_exam_eng_p4_pi181_table_at_column_top` — RED → GREEN
+
+### Issue #703 본 케이스 보존
+
+- `tests/issue_703.rs::issue_703_calendar_year_single_page` — GREEN 유지
+- `tests/issue_703.rs::issue_703_tonghap_2010_11_single_page` — `#[ignore]` (Issue #704)
+- `tests/issue_703.rs::issue_703_tonghap_2011_10_single_page` — `#[ignore]` (Issue #704)
+
+### 라이브러리 회귀 0
+
+```
+$ cargo test --release
+총 통과: 1338  실패: 0  ignored: 5
+```
+
+### 광범위 sweep — 다단 6 fixture / 164 페이지
+
+| sample | 페이지 | byte diff | 상태 |
+|--------|--------|-----------|------|
+| exam_kor | 20 | 0 | ✅ |
+| **exam_eng** | **8** | **2** | ⚠️ p4 의도된 정정 + p2 ID 순서만 변경 |
+| exam_science | 4 | 0 | ✅ |
+| exam_math | 20 | 0 | ✅ |
+| synam-001 | 35 | 0 | ✅ |
+| aift | 77 | 0 | ✅ |
+
+**유일 변경**: exam_eng p2 (좌표 동일, cell-clip ID 순서만 변경 — 시각적 회귀 0) +
+exam_eng p4 (본 task 의도된 정정).
+
+### 골든 SVG 7개
+
+`issue_147_aift_page3`, `issue_157_page_1`, `issue_267_ktx_toc_page`, `form_002_page_0`,
+`issue_617_exam_kor_page5`, `table_text_page_0`, `render_is_deterministic_within_process`
+— 모두 GREEN.
+
+## 6. PDF 권위 자료 정합
+
+본 환경 (macOS, 한컴 편집기 미접근) 에서 PDF 직접 비교 불가. 정합 체인:
+
+1. 본 fix 동작 = Task #703 이전 (`afa70578`) 동작 (다단 영역 한정)
+2. Task #703 이전 동작 = PDF 권위 자료 정합 (bisect 단계 측정 cell-clip y=277.08)
+3. 본 fix 후 cell-clip y = 277.08 (Stage 2 검증)
+
+→ **PDF 정합 입증 완료**.
+
+## 7. 변경 영향 범위
+
+| 분기 조합 | 처리 동작 | 영향 |
+|-----------|-----------|------|
+| 단일 컬럼 + InFrontOfText/BehindText 표 | push-only (Task #703 fix) | 변경 없음 |
+| **다단 + InFrontOfText/BehindText 표** | **cur_h 누적 (종전 동작 복귀)** | **본 fix 영향** |
+| 그 외 wrap (TopAndBottom/Square/None/InsideText) | 변경 없음 | 변경 없음 |
+
+영향 범위 = 다단 + 데코레이션 표 조합. exam_eng 만 해당. 다른 5개 다단 fixture 영향 0.
+
+## 8. 산출물
+
+| 영역 | 파일 |
+|------|------|
+| 거버넌스 — 수행 계획서 | `mydocs/plans/task_m100_775.md` |
+| 거버넌스 — 구현 계획서 | `mydocs/plans/task_m100_775_impl.md` |
+| 거버넌스 — Stage 1 보고서 | `mydocs/working/task_m100_775_stage1.md` |
+| 거버넌스 — Stage 2 보고서 | `mydocs/working/task_m100_775_stage2.md` |
+| 거버넌스 — Stage 3 보고서 | `mydocs/working/task_m100_775_stage3.md` |
+| 거버넌스 — Stage 4 보고서 | `mydocs/working/task_m100_775_stage4.md` |
+| 거버넌스 — 본 보고서 | `mydocs/report/task_m100_775_report.md` |
+| 본질 정정 | `src/renderer/typeset.rs:1553-1568` (+5/-1) |
+| 회귀 가드 | `tests/issue_775.rs` (+73) |
+
+## 9. 후속
+
+- 이슈 #775 close 권장 (closes #775)
+- Issue #704 (TopAndBottom TAC + 각주 환경 borderline) 별건 영역 — 본 task 영향 없음
+- WASM 빌드 + 시각 판정 영역은 작업지시자 결정 후 진행
+- merge 절차: `local/task775` → push origin (fork) → upstream PR → cherry-pick 절차
+
+## 10. 결론
+
+Task #703 의 본 케이스 (단일 컬럼 BehindText 1×1 wrapper) 정합을 보존하면서 다단 영역의
+회귀 (exam_eng.hwp p4 27번 보기 +446.6 px 시프트) 를 본질 정정. column_count 기반
+1-line 가드로 두 케이스 모두 정합 달성. 라이브러리 회귀 0, 다단 광범위 sweep 회귀 0.

--- a/mydocs/working/task_m100_775_stage1.md
+++ b/mydocs/working/task_m100_775_stage1.md
@@ -1,0 +1,88 @@
+# Task #775 Stage 1 보고서 — RED 테스트 + IR 사전 검사
+
+## 결과 요약
+
+- ✅ RED 통합 테스트 작성 (`tests/issue_775.rs`)
+- ✅ FAIL 확인 — 회귀 측정값 = +446.61 px
+- ✅ calendar_year.hwp / exam_eng.hwp IR 사전 검사 완료
+- ⚠️ **옵션 B 폐기**, **옵션 A 채택**
+
+## 1. RED 테스트
+
+### 파일
+`tests/issue_775.rs` (+~70 lines)
+
+### 검증 내용
+- `samples/exam_eng.hwp` page 4 (0-idx 3) pi=181 ci=1 = 1×1 InFrontOfText 표 (27번 보기 그림 위 데코레이션)
+- `build_page_render_tree(3)` 의 RenderTree 에서 Table 노드 bbox 추출
+- 정상 y_top ≈ 277.08 px ± 5.0 px 가드
+
+### FAIL 결과
+
+```
+[issue_775] page=4 pi=181 ci=1 bbox=[723.69..1146.72] (height=423.03)
+pi=181 ci=1 (27번 보기 InFrontOfText 표) 가 단 1 상단(≈y=277.08)에 위치해야 함.
+실제 y=723.69 px (PDF 정상값과 차이=446.61 px).
+```
+
+회귀 측정값 =bisect 단계의 SVG cell-clip y 분석 결과와 정확히 일치 (+446.61 px).
+
+## 2. IR 사전 검사
+
+### calendar_year.hwp (Task #703 본 케이스)
+
+```
+샘플: samples/basic/calendar_year.hwp
+용지: 210.0×297.0 mm
+구역 0:
+  단정의: 1단 (column_count == 1)
+  표 IR: 1×1 wrapper, treat_as_char=false, wrap=글뒤로(BehindText)
+  vert=문단(643=2.3mm) ← vert_rel_to=Para
+  size=51974×2782 HU (183.4×9.8 mm) ← 매우 얇음 (carrier wrapper)
+```
+
+### exam_eng.hwp (회귀 케이스)
+
+```
+샘플: samples/exam_eng.hwp
+용지: 297.0×420.0 mm (A4 가로형 변형 → A3)
+구역 0:
+  단정의: 2단 간격=11.0mm (column_count == 2) ← 다단
+  pi=181 ci=1: 1×1 표, treat_as_char=false, wrap=글앞으로(InFrontOfText)
+  vert=문단(672=2.4mm) ← vert_rel_to=Para
+  size=30047×31727 HU (106.0×111.9 mm) ← 큼 (그림 위 데코레이션)
+```
+
+## 3. 옵션 비교 결론
+
+### 옵션 B (`vert_rel_to == Page` 한정 push-only) — ❌ **폐기**
+
+calendar_year.hwp 의 BehindText 표 `vert=문단(Para)` 이므로 옵션 B 적용 시 push-only 제외 → Task #703 본 케이스 **회귀 발생** (단일 페이지 → 2 페이지로 복귀).
+
+### 옵션 A (`column_count == 1` 한정 push-only) — ✅ **채택**
+
+| 케이스 | column_count | 옵션 A 동작 | 결과 |
+|--------|--------------|-------------|------|
+| calendar_year.hwp | 1 | push-only (현행 fix 유지) | ✅ Task #703 본 케이스 보존 |
+| exam_eng.hwp p4 | 2 | cur_h 누적 (종전 동작 복귀) | ✅ 회귀 해소 |
+
+두 케이스 모두 정합. column_count 가 결정적 차별화 요소 확인.
+
+### typeset.rs 의 column_count 접근
+
+`st.col_count: u16` (typeset.rs:101) — 이미 State 에 존재. 추가 인프라 불필요.
+
+## 4. Stage 2 진행 조건
+
+- Stage 1 RED + IR 검사 결과 본 보고서 승인
+- 옵션 A 적용 위치 = `src/renderer/typeset.rs:1553-1563` 의 `matches!(...)` 조건에 `&& st.col_count == 1` 추가
+- 변경 라인 = 1 (단순 가드 추가)
+
+## 파일 변경
+
+| 파일 | 변경 종류 | 라인 |
+|------|----------|------|
+| `tests/issue_775.rs` | 신규 RED 테스트 | +73 |
+| `mydocs/plans/task_m100_775.md` | 수행 계획서 (Stage 0) | +94 |
+| `mydocs/plans/task_m100_775_impl.md` | 구현 계획서 (Stage 0) | +120 |
+| `mydocs/working/task_m100_775_stage1.md` | 본 단계 보고서 | (본 파일) |

--- a/mydocs/working/task_m100_775_stage2.md
+++ b/mydocs/working/task_m100_775_stage2.md
@@ -1,0 +1,71 @@
+# Task #775 Stage 2 보고서 — GREEN (옵션 A 가드 추가)
+
+## 결과 요약
+
+- ✅ `src/renderer/typeset.rs:1553-1568` 가드 조건 정밀화 (옵션 A)
+- ✅ `tests/issue_775.rs::issue_775_exam_eng_p4_pi181_table_at_column_top` GREEN (회귀 해소)
+- ✅ `tests/issue_703.rs::issue_703_calendar_year_single_page` GREEN (본 케이스 보존)
+
+## 변경 내용
+
+### `src/renderer/typeset.rs` (+5/-1)
+
+```diff
+                Control::Table(table) => {
+                    // [Issue #703] 글앞으로 / 글뒤로 표는 Shape처럼 취급 — 본문 흐름 공간 차지 없음.
+                    // pagination/engine.rs:976-981 와 동일 시멘틱: 데코레이션 표는 절대 좌표로 배치되며
+                    // current_height 누적에 영향을 주지 않는다.
++                   //
++                   // [Issue #775] 단일 컬럼 한정. 다단(col_count>=2) 영역에서는 InFrontOfText/BehindText
++                   // 표라도 cur_h 누적이 컬럼 분배에 필요 (exam_eng.hwp p4 27번 보기 그림 위
++                   // 데코레이션 표 회귀 차단).
+                    if matches!(
+                        table.common.text_wrap,
+                        crate::model::shape::TextWrap::InFrontOfText
+                            | crate::model::shape::TextWrap::BehindText
+-                   ) {
++                   ) && st.col_count == 1
++                   {
+                        st.current_items.push(PageItem::Shape {
+                            para_index: para_idx,
+                            control_index: ctrl_idx,
+                        });
+                        continue;
+                    }
+```
+
+## 검증
+
+### Issue #775 RED → GREEN
+
+```
+$ cargo test --release --test issue_775
+test issue_775_exam_eng_p4_pi181_table_at_column_top ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out
+```
+
+bbox 정상 복원: `[277.08..700.10] (height=423.03)` (Stage 1 RED 시 `[723.69..1146.72]` → +446.61 px 시프트 해소)
+
+### Issue #703 본 케이스 보존 검증
+
+```
+$ cargo test --release --test issue_703
+test issue_703_calendar_year_single_page ... ok
+test issue_703_tonghap_2010_11_single_page ... ignored (Issue #704)
+test issue_703_tonghap_2011_10_single_page ... ignored (Issue #704)
+test result: ok. 1 passed; 0 failed; 2 ignored
+```
+
+calendar_year.hwp 단일 페이지 정합 유지 → Task #703 fix 본 케이스(단일 컬럼 BehindText 표) 영향 0.
+
+## 메커니즘
+
+| 케이스 | column_count | 가드 매칭 | 동작 | 결과 |
+|--------|--------------|-----------|------|------|
+| calendar_year.hwp (Task #703 본 케이스) | 1 | ✅ | push-only | calendar_year 1 page 유지 |
+| exam_eng.hwp p4 (Issue #775 회귀) | 2 | ❌ | 종전 cur_h 누적 | y=277 정상 복원 |
+
+## Stage 3 진행 조건
+
+- 본 단계 보고서 승인
+- Stage 3: cargo test --release 전체 회귀 검증 (1250+ 테스트, 회귀 0)

--- a/mydocs/working/task_m100_775_stage3.md
+++ b/mydocs/working/task_m100_775_stage3.md
@@ -1,0 +1,86 @@
+# Task #775 Stage 3 보고서 — cargo test --release 전체 회귀 검증
+
+## 결과 요약
+
+- ✅ **총 통과 1338 / 실패 0 / ignored 5** — 회귀 0
+- ✅ Issue #775 본 테스트 GREEN
+- ✅ Issue #703 본 케이스 (calendar_year) GREEN
+- ✅ Issue #704 (통합재정통계) ignored 유지
+- ✅ Issue #643/#712/#713/#716 등 후속 회귀 가드 모두 GREEN
+
+## 명령
+
+```bash
+cargo test --release
+```
+
+## 집계
+
+```
+Compiling rhwp v0.7.10 (/Users/planet/rhwp)
+warning: unnecessary parentheses around assigned value (기존 — 본 변경 무관)
+warning: function `footnote_emits_autoNum` (기존 — 본 변경 무관)
+warning: function `test_merge_then_control_layout_has_colSpan` (기존 — 본 변경 무관)
+... (5 warnings — 기존 코드 영역, 본 변경에 의한 신규 경고 0)
+
+Finished `release` profile [optimized] target(s) in 1m 36s
+
+총 통과: 1338  실패: 0  ignored: 5
+FAILED 줄: 0
+panic 줄: 0
+```
+
+## 주요 가드 통과 확인
+
+### 본 task 회귀 차단 가드
+
+| 테스트 | 결과 |
+|--------|------|
+| `tests/issue_775.rs::issue_775_exam_eng_p4_pi181_table_at_column_top` | ✅ ok |
+
+### 회귀 위험 영역 — Issue #703 + 후속 회귀 task
+
+| 테스트 | 결과 |
+|--------|------|
+| `tests/issue_703.rs::issue_703_calendar_year_single_page` | ✅ ok (Task #703 본 케이스 보존) |
+| `tests/issue_703.rs::issue_703_tonghap_2010_11_single_page` | ⏸ ignored (Issue #704) |
+| `tests/issue_703.rs::issue_703_tonghap_2011_10_single_page` | ⏸ ignored (Issue #704) |
+| `tests/issue_643.rs` | ✅ ok |
+| `tests/issue_712.rs` | ✅ ok |
+| `tests/issue_713.rs` | ✅ ok |
+| `tests/issue_716.rs` | ✅ ok |
+
+### 골든 SVG 영역
+
+```
+Running tests/svg_snapshot.rs
+test result: ok. 7 passed; 0 failed; 0 ignored; 0 measured (post-Stage 2 변경에도 회귀 0)
+```
+
+`issue_147_aift_page3`, `issue_157_page_1`, `issue_267_ktx_toc_page`, `form_002_page_0`,
+`issue_617_exam_kor_page5`, `table_text_page_0`, `render_is_deterministic_within_process`
+모두 GREEN.
+
+### 다단 영역 가드
+
+```
+Running tests/exam_eng_multicolumn.rs
+test result: ok. (다단 본 환경 핵심 fixtures 회귀 0)
+```
+
+## 변경 영향 범위 요약
+
+`typeset.rs:1553` 의 가드 조건은 기존 `InFrontOfText | BehindText` 매칭에 `&& st.col_count == 1` 만 추가:
+
+| 분기 | column_count | 동작 변경 여부 |
+|------|--------------|----------------|
+| InFrontOfText/BehindText 표 | 1 (단일 컬럼) | 변경 없음 (Task #703 fix 그대로 적용) |
+| InFrontOfText/BehindText 표 | ≥2 (다단) | 종전(Task #703 fix 이전) 동작 복귀 |
+| 그 외 표 (TopAndBottom, Square, …) | * | 변경 없음 |
+
+따라서 영향 범위는 **다단 + InFrontOfText/BehindText 표** 조합만이고, 본 fix 가 Task #703 의 본 케이스(단일 컬럼) 와 직교하므로 라이브러리 회귀 0 정합.
+
+## Stage 4 진행 조건
+
+- 본 단계 보고서 승인
+- Stage 4: 광범위 sweep (samples/ 다단 + InFrontOfText/BehindText 케이스 + 골든 SVG 회귀 확인 + PDF 권위 자료 정합 시각 판정)

--- a/mydocs/working/task_m100_775_stage4.md
+++ b/mydocs/working/task_m100_775_stage4.md
@@ -1,0 +1,103 @@
+# Task #775 Stage 4 보고서 — 광범위 sweep + 시각 판정
+
+## 결과 요약
+
+- ✅ 6개 다단 fixture sweep — `exam_eng` 만 변경 (의도된 정정), 5개 **회귀 0**
+- ✅ exam_eng 8 페이지 중 2 페이지 변경 — 모두 시각적 회귀 0
+  - p4: 본 task 의도된 정정 (y=723→277)
+  - p2: 좌표 100% 동일, cell-clip ID 순서만 변경 (시각 정합 유지)
+- ✅ 단일 컬럼 본 케이스 보존 — `calendar_year.hwp` / `calendar_monthly.hwp` 모두 1 페이지 유지
+- ✅ 골든 SVG 7개 (Stage 3 에서 확인) 회귀 0
+
+## 다단 sweep — 6 fixture × 페이지 byte 비교
+
+```bash
+# baseline = upstream/devel (e30e52f4 — 회귀 상태)
+# after = local/task775 (본 fix)
+```
+
+| sample | 페이지 | byte diff | 상태 |
+|--------|--------|-----------|------|
+| exam_kor | 20 | 0 | ✅ 회귀 0 |
+| **exam_eng** | **8** | **2** | ⚠️ 의도된 정정 (분석 ↓) |
+| exam_science | 4 | 0 | ✅ 회귀 0 |
+| exam_math | 20 | 0 | ✅ 회귀 0 |
+| synam-001 | 35 | 0 | ✅ 회귀 0 |
+| aift | 77 | 0 | ✅ 회귀 0 |
+
+**총 다단 페이지: 164  변경: 2 (exam_eng p2 + p4)**
+
+## exam_eng 변경 분석
+
+### page 4 — 본 task 의도된 정정 ✅
+
+```
+[Before fix]  cell-clip-211: y=723.69 (회귀)
+[After fix]   cell-clip-160: y=277.08 (PDF 정합 정상값)
+```
+
+27번 보기 그림 (1×1 InFrontOfText 표) 가 단 1 상단으로 복귀. PDF 권위 자료
+(`pdf/exam_eng-2022.pdf`) 와 정합.
+
+### page 2 — 좌표 동일, ID 순서만 변경 ✅ (회귀 0)
+
+```
+$ diff <(grep -oE '<text[^>]*' before/exam_eng_002.svg | sort) \
+       <(grep -oE '<text[^>]*' after/exam_eng_002.svg  | sort) | wc -l
+0
+```
+
+**텍스트 좌표 100% 동일** — 변경은 cell-clip ID 부여 순서 차이뿐:
+
+| Before | After | 좌표 |
+|--------|-------|------|
+| cell-clip-219 | cell-clip-218 | x=597.12 y=243.59 (동일) |
+| cell-clip-192 | cell-clip-179 | x=117.17 y=1362.08 (동일) |
+
+InFrontOfText 표가 cur_h 누적 분기로 변경되면서 `current_items.push` 순서가
+1 step 변경 → ID 부여 순서만 시프트. **시각적 출력 100% 동일**.
+
+## 단일 컬럼 본 케이스 보존 검증
+
+```
+calendar_year.hwp     pages=1  ✅ (Task #703 본 케이스 — BehindText 1×1 wrapper)
+calendar_monthly.hwp  pages=1  ✅ (동일 패턴)
+```
+
+→ 단일 컬럼 영역에서 Task #703 fix 그대로 적용되어 본 케이스 보존.
+
+## 골든 SVG 영역 (Stage 3 인용)
+
+```
+Running tests/svg_snapshot.rs
+test result: ok. 7 passed; 0 failed
+```
+
+`issue_147_aift_page3`, `issue_157_page_1`, `issue_267_ktx_toc_page`, `form_002_page_0`,
+`issue_617_exam_kor_page5`, `table_text_page_0`, `render_is_deterministic_within_process`
+모두 회귀 0.
+
+## PDF 권위 자료 정합
+
+본 환경 (macOS) 에서 PDF 직접 비교 불가. 다음 정합 체인으로 입증:
+
+1. **본 fix 의 동작** = `Task #703 이전 (afa70578) 동작` (다단 영역 한정)
+2. **Task #703 이전 동작** = PDF 권위 자료 정합 (bisect 단계에서 cell-clip y=277.08 측정)
+3. **본 fix 후 cell-clip y** = 277.08 (Stage 2 검증)
+
+→ **PDF 정합 입증 완료**.
+
+## 영향 범위 정리
+
+| 분기 조합 | 처리 동작 | 영향 |
+|-----------|-----------|------|
+| 단일 컬럼 + InFrontOfText/BehindText 표 | push-only (Task #703 fix) | 변경 없음 |
+| **다단 + InFrontOfText/BehindText 표** | **cur_h 누적 (종전 동작 복귀)** | **본 fix 영향** |
+| 그 외 (TopAndBottom/Square/None) | 변경 없음 | 변경 없음 |
+
+→ 영향 범위 = 다단 + 데코레이션 표 조합. exam_eng 만 해당 (sweep 결과 정합).
+
+## Stage 5 진행 조건
+
+- 본 단계 보고서 승인
+- Stage 5: 최종 결과 보고서 (`mydocs/report/task_m100_775_report.md`) + orders 갱신

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -1550,11 +1550,16 @@ impl TypesetEngine {
                     // [Issue #703] 글앞으로 / 글뒤로 표는 Shape처럼 취급 — 본문 흐름 공간 차지 없음.
                     // pagination/engine.rs:976-981 와 동일 시멘틱: 데코레이션 표는 절대 좌표로 배치되며
                     // current_height 누적에 영향을 주지 않는다.
+                    //
+                    // [Issue #775] 단일 컬럼 한정. 다단(col_count>=2) 영역에서는 InFrontOfText/BehindText
+                    // 표라도 cur_h 누적이 컬럼 분배에 필요 (exam_eng.hwp p4 27번 보기 그림 위
+                    // 데코레이션 표 회귀 차단).
                     if matches!(
                         table.common.text_wrap,
                         crate::model::shape::TextWrap::InFrontOfText
                             | crate::model::shape::TextWrap::BehindText
-                    ) {
+                    ) && st.col_count == 1
+                    {
                         st.current_items.push(PageItem::Shape {
                             para_index: para_idx,
                             control_index: ctrl_idx,

--- a/tests/issue_775.rs
+++ b/tests/issue_775.rs
@@ -1,0 +1,73 @@
+//! Issue #775: Task #703 회귀 — `samples/exam_eng.hwp` 4페이지 27번 보기 그림 (1×1 InFrontOfText 표)
+//! 이 다단(2단) 단 1 (우측 컬럼) 상단(정상 y≈277.08 px)에서 단 1 중반(현재 y≈723.69 px)으로
+//! 약 +446.6 px 밀리는 회귀.
+//!
+//! 회귀 진원지: a759a1c2 (Task #703 / PR #707 — typeset.rs 의 InFrontOfText/BehindText 가드).
+//! Task #703 fix 가 단일 컬럼 케이스(calendar_year.hwp)에서는 정확하나, 다단 영역에서
+//! 컬럼 분배 자체를 변경하여 회귀.
+//!
+//! 권위 자료: `pdf/exam_eng-2022.pdf` (한글 2022 편집기 PDF)
+//!
+//! 결함 메커니즘:
+//! - pi=181 ci=1: 1×1 InFrontOfText 표, treat_as_char=false, vert=문단(2.4mm),
+//!   size=106.0×111.9 mm. 그림(pi=181 ci=0) 위 데코레이션
+//! - exam_eng.hwp 는 2단 (column_count == 2) 다단 영역
+//! - Task #703 fix 적용 시 InFrontOfText 표를 cur_h 누적에서 제외 → 단 0/1 컨텐츠 분배 변경
+//!   → pi=181 paragraph 가 단 1 상단(y≈277)에서 단 1 중반(y≈723)으로 밀림
+
+use std::fs;
+use std::path::Path;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str = "samples/exam_eng.hwp";
+const TARGET_PAGE: u32 = 3; // 0-indexed: page 4
+
+/// para_index/control_index 일치하는 첫 Table 노드의 bbox 를 (y_top, y_bottom) 으로 반환.
+fn find_table_bbox(root: &RenderNode, target_pi: usize, target_ci: usize) -> Option<(f64, f64)> {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        if let RenderNodeType::Table(t) = &node.node_type {
+            if t.para_index == Some(target_pi) && t.control_index == Some(target_ci) {
+                let bbox = &node.bbox;
+                return Some((bbox.y, bbox.y + bbox.height));
+            }
+        }
+        for child in &node.children {
+            stack.push(child);
+        }
+    }
+    None
+}
+
+#[test]
+fn issue_775_exam_eng_p4_pi181_table_at_column_top() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join(SAMPLE);
+    let bytes = fs::read(&hwp_path).unwrap_or_else(|e| panic!("read {}: {}", SAMPLE, e));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {}: {}", SAMPLE, e));
+
+    let tree = doc.build_page_render_tree(TARGET_PAGE)
+        .expect("build_page_render_tree page 4");
+
+    // pi=181 ci=1 = 1×1 InFrontOfText 표 (27번 보기 그림 위 데코레이션)
+    let (pi181_top, pi181_bottom) = find_table_bbox(&tree.root, 181, 1)
+        .expect("pi=181 ci=1 (27번 보기 1×1 InFrontOfText 표) Table 노드 누락");
+
+    eprintln!(
+        "[issue_775] page=4 pi=181 ci=1 bbox=[{:.2}..{:.2}] (height={:.2})",
+        pi181_top, pi181_bottom, pi181_bottom - pi181_top,
+    );
+
+    // 정상 동작: pi=181 ci=1 표가 단 1 상단 ≈ y=277.08 px (PDF 권위 정합).
+    // 회귀: y=723.69 px (+446.6 px 밀림).
+    // 5 px 허용 오차 (rounding / 후속 fix 누적 drift 안전 마진).
+    assert!(
+        (pi181_top - 277.08).abs() <= 5.0,
+        "pi=181 ci=1 (27번 보기 InFrontOfText 표) 가 단 1 상단(≈y=277.08)에 위치해야 함. \
+         실제 y={:.2} px (PDF 정상값과 차이={:.2} px). \
+         회귀 진원지: a759a1c2 (Task #703 / PR #707) — typeset.rs:1550 InFrontOfText 가드 \
+         가 다단 영역에서 컬럼 분배를 변경.",
+        pi181_top, pi181_top - 277.08,
+    );
+}


### PR DESCRIPTION
## 개요

이슈 #775 정정. Task #703 / PR #707 의 InFrontOfText/BehindText 가드가 다단 영역에서 컬럼 분배를 변경하여 발생한 회귀를 정밀화. **단일 컬럼 한정** (`col_count == 1`) 으로 가드 조건 정밀화 → 두 케이스 모두 정합.

## 회귀 진원지 (bisect 확정)

**커밋 `a759a1c2`** — Task #703 / PR #707 \"BehindText/InFrontOfText 표 본문 흐름 누락 정정\"

| 시점 | 커밋 | cell-clip y | 상태 |
|------|-----|-------------|-----|
| Pre Task#703 (RED) | `afa70578` | 277.08 | ✅ |
| **Post Task#703 GREEN** | **`a759a1c2`** | **723.69** | ❌ **회귀** |
| 현재 devel | `e30e52f4` | 723.69 | ❌ |

## 변경 내역

| 영역 | 경로 | 변경 |
|------|------|------|
| 본질 정정 | `src/renderer/typeset.rs` | +5/-1 (`&& st.col_count == 1` 가드 추가) |
| 회귀 가드 | `tests/issue_775.rs` | +73 (신규 통합 테스트) |
| 거버넌스 | `mydocs/plans/task_m100_775{,_impl}.md` | 수행/구현 계획서 |
| 거버넌스 | `mydocs/working/task_m100_775_stage{1..4}.md` | 단계별 보고서 |
| 거버넌스 | `mydocs/report/task_m100_775_report.md` | 최종 결과 보고서 |

## 메커니즘

| 케이스 | column_count | text_wrap | vert_rel_to | 본 fix 동작 | 결과 |
|--------|--------------|-----------|-------------|-------------|------|
| calendar_year.hwp | **1** | BehindText | Para | push-only (Task #703 fix 유지) | ✅ 1 page 유지 |
| **exam_eng.hwp p4** | **2** | InFrontOfText | Para | cur_h 누적 (종전 동작) | ✅ y=277.08 정상 복원 |

## 검증

### 라이브러리 회귀

\`\`\`
$ cargo test --release
총 통과: 1338  실패: 0  ignored: 5
\`\`\`

### 다단 광범위 sweep — 6 fixture / 164 페이지

| sample | 페이지 | byte diff | 상태 |
|--------|--------|-----------|------|
| exam_kor | 20 | 0 | ✅ |
| **exam_eng** | **8** | **2** | ⚠️ p4 의도된 정정 + p2 ID 순서만 변경 |
| exam_science | 4 | 0 | ✅ |
| exam_math | 20 | 0 | ✅ |
| synam-001 | 35 | 0 | ✅ |
| aift | 77 | 0 | ✅ |

exam_eng p2: 텍스트 좌표 100% 동일, cell-clip ID 순서만 변경 → 시각적 회귀 0.

### 단일 컬럼 본 케이스 보존

- `tests/issue_703.rs::issue_703_calendar_year_single_page` — GREEN 유지
- `samples/basic/calendar_year.hwp` — 1 page 유지
- `samples/basic/calendar_monthly.hwp` — 1 page 유지

### 골든 SVG 7개

`issue_147_aift_page3`, `issue_157_page_1`, `issue_267_ktx_toc_page`, `form_002_page_0`, `issue_617_exam_kor_page5`, `table_text_page_0`, `render_is_deterministic_within_process` — 모두 GREEN.

## 영향 범위

| 분기 조합 | 처리 동작 | 영향 |
|-----------|-----------|------|
| 단일 컬럼 + InFrontOfText/BehindText 표 | push-only (Task #703 fix) | 변경 없음 |
| **다단 + InFrontOfText/BehindText 표** | **cur_h 누적 (종전 동작)** | **본 fix 영향** |
| 그 외 wrap (TopAndBottom/Square/None) | 변경 없음 | 변경 없음 |

## PDF 권위 자료 정합

본 환경 (macOS) PDF 직접 비교 불가. 정합 체인:
1. 본 fix 동작 = Task #703 이전 동작 (다단 영역 한정)
2. Task #703 이전 동작 = PDF 권위 자료 정합 (cell-clip y=277.08)
3. 본 fix 후 cell-clip y = 277.08

## 관련

- 회귀 진원지: PR #707 (Task #703, `a759a1c2`)
- Issue #775 (본 PR closes)
- Issue #704 (TopAndBottom TAC + 각주 borderline) — 별건 영역, 본 PR 영향 없음