### PR TITLE
feat: 메뉴 열린 상태 단일 키 hotkey 항목 활성 인프라 (#792)

### DIFF
--- a/rhwp-studio/src/ui/menu-bar.ts
+++ b/rhwp-studio/src/ui/menu-bar.ts
@@ -92,11 +92,31 @@ export class MenuBar {
     });
   }
 
-  /** Escape 키 → 닫기 */
+  /** 메뉴 열린 상태 키보드 처리: Escape 닫기 + 단일 키 hotkey 항목 활성 (#792) */
   private setupKeyboardClose(): void {
     document.addEventListener('keydown', (e) => {
-      if (e.key === 'Escape' && this.openMenu) {
+      if (!this.openMenu) return;
+      if (e.key === 'Escape') {
         this.closeAll();
+        return;
+      }
+      // 메뉴 열린 상태에서 단일 키 (modifier 없음) → shortcutLabel 매칭
+      if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) return;
+      if (e.key.length !== 1) return;
+      const key = e.key.toUpperCase();
+      const items = this.openMenu.querySelectorAll('.md-item[data-cmd]:not(.disabled)');
+      for (const item of items) {
+        const shortcut = item.querySelector('.md-shortcut');
+        if (shortcut && shortcut.textContent?.toUpperCase() === key) {
+          e.preventDefault();
+          const cmd = (item as HTMLElement).dataset.cmd;
+          if (cmd) {
+            const params: Record<string, unknown> = { anchorEl: item };
+            this.dispatcher.dispatch(cmd, params);
+          }
+          this.closeAll();
+          return;
+        }
       }
     });
   }

--- a/rhwp-studio/src/ui/menu-bar.ts
+++ b/rhwp-studio/src/ui/menu-bar.ts
@@ -109,9 +109,13 @@ export class MenuBar {
         const shortcut = item.querySelector('.md-shortcut');
         if (shortcut && shortcut.textContent?.toUpperCase() === key) {
           e.preventDefault();
-          const cmd = (item as HTMLElement).dataset.cmd;
+          const el = item as HTMLElement;
+          const cmd = el.dataset.cmd;
           if (cmd) {
             const params: Record<string, unknown> = { anchorEl: item };
+            for (const [k, v] of Object.entries(el.dataset)) {
+              if (k !== 'cmd') params[k] = v;
+            }
             this.dispatcher.dispatch(cmd, params);
           }
           this.closeAll();


### PR DESCRIPTION
## 변경 내용

메뉴 드롭다운 열린 상태에서 단일 키 입력 시 `.md-shortcut` 텍스트와 매칭하여 해당 항목의 커맨드를 실행.

## 동작

1. 메뉴 열림 (예: 표 메뉴)
2. 사용자 `H` 키 입력
3. 열린 드롭다운의 활성 항목 중 `shortcutLabel === 'H'` 매칭
4. 해당 커맨드 디스패치 (`table:cell-height-equal`) + 메뉴 닫기

## 제약 조건

- modifier 키 (Ctrl/Alt/Shift/Meta) 동반 시 무시 — 전역 단축키와 충돌 방지
- 단일 문자 키만 (`.key.length === 1`)
- disabled 항목 제외
- 대소문자 무시

## 테스트

- TypeScript `tsc --noEmit` 통과

closes #792

감사합니다.