### PR TITLE
Task #1073: 중첩 표(셀 내부 표) 페이지 분할 — 본문 하단 overflow 해소 (closes #1073)

### DIFF
--- a/mydocs/plans/task_m100_1073.md
+++ b/mydocs/plans/task_m100_1073.md
@@ -1,0 +1,43 @@
+# 수행계획서 — Task #1073: 중첩 표가 페이지보다 클 때 미분할 본문 하단 overflow
+
+- 이슈: edwardkim/rhwp#1073
+- 브랜치: `local/task1073` (stream/devel `be2a71c4` 기준)
+- 인벤토리 B군 (A군 #1070 / C군 누적드리프트 / D군 Shape 와 별개)
+
+## 목표
+셀 안에 페이지보다 큰 중첩 표(nested table)가 있는 표가 페이지 경계에서, 외부 행 분할만으로
+페이지에 안 들어가 본문 하단을 758px 초과하는 결함을 조사하고, 한컴 정합 기준 해소 방안을 찾는다.
+
+## 재현 / 사전 진단
+- `samples/kps-ai.hwp` pi=674: 외부 3×6 표(쪽나눔=RowBreak, wrap=어울림). 셀[0] 전폭 span +
+  **29행 중첩 표**(~1676px) > 본문 918.4px.
+- `LAYOUT_OVERFLOW page=66 PartialTable y=1805 overflow=758px`. page66 rows=0..2(cont=false) /
+  page67 rows=2..3(cont=true, used=1676.5px).
+- 외부 RowBreak 분할은 외부 행 단위 → 중첩 표 품은 단일 외부 행이 페이지보다 크면 분할 불가.
+- vert offset 비정상(`4294967155≈-141`) 동반.
+
+## 접근 (단계 개요 — 상세는 구현계획서)
+1. **조사 + 타당성 평가 (소스 무변경)**:
+   - 외부 표 분할 경로(`typeset_block_table` split / `advance_row_cut` / `layout_partial_table`)가
+     중첩 표를 어떻게 다루는지 정독. 중첩 표 행 경계 분할 가능 여부 확인.
+   - **한컴 정답지 동작 확정 (`pdf/kps-ai-2022.pdf` p62~63 = 한글 2022)**: 큰 표("소프트웨어사업
+     영향평가 결과서")를 **페이지 경계에서 행 단위로 분할**해 흘림.
+     - p62: 제목 + 1.기본정보 + 2.운영계획 + 3.민간소프트웨어(시작)
+     - p63: 시장침해 가능성 + 4.사업의 필요성 + 5.종합의견 + 푸터
+     → 방향 = **중첩 표 행 단위 페이지 분할**(통째 이월 아님).
+   - vert offset 비정상값(`4294967155≈-141`)이 배치에 영향 주는지 분리 확인.
+   - **go/no-go**: 기존 split 경로(advance_row_cut/layout_partial_table)가 중첩 표 행 분할을
+     지원하는지(=소규모 정정) vs 신규 구현 필요(=대규모) 판정 → 범위를 작업지시자와 합의.
+2. **설계**: 확정된 한컴 동작에 맞는 최소 변경안 + 비회귀 케이스 점검.
+3. **구현**: 최소 변경 + 단위 검증.
+4. **회귀검증**: kps-ai overflow 해소 + 전수 sweep 회귀 0 + 골든 8 + cargo test + (가능 시 가드).
+
+## 산출물
+`plans/task_m100_1073_impl.md`, `working/task_m100_1073_stage{N}.md`,
+`report/task_m100_1073_report.md`.
+
+## 리스크
+- **중첩 표 페이지 분할은 신규 기능 성격** — 구현 난이도 높을 수 있음. Stage 1 타당성 평가로
+  범위 확정(전면 분할 vs 최소 대안) 후 진행.
+- 한컴 정답지(PDF) 부재 → 작업지시자 시각 판정이 방향 결정의 권위(`reference_authoritative_hancom`).
+- 외부 표 split 경로 변경은 다수 표 문서 회귀 위험 → Stage 2 비회귀 케이스 전수 점검.

--- a/mydocs/plans/task_m100_1073_impl.md
+++ b/mydocs/plans/task_m100_1073_impl.md
@@ -1,0 +1,61 @@
+# 구현계획서 — Task #1073: 중첩 표 행 단위 다중 페이지 분할 (전면 구현 A)
+
+- 이슈: edwardkim/rhwp#1073
+- 브랜치: `local/task1073` (stream/devel `be2a71c4` 기준)
+- 수행계획서: `task_m100_1073.md` (승인) / Stage 1 조사: `working/task_m100_1073_stage1.md` (승인)
+
+## 목표
+셀 안의 페이지보다 큰 중첩 표를 **중첩 표 행 경계에서 페이지에 걸쳐 분할**한다
+(한컴 2022 정합 — `pdf/kps-ai-2022.pdf` p62~63). kps-ai pi=674 758px overflow 해소.
+
+## 변경 대상 4 레이어 (Stage 1 확정)
+1. **측정** `MeasuredCell` (`height_measurer.rs`): 중첩 표 셀의 분할 단위(중첩행 높이) 노출.
+2. **분할 가부** `is_row_splittable`(`height_measurer.rs:1490`): 중첩 표 셀을 splittable 로 인정.
+3. **컷 모델** `cell_units`(`table_layout.rs:3519`): 중첩 표를 per-중첩행 유닛으로 분해 +
+   `row_cut_content_height`(`table_layout.rs:3862`) 높이 정합.
+4. **부분 렌더** `table_partial.rs`: typeset 컷 → `NestedTableSplit`(중첩행 범위) 매핑을 페이지
+   chunk 별로 배선(현재 단일 셀 available_h 기반 → 컷 구동으로 전환).
+
+## CellUnit 의미 확장 (설계 핵심)
+현재 `vis_start/vis_end` = 문단 줄 범위. 중첩 표 유닛은 **nested-row 범위**가 필요 →
+`CellUnit` 에 유닛 종류(텍스트줄 / 중첩행) 식별 + nested row index 보강. 렌더가 컷의
+nested-row 범위를 `NestedTableSplit{start_row,end_row,offset_within_start,...}` 로 변환.
+
+## 단계 (Stage 2~5)
+
+### Stage 2 — 설계 + 페이퍼 검증 (소스 무변경)
+- CellUnit 확장 스키마 + 4 레이어 인터페이스 확정(측정→가부→컷→렌더 데이터 흐름).
+- 한컴 정합 기준(중첩행 경계 분할, 부분 행 미발생) + 비회귀 케이스(중첩 표가 페이지에 들어가는
+  기존 문서 — nested-table-border/688 등) 모순 점검 표.
+- 산출물: `working/task_m100_1073_stage2.md`.
+
+### Stage 3 — 측정·컷 레이어 (렌더 전, 페이지네이션 검증)
+- MeasuredCell + is_row_splittable + cell_units + row_cut_content_height 가 중첩행 단위 인식.
+- 검증: `dump-pages` 로 kps-ai pi=674 가 중첩행 경계로 **올바른 청크**(p62/p63 대응)로 분할되는지
+  확인(렌더 매핑 전이라 시각은 미완 가능). 전수 sweep 로 페이지수 변화·회귀 1차 측정.
+- 산출물: 소스 + `working/task_m100_1073_stage3.md`.
+
+### Stage 4 — 부분 렌더 매핑
+- 컷(nested-row 범위) → `NestedTableSplit` 배선. 각 페이지 chunk 가 정확한 중첩행 범위 렌더
+  (외곽 박스/테두리·셀 spacing 정합 포함).
+- 검증: kps-ai SVG 가 PDF p62~63 와 시각 정합(작업지시자 판정 보조: PDF 권위자료).
+- 산출물: 소스 + `working/task_m100_1073_stage4.md`.
+
+### Stage 5 — 회귀 검증 + 가드
+- kps-ai overflow 758px 해소. 전수 sweep(samples) LAYOUT_OVERFLOW 합 **회귀 0**.
+- 골든 SVG 8, `cargo test --release`(lib+통합), clippy/fmt. 회귀 가드 `tests/issue_1073_*.rs`
+  (kps-ai 영향 페이지 text/표 max_y ≤ 페이지 높이 + 중첩행 분할 청크 검증).
+- 산출물: `working/task_m100_1073_stage5.md` → `report/task_m100_1073_report.md`.
+
+## 완료 기준
+중첩 표가 페이지 경계에서 중첩행 단위 분할(PDF 정합) + kps-ai overflow 해소 + 비회귀 0 + 골든 0
++ 회귀 가드.
+
+## 리스크
+- `cell_units`/`advance_row_cut`/`row_cut_content_height`/`is_row_splittable` 는 **모든 표 분할
+  공유** → 광범위 회귀. Stage 3 에서 dump-pages + 전수 sweep 으로 단계적 측정, Stage 2 비회귀
+  케이스 사전 점검.
+- 중첩의 중첩(2단계 이상) / rowspan 걸친 중첩행 / TAC 중첩 표 경계 → Stage 2 에서 범위 명시
+  (1단계 중첩 우선, 그 외는 기존 atom 폴백 유지).
+- 부분 행(한 중첩행이 페이지보다 큼) 발생 시 한컴 동작 확인 — 우선 행 경계까지만 분할(부분 행
+  미분할) 후 필요 시 확장.

--- a/mydocs/report/task_m100_1073_report.md
+++ b/mydocs/report/task_m100_1073_report.md
@@ -1,0 +1,43 @@
+# 최종 보고서 — Task #1073: 중첩 표(셀 내부 표) 페이지 분할
+
+- 이슈: edwardkim/rhwp#1073
+- 브랜치: `local/task1073` (stream/devel `be2a71c4` 기준)
+- 수정: `table_layout.rs`, `height_measurer.rs`, `table_partial.rs` + 회귀 가드 `tests/issue_1073_*.rs`
+
+## 증상
+셀 안에 페이지보다 큰 중첩 표가 있는 표가 페이지 경계에서, 외부 행 분할만으로 페이지에 안 들어가
+본문 하단을 758px 초과(`kps-ai.hwp` pi=674, 외부 3×6 래퍼표 셀[0]의 29행 중첩 표).
+
+## 근본 원인
+중첩 표가 4개 레이어에서 atom 으로 취급되어 `advance_row_cut` 진입 자체가 차단:
+1. `is_row_splittable`(line_heights.len()>1) — 중첩 표 셀은 1 → false.
+2. `MeasuredCell` — 중첩 표를 단일 높이로 측정.
+3. `cell_units` — 중첩 표 atom 1개.
+4. 부분 렌더 — 단일 셀 available_h 휴리스틱(연속 페이지 row0 재렌더).
+
+## 한컴 정답지 (`pdf/kps-ai-2022.pdf` p62~63)
+큰 표를 페이지 경계에서 **행 단위로 분할**(p62 제목~3.민간소프트웨어 / p63 시장침해~5.종합의견).
+
+## 수정 (5점, 4 레이어)
+- `CellUnit + nested_row`: 가시 텍스트 없는 단일 중첩 표(2행+) 문단을 per-중첩행 유닛 분해.
+  Σ = `calc_nested_table_height`(드리프트 0).
+- `MeasuredCell.nested_split_row_count` + `is_row_splittable` 확장.
+- `row_cut_content_height`/`cell_line_ranges_from_cut` 유닛 기반 자동 정합.
+- `layout_partial_table`: 컷 유닛 인덱스 → `NestedTableSplit{start_row,end_row}` 직접 구성
+  (연속 페이지 start_row 반영).
+- `layout_table_cells`: 연속 페이지(sr>0) 의 `r<sr` rowspan 라벨 셀 공란화
+  (외부 advance_row_block_cut 정합).
+
+## 검증
+- kps-ai pi=674: 중첩행 컷(end_cut=[20]/start_cut=[20]), **758px overflow 해소**.
+  page66=제목~3.민간소프트웨어(PDF p62), page67=시장침해~5.종합의견+footer(PDF p63).
+  콘텐츠 완전, 누락/중복 없음, rowspan 라벨 연속 페이지 공란.
+- 전수 sweep: 3057→3055 lines / 382815→382054px (**회귀 0**, kps-ai·hwpctl 개선).
+- 회귀 가드 3 신규, 골든 8/8, cargo test lib 1324 + 통합 0 failed, clippy/fmt clean.
+
+## 잔여 (known limitation)
+- break row 가 한컴 대비 ~2 중첩행 늦음(측정 정밀도). 구조/콘텐츠 정합·overflow 0 달성.
+- 범위 외(atom 폴백): 2단계+ 중첩, 텍스트 동거 문단 중첩 표.
+
+## 후속
+overflow 인벤토리 B군 처리 완료. C군(교육/실전 통합 누적 드리프트), D군(pr-149 Shape)은 별도.

--- a/mydocs/working/task_m100_1073_stage1.md
+++ b/mydocs/working/task_m100_1073_stage1.md
@@ -1,0 +1,69 @@
+# Stage 1 보고서 — Task #1073: 조사 + 타당성(go/no-go) 평가
+
+- 브랜치: `local/task1073` (소스 무변경)
+
+## 근본 원인 확정
+
+분할 컷 모델이 **중첩 표를 단일 atomic 유닛으로 취급** → 페이지 경계에서 쪼갤 수 없음.
+
+- `cell_units`(`table_layout.rs:3519~3571`): 셀 문단에 `Control::Table`(중첩 표)이 있으면
+  (`has_table_in_para`) **CellUnit 1개**(height = 중첩 표 전체 높이, vis 0..line_count) push.
+- `advance_row_cut`(`table_layout.rs:3652`): 셀 유닛을 순회하며 `avail_height` 까지 누적 후
+  컷. 시작 유닛(j==start)은 항상 소비 → 중첩 표 atom 1개는 통째 소비, `fully_consumed=true`.
+- `typeset_block_table` 분할 walk(`typeset.rs:3135~3158`): `is_row_splittable` + advance_row_cut
+  `fully_consumed` → 페이지 시작 행이면 **강제 통째 배치(오버플로 감수)**(3137~3140).
+
+→ kps-ai pi=674: 외부 3×6 래퍼표 셀[0](rs=1,cs=6)이 **29행 중첩 표**(~1676px) 보유. 이 행이
+페이지(918px) 시작에서 atom 통째 배치 → **758px overflow**(y=1805).
+
+## 한컴 정답지 (확정)
+
+`pdf/kps-ai-2022.pdf` p62~63: 표를 **행 단위로 페이지 분할**(p62 제목+1.기본정보+2.운영계획+
+3.민간소프트웨어 / p63 시장침해+4.필요성+5.종합의견+푸터). = 중첩 표 행 경계 분할.
+
+## 기존 자산 (부분)
+
+- 렌더러 `table_partial.rs:1067~1132`: 중첩 표가 셀 가용 공간 초과 시 `calc_nested_split_rows`
+  로 **행 범위 필터(부분 렌더)** 지원. 단 **단일 셀 `available_h` 기반**이며, 페이지네이션
+  컷이 아니라 렌더 시점 inner_area 로 계산. 페이지네이션이 중첩 표를 atom 으로 두므로
+  inner_area = 중첩 표 전체 높이 → `nested_h <= available_h` → 분할 미발동 → 통째 렌더.
+- 즉 **부분 렌더 primitive 는 있으나, 페이지네이션→렌더 다중 페이지 흐름이 미연결**.
+
+## 부가 관찰
+- pi=674 표 `vert=문단(4294967155≈-141)` 비정상값 — 어울림(Square) wrap. overflow 의 직접
+  원인은 atom 미분할이며 vert offset 은 2차(배치 y). Stage 2 에서 분리 확인.
+
+## go/no-go 평가
+
+**중첩 표 페이지 분할 = 중규모~대규모 신규 기능.** 필요한 변경:
+1. `cell_units`: 중첩 표 셀을 **per-중첩행 유닛**으로 분해(현재 atom 1개) — 컷 모델 핵심 변경.
+2. `advance_row_cut`/`row_cut_content_height`: 유닛 기반이라 대체로 수용하나 vis 의미(현재 줄
+   범위) 와 중첩행 범위 충돌 → 의미 확장 필요.
+3. 부분 렌더: typeset 컷 → `NestedTableSplit`(중첩행 범위) 매핑을 페이지 chunk 별로 배선.
+- **리스크**: `cell_units`/`advance_row_cut`/`row_cut_content_height` 는 **모든 표 분할이 공유**
+  하는 단일 측정·컷 공간 → 광범위 표 문서 회귀 위험. 부분 렌더 매핑도 신규.
+
+## PoC 결과 (C안 — 회귀폭 측정 시도)
+
+`cell_units`(table_layout.rs) 의 중첩 표 atom 을 **per-중첩행 유닛으로 분해**하는 PoC
+(`POC_1073` env gate) 적용 → kps-ai pi=674 overflow **758px 불변**.
+
+원인: 분할이 cell_units 한 곳이 아니라 **독립 4 레이어에서 atom 취급**되어, 단일점 변경으로는
+경로가 활성화조차 안 됨:
+1. `is_row_splittable`(height_measurer.rs:1499): 셀 `line_heights.len() > 1` 일 때만 true.
+   중첩 표 셀 = line_heights 1개(atom) → **false → advance_row_cut 경로 진입 차단**(typeset.rs:3135).
+2. `MeasuredCell.line_heights`: 중첩 표를 단일 높이로 측정 → splittable 신호 없음.
+3. `cell_units`: atom 1개(본 PoC 대상).
+4. 부분 렌더(table_partial.rs): 컷→`NestedTableSplit` 매핑은 단일 셀 available_h 기반.
+
+→ **회귀폭을 단일점 PoC 로 측정 불가** — 측정하려면 1~4 를 동시에 바꿔야 하며, 이는 사실상
+전면 구현(A)의 대부분. PoC 자체가 "값싼 격리 변경 불가능 + 다층 좌표 변경 필수"를 입증.
+
+## 갱신 권고 (작업지시자 결정 필요)
+- **(A) 전면 구현 (별도 대형 타스크)**: is_row_splittable + MeasuredCell 측정 + cell_units +
+  row_cut_content_height + 부분 렌더 매핑을 함께. 정합 최상이나 공유 컷 모델 광범위 회귀 검증 부담.
+- **(B) 보류 + 한계 문서화 (권고)**: 본 결함을 known limitation 으로 기록(troubleshootings),
+  C군(대용량 누적 드리프트)/D군(Shape) 우선 — 비용 대비 효과 우위.
+
+→ PoC 결과상 값싼 부분 수정 경로가 없으므로 (A)는 독립 대형 타스크로 분리, 현 #1073 은 (B)
+권고. 방향 승인 요청.

--- a/mydocs/working/task_m100_1073_stage2.md
+++ b/mydocs/working/task_m100_1073_stage2.md
@@ -1,0 +1,82 @@
+# Stage 2 보고서 — Task #1073: 중첩 표 분할 설계 + 페이퍼 검증
+
+- 브랜치: `local/task1073` (소스 무변경)
+
+## 컷→렌더 데이터 흐름 (현행)
+```
+cell_units(cell) → Vec<CellUnit>            // 셀 콘텐츠 분할 단위
+  ↓ (per-cell 유닛 인덱스)
+advance_row_cut → start_cut/end_cut         // 페이지에 들어가는 유닛 컷
+  ↓
+row_cut_content_height(cut)  = Σ units[su..eu].height   // 행 높이
+cell_line_ranges_from_cut(cut) = per-para (vis_start,vis_end)  // 렌더 가시 줄
+  ↓
+layout_partial_table(start_cut,end_cut) → line_ranges → 가시 줄 렌더
+```
+- **비분할 행**(start/end_cut 빈 Vec): line_ranges 미산출 → 셀 전체 렌더(영향 없음).
+- 현 중첩 표: cell_units 가 **atom 1개**(vis 0..line_count) → is_row_splittable=false(아래) →
+  분할 경로 미진입.
+
+## 설계 — 중첩행을 컷 1급 단위로
+
+### (1) CellUnit 확장
+```rust
+struct CellUnit {
+    height: f64,
+    hard_break_before: bool,
+    para_idx: usize,
+    vis_start: usize,
+    vis_end: usize,
+    nested_row: Option<usize>,   // [신규] 이 유닛이 표현하는 중첩 표 행 인덱스
+}
+```
+- 텍스트 줄 유닛: `nested_row=None` (기존 의미 불변).
+- 중첩 표 유닛: para 당 **per-중첩행 유닛 N개**, `nested_row=Some(ri)`, height=중첩행 높이
+  (+cell_spacing), vis_start/vis_end 는 해당 para 전체 줄 범위(폴백).
+
+### (2) cell_units (table_layout.rs:3519)
+- 중첩 표 보유 para 에서 `resolve_row_heights(nested)` 로 per-행 유닛 push.
+- **2단계 이상 중첩 / rowspan 걸친 중첩행은 범위 외** → 기존 atom 폴백(가드).
+- 단일 셀 1개 nested table(paragraphs.len()==1, find_map 첫 nested) 우선.
+
+### (3) is_row_splittable (height_measurer.rs:1490)
+- 현행: `line_heights.len() > 1`. 중첩 표 셀은 1 → false.
+- 변경: MeasuredCell 에 `nested_row_count: usize`(신규) 추가(측정 시 채움). splittable =
+  `line_heights.len() > 1 || cells.any(nested_row_count > 1)`.
+
+### (4) row_cut_content_height (table_layout.rs:3862)
+- 이미 `Σ units[su..eu].height` → per-중첩행 유닛에 자동 정합.
+- **정합 가드(Stage 3 핵심)**: 비분할 행 `Σ(중첩행 높이) == calc_nested_table_height` 여야
+  기존 측정과 동일(드리프트 0). 불일치 시 보정항 추가.
+
+### (5) 부분 렌더 (table_partial.rs:1067 Control::Table)
+- 현행: `available_h` 휴리스틱으로 `calc_nested_split_rows` 호출.
+- 변경: 분할 행(start_cut/end_cut 존재)일 때 **컷 유닛 인덱스 → 중첩행 범위**로
+  `NestedTableSplit{start_row,end_row,offset_within_start,visible_height}` 구성. 신규 헬퍼
+  `cell_nested_split_from_cut(cell, start_unit, end_unit)`. 비분할 행은 현행 유지.
+
+## 페이퍼 검증 (비회귀)
+
+| 케이스 | cell_units | 분할 경로 | 동작 |
+|------|-----------|----------|------|
+| 중첩 표 없는 셀 | 기존 줄 유닛 | 불변 | 불변 |
+| 중첩 표가 페이지에 들어감(비분할) | per-행 유닛 N | is_whole_row → line_ranges 미산출 | 셀 전체 렌더(불변) |
+| 중첩 표 > 페이지(분할) | per-행 유닛 N | splittable → advance_row_cut 중첩행 컷 | **신규: 중첩행 경계 분할** |
+| 2단계+ 중첩 / rowspan 중첩 | atom 폴백 | 불변 | 불변(범위 외) |
+| TAC 중첩 표 | per-행 유닛(treat_as_char 무관) | 분할 가능 | 검증 필요(Stage 4) |
+
+- 비분할 행 무영향의 근거: line_ranges 는 `is_in_split_row` 에서만 산출(table_partial.rs:569).
+- row_cut_content_height 의 whole-row 합이 atom 높이와 동일해야 함(정합 가드, Stage 3 측정).
+
+## 한컴 정합 기준
+- 중첩행 경계 분할(부분 행 미발생) — `pdf/kps-ai-2022.pdf` p62~63 정합.
+- 부분 행(단일 중첩행 > 페이지)은 우선 행 경계까지만(부분 행 미분할), 발생 시 Stage 4 확장.
+
+## 리스크 / Stage 3 선결
+- **whole-row 높이 정합**: `Σ 중첩행 높이(+spacing) == calc_nested_table_height` 검증 필수
+  (드리프트 0 가드). 불일치 시 전수 sweep 광범위 회귀.
+- 공유 함수(cell_units/row_cut_content_height/cell_line_ranges_from_cut) 변경 → Stage 3 에서
+  dump-pages(kps-ai 청크) + 전수 sweep 단계적 측정.
+
+## 다음 (Stage 3)
+측정·컷 레이어 구현 → kps-ai dump-pages 중첩행 청크 확인 + whole-row 높이 정합 + 전수 sweep 1차.

--- a/mydocs/working/task_m100_1073_stage3.md
+++ b/mydocs/working/task_m100_1073_stage3.md
@@ -1,0 +1,43 @@
+# Stage 3 보고서 — Task #1073: 측정·컷 레이어 구현
+
+- 브랜치: `local/task1073`
+- 수정: `src/renderer/layout/table_layout.rs`, `src/renderer/height_measurer.rs`
+
+## 구현 (컷 레이어, 렌더 전)
+
+### CellUnit + nested_row (table_layout.rs)
+- `CellUnit` 에 `nested_row: Option<usize>` 추가(기존 3 사이트 = None).
+- `cell_units`: **가시 텍스트 없는 문단(`p.text.trim().is_empty()`) + 단일 중첩 표 + 2행 이상**
+  이면 per-중첩행 유닛으로 분해. height = row_h(+cs, +om_top/spacing_before 첫행,
+  +om_bot/spacing_after 끝행) → **Σ = calc_nested_table_height (드리프트 0)**.
+- 2단계+ 중첩 / 텍스트 동거 / rowspan 중첩행은 atom 폴백(범위 외).
+
+### MeasuredCell.nested_split_row_count (height_measurer.rs)
+- 신규 필드: 분해 가능한 중첩 표의 행 수(조건 동일). `is_row_splittable` 가
+  `line_heights.len() > 1 || nested_split_row_count > 1` 로 중첩 표 행 분할 가부 인정.
+
+### 자동 정합
+- `row_cut_content_height` / `cell_line_ranges_from_cut` 는 cell_units 유닛 기반 → 추가 변경 없이
+  per-중첩행 유닛 수용.
+
+## 검증 (dump-pages — 핵심 발견)
+- kps-ai pi=674: 외부 행 분할 `rows=0..2/2..3` → **중첩행 컷** `end_cut=[20] / start_cut=[20]`.
+  page66 = 중첩행 0..20, page67 = 20..29. **LAYOUT_OVERFLOW 758px 해소.**
+- 진단 경위: 중첩 표 para 는 `line_count=0` 이 아니라 `line_count=1`(placeholder) + `text=""`
+  → 최초 `line_count==0` 조건 미스 → `text.trim().is_empty()` 로 정정.
+
+## 전수 sweep (Stage 3 1차) — 회귀 0
+baseline 3057 lines / 382815px → **3055 / 382054px**. 변화 파일 2개, **둘 다 개선**:
+- kps-ai.hwp 10/849px → 9/90px (758 overflow 해소).
+- hwpctl_ParameterSetID_Item_v1.2.hwp 6/53px → 5/51px (보너스 중첩표 케이스).
+- 그 외 281 샘플 변화 0, 신규 overflow 0. **공유 컷 모델 변경 무회귀(페이지네이션 레벨).**
+- lib **1324 passed**, clippy/fmt clean.
+
+## 남은 Stage 4 갭 (렌더)
+페이지네이션 컷은 정확하나 **렌더가 컷을 미반영** — page67(연속)이 `start_cut=[20]` 무시,
+중첩행 0부터 재렌더(중복). 렌더의 `NestedTableSplit` 가 `available_h` 휴리스틱 기반이라
+연속 페이지 start_row 미적용. → Stage 4: 컷(start_cut/end_cut) → NestedTableSplit 배선.
+
+## 다음 (Stage 4)
+부분 렌더 매핑 — 컷 유닛 인덱스 → 중첩행 범위 → NestedTableSplit{start_row,end_row,
+offset_within_start}. kps-ai SVG 가 PDF p62~63 정합.

--- a/mydocs/working/task_m100_1073_stage4.md
+++ b/mydocs/working/task_m100_1073_stage4.md
@@ -1,0 +1,43 @@
+# Stage 4 보고서 — Task #1073: 부분 렌더 매핑 (컷 → NestedTableSplit)
+
+- 브랜치: `local/task1073`
+- 수정: `src/renderer/layout/table_partial.rs`
+
+## 구현
+`layout_partial_table` 의 중첩 표 렌더 분기를 페이지네이션 컷 구동으로 전환:
+- 셀 컷 유닛 `(start_unit, end_unit)` 을 셀 스코프로 hoist(`cut_units`).
+- 셀이 per-중첩행 분해 대상(단일 문단 + 가시 텍스트 없음 + 단일 중첩 표)이면
+  `nested_cut_range = Some((su, eu))` — cut 유닛 인덱스 = 중첩행 범위.
+- 중첩 표 렌더: `nested_cut_range` 가 있으면 `NestedTableSplit{start_row=su, end_row=eu,
+  offset_within_start=0, visible_height=Σrow_h[su..eu]}` 직접 구성(연속 페이지 start_row 반영).
+  없으면 기존 `available_h` 휴리스틱 폴백(비분할/비대상 불변).
+
+## 검증 (kps-ai)
+- **연속 페이지 정정**: page67(연속)이 더 이상 중첩행 0(제목)부터 재렌더하지 않음.
+  - page66: 제목 ~ 3.민간소프트웨어 섹션(있음/없음/※없음) — PDF p62 정합.
+  - page67: 시장침해 가능성 ~ 4.사업의 필요성 ~ 5.종합의견 — PDF p63 정합.
+  - 전체 중복 렌더 제거, 본문 누락 없음, overflow 없음.
+- **잔여(rowspan 라벨 누수)**: 중첩 표 내부 rowspan 섹션 라벨("3.민간소프트웨어")이 분할 경계를
+  걸칠 때 연속 페이지(page67) 상단에도 그려짐. PDF p63 은 해당 라벨 공란. 외부 표의
+  `advance_row_block_cut`(rs>1 라벨 연속 조각 공란) 처리가 **중첩 표 분할엔 미적용**.
+  → 본문/구조 정합은 달성, **rowspan 라벨 블랭킹만 잔여**(별도 정밀화).
+
+## 회귀 (Stage 4)
+- 전수 sweep 3055 lines / 382054px (Stage 3 동일 — 렌더 변경은 overflow 미영향).
+- 골든 SVG **8/8**, clippy/fmt clean.
+
+## Stage 4b — rowspan 라벨 블랭킹 (승인: 가)
+`layout_table_cells`: 중첩 표 분할 연속 페이지(row_filter `sr>0`)에서 분할 시작 행보다 먼저
+시작한 rowspan 셀(`r < sr`)의 `composed_paras` 를 clear → 라벨 텍스트 미렌더(영역/배경만).
+row_filter 는 중첩 표 분할 전용(외부 표는 layout_partial_table 경로)이라 외부 표 무영향.
+
+검증:
+- page67: "3.민간소프트웨어"/"시장침해 가능성" rowspan 라벨 공란화 → "주요기능…" 부터 시작.
+- 누락 검사: "시장침해" p66(라벨 1)·p67(섹션5 내용 2), footer(기관명…직인) p67 완결 → **콘텐츠
+  완전, 누락/중복 없음**.
+- 골든 8/8, lib 1324, 전수 sweep 3055/382054(무회귀), clippy/fmt clean.
+
+## 잔여 (minor) — break 위치 정밀도
+rhwp 컷이 한컴(PDF p62/p63) 대비 ~2 중첩행 늦음(시장침해 블록을 p66 에서 시작) → 블록이 페이지
+경계를 걸쳐 라벨은 p66, 잔여는 p67(공란). 콘텐츠/구조 정합·overflow 0 달성, **break row 정확
+일치만 잔여**(available-height/overhead 측정 정밀도). known limitation 로 기록, 별도 정밀화 대상.

--- a/mydocs/working/task_m100_1073_stage5.md
+++ b/mydocs/working/task_m100_1073_stage5.md
@@ -1,0 +1,26 @@
+# Stage 5 보고서 — Task #1073: 회귀 가드 + 최종 검증
+
+- 브랜치: `local/task1073`
+- 신규: `tests/issue_1073_nested_table_split.rs`
+
+## 회귀 가드 (kps-ai.hwp, 공개 샘플) — 3/3 통과
+- `kps_ai_nested_table_first_chunk_no_overflow`: page 65(첫 조각) text max_y ≤ 페이지 높이
+  (758px overflow 회귀 차단).
+- `kps_ai_nested_table_continuation_no_overflow`: page 66(연속) 동일.
+- `kps_ai_nested_table_split_no_title_duplication`: 첫 조각에 표 제목("소프트웨어사업") 존재 +
+  연속 페이지엔 제목 미존재 → 분할 발생 + 전체 재렌더 중복/rowspan 라벨 누수 회귀 차단.
+
+## 최종 검증
+- 전수 sweep: baseline 3057 lines / 382815px → **3055 / 382054px** (회귀 0; kps-ai 758
+  overflow 해소, hwpctl_ParameterSetID 보너스 개선).
+- 골든 SVG **8/8**, `cargo test --release` 전체 0 failed(lib 1324 + 통합, 신규 3 포함),
+  clippy clean, fmt clean.
+
+## 잔여 (known limitation)
+- 중첩 표 분할 break row 가 한컴(PDF) 대비 ~2 중첩행 늦음(available-height/overhead 측정
+  정밀도). 콘텐츠/구조 정합·overflow 0 달성, break 정확 일치만 잔여 → 별도 정밀화 대상.
+- 범위 외(atom 폴백 유지): 2단계+ 중첩, 텍스트 동거 문단의 중첩 표.
+
+## 결론
+중첩 표(셀 내부 표)가 페이지보다 클 때 중첩행 단위 페이지 분할 구현 완료 — kps-ai 758px
+overflow 해소, 한컴 PDF 구조 정합, 비회귀 0. 최종 보고서 → PR.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -146,6 +146,9 @@ pub struct MeasuredCell {
     pub para_line_counts: Vec<usize>,
     /// 셀 내 중첩 표 포함 여부
     pub has_nested_table: bool,
+    /// [Task #1073] 셀이 분할 가능한 단일 중첩 표(텍스트 없는 문단 + 2행 이상)를 가지면
+    /// 그 표의 행 수. 아니면 0. `is_row_splittable` 가 중첩행 분할 가부 판정에 사용.
+    pub nested_split_row_count: usize,
 }
 
 /// 구역 전체의 측정 결과
@@ -1137,6 +1140,33 @@ impl HeightMeasurer {
                         .iter()
                         .any(|p| p.controls.iter().any(|c| matches!(c, Control::Table(_))));
 
+                    // [Task #1073] cell_units 의 per-중첩행 분해 조건과 동일:
+                    // 텍스트 없는 문단(line_segs 합성 줄 0) + 단일 중첩 표 + 2행 이상.
+                    let nested_split_row_count = cell
+                        .paragraphs
+                        .iter()
+                        .filter_map(|p| {
+                            let tables: Vec<&crate::model::table::Table> = p
+                                .controls
+                                .iter()
+                                .filter_map(|c| match c {
+                                    Control::Table(t) => Some(t.as_ref()),
+                                    _ => None,
+                                })
+                                .collect();
+                            // 가시 텍스트 없는 문단의 단일 중첩 표만 분해 대상
+                            if p.text.trim().is_empty()
+                                && tables.len() == 1
+                                && tables[0].row_count >= 2
+                            {
+                                Some(tables[0].row_count as usize)
+                            } else {
+                                None
+                            }
+                        })
+                        .next()
+                        .unwrap_or(0);
+
                     MeasuredCell {
                         row: cell.row as usize,
                         col: cell.col as usize,
@@ -1147,6 +1177,7 @@ impl HeightMeasurer {
                         total_content_height: line_sum,
                         para_line_counts,
                         has_nested_table,
+                        nested_split_row_count,
                     }
                 })
                 .collect::<Vec<_>>()
@@ -1496,7 +1527,10 @@ impl MeasuredTable {
         if cells_in_row.is_empty() {
             return false;
         }
-        cells_in_row.iter().any(|c| c.line_heights.len() > 1)
+        // [Task #1073] 다줄 셀 또는 per-중첩행 분해 가능한 중첩 표 셀(2행 이상)이면 분할 가능.
+        cells_in_row
+            .iter()
+            .any(|c| c.line_heights.len() > 1 || c.nested_split_row_count > 1)
     }
 
     /// 지정 행에서 첫 번째 줄의 최소 높이를 반환한다 (인트라-로우 분할 가능 여부 판단용).

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -77,6 +77,9 @@ struct CellUnit {
     /// 텍스트 줄 유닛 = `(li, li+1)`, 중첩/빈 atom = `(0, line_count.max(1))`.
     vis_start: usize,
     vis_end: usize,
+    /// [Task #1073] 이 유닛이 중첩 표의 한 행을 표현하면 그 행 인덱스. 텍스트/일반 유닛은 None.
+    /// 분할 행에서 컷 → `NestedTableSplit`(중첩행 범위) 매핑에 사용.
+    nested_row: Option<usize>,
 }
 
 /// 중첩 표 부분 렌더링을 위한 행 범위 정보
@@ -1683,6 +1686,16 @@ impl LayoutEngine {
                 .iter()
                 .map(|p| compose_paragraph(p))
                 .collect();
+
+            // [Task #1073] 중첩 표 분할 연속 페이지(row_filter sr>0)에서 분할 시작 행보다
+            // 먼저 시작한 rowspan 셀(r < sr)은 라벨이 이전 페이지에 이미 렌더됨 → 연속
+            // 페이지에선 공란(영역/배경만, 텍스트 미렌더). 외부 표 advance_row_block_cut 의
+            // rs>1 라벨 공란 정합. row_filter 는 중첩 표 분할 전용(외부 표는 별도 경로).
+            if let Some((sr, _)) = row_filter {
+                if sr > 0 && r < sr {
+                    composed_paras.clear();
+                }
+            }
 
             // 텍스트 오버플로우 시 좌우 패딩 축소
             let (new_pl, new_pr) = self.shrink_cell_padding_for_overflow(
@@ -3516,6 +3529,52 @@ impl LayoutEngine {
             };
             let has_table_in_para = p.controls.iter().any(|c| matches!(c, Control::Table(_)));
             let line_count = comp.lines.len();
+            // [Task #1073] 텍스트 없는 문단(가시 텍스트 없음 — 합성 줄은 placeholder)에 단일
+            // 중첩 표가 있고 그 표가 2행 이상이면 per-중첩행 유닛으로 분해 — advance_row_cut 가
+            // 중첩 표 행 경계에서 페이지 분할할 수 있게 한다. whole-row 높이 합은
+            // calc_nested_table_height 와 정확히 일치(드리프트 0):
+            // Σ row_h + cs*(n-1) + om_top + om_bottom + spacing.
+            // 2단계+ 중첩/텍스트 동거 문단은 아래 atom 폴백 유지(범위 외).
+            if has_table_in_para && p.text.trim().is_empty() {
+                let nested_tables: Vec<&crate::model::table::Table> = p
+                    .controls
+                    .iter()
+                    .filter_map(|c| match c {
+                        Control::Table(t) => Some(t.as_ref()),
+                        _ => None,
+                    })
+                    .collect();
+                if nested_tables.len() == 1 && nested_tables[0].row_count >= 2 {
+                    let nt = nested_tables[0];
+                    let ncol = nt.col_count as usize;
+                    let nrow = nt.row_count as usize;
+                    let rhs = self.resolve_row_heights(nt, ncol, nrow, None, styles);
+                    let ncs = hwpunit_to_px(nt.cell_spacing as i32, self.dpi);
+                    let om_top = hwpunit_to_px(nt.outer_margin_top as i32, self.dpi);
+                    let om_bot = hwpunit_to_px(nt.outer_margin_bottom as i32, self.dpi);
+                    for (ri, rh) in rhs.iter().enumerate() {
+                        let mut uh = *rh;
+                        if ri + 1 < nrow {
+                            uh += ncs;
+                        }
+                        if ri == 0 {
+                            uh += om_top + spacing_before;
+                        }
+                        if ri + 1 == nrow {
+                            uh += om_bot + spacing_after;
+                        }
+                        units.push(CellUnit {
+                            height: uh,
+                            hard_break_before: reset_before && ri == 0,
+                            para_idx: pi,
+                            vis_start: 0,
+                            vis_end: line_count.max(1),
+                            nested_row: Some(ri),
+                        });
+                    }
+                    continue;
+                }
+            }
             if line_count == 0 || has_table_in_para {
                 // 중첩 표/빈 문단 — atomic 유닛 1개.
                 let nested_h: f64 = p
@@ -3566,6 +3625,7 @@ impl LayoutEngine {
                     para_idx: pi,
                     vis_start: 0,
                     vis_end: line_count.max(1),
+                    nested_row: None,
                 });
             } else {
                 // 일반 텍스트 문단 — 합성 줄마다 유닛 1개.
@@ -3587,6 +3647,7 @@ impl LayoutEngine {
                         para_idx: pi,
                         vis_start: li,
                         vis_end: li + 1,
+                        nested_row: None,
                     });
                 }
             }
@@ -3629,6 +3690,7 @@ impl LayoutEngine {
                         para_idx: last_para,
                         vis_start: 0,
                         vis_end: 0,
+                        nested_row: None,
                     });
                     remaining -= h;
                 }

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -567,8 +567,8 @@ impl LayoutEngine {
 
             // 분할 행: [Task #993/#1025] start_cut/end_cut(유닛 컷)으로 표시할 줄 범위 계산.
             // 블록 분할이면 블록-셀 (row,col) 인덱스, 그 외는 행내 row_span==1 col 인덱스.
-            let line_ranges: Option<Vec<(usize, usize)>> = if is_in_split_row {
-                let (start_unit, end_unit) = if is_block_split {
+            let cut_units: Option<(usize, usize)> = if is_in_split_row {
+                let pair = if is_block_split {
                     let su = match (is_split_start_row, split_start_block) {
                         (true, Some((bs, be))) => block_cut_index(table, bs, be, cell)
                             .and_then(|i| start_cut.get(i).copied())
@@ -600,10 +600,25 @@ impl LayoutEngine {
                     };
                     (su, eu)
                 };
-                Some(self.cell_line_ranges_from_cut(cell, table, styles, start_unit, end_unit))
+                Some(pair)
             } else {
                 None
             };
+            let line_ranges: Option<Vec<(usize, usize)>> = cut_units
+                .map(|(su, eu)| self.cell_line_ranges_from_cut(cell, table, styles, su, eu));
+            // [Task #1073] 이 셀이 per-중첩행 분해 대상(단일 문단 + 가시 텍스트 없음 + 단일
+            // 중첩 표 2행+)이면 cut 유닛 인덱스가 곧 중첩행 범위 → 렌더 NestedTableSplit 에
+            // start_row 로 전달(연속 페이지가 중첩행 0부터 재렌더되는 결함 정정).
+            let nested_cut_range: Option<(usize, usize)> = cut_units.filter(|_| {
+                cell.paragraphs.len() == 1
+                    && cell.paragraphs[0].text.trim().is_empty()
+                    && cell.paragraphs[0]
+                        .controls
+                        .iter()
+                        .filter(|c| matches!(c, crate::model::control::Control::Table(_)))
+                        .count()
+                        == 1
+            });
 
             // 셀 내 텍스트 높이 (분할 행이면 줄 범위 내만 계산)
             // spacing_before: 셀 첫 문단 제외, spacing_after: 셀 마지막 문단 제외
@@ -1118,7 +1133,39 @@ impl LayoutEngine {
                                     };
 
                                     // 중첩 표가 가용 공간을 초과하면 NestedTableSplit 적용
-                                    let split_info = if nested_h > available_h + 0.5 {
+                                    let split_info = if let Some((su, eu)) = nested_cut_range {
+                                        // [Task #1073] 페이지네이션 컷(중첩행 범위)으로 직접
+                                        // NestedTableSplit 구성 — 연속 페이지가 start_row 부터
+                                        // 렌더(available_h 휴리스틱의 row0 재렌더 결함 정정).
+                                        let ncol = nested_table.col_count as usize;
+                                        let nrow = nested_table.row_count as usize;
+                                        let nrow_heights = self.resolve_row_heights(
+                                            nested_table,
+                                            ncol,
+                                            nrow,
+                                            None,
+                                            styles,
+                                        );
+                                        let ncs = hwpunit_to_px(
+                                            nested_table.cell_spacing as i32,
+                                            self.dpi,
+                                        );
+                                        let start_row = su.min(nrow);
+                                        let end_row = eu.min(nrow);
+                                        let mut vis_h = 0.0;
+                                        for r in start_row..end_row {
+                                            vis_h += nrow_heights[r];
+                                            if r + 1 < end_row {
+                                                vis_h += ncs;
+                                            }
+                                        }
+                                        Some(NestedTableSplit {
+                                            start_row,
+                                            end_row,
+                                            visible_height: vis_h,
+                                            offset_within_start: 0.0,
+                                        })
+                                    } else if nested_h > available_h + 0.5 {
                                         let ncol = nested_table.col_count as usize;
                                         let nrow = nested_table.row_count as usize;
                                         let nrow_heights = self.resolve_row_heights(

--- a/tests/issue_1073_nested_table_split.rs
+++ b/tests/issue_1073_nested_table_split.rs
@@ -1,0 +1,109 @@
+//! Issue #1073: 셀 안의 페이지보다 큰 중첩 표(nested table)가 페이지 경계에서 중첩 표
+//! 행 단위로 분할되는지 회귀 가드.
+//!
+//! 재현 문서 (tracked 공개 샘플): `samples/kps-ai.hwp` (HWP5).
+//! 한컴 정답지: `pdf/kps-ai-2022.pdf` p62~63 — "소프트웨어사업 영향평가 결과서" 표를
+//! 페이지에 걸쳐 행 단위로 분할.
+//!
+//! 결함 본질: 중첩 표가 is_row_splittable/cell_units/부분 렌더에서 atom 으로 취급되어
+//! 외부 행이 통째 배치 → 758px overflow + 연속 페이지 전체 재렌더.
+//! 정정: cell_units per-중첩행 유닛 분해 + NestedTableSplit 컷 구동 + 연속 페이지 rowspan
+//! 라벨 공란화.
+//!
+//! pi=674 표가 걸치는 페이지(0-based global index): 65(첫 조각), 66(연속).
+
+use std::fs;
+use std::path::Path;
+
+fn load_doc(rel: &str) -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse")
+}
+
+fn svg_height(svg: &str) -> f64 {
+    let i = svg.find("height=\"").expect("svg height attr") + "height=\"".len();
+    let rest = &svg[i..];
+    let end = rest.find('"').expect("height close");
+    rest[..end].parse().expect("height f64")
+}
+
+fn max_text_y(svg: &str) -> f64 {
+    let mut max = 0.0_f64;
+    let mut rest = svg;
+    while let Some(open) = rest.find("<text") {
+        let tag_end = rest[open..]
+            .find('>')
+            .map(|g| open + g)
+            .unwrap_or(rest.len());
+        let tag = &rest[open..tag_end];
+        if let Some(yi) = tag.find(" y=\"") {
+            let yrest = &tag[yi + 4..];
+            if let Some(ye) = yrest.find('"') {
+                if let Ok(y) = yrest[..ye].parse::<f64>() {
+                    max = max.max(y);
+                }
+            }
+        }
+        rest = &rest[tag_end..];
+    }
+    max
+}
+
+/// SVG 내 모든 `<text>` 내용을 이어붙인다(부분 문자열 검색용).
+fn svg_text(svg: &str) -> String {
+    let mut out = String::new();
+    let mut rest = svg;
+    while let Some(open) = rest.find("<text") {
+        if let Some(gt) = rest[open..].find('>') {
+            let after = &rest[open + gt + 1..];
+            if let Some(close) = after.find("</text>") {
+                out.push_str(&after[..close]);
+                rest = &after[close + 7..];
+                continue;
+            }
+        }
+        break;
+    }
+    out
+}
+
+#[test]
+fn kps_ai_nested_table_first_chunk_no_overflow() {
+    let doc = load_doc("samples/kps-ai.hwp");
+    let svg = doc.render_page_svg_native(65).expect("render page 65");
+    let (h, max_y) = (svg_height(&svg), max_text_y(&svg));
+    assert!(
+        max_y <= h,
+        "kps-ai page 65(첫 조각): text max_y={max_y:.1} > 페이지 높이 {h:.1} (중첩 표 미분할 회귀)"
+    );
+}
+
+#[test]
+fn kps_ai_nested_table_continuation_no_overflow() {
+    let doc = load_doc("samples/kps-ai.hwp");
+    let svg = doc.render_page_svg_native(66).expect("render page 66");
+    let (h, max_y) = (svg_height(&svg), max_text_y(&svg));
+    assert!(
+        max_y <= h,
+        "kps-ai page 66(연속): text max_y={max_y:.1} > 페이지 높이 {h:.1}"
+    );
+}
+
+/// 분할이 실제로 일어나며(첫 조각에 표 제목 존재), 연속 페이지가 제목을 재렌더하지 않음
+/// (전체 재렌더 중복 + rowspan 라벨 누수 회귀 차단).
+#[test]
+fn kps_ai_nested_table_split_no_title_duplication() {
+    let doc = load_doc("samples/kps-ai.hwp");
+    let first = svg_text(&doc.render_page_svg_native(65).expect("page 65"));
+    let cont = svg_text(&doc.render_page_svg_native(66).expect("page 66"));
+    const TITLE: &str = "소프트웨어사업";
+    assert!(
+        first.contains(TITLE),
+        "첫 조각(page 65)에 표 제목 누락 — 분할 미발생 의심"
+    );
+    assert!(
+        !cont.contains(TITLE),
+        "연속(page 66)에 표 제목 재렌더 — 전체 재렌더 중복/rowspan 라벨 누수 회귀"
+    );
+}


### PR DESCRIPTION
## 증상
셀 안에 페이지보다 큰 중첩 표가 있는 표가 페이지 경계에서, 외부 행 분할만으로 페이지에 안 들어가 본문 하단을 **758px 초과**(`kps-ai.hwp` pi=674, 외부 3×6 래퍼표 셀[0]의 29행 중첩 표).

## 근본 원인
중첩 표가 `is_row_splittable` / `MeasuredCell` / `cell_units` / 부분 렌더 **4 레이어**에서 atom 으로 취급되어 `advance_row_cut` 진입 자체가 차단.

## 한컴 정답지 (`pdf/kps-ai-2022.pdf` p62~63)
큰 표("소프트웨어사업 영향평가 결과서")를 페이지 경계에서 **행 단위로 분할**.

## 수정 (5점, 4 레이어)
- `CellUnit + nested_row`: 가시 텍스트 없는 단일 중첩 표(2행+) 문단을 per-중첩행 유닛 분해. Σ = `calc_nested_table_height`(드리프트 0).
- `MeasuredCell.nested_split_row_count` + `is_row_splittable` 확장.
- `row_cut_content_height`/`cell_line_ranges_from_cut` 유닛 기반 자동 정합.
- `layout_partial_table`: 컷 유닛 → `NestedTableSplit{start_row,end_row}` 직접 구성(연속 페이지 start_row 반영).
- `layout_table_cells`: 연속 페이지(sr>0)의 `r<sr` rowspan 라벨 셀 공란화(외부 advance_row_block_cut 정합).

## 검증
- kps-ai pi=674: 중첩행 컷 `end_cut=[20]`, **758px overflow 해소**. page66=PDF p62 / page67=PDF p63, 콘텐츠 완전.
- 전수 sweep 3057→3055 lines (**회귀 0**, kps-ai·hwpctl 개선). 회귀 가드 3 신규.
- golden 8/8, `cargo test` lib 1324 + 통합 0 failed, clippy/fmt clean.

## 잔여 (known limitation)
break row 가 한컴 대비 ~2 중첩행 늦음(available-height 측정 정밀도). 구조/콘텐츠 정합·overflow 0 달성. 범위 외(atom 폴백): 2단계+ 중첩, 텍스트 동거 문단.

🤖 Generated with [Claude Code](https://claude.com/claude-code)