### PR TITLE
feat: 플랫폼별 메뉴 단축키 표시 정리 (#978)

### DIFF
--- a/rhwp-studio/src/command/extension-api.ts
+++ b/rhwp-studio/src/command/extension-api.ts
@@ -1,6 +1,7 @@
 import type { CommandDef } from './types';
 import type { CommandRegistry } from './registry';
 import type { CommandDispatcher } from './dispatcher';
+import { formatShortcutLabel } from '@/engine/navigation-keymap';
 
 /**
  * 고객사 확장 API
@@ -60,7 +61,7 @@ export class StudioExtensionAPI {
     if (def.shortcutLabel) {
       const shortcut = document.createElement('span');
       shortcut.className = 'md-shortcut';
-      shortcut.textContent = def.shortcutLabel;
+      shortcut.textContent = formatShortcutLabel(def.shortcutLabel);
       item.appendChild(shortcut);
     }
 

--- a/rhwp-studio/src/engine/navigation-keymap.ts
+++ b/rhwp-studio/src/engine/navigation-keymap.ts
@@ -103,3 +103,11 @@ export function shouldSuppressUnmappedNavigation(
     !input.metaKey &&
     (key === 'ArrowLeft' || key === 'ArrowRight');
 }
+
+export function formatShortcutLabel(
+  label: string,
+  platform: PlatformKind = detectPlatformKind(),
+): string {
+  if (platform !== 'mac') return label;
+  return label.replace(/\bCtrl\b/g, 'Command');
+}

--- a/rhwp-studio/src/ui/command-palette.ts
+++ b/rhwp-studio/src/ui/command-palette.ts
@@ -1,6 +1,7 @@
 import type { CommandRegistry } from '@/command/registry';
 import type { CommandDispatcher } from '@/command/dispatcher';
 import type { CommandDef } from '@/command/types';
+import { formatShortcutLabel } from '@/engine/navigation-keymap';
 
 /**
  * `/` 커맨드 팔레트
@@ -154,7 +155,7 @@ export class CommandPalette {
     return this.items.filter(def => {
       if (def.label.toLowerCase().includes(q)) return true;
       if (def.id.toLowerCase().includes(q)) return true;
-      if (def.shortcutLabel?.toLowerCase().includes(q)) return true;
+      if (def.shortcutLabel && formatShortcutLabel(def.shortcutLabel).toLowerCase().includes(q)) return true;
       return false;
     });
   }
@@ -185,7 +186,7 @@ export class CommandPalette {
       if (def.shortcutLabel) {
         const kbd = document.createElement('span');
         kbd.className = 'cp-item-shortcut';
-        kbd.textContent = def.shortcutLabel;
+        kbd.textContent = formatShortcutLabel(def.shortcutLabel);
         row.appendChild(kbd);
       }
 

--- a/rhwp-studio/src/ui/command-palette.ts
+++ b/rhwp-studio/src/ui/command-palette.ts
@@ -155,7 +155,7 @@ export class CommandPalette {
     return this.items.filter(def => {
       if (def.label.toLowerCase().includes(q)) return true;
       if (def.id.toLowerCase().includes(q)) return true;
-      if (def.shortcutLabel && formatShortcutLabel(def.shortcutLabel).toLowerCase().includes(q)) return true;
+      if (def.shortcutLabel && (def.shortcutLabel.toLowerCase().includes(q) || formatShortcutLabel(def.shortcutLabel).toLowerCase().includes(q))) return true;
       return false;
     });
   }

--- a/rhwp-studio/src/ui/context-menu.ts
+++ b/rhwp-studio/src/ui/context-menu.ts
@@ -1,5 +1,6 @@
 import type { CommandDispatcher } from '@/command/dispatcher';
 import type { CommandRegistry } from '@/command/registry';
+import { formatShortcutLabel } from '@/engine/navigation-keymap';
 
 /** 컨텍스트 메뉴 항목 정의 */
 export interface ContextMenuItem {
@@ -61,7 +62,7 @@ export class ContextMenu {
       if (def.shortcutLabel) {
         const shortcut = document.createElement('span');
         shortcut.className = 'md-shortcut';
-        shortcut.textContent = def.shortcutLabel;
+        shortcut.textContent = formatShortcutLabel(def.shortcutLabel);
         row.appendChild(shortcut);
       }
 

--- a/rhwp-studio/tests/navigation-keymap.test.ts
+++ b/rhwp-studio/tests/navigation-keymap.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   detectPlatformKind,
+  formatShortcutLabel,
   getNavigationAction,
   shouldSuppressUnmappedNavigation,
   type NavigationKeyInput,
@@ -103,4 +104,34 @@ test('일반 command shortcut 입력은 navigation helper가 처리하지 않는
 test('IME pending nav처럼 key가 Process여도 code로 navigation을 판별한다', () => {
   assert.equal(action({ key: 'Process', code: 'ArrowLeft', ctrlKey: true }, 'other'), 'wordBackward');
   assert.equal(action({ key: 'Process', code: 'ArrowRight', altKey: true }, 'mac'), 'wordForward');
+});
+
+test('formatShortcutLabel은 macOS에서 Ctrl을 Command로 치환한다', () => {
+  assert.equal(formatShortcutLabel('Ctrl+S', 'mac'), 'Command+S');
+  assert.equal(formatShortcutLabel('Ctrl+Shift+Z', 'mac'), 'Command+Shift+Z');
+  assert.equal(formatShortcutLabel('Ctrl+Alt+C', 'mac'), 'Command+Alt+C');
+  assert.equal(formatShortcutLabel('Ctrl+M,K', 'mac'), 'Command+M,K');
+  assert.equal(formatShortcutLabel('Ctrl+Enter', 'mac'), 'Command+Enter');
+});
+
+test('formatShortcutLabel은 Windows/Linux에서 원본을 유지한다', () => {
+  assert.equal(formatShortcutLabel('Ctrl+S', 'other'), 'Ctrl+S');
+  assert.equal(formatShortcutLabel('Ctrl+Shift+Z', 'other'), 'Ctrl+Shift+Z');
+});
+
+test('formatShortcutLabel은 Ctrl이 없는 라벨을 변경하지 않는다', () => {
+  assert.equal(formatShortcutLabel('F7', 'mac'), 'F7');
+  assert.equal(formatShortcutLabel('Alt+G', 'mac'), 'Alt+G');
+  assert.equal(formatShortcutLabel('Shift+Num +', 'mac'), 'Shift+Num +');
+  assert.equal(formatShortcutLabel('H', 'mac'), 'H');
+  assert.equal(formatShortcutLabel('Alt+Shift+V', 'mac'), 'Alt+Shift+V');
+});
+
+test('formatShortcutLabel은 테스트 override를 존중한다', () => {
+  const globalForTest = globalThis as typeof globalThis & { __rhwpTestPlatformKind?: PlatformKind };
+  globalForTest.__rhwpTestPlatformKind = 'mac';
+  assert.equal(formatShortcutLabel('Ctrl+S'), 'Command+S');
+  globalForTest.__rhwpTestPlatformKind = 'other';
+  assert.equal(formatShortcutLabel('Ctrl+S'), 'Ctrl+S');
+  delete globalForTest.__rhwpTestPlatformKind;
 });

--- a/rhwp-studio/tests/navigation-keymap.test.ts
+++ b/rhwp-studio/tests/navigation-keymap.test.ts
@@ -129,9 +129,12 @@ test('formatShortcutLabel은 Ctrl이 없는 라벨을 변경하지 않는다', (
 
 test('formatShortcutLabel은 테스트 override를 존중한다', () => {
   const globalForTest = globalThis as typeof globalThis & { __rhwpTestPlatformKind?: PlatformKind };
-  globalForTest.__rhwpTestPlatformKind = 'mac';
-  assert.equal(formatShortcutLabel('Ctrl+S'), 'Command+S');
-  globalForTest.__rhwpTestPlatformKind = 'other';
-  assert.equal(formatShortcutLabel('Ctrl+S'), 'Ctrl+S');
-  delete globalForTest.__rhwpTestPlatformKind;
+  try {
+    globalForTest.__rhwpTestPlatformKind = 'mac';
+    assert.equal(formatShortcutLabel('Ctrl+S'), 'Command+S');
+    globalForTest.__rhwpTestPlatformKind = 'other';
+    assert.equal(formatShortcutLabel('Ctrl+S'), 'Ctrl+S');
+  } finally {
+    delete globalForTest.__rhwpTestPlatformKind;
+  }
 });


### PR DESCRIPTION
## 요약

macOS에서 메뉴/컨텍스트 메뉴/커맨드 팔레트의 단축키 라벨이 `Ctrl+S` 대신 `Command+S`로 표시되도록 합니다. Windows/Linux에서는 기존과 동일하게 `Ctrl+S`로 표시됩니다.

Closes #978

## 변경 사항

- `navigation-keymap.ts`에 `formatShortcutLabel(label, platform?)` 함수 추가
  - `detectPlatformKind()` 재사용하여 플랫폼 감지
  - `\bCtrl\b` → `Command` 치환 (word boundary로 정확 매칭)
  - `Alt`, `Shift`, `F키`, 단일 문자 라벨은 변경 없음
- 3곳의 단축키 표시 렌더링에 일관 적용:
  - `extension-api.ts` (메뉴바 항목 추가 API)
  - `context-menu.ts` (우클릭 컨텍스트 메뉴)
  - `command-palette.ts` (커맨드 팔레트 표시 + 검색 필터)
- 단위 테스트 4개 추가

## 설계 판단

- `shortcutLabel` 원본 데이터는 수정하지 않고, **렌더링 시점에만** 포맷 변환합니다
- 1차 구현은 이슈 명세에 따라 `Command+S` 텍스트 표기를 사용합니다 (`⌘S` 심볼 표기는 별도 디자인 판단 필요)
- `detectPlatformKind()`의 테스트 override (`__rhwpTestPlatformKind`)를 존중하여 테스트 격리 가능

## 검증

```bash
cd rhwp-studio
node --experimental-strip-types --test tests/navigation-keymap.test.ts
# 16 pass, 0 fail (기존 12 + 신규 4)
```