### PR TITLE
Task #1143: external image bytes injection contract 추가

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -44,7 +44,11 @@ impl DocumentCore {
     /// 반환: load 영역 image 영역.
     #[cfg(not(target_arch = "wasm32"))]
     pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize {
-        self.document.populate_external_images_from_dir(base_dir)
+        let loaded = self.document.populate_external_images_from_dir(base_dir);
+        if loaded > 0 {
+            self.invalidate_page_tree_cache();
+        }
+        loaded
     }
 
     pub fn from_bytes(data: &[u8]) -> Result<DocumentCore, HwpError> {

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -233,6 +233,82 @@ pub struct SectionDef {
 }
 
 impl Document {
+    /// 외부 이미지 binDataId가 이미 로드되었는지 확인한다.
+    ///
+    /// 렌더러는 `bin_data_id - 1` 인덱스를 먼저 조회하므로, 저장소 엔트리의
+    /// `id` 필드보다 인덱스 위치를 우선한다. 인덱스가 없을 때만 `id` 검색으로
+    /// fallback한다.
+    pub(crate) fn external_image_loaded(&self, bin_data_id: u16) -> bool {
+        if bin_data_id == 0 {
+            return false;
+        }
+
+        if let Some(content) = self.bin_data_content.get((bin_data_id - 1) as usize) {
+            return !content.data.is_empty();
+        }
+
+        self.bin_data_content
+            .iter()
+            .any(|content| content.id == bin_data_id && !content.data.is_empty())
+    }
+
+    /// 외부 이미지 바이너리를 렌더러 조회 규칙에 맞는 위치에 주입한다.
+    ///
+    /// 반환값은 실제 주입 여부이다. 호출자는 true일 때 렌더 캐시를 무효화해야 한다.
+    pub(crate) fn inject_external_image_data(
+        &mut self,
+        bin_data_id: u16,
+        data: Vec<u8>,
+        extension: String,
+    ) -> bool {
+        if bin_data_id == 0 {
+            return false;
+        }
+
+        let idx = (bin_data_id as usize).saturating_sub(1);
+        if idx < self.bin_data_content.len() {
+            self.bin_data_content[idx].id = bin_data_id;
+            self.bin_data_content[idx].data = data;
+            self.bin_data_content[idx].extension = extension;
+        } else {
+            self.bin_data_content
+                .push(crate::model::bin_data::BinDataContent {
+                    id: bin_data_id,
+                    data,
+                    extension,
+                });
+        }
+
+        true
+    }
+
+    /// 같은 binDataId를 참조하는 외부 이미지의 표시 경로를 갱신한다.
+    pub(crate) fn update_external_image_display_path(
+        &mut self,
+        bin_data_id: u16,
+        display_path: &str,
+    ) {
+        for section in &mut self.sections {
+            for para in &mut section.paragraphs {
+                for ctrl in &mut para.controls {
+                    let pic = match ctrl {
+                        crate::model::control::Control::Picture(p) => p,
+                        crate::model::control::Control::Shape(s) => match s.as_mut() {
+                            crate::model::shape::ShapeObject::Picture(p) => p,
+                            _ => continue,
+                        },
+                        _ => continue,
+                    };
+                    if pic.image_attr.bin_data_id == bin_data_id
+                        && pic.image_attr.external_path.is_some()
+                    {
+                        pic.image_attr.external_path = Some(display_path.to_string());
+                    }
+                }
+            }
+        }
+    }
+
     /// 배포용(읽기전용) 문서를 편집 가능한 일반 문서로 변환한다.
     ///
     /// 변환 내용:
@@ -355,10 +431,11 @@ impl Document {
     pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize {
         use crate::model::control::Control;
         use crate::model::shape::ShapeObject;
+        use std::collections::BTreeMap;
 
         let mut loaded = 0;
         // (storage_id, basename, extension) 영역 영역 image 영역 수집
-        let mut to_load: Vec<(u16, String, String)> = Vec::new();
+        let mut to_load: BTreeMap<u16, (String, String)> = BTreeMap::new();
         for section in &self.sections {
             for para in &section.paragraphs {
                 for ctrl in &para.controls {
@@ -373,11 +450,7 @@ impl Document {
                     if let Some(ref path) = pic.image_attr.external_path {
                         let id = pic.image_attr.bin_data_id;
                         // 이미 load 영역 (bin_data_content 영역 영역 entry 보유) 영역 skip
-                        let already_loaded = self
-                            .bin_data_content
-                            .iter()
-                            .any(|c| c.id == id && !c.data.is_empty());
-                        if already_loaded {
+                        if self.external_image_loaded(id) {
                             continue;
                         }
 
@@ -391,54 +464,26 @@ impl Document {
                             .and_then(|e| e.to_str())
                             .unwrap_or("")
                             .to_string();
-                        to_load.push((id, basename.to_string(), ext));
+                        to_load.entry(id).or_insert((basename.to_string(), ext));
                     }
                 }
             }
         }
 
-        for (id, basename, ext) in to_load {
+        for (id, (basename, ext)) in to_load {
             let full_path = base_dir.join(&basename);
             if let Ok(data) = std::fs::read(&full_path) {
-                // 본질: bin_data_content 영역 영역 (id-1) index 영역 영역 access (utils.rs:23).
-                let idx = (id as usize).saturating_sub(1);
-                if idx < self.bin_data_content.len() {
-                    self.bin_data_content[idx].id = id;
-                    self.bin_data_content[idx].data = data;
-                    self.bin_data_content[idx].extension = ext;
-                } else {
-                    self.bin_data_content
-                        .push(crate::model::bin_data::BinDataContent {
-                            id,
-                            data,
-                            extension: ext,
-                        });
+                if !self.inject_external_image_data(id, data, ext) {
+                    continue;
                 }
+
                 loaded += 1;
 
                 // [한컴 viewer 정합] 원본 절대 경로 영역 영역 access 부재 시 HWP file 영역
                 // 영역 같은 dir 영역 image 영역 발견 영역 영역 dialog 영역 영역 영역 의 path 영역
                 // resolved local path 영역 영역 갱신 (basename 영역만 부재 영역).
                 let resolved = full_path.to_string_lossy().to_string();
-                for section in &mut self.sections {
-                    for para in &mut section.paragraphs {
-                        for ctrl in &mut para.controls {
-                            let pic = match ctrl {
-                                crate::model::control::Control::Picture(p) => p,
-                                crate::model::control::Control::Shape(s) => match s.as_mut() {
-                                    crate::model::shape::ShapeObject::Picture(p) => p,
-                                    _ => continue,
-                                },
-                                _ => continue,
-                            };
-                            if pic.image_attr.bin_data_id == id
-                                && pic.image_attr.external_path.is_some()
-                            {
-                                pic.image_attr.external_path = Some(resolved.clone());
-                            }
-                        }
-                    }
-                }
+                self.update_external_image_display_path(id, &resolved);
             }
         }
         loaded

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -633,6 +633,7 @@ fn image_transition_detail(
     resolved: Option<&ResolvedImagePayload>,
 ) -> Option<String> {
     let mut detail = Vec::new();
+    let has_replayable_payload = image_has_replayable_payload(image, resolved);
     if let Some(payload) = resolved {
         detail.push(format!(
             "resolved={}",
@@ -641,7 +642,12 @@ fn image_transition_detail(
     }
     if image.external_path.is_some() {
         detail.push("externalImage".to_string());
-    } else if image.data.is_none() && resolved.is_none() {
+        if has_replayable_payload {
+            detail.push("injectedImageData".to_string());
+        } else {
+            detail.push("missingImageData".to_string());
+        }
+    } else if !has_replayable_payload {
         detail.push("missingImageData".to_string());
     }
     if let Some(fill_mode) = image.fill_mode {
@@ -677,12 +683,19 @@ fn image_transition_detail(
 }
 
 fn image_can_replay_directly(image: &ImageNode, resolved: Option<&ResolvedImagePayload>) -> bool {
-    let has_replayable_payload = image.data.is_some() || resolved.is_some();
+    let has_replayable_payload = image_has_replayable_payload(image, resolved);
     let effects_are_supported = resolved.is_some_and(|payload| payload.suppress_effects)
         || (matches!(image.effect, ImageEffect::RealPic)
             && image.brightness == 0
             && image.contrast == 0);
-    has_replayable_payload && image.external_path.is_none() && effects_are_supported
+    has_replayable_payload && effects_are_supported
+}
+
+fn image_has_replayable_payload(
+    image: &ImageNode,
+    resolved: Option<&ResolvedImagePayload>,
+) -> bool {
+    resolved.is_some() || image.data.as_ref().is_some_and(|data| !data.is_empty())
 }
 
 fn resolved_image_kind_detail(value: ResolvedImageKind) -> &'static str {
@@ -968,8 +981,31 @@ mod tests {
 
         let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
 
+        assert_eq!(plan.items[0].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(
+            plan.items[0].detail.as_deref(),
+            Some("externalImage;injectedImageData")
+        );
+    }
+
+    #[test]
+    fn image_replay_plan_reports_external_path_without_payload_as_missing() {
+        let mut image = ImageNode::new(1, None);
+        image.external_path = Some("linked-image.png".to_string());
+
+        let tree = tree_with_ops(vec![PaintOp::Image {
+            bbox: bbox(),
+            image,
+            resolved: None,
+        }]);
+
+        let plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
+
         assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
-        assert_eq!(plan.items[0].detail.as_deref(), Some("externalImage"));
+        assert_eq!(
+            plan.items[0].detail.as_deref(),
+            Some("externalImage;missingImageData")
+        );
     }
 
     #[test]

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4806,6 +4806,7 @@ impl LayoutEngine {
                                     // 판별에 사용 (BehindText 워터마크가 본문 뒤로). PaintOp
                                     // 경로(skia/canvaskit)는 별도로 image.text_wrap 을 set 하므로 무관.
                                     text_wrap: Some(pic.common.text_wrap),
+                                    external_path: pic.image_attr.external_path.clone(),
                                     ..ImageNode::new(bin_data_id, image_data)
                                 }),
                                 BoundingBox::new(pic_x, pic_y, pic_w, pic_h),

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -4194,6 +4194,7 @@ fn make_picture_image_node(
             contrast: pic.image_attr.contrast,
             text_wrap: Some(pic.common.text_wrap),
             transform: extract_shape_transform(&pic.shape_attr),
+            external_path: pic.image_attr.external_path.clone(),
             ..ImageNode::new(bin_data_id, image_data)
         }),
         bbox,

--- a/src/renderer/layout/picture_footnote.rs
+++ b/src/renderer/layout/picture_footnote.rs
@@ -427,6 +427,7 @@ impl LayoutEngine {
                 contrast: picture.image_attr.contrast,
                 text_wrap: Some(picture.common.text_wrap),
                 transform: extract_shape_transform(&picture.shape_attr),
+                external_path: picture.image_attr.external_path.clone(),
                 ..ImageNode::new(bin_data_id, image_data)
             }),
             BoundingBox::new(adjusted_pic_x, pic_y, pic_width, pic_height),

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -1400,6 +1400,7 @@ impl LayoutEngine {
                         brightness: pic.image_attr.brightness,
                         contrast: pic.image_attr.contrast,
                         text_wrap: Some(pic.common.text_wrap),
+                        external_path: pic.image_attr.external_path.clone(),
                         ..ImageNode::new(bin_data_id, image_data)
                     }),
                     BoundingBox::new(render_x, render_y, render_w, render_h),

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -16,7 +16,6 @@ use web_sys::HtmlCanvasElement;
 
 use crate::document_core::{DocumentCore, DEFAULT_FALLBACK_FONT};
 use crate::error::HwpError;
-use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
 use crate::model::document::{Document, Section};
 use crate::model::page::ColumnDef;
@@ -116,20 +115,6 @@ fn external_path_extension(basename: &str) -> String {
         .to_string()
 }
 
-fn external_image_loaded(bin_data_content: &[BinDataContent], bin_data_id: u16) -> bool {
-    if bin_data_id == 0 {
-        return false;
-    }
-
-    if let Some(content) = bin_data_content.get((bin_data_id - 1) as usize) {
-        return !content.data.is_empty();
-    }
-
-    bin_data_content
-        .iter()
-        .any(|content| content.id == bin_data_id && !content.data.is_empty())
-}
-
 fn collect_external_image_references(document: &Document) -> Vec<ExternalImageReference> {
     let mut references = std::collections::BTreeMap::new();
 
@@ -158,7 +143,7 @@ fn collect_external_image_references(document: &Document) -> Vec<ExternalImageRe
                         extension: external_path_extension(&basename),
                         basename,
                         original_path: original_path.clone(),
-                        loaded: external_image_loaded(&document.bin_data_content, bin_data_id),
+                        loaded: document.external_image_loaded(bin_data_id),
                     }
                 });
             }
@@ -2370,10 +2355,11 @@ impl HwpDocument {
     ) -> u32 {
         use crate::model::control::Control;
         use crate::model::shape::ShapeObject;
+        use std::collections::BTreeMap;
 
         let mut injected: u32 = 0;
         // 영역 외부 image 영역 영역 영역 영역 basename 매칭 영역 영역 (id, ext) 수집
-        let mut targets: Vec<(u16, String)> = Vec::new();
+        let mut targets: BTreeMap<u16, String> = BTreeMap::new();
         for section in &self.document().sections {
             for para in &section.paragraphs {
                 for ctrl in &para.controls {
@@ -2394,12 +2380,7 @@ impl HwpDocument {
                             continue;
                         }
                         let id = pic.image_attr.bin_data_id;
-                        let already_loaded = self
-                            .document()
-                            .bin_data_content
-                            .iter()
-                            .any(|c| c.id == id && !c.data.is_empty());
-                        if already_loaded {
+                        if self.document().external_image_loaded(id) {
                             continue;
                         }
                         let ext = std::path::Path::new(basename)
@@ -2407,27 +2388,20 @@ impl HwpDocument {
                             .and_then(|e| e.to_str())
                             .unwrap_or("")
                             .to_string();
-                        targets.push((id, ext));
+                        targets.entry(id).or_insert(ext);
                     }
                 }
             }
         }
 
         for (id, ext) in targets {
-            let idx = (id as usize).saturating_sub(1);
-            if idx < self.document().bin_data_content.len() {
-                self.document_mut().bin_data_content[idx].id = id;
-                self.document_mut().bin_data_content[idx].data = data.to_vec();
-                self.document_mut().bin_data_content[idx].extension = ext;
-            } else {
-                self.document_mut()
-                    .bin_data_content
-                    .push(crate::model::bin_data::BinDataContent {
-                        id,
-                        data: data.to_vec(),
-                        extension: ext,
-                    });
+            if !self
+                .document_mut()
+                .inject_external_image_data(id, data.to_vec(), ext)
+            {
+                continue;
             }
+
             injected += 1;
 
             // [한컴 viewer 정합] 원본 path 영역 영역 access 부재 시 HWP file 영역 영역
@@ -2440,26 +2414,14 @@ impl HwpDocument {
             } else {
                 display_path.to_string()
             };
-            for section in &mut self.document_mut().sections {
-                for para in &mut section.paragraphs {
-                    for ctrl in &mut para.controls {
-                        let pic = match ctrl {
-                            crate::model::control::Control::Picture(p) => p,
-                            crate::model::control::Control::Shape(s) => match s.as_mut() {
-                                crate::model::shape::ShapeObject::Picture(p) => p,
-                                _ => continue,
-                            },
-                            _ => continue,
-                        };
-                        if pic.image_attr.bin_data_id == id
-                            && pic.image_attr.external_path.is_some()
-                        {
-                            pic.image_attr.external_path = Some(resolved.clone());
-                        }
-                    }
-                }
-            }
+            self.document_mut()
+                .update_external_image_display_path(id, &resolved);
         }
+
+        if injected > 0 {
+            self.invalidate_page_tree_cache();
+        }
+
         injected
     }
 

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -115,6 +115,11 @@ fn external_path_extension(basename: &str) -> String {
         .to_string()
 }
 
+fn parse_external_image_key(key: &str) -> Option<u16> {
+    let bin_data_id = key.strip_prefix("binData:")?.parse::<u16>().ok()?;
+    (bin_data_id != 0).then_some(bin_data_id)
+}
+
 fn collect_external_image_references(document: &Document) -> Vec<ExternalImageReference> {
     let mut references = std::collections::BTreeMap::new();
 
@@ -189,6 +194,44 @@ impl HwpDocument {
 
     pub fn find_column_def_for_paragraph(paragraphs: &[Paragraph], para_idx: usize) -> ColumnDef {
         DocumentCore::find_column_def_for_paragraph(paragraphs, para_idx)
+    }
+
+    fn inject_external_image_by_bin_data_id(
+        &mut self,
+        bin_data_id: u16,
+        data: &[u8],
+        display_path: &str,
+        fallback_basename: Option<&str>,
+    ) -> u32 {
+        let Some(reference) = collect_external_image_references(self.document())
+            .into_iter()
+            .find(|reference| reference.bin_data_id == bin_data_id)
+        else {
+            return 0;
+        };
+
+        if reference.loaded {
+            return 0;
+        }
+
+        if !self.document_mut().inject_external_image_data(
+            bin_data_id,
+            data.to_vec(),
+            reference.extension.clone(),
+        ) {
+            return 0;
+        }
+
+        let basename = fallback_basename.unwrap_or(&reference.basename);
+        let resolved = if display_path.is_empty() {
+            format!("/samples/{basename}")
+        } else {
+            display_path.to_string()
+        };
+        self.document_mut()
+            .update_external_image_display_path(bin_data_id, &resolved);
+
+        1
     }
 }
 
@@ -2355,11 +2398,11 @@ impl HwpDocument {
     ) -> u32 {
         use crate::model::control::Control;
         use crate::model::shape::ShapeObject;
-        use std::collections::BTreeMap;
+        use std::collections::BTreeSet;
 
         let mut injected: u32 = 0;
-        // 영역 외부 image 영역 영역 영역 영역 basename 매칭 영역 영역 (id, ext) 수집
-        let mut targets: BTreeMap<u16, String> = BTreeMap::new();
+        // 영역 외부 image 영역 영역 영역 영역 basename 매칭 영역 영역 id 수집
+        let mut targets: BTreeSet<u16> = BTreeSet::new();
         for section in &self.document().sections {
             for para in &section.paragraphs {
                 for ctrl in &para.controls {
@@ -2383,45 +2426,44 @@ impl HwpDocument {
                         if self.document().external_image_loaded(id) {
                             continue;
                         }
-                        let ext = std::path::Path::new(basename)
-                            .extension()
-                            .and_then(|e| e.to_str())
-                            .unwrap_or("")
-                            .to_string();
-                        targets.entry(id).or_insert(ext);
+                        targets.insert(id);
                     }
                 }
             }
         }
 
-        for (id, ext) in targets {
-            if !self
-                .document_mut()
-                .inject_external_image_data(id, data.to_vec(), ext)
-            {
-                continue;
-            }
-
-            injected += 1;
-
-            // [한컴 viewer 정합] 원본 path 영역 영역 access 부재 시 HWP file 영역 영역
-            // 같은 영역 영역 image 영역 영역 영역 dialog 영역 영역 resolved path 영역 영역 갱신.
-            // display_path 영역 영역 영역 영역 (Vite middleware 영역 영역 X-File-Path header
-            // 영역 영역 영역 OS 절대 경로) 영역 사용, 빈 문자열 영역 fallback 영역 영역
-            // `/samples/<basename>` 영역 사용.
-            let resolved = if display_path.is_empty() {
-                format!("/samples/{}", basename)
-            } else {
-                display_path.to_string()
-            };
-            self.document_mut()
-                .update_external_image_display_path(id, &resolved);
+        for id in targets {
+            injected +=
+                self.inject_external_image_by_bin_data_id(id, data, display_path, Some(basename));
         }
 
         if injected > 0 {
             self.invalidate_page_tree_cache();
         }
 
+        injected
+    }
+
+    /// [Task #1143] `getExternalImageReferences()` 의 key로 외부 이미지 bytes를 주입한다.
+    ///
+    /// 지원 key: `binData:<bin_data_id>`.
+    /// 잘못된 key, 존재하지 않는 key, 이미 loaded 상태인 reference는 0을 반환한다.
+    #[wasm_bindgen(js_name = injectExternalImageByKey)]
+    pub fn inject_external_image_by_key(
+        &mut self,
+        key: &str,
+        data: &[u8],
+        display_path: &str,
+    ) -> u32 {
+        let Some(bin_data_id) = parse_external_image_key(key) else {
+            return 0;
+        };
+
+        let injected =
+            self.inject_external_image_by_bin_data_id(bin_data_id, data, display_path, None);
+        if injected > 0 {
+            self.invalidate_page_tree_cache();
+        }
         injected
     }
 

--- a/tests/issue_1143.rs
+++ b/tests/issue_1143.rs
@@ -21,6 +21,18 @@ struct ExternalImageReference {
     loaded: bool,
 }
 
+const SAMPLE10_EXTERNAL_FORMATS: &[(&str, &str)] = &[
+    ("hwp3", "samples/hwp3-sample10.hwp"),
+    ("hwp5", "samples/hwp3-sample10-hwp5.hwp"),
+    ("hwpx", "samples/hwp3-sample10-hwpx.hwpx"),
+];
+
+const SAMPLE10_EXTERNAL_IMAGES: &[(u16, &str, &str, &str)] = &[
+    (1, "oracle.gif", "gif", "samples/oracle.gif"),
+    (2, "rdb02.gif", "gif", "samples/rdb02.gif"),
+    (3, "s1.jpg", "jpg", "samples/s1.jpg"),
+];
+
 fn load_doc(rel_path: &str) -> HwpDocument {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
@@ -100,6 +112,44 @@ fn item_detail_contains(item: &Value, needle: &str) -> bool {
     item["detail"]
         .as_str()
         .is_some_and(|detail| detail.split(';').any(|part| part == needle))
+}
+
+fn expected_sample10_basenames_from(start: usize) -> Vec<String> {
+    SAMPLE10_EXTERNAL_IMAGES[start..]
+        .iter()
+        .map(|(_, basename, _, _)| (*basename).to_string())
+        .collect()
+}
+
+fn assert_sample10_external_refs(
+    label: &str,
+    refs: &[ExternalImageReference],
+    loaded_through: usize,
+) {
+    assert_eq!(
+        refs.len(),
+        SAMPLE10_EXTERNAL_IMAGES.len(),
+        "{label}: sample10 should expose three external image refs"
+    );
+
+    for (index, (reference, (bin_id, basename, extension, _sample_path))) in
+        refs.iter().zip(SAMPLE10_EXTERNAL_IMAGES.iter()).enumerate()
+    {
+        assert_eq!(reference.bin_data_id, *bin_id, "{label}: binDataId");
+        assert_eq!(reference.key, format!("binData:{bin_id}"), "{label}: key");
+        assert_eq!(reference.basename, *basename, "{label}: basename");
+        assert_eq!(reference.extension, *extension, "{label}: extension");
+        assert!(
+            reference.original_path.ends_with(basename),
+            "{label}: original path should end with {basename}. got={}",
+            reference.original_path
+        );
+        assert_eq!(
+            reference.loaded,
+            index < loaded_through,
+            "{label}: loaded state for {basename}"
+        );
+    }
 }
 
 #[test]
@@ -242,6 +292,87 @@ fn issue_1143_key_injection_uses_discovery_key_and_invalidates_cache() {
         after_payloads > before_payloads,
         "key injection should invalidate cached PageLayerTrees"
     );
+}
+
+#[test]
+fn issue_1143_key_injection_works_across_hwp3_hwp5_and_hwpx_sample10() {
+    for (label, rel_path) in SAMPLE10_EXTERNAL_FORMATS {
+        let mut doc = load_doc(rel_path);
+        let refs = external_image_refs(&doc);
+        assert_sample10_external_refs(label, &refs, 0);
+        assert_eq!(
+            external_image_basenames(&doc),
+            expected_sample10_basenames_from(0),
+            "{label}: basename API should list missing images before injection"
+        );
+
+        let before_payloads = page_layer_image_payload_count(&doc, 0);
+        assert_eq!(
+            before_payloads, 0,
+            "{label}: sample10 page 1 external images should have no payload before injection"
+        );
+
+        let before_items = canvaskit_image_items(&doc, 0);
+        assert!(
+            before_items.iter().any(|item| {
+                item["status"].as_str() == Some("directRequired")
+                    && item_detail_contains(item, "externalImage")
+                    && item_detail_contains(item, "missingImageData")
+            }),
+            "{label}: CanvasKit should report missing external image bytes before injection: {before_items:?}"
+        );
+
+        for (image_index, (bin_id, basename, _extension, sample_path)) in
+            SAMPLE10_EXTERNAL_IMAGES.iter().enumerate()
+        {
+            let reference = refs
+                .iter()
+                .find(|reference| reference.bin_data_id == *bin_id)
+                .unwrap_or_else(|| panic!("{label}: binDataId {bin_id} ref"));
+            let data = read_sample(sample_path);
+            let display_path = format!("/tmp/{basename}");
+            assert_eq!(
+                doc.inject_external_image_by_key(&reference.key, &data, &display_path),
+                1,
+                "{label}: key injection should load {basename}"
+            );
+
+            let refs_after_step = external_image_refs(&doc);
+            assert_sample10_external_refs(label, &refs_after_step, image_index + 1);
+            assert_eq!(
+                external_image_basenames(&doc),
+                expected_sample10_basenames_from(image_index + 1),
+                "{label}: basename API should list only still-missing images after injecting {basename}"
+            );
+        }
+
+        let after_payloads = page_layer_image_payload_count(&doc, 0);
+        assert!(
+            after_payloads >= SAMPLE10_EXTERNAL_IMAGES.len(),
+            "{label}: PageLayerTree should include mime/base64 payloads after injection"
+        );
+
+        let after_items = canvaskit_image_items(&doc, 0);
+        let injected_direct = after_items
+            .iter()
+            .filter(|item| {
+                item["status"].as_str() == Some("direct")
+                    && item_detail_contains(item, "externalImage")
+                    && item_detail_contains(item, "injectedImageData")
+            })
+            .count();
+        assert!(
+            injected_direct >= SAMPLE10_EXTERNAL_IMAGES.len(),
+            "{label}: injected external images should be directly replayable: {after_items:?}"
+        );
+        assert!(
+            !after_items.iter().any(|item| {
+                item_detail_contains(item, "externalImage")
+                    && item_detail_contains(item, "missingImageData")
+            }),
+            "{label}: injected external images should not remain in missing-image state: {after_items:?}"
+        );
+    }
 }
 
 #[test]

--- a/tests/issue_1143.rs
+++ b/tests/issue_1143.rs
@@ -1,0 +1,198 @@
+//! Issue #1143: external image bytes injection and PageLayerTree cache invalidation.
+//!
+//! Injection must share the renderer's binDataId index-first lookup semantics and
+//! must invalidate cached page trees when image bytes become available after the
+//! tree has already been built.
+
+use rhwp::model::bin_data::BinDataContent;
+use rhwp::wasm_api::HwpDocument;
+use serde::Deserialize;
+use serde_json::Value;
+use std::path::Path;
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct ExternalImageReference {
+    key: String,
+    bin_data_id: u16,
+    original_path: String,
+    basename: String,
+    extension: String,
+    loaded: bool,
+}
+
+fn load_doc(rel_path: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {}: {e}", path.display()))
+}
+
+fn read_sample(rel_path: &str) -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel_path);
+    std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e))
+}
+
+fn external_image_refs(doc: &HwpDocument) -> Vec<ExternalImageReference> {
+    let json = doc.get_external_image_references();
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse refs JSON {json}: {e}"))
+}
+
+fn external_image_basenames(doc: &HwpDocument) -> Vec<String> {
+    let json = doc.get_external_image_basenames();
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse basename JSON {json}: {e}"))
+}
+
+fn collect_image_ops<'a>(value: &'a Value, out: &mut Vec<&'a Value>) {
+    match value {
+        Value::Object(map) => {
+            if value.get("type").and_then(Value::as_str) == Some("image") {
+                out.push(value);
+            }
+            for child in map.values() {
+                collect_image_ops(child, out);
+            }
+        }
+        Value::Array(items) => {
+            for child in items {
+                collect_image_ops(child, out);
+            }
+        }
+        _ => {}
+    }
+}
+
+fn page_layer_image_payload_count(doc: &HwpDocument, page: u32) -> usize {
+    let json = doc
+        .get_page_layer_tree_native(page)
+        .unwrap_or_else(|e| panic!("page layer tree {page}: {e}"));
+    let parsed: Value =
+        serde_json::from_str(&json).unwrap_or_else(|e| panic!("PageLayerTree JSON: {e}"));
+    let mut images = Vec::new();
+    collect_image_ops(&parsed, &mut images);
+    images
+        .iter()
+        .filter(|image| {
+            image.get("mime").is_some()
+                && image
+                    .get("base64")
+                    .and_then(Value::as_str)
+                    .is_some_and(|data| !data.is_empty())
+        })
+        .count()
+}
+
+#[test]
+fn issue_1143_basename_injection_marks_reference_loaded() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+    let oracle = read_sample("samples/oracle.gif");
+
+    let before = external_image_refs(&doc);
+    let oracle_ref = before
+        .iter()
+        .find(|reference| reference.bin_data_id == 1)
+        .expect("binDataId 1 ref");
+    assert_eq!(oracle_ref.key, "binData:1");
+    assert_eq!(oracle_ref.basename, "oracle.gif");
+    assert_eq!(oracle_ref.extension, "gif");
+    assert!(oracle_ref.original_path.ends_with("oracle.gif"));
+    assert!(!oracle_ref.loaded);
+
+    let injected = doc.inject_external_image("oracle.gif", &oracle, "/tmp/oracle.gif");
+    assert_eq!(injected, 1);
+
+    let after = external_image_refs(&doc);
+    let oracle_ref = after
+        .iter()
+        .find(|reference| reference.bin_data_id == 1)
+        .expect("binDataId 1 ref");
+    assert!(oracle_ref.loaded);
+
+    let basenames = external_image_basenames(&doc);
+    assert!(
+        !basenames.iter().any(|name| name == "oracle.gif"),
+        "injected basename should be hidden from the legacy missing-image API"
+    );
+    assert!(
+        basenames.iter().any(|name| name == "rdb02.gif")
+            && basenames.iter().any(|name| name == "s1.jpg"),
+        "still-missing image basenames should remain visible"
+    );
+}
+
+#[test]
+fn issue_1143_basename_injection_respects_index_first_loaded_state() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    doc.document_mut().bin_data_content[0] = BinDataContent {
+        id: 99,
+        data: vec![b'G', b'I', b'F'],
+        extension: "gif".to_string(),
+    };
+    let before = doc.document().bin_data_content[0].clone();
+
+    let injected = doc.inject_external_image("oracle.gif", &read_sample("samples/oracle.gif"), "");
+    assert_eq!(
+        injected, 0,
+        "already-loaded detection must follow bin_data_content[binDataId - 1]"
+    );
+    assert_eq!(doc.document().bin_data_content[0].id, before.id);
+    assert_eq!(doc.document().bin_data_content[0].data, before.data);
+    assert_eq!(
+        doc.document().bin_data_content[0].extension,
+        before.extension
+    );
+}
+
+#[test]
+fn issue_1143_wasm_injection_invalidates_cached_page_layer_tree() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    let before = page_layer_image_payload_count(&doc, 0);
+    assert_eq!(
+        before, 0,
+        "sample10 page 1 external images should have no payload before injection"
+    );
+
+    for (basename, sample_path) in [
+        ("oracle.gif", "samples/oracle.gif"),
+        ("rdb02.gif", "samples/rdb02.gif"),
+        ("s1.jpg", "samples/s1.jpg"),
+    ] {
+        let data = read_sample(sample_path);
+        assert_eq!(doc.inject_external_image(basename, &data, ""), 1);
+    }
+
+    let after = page_layer_image_payload_count(&doc, 0);
+    assert!(
+        after > before,
+        "PageLayerTree cache should be rebuilt with injected image payloads"
+    );
+}
+
+#[test]
+fn issue_1143_native_dir_population_invalidates_cached_page_layer_tree() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    let before = page_layer_image_payload_count(&doc, 0);
+    assert_eq!(
+        before, 0,
+        "sample10 page 1 external images should have no payload before directory population"
+    );
+
+    let sample_dir = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples");
+    let loaded = doc.populate_external_images_from_dir(&sample_dir);
+    assert_eq!(loaded, 3);
+
+    assert!(
+        external_image_refs(&doc)
+            .iter()
+            .all(|reference| reference.loaded),
+        "all discovered sample10 external image refs should be loaded"
+    );
+
+    let after = page_layer_image_payload_count(&doc, 0);
+    assert!(
+        after > before,
+        "native directory population should rebuild cached PageLayerTrees"
+    );
+}

--- a/tests/issue_1143.rs
+++ b/tests/issue_1143.rs
@@ -120,6 +120,127 @@ fn issue_1143_basename_injection_marks_reference_loaded() {
 }
 
 #[test]
+fn issue_1143_key_injection_uses_discovery_key_and_invalidates_cache() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    let oracle_ref = external_image_refs(&doc)
+        .into_iter()
+        .find(|reference| reference.bin_data_id == 1)
+        .expect("binDataId 1 ref");
+    assert_eq!(oracle_ref.key, "binData:1");
+
+    let before_payloads = page_layer_image_payload_count(&doc, 0);
+    assert_eq!(
+        before_payloads, 0,
+        "sample10 page 1 external images should have no payload before key injection"
+    );
+
+    let oracle = read_sample("samples/oracle.gif");
+    assert_eq!(
+        doc.inject_external_image_by_key(&oracle_ref.key, &oracle, "/tmp/oracle.gif"),
+        1
+    );
+    assert_eq!(
+        doc.inject_external_image_by_key(&oracle_ref.key, &oracle, "/tmp/oracle.gif"),
+        0,
+        "already-loaded key injection should be idempotent"
+    );
+
+    let refs = external_image_refs(&doc);
+    assert!(
+        refs.iter()
+            .any(|reference| reference.bin_data_id == 1 && reference.loaded),
+        "target reference should be marked loaded after key injection"
+    );
+    assert!(
+        refs.iter()
+            .any(|reference| reference.bin_data_id == 2 && !reference.loaded)
+            && refs
+                .iter()
+                .any(|reference| reference.bin_data_id == 3 && !reference.loaded),
+        "key injection should not load unrelated references"
+    );
+
+    let basenames = external_image_basenames(&doc);
+    assert!(
+        !basenames.iter().any(|name| name == "oracle.gif"),
+        "key-injected basename should be hidden from the legacy missing-image API"
+    );
+    assert!(
+        basenames.iter().any(|name| name == "rdb02.gif")
+            && basenames.iter().any(|name| name == "s1.jpg"),
+        "unrelated missing basenames should remain visible"
+    );
+
+    let after_payloads = page_layer_image_payload_count(&doc, 0);
+    assert!(
+        after_payloads > before_payloads,
+        "key injection should invalidate cached PageLayerTrees"
+    );
+}
+
+#[test]
+fn issue_1143_key_injection_targets_only_the_requested_reference() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    let rdb02_ref = external_image_refs(&doc)
+        .into_iter()
+        .find(|reference| reference.bin_data_id == 2)
+        .expect("binDataId 2 ref");
+    assert_eq!(rdb02_ref.key, "binData:2");
+    assert_eq!(rdb02_ref.basename, "rdb02.gif");
+
+    let rdb02 = read_sample("samples/rdb02.gif");
+    assert_eq!(
+        doc.inject_external_image_by_key(&rdb02_ref.key, &rdb02, "/tmp/rdb02.gif"),
+        1
+    );
+
+    let refs = external_image_refs(&doc);
+    assert!(
+        refs.iter()
+            .any(|reference| reference.bin_data_id == 2 && reference.loaded),
+        "requested key should be loaded"
+    );
+    assert!(
+        refs.iter()
+            .any(|reference| reference.bin_data_id == 1 && !reference.loaded)
+            && refs
+                .iter()
+                .any(|reference| reference.bin_data_id == 3 && !reference.loaded),
+        "key injection must not fall back to basename matching"
+    );
+}
+
+#[test]
+fn issue_1143_key_injection_rejects_invalid_or_unknown_keys() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+    let oracle = read_sample("samples/oracle.gif");
+
+    for key in [
+        "",
+        "oracle.gif",
+        "binData:",
+        "binData:0",
+        "binData:not-a-number",
+        "binData:999",
+    ] {
+        assert_eq!(
+            doc.inject_external_image_by_key(key, &oracle, ""),
+            0,
+            "invalid or unknown key should not inject: {key}"
+        );
+    }
+
+    assert!(
+        external_image_refs(&doc)
+            .iter()
+            .all(|reference| !reference.loaded),
+        "invalid key attempts must not mutate external image loaded state"
+    );
+}
+
+#[test]
 fn issue_1143_basename_injection_respects_index_first_loaded_state() {
     let mut doc = load_doc("samples/hwp3-sample10.hwp");
 

--- a/tests/issue_1143.rs
+++ b/tests/issue_1143.rs
@@ -81,6 +81,27 @@ fn page_layer_image_payload_count(doc: &HwpDocument, page: u32) -> usize {
         .count()
 }
 
+fn canvaskit_image_items(doc: &HwpDocument, page: u32) -> Vec<Value> {
+    let json = doc
+        .get_canvaskit_replay_plan_native(page, "default")
+        .unwrap_or_else(|e| panic!("CanvasKit replay plan {page}: {e}"));
+    let parsed: Value =
+        serde_json::from_str(&json).unwrap_or_else(|e| panic!("CanvasKit plan JSON: {e}"));
+    parsed["items"]
+        .as_array()
+        .expect("CanvasKit plan items")
+        .iter()
+        .filter(|item| item["opType"].as_str() == Some("image"))
+        .cloned()
+        .collect()
+}
+
+fn item_detail_contains(item: &Value, needle: &str) -> bool {
+    item["detail"]
+        .as_str()
+        .is_some_and(|detail| detail.split(';').any(|part| part == needle))
+}
+
 #[test]
 fn issue_1143_basename_injection_marks_reference_loaded() {
     let mut doc = load_doc("samples/hwp3-sample10.hwp");
@@ -116,6 +137,50 @@ fn issue_1143_basename_injection_marks_reference_loaded() {
         basenames.iter().any(|name| name == "rdb02.gif")
             && basenames.iter().any(|name| name == "s1.jpg"),
         "still-missing image basenames should remain visible"
+    );
+}
+
+#[test]
+fn issue_1143_canvaskit_plan_distinguishes_missing_and_injected_external_images() {
+    let mut doc = load_doc("samples/hwp3-sample10.hwp");
+
+    let before_items = canvaskit_image_items(&doc, 0);
+    assert!(
+        before_items.iter().any(|item| {
+            item["status"].as_str() == Some("directRequired")
+                && item_detail_contains(item, "externalImage")
+                && item_detail_contains(item, "missingImageData")
+        }),
+        "external image without injected bytes should be reported as missing: {before_items:?}"
+    );
+
+    let oracle_ref = external_image_refs(&doc)
+        .into_iter()
+        .find(|reference| reference.bin_data_id == 1)
+        .expect("binDataId 1 ref");
+    let oracle = read_sample("samples/oracle.gif");
+    assert_eq!(
+        doc.inject_external_image_by_key(&oracle_ref.key, &oracle, "/tmp/oracle.gif"),
+        1
+    );
+
+    let after_items = canvaskit_image_items(&doc, 0);
+    assert!(
+        after_items.iter().any(|item| {
+            item["status"].as_str() == Some("direct")
+                && item_detail_contains(item, "externalImage")
+                && item_detail_contains(item, "injectedImageData")
+                && !item_detail_contains(item, "missingImageData")
+        }),
+        "injected external image should be directly replayable and not reported as missing: {after_items:?}"
+    );
+    assert!(
+        after_items.iter().any(|item| {
+            item["status"].as_str() == Some("directRequired")
+                && item_detail_contains(item, "externalImage")
+                && item_detail_contains(item, "missingImageData")
+        }),
+        "other external images on the page should remain missing until injected: {after_items:?}"
     );
 }
 


### PR DESCRIPTION
## 개요

#1142에서 추가한 external image reference discovery contract의 후속 작업입니다.

이번 PR은 discovery된 external image reference에 대응하는 bytes를 core document state에 주입하고, 주입 전후의 loaded state를 PageLayerTree / CanvasKit replay plan이 같은 기준으로 보도록 정리합니다. 핵심은 renderer backend가 외부 파일을 직접 찾지 않고, consumer가 준비한 bytes를 discovery key로 주입한 뒤 기존 image payload 흐름을 replay하게 만드는 것입니다.

## 변경 내용

- external image loaded/injection 공통 helper 추가
  - `bin_data_content[binDataId - 1]` index-first 조회 규칙을 renderer와 맞춤
  - 이미 loaded인 reference는 재주입하지 않도록 idempotent 처리
  - 주입 시 display path를 갱신해 diagnostic/debug 정보가 실제 consumer 경로를 반영
- WASM/API entrypoint 보강
  - `injectExternalImageByKey(key, data, displayPath)` 추가
  - discovery 결과의 `binData:N` key로 정확한 reference를 지정
  - 기존 basename 기반 `injectExternalImage(...)`는 source compatibility를 유지하면서 같은 helper를 재사용
- PageLayerTree cache invalidation 정리
  - WASM injection과 native directory population 모두 image bytes가 새로 채워지면 cached PageLayerTree를 무효화
  - 이미 생성된 PageLayerTree가 missing image state를 계속 들고 있는 문제를 방지
- CanvasKit replay diagnostic 정리
  - external path만으로 direct replay를 막지 않고 실제 image payload 준비 여부를 기준으로 판단
  - `externalImage;missingImageData`와 `externalImage;injectedImageData`를 구분
  - injected external image는 missing resource가 아니라 direct replay 가능한 image로 보고
- layout 경로의 `external_path` 보존 보강
  - 본문/도형/문단/머리말·꼬리말 picture layout 경로에서 external path metadata를 `ImageNode`까지 전달
- 회귀 테스트 추가
  - HWP3 / HWP5 링크 변환 / HWPX sample10에서 key 기반 injection을 동일 시나리오로 검증
  - discovery loaded 상태, legacy basename API, PageLayerTree `mime/base64`, CanvasKit replay plan 상태를 함께 확인

## 작업의 본질

이 PR은 "외부 이미지 파일을 어디에서 어떻게 찾을 것인가"가 아니라, consumer가 이미 확보한 image bytes를 rhwp document state에 안정적으로 주입하는 contract를 고정합니다.

책임 경계는 다음과 같이 두었습니다.

- renderer consumer: 파일 선택, 권한, 경로 정책, bytes 준비
- core document state: discovery key와 연결된 `bin_data_content` 갱신
- renderer backend: 이미 주입된 document state와 resolved image payload를 replay

따라서 renderer backend별 파일 탐색 분기를 추가하지 않고, PageLayerTree / CanvasKit / Skia 계열이 같은 loaded state를 공유할 수 있습니다.

## 리뷰 포인트

- #1142의 `getExternalImageReferences()` key를 그대로 injection key로 사용합니다.
- `binDataId`와 `BinDataContent.id`가 항상 같지 않을 수 있어, renderer lookup과 같은 index-first 규칙을 테스트로 고정했습니다.
- basename 기반 API는 기존 caller 호환을 위해 유지하되, 새 key 기반 API가 ambiguous basename/path 문제를 피하는 기본 contract입니다.
- injection 후 cache invalidation은 bytes가 실제로 새로 채워진 경우에만 수행합니다.
- CanvasKit policy는 external path 존재 여부가 아니라 replay 가능한 payload 존재 여부를 기준으로 direct/missing 상태를 판단합니다.
- 새 fixture 파일은 추가하지 않고 기존 `samples/hwp3-sample10*` 문서와 `samples/oracle.gif`, `samples/rdb02.gif`, `samples/s1.jpg`를 재사용했습니다.

## Non-goals

- 외부 파일 시스템 탐색 정책이나 browser 권한 정책을 core renderer에 추가하지 않습니다.
- #1017의 BehindText / InFrontOfText z-order 합성 정책은 이 PR 범위가 아닙니다.
- image effect / brightness / contrast의 pixel parity 전체를 닫지 않습니다.

## 검증

- [x] `cargo fmt --all -- --check`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test`
- [x] `cargo test --lib canvaskit_policy`
- [x] `cargo test --test issue_1143`
- [x] `cargo test --test issue_824 --test issue_1142 --test issue_1143`
- [x] `cargo test --test issue_938 --test issue_1017`
- [x] `git diff --check`

## 관련 이슈

- 관련: #1143
- Parent: #1141
- Follow-up: #1142 / PR #1175
- Refs: #536, #1018
- Related: #741, #873, #875

## 스크린샷

external image bytes injection contract와 replay diagnostic 회귀 테스트 중심 변경이라 별도 스크린샷은 없습니다.
