### PR TITLE
fix: searchAllText API 추가 — rhwpDev.search() 다중 매치 수정 (#692)

### DIFF
--- a/rhwp-studio/src/core/rhwp-dev.ts
+++ b/rhwp-studio/src/core/rhwp-dev.ts
@@ -1,0 +1,121 @@
+import type { WasmBridge } from './wasm-bridge';
+import type { SearchHit } from './types';
+
+interface TextRunInfo {
+  secIdx: number;
+  paraIdx: number;
+  charStart: number;
+  x: number;
+  y: number;
+  text: string;
+  parentParaIdx?: number;
+  controlIdx?: number;
+  cellIdx?: number;
+  cellParaIdx?: number;
+}
+
+function containerKey(run: TextRunInfo): string {
+  if (run.parentParaIdx != null) {
+    return `cell[p${run.parentParaIdx},c${run.controlIdx ?? 0},i${run.cellIdx ?? 0}]`;
+  }
+  return 'body';
+}
+
+
+export function initRhwpDev(wasm: WasmBridge): void {
+  const dev = {
+    showAllIds(pageNum?: number): void {
+      const totalPages = wasm.pageCount;
+      const startPage = pageNum ?? 0;
+      const endPage = pageNum != null ? pageNum + 1 : totalPages;
+      const entries: Array<{
+        page: number; container: string;
+        secIdx: number; paraIdx: number; charStart: number;
+        x: number; y: number; text: string;
+      }> = [];
+
+      for (let p = startPage; p < endPage; p++) {
+        let data: any;
+        try {
+          const layout = (wasm as any).doc.getPageTextLayout(p);
+          data = JSON.parse(layout);
+        } catch { continue; }
+        if (!data || !Array.isArray(data.runs)) continue;
+
+        for (const run of data.runs as TextRunInfo[]) {
+          if (run.secIdx == null || run.paraIdx == null) continue;
+          entries.push({
+            page: p,
+            container: containerKey(run),
+            secIdx: run.secIdx,
+            paraIdx: run.paraIdx,
+            charStart: run.charStart ?? 0,
+            x: run.x ?? 0,
+            y: run.y ?? 0,
+            text: (run.text ?? '').slice(0, 20),
+          });
+        }
+      }
+
+      const seen = new Set<string>();
+      const unique = entries.filter(e => {
+        const key = `${e.page}:${e.container}:${e.secIdx}:${e.paraIdx}`;
+        if (seen.has(key)) return false;
+        seen.add(key);
+        return true;
+      });
+
+      console.table(unique);
+      console.log(`[rhwpDev] showAllIds: ${unique.length} unique paragraph IDs across pages ${startPage}~${endPage - 1}`);
+    },
+
+    search(text: string, includeCells: boolean = false): SearchHit[] {
+      const results = wasm.searchAllText(text, false, includeCells);
+      if (results.length === 0) {
+        console.warn(`[rhwpDev] search("${text}"): not found`);
+      } else {
+        console.log(`[rhwpDev] search("${text}"): ${results.length} match(es)`);
+        console.table(results);
+      }
+      return results;
+    },
+
+    findNearest(targetId: number, pageNum?: number): { paraIdx: number; distance: number; text: string; container: string } | null {
+      const totalPages = wasm.pageCount;
+      const page = pageNum ?? 0;
+      if (page >= totalPages) return null;
+
+      let data: any;
+      try {
+        const layout = (wasm as any).doc.getPageTextLayout(page);
+        data = JSON.parse(layout);
+      } catch { return null; }
+      if (!data || !Array.isArray(data.runs)) return null;
+
+      let nearest: { paraIdx: number; distance: number; text: string; container: string } | null = null;
+      for (const run of data.runs as TextRunInfo[]) {
+        const id = run.paraIdx;
+        if (id == null) continue;
+        const dist = Math.abs(id - targetId);
+        if (!nearest || dist < nearest.distance) {
+          nearest = { paraIdx: id, distance: dist, text: (run.text ?? '').slice(0, 30), container: containerKey(run) };
+        }
+      }
+      if (nearest) {
+        console.log(`[rhwpDev] findNearest(${targetId}, page=${page}): closest paraIdx=${nearest.paraIdx} (${nearest.container}, distance=${nearest.distance}) "${nearest.text}"`);
+      }
+      return nearest;
+    },
+
+    help(): void {
+      console.log(`%c[rhwpDev]%c Debugging Toolkit
+  .showAllIds(page?)           — list all paragraph IDs with container context (console.table)
+  .search("text", cells?)      — find all matches: section/paragraph/offset (returns array)
+  .findNearest(id, page?)      — find nearest valid paraIdx to a given ID
+  .help()                      — this message`, 'color:#2563eb;font-weight:bold', 'color:inherit');
+    },
+  };
+
+  (window as any).rhwpDev = dev;
+  console.log('%c[rhwpDev]%c Debugging toolkit loaded — rhwpDev.help() for usage', 'color:#2563eb;font-weight:bold', 'color:inherit');
+}

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -568,6 +568,20 @@ export interface SearchResult {
   };
 }
 
+/** 전체 검색 결과 항목 */
+export interface SearchHit {
+  sec: number;
+  para: number;
+  charOffset: number;
+  length: number;
+  cellContext?: {
+    parentPara: number;
+    ctrlIdx: number;
+    cellIdx: number;
+    cellPara: number;
+  };
+}
+
 /** 치환 결과 */
 export interface ReplaceResult {
   ok: boolean;

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -571,9 +571,11 @@ export interface SearchResult {
 /** 전체 검색 결과 항목 */
 export interface SearchHit {
   sec: number;
+  /** 본문 매치: 문단 인덱스. 셀 매치: 부모(호스트) 문단 인덱스 (= cellContext.parentPara) */
   para: number;
   charOffset: number;
   length: number;
+  /** 표 셀/글상자 내부 매치 시 컨텍스트. cellPara가 실제 매치 문단 인덱스 */
   cellContext?: {
     parentPara: number;
     ctrlIdx: number;

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1274,6 +1274,11 @@ export class WasmBridge {
     return JSON.parse((this.doc as any).searchText(query, fromSec, fromPara, fromChar, forward, caseSensitive));
   }
 
+  searchAllText(query: string, caseSensitive: boolean, includeCells: boolean = false): import('./types').SearchHit[] {
+    if (!this.doc || typeof (this.doc as any).searchAllText !== 'function') return [];
+    return JSON.parse((this.doc as any).searchAllText(query, caseSensitive, includeCells));
+  }
+
   replaceText(sec: number, para: number, charOffset: number, length: number, newText: string): import('./types').ReplaceResult {
     if (!this.doc || typeof (this.doc as any).replaceText !== 'function') return { ok: false };
     return JSON.parse((this.doc as any).replaceText(sec, para, charOffset, length, newText));

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -21,6 +21,7 @@ import { ContextMenu } from '@/ui/context-menu';
 import { CommandPalette } from '@/ui/command-palette';
 import { showValidationModalIfNeeded } from '@/ui/validation-modal';
 import { showToast } from '@/ui/toast';
+import { initRhwpDev } from '@/core/rhwp-dev';
 import { CellSelectionRenderer } from '@/engine/cell-selection-renderer';
 import { TableObjectRenderer } from '@/engine/table-object-renderer';
 import { TableResizeRenderer } from '@/engine/table-resize-renderer';
@@ -29,10 +30,11 @@ import { Ruler } from '@/view/ruler';
 const wasm = new WasmBridge();
 const eventBus = new EventBus();
 
-// E2E 테스트용 전역 노출 (개발 모드 전용)
+// E2E 테스트용 전역 노출 (개발 모드 전���)
 if (import.meta.env.DEV) {
   (window as any).__wasm = wasm;
   (window as any).__eventBus = eventBus;
+  initRhwpDev(wasm);
 }
 let canvasView: CanvasView | null = null;
 let inputHandler: InputHandler | null = null;

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -30,7 +30,7 @@ import { Ruler } from '@/view/ruler';
 const wasm = new WasmBridge();
 const eventBus = new EventBus();
 
-// E2E 테스트용 전역 노출 (개발 모드 전���)
+// E2E 테스트용 전역 노출 (개발 모드 전용)
 if (import.meta.env.DEV) {
   (window as any).__wasm = wasm;
   (window as any).__eventBus = eventBus;

--- a/src/document_core/queries/search_query.rs
+++ b/src/document_core/queries/search_query.rs
@@ -186,6 +186,51 @@ impl DocumentCore {
         }
     }
 
+    /// 문서 전체 검색 (모든 매치 반환)
+    ///
+    /// 본문 문단의 모든 매치를 배열로 반환한다. 표/글상자 내부 포함 여부는
+    /// include_cells 파라미터로 결정.
+    ///
+    /// 반환: JSON `[{"sec":0,"para":1,"charOffset":5,"length":3,"cellContext":...}, ...]`
+    pub fn search_all_text_native(
+        &self,
+        query: &str,
+        case_sensitive: bool,
+        include_cells: bool,
+    ) -> Result<String, HwpError> {
+        if query.is_empty() {
+            return Ok("[]".to_string());
+        }
+
+        let all_hits = search_all(self, query, case_sensitive);
+        if all_hits.is_empty() {
+            return Ok("[]".to_string());
+        }
+
+        let hits: Vec<&SearchHit> = if include_cells {
+            all_hits.iter().collect()
+        } else {
+            all_hits.iter().filter(|h| h.cell_context.is_none()).collect()
+        };
+
+        let mut json_parts: Vec<String> = Vec::with_capacity(hits.len());
+        for h in &hits {
+            let cell_ctx = match &h.cell_context {
+                Some((pp, ci, cell, cp)) => format!(
+                    ",\"cellContext\":{{\"parentPara\":{},\"ctrlIdx\":{},\"cellIdx\":{},\"cellPara\":{}}}",
+                    pp, ci, cell, cp
+                ),
+                None => String::new(),
+            };
+            json_parts.push(format!(
+                "{{\"sec\":{},\"para\":{},\"charOffset\":{},\"length\":{}{}}}",
+                h.sec, h.para, h.char_offset, h.length, cell_ctx
+            ));
+        }
+
+        Ok(format!("[{}]", json_parts.join(",")))
+    }
+
     /// 텍스트 치환 (단일)
     ///
     /// 검색 결과 위치의 텍스트를 new_text로 교체한다.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2726,6 +2726,19 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// 문서 전체 검색 (모든 매치 반환)
+    #[wasm_bindgen(js_name = searchAllText)]
+    pub fn search_all_text(
+        &self,
+        query: &str,
+        case_sensitive: bool,
+        include_cells: bool,
+    ) -> Result<String, JsValue> {
+        self.core
+            .search_all_text_native(query, case_sensitive, include_cells)
+            .map_err(|e| e.into())
+    }
+
     /// 텍스트 치환 (단일)
     #[wasm_bindgen(js_name = replaceText)]
     pub fn replace_text(


### PR DESCRIPTION
## 문제

`rhwpDev.search(text)` 다중 매치 수집이 불완전합니다 (#692).

**근본 원인**: `search_text_native`의 단건 검색은 `h.char_offset > from_char` (strict greater-than)으로 비교하여, 위치 0에서 시작하는 매치를 누락합니다. 반복 호출 방식은 wrap-around 가드, 후진 가드 등의 복잡한 종료 조건이 필요하며, 이들이 불완전하여 결과가 미정합됩니다.

## 해결

`search_all()` 내부 함수를 WASM으로 직접 노출하는 `searchAllText` API를 추가하여 모든 매치를 일괄 반환합니다. `rhwpDev.search()`를 반복 호출 → 일괄 호출로 교체하여 iteration 관련 버그를 근본적으로 제거합니다.

## 변경 사항

| 파일 | 변경 |
|------|------|
| `search_query.rs` | `search_all_text_native()` 메서드 추가 — 본문/셀 포함 여부 선택 가능 |
| `wasm_api.rs` | `searchAllText(query, caseSensitive, includeCells)` WASM 바인딩 |
| `types.ts` | `SearchHit` 인터페이스 추가 |
| `wasm-bridge.ts` | `searchAllText()` 브릿지 메서드 |
| `rhwp-dev.ts` | `search()`를 `searchAllText()` 기반으로 재작성, `includeCells` 옵션 추가 |
| `main.ts` | DEV 모드에서 `initRhwpDev(wasm)` 호출 추가 |

## 검증

- `cargo test` 전체 통과
- `cargo clippy -- -D warnings` 경고 없음

감사합니다.