### PR TITLE
제목: fix(renderer): 회전 90°/270° 이미지의 bbox 이중회전 정정 — 페이지 폭 초과/잘림 해소

### DIFF
--- a/src/renderer/canvas.rs
+++ b/src/renderer/canvas.rs
@@ -148,14 +148,16 @@ impl CanvasRenderer {
                 );
             }
             RenderNodeType::Image(img) => {
-                self.open_shape_transform(&img.transform, &node.bbox);
+                // [shot 05] 회전 90/270° 시 bbox extent swap — 이중회전 방지.
+                let eff_bbox = img.transform.effective_image_bbox(&node.bbox);
+                self.open_shape_transform(&img.transform, &eff_bbox);
                 if let Some(ref data) = img.data {
                     self.draw_image(
                         data,
-                        node.bbox.x,
-                        node.bbox.y,
-                        node.bbox.width,
-                        node.bbox.height,
+                        eff_bbox.x,
+                        eff_bbox.y,
+                        eff_bbox.width,
+                        eff_bbox.height,
                     );
                 }
             }
@@ -239,13 +241,21 @@ impl CanvasRenderer {
                             image,
                             resolved,
                         } => {
-                            self.open_shape_transform(&image.transform, bbox);
+                            // [shot 05] 회전 90/270° 시 bbox extent swap — 이중회전 방지.
+                            let eff_bbox = image.transform.effective_image_bbox(bbox);
+                            self.open_shape_transform(&image.transform, &eff_bbox);
                             let data = resolved
                                 .as_deref()
                                 .map(|payload| payload.data.as_slice())
                                 .or(image.data.as_deref());
                             if let Some(data) = data {
-                                self.draw_image(data, bbox.x, bbox.y, bbox.width, bbox.height);
+                                self.draw_image(
+                                    data,
+                                    eff_bbox.x,
+                                    eff_bbox.y,
+                                    eff_bbox.width,
+                                    eff_bbox.height,
+                                );
                             }
                             self.close_shape_transform_value(&image.transform);
                         }

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -557,6 +557,27 @@ impl ShapeTransform {
     pub fn has_transform(&self) -> bool {
         self.rotation != 0.0 || self.horz_flip || self.vert_flip
     }
+
+    /// 그림 노드 한정: 회전각 90°/270° (±1° 톨러런스) 일 때 bbox extent 만 swap.
+    /// 그 외 각도(0/45/180 등)는 입력 bbox 그대로 반환.
+    ///
+    /// hwpx 의 `<hp:sz>` 는 회전 후 외접 사각형 치수라서 portrait → 90° 회전 시
+    /// bbox 가 landscape 로 들어온다. 그 위에 `rotate(90, cx, cy)` transform 을 다시
+    /// 적용하면 이중회전이 되어 페이지 밖으로 튀어 나간다. 회전 전 치수로 swap 한
+    /// bbox 위에 동일 rotation transform 을 적용하면 한컴 정답지와 정합한다.
+    /// cx, cy 는 swap 전후 동일하므로 rotate 식 자체는 그대로 둔다.
+    pub fn effective_image_bbox(&self, bbox: &BoundingBox) -> BoundingBox {
+        let r = self.rotation.rem_euclid(360.0);
+        let is_perpendicular = (r - 90.0).abs() < 1.0 || (r - 270.0).abs() < 1.0;
+        if !is_perpendicular {
+            return *bbox;
+        }
+        let cx = bbox.x + bbox.width / 2.0;
+        let cy = bbox.y + bbox.height / 2.0;
+        let new_w = bbox.height;
+        let new_h = bbox.width;
+        BoundingBox::new(cx - new_w / 2.0, cy - new_h / 2.0, new_w, new_h)
+    }
 }
 
 /// 직선 노드

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -409,8 +409,10 @@ impl SvgRenderer {
                 );
             }
             RenderNodeType::Image(img) => {
-                self.open_shape_transform(&img.transform, &node.bbox);
-                self.render_image_node(img, &node.bbox);
+                // [shot 05] 회전 90/270° 시 bbox extent swap — 이중회전 방지.
+                let eff_bbox = img.transform.effective_image_bbox(&node.bbox);
+                self.open_shape_transform(&img.transform, &eff_bbox);
+                self.render_image_node(img, &eff_bbox);
             }
             RenderNodeType::Path(path) => {
                 self.open_shape_transform(&path.transform, &node.bbox);

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -526,12 +526,14 @@ impl WebCanvasRenderer {
                 );
             }
             RenderNodeType::Image(img) => {
-                self.open_shape_transform(&img.transform, &node.bbox);
+                // [shot 05] 회전 90/270° 시 bbox extent swap — 이중회전 방지.
+                let eff_bbox = img.transform.effective_image_bbox(&node.bbox);
+                self.open_shape_transform(&img.transform, &eff_bbox);
                 // [Task #741 후속] 외부 file path 그림 (data 부재 + external_path 보유) →
                 // placeholder 영역 (회색 점선 사각형 + file path 텍스트). SVG renderer
                 // (svg.rs:1075~) 영역 정합. 본 분기 부재 시 image 표시 부재.
                 if img.data.is_none() && img.external_path.is_some() {
-                    let bbox = &node.bbox;
+                    let bbox = &eff_bbox;
                     self.ctx.set_fill_style_str("#f0f0f0");
                     self.ctx.fill_rect(bbox.x, bbox.y, bbox.width, bbox.height);
                     self.ctx.set_stroke_style_str("#999999");
@@ -589,7 +591,7 @@ impl WebCanvasRenderer {
                     }
                     self.draw_image_with_fill_mode(
                         render_data.as_ref(),
-                        &node.bbox,
+                        &eff_bbox,
                         img.fill_mode,
                         img.original_size,
                         img.crop,


### PR DESCRIPTION
## 증상
90°(또는 270°) 회전된 이미지가 페이지 폭을 초과해 잘려 보입니다.
- 자체 문서 "참고2 클라우드 시범사업 망 구성도": 가로로 긴 원본을 90° 회전해 세로로 배치하는 그림인데, rhwp에서 가로 방향으로 페이지 폭을 넘겨 우측이 잘림.

**[before/after 이미지]**
※ 좌=한컴2024 / 우=rhwp. 

before: 그림이 가로로 펼쳐져 페이지 우측 초과·잘림. 
<img width="1556" height="702" alt="고쳣어요1" src="https://github.com/user-attachments/assets/b391a8de-cb74-4cb1-abeb-a787c73ffbcd" />


after: 세로(portrait)로 제자리 배치, 한컴과 정합.
<img width="1438" height="730" alt="고쳣어요2" src="https://github.com/user-attachments/assets/06272d33-cb19-409a-b2f7-2142ae3bec08" />

## 근본 원인
회전 이미지에서 bbox extent를 **회전 후 치수(sz, portrait)**로 잡은 상태에서 rotation transform(`rotate(90, cx, cy)`)을 **또** 적용 → 사실상 이중 회전 → 시각적으로 다시 가로(landscape)가 되어 페이지 폭 초과.
- 치수 관계: sz(회전후 170×243mm) = curSz(회전전 243×170mm)의 width/height swap. rotation transform은 이미 90° 회전을 담당하므로, bbox는 **회전 전 치수**여야 함.
- 한컴 PDF 실측: 해당 그림이 170.6×242.7mm(portrait)로 배치 — sz 정합.

## 수정
`ShapeTransform::effective_image_bbox()` 헬퍼 추가: rotation이 90°/270°(±1°)일 때 bbox extent를 swap(width↔height)하고 중심(cx, cy)은 불변 유지. 그 외 각도(0 포함)는 입력 bbox 그대로(분기 미진입).
3개 렌더 backend(svg.rs / canvas.rs / web_canvas.rs)에 일관 적용.

## 검증
- ★before≠after(망구성도): bbox `(75.59,124.40,645×918 portrait)` → `(-60.95,260.93,918×645 landscape swap)`, rotation transform 불변. 회전 적용 후 시각 portrait 645×918 @ (75.59,124.40), 우측 끝 720<793(페이지폭) — 잘림 해소. 한컴 170.6×242.7mm 정합.
- ★angle=0 이미지 회귀 0: 미회전 이미지 before==after byte-identical.
- cargo test --lib 1336 passed / svg_snapshot 8골든 byte-exact 불변 / fmt·clippy(--lib) 통과 / native + WASM.

## 비고
- 임의 각도(예 45°)는 분기 미진입으로 현 동작 유지 — 별도 작업 영역입니다.
- 이미지 내용의 종횡비 미세 정합(preserveAspectRatio)은 본 PR 범위 밖(extent/위치 정정)으로 두었으며, 필요 시 후속 정리하겠습니다.