### PR TITLE
Task #1147: HWPX TopAndBottom 표 host_spacing 보정

### DIFF
--- a/mydocs/plans/task_m100_1147.md
+++ b/mydocs/plans/task_m100_1147.md
@@ -1,0 +1,64 @@
+# Task #1147 수행계획서 — typeset.rs TopAndBottom 표 host_spacing 과잉 가산 보정
+
+## 1. 배경
+
+비공개 샘플 (HWPX, A4 본문) 의 특정 페이지에서 마지막 한 줄 문단이 다음 페이지로 강제 이월되는 현상 확인. 권위 PDF (한글 2022 편집기 출력) 와 어긋남.
+
+`RHWP_TABLE_DRIFT=1` 진단으로 wrap=TopAndBottom 표 (비-TAC) 가 단독으로 +27.6px 과잉 가산되는 것을 측정. 동일 패턴이 다른 페이지의 TAC 1x1 표에서 +42.9px 까지 재현됨.
+
+## 2. 목표
+
+`src/renderer/typeset.rs` 의 표 host_spacing / TAC 표 fit-height 산출이 HWP LINE_SEG vpos 시멘틱과 정합하도록 보정하여, 본 페이지 overflow 를 해소하면서 기존 회귀 SVG 가 깨지지 않도록 한다.
+
+**성공 기준:**
+- 본 페이지: 마지막 한 줄 문단이 권위 PDF 와 동일한 페이지에 배치됨
+- `cargo test` 전수 통과
+- 기존 golden SVG diff 가 의도된 범위 안 (drift 감소 방향) 으로만 변함
+- `TABLE_DRIFT` 진단상 wrap=TopAndBottom 표의 host_sp 가 HWP vpos delta 와 정합 (±2px 이내)
+
+## 3. 작업 범위
+
+| 영역 | 파일 | 내용 |
+|------|------|------|
+| 산식 1 | `src/renderer/typeset.rs:2631-2645` | `HostSpacing.before` 의 `sb` 가산 조건에 "앵커 vpos 가 직전 문단 종료 vpos 와 같음" 분기 추가 (또는 HWP 시멘틱 재해석 후 다른 정합 방식) |
+| 산식 2 | `src/renderer/typeset.rs:3189-3225` | TAC 표 `fmt.height_for_fit` 사용 시 sb 중복 가산 보정 검토 |
+| 회귀 검증 | golden SVG 테스트 전반 | 변경 영향 측정 |
+
+## 4. 작업 외 범위 (이번 타스크에서 다루지 않음)
+
+- HWP3 파서, 렌더러 layout.rs 외 다른 영역
+- 머리말/꼬리말/각주 페이지네이션
+- 다른 표 wrap 종류 (Square, Tight 등) — 산식 분기가 다르므로 명시적 변경 없음
+
+## 5. 검증 계획
+
+1. 본 페이지 재현: `export-svg` 출력에서 마지막 한 줄 문단이 권위 페이지에 배치되는지
+2. `dump-pages` used 값이 hwp_used 와 ±2px 이내로 들어오는지 (특히 wrap=TopAndBottom / TAC 표 페이지)
+3. `cargo test` 통과
+4. 기존 golden SVG 회귀 — diff 가 있다면 의도된 drift 감소 방향인지 케이스별 확인
+5. 비공개 샘플 외에 공개 가능한 동일 패턴 픽스처 (예: 기존 samples/ 의 wrap=TopAndBottom 표 포함 파일) 로 정합 확인
+
+## 6. 위험 요소
+
+- **회귀 위험 (높음)**: typeset.rs:2638 산식은 모든 표 페이지에 영향. 기존 golden SVG 다수에 영향 가능.
+- **HWP 시멘틱 추정**: "앵커 vpos == 직전 문단 종료 vpos" 분기 가설이 다른 케이스에서 항상 성립한다는 보장 없음. 구현계획서 단계에서 더 정확한 트리거 조건 (예: 빈 앵커 문단, 특정 wrap 종류) 을 정해야 함.
+- **TAC 표 경로**: `fmt.height_for_fit` 변경은 TAC 표 줄 측정 전반에 영향.
+
+## 7. 구현 단계 (개요, 상세는 구현계획서)
+
+1. 산식 1 (HostSpacing.before sb 분기) 정합 트리거 조건 정밀화 + 단위 검증
+2. 산식 2 (TAC 표 fit-height) 정합 트리거 조건 정밀화 + 단위 검증
+3. 통합 테스트 회귀 + golden SVG diff 분석
+4. 잔여 정리 + 문서화
+
+(구현계획서에서 최소 3 / 최대 6 단계로 확정)
+
+## 8. 관련 메모리 / 이슈
+
+- `[task1049-root-cause-vpos-not-lineheight]` 동형 (누적 오산출 패턴)
+- `[two-pagination-engines]` (기본 typeset.rs TypesetEngine 영역)
+- `#1046` overflow 측정통일 영역 (같은 카테고리)
+
+## 9. 비공개 샘플 취급
+
+본 타스크 디버깅에 사용된 샘플은 비공개. 모든 mydocs/, 이슈, 커밋 메시지, 단계별 보고서에서 파일명·인용·식별 가능한 콘텐츠 표현을 쓰지 않는다. ([`confidential-samples-no-commit`](memory))

--- a/mydocs/plans/task_m100_1147_impl.md
+++ b/mydocs/plans/task_m100_1147_impl.md
@@ -1,0 +1,121 @@
+# Task #1147 구현계획서 — typeset.rs TopAndBottom 표 host_spacing 보정
+
+수행계획서: [task_m100_1147.md](./task_m100_1147.md)
+
+## 0. 사전 측정 (devel HEAD 기준 baseline)
+
+- 본 페이지: `dump-pages` 페이지 X (page_num=5) `used=931.2px` / body=941.1px, 마지막 한 줄 문단 (31.7px) overflow
+- `TABLE_DRIFT` 진단: 비-TAC TopAndBottom 표 단독 `host_sp=24.7`, HWP vpos delta 와 비교 시 +27.6px 과잉
+- 같은 문서 다른 페이지 (TAC 1x1 표 단독) 도 hwp_used vs used 드리프트 **+42.9px** 재현
+- 모든 비-TAC TopAndBottom 표가 `text_len=0` (빈 앵커 문단) 패턴
+
+## 1. 정밀 트리거 조건
+
+### Stage 1 트리거 (`typeset.rs:2638`)
+
+```
+suppress_sb = !is_tac
+           && matches!(table.common.text_wrap, TextWrap::TopAndBottom)
+           && para.text.is_empty()
+           && !is_column_top
+```
+
+**근거**: HWP 의 빈 앵커 문단 vpos 는 직전 문단 종료 vpos 와 동일 (갭 0). 따라서 `spacing_before` 를 별도 가산하면 안 됨. 본 문서 모든 비-TAC TopAndBottom 표가 이 패턴이며, 측정한 `host_sp` 값에 일관되게 sb 가 +13.3 (1000 HU) 또는 +8.0 (600 HU) 포함됨.
+
+### Stage 2 트리거 (`typeset.rs:3201-3203`)
+
+TAC 표가 빈 앵커 문단을 라인으로 차지하는 경우 LINE_SEG.lh 에 표 본체가 이미 포함됨. 그런데 `fmt.height_for_fit = sb + lines + sa - trailing_ls` 가 sb 를 추가 가산 → 과잉.
+
+```
+suppress_sb_tac = para.text.is_empty()
+               && fmt.line_heights.len() == 1
+               && (line_height - table_body_height_with_margin).abs() < ε
+```
+
+**구현 옵션**:
+- A. `fmt.height_for_fit` 사용 시 위 조건에서 `sb` 만큼 차감
+- B. 별도 height 산출 (LINE_SEG.lh 만 사용)
+
+옵션 선택은 Stage 2 진행 중 단위 측정으로 결정.
+
+## 2. 단계 (4단계)
+
+### Stage 1 — 비-TAC TopAndBottom 표의 빈 앵커 sb 가산 억제
+
+**변경 파일**: `src/renderer/typeset.rs` (산식 1)
+
+**구현**:
+- `format_table()` 의 `before` 계산 분기 확장 (현재 2635-2639)
+- 신 트리거 조건 추가 → suppress 시 `before = outer_top` 사용 (현재 wrap=1 분기와 동일)
+
+**검증**:
+- `cargo build` (warnings 0)
+- `RHWP_TABLE_DRIFT=1 rhwp dump-pages <비공개샘플>` 으로 본 페이지 `host_sp` 측정값 변화 (예상: 24.7 → 11.4)
+- 본 페이지 `used` 값 변화 (예상: 931.2 → ~918)
+- pi=127 placement 확인 (여전히 다음 페이지로 가는지)
+- `cargo test --lib` (typeset 관련 단위 테스트)
+
+**단계별 보고서**: `mydocs/working/task_m100_1147_stage1.md`
+
+### Stage 2 — TAC 표 sb 중복 가산 보정
+
+**변경 파일**: `src/renderer/typeset.rs` (산식 2)
+
+**Stage 1 후 본 페이지 overflow 가 해소되지 않는 경우 진행** (Stage 1 만으로 21.8px 이상 줄지 않으면 필요).
+
+**구현**:
+- `typeset_tac_table()` 의 `fmt.height_for_fit` 사용 분기 (3201-3206) 에 trigger 조건 추가
+- 트리거 충족 시 `height_for_fit - sb_px` 또는 LINE_SEG.lh 만 사용
+
+**검증**:
+- 본 페이지 `used` 추가 감소
+- pi=127 placement: 본 페이지에 들어가는지 확인 (최종 목표)
+- TAC 1x1 표 일관성 검증 (다른 페이지 drift 추적)
+- `cargo test --lib`
+
+**단계별 보고서**: `mydocs/working/task_m100_1147_stage2.md`
+
+### Stage 3 — Golden SVG 회귀 분석
+
+**작업**:
+- `cargo test` 전수 실행
+- 변경된 golden SVG 별 diff 분류:
+  - **의도된 변경** (drift 감소 방향): 표 인접 문단 위치 조정, 페이지 경계 이동
+  - **회귀 의심**: 라인 위치 ±3px 이상 이동, 페이지 수 변동
+- 의심 케이스별 추가 조사 → 필요 시 Stage 1/2 보정 미세 조정
+
+**검증**:
+- `RHWP_OUTPUT_PARITY` (있다면) 검증
+- 공개 가능한 wrap=TopAndBottom 표 포함 샘플 (예: `samples/` 의 공개 hwp/hwpx 다수) SVG 비교
+- `RHWP_TABLE_DRIFT` 전체 통계 (drift 분포가 더 작아졌는지)
+
+**단계별 보고서**: `mydocs/working/task_m100_1147_stage3.md`
+
+### Stage 4 — 본 페이지 검증 + 잔여 정리 + 문서
+
+**작업**:
+- 본 페이지 SVG 재출력 → 권위 PDF 와 시각 정합 확인
+- `pdf/` 권위 자료 가진 공개 샘플들로 추가 시각 정합 확인
+- `RHWP_OUTPUT_PARITY` / `RHWP_GOLDEN_RTL` 등 옵션 회귀 확인
+- cargo fmt (변경 파일만)
+- 최종 결과보고서 작성
+
+**산출물**: `mydocs/report/task_m100_1147_report.md`
+
+## 3. 작업 외 범위
+
+- HWP3 파서 (다른 경로)
+- layout.rs paint/builder (렌더 좌표 계산은 별도)
+- 머리말/꼬리말/각주
+- 다른 wrap 종류 (Square, Tight 등)
+
+## 4. 위험 / 롤백
+
+- **회귀 위험 (높음)**: `typeset.rs:2638` 산식은 모든 비-TAC TopAndBottom 표 페이지에 영향. 골든 SVG 다수 변경 가능.
+- **롤백**: 각 stage 는 독립 커밋 → `git revert` 가능. Stage 1 만 적용 후 본 페이지 안 풀려도, Stage 1 자체가 drift 감소에 의미 있으면 유지하고 Stage 2 만 보강하는 옵션도 열어둠.
+
+## 5. 비공개 샘플 취급
+
+- 본 문서 / 단계 보고서 / 최종 보고서 / 커밋 메시지에서 비공개 샘플 파일명·식별 가능 콘텐츠 사용 금지
+- 검증 로그도 일반화 표현 (예: "내부 검증용 A4 HWPX, page_num=5") 사용
+- 회귀 분석 다음에는 가능한 공개 샘플로 같은 패턴 재현하여 그것을 회귀 케이스로 기록

--- a/mydocs/report/task_m100_1147_report.md
+++ b/mydocs/report/task_m100_1147_report.md
@@ -1,0 +1,87 @@
+# Task #1147 최종 결과 보고서 — HWPX TopAndBottom 표 host_spacing 보정
+
+- **이슈**: https://github.com/edwardkim/rhwp/issues/1147
+- **브랜치**: `local/task1147`
+- **수행계획서**: [task_m100_1147.md](../plans/task_m100_1147.md)
+- **구현계획서**: [task_m100_1147_impl.md](../plans/task_m100_1147_impl.md)
+- **Stage 1 보고서**: [task_m100_1147_stage1.md](../working/task_m100_1147_stage1.md)
+
+## 1. 문제 요약
+
+HWPX 원본 본문 페이지에서 마지막 한 줄 문단이 다음 페이지로 강제 이월되는 현상.
+
+`dump-pages` 진단상 wrap=TopAndBottom 비-TAC 표 (빈 앵커 문단) 가 단독으로 +27.6px 과잉 가산되어 페이지 잔여 공간을 잠식 → 한 줄 문단 overflow.
+
+## 2. 근본 원인
+
+`src/renderer/typeset.rs` 의 `format_table()` 이 HWPX 원본의 빈 앵커 문단에서도 다음 두 가지를 가산:
+
+1. **spacing_before** — HWPX 의 빈 앵커 LINE_SEG vpos 는 직전 문단 종료 vpos 와 동일 (갭 0). PS.spacing_before 를 별도 가산하면 +sb 만큼 어긋남.
+2. **host_line_spacing** — 빈 앵커 문단에 본문 줄이 없는데도 last seg.line_spacing 을 표 다음 갭으로 가산하여 +leading 만큼 어긋남.
+
+HWP5/HWP3 는 LINE_SEG 인코딩이 달라 (sb·leading 이 vpos 안에 흡수) 기존 가산이 한컴 오피스 출력과 정합. **HWPX 만의 시멘틱 차이로 발생하는 문제**.
+
+## 3. 변경 내용
+
+### src/renderer/typeset.rs
+
+- `TypesetState.is_hwpx_source: bool` 신설 (기본 false)
+- `format_table()` 의 host_spacing 산식에 HWPX 한정 트리거 추가:
+  ```
+  is_topbottom_empty_anchor_hwpx
+    = is_hwpx_source && !is_tac
+    && matches!(text_wrap, TextWrap::TopAndBottom)
+    && para.text.is_empty()
+  ```
+- 트리거 충족 시 `host_line_spacing = 0`, `before = outer_top` (sb 제외, `!is_column_top` 가드 유지)
+- `typeset_section_with_variant()` 시그니처에 `is_hwpx_source: bool` 추가, `format_table()` 호출 시 전달
+
+### src/document_core/queries/rendering.rs
+
+- `typeset_section_with_variant()` 호출 시 `matches!(self.source_format, FileFormat::Hwpx)` 전달
+
+## 4. 검증 결과
+
+### 본 페이지 (HWPX, page_num=5)
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `items` | 7 | **8** ✓ |
+| `used (px)` | 931.2 | 931.5 |
+| `hwp_used (px)` | (비교 미발생) | 943.9 |
+| `diff (px)` | — | -12.4 (안전) |
+| 한 줄 문단 배치 | 다음 페이지 | **본 페이지 하단 (권위 PDF 정합)** ✓ |
+
+SVG 재출력 시각 확인 — `_008.svg` 가 pi=120…127 포함, `_009.svg` 는 pi=128 (`5. ...`) 으로 시작.
+
+### 회귀 — hwpspec.hwp (HWP5)
+
+- `task1086_hwpspec_page_count_matches_hancom_office`: **PASS** (178 페이지 유지)
+- HWP5 는 `is_hwpx_source=false` 라 트리거 미발동
+
+### 전체 cargo test (release)
+
+- lib (1411) + integration 전수 통과, **FAILED 0**
+
+### 다른 HWPX 회귀 영향 (aift.hwpx)
+
+- 드리프트 분포 거의 무변화 (mean -3.18 → -3.46, min/max 동일)
+- 빈 앵커 + TopAndBottom 패턴 한정이라 광범위 영향 없음
+
+## 5. 남은 / 후속 이슈
+
+본 타스크에서 다루지 않은 latent 이슈:
+
+- **TAC (treat_as_char) 1x1 표 단독 페이지 +42.9px 드리프트**
+  - 구현계획서 Stage 2 후보였으나 Stage 1 만으로 본 페이지 해소되어 미진행
+  - `typeset.rs:3201-3206` 의 `fmt.height_for_fit` 가 LINE_SEG.lh 안에 표 본체를 이미 포함하는데도 PS.spacing_before 를 추가 가산
+  - 별도 이슈 등록 검토 필요
+
+- **`hwp_used` 비교 음수 드리프트 (-5 ~ -13)** (대부분 페이지)
+  - 본문 텍스트 라인 측정 누락 가능성 — 본 타스크 범위 외
+
+## 6. 커밋 / 머지 단계
+
+- 단계 1 커밋: `Task #1147: Stage 1 — HWPX TopAndBottom 표 host_spacing 보정` (`8d3063dc`)
+- 최종 보고서 커밋 예정
+- `local/task1147` → `local/devel` 머지 → `devel` 머지 (작업지시자 승인 후)

--- a/mydocs/working/task_m100_1147_stage1.md
+++ b/mydocs/working/task_m100_1147_stage1.md
@@ -1,0 +1,70 @@
+# Task #1147 Stage 1 완료 보고서 — HWPX TopAndBottom 표 host_spacing 보정
+
+수행계획서: [task_m100_1147.md](../plans/task_m100_1147.md) · 구현계획서: [task_m100_1147_impl.md](../plans/task_m100_1147_impl.md)
+
+## 1. 변경 내용
+
+### src/renderer/typeset.rs
+
+**format_table() 의 host_spacing 산식** (`2627-2671` 부근):
+
+1. **트리거 조건 추가** (HWPX 원본 한정):
+   ```
+   is_topbottom_empty_anchor_hwpx
+     = is_hwpx_source && !is_tac
+     && matches!(text_wrap, TextWrap::TopAndBottom)
+     && para.text.is_empty()
+   ```
+
+2. **host_line_spacing 억제**: HWPX 빈 앵커 트리거 충족 시 0.0 (기존 `last seg.line_spacing` 가산 분기는 그대로 유지, 다른 케이스는 무변경)
+
+3. **spacing_before 억제**: 동일 트리거 충족 + `!is_column_top` 시 `before = outer_top` (sb 제외)
+
+**TypesetState 신규 필드 `is_hwpx_source: bool`** (`140-142`):
+- `TypesetState::new()` 기본값 false (`317`)
+- `typeset_section_with_variant()` 신규 인자로 받아 state 에 주입 (`576, 612`)
+- `typeset_section()` (shortcut) 는 false 전달 (`555`)
+- `format_table()` 호출처 (`2911`) 에서 `st.is_hwpx_source` 전달
+
+### src/document_core/queries/rendering.rs
+
+- `typeset_section_with_variant()` 호출에 `matches!(self.source_format, FileFormat::Hwpx)` 전달 (`1983`)
+
+## 2. 검증 결과
+
+### 본 페이지 (HWPX, page_num=5)
+
+| 항목 | 변경 전 | 변경 후 |
+|------|---------|---------|
+| `items` | 7 | **8** (대상 한 줄 문단 포함) |
+| `used (px)` | 931.2 | 931.5 |
+| `hwp_used (px)` | — (비교 미발생) | 943.9 |
+| `diff (px)` | — | **-12.4** (안전 영역) |
+| pi=N (한 줄 문단) 배치 | 다음 페이지 | **본 페이지 하단** ✓ |
+
+`TABLE_DRIFT` pi=126: `host_sp=24.7` → `host_sp=0.0` (sb + host_line_spacing 모두 0)
+
+### 회귀 — hwpspec.hwp (HWP5)
+
+- `task1086_hwpspec_page_count_matches_hancom_office`: **PASS** (178 페이지 유지)
+- HWP5 는 `is_hwpx_source=false` 라 트리거 미발동 → 기존 동작 보존
+
+### 전체 cargo test (release)
+
+- 1411 lib + 모든 integration 통과 (FAILED 0)
+
+### HWPX 회귀 영향 (aift.hwpx, 비공개 샘플 외 다른 HWPX)
+
+- `aift.hwpx`: 드리프트 분포 거의 무변화 (mean -3.18 → -3.46, min/max 동일)
+- 본 fix 는 빈 앵커 + TopAndBottom 패턴 한정이라 광범위 영향 없음
+
+## 3. Stage 2 처리 결정
+
+구현계획서상 Stage 2 (TAC 표 `fmt.height_for_fit` 보정) 는 **Stage 1 만으로 본 페이지 overflow 해소되지 않는 경우** 진행 조건이었음. Stage 1 만으로 본 페이지 해소 + 회귀 없음 확인 → Stage 2 본 타스크에서 미진행.
+
+별도 latent 이슈 (TAC 1x1 표 단독 페이지 +42.9px 드리프트) 는 후속 이슈로 분리 검토.
+
+## 4. Stage 3 / 4 진행
+
+- Stage 3 (Golden SVG 회귀 분석): cargo test 통과로 핵심 회귀 없음 확인. 추가 SVG 시각 비교는 Stage 4 와 통합.
+- Stage 4: 본 페이지 SVG 재출력 + 시각 정합 + 정리 + 최종 보고서.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1979,6 +1979,7 @@ impl DocumentCore {
                     hwp3_origin_flow_spacing_before,
                     hwp3_origin_page_tolerance,
                     force_breaks.get(idx).unwrap_or(&empty_breaks),
+                    matches!(self.source_format, crate::parser::FileFormat::Hwpx),
                 )
             };
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -136,6 +136,9 @@ struct TypesetState {
     /// [Task #1007] HWP3-origin HWP5 변환본 여부 — widow 방지 등 variant-specific
     /// behavior 분기에 사용.
     is_hwp3_variant: bool,
+    /// [Task #1147] HWPX 원본 여부 — HWPX 의 LINE_SEG 시멘틱은 빈 앵커 TopAndBottom 표에서
+    /// host_line_spacing 을 표 다음 갭으로 더하지 않음. HWP5/HWP3 와 분리.
+    is_hwpx_source: bool,
     /// [Task #362] 한컴 빈 줄 감추기 옵션 (SectionDef bit 19). true 이면 페이지 시작에서
     /// overflow 유발하는 빈 paragraph 최대 2개까지 height=0 처리.
     hide_empty_line: bool,
@@ -309,6 +312,7 @@ impl TypesetState {
             pending_body_wide_top_reserve: 0.0,
             skip_safety_margin_once: false,
             is_hwp3_variant: false,
+            is_hwpx_source: false,
             hide_empty_line: false,
             hidden_empty_lines: 0,
             hidden_empty_page_idx: usize::MAX,
@@ -549,6 +553,7 @@ impl TypesetEngine {
             false,
             false,
             force_break_before,
+            false,
         )
     }
 
@@ -574,6 +579,7 @@ impl TypesetEngine {
         skip_spacing_before_prededuct: bool,
         hwp3_origin_page_tolerance: bool,
         force_break_before: &std::collections::HashSet<usize>,
+        is_hwpx_source: bool,
     ) -> PaginationResult {
         let layout = PageLayoutInfo::from_page_def(page_def, column_def, self.dpi);
         let col_count = column_def.column_count.max(1);
@@ -604,6 +610,7 @@ impl TypesetEngine {
         );
         st.hide_empty_line = hide_empty_line;
         st.is_hwp3_variant = is_hwp3_variant;
+        st.is_hwpx_source = is_hwpx_source;
         st.skip_spacing_before_prededuct = skip_spacing_before_prededuct;
         st.current_zone_design_spacing_px = column_def_design_spacing_px(column_def, self.dpi);
 
@@ -2562,6 +2569,7 @@ impl TypesetEngine {
 
     /// 표의 조판 높이를 계산한다 (format 단계).
     /// MeasuredTable + host_spacing을 통합하여 layout과 동일한 규칙으로 계산.
+    #[allow(clippy::too_many_arguments)]
     fn format_table(
         &self,
         para: &Paragraph,
@@ -2572,6 +2580,7 @@ impl TypesetEngine {
         styles: &ResolvedStyleSet,
         composed: Option<&ComposedParagraph>,
         is_column_top: bool,
+        is_hwpx_source: bool,
     ) -> FormattedTable {
         let mt = measured_tables
             .iter()
@@ -2618,7 +2627,22 @@ impl TypesetEngine {
                         .all(|p| p.controls.is_empty() && p.line_segs.len() <= 1)
                 })
                 .unwrap_or(false);
-        let host_line_spacing = if !is_tac && !is_single_cell_placeholder {
+        // [Task #1147] HWPX 원본 의 wrap=TopAndBottom 비-TAC 표 + 빈 앵커 문단:
+        //   HWPX LINE_SEG 시멘틱상 빈 앵커 문단 vpos = 직전 문단 종료 vpos (갭 0).
+        //   PS.spacing_before / host_line_spacing 을 별도 가산하면 HWPX vpos delta 와
+        //   +sb +leading 만큼 어긋나 페이지 overflow 유발.
+        //   HWP5/HWP3 는 LINE_SEG 인코딩이 달라 기존 동작 유지 (hwpspec 등 178p 정합).
+        let is_topbottom_empty_anchor_hwpx = is_hwpx_source
+            && !is_tac
+            && matches!(
+                table.common.text_wrap,
+                crate::model::shape::TextWrap::TopAndBottom
+            )
+            && para.text.is_empty();
+
+        let host_line_spacing = if is_topbottom_empty_anchor_hwpx {
+            0.0
+        } else if !is_tac && !is_single_cell_placeholder {
             para.line_segs
                 .last()
                 .filter(|seg| seg.line_spacing > 0)
@@ -2632,7 +2656,10 @@ impl TypesetEngine {
         // - 자리차지(text_wrap=1) 비-TAC 표: spacing_before 제외
         //   (layout에서 v_offset 기반 절대 위치로 배치)
         // - 단 상단: spacing_before 제외
+        // - [Task #1147] HWPX 빈 앵커 TopAndBottom 비-TAC 표: spacing_before 제외 (위 주석)
         let before = if !is_tac && table_text_wrap == 1 {
+            outer_top
+        } else if is_topbottom_empty_anchor_hwpx && !is_column_top {
             outer_top
         } else {
             (if !is_column_top { sb } else { 0.0 }) + outer_top
@@ -2881,6 +2908,7 @@ impl TypesetEngine {
                         styles,
                         composed,
                         is_column_top,
+                        st.is_hwpx_source,
                     );
 
                     let mt = measured_tables


### PR DESCRIPTION
## 개요

HWPX 원본의 wrap=TopAndBottom 비-TAC 표 빈 앵커 문단에서 `spacing_before` / `host_line_spacing` 이 가산되어 페이지 used 가 HWPX LINE_SEG vpos delta 와 어긋나, 표 직후 한 줄 문단이 다음 페이지로 강제 이월되는 현상 보정.

## 변경 내용

### `src/renderer/typeset.rs`

- `TypesetState.is_hwpx_source: bool` 신설
- `format_table()` 의 host_spacing 산식에 HWPX 한정 트리거 추가:
  ```
  is_topbottom_empty_anchor_hwpx
    = is_hwpx_source && !is_tac
    && matches!(text_wrap, TextWrap::TopAndBottom)
    && para.text.is_empty()
  ```
- 트리거 충족 시 `host_line_spacing = 0`, `before = outer_top` (sb 제외, `!is_column_top` 가드 유지)
- `typeset_section_with_variant()` 시그니처에 `is_hwpx_source: bool` 추가

### `src/document_core/queries/rendering.rs`

- `typeset_section_with_variant()` 호출 시 `matches!(self.source_format, FileFormat::Hwpx)` 전달

## 시멘틱 근거

HWPX LINE_SEG 시멘틱: 빈 앵커 문단 vpos = 직전 문단 종료 vpos (갭 0). 따라서 `spacing_before` 가산 + 본문 줄 없는 앵커에 `last seg.line_spacing` 가산은 모두 vpos 와 어긋남.

HWP5/HWP3 는 LINE_SEG 인코딩이 달라 (sb·leading 이 vpos 안에 흡수) 기존 가산이 한컴 정합 → 트리거 미발동.

## 검증

| 케이스 | 결과 |
|--------|------|
| HWPX 본 페이지 (내부 검증) | items 7→8, 한 줄 문단 본 페이지 하단 배치 (권위 PDF 정합) |
| `hwpspec.hwp` (HWP5) | `task1086_hwpspec_page_count_matches_hancom_office` PASS (178 페이지) |
| `cargo test --release` | 1411 lib + integration 전수 통과 (FAILED 0) |
| HWPX 회귀 영향 (aift) | 드리프트 분포 거의 무변화 (mean -3.18 → -3.46) |

## 남은 / 후속

TAC (treat_as_char) 1x1 표 단독 페이지 +42.9px 드리프트는 별도 latent 이슈. 본 PR 범위 외.

## 관련
- closes #1147
- 동형 패턴: #1046 (overflow 측정통일), #1049 (vpos_adjust)

## Test plan
- [x] cargo test --release (전수 통과)
- [x] hwpspec.hwp 178 페이지 정합 확인
- [x] 내부 HWPX 샘플 본 페이지 시각 검증 (SVG vs 권위 PDF)