### PR TITLE
Task #1151: rhwp-studio 표 셀 안 이미지 삽입 (floating picture 방식)

### DIFF
--- a/mydocs/plans/task_m100_1151.md
+++ b/mydocs/plans/task_m100_1151.md
@@ -1,0 +1,98 @@
+# Task #1151 수행계획서 — 표 셀 내 이미지 삽입: floating picture 방식
+
+## 1. 배경
+
+rhwp-studio 에서 표 셀 안에 커서를 두고 이미지를 삽입하면, 이미지가 **항상 표 밖 본문 문단**에 배치된다. 한컴 2022 는 동일 조작이 표 셀 영역에 이미지를 정상 배치한다.
+
+### 한컴 패턴 분석 (사용자 검증 샘플)
+
+`incellpicture.hwp` (사용자가 한컴에서 직접 표 + 이미지 삽입한 산출물) dump 결과:
+
+```
+[2] 표: 2행×2열, 셀=4 — 셀들은 모두 비어있음 (paras=1, ctrls=0, text="")
+[3] 그림: tac=false 배치=어울림 (wrap=Square)
+        horz_rel_to=Paper offset=11845 align=Left
+        vert_rel_to=Paper offset=15595 align=Top
+```
+
+→ 한컴은 **floating picture (`tac=false`, wrap=Square, Paper-relative offset)** 를 표와 같은 paragraph 의 sibling control 로 삽입한다. 셀 자체는 비어있다.
+
+### 비교: 인라인 셀 picture (사전 검증)
+
+`samples/pic-in-table-01.hwp` page 22 의 inline picture (tac=true, 셀 paragraph 내부) 는 동일 rhwp-studio 환경에서 **클릭 시 cursor 이동이 안 되는 동일 증상** 발생 (picture 선택 모드 진입). 즉 inline 셀 picture 는 한컴/rhwp 모두 "cursor 진입 안 됨" 이 본래 동작. floating 이 한컴 기본 패턴.
+
+### 선행 작업
+
+#194 (CLOSED, 2026-04-19 작성자 철회) 와 PR #1150 (#1138 셀 안 도형 속성 편집, 머지 완료) 가 인접 영역. PR #1150 의 커밋 `50bc6d2a` 정리: picture 의 셀 내부 정보는 `paragraph_layout.rs` 의 TAC inline picture 사이트가 ImageNode 의 section/para/control 을 채워 외부 좌표 path 로 처리하므로 별도 cellPath 분기 불필요. **본 task 의 결함은 inline 삽입이 아니라 floating 미지원 의 결과.**
+
+## 2. 목표
+
+`insert_picture_native` 가 표 셀 컨텍스트에서 호출될 때, 한컴 패턴 (floating picture, Paper-relative 좌표) 으로 삽입하여 셀 클릭성 보존 + 시각적으로 셀 영역에 배치.
+
+### 성공 기준
+
+- 신규 문서 → 표 생성 → 셀 안 커서 → 이미지 삽입 시 picture 가 셀 영역에 floating 으로 배치됨
+- 삽입 직후 다른 셀 / 본문 클릭 시 cursor 정상 이동 (#1151 핵심 결함 해소)
+- 본문 (cell_path 없음) 이미지 삽입 회귀 없음
+- `cargo test` 전수 통과 + `cargo clippy --lib -- -D warnings` 무경고
+- 한컴 2022 산출물 (`incellpicture.hwp`) 와 구조적으로 정합 (tac=false, Paper-relative offset)
+
+## 3. 작업 범위
+
+| Layer | 파일 | 변경 |
+|---|---|---|
+| Rust API | `src/document_core/commands/object_ops.rs` (`insert_picture_native`) | `cell_path: &[(usize,usize,usize)]` 인자 추가. 비어있지 않으면 floating 분기 진입 |
+| Rust 좌표 계산 | (object_ops.rs 또는 helpers) | 표 셀 paragraph 내 render bbox 조회 → page 좌표 → Paper-offset 환산 |
+| Rust WASM export | `src/wasm_api.rs` | `insertPicture` 시그니처에 `cell_path_json: &str` 추가 |
+| TS bridge | `rhwp-studio/src/core/wasm-bridge.ts` | `insertPicture` 래퍼에 `cellPathJson` 인자 노출 |
+| TS handler | `rhwp-studio/src/engine/input-handler-table.ts` (`finishImagePlacement`) + `input-handler-keyboard.ts` (paste) | hit / cursor 의 cellPath 추출 → bridge 로 전달 |
+| 테스트 | `src/document_core/commands/object_ops.rs` 내 `#[cfg(test)] mod` | 셀 안 floating 삽입 정합 단위 테스트 |
+
+### 재사용 자산
+- `cursor_nav.rs` 의 `parse_cell_path`, `resolve_cell_by_path`, `resolve_table_by_path` (devel 에 이미 존재)
+- 표 셀 bbox 조회는 `get_table_cell_bboxes_by_path_native` 패턴 참조
+
+## 4. 작업 외 범위
+
+- 한컴 Automation `InsertPicture` 의 `sizeoption`/`reverse`/`watermark`/`effect` 옵션 — 후속 타스크
+- Inline 셀 picture (tac=true) 와 floating 의 사용자 선택 옵션 — 본 PR scope 외 (한컴 기본 floating 만)
+- 중첩 표(셀 안 표) N-depth — 1-level 우선
+- 셀 안 도형(shape) 삽입 — picture 한정
+
+## 5. 검증 계획
+
+1. **Rust 단위 테스트** (`tests/issue_1151_cell_picture_insert_tests`)
+   - 1×1 표 셀에 picture 삽입 → section.paragraphs 의 table 같은 paragraph 에 Control::Picture 가 sibling 으로 존재 + `picture.common.treat_as_char == false`
+   - 본문 picture 삽입 (cell_path=&[]) → 기존 inline 동작 회귀
+   - 잘못된 cell_path → Err 반환
+2. **시각/UX 검증** (browser 수동)
+   - 표 셀에 이미지 삽입 → 이미지가 셀 영역에 표시 + 다른 셀 클릭 시 cursor 이동
+3. **구조 정합 검증**
+   - 삽입 결과 doc 의 picture control 속성이 `incellpicture.hwp` 와 동일 패턴 (tac=false, horz_rel_to=Paper, wrap=Square)
+4. **자동 회귀**
+   - `cargo test`, `cargo clippy --lib -- -D warnings`, `cargo fmt --all -- --check`
+   - WASM 빌드 + rhwp-studio `npx tsc --noEmit`
+
+## 6. 위험 요소
+
+- **회귀 위험 (낮음~중간)**: `insert_picture_native` 시그니처 확장은 추가 인자라 본문 호출은 빈 cell_path 로 호환. WASM 시그니처 변경 시 호출부 동기.
+- **좌표 계산**: 셀의 page 좌표를 얻으려면 layout/render tree 가 이미 빌드되어 있어야 함. 신규 표 직후 바로 picture 삽입하는 시나리오에서 layout 이 준비된 상태인지 확인 필요. 실패 시 fallback (현재 표가 있는 paragraph 의 0,0 offset 등).
+- **paper / page / column 단위**: `incellpicture.hwp` 는 horz/vert_rel_to=Paper. Page 와 Paper 차이 (머리말 등 영향) 가능성. 기본은 Paper.
+
+## 7. 구현 단계 (개요, 상세는 구현계획서)
+
+1. **Stage A** — Rust `insert_picture_native` floating 분기 + 셀 좌표 조회 helper + WASM export + 단위 테스트
+2. **Stage B** — TS bridge `insertPicture` 시그니처 확장 + `finishImagePlacement` / paste 핸들러에서 cellPath 전달
+3. **Stage C** — WASM 빌드 + 브라우저 수동 검증 + 회귀 + 최종 보고서 + PR
+
+(구현계획서에서 단계 세분화)
+
+## 8. 관련 이슈
+
+- #194 (CLOSED, 철회) — 동일 주제 선행 설계 (inline 접근)
+- #1138 (MERGED, PR #1150) — 셀 안 도형 속성 편집. 인접 영역
+- #1152 (MERGED) — TAC 표 vpos-reset 가드 (devel 최신)
+
+## 9. 외부 컨트리뷰터 패턴 정합
+
+johndoekim Fork → `local/task1151` → upstream `edwardkim:devel` PR. CONTRIBUTING.md "Fork & PR 워크플로우" 준수.

--- a/mydocs/plans/task_m100_1151_impl.md
+++ b/mydocs/plans/task_m100_1151_impl.md
@@ -1,0 +1,116 @@
+# Task #1151 구현계획서 — Floating picture 방식
+
+수행계획서: [task_m100_1151.md](task_m100_1151.md)
+
+## 0. 설계 결정
+
+### 0-1. cell_path 전달 방식 (WASM)
+- `cell_path_json: &str` — wasm_api.rs 의 9개 셀 API 와 동일 패턴 (`controlIndex/cellIndex/cellParaIndex` long form). devel 에 이미 존재하는 `parse_cell_path` 재사용.
+
+### 0-2. Picture 속성 (floating, 한컴 정합)
+- `treat_as_char = false`
+- `horz_rel_to = Page` (Paper 와 거의 동등, 단순화 위해 Page 사용; section 의 page_def 기준)
+- `vert_rel_to = Page`
+- `text_wrap = Square` (어울림)
+- `horizontal_offset / vertical_offset` = 셀의 page bbox 좌상단 (HWPUNIT)
+- z_order 는 기존 패턴 (1+ 적절히)
+
+### 0-3. 셀 좌표 조회
+- `cursor_rect.rs:get_table_cell_bboxes_by_path_native` 패턴 차용 — render tree 에서 cell bbox 를 page-relative px 로 얻음
+- px → HWPUNIT 환산: `× 75` (1px = 75 HWPUNIT at 96 DPI)
+- 신규 helper: `compute_cell_page_offset` (object_ops.rs 내부) 또는 인라인
+
+### 0-4. 삽입 위치 (section.paragraphs 중 어디에)
+- `incellpicture.hwp` 분석: table 과 같은 paragraph (section.paragraphs[0]) 의 sibling control 로 삽입됨 (인덱스는 table 다음)
+- 우리 코드: parent_para_idx (= 표가 들어있는 paragraph) 의 controls 마지막에 picture 를 append. ctrl_data_records 도 동기.
+
+### 0-5. 본문 vs 셀 분기
+- `cell_path.is_empty()` → 기존 inline 본문 삽입 (변경 없음)
+- `cell_path` 있음 → 신규 floating 분기
+
+---
+
+## Stage A — Rust `insert_picture_native` floating 분기 + WASM export + 테스트
+
+### A-1. helper 추가 (object_ops.rs 내부)
+`compute_cell_page_bbox(section_idx, parent_para_idx, cell_path) -> Option<(i32 offset_x_hu, i32 offset_y_hu)>`
+- `build_page_tree` 순회 (모든 페이지) → TableCell 매칭 → bbox.x/y 추출 → ×75 환산
+- 매칭 실패 시 None (호출 측은 fallback 으로 0,0)
+
+### A-2. insert_picture_native 시그니처 확장
+```rust
+pub fn insert_picture_native(
+    &mut self,
+    section_idx: usize,
+    para_idx: usize,
+    char_offset: usize,
+    cell_path: &[(usize, usize, usize)],  // 신규
+    image_data: &[u8], width: u32, height: u32,
+    natural_width_px: u32, natural_height_px: u32,
+    extension: &str, description: &str,
+) -> Result<String, HwpError>
+```
+- 본문 (`cell_path.is_empty()`): 기존 로직 그대로 (inline tac=true, body paragraph 삽입)
+- 셀 (`!cell_path.is_empty()`): floating 분기
+  - 셀 좌표 조회 (A-1)
+  - Picture 생성 (tac=false, wrap=Square, horz/vert_rel_to=Page, offsets)
+  - `section.paragraphs[parent_para_idx].controls.push(Control::Picture)` + `ctrl_data_records.push(None)` + raw_stream=None
+  - Table.dirty 마킹, mark_section_dirty, paginate_if_needed
+
+### A-3. WASM export 동기
+`src/wasm_api.rs` `insertPicture` 에 `cell_path_json: &str` 추가. 빈 문자열/`"[]"` → 본문, 그 외 `parse_cell_path` → slice.
+
+### A-4. 단위 테스트
+`src/document_core/commands/object_ops.rs` 내 `#[cfg(test)] mod`:
+1. 1×1 표 셀에 picture 삽입 → table 같은 paragraph 에 sibling Control::Picture, picture.common.treat_as_char==false
+2. 본문 picture 삽입 (cell_path=&[]) → 기존 inline 동작 회귀
+3. 잘못된 cell_path → Err
+
+### A-5. 검증
+- `cargo test --lib issue_1151`: GREEN
+- `cargo test --lib`: 회귀 0
+- `cargo clippy --lib -- -D warnings`, `cargo fmt --all -- --check`
+
+---
+
+## Stage B — TS bridge + handler
+
+### B-1. wasm-bridge.ts
+`insertPicture(sec, paraIdx, charOffset, cellPathJson, imageData, ...)` 시그니처 확장. 반환 타입은 기존 본문 패턴 그대로 (`{ok, paraIdx, controlIdx}`).
+
+### B-2. input-handler-table.ts (finishImagePlacement)
+- `hit.cellPath` 존재 시 `JSON.stringify(hit.cellPath)` 와 `hit.parentParaIndex` 사용
+- 본문: 빈 cellPathJson
+
+### B-3. input-handler-keyboard.ts (paste image)
+- `cursor.getPosition()` 의 cellPath 동일 처리
+
+### B-4. 검증
+- `npx tsc --noEmit` (사전 무관 canvaskit 에러 제외)
+- WASM 빌드 (`docker compose --env-file .env.docker run --rm wasm`)
+
+---
+
+## Stage C — 수동 검증 + 회귀 + 최종 보고서 + PR
+
+### C-1. 수동 시나리오
+1. 신규 문서 → 표 (3×3) 만들기 → 셀 클릭 → 이미지 삽입
+2. 이미지가 셀 영역에 floating 으로 표시되는지
+3. **다른 셀 클릭 시 cursor 이동 정상** (#1151 핵심)
+4. 본문 클릭 → 이미지 삽입 (회귀)
+5. Ctrl+V paste 이미지 (셀/본문)
+
+### C-2. 자동 회귀
+- `cargo test`, `cargo clippy --lib -- -D warnings`, `cargo fmt --all -- --check`
+- rhwp-studio `npx tsc --noEmit`
+
+### C-3. 보고서 + PR
+- `mydocs/working/task_m100_1151_stage{1,2,3}.md` (단계별)
+- `mydocs/report/task_m100_1151_report.md` (최종)
+- `git push -u origin local/task1151`
+- `gh pr create --repo edwardkim/rhwp --base devel --head johndoekim:local/task1151 --title "Task #1151: ..."`
+
+---
+
+## 단계별 보고서 위치
+각 Stage 완료 시 `mydocs/working/task_m100_1151_stage{N}.md` 와 함께 커밋.

--- a/mydocs/report/task_m100_1151_report.md
+++ b/mydocs/report/task_m100_1151_report.md
@@ -1,0 +1,132 @@
+# Task #1151 최종 결과 보고서 — 표 셀 안 이미지 삽입 (floating picture)
+
+이슈: [#1151](https://github.com/edwardkim/rhwp/issues/1151)
+브랜치: `local/task1151` → PR 대상 upstream `edwardkim:devel`
+
+수행계획서: [task_m100_1151.md](../plans/task_m100_1151.md)
+구현계획서: [task_m100_1151_impl.md](../plans/task_m100_1151_impl.md)
+단계별 보고서: [Stage 1](../working/task_m100_1151_stage1.md) · [Stage 2](../working/task_m100_1151_stage2.md) · [Stage 3](../working/task_m100_1151_stage3.md)
+
+## 1. 해결한 문제
+
+**현상**: rhwp-studio 에서 표 셀 안에 커서를 두고 이미지를 삽입하면 이미지가 항상 표 밖 본문 문단에 배치됨. 한컴 2022 (incellpicture.hwp 검증) 와 동작 불일치.
+
+**근본 원인**: `insert_picture_native` 가 본문 paragraph 만 받도록 설계되어 표 셀 영역에 picture 를 배치할 경로 부재.
+
+## 2. 한컴 패턴 분석 (incellpicture.hwp dump)
+
+한컴 2022 가 표 셀 안에 picture 를 배치할 때 사용하는 구조:
+
+```
+[2] 표: 셀들은 모두 비어있음 (paras=1, ctrls=0, text="")
+[3] 그림: tac=false (treat_as_char=false)
+        wrap=Square (어울림)
+        horz_rel_to=Paper offset=11845
+        vert_rel_to=Paper offset=15595
+```
+
+→ **floating picture (`tac=false`, wrap=Square, Paper/Page-relative offset)** 를 표와 같은 paragraph 의 sibling control 로 삽입. 셀 자체는 비어있다.
+
+비교: `samples/pic-in-table-01.hwp` page 22 의 inline 셀 picture (tac=true, 셀 paragraph 내부) 는 rhwp/한컴 모두 클릭 시 cursor 진입 불가 — inline 의 본래 동작.
+
+## 3. 변경 내용
+
+### Rust
+
+**`src/document_core/commands/object_ops.rs`** — `insert_picture_native`:
+- 시그니처에 `cell_path: &[(usize, usize, usize)]` 인자 추가.
+- 본문 (`cell_path.is_empty()`): 기존 inline 동작 그대로 (tac=true, pic_para + empty_para 본문에 삽입).
+- 셀 (`cell_path` 있음): **floating picture 분기** — tac=false, wrap=Square, horz/vert_rel_to=Page, offset 은 셀의 render bbox 좌상단 HWPUNIT. Picture 는 표가 들어있는 paragraph 의 sibling control 로 `controls.push()`. 셀 paragraph 는 손대지 않음.
+- 신규 helper `compute_cell_page_offset` (object_ops.rs): render tree 순회 → TableCell 매칭 → bbox.x/y px → ×75 HWPUNIT. 매칭 실패 시 (0, 0) fallback.
+- 셀 분기 사후처리: outer Table.dirty=true + mark_section_dirty + paginate_if_needed.
+
+**`src/wasm_api.rs`** — `insertPicture` WASM export:
+- 시그니처에 `cell_path_json: &str` 추가.
+- 빈 문자열 또는 `"[]"` → 본문 inline. 그 외 → `DocumentCore::parse_cell_path` 파싱 후 native 호출.
+
+### TypeScript
+
+**`rhwp-studio/src/core/wasm-bridge.ts`** — `insertPicture` 래퍼:
+- `cellPathJson: string` 인자 추가. JSDoc 으로 본문 inline vs 셀 floating 분기 명시.
+
+**`rhwp-studio/src/engine/input-handler-table.ts`** — `finishImagePlacement`:
+- `hit.cellPath` 가 있고 `hit.parentParaIndex !== undefined` 이면 outer parentParaIndex + JSON.stringify(cellPath) 전달. 본문 클릭은 기존 paragraphIndex.
+
+**`rhwp-studio/src/engine/input-handler-keyboard.ts`** — Ctrl+V paste 이미지:
+- `cursor.getPosition()` 의 cellPath 검사 후 동일 패턴으로 parentParaIndex + cellPath JSON 전달.
+
+### 테스트
+
+**`src/document_core/commands/object_ops.rs`** 내 `#[cfg(test)] mod issue_1151_cell_picture_insert_tests`:
+
+1. `issue1151_insert_picture_into_table_cell_is_floating_sibling`: 1×1 표 → 셀 안 picture 삽입 → 셀 paragraph controls 비어있음 + table 같은 paragraph 에 sibling Picture 존재 + `picture.common.treat_as_char == false` + `text_wrap == Square` 단언.
+2. `issue1151_insert_picture_body_keeps_existing_inline_behavior`: cell_path=&[] 본문 삽입 → inline (`treat_as_char == true`) 회귀 확인.
+3. `issue1151_invalid_cell_path_returns_error`: 범위 초과 셀 → Err.
+
+TDD RED → GREEN → REFACTOR.
+
+## 4. 검증 결과
+
+| 검증 | 결과 |
+|---|---|
+| `cargo test --lib` | **1425 passed, 0 failed**, 6 ignored |
+| `cargo test --tests` | 통합 그룹 모두 통과 (FAILED 0) |
+| `cargo test --lib issue_1151` | **3 passed, 0 failed** |
+| `cargo clippy --lib -- -D warnings` | **무경고** |
+| `cargo fmt --all -- --check` | **clean** |
+| WASM 빌드 (docker compose) | success |
+| `npx tsc --noEmit` (rhwp-studio) | 본 작업 관련 에러 0 (사전 canvaskit 모듈 부재 에러만 잔존, 무관) |
+| **사용자 시각 검증** | "이게 정답이였음. 잘 된다" ✓ |
+
+## 5. 수동 검증 절차
+
+1. WASM 빌드 후 dev server 기동:
+   ```bash
+   docker compose --env-file .env.docker run --rm wasm
+   cd rhwp-studio && npx vite --port 7700
+   ```
+2. http://localhost:7700 → 신규 문서 → 표 (예: 3×3) 생성
+3. 셀 안 커서 → 메뉴 → 입력 → 그림 → 이미지 파일 선택 → 클릭으로 위치 확정
+4. **기대 결과**: 이미지가 셀 영역에 floating 으로 배치 + **다른 셀/본문 클릭 시 cursor 이동 정상** (#1151 핵심)
+5. 회귀: 본문 클릭 → 이미지 삽입 → 본문에 inline 정상 삽입
+6. Ctrl+V 클립보드 이미지 paste → 셀 안 / 본문 모두 정상
+
+## 6. v1 → v2 설계 전환 기록
+
+v1 (cell_path 로 셀 내부 inline 삽입) 은 한컴 패턴과 불일치 + 사용자 보고된 "셀 클릭 무반응" 결함 재현. 분석 결과 inline 셀 picture 는 한컴 원본 파일 (`pic-in-table-01.hwp` page 22) 에서도 동일한 "클릭 시 cursor 진입 불가" 동작. 한컴이 실제 셀 picture 삽입에 사용하는 방식은 floating (incellpicture.hwp 검증).
+
+v1 진행 중 시도한 fix (segment_width 셀 폭 조정, horz_rel_to=Para, text_wrap=InFrontOfText, Table.dirty, reflow_cell_paragraph 제거 등) 모두 inline 의 구조적 한계 해소 못함 → v2 floating 으로 완전 재설계 후 사용자 검증 통과.
+
+자세한 분석 흐름 + 사용자 incellpicture.hwp 비교는 수행계획서 / 구현계획서 참조.
+
+## 7. 후속 이슈 권고 (본 PR scope 외)
+
+본 task 진행 중 발견된 별개 사안 — 후속 이슈로 분리:
+
+### A. 셀 안 picture 복사 (Ctrl+C) 미지원
+
+- `src/document_core/commands/clipboard.rs:copy_control_native(section_idx, para_idx, control_idx)` 가 outer paragraph controls 만 인덱싱 — 셀 paragraph 내부 picture 의 control_idx 를 받으면 outer 에서 lookup 실패.
+- 영향: HWP 원본 파일의 inline 셀 picture (samples/pic-in-table-01.hwp 등) 복사 불가.
+- 해결 방향: `copy_control_native` 에 cell_path 인자 추가 또는 별도 `copy_control_in_cell_native` 신규.
+- **본 PR 의 floating sibling picture 는 outer 에 직접 위치하므로 영향 없음.**
+
+### B. 한컴 Automation `InsertPicture` 옵션 호환
+
+`sizeoption` / `reverse` / `watermark` / `effect` — #194 에서 제안된 옵션. 본 PR 은 기본 동작만 다룸.
+
+### C. 중첩 표 (N-depth) 셀 picture 삽입
+
+본 PR 은 1-level cell_path 우선. N-depth 의 cell page bbox 계산 + 정합은 후속.
+
+## 8. 커밋 이력 (local/task1151)
+
+| Commit | 내용 |
+|---|---|
+| `a1b60239` | 수행계획서 + 구현계획서 (floating picture 방식) |
+| `e47052c0` | Stage 1 (A): Rust insert_picture_native floating 분기 + WASM export + 테스트 |
+| `5b179e7b` | Stage 2 (B): TS bridge + handler floating 전달 |
+| (Stage 3) | 본 최종 보고서 |
+
+## 9. 외부 컨트리뷰터 패턴 정합
+
+johndoekim Fork → `local/task1151` → upstream `edwardkim:devel` PR. CONTRIBUTING.md "Fork & PR 워크플로우" 준수. 머지 전 `cargo fmt --all -- --check`, `cargo test`, `cargo clippy -- -D warnings` 통과 확인.

--- a/mydocs/working/task_m100_1151_stage1.md
+++ b/mydocs/working/task_m100_1151_stage1.md
@@ -1,0 +1,62 @@
+# Task #1151 Stage 1 (A) 완료 보고서 — insert_picture_native floating 분기 + WASM export
+
+수행계획서: [task_m100_1151.md](../plans/task_m100_1151.md) · 구현계획서: [task_m100_1151_impl.md](../plans/task_m100_1151_impl.md)
+
+## 1. 변경 내용
+
+### src/document_core/commands/object_ops.rs
+- `insert_picture_native` 시그니처에 `cell_path: &[(usize, usize, usize)]` 인자 추가.
+- 본문 / 셀 분기:
+  - `cell_path.is_empty()` → 기존 inline 본문 삽입 (tac=true) 동작 그대로 유지.
+  - `cell_path` 있음 → **floating picture 분기**: 셀의 page 좌표를 조회해 `horz_rel_to=Page`, `vert_rel_to=Page`, `horizontal_offset/vertical_offset` HWPUNIT 으로 환산. Picture 는 표가 들어있는 paragraph 의 sibling control 로 `controls.push()`. tac=false, wrap=Square (어울림), z_order=1.
+- 신규 helper `compute_cell_page_offset(section_idx, parent_para_idx, cell_path) -> (i32, i32)`:
+  - 전 페이지 render tree 순회 → TableCell 매칭 → bbox.x/bbox.y px → ×75 HWPUNIT.
+  - 매칭 실패 시 (0, 0) fallback.
+- 셀 분기 사후처리: outer Table.dirty=true + mark_section_dirty + paginate_if_needed (insert_text_in_cell_native 패턴 정합).
+
+### src/wasm_api.rs
+- `insertPicture` WASM export 시그니처에 `cell_path_json: &str` 추가.
+- 빈 문자열 또는 `"[]"` → 본문 inline. 그 외 → `DocumentCore::parse_cell_path` 파싱 후 native 호출.
+
+### 테스트 (src/document_core/commands/object_ops.rs 내 `#[cfg(test)] mod issue_1151_cell_picture_insert_tests`)
+- `issue1151_insert_picture_into_table_cell_is_floating_sibling`:
+  - 1×1 표 → 셀 안에 picture 삽입 → 셀 paragraph 의 controls 는 비어있음 + table 같은 paragraph 에 sibling Picture 존재 + `picture.common.treat_as_char == false` + `text_wrap == Square` 단언.
+- `issue1151_insert_picture_body_keeps_existing_inline_behavior`:
+  - cell_path=&[] 로 본문 삽입 → body paragraph 에 inline Picture (`treat_as_char == true`) 회귀 확인.
+- `issue1151_invalid_cell_path_returns_error`:
+  - 범위 초과 셀 인덱스 → Err.
+
+## 2. TDD 사이클
+
+| Step | 결과 |
+|------|------|
+| RED | 3 테스트 작성 → 컴파일 에러 (cell_path 인자 부재) ✓ |
+| GREEN | helper + floating 분기 + WASM export 동기 → 3/3 PASS ✓ |
+| REFACTOR | 공통 자원(shape_attr, border, crop, image_attr) 을 분기 위에 추출하여 두 분기에서 공유 |
+
+## 3. 검증 결과
+
+- `cargo test --lib issue_1151`: **3 passed, 0 failed**
+- `cargo test --lib`: **1425 passed, 0 failed, 6 ignored** (회귀 0)
+- `cargo test --tests`: 통합 테스트 그룹 모두 통과
+- `cargo clippy --lib -- -D warnings`: **무경고**
+- `cargo fmt --all -- --check`: **clean** (변경 파일 fmt 적용 후)
+
+## 4. 한컴 정합 검증
+
+`incellpicture.hwp` 의 floating picture 와 동일 패턴:
+- `tac=false` ✓
+- `text_wrap = Square` (어울림) ✓
+- `horz_rel_to = Page`, `vert_rel_to = Page` ✓
+- `horizontal_offset / vertical_offset` 으로 위치 지정 ✓
+- 표가 있는 paragraph 의 sibling control 로 배치 ✓
+
+(한컴 원본은 `horz_rel_to=Paper` 인데 본 구현은 `Page` 로 단순화. Page 와 Paper 의 의미상 차이가 layout 에 영향이 있는지는 Stage C 시각 검증에서 확인.)
+
+## 5. Stage 2 진입 조건
+
+- 시그니처 확정 ✓
+- 본문 회귀 0 ✓
+- 셀 floating 단위 검증 통과 ✓
+
+→ Stage 2 (TS bridge + handler) 진행 가능.

--- a/mydocs/working/task_m100_1151_stage2.md
+++ b/mydocs/working/task_m100_1151_stage2.md
@@ -1,0 +1,28 @@
+# Task #1151 Stage 2 (B) 완료 보고서 — TS bridge + handler floating 전달
+
+수행계획서: [task_m100_1151.md](../plans/task_m100_1151.md) · 구현계획서: [task_m100_1151_impl.md](../plans/task_m100_1151_impl.md) · Stage 1: [task_m100_1151_stage1.md](task_m100_1151_stage1.md)
+
+## 1. 변경 내용
+
+### rhwp-studio/src/core/wasm-bridge.ts
+`insertPicture` 시그니처에 `cellPathJson: string` 인자 추가. 반환 타입은 본문/셀 공통 `{ok, paraIdx, controlIdx}` 유지. JSDoc 으로 본문 inline vs 셀 floating 분기 설명.
+
+### rhwp-studio/src/engine/input-handler-table.ts
+`finishImagePlacement`: hit.cellPath 가 있으면 `parentParaIndex` (= 표가 들어있는 outer paragraph) 와 `JSON.stringify(hit.cellPath)` 를 전달. 본문 클릭은 기존 paragraphIndex / 빈 cellPathJson.
+
+### rhwp-studio/src/engine/input-handler-keyboard.ts
+Ctrl+V paste 이미지 핸들러도 동일 패턴 — `cursor.getPosition()` 의 cellPath 검사 후 parentParaIndex / cellPath JSON 전달.
+
+## 2. 검증 결과
+
+- WASM 빌드: `docker compose --env-file .env.docker run --rm wasm` → success
+- TypeScript: `cd rhwp-studio && npx tsc --noEmit` → **무경고** (사전 무관 canvaskit-wasm 모듈 부재 에러 제외)
+- Stage 1 의 Rust 단위 테스트 GREEN 상태 유지 확인
+
+## 3. Stage 3 진입 조건
+
+- TS bridge cellPath 관통 ✓
+- WASM .d.ts 시그니처 동기 ✓
+- 본문 호출 패턴 유지 (빈 cellPathJson) ✓
+
+→ Stage 3 (브라우저 수동 검증 + 회귀 + 보고서 + PR) 진행 가능.

--- a/mydocs/working/task_m100_1151_stage3.md
+++ b/mydocs/working/task_m100_1151_stage3.md
@@ -1,0 +1,50 @@
+# Task #1151 Stage 3 (C) 완료 보고서 — 시각 검증 + 회귀 검증
+
+수행계획서: [task_m100_1151.md](../plans/task_m100_1151.md) · 구현계획서: [task_m100_1151_impl.md](../plans/task_m100_1151_impl.md) · Stage 1: [task_m100_1151_stage1.md](task_m100_1151_stage1.md) · Stage 2: [task_m100_1151_stage2.md](task_m100_1151_stage2.md)
+
+## 1. 사용자 시각 검증
+
+dev server (http://localhost:7700) 에서 사용자가 직접 시나리오 확인:
+
+1. 신규 문서 → 표 (3×3) 생성
+2. 셀 안 커서 → 이미지 삽입
+3. 결과: 이미지가 셀 영역에 floating 으로 정상 배치
+4. **삽입 직후 셀 클릭 → cursor 이동 정상** (#1151 핵심 결함 해소)
+
+사용자 확인: "이게 정답이였음. 잘 된다"
+
+## 2. 자동 회귀 (Stage 1 시점 + 본 단계 재확인)
+
+- `cargo test --lib`: 1425 passed, 0 failed, 6 ignored
+- `cargo test --tests`: 통합 테스트 그룹 모두 통과
+- `cargo clippy --lib -- -D warnings`: 무경고
+- `cargo fmt --all -- --check`: clean
+- WASM 빌드 (docker compose): success
+- rhwp-studio `npx tsc --noEmit`: 본 작업 관련 에러 0 (사전 canvaskit 에러만 잔존, 무관)
+
+## 3. v1 대비 v2 (현재) 차이
+
+v1 (cell_path 로 inline 셀 내부 삽입) 은 한컴 패턴과 불일치 + 셀 클릭 무반응 발생. v2 는 한컴 incellpicture.hwp 와 정합:
+
+| 항목 | v1 (실패) | v2 (현재) |
+|---|---|---|
+| 셀 안 picture 구조 | inline 셀 내부 (tac=true) | floating sibling (tac=false) |
+| 위치 결정 | 셀 paragraph 내부 | 표 같은 paragraph 의 sibling, horz/vert_rel_to=Page + offset |
+| 셀 자체 상태 | picture 가 들어감 | 비어있음 (한컴 정합) |
+| 셀 클릭 | 무반응 (picture 선택 모드) | cursor 진입 정상 ✓ |
+
+## 4. 후속 이슈로 분리 보류 사항
+
+본 PR scope 외 (별도 이슈 후보):
+
+- 한컴 Automation `InsertPicture` 의 `sizeoption`/`reverse`/`watermark`/`effect` 옵션 — #194 에서 제안된 사양
+- Inline 셀 picture (tac=true, samples/pic-in-table-01.hwp page 22) 의 "클릭 시 cursor 진입 안 됨" 본래 동작 — UX 개선 여지 있으나 본 task 결함과 별개
+- 중첩 표 (N-depth) 셀 안 picture 삽입 — 현재는 1-level cell_path 우선
+
+## 5. PR 준비
+
+- 모든 단계 보고서 + 최종 보고서 작성 완료
+- 빌드 / 테스트 / clippy / fmt 통과
+- 한컴 정합 + 사용자 시각 검증 통과
+
+→ push + PR 생성 가능.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -821,12 +821,23 @@ export class WasmBridge {
     return this.doc.evaluateTableFormula(sec, parentPara, controlIdx, targetRow, targetCol, formula, writeResult);
   }
 
+  /**
+   * 커서 위치에 그림을 삽입한다.
+   *
+   * @param cellPathJson 표 셀 안 삽입 시 cellPath JSON (#1151).
+   *   빈 문자열 또는 `'[]'` 면 본문 inline 삽입 (기존 동작, treat_as_char=true).
+   *   비어있지 않으면 셀 영역에 floating picture 삽입 (한컴 정합, tac=false,
+   *   wrap=Square, Page-relative offset). 셀 자체는 비어있는 채로 유지되어
+   *   클릭 시 cursor 가 정상 동작한다.
+   *   예: `JSON.stringify([{controlIndex:0, cellIndex:2, cellParaIndex:0}])`
+   */
   insertPicture(sec: number, paraIdx: number, charOffset: number,
+                cellPathJson: string,
                 imageData: Uint8Array, width: number, height: number,
                 naturalWidthPx: number, naturalHeightPx: number,
                 extension: string, description: string = ''): { ok: boolean; paraIdx: number; controlIdx: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
-    return JSON.parse(this.doc.insertPicture(sec, paraIdx, charOffset, imageData, width, height, naturalWidthPx, naturalHeightPx, extension, description));
+    return JSON.parse(this.doc.insertPicture(sec, paraIdx, charOffset, cellPathJson, imageData, width, height, naturalWidthPx, naturalHeightPx, extension, description));
   }
 
   // ── 그림 속성 API ─────────────────────────────────────

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1552,9 +1552,13 @@ async function pasteImageFile(this: any, file: File, hasSelection: boolean): Pro
     this.executeOperation({ kind: 'snapshot', operationType: 'pasteImage', operation: (wasm: WasmBridge) => {
       if (hasSelection) this.deleteSelection();
       const p = this.cursor.getPosition();
+      // 표 셀 안 paste (#1151): floating picture 분기 — parentParaIndex + cellPath 전달.
+      const inCell = (p.cellPath?.length ?? 0) > 0 && p.parentParaIndex !== undefined;
+      const paraForCall = inCell ? p.parentParaIndex! : p.paragraphIndex;
+      const cellPathJson = inCell ? JSON.stringify(p.cellPath) : '';
       const result = wasm.insertPicture(
-        p.sectionIndex, p.paragraphIndex, p.charOffset,
-        data, wHwp, hHwp, natW, natH, ext, '',
+        p.sectionIndex, paraForCall, p.charOffset,
+        cellPathJson, data, wHwp, hHwp, natW, natH, ext, '',
       );
       if (result.ok) {
         return {

--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -264,8 +264,13 @@ export function finishImagePlacement(this: any, e: MouseEvent): void {
   if (!hit) { this.cancelImagePlacement(); return; }
 
   const sec = hit.sectionIndex;
-  const paraIdx = hit.paragraphIndex;
+  // 표 셀 안 클릭 (#1151): floating picture 분기를 위해 cellPath 와
+  // parentParaIndex (= 표가 들어있는 outer paragraph) 사용. 본문 클릭은
+  // 기존 paragraphIndex 그대로.
+  const inCell = (hit.cellPath?.length ?? 0) > 0 && hit.parentParaIndex !== undefined;
+  const paraIdx = inCell ? hit.parentParaIndex! : hit.paragraphIndex;
   const charOffset = hit.charOffset;
+  const cellPathJson = inCell ? JSON.stringify(hit.cellPath) : '';
 
   // 크기 결정
   const zoom = this.viewportManager.getZoom();
@@ -302,7 +307,7 @@ export function finishImagePlacement(this: any, e: MouseEvent): void {
 
   // WASM 호출
   try {
-    const result = this.wasm.insertPicture(sec, paraIdx, charOffset, imgData.data, wHwp, hHwp, imgData.naturalWidth, imgData.naturalHeight, imgData.ext, desc);
+    const result = this.wasm.insertPicture(sec, paraIdx, charOffset, cellPathJson, imgData.data, wHwp, hHwp, imgData.naturalWidth, imgData.naturalHeight, imgData.ext, desc);
     if (result.ok) {
       this.eventBus.emit('document-changed');
     }

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -1386,11 +1386,18 @@ impl DocumentCore {
     }
 
     /// 커서 위치에 그림을 삽입한다 (네이티브).
+    ///
+    /// - `cell_path` 가 비어있으면 본문 paragraph 에 inline (treat_as_char=true) 삽입.
+    /// - `cell_path` 가 있으면 표 셀 영역에 floating picture (tac=false, wrap=Square,
+    ///   Page-relative offset) 로 삽입한다. 셀 자체는 비어있는 채로 유지되어 cursor
+    ///   클릭이 정상 동작 (#1151). 한컴 2022 의 셀 이미지 삽입 패턴과 동일
+    ///   (incellpicture.hwp 검증).
     pub fn insert_picture_native(
         &mut self,
         section_idx: usize,
         para_idx: usize,
         char_offset: usize,
+        cell_path: &[(usize, usize, usize)],
         image_data: &[u8],
         width: u32,
         height: u32,
@@ -1424,6 +1431,10 @@ impl DocumentCore {
                 "이미지 데이터가 비어 있습니다".to_string(),
             ));
         }
+        // cell_path 가 있으면 경로가 유효한지 사전 검증.
+        if !cell_path.is_empty() {
+            self.resolve_cell_by_path(section_idx, para_idx, cell_path)?;
+        }
 
         // --- 1. BinDataContent 추가 ---
         let next_id = self.document.bin_data_content.len() as u16 + 1;
@@ -1449,6 +1460,101 @@ impl DocumentCore {
         });
         self.document.doc_info.raw_stream = None; // DocInfo 재직렬화
 
+        // --- 공통 자원 ---
+        let shape_attr = ShapeComponentAttr {
+            original_width: width,
+            original_height: height,
+            current_width: width,
+            current_height: height,
+            local_file_version: 1,
+            render_sx: 1.0,
+            render_sy: 1.0,
+            ..Default::default()
+        };
+        let bx = [0i32, 0, width as i32, 0];
+        let by = [width as i32, height as i32, 0, height as i32];
+        let crop = CropInfo {
+            left: 0,
+            top: 0,
+            right: (natural_width_px * 75) as i32,
+            bottom: (natural_height_px * 75) as i32,
+        };
+        let image_attr = ImageAttr {
+            bin_data_id: next_id,
+            brightness: 0,
+            contrast: 0,
+            effect: ImageEffect::RealPic,
+            external_path: None,
+        };
+
+        if !cell_path.is_empty() {
+            // === 셀 floating picture 분기 (#1151 v2 — 한컴 패턴 정합) ===
+            // Picture 는 표가 들어있는 paragraph 의 sibling control 로 append 된다.
+            // tac=false, wrap=Square (어울림), horz/vert_rel_to=Page, offset 은 셀의 page bbox 좌상단.
+            let (offset_x_hu, offset_y_hu) =
+                self.compute_cell_page_offset(section_idx, para_idx, cell_path);
+
+            // CommonObjAttr (floating):
+            //   bits 3-4=vert_rel_to(1=Page), bits 8-10=horz_rel_to(1=Page),
+            //   bits 15-17=width_criterion(4=Absolute), bits 18-20=height_criterion(2=Absolute),
+            //   bits 21-23=text_wrap(0=Square)
+            let common_attr: u32 = (1 << 3) | (1 << 8) | (4 << 15) | (2 << 18);
+            let common = CommonObjAttr {
+                ctrl_id: 0x67736F20,
+                attr: common_attr,
+                treat_as_char: false,
+                vert_rel_to: VertRelTo::Page,
+                horz_rel_to: HorzRelTo::Page,
+                text_wrap: crate::model::shape::TextWrap::Square,
+                horizontal_offset: offset_x_hu.max(0) as u32,
+                vertical_offset: offset_y_hu.max(0) as u32,
+                width,
+                height,
+                z_order: 1,
+                description: description.to_string(),
+                ..Default::default()
+            };
+            let pic = Picture {
+                common,
+                shape_attr,
+                border_x: bx,
+                border_y: by,
+                crop,
+                image_attr,
+                ..Default::default()
+            };
+
+            // table 같은 paragraph 의 sibling control 로 append.
+            self.document.sections[section_idx].raw_stream = None;
+            let parent = &mut self.document.sections[section_idx].paragraphs[para_idx];
+            let new_ctrl_idx = parent.controls.len();
+            parent.controls.push(Control::Picture(Box::new(pic)));
+            parent.ctrl_data_records.push(None);
+
+            // outer table dirty 마킹 (재측정 유도)
+            let outer_ctrl = cell_path[0].0;
+            if let Some(Control::Table(t)) = self.document.sections[section_idx].paragraphs
+                [para_idx]
+                .controls
+                .get_mut(outer_ctrl)
+            {
+                t.dirty = true;
+            }
+            self.mark_section_dirty(section_idx);
+            self.paginate_if_needed();
+
+            self.event_log.push(DocumentEvent::PictureInserted {
+                section: section_idx,
+                para: para_idx,
+            });
+            return Ok(super::super::helpers::json_ok_with(&format!(
+                "\"paraIdx\":{},\"controlIdx\":{}",
+                para_idx, new_ctrl_idx
+            )));
+        }
+
+        // === 본문 inline picture 분기 (기존 동작 유지) ===
+
         // --- 3. Picture 컨트롤 생성 ---
         // CommonObjAttr: treat_as_char, vert_rel_to=Para, horz_rel_to=Column,
         // width_criterion=absolute(4), height_criterion=absolute(2)
@@ -1466,44 +1572,13 @@ impl DocumentCore {
             ..Default::default()
         };
 
-        let shape_attr = ShapeComponentAttr {
-            original_width: width,
-            original_height: height,
-            current_width: width,
-            current_height: height,
-            local_file_version: 1,
-            render_sx: 1.0,
-            render_sy: 1.0,
-            ..Default::default()
-        };
-
-        // border_x/border_y: 4 꼭짓점 좌표 (x,y 쌍으로 연속 저장)
-        // [tl.x, tl.y, tr.x, tr.y], [br.x, br.y, bl.x, bl.y]
-        let bx = [0i32, 0, width as i32, 0];
-        let by = [width as i32, height as i32, 0, height as i32];
-
-        // crop: 비크롭 시 이미지 원본 범위 (원본 크기 = 디스플레이 크기일 때)
-        // crop: 이미지 원본 픽셀 크기 × 75 (HWPUNIT/pixel at 96DPI)
-        let crop = CropInfo {
-            left: 0,
-            top: 0,
-            right: (natural_width_px * 75) as i32,
-            bottom: (natural_height_px * 75) as i32,
-        };
-
         let pic = Picture {
             common,
             shape_attr,
             border_x: bx,
             border_y: by,
             crop,
-            image_attr: ImageAttr {
-                bin_data_id: next_id,
-                brightness: 0,
-                contrast: 0,
-                effect: ImageEffect::RealPic,
-                external_path: None,
-            },
+            image_attr,
             ..Default::default()
         };
 
@@ -1568,23 +1643,21 @@ impl DocumentCore {
                 .paragraphs
                 .insert(para_idx, pic_para);
             insert_para_idx = para_idx;
+        } else if char_offset > 0 && !para.text.is_empty() {
+            let new_para =
+                self.document.sections[section_idx].paragraphs[para_idx].split_at(char_offset);
+            self.document.sections[section_idx]
+                .paragraphs
+                .insert(para_idx + 1, new_para);
+            self.document.sections[section_idx]
+                .paragraphs
+                .insert(para_idx + 1, pic_para);
+            insert_para_idx = para_idx + 1;
         } else {
-            if char_offset > 0 && !para.text.is_empty() {
-                let new_para =
-                    self.document.sections[section_idx].paragraphs[para_idx].split_at(char_offset);
-                self.document.sections[section_idx]
-                    .paragraphs
-                    .insert(para_idx + 1, new_para);
-                self.document.sections[section_idx]
-                    .paragraphs
-                    .insert(para_idx + 1, pic_para);
-                insert_para_idx = para_idx + 1;
-            } else {
-                self.document.sections[section_idx]
-                    .paragraphs
-                    .insert(para_idx + 1, pic_para);
-                insert_para_idx = para_idx + 1;
-            }
+            self.document.sections[section_idx]
+                .paragraphs
+                .insert(para_idx + 1, pic_para);
+            insert_para_idx = para_idx + 1;
         }
 
         // 그림 아래에 빈 문단 추가
@@ -1632,6 +1705,92 @@ impl DocumentCore {
             "\"paraIdx\":{},\"controlIdx\":0",
             insert_para_idx
         )))
+    }
+
+    /// 표 셀의 page-relative 좌상단 좌표를 HWPUNIT 단위로 계산 (#1151 floating).
+    ///
+    /// render tree 를 순회하여 cell_path 와 매칭되는 TableCell 노드를 찾고
+    /// bbox.x / bbox.y (px) 를 HWPUNIT 으로 환산 (× 75).
+    ///
+    /// 매칭 실패 / 페이지 미빌드 시 (0, 0) fallback — picture 가 페이지 좌상단에
+    /// 떠도 사용자가 드래그로 위치 조정 가능.
+    pub(crate) fn compute_cell_page_offset(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        cell_path: &[(usize, usize, usize)],
+    ) -> (i32, i32) {
+        use crate::renderer::render_tree::{RenderNode, RenderNodeType};
+
+        if cell_path.is_empty() {
+            return (0, 0);
+        }
+
+        fn matches_cell_run(
+            node: &RenderNode,
+            parent_para: usize,
+            path: &[(usize, usize, usize)],
+        ) -> bool {
+            if let RenderNodeType::TextRun(ref tr) = node.node_type {
+                return tr.cell_context.as_ref().is_some_and(|ctx| {
+                    ctx.parent_para_index == parent_para
+                        && ctx.path.len() == path.len()
+                        && ctx
+                            .path
+                            .iter()
+                            .zip(path.iter())
+                            .all(|(a, b)| a.control_index == b.0 && a.cell_index == b.1)
+                });
+            }
+            for child in &node.children {
+                if matches!(child.node_type, RenderNodeType::Table(_)) {
+                    continue;
+                }
+                if matches_cell_run(child, parent_para, path) {
+                    return true;
+                }
+            }
+            false
+        }
+
+        fn find_cell(
+            node: &RenderNode,
+            parent_para: usize,
+            path: &[(usize, usize, usize)],
+        ) -> Option<(f64, f64)> {
+            if let RenderNodeType::Table(_) = node.node_type {
+                if matches_cell_run(node, parent_para, path) {
+                    let target_cell = path.last().unwrap().1;
+                    for child in node.children.iter() {
+                        if let RenderNodeType::TableCell(ref tc) = child.node_type {
+                            if tc.model_cell_index == Some(target_cell as u32) {
+                                return Some((child.bbox.x, child.bbox.y));
+                            }
+                        }
+                    }
+                }
+            }
+            for child in &node.children {
+                if let Some(found) = find_cell(child, parent_para, path) {
+                    return Some(found);
+                }
+            }
+            None
+        }
+
+        let total_pages = self.page_count();
+        for p in 0..total_pages {
+            if let Ok(tree) = self.build_page_tree(p) {
+                if let Some((px, py)) = find_cell(&tree.root, parent_para_idx, cell_path) {
+                    // px → HWPUNIT (1px = 75 HWPUNIT at 96 DPI 가정).
+                    // 단, section_idx 가 의미 있는 단위 정합을 위해 section 자체의
+                    // 보정은 호출 측 (Picture.horz/vert_rel_to=Page) 가 처리.
+                    let _ = section_idx;
+                    return ((px * 75.0) as i32, (py * 75.0) as i32);
+                }
+            }
+        }
+        (0, 0)
     }
 
     /// 표의 모든 셀 bbox를 반환한다 (네이티브).
@@ -5502,5 +5661,181 @@ impl crate::document_core::DocumentCore {
             "\"controlIdx\":{}",
             insert_idx
         )))
+    }
+}
+
+#[cfg(test)]
+mod issue_1151_cell_picture_insert_tests {
+    //! Issue #1151: 표 셀 안 이미지 삽입이 항상 표 밖 본문 문단에 들어가는 결함.
+    //!
+    //! v2 설계 — 한컴 정합 floating picture 접근:
+    //! 셀 안 삽입 (cell_path 비어있지 않음) 시 picture 는 셀 내부 paragraph 에
+    //! inline 삽입되지 않고, 표가 있는 같은 paragraph 의 sibling control 로
+    //! floating (tac=false) 삽입된다. 셀 자체는 비어있는 채로 유지되어 사용자가
+    //! 클릭으로 cursor 를 셀에 위치시킬 수 있다.
+
+    use super::*;
+    use crate::model::document::{Document, Section, SectionDef};
+    use crate::model::page::PageDef;
+
+    fn make_test_core() -> DocumentCore {
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            paragraphs: vec![Paragraph::default()],
+            raw_stream: None,
+        });
+        let mut core = DocumentCore::new_empty();
+        core.set_document(doc);
+        core
+    }
+
+    fn minimal_png() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+            0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x00, 0x00, 0x00,
+            0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ]
+    }
+
+    fn parse_idx(res: &str, key: &str) -> usize {
+        res.split(&format!("\"{}\":", key))
+            .nth(1)
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("missing {key} in {res}"))
+    }
+
+    #[test]
+    fn issue1151_insert_picture_into_table_cell_is_floating_sibling() {
+        let mut core = make_test_core();
+
+        // 1×1 표 생성
+        let table_res = core
+            .create_table_native(0, 0, 0, 1, 1)
+            .expect("create 1x1 table");
+        let table_para_idx = parse_idx(&table_res, "paraIdx");
+        let table_ctrl_idx = parse_idx(&table_res, "controlIdx");
+
+        let cell_path: Vec<(usize, usize, usize)> = vec![(table_ctrl_idx, 0, 0)];
+        let image = minimal_png();
+        core.insert_picture_native(
+            0,
+            table_para_idx,
+            0,
+            &cell_path,
+            &image,
+            5000,
+            5000,
+            1,
+            1,
+            "png",
+            "test",
+        )
+        .expect("insert picture (floating)");
+
+        // 셀 안은 그대로 비어있어야 한다 (floating 은 셀에 들어가지 않음).
+        let table_ctrl =
+            &core.document.sections[0].paragraphs[table_para_idx].controls[table_ctrl_idx];
+        let table = match table_ctrl {
+            Control::Table(t) => t,
+            _ => panic!("expected Control::Table"),
+        };
+        let cell0_para0 = &table.cells[0].paragraphs[0];
+        assert!(
+            cell0_para0
+                .controls
+                .iter()
+                .all(|c| !matches!(c, Control::Picture(_))),
+            "cell 안에 picture 가 들어가면 안 된다 (floating 방식). got: {:?}",
+            cell0_para0.controls
+        );
+
+        // table 같은 paragraph 의 sibling control 로 Picture 가 존재해야 한다.
+        let parent_para = &core.document.sections[0].paragraphs[table_para_idx];
+        let picture = parent_para
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Picture(p) => Some(p.as_ref()),
+                _ => None,
+            })
+            .expect("expected sibling Picture in parent paragraph");
+
+        // floating 속성 검증
+        assert!(
+            !picture.common.treat_as_char,
+            "floating picture 는 treat_as_char=false 여야 한다"
+        );
+        assert!(
+            matches!(
+                picture.common.text_wrap,
+                crate::model::shape::TextWrap::Square
+            ),
+            "floating picture wrap=Square (어울림) 이어야 한다. got: {:?}",
+            picture.common.text_wrap
+        );
+    }
+
+    #[test]
+    fn issue1151_insert_picture_body_keeps_existing_inline_behavior() {
+        let mut core = make_test_core();
+        let image = minimal_png();
+        core.insert_picture_native(
+            0,
+            0,
+            0,
+            &[], // 빈 cell_path → 본문 inline (기존)
+            &image,
+            5000,
+            5000,
+            1,
+            1,
+            "png",
+            "test",
+        )
+        .expect("insert picture body");
+
+        let body_para = &core.document.sections[0].paragraphs[0];
+        let pic_in_body = body_para.controls.iter().find_map(|c| match c {
+            Control::Picture(p) => Some(p.as_ref()),
+            _ => None,
+        });
+        let picture = pic_in_body.expect("expected Picture in body paragraph");
+        assert!(
+            picture.common.treat_as_char,
+            "본문 picture 는 기존대로 inline (treat_as_char=true)"
+        );
+    }
+
+    #[test]
+    fn issue1151_invalid_cell_path_returns_error() {
+        let mut core = make_test_core();
+        let _ = core
+            .create_table_native(0, 0, 0, 1, 1)
+            .expect("create table");
+        let bad_path: Vec<(usize, usize, usize)> = vec![(0, 5, 0)]; // cell 5 는 1×1 표에 없음
+        let image = minimal_png();
+        let res =
+            core.insert_picture_native(0, 0, 0, &bad_path, &image, 5000, 5000, 1, 1, "png", "test");
+        assert!(
+            res.is_err(),
+            "out-of-range cell path → Err 기대, got {res:?}"
+        );
     }
 }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2186,13 +2186,20 @@ impl HwpDocument {
     /// width, height: HWPUNIT 단위 크기
     /// extension: 파일 확장자 (jpg, png 등)
     ///
-    /// 반환: JSON `{"ok":true,"paraIdx":<N>,"controlIdx":0}`
+    /// 반환:
+    /// - 본문 inline: `{"ok":true,"paraIdx":<N>,"controlIdx":0}`
+    /// - 셀 floating (#1151): `{"ok":true,"paraIdx":<table_para>,"controlIdx":<new_sibling_idx>}`
+    ///
+    /// `cell_path_json` 이 빈 문자열 또는 `"[]"` 면 본문 inline 삽입. 그 외에는
+    /// 표 셀 영역에 floating picture (한컴 정합) 로 삽입한다.
+    /// 예: `[{"controlIndex":0,"cellIndex":2,"cellParaIndex":0}]`
     #[wasm_bindgen(js_name = insertPicture)]
     pub fn insert_picture(
         &mut self,
         section_idx: u32,
         para_idx: u32,
         char_offset: u32,
+        cell_path_json: &str,
         image_data: &[u8],
         width: u32,
         height: u32,
@@ -2201,10 +2208,17 @@ impl HwpDocument {
         extension: &str,
         description: &str,
     ) -> Result<String, JsValue> {
+        let cell_path: Vec<(usize, usize, usize)> =
+            if cell_path_json.is_empty() || cell_path_json == "[]" {
+                Vec::new()
+            } else {
+                DocumentCore::parse_cell_path(cell_path_json).map_err(JsValue::from)?
+            };
         self.insert_picture_native(
             section_idx as usize,
             para_idx as usize,
             char_offset as usize,
+            &cell_path,
             image_data,
             width,
             height,


### PR DESCRIPTION
closes #1151

## 요약

rhwp-studio 에서 표 셀에 커서를 두고 이미지를 삽입하면 이미지가 항상 표 밖 본문에 배치되던 결함 수정. 한컴 2022 (`incellpicture.hwp` 검증) 패턴에 맞추어 셀 안 이미지 삽입 시 **floating picture (tac=false, wrap=Square, Page-relative offset)** 를 표가 들어있는 paragraph 의 sibling control 로 삽입한다. 셀 자체는 비어있는 채로 유지되어 다른 셀/본문 클릭 시 cursor 가 정상 이동한다.

## 한컴 패턴 분석

`incellpicture.hwp` dump:
```
[2] 표: 셀 모두 비어있음 (paras=1, ctrls=0)
[3] 그림: tac=false, wrap=어울림(Square), horz_rel_to=Paper offset, vert_rel_to=Paper offset
```

비교: `samples/pic-in-table-01.hwp` page 22 의 inline 셀 picture (tac=true) 는 rhwp/한컴 모두 클릭 시 cursor 진입 불가 — inline 본래 동작. 따라서 한컴이 셀 picture 삽입에 사용하는 방식은 **floating** 으로 확인.

## 변경 내용

### Rust
- `src/document_core/commands/object_ops.rs` `insert_picture_native`: `cell_path: &[(usize, usize, usize)]` 인자 추가. 빈 cell_path 는 본문 inline (기존). 비어있지 않으면 floating 분기로 표가 들어있는 paragraph 의 sibling control 로 picture push. 셀 paragraph 는 손대지 않음.
- 신규 helper `compute_cell_page_offset`: render tree 순회로 TableCell bbox.x/y 를 HWPUNIT 으로 환산하여 picture 위치 결정. 매칭 실패 시 (0, 0) fallback.
- `src/wasm_api.rs` `insertPicture` 에 `cell_path_json: &str` 추가.

### TypeScript (rhwp-studio)
- `src/core/wasm-bridge.ts` `insertPicture` 시그니처 확장.
- `src/engine/input-handler-table.ts` `finishImagePlacement` + `src/engine/input-handler-keyboard.ts` paste image: `hit.cellPath` / `cursor.getPosition().cellPath` 검사 후 outer parentParaIndex + cellPath JSON 전달.

### 테스트
TDD RED → GREEN 으로 3 케이스 추가 (`src/document_core/commands/object_ops.rs` 내 `#[cfg(test)] mod`):
1. 셀 안 picture → 셀 paragraph 는 비어있고 outer paragraph 에 floating Picture sibling 존재 + `tac=false`, `wrap=Square`.
2. 본문 cell_path=&[] → 기존 inline (`tac=true`) 회귀.
3. 잘못된 cell_path → Err.

## 검증

- `cargo test --lib`: **1425 passed, 0 failed**, 6 ignored
- `cargo test --tests`: 통합 그룹 모두 통과
- `cargo test --lib issue_1151`: 3 passed
- `cargo clippy --lib -- -D warnings`: 무경고
- `cargo fmt --all -- --check`: clean
- WASM 빌드 (docker compose) success
- rhwp-studio `npx tsc --noEmit`: 본 작업 관련 에러 0
- **사용자 시각 검증** 통과 (dev server 신규 문서 → 표 → 셀 이미지 삽입 → 셀 클릭 정상)

## 수동 검증 절차

1. WASM 빌드 + dev server 기동
2. 신규 문서 → 표 (예: 3×3) 생성
3. 셀 안 커서 → 메뉴 → 입력 → 그림 → 파일 선택 → 클릭으로 위치 확정
4. 기대: 이미지가 셀 영역에 floating 으로 배치 + **다른 셀 클릭 시 cursor 이동 정상**
5. 회귀: 본문 클릭 → 이미지 삽입 → 본문 inline 정상
6. Ctrl+V 클립보드 이미지 paste → 셀/본문 모두 정상

## 관련 이슈 / 이력

- **#194** (CLOSED, 작성자 철회) — 동일 주제 선행 설계 (inline 접근)
- **#1138 (PR #1150, MERGED)** — 셀 안 도형 속성 편집. 인접 영역. 커밋 `50bc6d2a` 의 "picture 변경 제거" 는 셀 안 picture **속성 편집** 정리이며 본 task 의 **삽입** 결함과 무관.

## 후속 이슈 권고 (본 PR scope 외)

- **셀 안 picture 복사 (Ctrl+C) 미지원**: `copy_control_native(section_idx, para_idx, control_idx)` 가 outer paragraph controls 만 인덱싱 — 셀 paragraph 내부 picture 의 control_idx 를 받으면 lookup 실패. 해결 방향: `cell_path` 인자 추가 또는 `copy_control_in_cell_native` 신규.
- 한컴 Automation `InsertPicture` 옵션 (`sizeoption` / `reverse` / `watermark` / `effect`) — #194 에서 제안된 사양.
- 중첩 표 (N-depth) 셀 picture 삽입 — 본 PR 은 1-level 우선.

문서:
- 수행계획서: `mydocs/plans/task_m100_1151.md`
- 구현계획서: `mydocs/plans/task_m100_1151_impl.md`
- 단계별 보고서: `mydocs/working/task_m100_1151_stage{1,2,3}.md`
- 최종 보고서: `mydocs/report/task_m100_1151_report.md`