### PR TITLE
task 1179: Rust 테스트 경고 정리

### DIFF
--- a/mydocs/orders/20260530.md
+++ b/mydocs/orders/20260530.md
@@ -47,3 +47,28 @@
 - [x] Stage 3: 통합 검증(--tests + native-skia 32 + fmt + clippy) + wasm + 작업지시자 동작 판정 통과
 - [x] 최종 보고서 + issue_1166 6 테스트(파싱 3 + round-trip 3)
 - [ ] commit + devel 머지 + close #1166
+
+## Task M100-1179 — Rust 테스트 경고 정리 (#1179)
+
+- 이슈: [#1179](https://github.com/edwardkim/rhwp/issues/1179)
+- 브랜치: `local/task_m100_1179`
+- 기준: 최신 `upstream/devel`
+- 상태: PR #1180 생성 완료
+
+### 진행 항목
+
+- [x] 작업지시자 경고 로그 확인
+- [x] 이슈 #1179 생성
+- [x] 최신 `upstream/devel` 기준 새 브랜치 생성
+- [x] Stage1 문서 생성
+- [x] 경고 재현
+- [x] 경고 제거 수정
+- [x] 검증
+- [x] 커밋 및 PR 준비
+
+### 현재 판단
+
+- 대상 경고는 테스트 실패가 아니라 `cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture` 실행 중 출력되는 warning 6개다.
+- 수정 범위는 테스트/진단 코드의 attribute, 네이밍, unused result 정리로 제한했다.
+- 검증: `cargo fmt --all --check`, `cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture` warning 없이 통과.
+- PR: [#1180](https://github.com/edwardkim/rhwp/pull/1180)

--- a/mydocs/working/task_m100_1179_stage1.md
+++ b/mydocs/working/task_m100_1179_stage1.md
@@ -1,0 +1,48 @@
+# Task M100 #1179 Stage 1
+
+## 목적
+
+`cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture` 실행 시 출력되는 Rust warning을 제거한다.
+
+## 시작 기준
+
+- 이슈: [#1179](https://github.com/edwardkim/rhwp/issues/1179)
+- 기준 브랜치: 최신 `upstream/devel`
+- 작업 브랜치: `local/task_m100_1179`
+
+## 경고 목록
+
+- `src/renderer/equation/parser.rs`: 중복 `#[test]` attribute
+- `src/renderer/layout/integration_tests.rs`: 불필요한 괄호
+- `src/serializer/hwpx/field.rs`: non-snake-case 테스트 함수명
+- `src/wasm_api/tests.rs`: non-snake-case 테스트 함수명
+- `src/wasm_api/tests.rs`: `insert_text_native` 반환 `Result` 미사용
+- `src/wasm_api/tests.rs`: `convert_to_editable_native` 반환 `Result` 미사용
+
+## 계획
+
+1. 붙여넣은 로그 기준 경고 위치를 확인한다.
+2. 테스트 의미를 바꾸지 않고 attribute, 함수명, unused result만 정리한다.
+3. 대상 재현 명령과 포맷을 검증한다.
+
+## 현재 상태
+
+- 2026-05-30: 작업지시자가 warning 제거를 위한 새 이슈 등록과 `upstream/devel` 기준 해결을 지시했다.
+- 2026-05-30: 이슈 #1179를 생성하고 최신 `upstream/devel`에서 `local/task_m100_1179` 브랜치를 만들었다.
+- 2026-05-30: 재현 명령에서 warning 6개가 출력되는 것을 확인했다.
+- 2026-05-30: 중복 `#[test]`, 불필요한 괄호, non-snake-case 테스트명 2개, unused `Result` 2개를 정리했다.
+- 2026-05-30: `cargo fmt --all --check` 통과.
+- 2026-05-30: `cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture` 재실행 결과 warning 없이 통과.
+- 2026-05-31: 작업지시자 승인 후 커밋하고 PR #1180을 생성했다.
+
+## 수정 파일
+
+- `src/renderer/equation/parser.rs`
+- `src/renderer/layout/integration_tests.rs`
+- `src/serializer/hwpx/field.rs`
+- `src/wasm_api/tests.rs`
+
+## PR
+
+- 커밋: `task 1179: Rust 테스트 경고 정리`
+- PR: [#1180](https://github.com/edwardkim/rhwp/pull/1180)

--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -2376,7 +2376,6 @@ mod latex_compat_tests {
     }
 
     #[test]
-    #[test]
     fn test_hwpeq_inf_remains_symbol() {
         let ast = parse("lim _{n→inf}");
         fn has_infinity(node: &EqNode) -> bool {

--- a/src/renderer/layout/integration_tests.rs
+++ b/src/renderer/layout/integration_tests.rs
@@ -662,7 +662,7 @@ mod tests {
         );
 
         // IR delta 정합 검증: 5448 HU = 72.64 px.
-        let expected_gap = (5448.0_f64 * 96.0 / 7200.0_f64);
+        let expected_gap = 5448.0_f64 * 96.0 / 7200.0_f64;
         assert!(
             (gap_12 - expected_gap).abs() < 0.5,
             "①→② gap({:.2}) 가 IR vpos delta({:.2}) 와 일치해야 함",

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -189,7 +189,7 @@ mod tests {
     }
 
     #[test]
-    fn footnote_emits_autoNum() {
+    fn footnote_emits_auto_num() {
         let xml = to_string(|w| {
             write_footnote_open(w, 3)?;
             write_footnote_close(w)

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -632,7 +632,7 @@ fn test_split_table_cell() {
 }
 
 #[test]
-fn test_merge_then_control_layout_has_colSpan() {
+fn test_merge_then_control_layout_has_col_span() {
     let mut doc = create_doc_with_table();
     // 병합 전: colSpan=1
     let layout_before = doc.get_page_control_layout_native(0).unwrap();
@@ -11301,7 +11301,7 @@ fn test_text_insert_detailed_diff() {
     let mut doc = HwpDocument::from_bytes(&orig_data).unwrap();
 
     // 텍스트 삽입
-    doc.insert_text_native(0, 0, 0, "가나다라마바사아");
+    doc.insert_text_native(0, 0, 0, "가나다라마바사아").unwrap();
     let saved = doc.export_hwp_native().unwrap();
 
     // 레코드 파싱
@@ -15780,7 +15780,7 @@ fn test_textbox_render_tree_debug() {
 
     let data = std::fs::read(path).unwrap();
     let mut doc = HwpDocument::from_bytes(&data).unwrap();
-    doc.convert_to_editable_native();
+    doc.convert_to_editable_native().unwrap();
 
     // 문서 구조 확인: Shape 컨트롤 찾기
     let mut shape_found = false;


### PR DESCRIPTION
## 작업 내용

`cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture` 실행 중 출력되던 Rust warning 6개를 정리했습니다.

- 중복 `#[test]` attribute 제거
- 불필요한 괄호 제거
- non-snake-case 테스트 함수명 2개 정리
- unused `Result` 2개를 `.unwrap()`으로 명시 처리
- `mydocs/orders/20260530.md`, `mydocs/working/task_m100_1179_stage1.md`에 작업 진행과 검증 결과 기록

## 영향 범위

테스트/진단 코드의 경고 제거만 포함하며, 런타임 동작 변경은 없습니다.

## 검증

- `cargo fmt --all --check`
- `cargo test renderer::height_cursor::tests::compact_endnote -- --nocapture`
  - 수정 후 warning 없이 통과

Closes #1179
