### PR TITLE
feat: Alt/Option+Arrow 단어 단위 커서 이동 (#223)

### DIFF
--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -544,16 +544,16 @@ export class CursorState {
     const cpi = pos.cellParaIndex!;
 
     try {
-      const text = this.wasm.getTextInCell(sec, ppi, ci, cei, cpi, 0, 9999);
-      const paraLen = text.length;
+      const paraLen = this.wasm.getCellParagraphLength(sec, ppi, ci, cei, cpi);
 
       if (direction === 1) {
         if (pos.charOffset >= paraLen) {
           this.moveHorizontal(1);
           return;
         }
-        const slice = text.slice(pos.charOffset, pos.charOffset + 50);
-        const offset = findWordBoundaryForward(slice);
+        const remaining = paraLen - pos.charOffset;
+        const text = this.wasm.getTextInCell(sec, ppi, ci, cei, cpi, pos.charOffset, Math.min(remaining, 50));
+        const offset = findWordBoundaryForward(text);
         this.position = { ...pos, charOffset: pos.charOffset + offset };
       } else {
         if (pos.charOffset <= 0) {
@@ -561,8 +561,9 @@ export class CursorState {
           return;
         }
         const start = Math.max(0, pos.charOffset - 50);
-        const slice = text.slice(start, pos.charOffset);
-        const offset = findWordBoundaryBackward(slice);
+        const count = pos.charOffset - start;
+        const text = this.wasm.getTextInCell(sec, ppi, ci, cei, cpi, start, count);
+        const offset = findWordBoundaryBackward(text);
         this.position = { ...pos, charOffset: start + offset };
       }
       this.updateRect();

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -490,6 +490,88 @@ export class CursorState {
     }
   }
 
+  // ─── 단어 단위 이동 (Alt/Option+Arrow) ────────────────
+
+  /** 단어 경계로 이동 (direction: -1=왼쪽, +1=오른쪽) */
+  moveToWordBoundary(direction: -1 | 1): void {
+    this.preferredX = null;
+    const pos = this.position;
+
+    if (this.isInCell() && !this.isInTextBox()) {
+      this.moveToWordBoundaryInCell(direction);
+      return;
+    }
+
+    try {
+      const sec = pos.sectionIndex;
+      const para = pos.paragraphIndex;
+      const paraLen = this.wasm.getParagraphLength(sec, para);
+
+      if (direction === 1) {
+        if (pos.charOffset >= paraLen) {
+          // 문단 끝 → 다음 문단 시작으로 이동
+          this.moveHorizontal(1);
+          return;
+        }
+        const remaining = paraLen - pos.charOffset;
+        const text = this.wasm.getTextRange(sec, para, pos.charOffset, Math.min(remaining, 50));
+        const offset = findWordBoundaryForward(text);
+        this.position = { ...pos, charOffset: pos.charOffset + offset };
+      } else {
+        if (pos.charOffset <= 0) {
+          // 문단 시작 → 이전 문단 끝으로 이동
+          this.moveHorizontal(-1);
+          return;
+        }
+        const start = Math.max(0, pos.charOffset - 50);
+        const count = pos.charOffset - start;
+        const text = this.wasm.getTextRange(sec, para, start, count);
+        const offset = findWordBoundaryBackward(text);
+        this.position = { ...pos, charOffset: start + offset };
+      }
+      this.updateRect();
+    } catch (e) {
+      console.warn('[CursorState] moveToWordBoundary 실패:', e);
+    }
+  }
+
+  private moveToWordBoundaryInCell(direction: -1 | 1): void {
+    const pos = this.position;
+    const sec = pos.sectionIndex;
+    const ppi = pos.parentParaIndex!;
+    const ci = pos.controlIndex!;
+    const cei = pos.cellIndex!;
+    const cpi = pos.cellParaIndex!;
+
+    try {
+      const text = this.wasm.getTextInCell(sec, ppi, ci, cei, cpi, 0, 9999);
+      const paraLen = text.length;
+
+      if (direction === 1) {
+        if (pos.charOffset >= paraLen) {
+          this.moveHorizontal(1);
+          return;
+        }
+        const slice = text.slice(pos.charOffset, pos.charOffset + 50);
+        const offset = findWordBoundaryForward(slice);
+        this.position = { ...pos, charOffset: pos.charOffset + offset };
+      } else {
+        if (pos.charOffset <= 0) {
+          this.moveHorizontal(-1);
+          return;
+        }
+        const start = Math.max(0, pos.charOffset - 50);
+        const slice = text.slice(start, pos.charOffset);
+        const offset = findWordBoundaryBackward(slice);
+        this.position = { ...pos, charOffset: start + offset };
+      }
+      this.updateRect();
+    } catch (e) {
+      console.warn('[CursorState] moveToWordBoundaryInCell 실패:', e);
+      this.moveHorizontal(direction);
+    }
+  }
+
   // ─── 셀 탐색 (Tab/Shift+Tab) ──────────────────────────
 
   /** 읽기 순서(row → col)로 정렬된 cellIdx 배열을 반환한다 */
@@ -1234,4 +1316,49 @@ export class CursorState {
 
     this.updateRect();
   }
+}
+
+// ─── 단어 경계 탐색 유틸 ──────────────────────────────────
+
+const enum CharClass { Space, Hangul, Latin, Digit, Punct }
+
+function classifyChar(ch: string): CharClass {
+  const c = ch.charCodeAt(0);
+  if (c === 0x20 || c === 0x09 || c === 0x0A || c === 0x0D || c === 0xA0) return CharClass.Space;
+  if (c >= 0xAC00 && c <= 0xD7AF) return CharClass.Hangul; // 완성형
+  if (c >= 0x3131 && c <= 0x318E) return CharClass.Hangul; // 자모
+  if (c >= 0x1100 && c <= 0x11FF) return CharClass.Hangul; // 첫가끝
+  if ((c >= 0x41 && c <= 0x5A) || (c >= 0x61 && c <= 0x7A)) return CharClass.Latin;
+  if (c >= 0x30 && c <= 0x39) return CharClass.Digit;
+  return CharClass.Punct;
+}
+
+function findWordBoundaryForward(text: string): number {
+  if (text.length === 0) return 0;
+  const startClass = classifyChar(text[0]);
+  let i = 0;
+  // Skip current word (same class)
+  if (startClass === CharClass.Space) {
+    while (i < text.length && classifyChar(text[i]) === CharClass.Space) i++;
+  } else {
+    while (i < text.length && classifyChar(text[i]) === startClass) i++;
+    // Also skip trailing spaces
+    while (i < text.length && classifyChar(text[i]) === CharClass.Space) i++;
+  }
+  return i || 1;
+}
+
+function findWordBoundaryBackward(text: string): number {
+  if (text.length === 0) return 0;
+  let i = text.length;
+  const endClass = classifyChar(text[i - 1]);
+  // Skip trailing spaces
+  if (endClass === CharClass.Space) {
+    while (i > 0 && classifyChar(text[i - 1]) === CharClass.Space) i--;
+  }
+  if (i === 0) return 0;
+  // Skip the word (same class)
+  const wordClass = classifyChar(text[i - 1]);
+  while (i > 0 && classifyChar(text[i - 1]) === wordClass) i--;
+  return i;
 }

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -679,8 +679,8 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     return;
   }
 
-  // Alt 조합 단축키 처리
-  if (e.altKey && this.dispatcher) {
+  // Alt 조합 단축키 처리 (Alt+Arrow는 단어 이동 → 아래 Arrow case에서 처리)
+  if (e.altKey && !e.key.startsWith('Arrow') && this.dispatcher) {
     // Alt+V → Chord 대기 (보기 메뉴 단축키, 한컴 Alt+V,T 계승)
     if ((e.key === 'v' || e.key === 'V' || e.key === 'ㅍ') && !e.shiftKey && !e.ctrlKey) {
       e.preventDefault();
@@ -739,6 +739,11 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       e.preventDefault();
       if (this.cursor.hasSelection()) {
         this.deleteSelection();
+      } else if (e.altKey) {
+        // Alt/Option+Backspace: 단어 삭제 (macOS standard)
+        this.cursor.setAnchor();
+        this.cursor.moveToWordBoundary(e.key === 'Backspace' ? -1 : 1);
+        if (this.cursor.hasSelection()) this.deleteSelection();
       } else if (e.key === 'Backspace') {
         this.handleBackspace(pos, inCell);
       } else {
@@ -764,6 +769,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     case 'ArrowUp':
     case 'ArrowDown': {
       e.preventDefault();
+      // Alt/Option+Arrow: 단어 단위 이동 (macOS standard)
+      if (e.altKey && (e.key === 'ArrowLeft' || e.key === 'ArrowRight')) {
+        if (e.shiftKey) this.cursor.setAnchor();
+        else this.cursor.clearSelection();
+        this.cursor.moveToWordBoundary(e.key === 'ArrowLeft' ? -1 : 1);
+        this.updateCaret();
+        if (e.shiftKey) this.updateSelection();
+        break;
+      }
       const vertical = this.cursor.isInVerticalCell();
       // 세로쓰기 셀: ↑↓=글자이동(horizontal), ←→=줄이동(vertical)
       // 가로쓰기:    ←→=글자이동(horizontal), ↑↓=줄이동(vertical)

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -740,7 +740,7 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       if (this.cursor.hasSelection()) {
         this.deleteSelection();
       } else if (e.altKey) {
-        // Alt/Option+Backspace: 단어 삭제 (macOS standard)
+        // Alt/Option+Backspace/Delete: 단어 삭제 (macOS standard)
         this.cursor.setAnchor();
         this.cursor.moveToWordBoundary(e.key === 'Backspace' ? -1 : 1);
         if (this.cursor.hasSelection()) this.deleteSelection();


### PR DESCRIPTION
## 요약

macOS 표준 단어 이동 단축키 구현:

- **Option+←/→**: 단어 단위 커서 이동
- **Option+Shift+←/→**: 단어 단위 선택 확장
- **Option+Backspace**: 이전 단어 삭제
- **Option+Delete**: 다음 단어 삭제

## 구현

1. `CursorState.moveToWordBoundary(direction)` — 단어 경계 탐색 후 커서 이동
2. 문자 클래스 기반 경계 탐지 (한글/영문/숫자/공백/구두점 5종)
3. 본문 및 표 셀 내부 모두 지원 (`getTextRange` / `getTextInCell` 활용)
4. Alt 단축키 핸들러에서 Arrow 키 제외 가드 추가

## 문자 클래스 경계 규칙

- 같은 클래스 문자열을 하나의 "단어"로 취급
- 전진 시: 현재 단어 끝 + 후행 공백 건너뜀
- 후진 시: 선행 공백 건너뜀 + 이전 단어 시작까지

## 테스트

- `cargo test` + `cargo clippy` 통과
- TypeScript 타입 검사 통과 (WASM 모듈 제외 기존 에러만)

감사합니다.