### PR TITLE
Task #898: exam_math.hwp 바탕쪽 표 outer_margin_top 미적용 정정

### DIFF
--- a/mydocs/plans/task_m100_898.md
+++ b/mydocs/plans/task_m100_898.md
@@ -1,0 +1,67 @@
+# 수행계획서: Task #898
+
+`exam_math.hwp` 페이지 1 단 구분선이 바탕쪽 쪽번호 박스까지 길어져 PDF(한컴 2022) 와 시각 차이가 발생하는 문제를 수정한다.
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/898
+- 마일스톤: v1.0.0 (M100)
+- 브랜치: `local/task898` (← `local/devel`)
+
+## 1. 현상 요약
+
+페이지 1 (2단 레이아웃) 가운데 단 구분선이 본문 영역 바닥(`y≈1358`)까지 그어져 바탕쪽(MasterPage) 쪽번호 박스(`1/20`, `y=1359~1388`) 와 약 1px 간격으로 거의 붙어 보임.
+
+한컴 2022 PDF(`pdf/exam_math-2022.pdf`)는 단 구분선과 쪽번호 박스 사이에 명확한 여백(약 30mm) 이 있음.
+
+## 2. 측정 데이터
+
+| 항목 | SVG 출력 | HWP 좌표 |
+|------|----------|----------|
+| 페이지 크기 | 1028 × 1489 px | 272×394mm (77102×111685 HU) |
+| 본문 영역(body) | x=71.4 y=147.4 w=884.4 h=1213.3 | top=39mm, bottom=360mm |
+| 단 구분선 | x=515.4, y=224.6 → y=1358.4 | (column_area 전 구간) |
+| 바탕쪽 쪽번호 표 | y=1359.4 ~ 1388.7 (3개 셀) | vert=Paper/101954 (≈359.5mm) |
+
+바탕쪽 표는 `vert=Paper/101954 HU` 로 종이 기준 절대 위치(본문 바닥 부근) 에 배치되어 있음. 본문 영역 바닥(360mm) 보다 0.5mm 위쪽에 표 상단이 위치 — 본문 영역 안쪽 끝선과 맞닿음.
+
+## 3. 원인 가설
+
+`src/renderer/layout.rs:1100 build_column_separators` 는 `column_area.y` ~ `column_area.y + column_area.height` 전 구간에 구분선을 그림. 즉 본문 영역 바닥까지 항상 연장.
+
+한컴은 바탕쪽 객체(특히 종이 기준 절대 위치로 본문 하단을 덮는 표/도형) 의 상단 또는 그 위쪽 일정 여백 지점에서 구분선을 잘라내는 것으로 보임. 후보:
+
+- (A) **바탕쪽 객체 침범 차단** — 본문 영역 안쪽에 침범하거나 인접한 바탕쪽 객체(`vert=Paper`) 가 있으면 그 객체 상단보다 위에서 구분선을 멈춤.
+- (B) **단정의 추가 필드** — HWP5 `cold` 컨트롤(단정의) 에 separator_type/width/color 이후 미파싱 바이트가 존재할 수 있고, 그 안에 separator 길이/여백 정보가 있을 가능성.
+- (C) **하단 고정 여백** — 한컴 내부 규칙으로 본문 바닥에서 일정 여백(예: 꼬리말 여백 25mm) 만큼 들여 끝을 자르는 단순 규칙.
+
+조사 결과 (C) 는 30mm 가량의 PDF 여백을 설명할 수 있고, (A) 는 본문에 침범한 바탕쪽 객체가 있는 페이지에서만 동작. (B) 는 검증 필요.
+
+구현 계획서 단계에서 (B) → (A) → (C) 순으로 검증 후 단순/안전한 규칙을 채택한다.
+
+## 4. 작업 범위
+
+수정 대상 파일 (예상):
+- `src/parser/body_text.rs` `parse_column_def_ctrl` — 단정의 잔여 바이트 분석 / 추가 필드 파싱 (필요 시)
+- `src/model/page.rs` `ColumnDef` — 새 필드 추가 (필요 시)
+- `src/renderer/page_layout.rs` `PageLayoutInfo` — separator 정지 y 전달 (필요 시)
+- `src/renderer/layout.rs` `build_column_separators` — 정지 위치 계산 로직
+
+추가 영향:
+- `src/main.rs` dump 출력 갱신 (단정의 새 필드)
+- 골든 SVG 회귀 — `exam_math.hwp` 외 2단/3단 문서들 (`shortcut.hwp`, `aift.hwp` 등) 의 SVG 변경 검토
+
+## 5. 검증 방안
+
+- `samples/exam_math.hwp` 전 20페이지 SVG ↔ `pdf/exam_math-2022.pdf` 시각 비교
+- `samples/aift.hwp` (2단), `samples/shortcut.hwp` (다단 zone) 회귀 — 단 구분선 길이가 PDF와 합치하는지
+- `cargo test` 전체 통과
+- `cargo clippy --all-targets -- -D warnings` 통과
+
+## 6. 산출물
+
+- 구현 계획서: `mydocs/plans/task_m100_898_impl.md` (3~6 단계)
+- 단계별 보고서: `mydocs/working/task_m100_898_stage{N}.md`
+- 최종 보고서: `mydocs/report/task_m100_898_report.md`
+
+## 7. 승인 요청
+
+본 수행계획에 대한 작업지시자의 승인을 요청합니다. 승인 후 구현 계획서 작성으로 진행합니다.

--- a/mydocs/plans/task_m100_898_impl.md
+++ b/mydocs/plans/task_m100_898_impl.md
@@ -1,0 +1,93 @@
+# 구현 계획서: Task #898
+
+수행계획서: [`task_m100_898.md`](task_m100_898.md)
+브랜치: `local/task898`
+
+## 0. 원인 분석 재확인 (수행계획 단계 추가 조사 결과)
+
+수행계획서 단계의 가설 (단정의 separator 추가 필드 / 단 구분선 정지 위치) 은 **틀렸음** 을 확인.
+
+- `parse_column_def_ctrl` 잔여 바이트 분석: `cold` ctrl_data 12바이트 전부 파싱됨 (`08 10 f4 0c 00 00 00 00 00 00 00 00`). `separator_type=0` → **단 구분선 없음**.
+- 가운데 세로 선은 단 구분선이 아니라 **문서 본문 0.0 컨트롤 [5] 직선 Shape**.
+  - 크기: `0×85039 HU` (≈0×300mm), 선 굵기 100 HU
+  - 위치: 가로 = `용지/Center +105 HU` (≈가로 중앙), 세로 = `용지/Top +16842 HU` (≈59.4mm)
+  - 렌더 범위 y=224.6 ~ 1358.4 → 페이지 비율 15.1% ~ 91.2%
+- 쪽번호 박스는 **바탕쪽(MasterPage) 표 1×3**:
+  - 위치: `vert=Paper/101954 HU` (≈359.55mm), `horz=Paper/85 HU` (≈Center)
+  - 크기: `58408×2196 HU` (≈205.4×7.7mm)
+  - 렌더 범위 y=1359.4 ~ 1388.7 → 페이지 비율 91.3% ~ 93.3%
+
+PDF (한컴 2022, A3 1169×1653 px 렌더) 측정:
+- 직선 끝 y=1509 (91.3%) — **우리 렌더와 거의 일치**
+- 쪽번호 박스 상단 y=1530 (92.6%) — **우리 렌더(91.3%)보다 ≈1.3%(≈21px=5.3mm) 낮음**
+
+**결론**: 단 구분선 / 직선 길이 문제가 아니라, **바탕쪽 쪽번호 표의 Y 위치가 약 5mm 위쪽으로 잘못 배치** 되어 직선 끝과 시각적으로 붙는 것이 원인.
+
+## 1. 수정 대상 (예상)
+
+- `src/renderer/layout.rs` `build_master_page` — 바탕쪽 표 컨트롤 배치 시 `Paper`/`vert` 좌표 해석
+- `src/renderer/layout/shape_layout.rs` `compute_table_y_position` 또는 `compute_object_position` — Paper 기준 Y 좌표 + outer_margin / 크기 / VerticalAlign 처리
+- 가설 후보:
+  - (a) **outer_margin_top 미적용** — 표의 outer_margin_top 만큼 아래로 추가 이동해야 하는데 빠뜨림
+  - (b) **vert offset 해석 오류** — `Paper/101954` 가 표 상단이 아니라 표 베이스라인/하단 기준일 가능성
+  - (c) **이중 바탕쪽 합산** — 바탕쪽이 2개(`[0]`, `[1]`) 모두 그려지지만 둘 다 동일 좌표 → 동일 표 2회 겹쳐 그림. 위치 차이는 없으나 검증 필요
+  - (d) **MasterPage paper_area 좌표계 오프셋** — `paper_area.y = 0` 기준 vert offset 합산 시 부정확
+
+## 2. 단계 분할 (4단계)
+
+### Stage 1 — 정밀 원인 규명 + 단위 테스트 추가
+
+목표: 바탕쪽 표의 실제 SVG y 좌표가 어떤 계산식으로 산출되는지 추적하고, HWP/HWPX 스펙 및 한컴 동작과 합치하는 기대값 도출.
+
+작업:
+1. `src/renderer/layout.rs` `build_master_page` 에서 표 컨트롤 처리 경로 (`Control::Table → layout_table`) 추적
+2. `compute_table_y_position` 동작 분석 — `vert_rel_to=Paper`, `vertical_offset=101954`, outer_margin_top 의 합산식 확인
+3. 비교 자료:
+   - HWP5 스펙 (hwp5 control common 부분) outer_margin 적용 규칙
+   - HWPX 동등 문서가 있다면 대조 (현재 `samples/` 에 `exam_math.hwpx` 없음 — 한컴에서 추출하거나 수동 변환 필요 시 도움 요청)
+4. 단위 테스트 신설: `tests/master_page_table_position.rs` 또는 기존 `src/renderer/page_layout.rs` 테스트 확장 — `Paper` 기준 + outer_margin 케이스 명시
+
+산출물: `mydocs/working/task_m100_898_stage1.md` (원인 결론 + 기대 좌표 산출식)
+
+### Stage 2 — 수정 구현
+
+목표: Stage 1 에서 확정된 좌표 산출식으로 바탕쪽 표 Y 배치 로직 수정.
+
+작업:
+1. 해당 함수(`compute_object_position` 또는 `build_master_page` 분기) 수정
+2. 변경 영향이 본문 표/그림 배치에 미치지 않도록 분리 — 바탕쪽 컨텍스트 전용 분기 또는 outer_margin 적용 누락 보강
+3. Stage 1 단위 테스트 통과 확인
+
+산출물: `mydocs/working/task_m100_898_stage2.md` (수정 diff + 테스트 결과)
+
+### Stage 3 — 시각 회귀 검증
+
+목표: `exam_math.hwp` 전 20페이지 SVG ↔ PDF 시각 비교 + 관련 문서 회귀 확인.
+
+작업:
+1. `rhwp export-svg samples/exam_math.hwp -o output/svg/exam_math/` 재생성
+2. `rsvg-convert` + `pdftoppm` 으로 각 페이지 비교 (Python 스크립트로 vertical line / pagenum box y 좌표 측정)
+3. `aift.hwp`, `shortcut.hwp`, `exam_math_8.hwp`, `exam_math_no.hwp` 회귀 검토
+4. 골든 SVG (있다면) 갱신 — Issue #267/#617/#677 케이스 등
+
+산출물: `mydocs/working/task_m100_898_stage3.md` (페이지별 측정 표, 회귀 결과)
+
+### Stage 4 — 최종 마무리
+
+작업:
+1. `cargo test`, `cargo clippy --all-targets -- -D warnings` 통과
+2. 골든 SVG 갱신 커밋 (필요 시)
+3. 최종 결과보고서: `mydocs/report/task_m100_898_report.md`
+4. 오늘할일(`mydocs/orders/`) 갱신 — **Orders 변경 금지** 메모리 룰에 따라 작업지시자 지시 확인 후만
+
+산출물: `mydocs/report/task_m100_898_report.md`
+
+## 3. 위험 / 주의 사항
+
+- 바탕쪽 표 위치 수정이 **모든 문서의 머리말/꼬리말 영역 객체 위치에 영향**을 줄 수 있음. Stage 3 회귀 범위를 충분히 확보해야 함.
+- 가설 (b) `vert offset 이 표 baseline 기준` 이 맞다면 **모든 Paper 기준 객체** 의 Y 계산을 일괄 수정해야 함 → 영향 범위 큼. 이 경우 Stage 2 직전에 작업지시자에게 추가 승인 요청.
+- 가설 (a) outer_margin_top 미적용만 해결하면 영향 범위 작음 — 우선 검증.
+
+## 4. 승인 요청
+
+본 구현 계획에 대한 작업지시자의 승인을 요청합니다. 승인 후 Stage 1 부터 진행합니다.

--- a/mydocs/report/task_m100_898_report.md
+++ b/mydocs/report/task_m100_898_report.md
@@ -1,0 +1,84 @@
+# 최종 결과 보고서: Task #898
+
+`exam_math.hwp` 가운데 세로선 (직선 Shape) 끝과 바탕쪽 쪽번호 박스가 시각적으로 붙어 PDF (한컴 2022) 와 차이를 보이는 결함 수정.
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/898
+- 마일스톤: v1.0.0 (M100)
+- 브랜치: `local/task898` (← `devel`)
+- 수행계획: [`mydocs/plans/task_m100_898.md`](../plans/task_m100_898.md)
+- 구현계획: [`mydocs/plans/task_m100_898_impl.md`](../plans/task_m100_898_impl.md)
+
+## 1. 결함 요약
+
+`samples/exam_math.hwp` 페이지 1 (및 전 페이지):
+- 본문 문단 0 직선 Shape (0×300mm, 페이지 중앙) 끝 y ≈ 1358 px
+- 바탕쪽 표 1×3 쪽번호 박스 (`1/20`) 상단 y ≈ 1359 px
+- 두 객체 사이 간격 약 1 px — PDF(약 20 px) 와 차이 → 시각적으로 붙음
+
+## 2. 원인 (Stage 1)
+
+`src/renderer/layout/table_layout.rs::compute_table_y_position` 의 **Paper-relative + depth=0 + wrap=TopAndBottom/BehindText/InFrontOfText** 분기에서 `outer_margin_top` 이 산식에 누락.
+
+기존: `raw_y = v_offset` (≈ 1359.39 px)
+한컴: `raw_y = v_offset + outer_margin_top` (≈ 1378.28 px)
+
+바탕쪽 표 데이터 (exam_math.hwp 1×3 표):
+- `vertical_offset` = 101954 HU = 359.55 mm
+- `outer_margin_top` = **1417 HU = 5.00 mm**
+- 기대 표 상단 = 364.55 mm = 1378.28 px ↔ PDF 측정 1378.1 px (0.18 px 오차)
+
+## 3. 수정 (Stage 2)
+
+`src/renderer/layout/table_layout.rs:1200~1205`:
+
+```rust
+let om_top_px = if matches!(vert_rel_to, VertRelTo::Paper) {
+    hwpunit_to_px(table.outer_margin_top as i32, self.dpi)
+} else { 0.0 };
+let om_bottom_px = if matches!(vert_rel_to, VertRelTo::Paper) {
+    hwpunit_to_px(table.outer_margin_bottom as i32, self.dpi)
+} else { 0.0 };
+let raw_y = match vert_align {
+    Top | Inside  => ref_y + v_offset + caption_top_offset + om_top_px,
+    Center        => ref_y + (ref_h - table_height) / 2.0 + v_offset + caption_top_offset,
+    Bottom|Outside => ref_y + ref_h - table_height - v_offset + caption_top_offset - om_bottom_px,
+};
+```
+
+영향 범위 한정: `vert_rel_to == Paper` 만 적용. Page/Para 기준 표는 변화 없음.
+
+## 4. 검증 (Stage 3)
+
+### 단위 테스트
+- 신규 `tests/issue_898.rs::master_page_table_includes_outer_margin_top` 추가 — 회귀 가드
+- 전체 `cargo test --release`: **1412 passed, 0 failed**
+
+### Lint
+- `cargo clippy --release --lib -- -D warnings`: **clean**
+
+### 시각 회귀
+- exam_math.hwp 20쪽: 전 페이지 표 셀 y=1378.28 일관성 ✓
+- exam_kor/eng/social/science, shortcut, KTX: 오류 없음, 시각 정상
+- 골든 SVG snapshot 8건 (issue_617 exam_kor 포함): 변화 없음 ✓
+
+### 시각 확인 (페이지 1 + 5)
+가운데 세로선과 쪽번호 박스 사이 명확한 여백 확보 — PDF (한컴 2022) 와 시각 일치.
+
+## 5. 변경 파일
+
+- `src/renderer/layout/table_layout.rs` — Paper-relative `outer_margin_top/bottom` 적용
+- `tests/issue_898.rs` — 신규 회귀 가드 테스트
+- `mydocs/plans/task_m100_898.md` — 수행계획서
+- `mydocs/plans/task_m100_898_impl.md` — 구현계획서
+- `mydocs/working/task_m100_898_stage{1,2,3}.md` — 단계별 보고서
+- `mydocs/report/task_m100_898_report.md` — 최종 보고서
+
+## 6. 회귀 차단
+
+- `tests/issue_898.rs` 회귀 가드 — y=1359.x 위치로 되돌아가면 테스트 실패
+- 골든 SVG snapshot 8건 유지
+
+## 7. 결론
+
+Issue #898 사용자 보고 결함 해결. 한컴 PDF 와 시각 정합 (0.18 px 오차).
+회귀 0건, 영향 범위 Paper-relative 표로 한정.

--- a/mydocs/working/task_m100_898_stage1.md
+++ b/mydocs/working/task_m100_898_stage1.md
@@ -1,0 +1,81 @@
+# Stage 1 보고서: Task #898 — 원인 정밀 규명
+
+## 1. 좌표 산출식 추적
+
+`src/renderer/layout/table_layout.rs::compute_table_y_position` (1152~1241행) 분석 결과:
+
+```
+[Paper-relative, depth=0, wrap=TopAndBottom 분기 (1180~1188행)]
+  ref_y = 0.0
+  ref_h = page_h_approx
+  vert_align = Top → raw_y = ref_y + v_offset + caption_top_offset
+  ⇒ raw_y = v_offset
+```
+
+**`outer_margin_top` 가 산식에 포함되지 않음.** (depth>0 중첩 표 분기에서만 적용)
+
+## 2. 측정값 검증
+
+`samples/exam_math.hwp` 페이지 1 바탕쪽 표 (1×3 쪽번호 박스):
+
+| 값 | HU | px(96dpi) |
+|----|-----|-----------|
+| `vert_rel_to` | Paper | — |
+| `vertical_offset` | 101954 | 1359.39 |
+| `outer_margin_top` | **1417** | **18.89** |
+| `outer_margin_bottom` | 283 | 3.77 |
+| `outer_margin_left/right` | 283 | 3.77 |
+
+**기대 표 상단 y** = `v_offset + outer_margin_top` = 101954 + 1417 = 103371 HU = **1378.28 px**
+
+## 3. PDF 측정 비교
+
+`pdf/exam_math-2022.pdf` 페이지 1 (1169×1653 px, A3 100dpi 렌더):
+- 페이지번호 박스 상단 y = 1530 → 페이지 비율 92.6%
+- SVG 1489 px 환산: 1489 × 0.926 = **1378.1 px**
+
+→ **기대 1378.28 px 와 PDF 측정 1378.1 px 일치** (0.18px 오차)
+
+## 4. 현재 rhwp 출력
+
+`output/svg/exam_math/exam_math_001.svg`:
+- 바탕쪽 표 셀 클립 y = **1359.39 px** (= v_offset 만 적용)
+- PDF 대비 **18.9 px (=outer_margin_top) 위쪽으로 잘못 배치**
+
+## 5. 결론
+
+가설 (a) **`outer_margin_top` 미적용** 이 정답. Paper-relative + depth=0 + TopAndBottom 분기에 `outer_margin_top` 추가 필요.
+
+## 6. 수정 후보 위치
+
+`src/renderer/layout/table_layout.rs:1180~1205`:
+
+```rust
+let (ref_y, ref_h) = match vert_rel_to {
+    ...
+    crate::model::shape::VertRelTo::Paper => (0.0, page_h_approx),
+};
+// 현재:
+let raw_y = match vert_align {
+    VertAlign::Top => ref_y + v_offset + caption_top_offset,
+    VertAlign::Center => ref_y + (ref_h - table_height) / 2.0 + v_offset + caption_top_offset,
+    VertAlign::Bottom => ref_y + ref_h - table_height - v_offset + caption_top_offset,
+};
+```
+
+수정 방향:
+- `VertAlign::Top` 분기에 `+ om_top` 추가
+- `VertAlign::Bottom` 분기에서 `- om_bottom` 추가 (대칭)
+- `VertAlign::Center` 는 외곽 박스 중앙 정렬이므로 표 본체 위치 = `ref_y + (ref_h - (table_h + om_top + om_bottom)) / 2 + om_top` ≈ 영향 작음
+
+영향 범위:
+- **Paper-positioned table** (주로 바탕쪽 + 일부 머리말/꼬리말 fixed 표)
+- 본문 표 (Para-positioned) 는 영향 없음
+- HWPX와 HWP5 동일 적용
+
+## 7. 다음 단계
+
+Stage 2 — 수정 구현 + 단위 테스트 신설
+- `compute_table_y_position` 수정
+- `tests/master_page_table_outer_margin.rs` 등 단위 테스트 추가
+- 회귀 확인용 데이터: `exam_math.hwp` 외 바탕쪽 사용 문서 목록 작성

--- a/mydocs/working/task_m100_898_stage2.md
+++ b/mydocs/working/task_m100_898_stage2.md
@@ -1,0 +1,54 @@
+# Stage 2 보고서: Task #898 — 수정 구현
+
+## 1. 수정 내용
+
+### `src/renderer/layout/table_layout.rs::compute_table_y_position`
+
+Paper-relative 분기 (depth=0, wrap=TopAndBottom/BehindText/InFrontOfText) 의 `raw_y` 산식에 `outer_margin_top` (Top/Inside 정렬) 및 `outer_margin_bottom` (Bottom/Outside 정렬) 가산.
+
+```rust
+// [Task #898] Paper-relative 표는 v_offset 이 외곽 박스 (outer_margin 포함) 기준이므로
+// 가시 표 상단 = v_offset + outer_margin_top.
+let om_top_px = if matches!(vert_rel_to, VertRelTo::Paper) {
+    hwpunit_to_px(table.outer_margin_top as i32, self.dpi)
+} else { 0.0 };
+let om_bottom_px = if matches!(vert_rel_to, VertRelTo::Paper) {
+    hwpunit_to_px(table.outer_margin_bottom as i32, self.dpi)
+} else { 0.0 };
+let raw_y = match vert_align {
+    Top | Inside  => ref_y + v_offset + caption_top_offset + om_top_px,
+    Center        => ref_y + (ref_h - table_height) / 2.0 + v_offset + caption_top_offset,
+    Bottom|Outside => ref_y + ref_h - table_height - v_offset + caption_top_offset - om_bottom_px,
+};
+```
+
+영향 범위: `vert_rel_to=Paper` 인 표만. Page/Para 기준 표는 변화 없음.
+
+## 2. 테스트
+
+신규: `tests/issue_898.rs::master_page_table_includes_outer_margin_top`
+- exam_math.hwp 페이지 1 SVG 에서 바탕쪽 표 셀 y=1378.28 px 확인
+- 회귀 가드: y=1359.x (outer_margin_top 미적용) 위치 검출 시 실패
+
+결과: **pass**
+
+## 3. 측정 검증
+
+`output/svg/exam_math/exam_math_001.svg`:
+- 직선 끝 y = 1358.41 px (변화 없음)
+- 바탕쪽 표 셀 y = **1378.28 px** (수정 전 1359.39 px → +18.89 px = outer_margin_top)
+- 두 객체 간격 = **19.87 px ≈ 5.26 mm**
+- PDF 측정 간격 = 5.3 mm (1378.1 - 1358.4 환산) → **일치**
+
+시각 확인: `/tmp/em_fixed_p1.png` 페이지 1 — 가운데 세로선과 1/20 박스 사이 명확한 여백 확보.
+
+## 4. 회귀
+
+`cargo test --release --lib`: **1257 passed, 0 failed**
+
+## 5. 다음 단계
+
+Stage 3 — 시각 회귀 검증:
+- exam_math.hwp 전 20쪽 PDF 대비 측정
+- 바탕쪽 사용 다른 샘플 (있다면) 회귀
+- 골든 SVG 영향 확인

--- a/mydocs/working/task_m100_898_stage3.md
+++ b/mydocs/working/task_m100_898_stage3.md
@@ -1,0 +1,76 @@
+# Stage 3 보고서: Task #898 — 시각 회귀 검증
+
+## 1. exam_math.hwp 전 20쪽
+
+전 페이지 바탕쪽 표 셀 y 좌표 일관성 확인:
+
+| 페이지 | 표 셀 y |
+|--------|---------|
+| 1 | 1378.28 |
+| 2 | 1378.28 |
+| 5 | 1378.28 |
+| 10 | 1378.28 |
+| 19 | 1378.28 |
+| 20 | 1378.28 |
+
+모든 페이지 동일 — `v_offset (101954) + outer_margin_top (1417)` = 103371 HU = 1378.28 px.
+
+시각 확인:
+- 페이지 1 (`/tmp/em_fixed_p1.png`): 가운데 세로선과 `1/20` 박스 사이 ≈20px 여백 ✓
+- 페이지 5 (`/tmp/em_p5.png`): 동일 ✓
+
+## 2. 바탕쪽 사용 다른 샘플 회귀
+
+`grep "바탕쪽: [1-9]"` 로 식별된 18개 샘플 중 대표 6건 렌더:
+
+| 샘플 | 페이지 수 | 오류 |
+|------|---------|------|
+| samples/exam_kor.hwp | 20 | 없음 |
+| samples/exam_eng.hwp | 8 | 없음 |
+| samples/exam_social.hwp | 4 | 없음 |
+| samples/exam_science.hwp | 4 | 없음 |
+| samples/basic/shortcut.hwp | 7 | 없음 |
+| samples/basic/KTX.hwp | 1 | 없음 |
+
+시각 확인:
+- exam_kor 1쪽 (`/tmp/exam_kor_p1.png`): 정상 (페이지 번호 `1` 우상단)
+- shortcut 1쪽 (`/tmp/shortcut_p1.png`): 정상 (페이지 번호 `1` 우하단)
+
+## 3. 골든 SVG 회귀
+
+`cargo test --release --test svg_snapshot`:
+
+```
+test issue_157_page_1 ... ok
+test issue_677_bokhakwonseo_page1 ... ok
+test issue_267_ktx_toc_page ... ok
+test form_002_page_0 ... ok
+test render_is_deterministic_within_process ... ok
+test issue_147_aift_page3 ... ok
+test issue_617_exam_kor_page5 ... ok
+test result: ok. 8 passed; 0 failed
+```
+
+특히 `issue_617_exam_kor_page5` 는 바탕쪽 사용 문서 골든 → **변화 없음**.
+
+## 4. 전체 테스트
+
+`cargo test --release`:
+- **TOTAL passed=1412, failed=0**
+- 40개 테스트 그룹 전부 통과
+- 신규 `tests/issue_898.rs::master_page_table_includes_outer_margin_top` 포함
+
+## 5. 결론
+
+- exam_math.hwp 사용자 보고 결함 해결
+- 다른 바탕쪽 사용 문서 회귀 없음
+- 골든 SVG 변화 없음 (Paper-relative + outer_margin_top > 0 케이스는 exam 시리즈 / shortcut 등 일부 문서에만 해당, 골든은 영향 없음)
+- 전체 단위 테스트 통과
+
+## 6. 다음 단계
+
+Stage 4 — 최종 마무리:
+- clippy 검증 (lib 단독)
+- 골든 SVG 갱신 필요성 재확인 (불필요 예상)
+- 최종 결과 보고서: `mydocs/report/task_m100_898_report.md`
+- 커밋

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1198,10 +1198,18 @@ impl LayoutEngine {
                 0.0
             };
             let vert_align = table.common.vert_align;
+            // [Task #898] Paper-relative 표는 v_offset 이 외곽 박스 (outer_margin 포함) 기준이므로
+            // 가시 표 상단 = v_offset + outer_margin_top. 한컴 PDF (exam_math.hwp 바탕쪽 쪽번호 박스) 정합.
+            let om_top_px = if matches!(vert_rel_to, crate::model::shape::VertRelTo::Paper) {
+                hwpunit_to_px(table.outer_margin_top as i32, self.dpi)
+            } else { 0.0 };
+            let om_bottom_px = if matches!(vert_rel_to, crate::model::shape::VertRelTo::Paper) {
+                hwpunit_to_px(table.outer_margin_bottom as i32, self.dpi)
+            } else { 0.0 };
             let raw_y = match vert_align {
-                crate::model::shape::VertAlign::Top | crate::model::shape::VertAlign::Inside => ref_y + v_offset + caption_top_offset,
+                crate::model::shape::VertAlign::Top | crate::model::shape::VertAlign::Inside => ref_y + v_offset + caption_top_offset + om_top_px,
                 crate::model::shape::VertAlign::Center => ref_y + (ref_h - table_height) / 2.0 + v_offset + caption_top_offset,
-                crate::model::shape::VertAlign::Bottom | crate::model::shape::VertAlign::Outside => ref_y + ref_h - table_height - v_offset + caption_top_offset,
+                crate::model::shape::VertAlign::Bottom | crate::model::shape::VertAlign::Outside => ref_y + ref_h - table_height - v_offset + caption_top_offset - om_bottom_px,
             };
             // Para 기준 + bit 13: 본문 영역으로 제한
             // 앞선 표/텍스트가 차지한 영역(y_start) 아래로 밀어내고, 본문 영역 내로 클램핑

--- a/tests/issue_898.rs
+++ b/tests/issue_898.rs
@@ -1,0 +1,53 @@
+//! Issue #898: exam_math.hwp 가운데 세로선 (직선 Shape) 끝과 바탕쪽 쪽번호 박스가
+//! 거의 붙어 PDF (한컴 2022) 와 시각 차이.
+//!
+//! 원인: `compute_table_y_position` 의 Paper-relative 분기에서
+//! `outer_margin_top` 이 산식에 누락. v_offset(101954 HU=359.5mm) + outer_margin_top
+//! (1417 HU=5.0mm) = 364.5mm 가 가시 표 상단인데, 1417 HU 빠뜨려 5mm 위쪽 배치.
+//!
+//! 이 테스트는 페이지 1 바탕쪽 쪽번호 표 셀 상단 y 좌표가 outer_margin_top 반영
+//! 후 위치 (≈1378 px) 임을 검증한다.
+
+use std::fs;
+use std::path::Path;
+
+#[test]
+fn master_page_table_includes_outer_margin_top() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/exam_math.hwp");
+    let bytes = fs::read(&hwp_path)
+        .unwrap_or_else(|e| panic!("read {}: {}", hwp_path.display(), e));
+
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .expect("parse exam_math.hwp");
+
+    let svg = doc
+        .render_page_svg_native(0)
+        .expect("render exam_math.hwp page 1");
+
+    // 바탕쪽 쪽번호 표 셀의 clipPath y 좌표 — outer_margin_top 적용 시 1378.28 px,
+    // 미적용 회귀 시 1359.39 px.
+    //
+    // SVG 부동소수 표현 차이 흡수: y="1378" 이 포함되는지 확인.
+    // 회귀(미적용) 값은 1359.x 이므로 "y=\"1378" 패턴 매칭 시 충분.
+    let has_correct_y = svg.contains("y=\"1378.")
+        || svg.contains("y=\"1378\"");
+    assert!(
+        has_correct_y,
+        "바탕쪽 표 셀 y 좌표가 outer_margin_top 미반영 (회귀). SVG snippet:\n{}",
+        svg.lines()
+            .filter(|l| l.contains("cell-clip") && l.contains("1359"))
+            .take(3)
+            .collect::<Vec<_>>()
+            .join("\n")
+    );
+
+    // 회귀 가드: 1359.x 좌표가 셀 클립에 나타나지 않아야 함
+    let regression = svg
+        .lines()
+        .any(|l| l.contains("clipPath") && l.contains("cell-clip") && l.contains("y=\"1359."));
+    assert!(
+        !regression,
+        "바탕쪽 표 셀이 outer_margin_top 미적용 y=1359 위치로 회귀."
+    );
+}


### PR DESCRIPTION
## 요약

`samples/exam_math.hwp` 페이지 1 (및 전 페이지) 에서 가운데 세로선 (직선 Shape) 끝과 바탕쪽 쪽번호 박스 (`1/20`) 가 약 1px 간격으로 붙어 한컴 2022 PDF 와 시각 차이가 발생.

원인: `compute_table_y_position` 의 Paper-relative + depth=0 분기에서 `outer_margin_top` 이 산식에 누락. v_offset (101954 HU) + outer_margin_top (1417 HU = 5mm) 이 한컴 가시 표 상단인데 outer_margin_top 빠뜨려 5mm 위쪽 배치.

## 수정

`src/renderer/layout/table_layout.rs` Paper-relative `raw_y` 산식에 `outer_margin_top` / `outer_margin_bottom` 가산. 영향 범위: `vert_rel_to == Paper` 표만 (Para/Page 기준 표는 변화 없음).

## 검증

- 표 셀 y 좌표: 1359.39 → **1378.28 px** (PDF 측정 1378.1 px 와 0.18 px 오차)
- 가운데 세로선과 쪽번호 박스 사이 ≈20 px 여백 복원
- 신규 회귀 가드: `tests/issue_898.rs`
- 전체 단위 테스트: 1412 passed, 0 failed
- 골든 SVG snapshot 8건: 변화 없음
- 바탕쪽 사용 6개 샘플 (exam_kor/eng/social/science, shortcut, KTX) 회귀 없음

## 관련

closes #898

## 산출물

- `mydocs/plans/task_m100_898{,_impl}.md` — 계획서
- `mydocs/working/task_m100_898_stage{1,2,3}.md` — 단계별 보고서
- `mydocs/report/task_m100_898_report.md` — 최종 보고서