### PR TITLE
Task #1043: 중첩 표 1×1 wrapper 외곽 테두리 lookup off-by-one 정정

### DIFF
--- a/mydocs/plans/task_m100_1043.md
+++ b/mydocs/plans/task_m100_1043.md
@@ -1,0 +1,52 @@
+# 수행계획서 — Task M100 #1043 (버그 수정)
+
+## 이슈
+- edwardkim/rhwp#1043 — 중첩 표 외곽선 미표시 (1×1 wrapper 외곽 테두리 lookup off-by-one)
+- 마일스톤: v1.0.0 (M100) / 브랜치: `local/task1043` (기준 `stream/devel` @ ac6aeed4)
+
+## 현상
+`samples/2. 인공지능(AI) 기반 재정통합시스템 구축 용역 제안요청서.hwpx` 8페이지 "추진조직 구성"
+조직도에서 **전체를 감싸는 가장 바깥 사각형 테두리**가 렌더되지 않는다. 내부 박스는 정상.
+한컴 2022 PDF p8 에는 외곽 박스가 존재한다.
+
+## 구조
+- 외곽 `1×1` 표(pi=124), 셀 `borderFillIDRef=4` → HWPX `borderFill id=4` = 4변 SOLID 검정(외곽 박스)
+- 그 안에 `9×8` 내부 표 → 내부 박스들(정상)
+
+## 루트 원인 (조사 완료)
+`src/renderer/layout/table_layout.rs` 의 **중첩 표(1×1 wrapper) 외곽선 그리기 경로**가
+`cell.border_fill_id` 를 `border_styles` 인덱스로 그대로 사용한다:
+
+```rust
+styles.border_styles.get(cell.border_fill_id as usize)   // -1 누락
+```
+
+- HWPX `borderFillIDRef` 는 1-based, `border_styles` 는 0-based Vec.
+- 같은 파일의 다른 모든 테두리 lookup(일반 셀 ~1679, 표 ~523, zone ~543/642)은 전부
+  `.saturating_sub(1)` 로 0-based 변환한다.
+- 이 경로만 `-1` 이 빠져 `get(4)` 가 HWPX id=5(NONE×4)를 반환 → `any_border=false` → 외곽선 미표시.
+- 내부 박스는 `-1` 경로라 정상.
+
+디버그 검증: `border_styles[4]` = `[None×4]`(=id5), `border_styles[3]` = `[Solid×4]`(=id4).
+
+## 수정 방향
+해당 lookup을 다른 경로와 동일하게:
+```rust
+styles.border_styles.get((cell.border_fill_id as usize).saturating_sub(1))
+```
+한 줄 수정. (조사 단계에서 적용해 외곽 박스가 PDF p8과 정합됨을 로컬 확인 후 원복함.)
+
+## 영향 범위 / 리스크
+- 수정 파일: `src/renderer/layout/table_layout.rs` 단일 (lookup 1곳).
+- 다른 경로는 이미 `-1` 적용 → 본 수정으로 모든 lookup이 일관됨.
+- 리스크: `border_fill_id==0`(테두리 없음) 케이스는 `saturating_sub(1)=0` 이지만, 본 분기는
+  `has_outer_padding && any_border` 가드 안에 있어 영향 미미. 회귀 테스트로 가드.
+
+## 검증 계획
+1. 단위/회귀 테스트: 1×1 wrapper + 내부 표 + 외곽 borderFill 셋업에서 외곽선 4변 생성 확인.
+2. `export-svg -p 7` → 조직도 외곽 박스(전폭 연속 테두리) 렌더 확인 (PDF p8 정합).
+3. `cargo test` 전체 통과, 기존 중첩 표 회귀(exam_social 등) 무영향 확인.
+4. 수정 파일 한정 fmt.
+
+## 절차
+수행계획서 승인 → 구현계획서(3단계) → 승인 → 단계별 구현·보고 → 최종 보고서.

--- a/mydocs/plans/task_m100_1043_impl.md
+++ b/mydocs/plans/task_m100_1043_impl.md
@@ -1,0 +1,59 @@
+# 구현계획서 — Task M100 #1043 (버그 수정)
+
+## 이슈
+- edwardkim/rhwp#1043 — 중첩 표 외곽선 미표시 (1×1 wrapper 외곽 테두리 lookup off-by-one)
+- 브랜치: `local/task1043` (기준 `stream/devel` @ ac6aeed4)
+
+## 설계 근거
+`src/renderer/layout/table_layout.rs::layout_table` 의 1×1 wrapper 분기에서 외곽 테두리 borderFill 을
+조회하는 부분(현재 라인 243)이 `cell.border_fill_id` 를 `border_styles` 인덱스로 **그대로** 사용한다:
+
+```rust
+styles.border_styles.get(cell.border_fill_id as usize)   // -1 누락
+```
+
+`borderFillIDRef` 는 1-based, `border_styles` 는 0-based Vec 이다. 같은 파일의 다른 모든 lookup —
+일반 셀(~1679 `idx = border_fill_id.saturating_sub(1)`), 표(~523), zone(~543/642) — 은 전부
+`.saturating_sub(1)` 로 변환한다. 이 분기만 누락되어 `get(4)` 가 HWPX id=5(NONE×4)를 반환,
+`any_border=false` → 외곽선 미표시.
+
+### 사전 실증 (조사 단계 완료)
+- `border_styles[4]` = `[None×4]`(=id5), `border_styles[3]` = `[Solid×4]`(=id4).
+- `.saturating_sub(1)` 적용 시:
+  - 인공지능(HWPX) 8p 조직도: 외곽 전폭 연속선 생성 (PDF p8 정합).
+  - **기존 회귀 테스트 `tests/issue_nested_table_border.rs`(exam_social.hwp, HWP5): 수정 후에도 통과** —
+    exam_social 의 의도 borderFill 도 borders 보유하므로 안전. 오히려 의도한 id 로 정확해짐.
+
+## 단계별 계획 (3단계)
+
+### Stage 1 — 코드 수정 (`src/renderer/layout/table_layout.rs`)
+- 1×1 wrapper 외곽 테두리 lookup 한 줄을 다른 경로와 동일하게:
+  ```rust
+  styles.border_styles.get((cell.border_fill_id as usize).saturating_sub(1))
+  ```
+- 다른 변경 없음(좌표/렌더 로직 동일).
+- 커밋: `Task #1043: 중첩 표 외곽선 lookup off-by-one 정정`
+- 보고서: `mydocs/working/task_m100_1043_stage1.md`
+
+### Stage 2 — 회귀 테스트 (`tests/issue_nested_table_border.rs`)
+- HWPX 케이스 회귀 테스트 추가: `samples/2. 인공지능(AI) … 제안요청서.hwpx` 8페이지(index 7)
+  렌더 SVG 에서 조직도 외곽 박스의 **전폭 연속 가로 외곽선**(x 좌측~우측 전구간, stroke=#000000)이
+  존재하는지 검증. 좌표 hardcode 회피 — "전폭(>500px) 연속 가로선 ≥ 1" 형태로 가드.
+- 기존 exam_social 테스트는 그대로 유지(수정 후 통과 확인됨).
+- 커밋: `Task #1043: HWPX 중첩 표 외곽선 회귀 가드`
+- 보고서: `mydocs/working/task_m100_1043_stage2.md`
+
+### Stage 3 — 검증 및 최종 정리
+1. `cargo test` 전체 통과(특히 `issue_nested_table_border` 2건).
+2. `export-svg -p 7` → 조직도 외곽 박스 시각 확인(PDF p8 정합).
+3. exam_social 등 기존 중첩 표 무영향 재확인.
+4. 수정 파일 한정 fmt.
+- 최종 보고서: `mydocs/report/task_m100_1043_report.md`. orders 미편집(작업지시자 관할).
+- 커밋: `Task #1043: 검증 + 최종 보고서 (closes #1043)` — closes 번호 push 전 재확인.
+
+## 영향 범위 / 리스크
+- 수정: `src/renderer/layout/table_layout.rs` 단일 lookup(1줄).
+- 본 수정으로 모든 borderFill lookup 이 `-1` 로 일관됨.
+- 리스크: `border_fill_id==0` 은 `saturating_sub(1)=0` 이나, 본 분기는 `has_outer_padding && any_border`
+  가드 안 → 무테두리 wrapper 에는 영향 없음.
+- 기존 exam_social 회귀: 수정 후 통과 실증 완료.

--- a/mydocs/report/task_m100_1043_report.md
+++ b/mydocs/report/task_m100_1043_report.md
@@ -1,0 +1,72 @@
+# 최종 결과보고서 — Task M100 #1043
+
+## 이슈
+edwardkim/rhwp#1043 — 중첩 표 외곽선 미표시 (1×1 wrapper 외곽 테두리 lookup off-by-one)
+
+## 원인
+`src/renderer/layout/table_layout.rs::layout_table` 의 1×1 wrapper 분기에서 외곽 테두리
+borderFill 을 조회할 때 `cell.border_fill_id`(1-based `borderFillIDRef`)를 0-based `border_styles`
+Vec 인덱스로 **그대로** 사용했다. 같은 파일의 다른 모든 lookup(일반 셀/표/zone)은 `.saturating_sub(1)`
+로 변환하는데 이 분기만 누락되어, 한 칸 어긋난 borderFill(테두리 NONE)을 읽어 `any_border=false`
+→ wrapper 외곽 실선 테두리가 통째로 누락되었다.
+
+## 수정
+1×1 wrapper 외곽 테두리 lookup 한 줄을 다른 경로와 동일하게 0-based 변환:
+```rust
+// before
+styles.border_styles.get(cell.border_fill_id as usize)
+// after
+styles.border_styles.get((cell.border_fill_id as usize).saturating_sub(1))
+```
+좌표/렌더 로직 변경 없음. 본 수정으로 모든 borderFill lookup 이 `-1` 로 일관된다.
+
+## 단계 요약
+| 단계 | 내용 | 커밋 |
+|------|------|------|
+| Stage 1 | 코드 정정(1줄) + 근거 주석 | `ff252c71` |
+| Stage 2 | 회귀 가드 추가. 초안의 비공개 픽스처 의존을 **tracked 샘플로 교체** | `da3fd68a` (41acfcdc amend) |
+| Stage 3 | 전체 검증 + 시각 확인 + 최종 보고서 | (본 커밋) |
+
+### Stage 2 픽스처 교체 경위
+초안 회귀 테스트는 `samples/2. 인공지능…hwpx` 를 썼으나 이 파일은 **비공개 문서(git 미추적,
+커밋 금지)** 라 테스트만 커밋되면 CI/타 환경에서 `cargo test` 가 깨진다. 버그/정정 두 빌드로 263개
+tracked 비공개제외 샘플 전 페이지 SVG 를 렌더·diff 하여, 정정으로 외곽선이 달라지는 샘플 2건
+(`exam_social.hwp`, `k-water-rfp.hwp`) 을 추출했다. 강신호인 **`samples/k-water-rfp.hwp`
+p19(index 18)** 를 채택했다.
+
+## 회귀 테스트 (`tests/issue_nested_table_border.rs`)
+- 기존: `nested_table_border_exam_social_p1_q4_outline_present` (HWP5, 유지).
+- 신규: **`nested_table_border_kwater_rfp_p19_outer_outline_present`** (HWP5).
+  내부 표 외곽 격자는 점선(`stroke-dasharray`), wrapper 외곽 테두리는 같은 y 에 겹치는 실선이다.
+  가드는 좌표 hardcode 없이 "전폭(>500px) 수평선 중 점선과 y 가 일치(±1px)하는 실선이 ≥1 존재"를
+  확인한다 ("외곽 박스 = 내부 표 외곽" 관계). 무관한 다른 표 실선·페이지네이션 시프트에 무영향.
+- 두 테스트 모두 **git-tracked 픽스처** 기반.
+
+### 양방향 검증
+| 코드 상태 | `kwater_rfp_p19` | `exam_social` |
+|-----------|------------------|----------------|
+| 정정 적용 | 통과 — 점선과 겹치는 전폭 실선 2건(상 y=583.3, 하 y=993.9, w=621) | 통과 |
+| 버그 임시 복원 | 실패 — 겹치는 전폭 실선 0건 | 통과 |
+
+## 검증 결과
+- `cargo test` 전체 **0 failed** (모든 suite 통과).
+- `cargo test --test issue_nested_table_border`: 2 passed.
+- `cargo fmt --check tests/issue_nested_table_border.rs`: clean (수정 파일 한정).
+- closes 번호 검증: `gh issue view 1043` → OPEN, 제목 정확히 일치 → `closes #1043` 안전.
+
+### 시각 확인
+- `export-svg samples/k-water-rfp.hwp -p 18` 렌더 결과 wrapper 외곽 박스 4변 실선
+  (상 y=583.3 / 하 y=993.9 / 좌 x=80 / 우 x=701.2) 복원 확인. 래스터 PNG 에서 외곽 박스 가시.
+- 권위 PDF(`pdf/k-water-rfp-2022.pdf`, 27쪽)는 rhwp 렌더(29쪽)와 페이지네이션이 어긋나(해당 구간
+  PDF 는 예정공정표/기타사항/첨부 텍스트) 이 박스의 1:1 PDF 오버레이는 성립하지 않았다. 외곽선
+  존재/누락 판정은 SVG 선 분석 + 양방향 회귀 테스트로 확정했다.
+
+## 영향 범위 / 리스크
+- 수정: `src/renderer/layout/table_layout.rs` 단일 lookup 1줄.
+- `border_fill_id==0` 은 `saturating_sub(1)=0` 이나 본 분기는 `has_outer_padding && any_border`
+  가드 안이라 무테두리 wrapper 에 영향 없음.
+- 기존 exam_social 중첩 표: 정정 후에도 통과(무영향) 재확인.
+
+## 후속
+- orders 갱신은 작업지시자 관할(미편집).
+- 커밋 후 `local/devel` merge 시점은 작업지시자 결정.

--- a/mydocs/working/task_m100_1043_stage1.md
+++ b/mydocs/working/task_m100_1043_stage1.md
@@ -1,0 +1,25 @@
+# Stage 1 완료보고서 — Task M100 #1043
+
+## 작업
+중첩 표(1×1 wrapper) 외곽 테두리 borderFill lookup 의 off-by-one 정정.
+
+## 변경 (`src/renderer/layout/table_layout.rs`)
+1×1 wrapper 분기의 외곽 테두리 lookup 을 다른 모든 경로(일반 셀/표/zone)와 동일하게
+`border_fill_id` 를 0-based 변환하도록 수정:
+
+```rust
+// before
+styles.border_styles.get(cell.border_fill_id as usize)
+// after
+styles.border_styles.get((cell.border_fill_id as usize).saturating_sub(1))
+```
+
+`borderFillIDRef` 는 1-based, `border_styles` 는 0-based Vec 이므로 `-1` 이 필요하다.
+주석으로 근거 명시. 좌표/렌더 로직 변경 없음.
+
+## 검증 (예비)
+- `cargo build` 통과.
+- `export-svg -p 7`: 조직도 외곽 박스의 **전폭 연속 가로선** 생성 확인
+  (y=615.6, x 75.6→672.7 = body 좌→우 전구간). 기존엔 박스 사이 gap 으로 끊겨 외곽선 부재였음.
+
+정식 회귀 테스트/전체 검증은 Stage 2~3.

--- a/mydocs/working/task_m100_1043_stage2.md
+++ b/mydocs/working/task_m100_1043_stage2.md
@@ -1,0 +1,43 @@
+# Stage 2 완료보고서 — Task M100 #1043
+
+## 작업
+중첩 표(1×1 wrapper) 외곽선 회귀 테스트 추가 (`tests/issue_nested_table_border.rs`).
+
+## 픽스처 교체 경위 (v2)
+초안 테스트는 `samples/2. 인공지능(AI) … 제안요청서.hwpx` 를 픽스처로 썼으나, 이 파일은
+**비공개 문서(git 미추적, 커밋 금지)** 다. 테스트 코드만 커밋되고 픽스처는 추가 불가하므로
+CI·타 컨트리뷰터·fresh clone 에서 `cargo test` 가 깨진다. 작업지시자 승인에 따라 **git-tracked
+공개 샘플**로 교체했다.
+
+교체 대상 선정: 버그 빌드(`get(id)`) vs 정정 빌드(`get(id-1)`)로 263개 tracked 비공개제외 샘플의
+전 페이지 SVG 를 렌더·diff 하여, 정정으로 외곽선 렌더가 달라지는 샘플을 추출했다. 결과 2건:
+- `samples/exam_social.hwp` p1 — 외곽선 stroke-width 만 변화(0.75→0.5), 폭 <500px (약신호).
+- **`samples/k-water-rfp.hwp` p19(index 18)** — 외곽 실선 4변이 정정 빌드에만 존재(강신호) → 채택.
+
+## 신규 테스트
+**`nested_table_border_kwater_rfp_p19_outer_outline_present`**
+- 대상: `samples/k-water-rfp.hwp` 19페이지(index 18). 외곽 1×1 wrapper 표 + 내부 표 자료 박스.
+- 구조 관찰: 내부 표 외곽 격자는 **점선**(`stroke-dasharray`), wrapper 외곽 테두리는 같은 y 에
+  겹치는 **실선**으로 그려진다. off-by-one 버그에서는 wrapper borderFill 을 한 칸 어긋나게
+  읽어(NONE) 실선 외곽선이 통째로 누락되고 내부 점선만 남는다.
+- 가드(좌표 hardcode 회피): 전폭(>500px) 수평선 중 **점선과 y 가 일치(±1px)하는 실선**이 ≥1
+  존재하는지 확인. "외곽 박스 = 내부 표 외곽" 관계로 판정하므로 무관한 다른 표의 실선(겹치는
+  점선 없음)·페이지네이션 시프트에 영향받지 않는다.
+
+헬퍼 `parse_lines()` 를 `(x1,y1,x2,y2,dashed)` 반환으로 확장(점선 여부 포함).
+
+## 양방향 검증 (가드 유효성)
+| 코드 상태 | `kwater_rfp_p19` | `exam_social` |
+|-----------|------------------|----------------|
+| 정정 적용 | **통과** — 점선과 겹치는 전폭 실선 2건(상 y=583.3, 하 y=993.9, width 621) | 통과 |
+| 버그 임시 복원 | **실패** — "겹치는 전폭 실선 0건" | 통과 |
+
+→ 버그 재발 시 즉시 실패하는 유효한 회귀 가드 확인. 검증 후 정정 코드 복원(작업 트리 clean).
+
+## 검증
+- `cargo test --test issue_nested_table_border`: **2 passed**
+  (exam_social HWP5 기존 + k-water-rfp HWP5 신규, 모두 tracked 픽스처).
+- 작업 트리 추적 변경: `tests/issue_nested_table_border.rs` 1건뿐.
+
+## 비고
+- 비공개 픽스처 의존 테스트는 폐기. 신규 테스트는 전부 공개 tracked 샘플 기반.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -239,8 +239,11 @@ impl LayoutEngine {
                                 || cell.padding.top != 0
                                 || cell.padding.bottom != 0;
                             if has_outer_padding {
-                                if let Some(bs) =
-                                    styles.border_styles.get(cell.border_fill_id as usize)
+                                // border_fill_id 는 1-based(borderFillIDRef), border_styles 는
+                                // 0-based Vec 이므로 -1 변환한다. (일반 셀/표/zone lookup 과 동일)
+                                if let Some(bs) = styles
+                                    .border_styles
+                                    .get((cell.border_fill_id as usize).saturating_sub(1))
                                 {
                                     let any_border = bs.borders.iter().any(|b| {
                                         b.line_type != crate::model::style::BorderLineType::None

--- a/tests/issue_nested_table_border.rs
+++ b/tests/issue_nested_table_border.rs
@@ -65,3 +65,68 @@ fn nested_table_border_exam_social_p1_q4_outline_present() {
         "4번 박스 좌측+상단 라인 영역의 lx 좌표 ≥ 2건 영역 필요 영역 (실제: {outline_count})"
     );
 }
+
+/// SVG 문자열에서 `<line>` 요소의 좌표와 점선 여부를 추출한다.
+/// 반환: `(x1, y1, x2, y2, dashed)` — `dashed` 는 `stroke-dasharray` 보유 여부.
+fn parse_lines(svg: &str) -> Vec<(f64, f64, f64, f64, bool)> {
+    let mut out = Vec::new();
+    for seg in svg.split("<line ").skip(1) {
+        let head = &seg[..seg.find('>').unwrap_or(seg.len())];
+        let get = |k: &str| -> Option<f64> {
+            let p = head.find(&format!("{k}=\""))? + k.len() + 2;
+            let rest = &head[p..];
+            rest[..rest.find('"')?].parse().ok()
+        };
+        if let (Some(x1), Some(y1), Some(x2), Some(y2)) =
+            (get("x1"), get("y1"), get("x2"), get("y2"))
+        {
+            let dashed = head.contains("stroke-dasharray");
+            out.push((x1, y1, x2, y2, dashed));
+        }
+    }
+    out
+}
+
+/// #1043 회귀 가드: 중첩 표(1×1 wrapper) 외곽 테두리 누락 정정 (HWP5 케이스).
+///
+/// `samples/k-water-rfp.hwp` 19페이지(index 18)는 외곽 1×1 wrapper 표 안에 내부 표가
+/// 든 자료 박스 구조다. 내부 표의 외곽 격자는 점선(`stroke-dasharray`)으로, wrapper
+/// 외곽 테두리는 그 위에 겹치는 실선으로 그려진다. off-by-one lookup 버그에서는
+/// wrapper 외곽 borderFill 을 한 칸 어긋나게 읽어(NONE) 실선 외곽선이 통째로 누락되고
+/// 내부 표 점선만 남았다. 정정 후에는 점선 외곽과 같은 y 에 실선 외곽선이 존재해야 한다.
+///
+/// 가드: 전폭(>500px) 수평선 중 **점선과 y 가 일치하는 실선**이 ≥1 존재하는지 확인한다.
+/// 좌표를 hardcode 하지 않고 "외곽 박스 = 내부 표 외곽" 관계로 판정하므로, 무관한
+/// 다른 표의 실선(겹치는 점선 없음)이나 페이지네이션 시프트에 영향받지 않는다.
+/// (버그: 일치 0건 → 실패 / 정정: 상·하 2건 일치 → 통과)
+#[test]
+fn nested_table_border_kwater_rfp_p19_outer_outline_present() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join("samples/k-water-rfp.hwp");
+    let bytes = fs::read(&path).expect("read k-water-rfp.hwp");
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse k-water-rfp.hwp");
+
+    // 페이지 19 (index 18) 렌더
+    let svg = doc.render_page_svg(18).expect("render_page_svg p19");
+
+    let lines = parse_lines(&svg);
+    // 전폭(>500px) 수평선만 추려 점선/실선 y 집합으로 분리한다.
+    let is_wide_horiz =
+        |x1: f64, y1: f64, x2: f64, y2: f64| (y1 - y2).abs() < 0.01 && (x2 - x1).abs() > 500.0;
+    let dashed_ys: Vec<f64> = lines
+        .iter()
+        .filter(|(x1, y1, x2, y2, dashed)| *dashed && is_wide_horiz(*x1, *y1, *x2, *y2))
+        .map(|(_, y1, ..)| *y1)
+        .collect();
+    // 점선(내부 표 외곽 격자)과 y 가 일치(±1px)하는 실선(wrapper 외곽 테두리) 개수.
+    let outer_solid_on_inner = lines
+        .iter()
+        .filter(|(x1, y1, x2, y2, dashed)| !*dashed && is_wide_horiz(*x1, *y1, *x2, *y2))
+        .filter(|(_, y1, ..)| dashed_ys.iter().any(|dy| (dy - *y1).abs() < 1.0))
+        .count();
+
+    assert!(
+        outer_solid_on_inner >= 1,
+        "wrapper 외곽 실선 테두리 누락 (내부 표 점선 외곽과 겹치는 전폭 실선 {outer_solid_on_inner}건)"
+    );
+}


### PR DESCRIPTION
## 이슈
closes #1043 — 중첩 표 외곽선 미표시 (1×1 wrapper 외곽 테두리 lookup off-by-one)

## 원인
`src/renderer/layout/table_layout.rs::layout_table` 의 1×1 wrapper 분기에서 외곽 테두리 borderFill 을 조회할 때 `cell.border_fill_id`(1-based `borderFillIDRef`)를 0-based `border_styles` Vec 인덱스로 **그대로** 사용했다. 같은 파일의 다른 모든 lookup(일반 셀/표/zone)은 `.saturating_sub(1)` 로 변환하는데 이 분기만 누락되어, 한 칸 어긋난 borderFill(테두리 NONE)을 읽어 wrapper 외곽 실선 테두리가 누락되었다.

## 수정
```rust
// before
styles.border_styles.get(cell.border_fill_id as usize)
// after
styles.border_styles.get((cell.border_fill_id as usize).saturating_sub(1))
```
좌표/렌더 로직 변경 없음. 본 수정으로 모든 borderFill lookup 이 `-1` 로 일관된다.

## 회귀 테스트
`tests/issue_nested_table_border.rs` 신규 테스트 `nested_table_border_kwater_rfp_p19_outer_outline_present` (tracked `samples/k-water-rfp.hwp` p19). 내부 표 점선 외곽과 y 가 겹치는 전폭(>500px) 실선 외곽선 존재를 확인 — 좌표 hardcode 없이 '외곽 박스 = 내부 표 외곽' 관계로 판정.

| 코드 상태 | 결과 |
|-----------|------|
| 정정 적용 | 통과 (겹치는 전폭 실선 2건) |
| 버그 임시 복원 | 실패 (0건) |

기존 `exam_social` 테스트는 무영향 유지.

## 검증
- `cargo test` 전체 0 failed
- `cargo fmt --check` (수정 파일) clean
- k-water-rfp p19 wrapper 외곽 박스 4변 실선 복원 시각 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)