### PR TITLE
fix: WMF 한글 텍스트 y 위치 50% 하단 오프셋 보정

### DIFF
--- a/src/wmf/converter/svg/mod.rs
+++ b/src/wmf/converter/svg/mod.rs
@@ -813,14 +813,16 @@ impl crate::wmf::converter::Player for SVGPlayer {
                 } + match self.context_current.text_align_vertical {
                     // [Task #965 / PR #918 Stage 33-A] WMF 의 ExtTextOut y 는
                     // text_align_vertical 에 따라 reference point 가 결정된다:
-                    //   VTA_BASELINE (default): y 가 baseline — 그대로 사용
                     //   VTA_TOP: y 가 cell 의 top — baseline = y + ascent
                     //   VTA_BOTTOM: y 가 cell 의 bottom — baseline = y - descent
+                    //   VTA_BASELINE (default): WMF spec 상으로는 y=baseline 이지만,
+                    //     한컴 WMF 생성기는 SetTextAlign 과 무관하게 y 좌표를 텍스트
+                    //     top 기준으로 제공한다 (Issue #914). HWP 내장 WMF 는 모두
+                    //     한컴 생성이므로 VTA_TOP 과 동일하게 ascent 보정한다.
                     // font.height 의 부호는 magnitude 의 해석 (cell vs char) 만 바꾸며
-                    // reference point 와 무관하다 (이전 구현이 font.height < 0 일 때
-                    // -font.height 만큼 y 를 더했던 것은 잘못된 보정으로, 텍스트가 박스
-                    // 하단으로 baseline shift 되는 원인).
-                    VerticalTextAlignmentMode::VTA_TOP => {
+                    // reference point 와 무관하다.
+                    VerticalTextAlignmentMode::VTA_TOP |
+                    VerticalTextAlignmentMode::VTA_BASELINE => {
                         let em = font.height.abs();
                         (em as f64 * 0.8) as i16
                     }
@@ -828,8 +830,6 @@ impl crate::wmf::converter::Player for SVGPlayer {
                         let em = font.height.abs();
                         -((em as f64 * 0.2) as i16)
                     }
-                    VerticalTextAlignmentMode::VTA_BASELINE => 0,
-                    // VTA_CENTER / VTA_LEFT: 드물게 사용; baseline 과 동일 처리
                     _ => 0,
                 },
             };

--- a/src/wmf/converter/svg/mod.rs
+++ b/src/wmf/converter/svg/mod.rs
@@ -1547,7 +1547,9 @@ impl crate::wmf::converter::Player for SVGPlayer {
                     + match self.context_current.text_align_vertical {
                         // [Task #965 / PR #918 Stage 33-A] META_TEXTOUT 의 y 도 동일.
                         // ext_text_out 의 baseline 보정과 일관성 유지.
-                        VerticalTextAlignmentMode::VTA_TOP => {
+                        // Issue #914: 한컴 WMF 생성기는 VTA_BASELINE 에서도 y=top.
+                        VerticalTextAlignmentMode::VTA_TOP |
+                        VerticalTextAlignmentMode::VTA_BASELINE => {
                             let em = font.height.abs();
                             (em as f64 * 0.8) as i16
                         }
@@ -1555,7 +1557,6 @@ impl crate::wmf::converter::Player for SVGPlayer {
                             let em = font.height.abs();
                             -((em as f64 * 0.2) as i16)
                         }
-                        VerticalTextAlignmentMode::VTA_BASELINE => 0,
                         _ => 0,
                     },
             };


### PR DESCRIPTION
closes #914

## 문제

`samples/hwp3-sample16.hwp` 페이지 18 WMF 다이어그램에서 한글 텍스트("주전산센터 목표시스템 구성(안)")가 박스 중앙이 아닌 글자 높이 약 50% 하단으로 출력됩니다.

## 원인

한컴 WMF 생성기는 `SetTextAlign` 설정과 무관하게 y 좌표를 텍스트 **top** 기준으로 제공합니다. 기존 코드는 `VTA_BASELINE` (기본값)일 때 y 를 baseline 으로 해석하여 보정 없이 사용 → 텍스트가 `em × 0.8` (ascent) 만큼 아래로 밀렸습니다.

## 수정

`VTA_BASELINE` 분기도 `VTA_TOP` 과 동일하게 ascent 오프셋 (`em × 0.8`)을 적용합니다. HWP 내장 WMF 는 모두 한컴 생성이므로 안전합니다.

## 검증

- `cargo test` — 1288 passed
- `cargo clippy -- -D warnings` — 0 warnings
- `export-svg samples/hwp3-sample16.hwp -p 17` 시각 확인: 텍스트가 박스 중앙에 정렬

감사합니다.