### PR TITLE
render: add CanvasKit replay policy diagnostics

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,8 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P6 adds native Skia `RawSvg` fragment rasterization through `resvg`, with external file href loading disabled.
 - P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path.
 - P12 adds guarded `GlyphRun` sidecar variants, font blob/face identity metadata, and a shape-lowering API. Canvas2D/layered SVG still use `TextRun` fallback; native Skia also keeps the fallback until exact blob-backed typeface replay is wired. Normal lowering does not emit glyph ids until a shaping pass explicitly inserts them.
+- P14 adds guarded `GlyphOutline` sidecar variants and backend text variant selection diagnostics. Existing renderers still keep the `TextRun` fallback path.
+- P15 adds diagnostics-only CanvasKit replay policy planning through `getCanvasKitReplayPlan(page, mode)`. `default` mode forbids hidden Canvas2D overlays, while `compat` mode reports transition overlays explicitly.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
 - The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, exact native glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -125,6 +125,60 @@ sidecar and use `TextRun`.
 - Glyph ids require portable font identity. Consumers must not replay glyph ids
   against an arbitrary local font just because the family name matches.
 
+## CanvasKit Direct Replay and Overlay Policy
+
+P15 promotes CanvasKit planning from an implicit Canvas2D-assisted preview idea
+into an explicit replay policy. This still does not switch the public renderer.
+Instead, `getCanvasKitReplayPlan(page, mode)` exposes a diagnostics-only plan
+from the current `PageLayerTree` so a frontend can see which operations are
+direct replay candidates, which operations need a transition overlay, and which
+text variants select a strict sidecar or fall back to `TextRun`.
+
+CanvasKit has two operational modes:
+
+- `default`: native-preparation mode. CanvasKit should prefer direct replay and
+  must not silently hide unsupported operations behind a Canvas2D overlay. If an
+  operation is not covered yet, the plan reports `directRequired` with
+  `hiddenOverlayForbidden` so the gap remains visible.
+- `compat`: user-visible stability mode. Existing Canvas2D overlays may remain
+  as transition fallbacks while direct replay coverage is expanded. The plan
+  reports those cases as `compatOverlay` and keeps them separate from true
+  direct replay.
+
+The first overlay inventory is deliberately conservative. Raster images,
+equations, form controls, raw SVG fragments, placeholders, special text visual
+ops, and effect-heavy `TextRun` payloads are visible in the plan before any
+hidden overlay is removed. Basic page background, vector primitives, clipping,
+and simple `TextRun` payloads are direct candidates. `GlyphRun` and
+`GlyphOutline` stay under the P14 text variant selection diagnostics: if the
+strict sidecar is not selected, CanvasKit must use the `TextRun` fallback.
+
+Overlay removal should be staged from low-risk paint operations toward text and
+variant-sensitive operations:
+
+1. Raster image replay: crop, tile, image-effect preprocessing, filtering, and
+   resource-cache behavior should match Canvas2D through direct CanvasKit image
+   replay first. `compat` may keep an overlay until the direct path has a parity
+   fixture; `default` should make the gap visible.
+2. Equation and form-object replay: parity fixtures should decide whether the
+   vector/layout-box path or an image fallback is the canonical replay for each
+   operation before the overlay is removed.
+3. TextRun effects: vertical text, rotation, synthetic style, ratio scaling,
+   shade, outline, shadow, decorations, emphasis dots, tab leaders, and control
+   markers should be promoted effect-by-effect. Unsupported text effects must
+   not trigger approximate `GlyphRun` replay.
+4. GlyphRun/GlyphOutline gates: CanvasKit should choose a strict variant only
+   when the P14 selection report says it is replayable. Opening outline replay
+   in CanvasKit is a backend parity milestone, not a schema change.
+
+Every overlay removal requires a Canvas2D-vs-CanvasKit fixture. Rasterizer
+output can use fuzzy PNG comparison, but semantic decisions must be exact:
+selected variant id, fallback reason, resource resolution, effect preprocessing
+diagnostics, and cache behavior should be asserted without tolerance. When a
+direct CanvasKit path intentionally differs from Canvas2D because it is closer
+to native Skia semantics, the fixture should label that as a Skia strict replay
+improvement rather than a Canvas2D compatibility match.
+
 ## Follow-Ups
 
 - Wire real document font blob extraction into `ResourceArena`.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -319,6 +319,32 @@ export class WasmBridge {
     return '{"layers":[]}';
   }
 
+  getCanvasKitReplayPlan(pageNum: number, mode: 'default' | 'compat' = 'default'): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as {
+      getCanvasKitReplayPlan?: (p: number, mode: string) => string;
+    };
+    if (typeof d.getCanvasKitReplayPlan === 'function') {
+      return d.getCanvasKitReplayPlan(pageNum, mode);
+    }
+    return JSON.stringify({
+      mode,
+      hiddenCanvas2dOverlayAllowed: mode === 'compat',
+      directReplayRequired: mode === 'default',
+      summary: {
+        totalItems: 0,
+        directItems: 0,
+        directRequiredItems: 0,
+        compatOverlayItems: 0,
+        textFallbackItems: 0,
+        unsupportedItems: 0,
+        hiddenOverlayViolations: 0,
+      },
+      items: [],
+      textVariants: [],
+    });
+  }
+
   getPageOverlayImages(pageNum: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     const d = this.doc as unknown as { getPageOverlayImages?: (p: number) => string };

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -148,6 +148,29 @@ impl DocumentCore {
         Ok(renderer.command_count() as u32)
     }
 
+    pub fn get_canvaskit_replay_plan_native(
+        &self,
+        page_num: u32,
+        mode: &str,
+    ) -> Result<String, HwpError> {
+        use crate::renderer::canvaskit_policy::{
+            analyze_canvaskit_replay_plan, CanvasKitReplayMode,
+        };
+
+        let mode = CanvasKitReplayMode::from_str(mode).ok_or_else(|| {
+            HwpError::RenderError(format!(
+                "지원하지 않는 CanvasKit replay mode입니다: {mode}"
+            ))
+        })?;
+        let tree = self.build_page_layer_tree(page_num)?;
+        let plan = analyze_canvaskit_replay_plan(&tree, mode);
+        serde_json::to_string(&plan).map_err(|error| {
+            HwpError::RenderError(format!(
+                "CanvasKit replay plan JSON 직렬화에 실패했습니다: {error}"
+            ))
+        })
+    }
+
     #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
     pub fn render_page_png_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError> {
         use crate::renderer::layer_renderer::LayerRasterRenderer;

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -159,7 +159,7 @@ impl DocumentCore {
 
         let mode = CanvasKitReplayMode::from_str(mode).ok_or_else(|| {
             HwpError::RenderError(format!(
-                "지원하지 않는 CanvasKit replay mode입니다: {mode}"
+                "지원하지 않는 CanvasKit replay mode입니다: {mode}. allowed modes: default, compat"
             ))
         })?;
         let tree = self.build_page_layer_tree(page_num)?;

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -10,7 +10,7 @@ use crate::renderer::layer_renderer::{
     analyze_text_variant_selection, TextVariantSelectionOptions, VariantSelectedReason,
     VariantSelectionBackend,
 };
-use crate::renderer::render_tree::{FieldMarkerType, TextRunNode};
+use crate::renderer::render_tree::{FieldMarkerType, PageBackgroundNode, TextRunNode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -290,17 +290,23 @@ impl CanvasKitReplayPlanBuilder {
 
     fn item_for_op(&self, op: &PaintOp, path: String) -> CanvasKitReplayItem {
         match op {
-            PaintOp::PageBackground { .. } => direct_item(
-                path,
-                "pageBackground",
-                CanvasKitReplayFeature::PageBackground,
-            ),
+            PaintOp::PageBackground { background, .. } => {
+                self.page_background_item(path, background)
+            }
             PaintOp::Line { .. }
             | PaintOp::Rectangle { .. }
             | PaintOp::Ellipse { .. }
-            | PaintOp::Path { .. }
-            | PaintOp::FootnoteMarker { .. } => {
+            | PaintOp::Path { .. } => {
                 direct_item(path, paint_op_type(op), CanvasKitReplayFeature::VectorShape)
+            }
+            PaintOp::FootnoteMarker { .. } => {
+                let mut item = self.transition_overlay_item(
+                    path,
+                    paint_op_type(op),
+                    CanvasKitReplayFeature::TextSpecialVisual,
+                );
+                item.detail = Some("footnoteMarker".to_string());
+                item
             }
             PaintOp::Image { .. } => {
                 self.transition_overlay_item(path, "image", CanvasKitReplayFeature::RasterImage)
@@ -345,14 +351,44 @@ impl CanvasKitReplayPlanBuilder {
         }
     }
 
+    fn page_background_item(
+        &self,
+        path: String,
+        background: &PageBackgroundNode,
+    ) -> CanvasKitReplayItem {
+        if background.image.is_some() {
+            let mut item = self.transition_overlay_item(
+                path,
+                "pageBackground",
+                CanvasKitReplayFeature::RasterImage,
+            );
+            item.detail = Some("imageFill".to_string());
+            item
+        } else if background.gradient.is_some() {
+            let mut item = self.transition_overlay_item(
+                path,
+                "pageBackground",
+                CanvasKitReplayFeature::PageBackground,
+            );
+            item.detail = Some("gradientFill".to_string());
+            item
+        } else {
+            direct_item(
+                path,
+                "pageBackground",
+                CanvasKitReplayFeature::PageBackground,
+            )
+        }
+    }
+
     fn text_run_item(&self, path: String, run: &TextRunNode) -> CanvasKitReplayItem {
         if let Some(detail) = text_run_transition_detail(run) {
             let mut item =
-                self.transition_overlay_item(path, "text", CanvasKitReplayFeature::TextRun);
+                self.transition_overlay_item(path, "textRun", CanvasKitReplayFeature::TextRun);
             item.detail = Some(detail.to_string());
             item
         } else {
-            direct_item(path, "text", CanvasKitReplayFeature::TextRun)
+            direct_item(path, "textRun", CanvasKitReplayFeature::TextRun)
         }
     }
 
@@ -455,7 +491,7 @@ fn direct_item(
 fn paint_op_type(op: &PaintOp) -> &'static str {
     match op {
         PaintOp::PageBackground { .. } => "pageBackground",
-        PaintOp::TextRun { .. } => "text",
+        PaintOp::TextRun { .. } => "textRun",
         PaintOp::GlyphRun { .. } => "glyphRun",
         PaintOp::GlyphOutline { .. } => "glyphOutline",
         PaintOp::CharOverlap { .. } => "charOverlap",
@@ -544,9 +580,12 @@ fn selected_reason_as_str(reason: VariantSelectedReason) -> &'static str {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::model::style::ImageFillMode;
     use crate::paint::LayerNode;
-    use crate::renderer::render_tree::{BoundingBox, ImageNode};
-    use crate::renderer::TextStyle;
+    use crate::renderer::render_tree::{
+        BoundingBox, FootnoteMarkerNode, ImageNode, PageBackgroundImage,
+    };
+    use crate::renderer::{GradientFillInfo, TextStyle};
 
     fn bbox() -> BoundingBox {
         BoundingBox::new(0.0, 0.0, 20.0, 20.0)
@@ -579,6 +618,19 @@ mod tests {
             border_fill_id: 0,
             baseline: 12.0,
             field_marker: FieldMarkerType::None,
+        }
+    }
+
+    fn page_background(
+        image: Option<PageBackgroundImage>,
+        gradient: Option<Box<GradientFillInfo>>,
+    ) -> PageBackgroundNode {
+        PageBackgroundNode {
+            background_color: None,
+            border_color: None,
+            border_width: 0.0,
+            gradient,
+            image,
         }
     }
 
@@ -619,6 +671,57 @@ mod tests {
     }
 
     #[test]
+    fn page_background_image_and_gradient_are_policy_visible() {
+        let image_background = page_background(
+            Some(PageBackgroundImage {
+                data: vec![1, 2, 3],
+                fill_mode: ImageFillMode::FitToSize,
+            }),
+            None,
+        );
+        let gradient_background = page_background(
+            None,
+            Some(Box::new(GradientFillInfo {
+                gradient_type: 1,
+                angle: 0,
+                center_x: 50,
+                center_y: 50,
+                colors: vec![0x0000_0000, 0x00FF_FFFF],
+                positions: vec![0.0, 1.0],
+            })),
+        );
+        let tree = tree_with_ops(vec![
+            PaintOp::PageBackground {
+                bbox: bbox(),
+                background: image_background,
+            },
+            PaintOp::PageBackground {
+                bbox: bbox(),
+                background: gradient_background,
+            },
+        ]);
+
+        let default_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+        assert_eq!(default_plan.summary.direct_required_items, 2);
+        assert_eq!(
+            default_plan.items[0].feature,
+            CanvasKitReplayFeature::RasterImage
+        );
+        assert_eq!(default_plan.items[0].detail.as_deref(), Some("imageFill"));
+        assert_eq!(
+            default_plan.items[1].feature,
+            CanvasKitReplayFeature::PageBackground
+        );
+        assert_eq!(
+            default_plan.items[1].detail.as_deref(),
+            Some("gradientFill")
+        );
+
+        let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
+        assert_eq!(compat_plan.summary.compat_overlay_items, 2);
+    }
+
+    #[test]
     fn simple_text_is_direct_but_text_effect_is_policy_visible() {
         let mut vertical = text_run("A");
         vertical.is_vertical = true;
@@ -645,6 +748,55 @@ mod tests {
         assert_eq!(compat_plan.summary.direct_items, 1);
         assert_eq!(compat_plan.summary.compat_overlay_items, 1);
         assert_eq!(compat_plan.items[1].detail.as_deref(), Some("verticalText"));
+    }
+
+    #[test]
+    fn text_run_op_type_matches_layer_tree_schema_name() {
+        let tree = tree_with_ops(vec![PaintOp::TextRun {
+            bbox: bbox(),
+            run: text_run("A"),
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.items[0].op_type, "textRun");
+    }
+
+    #[test]
+    fn footnote_marker_is_reported_as_text_special_visual() {
+        let tree = tree_with_ops(vec![PaintOp::FootnoteMarker {
+            bbox: bbox(),
+            marker: FootnoteMarkerNode {
+                number: 1,
+                text: "1)".to_string(),
+                base_font_size: 12.0,
+                font_family: "Test".to_string(),
+                color: 0x0000_0000,
+                section_index: 0,
+                para_index: 0,
+                control_index: 0,
+            },
+        }]);
+
+        let default_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+        assert_eq!(
+            default_plan.items[0].feature,
+            CanvasKitReplayFeature::TextSpecialVisual
+        );
+        assert_eq!(
+            default_plan.items[0].status,
+            CanvasKitReplayStatus::DirectRequired
+        );
+        assert_eq!(
+            default_plan.items[0].detail.as_deref(),
+            Some("footnoteMarker")
+        );
+
+        let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
+        assert_eq!(
+            compat_plan.items[0].status,
+            CanvasKitReplayStatus::CompatOverlay
+        );
     }
 
     #[test]

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -1,0 +1,677 @@
+use serde::Serialize;
+use std::collections::BTreeMap;
+
+use crate::model::style::UnderlineType;
+use crate::paint::{
+    CacheHint, ClipKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp, TextDecorationKind,
+    TextVariantKind,
+};
+use crate::renderer::layer_renderer::{
+    analyze_text_variant_selection, TextVariantSelectionOptions, VariantSelectedReason,
+    VariantSelectionBackend,
+};
+use crate::renderer::render_tree::{FieldMarkerType, TextRunNode};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CanvasKitReplayMode {
+    Default,
+    Compat,
+}
+
+impl CanvasKitReplayMode {
+    pub fn from_str(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "" | "default" => Some(Self::Default),
+            "compat" | "compatibility" => Some(Self::Compat),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Default => "default",
+            Self::Compat => "compat",
+        }
+    }
+
+    pub fn allows_canvas2d_overlay(self) -> bool {
+        matches!(self, Self::Compat)
+    }
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasKitReplayPlan {
+    pub mode: CanvasKitReplayMode,
+    pub hidden_canvas2d_overlay_allowed: bool,
+    pub direct_replay_required: bool,
+    pub summary: CanvasKitReplaySummary,
+    pub items: Vec<CanvasKitReplayItem>,
+    pub text_variants: Vec<CanvasKitTextVariantReport>,
+}
+
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasKitReplaySummary {
+    pub total_items: u32,
+    pub direct_items: u32,
+    pub direct_required_items: u32,
+    pub compat_overlay_items: u32,
+    pub text_fallback_items: u32,
+    pub unsupported_items: u32,
+    pub hidden_overlay_violations: u32,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasKitReplayItem {
+    pub path: String,
+    pub op_type: &'static str,
+    pub feature: CanvasKitReplayFeature,
+    pub status: CanvasKitReplayStatus,
+    pub reason: CanvasKitReplayReason,
+    pub compat_overlay_allowed: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub detail: Option<String>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CanvasKitReplayFeature {
+    PageBackground,
+    VectorShape,
+    RasterImage,
+    Equation,
+    FormObject,
+    RawSvgFragment,
+    Placeholder,
+    TextRun,
+    TextSpecialVisual,
+    TextVariant,
+    Clip,
+    CacheHint,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CanvasKitReplayStatus {
+    Direct,
+    DirectRequired,
+    CompatOverlay,
+    TextFallback,
+    Unsupported,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum CanvasKitReplayReason {
+    DirectReplaySupported,
+    DirectReplayRequired,
+    CompatOverlayAllowed,
+    HiddenOverlayForbidden,
+    ExplicitTextRunFallback,
+    UnsupportedFeature,
+}
+
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasKitTextVariantReport {
+    pub equivalence_group: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_variant_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub selected_variant_kind: Option<&'static str>,
+    pub selected_reason: &'static str,
+    pub fallback_required: bool,
+    pub rejected_variants: Vec<CanvasKitRejectedTextVariant>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct CanvasKitRejectedTextVariant {
+    pub variant_id: String,
+    pub variant_kind: &'static str,
+    pub reasons: Vec<&'static str>,
+}
+
+pub fn analyze_canvaskit_replay_plan(
+    tree: &PageLayerTree,
+    mode: CanvasKitReplayMode,
+) -> CanvasKitReplayPlan {
+    let variant_reports = analyze_text_variant_selection(
+        tree,
+        TextVariantSelectionOptions {
+            backend: VariantSelectionBackend::CanvasKit,
+            ..TextVariantSelectionOptions::canvaskit()
+        },
+    );
+    let selected_variants = variant_reports
+        .iter()
+        .filter_map(|report| {
+            let variant_id = report.selected_variant_id.as_ref()?;
+            let variant_kind = report.selected_variant_kind?;
+            Some((
+                report.equivalence_group.clone(),
+                SelectedTextVariant {
+                    variant_id: variant_id.clone(),
+                    variant_kind,
+                    fallback_required: report.fallback_required,
+                },
+            ))
+        })
+        .collect::<BTreeMap<_, _>>();
+    let mut builder = CanvasKitReplayPlanBuilder::new(mode, selected_variants);
+    builder.visit_node(&tree.root, "root");
+    let text_variants = variant_reports
+        .into_iter()
+        .map(|report| CanvasKitTextVariantReport {
+            equivalence_group: report.equivalence_group,
+            selected_variant_id: report.selected_variant_id,
+            selected_variant_kind: report.selected_variant_kind.map(TextVariantKind::as_str),
+            selected_reason: selected_reason_as_str(report.selected_reason),
+            fallback_required: report.fallback_required,
+            rejected_variants: report
+                .rejected_variants
+                .into_iter()
+                .map(|rejected| CanvasKitRejectedTextVariant {
+                    variant_id: rejected.variant_id,
+                    variant_kind: rejected.variant_kind.as_str(),
+                    reasons: rejected
+                        .reasons
+                        .into_iter()
+                        .map(|reason| reason.as_str())
+                        .collect(),
+                })
+                .collect(),
+        })
+        .collect();
+    builder.finish(text_variants)
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct SelectedTextVariant {
+    variant_id: String,
+    variant_kind: TextVariantKind,
+    fallback_required: bool,
+}
+
+struct CanvasKitReplayPlanBuilder {
+    mode: CanvasKitReplayMode,
+    selected_variants: BTreeMap<String, SelectedTextVariant>,
+    summary: CanvasKitReplaySummary,
+    items: Vec<CanvasKitReplayItem>,
+}
+
+impl CanvasKitReplayPlanBuilder {
+    fn new(
+        mode: CanvasKitReplayMode,
+        selected_variants: BTreeMap<String, SelectedTextVariant>,
+    ) -> Self {
+        Self {
+            mode,
+            selected_variants,
+            summary: CanvasKitReplaySummary::default(),
+            items: Vec::new(),
+        }
+    }
+
+    fn finish(self, text_variants: Vec<CanvasKitTextVariantReport>) -> CanvasKitReplayPlan {
+        CanvasKitReplayPlan {
+            mode: self.mode,
+            hidden_canvas2d_overlay_allowed: self.mode.allows_canvas2d_overlay(),
+            direct_replay_required: matches!(self.mode, CanvasKitReplayMode::Default),
+            summary: self.summary,
+            items: self.items,
+            text_variants,
+        }
+    }
+
+    fn visit_node(&mut self, node: &LayerNode, path: &str) {
+        match &node.kind {
+            LayerNodeKind::Group {
+                children,
+                cache_hint,
+                ..
+            } => {
+                if !matches!(cache_hint, CacheHint::None) {
+                    self.push_cache_hint_item(path, *cache_hint);
+                }
+                for (index, child) in children.iter().enumerate() {
+                    self.visit_node(child, &format!("{path}/group/{index}"));
+                }
+            }
+            LayerNodeKind::ClipRect {
+                child, clip_kind, ..
+            } => {
+                self.push(CanvasKitReplayItem {
+                    path: format!("{path}/clip"),
+                    op_type: "clipRect",
+                    feature: CanvasKitReplayFeature::Clip,
+                    status: CanvasKitReplayStatus::Direct,
+                    reason: CanvasKitReplayReason::DirectReplaySupported,
+                    compat_overlay_allowed: false,
+                    detail: Some(clip_kind_detail(*clip_kind).to_string()),
+                });
+                self.visit_node(child, &format!("{path}/clip/child"));
+            }
+            LayerNodeKind::Leaf { ops } => {
+                for (index, op) in ops.iter().enumerate() {
+                    self.push(self.item_for_op(op, format!("{path}/leaf/{index}")));
+                }
+            }
+        }
+    }
+
+    fn push_cache_hint_item(&mut self, path: &str, cache_hint: CacheHint) {
+        let (status, reason, compat_overlay_allowed) = if self.mode.allows_canvas2d_overlay() {
+            (
+                CanvasKitReplayStatus::CompatOverlay,
+                CanvasKitReplayReason::CompatOverlayAllowed,
+                true,
+            )
+        } else {
+            (
+                CanvasKitReplayStatus::DirectRequired,
+                CanvasKitReplayReason::HiddenOverlayForbidden,
+                false,
+            )
+        };
+        self.push(CanvasKitReplayItem {
+            path: format!("{path}/cacheHint"),
+            op_type: "cacheHint",
+            feature: CanvasKitReplayFeature::CacheHint,
+            status,
+            reason,
+            compat_overlay_allowed,
+            detail: Some(format!("{cache_hint:?}")),
+        });
+    }
+
+    fn item_for_op(&self, op: &PaintOp, path: String) -> CanvasKitReplayItem {
+        match op {
+            PaintOp::PageBackground { .. } => direct_item(
+                path,
+                "pageBackground",
+                CanvasKitReplayFeature::PageBackground,
+            ),
+            PaintOp::Line { .. }
+            | PaintOp::Rectangle { .. }
+            | PaintOp::Ellipse { .. }
+            | PaintOp::Path { .. }
+            | PaintOp::FootnoteMarker { .. } => {
+                direct_item(path, paint_op_type(op), CanvasKitReplayFeature::VectorShape)
+            }
+            PaintOp::Image { .. } => {
+                self.transition_overlay_item(path, "image", CanvasKitReplayFeature::RasterImage)
+            }
+            PaintOp::Equation { .. } => {
+                self.transition_overlay_item(path, "equation", CanvasKitReplayFeature::Equation)
+            }
+            PaintOp::FormObject { .. } => {
+                self.transition_overlay_item(path, "formObject", CanvasKitReplayFeature::FormObject)
+            }
+            PaintOp::RawSvg { .. } => {
+                self.transition_overlay_item(path, "rawSvg", CanvasKitReplayFeature::RawSvgFragment)
+            }
+            PaintOp::Placeholder { .. } => self.transition_overlay_item(
+                path,
+                "placeholder",
+                CanvasKitReplayFeature::Placeholder,
+            ),
+            PaintOp::TextRun { run, .. } => self.text_run_item(path, run),
+            PaintOp::CharOverlap { .. }
+            | PaintOp::TextControlMark { .. }
+            | PaintOp::TabLeader { .. }
+            | PaintOp::TextDecoration { .. } => self.transition_overlay_item(
+                path,
+                paint_op_type(op),
+                CanvasKitReplayFeature::TextSpecialVisual,
+            ),
+            PaintOp::GlyphRun { run, .. } => self.text_variant_item(
+                path,
+                "glyphRun",
+                &run.variant.equivalence_group,
+                &run.variant.variant_id,
+                TextVariantKind::GlyphRun,
+            ),
+            PaintOp::GlyphOutline { outline, .. } => self.text_variant_item(
+                path,
+                "glyphOutline",
+                &outline.variant.equivalence_group,
+                &outline.variant.variant_id,
+                TextVariantKind::GlyphOutline,
+            ),
+        }
+    }
+
+    fn text_run_item(&self, path: String, run: &TextRunNode) -> CanvasKitReplayItem {
+        if let Some(detail) = text_run_transition_detail(run) {
+            let mut item =
+                self.transition_overlay_item(path, "text", CanvasKitReplayFeature::TextRun);
+            item.detail = Some(detail.to_string());
+            item
+        } else {
+            direct_item(path, "text", CanvasKitReplayFeature::TextRun)
+        }
+    }
+
+    fn text_variant_item(
+        &self,
+        path: String,
+        op_type: &'static str,
+        equivalence_group: &str,
+        variant_id: &str,
+        variant_kind: TextVariantKind,
+    ) -> CanvasKitReplayItem {
+        let selected = self.selected_variants.get(equivalence_group);
+        if selected.is_some_and(|selected| {
+            !selected.fallback_required
+                && selected.variant_id == variant_id
+                && selected.variant_kind == variant_kind
+        }) {
+            return CanvasKitReplayItem {
+                path,
+                op_type,
+                feature: CanvasKitReplayFeature::TextVariant,
+                status: CanvasKitReplayStatus::DirectRequired,
+                reason: CanvasKitReplayReason::DirectReplayRequired,
+                compat_overlay_allowed: false,
+                detail: Some(format!("selectedVariant={variant_id}")),
+            };
+        }
+        CanvasKitReplayItem {
+            path,
+            op_type,
+            feature: CanvasKitReplayFeature::TextVariant,
+            status: CanvasKitReplayStatus::TextFallback,
+            reason: CanvasKitReplayReason::ExplicitTextRunFallback,
+            compat_overlay_allowed: false,
+            detail: Some(format!("fallbackVariantGroup={equivalence_group}")),
+        }
+    }
+
+    fn transition_overlay_item(
+        &self,
+        path: String,
+        op_type: &'static str,
+        feature: CanvasKitReplayFeature,
+    ) -> CanvasKitReplayItem {
+        if self.mode.allows_canvas2d_overlay() {
+            CanvasKitReplayItem {
+                path,
+                op_type,
+                feature,
+                status: CanvasKitReplayStatus::CompatOverlay,
+                reason: CanvasKitReplayReason::CompatOverlayAllowed,
+                compat_overlay_allowed: true,
+                detail: None,
+            }
+        } else {
+            CanvasKitReplayItem {
+                path,
+                op_type,
+                feature,
+                status: CanvasKitReplayStatus::DirectRequired,
+                reason: CanvasKitReplayReason::HiddenOverlayForbidden,
+                compat_overlay_allowed: false,
+                detail: None,
+            }
+        }
+    }
+
+    fn push(&mut self, item: CanvasKitReplayItem) {
+        self.summary.total_items += 1;
+        match item.status {
+            CanvasKitReplayStatus::Direct => self.summary.direct_items += 1,
+            CanvasKitReplayStatus::DirectRequired => self.summary.direct_required_items += 1,
+            CanvasKitReplayStatus::CompatOverlay => self.summary.compat_overlay_items += 1,
+            CanvasKitReplayStatus::TextFallback => self.summary.text_fallback_items += 1,
+            CanvasKitReplayStatus::Unsupported => self.summary.unsupported_items += 1,
+        }
+        if matches!(item.reason, CanvasKitReplayReason::HiddenOverlayForbidden) {
+            self.summary.hidden_overlay_violations += 1;
+        }
+        self.items.push(item);
+    }
+}
+
+fn direct_item(
+    path: String,
+    op_type: &'static str,
+    feature: CanvasKitReplayFeature,
+) -> CanvasKitReplayItem {
+    CanvasKitReplayItem {
+        path,
+        op_type,
+        feature,
+        status: CanvasKitReplayStatus::Direct,
+        reason: CanvasKitReplayReason::DirectReplaySupported,
+        compat_overlay_allowed: false,
+        detail: None,
+    }
+}
+
+fn paint_op_type(op: &PaintOp) -> &'static str {
+    match op {
+        PaintOp::PageBackground { .. } => "pageBackground",
+        PaintOp::TextRun { .. } => "text",
+        PaintOp::GlyphRun { .. } => "glyphRun",
+        PaintOp::GlyphOutline { .. } => "glyphOutline",
+        PaintOp::CharOverlap { .. } => "charOverlap",
+        PaintOp::TextControlMark { .. } => "textControlMark",
+        PaintOp::TabLeader { .. } => "tabLeader",
+        PaintOp::TextDecoration {
+            kind: TextDecorationKind::Underline,
+            ..
+        } => "underline",
+        PaintOp::TextDecoration {
+            kind: TextDecorationKind::Strikethrough,
+            ..
+        } => "strikethrough",
+        PaintOp::TextDecoration {
+            kind: TextDecorationKind::EmphasisDot,
+            ..
+        } => "emphasisDot",
+        PaintOp::FootnoteMarker { .. } => "footnoteMarker",
+        PaintOp::Line { .. } => "line",
+        PaintOp::Rectangle { .. } => "rectangle",
+        PaintOp::Ellipse { .. } => "ellipse",
+        PaintOp::Path { .. } => "path",
+        PaintOp::Image { .. } => "image",
+        PaintOp::Equation { .. } => "equation",
+        PaintOp::FormObject { .. } => "formObject",
+        PaintOp::Placeholder { .. } => "placeholder",
+        PaintOp::RawSvg { .. } => "rawSvg",
+    }
+}
+
+fn clip_kind_detail(clip_kind: ClipKind) -> &'static str {
+    match clip_kind {
+        ClipKind::Body => "body",
+        ClipKind::TableCell => "tableCell",
+        ClipKind::Generic => "generic",
+    }
+}
+
+fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
+    if run.is_vertical {
+        return Some("verticalText");
+    }
+    if run.rotation.abs() > f64::EPSILON {
+        return Some("rotatedText");
+    }
+    if run.char_overlap.is_some() {
+        return Some("charOverlap");
+    }
+    if run.field_marker != FieldMarkerType::None || run.is_para_end || run.is_line_break_end {
+        return Some("controlMark");
+    }
+    if !run.style.tab_leaders.is_empty() {
+        return Some("tabLeader");
+    }
+    if !matches!(run.style.underline, UnderlineType::None) || run.style.strikethrough {
+        return Some("textDecoration");
+    }
+    if run.style.emphasis_dot != 0 {
+        return Some("emphasisDot");
+    }
+    if run.style.outline_type != 0 {
+        return Some("outlineTextEffect");
+    }
+    if run.style.shadow_type != 0 {
+        return Some("shadowTextEffect");
+    }
+    if run.style.emboss {
+        return Some("embossTextEffect");
+    }
+    if run.style.engrave {
+        return Some("engraveTextEffect");
+    }
+    if run.style.shade_color != 0x00FF_FFFF {
+        return Some("shadeTextEffect");
+    }
+    if (run.style.ratio - 1.0).abs() > f64::EPSILON {
+        return Some("ratioTextEffect");
+    }
+    None
+}
+
+fn selected_reason_as_str(reason: VariantSelectedReason) -> &'static str {
+    reason.as_str()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::paint::LayerNode;
+    use crate::renderer::render_tree::{BoundingBox, ImageNode};
+    use crate::renderer::TextStyle;
+
+    fn bbox() -> BoundingBox {
+        BoundingBox::new(0.0, 0.0, 20.0, 20.0)
+    }
+
+    fn tree_with_ops(ops: Vec<PaintOp>) -> PageLayerTree {
+        PageLayerTree::new(100.0, 100.0, LayerNode::leaf(bbox(), None, ops))
+    }
+
+    fn text_run(text: &str) -> TextRunNode {
+        TextRunNode {
+            text: text.to_string(),
+            style: TextStyle {
+                font_family: "Test".to_string(),
+                font_size: 12.0,
+                shade_color: 0x00FF_FFFF,
+                ..Default::default()
+            },
+            char_shape_id: None,
+            para_shape_id: None,
+            section_index: None,
+            para_index: None,
+            char_start: None,
+            cell_context: None,
+            is_para_end: false,
+            is_line_break_end: false,
+            rotation: 0.0,
+            is_vertical: false,
+            char_overlap: None,
+            border_fill_id: 0,
+            baseline: 12.0,
+            field_marker: FieldMarkerType::None,
+        }
+    }
+
+    #[test]
+    fn default_mode_forbids_hidden_image_overlay() {
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image: ImageNode::new(1, Some(vec![1, 2, 3])),
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.summary.direct_required_items, 1);
+        assert_eq!(plan.summary.compat_overlay_items, 0);
+        assert_eq!(plan.summary.hidden_overlay_violations, 1);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(
+            plan.items[0].reason,
+            CanvasKitReplayReason::HiddenOverlayForbidden
+        );
+        assert!(!plan.items[0].compat_overlay_allowed);
+    }
+
+    #[test]
+    fn compat_mode_reports_transition_overlay_for_image() {
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image: ImageNode::new(1, Some(vec![1, 2, 3])),
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
+
+        assert_eq!(plan.summary.direct_required_items, 0);
+        assert_eq!(plan.summary.compat_overlay_items, 1);
+        assert_eq!(plan.summary.hidden_overlay_violations, 0);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::CompatOverlay);
+        assert!(plan.items[0].compat_overlay_allowed);
+    }
+
+    #[test]
+    fn simple_text_is_direct_but_text_effect_is_policy_visible() {
+        let mut vertical = text_run("A");
+        vertical.is_vertical = true;
+        let tree = tree_with_ops(vec![
+            PaintOp::TextRun {
+                bbox: bbox(),
+                run: text_run("A"),
+            },
+            PaintOp::TextRun {
+                bbox: bbox(),
+                run: vertical,
+            },
+        ]);
+
+        let default_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+        assert_eq!(default_plan.summary.direct_items, 1);
+        assert_eq!(default_plan.summary.direct_required_items, 1);
+        assert_eq!(
+            default_plan.items[1].detail.as_deref(),
+            Some("verticalText")
+        );
+
+        let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
+        assert_eq!(compat_plan.summary.direct_items, 1);
+        assert_eq!(compat_plan.summary.compat_overlay_items, 1);
+        assert_eq!(compat_plan.items[1].detail.as_deref(), Some("verticalText"));
+    }
+
+    #[test]
+    fn mode_parser_defaults_empty_string() {
+        assert_eq!(
+            CanvasKitReplayMode::from_str(""),
+            Some(CanvasKitReplayMode::Default)
+        );
+        assert_eq!(
+            CanvasKitReplayMode::from_str("compatibility"),
+            Some(CanvasKitReplayMode::Compat)
+        );
+        assert_eq!(CanvasKitReplayMode::from_str("canvas2d"), None);
+    }
+
+    #[test]
+    fn replay_plan_serializes_mode_and_summary() {
+        let tree = tree_with_ops(vec![PaintOp::TextRun {
+            bbox: bbox(),
+            run: text_run("A"),
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+        let json = serde_json::to_string(&plan).expect("serialize CanvasKit replay plan");
+
+        assert!(json.contains("\"mode\":\"default\""));
+        assert!(json.contains("\"directItems\":1"));
+        assert!(json.contains("\"hiddenCanvas2dOverlayAllowed\":false"));
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -8,6 +8,7 @@ use serde::Serialize;
 use crate::model::style::{LineSpacingType, UnderlineType};
 
 pub mod canvas;
+pub mod canvaskit_policy;
 pub mod composer;
 pub mod equation;
 pub mod font_metrics_data;

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -371,6 +371,19 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
+    /// CanvasKit direct replay/compat overlay 정책 진단을 JSON 문자열로 반환한다.
+    ///
+    /// `mode` 는 `"default"` 또는 `"compat"` 를 받는다. 빈 문자열은 `"default"` 로 처리한다.
+    #[wasm_bindgen(js_name = getCanvasKitReplayPlan)]
+    pub fn get_canvaskit_replay_plan(
+        &self,
+        page_num: u32,
+        mode: &str,
+    ) -> Result<String, JsValue> {
+        self.get_canvaskit_replay_plan_native(page_num, mode)
+            .map_err(|e| e.into())
+    }
+
     /// 페이지 overlay 이미지 정보만 JSON 문자열로 반환한다.
     #[wasm_bindgen(js_name = getPageOverlayImages)]
     pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue> {

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -110,7 +110,10 @@
         assert!(compat_json.contains("\"directReplayRequired\":false"));
 
         let invalid = doc.get_canvaskit_replay_plan_native(0, "canvas2d");
-        assert!(invalid.is_err());
+        let error = invalid.expect_err("unsupported CanvasKit replay mode should fail");
+        let message = error.to_string();
+        assert!(message.contains("canvas2d"));
+        assert!(message.contains("allowed modes: default, compat"));
     }
 
     #[test]

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -92,6 +92,28 @@
     }
 
     #[test]
+    fn test_canvaskit_replay_plan_export_uses_mode_policy() {
+        let doc = HwpDocument::create_empty();
+
+        let default_json = doc
+            .get_canvaskit_replay_plan_native(0, "default")
+            .expect("empty document CanvasKit plan should export");
+        assert!(default_json.contains("\"mode\":\"default\""));
+        assert!(default_json.contains("\"hiddenCanvas2dOverlayAllowed\":false"));
+        assert!(default_json.contains("\"directReplayRequired\":true"));
+
+        let compat_json = doc
+            .get_canvaskit_replay_plan_native(0, "compat")
+            .expect("compat CanvasKit plan should export");
+        assert!(compat_json.contains("\"mode\":\"compat\""));
+        assert!(compat_json.contains("\"hiddenCanvas2dOverlayAllowed\":true"));
+        assert!(compat_json.contains("\"directReplayRequired\":false"));
+
+        let invalid = doc.get_canvaskit_replay_plan_native(0, "canvas2d");
+        assert!(invalid.is_err());
+    }
+
+    #[test]
     fn test_normalize_canvas_scale_rejects_invalid_page_dimensions() {
         for (width, height) in [
             (0.0, 100.0),


### PR DESCRIPTION
## What

- CanvasKit replay policy plan을 추가했습니다.
- `getCanvasKitReplayPlan(page, mode)` native/WASM API를 추가해서 현재 `PageLayerTree`가 CanvasKit에서 어떻게 replay될지 diagnostics JSON으로 확인할 수 있게 했습니다.
- CanvasKit mode를 `default` / `compat`으로 나눴습니다.
  - `default`: native Skia로 이어지는 direct replay 준비 모드입니다. 지원하지 못하는 op를 Canvas2D overlay로 조용히 숨기지 않고 `directRequired` / `hiddenOverlayForbidden`으로 드러냅니다.
  - `compat`: 사용자-visible 안정성을 위한 transition 모드입니다. 아직 direct replay가 없는 op는 `compatOverlay`로 표시하고, overlay 허용 여부를 명시합니다.
- P14에서 추가한 `analyze_text_variant_selection` 결과를 CanvasKit replay plan에 연결했습니다. `GlyphRun` / `GlyphOutline`은 여전히 strict sidecar gate를 통과할 때만 direct candidate가 되고, 아니면 `TextRun` fallback을 유지합니다.
- Studio wasm bridge에도 `getCanvasKitReplayPlan` fallback을 추가해서 새 wasm이 아니어도 호출부가 깨지지 않게 했습니다.
- `docs/text-ir-v2.md`와 README에 P15 방향을 문서화했습니다.

## Why

P14까지는 Text IR v2의 strict sidecar 후보와 backend selection diagnostics를 잡는 단계였습니다. P15는 그 다음 단계로, CanvasKit을 Canvas2D-assisted preview가 아니라 native Skia로 이어지는 독립 replay backend로 키우기 위한 policy boundary를 먼저 만듭니다.

이번 PR은 CanvasKit renderer를 실제 public path로 전환하지 않습니다. 목적은 “무엇이 direct replay 가능하고, 무엇이 아직 overlay/fallback인지”를 숨기지 않고 reviewer와 후속 PR이 볼 수 있게 만드는 것입니다. 특히 hidden Canvas2D overlay가 기본 경로처럼 굳어지지 않도록 `default` mode에서는 gap을 명시적으로 드러냅니다.

## Non-goals

- public Canvas / CanvasKit render path를 바꾸지 않습니다.
- CanvasKit에서 image/equation/form/text effect를 직접 그리도록 전환하지 않습니다.
- Canvas2D overlay를 실제로 제거하지 않습니다.
- `GlyphRun` / `GlyphOutline`을 canonical text path로 바꾸지 않습니다.
- native Skia glyph replay나 CanvasKit glyph replay를 기본값으로 켜지 않습니다.
- resource interning / font blob extraction은 하지 않습니다.

## Compatibility

- 기존 SVG/Canvas/native Skia 출력은 바뀌지 않습니다.
- `getCanvasKitReplayPlan`은 diagnostics-only API입니다.
- `default` mode는 hidden Canvas2D overlay를 금지하는 계획을 보여줄 뿐, 현재 public render output을 바꾸지 않습니다.
- `compat` mode는 transition overlay를 명시적으로 보고합니다.
- 새 wasm API가 없는 Studio 빌드에서도 bridge fallback이 빈 plan JSON을 반환합니다.

## 관련 이슈

Refs #536

## Tests

- [x] `git diff --check upstream/devel...HEAD`
- [x] `cargo test renderer::canvaskit_policy --lib`
- [x] `cargo test test_canvaskit_replay_plan_export_uses_mode_policy --lib`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --lib`

## 스크린샷

없음.

이번 PR은 renderer output 변경이 아니라 CanvasKit replay policy diagnostics 추가입니다.
