### PR TITLE
render: harden CanvasKit direct replay contract

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -682,10 +682,7 @@ export class WasmBridge {
   /** [Task #919] 글상자/도형 컨트롤의 페이지 좌표 바운딩박스 */
   getShapeBBox(sec: number, parentPara: number, controlIdx: number): { pageIndex: number; x: number; y: number; width: number; height: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    const d = this.doc as unknown as {
-      getShapeBBox: (sectionIdx: number, parentParaIdx: number, controlIdx: number) => string;
-    };
-    return JSON.parse(d.getShapeBBox(sec, parentPara, controlIdx));
+    return JSON.parse(this.doc.getShapeBBox(sec, parentPara, controlIdx));
   }
 
   deleteTableControl(sec: number, parentPara: number, controlIdx: number): { ok: boolean } {

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -378,8 +378,8 @@ export class WasmBridge {
     }
     return JSON.stringify({
       mode,
-      hiddenCanvas2dOverlayAllowed: mode === 'compat',
-      directReplayRequired: mode === 'default',
+      hiddenCanvas2dOverlayAllowed: false,
+      directReplayRequired: true,
       summary: {
         totalItems: 0,
         directItems: 0,
@@ -682,7 +682,10 @@ export class WasmBridge {
   /** [Task #919] 글상자/도형 컨트롤의 페이지 좌표 바운딩박스 */
   getShapeBBox(sec: number, parentPara: number, controlIdx: number): { pageIndex: number; x: number; y: number; width: number; height: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    return JSON.parse(this.doc.getShapeBBox(sec, parentPara, controlIdx));
+    const d = this.doc as unknown as {
+      getShapeBBox: (sectionIdx: number, parentParaIdx: number, controlIdx: number) => string;
+    };
+    return JSON.parse(d.getShapeBBox(sec, parentPara, controlIdx));
   }
 
   deleteTableControl(sec: number, parentPara: number, controlIdx: number): { ok: boolean } {

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -75,9 +75,9 @@ test('CanvasKit renderer source does not introduce Canvas2D overlay replay', () 
 
 test('CanvasKit replay bridge fallback keeps compat on direct replay contract', () => {
   const source = readFileSync(new URL('../src/core/wasm-bridge.ts', import.meta.url), 'utf8');
-  const fallbackStart = source.indexOf('return JSON.stringify({\n      mode,');
-  assert.notEqual(fallbackStart, -1);
-  const fallback = source.slice(fallbackStart, fallbackStart + 260);
+  const method = source.match(/getCanvasKitReplayPlan\([^)]*\): string \{(?<body>[\s\S]*?)\n  \}/);
+  assert.ok(method?.groups?.body);
+  const fallback = method.groups.body;
   assert.match(fallback, /hiddenCanvas2dOverlayAllowed:\s*false/);
   assert.match(fallback, /directReplayRequired:\s*true/);
   assert.equal(fallback.includes("mode === 'compat'"), false);

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -72,3 +72,14 @@ test('CanvasKit renderer source does not introduce Canvas2D overlay replay', () 
   assert.equal(source.includes('renderPageToCanvas'), false);
   assert.equal(source.includes('rhwpOverlay'), false);
 });
+
+test('CanvasKit replay bridge fallback keeps compat on direct replay contract', () => {
+  const source = readFileSync(new URL('../src/core/wasm-bridge.ts', import.meta.url), 'utf8');
+  const fallbackStart = source.indexOf('return JSON.stringify({\n      mode,');
+  assert.notEqual(fallbackStart, -1);
+  const fallback = source.slice(fallbackStart, fallbackStart + 260);
+  assert.match(fallback, /hiddenCanvas2dOverlayAllowed:\s*false/);
+  assert.match(fallback, /directReplayRequired:\s*true/);
+  assert.equal(fallback.includes("mode === 'compat'"), false);
+  assert.equal(fallback.includes("mode === 'default'"), false);
+});

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -35,33 +35,17 @@ mod tests {
     use super::*;
 
     #[test]
-    fn layer_tree_schema_contract_is_stable() {
-        assert_eq!(LAYER_TREE_SCHEMA.schema_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.schema_minor_version, 13);
-        assert_eq!(LAYER_TREE_SCHEMA.resource_table_version, 1);
-        assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 3);
-        assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
-        assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left-y-down");
+    fn layer_tree_schema_constants_match_schema() {
         assert_eq!(
-            PAGE_LAYER_TREE_SCHEMA_VERSION,
-            LAYER_TREE_SCHEMA.schema_version
-        );
-        assert_eq!(
-            PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION,
-            LAYER_TREE_SCHEMA.schema_minor_version
-        );
-        assert_eq!(
-            PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
-            LAYER_TREE_SCHEMA.resource_table_version
-        );
-        assert_eq!(
-            PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION,
-            LAYER_TREE_SCHEMA.resource_table_minor_version
-        );
-        assert_eq!(PAGE_LAYER_TREE_UNIT, LAYER_TREE_SCHEMA.unit);
-        assert_eq!(
-            PAGE_LAYER_TREE_COORDINATE_SYSTEM,
-            LAYER_TREE_SCHEMA.coordinate_system
+            LAYER_TREE_SCHEMA,
+            LayerTreeSchema {
+                schema_version: PAGE_LAYER_TREE_SCHEMA_VERSION,
+                schema_minor_version: PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION,
+                resource_table_version: PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
+                resource_table_minor_version: PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION,
+                unit: PAGE_LAYER_TREE_UNIT,
+                coordinate_system: PAGE_LAYER_TREE_COORDINATE_SYSTEM,
+            }
         );
     }
 }

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -42,5 +42,26 @@ mod tests {
         assert_eq!(LAYER_TREE_SCHEMA.resource_table_minor_version, 3);
         assert_eq!(LAYER_TREE_SCHEMA.unit, "px");
         assert_eq!(LAYER_TREE_SCHEMA.coordinate_system, "page-top-left-y-down");
+        assert_eq!(
+            PAGE_LAYER_TREE_SCHEMA_VERSION,
+            LAYER_TREE_SCHEMA.schema_version
+        );
+        assert_eq!(
+            PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION,
+            LAYER_TREE_SCHEMA.schema_minor_version
+        );
+        assert_eq!(
+            PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION,
+            LAYER_TREE_SCHEMA.resource_table_version
+        );
+        assert_eq!(
+            PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION,
+            LAYER_TREE_SCHEMA.resource_table_minor_version
+        );
+        assert_eq!(PAGE_LAYER_TREE_UNIT, LAYER_TREE_SCHEMA.unit);
+        assert_eq!(
+            PAGE_LAYER_TREE_COORDINATE_SYSTEM,
+            LAYER_TREE_SCHEMA.coordinate_system
+        );
     }
 }

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -35,9 +35,28 @@ impl CanvasKitReplayMode {
         }
     }
 
-    pub fn allows_canvas2d_overlay(self) -> bool {
-        false
+    fn policy(self) -> CanvasKitReplayPolicy {
+        match self {
+            // P17 intentionally keeps both public modes on the same direct replay
+            // contract. `compat` is still accepted for API/URL compatibility and
+            // future conservative direct-replay tuning, but it must not mean a
+            // hidden Canvas2D paint overlay.
+            Self::Default | Self::Compat => CanvasKitReplayPolicy::DIRECT_ONLY,
+        }
     }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+struct CanvasKitReplayPolicy {
+    hidden_canvas2d_overlay_allowed: bool,
+    direct_replay_required: bool,
+}
+
+impl CanvasKitReplayPolicy {
+    const DIRECT_ONLY: Self = Self {
+        hidden_canvas2d_overlay_allowed: false,
+        direct_replay_required: true,
+    };
 }
 
 #[derive(Debug, Clone, PartialEq, Serialize)]
@@ -198,6 +217,7 @@ struct SelectedTextVariant {
 
 struct CanvasKitReplayPlanBuilder {
     mode: CanvasKitReplayMode,
+    policy: CanvasKitReplayPolicy,
     selected_variants: BTreeMap<String, SelectedTextVariant>,
     summary: CanvasKitReplaySummary,
     items: Vec<CanvasKitReplayItem>,
@@ -210,6 +230,7 @@ impl CanvasKitReplayPlanBuilder {
     ) -> Self {
         Self {
             mode,
+            policy: mode.policy(),
             selected_variants,
             summary: CanvasKitReplaySummary::default(),
             items: Vec::new(),
@@ -219,8 +240,8 @@ impl CanvasKitReplayPlanBuilder {
     fn finish(self, text_variants: Vec<CanvasKitTextVariantReport>) -> CanvasKitReplayPlan {
         CanvasKitReplayPlan {
             mode: self.mode,
-            hidden_canvas2d_overlay_allowed: self.mode.allows_canvas2d_overlay(),
-            direct_replay_required: true,
+            hidden_canvas2d_overlay_allowed: self.policy.hidden_canvas2d_overlay_allowed,
+            direct_replay_required: self.policy.direct_replay_required,
             summary: self.summary,
             items: self.items,
             text_variants,
@@ -264,19 +285,20 @@ impl CanvasKitReplayPlanBuilder {
     }
 
     fn push_cache_hint_item(&mut self, path: &str, cache_hint: CacheHint) {
-        let (status, reason, compat_overlay_allowed) = if self.mode.allows_canvas2d_overlay() {
-            (
-                CanvasKitReplayStatus::CompatOverlay,
-                CanvasKitReplayReason::CompatOverlayAllowed,
-                true,
-            )
-        } else {
-            (
-                CanvasKitReplayStatus::DirectRequired,
-                CanvasKitReplayReason::HiddenOverlayForbidden,
-                false,
-            )
-        };
+        let (status, reason, compat_overlay_allowed) =
+            if self.policy.hidden_canvas2d_overlay_allowed {
+                (
+                    CanvasKitReplayStatus::CompatOverlay,
+                    CanvasKitReplayReason::CompatOverlayAllowed,
+                    true,
+                )
+            } else {
+                (
+                    CanvasKitReplayStatus::DirectRequired,
+                    CanvasKitReplayReason::HiddenOverlayForbidden,
+                    false,
+                )
+            };
         self.push(CanvasKitReplayItem {
             path: format!("{path}/cacheHint"),
             op_type: "cacheHint",
@@ -433,7 +455,7 @@ impl CanvasKitReplayPlanBuilder {
         op_type: &'static str,
         feature: CanvasKitReplayFeature,
     ) -> CanvasKitReplayItem {
-        if self.mode.allows_canvas2d_overlay() {
+        if self.policy.hidden_canvas2d_overlay_allowed {
             CanvasKitReplayItem {
                 path,
                 op_type,

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -36,7 +36,7 @@ impl CanvasKitReplayMode {
     }
 
     pub fn allows_canvas2d_overlay(self) -> bool {
-        matches!(self, Self::Compat)
+        false
     }
 }
 
@@ -220,7 +220,7 @@ impl CanvasKitReplayPlanBuilder {
         CanvasKitReplayPlan {
             mode: self.mode,
             hidden_canvas2d_overlay_allowed: self.mode.allows_canvas2d_overlay(),
-            direct_replay_required: matches!(self.mode, CanvasKitReplayMode::Default),
+            direct_replay_required: true,
             summary: self.summary,
             items: self.items,
             text_variants,
@@ -656,7 +656,7 @@ mod tests {
     }
 
     #[test]
-    fn compat_mode_reports_transition_overlay_for_image() {
+    fn compat_mode_keeps_image_on_direct_replay_contract() {
         let tree = tree_with_ops(vec![PaintOp::Image {
             bbox: bbox(),
             image: ImageNode::new(1, Some(vec![1, 2, 3])),
@@ -665,11 +665,17 @@ mod tests {
 
         let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
 
-        assert_eq!(plan.summary.direct_required_items, 0);
-        assert_eq!(plan.summary.compat_overlay_items, 1);
-        assert_eq!(plan.summary.hidden_overlay_violations, 0);
-        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::CompatOverlay);
-        assert!(plan.items[0].compat_overlay_allowed);
+        assert!(!plan.hidden_canvas2d_overlay_allowed);
+        assert!(plan.direct_replay_required);
+        assert_eq!(plan.summary.direct_required_items, 1);
+        assert_eq!(plan.summary.compat_overlay_items, 0);
+        assert_eq!(plan.summary.hidden_overlay_violations, 1);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(
+            plan.items[0].reason,
+            CanvasKitReplayReason::HiddenOverlayForbidden
+        );
+        assert!(!plan.items[0].compat_overlay_allowed);
     }
 
     #[test]
@@ -720,7 +726,10 @@ mod tests {
         );
 
         let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
-        assert_eq!(compat_plan.summary.compat_overlay_items, 2);
+        assert!(!compat_plan.hidden_canvas2d_overlay_allowed);
+        assert!(compat_plan.direct_replay_required);
+        assert_eq!(compat_plan.summary.direct_required_items, 2);
+        assert_eq!(compat_plan.summary.compat_overlay_items, 0);
     }
 
     #[test]
@@ -748,7 +757,8 @@ mod tests {
 
         let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
         assert_eq!(compat_plan.summary.direct_items, 1);
-        assert_eq!(compat_plan.summary.compat_overlay_items, 1);
+        assert_eq!(compat_plan.summary.direct_required_items, 1);
+        assert_eq!(compat_plan.summary.compat_overlay_items, 0);
         assert_eq!(compat_plan.items[1].detail.as_deref(), Some("verticalText"));
     }
 
@@ -797,7 +807,7 @@ mod tests {
         let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
         assert_eq!(
             compat_plan.items[0].status,
-            CanvasKitReplayStatus::CompatOverlay
+            CanvasKitReplayStatus::DirectRequired
         );
     }
 

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -380,6 +380,8 @@ impl HwpDocument {
     /// CanvasKit direct replay 정책 진단을 JSON 문자열로 반환한다.
     ///
     /// `mode` 는 `"default"` 또는 `"compat"` 를 받는다. 빈 문자열은 `"default"` 로 처리한다.
+    /// 현재 두 mode 모두 hidden Canvas2D overlay 없이 direct replay required 정책을 따른다.
+    /// `compat` 는 API/URL 호환성과 이후 보수적인 direct replay 튜닝을 위해 남겨 둔 선택지다.
     #[wasm_bindgen(js_name = getCanvasKitReplayPlan)]
     pub fn get_canvaskit_replay_plan(&self, page_num: u32, mode: &str) -> Result<String, JsValue> {
         self.get_canvaskit_replay_plan_native(page_num, mode)

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -377,7 +377,7 @@ impl HwpDocument {
             .map_err(|e| e.into())
     }
 
-    /// CanvasKit direct replay/compat overlay 정책 진단을 JSON 문자열로 반환한다.
+    /// CanvasKit direct replay 정책 진단을 JSON 문자열로 반환한다.
     ///
     /// `mode` 는 `"default"` 또는 `"compat"` 를 받는다. 빈 문자열은 `"default"` 로 처리한다.
     #[wasm_bindgen(js_name = getCanvasKitReplayPlan)]

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -106,8 +106,8 @@ fn test_canvaskit_replay_plan_export_uses_mode_policy() {
         .get_canvaskit_replay_plan_native(0, "compat")
         .expect("compat CanvasKit plan should export");
     assert!(compat_json.contains("\"mode\":\"compat\""));
-    assert!(compat_json.contains("\"hiddenCanvas2dOverlayAllowed\":true"));
-    assert!(compat_json.contains("\"directReplayRequired\":false"));
+    assert!(compat_json.contains("\"hiddenCanvas2dOverlayAllowed\":false"));
+    assert!(compat_json.contains("\"directReplayRequired\":true"));
 
     let invalid = doc.get_canvaskit_replay_plan_native(0, "canvas2d");
     let error = invalid.expect_err("unsupported CanvasKit replay mode should fail");


### PR DESCRIPTION
## What

- CanvasKit `compat` replay diagnostics를 Canvas2D overlay 허용이 아니라 direct replay required policy로 고정합니다.
- WASM/Studio fallback `getCanvasKitReplayPlan`도 `hiddenCanvas2dOverlayAllowed=false`, `directReplayRequired=true`를 반환하도록 맞춥니다.
- CanvasKit replay mode별 policy를 `DIRECT_ONLY` 계약으로 모아서 `compat`가 hidden Canvas2D overlay fallback으로 해석되지 않게 합니다.
- layer schema constant export가 `LAYER_TREE_SCHEMA`와 동기화되는지 테스트를 보강합니다.
- Studio regression test로 CanvasKit renderer가 Canvas2D overlay replay를 들여오지 않고, fallback replay plan도 direct contract를 유지하는지 확인합니다.

## Why

P16에서 browser CanvasKit direct renderer가 들어갔으므로, P17은 실제 coverage를 크게 넓히기 전에 replay contract를 먼저 닫는 단계입니다.

중요한 기준은 `default`와 `compat` 모두 Canvas2D overlay fallback이 아니라는 점입니다. `compat`는 보수적인 direct replay mode일 뿐, hidden Canvas2D paint로 unsupported op를 덮는 모드가 아닙니다. 따라서 native/WASM diagnostics와 Studio fallback bridge가 같은 contract를 말해야 합니다.

## Compatibility

- 기본 renderer는 계속 Canvas2D입니다.
- CanvasKit은 opt-in path입니다.
- public native Skia/PDF API는 바꾸지 않습니다.
- CanvasKit full parity를 이 PR에서 닫지 않습니다.

## Non-goals

- Raster image/effect coverage 확장은 P18로 넘깁니다.
- Text/glyph advanced payload gates는 P19로 넘깁니다.
- Renderer sweep/WebGPU/performance artifact는 P20으로 넘깁니다.
- PDF export는 P21로 넘깁니다.

## Validation

- `wasm-pack build --target web --dev`
- `npm --prefix rhwp-studio test`
- `npm --prefix rhwp-studio run build`
- `cargo test canvaskit --lib`
- `cargo test layer_tree_schema_constants_match_schema --lib`
- `cargo fmt --check`
- `git diff --check`

Refs #536