### PR TITLE
fix: 도구 모음 클릭 시 마우스 드래그 선택 보존 (closes #780)

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -176,6 +176,17 @@ async function initialize(): Promise<void> {
       document.querySelectorAll('.tb-split.open').forEach(s => s.classList.remove('open'));
     });
 
+    // #780: 도구 모음/서식 도구 모음 영역 mousedown 시 focus 이동 방지
+    // — 편집 영역의 텍스트 선택(cursor.anchor)이 보존되어야 서식 적용이 동작함
+    for (const id of ['icon-toolbar', 'style-bar']) {
+      const el = document.getElementById(id);
+      if (el) el.addEventListener('mousedown', (e) => {
+        if ((e.target as HTMLElement).tagName !== 'INPUT' && (e.target as HTMLElement).tagName !== 'SELECT') {
+          e.preventDefault();
+        }
+      });
+    }
+
     setupFileInput();
     setupZoomControls();
     setupEventListeners();


### PR DESCRIPTION
## 요약

마우스 드래그로 텍스트 블럭 선택 후 서식 도구 모음(style-bar) 또는 도구 상자(icon-toolbar) 버튼 클릭 시 폰트 크기 변경 등 서식 적용이 동작하지 않는 문제 수정.

## 원인

개별 버튼에 `mousedown` → `preventDefault()` 처리가 되어 있으나, 버튼 간 빈 영역/라벨 클릭 시 브라우저 기본 동작(focus 이동)으로 hidden textarea가 blur → `cursor.hasSelection()` false 반환 → `format-char` / `adjustFontSize` 조기 종료.

## 수정 내용

`#icon-toolbar`, `#style-bar` 컨테이너에 mousedown `preventDefault` 추가:
- `<input>`, `<select>` 요소는 제외 (글꼴명/크기 입력 필드는 사용자 포커스 필요)
- 그 외 모든 mousedown 이벤트에서 `preventDefault()` 호출

## 검증

- `tsc --noEmit` ✅ (기존 @wasm 모듈 에러 외 신규 없음)
- 키보드 선택 (Shift+Arrow) 경로: 변경 사항 영향 없음 (기존 동작 유지)

감사합니다.