### PR TITLE
render: add browser CanvasKit direct renderer

### DIFF
--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,13 +1,16 @@
 {
   "name": "rhwp-studio",
-  "version": "0.7.11",
+  "version": "0.7.12",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.7.11",
+      "version": "0.7.12",
       "license": "MIT",
+      "dependencies": {
+        "canvaskit-wasm": "^0.41.1"
+      },
       "devDependencies": {
         "@types/chrome": "^0.1.42",
         "puppeteer-core": "^24.43.0",
@@ -2635,6 +2638,12 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@webgpu/types": {
+      "version": "0.1.21",
+      "resolved": "https://registry.npmjs.org/@webgpu/types/-/types-0.1.21.tgz",
+      "integrity": "sha512-pUrWq3V5PiSGFLeLxoGqReTZmiiXwY3jRkIG5sLLKjyqNxrwm/04b4nw7LSmGWJcKk59XOM/YRTUwOzo4MMlow==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/acorn": {
       "version": "8.16.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.16.0.tgz",
@@ -3127,6 +3136,15 @@
         }
       ],
       "license": "CC-BY-4.0"
+    },
+    "node_modules/canvaskit-wasm": {
+      "version": "0.41.1",
+      "resolved": "https://registry.npmjs.org/canvaskit-wasm/-/canvaskit-wasm-0.41.1.tgz",
+      "integrity": "sha512-gO2rNMIE0lOQ8MaarM4qNeq2zZAEknAObKP2XAKidMSAY8P5sURGdFkrx1TSdHuBFqTf5w35JqjuUzjibqkD5g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@webgpu/types": "0.1.21"
+      }
     },
     "node_modules/chromium-bidi": {
       "version": "14.0.0",

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -25,5 +25,8 @@
   },
   "overrides": {
     "serialize-javascript": "7.0.5"
+  },
+  "dependencies": {
+    "canvaskit-wasm": "^0.41.1"
   }
 }

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -674,3 +674,276 @@ export interface BookmarkInfo {
   ctrlIdx: number;
   charPos: number;
 }
+
+export type LayerRenderProfile = 'fastPreview' | 'screen' | 'print' | 'highQuality';
+
+export interface LayerBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface PageLayerTree {
+  schemaVersion?: number;
+  schemaMinorVersion?: number;
+  schema?: {
+    major: number;
+    minor: number;
+  };
+  unit?: 'px';
+  coordinateSystem?: string;
+  profile?: LayerRenderProfile;
+  pageWidth: number;
+  pageHeight: number;
+  outputOptions?: {
+    showParagraphMarks?: boolean;
+    showControlCodes?: boolean;
+    showTransparentBorders?: boolean;
+    clipEnabled?: boolean;
+    debugOverlay?: boolean;
+  };
+  resources?: LayerResources;
+  root: LayerNode;
+}
+
+export interface LayerResources {
+  tableId?: number;
+  images?: Array<Uint8Array | number[] | string | undefined>;
+  imageHashes?: string[];
+  imageKeys?: string[];
+  svgFragments?: Array<string | undefined>;
+  svgHashes?: string[];
+  svgKeys?: string[];
+}
+
+export type LayerNode = LayerGroupNode | LayerClipNode | LayerLeafNode;
+
+export interface LayerGroupNode {
+  kind: 'group';
+  bounds: LayerBounds;
+  groupKind?: { kind: string; [key: string]: unknown };
+  cacheHint?: LayerCacheHint;
+  children: LayerNode[];
+}
+
+export interface LayerClipNode {
+  kind: 'clipRect';
+  bounds: LayerBounds;
+  clip: LayerBounds;
+  clipKind: 'body' | 'tableCell' | 'generic';
+  child: LayerNode;
+}
+
+export interface LayerLeafNode {
+  kind: 'leaf';
+  bounds: LayerBounds;
+  ops: LayerPaintOp[];
+}
+
+export type LayerCacheHint =
+  | 'none'
+  | 'staticSubtree'
+  | 'preferRaster'
+  | 'preferVectorRecording';
+
+export type LayerPaintOp =
+  | LayerPageBackgroundOp
+  | LayerTextRunOp
+  | LayerFootnoteMarkerOp
+  | LayerLineOp
+  | LayerRectangleOp
+  | LayerEllipseOp
+  | LayerPathOp
+  | LayerImageOp
+  | LayerEquationOp
+  | LayerFormObjectOp
+  | LayerPlaceholderOp
+  | LayerRawSvgOp
+  | LayerTextDecorationOp
+  | LayerTextControlMarkOp
+  | LayerTabLeaderOp
+  | LayerCharOverlapOp
+  | LayerGlyphRunOp
+  | LayerGlyphOutlineOp;
+
+export interface LayerPageBackgroundOp {
+  type: 'pageBackground';
+  bbox: LayerBounds;
+  backgroundColor?: string;
+  borderColor?: string;
+  borderWidth?: number;
+}
+
+export interface LayerTextStyle {
+  fontFamily?: string;
+  fontSize?: number;
+  color?: string;
+  bold?: boolean;
+  italic?: boolean;
+  ratio?: number;
+  underline?: string;
+  strikethrough?: boolean;
+  shadeColor?: string;
+}
+
+export interface LayerTextRunOp {
+  type: 'textRun';
+  bbox: LayerBounds;
+  text: string;
+  baseline?: number;
+  rotation?: number;
+  isVertical?: boolean;
+  style?: LayerTextStyle;
+  positions?: number[];
+}
+
+export interface LayerFootnoteMarkerOp {
+  type: 'footnoteMarker';
+  bbox: LayerBounds;
+  text: string;
+  fontFamily?: string;
+  fontSize?: number;
+  color?: string;
+}
+
+export interface LayerLineStyle {
+  color?: string;
+  width?: number;
+  dash?: string;
+  lineType?: string;
+  startArrow?: string;
+  endArrow?: string;
+}
+
+export interface LayerShapeStyle {
+  fillColor?: string | null;
+  strokeColor?: string | null;
+  strokeWidth?: number;
+  strokeDash?: string;
+  opacity?: number;
+}
+
+export interface LayerLineOp {
+  type: 'line';
+  bbox: LayerBounds;
+  x1: number;
+  y1: number;
+  x2: number;
+  y2: number;
+  style?: LayerLineStyle;
+}
+
+export interface LayerRectangleOp {
+  type: 'rectangle';
+  bbox: LayerBounds;
+  cornerRadius?: number;
+  style?: LayerShapeStyle;
+}
+
+export interface LayerEllipseOp {
+  type: 'ellipse';
+  bbox: LayerBounds;
+  style?: LayerShapeStyle;
+}
+
+export type LayerPathCommand =
+  | { type: 'moveTo'; x: number; y: number }
+  | { type: 'lineTo'; x: number; y: number }
+  | { type: 'curveTo'; x1: number; y1: number; x2: number; y2: number; x3: number; y3: number }
+  | { type: 'arcTo'; rx: number; ry: number; rotation: number; largeArc: boolean; sweep: boolean; x: number; y: number }
+  | { type: 'closePath' };
+
+export interface LayerPathOp {
+  type: 'path';
+  bbox: LayerBounds;
+  commands?: LayerPathCommand[];
+  style?: LayerShapeStyle;
+  lineStyle?: LayerLineStyle;
+}
+
+export interface LayerImageOp {
+  type: 'image';
+  bbox: LayerBounds;
+  mime?: string;
+  base64?: string;
+  imageRef?: number | string;
+  fillMode?: string;
+  effect?: string;
+  brightness?: number;
+  contrast?: number;
+  wrap?: 'behindText' | 'inFrontOfText' | string;
+}
+
+export interface LayerEquationOp {
+  type: 'equation';
+  bbox: LayerBounds;
+  svgContent?: string;
+  color?: string;
+  fontSize?: number;
+}
+
+export interface LayerFormObjectOp {
+  type: 'formObject';
+  bbox: LayerBounds;
+  formType?: string;
+  caption?: string;
+  text?: string;
+  foreColor?: string;
+  backColor?: string;
+  value?: boolean;
+  enabled?: boolean;
+}
+
+export interface LayerPlaceholderOp {
+  type: 'placeholder';
+  bbox: LayerBounds;
+  fillColor?: string;
+  strokeColor?: string;
+  label?: string;
+}
+
+export interface LayerRawSvgOp {
+  type: 'rawSvg';
+  bbox: LayerBounds;
+  svg?: string;
+}
+
+export interface LayerTextDecorationOp {
+  type: 'textDecoration';
+  bbox: LayerBounds;
+  decoration?: unknown;
+}
+
+export interface LayerTextControlMarkOp {
+  type: 'textControlMark';
+  bbox: LayerBounds;
+  fieldMarker?: string | { kind?: string };
+}
+
+export interface LayerTabLeaderOp {
+  type: 'tabLeader';
+  bbox: LayerBounds;
+  leaders?: Array<{ startX: number; endX: number; fillType: number }>;
+  color?: string;
+  fontSize?: number;
+  baseline?: number;
+}
+
+export interface LayerCharOverlapOp {
+  type: 'charOverlap';
+  bbox: LayerBounds;
+  text?: string;
+  baseline?: number;
+  style?: LayerTextStyle;
+}
+
+export interface LayerGlyphRunOp {
+  type: 'glyphRun';
+  bbox: LayerBounds;
+}
+
+export interface LayerGlyphOutlineOp {
+  type: 'glyphOutline';
+  bbox: LayerBounds;
+}

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1,5 +1,5 @@
 import init, { HwpDocument, version } from '@wasm/rhwp.js';
-import type { DocumentInfo, PageInfo, PageDef, SectionDef, CursorRect, HitTestResult, BodyFootnoteMarkerHit, FootnoteAtCursorResult, DeleteFootnoteResult, LineInfo, TableDimensions, CellInfo, CellBbox, CellProperties, TableProperties, DocumentPosition, MoveVerticalResult, SelectionRect, CharProperties, ParaProperties, CellPathEntry, NavContextEntry, FieldInfoResult, BookmarkInfo } from './types';
+import type { DocumentInfo, PageInfo, PageDef, SectionDef, CursorRect, HitTestResult, BodyFootnoteMarkerHit, FootnoteAtCursorResult, DeleteFootnoteResult, LineInfo, TableDimensions, CellInfo, CellBbox, CellProperties, TableProperties, DocumentPosition, MoveVerticalResult, SelectionRect, CharProperties, ParaProperties, CellPathEntry, NavContextEntry, FieldInfoResult, BookmarkInfo, LayerRenderProfile, PageLayerTree } from './types';
 
 /** HWPX 비표준 감지 경고 리포트 (#177). */
 export interface ValidationReport {
@@ -316,7 +316,56 @@ export class WasmBridge {
     if (typeof d.getPageLayerTree === 'function') {
       return d.getPageLayerTree(pageNum);
     }
-    return '{"layers":[]}';
+    return '{"pageWidth":0,"pageHeight":0,"profile":"screen","root":{"kind":"leaf","bounds":{"x":0,"y":0,"width":0,"height":0},"ops":[]}}';
+  }
+
+  getPageLayerTreeObject(pageNum: number, profile: LayerRenderProfile = 'screen'): PageLayerTree {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    const d = this.doc as unknown as {
+      getPageLayerTreeWithProfile?: (p: number, profile: string) => string;
+      getPageLayerTree?: (p: number) => string;
+    };
+    const json = typeof d.getPageLayerTreeWithProfile === 'function'
+      ? d.getPageLayerTreeWithProfile(pageNum, profile)
+      : this.getPageLayerTree(pageNum);
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(json);
+    } catch (error) {
+      throw new Error(`[WasmBridge] PageLayerTree JSON parse 실패 (page=${pageNum}): ${error}`);
+    }
+    if (!parsed || typeof parsed !== 'object') {
+      throw new Error(`[WasmBridge] PageLayerTree JSON shape 오류 (page=${pageNum}): object가 아닙니다`);
+    }
+    const tree = parsed as Partial<PageLayerTree> & { layers?: unknown };
+    if (!tree.root || typeof tree.root !== 'object' || !('kind' in tree.root)) {
+      if (Array.isArray(tree.layers)) {
+        const pageInfo = this.getPageInfo(pageNum);
+        return {
+          pageWidth: pageInfo.width,
+          pageHeight: pageInfo.height,
+          profile,
+          root: {
+            kind: 'leaf',
+            bounds: { x: 0, y: 0, width: pageInfo.width, height: pageInfo.height },
+            ops: [],
+          },
+        };
+      }
+      throw new Error(`[WasmBridge] PageLayerTree JSON shape 오류 (page=${pageNum}): root.kind가 없습니다`);
+    }
+    const rootKind = (tree.root as { kind?: unknown }).kind;
+    if (rootKind !== 'group' && rootKind !== 'clipRect' && rootKind !== 'leaf') {
+      throw new Error(`[WasmBridge] PageLayerTree JSON shape 오류 (page=${pageNum}): 알 수 없는 root.kind=${String(rootKind)}`);
+    }
+    if (!tree.profile) {
+      tree.profile = profile;
+    }
+    return tree as PageLayerTree;
+  }
+
+  clearLayerResourceCache(): void {
+    /* Reserved for JS-value resource transport builds. JSON export is self-contained. */
   }
 
   getCanvasKitReplayPlan(pageNum: number, mode: 'default' | 'compat' = 'default'): string {

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -27,6 +27,13 @@ import { CellSelectionRenderer } from '@/engine/cell-selection-renderer';
 import { TableObjectRenderer } from '@/engine/table-object-renderer';
 import { TableResizeRenderer } from '@/engine/table-resize-renderer';
 import { Ruler } from '@/view/ruler';
+import type { CanvasKitLayerRenderer } from '@/view/canvaskit-renderer';
+import {
+  resolveCanvasKitRenderMode,
+  resolveCanvasKitSurfaceRequest,
+  resolveRenderBackendRequest,
+  resolveRenderProfile,
+} from '@/view/render-backend';
 
 const wasm = new WasmBridge();
 const eventBus = new EventBus();
@@ -106,10 +113,39 @@ async function initialize(): Promise<void> {
     if (import.meta.env.DEV) {
       initRhwpDev(wasm);
     }
+    const renderBackendRequest = resolveRenderBackendRequest(window.location.search);
+    const canvaskitMode = resolveCanvasKitRenderMode(window.location.search);
+    const canvaskitSurfaceRequest = resolveCanvasKitSurfaceRequest(window.location.search);
+    const renderProfile = resolveRenderProfile(window.location.search);
+    if (renderBackendRequest.unsupportedReason) {
+      console.warn(
+        `[main] 지원하지 않는 renderer 값입니다: ${renderBackendRequest.requested}; Canvas2D를 사용합니다.`,
+      );
+    }
+    let renderBackend = renderBackendRequest.backend;
+    let canvaskitRenderer: CanvasKitLayerRenderer | null = null;
+
+    if (renderBackend === 'canvaskit') {
+      msg.textContent = 'CanvasKit 로딩 중...';
+      try {
+        const { CanvasKitLayerRenderer } = await import('@/view/canvaskit-renderer');
+        canvaskitRenderer = await CanvasKitLayerRenderer.create(canvaskitMode, canvaskitSurfaceRequest);
+      } catch (error) {
+        console.error('[main] CanvasKit 초기화 실패, Canvas2D로 폴백합니다:', error);
+        renderBackend = 'canvas2d';
+      }
+    }
     msg.textContent = 'HWP 파일을 선택해주세요.';
 
     const container = document.getElementById('scroll-container')!;
-    canvasView = new CanvasView(container, wasm, eventBus);
+    canvasView = new CanvasView(
+      container,
+      wasm,
+      eventBus,
+      renderBackend,
+      renderProfile,
+      canvaskitRenderer,
+    );
 
     // 눈금자 초기화
     ruler = new Ruler(
@@ -208,6 +244,10 @@ async function initialize(): Promise<void> {
     if (import.meta.env.DEV) {
       (window as any).__inputHandler = inputHandler;
       (window as any).__canvasView = canvasView;
+      (window as any).__renderBackend = renderBackend;
+      (window as any).__canvaskitRenderMode = canvaskitMode;
+      (window as any).__canvaskitSurfaceRequest = canvaskitSurfaceRequest;
+      (window as any).__renderProfile = renderProfile;
     }
   } catch (error) {
     msg.textContent = `WASM 초기화 실패: ${error}`;

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -6,6 +6,9 @@ import { CanvasPool } from './canvas-pool';
 import { PageRenderer } from './page-renderer';
 import { ViewportManager } from './viewport-manager';
 import { CoordinateSystem } from './coordinate-system';
+import type { CanvasKitLayerRenderer } from './canvaskit-renderer';
+import { clampRenderScale, type RenderBackend } from './render-backend';
+import type { LayerRenderProfile } from '@/core/types';
 
 export class CanvasView {
   private virtualScroll: VirtualScroll;
@@ -23,10 +26,13 @@ export class CanvasView {
     private container: HTMLElement,
     private wasm: WasmBridge,
     private eventBus: EventBus,
+    renderBackend: RenderBackend = 'canvas2d',
+    renderProfile: LayerRenderProfile = 'screen',
+    canvaskitRenderer: CanvasKitLayerRenderer | null = null,
   ) {
     this.virtualScroll = new VirtualScroll();
     this.canvasPool = new CanvasPool();
-    this.pageRenderer = new PageRenderer(wasm);
+    this.pageRenderer = new PageRenderer(wasm, renderBackend, renderProfile, canvaskitRenderer);
     this.viewportManager = new ViewportManager(eventBus);
     this.coordinateSystem = new CoordinateSystem(this.virtualScroll);
 
@@ -136,20 +142,15 @@ export class CanvasView {
     const zoom = this.viewportManager.getZoom();
     const rawDpr = window.devicePixelRatio || 1;
 
-    // iOS WebKit Canvas 최대 크기 제한 (64MP = 67,108,864 pixels)
-    // 물리 크기 = pageSize × zoom × dpr 가 제한을 초과하면 dpr을 낮춘다
     const pageInfo = this.pages[pageIdx];
-    const MAX_CANVAS_PIXELS = 67108864;
-    let dpr = rawDpr;
-    if (pageInfo) {
-      const physW = pageInfo.width * zoom * dpr;
-      const physH = pageInfo.height * zoom * dpr;
-      if (physW * physH > MAX_CANVAS_PIXELS) {
-        dpr = Math.sqrt(MAX_CANVAS_PIXELS / (pageInfo.width * zoom * pageInfo.height * zoom));
-        dpr = Math.max(1, Math.floor(dpr)); // 최소 1, 정수로 내림
-      }
+    if (!pageInfo) {
+      console.error(`[CanvasView] 페이지 ${pageIdx} 정보가 없습니다`);
+      this.canvasPool.release(pageIdx);
+      return;
     }
-    const renderScale = zoom * dpr;
+    // iOS/WebKit과 GPU surface가 감당하기 어려운 물리 픽셀 수를 중앙 정책으로 제한한다.
+    const renderScale = clampRenderScale(pageInfo, zoom * rawDpr);
+    const dpr = renderScale / (zoom > 0 ? zoom : 1);
 
     // Canvas를 DOM에 추가하고 위치를 설정한다
     canvas.style.top = `${this.virtualScroll.getPageOffset(pageIdx)}px`;
@@ -273,6 +274,7 @@ export class CanvasView {
   /** 전체 정리 */
   dispose(): void {
     this.reset();
+    this.pageRenderer.dispose();
     this.viewportManager.detach();
     for (const unsub of this.unsubscribers) {
       unsub();
@@ -286,6 +288,10 @@ export class CanvasView {
 
   getViewportManager(): ViewportManager {
     return this.viewportManager;
+  }
+
+  getRenderBackend(): RenderBackend {
+    return this.pageRenderer.getBackend();
   }
 
   getCoordinateSystem(): CoordinateSystem {

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -1,0 +1,608 @@
+import CanvasKitInit from 'canvaskit-wasm';
+import type {
+  Canvas,
+  CanvasKit,
+  Color,
+  Image as SkImage,
+  Paint,
+  Path,
+  PathBuilder,
+  Rect,
+  Surface,
+  Typeface,
+} from 'canvaskit-wasm';
+import canvaskitWasmUrl from 'canvaskit-wasm/bin/canvaskit.wasm?url';
+
+import type {
+  LayerBounds,
+  LayerClipNode,
+  LayerEllipseOp,
+  LayerFormObjectOp,
+  LayerImageOp,
+  LayerLeafNode,
+  LayerLineOp,
+  LayerNode,
+  LayerPageBackgroundOp,
+  LayerPaintOp,
+  LayerPathCommand,
+  LayerPathOp,
+  LayerPlaceholderOp,
+  LayerRectangleOp,
+  LayerRenderProfile,
+  LayerShapeStyle,
+  LayerTextRunOp,
+  PageInfo,
+  PageLayerTree,
+} from '@/core/types';
+import {
+  DEFAULT_CANVASKIT_SURFACE_REQUEST,
+  type CanvasKitRenderMode,
+  type CanvasKitSurfacePreference,
+  type CanvasKitSurfaceRequest,
+} from './render-backend';
+import { canvaskitClipRightPad } from './canvaskit/policy';
+
+type CanvasKitApi = CanvasKit;
+type SkCanvas = Canvas;
+type SkPaint = Paint;
+type SkSurface = Surface;
+type MutablePath = Path & Pick<PathBuilder, 'arcToRotated' | 'close' | 'cubicTo' | 'lineTo' | 'moveTo'>;
+
+export interface CanvasKitRenderDiagnostics {
+  mode: CanvasKitRenderMode;
+  surfacePreference: CanvasKitSurfacePreference;
+  surfaceFallbackReason: string | null;
+  lastUnsupportedOps: string[];
+  lastRenderError: string | null;
+  hiddenCanvas2dOverlayUsed: false;
+}
+
+export class CanvasKitLayerRenderer {
+  private readonly imageCache = new Map<string, SkImage>();
+  private readonly unsupportedOps = new Set<string>();
+  private surfaceFallbackReason: string | null = null;
+  private lastRenderError: string | null = null;
+  private disposed = false;
+
+  private constructor(
+    private readonly canvasKit: CanvasKitApi,
+    private readonly renderMode: CanvasKitRenderMode,
+    private readonly surfaceRequest: CanvasKitSurfaceRequest,
+    private readonly defaultTypeface: Typeface | null,
+  ) {}
+
+  static async create(
+    renderMode: CanvasKitRenderMode = 'default',
+    surfaceRequest: CanvasKitSurfaceRequest | CanvasKitSurfacePreference = DEFAULT_CANVASKIT_SURFACE_REQUEST,
+  ): Promise<CanvasKitLayerRenderer> {
+    const canvasKit = await CanvasKitInit({
+      locateFile: (file) => file === 'canvaskit.wasm' ? canvaskitWasmUrl : file,
+    });
+    const resolvedSurfaceRequest = typeof surfaceRequest === 'string'
+      ? { ...DEFAULT_CANVASKIT_SURFACE_REQUEST, preference: surfaceRequest, requested: surfaceRequest }
+      : surfaceRequest;
+    let defaultTypeface: Typeface | null = null;
+    try {
+      const response = await fetch('fonts/NotoSansKR-Regular.woff2');
+      if (response.ok) {
+        const bytes = await response.arrayBuffer();
+        defaultTypeface = canvasKit.Typeface.MakeFreeTypeFaceFromData(bytes)
+          ?? canvasKit.Typeface.MakeTypefaceFromData(bytes);
+      }
+    } catch (error) {
+      console.warn('[CanvasKitLayerRenderer] 기본 CJK 폰트 로딩 실패:', error);
+    }
+    return new CanvasKitLayerRenderer(canvasKit, renderMode, resolvedSurfaceRequest, defaultTypeface);
+  }
+
+  renderPage(tree: PageLayerTree, targetCanvas: HTMLCanvasElement, scale: number, pageInfo?: PageInfo): void {
+    if (this.disposed) {
+      throw new Error('CanvasKit renderer가 이미 dispose되었습니다');
+    }
+    this.unsupportedOps.clear();
+    this.lastRenderError = null;
+    let surface: SkSurface | null = null;
+    try {
+      surface = this.makeSurface(targetCanvas);
+      const canvas = surface.getCanvas();
+      let hasPageBackground = false;
+      const stack: LayerNode[] = [tree.root];
+      while (stack.length > 0 && !hasPageBackground) {
+        const node = stack.pop()!;
+        if (node.kind === 'group') {
+          stack.push(...node.children);
+        } else if (node.kind === 'clipRect') {
+          stack.push(node.child);
+        } else {
+          hasPageBackground = node.ops.some((op) => op.type === 'pageBackground');
+        }
+      }
+      canvas.save();
+      canvas.clear(this.color(hasPageBackground ? 'rgba(0,0,0,0)' : '#ffffff'));
+      canvas.scale(scale, scale);
+      this.renderNode(canvas, tree.root, tree.profile ?? 'screen');
+      if (pageInfo) {
+        const paint = this.makeStrokePaint('#c0c0c0', 0.3);
+        const left = pageInfo.marginLeft;
+        const top = pageInfo.marginHeader + pageInfo.marginTop;
+        const right = pageInfo.width - pageInfo.marginRight;
+        const bottom = pageInfo.height - pageInfo.marginFooter - pageInfo.marginBottom;
+        const length = 15;
+        canvas.drawLine(left, top - length, left, top, paint);
+        canvas.drawLine(left, top, left - length, top, paint);
+        canvas.drawLine(right + length, top, right, top, paint);
+        canvas.drawLine(right, top, right, top - length, paint);
+        canvas.drawLine(left - length, bottom, left, bottom, paint);
+        canvas.drawLine(left, bottom, left, bottom + length, paint);
+        canvas.drawLine(right, bottom + length, right, bottom, paint);
+        canvas.drawLine(right, bottom, right + length, bottom, paint);
+        paint.delete();
+      }
+      canvas.restore();
+      surface.flush();
+    } catch (error) {
+      this.recordRenderFailure(error);
+      throw error;
+    } finally {
+      surface?.delete();
+    }
+  }
+
+  releaseLayerTree(_tree: PageLayerTree): void {
+    /* P16 does not intern per-tree native pictures yet. */
+  }
+
+  diagnostics(): CanvasKitRenderDiagnostics {
+    return {
+      mode: this.renderMode,
+      surfacePreference: this.surfaceRequest.preference,
+      surfaceFallbackReason: this.surfaceFallbackReason ?? this.surfaceRequest.unsupportedReason ?? null,
+      lastUnsupportedOps: [...this.unsupportedOps].sort(),
+      lastRenderError: this.lastRenderError,
+      hiddenCanvas2dOverlayUsed: false,
+    };
+  }
+
+  recordRenderFailure(error: unknown): void {
+    this.lastRenderError = error instanceof Error ? error.message : String(error);
+    this.unsupportedOps.add('renderPage');
+  }
+
+  dispose(): void {
+    this.disposed = true;
+    for (const image of this.imageCache.values()) {
+      image?.delete?.();
+    }
+    this.imageCache.clear();
+    this.defaultTypeface?.delete();
+  }
+
+  private makeSurface(targetCanvas: HTMLCanvasElement): SkSurface {
+    this.surfaceFallbackReason = this.surfaceRequest.unsupportedReason ?? null;
+    if (this.surfaceRequest.preference === 'software') {
+      const swSurface = this.canvasKit.MakeSWCanvasSurface(targetCanvas);
+      if (swSurface) return swSurface;
+      this.surfaceFallbackReason = 'softwareSurfaceUnavailable';
+    }
+    if (this.surfaceRequest.preference === 'webgpu') {
+      this.surfaceFallbackReason = 'webgpuSurfaceUnsupportedInP16';
+    }
+    const surface = this.canvasKit.MakeCanvasSurface(targetCanvas)
+      ?? this.canvasKit.MakeSWCanvasSurface(targetCanvas);
+    if (!surface) {
+      throw new Error('CanvasKit surface를 만들 수 없습니다');
+    }
+    if (this.surfaceRequest.preference === 'software') {
+      this.surfaceFallbackReason = 'softwareSurfaceUnavailableUsingDefaultSurface';
+    }
+    return surface;
+  }
+
+  private renderNode(canvas: SkCanvas, node: LayerNode, profile: LayerRenderProfile): void {
+    if (node.kind === 'group') {
+      for (const child of node.children) {
+        this.renderNode(canvas, child, profile);
+      }
+      return;
+    }
+    if (node.kind === 'clipRect') {
+      this.renderClipNode(canvas, node, profile);
+      return;
+    }
+    this.renderLeaf(canvas, node);
+  }
+
+  private renderClipNode(canvas: SkCanvas, node: LayerClipNode, profile: LayerRenderProfile): void {
+    const pad = canvaskitClipRightPad(this.renderMode, profile, node.clipKind);
+    const clip = {
+      ...node.clip,
+      width: node.clip.width + pad,
+    };
+    canvas.save();
+    canvas.clipRect(this.rect(clip), this.canvasKit.ClipOp?.Intersect ?? 0, true);
+    this.renderNode(canvas, node.child, profile);
+    canvas.restore();
+  }
+
+  private renderLeaf(canvas: SkCanvas, node: LayerLeafNode): void {
+    for (const op of node.ops) {
+      this.renderOp(canvas, op);
+    }
+  }
+
+  private renderOp(canvas: SkCanvas, op: LayerPaintOp): void {
+    switch (op.type) {
+      case 'pageBackground':
+        this.renderPageBackground(canvas, op);
+        return;
+      case 'rectangle':
+        this.renderRectangle(canvas, op);
+        return;
+      case 'ellipse':
+        this.renderEllipse(canvas, op);
+        return;
+      case 'line':
+        this.renderLine(canvas, op);
+        return;
+      case 'path':
+        this.renderPath(canvas, op);
+        return;
+      case 'image':
+        this.renderImage(canvas, op);
+        return;
+      case 'textRun':
+        this.renderTextRun(canvas, op);
+        return;
+      case 'footnoteMarker':
+        this.renderTextRun(canvas, {
+          type: 'textRun',
+          bbox: op.bbox,
+          text: op.text,
+          baseline: op.bbox.y + (op.fontSize ?? 7),
+          style: { fontFamily: op.fontFamily, fontSize: op.fontSize, color: op.color },
+        });
+        return;
+      case 'formObject':
+        this.renderFormObject(canvas, op);
+        return;
+      case 'placeholder':
+        this.renderPlaceholder(canvas, op);
+        return;
+      case 'equation':
+      case 'rawSvg':
+      case 'charOverlap':
+      case 'glyphRun':
+      case 'glyphOutline':
+      case 'tabLeader':
+      case 'textControlMark':
+      case 'textDecoration':
+        this.unsupportedOps.add(op.type);
+        return;
+      default:
+        this.unsupportedOps.add((op as { type?: string }).type ?? 'unknown');
+    }
+  }
+
+  private renderPageBackground(canvas: SkCanvas, op: LayerPageBackgroundOp): void {
+    if (op.backgroundColor) {
+      const paint = this.makeFillPaint(op.backgroundColor);
+      canvas.drawRect(this.rect(op.bbox), paint);
+      paint.delete?.();
+    }
+    if (op.borderColor && (op.borderWidth ?? 0) > 0) {
+      const paint = this.makeStrokePaint(op.borderColor, op.borderWidth ?? 1);
+      canvas.drawRect(this.rect(op.bbox), paint);
+      paint.delete?.();
+    }
+  }
+
+  private renderRectangle(canvas: SkCanvas, op: LayerRectangleOp): void {
+    this.drawStyledShape(canvas, op.bbox, op.style, (paint) => {
+      const cornerRadius = op.cornerRadius ?? 0;
+      if (cornerRadius > 0) {
+        canvas.drawRRect(this.canvasKit.RRectXY(this.rect(op.bbox), cornerRadius, cornerRadius), paint);
+      } else {
+        canvas.drawRect(this.rect(op.bbox), paint);
+      }
+    });
+  }
+
+  private renderEllipse(canvas: SkCanvas, op: LayerEllipseOp): void {
+    this.drawStyledShape(canvas, op.bbox, op.style, (paint) => {
+      canvas.drawOval(this.rect(op.bbox), paint);
+    });
+  }
+
+  private renderLine(canvas: SkCanvas, op: LayerLineOp): void {
+    const paint = this.makeStrokePaint(op.style?.color ?? '#000000', op.style?.width ?? 1);
+    canvas.drawLine(op.x1, op.y1, op.x2, op.y2, paint);
+    paint.delete?.();
+  }
+
+  private renderPath(canvas: SkCanvas, op: LayerPathOp): void {
+    const path = new this.canvasKit.Path() as MutablePath;
+    let currentX = op.bbox.x;
+    let currentY = op.bbox.y;
+    for (const command of op.commands ?? []) {
+      [currentX, currentY] = this.applyPathCommand(path, command, currentX, currentY);
+    }
+    const style = op.style ?? {
+      strokeColor: op.lineStyle?.color ?? '#000000',
+      strokeWidth: op.lineStyle?.width ?? 1,
+      fillColor: null,
+    };
+    this.drawStyledPath(canvas, path, style);
+    path.delete?.();
+  }
+
+  private applyPathCommand(path: MutablePath, command: LayerPathCommand, currentX: number, currentY: number): [number, number] {
+    switch (command.type) {
+      case 'moveTo':
+        path.moveTo(command.x, command.y);
+        return [command.x, command.y];
+      case 'lineTo':
+        path.lineTo(command.x, command.y);
+        return [command.x, command.y];
+      case 'curveTo':
+        path.cubicTo(command.x1, command.y1, command.x2, command.y2, command.x3, command.y3);
+        return [command.x3, command.y3];
+      case 'arcTo':
+        if (typeof path.arcToRotated === 'function') {
+          path.arcToRotated(command.rx, command.ry, command.rotation, command.largeArc, command.sweep, command.x, command.y);
+        } else {
+          path.lineTo(command.x, command.y);
+        }
+        return [command.x, command.y];
+      case 'closePath':
+        path.close();
+        return [currentX, currentY];
+    }
+  }
+
+  private renderImage(canvas: SkCanvas, op: LayerImageOp): void {
+    const image = this.imageForOp(op);
+    if (!image) {
+      this.unsupportedOps.add('image');
+      return;
+    }
+    const paint = new this.canvasKit.Paint();
+    paint.setAntiAlias?.(true);
+    const dest = this.rect(op.bbox);
+    const source = typeof image.width === 'function' && typeof image.height === 'function'
+      ? this.canvasKit.XYWHRect(0, 0, image.width(), image.height())
+      : null;
+    try {
+      if (source) {
+        canvas.drawImageRect(image, source, dest, paint);
+      } else {
+        canvas.drawImage(image, op.bbox.x, op.bbox.y, paint);
+      }
+    } finally {
+      paint.delete?.();
+    }
+  }
+
+  private renderTextRun(canvas: SkCanvas, op: LayerTextRunOp): void {
+    if (!op.text) return;
+    const style = op.style ?? {};
+    const paint = this.makeFillPaint(style.color ?? '#000000');
+    paint.setAntiAlias?.(true);
+    const fontSize = style.fontSize ?? Math.max(1, op.bbox.height || 12);
+    if (!this.defaultTypeface && /[^\u0000-\u00ff]/.test(op.text)) {
+      this.unsupportedOps.add('textRunFont');
+      paint.delete();
+      return;
+    }
+    const font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
+    const x = op.bbox.x;
+    const y = op.baseline ?? op.bbox.y + fontSize;
+    const rotation = op.rotation ?? 0;
+    canvas.save();
+    if (rotation !== 0) {
+      canvas.rotate(rotation, x, y);
+    }
+    canvas.drawText(op.text, x, y, paint, font);
+    canvas.restore();
+    font.delete?.();
+    paint.delete?.();
+  }
+
+  private renderFormObject(canvas: SkCanvas, op: LayerFormObjectOp): void {
+    const fill = op.backColor && op.backColor !== '#000000' ? op.backColor : '#f7f7f7';
+    this.drawStyledShape(canvas, op.bbox, {
+      fillColor: fill,
+      strokeColor: op.foreColor ?? '#555555',
+      strokeWidth: 1,
+      opacity: op.enabled === false ? 0.55 : 1,
+    }, (paint) => canvas.drawRect(this.rect(op.bbox), paint));
+    if (op.value && (op.formType === 'checkbox' || op.formType === 'radio')) {
+      const paint = this.makeStrokePaint(op.foreColor ?? '#111111', 1.5);
+      const b = op.bbox;
+      canvas.drawLine(b.x + b.width * 0.25, b.y + b.height * 0.55, b.x + b.width * 0.45, b.y + b.height * 0.75, paint);
+      canvas.drawLine(b.x + b.width * 0.45, b.y + b.height * 0.75, b.x + b.width * 0.78, b.y + b.height * 0.28, paint);
+      paint.delete?.();
+    }
+    const label = op.caption || op.text;
+    if (label) {
+      this.renderTextRun(canvas, {
+        type: 'textRun',
+        bbox: { ...op.bbox, x: op.bbox.x + 4, width: Math.max(0, op.bbox.width - 8) },
+        text: label,
+        baseline: op.bbox.y + Math.max(10, op.bbox.height * 0.68),
+        style: { fontSize: Math.max(9, Math.min(14, op.bbox.height * 0.55)), color: op.foreColor ?? '#111111' },
+      });
+    }
+  }
+
+  private renderPlaceholder(canvas: SkCanvas, op: LayerPlaceholderOp): void {
+    this.drawStyledShape(canvas, op.bbox, {
+      fillColor: op.fillColor ?? '#f2f2f2',
+      strokeColor: op.strokeColor ?? '#999999',
+      strokeWidth: 1,
+    }, (paint) => canvas.drawRect(this.rect(op.bbox), paint));
+    if (op.label) {
+      this.renderTextRun(canvas, {
+        type: 'textRun',
+        bbox: { ...op.bbox, x: op.bbox.x + 4 },
+        text: op.label,
+        baseline: op.bbox.y + Math.max(10, op.bbox.height * 0.65),
+        style: { fontSize: Math.max(9, Math.min(14, op.bbox.height * 0.45)), color: '#555555' },
+      });
+    }
+  }
+
+  private drawStyledShape(
+    canvas: SkCanvas,
+    bounds: LayerBounds,
+    style: LayerShapeStyle | undefined,
+    draw: (paint: SkPaint) => void,
+  ): void {
+    if (style?.fillColor) {
+      const paint = this.makeFillPaint(style.fillColor, style.opacity);
+      draw(paint);
+      paint.delete?.();
+    }
+    if (style?.strokeColor && (style.strokeWidth ?? 0) > 0) {
+      const paint = this.makeStrokePaint(style.strokeColor, style.strokeWidth ?? 1, style.opacity);
+      draw(paint);
+      paint.delete?.();
+    }
+    if (!style?.fillColor && !style?.strokeColor) {
+      const paint = this.makeStrokePaint('#000000', 1);
+      draw(paint);
+      paint.delete?.();
+    }
+  }
+
+  private drawStyledPath(canvas: SkCanvas, path: Path, style: LayerShapeStyle): void {
+    let drawn = false;
+    if (style.fillColor) {
+      const paint = this.makeFillPaint(style.fillColor, style.opacity);
+      canvas.drawPath(path, paint);
+      paint.delete?.();
+      drawn = true;
+    }
+    if (style.strokeColor && (style.strokeWidth ?? 0) > 0) {
+      const paint = this.makeStrokePaint(style.strokeColor, style.strokeWidth ?? 1, style.opacity);
+      canvas.drawPath(path, paint);
+      paint.delete?.();
+      drawn = true;
+    }
+    if (!drawn) {
+      const paint = this.makeStrokePaint('#000000', 1);
+      canvas.drawPath(path, paint);
+      paint.delete?.();
+    }
+  }
+
+  private imageForOp(op: LayerImageOp): SkImage | null {
+    let key: string | null = null;
+    if (op.imageRef !== undefined) {
+      key = `ref:${String(op.imageRef)}`;
+    } else if (op.base64) {
+      let hash = 2166136261;
+      for (let i = 0; i < op.base64.length; i += 1) {
+        hash ^= op.base64.charCodeAt(i);
+        hash = Math.imul(hash, 16777619);
+      }
+      key = `${op.mime ?? 'application/octet-stream'}:${op.base64.length}:${(hash >>> 0).toString(16)}`;
+    }
+    if (!key) return null;
+    const cached = this.imageCache.get(key);
+    if (cached) return cached;
+    const bytes = base64ToBytes(op.base64 ?? '');
+    const image = this.canvasKit.MakeImageFromEncoded(bytes);
+    if (!image) return null;
+    this.imageCache.set(key, image);
+    return image;
+  }
+
+  private makeFillPaint(color: string, opacity = 1): SkPaint {
+    const paint = new this.canvasKit.Paint();
+    paint.setAntiAlias?.(true);
+    paint.setStyle(this.canvasKit.PaintStyle.Fill);
+    paint.setColor(this.color(color, opacity));
+    return paint;
+  }
+
+  private makeStrokePaint(color: string, width: number, opacity = 1): SkPaint {
+    const paint = new this.canvasKit.Paint();
+    paint.setAntiAlias?.(true);
+    paint.setStyle(this.canvasKit.PaintStyle.Stroke);
+    paint.setStrokeWidth(Math.max(0.1, width));
+    paint.setColor(this.color(color, opacity));
+    return paint;
+  }
+
+  private rect(bounds: LayerBounds): Rect {
+    return this.canvasKit.XYWHRect(bounds.x, bounds.y, bounds.width, bounds.height);
+  }
+
+  private color(cssColor: string, opacity = 1): Color {
+    const { r, g, b, a } = parseCssColor(cssColor);
+    const alpha = Math.max(0, Math.min(1, a * opacity));
+    return this.canvasKit.Color(r, g, b, alpha);
+  }
+}
+
+function parseCssColor(value: string): { r: number; g: number; b: number; a: number } {
+  const trimmed = value.trim();
+  if (trimmed === 'transparent') {
+    return { r: 0, g: 0, b: 0, a: 0 };
+  }
+  if (trimmed === 'black') {
+    return { r: 0, g: 0, b: 0, a: 1 };
+  }
+  if (trimmed === 'white') {
+    return { r: 255, g: 255, b: 255, a: 1 };
+  }
+  const shortHex = /^#?([0-9a-f]{3,4})$/i.exec(trimmed);
+  if (shortHex) {
+    const value = shortHex[1];
+    return {
+      r: Number.parseInt(value[0] + value[0], 16),
+      g: Number.parseInt(value[1] + value[1], 16),
+      b: Number.parseInt(value[2] + value[2], 16),
+      a: value.length === 4 ? Number.parseInt(value[3] + value[3], 16) / 255 : 1,
+    };
+  }
+  const hexWithAlpha = /^#?([0-9a-f]{8})$/i.exec(trimmed);
+  if (hexWithAlpha) {
+    const n = Number.parseInt(hexWithAlpha[1], 16);
+    return {
+      r: (n >> 24) & 0xff,
+      g: (n >> 16) & 0xff,
+      b: (n >> 8) & 0xff,
+      a: (n & 0xff) / 255,
+    };
+  }
+  const hex = /^#?([0-9a-f]{6})$/i.exec(trimmed);
+  if (hex) {
+    const n = Number.parseInt(hex[1], 16);
+    return {
+      r: (n >> 16) & 0xff,
+      g: (n >> 8) & 0xff,
+      b: n & 0xff,
+      a: 1,
+    };
+  }
+  const rgb = /^rgba?\((\d+),\s*(\d+),\s*(\d+)(?:,\s*([0-9.]+))?\)$/i.exec(trimmed);
+  if (rgb) {
+    return {
+      r: Number(rgb[1]),
+      g: Number(rgb[2]),
+      b: Number(rgb[3]),
+      a: rgb[4] === undefined ? 1 : Number(rgb[4]),
+    };
+  }
+  return { r: 0, g: 0, b: 0, a: 1 };
+}
+
+function base64ToBytes(base64: string): Uint8Array {
+  const binary = atob(base64);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return bytes;
+}

--- a/rhwp-studio/src/view/canvaskit/policy.ts
+++ b/rhwp-studio/src/view/canvaskit/policy.ts
@@ -1,0 +1,20 @@
+import type { CanvasKitRenderMode } from '@/view/render-backend';
+import type { LayerClipNode, LayerRenderProfile } from '@/core/types';
+
+export function canvaskitClipRightPad(
+  renderMode: CanvasKitRenderMode,
+  profile: LayerRenderProfile,
+  clipKind: LayerClipNode['clipKind'],
+  rightOverflowSlop?: number,
+): number {
+  if (typeof rightOverflowSlop === 'number' && Number.isFinite(rightOverflowSlop)) {
+    return Math.max(0, rightOverflowSlop);
+  }
+  // P16 only mirrors the known legacy text overflow case: HWP body/table-cell clips can
+  // trim the right edge of glyphs in fast preview. This is not a general clip inflation
+  // policy; broader native/browser parity rules belong with the later CanvasKit coverage work.
+  if (renderMode === 'compat' && profile === 'fastPreview' && (clipKind === 'body' || clipKind === 'tableCell')) {
+    return 4;
+  }
+  return 0;
+}

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -1,4 +1,7 @@
 import { WasmBridge } from '@/core/wasm-bridge';
+import type { LayerRenderProfile } from '@/core/types';
+import type { CanvasKitLayerRenderer } from './canvaskit-renderer';
+import type { RenderBackend } from './render-backend';
 
 /**
  * PageLayerTree JSON 의 PaintOp::Image 메타정보 (Task #516, Stage 5.2).
@@ -26,7 +29,12 @@ export class PageRenderer {
   private reRenderTimers = new Map<number, ReturnType<typeof setTimeout>[]>();
   private imageRetryCounts = new Map<number, number>();
 
-  constructor(private wasm: WasmBridge) {}
+  constructor(
+    private wasm: WasmBridge,
+    private backend: RenderBackend = 'canvas2d',
+    private renderProfile: LayerRenderProfile = 'screen',
+    private canvaskitRenderer: CanvasKitLayerRenderer | null = null,
+  ) {}
 
   /** 페이지를 Canvas에 렌더링한다 (renderScale = zoom × DPR) */
   renderPage(
@@ -36,6 +44,11 @@ export class PageRenderer {
     displayScale: number,
     dpr: number,
   ): void {
+    if (this.backend === 'canvaskit') {
+      this.renderPageCanvasKit(pageIdx, canvas, renderScale);
+      return;
+    }
+
     // Task #516 Stage 5.2: 다층 layer 모드.
     // 1) 본문 Canvas 는 'flow' 필터로 BehindText/InFrontOfText 그림 제외
     // 2) overlay (BehindText / InFrontOfText) 는 같은 부모 컨테이너에 <img> 로 추가
@@ -43,6 +56,42 @@ export class PageRenderer {
     this.drawMarginGuides(pageIdx, canvas, renderScale);
     const overlays = this.applyOverlays(pageIdx, canvas, displayScale, dpr);
     this.scheduleReRender(pageIdx, canvas, renderScale, overlays.imageCount);
+  }
+
+  getBackend(): RenderBackend {
+    return this.backend;
+  }
+
+  private renderPageCanvasKit(
+    pageIdx: number,
+    canvas: HTMLCanvasElement,
+    renderScale: number,
+  ): void {
+    if (!this.canvaskitRenderer) {
+      throw new Error('CanvasKit renderer가 초기화되지 않았습니다');
+    }
+
+    const parent = canvas.parentElement;
+    if (parent) {
+      this.removePageLayers(parent, pageIdx);
+    }
+
+    const pageInfo = this.wasm.getPageInfo(pageIdx);
+    canvas.width = Math.max(1, Math.floor(pageInfo.width * renderScale));
+    canvas.height = Math.max(1, Math.floor(pageInfo.height * renderScale));
+
+    const tree = this.wasm.getPageLayerTreeObject(pageIdx, this.renderProfile);
+    try {
+      this.canvaskitRenderer.renderPage(tree, canvas, renderScale, pageInfo);
+    } catch (error) {
+      this.canvaskitRenderer.recordRenderFailure(error);
+      console.error(`[PageRenderer] CanvasKit 페이지 렌더링 실패 (page=${pageIdx}):`, error);
+      this.cancelReRender(pageIdx);
+      this.imageRetryCounts.delete(pageIdx);
+      return;
+    }
+    this.cancelReRender(pageIdx);
+    this.imageRetryCounts.delete(pageIdx);
   }
 
   /**
@@ -354,6 +403,12 @@ export class PageRenderer {
 
   resetImageRetryState(): void {
     this.imageRetryCounts.clear();
+  }
+
+  dispose(): void {
+    this.cancelAll();
+    this.canvaskitRenderer?.dispose();
+    this.canvaskitRenderer = null;
   }
 }
 

--- a/rhwp-studio/src/view/render-backend.ts
+++ b/rhwp-studio/src/view/render-backend.ts
@@ -1,0 +1,126 @@
+import type { LayerRenderProfile, PageInfo } from '@/core/types';
+
+export type RenderBackend = 'canvas2d' | 'canvaskit';
+export type CanvasKitRenderMode = 'default' | 'compat';
+export type CanvasKitSurfacePreference = 'auto' | 'webgpu' | 'webgl' | 'software';
+export type CanvasKitSurfaceUnsupportedReason = 'unsupportedSurfaceBackend';
+export type RenderBackendUnsupportedReason = 'unsupportedRenderBackend';
+
+export interface CanvasKitSurfaceRequest {
+  preference: CanvasKitSurfacePreference;
+  requested: string;
+  unsupportedReason?: CanvasKitSurfaceUnsupportedReason;
+}
+
+export interface RenderBackendRequest {
+  backend: RenderBackend;
+  requested?: string;
+  unsupportedReason?: RenderBackendUnsupportedReason;
+}
+
+export type { LayerRenderProfile } from '@/core/types';
+
+export const DEFAULT_CANVASKIT_SURFACE_REQUEST: CanvasKitSurfaceRequest = {
+  preference: 'auto',
+  requested: 'auto',
+};
+
+const BACKEND_STORAGE_KEY = 'rhwp.renderBackend';
+const CANVASKIT_MODE_STORAGE_KEY = 'rhwp.canvaskitMode';
+const RENDER_PROFILE_STORAGE_KEY = 'rhwp.renderProfile';
+
+function readStorage(key: string): string | null {
+  try {
+    return globalThis.localStorage?.getItem(key) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+function writeStorage(key: string, value: string): void {
+  try {
+    globalThis.localStorage?.setItem(key, value);
+  } catch {
+    /* storage can be unavailable in private contexts */
+  }
+}
+
+function searchParam(search: string, ...keys: string[]): string | null {
+  const params = new URLSearchParams(search);
+  for (const key of keys) {
+    const value = params.get(key);
+    if (value !== null) return value;
+  }
+  return null;
+}
+
+export function resolveRenderBackend(search = ''): RenderBackend {
+  return resolveRenderBackendRequest(search).backend;
+}
+
+export function resolveRenderBackendRequest(search = ''): RenderBackendRequest {
+  const explicit = searchParam(search, 'renderer', 'renderBackend', 'backend');
+  const normalized = explicit?.trim().toLowerCase();
+  if (!normalized) return { backend: 'canvas2d' };
+  if (normalized === 'canvaskit' || normalized === 'skia') {
+    return { backend: 'canvaskit', requested: normalized };
+  }
+  if (normalized === 'canvas' || normalized === 'canvas2d' || normalized === 'legacy') {
+    return { backend: 'canvas2d', requested: normalized };
+  }
+  return {
+    backend: 'canvas2d',
+    requested: explicit ?? normalized,
+    unsupportedReason: 'unsupportedRenderBackend',
+  };
+}
+
+export function persistRenderBackend(value: RenderBackend): void {
+  writeStorage(BACKEND_STORAGE_KEY, value);
+}
+
+export function resolveCanvasKitRenderMode(search = ''): CanvasKitRenderMode {
+  const explicit = searchParam(search, 'canvaskitMode', 'skiaMode') ?? readStorage(CANVASKIT_MODE_STORAGE_KEY);
+  const normalized = explicit?.trim().toLowerCase();
+  if (normalized === 'compat' || normalized === 'compatibility') return 'compat';
+  return 'default';
+}
+
+export function persistCanvasKitRenderMode(value: CanvasKitRenderMode): void {
+  writeStorage(CANVASKIT_MODE_STORAGE_KEY, value);
+}
+
+export function resolveCanvasKitSurfaceRequest(search = ''): CanvasKitSurfaceRequest {
+  const requested = searchParam(search, 'canvaskitSurface', 'skiaSurface')?.trim().toLowerCase() ?? 'auto';
+  if (requested === 'auto' || requested === 'webgpu' || requested === 'webgl' || requested === 'software') {
+    return { preference: requested, requested };
+  }
+  if (requested === 'gpu') return { preference: 'webgl', requested };
+  if (requested === 'sw' || requested === 'cpu') return { preference: 'software', requested };
+  return {
+    preference: 'auto',
+    requested,
+    unsupportedReason: 'unsupportedSurfaceBackend',
+  };
+}
+
+export function resolveRenderProfile(search = ''): LayerRenderProfile {
+  const explicit = searchParam(search, 'renderProfile', 'profile') ?? readStorage(RENDER_PROFILE_STORAGE_KEY);
+  const normalized = explicit?.trim().toLowerCase();
+  if (normalized === 'fast' || normalized === 'fast-preview' || normalized === 'fastpreview') return 'fastPreview';
+  if (normalized === 'print') return 'print';
+  if (normalized === 'high' || normalized === 'high-quality' || normalized === 'highquality') return 'highQuality';
+  return 'screen';
+}
+
+export function persistRenderProfile(value: LayerRenderProfile): void {
+  writeStorage(RENDER_PROFILE_STORAGE_KEY, value);
+}
+
+export function clampRenderScale(pageInfo: PageInfo, requestedScale: number): number {
+  const scale = Number.isFinite(requestedScale) && requestedScale > 0 ? requestedScale : 1;
+  const maxPixels = 67_108_864;
+  const pixels = pageInfo.width * scale * pageInfo.height * scale;
+  if (pixels <= maxPixels) return scale;
+  return Math.max(1, Math.sqrt(maxPixels / (pageInfo.width * pageInfo.height)));
+}

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+import {
+  resolveCanvasKitRenderMode,
+  resolveCanvasKitSurfaceRequest,
+  resolveRenderBackend,
+  resolveRenderBackendRequest,
+  resolveRenderProfile,
+} from '../src/view/render-backend.ts';
+
+test('render backend resolver keeps Canvas2D as the default and accepts skia aliases', () => {
+  assert.equal(resolveRenderBackend(''), 'canvas2d');
+  assert.equal(resolveRenderBackend('?renderer=canvas'), 'canvas2d');
+  assert.equal(resolveRenderBackend('?renderer=canvas2d'), 'canvas2d');
+  assert.equal(resolveRenderBackend('?renderer=canvaskit'), 'canvaskit');
+  assert.equal(resolveRenderBackend('?renderer=skia'), 'canvaskit');
+});
+
+test('render backend resolver reports invalid explicit values and keeps URL opt-ins ephemeral', () => {
+  const originalStorage = (globalThis as { localStorage?: unknown }).localStorage;
+  (globalThis as { localStorage?: unknown }).localStorage = {
+    getItem: () => 'canvaskit',
+    setItem: () => undefined,
+  };
+  try {
+    assert.equal(resolveRenderBackend(''), 'canvas2d');
+    assert.deepEqual(resolveRenderBackendRequest('?renderer=unknown'), {
+      backend: 'canvas2d',
+      requested: 'unknown',
+      unsupportedReason: 'unsupportedRenderBackend',
+    });
+  } finally {
+    (globalThis as { localStorage?: unknown }).localStorage = originalStorage;
+  }
+});
+
+test('CanvasKit mode resolver exposes default and conservative compat direct modes', () => {
+  assert.equal(resolveCanvasKitRenderMode(''), 'default');
+  assert.equal(resolveCanvasKitRenderMode('?canvaskitMode=compat'), 'compat');
+  assert.equal(resolveCanvasKitRenderMode('?skiaMode=compatibility'), 'compat');
+  assert.equal(resolveCanvasKitRenderMode('?canvaskitMode=overlay'), 'default');
+});
+
+test('CanvasKit surface resolver records unsupported requests without throwing', () => {
+  assert.deepEqual(resolveCanvasKitSurfaceRequest('?canvaskitSurface=webgpu'), {
+    preference: 'webgpu',
+    requested: 'webgpu',
+  });
+  assert.deepEqual(resolveCanvasKitSurfaceRequest('?canvaskitSurface=cpu'), {
+    preference: 'software',
+    requested: 'cpu',
+  });
+  assert.deepEqual(resolveCanvasKitSurfaceRequest('?canvaskitSurface=metal'), {
+    preference: 'auto',
+    requested: 'metal',
+    unsupportedReason: 'unsupportedSurfaceBackend',
+  });
+});
+
+test('render profile resolver keeps screen as the stable browser default', () => {
+  assert.equal(resolveRenderProfile(''), 'screen');
+  assert.equal(resolveRenderProfile('?renderProfile=fast-preview'), 'fastPreview');
+  assert.equal(resolveRenderProfile('?profile=print'), 'print');
+  assert.equal(resolveRenderProfile('?profile=highQuality'), 'highQuality');
+});
+
+test('CanvasKit renderer source does not introduce Canvas2D overlay replay', () => {
+  const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
+  assert.equal(source.includes("getContext('2d')"), false);
+  assert.equal(source.includes('renderPageToCanvas'), false);
+  assert.equal(source.includes('rhwpOverlay'), false);
+});


### PR DESCRIPTION
## What

- Studio에 browser CanvasKit renderer를 추가합니다.
- `renderer=canvaskit` / `renderer=skia` alias로 opt-in browser backend를 선택할 수 있게 합니다.
- `canvaskitMode=default|compat`, `canvaskitSurface=auto|webgpu|webgl|software`, `renderProfile` resolver를 추가합니다.
- CanvasKit renderer는 `PageLayerTree` JSON을 직접 replay합니다.
- 기본 Canvas2D path가 CanvasKit bundle을 바로 가져오지 않도록 renderer module은 dynamic import로 분리했습니다.
- browser 쪽 `PageLayerTree` 타입과 `getPageLayerTreeObject(page, profile)` bridge를 추가했습니다.
- CanvasKit renderer source가 Canvas2D overlay replay를 호출하지 않는 regression test를 추가했습니다.

## Why

P15는 CanvasKit replay policy를 diagnostics-only API로 먼저 열었습니다. 이번 P16은 그 다음 단계로, Studio에서 실제 browser CanvasKit backend를 opt-in으로 실행할 수 있게 하는 foundation입니다.

여기서 중요한 기준은 CanvasKit을 Canvas2D-assisted preview로 두지 않는 것입니다. `default`와 `compat` 모두 Canvas2D overlay fallback이 아니라 CanvasKit direct replay mode로 다룹니다. 아직 모든 op를 완전하게 그리는 단계는 아니고, unsupported op는 조용히 Canvas2D로 덮지 않고 renderer diagnostics에 남깁니다.

## Compatibility

- 기본 renderer는 계속 Canvas2D입니다.
- 기존 Canvas2D overlay path는 기본 path에서 유지됩니다.
- CanvasKit은 query/localStorage opt-in일 때만 초기화됩니다.
- P15의 `getCanvasKitReplayPlan(page, mode)` API는 유지합니다.
- public native Skia/PDF API는 바꾸지 않습니다.

## Non-goals

- CanvasKit full parity를 이 PR에서 닫지 않습니다.
- TextRun effects, equation/raw SVG, glyph sidecar direct replay를 이 PR에서 완성하지 않습니다.
- CanvasKit/native raster/PDF 전체 visual diff pipeline은 이 PR 범위가 아닙니다.

## Validation

- `wasm-pack build --target web --dev`
- `npm --prefix rhwp-studio test`
- `npm --prefix rhwp-studio run build`
- `cargo test test_canvaskit_replay_plan_export_uses_mode_policy --lib`
- `git diff --check`

Refs #536
