### PR TITLE
fix: moveToDocumentEnd 다중 구역 문서 지원 (#784)

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -159,6 +159,10 @@ export class WasmBridge {
     return this.doc?.pageCount() ?? 0;
   }
 
+  getSectionCount(): number {
+    return this.doc?.getSectionCount() ?? 0;
+  }
+
   getPageInfo(pageNum: number): PageInfo {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse(this.doc.getPageInfo(pageNum));

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -474,15 +474,15 @@ export class CursorState {
   moveToDocumentEnd(): void {
     this.preferredX = null;
     try {
-      // 마지막 구역의 마지막 문단 끝
-      const sec = 0; // 현재 단일 구역 가정
-      const paraCount = this.wasm.getParagraphCount(sec);
+      const secCount = this.wasm.getSectionCount();
+      const lastSec = secCount > 0 ? secCount - 1 : 0;
+      const paraCount = this.wasm.getParagraphCount(lastSec);
       if (paraCount > 0) {
         const lastPara = paraCount - 1;
-        const paraLen = this.wasm.getParagraphLength(sec, lastPara);
-        this.position = { sectionIndex: sec, paragraphIndex: lastPara, charOffset: paraLen };
+        const paraLen = this.wasm.getParagraphLength(lastSec, lastPara);
+        this.position = { sectionIndex: lastSec, paragraphIndex: lastPara, charOffset: paraLen };
       } else {
-        this.position = { sectionIndex: 0, paragraphIndex: 0, charOffset: 0 };
+        this.position = { sectionIndex: lastSec, paragraphIndex: 0, charOffset: 0 };
       }
       this.updateRect();
     } catch (e) {


### PR DESCRIPTION
## 변경 내용

`moveToDocumentEnd`가 `sectionIndex = 0` 하드코드로 다중 구역 문서에서 올바른 문서 끝 위치를 찾지 못하는 문제 수정.

## 원인

`const sec = 0` 하드코드 — 다중 구역 문서(예: aift.hwp, 3구역)에서 구역 0의 paragraphCount만 조회하여 마지막 구역의 문단에 도달 불가.

## 수정

`getSectionCount()`로 마지막 구역을 찾아 해당 구역의 마지막 문단 끝으로 이동.

```typescript
const secCount = this.wasm.getSectionCount();
const lastSec = secCount > 0 ? secCount - 1 : 0;
```

## 테스트

- `cargo test` + `cargo clippy -- -D warnings` 통과

closes #784

감사합니다.