### PR TITLE
Task #935: HWPX wrap=TopAndBottom Picture 위치 외곽 overflow 해결

### DIFF
--- a/examples/diag_935.rs
+++ b/examples/diag_935.rs
@@ -1,0 +1,45 @@
+// [Task #935] HWPX wrap=TopAndBottom Picture 위치 회귀 검증.
+//
+// HWPX 변환본의 wrap=TopAndBottom Picture 가 page boundary 안에 위치하는지
+// 확인. 회귀 시 picture 가 우측으로 shift 되어 페이지 외곽 overflow.
+//
+// 사용: cargo run --release --example diag_935 [-- path/to.hwpx]
+
+use rhwp::document_core::DocumentCore;
+use std::path::PathBuf;
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    let path = args.get(1).map(PathBuf::from).unwrap_or_else(|| {
+        PathBuf::from("samples/hwp3-sample16-hwp5.hwpx")
+    });
+    let bytes = std::fs::read(&path).expect("read file");
+    let core = DocumentCore::from_bytes(&bytes).expect("parse");
+    let doc = core.document();
+
+    println!("파일: {:?}", path);
+    let mut wmf_count = 0;
+    let mut tac_topbot = 0;
+    for bd in &doc.bin_data_content {
+        if bd.extension.to_lowercase().contains("wmf") {
+            wmf_count += 1;
+            println!("  BinData id={} ext={:?} size={} bytes", bd.id, bd.extension, bd.data.len());
+        }
+    }
+    for sec in &doc.sections {
+        for para in &sec.paragraphs {
+            for ctrl in &para.controls {
+                if let rhwp::model::control::Control::Picture(p) = ctrl {
+                    if p.common.treat_as_char
+                        && matches!(p.common.text_wrap, rhwp::model::shape::TextWrap::TopAndBottom)
+                    {
+                        tac_topbot += 1;
+                    }
+                }
+            }
+        }
+    }
+    println!("WMF binary 수: {}", wmf_count);
+    println!("TAC wrap=TopAndBottom Picture 수: {}", tac_topbot);
+    println!("페이지 수: {}", core.page_count());
+}

--- a/mydocs/plans/task_m100_935.md
+++ b/mydocs/plans/task_m100_935.md
@@ -1,0 +1,75 @@
+# Task #935 수행 계획서 — HWPX 의 WMF binary 누락
+
+## 이슈
+
+[#935](https://github.com/edwardkim/rhwp/issues/935) — HWPX 파일의 내부 WMF binary 가 SVG 출력에 누락. 같은 원본의 HWP3 변환본 대비 SVG 크기 5% (3.4MB → 156KB).
+
+## 1차 진단 (사전 조사)
+
+### HWPX 내부 구조 (sample16-hwp5.hwpx)
+
+```
+BinData/image1.gif (2.9 KB)
+BinData/image2.gif (15.3 KB)
+BinData/image3.WMF (4.7 MB)   ← 대문자 .WMF
+BinData/image4.bmp (1.4 MB)
+BinData/image5.WMF (6.8 MB)   ← 대문자 .WMF
+BinData/image6.BMP (1.7 MB)
+BinData/image7.wmf (83 KB)    ← 소문자 .wmf
+```
+
+WMF 파일이 3개 존재. 확장자 대소문자 혼재 (.WMF, .wmf).
+
+### 검토한 잠재 원인
+
+| 원인 후보 | 검토 결과 |
+|----------|---------|
+| 확장자 대소문자 (.WMF vs .wmf) | ❌ — MIME 감지는 file signature (`D7 CD C6 9A` / `01 00 09 00`) 기반, 확장자 무관 |
+| HWPX BinData 로드 누락 | 확인 필요 (다음 단계) |
+| Picture/Shape 의 bin_data_id 매핑 | 확인 필요 |
+| SVG renderer 의 image 데이터 전달 | 확인 필요 |
+
+## 작업 범위
+
+### 영향 모듈
+- `src/parser/hwpx/mod.rs` — BinData 로드 (line 85, 123)
+- `src/parser/hwpx/section.rs` — Picture 추출 (line 1324 의 bin_data_id 매핑)
+- `src/renderer/svg.rs` — draw_image 호출까지 전달되는 경로
+
+## 절차 (waterfall)
+
+**Stage 1 — 진단 심화**
+- HWPX 파싱 후 IR (Document) 에서 Picture 컨트롤이 페이지 18 에 존재하는지
+- Picture 의 bin_data_id 가 DocInfo.bin_data_list 의 항목과 매핑되는지
+- BinData.data (bytes) 가 정상 WMF binary 인지
+- SVG renderer 의 draw_image 가 호출되는지 + 어떤 data 받는지
+
+**Stage 2 — Root cause 수정**
+- Stage 1 의 진단 결과에 따라 가장 큰 원인 수정
+
+**Stage 3 — 회귀 점검 + CI**
+- 다른 HWPX sample (sample14-hwp5.hwpx 등) 회귀 없음
+- HWP3 sample16: 페이지 수, WMF 처리 변화 없음 (HWP3 경로 무영향 확인)
+- cargo test --lib, clippy, wasm32 check 통과
+
+**Stage 4 — 최종 보고서 + PR**
+
+## 검증 기준
+
+- `hwp3-sample16-hwp5.hwpx` 페이지 18 SVG 크기 ≈ HWP3 동등 (3-4 MB 수준)
+- WMF inline marker (`wmf{N}_elem`) 등장
+- 시각: 다이어그램 (서버 구성도) 표시 가능
+- 다른 HWPX sample 회귀 없음
+- CI 모든 체크 통과
+
+## 잠재 위험
+
+- HWPX parser 변경이 HWP5 (OLE) 와 HWP3 의 동일 경로에 영향 가능 — 격리 필요
+- BinData 매핑 변경 시 Picture/Chart/Equation 등 image 사용 control 모두 영향 가능
+
+## scope 외 (별도 follow-up)
+
+- HWP5 의 WMF inline 미적용 — [#936](https://github.com/edwardkim/rhwp/issues/936) (다른 세션에서 진행)
+- HWPX 의 OLE chart, Form 등 다른 image type 영향 — 본 task scope 외
+
+작업지시자 승인 후 Stage 1 진단 심화 진행.

--- a/mydocs/working/task_m100_935_stage1.md
+++ b/mydocs/working/task_m100_935_stage1.md
@@ -1,0 +1,99 @@
+# Task #935 단계별 완료 보고서 — Stage 1 (진단 + 수정 통합)
+
+## 이슈
+
+[#935](https://github.com/edwardkim/rhwp/issues/935) — HWPX 의 WMF Picture 위치 산출 오류. 페이지 외곽선 밖으로 다이어그램이 overflow.
+
+## scope 정정
+
+- 초기 가설 ❌ "WMF binary 누락" — 진단 결과 binary 는 정상 로드 (6개 모두), `bin_data_id` 매핑 정상, image 데이터 전달 정상.
+- 실제 회귀 ✅ **HWPX 변환본의 wrap=TopAndBottom Picture 가 선행 TAC width 만큼 우측 shift 되어 페이지 외곽으로 overflow**.
+
+이전 PR #918 follow-up 시 "page 18 SVG 156KB" 로 진단했던 것은 **페이지 번호 매핑 불일치** 로 인한 잘못된 비교 (HWP3 page 18 ≠ HWPX page 18). 실제 다이어그램은 HWPX page 19 에 있고 image 자체는 존재.
+
+## Root cause
+
+`paragraph_layout` 의 inline emit 경로 (paragraph_layout.rs:1973~):
+
+```rust
+// 이전: wrap 종류 무관하게 inline emit
+if let Control::Picture(pic) = ctrl {
+    let pic_h = ...;
+    let img_y = ...;
+    // BoundingBox(x, ...) - x 는 선행 TAC 후 cursor 위치
+    let img_node = RenderNode::new(...,
+        BoundingBox::new(x, img_y, tac_w, pic_h));
+    line_node.children.push(img_node);
+}
+```
+
+HWPX `pi=394` 구성:
+- 3 controls: Table[0] (89mm) → Picture (161mm, wrap=TopAndBottom) → Table[2] (47mm)
+- 모두 tac=true → inline 으로 직렬 배치
+- Picture 의 inline x = Table[0] width = 336 px = 89mm shift
+- Picture 의 right edge = 472 + 608 = **1081 px**, page right edge = 794 px → **287px overflow**
+
+대신에 wrap=TopAndBottom Picture 는 본래 별도 line 에 배치되어야 함. `layout_shape_item` 이 적절한 pic_x (col_area.x + paragraph margin) 로 emit 하도록 위임해야 함.
+
+추가로 `layout_shape_item` 의 emit 조건 `!has_real_text` 가 whitespace 도 "real text" 로 판정 → HWPX whitespace-only 텍스트 paragraph 의 Picture emit 회피하던 문제 동반 수정.
+
+## 수정
+
+### 1. `src/renderer/layout/paragraph_layout.rs:1975-1985`
+
+inline Picture emit 전 조건 검사 추가:
+
+```rust
+// [Task #935] HWPX 변환본의 top-level paragraph 에 wrap=TopAndBottom Picture 가
+// 선행 TAC (table 등) 뒤에 inline 으로 emit 되면 선행 width 만큼 우측 shift →
+// 페이지 외곽 overflow. 표 셀 안의 Picture 는 영향 없음 (cell_ctx.is_some()).
+// top-level + TopAndBottom 인 경우만 layout_shape_item 으로 위임.
+if cell_ctx.is_none()
+    && matches!(pic.common.text_wrap, crate::model::shape::TextWrap::TopAndBottom)
+{
+    x += tac_w;
+    continue;
+}
+```
+
+### 2. `src/renderer/layout.rs:3329-3331`
+
+`layout_shape_item::has_real_text` 가 whitespace 제외:
+
+```rust
+// 이전: c > '\u{001F}' && c != '\u{FFFC}'  (whitespace 도 true)
+// 변경: !c.is_whitespace() 추가
+let has_real_text = para.text.chars()
+    .any(|c| !c.is_whitespace() && c > '\u{001F}' && c != '\u{FFFC}');
+```
+
+## 검증
+
+### 시각
+
+| 항목 | 수정 전 | 수정 후 |
+|------|--------|--------|
+| HWPX page 19 image x | 472.91 px (overflow) | **96.69 px** (정상) |
+| 페이지 외곽선 overflow | 287 px | 없음 |
+| 다이어그램 표시 | 페이지 밖 | 페이지 안 |
+
+### 자동화 검증
+
+| 항목 | 결과 |
+|------|------|
+| cargo test --lib | 1275 passed / 0 failed |
+| cargo check --target wasm32-unknown-unknown --lib | OK |
+| cargo clippy -- -D warnings | clean |
+| 다른 sample (sample14, sample16-hwp3/hwp5, exam_kor) 페이지 수 회귀 | 없음 |
+
+## scope 외 / 후속
+
+- **다이어그램 y 좌표 정합**: 수정 후 image y=75.6 (페이지 상단). 한컴 viewer 는 "가. 주전산센터..." 라벨 뒤에 위치. 별도 후속 작업 필요.
+- **다른 HWPX 변환본 검증**: sample14-hwp5.hwpx 등도 회귀 점검 필요 (CLI 페이지 수만 동일 확인).
+- **HWP5 의 WMF 처리** (이슈 #936) — 다른 세션에서 진행 예정.
+
+## 진단 도구
+
+`examples/diag_935.rs` — WMF binary / TAC wrap=TopAndBottom Picture 개수 검증.
+
+작업지시자 승인 후 커밋 + PR 진행.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -3326,8 +3326,12 @@ impl LayoutEngine {
                         // 박스 프레임 시각이 사라지고 후속 InFrontOfText 표가 위로 겹침.
                         // 호스트 문단에 실제 텍스트가 없으면 여기서 직접 이미지 노드를 생성하고
                         // y_offset을 그림 높이만큼 진행시킨다.
+                        // [Task #935] HWPX 변환본의 whitespace-only 텍스트 paragraph 도 본 분기로
+                        // emit 되어야 함 (paragraph_layout 의 inline 경로는 wrap=TopAndBottom Picture
+                        // 를 skip 하도록 변경; 여기서 받아 적절한 pic_x 로 emit). 공백 외 의미있는
+                        // 문자만 has_real_text 로 카운트.
                         let has_real_text = para.text.chars()
-                            .any(|c| c > '\u{001F}' && c != '\u{FFFC}');
+                            .any(|c| !c.is_whitespace() && c > '\u{001F}' && c != '\u{FFFC}');
                         // [Task #418/#376] paragraph_layout 의 빈 문단 + TAC Picture 분기에서
                         // 이미 ImageNode 가 emit 되어 inline_shape_position 이 등록된 경우,
                         // 여기서 또 push 하면 이중 emit 이 된다. 등록된 경우 push 를 스킵하고

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1973,6 +1973,17 @@ impl LayoutEngine {
                         if let (Some(p), Some(bdc)) = (para, bin_data_content) {
                             if let Some(ctrl) = p.controls.get(tac_ci) {
                                 if let Control::Picture(pic) = ctrl {
+                                    // [Task #935] HWPX 변환본의 top-level paragraph 에 wrap=TopAndBottom
+                                    // Picture 가 선행 TAC (table 등) 뒤에 inline 으로 emit 되면 선행
+                                    // width 만큼 우측 shift → 페이지 외곽 overflow. 표 셀 안의
+                                    // Picture 는 영향 없음 (cell_ctx.is_some()). top-level + TopAndBottom
+                                    // 인 경우만 layout_shape_item 으로 위임.
+                                    if cell_ctx.is_none()
+                                        && matches!(pic.common.text_wrap, crate::model::shape::TextWrap::TopAndBottom)
+                                    {
+                                        x += tac_w;
+                                        continue;
+                                    }
                                     let pic_h = hwpunit_to_px(pic.common.height as i32, self.dpi);
                                     let img_y = (y + baseline - pic_h).max(y);
                                     let bin_data_id = pic.image_attr.bin_data_id;


### PR DESCRIPTION
## Summary

closes #935 — HWPX 변환본의 wrap=TopAndBottom Picture (예: hwp3-sample16-hwp5.hwpx 의 서버 구성도) 가 페이지 외곽선 밖으로 overflow 되는 회귀 해결.

### Root cause

`paragraph_layout` 의 inline Picture emit 경로가 top-level paragraph 에서도 wrap=TopAndBottom Picture 를 inline 으로 emit. 선행 TAC (Table 등) width 만큼 picture x 가 우측 shift → 페이지 외곽 287px overflow.

HWPX `pi=394` 구성: Table[0] (89mm) → Picture (161mm) → Table[2] (47mm). Picture 의 inline x = Table[0] width = 336 px → right edge 1081 px (page right = 794 px) overflow.

### 수정 (2 파일)

1. **paragraph_layout.rs inline emit**: top-level (`cell_ctx.is_none()`) + wrap=TopAndBottom Picture 는 skip → `layout_shape_item` 으로 위임. 표 셀 안의 Picture 는 영향 없음.
2. **layout.rs layout_shape_item**: `has_real_text` 가 `!c.is_whitespace()` 추가 → whitespace-only text 도 본 분기로 emit.

## Test plan

- [x] cargo test --lib: 1275 passed / 0 failed
- [x] cargo check --target wasm32-unknown-unknown --lib: OK
- [x] cargo clippy -- -D warnings: clean
- [x] HWPX sample16 page 19 image x: 472.91 → 96.69 (페이지 안 정상)
- [x] CLI 다른 sample 페이지 수 회귀 없음 (sample14: 11p, sample16-hwp3: 64p, sample16-hwp5: 62p, exam_kor: 20p)

## 잔존 한계 / 별도 follow-up

- **다이어그램 y 좌표 정합**: 수정 후 image y=75.6 (페이지 상단). 한컴 viewer 의 "가. 주전산센터..." 라벨 뒤 위치와 다름. 별도 후속 작업.
- **HWP5 의 WMF 처리** ([#936](https://github.com/edwardkim/rhwp/issues/936)) — 다른 세션 진행 중.

## 진단 도구

`examples/diag_935.rs` — WMF binary / TAC wrap=TopAndBottom Picture 개수 검증:

```bash
cargo run --release --example diag_935 [-- path/to.hwpx]
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)