### PR TITLE
fix: master page 글상자 더블클릭 시 첫 페이지 jump 방지 (#686)

### DIFF
--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -815,6 +815,18 @@ export function onDblClick(this: any, e: MouseEvent): void {
     // 글상자 객체 → 텍스트 편집 진입
     if (ref && ref.type === 'shape') {
       e.preventDefault();
+      // #686: master page 글상자 (sec=0, ppi=0 앵커) 더블클릭 시 page jump 방지
+      // master page 글상자는 첫 문단(ppi=0)에 앵커 → cursor rect 가 page 0 으로 잡힘
+      // 현재 보고 있는 페이지와 다르면 진입 차단, 선택만 해제
+      const currentPage = this.cursor.getRect()?.pageIndex ?? 0;
+      if (ref.ppi === 0 && currentPage > 0) {
+        this.cursor.exitPictureObjectSelection();
+        this.pictureObjectRenderer?.clear();
+        this.eventBus.emit('picture-object-selection-changed', false);
+        this.updateCaret();
+        this.textarea.focus();
+        return;
+      }
       this.cursor.exitPictureObjectSelection();
       this.pictureObjectRenderer?.clear();
       this.eventBus.emit('picture-object-selection-changed', false);

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -815,17 +815,17 @@ export function onDblClick(this: any, e: MouseEvent): void {
     // 글상자 객체 → 텍스트 편집 진입
     if (ref && ref.type === 'shape') {
       e.preventDefault();
-      // #686: master page 글상자 (sec=0, ppi=0 앵커) 더블클릭 시 page jump 방지
-      // master page 글상자는 첫 문단(ppi=0)에 앵커 → cursor rect 가 page 0 으로 잡힘
-      // 현재 보고 있는 페이지와 다르면 진입 차단, 선택만 해제
-      const currentPage = this.cursor.getRect()?.pageIndex ?? 0;
-      if (ref.ppi === 0 && currentPage > 0) {
-        this.cursor.exitPictureObjectSelection();
-        this.pictureObjectRenderer?.clear();
-        this.eventBus.emit('picture-object-selection-changed', false);
-        this.updateCaret();
-        this.textarea.focus();
-        return;
+      // #686: ppi=0 앵커 도형 (master page 글상자 등)은 모든 페이지에 반복 표시됨.
+      // 텍스트 진입 시 cursor가 page 0으로 잡혀 뷰가 점프하므로, page 0이 아닐 때 차단.
+      if (ref.ppi === 0) {
+        const cursorPage = this.cursor.getRect()?.pageIndex ?? -1;
+        if (cursorPage !== 0) {
+          this.cursor.exitPictureObjectSelection();
+          this.pictureObjectRenderer?.clear();
+          this.eventBus.emit('picture-object-selection-changed', false);
+          this.textarea.focus();
+          return;
+        }
       }
       this.cursor.exitPictureObjectSelection();
       this.pictureObjectRenderer?.clear();


### PR DESCRIPTION
## 변경 내용

master page 자동번호 글상자 (ppi=0 앵커) 더블클릭 시 viewport 가 첫 페이지로 점프하는 문제 수정.

## 원인

master page 글상자는 `sec=0, para=0, control=0`에 앵커되어 모든 페이지에 출력됨.
더블클릭 시 `enterTextboxEditing`이 cursor를 sec=0, para=0 기준으로 이동 →
`cursor.getRect().pageIndex = 0` → `scrollCaretIntoView` 가 page 0 부근으로 스크롤.

## 수정

`ppi === 0` 앵커 shape 에 대해 현재 보고 있는 페이지가 0보다 크면:
- 텍스트 편집 진입 차단 (한컴 동작: body 가장 가까운 caret 으로 fallback)
- 선택만 해제하고 현재 페이지 유지

## 한컴 동작 정합

한컴에서도 master page 글상자 더블클릭 시 텍스트 편집 모드 진입 안 됨 — 본문 마지막 caret 으로 fallback.

## 테스트

- TypeScript `tsc --noEmit` 통과

closes #686

감사합니다.