### PR TITLE
fix(typeset): 같은 문단 컨트롤 배치를 vertical_offset 기준으로 정합 — para-float 표 vs in-flow 라벨 순서 (closes #1087)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2344,7 +2344,47 @@ impl TypesetEngine {
         let mut para_float_lanes = FloatLaneSet::new();
 
         // 각 컨트롤에 대해 format → fits → place/split
-        for (ctrl_idx, ctrl) in para.controls.iter().enumerate() {
+        // [참고2 순서 역전 fix] para-relative float 표(비-TAC, wrap=위아래, vert=문단)는
+        // 흐름과 무관하게 vertical_offset 위치에 배치되는 out-of-flow 개체다.
+        // para.controls 배열 순서는 시각적 위·아래 순서와 다를 수 있어(한컴은
+        // vertical_offset 으로 위치 결정), 배열 순서대로 처리하면 라벨·표가 역전
+        // 배치된다 (공직기강 참고2: 표 v_off=+3063·라벨 0 → 라벨이 표 뒤 페이지로 밀림).
+        // → vertical_offset 오름차순(시각 위→아래) 안정정렬로 처리 순서를 맞춘다.
+        //   in-flow·TAC 컨트롤은 키 0. 동률은 배열 순서 유지(stable). ctrl_idx 는
+        //   원래 배열 인덱스를 그대로 사용한다 (format_table·measured_tables·
+        //   PageItem 조회가 의존). 국립국어원 pi586(표 v_off=-1796<라벨 0)·pic-in-*
+        //   (전부 0)처럼 표가 라벨보다 먼저인 경우는 정렬상 배열 순서가 유지된다.
+        let float_table_voffset = |ctrl: &Control| -> i32 {
+            match ctrl {
+                Control::Table(t)
+                    if !t.common.treat_as_char
+                        && matches!(
+                            t.common.text_wrap,
+                            crate::model::shape::TextWrap::TopAndBottom
+                        )
+                        && matches!(t.common.vert_rel_to, crate::model::shape::VertRelTo::Para) =>
+                {
+                    t.common.vertical_offset as i32
+                }
+                _ => 0,
+            }
+        };
+        let mut ctrl_order: Vec<usize> = (0..para.controls.len()).collect();
+        ctrl_order.sort_by_key(|&i| float_table_voffset(&para.controls[i]));
+        // is_first_table/is_last_table 는 배열순서가 아닌 "놓이는 순서(ctrl_order)"
+        // 기준으로 잡아, pre/post 텍스트와 spacing 이 실제 배치 첫/마지막 표에 붙도록 한다.
+        let first_placed_table = ctrl_order
+            .iter()
+            .copied()
+            .find(|&i| matches!(para.controls[i], Control::Table(_)));
+        let last_placed_table = ctrl_order
+            .iter()
+            .copied()
+            .rev()
+            .find(|&i| matches!(para.controls[i], Control::Table(_)));
+
+        for ctrl_idx in ctrl_order {
+            let ctrl = &para.controls[ctrl_idx];
             match ctrl {
                 Control::Table(table) => {
                     // [Issue #703] 글앞으로 / 글뒤로 표는 Shape처럼 취급 — 본문 흐름 공간 차지 없음.
@@ -2399,9 +2439,20 @@ impl TypesetEngine {
                     let mt = measured_tables
                         .iter()
                         .find(|mt| mt.para_index == para_idx && mt.control_index == ctrl_idx);
+                    let is_first_placed = first_placed_table == Some(ctrl_idx);
+                    let is_last_placed = last_placed_table == Some(ctrl_idx);
                     if ft.is_tac {
                         self.typeset_tac_table(
-                            st, para_idx, ctrl_idx, para, table, &ft, &fmt, tac_count,
+                            st,
+                            para_idx,
+                            ctrl_idx,
+                            para,
+                            table,
+                            &ft,
+                            &fmt,
+                            tac_count,
+                            is_first_placed,
+                            is_last_placed,
                         );
                     } else if self.try_typeset_empty_para_float_table(
                         st,
@@ -2418,7 +2469,17 @@ impl TypesetEngine {
                         // Empty host para-float table placed by horizontal lane reservation.
                     } else {
                         self.typeset_block_table(
-                            st, para_idx, ctrl_idx, para, table, &ft, &fmt, mt, styles,
+                            st,
+                            para_idx,
+                            ctrl_idx,
+                            para,
+                            table,
+                            &ft,
+                            &fmt,
+                            mt,
+                            styles,
+                            is_first_placed,
+                            is_last_placed,
                         );
                     }
 
@@ -2641,6 +2702,7 @@ impl TypesetEngine {
     }
 
     /// TAC(treat_as_char) 표의 조판.
+    #[allow(clippy::too_many_arguments)]
     fn typeset_tac_table(
         &self,
         st: &mut TypesetState,
@@ -2651,6 +2713,8 @@ impl TypesetEngine {
         ft: &FormattedTable,
         fmt: &FormattedParagraph,
         tac_count: usize,
+        is_first_placed: bool,
+        is_last_placed: bool,
     ) {
         // 다중 TAC 표: LINE_SEG 기반 개별 높이 계산
         let table_height = if tac_count > 1 {
@@ -2685,10 +2749,21 @@ impl TypesetEngine {
             st.advance_column_or_new_page();
         }
 
-        self.place_table_with_text(st, para_idx, ctrl_idx, para, table, fmt, table_height);
+        self.place_table_with_text(
+            st,
+            para_idx,
+            ctrl_idx,
+            para,
+            table,
+            fmt,
+            table_height,
+            is_first_placed,
+            is_last_placed,
+        );
     }
 
     /// 표를 pre-text/table/post-text와 함께 배치한다 (Paginator place_table_fits 동일).
+    #[allow(clippy::too_many_arguments)]
     fn place_table_with_text(
         &self,
         st: &mut TypesetState,
@@ -2698,6 +2773,8 @@ impl TypesetEngine {
         table: &crate::model::table::Table,
         fmt: &FormattedParagraph,
         table_total_height: f64,
+        is_first_placed: bool,
+        is_last_placed: bool,
     ) {
         let vertical_offset = Self::get_table_vertical_offset(table);
         let total_lines = fmt.line_heights.len();
@@ -2738,11 +2815,8 @@ impl TypesetEngine {
             );
 
         // pre-table 텍스트 (첫 번째 표에서만)
-        let is_first_table = !para
-            .controls
-            .iter()
-            .take(ctrl_idx)
-            .any(|c| matches!(c, Control::Table(_)));
+        // [참고2 fix] 배열순서가 아닌 배치순서 기준 (typeset_table_paragraph 산출).
+        let is_first_table = is_first_placed;
         let pre_height: f64 = if pre_table_end_line > 0 && is_first_table {
             let h = fmt.line_advances_sum(0..pre_table_end_line);
             st.current_items.push(PageItem::PartialParagraph {
@@ -2784,11 +2858,7 @@ impl TypesetEngine {
         }
 
         // post-table 텍스트
-        let is_last_table = !para
-            .controls
-            .iter()
-            .skip(ctrl_idx + 1)
-            .any(|c| matches!(c, Control::Table(_)));
+        let is_last_table = is_last_placed;
         let tac_table_count = para
             .controls
             .iter()
@@ -2854,6 +2924,8 @@ impl TypesetEngine {
         fmt: &FormattedParagraph,
         mt: Option<&MeasuredTable>,
         styles: &ResolvedStyleSet,
+        is_first_placed: bool,
+        is_last_placed: bool,
     ) {
         // 표 내 각주를 고려한 가용 높이 계산 (Paginator engine.rs:583-586 동일)
         let table_fn_h = ft.table_footnote_height;
@@ -2906,7 +2978,17 @@ impl TypesetEngine {
                     st.current_height = target_y;
                     // table_total = 0: 표 자체는 cur_h advance 에 영향 없음 (Paper-absolute).
                     // 호스트 본문 lines 만 place_table_with_text 가 pre_height 로 추가.
-                    self.place_table_with_text(st, para_idx, ctrl_idx, para, table, fmt, 0.0);
+                    self.place_table_with_text(
+                        st,
+                        para_idx,
+                        ctrl_idx,
+                        para,
+                        table,
+                        fmt,
+                        0.0,
+                        is_first_placed,
+                        is_last_placed,
+                    );
                     return;
                 }
             }
@@ -2914,7 +2996,17 @@ impl TypesetEngine {
 
         // fits: 전체가 현재 페이지에 들어가는가?
         if st.current_height + table_total <= available {
-            self.place_table_with_text(st, para_idx, ctrl_idx, para, table, fmt, table_total);
+            self.place_table_with_text(
+                st,
+                para_idx,
+                ctrl_idx,
+                para,
+                table,
+                fmt,
+                table_total,
+                is_first_placed,
+                is_last_placed,
+            );
             return;
         }
 
@@ -2931,7 +3023,17 @@ impl TypesetEngine {
             if !st.current_items.is_empty() {
                 st.advance_column_or_new_page();
             }
-            self.place_table_with_text(st, para_idx, ctrl_idx, para, table, fmt, table_total);
+            self.place_table_with_text(
+                st,
+                para_idx,
+                ctrl_idx,
+                para,
+                table,
+                fmt,
+                table_total,
+                is_first_placed,
+                is_last_placed,
+            );
             return;
         }
 


### PR DESCRIPTION
## 배경
#103/#157/#266 후속. #266이 비-TAC wrap=위아래 표의 out-of-flow vpos·높이를 처리했으나, 같은 문단 내
컨트롤 **배치 순서**는 본선 typeset.rs에서 배열 인덱스 순으로 남아 있어, [표, 라벨] 배열 문단에서 라벨이 표 뒤로 역전됩니다.

## 근본 원인
typeset.rs:2277 표 루프가 `para.controls`를 배열 인덱스 순으로 순회. 한컴 정답은 컨트롤 vertical_offset 순:
- 공직기강 pi407: 라벨 0, 표 +3063 → 라벨 먼저
- 국립국어원 pi586: 표 −1796, 라벨 0 → 표 먼저
(둘 다 배열 [표, 라벨]이나 정답 반대)

## 수정
표 루프 진입 전 `para.controls`를 vertical_offset 오름차순 **안정정렬**(동률 시 배열 순서 유지).
데이터 조회용 원래 인덱스는 보존, is_first/last는 배치 순서 기준.

## 검증
- devel 최신 기준 cargo test --lib 1336 passed / svg_snapshot 8골든 불변 / fmt·clippy 통과 / native + WASM
- 전 samples 276개: 페이지수·LAYOUT_OVERFLOW 변동 0
- 한컴 PDF 좌표 대조: 공직기강(22p) 라벨-위 / 국립국어원(35p) 표-라벨 — 둘 다 정합, 회귀 0
**공직기강 문서 확인 예시**
<img width="945" height="325" alt="해결" src="https://github.com/user-attachments/assets/cdca2843-7875-4aaf-8c11-8be2b9ab2ff6" />

- #103 원본 케이스(hwpspec sec3.pi238)도 라벨앞으로 올바로 교정 (v_off 0<9555)