### PR TITLE
fix: 이미지(Picture) 회전/대칭 버튼 동작 (#831)

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -376,12 +376,12 @@ function setProps(services: import('../types').CommandServices, ref: { sec: numb
   }
 }
 
-/** 현재 회전각에 delta(도)를 더한다. */
+/** 현재 회전각에 delta(도)를 더한다 (shape + image 지원). */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
   if (!ih) return;
   const ref = ih.getSelectedPictureRef();
-  if (!ref || ref.type === 'equation' || ref.type === 'group') return;
+  if (!ref || ref.type === 'equation' || ref.type === 'group' || ref.type === 'line') return;
   const props = getProps(services, ref);
   const cur = ((props.rotationAngle as number) ?? 0);
   let next = cur + delta;
@@ -392,12 +392,12 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   services.eventBus.emit('document-changed');
 }
 
-/** horzFlip/vertFlip을 토글한다. */
+/** horzFlip/vertFlip을 토글한다 (shape + image 지원). */
 function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip' | 'vertFlip'): void {
   const ih = services.getInputHandler();
   if (!ih) return;
   const ref = ih.getSelectedPictureRef();
-  if (!ref || ref.type === 'equation' || ref.type === 'group') return;
+  if (!ref || ref.type === 'equation' || ref.type === 'group' || ref.type === 'line') return;
   const props = getProps(services, ref);
   const cur = !!props[key];
   setProps(services, ref, { [key]: !cur });

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -376,12 +376,12 @@ function setProps(services: import('../types').CommandServices, ref: { sec: numb
   }
 }
 
-/** 현재 회전각에 delta(도)를 더한다 (Shape만 지원). */
+/** 현재 회전각에 delta(도)를 더한다. */
 function applyRotationDelta(services: import('../types').CommandServices, delta: number): void {
   const ih = services.getInputHandler();
   if (!ih) return;
   const ref = ih.getSelectedPictureRef();
-  if (!ref || ref.type !== 'shape') return;
+  if (!ref || ref.type === 'equation' || ref.type === 'group') return;
   const props = getProps(services, ref);
   const cur = ((props.rotationAngle as number) ?? 0);
   let next = cur + delta;
@@ -392,12 +392,12 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   services.eventBus.emit('document-changed');
 }
 
-/** horzFlip/vertFlip을 토글한다 (Shape만 지원). */
+/** horzFlip/vertFlip을 토글한다. */
 function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip' | 'vertFlip'): void {
   const ih = services.getInputHandler();
   if (!ih) return;
   const ref = ih.getSelectedPictureRef();
-  if (!ref || ref.type !== 'shape') return;
+  if (!ref || ref.type === 'equation' || ref.type === 'group') return;
   const props = getProps(services, ref);
   const cur = !!props[key];
   setProps(services, ref, { [key]: !cur });


### PR DESCRIPTION
## 변경 내용

Closes #831

도구 상자의 회전/대칭 4개 버튼(`insert:rotate-cw`, `insert:rotate-ccw`, `insert:flip-horz`, `insert:flip-vert`)이 이미지(Picture) 객체에서도 동작하도록 수정합니다.

### 원인

`applyRotationDelta()`와 `toggleFlip()`에서 `ref.type !== 'shape'` 가드로 인해 shape 이외의 객체 타입이 모두 차단되었습니다. `getProps()`/`setProps()` 헬퍼는 이미 image 경로(`getPictureProperties`/`setPictureProperties`)를 지원합니다.

### 수정

- `ref.type !== 'shape'` → `ref.type === 'equation' || ref.type === 'group'`
- 수식(equation)과 그룹(group)만 제외, image/line 등 허용

### 테스트

- `cargo test` 통과
- `cargo clippy -- -D warnings` 경고 없음

감사합니다.