### PR TITLE
fix(parser/renderer): 글자겹침(hp:compose) 동그라미 글자 누락 + 한컴2024 시각 정합

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -3845,6 +3845,9 @@ fn parse_compose(
                     _ => 0, // SPREAD
                 };
             }
+            // 한컴 HWPX는 `composeText="장"`처럼 속성에 글자를 넣기도 한다.
+            // 자식 element form(<composeText>장</composeText>)이 뒤에 나오면 그쪽이 덮어쓴다.
+            b"composeText" => co.chars = attr_str(&attr).chars().collect(),
             _ => {}
         }
     }

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -1701,20 +1701,25 @@ impl SvgRenderer {
         let is_circle = overlap.border_type == 1 || overlap.border_type == 2;
         let is_rect = overlap.border_type == 3 || overlap.border_type == 4;
 
+        // inner_char_size 해석:
+        //   > 0 → percent ratio (HWPX 양수 case 보존: 50 = 0.5)
+        //   < 0 → 10% step 축소 (한컴 정합: charSz=-3 → 1.0 + (-3)×0.10 = 0.70, 13pt→9.1pt)
+        //   == 0 → 기본 100%
         let size_ratio = if overlap.inner_char_size > 0 {
             overlap.inner_char_size as f64 / 100.0
+        } else if overlap.inner_char_size < 0 {
+            1.0 + overlap.inner_char_size as f64 * 0.10
         } else {
             1.0
         };
         let inner_font_size = font_size * size_ratio;
 
+        // 한컴은 동그라미 테두리도 글자색과 동일 색상으로 그림 (raw PDF 0 0 1 RG/rg).
+        // reversed(반전)는 기존대로 검정 채움 + 흰 글자.
+        let glyph_color = color_to_svg(style.color);
         let fill_color = if is_reversed { "#000000" } else { "none" };
-        let stroke_color = "#000000";
-        let text_color = if is_reversed {
-            "#FFFFFF"
-        } else {
-            &color_to_svg(style.color)
-        };
+        let stroke_color: &str = if is_reversed { "#000000" } else { &glyph_color };
+        let text_color: &str = if is_reversed { "#FFFFFF" } else { &glyph_color };
 
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
@@ -1752,10 +1757,12 @@ impl SvgRenderer {
             let cy = bbox_y + bbox_h / 2.0;
 
             if is_circle {
-                let r = box_size / 2.0;
+                // 한컴 글자겹침은 세로로 긴 타원 (h/w ≈ 1.18). 한글 글리프 비율과 정합.
+                let ry = box_size / 2.0;
+                let rx = ry * 0.85;
                 self.output.push_str(&format!(
-                    "<circle cx=\"{:.2}\" cy=\"{:.2}\" r=\"{:.2}\" fill=\"{}\" stroke=\"{}\" stroke-width=\"0.8\"/>\n",
-                    cx, cy, r, fill_color, stroke_color,
+                    "<ellipse cx=\"{:.2}\" cy=\"{:.2}\" rx=\"{:.2}\" ry=\"{:.2}\" fill=\"{}\" stroke=\"{}\" stroke-width=\"0.8\"/>\n",
+                    cx, cy, rx, ry, fill_color, stroke_color,
                 ));
             } else if is_rect {
                 let rx = cx - box_size / 2.0;
@@ -1804,20 +1811,20 @@ impl SvgRenderer {
         let is_circle = effective_border == 1 || effective_border == 2;
         let is_rect = effective_border == 3 || effective_border == 4;
 
+        // inner_char_size 해석 (draw_char_overlap와 동일 — 음수=10% step 축소)
         let size_ratio = if overlap.inner_char_size > 0 {
             overlap.inner_char_size as f64 / 100.0
+        } else if overlap.inner_char_size < 0 {
+            1.0 + overlap.inner_char_size as f64 * 0.10
         } else {
             1.0
         };
         let inner_font_size = font_size * size_ratio;
 
+        let glyph_color = color_to_svg(style.color);
         let fill_color = if is_reversed { "#000000" } else { "none" };
-        let stroke_color = "#000000";
-        let text_color = if is_reversed {
-            "#FFFFFF"
-        } else {
-            &color_to_svg(style.color)
-        };
+        let stroke_color: &str = if is_reversed { "#000000" } else { &glyph_color };
+        let text_color: &str = if is_reversed { "#FFFFFF" } else { &glyph_color };
 
         let font_family_str = if style.font_family.is_empty() {
             "sans-serif".to_string()
@@ -1842,12 +1849,13 @@ impl SvgRenderer {
         let cx = bbox_x + box_size / 2.0;
         let cy = bbox_y + bbox_h / 2.0;
 
-        // 도형 렌더링
+        // 도형 렌더링 — 세로로 긴 타원 (한컴 정합, rx=ry*0.85)
         if is_circle {
-            let r = box_size / 2.0;
+            let ry = box_size / 2.0;
+            let rx = ry * 0.85;
             self.output.push_str(&format!(
-                "<circle cx=\"{:.2}\" cy=\"{:.2}\" r=\"{:.2}\" fill=\"{}\" stroke=\"{}\" stroke-width=\"0.8\"/>\n",
-                cx, cy, r, fill_color, stroke_color,
+                "<ellipse cx=\"{:.2}\" cy=\"{:.2}\" rx=\"{:.2}\" ry=\"{:.2}\" fill=\"{}\" stroke=\"{}\" stroke-width=\"0.8\"/>\n",
+                cx, cy, rx, ry, fill_color, stroke_color,
             ));
         } else if is_rect {
             let rx = cx - box_size / 2.0;

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -2650,19 +2650,27 @@ impl WebCanvasRenderer {
         let is_circle = overlap.border_type == 1 || overlap.border_type == 2;
         let is_rect = overlap.border_type == 3 || overlap.border_type == 4;
 
+        // inner_char_size 해석:
+        //   > 0 → percent ratio (HWPX 양수 case 보존)
+        //   < 0 → 10% step 축소 (한컴 정합: charSz=-3 → 0.70)
+        //   == 0 → 기본 100%
         let size_ratio = if overlap.inner_char_size > 0 {
             overlap.inner_char_size as f64 / 100.0
+        } else if overlap.inner_char_size < 0 {
+            1.0 + overlap.inner_char_size as f64 * 0.10
         } else {
             1.0
         };
         let inner_font_size = font_size * size_ratio;
 
+        // 동그라미 테두리 색 = 글자색 (한컴 정합). reversed는 기존대로 검정 채움.
+        let glyph_color = color_to_css(style.color);
         let fill_color = if is_reversed { "#000000" } else { "none" };
-        let stroke_color = "#000000";
+        let stroke_color: &str = if is_reversed { "#000000" } else { &glyph_color };
         let text_color = if is_reversed {
             "#FFFFFF".to_string()
         } else {
-            color_to_css(style.color)
+            glyph_color.clone()
         };
 
         let font_family = if style.font_family.is_empty() {
@@ -2694,9 +2702,13 @@ impl WebCanvasRenderer {
             let cy = bbox_y + bbox_h - box_size / 2.0;
 
             if is_circle {
-                let r = box_size / 2.0;
+                // 세로로 긴 타원 (한컴 정합, rx=ry*0.85)
+                let ry = box_size / 2.0;
+                let rx = ry * 0.85;
                 self.ctx.begin_path();
-                let _ = self.ctx.arc(cx, cy, r, 0.0, std::f64::consts::PI * 2.0);
+                let _ = self
+                    .ctx
+                    .ellipse(cx, cy, rx, ry, 0.0, 0.0, std::f64::consts::TAU);
                 if is_reversed {
                     self.ctx.set_fill_style_str(fill_color);
                     self.ctx.fill();
@@ -2755,19 +2767,23 @@ impl WebCanvasRenderer {
         let is_circle = effective_border == 1 || effective_border == 2;
         let is_rect = effective_border == 3 || effective_border == 4;
 
+        // inner_char_size 해석 (draw_char_overlap와 동일 — 음수=10% step 축소)
         let size_ratio = if overlap.inner_char_size > 0 {
             overlap.inner_char_size as f64 / 100.0
+        } else if overlap.inner_char_size < 0 {
+            1.0 + overlap.inner_char_size as f64 * 0.10
         } else {
             1.0
         };
         let inner_font_size = font_size * size_ratio;
 
+        let glyph_color = color_to_css(style.color);
         let fill_color = if is_reversed { "#000000" } else { "none" };
-        let stroke_color = "#000000";
+        let stroke_color: &str = if is_reversed { "#000000" } else { &glyph_color };
         let text_color = if is_reversed {
             "#FFFFFF".to_string()
         } else {
-            color_to_css(style.color)
+            glyph_color.clone()
         };
 
         let font_family = if style.font_family.is_empty() {
@@ -2780,11 +2796,14 @@ impl WebCanvasRenderer {
         let cx = bbox_x + box_size / 2.0;
         let cy = bbox_y + bbox_h - box_size / 2.0;
 
-        // 도형 렌더링
+        // 도형 렌더링 — 세로로 긴 타원 (한컴 정합, rx=ry*0.85)
         if is_circle {
-            let r = box_size / 2.0;
+            let ry = box_size / 2.0;
+            let rx = ry * 0.85;
             self.ctx.begin_path();
-            let _ = self.ctx.arc(cx, cy, r, 0.0, std::f64::consts::PI * 2.0);
+            let _ = self
+                .ctx
+                .ellipse(cx, cy, rx, ry, 0.0, 0.0, std::f64::consts::TAU);
             if is_reversed {
                 self.ctx.set_fill_style_str(fill_color);
                 self.ctx.fill();


### PR DESCRIPTION
# 증상
원 안에 글자를 넣는 글자겹침(SHAPE_CIRCLE)에서:
1. 한컴 HWPX가 글자를 속성 폼(`composeText="장"`)으로 저장한 경우 글자가 통째 누락(빈 원).
2. 글자가 나오더라도 동그라미 테두리 색·글자 크기·원 비율이 한컴2024와 달랐음(테두리 검정, 글자 과대, 정원).

자체 문서 "주요 논의내용" 표의 ㉠/㉡(장/단) 동그라미에서 발생.

### **[before/after 이미지]**
※ 좌=한컴2024 / 우=rhwp.

### **before: 장/단 동그라미 누락** 
<img width="1646" height="632" alt="고쳣어요1" src="https://github.com/user-attachments/assets/cad50a84-8325-4a0c-91e8-1c656b0dc74d" />

### **after: 글자 복원 + 파랑/빨강 타원·크기 정합.**
<img width="1667" height="664" alt="고쳣어요2" src="https://github.com/user-attachments/assets/7a9abcba-028a-40a6-96e5-1cf6fd628437" />

# 근본 원인 / 수정

**(1) 글자 누락** — src/parser/hwpx/section.rs `parse_compose`가 composeText를 자식 element(`<hp:composeText>장</hp:composeText>`)로만 읽어, 속성 폼(`<hp:compose … composeText="장">`)을 놓쳐 `co.chars`가 빈 채 IR 진입.
→ 속성 match에 `composeText` arm 추가. 기존 element 폼 경로는 유지하여 두 폼 모두 지원.

**(2) 시각 정합** — draw_char_overlap 4함수(svg.rs·web_canvas.rs 각 일반/combined)에서:
- 테두리 색: `#000000` 하드코딩 → 글자색(charPr textColor)과 동일. 한컴 PDF raw stream상 글자·테두리가 동색(파랑/빨강)으로 지정됨을 확인.
- 글자 크기: 음수 inner_char_size(charSz) 미반영 → `1.0 + charSz*0.10` 적용(charSz=-3 → ×0.70 → 9.10pt, 한컴 PDF 실측 9.12pt 정합). 양수·0은 기존 동작 보존.
- 원 비율: 정원 `<circle r>` → 세로 타원 `<ellipse rx ry>`(rx=ry×0.85).

# 검증
- ★before≠after: stroke `#000000`→`#0000ff`/`#ff0000`, font 13pt→9.10pt, circle→ellipse(rx/ry=0.85)가 본선 IR/렌더에 반영됨을 export-svg로 확인. native + WASM 공유 함수 4곳 일관.
- cargo test --lib 1336 passed / svg_snapshot 8골든 불변(compose 보유 issue_147_aift_page3 포함) / fmt·clippy(--lib) 통과.
- compose sweep(보유 4샘플): border_type=0(CHAR) 케이스 무영향, 양수 charSz 사용 샘플 0건 — 회귀 0.

# 비고
- 한컴 9.12pt vs rhwp 9.10pt 오차 0.02pt(인지 불가 수준).
- 타원 비율 0.85는 한컴 글자 bbox 비율 기반 근사입니다. 한컴 동그라미가 PDF상 합성 글리프로 렌더되어 벡터 단위 정밀 측정이 불가한 점을 반영했으며, 필요 시 폰트 metric 기반으로 정밀화할 수 있습니다.