### PR TITLE
render: add guarded GlyphRun layer variant contract

### DIFF
--- a/README.md
+++ b/README.md
@@ -220,11 +220,12 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P5 adds native Skia equation replay from `EquationNode.layout_box`, so equations are no longer placeholder boxes in the PNG path.
 - P5 replays the existing equation layout tree directly; it does not add CanvasKit equation replay or native form replay.
 - P6 adds native Skia `RawSvg` fragment rasterization through `resvg`, with external file href loading disabled.
-- P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path; `GlyphRun` and native glyph replay stay as follow-up work.
+- P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path.
+- P12 adds guarded `GlyphRun` sidecar variants, font blob/face identity metadata, a shape-lowering API, and native Skia variant selection guards. Canvas2D/layered SVG still use `TextRun` fallback; normal lowering does not emit glyph ids until a shaping pass explicitly inserts them.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
-- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit, resource interning/cache, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
-- `ResourceArena` is reserved in `PageLayerTree`; binary resource interning is not implemented yet.
+- `ResourceArena` now reserves font blob storage and font resource identity for glyph replay; document image/SVG interning stays as follow-up work.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.
 
 ### Web Editor (웹 에디터)

--- a/README.md
+++ b/README.md
@@ -221,9 +221,9 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P5 replays the existing equation layout tree directly; it does not add CanvasKit equation replay or native form replay.
 - P6 adds native Skia `RawSvg` fragment rasterization through `resvg`, with external file href loading disabled.
 - P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path.
-- P12 adds guarded `GlyphRun` sidecar variants, font blob/face identity metadata, a shape-lowering API, and native Skia variant selection guards. Canvas2D/layered SVG still use `TextRun` fallback; normal lowering does not emit glyph ids until a shaping pass explicitly inserts them.
+- P12 adds guarded `GlyphRun` sidecar variants, font blob/face identity metadata, and a shape-lowering API. Canvas2D/layered SVG still use `TextRun` fallback; native Skia also keeps the fallback until exact blob-backed typeface replay is wired. Normal lowering does not emit glyph ids until a shaping pass explicitly inserts them.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
-- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, exact native glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` now reserves font blob storage and font resource identity for glyph replay; document image/SVG interning stays as follow-up work.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -1,6 +1,6 @@
 # Text IR v2 Migration Contract
 
-This document records the P11 text paint contract for the layered renderer.
+This document records the P11/P12 text paint contract for the layered renderer.
 The goal is to make source identity and future text variants explicit without
 breaking the existing `TextRun` replay path.
 
@@ -11,10 +11,11 @@ projection, style, explicit positions, HWP text flags, and legacy visual
 payloads that SVG, Canvas2D, and native Skia can replay with existing string
 APIs.
 
-P11 does not make glyph ids canonical. Portable `GlyphRun` replay needs exact
-font bytes or a verified font face, face index, synthetic style flags, shaping
-features, script/language, fallback policy, and diagnostics. Those remain a
-follow-up phase.
+P12 adds the first guarded `GlyphRun` variant contract. Glyph ids are still not
+canonical by default: `TextRun` remains the fallback replay path, and a
+`GlyphRun` may only be selected when the variant is complete, the diagnostics
+are exact or position-adjusted, the font resource is self-contained, and the
+paint style is fill-only.
 
 ## Export Contract
 
@@ -35,11 +36,19 @@ Layer JSON now provides additive text metadata:
   when a separate visual op exists.
 - Explicit special visual ops: `charOverlap`, `textControlMark`, `tabLeader`,
   and `textDecoration`.
+- `fontResources`, an additive table for font blob/face identity.
+- Optional `GlyphRun` sidecar ops with `variant`, `shapeKey`, glyph ids,
+  glyph positions, shaped clusters, and replay diagnostics.
 
 The explicit visual ops are additive. Existing renderers skip them and keep
 drawing the paired `TextRun` mirror, so visual output does not double-paint.
 Future backends can choose the explicit op and suppress the corresponding
 legacy mirror.
+
+`GlyphRun` is also additive. Backends must choose a single variant set per
+`equivalenceGroup`. If a glyph variant is unsupported, incomplete, or fails its
+diagnostics/resource guard, the backend must paint the default `TextRun`
+fallback instead.
 
 ## Invariants
 
@@ -55,13 +64,18 @@ legacy mirror.
   cross-document or cross-export stable ids.
 - Field marker, paragraph-end, and line-break metadata also appear as source
   annotations.
-- P11 does not enable `GlyphRun`, CanvasKit glyph replay, or native glyph
-  outline replay. Those require a guarded variant selection contract.
+- P12 enables the `GlyphRun` schema contract and native Skia selection guard,
+  but normal layer lowering still emits `TextRun` only unless a shaping pass
+  explicitly inserts glyph alternatives.
+- Canvas2D/layered SVG keep using the `TextRun` fallback and ignore glyph
+  sidecars.
+- Glyph ids require portable font identity. Consumers must not replay glyph ids
+  against an arbitrary local font just because the family name matches.
 
 ## Follow-Ups
 
-- Add guarded `GlyphRun` variants only when exact or verified font identity is
-  available.
-- Add native glyph outline/glyph run replay behind the variant gate.
+- Wire real document font blob extraction into `ResourceArena`.
+- Add CanvasKit glyph replay behind the same variant gate.
+- Add native glyph outline replay behind a separate strict visual variant.
 - Add resource table entries for font blobs and face identity.
 - Promote renderer diagnostics once glyph alternatives exist.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -15,7 +15,9 @@ P12 adds the first guarded `GlyphRun` variant contract. Glyph ids are still not
 canonical by default: `TextRun` remains the fallback replay path, and a
 `GlyphRun` may only be selected when the variant is complete, the diagnostics
 are exact or position-adjusted, the font resource is self-contained, and the
-paint style is fill-only.
+paint style is fill-only. Native Skia deliberately keeps using the `TextRun`
+fallback in P12 because exact blob-backed typeface construction is not wired
+yet.
 
 ## Export Contract
 
@@ -64,9 +66,10 @@ fallback instead.
   cross-document or cross-export stable ids.
 - Field marker, paragraph-end, and line-break metadata also appear as source
   annotations.
-- P12 enables the `GlyphRun` schema contract and native Skia selection guard,
-  but normal layer lowering still emits `TextRun` only unless a shaping pass
-  explicitly inserts glyph alternatives.
+- P12 enables the `GlyphRun` schema contract and native Skia contract guard,
+  but native Skia selection remains disabled until it can instantiate the exact
+  referenced font blob/face. Normal layer lowering still emits `TextRun` only
+  unless a shaping pass explicitly inserts glyph alternatives.
 - Canvas2D/layered SVG keep using the `TextRun` fallback and ignore glyph
   sidecars.
 - Glyph ids require portable font identity. Consumers must not replay glyph ids

--- a/src/paint/font.rs
+++ b/src/paint/font.rs
@@ -1,0 +1,298 @@
+/// Export-local identifier for a font blob or collection.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FontBlobKey(pub String);
+
+/// Export-local identifier for an exact font face inside a blob or collection.
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FontFaceKey(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FontDigest {
+    pub algorithm: String,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct BinaryResourceRef {
+    pub kind: BinaryResourceKind,
+    pub id: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum BinaryResourceKind {
+    FontBlob,
+    ExternalFont,
+}
+
+impl BinaryResourceKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FontBlob => "fontBlob",
+            Self::ExternalFont => "externalFont",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Hash)]
+pub struct FontExternalRef {
+    pub url: String,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FontResourceSource {
+    Embedded,
+    Bundled,
+    SystemResolved,
+    ExternalUrl,
+    UnresolvedFallback,
+}
+
+impl FontResourceSource {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Embedded => "embedded",
+            Self::Bundled => "bundled",
+            Self::SystemResolved => "systemResolved",
+            Self::ExternalUrl => "externalUrl",
+            Self::UnresolvedFallback => "unresolvedFallback",
+        }
+    }
+}
+
+/// Whether a font resource is sufficient for portable glyph-id replay.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum FontPortability {
+    PortableBlob {
+        digest: FontDigest,
+        data_ref: BinaryResourceRef,
+    },
+    ExternalVerified {
+        digest: FontDigest,
+        external_ref: FontExternalRef,
+    },
+    ResolvedButNotEmbedded {
+        digest: Option<FontDigest>,
+    },
+    SystemNameOnly,
+    UnresolvedFallback,
+}
+
+impl FontPortability {
+    pub fn kind(&self) -> FontPortabilityKind {
+        match self {
+            Self::PortableBlob { .. } => FontPortabilityKind::PortableBlob,
+            Self::ExternalVerified { .. } => FontPortabilityKind::ExternalVerified,
+            Self::ResolvedButNotEmbedded { .. } => FontPortabilityKind::ResolvedButNotEmbedded,
+            Self::SystemNameOnly => FontPortabilityKind::SystemNameOnly,
+            Self::UnresolvedFallback => FontPortabilityKind::UnresolvedFallback,
+        }
+    }
+
+    pub fn is_self_contained_replayable(&self) -> bool {
+        matches!(self, Self::PortableBlob { .. })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum FontPortabilityKind {
+    PortableBlob,
+    ExternalVerified,
+    ResolvedButNotEmbedded,
+    SystemNameOnly,
+    UnresolvedFallback,
+}
+
+impl FontPortabilityKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::PortableBlob => "portableBlob",
+            Self::ExternalVerified => "externalVerified",
+            Self::ResolvedButNotEmbedded => "resolvedButNotEmbedded",
+            Self::SystemNameOnly => "systemNameOnly",
+            Self::UnresolvedFallback => "unresolvedFallback",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LocalizedName {
+    pub locale: Option<String>,
+    pub value: String,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FontBlobResource {
+    pub id: FontBlobKey,
+    pub digest: Option<FontDigest>,
+    pub source: FontResourceSource,
+    pub data_ref: Option<BinaryResourceRef>,
+    pub portability: FontPortability,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FontFaceResource {
+    pub id: FontFaceKey,
+    pub blob_key: FontBlobKey,
+    /// Explicit TTC/OTC face index. This stays visible so backend diagnostics
+    /// and future CanvasKit/native Skia typeface construction are unambiguous.
+    pub face_index: u32,
+    pub postscript_name: Option<String>,
+    pub family_names: Vec<LocalizedName>,
+    pub style_names: Vec<LocalizedName>,
+    pub weight_class: Option<u16>,
+    pub width_class: Option<u16>,
+    pub italic: Option<bool>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
+pub struct FontResourceTable {
+    pub blobs: Vec<FontBlobResource>,
+    pub faces: Vec<FontFaceResource>,
+}
+
+impl FontResourceTable {
+    pub fn is_empty(&self) -> bool {
+        self.blobs.is_empty() && self.faces.is_empty()
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct VariationAxisValue {
+    pub tag: String,
+    pub value: f32,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OpenTypeFeatureSetting {
+    pub tag: String,
+    pub enabled: bool,
+    pub value: Option<u32>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ScriptTag(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LanguageTag(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ShapingEngineId(pub String);
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FontFallbackPolicyId(pub String);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum TextDirection {
+    Ltr,
+    Rtl,
+    Auto,
+}
+
+impl TextDirection {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ltr => "ltr",
+            Self::Rtl => "rtl",
+            Self::Auto => "auto",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum WritingMode {
+    HorizontalTb,
+    VerticalRl,
+    VerticalLr,
+}
+
+impl WritingMode {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::HorizontalTb => "horizontal-tb",
+            Self::VerticalRl => "vertical-rl",
+            Self::VerticalLr => "vertical-lr",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FontInstanceKey {
+    pub face_key: FontFaceKey,
+    pub size_px: f64,
+    pub variations: Vec<VariationAxisValue>,
+    pub synthetic_bold: bool,
+    pub synthetic_italic: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ShapeKey {
+    pub font_instance: FontInstanceKey,
+    pub direction: TextDirection,
+    pub writing_mode: WritingMode,
+    pub script: Option<ScriptTag>,
+    pub language: Option<LanguageTag>,
+    pub features: Vec<OpenTypeFeatureSetting>,
+    pub shaping_engine: ShapingEngineId,
+    pub fallback_policy: FontFallbackPolicyId,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub enum GlyphRunReplayEligibility {
+    Portable,
+    ConditionalExternalFont,
+    LocalDiagnosticOnly,
+    NotReplayable,
+}
+
+impl GlyphRunReplayEligibility {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Portable => "portable",
+            Self::ConditionalExternalFont => "conditionalExternalFont",
+            Self::LocalDiagnosticOnly => "localDiagnosticOnly",
+            Self::NotReplayable => "notReplayable",
+        }
+    }
+}
+
+impl From<FontPortabilityKind> for GlyphRunReplayEligibility {
+    fn from(kind: FontPortabilityKind) -> Self {
+        match kind {
+            FontPortabilityKind::PortableBlob => Self::Portable,
+            FontPortabilityKind::ExternalVerified => Self::ConditionalExternalFont,
+            FontPortabilityKind::ResolvedButNotEmbedded | FontPortabilityKind::SystemNameOnly => {
+                Self::LocalDiagnosticOnly
+            }
+            FontPortabilityKind::UnresolvedFallback => Self::NotReplayable,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn font_portability_maps_to_replay_eligibility() {
+        assert_eq!(
+            GlyphRunReplayEligibility::from(FontPortabilityKind::PortableBlob),
+            GlyphRunReplayEligibility::Portable
+        );
+        assert_eq!(
+            GlyphRunReplayEligibility::from(FontPortabilityKind::ExternalVerified),
+            GlyphRunReplayEligibility::ConditionalExternalFont
+        );
+        assert_eq!(
+            GlyphRunReplayEligibility::from(FontPortabilityKind::ResolvedButNotEmbedded),
+            GlyphRunReplayEligibility::LocalDiagnosticOnly
+        );
+        assert_eq!(
+            GlyphRunReplayEligibility::from(FontPortabilityKind::SystemNameOnly),
+            GlyphRunReplayEligibility::LocalDiagnosticOnly
+        );
+        assert_eq!(
+            GlyphRunReplayEligibility::from(FontPortabilityKind::UnresolvedFallback),
+            GlyphRunReplayEligibility::NotReplayable
+        );
+    }
+}

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -7,9 +7,11 @@ use crate::model::control::FormType;
 use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
-    CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
-    RenderProfile, TextDecorationKind, TextSourceAnnotation, TextSourceEntry, TextSourceId,
-    TextSourceRange, TextSourceSpan, TextSourceTable, LAYER_TREE_SCHEMA,
+    CacheHint, ClipKind, FontResourceTable, GlyphCluster, GlyphRunDiagnostics, GlyphTransform,
+    GroupKind, LayerAffineTransform, LayerNode, LayerNodeKind, LayerPoint, LayerVector,
+    PageLayerTree, PaintOp, PaintTextStyle, PaintVariantMeta, RenderProfile, ShapeKey,
+    TextDecorationKind, TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange,
+    TextSourceSpan, TextSourceTable, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
@@ -48,6 +50,8 @@ impl PageLayerTree {
         self.root.write_json(&mut buf, &mut text_source_state);
         buf.push_str(",\"textSources\":");
         write_text_source_entries(&mut buf, &self.text_sources);
+        buf.push_str(",\"fontResources\":");
+        write_font_resources(&mut buf, self.resources.font_resources());
         write_text_export_metadata(&mut buf, &self.root);
         buf.push('}');
         buf
@@ -56,7 +60,15 @@ impl PageLayerTree {
 
 fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let externalized_visuals = externalized_text_visuals(root);
+    let has_variant_groups = has_text_variant_groups(root);
+    let has_glyph_runs = has_glyph_runs(root);
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.projectionKind\",\"text.legacyVisuals\"");
+    if has_glyph_runs {
+        buf.push_str(",\"fontResources\",\"text.glyphRun\"");
+    }
+    if has_variant_groups {
+        buf.push_str(",\"text.variantGroups\"");
+    }
     if externalized_visuals.contains(&"charOverlap") {
         buf.push_str(",\"text.charOverlapOp\"");
     }
@@ -69,7 +81,15 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     if externalized_visuals.contains(&"decorations") {
         buf.push_str(",\"text.decorationOp\"");
     }
-    buf.push_str("],\"optionalFeatures\":[],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"],\"variantSelection\":\"exclusiveVariantSet\",\"sourceTextPreserved\":true,\"clusterEncoding\":[\"utf8\",\"utf16\"],\"fallbackRequired\":true,\"placementAuthority\":\"compatibilityProjection\",\"externalizedVisuals\":[");
+    buf.push_str("],\"optionalFeatures\":[");
+    if has_glyph_runs {
+        buf.push_str("\"fontResources\",\"text.glyphRun\"");
+    }
+    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    if has_glyph_runs {
+        buf.push_str(",\"glyphRun\"");
+    }
+    buf.push_str("],\"variantSelection\":\"exclusiveVariantSet\",\"sourceTextPreserved\":true,\"clusterEncoding\":[\"utf8\",\"utf16\"],\"fallbackRequired\":true,\"placementAuthority\":\"compatibilityProjection\",\"externalizedVisuals\":[");
     for (idx, visual) in externalized_visuals.iter().enumerate() {
         if idx > 0 {
             buf.push(',');
@@ -77,6 +97,30 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         buf.push_str(&json_escape(visual));
     }
     buf.push_str("]}");
+}
+
+fn has_text_variant_groups(root: &LayerNode) -> bool {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    stack.push(child);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
+            LayerNodeKind::Leaf { ops } => {
+                if ops.iter().any(|op| matches!(op, PaintOp::GlyphRun { .. })) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn has_glyph_runs(root: &LayerNode) -> bool {
+    has_text_variant_groups(root)
 }
 
 fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {
@@ -175,7 +219,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf, text_sources, leaf_visuals);
+                    op.write_json(buf, text_sources, &leaf_visuals);
                 }
                 buf.push(']');
             }
@@ -189,7 +233,7 @@ impl PaintOp {
         &self,
         buf: &mut String,
         text_sources: &mut TextSourceExportState,
-        leaf_visuals: LeafTextVisualOps,
+        leaf_visuals: &LeafTextVisualOps,
     ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
@@ -247,6 +291,13 @@ impl PaintOp {
                 write_text_clusters(buf, run);
                 buf.push_str(",\"source\":");
                 write_text_source_span(buf, &source);
+                if let Some(equivalence_group) = leaf_visuals.variant_group_for_source(source.id) {
+                    buf.push_str(",\"variant\":");
+                    write_paint_variant_meta(
+                        buf,
+                        &PaintVariantMeta::text_run_default(equivalence_group),
+                    );
+                }
                 buf.push_str(",\"style\":");
                 write_text_style(buf, &run.style);
                 buf.push_str(",\"paintStyle\":");
@@ -266,6 +317,53 @@ impl PaintOp {
                 write_field_marker(buf, run.field_marker);
                 buf.push_str(",\"charOverlap\":");
                 write_char_overlap(buf, run.char_overlap.as_ref());
+                buf.push('}');
+            }
+            PaintOp::GlyphRun { bbox, run } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"glyphRun\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                buf.push_str(",\"source\":");
+                write_text_source_span(buf, &run.source);
+                buf.push_str(",\"variant\":");
+                write_paint_variant_meta(buf, &run.variant);
+                buf.push_str(",\"paintStyle\":");
+                write_paint_text_style(buf, &run.paint_style);
+                buf.push_str(",\"shapeKey\":");
+                write_shape_key(buf, &run.shape_key);
+                buf.push_str(",\"placement\":");
+                write_text_run_placement_value(buf, run.placement);
+                buf.push_str(",\"glyphIds\":[");
+                for (idx, glyph_id) in run.glyph_ids.iter().enumerate() {
+                    if idx > 0 {
+                        buf.push(',');
+                    }
+                    let _ = write!(buf, "{}", glyph_id);
+                }
+                buf.push_str("],\"positions\":");
+                write_points(buf, &run.positions);
+                if let Some(advances) = &run.advances {
+                    buf.push_str(",\"advances\":");
+                    write_vectors(buf, advances);
+                }
+                buf.push_str(",\"clusters\":");
+                write_glyph_clusters(buf, &run.clusters);
+                let _ = write!(
+                    buf,
+                    ",\"direction\":{},\"writingMode\":{},\"orientation\":{}",
+                    json_escape(run.direction.as_str()),
+                    json_escape(run.writing_mode.as_str()),
+                    json_escape(run.orientation.as_str()),
+                );
+                if let Some(bidi_level) = run.bidi_level {
+                    let _ = write!(buf, ",\"bidiLevel\":{}", bidi_level);
+                }
+                if let Some(transforms) = &run.glyph_transforms {
+                    buf.push_str(",\"glyphTransforms\":");
+                    write_glyph_transforms(buf, transforms);
+                }
+                buf.push_str(",\"diagnostics\":");
+                write_glyph_run_diagnostics(buf, &run.diagnostics);
                 buf.push('}');
             }
             PaintOp::CharOverlap { bbox, run } => {
@@ -593,12 +691,13 @@ impl TextSourceExportState {
     }
 }
 
-#[derive(Debug, Clone, Copy, Default)]
+#[derive(Debug, Clone, Default)]
 struct LeafTextVisualOps {
     char_overlap: bool,
     control_marks: bool,
     tab_leaders: bool,
     decorations: bool,
+    glyph_variant_groups: Vec<(u32, String)>,
 }
 
 impl LeafTextVisualOps {
@@ -610,10 +709,19 @@ impl LeafTextVisualOps {
                 PaintOp::TextControlMark { .. } => visuals.control_marks = true,
                 PaintOp::TabLeader { .. } => visuals.tab_leaders = true,
                 PaintOp::TextDecoration { .. } => visuals.decorations = true,
+                PaintOp::GlyphRun { run, .. } => visuals
+                    .glyph_variant_groups
+                    .push((run.source.id.0, run.variant.equivalence_group.clone())),
                 _ => {}
             }
         }
         visuals
+    }
+
+    fn variant_group_for_source(&self, source: TextSourceId) -> Option<String> {
+        self.glyph_variant_groups
+            .iter()
+            .find_map(|(id, group)| (*id == source.0).then(|| group.clone()))
     }
 }
 
@@ -652,6 +760,85 @@ fn write_text_source_entries(buf: &mut String, table: &TextSourceTable) {
             buf.push(',');
         }
         write_text_source_entry(buf, entry);
+    }
+    buf.push(']');
+}
+
+fn write_font_resources(buf: &mut String, table: &FontResourceTable) {
+    buf.push_str("{\"blobs\":[");
+    for (idx, blob) in table.blobs.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "{{\"id\":{},\"source\":{},\"portability\":{}",
+            json_escape(&blob.id.0),
+            json_escape(blob.source.as_str()),
+            json_escape(blob.portability.kind().as_str()),
+        );
+        if let Some(digest) = &blob.digest {
+            let _ = write!(
+                buf,
+                ",\"digest\":{{\"algorithm\":{},\"value\":{}}}",
+                json_escape(&digest.algorithm),
+                json_escape(&digest.value),
+            );
+        }
+        if let Some(data_ref) = &blob.data_ref {
+            let _ = write!(
+                buf,
+                ",\"dataRef\":{{\"kind\":{},\"id\":{}}}",
+                json_escape(data_ref.kind.as_str()),
+                json_escape(&data_ref.id),
+            );
+        }
+        buf.push('}');
+    }
+    buf.push_str("],\"faces\":[");
+    for (idx, face) in table.faces.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "{{\"id\":{},\"blobKey\":{},\"faceIndex\":{}",
+            json_escape(&face.id.0),
+            json_escape(&face.blob_key.0),
+            face.face_index,
+        );
+        if let Some(postscript_name) = &face.postscript_name {
+            let _ = write!(buf, ",\"postscriptName\":{}", json_escape(postscript_name));
+        }
+        buf.push_str(",\"familyNames\":");
+        write_localized_names(buf, &face.family_names);
+        buf.push_str(",\"styleNames\":");
+        write_localized_names(buf, &face.style_names);
+        if let Some(weight_class) = face.weight_class {
+            let _ = write!(buf, ",\"weightClass\":{}", weight_class);
+        }
+        if let Some(width_class) = face.width_class {
+            let _ = write!(buf, ",\"widthClass\":{}", width_class);
+        }
+        if let Some(italic) = face.italic {
+            let _ = write!(buf, ",\"italic\":{}", italic);
+        }
+        buf.push('}');
+    }
+    buf.push_str("]}");
+}
+
+fn write_localized_names(buf: &mut String, names: &[crate::paint::LocalizedName]) {
+    buf.push('[');
+    for (idx, name) in names.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(buf, "{{\"value\":{}", json_escape(&name.value));
+        if let Some(locale) = &name.locale {
+            let _ = write!(buf, ",\"locale\":{}", json_escape(locale));
+        }
+        buf.push('}');
     }
     buf.push(']');
 }
@@ -747,6 +934,39 @@ fn write_text_source_annotations(buf: &mut String, annotations: &[TextSourceAnno
     buf.push(']');
 }
 
+fn write_paint_variant_meta(buf: &mut String, variant: &PaintVariantMeta) {
+    let _ = write!(
+        buf,
+        "{{\"equivalenceGroup\":{},\"variantId\":{},\"variantKind\":{},\"partIndex\":{},\"partCount\":{},\"isDefaultFallback\":{}",
+        json_escape(&variant.equivalence_group),
+        json_escape(&variant.variant_id),
+        json_escape(variant.variant_kind.as_str()),
+        variant.part_index,
+        variant.part_count,
+        variant.is_default_fallback,
+    );
+    if !variant.requires.is_empty() {
+        buf.push_str(",\"requires\":[");
+        for (idx, feature) in variant.requires.iter().enumerate() {
+            if idx > 0 {
+                buf.push(',');
+            }
+            let _ = write!(buf, "{}", json_escape(feature));
+        }
+        buf.push(']');
+    }
+    if let Some(quality) = variant.quality {
+        let _ = write!(buf, ",\"quality\":{}", json_escape(quality.as_str()));
+    }
+    if let Some(anchor_op_id) = &variant.anchor_op_id {
+        let _ = write!(buf, ",\"anchorOpId\":{}", json_escape(anchor_op_id));
+    }
+    if let Some(local_paint_order) = variant.local_paint_order {
+        let _ = write!(buf, ",\"localPaintOrder\":{}", local_paint_order);
+    }
+    buf.push('}');
+}
+
 fn write_group_kind(buf: &mut String, group_kind: &GroupKind) {
     match group_kind {
         GroupKind::Generic => buf.push_str("{\"kind\":\"generic\"}"),
@@ -824,6 +1044,38 @@ fn clip_kind_str(value: ClipKind) -> &'static str {
 }
 
 fn write_text_style(buf: &mut String, style: &TextStyle) {
+    buf.push('{');
+    let _ = write!(
+        buf,
+        "\"fontFamily\":{},\"fontSize\":{:.3},\"color\":{},\"bold\":{},\"italic\":{},\"ratio\":{:.6},\"underline\":{},\"underlineShape\":{},\"strikethrough\":{},\"strikeShape\":{},\"outlineType\":{},\"shadowType\":{},\"shadowColor\":{},\"shadowOffsetX\":{:.3},\"shadowOffsetY\":{:.3},\"emboss\":{},\"engrave\":{},\"superscript\":{},\"subscript\":{},\"underlineColor\":{},\"strikeColor\":{},\"shadeColor\":{},\"emphasisDot\":{}",
+        json_escape(&style.font_family),
+        style.font_size,
+        json_escape(&color_ref_to_css(style.color)),
+        style.bold,
+        style.italic,
+        style.ratio,
+        json_escape(underline_type_str(style.underline)),
+        style.underline_shape,
+        style.strikethrough,
+        style.strike_shape,
+        style.outline_type,
+        style.shadow_type,
+        json_escape(&color_ref_to_css(style.shadow_color)),
+        style.shadow_offset_x,
+        style.shadow_offset_y,
+        style.emboss,
+        style.engrave,
+        style.superscript,
+        style.subscript,
+        json_escape(&color_ref_to_css(style.underline_color)),
+        json_escape(&color_ref_to_css(style.strike_color)),
+        json_escape(&color_ref_to_css(style.shade_color)),
+        style.emphasis_dot,
+    );
+    buf.push('}');
+}
+
+fn write_paint_text_style(buf: &mut String, style: &PaintTextStyle) {
     buf.push('{');
     let _ = write!(
         buf,
@@ -945,7 +1197,11 @@ fn text_projection_kind_str(run: &TextRunNode) -> &'static str {
     }
 }
 
-fn write_text_legacy_visuals(buf: &mut String, run: &TextRunNode, leaf_visuals: LeafTextVisualOps) {
+fn write_text_legacy_visuals(
+    buf: &mut String,
+    run: &TextRunNode,
+    leaf_visuals: &LeafTextVisualOps,
+) {
     let has_decorations = run.style.underline != UnderlineType::None
         || run.style.strikethrough
         || run.style.emphasis_dot > 0;
@@ -1020,6 +1276,20 @@ fn write_text_run_placement(buf: &mut String, bbox: BoundingBox, run: &TextRunNo
     );
 }
 
+fn write_text_run_placement_value(buf: &mut String, placement: crate::paint::TextRunPlacement) {
+    buf.push_str("{\"runToPage\":");
+    write_affine_transform(buf, placement.run_to_page);
+    let _ = write!(buf, ",\"baselineY\":{:.6}}}", placement.baseline_y);
+}
+
+fn write_affine_transform(buf: &mut String, transform: LayerAffineTransform) {
+    let _ = write!(
+        buf,
+        "{{\"a\":{:.6},\"b\":{:.6},\"c\":{:.6},\"d\":{:.6},\"e\":{:.6},\"f\":{:.6}}}",
+        transform.a, transform.b, transform.c, transform.d, transform.e, transform.f,
+    );
+}
+
 fn write_text_clusters(buf: &mut String, run: &TextRunNode) {
     let positions = compute_char_positions(&run.text, &run.style);
     let mut utf16_start = 0_u32;
@@ -1066,6 +1336,157 @@ fn write_text_clusters(buf: &mut String, run: &TextRunNode) {
         utf16_start = utf16_end;
     }
     buf.push(']');
+}
+
+fn write_shape_key(buf: &mut String, shape_key: &ShapeKey) {
+    buf.push_str("{\"fontInstance\":{");
+    let instance = &shape_key.font_instance;
+    let _ = write!(
+        buf,
+        "\"faceKey\":{},\"sizePx\":{:.6},\"syntheticBold\":{},\"syntheticItalic\":{}",
+        json_escape(&instance.face_key.0),
+        instance.size_px,
+        instance.synthetic_bold,
+        instance.synthetic_italic,
+    );
+    buf.push_str(",\"variations\":[");
+    for (idx, axis) in instance.variations.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "{{\"tag\":{},\"value\":{:.6}}}",
+            json_escape(&axis.tag),
+            axis.value
+        );
+    }
+    buf.push_str("]}");
+    let _ = write!(
+        buf,
+        ",\"direction\":{},\"writingMode\":{},\"shapingEngine\":{},\"fallbackPolicy\":{}",
+        json_escape(shape_key.direction.as_str()),
+        json_escape(shape_key.writing_mode.as_str()),
+        json_escape(&shape_key.shaping_engine.0),
+        json_escape(&shape_key.fallback_policy.0),
+    );
+    if let Some(script) = &shape_key.script {
+        let _ = write!(buf, ",\"script\":{}", json_escape(&script.0));
+    }
+    if let Some(language) = &shape_key.language {
+        let _ = write!(buf, ",\"language\":{}", json_escape(&language.0));
+    }
+    buf.push_str(",\"features\":[");
+    for (idx, feature) in shape_key.features.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "{{\"tag\":{},\"enabled\":{}",
+            json_escape(&feature.tag),
+            feature.enabled
+        );
+        if let Some(value) = feature.value {
+            let _ = write!(buf, ",\"value\":{}", value);
+        }
+        buf.push('}');
+    }
+    buf.push_str("]}");
+}
+
+fn write_points(buf: &mut String, points: &[LayerPoint]) {
+    buf.push('[');
+    for (idx, point) in points.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(buf, "{{\"x\":{:.6},\"y\":{:.6}}}", point.x, point.y);
+    }
+    buf.push(']');
+}
+
+fn write_vectors(buf: &mut String, vectors: &[LayerVector]) {
+    buf.push('[');
+    for (idx, vector) in vectors.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(buf, "{{\"dx\":{:.6},\"dy\":{:.6}}}", vector.dx, vector.dy);
+    }
+    buf.push(']');
+}
+
+fn write_glyph_clusters(buf: &mut String, clusters: &[GlyphCluster]) {
+    buf.push('[');
+    for (idx, cluster) in clusters.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        buf.push('{');
+        buf.push_str("\"sourceRangeUtf8\":");
+        write_text_source_range(buf, cluster.source_range_utf8);
+        if let Some(range) = cluster.source_range_utf16 {
+            buf.push_str(",\"sourceRangeUtf16\":");
+            write_text_source_range(buf, range);
+        }
+        if let Some(range) = cluster.text_range_utf8 {
+            buf.push_str(",\"textRangeUtf8\":");
+            write_text_source_range(buf, range);
+        }
+        let _ = write!(
+            buf,
+            ",\"glyphRange\":{{\"start\":{},\"end\":{}}}",
+            cluster.glyph_range.start, cluster.glyph_range.end
+        );
+        if !cluster.flags.is_empty() {
+            buf.push_str(",\"flags\":[");
+            for (flag_idx, flag) in cluster.flags.iter().enumerate() {
+                if flag_idx > 0 {
+                    buf.push(',');
+                }
+                let _ = write!(buf, "{}", json_escape(flag.as_str()));
+            }
+            buf.push(']');
+        }
+        buf.push('}');
+    }
+    buf.push(']');
+}
+
+fn write_glyph_transforms(buf: &mut String, transforms: &[GlyphTransform]) {
+    buf.push('[');
+    for (idx, transform) in transforms.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "{{\"xx\":{:.6},\"xy\":{:.6},\"yx\":{:.6},\"yy\":{:.6},\"tx\":{:.6},\"ty\":{:.6}}}",
+            transform.xx, transform.xy, transform.yx, transform.yy, transform.tx, transform.ty
+        );
+    }
+    buf.push(']');
+}
+
+fn write_glyph_run_diagnostics(buf: &mut String, diagnostics: &GlyphRunDiagnostics) {
+    let _ = write!(
+        buf,
+        "{{\"quality\":{},\"replayEligibility\":{},\"strictVisualEligible\":{},\"maxOriginDeltaPx\":{:.6},\"maxAdvanceDeltaPx\":{:.6},\"maxResidualAfterAdjustmentPx\":{:.6},\"clusterMismatchCount\":{},\"missingGlyphCount\":{},\"usedFallbackFontCount\":{}",
+        json_escape(diagnostics.quality.as_str()),
+        json_escape(diagnostics.replay_eligibility.as_str()),
+        diagnostics.strict_visual_eligible,
+        diagnostics.max_origin_delta_px,
+        diagnostics.max_advance_delta_px,
+        diagnostics.max_residual_after_adjustment_px,
+        diagnostics.cluster_mismatch_count,
+        diagnostics.missing_glyph_count,
+        diagnostics.used_fallback_font_count,
+    );
+    if let Some(reason) = &diagnostics.reason {
+        let _ = write!(buf, ",\"reason\":{}", json_escape(reason));
+    }
+    buf.push('}');
 }
 
 fn write_text_decoration(buf: &mut String, kind: TextDecorationKind, run: &TextRunNode) {
@@ -1361,7 +1782,12 @@ fn form_type_str(value: FormType) -> &'static str {
 mod tests {
     use super::*;
     use crate::paint::{
-        CacheHint, ClipKind, GroupKind, LayerNode, PageLayerTree, TextDecorationKind,
+        CacheHint, ClipKind, FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster,
+        GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
+        LayerAffineTransform, LayerGlyphRunPaint, LayerNode, LayerPoint, LayerVector,
+        PageLayerTree, PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey, ShapingEngineId,
+        TextDecorationKind, TextDirection, TextSourceId, TextSourceRange, TextSourceSpan,
+        TextVariantKind, TextVariantQuality, WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -1452,11 +1878,11 @@ mod tests {
 
         assert!(json.contains("\"kind\":\"leaf\""));
         assert!(json.contains("\"schemaVersion\":1"));
-        assert!(json.contains("\"schemaMinorVersion\":8"));
-        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":8}"));
+        assert!(json.contains("\"schemaMinorVersion\":9"));
+        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":9}"));
         assert!(json.contains("\"resourceTableVersion\":1"));
-        assert!(json.contains("\"resourceTableMinorVersion\":2"));
-        assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":2}"));
+        assert!(json.contains("\"resourceTableMinorVersion\":3"));
+        assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":3}"));
         assert!(json.contains("\"unit\":\"px\""));
         assert!(json.contains("\"coordinateSystem\":\"page-top-left-y-down\""));
         assert!(json.contains("\"profile\":\"screen\""));
@@ -1477,6 +1903,7 @@ mod tests {
         assert!(json.contains("\"charOverlap\":{\"borderType\":1,\"innerCharSize\":90}"));
         assert!(json.contains("\"usedFeatures\":[\"text.paintStyle\""));
         assert!(json.contains("\"knownFeatures\":[\"fontResources\""));
+        assert!(json.contains("\"fontResources\":{\"blobs\":[],\"faces\":[]}"));
         assert!(json.contains("\"text\":{\"defaultVariant\":\"textRun\""));
         assert!(json.contains("\"fontFamily\":\"Noto Sans KR\""));
         assert!(json.contains("\"italic\":true"));
@@ -1577,6 +2004,144 @@ mod tests {
         assert!(json.contains("\"text.decorationOp\""));
         assert!(json.contains("\"externalizedVisuals\":[\"charOverlap\",\"controlMarks\",\"tabLeaders\",\"decorations\"]"));
         assert!(json.contains("\"legacyVisuals\":{\"charOverlap\":\"mirror\""));
+    }
+
+    #[test]
+    fn serializes_optional_glyph_run_variant_with_text_run_fallback() {
+        let source = TextSourceSpan {
+            id: TextSourceId(0),
+            utf8_range: TextSourceRange::new(0, 1),
+            utf16_range: TextSourceRange::new(0, 1),
+            stable_source_key: None,
+        };
+        let shape_key = ShapeKey {
+            font_instance: FontInstanceKey {
+                face_key: FontFaceKey("face-0".to_string()),
+                size_px: 12.0,
+                variations: Vec::new(),
+                synthetic_bold: false,
+                synthetic_italic: false,
+            },
+            direction: TextDirection::Ltr,
+            writing_mode: WritingMode::HorizontalTb,
+            script: Some(ScriptTag("DFLT".to_string())),
+            language: None,
+            features: Vec::new(),
+            shaping_engine: ShapingEngineId("test".to_string()),
+            fallback_policy: FontFallbackPolicyId("none".to_string()),
+        };
+        let text_run = PaintOp::TextRun {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            run: TextRunNode {
+                text: "A".to_string(),
+                style: TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 12.0,
+                field_marker: FieldMarkerType::None,
+            },
+        };
+        let glyph_run = PaintOp::GlyphRun {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            run: LayerGlyphRunPaint {
+                source,
+                variant: PaintVariantMeta {
+                    equivalence_group: "text-0".to_string(),
+                    variant_id: "glyphRun".to_string(),
+                    variant_kind: TextVariantKind::GlyphRun,
+                    part_index: 0,
+                    part_count: 1,
+                    is_default_fallback: false,
+                    requires: vec!["fontResources".to_string(), "text.glyphRun".to_string()],
+                    quality: Some(TextVariantQuality::Exact),
+                    anchor_op_id: None,
+                    local_paint_order: None,
+                },
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                shape_key,
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 12.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                glyph_ids: vec![42],
+                positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+                advances: Some(vec![LayerVector { dx: 12.0, dy: 0.0 }]),
+                clusters: vec![GlyphCluster {
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    source_range_utf16: Some(TextSourceRange::new(0, 1)),
+                    text_range_utf8: Some(TextSourceRange::new(0, 1)),
+                    glyph_range: GlyphRange::new(0, 1),
+                    flags: Vec::new(),
+                }],
+                direction: TextDirection::Ltr,
+                bidi_level: None,
+                writing_mode: WritingMode::HorizontalTb,
+                orientation: GlyphRunOrientation::Horizontal,
+                glyph_transforms: None,
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            },
+        };
+
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![text_run, glyph_run],
+            ),
+        );
+        let json = tree.to_json();
+
+        assert!(json.contains("\"type\":\"glyphRun\""));
+        assert!(json.contains("\"fontResources\":{\"blobs\":[],\"faces\":[]}"));
+        assert!(json.contains("\"optionalFeatures\":[\"fontResources\",\"text.glyphRun\"]"));
+        assert!(json.contains("\"variants\":[\"textRun\",\"glyphRun\"]"));
+        assert!(
+            json.contains("\"variant\":{\"equivalenceGroup\":\"text-0\",\"variantId\":\"textRun\"")
+        );
+        assert!(json.contains("\"variantId\":\"glyphRun\""));
+        assert!(json.contains("\"glyphIds\":[42]"));
+        assert!(json.contains("\"replayEligibility\":\"portable\""));
+        assert!(json.contains("\"strictVisualEligible\":true"));
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -2058,7 +2058,7 @@ mod tests {
         };
         let glyph_run = PaintOp::GlyphRun {
             bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
-            run: LayerGlyphRunPaint {
+            run: Box::new(LayerGlyphRunPaint {
                 source,
                 variant: PaintVariantMeta {
                     equivalence_group: "text-0".to_string(),
@@ -2117,7 +2117,7 @@ mod tests {
                     used_fallback_font_count: 0,
                     reason: None,
                 },
-            },
+            }),
         };
 
         let tree = PageLayerTree::new(

--- a/src/paint/layer_tree.rs
+++ b/src/paint/layer_tree.rs
@@ -27,7 +27,7 @@ impl PageLayerTree {
             profile: RenderProfile::Screen,
             output_options: LayerOutputOptions::default(),
             root,
-            resources: ResourceArena,
+            resources: ResourceArena::default(),
             text_sources,
         }
     }
@@ -45,7 +45,7 @@ impl PageLayerTree {
             profile,
             output_options: LayerOutputOptions::default(),
             root,
-            resources: ResourceArena,
+            resources: ResourceArena::default(),
             text_sources,
         }
     }

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -3,27 +3,47 @@
 //! semantic render tree를 backend-friendly layer tree로 변환한다.
 
 pub mod builder;
+pub mod font;
 mod json;
 pub mod layer_tree;
 pub mod paint_op;
 pub mod profile;
 pub mod resources;
 pub mod schema;
+pub mod text_shape;
+pub mod text_variants;
 
 pub use builder::LayerBuilder;
+pub use font::{
+    BinaryResourceKind, BinaryResourceRef, FontBlobKey, FontBlobResource, FontDigest,
+    FontExternalRef, FontFaceKey, FontFaceResource, FontFallbackPolicyId, FontInstanceKey,
+    FontPortability, FontPortabilityKind, FontResourceSource, FontResourceTable,
+    GlyphRunReplayEligibility, LanguageTag, LocalizedName, OpenTypeFeatureSetting, ScriptTag,
+    ShapeKey, ShapingEngineId, TextDirection, VariationAxisValue, WritingMode,
+};
 pub use layer_tree::{
     CacheHint, ClipKind, GroupKind, LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree,
     TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
     TextSourceTable,
 };
-pub use paint_op::{PaintOp, TextDecorationKind};
+pub use paint_op::{
+    GlyphCluster, GlyphClusterFlag, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
+    GlyphTransform, LayerAffineTransform, LayerGlyphRunPaint, LayerPoint, LayerVector, PaintOp,
+    PaintTextStyle, PaintVariantMeta, TextDecorationKind, TextRunPlacement, TextVariantKind,
+    TextVariantQuality,
+};
 pub use profile::RenderProfile;
 pub use resources::{
-    image_resource_key, resource_digest_hex, svg_resource_key, ResourceArena,
-    RESOURCE_KEY_ALGORITHM,
+    font_blob_resource_key, image_resource_key, resource_digest_hex, svg_resource_key,
+    FontBlobResourceId, ImageResourceId, ResourceArena, SvgResourceId, RESOURCE_KEY_ALGORITHM,
 };
 pub use schema::{
     LayerTreeSchema, LAYER_TREE_SCHEMA, PAGE_LAYER_TREE_COORDINATE_SYSTEM,
     PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION, PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
     PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION, PAGE_LAYER_TREE_SCHEMA_VERSION, PAGE_LAYER_TREE_UNIT,
 };
+pub use text_shape::{
+    FontRequest, FontResolver, GlyphRunQuality, NoopFontResolver, ResolvedFontFace,
+    ResolvedGlyphRun, TextShapeDiagnostic, TextShapeLowerer, TextShapeReport,
+};
+pub use text_variants::{validate_text_variant_scope, TextVariantScopeError};

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -1,8 +1,13 @@
+use crate::model::style::UnderlineType;
+use crate::model::ColorRef;
+use crate::paint::font::{GlyphRunReplayEligibility, ShapeKey, TextDirection, WritingMode};
+use crate::paint::layer_tree::{TextSourceRange, TextSourceSpan};
 use crate::renderer::render_tree::{
     BoundingBox, EllipseNode, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
     LineNode, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode,
     TextRunNode,
 };
+use crate::renderer::TextStyle;
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextDecorationKind {
@@ -34,6 +39,10 @@ pub enum PaintOp {
     TextRun {
         bbox: BoundingBox,
         run: TextRunNode,
+    },
+    GlyphRun {
+        bbox: BoundingBox,
+        run: LayerGlyphRunPaint,
     },
     /// HWP 글자겹침의 명시 visual op.
     ///
@@ -106,6 +115,7 @@ impl PaintOp {
         match self {
             PaintOp::PageBackground { bbox, .. }
             | PaintOp::TextRun { bbox, .. }
+            | PaintOp::GlyphRun { bbox, .. }
             | PaintOp::CharOverlap { bbox, .. }
             | PaintOp::TextControlMark { bbox, .. }
             | PaintOp::TabLeader { bbox, .. }
@@ -121,5 +131,291 @@ impl PaintOp {
             | PaintOp::Placeholder { bbox, .. }
             | PaintOp::RawSvg { bbox, .. } => *bbox,
         }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LayerGlyphRunPaint {
+    pub source: TextSourceSpan,
+    pub variant: PaintVariantMeta,
+    pub paint_style: PaintTextStyle,
+    pub shape_key: ShapeKey,
+    pub placement: TextRunPlacement,
+    pub glyph_ids: Vec<u32>,
+    pub positions: Vec<LayerPoint>,
+    pub advances: Option<Vec<LayerVector>>,
+    pub clusters: Vec<GlyphCluster>,
+    pub direction: TextDirection,
+    pub bidi_level: Option<u8>,
+    pub writing_mode: WritingMode,
+    pub orientation: GlyphRunOrientation,
+    pub glyph_transforms: Option<Vec<GlyphTransform>>,
+    pub diagnostics: GlyphRunDiagnostics,
+}
+
+/// Variant grouping metadata for TextRun/GlyphRun alternatives.
+///
+/// Consumers select one `variant_id` per `equivalence_group` and paint every
+/// part belonging to that variant. A `TextRun` fallback remains required.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct PaintVariantMeta {
+    pub equivalence_group: String,
+    pub variant_id: String,
+    pub variant_kind: TextVariantKind,
+    pub part_index: u32,
+    pub part_count: u32,
+    pub is_default_fallback: bool,
+    pub requires: Vec<String>,
+    pub quality: Option<TextVariantQuality>,
+    pub anchor_op_id: Option<String>,
+    pub local_paint_order: Option<u32>,
+}
+
+impl PaintVariantMeta {
+    pub fn text_run_default(equivalence_group: impl Into<String>) -> Self {
+        Self {
+            equivalence_group: equivalence_group.into(),
+            variant_id: "textRun".to_string(),
+            variant_kind: TextVariantKind::TextRun,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: true,
+            requires: Vec::new(),
+            quality: None,
+            anchor_op_id: None,
+            local_paint_order: None,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextVariantKind {
+    TextRun,
+    GlyphRun,
+}
+
+impl TextVariantKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::TextRun => "textRun",
+            Self::GlyphRun => "glyphRun",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TextVariantQuality {
+    Exact,
+    PositionAdjusted,
+    Approximate,
+    DiagnosticOnly,
+    Omitted,
+}
+
+impl TextVariantQuality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::PositionAdjusted => "positionAdjusted",
+            Self::Approximate => "approximate",
+            Self::DiagnosticOnly => "diagnosticOnly",
+            Self::Omitted => "omitted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerPoint {
+    pub x: f64,
+    pub y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerVector {
+    pub dx: f64,
+    pub dy: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct LayerAffineTransform {
+    pub a: f64,
+    pub b: f64,
+    pub c: f64,
+    pub d: f64,
+    pub e: f64,
+    pub f: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TextRunPlacement {
+    pub run_to_page: LayerAffineTransform,
+    pub baseline_y: f64,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphRunOrientation {
+    Horizontal,
+    VerticalUpright,
+    VerticalSideways,
+    MixedPerGlyph,
+}
+
+impl GlyphRunOrientation {
+    pub fn from_text_run(run: &TextRunNode) -> Self {
+        if !run.is_vertical {
+            Self::Horizontal
+        } else if run.rotation.abs() > f64::EPSILON {
+            Self::VerticalSideways
+        } else {
+            Self::VerticalUpright
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Horizontal => "horizontal",
+            Self::VerticalUpright => "vertical-upright",
+            Self::VerticalSideways => "vertical-sideways",
+            Self::MixedPerGlyph => "mixedPerGlyph",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct GlyphTransform {
+    pub xx: f32,
+    pub xy: f32,
+    pub yx: f32,
+    pub yy: f32,
+    pub tx: f32,
+    pub ty: f32,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct GlyphRange {
+    pub start: u32,
+    pub end: u32,
+}
+
+impl GlyphRange {
+    pub fn new(start: u32, end: u32) -> Self {
+        Self { start, end }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphClusterFlag {
+    Ligature,
+    FallbackBoundary,
+}
+
+impl GlyphClusterFlag {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Ligature => "ligature",
+            Self::FallbackBoundary => "fallbackBoundary",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GlyphCluster {
+    pub source_range_utf8: TextSourceRange,
+    pub source_range_utf16: Option<TextSourceRange>,
+    pub text_range_utf8: Option<TextSourceRange>,
+    pub glyph_range: GlyphRange,
+    pub flags: Vec<GlyphClusterFlag>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GlyphRunDiagnostics {
+    pub quality: TextVariantQuality,
+    pub replay_eligibility: GlyphRunReplayEligibility,
+    pub strict_visual_eligible: bool,
+    pub max_origin_delta_px: f64,
+    pub max_advance_delta_px: f64,
+    pub max_residual_after_adjustment_px: f64,
+    pub cluster_mismatch_count: u32,
+    pub missing_glyph_count: u32,
+    pub used_fallback_font_count: u32,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone)]
+pub struct PaintTextStyle {
+    pub font_family: String,
+    pub font_size: f64,
+    pub color: ColorRef,
+    pub bold: bool,
+    pub italic: bool,
+    pub underline: UnderlineType,
+    pub strikethrough: bool,
+    pub ratio: f64,
+    pub tab_leaders: Vec<crate::renderer::TabLeaderInfo>,
+    pub outline_type: u8,
+    pub shadow_type: u8,
+    pub shadow_color: ColorRef,
+    pub shadow_offset_x: f64,
+    pub shadow_offset_y: f64,
+    pub emboss: bool,
+    pub engrave: bool,
+    pub superscript: bool,
+    pub subscript: bool,
+    pub emphasis_dot: u8,
+    pub underline_shape: u8,
+    pub strike_shape: u8,
+    pub underline_color: ColorRef,
+    pub strike_color: ColorRef,
+    pub shade_color: ColorRef,
+}
+
+impl From<&TextStyle> for PaintTextStyle {
+    fn from(style: &TextStyle) -> Self {
+        Self {
+            font_family: style.font_family.clone(),
+            font_size: style.font_size,
+            color: style.color,
+            bold: style.bold,
+            italic: style.italic,
+            underline: style.underline,
+            strikethrough: style.strikethrough,
+            ratio: style.ratio,
+            tab_leaders: style.tab_leaders.clone(),
+            outline_type: style.outline_type,
+            shadow_type: style.shadow_type,
+            shadow_color: style.shadow_color,
+            shadow_offset_x: style.shadow_offset_x,
+            shadow_offset_y: style.shadow_offset_y,
+            emboss: style.emboss,
+            engrave: style.engrave,
+            superscript: style.superscript,
+            subscript: style.subscript,
+            emphasis_dot: style.emphasis_dot,
+            underline_shape: style.underline_shape,
+            strike_shape: style.strike_shape,
+            underline_color: style.underline_color,
+            strike_color: style.strike_color,
+            shade_color: style.shade_color,
+        }
+    }
+}
+
+impl PaintTextStyle {
+    /// Returns whether a backend may replay this text as a simple fill-only
+    /// positioned glyph run without losing HWP text effects.
+    pub fn is_fill_only_glyph_replay(&self) -> bool {
+        let ratio = if self.ratio > 0.0 { self.ratio } else { 1.0 };
+        (ratio - 1.0).abs() <= 0.001
+            && self.tab_leaders.is_empty()
+            && self.underline == UnderlineType::None
+            && !self.strikethrough
+            && self.outline_type == 0
+            && self.shadow_type == 0
+            && !self.emboss
+            && !self.engrave
+            && !self.superscript
+            && !self.subscript
+            && self.emphasis_dot == 0
+            && (self.shade_color & 0x00FF_FFFF) == 0x00FF_FFFF
     }
 }

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -42,7 +42,7 @@ pub enum PaintOp {
     },
     GlyphRun {
         bbox: BoundingBox,
-        run: LayerGlyphRunPaint,
+        run: Box<LayerGlyphRunPaint>,
     },
     /// HWP 글자겹침의 명시 visual op.
     ///

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -1,11 +1,101 @@
+use std::collections::HashMap;
+
+use crate::paint::font::FontResourceTable;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ImageResourceId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct SvgResourceId(pub usize);
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct FontBlobResourceId(pub usize);
+
 pub const RESOURCE_KEY_ALGORITHM: &str = "blake3";
 
-/// 추후 이미지/패스/셰이프 캐시 공유를 위한 arena placeholder.
+/// 레이어 replay가 공유하는 바이너리/문자열 자원 저장소.
 ///
-/// 레이어드 렌더러 전환 1차에서는 leaf payload를 직접 보관하되,
-/// IR 상에 arena 자리를 먼저 확보해 이후 Skia/CanvasKit 자원 공유로 확장한다.
+/// 현재 leaf payload는 대부분 직접 보관하지만, P12부터 font blob/face
+/// identity는 glyph replay contract에서 참조할 수 있게 한다.
 #[derive(Debug, Clone, Default)]
-pub struct ResourceArena;
+pub struct ResourceArena {
+    font_blob_bytes: Vec<Vec<u8>>,
+    font_blob_hashes: Vec<u64>,
+    font_blob_fingerprints: Vec<[u8; 16]>,
+    font_blob_lookup: HashMap<u64, Vec<FontBlobResourceId>>,
+    font_resources: FontResourceTable,
+}
+
+impl ResourceArena {
+    pub fn intern_font_blob_bytes(&mut self, bytes: &[u8]) -> FontBlobResourceId {
+        let hash = resource_hash(bytes);
+        if let Some(candidates) = self.font_blob_lookup.get(&hash) {
+            for id in candidates {
+                if self.font_blob_bytes[id.0].as_slice() == bytes {
+                    return *id;
+                }
+            }
+        }
+
+        let id = FontBlobResourceId(self.font_blob_bytes.len());
+        self.font_blob_bytes.push(bytes.to_vec());
+        self.font_blob_hashes.push(hash);
+        self.font_blob_fingerprints
+            .push(resource_fingerprint(bytes));
+        self.font_blob_lookup.entry(hash).or_default().push(id);
+        id
+    }
+
+    pub fn font_blob_bytes(&self, id: FontBlobResourceId) -> Option<&[u8]> {
+        self.font_blob_bytes.get(id.0).map(Vec::as_slice)
+    }
+
+    pub fn font_blob_count(&self) -> usize {
+        self.font_blob_bytes.len()
+    }
+
+    pub fn font_blob_hash(&self, id: FontBlobResourceId) -> Option<u64> {
+        self.font_blob_hashes.get(id.0).copied()
+    }
+
+    pub fn font_blob_fingerprint(&self, id: FontBlobResourceId) -> Option<[u8; 16]> {
+        self.font_blob_fingerprints.get(id.0).copied()
+    }
+
+    pub fn font_blob_resources(&self) -> impl Iterator<Item = (FontBlobResourceId, &[u8])> + '_ {
+        self.font_blob_bytes
+            .iter()
+            .enumerate()
+            .map(|(index, bytes)| (FontBlobResourceId(index), bytes.as_slice()))
+    }
+
+    pub fn font_resources(&self) -> &FontResourceTable {
+        &self.font_resources
+    }
+
+    pub fn font_resources_mut(&mut self) -> &mut FontResourceTable {
+        &mut self.font_resources
+    }
+}
+
+fn resource_hash(bytes: impl AsRef<[u8]>) -> u64 {
+    const FNV_OFFSET_BASIS: u64 = 0xcbf2_9ce4_8422_2325;
+    const FNV_PRIME: u64 = 0x0000_0100_0000_01b3;
+
+    let mut hash = FNV_OFFSET_BASIS;
+    for byte in bytes.as_ref() {
+        hash ^= u64::from(*byte);
+        hash = hash.wrapping_mul(FNV_PRIME);
+    }
+    hash
+}
+
+fn resource_fingerprint(bytes: impl AsRef<[u8]>) -> [u8; 16] {
+    let digest = blake3::hash(bytes.as_ref());
+    let mut fingerprint = [0; 16];
+    fingerprint.copy_from_slice(&digest.as_bytes()[..16]);
+    fingerprint
+}
 
 pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String {
     blake3::hash(bytes.as_ref()).to_hex().to_string()
@@ -19,13 +109,42 @@ pub fn svg_resource_key(byte_len: usize, digest: &str) -> String {
     resource_key("svg", byte_len, digest)
 }
 
+pub fn font_blob_resource_key(byte_len: usize, digest: &str) -> String {
+    resource_key("font", byte_len, digest)
+}
+
 fn resource_key(kind: &str, byte_len: usize, digest: &str) -> String {
     format!("{kind}:{RESOURCE_KEY_ALGORITHM}:{byte_len}:{digest}")
 }
 
 #[cfg(test)]
 mod tests {
-    use super::{image_resource_key, resource_digest_hex, svg_resource_key};
+    use super::{
+        font_blob_resource_key, image_resource_key, resource_digest_hex, resource_fingerprint,
+        svg_resource_key, FontBlobResourceId, ResourceArena,
+    };
+
+    #[test]
+    fn interns_duplicate_font_blobs_once() {
+        let mut arena = ResourceArena::default();
+        let font_a = arena.intern_font_blob_bytes(&[5, 6, 7, 8]);
+        let font_b = arena.intern_font_blob_bytes(&[5, 6, 7, 8]);
+
+        assert_eq!(font_a, FontBlobResourceId(0));
+        assert_eq!(font_b, FontBlobResourceId(0));
+        assert_eq!(arena.font_blob_count(), 1);
+        assert_eq!(arena.font_blob_bytes(font_a), Some(&[5, 6, 7, 8][..]));
+        assert_eq!(arena.font_blob_hash(font_a), arena.font_blob_hash(font_b));
+        assert!(arena.font_blob_hash(font_a).is_some());
+        assert_eq!(
+            arena.font_blob_fingerprint(font_a),
+            Some(resource_fingerprint([5, 6, 7, 8]))
+        );
+        assert_eq!(
+            arena.font_blob_resources().collect::<Vec<_>>(),
+            vec![(FontBlobResourceId(0), &[5, 6, 7, 8][..])]
+        );
+    }
 
     #[test]
     fn resource_digest_is_stable_and_content_dependent() {
@@ -42,5 +161,6 @@ mod tests {
             svg_resource_key(6, "0123456789abcdef"),
             "svg:blake3:6:0123456789abcdef"
         );
+        assert_eq!(font_blob_resource_key(8, "feed"), "font:blake3:8:feed");
     }
 }

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,9 +15,9 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 8,
+    schema_minor_version: 9,
     resource_table_version: 1,
-    resource_table_minor_version: 2,
+    resource_table_minor_version: 3,
     unit: "px",
     coordinate_system: "page-top-left-y-down",
 };
@@ -37,9 +37,9 @@ mod tests {
     #[test]
     fn layer_tree_schema_contract_is_stable() {
         assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 8);
+        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 9);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 2);
+        assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 3);
         assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
         assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left-y-down");
     }

--- a/src/paint/text_shape.rs
+++ b/src/paint/text_shape.rs
@@ -179,7 +179,7 @@ impl<'a> TextShapeLowerer<'a> {
                         if let Some(glyph_run) = glyph_run {
                             lowered.push(PaintOp::GlyphRun {
                                 bbox,
-                                run: glyph_run,
+                                run: Box::new(glyph_run),
                             });
                         }
                         *next_text_source_id = (*next_text_source_id).saturating_add(1);

--- a/src/paint/text_shape.rs
+++ b/src/paint/text_shape.rs
@@ -1,0 +1,576 @@
+use crate::paint::{
+    FontPortabilityKind, GlyphCluster, GlyphRunDiagnostics, GlyphRunOrientation,
+    GlyphRunReplayEligibility, LayerAffineTransform, LayerGlyphRunPaint, LayerNode, LayerNodeKind,
+    LayerPoint, LayerVector, PaintOp, PaintTextStyle, ShapeKey, TextRunPlacement, TextVariantKind,
+    TextVariantQuality,
+};
+use crate::renderer::render_tree::{BoundingBox, TextRunNode};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FontRequest {
+    pub family: String,
+    pub bold: bool,
+    pub italic: bool,
+}
+
+impl From<&TextRunNode> for FontRequest {
+    fn from(run: &TextRunNode) -> Self {
+        Self {
+            family: run.style.font_family.clone(),
+            bold: run.style.bold,
+            italic: run.style.italic,
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedFontFace {
+    pub portability: FontPortabilityKind,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedGlyphRun {
+    pub shape_key: ShapeKey,
+    pub glyph_ids: Vec<u32>,
+    pub positions: Vec<LayerPoint>,
+    pub advances: Option<Vec<LayerVector>>,
+    pub clusters: Vec<GlyphCluster>,
+    pub diagnostics: GlyphRunDiagnostics,
+}
+
+pub trait FontResolver {
+    fn resolve_font(&self, request: &FontRequest) -> ResolvedFontFace;
+
+    fn shape_glyph_run(
+        &self,
+        _request: &FontRequest,
+        _run: &TextRunNode,
+        _resolved: &ResolvedFontFace,
+    ) -> Option<ResolvedGlyphRun> {
+        None
+    }
+}
+
+#[derive(Debug, Default)]
+pub struct NoopFontResolver;
+
+impl FontResolver for NoopFontResolver {
+    fn resolve_font(&self, _request: &FontRequest) -> ResolvedFontFace {
+        ResolvedFontFace {
+            portability: FontPortabilityKind::UnresolvedFallback,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphRunQuality {
+    Exact,
+    PositionAdjusted,
+    Approximate,
+    DiagnosticOnly,
+    Omitted,
+}
+
+impl GlyphRunQuality {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Exact => "exact",
+            Self::PositionAdjusted => "positionAdjusted",
+            Self::Approximate => "approximate",
+            Self::DiagnosticOnly => "diagnosticOnly",
+            Self::Omitted => "omitted",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextShapeDiagnostic {
+    pub text: String,
+    pub attempted: bool,
+    pub public_glyph_run_emitted: bool,
+    pub quality: GlyphRunQuality,
+    pub replay_eligibility: GlyphRunReplayEligibility,
+    pub strict_visual_eligible: bool,
+    pub reason: Option<String>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq)]
+pub struct TextShapeReport {
+    pub diagnostics: Vec<TextShapeDiagnostic>,
+}
+
+impl TextShapeReport {
+    pub fn public_glyph_run_count(&self) -> usize {
+        self.diagnostics
+            .iter()
+            .filter(|diagnostic| diagnostic.public_glyph_run_emitted)
+            .count()
+    }
+}
+
+pub struct TextShapeLowerer<'a> {
+    resolver: &'a dyn FontResolver,
+}
+
+impl<'a> TextShapeLowerer<'a> {
+    pub fn new(resolver: &'a dyn FontResolver) -> Self {
+        Self { resolver }
+    }
+
+    pub fn diagnostics_only(resolver: &'a dyn FontResolver) -> Self {
+        Self::new(resolver)
+    }
+
+    pub fn analyze_root(&self, root: &LayerNode) -> TextShapeReport {
+        let mut report = TextShapeReport::default();
+        self.collect_node(root, &mut report);
+        report
+    }
+
+    pub fn lower_root(&self, root: &mut LayerNode) -> TextShapeReport {
+        let mut report = TextShapeReport::default();
+        let mut next_text_source_id = 0_u32;
+        self.lower_node(root, &mut report, &mut next_text_source_id);
+        report
+    }
+
+    fn collect_node(&self, node: &LayerNode, report: &mut TextShapeReport) {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    self.collect_node(child, report);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => self.collect_node(child, report),
+            LayerNodeKind::Leaf { ops } => {
+                for op in ops {
+                    if let PaintOp::TextRun { run, .. } = op {
+                        report.diagnostics.push(self.analyze_text_run(run));
+                    }
+                }
+            }
+        }
+    }
+
+    fn lower_node(
+        &self,
+        node: &mut LayerNode,
+        report: &mut TextShapeReport,
+        next_text_source_id: &mut u32,
+    ) {
+        match &mut node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    self.lower_node(child, report, next_text_source_id);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => {
+                self.lower_node(child, report, next_text_source_id);
+            }
+            LayerNodeKind::Leaf { ops } => {
+                let mut lowered = Vec::with_capacity(ops.len());
+                for op in ops.drain(..) {
+                    if let PaintOp::TextRun { bbox, run } = op {
+                        let text_source_id = *next_text_source_id;
+                        let (diagnostic, glyph_run) =
+                            self.lower_text_run(bbox, &run, text_source_id);
+                        report.diagnostics.push(diagnostic);
+                        lowered.push(PaintOp::TextRun { bbox, run });
+                        if let Some(glyph_run) = glyph_run {
+                            lowered.push(PaintOp::GlyphRun {
+                                bbox,
+                                run: glyph_run,
+                            });
+                        }
+                        *next_text_source_id = (*next_text_source_id).saturating_add(1);
+                    } else {
+                        lowered.push(op);
+                    }
+                }
+                *ops = lowered;
+            }
+        }
+    }
+
+    fn analyze_text_run(&self, run: &TextRunNode) -> TextShapeDiagnostic {
+        self.evaluate_text_run(None, run, 0).0
+    }
+
+    fn lower_text_run(
+        &self,
+        bbox: BoundingBox,
+        run: &TextRunNode,
+        text_source_id: u32,
+    ) -> (TextShapeDiagnostic, Option<LayerGlyphRunPaint>) {
+        self.evaluate_text_run(Some(bbox), run, text_source_id)
+    }
+
+    fn evaluate_text_run(
+        &self,
+        bbox: Option<BoundingBox>,
+        run: &TextRunNode,
+        text_source_id: u32,
+    ) -> (TextShapeDiagnostic, Option<LayerGlyphRunPaint>) {
+        if run.char_overlap.is_some() || run.text.is_empty() {
+            return (
+                TextShapeDiagnostic {
+                    text: run.text.clone(),
+                    attempted: false,
+                    public_glyph_run_emitted: false,
+                    quality: GlyphRunQuality::Omitted,
+                    replay_eligibility: GlyphRunReplayEligibility::NotReplayable,
+                    strict_visual_eligible: false,
+                    reason: Some("notShapingCandidate".to_string()),
+                },
+                None,
+            );
+        }
+
+        let request = FontRequest::from(run);
+        let resolved = self.resolver.resolve_font(&request);
+        let replay_eligibility = GlyphRunReplayEligibility::from(resolved.portability);
+        let attempted = matches!(
+            replay_eligibility,
+            GlyphRunReplayEligibility::Portable
+                | GlyphRunReplayEligibility::ConditionalExternalFont
+                | GlyphRunReplayEligibility::LocalDiagnosticOnly
+        );
+        let mut diagnostic_quality = if attempted {
+            GlyphRunQuality::DiagnosticOnly
+        } else {
+            GlyphRunQuality::Omitted
+        };
+        let mut reason = match replay_eligibility {
+            GlyphRunReplayEligibility::Portable => Some("diagnosticsOnlySkeleton".to_string()),
+            GlyphRunReplayEligibility::ConditionalExternalFont => {
+                Some("externalFontRequiresConsumerVerification".to_string())
+            }
+            GlyphRunReplayEligibility::LocalDiagnosticOnly => {
+                Some("localDiagnosticOnly".to_string())
+            }
+            GlyphRunReplayEligibility::NotReplayable => Some("fontResourceUnavailable".to_string()),
+        };
+
+        let mut public_glyph_run = None;
+        let mut public_glyph_run_emitted = false;
+        let mut strict_visual_eligible = false;
+        let paint_style = PaintTextStyle::from(&run.style);
+
+        if matches!(
+            replay_eligibility,
+            GlyphRunReplayEligibility::Portable
+                | GlyphRunReplayEligibility::ConditionalExternalFont
+        ) {
+            if let Some(bbox) = bbox {
+                if let Some(shaped) = self.resolver.shape_glyph_run(&request, run, &resolved) {
+                    if !paint_style.is_fill_only_glyph_replay() {
+                        reason = Some("unsupportedGlyphRunPaintEffect".to_string());
+                    } else if glyph_run_is_exportable(&shaped) {
+                        let equivalence_group = format!("text-{text_source_id}");
+                        let mut glyph_variant =
+                            crate::paint::PaintVariantMeta::text_run_default(equivalence_group);
+                        glyph_variant.variant_id = "glyphRun".to_string();
+                        glyph_variant.variant_kind = TextVariantKind::GlyphRun;
+                        glyph_variant.is_default_fallback = false;
+                        glyph_variant.requires =
+                            vec!["fontResources".to_string(), "text.glyphRun".to_string()];
+                        glyph_variant.quality = Some(shaped.diagnostics.quality);
+                        diagnostic_quality = glyph_quality_from_variant(shaped.diagnostics.quality);
+                        strict_visual_eligible = shaped.diagnostics.strict_visual_eligible;
+                        reason = shaped.diagnostics.reason.clone();
+                        public_glyph_run_emitted = true;
+                        public_glyph_run = Some(LayerGlyphRunPaint {
+                            source: crate::paint::TextSourceSpan {
+                                id: crate::paint::TextSourceId(text_source_id),
+                                utf8_range: crate::paint::TextSourceRange::new(
+                                    0,
+                                    run.text.len() as u32,
+                                ),
+                                utf16_range: crate::paint::TextSourceRange::new(
+                                    0,
+                                    run.text.encode_utf16().count() as u32,
+                                ),
+                                stable_source_key: None,
+                            },
+                            variant: glyph_variant,
+                            paint_style: paint_style.clone(),
+                            shape_key: shaped.shape_key.clone(),
+                            placement: fallback_placement(bbox, run),
+                            glyph_ids: shaped.glyph_ids,
+                            positions: shaped.positions,
+                            advances: shaped.advances,
+                            clusters: shaped.clusters,
+                            direction: shaped.shape_key.direction,
+                            bidi_level: None,
+                            writing_mode: shaped.shape_key.writing_mode,
+                            orientation: GlyphRunOrientation::from_text_run(run),
+                            glyph_transforms: None,
+                            diagnostics: shaped.diagnostics,
+                        });
+                    } else {
+                        reason = Some("glyphRunDiagnosticsNotExportable".to_string());
+                    }
+                }
+            }
+        }
+
+        (
+            TextShapeDiagnostic {
+                text: run.text.clone(),
+                attempted,
+                public_glyph_run_emitted,
+                quality: diagnostic_quality,
+                replay_eligibility,
+                strict_visual_eligible,
+                reason,
+            },
+            public_glyph_run,
+        )
+    }
+}
+
+fn fallback_placement(bbox: BoundingBox, run: &TextRunNode) -> TextRunPlacement {
+    let radians = run.rotation.to_radians();
+    let (sin, cos) = radians.sin_cos();
+    let local_origin_x = -bbox.width / 2.0;
+    let local_origin_y = -bbox.height / 2.0 + run.baseline;
+    let center_x = bbox.x + bbox.width / 2.0;
+    let center_y = bbox.y + bbox.height / 2.0;
+    TextRunPlacement {
+        run_to_page: LayerAffineTransform {
+            a: cos,
+            b: sin,
+            c: -sin,
+            d: cos,
+            e: center_x + cos * local_origin_x - sin * local_origin_y,
+            f: center_y + sin * local_origin_x + cos * local_origin_y,
+        },
+        baseline_y: 0.0,
+    }
+}
+
+fn glyph_run_is_exportable(shaped: &ResolvedGlyphRun) -> bool {
+    !shaped.glyph_ids.is_empty()
+        && shaped.glyph_ids.len() == shaped.positions.len()
+        && shaped
+            .advances
+            .as_ref()
+            .map_or(true, |advances| advances.len() == shaped.glyph_ids.len())
+        && !shaped.clusters.is_empty()
+        && matches!(
+            shaped.diagnostics.replay_eligibility,
+            GlyphRunReplayEligibility::Portable
+                | GlyphRunReplayEligibility::ConditionalExternalFont
+        )
+        && matches!(
+            shaped.diagnostics.quality,
+            TextVariantQuality::Exact | TextVariantQuality::PositionAdjusted
+        )
+        && shaped.diagnostics.missing_glyph_count == 0
+        && shaped.diagnostics.cluster_mismatch_count == 0
+}
+
+fn glyph_quality_from_variant(quality: TextVariantQuality) -> GlyphRunQuality {
+    match quality {
+        TextVariantQuality::Exact => GlyphRunQuality::Exact,
+        TextVariantQuality::PositionAdjusted => GlyphRunQuality::PositionAdjusted,
+        TextVariantQuality::Approximate => GlyphRunQuality::Approximate,
+        TextVariantQuality::DiagnosticOnly => GlyphRunQuality::DiagnosticOnly,
+        TextVariantQuality::Omitted => GlyphRunQuality::Omitted,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::{
+        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphRange, LayerNode,
+        ScriptTag, ShapingEngineId, TextDirection, TextSourceRange, WritingMode,
+    };
+
+    struct PortableResolver;
+
+    impl FontResolver for PortableResolver {
+        fn resolve_font(&self, _request: &FontRequest) -> ResolvedFontFace {
+            ResolvedFontFace {
+                portability: FontPortabilityKind::PortableBlob,
+            }
+        }
+    }
+
+    struct EmittingResolver;
+
+    impl FontResolver for EmittingResolver {
+        fn resolve_font(&self, _request: &FontRequest) -> ResolvedFontFace {
+            ResolvedFontFace {
+                portability: FontPortabilityKind::PortableBlob,
+            }
+        }
+
+        fn shape_glyph_run(
+            &self,
+            _request: &FontRequest,
+            run: &TextRunNode,
+            _resolved: &ResolvedFontFace,
+        ) -> Option<ResolvedGlyphRun> {
+            Some(ResolvedGlyphRun {
+                shape_key: placeholder_shape_key(
+                    FontFaceKey("font-face-0".to_string()),
+                    run.style.font_size.max(12.0),
+                ),
+                glyph_ids: vec![42],
+                positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+                advances: Some(vec![LayerVector { dx: 12.0, dy: 0.0 }]),
+                clusters: vec![GlyphCluster {
+                    source_range_utf8: TextSourceRange::new(0, run.text.len() as u32),
+                    source_range_utf16: Some(TextSourceRange::new(
+                        0,
+                        run.text.encode_utf16().count() as u32,
+                    )),
+                    text_range_utf8: Some(TextSourceRange::new(0, run.text.len() as u32)),
+                    glyph_range: GlyphRange::new(0, 1),
+                    flags: Vec::new(),
+                }],
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            })
+        }
+    }
+
+    fn placeholder_shape_key(face_key: FontFaceKey, size_px: f64) -> ShapeKey {
+        ShapeKey {
+            font_instance: FontInstanceKey {
+                face_key,
+                size_px,
+                variations: Vec::new(),
+                synthetic_bold: false,
+                synthetic_italic: false,
+            },
+            direction: TextDirection::Ltr,
+            writing_mode: WritingMode::HorizontalTb,
+            script: Some(ScriptTag("DFLT".to_string())),
+            language: None,
+            features: Vec::new(),
+            shaping_engine: ShapingEngineId("test".to_string()),
+            fallback_policy: FontFallbackPolicyId("none".to_string()),
+        }
+    }
+
+    fn text_run(text: &str) -> TextRunNode {
+        TextRunNode {
+            text: text.to_string(),
+            style: crate::renderer::TextStyle {
+                font_family: "Test".to_string(),
+                font_size: 12.0,
+                shade_color: 0x00FF_FFFF,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 12.0,
+            field_marker: crate::renderer::render_tree::FieldMarkerType::None,
+        }
+    }
+
+    #[test]
+    fn diagnostics_only_lowerer_never_emits_public_glyph_runs() {
+        let root = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+            None,
+            vec![PaintOp::TextRun {
+                bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                run: text_run("A"),
+            }],
+        );
+        let lowerer = TextShapeLowerer::diagnostics_only(&PortableResolver);
+        let report = lowerer.analyze_root(&root);
+
+        assert_eq!(report.public_glyph_run_count(), 0);
+        assert_eq!(report.diagnostics.len(), 1);
+        assert!(report.diagnostics[0].attempted);
+        assert_eq!(
+            report.diagnostics[0].replay_eligibility,
+            GlyphRunReplayEligibility::Portable
+        );
+        assert_eq!(
+            report.diagnostics[0].quality,
+            GlyphRunQuality::DiagnosticOnly
+        );
+    }
+
+    #[test]
+    fn lowerer_emits_public_glyph_run_only_from_exportable_shaped_data() {
+        let mut root = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+            None,
+            vec![PaintOp::TextRun {
+                bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                run: text_run("A"),
+            }],
+        );
+        let lowerer = TextShapeLowerer::new(&EmittingResolver);
+        let report = lowerer.lower_root(&mut root);
+
+        assert_eq!(report.public_glyph_run_count(), 1);
+        let LayerNodeKind::Leaf { ops } = &root.kind else {
+            panic!("expected leaf root");
+        };
+        assert!(matches!(ops[0], PaintOp::TextRun { .. }));
+        let PaintOp::GlyphRun { run, .. } = &ops[1] else {
+            panic!("expected glyph run variant");
+        };
+        assert_eq!(run.variant.equivalence_group, "text-0");
+        assert_eq!(run.variant.variant_id, "glyphRun");
+        assert_eq!(run.variant.variant_kind, TextVariantKind::GlyphRun);
+        assert!(!run.variant.is_default_fallback);
+        assert_eq!(run.glyph_ids, vec![42]);
+        assert!(run.diagnostics.strict_visual_eligible);
+    }
+
+    #[test]
+    fn lowerer_keeps_text_fallback_when_glyph_run_effects_are_not_fill_only() {
+        let mut run = text_run("A");
+        run.style.underline = crate::model::style::UnderlineType::Bottom;
+        let mut root = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+            None,
+            vec![PaintOp::TextRun {
+                bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                run,
+            }],
+        );
+        let lowerer = TextShapeLowerer::new(&EmittingResolver);
+        let report = lowerer.lower_root(&mut root);
+
+        assert_eq!(report.public_glyph_run_count(), 0);
+        assert_eq!(
+            report.diagnostics[0].reason.as_deref(),
+            Some("unsupportedGlyphRunPaintEffect")
+        );
+        let LayerNodeKind::Leaf { ops } = &root.kind else {
+            panic!("expected leaf root");
+        };
+        assert_eq!(ops.len(), 1);
+        assert!(matches!(ops[0], PaintOp::TextRun { .. }));
+    }
+}

--- a/src/paint/text_shape.rs
+++ b/src/paint/text_shape.rs
@@ -5,6 +5,7 @@ use crate::paint::{
     TextVariantQuality,
 };
 use crate::renderer::render_tree::{BoundingBox, TextRunNode};
+use std::collections::HashSet;
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FontRequest {
@@ -168,10 +169,25 @@ impl<'a> TextShapeLowerer<'a> {
                 self.lower_node(child, report, next_text_source_id);
             }
             LayerNodeKind::Leaf { ops } => {
+                let existing_glyph_groups = ops
+                    .iter()
+                    .filter_map(|op| match op {
+                        PaintOp::GlyphRun { run, .. } => {
+                            Some(run.variant.equivalence_group.clone())
+                        }
+                        _ => None,
+                    })
+                    .collect::<HashSet<_>>();
                 let mut lowered = Vec::with_capacity(ops.len());
                 for op in ops.drain(..) {
                     if let PaintOp::TextRun { bbox, run } = op {
                         let text_source_id = *next_text_source_id;
+                        let equivalence_group = format!("text-{text_source_id}");
+                        if existing_glyph_groups.contains(&equivalence_group) {
+                            lowered.push(PaintOp::TextRun { bbox, run });
+                            *next_text_source_id = (*next_text_source_id).saturating_add(1);
+                            continue;
+                        }
                         let (diagnostic, glyph_run) =
                             self.lower_text_run(bbox, &run, text_source_id);
                         report.diagnostics.push(diagnostic);
@@ -545,6 +561,33 @@ mod tests {
         assert!(!run.variant.is_default_fallback);
         assert_eq!(run.glyph_ids, vec![42]);
         assert!(run.diagnostics.strict_visual_eligible);
+    }
+
+    #[test]
+    fn lowerer_does_not_duplicate_existing_glyph_run_sidecars() {
+        let mut root = LayerNode::leaf(
+            BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+            None,
+            vec![PaintOp::TextRun {
+                bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                run: text_run("A"),
+            }],
+        );
+        let lowerer = TextShapeLowerer::new(&EmittingResolver);
+        let first_report = lowerer.lower_root(&mut root);
+        let second_report = lowerer.lower_root(&mut root);
+
+        assert_eq!(first_report.public_glyph_run_count(), 1);
+        assert_eq!(second_report.public_glyph_run_count(), 0);
+        let LayerNodeKind::Leaf { ops } = &root.kind else {
+            panic!("expected leaf root");
+        };
+        assert_eq!(
+            ops.iter()
+                .filter(|op| matches!(op, PaintOp::GlyphRun { .. }))
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src/paint/text_variants.rs
+++ b/src/paint/text_variants.rs
@@ -267,7 +267,7 @@ mod tests {
     fn glyph_op(variant: PaintVariantMeta) -> PaintOp {
         PaintOp::GlyphRun {
             bbox: bbox(),
-            run: LayerGlyphRunPaint {
+            run: Box::new(LayerGlyphRunPaint {
                 source: TextSourceSpan {
                     id: TextSourceId(0),
                     utf8_range: TextSourceRange::new(0, 1),
@@ -330,7 +330,7 @@ mod tests {
                     used_fallback_font_count: 0,
                     reason: None,
                 },
-            },
+            }),
         }
     }
 

--- a/src/paint/text_variants.rs
+++ b/src/paint/text_variants.rs
@@ -1,0 +1,444 @@
+//! Text variant grouping validation.
+//!
+//! Schema v1 keeps `TextRun` as the root fallback op and attaches optional
+//! visual alternatives such as `GlyphRun` through variant metadata. Consumers
+//! choose one variant set per equivalence group.
+
+use std::collections::{HashMap, HashSet};
+use std::fmt;
+
+use crate::paint::{LayerNode, LayerNodeKind, PageLayerTree, PaintOp, PaintVariantMeta};
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum TextVariantScopeError {
+    CrossLeafGroup {
+        equivalence_group: String,
+        first_leaf: String,
+        second_leaf: String,
+    },
+    MissingDefaultFallback {
+        equivalence_group: String,
+        leaf: String,
+    },
+    EmptyVariantSet {
+        equivalence_group: String,
+        variant_id: String,
+        leaf: String,
+    },
+    DuplicatePart {
+        equivalence_group: String,
+        variant_id: String,
+        part_index: u32,
+        leaf: String,
+    },
+    PartCountMismatch {
+        equivalence_group: String,
+        variant_id: String,
+        expected: u32,
+        actual: u32,
+        leaf: String,
+    },
+}
+
+impl fmt::Display for TextVariantScopeError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::CrossLeafGroup {
+                equivalence_group,
+                first_leaf,
+                second_leaf,
+            } => write!(
+                f,
+                "text variant group `{equivalence_group}` crosses leaf scope `{first_leaf}` and `{second_leaf}`"
+            ),
+            Self::MissingDefaultFallback {
+                equivalence_group,
+                leaf,
+            } => write!(
+                f,
+                "text variant group `{equivalence_group}` in leaf `{leaf}` has no default fallback"
+            ),
+            Self::EmptyVariantSet {
+                equivalence_group,
+                variant_id,
+                leaf,
+            } => write!(
+                f,
+                "text variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` has zero parts"
+            ),
+            Self::DuplicatePart {
+                equivalence_group,
+                variant_id,
+                part_index,
+                leaf,
+            } => write!(
+                f,
+                "text variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` repeats part {part_index}"
+            ),
+            Self::PartCountMismatch {
+                equivalence_group,
+                variant_id,
+                expected,
+                actual,
+                leaf,
+            } => write!(
+                f,
+                "text variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` has {actual} parts, expected {expected}"
+            ),
+        }
+    }
+}
+
+impl std::error::Error for TextVariantScopeError {}
+
+#[derive(Debug, Default)]
+struct LeafGroupState {
+    has_default_fallback: bool,
+    variants: HashMap<String, VariantPartState>,
+}
+
+#[derive(Debug, Default)]
+struct VariantPartState {
+    expected_part_count: Option<u32>,
+    parts: HashSet<u32>,
+}
+
+pub fn validate_text_variant_scope(tree: &PageLayerTree) -> Result<(), TextVariantScopeError> {
+    let mut group_leaf_paths = HashMap::new();
+    validate_node(&tree.root, "root".to_string(), &mut group_leaf_paths)
+}
+
+fn validate_node(
+    node: &LayerNode,
+    path: String,
+    group_leaf_paths: &mut HashMap<String, String>,
+) -> Result<(), TextVariantScopeError> {
+    match &node.kind {
+        LayerNodeKind::Group { children, .. } => {
+            for (index, child) in children.iter().enumerate() {
+                validate_node(child, format!("{path}/group[{index}]"), group_leaf_paths)?;
+            }
+        }
+        LayerNodeKind::ClipRect { child, .. } => {
+            validate_node(child, format!("{path}/clip"), group_leaf_paths)?;
+        }
+        LayerNodeKind::Leaf { ops } => {
+            validate_leaf(ops, path, group_leaf_paths)?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_leaf(
+    ops: &[PaintOp],
+    leaf_path: String,
+    group_leaf_paths: &mut HashMap<String, String>,
+) -> Result<(), TextVariantScopeError> {
+    let mut groups = HashMap::<String, LeafGroupState>::new();
+    let has_text_run_fallback = ops.iter().any(|op| matches!(op, PaintOp::TextRun { .. }));
+    for op in ops {
+        let Some(variant) = op_variant(op) else {
+            continue;
+        };
+        if let Some(first_leaf) = group_leaf_paths.get(&variant.equivalence_group) {
+            if first_leaf != &leaf_path {
+                return Err(TextVariantScopeError::CrossLeafGroup {
+                    equivalence_group: variant.equivalence_group.clone(),
+                    first_leaf: first_leaf.clone(),
+                    second_leaf: leaf_path,
+                });
+            }
+        } else {
+            group_leaf_paths.insert(variant.equivalence_group.clone(), leaf_path.clone());
+        }
+
+        let group = groups.entry(variant.equivalence_group.clone()).or_default();
+        group.has_default_fallback |= has_text_run_fallback || variant.is_default_fallback;
+        let state = group
+            .variants
+            .entry(variant.variant_id.clone())
+            .or_default();
+        match state.expected_part_count {
+            Some(expected) if expected != variant.part_count => {
+                return Err(TextVariantScopeError::PartCountMismatch {
+                    equivalence_group: variant.equivalence_group.clone(),
+                    variant_id: variant.variant_id.clone(),
+                    expected,
+                    actual: variant.part_count,
+                    leaf: leaf_path,
+                });
+            }
+            Some(_) => {}
+            None => {
+                state.expected_part_count = Some(variant.part_count);
+            }
+        }
+        if variant.part_count == 0 {
+            return Err(TextVariantScopeError::EmptyVariantSet {
+                equivalence_group: variant.equivalence_group.clone(),
+                variant_id: variant.variant_id.clone(),
+                leaf: leaf_path,
+            });
+        }
+        if !state.parts.insert(variant.part_index) {
+            return Err(TextVariantScopeError::DuplicatePart {
+                equivalence_group: variant.equivalence_group.clone(),
+                variant_id: variant.variant_id.clone(),
+                part_index: variant.part_index,
+                leaf: leaf_path,
+            });
+        }
+    }
+
+    for (equivalence_group, group) in groups {
+        if !group.has_default_fallback {
+            return Err(TextVariantScopeError::MissingDefaultFallback {
+                equivalence_group,
+                leaf: leaf_path,
+            });
+        }
+        for (variant_id, state) in group.variants {
+            let expected = state.expected_part_count.unwrap_or_default();
+            let actual = state.parts.len() as u32;
+            if expected != actual || !(0..expected).all(|index| state.parts.contains(&index)) {
+                return Err(TextVariantScopeError::PartCountMismatch {
+                    equivalence_group: equivalence_group.clone(),
+                    variant_id,
+                    expected,
+                    actual,
+                    leaf: leaf_path,
+                });
+            }
+        }
+    }
+    Ok(())
+}
+
+fn op_variant(op: &PaintOp) -> Option<PaintVariantMeta> {
+    match op {
+        PaintOp::GlyphRun { run, .. } => Some(run.variant.clone()),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::resources::ResourceArena;
+    use crate::paint::{
+        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphRange,
+        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, LayerAffineTransform,
+        LayerGlyphRunPaint, LayerNode, LayerOutputOptions, LayerPoint, PaintTextStyle,
+        RenderProfile, ScriptTag, ShapeKey, ShapingEngineId, TextDirection, TextSourceId,
+        TextSourceRange, TextSourceSpan, TextSourceTable, TextVariantKind, TextVariantQuality,
+        WritingMode,
+    };
+    use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
+    use crate::renderer::TextStyle;
+
+    fn bbox() -> BoundingBox {
+        BoundingBox::new(0.0, 0.0, 10.0, 10.0)
+    }
+
+    fn text_op() -> PaintOp {
+        PaintOp::TextRun {
+            bbox: bbox(),
+            run: TextRunNode {
+                text: "A".to_string(),
+                style: TextStyle::default(),
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 10.0,
+                field_marker: FieldMarkerType::None,
+            },
+        }
+    }
+
+    fn glyph_op(variant: PaintVariantMeta) -> PaintOp {
+        PaintOp::GlyphRun {
+            bbox: bbox(),
+            run: LayerGlyphRunPaint {
+                source: TextSourceSpan {
+                    id: TextSourceId(0),
+                    utf8_range: TextSourceRange::new(0, 1),
+                    utf16_range: TextSourceRange::new(0, 1),
+                    stable_source_key: None,
+                },
+                variant,
+                paint_style: PaintTextStyle::from(&TextStyle::default()),
+                shape_key: ShapeKey {
+                    font_instance: FontInstanceKey {
+                        face_key: FontFaceKey("face-0".to_string()),
+                        size_px: 12.0,
+                        variations: Vec::new(),
+                        synthetic_bold: false,
+                        synthetic_italic: false,
+                    },
+                    direction: TextDirection::Ltr,
+                    writing_mode: WritingMode::HorizontalTb,
+                    script: Some(ScriptTag("DFLT".to_string())),
+                    language: None,
+                    features: Vec::new(),
+                    shaping_engine: ShapingEngineId("test".to_string()),
+                    fallback_policy: FontFallbackPolicyId("none".to_string()),
+                },
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 0.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                glyph_ids: vec![42],
+                positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+                advances: None,
+                clusters: vec![GlyphCluster {
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    source_range_utf16: Some(TextSourceRange::new(0, 1)),
+                    text_range_utf8: Some(TextSourceRange::new(0, 1)),
+                    glyph_range: GlyphRange::new(0, 1),
+                    flags: Vec::new(),
+                }],
+                direction: TextDirection::Ltr,
+                bidi_level: None,
+                writing_mode: WritingMode::HorizontalTb,
+                orientation: GlyphRunOrientation::Horizontal,
+                glyph_transforms: None,
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            },
+        }
+    }
+
+    fn tree(root: LayerNode) -> PageLayerTree {
+        PageLayerTree {
+            page_width: 100.0,
+            page_height: 100.0,
+            profile: RenderProfile::default(),
+            output_options: LayerOutputOptions::default(),
+            root,
+            resources: ResourceArena::default(),
+            text_sources: TextSourceTable::default(),
+        }
+    }
+
+    #[test]
+    fn accepts_variant_set_inside_one_leaf() {
+        let glyph_part_0 = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphRun".to_string(),
+            variant_kind: TextVariantKind::GlyphRun,
+            part_index: 0,
+            part_count: 2,
+            is_default_fallback: false,
+            requires: vec!["fontResources".to_string(), "text.glyphRun".to_string()],
+            quality: None,
+            anchor_op_id: None,
+            local_paint_order: None,
+        };
+        let mut glyph_part_1 = glyph_part_0.clone();
+        glyph_part_1.part_index = 1;
+        let tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![text_op(), glyph_op(glyph_part_0), glyph_op(glyph_part_1)],
+        ));
+        validate_text_variant_scope(&tree).unwrap();
+    }
+
+    #[test]
+    fn rejects_cross_leaf_variant_group() {
+        let tree = tree(LayerNode::group(
+            bbox(),
+            None,
+            vec![
+                LayerNode::leaf(
+                    bbox(),
+                    None,
+                    vec![glyph_op(PaintVariantMeta::text_run_default("text-1"))],
+                ),
+                LayerNode::leaf(
+                    bbox(),
+                    None,
+                    vec![glyph_op(PaintVariantMeta::text_run_default("text-1"))],
+                ),
+            ],
+            crate::paint::CacheHint::None,
+            crate::paint::GroupKind::Generic,
+        ));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::CrossLeafGroup { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_incomplete_variant_parts() {
+        let glyph_part = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphRun".to_string(),
+            variant_kind: TextVariantKind::GlyphRun,
+            part_index: 0,
+            part_count: 2,
+            is_default_fallback: false,
+            requires: Vec::new(),
+            quality: None,
+            anchor_op_id: None,
+            local_paint_order: None,
+        };
+        let tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![text_op(), glyph_op(glyph_part)],
+        ));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::PartCountMismatch { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_variant_group_without_default_fallback() {
+        let glyph_part = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphRun".to_string(),
+            variant_kind: TextVariantKind::GlyphRun,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: false,
+            requires: Vec::new(),
+            quality: None,
+            anchor_op_id: None,
+            local_paint_order: None,
+        };
+        let tree = tree(LayerNode::leaf(bbox(), None, vec![glyph_op(glyph_part)]));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::MissingDefaultFallback { .. })
+        ));
+    }
+}

--- a/src/renderer/canvas.rs
+++ b/src/renderer/canvas.rs
@@ -247,6 +247,7 @@ impl CanvasRenderer {
                             self.close_shape_transform_value(&path.transform);
                         }
                         PaintOp::FootnoteMarker { .. }
+                        | PaintOp::GlyphRun { .. }
                         | PaintOp::CharOverlap { .. }
                         | PaintOp::TextControlMark { .. }
                         | PaintOp::TabLeader { .. }

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,13 +1,16 @@
 use skia_safe::{
-    paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Paint,
-    PathBuilder, PathEffect, RRect, Rect, Typeface,
+    font, paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Matrix,
+    Paint, PathBuilder, PathEffect, RRect, Rect, Typeface,
 };
-use std::collections::HashMap;
+use std::collections::{HashMap, HashSet};
 
 use crate::error::HwpError;
 use crate::model::image::ImageEffect;
 use crate::model::ColorRef;
-use crate::paint::{LayerNode, LayerNodeKind, LayerOutputOptions, PageLayerTree, PaintOp};
+use crate::paint::{
+    GlyphRunOrientation, GlyphRunReplayEligibility, LayerGlyphRunPaint, LayerNode, LayerNodeKind,
+    LayerOutputOptions, PageLayerTree, PaintOp, ResourceArena, TextVariantQuality,
+};
 use crate::renderer::layer_renderer::{
     LayerRasterRenderer, LayerRenderResult, RasterOutputFormat, RasterRenderOptions,
     RasterRenderOutput,
@@ -17,6 +20,77 @@ use crate::renderer::{svg_arc_to_beziers, LineStyle, PathCommand, ShapeStyle, St
 use super::equation_conv::render_equation;
 use super::image_conv::{draw_image_bytes, draw_svg_fragment, ImageSampling};
 use super::text_replay::SkiaTextReplay;
+
+fn native_skia_can_replay_glyph_run(run: &LayerGlyphRunPaint, resources: &ResourceArena) -> bool {
+    if run.glyph_ids.is_empty()
+        || run.glyph_ids.len() != run.positions.len()
+        || run
+            .advances
+            .as_ref()
+            .is_some_and(|advances| advances.len() != run.glyph_ids.len())
+        || run.glyph_transforms.is_some()
+        || run.orientation == GlyphRunOrientation::MixedPerGlyph
+        || !run.diagnostics.strict_visual_eligible
+        || run.diagnostics.missing_glyph_count != 0
+        || run.diagnostics.cluster_mismatch_count != 0
+        || !matches!(
+            run.diagnostics.quality,
+            TextVariantQuality::Exact | TextVariantQuality::PositionAdjusted
+        )
+        || run.diagnostics.replay_eligibility != GlyphRunReplayEligibility::Portable
+    {
+        return false;
+    }
+    if run.diagnostics.quality == TextVariantQuality::PositionAdjusted {
+        let tolerance = 0.5_f64.min(0.25_f64.max(run.paint_style.font_size * 0.005));
+        if !run.diagnostics.max_residual_after_adjustment_px.is_finite()
+            || run.diagnostics.max_residual_after_adjustment_px > tolerance
+        {
+            return false;
+        }
+    }
+    if !run.paint_style.is_fill_only_glyph_replay() {
+        return false;
+    }
+    let font_resources = resources.font_resources();
+    let Some(face) = font_resources
+        .faces
+        .iter()
+        .find(|face| face.id == run.shape_key.font_instance.face_key)
+    else {
+        return false;
+    };
+    let Some(blob) = font_resources
+        .blobs
+        .iter()
+        .find(|blob| blob.id == face.blob_key)
+    else {
+        return false;
+    };
+    if !blob.portability.is_self_contained_replayable() {
+        return false;
+    }
+    let transform = run.placement.run_to_page;
+    [
+        transform.a,
+        transform.b,
+        transform.c,
+        transform.d,
+        transform.e,
+        transform.f,
+        run.placement.baseline_y,
+    ]
+    .into_iter()
+    .all(f64::is_finite)
+        && run
+            .glyph_ids
+            .iter()
+            .all(|glyph_id| *glyph_id <= u16::MAX as u32)
+        && run
+            .positions
+            .iter()
+            .all(|position| position.x.is_finite() && position.y.is_finite())
+}
 
 pub struct SkiaLayerRenderer {
     font_mgr: FontMgr,
@@ -140,7 +214,14 @@ impl SkiaLayerRenderer {
         if options.scale != 1.0 {
             canvas.scale((options.scale as f32, options.scale as f32));
         }
-        self.render_node(canvas, &tree.root, &tree.output_options);
+        let mut next_text_source_id = 0_u32;
+        self.render_node(
+            canvas,
+            &tree.root,
+            &tree.output_options,
+            &tree.resources,
+            &mut next_text_source_id,
+        );
 
         let image = surface.image_snapshot();
         let data = image
@@ -156,7 +237,14 @@ impl SkiaLayerRenderer {
         })
     }
 
-    fn render_node(&self, canvas: &Canvas, node: &LayerNode, output_options: &LayerOutputOptions) {
+    fn render_node(
+        &self,
+        canvas: &Canvas,
+        node: &LayerNode,
+        output_options: &LayerOutputOptions,
+        resources: &ResourceArena,
+        next_text_source_id: &mut u32,
+    ) {
         let clip_enabled = output_options.clip_enabled;
         let apply_dash = |paint: &mut Paint, dash: StrokeDash| {
             let base_width = paint.stroke_width().max(1.0);
@@ -296,12 +384,24 @@ impl SkiaLayerRenderer {
         match &node.kind {
             LayerNodeKind::Group { children, .. } => {
                 for child in children {
-                    self.render_node(canvas, child, output_options);
+                    self.render_node(
+                        canvas,
+                        child,
+                        output_options,
+                        resources,
+                        next_text_source_id,
+                    );
                 }
             }
             LayerNodeKind::ClipRect { clip, child, .. } => {
                 if !clip_enabled {
-                    self.render_node(canvas, child, output_options);
+                    self.render_node(
+                        canvas,
+                        child,
+                        output_options,
+                        resources,
+                        next_text_source_id,
+                    );
                     return;
                 }
                 canvas.save();
@@ -315,11 +415,80 @@ impl SkiaLayerRenderer {
                     None,
                     Some(true),
                 );
-                self.render_node(canvas, child, output_options);
+                self.render_node(
+                    canvas,
+                    child,
+                    output_options,
+                    resources,
+                    next_text_source_id,
+                );
                 canvas.restore();
             }
             LayerNodeKind::Leaf { ops } => {
+                let mut variant_order = 0usize;
+                let mut glyph_variants =
+                    HashMap::<String, HashMap<String, (usize, u32, HashSet<u32>, bool)>>::new();
+                let mut glyph_variant_sources = HashMap::<String, u32>::new();
                 for op in ops {
+                    if let PaintOp::GlyphRun { run, .. } = op {
+                        glyph_variant_sources
+                            .entry(run.variant.equivalence_group.clone())
+                            .or_insert(run.source.id.0);
+                        let group = glyph_variants
+                            .entry(run.variant.equivalence_group.clone())
+                            .or_default();
+                        let state =
+                            group
+                                .entry(run.variant.variant_id.clone())
+                                .or_insert_with(|| {
+                                    let order = variant_order;
+                                    variant_order = variant_order.saturating_add(1);
+                                    (order, run.variant.part_count, HashSet::new(), true)
+                                });
+                        if state.1 != run.variant.part_count || run.variant.part_count == 0 {
+                            state.3 = false;
+                        }
+                        if !state.2.insert(run.variant.part_index) {
+                            state.3 = false;
+                        }
+                        state.3 &= native_skia_can_replay_glyph_run(run, resources);
+                    }
+                }
+                let mut selected_text_variants = HashMap::new();
+                for (group, variants) in glyph_variants {
+                    let mut candidates = variants.into_iter().collect::<Vec<_>>();
+                    candidates.sort_by_key(|(_, (order, _, _, _))| *order);
+                    for (variant_id, (_, expected_part_count, parts, supported)) in candidates {
+                        let parts_complete = parts.len() as u32 == expected_part_count
+                            && (0..expected_part_count).all(|index| parts.contains(&index));
+                        if supported && parts_complete {
+                            selected_text_variants.insert(group, variant_id);
+                            break;
+                        }
+                    }
+                }
+                let selected_text_sources = selected_text_variants
+                    .keys()
+                    .filter_map(|group| glyph_variant_sources.get(group).copied())
+                    .collect::<HashSet<_>>();
+                for op in ops {
+                    let skip_unselected_text_variant = match op {
+                        PaintOp::TextRun { .. } => {
+                            let source_id = *next_text_source_id;
+                            *next_text_source_id = (*next_text_source_id).saturating_add(1);
+                            selected_text_sources.contains(&source_id)
+                        }
+                        PaintOp::GlyphRun { run, .. } => {
+                            match selected_text_variants.get(&run.variant.equivalence_group) {
+                                Some(selected) => selected != &run.variant.variant_id,
+                                None => true,
+                            }
+                        }
+                        _ => false,
+                    };
+                    if skip_unselected_text_variant {
+                        continue;
+                    }
                     match op {
                         PaintOp::PageBackground { bbox, background } => {
                             let rect = Rect::from_xywh(
@@ -380,6 +549,72 @@ impl SkiaLayerRenderer {
                                 run.is_para_end,
                                 run.is_line_break_end,
                             );
+                        }
+                        PaintOp::GlyphRun { run, .. } => {
+                            if !native_skia_can_replay_glyph_run(run, resources) {
+                                continue;
+                            }
+                            let font_style = match (run.paint_style.bold, run.paint_style.italic) {
+                                (true, true) => FontStyle::bold_italic(),
+                                (true, false) => FontStyle::bold(),
+                                (false, true) => FontStyle::italic(),
+                                (false, false) => FontStyle::normal(),
+                            };
+                            let font_size = if run.paint_style.font_size > 0.0 {
+                                run.paint_style.font_size as f32
+                            } else {
+                                12.0
+                            };
+                            let typeface = self
+                                .custom_typefaces
+                                .get(run.paint_style.font_family.as_str())
+                                .cloned()
+                                .or_else(|| {
+                                    self.font_mgr.match_family_style(
+                                        run.paint_style.font_family.as_str(),
+                                        font_style,
+                                    )
+                                })
+                                .or_else(|| {
+                                    self.font_mgr.legacy_make_typeface(None::<&str>, font_style)
+                                });
+                            let mut font = if let Some(typeface) = typeface {
+                                Font::new(typeface, font_size)
+                            } else {
+                                let mut fallback = Font::default();
+                                fallback.set_size(font_size);
+                                fallback
+                            };
+                            font.set_edging(font::Edging::AntiAlias);
+
+                            let transform = run.placement.run_to_page;
+                            let matrix = Matrix::from_affine(&[
+                                transform.a as f32,
+                                transform.b as f32,
+                                transform.c as f32,
+                                transform.d as f32,
+                                transform.e as f32,
+                                transform.f as f32,
+                            ]);
+                            let mut fill_paint = Paint::default();
+                            fill_paint.set_anti_alias(true);
+                            fill_paint.set_style(paint::Style::Fill);
+                            fill_paint.set_color(colorref_to_skia(run.paint_style.color, 1.0));
+
+                            canvas.save();
+                            canvas.concat(&matrix);
+                            for (glyph_id, position) in
+                                run.glyph_ids.iter().zip(run.positions.iter())
+                            {
+                                if let Some(path) = font.get_path(*glyph_id as u16) {
+                                    let path = path.with_offset((
+                                        position.x as f32,
+                                        position.y as f32 + run.placement.baseline_y as f32,
+                                    ));
+                                    canvas.draw_path(&path, &fill_paint);
+                                }
+                            }
+                            canvas.restore();
                         }
                         PaintOp::FootnoteMarker { bbox, marker } => {
                             let style = crate::renderer::TextStyle {

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1,6 +1,6 @@
 use skia_safe::{
-    font, paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Matrix,
-    Paint, PathBuilder, PathEffect, RRect, Rect, Typeface,
+    paint, surfaces, Canvas, Color, EncodedImageFormat, Font, FontMgr, FontStyle, Paint,
+    PathBuilder, PathEffect, RRect, Rect, Typeface,
 };
 use std::collections::{HashMap, HashSet};
 
@@ -22,6 +22,19 @@ use super::image_conv::{draw_image_bytes, draw_svg_fragment, ImageSampling};
 use super::text_replay::SkiaTextReplay;
 
 fn native_skia_can_replay_glyph_run(run: &LayerGlyphRunPaint, resources: &ResourceArena) -> bool {
+    if !native_skia_glyph_run_contract_is_replayable(run, resources) {
+        return false;
+    }
+
+    // Glyph ids are face-local. Native Skia must not select a GlyphRun until it
+    // can build the exact typeface from the referenced font blob/face resource.
+    false
+}
+
+fn native_skia_glyph_run_contract_is_replayable(
+    run: &LayerGlyphRunPaint,
+    resources: &ResourceArena,
+) -> bool {
     if run.glyph_ids.is_empty()
         || run.glyph_ids.len() != run.positions.len()
         || run
@@ -29,7 +42,7 @@ fn native_skia_can_replay_glyph_run(run: &LayerGlyphRunPaint, resources: &Resour
             .as_ref()
             .is_some_and(|advances| advances.len() != run.glyph_ids.len())
         || run.glyph_transforms.is_some()
-        || run.orientation == GlyphRunOrientation::MixedPerGlyph
+        || run.orientation != GlyphRunOrientation::Horizontal
         || !run.diagnostics.strict_visual_eligible
         || run.diagnostics.missing_glyph_count != 0
         || run.diagnostics.cluster_mismatch_count != 0
@@ -554,67 +567,8 @@ impl SkiaLayerRenderer {
                             if !native_skia_can_replay_glyph_run(run, resources) {
                                 continue;
                             }
-                            let font_style = match (run.paint_style.bold, run.paint_style.italic) {
-                                (true, true) => FontStyle::bold_italic(),
-                                (true, false) => FontStyle::bold(),
-                                (false, true) => FontStyle::italic(),
-                                (false, false) => FontStyle::normal(),
-                            };
-                            let font_size = if run.paint_style.font_size > 0.0 {
-                                run.paint_style.font_size as f32
-                            } else {
-                                12.0
-                            };
-                            let typeface = self
-                                .custom_typefaces
-                                .get(run.paint_style.font_family.as_str())
-                                .cloned()
-                                .or_else(|| {
-                                    self.font_mgr.match_family_style(
-                                        run.paint_style.font_family.as_str(),
-                                        font_style,
-                                    )
-                                })
-                                .or_else(|| {
-                                    self.font_mgr.legacy_make_typeface(None::<&str>, font_style)
-                                });
-                            let mut font = if let Some(typeface) = typeface {
-                                Font::new(typeface, font_size)
-                            } else {
-                                let mut fallback = Font::default();
-                                fallback.set_size(font_size);
-                                fallback
-                            };
-                            font.set_edging(font::Edging::AntiAlias);
-
-                            let transform = run.placement.run_to_page;
-                            let matrix = Matrix::from_affine(&[
-                                transform.a as f32,
-                                transform.b as f32,
-                                transform.c as f32,
-                                transform.d as f32,
-                                transform.e as f32,
-                                transform.f as f32,
-                            ]);
-                            let mut fill_paint = Paint::default();
-                            fill_paint.set_anti_alias(true);
-                            fill_paint.set_style(paint::Style::Fill);
-                            fill_paint.set_color(colorref_to_skia(run.paint_style.color, 1.0));
-
-                            canvas.save();
-                            canvas.concat(&matrix);
-                            for (glyph_id, position) in
-                                run.glyph_ids.iter().zip(run.positions.iter())
-                            {
-                                if let Some(path) = font.get_path(*glyph_id as u16) {
-                                    let path = path.with_offset((
-                                        position.x as f32,
-                                        position.y as f32 + run.placement.baseline_y as f32,
-                                    ));
-                                    canvas.draw_path(&path, &fill_paint);
-                                }
-                            }
-                            canvas.restore();
+                            // Unreachable until native_skia_can_replay_glyph_run can verify
+                            // blob-backed typeface construction. Keep the TextRun fallback.
                         }
                         PaintOp::FootnoteMarker { bbox, marker } => {
                             let style = crate::renderer::TextStyle {
@@ -1178,7 +1132,14 @@ mod tests {
     use super::*;
     use crate::model::control::FormType;
     use crate::model::style::{ImageFillMode, UnderlineType};
-    use crate::paint::{CacheHint, GroupKind, LayerNode, LayerOutputOptions};
+    use crate::paint::{
+        BinaryResourceKind, BinaryResourceRef, CacheHint, FontBlobKey, FontBlobResource,
+        FontDigest, FontFaceKey, FontFaceResource, FontFallbackPolicyId, FontInstanceKey,
+        FontPortability, FontResourceSource, GlyphCluster, GlyphRange, GroupKind,
+        LayerAffineTransform, LayerNode, LayerOutputOptions, LayerPoint, PaintTextStyle,
+        PaintVariantMeta, ScriptTag, ShapeKey, ShapingEngineId, TextDirection, TextSourceId,
+        TextSourceRange, TextSourceSpan, TextVariantKind, WritingMode,
+    };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::ast::EqNode;
     use crate::renderer::equation::layout::EqLayout;
@@ -1206,6 +1167,117 @@ mod tests {
 
     fn count_ink(image: &image::RgbaImage) -> usize {
         image.pixels().filter(|pixel| pixel[3] > 0).count()
+    }
+
+    fn portable_font_resources() -> ResourceArena {
+        let mut resources = ResourceArena::default();
+        let blob_key = FontBlobKey("blob-0".to_string());
+        let face_key = FontFaceKey("face-0".to_string());
+        let digest = FontDigest {
+            algorithm: "blake3".to_string(),
+            value: "0123456789abcdef".to_string(),
+        };
+        let data_ref = BinaryResourceRef {
+            kind: BinaryResourceKind::FontBlob,
+            id: "font:blake3:4:0123456789abcdef".to_string(),
+        };
+        resources.font_resources_mut().blobs.push(FontBlobResource {
+            id: blob_key.clone(),
+            digest: Some(digest.clone()),
+            source: FontResourceSource::Embedded,
+            data_ref: Some(data_ref.clone()),
+            portability: FontPortability::PortableBlob { digest, data_ref },
+        });
+        resources.font_resources_mut().faces.push(FontFaceResource {
+            id: face_key,
+            blob_key,
+            face_index: 0,
+            postscript_name: None,
+            family_names: Vec::new(),
+            style_names: Vec::new(),
+            weight_class: None,
+            width_class: None,
+            italic: None,
+        });
+        resources
+    }
+
+    fn portable_glyph_run(orientation: GlyphRunOrientation) -> LayerGlyphRunPaint {
+        let mut variant = PaintVariantMeta::text_run_default("text-0");
+        variant.variant_id = "glyphRun".to_string();
+        variant.variant_kind = TextVariantKind::GlyphRun;
+        variant.is_default_fallback = false;
+        variant.requires = vec!["fontResources".to_string(), "text.glyphRun".to_string()];
+        variant.quality = Some(TextVariantQuality::Exact);
+
+        LayerGlyphRunPaint {
+            source: TextSourceSpan {
+                id: TextSourceId(0),
+                utf8_range: TextSourceRange::new(0, 1),
+                utf16_range: TextSourceRange::new(0, 1),
+                stable_source_key: None,
+            },
+            variant,
+            paint_style: PaintTextStyle::from(&TextStyle {
+                font_family: "Test".to_string(),
+                font_size: 12.0,
+                ..Default::default()
+            }),
+            shape_key: ShapeKey {
+                font_instance: FontInstanceKey {
+                    face_key: FontFaceKey("face-0".to_string()),
+                    size_px: 12.0,
+                    variations: Vec::new(),
+                    synthetic_bold: false,
+                    synthetic_italic: false,
+                },
+                direction: TextDirection::Ltr,
+                writing_mode: WritingMode::HorizontalTb,
+                script: Some(ScriptTag("DFLT".to_string())),
+                language: None,
+                features: Vec::new(),
+                shaping_engine: ShapingEngineId("test".to_string()),
+                fallback_policy: FontFallbackPolicyId("none".to_string()),
+            },
+            placement: crate::paint::TextRunPlacement {
+                run_to_page: LayerAffineTransform {
+                    a: 1.0,
+                    b: 0.0,
+                    c: 0.0,
+                    d: 1.0,
+                    e: 0.0,
+                    f: 0.0,
+                },
+                baseline_y: 0.0,
+            },
+            glyph_ids: vec![42],
+            positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+            advances: None,
+            clusters: vec![GlyphCluster {
+                source_range_utf8: TextSourceRange::new(0, 1),
+                source_range_utf16: Some(TextSourceRange::new(0, 1)),
+                text_range_utf8: Some(TextSourceRange::new(0, 1)),
+                glyph_range: GlyphRange::new(0, 1),
+                flags: Vec::new(),
+            }],
+            direction: TextDirection::Ltr,
+            bidi_level: None,
+            writing_mode: WritingMode::HorizontalTb,
+            orientation,
+            glyph_transforms: None,
+            diagnostics: crate::paint::GlyphRunDiagnostics {
+                quality: TextVariantQuality::Exact,
+                replay_eligibility: GlyphRunReplayEligibility::Portable,
+                strict_visual_eligible: true,
+                max_origin_delta_px: 0.0,
+                max_advance_delta_px: 0.0,
+                max_residual_after_adjustment_px: 0.0,
+                cluster_mismatch_count: 0,
+                missing_glyph_count: 0,
+                used_fallback_font_count: 0,
+                reason: None,
+            },
+        }
     }
 
     fn solid_png(color: [u8; 4]) -> Vec<u8> {
@@ -1242,6 +1314,28 @@ mod tests {
             .write_to(&mut cursor, ImageFormat::Png)
             .expect("encode png");
         cursor.into_inner()
+    }
+
+    #[test]
+    fn native_skia_keeps_glyph_run_disabled_until_blob_typeface_replay_exists() {
+        let resources = portable_font_resources();
+        let run = portable_glyph_run(GlyphRunOrientation::Horizontal);
+
+        assert!(native_skia_glyph_run_contract_is_replayable(
+            &run, &resources
+        ));
+        assert!(!native_skia_can_replay_glyph_run(&run, &resources));
+    }
+
+    #[test]
+    fn native_skia_rejects_vertical_glyph_run_contract_for_now() {
+        let resources = portable_font_resources();
+        let run = portable_glyph_run(GlyphRunOrientation::VerticalUpright);
+
+        assert!(!native_skia_glyph_run_contract_is_replayable(
+            &run, &resources
+        ));
+        assert!(!native_skia_can_replay_glyph_run(&run, &resources));
     }
 
     fn solid_rect_tree(

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -181,7 +181,8 @@ impl SvgLayerRenderer {
                 RenderNodeType::RawSvg(raw.clone()),
                 *bbox,
             ),
-            PaintOp::CharOverlap { .. }
+            PaintOp::GlyphRun { .. }
+            | PaintOp::CharOverlap { .. }
             | PaintOp::TextControlMark { .. }
             | PaintOp::TabLeader { .. }
             | PaintOp::TextDecoration { .. } => return None,

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -748,6 +748,7 @@ impl WebCanvasRenderer {
                                 if ops.iter().all(|op| matches!(
                                     op,
                                     PaintOp::TextRun { .. }
+                                        | PaintOp::GlyphRun { .. }
                                         | PaintOp::CharOverlap { .. }
                                         | PaintOp::TextControlMark { .. }
                                         | PaintOp::TabLeader { .. }
@@ -878,7 +879,8 @@ impl WebCanvasRenderer {
                             RenderNodeType::RawSvg(raw.clone()),
                             *bbox,
                         ),
-                        PaintOp::CharOverlap { .. }
+                        PaintOp::GlyphRun { .. }
+                        | PaintOp::CharOverlap { .. }
                         | PaintOp::TextControlMark { .. }
                         | PaintOp::TabLeader { .. }
                         | PaintOp::TextDecoration { .. } => continue,


### PR DESCRIPTION
## What

- Text IR v2 위에 optional `GlyphRun` sidecar variant 계약을 추가합니다.
- `fontResources`, font blob, face identity, replay eligibility 타입을 추가해서 glyph replay가 참조할 최소 폰트 메타데이터를 둡니다.
- `TextShapeLowerer`를 추가합니다. 기본 lowering은 기존 `TextRun` fallback을 유지하고, shaping resolver가 export 가능한 glyph data를 줄 때만 `GlyphRun` sidecar를 붙입니다.
- Layer JSON schema/resource table minor를 올립니다. 이번 PR 기준은 schema `1.9`, resource table `1.3`입니다.
- native Skia path는 complete/portable/fill-only glyph variant만 선택하고, 조건이 맞지 않으면 `TextRun` fallback을 사용합니다.
- Canvas2D/layered SVG transition path는 `GlyphRun` sidecar를 건너뛰고 기존 `TextRun` fallback을 유지합니다.
- README와 `docs/text-ir-v2.md`에 P12의 범위와 현재 제한을 정리합니다.

## Non-goals

- 일반 문서 lowering에서 glyph id를 기본 emit하지 않습니다.
- CanvasKit glyph replay는 아직 포함하지 않습니다.
- glyph outline/stroke payload나 variantOps 기반 고급 sidecar 선택은 후속 단계로 둡니다.
- 실제 문서 폰트 blob 추출 및 완전한 resource interning을 끝내는 PR은 아닙니다.

## Compatibility

- 기본 렌더링 경로는 계속 `TextRun` fallback입니다.
- `requiredFeatures`는 비워 두고, `GlyphRun`은 optional sidecar로만 노출합니다.
- 기존 Canvas/SVG consumer는 `GlyphRun`을 무시해도 동일하게 fallback replay를 사용할 수 있습니다.

## Validation

- `cargo test -q paint::`
- `cargo test -q --features native-skia skia --lib`
- `cargo test -q`
