### PR TITLE
render: expand CanvasKit image replay coverage

### DIFF
--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -885,11 +885,14 @@ export interface LayerImageOp {
   base64?: string;
   imageRef?: number | string;
   fillMode?: string;
+  originalSize?: { width: number; height: number };
+  crop?: { left: number; top: number; right: number; bottom: number };
   effect?: string;
   brightness?: number;
   contrast?: number;
   bakedWatermark?: boolean;
   wrap?: 'behindText' | 'inFrontOfText' | string;
+  transform?: LayerPathTransform;
 }
 
 export interface LayerEquationOp {

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -468,14 +468,17 @@ export class CanvasKitLayerRenderer {
     if (!Number.isFinite(tileHeight) || tileHeight <= 0) tileHeight = imageHeight;
 
     canvas.save();
-    canvas.clipRect(this.rect(op.bbox), this.canvasKit.ClipOp?.Intersect ?? 0, true);
-    if (canvasKitImageFillModeTiles(fillMode)) {
-      this.drawTiledImage(canvas, op.bbox, fillMode, tileWidth, tileHeight, drawImage);
-    } else {
-      const placed = canvasKitImagePlacement(fillMode, op.bbox, tileWidth, tileHeight);
-      drawImage(placed.x, placed.y, tileWidth, tileHeight);
+    try {
+      canvas.clipRect(this.rect(op.bbox), this.canvasKit.ClipOp?.Intersect ?? 0, true);
+      if (canvasKitImageFillModeTiles(fillMode)) {
+        this.drawTiledImage(canvas, op.bbox, fillMode, tileWidth, tileHeight, drawImage);
+      } else {
+        const placed = canvasKitImagePlacement(fillMode, op.bbox, tileWidth, tileHeight);
+        drawImage(placed.x, placed.y, tileWidth, tileHeight);
+      }
+    } finally {
+      canvas.restore();
     }
-    canvas.restore();
   }
 
   private drawImageRect(canvas: SkCanvas, image: SkImage, source: Rect, dest: Rect): void {
@@ -560,6 +563,7 @@ export class CanvasKitLayerRenderer {
   }
 
   private recordImageCoverageGaps(op: LayerImageOp): void {
+    if (op.bakedWatermark) return;
     if (op.effect && op.effect !== 'realPic') {
       this.unsupportedOps.add(`imageEffect:${op.effect}`);
     }

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -40,6 +40,12 @@ import {
   type CanvasKitSurfacePreference,
   type CanvasKitSurfaceRequest,
 } from './render-backend';
+import {
+  canvasKitImageCacheKey,
+  canvasKitImageFillModeTiles,
+  canvasKitImagePlacement,
+  canvasKitImageSourceRect,
+} from './canvaskit/image-replay';
 import { canvaskitClipRightPad } from './canvaskit/policy';
 
 type CanvasKitApi = CanvasKit;
@@ -395,24 +401,154 @@ export class CanvasKitLayerRenderer {
   private renderImage(canvas: SkCanvas, op: LayerImageOp): void {
     const image = this.imageForOp(op);
     if (!image) {
-      this.unsupportedOps.add('image');
+      this.unsupportedOps.add('image:dataMissing');
       return;
     }
+    this.recordImageCoverageGaps(op);
+    this.withImageTransform(canvas, op.bbox, op.transform, () => this.drawImageOp(canvas, image, op));
+  }
+
+  private drawImageOp(canvas: SkCanvas, image: SkImage, op: LayerImageOp): void {
+    const imageWidth = typeof image.width === 'function' ? image.width() : 0;
+    const imageHeight = typeof image.height === 'function' ? image.height() : 0;
+    if (
+      !Number.isFinite(imageWidth)
+      || !Number.isFinite(imageHeight)
+      || imageWidth <= 0
+      || imageHeight <= 0
+      || !this.boundsAreDrawable(op.bbox)
+    ) {
+      this.unsupportedOps.add('image:invalidBounds');
+      return;
+    }
+
+    const crop = canvasKitImageSourceRect(imageWidth, imageHeight, op.crop);
+    const drawImage = (dstX: number, dstY: number, dstW: number, dstH: number) => {
+      const src = crop
+        ? this.canvasKit.XYWHRect(crop.x, crop.y, crop.width, crop.height)
+        : this.canvasKit.XYWHRect(0, 0, imageWidth, imageHeight);
+      this.drawImageRect(canvas, image, src, this.canvasKit.XYWHRect(dstX, dstY, dstW, dstH));
+    };
+
+    const fillMode = op.fillMode ?? 'fitToSize';
+    if (fillMode === 'fitToSize') {
+      drawImage(op.bbox.x, op.bbox.y, op.bbox.width, op.bbox.height);
+      return;
+    }
+
+    let tileWidth = op.originalSize?.width ?? imageWidth;
+    let tileHeight = op.originalSize?.height ?? imageHeight;
+    if (!Number.isFinite(tileWidth) || tileWidth <= 0) tileWidth = imageWidth;
+    if (!Number.isFinite(tileHeight) || tileHeight <= 0) tileHeight = imageHeight;
+
+    canvas.save();
+    canvas.clipRect(this.rect(op.bbox), this.canvasKit.ClipOp?.Intersect ?? 0, true);
+    if (canvasKitImageFillModeTiles(fillMode)) {
+      this.drawTiledImage(canvas, op.bbox, fillMode, tileWidth, tileHeight, drawImage);
+    } else {
+      const placed = canvasKitImagePlacement(fillMode, op.bbox, tileWidth, tileHeight);
+      drawImage(placed.x, placed.y, tileWidth, tileHeight);
+    }
+    canvas.restore();
+  }
+
+  private drawImageRect(canvas: SkCanvas, image: SkImage, source: Rect, dest: Rect): void {
     const paint = new this.canvasKit.Paint();
     paint.setAntiAlias?.(true);
-    const dest = this.rect(op.bbox);
-    const source = typeof image.width === 'function' && typeof image.height === 'function'
-      ? this.canvasKit.XYWHRect(0, 0, image.width(), image.height())
-      : null;
     try {
-      if (source) {
-        canvas.drawImageRect(image, source, dest, paint);
-      } else {
-        canvas.drawImage(image, op.bbox.x, op.bbox.y, paint);
-      }
+      canvas.drawImageRect(image, source, dest, paint);
     } finally {
       paint.delete?.();
     }
+  }
+
+  private drawTiledImage(
+    canvas: SkCanvas,
+    bbox: LayerBounds,
+    fillMode: string,
+    tileWidth: number,
+    tileHeight: number,
+    drawImage: (dstX: number, dstY: number, dstW: number, dstH: number) => void,
+  ): void {
+    const maxTileDraws = 4096;
+    let tileDraws = 0;
+    const drawTile = (x: number, y: number) => {
+      if (tileDraws >= maxTileDraws) return;
+      drawImage(x, y, tileWidth, tileHeight);
+      tileDraws += 1;
+    };
+
+    if (fillMode === 'tileAll') {
+      for (let y = bbox.y; y < bbox.y + bbox.height && tileDraws < maxTileDraws; y += tileHeight) {
+        for (let x = bbox.x; x < bbox.x + bbox.width && tileDraws < maxTileDraws; x += tileWidth) {
+          drawTile(x, y);
+        }
+      }
+    } else if (fillMode === 'tileHorzTop' || fillMode === 'tileHorzBottom') {
+      const y = fillMode === 'tileHorzTop' ? bbox.y : bbox.y + bbox.height - tileHeight;
+      for (let x = bbox.x; x < bbox.x + bbox.width && tileDraws < maxTileDraws; x += tileWidth) {
+        drawTile(x, y);
+      }
+    } else {
+      const x = fillMode === 'tileVertLeft' ? bbox.x : bbox.x + bbox.width - tileWidth;
+      for (let y = bbox.y; y < bbox.y + bbox.height && tileDraws < maxTileDraws; y += tileHeight) {
+        drawTile(x, y);
+      }
+    }
+
+    if (tileDraws >= maxTileDraws) {
+      this.unsupportedOps.add('image:tileLimit');
+    }
+  }
+
+  private withImageTransform(
+    canvas: SkCanvas,
+    bounds: LayerBounds,
+    transform: LayerImageOp['transform'],
+    draw: () => void,
+  ): void {
+    const rotation = transform?.rotation ?? 0;
+    const horzFlip = transform?.horzFlip ?? false;
+    const vertFlip = transform?.vertFlip ?? false;
+    if (rotation === 0 && !horzFlip && !vertFlip) {
+      draw();
+      return;
+    }
+
+    const cx = bounds.x + bounds.width / 2;
+    const cy = bounds.y + bounds.height / 2;
+    canvas.save();
+    try {
+      if (horzFlip || vertFlip) {
+        canvas.translate(cx, cy);
+        canvas.scale(horzFlip ? -1 : 1, vertFlip ? -1 : 1);
+        canvas.translate(-cx, -cy);
+      }
+      if (rotation !== 0) {
+        canvas.rotate(rotation, cx, cy);
+      }
+      draw();
+    } finally {
+      canvas.restore();
+    }
+  }
+
+  private recordImageCoverageGaps(op: LayerImageOp): void {
+    if (op.effect && op.effect !== 'realPic') {
+      this.unsupportedOps.add(`imageEffect:${op.effect}`);
+    }
+    if ((op.brightness ?? 0) !== 0 || (op.contrast ?? 0) !== 0) {
+      this.unsupportedOps.add('imageEffect:brightnessContrast');
+    }
+  }
+
+  private boundsAreDrawable(bounds: LayerBounds): boolean {
+    return Number.isFinite(bounds.x)
+      && Number.isFinite(bounds.y)
+      && Number.isFinite(bounds.width)
+      && Number.isFinite(bounds.height)
+      && bounds.width > 0
+      && bounds.height > 0;
   }
 
   private renderTextRun(canvas: SkCanvas, op: LayerTextRunOp): void {
@@ -533,17 +669,7 @@ export class CanvasKitLayerRenderer {
   }
 
   private imageForOp(op: LayerImageOp): SkImage | null {
-    let key: string | null = null;
-    if (op.imageRef !== undefined) {
-      key = `ref:${String(op.imageRef)}`;
-    } else if (op.base64) {
-      let hash = 2166136261;
-      for (let i = 0; i < op.base64.length; i += 1) {
-        hash ^= op.base64.charCodeAt(i);
-        hash = Math.imul(hash, 16777619);
-      }
-      key = `${op.mime ?? 'application/octet-stream'}:${op.base64.length}:${(hash >>> 0).toString(16)}`;
-    }
+    const key = canvasKitImageCacheKey(op);
     if (!key) return null;
     const cached = this.imageCache.get(key);
     if (cached) return cached;

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -64,6 +64,9 @@ export interface CanvasKitRenderDiagnostics {
 }
 
 export class CanvasKitLayerRenderer {
+  // Prevent pathological tiled fills from monopolizing the render loop.
+  private static readonly MAX_IMAGE_TILE_DRAWS = 4096;
+
   private readonly imageCache = new Map<string, SkImage>();
   private readonly unsupportedOps = new Set<string>();
   private surfaceFallbackReason: string | null = null;
@@ -409,16 +412,39 @@ export class CanvasKitLayerRenderer {
   }
 
   private drawImageOp(canvas: SkCanvas, image: SkImage, op: LayerImageOp): void {
-    const imageWidth = typeof image.width === 'function' ? image.width() : 0;
-    const imageHeight = typeof image.height === 'function' ? image.height() : 0;
+    const imageWithDimensions = image as SkImage & { width?: unknown; height?: unknown };
+    const widthMember = imageWithDimensions.width;
+    const heightMember = imageWithDimensions.height;
+    const imageWidth = typeof widthMember === 'function'
+      ? (widthMember as () => number).call(image)
+      : typeof widthMember === 'number'
+        ? widthMember
+        : null;
+    const imageHeight = typeof heightMember === 'function'
+      ? (heightMember as () => number).call(image)
+      : typeof heightMember === 'number'
+        ? heightMember
+        : null;
+    if (!this.boundsAreDrawable(op.bbox)) {
+      this.unsupportedOps.add('image:invalidBounds');
+      return;
+    }
     if (
-      !Number.isFinite(imageWidth)
+      imageWidth === null
+      || imageHeight === null
+      || !Number.isFinite(imageWidth)
       || !Number.isFinite(imageHeight)
       || imageWidth <= 0
       || imageHeight <= 0
-      || !this.boundsAreDrawable(op.bbox)
     ) {
-      this.unsupportedOps.add('image:invalidBounds');
+      const paint = new this.canvasKit.Paint();
+      paint.setAntiAlias?.(true);
+      try {
+        canvas.drawImage(image, op.bbox.x, op.bbox.y, paint);
+        this.unsupportedOps.add('image:dimensionUnavailable');
+      } finally {
+        paint.delete?.();
+      }
       return;
     }
 
@@ -470,7 +496,7 @@ export class CanvasKitLayerRenderer {
     tileHeight: number,
     drawImage: (dstX: number, dstY: number, dstW: number, dstH: number) => void,
   ): void {
-    const maxTileDraws = 4096;
+    const maxTileDraws = CanvasKitLayerRenderer.MAX_IMAGE_TILE_DRAWS;
     let tileDraws = 0;
     const drawTile = (x: number, y: number) => {
       if (tileDraws >= maxTileDraws) return;

--- a/rhwp-studio/src/view/canvaskit/image-replay.ts
+++ b/rhwp-studio/src/view/canvaskit/image-replay.ts
@@ -1,0 +1,133 @@
+export interface CanvasKitImageBounds {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CanvasKitImageCrop {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
+export interface CanvasKitImageSourceRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface CanvasKitImageCacheKeyInput {
+  imageRef?: number | string;
+  mime?: string;
+  base64?: string;
+}
+
+export function canvasKitImageCacheKey(input: CanvasKitImageCacheKeyInput): string | null {
+  const parts: string[] = [];
+  if (input.imageRef !== undefined) {
+    parts.push(`ref:${String(input.imageRef)}`);
+  }
+  if (input.base64) {
+    parts.push(`${input.mime ?? 'application/octet-stream'}:${input.base64.length}:${fnv1a32(input.base64)}`);
+  }
+  return parts.length > 0 ? parts.join('|') : null;
+}
+
+export function canvasKitImageSourceRect(
+  imageWidth: number,
+  imageHeight: number,
+  crop?: CanvasKitImageCrop,
+): CanvasKitImageSourceRect | null {
+  if (!crop) return null;
+  if (
+    !Number.isFinite(imageWidth)
+    || !Number.isFinite(imageHeight)
+    || imageWidth <= 0
+    || imageHeight <= 0
+    || !Number.isFinite(crop.left)
+    || !Number.isFinite(crop.top)
+    || !Number.isFinite(crop.right)
+    || !Number.isFinite(crop.bottom)
+  ) {
+    return null;
+  }
+
+  const huPerPixel = 75;
+  const x = crop.left / huPerPixel;
+  const y = crop.top / huPerPixel;
+  const width = (crop.right - crop.left) / huPerPixel;
+  const height = (crop.bottom - crop.top) / huPerPixel;
+  if (width <= 0 || height <= 0) return null;
+
+  const clampedX = clamp(x, 0, imageWidth);
+  const clampedY = clamp(y, 0, imageHeight);
+  const clampedWidth = clamp(width, 0, imageWidth - clampedX);
+  const clampedHeight = clamp(height, 0, imageHeight - clampedY);
+  if (clampedWidth <= 0 || clampedHeight <= 0) return null;
+
+  const isCropped = x > 0.5
+    || y > 0.5
+    || Math.abs(clampedWidth - imageWidth) > 1
+    || Math.abs(clampedHeight - imageHeight) > 1;
+  if (!isCropped) return null;
+
+  return {
+    x: clampedX,
+    y: clampedY,
+    width: clampedWidth,
+    height: clampedHeight,
+  };
+}
+
+export function canvasKitImagePlacement(
+  fillMode: string | undefined,
+  bbox: CanvasKitImageBounds,
+  imageWidth: number,
+  imageHeight: number,
+): { x: number; y: number } {
+  switch (fillMode) {
+    case 'centerTop':
+      return { x: bbox.x + (bbox.width - imageWidth) / 2, y: bbox.y };
+    case 'rightTop':
+      return { x: bbox.x + bbox.width - imageWidth, y: bbox.y };
+    case 'leftCenter':
+      return { x: bbox.x, y: bbox.y + (bbox.height - imageHeight) / 2 };
+    case 'center':
+      return { x: bbox.x + (bbox.width - imageWidth) / 2, y: bbox.y + (bbox.height - imageHeight) / 2 };
+    case 'rightCenter':
+      return { x: bbox.x + bbox.width - imageWidth, y: bbox.y + (bbox.height - imageHeight) / 2 };
+    case 'leftBottom':
+      return { x: bbox.x, y: bbox.y + bbox.height - imageHeight };
+    case 'centerBottom':
+      return { x: bbox.x + (bbox.width - imageWidth) / 2, y: bbox.y + bbox.height - imageHeight };
+    case 'rightBottom':
+      return { x: bbox.x + bbox.width - imageWidth, y: bbox.y + bbox.height - imageHeight };
+    case 'leftTop':
+    default:
+      return { x: bbox.x, y: bbox.y };
+  }
+}
+
+export function canvasKitImageFillModeTiles(fillMode: string | undefined): boolean {
+  return fillMode === 'tileAll'
+    || fillMode === 'tileHorzTop'
+    || fillMode === 'tileHorzBottom'
+    || fillMode === 'tileVertLeft'
+    || fillMode === 'tileVertRight';
+}
+
+function fnv1a32(value: string): string {
+  let hash = 2166136261;
+  for (let i = 0; i < value.length; i += 1) {
+    hash ^= value.charCodeAt(i);
+    hash = Math.imul(hash, 16777619);
+  }
+  return (hash >>> 0).toString(16);
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}

--- a/rhwp-studio/src/view/canvaskit/image-replay.ts
+++ b/rhwp-studio/src/view/canvaskit/image-replay.ts
@@ -19,6 +19,12 @@ export interface CanvasKitImageSourceRect {
   height: number;
 }
 
+/**
+ * HWPUNIT image crop coordinates use the same 96 DPI scale as SVG replay:
+ * 7200 HWPUNIT = 96 px, so 75 HWPUNIT = 1 px.
+ */
+export const HWPUNIT_PER_PIXEL = 75;
+
 export interface CanvasKitImageCacheKeyInput {
   imageRef?: number | string;
   mime?: string;
@@ -55,11 +61,10 @@ export function canvasKitImageSourceRect(
     return null;
   }
 
-  const huPerPixel = 75;
-  const x = crop.left / huPerPixel;
-  const y = crop.top / huPerPixel;
-  const width = (crop.right - crop.left) / huPerPixel;
-  const height = (crop.bottom - crop.top) / huPerPixel;
+  const x = crop.left / HWPUNIT_PER_PIXEL;
+  const y = crop.top / HWPUNIT_PER_PIXEL;
+  const width = (crop.right - crop.left) / HWPUNIT_PER_PIXEL;
+  const height = (crop.bottom - crop.top) / HWPUNIT_PER_PIXEL;
   if (width <= 0 || height <= 0) return null;
 
   const clampedX = clamp(x, 0, imageWidth);

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -9,6 +9,11 @@ import {
   resolveRenderBackendRequest,
   resolveRenderProfile,
 } from '../src/view/render-backend.ts';
+import {
+  canvasKitImageCacheKey,
+  canvasKitImagePlacement,
+  canvasKitImageSourceRect,
+} from '../src/view/canvaskit/image-replay.ts';
 
 test('render backend resolver keeps Canvas2D as the default and accepts skia aliases', () => {
   assert.equal(resolveRenderBackend(''), 'canvas2d');
@@ -82,4 +87,28 @@ test('CanvasKit replay bridge fallback keeps compat on direct replay contract', 
   assert.match(fallback, /directReplayRequired:\s*true/);
   assert.equal(fallback.includes("mode === 'compat'"), false);
   assert.equal(fallback.includes("mode === 'default'"), false);
+});
+
+test('CanvasKit image replay cache key includes payload fingerprint with repeated image refs', () => {
+  const first = canvasKitImageCacheKey({ imageRef: 7, mime: 'image/png', base64: 'AAAA' });
+  const second = canvasKitImageCacheKey({ imageRef: 7, mime: 'image/png', base64: 'BBBB' });
+  assert.notEqual(first, second);
+  assert.ok((first ?? '').startsWith('ref:7|image/png:4:'));
+});
+
+test('CanvasKit image crop source follows the same HWPUNIT crop scale as SVG replay', () => {
+  const crop = canvasKitImageSourceRect(2320, 354, { left: 0, top: 0, right: 102366, bottom: 26580 });
+  assert.ok(crop);
+  assert.equal(crop.x, 0);
+  assert.equal(crop.y, 0);
+  assert.ok(Math.abs(crop.width - 1364.88) < 0.01);
+  assert.equal(crop.height, 354);
+  assert.equal(canvasKitImageSourceRect(2320, 354, { left: 0, top: 0, right: 174000, bottom: 26580 }), null);
+});
+
+test('CanvasKit image placement follows layer fill-mode anchors', () => {
+  const bbox = { x: 10, y: 20, width: 100, height: 80 };
+  assert.deepEqual(canvasKitImagePlacement('center', bbox, 40, 20), { x: 40, y: 50 });
+  assert.deepEqual(canvasKitImagePlacement('rightBottom', bbox, 40, 20), { x: 70, y: 80 });
+  assert.deepEqual(canvasKitImagePlacement('leftTop', bbox, 40, 20), { x: 10, y: 20 });
 });

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -11,8 +11,10 @@ import {
 } from '../src/view/render-backend.ts';
 import {
   canvasKitImageCacheKey,
+  canvasKitImageFillModeTiles,
   canvasKitImagePlacement,
   canvasKitImageSourceRect,
+  HWPUNIT_PER_PIXEL,
 } from '../src/view/canvaskit/image-replay.ts';
 
 test('render backend resolver keeps Canvas2D as the default and accepts skia aliases', () => {
@@ -101,7 +103,7 @@ test('CanvasKit image crop source follows the same HWPUNIT crop scale as SVG rep
   assert.ok(crop);
   assert.equal(crop.x, 0);
   assert.equal(crop.y, 0);
-  assert.ok(Math.abs(crop.width - 1364.88) < 0.01);
+  assert.ok(Math.abs(crop.width - (102366 / HWPUNIT_PER_PIXEL)) < 0.01);
   assert.equal(crop.height, 354);
   assert.equal(canvasKitImageSourceRect(2320, 354, { left: 0, top: 0, right: 174000, bottom: 26580 }), null);
 });
@@ -111,4 +113,13 @@ test('CanvasKit image placement follows layer fill-mode anchors', () => {
   assert.deepEqual(canvasKitImagePlacement('center', bbox, 40, 20), { x: 40, y: 50 });
   assert.deepEqual(canvasKitImagePlacement('rightBottom', bbox, 40, 20), { x: 70, y: 80 });
   assert.deepEqual(canvasKitImagePlacement('leftTop', bbox, 40, 20), { x: 10, y: 20 });
+});
+
+test('CanvasKit image fill-mode tiling detection stays explicit', () => {
+  for (const mode of ['tileAll', 'tileHorzTop', 'tileHorzBottom', 'tileVertLeft', 'tileVertRight']) {
+    assert.equal(canvasKitImageFillModeTiles(mode), true);
+  }
+  for (const mode of [undefined, 'fitToSize', 'none', 'center', 'leftTop', 'rightBottom']) {
+    assert.equal(canvasKitImageFillModeTiles(mode), false);
+  }
 });

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -1,7 +1,9 @@
 use serde::Serialize;
 use std::collections::BTreeMap;
 
-use crate::model::style::UnderlineType;
+use crate::model::image::ImageEffect;
+use crate::model::shape::TextWrap;
+use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
     CacheHint, ClipKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp, TextDecorationKind,
     TextVariantKind,
@@ -10,7 +12,7 @@ use crate::renderer::layer_renderer::{
     analyze_text_variant_selection, TextVariantSelectionOptions, VariantSelectedReason,
     VariantSelectionBackend,
 };
-use crate::renderer::render_tree::{FieldMarkerType, PageBackgroundNode, TextRunNode};
+use crate::renderer::render_tree::{FieldMarkerType, ImageNode, PageBackgroundNode, TextRunNode};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -330,9 +332,7 @@ impl CanvasKitReplayPlanBuilder {
                 item.detail = Some("footnoteMarker".to_string());
                 item
             }
-            PaintOp::Image { .. } => {
-                self.transition_overlay_item(path, "image", CanvasKitReplayFeature::RasterImage)
-            }
+            PaintOp::Image { image, .. } => self.image_item(path, image),
             PaintOp::Equation { .. } => {
                 self.transition_overlay_item(path, "equation", CanvasKitReplayFeature::Equation)
             }
@@ -411,6 +411,20 @@ impl CanvasKitReplayPlanBuilder {
             item
         } else {
             direct_item(path, "textRun", CanvasKitReplayFeature::TextRun)
+        }
+    }
+
+    fn image_item(&self, path: String, image: &ImageNode) -> CanvasKitReplayItem {
+        let detail = image_transition_detail(image);
+        if image_can_replay_directly(image) {
+            let mut item = direct_item(path, "image", CanvasKitReplayFeature::RasterImage);
+            item.detail = detail;
+            item
+        } else {
+            let mut item =
+                self.transition_overlay_item(path, "image", CanvasKitReplayFeature::RasterImage);
+            item.detail = detail;
+            item
         }
     }
 
@@ -595,6 +609,95 @@ fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
     None
 }
 
+fn image_transition_detail(image: &ImageNode) -> Option<String> {
+    let mut detail = Vec::new();
+    if image.data.is_none() {
+        if image.external_path.is_some() {
+            detail.push("externalImage".to_string());
+        } else {
+            detail.push("missingImageData".to_string());
+        }
+    }
+    if let Some(fill_mode) = image.fill_mode {
+        detail.push(format!("fillMode={}", image_fill_mode_detail(fill_mode)));
+    }
+    if image.crop.is_some() {
+        detail.push("crop".to_string());
+    }
+    if !matches!(image.effect, ImageEffect::RealPic) {
+        detail.push(format!("effect={}", image_effect_detail(image.effect)));
+    }
+    if image.brightness != 0 || image.contrast != 0 {
+        detail.push(format!(
+            "adjustment=brightness:{},contrast:{}",
+            image.brightness, image.contrast
+        ));
+    }
+    if let Some(wrap) = image.text_wrap {
+        detail.push(format!("wrap={}", text_wrap_detail(wrap)));
+    }
+    if image.transform.has_transform() {
+        detail.push("transform".to_string());
+    }
+    if image.header_footer_ref.is_some() {
+        detail.push("headerFooterImage".to_string());
+    }
+    if detail.is_empty() {
+        None
+    } else {
+        Some(detail.join(";"))
+    }
+}
+
+fn image_can_replay_directly(image: &ImageNode) -> bool {
+    image.data.is_some()
+        && image.external_path.is_none()
+        && matches!(image.effect, ImageEffect::RealPic)
+        && image.brightness == 0
+        && image.contrast == 0
+}
+
+fn image_effect_detail(value: ImageEffect) -> &'static str {
+    match value {
+        ImageEffect::RealPic => "realPic",
+        ImageEffect::GrayScale => "grayScale",
+        ImageEffect::BlackWhite => "blackWhite",
+        ImageEffect::Pattern8x8 => "pattern8x8",
+    }
+}
+
+fn image_fill_mode_detail(value: ImageFillMode) -> &'static str {
+    match value {
+        ImageFillMode::TileAll => "tileAll",
+        ImageFillMode::TileHorzTop => "tileHorzTop",
+        ImageFillMode::TileHorzBottom => "tileHorzBottom",
+        ImageFillMode::TileVertLeft => "tileVertLeft",
+        ImageFillMode::TileVertRight => "tileVertRight",
+        ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Center => "center",
+        ImageFillMode::CenterTop => "centerTop",
+        ImageFillMode::CenterBottom => "centerBottom",
+        ImageFillMode::LeftCenter => "leftCenter",
+        ImageFillMode::LeftTop => "leftTop",
+        ImageFillMode::LeftBottom => "leftBottom",
+        ImageFillMode::RightCenter => "rightCenter",
+        ImageFillMode::RightTop => "rightTop",
+        ImageFillMode::RightBottom => "rightBottom",
+        ImageFillMode::None => "none",
+    }
+}
+
+fn text_wrap_detail(value: TextWrap) -> &'static str {
+    match value {
+        TextWrap::Square => "square",
+        TextWrap::Tight => "tight",
+        TextWrap::Through => "through",
+        TextWrap::TopAndBottom => "topAndBottom",
+        TextWrap::BehindText => "behindText",
+        TextWrap::InFrontOfText => "inFrontOfText",
+    }
+}
+
 fn selected_reason_as_str(reason: VariantSelectedReason) -> &'static str {
     reason.as_str()
 }
@@ -657,7 +760,7 @@ mod tests {
     }
 
     #[test]
-    fn default_mode_forbids_hidden_image_overlay() {
+    fn default_mode_reports_simple_image_as_direct() {
         let tree = tree_with_ops(vec![PaintOp::Image {
             bbox: bbox(),
             image: ImageNode::new(1, Some(vec![1, 2, 3])),
@@ -666,19 +769,20 @@ mod tests {
 
         let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
 
-        assert_eq!(plan.summary.direct_required_items, 1);
+        assert_eq!(plan.summary.direct_items, 1);
+        assert_eq!(plan.summary.direct_required_items, 0);
         assert_eq!(plan.summary.compat_overlay_items, 0);
-        assert_eq!(plan.summary.hidden_overlay_violations, 1);
-        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(plan.summary.hidden_overlay_violations, 0);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
         assert_eq!(
             plan.items[0].reason,
-            CanvasKitReplayReason::HiddenOverlayForbidden
+            CanvasKitReplayReason::DirectReplaySupported
         );
         assert!(!plan.items[0].compat_overlay_allowed);
     }
 
     #[test]
-    fn compat_mode_keeps_image_on_direct_replay_contract() {
+    fn compat_mode_reports_simple_image_as_direct() {
         let tree = tree_with_ops(vec![PaintOp::Image {
             bbox: bbox(),
             image: ImageNode::new(1, Some(vec![1, 2, 3])),
@@ -689,15 +793,60 @@ mod tests {
 
         assert!(!plan.hidden_canvas2d_overlay_allowed);
         assert!(plan.direct_replay_required);
-        assert_eq!(plan.summary.direct_required_items, 1);
+        assert_eq!(plan.summary.direct_items, 1);
+        assert_eq!(plan.summary.direct_required_items, 0);
         assert_eq!(plan.summary.compat_overlay_items, 0);
-        assert_eq!(plan.summary.hidden_overlay_violations, 1);
-        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(plan.summary.hidden_overlay_violations, 0);
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
         assert_eq!(
             plan.items[0].reason,
-            CanvasKitReplayReason::HiddenOverlayForbidden
+            CanvasKitReplayReason::DirectReplaySupported
         );
         assert!(!plan.items[0].compat_overlay_allowed);
+    }
+
+    #[test]
+    fn image_replay_plan_reports_direct_geometry_payload() {
+        let mut image = ImageNode::new(1, Some(vec![1, 2, 3]));
+        image.fill_mode = Some(ImageFillMode::Center);
+        image.crop = Some((10, 20, 90, 80));
+        image.transform.rotation = 15.0;
+
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image,
+            resolved: None,
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(
+            plan.items[0].detail.as_deref(),
+            Some("fillMode=center;crop;transform")
+        );
+    }
+
+    #[test]
+    fn image_replay_plan_reports_unimplemented_image_effects() {
+        let mut image = ImageNode::new(1, Some(vec![1, 2, 3]));
+        image.effect = ImageEffect::GrayScale;
+        image.brightness = 10;
+        image.contrast = -20;
+
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image,
+            resolved: None,
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(
+            plan.items[0].detail.as_deref(),
+            Some("effect=grayScale;adjustment=brightness:10,contrast:-20")
+        );
     }
 
     #[test]

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -5,8 +5,8 @@ use crate::model::image::ImageEffect;
 use crate::model::shape::TextWrap;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
-    CacheHint, ClipKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp, TextDecorationKind,
-    TextVariantKind,
+    CacheHint, ClipKind, LayerNode, LayerNodeKind, PageLayerTree, PaintOp, ResolvedImageKind,
+    ResolvedImagePayload, TextDecorationKind, TextVariantKind,
 };
 use crate::renderer::layer_renderer::{
     analyze_text_variant_selection, TextVariantSelectionOptions, VariantSelectedReason,
@@ -332,7 +332,9 @@ impl CanvasKitReplayPlanBuilder {
                 item.detail = Some("footnoteMarker".to_string());
                 item
             }
-            PaintOp::Image { image, .. } => self.image_item(path, image),
+            PaintOp::Image {
+                image, resolved, ..
+            } => self.image_item(path, image, resolved.as_deref()),
             PaintOp::Equation { .. } => {
                 self.transition_overlay_item(path, "equation", CanvasKitReplayFeature::Equation)
             }
@@ -414,9 +416,14 @@ impl CanvasKitReplayPlanBuilder {
         }
     }
 
-    fn image_item(&self, path: String, image: &ImageNode) -> CanvasKitReplayItem {
-        let detail = image_transition_detail(image);
-        if image_can_replay_directly(image) {
+    fn image_item(
+        &self,
+        path: String,
+        image: &ImageNode,
+        resolved: Option<&ResolvedImagePayload>,
+    ) -> CanvasKitReplayItem {
+        let detail = image_transition_detail(image, resolved);
+        if image_can_replay_directly(image, resolved) {
             let mut item = direct_item(path, "image", CanvasKitReplayFeature::RasterImage);
             item.detail = detail;
             item
@@ -609,11 +616,20 @@ fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
     None
 }
 
-fn image_transition_detail(image: &ImageNode) -> Option<String> {
+fn image_transition_detail(
+    image: &ImageNode,
+    resolved: Option<&ResolvedImagePayload>,
+) -> Option<String> {
     let mut detail = Vec::new();
+    if let Some(payload) = resolved {
+        detail.push(format!(
+            "resolved={}",
+            resolved_image_kind_detail(payload.kind)
+        ));
+    }
     if image.external_path.is_some() {
         detail.push("externalImage".to_string());
-    } else if image.data.is_none() {
+    } else if image.data.is_none() && resolved.is_none() {
         detail.push("missingImageData".to_string());
     }
     if let Some(fill_mode) = image.fill_mode {
@@ -622,10 +638,11 @@ fn image_transition_detail(image: &ImageNode) -> Option<String> {
     if image.crop.is_some() {
         detail.push("crop".to_string());
     }
-    if !matches!(image.effect, ImageEffect::RealPic) {
+    let effects_are_baked = resolved.is_some_and(|payload| payload.suppress_effects);
+    if !effects_are_baked && !matches!(image.effect, ImageEffect::RealPic) {
         detail.push(format!("effect={}", image_effect_detail(image.effect)));
     }
-    if image.brightness != 0 || image.contrast != 0 {
+    if !effects_are_baked && (image.brightness != 0 || image.contrast != 0) {
         detail.push(format!(
             "adjustment=brightness:{},contrast:{}",
             image.brightness, image.contrast
@@ -647,12 +664,20 @@ fn image_transition_detail(image: &ImageNode) -> Option<String> {
     }
 }
 
-fn image_can_replay_directly(image: &ImageNode) -> bool {
-    image.data.is_some()
-        && image.external_path.is_none()
-        && matches!(image.effect, ImageEffect::RealPic)
-        && image.brightness == 0
-        && image.contrast == 0
+fn image_can_replay_directly(image: &ImageNode, resolved: Option<&ResolvedImagePayload>) -> bool {
+    let has_replayable_payload = image.data.is_some() || resolved.is_some();
+    let effects_are_supported = resolved.is_some_and(|payload| payload.suppress_effects)
+        || (matches!(image.effect, ImageEffect::RealPic)
+            && image.brightness == 0
+            && image.contrast == 0);
+    has_replayable_payload && image.external_path.is_none() && effects_are_supported
+}
+
+fn resolved_image_kind_detail(value: ResolvedImageKind) -> &'static str {
+    match value {
+        ResolvedImageKind::FormatConverted => "formatConverted",
+        ResolvedImageKind::BakedWatermark => "bakedWatermark",
+    }
 }
 
 fn image_effect_detail(value: ImageEffect) -> &'static str {
@@ -704,7 +729,7 @@ fn selected_reason_as_str(reason: VariantSelectedReason) -> &'static str {
 mod tests {
     use super::*;
     use crate::model::style::ImageFillMode;
-    use crate::paint::LayerNode;
+    use crate::paint::{LayerNode, ResolvedImageKind, ResolvedImagePayload};
     use crate::renderer::render_tree::{
         BoundingBox, FootnoteMarkerNode, ImageNode, PageBackgroundImage,
     };
@@ -844,6 +869,33 @@ mod tests {
         assert_eq!(
             plan.items[0].detail.as_deref(),
             Some("effect=grayScale;adjustment=brightness:10,contrast:-20")
+        );
+    }
+
+    #[test]
+    fn image_replay_plan_treats_baked_watermark_payload_as_direct() {
+        let mut image = ImageNode::new(1, Some(vec![1, 2, 3]));
+        image.effect = ImageEffect::GrayScale;
+        image.brightness = 70;
+        image.contrast = -50;
+
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image,
+            resolved: Some(Box::new(ResolvedImagePayload {
+                data: vec![4, 5, 6],
+                mime: "image/png",
+                kind: ResolvedImageKind::BakedWatermark,
+                suppress_effects: true,
+            })),
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(
+            plan.items[0].detail.as_deref(),
+            Some("resolved=bakedWatermark")
         );
     }
 

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -611,12 +611,10 @@ fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
 
 fn image_transition_detail(image: &ImageNode) -> Option<String> {
     let mut detail = Vec::new();
-    if image.data.is_none() {
-        if image.external_path.is_some() {
-            detail.push("externalImage".to_string());
-        } else {
-            detail.push("missingImageData".to_string());
-        }
+    if image.external_path.is_some() {
+        detail.push("externalImage".to_string());
+    } else if image.data.is_none() {
+        detail.push("missingImageData".to_string());
     }
     if let Some(fill_mode) = image.fill_mode {
         detail.push(format!("fillMode={}", image_fill_mode_detail(fill_mode)));
@@ -847,6 +845,23 @@ mod tests {
             plan.items[0].detail.as_deref(),
             Some("effect=grayScale;adjustment=brightness:10,contrast:-20")
         );
+    }
+
+    #[test]
+    fn image_replay_plan_reports_external_path_with_embedded_data() {
+        let mut image = ImageNode::new(1, Some(vec![1, 2, 3]));
+        image.external_path = Some("linked-image.png".to_string());
+
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image,
+            resolved: None,
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+        assert_eq!(plan.items[0].detail.as_deref(), Some("externalImage"));
     }
 
     #[test]


### PR DESCRIPTION
## What

- CanvasKit image replay가 layer `crop`, `originalSize`, `fillMode`, `transform` payload를 소비하도록 확장합니다.
- image cache key를 `imageRef`만 보지 않고 base64 payload fingerprint까지 포함하도록 바꿔 같은 ref의 다른 payload 충돌을 막습니다.
- CanvasKit image helper를 순수 함수로 분리하고 crop/source rect, fill-mode anchor, cache-key 회귀 테스트를 추가합니다.
- `getCanvasKitReplayPlan`에서 단순 image는 direct item으로 보고, image effect/brightness/contrast처럼 아직 직접 적용하지 않는 항목은 deterministic detail로 남깁니다.
- image effect/brightness/contrast는 아직 direct pixel effect로 적용하지 않고 `imageEffect:*` diagnostics로 드러냅니다.

## Why

P17에서 `default`/`compat` 모두 hidden Canvas2D overlay 없이 direct replay contract로 고정했습니다. P18은 그 다음 단계로 CanvasKit image replay가 이미 layer JSON에 있는 image geometry payload를 실제로 소비하게 만드는 작업입니다.

특히 crop/fill-mode/transform은 Canvas2D overlay 없이도 CanvasKit이 직접 replay할 수 있는 범위라 이번 PR에 넣고, raster effect/filter와 resource-cache 확장은 후속 범위로 남깁니다.

## Compatibility

- 기본 renderer는 계속 Canvas2D입니다.
- CanvasKit은 opt-in path입니다.
- image effect/brightness/contrast는 렌더 결과를 조용히 바꾸지 않고 diagnostics에 남깁니다.
- public native Skia/PDF API는 바꾸지 않습니다.

## Non-goals

- grayscale/blackWhite/pattern8x8 pixel filter direct 적용은 이 PR에서 닫지 않습니다.
- RawSvg/WMF/OLE object replay 확장은 후속 PR로 넘깁니다.
- TextRun effect/glyph payload replay는 별도 gate로 넘깁니다.
- renderer sweep/WebGPU/performance/PDF는 후속 범위입니다.

## Validation

- `npm --prefix rhwp-studio test`
- `npm --prefix rhwp-studio run build`
- `cargo test canvaskit --lib`
- `cargo fmt --check`
- `git diff --cached --check`

Refs #536
