### PR TITLE
fix: 표 위치 편집 시 raw_ctrl_data 오프셋 4바이트 밀림 — flags 오염 (#698)

### DIFF
--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -989,35 +989,38 @@ impl DocumentCore {
 
         let bf_json = self.build_border_fill_json_by_id(table.border_fill_id);
 
-        // raw_ctrl_data에서 표 크기 & 바깥 여백 추출
+        // raw_ctrl_data에서 표 크기 & 바깥 여백 추출 (parse_common_obj_attr 정합)
+        // [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset, [12..16]=width, [16..20]=height
         let rd = &table.raw_ctrl_data;
-        let table_width = if rd.len() >= 12 {
-            u32::from_le_bytes([rd[8], rd[9], rd[10], rd[11]])
-        } else {
-            0
-        };
-        let table_height = if rd.len() >= 16 {
+        let table_width = if rd.len() >= 16 {
             u32::from_le_bytes([rd[12], rd[13], rd[14], rd[15]])
         } else {
             0
         };
-        let outer_left = if rd.len() >= 22 {
-            i16::from_le_bytes([rd[20], rd[21]])
+        let table_height = if rd.len() >= 20 {
+            u32::from_le_bytes([rd[16], rd[17], rd[18], rd[19]])
         } else {
             0
         };
-        let outer_right = if rd.len() >= 24 {
-            i16::from_le_bytes([rd[22], rd[23]])
-        } else {
-            0
-        };
-        let outer_top = if rd.len() >= 26 {
+        // outer_margin: [24..32] (parse_common_obj_attr 정합)
+        // [20..24]=z_order, [24..26]=left, [26..28]=right, [28..30]=top, [30..32]=bottom
+        let outer_left = if rd.len() >= 26 {
             i16::from_le_bytes([rd[24], rd[25]])
         } else {
             0
         };
-        let outer_bottom = if rd.len() >= 28 {
+        let outer_right = if rd.len() >= 28 {
             i16::from_le_bytes([rd[26], rd[27]])
+        } else {
+            0
+        };
+        let outer_top = if rd.len() >= 30 {
+            i16::from_le_bytes([rd[28], rd[29]])
+        } else {
+            0
+        };
+        let outer_bottom = if rd.len() >= 32 {
+            i16::from_le_bytes([rd[30], rd[31]])
         } else {
             0
         };
@@ -1089,9 +1092,10 @@ impl DocumentCore {
         };
         let restrict_in_page = (table.attr >> 13) & 0x01 != 0;
         let allow_overlap = (table.attr >> 14) & 0x01 != 0;
-        // raw_ctrl_data[32..36] = prevent_page_break (개체와 조판부호를 항상 같은 쪽에 놓기)
-        let keep_with_anchor = if rd.len() >= 36 {
-            i32::from_le_bytes([rd[32], rd[33], rd[34], rd[35]]) != 0
+        // raw_ctrl_data[36..40] = prevent_page_break (parse_common_obj_attr 정합)
+        // [32..36]=instance_id, [36..40]=prevent_page_break
+        let keep_with_anchor = if rd.len() >= 40 {
+            i32::from_le_bytes([rd[36], rd[37], rd[38], rd[39]]) != 0
         } else {
             false
         };
@@ -1235,28 +1239,31 @@ impl DocumentCore {
                 table.attr &= !(1 << 14);
             }
         }
-        // keepWithAnchor → raw_ctrl_data[32..36] (prevent_page_break)
+        // keepWithAnchor → raw_ctrl_data[36..40] (prevent_page_break)
+        // [32..36]=instance_id, [36..40]=prevent_page_break (parse_common_obj_attr 정합)
         if let Some(v) = json_bool(json, "keepWithAnchor") {
-            while table.raw_ctrl_data.len() < 36 {
+            while table.raw_ctrl_data.len() < 40 {
                 table.raw_ctrl_data.push(0);
             }
             let val: i32 = if v { 1 } else { 0 };
-            table.raw_ctrl_data[32..36].copy_from_slice(&val.to_le_bytes());
+            table.raw_ctrl_data[36..40].copy_from_slice(&val.to_le_bytes());
         }
 
-        // 바깥 여백 (raw_ctrl_data[20..28])
-        if table.raw_ctrl_data.len() >= 28 {
+        // 바깥 여백 (raw_ctrl_data[24..32], parse_common_obj_attr 정합)
+        // [20..24]=z_order, [24..26]=margin_left, [26..28]=margin_right,
+        // [28..30]=margin_top, [30..32]=margin_bottom
+        if table.raw_ctrl_data.len() >= 32 {
             if let Some(v) = json_i16(json, "outerLeft") {
-                table.raw_ctrl_data[20..22].copy_from_slice(&v.to_le_bytes());
-            }
-            if let Some(v) = json_i16(json, "outerRight") {
-                table.raw_ctrl_data[22..24].copy_from_slice(&v.to_le_bytes());
-            }
-            if let Some(v) = json_i16(json, "outerTop") {
                 table.raw_ctrl_data[24..26].copy_from_slice(&v.to_le_bytes());
             }
-            if let Some(v) = json_i16(json, "outerBottom") {
+            if let Some(v) = json_i16(json, "outerRight") {
                 table.raw_ctrl_data[26..28].copy_from_slice(&v.to_le_bytes());
+            }
+            if let Some(v) = json_i16(json, "outerTop") {
+                table.raw_ctrl_data[28..30].copy_from_slice(&v.to_le_bytes());
+            }
+            if let Some(v) = json_i16(json, "outerBottom") {
+                table.raw_ctrl_data[30..32].copy_from_slice(&v.to_le_bytes());
             }
         }
 
@@ -1837,5 +1844,42 @@ mod tests {
         );
         assert_eq!(common.width, 5000);
         assert_eq!(common.height, 3000);
+    }
+
+    #[test]
+    fn update_ctrl_dimensions_writes_correct_slots() {
+        use crate::model::table::{Cell, Table};
+
+        let mut tbl = Table::default();
+        tbl.col_count = 2;
+        tbl.row_count = 1;
+        tbl.cells = vec![
+            Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 5000,
+                height: 3000,
+                ..Default::default()
+            },
+            Cell {
+                row: 0,
+                col: 1,
+                col_span: 1,
+                row_span: 1,
+                width: 4000,
+                height: 3000,
+                ..Default::default()
+            },
+        ];
+        tbl.raw_ctrl_data = vec![0u8; 36];
+
+        tbl.update_ctrl_dimensions();
+
+        let common = parse_common_obj_attr(&tbl.raw_ctrl_data);
+        assert_eq!(common.width, 9000, "width at [12..16]");
+        assert_eq!(common.height, 3000, "height at [16..20]");
+        assert_eq!(common.horizontal_offset, 0, "h_offset at [8..12] untouched");
     }
 }

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -862,43 +862,43 @@ impl DocumentCore {
     ) -> Result<String, HwpError> {
         let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
 
-        // raw_ctrl_data가 8바이트 미만이면 0으로 패딩
-        while table.raw_ctrl_data.len() < 8 {
+        // CommonObjAttr 바이트 레이아웃: [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset
+        while table.raw_ctrl_data.len() < 12 {
             table.raw_ctrl_data.push(0);
         }
 
         let is_treat_as_char = (table.attr & 0x01) != 0;
 
-        // vertical_offset: raw_ctrl_data[0..4] (i32 LE)
+        // vertical_offset: raw_ctrl_data[4..8] (i32 LE)
         let mut new_v = if delta_v != 0 {
             let cur_v = i32::from_le_bytes([
-                table.raw_ctrl_data[0],
-                table.raw_ctrl_data[1],
-                table.raw_ctrl_data[2],
-                table.raw_ctrl_data[3],
-            ]);
-            let nv = cur_v.wrapping_add(delta_v);
-            table.raw_ctrl_data[0..4].copy_from_slice(&nv.to_le_bytes());
-            nv
-        } else {
-            i32::from_le_bytes([
-                table.raw_ctrl_data[0],
-                table.raw_ctrl_data[1],
-                table.raw_ctrl_data[2],
-                table.raw_ctrl_data[3],
-            ])
-        };
-
-        // horizontal_offset: raw_ctrl_data[4..8] (i32 LE)
-        if delta_h != 0 {
-            let cur_h = i32::from_le_bytes([
                 table.raw_ctrl_data[4],
                 table.raw_ctrl_data[5],
                 table.raw_ctrl_data[6],
                 table.raw_ctrl_data[7],
             ]);
+            let nv = cur_v.wrapping_add(delta_v);
+            table.raw_ctrl_data[4..8].copy_from_slice(&nv.to_le_bytes());
+            nv
+        } else {
+            i32::from_le_bytes([
+                table.raw_ctrl_data[4],
+                table.raw_ctrl_data[5],
+                table.raw_ctrl_data[6],
+                table.raw_ctrl_data[7],
+            ])
+        };
+
+        // horizontal_offset: raw_ctrl_data[8..12] (i32 LE)
+        if delta_h != 0 {
+            let cur_h = i32::from_le_bytes([
+                table.raw_ctrl_data[8],
+                table.raw_ctrl_data[9],
+                table.raw_ctrl_data[10],
+                table.raw_ctrl_data[11],
+            ]);
             let new_h = cur_h.wrapping_add(delta_h);
-            table.raw_ctrl_data[4..8].copy_from_slice(&new_h.to_le_bytes());
+            table.raw_ctrl_data[8..12].copy_from_slice(&new_h.to_le_bytes());
         }
 
         // treat_as_char 표: 문단 경계를 넘으면 문단 이동 (다중 경계 루프)
@@ -940,7 +940,7 @@ impl DocumentCore {
             // 최종 v_offset 갱신
             if result_ppi != parent_para_idx {
                 let tbl = self.get_table_mut(section_idx, result_ppi, control_idx)?;
-                tbl.raw_ctrl_data[0..4].copy_from_slice(&new_v.to_le_bytes());
+                tbl.raw_ctrl_data[4..8].copy_from_slice(&new_v.to_le_bytes());
             }
         }
 
@@ -1076,13 +1076,14 @@ impl DocumentCore {
             crate::model::shape::HorzAlign::Inside => "Inside",
             crate::model::shape::HorzAlign::Outside => "Outside",
         };
-        let vert_offset = if rd.len() >= 4 {
-            i32::from_le_bytes([rd[0], rd[1], rd[2], rd[3]])
+        // CommonObjAttr: [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset
+        let vert_offset = if rd.len() >= 8 {
+            i32::from_le_bytes([rd[4], rd[5], rd[6], rd[7]])
         } else {
             0
         };
-        let horz_offset = if rd.len() >= 8 {
-            i32::from_le_bytes([rd[4], rd[5], rd[6], rd[7]])
+        let horz_offset = if rd.len() >= 12 {
+            i32::from_le_bytes([rd[8], rd[9], rd[10], rd[11]])
         } else {
             0
         };
@@ -1208,15 +1209,15 @@ impl DocumentCore {
             };
             table.attr = (table.attr & !(0x07 << 10)) | (bits << 10);
         }
-        // 위치 오프셋: raw_ctrl_data
-        while table.raw_ctrl_data.len() < 8 {
+        // 위치 오프셋: CommonObjAttr [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset
+        while table.raw_ctrl_data.len() < 12 {
             table.raw_ctrl_data.push(0);
         }
         if let Some(v) = json_i32(json, "vertOffset") {
-            table.raw_ctrl_data[0..4].copy_from_slice(&v.to_le_bytes());
+            table.raw_ctrl_data[4..8].copy_from_slice(&v.to_le_bytes());
         }
         if let Some(v) = json_i32(json, "horzOffset") {
-            table.raw_ctrl_data[4..8].copy_from_slice(&v.to_le_bytes());
+            table.raw_ctrl_data[8..12].copy_from_slice(&v.to_le_bytes());
         }
         // restrictInPage → attr bit 13
         if let Some(v) = json_bool(json, "restrictInPage") {

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1810,3 +1810,26 @@ fn json_escape(s: &str) -> String {
     r.push('"');
     r
 }
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::control::parse_common_obj_attr;
+
+    #[test]
+    fn raw_ctrl_data_offsets_match_parser() {
+        // CommonObjAttr layout: [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset, [12..16]=width
+        let mut data = vec![0u8; 36];
+        let flags: u32 = (2 << 3) | (3 << 8) | (1 << 21); // vert=Para, horz=Para, wrap=TopAndBottom
+        data[0..4].copy_from_slice(&flags.to_le_bytes());
+        data[4..8].copy_from_slice(&42_u32.to_le_bytes()); // v_offset = 42
+        data[8..12].copy_from_slice(&99_u32.to_le_bytes()); // h_offset = 99
+        data[12..16].copy_from_slice(&5000_u32.to_le_bytes()); // width
+        data[16..20].copy_from_slice(&3000_u32.to_le_bytes()); // height
+
+        let common = parse_common_obj_attr(&data);
+        assert_eq!(common.vertical_offset, 42, "v_offset must be at bytes [4..8]");
+        assert_eq!(common.horizontal_offset, 99, "h_offset must be at bytes [8..12]");
+        assert_eq!(common.width, 5000);
+        assert_eq!(common.height, 3000);
+    }
+}

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1827,8 +1827,14 @@ mod tests {
         data[16..20].copy_from_slice(&3000_u32.to_le_bytes()); // height
 
         let common = parse_common_obj_attr(&data);
-        assert_eq!(common.vertical_offset, 42, "v_offset must be at bytes [4..8]");
-        assert_eq!(common.horizontal_offset, 99, "h_offset must be at bytes [8..12]");
+        assert_eq!(
+            common.vertical_offset, 42,
+            "v_offset must be at bytes [4..8]"
+        );
+        assert_eq!(
+            common.horizontal_offset, 99,
+            "h_offset must be at bytes [8..12]"
+        );
         assert_eq!(common.width, 5000);
         assert_eq!(common.height, 3000);
     }

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -248,17 +248,18 @@ impl Table {
 
     /// raw_ctrl_data 내 CommonObjAttr의 width/height를 재계산하여 갱신한다.
     ///
-    /// raw_ctrl_data 레이아웃 (attr 4바이트 이후):
-    ///   [0..4] vertical_offset, [4..8] horizontal_offset,
-    ///   [8..12] width, [12..16] height, ...
+    /// raw_ctrl_data 레이아웃 (parse_common_obj_attr 정합):
+    ///   [0..4] flags, [4..8] v_offset, [8..12] h_offset,
+    ///   [12..16] width, [16..20] height, [20..24] z_order,
+    ///   [24..32] outer_margin (i16×4), [32..36] instance_id
     pub fn update_ctrl_dimensions(&mut self) {
-        if self.raw_ctrl_data.len() < 16 {
+        if self.raw_ctrl_data.len() < 20 {
             return;
         }
         let total_width: HwpUnit = self.get_column_widths().iter().sum();
         let total_height: HwpUnit = self.get_row_heights().iter().sum();
-        self.raw_ctrl_data[8..12].copy_from_slice(&total_width.to_le_bytes());
-        self.raw_ctrl_data[12..16].copy_from_slice(&total_height.to_le_bytes());
+        self.raw_ctrl_data[12..16].copy_from_slice(&total_width.to_le_bytes());
+        self.raw_ctrl_data[16..20].copy_from_slice(&total_height.to_le_bytes());
     }
 
     /// 열별 폭을 추출한다 (col_span==1인 셀 기준).


### PR DESCRIPTION
## 요약

rHwp에서 생성한 표를 이동하거나 속성을 변경하면, 저장 후 다시 열었을 때 표 위치가 망가지는 v1.0.0 마일스톤 버그를 수정합니다.

Closes #698

## 원인

`table_ops.rs`의 3곳에서 `raw_ctrl_data`의 CommonObjAttr 오프셋을 4바이트씩 잘못 접근하고 있었습니다:

| 필드 | 올바른 위치 | 기존 코드 | 결과 |
|------|------------|----------|------|
| flags | [0..4] | v_offset로 덮어씀 | **flags 오염** |
| vertical_offset | [4..8] | h_offset로 덮어씀 | **v/h 뒤바뀜** |
| horizontal_offset | [8..12] | 접근 안 함 | **h_offset 미갱신** |

`parse_common_obj_attr` (shape.rs:332) 기준 CommonObjAttr 바이트 레이아웃:
```
[0..4]  = attr/flags (u32)
[4..8]  = vertical_offset (u32)
[8..12] = horizontal_offset (u32)
[12..16] = width (u32)
[16..20] = height (u32)
...
```

첨부 파일(`표 위치 오류.hwp`) 덤프에서 `horz=문단(41950=148.0mm)` 확인 — 의도값 0이 아닌 비정상 h_offset이 저장되어 있었으며, raw bytes `[DE, A3, 00, 00]` at offset [8..12]이 이를 확인합니다.

## 수정 범위

`table_ops.rs` 4곳 교정:
1. **`move_table_position`** — v_offset 읽기/쓰기: [0..4] → [4..8]
2. **`move_table_position`** — h_offset 읽기/쓰기: [4..8] → [8..12]
3. **`move_table_position`** — 문단 교환 후 v_offset 갱신: [0..4] → [4..8]
4. **`set_table_properties_json`** — vertOffset/horzOffset 쓰기: +4 시프트
5. **`get_table_properties_json`** — vertOffset/horzOffset 읽기: +4 시프트
6. **패딩 가드** — `while len < 8` → `while len < 12`

## 검증

```bash
cargo test --lib                    # 1335 passed, 0 failed
cargo clippy --lib -- -D warnings   # 경고 0건
```

## 재현 방법

1. rHwp에서 표를 생성하여 문서 작성
2. 표를 드래그 이동 (또는 속성 변경)
3. 저장 후 다시 열기
4. 표 위치가 줄 끝으로 밀려 보이지 않음