### PR TITLE
Task #1144: filename field context를 멀티 렌더러 경로에서 일관화

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -189,6 +189,7 @@ export class WasmBridge {
 
   set fileName(name: string) {
     this._fileName = name;
+    this.doc?.setFileName(name);
   }
 
   get currentFileHandle(): FileSystemFileHandleLike | null {

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -505,7 +505,10 @@ impl HwpDocument {
     /// 파일 이름을 설정한다 (머리말/꼬리말 필드 치환용).
     #[wasm_bindgen(js_name = setFileName)]
     pub fn set_file_name(&mut self, name: &str) {
-        self.core.file_name = name.to_string();
+        if self.core.file_name != name {
+            self.core.file_name = name.to_string();
+            self.core.invalidate_page_tree_cache();
+        }
     }
 
     /// 현재 DPI를 반환한다.

--- a/tests/issue_1144.rs
+++ b/tests/issue_1144.rs
@@ -1,0 +1,155 @@
+//! Issue #1144: filename field context must be resolved before PageLayerTree.
+//!
+//! Filename is document context, not renderer-local metadata. PageLayerTree,
+//! native Skia export, and CanvasKit direct replay all consume the same
+//! filename-resolved layer state through `build_page_layer_tree`.
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+fn document_with_filename_footer() -> HwpDocument {
+    let mut doc = HwpDocument::create_empty();
+    doc.create_blank_document()
+        .expect("create blank document fixture");
+    doc.apply_hf_template(0, false, 0, 4)
+        .expect("apply footer template with page number and filename field");
+    doc
+}
+
+fn collect_text_runs(value: &Value, out: &mut Vec<String>) {
+    match value {
+        Value::Object(map) => {
+            if map.get("type").and_then(Value::as_str) == Some("textRun") {
+                if let Some(text) = map.get("text").and_then(Value::as_str) {
+                    out.push(text.to_string());
+                }
+            }
+            for child in map.values() {
+                collect_text_runs(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for item in items {
+                collect_text_runs(item, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn layer_tree_texts(doc: &HwpDocument) -> Vec<String> {
+    let json = doc
+        .get_page_layer_tree_native(0)
+        .expect("page 1 PageLayerTree JSON");
+    let parsed: Value = serde_json::from_str(&json).expect("parse PageLayerTree JSON");
+    let mut texts = Vec::new();
+    collect_text_runs(&parsed, &mut texts);
+    texts
+}
+
+#[test]
+fn issue_1144_page_layer_tree_uses_filename_context() {
+    let mut doc = document_with_filename_footer();
+    doc.set_file_name("issue-1144-fixture.hwp");
+
+    let texts = layer_tree_texts(&doc);
+
+    assert!(
+        texts
+            .iter()
+            .any(|text| text.contains("issue-1144-fixture.hwp")),
+        "PageLayerTree text runs should contain resolved filename. texts={texts:?}"
+    );
+    assert!(
+        texts.iter().all(|text| !text.contains('\u{0017}')),
+        "PageLayerTree should not leak raw filename field marker. texts={texts:?}"
+    );
+}
+
+#[test]
+fn issue_1144_set_file_name_invalidates_cached_page_tree() {
+    let mut doc = document_with_filename_footer();
+    doc.set_file_name("old-name.hwp");
+
+    let old_texts = layer_tree_texts(&doc);
+    assert!(
+        old_texts.iter().any(|text| text.contains("old-name.hwp")),
+        "initial render should resolve old filename. texts={old_texts:?}"
+    );
+
+    doc.set_file_name("new-name.hwp");
+    let new_texts = layer_tree_texts(&doc);
+
+    assert!(
+        new_texts.iter().any(|text| text.contains("new-name.hwp")),
+        "cached PageRenderTree should be invalidated after filename change. texts={new_texts:?}"
+    );
+    assert!(
+        new_texts.iter().all(|text| !text.contains("old-name.hwp")),
+        "stale filename should not survive cache invalidation. texts={new_texts:?}"
+    );
+}
+
+#[test]
+fn issue_1144_canvas_kit_plan_entrypoint_does_not_freeze_filename_context() {
+    let mut doc = document_with_filename_footer();
+    doc.set_file_name("canvas-kit-old.hwp");
+
+    doc.get_canvaskit_replay_plan_native(0, "default")
+        .expect("CanvasKit replay plan should build through PageLayerTree");
+
+    doc.set_file_name("canvas-kit-new.hwp");
+    let texts = layer_tree_texts(&doc);
+
+    assert!(
+        texts.iter().any(|text| text.contains("canvas-kit-new.hwp")),
+        "CanvasKit replay plan entrypoint should not leave stale cached filename. texts={texts:?}"
+    );
+    assert!(
+        texts
+            .iter()
+            .all(|text| !text.contains("canvas-kit-old.hwp")),
+        "old filename from CanvasKit plan build should not remain cached. texts={texts:?}"
+    );
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+#[test]
+fn issue_1144_skia_png_export_entrypoint_does_not_freeze_filename_context() {
+    let mut doc = document_with_filename_footer();
+    doc.set_file_name("skia-old.hwp");
+
+    let png = doc
+        .render_page_png_native(0)
+        .expect("Skia PNG export should build through PageLayerTree");
+    assert!(!png.is_empty(), "Skia PNG export should produce bytes");
+
+    doc.set_file_name("skia-new.hwp");
+    let texts = layer_tree_texts(&doc);
+
+    assert!(
+        texts.iter().any(|text| text.contains("skia-new.hwp")),
+        "Skia export entrypoint should not leave stale cached filename. texts={texts:?}"
+    );
+    assert!(
+        texts.iter().all(|text| !text.contains("skia-old.hwp")),
+        "old filename from Skia export should not remain cached. texts={texts:?}"
+    );
+}
+
+#[test]
+fn issue_1144_empty_filename_context_resolves_to_empty_string() {
+    let mut doc = document_with_filename_footer();
+    doc.set_file_name("");
+
+    let texts = layer_tree_texts(&doc);
+
+    assert!(
+        texts.iter().any(|text| text == "1\t"),
+        "empty filename should resolve to empty string while preserving surrounding text. texts={texts:?}"
+    );
+    assert!(
+        texts.iter().all(|text| !text.contains('\u{0017}')),
+        "empty filename fallback should not leak raw marker. texts={texts:?}"
+    );
+}


### PR DESCRIPTION
## 변경 요약

#1144의 filename field context를 PageLayerTree / Skia PNG export / CanvasKit direct replay 경로에서 일관되게 사용하도록 정리했습니다.

- filename field가 포함된 머리말/꼬리말 fixture를 동적으로 만들고 PageLayerTree text output contract를 테스트로 고정했습니다.
- `setFileName`으로 filename context가 바뀌면 cached PageRenderTree를 무효화하도록 했습니다.
- rhwp-studio의 `WasmBridge.fileName` setter가 로컬 `_fileName`뿐 아니라 로드된 WASM 문서의 `setFileName`도 함께 갱신하도록 했습니다.

## Root cause

현재 filename field 치환 경로 자체는 이미 `DocumentCore.file_name -> LayoutEngine.set_file_name -> header/footer field marker 치환 -> PageRenderTree -> PageLayerTree`로 구성되어 있습니다.

문제는 PageRenderTree cache가 filename-resolved text state를 보관하는데, 기존 `setFileName`은 `DocumentCore.file_name`만 바꾸고 cache를 무효화하지 않았다는 점입니다. 따라서 다음 순서에서 stale filename이 남을 수 있었습니다.

```text
PageLayerTree 또는 CanvasKit replay plan 생성
-> PageRenderTree cache 생성
-> setFileName("new-name.hwp")
-> 다시 PageLayerTree / Skia PNG / CanvasKit direct replay 진입
-> 이전 filename으로 치환된 cached tree 재사용
```

또한 rhwp-studio의 `fileName` setter는 `_fileName`만 갱신하고 WASM core의 `setFileName`을 호출하지 않아, Save / Save As 같은 Studio 파일명 변경 경로와 core filename context가 어긋날 수 있었습니다.

## 변경

### Stage 1 — regression tests

- `tests/issue_1144.rs` 추가
- 빈 문서 + 꼬리말 템플릿 4(쪽번호 + 파일이름)로 동적 fixture 구성
- PageLayerTree text output이 `setFileName` 값을 포함하는지 확인
- raw filename marker `\u{0017}`이 output에 남지 않는지 확인
- 첫 렌더 후 filename 변경 시 stale filename이 남지 않는지 확인
- CanvasKit replay plan entrypoint가 먼저 cache를 만든 뒤에도 새 filename이 반영되는지 확인
- `native-skia` feature에서 Skia PNG export entrypoint도 같은 cache invalidation을 따르는지 확인
- empty filename fallback은 빈 문자열 치환으로 고정

### Stage 2 — core cache invalidation

- `src/wasm_api.rs`
- `HwpDocument::set_file_name`에서 filename 값이 실제로 바뀐 경우 `invalidate_page_tree_cache()` 호출
- 기존 public API signature는 유지

### Stage 3 — Studio propagation

- `rhwp-studio/src/core/wasm-bridge.ts`
- `WasmBridge.fileName` setter가 `this.doc?.setFileName(name)`을 함께 호출하도록 변경

## 메인테이너 리뷰 포인트

- renderer backend가 filename field 치환 규칙을 새로 추측하지 않습니다. 치환은 계속 layout 단계에서 확정됩니다.
- PageLayerTree / Skia PNG / CanvasKit direct replay는 모두 filename-resolved PageLayerTree state를 공유하는 방향입니다.
- #982 `displayText` / `displayPositions` contract는 건드리지 않습니다.
- 새 샘플 파일이나 LFS fixture를 추가하지 않고, command API 기반 동적 fixture로 회귀를 고정했습니다.
- empty filename은 기존 동작을 유지해 빈 문자열로 치환하고 raw marker를 남기지 않습니다.

## 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo test`
- [x] `cargo test --test issue_1144 --test issue_948 --test issue_1017`
- [x] `cargo test --features native-skia --test issue_1144 issue_1144_skia_png_export_entrypoint_does_not_freeze_filename_context`
- [x] `cargo clippy -- -D warnings`
- [x] `npm run build`

## 관련 이슈

- 관련: #1144
- Parent: #1141
- Refs: #536, #982

## 스크린샷

렌더링 contract / cache invalidation 회귀 테스트 중심 변경이라 별도 스크린샷은 없습니다.
