### PR TITLE
fix: Ctrl+N,M 수식 단축키 + 수식 삭제 오류 수정 (closes #767, closes #766)

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -280,6 +280,8 @@ export const insertCommands: CommandDef[] = [
       if (!ref) return;
       if (ref.type === 'shape' || ref.type === 'line' || ref.type === 'group') {
         services.wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
+      } else if (ref.type === 'equation') {
+        services.wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
       } else {
         services.wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
       }

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -590,6 +590,11 @@ export class WasmBridge {
     return JSON.parse(this.doc.deleteShapeControl(sec, para, ci));
   }
 
+  deleteEquationControl(sec: number, para: number, ci: number): { ok: boolean } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse(this.doc.deleteEquationControl(sec, para, ci));
+  }
+
   changeShapeZOrder(sec: number, para: number, ci: number, operation: string): { ok: boolean; zOrder?: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.changeShapeZOrder(sec, para, ci, operation));

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -58,6 +58,8 @@ const chordMapN: Record<string, string> = {
   ㅜ: 'insert:footnote', // 한글 IME
   s: 'page:hide',
   ㄴ: 'page:hide', // 한글 IME
+  m: 'insert:equation',
+  ㅡ: 'insert:equation', // 한글 IME
 };
 
 /** 코드 단축키 → 커맨드 ID 매핑 (Alt+V,? 형태 — 보기 메뉴) */
@@ -413,6 +415,8 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         this.executeOperation({ kind: 'snapshot', operationType: 'deleteObject', operation: (wasm: WasmBridge) => {
           if (ref.type === 'image') {
             wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+          } else if (ref.type === 'equation') {
+            wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
           } else {
             wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
           }
@@ -468,6 +472,8 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         this.executeOperation({ kind: 'snapshot', operationType: 'cutObject', operation: (wasm: WasmBridge) => {
           if (ref.type === 'image') {
             wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+          } else if (ref.type === 'equation') {
+            wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
           } else {
             wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
           }
@@ -1026,6 +1032,8 @@ export function onCut(this: any, e: ClipboardEvent): void {
       this.executeOperation({ kind: 'snapshot', operationType: 'cutObject', operation: (wasm: WasmBridge) => {
         if (ref.type === 'image') {
           wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+        } else if (ref.type === 'equation') {
+          wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
         } else {
           wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
         }

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -260,6 +260,8 @@ export function setObjectProperties(this: any, ref: { sec: number; ppi: number; 
 export function deleteObjectControl(this: any, ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' | 'line' }): void {
   if (ref.type === 'shape' || ref.type === 'group' || ref.type === 'line') {
     this.wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
+  } else if (ref.type === 'equation') {
+    this.wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
   } else {
     this.wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
   }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2229,6 +2229,8 @@ export class InputHandler {
         this.executeOperation({ kind: 'snapshot', operationType: 'cutObject', operation: (wasm: WasmBridge) => {
           if (ref.type === 'image') {
             wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+          } else if (ref.type === 'equation') {
+            wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
           } else {
             wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
           }

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -3390,6 +3390,78 @@ impl DocumentCore {
         Ok(svg)
     }
 
+    /// 수식(Equation) 컨트롤을 문단에서 삭제한다.
+    pub fn delete_equation_control_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) -> Result<String, HwpError> {
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!("구역 인덱스 {} 범위 초과", section_idx)));
+        }
+        let section = &mut self.document.sections[section_idx];
+        if parent_para_idx >= section.paragraphs.len() {
+            return Err(HwpError::RenderError(format!("문단 인덱스 {} 범위 초과", parent_para_idx)));
+        }
+        let para = &mut section.paragraphs[parent_para_idx];
+        if control_idx >= para.controls.len() {
+            return Err(HwpError::RenderError(format!("컨트롤 인덱스 {} 범위 초과", control_idx)));
+        }
+        if !matches!(&para.controls[control_idx], Control::Equation(_)) {
+            return Err(HwpError::RenderError("지정된 컨트롤이 수식이 아닙니다".to_string()));
+        }
+
+        let text_chars: Vec<char> = para.text.chars().collect();
+        let mut ci = 0usize;
+        let mut prev_end: u32 = 0;
+        let mut gap_start: Option<u32> = None;
+        'outer: for i in 0..text_chars.len() {
+            let offset = if i < para.char_offsets.len() { para.char_offsets[i] } else { prev_end };
+            while prev_end + 8 <= offset && ci < para.controls.len() {
+                if ci == control_idx { gap_start = Some(prev_end); break 'outer; }
+                ci += 1;
+                prev_end += 8;
+            }
+            let char_size: u32 = if text_chars[i] == '\t' { 8 }
+                else if text_chars[i].len_utf16() == 2 { 2 }
+                else { 1 };
+            prev_end = offset + char_size;
+        }
+        if gap_start.is_none() {
+            while ci < para.controls.len() {
+                if ci == control_idx { gap_start = Some(prev_end); break; }
+                ci += 1;
+                prev_end += 8;
+            }
+        }
+
+        if let Some(gs) = gap_start {
+            let threshold = gs + 8;
+            for offset in para.char_offsets.iter_mut() {
+                if *offset >= threshold {
+                    *offset -= 8;
+                }
+            }
+        }
+
+        para.controls.remove(control_idx);
+        if control_idx < para.ctrl_data_records.len() {
+            para.ctrl_data_records.remove(control_idx);
+        }
+        if para.char_count >= 8 {
+            para.char_count -= 8;
+        }
+
+        Self::reflow_paragraph_line_segs_after_control_delete(para, &self.styles, self.dpi);
+        section.raw_stream = None;
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+
+        self.event_log.push(DocumentEvent::PictureDeleted { section: section_idx, para: parent_para_idx, ctrl: control_idx });
+        Ok("{\"ok\":true}".to_string())
+    }
+
     // ─── 각주 삽입/삭제 API ──────────────────────────────
 
     /// 각주를 삽입한다.

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -473,6 +473,7 @@ impl DocumentCore {
             match ctrl {
                 Control::Picture(pic) => pic.common.height as i32,
                 Control::Shape(shape) => shape.common().height as i32,
+                Control::Equation(eq) => eq.common.height as i32,
                 _ => 0,
             }
         }).max().unwrap_or(0);

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2046,6 +2046,24 @@ impl HwpDocument {
 
     // ─── Equation(수식) API ──────────────────────────────
 
+    /// 수식 컨트롤을 문단에서 삭제한다.
+    ///
+    /// 반환: JSON `{"ok":true}`
+    #[wasm_bindgen(js_name = deleteEquationControl)]
+    pub fn delete_equation_control(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        control_idx: u32,
+    ) -> Result<String, JsValue> {
+        self.delete_equation_control_native(
+            section_idx as usize,
+            parent_para_idx as usize,
+            control_idx as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 수식 컨트롤의 속성을 조회한다.
     ///
     /// 반환: JSON `{ script, fontSize, color, baseline, fontName }`


### PR DESCRIPTION
## 요약

PR #739 (수식 신규 입력) 후속 버그 2건 수정:

### 1. Ctrl+N,M 단축키 매핑 누락 (#767)

`chordMapN`에 `m`/`ㅡ`(한글 IME) → `insert:equation` 매핑 추가.
기존: Ctrl+N 후 M 입력 시 `chordMapN['m']` 미발견 → `preventDefault()` 미호출 → 브라우저 기본 동작(새 창).

### 2. 수식 객체 Backspace/Delete 삭제 오류 (#766)

수식 객체 선택 후 Backspace 시 `deleteShapeControl` 호출 → `Control::Equation` 타입 불일치로 "Shape이 아닙니다" 오류.

**수정 내용**:
- `delete_equation_control_native` + WASM export `deleteEquationControl` 신규
- 키보드 핸들러 4개소 삭제 디스패치에 `ref.type === 'equation'` 분기 추가:
  - `input-handler-keyboard.ts` (Backspace, Ctrl+X, Ctrl+X in Ctrl handler)
  - `input-handler.ts` (cut handler)
  - `input-handler-picture.ts` (`deleteObjectControl` helper)
  - `command/commands/insert.ts` (object:delete command)
- `wasm-bridge.ts`에 `deleteEquationControl` wrapper 추가

## 검증

- `cargo test --release` ✅ ALL GREEN
- `cargo clippy -- -D warnings` ✅ 경고 없음
- `tsc --noEmit` ✅ (기존 @wasm 모듈 에러 외 신규 없음)

감사합니다.