### PR TITLE
feat: F5 본문 블록 선택 모드 + F3 영역 확장 선택 (#220)

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -264,6 +264,11 @@ export class WasmBridge {
     return this.doc.getParagraphLength(sec, para);
   }
 
+  getSectionCount(): number {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).getSectionCount();
+  }
+
   getParagraphCount(sec: number): number {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.getParagraphCount(sec);

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -51,6 +51,10 @@ export class CursorState {
   /** 셀 선택 모드 시 표의 식별 정보 (sec/ppi/ci/dims) */
   private cellTableCtx: { sec: number; ppi: number; ci: number; rowCount: number; colCount: number; cellPath?: CellPathEntry[] } | null = null;
 
+  // ─── F5 본문 블록 선택 모드 (#220) ────────────────────────
+  private _blockSelectionMode = false;
+  private _expandPhase = 0; // F3 확장 단계: 0=none, 1=word, 2=paragraph, 3=section, 4=document
+
   // ─── 표 객체 선택 ──────────────────────────────────────
   private _tableObjectSelected = false;
   private selectedTableRef: { sec: number; ppi: number; ci: number; cellPath?: CellPathEntry[] } | null = null;
@@ -786,6 +790,61 @@ export class CursorState {
     return this._cellSelectionMode;
   }
 
+  // ─── F5 본문 블록 선택 (#220) ──────────────────────
+  isInBlockSelectionMode(): boolean { return this._blockSelectionMode; }
+
+  enterBlockSelectionMode(): void {
+    this._blockSelectionMode = true;
+    this._expandPhase = 0;
+    this.setAnchor();
+  }
+
+  exitBlockSelectionMode(): void {
+    this._blockSelectionMode = false;
+    this._expandPhase = 0;
+    this.clearSelection();
+  }
+
+  expandSelection(): void {
+    this._expandPhase++;
+    const pos = this.position;
+    const sec = pos.sectionIndex;
+    const para = pos.paragraphIndex;
+    try {
+      if (this._expandPhase === 1) {
+        // 단어 선택 — 현재 위치의 단어 범위
+        const paraLen = this.wasm.getParagraphLength(sec, para);
+        const text = this.wasm.getTextRange(sec, para, 0, paraLen);
+        const { start, end } = findWordAt(text, pos.charOffset);
+        this.anchor = { ...pos, charOffset: start };
+        this.position = { ...pos, charOffset: end };
+      } else if (this._expandPhase === 2) {
+        // 문단 전체 선택
+        const paraLen = this.wasm.getParagraphLength(sec, para);
+        this.anchor = { ...pos, charOffset: 0 };
+        this.position = { ...pos, charOffset: paraLen };
+      } else if (this._expandPhase === 3) {
+        // 구역 전체 선택
+        const paraCount = this.wasm.getParagraphCount(sec);
+        const lastParaLen = this.wasm.getParagraphLength(sec, paraCount - 1);
+        this.anchor = { sectionIndex: sec, paragraphIndex: 0, charOffset: 0 };
+        this.position = { sectionIndex: sec, paragraphIndex: paraCount - 1, charOffset: lastParaLen };
+      } else {
+        // 문서 전체 선택
+        const secCount = this.wasm.getSectionCount();
+        const lastSec = secCount - 1;
+        const lastParaCount = this.wasm.getParagraphCount(lastSec);
+        const lastParaLen = this.wasm.getParagraphLength(lastSec, lastParaCount - 1);
+        this.anchor = { sectionIndex: 0, paragraphIndex: 0, charOffset: 0 };
+        this.position = { sectionIndex: lastSec, paragraphIndex: lastParaCount - 1, charOffset: lastParaLen };
+        this._expandPhase = 4; // cap
+      }
+      this.updateRect();
+    } catch (e) {
+      console.warn('[CursorState] expandSelection 실패:', e);
+    }
+  }
+
   /** 셀 선택을 화살표 방향으로 이동한다 (anchor/focus 함께 이동, 단일 셀 선택). */
   moveCellSelection(deltaRow: number, deltaCol: number): void {
     if (!this._cellSelectionMode || !this.cellFocus || !this.cellTableCtx) return;
@@ -1234,4 +1293,29 @@ export class CursorState {
 
     this.updateRect();
   }
+}
+
+function isWordChar(c: string): boolean {
+  const code = c.charCodeAt(0);
+  if (code >= 0x30 && code <= 0x39) return true; // digit
+  if (code >= 0x41 && code <= 0x5A) return true; // A-Z
+  if (code >= 0x61 && code <= 0x7A) return true; // a-z
+  if (code >= 0xAC00 && code <= 0xD7AF) return true; // Hangul
+  if (code >= 0x3131 && code <= 0x318E) return true; // Hangul Jamo
+  return false;
+}
+
+function findWordAt(text: string, offset: number): { start: number; end: number } {
+  if (!text || offset >= text.length) return { start: offset, end: offset };
+  const atWord = isWordChar(text[offset] ?? '');
+  let start = offset;
+  let end = offset;
+  if (atWord) {
+    while (start > 0 && isWordChar(text[start - 1])) start--;
+    while (end < text.length && isWordChar(text[end])) end++;
+  } else {
+    while (start > 0 && !isWordChar(text[start - 1])) start--;
+    while (end < text.length && !isWordChar(text[end])) end++;
+  }
+  return { start, end };
 }

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -796,7 +796,7 @@ export class CursorState {
   enterBlockSelectionMode(): void {
     this._blockSelectionMode = true;
     this._expandPhase = 0;
-    this.setAnchor();
+    this.anchor = { ...this.position };
   }
 
   exitBlockSelectionMode(): void {

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -361,23 +361,42 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     return;
   }
 
-  // ─── F5 셀 선택 모드 진입/단계 전환 ────────────────────────────────
+  // ─── F5 블록 선택 모드 진입/해제 ────────────────────────────────
   if (e.key === 'F5') {
     e.preventDefault();
     if (this.cursor.isInCell() && !this.cursor.isInTextBox()) {
       if (this.cursor.isInCellSelectionMode()) {
-        // 이미 셀 선택 모드 → 다음 단계로 전환
         this.cursor.advanceCellSelectionPhase();
         this.updateCellSelection();
       } else {
-        // 셀 선택 모드 진입 (phase 1)
         if (this.cursor.enterCellSelectionMode()) {
           this.caret.hide();
           this.selectionRenderer.clear();
           this.updateCellSelection();
         }
       }
+    } else {
+      // 본문 블록 선택 모드 (#220)
+      if (this.cursor.isInBlockSelectionMode()) {
+        this.cursor.exitBlockSelectionMode();
+        this.selectionRenderer.clear();
+        this.updateCaret();
+      } else {
+        this.cursor.enterBlockSelectionMode();
+        this.updateSelection();
+      }
     }
+    return;
+  }
+
+  // ─── F3 선택 영역 확장 (#220) ──────────────────────────
+  if (e.key === 'F3') {
+    e.preventDefault();
+    if (!this.cursor.isInBlockSelectionMode()) {
+      this.cursor.enterBlockSelectionMode();
+    }
+    this.cursor.expandSelection();
+    this.updateSelection();
     return;
   }
 
@@ -599,6 +618,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     this.cursor.exitTableObjectSelection();
     this.eventBus.emit('table-object-selection-changed', false);
     // fall through
+  }
+
+  // ─── 본문 블록 선택 모드 해제 (#220) ──────────────────────
+  if (this.cursor.isInBlockSelectionMode() && e.key === 'Escape') {
+    e.preventDefault();
+    this.cursor.exitBlockSelectionMode();
+    this.selectionRenderer.clear();
+    this.updateCaret();
+    return;
   }
 
   // ─── 셀 선택 모드 중 키 처리 ────────────────────────────


### PR DESCRIPTION
## 변경 내용

한컴 HWP의 F5 블록 선택 + F3 영역 확장 기능 구현.

## F5 블록 선택 모드 (본문)

- 본문에서 F5: 현재 위치에 anchor 설정, 블록 선택 모드 진입
- 이후 화살표 키 이동 시 선택 영역 자동 확장 (Shift 없이)
- F5 재입력 또는 Esc: 모드 해제 + 선택 해제
- 기존 F5 표 셀 선택 모드는 그대로 유지 (`isInCell()` 분기)

## F3 선택 영역 확장

| 입력 횟수 | 확장 범위 |
|-----------|----------|
| F3 1회 | 현재 커서 위치의 단어 |
| F3 2회 | 현재 문단 전체 |
| F3 3회 | 현재 구역 전체 |
| F3 4회 | 문서 전체 |

- F3 첫 입력 시 블록 모드 자동 진입
- `findWordAt()` 헬퍼: Hangul/Latin/Digit 분류 기반 단어 경계 감지

## 추가 변경

- `wasm-bridge.ts`: `getSectionCount()` 메서드 추가

## 테스트

- `cargo clippy -- -D warnings` 통과
- TypeScript `tsc --noEmit` 통과

closes #220

감사합니다.