### PR TITLE
test: PUA U+F02B1~F02BC CharOverlap 변환 검증 (#727)

### DIFF
--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -660,3 +660,40 @@ fn test_tokenize_line_break() {
     assert_eq!(tokens.len(), 3);
     assert!(matches!(tokens[1], BreakToken::LineBreak { idx: 1 }));
 }
+
+/// PUA U+F02B1~F02BC → CharOverlap (border_type=3, 사각형 안 숫자)
+#[test]
+fn test_pua_enclosed_number_becomes_char_overlap() {
+    let para = Paragraph {
+        text: "\u{F02B1} 테스트".to_string(),
+        char_offsets: vec![0, 1, 2, 3, 4],
+        char_count: 6,
+        char_shapes: vec![CharShapeRef { start_pos: 0, char_shape_id: 0 }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            line_height: 800,
+            baseline_distance: 640,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let composed = compose_paragraph(&para);
+    assert_eq!(composed.lines.len(), 1);
+    let runs = &composed.lines[0].runs;
+    let overlap_run = runs.iter().find(|r| r.char_overlap.is_some());
+    assert!(overlap_run.is_some(), "U+F02B1 should produce a CharOverlap run");
+    let overlap = overlap_run.unwrap().char_overlap.as_ref().unwrap();
+    assert_eq!(overlap.border_type, 3, "border_type should be 3 (rectangle)");
+}
+
+/// pua_to_display_text correctly converts F02B1~F02BC to "1"~"12"
+#[test]
+fn test_pua_to_display_text_range() {
+    assert_eq!(pua_to_display_text('\u{F02B1}'), Some("1".to_string()));
+    assert_eq!(pua_to_display_text('\u{F02B9}'), Some("9".to_string()));
+    assert_eq!(pua_to_display_text('\u{F02BA}'), Some("10".to_string()));
+    assert_eq!(pua_to_display_text('\u{F02BB}'), Some("11".to_string()));
+    assert_eq!(pua_to_display_text('\u{F02BC}'), Some("12".to_string()));
+    assert_eq!(pua_to_display_text('\u{F02C4}'), Some("20".to_string()));
+}

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -661,7 +661,7 @@ fn test_tokenize_line_break() {
     assert!(matches!(tokens[1], BreakToken::LineBreak { idx: 1 }));
 }
 
-/// PUA U+F02B1~F02BC → CharOverlap (border_type=3, 사각형 안 숫자)
+/// PUA U+F02B1~F02C4 → CharOverlap (border_type=3, 사각형 안 숫자 1~20)
 #[test]
 fn test_pua_enclosed_number_becomes_char_overlap() {
     let para = Paragraph {
@@ -687,7 +687,7 @@ fn test_pua_enclosed_number_becomes_char_overlap() {
     assert_eq!(overlap.border_type, 3, "border_type should be 3 (rectangle)");
 }
 
-/// pua_to_display_text correctly converts F02B1~F02BC to "1"~"12"
+/// pua_to_display_text correctly converts F02B1~F02C4 to "1"~"20"
 #[test]
 fn test_pua_to_display_text_range() {
     assert_eq!(pua_to_display_text('\u{F02B1}'), Some("1".to_string()));


### PR DESCRIPTION
## 요약

Issue #727 조사 결과 및 단위 테스트 추가.

## 조사 결과

`convert_pua_enclosed_numbers` 메커니즘은 정상 동작합니다:
- U+F02B1~F02C4 → `CharOverlapInfo { border_type: 3 }` (사각형) 정확히 변환
- `pua_to_display_text` → "1"~"20" 정확히 반환
- SVG/Canvas 렌더러의 `draw_char_overlap` → border_type=3 시 사각형 + 숫자 텍스트 렌더링

웹 뷰어에서 ① 출력 현상은 중첩 표(11×3 그리드)의 렌더링 경로와 관련될 가능성이 있습니다. 현재 SVG 내보내기에서는 중첩 표 셀 내용이 출력되지 않으며 (#726), 이는 별도 이슈입니다.

## 추가된 테스트

1. `test_pua_enclosed_number_becomes_char_overlap`: compose_paragraph 통과 시 CharOverlap(border_type=3) 런 생성 확인
2. `test_pua_to_display_text_range`: F02B1~F02BC → "1"~"12", F02C4 → "20" 변환 확인

## 검증

- `cargo test --lib pua` — 2건 통과
- `cargo test` — 1068건 전체 통과
- `cargo clippy -- -D warnings` — 경고 없음

감사합니다.