### PR TITLE
Task #948: PageLayerTree textRun display text contract

### DIFF
--- a/mydocs/orders/20260518.md
+++ b/mydocs/orders/20260518.md
@@ -74,3 +74,17 @@
 - [x] 작업지시자 시각 판정 통과
 
 보고서: `mydocs/report/task_m100_974_report.md`
+
+---
+
+## Task #948 — PageLayerTree textRun JSON 렌더링용 텍스트/positions 추가
+
+- [x] Issue 확인 + branch 생성
+- [x] 수행 계획서 작성
+- [x] Stage 1 — PageLayerTree JSON source/display text 경로 진단
+- [x] Stage 2 — 구현 계획서 작성
+- [x] Stage 3 — `displayText` / `displayPositions` additive contract 구현
+- [x] Stage 4 — cargo test + clippy 검증 통과
+- [x] Stage 5 — 최종 보고서 작성
+
+보고서: `mydocs/report/task_m100_948_report.md`

--- a/mydocs/plans/task_m100_948.md
+++ b/mydocs/plans/task_m100_948.md
@@ -1,0 +1,118 @@
+# 수행 계획서 — Task #948: PageLayerTree textRun JSON 렌더링용 텍스트/positions 추가
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 마일스톤: M100 / v1.0.0
+- 브랜치: `task-948-pagelayertree-display-text` (base = upstream/devel `39d90d9d`)
+- 관련: [#937](https://github.com/edwardkim/rhwp/issues/937), [PR #947](https://github.com/edwardkim/rhwp/pull/947)
+
+## 1. 증상
+
+#947 에서 SVG / WebCanvas / HTML / Canvas / Skia 계열 렌더러는 core 의 PUA display text 규칙을 사용하도록 정정되었다.
+
+하지만 `PageLayerTree` JSON 경로는 아직 `textRun` op 에 문서 원문 `text` 만 내보내고, 실제 렌더러가 그려야 하는 display text 를 별도 필드로 제공하지 않는다.
+
+현재 구조에서는 PageLayerTree 소비자가 다음 중 하나를 선택해야 한다.
+
+- `text` 를 그대로 그려 `U+F012B` 같은 한컴 PUA 문자를 깨진 글리프로 출력
+- downstream renderer 에 rhwp core 의 PUA/display-text 규칙을 중복 구현
+
+이는 PageLayerTree 를 renderer-independent paint contract 로 쓰려는 방향과 맞지 않는다.
+
+## 2. 목표
+
+`textRun` JSON 에 source text 와 draw/display text 를 분리해서 제공한다.
+
+- 기존 `text`: 문서 원문/IR 의미 보존용 텍스트로 유지
+- 기존 `positions`: 기존 호환성을 위해 `text` 기준 위치로 유지
+- 신규 `displayText`: core 가 해석한 실제 렌더링용 텍스트
+- 신규 `displayPositions`: `displayText` 기준 위치 배열
+
+downstream fallback 규칙은 다음 계약을 의도한다.
+
+```text
+drawText = displayText ?? text
+drawPositions = displayPositions ?? positions
+```
+
+## 3. 비목표
+
+- 모든 PUA 문자의 의미를 추측하지 않는다.
+- C ABI 를 추가하지 않는다.
+- 특정 downstream renderer 를 수정하지 않는다.
+- 일반 complex text shaping 개선은 포함하지 않는다.
+- 기존 `text` / `positions` 의미를 변경하지 않는다.
+
+## 4. 예상 수정 범위
+
+### 4.1 PUA display text helper 공유화
+
+현재 렌더러별로 쓰는 PUA 표시 변환을 PageLayerTree JSON 생성 경로에서도 재사용 가능하게 정리한다.
+
+핵심 규칙:
+- 옛한글 PUA 확장
+- 기존 PUA bullet/char-overlap 표시 규칙
+- `U+F012B -> "(인)"`
+- `U+F081C -> ""`
+- 알 수 없는 PUA 는 변환하지 않음
+
+### 4.2 `TextRunNode` 또는 paint/json 경로에 display text 산출 연결
+
+`src/paint/json.rs` 의 `textRun` JSON 출력 시 display text 를 계산하고, 원문과 달라지는 경우 `displayText` / `displayPositions` 를 추가한다.
+
+후보:
+- `TextRunNode` 에 display text 필드를 보존하는 방식
+- JSON export 시 공용 helper 로 계산하는 방식
+
+구현 계획서에서 기존 렌더 트리 데이터 흐름을 확인한 뒤 더 작은 변경을 선택한다.
+
+### 4.3 positions 계산 기준 분리
+
+`positions` 는 기존처럼 `run.text` 기준으로 유지한다.
+
+`displayPositions` 는 `displayText` 기준으로 계산한다. 특히 `U+F012B -> "(인)"` 처럼 1 codepoint 가 여러 문자로 확장되는 케이스에서 `displayText` 와 `displayPositions` 길이 기준이 일치해야 한다.
+
+## 5. 단계 구성
+
+- **Stage 1**: 현행 경로 정밀 확인
+  - `RenderNodeType::TextRun` → `PaintOp::TextRun` → `PageLayerTree::to_json` 흐름 확인
+  - #947 display text helper 위치와 적용 범위 확인
+  - `samples/복학원서.hwp` page 0 의 현재 PageLayerTree JSON 증상 재현
+
+- **Stage 2**: 구현 계획서 작성
+  - helper 공유 위치 확정
+  - `displayText` / `displayPositions` 출력 조건 확정
+  - 테스트 위치와 assertion 확정
+
+- **Stage 3**: 구현
+  - 공용 display text helper 적용
+  - `textRun` JSON additive 필드 추가
+  - source-compatible contract 유지
+
+- **Stage 4**: 검증
+  - `samples/복학원서.hwp` 기반 PageLayerTree JSON 회귀 테스트
+  - `displayText` 에 `(인)` 포함
+  - `displayText` 에 `U+F012B` / `U+F081C` 미포함
+  - `displayPositions` 가 `displayText` 기준과 일치
+  - 일반 textRun fallback 호환성 확인
+
+- **Stage 5**: 최종 보고 및 PR 준비
+  - 단계 보고서 / 최종 보고서 작성
+  - `cargo test` 및 필요한 한정 테스트 결과 정리
+  - PR 본문에 source/display contract 명시
+
+## 6. 위험 평가
+
+| 위험 | 평가 | 대응 |
+|------|------|------|
+| JSON schema 소비자 호환성 | 중 | additive field 로만 추가, 기존 `text` / `positions` 의미 유지 |
+| display text 와 display positions 불일치 | 중 | 동일 helper 결과 문자열 기준으로 위치 계산, 테스트로 길이/순서 고정 |
+| PUA 규칙 중복/드리프트 | 중 | 기존 렌더러와 PageLayerTree 가 같은 helper 를 쓰도록 정리 |
+| 알 수 없는 PUA 오변환 | 낮음 | 명시 규칙 없는 PUA 는 원문 유지 |
+| JSON 크기 증가 | 낮음 | 가능하면 `displayText != text` 인 경우에만 신규 필드 출력 |
+
+## 7. 진행 규칙
+
+- 자동 진행 안함
+- 단계별 명시 승인 후 다음 단계 진행
+- 소스 수정 전 구현 계획서 승인 필요
+- 이슈 close 는 작업지시자 승인 후에만 수행

--- a/mydocs/plans/task_m100_948_impl.md
+++ b/mydocs/plans/task_m100_948_impl.md
@@ -1,0 +1,196 @@
+# 구현 계획서 — Task #948: PageLayerTree textRun displayText/displayPositions contract
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 수행 계획서: `mydocs/plans/task_m100_948.md`
+- Stage 1 보고서: `mydocs/working/task_m100_948_stage1.md`
+- 브랜치: `task-948-pagelayertree-display-text`
+
+## 1. 구현 목표
+
+PageLayerTree JSON 의 `textRun` op 에 source text 와 draw/display text 를 분리해 제공한다.
+
+기존 필드 의미는 바꾸지 않는다.
+
+- `text`: 기존처럼 `run.text` 원문
+- `positions`: 기존처럼 `run.text` 기준 위치
+- `clusters`: 기존처럼 `run.text` 기준 cluster/source range
+
+신규 additive field:
+
+- `displayText`: 실제 downstream renderer 가 draw 해야 하는 텍스트
+- `displayPositions`: `displayText` 기준 위치
+
+소비자 fallback:
+
+```text
+drawText = displayText ?? text
+drawPositions = displayPositions ?? positions
+```
+
+## 2. 수정 파일
+
+### 2.1 `src/renderer/composer.rs`
+
+렌더링용 plain text helper 를 공용 함수로 추가한다.
+
+후보 함수:
+
+```rust
+pub fn expand_pua_display_text(text: &str) -> String
+```
+
+처리 순서:
+
+1. `U+F081C` 는 출력에서 제거
+2. `pua_plain_text_display(ch)` 적용
+   - `U+F012B -> "(인)"`
+3. `map_pua_old_hangul(ch)` 적용
+4. `layout::map_pua_bullet_char(ch)` 적용
+5. 알 수 없는 PUA 는 원문 유지
+
+기존 `expand_pua_render_text()` 는 호환성을 위해 유지하되, 가능하면 새 helper 를 호출하도록 정리한다.
+
+주의:
+
+- `effective_text_for_metrics()` 의 `U+F081C` 원문 측정 예외는 유지한다.
+- CharOverlap 전용 숫자 변환(`pua_to_display_text`)은 기존 역할을 유지한다.
+
+### 2.2 `src/paint/json.rs`
+
+`PaintOp::TextRun` 직렬화에 display field 를 추가한다.
+
+구현 후보:
+
+```rust
+fn display_text_for_text_run(run: &TextRunNode) -> Option<String>
+```
+
+규칙:
+
+- `composer::expand_pua_display_text(&run.text)` 결과가 `run.text` 와 다르면 `Some(display)`
+- 같으면 `None`
+- `displayText` 는 `display_text_for_text_run()` 이 `Some` 인 경우에만 출력
+- `displayPositions` 는 동일 display 문자열 기준 `compute_char_positions(display, &run.style)` 로 출력
+- 단, `displayText == ""` 인 숨김 filler 케이스는 `displayPositions: []` 로 출력
+
+신규 helper:
+
+```rust
+fn write_text_positions_for_text(buf: &mut String, text: &str, style: &TextStyle)
+```
+
+기존 `write_text_positions(buf, run)` 은 source-compatible 유지하되 내부에서 새 helper 를 재사용한다.
+
+`clusters` 는 이번 task 에서 변경하지 않는다. source range contract 는 원문 기준이어야 하며, display text 는 별도 draw hint 로만 제공한다.
+
+### 2.3 `src/paint/schema.rs`
+
+PageLayerTree additive contract 이므로 schema minor 를 올린다.
+
+- `schema_minor_version: 11 -> 12`
+- `layer_tree_schema_contract_is_stable` 테스트 갱신
+
+### 2.4 `src/paint/json.rs` metadata
+
+`usedFeatures` / `knownFeatures` 에 display text feature 를 반영한다.
+
+제안 feature name:
+
+```text
+text.displayText
+```
+
+규칙:
+
+- `knownFeatures` 에 항상 포함
+- 실제 display field 가 존재하는 tree 에만 `usedFeatures` 에 포함
+- `requiredFeatures` 는 비워 둔다. 기존 소비자는 `text` / `positions` fallback 이 가능해야 한다.
+
+이를 위해 text feature 탐색 구조체에 `has_display_text` 를 추가한다.
+
+## 3. 테스트 계획
+
+### 3.1 `tests/issue_948.rs` 신규
+
+fixture:
+
+- `samples/복학원서.hwp`, page 0
+
+검증:
+
+1. PageLayerTree JSON 에 원문 `U+F012B` 가 `text` 또는 `textSources` 에 보존됨
+2. `displayText` 가 존재하고 `(인)(Signature)` 를 포함
+3. `displayText` 에 `U+F012B` / `U+F081C` 가 포함되지 않음
+4. `displayPositions` 가 존재
+5. `displayPositions` 원소 수가 `displayText.chars().count() + 1` 과 일치하는 textRun 이 존재
+6. 일반 textRun 은 `displayText` 를 불필요하게 출력하지 않음
+
+JSON 파싱은 `serde_json::Value` 를 사용한다. string contains 기반 검증만으로는 `displayPositions` 길이와 해당 `displayText` 의 pair 를 안정적으로 검증하기 어렵기 때문이다.
+
+### 3.2 `src/paint/json.rs` 단위 테스트 추가
+
+작은 synthetic `TextRunNode` 로 다음을 고정한다.
+
+- `text = "\u{F012B}(Signature)"`
+- JSON 에 `text:"\uF012B(Signature)"` 보존
+- JSON 에 `displayText:"(인)(Signature)"` 출력
+- `positions` 는 source 기준
+- `displayPositions` 는 display 기준
+- `usedFeatures` 에 `text.displayText` 포함
+
+또 다른 synthetic 일반 textRun:
+
+- `text = "ABC"`
+- `displayText` 미출력
+- `text.displayText` feature 미사용
+
+## 4. 검증 명령
+
+우선 실행:
+
+```bash
+cargo test --test issue_948
+cargo test --test issue_937
+cargo test page_layer_tree_export
+cargo test -p rhwp paint::json
+cargo test -p rhwp paint::schema
+```
+
+최종 최소 검증:
+
+```bash
+cargo test
+```
+
+시간이 길거나 환경 문제가 있으면 한정 테스트 결과와 미실행 범위를 보고한다.
+
+## 5. 호환성 판단
+
+이 변경은 additive 이다.
+
+- 기존 소비자: `text` / `positions` 계속 사용 가능
+- 신규 소비자: `displayText` / `displayPositions` 우선 사용 가능
+- schema major 는 유지
+- schema minor 만 additive revision 으로 갱신
+- `requiredFeatures` 는 변경하지 않음
+
+## 6. 위험 및 대응
+
+| 위험 | 대응 |
+|------|------|
+| source range 와 display text range 혼동 | `clusters` 는 source 기준 유지, displayPositions 만 display 기준 명시 |
+| JSON 크기 증가 | `displayText != text` 인 경우에만 신규 field 출력 |
+| helper 중복 | `composer.rs` 공용 helper 를 JSON / 렌더러에서 공유 |
+| `U+F081C` 측정 회귀 | `effective_text_for_metrics()` 예외 유지, display helper 에서만 제거 |
+| schema feature drift | schema minor + `knownFeatures` / `usedFeatures` 테스트로 고정 |
+
+## 7. 구현 순서
+
+1. `composer.rs` 에 공용 display text helper 추가 및 기존 helper 정리
+2. `json.rs` 에 display text 산출 / display positions writer 추가
+3. `json.rs` metadata feature flag 추가
+4. `schema.rs` minor version 갱신
+5. synthetic JSON 단위 테스트 추가
+6. `tests/issue_948.rs` 통합 테스트 추가
+7. 한정 테스트 실행
+8. Stage 3 보고서 작성

--- a/mydocs/report/task_m100_948_report.md
+++ b/mydocs/report/task_m100_948_report.md
@@ -1,0 +1,138 @@
+# Task #948 — 최종 보고서
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 마일스톤: M100 / v1.0.0
+- 브랜치: `task-948-pagelayertree-display-text`
+- 기간: 2026-05-18
+
+## 1. 작업 범위
+
+PageLayerTree JSON 의 `textRun` op 에 source text 와 렌더링용 display text 를 분리하는 additive contract 를 추가했다.
+
+이번 작업의 목표는 모든 PUA 문자의 의미를 추측하는 것이 아니라, rhwp core 가 이미 알고 있는 한컴/HWP PUA 표시 규칙을 renderer-independent paint contract 인 PageLayerTree JSON 에도 전달하는 것이다.
+
+## 2. Root cause
+
+기존 PageLayerTree JSON 은 `textRun` 에 다음 필드만 제공했다.
+
+- `text`: `run.text`
+- `positions`: `run.text` 기준 위치
+- `clusters`: `run.text` 기준 cluster/source range
+
+이 구조에서는 `U+F012B -> "(인)"` 처럼 source text 와 실제 렌더링 문자열 길이가 달라지는 경우, PageLayerTree 소비자가 다음 중 하나를 선택해야 했다.
+
+- `text` 를 그대로 그려 PUA glyph 를 깨진 문자로 출력
+- downstream renderer 에 rhwp core 의 PUA/display text 규칙을 중복 구현
+
+이는 PageLayerTree 를 renderer-independent paint contract 로 쓰려는 방향과 맞지 않는다.
+
+## 3. Fix
+
+### 3.1 display text helper
+
+`src/renderer/composer.rs` 에 `expand_pua_display_text()` 를 추가했다.
+
+처리 범위:
+
+- `U+F081C` TAC filler 제거
+- `U+F012B -> "(인)"`
+- Hanyang-PUA 옛한글 자모 시퀀스 확장
+- 기존 PUA bullet mapping 적용
+- 알 수 없는 PUA 는 원문 유지
+
+기존 `expand_pua_render_text()` 는 새 helper 를 호출하도록 유지했다.
+
+### 3.2 PageLayerTree JSON contract
+
+`src/paint/json.rs` 의 `PaintOp::TextRun` 직렬화에 다음 필드를 추가했다.
+
+- `displayText`: display text 가 source text 와 다를 때만 출력
+- `displayPositions`: `displayText` 기준 위치 배열
+
+기존 필드는 변경하지 않았다.
+
+- `text`: source text 유지
+- `positions`: source text 기준 유지
+- `clusters`: source text 기준 유지
+
+`U+F081C` 처럼 출력에서 사라지는 filler 는 `displayText: ""`, `displayPositions: []` 로 직렬화한다.
+
+### 3.3 schema metadata
+
+`src/paint/schema.rs`:
+
+- `schemaMinorVersion`: 11 → 12
+
+`src/paint/json.rs` metadata:
+
+- `knownFeatures` 에 `text.displayText` 추가
+- 실제 display field 가 있는 tree 의 `usedFeatures` 에만 `text.displayText` 추가
+- `requiredFeatures` 는 변경하지 않음
+
+## 4. 테스트
+
+### 4.1 신규 테스트
+
+`tests/issue_948.rs` 추가:
+
+- `samples/복학원서.hwp` page 0 PageLayerTree JSON 검증
+- `U+F012B` source 보존 확인
+- `displayText` 에 `(인)` 제공 확인
+- `displayText` 에 `U+F012B` / `U+F081C` 미노출 확인
+- `positions` 는 source text 기준, `displayPositions` 는 display text 기준 확인
+- 일반 textRun 은 display field 없이 fallback 유지 확인
+
+`src/paint/json.rs` 단위 테스트 추가:
+
+- PUA textRun 의 `displayText` / `displayPositions`
+- `U+F081C` hidden filler 의 빈 display positions
+- 일반 textRun 의 display field 생략
+
+## 5. 검증 결과
+
+실행한 명령:
+
+```text
+cargo test --test issue_948
+cargo test paint::json
+cargo test page_layer_tree_export
+cargo test --test issue_937
+cargo test paint::schema
+cargo test
+cargo clippy -- -D warnings
+git diff --check
+```
+
+결과:
+
+- `issue_948`: 1 passed
+- `paint::json`: 9 passed
+- `page_layer_tree_export`: 2 passed
+- `issue_937`: 4 passed
+- `paint::schema`: 1 passed
+- 전체 `cargo test`: 통과
+  - lib: 1299 passed, 2 ignored
+  - integration/doc tests 통과
+- `cargo clippy -- -D warnings`: 통과
+- `git diff --check`: 통과
+
+## 6. 호환성
+
+이 변경은 additive 이다.
+
+- 기존 소비자는 `text` / `positions` 를 그대로 사용할 수 있다.
+- 신규 소비자는 `displayText ?? text`, `displayPositions ?? positions` fallback 규칙으로 렌더링 문자열을 선택할 수 있다.
+- schema major 는 유지하고 minor 만 올렸다.
+- `requiredFeatures` 는 변경하지 않았다.
+
+## 7. 특이사항
+
+검증 중 `mydocs/orders/20260518.md` 가 upstream 에 이미 존재하는 파일임을 확인했다. 초기 할일 등록 단계에서 기존 내용을 축약해 덮어쓴 상태였으므로, 원문을 복원하고 #948 섹션만 추가하는 형태로 정정했다.
+
+또한 `samples/복학원서.hwp` PageLayerTree 에서 `U+F012B` 와 `(Signature)` 는 동일 textRun 이 아니라 런 단위로 분리되어 있었다. 따라서 통합 테스트는 `U+F012B` source run 의 display contract 를 직접 검증한다.
+
+## 8. 판정
+
+#948 의 목표인 PageLayerTree `textRun` JSON source/display text 분리와 display positions 제공은 완료로 판정한다.
+
+남은 작업은 커밋, push, PR 생성이다.

--- a/mydocs/working/task_m100_948_stage1.md
+++ b/mydocs/working/task_m100_948_stage1.md
@@ -1,0 +1,99 @@
+# Task #948 Stage 1 진단 보고서
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 브랜치: `task-948-pagelayertree-display-text`
+- 기준 커밋: upstream/devel `39d90d9d`
+- 작성일: 2026-05-18
+
+## 1. 확인한 경로
+
+PageLayerTree JSON 출력 경로는 다음과 같다.
+
+```text
+DocumentCore::get_page_layer_tree_native()
+  -> build_page_layer_tree()
+  -> LayerBuilder::build()
+  -> RenderNodeType::TextRun(run)
+  -> PaintOp::TextRun { bbox, run: run.clone() }
+  -> PageLayerTree::to_json()
+  -> src/paint/json.rs 의 textRun 직렬화
+```
+
+현재 `src/paint/json.rs` 의 `PaintOp::TextRun` 직렬화는 다음 기준을 사용한다.
+
+- `text`: `run.text`
+- `clusters`: `run.text` 기준
+- `positions`: `compute_char_positions(&run.text, &run.style)` 기준
+
+따라서 `U+F012B -> "(인)"` 처럼 source text 와 display text 길이가 달라지는 경우, JSON 소비자는 core 의 display text 의미를 알 수 없다.
+
+## 2. #947 display text 규칙 위치
+
+`src/renderer/composer.rs` 에 이미 #947 계열 helper 가 존재한다.
+
+- `pua_plain_text_display(ch)`
+  - `U+F012B -> "(인)"`
+- `expand_pua_render_text(text)`
+  - `U+F081C` 제거
+  - `U+F012B` 같은 한컴 PUA 표시 문자열 확장
+  - `map_pua_bullet_char` 적용
+- `pua_to_display_text(ch)`
+  - CharOverlap 렌더러용 PUA 표시 문자열
+
+또한 `ComposedTextRun` 에는 `display_text: Option<String>` 이 있고, `convert_pua_display_text()` 가 옛한글 PUA / 한컴 PUA 표시 문자열을 계산한다.
+
+하지만 `TextRunNode` 구조체에는 `display_text` 필드가 없고, 렌더 트리 생성 단계에서 `ComposedTextRun.display_text` 는 보존되지 않는다. 현재 built-in renderer 들은 최종 draw 단계에서 `expand_pua_render_text()` 또는 별도 옛한글 helper 를 다시 적용한다.
+
+## 3. 현재 renderer 적용 상태
+
+확인된 적용 경로:
+
+- `src/renderer/svg.rs`
+- `src/renderer/web_canvas.rs`
+- `src/renderer/html.rs`
+- `src/renderer/canvas.rs`
+- `src/renderer/skia/text_replay.rs`
+
+위 경로는 `expand_pua_render_text()` 를 사용해 `U+F012B` 와 `U+F081C` 렌더링을 처리한다.
+
+반면 `src/paint/json.rs` 는 이 helper 를 사용하지 않는다.
+
+## 4. 현행 테스트 결과
+
+실행:
+
+```bash
+cargo test --test issue_937
+cargo test page_layer_tree_export
+```
+
+결과:
+
+- `issue_937`: 4 passed
+- `page_layer_tree_export`: 2 passed
+
+의미:
+
+- SVG 계열 #947 회귀는 현재 통과한다.
+- PageLayerTree 기본 schema/export 테스트는 통과하지만, display text contract 검증은 아직 없다.
+
+## 5. 결론
+
+Task #948 의 root cause 는 PageLayerTree JSON 직렬화가 source text 만 내보내고 display text 를 별도 contract 로 노출하지 않는 것이다.
+
+구현은 다음 방향이 적절하다.
+
+1. renderer 공용 display text helper 를 PageLayerTree JSON에서도 사용한다.
+2. `text` / `positions` 는 기존 source-compatible 의미로 유지한다.
+3. `displayText` / `displayPositions` 를 additive field 로 추가한다.
+4. `displayText != text` 인 경우에만 신규 필드를 출력해 JSON 크기 증가를 줄인다.
+5. 회귀 테스트는 `samples/복학원서.hwp` page 0 의 PageLayerTree JSON에서 `U+F012B` source 보존과 `(인)` display 제공을 동시에 검증한다.
+
+## 6. Stage 2 구현 계획서 후보
+
+구현 계획서에서 확정할 세부 항목:
+
+- helper 위치: `composer.rs` 유지 + JSON 경로에서 재사용할지, 별도 text utility 로 이동할지
+- 옛한글 PUA까지 `displayText` contract 에 포함할지 여부
+- `displayPositions` 계산 함수 시그니처
+- 테스트 위치: `tests/issue_937.rs` 확장 또는 `tests/issue_948.rs` 신규

--- a/mydocs/working/task_m100_948_stage3.md
+++ b/mydocs/working/task_m100_948_stage3.md
@@ -1,0 +1,111 @@
+# Task #948 Stage 3 구현 보고서
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 브랜치: `task-948-pagelayertree-display-text`
+- 작성일: 2026-05-18
+
+## 1. 구현 요약
+
+PageLayerTree `textRun` JSON 에 source text 와 display text 를 분리하는 additive contract 를 추가했다.
+
+기존 필드는 유지:
+
+- `text`: 기존 `run.text` 원문 유지
+- `positions`: 기존 `run.text` 기준 위치 유지
+- `clusters`: 기존 source text 기준 유지
+
+신규 필드:
+
+- `displayText`: core 의 PUA display text helper 로 계산한 렌더링용 텍스트
+- `displayPositions`: `displayText` 기준 위치 배열
+
+`displayText == text` 인 일반 textRun 은 신규 필드를 생략한다.
+
+## 2. 변경 파일
+
+### `src/renderer/composer.rs`
+
+- `expand_pua_display_text()` 공용 helper 추가
+- 기존 `expand_pua_render_text()` 는 새 helper 를 호출하도록 정리
+- 처리 범위:
+  - `U+F081C` TAC filler 제거
+  - `U+F012B -> "(인)"`
+  - Hanyang-PUA 옛한글 자모 시퀀스 확장
+  - 기존 PUA bullet mapping 적용
+  - 알 수 없는 PUA 는 원문 유지
+
+### `src/paint/json.rs`
+
+- `PaintOp::TextRun` 직렬화에 `displayText` / `displayPositions` 추가
+- `displayText != text` 인 경우에만 출력
+- `displayText == ""` 인 숨김 filler 는 `displayPositions: []` 로 출력
+- `text.displayText` 를 `knownFeatures` 에 추가
+- 실제 display field 가 있는 tree 에만 `usedFeatures` 에 `text.displayText` 추가
+- 기존 `positions` writer 를 source/display 공용 helper 로 분리
+
+### `src/paint/schema.rs`
+
+- PageLayerTree additive revision 으로 `schemaMinorVersion` 11 → 12 갱신
+
+### `tests/issue_948.rs`
+
+- `samples/복학원서.hwp` page 0 PageLayerTree JSON 통합 테스트 추가
+- `U+F012B` source 보존, `(인)` display 제공, display/source positions 기준 분리를 검증
+
+## 3. 테스트 보강
+
+`src/paint/json.rs` 단위 테스트 추가:
+
+- PUA textRun 의 `displayText` / `displayPositions` 출력
+- `U+F081C` 숨김 filler 의 빈 display text / 빈 display positions 출력
+- 일반 textRun 은 display field 를 출력하지 않는 fallback 유지
+
+`tests/issue_948.rs` 통합 테스트 추가:
+
+- PageLayerTree metadata 의 `text.displayText` feature 노출
+- source `text` 의 `U+F012B` 보존
+- `displayText` 의 `(인)` 제공
+- `displayText` 의 `U+F012B` / `U+F081C` 누출 방지
+- `positions` 는 source text 기준, `displayPositions` 는 display text 기준
+
+## 4. 검증 결과
+
+실행한 명령:
+
+```bash
+cargo test --test issue_948
+cargo test paint::json
+cargo test page_layer_tree_export
+cargo test --test issue_937
+cargo test paint::schema
+cargo test
+```
+
+결과:
+
+- `issue_948`: 1 passed
+- `paint::json`: 9 passed
+- `page_layer_tree_export`: 2 passed
+- `issue_937`: 4 passed
+- `paint::schema`: 1 passed
+- 전체 `cargo test`: 통과
+  - lib: 1299 passed, 2 ignored
+  - integration tests 포함 전체 통과
+
+기존 경고는 유지:
+
+- `duplicated attribute`
+- `unused_parens`
+- 일부 `non_snake_case`
+- 일부 `unused_must_use`
+
+본 task 변경으로 새로 발생한 실패는 없다.
+
+## 5. 특이사항
+
+`samples/복학원서.hwp` PageLayerTree 에서 `U+F012B` 와 `(Signature)` 는 동일 textRun 이 아니라 런 단위로 분리되어 있었다. 따라서 통합 테스트는 `U+F012B` source run 의 display contract 를 직접 검증하는 방식으로 작성했다.
+
+## 6. 남은 단계
+
+- Stage 4: 검증 결과 검토 및 필요 시 추가 범위 테스트
+- Stage 5: 최종 보고서 작성 및 PR 준비

--- a/mydocs/working/task_m100_948_stage4.md
+++ b/mydocs/working/task_m100_948_stage4.md
@@ -1,0 +1,74 @@
+# Task #948 Stage 4 검증 보고서
+
+- 이슈: [#948](https://github.com/edwardkim/rhwp/issues/948)
+- 브랜치: `task-948-pagelayertree-display-text`
+- 작성일: 2026-05-18
+
+## 1. 검증 범위
+
+Stage 3 구현의 검증 범위는 다음과 같다.
+
+- PageLayerTree JSON contract 변경 검증
+- #947 SVG 렌더링 회귀 보존
+- schema minor 갱신 정합
+- 전체 Rust 테스트 회귀 확인
+- clippy strict 확인
+- diff whitespace 확인
+
+## 2. 실행 결과
+
+실행한 명령:
+
+```bash
+cargo test --test issue_948
+cargo test paint::json
+cargo test page_layer_tree_export
+cargo test --test issue_937
+cargo test paint::schema
+cargo test
+cargo clippy -- -D warnings
+git diff --check
+```
+
+결과:
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test --test issue_948` | 통과 — 1 passed |
+| `cargo test paint::json` | 통과 — 9 passed |
+| `cargo test page_layer_tree_export` | 통과 — 2 passed |
+| `cargo test --test issue_937` | 통과 — 4 passed |
+| `cargo test paint::schema` | 통과 — 1 passed |
+| `cargo test` | 통과 — lib 1299 passed, 2 ignored + integration/doc tests 통과 |
+| `cargo clippy -- -D warnings` | 통과 |
+| `git diff --check` | 통과 |
+
+## 3. 확인된 contract
+
+`textRun` JSON 은 다음 계약을 만족한다.
+
+- `text` 는 source text 로 유지
+- `positions` 는 source `text` 기준 유지
+- `displayText` 는 source text 와 렌더링용 텍스트가 다를 때만 출력
+- `displayPositions` 는 `displayText` 기준으로 출력
+- `U+F012B` 는 source `text` 에 보존되고 `displayText` 에서는 `(인)` 으로 노출
+- `U+F081C` filler 는 `displayText: ""`, `displayPositions: []` 로 노출
+- 일반 textRun 은 `displayText` 없이 기존 fallback 을 유지
+- `knownFeatures` 에 `text.displayText` 포함
+- 실제 display field 가 있는 tree 만 `usedFeatures` 에 `text.displayText` 포함
+
+## 4. 추가 확인 사항
+
+검증 중 `mydocs/orders/20260518.md` 가 upstream 에 이미 존재하는 파일임을 확인했다. 초기 할일 등록 단계에서 기존 내용을 축약해 덮어쓴 상태였으므로, Stage 4 중 upstream 원문을 복원하고 #948 섹션만 추가하는 형태로 정정했다.
+
+현재 diff 상 `mydocs/orders/20260518.md` 변경은 #948 섹션 추가뿐이다.
+
+## 5. 잔여 위험
+
+남은 위험은 낮다.
+
+- JSON consumer 가 기존 `text` / `positions` 만 사용하는 경우 기존 동작 유지
+- 신규 consumer 는 `displayText` / `displayPositions` 를 우선 사용 가능
+- schema major 변경 없이 minor additive revision 으로만 노출
+
+다음 단계는 최종 보고서 작성과 PR 준비이다.

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -14,6 +14,7 @@ use crate::paint::{
     TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan, TextSourceTable,
     TextV2Diagnostics, LAYER_TREE_SCHEMA,
 };
+use crate::renderer::composer::expand_pua_display_text;
 use crate::renderer::layout::compute_char_positions;
 use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, ShapeTransform, TextRunNode};
 use crate::renderer::{
@@ -67,7 +68,11 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let has_variant_groups = text_variant_features.has_variant_groups();
     let has_glyph_runs = text_variant_features.has_glyph_runs;
     let has_glyph_outlines = text_variant_features.has_glyph_outlines;
+    let has_display_text = text_variant_features.has_display_text;
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.v2.diagnostics\",\"text.projectionKind\",\"text.legacyVisuals\"");
+    if has_display_text {
+        buf.push_str(",\"text.displayText\"");
+    }
     if has_glyph_runs {
         buf.push_str(",\"fontResources\",\"text.glyphRun\"");
     }
@@ -105,7 +110,7 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         }
         buf.push_str(&json_escape(feature));
     }
-    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
         buf.push_str(",\"glyphRun\"");
     }
@@ -126,6 +131,7 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
 struct TextVariantFeatureFlags {
     has_glyph_runs: bool,
     has_glyph_outlines: bool,
+    has_display_text: bool,
 }
 
 impl TextVariantFeatureFlags {
@@ -148,12 +154,18 @@ fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
             LayerNodeKind::Leaf { ops } => {
                 for op in ops {
                     match op {
+                        PaintOp::TextRun { run, .. } => {
+                            features.has_display_text |= display_text_for_text_run(run).is_some()
+                        }
                         PaintOp::GlyphRun { .. } => features.has_glyph_runs = true,
                         PaintOp::GlyphOutline { .. } => features.has_glyph_outlines = true,
                         _ => {}
                     }
                 }
-                if features.has_glyph_runs && features.has_glyph_outlines {
+                if features.has_glyph_runs
+                    && features.has_glyph_outlines
+                    && features.has_display_text
+                {
                     return features;
                 }
             }
@@ -314,6 +326,7 @@ impl PaintOp {
                 buf.push_str("\"type\":\"textRun\",\"bbox\":");
                 write_bbox(buf, *bbox);
                 let source = text_sources.next_text_run_span(run);
+                let display_text = display_text_for_text_run(run);
                 let _ = write!(
                     buf,
                     ",\"text\":{},\"baseline\":{:.3},\"rotation\":{:.3},\"isVertical\":{},\"orientation\":{},\"projectionKind\":{},\"clusterBasis\":\"legacyPosition\"",
@@ -324,6 +337,9 @@ impl PaintOp {
                     json_escape(text_orientation_str(run)),
                     json_escape(text_projection_kind_str(run)),
                 );
+                if let Some(display_text) = &display_text {
+                    let _ = write!(buf, ",\"displayText\":{}", json_escape(display_text));
+                }
                 buf.push_str(",\"placement\":");
                 write_text_run_placement(buf, *bbox, run);
                 buf.push_str(",\"clusters\":");
@@ -344,6 +360,14 @@ impl PaintOp {
                 write_text_legacy_visuals(buf, run, leaf_visuals);
                 buf.push_str(",\"positions\":");
                 write_text_positions(buf, run);
+                if let Some(display_text) = &display_text {
+                    buf.push_str(",\"displayPositions\":");
+                    if display_text.is_empty() {
+                        buf.push_str("[]");
+                    } else {
+                        write_text_positions_for_text(buf, display_text, &run.style);
+                    }
+                }
                 if !run.style.tab_leaders.is_empty() {
                     buf.push_str(",\"tabLeaders\":");
                     write_tab_leaders(buf, &run.style.tab_leaders);
@@ -1178,7 +1202,11 @@ fn write_paint_text_style(buf: &mut String, style: &PaintTextStyle) {
 }
 
 fn write_text_positions(buf: &mut String, run: &TextRunNode) {
-    let positions = compute_char_positions(&run.text, &run.style);
+    write_text_positions_for_text(buf, &run.text, &run.style);
+}
+
+fn write_text_positions_for_text(buf: &mut String, text: &str, style: &TextStyle) {
+    let positions = compute_char_positions(text, style);
     buf.push('[');
     for (idx, position) in positions.iter().enumerate() {
         if idx > 0 {
@@ -1187,6 +1215,11 @@ fn write_text_positions(buf: &mut String, run: &TextRunNode) {
         let _ = write!(buf, "{:.3}", position);
     }
     buf.push(']');
+}
+
+fn display_text_for_text_run(run: &TextRunNode) -> Option<String> {
+    let display_text = expand_pua_display_text(&run.text);
+    (display_text != run.text.as_str()).then_some(display_text)
 }
 
 fn write_tab_leaders(buf: &mut String, leaders: &[TabLeaderInfo]) {
@@ -1986,8 +2019,8 @@ mod tests {
 
         assert!(json.contains("\"kind\":\"leaf\""));
         assert!(json.contains("\"schemaVersion\":1"));
-        assert!(json.contains("\"schemaMinorVersion\":11"));
-        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":11}"));
+        assert!(json.contains("\"schemaMinorVersion\":12"));
+        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":12}"));
         assert!(json.contains("\"resourceTableVersion\":1"));
         assert!(json.contains("\"resourceTableMinorVersion\":3"));
         assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":3}"));
@@ -2005,6 +2038,8 @@ mod tests {
         assert!(json.contains("\"clusters\":[{\"sourceRangeUtf8\""));
         assert!(json.contains("\"legacyVisuals\":{"));
         assert!(json.contains(&positions_json));
+        assert!(!json.contains("\"displayText\""));
+        assert!(!json.contains("\"displayPositions\""));
         assert!(json.contains("\"isParaEnd\":true"));
         assert!(json.contains("\"isLineBreakEnd\":true"));
         assert!(json.contains("\"fieldMarker\":{\"kind\":\"fieldBegin\"}"));
@@ -2022,6 +2057,116 @@ mod tests {
         assert!(json.contains("\"emphasisDot\":2"));
         assert!(json.contains("\"type\":\"rectangle\""));
         assert!(json.contains("\"cornerRadius\":4.000"));
+    }
+
+    #[test]
+    fn serializes_display_text_for_pua_text_run() {
+        let style = TextStyle {
+            font_family: "Noto Sans KR".to_string(),
+            font_size: 16.0,
+            ..Default::default()
+        };
+        let text = "\u{F012B}(Signature)";
+        let display_text = "(인)(Signature)";
+        let source_positions = compute_char_positions(text, &style);
+        let display_positions = compute_char_positions(display_text, &style);
+        let text_run = PaintOp::TextRun {
+            bbox: BoundingBox::new(10.0, 20.0, 80.0, 18.0),
+            run: TextRunNode {
+                text: text.to_string(),
+                style: style.clone(),
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 13.0,
+                field_marker: FieldMarkerType::None,
+            },
+        };
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![text_run],
+            ),
+        );
+
+        let json = tree.to_json();
+        let source_positions_json = format!(
+            "\"positions\":[{}]",
+            source_positions
+                .iter()
+                .map(|position| format!("{:.3}", position))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+        let display_positions_json = format!(
+            "\"displayPositions\":[{}]",
+            display_positions
+                .iter()
+                .map(|position| format!("{:.3}", position))
+                .collect::<Vec<_>>()
+                .join(",")
+        );
+
+        assert!(json.contains(&format!("\"text\":\"{}\"", text)));
+        assert!(json.contains(&format!("\"displayText\":\"{}\"", display_text)));
+        assert!(json.contains(&source_positions_json));
+        assert!(json.contains(&display_positions_json));
+        assert!(json.contains("\"text.displayText\""));
+    }
+
+    #[test]
+    fn serializes_empty_display_positions_for_hidden_pua_filler() {
+        let text_run = PaintOp::TextRun {
+            bbox: BoundingBox::new(10.0, 20.0, 80.0, 18.0),
+            run: TextRunNode {
+                text: "\u{F081C}".to_string(),
+                style: TextStyle {
+                    font_family: "Noto Sans KR".to_string(),
+                    font_size: 16.0,
+                    ..Default::default()
+                },
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: None,
+                para_index: None,
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline: 13.0,
+                field_marker: FieldMarkerType::None,
+            },
+        };
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 120.0, 80.0),
+                None,
+                vec![text_run],
+            ),
+        );
+
+        let json = tree.to_json();
+
+        assert!(json.contains("\"displayText\":\"\""));
+        assert!(json.contains("\"displayPositions\":[]"));
     }
 
     #[test]

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,7 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 11,
+    schema_minor_version: 12,
     resource_table_version: 1,
     resource_table_minor_version: 3,
     unit: "px",
@@ -37,7 +37,7 @@ mod tests {
     #[test]
     fn layer_tree_schema_contract_is_stable() {
         assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 11);
+        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 12);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 3);
         assert_eq!(LAYER_TREE_SCHEMA.unit, "px");

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -1330,14 +1330,18 @@ fn pua_plain_text_display(ch: char) -> Option<&'static str> {
     }
 }
 
-/// 일반 텍스트 렌더링 경로에서 한컴 PUA 문자를 표시 문자열로 확장한다.
+/// 일반 텍스트 렌더링/paint contract 경로에서 한컴 PUA 문자를 표시 문자열로 확장한다.
 ///
 /// HWP TAC filler `U+F081C` 는 레이아웃 측정에는 원문으로 남겨 0폭 규칙을
 /// 적용하되, 실제 출력에서는 글리프가 없어 깨진 문자로 보이지 않도록 숨긴다.
 ///
+/// Hanyang-PUA 옛한글은 KS X 1026-1:2007 자모 시퀀스로 확장한다.
+///
 /// CharOverlap 전용 숫자(`U+F02CE..=U+F02E1`)는 여기서 확장하지 않는다.
 /// 해당 문자는 `pua_to_display_text()`가 글자겹침 렌더러에서만 처리한다.
-pub fn expand_pua_render_text(text: &str) -> String {
+pub fn expand_pua_display_text(text: &str) -> String {
+    use super::pua_oldhangul::map_pua_old_hangul;
+
     let mut out = String::with_capacity(text.len());
     for ch in text.chars() {
         if ch == '\u{F081C}' {
@@ -1345,11 +1349,18 @@ pub fn expand_pua_render_text(text: &str) -> String {
         }
         if let Some(replacement) = pua_plain_text_display(ch) {
             out.push_str(replacement);
+        } else if let Some(jamos) = map_pua_old_hangul(ch) {
+            out.extend(jamos.iter().copied());
         } else {
             out.push(super::layout::map_pua_bullet_char(ch));
         }
     }
     out
+}
+
+/// 일반 텍스트 렌더링 경로의 기존 helper 이름.
+pub fn expand_pua_render_text(text: &str) -> String {
+    expand_pua_display_text(text)
 }
 
 /// PUA 테두리 숫자와 한컴 PUA 기호를 표시 문자열로 변환한다. (렌더러 전용)

--- a/tests/issue_948.rs
+++ b/tests/issue_948.rs
@@ -1,0 +1,116 @@
+//! Issue #948: PageLayerTree textRun JSON display text contract.
+//!
+//! PageLayerTree consumers should not have to duplicate rhwp core's
+//! HWP/Hancom PUA display-text rules. The JSON contract keeps source `text`
+//! while exposing additive `displayText` / `displayPositions` for drawing.
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::{Map, Value};
+use std::fs;
+use std::path::Path;
+
+fn read_bokhakwonseo() -> Vec<u8> {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let hwp_path = Path::new(repo_root).join("samples/복학원서.hwp");
+    fs::read(&hwp_path).unwrap_or_else(|e| panic!("read {}: {}", hwp_path.display(), e))
+}
+
+fn collect_text_runs<'a>(value: &'a Value, out: &mut Vec<&'a Map<String, Value>>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("type").and_then(Value::as_str) == Some("textRun") {
+                out.push(map);
+            }
+            for child in map.values() {
+                collect_text_runs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text_runs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+#[test]
+fn issue_948_layer_tree_text_run_exposes_signature_display_text() {
+    let bytes = read_bokhakwonseo();
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse samples/복학원서.hwp");
+    let json = doc
+        .get_page_layer_tree_native(0)
+        .expect("render samples/복학원서.hwp page 1 layer tree");
+    let root: Value = serde_json::from_str(&json).expect("parse PageLayerTree JSON");
+
+    assert!(
+        json.contains("\"text.displayText\""),
+        "PageLayerTree metadata should advertise the additive display text feature",
+    );
+
+    let mut runs = Vec::new();
+    collect_text_runs(&root, &mut runs);
+    assert!(
+        !runs.is_empty(),
+        "page layer tree should contain textRun ops"
+    );
+
+    let signature_run = runs
+        .iter()
+        .find(|run| {
+            run.get("text")
+                .and_then(Value::as_str)
+                .is_some_and(|text| text.contains('\u{F012B}'))
+        })
+        .expect("signature source textRun should preserve U+F012B in text");
+
+    let source_text = signature_run
+        .get("text")
+        .and_then(Value::as_str)
+        .expect("signature textRun should have text");
+    let display_text = signature_run
+        .get("displayText")
+        .and_then(Value::as_str)
+        .expect("signature textRun should expose displayText");
+    let source_positions = signature_run
+        .get("positions")
+        .and_then(Value::as_array)
+        .expect("signature textRun should have source positions");
+    let display_positions = signature_run
+        .get("displayPositions")
+        .and_then(Value::as_array)
+        .expect("signature textRun should have display positions");
+
+    assert!(source_text.contains('\u{F012B}'));
+    assert!(
+        display_text.contains("(인)"),
+        "displayText should expose the core-rendered signature seal text. got: {:?}",
+        display_text,
+    );
+    assert!(
+        !display_text.contains('\u{F012B}') && !display_text.contains('\u{F081C}'),
+        "displayText should not leak source PUA/filler characters. got: {:?}",
+        display_text,
+    );
+    assert_eq!(
+        source_positions.len(),
+        source_text.chars().count() + 1,
+        "source positions should remain source-text based",
+    );
+    assert_eq!(
+        display_positions.len(),
+        display_text.chars().count() + 1,
+        "displayPositions should be displayText based",
+    );
+
+    assert!(
+        runs.iter().any(|run| {
+            run.get("displayText").is_none()
+                && run
+                    .get("text")
+                    .and_then(Value::as_str)
+                    .is_some_and(|text| !text.contains('\u{F012B}') && !text.contains('\u{F081C}'))
+        }),
+        "ordinary textRun ops should keep using text/positions fallback without displayText",
+    );
+}


### PR DESCRIPTION
## Summary

Refs #948 — PageLayerTree JSON의 `textRun` op에 source text와 renderer가 실제로 그려야 하는 display text를 분리하는 additive contract를 추가했습니다.

- 기존 `text` / `positions` / `clusters`는 source-compatible하게 유지합니다.
- 신규 `displayText`는 rhwp core가 해석한 렌더링용 텍스트를 제공합니다.
- 신규 `displayPositions`는 `displayText` 기준 위치 배열을 제공합니다.
- `displayText == text`인 일반 textRun은 JSON 크기와 호환성을 위해 신규 필드를 생략합니다.
- schema minor를 `1.11 -> 1.12`로 올리고 `text.displayText` feature metadata를 추가했습니다.

## Root cause

#947에서 SVG / WebCanvas / HTML / Canvas / Skia 계열 렌더러는 core의 PUA display text 규칙을 사용하도록 정정됐지만, renderer-independent paint contract인 PageLayerTree JSON은 여전히 `run.text`만 내보내고 있었습니다.

이 때문에 PageLayerTree consumer는 다음 중 하나를 선택해야 했습니다.

1. `text`를 그대로 그려 `U+F012B` 같은 한컴 PUA를 깨진 glyph로 출력
2. downstream renderer에서 rhwp core의 PUA/display-text 규칙을 중복 구현

특히 `U+F012B -> "(인)"`처럼 source codepoint 1개가 display 문자 여러 개로 확장되는 경우, 기존 `positions`만으로는 draw text와 위치 기준을 맞출 수 없었습니다.

## Contract

기존 필드는 그대로 source 기준입니다.

```text
text      = source text from run.text
positions = source text based positions
clusters  = source text/source range based clusters
```

신규 필드는 draw/display 기준입니다.

```text
displayText      = core-interpreted text for drawing
displayPositions = positions computed from displayText
```

권장 consumer fallback:

```text
drawText = displayText ?? text
drawPositions = displayPositions ?? positions
```

`U+F081C`처럼 출력에서 숨겨야 하는 TAC filler는 `displayText: ""`, `displayPositions: []`로 직렬화합니다.

## Changes

### `src/renderer/composer.rs`

- `expand_pua_display_text()` 공용 helper를 추가했습니다.
- 기존 `expand_pua_render_text()`는 새 helper를 호출하도록 유지했습니다.
- helper 처리 범위:
  - `U+F081C` TAC filler 제거
  - `U+F012B -> "(인)"`
  - Hanyang-PUA 옛한글 자모 시퀀스 확장
  - 기존 PUA bullet mapping 적용
  - 알 수 없는 PUA는 원문 유지

### `src/paint/json.rs`

- `PaintOp::TextRun` JSON에 `displayText` / `displayPositions`를 추가했습니다.
- `displayText != text`인 경우에만 신규 필드를 출력합니다.
- source `positions` writer를 source/display 공용 helper로 분리했습니다.
- `knownFeatures`에 `text.displayText`를 추가했습니다.
- 실제 display field가 있는 tree에만 `usedFeatures`에 `text.displayText`를 추가합니다.
- `requiredFeatures`는 비워 둬 기존 consumer fallback을 유지합니다.

### `src/paint/schema.rs`

- PageLayerTree additive revision으로 `schemaMinorVersion`을 `11 -> 12`로 갱신했습니다.

### Tests / docs

- `tests/issue_948.rs`를 추가해 `samples/복학원서.hwp` page 0 PageLayerTree JSON을 검증합니다.
- `src/paint/json.rs` synthetic unit tests를 추가했습니다.
- hyper-waterfall 산출물(`task_m100_948*`)과 최종 보고서를 추가했습니다.

## Validation

- [x] `cargo test --test issue_948`
- [x] `cargo test paint::json`
- [x] `cargo test page_layer_tree_export`
- [x] `cargo test --test issue_937`
- [x] `cargo test paint::schema`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `git diff --check`

## Notes for reviewers

- This PR intentionally does not change the meaning of existing `text`, `positions`, or `clusters`.
- `displayText` / `displayPositions` are additive and optional.
- Unknown PUA characters are not guessed; they remain unchanged unless covered by existing rhwp core display rules.
- The issue is referenced with `Refs #948` only. It does not use `Closes` because issue closing should remain a maintainer decision.
