### PR TITLE
HWPX slash/backSlash 형태 enum 파싱 분리 (#1038)

### DIFF
--- a/mydocs/plans/task_m100_1038.md
+++ b/mydocs/plans/task_m100_1038.md
@@ -1,0 +1,50 @@
+# 수행계획서 — Task M100 #1038
+
+## 이슈
+- 번호: edwardkim/rhwp#1038 (마일스톤 v1.0.0 / M100)
+- 제목: HWPX slash/backSlash type을 선 종류로 오파싱 → 대각선 없는 셀에 검은 대각선 렌더
+- 브랜치: `local/task1038` (기준: `stream/devel` @ d359c302)
+
+## 배경 / 현상
+`samples/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서.hwpx` 4페이지 헤딩
+"Ⅰ 사업안내"(1행×3열 표, treat_as_char)의 세 셀에 검은 대각선(좌하→우상)이 그려진다.
+한컴 2022 PDF(`pdf/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서-2022.pdf` p4)에는 대각선이 없다.
+
+## 루트 원인 (조사 완료)
+HWPX borderFill에서 대각선은 **두 요소**로 표현된다:
+1. `<hh:slash type="...">` / `<hh:backSlash type="...">` — 대각선 **방향/형태** enum (NONE/CENTER/…)
+2. `<hh:diagonal type="..." width color>` — 실제 **선 종류**(SOLID/NONE/…)·굵기·색
+
+문제 셀의 borderFill 341/342/343 은 `slash type="CENTER"` 만 있고 `<hh:diagonal>` 요소가 **없다**.
+한컴은 두 요소가 모두 있어야 대각선을 그리므로 미표시.
+
+우리 파서(`src/parser/hwpx/header.rs`)의 `slash`/`backSlash` 핸들러는 `type` 값을
+`parse_border_line_type_code()`(선 종류 파서)에 넘긴다. `"CENTER"`는 선 종류 enum에 없어
+`_ => Solid(1)` 로 폴백되고, 그 결과:
+- `set_diagonal_attr_bits(bf, 2, 1)` → slash 방향 비트 `0b010` 설정
+- `bf.diagonal.diagonal_type = 1` ← **핵심 오류**. 렌더 트리거(`src/renderer/layout/border_rendering.rs:601`,
+  `diagonal_type != 0`)가 켜지고, 색/굵기 미지정이라 기본 검정 실선으로 그려짐.
+
+`<hh:diagonal>` 가 없으면 `diagonal_type` 은 0이어야 하는데, slash 핸들러가 자기 `type` 을
+선 종류로 오해해 1로 만든다.
+
+## 수정 방향
+- `slash`/`backSlash` 핸들러는 `type` 을 대각선 **형태 enum**(NONE/CENTER/CENTER_ABOVE/…)으로만
+  해석하여 `bf.attr` 의 방향 비트만 설정한다. `bf.diagonal.diagonal_type` 은 건드리지 않는다.
+- 대각선 선 종류/굵기/색은 오직 `<hh:diagonal>` 요소에서만 설정한다 (기존 `b"diagonal"` 핸들러 유지).
+- 결과: 341/342/343 은 `diagonal_type==0` 으로 남아 대각선 미표시(PDF 정합).
+  실제 `<hh:diagonal>` 가 있는 표는 영향 없음.
+
+## 영향 범위
+- 수정 파일(예상): `src/parser/hwpx/header.rs` (slash/backSlash 핸들러, slash 형태 enum 파서 추가)
+- 렌더러(`border_rendering.rs`)는 수정 불필요 (방향 비트 + diagonal_type 조건 그대로 활용)
+- HWP5/HWP3 경로 무관 (HWPX 전용 파싱 버그)
+
+## 검증 계획
+1. 회귀 가드: slash 형태 enum 파싱 단위 테스트 (CENTER → 방향 비트, diagonal_type 불변)
+2. `export-svg -p 3` 재생성 후 헤딩 3개 셀에 검은 대각선(`stroke="#000000"`) 사라짐 확인
+3. 실제 대각선 표 샘플 회귀 확인 (`<hh:diagonal>` 보유 borderFill 렌더 유지)
+4. `cargo test` 전체 통과, 신규/수정 파일 한정 fmt
+
+## 절차
+수행계획서 승인 → 구현계획서(3~6단계) 작성 → 승인 → 단계별 구현·보고 → 최종 보고서.

--- a/mydocs/plans/task_m100_1038_impl.md
+++ b/mydocs/plans/task_m100_1038_impl.md
@@ -1,0 +1,66 @@
+# 구현계획서 — Task M100 #1038
+
+## 이슈
+- edwardkim/rhwp#1038 — HWPX slash/backSlash type을 선 종류로 오파싱 → 대각선 없는 셀에 검은 대각선 렌더
+- 브랜치: `local/task1038` (기준 `stream/devel` @ d359c302)
+
+## 설계 근거
+HWP5 바이너리(`src/parser/doc_info.rs:295~335`)에서 셀 대각선은 **독립된 두 필드**다:
+- `attr`(u16) 속성 비트: slash 방향 = bits 2~4, backSlash 방향 = bits 5~7 (3비트 코드)
+- `diagonal`(DiagonalLine): 대각선 **선 종류**(0=없음/1=실선/…)·굵기·색
+
+렌더러(`src/renderer/layout/border_rendering.rs:591~603`)는
+`slash_bits=(attr>>2)&7`, `backslash_bits=(attr>>5)&7` **그리고** `diagonal.diagonal_type != 0`
+두 조건이 모두 참일 때만 대각선을 그린다.
+
+HWPX 파서는 이 구조를 그대로 미러링해야 한다:
+- `<hh:diagonal type width color>` → `bf.diagonal` (선 종류/굵기/색) — 현행 `b"diagonal"` 핸들러 유지
+- `<hh:slash type>` / `<hh:backSlash type>` → `bf.attr` 방향 비트 **only**
+
+현행 버그: slash/backSlash 핸들러가 `type`("CENTER")을 `parse_border_line_type_code()`로 넘겨
+`Solid(1)`로 폴백 → `set_diagonal_attr_bits`로 방향 비트(0b010) + **`bf.diagonal.diagonal_type=1`** 설정.
+선 정의(`<hh:diagonal>`)가 없는 셀(341/342/343)에도 diagonal_type가 켜져 검정 실선이 그려진다.
+
+### slash 형태 enum → 3비트 방향 코드 (HWP5 정합)
+| HWPX type | 3비트 | 렌더러 대응 |
+|-----------|-------|------------|
+| `NONE` | 0 | 미표시 |
+| `CENTER` | 0b010 (2) | 단순 슬래시 |
+| `CENTER_BELOW` | 0b011 (3) | 가운데+아래 |
+| `CENTER_ABOVE` | 0b110 (6) | 가운데+위 |
+| 기타/`ALL` | 0b111 (7) | 3방향 |
+
+## 단계별 계획 (3단계)
+
+### Stage 1 — 파서 수정 (`src/parser/hwpx/header.rs`)
+1. `parse_slash_shape_code(attr) -> u8` 신규 함수: slash 형태 enum 문자열 → 3비트 방향 코드(위 표).
+2. `set_diagonal_attr_bits(bf, shift, code)` 변경: 인자로 받은 3비트 `code`를 해당 shift에 그대로 기록
+   (현행은 nonzero를 무조건 0b010으로 축소). `code==0`이면 비트 클리어.
+3. `b"slash"` / `b"backSlash"` `type` 분기:
+   - `parse_border_line_type_code` 호출 제거 → `parse_slash_shape_code` 호출.
+   - `bf.diagonal.diagonal_type = …` 할당 **제거** (방향 비트만 설정).
+   - slash/backSlash의 `width`/`color` 분기 제거 (OWPML에서 slash는 선 스타일을 갖지 않음; 선은 `<hh:diagonal>` 전담).
+- 커밋: `Task #1038: HWPX slash/backSlash 형태 enum 파싱 분리 (diagonal_type 미오염)`
+- 보고서: `mydocs/working/task_m100_1038_stage1.md`
+
+### Stage 2 — 단위 테스트 (`src/parser/hwpx/header.rs` #[cfg(test)])
+1. `parse_slash_shape_code`: NONE→0, CENTER→2, CENTER_BELOW→3, CENTER_ABOVE→6, 미지값→7 검증.
+2. borderFill 파싱 통합 테스트:
+   - `slash type="CENTER"` + `<hh:diagonal>` 없음 → `diagonal.diagonal_type==0`, `attr` slash 비트==0b010.
+   - `slash type="NONE"` + `<hh:diagonal type="SOLID">` → `diagonal_type==1`, slash 비트==0.
+- 커밋: `Task #1038: slash 형태 파싱 + diagonal_type 불변 회귀 가드`
+- 보고서: `mydocs/working/task_m100_1038_stage2.md`
+
+### Stage 3 — 검증 및 최종 정리
+1. `cargo build` + `cargo test` 전체 통과.
+2. `export-svg -p 3` 재생성 → 헤딩 3개 셀 검정 대각선(`stroke="#000000"`) 제거 확인
+   (`samples/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서.hwpx`, PDF p4 정합).
+3. 실제 `<hh:diagonal>` 보유 표 샘플 회귀: 대각선 정상 렌더 유지 확인.
+4. 수정·신규 파일 한정 `rustfmt` 정리 (전체 fmt 금지).
+- 최종 보고서: `mydocs/report/task_m100_1038_report.md`, 오늘할일은 작업지시자 관할이므로 미편집.
+- 커밋: `Task #1038: 검증 + 최종 보고서 (closes #1038)` — closes 번호는 push 전 재확인.
+
+## 영향 범위 / 리스크
+- 수정: `src/parser/hwpx/header.rs` 단일 파일.
+- 렌더러/모델/HWP5·HWP3 경로 무수정.
+- 리스크: `set_diagonal_attr_bits`가 이제 실제 3비트 코드를 기록 → 기존엔 모든 방향이 0b010으로 축소됐던 동작이 정밀화됨. CENTER는 0b010 동일이라 기존 정상 렌더 표는 영향 없음. CENTER_BELOW/ABOVE 보유 표는 더 정확해짐(회귀 아님).

--- a/mydocs/report/task_m100_1038_report.md
+++ b/mydocs/report/task_m100_1038_report.md
@@ -1,0 +1,50 @@
+# 최종 결과보고서 — Task M100 #1038
+
+## 이슈
+- edwardkim/rhwp#1038 — HWPX slash/backSlash type을 선 종류로 오파싱 → 대각선 없는 셀에 검은 대각선 렌더
+- 마일스톤: v1.0.0 (M100) / 브랜치: `local/task1038` (기준 `stream/devel` @ d359c302)
+
+## 문제
+`samples/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서.hwpx` 4페이지 헤딩
+"Ⅰ 사업안내"(1×3 표, treat_as_char)의 세 셀에 검은 대각선(좌하→우상)이 그려졌다.
+한컴 2022 PDF p4 에는 대각선이 없다.
+
+## 루트 원인
+HWPX borderFill 에서 셀 대각선은 **독립된 두 요소**로 표현된다:
+- `<hh:slash>`/`<hh:backSlash>` `type` → 대각선 **방향/형태** enum (NONE/CENTER/…)
+- `<hh:diagonal>` `type/width/color` → 실제 **선 종류·굵기·색** (HWP5 attr 비트 + DiagonalLine 과 1:1)
+
+문제 셀(borderFill 341/342/343)은 `slash type="CENTER"` 만 있고 `<hh:diagonal>` 가 없다.
+한컴은 두 요소가 모두 있어야 그리므로 미표시.
+
+기존 파서는 slash/backSlash 의 `type`("CENTER")을 선 종류 파서(`parse_border_line_type_code`)에
+넘겨 `Solid(1)`로 폴백 → 방향 비트 + `bf.diagonal.diagonal_type=1` 을 설정했다. 선 정의가 없는
+셀에도 렌더 트리거(`border_rendering.rs:601`, `diagonal_type != 0`)가 켜져 기본 검정 실선이 그려졌다.
+
+## 수정 (`src/parser/hwpx/header.rs` 단일 파일)
+1. `parse_slash_shape_code(attr) -> u8` 신규 — slash 형태 enum → HWP5 attr 3비트 방향 코드
+   (NONE→0, CENTER→0b010, CENTER_BELOW→0b011, CENTER_ABOVE→0b110, 기타→0b111).
+2. `set_diagonal_attr_bits(bf, shift, code)` — 3비트 `code` 를 그대로 기록(기존: nonzero→0b010 축소),
+   `code==0`이면 클리어.
+3. `slash`/`backSlash` 핸들러 — `type` 을 방향 비트(attr)만 설정하도록 분리. `diagonal_type` 할당 제거,
+   slash 의 width/color 분기 제거. 선 종류/굵기/색은 `<hh:diagonal>` 핸들러가 단독 책임.
+
+렌더러/모델/HWP5·HWP3 경로 무수정.
+
+## 검증
+| 항목 | 결과 |
+|------|------|
+| `cargo test` 전체 | 통과 (47개 그룹, 실패 0) |
+| 신규 단위/회귀 테스트 4건 | 통과 (slash 형태 파싱, diagonal_type 불변 가드 포함) |
+| p4 헤딩 (문제 샘플) | 검정 대각선 3 → **0**, 박스 테두리만 잔존 → PDF p4 정합 |
+| `tac-img-02.hwpx` 회귀 | `<hh:diagonal>` 보유 셀(slash CENTER + diagonal SOLID 포함) 대각선 4개 정상 유지 |
+| rustfmt (header.rs) | 정합 (변경 없음) |
+
+## 커밋
+- `84039317` Stage 1: slash/backSlash 형태 enum 파싱 분리 (diagonal_type 미오염)
+- `bdf7cd0f` Stage 2: slash 형태 파싱 + diagonal_type 불변 회귀 가드
+- (Stage 3) 검증 + 최종 보고서
+
+## 비고
+- `closes #1038` 은 push/merge 전 실제 upstream 이슈 번호 재확인 후 반영.
+- 오늘할일(`orders/`)은 작업지시자 관할로 미편집.

--- a/mydocs/working/task_m100_1038_stage1.md
+++ b/mydocs/working/task_m100_1038_stage1.md
@@ -1,0 +1,27 @@
+# Stage 1 완료보고서 — Task M100 #1038
+
+## 작업
+HWPX `slash`/`backSlash` 핸들러를 대각선 **방향 비트 전담**으로 수정하고,
+선 종류/굵기/색은 `<hh:diagonal>` 요소가 단독 책임지도록 분리.
+
+## 변경 (`src/parser/hwpx/header.rs`)
+1. **`parse_slash_shape_code(attr) -> u8` 신규**: slash 형태 enum 문자열 → HWP5 attr 3비트 방향 코드.
+   - `NONE`→0, `CENTER`→0b010, `CENTER_BELOW`→0b011, `CENTER_ABOVE`→0b110, 기타→0b111.
+2. **`set_diagonal_attr_bits(bf, shift, code)` 변경**: 받은 3비트 `code`를 해당 shift에 그대로 기록
+   (기존: nonzero를 무조건 0b010으로 축소). `code==0`이면 비트 클리어.
+3. **`b"slash"` / `b"backSlash"` 핸들러 수정**:
+   - `parse_border_line_type_code` 호출 → `parse_slash_shape_code` 로 교체.
+   - `bf.diagonal.diagonal_type = …` 할당 **제거** (방향 비트만 설정).
+   - slash/backSlash 의 `width`/`color` 분기 제거 (OWPML에서 slash는 선 스타일 미보유).
+
+`<hh:diagonal>` 핸들러(선 종류/굵기/색)와 `parse_diagonal_width`/`parse_border_line_type_code`는
+그대로 유지 (diagonal 요소가 계속 사용).
+
+## 검증 (예비)
+- `cargo build` 통과, 미사용 경고 없음.
+- `export-svg -p 3` 재생성:
+  - 검정 대각선(`stroke="#000000"`) line: **3 → 0**
+  - 전체 line: 9 → 6 (파란 박스 테두리만 잔존)
+  - 헤딩 "Ⅰ 사업안내" 시각 확인 → 한컴 2022 PDF p4 정합.
+
+정식 단위 테스트/전체 회귀는 Stage 2~3에서 수행.

--- a/mydocs/working/task_m100_1038_stage2.md
+++ b/mydocs/working/task_m100_1038_stage2.md
@@ -1,0 +1,24 @@
+# Stage 2 완료보고서 — Task M100 #1038
+
+## 작업
+`src/parser/hwpx/header.rs` 테스트 모듈에 slash 형태 파싱·diagonal_type 불변 회귀 가드 추가.
+
+## 신규 테스트 (4건)
+1. **`test_parse_slash_shape_code`** — 형태 enum → 3비트 방향 코드
+   - NONE→0, CENTER→0b010, CENTER_BELOW→0b011, CENTER_ABOVE→0b110, ALL(미지)→0b111.
+2. **`test_set_diagonal_attr_bits`** — 3비트 코드를 shift 2(slash)/5(backSlash)에 정확히 기록,
+   타 비트 보존, code 0 → 클리어.
+3. **`test_slash_center_without_diagonal_no_line`** — #1038 핵심 회귀 가드
+   - `slash type="CENTER"` + `<hh:diagonal>` 없음 → slash 비트 0b010, **diagonal_type==0** (미표시).
+4. **`test_diagonal_element_sets_line_independent_of_slash`**
+   - `slash type="NONE"` + `<hh:diagonal type="SOLID">` → slash 비트 0, **diagonal_type==1**.
+
+테스트 헬퍼: `slash_code()`(Attribute 직접 파싱), `parse_single_border_fill()`(헤더 XML 래핑 후
+`parse_hwpx_header` 경유 end-to-end 파싱).
+
+## 검증
+- `cargo test --lib parser::hwpx::header`: **13 passed, 0 failed** (신규 4건 포함).
+- 핵심 회귀 가드(#3)가 버그 재발 시 실패하도록 고정.
+
+## 비고
+- raw string 내 `color="#000000"` 의 `"#` 충돌로 해당 테스트만 `r##"..."##` 구분자 사용.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1134,34 +1134,22 @@ fn parse_border_fill(
                             }
                         }
                         b"slash" => {
+                            // slash/backSlash 의 type 은 대각선 "방향/형태" enum 이며
+                            // 선 종류가 아니다. 방향 비트(attr bits 2~4)만 설정하고,
+                            // 선 종류/굵기/색은 <hh:diagonal> 요소가 전담한다.
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
-                                    b"type" => {
-                                        let line_type = parse_border_line_type_code(&attr);
-                                        set_diagonal_attr_bits(&mut bf, 2, line_type);
-                                        if line_type != 0 {
-                                            bf.diagonal.diagonal_type = line_type;
-                                        }
-                                    }
-                                    b"width" => bf.diagonal.width = parse_diagonal_width(&attr),
-                                    b"color" => bf.diagonal.color = parse_color(&attr),
-                                    _ => {}
+                                if attr.key.as_ref() == b"type" {
+                                    let code = parse_slash_shape_code(&attr);
+                                    set_diagonal_attr_bits(&mut bf, 2, code);
                                 }
                             }
                         }
                         b"backSlash" => {
+                            // backSlash 방향 비트(attr bits 5~7)만 설정.
                             for attr in ce.attributes().flatten() {
-                                match attr.key.as_ref() {
-                                    b"type" => {
-                                        let line_type = parse_border_line_type_code(&attr);
-                                        set_diagonal_attr_bits(&mut bf, 5, line_type);
-                                        if line_type != 0 {
-                                            bf.diagonal.diagonal_type = line_type;
-                                        }
-                                    }
-                                    b"width" => bf.diagonal.width = parse_diagonal_width(&attr),
-                                    b"color" => bf.diagonal.color = parse_color(&attr),
-                                    _ => {}
+                                if attr.key.as_ref() == b"type" {
+                                    let code = parse_slash_shape_code(&attr);
+                                    set_diagonal_attr_bits(&mut bf, 5, code);
                                 }
                             }
                         }
@@ -1460,15 +1448,33 @@ fn parse_border_line_type_code(attr: &quick_xml::events::attributes::Attribute) 
     }
 }
 
-fn set_diagonal_attr_bits(bf: &mut BorderFill, shift: u16, line_type: u8) {
+/// HWPX slash/backSlash 의 형태(type) enum 을 HWP5 BORDER_FILL attr 의
+/// 3비트 방향 코드로 변환한다. (선 종류가 아니라 대각선 방향/형태)
+///
+/// | HWPX type     | 3비트 | 의미              |
+/// |---------------|-------|-------------------|
+/// | NONE          | 0     | 없음              |
+/// | CENTER        | 0b010 | 단순 슬래시       |
+/// | CENTER_BELOW  | 0b011 | 가운데 + 아래     |
+/// | CENTER_ABOVE  | 0b110 | 가운데 + 위       |
+/// | 기타/ALL      | 0b111 | 3방향             |
+fn parse_slash_shape_code(attr: &quick_xml::events::attributes::Attribute) -> u8 {
+    match attr_str(attr).as_str() {
+        "NONE" => 0,
+        "CENTER" => 0b010,
+        "CENTER_BELOW" => 0b011,
+        "CENTER_ABOVE" => 0b110,
+        _ => 0b111,
+    }
+}
+
+/// HWP5 BORDER_FILL attr 의 대각선 방향 비트 필드를 설정한다.
+/// slash 는 shift=2, backSlash 는 shift=5 위치의 3비트.
+/// `code` 는 [`parse_slash_shape_code`] 가 반환한 3비트 방향 코드.
+fn set_diagonal_attr_bits(bf: &mut BorderFill, shift: u16, code: u8) {
     let mask = 0x07u16 << shift;
     bf.attr &= !mask;
-    if line_type != 0 {
-        // HWP5 BORDER_FILL attr stores diagonal direction presence separately
-        // from DiagonalLine(type,width,color). Hancom-authored samples use
-        // value 2 for a visible slash/backSlash direction bit-field.
-        bf.attr |= 0x02u16 << shift;
-    }
+    bf.attr |= ((code as u16) & 0x07) << shift;
 }
 
 fn parse_diagonal_width(attr: &quick_xml::events::attributes::Attribute) -> u8 {
@@ -1637,5 +1643,98 @@ mod tests {
         assert!(!is_real_strike_shape("Ghost"));
         assert!(!is_real_strike_shape(""));
         assert!(!is_real_strike_shape("solid")); // 대소문자 구분
+    }
+
+    /// `slash`/`backSlash` 의 type 속성으로 [`parse_slash_shape_code`] 를 호출한다.
+    fn slash_code(type_val: &str) -> u8 {
+        let xml = format!(r#"<e type="{type_val}"/>"#);
+        let mut reader = Reader::from_str(&xml);
+        let mut buf = Vec::new();
+        if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
+            for attr in e.attributes().flatten() {
+                if attr.key.as_ref() == b"type" {
+                    return parse_slash_shape_code(&attr);
+                }
+            }
+        }
+        panic!("type 속성 파싱 실패");
+    }
+
+    #[test]
+    fn test_parse_slash_shape_code() {
+        // 형태 enum → HWP5 attr 3비트 방향 코드. (선 종류가 아님)
+        assert_eq!(slash_code("NONE"), 0);
+        assert_eq!(slash_code("CENTER"), 0b010);
+        assert_eq!(slash_code("CENTER_BELOW"), 0b011);
+        assert_eq!(slash_code("CENTER_ABOVE"), 0b110);
+        // 미지 형태는 3방향(0b111)으로 폴백.
+        assert_eq!(slash_code("ALL"), 0b111);
+    }
+
+    #[test]
+    fn test_set_diagonal_attr_bits() {
+        let mut bf = BorderFill::default();
+        // slash = shift 2 (bits 2~4)
+        set_diagonal_attr_bits(&mut bf, 2, 0b010);
+        assert_eq!((bf.attr >> 2) & 0x07, 0b010);
+        // backSlash = shift 5 (bits 5~7), slash 비트 보존
+        set_diagonal_attr_bits(&mut bf, 5, 0b011);
+        assert_eq!((bf.attr >> 5) & 0x07, 0b011);
+        assert_eq!((bf.attr >> 2) & 0x07, 0b010);
+        // code 0 → 비트 클리어
+        set_diagonal_attr_bits(&mut bf, 2, 0);
+        assert_eq!((bf.attr >> 2) & 0x07, 0);
+    }
+
+    /// 단일 borderFill 을 헤더 XML 로 감싸 파싱한 뒤 첫 borderFill 을 돌려준다.
+    fn parse_single_border_fill(border_fill_xml: &str) -> BorderFill {
+        let xml = format!(
+            r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"
+         xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hh:refList>
+    <hh:borderFills itemCnt="1">{border_fill_xml}</hh:borderFills>
+  </hh:refList>
+</hh:head>"##
+        );
+        let (doc_info, _) = parse_hwpx_header(&xml).unwrap();
+        doc_info
+            .border_fills
+            .into_iter()
+            .next()
+            .expect("borderFill 파싱 실패")
+    }
+
+    #[test]
+    fn test_slash_center_without_diagonal_no_line() {
+        // #1038 회귀 가드: slash type="CENTER" 만 있고 <hh:diagonal> 가 없으면
+        // 방향 비트만 설정되고 diagonal_type 은 0 으로 남아야 한다(대각선 미표시).
+        let bf = parse_single_border_fill(
+            r#"<hh:borderFill id="341">
+                 <hh:slash type="CENTER" Crooked="0" isCounter="0"/>
+                 <hh:backSlash type="NONE" Crooked="0" isCounter="0"/>
+               </hh:borderFill>"#,
+        );
+        assert_eq!((bf.attr >> 2) & 0x07, 0b010, "slash 방향 비트 설정");
+        assert_eq!((bf.attr >> 5) & 0x07, 0, "backSlash 비트 없음");
+        assert_eq!(
+            bf.diagonal.diagonal_type, 0,
+            "diagonal 요소 없음 → diagonal_type 0 (대각선 미표시)"
+        );
+    }
+
+    #[test]
+    fn test_diagonal_element_sets_line_independent_of_slash() {
+        // slash type="NONE" 이라도 <hh:diagonal type="SOLID"> 가 있으면
+        // diagonal_type 은 선 종류에서 설정되고, slash 방향 비트는 0.
+        let bf = parse_single_border_fill(
+            r##"<hh:borderFill id="1">
+                 <hh:slash type="NONE" Crooked="0" isCounter="0"/>
+                 <hh:backSlash type="NONE" Crooked="0" isCounter="0"/>
+                 <hh:diagonal type="SOLID" width="0.1 mm" color="#000000"/>
+               </hh:borderFill>"##,
+        );
+        assert_eq!((bf.attr >> 2) & 0x07, 0, "slash 방향 비트 없음");
+        assert_eq!(bf.diagonal.diagonal_type, 1, "diagonal SOLID → 선 종류 1");
     }
 }


### PR DESCRIPTION
## 문제
일부 HWPX 표 셀(borderFill에 `<hh:slash type="CENTER">` 만 있고 `<hh:diagonal>` 요소가 없는 경우)에 한컴 편집기/PDF에는 없는 검정 대각선이 그려진다.

예: `samples/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서.hwpx` 4페이지 헤딩 "Ⅰ 사업안내"(1×3 표). 한컴 2022 PDF p4에는 대각선이 없다.

## 원인
HWPX borderFill에서 셀 대각선은 **독립된 두 요소**로 표현된다:
- `<hh:slash>`/`<hh:backSlash>` `type` → 대각선 **방향/형태** enum (NONE/CENTER/…)
- `<hh:diagonal>` `type/width/color` → 실제 **선 종류·굵기·색** (HWP5 attr 비트 + DiagonalLine 과 1:1)

기존 파서는 slash/backSlash의 `type`("CENTER")을 선 종류 파서(`parse_border_line_type_code`)에 넘겨 `Solid`로 폴백시키고 `diagonal.diagonal_type=1`을 설정했다. 선 정의(`<hh:diagonal>`)가 없는 셀에도 렌더 트리거(`border_rendering.rs`, `diagonal_type != 0`)가 켜져 기본 검정 실선이 그려졌다.

## 수정 (`src/parser/hwpx/header.rs` 단일 파일)
- `parse_slash_shape_code()` 신규: slash 형태 enum → HWP5 attr 3비트 방향 코드 (NONE→0, CENTER→0b010, CENTER_BELOW→0b011, CENTER_ABOVE→0b110, 기타→0b111).
- `set_diagonal_attr_bits()`: 3비트 코드를 그대로 기록(기존 nonzero→0b010 축소 제거).
- `slash`/`backSlash` 핸들러: `type`을 방향 비트(`attr`)만 설정하도록 분리. `diagonal_type` 할당·width/color 분기 제거. 선 종류/굵기/색은 `<hh:diagonal>`가 단독 책임.

렌더러/모델/HWP5·HWP3 경로 무수정.

## 검증
- `cargo test` 전체 통과(실패 0) + 신규 단위/회귀 테스트 4건.
- 문제 샘플 p4 헤딩: 검정 대각선 **3→0** (한컴 PDF 정합).
- 실제 `<hh:diagonal>` 보유 표(`tac-img-02.hwpx`, slash CENTER + diagonal SOLID 셀 포함): 대각선 정상 유지(회귀 없음).

closes #1038

🤖 Generated with [Claude Code](https://claude.com/claude-code)