### PR TITLE
fix(text_measurement): U+00B7 폭 폰트 metric 정합 — 비례폰트 .notdef 위장값 가드

### DIFF
--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1352,6 +1352,36 @@ pub(crate) fn resolved_to_text_style(
 
 // ── 내장 폰트 메트릭 측정 ───────────────────────────────────────────
 
+/// 폰트가 고정폭(monospace)인지 판정한다.
+///
+/// Basic Latin (U+0021~U+007E) 의 0 이 아닌 글자폭이 모두 동일하면 monospace.
+/// 돋움체/바탕체/굴림체 등 한컴 고정폭 폰트는 `·` 를 포함한 모든 글리프가
+/// em_size 폭을 가지므로, U+00B7 의 `.notdef` 위장값 가드에서 이들을 제외해
+/// 전각 측정을 보존하기 위함이다 (Issue #630, aift 목차 right-tab 정합).
+fn is_monospace_metric(metric: &font_metrics_data::FontMetric) -> bool {
+    let mut common: Option<u16> = None;
+    let mut count = 0u32;
+    for range in metric.latin_ranges {
+        if range.start > 0x007E || range.end < 0x0021 {
+            continue;
+        }
+        for (i, &w) in range.widths.iter().enumerate() {
+            let code = range.start + i as u32;
+            if !(0x0021..=0x007E).contains(&code) || w == 0 {
+                continue;
+            }
+            count += 1;
+            match common {
+                None => common = Some(w),
+                Some(cw) if cw != w => return false,
+                _ => {}
+            }
+        }
+    }
+    // 표본이 충분할 때만 monospace 로 판정 (Latin 글리프가 거의 없는 폰트 오판 방지).
+    count >= 16
+}
+
 /// 내장 폰트 메트릭으로 문자 폭 측정 (em 단위 → px 변환)
 ///
 /// 내장 메트릭이 있으면 JS 브릿지 호출 없이 즉시 반환.
@@ -1386,7 +1416,17 @@ fn measure_char_width_embedded(
         // glyph_w 가 비정상 fullwidth (>= em_size) 일 때만 0.3 em 강제 — 함초롬
         // 바탕 (0.32) / Pretendard (0.22) 등 정상 DB 값은 조건 미충족으로 영향 없음.
         let is_narrow_unicode_punct = matches!(c, '\u{2018}' | '\u{2019}' | '\u{2027}');
-        if is_narrow_unicode_punct && glyph_w >= mm.metric.em_size {
+        // [U+00B7 .notdef 위장값 정정] 비례폰트(휴먼명조 등)가 `·` (가운뎃점)
+        // 글리프를 갖지 않으면 cmap 이 .notdef(glyph 0) 로 매핑돼 advance 가
+        // em_size(전각) 로 기록된다. 한컴은 이 경우 점 글리프를 가진 대체
+        // 폰트(바탕 ≈0.33em 등)로 `·` 를 렌더하므로 전각 advance 는 PDF 대비
+        // 과대 (시·군 점 좌우 공백 큼). 비례폰트에서 U+00B7 이 전각이면 위장값
+        // 으로 보고 0.3em 으로 정정한다. 고정폭(monospace) 폰트(돋움체 등)는
+        // 모든 글리프가 em_size 이므로 제외 — 해당 `·` 는 진짜 전각이다
+        // (Issue #630, aift 목차 right-tab 정합 보존).
+        let is_b7_notdef_artifact =
+            c == '\u{00B7}' && glyph_w >= mm.metric.em_size && !is_monospace_metric(mm.metric);
+        if (is_narrow_unicode_punct && glyph_w >= mm.metric.em_size) || is_b7_notdef_artifact {
             (mm.metric.em_size as f64 * 0.3) as u16
         } else if is_halfwidth_punct && glyph_w >= mm.metric.em_size {
             mm.metric.em_size / 2
@@ -2180,6 +2220,33 @@ mod tests {
             expected,
             dot_advance,
             expected / 2.0
+        );
+    }
+
+    /// [U+00B7 .notdef 위장값 정정] 비례폰트(휴먼명조)에서 `·`(U+00B7) 글리프
+    /// 부재로 cmap 이 .notdef(em_size) 로 위장 → 전각 측정되던 것을 narrow 로
+    /// 정정한다. 한컴은 점 글리프를 가진 대체 폰트(바탕 ≈0.33em)로 `·` 를
+    /// 렌더하므로 한컴 PDF 정합. 고정폭 폰트(돋움체)는 영향 없음 —
+    /// test_630_middle_dot_full_width_in_registered_font 가 전각 보존을 가드.
+    #[test]
+    fn test_b7_notdef_artifact_narrow_in_proportional_font() {
+        let m = EmbeddedTextMeasurer;
+        let style = TextStyle {
+            font_family: "휴먼명조".to_string(),
+            font_size: 20.0,
+            ratio: 1.0,
+            ..Default::default()
+        };
+        let positions = m.compute_char_positions("가\u{00B7}나", &style);
+        assert!(positions.len() >= 3, "positions should have ≥ 3 entries");
+        let dot_advance = positions[2] - positions[1];
+        // 비례폰트의 .notdef 위장 전각(≈20px) 이 아니라 narrow(0.3em ≈ 6px) 여야 함.
+        assert!(
+            dot_advance <= style.font_size * 0.4,
+            "휴먼명조의 `·` (U+00B7) 는 .notdef 위장 전각이 아니라 narrow \
+             (≤ font_size * 0.4 = {:.2}) 로 측정되어야 함, got {:.2}",
+            style.font_size * 0.4,
+            dot_advance
         );
     }
 


### PR DESCRIPTION
## 배경 / 원인

`·` (U+00B7 MIDDLE DOT, 가운뎃점)은 한글 문서에서 매우 흔하다 (예: `시·군`,
`4급 이상·배우자`).

휴먼명조·HY신명조·한양 계열 등 다수의 비례폰트는 자체 `·` 글리프를 갖지
않는다. 이때 폰트 cmap이 U+00B7을 `.notdef`(glyph 0)로 매핑하고 `.notdef`의
advance는 통상 `em_size`(전각)이므로, 폰트 메트릭 DB에 해당 폰트의 U+00B7
폭이 **전각(1.0em)으로 위장 기록**된다.

한컴은 이 경우 `·` 글리프를 가진 대체 폰트(바탕 등, ≈0.33em)로 점을 렌더한다.
따라서 rhwp가 위장된 전각 폭을 그대로 쓰면 가운뎃점 좌우 공백이 한컴 대비
비정상으로 벌어진다.

## 증상 (한컴2024 vs rhwp)
시·군, 4급 이상·배우자 등에서 가운뎃점 좌우 공백이 벌어진다 (좌: 한컴2024, 우: rhwp).
### before
<img width="932" height="259" alt="점고치기 전" src="https://github.com/user-attachments/assets/b0a21052-a61e-4228-99d9-f342a991acd8" />

### after
<img width="1632" height="378" alt="점고치기 후" src="https://github.com/user-attachments/assets/d5a723d5-7796-4665-b9bd-9d8fcfb1a984" />


## 변경 내용

`measure_char_width_embedded`에 가드를 추가한다.

- `c == U+00B7` && `glyph_w >= em_size`(전각) && **비례폰트** → 0.3em으로 정정
- 고정폭(monospace) 폰트(돋움체·바탕체 등)는 모든 글리프가 `em_size`이고
  `·`도 진짜 전각이므로 제외 — 신규 헬퍼 `is_monospace_metric`(Basic Latin
  글자폭이 모두 동일한지)로 판별

가드는 native·WASM 공유 함수에 위치하여 양 렌더 경로에 동시 적용된다.

## 영향 범위

폰트 메트릭 DB 595종 중 **70종**이 해당한다 (비례폰트 + U+00B7 위장 전각):
HY 계열 36종(HY신명조·HY명조·HYGothic 류·HY견고딕·HY궁서·HY헤드라인 등),
휴먼 계열 13종, MD 5종, YJ 9종, 안상수 4종, 펜흘림 1종.
monospace 4종(BatangChe/DotumChe/GulimChe/GungsuhChe)은 가드가 제외한다.

본 저장소 `samples/`의 HWPX 50종 중 30종이 위 비례폰트를 사용한다.

## 근거 — 한컴 변환 PDF 좌표 측정

`·` 앞·뒤 글자의 x좌표로 측정한 advance (em 비율):

| 대상 | 폰트 | 한컴 PDF | rhwp (전) | rhwp (후) |
|---|---|---|---|---|
| 본문 `시·군` | 휴먼명조 (비례) | 0.34em | 1.02em | 0.32em |
| 본문 `이상·배우자` | 휴먼명조 (비례) | 0.34em | 1.00em | 0.30em |
| 목차 `기술·제품` | 돋움체 (고정폭) | 1.01em | 1.00em | 1.00em |

`pdf/aift-2022.pdf` 목차의 `·`는 돋움체(고정폭)라 전각이며 정정 후에도 보존된다.

## 검증

- `cargo test --lib`: 1324 passed
- `cargo test --test svg_snapshot`: 8/8 — `issue_147_aift_page3`(돋움체 목차
  전각) 불변
- `cargo clippy -- -D warnings`: clean / `cargo fmt --check`: clean
- 회귀 테스트 `test_b7_notdef_artifact_narrow_in_proportional_font` 추가
- native·WASM 양 경로 동시 적용 (공유 함수)

## sweep 영향 예고

비례폰트 + U+00B7 조합이 등장하는 페이지의 가운뎃점이 narrow로 바뀐다.
이는 의도된 한컴 정합 정정이며, golden 8종은 불변임을 확인했다.

## Issue #630 과의 관계

Issue #630(돋움체 목차 `·` 전각 측정)은 본 변경과 무관하며 그대로 옳다 —
돋움체는 고정폭이라 가드가 발동하지 않아 전각이 보존된다. 본 PR은 #630이
다루지 않은 비례폰트의 위장 전각만을 정정한다. 좁은 구두점
(U+2018/U+2019/U+2027) 폭 분류를 다룬 PR #1026과도 독립적이다 — 본 변경은
U+00B7 전용이다.