### PR TITLE
docs(compare): diff-engine-readme에 UI 진입점 안내 추가 (#571, #799 후속)

### DIFF
--- a/rhwp-studio/src/compare/diff-engine-readme.md
+++ b/rhwp-studio/src/compare/diff-engine-readme.md
@@ -396,6 +396,15 @@ flowchart LR
 | `src/ui/history-dialog.ts` | `buildSnapshotFromWasm`, `compareSnapshots`, `compareDocuments` | 편집 문서 스냅샷 + 이력/비교 |
 | `src/ui/compare-dialog.ts` | `compareDocuments` | 외부 두 파일 비교 |
 
+### 6.1 rhwp-studio 진입점
+
+| 기능 | 메뉴 | 단축키 | 엔진 |
+|------|------|--------|------|
+| 문서 비교 | 편집 → 문서 비교 | `Alt+Shift+V` | `compareDocuments` — `strategy: 'alignment'` (외부 두 파일) |
+| 문서 이력 | 편집 → 문서 이력 관리 | `Ctrl+Shift+H` | `compareSnapshots` — `strategy: 'identity'` (같은 세션·stable_id) |
+
+비교 결과 탐색·상세 창은 `compare-result-window.ts`, 세션 공유는 `compare/session.ts`를 참고한다.
+
 ---
 
 ## 7. 디버그 로그 ①②③


### PR DESCRIPTION
#571, #799(문서 비교·이력) 후속으로, 코드/기능 변경 없이 `diff-engine-readme.md`에만 rhwp-studio 진입점 안내를 추가했습니다.

## 변경 내용
`rhwp-studio/src/compare/diff-engine-readme.md` §6.1 **rhwp-studio 진입점** 추가:
| 기능 | 메뉴 | 단축키 | 엔진 |
|------|------|--------|------|
| 문서 비교 | 편집 → 문서 비교 | `Alt+Shift+V` | `compareDocuments` (`strategy: alignment`, 외부 두 파일) |
| 문서 이력 | 편집 → 문서 이력 관리 | `Ctrl+Shift+H` | `compareSnapshots` (`strategy: identity`, 같은 세션·stable_id) |
- 비교 결과 상세·탐색: `compare-result-window.ts`
- 세션 공유: `compare/session.ts`

## 관련 이슈

closes #

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷

변경 전후 비교가 필요한 경우 첨부해주세요.
