### PR TITLE
fix: 1×1 래퍼 표 shortcut 다수 중첩 표 누락 수정 (#726)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -131,11 +131,16 @@ impl LayoutEngine {
             if depth == 0 { return y_start; } else { return 0.0; }
         }
         // 1x1 래퍼 표 감지: 외곽 표를 무시하고 내부 표를 직접 렌더링
+        // 단, 셀 안에 표가 정확히 1개일 때만 shortcut 적용 (다수 표 시 일반 경로)
         if table.row_count == 1 && table.col_count == 1 && table.cells.len() == 1 {
             let cell = &table.cells[0];
             let has_visible_text = cell.paragraphs.iter()
                 .any(|p| p.text.chars().any(|ch| !ch.is_whitespace() && ch != '\r' && ch != '\n'));
-            if !has_visible_text {
+            let nested_table_count = cell.paragraphs.iter()
+                .flat_map(|p| p.controls.iter())
+                .filter(|c| matches!(c, Control::Table(_)))
+                .count();
+            if !has_visible_text && nested_table_count == 1 {
                 if let Some(nested) = cell.paragraphs.iter()
                     .flat_map(|p| p.controls.iter())
                     .find_map(|c| if let Control::Table(t) = c { Some(t.as_ref()) } else { None })


### PR DESCRIPTION
## 문제

`table-vpos-01.hwpx` 5쪽 nested 11×3 그리드가 SVG 출력에서 완전히 누락됩니다 (#726).

## 근본 원인

`table_layout.rs`의 1×1 래퍼 표 감지 최적화:
```rust
if let Some(nested) = cell.paragraphs.iter()
    .flat_map(|p| p.controls.iter())
    .find_map(|c| if let Control::Table(t) = c { Some(t) })
{
    return self.layout_table(..., nested, ...);
}
```

`find_map`이 첫 번째 `Control::Table`만 반환 후 즉시 `return` → 셀 안에 표가 2개 이상일 때 두 번째부터 렌더링 누락.

`table-vpos-01.hwpx` p.5 구조:
- 외곽 1×1 래퍼 표
  - 셀[0] paras=2
    - p[0]: 제목 1×1 표 ✅ (find_map으로 찾음)
    - p[1]: 본문 11×3 그리드 ❌ (find_map 이후 return으로 스킵)

## 수정

셀 안 중첩 표가 정확히 1개일 때만 shortcut 적용. 2개 이상이면 일반 `layout_table_cells` 경로로 폴스루하여 모든 중첩 표 렌더링.

## 검증

SVG 내보내기 비교 (table-vpos-01.hwpx p.5):

| 항목 | 수정 전 | 수정 후 |
|------|---------|---------|
| SVG 행 수 | 89 | 485 |
| `<text>` 요소 | 55 | 343 |
| CharOverlap 사각형 | 0 | 9 |
| 그리드 내용 | 없음 | 4대 추진전략 + 12대 추진과제 전체 |

- `cargo test` — 전체 통과
- `cargo clippy -- -D warnings` — 경고 없음

감사합니다.