### PR TITLE
Add iOS smoke path for native writer milestones

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -92,5 +92,6 @@ rhwp-safari/HWP Viewer/
 rhwp-safari/.DS_Store
 
 # Xcode 사용자별 설정
+rhwp-ios/DerivedData/
 xcuserdata/
 *.xcuserstate

--- a/Milestone.md
+++ b/Milestone.md
@@ -1,0 +1,143 @@
+# HWP Writer Milestones
+
+Target branch: `ios/devel`
+
+This file tracks the Swift/iOS writer lane. Check an item only when the named
+test, script, or manual gate exists and the result is recorded in the PR.
+
+## Direction
+
+- Primary generation target is `.hwp`, not `.hwpx`.
+- Keep HWPX as an input/conversion reference lane, not the first writer output.
+- Follow TDD: write the failing test or smoke first, make the narrowest change,
+  then refactor only after the proof is green.
+- Treat rhwp self-roundtrip as necessary but insufficient. HWP writer completion
+  needs Hancom 2020 or Hancom 2022 manual-open evidence before claiming
+  compatibility.
+- Keep Swift/iOS work based on `ios/devel`.
+
+## Current Baseline
+
+- [x] Swift native read bindings landed in upstream `devel` and were synced to
+  `ios/devel`.
+- [x] `bindings/swift` exposes `Rhwp.readText(inputFile:page:)` and
+  `RhwpDocumentTextView`.
+- [x] `bindings/swift/Examples/read_text_ffi.swift` documents direct
+  `rhwp_read_text` usage.
+- [x] Rust already has the HWP writer entrypoint:
+  `src/serializer/cfb_writer.rs::serialize_hwp`.
+- [x] WASM already exposes the writer as `HwpDocument.exportHwp()` and
+  verification metadata as `HwpDocument.exportHwpVerify()`.
+- [ ] iOS simulator runtime smoke for the Swift package is recorded.
+- [ ] HWP writer API for Swift/iOS has a byte-returning native ABI.
+
+## Milestone -1: Baseline Inventory
+
+Goal: keep future work grounded in the writer that already exists.
+
+- [x] Record HWP writer entrypoint: `serialize_hwp(doc)`.
+- [x] Record public serializer API: `DocumentSerializer`, `HwpSerializer`,
+  `HwpxSerializer`, `serialize_document(doc)`.
+- [x] Record WASM export API: `exportHwp`, `exportHwpx`, `exportHwpVerify`.
+- [x] Record current iOS gap: Swift bindings read/export text but do not return
+  generated HWP bytes.
+- [ ] Add the first new failing test in the existing writer regression surface,
+  preferably `src/serializer/cfb_writer/tests.rs` or a narrowly scoped
+  integration test under `tests/`.
+
+## Milestone 0: iOS Test App Harness
+
+Goal: prove the Apple lane can run real native rhwp calls on an iOS simulator
+without depending on the production app flow.
+
+- [ ] Add a small iOS smoke target or clearly separated smoke screen under
+  `rhwp-ios`.
+- [ ] Build the native library for Apple Silicon simulator in a script.
+- [ ] Launch the smoke app on an iOS simulator and render the result of
+  `rhwp_read_text` from a bundled sample.
+- [ ] Save the reproduction command in `scripts/`.
+- [ ] Record the simulator, command, and result in the PR body.
+
+Suggested first proof:
+
+```sh
+cargo build --target aarch64-apple-ios-sim --release
+scripts/ios-smoke-read.sh
+```
+
+## Milestone 1: HWP Writer Red Tests
+
+Goal: define the writer contract before adding Swift surface area.
+
+- [ ] Add a Rust test that creates an empty document, exports `.hwp`, reloads it
+  with `HwpDocument::from_bytes`, and asserts page count and stream presence.
+- [ ] Add a Rust test that inserts Korean/English mixed text, exports `.hwp`,
+  reloads it, and asserts extracted text contains the inserted text.
+- [ ] Add stream-level invariants for FileHeader, DocInfo, BodyText/Section0,
+  BinData, and compression behavior where relevant.
+- [ ] Add source-format boundary coverage: HWP source is allowed; HWPX source is
+  blocked or routed only through a full converter milestone.
+- [ ] Add a Native binding test for the missing writer ABI. The first version
+  should fail because the symbol does not exist yet.
+- [ ] Keep the tests focused on `.hwp` bytes and CFB structure, not HWPX ZIP
+  output.
+
+Proposed ABI shape to test first:
+
+```c
+unsigned char *rhwp_write_text_hwp(const char *text, size_t *out_len);
+void rhwp_bytes_free(unsigned char *ptr, size_t len);
+```
+
+## Milestone 2: Minimal HWP Generation
+
+Goal: make the smallest `.hwp` that rhwp can reload and Hancom can open.
+
+- [ ] Implement the native byte-returning writer ABI.
+- [ ] Generate a one-page `.hwp` from plain UTF-8 text.
+- [ ] Return structured errors for null text, invalid UTF-8, and serialization
+  failure.
+- [ ] Verify CFB signature, required streams, and rhwp reload.
+- [ ] Run Hancom manual-open verification before marking compatibility.
+- [ ] Store generated smoke artifacts under a deterministic output folder and
+  reference that path in the PR.
+
+## Milestone 3: Swift Writer API
+
+Goal: make HWP generation natural for Swift callers.
+
+- [ ] Add `Rhwp.writeTextHwp(text:) throws -> Data`.
+- [ ] Add Swift tests that call the native writer and verify the returned data
+  starts with the HWP CFB signature.
+- [ ] Add a Swift test that writes the data to a temporary `.hwp`, then reads it
+  back through `Rhwp.readText`.
+- [ ] Document the API in `bindings/swift/README.md`.
+
+## Milestone 4: Test App Create Flow
+
+Goal: prove the writer is usable from an iOS user flow.
+
+- [ ] Add a smoke UI path that enters text and generates `.hwp` data.
+- [ ] Save or share the generated `.hwp` through the iOS document flow.
+- [ ] Re-open the generated file in the smoke app and display extracted text.
+- [ ] Keep the UX minimal; this is a verification app, not the full editor.
+
+## Milestone 5: Writer Expansion
+
+Goal: expand only after the plain-text path is proven.
+
+- [ ] Paragraph breaks.
+- [ ] Basic page settings.
+- [ ] Character style defaults.
+- [ ] Tables.
+- [ ] Images.
+- [ ] Picture in table.
+- [ ] HWPX-to-HWP conversion, only after the HWP-origin writer path has
+  compatibility evidence.
+
+## Do Not Reopen
+
+- Do not start with HWPX generation for the Swift/iOS writer lane.
+- Do not treat `from_bytes(export_hwp(doc))` as Hancom compatibility proof.
+- Do not use a simple HWPX-to-HWP adapter as the writer foundation.
+- Do not mix production iOS app redesign with writer smoke verification.

--- a/Milestone.md
+++ b/Milestone.md
@@ -3,7 +3,8 @@
 Target branch: `ios/devel`
 
 This file tracks the Swift/iOS writer lane. Check an item only when the named
-test, script, or manual gate exists and the result is recorded in the PR.
+test, script, or manual gate exists and the result is recorded here or in the
+PR.
 
 ## Direction
 
@@ -28,7 +29,8 @@ test, script, or manual gate exists and the result is recorded in the PR.
   `src/serializer/cfb_writer.rs::serialize_hwp`.
 - [x] WASM already exposes the writer as `HwpDocument.exportHwp()` and
   verification metadata as `HwpDocument.exportHwpVerify()`.
-- [ ] iOS simulator runtime smoke for the Swift package is recorded.
+- [x] iOS simulator runtime smoke for the AlHangeul app is reproducible through
+  `scripts/ios-smoke-alhangeul.sh`.
 - [ ] HWP writer API for Swift/iOS has a byte-returning native ABI.
 
 ## Milestone -1: Baseline Inventory
@@ -52,18 +54,24 @@ without depending on the production app flow.
 
 - [ ] Add a small iOS smoke target or clearly separated smoke screen under
   `rhwp-ios`.
-- [ ] Build the native library for Apple Silicon simulator in a script.
-- [ ] Launch the smoke app on an iOS simulator and render the result of
-  `rhwp_read_text` from a bundled sample.
-- [ ] Save the reproduction command in `scripts/`.
+- [x] Build the native library for Apple Silicon simulator in a script.
+- [x] Launch the smoke app on an iOS simulator and render a bundled HWPX sample
+  through the native iOS FFI path.
+- [x] Save the reproduction command in `scripts/`.
 - [ ] Record the simulator, command, and result in the PR body.
 
 Suggested first proof:
 
 ```sh
-cargo build --target aarch64-apple-ios-sim --release
-scripts/ios-smoke-read.sh
+scripts/ios-smoke-alhangeul.sh
 ```
+
+Latest local proof:
+
+- Date: 2026-05-13
+- Simulator: iPhone 17, iOS 26.5 (`566832F4-2C84-4145-8D73-1CEEDA1B9B4E`)
+- Result: `sample.hwpx` bundled, app launched, screenshot showed page `1 / 70`
+  rendered.
 
 ## Milestone 1: HWP Writer Red Tests
 

--- a/rhwp-ios/AlHangeul.xcodeproj/project.pbxproj
+++ b/rhwp-ios/AlHangeul.xcodeproj/project.pbxproj
@@ -121,7 +121,6 @@
 				LastUpgradeCheck = 1600;
 				TargetAttributes = {
 					5D95FFCC81A27C7524AE135E = {
-						DevelopmentTeam = FSFG3AQ4KZ;
 						ProvisioningStyle = Automatic;
 					};
 				};
@@ -241,7 +240,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = FSFG3AQ4KZ;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -254,7 +252,7 @@
 					"-framework Security",
 					"-framework CoreFoundation",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.edwardkim.alhangeul;
+				PRODUCT_BUNDLE_IDENTIFIER = org.rhwp.alhangeul;
 				PRODUCT_NAME = "알한글";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/rhwp-Bridging-Header.h";
@@ -268,7 +266,6 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				CODE_SIGN_IDENTITY = "iPhone Developer";
 				CODE_SIGN_STYLE = Automatic;
-				DEVELOPMENT_TEAM = FSFG3AQ4KZ;
 				INFOPLIST_FILE = Sources/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
@@ -281,7 +278,7 @@
 					"-framework Security",
 					"-framework CoreFoundation",
 				);
-				PRODUCT_BUNDLE_IDENTIFIER = com.edwardkim.alhangeul;
+				PRODUCT_BUNDLE_IDENTIFIER = org.rhwp.alhangeul;
 				PRODUCT_NAME = "알한글";
 				SDKROOT = iphoneos;
 				SWIFT_OBJC_BRIDGING_HEADER = "Sources/rhwp-Bridging-Header.h";

--- a/rhwp-ios/AlHangeul.xcodeproj/project.pbxproj
+++ b/rhwp-ios/AlHangeul.xcodeproj/project.pbxproj
@@ -14,6 +14,7 @@
 		730CE2A5AF99054D86EB9038 /* DocumentViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9C7F329F4166423A625506DD /* DocumentViewModel.swift */; };
 		7F64A3020F384CCB48BBBB0A /* PageCanvasView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 188DE8ED3639F4BF4A1D96DF /* PageCanvasView.swift */; };
 		8D170811EBEFD2866D523A83 /* RhwpDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20AA63FCFF8477F97B2B6910 /* RhwpDocument.swift */; };
+		A1B2C3D4E5F60718293A4B5C /* sample.hwpx in Resources */ = {isa = PBXBuildFile; fileRef = B1C2D3E4F5061728394A5B6C /* sample.hwpx */; };
 		B9648C32D058571321CA8925 /* DocumentPickerView.swift in Sources */ = {isa = PBXBuildFile; fileRef = A7D4F365530B8855C23169F3 /* DocumentPickerView.swift */; };
 		BC339AD1E9DD385231838480 /* CGTreeRenderer.swift in Sources */ = {isa = PBXBuildFile; fileRef = E62AC520236EFEAA4A1092B4 /* CGTreeRenderer.swift */; };
 		DE8D5FE5B009F9EEAF305AD5 /* ContentView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 17058FF4439FDF1A0D106BBA /* ContentView.swift */; };
@@ -34,6 +35,7 @@
 		9C7F329F4166423A625506DD /* DocumentViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentViewModel.swift; sourceTree = "<group>"; };
 		A6C69CA5A7BB9EDAC1ED2BAB /* AlHangeulApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AlHangeulApp.swift; sourceTree = "<group>"; };
 		A7D4F365530B8855C23169F3 /* DocumentPickerView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentPickerView.swift; sourceTree = "<group>"; };
+		B1C2D3E4F5061728394A5B6C /* sample.hwpx */ = {isa = PBXFileReference; lastKnownFileType = file; path = sample.hwpx; sourceTree = "<group>"; };
 		BA525A506B67F9EA884FCB4A /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		C8A2986666EFCD03085A7319 /* rhwp.h */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.c.h; path = rhwp.h; sourceTree = "<group>"; };
 		E62AC520236EFEAA4A1092B4 /* CGTreeRenderer.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CGTreeRenderer.swift; sourceTree = "<group>"; };
@@ -53,9 +55,18 @@
 			isa = PBXGroup;
 			children = (
 				16430382271CB022467AF399 /* Assets.xcassets */,
+				C1D2E3F40516273849A5B6C7 /* Resources */,
 				F3A87CD73C5FF6A801D3A86D /* Sources */,
 				B80BBC760C44B9077204BF0E /* Products */,
 			);
+			sourceTree = "<group>";
+		};
+		C1D2E3F40516273849A5B6C7 /* Resources */ = {
+			isa = PBXGroup;
+			children = (
+				B1C2D3E4F5061728394A5B6C /* sample.hwpx */,
+			);
+			path = Resources;
 			sourceTree = "<group>";
 		};
 		F3A87CD73C5FF6A801D3A86D /* Sources */ = {
@@ -140,6 +151,7 @@
 			buildActionMask = 2147483647;
 			files = (
 				260F88D2594A6CDE2983B5B7 /* Assets.xcassets in Resources */,
+				A1B2C3D4E5F60718293A4B5C /* sample.hwpx in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/rhwp-ios/Sources/Info.plist
+++ b/rhwp-ios/Sources/Info.plist
@@ -22,6 +22,8 @@
     <string>1</string>
     <key>LSRequiresIPhoneOS</key>
     <true/>
+    <key>LSSupportsOpeningDocumentsInPlace</key>
+    <true/>
     <key>UILaunchScreen</key>
     <dict/>
     <key>UIRequiredDeviceCapabilities</key>

--- a/rhwp-ios/project.yml
+++ b/rhwp-ios/project.yml
@@ -1,6 +1,6 @@
 name: AlHangeul
 options:
-  bundleIdPrefix: com.edwardkim
+  bundleIdPrefix: org.rhwp
   deploymentTarget:
     iOS: "16.0"
   xcodeVersion: "16.0"
@@ -17,7 +17,7 @@ targets:
         buildPhase: resources
     settings:
       base:
-        PRODUCT_BUNDLE_IDENTIFIER: com.edwardkim.alhangeul
+        PRODUCT_BUNDLE_IDENTIFIER: org.rhwp.alhangeul
         PRODUCT_NAME: 알한글
         INFOPLIST_FILE: Sources/Info.plist
         SWIFT_OBJC_BRIDGING_HEADER: Sources/rhwp-Bridging-Header.h
@@ -25,7 +25,6 @@ targets:
           - "-lrhwp"
           - "-framework Security"
           - "-framework CoreFoundation"
-        DEVELOPMENT_TEAM: "FSFG3AQ4KZ"
         ASSETCATALOG_COMPILER_APPICON_NAME: "AppIcon"
         CODE_SIGN_STYLE: "Automatic"
       configs:

--- a/scripts/ios-smoke-alhangeul.sh
+++ b/scripts/ios-smoke-alhangeul.sh
@@ -5,7 +5,7 @@ ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
 PROJECT_PATH="$ROOT_DIR/rhwp-ios/AlHangeul.xcodeproj"
 DERIVED_DATA="$ROOT_DIR/rhwp-ios/DerivedData"
 APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphonesimulator/알한글.app"
-BUNDLE_ID="com.edwardkim.alhangeul"
+BUNDLE_ID="org.rhwp.alhangeul"
 SCREENSHOT_PATH="$ROOT_DIR/output/ios-smoke/alhangeul-sample.png"
 
 find_simulator_id() {

--- a/scripts/ios-smoke-alhangeul.sh
+++ b/scripts/ios-smoke-alhangeul.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+PROJECT_PATH="$ROOT_DIR/rhwp-ios/AlHangeul.xcodeproj"
+DERIVED_DATA="$ROOT_DIR/rhwp-ios/DerivedData"
+APP_PATH="$DERIVED_DATA/Build/Products/Debug-iphonesimulator/알한글.app"
+BUNDLE_ID="com.edwardkim.alhangeul"
+SCREENSHOT_PATH="$ROOT_DIR/output/ios-smoke/alhangeul-sample.png"
+
+find_simulator_id() {
+  if [[ -n "${RHWP_IOS_SIMULATOR_ID:-}" ]]; then
+    printf '%s\n' "$RHWP_IOS_SIMULATOR_ID"
+    return
+  fi
+
+  local booted
+  booted="$(xcrun simctl list devices available \
+    | sed -nE 's/^[[:space:]]*iPhone 17 \(([0-9A-F-]+)\) \(Booted\)[[:space:]]*$/\1/p' \
+    | head -n 1)"
+  if [[ -n "$booted" ]]; then
+    printf '%s\n' "$booted"
+    return
+  fi
+
+  xcrun simctl list devices available \
+    | sed -nE 's/^[[:space:]]*iPhone 17 \(([0-9A-F-]+)\).*$/\1/p' \
+    | head -n 1
+}
+
+SIMULATOR_ID="$(find_simulator_id)"
+if [[ -z "$SIMULATOR_ID" ]]; then
+  echo "ERROR: no available iPhone 17 simulator found. Set RHWP_IOS_SIMULATOR_ID." >&2
+  exit 1
+fi
+
+cd "$ROOT_DIR"
+
+echo "==> Building Rust static library for iOS simulator"
+cargo build --target aarch64-apple-ios-sim --release
+
+echo "==> Building AlHangeul for simulator $SIMULATOR_ID"
+xcodebuild \
+  -project "$PROJECT_PATH" \
+  -scheme AlHangeul \
+  -configuration Debug \
+  -derivedDataPath "$DERIVED_DATA" \
+  -destination "id=$SIMULATOR_ID" \
+  build
+
+if [[ ! -f "$APP_PATH/sample.hwpx" ]]; then
+  echo "ERROR: sample.hwpx was not copied into $APP_PATH" >&2
+  exit 1
+fi
+
+echo "==> Booting, installing, and launching AlHangeul"
+xcrun simctl boot "$SIMULATOR_ID" >/dev/null 2>&1 || true
+xcrun simctl install "$SIMULATOR_ID" "$APP_PATH"
+xcrun simctl launch "$SIMULATOR_ID" "$BUNDLE_ID"
+
+mkdir -p "$(dirname "$SCREENSHOT_PATH")"
+sleep "${RHWP_IOS_SMOKE_SCREENSHOT_DELAY:-2}"
+xcrun simctl io "$SIMULATOR_ID" screenshot "$SCREENSHOT_PATH" >/dev/null
+
+echo "OK: AlHangeul launched with bundled sample.hwpx"
+echo "Screenshot: $SCREENSHOT_PATH"


### PR DESCRIPTION
## Summary
- add `Milestone.md` for the `.hwp` writer rollout, TDD checkpoints, and Hancom compatibility gates
- make the AlHangeul iOS sample smoke reproducible by bundling `sample.hwpx` and adding `scripts/ios-smoke-alhangeul.sh`
- remove fixed signing identity values from the iOS sample app and use the neutral `org.rhwp.alhangeul` bundle id

## Verification
- `git diff --check`
- `cargo test --lib test_export_hwp_empty`
- `cargo build --manifest-path bindings/Native/Cargo.toml`
- `swift test -Xlinker -L../../bindings/Native/target/debug`
- `cargo build --manifest-path bindings/Native/Cargo.toml --release`
- `swift bindings/swift/Examples/read_text_ffi.swift`
- `cargo build --target aarch64-apple-ios-sim --release`
- `RHWP_IOS_SIMULATOR_ID=... scripts/ios-smoke-alhangeul.sh`
- simulator screenshot showed `sample.hwpx` page `1 / 70` rendered
- manual simulator swipe advanced the document from page `2 / 70` to `7 / 70`

## Notes
- Writer implementation is intentionally not included in this PR; the next PR should start with writer red tests.
- Hancom 2020/2022 manual-open verification is not covered here.
