### PR TITLE
Task #1070: HWPX TAC 표 line0 + 본문줄 post-text 표줄 제외 — 본문 하단 overflow 해소 (closes #1070)

### DIFF
--- a/mydocs/plans/task_m100_1070.md
+++ b/mydocs/plans/task_m100_1070.md
@@ -1,0 +1,44 @@
+# 수행계획서 — Task #1070: TAC 표 문단 후속/제목 텍스트 표 높이만큼 추가 하강 overflow
+
+- 이슈: edwardkim/rhwp#1070
+- 브랜치: `local/task1070` (stream/devel `be2a71c4` 기준)
+- 관련: #1068(해소 — 별개 원인) 의 친척 결함. 본 건은 lh 이중계상이 아님.
+
+## 목표
+거의 한 페이지 크기 `treat_as_char` 표가 있는 문단에서, 표는 거의 fit하나 같은 문단의
+텍스트(PartialParagraph)가 표 높이만큼 더 아래로 그려져 본문 하단을 수백 px 넘는 overflow를
+해소한다(한컴 PDF 정합).
+
+## 재현 (현재 base + #1068 무관)
+| 파일 | 문단 | overflow |
+|------|------|----------|
+| `2025년 기부·답례품…양식.hwpx` | pi=25 | 472px |
+| `hwpx/hwpx-h-02.hwpx` | pi=51 | 348px |
+| `hwpx/2025년 2분기 해외직접투자 (최종).hwpx` | pi=51 | 348px (동일 양식) |
+
+## 사전 진단 (조사 출발점, 가설)
+- dump-pages(기부·답례품 pi=25): `Table pi=25` + `PartialParagraph pi=25 lines=0..2`.
+  PartialParagraph가 **표줄(line0, lh=32352=표높이)까지 포함** → 텍스트가 표 높이만큼 하강.
+- `ls[0] lh=32352(표높이) th=32352`, `ls[1] lh=1200` — 표줄 lh는 실제 linesegarray 값(정상).
+  → #1068 의 `already_covered` 가드가 적용되어 lh 보정 미발동 = **lh 이중계상 아님**.
+- 의심 지점: `place_table_with_text`(typeset.rs:2517) 의 `post_table_start`(2624)가
+  `table.attr & 0x01 != 0` 에 의존. HWPX TAC 표는 비트0=0 → `pre_table_end_line.max(1)`
+  분기 미진입 → post_table_start=0 → 표줄(line0)이 post-text 에 포함 → 이중 그리기.
+
+## 접근 (단계 개요 — 상세는 구현계획서)
+1. **조사**: 위 가설을 DIAG 로 확정(post_table_start, pre_table_end_line, 표줄 인덱스).
+   3 파일 공통 경로 확인. #1068 실험B(블록 경로 attr↔treat_as_char 동일시)가 왜
+   sample16/aift/mel-001 을 회귀시켰는지 구조 차이 규명(이번 정밀 조건의 근거).
+2. **설계**: 표줄을 post-text 에서 정밀 제외하는 최소 조건(실험B 광범위 회귀 회피).
+3. **구현**: typeset.rs 최소 변경 + 단위 검증.
+4. **회귀검증**: 3 파일 해소 + 전수 sweep 회귀 0 + 골든 8 + cargo test + fmt/clippy.
+
+## 산출물
+- `plans/task_m100_1070_impl.md`(구현계획서), `working/task_m100_1070_stage{N}.md`,
+  `report/task_m100_1070_report.md`.
+
+## 리스크
+- #1068 실험B 처럼 "HWPX TAC 표 = HWP5 TAC" 광범위 동일시는 sample16/aift/mel-001 회귀.
+  → 본 타스크는 **표줄 post-text 포함 케이스만** 정밀 타깃. Stage 2 에서 비회귀 케이스
+  (tac-img-*, tac-case-*, table-in-tbox) 모순 점검 필수.
+- 공개 픽스처: 재현 3 파일 모두 tracked 공개 샘플 → 회귀 가드 추가 가능.

--- a/mydocs/plans/task_m100_1070_impl.md
+++ b/mydocs/plans/task_m100_1070_impl.md
@@ -1,0 +1,60 @@
+# 구현계획서 — Task #1070: TAC 표 문단 후속 텍스트 표 높이만큼 추가 하강 overflow
+
+- 이슈: edwardkim/rhwp#1070
+- 브랜치: `local/task1070` (stream/devel `be2a71c4` 기준)
+- 수행계획서: `task_m100_1070.md` (승인 완료)
+
+## 관련 코드 (정독 출발점)
+
+- `place_table_with_text`(`typeset.rs:2517`):
+  - `pre_table_end_line` 산출 (2529~) — 표줄 인덱스 판정(lh 기반 find).
+  - `tac_wrap_split`(2597) — `treat_as_char && pre_end>0 && pre_end<total_lines`.
+  - **`post_table_start`(2622~2630)** — 핵심 의심처. 2624 `else if table.attr & 0x01 != 0`
+    분기가 HWPX TAC 표(비트0=0)에서 미진입 → else(2629) `pre_table_end_line`(=0) →
+    표줄(line0) 포함.
+  - `should_add_post_text`(2639) / post PartialParagraph push(2644~).
+- 표 디스패치 + TAC 높이 보정(2332, 2421~2465) — attr&0x01 의존 사이트.
+- 비교 기준: #1068 실험B revert 기록(`working/task_m100_1068_stage4.md`) — 블록 경로
+  attr↔treat_as_char 동일시가 sample16/aift/mel-001 회귀.
+
+## 단계 (4단계)
+
+### Stage 1 — 조사 + 회귀 구조 규명 (소스 무변경)
+- DIAG 로 3 재현 파일(기부·답례품 pi=25, hwpx-h-02/해외직접투자 pi=51)의
+  `pre_table_end_line / post_table_start / total_lines / 표줄 인덱스` 확정.
+- **#1068 실험B 회귀 구조 규명**: sample16/aift/mel-001 의 해당 TAC 표 문단 구조
+  (pre_table_end_line, 표 위치, post-text 유무)를 dump 로 비교 → "표줄이 line0 이고
+  post-text 가 표줄을 포함하는 케이스" 와 "정상 케이스" 의 판별 신호 도출.
+- 산출물: `working/task_m100_1070_stage1.md`.
+
+### Stage 2 — 설계 + 페이퍼 검증 (소스 무변경)
+- 정밀 조건 설계: post-text 가 **표줄(pre_table_end_line)을 포함하지 않도록** 보정하되,
+  실험B 광범위 회귀를 피하는 최소 게이트.
+  - 후보: `treat_as_char` 표 + 표줄이 식별됨(pre_table_end_line 유효) + post-text 가
+    표줄을 포함(post_table_start ≤ pre_table_end_line) → post_table_start 를
+    `pre_table_end_line + 1` 로 보정.
+  - tac_wrap_split(표줄이 마지막 줄이 아닐 때) 와의 경계 명시.
+- 비회귀 케이스 표(tac-img-*, tac-case-*, table-in-tbox, sample16/aift/mel-001)로
+  모순 점검 — 각 케이스에서 보정 발동 여부 + 기대 동작 일치 확인.
+- 산출물: `working/task_m100_1070_stage2.md`.
+
+### Stage 3 — 구현
+- `place_table_with_text` post_table_start 산식에 Stage 2 정밀 조건 반영. 최소 변경.
+- 단위 검증: 3 파일 overflow 해소 + 6 비회귀 파일(#1068 회귀세트) smoke.
+- 산출물: 소스 + `working/task_m100_1070_stage3.md`.
+
+### Stage 4 — 회귀 검증 + 회귀 가드
+- 3 재현 파일 overflow 해소. 전수 sweep(samples hwp/hwpx) LAYOUT_OVERFLOW 합 회귀 0.
+- 골든 SVG 8 종, `cargo test --release`(lib + 통합), clippy/fmt(변경 파일).
+- 공개 픽스처 기반 회귀 가드 1~N 추가(`tests/issue_1070_*.rs`).
+- 산출물: `working/task_m100_1070_stage4.md` → `report/task_m100_1070_report.md`.
+
+## 완료 기준
+3 재현 파일 표 문단 텍스트 overflow 해소(표 바로 아래 배치) + 비회귀 0 + 골든 회귀 0
++ 회귀 가드 통과.
+
+## 리스크
+- post_table_start 보정이 다중 TAC 표/Square wrap/페이지 분할 표와 상호작용 → Stage 2
+  경계 명시 + 비회귀 케이스 전수 점검으로 차단.
+- 표 바로 아래 텍스트가 한 페이지에 안 들어가는 경우(이월 필요)는 본 타스크 범위 외 가능 —
+  Stage 1 에서 3 파일이 "표 fit + 텍스트만 hang" 인지 "표+텍스트 page-larger" 인지 구분.

--- a/mydocs/report/task_m100_1070_report.md
+++ b/mydocs/report/task_m100_1070_report.md
@@ -1,0 +1,57 @@
+# 최종 보고서 — Task #1070: HWPX TAC 표 문단 후속 본문 표 높이만큼 하강 overflow
+
+- 이슈: edwardkim/rhwp#1070
+- 브랜치: `local/task1070` (stream/devel `be2a71c4` 기준)
+- 수정 파일: `src/renderer/typeset.rs` (1 곳) + 회귀 가드 `tests/issue_1070_*.rs` (신규)
+
+## 증상
+거의 한 페이지 크기 `treat_as_char`(TAC) 표가 첫 줄에 있고 그 뒤에 본문 줄이 있는 문단에서,
+표는 거의 fit하나 후속 본문 텍스트가 표 높이만큼 추가 하강해 편집영역 하단을 348~472px 초과.
+
+| 파일 | 문단 | overflow(전→후) |
+|------|------|------|
+| `2025년 기부·답례품…양식.hwpx` | pi=25 (page2) | 472 → 해소(표잔여 5.6) |
+| `hwpx/hwpx-h-02.hwpx` | pi=51 (page2) | 348 → 7.4 |
+| `hwpx/2025년 2분기 해외직접투자 (최종).hwpx` | pi=51 (page2) | 348 → 7.4 |
+
+## 근본 원인
+`place_table_with_text`(`typeset.rs:2517`) 의 `post_table_start` 산식이 `attr & 0x01`(HWP5
+TAC 비트)에만 의존. HWPX TAC 표는 비트0=0 → 마지막 else → `post_table_start = pre_end(=0)`
+→ 표줄(line0)이 post-text PartialParagraph(0..total_lines)에 포함 → 후속 본문 줄이 표 높이
+만큼 하강. HWP5 TAC(attr&0x01)는 `pre_end.max(1)` 로 이미 표줄 제외 → **HWPX 한정 갭**.
+
+#1068(제목줄 LINE_SEG lh over-inflation)과 외형 유사하나 별개 원인. #1068 PR 의
+`already_covered` 가드로 lh 보정이 안 되는 표(실제 linesegarray 보유)에서 발생.
+
+## 수정
+```rust
+} else if table.attr & 0x01 != 0 {
+    pre_table_end_line.max(1)
+} else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
+    // 표줄 다음에 실제 본문 줄이 있는 HWPX TAC 표: 표줄을 post-text 에서 제외
+    pre_table_end_line + 1
+} else if is_last_table && !is_first_table {
+    0
+} else {
+    pre_table_end_line
+};
+```
+`treat_as_char && total_lines > pre_end + 1`(표줄 뒤에 실제 본문 줄) 일 때만 표줄 제외.
+**단일줄 TAC 표는 불변** — 단순 blanket 확장(`|| treat_as_char`)은 단일줄 표의 post-text 까지
+제거해 mel-001 +5 회귀(Stage 1 실험으로 확정), 정밀 게이트로 회피.
+
+## 검증
+- 재현 3파일 본문 overflow 해소. dump-pages 구조 정합(`lines=0..2 → 1..2`).
+- 전수 sweep: 3057→3043 lines / 382815→376707px (−14/−6108, **회귀 0**, sample16 35→15·aift
+  5→4·tac-img-02.hwpx 7→6 개선).
+- 회귀 가드 3 신규(SVG text max_y ≤ 페이지 높이) 통과.
+- 골든 SVG 8/8, cargo test --release lib 1324 + 통합 0 failed, clippy/fmt clean.
+
+## 경계 안전성 (Stage 2 페이퍼 검증)
+신규 arm 은 `treat_as_char && pre_end==0 && total_lines>1` 만 발동. tac_wrap_split / HWP5
+attr&0x01 / 단일줄 / vertical_offset / Square wrap / 비-TAC / page-larger 와 모순 없음(전수
+sweep 0 회귀로 실증).
+
+## 후속
+A군 해소. 동일 인벤토리의 B군(kps-ai PartialTable 758px), C군(교육/실전 통합 누적 드리프트),
+D군(pr-149 Shape)은 별도 타스크.

--- a/mydocs/working/task_m100_1070_stage1.md
+++ b/mydocs/working/task_m100_1070_stage1.md
@@ -1,0 +1,71 @@
+# Stage 1 보고서 — Task #1070: 조사 + 정밀 조건 도출
+
+- 브랜치: `local/task1070` (stream/devel `be2a71c4` 기준)
+
+## 근본 원인 확정
+
+`place_table_with_text`(`typeset.rs:2517`) 의 `post_table_start`(2622) 산식:
+```rust
+} else if table.attr & 0x01 != 0 {   // HWP5 TAC → pre_end.max(1) (표줄 제외)
+    pre_table_end_line.max(1)
+} else if is_last_table && !is_first_table { 0 }
+else { pre_table_end_line }          // ← HWPX TAC(비트0=0) 가 여기로
+```
+HWPX TAC 표는 `attr & 0x01 == 0` → 마지막 else → `post_table_start = pre_table_end_line(=0)`.
+표줄(line0)이 post-text PartialParagraph(0..total_lines)에 포함 → 표줄 높이만큼 본문 줄이
+하강 → overflow.
+
+DIAG_1070 (재현):
+```
+pi=25 tac_attr=false total_lines=2 pre_end=0 post_start=0 ... includes_table_line=true
+pi=51 tac_attr=false total_lines=2 pre_end=0 post_start=0 ... includes_table_line=true
+```
+HWP5 TAC(attr&0x01)는 `pre_end.max(1)` 로 이미 표줄을 제외 → 본 결함은 **HWPX 한정 갭**.
+
+## 회귀 구조 규명 (실험)
+
+`includes_table_line=true` 신호는 재현 파일뿐 아니라 #1068 회귀세트(sample16/aift/mel-001/
+tac-img-02)의 **다수 단일줄(total_lines=1) TAC 표 문단**에서도 발동. 단순 blanket 확장이
+회귀하는 이유.
+
+### 실험 A — blanket (`attr&0x01 || treat_as_char`)
+| 파일 | baseline | A |
+|------|----------|---|
+| 재현 3 | 472/348/348 | 5.6/7.4/7.4 ✅ |
+| mel-001 | 3 | **8 (+5)** ❌ |
+| tac-img-02.hwpx | 7 | **8 (+1)** ❌ |
+| sample16-hwp5 | 35/249.5 | 20/253.3 (max +3.8) |
+
+→ 단일줄(total_lines=1) TAC 표는 `post_start=pre_end.max(1)=1`, `total_lines(1)>1` 거짓 →
+post-text 제거 → mel-001 회귀. 단일줄 표는 **건드리면 안 됨**.
+
+### 실험 B — 정밀 조건 (`treat_as_char && total_lines > pre_end + 1`)
+표줄 **다음에 실제 본문 줄이 있을 때만** 표줄 제외(단일줄 불변).
+```rust
+} else if table.attr & 0x01 != 0 {
+    pre_table_end_line.max(1)
+} else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
+    pre_table_end_line + 1
+} else if is_last_table && !is_first_table { 0 }
+else { pre_table_end_line };
+```
+| 파일 | baseline | B |
+|------|----------|---|
+| 재현 3 | 472/348/348 | **5.6/7.4/7.4** ✅ |
+| sample11-hwpx | 0 | 0 |
+| tac-img-02.hwpx | 7 | **6** ✅개선 |
+| tac-img-02.hwp | 8 | 8 |
+| sample16-hwp5 | 35 | **15** ✅개선 |
+| aift.hwpx | 5 | **4** ✅개선 |
+| mel-001.hwpx | 3 | 3 ✅불변 |
+
+## 검증 (정밀 조건 B)
+
+- **전수 sweep**(samples hwp/hwpx, overflow 97파일): baseline 3057 lines / 382815px →
+  **3043 lines / 376707px** (−14 lines, −6108px, 회귀 0·개선).
+- 골든 SVG **8/8**, cargo test --release lib **1324 passed**, clippy/fmt clean.
+
+## 결론 / 다음
+정밀 조건 B 가 재현 3파일 해소 + 4파일 개선 + 회귀 0 으로 검증됨. Stage 2(설계 페이퍼 검증
+— tac_wrap_split/다중표/Square wrap 경계 모순 점검) → Stage 3(현 소스 확정) → Stage 4(공개
+픽스처 회귀 가드 + 최종 검증).

--- a/mydocs/working/task_m100_1070_stage2.md
+++ b/mydocs/working/task_m100_1070_stage2.md
@@ -1,0 +1,41 @@
+# Stage 2 보고서 — Task #1070: 설계 페이퍼 검증 (경계 모순 점검)
+
+- 브랜치: `local/task1070`
+- 소스 무변경(설계 검증). 적용 코드는 Stage 3 확정.
+
+## 신규 arm (typeset.rs:2626~2630)
+```rust
+} else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
+    pre_table_end_line + 1
+}
+```
+`tac_wrap_split`(2622) · `attr&0x01`(2624) **다음**, `is_last&&!is_first`(2631) **앞**.
+
+## 발동 영역 (정밀)
+신규 arm 은 **`treat_as_char && pre_end == 0 && total_lines > 1`** 일 때만 실효한다(아래 도출).
+= "표가 첫 줄(line0)에 있고 그 뒤에 실제 본문 줄이 있는 HWPX TAC 표".
+
+## 경계 모순 점검
+
+| 케이스 | 선행 분기/조건 | 신규 arm 발동? | 동작 | 모순 |
+|--------|----------------|----------------|------|------|
+| tac_wrap_split (pre_end>0 && <total) | 2622 먼저 매칭 | ✗ (선행 arm) | 기존 | 없음 |
+| HWP5 TAC (attr&0x01) | 2624 먼저 매칭 | ✗ | 기존 pre_end.max(1) | 없음 |
+| HWPX TAC, pre_end==0, total>1 | 2626 매칭 | **✓** | post_start=1 (표줄 제외) | **타깃** |
+| HWPX TAC, 단일줄 (total==1, pre_end==0) | total>pre_end+1=1 거짓 | ✗ | else→pre_end(0) 기존 | 없음(mel-001 불변) |
+| vertical_offset>0 (pre_end=total) | total>total+1 거짓 | ✗ | else 기존 | 없음 |
+| Square wrap 어울림 (비-TAC) | treat_as_char 거짓 | ✗ | 기존 | 없음 |
+| 비-TAC 블록표 | treat_as_char 거짓 | ✗ | is_last&&!is_first / else | 없음 |
+| page-larger TAC (분할) | post_start 은 split 후 post-text 만 관여 | 직교 | 분할 로직 불변 | 없음 |
+
+- HWP5 attr&0x01 의 `pre_end.max(1)` 와 정합: pre_end==0 일 때 둘 다 1 → 표줄 제외 동일.
+- 다중 HWPX TAC 표 문단: `tac_table_count`(attr&0x01 카운트, HWPX=0) `<=1` 로 should_add_post_text
+  유지. 신규 arm 은 현재 표의 post_start 만 조정 → 전수 sweep 0 회귀로 실증.
+
+## 비회귀 케이스 실증 (Stage 1 재인용)
+sample11-hwpx 0→0, tac-img-02.hwp 8→8, mel-001 3→3 (단일줄 불변),
+tac-img-02.hwpx 7→6 / sample16 35→15 / aift 5→4 (다행 케이스 개선).
+
+## 결론
+신규 arm 은 타깃 패턴(HWPX TAC 표 line0 + 본문줄)만 정밀 발동하며 tac_wrap_split / HWP5 /
+단일줄 / vertical_offset / Square wrap / 비-TAC / page-larger 와 모순 없음. Stage 3 확정.

--- a/mydocs/working/task_m100_1070_stage3.md
+++ b/mydocs/working/task_m100_1070_stage3.md
@@ -1,0 +1,33 @@
+# Stage 3 보고서 — Task #1070: 구현 확정
+
+- 브랜치: `local/task1070`
+- 수정 파일: `src/renderer/typeset.rs` (1 곳, `place_table_with_text`)
+
+## 변경 (typeset.rs:2624~2630)
+`post_table_start` 산식에 HWPX TAC 표 전용 arm 추가:
+```rust
+} else if table.attr & 0x01 != 0 {
+    pre_table_end_line.max(1)
+} else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
+    // HWPX TAC 표(attr 비트0=0): 표줄(pre_table_end_line) 다음에 실제 본문 줄이
+    // 있으면 표줄을 post-text 에서 제외(HWP5 attr&0x01 의 pre_end.max(1) 와 정합).
+    // 단일 줄(표줄만)은 건드리지 않아 기존 동작 보존.
+    pre_table_end_line + 1
+} else if is_last_table && !is_first_table {
+    0
+} else {
+    pre_table_end_line
+};
+```
+
+## 단위 검증 (smoke)
+- 재현 3파일: 기부·답례품 472→**5.6**, hwpx-h-02 348→**7.4**, 해외직접투자 348→**7.4** px.
+- 회귀세트 6파일: sample11-hwpx 0, tac-img-02.hwpx **6**(←7), tac-img-02.hwp 8, sample16-hwp5
+  **15**(←35), aift **4**(←5), mel-001 3 — 회귀 0.
+
+## 빌드/품질
+- cargo build --release OK, cargo test --release lib **1324 passed** + 골든 **8/8**.
+- clippy clean, fmt clean (typeset.rs).
+
+## 다음
+Stage 4 — 공개 픽스처 회귀 가드(`tests/issue_1070_*.rs`) + 전수 sweep 최종 + 최종 보고서.

--- a/mydocs/working/task_m100_1070_stage4.md
+++ b/mydocs/working/task_m100_1070_stage4.md
@@ -1,0 +1,23 @@
+# Stage 4 보고서 — Task #1070: 회귀 가드 + 최종 검증
+
+- 브랜치: `local/task1070`
+- 신규 파일: `tests/issue_1070_tac_table_post_text_overflow.rs`
+
+## 회귀 가드 (공개 픽스처 3)
+재현 3파일 모두 tracked 공개 샘플 → SVG 좌표 기반 가드 작성.
+- 검증 방식: 영향 페이지(page 2) 렌더 → `<text>` 최대 y 가 물리 페이지 높이(1122.48px)
+  이내인지 단언. 결함 시 후속 본문이 y≈1490px(페이지 초과)로 렌더 → 단언 실패.
+- 테스트: `gibu_dalryepum_page2` / `hwpx_h_02_page2` / `haewoe_jikjeop_tuja_page2` — **3/3 통과**.
+- 임계값 근거: 수정 전 max_y≈1490px > 1122 (실패) / 수정 후 max_y≈1069.7px < 1122 (통과).
+
+## 최종 검증
+- **재현 3파일**: 기부·답례품 472→해소(표 잔여 5.6), hwpx-h-02 348→7.4, 해외직접투자 348→7.4.
+  - 구조 정합: dump-pages `PartialParagraph pi=25 lines=0..2 → 1..2`(표줄 제외).
+- **전수 sweep**(samples hwp/hwpx, overflow 97파일): baseline 3057 lines / 382815px →
+  **3043 lines / 376707px** (−14 lines, −6108px, 회귀 0·개선).
+- **cargo test --release**: lib **1324 passed** + 통합 전부 ok(신규 3 포함), FAILED 0.
+- **골든 SVG 8/8**, clippy clean, fmt clean(typeset.rs + 신규 테스트).
+
+## 결론
+HWPX TAC 표 line0 + 본문줄 post-text 표줄 포함 결함 해소. 회귀 가드 3 추가. 비회귀·골든 0.
+최종 보고서 → 작업지시자 한컴 시각 판정 → PR.

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2623,6 +2623,11 @@ impl TypesetEngine {
             (pre_table_end_line + 1).min(total_lines).max(1)
         } else if table.attr & 0x01 != 0 {
             pre_table_end_line.max(1)
+        } else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
+            // HWPX TAC 표(attr 비트0=0): 표줄(pre_table_end_line) 다음에 실제 본문 줄이
+            // 있으면 표줄을 post-text 에서 제외(HWP5 attr&0x01 의 pre_end.max(1) 와 정합).
+            // 단일 줄(표줄만)은 건드리지 않아 기존 동작 보존.
+            pre_table_end_line + 1
         } else if is_last_table && !is_first_table {
             0
         } else {

--- a/tests/issue_1070_tac_table_post_text_overflow.rs
+++ b/tests/issue_1070_tac_table_post_text_overflow.rs
@@ -1,0 +1,82 @@
+//! Issue #1070: 거의 한 페이지 크기 treat_as_char(TAC) 표가 첫 줄에 있고 그 뒤에
+//! 본문 줄이 있는 문단에서, 후속 본문 텍스트가 표 높이만큼 추가로 하강해 편집영역
+//! 하단을 넘어 렌더링되는 결함의 회귀 가드.
+//!
+//! 재현 문서 (tracked 공개 샘플):
+//! - `samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx` (page 2, pi=25, 472px)
+//! - `samples/hwpx/hwpx-h-02.hwpx` (page 2, pi=51, 348px)
+//! - `samples/hwpx/2025년 2분기 해외직접투자 (최종).hwpx` (page 2, pi=51, 348px)
+//!
+//! 결함 본질: `place_table_with_text` (typeset.rs) 의 `post_table_start` 산식이
+//! `attr & 0x01` (HWP5 TAC 비트) 에만 의존 → HWPX TAC 표(비트0=0)는 표줄(line0)을
+//! post-text PartialParagraph 에 포함 → 후속 본문 줄이 표 높이만큼 하강.
+//! 수정: `treat_as_char && total_lines > pre_end + 1` 일 때 표줄을 post-text 에서 제외
+//! (HWP5 `pre_end.max(1)` 와 정합, 단일줄 TAC 표는 불변).
+
+use std::fs;
+use std::path::Path;
+
+fn load_doc(rel: &str) -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+/// SVG 의 `height="..."` 속성값(물리 페이지 높이 px).
+fn svg_height(svg: &str) -> f64 {
+    let i = svg.find("height=\"").expect("svg height attr") + "height=\"".len();
+    let rest = &svg[i..];
+    let end = rest.find('"').expect("height close");
+    rest[..end].parse().expect("height f64")
+}
+
+/// SVG 내 모든 `<text ... y="..."`> 의 최대 y 좌표(px). 없으면 0.
+fn max_text_y(svg: &str) -> f64 {
+    let mut max = 0.0_f64;
+    let mut rest = svg;
+    while let Some(open) = rest.find("<text") {
+        let after = &rest[open..];
+        let tag_end = after.find('>').map(|g| open + g).unwrap_or(rest.len());
+        let tag = &rest[open..tag_end];
+        if let Some(yi) = tag.find(" y=\"") {
+            let yrest = &tag[yi + 4..];
+            if let Some(ye) = yrest.find('"') {
+                if let Ok(y) = yrest[..ye].parse::<f64>() {
+                    max = max.max(y);
+                }
+            }
+        }
+        rest = &rest[tag_end..];
+    }
+    max
+}
+
+/// 지정 페이지에서 본문 텍스트가 물리 페이지 높이를 넘지 않음을 검증.
+/// 결함 시 후속 본문이 y ≈ 1490px (페이지 높이 1122px 초과) 로 그려진다.
+fn assert_no_text_below_page(rel: &str, page: u32) {
+    let doc = load_doc(rel);
+    let svg = doc
+        .render_page_svg_native(page)
+        .expect("render_page_svg_native");
+    let h = svg_height(&svg);
+    let max_y = max_text_y(&svg);
+    assert!(
+        max_y <= h,
+        "{rel} page {page}: text max_y={max_y:.1} 가 페이지 높이 {h:.1} 초과 (TAC 표 post-text 하강 회귀)"
+    );
+}
+
+#[test]
+fn gibu_dalryepum_page2_no_text_overflow() {
+    assert_no_text_below_page("samples/2025년 기부·답례품 실적 지자체 보고서_양식.hwpx", 2);
+}
+
+#[test]
+fn hwpx_h_02_page2_no_text_overflow() {
+    assert_no_text_below_page("samples/hwpx/hwpx-h-02.hwpx", 2);
+}
+
+#[test]
+fn haewoe_jikjeop_tuja_page2_no_text_overflow() {
+    assert_no_text_below_page("samples/hwpx/2025년 2분기 해외직접투자 (최종).hwpx", 2);
+}


### PR DESCRIPTION
## 증상
거의 한 페이지 크기 `treat_as_char`(TAC) 표가 첫 줄에 있고 그 뒤에 본문 줄이 있는 문단에서, 표는 거의 fit하나 **후속 본문 텍스트가 표 높이만큼 추가 하강**해 편집영역 하단을 348~472px 초과 (#1070).

| 파일 | 문단 | overflow(전→후) |
|------|------|------|
| `2025년 기부·답례품…양식.hwpx` | pi=25 (page2) | 472 → 해소(표잔여 5.6) |
| `hwpx/hwpx-h-02.hwpx` | pi=51 (page2) | 348 → 7.4 |
| `hwpx/2025년 2분기 해외직접투자 (최종).hwpx` | pi=51 | 348 → 7.4 |

## 근본 원인
`place_table_with_text`(`typeset.rs`)의 `post_table_start` 가 `attr & 0x01`(HWP5 TAC 비트)에만 의존. HWPX TAC 표는 비트0=0 → 마지막 `else` → `post_table_start = pre_end(=0)` → 표줄(line0)이 post-text `PartialParagraph(0..total_lines)` 에 포함 → 후속 본문 줄이 표 높이만큼 하강.

HWP5 TAC(attr&0x01)는 `pre_end.max(1)` 로 이미 표줄을 제외 → **HWPX 한정 갭**. (#1068의 lh over-inflation 과는 별개 원인.)

## 수정
```rust
} else if table.attr & 0x01 != 0 {
    pre_table_end_line.max(1)
} else if table.common.treat_as_char && total_lines > pre_table_end_line + 1 {
    // 표줄 다음에 실제 본문 줄이 있는 HWPX TAC 표: 표줄을 post-text 에서 제외
    pre_table_end_line + 1
} else if is_last_table && !is_first_table {
    0
} else {
    pre_table_end_line
};
```
`treat_as_char && total_lines > pre_end + 1`(표줄 뒤에 실제 본문 줄) 일 때만 표줄 제외. **단일줄 TAC 표는 불변** — 단순 blanket 확장(`|| treat_as_char`)은 단일줄 표의 post-text 까지 제거해 mel-001 회귀(검증으로 확정), 정밀 게이트로 회피.

## 검증
- 재현 3파일 본문 overflow 해소 (dump-pages `lines=0..2 → 1..2`, 표줄 제외).
- 전수 sweep(samples hwp/hwpx): **3057→3043 lines / 382815→376707px** (−14/−6108, **회귀 0**, `hwp3-sample16-hwp5.hwpx` 35→15 · `aift.hwpx` 5→4 · `tac-img-02.hwpx` 7→6 개선).
- 회귀 가드 3 신규(`tests/issue_1070_tac_table_post_text_overflow.rs` — SVG `<text>` max_y ≤ 페이지 높이) 통과.
- golden SVG **8/8**, `cargo test --release` lib **1324 passed** + 통합 0 failed, clippy/fmt clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)