### PR TITLE
Task #990: 빈 문단 위 treat-as-char 글상자 advance 이중 가산 정정 (closes #990)

### DIFF
--- a/mydocs/plans/task_m100_990.md
+++ b/mydocs/plans/task_m100_990.md
@@ -1,0 +1,81 @@
+# Task #990 수행계획서
+
+**제목**: 빈 문단 위 treat-as-char 글상자 — `FullParagraph`/`Shape` PageItem advance 이중 가산 정정
+**관련 이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+**마일스톤**: M100 (v1.0.0)
+
+---
+
+## 1. 배경
+
+빈 문단(텍스트 없음) 위에 얹힌 `treat_as_char` 글상자(도형)가 세로로 연속 배치될 때,
+박스 사이 세로 간격이 한컴 PDF(한글 2022) 대비 **정확히 2배**로 벌어진다.
+
+작업지시자 보고 — 내부 검증 문서 본문 1쪽의 글상자 3개(`※ 본 사업은 …`).
+
+## 2. 결함 분석 (조사 완료)
+
+### 정밀 측정
+
+박스 advance 를 같은 페이지 일반 본문 줄(줄간격 200%) advance 로 정규화한 비율:
+
+| | 박스↔박스 | 본문 줄 | 비율 |
+|--|--|--|--|
+| PDF(한글 2022, 정답지) | 35.4 pt | 18.4 pt | **1.92** |
+| rhwp | 132.9 px | 34.7 px | **3.83** |
+
+→ rhwp 비율이 PDF 의 **정확히 2.0배**. 박스 줄 advance = `9966 HU`,
+올바른 값(저장된 LINE_SEG `vertsize 3683 + spacing 1300`) = `4983 HU`.
+
+### Root cause
+
+빈 호스트 문단이 컬럼 레이아웃에서 **PageItem 2개**(`FullParagraph` + `Shape`)로
+분리 emit 되고, 두 항목이 **각각 `y_offset` 을 진행**시킨다.
+
+1. `FullParagraph` → `layout_paragraph()` (`src/renderer/layout.rs:3100`)
+   — 호스트 문단 LINE_SEG(`lh + ls = 4983 HU`)만큼 y 진행.
+   직후 `layout.rs:3119~3154` "TAC Shape 높이 보정" 블록은
+   `shape_bottom > y_offset` 가드가 있어 재진행하지 않음.
+2. `Shape` → `layout_shape_item()` (`src/renderer/layout.rs:4622~4692`)
+   — `!has_real_text`(빈 문단) 분기에서 **가드 없이** 재진행:
+   ```rust
+   let line_advance = ls.line_height + ls.line_spacing;  // 4983 HU
+   result_y = shape_y + line_advance.max(shape_h);        // 또 4983 진행
+   ```
+
+→ `4983 + 4983 = 9966 HU` 이중 가산.
+
+텍스트가 있는 문단은 `has_real_text=true` 라 위 분기를 건너뛰므로 정상
+— **빈 호스트 문단 경로 한정 버그**.
+
+부수: `shape_y = y_offset`(FullParagraph 진행 후 값)이므로 글상자 자체도
+문단 시작이 아닌 `para_start + 4983` 위치에 그려진다 — 위치도 함께 어긋남.
+
+## 3. 정정 방향
+
+`layout_shape_item()` 의 `!has_real_text` 분기에서:
+
+- 글상자 위치를 `y_offset`(이미 진행된 값)이 아닌 **호스트 문단 시작
+  (`para_start_y[para_index]`)** 으로 잡는다.
+- `FullParagraph` 항목이 이미 LINE_SEG 만큼 advance 했으므로 `result_y` 는
+  **재진행하지 않는다**(= 입력 `y_offset` 유지).
+
+→ 빈 문단 + treat-as-char 글상자의 세로 advance = LINE_SEG 1회분(`4983 HU`).
+
+## 4. 검증 방침
+
+- TDD: RED 통합 테스트 1건(빈 문단 + treat-as-char 글상자 2개 연속) → 정정 후 GREEN.
+  committed 회귀 샘플은 기존 샘플 중 동일 구조 탐색, 없으면 최소 재현 HWPX 추가.
+- 전체 `cargo test` 0 회귀.
+- 광범위 회귀: 기존 샘플 다수 `export-svg` 차분(음의 시프트 0건 확인).
+- 내부 검증 문서: 글상자 3개 advance 측정 → PDF 비율(1.92)과 정합 확인(로컬 한정).
+- WASM 재빌드.
+
+## 5. 비고
+
+- PR #989("lineSegArray line_spacing double-count")와 주제는 같으나, 그쪽은
+  `hwp3-sample16-hwp5.hwpx`(PUA 항목부호) 재현 — 본 건은 **빈 문단 +
+  treat-as-char 글상자**라는 별개 경로.
+- 이중 가산 제거 후에도 PDF 와 ~1400 HU 잔차(matrix 스케일 + spacing 1300)
+  가능 — 부차적, 본 task 범위 외(필요 시 후속 issue).

--- a/mydocs/plans/task_m100_990_impl.md
+++ b/mydocs/plans/task_m100_990_impl.md
@@ -1,0 +1,62 @@
+# Task #990 구현계획서
+
+**관련 이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+**수행계획서**: `task_m100_990.md`
+
+---
+
+## 단계 구성 (4단계)
+
+### Stage 1 — 재현 + 진단 (RED)
+
+- 빈 문단 위 treat-as-char 글상자 2개 이상 연속 구조의 committed 회귀 샘플 탐색.
+  없으면 최소 재현 HWPX(`samples/` 또는 `tests/` 픽스처) 추가.
+- TDD: 박스 advance = LINE_SEG 1회분(`lh + ls`)임을 검사하는 통합 테스트 작성
+  → 현재 코드에서 **FAIL(RED)** 확인 (advance ≈ 2배).
+- `layout_paragraph()`(`layout.rs:3100`)가 빈 호스트 문단에서 advance 하는 양과,
+  `layout_shape_item()`(`layout.rs:4622~4692`)의 재진행을 로그/덤프로 확정.
+- 산출물: `task_m100_990_stage1.md`
+
+### Stage 2 — 정정 (GREEN)
+
+- `layout_shape_item()` 의 `!has_real_text` 분기 정정:
+  - `shape_y` 를 `para_start_y[para_index]`(호스트 문단 시작)로 산출.
+  - `result_y` 는 입력 `y_offset` 유지(재진행 제거) — `FullParagraph` 항목이
+    이미 LINE_SEG 만큼 진행한 경우에 한함.
+  - 진행 여부 판정: `y_offset > para_start_y[para_index]` (FullParagraph 선행 emit 확인).
+- Stage 1 RED 테스트 → **GREEN** 전환 확인.
+- 변경 최소화 — `treat_as_char` 글상자 + 빈 문단 경로만 영향, 그 외 분기 불변.
+- 산출물: `task_m100_990_stage2.md` + 소스 커밋
+
+### Stage 3 — 검증 (회귀)
+
+- 전체 `cargo test` — 0 회귀 확인.
+- 광범위 회귀: 기존 샘플 다수 `export-svg` 전/후 차분
+  (treat-as-char 글상자/그림 보유 샘플 우선) — 음의 시프트 0건 확인.
+- 내부 검증 문서: 글상자 3개 advance 측정 → PDF 비율(1.92) 정합 확인(로컬).
+- `cargo fmt`(신규/수정 파일 한정), `cargo clippy`.
+- 산출물: `task_m100_990_stage3.md`
+
+### Stage 4 — WASM 빌드 + 최종 보고
+
+- Docker WASM 빌드(`pkg/` 갱신) — rhwp-studio 시각 확인.
+- 최종 결과보고서 `mydocs/report/task_m100_990_report.md` 작성.
+- `mydocs/orders/20260518.md` 상태 갱신.
+- 산출물: `task_m100_990_report.md` + 커밋 + merge 요청
+
+---
+
+## 영향 범위
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout.rs` | `layout_shape_item()` `!has_real_text` 분기 (shape_y / result_y) |
+| `tests/` | 통합 테스트 1건 (신규) |
+| `samples/` 또는 `tests/` 픽스처 | 최소 재현 샘플 (기존 샘플로 대체 가능 시 생략) |
+
+## 리스크
+
+- treat-as-char 글상자가 **텍스트 있는 문단**에 놓인 경우는 `has_real_text=true`
+  분기로 본 수정과 무관 — 회귀 위험 낮음.
+- `para_start_y` 미등록 케이스(이론상) — `unwrap_or(y_offset)` 폴백 유지.

--- a/mydocs/report/task_m100_990_report.md
+++ b/mydocs/report/task_m100_990_report.md
@@ -46,9 +46,13 @@ Task #974 의 `set_inline_shape_position` 등록 의도는 보존.
 
 ## 4. 검증
 
-- **회귀 테스트**: `tests/issue_990.rs` + 픽스처 `samples/issue-990-tac-box.hwpx`
-  — 박스 advance 132.88px → **66.44px**(RED→GREEN). PDF 비율 1.92 정합.
-- **전체 `cargo test`**: 1477 passed, 0 failed.
+- **회귀 진단(개발 단계)**: 비공개 문서(treat-as-char 글상자 3개)로
+  RED 재현 — 박스 advance 132.88px → **66.44px**, PDF 비율 1.92 정합.
+  해당 문서·임시 테스트는 비공개 자료라 커밋하지 않음(작업지시자 지시).
+- **커밋된 회귀 가드**: `issue_table_vpos_01_page5_cell_hit_test` —
+  `table-vpos-01.hwp` 5쪽 `pi=33`(빈 문단 + treat-as-char 도형)이 본 정정의
+  동일 코드 경로를 거치므로, 이중 가산이 재발하면 셀 hit-test 가 실패한다.
+- **전체 `cargo test`**: 1483 passed, 0 failed.
 - **`cargo clippy` / `fmt`**: clean.
 - **광범위 SVG sweep**(14 샘플): 123 byte-identical, 회귀 0.
   - `hy-001`: devel 과 동일(Task #974 동작 보존 확인).
@@ -63,9 +67,10 @@ Task #974 의 `set_inline_shape_position` 등록 의도는 보존.
 | 파일 | 내용 |
 |------|------|
 | `src/renderer/layout.rs` | `layout_shape_item` 빈 문단 분기 정정 |
-| `tests/issue_990.rs` | 회귀 테스트 (신규) |
-| `samples/issue-990-tac-box.hwpx` | 재현 픽스처 (신규) |
 | `tests/issue_table_vpos_01_page5_cell_hit_test.rs` | #974 박제 좌표 8건 정정 |
+
+> 개발 중 작성한 임시 회귀 테스트(`tests/issue_990.rs`)와 재현 픽스처는
+> 비공개 문서 기반이라 커밋하지 않는다.
 
 ## 6. WASM 빌드
 

--- a/mydocs/report/task_m100_990_report.md
+++ b/mydocs/report/task_m100_990_report.md
@@ -1,0 +1,80 @@
+# Task #990 최종 결과보고서
+
+**제목**: 빈 문단 위 treat-as-char 글상자 — `FullParagraph`/`Shape` PageItem advance 이중 가산 정정
+**이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+**마일스톤**: M100 (v1.0.0)
+
+---
+
+## 1. 증상
+
+빈 문단(텍스트 없음) 위에 얹힌 `treat_as_char` 글상자(도형)가 세로로 연속
+배치될 때, 박스 사이 세로 간격이 한컴 PDF 대비 **정확히 2배**로 벌어졌다.
+
+## 2. Root cause — Task #974 회귀
+
+bisect 결과 커밋 `c3e32151`("Fix textbox picture rendering", Task #974)가
+`layout_shape_item()` 에 `Control::Shape` 분기를 **신규 추가**하면서 회귀 발생.
+
+| 지점 | 박스 advance |
+|------|-------------|
+| `c3e32151~1` (Task #974 직전) | 66.44px (정상) |
+| `c3e32151` 이후 / `devel` | 132.88px (2배) |
+
+빈 문단 호스트는 `FullParagraph` PageItem 의 `layout_paragraph()` 가 이미
+LINE_SEG advance(`lh+ls`)를 마친 상태인데, Task #974 가 추가한
+`Shape` PageItem 분기가 `result_y = shape_y + line_advance.max(shape_h)` 로
+**또 한 번 advance** → `4983 + 4983 = 9966 HU`.
+
+## 3. 정정
+
+`src/renderer/layout.rs` — `layout_shape_item()` 의 `!has_real_text` 분기:
+
+- 해당 문단에 `PageItem::FullParagraph` 가 발행되었는지 확인
+  (`has_full_para_item`).
+- **있으면**(빈 문단 호스트 = RFP 형): 글상자를 호스트 문단 시작
+  (`para_start`)에 배치하고 `result_y` 재진행을 생략 — 이중 가산 제거.
+- **없으면**(선행 표 등에 이어 붙은 Shape, 예: `hy-001` pi=27):
+  Task #974 동작(`shape_y=y_offset`, `result_y` 진행)을 유지.
+
+Task #974 의 `set_inline_shape_position` 등록 의도는 보존.
+
+> 초기안(Stage 2)은 FullParagraph 유무를 구분하지 않아 `hy-001` pi=27
+> (선행 표 + Shape)의 글상자를 표 위로 올려 표를 가리는 회귀를 일으켰고,
+> Stage 2 v2 에서 `has_full_para_item` 분기로 정밀화하여 해소.
+
+## 4. 검증
+
+- **회귀 테스트**: `tests/issue_990.rs` + 픽스처 `samples/issue-990-tac-box.hwpx`
+  — 박스 advance 132.88px → **66.44px**(RED→GREEN). PDF 비율 1.92 정합.
+- **전체 `cargo test`**: 1477 passed, 0 failed.
+- **`cargo clippy` / `fmt`**: clean.
+- **광범위 SVG sweep**(14 샘플): 123 byte-identical, 회귀 0.
+  - `hy-001`: devel 과 동일(Task #974 동작 보존 확인).
+  - `group-box`: 투명 rect 좌표 정정, PNG 렌더 바이트 동일(시각 변화 0).
+- **`issue_table_vpos_01_page5_cell_hit_test`**: `pi=33` 이 동일 구조라
+  `pi=34` 가 30.84px 상향 이동. 테스트 기댓값은 커밋 `c2d2157d` 가 #974
+  버그 레이아웃에 박제한 stale 값 — `pi=34` inner 11x3 좌표 8건을
+  정정 레이아웃에 맞춰 갱신(13/13 통과). 한컴 PDF 와 정합 확인.
+
+## 5. 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `src/renderer/layout.rs` | `layout_shape_item` 빈 문단 분기 정정 |
+| `tests/issue_990.rs` | 회귀 테스트 (신규) |
+| `samples/issue-990-tac-box.hwpx` | 재현 픽스처 (신규) |
+| `tests/issue_table_vpos_01_page5_cell_hit_test.rs` | #974 박제 좌표 8건 정정 |
+
+## 6. WASM 빌드
+
+Docker WASM 빌드 완료 — `pkg/rhwp_bg.wasm` (4.6 MB) 갱신.
+
+## 7. 비고
+
+- 본 task 브랜치는 `local/devel` 이 PR #538 시점(659+ 커밋) stale 하여
+  `stream/devel` 로 정렬 후 진행(`local/devel` 직전 상태는
+  `backup/local-devel-20260518` 보존).
+- 이중 가산 제거 후에도 RFP 박스는 PDF 대비 ~1400 HU 잔차(matrix 스케일 +
+  spacing) 가능 — 부차적, 별도 issue 후보.

--- a/mydocs/working/task_m100_990_stage1.md
+++ b/mydocs/working/task_m100_990_stage1.md
@@ -1,0 +1,65 @@
+# Task #990 Stage 1 완료보고서 — 재현 + 진단 (RED)
+
+**이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+
+---
+
+## 1. 재현 픽스처
+
+`samples/issue-990-tac-box.hwpx` — 4쪽(global_idx=3)에 `※ …` 글상자 3개가
+빈 문단(`pi=54/55/56`) 위에 연속 배치된 문서.
+
+## 2. RED 테스트
+
+`tests/issue_990.rs` — `build_page_render_tree(3)` 의 `Rectangle` 노드
+(글상자, `para_index=54/55/56`)를 수집해 박스 사이 세로 advance 를 검사.
+
+```
+issue #990 box y=[344.08, 476.96, 609.84] h1=49.11 advance=[132.88, 132.88]
+test result: FAILED
+```
+
+- 박스↔박스 advance = **132.88px** — 기대(빈 호스트 문단 LINE_SEG 1회분
+  `lh + ls = 4983 HU ≈ 66.44px`)의 **정확히 2배**.
+
+## 3. 진단 — 회귀 확정 (bisect)
+
+| 지점 | advance | 상태 |
+|------|---------|------|
+| `c3e32151~1` (Task #974 직전) | 66.44px | ✅ 정상 |
+| **`c3e32151`** ("Fix textbox picture rendering", Task #974) | 132.88px | ❌ 회귀 도입 |
+| `devel` HEAD (`39d90d9d`) | 132.88px | ❌ |
+
+**원인**: 커밋 `c3e32151` 가 `layout_shape_item()` 에 `Control::Shape` 분기를
+**신규 추가**(`c3e32151~1` 에는 해당 분기 자체가 없음). 추가된 코드 말미:
+
+```rust
+let line_advance = ls.line_height + ls.line_spacing;   // 4983 HU
+result_y = shape_y + line_advance.max(shape_h);         // ← 신규 재진행
+```
+
+빈 문단 위 treat-as-char 글상자는 `FullParagraph` PageItem 의
+`layout_paragraph()` 가 이미 LINE_SEG 만큼 advance 한 상태인데, 추가된
+`Shape` PageItem 분기가 `result_y` 를 **또 한 번 진행** → `4983 + 4983 = 9966 HU`.
+
+부수: `shape_y = y_offset`(FullParagraph 진행 후 값) 이라 글상자 자체도
+`para_start + 4983` 위치에 그려짐 — 위치도 어긋남.
+
+## 4. 브랜치 정비
+
+`local/devel` 이 PR #538 시점(merge-base `e585b589`)에서 분기해 stale
+(local 139 / stream 635 비-merge 커밋). `local/devel` 의 커밋들은 git rebase
+판정상 대부분 "already upstream".
+
+- `local/devel` → `stream/devel`(= `devel` HEAD `39d90d9d`) 정렬.
+  stale 커밋 139개는 `backup/local-devel-20260518` 에 보존.
+- `local/task990` → 새 `local/devel` 베이스로 재정렬(`rebase --onto`).
+  → 회귀(Task #974) 가 베이스에 포함되어 RED 재현 성립.
+
+## 5. 다음 단계 (Stage 2)
+
+`layout_shape_item()` 의 `!has_real_text` 분기 정정:
+- `shape_y` 를 `para_start_y[para_index]`(호스트 문단 시작)로 산출.
+- `result_y` 재진행 제거(입력 `y_offset` 유지) — `FullParagraph` 가 이미 진행.
+- Task #974 의도(`set_inline_shape_position` 등록, hy-001 글상자 그림) 보존 확인.

--- a/mydocs/working/task_m100_990_stage1.md
+++ b/mydocs/working/task_m100_990_stage1.md
@@ -3,6 +3,11 @@
 **이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
 **브랜치**: `local/task990`
 
+> **후속 정정**: 아래 재현 픽스처(`samples/issue-990-tac-box.hwpx`)와 RED
+> 테스트(`tests/issue_990.rs`)는 비공개 문서 기반이라 작업지시자 지시로
+> git 에서 제거됨 — 개발 단계 로컬 검증 기록으로만 참조. 커밋된 회귀
+> 가드는 `issue_table_vpos_01_page5_cell_hit_test`.
+
 ---
 
 ## 1. 재현 픽스처

--- a/mydocs/working/task_m100_990_stage2.md
+++ b/mydocs/working/task_m100_990_stage2.md
@@ -1,0 +1,53 @@
+# Task #990 Stage 2 완료보고서 — 정정 (GREEN)
+
+**이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+
+---
+
+## 1. 정정 내용
+
+`src/renderer/layout.rs` — `layout_shape_item()` 의 `!has_real_text`
+(treat-as-char 글상자가 빈 문단 위에 놓인) 분기:
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `shape_y` | `y_offset` (선행 FullParagraph 진행 후 값) | `para_start_y[para_index]` (호스트 문단 시작) |
+| `result_y` | 무조건 `shape_y + line_advance.max(shape_h)` 재진행 | `y_offset <= para_start` (FullParagraph 미선행 = 글상자 단독) 인 경우에만 진행. 선행 FullParagraph 가 이미 LINE_SEG advance 를 마친 경우 재진행 없음 |
+
+`FullParagraph` PageItem 의 `layout_paragraph()` 가 빈 호스트 문단의 LINE_SEG
+(`lh + ls`)만큼 이미 advance 했으므로, `Shape` PageItem 은 위치만 등록하고
+재진행하지 않는다. Task #974(`c3e32151`)가 추가한 `set_inline_shape_position`
+등록 자체는 보존 — 이중 가산만 제거.
+
+## 2. RED → GREEN
+
+```
+변경 전: issue #990 box y=[344.08, 476.96, 609.84]  advance=[132.88, 132.88]  FAILED
+변경 후: issue #990 box y=[344.08, 410.52, 476.96]  advance=[ 66.44,  66.44]  ok
+```
+
+박스 advance 132.88px → **66.44px** (LINE_SEG 1회분 `4983 HU`). 박스↔본문 줄
+비율 = 66.44 / 34.67 = **1.92** — 한컴 PDF 비율(1.92)과 정확히 일치.
+
+`export-svg` 의 `LAYOUT_OVERFLOW page=3 overflow=215.9px` 경고도 해소.
+
+## 3. Task #974 의도 보존 검증
+
+textbox 관련 테스트 4건 전부 통과:
+
+```
+test test_hy001_textbox_inline_pictures_render_for_hwp_and_hwpx ... ok   (Task #974 회귀 테스트)
+test test_task78_rectangle_textbox_inline_images ................. ok
+test test_textbox_render_tree_debug .............................. ok
+test test_624_textbox_inline_shape_y_on_line2_p2_q7 .............. ok
+```
+
+## 4. 시각 검증
+
+`samples/issue-990-tac-box.hwpx` 4쪽 SVG — 글상자 3개가 한컴 PDF 와 동일하게
+밀착 배치(`※ 본 사업은 …` ×3) 후 `2. 추진배경 및 필요성` 이어짐.
+
+## 5. 다음 단계 (Stage 3)
+
+전체 `cargo test` 0 회귀, 광범위 `export-svg` 차분, `cargo clippy`/`fmt`.

--- a/mydocs/working/task_m100_990_stage2.md
+++ b/mydocs/working/task_m100_990_stage2.md
@@ -3,6 +3,9 @@
 **이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
 **브랜치**: `local/task990`
 
+> **후속 정정**: 본 보고서가 참조하는 RED 테스트(`tests/issue_990.rs`)와
+> 픽스처는 비공개 문서 기반이라 작업지시자 지시로 git 에서 제거됨.
+
 ---
 
 ## 1. 정정 내용

--- a/mydocs/working/task_m100_990_stage3.md
+++ b/mydocs/working/task_m100_990_stage3.md
@@ -1,0 +1,56 @@
+# Task #990 Stage 3 완료보고서 — 검증
+
+**이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
+**브랜치**: `local/task990`
+
+---
+
+## 1. 전체 테스트
+
+`cargo test` — **전 바이너리 합계 1477 passed, 0 failed** (`issue_990` 포함).
+`cargo clippy --release` — 경고 0.
+`cargo fmt --check` (수정 파일) — clean.
+
+## 2. 광범위 SVG sweep (14 샘플 / 비-RFP 124 SVG)
+
+`devel`(before) vs `local/task990`(after) `export-svg` 차분:
+
+- **123 byte-identical** — exam_kor/math/science, synam-001, KTX, shortcut,
+  table-in-tbox 등 회귀 0.
+- 변경 2건:
+  - `hy-001_002.svg` — 초기 fix(Stage 2)가 선행 표+Shape 문단(pi=27)에서
+    글상자를 표 위로 올려 표를 가림. **Stage 2 v2**(`has_full_para_item`
+    분기)로 복원 — devel 과 동일.
+  - `group-box.svg` — `fill="none"`(투명) rect 1개 y 이동, PNG 렌더
+    **바이트 동일**. 시각 변화 0(투명 도형 경계의 내부 좌표 정정).
+
+## 3. 회귀 1건 발견 → 정정: `issue_table_vpos_01_page5_cell_hit_test`
+
+초기 전체 테스트에서 이 파일 4건 실패(c2 본문 셀 hit-test).
+
+- **원인**: `table-vpos-01` 5쪽 `pi=33`(빈 문단 + treat-as-char 다각형) 은
+  RFP 와 동일 구조 — 본 수정으로 `pi=34`(외곽 표 + 내부 11x3) 가 위로 이동.
+  테스트 기댓값은 커밋 `c2d2157d "test: update expectations for current
+  layout"` 에서 #974 머지 직후 갱신 — **#974 이중 가산 버그가 박제된 좌표**.
+- **이동량**: `--debug-overlay` 측정 — `devel` `pi=34` y=260.69 →
+  수정 후 229.85 = **30.84px**(`.hwp` 기준).
+- **정정**: `pi=34` inner 11x3 의 c0/c2 hit-test 좌표 8건 + cell-clip 주석을
+  −30.84px 갱신. `pi=30/pi=32`(pi=33 위) 좌표는 불변. title 셀 검증은
+  loose(임의 pi=34 nested hit) 라 기존 좌표 유지.
+- **결과**: 13/13 통과.
+
+한컴 PDF(`pdf/table-vpos-01-2022.pdf`) 대조 — 수정 후 빨강 배너↓~큰 표↑
+간격이 devel 대비 PDF 에 부합(devel 71.84px → 수정 38.86px, `.hwpx` 기준).
+
+## 4. 산출물
+
+| 파일 | 변경 |
+|------|------|
+| `src/renderer/layout.rs` | `layout_shape_item` 빈 문단 분기 (Stage 2 v2, fmt 정리) |
+| `tests/issue_990.rs` | RED→GREEN 회귀 테스트 (Stage 1) |
+| `samples/issue-990-tac-box.hwpx` | 재현 픽스처 (Stage 1) |
+| `tests/issue_table_vpos_01_page5_cell_hit_test.rs` | #974 박제 좌표 8건 −30.84px 정정 |
+
+## 5. 다음 단계 (Stage 4)
+
+Docker WASM 빌드, 최종 보고서, 오늘할일 갱신.

--- a/mydocs/working/task_m100_990_stage3.md
+++ b/mydocs/working/task_m100_990_stage3.md
@@ -3,6 +3,9 @@
 **이슈**: [#990](https://github.com/edwardkim/rhwp/issues/990)
 **브랜치**: `local/task990`
 
+> **후속 정정**: RED 테스트(`tests/issue_990.rs`)와 픽스처는 비공개 문서
+> 기반이라 작업지시자 지시로 git 에서 제거됨 — 산출물 표에서 제외.
+
 ---
 
 ## 1. 전체 테스트
@@ -47,9 +50,9 @@
 | 파일 | 변경 |
 |------|------|
 | `src/renderer/layout.rs` | `layout_shape_item` 빈 문단 분기 (Stage 2 v2, fmt 정리) |
-| `tests/issue_990.rs` | RED→GREEN 회귀 테스트 (Stage 1) |
-| `samples/issue-990-tac-box.hwpx` | 재현 픽스처 (Stage 1) |
 | `tests/issue_table_vpos_01_page5_cell_hit_test.rs` | #974 박제 좌표 8건 −30.84px 정정 |
+
+(개발 단계의 `tests/issue_990.rs` + 픽스처는 비공개 문서 기반 — 비커밋.)
 
 ## 5. 다음 단계 (Stage 4)
 

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4710,8 +4710,11 @@ impl LayoutEngine {
                                 });
                             let para_start =
                                 para_start_y.get(&para_index).copied().unwrap_or(y_offset);
-                            let shape_y =
-                                if has_full_para_item { para_start } else { y_offset };
+                            let shape_y = if has_full_para_item {
+                                para_start
+                            } else {
+                                y_offset
+                            };
 
                             if !already_registered {
                                 let comp = composed.get(para_index);

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4691,12 +4691,27 @@ impl LayoutEngine {
                         if !has_real_text {
                             let shape_w = hwpunit_to_px(common.width as i32, self.dpi);
                             let shape_h = hwpunit_to_px(common.height as i32, self.dpi);
-                            // [Task #990] 글상자는 호스트 문단 시작에 배치한다.
-                            // y_offset 은 선행 FullParagraph 항목이 이미 진행시킨
-                            // 값이므로 그대로 쓰면 글상자가 한 줄 아래로 밀린다.
+                            // [Task #990] 해당 문단에 PageItem::FullParagraph 가
+                            // 발행되었으면(빈 문단이 호스트인 RFP 형) layout_paragraph
+                            // 가 이미 LINE_SEG advance 를 마쳤으므로, Shape 항목은
+                            // 글상자를 호스트 문단 시작(para_start)에 배치하고 재진행
+                            // 하지 않는다 — 이중 가산 방지(Task #974 c3e32151 회귀).
+                            // FullParagraph 항목이 없으면(선행 표 등에 이어 붙은
+                            // Shape, 예: hy-001 pi=27) Task #974 동작을 유지한다.
+                            let has_full_para_item =
+                                page_content.column_contents.iter().any(|cc| {
+                                    cc.items.iter().any(|it| {
+                                        matches!(
+                                            it,
+                                            PageItem::FullParagraph { para_index: pi }
+                                                if *pi == para_index
+                                        )
+                                    })
+                                });
                             let para_start =
                                 para_start_y.get(&para_index).copied().unwrap_or(y_offset);
-                            let shape_y = para_start;
+                            let shape_y =
+                                if has_full_para_item { para_start } else { y_offset };
 
                             if !already_registered {
                                 let comp = composed.get(para_index);
@@ -4744,13 +4759,10 @@ impl LayoutEngine {
                                 );
                             }
 
-                            // [Task #990] 빈 문단 위 treat-as-char 글상자: 선행
-                            // FullParagraph 항목의 layout_paragraph 가 이미 LINE_SEG
-                            // advance 를 마쳤다면(y_offset > para_start) 재진행하지
-                            // 않는다 — 이중 가산 방지(Task #974 c3e32151 회귀).
-                            // FullParagraph 항목이 없는 글상자 단독 케이스에서만
-                            // LINE_SEG 1회분을 진행한다.
-                            if y_offset <= para_start {
+                            // [Task #990] FullParagraph 항목이 없는 경우에만
+                            // LINE_SEG 1회분을 진행한다. FullParagraph 가 있으면
+                            // 이미 진행되었으므로 result_y(=y_offset)를 유지한다.
+                            if !has_full_para_item {
                                 let line_advance = para
                                     .line_segs
                                     .first()
@@ -4758,7 +4770,7 @@ impl LayoutEngine {
                                         hwpunit_to_px(ls.line_height + ls.line_spacing, self.dpi)
                                     })
                                     .unwrap_or(shape_h);
-                                result_y = para_start + line_advance.max(shape_h);
+                                result_y = shape_y + line_advance.max(shape_h);
                             }
                         }
                     }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4691,7 +4691,12 @@ impl LayoutEngine {
                         if !has_real_text {
                             let shape_w = hwpunit_to_px(common.width as i32, self.dpi);
                             let shape_h = hwpunit_to_px(common.height as i32, self.dpi);
-                            let shape_y = y_offset;
+                            // [Task #990] 글상자는 호스트 문단 시작에 배치한다.
+                            // y_offset 은 선행 FullParagraph 항목이 이미 진행시킨
+                            // 값이므로 그대로 쓰면 글상자가 한 줄 아래로 밀린다.
+                            let para_start =
+                                para_start_y.get(&para_index).copied().unwrap_or(y_offset);
+                            let shape_y = para_start;
 
                             if !already_registered {
                                 let comp = composed.get(para_index);
@@ -4739,12 +4744,22 @@ impl LayoutEngine {
                                 );
                             }
 
-                            let line_advance = para
-                                .line_segs
-                                .first()
-                                .map(|ls| hwpunit_to_px(ls.line_height + ls.line_spacing, self.dpi))
-                                .unwrap_or(shape_h);
-                            result_y = shape_y + line_advance.max(shape_h);
+                            // [Task #990] 빈 문단 위 treat-as-char 글상자: 선행
+                            // FullParagraph 항목의 layout_paragraph 가 이미 LINE_SEG
+                            // advance 를 마쳤다면(y_offset > para_start) 재진행하지
+                            // 않는다 — 이중 가산 방지(Task #974 c3e32151 회귀).
+                            // FullParagraph 항목이 없는 글상자 단독 케이스에서만
+                            // LINE_SEG 1회분을 진행한다.
+                            if y_offset <= para_start {
+                                let line_advance = para
+                                    .line_segs
+                                    .first()
+                                    .map(|ls| {
+                                        hwpunit_to_px(ls.line_height + ls.line_spacing, self.dpi)
+                                    })
+                                    .unwrap_or(shape_h);
+                                result_y = para_start + line_advance.max(shape_h);
+                            }
                         }
                     }
                 }

--- a/tests/issue_table_vpos_01_page5_cell_hit_test.rs
+++ b/tests/issue_table_vpos_01_page5_cell_hit_test.rs
@@ -9,6 +9,9 @@
 //! 좌표는 `cargo run -- export-svg samples/table-vpos-01.hwp -p 4 --debug-overlay`
 //! SVG 의 cell-clip 영역에서 측정 (96 DPI).
 //!
+//! [Task #990] pi=33(빈 문단 위 treat-as-char 도형) advance 이중 가산 정정으로
+//! pi=34 외곽 표 및 내부 11x3 표가 30.84px 위로 이동 — pi=34 inner 11x3 좌표 갱신.
+//!
 //! 본 테스트는 hit_test_native 반환 검증 + 실제 cell-entry(insert_text_in_cell_by_path)
 //! 검증을 모두 수행한다.
 
@@ -135,38 +138,38 @@ fn page5_big_inner_title_cell_returns_nested_path() {
 // pi=34 inner 11x3 — c=0 column 라벨 셀들 (rowspan=2)
 // =======================================================================
 
-/// cell[0] r=0,c=0 "1|참여소통" — cell-clip-52 (x=86.2 y=298.0 w=83.4 h=164.9), 중심 (128, 380)
+/// cell[0] r=0,c=0 "1|참여소통" — cell-clip-52 (x=86.2 y=267.16 w=83.4 h=164.9), 중심 (128, 349.16)
 #[test]
 fn page5_inner_11x3_c0_row0_label_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 128.0, 380.0);
+    let hit = hit_json(&doc, 4, 128.0, 349.16);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 0);
 }
 
-/// cell[7] r=3,c=0 "2|기본사회" — cell-clip-82 (x=86.2 y=475.6 w=83.4 h=164.9), 중심 (128, 558)
+/// cell[7] r=3,c=0 "2|기본사회" — cell-clip-82 (x=86.2 y=444.76 w=83.4 h=164.9), 중심 (128, 527.16)
 #[test]
 fn page5_inner_11x3_c0_row3_label_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 128.0, 558.0);
+    let hit = hit_json(&doc, 4, 128.0, 527.16);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 7);
 }
 
-/// cell[14] r=6,c=0 "3|공직혁신" — cell-clip-111 (x=86.2 y=653.1 w=83.4 h=159.1), 중심 (128, 732.7)
+/// cell[14] r=6,c=0 "3|공직혁신" — cell-clip-111 (x=86.2 y=622.26 w=83.4 h=159.1), 중심 (128, 701.86)
 #[test]
 fn page5_inner_11x3_c0_row6_label_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 128.0, 732.7);
+    let hit = hit_json(&doc, 4, 128.0, 701.86);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 14);
 }
 
-/// cell[19] r=9,c=0 "4|공공 AX" — cell-clip-136 (x=86.2 y=849.4 w=83.4 h=157.4), 중심 (128, 928.1)
+/// cell[19] r=9,c=0 "4|공공 AX" — cell-clip-136 (x=86.2 y=818.56 w=83.4 h=157.4), 중심 (128, 897.26)
 #[test]
 fn page5_inner_11x3_c0_row9_label_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 128.0, 928.1);
+    let hit = hit_json(&doc, 4, 128.0, 897.26);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 19);
 }
@@ -175,38 +178,38 @@ fn page5_inner_11x3_c0_row9_label_cell() {
 // pi=34 inner 11x3 — c=2 column 본문 셀들
 // =======================================================================
 
-/// cell[2] r=0,c=2 "국민 주도..." — cell-clip-61 (x=177.6 y=328.9 w=529.9 h=45.1), 중심 (442.5, 351.4)
+/// cell[2] r=0,c=2 "국민 주도..." — cell-clip-61 (x=177.6 y=298.06 w=529.9 h=45.1), 중심 (442.5, 320.56)
 #[test]
 fn page5_inner_11x3_c2_row0_content_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 442.5, 351.4);
+    let hit = hit_json(&doc, 4, 442.5, 320.56);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 2);
 }
 
-/// cell[3] r=1,c=2 "대국민 소통..." — cell-clip-65 (x=177.6 y=343.1 w=529.9 h=119.9), 중심 (442.5, 403)
+/// cell[3] r=1,c=2 "대국민 소통..." — cell-clip-65 (x=177.6 y=312.26 w=529.9 h=119.9), 중심 (442.5, 372.16)
 #[test]
 fn page5_inner_11x3_c2_row1_content_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 442.5, 403.0);
+    let hit = hit_json(&doc, 4, 442.5, 372.16);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 3);
 }
 
-/// cell[9] r=3,c=2 "포용과 균형의 기본사회 구현" — cell-clip-91 (x=177.6 y=506.4 w=529.9 h=45.1), 중심 (442.5, 529.0)
+/// cell[9] r=3,c=2 "포용과 균형의 기본사회 구현" — cell-clip-91 (x=177.6 y=475.56 w=529.9 h=45.1), 중심 (442.5, 498.16)
 #[test]
 fn page5_inner_11x3_c2_row3_content_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 442.5, 529.0);
+    let hit = hit_json(&doc, 4, 442.5, 498.16);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 9);
 }
 
-/// cell[16] r=6,c=2 "성과로 신뢰..." — cell-clip-120 (x=177.6 y=684.0 w=529.9 h=45.1), 중심 (442.5, 706.5)
+/// cell[16] r=6,c=2 "성과로 신뢰..." — cell-clip-120 (x=177.6 y=653.16 w=529.9 h=45.1), 중심 (442.5, 675.66)
 #[test]
 fn page5_inner_11x3_c2_row6_content_cell() {
     let doc = load_doc();
-    let hit = hit_json(&doc, 4, 442.5, 706.5);
+    let hit = hit_json(&doc, 4, 442.5, 675.66);
     assert_table_hit(&hit, 34, 0);
     assert_nested_inner_cell(&hit, 16);
 }
@@ -224,7 +227,7 @@ fn page5_inner_11x3_c2_row6_content_cell() {
 #[test]
 fn page5_inner_11x3_c2_row0_insert_lands_in_inner_cell() {
     let mut doc = load_doc();
-    let hit = hit_json(&doc, 4, 442.5, 351.4);
+    let hit = hit_json(&doc, 4, 442.5, 320.56);
     let path = path_tuples(&hit);
     let parent_para = hit["parentParaIndex"].as_u64().expect("parentParaIndex") as usize;
     let char_offset = hit["charOffset"].as_u64().expect("charOffset") as usize;


### PR DESCRIPTION
## 개요

빈 문단(텍스트 없음) 위에 얹힌 `treat_as_char` 글상자(도형)가 세로로 연속
배치될 때, 박스 사이 세로 간격이 한컴 PDF 대비 **정확히 2배**로 벌어지는 버그를 정정한다.

## Root cause — Task #974 회귀

bisect 결과 커밋 `c3e32151`("Fix textbox picture rendering", Task #974)가
`layout_shape_item()` 에 `Control::Shape` 분기를 신규 추가하면서 발생.

| 지점 | 박스 advance |
|------|-------------|
| `c3e32151~1` (Task #974 직전) | 66.44px (정상) |
| `c3e32151` 이후 | 132.88px (2배) |

빈 문단 호스트는 `FullParagraph` PageItem 의 `layout_paragraph()` 가 이미
LINE_SEG advance(`lh+ls`)를 마친 상태인데, `Shape` PageItem 분기가
`result_y = shape_y + line_advance.max(shape_h)` 로 또 한 번 advance → 이중 가산.

## 정정

`layout_shape_item()` 의 `!has_real_text` 분기에서 해당 문단에
`PageItem::FullParagraph` 가 발행되었는지(`has_full_para_item`) 판별:

- **있으면**(빈 문단 호스트): 글상자를 호스트 문단 시작에 배치하고
  `result_y` 재진행을 생략 — 이중 가산 제거.
- **없으면**(선행 표 등에 이어 붙은 Shape, 예: `hy-001` pi=27):
  Task #974 동작을 유지.

Task #974 의 `set_inline_shape_position` 등록 의도는 보존.

## 검증

- 회귀 진단: 비공개 문서(treat-as-char 글상자 3개)로 RED 재현 —
  박스 advance 132.88px → 66.44px. 해당 문서·임시 테스트는 비공개 자료라
  커밋하지 않음.
- 전체 `cargo test` 1483 passed, 0 failed. `clippy`/`fmt` clean.
- 광범위 SVG sweep(14 샘플): 회귀 0 — `hy-001` Task #974 동작 보존 확인.
- **커밋된 회귀 가드**: `issue_table_vpos_01_page5_cell_hit_test` —
  `table-vpos-01.hwp` 5쪽 `pi=33`(빈 문단 + treat-as-char 도형)이 본 정정과
  동일 코드 경로라, 이중 가산 재발 시 셀 hit-test 가 실패한다. `pi=33` 정정으로
  `pi=34` 표가 30.84px 상향 이동 — 기존 기댓값은 커밋 `c2d2157d` 가 #974 버그
  레이아웃에 박제한 stale 값이므로 inner 11x3 좌표 8건을 정정 레이아웃에 맞춰 갱신.

## 변경 파일

- `src/renderer/layout.rs` — `layout_shape_item` 빈 문단 분기 정정
- `tests/issue_table_vpos_01_page5_cell_hit_test.rs` — #974 박제 좌표 8건 정정

🤖 Generated with [Claude Code](https://claude.com/claude-code)