### PR TITLE
fix(#1181): RawSvg(OLE/차트) 첫 로드 백지 렌더 — 비동기 디코드 안전망 누락

### DIFF
--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -471,16 +471,11 @@ export class PageRenderer {
     } catch {
       return;
     }
-    // image 항목들의 mime + base64 추출 (간단한 정규식)
-    const re = /"type":"image"[^}]*?(?:"wrap":"(behindText|inFrontOfText)")?[^}]*?"mime":"([^"]+)","base64":"([^"]+)"/g;
     const tasks: Promise<unknown>[] = [];
-    let m: RegExpExecArray | null;
-    while ((m = re.exec(json)) !== null) {
-      const wrap = m[1]; // overlay wrap 은 prefetch 대상 아님 (별도 <img>)
-      if (wrap === 'behindText' || wrap === 'inFrontOfText') continue;
-      const mime = m[2];
-      const b64 = m[3];
-      const dataUrl = `data:${mime};base64,${b64}`;
+    const seen = new Set<string>();
+    const enqueue = (dataUrl: string) => {
+      if (seen.has(dataUrl)) return;
+      seen.add(dataUrl);
       tasks.push(
         new Promise<void>((resolve) => {
           const img = new Image();
@@ -493,6 +488,22 @@ export class PageRenderer {
           }
         }),
       );
+    };
+    // image 항목들의 mime + base64 추출 (간단한 정규식)
+    const re = /"type":"image"[^}]*?(?:"wrap":"(behindText|inFrontOfText)")?[^}]*?"mime":"([^"]+)","base64":"([^"]+)"/g;
+    let m: RegExpExecArray | null;
+    while ((m = re.exec(json)) !== null) {
+      const wrap = m[1]; // overlay wrap 은 prefetch 대상 아님 (별도 <img>)
+      if (wrap === 'behindText' || wrap === 'inFrontOfText') continue;
+      enqueue(`data:${m[2]};base64,${m[3]}`);
+    }
+    // rawSvg 항목 (OLE/차트 미리보기) 의 embedded data URL 추출.
+    // svg 필드는 JSON 인코딩 문자열이며 내부에 data:image/MIME;base64,... 가 등장한다.
+    // rawSvg 의 wrap 은 항상 flow 이므로 overlay 필터링 불필요.
+    const dataUrlRe = /data:(image\/[A-Za-z0-9.+-]+);base64,([A-Za-z0-9+/=]+)/g;
+    let d: RegExpExecArray | null;
+    while ((d = dataUrlRe.exec(json)) !== null) {
+      enqueue(`data:${d[1]};base64,${d[2]}`);
     }
     await Promise.all(tasks);
   }

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -657,34 +657,42 @@ impl DocumentCore {
                 LayerNodeKind::ClipRect { child, .. } => collect(child, behind, front, image_count),
                 LayerNodeKind::Leaf { ops } => {
                     for op in ops {
-                        if let PaintOp::Image {
-                            bbox,
-                            image,
-                            resolved,
-                        } = op
-                        {
-                            *image_count += 1;
-                            match image.text_wrap {
-                                Some(TextWrap::BehindText) => {
-                                    write_overlay_image(
-                                        behind,
-                                        *bbox,
-                                        image,
-                                        resolved.as_deref(),
-                                        TextWrap::BehindText,
-                                    );
+                        match op {
+                            PaintOp::Image {
+                                bbox,
+                                image,
+                                resolved,
+                            } => {
+                                *image_count += 1;
+                                match image.text_wrap {
+                                    Some(TextWrap::BehindText) => {
+                                        write_overlay_image(
+                                            behind,
+                                            *bbox,
+                                            image,
+                                            resolved.as_deref(),
+                                            TextWrap::BehindText,
+                                        );
+                                    }
+                                    Some(TextWrap::InFrontOfText) => {
+                                        write_overlay_image(
+                                            front,
+                                            *bbox,
+                                            image,
+                                            resolved.as_deref(),
+                                            TextWrap::InFrontOfText,
+                                        );
+                                    }
+                                    _ => {}
                                 }
-                                Some(TextWrap::InFrontOfText) => {
-                                    write_overlay_image(
-                                        front,
-                                        *bbox,
-                                        image,
-                                        resolved.as_deref(),
-                                        TextWrap::InFrontOfText,
-                                    );
-                                }
-                                _ => {}
                             }
+                            // OLE/차트 미리보기 등은 RawSvg 로 emit 되며 web_canvas 의 draw_image
+                            // 경로(IMAGE_CACHE 비동기 디코드)를 그대로 탄다. scheduleReRender 재시도
+                            // 발화를 위해 image_count 에 포함한다.
+                            PaintOp::RawSvg { .. } => {
+                                *image_count += 1;
+                            }
+                            _ => {}
                         }
                     }
                 }


### PR DESCRIPTION
## Summary

- 한셀 OLE / 차트 OOXML / EMF 등 `PaintOp::RawSvg` 로 emit 되는 미리보기 페이지가 rhwp-studio 첫 로드 시 백지로 그려지던 회귀를 수정.
- #1154 v2 (PR #1164) 의 디코드 안전망이 `PaintOp::Image` 만 대상으로 잡고 있어 RawSvg 경로 누락.

Closes #1181

## 원인

OLE/차트 미리보기는 `PaintOp::RawSvg` 로 emit (`src/paint/json.rs:814`) 되며 web_canvas RawSvg 핸들러는 `<image data:...>` / SVG 조각을 `draw_image()` 로 그려서 IMAGE_CACHE 비동기 디코드 경로를 그대로 탑니다. 그런데 #1154 v2 의 안전망은:

- `rendering.rs collect()` : `PaintOp::Image` 만 image_count++ → RawSvg 페이지는 `image_count == 0`
- `page-renderer.ts scheduleReRender` : `if (imageCount <= 0) return` 으로 200/600/1500ms 재시도 자체 미발화
- `prefetchFlowImages` 정규식 `"type":"image"` → rawSvg 미매칭

첫 렌더 후 캔버스가 백지로 남고, 두 번째 로드 때만 모듈 static `IMAGE_CACHE` 가 디코드 완료된 element 를 유지하고 있어 `img.complete()` 분기로 즉시 그려지는 패턴.

## 수정

| 파일 | 변경 |
|------|------|
| `src/document_core/queries/rendering.rs` | `collect()` 가 `PaintOp::RawSvg` 도 `image_count += 1` 처리. |
| `rhwp-studio/src/view/page-renderer.ts` | `prefetchFlowImages` 가 전체 JSON 의 `data:image/MIME;base64,...` 패턴을 직접 스캔, rawSvg 내장 data URL 도 prefetch. 중복 dedupe Set 추가. 기존 image regex 유지. |

## Test plan

- [x] Puppeteer 자동 측정 (samples/한셀OLE.hwp, 1페이지 OLE PNG 미리보기)
  - 수정 전 load #1 t+3000ms : nonWhite=6 (백지)
  - 수정 후 load #1 t+0ms : nonWhite=1276 (정상)
  - 수정 후 load #2 t+0ms : nonWhite=1276 (정상)
- [x] `cargo test --lib document_core::queries::rendering` : 6 passed
- [x] `cargo fmt` 변경 파일 적용
- [ ] (메인테이너) rhwp-studio 에서 수동 확인 — `samples/한셀OLE.hwp` 첫 로드, 한컴 PDF 시각 비교

## 적용 범위

`PaintOp::RawSvg` 경로를 타는 모든 미리보기 (한셀 OLE / OOXML 차트 / EMF). 일반 그림(`PaintOp::Image`) 동작은 변화 없음.