### PR TITLE
fix: SVG 폰트 폴백 체인 — 영문 세리프 폰트명 인식 개선 (#616)

### DIFF
--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -570,7 +570,7 @@ pub fn generic_fallback(font_family: &str) -> &'static str {
         // AppleMyungjo 보다 앞에 두어야 macOS Chrome 에서 CJK 글리프 bold 매칭 성공.
         return "'Batang','바탕','Nanum Myeongjo','AppleMyungjo','Noto Serif KR','Noto Serif CJK KR',serif";
     }
-    // 세리프 키워드 (영문) — "serif" 포함 but "sans-serif" 제외
+    // 세리프 키워드 (영문) — "serif" 포함하되 "sans" 부분 문자열을 가진 폰트명 전체 제외
     if lower.contains("times") || lower.contains("hymjre")
         || lower.contains("palatino") || lower.contains("georgia")
         || lower.contains("batang") || lower.contains("gungsuh")
@@ -966,6 +966,15 @@ mod tests {
         assert_eq!(generic_fallback("굴림체"), mono);
         assert_eq!(generic_fallback("바탕체"), mono);
         assert_eq!(generic_fallback("Courier New"), mono);
+        assert_eq!(generic_fallback("D2Coding ligature"), mono);
+        assert_eq!(generic_fallback("Noto Sans Mono"), mono);
+        // 영문 세리프 (issue #616)
+        assert_eq!(generic_fallback("Noto Serif CJK SC"), serif);
+        assert_eq!(generic_fallback("Liberation Serif"), serif);
+        assert_eq!(generic_fallback("Noto Serif KR"), serif);
+        // "sans" 포함 폰트는 세리프로 분류되지 않음
+        assert_eq!(generic_fallback("Liberation Sans"), sans);
+        assert_eq!(generic_fallback("Noto Sans KR"), sans);
         // 빈 문자열
         assert_eq!(generic_fallback(""), sans);
     }

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -556,6 +556,7 @@ pub fn generic_fallback(font_family: &str) -> &'static str {
     if font_family.contains("굴림체") || font_family.contains("바탕체")
         || lower.contains("gulimche") || lower.contains("batangche")
         || lower.contains("coding") || lower.contains("courier")
+        || lower.contains("mono")
     {
         // Monospace: Windows → 오픈소스 → generic
         return "'GulimChe','굴림체','D2Coding','Noto Sans Mono',monospace";
@@ -569,10 +570,11 @@ pub fn generic_fallback(font_family: &str) -> &'static str {
         // AppleMyungjo 보다 앞에 두어야 macOS Chrome 에서 CJK 글리프 bold 매칭 성공.
         return "'Batang','바탕','Nanum Myeongjo','AppleMyungjo','Noto Serif KR','Noto Serif CJK KR',serif";
     }
-    // 세리프 키워드 (영문)
+    // 세리프 키워드 (영문) — "serif" 포함 but "sans-serif" 제외
     if lower.contains("times") || lower.contains("hymjre")
         || lower.contains("palatino") || lower.contains("georgia")
         || lower.contains("batang") || lower.contains("gungsuh")
+        || (lower.contains("serif") && !lower.contains("sans"))
     {
         return "'Batang','바탕','Nanum Myeongjo','AppleMyungjo','Noto Serif KR','Noto Serif CJK KR',serif";
     }

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -1403,7 +1403,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            format!("{},sans-serif", style.font_family)
+            let fb = super::generic_fallback(&style.font_family);
+            format!("{},{}", style.font_family, fb)
         };
         let mut font_attrs = format!("font-family=\"{}\" font-size=\"{:.2}\"", escape_xml(&font_family_str), inner_font_size);
         if style.is_visually_bold() { font_attrs.push_str(" font-weight=\"bold\""); }
@@ -1477,7 +1478,8 @@ impl SvgRenderer {
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
         } else {
-            format!("{},sans-serif", style.font_family)
+            let fb = super::generic_fallback(&style.font_family);
+            format!("{},{}", style.font_family, fb)
         };
         let mut font_attrs = format!("font-family=\"{}\" font-size=\"{:.2}\"", escape_xml(&font_family_str), inner_font_size);
         if style.is_visually_bold() { font_attrs.push_str(" font-weight=\"bold\""); }


### PR DESCRIPTION
## 요약

`generic_fallback()`이 영문 세리프/고정폭 폰트명을 제대로 인식하지 못해, 폰트 미설치 환경에서 잘못된 폴백 체인이 적용되던 문제를 수정합니다.

## 문제

- `Noto Serif CJK SC`, `Liberation Serif` 등 영문명에 "Serif"를 포함하는 폰트가 sans-serif 폴백을 받음
- char_overlap 렌더링(원문자/사각형 번호)에서 `generic_fallback()` 대신 하드코딩된 `,sans-serif` 사용

## 수정

| 변경 | 파일 |
|------|------|
| "serif" 포함 + "sans" 미포함 → 세리프 폴백 | `renderer/mod.rs` |
| "mono" 포함 → 고정폭 폴백 | `renderer/mod.rs` |
| char_overlap에서 `generic_fallback()` 사용 | `renderer/svg.rs` |

## 검증

[freedomofpress/dangerzone-image](https://github.com/freedomofpress/dangerzone-image) 샘플로 테스트:

```
# Before
Noto Serif CJK SC → sans-serif chain (잘못됨)
Liberation Serif   → sans-serif chain (잘못됨)

# After
Noto Serif CJK SC → Batang,바탕,Nanum Myeongjo,...,serif (올바름)
Liberation Serif   → Batang,바탕,Nanum Myeongjo,...,serif (올바름)
```

Ref #616

감사합니다.