### PR TITLE
fix: 표 셀 검정 배경 렌더링 — pattern_type 검사 누락 수정 (closes #782)

### DIFF
--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -692,9 +692,10 @@ fn resolve_border_styles(doc_info: &DocInfo) -> Vec<ResolvedBorderStyle> {
 fn resolve_single_border_style(bf: &BorderFill) -> ResolvedBorderStyle {
     let fill_color = match bf.fill.fill_type {
         FillType::Solid => bf.fill.solid.as_ref().and_then(|s| {
+            // pattern_type > 0: 패턴 채우기 → 단색 fill 아님 (background_color는 패턴 배경)
             // ColorRef 상위 바이트가 0이 아니면 "채우기 없음" (투명)
             // 0xFFFFFFFF = CLR_INVALID/CLR_DEFAULT (Windows COLORREF)
-            if (s.background_color >> 24) != 0 {
+            if s.pattern_type > 0 || (s.background_color >> 24) != 0 {
                 None
             } else {
                 Some(s.background_color)


### PR DESCRIPTION
## 요약

HWP 문서의 표 셀이 검정 배경으로 렌더링되는 문제 수정.

## 원인

`style_resolver.rs`의 `resolve_single_border_style`에서 셀 `fill_color` 결정 시 `pattern_type` 검사 누락:

```rust
// 기존: alpha만 검사
if (s.background_color >> 24) != 0 { None }

// 수정: pattern_type + alpha 검사
if s.pattern_type > 0 || (s.background_color >> 24) != 0 { None }
```

`pattern_type > 0`일 때 `background_color`는 패턴의 배경색이지 셀의 단색 fill이 아님.
`layout/utils.rs`(도형 경로)는 이미 동일 로직 적용 중이었으나 `style_resolver.rs`(표 셀 경로)만 누락.

## 영향

- `samples/aift.hwp` 페이지 2 등 패턴 채우기 사용 표에서 검정 배경 제거
- PR #744 (HWPX ColorRef alpha) 와 별도 — HWP 전용 수정

## 검증

- `cargo test --release` ✅ ALL GREEN
- `cargo clippy -- -D warnings` ✅ 경고 없음

감사합니다.