### PR TITLE
render: adopt guarded text variants for backend replay

### DIFF
--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -104,7 +104,8 @@ sidecar and use `TextRun`.
   They must not change renderer output or make `GlyphRun` the canonical path.
 - P14 `GlyphOutline` is a strict sidecar. It must carry `anchorOpId`, stay in
   the same `equivalenceGroup`, and complete every declared variant part before
-  selection.
+  selection. In schema v1 the `equivalenceGroup` is also the paint-order slot id
+  because fallback `TextRun` ops do not yet have stable per-op ids.
 - P14 backend selection diagnostics are deterministic and report-only. They
   explain CanvasKit/native eligibility, glyph-id range limits, font portability,
   missing glyphs, cluster mismatch, unsupported text effects, incomplete

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -26,6 +26,12 @@ structured validation issues, the v1 downgrade path, fallback-free profile
 guards, and line-break risk telemetry for text runs whose shaped replay could
 affect layout-sensitive behavior.
 
+P14 adopts the first backend-facing text variant policy. It adds a
+`GlyphOutline` strict sidecar contract for producer-resolved glyph paths and a
+shared backend selection diagnostic that can explain why CanvasKit/native-style
+replay selects a strict variant or falls back to `TextRun`. This is still a
+guarded contract, not a public default path switch.
+
 ## Export Contract
 
 Layer JSON now provides additive text metadata:
@@ -48,6 +54,10 @@ Layer JSON now provides additive text metadata:
 - `fontResources`, an additive table for font blob/face identity.
 - Optional `GlyphRun` sidecar ops with `variant`, `shapeKey`, glyph ids,
   glyph positions, shaped clusters, and replay diagnostics.
+- Optional `GlyphOutline` sidecar ops with `variant`, `anchorOpId`,
+  `payloadKind`, placement, outline paths, strict stroke metadata when present,
+  and replay diagnostics. These sidecars are text alternatives, not generic
+  shape paths.
 - `textV2`, an additive diagnostics object with:
   - `compatibilityProfile`, currently `v1Compat` for normal exports.
   - `fallbackRequired`, which stays true for the v1 compatibility writer.
@@ -65,6 +75,12 @@ legacy mirror.
 `equivalenceGroup`. If a glyph variant is unsupported, incomplete, or fails its
 diagnostics/resource guard, the backend must paint the default `TextRun`
 fallback instead.
+
+`GlyphOutline` follows the same variant rule but is anchored to the same
+paint-order slot through `anchorOpId`. The strict subset currently allows
+monochrome fill outlines and a small fill/stroke subset with deterministic
+stroke style. Backends that cannot preserve that payload must reject the
+sidecar and use `TextRun`.
 
 ## Invariants
 
@@ -86,6 +102,13 @@ fallback instead.
   unless a shaping pass explicitly inserts glyph alternatives.
 - P13 `textV2` diagnostics are additive and report-only for normal exports.
   They must not change renderer output or make `GlyphRun` the canonical path.
+- P14 `GlyphOutline` is a strict sidecar. It must carry `anchorOpId`, stay in
+  the same `equivalenceGroup`, and complete every declared variant part before
+  selection.
+- P14 backend selection diagnostics are deterministic and report-only. They
+  explain CanvasKit/native eligibility, glyph-id range limits, font portability,
+  missing glyphs, cluster mismatch, unsupported text effects, incomplete
+  variants, and outline payload/stroke rejection.
 - A fallback-free text profile is only valid when every text variant slot has a
   strict visual variant. In schema v1 the default writer still exports the
   fallback, and the fallback-free profile is only exposed as a guard/validator.
@@ -105,7 +128,7 @@ fallback instead.
 
 - Wire real document font blob extraction into `ResourceArena`.
 - Add CanvasKit glyph replay behind the same variant gate.
-- Add native glyph outline replay behind a separate strict visual variant.
+- Add native glyph outline replay behind the strict `GlyphOutline` variant.
 - Add resource table entries for font blobs and face identity.
 - Promote renderer diagnostics from report-only to backend selection telemetry
   once CanvasKit/native glyph alternatives are actually consumed.

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -63,9 +63,10 @@ impl PageLayerTree {
 
 fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let externalized_visuals = externalized_text_visuals(root);
-    let has_variant_groups = has_text_variant_groups(root);
-    let has_glyph_runs = has_glyph_runs(root);
-    let has_glyph_outlines = has_glyph_outlines(root);
+    let text_variant_features = collect_text_variant_features(root);
+    let has_variant_groups = text_variant_features.has_variant_groups();
+    let has_glyph_runs = text_variant_features.has_glyph_runs;
+    let has_glyph_outlines = text_variant_features.has_glyph_outlines;
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.v2.diagnostics\",\"text.projectionKind\",\"text.legacyVisuals\"");
     if has_glyph_runs {
         buf.push_str(",\"fontResources\",\"text.glyphRun\"");
@@ -88,17 +89,21 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     if externalized_visuals.contains(&"decorations") {
         buf.push_str(",\"text.decorationOp\"");
     }
-    buf.push_str("],\"optionalFeatures\":[");
-    let mut optional_feature_count = 0usize;
+    let mut optional_features = Vec::new();
     if has_glyph_runs {
-        buf.push_str("\"fontResources\",\"text.glyphRun\"");
-        optional_feature_count += 2;
+        optional_features.push("fontResources");
+        optional_features.push("text.glyphRun");
     }
     if has_glyph_outlines {
-        if optional_feature_count > 0 {
+        optional_features.push("text.glyphOutline");
+        optional_features.push("text.glyphOutline.strictSidecar");
+    }
+    buf.push_str("],\"optionalFeatures\":[");
+    for (idx, feature) in optional_features.iter().enumerate() {
+        if idx > 0 {
             buf.push(',');
         }
-        buf.push_str("\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\"");
+        buf.push_str(&json_escape(feature));
     }
     buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
@@ -117,50 +122,20 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     buf.push_str("]}");
 }
 
-fn has_text_variant_groups(root: &LayerNode) -> bool {
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        match &node.kind {
-            LayerNodeKind::Group { children, .. } => {
-                for child in children {
-                    stack.push(child);
-                }
-            }
-            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
-            LayerNodeKind::Leaf { ops } => {
-                if ops
-                    .iter()
-                    .any(|op| matches!(op, PaintOp::GlyphRun { .. } | PaintOp::GlyphOutline { .. }))
-                {
-                    return true;
-                }
-            }
-        }
-    }
-    false
+#[derive(Debug, Clone, Copy, Default)]
+struct TextVariantFeatureFlags {
+    has_glyph_runs: bool,
+    has_glyph_outlines: bool,
 }
 
-fn has_glyph_runs(root: &LayerNode) -> bool {
-    let mut stack = vec![root];
-    while let Some(node) = stack.pop() {
-        match &node.kind {
-            LayerNodeKind::Group { children, .. } => {
-                for child in children {
-                    stack.push(child);
-                }
-            }
-            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
-            LayerNodeKind::Leaf { ops } => {
-                if ops.iter().any(|op| matches!(op, PaintOp::GlyphRun { .. })) {
-                    return true;
-                }
-            }
-        }
+impl TextVariantFeatureFlags {
+    fn has_variant_groups(self) -> bool {
+        self.has_glyph_runs || self.has_glyph_outlines
     }
-    false
 }
 
-fn has_glyph_outlines(root: &LayerNode) -> bool {
+fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
+    let mut features = TextVariantFeatureFlags::default();
     let mut stack = vec![root];
     while let Some(node) = stack.pop() {
         match &node.kind {
@@ -171,16 +146,20 @@ fn has_glyph_outlines(root: &LayerNode) -> bool {
             }
             LayerNodeKind::ClipRect { child, .. } => stack.push(child),
             LayerNodeKind::Leaf { ops } => {
-                if ops
-                    .iter()
-                    .any(|op| matches!(op, PaintOp::GlyphOutline { .. }))
-                {
-                    return true;
+                for op in ops {
+                    match op {
+                        PaintOp::GlyphRun { .. } => features.has_glyph_runs = true,
+                        PaintOp::GlyphOutline { .. } => features.has_glyph_outlines = true,
+                        _ => {}
+                    }
+                }
+                if features.has_glyph_runs && features.has_glyph_outlines {
+                    return features;
                 }
             }
         }
     }
-    false
+    features
 }
 
 fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -7,11 +7,12 @@ use crate::model::control::FormType;
 use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
-    CacheHint, ClipKind, FontResourceTable, GlyphCluster, GlyphRunDiagnostics, GlyphTransform,
-    GroupKind, LayerAffineTransform, LayerNode, LayerNodeKind, LayerPoint, LayerVector,
-    PageLayerTree, PaintOp, PaintTextStyle, PaintVariantMeta, RenderProfile, ShapeKey,
-    TextDecorationKind, TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange,
-    TextSourceSpan, TextSourceTable, TextV2Diagnostics, LAYER_TREE_SCHEMA,
+    CacheHint, ClipKind, FontResourceTable, GlyphCluster, GlyphOutlineStrokeStyle,
+    GlyphRunDiagnostics, GlyphTransform, GroupKind, LayerAffineTransform, LayerGlyphOutlinePath,
+    LayerNode, LayerNodeKind, LayerPoint, LayerVector, PageLayerTree, PaintOp, PaintTextStyle,
+    PaintVariantMeta, RenderProfile, ShapeKey, TextDecorationKind, TextSourceAnnotation,
+    TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan, TextSourceTable,
+    TextV2Diagnostics, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
@@ -64,9 +65,13 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let externalized_visuals = externalized_text_visuals(root);
     let has_variant_groups = has_text_variant_groups(root);
     let has_glyph_runs = has_glyph_runs(root);
+    let has_glyph_outlines = has_glyph_outlines(root);
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.v2.diagnostics\",\"text.projectionKind\",\"text.legacyVisuals\"");
     if has_glyph_runs {
         buf.push_str(",\"fontResources\",\"text.glyphRun\"");
+    }
+    if has_glyph_outlines {
+        buf.push_str(",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\"");
     }
     if has_variant_groups {
         buf.push_str(",\"text.variantGroups\"");
@@ -84,12 +89,23 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         buf.push_str(",\"text.decorationOp\"");
     }
     buf.push_str("],\"optionalFeatures\":[");
+    let mut optional_feature_count = 0usize;
     if has_glyph_runs {
         buf.push_str("\"fontResources\",\"text.glyphRun\"");
+        optional_feature_count += 2;
     }
-    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    if has_glyph_outlines {
+        if optional_feature_count > 0 {
+            buf.push(',');
+        }
+        buf.push_str("\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\"");
+    }
+    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
         buf.push_str(",\"glyphRun\"");
+    }
+    if has_glyph_outlines {
+        buf.push_str(",\"glyphOutline\"");
     }
     buf.push_str("],\"variantSelection\":\"exclusiveVariantSet\",\"sourceTextPreserved\":true,\"clusterEncoding\":[\"utf8\",\"utf16\"],\"fallbackRequired\":true,\"placementAuthority\":\"compatibilityProjection\",\"externalizedVisuals\":[");
     for (idx, visual) in externalized_visuals.iter().enumerate() {
@@ -112,7 +128,10 @@ fn has_text_variant_groups(root: &LayerNode) -> bool {
             }
             LayerNodeKind::ClipRect { child, .. } => stack.push(child),
             LayerNodeKind::Leaf { ops } => {
-                if ops.iter().any(|op| matches!(op, PaintOp::GlyphRun { .. })) {
+                if ops
+                    .iter()
+                    .any(|op| matches!(op, PaintOp::GlyphRun { .. } | PaintOp::GlyphOutline { .. }))
+                {
                     return true;
                 }
             }
@@ -122,7 +141,46 @@ fn has_text_variant_groups(root: &LayerNode) -> bool {
 }
 
 fn has_glyph_runs(root: &LayerNode) -> bool {
-    has_text_variant_groups(root)
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    stack.push(child);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
+            LayerNodeKind::Leaf { ops } => {
+                if ops.iter().any(|op| matches!(op, PaintOp::GlyphRun { .. })) {
+                    return true;
+                }
+            }
+        }
+    }
+    false
+}
+
+fn has_glyph_outlines(root: &LayerNode) -> bool {
+    let mut stack = vec![root];
+    while let Some(node) = stack.pop() {
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    stack.push(child);
+                }
+            }
+            LayerNodeKind::ClipRect { child, .. } => stack.push(child),
+            LayerNodeKind::Leaf { ops } => {
+                if ops
+                    .iter()
+                    .any(|op| matches!(op, PaintOp::GlyphOutline { .. }))
+                {
+                    return true;
+                }
+            }
+        }
+    }
+    false
 }
 
 fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {
@@ -366,6 +424,33 @@ impl PaintOp {
                 }
                 buf.push_str(",\"diagnostics\":");
                 write_glyph_run_diagnostics(buf, &run.diagnostics);
+                buf.push('}');
+            }
+            PaintOp::GlyphOutline { bbox, outline } => {
+                buf.push('{');
+                buf.push_str("\"type\":\"glyphOutline\",\"bbox\":");
+                write_bbox(buf, *bbox);
+                buf.push_str(",\"source\":");
+                write_text_source_span(buf, &outline.source);
+                buf.push_str(",\"variant\":");
+                write_paint_variant_meta(buf, &outline.variant);
+                let _ = write!(
+                    buf,
+                    ",\"payloadKind\":{}",
+                    json_escape(outline.payload_kind.as_str())
+                );
+                buf.push_str(",\"paintStyle\":");
+                write_paint_text_style(buf, &outline.paint_style);
+                buf.push_str(",\"placement\":");
+                write_text_run_placement_value(buf, outline.placement);
+                buf.push_str(",\"paths\":");
+                write_glyph_outline_paths(buf, &outline.paths);
+                if let Some(stroke) = &outline.stroke {
+                    buf.push_str(",\"stroke\":");
+                    write_glyph_outline_stroke(buf, stroke);
+                }
+                buf.push_str(",\"diagnostics\":");
+                write_glyph_run_diagnostics(buf, &outline.diagnostics);
                 buf.push('}');
             }
             PaintOp::CharOverlap { bbox, run } => {
@@ -714,6 +799,10 @@ impl LeafTextVisualOps {
                 PaintOp::GlyphRun { run, .. } => visuals
                     .glyph_variant_groups
                     .push((run.source.id.0, run.variant.equivalence_group.clone())),
+                PaintOp::GlyphOutline { outline, .. } => visuals.glyph_variant_groups.push((
+                    outline.source.id.0,
+                    outline.variant.equivalence_group.clone(),
+                )),
                 _ => {}
             }
         }
@@ -1456,6 +1545,42 @@ fn write_glyph_clusters(buf: &mut String, clusters: &[GlyphCluster]) {
     buf.push(']');
 }
 
+fn write_glyph_outline_paths(buf: &mut String, paths: &[LayerGlyphOutlinePath]) {
+    buf.push('[');
+    for (idx, path) in paths.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(buf, "{{\"glyphId\":{},\"sourceRangeUtf8\":", path.glyph_id);
+        write_text_source_range(buf, path.source_range_utf8);
+        let _ = write!(
+            buf,
+            ",\"glyphRange\":{{\"start\":{},\"end\":{}}},\"fillRule\":{}",
+            path.glyph_range.start,
+            path.glyph_range.end,
+            json_escape(path.fill_rule.as_str())
+        );
+        buf.push_str(",\"commands\":");
+        write_path_commands(buf, &path.commands);
+        buf.push('}');
+    }
+    buf.push(']');
+}
+
+fn write_glyph_outline_stroke(buf: &mut String, stroke: &GlyphOutlineStrokeStyle) {
+    let _ = write!(
+        buf,
+        "{{\"color\":{},\"width\":{:.6},\"join\":{},\"cap\":{},\"miterLimit\":{:.6},\"paintOrder\":{},\"strictSubset\":{}}}",
+        json_escape(&color_ref_to_css(stroke.color)),
+        stroke.width,
+        json_escape(stroke.join.as_str()),
+        json_escape(stroke.cap.as_str()),
+        stroke.miter_limit,
+        json_escape(stroke.paint_order.as_str()),
+        stroke.is_strict_subset()
+    );
+}
+
 fn write_glyph_transforms(buf: &mut String, transforms: &[GlyphTransform]) {
     buf.push('[');
     for (idx, transform) in transforms.iter().enumerate() {
@@ -1785,11 +1910,13 @@ mod tests {
     use super::*;
     use crate::paint::{
         CacheHint, ClipKind, FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster,
-        GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
-        LayerAffineTransform, LayerGlyphRunPaint, LayerNode, LayerPoint, LayerVector,
-        PageLayerTree, PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey, ShapingEngineId,
-        TextDecorationKind, TextDirection, TextSourceId, TextSourceRange, TextSourceSpan,
-        TextVariantKind, TextVariantQuality, WritingMode,
+        GlyphOutlineFillRule, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
+        GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
+        GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind, LayerAffineTransform,
+        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
+        LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey,
+        ShapingEngineId, TextDecorationKind, TextDirection, TextSourceId, TextSourceRange,
+        TextSourceSpan, TextVariantKind, TextVariantQuality, WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -1880,8 +2007,8 @@ mod tests {
 
         assert!(json.contains("\"kind\":\"leaf\""));
         assert!(json.contains("\"schemaVersion\":1"));
-        assert!(json.contains("\"schemaMinorVersion\":10"));
-        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":10}"));
+        assert!(json.contains("\"schemaMinorVersion\":11"));
+        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":11}"));
         assert!(json.contains("\"resourceTableVersion\":1"));
         assert!(json.contains("\"resourceTableMinorVersion\":3"));
         assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":3}"));
@@ -2149,6 +2276,135 @@ mod tests {
         assert!(json.contains("\"strictVisualEligible\":true"));
         assert!(json.contains("\"slotDiagnostics\":[{\"paintOrderSlotId\":\"text-0\""));
         assert!(json.contains("\"strictVariantAvailable\":true"));
+    }
+
+    #[test]
+    fn serializes_glyph_outline_variant_with_strict_sidecar_contract() {
+        let source = TextSourceSpan {
+            id: TextSourceId(0),
+            utf8_range: TextSourceRange::new(0, 1),
+            utf16_range: TextSourceRange::new(0, 1),
+            stable_source_key: None,
+        };
+        let text_run = PaintOp::TextRun {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            run: TextRunNode {
+                text: "A".to_string(),
+                style: TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 12.0,
+                field_marker: FieldMarkerType::None,
+            },
+        };
+        let outline = PaintOp::GlyphOutline {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            outline: Box::new(LayerGlyphOutlinePaint {
+                source,
+                variant: PaintVariantMeta {
+                    equivalence_group: "text-0".to_string(),
+                    variant_id: "glyphOutline".to_string(),
+                    variant_kind: TextVariantKind::GlyphOutline,
+                    part_index: 0,
+                    part_count: 1,
+                    is_default_fallback: false,
+                    requires: vec![
+                        "text.glyphOutline".to_string(),
+                        "text.glyphOutline.strictSidecar".to_string(),
+                    ],
+                    quality: Some(TextVariantQuality::Exact),
+                    anchor_op_id: Some("text-0".to_string()),
+                    local_paint_order: Some(0),
+                },
+                payload_kind: GlyphOutlinePayloadKind::MonochromeFillStroke,
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 12.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                paths: vec![LayerGlyphOutlinePath {
+                    glyph_id: 42,
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    glyph_range: GlyphRange::new(0, 1),
+                    commands: vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(10.0, 0.0),
+                        PathCommand::ClosePath,
+                    ],
+                    fill_rule: GlyphOutlineFillRule::NonZero,
+                }],
+                stroke: Some(GlyphOutlineStrokeStyle {
+                    color: 0x00000000,
+                    width: 1.0,
+                    join: GlyphOutlineStrokeJoin::Miter,
+                    cap: GlyphOutlineStrokeCap::Butt,
+                    miter_limit: 2.0,
+                    paint_order: crate::paint::GlyphOutlinePaintOrder::FillThenStroke,
+                }),
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            }),
+        };
+
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![text_run, outline],
+            ),
+        );
+        let json = tree.to_json();
+
+        assert!(json.contains("\"type\":\"glyphOutline\""));
+        assert!(json.contains("\"payloadKind\":\"monochromeFillStroke\""));
+        assert!(json.contains("\"anchorOpId\":\"text-0\""));
+        assert!(json.contains("\"paths\":[{\"glyphId\":42"));
+        assert!(json.contains("\"fillRule\":\"nonzero\""));
+        assert!(json.contains("\"stroke\":{\"color\":\"#000000\""));
+        assert!(json.contains("\"strictSubset\":true"));
+        assert!(json.contains("\"text.glyphOutline\""));
+        assert!(json.contains("\"text.glyphOutline.strictSidecar\""));
+        assert!(json.contains("\"variants\":[\"textRun\",\"glyphOutline\"]"));
+        assert!(json.contains("\"variantKind\":\"glyphOutline\""));
     }
 
     #[test]

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -28,10 +28,12 @@ pub use layer_tree::{
     TextSourceTable,
 };
 pub use paint_op::{
-    GlyphCluster, GlyphClusterFlag, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
-    GlyphTransform, LayerAffineTransform, LayerGlyphRunPaint, LayerPoint, LayerVector, PaintOp,
-    PaintTextStyle, PaintVariantMeta, TextDecorationKind, TextRunPlacement, TextVariantKind,
-    TextVariantQuality,
+    GlyphCluster, GlyphClusterFlag, GlyphOutlineFillRule, GlyphOutlinePaintOrder,
+    GlyphOutlinePayloadKind, GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin,
+    GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation, GlyphTransform,
+    LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint,
+    LayerPoint, LayerVector, PaintOp, PaintTextStyle, PaintVariantMeta, TextDecorationKind,
+    TextRunPlacement, TextVariantKind, TextVariantQuality,
 };
 pub use profile::RenderProfile;
 pub use resources::{

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -7,7 +7,7 @@ use crate::renderer::render_tree::{
     LineNode, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode,
     TextRunNode,
 };
-use crate::renderer::TextStyle;
+use crate::renderer::{PathCommand, TextStyle};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum TextDecorationKind {
@@ -43,6 +43,10 @@ pub enum PaintOp {
     GlyphRun {
         bbox: BoundingBox,
         run: Box<LayerGlyphRunPaint>,
+    },
+    GlyphOutline {
+        bbox: BoundingBox,
+        outline: Box<LayerGlyphOutlinePaint>,
     },
     /// HWP 글자겹침의 명시 visual op.
     ///
@@ -116,6 +120,7 @@ impl PaintOp {
             PaintOp::PageBackground { bbox, .. }
             | PaintOp::TextRun { bbox, .. }
             | PaintOp::GlyphRun { bbox, .. }
+            | PaintOp::GlyphOutline { bbox, .. }
             | PaintOp::CharOverlap { bbox, .. }
             | PaintOp::TextControlMark { bbox, .. }
             | PaintOp::TabLeader { bbox, .. }
@@ -153,7 +158,143 @@ pub struct LayerGlyphRunPaint {
     pub diagnostics: GlyphRunDiagnostics,
 }
 
-/// Variant grouping metadata for TextRun/GlyphRun alternatives.
+/// Strict-visual text alternative that carries producer-resolved glyph paths.
+///
+/// A GlyphOutline is still a text variant, not a generic Path. Consumers must
+/// select it through the same equivalence group as the TextRun fallback and
+/// reject it when the backend cannot preserve the declared payload.
+#[derive(Debug, Clone)]
+pub struct LayerGlyphOutlinePaint {
+    pub source: TextSourceSpan,
+    pub variant: PaintVariantMeta,
+    pub payload_kind: GlyphOutlinePayloadKind,
+    pub paint_style: PaintTextStyle,
+    pub placement: TextRunPlacement,
+    pub paths: Vec<LayerGlyphOutlinePath>,
+    pub stroke: Option<GlyphOutlineStrokeStyle>,
+    pub diagnostics: GlyphRunDiagnostics,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphOutlinePayloadKind {
+    MonochromeFill,
+    MonochromeFillStroke,
+}
+
+impl GlyphOutlinePayloadKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::MonochromeFill => "monochromeFill",
+            Self::MonochromeFillStroke => "monochromeFillStroke",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct LayerGlyphOutlinePath {
+    pub glyph_id: u32,
+    pub source_range_utf8: TextSourceRange,
+    pub glyph_range: GlyphRange,
+    pub commands: Vec<PathCommand>,
+    pub fill_rule: GlyphOutlineFillRule,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphOutlineFillRule {
+    NonZero,
+    EvenOdd,
+}
+
+impl GlyphOutlineFillRule {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NonZero => "nonzero",
+            Self::EvenOdd => "evenodd",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct GlyphOutlineStrokeStyle {
+    pub color: ColorRef,
+    pub width: f64,
+    pub join: GlyphOutlineStrokeJoin,
+    pub cap: GlyphOutlineStrokeCap,
+    pub miter_limit: f64,
+    pub paint_order: GlyphOutlinePaintOrder,
+}
+
+impl GlyphOutlineStrokeStyle {
+    pub fn is_strict_subset(&self) -> bool {
+        self.width.is_finite()
+            && self.width > 0.0
+            && self.miter_limit.is_finite()
+            && self.miter_limit >= 1.0
+            && matches!(self.join, GlyphOutlineStrokeJoin::Miter)
+            && matches!(self.cap, GlyphOutlineStrokeCap::Butt)
+            && matches!(
+                self.paint_order,
+                GlyphOutlinePaintOrder::FillOnly
+                    | GlyphOutlinePaintOrder::FillThenStroke
+                    | GlyphOutlinePaintOrder::StrokeThenFill
+            )
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphOutlineStrokeJoin {
+    Miter,
+    Round,
+    Bevel,
+}
+
+impl GlyphOutlineStrokeJoin {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Miter => "miter",
+            Self::Round => "round",
+            Self::Bevel => "bevel",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphOutlineStrokeCap {
+    Butt,
+    Round,
+    Square,
+}
+
+impl GlyphOutlineStrokeCap {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Butt => "butt",
+            Self::Round => "round",
+            Self::Square => "square",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum GlyphOutlinePaintOrder {
+    FillOnly,
+    StrokeOnly,
+    FillThenStroke,
+    StrokeThenFill,
+}
+
+impl GlyphOutlinePaintOrder {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::FillOnly => "fillOnly",
+            Self::StrokeOnly => "strokeOnly",
+            Self::FillThenStroke => "fillThenStroke",
+            Self::StrokeThenFill => "strokeThenFill",
+        }
+    }
+}
+
+/// Variant grouping metadata for TextRun/GlyphRun/GlyphOutline alternatives.
 ///
 /// Consumers select one `variant_id` per `equivalence_group` and paint every
 /// part belonging to that variant. A `TextRun` fallback remains required.
@@ -192,6 +333,7 @@ impl PaintVariantMeta {
 pub enum TextVariantKind {
     TextRun,
     GlyphRun,
+    GlyphOutline,
 }
 
 impl TextVariantKind {
@@ -199,6 +341,7 @@ impl TextVariantKind {
         match self {
             Self::TextRun => "textRun",
             Self::GlyphRun => "glyphRun",
+            Self::GlyphOutline => "glyphOutline",
         }
     }
 }

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -234,9 +234,7 @@ impl GlyphOutlineStrokeStyle {
             && matches!(self.cap, GlyphOutlineStrokeCap::Butt)
             && matches!(
                 self.paint_order,
-                GlyphOutlinePaintOrder::FillOnly
-                    | GlyphOutlinePaintOrder::FillThenStroke
-                    | GlyphOutlinePaintOrder::StrokeThenFill
+                GlyphOutlinePaintOrder::FillThenStroke | GlyphOutlinePaintOrder::StrokeThenFill
             )
     }
 }

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,7 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 10,
+    schema_minor_version: 11,
     resource_table_version: 1,
     resource_table_minor_version: 3,
     unit: "px",
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn layer_tree_schema_contract_is_stable() {
         assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 10);
+        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 11);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 3);
         assert_eq!(LAYER_TREE_SCHEMA.unit, "px");

--- a/src/paint/text_v2.rs
+++ b/src/paint/text_v2.rs
@@ -13,8 +13,9 @@ use serde::Serialize;
 use crate::document_core::helpers::json_escape as raw_json_escape;
 use crate::model::style::UnderlineType;
 use crate::paint::{
-    GlyphRunDiagnostics, GlyphRunReplayEligibility, LayerNode, LayerNodeKind, PageLayerTree,
-    PaintOp, TextVariantKind, TextVariantQuality,
+    GlyphOutlinePayloadKind, GlyphRunDiagnostics, GlyphRunReplayEligibility,
+    LayerGlyphOutlinePaint, LayerNode, LayerNodeKind, PageLayerTree, PaintOp, TextVariantKind,
+    TextVariantQuality,
 };
 use crate::renderer::render_tree::{FieldMarkerType, TextRunNode};
 
@@ -408,6 +409,39 @@ fn collect_node(
                             .take()
                             .or_else(|| glyph_run_fallback_reason(&run.diagnostics));
                     }
+                    PaintOp::GlyphOutline { outline, .. } => {
+                        let variant = &outline.variant;
+                        let group = groups.entry(variant.equivalence_group.clone()).or_default();
+                        let entry = group.entry(variant.variant_id.clone()).or_insert_with(|| {
+                            VariantAccumulator {
+                                variant_id: variant.variant_id.clone(),
+                                variant_kind: variant.variant_kind,
+                                required_features: variant
+                                    .requires
+                                    .iter()
+                                    .cloned()
+                                    .collect::<BTreeSet<_>>(),
+                                part_count: variant.part_count,
+                                present_parts: BTreeSet::new(),
+                                strict_parts: BTreeSet::new(),
+                                quality: variant.quality,
+                                fallback_reason: None,
+                            }
+                        });
+                        entry
+                            .required_features
+                            .extend(variant.requires.iter().cloned());
+                        entry.part_count = entry.part_count.max(variant.part_count);
+                        entry.present_parts.insert(variant.part_index);
+                        entry.quality = entry.quality.or(variant.quality);
+                        if glyph_outline_is_strict(outline) {
+                            entry.strict_parts.insert(variant.part_index);
+                        }
+                        entry.fallback_reason = entry
+                            .fallback_reason
+                            .take()
+                            .or_else(|| glyph_outline_fallback_reason(outline));
+                    }
                     _ => {}
                 }
             }
@@ -512,6 +546,46 @@ fn glyph_run_fallback_reason(diagnostics: &GlyphRunDiagnostics) -> Option<String
     Some("strictVariantUnavailable".to_string())
 }
 
+fn glyph_outline_is_strict(outline: &LayerGlyphOutlinePaint) -> bool {
+    glyph_run_is_strict(&outline.diagnostics)
+        && !outline.paths.is_empty()
+        && outline.paint_style.is_fill_only_glyph_replay()
+        && match outline.payload_kind {
+            GlyphOutlinePayloadKind::MonochromeFill => outline.stroke.is_none(),
+            GlyphOutlinePayloadKind::MonochromeFillStroke => outline
+                .stroke
+                .as_ref()
+                .is_some_and(|stroke| stroke.is_strict_subset()),
+        }
+}
+
+fn glyph_outline_fallback_reason(outline: &LayerGlyphOutlinePaint) -> Option<String> {
+    if glyph_outline_is_strict(outline) {
+        return None;
+    }
+    if outline.paths.is_empty() {
+        return Some("emptyGlyphOutline".to_string());
+    }
+    if !outline.paint_style.is_fill_only_glyph_replay() {
+        return Some("unsupportedPaintEffect".to_string());
+    }
+    match outline.payload_kind {
+        GlyphOutlinePayloadKind::MonochromeFill if outline.stroke.is_some() => {
+            return Some("unexpectedOutlineStroke".to_string());
+        }
+        GlyphOutlinePayloadKind::MonochromeFillStroke
+            if !outline
+                .stroke
+                .as_ref()
+                .is_some_and(|stroke| stroke.is_strict_subset()) =>
+        {
+            return Some("unsupportedOutlineStroke".to_string());
+        }
+        _ => {}
+    }
+    glyph_run_fallback_reason(&outline.diagnostics)
+}
+
 fn line_break_risk_for_run(leaf_path: &str, run: &TextRunNode) -> Option<TextV2LineBreakRisk> {
     let mut reasons = Vec::new();
     if run.char_overlap.is_some() {
@@ -579,13 +653,14 @@ fn line_break_risk_for_run(leaf_path: &str, run: &TextRunNode) -> Option<TextV2L
 mod tests {
     use super::*;
     use crate::paint::{
-        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphRange,
-        GlyphRunOrientation, LayerAffineTransform, LayerGlyphRunPaint, LayerNode, LayerPoint,
+        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
+        GlyphOutlinePayloadKind, GlyphRange, GlyphRunOrientation, LayerAffineTransform,
+        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
         PaintTextStyle, ScriptTag, ShapeKey, ShapingEngineId, TextDirection, TextSourceId,
         TextSourceRange, TextSourceSpan, WritingMode,
     };
     use crate::renderer::render_tree::BoundingBox;
-    use crate::renderer::TextStyle;
+    use crate::renderer::{PathCommand, TextStyle};
 
     fn text_run(text: &str) -> TextRunNode {
         TextRunNode {
@@ -715,6 +790,75 @@ mod tests {
         }
     }
 
+    fn glyph_outline_op() -> PaintOp {
+        PaintOp::GlyphOutline {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            outline: Box::new(LayerGlyphOutlinePaint {
+                source: TextSourceSpan {
+                    id: TextSourceId(0),
+                    utf8_range: TextSourceRange::new(0, 1),
+                    utf16_range: TextSourceRange::new(0, 1),
+                    stable_source_key: None,
+                },
+                variant: {
+                    let mut variant = crate::paint::PaintVariantMeta::text_run_default("text-0");
+                    variant.variant_id = "glyphOutline".to_string();
+                    variant.variant_kind = TextVariantKind::GlyphOutline;
+                    variant.is_default_fallback = false;
+                    variant.requires = vec![
+                        "text.glyphOutline".to_string(),
+                        "text.glyphOutline.strictSidecar".to_string(),
+                    ];
+                    variant.quality = Some(TextVariantQuality::Exact);
+                    variant.anchor_op_id = Some("text-0".to_string());
+                    variant
+                },
+                payload_kind: GlyphOutlinePayloadKind::MonochromeFill,
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 12.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                paths: vec![LayerGlyphOutlinePath {
+                    glyph_id: 42,
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    glyph_range: GlyphRange::new(0, 1),
+                    commands: vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(8.0, 0.0),
+                        PathCommand::ClosePath,
+                    ],
+                    fill_rule: GlyphOutlineFillRule::NonZero,
+                }],
+                stroke: None,
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            }),
+        }
+    }
+
     #[test]
     fn reports_strict_glyph_slot_without_validation_errors() {
         let tree = PageLayerTree::new(
@@ -733,6 +877,56 @@ mod tests {
         assert_eq!(diagnostics.slot_diagnostics.len(), 1);
         assert!(diagnostics.slot_diagnostics[0].strict_variant_available);
         assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn reports_strict_glyph_outline_slot_without_validation_errors() {
+        let tree = PageLayerTree::new(
+            100.0,
+            100.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+                None,
+                vec![text_op("A"), glyph_outline_op()],
+            ),
+        );
+        let diagnostics = TextV2Diagnostics::from_layer_tree_with_profile(
+            &tree,
+            TextV2CompatibilityProfile::FallbackFreeStrict,
+        );
+        assert_eq!(diagnostics.slot_diagnostics.len(), 1);
+        assert!(diagnostics.slot_diagnostics[0].strict_variant_available);
+        assert_eq!(
+            diagnostics.slot_diagnostics[0].variants[0].variant_kind,
+            "glyphOutline"
+        );
+        assert!(!diagnostics.has_errors());
+    }
+
+    #[test]
+    fn reports_glyph_outline_fallback_reason_when_payload_is_not_strict() {
+        let mut op = glyph_outline_op();
+        if let PaintOp::GlyphOutline { outline, .. } = &mut op {
+            outline.paths.clear();
+        }
+        let tree = PageLayerTree::new(
+            100.0,
+            100.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 100.0, 100.0),
+                None,
+                vec![text_op("A"), op],
+            ),
+        );
+        let diagnostics = TextV2Diagnostics::from_layer_tree_with_profile(
+            &tree,
+            TextV2CompatibilityProfile::FallbackFreeStrict,
+        );
+        assert!(diagnostics.has_errors());
+        assert_eq!(
+            diagnostics.slot_diagnostics[0].fallback_reason.as_deref(),
+            Some("emptyGlyphOutline")
+        );
     }
 
     #[test]

--- a/src/paint/text_variants.rs
+++ b/src/paint/text_variants.rs
@@ -267,6 +267,9 @@ fn validate_sidecar_anchor(
             leaf: leaf_path.to_string(),
         });
     };
+    // Schema v1 does not assign an explicit op id to the fallback TextRun.
+    // The equivalence group is the exported paint-order slot id, so P14
+    // sidecars anchor to that slot until per-op ids exist.
     if anchor_op_id != &variant.equivalence_group {
         return Err(TextVariantScopeError::InvalidSidecarAnchor {
             equivalence_group: variant.equivalence_group.clone(),

--- a/src/paint/text_variants.rs
+++ b/src/paint/text_variants.rs
@@ -7,7 +7,9 @@
 use std::collections::{HashMap, HashSet};
 use std::fmt;
 
-use crate::paint::{LayerNode, LayerNodeKind, PageLayerTree, PaintOp, PaintVariantMeta};
+use crate::paint::{
+    LayerNode, LayerNodeKind, PageLayerTree, PaintOp, PaintVariantMeta, TextVariantKind,
+};
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub enum TextVariantScopeError {
@@ -18,6 +20,17 @@ pub enum TextVariantScopeError {
     },
     MissingDefaultFallback {
         equivalence_group: String,
+        leaf: String,
+    },
+    MissingSidecarAnchorOpId {
+        equivalence_group: String,
+        variant_id: String,
+        leaf: String,
+    },
+    InvalidSidecarAnchor {
+        equivalence_group: String,
+        variant_id: String,
+        anchor_op_id: String,
         leaf: String,
     },
     EmptyVariantSet {
@@ -57,6 +70,23 @@ impl fmt::Display for TextVariantScopeError {
             } => write!(
                 f,
                 "text variant group `{equivalence_group}` in leaf `{leaf}` has no default fallback"
+            ),
+            Self::MissingSidecarAnchorOpId {
+                equivalence_group,
+                variant_id,
+                leaf,
+            } => write!(
+                f,
+                "text sidecar variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` has no anchorOpId"
+            ),
+            Self::InvalidSidecarAnchor {
+                equivalence_group,
+                variant_id,
+                anchor_op_id,
+                leaf,
+            } => write!(
+                f,
+                "text sidecar variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` anchors `{anchor_op_id}`, expected the same paint-order slot"
             ),
             Self::EmptyVariantSet {
                 equivalence_group,
@@ -140,6 +170,7 @@ fn validate_leaf(
         let Some(variant) = op_variant(op) else {
             continue;
         };
+        validate_sidecar_anchor(&variant, &leaf_path)?;
         if let Some(first_leaf) = group_leaf_paths.get(&variant.equivalence_group) {
             if first_leaf != &leaf_path {
                 return Err(TextVariantScopeError::CrossLeafGroup {
@@ -217,8 +248,34 @@ fn validate_leaf(
 fn op_variant(op: &PaintOp) -> Option<PaintVariantMeta> {
     match op {
         PaintOp::GlyphRun { run, .. } => Some(run.variant.clone()),
+        PaintOp::GlyphOutline { outline, .. } => Some(outline.variant.clone()),
         _ => None,
     }
+}
+
+fn validate_sidecar_anchor(
+    variant: &PaintVariantMeta,
+    leaf_path: &str,
+) -> Result<(), TextVariantScopeError> {
+    if variant.variant_kind != TextVariantKind::GlyphOutline {
+        return Ok(());
+    }
+    let Some(anchor_op_id) = &variant.anchor_op_id else {
+        return Err(TextVariantScopeError::MissingSidecarAnchorOpId {
+            equivalence_group: variant.equivalence_group.clone(),
+            variant_id: variant.variant_id.clone(),
+            leaf: leaf_path.to_string(),
+        });
+    };
+    if anchor_op_id != &variant.equivalence_group {
+        return Err(TextVariantScopeError::InvalidSidecarAnchor {
+            equivalence_group: variant.equivalence_group.clone(),
+            variant_id: variant.variant_id.clone(),
+            anchor_op_id: anchor_op_id.clone(),
+            leaf: leaf_path.to_string(),
+        });
+    }
+    Ok(())
 }
 
 #[cfg(test)]
@@ -226,15 +283,16 @@ mod tests {
     use super::*;
     use crate::paint::resources::ResourceArena;
     use crate::paint::{
-        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphRange,
-        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, LayerAffineTransform,
-        LayerGlyphRunPaint, LayerNode, LayerOutputOptions, LayerPoint, PaintTextStyle,
-        RenderProfile, ScriptTag, ShapeKey, ShapingEngineId, TextDirection, TextSourceId,
-        TextSourceRange, TextSourceSpan, TextSourceTable, TextVariantKind, TextVariantQuality,
-        WritingMode,
+        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
+        GlyphOutlinePayloadKind, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
+        GlyphRunReplayEligibility, LayerAffineTransform, LayerGlyphOutlinePaint,
+        LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerOutputOptions, LayerPoint,
+        PaintTextStyle, RenderProfile, ScriptTag, ShapeKey, ShapingEngineId, TextDirection,
+        TextSourceId, TextSourceRange, TextSourceSpan, TextSourceTable, TextVariantKind,
+        TextVariantQuality, WritingMode,
     };
     use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
-    use crate::renderer::TextStyle;
+    use crate::renderer::{PathCommand, TextStyle};
 
     fn bbox() -> BoundingBox {
         BoundingBox::new(0.0, 0.0, 10.0, 10.0)
@@ -318,6 +376,58 @@ mod tests {
                 writing_mode: WritingMode::HorizontalTb,
                 orientation: GlyphRunOrientation::Horizontal,
                 glyph_transforms: None,
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            }),
+        }
+    }
+
+    fn glyph_outline_op(variant: PaintVariantMeta) -> PaintOp {
+        PaintOp::GlyphOutline {
+            bbox: bbox(),
+            outline: Box::new(LayerGlyphOutlinePaint {
+                source: TextSourceSpan {
+                    id: TextSourceId(0),
+                    utf8_range: TextSourceRange::new(0, 1),
+                    utf16_range: TextSourceRange::new(0, 1),
+                    stable_source_key: None,
+                },
+                variant,
+                payload_kind: GlyphOutlinePayloadKind::MonochromeFill,
+                paint_style: PaintTextStyle::from(&TextStyle::default()),
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 0.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                paths: vec![LayerGlyphOutlinePath {
+                    glyph_id: 42,
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    glyph_range: GlyphRange::new(0, 1),
+                    commands: vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(8.0, 0.0),
+                        PathCommand::ClosePath,
+                    ],
+                    fill_rule: GlyphOutlineFillRule::NonZero,
+                }],
+                stroke: None,
                 diagnostics: GlyphRunDiagnostics {
                     quality: TextVariantQuality::Exact,
                     replay_eligibility: GlyphRunReplayEligibility::Portable,
@@ -439,6 +549,92 @@ mod tests {
         assert!(matches!(
             validate_text_variant_scope(&tree),
             Err(TextVariantScopeError::MissingDefaultFallback { .. })
+        ));
+    }
+
+    #[test]
+    fn accepts_glyph_outline_sidecar_anchored_to_same_slot() {
+        let mut outline = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphOutline".to_string(),
+            variant_kind: TextVariantKind::GlyphOutline,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: false,
+            requires: vec!["text.glyphOutline".to_string()],
+            quality: Some(TextVariantQuality::Exact),
+            anchor_op_id: Some("text-1".to_string()),
+            local_paint_order: Some(0),
+        };
+        let single_part_tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![text_op(), glyph_outline_op(outline.clone())],
+        ));
+        validate_text_variant_scope(&single_part_tree).unwrap();
+
+        outline.part_count = 2;
+        let mut part_1 = outline.clone();
+        part_1.part_index = 1;
+        let multipart_tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![
+                text_op(),
+                glyph_outline_op(outline),
+                glyph_outline_op(part_1),
+            ],
+        ));
+        validate_text_variant_scope(&multipart_tree).unwrap();
+    }
+
+    #[test]
+    fn rejects_glyph_outline_without_anchor() {
+        let outline = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphOutline".to_string(),
+            variant_kind: TextVariantKind::GlyphOutline,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: false,
+            requires: vec!["text.glyphOutline".to_string()],
+            quality: Some(TextVariantQuality::Exact),
+            anchor_op_id: None,
+            local_paint_order: None,
+        };
+        let tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![text_op(), glyph_outline_op(outline)],
+        ));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::MissingSidecarAnchorOpId { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_glyph_outline_anchored_to_different_slot() {
+        let outline = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphOutline".to_string(),
+            variant_kind: TextVariantKind::GlyphOutline,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: false,
+            requires: vec!["text.glyphOutline".to_string()],
+            quality: Some(TextVariantQuality::Exact),
+            anchor_op_id: Some("text-2".to_string()),
+            local_paint_order: None,
+        };
+        let tree = tree(LayerNode::leaf(
+            bbox(),
+            None,
+            vec![text_op(), glyph_outline_op(outline)],
+        ));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::InvalidSidecarAnchor { .. })
         ));
     }
 }

--- a/src/renderer/canvas.rs
+++ b/src/renderer/canvas.rs
@@ -248,6 +248,7 @@ impl CanvasRenderer {
                         }
                         PaintOp::FootnoteMarker { .. }
                         | PaintOp::GlyphRun { .. }
+                        | PaintOp::GlyphOutline { .. }
                         | PaintOp::CharOverlap { .. }
                         | PaintOp::TextControlMark { .. }
                         | PaintOp::TabLeader { .. }

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -139,6 +139,7 @@ pub enum VariantRejectReason {
     GlyphOutlineUnsupported,
     UnsupportedOutlinePayload,
     GlyphOutlineStrokeStyleUnsupported,
+    PositionAdjustedNotAllowed,
     PositionAdjustedResidualTooLarge,
 }
 
@@ -159,6 +160,7 @@ impl VariantRejectReason {
             Self::GlyphOutlineUnsupported => "glyphOutlineUnsupported",
             Self::UnsupportedOutlinePayload => "unsupportedOutlinePayload",
             Self::GlyphOutlineStrokeStyleUnsupported => "glyphOutlineStrokeStyleUnsupported",
+            Self::PositionAdjustedNotAllowed => "positionAdjustedNotAllowed",
             Self::PositionAdjustedResidualTooLarge => "positionAdjustedResidualTooLarge",
         }
     }
@@ -221,7 +223,8 @@ pub fn analyze_text_variant_selection(
     options: TextVariantSelectionOptions,
 ) -> Vec<TextVariantSelectionReport> {
     let mut groups = BTreeMap::<String, TextVariantGroupState>::new();
-    collect_text_variant_groups(&tree.root, &mut groups);
+    let mut next_order = 0usize;
+    collect_text_variant_groups(&tree.root, &mut groups, &mut next_order);
     groups
         .into_iter()
         .map(|(equivalence_group, group)| group.finish(equivalence_group, options))
@@ -240,37 +243,43 @@ impl TextVariantGroupState {
         equivalence_group: String,
         options: TextVariantSelectionOptions,
     ) -> TextVariantSelectionReport {
-        let mut candidates = self.variants.into_values().collect::<Vec<_>>();
-        candidates.sort_by_key(|candidate| candidate.order);
-        let rejected_variants = candidates
-            .iter()
-            .filter_map(|candidate| {
+        let mut evaluated = self
+            .variants
+            .into_values()
+            .map(|candidate| {
                 let reasons = candidate.reject_reasons(options);
-                (!reasons.is_empty()).then(|| TextVariantRejectReport {
-                    variant_id: candidate.variant_id.clone(),
-                    variant_kind: candidate.variant_kind,
-                    reasons,
+                EvaluatedTextVariantCandidate { candidate, reasons }
+            })
+            .collect::<Vec<_>>();
+        evaluated.sort_by_key(|evaluated| evaluated.candidate.order);
+        let rejected_variants = evaluated
+            .iter()
+            .filter_map(|evaluated| {
+                (!evaluated.reasons.is_empty()).then(|| TextVariantRejectReport {
+                    variant_id: evaluated.candidate.variant_id.clone(),
+                    variant_kind: evaluated.candidate.variant_kind,
+                    reasons: evaluated.reasons.clone(),
                 })
             })
             .collect::<Vec<_>>();
         let outline_selection = options
             .prefer_strict_outline
             .then(|| {
-                candidates.iter().find(|candidate| {
-                    candidate.variant_kind == TextVariantKind::GlyphOutline
-                        && candidate.reject_reasons(options).is_empty()
+                evaluated.iter().find(|evaluated| {
+                    evaluated.candidate.variant_kind == TextVariantKind::GlyphOutline
+                        && evaluated.reasons.is_empty()
                 })
             })
             .flatten();
-        let glyph_selection = candidates.iter().find(|candidate| {
-            candidate.variant_kind == TextVariantKind::GlyphRun
-                && candidate.reject_reasons(options).is_empty()
+        let glyph_selection = evaluated.iter().find(|evaluated| {
+            evaluated.candidate.variant_kind == TextVariantKind::GlyphRun
+                && evaluated.reasons.is_empty()
         });
         let fallback_outline_selection = (!options.prefer_strict_outline)
             .then(|| {
-                candidates.iter().find(|candidate| {
-                    candidate.variant_kind == TextVariantKind::GlyphOutline
-                        && candidate.reject_reasons(options).is_empty()
+                evaluated.iter().find(|evaluated| {
+                    evaluated.candidate.variant_kind == TextVariantKind::GlyphOutline
+                        && evaluated.reasons.is_empty()
                 })
             })
             .flatten();
@@ -281,15 +290,9 @@ impl TextVariantGroupState {
             return TextVariantSelectionReport {
                 backend: options.backend,
                 equivalence_group,
-                selected_variant_id: Some(selected.variant_id.clone()),
-                selected_variant_kind: Some(selected.variant_kind),
-                selected_reason: match selected.variant_kind {
-                    TextVariantKind::GlyphRun => VariantSelectedReason::GlyphRunStrictEligible,
-                    TextVariantKind::GlyphOutline => {
-                        VariantSelectedReason::GlyphOutlineStrictProfile
-                    }
-                    TextVariantKind::TextRun => VariantSelectedReason::DefaultTextRunFallback,
-                },
+                selected_variant_id: Some(selected.candidate.variant_id.clone()),
+                selected_variant_kind: Some(selected.candidate.variant_kind),
+                selected_reason: selected_reason_for_variant(selected.candidate.variant_kind),
                 fallback_required: false,
                 rejected_variants,
             };
@@ -306,6 +309,22 @@ impl TextVariantGroupState {
             },
             fallback_required: true,
             rejected_variants,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct EvaluatedTextVariantCandidate {
+    candidate: TextVariantCandidate,
+    reasons: Vec<VariantRejectReason>,
+}
+
+fn selected_reason_for_variant(variant_kind: TextVariantKind) -> VariantSelectedReason {
+    match variant_kind {
+        TextVariantKind::GlyphRun => VariantSelectedReason::GlyphRunStrictEligible,
+        TextVariantKind::GlyphOutline => VariantSelectedReason::GlyphOutlineStrictProfile,
+        TextVariantKind::TextRun => {
+            unreachable!("TextRun fallback is tracked through fallback_present, not candidates")
         }
     }
 }
@@ -352,7 +371,9 @@ impl TextVariantCandidate {
         let mut reasons = BTreeSet::<VariantRejectReason>::new();
         self.collect_structure_reasons(&mut reasons);
         match self.variant_kind {
-            TextVariantKind::TextRun => {}
+            TextVariantKind::TextRun => {
+                unreachable!("TextRun fallback is tracked through fallback_present, not candidates")
+            }
             TextVariantKind::GlyphRun => {
                 if !matches!(
                     options.backend,
@@ -399,20 +420,19 @@ impl TextVariantCandidate {
 fn collect_text_variant_groups(
     node: &LayerNode,
     groups: &mut BTreeMap<String, TextVariantGroupState>,
+    next_order: &mut usize,
 ) {
     match &node.kind {
         LayerNodeKind::Group { children, .. } => {
             for child in children {
-                collect_text_variant_groups(child, groups);
+                collect_text_variant_groups(child, groups, next_order);
             }
         }
-        LayerNodeKind::ClipRect { child, .. } => collect_text_variant_groups(child, groups),
+        LayerNodeKind::ClipRect { child, .. } => {
+            collect_text_variant_groups(child, groups, next_order);
+        }
         LayerNodeKind::Leaf { ops } => {
             let fallback_present = ops.iter().any(|op| matches!(op, PaintOp::TextRun { .. }));
-            let mut order = groups
-                .values()
-                .map(|group| group.variants.len())
-                .sum::<usize>();
             for op in ops {
                 match op {
                     PaintOp::GlyphRun { run, .. } => {
@@ -424,10 +444,10 @@ fn collect_text_variant_groups(
                             .variants
                             .entry(run.variant.variant_id.clone())
                             .or_insert_with(|| {
-                                let next_order = order;
-                                order = order.saturating_add(1);
+                                let order = *next_order;
+                                *next_order = (*next_order).saturating_add(1);
                                 TextVariantCandidate::new(
-                                    next_order,
+                                    order,
                                     run.variant.variant_id.clone(),
                                     run.variant.variant_kind,
                                 )
@@ -443,10 +463,10 @@ fn collect_text_variant_groups(
                             .variants
                             .entry(outline.variant.variant_id.clone())
                             .or_insert_with(|| {
-                                let next_order = order;
-                                order = order.saturating_add(1);
+                                let order = *next_order;
+                                *next_order = (*next_order).saturating_add(1);
                                 TextVariantCandidate::new(
-                                    next_order,
+                                    order,
                                     outline.variant.variant_id.clone(),
                                     outline.variant.variant_kind,
                                 )
@@ -471,37 +491,7 @@ fn collect_glyph_run_reject_reasons(
     if !matches!(run.orientation, GlyphRunOrientation::Horizontal) {
         reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
     }
-    match run.diagnostics.replay_eligibility {
-        GlyphRunReplayEligibility::Portable => {}
-        GlyphRunReplayEligibility::ConditionalExternalFont => {
-            reasons.insert(VariantRejectReason::ExternalFontNotVerified);
-        }
-        GlyphRunReplayEligibility::LocalDiagnosticOnly
-        | GlyphRunReplayEligibility::NotReplayable => {
-            reasons.insert(VariantRejectReason::FontNotPortable);
-        }
-    }
-    match run.diagnostics.quality {
-        TextVariantQuality::Exact => {}
-        TextVariantQuality::PositionAdjusted
-            if options.allow_position_adjusted
-                && run.diagnostics.max_residual_after_adjustment_px
-                    <= options.max_position_adjusted_residual_px => {}
-        TextVariantQuality::PositionAdjusted => {
-            reasons.insert(VariantRejectReason::PositionAdjustedResidualTooLarge);
-        }
-        TextVariantQuality::Approximate
-        | TextVariantQuality::DiagnosticOnly
-        | TextVariantQuality::Omitted => {
-            reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
-        }
-    }
-    if run.diagnostics.missing_glyph_count > 0 {
-        reasons.insert(VariantRejectReason::MissingGlyph);
-    }
-    if run.diagnostics.cluster_mismatch_count > 0 {
-        reasons.insert(VariantRejectReason::ClusterMismatch);
-    }
+    collect_text_variant_diagnostics_reject_reasons(&run.diagnostics, options, reasons);
     if run
         .glyph_ids
         .iter()
@@ -513,7 +503,7 @@ fn collect_glyph_run_reject_reasons(
 
 fn collect_glyph_outline_reject_reasons(
     outline: &LayerGlyphOutlinePaint,
-    _options: TextVariantSelectionOptions,
+    options: TextVariantSelectionOptions,
     reasons: &mut BTreeSet<VariantRejectReason>,
 ) {
     if outline.paths.is_empty() {
@@ -538,32 +528,49 @@ fn collect_glyph_outline_reject_reasons(
             }
         }
     }
-    collect_glyph_run_reject_reasons_for_outline_diagnostics(outline, reasons);
+    collect_text_variant_diagnostics_reject_reasons(&outline.diagnostics, options, reasons);
 }
 
-fn collect_glyph_run_reject_reasons_for_outline_diagnostics(
-    outline: &LayerGlyphOutlinePaint,
+fn collect_text_variant_diagnostics_reject_reasons(
+    diagnostics: &crate::paint::GlyphRunDiagnostics,
+    options: TextVariantSelectionOptions,
     reasons: &mut BTreeSet<VariantRejectReason>,
 ) {
-    if !matches!(
-        outline.diagnostics.replay_eligibility,
-        GlyphRunReplayEligibility::Portable | GlyphRunReplayEligibility::ConditionalExternalFont
-    ) {
-        reasons.insert(VariantRejectReason::FontNotPortable);
+    match diagnostics.replay_eligibility {
+        GlyphRunReplayEligibility::Portable => {}
+        GlyphRunReplayEligibility::ConditionalExternalFont => {
+            reasons.insert(VariantRejectReason::ExternalFontNotVerified);
+        }
+        GlyphRunReplayEligibility::LocalDiagnosticOnly
+        | GlyphRunReplayEligibility::NotReplayable => {
+            reasons.insert(VariantRejectReason::FontNotPortable);
+        }
     }
-    if matches!(
-        outline.diagnostics.quality,
+    match diagnostics.quality {
+        TextVariantQuality::Exact => {}
+        TextVariantQuality::PositionAdjusted if !options.allow_position_adjusted => {
+            reasons.insert(VariantRejectReason::PositionAdjustedNotAllowed);
+        }
+        TextVariantQuality::PositionAdjusted
+            if diagnostics.max_residual_after_adjustment_px
+                <= options.max_position_adjusted_residual_px => {}
+        TextVariantQuality::PositionAdjusted => {
+            reasons.insert(VariantRejectReason::PositionAdjustedResidualTooLarge);
+        }
         TextVariantQuality::Approximate
-            | TextVariantQuality::DiagnosticOnly
-            | TextVariantQuality::Omitted
-    ) {
-        reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+        | TextVariantQuality::DiagnosticOnly
+        | TextVariantQuality::Omitted => {
+            reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+        }
     }
-    if outline.diagnostics.missing_glyph_count > 0 {
+    if diagnostics.missing_glyph_count > 0 {
         reasons.insert(VariantRejectReason::MissingGlyph);
     }
-    if outline.diagnostics.cluster_mismatch_count > 0 {
+    if diagnostics.cluster_mismatch_count > 0 {
         reasons.insert(VariantRejectReason::ClusterMismatch);
+    }
+    if diagnostics.used_fallback_font_count > 0 {
+        reasons.insert(VariantRejectReason::FontNotPortable);
     }
 }
 
@@ -851,6 +858,28 @@ mod tests {
     }
 
     #[test]
+    fn canvaskit_can_disallow_position_adjusted_variants() {
+        let mut diagnostics = diagnostics();
+        diagnostics.quality = TextVariantQuality::PositionAdjusted;
+        diagnostics.max_residual_after_adjustment_px = 0.0;
+        let rejected = first_report(
+            vec![text_op(), glyph_run(diagnostics, 42)],
+            TextVariantSelectionOptions {
+                allow_position_adjusted: false,
+                ..TextVariantSelectionOptions::canvaskit()
+            },
+        );
+        assert_eq!(
+            rejected.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert_eq!(
+            rejected.rejected_variants[0].reasons,
+            vec![VariantRejectReason::PositionAdjustedNotAllowed]
+        );
+    }
+
+    #[test]
     fn strict_outline_profile_can_select_glyph_outline() {
         let report = first_report(
             vec![text_op(), glyph_run(diagnostics(), 42), glyph_outline(None)],
@@ -861,6 +890,23 @@ mod tests {
             report.selected_reason,
             VariantSelectedReason::GlyphOutlineStrictProfile
         );
+    }
+
+    #[test]
+    fn glyph_outline_uses_position_adjusted_residual_gate() {
+        let mut outline = glyph_outline(None);
+        if let PaintOp::GlyphOutline { outline, .. } = &mut outline {
+            outline.diagnostics.quality = TextVariantQuality::PositionAdjusted;
+            outline.diagnostics.max_residual_after_adjustment_px = 0.5;
+        }
+        let report = first_report(
+            vec![text_op(), outline],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::PositionAdjustedResidualTooLarge));
     }
 
     #[test]
@@ -875,6 +921,28 @@ mod tests {
                     cap: GlyphOutlineStrokeCap::Butt,
                     miter_limit: 2.0,
                     paint_order: GlyphOutlinePaintOrder::FillThenStroke,
+                })),
+            ],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::GlyphOutlineStrokeStyleUnsupported));
+    }
+
+    #[test]
+    fn outline_stroke_payload_rejects_fill_only_paint_order() {
+        let report = first_report(
+            vec![
+                text_op(),
+                glyph_outline(Some(GlyphOutlineStrokeStyle {
+                    color: 0x00000000,
+                    width: 1.0,
+                    join: GlyphOutlineStrokeJoin::Miter,
+                    cap: GlyphOutlineStrokeCap::Butt,
+                    miter_limit: 2.0,
+                    paint_order: GlyphOutlinePaintOrder::FillOnly,
                 })),
             ],
             TextVariantSelectionOptions::canvaskit_strict_outline(),

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -254,12 +254,11 @@ impl TextVariantGroupState {
         evaluated.sort_by_key(|evaluated| evaluated.candidate.order);
         let rejected_variants = evaluated
             .iter()
-            .filter_map(|evaluated| {
-                (!evaluated.reasons.is_empty()).then(|| TextVariantRejectReport {
-                    variant_id: evaluated.candidate.variant_id.clone(),
-                    variant_kind: evaluated.candidate.variant_kind,
-                    reasons: evaluated.reasons.clone(),
-                })
+            .filter(|evaluated| !evaluated.reasons.is_empty())
+            .map(|evaluated| TextVariantRejectReport {
+                variant_id: evaluated.candidate.variant_id.clone(),
+                variant_kind: evaluated.candidate.variant_kind,
+                reasons: evaluated.reasons.clone(),
             })
             .collect::<Vec<_>>();
         let outline_selection = options

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -1,6 +1,11 @@
 use crate::error::HwpError;
 use crate::model::ColorRef;
-use crate::paint::PageLayerTree;
+use crate::paint::{
+    GlyphOutlinePayloadKind, GlyphRunOrientation, GlyphRunReplayEligibility,
+    LayerGlyphOutlinePaint, LayerGlyphRunPaint, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
+    TextVariantKind, TextVariantQuality,
+};
+use std::collections::{BTreeMap, BTreeSet};
 
 pub type LayerRenderResult<T> = Result<T, HwpError>;
 
@@ -78,4 +83,838 @@ pub trait LayerRasterRenderer {
         tree: &PageLayerTree,
         options: RasterRenderOptions,
     ) -> LayerRenderResult<RasterRenderOutput>;
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariantSelectionBackend {
+    NativeSkia,
+    CanvasKit,
+    Canvas2D,
+    Svg,
+}
+
+impl VariantSelectionBackend {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::NativeSkia => "nativeSkia",
+            Self::CanvasKit => "canvasKit",
+            Self::Canvas2D => "canvas2d",
+            Self::Svg => "svg",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VariantSelectedReason {
+    GlyphRunStrictEligible,
+    GlyphOutlineStrictProfile,
+    DefaultTextRunFallback,
+    NoSupportedVariant,
+}
+
+impl VariantSelectedReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::GlyphRunStrictEligible => "glyphRunStrictEligible",
+            Self::GlyphOutlineStrictProfile => "glyphOutlineStrictProfile",
+            Self::DefaultTextRunFallback => "defaultTextRunFallback",
+            Self::NoSupportedVariant => "noSupportedVariant",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, PartialOrd, Ord)]
+pub enum VariantRejectReason {
+    BackendDoesNotSupportVariant,
+    FontNotPortable,
+    ExternalFontNotVerified,
+    GlyphIdOutOfRange,
+    MissingGlyph,
+    ClusterMismatch,
+    UnsupportedPaintEffect,
+    IncompleteVariantSet,
+    VariantPartCountMismatch,
+    VariantDuplicatePart,
+    VariantPartsIncomplete,
+    GlyphOutlineUnsupported,
+    UnsupportedOutlinePayload,
+    GlyphOutlineStrokeStyleUnsupported,
+    PositionAdjustedResidualTooLarge,
+}
+
+impl VariantRejectReason {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::BackendDoesNotSupportVariant => "backendDoesNotSupportVariant",
+            Self::FontNotPortable => "fontNotPortable",
+            Self::ExternalFontNotVerified => "externalFontNotVerified",
+            Self::GlyphIdOutOfRange => "glyphIdOutOfRange",
+            Self::MissingGlyph => "missingGlyph",
+            Self::ClusterMismatch => "clusterMismatch",
+            Self::UnsupportedPaintEffect => "unsupportedPaintEffect",
+            Self::IncompleteVariantSet => "incompleteVariantSet",
+            Self::VariantPartCountMismatch => "variantPartCountMismatch",
+            Self::VariantDuplicatePart => "variantDuplicatePart",
+            Self::VariantPartsIncomplete => "variantPartsIncomplete",
+            Self::GlyphOutlineUnsupported => "glyphOutlineUnsupported",
+            Self::UnsupportedOutlinePayload => "unsupportedOutlinePayload",
+            Self::GlyphOutlineStrokeStyleUnsupported => "glyphOutlineStrokeStyleUnsupported",
+            Self::PositionAdjustedResidualTooLarge => "positionAdjustedResidualTooLarge",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub struct TextVariantSelectionOptions {
+    pub backend: VariantSelectionBackend,
+    pub prefer_strict_outline: bool,
+    pub allow_position_adjusted: bool,
+    pub max_position_adjusted_residual_px: f64,
+    pub max_canvas_glyph_id: u32,
+}
+
+impl Default for TextVariantSelectionOptions {
+    fn default() -> Self {
+        Self::canvaskit()
+    }
+}
+
+impl TextVariantSelectionOptions {
+    pub fn canvaskit() -> Self {
+        Self {
+            backend: VariantSelectionBackend::CanvasKit,
+            prefer_strict_outline: false,
+            allow_position_adjusted: true,
+            max_position_adjusted_residual_px: 0.25,
+            max_canvas_glyph_id: u16::MAX as u32,
+        }
+    }
+
+    pub fn canvaskit_strict_outline() -> Self {
+        Self {
+            prefer_strict_outline: true,
+            ..Self::canvaskit()
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextVariantSelectionReport {
+    pub backend: VariantSelectionBackend,
+    pub equivalence_group: String,
+    pub selected_variant_id: Option<String>,
+    pub selected_variant_kind: Option<TextVariantKind>,
+    pub selected_reason: VariantSelectedReason,
+    pub fallback_required: bool,
+    pub rejected_variants: Vec<TextVariantRejectReport>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct TextVariantRejectReport {
+    pub variant_id: String,
+    pub variant_kind: TextVariantKind,
+    pub reasons: Vec<VariantRejectReason>,
+}
+
+pub fn analyze_text_variant_selection(
+    tree: &PageLayerTree,
+    options: TextVariantSelectionOptions,
+) -> Vec<TextVariantSelectionReport> {
+    let mut groups = BTreeMap::<String, TextVariantGroupState>::new();
+    collect_text_variant_groups(&tree.root, &mut groups);
+    groups
+        .into_iter()
+        .map(|(equivalence_group, group)| group.finish(equivalence_group, options))
+        .collect()
+}
+
+#[derive(Debug, Default)]
+struct TextVariantGroupState {
+    fallback_present: bool,
+    variants: BTreeMap<String, TextVariantCandidate>,
+}
+
+impl TextVariantGroupState {
+    fn finish(
+        self,
+        equivalence_group: String,
+        options: TextVariantSelectionOptions,
+    ) -> TextVariantSelectionReport {
+        let mut candidates = self.variants.into_values().collect::<Vec<_>>();
+        candidates.sort_by_key(|candidate| candidate.order);
+        let rejected_variants = candidates
+            .iter()
+            .filter_map(|candidate| {
+                let reasons = candidate.reject_reasons(options);
+                (!reasons.is_empty()).then(|| TextVariantRejectReport {
+                    variant_id: candidate.variant_id.clone(),
+                    variant_kind: candidate.variant_kind,
+                    reasons,
+                })
+            })
+            .collect::<Vec<_>>();
+        let outline_selection = options
+            .prefer_strict_outline
+            .then(|| {
+                candidates.iter().find(|candidate| {
+                    candidate.variant_kind == TextVariantKind::GlyphOutline
+                        && candidate.reject_reasons(options).is_empty()
+                })
+            })
+            .flatten();
+        let glyph_selection = candidates.iter().find(|candidate| {
+            candidate.variant_kind == TextVariantKind::GlyphRun
+                && candidate.reject_reasons(options).is_empty()
+        });
+        let fallback_outline_selection = (!options.prefer_strict_outline)
+            .then(|| {
+                candidates.iter().find(|candidate| {
+                    candidate.variant_kind == TextVariantKind::GlyphOutline
+                        && candidate.reject_reasons(options).is_empty()
+                })
+            })
+            .flatten();
+        let selected = outline_selection
+            .or(glyph_selection)
+            .or(fallback_outline_selection);
+        if let Some(selected) = selected {
+            return TextVariantSelectionReport {
+                backend: options.backend,
+                equivalence_group,
+                selected_variant_id: Some(selected.variant_id.clone()),
+                selected_variant_kind: Some(selected.variant_kind),
+                selected_reason: match selected.variant_kind {
+                    TextVariantKind::GlyphRun => VariantSelectedReason::GlyphRunStrictEligible,
+                    TextVariantKind::GlyphOutline => {
+                        VariantSelectedReason::GlyphOutlineStrictProfile
+                    }
+                    TextVariantKind::TextRun => VariantSelectedReason::DefaultTextRunFallback,
+                },
+                fallback_required: false,
+                rejected_variants,
+            };
+        }
+        TextVariantSelectionReport {
+            backend: options.backend,
+            equivalence_group,
+            selected_variant_id: self.fallback_present.then(|| "textRun".to_string()),
+            selected_variant_kind: self.fallback_present.then_some(TextVariantKind::TextRun),
+            selected_reason: if self.fallback_present {
+                VariantSelectedReason::DefaultTextRunFallback
+            } else {
+                VariantSelectedReason::NoSupportedVariant
+            },
+            fallback_required: true,
+            rejected_variants,
+        }
+    }
+}
+
+#[derive(Debug)]
+struct TextVariantCandidate {
+    order: usize,
+    variant_id: String,
+    variant_kind: TextVariantKind,
+    part_counts: BTreeSet<u32>,
+    present_parts: BTreeSet<u32>,
+    duplicate_part: bool,
+    glyph_runs: Vec<LayerGlyphRunPaint>,
+    glyph_outlines: Vec<LayerGlyphOutlinePaint>,
+}
+
+impl TextVariantCandidate {
+    fn new(order: usize, variant_id: String, variant_kind: TextVariantKind) -> Self {
+        Self {
+            order,
+            variant_id,
+            variant_kind,
+            part_counts: BTreeSet::new(),
+            present_parts: BTreeSet::new(),
+            duplicate_part: false,
+            glyph_runs: Vec::new(),
+            glyph_outlines: Vec::new(),
+        }
+    }
+
+    fn add_glyph_run(&mut self, run: &LayerGlyphRunPaint) {
+        self.part_counts.insert(run.variant.part_count);
+        self.duplicate_part |= !self.present_parts.insert(run.variant.part_index);
+        self.glyph_runs.push(run.clone());
+    }
+
+    fn add_glyph_outline(&mut self, outline: &LayerGlyphOutlinePaint) {
+        self.part_counts.insert(outline.variant.part_count);
+        self.duplicate_part |= !self.present_parts.insert(outline.variant.part_index);
+        self.glyph_outlines.push(outline.clone());
+    }
+
+    fn reject_reasons(&self, options: TextVariantSelectionOptions) -> Vec<VariantRejectReason> {
+        let mut reasons = BTreeSet::<VariantRejectReason>::new();
+        self.collect_structure_reasons(&mut reasons);
+        match self.variant_kind {
+            TextVariantKind::TextRun => {}
+            TextVariantKind::GlyphRun => {
+                if !matches!(
+                    options.backend,
+                    VariantSelectionBackend::CanvasKit | VariantSelectionBackend::NativeSkia
+                ) {
+                    reasons.insert(VariantRejectReason::BackendDoesNotSupportVariant);
+                }
+                for run in &self.glyph_runs {
+                    collect_glyph_run_reject_reasons(run, options, &mut reasons);
+                }
+            }
+            TextVariantKind::GlyphOutline => {
+                if matches!(options.backend, VariantSelectionBackend::Canvas2D) {
+                    reasons.insert(VariantRejectReason::BackendDoesNotSupportVariant);
+                }
+                for outline in &self.glyph_outlines {
+                    collect_glyph_outline_reject_reasons(outline, options, &mut reasons);
+                }
+            }
+        }
+        reasons.into_iter().collect()
+    }
+
+    fn collect_structure_reasons(&self, reasons: &mut BTreeSet<VariantRejectReason>) {
+        if self.part_counts.is_empty() || self.part_counts.contains(&0) {
+            reasons.insert(VariantRejectReason::IncompleteVariantSet);
+        }
+        if self.part_counts.len() > 1 {
+            reasons.insert(VariantRejectReason::VariantPartCountMismatch);
+        }
+        if self.duplicate_part {
+            reasons.insert(VariantRejectReason::VariantDuplicatePart);
+        }
+        let expected = self.part_counts.iter().next().copied().unwrap_or_default();
+        if expected == 0
+            || self.present_parts.len() as u32 != expected
+            || !(0..expected).all(|index| self.present_parts.contains(&index))
+        {
+            reasons.insert(VariantRejectReason::VariantPartsIncomplete);
+        }
+    }
+}
+
+fn collect_text_variant_groups(
+    node: &LayerNode,
+    groups: &mut BTreeMap<String, TextVariantGroupState>,
+) {
+    match &node.kind {
+        LayerNodeKind::Group { children, .. } => {
+            for child in children {
+                collect_text_variant_groups(child, groups);
+            }
+        }
+        LayerNodeKind::ClipRect { child, .. } => collect_text_variant_groups(child, groups),
+        LayerNodeKind::Leaf { ops } => {
+            let fallback_present = ops.iter().any(|op| matches!(op, PaintOp::TextRun { .. }));
+            let mut order = groups
+                .values()
+                .map(|group| group.variants.len())
+                .sum::<usize>();
+            for op in ops {
+                match op {
+                    PaintOp::GlyphRun { run, .. } => {
+                        let group = groups
+                            .entry(run.variant.equivalence_group.clone())
+                            .or_default();
+                        group.fallback_present |= fallback_present;
+                        let candidate = group
+                            .variants
+                            .entry(run.variant.variant_id.clone())
+                            .or_insert_with(|| {
+                                let next_order = order;
+                                order = order.saturating_add(1);
+                                TextVariantCandidate::new(
+                                    next_order,
+                                    run.variant.variant_id.clone(),
+                                    run.variant.variant_kind,
+                                )
+                            });
+                        candidate.add_glyph_run(run);
+                    }
+                    PaintOp::GlyphOutline { outline, .. } => {
+                        let group = groups
+                            .entry(outline.variant.equivalence_group.clone())
+                            .or_default();
+                        group.fallback_present |= fallback_present;
+                        let candidate = group
+                            .variants
+                            .entry(outline.variant.variant_id.clone())
+                            .or_insert_with(|| {
+                                let next_order = order;
+                                order = order.saturating_add(1);
+                                TextVariantCandidate::new(
+                                    next_order,
+                                    outline.variant.variant_id.clone(),
+                                    outline.variant.variant_kind,
+                                )
+                            });
+                        candidate.add_glyph_outline(outline);
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+}
+
+fn collect_glyph_run_reject_reasons(
+    run: &LayerGlyphRunPaint,
+    options: TextVariantSelectionOptions,
+    reasons: &mut BTreeSet<VariantRejectReason>,
+) {
+    if !run.paint_style.is_fill_only_glyph_replay() {
+        reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+    }
+    if !matches!(run.orientation, GlyphRunOrientation::Horizontal) {
+        reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+    }
+    match run.diagnostics.replay_eligibility {
+        GlyphRunReplayEligibility::Portable => {}
+        GlyphRunReplayEligibility::ConditionalExternalFont => {
+            reasons.insert(VariantRejectReason::ExternalFontNotVerified);
+        }
+        GlyphRunReplayEligibility::LocalDiagnosticOnly
+        | GlyphRunReplayEligibility::NotReplayable => {
+            reasons.insert(VariantRejectReason::FontNotPortable);
+        }
+    }
+    match run.diagnostics.quality {
+        TextVariantQuality::Exact => {}
+        TextVariantQuality::PositionAdjusted
+            if options.allow_position_adjusted
+                && run.diagnostics.max_residual_after_adjustment_px
+                    <= options.max_position_adjusted_residual_px => {}
+        TextVariantQuality::PositionAdjusted => {
+            reasons.insert(VariantRejectReason::PositionAdjustedResidualTooLarge);
+        }
+        TextVariantQuality::Approximate
+        | TextVariantQuality::DiagnosticOnly
+        | TextVariantQuality::Omitted => {
+            reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+        }
+    }
+    if run.diagnostics.missing_glyph_count > 0 {
+        reasons.insert(VariantRejectReason::MissingGlyph);
+    }
+    if run.diagnostics.cluster_mismatch_count > 0 {
+        reasons.insert(VariantRejectReason::ClusterMismatch);
+    }
+    if run
+        .glyph_ids
+        .iter()
+        .any(|glyph_id| *glyph_id > options.max_canvas_glyph_id)
+    {
+        reasons.insert(VariantRejectReason::GlyphIdOutOfRange);
+    }
+}
+
+fn collect_glyph_outline_reject_reasons(
+    outline: &LayerGlyphOutlinePaint,
+    _options: TextVariantSelectionOptions,
+    reasons: &mut BTreeSet<VariantRejectReason>,
+) {
+    if outline.paths.is_empty() {
+        reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
+    }
+    if !outline.paint_style.is_fill_only_glyph_replay() {
+        reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+    }
+    match outline.payload_kind {
+        GlyphOutlinePayloadKind::MonochromeFill => {
+            if outline.stroke.is_some() {
+                reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
+            }
+        }
+        GlyphOutlinePayloadKind::MonochromeFillStroke => {
+            if !outline
+                .stroke
+                .as_ref()
+                .is_some_and(|stroke| stroke.is_strict_subset())
+            {
+                reasons.insert(VariantRejectReason::GlyphOutlineStrokeStyleUnsupported);
+            }
+        }
+    }
+    collect_glyph_run_reject_reasons_for_outline_diagnostics(outline, reasons);
+}
+
+fn collect_glyph_run_reject_reasons_for_outline_diagnostics(
+    outline: &LayerGlyphOutlinePaint,
+    reasons: &mut BTreeSet<VariantRejectReason>,
+) {
+    if !matches!(
+        outline.diagnostics.replay_eligibility,
+        GlyphRunReplayEligibility::Portable | GlyphRunReplayEligibility::ConditionalExternalFont
+    ) {
+        reasons.insert(VariantRejectReason::FontNotPortable);
+    }
+    if matches!(
+        outline.diagnostics.quality,
+        TextVariantQuality::Approximate
+            | TextVariantQuality::DiagnosticOnly
+            | TextVariantQuality::Omitted
+    ) {
+        reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
+    }
+    if outline.diagnostics.missing_glyph_count > 0 {
+        reasons.insert(VariantRejectReason::MissingGlyph);
+    }
+    if outline.diagnostics.cluster_mismatch_count > 0 {
+        reasons.insert(VariantRejectReason::ClusterMismatch);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::{
+        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
+        GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
+        GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
+        GlyphRunOrientation, LayerAffineTransform, LayerGlyphOutlinePath, LayerNode, LayerPoint,
+        PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey, ShapingEngineId, TextDirection,
+        TextRunPlacement, TextSourceId, TextSourceRange, TextSourceSpan, WritingMode,
+    };
+    use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
+    use crate::renderer::{PathCommand, TextStyle};
+
+    fn bbox() -> BoundingBox {
+        BoundingBox::new(0.0, 0.0, 24.0, 24.0)
+    }
+
+    fn text_op() -> PaintOp {
+        PaintOp::TextRun {
+            bbox: bbox(),
+            run: TextRunNode {
+                text: "A".to_string(),
+                style: TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 12.0,
+                field_marker: FieldMarkerType::None,
+            },
+        }
+    }
+
+    fn variant(kind: TextVariantKind, id: &str) -> PaintVariantMeta {
+        let mut variant = PaintVariantMeta::text_run_default("text-0");
+        variant.variant_id = id.to_string();
+        variant.variant_kind = kind;
+        variant.is_default_fallback = false;
+        variant.requires = match kind {
+            TextVariantKind::GlyphRun => {
+                vec!["fontResources".to_string(), "text.glyphRun".to_string()]
+            }
+            TextVariantKind::GlyphOutline => {
+                variant.anchor_op_id = Some("text-0".to_string());
+                vec![
+                    "text.glyphOutline".to_string(),
+                    "text.glyphOutline.strictSidecar".to_string(),
+                ]
+            }
+            TextVariantKind::TextRun => Vec::new(),
+        };
+        variant.quality = Some(TextVariantQuality::Exact);
+        variant
+    }
+
+    fn diagnostics() -> GlyphRunDiagnostics {
+        GlyphRunDiagnostics {
+            quality: TextVariantQuality::Exact,
+            replay_eligibility: GlyphRunReplayEligibility::Portable,
+            strict_visual_eligible: true,
+            max_origin_delta_px: 0.0,
+            max_advance_delta_px: 0.0,
+            max_residual_after_adjustment_px: 0.0,
+            cluster_mismatch_count: 0,
+            missing_glyph_count: 0,
+            used_fallback_font_count: 0,
+            reason: None,
+        }
+    }
+
+    fn source() -> TextSourceSpan {
+        TextSourceSpan {
+            id: TextSourceId(0),
+            utf8_range: TextSourceRange::new(0, 1),
+            utf16_range: TextSourceRange::new(0, 1),
+            stable_source_key: None,
+        }
+    }
+
+    fn placement() -> TextRunPlacement {
+        TextRunPlacement {
+            run_to_page: LayerAffineTransform {
+                a: 1.0,
+                b: 0.0,
+                c: 0.0,
+                d: 1.0,
+                e: 0.0,
+                f: 12.0,
+            },
+            baseline_y: 0.0,
+        }
+    }
+
+    fn shape_key() -> ShapeKey {
+        ShapeKey {
+            font_instance: FontInstanceKey {
+                face_key: FontFaceKey("face-0".to_string()),
+                size_px: 12.0,
+                variations: Vec::new(),
+                synthetic_bold: false,
+                synthetic_italic: false,
+            },
+            direction: TextDirection::Ltr,
+            writing_mode: WritingMode::HorizontalTb,
+            script: Some(ScriptTag("DFLT".to_string())),
+            language: None,
+            features: Vec::new(),
+            shaping_engine: ShapingEngineId("test".to_string()),
+            fallback_policy: FontFallbackPolicyId("none".to_string()),
+        }
+    }
+
+    fn glyph_run(mut diagnostics: GlyphRunDiagnostics, glyph_id: u32) -> PaintOp {
+        diagnostics.strict_visual_eligible = diagnostics.strict_visual_eligible
+            && diagnostics.missing_glyph_count == 0
+            && diagnostics.cluster_mismatch_count == 0;
+        PaintOp::GlyphRun {
+            bbox: bbox(),
+            run: Box::new(LayerGlyphRunPaint {
+                source: source(),
+                variant: variant(TextVariantKind::GlyphRun, "glyphRun"),
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                shape_key: shape_key(),
+                placement: placement(),
+                glyph_ids: vec![glyph_id],
+                positions: vec![LayerPoint { x: 0.0, y: 0.0 }],
+                advances: None,
+                clusters: vec![GlyphCluster {
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    source_range_utf16: Some(TextSourceRange::new(0, 1)),
+                    text_range_utf8: Some(TextSourceRange::new(0, 1)),
+                    glyph_range: GlyphRange::new(0, 1),
+                    flags: Vec::new(),
+                }],
+                direction: TextDirection::Ltr,
+                bidi_level: None,
+                writing_mode: WritingMode::HorizontalTb,
+                orientation: GlyphRunOrientation::Horizontal,
+                glyph_transforms: None,
+                diagnostics,
+            }),
+        }
+    }
+
+    fn glyph_outline(stroke: Option<GlyphOutlineStrokeStyle>) -> PaintOp {
+        PaintOp::GlyphOutline {
+            bbox: bbox(),
+            outline: Box::new(LayerGlyphOutlinePaint {
+                source: source(),
+                variant: variant(TextVariantKind::GlyphOutline, "glyphOutline"),
+                payload_kind: if stroke.is_some() {
+                    GlyphOutlinePayloadKind::MonochromeFillStroke
+                } else {
+                    GlyphOutlinePayloadKind::MonochromeFill
+                },
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                placement: placement(),
+                paths: vec![LayerGlyphOutlinePath {
+                    glyph_id: 42,
+                    source_range_utf8: TextSourceRange::new(0, 1),
+                    glyph_range: GlyphRange::new(0, 1),
+                    commands: vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(10.0, 0.0),
+                        PathCommand::LineTo(10.0, 10.0),
+                        PathCommand::ClosePath,
+                    ],
+                    fill_rule: GlyphOutlineFillRule::NonZero,
+                }],
+                stroke,
+                diagnostics: diagnostics(),
+            }),
+        }
+    }
+
+    fn tree(ops: Vec<PaintOp>) -> PageLayerTree {
+        PageLayerTree::new(100.0, 100.0, LayerNode::leaf(bbox(), None, ops))
+    }
+
+    fn first_report(
+        ops: Vec<PaintOp>,
+        options: TextVariantSelectionOptions,
+    ) -> TextVariantSelectionReport {
+        analyze_text_variant_selection(&tree(ops), options)
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
+    #[test]
+    fn canvaskit_selects_strict_glyph_run() {
+        let report = first_report(
+            vec![text_op(), glyph_run(diagnostics(), 42)],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(report.selected_variant_id.as_deref(), Some("glyphRun"));
+        assert_eq!(
+            report.selected_reason,
+            VariantSelectedReason::GlyphRunStrictEligible
+        );
+        assert!(!report.fallback_required);
+        assert!(report.rejected_variants.is_empty());
+    }
+
+    #[test]
+    fn canvaskit_rejects_large_glyph_ids_and_falls_back() {
+        let report = first_report(
+            vec![text_op(), glyph_run(diagnostics(), u16::MAX as u32 + 1)],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.fallback_required);
+        assert_eq!(
+            report.rejected_variants[0].reasons,
+            vec![VariantRejectReason::GlyphIdOutOfRange]
+        );
+    }
+
+    #[test]
+    fn canvaskit_rejects_unsupported_text_effects() {
+        let mut op = glyph_run(diagnostics(), 42);
+        if let PaintOp::GlyphRun { run, .. } = &mut op {
+            run.paint_style.shadow_type = 1;
+        }
+        let report = first_report(
+            vec![text_op(), op],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedPaintEffect));
+    }
+
+    #[test]
+    fn canvaskit_position_adjusted_threshold_is_explicit() {
+        let mut diagnostics = diagnostics();
+        diagnostics.quality = TextVariantQuality::PositionAdjusted;
+        diagnostics.max_residual_after_adjustment_px = 0.2;
+        let accepted = first_report(
+            vec![text_op(), glyph_run(diagnostics.clone(), 42)],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(accepted.selected_variant_id.as_deref(), Some("glyphRun"));
+
+        diagnostics.max_residual_after_adjustment_px = 0.5;
+        let rejected = first_report(
+            vec![text_op(), glyph_run(diagnostics, 42)],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(
+            rejected.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(rejected.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::PositionAdjustedResidualTooLarge));
+    }
+
+    #[test]
+    fn strict_outline_profile_can_select_glyph_outline() {
+        let report = first_report(
+            vec![text_op(), glyph_run(diagnostics(), 42), glyph_outline(None)],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(report.selected_variant_id.as_deref(), Some("glyphOutline"));
+        assert_eq!(
+            report.selected_reason,
+            VariantSelectedReason::GlyphOutlineStrictProfile
+        );
+    }
+
+    #[test]
+    fn outline_stroke_payload_requires_strict_stroke_subset() {
+        let report = first_report(
+            vec![
+                text_op(),
+                glyph_outline(Some(GlyphOutlineStrokeStyle {
+                    color: 0x00000000,
+                    width: 1.0,
+                    join: GlyphOutlineStrokeJoin::Round,
+                    cap: GlyphOutlineStrokeCap::Butt,
+                    miter_limit: 2.0,
+                    paint_order: GlyphOutlinePaintOrder::FillThenStroke,
+                })),
+            ],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::GlyphOutlineStrokeStyleUnsupported));
+    }
+
+    #[test]
+    fn canvas2d_keeps_text_fallback_for_variant_sidecars() {
+        let report = first_report(
+            vec![text_op(), glyph_run(diagnostics(), 42), glyph_outline(None)],
+            TextVariantSelectionOptions {
+                backend: VariantSelectionBackend::Canvas2D,
+                ..TextVariantSelectionOptions::canvaskit()
+            },
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.fallback_required);
+        assert_eq!(report.rejected_variants.len(), 2);
+        assert!(report.rejected_variants.iter().all(|reject| reject
+            .reasons
+            .contains(&VariantRejectReason::BackendDoesNotSupportVariant)));
+    }
+
+    #[test]
+    fn incomplete_variant_parts_are_rejected_before_selection() {
+        let mut op = glyph_run(diagnostics(), 42);
+        if let PaintOp::GlyphRun { run, .. } = &mut op {
+            run.variant.part_count = 2;
+        }
+        let report = first_report(
+            vec![text_op(), op],
+            TextVariantSelectionOptions::canvaskit(),
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::VariantPartsIncomplete));
+    }
 }

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -497,6 +497,7 @@ impl SkiaLayerRenderer {
                                 None => true,
                             }
                         }
+                        PaintOp::GlyphOutline { .. } => true,
                         _ => false,
                     };
                     if skip_unselected_text_variant {
@@ -570,6 +571,7 @@ impl SkiaLayerRenderer {
                             // Unreachable until native_skia_can_replay_glyph_run can verify
                             // blob-backed typeface construction. Keep the TextRun fallback.
                         }
+                        PaintOp::GlyphOutline { .. } => {}
                         PaintOp::FootnoteMarker { bbox, marker } => {
                             let style = crate::renderer::TextStyle {
                                 font_family: marker.font_family.clone(),

--- a/src/renderer/svg_layer.rs
+++ b/src/renderer/svg_layer.rs
@@ -182,6 +182,7 @@ impl SvgLayerRenderer {
                 *bbox,
             ),
             PaintOp::GlyphRun { .. }
+            | PaintOp::GlyphOutline { .. }
             | PaintOp::CharOverlap { .. }
             | PaintOp::TextControlMark { .. }
             | PaintOp::TabLeader { .. }

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -749,6 +749,7 @@ impl WebCanvasRenderer {
                                     op,
                                     PaintOp::TextRun { .. }
                                         | PaintOp::GlyphRun { .. }
+                                        | PaintOp::GlyphOutline { .. }
                                         | PaintOp::CharOverlap { .. }
                                         | PaintOp::TextControlMark { .. }
                                         | PaintOp::TabLeader { .. }
@@ -880,6 +881,7 @@ impl WebCanvasRenderer {
                             *bbox,
                         ),
                         PaintOp::GlyphRun { .. }
+                        | PaintOp::GlyphOutline { .. }
                         | PaintOp::CharOverlap { .. }
                         | PaintOp::TextControlMark { .. }
                         | PaintOp::TabLeader { .. }


### PR DESCRIPTION
## What

- `PaintOp::GlyphOutline`을 추가해서 Text IR v2의 strict outline sidecar 계약을 잡았습니다.
- Layer JSON schema minor를 11로 올리고 `text.glyphOutline` / `text.glyphOutline.strictSidecar` feature metadata와 outline payload serialization을 추가했습니다.
- `TextRun` fallback은 계속 기본 경로로 유지하고, SVG/Canvas/native Skia adapter는 `GlyphOutline`을 직접 그리지 않도록 fallback-safe하게 처리했습니다.
- CanvasKit/native 계열 backend가 나중에 같은 기준으로 variant를 고를 수 있도록 `analyze_text_variant_selection` 진단 API를 추가했습니다.

## Why

P13까지는 Text IR v2 diagnostics가 “이 슬롯이 strict variant로 승격 가능한가”를 설명하는 단계였습니다. P14는 그 다음 단계로, 실제 backend가 선택할 수 있는 variant 후보와 거절 사유를 안정적으로 만들기 위한 준비입니다.

이번 PR은 public canvas/default render path를 바꾸지 않습니다. 아직 glyph/outline을 실제로 그리는 PR이 아니라, backend가 안전하게 선택하거나 `TextRun`으로 되돌아갈 수 있는 계약과 테스트를 먼저 넣는 쪽입니다.

## Non-goals

- Canvas public render path 전환은 하지 않습니다.
- CanvasKit/native glyph 또는 outline replay 구현은 하지 않습니다.
- font blob extraction/resource interning은 하지 않습니다.
- fallback-free text export를 기본값으로 바꾸지 않습니다.

## Tests

- `cargo test text_variant --lib`
- `cargo test glyph_outline --lib`
- `cargo test canvaskit --lib`
- `cargo test renderer::layer_renderer --lib`
- `cargo test paint::json --lib`
- `cargo test paint::text_v2 --lib`
- `cargo test --lib`