### PR TITLE
fix: 표 셀 내부 드래그 선택 시 셀 컨텍스트 이탈 방지 (#669)

### DIFF
--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -1073,6 +1073,20 @@ export function onMouseMove(this: any, e: MouseEvent): void {
       if (!this.isDragging) return;
       const hit = this.hitTestFromEvent(e);
       if (hit && hit.paragraphIndex < 0xFFFFFF00) {
+        // 셀 내부 드래그: anchor와 같은 셀 컨텍스트인 경우만 커서 이동
+        // 셀↔본문 혼합은 선택 렌더링 불가이므로 무시
+        const sel = this.cursor.getSelection();
+        if (sel) {
+          const anchorInCell = sel.anchor.parentParaIndex !== undefined;
+          const hitInSameCell = anchorInCell &&
+            hit.parentParaIndex === sel.anchor.parentParaIndex &&
+            hit.controlIndex === sel.anchor.controlIndex &&
+            hit.cellIndex === sel.anchor.cellIndex;
+          if (anchorInCell && !hitInSameCell) {
+            // anchor가 셀이지만 hit가 다른 위치 → 무시 (셀 내 선택 유지)
+            return;
+          }
+        }
         this.cursor.moveTo(hit);
         this.updateCaret();
       }


### PR DESCRIPTION
## 문제

표 셀 내부에서 텍스트를 드래그 선택하면 선택이 보이지 않고 커서만 이동하는 현상.

## 원인 분석

드래그 중 `hitTest`가 셀 내부의 빈 영역(텍스트 라인 외부)에서 본문 레벨 위치를 반환하면:
- anchor: 셀 내부 (`parentParaIndex` 있음)
- focus: 본문 (`parentParaIndex` 없음)

`updateSelection()`에서 이 조합은 "셀↔본문 혼합 선택"으로 판별되어 `selectionRenderer.clear()`가 호출됨. 결과적으로 선택 하이라이트가 렌더링되지 않음.

## 수정

드래그 핸들러(`onMouseMove`)에서 anchor가 셀 내부일 때, hitTest 결과가 같은 셀 컨텍스트(`parentParaIndex`/`controlIndex`/`cellIndex` 일치)가 아니면 커서 이동을 건너뜀.

이로써 셀 내부 드래그 시 커서가 항상 같은 셀 내에 머물러 선택 렌더링이 정상 동작함.

## 테스트

- TypeScript 타입 검사 통과
- `cargo test` + `cargo clippy` 통과

감사합니다.