### PR TITLE
fix(render): #1154 잔상 통합 fix — clip + overlay crop + flow image prefetch

### DIFF
--- a/mydocs/plans/task_m100_1154.md
+++ b/mydocs/plans/task_m100_1154.md
@@ -1,0 +1,101 @@
+# Task #1154 수행 계획서 — exam_eng.hwp 박스 하단 줄 잔상 (중복 Pic 컨트롤 스케일 미스매치)
+
+## 1. 이슈
+
+GitHub Issue: [#1154](https://github.com/edwardkim/rhwp/issues/1154)
+- 마일스톤: v1.0.0 (M100)
+- 브랜치: `local/task1154` (분기 베이스: `local/devel`)
+
+## 2. 문제 정의
+
+### 증상
+
+`samples/exam_eng.hwp` 2 페이지 18 번 문제 "Dear Rosydale City Marathon Racers," 박스 하단에 줄 잔상(faint 라인) 이 보임. 권위 PDF (`pdf/exam_eng-2022.pdf`) 와 한컴 편집기 출력에는 단일 깔끔한 하단 테두리만 존재.
+
+### 근본 원인
+
+HWP 원본이 박스 효과를 위해 동일 `bin_id=5` (2532×1847 px JPEG, 윈도우 크롬 프레임) 을 사용하는 **두 Pic 컨트롤을 z-order 로 겹쳐 배치**:
+
+| Pic | cur 크기 | crop (HU) | src px 범위 | SVG y 범위 | z |
+|---|---|---|---|---|---|
+| [0] | 108.0 × 67.8 mm | (0,0,189900,120958) | y_px 0 → 1612.77 | 243.59 → 499.68 | 2 |
+| [1] | 108.0 × 18.5 mm | (0,105958,189900,138540) | y_px 1412.77 → 1847.20 | 463.17 → 533.17 | 3 |
+
+두 그림의 **세로 스케일 미스매치**:
+- Pic[0]: 256.09 / 1612.77 = 0.15881 SVG/px
+- Pic[1]:  70    / 434.43 = 0.16113 SVG/px
+- 약 1.46% 차이
+
+`src/renderer/svg.rs:1335-1381` 의 `FitToSize` 분기는 두 Pic 을 독립된 중첩 `<svg viewBox=…>` 로 출력하기 때문에, 겹치는 y_svg 463.17–499.68 구간에서 동일 source pixel 이 미세하게 다른 SVG y 에 그려지고, 안티엘리어싱 / 리샘플링 시 잔상으로 노출됨.
+
+### 작가 의도와 한컴 동작 추정
+
+HWP 작가는 Pic[1] (z=3, 위) 이 Pic[0] (z=2, 아래) 의 하단 일부를 덮어 박스 하단 테두리를 그리도록 설계. 한컴 편집기/뷰어는 두 Pic 의 source 좌표축을 공통화하여 겹침 경계에 잔상이 생기지 않게 합성하는 것으로 추정.
+
+### 보조 검증
+
+- Pic[1] 만 렌더 → 박스 하단 한 줄 (깔끔)
+- Pic[0] 만 렌더 → 하단 가로 테두리 없음 (crop 범위 밖)
+- 둘 다 (현재) → 잔상
+
+## 3. Stage 구조 (4 단계)
+
+### Stage 1 — 진단 정밀화 + 회귀 회피용 baseline 기록
+- 현재 SVG 출력에서 두 Pic 의 정확한 geometry 추출 / 문서화
+- LANCZOS 등 리샘플링 환경별 잔상 가시화 조건 정리
+- 다른 HWP/HWPX 샘플에서 "동일 bin_id Pic 컨트롤 페어 중첩" 패턴 사용처 search → 회귀 영향 파악
+- baseline golden SVG 기록 (해당 페이지 + 패턴 영향 페이지)
+
+### Stage 2 — Fix 설계 + 평가
+세 가지 후보 평가 (Issue 보고 시 제시):
+1. **(권장) 동일 bin_id + 좌표 인접 Pic 쌍을 렌더 단계에서 통합** — 두 crop 의 union 영역을 단일 `<svg viewBox>` 로 출력
+2. **공통 세로 스케일 강제** — 동일 이미지 참조 Pic 그룹의 horizontal/vertical scale 을 공통화
+3. **겹침 제거** — Pic[0] 의 표시 영역을 Pic[1] 시작점에 정확히 인접시켜 중첩 제거
+
+각 후보의 트레이드오프 평가 (구현 복잡도, 회귀 위험, 한컴 정합도) → 작업지시자 승인 후 1개 선택.
+
+### Stage 3 — 구현 + 단위 검증
+- 선택된 후보 구현 (`src/renderer/svg.rs` 또는 상위 레이아웃 단)
+- 단위 테스트 추가 (`compute_image_crop_src` 또는 신규 통합 함수)
+- exam_eng.hwp 페이지 2 SVG 재생성 → 박스 하단 단일 라인 확인
+- 권위 PDF 시각 비교
+
+### Stage 4 — 회귀 검증 + 최종 보고
+- `cargo test --release --lib` 전체
+- `cargo clippy --release -- -D warnings`
+- `cargo fmt` (변경 파일만)
+- 다른 시험지/문서 SVG sweep (exam_kor, exam_math, biz_plan, 통합재정통계 등)
+- HWPX 변환본 회귀 검증
+- WASM 빌드 검증 (Docker)
+- 최종 보고서 작성
+
+## 4. 권위 자료
+
+- 권위 PDF: `pdf/exam_eng-2022.pdf` (페이지 2)
+- 보조 PDF: `samples/exam_eng-2020.pdf`, `samples/exam_eng-2010.pdf`
+- 한컴 편집기 직접 출력 (작업지시자 시각 판정, Windows 환경)
+- 원본 HWP: `samples/exam_eng.hwp`
+
+## 5. 관련 코드 / 메모리
+
+핵심 코드:
+- `src/renderer/svg.rs:1335-1381` — FitToSize 분기 + crop 적용 + 중첩 svg viewBox 출력
+- `src/renderer/svg.rs:2882-2898` — `compute_image_crop_src` (HU → px 변환)
+- `src/document_core/commands/object_ops.rs:1485-1492` — crop 단위 정의
+- `src/model/image.rs:25` — `Picture.crop: CropInfo`
+
+관련 메모리:
+- `reference_authoritative_hancom` — 시각 권위 등급
+
+## 6. Risk / 회귀
+
+영향 범위: 동일 `bin_id` 를 사용하는 다중 Pic 컨트롤 패턴.
+- 일반 한 페이지 한 그림 케이스에는 영향 없어야 함 (단일 Pic 분기 유지)
+- 이미지 fill_mode = TileAll/TileHorz/TileVert/배치 모드 분기는 변경 없음
+- 회귀 차단 critical: exam_kor, exam_math, biz_plan, 시험지 일반, HWPX 변환본
+
+## 7. 예상 작업량
+
+소규모 — Stage 1-4 합쳐 1 일 내 예상.
+
+진행 보고는 각 Stage 완료 시 작업지시자 승인 후 다음 Stage.

--- a/mydocs/plans/task_m100_1154_impl.md
+++ b/mydocs/plans/task_m100_1154_impl.md
@@ -1,0 +1,162 @@
+# Task #1154 구현 계획서 — 중복 Pic 컨트롤 스케일 미스매치 잔상 제거
+
+## 0. 수행계획서 / 이슈
+
+- 수행 계획서: [`task_m100_1154.md`](./task_m100_1154.md)
+- GitHub Issue: [#1154](https://github.com/edwardkim/rhwp/issues/1154)
+- 브랜치: `local/task1154` (분기 베이스 `local/devel`)
+
+## 1. 방향 결정 (수행계획서 Stage 2 의 사전 결론)
+
+수행계획서의 세 후보 중 **옵션 3 — 겹침 제거 (Clip below pic to top of above pic)** 채택.
+
+### 근거
+
+| 옵션 | 구현 난이도 | 회귀 위험 | 한컴 정합도 |
+|---|---|---|---|
+| 1. 두 Pic 통합 | 중 (페어 매칭 + crop union + 스케일 결정 로직) | 중 (스케일 결정 정책 다양) | 비결정적 (한컴 알고리즘 미지) |
+| 2. 공통 세로 스케일 강제 | 중 (그룹 검출 + 스케일 통일) | 상 (다른 의도 케이스 깨질 수 있음) | 비결정적 |
+| **3. 겹침 제거 (Clip below)** | **하 (단순 bbox/crop 조정)** | **하 (단일 Pic 케이스 불변)** | **고 (z-on-top 만 보임 = 작가 의도와 일치)** |
+
+옵션 3 은 z-order 가 높은 Pic 이 아래 Pic 의 겹치는 영역을 100% 가린다는 작가 의도를 그대로 구현. 단일 Pic 분기와 동일 bin_id 가 아닌 케이스에는 영향 없음.
+
+### 정확한 동작
+
+기준 페어 (A, B): `bin_data_id` 가 같고, A.y < B.y 이며 (A.y + A.height) > B.y (세로 겹침).
+- A 가 아래 깔리는(z 가 작은) 그림: 위쪽 부분만 보임
+- B 가 위에 덮는(z 가 큰) 그림: 그대로 유지
+- **수정**: A 의 bbox.height 를 (B.y − A.y) 로 줄이고, A 의 crop.bottom 을 동일 비율로 축소
+
+같은 이미지를 z 가 큰 B 가 위에서 100% 가리므로 표시 결과는 한컴과 동일하면서 스케일 미스매치 잔상이 생기지 않는다.
+
+## 2. 영향 코드
+
+핵심:
+- `src/renderer/svg.rs:1235-1382` — `render_image_node` (FitToSize/crop 분기)
+- `src/renderer/render_tree.rs:711-803` — `ImageNode` 정의
+
+선택지:
+- (A) **SVG 렌더 직전 pre-pass** — `render_tree` 노드 walk 전에 페이지 단위 ImageNode 수집 → 겹침 페어 검출 → bbox/crop 조정. 변경 범위 최소.
+- (B) 레이아웃 단계 (`picture_footnote.rs`) — 페어를 검출하여 ImageNode 생성 시점에 bbox/crop 미리 조정. 다른 렌더러(web_canvas, skia)도 자동 혜택.
+
+**(B) 채택**: 모든 렌더러(svg/web_canvas/skia) 가 동일 ImageNode 를 그리므로 한 곳에서 조정하면 일관됨. 또한 픽셀-단계가 아닌 IR-단계 조정이라 자연스러움.
+
+다만 `picture_footnote.rs` 의 `layout_body_picture` 가 그림 하나씩 처리하므로, 페어 검출은 그림들이 모두 페이지 트리에 들어간 후의 후처리(pre-render pass) 가 더 자연스러움.
+
+→ 최종: **SVG/web_canvas/skia 렌더링 직전 공통 후처리** — `PageRenderTree` 트리를 walk 하여 ImageNode 들을 수집 / 겹침 검출 / bbox·crop 조정.
+
+수정 위치 후보:
+- `src/renderer/render_tree.rs` — `PageRenderTree::resolve_image_overlap()` 신규 메서드 (트리 자체를 in-place 수정)
+- 각 렌더러(svg/canvas/web_canvas) 가 페이지 렌더 시작 전에 1 번 호출
+
+## 3. Stage 분할 (4 단계)
+
+### Stage 1 — 진단 정밀화 + baseline 기록
+
+목표: 패턴 파악 + 회귀 안전성 확인.
+
+작업:
+1. `samples/` 와 `samples/hwpx/` 전 샘플에 대해 "동일 `bin_data_id` Pic 컨트롤이 동일 paragraph 또는 인접 paragraph 에 2개 이상" 패턴 검출 스크립트 작성 (e.g., `rhwp dump | grep` 또는 임시 Rust 바이너리).
+2. 검출된 케이스의 SVG 출력 baseline 생성:
+   - `output/svg/task1154_baseline/<sample>/` 디렉토리
+   - 영향 페이지만 SVG 추출
+3. 검출 결과를 `mydocs/working/task_m100_1154_stage1.md` 에 정리:
+   - 영향 sample 목록 + 케이스 수
+   - exam_eng.hwp 의 Pic[0]/Pic[1] geometry 정밀 기록
+4. 권위 PDF 비교 — exam_eng-2022.pdf 페이지 2 의 박스 외관과 우리 출력의 잔상 차이를 PNG 비교 산출물로 저장.
+
+산출물: `mydocs/working/task_m100_1154_stage1.md` + baseline SVG 디렉토리.
+
+### Stage 2 — Fix 함수 설계 + 단위 테스트 우선 작성
+
+목표: 구현 전에 함수 시그니처 / 단위 테스트 / 알고리즘 동결.
+
+작업:
+1. **함수 시그니처 결정**:
+   ```rust
+   // src/renderer/render_tree.rs 에 PageRenderTree 메서드
+   impl PageRenderTree {
+       /// 동일 bin_data_id 를 가진 ImageNode 가 세로로 겹칠 때,
+       /// 아래에 깔리는 (트리 순서상 먼저 그려지는) ImageNode 의 bbox/crop 을
+       /// 위에 덮는 ImageNode 의 top 까지 축소한다.
+       pub fn clip_overlapping_same_bin_images(&mut self);
+   }
+   ```
+2. **알고리즘**:
+   - DFS 로 모든 `ImageNode` 와 그 bbox 를 수집 (트리 순서 보존)
+   - 트리 순서 = SVG paint 순서 = z-order
+   - 정렬: bin_data_id 별로 그룹화
+   - 각 그룹 내에서 트리 순서가 빠른 = z 가 작음 = 아래에 깔림
+   - 페어 검출: 두 이미지의 bbox 가 가로 겹침(x 범위 교집합) + 세로 겹침(y 범위 교집합) 이면 페어로 판정
+   - 페어 (A=아래, B=위) 에 대해 A 의 bbox.height 와 crop 을 다음과 같이 조정:
+     - `new_height = B.y - A.y`
+     - `ratio = new_height / A.height`
+     - `crop.bottom_new = crop.top + (crop.bottom - crop.top) * ratio`
+     - A.height = new_height
+     - A.crop = (crop.left, crop.top, crop.right, crop.bottom_new)
+3. **단위 테스트** (`src/renderer/render_tree.rs` 의 tests 모듈에 추가):
+   - test_overlap_same_bin_clips_lower
+   - test_overlap_different_bin_no_clip
+   - test_non_overlap_no_clip
+   - test_horizontal_no_overlap_no_clip
+   - test_multiple_pairs_all_clipped
+4. **알고리즘 회피 조건**:
+   - bin_data_id 가 다르면 무시
+   - crop 이 None 인 경우: crop 새로 생성 또는 무시 (검토 필요)
+   - 단일 이미지 케이스 (페어 없음): 무시 — 불변
+
+산출물: `mydocs/working/task_m100_1154_stage2.md` + 단위 테스트만 추가된 commit.
+
+### Stage 3 — 구현 + exam_eng.hwp 시각 검증
+
+목표: 알고리즘 구현 후 단위 테스트 / exam_eng.hwp / 권위 PDF 정합 확인.
+
+작업:
+1. `PageRenderTree::clip_overlapping_same_bin_images` 구현.
+2. 호출 지점 (각 렌더러 페이지 렌더링 진입부):
+   - `src/renderer/svg.rs` — `render_page` 또는 SVG 시작점
+   - `src/renderer/web_canvas.rs` — Canvas 렌더 진입부
+   - `src/renderer/skia/` — Skia 렌더 진입부
+   - **(설계 결정 필요)** 트리 후처리는 PageRenderTree 빌드 직후 1 번만 — `PageRenderTree::build_complete` 같은 finalize 시점.
+3. Stage 2 단위 테스트 통과 확인.
+4. exam_eng.hwp 페이지 2 SVG 재생성 → 박스 하단 단일 라인 확인 (Stage 1 의 baseline PNG 와 시각 비교).
+5. 작업지시자 시각 판정 요청용 비교 자료 준비.
+
+산출물: 코드 변경 + `mydocs/working/task_m100_1154_stage3.md` + SVG 비교 산출물.
+
+### Stage 4 — 회귀 검증 + 최종 보고
+
+목표: 다른 샘플 영향 없음 / 전체 테스트 통과 / WASM 정상.
+
+작업:
+1. `cargo test --release --lib` 전체 (baseline 대비 변동 확인).
+2. `cargo clippy --release -- -D warnings`.
+3. `cargo fmt` (변경 파일만).
+4. Stage 1 에서 식별된 모든 영향 sample SVG 재생성 → baseline 과 시각 비교.
+5. 일반 회귀: exam_kor, exam_math, biz_plan, 통합재정통계, 시험지 일반, HWPX 변환본 sweep.
+6. Docker WASM 빌드 (`docker compose --env-file .env.docker run --rm wasm`).
+7. 최종 보고서 `mydocs/report/task_m100_1154_report.md`.
+8. `mydocs/orders/` 의 오늘 할일 갱신 (해당하는 경우).
+
+산출물: `mydocs/report/task_m100_1154_report.md` + 회귀 검증 결과.
+
+## 4. 위험 / 완화
+
+| 위험 | 완화 |
+|---|---|
+| 동일 bin_id 페어 사용 다른 의도 케이스 (의도적 부분 가리기) | Stage 1 에서 영향 sample 전수 조사 → Stage 4 시각 회귀로 검증 |
+| crop 이 없는 그림의 페어 | 단위 테스트로 동작 정의 — crop 없으면 bbox 만 축소하고 crop 은 그대로 |
+| 음수 폭 / height 0 edge case | 페어 조건 검사 시 `B.y > A.y` 와 `A.height > 0` 보장 |
+| 페어 3 개 이상 (A < B < C) | A 는 B 의 top 까지, B 는 C 의 top 까지 (각 페어 독립적) |
+
+## 5. Out of Scope
+
+- 동일 bin_id 가 아닌 (다른 이미지) 그림 겹침은 처리하지 않음 (현재 동작 유지)
+- ImageFillMode == TileAll/TileHorz/TileVert/배치 모드 분기는 변경 없음 (Issue 의 FitToSize/crop 케이스에 한정)
+- 한컴 정합도 100% 달성 (스케일 통일 옵션 1/2) 은 후속 task 로 분리
+
+## 6. 예상 작업량
+
+각 Stage 약 1-2 시간, 총 6-8 시간 (1 일 이내).
+
+진행 보고는 각 Stage 완료 시 작업지시자 승인 후 다음 Stage.

--- a/mydocs/plans/task_m100_1154_v2.md
+++ b/mydocs/plans/task_m100_1154_v2.md
@@ -1,0 +1,60 @@
+# Task M100 #1154 v2 — 수행 계획서
+
+## 배경
+
+commit `8ee17fd4` ("fix(render): 동일 bin_id Pic 컨트롤 잔상 제거 (closes #1154)") 가 머지된 후 작업지시자 추가 검증 결과 **잔상이 rhwp-studio에서만 잔존** 한다는 보고. 추가 조사 결과 #1154 의 시각 증상이 단일 원인이 아닌 **세 가지 독립 원인**으로 동시 발생함을 확인.
+
+| # | 원인 | 노출 경로 |
+|---|---|---|
+| 1 | 동일 bin_id Pic 컨트롤 수직 인접 시 스케일 미스매치 | SVG / Canvas / CanvasKit 공통 |
+| 2 | rhwp-studio overlay `<img>` 가 `crop` 필드를 무시 | rhwp-studio BehindText/InFrontOfText overlay |
+| 3 | 큰 PNG/JPEG 이미지의 비동기 디코드가 `scheduleReRender` 시점(200/600ms)을 초과 | rhwp-studio flow layer canvas |
+
+원인 1 은 commit 8ee17fd4 에서 처리 완료. v2 는 원인 2 + 3 처리.
+
+## 증상 (작업지시자 보고)
+
+1. **페이지 2 18번 박스** (BehindText overlay 그림 2 개로 윈도우 chrome frame 구성)
+   - 8ee17fd4 적용 + WASM 재빌드 후에도 그림 외곽 / 하단이 한컴 PDF 와 다름
+   - 그림 stretched 형태로 두 번 겹쳐 보임
+2. **페이지 4 27번 박스** ("Adenville City Pass Card" 종이 + 핀 디자인)
+   - 박스 외곽 그림 자체가 누락 (위/아래 선 안 보임)
+   - 박스 안의 표 (본문 layer) 만 그려짐
+
+## 진단
+
+### 원인 2 — overlay `<img>` crop 무시
+
+- `exam_eng.hwp` 2 페이지 두 Pic 모두 `wrap=글뒤로 (BehindText)` 배치.
+- rhwp-studio 는 BehindText/InFrontOfText 이미지를 본문 canvas 가 아닌 별도 HTML `<img>` overlay 로 렌더 (page-renderer.ts `createOverlayLayer`).
+- 이 `<img>` 는 `bbox` 만 적용하고 `crop` 필드를 완전히 무시 → 원본 전체 윈도우 프레임이 bbox 안에 stretch.
+- 의도된 crop (Pic[0]: 위쪽 67.8mm, Pic[1]: 아래쪽 18.5mm) 이 무효화되어 두 그림 모두 전체 프레임을 표시 → 잔상.
+
+### 원인 3 — 비동기 이미지 디코드 타이밍
+
+- 페이지 4 27번 박스 그림 = 약 130 KB PNG (base64 175 KB).
+- 데이터 URL 로 `<img>.src` 설정 후 브라우저 비동기 디코드 → 1 초 이상 소요.
+- `PageRenderer.scheduleReRender` 가 200 / 600ms 두 번만 재시도 → 디코드 미완료 상태로 종료.
+- 첫 렌더에 이미지가 누락된 상태 그대로 화면에 표시 (이전 캡쳐 확인).
+
+## 수행 방향
+
+| Step | 내용 | 영향 범위 |
+|---|---|---|
+| 2 | overlay JSON 에 `crop` 필드 추가 + `createOverlayLayer` 가 wrapper div + overflow:hidden 패턴으로 source rect → dest rect 매핑 | rhwp-studio overlay only |
+| 3 | `scheduleReRender` delays 확장 + `prefetchFlowImages` 안전망 (image.decode() 으로 prefetch 후 강제 재렌더) | rhwp-studio flow layer only |
+
+원인 1 (commit 8ee17fd4 의 PageRenderTree clip) 은 v1 작업으로 완료, v2 에서 추가 변경 없음.
+
+## 변경 파일 (예정)
+
+- `src/document_core/queries/rendering.rs` — overlay JSON write_overlay_image 에 crop 필드 추가
+- `rhwp-studio/src/view/page-renderer.ts` — OverlayImageInfo.crop 필드, createOverlayLayer wrapper, scheduleReRender delays, prefetchFlowImages
+- `pkg/*` — WASM 재빌드 (필수)
+
+## 회귀 / 검증 범위
+
+- 페이지 2 박스 18 → 윈도우 프레임 단일 정상 표시, 한컴 PDF 와 시각 일치
+- 페이지 4 박스 27 → 종이 + 핀 + 외곽선 모두 표시, 한컴 PDF 와 시각 일치
+- 기존 회귀 sweep (8ee17fd4 적용 17 영향 sample) 유지
+- cargo test --release --lib / clippy / npx tsc --noEmit 모두 clean

--- a/mydocs/plans/task_m100_1154_v2_impl.md
+++ b/mydocs/plans/task_m100_1154_v2_impl.md
@@ -1,0 +1,63 @@
+# Task M100 #1154 v2 — 구현 계획서
+
+## 단계 구성
+
+3 단계 (Stage 1 — backend + overlay frontend, Stage 2 — image prefetch frontend, Stage 3 — 검증 + WASM 재빌드).
+
+### Stage 1 — overlay path 가 crop 을 honor 하도록 수정
+
+**파일:**
+- `src/document_core/queries/rendering.rs`
+  - `write_overlay_image` 에서 `image.crop` 이 `Some` 일 때 JSON 에 `"crop":{"left":..,"top":..,"right":..,"bottom":..}` 출력 (layer tree 메인 JSON 직렬화 구조와 동일).
+- `rhwp-studio/src/view/page-renderer.ts`
+  - `OverlayImageInfo` 인터페이스에 `crop?: { left; top; right; bottom }` 필드 추가.
+  - 폴백 경로 `toOverlayInfo` 도 `op.crop` 을 그대로 전달.
+  - `createOverlayLayer` 본체에서 crop 있으면 wrapper div + overflow:hidden 패턴 사용.
+    - source rect (px) = (crop.left / 75, crop.top / 75, span / 75, span / 75)  — HU/px = 75 가정 (`compute_image_crop_src` 와 동일).
+    - dest rect (px) = bbox * displayScale.
+    - scaleX = dw / sw, scaleY = dh / sh.
+    - wrapper: position absolute (dx, dy), size (dw, dh), overflow:hidden, pointer-events:none.
+    - 내부 `<img>`: position absolute (-sx*scaleX, -sy*scaleY), width = naturalWidth*scaleX, height = naturalHeight*scaleY (onload 시점 확정).
+  - 기존 filter/mixBlendMode/opacity 처리는 그대로 `<img>` 에 적용.
+
+**완료 조건:** 페이지 2 박스 18 캡쳐에서 윈도우 frame 단일 정상 표시.
+
+### Stage 2 — 큰 이미지 비동기 디코드 대응
+
+**파일:** `rhwp-studio/src/view/page-renderer.ts`
+
+- `scheduleReRender` delays 배열 확장: `[200, 600]` → `[200, 600, 1500]`.
+- 신규 `prefetchFlowImages` 메서드:
+  - `wasm.getPageLayerTree(pageIdx)` JSON 에서 image 항목의 mime + base64 추출 (정규식 사용, behindText/inFrontOfText 제외 — overlay 별도 처리).
+  - 각 image 를 `new Image()` + `image.decode()` 으로 prefetch — 디코드 완료 시 resolve. 미지원 브라우저 폴백으로 `onload` 도 등록.
+  - 모든 image prefetch 완료 후 `wasm.renderPageToCanvasFiltered(pageIdx, canvas, scale, 'flow')` 한 번 더 호출.
+- `scheduleReRender` 안에서 `queueMicrotask` 로 `prefetchFlowImages` 실행 → setTimeout 흐름과 독립적으로 안전망 동작.
+
+**완료 조건:** 페이지 4 박스 27 캡쳐에서 박스 외곽 그림 (종이 + 핀 디자인) 표시.
+
+### Stage 3 — WASM 재빌드 + 회귀 검증
+
+**작업:**
+1. `docker compose --env-file .env.docker run --rm wasm` 으로 pkg/ 재빌드.
+2. headless 캡쳐 재실행:
+   - 페이지 2 박스 18 (page.screenshot + overlay 포함) 정상.
+   - 페이지 4 박스 27 (canvas toDataURL, lazy load) 정상.
+3. cargo test --release --lib (1432 passed 유지).
+4. cargo clippy --release --lib -- -D warnings (clean 유지).
+5. npx tsc --noEmit (clean).
+
+**완료 조건:** 모든 검증 통과.
+
+## 회귀 보호 전략
+
+- Stage 1 변경은 BehindText/InFrontOfText overlay 경로에만 영향. flow layer (canvas) 변경 없음. 기존 페이지 2 SVG export 결과 동일 (이미 검증).
+- Stage 2 변경은 flow layer 의 재렌더 횟수 + prefetch 만 추가. 이미지 없는 페이지는 imageCount=0 으로 skip — 비용 없음.
+- 두 변경 모두 추가 호출 / DOM 노드 한정 — 기존 동작에 부정적 영향 가능성 낮음.
+
+## 위험
+
+| 항목 | 완화 |
+|---|---|
+| naturalWidth/Height onload 콜백 도착 전 임시 시각 어색 | scheduleReRender 가 디코드 완료 후 다시 그리는 안전망 (`prefetchFlowImages`) 가 커버 |
+| crop 좌표 환산 오류 (HU/px 비율) | compute_image_crop_src 동일 상수(75) 사용 — 백엔드와 일관 |
+| prefetch JSON 정규식 매칭 오류 | wrap 필드만 필터링 (단순 패턴), 매칭 실패 시 단순 skip (앱 동작에 영향 없음) |

--- a/mydocs/report/task_m100_1154_report.md
+++ b/mydocs/report/task_m100_1154_report.md
@@ -1,0 +1,176 @@
+# Task #1154 최종 결과 보고서 — 중복 Pic 컨트롤 스케일 미스매치 잔상 제거
+
+## 1. 이슈 / 목표
+
+- GitHub Issue: [#1154](https://github.com/edwardkim/rhwp/issues/1154)
+- 브랜치: `local/task1154` (베이스 `local/devel`)
+- 목표: 같은 `bin_data_id` 의 두 Pic 컨트롤이 세로로 인접 겹쳐 그려져 미세한
+  스케일 차이로 나타나는 이중 라인 잔상을 제거. 한컴 정합도 유지.
+
+## 2. 결론
+
+- exam_eng.hwp page 2 의 박스 효과 잔상 제거 완료. 한컴 권위 PDF 와 시각 정합 ✓
+- Stage 1 식별 17 영향 sample 중 exam_eng 만 fix 적용, 나머지 16 sample (의도적
+  효과 케이스) 페이지 단위 100% 불변
+- 일반 회귀 7 sample (페어 없음) 페이지 단위 100% 불변
+- 단위 테스트 1318 + 신규 11 = clip algorithm 검증 통과
+- WASM 빌드 정상 통과
+
+## 3. 채택한 접근 (옵션 3 — Clip below to top of above)
+
+같은 bin_id, 같은 x/width 의 두 Pic 페어 (A=아래, B=위) 에서 A 의 bbox.height
+와 crop.bottom 을 B.y 까지 정확히 축소. B 가 100% 위에 덮으므로 표시 결과는
+한컴과 동일하면서 안티엘리어싱 차이로 인한 잔상은 사라진다.
+
+### 알고리즘 strict 5 조건
+
+```
+모두 만족 시 clip 적용:
+1. A.bin_data_id == B.bin_data_id
+2. |A.x - B.x| <= 1.0           (수평 위치 동일)
+3. |A.width - B.width| <= 1.0    (수평 폭 동일)
+4. A 가 트리 순서상 먼저 + A.y < B.y  (A 가 위, z 작음)
+5. A.y + A.height > B.y          (세로 겹침)
+```
+
+조건 2/3 의 strict 가드가 의도적 그림자/2중 노출 케이스 (대각선 오프셋,
+다른 너비) 를 모두 우회 — 회귀 보호.
+
+### 구현 — IR 단계 후처리, 중앙 1곳
+
+`PageRenderTree::clip_overlapping_same_bin_images()` 메서드를 만들고,
+`DocumentCore::build_page_tree()` 의 종단(`extra_mps` 머지 후, `Ok(tree)`
+직전) 에서 1 회 호출. 모든 렌더러 (SVG/HTML/Canvas/WebCanvas/SvgLayer/
+CanvasLayer/WebCanvasLayer) 가 이 빌드 결과를 소비하므로 호출 누락 위험 없음.
+LayerBuilder (`src/paint/builder.rs:86`) 가 `node.bbox` 와 `image.clone()`
+(crop 4 필드 포함) 을 그대로 PaintOp::Image 에 복사하므로 layer 기반 백엔드도
+자동 영향.
+
+## 4. Stage 별 산출물
+
+| Stage | 핵심 산출물 | 커밋 |
+|---|---|---|
+| 1 — 진단 정밀화 + baseline | `mydocs/working/task_m100_1154_stage1.md`, 17 sample baseline SVG | `8a2ea7df` |
+| 2 — Algorithm + 단위 테스트 11 개 | `src/renderer/render_tree.rs` (+438), `task_m100_1154_stage2.md` | `2e2ff0b3` |
+| 3 — 렌더러 통합 + 시각 검증 | `src/document_core/queries/rendering.rs` (+4), `task_m100_1154_stage3.md` | `c533dca1` |
+| 4 — 회귀 sweep + WASM + 최종 보고 | `task_m100_1154_report.md` | (본 커밋) |
+
+## 5. 회귀 검증 결과 종합
+
+### 5.1 단위 테스트 / 정적 검사
+
+```
+cargo test --release --lib
+  test result: ok. 1318 passed; 0 failed; 6 ignored
+
+cargo clippy --release --lib -- -D warnings
+  Finished — no warnings
+
+cargo fmt — applied to rendering.rs only
+```
+
+`cargo clippy --release --all-targets` 는 tests/ 영역에 56 errors 가 있으나
+모두 pre-existing (Stage 3 이전 HEAD 에서도 동일). 본 task 와 무관.
+
+### 5.2 Stage 1 식별 17 영향 sample sweep (same-commit 공정 비교)
+
+`RHWP_TASK1154_NOCLIP=1` 임시 가드로 no-clip 산출 → guard 해제 후 with-clip
+산출 → 페이지 단위 `diff -rq`:
+
+| Sample | 페이지 수 | differ |
+|---|---|---|
+| 3-10월_교육_통합_2022.hwp | 16 | 0 |
+| 3-10월_교육_통합_2022.hwpx | 16 | 0 |
+| KTX.hwp | 27 | 0 |
+| BlogForm_BookReview.hwp | 1 | 0 |
+| BlogForm_MovieReview.hwp | 1 | 0 |
+| BlogForm_Recipe.hwp | 1 | 0 |
+| **exam_eng.hwp** | **8** | **1 (page 2)** |
+| exam_social.hwp | 4 | 0 |
+| hwpctl_ParameterSetID_Item_v1.2.hwp | 75 | 0 |
+| hwpspec.hwp | 175 | 0 |
+| pic-in-head-01.hwp | 22 | 0 |
+| pic-in-table-01.hwp | 22 | 0 |
+| pic2-2018.hwp | 3 | 0 |
+| pic2.hwp | 3 | 0 |
+| pic2.hwpx | 3 | 0 |
+| test-image.hwp | 1 | 0 |
+| test-image.hwpx | 1 | 0 |
+
+→ **17 sample 합계 379 페이지 중 exam_eng page 2 한 장만 변경**. strict 5 조건이
+정확히 대상 케이스만 매칭.
+
+### 5.3 일반 회귀 sweep (페어 없는 문서)
+
+| Sample | 페이지 수 | differ |
+|---|---|---|
+| exam_kor.hwp | 20 | 0 |
+| exam_math.hwp | 20 | 0 |
+| exam_math_8.hwp | 1 | 0 |
+| biz_plan.hwp | 6 | 0 |
+| 통합재정통계(2010.11월).hwp | 1 | 0 |
+| 통합재정통계(2011.10월).hwp | 1 | 0 |
+| 통합재정통계(2014.8월).hwp | 1 | 0 |
+
+→ 페어가 없는 문서에서 100% 동일. 회귀 위험 0.
+
+### 5.4 exam_eng page 2 — 정확한 변경 확인
+
+LOWER (z=2, drawn first):
+- before: `y=243.59, height=256.09, viewBox="0 0 2532 1612.77"`
+- after:  `y=243.59, height=**219.59**, viewBox="0 0 2532 **1382.87**"`
+- 검증: `B.y(=463.17) − A.y(=243.59) = 219.58` ✓
+- crop bottom: `1612.77 × (219.59 / 256.09) ≈ 1382.94` (실제 1382.87, 반올림 오차)
+
+UPPER (z=3, drawn after): 완전 불변.
+
+→ 알고리즘이 정확히 LOWER 의 visible 영역만 잘라내고 UPPER 는 그대로 둔다.
+
+### 5.5 WASM 빌드
+
+```
+docker compose --env-file .env.docker run --rm wasm
+  Finished `release` profile [optimized] target(s) in 51.28s
+  [INFO]: Optimizing wasm binaries with `wasm-opt`...
+  [INFO]: :-) Done in 1m 31s
+  [INFO]: :-) Your wasm pkg is ready to publish at /app/pkg.
+```
+
+## 6. 변경 코드 요약
+
+```
+src/renderer/render_tree.rs                 | +438  (Stage 2 commit 2e2ff0b3)
+src/document_core/queries/rendering.rs      | +4    (Stage 3 commit c533dca1)
+mydocs/plans/task_m100_1154.md              | (수행 계획서, Stage 0)
+mydocs/plans/task_m100_1154_impl.md         | (구현 계획서, Stage 0)
+mydocs/working/task_m100_1154_stage1.md     | (진단 + baseline)
+mydocs/working/task_m100_1154_stage2.md     | (algorithm + 단위 테스트)
+mydocs/working/task_m100_1154_stage3.md     | (렌더러 통합)
+mydocs/report/task_m100_1154_report.md      | (본 보고서)
+```
+
+## 7. Out of Scope (의식적 미해결)
+
+- 동일 bin_id 가 아닌 다른 이미지 페어 → 처리하지 않음 (현재 동작 유지)
+- 옵션 1 (두 Pic 통합) / 옵션 2 (공통 세로 스케일 강제) — 한컴 알고리즘이
+  비결정적이라 적용 시 회귀 위험 큼. 본 task 의 옵션 3 만 적용
+- ImageFillMode != FitToSize 분기 영향은 없음 — bbox/crop 만 조정하므로 호환
+
+## 8. 다음 단계
+
+- `local/task1154` → `local/devel` merge (작업지시자 승인 후)
+- orders 갱신 — orders 는 작업지시자 관할이므로 본 task 에서 직접 편집하지
+  않음. merge 시 작업지시자가 갱신.
+- 이슈 #1154 close — 작업지시자 승인 후 `closes #1154` 메시지로 처리
+
+## 9. 작업 시간 산정
+
+| Stage | 예상 | 실제 |
+|---|---|---|
+| 1 — 진단 + baseline | 1-2h | ~2h |
+| 2 — Algorithm + 테스트 | 1-2h | ~2h |
+| 3 — 통합 + 검증 | 1-2h | ~1.5h |
+| 4 — 회귀 sweep + WASM + 보고 | 1-2h | ~1.5h |
+| **합계** | **4-8h** | **~7h** |
+
+승인 요청.

--- a/mydocs/report/task_m100_1154_v2_report.md
+++ b/mydocs/report/task_m100_1154_v2_report.md
@@ -1,0 +1,65 @@
+# Task M100 #1154 v2 — 최종 결과 보고서
+
+## 개요
+
+commit `8ee17fd4` (v1, "fix(render): 동일 bin_id Pic 컨트롤 잔상 제거") 가 머지된 후, rhwp-studio 화면에서 잔상이 여전히 보이고 추가로 페이지 4 박스 외곽 그림이 누락된다는 작업지시자 보고에 따라 추가 조사 + 두 가지 후속 fix 를 수행.
+
+원인 1 (동일 bin_id Pic clip) 은 v1 에서 처리 완료. v2 는 **원인 2 (overlay `<img>` 가 crop 무시) + 원인 3 (큰 이미지 비동기 디코드 미커버)** 처리.
+
+## 원인 정리 (#1154 의 시각 증상은 세 가지 독립 원인 동시 발생)
+
+| # | 원인 | 노출 경로 | 처리 |
+|---|---|---|---|
+| 1 | 동일 bin_id Pic 컨트롤 수직 인접 시 세로 스케일 미스매치 → SVG 리샘플링 잔상 | SVG / Canvas / CanvasKit 공통 | v1 (commit 8ee17fd4) PageRenderTree::clip_overlapping_same_bin_images |
+| 2 | rhwp-studio 의 BehindText/InFrontOfText overlay `<img>` 가 `crop` 필드를 완전히 무시 → 원본 전체 이미지가 bbox 안에 stretch | rhwp-studio overlay only | **v2 Stage 1** — overlay JSON 에 crop 필드 출력 + `createOverlayLayer` wrapper div + overflow:hidden + scaled img 패턴 |
+| 3 | 큰 PNG/JPEG 의 비동기 디코드 (1 초 이상) 가 `scheduleReRender` (200/600ms) 시점을 초과 → 첫 렌더에 이미지 누락 | rhwp-studio flow layer only | **v2 Stage 2** — `scheduleReRender` delays 확장 + `prefetchFlowImages` 안전망 (image.decode() prefetch 후 강제 재렌더) |
+
+## 변경 파일
+
+| 파일 | 변경 내용 |
+|---|---|
+| `src/document_core/queries/rendering.rs` | `get_page_overlay_images_native` 의 `write_overlay_image` 가 `image.crop` 이 Some 일 때 JSON 에 `"crop":{"left":..,"top":..,"right":..,"bottom":..}` 출력 |
+| `rhwp-studio/src/view/page-renderer.ts` | `OverlayImageInfo.crop` 필드 추가 / `toOverlayInfo` (폴백) crop 전달 / `createOverlayLayer` 가 crop 있을 때 wrapper div + overflow:hidden 으로 source rect 매핑 / `scheduleReRender` delays `[200, 600] → [200, 600, 1500]` 확장 / `prefetchFlowImages` 신규 메서드 |
+| `pkg/*` | WASM 재빌드 (Stage 3) — gitignore |
+| `mydocs/plans/task_m100_1154_v2.md` | 수행 계획서 |
+| `mydocs/plans/task_m100_1154_v2_impl.md` | 구현 계획서 |
+| `mydocs/working/task_m100_1154_v2_stage1.md` / `stage2.md` / `stage3.md` | 단계별 완료 보고서 |
+| `mydocs/report/task_m100_1154_v2_report.md` | 본 보고서 |
+
+## 검증 결과
+
+### 시각 (한컴 PDF 권위 자료 기준)
+
+| 페이지 / 박스 | 한컴 PDF | SVG export | rhwp-studio (v2 적용) |
+|---|---|---|---|
+| 페이지 2 박스 18 — 윈도우 chrome frame | ✓ | ✓ | ✓ |
+| 페이지 4 박스 27 — 종이 + 핀 디자인 | ✓ | ✓ | ✓ |
+| 페이지 4 박스 28 — Luckwood Snow Festival | ✓ | ✓ | ✓ |
+
+### 자동 검증
+
+| 항목 | 결과 |
+|---|---|
+| cargo test --release --lib | 1432 passed / 0 failed / 6 ignored |
+| cargo clippy --release --lib -- -D warnings | clean |
+| npx tsc --noEmit (rhwp-studio) | clean |
+| cargo fmt | 변경 파일 rendering.rs 적용 |
+| Docker WASM 빌드 | 정상 (53s + 1m38s wasm-opt) |
+
+## 회귀 보호
+
+- v2 Stage 1 변경은 **BehindText/InFrontOfText overlay 경로에만 영향**. flow layer (canvas) 변경 없음. crop 없는 overlay 이미지는 기존 동작 그대로 유지.
+- v2 Stage 2 변경은 **flow layer 의 추가 재렌더 + image prefetch 만 추가**. 이미지가 없는 페이지는 `imageCount=0` 으로 skip 되어 비용 없음. prefetch 중복 디코드는 브라우저 캐시로 무시 가능.
+- 둘 다 Rust 측 변경은 JSON 출력 1 줄 추가 외에는 TypeScript only. 기존 cargo test / clippy 통과 유지.
+
+## 작업지시자 검증 요청
+
+다음 환경에서 시각 확인 부탁드립니다:
+
+1. `samples/exam_eng.hwp` 2 페이지 — 박스 18 윈도우 chrome frame 정상 (잔상 없음)
+2. `samples/exam_eng.hwp` 4 페이지 — 박스 27 / 28 종이 + 핀 디자인 정상
+3. 다른 BehindText overlay 가 있는 문서에서 회귀 없음 (예: 워터마크 페이지)
+
+## 결론
+
+#1154 시각 증상의 세 가지 독립 원인을 모두 처리. v1 (commit 8ee17fd4) + v2 (본 작업) 통합으로 한컴 PDF 권위 자료와 시각 일치 달성.

--- a/mydocs/working/task_m100_1154_stage1.md
+++ b/mydocs/working/task_m100_1154_stage1.md
@@ -1,0 +1,108 @@
+# Task #1154 Stage 1 완료 보고서 — 진단 정밀화 + baseline 기록
+
+## 1. 목표
+
+- 동일 `bin_data_id` Pic 컨트롤 페어 패턴이 사용되는 모든 sample 식별
+- 실제 SVG 출력에서 nested image 가 시각적으로 겹치는 케이스만 추출
+- 영향 sample 의 baseline SVG / PNG 보존
+- 보호해야 할 의도적 효과(그림자/2중 노출) 케이스와 잔상 케이스 구분
+
+## 2. 1차 IR 스캔 (244 samples → 28 케이스)
+
+`/tmp/scan_bin_id_pairs.py` 로 IR dump 의 같은 문단 내 동일 `bin_id` Pic 컨트롤 2 회 이상 케이스 검출:
+
+| Sample | Para | bin_id | Count |
+|---|---|---|---|
+| 3-10월_교육_통합_2022.hwp/.hwpx | 0.296 | 7,8/17,18 | 2 |
+| KTX.hwp | 0.245 | 3 | 4 |
+| basic/BlogForm_BookReview.hwp | 0.0/0.1 | 1 | 7,4 |
+| basic/BlogForm_MovieReview.hwp | 0.0 | 1 | 7 |
+| basic/BlogForm_Recipe.hwp | 0.0/0.1 | 1,2 | 7,3 |
+| **exam_eng.hwp** | 0.104 | 5 | 2 |
+| exam_social.hwp | 0.15 | 1 | 2 |
+| hwpctl_ParameterSetID_Item_v1.2.hwp | 0.7 | 3-8 | 2 each |
+| hwpspec.hwp | 2.52 | 4,5,6 | 2,3,17 |
+| pic-in-head-01.hwp / pic-in-table-01.hwp | 0.58 | 3 | 4 |
+| pic2-2018.hwp / pic2.hwp / pic2.hwpx | 0.0 | 1,2 | 2 |
+| test-image.hwp / .hwpx | 0.0 | 1 | 4 |
+
+총 17 sample / 28 (sample, para, bin_id) 페어.
+
+## 3. 2차 정밀 검증 (실제 SVG 겹침)
+
+IR 스캔은 단순 "같은 문단 내 같은 bin_id 가 2 회 이상" 검출이지만, 실제 렌더링 시점에 시각적 겹침이 있는지는 별개. baseline SVG 생성 후 `/tmp/find_real_overlaps.py` 로 nested `<svg>` / `<image>` 의 bbox 겹침을 검사한 결과 **단 7 SVG 의 25 페어**만 실제 겹침:
+
+| SVG | 페어 수 | 패턴 |
+|---|---|---|
+| **exam_eng_002.svg** | **1** | **x/width 동일, 세로만 인접 겹침 (대상 이슈)** |
+| 3-10월_교육_통합_2022_hwp/010.svg | 6 | x 대각선 오프셋 (의도적) |
+| 3-10월_교육_통합_2022_hwp/011.svg | 3 | x 대각선 오프셋 (의도적) |
+| 3-10월_교육_통합_2022_hwpx/010.svg | 6 | x 대각선 오프셋 (의도적) |
+| 3-10월_교육_통합_2022_hwpx/011.svg | 3 | x 대각선 오프셋 (의도적) |
+| test-image_hwp/test-image.svg | 3 | x 다름 (의도적 다중 배치) |
+| test-image_hwpx/test-image.svg | 3 | x 다름 (의도적 다중 배치) |
+
+### exam_eng.hwp page 2 의 페어 (대상)
+
+```
+LOWER (z=2, drawn first): bbox=(597.15, 243.59, 1005.34, 499.68)
+                          x=597.15, width=408.19, height=256.09
+                          viewBox=(0, 0, 2532, 1612.77) — src px 0-1612.77
+UPPER (z=3, drawn after): bbox=(597.15, 463.17, 1005.34, 533.17)
+                          x=597.15, width=408.19, height=70
+                          viewBox=(0, 1412.77, 2532, 434.43) — src px 1412.77-1847.20
+```
+
+핵심: **x 동일 (597.15) + width 동일 (408.19)** + 세로 겹침 (y 463.17-499.68).
+
+### 의도적 효과 케이스 (보호 대상)
+
+```
+test-image.hwp:
+  LOWER: bbox=(113.4, 132.3, 325.4, 334.7)  x=113.4, w=212.0
+  UPPER: bbox=(242.5, 132.3, 454.5, 334.7)  x=242.5, w=212.0
+  → x 다름 (offset 129px), 의도적 다중 배치
+
+3-10월_교육_통합_2022.hwp page 10:
+  LOWER: bbox=(736.0, 834.7, 1005.3, 941.4)
+  UPPER: bbox=(744.2, 852.7, 1013.5, 959.4)
+  → x 살짝 다름 (offset 8.2px), y 도 다름 → 대각선 오프셋 (그림자 효과 추정)
+```
+
+## 4. Algorithm 조건 결정 (Stage 2 의 사전 정리)
+
+위 분석에 기반하여 clip algorithm 조건을 **strict** 하게 설정해야 함:
+
+```
+모두 만족 시 clip 적용:
+1. A.bin_data_id == B.bin_data_id
+2. |A.x - B.x| <= 1.0 (수평 위치 동일)
+3. |A.width - B.width| <= 1.0 (수평 폭 동일)
+4. max(A.y, B.y) < min(A.y+A.height, B.y+B.height) (세로 겹침)
+5. A 가 트리 순서상 먼저 (z 작음), A.y < B.y (A 가 위)
+```
+
+이 strict 조건은 **exam_eng.hwp 의 정확한 케이스만 매칭**하고, test-image / 3-10월_교육_통합 등 의도적 효과를 그대로 보존.
+
+## 5. Baseline 산출물
+
+- SVG: `output/svg/task1154_baseline/<sample>_<ext>/<file>.svg` (영향 17 sample)
+- PNG (영향 페이지 4 개): `output/svg/task1154_baseline/png/`
+  - `exam_eng_hwp_exam_eng_002.png`
+  - `3-10월_교육_통합_2022_hwp_3-10월_교육_통합_2022_010.png`
+  - `3-10월_교육_통합_2022_hwp_3-10월_교육_통합_2022_011.png`
+  - `test-image_hwp_test-image.png`
+
+## 6. 다음 단계 (Stage 2)
+
+- `PageRenderTree::clip_overlapping_same_bin_images()` 함수 시그니처 동결
+- 위 5 조건 algorithm 의 단위 테스트 우선 작성 (TDD)
+- 단위 테스트 commit 만 분리 (구현 미포함)
+
+## 7. 산출물 / 도구
+
+- IR 스캔 스크립트: `/tmp/scan_bin_id_pairs.py`
+- 실제 겹침 검출 스크립트: `/tmp/find_real_overlaps.py`
+- 실행 로그: `/tmp/scan_results.log`, `/tmp/real_overlaps.log`
+
+승인 후 Stage 2 진행.

--- a/mydocs/working/task_m100_1154_stage2.md
+++ b/mydocs/working/task_m100_1154_stage2.md
@@ -1,0 +1,80 @@
+# Task #1154 Stage 2 완료 보고서 — Algorithm 구현 + 단위 테스트
+
+## 1. 목표
+
+- `PageRenderTree::clip_overlapping_same_bin_images()` 메서드 구현 (algorithm 단독, 호출 지점 통합은 Stage 3)
+- Stage 1 에서 도출한 strict 5 조건의 단위 테스트로 algorithm 검증
+- 의도적 효과 (test-image, 3-10월_교육_통합) 보호 회귀 보장
+
+## 2. 구현
+
+`src/renderer/render_tree.rs` 에 추가:
+
+```rust
+impl PageRenderTree {
+    /// 동일 bin_data_id 를 가진 ImageNode 가 세로로 인접 겹칠 때,
+    /// 트리 순서상 먼저 그려지는 (z 가 작은) 쪽의 bbox/crop 을 위에 덮는
+    /// (z 가 큰) 쪽의 top 까지 축소한다.
+    pub fn clip_overlapping_same_bin_images(&mut self);
+}
+```
+
+### Algorithm (3-phase)
+
+1. **Phase 1 (수집)**: 트리 DFS pre-order 로 `(NodeId, BoundingBox, bin_id, crop)` 튜플 수집. 트리 순서 = SVG paint 순서 = z-order.
+2. **Phase 2 (페어 검출)**: 5 조건 모두 만족하는 (A=lower, B=upper) 페어 검출:
+   - 같은 `bin_data_id`
+   - `|A.x - B.x| <= 1.0`
+   - `|A.width - B.width| <= 1.0`
+   - `A.y < B.y` (A 가 위)
+   - `A.y + A.height > B.y` (세로 겹침)
+   - A 의 new_height = `B.y - A.y`, new_crop.bottom = `crop.top + (crop.bottom - crop.top) * ratio` (round)
+   - 여러 UPPER 와 겹치는 A 의 경우 가장 작은 new_height 채택
+3. **Phase 3 (적용)**: HashMap<NodeId, (new_height, new_crop)> 으로 트리 walk 하여 mutation.
+
+## 3. 단위 테스트 (11 개, 모두 통과)
+
+| 테스트 | 검증 |
+|---|---|
+| `test_clip_exam_eng_pattern` | exam_eng.hwp page 2 의 정확한 geometry (LOWER bbox/crop 축소, UPPER 불변) |
+| `test_clip_different_bin_id_no_clip` | 다른 bin_id → 무시 |
+| `test_clip_no_vertical_overlap_no_clip` | 세로 gap → 무시 |
+| `test_clip_different_x_no_clip` | x 다름 (대각선 오프셋) → 무시 — **test-image / 3-10월_교육_통합 회귀 보호** |
+| `test_clip_different_width_no_clip` | width 다름 (다른 크기) → 무시 — **pic2.hwp 회귀 보호** |
+| `test_clip_reversed_order_no_clip` | 트리 순서가 반대 (A.y > B.y) → 무시 |
+| `test_clip_without_crop` | crop=None 케이스: bbox 만 축소 |
+| `test_clip_three_overlapping_chain` | A < B < C: A→B.top, B→C.top, C 불변 |
+| `test_clip_nested_children` | Body > Children 깊이의 ImageNode 도 처리 |
+| `test_clip_single_image_no_op` | 단일 이미지 → no-op |
+
+### 핵심 회귀 보호 테스트 (test_clip_different_x_no_clip)
+
+Stage 1 에서 식별한 의도적 효과 케이스를 모방. test-image.hwp / 3-10월_교육_통합_2022 의 패턴 (x 가 8px 등 다른 그림자/2중 효과)이 변형되지 않음을 가드.
+
+## 4. 검증 결과
+
+```
+cargo test --release --lib clip_
+  test result: ok. 11 passed; 0 failed; 0 ignored
+
+cargo test --release --lib (전체)
+  test result: ok. 1318 passed; 0 failed; 6 ignored; 0 measured
+
+cargo clippy --release --lib -- -D warnings
+  Finished — no warnings
+
+cargo fmt — applied to render_tree.rs only
+```
+
+## 5. 산출물
+
+- 코드: `src/renderer/render_tree.rs` (+438 lines: impl + 11 tests + helpers)
+- 보고서: `mydocs/working/task_m100_1154_stage2.md`
+
+## 6. 다음 단계 (Stage 3)
+
+- 각 렌더러 (svg/web_canvas/skia) 의 페이지 렌더 진입부에서 `clip_overlapping_same_bin_images()` 호출 통합
+- exam_eng.hwp page 2 SVG 재생성 → 권위 PDF (`pdf/exam_eng-2022.pdf`) 와 시각 비교
+- 회귀 sample 인 test-image / 3-10월_교육_통합 의 시각 불변 확인
+
+승인 후 Stage 3 진행.

--- a/mydocs/working/task_m100_1154_stage3.md
+++ b/mydocs/working/task_m100_1154_stage3.md
@@ -1,0 +1,120 @@
+# Task #1154 Stage 3 완료 보고서 — 렌더러 호출 지점 통합 + 시각 검증
+
+## 1. 목표
+
+- Stage 2 에서 도입한 `PageRenderTree::clip_overlapping_same_bin_images()` 의
+  호출 지점을 결정/통합.
+- exam_eng.hwp page 2 의 잔상(이중 라인) 제거 시각 확인.
+- 의도적 효과 sample(test-image, 3-10월_교육_통합) 회귀 무영향 확인.
+
+## 2. 호출 지점 분석 (렌더러 7곳 vs. 중앙 1곳)
+
+조사 결과 PageRenderTree 를 소비하는 렌더러 진입부는 총 7곳:
+
+| 위치 | 시그니처 | 입력 |
+|---|---|---|
+| `svg.rs:173` | `render_tree(&PageRenderTree)` | PageRenderTree |
+| `svg_layer.rs:240` | `render_tree(&PageRenderTree)` | PageLayerTree → 재조립 |
+| `canvas.rs:83` | `render_tree(&PageRenderTree)` (legacy) | PageRenderTree |
+| `canvas.rs:317` | `render_page(&PageLayerTree)` | PageLayerTree |
+| `web_canvas.rs:308` | `render_tree(&PageRenderTree)` (WASM) | PageRenderTree |
+| `web_canvas.rs:1860` | `render_page(&PageLayerTree)` | PageLayerTree |
+| `html.rs:44` | `render_tree(&PageRenderTree)` | PageRenderTree |
+
+이 모든 렌더러는 `DocumentCore::build_page_tree()` 또는 (캐시 경유)
+`build_page_tree_cached()` 가 만든 PageRenderTree 를 소비. 또한
+`build_page_layer_tree()` 도 내부에서 `build_page_tree_cached()` 를 호출하고
+`LayerBuilder` 가 ImageNode bbox / crop 을 그대로 PaintOp::Image 에 복사
+(`src/paint/builder.rs:86`)하므로 layer 경로도 동일하게 영향을 받는다.
+
+### 설계 결정 — 중앙 1곳 통합
+
+수행계획서/구현계획서의 권장(“PageRenderTree 빌드 직후 1 회만, finalize 시점”)에
+따라 **`build_page_tree()` 의 종단**(`extra_mps` 머지 후, `Ok(tree)` 직전)에
+1 회 호출.
+
+근거:
+- 단일 진실 공급원 — 신규 렌더러 추가 시 호출 누락 위험 없음.
+- 캐시(`build_page_tree_cached`) 도 자동으로 clip 적용된 트리를 보관.
+- WASM `getPageRenderTree` JSON 도 정정된 트리 반환 → 외부 소비자 일관성.
+- IR 단계 후처리(픽셀이 아닌 IR 에서 정정) — 자연스러운 추상화.
+
+## 3. 변경 사항
+
+`src/document_core/queries/rendering.rs:2585-2591`:
+
+```rust
+// 확장 바탕쪽 추가 렌더링
+for ext_mp in &extra_mps {
+    self.layout_engine.build_master_page_into(...);
+}
+// Task #1154: 동일 bin_data_id Pic 컨트롤이 수직으로 인접 겹쳐 그려질 때
+// 두 그림의 미세한 세로 스케일 차이로 인한 잔상(이중 라인) 제거.
+// build 직후 1회만 적용 — 모든 렌더러(SVG/Canvas/Skia/HTML/Layer) 공통.
+tree.clip_overlapping_same_bin_images();
+Ok(tree)
+```
+
+## 4. 검증 결과
+
+### 4.1 단위 테스트 / clippy / fmt
+
+```
+cargo test --release --lib
+  test result: ok. 1318 passed; 0 failed; 6 ignored
+
+cargo clippy --release --lib -- -D warnings
+  Finished — no warnings
+
+cargo fmt — applied to rendering.rs only
+```
+
+### 4.2 exam_eng.hwp page 2 (대상 케이스)
+
+`output/svg/task1154_baseline/exam_eng_hwp/exam_eng_002.svg`(stale text rendering
+diff 포함)이 아닌 “same-commit no-clip 산출물”로 공정 비교 수행:
+
+- no-clip: `RHWP_TASK1154_NOCLIP=1 ...` 임시 가드 경유 산출 (검증용, 본 커밋엔 제외)
+- with-clip: 일반 산출
+
+LOWER (z=2):
+- before: `y=243.59, height=256.09, viewBox="0 0 2532 1612.77"`
+- after:  `y=243.59, height=**219.59**, viewBox="0 0 2532 **1382.87**"`
+- height 변화 = `B.y(=463.17) − A.y(=243.59) = 219.58` ✓
+- crop bottom 비례 축소: `1612.77 × (219.59 / 256.09) ≈ 1382.87` ✓
+
+UPPER (z=3):
+- before/after 모두 `y=463.17, height=70, viewBox="0 1412.77 2532 434.43"` (불변) ✓
+
+### 4.3 의도적 효과 회귀 무영향
+
+| Sample | 페이지 수 | no-clip vs with-clip diff |
+|---|---|---|
+| test-image.hwp | 1 | **동일** |
+| 3-10월_교육_통합_2022.hwp | 16 | **모든 페이지 동일** |
+| exam_eng.hwp | 8 | page 2 만 차이 |
+
+→ strict 5 조건이 의도된 회귀 보호(x/width 동일 가드)를 정확히 수행.
+
+### 4.4 LayerBuilder 검증
+
+`src/paint/builder.rs:86` 에서 `RenderNodeType::Image(image)` 는 `node.bbox` 와
+`image.clone()` (crop 4 필드 포함)을 그대로 `PaintOp::Image` 에 복사하므로
+PageRenderTree 단계 clip 은 layer 트리에 그대로 전파. CanvasRenderer /
+SvgLayerRenderer / 기타 layer 기반 백엔드도 fix 의 혜택을 자동으로 받는다.
+
+## 5. 산출물
+
+- 코드: `src/document_core/queries/rendering.rs` (build_page_tree 끝에 1줄 추가)
+- 보고서: `mydocs/working/task_m100_1154_stage3.md`
+- 검증 산출물: `/tmp/task1154_no_clip/`, `/tmp/task1154_with_clip/` (임시)
+
+## 6. 다음 단계 (Stage 4)
+
+- 전체 sample sweep (Stage 1 식별 17 sample) 회귀 시각/diff 검증.
+- 일반 회귀: exam_kor, exam_math, biz_plan, 통합재정통계, 시험지 일반,
+  HWPX 변환본 sweep.
+- WASM 빌드 (`docker compose --env-file .env.docker run --rm wasm`).
+- 최종 결과 보고서 `mydocs/report/task_m100_1154_report.md`.
+
+승인 후 Stage 4 진행.

--- a/mydocs/working/task_m100_1154_v2_stage1.md
+++ b/mydocs/working/task_m100_1154_v2_stage1.md
@@ -1,0 +1,52 @@
+# Task M100 #1154 v2 — Stage 1 완료 보고서
+
+## 구현 내용
+
+### Backend: overlay JSON 에 crop 필드 추가
+
+`src/document_core/queries/rendering.rs` `write_overlay_image`:
+
+```rust
+write_json_str(buf, wrap_str(wrap));
+
+if let Some((left, top, right, bottom)) = image.crop {
+    let _ = write!(
+        buf,
+        ",\"crop\":{{\"left\":{},\"top\":{},\"right\":{},\"bottom\":{}}}",
+        left, top, right, bottom
+    );
+}
+```
+
+기존 layer tree 메인 JSON (`paint/json.rs::PaintOp::Image`) 의 crop 직렬화 형태와 정확히 동일.
+
+### Frontend: OverlayImageInfo 확장 + createOverlayLayer wrapper
+
+`rhwp-studio/src/view/page-renderer.ts`:
+
+1. **타입**: `OverlayImageInfo` 에 `crop?: { left; top; right; bottom }` 추가 (HWPUNIT).
+2. **폴백**: `toOverlayInfo` (PageLayerTree JSON 직접 파싱 폴백 경로) 도 `op.crop` 전달.
+3. **렌더링**: `createOverlayLayer` 분기:
+   - crop 이 의미 있는 경우 (`right > left` 그리고 `bottom > top`):
+     - sxPx = crop.left/75, syPx = crop.top/75, swPx, shPx 계산.
+     - scaleX = dw/swPx, scaleY = dh/shPx.
+     - wrapper div: `position: absolute`, bbox 크기, `overflow: hidden`.
+     - 내부 `<img>`: `position: absolute`, `(-sx*scaleX, -sy*scaleY)`, `width/height = naturalWidth*scaleX / naturalHeight*scaleY` (onload 시점 확정).
+   - crop 없으면 기존 직접 bbox 배치 유지.
+4. CSS filter / mixBlendMode / opacity 는 `<img>` 자체에 그대로 적용 — wrapper 가 단순 clip 역할.
+
+## 검증
+
+| 검증 | 결과 |
+|---|---|
+| 페이지 2 박스 18 시각 (page.screenshot, overlay 포함) | 윈도우 chrome frame 단일 정상 표시, SVG export 와 시각 일치 ✓ |
+| 페이지 2 layer JSON crop 필드 존재 | image #2 (LOWER): crop=(0, 0, 189900, 120958), image #3 (UPPER): crop=(0, 105958, 189900, 138540) ✓ |
+| overlay 렌더 결과의 bbox/scale 일관성 | image #2 bbox.height=219.587 (commit 8ee17fd4 clip 적용), wrapper 가 source rect 0~120958 HU 만 표시 ✓ |
+| 페이지 2 SVG export (변경 영향 없음 확인) | 8ee17fd4 commit 시점과 동일 ✓ |
+| cargo test --release --lib | 1432 passed / 0 failed (Rust 변경은 JSON 출력 1 줄 추가, 기존 테스트 영향 없음) |
+| cargo clippy --release --lib -- -D warnings | clean |
+| npx tsc --noEmit | clean |
+
+## 다음
+
+Stage 2 — 페이지 4 박스 27 (flow layer 큰 PNG 비동기 디코드) 안전망 추가.

--- a/mydocs/working/task_m100_1154_v2_stage2.md
+++ b/mydocs/working/task_m100_1154_v2_stage2.md
@@ -1,0 +1,52 @@
+# Task M100 #1154 v2 — Stage 2 완료 보고서
+
+## 구현 내용
+
+### scheduleReRender delays 확장 + prefetchFlowImages 안전망
+
+`rhwp-studio/src/view/page-renderer.ts`:
+
+#### 1. delays 배열 확장
+
+```typescript
+const delays = [200, 600, 1500];   // 기존 [200, 600]
+```
+
+큰 PNG/JPEG (수십~수백 KB) 의 디코드가 1 초 이상 걸리는 경우 커버.
+
+#### 2. prefetchFlowImages 신규 메서드
+
+```typescript
+private async prefetchFlowImages(pageIdx: number): Promise<void> {
+  // wasm.getPageLayerTree(pageIdx) JSON 에서 image 항목 추출
+  // mime + base64 만 사용 (정규식, behindText/inFrontOfText 제외)
+  // 각 image 마다 new Image() + image.decode() 으로 prefetch
+  // 모든 image 디코드 완료 후 resolve
+}
+```
+
+`scheduleReRender` 안에서 `queueMicrotask(() => this.prefetchFlowImages(...).then(() => 재렌더))` 으로 setTimeout 흐름과 독립 실행. 디코드 완료 시 한 번 더 강제 `renderPageToCanvasFiltered` 호출.
+
+decode() 미지원 브라우저 (구형) 대응으로 `onload` / `onerror` 도 등록 (둘 다 resolve).
+
+## 검증
+
+| 검증 | 결과 |
+|---|---|
+| 페이지 4 박스 27 시각 (canvas toDataURL, lazy load) | 종이 디자인 + 핀 두 개 + 외곽선 모두 정상 표시 ✓ |
+| 직접 렌더 (renderPageToCanvas) 두 번 호출 + 대기 패턴 | 첫 호출 누락 → 두 번째 호출 정상 (디코드 완료) ✓ — 안전망 동작 원리 확인 |
+| 페이지 4 layer JSON image bbox | image #3 = (597.1, 268.1, 403.7, 432.3), bbox 변경 없음 (clip 적용 흔적 없음 — 페이지 4 와 commit 8ee17fd4 의 PageRenderTree clip 은 무관) |
+| 페이지 2 박스 18 시각 (Stage 1 회귀 검증) | 정상 유지 ✓ |
+| 다른 페이지 (1, 3, 5~8) lazy load 시각 | 회귀 없음 (단순 확인, BehindText overlay 없는 페이지는 prefetch 도 동작 없음) |
+| cargo test --release --lib | 1432 passed / 0 failed |
+| cargo clippy --release --lib -- -D warnings | clean |
+| npx tsc --noEmit | clean |
+
+## 부수 효과
+
+- `scheduleReRender` 호출 횟수 증가: 페이지당 최대 3 번 (기존 2 번) + prefetch 콜백 1 번. 이미지 없는 페이지는 `imageCount=0` 으로 skip 되어 비용 없음.
+- prefetch 중복 디코드 비용은 무시 가능 (브라우저 캐시).
+
+## 다음
+
+Stage 3 — WASM 재빌드 + 통합 회귀 검증.

--- a/mydocs/working/task_m100_1154_v2_stage3.md
+++ b/mydocs/working/task_m100_1154_v2_stage3.md
@@ -1,0 +1,53 @@
+# Task M100 #1154 v2 — Stage 3 완료 보고서
+
+## 수행
+
+1. **WASM 재빌드**: `docker compose --env-file .env.docker run --rm wasm` — Stage 1 의 Rust 변경 (overlay JSON crop 필드) 반영. 결과 `pkg/rhwp_bg.wasm` 5,311 KB.
+2. **헤드리스 캡쳐 재실행**:
+   - 페이지 2 박스 18 (page.screenshot, overlay 포함): 정상 ✓
+   - 페이지 4 박스 27 (canvas toDataURL, lazy load + 3 초 대기): 정상 ✓
+3. **lint / test 재실행**.
+
+## 검증 결과
+
+### 시각
+
+| 환경 | 페이지 2 박스 18 | 페이지 4 박스 27 |
+|---|---|---|
+| 한컴 PDF (권위) | ✓ | ✓ |
+| SVG export (`rhwp export-svg`) | ✓ | ✓ |
+| rhwp-studio (Step 1만, 8ee17fd4 적용 + WASM 재빌드) | 잔상 (stretched overlay) | 외곽 그림 누락 |
+| rhwp-studio (Step 1 + Step 2 = Stage 1 적용) | **정상** | 외곽 그림 누락 |
+| rhwp-studio (Step 1 + Step 2 + Step 3 = Stage 1 + Stage 2 적용) | **정상** | **정상** |
+
+### 자동 검증
+
+| 검증 | 결과 |
+|---|---|
+| cargo test --release --lib | 1432 passed / 0 failed / 6 ignored |
+| cargo clippy --release --lib -- -D warnings | clean |
+| npx tsc --noEmit (rhwp-studio) | clean |
+| cargo fmt 적용 | 변경 파일만 (rendering.rs) |
+
+## 변경 파일 (v2 누적)
+
+| 파일 | 변경 내용 | LoC 변화 |
+|---|---|---|
+| `src/document_core/queries/rendering.rs` | `write_overlay_image` 에 crop 필드 출력 | +7 |
+| `rhwp-studio/src/view/page-renderer.ts` | `OverlayImageInfo.crop`, `toOverlayInfo.crop`, `createOverlayLayer` wrapper, `scheduleReRender` delays, `prefetchFlowImages` 추가 | +120 / -13 |
+| `pkg/*` | WASM 재빌드 (gitignore) | — |
+
+## 한컴 PDF 권위 자료 비교 (시각)
+
+- 페이지 2 박스 18 "Dear Rosydale City Marathon Racers" : 윈도우 chrome frame 단일, 하단 단일 라인, SVG / rhwp-studio 모두 PDF 와 시각 일치
+- 페이지 4 박스 27 "Adenville City Pass Card" : 종이 디자인 + 핀 두 개 + 외곽선, SVG / rhwp-studio 모두 PDF 와 시각 일치
+
+## 회귀 보호
+
+- Stage 1 (overlay crop) — BehindText/InFrontOfText overlay 경로에만 영향. flow layer 비변경.
+- Stage 2 (prefetch) — flow layer 의 추가 재렌더 + image prefetch. 이미지 없는 페이지는 skip.
+- 둘 다 Rust 측 변경 1 줄 (JSON 추가) 외에는 TypeScript only. 기존 cargo test / clippy 통과 유지.
+
+## 결론
+
+페이지 2 박스 18 + 페이지 4 박스 27 모두 한컴 PDF 와 시각 일치 달성. v2 작업 완료.

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -18,6 +18,8 @@ export interface OverlayImageInfo {
   bakedWatermark?: boolean;
   wrap: 'behindText' | 'inFrontOfText';
   transform?: { rotation: number; horzFlip: boolean; vertFlip: boolean };
+  /** 그림 자르기 (HWPUNIT, 75 HU = 1 px @ 96 DPI). `<img>` 의 source rect → bbox 매핑용. */
+  crop?: { left: number; top: number; right: number; bottom: number };
 }
 
 interface OverlayImagesResult {
@@ -220,16 +222,11 @@ export class PageRenderer {
     for (const img of images) {
       const el = document.createElement('img');
       el.src = `data:${img.mime};base64,${img.base64}`;
-      el.style.position = 'absolute';
-      // bbox 는 zoom=1 페이지 좌표계이므로 화면 표시 배율을 적용한다.
-      el.style.left = `${img.bbox.x * displayScale}px`;
-      el.style.top = `${img.bbox.y * displayScale}px`;
-      el.style.width = `${img.bbox.width * displayScale}px`;
-      el.style.height = `${img.bbox.height * displayScale}px`;
       el.style.pointerEvents = 'none';
+
+      const filterParts: string[] = [];
       if (!img.bakedWatermark) {
         // CSS filter (그림 효과 + 밝기 + 대비)
-        const filterParts: string[] = [];
         if (img.effect === 'grayScale' || img.effect === 'pattern8x8') {
           filterParts.push('grayscale(100%)');
         } else if (img.effect === 'blackWhite') {
@@ -253,7 +250,64 @@ export class PageRenderer {
         el.style.opacity = '0.17';
       }
       // transform (회전/플립) — 작업 우선순위 낮음, 본 사이클은 미적용
-      layer.appendChild(el);
+
+      // bbox 는 zoom=1 페이지 좌표계이므로 화면 표시 배율을 적용한다.
+      const dx = img.bbox.x * displayScale;
+      const dy = img.bbox.y * displayScale;
+      const dw = img.bbox.width * displayScale;
+      const dh = img.bbox.height * displayScale;
+
+      // crop (HWPUNIT, 75 HU = 1 px @ 96 DPI) 가 있고 자르기가 의미 있는 경우 source rect 처리.
+      // <img> 는 직접 source rect 를 지정할 수 없으므로 wrapper div + overflow:hidden 으로
+      // 시각 영역만 노출하고 내부 img 를 scale + offset 으로 배치한다 (Task #1154).
+      const crop = img.crop;
+      const cropSpanW = crop ? Math.max(0, crop.right - crop.left) : 0;
+      const cropSpanH = crop ? Math.max(0, crop.bottom - crop.top) : 0;
+      const hasCrop = !!crop && cropSpanW > 0 && cropSpanH > 0;
+      if (hasCrop && crop) {
+        // crop_hu / 75 → source rect (px) in image natural pixel space.
+        const sxPx = crop.left / 75;
+        const syPx = crop.top / 75;
+        const swPx = cropSpanW / 75;
+        const shPx = cropSpanH / 75;
+        const scaleX = dw / swPx;
+        const scaleY = dh / shPx;
+
+        const wrapper = document.createElement('div');
+        wrapper.style.position = 'absolute';
+        wrapper.style.left = `${dx}px`;
+        wrapper.style.top = `${dy}px`;
+        wrapper.style.width = `${dw}px`;
+        wrapper.style.height = `${dh}px`;
+        wrapper.style.overflow = 'hidden';
+        wrapper.style.pointerEvents = 'none';
+
+        el.style.position = 'absolute';
+        el.style.left = `${-sxPx * scaleX}px`;
+        el.style.top = `${-syPx * scaleY}px`;
+        // img.naturalWidth/Height 는 디코딩 완료 후에만 정확하므로 onload 시점에 적용.
+        // 첫 렌더 즉시 비율로 width 만 지정 (naturalWidth 대신 swPx*scaleX = dw 같은
+        // 자명한 단서가 없어, 로드 전에는 시각이 어색할 수 있다. scheduleReRender 가
+        // 이미 비동기 디코드를 처리하므로 onload 콜백으로 최종 크기를 확정한다).
+        const applyNaturalSize = () => {
+          el.style.width = `${el.naturalWidth * scaleX}px`;
+          el.style.height = `${el.naturalHeight * scaleY}px`;
+        };
+        if (el.complete && el.naturalWidth > 0) {
+          applyNaturalSize();
+        } else {
+          el.addEventListener('load', applyNaturalSize, { once: true });
+        }
+        wrapper.appendChild(el);
+        layer.appendChild(wrapper);
+      } else {
+        el.style.position = 'absolute';
+        el.style.left = `${dx}px`;
+        el.style.top = `${dy}px`;
+        el.style.width = `${dw}px`;
+        el.style.height = `${dh}px`;
+        layer.appendChild(el);
+      }
     }
     return layer;
   }
@@ -354,7 +408,10 @@ export class PageRenderer {
   /**
    * 비동기 이미지 로드 대응: data URL 이미지가 첫 렌더링 시
    * 아직 디코딩되지 않았을 수 있으므로 점진적 재렌더링한다.
-   * 200ms, 600ms 두 번 재시도하여 대부분의 이미지 로드를 커버한다.
+   *
+   * 작은 이미지 (헤더 라벨 등) 는 200/600ms 안에 디코드되지만, 큰 PNG/JPEG
+   * (수십 KB~수백 KB) 는 디코드가 1초 이상 걸릴 수 있어 한 번 더 시도하고
+   * (Task #1154), 그래도 누락이면 마지막에 자체 prefetch로 강제 디코드한다.
    */
   private scheduleReRender(
     pageIdx: number,
@@ -372,7 +429,7 @@ export class PageRenderer {
     this.cancelReRender(pageIdx);
     this.imageRetryCounts.set(pageIdx, imageCount);
 
-    const delays = [200, 600];
+    const delays = [200, 600, 1500];
     const timers: ReturnType<typeof setTimeout>[] = [];
 
     for (const delay of delays) {
@@ -384,7 +441,60 @@ export class PageRenderer {
       }, delay);
       timers.push(timer);
     }
+
+    // 안전망: 1500ms 시점에서도 큰 이미지가 디코드 안 끝났을 수 있으므로,
+    // 페이지의 flow image base64 들을 자체 prefetch (Image.decode()) 한 후
+    // 모두 완료되면 한 번 더 렌더링한다. setTimeout 과 별개로 동작.
+    queueMicrotask(() => {
+      this.prefetchFlowImages(pageIdx)
+        .then(() => {
+          if (canvas.parentElement) {
+            this.wasm.renderPageToCanvasFiltered(pageIdx, canvas, renderScale, 'flow');
+            this.drawMarginGuides(pageIdx, canvas, renderScale);
+          }
+        })
+        .catch(() => {});
+    });
+
     this.reRenderTimers.set(pageIdx, timers);
+  }
+
+  /**
+   * 페이지의 flow layer image (BehindText/InFrontOfText 제외) base64 데이터를
+   * 자체 prefetch 하여 모든 이미지가 브라우저에 디코드 완료될 때까지 대기.
+   * Task #1154 — IMAGE_CACHE 의 비동기 디코드 누락 안전망.
+   */
+  private async prefetchFlowImages(pageIdx: number): Promise<void> {
+    let json: string;
+    try {
+      json = this.wasm.getPageLayerTree(pageIdx);
+    } catch {
+      return;
+    }
+    // image 항목들의 mime + base64 추출 (간단한 정규식)
+    const re = /"type":"image"[^}]*?(?:"wrap":"(behindText|inFrontOfText)")?[^}]*?"mime":"([^"]+)","base64":"([^"]+)"/g;
+    const tasks: Promise<unknown>[] = [];
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(json)) !== null) {
+      const wrap = m[1]; // overlay wrap 은 prefetch 대상 아님 (별도 <img>)
+      if (wrap === 'behindText' || wrap === 'inFrontOfText') continue;
+      const mime = m[2];
+      const b64 = m[3];
+      const dataUrl = `data:${mime};base64,${b64}`;
+      tasks.push(
+        new Promise<void>((resolve) => {
+          const img = new Image();
+          img.onload = () => resolve();
+          img.onerror = () => resolve();
+          img.src = dataUrl;
+          // decode() 이 더 정확하지만 일부 브라우저 미지원
+          if (typeof img.decode === 'function') {
+            img.decode().then(() => resolve()).catch(() => resolve());
+          }
+        }),
+      );
+    }
+    await Promise.all(tasks);
   }
 
   /** 특정 페이지의 지연 재렌더링을 취소한다 */
@@ -459,5 +569,6 @@ function toOverlayInfo(op: any, wrap: 'behindText' | 'inFrontOfText'): OverlayIm
     bakedWatermark: op.bakedWatermark === true,
     wrap,
     transform: op.transform,
+    crop: op.crop,
   };
 }

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -3087,6 +3087,10 @@ impl DocumentCore {
                 page_content.page_number,
             );
         }
+        // Task #1154: 동일 bin_data_id Pic 컨트롤이 수직으로 인접 겹쳐 그려질 때
+        // 두 그림의 미세한 세로 스케일 차이로 인한 잔상(이중 라인) 제거.
+        // build 직후 1회만 적용 — 모든 렌더러(SVG/Canvas/Skia/HTML/Layer) 공통.
+        tree.clip_overlapping_same_bin_images();
         Ok(tree)
     }
 

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -613,6 +613,14 @@ impl DocumentCore {
             );
             write_json_str(buf, wrap_str(wrap));
 
+            if let Some((left, top, right, bottom)) = image.crop {
+                let _ = write!(
+                    buf,
+                    ",\"crop\":{{\"left\":{},\"top\":{},\"right\":{},\"bottom\":{}}}",
+                    left, top, right, bottom
+                );
+            }
+
             let attr = crate::model::image::ImageAttr {
                 brightness: image.brightness,
                 contrast: image.contrast,

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1071,6 +1071,117 @@ impl PageRenderTree {
     pub fn mark_all_clean(&mut self) {
         self.root.mark_clean_recursive();
     }
+
+    /// 동일 `bin_data_id` 를 가진 ImageNode 가 세로로 인접 겹칠 때,
+    /// 트리 순서상 먼저 그려지는 (z 가 작은) 쪽의 bbox/crop 을 위에 덮는
+    /// (z 가 큰) 쪽의 top 까지 축소한다.
+    ///
+    /// Task #1154: 동일 이미지를 두 Pic 컨트롤로 겹쳐 박스 효과를 만든 경우
+    /// 두 그림의 세로 스케일이 미세하게 달라 안티엘리어싱/리샘플링 시 잔상
+    /// (이중 라인) 이 노출되는 문제를 해결한다.
+    ///
+    /// 적용 조건 (모두 만족 시 clip):
+    /// 1. `A.bin_data_id == B.bin_data_id`
+    /// 2. `|A.x - B.x| <= 1.0` (수평 위치 동일)
+    /// 3. `|A.width - B.width| <= 1.0` (수평 폭 동일)
+    /// 4. A 가 트리 순서상 먼저 + `A.y < B.y` (A 가 위에 있음)
+    /// 5. `A.y + A.height > B.y` (세로 겹침)
+    ///
+    /// 조건 2/3 은 의도적 시각 효과 (test-image, 3-10월_교육_통합 의 대각선
+    /// 오프셋 등) 를 보호하기 위한 strict 가드.
+    pub fn clip_overlapping_same_bin_images(&mut self) {
+        // Phase 1: 트리 순서대로 ImageNode 의 (id, bbox, bin_id, crop) 수집
+        let mut images: Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)> = Vec::new();
+        Self::collect_image_nodes(&self.root, &mut images);
+
+        if images.len() < 2 {
+            return;
+        }
+
+        // Phase 2: 페어 검출 + 각 LOWER 노드별 최종 clip 결정
+        // 한 노드가 여러 UPPER 와 겹치면 가장 위쪽 UPPER 를 기준으로 가장 작은 height 적용
+        let mut clips: std::collections::HashMap<NodeId, (f64, Option<(i32, i32, i32, i32)>)> =
+            std::collections::HashMap::new();
+
+        for i in 0..images.len() {
+            for j in (i + 1)..images.len() {
+                let (id_a, bbox_a, bin_a, crop_a) = &images[i];
+                let (_id_b, bbox_b, bin_b, _crop_b) = &images[j];
+                // 조건 1: 같은 bin_id
+                if bin_a != bin_b {
+                    continue;
+                }
+                // 조건 2/3: x, width 동일 (1px tolerance)
+                if (bbox_a.x - bbox_b.x).abs() > 1.0 {
+                    continue;
+                }
+                if (bbox_a.width - bbox_b.width).abs() > 1.0 {
+                    continue;
+                }
+                // 조건 4: A 가 위 (A.y < B.y)
+                if bbox_a.y >= bbox_b.y {
+                    continue;
+                }
+                // 조건 5: 세로 겹침 (A.y + A.height > B.y)
+                let a_bottom = bbox_a.y + bbox_a.height;
+                if a_bottom <= bbox_b.y {
+                    continue;
+                }
+                // Clip 계산: A 의 new_height = B.y - A.y
+                let new_height = bbox_b.y - bbox_a.y;
+                if new_height <= 0.0 || new_height >= bbox_a.height {
+                    continue;
+                }
+                let ratio = new_height / bbox_a.height;
+                let new_crop = crop_a.map(|(cl, ct, cr, cb)| {
+                    let span = (cb - ct) as f64;
+                    let new_cb = ct + (span * ratio).round() as i32;
+                    (cl, ct, cr, new_cb)
+                });
+                // 여러 UPPER 와 겹칠 때 가장 작은 new_height 채택
+                let entry = clips.entry(*id_a).or_insert((new_height, new_crop));
+                if new_height < entry.0 {
+                    *entry = (new_height, new_crop);
+                }
+            }
+        }
+
+        if clips.is_empty() {
+            return;
+        }
+
+        // Phase 3: 트리 walk 하여 mutation 적용
+        Self::apply_image_clips(&mut self.root, &clips);
+    }
+
+    fn collect_image_nodes(
+        node: &RenderNode,
+        out: &mut Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)>,
+    ) {
+        if let RenderNodeType::Image(img) = &node.node_type {
+            out.push((node.id, node.bbox, img.bin_data_id, img.crop));
+        }
+        for child in &node.children {
+            Self::collect_image_nodes(child, out);
+        }
+    }
+
+    fn apply_image_clips(
+        node: &mut RenderNode,
+        clips: &std::collections::HashMap<NodeId, (f64, Option<(i32, i32, i32, i32)>)>,
+    ) {
+        if let Some((new_height, new_crop)) = clips.get(&node.id) {
+            node.bbox.height = *new_height;
+            if let RenderNodeType::Image(ref mut img) = &mut node.node_type {
+                if let Some(c) = new_crop {
+                    img.crop = Some(*c);
+                }
+            }
+        }
+        for child in &mut node.children {
+            Self::apply_image_clips(child, clips);
+        }
+    }
 }
 
 #[cfg(test)]
@@ -1130,5 +1241,332 @@ mod tests {
         let bbox = BoundingBox::from_hwpunit_rect(&rect, 96.0);
         assert!((bbox.width - 96.0).abs() < 0.01);
         assert!((bbox.height - 96.0).abs() < 0.01);
+    }
+
+    // === Task #1154: clip_overlapping_same_bin_images 단위 테스트 ===
+
+    fn make_image_node(
+        id: NodeId,
+        bbox: BoundingBox,
+        bin_id: u16,
+        crop: Option<(i32, i32, i32, i32)>,
+    ) -> RenderNode {
+        let img = ImageNode {
+            crop,
+            ..ImageNode::new(bin_id, None)
+        };
+        RenderNode::new(id, RenderNodeType::Image(img), bbox)
+    }
+
+    fn image_bbox(node: &RenderNode) -> BoundingBox {
+        node.bbox
+    }
+
+    fn image_crop(node: &RenderNode) -> Option<(i32, i32, i32, i32)> {
+        match &node.node_type {
+            RenderNodeType::Image(img) => img.crop,
+            _ => None,
+        }
+    }
+
+    /// exam_eng.hwp 페이지 2 의 정확한 케이스 (수평 동일 + 세로 인접)
+    /// → LOWER 의 bbox.height 와 crop.bottom 이 UPPER 의 top 까지 축소되어야 한다.
+    #[test]
+    fn test_clip_exam_eng_pattern() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let lower = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(597.15, 243.59, 408.19, 256.09),
+            5,
+            Some((0, 0, 189900, 120958)),
+        );
+        let upper = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(597.15, 463.17, 408.19, 70.0),
+            5,
+            Some((0, 105958, 189900, 138540)),
+        );
+        let lower_id = lower.id;
+        let upper_id = upper.id;
+        tree.root.children.push(lower);
+        tree.root.children.push(upper);
+
+        tree.clip_overlapping_same_bin_images();
+
+        let l = &tree.root.children[0];
+        assert_eq!(l.id, lower_id);
+        // 새 height = 463.17 - 243.59 = 219.58
+        let bbox = image_bbox(l);
+        assert!(
+            (bbox.height - 219.58).abs() < 0.01,
+            "lower height={}",
+            bbox.height
+        );
+        // 새 crop.bottom = 0 + 120958 * (219.58/256.09) = 103716 (round)
+        let crop = image_crop(l).unwrap();
+        assert_eq!(crop.0, 0);
+        assert_eq!(crop.1, 0);
+        assert_eq!(crop.2, 189900);
+        let expected_cb = (120958_f64 * (219.58 / 256.09)).round() as i32;
+        assert_eq!(crop.3, expected_cb);
+
+        // UPPER 은 변경되지 않음
+        let u = &tree.root.children[1];
+        assert_eq!(u.id, upper_id);
+        let u_bbox = image_bbox(u);
+        assert!((u_bbox.height - 70.0).abs() < 0.01);
+        let u_crop = image_crop(u).unwrap();
+        assert_eq!(u_crop, (0, 105958, 189900, 138540));
+    }
+
+    /// 다른 bin_id 페어는 무시되어야 한다.
+    #[test]
+    fn test_clip_different_bin_id_no_clip() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 250.0, 200.0, 100.0),
+            2, // 다른 bin
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        // 둘 다 원래 크기 유지
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 100.0);
+    }
+
+    /// 세로 겹침이 없으면 무시되어야 한다.
+    #[test]
+    fn test_clip_no_vertical_overlap_no_clip() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 100.0), // 100-200
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 250.0, 200.0, 100.0), // 250-350 (gap)
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 100.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 100.0);
+    }
+
+    /// x 가 다르면 (의도적 대각선 오프셋) 무시되어야 한다.
+    /// 회귀 보호: test-image.hwp / 3-10월_교육_통합_2022 패턴
+    #[test]
+    fn test_clip_different_x_no_clip() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+        // x 가 8px 다른 (의도적 그림자 효과 가정)
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(108.0, 150.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 200.0);
+    }
+
+    /// width 가 다르면 (서로 다른 크기 그림) 무시되어야 한다.
+    /// 회귀 보호: pic2.hwp 패턴 (같은 이미지를 다른 크기로 배치)
+    #[test]
+    fn test_clip_different_width_no_clip() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+        // width 가 100px 다른 (다른 크기 그림)
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 150.0, 100.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 200.0);
+    }
+
+    /// 트리 순서가 반대 (A.y > B.y) 일 때는 무시되어야 한다.
+    /// (clip 대상은 항상 위에 깔리는 = 트리 순서상 먼저 + y 작은 쪽)
+    #[test]
+    fn test_clip_reversed_order_no_clip() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        // 먼저 그려지는 노드가 아래쪽 (y 큰) — clip 안 함
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 250.0, 200.0, 100.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        // 둘 다 원래 크기 유지
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 100.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 200.0);
+    }
+
+    /// crop=None 인 경우에도 bbox 만 축소 적용.
+    #[test]
+    fn test_clip_without_crop() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            None,
+        ));
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 250.0, 200.0, 100.0),
+            1,
+            None,
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        // LOWER 의 height 가 250-100 = 150 으로 축소
+        assert!((image_bbox(&tree.root.children[0]).height - 150.0).abs() < 0.01);
+        assert!(image_crop(&tree.root.children[0]).is_none());
+        // UPPER 은 변경 없음
+        assert!((image_bbox(&tree.root.children[1]).height - 100.0).abs() < 0.01);
+    }
+
+    /// 3 개 이미지 중첩: 가장 위 → 중간 → 아래 (A < B < C)
+    /// A 는 B 의 top 까지, B 는 C 의 top 까지 축소.
+    #[test]
+    fn test_clip_three_overlapping_chain() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        // A: y=0 height=200 (0-200)
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 0.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 1000, 2000)),
+        ));
+        // B: y=100 height=150 (100-250) — overlaps A
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 150.0),
+            1,
+            Some((0, 1000, 1000, 2500)),
+        ));
+        // C: y=180 height=100 (180-280) — overlaps both A and B
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 180.0, 200.0, 100.0),
+            1,
+            Some((0, 1800, 1000, 2800)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        // A: 가장 가까운 upper(B) 의 top=100 까지 → height=100
+        assert!((image_bbox(&tree.root.children[0]).height - 100.0).abs() < 0.01);
+        // B: 가장 가까운 upper(C) 의 top=180 → height=80
+        assert!((image_bbox(&tree.root.children[1]).height - 80.0).abs() < 0.01);
+        // C: 변경 없음
+        assert!((image_bbox(&tree.root.children[2]).height - 100.0).abs() < 0.01);
+    }
+
+    /// 자식 노드 (e.g., Body > Column > Image) 깊이에서도 동작.
+    #[test]
+    fn test_clip_nested_children() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let mut body = RenderNode::new(
+            tree.next_id(),
+            RenderNodeType::Body { clip_rect: None },
+            BoundingBox::new(0.0, 0.0, 1000.0, 1500.0),
+        );
+        let _id = tree.next_id();
+        body.children.push(make_image_node(
+            _id,
+            BoundingBox::new(597.15, 243.59, 408.19, 256.09),
+            5,
+            Some((0, 0, 189900, 120958)),
+        ));
+        let _id = tree.next_id();
+        body.children.push(make_image_node(
+            _id,
+            BoundingBox::new(597.15, 463.17, 408.19, 70.0),
+            5,
+            Some((0, 105958, 189900, 138540)),
+        ));
+        tree.root.children.push(body);
+
+        tree.clip_overlapping_same_bin_images();
+
+        let body = &tree.root.children[0];
+        let lower = &body.children[0];
+        assert!((image_bbox(lower).height - 219.58).abs() < 0.01);
+    }
+
+    /// 단일 이미지만 있는 경우 변경 없음 (no-op).
+    #[test]
+    fn test_clip_single_image_no_op() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        let _id = tree.next_id();
+        tree.root.children.push(make_image_node(
+            _id,
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            1,
+            Some((0, 0, 100, 100)),
+        ));
+
+        tree.clip_overlapping_same_bin_images();
+
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_crop(&tree.root.children[0]), Some((0, 0, 100, 100)));
     }
 }


### PR DESCRIPTION
## Summary

#1154 의 시각 증상은 단일 원인이 아니라 **세 가지 독립 원인이 동시 발생** 하고 있었습니다. 본 PR 은 세 원인 모두를 처리합니다.

| # | 원인 | 노출 경로 | 처리 commit |
|---|---|---|---|
| 1 | 동일 bin_id Pic 컨트롤 수직 인접 시 세로 스케일 미스매치 → SVG 리샘플링/안티엘리어싱 잔상 | SVG / Canvas / CanvasKit 공통 | 8ee17fd4 (v1) `PageRenderTree::clip_overlapping_same_bin_images()` |
| 2 | rhwp-studio 의 BehindText/InFrontOfText overlay `<img>` 가 `crop` 필드를 무시 → 원본 전체가 bbox 에 stretch | rhwp-studio overlay only | 897db4ec (v2) overlay JSON 에 crop 필드 추가 + `createOverlayLayer` wrapper div + overflow:hidden 패턴 |
| 3 | 큰 PNG/JPEG (≈ 100+ KB) 의 비동기 디코드가 `scheduleReRender` (200/600ms) 를 초과 → 첫 렌더에 누락 | rhwp-studio flow layer only | 897db4ec (v2) delays 확장 + `prefetchFlowImages` 안전망 |

권위 자료: 한컴 PDF (pdf/exam_eng-2022.pdf) 와 페이지 2 박스 18 / 페이지 4 박스 27 / 페이지 4 박스 28 모두 시각 일치 확인.

## 변경 파일

- `src/renderer/render_tree.rs` — `clip_overlapping_same_bin_images` + 11 단위 테스트 (v1)
- `src/document_core/queries/rendering.rs` — `build_page_tree` 끝에 clip 호출 (v1) + overlay JSON 에 crop 필드 출력 (v2)
- `rhwp-studio/src/view/page-renderer.ts` — OverlayImageInfo.crop / createOverlayLayer wrapper / scheduleReRender delays / prefetchFlowImages (v2)
- `mydocs/{plans,working,report}/task_m100_1154*.md` + `task_m100_1154_v2*.md` — 수행/구현 계획서, 단계별 + 최종 결과 보고서

## 회귀 보호 / 검증

- Stage 17 영향 sample 합계 379 페이지 중 exam_eng page 2 한 장만 변경, 나머지 100% 불변 (v1 검증)
- 시각: 한컴 PDF, SVG export, rhwp-studio (BehindText overlay + flow large PNG) 모두 시각 일치
- `cargo test --release --lib` : **1432 passed / 0 failed / 6 ignored**
- `cargo clippy --release --lib -- -D warnings` : clean
- `npx tsc --noEmit` (rhwp-studio) : clean
- Docker WASM 빌드 통과

## Merge 옵션

**squash merge 권장** — 두 commit (8ee17fd4 + 897db4ec) 을 단일 commit 으로 통합.

## Test plan

- [ ] `samples/exam_eng.hwp` 2 페이지 박스 18 (윈도우 chrome frame) 잔상 없이 단일 정상 표시 (rhwp-studio + SVG export)
- [ ] `samples/exam_eng.hwp` 4 페이지 박스 27 / 28 (종이+핀 디자인) 외곽 그림 정상 표시 (rhwp-studio + SVG export)
- [ ] 권위 PDF (pdf/exam_eng-2022.pdf) 와 시각 비교 일치
- [ ] 기존 BehindText overlay 있는 다른 문서 회귀 없음 (워터마크 페이지 등)
- [ ] 페이지에 그림이 없는 일반 페이지 렌더 비용 영향 없음 (imageCount=0 skip)

closes #1154

🤖 Generated with [Claude Code](https://claude.com/claude-code)