### PR TITLE
feat: Ctrl+Delete 단어 단위 전방 삭제 (#260)

### DIFF
--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -895,6 +895,7 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
   // 커맨드 시스템에 없는 직접 처리 (Ctrl+Home/End, Ctrl+Delete 등)
   switch (e.key.toLowerCase()) {
     case 'delete': {
+      if (!e.ctrlKey) break;
       e.preventDefault();
       deleteWordForward.call(this);
       break;
@@ -942,13 +943,48 @@ function deleteWordForward(this: any): void {
     return;
   }
   const pos = this.cursor.getPosition();
+  const inCell = this.cursor.isInCell();
   const { sectionIndex: sec, paragraphIndex: para, charOffset } = pos;
-  const paraLen = this.wasm.getParagraphLength(sec, para);
+  // 필드 경계 보호
+  try {
+    const fi = this.wasm.getFieldInfoAt(pos);
+    if (fi.inField && charOffset >= fi.endCharIdx) return;
+  } catch { /* ignore */ }
+  let paraLen: number;
+  if (inCell && pos.parentParaIndex != null && pos.controlIndex != null && pos.cellIndex != null && pos.cellParaIndex != null) {
+    try {
+      paraLen = this.wasm.getCellParagraphLength(sec, pos.parentParaIndex, pos.controlIndex, pos.cellIndex, pos.cellParaIndex);
+    } catch { paraLen = this.wasm.getParagraphLength(sec, para); }
+  } else {
+    paraLen = this.wasm.getParagraphLength(sec, para);
+  }
   if (charOffset >= paraLen) {
-    this.handleDelete(pos, this.cursor.isInCell());
+    this.handleDelete(pos, inCell);
     return;
   }
-  const wordEnd = findWordBoundaryForward(this.wasm, sec, para, charOffset, paraLen);
+  let text: string;
+  const remaining = paraLen - charOffset;
+  if (inCell && pos.parentParaIndex != null && pos.controlIndex != null && pos.cellIndex != null && pos.cellParaIndex != null) {
+    try {
+      text = this.wasm.getTextInCell(sec, pos.parentParaIndex, pos.controlIndex, pos.cellIndex, pos.cellParaIndex, charOffset, remaining);
+    } catch { text = this.wasm.getTextRange(sec, para, charOffset, remaining); }
+  } else {
+    text = this.wasm.getTextRange(sec, para, charOffset, remaining);
+  }
+  const delta = findWordEndInText(text);
+  const wordEnd = charOffset + delta;
+  // 필드 경계 클램프
+  try {
+    const fi = this.wasm.getFieldInfoAt(pos);
+    if (fi.inField && wordEnd > fi.endCharIdx) {
+      if (fi.endCharIdx > charOffset) {
+        this.cursor.setAnchor();
+        this.cursor.moveTo({ ...pos, charOffset: fi.endCharIdx });
+        this.deleteSelection();
+      }
+      return;
+    }
+  } catch { /* ignore */ }
   if (wordEnd > charOffset) {
     this.cursor.setAnchor();
     this.cursor.moveTo({ ...pos, charOffset: wordEnd });
@@ -956,16 +992,11 @@ function deleteWordForward(this: any): void {
   }
 }
 
-function findWordBoundaryForward(wasm: WasmBridge, sec: number, para: number, offset: number, paraLen: number): number {
-  if (offset >= paraLen) return paraLen;
-  const remaining = paraLen - offset;
-  const text = wasm.getTextRange(sec, para, offset, remaining);
+function findWordEndInText(text: string): number {
   let i = 0;
-  // 1) 단어 문자 건너뛰기
   while (i < text.length && !isWordSep(text[i])) i++;
-  // 2) 공백/구두점 건너뛰기
   while (i < text.length && isWordSep(text[i])) i++;
-  return offset + i;
+  return i;
 }
 
 function isWordSep(ch: string): boolean {

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -892,8 +892,13 @@ export function handleCtrlKey(this: any, e: KeyboardEvent): void {
     return;
   }
 
-  // 커맨드 시스템에 없는 직접 처리 (Ctrl+Home/End 등 커서 이동)
+  // 커맨드 시스템에 없는 직접 처리 (Ctrl+Home/End, Ctrl+Delete 등)
   switch (e.key.toLowerCase()) {
+    case 'delete': {
+      e.preventDefault();
+      deleteWordForward.call(this);
+      break;
+    }
     case 'home': {
       e.preventDefault();
       if (e.shiftKey) {
@@ -928,6 +933,43 @@ export function handleSelectAll(this: any): void {
   this.cursor.setAnchor();
   this.cursor.moveToDocumentEnd();
   this.updateCaret();
+}
+
+/** Ctrl+Delete: 다음 단어 경계까지 삭제 */
+function deleteWordForward(this: any): void {
+  if (this.cursor.hasSelection()) {
+    this.deleteSelection();
+    return;
+  }
+  const pos = this.cursor.getPosition();
+  const { sectionIndex: sec, paragraphIndex: para, charOffset } = pos;
+  const paraLen = this.wasm.getParagraphLength(sec, para);
+  if (charOffset >= paraLen) {
+    this.handleDelete(pos, this.cursor.isInCell());
+    return;
+  }
+  const wordEnd = findWordBoundaryForward(this.wasm, sec, para, charOffset, paraLen);
+  if (wordEnd > charOffset) {
+    this.cursor.setAnchor();
+    this.cursor.moveTo({ ...pos, charOffset: wordEnd });
+    this.deleteSelection();
+  }
+}
+
+function findWordBoundaryForward(wasm: WasmBridge, sec: number, para: number, offset: number, paraLen: number): number {
+  if (offset >= paraLen) return paraLen;
+  const remaining = paraLen - offset;
+  const text = wasm.getTextRange(sec, para, offset, remaining);
+  let i = 0;
+  // 1) 단어 문자 건너뛰기
+  while (i < text.length && !isWordSep(text[i])) i++;
+  // 2) 공백/구두점 건너뛰기
+  while (i < text.length && isWordSep(text[i])) i++;
+  return offset + i;
+}
+
+function isWordSep(ch: string): boolean {
+  return /[\s　.,;:!?'"()[\]{}<>\/\\|@#$%^&*~`+=\-_]/.test(ch);
 }
 
 export function onCopy(this: any, e: ClipboardEvent): void {


### PR DESCRIPTION
## 요약

Ctrl+Delete로 커서 위치에서 다음 단어 경계까지 삭제하는 기능을 구현합니다.

## 동작

- **Ctrl+Delete**: 현재 단어 문자를 건너뛴 뒤 후행 공백/구두점까지 삭제
- **문단 끝에서**: 일반 Delete와 동일 (다음 문단과 병합)
- **선택 영역 있으면**: 선택 영역 삭제 (기존 동작과 일관)

## 구현

- `handleCtrlKey()`의 switch에 `'delete'` 케이스 추가
- `deleteWordForward()`: 앵커 설정 → 다음 단어 경계 탐색 → 선택 영역 삭제
- `findWordBoundaryForward()`: 단어문자 skip → 공백/구두점 skip

## 관련 PR

- PR #819: Cmd+Backspace / Alt+Backspace (역방향)
- 본 PR: Ctrl+Delete (정방향) — 독립적으로 적용 가능

Ref #260

감사합니다.