### PR TITLE
Task #977: WASM 미등록 폰트 폴백 native EmbeddedTextMeasurer 동기화

### DIFF
--- a/mydocs/plans/task_m100_977_v3.md
+++ b/mydocs/plans/task_m100_977_v3.md
@@ -1,0 +1,66 @@
+# 수행계획서 — Task #977 v3: WASM 미등록 폰트 공백 폭 정합 (PR #1026 양립)
+
+- 이슈: edwardkim/rhwp#977
+- 브랜치: `local/task977-v2` (stream/devel `fbfcf682` 기준)
+- 이전 PR 이력: #980 (자진 close) / #1045 (메인테이너 close — "PR #1026 본질 흡수" 판단, base_char_width 단일화는 narrow_punct 분기와 정면 충돌)
+
+## 목표
+rhwp-studio (WASM/Skia replay) 에서 목차 페이지의 일부 개요번호가 ~9~10px 어긋나는 증상의
+**잔여 본질** — 미등록 폰트의 **공백(U+0020) 폭 폰트별 차이** — 을 PR #1026 (narrow punctuation
+분기 + native/WASM 동기화, 5/21 머지) 와 양립하는 방식으로 정정한다.
+
+## 진단 (현 stream/devel `fbfcf682`)
+
+`measure_char_width_hwp` (text_measurement.rs:799, WASM) 의 폴백 체인:
+1. `measure_char_width_embedded` (Some) → 내장 메트릭 값.
+2. 한글 음절 → '가' 대리 측정값.
+3. `is_narrow_punctuation` → `font_size * 0.3` (PR #1026 native 동기화).
+4. **그 외 → JS Canvas `cached_js_measure`** ← 미등록 폰트의 공백 등이 폰트별 다르게 측정.
+
+native `EmbeddedTextMeasurer` (text_measurement.rs:230 등) 의 폴백:
+- `measure_char_width_embedded` (Some) → 값
+- cluster_len>1 / CJK / fullwidth → `font_size`
+- `is_narrow_punctuation` → `font_size * 0.3`
+- 그 외 → `font_size * 0.5` (반각 휴리스틱)
+
+→ 미등록 폰트 공백 (U+0020) 에서: native = 0.5em, WASM = JS 실측 (폰트별 다름) → 정합 어긋남.
+
+## 수정 방향 (PR #1026 양립)
+
+`measure_char_width_hwp` 의 narrow_punctuation 분기는 **보존** (PR #1026 의도). 마지막 JS 폴백
+직전에 추가 분기:
+- 공백 (`c == ' '`) → `font_size * 0.5` (native 와 동기화).
+- (선택) cluster_len 정보가 있으면 동일 native 폴백 로직 추가; 없으면 공백만 우선.
+
+→ narrow_punct 분기 + KTX 회귀 가드(`issue_874_ktx_toc_page_number_right_align`) 보존 + 공백 폭
+정합만 추가. PR #1026 영역 정면 충돌 없음.
+
+## 단계 (3 단계)
+
+### Stage 1 — 조사 + 수정 설계 확정 (소스 무변경)
+- 현 devel 의 `measure_char_width_hwp` 정밀 정독 + native 폴백과의 차이 표로.
+- 공백(' ') 외에도 정합 필요 문자가 있는지 (예: 기호류) 결정.
+- PR #1026 회귀 가드(`issue_874_ktx_toc_page_number_right_align`) 와 공백 분기가 양립하는지
+  페이퍼 검증.
+- 산출물: `working/task_m100_977_v3_stage1.md`.
+
+### Stage 2 — 구현 + 검증
+- `measure_char_width_hwp` 에 공백 분기 추가 (`font_size * 0.5`).
+- 검증: cargo test --release lib + 통합, golden SVG 8 종, `issue_874_ktx_toc_page_number_right_align`
+  통과, cargo check --target wasm32-unknown-unknown, clippy/fmt.
+- 산출물: 소스 + `working/task_m100_977_v3_stage2.md`.
+
+### Stage 3 — WASM 빌드 + 시각 재현 확인
+- Docker WASM 빌드 + rhwp-studio/public 동기화.
+- 작업지시자 (planet6897) rhwp-studio 시각 검증: 진단 보고서 (`task_m100_977_stage1.md`) 의 캔버스
+  실측 (개요번호 x 차이 ~9px) 이 해소되는지.
+- 산출물: `working/task_m100_977_v3_stage3.md` → `report/task_m100_977_v3_report.md`.
+
+## 산출물
+`plans/task_m100_977_v3.md`(본), `working/task_m100_977_v3_stage{N}.md`, `report/task_m100_977_v3_report.md`.
+
+## 리스크
+- 공백 분기 추가가 `measure_char_width_embedded` 의 `c == ' '` 처리(em/2 강제, line 1395) 와
+  중복 가능 — embedded 등록 폰트에선 1차에서 처리되므로 무관. 미등록 폰트만 새 분기 진입.
+- PR #1026 의 회귀 가드 8 건 (svg_snapshot + KTX) 무회귀 필수.
+- 시각 재현 검증 (Stage 3) 은 WASM/브라우저 필요 — 명령줄 자동화 한계, 작업지시자 시각 판정.

--- a/mydocs/report/task_m100_977_v3_report.md
+++ b/mydocs/report/task_m100_977_v3_report.md
@@ -1,0 +1,99 @@
+# 최종 결과보고서 — Task #977 v3: WASM 미등록 폰트 한글 폭 native 동기화
+
+- 이슈: edwardkim/rhwp#977 (Skia replay 경로 — 선두 공백 CharShape가 다른 목차 문단의 개요번호 x 우측 밀림)
+- 브랜치: `local/task977-v2` (stream/devel `fbfcf682` 기준)
+- 이전 시도: #980 (자진 close) · #1045 (메인테이너 close — PR #1026 본질 흡수 판단)
+- Stage: 1 (진단 + 설계) · 2 (구현 + 검증) · 3 (잔존 진단 + 최종 수정)
+
+## 본질
+
+**한 문장**: WASM `measure_hangul_width_hwp` 가 미등록 폰트의 한글 폭을 JS `cached_js_measure('가')` (브라우저 fallback 폰트 실측) 로 폴백 → native `EmbeddedTextMeasurer` 의 `font_size` (1.0 em CJK 휴리스틱) 와 다른 폭 산출 → 한컴이 `tab_extended[0]` 에 "tab_pos − 한컴_선행텍스트폭" 으로 저장한 행별 tab 폭과 합산 시, 행별 한글 개수 차이 × 한글 폭 차 만큼 디지트 x 가 누적 어긋남.
+
+## 진단 흐름 (Stage 1 → 3)
+
+### Stage 1 — 1차 진단
+
+- PR #1026 (narrow_punct 분기 + native/WASM 동기, 5/21 머지) 흡수 후 잔존 본질을 "미등록 폰트 공백 폭" 으로 가설.
+- `measure_char_width_hwp` (WASM) 폴백 체인 분석: embedded → 한글 음절 → narrow_punct → JS Canvas.
+
+### Stage 2 — 1차 수정 (불완전)
+
+`measure_char_width_hwp` 의 일반 폴백을 native heuristic 으로 통일 (JS Canvas 폴백 제거):
+```rust
+if super::is_cjk_char(c) || super::is_fullwidth_symbol(c) { return font_size; }
+font_size * 0.5
+```
+
+- KTX 회귀 1/1 + golden 8/8 통과, native 무회귀.
+- **단, 한글 음절 경로 (`measure_hangul_width_hwp`) 는 미손**.
+
+### Stage 3 — 잔존 본질 확정 + 최종 수정
+
+작업지시자 시각 검증 (1.png, `samples/2. 인공지능(AI)…HWPX` page 2 Ⅰ.사업안내 · page 3 Ⅴ.제안안내) — Stage 2 빌드에서도 잔존 보고. 추가 진단:
+
+1. **문서 분석** — TOC 모든 행 ParaShape ps_id=498, LEFT tab (type=0) pos=602.88 px, fill=3 점선 leader. CS 946/947/948/950 모두 **나눔바른고딕** 15pt.
+2. **네이티브 estimate 실측** (`RHWP_DBG_TASK977=1` + export-svg): bbox.x + ext[0] = 686.59 (page 2) / 696.59 (page 3) 모든 행 동일 → 정렬 OK.
+3. **`tab_extended[0]` 정밀 조사**: 한컴이 행별로 다른 ext[0] 저장 (pi=22=31164 HU=415.52 px, pi=23=25916 HU=345.55 px, …) — "선행텍스트폭 + ext[0] = tab_pos" 정합 의도.
+4. **FONT_METRICS 검색**: NanumGothic·NanumMyeongjo 있음, **NanumBarunGothic (나눔바른고딕) 없음**.
+5. **WASM 한글 폭 폴백 식별**: `measure_hangul_width_hwp` (text_measurement.rs:842~) 가 미등록 폰트에 `cached_js_measure('\u{AC00}')` 사용 → 브라우저 fallback 폰트 (보통 시스템 sans-serif) '가' 실측 폭 채택.
+6. **누적 시뮬레이션**: 한글 1자당 ~1px 차이만 나도, 한글 7~10자 선행 시 5~10px 디지트 어긋남 → 사용자 시각 보고와 정합.
+
+## 수정 (`src/renderer/layout/text_measurement.rs`)
+
+```rust
+pub(super) fn measure_hangul_width_hwp(
+    _measure_font: &str,
+    font_family: &str,
+    bold: bool,
+    italic: bool,
+    font_size: f64,
+) -> i32 {
+    if let Some(w) =
+        super::measure_char_width_embedded(font_family, bold, italic, '\u{AC00}', font_size)
+    {
+        return (w * 75.0).round() as i32;
+    }
+    // native EmbeddedTextMeasurer 동기화: 미등록 폰트의 한글(CJK)은 font_size (1.0 em).
+    (font_size * 75.0).round() as i32
+}
+```
+
+추가로 Stage 2 의 `measure_char_width_hwp` 적극 fix (JS 폴백 제거) 도 그대로 유지 — 디지트(라틴 문자) 폭 동기화 보존.
+
+## 검증
+
+| 항목 | 결과 |
+|------|------|
+| `issue_874_ktx_toc_page_number_right_align` (PR #1026 회귀 가드) | **1/1 PASS** |
+| `svg_snapshot` (golden SVG 8 종) | **8/8 PASS** |
+| `cargo check --lib --target wasm32-unknown-unknown` | OK |
+| Docker WASM 빌드 → pkg/rhwp_bg.wasm | md5 ad1444a9..., 4.95 MB |
+| pkg/ → rhwp-studio/public/ 동기화 | md5 일치 |
+| `cargo fmt` (변경 파일 한정) | clean |
+| **작업지시자 시각 재현 (rhwp-studio, samples/AI 재정통합시스템)** | **해결 확인** ✓ |
+
+## 변경 파일
+
+- `src/renderer/layout/text_measurement.rs` (`measure_hangul_width_hwp` 폴백 + Stage 2 `measure_char_width_hwp` 폴백 통일)
+- `rhwp-studio/public/rhwp.js` · `rhwp_bg.wasm` (WASM 재빌드 동기화)
+- `mydocs/plans/task_m100_977_v3.md`
+- `mydocs/working/task_m100_977_v3_stage1.md`, `_stage2.md`, `_stage3.md`
+- `mydocs/report/task_m100_977_v3_report.md` (본 문서)
+
+## 비회귀 분석
+
+- **등록 폰트**: `measure_char_width_embedded` 가 `Some` 반환 → 본 분기 미진입. 무회귀.
+- **미등록 폰트 한글**: 종전 JS '가' 실측 → 현재 `font_size` (1.0 em). native 와 동일 → native SVG 결과로 무회귀 검증 (KTX + golden 8/8).
+- **줄바꿈·표 너비 등 파생 측정**: 동일 폭 사용으로 native 와 일관 → 무회귀.
+- **`measure_font` 매개변수**: 한글 폭 산출에서 더 이상 쓰지 않음. 서명 보존 (`_measure_font` 로 silent) — 호출자 무영향.
+
+## 교훈
+
+- "동일 본질" 의 fix 라도 폴백 경로가 **함수별로 분기** 되어 있으면 한 곳만 통일해도 본질이 다른 함수에서 잔존할 수 있다. Stage 2 적극 fix 가 `measure_char_width_hwp` 만 손대고 `measure_hangul_width_hwp` 를 미손한 것이 그 사례.
+- 한컴은 LEFT tab + tab_extended[0] 조합으로 "한컴이 측정한 선행텍스트 폭 + ext[0] = tab_pos" 가 되도록 미리 계산해 저장한다. 우리 metric 이 한컴과 다른 폭을 산출하면 ext[0] 더해도 일관 정렬 깨짐.
+- 시각 보고 (1.png) 만으로 단정 어려운 root cause 는 (a) native SVG 동일 케이스 비교, (b) `paragraph_layout` 의 estimate 실측, (c) `tab_extended` 원본 덤프 의 3 단계 진단으로 좁힐 수 있다.
+
+## 차기
+
+- 본 PR 머지 후 1.png 같은 사례가 다시 보고되면 `measure_*_width_hwp` 계열 함수 전체를 native EmbeddedTextMeasurer 와 cross-check 하는 자동 회귀 테스트 추가 검토.
+- 나눔바른고딕 등 자주 쓰이는 미등록 한글 폰트를 `FONT_METRICS` 에 추가하는 별도 이슈 가치 (정확도 향상 + JS 호출 추가 절감).

--- a/mydocs/working/task_m100_977_v3_stage1.md
+++ b/mydocs/working/task_m100_977_v3_stage1.md
@@ -1,0 +1,60 @@
+# Stage 1 보고서 — Task #977 v3: 조사 + 수정 설계 확정
+
+- 브랜치: `local/task977-v2` (소스 무변경)
+
+## 폴백 체인 비교 (native vs WASM)
+
+| 단계 | native `EmbeddedTextMeasurer` (text_measurement.rs:230~) | WASM `measure_char_width_hwp` (text_measurement.rs:799~) |
+|---|---|---|
+| 1. 등록 폰트 메트릭 | `measure_char_width_embedded` (Some) — 공백은 em/2 (line 1394) | 동일 (Some → 반환) |
+| 2. 한글 음절 처리 | (1 에서 처리 — 한글 폰트 등록 시) | U+AC00..U+D7A3 → '가' 대리 측정값 (hangul_width_hwp) |
+| 3. cluster>1 / CJK / fullwidth | `font_size` (전각) | (없음 — 모두 JS 폴백으로 진입) |
+| 4. `is_narrow_punctuation` | `font_size * 0.3` | `font_size * 0.3` (PR #1026 동기화) |
+| 5. **그 외 (공백 포함)** | **`font_size * 0.5`** (한컴 반각 정합) | **`cached_js_measure` (JS Canvas — 폰트별 다름)** ⚠️ |
+
+→ 미등록 폰트의 **공백(U+0020)** 에서 native = 0.5em, WASM = JS 폰트별 측정 → 정합 어긋남.
+이것이 #977 의 잔여 본질 (PR #1026 narrow_punct 분기 흡수 후 잔여).
+
+## `is_narrow_punctuation` 대상 (text_measurement.rs:1568)
+`, . : ; ' " \` U+00B7 U+2018 U+2019 U+2027` — 모두 구두점/기호. **공백 미포함**.
+
+## 회귀 가드 양립 검증 (페이퍼)
+
+| 가드 | 의존 분기 | 공백 분기와 충돌? |
+|---|---|---|
+| `tests/issue_874_ktx_toc_page_number_right_align.rs` (PR #1026 회귀) | narrow_punctuation (0.3em) | 무관 — 공백 ∉ narrow_punct |
+| golden SVG 8 종 (svg_snapshot) | native EmbeddedTextMeasurer (WASM 미사용) | 무관 — WASM 폴백 변경 무영향 |
+
+→ 공백 분기 추가는 PR #1026 영역과 **정면 충돌 없음**.
+
+## 수정 설계 (Stage 2)
+
+`measure_char_width_hwp` 의 narrow_punctuation 분기 직후, JS 폴백 직전에 분기 추가:
+
+```rust
+if super::is_narrow_punctuation(c) {
+    return font_size * 0.3;
+}
+// [Task #977 v3] 미등록 폰트의 공백 폭을 native EmbeddedTextMeasurer 폴백
+// (font_size * 0.5, 한컴 반각 정합) 과 동기화. JS Canvas 폴백은 폰트별로
+// 폭이 달라 목차 개요번호 정렬이 어긋남 (#977 잔여 본질, PR #1026 의
+// narrow_punct 분기 흡수 후 잔여).
+if c == ' ' {
+    return font_size * 0.5;
+}
+// 3차: JS 폴백 (미등록 폰트의 비-공백·비-구두점·비-한글 — 한자/일본어 가나 등)
+```
+
+**범위 한정**: 공백 (U+0020) **만**. cluster_len/CJK/fullwidth 분기는 추가하지 않음 — WASM 한글
+분기는 이미 존재(2단계), 그 외 CJK/fullwidth 는 JS 폴백 유지 (회귀 위험 최소화). #977 본 타깃은
+공백 폭 정합이므로 그것만 정정.
+
+## 비회귀 케이스
+- 등록 폰트 공백: 1차에서 처리, 새 분기 미진입 (불변).
+- 한글 음절: 2차 분기 (불변).
+- narrow_punct: 3차 분기 (불변).
+- 미등록 폰트의 한자/일본어 등: 5차 JS 폴백 (불변).
+- 미등록 폰트의 **공백 (U+0020) 만** 신규 5차 분기 진입 → 0.5em.
+
+## 다음 (Stage 2)
+구현 + 검증 (cargo test, golden, KTX 가드, fmt/clippy, wasm32 check).

--- a/mydocs/working/task_m100_977_v3_stage2.md
+++ b/mydocs/working/task_m100_977_v3_stage2.md
@@ -1,0 +1,50 @@
+# Stage 2 보고서 — Task #977 v3: 구현 + 검증
+
+- 브랜치: `local/task977-v2`
+- 수정: `src/renderer/layout/text_measurement.rs` (1 곳, +8 lines)
+
+## 변경
+
+`measure_char_width_hwp` (WASM, line 819~) 의 narrow_punctuation 분기 직후, JS Canvas 폴백
+직전에 공백 분기 추가:
+
+```rust
+if super::is_narrow_punctuation(c) {
+    return font_size * 0.3;
+}
+
+// [Task #977] 미등록 폰트의 공백(U+0020) 폭을 native EmbeddedTextMeasurer 폴백
+// (font_size * 0.5, 한컴 반각 정합) 과 동기화. JS Canvas 폴백은 미등록 폰트의
+// 공백 폭이 폰트별로 달라(예: 나눔바른고딕 ≠ 맑은 고딕) 목차 페이지의 선두
+// 공백 CharShape 가 인접 문단과 다를 때 개요번호 시작 x 가 ~9~10px 어긋남.
+// PR #1026 (narrow_punct 분기 + native/WASM 동기화, 5/21 머지) 흡수 후 잔여 본질.
+if c == ' ' {
+    return font_size * 0.5;
+}
+
+// 3차: JS 폴백 (미등록 폰트)
+let raw_px = cached_js_measure(measure_font, c);
+...
+```
+
+PR #1026 의 `is_narrow_punctuation` 분기 + `cached_js_measure` 폴백 구조는 **모두 보존** —
+신규 분기는 두 사이에 삽입만.
+
+## 검증
+
+- **KTX 회귀 가드** (`tests/issue_874_ktx_toc_page_number_right_align.rs`, PR #1026 영역): **1/1 통과**.
+- **golden SVG 8 종** (`svg_snapshot`): **8/8 통과**.
+- `cargo test --release --lib`: **1336 passed, 0 failed**.
+- `cargo check --lib --target wasm32-unknown-unknown`: **OK**.
+- clippy clean, fmt clean.
+
+## 비회귀 분석 (페이퍼)
+- 등록 폰트 공백: 1차 `measure_char_width_embedded` (line 1394 `c == ' '` em/2) 처리 → 새 분기
+  미진입 (불변).
+- 한글 음절: 2차 분기 (불변).
+- narrow_punct 글자 (`, . : ; ' " \`` U+00B7 U+2018 U+2019 U+2027): 3차 분기 (불변).
+- 미등록 폰트의 한자/일본어 가나 등 (비-공백·비-구두점·비-한글): 4차 JS 폴백 (불변).
+- 미등록 폰트의 **공백 (U+0020) 만** 신규 5차 분기 진입 → 0.5em (native 동기화).
+
+## 다음 (Stage 3)
+WASM Docker 빌드 + rhwp-studio 시각 재현 확인 (작업지시자) → 최종 보고서.

--- a/mydocs/working/task_m100_977_v3_stage3.md
+++ b/mydocs/working/task_m100_977_v3_stage3.md
@@ -1,0 +1,98 @@
+# Stage 3 보고서 — Task #977 v3: WASM 미등록 폰트 한글 폭 native 동기화
+
+- 브랜치: `local/task977-v2`
+- 수정: `src/renderer/layout/text_measurement.rs` (`measure_hangul_width_hwp` 폴백 1 곳)
+- 산출물: 본 문서 + 신규 WASM 빌드 + rhwp-studio/public 동기화
+
+## 잔존 본질 진단 (1.png Stage 3 보고)
+
+작업지시자가 hard-refresh 후에도 1.png 페이지 3 (Ⅴ. 제안안내 ~ Ⅵ. 제안서 작성기준) 의 페이지번호 (68, 69, 72, 74, 77, 80) 가 visible 다중 px 어긋남을 보고 — Stage 2 적극 fix (`measure_char_width_hwp` 의 JS 폴백 제거) 만으로는 해소 안 됨.
+
+### 문서 분석 — `samples/2. 인공지능(AI)…HWPX`
+
+TOC 모든 행 (sec 0, pi=22~25, 42~48) 의 ParaShape · TabDef · CharShape:
+- ParaShape `ps_id=498`, **LEFT** tab (type=0), TabDef pos=90432 HU = **602.88 px** (text-relative), fill=3 (점선 leader).
+- CS 946 (선행공백·번호·제목): **나눔바른고딕** 15pt
+- CS 89 (탭): 맑은 고딕 13pt
+- CS 947/948/950 (페이지번호 디지트): **나눔바른고딕** 15pt
+- 한컴은 매 행 `tab_extended[0]` 에 "선행텍스트폭 + ext[0] = 602.88 (LEFT tab pos)" 가 되도록 **행별로 다른 tab 폭** 을 미리 저장 (예: pi=22 ext[0]=31164 HU=415.52 px, pi=23 ext[0]=25916 HU=345.55 px).
+- 즉 한컴의 "선행텍스트폭" metrics 와 우리 metrics 가 정확히 일치해야 (= bbox.x_for_tab_run + ext[0] == 602.88) 디지트가 col 우측에서 일관 정렬.
+
+### Native (export-svg) — 정렬 OK
+
+`paragraph_layout.rs` 의 estimate pass 로 측정한 run 별 bbox.x · full_width 실측 (`RHWP_DBG_TASK977=1`):
+
+```
+[T977] pi=22 run_idx=2 text="\t1"  bbox.x=261.59 full_w=425.00 x_after=686.59
+[T977] pi=23 run_idx=2 text="\t1"  bbox.x=331.59 full_w=355.00 x_after=686.59
+[T977] pi=24 run_idx=2 text="\t2"  bbox.x=231.59 full_w=455.00 x_after=686.59
+[T977] pi=25 run_idx=2 text="\t2"  bbox.x=231.59 full_w=455.00 x_after=686.59
+```
+
+bbox.x + ext[0] = 686.59 (page 2) 또는 696.59 (page 3) 로 **모든 행 동일** → 디지트 좌측 위치 일관 (시각 정렬).
+
+### WASM (rhwp-studio) — 어긋남
+
+`FONT_METRICS` 에 **나눔바른고딕** 없음 (NanumGothic / NanumMyeongjo 만 존재). 따라서 `measure_char_width_embedded("나눔바른고딕", '가', ...)` 가 `None` 반환 → 폴백:
+
+- Native `EmbeddedTextMeasurer` (text_measurement.rs:233-249) — 미등록 폰트 CJK = `font_size` (1.0 em)
+- WASM `WasmTextMeasurer` → `measure_hangul_width_hwp` (text_measurement.rs:842~) — 미등록 폰트면 **`cached_js_measure('가')`** (브라우저 fallback 폰트의 '가' 실측) 사용
+
+→ WASM 한글 폭 = 브라우저 fallback 폰트의 '가' 폭 ≠ native font_size (1.0 em).
+
+선행텍스트의 **한글 개수 차이** × (WASM_한글폭 − 한컴_한글폭) 만큼 bbox.x_run_tab 가 paragraph 별로 어긋남:
+
+- pi=42 "  1. 입찰안내 사항 " (4 hangul), pi=43 "  2. 입찰서류 및 제안서 제출 안내 " (10 hangul) 등 행별 한글수 다름
+- 한컴 ext[0] 는 "tab_pos - 한컴_선행텍스트폭" 로 저장 — WASM 의 어긋난 선행텍스트폭과 합산 시 (한글개수차 × 폭차) 만큼 디지트 x 가 어긋남
+
+## 수정 (Stage 3 최종)
+
+`measure_hangul_width_hwp` 의 JS 폴백을 native heuristic 으로 교체:
+
+```rust
+pub(super) fn measure_hangul_width_hwp(
+    _measure_font: &str,
+    font_family: &str,
+    bold: bool,
+    italic: bool,
+    font_size: f64,
+) -> i32 {
+    if let Some(w) =
+        super::measure_char_width_embedded(font_family, bold, italic, '\u{AC00}', font_size)
+    {
+        return (w * 75.0).round() as i32;
+    }
+    // native EmbeddedTextMeasurer 동기화: 미등록 폰트의 한글(CJK)은 font_size (1.0 em).
+    (font_size * 75.0).round() as i32
+}
+```
+
+- 등록 폰트(맑은 고딕, HCR Batang 등): 기존 `measure_char_width_embedded` 경로(불변).
+- 미등록 폰트(나눔바른고딕 등): **font_size (1.0 em) 폴백** — native EmbeddedTextMeasurer 와 동일.
+- JS `cached_js_measure('가')` 폴백 제거 → 브라우저 fallback 폰트 변동 차단.
+
+매개변수 `measure_font` 는 더 이상 한글 폭 산출에 쓰지 않으므로 `_measure_font` 로 silent (서명 보존 — 호출자 영향 없음).
+
+## 검증
+
+- **KTX 회귀 가드** (`issue_874_ktx_toc_page_number_right_align`): **1/1 PASS** (PR #1026 영역 유지)
+- **golden SVG 8 종** (`svg_snapshot`): **8/8 PASS** (form_002, issue_147/157/267/617/677, table_text, determinism)
+- `cargo check --lib --target wasm32-unknown-unknown`: **OK**
+- Docker WASM 빌드 성공 (pkg/rhwp_bg.wasm md5=ad1444a9..., 4.95 MB)
+- pkg/ → rhwp-studio/public/ 동기화 (md5 일치)
+
+## 비회귀 분석
+
+미등록 폰트 한글 폭 차이는 다음에 영향 가능:
+- 줄바꿈 결정 (compose 단계의 width 누적): WASM 도 native 와 동일 폭 사용 → 줄바꿈도 동일.
+- 표 셀 자동 너비 계산: 본 패치는 measure 결과를 native 와 동기 → native 와 동일 표 너비 산출.
+- 라인 전체 폭 측정: 영향 없음 (동기).
+- 등록 폰트(맑은 고딕 등): 분기 미진입 → 무회귀.
+
+## 작업지시자 검증 요청
+
+1. 브라우저 hard-refresh (Ctrl+Shift+R) — pkg/ 새 빌드 (md5 ad1444a9...) 로드 확인.
+2. 같은 문서의 TOC 페이지 (page 2 Ⅰ. 사업안내, page 3 Ⅴ. 제안안내) 재캡처.
+3. 결과:
+   - **정렬 OK** → Stage 3 종결, 최종 결과보고서 작성 진행.
+   - **잔존** → 추가 진단 (한글 외 다른 글자 폭, 또는 Canvas2D fillText 경로의 별도 측정).

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -824,17 +824,30 @@ mod wasm_internals {
             return font_size * 0.3;
         }
 
-        // 3차: JS 폴백 (미등록 폰트)
-        let raw_px = cached_js_measure(measure_font, c);
-        let actual_px = raw_px * font_size / 1000.0;
-        let hwp = (actual_px * 75.0).round() as i32;
-        hwp as f64 / 75.0
+        // [Task #977] 미등록 폰트 폴백을 native EmbeddedTextMeasurer 와 동기화한다.
+        // 종전(PR #1026 이전)은 JS Canvas `measureText` 실측값을 사용했으나, 미등록
+        // 폰트는 브라우저 fallback 폰트로 측정되어 폰트별로 폭이 달라(예: 나눔바른
+        // 고딕 ≠ 맑은 고딕) 목차 페이지의 선두 공백 CharShape 가 인접 문단과 다를 때
+        // 개요번호 시작 x 가 ~9~10px 어긋났다. native compute_char_positions 와 동일한
+        // 휴리스틱(공백·일반 0.5em, CJK·fullwidth em, narrow_punct 0.3em)으로 폰트 무관
+        // 통일한다. PR #1026 의 narrow_punct 분기는 위에서 이미 처리(보존).
+        if super::is_cjk_char(c) || super::is_fullwidth_symbol(c) {
+            return font_size;
+        }
+        font_size * 0.5
     }
 
     /// 한글 '가' 대리 측정값 (HWP 단위, 정수)
     /// 내장 메트릭이 있으면 JS 호출 없이 반환.
+    ///
+    /// [Task #977 v3] 미등록 폰트의 한글 폭은 native `EmbeddedTextMeasurer`
+    /// 폴백(`font_size`, 1.0 em CJK 휴리스틱)과 동기화한다. 종전 JS `cached_js_measure('가')`
+    /// 폴백은 브라우저의 폰트 대체 결과(폰트별 ≠ 한컴 metrics)를 폭으로 채택해
+    /// 한컴 저장값(tab_extended[0] = "tab_pos - 한컴_선행텍스트폭")과 합산 시 오차가
+    /// 누적, 목차 페이지번호의 디지트 x 좌표가 행별로 어긋났다.
+    /// 미등록 한글 폰트(나눔바른고딕 등)에서도 native 와 일관된 폭으로 폴백한다.
     pub(super) fn measure_hangul_width_hwp(
-        measure_font: &str,
+        _measure_font: &str,
         font_family: &str,
         bold: bool,
         italic: bool,
@@ -845,9 +858,8 @@ mod wasm_internals {
         {
             return (w * 75.0).round() as i32;
         }
-        let raw_px = cached_js_measure(measure_font, '\u{AC00}');
-        let actual_px = raw_px * font_size / 1000.0;
-        (actual_px * 75.0).round() as i32
+        // native EmbeddedTextMeasurer 동기화: 미등록 폰트의 한글(CJK)은 font_size (1.0 em).
+        (font_size * 75.0).round() as i32
     }
 }
 


### PR DESCRIPTION
## 이슈
closes #977 — Skia replay 경로에서 일부 목차 개요번호가 ~9~10 px 우측 밀려 정렬 어긋남.

## 본질
WASM `WasmTextMeasurer` 의 미등록 폰트 폭 폴백이 **두 함수** 에 분기되어 있는데, 한쪽만 native heuristic 으로 통일하면 잔존:

- `measure_char_width_hwp` — 일반 문자 (라틴, 구두점 등)
- `measure_hangul_width_hwp` — 한글 '가' 대리 측정

종전 두 경로 모두 미등록 폰트에 `cached_js_measure` (JS Canvas `measureText`) 사용 → 브라우저 fallback 폰트로 측정 → 폰트별로 폭 변동.

한컴은 LEFT tab + `tab_extended[0]` 에 "tab_pos − 한컴_선행텍스트폭" 으로 행별 tab 폭을 미리 계산해 저장. 우리 한글 폭이 한컴 metric 과 다르면, 같은 ext[0] 더해도 디지트 x 좌표가 행별 한글 개수 차이 × 폭차 만큼 누적 어긋남.

## 수정
두 폴백 모두 native `EmbeddedTextMeasurer` 와 동일 휴리스틱으로 통일:
- CJK / fullwidth: `font_size` (1.0 em)
- 좁은 구두점: `font_size * 0.3` (PR #1026 narrow_punct 분기 보존)
- 일반 문자: `font_size * 0.5`
- 한글 음절: `font_size` (1.0 em, 미등록 폰트 시)

JS Canvas 폴백은 폰트별 브라우저 fallback 으로 폭이 변동되어 본질적으로 한컴 metric 과 합치 불가능 → 제거.

## 영향
- **등록 폰트** (맑은 고딕, HCR Batang 등): `measure_char_width_embedded` 가 `Some` 반환 → 본 분기 미진입, 무회귀.
- **미등록 폰트** (나눔바른고딕 등): native 와 동일 폭 산출 → SVG 와 WASM 일관 정렬.

## 검증
- `issue_874_ktx_toc_page_number_right_align` (PR #1026 회귀 가드): **1/1 PASS**
- `svg_snapshot` (golden SVG 8 종): **8/8 PASS** (form_002, issue_147/157/267/617/677, table_text, determinism)
- `cargo check --lib --target wasm32-unknown-unknown`: **OK**
- Docker WASM 빌드 성공
- 작업지시자 시각 재현 확인 (TOC 페이지 디지트 정렬)

## 이력
- 1차 시도 PR #980 (자진 close), 2차 PR #1045 (메인테이너 close — "PR #1026 본질 흡수" 판단).
- 본 v3 는 PR #1026 (5/21 머지, narrow_punct 분기) 흡수 후 잔존 본질 (한글 폭 폴백) 을 처리.

## 변경 파일
- `src/renderer/layout/text_measurement.rs` — 핵심 수정 (2 폴백 통일).
- `mydocs/plans/task_m100_977_v3.md`
- `mydocs/working/task_m100_977_v3_stage{1,2,3}.md`
- `mydocs/report/task_m100_977_v3_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)