### PR TITLE
fix: HWP3 margin_bottom 원본값 보존 — 쪽 테두리/페이지 번호 위치 정상화

### DIFF
--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -23,6 +23,9 @@ pub struct PageDef {
     pub margin_footer: HwpUnit,
     /// 제본 여백
     pub margin_gutter: HwpUnit,
+    /// 페이지네이션 하단 허용치 (HWPUNIT). margin_bottom 을 변조하지 않고
+    /// paginator 에게만 추가 공간을 허용할 때 사용. 기본 0.
+    pub pagination_bottom_tolerance: HwpUnit,
     /// 속성 비트 플래그
     pub attr: u32,
     /// 용지 방향 (0: 좁게/세로, 1: 넓게/가로)

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2347,12 +2347,14 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
         margin_left: (doc_info.left_margin as u32) * 4,
         margin_right: (doc_info.right_margin as u32) * 4,
         margin_top: (doc_info.top_margin as u32) * 4,
-        // HWP3 last-line tolerance: 한글97은 마지막 줄이 본문 영역을 약간 넘어도 해당 페이지에 배치한다.
-        // 1600 HWPUNIT(= 한 빈 줄 높이)만큼 하단 여백을 줄여 이 동작을 근사한다.
-        margin_bottom: ((doc_info.bottom_margin as u32) * 4).saturating_sub(1600),
+        margin_bottom: (doc_info.bottom_margin as u32) * 4,
         margin_header: (doc_info.header_length as u32) * 4,
         margin_footer: (doc_info.footer_length as u32) * 4,
         margin_gutter: (doc_info.binding_margin as u32) * 4,
+        // HWP3 last-line tolerance: 한글97은 마지막 줄이 본문 영역을 약간 넘어도 해당 페이지에 배치한다.
+        // margin_bottom 을 직접 줄이면 쪽 테두리/페이지 번호 위치까지 영향받으므로
+        // pagination_bottom_tolerance 로 paginator 에게만 추가 공간을 허용한다.
+        pagination_bottom_tolerance: 1600,
         landscape: doc_info.paper_direction != 0,
         ..Default::default()
     };

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2354,7 +2354,8 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
         // HWP3 last-line tolerance: 한글97은 마지막 줄이 본문 영역을 약간 넘어도 해당 페이지에 배치한다.
         // margin_bottom 을 직접 줄이면 쪽 테두리/페이지 번호 위치까지 영향받으므로
         // pagination_bottom_tolerance 로 paginator 에게만 추가 공간을 허용한다.
-        pagination_bottom_tolerance: 1600,
+        // min(1600, margin_bottom) 으로 clamp: 기존 saturating_sub 동작과 동일한 상한 유지.
+        pagination_bottom_tolerance: 1600u32.min((doc_info.bottom_margin as u32) * 4),
         landscape: doc_info.paper_direction != 0,
         ..Default::default()
     };

--- a/src/renderer/layout/integration_tests.rs
+++ b/src/renderer/layout/integration_tests.rs
@@ -1484,7 +1484,8 @@ mod tests {
             return;
         };
         let svg = core.render_page_svg_native(0).unwrap_or_default();
-        let count = count_text_at_y(&svg, 1061.4666666666667);
+        // Issue #951: margin_bottom 원본값 보존 후 쪽번호 위치 보정 (1061.4→1050.8)
+        let count = count_text_at_y(&svg, 1050.8);
         assert_eq!(
             count, 3,
             "hwp3-sample.hwp 페이지 1 (NewNumber 0개) 은 쪽번호 표시되어야 함 (회귀 방지)."

--- a/src/renderer/page_layout.rs
+++ b/src/renderer/page_layout.rs
@@ -28,6 +28,8 @@ pub struct PageLayoutInfo {
     pub separator_width: u8,
     /// 단 구분선 색상
     pub separator_color: u32,
+    /// 페이지네이션 하단 허용치 (px). body_area 를 변경하지 않고 paginator 에게만 추가 공간 제공.
+    pub pagination_tolerance_px: f64,
 }
 
 /// 레이아웃 영역 (픽셀 단위)
@@ -73,6 +75,8 @@ impl PageLayoutInfo {
         // 다단 영역 계산
         let column_areas = calculate_column_areas(&body_area, column_def, dpi);
 
+        let pagination_tolerance_px = hwpunit_to_px(page_def.pagination_bottom_tolerance as i32, dpi);
+
         Self {
             page_width,
             page_height,
@@ -85,6 +89,7 @@ impl PageLayoutInfo {
             separator_type: column_def.separator_type,
             separator_width: column_def.separator_width,
             separator_color: column_def.separator_color,
+            pagination_tolerance_px,
         }
     }
 
@@ -93,9 +98,9 @@ impl PageLayoutInfo {
         Self::from_page_def(page_def, column_def, DEFAULT_DPI)
     }
 
-    /// 본문 영역의 사용 가능한 높이 (각주 영역 제외)
+    /// 본문 영역의 사용 가능한 높이 (각주 영역 제외 + 페이지네이션 허용치 포함)
     pub fn available_body_height(&self) -> f64 {
-        self.body_area.height - self.footnote_area.height
+        self.body_area.height - self.footnote_area.height + self.pagination_tolerance_px
     }
 
     /// 단 너비 (HWPUNIT) — vpos 보정에서 segment_width 비교에 사용

--- a/src/renderer/page_number.rs
+++ b/src/renderer/page_number.rs
@@ -106,6 +106,7 @@ mod tests {
             separator_type: 0,
             separator_width: 0,
             separator_color: 0,
+            pagination_tolerance_px: 0.0,
         }
     }
 


### PR DESCRIPTION
closes #951

## 문제

`src/parser/hwp3/mod.rs`에서 `margin_bottom`을 `saturating_sub(1600)`으로 직접 감산하여 HWP3 last-line tolerance를 구현했으나, 이로 인해:
- 쪽 테두리 위치가 한컴 대비 ~5.6mm 위로 올라감
- 페이지 번호 위치가 잘못됨 (rhwp 4.4mm vs 한컴 10.0mm 하단 여백)

## 수정

`PageDef`에 `pagination_bottom_tolerance` 필드를 추가하여 margin_bottom 원본값은 보존하면서 paginator에게만 추가 공간을 허용합니다.

- `PageDef.pagination_bottom_tolerance: HwpUnit` — 기본 0
- `PageLayoutInfo.pagination_tolerance_px` — `available_body_height()`에 반영
- HWP3 파서: `margin_bottom` 그대로 유지, `pagination_bottom_tolerance: 1600`으로 분리

## 검증

- `cargo test` — 1288 passed (page number y좌표 보정 포함)
- `cargo clippy -- -D warnings` — 0 warnings
- `export-svg samples/hwp3-sample16.hwp -p 0` 시각 확인: 쪽 테두리 하단 여백 정상

감사합니다.