### PR TITLE
refactor: CommonObjAttr raw_ctrl_data 바이트 오프셋 상수 모듈 (#698 후속)

### DIFF
--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -9,7 +9,7 @@ use super::*;
 /// `parse_common_obj_attr` 및 `serialize_common_obj_attr` 과 일치해야 한다.
 /// `table_ops.rs`, `object_ops.rs`, `html_table_import.rs` 등에서 직접 바이트
 /// 인덱싱 대신 이 상수를 사용한다.
-pub mod common_obj_offsets {
+pub(crate) mod common_obj_offsets {
     pub const FLAGS: std::ops::Range<usize> = 0..4;
     pub const V_OFFSET: std::ops::Range<usize> = 4..8;
     pub const H_OFFSET: std::ops::Range<usize> = 8..12;
@@ -21,7 +21,7 @@ pub mod common_obj_offsets {
     pub const MARGIN_TOP: std::ops::Range<usize> = 28..30;
     pub const MARGIN_BOTTOM: std::ops::Range<usize> = 30..32;
     pub const INSTANCE_ID: std::ops::Range<usize> = 32..36;
-    pub const MIN_LEN: usize = 36;
+    pub const MIN_LEN: usize = INSTANCE_ID.end;
 }
 
 /// 개체 공통 속성 (모든 개체에 공통)

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -4,6 +4,26 @@ use super::paragraph::Paragraph;
 use super::style::{Fill, ShapeBorderLine};
 use super::*;
 
+/// `raw_ctrl_data` (CTRL_HEADER) 바이트 오프셋 상수.
+///
+/// `parse_common_obj_attr` 및 `serialize_common_obj_attr` 과 일치해야 한다.
+/// `table_ops.rs`, `object_ops.rs`, `html_table_import.rs` 등에서 직접 바이트
+/// 인덱싱 대신 이 상수를 사용한다.
+pub mod common_obj_offsets {
+    pub const FLAGS: std::ops::Range<usize> = 0..4;
+    pub const V_OFFSET: std::ops::Range<usize> = 4..8;
+    pub const H_OFFSET: std::ops::Range<usize> = 8..12;
+    pub const WIDTH: std::ops::Range<usize> = 12..16;
+    pub const HEIGHT: std::ops::Range<usize> = 16..20;
+    pub const Z_ORDER: std::ops::Range<usize> = 20..24;
+    pub const MARGIN_LEFT: std::ops::Range<usize> = 24..26;
+    pub const MARGIN_RIGHT: std::ops::Range<usize> = 26..28;
+    pub const MARGIN_TOP: std::ops::Range<usize> = 28..30;
+    pub const MARGIN_BOTTOM: std::ops::Range<usize> = 30..32;
+    pub const INSTANCE_ID: std::ops::Range<usize> = 32..36;
+    pub const MIN_LEN: usize = 36;
+}
+
 /// 개체 공통 속성 (모든 개체에 공통)
 #[derive(Debug, Clone, Default)]
 pub struct CommonObjAttr {


### PR DESCRIPTION
## 요약

PR #1077, #1078에서 발견한 CommonObjAttr 4바이트 오프셋 밀림 패턴의 재발을 방지하기 위해, `raw_ctrl_data` 바이트 인덱스를 명명된 상수로 참조할 수 있는 `common_obj_offsets` 모듈을 추가합니다.

Related to #698

## 동기

`table_ops.rs`와 `html_table_import.rs`에서 동일한 버그 패턴이 발견되었습니다:
- `raw_ctrl_data[0..4]`를 `v_offset`으로 사용 (실제: `flags`)
- `raw_ctrl_data[4..8]`를 `h_offset`으로 사용 (실제: `v_offset`)

Raw 바이트 인덱스를 직접 사용하면 이 실수가 반복될 수 있습니다.

## 변경 내용

`src/model/shape.rs`에 `common_obj_offsets` 모듈 추가:

```rust
pub mod common_obj_offsets {
    pub const FLAGS: Range<usize> = 0..4;
    pub const V_OFFSET: Range<usize> = 4..8;
    pub const H_OFFSET: Range<usize> = 8..12;
    pub const WIDTH: Range<usize> = 12..16;
    // ...
    pub const MIN_LEN: usize = 36;
}
```

이 상수들은 `parse_common_obj_attr` 및 `serialize_common_obj_attr`의 바이트 레이아웃과 일치합니다. 기존 코드의 직접 바이트 인덱싱을 점진적으로 이 상수로 마이그레이션할 수 있습니다.

## 검증

```bash
cargo test --lib     # 1335+ passed
cargo clippy --lib   # 0 warnings
cargo fmt -- --check # clean
```

## 향후 마이그레이션 (별도 PR)

기존 `table_ops.rs`, `object_ops.rs`, `html_table_import.rs` 등의 raw 바이트 인덱싱을 `common_obj_offsets::*` 상수로 교체하는 작업은 이 PR 머지 후 별도로 진행하면 좋겠습니다.