### PR TITLE
Task #900: 수식 Canvas/WASM 렌더 + tab 정합 (closes #900)

### DIFF
--- a/src/renderer/equation/canvas_render.rs
+++ b/src/renderer/equation/canvas_render.rs
@@ -42,7 +42,10 @@ fn render_box(
             }
         }
         LayoutKind::Text(text) => {
-            let fi = font_size_from_box(lb, fs);
+            // [Issue #900] SVG 경로 (svg_render.rs:43, commit 5a6f9a87 / Task #142) 와
+            // 동기화 — font_size_from_box(lb.height) 는 복합 박스 (Limit, BigOp 등)
+            // 의 전체 높이를 font-size 로 오용. 부모 전달 fs 사용.
+            let fi = fs;
             // CJK 문자는 italic 미적용. FontStyle::Roman(`rm`)으로 italic=false 가
             // 전달된 경우에도 italic 미적용 (svg_render.rs Text arm 과 동일 정책).
             let has_cjk = text.chars().any(|c| matches!(c,
@@ -53,13 +56,15 @@ fn render_box(
             let _ = ctx.fill_text(text, x, y + lb.baseline);
         }
         LayoutKind::Number(text) => {
-            let fi = font_size_from_box(lb, fs);
+            // [Issue #900] svg_render.rs Number arm 과 동기화 — fs 사용.
+            let fi = fs;
             set_font(ctx, fi, false, bold);
             ctx.set_fill_style_str(color);
             let _ = ctx.fill_text(text, x, y + lb.baseline);
         }
         LayoutKind::Symbol(text) => {
-            let fi = font_size_from_box(lb, fs);
+            // [Issue #900] svg_render.rs Symbol arm 과 동기화 — fs 사용.
+            let fi = fs;
             set_font(ctx, fi, false, false);
             ctx.set_fill_style_str(color);
             ctx.set_text_align("center");
@@ -67,13 +72,17 @@ fn render_box(
             ctx.set_text_align("start");
         }
         LayoutKind::MathSymbol(text) => {
-            let fi = font_size_from_box(lb, fs);
+            // [Issue #900] svg_render.rs MathSymbol arm 과 동기화 (commit 292dbbef).
+            // 적분 기호는 layout 에서 BIG_OP_SCALE 적용된 lb.height 를 font-size 로 사용,
+            // 그 외 MathSymbol 은 부모 전달 fs.
+            let fi = if super::layout::is_integral_symbol(text) { lb.height } else { fs };
             set_font(ctx, fi, false, false);
             ctx.set_fill_style_str(color);
             let _ = ctx.fill_text(text, x, y + lb.baseline);
         }
         LayoutKind::Function(name) => {
-            let fi = font_size_from_box(lb, fs);
+            // [Issue #900] svg_render.rs Function arm 과 동기화 — fs 사용.
+            let fi = fs;
             set_font(ctx, fi, false, false);
             ctx.set_fill_style_str(color);
             let _ = ctx.fill_text(name, x, y + lb.baseline);
@@ -136,13 +145,24 @@ fn render_box(
             render_box(ctx, sup, x, y, color, fs * SCRIPT_SCALE, italic, bold);
         }
         LayoutKind::BigOp { symbol, sub, sup } => {
+            // [Issue #900] svg_render.rs BigOp arm 과 동기화 (commit 292dbbef).
+            // 적분 (∫, ∮ 등): 기호 좌측, 첨자 우상단/우하단 (nolimits)
+            // 그 외 (∑, ∏ 등): 기호 중앙, 첨자 위/아래 (limits)
             let op_fs = fs * BIG_OP_SCALE;
-            let sup_h = sup.as_ref().map(|b| b.height + fs * 0.05).unwrap_or(0.0);
-            let op_x = x + (lb.width - estimate_op_width(symbol, op_fs)) / 2.0;
-            let op_y = y + sup_h + op_fs * 0.8;
+            let is_integral = super::layout::is_integral_symbol(symbol);
             set_font(ctx, op_fs, false, false);
             ctx.set_fill_style_str(color);
-            let _ = ctx.fill_text(symbol, op_x, op_y);
+            if is_integral {
+                let op_x = x;
+                let op_y = y + op_fs * 0.8;
+                let _ = ctx.fill_text(symbol, op_x, op_y);
+            } else {
+                let sup_h = sup.as_ref().map(|b| b.height + fs * 0.05).unwrap_or(0.0);
+                let op_x = x + (lb.width - estimate_op_width(symbol, op_fs)) / 2.0;
+                let op_y = y + sup_h + op_fs * 0.8;
+                let _ = ctx.fill_text(symbol, op_x, op_y);
+            }
+            // 위/아래 첨자 — LayoutBox 자식 좌표 사용 (적분/일반 공통)
             if let Some(sup_box) = sup {
                 render_box(ctx, sup_box, x, y, color, fs * SCRIPT_SCALE, false, false);
             }
@@ -236,10 +256,6 @@ fn render_box(
         }
         LayoutKind::Space(_) | LayoutKind::Newline | LayoutKind::Empty => {}
     }
-}
-
-fn font_size_from_box(lb: &LayoutBox, base_fs: f64) -> f64 {
-    if lb.height > 0.0 { lb.height } else { base_fs }
 }
 
 fn estimate_op_width(text: &str, fs: f64) -> f64 {

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -739,9 +739,16 @@ impl TextMeasurer for WasmTextMeasurer {
                     let tab_target = total + tab_width_px;
                     // [Task #874] auto_tab_right paragraph + 단일 tab: native 와 동일.
                     let has_more_tabs_after = chars[i+1..].iter().any(|c| *c == '\t');
+                    // [Issue #900] Task #874 #10 와 동일 — ext[2] high-byte 가 명시적
+                    // LEFT(1)/DECIMAL(4) 면 auto_tab_right paragraph 라도 override 금지.
+                    // exam_math.hwp pi=0 ("1.\t의 값은? [2점]") 의 inline LEFT tab 이
+                    // WASM 에서 right-align 되어 equation/text 가 column 우측으로 밀리는
+                    // 회귀 차단. EmbeddedTextMeasurer (native) 는 이미 가드 적용.
+                    let inline_is_explicit_left = tab_type == 1 || tab_type == 4;
                     let override_to_right = style.auto_tab_right
                         && !has_more_tabs_after
-                        && style.available_width > 0.0;
+                        && style.available_width > 0.0
+                        && !inline_is_explicit_left;
                     if override_to_right {
                         // [Task #874 #2] lang split 후속 run 합산 override (native 와 동일).
                         let seg_w = style.right_tab_block_width_override
@@ -881,9 +888,15 @@ impl TextMeasurer for WasmTextMeasurer {
                     let tab_target = x + tab_width_px;
                     // [Task #874] auto_tab_right paragraph + 단일 tab: native 와 동일.
                     let has_more_tabs_after = chars[i+1..].iter().any(|c| *c == '\t');
+                    // [Issue #900] Task #874 #10 와 동일 가드 — 인라인 LEFT(1)/DECIMAL(4)
+                    // 탭은 auto_tab_right 라도 right-align 금지. estimate_text_width 와
+                    // 동일 처리 — pi=0 의 tab 위치 정합 (equation/text 가 column 우측으로
+                    // 밀리는 회귀 차단).
+                    let inline_is_explicit_left = tab_type == 1 || tab_type == 4;
                     let override_to_right = style.auto_tab_right
                         && !has_more_tabs_after
-                        && style.available_width > 0.0;
+                        && style.available_width > 0.0
+                        && !inline_is_explicit_left;
                     // [Issue #630 Stage 6] RIGHT + leader (fill ≠ 0): ')' 끝이 본문
                     // 우측 끝까지 정렬.
                     let body_right_text_rel = if style.available_width > 0.0 {


### PR DESCRIPTION
## Summary
- `canvas_render.rs`: SVG 경로 정정 2건 (font_size_from_box 제거, 적분 nolimits) 동기화
- `WasmTextMeasurer`: inline_is_explicit_left 가드 (Task #874 #10) 동기화

## 현상
rhwp-studio (WASM Canvas 경로) 에서 `samples/exam_math.hwp` 가 한컴 2022 PDF
(`samples/exam_math.pdf`) 와 불일치. CLI `export-svg` 는 정상.

- 수식 글리프가 비정상 크게 렌더 (font_size_from_box → lb.height 오용)
- 적분 기호 + 첨자 배치가 limits (중앙) 로 잘못 처리 (PDF 는 nolimits 좌측)
- pi=0 ("1.\t의 값은? [2점]") 의 inline LEFT tab 이 auto_tab_right paragraph
  에서 right-align 되어 equation/text 가 column 우측으로 밀림

## 원인
1. SVG 경로 (`svg_render.rs`) 정정 PR 2건이 Canvas 경로 (`canvas_render.rs`) 미반영:
   - commit 5a6f9a87 (Task #142): font_size_from_box 제거
   - commit 292dbbef (Task #142): 적분 nolimits 재구현
2. Task #874 #10 의 `inline_is_explicit_left` 가드가 EmbeddedTextMeasurer (native)
   에만 적용되고 WasmTextMeasurer (WASM) 에 누락 — 인라인 LEFT(1)/DECIMAL(4)
   탭이 auto_tab_right paragraph 에서 잘못 right-align.

## 변경 영역
| 파일 | 변경 |
|------|------|
| `equation/canvas_render.rs` | 5개 arm (Text/Number/Symbol/MathSymbol/Function) 의 `font_size_from_box(lb, fs)` → `fs` 교체 / MathSymbol 적분 시 `lb.height` 유지 / BigOp `is_integral_symbol` 분기 추가 (적분 좌측 nolimits, 그 외 중앙 limits) / 미사용 `font_size_from_box` 함수 제거 |
| `layout/text_measurement.rs` | WasmTextMeasurer 의 `estimate_text_width` / `compute_char_positions` inline_tabs 분기에 `inline_is_explicit_left` 가드 추가 (Task #874 #10 동기화) |

두 변경 모두 SVG / EmbeddedTextMeasurer (native) 와 1:1 동기화 — 새로운 동작 도입 없음.

## Test plan
- [x] cargo build --release
- [x] cargo test --release --lib (1257 pass / 0 fail / 2 ignored)
- [x] WASM canvas (exam_math 페이지 1) PDF 정합 시각 확인
- [x] 위치 검증: equation "3" x 394→96, "의" x 456→158 (SVG 정합)

closes #900