### PR TITLE
fix: prevent PDF content clipping caused by BBox in multi-page export

### DIFF
--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -29,6 +29,108 @@ fn add_font_fallbacks(svg: &str) -> String {
        .replace("font-family=\"HCI Poppy\"", "font-family=\"HCI Poppy, 맑은 고딕, sans-serif\"")
 }
 
+/// SVG 콘텐츠에서 최대 X 좌표(x + width)를 스캔한다.
+/// clipPath 등의 rect에서 뷰포트를 넘는 콘텐츠를 탐지.
+#[cfg(not(target_arch = "wasm32"))]
+fn scan_svg_max_x(svg: &str) -> f32 {
+    let mut max_x: f32 = 0.0;
+
+    // 루트 <svg> 태그 이후만 스캔
+    let body = match svg.find('>') {
+        Some(pos) => &svg[pos + 1..],
+        None => return 0.0,
+    };
+
+    // <rect ... x="X" ... width="W" .../> 패턴에서 x + width 계산
+    // rhwp의 clipPath rect가 뷰포트를 넘는 주요 원인
+    let mut search_from = 0;
+    while let Some(rect_pos) = body[search_from..].find("<rect ") {
+        let abs_pos = search_from + rect_pos;
+        let tag_end = match body[abs_pos..].find("/>") {
+            Some(e) => abs_pos + e + 2,
+            None => match body[abs_pos..].find('>') {
+                Some(e) => abs_pos + e + 1,
+                None => break,
+            },
+        };
+        let tag = &body[abs_pos..tag_end];
+
+        let mut rect_x: f32 = 0.0;
+        let mut rect_w: f32 = 0.0;
+
+        // x="..." 추출
+        if let Some(xi) = tag.find(" x=\"") {
+            let val_start = xi + 4;
+            if let Some(val_end) = tag[val_start..].find('"') {
+                rect_x = tag[val_start..val_start + val_end].parse().unwrap_or(0.0);
+            }
+        }
+        // width="..." 추출
+        if let Some(wi) = tag.find(" width=\"") {
+            let val_start = wi + 8;
+            if let Some(val_end) = tag[val_start..].find('"') {
+                rect_w = tag[val_start..val_start + val_end].parse().unwrap_or(0.0);
+            }
+        }
+
+        max_x = max_x.max(rect_x + rect_w);
+        search_from = tag_end;
+    }
+
+    max_x
+}
+
+/// SVG 루트 요소의 width, height, viewBox를 확장하여
+/// 콘텐츠가 BBox에 의해 잘리지 않도록 한다.
+#[cfg(not(target_arch = "wasm32"))]
+fn expand_svg_viewport(svg: &str, new_w: f32, new_h: f32) -> String {
+    use std::fmt::Write;
+
+    let mut result = String::with_capacity(svg.len() + 64);
+    if let Some(svg_tag_end) = svg.find('>') {
+        let tag = &svg[..=svg_tag_end];
+        let rest = &svg[svg_tag_end + 1..];
+
+        // width, height, viewBox 속성을 새 값으로 교체
+        let mut new_tag = String::with_capacity(tag.len() + 64);
+        let mut i = 0;
+        let bytes = tag.as_bytes();
+        while i < bytes.len() {
+            if tag[i..].starts_with("width=\"") {
+                new_tag.push_str("width=\"");
+                let _ = write!(new_tag, "{}", new_w);
+                new_tag.push('"');
+                // 기존 값 건너뛰기
+                i += 7; // skip `width="`
+                while i < bytes.len() && bytes[i] != b'"' { i += 1; }
+                i += 1; // skip closing `"`
+            } else if tag[i..].starts_with("height=\"") {
+                new_tag.push_str("height=\"");
+                let _ = write!(new_tag, "{}", new_h);
+                new_tag.push('"');
+                i += 8;
+                while i < bytes.len() && bytes[i] != b'"' { i += 1; }
+                i += 1;
+            } else if tag[i..].starts_with("viewBox=\"") {
+                new_tag.push_str("viewBox=\"");
+                let _ = write!(new_tag, "0 0 {} {}", new_w, new_h);
+                new_tag.push('"');
+                i += 9;
+                while i < bytes.len() && bytes[i] != b'"' { i += 1; }
+                i += 1;
+            } else {
+                new_tag.push(bytes[i] as char);
+                i += 1;
+            }
+        }
+        result.push_str(&new_tag);
+        result.push_str(rest);
+    } else {
+        return svg.to_string();
+    }
+    result
+}
+
 /// 단일 SVG를 PDF로 변환
 #[cfg(not(target_arch = "wasm32"))]
 pub fn svg_to_pdf(svg_content: &str) -> Result<Vec<u8>, String> {
@@ -79,12 +181,28 @@ pub fn svgs_to_pdf(svg_pages: &[String]) -> Result<Vec<u8>, String> {
         let tree = usvg::Tree::from_str(&svg_with_fallback, &options)
             .map_err(|e| format!("SVG 파싱 실패: {}", e))?;
 
-        let (chunk, svg_ref) = svg2pdf::to_chunk(&tree, svg2pdf::ConversionOptions::default())
+        let orig_w = tree.size().width();
+        let orig_h = tree.size().height();
+
+        // Fix: SVG 콘텐츠 좌표가 뷰포트를 넘는지 확인하여 BBox 클리핑 방지
+        // usvg의 bounding_box()는 뷰포트에 클리핑되므로 SVG 원본을 직접 스캔
+        let max_x = scan_svg_max_x(&svg_with_fallback);
+
+        let tree_for_chunk = if max_x > orig_w * 1.01 {
+            let expanded = expand_svg_viewport(&svg_with_fallback, max_x, orig_h);
+            usvg::Tree::from_str(&expanded, &options)
+                .map_err(|e| format!("SVG 재파싱 실패: {}", e))?
+        } else {
+            tree
+        };
+
+        let (chunk, svg_ref) = svg2pdf::to_chunk(&tree_for_chunk, svg2pdf::ConversionOptions::default())
             .map_err(|e| format!("SVG→chunk 변환 실패: {:?}", e))?;
 
+        // 페이지 크기는 원본 뷰포트 기준 (A4 유지)
         let dpi_ratio = 72.0 / 96.0; // 96 DPI → 72 pt
-        let w = tree.size().width() * dpi_ratio;
-        let h = tree.size().height() * dpi_ratio;
+        let w = orig_w * dpi_ratio;
+        let h = orig_h * dpi_ratio;
 
         page_datas.push(PageData { chunk, svg_ref, width: w, height: h });
     }


### PR DESCRIPTION
## Summary

When `svgs_to_pdf()` generates multi-page PDFs, `svg2pdf::to_chunk()` sets the Form XObject BBox to the SVG viewport size. However, some SVG elements (particularly `<clipPath>` `<rect>` elements) have coordinates that extend beyond the viewport (e.g., `x + width` exceeding the viewport width). This causes the BBox to clip content on the right side of the page.

### Root cause
- SVG viewport: `width="793.7"` (A4 at 96 DPI)
- clipPath rect: `x="75.57" width="982.8"` → right edge at 1058.37
- BBox clips at 793.7, hiding content between 793.7 and 1058.37

### Fix
Before calling `to_chunk()`, scan each SVG for `<rect>` elements whose `x + width` exceeds the viewport width. If overflow is detected, expand the SVG's `width`, `height`, and `viewBox` attributes to encompass all content, then re-parse. The page MediaBox remains at the original A4 size, so the content is properly scaled.

### Before / After

| Before (clipped) | After (fixed) |
|:-:|:-:|
| Right-side content cut off, unbalanced margins | Full content visible, balanced margins |

### Notes
- Only affects multi-page PDFs (`svgs_to_pdf`). Single-page PDFs use `to_pdf()` which handles DPI internally.
- Pages without overflow are unaffected (no re-parsing needed).
- Related: [svg2pdf#25](https://github.com/typst/svg2pdf/issues/25) (DPI scaling in `to_chunk` vs `to_pdf`)