### PR TITLE
fix: HTML 테이블 붙여넣기 raw_ctrl_data 오프셋 밀림 (#698 관련)

### DIFF
--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -492,25 +492,24 @@ impl DocumentCore {
         let total_width: u32 = col_widths.iter().sum();
         let total_height: u32 = row_heights.iter().sum();
 
-        // raw_ctrl_data: CommonObjAttr (table.attr 이후 데이터)
-        // [0..4] vertical_offset, [4..8] horizontal_offset,
-        // [8..12] width, [12..16] height, [16..20] z_order,
-        // [20..22] margin.left, [22..24] margin.right,
-        // [24..26] margin.top, [26..28] margin.bottom,
-        // [28..32] instance_id, [32..34] desc_len(=0)
+        // raw_ctrl_data: CommonObjAttr 전체 바이트
+        // [0..4] flags, [4..8] v_offset, [8..12] h_offset,
+        // [12..16] width, [16..20] height, [20..24] z_order,
+        // [24..26] margin.left, [26..28] margin.right,
+        // [28..30] margin.top, [30..32] margin.bottom,
+        // [32..36] instance_id, [36..38] reserved
         let outer_margin: i16 = 283; // 바깥 여백 ~1mm
-        let mut raw_ctrl_data = vec![0u8; 38]; // 32(base) + 2(desc_len) + 4(extra)
-        raw_ctrl_data[8..12].copy_from_slice(&total_width.to_le_bytes());
-        raw_ctrl_data[12..16].copy_from_slice(&total_height.to_le_bytes());
-        // 바깥 여백 (left, right, top, bottom)
-        raw_ctrl_data[20..22].copy_from_slice(&outer_margin.to_le_bytes());
-        raw_ctrl_data[22..24].copy_from_slice(&outer_margin.to_le_bytes());
+        let mut raw_ctrl_data = vec![0u8; 38];
+        raw_ctrl_data[0..4].copy_from_slice(&0x082A2311_u32.to_le_bytes()); // flags (= table_attr below)
+        // [4..12] v_offset, h_offset = 0 (default)
+        raw_ctrl_data[12..16].copy_from_slice(&total_width.to_le_bytes());
+        raw_ctrl_data[16..20].copy_from_slice(&total_height.to_le_bytes());
+        // [20..24] z_order = 0
         raw_ctrl_data[24..26].copy_from_slice(&outer_margin.to_le_bytes());
         raw_ctrl_data[26..28].copy_from_slice(&outer_margin.to_le_bytes());
-        // [28..32] instance_id (DIFF-7 수정: 해시 기반 유니크 값 생성)
-        // 정상 HWP 파일에서는 instance_id가 고유한 비-0 값을 가짐
+        raw_ctrl_data[28..30].copy_from_slice(&outer_margin.to_le_bytes());
+        raw_ctrl_data[30..32].copy_from_slice(&outer_margin.to_le_bytes());
         let instance_id: u32 = {
-            // 행/열 수, 셀 수, 총 폭/높이를 조합한 간단한 해시
             let mut h: u32 = 0x7c150000;
             h = h.wrapping_add(row_count as u32 * 0x1000);
             h = h.wrapping_add(col_count as u32 * 0x100);
@@ -519,11 +518,10 @@ impl DocumentCore {
             h ^= cells.len() as u32 * 0x4b69;
             if h == 0 {
                 h = 0x7c154b69;
-            } // 절대 0이 되지 않도록
+            }
             h
         };
-        raw_ctrl_data[28..32].copy_from_slice(&instance_id.to_le_bytes());
-        // [32..34] desc_len = 0, [34..38] reserved = 0
+        raw_ctrl_data[32..36].copy_from_slice(&instance_id.to_le_bytes());
 
         // row_sizes: 각 행의 셀 수
         let row_sizes: Vec<i16> = (0..row_count)

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -501,7 +501,7 @@ impl DocumentCore {
         let outer_margin: i16 = 283; // 바깥 여백 ~1mm
         let mut raw_ctrl_data = vec![0u8; 38];
         raw_ctrl_data[0..4].copy_from_slice(&0x082A2311_u32.to_le_bytes()); // flags (= table_attr below)
-        // [4..12] v_offset, h_offset = 0 (default)
+                                                                            // [4..12] v_offset, h_offset = 0 (default)
         raw_ctrl_data[12..16].copy_from_slice(&total_width.to_le_bytes());
         raw_ctrl_data[16..20].copy_from_slice(&total_height.to_le_bytes());
         // [20..24] z_order = 0

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2375,7 +2375,10 @@ fn test_paste_html_table_as_control() {
         // [24..32]=margins, [32..36]=instance_id
         assert!(tbl.raw_ctrl_data.len() >= 36, "raw_ctrl_data >= 36 bytes");
         let ctrl_flags = u32::from_le_bytes(tbl.raw_ctrl_data[0..4].try_into().unwrap());
-        assert_eq!(ctrl_flags, tbl.attr, "raw_ctrl_data[0..4] flags must match table.attr");
+        assert_eq!(
+            ctrl_flags, tbl.attr,
+            "raw_ctrl_data[0..4] flags must match table.attr"
+        );
         let ctrl_instance_id = u32::from_le_bytes(tbl.raw_ctrl_data[32..36].try_into().unwrap());
         assert_ne!(
             ctrl_instance_id, 0,

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2370,17 +2370,16 @@ fn test_paste_html_table_as_control() {
         ]);
         assert_eq!(inst, 0x80000000, "table para instance_id=0x80000000");
 
-        // DIFF-7: CTRL_HEADER instance_id (raw_ctrl_data[28..32]) 가 0이 아닌지 검증
-        assert!(tbl.raw_ctrl_data.len() >= 32, "raw_ctrl_data >= 32 bytes");
-        let ctrl_instance_id = u32::from_le_bytes([
-            tbl.raw_ctrl_data[28],
-            tbl.raw_ctrl_data[29],
-            tbl.raw_ctrl_data[30],
-            tbl.raw_ctrl_data[31],
-        ]);
+        // CommonObjAttr byte layout: [0..4]=flags, [4..8]=v_offset, [8..12]=h_offset,
+        // [12..16]=width, [16..20]=height, [20..24]=z_order,
+        // [24..32]=margins, [32..36]=instance_id
+        assert!(tbl.raw_ctrl_data.len() >= 36, "raw_ctrl_data >= 36 bytes");
+        let ctrl_flags = u32::from_le_bytes(tbl.raw_ctrl_data[0..4].try_into().unwrap());
+        assert_eq!(ctrl_flags, tbl.attr, "raw_ctrl_data[0..4] flags must match table.attr");
+        let ctrl_instance_id = u32::from_le_bytes(tbl.raw_ctrl_data[32..36].try_into().unwrap());
         assert_ne!(
             ctrl_instance_id, 0,
-            "DIFF-7: CTRL_HEADER instance_id != 0 (got 0x{:08X})",
+            "CTRL_HEADER instance_id != 0 (got 0x{:08X})",
             ctrl_instance_id
         );
     } else {


### PR DESCRIPTION
## 요약

PR #1077 (#698)과 동일한 CommonObjAttr 4바이트 오프셋 밀림 버그가 `html_table_import.rs`에도 존재합니다. HTML 테이블을 붙여넣기할 때 생성되는 표의 `raw_ctrl_data`가 잘못된 레이아웃으로 작성되어, 저장 후 한컴에서 표 위치/크기가 잘못 해석됩니다.

Related to #698

## 원인

`html_table_import.rs`의 `raw_ctrl_data` 바이트 레이아웃 주석과 코드가 `[0..4]=flags` 필드를 누락하고 `[0..4]=v_offset`으로 시작했습니다:

| 필드 | 올바른 위치 | 기존 코드 | 영향 |
|------|------------|----------|------|
| flags | [0..4] | 기록 안 함 (0) | table.attr과 불일치 |
| width | [12..16] | [8..12] | h_offset 위치에 기록 |
| height | [16..20] | [12..16] | width 위치에 기록 |
| margins | [24..32] | [20..28] | z_order/margin 위치 혼동 |
| instance_id | [32..36] | [28..32] | margin 위치에 기록 |

## 수정 내용

- 모든 필드를 `parse_common_obj_attr` (`shape.rs:332`) 및 `create_table_native` (`object_ops.rs`) 레이아웃과 일치하도록 +4 시프트
- `raw_ctrl_data[0..4]`에 `table_attr` (0x082A2311) flags 기록 추가
- 주석도 올바른 레이아웃으로 수정

## 검증

```bash
cargo test --lib                    # 1335 passed, 0 failed
cargo clippy --lib -- -D warnings   # 경고 0건
```