### PR TITLE
fix(serializer): OLE Storage BinData 4-byte size prefix 복원

### DIFF
--- a/src/serializer/cfb_writer.rs
+++ b/src/serializer/cfb_writer.rs
@@ -103,14 +103,35 @@ fn write_hwp_cfb(
 
     // 4. /BinData/BIN{XXXX}.{ext}
     // BinData는 개별 압축 속성에 따라 재압축
+    const CFB_MAGIC: [u8; 8] = [0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
     for content in bin_data_content {
-        let (storage_id, ext, should_compress) = find_bin_data_info_with_compress(bin_data_list, content, compressed);
+        let (storage_id, ext, should_compress) =
+            find_bin_data_info_with_compress(bin_data_list, content, compressed);
         let storage_name = format!("BIN{:04X}.{}", storage_id, ext);
         let path = format!("/BinData/{}", storage_name);
-        let data = if should_compress {
-            compress_stream(&content.data).unwrap_or_else(|_| content.data.clone())
+
+        // OLE Storage 복원: 파서(`load_bin_data_content`)는 내부 CFB 를 바로 노출하기 위해
+        // 선두 4-byte LE size prefix 를 제거(`drain(..4)`)한다. 직렬화 시 이를 다시 붙이지
+        // 않으면 한컴이 CFB 매직(D0CF11E0)을 OLE 개체 크기(~3.75GB)로 오인하여
+        // "메모리 부족" 오류가 발생한다. 파서의 strip 조건을 그대로 미러링한다.
+        let is_ole_storage = content.data.len() >= 8
+            && content.data[..8] == CFB_MAGIC
+            && bin_data_list
+                .iter()
+                .any(|bd| bd.data_type == BinDataType::Storage && bd.storage_id == content.id);
+        let payload: Vec<u8> = if is_ole_storage {
+            let mut v = Vec::with_capacity(content.data.len() + 4);
+            v.extend_from_slice(&(content.data.len() as u32).to_le_bytes());
+            v.extend_from_slice(&content.data);
+            v
         } else {
             content.data.clone()
+        };
+
+        let data = if should_compress {
+            compress_stream(&payload).unwrap_or_else(|_| payload.clone())
+        } else {
+            payload
         };
         streams.push((path, data));
     }

--- a/src/serializer/cfb_writer/tests.rs
+++ b/src/serializer/cfb_writer/tests.rs
@@ -1318,3 +1318,89 @@ fn write_hwp_with_cfb_crate(orig_data: &[u8]) -> Vec<u8> {
     let cursor = cfb.into_inner();
     cursor.into_inner()
 }
+
+/// OLE Storage BinData 는 `[4-byte LE size][CFB 컨테이너]` 형식이다.
+/// 파서(`load_bin_data_content`)가 내부 CFB 노출을 위해 size prefix 를 제거하므로,
+/// 직렬화 시 다시 복원해야 한다. 미복원 시 한컴이 CFB 매직(D0CF11E0)을 OLE 개체
+/// 크기(~3.75GB)로 오인하여 "메모리 부족" 오류로 문서를 열지 못한다.
+#[test]
+fn test_ole_storage_size_prefix_restored() {
+    use crate::model::bin_data::{BinData, BinDataContent, BinDataType};
+
+    // 가짜 OLE 내부 CFB: CFB 매직 + 임의 페이로드
+    let mut ole_cfb = vec![0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1];
+    ole_cfb.extend_from_slice(&[0x42u8; 64]);
+
+    let mut doc_info = DocInfo::default();
+    doc_info.bin_data_list.push(BinData {
+        data_type: BinDataType::Storage,
+        storage_id: 1,
+        extension: Some("OLE".to_string()),
+        ..Default::default()
+    });
+
+    let doc = Document {
+        header: FileHeader {
+            version: HwpVersion {
+                major: 5,
+                minor: 0,
+                build: 6,
+                revision: 1,
+            },
+            flags: 0,
+            compressed: false,
+            encrypted: false,
+            distribution: false,
+            raw_data: None,
+        },
+        doc_properties: DocProperties {
+            section_count: 1,
+            page_start_num: 1,
+            ..Default::default()
+        },
+        doc_info,
+        sections: vec![crate::model::document::Section {
+            section_def: SectionDef::default(),
+            paragraphs: vec![Paragraph {
+                line_segs: vec![LineSeg {
+                    line_height: 400,
+                    baseline_distance: 320,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }],
+            raw_stream: None,
+        }],
+        preview: None,
+        bin_data_content: vec![BinDataContent {
+            id: 1,
+            data: ole_cfb.clone(),
+            extension: "OLE".to_string(),
+        }],
+        extra_streams: Vec::new(),
+    };
+
+    let bytes = serialize_hwp(&doc).unwrap();
+    let mut cfb = crate::parser::cfb_reader::CfbReader::open(&bytes).unwrap();
+    let stream = cfb.read_bin_data("BIN0001.OLE").unwrap();
+
+    // 선두 4바이트 = OLE CFB 길이의 LE size prefix
+    assert!(
+        stream.len() >= 12,
+        "OLE 스트림이 prefix + CFB 매직 길이 이상이어야 한다"
+    );
+    let prefix = u32::from_le_bytes([stream[0], stream[1], stream[2], stream[3]]);
+    assert_eq!(
+        prefix as usize,
+        ole_cfb.len(),
+        "4-byte size prefix 가 OLE CFB 길이와 일치해야 한다"
+    );
+    // prefix 직후가 내부 CFB 매직
+    assert_eq!(
+        &stream[4..12],
+        &[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1],
+        "size prefix 다음은 CFB 매직이어야 한다"
+    );
+    // prefix 를 제외한 본문이 원본 OLE CFB 와 동일
+    assert_eq!(&stream[4..], &ole_cfb[..], "OLE CFB 본문이 보존되어야 한다");
+}


### PR DESCRIPTION
## 문제

OLE 임베디드 개체를 포함한 HWP 문서를 rhwp 로 파싱한 뒤 다시 직렬화(`serialize_hwp`)하면, 결과 파일을 한컴 오피스에서 열 때 **"메모리 부족"** 오류가 발생하며 문서가 열리지 않습니다. (rhwp 자체 파서로는 정상 재열림)

## 원인

HWP 의 OLE Storage BinData 스트림은 `[4-byte LE size][CFB 컨테이너]` 형식입니다.

- 파서 `load_bin_data_content` 는 내부 CFB(`D0CF11E0…`)를 바로 노출하기 위해 이 4-byte size prefix 를 제거합니다 (`decompressed.drain(..4)`, Task #195).
- 그러나 직렬화기 `cfb_writer::write_hwp_cfb` 는 BinData 를 그대로 다시 쓰며 prefix 를 복원하지 않습니다.

→ 재저장된 파일의 OLE BinData 는 prefix 없이 곧바로 CFB 매직으로 시작합니다. 한컴은 첫 4바이트 `D0 CF 11 E0` 를 OLE 개체 크기로 해석 → LE `0xE011CFD0` ≈ **3.75 GB** 할당 시도 → "메모리 부족".

실제 문서 비교에서, 재직렬화 파일의 모든 CFB 스트림(DocInfo · BodyText · 이미지 BinData 등)은 원본과 바이트 단위로 동일했고 **OLE BinData 만 정확히 4바이트 짧았습니다**.

## 수정

`write_hwp_cfb` 의 BinData 직렬화 루프에서, BinData 가 OLE Storage 타입이고 내용이 CFB 매직으로 시작하면 4-byte LE size prefix 를 복원합니다. 파서의 strip 조건(`is_storage && data[..8] != magic && data[4..12] == magic`)을 그대로 미러링하므로, prefix 가 없던 입력에는 영향을 주지 않습니다.

## 검증

- 회귀 테스트 `test_ole_storage_size_prefix_restored` 추가
- `cargo test serializer::cfb_writer` — 16개 전부 통과
- OLE 개체를 포함한 실제 문서 재직렬화 후 전 CFB 스트림이 원본과 바이트 일치 확인, 한컴 오피스에서 "메모리 부족" 없이 정상 열림 확인
