### PR TITLE
Task #1142: external image reference discovery contract 추가

### DIFF
--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -91,7 +91,6 @@ fn scaled_canvas_extent(page_extent: f64, scale: f64) -> u32 {
     (page_extent * scale).max(1.0).min(MAX_CANVAS_DIMENSION) as u32
 }
 
-#[allow(dead_code)]
 #[derive(Debug, Clone, serde::Serialize)]
 #[serde(rename_all = "camelCase")]
 struct ExternalImageReference {
@@ -2294,6 +2293,15 @@ impl HwpDocument {
             description,
         )
         .map_err(|e| e.into())
+    }
+
+    /// [Task #1142] 외부 file path 그림 reference 목록을 구조화된 JSON 배열로 반환한다.
+    ///
+    /// 반환: JSON 배열 `[{ key, binDataId, originalPath, basename, extension, loaded }, ...]`
+    #[wasm_bindgen(js_name = getExternalImageReferences)]
+    pub fn get_external_image_references(&self) -> String {
+        serde_json::to_string(&collect_external_image_references(self.document()))
+            .unwrap_or_else(|_| "[]".to_string())
     }
 
     /// [Task #741 후속] 외부 file path 그림 영역 영역 영역 영역 basename 목록 영역 반환.

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -16,11 +16,13 @@ use web_sys::HtmlCanvasElement;
 
 use crate::document_core::{DocumentCore, DEFAULT_FALLBACK_FONT};
 use crate::error::HwpError;
+use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
 use crate::model::document::{Document, Section};
 use crate::model::page::ColumnDef;
 use crate::model::paragraph::Paragraph;
 use crate::model::path::{path_from_flat, DocumentPath, PathSegment};
+use crate::model::shape::ShapeObject;
 use crate::renderer::canvas::CanvasRenderer;
 use crate::renderer::composer::{
     compose_paragraph, compose_section, reflow_line_segs, ComposedParagraph,
@@ -87,6 +89,84 @@ fn normalize_canvas_scale(
 #[cfg(target_arch = "wasm32")]
 fn scaled_canvas_extent(page_extent: f64, scale: f64) -> u32 {
     (page_extent * scale).max(1.0).min(MAX_CANVAS_DIMENSION) as u32
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, serde::Serialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalImageReference {
+    key: String,
+    bin_data_id: u16,
+    original_path: String,
+    basename: String,
+    extension: String,
+    loaded: bool,
+}
+
+fn external_path_basename(path: &str) -> &str {
+    path.rsplit(|c| c == '/' || c == '\\')
+        .find(|part| !part.is_empty())
+        .unwrap_or(path)
+}
+
+fn external_path_extension(basename: &str) -> String {
+    std::path::Path::new(basename)
+        .extension()
+        .and_then(|ext| ext.to_str())
+        .unwrap_or("")
+        .to_string()
+}
+
+fn external_image_loaded(bin_data_content: &[BinDataContent], bin_data_id: u16) -> bool {
+    if bin_data_id == 0 {
+        return false;
+    }
+
+    if let Some(content) = bin_data_content.get((bin_data_id - 1) as usize) {
+        return !content.data.is_empty();
+    }
+
+    bin_data_content
+        .iter()
+        .any(|content| content.id == bin_data_id && !content.data.is_empty())
+}
+
+fn collect_external_image_references(document: &Document) -> Vec<ExternalImageReference> {
+    let mut references = std::collections::BTreeMap::new();
+
+    for section in &document.sections {
+        for para in &section.paragraphs {
+            for ctrl in &para.controls {
+                let pic = match ctrl {
+                    Control::Picture(pic) => pic,
+                    Control::Shape(shape) => match shape.as_ref() {
+                        ShapeObject::Picture(pic) => pic,
+                        _ => continue,
+                    },
+                    _ => continue,
+                };
+
+                let Some(original_path) = pic.image_attr.external_path.as_ref() else {
+                    continue;
+                };
+
+                let bin_data_id = pic.image_attr.bin_data_id;
+                references.entry(bin_data_id).or_insert_with(|| {
+                    let basename = external_path_basename(original_path).to_string();
+                    ExternalImageReference {
+                        key: format!("binData:{bin_data_id}"),
+                        bin_data_id,
+                        extension: external_path_extension(&basename),
+                        basename,
+                        original_path: original_path.clone(),
+                        loaded: external_image_loaded(&document.bin_data_content, bin_data_id),
+                    }
+                });
+            }
+        }
+    }
+
+    references.into_values().collect()
 }
 
 /// WASM에서 사용할 HWP 문서 래퍼
@@ -2225,39 +2305,12 @@ impl HwpDocument {
     /// 반환: JSON 배열 `["oracle.gif", "rdb02.gif", ...]` (중복 제거)
     #[wasm_bindgen(js_name = getExternalImageBasenames)]
     pub fn get_external_image_basenames(&self) -> String {
-        use crate::model::control::Control;
-        use crate::model::shape::ShapeObject;
         use std::collections::BTreeSet;
 
         let mut names: BTreeSet<String> = BTreeSet::new();
-        for section in &self.document().sections {
-            for para in &section.paragraphs {
-                for ctrl in &para.controls {
-                    let pic = match ctrl {
-                        Control::Picture(p) => p,
-                        Control::Shape(s) => match s.as_ref() {
-                            ShapeObject::Picture(p) => p,
-                            _ => continue,
-                        },
-                        _ => continue,
-                    };
-                    if let Some(ref path) = pic.image_attr.external_path {
-                        let id = pic.image_attr.bin_data_id;
-                        let already_loaded = self
-                            .document()
-                            .bin_data_content
-                            .iter()
-                            .any(|c| c.id == id && !c.data.is_empty());
-                        if already_loaded {
-                            continue;
-                        }
-                        let basename = path
-                            .rsplit(|c| c == '/' || c == '\\')
-                            .next()
-                            .unwrap_or(path);
-                        names.insert(basename.to_string());
-                    }
-                }
+        for reference in collect_external_image_references(self.document()) {
+            if !reference.loaded {
+                names.insert(reference.basename);
             }
         }
         let arr: Vec<String> = names.into_iter().collect();

--- a/tests/issue_1142.rs
+++ b/tests/issue_1142.rs
@@ -1,0 +1,134 @@
+//! Issue #1142: external image reference discovery contract.
+//!
+//! The discovery API must expose renderer-consumer preparation data without
+//! depending on bytes injection (#1143). In particular, loaded detection must
+//! follow the renderer's bin_data_id index-first lookup semantics rather than
+//! assuming `BinDataContent.id == bin_data_id`.
+
+use rhwp::model::bin_data::BinDataContent;
+use rhwp::wasm_api::HwpDocument;
+use serde::Deserialize;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalImageReference {
+    key: String,
+    bin_data_id: u16,
+    original_path: String,
+    basename: String,
+    extension: String,
+    loaded: bool,
+}
+
+fn load_doc(rel_path: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn external_image_refs(doc: &HwpDocument) -> Vec<ExternalImageReference> {
+    let json = doc.get_external_image_references();
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse refs JSON {json}: {e}"))
+}
+
+fn external_image_basenames(doc: &HwpDocument) -> Vec<String> {
+    let json = doc.get_external_image_basenames();
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse basename JSON {json}: {e}"))
+}
+
+fn assert_sample10_external_refs(rel_path: &str) {
+    let doc = load_doc(rel_path);
+    let refs = external_image_refs(&doc);
+
+    assert_eq!(
+        refs.len(),
+        3,
+        "{rel_path} should expose three external image refs"
+    );
+
+    let expected = [
+        (1, "binData:1", "oracle.gif", "gif"),
+        (2, "binData:2", "rdb02.gif", "gif"),
+        (3, "binData:3", "s1.jpg", "jpg"),
+    ];
+
+    for (reference, (bin_id, key, basename, extension)) in refs.iter().zip(expected) {
+        assert_eq!(reference.bin_data_id, bin_id, "{rel_path}: binDataId");
+        assert_eq!(reference.key, key, "{rel_path}: key");
+        assert_eq!(reference.basename, basename, "{rel_path}: basename");
+        assert_eq!(reference.extension, extension, "{rel_path}: extension");
+        assert!(
+            reference.original_path.ends_with(basename),
+            "{rel_path}: original path should preserve source path and end with {basename}. got={}",
+            reference.original_path,
+        );
+        assert!(
+            !reference.loaded,
+            "{rel_path}: external reference should be missing before injection"
+        );
+    }
+}
+
+#[test]
+fn issue_1142_hwp3_external_image_references_are_structured() {
+    assert_sample10_external_refs("samples/hwp3-sample10.hwp");
+}
+
+#[test]
+fn issue_1142_hwp5_link_external_image_references_are_structured() {
+    assert_sample10_external_refs("samples/hwp3-sample10-hwp5.hwp");
+}
+
+#[test]
+fn issue_1142_hwpx_external_image_references_are_structured() {
+    assert_sample10_external_refs("samples/hwp3-sample10-hwpx.hwpx");
+}
+
+#[test]
+fn issue_1142_basename_api_keeps_existing_json_array_contract() {
+    let doc = load_doc("samples/hwp3-sample10.hwp");
+    let basenames = external_image_basenames(&doc);
+
+    assert_eq!(
+        basenames,
+        vec![
+            "oracle.gif".to_string(),
+            "rdb02.gif".to_string(),
+            "s1.jpg".to_string()
+        ],
+        "legacy basename API should keep deterministic string-array output"
+    );
+}
+
+#[test]
+fn issue_1142_loaded_detection_uses_bin_data_index_before_storage_id() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    doc.document_mut().bin_data_content[0] = BinDataContent {
+        id: 99,
+        data: vec![b'G', b'I', b'F'],
+        extension: "gif".to_string(),
+    };
+
+    let refs = external_image_refs(&doc);
+    let oracle = refs
+        .iter()
+        .find(|reference| reference.bin_data_id == 1)
+        .expect("binDataId 1 ref");
+    assert!(
+        oracle.loaded,
+        "loaded must follow bin_data_content[binDataId - 1], even when storage id differs"
+    );
+
+    let basenames = external_image_basenames(&doc);
+    assert!(
+        !basenames.iter().any(|name| name == "oracle.gif"),
+        "legacy basename API must hide references loaded through index-first lookup"
+    );
+    assert!(
+        basenames.iter().any(|name| name == "rdb02.gif")
+            && basenames.iter().any(|name| name == "s1.jpg"),
+        "only still-missing references should remain in basename API"
+    );
+}


### PR DESCRIPTION
## 개요

렌더러 consumer가 렌더 전에 필요한 외부 이미지 리소스를 준비할 수 있도록, external linked image reference를 구조화해서 조회하는 WASM API를 추가했습니다.

이번 PR은 discovery contract만 다룹니다. 실제 external image bytes 주입과 resolver 정책은 후속 #1143 범위로 남겼습니다.

## 변경 내용

- `getExternalImageReferences()` API 추가
  - `key`
  - `binDataId`
  - `originalPath`
  - `basename`
  - `extension`
  - `loaded`
- 기존 `getExternalImageBasenames()` API는 문자열 배열 반환 계약을 유지하면서 새 discovery 로직을 재사용하도록 정리
- `Control::Picture`와 `Control::Shape(ShapeObject::Picture)` 양쪽에서 `external_path`를 수집
- `loaded` 판정은 렌더러 조회 방식과 맞춰 `bin_data_content[bin_data_id - 1]` index-first 규칙을 우선 적용
- HWP3 / HWP5 링크 변환 / HWPX fixture 기반 회귀 테스트 추가

## 리뷰 포인트

- #1142의 목표인 렌더 전 reference discovery에만 범위를 제한했습니다.
- `bin_data_id`와 `BinDataContent.id`가 항상 같지 않을 수 있어, renderer lookup과 같은 index-first 판정을 테스트로 고정했습니다.
- basename-only API는 source compatibility를 위해 유지했고, 구조화 API는 renderer consumer가 resource 준비 단계에서 쓰기 쉬운 형태로 분리했습니다.
- file system search path, bytes loading, injection policy는 이 PR에 넣지 않았습니다.

## 검증

- `cargo fmt --all -- --check`
- `cargo clippy --lib --test issue_1142 -- -D warnings`
- `cargo test --test issue_1142`
- `cargo test --test issue_824 --test issue_1142`
- `cargo test`

## 관련 이슈

- 관련: #1142
- Parent: #1141
- Refs: #536
- Related: #741, #873, #875

## 참고

`cargo clippy --all-targets -- -D warnings`는 기존 테스트/모듈의 warning들이 `-D warnings`에 걸려 실패했습니다. 이 PR의 변경 범위인 library와 `issue_1142` 테스트 타깃 기준 clippy는 통과했습니다.
