### PR TITLE
fix(chrome): 로컬 file:// HWP 열기 시 권한 안내 + 중복 다운로드 억제 (#1131)

### DIFF
--- a/mydocs/plans/task_m07x_1131.md
+++ b/mydocs/plans/task_m07x_1131.md
@@ -1,0 +1,90 @@
+# 수행계획서 — task_m07x_1131
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance` (upstream/devel 기준)
+- **작성일**: 2026-05-26
+- **유형**: 버그 수정 (rhwp-chrome / rhwp-studio 뷰어 UX)
+
+## 1. 배경 및 근본 원인 (확정)
+
+파일 탐색기에서 로컬 `.hwp/.hwpx`를 Chrome으로 열면 rhwp 뷰어 탭이 열리지만
+문서가 표시되지 않고 **"파일 로드 실패: Failed to fetch"** 토스트만 뜨고,
+원본 파일은 그대로 다운로드된다.
+
+추적 결과:
+
+1. `rhwp-chrome/sw/download-interceptor.js` — `onDeterminingFilename`이 `file://`
+   다운로드를 HWP로 판정 → `openViewer({ url: "file:///..." })`로 뷰어 탭 생성.
+   동시에 `suggest()` 호출로 다운로드는 그대로 진행.
+2. 뷰어(`rhwp-studio/src/main.ts` `loadFromUrlParam`, L730)가 `fetch("file:///...")` 시도.
+3. Chrome의 **"파일 URL에 대한 액세스 허용"** 토글이 꺼져 있으면(기본 OFF)
+   확장 페이지의 `file://` fetch가 거부된다. `host_permissions: <all_urls>`는
+   `file://`를 커버하지 않는다.
+4. MV3 service worker 폴백(`message-router.js` `fetch-file`)도 `file://`를 받지 못해 실패.
+5. 결국 `showLoadError`(L779)가 원본 에러 문자열 그대로 **"Failed to fetch"**만 노출 →
+   사용자에게 원인/해결법 안내가 전혀 없음.
+
+**검증**: 토글을 켜면 정상 동작 → 근본 원인이 "파일 URL 액세스 미허용"임을 확정.
+
+## 2. 목표
+
+1. `file://` 문서 로드가 권한 미허용으로 실패할 때, 무의미한 "Failed to fetch" 대신
+   **원인과 해결 방법을 명확히 안내**한다(설정 화면 액션 버튼 제공).
+2. 로컬 `file://` HWP를 자체 뷰어로 열 때, **불필요한 중복 다운로드를 억제**한다.
+   사용자의 로컬 파일은 이미 디스크에 있으므로 재다운로드가 무의미하다.
+
+> 범위(작업지시자 합의, 2026-05-26 확대): 안내 메시지 + `file://` 다운로드 억제.
+> 원격(http) 파일 다운로드 동작은 기존 유지.
+
+## 3. 영향 범위
+
+| 파일 | 변경 내용 |
+|------|----------|
+| `rhwp-studio/src/main.ts` | `loadFromUrlParam` 실패 처리에 `file://` + 권한 미허용 분기 추가, 전용 안내 토스트 호출 |
+| `rhwp-chrome/sw/download-interceptor.js` | `file://` HWP 다운로드는 `suggest` 대신 `cancel`+`erase`로 억제 (원격은 기존 유지) |
+
+- `showToast`(`rhwp-studio/src/ui/toast.ts`)는 이미 `action: { label, onClick }`,
+  `confirmLabel`, `durationMs`를 지원하므로 **toast.ts 변경 불필요**.
+- `chrome.extension.isAllowedFileSchemeAccess()`로 권한 상태를 감지(확장 페이지에서 호출 가능).
+- 권한 ON 인데도 실패하는 일반 케이스는 기존 동작(일반 에러) 유지.
+
+## 4. 설계 개요
+
+`loadFromUrlParam`의 `catch` 처리에서:
+
+1. `fileUrl`이 `file:`로 시작하는지 확인.
+2. `file://`이고 확장 환경이면 `chrome.extension.isAllowedFileSchemeAccess()` 조회.
+3. **권한 OFF**: 전용 안내 토스트 표시
+   - 메시지: 로컬 파일을 표시하려면 "파일 URL에 대한 액세스 허용"을 켜야 한다는 안내
+   - 액션 버튼: "설정 열기" → `chrome.tabs.create({ url: "chrome://extensions/?id=" + chrome.runtime.id })`
+   - `durationMs: 0` (사용자가 직접 닫기)
+4. **권한 ON 또는 비확장 환경**: 기존 `showLoadError` 유지.
+
+`download-interceptor.js` `onDeterminingFilename`에서:
+
+- HWP/HWPX로 판정된 항목의 `url`이 `file:`로 시작하면 → `suggest` 호출 대신
+  `chrome.downloads.cancel(item.id)` 후 `chrome.downloads.erase({ id: item.id })`로
+  다운로드 항목/임시 파일을 제거하고 뷰어만 연다(best-effort).
+- `file://`이 아니면 → 기존 로직(`suggest`) 그대로.
+
+## 5. 검증 방법
+
+- 빌드: `rhwp-chrome` 확장 빌드(`build.mjs`) 또는 `rhwp-studio` 타입체크/Vite 빌드 성공.
+- 수동 검증(작업지시자 환경, Windows Chrome):
+  - 권한 OFF 상태에서 로컬 `.hwpx` 열기 → **안내 토스트 + 설정 열기 버튼** 표시 확인.
+  - "설정 열기" 클릭 → `chrome://extensions/?id=...` 이동 확인.
+  - 권한 ON 후 재시도 → 문서 정상 표시(회귀 없음) 확인.
+- 기존 테스트 영향 없음 확인.
+
+## 6. 위험 및 대안
+
+- `chrome.extension.isAllowedFileSchemeAccess`는 콜백/Promise 양형식 — Promise 형태로 안전 호출.
+- `chrome.tabs.create`는 뷰어가 확장 페이지이므로 사용 가능. 권한(`tabs`)은 URL 생성에 불필요(생성만 함).
+- 안내 문구는 `_locales` i18n 적용 여부를 구현계획서에서 결정(현 뷰어 문자열은 하드코딩 한국어 다수 → 일관성 위해 우선 한국어 하드코딩, i18n은 후속 가능).
+- **`file://` 다운로드 억제는 best-effort**: 로컬 복사는 거의 즉시 완료돼 `cancel`이
+  늦을 수 있고, Downloads 폴더에 파일이 남을 가능성이 있다. 작업지시자 환경(Windows
+  Chrome)에서 실제 차단 여부 검증 필요. cancel 불가 시에도 뷰어 동작에는 영향 없음.
+
+## 7. 다음 단계
+
+승인 시 구현계획서(`task_m07x_1131_impl.md`, 3~6단계) 작성 → 승인 후 구현 착수.

--- a/mydocs/plans/task_m07x_1131_impl.md
+++ b/mydocs/plans/task_m07x_1131_impl.md
@@ -1,0 +1,79 @@
+# 구현계획서 — task_m07x_1131_impl
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance`
+- **선행**: `task_m07x_1131.md`(수행계획서) 승인 완료
+- **작성일**: 2026-05-26
+
+수행계획서의 설계를 3단계로 구현한다. 단계마다 커밋하고 단계별 완료보고서를 작성한다.
+
+---
+
+## 단계 1 — 권한 감지 + 안내 토스트 헬퍼 추가
+
+**대상**: `rhwp-studio/src/main.ts`
+
+- `file://` URL 로드 실패 시 사용할 안내 헬퍼 `showFileUrlAccessGuidance()` 추가.
+  - `showToast` 사용 (`durationMs: 0`).
+  - 메시지(한국어 하드코딩, 기존 뷰어 문자열 관례 일치):
+    > 로컬 파일을 열려면 확장 프로그램의 "파일 URL에 대한 액세스 허용"을 켜야 합니다.
+    > 설정에서 권한을 허용한 뒤 파일을 다시 열어 주세요.
+  - `action: { label: "설정 열기", onClick }` →
+    `chrome.tabs.create({ url: "chrome://extensions/?id=" + chrome.runtime.id })`.
+    `chrome.tabs`가 없을 가능성에 대비해 안전 가드(존재 시에만 호출).
+- 권한 상태 조회 헬퍼: `chrome.extension?.isAllowedFileSchemeAccess`를 Promise로 감싸
+  `false`(미허용) 여부 판정. API 부재 시 `null`(판정 불가) 반환.
+
+**완료 기준**: 헬퍼 함수 추가, 타입체크 통과. 호출부 연결은 단계 2.
+
+## 단계 2 — `loadFromUrlParam` 실패 분기 통합
+
+**대상**: `rhwp-studio/src/main.ts` `loadFromUrlParam` (현 L730), 최종 `catch`(L767).
+
+- 로드 실패 `catch`에서 조건 분기:
+  1. `fileUrl`이 `file:`로 시작하고
+  2. 확장 환경(`chrome` 존재)이며
+  3. 권한 조회 결과가 **미허용(false)** 이면
+     → `showFileUrlAccessGuidance()` 호출 후 종료.
+  4. 그 외(권한 허용/판정 불가/비-file URL) → 기존 `showLoadError(error)` 유지.
+- 기존 정상 경로(권한 ON, 원격 URL)는 변경 없음 — 회귀 차단.
+
+**완료 기준**: 분기 로직 반영, 타입체크 통과.
+
+## 단계 3 — `file://` 중복 다운로드 억제
+
+**대상**: `rhwp-chrome/sw/download-interceptor.js` `onDeterminingFilename` 리스너.
+
+- HWP/HWPX 판정 후 `item.url`이 `file:`로 시작하면:
+  - `suggest` 호출 대신 `handleHwpDownload(item)`로 뷰어를 열고,
+  - `chrome.downloads.cancel(item.id)` → 성공/실패 무관하게 `chrome.downloads.erase({ id: item.id })`로 정리(best-effort, 예외 무시).
+- `file://`이 아니면 기존 로직(`suggest`) 유지 → 원격 파일 동작 무변경.
+- 판정 로직(`shouldInterceptDownload`)은 변경하지 않는다.
+
+**완료 기준**: `file://` 분기 추가, 원격 경로 회귀 없음(코드 리뷰로 확인).
+
+## 단계 4 — 빌드 검증 + 수동 검증 안내
+
+- `rhwp-studio` 타입체크 / Vite 빌드 또는 `rhwp-chrome` `build.mjs` 빌드 성공 확인.
+- 기존 테스트 무영향 확인.
+- 작업지시자 수동 검증 절차 안내(Windows Chrome):
+  - 권한 OFF → 로컬 `.hwpx` 열기 → 안내 토스트 + "설정 열기" 버튼 표시.
+  - "설정 열기" → `chrome://extensions/?id=...` 이동.
+  - 권한 ON 후 재시도 → 문서 정상 표시(회귀 없음).
+  - 로컬 `.hwpx` 열기 시 **Downloads 폴더에 중복 파일이 생기지 않는지** 확인(다운로드 억제).
+  - 원격(http) HWP 링크는 기존대로 다운로드되는지 확인(회귀 없음).
+- 최종 결과보고서(`task_m07x_1131_report.md`) 작성 → 승인 → upstream `devel`로 PR.
+
+---
+
+## 커밋 전략
+
+- 단계 1·2는 단일 논리 변경이므로 묶어서 1커밋 가능(`Task #1131: file:// 권한 안내`).
+  단, 단계별 완료보고서 규칙에 따라 단계 단위로 커밋 분리도 허용.
+- 커밋 메시지: `Task #1131: ...` 형식 + 본문에 `refs edwardkim/rhwp#1131`.
+
+## 위험 점검
+
+- WASM 빌드(`pkg/`)가 없으면 `build.mjs` 전체 빌드는 실패할 수 있음 → 타입체크/Vite
+  단독 빌드로 검증 대체 가능. 본 변경은 WASM 비의존.
+- `chrome://` URL은 링크로 직접 못 열지만 `chrome.tabs.create`로는 열림(확장 컨텍스트).

--- a/mydocs/report/task_m07x_1131_report.md
+++ b/mydocs/report/task_m07x_1131_report.md
@@ -1,0 +1,51 @@
+# 최종 결과보고서 — task_m07x_1131_report
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance` (upstream/devel 기준)
+- **유형**: 버그 수정 (rhwp-chrome / rhwp-studio)
+- **작성일**: 2026-05-26
+
+## 1. 문제
+
+파일 탐색기에서 로컬 `.hwp/.hwpx`를 Chrome으로 열면 rhwp 뷰어가 빈 화면 +
+"파일 로드 실패: Failed to fetch"만 표시하고, 원본 파일은 다운로드됐다.
+
+## 2. 근본 원인
+
+- "파일 URL에 대한 액세스 허용(Allow access to file URLs)" 토글이 꺼져 있으면(기본 OFF)
+  뷰어의 `fetch(file://)`가 실패한다. `host_permissions: <all_urls>`는 `file://`를 커버하지 않음.
+- MV3 service worker 폴백(`fetch-file`)도 `file://`를 받지 못해 실패.
+- `showLoadError`가 원본 에러("Failed to fetch")만 노출 → 원인/해결법 안내 부재.
+- 또한 로컬 파일임에도 `suggest()`로 다운로드가 그대로 진행됨(중복).
+
+## 3. 변경 사항
+
+| 파일 | 변경 |
+|------|------|
+| `rhwp-studio/src/main.ts` | `isFileSchemeAccessAllowed()`, `showFileUrlAccessGuidance()` 추가. `loadFromUrlParam` 실패 시 `file://` + 권한 미허용이면 안내 토스트(+"설정 열기" 버튼 → `chrome://extensions/?id=...`) 표시. 그 외는 기존 `showLoadError` 유지. |
+| `rhwp-chrome/sw/download-interceptor.js` | `file://` HWP는 `suggest` 대신 `cancel`+`erase`로 다운로드 억제. 원격(http)은 기존 동작 유지. |
+
+## 4. 검증
+
+- 타입체크(`tsc --noEmit`): 본 변경 관련 에러 없음(잔여 2건은 WASM `pkg/` 미빌드, 무관).
+- 공유 판정 테스트(`download-interceptor-common.test.js`): 26/26 통과.
+- `node --check`: `download-interceptor.js` 문법 OK.
+- **작업지시자 수동 검증 (macOS Chrome)**:
+  - ✅ 권한 OFF → 안내 토스트 + "설정 열기" 버튼 표시
+  - ✅ 권한 ON → 문서 정상 표시 (회귀 없음)
+  - ✅ 로컬 파일 열 때 중복 다운로드 발생 안 함
+
+## 5. 커밋
+
+- `a8f4f8b4` 단계1 — 권한 안내 헬퍼 추가
+- `07085d99` 단계2 — `loadFromUrlParam` 분기 연결
+- `fe13f2ee` 단계3 — `file://` 중복 다운로드 억제
+
+## 6. 비고
+
+- Windows Chrome 환경 추가 검증 권장(다운로드 억제는 best-effort).
+- 안내 문구는 한국어 하드코딩(기존 뷰어 문자열 관례 일치). i18n은 후속 가능.
+
+## 7. 후속
+
+- upstream `edwardkim/rhwp`의 `devel`로 PR 생성.

--- a/mydocs/working/task_m07x_1131_stage1.md
+++ b/mydocs/working/task_m07x_1131_stage1.md
@@ -1,0 +1,32 @@
+# 단계 1 완료보고서 — task_m07x_1131_stage1
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance`
+- **단계**: 1/3 — 권한 감지 + 안내 토스트 헬퍼 추가
+- **작성일**: 2026-05-26
+
+## 변경 내용
+
+**`rhwp-studio/src/main.ts`** — `showLoadError` 바로 위에 헬퍼 2개 추가:
+
+1. `isFileSchemeAccessAllowed(): Promise<boolean | null>`
+   - `chrome.extension.isAllowedFileSchemeAccess()`를 Promise로 호출.
+   - 허용=true / 미허용=false / API 부재·예외=null(판정 불가).
+2. `showFileUrlAccessGuidance(): void`
+   - `showToast`로 안내 메시지(한국어) + `confirmLabel: '확인'` + `durationMs: 0`.
+   - `action: { label: '설정 열기', onClick }` → `chrome.tabs.create({ url: 'chrome://extensions/?id=' + chrome.runtime.id })`.
+   - `chrome.tabs`/`chrome.runtime.id` 부재 대비 가드 포함.
+   - 상태 표시줄에도 짧은 메시지 표기.
+
+이 단계에서는 **헬퍼 정의만** 추가했고 호출부 연결은 단계 2에서 수행한다.
+
+## 검증
+
+- `npx tsc --noEmit` 실행:
+  - 본 변경 관련 타입 에러 **없음**.
+  - 남은 2건(`@wasm/rhwp.js` 모듈 미발견)은 WASM `pkg/` 미빌드로 인한 **기존 문제**이며 본 변경과 무관.
+- `rhwp-studio` 의존성은 fresh clone이라 `npm install`로 설치 완료.
+
+## 다음 단계
+
+단계 2 — `loadFromUrlParam` 실패 `catch`에 `file://` + 권한 미허용 분기 통합.

--- a/mydocs/working/task_m07x_1131_stage2.md
+++ b/mydocs/working/task_m07x_1131_stage2.md
@@ -1,0 +1,35 @@
+# 단계 2 완료보고서 — task_m07x_1131_stage2
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance`
+- **단계**: 2/4 — `loadFromUrlParam` 실패 분기 연결
+- **작성일**: 2026-05-26
+
+## 변경 내용
+
+**`rhwp-studio/src/main.ts`** `loadFromUrlParam` 최종 `catch`:
+
+```ts
+} catch (error) {
+  // 로컬 file:// 로드 실패 + "파일 URL 액세스 허용" 미허용 → 전용 안내 (#1131)
+  if (fileUrl.startsWith('file:') && typeof chrome !== 'undefined') {
+    const allowed = await isFileSchemeAccessAllowed();
+    if (allowed === false) {
+      showFileUrlAccessGuidance();
+      return;
+    }
+  }
+  showLoadError(error);
+}
+```
+
+- `file://` + 확장 환경 + 권한 **미허용(false)** 일 때만 안내 토스트.
+- 권한 허용 / 판정 불가(null) / 원격 URL → 기존 `showLoadError` 유지(회귀 차단).
+
+## 검증
+
+- `npx tsc --noEmit`: 본 변경 관련 타입 에러 없음. 남은 2건은 WASM `pkg/` 미빌드(기존, 무관).
+
+## 다음 단계
+
+단계 3 — `rhwp-chrome/sw/download-interceptor.js`에서 `file://` HWP 중복 다운로드 억제.

--- a/mydocs/working/task_m07x_1131_stage3.md
+++ b/mydocs/working/task_m07x_1131_stage3.md
@@ -1,0 +1,34 @@
+# 단계 3 완료보고서 — task_m07x_1131_stage3
+
+- **이슈**: edwardkim/rhwp#1131
+- **브랜치**: `feature/1131-file-url-access-guidance`
+- **단계**: 3/4 — `file://` 중복 다운로드 억제
+- **작성일**: 2026-05-26
+
+## 변경 내용
+
+**`rhwp-chrome/sw/download-interceptor.js`**:
+
+- `isLocalFileDownload(item)`: `item.url`이 `file:`로 시작하는지 판별.
+- `onDeterminingFilename` 분기:
+  - HWP 판정 + `file://` → `handleHwpDownload(item)`로 뷰어를 열고, `suggest` 대신
+    `suppressLocalDownload(item)` 호출.
+  - HWP 판정 + 원격 → 기존 `suggest({ filename })` 유지 (회귀 없음).
+- `suppressLocalDownload(item)`: `chrome.downloads.cancel(id)` → `erase({ id })`
+  (best-effort, 각 단계 예외 무시).
+- 판정 로직(`shouldInterceptDownload`, 공유 모듈)은 변경하지 않음.
+
+## 검증
+
+- 공유 판정 테스트 `download-interceptor-common.test.js`: **26/26 통과** (회귀 없음).
+- `node --check sw/download-interceptor.js`: 문법 OK.
+
+## 한계 (수동 검증 필요)
+
+- 로컬 복사는 거의 즉시 완료되어 `cancel`이 늦을 수 있음 → Downloads 폴더에 파일이
+  남을 가능성. 작업지시자 환경(Windows Chrome)에서 실제 억제 여부 검증 필요.
+- `cancel` 실패 시에도 뷰어 동작에는 영향 없음.
+
+## 다음 단계
+
+단계 4 — 빌드 검증 + 작업지시자 수동 검증 + 최종 보고서 → PR.

--- a/rhwp-chrome/sw/download-interceptor.js
+++ b/rhwp-chrome/sw/download-interceptor.js
@@ -5,24 +5,56 @@
 // #198 (chrome-fd-001): HWP 가 아닌 일반 파일 다운로드에는 suggest() 를 호출하지 않아
 //                       Chrome 의 마지막 저장 위치 기억 동작을 보존한다.
 // #207: 판정 로직은 rhwp-shared/sw/download-interceptor-common.js 와 공유.
+// #1131: 로컬 file:// HWP 는 이미 디스크에 있으므로 자체 뷰어로 열 때 중복 다운로드를
+//        억제한다 (cancel + erase, best-effort). 원격(http) 파일은 기존 동작 유지.
 
 import { openViewer } from './viewer-launcher.js';
 import { shouldInterceptDownload } from './download-interceptor-common.js';
 
+/** 다운로드 항목이 로컬 file:// 인지 판별. */
+function isLocalFileDownload(item) {
+  return typeof item?.url === 'string' && item.url.startsWith('file:');
+}
+
 /**
  * 다운로드 인터셉터를 설정한다.
  *
- * - HWP/HWPX 다운로드: handleHwpDownload + suggest 호출 (자체 뷰어 트리거)
+ * - 로컬 file:// HWP: 뷰어를 열고 다운로드는 cancel + erase 로 억제 (#1131)
+ * - 원격 HWP/HWPX 다운로드: handleHwpDownload + suggest 호출 (자체 뷰어 트리거)
  * - 일반 파일: suggest 호출 안 함 → Chrome 의 마지막 저장 위치 기억 동작 유지 (#198)
  */
 export function setupDownloadInterceptor() {
   chrome.downloads.onDeterminingFilename.addListener((item, suggest) => {
     if (shouldInterceptDownload(item)) {
       handleHwpDownload(item);
-      suggest({ filename: item.filename });
+      if (isLocalFileDownload(item)) {
+        // 로컬 파일은 재다운로드 불필요 — suggest 대신 다운로드 항목 취소/삭제 (#1131)
+        suppressLocalDownload(item);
+      } else {
+        suggest({ filename: item.filename });
+      }
     }
     // HWP 가 아니면 suggest 호출하지 않는다 — Chrome 기본 동작 유지 (#198)
   });
+}
+
+/**
+ * 로컬 file:// 다운로드를 취소하고 다운로드 목록에서 제거한다 (#1131, best-effort).
+ *
+ * 로컬 복사는 거의 즉시 완료되어 cancel 이 늦을 수 있으나, erase 로 항목을 정리한다.
+ * 실패해도 뷰어 동작에는 영향이 없으므로 예외는 무시한다.
+ */
+async function suppressLocalDownload(item) {
+  try {
+    await chrome.downloads.cancel(item.id);
+  } catch {
+    // 이미 완료/취소됨 — 무시하고 erase 로 진행
+  }
+  try {
+    await chrome.downloads.erase({ id: item.id });
+  } catch {
+    // 항목 제거 실패는 치명적이지 않음 — 무시
+  }
 }
 
 async function handleHwpDownload(item) {

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -770,6 +770,53 @@ async function loadFromUrlParam(): Promise<void> {
 }
 
 /**
+ * 확장 프로그램의 "파일 URL에 대한 액세스 허용" 권한 상태를 조회한다 (#1131).
+ *
+ * 확장 페이지에서만 의미가 있다. API 부재(비-확장 환경 등) 시 판정 불가로
+ * `null` 을 반환하여 호출부가 기존 동작(일반 에러)으로 폴백하도록 한다.
+ *
+ * @returns 허용=true, 미허용=false, 판정 불가=null
+ */
+async function isFileSchemeAccessAllowed(): Promise<boolean | null> {
+  const ext = (typeof chrome !== 'undefined' ? chrome.extension : undefined) as
+    | { isAllowedFileSchemeAccess?: () => Promise<boolean> }
+    | undefined;
+  if (!ext?.isAllowedFileSchemeAccess) return null;
+  try {
+    return await ext.isAllowedFileSchemeAccess();
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * 로컬 file:// 문서를 열 때 "파일 URL 액세스 허용" 권한이 꺼져 있어 로드가
+ * 실패한 경우, 일반 "Failed to fetch" 대신 원인과 해결 방법을 안내한다 (#1131).
+ *
+ * 설정 화면(chrome://extensions/?id=...)은 일반 링크로는 열리지 않으므로
+ * 확장 컨텍스트의 chrome.tabs.create 로 연다.
+ */
+function showFileUrlAccessGuidance(): void {
+  const errMsg = '로컬 파일을 열려면 확장 프로그램의 "파일 URL에 대한 액세스 허용"을 켜야 합니다.\n설정에서 권한을 허용한 뒤 파일을 다시 열어 주세요.';
+  const sb = sbMessage();
+  if (sb) sb.textContent = '파일 로드 실패: 파일 URL 액세스 권한이 필요합니다.';
+  console.error('[main] file:// 로드 실패 — 파일 URL 액세스 미허용 (#1131)');
+  showToast({
+    message: errMsg,
+    durationMs: 0, // 사용자가 읽고 직접 닫기
+    confirmLabel: '확인',
+    action: {
+      label: '설정 열기',
+      onClick: () => {
+        if (typeof chrome !== 'undefined' && chrome.tabs?.create && chrome.runtime?.id) {
+          chrome.tabs.create({ url: `chrome://extensions/?id=${chrome.runtime.id}` });
+        }
+      },
+    },
+  });
+}
+
+/**
  * 파일 로드 실패 시 사용자에게 에러를 명확히 알린다 (#265).
  *
  * 상태 표시줄은 22px 한 줄로 긴 에러 메시지가 ellipsis 로 잘리므로,

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -765,6 +765,14 @@ async function loadFromUrlParam(): Promise<void> {
     assertRemoteDocumentBytes(data, contentType);
     await loadBytes(data, fileName, null);
   } catch (error) {
+    // 로컬 file:// 로드 실패 + "파일 URL 액세스 허용" 미허용 → 전용 안내 (#1131)
+    if (fileUrl.startsWith('file:') && typeof chrome !== 'undefined') {
+      const allowed = await isFileSchemeAccessAllowed();
+      if (allowed === false) {
+        showFileUrlAccessGuidance();
+        return;
+      }
+    }
     showLoadError(error);
   }
 }


### PR DESCRIPTION
## 개요
Closes #1131

로컬 .hwp/.hwpx를 Chrome으로 열면 "Failed to fetch"만 뜨고 문서가 안 보이며 파일이 중복 다운로드되던 문제를 수정한다.

## 근본 원인
- "파일 URL에 대한 액세스 허용" OFF(기본값) 시 뷰어의 `fetch(file://)`가 실패 (`host_permissions: <all_urls>`는 file://를 커버하지 않음). SW 폴백도 file:// 불가.
- `showLoadError`가 원본 에러만 노출 → 원인/해결 안내 부재.
- 로컬 파일인데도 `suggest()`로 다운로드가 그대로 진행.

## 변경
- `rhwp-studio/src/main.ts`: `file://` + `isAllowedFileSchemeAccess()==false` 시 안내 토스트 + "설정 열기" 버튼(`chrome://extensions/?id=...`). 그 외 기존 동작 유지.
- `rhwp-chrome/sw/download-interceptor.js`: `file://` HWP는 `suggest` 대신 `cancel`+`erase`로 중복 다운로드 억제. 원격 http는 기존 동작 유지.

## 검증
- `tsc --noEmit`: 관련 에러 없음 (잔여 2건은 WASM pkg 미빌드, 무관)
- `download-interceptor-common.test.js`: 26/26 통과
- 수동(macOS Chrome): 권한 OFF 안내 표시 / 권한 ON 정상 표시 / 중복 다운로드 없음

## 비고
- 다운로드 억제는 best-effort. Windows Chrome 추가 검증 권장.
- 안내 문구는 한국어 하드코딩(기존 관례). i18n 후속 가능.