### PR TITLE
render: gate advanced glyph outline payloads

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,9 +225,9 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P14 adds guarded `GlyphOutline` sidecar variants and backend text variant selection diagnostics. Existing renderers still keep the `TextRun` fallback path.
 - P15-P17 add diagnostics-only CanvasKit replay policy planning and the browser CanvasKit direct renderer. Both `default` and `compat` keep hidden Canvas2D overlays forbidden; `compat` is a conservative direct replay policy, not an overlay fallback.
 - P18 expands CanvasKit image replay to consume crop, fill mode, original size, transform, and payload-fingerprint cache keys while leaving image effects as deterministic diagnostics.
-- P19 adds guarded richer `GlyphOutline` payload vocabulary for color layers, bitmap glyphs, and sanitized static SVG glyphs. These payload families stay behind explicit selection gates and keep the `TextRun` fallback.
+- P19 adds guarded richer `GlyphOutline` payload vocabulary for color layers, bitmap glyphs, and sanitized static SVG glyphs. It also opens the first explicit CanvasKit replay subset for COLRv1 solid/linear/radial/sweep color glyph paths while keeping unsupported graph nodes and the other payload families on the `TextRun` fallback.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
-- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, exact native glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
+- The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; full CanvasKit glyph replay, exact native glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.
 - `ResourceArena` now reserves font blob storage and font resource identity for glyph replay; document image/SVG interning stays as follow-up work.
 - This phase establishes the frontend/backend boundary for later CanvasKit and fuller native Skia backends.

--- a/README.md
+++ b/README.md
@@ -223,7 +223,9 @@ v0.7.x 배포 주기 누적 외부 기여자: [@ahnbu](https://github.com/ahnbu)
 - P11 adds the Text IR v2 compatibility contract: `textSources`, per-`TextRun` source spans, paint style metadata, run placement/clusters, feature arrays, and explicit special text visual ops. `TextRun` remains the fallback replay path.
 - P12 adds guarded `GlyphRun` sidecar variants, font blob/face identity metadata, and a shape-lowering API. Canvas2D/layered SVG still use `TextRun` fallback; native Skia also keeps the fallback until exact blob-backed typeface replay is wired. Normal lowering does not emit glyph ids until a shaping pass explicitly inserts them.
 - P14 adds guarded `GlyphOutline` sidecar variants and backend text variant selection diagnostics. Existing renderers still keep the `TextRun` fallback path.
-- P15 adds diagnostics-only CanvasKit replay policy planning through `getCanvasKitReplayPlan(page, mode)`. `default` mode forbids hidden Canvas2D overlays, while `compat` mode reports transition overlays explicitly.
+- P15-P17 add diagnostics-only CanvasKit replay policy planning and the browser CanvasKit direct renderer. Both `default` and `compat` keep hidden Canvas2D overlays forbidden; `compat` is a conservative direct replay policy, not an overlay fallback.
+- P18 expands CanvasKit image replay to consume crop, fill mode, original size, transform, and payload-fingerprint cache keys while leaving image effects as deterministic diagnostics.
+- P19 adds guarded richer `GlyphOutline` payload vocabulary for color layers, bitmap glyphs, and sanitized static SVG glyphs. These payload families stay behind explicit selection gates and keep the `TextRun` fallback.
 - CI covers the native Skia path with `cargo test --features native-skia skia --lib`; the feature is not available on `wasm32` targets.
 - The initial native Skia path is a PNG raster backend with core image/equation/raw-svg replay; CanvasKit glyph replay, exact native glyph replay, real font blob extraction, complex text shaping, advanced image parity, and native form replay stay as follow-up work.
 - C ABI export is intentionally left for a later PR.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -179,6 +179,11 @@ turning them into default replay paths.
   data. `ColorLayers.colrV0` uses resolved solid layer paths. `ColorLayers.colrV1`
   starts with a bounded graph vocabulary where `node.kind` is validated before a
   backend may select the variant.
+- CanvasKit may select only the bounded COLRv1 graph subset covered by this
+  phase: solid paths, single linear/radial/sweep gradient paths, and transform
+  chains that end in exactly one supported leaf. Composite, blend, clip, nested
+  paint, partial sweep angle, and invalid gradient-stop graphs still reject
+  deterministically and use the `TextRun` fallback.
 - `payloadKind: "bitmapGlyph"` is reserved for one producer-selected image strike.
   It must carry deterministic placement, scaling, and filtering metadata. Backend
   default strike selection is not part of the strict contract.
@@ -207,7 +212,7 @@ improvement rather than a Canvas2D compatibility match.
 ## Follow-Ups
 
 - Wire real document font blob extraction into `ResourceArena`.
-- Add CanvasKit glyph replay behind the same variant gate.
+- Expand CanvasKit glyph replay beyond the guarded COLRv1 solid/gradient subset.
 - Add native glyph outline replay behind the strict `GlyphOutline` variant.
 - Add resource table entries for font blobs and face identity.
 - Promote renderer diagnostics from report-only to backend selection telemetry

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -140,10 +140,9 @@ CanvasKit has two operational modes:
   must not silently hide unsupported operations behind a Canvas2D overlay. If an
   operation is not covered yet, the plan reports `directRequired` with
   `hiddenOverlayForbidden` so the gap remains visible.
-- `compat`: user-visible stability mode. Existing Canvas2D overlays may remain
-  as transition fallbacks while direct replay coverage is expanded. The plan
-  reports those cases as `compatOverlay` and keeps them separate from true
-  direct replay.
+- `compat`: conservative direct replay mode. It may choose more conservative
+  policy values such as clip padding or sampling, but it does not mean a hidden
+  Canvas2D overlay fallback.
 
 The first overlay inventory is deliberately conservative. Raster images,
 equations, form controls, raw SVG fragments, placeholders, special text visual
@@ -168,8 +167,34 @@ variant-sensitive operations:
    markers should be promoted effect-by-effect. Unsupported text effects must
    not trigger approximate `GlyphRun` replay.
 4. GlyphRun/GlyphOutline gates: CanvasKit should choose a strict variant only
-   when the P14 selection report says it is replayable. Opening outline replay
-   in CanvasKit is a backend parity milestone, not a schema change.
+   when the selection report says it is replayable. Opening outline replay in
+   CanvasKit is a backend parity milestone, not a schema change.
+
+## P19 Advanced Glyph Payload Gates
+
+P19 adds schema-v1 vocabulary for richer `GlyphOutline` payload families without
+turning them into default replay paths.
+
+- `payloadKind: "colorLayers"` is reserved for producer-normalized color glyph
+  data. `ColorLayers.colrV0` uses resolved solid layer paths. `ColorLayers.colrV1`
+  starts with a bounded graph vocabulary where `node.kind` is validated before a
+  backend may select the variant.
+- `payloadKind: "bitmapGlyph"` is reserved for one producer-selected image strike.
+  It must carry deterministic placement, scaling, and filtering metadata. Backend
+  default strike selection is not part of the strict contract.
+- `payloadKind: "svgGlyph"` is reserved for sanitized static vector resources.
+  Script, animation, external resource loading, and interactivity flags must stay
+  false before a backend may consider the payload strict.
+- Each `GlyphOutline` op may carry only one payload family. Mixing stroke,
+  color-layer, bitmap, and SVG payload fields is a validation error.
+- CanvasKit and Canvas2D report the same high-level reject reasons for advanced
+  payload families: `unsupportedColorGlyph`, `unsupportedBitmapGlyph`, and
+  `unsupportedSvgGlyph`. Canvas2D can still add
+  `backendDoesNotSupportVariant`.
+
+These gates keep writer emission closed until a payload family has a proof
+fixture and backend-specific replay path. The required `TextRun` fallback remains
+the compatibility path.
 
 Every overlay removal requires a Canvas2D-vs-CanvasKit fixture. Rasterizer
 output can use fuzzy PNG comparison, but semantic decisions must be exact:

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -684,6 +684,15 @@ export interface LayerBounds {
   height: number;
 }
 
+export interface LayerAffineTransform {
+  a: number;
+  b: number;
+  c: number;
+  d: number;
+  e: number;
+  f: number;
+}
+
 export interface PageLayerTree {
   schemaVersion?: number;
   schemaMinorVersion?: number;
@@ -961,9 +970,128 @@ export interface LayerCharOverlapOp {
 export interface LayerGlyphRunOp {
   type: 'glyphRun';
   bbox: LayerBounds;
+  variant?: LayerTextVariantMeta;
 }
 
 export interface LayerGlyphOutlineOp {
   type: 'glyphOutline';
   bbox: LayerBounds;
+  variant?: LayerTextVariantMeta;
+  payloadKind?: LayerGlyphOutlinePayloadKind;
+  paths?: LayerGlyphOutlinePath[];
+  stroke?: LayerGlyphOutlineStroke;
+  colorLayers?: LayerColorLayersPayload;
+  bitmapGlyph?: LayerBitmapGlyphPayload;
+  svgGlyph?: LayerSvgGlyphPayload;
+}
+
+export interface LayerTextVariantMeta {
+  equivalenceGroup?: string;
+  variantId?: string;
+  variantKind?: 'textRun' | 'glyphRun' | 'glyphOutline' | string;
+  partIndex?: number;
+  partCount?: number;
+  isDefaultFallback?: boolean;
+  requires?: string[];
+  quality?: string;
+  anchorOpId?: string;
+  localPaintOrder?: number;
+}
+
+export type LayerGlyphOutlinePayloadKind =
+  | 'monochromeFill'
+  | 'monochromeFillStroke'
+  | 'colorLayers'
+  | 'bitmapGlyph'
+  | 'svgGlyph'
+  | string;
+
+export interface LayerGlyphOutlinePath {
+  glyphId?: number;
+  sourceRangeUtf8?: LayerTextRange;
+  glyphRange?: LayerTextRange;
+  fillRule?: 'nonzero' | 'evenodd' | string;
+  commands?: LayerPathCommand[];
+}
+
+export interface LayerGlyphOutlineStroke {
+  color?: string;
+  width?: number;
+  join?: 'miter' | 'round' | 'bevel' | string;
+  cap?: 'butt' | 'round' | 'square' | string;
+  miterLimit?: number;
+  paintOrder?: 'fillOnly' | 'strokeOnly' | 'fillThenStroke' | 'strokeThenFill' | string;
+  strictSubset?: boolean;
+}
+
+export interface LayerTextRange {
+  start?: number;
+  end?: number;
+}
+
+export interface LayerResolvedColor {
+  colorSpace?: string;
+  rgba?: number[];
+}
+
+export interface LayerColorPaintGraphNode {
+  nodeId?: number;
+  kind?: string;
+  commands?: LayerPathCommand[];
+  fill?: LayerResolvedColor;
+  fillRule?: 'nonzero' | 'evenodd' | string;
+  childNodeId?: number;
+  transform?: LayerAffineTransform;
+  sourceRangeUtf8?: LayerTextRange;
+  glyphRange?: LayerTextRange;
+}
+
+export interface LayerColorPaintGraphPayload {
+  rootNodeId?: number;
+  nodes?: LayerColorPaintGraphNode[];
+}
+
+export interface LayerColorLayersPayload {
+  colorFormat?: 'colrV0' | 'colrV1' | 'other' | string;
+  layers?: Array<{
+    layerIndex?: number | null;
+    glyphId?: number;
+    glyphRange?: LayerTextRange;
+    sourceRangeUtf8?: LayerTextRange;
+    commands?: LayerPathCommand[];
+    fill?: LayerResolvedColor;
+    fillRule?: 'nonzero' | 'evenodd' | string;
+    paletteIndex?: number;
+    color?: string;
+    opacity?: number;
+    transformToRun?: LayerAffineTransform;
+  }>;
+  paintGraph?: LayerColorPaintGraphPayload;
+  sourceRangeUtf8?: LayerTextRange;
+  glyphRange?: LayerTextRange;
+}
+
+export interface LayerBitmapGlyphPayload {
+  imageRef?: number;
+  sourceRangeUtf8?: LayerTextRange;
+  glyphRange?: LayerTextRange;
+  placement?: LayerBounds;
+  alphaPremultiplied?: boolean;
+  scalingPolicy?: 'sourceExact' | 'pixelAligned' | 'backendDefault' | string;
+  filtering?: 'nearest' | 'linear' | string;
+  transformToRun?: LayerAffineTransform;
+}
+
+export interface LayerSvgGlyphPayload {
+  svgRef?: number;
+  sourceRangeUtf8?: LayerTextRange;
+  glyphRange?: LayerTextRange;
+  viewBox?: LayerBounds;
+  intrinsicSize?: { width?: number; height?: number };
+  staticSanitized?: boolean;
+  scriptAllowed?: boolean;
+  animationAllowed?: boolean;
+  externalResourcesAllowed?: boolean;
+  interactivityAllowed?: boolean;
+  transformToRun?: LayerAffineTransform;
 }

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -978,6 +978,7 @@ export interface LayerGlyphOutlineOp {
   bbox: LayerBounds;
   variant?: LayerTextVariantMeta;
   payloadKind?: LayerGlyphOutlinePayloadKind;
+  placement?: { runToPage?: LayerAffineTransform; baselineY?: number };
   paths?: LayerGlyphOutlinePath[];
   stroke?: LayerGlyphOutlineStroke;
   colorLayers?: LayerColorLayersPayload;
@@ -1034,16 +1035,89 @@ export interface LayerResolvedColor {
   rgba?: number[];
 }
 
-export interface LayerColorPaintGraphNode {
-  nodeId?: number;
-  kind?: string;
+export interface LayerColorGradientStop {
+  offset?: number;
+  color?: LayerResolvedColor;
+}
+
+export interface LayerColorSolidPathNode {
   commands?: LayerPathCommand[];
   fill?: LayerResolvedColor;
   fillRule?: 'nonzero' | 'evenodd' | string;
+  sourceGlyphId?: number;
+  paletteIndex?: number;
+}
+
+export interface LayerColorLinearGradient {
+  x0?: number;
+  y0?: number;
+  x1?: number;
+  y1?: number;
+  stops?: LayerColorGradientStop[];
+}
+
+export interface LayerColorRadialGradient {
+  cx?: number;
+  cy?: number;
+  radius?: number;
+  stops?: LayerColorGradientStop[];
+}
+
+export interface LayerColorSweepGradient {
+  cx?: number;
+  cy?: number;
+  startAngleDegrees?: number;
+  endAngleDegrees?: number;
+  stops?: LayerColorGradientStop[];
+}
+
+export interface LayerColorLinearGradientPathNode {
+  commands?: LayerPathCommand[];
+  gradient?: LayerColorLinearGradient;
+  fillRule?: 'nonzero' | 'evenodd' | string;
+  sourceGlyphId?: number;
+  paletteIndex?: number;
+}
+
+export interface LayerColorRadialGradientPathNode {
+  commands?: LayerPathCommand[];
+  gradient?: LayerColorRadialGradient;
+  fillRule?: 'nonzero' | 'evenodd' | string;
+  sourceGlyphId?: number;
+  paletteIndex?: number;
+}
+
+export interface LayerColorSweepGradientPathNode {
+  commands?: LayerPathCommand[];
+  gradient?: LayerColorSweepGradient;
+  fillRule?: 'nonzero' | 'evenodd' | string;
+  sourceGlyphId?: number;
+  paletteIndex?: number;
+}
+
+export interface LayerColorTransformNode {
   childNodeId?: number;
   transform?: LayerAffineTransform;
+}
+
+export interface LayerFontColorGlyphRef {
+  faceKey?: string;
+  glyphId?: number;
+  paletteIndex?: number;
+  colorFormat?: 'colrV0' | 'colrV1' | 'other' | string;
+}
+
+export interface LayerColorPaintGraphNode {
+  nodeId?: number;
+  kind?: string;
+  solidPath?: LayerColorSolidPathNode;
+  linearGradientPath?: LayerColorLinearGradientPathNode;
+  radialGradientPath?: LayerColorRadialGradientPathNode;
+  sweepGradientPath?: LayerColorSweepGradientPathNode;
+  transform?: LayerColorTransformNode;
   sourceRangeUtf8?: LayerTextRange;
   glyphRange?: LayerTextRange;
+  sourceFontRef?: LayerFontColorGlyphRef;
 }
 
 export interface LayerColorPaintGraphPayload {
@@ -1053,6 +1127,7 @@ export interface LayerColorPaintGraphPayload {
 
 export interface LayerColorLayersPayload {
   colorFormat?: 'colrV0' | 'colrV1' | 'other' | string;
+  sourceFontRef?: LayerFontColorGlyphRef;
   layers?: Array<{
     layerIndex?: number | null;
     glyphId?: number;

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -47,6 +47,7 @@ import {
   canvasKitImageSourceRect,
 } from './canvaskit/image-replay';
 import { canvaskitClipRightPad } from './canvaskit/policy';
+import { glyphOutlinePayloadStatus } from './glyph-outline-payload-status';
 
 type CanvasKitApi = CanvasKit;
 type SkCanvas = Canvas;
@@ -288,12 +289,16 @@ export class CanvasKitLayerRenderer {
       case 'rawSvg':
       case 'charOverlap':
       case 'glyphRun':
-      case 'glyphOutline':
       case 'tabLeader':
       case 'textControlMark':
       case 'textDecoration':
         this.unsupportedOps.add(op.type);
         return;
+      case 'glyphOutline': {
+        const status = glyphOutlinePayloadStatus(op);
+        this.unsupportedOps.add(status.reason ? `glyphOutline:${status.reason}` : 'glyphOutline');
+        return;
+      }
       default:
         this.unsupportedOps.add((op as { type?: string }).type ?? 'unknown');
     }

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -18,6 +18,7 @@ import type {
   LayerClipNode,
   LayerEllipseOp,
   LayerFormObjectOp,
+  LayerGlyphOutlineOp,
   LayerImageOp,
   LayerLeafNode,
   LayerLineOp,
@@ -54,6 +55,8 @@ type SkCanvas = Canvas;
 type SkPaint = Paint;
 type SkSurface = Surface;
 type MutablePath = Path & Pick<PathBuilder, 'arcToRotated' | 'close' | 'cubicTo' | 'lineTo' | 'moveTo'>;
+type LayerColorGraph = NonNullable<NonNullable<LayerGlyphOutlineOp['colorLayers']>['paintGraph']>;
+type LayerColorGraphNode = NonNullable<LayerColorGraph['nodes']>[number];
 
 export interface CanvasKitRenderDiagnostics {
   mode: CanvasKitRenderMode;
@@ -295,7 +298,11 @@ export class CanvasKitLayerRenderer {
         this.unsupportedOps.add(op.type);
         return;
       case 'glyphOutline': {
-        const status = glyphOutlinePayloadStatus(op);
+        const status = glyphOutlinePayloadStatus(op, { allowColrv1Stage1ColorGraph: true });
+        if (status.supported && op.payloadKind === 'colorLayers') {
+          this.renderGlyphOutline(canvas, op);
+          return;
+        }
         this.unsupportedOps.add(status.reason ? `glyphOutline:${status.reason}` : 'glyphOutline');
         return;
       }
@@ -414,6 +421,172 @@ export class CanvasKitLayerRenderer {
     }
     this.recordImageCoverageGaps(op);
     this.withImageTransform(canvas, op.bbox, op.transform, () => this.drawImageOp(canvas, image, op));
+  }
+
+  private renderGlyphOutline(canvas: SkCanvas, op: LayerGlyphOutlineOp): void {
+    const graph = op.colorLayers?.paintGraph;
+    const nodes = graph?.nodes ?? [];
+    if (!graph || nodes.length === 0 || graph.rootNodeId === undefined) {
+      this.unsupportedOps.add('glyphOutline:unsupportedColorGlyph');
+      return;
+    }
+    const nodesById = new Map<number, LayerColorGraphNode>();
+    for (const node of nodes) {
+      if (node.nodeId !== undefined) {
+        nodesById.set(node.nodeId, node);
+      }
+    }
+    canvas.save();
+    const transform = op.placement?.runToPage;
+    if (transform) {
+      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.([
+        transform.a,
+        transform.c,
+        transform.e,
+        transform.b,
+        transform.d,
+        transform.f,
+        0,
+        0,
+        1,
+      ]);
+    }
+    try {
+      this.renderColorPaintGraphNode(canvas, nodesById, graph.rootNodeId, new Set());
+    } finally {
+      canvas.restore();
+    }
+  }
+
+  private renderColorPaintGraphNode(
+    canvas: SkCanvas,
+    nodesById: Map<number, LayerColorGraphNode>,
+    nodeId: number,
+    visited: Set<number>,
+  ): void {
+    if (visited.has(nodeId)) return;
+    visited.add(nodeId);
+    const node = nodesById.get(nodeId);
+    if (!node) return;
+    if (node.kind === 'transform') {
+      const transformNode = node.transform;
+      if (!transformNode?.transform || transformNode.childNodeId === undefined) return;
+      const tr = transformNode.transform;
+      canvas.save();
+      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.([
+        tr.a,
+        tr.c,
+        tr.e,
+        tr.b,
+        tr.d,
+        tr.f,
+        0,
+        0,
+        1,
+      ]);
+      try {
+        this.renderColorPaintGraphNode(canvas, nodesById, transformNode.childNodeId, visited);
+      } finally {
+        canvas.restore();
+      }
+      return;
+    }
+    const pathNode = node.solidPath ?? node.linearGradientPath ?? node.radialGradientPath ?? node.sweepGradientPath;
+    if (!pathNode?.commands) return;
+    const path = new this.canvasKit.Path() as MutablePath;
+    let currentX = 0;
+    let currentY = 0;
+    for (const command of pathNode.commands) {
+      [currentX, currentY] = this.applyPathCommand(path, command, currentX, currentY);
+    }
+    this.applyFillRule(path, pathNode.fillRule);
+    const paint = new this.canvasKit.Paint();
+    let shader: unknown | undefined;
+    try {
+      paint.setAntiAlias?.(true);
+      paint.setStyle(this.canvasKit.PaintStyle.Fill);
+      if (node.kind === 'solidPath' && node.solidPath?.fill) {
+        paint.setColor(this.resolvedColor(node.solidPath.fill));
+      } else if (node.kind === 'linearGradientPath' && node.linearGradientPath?.gradient) {
+        shader = this.makeLinearGradientShader(node.linearGradientPath.gradient);
+        if (!shader) {
+          return;
+        }
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(shader);
+      } else if (node.kind === 'radialGradientPath' && node.radialGradientPath?.gradient) {
+        shader = this.makeRadialGradientShader(node.radialGradientPath.gradient);
+        if (!shader) {
+          return;
+        }
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(shader);
+      } else if (node.kind === 'sweepGradientPath' && node.sweepGradientPath?.gradient) {
+        shader = this.makeSweepGradientShader(node.sweepGradientPath.gradient);
+        if (!shader) {
+          return;
+        }
+        (paint as unknown as { setShader: (shader: unknown) => void }).setShader(shader);
+      } else {
+        return;
+      }
+      canvas.drawPath(path, paint);
+    } finally {
+      (shader as { delete?: () => void } | undefined)?.delete?.();
+      paint.delete?.();
+      path.delete?.();
+    }
+  }
+
+  private applyFillRule(path: MutablePath, fillRule: string | undefined): void {
+    if (fillRule === 'evenodd') {
+      (path as unknown as { setFillType?: (fillType: unknown) => void }).setFillType?.(this.canvasKit.FillType.EvenOdd);
+    }
+  }
+
+  private resolvedColor(color: { rgba?: number[] }): Color {
+    const rgba = color.rgba ?? [0, 0, 0, 1];
+    return this.canvasKit.Color(
+      clampUnit(rgba[0]),
+      clampUnit(rgba[1]),
+      clampUnit(rgba[2]),
+      clampUnit(rgba[3]),
+    );
+  }
+
+  private makeLinearGradientShader(gradient: NonNullable<LayerColorGraphNode['linearGradientPath']>['gradient']): unknown {
+    const shaderApi = this.canvasKit.Shader as unknown as { MakeLinearGradient?: (...args: unknown[]) => unknown };
+    return shaderApi.MakeLinearGradient?.(
+      [gradient?.x0 ?? 0, gradient?.y0 ?? 0],
+      [gradient?.x1 ?? 0, gradient?.y1 ?? 0],
+      gradientColors(gradient?.stops),
+      gradientPositions(gradient?.stops),
+      this.canvasKit.TileMode.Clamp,
+    );
+  }
+
+  private makeRadialGradientShader(gradient: NonNullable<LayerColorGraphNode['radialGradientPath']>['gradient']): unknown {
+    const shaderApi = this.canvasKit.Shader as unknown as { MakeRadialGradient?: (...args: unknown[]) => unknown };
+    return shaderApi.MakeRadialGradient?.(
+      [gradient?.cx ?? 0, gradient?.cy ?? 0],
+      gradient?.radius ?? 1,
+      gradientColors(gradient?.stops),
+      gradientPositions(gradient?.stops),
+      this.canvasKit.TileMode.Clamp,
+    );
+  }
+
+  private makeSweepGradientShader(gradient: NonNullable<LayerColorGraphNode['sweepGradientPath']>['gradient']): unknown {
+    const shaderApi = this.canvasKit.Shader as unknown as { MakeSweepGradient?: (...args: unknown[]) => unknown };
+    return shaderApi.MakeSweepGradient?.(
+      gradient?.cx ?? 0,
+      gradient?.cy ?? 0,
+      gradientColors(gradient?.stops),
+      gradientPositions(gradient?.stops),
+      this.canvasKit.TileMode.Clamp,
+      null,
+      0,
+      gradient?.startAngleDegrees ?? 0,
+      gradient?.endAngleDegrees ?? 360,
+    );
   }
 
   private drawImageOp(canvas: SkCanvas, image: SkImage, op: LayerImageOp): void {
@@ -794,6 +967,26 @@ function parseCssColor(value: string): { r: number; g: number; b: number; a: num
     };
   }
   return { r: 0, g: 0, b: 0, a: 1 };
+}
+
+function clampUnit(value: number | undefined): number {
+  return Math.max(0, Math.min(1, Number.isFinite(value) ? value ?? 0 : 0));
+}
+
+function gradientColors(stops: Array<{ color?: { rgba?: number[] } }> | undefined): number[][] {
+  return (stops ?? []).map((stop) => {
+    const rgba = stop.color?.rgba ?? [0, 0, 0, 1];
+    return [
+      clampUnit(rgba[0]),
+      clampUnit(rgba[1]),
+      clampUnit(rgba[2]),
+      clampUnit(rgba[3]),
+    ];
+  });
+}
+
+function gradientPositions(stops: Array<{ offset?: number }> | undefined): number[] {
+  return (stops ?? []).map((stop) => Math.max(0, Math.min(1, stop.offset ?? 0)));
 }
 
 function base64ToBytes(base64: string): Uint8Array {

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -18,6 +18,7 @@ import type {
   LayerClipNode,
   LayerEllipseOp,
   LayerFormObjectOp,
+  LayerAffineTransform,
   LayerGlyphOutlineOp,
   LayerImageOp,
   LayerLeafNode,
@@ -437,19 +438,9 @@ export class CanvasKitLayerRenderer {
       }
     }
     canvas.save();
-    const transform = op.placement?.runToPage;
-    if (transform) {
-      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.([
-        transform.a,
-        transform.c,
-        transform.e,
-        transform.b,
-        transform.d,
-        transform.f,
-        0,
-        0,
-        1,
-      ]);
+    const matrix = this.affineToCanvasKitMatrix(op.placement?.runToPage);
+    if (matrix) {
+      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.(matrix);
     }
     try {
       this.renderColorPaintGraphNode(canvas, nodesById, graph.rootNodeId, new Set());
@@ -464,26 +455,25 @@ export class CanvasKitLayerRenderer {
     nodeId: number,
     visited: Set<number>,
   ): void {
-    if (visited.has(nodeId)) return;
+    if (visited.has(nodeId)) {
+      this.unsupportedOps.add('glyphOutline:unsupportedColorGlyph');
+      return;
+    }
     visited.add(nodeId);
     const node = nodesById.get(nodeId);
-    if (!node) return;
+    if (!node) {
+      this.unsupportedOps.add('glyphOutline:unsupportedColorGlyph');
+      return;
+    }
     if (node.kind === 'transform') {
       const transformNode = node.transform;
-      if (!transformNode?.transform || transformNode.childNodeId === undefined) return;
-      const tr = transformNode.transform;
+      const matrix = this.affineToCanvasKitMatrix(transformNode?.transform);
+      if (!matrix || transformNode?.childNodeId === undefined) {
+        this.unsupportedOps.add('glyphOutline:unsupportedColorGlyph');
+        return;
+      }
       canvas.save();
-      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.([
-        tr.a,
-        tr.c,
-        tr.e,
-        tr.b,
-        tr.d,
-        tr.f,
-        0,
-        0,
-        1,
-      ]);
+      (canvas as unknown as { concat?: (matrix: number[]) => void }).concat?.(matrix);
       try {
         this.renderColorPaintGraphNode(canvas, nodesById, transformNode.childNodeId, visited);
       } finally {
@@ -492,7 +482,10 @@ export class CanvasKitLayerRenderer {
       return;
     }
     const pathNode = node.solidPath ?? node.linearGradientPath ?? node.radialGradientPath ?? node.sweepGradientPath;
-    if (!pathNode?.commands) return;
+    if (!pathNode?.commands) {
+      this.unsupportedOps.add('glyphOutline:unsupportedColorGlyph');
+      return;
+    }
     const path = new this.canvasKit.Path() as MutablePath;
     let currentX = 0;
     let currentY = 0;
@@ -534,6 +527,21 @@ export class CanvasKitLayerRenderer {
       paint.delete?.();
       path.delete?.();
     }
+  }
+
+  private affineToCanvasKitMatrix(transform: LayerAffineTransform | undefined): number[] | null {
+    if (!transform) return null;
+    return [
+      transform.a,
+      transform.c,
+      transform.e,
+      transform.b,
+      transform.d,
+      transform.f,
+      0,
+      0,
+      1,
+    ];
   }
 
   private applyFillRule(path: MutablePath, fillRule: string | undefined): void {

--- a/rhwp-studio/src/view/glyph-outline-payload-status.ts
+++ b/rhwp-studio/src/view/glyph-outline-payload-status.ts
@@ -1,5 +1,9 @@
 import type { LayerGlyphOutlineOp } from '@/core/types';
 
+type LayerColorPaintGraphNode = NonNullable<
+  NonNullable<NonNullable<LayerGlyphOutlineOp['colorLayers']>['paintGraph']>['nodes']
+>[number];
+
 export type GlyphOutlinePayloadRejectReason =
   | 'unsupportedOutlinePayload'
   | 'glyphOutlineStrokeStyleUnsupported'
@@ -22,7 +26,13 @@ export interface GlyphOutlinePayloadStatusOptions {
   allowSvgGlyph?: boolean;
 }
 
-const COLRV1_STAGE1_NODE_KINDS = new Set(['solidPath', 'transform']);
+const COLRV1_SUPPORTED_NODE_KINDS = new Set([
+  'solidPath',
+  'linearGradientPath',
+  'radialGradientPath',
+  'sweepGradientPath',
+  'transform',
+]);
 
 export function glyphOutlinePayloadStatus(
   op: LayerGlyphOutlineOp,
@@ -73,7 +83,7 @@ function colorLayersStatus(
   }
   if (colorLayers.colorFormat === 'colrV1') {
     const nodes = colorLayers.paintGraph?.nodes ?? [];
-    const unsupported = nodes.find((node) => !COLRV1_STAGE1_NODE_KINDS.has(node.kind ?? ''));
+    const unsupported = nodes.find((node) => !COLRV1_SUPPORTED_NODE_KINDS.has(node.kind ?? ''));
     if (unsupported) {
       return {
         payloadKind,
@@ -82,11 +92,195 @@ function colorLayersStatus(
         detail: `colrV1Node:${unsupported.kind ?? 'unknown'}`,
       };
     }
-    return options.allowColrv1Stage1ColorGraph && nodes.length > 0
+    if (!hasSupportedColrv1GraphContract(op)) {
+      return { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: 'colrV1InvalidGraph' };
+    }
+    return options.allowColrv1Stage1ColorGraph
       ? { payloadKind, supported: true }
       : { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: 'colrV1GateClosed' };
   }
   return { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: `format:${colorLayers.colorFormat ?? 'missing'}` };
+}
+
+function hasSupportedColrv1GraphContract(op: LayerGlyphOutlineOp): boolean {
+  const colorLayers = op.colorLayers;
+  const graph = colorLayers?.paintGraph;
+  const nodes = graph?.nodes ?? [];
+  const topLevelGlyphRange = colorLayers?.glyphRange;
+  if (
+    colorLayers?.colorFormat !== 'colrV1'
+    || !graph
+    || nodes.length === 0
+    || colorLayers.sourceFontRef === undefined
+    || !isValidTextRange(colorLayers.sourceRangeUtf8)
+    || !isValidTextRange(topLevelGlyphRange)
+    || (topLevelGlyphRange?.end ?? 0) <= (topLevelGlyphRange?.start ?? 0)
+  ) {
+    return false;
+  }
+  const nodesById = new Map<number, NonNullable<typeof nodes[number]>>();
+  for (const node of nodes) {
+    if (!Number.isInteger(node.nodeId) || node.nodeId === undefined || nodesById.has(node.nodeId)) {
+      return false;
+    }
+    nodesById.set(node.nodeId, node);
+  }
+  let nodeId = graph.rootNodeId;
+  const visited = new Set<number>();
+  for (let depth = 0; depth < 64; depth += 1) {
+    if (!Number.isInteger(nodeId) || nodeId === undefined || visited.has(nodeId)) {
+      return false;
+    }
+    visited.add(nodeId);
+    const node = nodesById.get(nodeId);
+    if (!node) {
+      return false;
+    }
+    switch (node.kind) {
+      case 'solidPath':
+        return visited.size === nodes.length
+          && node.solidPath !== undefined
+          && node.transform === undefined
+          && node.linearGradientPath === undefined
+          && node.radialGradientPath === undefined
+          && node.sweepGradientPath === undefined
+          && isLeafMetadataValid(node)
+          && isValidPathCommands(node.solidPath.commands)
+          && isValidResolvedColor(node.solidPath.fill)
+          && isSupportedFillRule(node.solidPath.fillRule);
+      case 'linearGradientPath':
+        return visited.size === nodes.length
+          && node.solidPath === undefined
+          && node.transform === undefined
+          && node.radialGradientPath === undefined
+          && node.sweepGradientPath === undefined
+          && node.linearGradientPath !== undefined
+          && isLeafMetadataValid(node)
+          && isValidPathCommands(node.linearGradientPath.commands)
+          && Number.isFinite(node.linearGradientPath.gradient?.x0)
+          && Number.isFinite(node.linearGradientPath.gradient?.y0)
+          && Number.isFinite(node.linearGradientPath.gradient?.x1)
+          && Number.isFinite(node.linearGradientPath.gradient?.y1)
+          && isValidColorGradientStops(node.linearGradientPath.gradient?.stops)
+          && isSupportedFillRule(node.linearGradientPath.fillRule);
+      case 'radialGradientPath':
+        return visited.size === nodes.length
+          && node.solidPath === undefined
+          && node.transform === undefined
+          && node.linearGradientPath === undefined
+          && node.sweepGradientPath === undefined
+          && node.radialGradientPath !== undefined
+          && isLeafMetadataValid(node)
+          && isValidPathCommands(node.radialGradientPath.commands)
+          && Number.isFinite(node.radialGradientPath.gradient?.cx)
+          && Number.isFinite(node.radialGradientPath.gradient?.cy)
+          && Number.isFinite(node.radialGradientPath.gradient?.radius)
+          && (node.radialGradientPath.gradient?.radius ?? 0) > 0
+          && isValidColorGradientStops(node.radialGradientPath.gradient?.stops)
+          && isSupportedFillRule(node.radialGradientPath.fillRule);
+      case 'sweepGradientPath':
+        return visited.size === nodes.length
+          && node.solidPath === undefined
+          && node.transform === undefined
+          && node.linearGradientPath === undefined
+          && node.radialGradientPath === undefined
+          && node.sweepGradientPath !== undefined
+          && isLeafMetadataValid(node)
+          && isValidPathCommands(node.sweepGradientPath.commands)
+          && Number.isFinite(node.sweepGradientPath.gradient?.cx)
+          && Number.isFinite(node.sweepGradientPath.gradient?.cy)
+          && isSupportedSweepGradientAngleRange(
+            node.sweepGradientPath.gradient?.startAngleDegrees,
+            node.sweepGradientPath.gradient?.endAngleDegrees,
+          )
+          && isValidColorGradientStops(node.sweepGradientPath.gradient?.stops)
+          && isSupportedFillRule(node.sweepGradientPath.fillRule);
+      case 'transform':
+        if (
+          node.solidPath !== undefined
+          || node.linearGradientPath !== undefined
+          || node.radialGradientPath !== undefined
+          || node.sweepGradientPath !== undefined
+          || node.transform === undefined
+          || !Number.isInteger(node.transform.childNodeId)
+          || !isFiniteAffine(node.transform.transform)
+        ) {
+          return false;
+        }
+        nodeId = node.transform.childNodeId;
+        continue;
+      default:
+        return false;
+    }
+  }
+  return false;
+}
+
+function isLeafMetadataValid(node: LayerColorPaintGraphNode): boolean {
+  return isValidTextRange(node.sourceRangeUtf8)
+    && isValidTextRange(node.glyphRange)
+    && node.sourceFontRef !== undefined;
+}
+
+function isValidTextRange(range: { start?: number; end?: number } | undefined): boolean {
+  return range !== undefined
+    && Number.isInteger(range.start)
+    && Number.isInteger(range.end)
+    && (range.end ?? -1) >= (range.start ?? 0);
+}
+
+function isFiniteAffine(transform: { a?: number; b?: number; c?: number; d?: number; e?: number; f?: number } | undefined): boolean {
+  return transform !== undefined
+    && Number.isFinite(transform.a)
+    && Number.isFinite(transform.b)
+    && Number.isFinite(transform.c)
+    && Number.isFinite(transform.d)
+    && Number.isFinite(transform.e)
+    && Number.isFinite(transform.f);
+}
+
+function isValidPathCommands(commands: unknown[] | undefined): boolean {
+  return Array.isArray(commands) && commands.length > 0;
+}
+
+function isValidResolvedColor(color: { rgba?: number[] } | undefined): boolean {
+  return Array.isArray(color?.rgba)
+    && color.rgba.length === 4
+    && color.rgba.every((component) => Number.isFinite(component) && component >= 0 && component <= 1);
+}
+
+function isValidColorGradientStops(stops: Array<{ offset?: number; color?: { rgba?: number[] } }> | undefined): boolean {
+  if (!Array.isArray(stops) || stops.length < 2) {
+    return false;
+  }
+  let previousOffset = Number.NEGATIVE_INFINITY;
+  for (const stop of stops) {
+    if (
+      !Number.isFinite(stop.offset)
+      || (stop.offset ?? -1) < 0
+      || (stop.offset ?? 2) > 1
+      || (stop.offset ?? -1) < previousOffset
+      || !isValidResolvedColor(stop.color)
+    ) {
+      return false;
+    }
+    previousOffset = stop.offset ?? previousOffset;
+  }
+  return true;
+}
+
+function isSupportedSweepGradientAngleRange(
+  startAngleDegrees: number | undefined,
+  endAngleDegrees: number | undefined,
+): boolean {
+  return Number.isFinite(startAngleDegrees)
+    && Number.isFinite(endAngleDegrees)
+    && (startAngleDegrees ?? 0) < (endAngleDegrees ?? 0)
+    && Math.abs((endAngleDegrees ?? 0) - (startAngleDegrees ?? 0) - 360) <= 1e-9;
+}
+
+function isSupportedFillRule(fillRule: string | undefined): boolean {
+  return fillRule === 'nonzero' || fillRule === 'evenodd';
 }
 
 function hasExclusivePayloadFamily(op: LayerGlyphOutlineOp, payloadKind: string): boolean {

--- a/rhwp-studio/src/view/glyph-outline-payload-status.ts
+++ b/rhwp-studio/src/view/glyph-outline-payload-status.ts
@@ -1,0 +1,145 @@
+import type { LayerGlyphOutlineOp } from '@/core/types';
+
+export type GlyphOutlinePayloadRejectReason =
+  | 'unsupportedOutlinePayload'
+  | 'glyphOutlineStrokeStyleUnsupported'
+  | 'unsupportedColorGlyph'
+  | 'unsupportedBitmapGlyph'
+  | 'unsupportedSvgGlyph';
+
+export interface GlyphOutlinePayloadStatus {
+  payloadKind: string;
+  supported: boolean;
+  reason?: GlyphOutlinePayloadRejectReason;
+  detail?: string;
+}
+
+export interface GlyphOutlinePayloadStatusOptions {
+  allowMonochromeFillStroke?: boolean;
+  allowColrv0ColorLayers?: boolean;
+  allowColrv1Stage1ColorGraph?: boolean;
+  allowBitmapGlyph?: boolean;
+  allowSvgGlyph?: boolean;
+}
+
+const COLRV1_STAGE1_NODE_KINDS = new Set(['solidPath', 'transform']);
+
+export function glyphOutlinePayloadStatus(
+  op: LayerGlyphOutlineOp,
+  options: GlyphOutlinePayloadStatusOptions = {},
+): GlyphOutlinePayloadStatus {
+  const payloadKind = op.payloadKind ?? 'monochromeFill';
+  if (!hasExclusivePayloadFamily(op, payloadKind)) {
+    return { payloadKind, supported: false, reason: 'unsupportedOutlinePayload', detail: 'mixedPayloadFamily' };
+  }
+  switch (payloadKind) {
+    case 'monochromeFill':
+      return { payloadKind, supported: Array.isArray(op.paths) && op.paths.length > 0, reason: op.paths?.length ? undefined : 'unsupportedOutlinePayload' };
+    case 'monochromeFillStroke':
+      if (!options.allowMonochromeFillStroke) {
+        return { payloadKind, supported: false, reason: 'glyphOutlineStrokeStyleUnsupported', detail: 'gateClosed' };
+      }
+      return isStrictStroke(op.stroke)
+        ? { payloadKind, supported: true }
+        : { payloadKind, supported: false, reason: 'glyphOutlineStrokeStyleUnsupported' };
+    case 'colorLayers':
+      return colorLayersStatus(op, options);
+    case 'bitmapGlyph':
+      return options.allowBitmapGlyph && hasBitmapGlyphContract(op)
+        ? { payloadKind, supported: true }
+        : { payloadKind, supported: false, reason: 'unsupportedBitmapGlyph' };
+    case 'svgGlyph':
+      return options.allowSvgGlyph && hasSvgGlyphContract(op)
+        ? { payloadKind, supported: true }
+        : { payloadKind, supported: false, reason: 'unsupportedSvgGlyph' };
+    default:
+      return { payloadKind, supported: false, reason: 'unsupportedOutlinePayload', detail: 'unknownPayloadKind' };
+  }
+}
+
+function colorLayersStatus(
+  op: LayerGlyphOutlineOp,
+  options: GlyphOutlinePayloadStatusOptions,
+): GlyphOutlinePayloadStatus {
+  const payloadKind = 'colorLayers';
+  const colorLayers = op.colorLayers;
+  if (!colorLayers) {
+    return { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: 'missingColorLayers' };
+  }
+  if (colorLayers.colorFormat === 'colrV0') {
+    return options.allowColrv0ColorLayers && Array.isArray(colorLayers.layers) && colorLayers.layers.length > 0
+      ? { payloadKind, supported: true }
+      : { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: 'colrV0GateClosed' };
+  }
+  if (colorLayers.colorFormat === 'colrV1') {
+    const nodes = colorLayers.paintGraph?.nodes ?? [];
+    const unsupported = nodes.find((node) => !COLRV1_STAGE1_NODE_KINDS.has(node.kind ?? ''));
+    if (unsupported) {
+      return {
+        payloadKind,
+        supported: false,
+        reason: 'unsupportedColorGlyph',
+        detail: `colrV1Node:${unsupported.kind ?? 'unknown'}`,
+      };
+    }
+    return options.allowColrv1Stage1ColorGraph && nodes.length > 0
+      ? { payloadKind, supported: true }
+      : { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: 'colrV1GateClosed' };
+  }
+  return { payloadKind, supported: false, reason: 'unsupportedColorGlyph', detail: `format:${colorLayers.colorFormat ?? 'missing'}` };
+}
+
+function hasExclusivePayloadFamily(op: LayerGlyphOutlineOp, payloadKind: string): boolean {
+  const families = [
+    op.stroke !== undefined,
+    op.colorLayers !== undefined,
+    op.bitmapGlyph !== undefined,
+    op.svgGlyph !== undefined,
+  ].filter(Boolean).length;
+  if (payloadKind === 'monochromeFill') return families === 0;
+  if (payloadKind === 'monochromeFillStroke') return op.stroke !== undefined && families === 1;
+  if (payloadKind === 'colorLayers') return op.colorLayers !== undefined && families === 1;
+  if (payloadKind === 'bitmapGlyph') return op.bitmapGlyph !== undefined && families === 1;
+  if (payloadKind === 'svgGlyph') return op.svgGlyph !== undefined && families === 1;
+  return families === 0;
+}
+
+function isStrictStroke(stroke: LayerGlyphOutlineOp['stroke']): boolean {
+  return !!stroke
+    && Number.isFinite(stroke.width)
+    && (stroke.width ?? 0) > 0
+    && stroke.join === 'miter'
+    && stroke.cap === 'butt'
+    && Number.isFinite(stroke.miterLimit)
+    && (stroke.miterLimit ?? 0) >= 1
+    && (stroke.paintOrder === 'fillThenStroke' || stroke.paintOrder === 'strokeThenFill');
+}
+
+function hasBitmapGlyphContract(op: LayerGlyphOutlineOp): boolean {
+  const glyph = op.bitmapGlyph;
+  return !!glyph
+    && typeof glyph.imageRef === 'number'
+    && glyph.scalingPolicy !== 'backendDefault'
+    && glyph.placement !== undefined
+    && isPositiveBounds(glyph.placement);
+}
+
+function hasSvgGlyphContract(op: LayerGlyphOutlineOp): boolean {
+  const glyph = op.svgGlyph;
+  return !!glyph
+    && typeof glyph.svgRef === 'number'
+    && glyph.staticSanitized === true
+    && glyph.scriptAllowed !== true
+    && glyph.animationAllowed !== true
+    && glyph.externalResourcesAllowed !== true
+    && glyph.interactivityAllowed !== true
+    && glyph.viewBox !== undefined
+    && isPositiveBounds(glyph.viewBox);
+}
+
+function isPositiveBounds(bounds: { width?: number; height?: number }): boolean {
+  return Number.isFinite(bounds.width)
+    && Number.isFinite(bounds.height)
+    && (bounds.width ?? 0) > 0
+    && (bounds.height ?? 0) > 0;
+}

--- a/rhwp-studio/src/view/glyph-outline-payload-status.ts
+++ b/rhwp-studio/src/view/glyph-outline-payload-status.ts
@@ -111,10 +111,10 @@ function hasSupportedColrv1GraphContract(op: LayerGlyphOutlineOp): boolean {
     colorLayers?.colorFormat !== 'colrV1'
     || !graph
     || nodes.length === 0
+    || nodes.length > 64
     || colorLayers.sourceFontRef === undefined
     || !isValidTextRange(colorLayers.sourceRangeUtf8)
-    || !isValidTextRange(topLevelGlyphRange)
-    || (topLevelGlyphRange?.end ?? 0) <= (topLevelGlyphRange?.start ?? 0)
+    || !isNonEmptyTextRange(topLevelGlyphRange)
   ) {
     return false;
   }
@@ -189,7 +189,7 @@ function hasSupportedColrv1GraphContract(op: LayerGlyphOutlineOp): boolean {
           && isValidPathCommands(node.sweepGradientPath.commands)
           && Number.isFinite(node.sweepGradientPath.gradient?.cx)
           && Number.isFinite(node.sweepGradientPath.gradient?.cy)
-          && isSupportedSweepGradientAngleRange(
+          && isSupportedFullCircleSweepGradient(
             node.sweepGradientPath.gradient?.startAngleDegrees,
             node.sweepGradientPath.gradient?.endAngleDegrees,
           )
@@ -218,7 +218,7 @@ function hasSupportedColrv1GraphContract(op: LayerGlyphOutlineOp): boolean {
 
 function isLeafMetadataValid(node: LayerColorPaintGraphNode): boolean {
   return isValidTextRange(node.sourceRangeUtf8)
-    && isValidTextRange(node.glyphRange)
+    && isNonEmptyTextRange(node.glyphRange)
     && node.sourceFontRef !== undefined;
 }
 
@@ -227,6 +227,10 @@ function isValidTextRange(range: { start?: number; end?: number } | undefined): 
     && Number.isInteger(range.start)
     && Number.isInteger(range.end)
     && (range.end ?? -1) >= (range.start ?? 0);
+}
+
+function isNonEmptyTextRange(range: { start?: number; end?: number } | undefined): boolean {
+  return isValidTextRange(range) && (range?.end ?? 0) > (range?.start ?? 0);
 }
 
 function isFiniteAffine(transform: { a?: number; b?: number; c?: number; d?: number; e?: number; f?: number } | undefined): boolean {
@@ -269,7 +273,7 @@ function isValidColorGradientStops(stops: Array<{ offset?: number; color?: { rgb
   return true;
 }
 
-function isSupportedSweepGradientAngleRange(
+function isSupportedFullCircleSweepGradient(
   startAngleDegrees: number | undefined,
   endAngleDegrees: number | undefined,
 ): boolean {

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -140,9 +140,14 @@ test('GlyphOutline advanced payload gates reject richer payloads by default', ()
           nodes: [{
             nodeId: 0,
             kind: 'solidPath',
-            commands: [{ type: 'moveTo', x: 0, y: 0 }],
-            fill: { rgba: [0, 0, 0, 1] },
-            fillRule: 'nonzero',
+            solidPath: {
+              commands: [{ type: 'moveTo', x: 0, y: 0 }],
+              fill: { rgba: [0, 0, 0, 1] },
+              fillRule: 'nonzero',
+            },
+            sourceRangeUtf8: { start: 0, end: 1 },
+            glyphRange: { start: 0, end: 1 },
+            sourceFontRef: { faceKey: 'fixture-face', glyphId: 42, colorFormat: 'colrV1' },
           }],
         },
       },
@@ -195,16 +200,66 @@ test('GlyphOutline COLRv1 gate reports unsupported graph node kind exactly', () 
       colorFormat: 'colrV1',
       paintGraph: {
         rootNodeId: 0,
-        nodes: [{ nodeId: 0, kind: 'sweepGradientPath' }],
+        nodes: [{ nodeId: 0, kind: 'composite' }],
       },
     },
   }, { allowColrv1Stage1ColorGraph: true });
   assert.equal(status.reason, 'unsupportedColorGlyph');
-  assert.equal(status.detail, 'colrV1Node:sweepGradientPath');
+  assert.equal(status.detail, 'colrV1Node:composite');
+});
+
+test('GlyphOutline COLRv1 gradient graph subset can pass the explicit gate', () => {
+  const commands = [{ type: 'moveTo', x: 0, y: 0 }, { type: 'lineTo', x: 10, y: 0 }, { type: 'closePath' }];
+  const stops = [
+    { offset: 0, color: { rgba: [1, 0, 0, 1] } },
+    { offset: 1, color: { rgba: [0, 0, 1, 1] } },
+  ];
+  const cases = [
+    {
+      kind: 'linearGradientPath',
+      field: 'linearGradientPath',
+      value: { commands, gradient: { x0: 0, y0: 0, x1: 10, y1: 10, stops }, fillRule: 'nonzero' },
+    },
+    {
+      kind: 'radialGradientPath',
+      field: 'radialGradientPath',
+      value: { commands, gradient: { cx: 5, cy: 5, radius: 5, stops }, fillRule: 'nonzero' },
+    },
+    {
+      kind: 'sweepGradientPath',
+      field: 'sweepGradientPath',
+      value: { commands, gradient: { cx: 5, cy: 5, startAngleDegrees: 0, endAngleDegrees: 360, stops }, fillRule: 'nonzero' },
+    },
+  ];
+  for (const entry of cases) {
+    const status = glyphOutlinePayloadStatus({
+      type: 'glyphOutline',
+      bbox: { x: 0, y: 0, width: 10, height: 10 },
+      payloadKind: 'colorLayers',
+      colorLayers: {
+        colorFormat: 'colrV1',
+        sourceRangeUtf8: { start: 0, end: 1 },
+        glyphRange: { start: 0, end: 1 },
+        sourceFontRef: { faceKey: 'fixture-face', glyphId: 42, colorFormat: 'colrV1' },
+        paintGraph: {
+          rootNodeId: 0,
+          nodes: [{
+            nodeId: 0,
+            kind: entry.kind,
+            [entry.field]: entry.value,
+            sourceRangeUtf8: { start: 0, end: 1 },
+            glyphRange: { start: 0, end: 1 },
+            sourceFontRef: { faceKey: 'fixture-face', glyphId: 42, colorFormat: 'colrV1' },
+          }],
+        },
+      },
+    }, { allowColrv1Stage1ColorGraph: true });
+    assert.equal(status.supported, true, entry.kind);
+  }
 });
 
 test('CanvasKit renderer diagnostics keep GlyphOutline payload reject reasons visible', () => {
   const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
-  assert.match(source, /glyphOutlinePayloadStatus\(op\)/);
+  assert.match(source, /glyphOutlinePayloadStatus\(op, \{ allowColrv1Stage1ColorGraph: true \}\)/);
   assert.match(source, /glyphOutline:\$\{status\.reason\}/);
 });

--- a/rhwp-studio/tests/render-backend.test.ts
+++ b/rhwp-studio/tests/render-backend.test.ts
@@ -16,6 +16,7 @@ import {
   canvasKitImageSourceRect,
   HWPUNIT_PER_PIXEL,
 } from '../src/view/canvaskit/image-replay.ts';
+import { glyphOutlinePayloadStatus } from '../src/view/glyph-outline-payload-status.ts';
 
 test('render backend resolver keeps Canvas2D as the default and accepts skia aliases', () => {
   assert.equal(resolveRenderBackend(''), 'canvas2d');
@@ -122,4 +123,88 @@ test('CanvasKit image fill-mode tiling detection stays explicit', () => {
   for (const mode of [undefined, 'fitToSize', 'none', 'center', 'leftTop', 'rightBottom']) {
     assert.equal(canvasKitImageFillModeTiles(mode), false);
   }
+});
+
+test('GlyphOutline advanced payload gates reject richer payloads by default', () => {
+  assert.deepEqual(
+    glyphOutlinePayloadStatus({
+      type: 'glyphOutline',
+      bbox: { x: 0, y: 0, width: 10, height: 10 },
+      payloadKind: 'colorLayers',
+      colorLayers: {
+        colorFormat: 'colrV1',
+        sourceRangeUtf8: { start: 0, end: 1 },
+        glyphRange: { start: 0, end: 1 },
+        paintGraph: {
+          rootNodeId: 0,
+          nodes: [{
+            nodeId: 0,
+            kind: 'solidPath',
+            commands: [{ type: 'moveTo', x: 0, y: 0 }],
+            fill: { rgba: [0, 0, 0, 1] },
+            fillRule: 'nonzero',
+          }],
+        },
+      },
+    }).reason,
+    'unsupportedColorGlyph',
+  );
+  assert.equal(
+    glyphOutlinePayloadStatus({
+      type: 'glyphOutline',
+      bbox: { x: 0, y: 0, width: 10, height: 10 },
+      payloadKind: 'bitmapGlyph',
+      bitmapGlyph: {
+        imageRef: 1,
+        sourceRangeUtf8: { start: 0, end: 1 },
+        glyphRange: { start: 0, end: 1 },
+        placement: { x: 0, y: 0, width: 10, height: 10 },
+        scalingPolicy: 'sourceExact',
+        filtering: 'linear',
+      },
+    }).reason,
+    'unsupportedBitmapGlyph',
+  );
+  assert.equal(
+    glyphOutlinePayloadStatus({
+      type: 'glyphOutline',
+      bbox: { x: 0, y: 0, width: 10, height: 10 },
+      payloadKind: 'svgGlyph',
+      svgGlyph: {
+        svgRef: 1,
+        sourceRangeUtf8: { start: 0, end: 1 },
+        glyphRange: { start: 0, end: 1 },
+        viewBox: { x: 0, y: 0, width: 10, height: 10 },
+        staticSanitized: true,
+        scriptAllowed: false,
+        animationAllowed: false,
+        externalResourcesAllowed: false,
+        interactivityAllowed: false,
+      },
+    }).reason,
+    'unsupportedSvgGlyph',
+  );
+});
+
+test('GlyphOutline COLRv1 gate reports unsupported graph node kind exactly', () => {
+  const status = glyphOutlinePayloadStatus({
+    type: 'glyphOutline',
+    bbox: { x: 0, y: 0, width: 10, height: 10 },
+    payloadKind: 'colorLayers',
+    colorLayers: {
+      colorFormat: 'colrV1',
+      paintGraph: {
+        rootNodeId: 0,
+        nodes: [{ nodeId: 0, kind: 'sweepGradientPath' }],
+      },
+    },
+  }, { allowColrv1Stage1ColorGraph: true });
+  assert.equal(status.reason, 'unsupportedColorGlyph');
+  assert.equal(status.detail, 'colrV1Node:sweepGradientPath');
+});
+
+test('CanvasKit renderer diagnostics keep GlyphOutline payload reject reasons visible', () => {
+  const source = readFileSync(new URL('../src/view/canvaskit-renderer.ts', import.meta.url), 'utf8');
+  assert.match(source, /glyphOutlinePayloadStatus\(op\)/);
+  assert.match(source, /glyphOutline:\$\{status\.reason\}/);
 });

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -7,12 +7,14 @@ use crate::model::control::FormType;
 use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
 use crate::paint::{
-    CacheHint, ClipKind, FontResourceTable, GlyphCluster, GlyphOutlineStrokeStyle,
-    GlyphRunDiagnostics, GlyphTransform, GroupKind, LayerAffineTransform, LayerGlyphOutlinePath,
-    LayerNode, LayerNodeKind, LayerPoint, LayerVector, PageLayerTree, PaintOp, PaintTextStyle,
-    PaintVariantMeta, RenderProfile, ResolvedImageKind, ShapeKey, TextDecorationKind,
-    TextSourceAnnotation, TextSourceEntry, TextSourceId, TextSourceRange, TextSourceSpan,
-    TextSourceTable, TextV2Diagnostics, LAYER_TREE_SCHEMA,
+    BitmapGlyphPayload, CacheHint, ClipKind, ColorLayerNode, ColorLayersPayload,
+    ColorPaintGraphNode, ColorPaintGraphPayload, FontColorGlyphRef, FontResourceTable,
+    GlyphCluster, GlyphOutlinePayloadKind, GlyphOutlineStrokeStyle, GlyphRunDiagnostics,
+    GlyphTransform, GroupKind, LayerAffineTransform, LayerGlyphOutlinePath, LayerNode,
+    LayerNodeKind, LayerPoint, LayerVector, PageLayerTree, PaintOp, PaintTextStyle,
+    PaintVariantMeta, PaletteRef, RenderProfile, ResolvedColor, ResolvedImageKind, ShapeKey,
+    SvgGlyphPayload, TextDecorationKind, TextSourceAnnotation, TextSourceEntry, TextSourceId,
+    TextSourceRange, TextSourceSpan, TextSourceTable, TextV2Diagnostics, LAYER_TREE_SCHEMA,
 };
 use crate::renderer::composer::expand_pua_display_text;
 use crate::renderer::layout::compute_char_positions;
@@ -68,6 +70,9 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let has_variant_groups = text_variant_features.has_variant_groups();
     let has_glyph_runs = text_variant_features.has_glyph_runs;
     let has_glyph_outlines = text_variant_features.has_glyph_outlines;
+    let has_glyph_outline_color_layers = text_variant_features.has_glyph_outline_color_layers;
+    let has_glyph_outline_bitmap = text_variant_features.has_glyph_outline_bitmap;
+    let has_glyph_outline_svg = text_variant_features.has_glyph_outline_svg;
     let has_display_text = text_variant_features.has_display_text;
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.v2.diagnostics\",\"text.projectionKind\",\"text.legacyVisuals\"");
     if has_display_text {
@@ -78,6 +83,15 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     }
     if has_glyph_outlines {
         buf.push_str(",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\"");
+    }
+    if has_glyph_outline_color_layers {
+        buf.push_str(",\"text.glyphOutline.colorLayers\"");
+    }
+    if has_glyph_outline_bitmap {
+        buf.push_str(",\"text.glyphOutline.bitmapGlyph\"");
+    }
+    if has_glyph_outline_svg {
+        buf.push_str(",\"text.glyphOutline.svgGlyph\"");
     }
     if has_variant_groups {
         buf.push_str(",\"text.variantGroups\"");
@@ -103,6 +117,15 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         optional_features.push("text.glyphOutline");
         optional_features.push("text.glyphOutline.strictSidecar");
     }
+    if has_glyph_outline_color_layers {
+        optional_features.push("text.glyphOutline.colorLayers");
+    }
+    if has_glyph_outline_bitmap {
+        optional_features.push("text.glyphOutline.bitmapGlyph");
+    }
+    if has_glyph_outline_svg {
+        optional_features.push("text.glyphOutline.svgGlyph");
+    }
     buf.push_str("],\"optionalFeatures\":[");
     for (idx, feature) in optional_features.iter().enumerate() {
         if idx > 0 {
@@ -110,7 +133,7 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         }
         buf.push_str(&json_escape(feature));
     }
-    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.glyphOutline.colorLayers\",\"text.glyphOutline.colorLayers.colrV0\",\"text.glyphOutline.colorLayers.colrV1\",\"text.glyphOutline.bitmapGlyph\",\"text.glyphOutline.svgGlyph\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
         buf.push_str(",\"glyphRun\"");
     }
@@ -131,6 +154,9 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
 struct TextVariantFeatureFlags {
     has_glyph_runs: bool,
     has_glyph_outlines: bool,
+    has_glyph_outline_color_layers: bool,
+    has_glyph_outline_bitmap: bool,
+    has_glyph_outline_svg: bool,
     has_display_text: bool,
 }
 
@@ -158,15 +184,21 @@ fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
                             features.has_display_text |= display_text_for_text_run(run).is_some()
                         }
                         PaintOp::GlyphRun { .. } => features.has_glyph_runs = true,
-                        PaintOp::GlyphOutline { .. } => features.has_glyph_outlines = true,
+                        PaintOp::GlyphOutline { outline, .. } => {
+                            features.has_glyph_outlines = true;
+                            features.has_glyph_outline_color_layers |= matches!(
+                                outline.payload_kind,
+                                GlyphOutlinePayloadKind::ColorLayers
+                            );
+                            features.has_glyph_outline_bitmap |= matches!(
+                                outline.payload_kind,
+                                GlyphOutlinePayloadKind::BitmapGlyph
+                            );
+                            features.has_glyph_outline_svg |=
+                                matches!(outline.payload_kind, GlyphOutlinePayloadKind::SvgGlyph);
+                        }
                         _ => {}
                     }
-                }
-                if features.has_glyph_runs
-                    && features.has_glyph_outlines
-                    && features.has_display_text
-                {
-                    return features;
                 }
             }
         }
@@ -451,6 +483,18 @@ impl PaintOp {
                 if let Some(stroke) = &outline.stroke {
                     buf.push_str(",\"stroke\":");
                     write_glyph_outline_stroke(buf, stroke);
+                }
+                if let Some(color_layers) = &outline.color_layers {
+                    buf.push_str(",\"colorLayers\":");
+                    write_color_layers_payload(buf, color_layers);
+                }
+                if let Some(bitmap_glyph) = &outline.bitmap_glyph {
+                    buf.push_str(",\"bitmapGlyph\":");
+                    write_bitmap_glyph_payload(buf, bitmap_glyph);
+                }
+                if let Some(svg_glyph) = &outline.svg_glyph {
+                    buf.push_str(",\"svgGlyph\":");
+                    write_svg_glyph_payload(buf, svg_glyph);
                 }
                 buf.push_str(",\"diagnostics\":");
                 write_glyph_run_diagnostics(buf, &outline.diagnostics);
@@ -1609,6 +1653,293 @@ fn write_glyph_outline_stroke(buf: &mut String, stroke: &GlyphOutlineStrokeStyle
     );
 }
 
+fn write_color_layers_payload(buf: &mut String, payload: &ColorLayersPayload) {
+    let _ = write!(
+        buf,
+        "{{\"colorFormat\":{}",
+        json_escape(payload.color_format.as_str())
+    );
+    if let Some(source_font_ref) = &payload.source_font_ref {
+        buf.push_str(",\"sourceFontRef\":");
+        write_font_color_glyph_ref(buf, source_font_ref);
+    }
+    if let Some(palette_ref) = &payload.palette_ref {
+        buf.push_str(",\"paletteRef\":");
+        write_palette_ref(buf, palette_ref);
+    }
+    buf.push_str(",\"layers\":");
+    write_color_layer_nodes(buf, &payload.layers);
+    if let Some(graph) = &payload.paint_graph {
+        buf.push_str(",\"paintGraph\":");
+        write_color_paint_graph(buf, graph);
+    }
+    if let Some(range) = payload.source_range_utf8 {
+        buf.push_str(",\"sourceRangeUtf8\":");
+        write_text_source_range(buf, range);
+    }
+    if let Some(range) = payload.glyph_range {
+        let _ = write!(
+            buf,
+            ",\"glyphRange\":{{\"start\":{},\"end\":{}}}",
+            range.start, range.end
+        );
+    }
+    let _ = write!(
+        buf,
+        ",\"colrv0ResolvedLayerContract\":{},\"colrv1Stage1GraphContract\":{}",
+        payload.has_colrv0_resolved_layer_contract(),
+        payload.has_colrv1_stage1_graph_contract()
+    );
+    buf.push('}');
+}
+
+fn write_color_layer_nodes(buf: &mut String, layers: &[ColorLayerNode]) {
+    buf.push('[');
+    for (idx, layer) in layers.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        buf.push('{');
+        if let Some(layer_index) = layer.layer_index {
+            let _ = write!(buf, "\"layerIndex\":{}", layer_index);
+        } else {
+            buf.push_str("\"layerIndex\":null");
+        }
+        if let Some(glyph_id) = layer.glyph_id {
+            let _ = write!(buf, ",\"glyphId\":{}", glyph_id);
+        }
+        if let Some(range) = layer.glyph_range {
+            let _ = write!(
+                buf,
+                ",\"glyphRange\":{{\"start\":{},\"end\":{}}}",
+                range.start, range.end
+            );
+        }
+        if let Some(range) = layer.source_range_utf8 {
+            buf.push_str(",\"sourceRangeUtf8\":");
+            write_text_source_range(buf, range);
+        }
+        if let Some(source_font_ref) = &layer.source_font_ref {
+            buf.push_str(",\"sourceFontRef\":");
+            write_font_color_glyph_ref(buf, source_font_ref);
+        }
+        if let Some(commands) = &layer.commands {
+            buf.push_str(",\"commands\":");
+            write_path_commands(buf, commands);
+        }
+        if let Some(fill) = &layer.fill {
+            buf.push_str(",\"fill\":");
+            write_resolved_color(buf, fill);
+        }
+        if let Some(fill_rule) = layer.fill_rule {
+            let _ = write!(buf, ",\"fillRule\":{}", json_escape(fill_rule.as_str()));
+        }
+        if let Some(palette_index) = layer.palette_index {
+            let _ = write!(buf, ",\"paletteIndex\":{}", palette_index);
+        }
+        if let Some(color) = layer.color {
+            let _ = write!(buf, ",\"color\":{}", json_escape(&color_ref_to_css(color)));
+        }
+        if let Some(opacity) = layer.opacity {
+            let _ = write!(buf, ",\"opacity\":{:.6}", opacity);
+        }
+        if let Some(transform) = layer.transform_to_run {
+            buf.push_str(",\"transformToRun\":");
+            write_affine_transform(buf, transform);
+        }
+        buf.push('}');
+    }
+    buf.push(']');
+}
+
+fn write_color_paint_graph(buf: &mut String, graph: &ColorPaintGraphPayload) {
+    let _ = write!(buf, "{{\"rootNodeId\":{},\"nodes\":[", graph.root_node_id);
+    for (idx, node) in graph.nodes.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        write_color_paint_graph_node(buf, node);
+    }
+    buf.push_str("]}");
+}
+
+fn write_color_paint_graph_node(buf: &mut String, node: &ColorPaintGraphNode) {
+    let _ = write!(
+        buf,
+        "{{\"nodeId\":{},\"kind\":{}",
+        node.node_id,
+        json_escape(node.kind.as_str())
+    );
+    if let Some(commands) = &node.commands {
+        buf.push_str(",\"commands\":");
+        write_path_commands(buf, commands);
+    }
+    if let Some(fill) = &node.fill {
+        buf.push_str(",\"fill\":");
+        write_resolved_color(buf, fill);
+    }
+    if let Some(fill_rule) = node.fill_rule {
+        let _ = write!(buf, ",\"fillRule\":{}", json_escape(fill_rule.as_str()));
+    }
+    if let Some(child_node_id) = node.child_node_id {
+        let _ = write!(buf, ",\"childNodeId\":{}", child_node_id);
+    }
+    if let Some(transform) = node.transform {
+        buf.push_str(",\"transform\":");
+        write_affine_transform(buf, transform);
+    }
+    if let Some(range) = node.source_range_utf8 {
+        buf.push_str(",\"sourceRangeUtf8\":");
+        write_text_source_range(buf, range);
+    }
+    if let Some(range) = node.glyph_range {
+        let _ = write!(
+            buf,
+            ",\"glyphRange\":{{\"start\":{},\"end\":{}}}",
+            range.start, range.end
+        );
+    }
+    if let Some(source_font_ref) = &node.source_font_ref {
+        buf.push_str(",\"sourceFontRef\":");
+        write_font_color_glyph_ref(buf, source_font_ref);
+    }
+    buf.push('}');
+}
+
+fn write_bitmap_glyph_payload(buf: &mut String, payload: &BitmapGlyphPayload) {
+    let _ = write!(
+        buf,
+        "{{\"imageRef\":{},\"sourceRangeUtf8\":",
+        payload.image_ref.0
+    );
+    write_text_source_range(buf, payload.source_range_utf8);
+    let _ = write!(
+        buf,
+        ",\"glyphRange\":{{\"start\":{},\"end\":{}}},\"placement\":",
+        payload.glyph_range.start, payload.glyph_range.end
+    );
+    write_bbox(buf, payload.placement);
+    let _ = write!(
+        buf,
+        ",\"alphaPremultiplied\":{},\"scalingPolicy\":{},\"filtering\":{},\"strictVisualContract\":{}",
+        payload.alpha_premultiplied,
+        json_escape(payload.scaling_policy.as_str()),
+        json_escape(payload.filtering.as_str()),
+        payload.has_strict_visual_contract()
+    );
+    if let Some(transform) = payload.transform_to_run {
+        buf.push_str(",\"transformToRun\":");
+        write_affine_transform(buf, transform);
+    }
+    buf.push('}');
+}
+
+fn write_svg_glyph_payload(buf: &mut String, payload: &SvgGlyphPayload) {
+    let _ = write!(
+        buf,
+        "{{\"svgRef\":{},\"sourceRangeUtf8\":",
+        payload.svg_ref.0
+    );
+    write_text_source_range(buf, payload.source_range_utf8);
+    let _ = write!(
+        buf,
+        ",\"glyphRange\":{{\"start\":{},\"end\":{}}},\"viewBox\":",
+        payload.glyph_range.start, payload.glyph_range.end
+    );
+    write_bbox(buf, payload.view_box);
+    if let Some(size) = payload.intrinsic_size {
+        let _ = write!(
+            buf,
+            ",\"intrinsicSize\":{{\"width\":{:.6},\"height\":{:.6}}}",
+            size.dx, size.dy
+        );
+    }
+    let _ = write!(
+        buf,
+        ",\"staticSanitized\":{},\"scriptAllowed\":{},\"animationAllowed\":{},\"externalResourcesAllowed\":{},\"interactivityAllowed\":{},\"staticSanitizedContract\":{}",
+        payload.static_sanitized,
+        payload.script_allowed,
+        payload.animation_allowed,
+        payload.external_resources_allowed,
+        payload.interactivity_allowed,
+        payload.has_static_sanitized_contract()
+    );
+    if let Some(transform) = payload.transform_to_run {
+        buf.push_str(",\"transformToRun\":");
+        write_affine_transform(buf, transform);
+    }
+    buf.push('}');
+}
+
+fn write_font_color_glyph_ref(buf: &mut String, value: &FontColorGlyphRef) {
+    buf.push('{');
+    let mut wrote = false;
+    if let Some(face_key) = &value.face_key {
+        let _ = write!(buf, "\"faceKey\":{}", json_escape(face_key));
+        wrote = true;
+    }
+    if let Some(glyph_id) = value.glyph_id {
+        if wrote {
+            buf.push(',');
+        }
+        let _ = write!(buf, "\"glyphId\":{}", glyph_id);
+        wrote = true;
+    }
+    if let Some(palette_index) = value.palette_index {
+        if wrote {
+            buf.push(',');
+        }
+        let _ = write!(buf, "\"paletteIndex\":{}", palette_index);
+        wrote = true;
+    }
+    if let Some(color_format) = value.color_format {
+        if wrote {
+            buf.push(',');
+        }
+        let _ = write!(
+            buf,
+            "\"colorFormat\":{}",
+            json_escape(color_format.as_str())
+        );
+    }
+    buf.push('}');
+}
+
+fn write_palette_ref(buf: &mut String, value: &PaletteRef) {
+    buf.push('{');
+    let mut wrote = false;
+    if let Some(id) = &value.id {
+        let _ = write!(buf, "\"id\":{}", json_escape(id));
+        wrote = true;
+    }
+    if let Some(index) = value.index {
+        if wrote {
+            buf.push(',');
+        }
+        let _ = write!(buf, "\"index\":{}", index);
+        wrote = true;
+    }
+    if let Some(cpal_digest) = &value.cpal_digest {
+        if wrote {
+            buf.push(',');
+        }
+        let _ = write!(buf, "\"cpalDigest\":{}", json_escape(cpal_digest));
+    }
+    buf.push('}');
+}
+
+fn write_resolved_color(buf: &mut String, color: &ResolvedColor) {
+    buf.push('{');
+    if let Some(color_space) = &color.color_space {
+        let _ = write!(buf, "\"colorSpace\":{},", json_escape(color_space));
+    }
+    let _ = write!(
+        buf,
+        "\"rgba\":[{:.6},{:.6},{:.6},{:.6}]}}",
+        color.rgba[0], color.rgba[1], color.rgba[2], color.rgba[3]
+    );
+}
+
 fn write_glyph_transforms(buf: &mut String, transforms: &[GlyphTransform]) {
     buf.push('[');
     for (idx, transform) in transforms.iter().enumerate() {
@@ -1937,14 +2268,16 @@ fn form_type_str(value: FormType) -> &'static str {
 mod tests {
     use super::*;
     use crate::paint::{
-        CacheHint, ClipKind, FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster,
-        GlyphOutlineFillRule, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
-        GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
-        GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind, LayerAffineTransform,
-        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
-        LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey,
-        ShapingEngineId, TextDecorationKind, TextDirection, TextSourceId, TextSourceRange,
-        TextSourceSpan, TextVariantKind, TextVariantQuality, WritingMode,
+        CacheHint, ClipKind, ColorGlyphFormat, ColorLayersPayload, ColorPaintGraphNode,
+        ColorPaintGraphNodeKind, ColorPaintGraphPayload, FontFaceKey, FontFallbackPolicyId,
+        FontInstanceKey, GlyphCluster, GlyphOutlineFillRule, GlyphOutlinePayloadKind,
+        GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange,
+        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
+        LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint,
+        LayerNode, LayerPoint, LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta,
+        ResolvedColor, ScriptTag, ShapeKey, ShapingEngineId, TextDecorationKind, TextDirection,
+        TextSourceId, TextSourceRange, TextSourceSpan, TextVariantKind, TextVariantQuality,
+        WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -2035,7 +2368,7 @@ mod tests {
 
         assert!(json.contains("\"kind\":\"leaf\""));
         assert!(json.contains("\"schemaVersion\":1"));
-        assert!(json.contains("\"schemaMinorVersion\":13"));
+        assert!(json.contains("\"schemaMinorVersion\":14"));
         assert!(json.contains("\"schema\":{\"major\":1,\"minor\":13}"));
         assert!(json.contains("\"resourceTableVersion\":1"));
         assert!(json.contains("\"resourceTableMinorVersion\":3"));
@@ -2472,6 +2805,9 @@ mod tests {
                     local_paint_order: Some(0),
                 },
                 payload_kind: GlyphOutlinePayloadKind::MonochromeFillStroke,
+                color_layers: None,
+                bitmap_glyph: None,
+                svg_glyph: None,
                 paint_style: PaintTextStyle::from(&TextStyle {
                     font_family: "Test".to_string(),
                     font_size: 12.0,
@@ -2545,6 +2881,115 @@ mod tests {
         assert!(json.contains("\"text.glyphOutline.strictSidecar\""));
         assert!(json.contains("\"variants\":[\"textRun\",\"glyphOutline\"]"));
         assert!(json.contains("\"variantKind\":\"glyphOutline\""));
+    }
+
+    #[test]
+    fn serializes_advanced_glyph_outline_payload_gate_metadata() {
+        let outline = PaintOp::GlyphOutline {
+            bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+            outline: Box::new(LayerGlyphOutlinePaint {
+                source: TextSourceSpan {
+                    id: TextSourceId(0),
+                    utf8_range: TextSourceRange::new(0, 1),
+                    utf16_range: TextSourceRange::new(0, 1),
+                    stable_source_key: None,
+                },
+                variant: PaintVariantMeta {
+                    equivalence_group: "text-0".to_string(),
+                    variant_id: "glyphOutlineColor".to_string(),
+                    variant_kind: TextVariantKind::GlyphOutline,
+                    part_index: 0,
+                    part_count: 1,
+                    is_default_fallback: false,
+                    requires: vec![
+                        "text.glyphOutline".to_string(),
+                        "text.glyphOutline.colorLayers".to_string(),
+                        "text.glyphOutline.colorLayers.colrV1".to_string(),
+                    ],
+                    quality: Some(TextVariantQuality::Exact),
+                    anchor_op_id: Some("text-0".to_string()),
+                    local_paint_order: Some(0),
+                },
+                payload_kind: GlyphOutlinePayloadKind::ColorLayers,
+                color_layers: Some(ColorLayersPayload {
+                    color_format: ColorGlyphFormat::ColrV1,
+                    source_font_ref: None,
+                    palette_ref: None,
+                    layers: Vec::new(),
+                    paint_graph: Some(ColorPaintGraphPayload {
+                        root_node_id: 0,
+                        nodes: vec![ColorPaintGraphNode {
+                            node_id: 0,
+                            kind: ColorPaintGraphNodeKind::SolidPath,
+                            commands: Some(vec![
+                                PathCommand::MoveTo(0.0, 0.0),
+                                PathCommand::LineTo(10.0, 0.0),
+                                PathCommand::ClosePath,
+                            ]),
+                            fill: Some(ResolvedColor {
+                                color_space: Some("sRGB".to_string()),
+                                rgba: [0.0, 0.0, 0.0, 1.0],
+                            }),
+                            fill_rule: Some(GlyphOutlineFillRule::NonZero),
+                            child_node_id: None,
+                            transform: None,
+                            source_range_utf8: Some(TextSourceRange::new(0, 1)),
+                            glyph_range: Some(GlyphRange::new(0, 1)),
+                            source_font_ref: None,
+                        }],
+                    }),
+                    source_range_utf8: Some(TextSourceRange::new(0, 1)),
+                    glyph_range: Some(GlyphRange::new(0, 1)),
+                }),
+                bitmap_glyph: None,
+                svg_glyph: None,
+                paint_style: PaintTextStyle::from(&TextStyle {
+                    font_family: "Test".to_string(),
+                    font_size: 12.0,
+                    shade_color: 0x00FF_FFFF,
+                    ..Default::default()
+                }),
+                placement: crate::paint::TextRunPlacement {
+                    run_to_page: LayerAffineTransform {
+                        a: 1.0,
+                        b: 0.0,
+                        c: 0.0,
+                        d: 1.0,
+                        e: 0.0,
+                        f: 12.0,
+                    },
+                    baseline_y: 0.0,
+                },
+                paths: Vec::new(),
+                stroke: None,
+                diagnostics: GlyphRunDiagnostics {
+                    quality: TextVariantQuality::Exact,
+                    replay_eligibility: GlyphRunReplayEligibility::Portable,
+                    strict_visual_eligible: true,
+                    max_origin_delta_px: 0.0,
+                    max_advance_delta_px: 0.0,
+                    max_residual_after_adjustment_px: 0.0,
+                    cluster_mismatch_count: 0,
+                    missing_glyph_count: 0,
+                    used_fallback_font_count: 0,
+                    reason: None,
+                },
+            }),
+        };
+
+        let tree = PageLayerTree::new(
+            120.0,
+            80.0,
+            LayerNode::leaf(BoundingBox::new(0.0, 0.0, 120.0, 80.0), None, vec![outline]),
+        );
+        let json = tree.to_json();
+
+        assert!(json.contains("\"payloadKind\":\"colorLayers\""));
+        assert!(json.contains("\"colorLayers\":{\"colorFormat\":\"colrV1\""));
+        assert!(json.contains("\"kind\":\"solidPath\""));
+        assert!(json.contains("\"colrv1Stage1GraphContract\":true"));
+        assert!(json.contains("\"text.glyphOutline.colorLayers\""));
+        assert!(json.contains("\"text.glyphOutline.colorLayers.colrV1\""));
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -1686,9 +1686,10 @@ fn write_color_layers_payload(buf: &mut String, payload: &ColorLayersPayload) {
     }
     let _ = write!(
         buf,
-        ",\"colrv0ResolvedLayerContract\":{},\"colrv1Stage1GraphContract\":{}",
+        ",\"colrv0ResolvedLayerContract\":{},\"colrv1Stage1GraphContract\":{},\"colrv1SupportedGraphContract\":{}",
         payload.has_colrv0_resolved_layer_contract(),
-        payload.has_colrv1_stage1_graph_contract()
+        payload.has_colrv1_stage1_graph_contract(),
+        payload.has_colrv1_supported_graph_contract()
     );
     buf.push('}');
 }
@@ -1770,23 +1771,25 @@ fn write_color_paint_graph_node(buf: &mut String, node: &ColorPaintGraphNode) {
         node.node_id,
         json_escape(node.kind.as_str())
     );
-    if let Some(commands) = &node.commands {
-        buf.push_str(",\"commands\":");
-        write_path_commands(buf, commands);
+    if let Some(solid) = &node.solid_path {
+        buf.push_str(",\"solidPath\":");
+        write_color_paint_solid_path_node(buf, solid);
     }
-    if let Some(fill) = &node.fill {
-        buf.push_str(",\"fill\":");
-        write_resolved_color(buf, fill);
+    if let Some(gradient_path) = &node.linear_gradient_path {
+        buf.push_str(",\"linearGradientPath\":");
+        write_color_paint_linear_gradient_path_node(buf, gradient_path);
     }
-    if let Some(fill_rule) = node.fill_rule {
-        let _ = write!(buf, ",\"fillRule\":{}", json_escape(fill_rule.as_str()));
+    if let Some(gradient_path) = &node.radial_gradient_path {
+        buf.push_str(",\"radialGradientPath\":");
+        write_color_paint_radial_gradient_path_node(buf, gradient_path);
     }
-    if let Some(child_node_id) = node.child_node_id {
-        let _ = write!(buf, ",\"childNodeId\":{}", child_node_id);
+    if let Some(gradient_path) = &node.sweep_gradient_path {
+        buf.push_str(",\"sweepGradientPath\":");
+        write_color_paint_sweep_gradient_path_node(buf, gradient_path);
     }
-    if let Some(transform) = node.transform {
+    if let Some(transform) = &node.transform {
         buf.push_str(",\"transform\":");
-        write_affine_transform(buf, transform);
+        write_color_paint_transform_node(buf, transform);
     }
     if let Some(range) = node.source_range_utf8 {
         buf.push_str(",\"sourceRangeUtf8\":");
@@ -1803,6 +1806,136 @@ fn write_color_paint_graph_node(buf: &mut String, node: &ColorPaintGraphNode) {
         buf.push_str(",\"sourceFontRef\":");
         write_font_color_glyph_ref(buf, source_font_ref);
     }
+    buf.push('}');
+}
+
+fn write_color_paint_solid_path_node(
+    buf: &mut String,
+    solid: &crate::paint::ColorPaintSolidPathNode,
+) {
+    buf.push_str("{\"commands\":");
+    write_path_commands(buf, &solid.commands);
+    buf.push_str(",\"fill\":");
+    write_resolved_color(buf, &solid.fill);
+    let _ = write!(
+        buf,
+        ",\"fillRule\":{}",
+        json_escape(solid.fill_rule.as_str())
+    );
+    if let Some(source_glyph_id) = solid.source_glyph_id {
+        let _ = write!(buf, ",\"sourceGlyphId\":{}", source_glyph_id);
+    }
+    if let Some(palette_index) = solid.palette_index {
+        let _ = write!(buf, ",\"paletteIndex\":{}", palette_index);
+    }
+    buf.push('}');
+}
+
+fn write_color_gradient_stops(buf: &mut String, stops: &[crate::paint::ColorGradientStop]) {
+    buf.push('[');
+    for (idx, stop) in stops.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        let _ = write!(buf, "{{\"offset\":{}", stop.offset);
+        buf.push_str(",\"color\":");
+        write_resolved_color(buf, &stop.color);
+        buf.push('}');
+    }
+    buf.push(']');
+}
+
+fn write_color_paint_linear_gradient_path_node(
+    buf: &mut String,
+    gradient_path: &crate::paint::ColorPaintLinearGradientPathNode,
+) {
+    buf.push_str("{\"commands\":");
+    write_path_commands(buf, &gradient_path.commands);
+    let _ = write!(
+        buf,
+        ",\"gradient\":{{\"x0\":{},\"y0\":{},\"x1\":{},\"y1\":{},\"stops\":",
+        gradient_path.gradient.x0,
+        gradient_path.gradient.y0,
+        gradient_path.gradient.x1,
+        gradient_path.gradient.y1
+    );
+    write_color_gradient_stops(buf, &gradient_path.gradient.stops);
+    let _ = write!(
+        buf,
+        "}},\"fillRule\":{}",
+        json_escape(gradient_path.fill_rule.as_str())
+    );
+    if let Some(source_glyph_id) = gradient_path.source_glyph_id {
+        let _ = write!(buf, ",\"sourceGlyphId\":{}", source_glyph_id);
+    }
+    if let Some(palette_index) = gradient_path.palette_index {
+        let _ = write!(buf, ",\"paletteIndex\":{}", palette_index);
+    }
+    buf.push('}');
+}
+
+fn write_color_paint_radial_gradient_path_node(
+    buf: &mut String,
+    gradient_path: &crate::paint::ColorPaintRadialGradientPathNode,
+) {
+    buf.push_str("{\"commands\":");
+    write_path_commands(buf, &gradient_path.commands);
+    let _ = write!(
+        buf,
+        ",\"gradient\":{{\"cx\":{},\"cy\":{},\"radius\":{},\"stops\":",
+        gradient_path.gradient.cx, gradient_path.gradient.cy, gradient_path.gradient.radius
+    );
+    write_color_gradient_stops(buf, &gradient_path.gradient.stops);
+    let _ = write!(
+        buf,
+        "}},\"fillRule\":{}",
+        json_escape(gradient_path.fill_rule.as_str())
+    );
+    if let Some(source_glyph_id) = gradient_path.source_glyph_id {
+        let _ = write!(buf, ",\"sourceGlyphId\":{}", source_glyph_id);
+    }
+    if let Some(palette_index) = gradient_path.palette_index {
+        let _ = write!(buf, ",\"paletteIndex\":{}", palette_index);
+    }
+    buf.push('}');
+}
+
+fn write_color_paint_sweep_gradient_path_node(
+    buf: &mut String,
+    gradient_path: &crate::paint::ColorPaintSweepGradientPathNode,
+) {
+    buf.push_str("{\"commands\":");
+    write_path_commands(buf, &gradient_path.commands);
+    let _ = write!(
+        buf,
+        ",\"gradient\":{{\"cx\":{},\"cy\":{},\"startAngleDegrees\":{},\"endAngleDegrees\":{},\"stops\":",
+        gradient_path.gradient.cx,
+        gradient_path.gradient.cy,
+        gradient_path.gradient.start_angle_degrees,
+        gradient_path.gradient.end_angle_degrees
+    );
+    write_color_gradient_stops(buf, &gradient_path.gradient.stops);
+    let _ = write!(
+        buf,
+        "}},\"fillRule\":{}",
+        json_escape(gradient_path.fill_rule.as_str())
+    );
+    if let Some(source_glyph_id) = gradient_path.source_glyph_id {
+        let _ = write!(buf, ",\"sourceGlyphId\":{}", source_glyph_id);
+    }
+    if let Some(palette_index) = gradient_path.palette_index {
+        let _ = write!(buf, ",\"paletteIndex\":{}", palette_index);
+    }
+    buf.push('}');
+}
+
+fn write_color_paint_transform_node(
+    buf: &mut String,
+    transform: &crate::paint::ColorPaintTransformNode,
+) {
+    let _ = write!(buf, "{{\"childNodeId\":{}", transform.child_node_id);
+    buf.push_str(",\"transform\":");
+    write_affine_transform(buf, transform.transform);
     buf.push('}');
 }
 
@@ -2269,15 +2402,15 @@ mod tests {
     use super::*;
     use crate::paint::{
         CacheHint, ClipKind, ColorGlyphFormat, ColorLayersPayload, ColorPaintGraphNode,
-        ColorPaintGraphNodeKind, ColorPaintGraphPayload, FontFaceKey, FontFallbackPolicyId,
-        FontInstanceKey, GlyphCluster, GlyphOutlineFillRule, GlyphOutlinePayloadKind,
-        GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange,
-        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
-        LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint,
-        LayerNode, LayerPoint, LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta,
-        ResolvedColor, ScriptTag, ShapeKey, ShapingEngineId, TextDecorationKind, TextDirection,
-        TextSourceId, TextSourceRange, TextSourceSpan, TextVariantKind, TextVariantQuality,
-        WritingMode,
+        ColorPaintGraphNodeKind, ColorPaintGraphPayload, ColorPaintSolidPathNode,
+        FontColorGlyphRef, FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster,
+        GlyphOutlineFillRule, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
+        GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
+        GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind, LayerAffineTransform,
+        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
+        LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta, ResolvedColor, ScriptTag,
+        ShapeKey, ShapingEngineId, TextDecorationKind, TextDirection, TextSourceId,
+        TextSourceRange, TextSourceSpan, TextVariantKind, TextVariantQuality, WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -2913,7 +3046,12 @@ mod tests {
                 payload_kind: GlyphOutlinePayloadKind::ColorLayers,
                 color_layers: Some(ColorLayersPayload {
                     color_format: ColorGlyphFormat::ColrV1,
-                    source_font_ref: None,
+                    source_font_ref: Some(FontColorGlyphRef {
+                        face_key: Some("fixture-face".to_string()),
+                        glyph_id: Some(42),
+                        palette_index: Some(0),
+                        color_format: Some(ColorGlyphFormat::ColrV1),
+                    }),
                     palette_ref: None,
                     layers: Vec::new(),
                     paint_graph: Some(ColorPaintGraphPayload {
@@ -2921,21 +3059,32 @@ mod tests {
                         nodes: vec![ColorPaintGraphNode {
                             node_id: 0,
                             kind: ColorPaintGraphNodeKind::SolidPath,
-                            commands: Some(vec![
-                                PathCommand::MoveTo(0.0, 0.0),
-                                PathCommand::LineTo(10.0, 0.0),
-                                PathCommand::ClosePath,
-                            ]),
-                            fill: Some(ResolvedColor {
-                                color_space: Some("sRGB".to_string()),
-                                rgba: [0.0, 0.0, 0.0, 1.0],
+                            solid_path: Some(ColorPaintSolidPathNode {
+                                commands: vec![
+                                    PathCommand::MoveTo(0.0, 0.0),
+                                    PathCommand::LineTo(10.0, 0.0),
+                                    PathCommand::ClosePath,
+                                ],
+                                fill: ResolvedColor {
+                                    color_space: Some("sRGB".to_string()),
+                                    rgba: [0.0, 0.0, 0.0, 1.0],
+                                },
+                                fill_rule: GlyphOutlineFillRule::NonZero,
+                                source_glyph_id: Some(42),
+                                palette_index: Some(0),
                             }),
-                            fill_rule: Some(GlyphOutlineFillRule::NonZero),
-                            child_node_id: None,
+                            linear_gradient_path: None,
+                            radial_gradient_path: None,
+                            sweep_gradient_path: None,
                             transform: None,
                             source_range_utf8: Some(TextSourceRange::new(0, 1)),
                             glyph_range: Some(GlyphRange::new(0, 1)),
-                            source_font_ref: None,
+                            source_font_ref: Some(FontColorGlyphRef {
+                                face_key: Some("fixture-face".to_string()),
+                                glyph_id: Some(42),
+                                palette_index: Some(0),
+                                color_format: Some(ColorGlyphFormat::ColrV1),
+                            }),
                         }],
                     }),
                     source_range_utf8: Some(TextSourceRange::new(0, 1)),

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -2500,9 +2500,18 @@ mod tests {
         );
 
         assert!(json.contains("\"kind\":\"leaf\""));
-        assert!(json.contains("\"schemaVersion\":1"));
-        assert!(json.contains("\"schemaMinorVersion\":14"));
-        assert!(json.contains("\"schema\":{\"major\":1,\"minor\":13}"));
+        assert!(json.contains(&format!(
+            "\"schemaVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_version
+        )));
+        assert!(json.contains(&format!(
+            "\"schemaMinorVersion\":{}",
+            LAYER_TREE_SCHEMA.schema_minor_version
+        )));
+        assert!(json.contains(&format!(
+            "\"schema\":{{\"major\":{},\"minor\":{}}}",
+            LAYER_TREE_SCHEMA.schema_version, LAYER_TREE_SCHEMA.schema_minor_version
+        )));
         assert!(json.contains("\"resourceTableVersion\":1"));
         assert!(json.contains("\"resourceTableMinorVersion\":3"));
         assert!(json.contains("\"resourceTable\":{\"major\":1,\"minor\":3}"));

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -202,6 +202,15 @@ fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
                 }
             }
         }
+        if features.has_glyph_runs
+            && features.has_glyph_outlines
+            && features.has_glyph_outline_color_layers
+            && features.has_glyph_outline_bitmap
+            && features.has_glyph_outline_svg
+            && features.has_display_text
+        {
+            return features;
+        }
     }
     features
 }
@@ -1688,7 +1697,7 @@ fn write_color_layers_payload(buf: &mut String, payload: &ColorLayersPayload) {
         buf,
         ",\"colrv0ResolvedLayerContract\":{},\"colrv1Stage1GraphContract\":{},\"colrv1SupportedGraphContract\":{}",
         payload.has_colrv0_resolved_layer_contract(),
-        payload.has_colrv1_stage1_graph_contract(),
+        payload.has_colrv1_supported_graph_contract(),
         payload.has_colrv1_supported_graph_contract()
     );
     buf.push('}');
@@ -1837,7 +1846,7 @@ fn write_color_gradient_stops(buf: &mut String, stops: &[crate::paint::ColorGrad
         if idx > 0 {
             buf.push(',');
         }
-        let _ = write!(buf, "{{\"offset\":{}", stop.offset);
+        let _ = write!(buf, "{{\"offset\":{:.6}", stop.offset);
         buf.push_str(",\"color\":");
         write_resolved_color(buf, &stop.color);
         buf.push('}');
@@ -1853,7 +1862,7 @@ fn write_color_paint_linear_gradient_path_node(
     write_path_commands(buf, &gradient_path.commands);
     let _ = write!(
         buf,
-        ",\"gradient\":{{\"x0\":{},\"y0\":{},\"x1\":{},\"y1\":{},\"stops\":",
+        ",\"gradient\":{{\"x0\":{:.6},\"y0\":{:.6},\"x1\":{:.6},\"y1\":{:.6},\"stops\":",
         gradient_path.gradient.x0,
         gradient_path.gradient.y0,
         gradient_path.gradient.x1,
@@ -1882,7 +1891,7 @@ fn write_color_paint_radial_gradient_path_node(
     write_path_commands(buf, &gradient_path.commands);
     let _ = write!(
         buf,
-        ",\"gradient\":{{\"cx\":{},\"cy\":{},\"radius\":{},\"stops\":",
+        ",\"gradient\":{{\"cx\":{:.6},\"cy\":{:.6},\"radius\":{:.6},\"stops\":",
         gradient_path.gradient.cx, gradient_path.gradient.cy, gradient_path.gradient.radius
     );
     write_color_gradient_stops(buf, &gradient_path.gradient.stops);
@@ -1908,7 +1917,7 @@ fn write_color_paint_sweep_gradient_path_node(
     write_path_commands(buf, &gradient_path.commands);
     let _ = write!(
         buf,
-        ",\"gradient\":{{\"cx\":{},\"cy\":{},\"startAngleDegrees\":{},\"endAngleDegrees\":{},\"stops\":",
+        ",\"gradient\":{{\"cx\":{:.6},\"cy\":{:.6},\"startAngleDegrees\":{:.6},\"endAngleDegrees\":{:.6},\"stops\":",
         gradient_path.gradient.cx,
         gradient_path.gradient.cy,
         gradient_path.gradient.start_angle_degrees,

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -28,13 +28,15 @@ pub use layer_tree::{
     TextSourceTable,
 };
 pub use paint_op::{
-    GlyphCluster, GlyphClusterFlag, GlyphOutlineFillRule, GlyphOutlinePaintOrder,
-    GlyphOutlinePayloadKind, GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin,
-    GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation, GlyphTransform,
-    LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint,
-    LayerPoint, LayerVector, PaintOp, PaintTextStyle, PaintVariantMeta, ResolvedImageKind,
-    ResolvedImagePayload, TextDecorationKind, TextRunPlacement, TextVariantKind,
-    TextVariantQuality,
+    BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, ColorGlyphFormat,
+    ColorLayerNode, ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind,
+    ColorPaintGraphPayload, FontColorGlyphRef, GlyphCluster, GlyphClusterFlag,
+    GlyphOutlineFillRule, GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
+    GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
+    GlyphRunOrientation, GlyphTransform, LayerAffineTransform, LayerGlyphOutlinePaint,
+    LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerPoint, LayerVector, PaintOp, PaintTextStyle,
+    PaintVariantMeta, PaletteRef, ResolvedColor, ResolvedImageKind, ResolvedImagePayload,
+    SvgGlyphPayload, TextDecorationKind, TextRunPlacement, TextVariantKind, TextVariantQuality,
 };
 pub use profile::RenderProfile;
 pub use resources::{

--- a/src/paint/mod.rs
+++ b/src/paint/mod.rs
@@ -29,14 +29,17 @@ pub use layer_tree::{
 };
 pub use paint_op::{
     BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, ColorGlyphFormat,
-    ColorLayerNode, ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind,
-    ColorPaintGraphPayload, FontColorGlyphRef, GlyphCluster, GlyphClusterFlag,
-    GlyphOutlineFillRule, GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
-    GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
-    GlyphRunOrientation, GlyphTransform, LayerAffineTransform, LayerGlyphOutlinePaint,
-    LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerPoint, LayerVector, PaintOp, PaintTextStyle,
-    PaintVariantMeta, PaletteRef, ResolvedColor, ResolvedImageKind, ResolvedImagePayload,
-    SvgGlyphPayload, TextDecorationKind, TextRunPlacement, TextVariantKind, TextVariantQuality,
+    ColorGradientStop, ColorLayerNode, ColorLayersPayload, ColorLinearGradient,
+    ColorPaintGraphNode, ColorPaintGraphNodeKind, ColorPaintGraphPayload,
+    ColorPaintLinearGradientPathNode, ColorPaintRadialGradientPathNode, ColorPaintSolidPathNode,
+    ColorPaintSweepGradientPathNode, ColorPaintTransformNode, ColorRadialGradient,
+    ColorSweepGradient, FontColorGlyphRef, GlyphCluster, GlyphClusterFlag, GlyphOutlineFillRule,
+    GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin,
+    GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation, GlyphTransform,
+    LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint,
+    LayerPoint, LayerVector, PaintOp, PaintTextStyle, PaintVariantMeta, PaletteRef, ResolvedColor,
+    ResolvedImageKind, ResolvedImagePayload, SvgGlyphPayload, TextDecorationKind, TextRunPlacement,
+    TextVariantKind, TextVariantQuality,
 };
 pub use profile::RenderProfile;
 pub use resources::{

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -298,10 +298,10 @@ pub struct ColorLayerNode {
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ColorPaintGraphNodeKind {
     SolidPath,
-    Transform,
     LinearGradientPath,
     RadialGradientPath,
     SweepGradientPath,
+    Transform,
     Composite,
 }
 
@@ -309,28 +309,109 @@ impl ColorPaintGraphNodeKind {
     pub fn as_str(self) -> &'static str {
         match self {
             Self::SolidPath => "solidPath",
-            Self::Transform => "transform",
             Self::LinearGradientPath => "linearGradientPath",
             Self::RadialGradientPath => "radialGradientPath",
             Self::SweepGradientPath => "sweepGradientPath",
+            Self::Transform => "transform",
             Self::Composite => "composite",
         }
     }
 
     pub fn is_colrv1_stage1_supported(self) -> bool {
-        matches!(self, Self::SolidPath | Self::Transform)
+        matches!(
+            self,
+            Self::SolidPath
+                | Self::LinearGradientPath
+                | Self::RadialGradientPath
+                | Self::SweepGradientPath
+                | Self::Transform
+        )
     }
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintSolidPathNode {
+    pub commands: Vec<PathCommand>,
+    pub fill: ResolvedColor,
+    pub fill_rule: GlyphOutlineFillRule,
+    pub source_glyph_id: Option<u32>,
+    pub palette_index: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorGradientStop {
+    pub offset: f64,
+    pub color: ResolvedColor,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorLinearGradient {
+    pub x0: f64,
+    pub y0: f64,
+    pub x1: f64,
+    pub y1: f64,
+    pub stops: Vec<ColorGradientStop>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorRadialGradient {
+    pub cx: f64,
+    pub cy: f64,
+    pub radius: f64,
+    pub stops: Vec<ColorGradientStop>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorSweepGradient {
+    pub cx: f64,
+    pub cy: f64,
+    pub start_angle_degrees: f64,
+    pub end_angle_degrees: f64,
+    pub stops: Vec<ColorGradientStop>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintLinearGradientPathNode {
+    pub commands: Vec<PathCommand>,
+    pub gradient: ColorLinearGradient,
+    pub fill_rule: GlyphOutlineFillRule,
+    pub source_glyph_id: Option<u32>,
+    pub palette_index: Option<u16>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintRadialGradientPathNode {
+    pub commands: Vec<PathCommand>,
+    pub gradient: ColorRadialGradient,
+    pub fill_rule: GlyphOutlineFillRule,
+    pub source_glyph_id: Option<u32>,
+    pub palette_index: Option<u16>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintSweepGradientPathNode {
+    pub commands: Vec<PathCommand>,
+    pub gradient: ColorSweepGradient,
+    pub fill_rule: GlyphOutlineFillRule,
+    pub source_glyph_id: Option<u32>,
+    pub palette_index: Option<u16>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ColorPaintTransformNode {
+    pub child_node_id: u32,
+    pub transform: LayerAffineTransform,
 }
 
 #[derive(Debug, Clone)]
 pub struct ColorPaintGraphNode {
     pub node_id: u32,
     pub kind: ColorPaintGraphNodeKind,
-    pub commands: Option<Vec<PathCommand>>,
-    pub fill: Option<ResolvedColor>,
-    pub fill_rule: Option<GlyphOutlineFillRule>,
-    pub child_node_id: Option<u32>,
-    pub transform: Option<LayerAffineTransform>,
+    pub solid_path: Option<ColorPaintSolidPathNode>,
+    pub linear_gradient_path: Option<ColorPaintLinearGradientPathNode>,
+    pub radial_gradient_path: Option<ColorPaintRadialGradientPathNode>,
+    pub sweep_gradient_path: Option<ColorPaintSweepGradientPathNode>,
+    pub transform: Option<ColorPaintTransformNode>,
     pub source_range_utf8: Option<TextSourceRange>,
     pub glyph_range: Option<GlyphRange>,
     pub source_font_ref: Option<FontColorGlyphRef>,
@@ -340,6 +421,212 @@ pub struct ColorPaintGraphNode {
 pub struct ColorPaintGraphPayload {
     pub root_node_id: u32,
     pub nodes: Vec<ColorPaintGraphNode>,
+}
+
+const MAX_COLRV1_GRAPH_NODES: usize = 64;
+const MAX_COLRV1_GRAPH_DEPTH: usize = 64;
+
+fn text_source_range_is_valid(range: TextSourceRange) -> bool {
+    range.end >= range.start
+}
+
+fn glyph_range_is_valid(range: GlyphRange) -> bool {
+    range.end >= range.start
+}
+
+fn path_commands_are_finite(commands: &[PathCommand]) -> bool {
+    !commands.is_empty()
+        && commands.iter().all(|command| match *command {
+            PathCommand::MoveTo(x, y) | PathCommand::LineTo(x, y) => x.is_finite() && y.is_finite(),
+            PathCommand::CurveTo(x1, y1, x2, y2, x, y) => {
+                [x1, y1, x2, y2, x, y].into_iter().all(f64::is_finite)
+            }
+            PathCommand::ArcTo(rx, ry, rotation, _, _, x, y) => {
+                [rx, ry, rotation, x, y].into_iter().all(f64::is_finite)
+            }
+            PathCommand::ClosePath => true,
+        })
+}
+
+fn resolved_color_is_valid(color: &ResolvedColor) -> bool {
+    color
+        .color_space
+        .as_ref()
+        .map(|color_space| !color_space.is_empty())
+        .unwrap_or(true)
+        && color
+            .rgba
+            .iter()
+            .all(|component| component.is_finite() && (0.0..=1.0).contains(component))
+}
+
+fn color_gradient_stops_are_valid(stops: &[ColorGradientStop]) -> bool {
+    if stops.len() < 2 {
+        return false;
+    }
+    let mut previous_offset = f64::NEG_INFINITY;
+    stops.iter().all(|stop| {
+        let valid = stop.offset.is_finite()
+            && (0.0..=1.0).contains(&stop.offset)
+            && stop.offset >= previous_offset
+            && resolved_color_is_valid(&stop.color);
+        previous_offset = stop.offset;
+        valid
+    })
+}
+
+fn color_sweep_angles_are_supported(start_angle_degrees: f64, end_angle_degrees: f64) -> bool {
+    start_angle_degrees.is_finite()
+        && end_angle_degrees.is_finite()
+        && start_angle_degrees < end_angle_degrees
+        && (end_angle_degrees - start_angle_degrees - 360.0).abs() <= 1e-9
+}
+
+fn graph_leaf_metadata_is_valid(node: &ColorPaintGraphNode) -> bool {
+    node.source_range_utf8
+        .is_some_and(text_source_range_is_valid)
+        && node.glyph_range.is_some_and(glyph_range_is_valid)
+        && node.source_font_ref.is_some()
+}
+
+impl ColorPaintGraphPayload {
+    pub fn has_colrv1_stage1_contract(&self) -> bool {
+        self.has_colrv1_supported_graph_contract()
+    }
+
+    pub fn has_colrv1_supported_graph_contract(&self) -> bool {
+        use std::collections::{HashMap, HashSet};
+
+        if self.nodes.is_empty() || self.nodes.len() > MAX_COLRV1_GRAPH_NODES {
+            return false;
+        }
+
+        let mut nodes_by_id = HashMap::with_capacity(self.nodes.len());
+        for node in &self.nodes {
+            if nodes_by_id.insert(node.node_id, node).is_some() {
+                return false;
+            }
+        }
+
+        let mut visited = HashSet::new();
+        let mut node_id = self.root_node_id;
+        let mut depth = 1usize;
+        loop {
+            if depth > MAX_COLRV1_GRAPH_DEPTH || !visited.insert(node_id) {
+                return false;
+            }
+            let Some(node) = nodes_by_id.get(&node_id) else {
+                return false;
+            };
+            match node.kind {
+                ColorPaintGraphNodeKind::SolidPath => {
+                    if visited.len() != self.nodes.len()
+                        || node.transform.is_some()
+                        || node.linear_gradient_path.is_some()
+                        || node.radial_gradient_path.is_some()
+                        || node.sweep_gradient_path.is_some()
+                        || !graph_leaf_metadata_is_valid(node)
+                    {
+                        return false;
+                    }
+                    let Some(solid) = node.solid_path.as_ref() else {
+                        return false;
+                    };
+                    return path_commands_are_finite(&solid.commands)
+                        && resolved_color_is_valid(&solid.fill);
+                }
+                ColorPaintGraphNodeKind::LinearGradientPath => {
+                    if visited.len() != self.nodes.len()
+                        || node.solid_path.is_some()
+                        || node.transform.is_some()
+                        || node.radial_gradient_path.is_some()
+                        || node.sweep_gradient_path.is_some()
+                        || !graph_leaf_metadata_is_valid(node)
+                    {
+                        return false;
+                    }
+                    let Some(gradient_path) = node.linear_gradient_path.as_ref() else {
+                        return false;
+                    };
+                    return path_commands_are_finite(&gradient_path.commands)
+                        && gradient_path.gradient.x0.is_finite()
+                        && gradient_path.gradient.y0.is_finite()
+                        && gradient_path.gradient.x1.is_finite()
+                        && gradient_path.gradient.y1.is_finite()
+                        && color_gradient_stops_are_valid(&gradient_path.gradient.stops);
+                }
+                ColorPaintGraphNodeKind::RadialGradientPath => {
+                    if visited.len() != self.nodes.len()
+                        || node.solid_path.is_some()
+                        || node.transform.is_some()
+                        || node.linear_gradient_path.is_some()
+                        || node.sweep_gradient_path.is_some()
+                        || !graph_leaf_metadata_is_valid(node)
+                    {
+                        return false;
+                    }
+                    let Some(gradient_path) = node.radial_gradient_path.as_ref() else {
+                        return false;
+                    };
+                    return path_commands_are_finite(&gradient_path.commands)
+                        && gradient_path.gradient.cx.is_finite()
+                        && gradient_path.gradient.cy.is_finite()
+                        && gradient_path.gradient.radius.is_finite()
+                        && gradient_path.gradient.radius > 0.0
+                        && color_gradient_stops_are_valid(&gradient_path.gradient.stops);
+                }
+                ColorPaintGraphNodeKind::SweepGradientPath => {
+                    if visited.len() != self.nodes.len()
+                        || node.solid_path.is_some()
+                        || node.transform.is_some()
+                        || node.linear_gradient_path.is_some()
+                        || node.radial_gradient_path.is_some()
+                        || !graph_leaf_metadata_is_valid(node)
+                    {
+                        return false;
+                    }
+                    let Some(gradient_path) = node.sweep_gradient_path.as_ref() else {
+                        return false;
+                    };
+                    return path_commands_are_finite(&gradient_path.commands)
+                        && gradient_path.gradient.cx.is_finite()
+                        && gradient_path.gradient.cy.is_finite()
+                        && color_sweep_angles_are_supported(
+                            gradient_path.gradient.start_angle_degrees,
+                            gradient_path.gradient.end_angle_degrees,
+                        )
+                        && color_gradient_stops_are_valid(&gradient_path.gradient.stops);
+                }
+                ColorPaintGraphNodeKind::Transform => {
+                    if node.solid_path.is_some()
+                        || node.linear_gradient_path.is_some()
+                        || node.radial_gradient_path.is_some()
+                        || node.sweep_gradient_path.is_some()
+                    {
+                        return false;
+                    }
+                    if node
+                        .source_range_utf8
+                        .is_some_and(|range| !text_source_range_is_valid(range))
+                        || node
+                            .glyph_range
+                            .is_some_and(|range| !glyph_range_is_valid(range))
+                    {
+                        return false;
+                    }
+                    let Some(transform) = node.transform.as_ref() else {
+                        return false;
+                    };
+                    if !layer_affine_is_finite(transform.transform) {
+                        return false;
+                    }
+                    node_id = transform.child_node_id;
+                    depth += 1;
+                }
+                ColorPaintGraphNodeKind::Composite => return false,
+            }
+        }
+    }
 }
 
 #[derive(Debug, Clone)]
@@ -381,46 +668,21 @@ impl ColorLayersPayload {
     }
 
     pub fn has_colrv1_stage1_graph_contract(&self) -> bool {
-        let Some(graph) = &self.paint_graph else {
-            return false;
-        };
+        self.has_colrv1_supported_graph_contract()
+    }
+
+    pub fn has_colrv1_supported_graph_contract(&self) -> bool {
         self.color_format == ColorGlyphFormat::ColrV1
             && self.layers.is_empty()
             && self
                 .source_range_utf8
-                .is_some_and(text_source_range_is_non_empty)
+                .is_some_and(text_source_range_is_valid)
             && self.glyph_range.is_some_and(GlyphRange::is_non_empty)
-            && !graph.nodes.is_empty()
-            && graph
-                .nodes
-                .iter()
-                .any(|node| node.node_id == graph.root_node_id)
-            && graph.nodes.iter().all(|node| {
-                node.kind.is_colrv1_stage1_supported()
-                    && node
-                        .source_range_utf8
-                        .is_some_and(text_source_range_is_non_empty)
-                    && node.glyph_range.is_some_and(GlyphRange::is_non_empty)
-                    && match node.kind {
-                        ColorPaintGraphNodeKind::SolidPath => {
-                            node.commands
-                                .as_ref()
-                                .is_some_and(|commands| !commands.is_empty())
-                                && node.fill.is_some()
-                                && node.fill_rule.is_some()
-                                && node.child_node_id.is_none()
-                                && node.transform.is_none()
-                        }
-                        ColorPaintGraphNodeKind::Transform => {
-                            node.commands.is_none()
-                                && node.fill.is_none()
-                                && node.fill_rule.is_none()
-                                && node.child_node_id.is_some()
-                                && node.transform.is_some_and(layer_affine_is_finite)
-                        }
-                        _ => false,
-                    }
-            })
+            && self.source_font_ref.is_some()
+            && self
+                .paint_graph
+                .as_ref()
+                .is_some_and(ColorPaintGraphPayload::has_colrv1_supported_graph_contract)
     }
 }
 

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -2,6 +2,7 @@ use crate::model::style::UnderlineType;
 use crate::model::ColorRef;
 use crate::paint::font::{GlyphRunReplayEligibility, ShapeKey, TextDirection, WritingMode};
 use crate::paint::layer_tree::{TextSourceRange, TextSourceSpan};
+use crate::paint::resources::{ImageResourceId, SvgResourceId};
 use crate::renderer::render_tree::{
     BoundingBox, EllipseNode, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
     LineNode, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode,
@@ -183,6 +184,9 @@ pub struct LayerGlyphOutlinePaint {
     pub source: TextSourceSpan,
     pub variant: PaintVariantMeta,
     pub payload_kind: GlyphOutlinePayloadKind,
+    pub color_layers: Option<ColorLayersPayload>,
+    pub bitmap_glyph: Option<BitmapGlyphPayload>,
+    pub svg_glyph: Option<SvgGlyphPayload>,
     pub paint_style: PaintTextStyle,
     pub placement: TextRunPlacement,
     pub paths: Vec<LayerGlyphOutlinePath>,
@@ -194,6 +198,9 @@ pub struct LayerGlyphOutlinePaint {
 pub enum GlyphOutlinePayloadKind {
     MonochromeFill,
     MonochromeFillStroke,
+    ColorLayers,
+    BitmapGlyph,
+    SvgGlyph,
 }
 
 impl GlyphOutlinePayloadKind {
@@ -201,8 +208,340 @@ impl GlyphOutlinePayloadKind {
         match self {
             Self::MonochromeFill => "monochromeFill",
             Self::MonochromeFillStroke => "monochromeFillStroke",
+            Self::ColorLayers => "colorLayers",
+            Self::BitmapGlyph => "bitmapGlyph",
+            Self::SvgGlyph => "svgGlyph",
         }
     }
+}
+
+impl LayerGlyphOutlinePaint {
+    pub fn has_exclusive_payload_family(&self) -> bool {
+        let has_stroke = self.stroke.is_some();
+        let has_color_layers = self.color_layers.is_some();
+        let has_bitmap_glyph = self.bitmap_glyph.is_some();
+        let has_svg_glyph = self.svg_glyph.is_some();
+        match self.payload_kind {
+            GlyphOutlinePayloadKind::MonochromeFill => {
+                !has_stroke && !has_color_layers && !has_bitmap_glyph && !has_svg_glyph
+            }
+            GlyphOutlinePayloadKind::MonochromeFillStroke => {
+                has_stroke && !has_color_layers && !has_bitmap_glyph && !has_svg_glyph
+            }
+            GlyphOutlinePayloadKind::ColorLayers => {
+                !has_stroke && has_color_layers && !has_bitmap_glyph && !has_svg_glyph
+            }
+            GlyphOutlinePayloadKind::BitmapGlyph => {
+                !has_stroke && !has_color_layers && has_bitmap_glyph && !has_svg_glyph
+            }
+            GlyphOutlinePayloadKind::SvgGlyph => {
+                !has_stroke && !has_color_layers && !has_bitmap_glyph && has_svg_glyph
+            }
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorGlyphFormat {
+    ColrV0,
+    ColrV1,
+    Other,
+}
+
+impl ColorGlyphFormat {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::ColrV0 => "colrV0",
+            Self::ColrV1 => "colrV1",
+            Self::Other => "other",
+        }
+    }
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct FontColorGlyphRef {
+    pub face_key: Option<String>,
+    pub glyph_id: Option<u32>,
+    pub palette_index: Option<u16>,
+    pub color_format: Option<ColorGlyphFormat>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct PaletteRef {
+    pub id: Option<String>,
+    pub index: Option<u16>,
+    pub cpal_digest: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ResolvedColor {
+    pub color_space: Option<String>,
+    pub rgba: [f32; 4],
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorLayerNode {
+    pub layer_index: Option<u32>,
+    pub glyph_id: Option<u32>,
+    pub glyph_range: Option<GlyphRange>,
+    pub source_range_utf8: Option<TextSourceRange>,
+    pub source_font_ref: Option<FontColorGlyphRef>,
+    pub commands: Option<Vec<PathCommand>>,
+    pub fill: Option<ResolvedColor>,
+    pub fill_rule: Option<GlyphOutlineFillRule>,
+    pub palette_index: Option<u16>,
+    pub color: Option<ColorRef>,
+    pub opacity: Option<f64>,
+    pub transform_to_run: Option<LayerAffineTransform>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ColorPaintGraphNodeKind {
+    SolidPath,
+    Transform,
+    LinearGradientPath,
+    RadialGradientPath,
+    SweepGradientPath,
+    Composite,
+}
+
+impl ColorPaintGraphNodeKind {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SolidPath => "solidPath",
+            Self::Transform => "transform",
+            Self::LinearGradientPath => "linearGradientPath",
+            Self::RadialGradientPath => "radialGradientPath",
+            Self::SweepGradientPath => "sweepGradientPath",
+            Self::Composite => "composite",
+        }
+    }
+
+    pub fn is_colrv1_stage1_supported(self) -> bool {
+        matches!(self, Self::SolidPath | Self::Transform)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintGraphNode {
+    pub node_id: u32,
+    pub kind: ColorPaintGraphNodeKind,
+    pub commands: Option<Vec<PathCommand>>,
+    pub fill: Option<ResolvedColor>,
+    pub fill_rule: Option<GlyphOutlineFillRule>,
+    pub child_node_id: Option<u32>,
+    pub transform: Option<LayerAffineTransform>,
+    pub source_range_utf8: Option<TextSourceRange>,
+    pub glyph_range: Option<GlyphRange>,
+    pub source_font_ref: Option<FontColorGlyphRef>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorPaintGraphPayload {
+    pub root_node_id: u32,
+    pub nodes: Vec<ColorPaintGraphNode>,
+}
+
+#[derive(Debug, Clone)]
+pub struct ColorLayersPayload {
+    pub color_format: ColorGlyphFormat,
+    pub source_font_ref: Option<FontColorGlyphRef>,
+    pub palette_ref: Option<PaletteRef>,
+    pub layers: Vec<ColorLayerNode>,
+    pub paint_graph: Option<ColorPaintGraphPayload>,
+    pub source_range_utf8: Option<TextSourceRange>,
+    pub glyph_range: Option<GlyphRange>,
+}
+
+impl ColorLayersPayload {
+    pub fn has_colrv0_resolved_layer_contract(&self) -> bool {
+        self.color_format == ColorGlyphFormat::ColrV0
+            && self.paint_graph.is_none()
+            && !self.layers.is_empty()
+            && self.layers.iter().all(|layer| {
+                layer
+                    .commands
+                    .as_ref()
+                    .is_some_and(|commands| !commands.is_empty())
+                    && layer.fill.is_some()
+                    && layer.fill_rule.is_some()
+                    && layer
+                        .source_range_utf8
+                        .is_some_and(text_source_range_is_non_empty)
+                    && layer.glyph_range.is_some_and(GlyphRange::is_non_empty)
+                    && layer
+                        .transform_to_run
+                        .map(layer_affine_is_finite)
+                        .unwrap_or(true)
+                    && layer
+                        .opacity
+                        .map(|opacity| opacity.is_finite())
+                        .unwrap_or(true)
+            })
+    }
+
+    pub fn has_colrv1_stage1_graph_contract(&self) -> bool {
+        let Some(graph) = &self.paint_graph else {
+            return false;
+        };
+        self.color_format == ColorGlyphFormat::ColrV1
+            && self.layers.is_empty()
+            && self
+                .source_range_utf8
+                .is_some_and(text_source_range_is_non_empty)
+            && self.glyph_range.is_some_and(GlyphRange::is_non_empty)
+            && !graph.nodes.is_empty()
+            && graph
+                .nodes
+                .iter()
+                .any(|node| node.node_id == graph.root_node_id)
+            && graph.nodes.iter().all(|node| {
+                node.kind.is_colrv1_stage1_supported()
+                    && node
+                        .source_range_utf8
+                        .is_some_and(text_source_range_is_non_empty)
+                    && node.glyph_range.is_some_and(GlyphRange::is_non_empty)
+                    && match node.kind {
+                        ColorPaintGraphNodeKind::SolidPath => {
+                            node.commands
+                                .as_ref()
+                                .is_some_and(|commands| !commands.is_empty())
+                                && node.fill.is_some()
+                                && node.fill_rule.is_some()
+                                && node.child_node_id.is_none()
+                                && node.transform.is_none()
+                        }
+                        ColorPaintGraphNodeKind::Transform => {
+                            node.commands.is_none()
+                                && node.fill.is_none()
+                                && node.fill_rule.is_none()
+                                && node.child_node_id.is_some()
+                                && node.transform.is_some_and(layer_affine_is_finite)
+                        }
+                        _ => false,
+                    }
+            })
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BitmapGlyphScalingPolicy {
+    SourceExact,
+    PixelAligned,
+    BackendDefault,
+}
+
+impl BitmapGlyphScalingPolicy {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::SourceExact => "sourceExact",
+            Self::PixelAligned => "pixelAligned",
+            Self::BackendDefault => "backendDefault",
+        }
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BitmapGlyphFiltering {
+    Nearest,
+    Linear,
+}
+
+impl BitmapGlyphFiltering {
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Nearest => "nearest",
+            Self::Linear => "linear",
+        }
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct BitmapGlyphPayload {
+    pub image_ref: ImageResourceId,
+    pub source_range_utf8: TextSourceRange,
+    pub glyph_range: GlyphRange,
+    pub placement: BoundingBox,
+    pub alpha_premultiplied: bool,
+    pub scaling_policy: BitmapGlyphScalingPolicy,
+    pub filtering: BitmapGlyphFiltering,
+    pub transform_to_run: Option<LayerAffineTransform>,
+}
+
+impl BitmapGlyphPayload {
+    pub fn has_strict_visual_contract(&self) -> bool {
+        text_source_range_is_non_empty(self.source_range_utf8)
+            && self.glyph_range.is_non_empty()
+            && bbox_is_finite_positive(self.placement)
+            && !matches!(
+                self.scaling_policy,
+                BitmapGlyphScalingPolicy::BackendDefault
+            )
+            && self
+                .transform_to_run
+                .map(layer_affine_is_finite)
+                .unwrap_or(true)
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct SvgGlyphPayload {
+    pub svg_ref: SvgResourceId,
+    pub source_range_utf8: TextSourceRange,
+    pub glyph_range: GlyphRange,
+    pub view_box: BoundingBox,
+    pub intrinsic_size: Option<LayerVector>,
+    pub static_sanitized: bool,
+    pub script_allowed: bool,
+    pub animation_allowed: bool,
+    pub external_resources_allowed: bool,
+    pub interactivity_allowed: bool,
+    pub transform_to_run: Option<LayerAffineTransform>,
+}
+
+impl SvgGlyphPayload {
+    pub fn has_static_sanitized_contract(&self) -> bool {
+        text_source_range_is_non_empty(self.source_range_utf8)
+            && self.glyph_range.is_non_empty()
+            && bbox_is_finite_positive(self.view_box)
+            && self
+                .intrinsic_size
+                .map(|size| {
+                    size.dx.is_finite() && size.dy.is_finite() && size.dx > 0.0 && size.dy > 0.0
+                })
+                .unwrap_or(true)
+            && self.static_sanitized
+            && !self.script_allowed
+            && !self.animation_allowed
+            && !self.external_resources_allowed
+            && !self.interactivity_allowed
+            && self
+                .transform_to_run
+                .map(layer_affine_is_finite)
+                .unwrap_or(true)
+    }
+}
+
+fn text_source_range_is_non_empty(range: TextSourceRange) -> bool {
+    range.end > range.start
+}
+
+fn layer_affine_is_finite(transform: LayerAffineTransform) -> bool {
+    transform.a.is_finite()
+        && transform.b.is_finite()
+        && transform.c.is_finite()
+        && transform.d.is_finite()
+        && transform.e.is_finite()
+        && transform.f.is_finite()
+}
+
+fn bbox_is_finite_positive(bbox: BoundingBox) -> bool {
+    bbox.x.is_finite()
+        && bbox.y.is_finite()
+        && bbox.width.is_finite()
+        && bbox.height.is_finite()
+        && bbox.width > 0.0
+        && bbox.height > 0.0
 }
 
 #[derive(Debug, Clone)]
@@ -456,6 +795,10 @@ pub struct GlyphRange {
 impl GlyphRange {
     pub fn new(start: u32, end: u32) -> Self {
         Self { start, end }
+    }
+
+    pub fn is_non_empty(self) -> bool {
+        self.end > self.start
     }
 }
 

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -475,7 +475,7 @@ fn color_gradient_stops_are_valid(stops: &[ColorGradientStop]) -> bool {
     })
 }
 
-fn color_sweep_angles_are_supported(start_angle_degrees: f64, end_angle_degrees: f64) -> bool {
+fn color_sweep_is_supported_full_circle(start_angle_degrees: f64, end_angle_degrees: f64) -> bool {
     start_angle_degrees.is_finite()
         && end_angle_degrees.is_finite()
         && start_angle_degrees < end_angle_degrees
@@ -485,11 +485,14 @@ fn color_sweep_angles_are_supported(start_angle_degrees: f64, end_angle_degrees:
 fn graph_leaf_metadata_is_valid(node: &ColorPaintGraphNode) -> bool {
     node.source_range_utf8
         .is_some_and(text_source_range_is_valid)
-        && node.glyph_range.is_some_and(glyph_range_is_valid)
+        && node.glyph_range.is_some_and(GlyphRange::is_non_empty)
         && node.source_font_ref.is_some()
 }
 
 impl ColorPaintGraphPayload {
+    /// Compatibility alias for the P19 first supported COLRv1 graph contract.
+    /// New code should use `has_colrv1_supported_graph_contract`.
+    #[deprecated(note = "use has_colrv1_supported_graph_contract")]
     pub fn has_colrv1_stage1_contract(&self) -> bool {
         self.has_colrv1_supported_graph_contract()
     }
@@ -591,7 +594,7 @@ impl ColorPaintGraphPayload {
                     return path_commands_are_finite(&gradient_path.commands)
                         && gradient_path.gradient.cx.is_finite()
                         && gradient_path.gradient.cy.is_finite()
-                        && color_sweep_angles_are_supported(
+                        && color_sweep_is_supported_full_circle(
                             gradient_path.gradient.start_angle_degrees,
                             gradient_path.gradient.end_angle_degrees,
                         )
@@ -667,6 +670,9 @@ impl ColorLayersPayload {
             })
     }
 
+    /// Compatibility alias for the P19 first supported COLRv1 graph contract.
+    /// New code should use `has_colrv1_supported_graph_contract`.
+    #[deprecated(note = "use has_colrv1_supported_graph_contract")]
     pub fn has_colrv1_stage1_graph_contract(&self) -> bool {
         self.has_colrv1_supported_graph_contract()
     }

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,7 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 13,
+    schema_minor_version: 14,
     resource_table_version: 1,
     resource_table_minor_version: 3,
     unit: "px",

--- a/src/paint/text_v2.rs
+++ b/src/paint/text_v2.rs
@@ -556,6 +556,9 @@ fn glyph_outline_is_strict(outline: &LayerGlyphOutlinePaint) -> bool {
                 .stroke
                 .as_ref()
                 .is_some_and(|stroke| stroke.is_strict_subset()),
+            GlyphOutlinePayloadKind::ColorLayers
+            | GlyphOutlinePayloadKind::BitmapGlyph
+            | GlyphOutlinePayloadKind::SvgGlyph => false,
         }
 }
 
@@ -580,6 +583,15 @@ fn glyph_outline_fallback_reason(outline: &LayerGlyphOutlinePaint) -> Option<Str
                 .is_some_and(|stroke| stroke.is_strict_subset()) =>
         {
             return Some("unsupportedOutlineStroke".to_string());
+        }
+        GlyphOutlinePayloadKind::ColorLayers => {
+            return Some("unsupportedColorGlyph".to_string());
+        }
+        GlyphOutlinePayloadKind::BitmapGlyph => {
+            return Some("unsupportedBitmapGlyph".to_string());
+        }
+        GlyphOutlinePayloadKind::SvgGlyph => {
+            return Some("unsupportedSvgGlyph".to_string());
         }
         _ => {}
     }
@@ -814,6 +826,9 @@ mod tests {
                     variant
                 },
                 payload_kind: GlyphOutlinePayloadKind::MonochromeFill,
+                color_layers: None,
+                bitmap_glyph: None,
+                svg_glyph: None,
                 paint_style: PaintTextStyle::from(&TextStyle {
                     font_family: "Test".to_string(),
                     font_size: 12.0,

--- a/src/paint/text_variants.rs
+++ b/src/paint/text_variants.rs
@@ -33,6 +33,11 @@ pub enum TextVariantScopeError {
         anchor_op_id: String,
         leaf: String,
     },
+    MixedGlyphOutlinePayload {
+        equivalence_group: String,
+        variant_id: String,
+        leaf: String,
+    },
     EmptyVariantSet {
         equivalence_group: String,
         variant_id: String,
@@ -87,6 +92,14 @@ impl fmt::Display for TextVariantScopeError {
             } => write!(
                 f,
                 "text sidecar variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` anchors `{anchor_op_id}`, expected the same paint-order slot"
+            ),
+            Self::MixedGlyphOutlinePayload {
+                equivalence_group,
+                variant_id,
+                leaf,
+            } => write!(
+                f,
+                "glyph outline variant `{variant_id}` in group `{equivalence_group}` at leaf `{leaf}` mixes payload families"
             ),
             Self::EmptyVariantSet {
                 equivalence_group,
@@ -171,6 +184,15 @@ fn validate_leaf(
             continue;
         };
         validate_sidecar_anchor(&variant, &leaf_path)?;
+        if let PaintOp::GlyphOutline { outline, .. } = op {
+            if !outline.has_exclusive_payload_family() {
+                return Err(TextVariantScopeError::MixedGlyphOutlinePayload {
+                    equivalence_group: variant.equivalence_group.clone(),
+                    variant_id: variant.variant_id.clone(),
+                    leaf: leaf_path,
+                });
+            }
+        }
         if let Some(first_leaf) = group_leaf_paths.get(&variant.equivalence_group) {
             if first_leaf != &leaf_path {
                 return Err(TextVariantScopeError::CrossLeafGroup {
@@ -287,12 +309,13 @@ mod tests {
     use crate::paint::resources::ResourceArena;
     use crate::paint::{
         FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
-        GlyphOutlinePayloadKind, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
-        GlyphRunReplayEligibility, LayerAffineTransform, LayerGlyphOutlinePaint,
-        LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerOutputOptions, LayerPoint,
-        PaintTextStyle, RenderProfile, ScriptTag, ShapeKey, ShapingEngineId, TextDirection,
-        TextSourceId, TextSourceRange, TextSourceSpan, TextSourceTable, TextVariantKind,
-        TextVariantQuality, WritingMode,
+        GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
+        GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
+        GlyphRunOrientation, GlyphRunReplayEligibility, LayerAffineTransform,
+        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode,
+        LayerOutputOptions, LayerPoint, PaintTextStyle, RenderProfile, ScriptTag, ShapeKey,
+        ShapingEngineId, TextDirection, TextSourceId, TextSourceRange, TextSourceSpan,
+        TextSourceTable, TextVariantKind, TextVariantQuality, WritingMode,
     };
     use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
     use crate::renderer::{PathCommand, TextStyle};
@@ -407,6 +430,9 @@ mod tests {
                 },
                 variant,
                 payload_kind: GlyphOutlinePayloadKind::MonochromeFill,
+                color_layers: None,
+                bitmap_glyph: None,
+                svg_glyph: None,
                 paint_style: PaintTextStyle::from(&TextStyle::default()),
                 placement: crate::paint::TextRunPlacement {
                     run_to_page: LayerAffineTransform {
@@ -638,6 +664,38 @@ mod tests {
         assert!(matches!(
             validate_text_variant_scope(&tree),
             Err(TextVariantScopeError::InvalidSidecarAnchor { .. })
+        ));
+    }
+
+    #[test]
+    fn rejects_mixed_glyph_outline_payload_family() {
+        let outline = PaintVariantMeta {
+            equivalence_group: "text-1".to_string(),
+            variant_id: "glyphOutline".to_string(),
+            variant_kind: TextVariantKind::GlyphOutline,
+            part_index: 0,
+            part_count: 1,
+            is_default_fallback: false,
+            requires: vec!["text.glyphOutline".to_string()],
+            quality: Some(TextVariantQuality::Exact),
+            anchor_op_id: Some("text-1".to_string()),
+            local_paint_order: None,
+        };
+        let mut op = glyph_outline_op(outline);
+        if let PaintOp::GlyphOutline { outline, .. } = &mut op {
+            outline.stroke = Some(GlyphOutlineStrokeStyle {
+                color: 0x00000000,
+                width: 1.0,
+                join: GlyphOutlineStrokeJoin::Miter,
+                cap: GlyphOutlineStrokeCap::Butt,
+                miter_limit: 2.0,
+                paint_order: GlyphOutlinePaintOrder::FillThenStroke,
+            });
+        }
+        let tree = tree(LayerNode::leaf(bbox(), None, vec![text_op(), op]));
+        assert!(matches!(
+            validate_text_variant_scope(&tree),
+            Err(TextVariantScopeError::MixedGlyphOutlinePayload { .. })
         ));
     }
 }

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -164,6 +164,7 @@ pub fn analyze_canvaskit_replay_plan(
         tree,
         TextVariantSelectionOptions {
             backend: VariantSelectionBackend::CanvasKit,
+            allow_colrv1_stage1_color_graph: true,
             ..TextVariantSelectionOptions::canvaskit()
         },
     );

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -139,6 +139,9 @@ pub enum VariantRejectReason {
     GlyphOutlineUnsupported,
     UnsupportedOutlinePayload,
     GlyphOutlineStrokeStyleUnsupported,
+    UnsupportedColorGlyph,
+    UnsupportedBitmapGlyph,
+    UnsupportedSvgGlyph,
     PositionAdjustedNotAllowed,
     PositionAdjustedResidualTooLarge,
 }
@@ -160,6 +163,9 @@ impl VariantRejectReason {
             Self::GlyphOutlineUnsupported => "glyphOutlineUnsupported",
             Self::UnsupportedOutlinePayload => "unsupportedOutlinePayload",
             Self::GlyphOutlineStrokeStyleUnsupported => "glyphOutlineStrokeStyleUnsupported",
+            Self::UnsupportedColorGlyph => "unsupportedColorGlyph",
+            Self::UnsupportedBitmapGlyph => "unsupportedBitmapGlyph",
+            Self::UnsupportedSvgGlyph => "unsupportedSvgGlyph",
             Self::PositionAdjustedNotAllowed => "positionAdjustedNotAllowed",
             Self::PositionAdjustedResidualTooLarge => "positionAdjustedResidualTooLarge",
         }
@@ -173,6 +179,10 @@ pub struct TextVariantSelectionOptions {
     pub allow_position_adjusted: bool,
     pub max_position_adjusted_residual_px: f64,
     pub max_canvas_glyph_id: u32,
+    pub allow_colrv0_color_layers: bool,
+    pub allow_colrv1_stage1_color_graph: bool,
+    pub allow_bitmap_glyph: bool,
+    pub allow_svg_glyph: bool,
 }
 
 impl Default for TextVariantSelectionOptions {
@@ -189,6 +199,10 @@ impl TextVariantSelectionOptions {
             allow_position_adjusted: true,
             max_position_adjusted_residual_px: 0.25,
             max_canvas_glyph_id: u16::MAX as u32,
+            allow_colrv0_color_layers: false,
+            allow_colrv1_stage1_color_graph: false,
+            allow_bitmap_glyph: false,
+            allow_svg_glyph: false,
         }
     }
 
@@ -505,7 +519,14 @@ fn collect_glyph_outline_reject_reasons(
     options: TextVariantSelectionOptions,
     reasons: &mut BTreeSet<VariantRejectReason>,
 ) {
-    if outline.paths.is_empty() {
+    if !outline.has_exclusive_payload_family() {
+        reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
+    }
+    if matches!(
+        outline.payload_kind,
+        GlyphOutlinePayloadKind::MonochromeFill | GlyphOutlinePayloadKind::MonochromeFillStroke
+    ) && outline.paths.is_empty()
+    {
         reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
     }
     if !outline.paint_style.is_fill_only_glyph_replay() {
@@ -526,6 +547,31 @@ fn collect_glyph_outline_reject_reasons(
                 reasons.insert(VariantRejectReason::GlyphOutlineStrokeStyleUnsupported);
             }
         }
+        GlyphOutlinePayloadKind::ColorLayers => match outline.color_layers.as_ref() {
+            Some(color_layers)
+                if color_layers.has_colrv0_resolved_layer_contract()
+                    && options.allow_colrv0_color_layers => {}
+            Some(color_layers)
+                if color_layers.has_colrv1_stage1_graph_contract()
+                    && options.allow_colrv1_stage1_color_graph => {}
+            _ => {
+                reasons.insert(VariantRejectReason::UnsupportedColorGlyph);
+            }
+        },
+        GlyphOutlinePayloadKind::BitmapGlyph => match outline.bitmap_glyph.as_ref() {
+            Some(bitmap_glyph)
+                if bitmap_glyph.has_strict_visual_contract() && options.allow_bitmap_glyph => {}
+            _ => {
+                reasons.insert(VariantRejectReason::UnsupportedBitmapGlyph);
+            }
+        },
+        GlyphOutlinePayloadKind::SvgGlyph => match outline.svg_glyph.as_ref() {
+            Some(svg_glyph)
+                if svg_glyph.has_static_sanitized_contract() && options.allow_svg_glyph => {}
+            _ => {
+                reasons.insert(VariantRejectReason::UnsupportedSvgGlyph);
+            }
+        },
     }
     collect_text_variant_diagnostics_reject_reasons(&outline.diagnostics, options, reasons);
 }
@@ -577,11 +623,14 @@ fn collect_text_variant_diagnostics_reject_reasons(
 mod tests {
     use super::*;
     use crate::paint::{
+        BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, ColorGlyphFormat,
+        ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind, ColorPaintGraphPayload,
         FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
         GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
         GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
-        GlyphRunOrientation, LayerAffineTransform, LayerGlyphOutlinePath, LayerNode, LayerPoint,
-        PaintTextStyle, PaintVariantMeta, ScriptTag, ShapeKey, ShapingEngineId, TextDirection,
+        GlyphRunOrientation, ImageResourceId, LayerAffineTransform, LayerGlyphOutlinePath,
+        LayerNode, LayerPoint, LayerVector, PaintTextStyle, PaintVariantMeta, ResolvedColor,
+        ScriptTag, ShapeKey, ShapingEngineId, SvgGlyphPayload, SvgResourceId, TextDirection,
         TextRunPlacement, TextSourceId, TextSourceRange, TextSourceSpan, WritingMode,
     };
     use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
@@ -747,6 +796,9 @@ mod tests {
                 } else {
                     GlyphOutlinePayloadKind::MonochromeFill
                 },
+                color_layers: None,
+                bitmap_glyph: None,
+                svg_glyph: None,
                 paint_style: PaintTextStyle::from(&TextStyle {
                     font_family: "Test".to_string(),
                     font_size: 12.0,
@@ -770,6 +822,106 @@ mod tests {
                 diagnostics: diagnostics(),
             }),
         }
+    }
+
+    fn color_layers_payload(kind: ColorPaintGraphNodeKind) -> ColorLayersPayload {
+        ColorLayersPayload {
+            color_format: ColorGlyphFormat::ColrV1,
+            source_font_ref: None,
+            palette_ref: None,
+            layers: Vec::new(),
+            paint_graph: Some(ColorPaintGraphPayload {
+                root_node_id: 0,
+                nodes: vec![ColorPaintGraphNode {
+                    node_id: 0,
+                    kind,
+                    commands: Some(vec![
+                        PathCommand::MoveTo(0.0, 0.0),
+                        PathCommand::LineTo(10.0, 0.0),
+                        PathCommand::ClosePath,
+                    ]),
+                    fill: Some(ResolvedColor {
+                        color_space: Some("sRGB".to_string()),
+                        rgba: [0.0, 0.0, 0.0, 1.0],
+                    }),
+                    fill_rule: Some(GlyphOutlineFillRule::NonZero),
+                    child_node_id: None,
+                    transform: None,
+                    source_range_utf8: Some(TextSourceRange::new(0, 1)),
+                    glyph_range: Some(GlyphRange::new(0, 1)),
+                    source_font_ref: None,
+                }],
+            }),
+            source_range_utf8: Some(TextSourceRange::new(0, 1)),
+            glyph_range: Some(GlyphRange::new(0, 1)),
+        }
+    }
+
+    fn color_layers_outline(kind: ColorPaintGraphNodeKind) -> PaintOp {
+        let mut op = glyph_outline(None);
+        if let PaintOp::GlyphOutline { outline, .. } = &mut op {
+            outline.payload_kind = GlyphOutlinePayloadKind::ColorLayers;
+            outline.paths.clear();
+            outline.color_layers = Some(color_layers_payload(kind));
+            outline
+                .variant
+                .requires
+                .push("text.glyphOutline.colorLayers".to_string());
+            outline
+                .variant
+                .requires
+                .push("text.glyphOutline.colorLayers.colrV1".to_string());
+        }
+        op
+    }
+
+    fn bitmap_glyph_outline() -> PaintOp {
+        let mut op = glyph_outline(None);
+        if let PaintOp::GlyphOutline { outline, .. } = &mut op {
+            outline.payload_kind = GlyphOutlinePayloadKind::BitmapGlyph;
+            outline.paths.clear();
+            outline.bitmap_glyph = Some(BitmapGlyphPayload {
+                image_ref: ImageResourceId(0),
+                source_range_utf8: TextSourceRange::new(0, 1),
+                glyph_range: GlyphRange::new(0, 1),
+                placement: BoundingBox::new(0.0, 0.0, 12.0, 12.0),
+                alpha_premultiplied: true,
+                scaling_policy: BitmapGlyphScalingPolicy::SourceExact,
+                filtering: BitmapGlyphFiltering::Linear,
+                transform_to_run: None,
+            });
+            outline
+                .variant
+                .requires
+                .push("text.glyphOutline.bitmapGlyph".to_string());
+        }
+        op
+    }
+
+    fn svg_glyph_outline() -> PaintOp {
+        let mut op = glyph_outline(None);
+        if let PaintOp::GlyphOutline { outline, .. } = &mut op {
+            outline.payload_kind = GlyphOutlinePayloadKind::SvgGlyph;
+            outline.paths.clear();
+            outline.svg_glyph = Some(SvgGlyphPayload {
+                svg_ref: SvgResourceId(0),
+                source_range_utf8: TextSourceRange::new(0, 1),
+                glyph_range: GlyphRange::new(0, 1),
+                view_box: BoundingBox::new(0.0, 0.0, 10.0, 10.0),
+                intrinsic_size: Some(LayerVector { dx: 10.0, dy: 10.0 }),
+                static_sanitized: true,
+                script_allowed: false,
+                animation_allowed: false,
+                external_resources_allowed: false,
+                interactivity_allowed: false,
+                transform_to_run: None,
+            });
+            outline
+                .variant
+                .requires
+                .push("text.glyphOutline.svgGlyph".to_string());
+        }
+        op
     }
 
     fn tree(ops: Vec<PaintOp>) -> PageLayerTree {
@@ -983,5 +1135,95 @@ mod tests {
         assert!(report.rejected_variants[0]
             .reasons
             .contains(&VariantRejectReason::VariantPartsIncomplete));
+    }
+
+    #[test]
+    fn advanced_glyph_outline_payloads_are_gated_by_default() {
+        let color_report = first_report(
+            vec![
+                text_op(),
+                color_layers_outline(ColorPaintGraphNodeKind::SolidPath),
+            ],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(
+            color_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(color_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedColorGlyph));
+
+        let bitmap_report = first_report(
+            vec![text_op(), bitmap_glyph_outline()],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(
+            bitmap_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(bitmap_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedBitmapGlyph));
+
+        let svg_report = first_report(
+            vec![text_op(), svg_glyph_outline()],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        assert_eq!(
+            svg_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(svg_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedSvgGlyph));
+    }
+
+    #[test]
+    fn colrv1_graph_node_kind_gate_is_explicit() {
+        let report = first_report(
+            vec![
+                text_op(),
+                color_layers_outline(ColorPaintGraphNodeKind::SweepGradientPath),
+            ],
+            TextVariantSelectionOptions {
+                allow_colrv1_stage1_color_graph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(report.selected_variant_kind, Some(TextVariantKind::TextRun));
+        assert!(report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedColorGlyph));
+    }
+
+    #[test]
+    fn canvaskit_and_canvas2d_share_advanced_payload_reject_reason() {
+        let canvas_kit = first_report(
+            vec![
+                text_op(),
+                color_layers_outline(ColorPaintGraphNodeKind::SolidPath),
+            ],
+            TextVariantSelectionOptions::canvaskit_strict_outline(),
+        );
+        let canvas_2d = first_report(
+            vec![
+                text_op(),
+                color_layers_outline(ColorPaintGraphNodeKind::SolidPath),
+            ],
+            TextVariantSelectionOptions {
+                backend: VariantSelectionBackend::Canvas2D,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert!(canvas_kit.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedColorGlyph));
+        assert!(canvas_2d.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedColorGlyph));
+        assert!(canvas_2d.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::BackendDoesNotSupportVariant));
     }
 }

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -624,8 +624,11 @@ mod tests {
     use super::*;
     use crate::paint::{
         BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, ColorGlyphFormat,
-        ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind, ColorPaintGraphPayload,
-        FontFaceKey, FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
+        ColorGradientStop, ColorLayersPayload, ColorLinearGradient, ColorPaintGraphNode,
+        ColorPaintGraphNodeKind, ColorPaintGraphPayload, ColorPaintLinearGradientPathNode,
+        ColorPaintRadialGradientPathNode, ColorPaintSolidPathNode, ColorPaintSweepGradientPathNode,
+        ColorRadialGradient, ColorSweepGradient, FontColorGlyphRef, FontFaceKey,
+        FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
         GlyphOutlinePaintOrder, GlyphOutlinePayloadKind, GlyphOutlineStrokeCap,
         GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
         GlyphRunOrientation, ImageResourceId, LayerAffineTransform, LayerGlyphOutlinePath,
@@ -825,9 +828,110 @@ mod tests {
     }
 
     fn color_layers_payload(kind: ColorPaintGraphNodeKind) -> ColorLayersPayload {
+        let source_font_ref = FontColorGlyphRef {
+            face_key: Some("fixture-face".to_string()),
+            glyph_id: Some(42),
+            palette_index: Some(0),
+            color_format: Some(ColorGlyphFormat::ColrV1),
+        };
+        let source_range_utf8 = Some(TextSourceRange::new(0, 1));
+        let glyph_range = Some(GlyphRange::new(0, 1));
+        let black = ResolvedColor {
+            color_space: Some("sRGB".to_string()),
+            rgba: [0.0, 0.0, 0.0, 1.0],
+        };
+        let commands = vec![
+            PathCommand::MoveTo(0.0, 0.0),
+            PathCommand::LineTo(10.0, 0.0),
+            PathCommand::LineTo(10.0, 10.0),
+            PathCommand::ClosePath,
+        ];
+        let red = ResolvedColor {
+            color_space: Some("sRGB".to_string()),
+            rgba: [1.0, 0.0, 0.0, 1.0],
+        };
+        let stops = vec![
+            ColorGradientStop {
+                offset: 0.0,
+                color: black.clone(),
+            },
+            ColorGradientStop {
+                offset: 1.0,
+                color: red,
+            },
+        ];
+        let (solid_path, linear_gradient_path, radial_gradient_path, sweep_gradient_path) =
+            match kind {
+                ColorPaintGraphNodeKind::SolidPath => (
+                    Some(ColorPaintSolidPathNode {
+                        commands: commands.clone(),
+                        fill: black.clone(),
+                        fill_rule: GlyphOutlineFillRule::NonZero,
+                        source_glyph_id: Some(42),
+                        palette_index: Some(0),
+                    }),
+                    None,
+                    None,
+                    None,
+                ),
+                ColorPaintGraphNodeKind::LinearGradientPath => (
+                    None,
+                    Some(ColorPaintLinearGradientPathNode {
+                        commands: commands.clone(),
+                        gradient: ColorLinearGradient {
+                            x0: 0.0,
+                            y0: 0.0,
+                            x1: 10.0,
+                            y1: 10.0,
+                            stops: stops.clone(),
+                        },
+                        fill_rule: GlyphOutlineFillRule::NonZero,
+                        source_glyph_id: Some(42),
+                        palette_index: Some(0),
+                    }),
+                    None,
+                    None,
+                ),
+                ColorPaintGraphNodeKind::RadialGradientPath => (
+                    None,
+                    None,
+                    Some(ColorPaintRadialGradientPathNode {
+                        commands: commands.clone(),
+                        gradient: ColorRadialGradient {
+                            cx: 5.0,
+                            cy: 5.0,
+                            radius: 5.0,
+                            stops: stops.clone(),
+                        },
+                        fill_rule: GlyphOutlineFillRule::NonZero,
+                        source_glyph_id: Some(42),
+                        palette_index: Some(0),
+                    }),
+                    None,
+                ),
+                ColorPaintGraphNodeKind::SweepGradientPath => (
+                    None,
+                    None,
+                    None,
+                    Some(ColorPaintSweepGradientPathNode {
+                        commands,
+                        gradient: ColorSweepGradient {
+                            cx: 5.0,
+                            cy: 5.0,
+                            start_angle_degrees: 0.0,
+                            end_angle_degrees: 360.0,
+                            stops,
+                        },
+                        fill_rule: GlyphOutlineFillRule::NonZero,
+                        source_glyph_id: Some(42),
+                        palette_index: Some(0),
+                    }),
+                ),
+                _ => (None, None, None, None),
+            };
         ColorLayersPayload {
             color_format: ColorGlyphFormat::ColrV1,
-            source_font_ref: None,
+            source_font_ref: Some(source_font_ref.clone()),
             palette_ref: None,
             layers: Vec::new(),
             paint_graph: Some(ColorPaintGraphPayload {
@@ -835,25 +939,18 @@ mod tests {
                 nodes: vec![ColorPaintGraphNode {
                     node_id: 0,
                     kind,
-                    commands: Some(vec![
-                        PathCommand::MoveTo(0.0, 0.0),
-                        PathCommand::LineTo(10.0, 0.0),
-                        PathCommand::ClosePath,
-                    ]),
-                    fill: Some(ResolvedColor {
-                        color_space: Some("sRGB".to_string()),
-                        rgba: [0.0, 0.0, 0.0, 1.0],
-                    }),
-                    fill_rule: Some(GlyphOutlineFillRule::NonZero),
-                    child_node_id: None,
+                    solid_path,
+                    linear_gradient_path,
+                    radial_gradient_path,
+                    sweep_gradient_path,
                     transform: None,
-                    source_range_utf8: Some(TextSourceRange::new(0, 1)),
-                    glyph_range: Some(GlyphRange::new(0, 1)),
-                    source_font_ref: None,
+                    source_range_utf8,
+                    glyph_range,
+                    source_font_ref: Some(source_font_ref),
                 }],
             }),
-            source_range_utf8: Some(TextSourceRange::new(0, 1)),
-            glyph_range: Some(GlyphRange::new(0, 1)),
+            source_range_utf8,
+            glyph_range,
         }
     }
 
@@ -1180,11 +1277,33 @@ mod tests {
     }
 
     #[test]
-    fn colrv1_graph_node_kind_gate_is_explicit() {
+    fn colrv1_graph_supported_gradient_gate_can_select_gradient_subset() {
+        for kind in [
+            ColorPaintGraphNodeKind::LinearGradientPath,
+            ColorPaintGraphNodeKind::RadialGradientPath,
+            ColorPaintGraphNodeKind::SweepGradientPath,
+        ] {
+            let report = first_report(
+                vec![text_op(), color_layers_outline(kind)],
+                TextVariantSelectionOptions {
+                    allow_colrv1_stage1_color_graph: true,
+                    ..TextVariantSelectionOptions::canvaskit_strict_outline()
+                },
+            );
+            assert_eq!(
+                report.selected_variant_kind,
+                Some(TextVariantKind::GlyphOutline)
+            );
+            assert!(report.rejected_variants.is_empty());
+        }
+    }
+
+    #[test]
+    fn colrv1_unsupported_graph_node_kind_gate_is_explicit() {
         let report = first_report(
             vec![
                 text_op(),
-                color_layers_outline(ColorPaintGraphNodeKind::SweepGradientPath),
+                color_layers_outline(ColorPaintGraphNodeKind::Composite),
             ],
             TextVariantSelectionOptions {
                 allow_colrv1_stage1_color_graph: true,

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -138,6 +138,8 @@ pub enum VariantRejectReason {
     VariantPartsIncomplete,
     GlyphOutlineUnsupported,
     UnsupportedOutlinePayload,
+    MixedGlyphOutlinePayload,
+    EmptyGlyphOutlinePayload,
     GlyphOutlineStrokeStyleUnsupported,
     UnsupportedColorGlyph,
     UnsupportedBitmapGlyph,
@@ -162,6 +164,8 @@ impl VariantRejectReason {
             Self::VariantPartsIncomplete => "variantPartsIncomplete",
             Self::GlyphOutlineUnsupported => "glyphOutlineUnsupported",
             Self::UnsupportedOutlinePayload => "unsupportedOutlinePayload",
+            Self::MixedGlyphOutlinePayload => "mixedGlyphOutlinePayload",
+            Self::EmptyGlyphOutlinePayload => "emptyGlyphOutlinePayload",
             Self::GlyphOutlineStrokeStyleUnsupported => "glyphOutlineStrokeStyleUnsupported",
             Self::UnsupportedColorGlyph => "unsupportedColorGlyph",
             Self::UnsupportedBitmapGlyph => "unsupportedBitmapGlyph",
@@ -180,6 +184,9 @@ pub struct TextVariantSelectionOptions {
     pub max_position_adjusted_residual_px: f64,
     pub max_canvas_glyph_id: u32,
     pub allow_colrv0_color_layers: bool,
+    /// Compatibility name for the first P19-supported COLRv1 graph subset:
+    /// solid paths, single linear/radial/full-circle sweep gradient paths, and
+    /// transform chains ending in one supported leaf.
     pub allow_colrv1_stage1_color_graph: bool,
     pub allow_bitmap_glyph: bool,
     pub allow_svg_glyph: bool,
@@ -520,14 +527,14 @@ fn collect_glyph_outline_reject_reasons(
     reasons: &mut BTreeSet<VariantRejectReason>,
 ) {
     if !outline.has_exclusive_payload_family() {
-        reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
+        reasons.insert(VariantRejectReason::MixedGlyphOutlinePayload);
     }
     if matches!(
         outline.payload_kind,
         GlyphOutlinePayloadKind::MonochromeFill | GlyphOutlinePayloadKind::MonochromeFillStroke
     ) && outline.paths.is_empty()
     {
-        reasons.insert(VariantRejectReason::UnsupportedOutlinePayload);
+        reasons.insert(VariantRejectReason::EmptyGlyphOutlinePayload);
     }
     if !outline.paint_style.is_fill_only_glyph_replay() {
         reasons.insert(VariantRejectReason::UnsupportedPaintEffect);
@@ -552,7 +559,7 @@ fn collect_glyph_outline_reject_reasons(
                 if color_layers.has_colrv0_resolved_layer_contract()
                     && options.allow_colrv0_color_layers => {}
             Some(color_layers)
-                if color_layers.has_colrv1_stage1_graph_contract()
+                if color_layers.has_colrv1_supported_graph_contract()
                     && options.allow_colrv1_stage1_color_graph => {}
             _ => {
                 reasons.insert(VariantRejectReason::UnsupportedColorGlyph);


### PR DESCRIPTION
## What

- `GlyphOutline` payload vocabulary에 `colorLayers`, `bitmapGlyph`, `svgGlyph`를 추가합니다.
- `ColorLayers.colrV0`, `ColorLayers.colrV1`, `BitmapGlyph`, `SvgGlyph` payload contract와 family exclusivity check를 추가합니다.
- COLRv1 paint graph를 solid path, linear/radial/sweep gradient path, transform chain으로 나누고, bounded graph validator와 JSON schema를 맞춥니다.
- CanvasKit text variant selection에서 advanced glyph payload는 기본적으로 선택하지 않고, 명시적으로 열린 COLRv1 subset만 replay합니다.
- CanvasKit renderer는 COLRv1 solid/linear/radial/sweep graph를 직접 path/shader로 replay하고, unsupported graph는 `unsupportedColorGlyph` reason으로 `TextRun` fallback을 유지합니다.
- Studio 타입과 CanvasKit diagnostics helper를 추가해서 browser 쪽에서도 같은 payload family와 reject reason을 구분합니다.
- README와 `docs/text-ir-v2.md`에 P19의 gate 성격, 열린 subset, non-goal을 정리합니다.

## Why

P18까지는 CanvasKit image replay의 direct coverage를 닫았습니다. 다음 단계에서 glyph payload를 전부 열면 fallback 조건과 payload family가 섞일 가능성이 큽니다.

이번 PR은 advanced glyph payload vocabulary와 reject/report contract를 먼저 고정하면서, 검증 가능한 첫 replay consumer로 COLRv1 solid/gradient graph subset만 엽니다. 즉 `TextRun` fallback은 계속 남겨두고, backend가 준비되지 않은 bitmap/SVG glyph나 복잡한 COLRv1 graph를 조용히 path/image처럼 처리하지 않도록 막습니다.

## Compatibility

- public renderer 기본값은 바꾸지 않습니다.
- CanvasKit은 계속 opt-in path입니다.
- `GlyphRun` / `GlyphOutline`은 canonical text path가 아니고 optional text variant입니다.
- advanced `GlyphOutline` payload는 default selection에서 직접 replay되지 않고 `TextRun` fallback을 유지합니다.
- COLRv1 solid/linear/radial/sweep graph는 명시적인 CanvasKit gate가 열릴 때만 선택합니다.
- schema는 `schemaVersion: 1` 유지, additive `schemaMinorVersion: 14`로 올립니다.

## Non-goals

- COLRv1 composite/blend/clip/nested paint replay를 구현하지 않습니다.
- BitmapGlyph image strike replay를 실제 renderer에 연결하지 않습니다.
- SvgGlyph static vector replay를 실제 renderer에 연결하지 않습니다.
- native Skia / SVG / Canvas2D full color glyph replay를 켜지 않습니다.
- font-native COLR/CPAL table을 consumer가 직접 해석하게 만들지 않습니다.
- font construction proof나 arbitrary glyph id replay를 완료하지 않습니다.

## Validation

- `cargo test --lib colrv1`
- `cargo test --lib serializes_advanced_glyph_outline_payload_gate_metadata`
- `npm --prefix rhwp-studio test -- render-backend`
- `npm --prefix rhwp-studio run build`
- `cargo fmt --check`
- `git diff --check`

Refs #536
