### PR TITLE
feat: F3 문장 단계 확장 추가 — 한컴 5단계 정합 (#839)

### DIFF
--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -56,7 +56,7 @@ export class CursorState {
 
   // ─── F5 본문 블록 선택 모드 (#220) ────────────────────────
   private _blockSelectionMode = false;
-  private _expandPhase = 0; // F3 확장 단계: 0=none, 1=word, 2=paragraph, 3=section, 4=document
+  private _expandPhase = 0; // F3 확장 단계: 0=none, 1=word, 2=sentence, 3=paragraph, 4=section, 5=document
 
   // ─── 표 객체 선택 ──────────────────────────────────────
   private _tableObjectSelected = false;
@@ -999,11 +999,18 @@ export class CursorState {
         this.anchor = { ...pos, charOffset: start };
         this.position = { ...pos, charOffset: end };
       } else if (this._expandPhase === 2) {
+        // 문장 선택 (#839, 한컴 F3 5단계 정합)
+        const paraLen = this.wasm.getParagraphLength(sec, para);
+        const text = this.wasm.getTextRange(sec, para, 0, paraLen);
+        const { start, end } = findSentenceAt(text, pos.charOffset);
+        this.anchor = { ...pos, charOffset: start };
+        this.position = { ...pos, charOffset: end };
+      } else if (this._expandPhase === 3) {
         // 문단 전체 선택
         const paraLen = this.wasm.getParagraphLength(sec, para);
         this.anchor = { ...pos, charOffset: 0 };
         this.position = { ...pos, charOffset: paraLen };
-      } else if (this._expandPhase === 3) {
+      } else if (this._expandPhase === 4) {
         // 구역 전체 선택
         const paraCount = this.wasm.getParagraphCount(sec);
         const lastParaLen = this.wasm.getParagraphLength(sec, paraCount - 1);
@@ -1017,7 +1024,7 @@ export class CursorState {
         const lastParaLen = this.wasm.getParagraphLength(lastSec, lastParaCount - 1);
         this.anchor = { sectionIndex: 0, paragraphIndex: 0, charOffset: 0 };
         this.position = { sectionIndex: lastSec, paragraphIndex: lastParaCount - 1, charOffset: lastParaLen };
-        this._expandPhase = 4; // cap
+        this._expandPhase = 5; // cap
       }
       this.updateRect();
     } catch (e) {
@@ -1570,5 +1577,32 @@ function findWordAt(text: string, offset: number): { start: number; end: number 
     while (start > 0 && !isWordChar(text[start - 1])) start--;
     while (end < text.length && !isWordChar(text[end])) end++;
   }
+  return { start, end };
+}
+
+// ─── 문장 범위 탐색 유틸 (#839, F3 단계 2 문장 선택) ──────────────────────────────────
+
+const SENTENCE_TERMINATORS = new Set(['.', '?', '!', '。', '？', '！']);
+
+function findSentenceAt(text: string, offset: number): { start: number; end: number } {
+  if (!text) return { start: offset, end: offset };
+  const len = text.length;
+  const clampedOffset = Math.min(offset, len);
+
+  let start = clampedOffset;
+  while (start > 0) {
+    const prev = text[start - 1];
+    if (SENTENCE_TERMINATORS.has(prev)) break;
+    start--;
+  }
+  while (start < clampedOffset && (text[start] === ' ' || text[start] === '\t')) start++;
+
+  let end = clampedOffset;
+  while (end < len) {
+    if (SENTENCE_TERMINATORS.has(text[end])) { end++; break; }
+    end++;
+  }
+  while (end < len && (text[end] === ' ' || text[end] === '\t')) end++;
+
   return { start, end };
 }

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1602,7 +1602,6 @@ function findSentenceAt(text: string, offset: number): { start: number; end: num
     if (SENTENCE_TERMINATORS.has(text[end])) { end++; break; }
     end++;
   }
-  while (end < len && (text[end] === ' ' || text[end] === '\t')) end++;
 
   return { start, end };
 }


### PR DESCRIPTION
## 요약

PR #811에서 구현한 F3 영역 확장 4단계(단어→문단→구역→문서)를 한컴 표준 5단계(단어→**문장**→문단→구역→문서)로 확장합니다.

Closes #839

## 한컴 표준 F3 5단계

| F3 횟수 | 범위 | 변경 |
|---------|------|------|
| 1회 | 단어 | 기존 유지 |
| **2회** | **문장** | **신규 추가** |
| 3회 | 문단 | 기존 phase 2 → 3 |
| 4회 | 구역 | 기존 phase 3 → 4 |
| 5회 | 문서 | 기존 phase 4 → 5 (cap) |

## 변경 사항

- `findSentenceAt(text, offset)` 문장 경계 검출 헬퍼 추가
  - 문장 종결 부호: `.` `?` `!` `。` `？` `！` (한/영/CJK)
  - `findWordAt` 패턴과 동일한 양방향 확장 방식
  - 이전 종결부호 직후 ~ 현재 종결부호 + 후행 공백까지 선택
- `expandSelection()` phase 매핑 변경 (2→5단계 cap)

## 검증 방법

1. 웹 에디터에서 여러 문장이 포함된 문단에 커서 배치
2. F5 → F3 반복 누름:
   - 1회: 현재 단어 선택
   - 2회: 현재 문장 선택 (종결부호 + 후행 공백 포함)
   - 3회: 전체 문단 선택
   - 4회: 전체 구역 선택
   - 5회: 전체 문서 선택

## 설계 메모

- 문장 검출은 문단 내부에서만 동작합니다 (문단 경계를 넘지 않음). 한컴의 F3 문장 선택도 문단 경계 내에서 동작합니다.
- `SENTENCE_TERMINATORS`를 `Set`으로 분리하여 향후 확장 용이합니다.