### PR TITLE
fix(renderer/table): 표 셀 내 문단 자동번호 누락 정정 — 본문 path 와 정합

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4042,7 +4042,20 @@ impl LayoutEngine {
                 if text.is_empty() {
                     return None;
                 }
-                text
+                // [Task Y-2 공백] Bullet 분기와 동일 패턴 — NumberingHead.text_distance > 0 시
+                // numbering text 와 body 사이 trailing space 추가. 한컴 렌더 룰 정합.
+                // HWP raw level_format 은 "^1." 형식 (공백 미포함). 한컴은 head.text_distance 로
+                // 본문과 간격 자동 추가. rhwp 미적용 시 "1.신뢰받는..." 으로 공백 누락.
+                let has_distance = numbering
+                    .heads
+                    .get(level_idx)
+                    .map(|h| h.text_distance > 0)
+                    .unwrap_or(false);
+                if has_distance {
+                    format!("{} ", text)
+                } else {
+                    text
+                }
             }
             HeadType::Bullet => {
                 // Bullet: numbering_id(1-based)로 Bullet 참조

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -606,10 +606,20 @@ impl LayoutEngine {
                 self.resolve_cell_padding(cell, table);
 
             // 셀 내 문단 레이아웃
-            let composed_paras: Vec<_> = cell
+            // [Task Y-2] head_type=Number/Outline paragraph 의 자동 번호 ("1." 등) 적용.
+            // 본문 paragraph path (layout.rs:2036/2055/2160) 는 호출하나 셀 path 는 호출 안 함.
+            // 결과: 셀 안 head_type=Number paragraph 의 numbering_text 미생성 → "1." 누락.
+            // 본문 path 와 동일 패턴: apply_paragraph_numbering 호출 → 결과 ComposedParagraph
+            // 사용. outline_numbering_id=0 (셀 안 paragraph 는 outline 영역 아님 — Number 타입은
+            // outline_numbering_id 영향 X).
+            let composed_paras: Vec<crate::renderer::composer::ComposedParagraph> = cell
                 .paragraphs
                 .iter()
-                .map(|p| compose_paragraph(p))
+                .map(|p| {
+                    let comp = compose_paragraph(p);
+                    self.apply_paragraph_numbering(Some(&comp), p, styles, 0)
+                        .unwrap_or(comp)
+                })
                 .collect();
 
             // 텍스트 오버플로우 시 좌우 패딩 축소

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1687,10 +1687,17 @@ impl LayoutEngine {
             let (mut pad_left, mut pad_right, pad_top, pad_bottom) =
                 self.resolve_cell_padding(cell, table);
 
-            let mut composed_paras: Vec<_> = cell
+            // [Task Y-2] 본문 표 cell paragraph 의 자동 번호 적용. 본문 paragraph path
+            // (layout.rs:2036/2055/2160) 와 동일 패턴. table_cell_content.rs (embedded table)
+            // 도 동일 fix 적용. 미적용 시 셀 안 head_type=Number paragraph 의 "1." 누락.
+            let mut composed_paras: Vec<crate::renderer::composer::ComposedParagraph> = cell
                 .paragraphs
                 .iter()
-                .map(|p| compose_paragraph(p))
+                .map(|p| {
+                    let comp = compose_paragraph(p);
+                    self.apply_paragraph_numbering(Some(&comp), p, styles, 0)
+                        .unwrap_or(comp)
+                })
                 .collect();
 
             // [Task #1073] 중첩 표 분할 연속 페이지(row_filter sr>0)에서 분할 시작 행보다

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -530,10 +530,15 @@ impl LayoutEngine {
                 self.resolve_cell_padding(cell, table);
 
             // 셀 내 문단 구성
-            let mut composed_paras: Vec<_> = cell
+            // [Task Y-2] 자동 번호 적용 (table_layout.rs / table_cell_content.rs 정합)
+            let mut composed_paras: Vec<crate::renderer::composer::ComposedParagraph> = cell
                 .paragraphs
                 .iter()
-                .map(|p| compose_paragraph(p))
+                .map(|p| {
+                    let comp = compose_paragraph(p);
+                    self.apply_paragraph_numbering(Some(&comp), p, styles, 0)
+                        .unwrap_or(comp)
+                })
                 .collect();
 
             // 텍스트 오버플로우 시 좌우 패딩 축소

--- a/tests/issue_cell_paragraph_numbering.rs
+++ b/tests/issue_cell_paragraph_numbering.rs
@@ -1,0 +1,84 @@
+//! 표 셀 내 문단 자동 번호 (head_type=Number/Outline) 정합 회귀 가드.
+//!
+//! 본문 paragraph path 는 `apply_paragraph_numbering` 을 호출하여
+//! head_type=Number/Outline paragraph 의 "1.", "2." 등 자동 번호를
+//! 생성하지만, 표 셀 paragraph path 3곳은 호출하지 않아 셀 안 paragraph 의
+//! 번호가 누락된다. 본 fix 는 셀 path 3곳 (`table_cell_content.rs`,
+//! `table_layout.rs`, `table_partial.rs`) 에 동일 호출을 추가한다.
+//!
+//! 권위 자료: `pdf/k-water-rfp-2024.pdf` (한글 2024 편집기, 정답지 등급 ★★).
+//! 같은 자료 페이지 18 (파일상 page 20) 예정공정표 28×13 표에서
+//! 한컴은 "1. 서버 클라우드 환경 구축" / "2. 전사 데이터 허브 구축" /
+//! "3. SaaS" 모두 번호 prefix 를 표시한다 (작업지시자 PDF 직접 확인).
+//!
+//! 가드 대상: `samples/hwpx/k-water-rfp.hwpx` 페이지 20 의 셀 안 paragraph
+//! 번호 prefix 존재 여부 — fix 적용 후 SVG 에 "1." / "2." 가 셀 안 line
+//! 시작부에 나타나야 한다.
+
+use rhwp::wasm_api::HwpDocument;
+use std::fs;
+use std::path::Path;
+
+fn render_page_svg(rel: &str, page_idx: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    let doc = HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {}: {:?}", rel, e));
+    doc.render_page_svg_native(page_idx)
+        .unwrap_or_else(|e| panic!("svg {}: {:?}", rel, e))
+}
+
+/// SVG 안에서 단일 문자 `ch` 를 그리는 `<text x="..." y="...">ch</text>` 의 모든
+/// y 좌표를 오름차순으로 반환한다. `<text transform="translate(...)">ch</text>`
+/// 형식(회전·스케일 텍스트)은 명시적 y 속성이 없어 본 가드에서 제외한다.
+fn all_text_y_for(svg: &str, ch: char) -> Vec<f64> {
+    let needle = format!(">{}</text>", ch);
+    let mut ys = Vec::new();
+    let mut cursor = 0usize;
+    while let Some(rel) = svg[cursor..].find(&needle) {
+        let end = cursor + rel;
+        let tag_start = svg[..end]
+            .rfind("<text ")
+            .unwrap_or_else(|| panic!("'{}' 매치 직전 <text 태그 없음", ch));
+        let tag = &svg[tag_start..end];
+        cursor = end + needle.len();
+        // transform 기반 텍스트는 y 속성이 없음 → 본 가드 대상 외, skip.
+        if let Some(y_off) = tag.find(" y=\"") {
+            let y_start = y_off + 4;
+            let y_end = tag[y_start..]
+                .find('"')
+                .unwrap_or_else(|| panic!("'{}' y 속성 종료 따옴표 없음", ch));
+            if let Ok(y) = tag[y_start..y_start + y_end].parse::<f64>() {
+                ys.push(y);
+            }
+        }
+    }
+    ys.sort_by(|a, b| a.partial_cmp(b).unwrap());
+    ys
+}
+
+#[test]
+fn cell_paragraph_number_prefix_appears_in_k_water_rfp_p20() {
+    let svg = render_page_svg("samples/hwpx/k-water-rfp.hwpx", 19);
+
+    // 페이지 20 예정공정표 셀 안 헤딩의 y 좌표(작업지시자 PDF 확인):
+    //   "1. 서버 클라우드 환경 구축"  ≈ y=270
+    //   "2. 전사 데이터 허브 구축"   ≈ y=558
+    // fix 미적용 시 "1." "2." 가 누락되어 셀 안에 단 한 개의 "1." 도 없을 수 있다.
+    // 정합된 fix 적용 후에는 셀 안 두 y 위치(≈270, ≈558) 에 "1." / "2." 가 존재.
+    let dot_ys = all_text_y_for(&svg, '1');
+    let near_270 = dot_ys.iter().any(|&y| (y - 270.0).abs() < 5.0);
+    let two_ys = all_text_y_for(&svg, '2');
+    let near_558 = two_ys.iter().any(|&y| (y - 558.0).abs() < 5.0);
+
+    assert!(
+        near_270,
+        "k-water-rfp.hwpx p20: 표 셀 안 '1.' 헤딩이 y≈270 에 출현해야 한다. \
+         미출현 시 head_type=Number 셀 paragraph 의 자동번호 미적용 결함. \
+         (작업지시자 한컴 2024 PDF 확인 — 한컴 정답에 '1. 서버 클라우드 환경 구축' 존재)"
+    );
+    assert!(
+        near_558,
+        "k-water-rfp.hwpx p20: 표 셀 안 '2.' 헤딩이 y≈558 에 출현해야 한다. \
+         미출현 시 head_type=Number 셀 paragraph 의 자동번호 미적용 결함."
+    );
+}


### PR DESCRIPTION
## 요약

`head_type=Number/Outline` 문단의 자동 번호("1.", "2." 등)가 본문 문단 경로에서는 `apply_paragraph_numbering` 호출로 생성되지만, 표 셀 문단 경로 3곳에서는 동일 호출이 누락되어 셀 안 헤딩의 번호가 사라지는 비대칭 결함을 정정합니다.

## 증상 (samples/hwpx/k-water-rfp.hwpx 페이지 20, 예정공정표 표)

**한컴 정답** — `pdf/k-water-rfp-2024.pdf` 페이지 18:
- "**1.** 서버 클라우드 환경 구축"
- "**2.** 전사 데이터 허브 구축"
- "**3.** SaaS"

세 헤딩 모두 자동 번호 prefix 가 표시됩니다.

**본 PR 적용 전 (upstream/devel)** — 좌: 한컴 / 우: rhwp
<img width="1572" height="723" alt="전!" src="https://github.com/user-attachments/assets/20c55f3f-e66c-4787-96d5-241454961545" />

표 셀 안 헤딩에서 "1.", "2." prefix 가 **완전히 누락**됩니다.

**본 PR 적용 후** — 좌: 한컴 / 우: rhwp

<img width="1601" height="756" alt="후!" src="https://github.com/user-attachments/assets/98ea0c34-ad96-4579-86e0-3c2b8d1411c4" />


한컴 정답과 일치하게 셀 안 헤딩에 번호가 출력됩니다.

## 근본 원인

`apply_paragraph_numbering` 은 본문 문단 경로(`layout.rs`)에서는 항상 호출되지만, 표 셀 문단을 처리하는 경로 3곳(`table_cell_content.rs` / `table_layout.rs` / `table_partial.rs`)에서는 호출되지 않았습니다. `head_type=Number/Outline` 은 문단 위치(본문/셀)와 무관하게 자동 번호가 적용되어야 하므로, 셀 경로의 미호출은 비대칭 결함입니다.

## 변경

| 파일 | 변경 |
|---|---|
| `table_cell_content.rs` | 셀 문단 compose 단계에 `apply_paragraph_numbering` 호출 추가 |
| `table_layout.rs` | 본문 표 셀에 동일 호출 추가 |
| `table_partial.rs` | RowBreak 로 분할된 셀에 동일 적용 |
| `paragraph_layout.rs` | Number/Outline 분기에 `text_distance > 0` 시 trailing space(`"1."` → `"1. "`) 추가 — 기존 Bullet 분기와 동일 패턴 |

## 회귀 가드

`tests/issue_cell_paragraph_numbering.rs` — k-water-rfp.hwpx 페이지 20 셀 안 "1."(y≈270) / "2."(y≈558) 출현을 검증. 미적용 시 해당 위치 문자 부재로 실패합니다.

## 검증

- `cargo fmt --all --check`: clean
- `cargo clippy --lib -- -D warnings`: clean
- `cargo test --lib`: 1405 passed, 0 failed
- `cargo test --test svg_snapshot`: 8/8 (골든 불변)
- 회귀 가드 테스트: passed

## 권위 자료

- `pdf/k-water-rfp-2024.pdf` (한글 2024 편집기 출력, 페이지 18)