### PR TITLE
feat: Ctrl+E 지우기 커맨드 구현

### DIFF
--- a/rhwp-studio/src/command/commands/edit.ts
+++ b/rhwp-studio/src/command/commands/edit.ts
@@ -70,8 +70,12 @@ export const editCommands: CommandDef[] = [
     label: '지우기',
     icon: 'icon-delete',
     shortcutLabel: 'Ctrl+E',
-    canExecute: () => false, // 미구현
-    execute() { /* TODO */ },
+    canExecute: (ctx) => ctx.hasDocument,
+    execute(services) {
+      const ih = services.getInputHandler();
+      if (!ih) return;
+      ih.performDelete();
+    },
   },
   {
     id: 'edit:select-all',

--- a/rhwp-studio/src/command/shortcut-map.ts
+++ b/rhwp-studio/src/command/shortcut-map.ts
@@ -15,6 +15,8 @@ export const defaultShortcuts: [ShortcutDef, string][] = [
   [{ key: 'z', ctrl: true, shift: true }, 'edit:redo'],
   [{ key: 'y', ctrl: true }, 'edit:redo'],
   [{ key: 'a', ctrl: true }, 'edit:select-all'],
+  [{ key: 'e', ctrl: true }, 'edit:delete'],
+  [{ key: 'ㄷ', ctrl: true }, 'edit:delete'],
 
   // 파일
   [{ key: 'n', alt: true }, 'file:new-doc'],

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2258,6 +2258,16 @@ export class InputHandler {
   /** 전체 선택 (커맨드 시스템용) */
   performSelectAll(): void { this.handleSelectAll(); }
 
+  /** 지우기 (커맨드 시스템용) — 선택 있으면 선택 삭제, 없으면 전방 1문자 삭제 */
+  performDelete(): void {
+    if (this.cursor.hasSelection()) {
+      this.deleteSelection();
+    } else {
+      const pos = this.cursor.getPosition();
+      this.handleDelete(pos, this.cursor.isInCell());
+    }
+  }
+
   /** 서식 토글 (커맨드 시스템용) */
   toggleFormat(prop: 'bold' | 'italic' | 'underline' | 'strikethrough' | 'emboss' | 'engrave' | 'outline' | 'superscript' | 'subscript'): void {
     this.applyToggleFormat(prop);

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2258,8 +2258,20 @@ export class InputHandler {
   /** 전체 선택 (커맨드 시스템용) */
   performSelectAll(): void { this.handleSelectAll(); }
 
-  /** 지우기 (커맨드 시스템용) — 선택 있으면 선택 삭제, 없으면 전방 1문자 삭제 */
+  /** 지우기 (커맨드 시스템용) — 개체/텍스트 선택 삭제, 없으면 전방 1문자 삭제 */
   performDelete(): void {
+    if (this.cursor.isInPictureObjectSelection()) {
+      const ref = this.cursor.getSelectedPictureRef();
+      if (ref) {
+        if (ref.type === 'shape' || ref.type === 'line' || ref.type === 'group') {
+          this.wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
+        } else {
+          this.wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+        }
+        this.exitPictureObjectSelectionAndAfterEdit();
+      }
+      return;
+    }
     if (this.cursor.hasSelection()) {
       this.deleteSelection();
     } else {


### PR DESCRIPTION
## 요약

편집 메뉴의 "지우기"(Ctrl+E) 커맨드를 구현합니다. 기존 TODO 스텁을 실동작 코드로 대체합니다.

## 동작

- **선택 영역 있음**: 선택된 텍스트/개체 삭제
- **선택 영역 없음**: 커서 위치에서 전방 1문자 삭제 (Delete 키와 동일)

## 변경 파일

| 파일 | 변경 |
|------|------|
| `commands/edit.ts` | `canExecute: () => false` → `ctx.hasDocument`, `execute` 구현 |
| `input-handler.ts` | `performDelete()` 공개 메서드 추가 |
| `shortcut-map.ts` | `Ctrl+E` / `Ctrl+ㄷ` (한글 IME) 매핑 추가 |

감사합니다.