### PR TITLE
feat: 쪽 새 번호로 시작 — insertNewNumber WASM API + dialog UI (#791)

### DIFF
--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from '../types';
 import { PageSetupDialog } from '@/ui/page-setup-dialog';
 import { SectionSettingsDialog } from '@/ui/section-settings-dialog';
+import { NewNumberDialog } from '@/ui/new-number-dialog';
 
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
   return {
@@ -267,7 +268,25 @@ export const pageCommands: CommandDef[] = [
       navigateHeaderFooter(services, 1);
     },
   },
-  stub('page:new-page-num', '새 번호로 시작'),
+  {
+    id: 'page:new-page-num',
+    label: '새 번호로 시작',
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      const cursor = (ih as any).cursor;
+      if (!cursor) return;
+      const pos = cursor.getPosition();
+      const wasm = services.wasm;
+      const eventBus = services.eventBus;
+      if (!wasm || !eventBus) return;
+      const dlg = new NewNumberDialog(wasm, eventBus, {
+        sec: pos.sectionIndex, para: pos.paragraphIndex, offset: pos.charOffset,
+      });
+      dlg.show();
+    },
+  },
   // ─── 머리말/꼬리말 현재 쪽 감추기 ──────────────
   {
     id: 'page:hide-headerfooter',

--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -271,7 +271,7 @@ export const pageCommands: CommandDef[] = [
   {
     id: 'page:new-page-num',
     label: '새 번호로 시작',
-    canExecute: (ctx) => ctx.hasDocument,
+    canExecute: (ctx) => ctx.hasDocument && !ctx.inTable,
     execute(services) {
       const ih = services.getInputHandler();
       if (!ih) return;

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -234,6 +234,11 @@ export class WasmBridge {
     return (this.doc as any).insertColumnBreak(sec, para, charOffset);
   }
 
+  insertNewNumber(sec: number, para: number, charOffset: number, startNum: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).insertNewNumber(sec, para, charOffset, startNum);
+  }
+
   setColumnDef(sec: number, columnCount: number, columnType: number, sameWidth: number, spacingHu: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).setColumnDef(sec, columnCount, columnType, sameWidth, spacingHu);

--- a/rhwp-studio/src/ui/new-number-dialog.ts
+++ b/rhwp-studio/src/ui/new-number-dialog.ts
@@ -57,8 +57,7 @@ export class NewNumberDialog extends ModalDialog {
       this.wasm.insertNewNumber(
         this.cursorPos.sec, this.cursorPos.para, this.cursorPos.offset, num,
       );
-      this.eventBus.emit('document:changed');
-      this.eventBus.emit('recompose:request');
+      this.eventBus.emit('document-changed');
     } catch (e) {
       console.warn('[NewNumberDialog] 삽입 실패:', e);
     }

--- a/rhwp-studio/src/ui/new-number-dialog.ts
+++ b/rhwp-studio/src/ui/new-number-dialog.ts
@@ -1,0 +1,66 @@
+import { ModalDialog } from './dialog';
+import type { EventBus } from '@/core/event-bus';
+
+export class NewNumberDialog extends ModalDialog {
+  private wasm: any;
+  private eventBus: EventBus;
+  private cursorPos: { sec: number; para: number; offset: number };
+  private numInput!: HTMLInputElement;
+
+  constructor(wasm: any, eventBus: EventBus, pos: { sec: number; para: number; offset: number }) {
+    super('새 번호로 시작', 300);
+    this.wasm = wasm;
+    this.eventBus = eventBus;
+    this.cursorPos = pos;
+  }
+
+  protected createBody(): HTMLElement {
+    const body = document.createElement('div');
+    body.style.padding = '16px';
+
+    const row = document.createElement('div');
+    row.style.display = 'flex';
+    row.style.alignItems = 'center';
+    row.style.gap = '8px';
+
+    const label = document.createElement('label');
+    label.textContent = '시작 번호:';
+    label.style.whiteSpace = 'nowrap';
+
+    this.numInput = document.createElement('input');
+    this.numInput.type = 'number';
+    this.numInput.min = '1';
+    this.numInput.max = '65535';
+    this.numInput.value = '1';
+    this.numInput.style.width = '80px';
+    this.numInput.style.padding = '4px 8px';
+
+    row.appendChild(label);
+    row.appendChild(this.numInput);
+    body.appendChild(row);
+
+    return body;
+  }
+
+  show(): void {
+    super.show();
+    setTimeout(() => {
+      this.numInput.focus();
+      this.numInput.select();
+    }, 50);
+  }
+
+  protected onConfirm(): void | boolean {
+    const num = parseInt(this.numInput.value, 10);
+    if (isNaN(num) || num < 1 || num > 65535) return false;
+    try {
+      this.wasm.insertNewNumber(
+        this.cursorPos.sec, this.cursorPos.para, this.cursorPos.offset, num,
+      );
+      this.eventBus.emit('document:changed');
+      this.eventBus.emit('recompose:request');
+    } catch (e) {
+      console.warn('[NewNumberDialog] 삽입 실패:', e);
+    }
+  }
+}

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -3750,3 +3750,66 @@ mod resize_clamp_tests {
         assert_eq!(common.height, 8000);
     }
 }
+
+impl crate::document_core::DocumentCore {
+    pub fn insert_new_number_native(
+        &mut self,
+        section_idx: usize,
+        para_idx: usize,
+        char_offset: usize,
+        start_num: u16,
+    ) -> Result<String, crate::error::HwpError> {
+        use crate::model::control::{Control, NewNumber, AutoNumberType};
+        use crate::error::HwpError;
+
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!("구역 인덱스 {} 범위 초과", section_idx)));
+        }
+        if para_idx >= self.document.sections[section_idx].paragraphs.len() {
+            return Err(HwpError::RenderError(format!("문단 인덱스 {} 범위 초과", para_idx)));
+        }
+
+        let new_number = NewNumber {
+            number_type: AutoNumberType::Page,
+            number: start_num,
+        };
+
+        self.document.sections[section_idx].raw_stream = None;
+        let paragraph = &mut self.document.sections[section_idx].paragraphs[para_idx];
+
+        let insert_idx = {
+            let positions = crate::document_core::helpers::find_control_text_positions(paragraph);
+            let mut idx = paragraph.controls.len();
+            for (i, &pos) in positions.iter().enumerate() {
+                if pos > char_offset {
+                    idx = i;
+                    break;
+                }
+            }
+            idx
+        };
+
+        paragraph.controls.insert(insert_idx, Control::NewNumber(new_number));
+        paragraph.ctrl_data_records.insert(insert_idx, None);
+
+        if !paragraph.char_offsets.is_empty() {
+            let text_len = paragraph.text.chars().count();
+            let safe_offset = char_offset.min(text_len);
+            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
+                *co += 8;
+            }
+        }
+        paragraph.char_count += 8;
+        paragraph.control_mask |= 1u32 << 0x0012;
+        paragraph.has_para_text = true;
+
+        self.reflow_paragraph(section_idx, para_idx);
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+        self.invalidate_page_tree_cache();
+
+        Ok(crate::document_core::helpers::json_ok_with(&format!(
+            "\"controlIdx\":{}", insert_idx
+        )))
+    }
+}

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1065,6 +1065,9 @@ impl HwpDocument {
         char_offset: u32,
         start_num: u32,
     ) -> Result<String, JsValue> {
+        if start_num == 0 || start_num > 65535 {
+            return Err(JsValue::from_str("start_num must be 1~65535"));
+        }
         self.insert_new_number_native(
             section_idx as usize,
             para_idx as usize,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1056,6 +1056,24 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    /// 새 번호 지정 컨트롤 삽입 (쪽 > 새 번호로 시작)
+    #[wasm_bindgen(js_name = insertNewNumber)]
+    pub fn insert_new_number(
+        &mut self,
+        section_idx: u32,
+        para_idx: u32,
+        char_offset: u32,
+        start_num: u32,
+    ) -> Result<String, JsValue> {
+        self.insert_new_number_native(
+            section_idx as usize,
+            para_idx as usize,
+            char_offset as usize,
+            start_num as u16,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 다단 설정 변경
     /// column_type: 0=일반, 1=배분, 2=평행
     /// same_width: 0=다른 너비, 1=같은 너비


### PR DESCRIPTION
## 변경 내용

`page:new-page-num` (쪽 > 새 번호로 시작) 커맨드를 stub에서 실동작으로 구현.

## 구현 범위

### Rust (WASM API)
- `insert_new_number_native`: 현재 커서 위치에 `Control::NewNumber(Page, startNum)` 삽입
  - `find_control_text_positions`로 삽입 인덱스 결정
  - `char_offsets` +8 조정 + `control_mask` 갱신
  - `reflow_paragraph` → `recompose_section` → `paginate_if_needed` 후처리
- WASM 바인딩: `insertNewNumber(sec, para, charOffset, startNum)`

### TypeScript (Dialog + Command)
- `NewNumberDialog`: ModalDialog 패턴, 시작 번호 입력 (1~65535)
- `wasm-bridge.ts`: `insertNewNumber` 메서드 추가
- `page.ts`: `page:new-page-num` stub → NewNumberDialog 호출로 교체

## 연동

PR #745 (Task #634)에서 구현된 NewNumber 페이지 번호 표시 로직과 연동:
- `typeset.rs`가 `Control::NewNumber`를 스캔하여 `new_page_numbers` 벡터에 적재
- 페이지 렌더링 시 해당 번호부터 표시

## 테스트

- `cargo test` + `cargo clippy -- -D warnings` 통과
- TypeScript `tsc --noEmit` 통과 (WASM 모듈 제외)

closes #791

감사합니다.