### PR TITLE
fix: set_cell_field_text 직접 대입 → delete+insert 사용 (#838 관련)

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -297,7 +297,13 @@ impl DocumentCore {
                         ))
                     })?;
                     if let Some(cell_para) = cell.paragraphs.first_mut() {
-                        cell_para.text = value.to_string();
+                        let old_len = cell_para.text.chars().count();
+                        if old_len > 0 {
+                            cell_para.delete_text_at(0, old_len);
+                        }
+                        if !value.is_empty() {
+                            cell_para.insert_text_at(0, value);
+                        }
                         rebuild_char_offsets(cell_para);
                     }
                     Ok(())


### PR DESCRIPTION
## 요약

PR #1076 (#838)과 동일한 패턴의 메타데이터 불일치 문제가 `set_cell_field_text`에도 존재합니다.

Related to #838

## 원인

```rust
// 기존: 직접 대입 (char_shapes, line_segs 등 미갱신)
cell_para.text = value.to_string();
rebuild_char_offsets(cell_para);
```

셀 필드(`field_name`이 있는 표 셀) 텍스트 교체 시, `para.text`를 직접 대입하면 `char_shapes`, `line_segs`, `range_tags`, `char_count` 메타데이터가 새 텍스트와 불일치합니다.

## 수정

```rust
// 수정: 안전한 delete+insert
let old_len = cell_para.text.chars().count();
if old_len > 0 { cell_para.delete_text_at(0, old_len); }
if !value.is_empty() { cell_para.insert_text_at(0, value); }
rebuild_char_offsets(cell_para);
```

## 검증

```bash
cargo test --lib     # 1335 passed, 0 failed
cargo clippy --lib   # 0 warnings
cargo fmt -- --check # clean
```