### PR TITLE
feat: 이미지 파일 드래그 앤 드롭 삽입 (#307)

### DIFF
--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -251,8 +251,20 @@ function setupFileInput(): void {
     const file = e.dataTransfer?.files[0];
     if (!file) return;
     const dropName = file.name.toLowerCase();
+    const imageExts = ['.png', '.jpg', '.jpeg', '.gif', '.bmp', '.webp'];
+    if (imageExts.some(ext => dropName.endsWith(ext))) {
+      if (!inputHandler || wasm.pageCount === 0) return;
+      const data = new Uint8Array(await file.arrayBuffer());
+      const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
+      const img = new Image();
+      img.src = URL.createObjectURL(file);
+      await new Promise<void>(r => { img.onload = () => r(); });
+      URL.revokeObjectURL(img.src);
+      inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      return;
+    }
     if (!dropName.endsWith('.hwp') && !dropName.endsWith('.hwpx')) {
-      alert('HWP/HWPX 파일만 지원합니다.');
+      alert('HWP/HWPX 파일 또는 이미지 파일만 지원합니다.');
       return;
     }
     await loadFile(file);

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -257,10 +257,16 @@ function setupFileInput(): void {
       const data = new Uint8Array(await file.arrayBuffer());
       const ext = file.name.split('.').pop()?.toLowerCase() || 'png';
       const img = new Image();
-      img.src = URL.createObjectURL(file);
-      await new Promise<void>(r => { img.onload = () => r(); });
-      URL.revokeObjectURL(img.src);
-      inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      const url = URL.createObjectURL(file);
+      try {
+        img.src = url;
+        await img.decode();
+        inputHandler.enterImagePlacementMode(data, ext, img.naturalWidth, img.naturalHeight, file.name);
+      } catch {
+        console.warn('[drop] 이미지 디코딩 실패:', file.name);
+      } finally {
+        URL.revokeObjectURL(url);
+      }
       return;
     }
     if (!dropName.endsWith('.hwp') && !dropName.endsWith('.hwpx')) {


### PR DESCRIPTION
## 변경 내용

Closes #307

편집 영역(scroll-container)에 이미지 파일을 드래그 앤 드롭하면 기존 `insert:image` 커맨드와 동일한 이미지 배치 모드로 진입합니다.

### 동작

1. 이미지 파일(png, jpg, jpeg, gif, bmp, webp)을 편집 영역에 드롭
2. Image 엘리먼트로 원본 크기를 측정
3. `enterImagePlacementMode()` 호출 → 마우스로 삽입 위치/크기 지정

### 변경 파일

| 파일 | 변경 |
|------|------|
| `main.ts` | drop 이벤트 핸들러에 이미지 확장자 감지 + 배치 모드 진입 로직 추가 |

기존 HWP/HWPX 파일 드롭 동작은 그대로 유지됩니다. 문서가 열려있지 않으면 이미지 드롭은 무시됩니다.

### 테스트

- `cargo test` 통과
- `cargo clippy -- -D warnings` 경고 없음

감사합니다.