### PR TITLE
render: add Text IR v2 compatibility contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,7 +207,7 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 ### Multi-Renderer Backends (멀티 렌더러 백엔드)
 - `PageRenderTree` can be lowered into a `PageLayerTree` paint IR before backend replay.
 - P1 public surfaces are Rust native `DocumentCore::build_page_layer_tree(page)` and WASM `getPageLayerTree(page)`.
-- Layer JSON starts at `schemaVersion: 1`, uses `unit: "px"`, and uses `coordinateSystem: "page-top-left"` to match the existing page render coordinates.
+- Layer JSON starts at `schemaVersion: 1`, uses additive `schemaMinorVersion` / `resourceTableMinorVersion`, `unit: "px"`, and `coordinateSystem: "page-top-left-y-down"` to match the existing page render coordinates.
 - Compatible schema changes should be additive; incompatible JSON shape changes require a schema version bump.
 - **Legacy SVG** remains the default compatibility output.
 - **Layered SVG** can be exercised with `RHWP_RENDER_PATH=layer-svg`.
@@ -220,6 +220,7 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P5 adds native Skia equation replay from `EquationNode.layout_box`, so equations are no longer placeholder boxes in the PNG path.
 - P5 replays the existing equation layout tree directly; it does not add CanvasKit equation replay or native form replay.
 - P6 adds native Skia `RawSvg` fragment rasterization through `resvg`, with external file href loading disabled.
+- P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path; `GlyphRun` and native glyph replay stay as follow-up work.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
 - The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -1,0 +1,67 @@
+# Text IR v2 Migration Contract
+
+This document records the P11 text paint contract for the layered renderer.
+The goal is to make source identity and future text variants explicit without
+breaking the existing `TextRun` replay path.
+
+## Current Position
+
+`TextRun` remains the compatibility paint contract. It still carries the text
+projection, style, explicit positions, HWP text flags, and legacy visual
+payloads that SVG, Canvas2D, and native Skia can replay with existing string
+APIs.
+
+P11 does not make glyph ids canonical. Portable `GlyphRun` replay needs exact
+font bytes or a verified font face, face index, synthetic style flags, shaping
+features, script/language, fallback policy, and diagnostics. Those remain a
+follow-up phase.
+
+## Export Contract
+
+Layer JSON now provides additive text metadata:
+
+- `schemaMinorVersion` and `resourceTableMinorVersion` for compatible schema
+  growth under major version 1.
+- `usedFeatures`, `requiredFeatures`, `optionalFeatures`, and `knownFeatures`
+  so consumers can decide what they can safely replay.
+- `textSources`, an export-local table of source text entries.
+- `TextRun.source`, a span into `textSources`.
+- `TextRun.paintStyle`, the paint-visible style projection.
+- `TextRun.projectionKind`, describing how `TextRun.text` relates to source.
+- `TextRun.placement`, run-local-to-page transform metadata.
+- `TextRun.clusterBasis` and `TextRun.clusters`, additive layout placement
+  clusters. These are not shaped glyph clusters.
+- `TextRun.legacyVisuals`, marking legacy inline visual payloads as mirrors
+  when a separate visual op exists.
+- Explicit special visual ops: `charOverlap`, `textControlMark`, `tabLeader`,
+  and `textDecoration`.
+
+The explicit visual ops are additive. Existing renderers skip them and keep
+drawing the paired `TextRun` mirror, so visual output does not double-paint.
+Future backends can choose the explicit op and suppress the corresponding
+legacy mirror.
+
+## Invariants
+
+- `schemaVersion` and `resourceTableVersion` stay major integer versions for
+  v1 compatibility.
+- Compatible changes use minor versions and feature arrays.
+- Source ranges are UTF-8 byte ranges. UTF-16 ranges are also exported for JS
+  and DOM consumers.
+- `TextRun.text` is a replay projection, not the long-term source identity.
+- `TextRun.placement` and clusters are metadata while
+  `text.placementAuthority` is `compatibilityProjection`.
+- `TextRun` source ids are dense and export-local. They must not be used as
+  cross-document or cross-export stable ids.
+- Field marker, paragraph-end, and line-break metadata also appear as source
+  annotations.
+- P11 does not enable `GlyphRun`, CanvasKit glyph replay, or native glyph
+  outline replay. Those require a guarded variant selection contract.
+
+## Follow-Ups
+
+- Add guarded `GlyphRun` variants only when exact or verified font identity is
+  available.
+- Add native glyph outline/glyph run replay behind the variant gate.
+- Add resource table entries for font blobs and face identity.
+- Promote renderer diagnostics once glyph alternatives exist.

--- a/src/paint/builder.rs
+++ b/src/paint/builder.rs
@@ -1,7 +1,8 @@
+use crate::model::style::UnderlineType;
 use crate::paint::layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
 };
-use crate::paint::paint_op::PaintOp;
+use crate::paint::paint_op::{PaintOp, TextDecorationKind};
 use crate::paint::profile::RenderProfile;
 use crate::renderer::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
 
@@ -59,10 +60,9 @@ impl LayerBuilder {
                 bbox: node.bbox,
                 background: background.clone(),
             }]),
-            RenderNodeType::TextRun(run) => Some(vec![PaintOp::TextRun {
-                bbox: node.bbox,
-                run: run.clone(),
-            }]),
+            RenderNodeType::TextRun(run) => {
+                Some(text_run_ops(node.bbox, run.clone(), self.output_options))
+            }
             RenderNodeType::FootnoteMarker(marker) => Some(vec![PaintOp::FootnoteMarker {
                 bbox: node.bbox,
                 marker: marker.clone(),
@@ -201,18 +201,87 @@ impl LayerBuilder {
     }
 }
 
+fn text_run_ops(
+    bbox: crate::renderer::render_tree::BoundingBox,
+    run: crate::renderer::render_tree::TextRunNode,
+    output_options: LayerOutputOptions,
+) -> Vec<PaintOp> {
+    let has_char_overlap = run.char_overlap.is_some();
+    let has_control_mark =
+        (output_options.show_paragraph_marks || output_options.show_control_codes)
+            && (run.field_marker != Default::default() || run.is_para_end || run.is_line_break_end);
+    let has_tab_leader = !run.style.tab_leaders.is_empty();
+    let has_underline = run.style.underline != UnderlineType::None;
+    let has_strikethrough = run.style.strikethrough;
+    let has_emphasis_dot = run.style.emphasis_dot > 0;
+
+    let mut ops = Vec::with_capacity(
+        1 + has_char_overlap as usize
+            + has_control_mark as usize
+            + has_tab_leader as usize
+            + has_underline as usize
+            + has_strikethrough as usize
+            + has_emphasis_dot as usize,
+    );
+    ops.push(PaintOp::TextRun {
+        bbox,
+        run: run.clone(),
+    });
+    if has_char_overlap {
+        ops.push(PaintOp::CharOverlap {
+            bbox,
+            run: run.clone(),
+        });
+    }
+    if has_control_mark {
+        ops.push(PaintOp::TextControlMark {
+            bbox,
+            run: run.clone(),
+        });
+    }
+    if has_tab_leader {
+        ops.push(PaintOp::TabLeader {
+            bbox,
+            run: run.clone(),
+        });
+    }
+    if has_underline {
+        ops.push(PaintOp::TextDecoration {
+            bbox,
+            run: run.clone(),
+            kind: TextDecorationKind::Underline,
+        });
+    }
+    if has_strikethrough {
+        ops.push(PaintOp::TextDecoration {
+            bbox,
+            run: run.clone(),
+            kind: TextDecorationKind::Strikethrough,
+        });
+    }
+    if has_emphasis_dot {
+        ops.push(PaintOp::TextDecoration {
+            bbox,
+            run,
+            kind: TextDecorationKind::EmphasisDot,
+        });
+    }
+    ops
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::model::control::FormType;
+    use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
     use crate::renderer::render_tree::{
-        BoundingBox, EllipseNode, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
-        LineNode, PageBackgroundNode, PageNode, PathNode, PlaceholderNode, RawSvgNode,
-        RectangleNode, RenderNode, RenderNodeType, TableCellNode, TableNode, TextLineNode,
-        TextRunNode,
+        BoundingBox, EllipseNode, EquationNode, FieldMarkerType, FootnoteMarkerNode,
+        FormObjectNode, ImageNode, LineNode, PageBackgroundNode, PageNode, PathNode,
+        PlaceholderNode, RawSvgNode, RectangleNode, RenderNode, RenderNodeType, TableCellNode,
+        TableNode, TextLineNode, TextRunNode,
     };
-    use crate::renderer::{LineStyle, PathCommand, ShapeStyle, TextStyle};
+    use crate::renderer::{LineStyle, PathCommand, ShapeStyle, TabLeaderInfo, TextStyle};
 
     #[test]
     fn builds_body_clip_layer() {
@@ -456,6 +525,78 @@ mod tests {
             panic!("expected child text paint op second");
         };
         assert!(matches!(label_ops[0], PaintOp::TextRun { .. }));
+    }
+
+    #[test]
+    fn lowers_text_special_visuals_to_external_paint_ops() {
+        let mut run = text_run("special\ttext");
+        run.field_marker = FieldMarkerType::FieldBegin;
+        run.is_para_end = true;
+        run.char_overlap = Some(CharOverlapInfo {
+            border_type: 1,
+            inner_char_size: 90,
+        });
+        run.style.tab_leaders.push(TabLeaderInfo {
+            start_x: 12.0,
+            end_x: 36.0,
+            fill_type: 3,
+        });
+        run.style.underline = UnderlineType::Bottom;
+        run.style.strikethrough = true;
+        run.style.emphasis_dot = 2;
+
+        let mut tree = PageRenderTree::new(0, 100.0, 100.0);
+        tree.root.children.push(RenderNode::new(
+            1,
+            RenderNodeType::TextRun(run),
+            BoundingBox::new(1.0, 2.0, 80.0, 20.0),
+        ));
+
+        let mut builder = LayerBuilder::new(RenderProfile::Screen).with_output_options(
+            LayerOutputOptions {
+                show_paragraph_marks: true,
+                show_control_codes: true,
+                ..Default::default()
+            },
+        );
+        let layer_tree = builder.build(&tree);
+
+        let LayerNodeKind::Group { children, .. } = &layer_tree.root.kind else {
+            panic!("expected root group");
+        };
+        let LayerNodeKind::Leaf { ops } = &children[0].kind else {
+            panic!("expected text leaf");
+        };
+
+        assert!(matches!(ops[0], PaintOp::TextRun { .. }));
+        assert!(ops
+            .iter()
+            .any(|op| matches!(op, PaintOp::CharOverlap { .. })));
+        assert!(ops
+            .iter()
+            .any(|op| matches!(op, PaintOp::TextControlMark { .. })));
+        assert!(ops.iter().any(|op| matches!(op, PaintOp::TabLeader { .. })));
+        assert!(ops.iter().any(|op| matches!(
+            op,
+            PaintOp::TextDecoration {
+                kind: TextDecorationKind::Underline,
+                ..
+            }
+        )));
+        assert!(ops.iter().any(|op| matches!(
+            op,
+            PaintOp::TextDecoration {
+                kind: TextDecorationKind::Strikethrough,
+                ..
+            }
+        )));
+        assert!(ops.iter().any(|op| matches!(
+            op,
+            PaintOp::TextDecoration {
+                kind: TextDecorationKind::EmphasisDot,
+                ..
+            }
+        )));
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -8,7 +8,8 @@ use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
-    RenderProfile, LAYER_TREE_SCHEMA,
+    RenderProfile, TextDecorationKind, TextSourceAnnotation, TextSourceEntry, TextSourceId,
+    TextSourceRange, TextSourceSpan, TextSourceTable, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
@@ -23,9 +24,15 @@ impl PageLayerTree {
         buf.push('{');
         let _ = write!(
             buf,
-            "\"schemaVersion\":{},\"resourceTableVersion\":{},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
+            "\"schemaVersion\":{},\"schemaMinorVersion\":{},\"schema\":{{\"major\":{},\"minor\":{}}},\"resourceTableVersion\":{},\"resourceTableMinorVersion\":{},\"resourceTable\":{{\"major\":{},\"minor\":{}}},\"unit\":{},\"coordinateSystem\":{},\"profile\":{},\"outputOptions\":{{\"showParagraphMarks\":{},\"showControlCodes\":{},\"showTransparentBorders\":{},\"clipEnabled\":{},\"debugOverlay\":{}}},\"pageWidth\":{:.3},\"pageHeight\":{:.3},\"root\":",
             LAYER_TREE_SCHEMA.schema_version,
+            LAYER_TREE_SCHEMA.schema_minor_version,
+            LAYER_TREE_SCHEMA.schema_version,
+            LAYER_TREE_SCHEMA.schema_minor_version,
             LAYER_TREE_SCHEMA.resource_table_version,
+            LAYER_TREE_SCHEMA.resource_table_minor_version,
+            LAYER_TREE_SCHEMA.resource_table_version,
+            LAYER_TREE_SCHEMA.resource_table_minor_version,
             json_escape(LAYER_TREE_SCHEMA.unit),
             json_escape(LAYER_TREE_SCHEMA.coordinate_system),
             json_escape(render_profile_str(self.profile)),
@@ -37,14 +44,87 @@ impl PageLayerTree {
             self.page_width,
             self.page_height
         );
-        self.root.write_json(&mut buf);
+        let mut text_source_state = TextSourceExportState::default();
+        self.root.write_json(&mut buf, &mut text_source_state);
+        buf.push_str(",\"textSources\":");
+        write_text_source_entries(&mut buf, &self.text_sources);
+        write_text_export_metadata(&mut buf, &self.root);
         buf.push('}');
         buf
     }
 }
 
+fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
+    let externalized_visuals = externalized_text_visuals(root);
+    buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.projectionKind\",\"text.legacyVisuals\"");
+    if externalized_visuals.contains(&"charOverlap") {
+        buf.push_str(",\"text.charOverlapOp\"");
+    }
+    if externalized_visuals.contains(&"controlMarks") {
+        buf.push_str(",\"text.controlMarkOp\"");
+    }
+    if externalized_visuals.contains(&"tabLeaders") {
+        buf.push_str(",\"text.tabLeaderOp\"");
+    }
+    if externalized_visuals.contains(&"decorations") {
+        buf.push_str(",\"text.decorationOp\"");
+    }
+    buf.push_str("],\"optionalFeatures\":[],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"],\"variantSelection\":\"exclusiveVariantSet\",\"sourceTextPreserved\":true,\"clusterEncoding\":[\"utf8\",\"utf16\"],\"fallbackRequired\":true,\"placementAuthority\":\"compatibilityProjection\",\"externalizedVisuals\":[");
+    for (idx, visual) in externalized_visuals.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        buf.push_str(&json_escape(visual));
+    }
+    buf.push_str("]}");
+}
+
+fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {
+    let mut has_char_overlap = false;
+    let mut has_control_marks = false;
+    let mut has_tab_leaders = false;
+    let mut has_decorations = false;
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    stack.push(child);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
+            LayerNodeKind::Leaf { ops } => {
+                has_char_overlap |= ops
+                    .iter()
+                    .any(|op| matches!(op, PaintOp::CharOverlap { .. }));
+                has_control_marks |= ops
+                    .iter()
+                    .any(|op| matches!(op, PaintOp::TextControlMark { .. }));
+                has_tab_leaders |= ops.iter().any(|op| matches!(op, PaintOp::TabLeader { .. }));
+                has_decorations |= ops
+                    .iter()
+                    .any(|op| matches!(op, PaintOp::TextDecoration { .. }));
+            }
+        }
+    }
+    let mut visuals = Vec::new();
+    if has_char_overlap {
+        visuals.push("charOverlap");
+    }
+    if has_control_marks {
+        visuals.push("controlMarks");
+    }
+    if has_tab_leaders {
+        visuals.push("tabLeaders");
+    }
+    if has_decorations {
+        visuals.push("decorations");
+    }
+    visuals
+}
+
 impl LayerNode {
-    fn write_json(&self, buf: &mut String) {
+    fn write_json(&self, buf: &mut String, text_sources: &mut TextSourceExportState) {
         buf.push('{');
         buf.push_str("\"bounds\":");
         write_bbox(buf, self.bounds);
@@ -69,7 +149,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    child.write_json(buf);
+                    child.write_json(buf, text_sources);
                 }
                 buf.push(']');
             }
@@ -86,15 +166,16 @@ impl LayerNode {
                     json_escape(clip_kind_str(*clip_kind))
                 );
                 buf.push_str(",\"child\":");
-                child.write_json(buf);
+                child.write_json(buf, text_sources);
             }
             LayerNodeKind::Leaf { ops } => {
                 buf.push_str(",\"kind\":\"leaf\",\"ops\":[");
+                let leaf_visuals = LeafTextVisualOps::from_ops(ops);
                 for (idx, op) in ops.iter().enumerate() {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf);
+                    op.write_json(buf, text_sources, leaf_visuals);
                 }
                 buf.push(']');
             }
@@ -104,7 +185,12 @@ impl LayerNode {
 }
 
 impl PaintOp {
-    fn write_json(&self, buf: &mut String) {
+    fn write_json(
+        &self,
+        buf: &mut String,
+        text_sources: &mut TextSourceExportState,
+        leaf_visuals: LeafTextVisualOps,
+    ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
                 buf.push('{');
@@ -144,16 +230,28 @@ impl PaintOp {
                 buf.push('{');
                 buf.push_str("\"type\":\"textRun\",\"bbox\":");
                 write_bbox(buf, *bbox);
+                let source = text_sources.next_text_run_span(run);
                 let _ = write!(
                     buf,
-                    ",\"text\":{},\"baseline\":{:.3},\"rotation\":{:.3},\"isVertical\":{}",
+                    ",\"text\":{},\"baseline\":{:.3},\"rotation\":{:.3},\"isVertical\":{},\"orientation\":{},\"projectionKind\":{},\"clusterBasis\":\"legacyPosition\"",
                     json_escape(&run.text),
                     run.baseline,
                     run.rotation,
                     run.is_vertical,
+                    json_escape(text_orientation_str(run)),
+                    json_escape(text_projection_kind_str(run)),
                 );
+                buf.push_str(",\"placement\":");
+                write_text_run_placement(buf, *bbox, run);
+                buf.push_str(",\"clusters\":");
+                write_text_clusters(buf, run);
+                buf.push_str(",\"source\":");
+                write_text_source_span(buf, &source);
                 buf.push_str(",\"style\":");
                 write_text_style(buf, &run.style);
+                buf.push_str(",\"paintStyle\":");
+                write_text_style(buf, &run.style);
+                write_text_legacy_visuals(buf, run, leaf_visuals);
                 buf.push_str(",\"positions\":");
                 write_text_positions(buf, run);
                 if !run.style.tab_leaders.is_empty() {
@@ -168,6 +266,83 @@ impl PaintOp {
                 write_field_marker(buf, run.field_marker);
                 buf.push_str(",\"charOverlap\":");
                 write_char_overlap(buf, run.char_overlap.as_ref());
+                buf.push('}');
+            }
+            PaintOp::CharOverlap { bbox, run } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"charOverlap\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                if let Some(source) = text_sources.last_source.as_ref() {
+                    buf.push_str(",\"source\":");
+                    write_text_source_span(buf, source);
+                }
+                let _ = write!(
+                    buf,
+                    ",\"text\":{},\"baseline\":{:.3},\"rotation\":{:.3},\"isVertical\":{},\"orientation\":{}",
+                    json_escape(&run.text),
+                    run.baseline,
+                    run.rotation,
+                    run.is_vertical,
+                    json_escape(text_orientation_str(run)),
+                );
+                buf.push_str(",\"style\":");
+                write_text_style(buf, &run.style);
+                buf.push_str(",\"paintStyle\":");
+                write_text_style(buf, &run.style);
+                buf.push_str(",\"positions\":");
+                write_text_positions(buf, run);
+                buf.push_str(",\"charOverlap\":");
+                write_char_overlap(buf, run.char_overlap.as_ref());
+                buf.push('}');
+            }
+            PaintOp::TextControlMark { bbox, run } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"textControlMark\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                if let Some(source) = text_sources.last_source.as_ref() {
+                    buf.push_str(",\"source\":");
+                    write_text_source_span(buf, source);
+                }
+                let _ = write!(
+                    buf,
+                    ",\"fieldMarker\":{},\"isParaEnd\":{},\"isLineBreakEnd\":{}",
+                    json_escape(field_marker_str(run.field_marker)),
+                    run.is_para_end,
+                    run.is_line_break_end,
+                );
+                if let FieldMarkerType::ShapeMarker(index) = run.field_marker {
+                    let _ = write!(buf, ",\"shapeMarkerIndex\":{}", index);
+                }
+                buf.push('}');
+            }
+            PaintOp::TabLeader { bbox, run } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"tabLeader\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                if let Some(source) = text_sources.last_source.as_ref() {
+                    buf.push_str(",\"source\":");
+                    write_text_source_span(buf, source);
+                }
+                buf.push_str(",\"leaders\":");
+                write_tab_leaders(buf, &run.style.tab_leaders);
+                let _ = write!(
+                    buf,
+                    ",\"color\":{},\"fontSize\":{:.3},\"baseline\":{:.3}}}",
+                    json_escape(&color_ref_to_css(run.style.color)),
+                    run.style.font_size,
+                    run.baseline,
+                );
+            }
+            PaintOp::TextDecoration { bbox, run, kind } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"textDecoration\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                if let Some(source) = text_sources.last_source.as_ref() {
+                    buf.push_str(",\"source\":");
+                    write_text_source_span(buf, source);
+                }
+                buf.push_str(",\"decoration\":");
+                write_text_decoration(buf, *kind, run);
                 buf.push('}');
             }
             PaintOp::FootnoteMarker { bbox, marker } => {
@@ -279,8 +454,14 @@ impl PaintOp {
                         } else {
                             (mime, std::borrow::Cow::Borrowed(data.as_slice()))
                         };
-                    let base64_data = base64::engine::general_purpose::STANDARD.encode(&*final_data);
-                    let _ = write!(buf, ",\"mime\":\"{}\",\"base64\":{}", final_mime, json_escape(&base64_data));
+                    let base64_data =
+                        base64::engine::general_purpose::STANDARD.encode(&*final_data);
+                    let _ = write!(
+                        buf,
+                        ",\"mime\":\"{}\",\"base64\":{}",
+                        final_mime,
+                        json_escape(&base64_data)
+                    );
                 }
                 if let Some(fill_mode) = image.fill_mode {
                     let _ = write!(
@@ -392,6 +573,180 @@ fn write_bbox(buf: &mut String, bbox: BoundingBox) {
     );
 }
 
+#[derive(Default)]
+struct TextSourceExportState {
+    next_id: u32,
+    last_source: Option<TextSourceSpan>,
+}
+
+impl TextSourceExportState {
+    fn next_text_run_span(&mut self, run: &TextRunNode) -> TextSourceSpan {
+        let span = TextSourceSpan {
+            id: TextSourceId(self.next_id),
+            utf8_range: TextSourceRange::new(0, run.text.len() as u32),
+            utf16_range: TextSourceRange::new(0, run.text.encode_utf16().count() as u32),
+            stable_source_key: stable_text_source_key(run),
+        };
+        self.next_id = self.next_id.saturating_add(1);
+        self.last_source = Some(span.clone());
+        span
+    }
+}
+
+#[derive(Debug, Clone, Copy, Default)]
+struct LeafTextVisualOps {
+    char_overlap: bool,
+    control_marks: bool,
+    tab_leaders: bool,
+    decorations: bool,
+}
+
+impl LeafTextVisualOps {
+    fn from_ops(ops: &[PaintOp]) -> Self {
+        let mut visuals = Self::default();
+        for op in ops {
+            match op {
+                PaintOp::CharOverlap { .. } => visuals.char_overlap = true,
+                PaintOp::TextControlMark { .. } => visuals.control_marks = true,
+                PaintOp::TabLeader { .. } => visuals.tab_leaders = true,
+                PaintOp::TextDecoration { .. } => visuals.decorations = true,
+                _ => {}
+            }
+        }
+        visuals
+    }
+}
+
+fn stable_text_source_key(run: &TextRunNode) -> Option<String> {
+    let section = run.section_index?;
+    let para = run.para_index?;
+    let char_start = run.char_start.unwrap_or(0);
+    let mut key = format!("section:{section}/para:{para}/char:{char_start}");
+    if let Some(cell) = &run.cell_context {
+        let path = cell
+            .path
+            .iter()
+            .map(|entry| {
+                format!(
+                    "{}:{}:{}:{}",
+                    entry.control_index,
+                    entry.cell_index,
+                    entry.cell_para_index,
+                    entry.text_direction
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(".");
+        key.push_str("/cell:");
+        key.push_str(&cell.parent_para_index.to_string());
+        key.push(':');
+        key.push_str(&path);
+    }
+    Some(key)
+}
+
+fn write_text_source_entries(buf: &mut String, table: &TextSourceTable) {
+    buf.push('[');
+    for (idx, entry) in table.entries.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        write_text_source_entry(buf, entry);
+    }
+    buf.push(']');
+}
+
+fn write_text_source_entry(buf: &mut String, entry: &TextSourceEntry) {
+    let _ = write!(
+        buf,
+        "{{\"id\":{},\"text\":{},\"utf8Range\":",
+        entry.id.0,
+        json_escape(&entry.text),
+    );
+    write_text_source_range(buf, entry.utf8_range);
+    buf.push_str(",\"utf16Range\":");
+    write_text_source_range(buf, entry.utf16_range);
+    if let Some(stable_source_key) = &entry.stable_source_key {
+        let _ = write!(
+            buf,
+            ",\"stableSourceKey\":{}",
+            json_escape(stable_source_key)
+        );
+    }
+    buf.push_str(",\"annotations\":");
+    write_text_source_annotations(buf, &entry.annotations);
+    buf.push('}');
+}
+
+fn write_text_source_span(buf: &mut String, span: &TextSourceSpan) {
+    let _ = write!(buf, "{{\"id\":{},\"utf8Range\":", span.id.0);
+    write_text_source_range(buf, span.utf8_range);
+    buf.push_str(",\"utf16Range\":");
+    write_text_source_range(buf, span.utf16_range);
+    if let Some(stable_source_key) = &span.stable_source_key {
+        let _ = write!(
+            buf,
+            ",\"stableSourceKey\":{}",
+            json_escape(stable_source_key)
+        );
+    }
+    buf.push('}');
+}
+
+fn write_text_source_range(buf: &mut String, range: TextSourceRange) {
+    let _ = write!(buf, "{{\"start\":{},\"end\":{}}}", range.start, range.end);
+}
+
+fn write_text_source_annotations(buf: &mut String, annotations: &[TextSourceAnnotation]) {
+    buf.push('[');
+    for (idx, annotation) in annotations.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        match annotation {
+            TextSourceAnnotation::FieldMarker {
+                marker,
+                range_utf8,
+                range_utf16,
+            } => {
+                let _ = write!(
+                    buf,
+                    "{{\"kind\":\"fieldMarker\",\"marker\":{},\"rangeUtf8\":",
+                    json_escape(field_marker_str(*marker))
+                );
+                write_text_source_range(buf, *range_utf8);
+                buf.push_str(",\"rangeUtf16\":");
+                write_text_source_range(buf, *range_utf16);
+                if let FieldMarkerType::ShapeMarker(index) = marker {
+                    let _ = write!(buf, ",\"shapeMarkerIndex\":{}", index);
+                }
+                buf.push('}');
+            }
+            TextSourceAnnotation::ParagraphEnd {
+                offset_utf8,
+                offset_utf16,
+            } => {
+                let _ = write!(
+                    buf,
+                    "{{\"kind\":\"paragraphEnd\",\"offsetUtf8\":{},\"offsetUtf16\":{}}}",
+                    offset_utf8, offset_utf16
+                );
+            }
+            TextSourceAnnotation::LineBreakEnd {
+                offset_utf8,
+                offset_utf16,
+            } => {
+                let _ = write!(
+                    buf,
+                    "{{\"kind\":\"lineBreakEnd\",\"offsetUtf8\":{},\"offsetUtf16\":{}}}",
+                    offset_utf8, offset_utf16
+                );
+            }
+        }
+    }
+    buf.push(']');
+}
+
 fn write_group_kind(buf: &mut String, group_kind: &GroupKind) {
     match group_kind {
         GroupKind::Generic => buf.push_str("{\"kind\":\"generic\"}"),
@@ -472,18 +827,26 @@ fn write_text_style(buf: &mut String, style: &TextStyle) {
     buf.push('{');
     let _ = write!(
         buf,
-        "\"fontFamily\":{},\"fontSize\":{:.3},\"color\":{},\"bold\":{},\"italic\":{},\"underline\":{},\"strikethrough\":{},\"shadowType\":{},\"shadowColor\":{},\"shadowOffsetX\":{:.3},\"shadowOffsetY\":{:.3},\"underlineColor\":{},\"strikeColor\":{},\"shadeColor\":{},\"emphasisDot\":{}",
+        "\"fontFamily\":{},\"fontSize\":{:.3},\"color\":{},\"bold\":{},\"italic\":{},\"ratio\":{:.6},\"underline\":{},\"underlineShape\":{},\"strikethrough\":{},\"strikeShape\":{},\"outlineType\":{},\"shadowType\":{},\"shadowColor\":{},\"shadowOffsetX\":{:.3},\"shadowOffsetY\":{:.3},\"emboss\":{},\"engrave\":{},\"superscript\":{},\"subscript\":{},\"underlineColor\":{},\"strikeColor\":{},\"shadeColor\":{},\"emphasisDot\":{}",
         json_escape(&style.font_family),
         style.font_size,
         json_escape(&color_ref_to_css(style.color)),
         style.bold,
         style.italic,
+        style.ratio,
         json_escape(underline_type_str(style.underline)),
+        style.underline_shape,
         style.strikethrough,
+        style.strike_shape,
+        style.outline_type,
         style.shadow_type,
         json_escape(&color_ref_to_css(style.shadow_color)),
         style.shadow_offset_x,
         style.shadow_offset_y,
+        style.emboss,
+        style.engrave,
+        style.superscript,
+        style.subscript,
         json_escape(&color_ref_to_css(style.underline_color)),
         json_escape(&color_ref_to_css(style.strike_color)),
         json_escape(&color_ref_to_css(style.shade_color)),
@@ -535,6 +898,16 @@ fn write_field_marker(buf: &mut String, marker: FieldMarkerType) {
     }
 }
 
+fn field_marker_str(value: FieldMarkerType) -> &'static str {
+    match value {
+        FieldMarkerType::None => "none",
+        FieldMarkerType::FieldBegin => "fieldBegin",
+        FieldMarkerType::FieldEnd => "fieldEnd",
+        FieldMarkerType::FieldBeginEnd => "fieldBeginEnd",
+        FieldMarkerType::ShapeMarker(_) => "shapeMarker",
+    }
+}
+
 fn write_char_overlap(
     buf: &mut String,
     overlap: Option<&crate::renderer::composer::CharOverlapInfo>,
@@ -548,6 +921,197 @@ fn write_char_overlap(
     } else {
         buf.push_str("null");
     }
+}
+
+fn text_orientation_str(run: &TextRunNode) -> &'static str {
+    if !run.is_vertical {
+        "horizontal"
+    } else if run.rotation.abs() > f64::EPSILON {
+        "vertical-sideways"
+    } else {
+        "vertical-upright"
+    }
+}
+
+fn text_projection_kind_str(run: &TextRunNode) -> &'static str {
+    if run.char_overlap.is_some() {
+        "syntheticVisual"
+    } else if run.field_marker != FieldMarkerType::None {
+        "fieldProjection"
+    } else if run.text.is_empty() && (run.is_para_end || run.is_line_break_end) {
+        "controlProjection"
+    } else {
+        "verbatim"
+    }
+}
+
+fn write_text_legacy_visuals(buf: &mut String, run: &TextRunNode, leaf_visuals: LeafTextVisualOps) {
+    let has_decorations = run.style.underline != UnderlineType::None
+        || run.style.strikethrough
+        || run.style.emphasis_dot > 0;
+    if run.char_overlap.is_none()
+        && !leaf_visuals.control_marks
+        && run.style.tab_leaders.is_empty()
+        && !has_decorations
+    {
+        return;
+    }
+
+    buf.push_str(",\"legacyVisuals\":{");
+    let mut wrote = false;
+    if run.char_overlap.is_some() {
+        let state = if leaf_visuals.char_overlap {
+            "mirror"
+        } else {
+            "canonical"
+        };
+        let _ = write!(buf, "\"charOverlap\":{}", json_escape(state));
+        wrote = true;
+    }
+    if leaf_visuals.control_marks {
+        if wrote {
+            buf.push(',');
+        }
+        buf.push_str("\"controlMarks\":\"mirror\"");
+        wrote = true;
+    }
+    if !run.style.tab_leaders.is_empty() {
+        if wrote {
+            buf.push(',');
+        }
+        let state = if leaf_visuals.tab_leaders {
+            "mirror"
+        } else {
+            "canonical"
+        };
+        let _ = write!(buf, "\"tabLeaders\":{}", json_escape(state));
+        wrote = true;
+    }
+    if has_decorations {
+        if wrote {
+            buf.push(',');
+        }
+        let state = if leaf_visuals.decorations {
+            "mirror"
+        } else {
+            "canonical"
+        };
+        let _ = write!(buf, "\"decorations\":{}", json_escape(state));
+    }
+    buf.push('}');
+}
+
+fn write_text_run_placement(buf: &mut String, bbox: BoundingBox, run: &TextRunNode) {
+    let radians = run.rotation.to_radians();
+    let (sin, cos) = radians.sin_cos();
+    let local_origin_x = -bbox.width / 2.0;
+    let local_origin_y = -bbox.height / 2.0 + run.baseline;
+    let center_x = bbox.x + bbox.width / 2.0;
+    let center_y = bbox.y + bbox.height / 2.0;
+    let _ = write!(
+        buf,
+        "{{\"runToPage\":{{\"a\":{:.6},\"b\":{:.6},\"c\":{:.6},\"d\":{:.6},\"e\":{:.6},\"f\":{:.6}}},\"baselineY\":0.000000}}",
+        cos,
+        sin,
+        -sin,
+        cos,
+        center_x + cos * local_origin_x - sin * local_origin_y,
+        center_y + sin * local_origin_x + cos * local_origin_y,
+    );
+}
+
+fn write_text_clusters(buf: &mut String, run: &TextRunNode) {
+    let positions = compute_char_positions(&run.text, &run.style);
+    let mut utf16_start = 0_u32;
+    let chars = run
+        .text
+        .char_indices()
+        .map(|(offset, ch)| (offset as u32, ch))
+        .collect::<Vec<_>>();
+
+    buf.push('[');
+    for (idx, (utf8_start, ch)) in chars.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let utf8_end = chars
+            .get(idx + 1)
+            .map_or(run.text.len() as u32, |(next, _)| *next);
+        let utf16_end = utf16_start + ch.len_utf16() as u32;
+        let origin_x = positions.get(idx).copied().unwrap_or_default();
+        let projection = text_projection_kind_str(run);
+        buf.push_str("{\"sourceRangeUtf8\":");
+        write_text_source_range(buf, TextSourceRange::new(*utf8_start, utf8_end));
+        buf.push_str(",\"textRangeUtf8\":");
+        write_text_source_range(buf, TextSourceRange::new(*utf8_start, utf8_end));
+        buf.push_str(",\"textRangeUtf16\":");
+        write_text_source_range(buf, TextSourceRange::new(utf16_start, utf16_end));
+        let _ = write!(
+            buf,
+            ",\"projection\":{},\"origin\":{{\"x\":{:.6},\"y\":0.000000}}",
+            json_escape(projection),
+            origin_x
+        );
+        if let Some(next_x) = positions.get(idx + 1) {
+            let _ = write!(
+                buf,
+                ",\"advance\":{{\"dx\":{:.6},\"dy\":0.000000}}",
+                next_x - origin_x
+            );
+        }
+        if run.char_overlap.is_some() {
+            buf.push_str(",\"flags\":[\"specialVisual\",\"notShapingCandidate\"]");
+        }
+        buf.push('}');
+        utf16_start = utf16_end;
+    }
+    buf.push(']');
+}
+
+fn write_text_decoration(buf: &mut String, kind: TextDecorationKind, run: &TextRunNode) {
+    let (color, shape, underline, emphasis_dot) = match kind {
+        TextDecorationKind::Underline => (
+            if run.style.underline_color != 0 {
+                run.style.underline_color
+            } else {
+                run.style.color
+            },
+            run.style.underline_shape,
+            run.style.underline,
+            0,
+        ),
+        TextDecorationKind::Strikethrough => (
+            if run.style.strike_color != 0 {
+                run.style.strike_color
+            } else {
+                run.style.color
+            },
+            run.style.strike_shape,
+            UnderlineType::None,
+            0,
+        ),
+        TextDecorationKind::EmphasisDot => (
+            run.style.color,
+            0,
+            UnderlineType::None,
+            run.style.emphasis_dot,
+        ),
+    };
+    let _ = write!(
+        buf,
+        "{{\"kind\":{},\"baseline\":{:.3},\"rotation\":{:.3},\"fontSize\":{:.3},\"ratio\":{:.6},\"color\":{},\"shape\":{},\"underline\":{},\"emphasisDot\":{},\"positions\":",
+        json_escape(kind.as_str()),
+        run.baseline,
+        run.rotation,
+        run.style.font_size,
+        run.style.ratio,
+        json_escape(&color_ref_to_css(color)),
+        shape,
+        json_escape(underline_type_str(underline)),
+        emphasis_dot,
+    );
+    write_text_positions(buf, run);
+    buf.push('}');
 }
 
 fn write_shape_style(buf: &mut String, style: &ShapeStyle) {
@@ -796,7 +1360,9 @@ fn form_type_str(value: FormType) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::paint::{CacheHint, ClipKind, GroupKind, LayerNode, PageLayerTree};
+    use crate::paint::{
+        CacheHint, ClipKind, GroupKind, LayerNode, PageLayerTree, TextDecorationKind,
+    };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
     use crate::renderer::render_tree::{
@@ -886,24 +1452,131 @@ mod tests {
 
         assert!(json.contains("\"kind\":\"leaf\""));
         assert!(json.contains("\"schemaVersion\":1"));
+        assert!(json.contains("\"schemaMinorVersion\":8"));
+        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":8}"));
         assert!(json.contains("\"resourceTableVersion\":1"));
+        assert!(json.contains("\"resourceTableMinorVersion\":2"));
+        assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":2}"));
         assert!(json.contains("\"unit\":\"px\""));
-        assert!(json.contains("\"coordinateSystem\":\"page-top-left\""));
+        assert!(json.contains("\"coordinateSystem\":\"page-top-left-y-down\""));
         assert!(json.contains("\"profile\":\"screen\""));
         assert!(json.contains("\"outputOptions\":{"));
         assert!(json.contains("\"clipEnabled\":true"));
         assert!(json.contains("\"type\":\"textRun\""));
+        assert!(json.contains("\"textSources\":[{\"id\":0,\"text\":\"가A\""));
+        assert!(json.contains("\"source\":{\"id\":0"));
+        assert!(json.contains("\"paintStyle\":{"));
+        assert!(json.contains("\"placement\":{\"runToPage\":"));
+        assert!(json.contains("\"clusterBasis\":\"legacyPosition\""));
+        assert!(json.contains("\"clusters\":[{\"sourceRangeUtf8\""));
+        assert!(json.contains("\"legacyVisuals\":{"));
         assert!(json.contains(&positions_json));
         assert!(json.contains("\"isParaEnd\":true"));
         assert!(json.contains("\"isLineBreakEnd\":true"));
         assert!(json.contains("\"fieldMarker\":{\"kind\":\"fieldBegin\"}"));
         assert!(json.contains("\"charOverlap\":{\"borderType\":1,\"innerCharSize\":90}"));
+        assert!(json.contains("\"usedFeatures\":[\"text.paintStyle\""));
+        assert!(json.contains("\"knownFeatures\":[\"fontResources\""));
+        assert!(json.contains("\"text\":{\"defaultVariant\":\"textRun\""));
         assert!(json.contains("\"fontFamily\":\"Noto Sans KR\""));
         assert!(json.contains("\"italic\":true"));
         assert!(json.contains("\"shadeColor\":\"#ffff00\""));
         assert!(json.contains("\"emphasisDot\":2"));
         assert!(json.contains("\"type\":\"rectangle\""));
         assert!(json.contains("\"cornerRadius\":4.000"));
+    }
+
+    #[test]
+    fn serializes_external_text_visual_ops_as_additive_features() {
+        let run = TextRunNode {
+            text: "A\tB".to_string(),
+            style: TextStyle {
+                font_family: "Noto Sans".to_string(),
+                font_size: 14.0,
+                color: 0x00000000,
+                underline: UnderlineType::Bottom,
+                strikethrough: true,
+                emphasis_dot: 1,
+                tab_leaders: vec![TabLeaderInfo {
+                    start_x: 10.0,
+                    end_x: 40.0,
+                    fill_type: 3,
+                }],
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: Some(1),
+            para_index: Some(2),
+            char_start: Some(3),
+            cell_context: None,
+            is_para_end: true,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: Some(CharOverlapInfo {
+                border_type: 2,
+                inner_char_size: 80,
+            }),
+            border_fill_id: 0,
+            baseline: 11.0,
+            field_marker: FieldMarkerType::FieldEnd,
+        };
+        let bbox = BoundingBox::new(10.0, 20.0, 40.0, 16.0);
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![
+                    PaintOp::TextRun {
+                        bbox,
+                        run: run.clone(),
+                    },
+                    PaintOp::CharOverlap {
+                        bbox,
+                        run: run.clone(),
+                    },
+                    PaintOp::TextControlMark {
+                        bbox,
+                        run: run.clone(),
+                    },
+                    PaintOp::TabLeader {
+                        bbox,
+                        run: run.clone(),
+                    },
+                    PaintOp::TextDecoration {
+                        bbox,
+                        run: run.clone(),
+                        kind: TextDecorationKind::Underline,
+                    },
+                    PaintOp::TextDecoration {
+                        bbox,
+                        run,
+                        kind: TextDecorationKind::EmphasisDot,
+                    },
+                ],
+            ),
+        );
+
+        let json = tree.to_json();
+
+        assert!(json.contains("\"type\":\"charOverlap\""));
+        assert!(json.contains("\"type\":\"textControlMark\""));
+        assert!(json.contains("\"type\":\"tabLeader\""));
+        assert!(json.contains("\"type\":\"textDecoration\""));
+        assert!(json.contains("\"kind\":\"underline\""));
+        assert!(json.contains("\"kind\":\"emphasisDot\""));
+        assert!(json.contains("\"textSources\":[{\"id\":0,\"text\":\"A\\tB\""));
+        assert!(json.contains("\"stableSourceKey\":\"section:1/para:2/char:3\""));
+        assert!(json.contains("\"marker\":\"fieldEnd\""));
+        assert!(json.contains("\"text.charOverlapOp\""));
+        assert!(json.contains("\"text.controlMarkOp\""));
+        assert!(json.contains("\"text.tabLeaderOp\""));
+        assert!(json.contains("\"text.decorationOp\""));
+        assert!(json.contains("\"externalizedVisuals\":[\"charOverlap\",\"controlMarks\",\"tabLeaders\",\"decorations\"]"));
+        assert!(json.contains("\"legacyVisuals\":{\"charOverlap\":\"mirror\""));
     }
 
     #[test]

--- a/src/paint/layer_tree.rs
+++ b/src/paint/layer_tree.rs
@@ -2,7 +2,8 @@ use crate::paint::paint_op::PaintOp;
 use crate::paint::profile::RenderProfile;
 use crate::paint::resources::ResourceArena;
 use crate::renderer::render_tree::{
-    BoundingBox, GroupNode, NodeId, TableCellNode, TableNode, TextLineNode,
+    BoundingBox, FieldMarkerType, GroupNode, NodeId, TableCellNode, TableNode, TextLineNode,
+    TextRunNode,
 };
 
 /// 한 페이지의 visual layer tree.
@@ -14,10 +15,12 @@ pub struct PageLayerTree {
     pub output_options: LayerOutputOptions,
     pub root: LayerNode,
     pub resources: ResourceArena,
+    pub text_sources: TextSourceTable,
 }
 
 impl PageLayerTree {
     pub fn new(page_width: f64, page_height: f64, root: LayerNode) -> Self {
+        let text_sources = TextSourceTable::from_layer_node(&root);
         Self {
             page_width,
             page_height,
@@ -25,6 +28,7 @@ impl PageLayerTree {
             output_options: LayerOutputOptions::default(),
             root,
             resources: ResourceArena,
+            text_sources,
         }
     }
 
@@ -34,6 +38,7 @@ impl PageLayerTree {
         root: LayerNode,
         profile: RenderProfile,
     ) -> Self {
+        let text_sources = TextSourceTable::from_layer_node(&root);
         Self {
             page_width,
             page_height,
@@ -41,6 +46,7 @@ impl PageLayerTree {
             output_options: LayerOutputOptions::default(),
             root,
             resources: ResourceArena,
+            text_sources,
         }
     }
 
@@ -48,6 +54,169 @@ impl PageLayerTree {
         self.output_options = output_options;
         self
     }
+
+    pub fn with_text_sources(mut self, text_sources: TextSourceTable) -> Self {
+        self.text_sources = text_sources;
+        self
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TextSourceId(pub u32);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct TextSourceRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl TextSourceRange {
+    pub fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct TextSourceSpan {
+    pub id: TextSourceId,
+    pub utf8_range: TextSourceRange,
+    pub utf16_range: TextSourceRange,
+    pub stable_source_key: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextSourceEntry {
+    pub id: TextSourceId,
+    pub stable_source_key: Option<String>,
+    pub text: String,
+    pub utf8_range: TextSourceRange,
+    pub utf16_range: TextSourceRange,
+    pub annotations: Vec<TextSourceAnnotation>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum TextSourceAnnotation {
+    FieldMarker {
+        marker: FieldMarkerType,
+        range_utf8: TextSourceRange,
+        range_utf16: TextSourceRange,
+    },
+    ParagraphEnd {
+        offset_utf8: u32,
+        offset_utf16: u32,
+    },
+    LineBreakEnd {
+        offset_utf8: u32,
+        offset_utf16: u32,
+    },
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TextSourceTable {
+    pub entries: Vec<TextSourceEntry>,
+}
+
+impl TextSourceTable {
+    pub fn from_layer_node(root: &LayerNode) -> Self {
+        let mut table = Self::default();
+        table.collect_from_node(root);
+        table
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.entries.is_empty()
+    }
+
+    fn collect_from_node(&mut self, node: &LayerNode) {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    self.collect_from_node(child);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => {
+                self.collect_from_node(child);
+            }
+            LayerNodeKind::Leaf { ops } => {
+                for op in ops {
+                    if let PaintOp::TextRun { run, .. } = op {
+                        let id = TextSourceId(self.entries.len() as u32);
+                        let utf8_range = TextSourceRange::new(0, run.text.len() as u32);
+                        let utf16_range =
+                            TextSourceRange::new(0, run.text.encode_utf16().count() as u32);
+                        self.entries.push(TextSourceEntry {
+                            id,
+                            stable_source_key: stable_text_source_key(run),
+                            text: run.text.clone(),
+                            utf8_range,
+                            utf16_range,
+                            annotations: text_source_annotations(
+                                run,
+                                utf8_range.end,
+                                utf16_range.end,
+                            ),
+                        });
+                    }
+                }
+            }
+        }
+    }
+}
+
+fn stable_text_source_key(run: &TextRunNode) -> Option<String> {
+    let section = run.section_index?;
+    let para = run.para_index?;
+    let char_start = run.char_start.unwrap_or(0);
+    let mut key = format!("section:{section}/para:{para}/char:{char_start}");
+    if let Some(cell) = &run.cell_context {
+        let path = cell
+            .path
+            .iter()
+            .map(|entry| {
+                format!(
+                    "{}:{}:{}:{}",
+                    entry.control_index,
+                    entry.cell_index,
+                    entry.cell_para_index,
+                    entry.text_direction
+                )
+            })
+            .collect::<Vec<_>>()
+            .join(".");
+        key.push_str("/cell:");
+        key.push_str(&cell.parent_para_index.to_string());
+        key.push(':');
+        key.push_str(&path);
+    }
+    Some(key)
+}
+
+fn text_source_annotations(
+    run: &TextRunNode,
+    utf8_end: u32,
+    utf16_end: u32,
+) -> Vec<TextSourceAnnotation> {
+    let mut annotations = Vec::new();
+    if run.field_marker != FieldMarkerType::None {
+        annotations.push(TextSourceAnnotation::FieldMarker {
+            marker: run.field_marker,
+            range_utf8: TextSourceRange::new(0, utf8_end),
+            range_utf16: TextSourceRange::new(0, utf16_end),
+        });
+    }
+    if run.is_para_end {
+        annotations.push(TextSourceAnnotation::ParagraphEnd {
+            offset_utf8: utf8_end,
+            offset_utf16: utf16_end,
+        });
+    }
+    if run.is_line_break_end {
+        annotations.push(TextSourceAnnotation::LineBreakEnd {
+            offset_utf8: utf8_end,
+            offset_utf16: utf16_end,
+        });
+    }
+    annotations
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -13,8 +13,10 @@ pub mod schema;
 pub use builder::LayerBuilder;
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
+    TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
+    TextSourceTable,
 };
-pub use paint_op::PaintOp;
+pub use paint_op::{PaintOp, TextDecorationKind};
 pub use profile::RenderProfile;
 pub use resources::{
     image_resource_key, resource_digest_hex, svg_resource_key, ResourceArena,
@@ -22,5 +24,6 @@ pub use resources::{
 };
 pub use schema::{
     LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,
-    PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION, PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
+    PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
+    PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION, PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
 };

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -4,6 +4,23 @@ use crate::renderer::render_tree::{
     TextRunNode,
 };
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextDecorationKind {
+    Underline,
+    Strikethrough,
+    EmphasisDot,
+}
+
+impl TextDecorationKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Underline => "underline",
+            Self::Strikethrough => "strikethrough",
+            Self::EmphasisDot => "emphasisDot",
+        }
+    }
+}
+
 /// backend가 재생하는 leaf paint operation.
 ///
 /// 1차 전환에서는 기존 leaf payload를 최대한 그대로 유지해
@@ -17,6 +34,30 @@ pub enum PaintOp {
     TextRun {
         bbox: BoundingBox,
         run: TextRunNode,
+    },
+    /// HWP 글자겹침의 명시 visual op.
+    ///
+    /// 전환기에는 paired TextRun 안에도 legacy mirror payload를 남긴다.
+    /// 새 backend는 이 op를 선택하고 TextRun mirror를 건너뛸 수 있다.
+    CharOverlap {
+        bbox: BoundingBox,
+        run: TextRunNode,
+    },
+    /// 문단 끝/줄 바꿈/필드 마커처럼 source text와 visual projection이 다른 표식.
+    TextControlMark {
+        bbox: BoundingBox,
+        run: TextRunNode,
+    },
+    /// 탭 리더 visual geometry.
+    TabLeader {
+        bbox: BoundingBox,
+        run: TextRunNode,
+    },
+    /// 밑줄/취소선/강조점 visual geometry.
+    TextDecoration {
+        bbox: BoundingBox,
+        run: TextRunNode,
+        kind: TextDecorationKind,
     },
     FootnoteMarker {
         bbox: BoundingBox,
@@ -65,6 +106,10 @@ impl PaintOp {
         match self {
             PaintOp::PageBackground { bbox, .. }
             | PaintOp::TextRun { bbox, .. }
+            | PaintOp::CharOverlap { bbox, .. }
+            | PaintOp::TextControlMark { bbox, .. }
+            | PaintOp::TabLeader { bbox, .. }
+            | PaintOp::TextDecoration { bbox, .. }
             | PaintOp::FootnoteMarker { bbox, .. }
             | PaintOp::Line { bbox, .. }
             | PaintOp::Rectangle { bbox, .. }

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -1,21 +1,32 @@
 /// Versioned root metadata for PageLayerTree JSON exports.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub struct LayerTreeSchema {
+    /// Major schema version. This remains an integer for v1 compatibility.
     pub schema_version: u32,
+    /// Additive schema revision within the current major version.
+    pub schema_minor_version: u32,
+    /// Major resource table version. This remains an integer for v1 compatibility.
     pub resource_table_version: u32,
+    /// Additive resource-table revision within the current major version.
+    pub resource_table_minor_version: u32,
     pub unit: &'static str,
     pub coordinate_system: &'static str,
 }
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
+    schema_minor_version: 8,
     resource_table_version: 1,
+    resource_table_minor_version: 2,
     unit: "px",
-    coordinate_system: "page-top-left",
+    coordinate_system: "page-top-left-y-down",
 };
 
 pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version;
+pub const PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION: u32 = LAYER_TREE_SCHEMA.schema_minor_version;
 pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version;
+pub const PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION: u32 =
+    LAYER_TREE_SCHEMA.resource_table_minor_version;
 pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit;
 pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system;
 
@@ -26,8 +37,10 @@ mod tests {
     #[test]
     fn layer_tree_schema_contract_is_stable() {
         assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 8);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
+        assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 2);
         assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
-        assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left");
+        assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left-y-down");
     }
 }

--- a/src/renderer/canvas.rs
+++ b/src/renderer/canvas.rs
@@ -247,6 +247,10 @@ impl CanvasRenderer {
                             self.close_shape_transform_value(&path.transform);
                         }
                         PaintOp::FootnoteMarker { .. }
+                        | PaintOp::CharOverlap { .. }
+                        | PaintOp::TextControlMark { .. }
+                        | PaintOp::TabLeader { .. }
+                        | PaintOp::TextDecoration { .. }
                         | PaintOp::Equation { .. }
                         | PaintOp::FormObject { .. }
                         | PaintOp::Placeholder { .. }

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -653,6 +653,10 @@ impl SkiaLayerRenderer {
                                 draw_placeholder(*bbox, "svg");
                             }
                         }
+                        PaintOp::CharOverlap { .. }
+                        | PaintOp::TextControlMark { .. }
+                        | PaintOp::TabLeader { .. }
+                        | PaintOp::TextDecoration { .. } => {}
                     }
                 }
             }

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -110,13 +110,17 @@ impl SvgLayerRenderer {
             }
             LayerNodeKind::Leaf { ops } => ops
                 .iter()
-                .map(|op| self.paint_op_to_render_node(op, node.source_node_id))
+                .filter_map(|op| self.paint_op_to_render_node(op, node.source_node_id))
                 .collect(),
         }
     }
 
-    fn paint_op_to_render_node(&mut self, op: &PaintOp, source_node_id: Option<u32>) -> RenderNode {
-        match op {
+    fn paint_op_to_render_node(
+        &mut self,
+        op: &PaintOp,
+        source_node_id: Option<u32>,
+    ) -> Option<RenderNode> {
+        let node = match op {
             PaintOp::PageBackground { bbox, background } => RenderNode::new(
                 self.take_node_id(source_node_id),
                 RenderNodeType::PageBackground(background.clone()),
@@ -177,7 +181,12 @@ impl SvgLayerRenderer {
                 RenderNodeType::RawSvg(raw.clone()),
                 *bbox,
             ),
-        }
+            PaintOp::CharOverlap { .. }
+            | PaintOp::TextControlMark { .. }
+            | PaintOp::TabLeader { .. }
+            | PaintOp::TextDecoration { .. } => return None,
+        };
+        Some(node)
     }
 
     fn group_kind_to_render_node_type(&self, group_kind: &GroupKind) -> RenderNodeType {

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -747,7 +747,12 @@ impl WebCanvasRenderer {
                             LayerNodeKind::Leaf { ops } => {
                                 if ops.iter().all(|op| matches!(
                                     op,
-                                    PaintOp::TextRun { .. } | PaintOp::FootnoteMarker { .. }
+                                    PaintOp::TextRun { .. }
+                                        | PaintOp::CharOverlap { .. }
+                                        | PaintOp::TextControlMark { .. }
+                                        | PaintOp::TabLeader { .. }
+                                        | PaintOp::TextDecoration { .. }
+                                        | PaintOp::FootnoteMarker { .. }
                                 )) {
                                     return false;
                                 }
@@ -873,6 +878,10 @@ impl WebCanvasRenderer {
                             RenderNodeType::RawSvg(raw.clone()),
                             *bbox,
                         ),
+                        PaintOp::CharOverlap { .. }
+                        | PaintOp::TextControlMark { .. }
+                        | PaintOp::TabLeader { .. }
+                        | PaintOp::TextDecoration { .. } => continue,
                     };
                     self.render_node(&render_node);
                 }


### PR DESCRIPTION
## 변경 요약

이번 PR은 render P11 단계로, P9까지 반영된 최신 `devel` 위에 Text IR v2 compatibility contract를 추가합니다.

핵심은 `TextRun` fallback 의미를 바꾸지 않으면서, 앞으로 GlyphRun/font resource/native glyph replay로 넘어갈 수 있는 schema contract를 먼저 여는 것입니다. 즉, 이번 단계는 GlyphRun을 기본 경로로 만드는 PR이 아니라 TextRun v2 compatibility contract를 완성하는 PR입니다.


## Text IR v2 설계 메모

P11은 이 시리즈에서 Text IR v2 개념이 처음 들어오는 지점입니다. 다만 이 PR에서 Text IR v2를 완성하거나 기존 text replay contract를 대체하지는 않습니다. 기존 `TextRun` fallback을 유지한 채, 후속 GlyphRun/font resource/native glyph replay가 붙을 수 있는 compatibility contract를 먼저 여는 단계입니다.

간단히 정리하면 아래 방향입니다.

- Compatibility first: 모든 backend는 계속 `TextRun` fallback으로 렌더링할 수 있어야 합니다.
- Additive schema: `schemaMinorVersion`, feature negotiation metadata, text metadata를 추가하되 기존 consumer를 깨지 않게 둡니다.
- Source traceability: `PageLayerTree.text_sources`와 `TextRun.source` span으로 text op의 원문 범위를 추적할 수 있게 합니다.
- Placement/cluster metadata: `paintStyle`, `projectionKind`, `orientation`, `placement`, `clusterBasis`, `clusters`, `legacyVisuals`로 text replay 의미를 더 명확히 표현합니다.
- External special visual ops: char overlap, control mark, tab leader, decoration을 별도 paint op로 낮추되, P11에서는 기존 renderer가 skip해서 double-painting을 막습니다.
- Still designing: `GlyphRun` eligibility, font resource table, cluster basis, fallback diagnostics는 P12 이후 guarded variant 작업에서 확정합니다.

자세한 배경과 설계 메모는 repo 문서에 정리했습니다: https://github.com/seo-rii/rhwp/blob/render-p11/docs/text-ir-v2.md

주요 변경은 아래와 같습니다.

- PageLayerTree JSON에 `schemaMinorVersion`, `resourceTableMinorVersion`, `schema`, `resourceTable` metadata 추가
- `usedFeatures`, `requiredFeatures`, `optionalFeatures`, `knownFeatures`, `text` metadata 추가
- `PageLayerTree.text_sources`와 export-local `TextSourceTable` 추가
- `TextRun.source` span을 JSON으로 export
- `TextRun.paintStyle`, `projectionKind`, `orientation`, `placement`, `clusterBasis`, `clusters`, `legacyVisuals` export
- `PaintOp::CharOverlap`, `PaintOp::TextControlMark`, `PaintOp::TabLeader`, `PaintOp::TextDecoration` 추가
- LayerBuilder에서 char overlap / tab leader / decoration / visible control mark를 explicit visual op로 낮춤
- 기존 SVG / Canvas / native Skia renderer는 새 special visual op를 skip해서 double-painting 방지
- `docs/text-ir-v2.md`에 Text IR v2 migration contract 문서화
- README에 P11 범위와 GlyphRun 후속 분리 명시

control mark 계열은 기존 renderer output option과 맞추기 위해 `showParagraphMarks` 또는 `showControlCodes`가 켜진 경우에만 external op로 낮춥니다. 반면 char overlap, tab leader, decoration은 visual payload가 항상 존재하므로 explicit op를 만들고, 기존 TextRun payload는 legacy mirror로 둡니다.

## 관련 이슈

Refs #536

## 범위

이번 PR에 포함한 범위는 아래 정도입니다.

- Text IR v2 compatibility metadata
- source table / source span export
- text placement / cluster metadata export
- special text visual externalization
- unknown/additive op를 기존 renderer가 안전하게 건너뛰는 처리
- JSON schema negotiation metadata
- Text IR v2 문서화

## 비목표

아래는 일부러 이번 PR에 넣지 않았습니다.

- GlyphRun을 canonical text path로 전환
- font blob / font face resource table 구현
- native Skia glyph id replay
- CanvasKit glyph replay
- glyph outline replay
- public render path 변경
- binary resource interning / typed array transport

GlyphRun 계열은 font identity와 fallback 검증이 같이 필요합니다. 그래서 P11에서는 TextRun fallback을 그대로 유지하고, P12에서 guarded GlyphRun variant replay로 넘기는 편이 맞습니다.

## 테스트

- [x] `git diff --check origin/devel..HEAD`
- [x] `cargo test --lib paint::json --features native-skia`
- [x] `cargo test --lib paint::builder --features native-skia`
- [x] `cargo test --lib layer --features native-skia`
- [x] `cargo test --features native-skia --lib skia`

## 스크린샷

없음.

이번 PR은 Text IR schema/export contract 변경입니다. renderer visual output은 기존 TextRun fallback을 유지하고, 새 explicit visual op는 기존 renderer에서 double-painting 되지 않도록 skip합니다.



