### PR TITLE
task 1189: task 1139 후속 미주/수식 정합 보정

### DIFF
--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -116,4 +116,13 @@
 - [x] Stage3 단일 회귀 검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
 - [x] Stage3 시각 확인 승인: 2026-06-01 작업지시자 승인.
 - [x] Stage3 커밋 전 전체 검증: `cargo test --tests` 통과.
-- [ ] 다음: Stage3 커밋.
+- [x] Stage3 커밋: `decee292` (`task 1189: 11쪽 미주 제목 간격 보정`).
+- [x] Stage4 시작: `3-10월_교육_통합_2022.hwp` 17쪽 미주 영역 드래그 선택 불일치. 작업지시자 자동 승인.
+- [x] Stage4 원인 분석: `pi=917..920`은 줄 끝 수식 컨트롤 때문에 TextRun 기반 selection end cursor가 실패해 드래그 하이라이트가 누락됨.
+- [x] Stage4 구현: 본문/미주 가상 문단 선택에서 TextRun 끝점이 없으면 같은 `TextLine` 오른쪽 끝을 fallback cursor로 사용.
+- [x] Stage4 단일 회귀 검증: `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_oct_page17_endnote_drag_selection_covers_equation_tail_lines -- --nocapture` 통과.
+- [x] Stage4 파일 단위 회귀 검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(32 passed).
+- [x] Stage4 포맷/공백 검증: `cargo fmt --all --check`, `git diff --check` 통과.
+- [x] Stage4 WASM 검증: `wasm-pack build --target web --out-dir pkg` 통과.
+- [x] Stage4 커밋 전 전체 검증: `cargo test --tests` 통과.
+- [x] Stage4 자동 승인 커밋 완료: `task 1189: 17쪽 미주 드래그 선택 보정`.

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -126,3 +126,9 @@
 - [x] Stage4 WASM 검증: `wasm-pack build --target web --out-dir pkg` 통과.
 - [x] Stage4 커밋 전 전체 검증: `cargo test --tests` 통과.
 - [x] Stage4 자동 승인 커밋 완료: `task 1189: 17쪽 미주 드래그 선택 보정`.
+- [x] Stage5 시작: `3-11월_실전_통합_2022.hwp` 10쪽 하단 미주 `문6)` 부근 오버랩 재분석.
+- [x] Stage5 구현: compact 미주 하단 새 문제 제목 간격을 직전 내용 하단 + 10px로 제한해 `pi=475` 꼬리 수식 overflow 제거.
+- [x] Stage5 검증: 10쪽 SVG 로그 overflow 없음 / rsvg-convert PNG 생성 / 단일 10~12쪽 회귀 테스트 통과 / `issue_1139_inline_picture_duplicate` 전체 통과(32 passed).
+- [x] Stage5 포맷/공백 검증: `cargo fmt --all --check`, `git diff --check` 통과.
+- [x] Stage5 커밋 전 전체 검증: `cargo test --tests` 통과.
+- [x] Stage5 WASM 검증: `wasm-pack build --target web --out-dir pkg` 통과.

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -85,3 +85,27 @@
 |------|--------|------|------|
 | #1187 | BookReview.hwp 글상자 내용이 영역 밖으로 출력되는 회귀 수정 | 완료 | PR #1190 머지(devel `6ca2be7f`), 시각 판정 통과, 이슈 CLOSED |
 | #1192 | CI 시간 단축 (테스트 중복/CodeQL 캐시/디스크/concurrency) | 완료 | devel `fe5d306c`, Build & Test 11.9분→3.5분(−70%), CI green, 이슈 CLOSED |
+
+## Task #1189 — task 1139 후속 보정: 2023 교육 통합 19쪽 정합
+
+- [x] 이슈 등록 확인: #1189 `3-09월_교육_통합_2023.hwp` 19쪽 렌더링 정합 불일치.
+- [x] 브랜치 생성: 최신 `upstream/devel` 기준 `local/task_m100_1189`.
+- [x] Stage1 분석 시작: `samples/3-09월_교육_통합_2023.hwp` 19쪽과 `pdf/3-09월_교육_통합_2023.pdf` 19쪽 비교 산출물 생성.
+- [x] 1차 판단: 일반 본문이 아니라 미주 흐름에서 `문29)` 이하가 아래로 밀리고, `pi=952/953`이 페이지 하단 overflow.
+- [x] Stage2 구현: compact 미주 질문 제목 forward gap cap + 큰 수식 줄 내부 되감기 split 우선 조건 추가.
+- [x] 추가 확인: `3-11월_실전_통합_2022.hwp` 16/17쪽 `pi=786` 분배를 `0..1`/`1..5`로 보정.
+- [x] 추가 확인: `3-11월_실전_통합_2022.hwp` 10~12쪽을 PDF와 비교. 12쪽 시작 누락(`pi=553 lines=8..11`)과 마지막 수식 Y축 찌그러짐을 보정.
+- [x] 추가 확인: `3-11월_실전_통합_2022.hwp` 14쪽/17쪽을 PDF와 비교. 17쪽 문28 `g(θ)=□CQRT-△CST` 줄 밀림은 HWP3식 수식-only 미주 문단에 HWP5 marker 합성이 과적용된 문제로 좁혀 보정.
+- [x] 추가 확인: `3-11월_실전_통합_2022.hwp` 12쪽 문19) 변화표 내부 수식 보정. HWP 대문자 대각 화살표 토큰 `SEARROW`/`NEARROW`가 문자열 그대로 렌더되던 문제를 `↘`/`↗` 매핑으로 수정.
+- [x] 비교 산출물: 14/17쪽 최신본은 `output/task1189_stage2_3-11_pages14_17/post2/`.
+- [x] 비교 산출물: 12쪽 문19) 최신본은 `output/task1189_stage2_3-11_pages10_12/post5/page12/`.
+- [x] 비교 산출물: SVG→PNG는 `rsvg-convert`, PDF 페이지 추출은 `pdftoppm` 기준으로 생성.
+- [x] 잔여 기록: 최신 산출물 기준 10쪽 `pi=475` 7.6px, 11쪽 `pi=553` 최대 55.7px overflow 로그가 남음. 작업지시자 시각 확인 기준 11쪽 overflow는 다음 Stage3에서 처리.
+- [x] 포맷 확인: `cargo fmt --all --check` 통과.
+- [x] 단일 회귀 검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
+- [x] 추가 단위 검증: `cargo test --lib test_arrows --quiet` 통과.
+- [x] 추가 단일 케이스 검증: `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf -- --nocapture` 통과.
+- [x] 문19) 추가 보정 후 파일 단위 회귀 재검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
+- [x] WASM 검증: `wasm-pack build --target web --out-dir pkg` 통과.
+- [x] 커밋 전 전체 검증: `cargo test --tests` 통과.
+- [ ] 다음: Stage2 커밋 후 Stage3 문서 생성.

--- a/mydocs/orders/20260531.md
+++ b/mydocs/orders/20260531.md
@@ -108,4 +108,12 @@
 - [x] 문19) 추가 보정 후 파일 단위 회귀 재검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
 - [x] WASM 검증: `wasm-pack build --target web --out-dir pkg` 통과.
 - [x] 커밋 전 전체 검증: `cargo test --tests` 통과.
-- [ ] 다음: Stage2 커밋 후 Stage3 문서 생성.
+- [x] Stage2 커밋: `6cb2fd55` (`task 1189: 미주 수식 흐름 후속 보정`).
+- [x] Stage3 시작: 11쪽 overflow 후속 보정 문서 `mydocs/working/task_m100_1189_stage3.md` 생성.
+- [x] Stage3 재분석: 11쪽 실제 overflow 지점은 오른쪽 단 `문14)` 꼬리(`pi=553 lines=0..8`)이며, `문13`/`문14` 제목이 직전 큰 수식 줄 trailing 간격 뒤로 과도하게 밀린 문제로 확인.
+- [x] Stage3 구현: lazy-base compact 미주 흐름에서 큰 display 수식 줄 뒤 새 문제 제목만 직전 내용 하단 + 10px로 배치. page-base 흐름은 기존 7mm 미주 간격 유지.
+- [x] Stage3 산출물: `output/task1189_stage3_3-11_page11/fixed/page11/rhwp_page11.png`.
+- [x] Stage3 단일 회귀 검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
+- [x] Stage3 시각 확인 승인: 2026-06-01 작업지시자 승인.
+- [x] Stage3 커밋 전 전체 검증: `cargo test --tests` 통과.
+- [ ] 다음: Stage3 커밋.

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -1,0 +1,10 @@
+# 2026-06-01 — 오늘 할일
+
+## Task #1189 — task 1139 후속 보정
+
+- [x] Stage6 시작: `3-11월_실전_통합_2022.hwp` 1쪽 `문1)`과 첫 수식 사이 간격 불일치 재분석.
+- [x] Stage6 비교: PDF/한컴 기준 산출물과 현재 SVG/PNG 비교.
+- [x] Stage6 구현: `U+FFFC` 인라인 객체 placeholder가 텍스트 폭에 포함되어 첫 수식이 오른쪽으로 밀리는 문제 보정.
+- [x] Stage6 검증: 대상 회귀 테스트와 시각 산출물 확인.
+- [x] Stage6 커밋 전 검증: `cargo test --tests`, `wasm-pack build --target web --out-dir pkg` 통과.
+- [ ] Stage6 커밋 및 PR 준비.

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -8,3 +8,10 @@
 - [x] Stage6 검증: 대상 회귀 테스트와 시각 산출물 확인.
 - [x] Stage6 커밋 전 검증: `cargo test --tests`, `wasm-pack build --target web --out-dir pkg` 통과.
 - [ ] Stage6 커밋 및 PR 준비.
+
+- [x] Stage7 시작: `3-10월_교육_통합_2022.hwp` 11쪽 미주 간격 이상 재확인.
+- [x] Stage7 비교: PDF/한컴 기준 산출물과 현재 SVG/PNG 비교.
+- [x] Stage7 구현: 빈 문단 뒤 compact 미주 제목의 추가 40px 완충 제거로 PR #1194 보정.
+- [x] Stage7 1차 검증: `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture`, `cargo fmt --all --check` 통과.
+- [x] Stage7 커밋 전 검증: `cargo test --tests`, `wasm-pack build --target web --out-dir pkg` 통과.
+- [ ] Stage7 커밋 및 PR #1194 브랜치 push.

--- a/mydocs/working/task_m100_1189_stage1.md
+++ b/mydocs/working/task_m100_1189_stage1.md
@@ -1,0 +1,71 @@
+# Task M100 #1189 Stage 1
+
+## 목적
+
+Task #1139 병합 이후 후속 보정으로, `3-09월_교육_통합_2023.hwp` 19쪽이 한컴/PDF 기준과 맞지 않는 문제를 분석한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 기준 브랜치: 최신 `upstream/devel`
+- 작업 브랜치: `local/task_m100_1189`
+- 대상 HWP: `samples/3-09월_교육_통합_2023.hwp`
+- 권위 PDF: `pdf/3-09월_교육_통합_2023.pdf`
+- 대상 페이지: 화면 기준 19쪽
+  - `export-svg`/`dump-pages`: `-p 18` (0-index)
+  - `pdftoppm`: `-f 19 -l 19` (1-index)
+
+## 재현 및 분석 산출물
+
+- 산출물 디렉터리: `output/task1189_stage1_page19_analysis/`
+- 현재 SVG: `output/task1189_stage1_page19_analysis/3-09월_교육_통합_2023_019.svg`
+- 현재 PNG: `output/task1189_stage1_page19_analysis/rhwp_page19.png`
+- 디버그 PNG: `output/task1189_stage1_page19_analysis/rhwp_page19_debug.png`
+- PDF 19쪽 PNG: `output/task1189_stage1_page19_analysis/pdf_page19-19.png`
+- 좌우 비교 PNG: `output/task1189_stage1_page19_analysis/rhwp_vs_pdf_page19.png`
+- 페이지 dump:
+  - `output/task1189_stage1_page19_analysis/dump_page18.txt`
+  - `output/task1189_stage1_page19_analysis/dump_page19.txt`
+  - `output/task1189_stage1_page19_analysis/dump_page20.txt`
+
+## 실행 명령
+
+```bash
+cargo run --bin rhwp -- export-svg samples/3-09월_교육_통합_2023.hwp -p 18 -o output/task1189_stage1_page19_analysis
+cargo run --bin rhwp -- export-svg samples/3-09월_교육_통합_2023.hwp -p 18 -o output/task1189_stage1_page19_analysis/debug --debug-overlay
+cargo run --bin rhwp -- dump-pages samples/3-09월_교육_통합_2023.hwp -p 18
+pdftoppm -f 19 -l 19 -r 144 -png pdf/3-09월_교육_통합_2023.pdf output/task1189_stage1_page19_analysis/pdf_page19
+rsvg-convert output/task1189_stage1_page19_analysis/3-09월_교육_통합_2023_019.svg -o output/task1189_stage1_page19_analysis/rhwp_page19.png
+rsvg-convert output/task1189_stage1_page19_analysis/debug/3-09월_교육_통합_2023_019.svg -o output/task1189_stage1_page19_analysis/rhwp_page19_debug.png
+```
+
+## 관찰 결과
+
+- 현재 rhwp 19쪽은 PDF 19쪽 대비 우측 단의 `문29)` 이하가 아래로 밀려 있다.
+- PDF 기준으로는 19쪽 우측 단에 `문29)` 본문과 그림이 함께 들어오지만, 현재 rhwp는 `문29)`가 하단에 걸리고 이후 내용이 20쪽으로 넘어간다.
+- `export-svg` 과정에서 19쪽 overflow가 직접 기록된다.
+  - `pi=935 line=1`: 단0 하단 `4.1px` overflow
+  - `pi=952 line=0`: 단1 하단 `17.6px` overflow
+  - `pi=953 line=0`: 단1 하단 `41.1px` overflow
+- `dump-pages -p 18` 기준 19쪽은 `pr.endnote_paragraphs`에 합쳐진 미주 흐름이다.
+  - 19쪽 단0: `pi=921`부터 시작, `pi=935`가 단0/단1에 걸쳐 분할됨
+  - 19쪽 단1: `pi=946`에서 `문29)` 시작, `pi=951` 그림, `pi=952`, `pi=953`이 페이지 하단을 넘김
+  - 20쪽 단0: `pi=953 lines=1..2`부터 이어짐
+- 따라서 이번 문제의 1차 범위는 일반 본문 조판이 아니라, Task #1139에서 본격 처리된 미주 흐름의 페이지/단 분할과 TAC 그림 주변 높이 산정이다.
+
+## 잠정 판단
+
+19쪽 불일치는 `문29)` 자체만의 문제가 아니라, 18~20쪽에 이어지는 미주 단 흐름에서 누적 높이가 PDF/한컴 기준보다 크게 잡혀 `문29)` 배치가 늦어지는 형태로 보인다. 특히 `pi=935` 분할 이후 19쪽 단1의 `pi=940`, `pi=951` TAC 그림과 주변 문단 높이/여백 산정이 우선 조사 대상이다.
+
+## 다음 분석 항목
+
+1. `pi=935`, `pi=940`, `pi=946`, `pi=951`, `pi=952`, `pi=953`의 문단 측정 높이와 그림 bbox를 분리해 확인한다.
+2. 19쪽 단1에서 `문29)` 시작 y 좌표와 `pi=951` 그림 y 좌표를 PDF 기준과 정량 비교한다.
+3. 미주 흐름에서 TAC 그림 주변 paragraph spacing, line segment vpos, partial paragraph 분할이 일반 본문과 다르게 처리되는지 확인한다.
+4. 원인이 좁혀진 뒤 회귀 테스트를 추가하고, 소스 수정은 작업지시자 승인 후 진행한다.
+
+## 현재 상태
+
+- 2026-05-31: 이슈 #1189를 확인하고 최신 `upstream/devel` 기준 `local/task_m100_1189` 브랜치를 생성했다.
+- 2026-05-31: 19쪽 SVG/PDF 비교 산출물과 18~20쪽 `dump-pages` 산출물을 생성했다.
+- 2026-05-31: 19쪽 문제는 미주 흐름의 누적 높이/단 분할 불일치로 1차 분류했다.

--- a/mydocs/working/task_m100_1189_stage2.md
+++ b/mydocs/working/task_m100_1189_stage2.md
@@ -1,0 +1,54 @@
+# Task M100 #1189 Stage 2
+
+## 목적
+
+Stage1에서 확인한 `3-09월_교육_통합_2023.hwp` 19쪽 미주 흐름 밀림과 후속으로 확인된 `3-11월_실전_통합_2022.hwp` 10~12쪽/17쪽 미주 분배 어긋남을 개선한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 작업 브랜치: `local/task_m100_1189`
+- Stage1 판단: 19쪽 우측 단에서 `문29)` 이하가 PDF보다 아래로 밀리고, `pi=952/953`이 페이지 하단 overflow.
+- 우선 조사 대상: 미주 흐름의 VPOS 되감김, TAC 그림 주변 gap, partial paragraph 분할.
+
+## 구현 가설
+
+1. 미주 흐름은 일반 본문과 달리 같은 단 안에서도 LINE_SEG VPOS가 크게 되감긴다.
+2. 현재 보정은 일부 하단 overflow를 막지만, `문29)` 앞의 TAC 그림/문단 조합에서 누적 높이를 과대 보존하는 구간이 남아 있다.
+3. `pi=935`, `pi=951`, `pi=952`, `pi=953` 주변의 VPOS anchor 선택과 picture-only paragraph 처리 조건을 조정하면 19쪽 단1 하단 overflow를 줄일 수 있다.
+4. `3-11월_실전_통합_2022.hwp` 16쪽 끝의 `pi=786`은 내부 LINE_SEG 되감기 직전 줄이 큰 수식 줄이다. 일반 텍스트 되감기보다 내부 split 신호를 우선해야 17쪽 첫머리 수식 이어짐이 한컴/PDF와 맞는다.
+5. `3-11월_실전_통합_2022.hwp` 12쪽 하단 수식은 렌더 bbox 높이를 식 자체에 Y축 스케일로 적용해 글자가 세로로 찌그러지는 문제가 있다. bbox 높이는 줄 높이와 여백을 포함한 배치 영역으로 보고, 식 SVG/Canvas 렌더에는 X축 스케일만 적용한다.
+
+## 진행 계획
+
+1. `src/renderer/height_cursor.rs`의 compact endnote 보정 조건을 확인한다.
+2. `dump-pages`와 debug SVG로 `pi=935`, `pi=951`, `pi=952`, `pi=953`의 y 흐름을 비교한다.
+3. 최소 범위 수정 후 19쪽 SVG/PDF 비교와 기존 task 1139 회귀 테스트를 확인한다.
+4. 개선 범위가 19쪽에만 국한되지 않는지 18~20쪽 dump와 기존 12/13/23쪽 회귀 케이스를 재확인한다.
+
+## 현재 상태
+
+- 2026-05-31: 작업지시자가 개선 시작을 승인했다.
+- 2026-05-31: `3-09월_교육_통합_2023.hwp` 19쪽 보정 중, 작업지시자가 `3-11월_실전_통합_2022.hwp` 17쪽도 같은 후속 보정 범위로 확인 후 수정하도록 지시했다.
+- 2026-05-31: 작업지시자가 중간 탐색 중 전체 `cargo test` 실행은 중단하고, 전체 테스트는 커밋 직전 검증 단계에서만 수행하도록 지시했다.
+- 2026-05-31: 작업지시자가 수정 직후 검증에는 `tests/issue_1139_inline_picture_duplicate.rs` 단일 통합 테스트를 수행해야 한다고 지시했다.
+- 2026-05-31: `3-11월_실전_통합_2022.hwp` 16/17쪽은 `rsvg-convert` 변환 PNG와 PDF 추출본으로 비교했다. 수정 전 `pi=786 lines=0..2`가 16쪽에 남아 overflow했으나, 수정 후 `16쪽 lines=0..1`, `17쪽 lines=1..5`로 분배되어 PDF 기준 첫 수식 이어짐이 맞아졌다.
+- 2026-05-31: `3-09월_교육_통합_2023.hwp` 19쪽은 `pi=935 lines=0..2 / 2..3`, `pi=953 lines=0..1` 분배를 유지해 Stage2 1차 보정 상태로 회복되는 것을 확인했다.
+- 2026-05-31: 코드 보정은 두 축이다. `height_cursor.rs`는 compact 미주 질문 제목의 큰 forward gap을 하단 영역에서 cap하고, `typeset.rs`는 내부 되감기 앞줄이 큰 수식 줄(`line_height >= 2000`)일 때만 internal rewind split을 fit split보다 우선한다.
+- 2026-05-31: 회귀 테스트에 `issue_1189_2022_nov_page17_internal_rewind_keeps_formula_tail_on_next_page`를 추가하고, 2023 19쪽 테스트에는 `pi=935` 분배 유지 조건을 추가했다.
+- 2026-05-31: 작업지시자가 `3-11월_실전_통합_2022.hwp` 10~12쪽을 모두 확인하고 12쪽 마지막 수식 깨짐을 수정하라고 지시했다.
+- 2026-05-31: 10~12쪽 최신 산출물은 `output/task1189_stage2_3-11_pages10_12/post4/`에 생성했다. PDF 추출은 `pdftoppm`, SVG→PNG 변환은 `rsvg-convert`를 사용했다.
+- 2026-05-31: 12쪽은 `pi=553 lines=8..11` 뒤 `pi=554` 그래프와 `pi=555` 문15가 이어지도록 보정했다. 누락되던 `h(x)=x(x+2)` 시작부가 12쪽 상단에 복구됐다.
+- 2026-05-31: 수식 렌더러는 `svg.rs`, `web_canvas.rs`, `paragraph_layout.rs`에서 수식 배치 높이를 식 자체의 Y축 스케일/베이스라인 스케일에 쓰지 않도록 수정했다. 12쪽 하단 `a_5` 관련 수식은 세로 찌그러짐이 사라졌다.
+- 2026-05-31: 10쪽은 `pi=475` 7.6px overflow 로그가 남고, 11쪽은 `pi=553 lines=0..8`에서 최대 55.7px overflow 로그가 남는다. 12쪽 누락/수식 깨짐은 개선됐지만, 11쪽 하단 overflow는 잔여 보정 후보로 기록한다.
+- 2026-05-31: 작업지시자가 `3-11월_실전_통합_2022.hwp` 14쪽과 17쪽 문28을 추가 확인하라고 지시했다. 최신 비교 산출물은 `output/task1189_stage2_3-11_pages14_17/post2/`에 생성했다. SVG→PNG 변환은 `rsvg-convert`, PDF 추출본은 기존 `pdftoppm` 산출물을 기준으로 비교했다.
+- 2026-05-31: 17쪽 문28은 HWP3식 미주 수식 문단(`줄바꿈/탭 + TAC 수식`)에 HWP5 누락 marker 합성 보정이 적용되어 `g(θ)=□CQRT-△CST`가 뒤쪽 줄로 밀리는 문제였다. `composer.rs`에서 본문 텍스트가 줄바꿈/탭/공백뿐이고 컨트롤이 TAC 개체뿐인 문단은 marker 합성을 건너뛰도록 좁혔다.
+- 2026-05-31: 수정 후 17쪽 문28의 `g(θ)=□CQRT-△CST`가 같은 줄로 돌아왔고, 뒤쪽 긴 수식도 PDF처럼 여러 줄로 내려오는 것을 확인했다. 14쪽은 문22~문27 시작 흐름이 유지되는 것을 확인하고 회귀 테스트 조건에 추가했다.
+- 2026-05-31: `cargo fmt --all --check`와 `git diff --check`는 통과했다.
+- 2026-05-31: 14/17쪽 보정 후 `cargo fmt --all --check`, `git diff --check`, `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed, 0 failed). 출력에 2023 19쪽 잔여 `LAYOUT_OVERFLOW` 로그 2건(`pi=935`, `pi=953`)이 남지만 회귀 테스트 조건은 통과했다. 전체 `cargo test`는 커밋 전 검증으로 남겨 둔다.
+- 2026-05-31: 작업지시자가 12쪽 문19) 변화표 내부 수식이 한컴과 다르다고 추가 지적했다. 원인은 HWP 수식 토큰 `SEARROW`/`NEARROW`가 화살표 기호로 매핑되지 않아 문자열 그대로 좁게 렌더되는 문제였다.
+- 2026-05-31: `src/renderer/equation/symbols.rs`에 HWP 대문자 대각 화살표 토큰(`NWARROW`, `NEARROW`, `SWARROW`, `SEARROW`)을 추가했다. 문19) 회귀 테스트에는 `SEARROW`/`NEARROW` 문자열이 SVG에 남지 않고 `↘`/`↗`가 렌더되는 조건을 추가했다.
+- 2026-05-31: 추가 보정 검증은 `cargo test --lib test_arrows --quiet`와 `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf -- --nocapture` 통과. 최신 12쪽 산출물은 `output/task1189_stage2_3-11_pages10_12/post5/page12/`에 생성했고, SVG→PNG 변환은 `rsvg-convert`를 사용했다.
+- 2026-05-31: 문19) 추가 보정 후 `cargo fmt --all --check`, `git diff --check`, `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed, 0 failed). 브라우저 확인용 `wasm-pack build --target web --out-dir pkg`도 통과했다.
+- 2026-05-31: 작업지시자가 `3-11월_실전_통합_2022.hwp` 11쪽 overflow가 아직 남아 있음을 시각 확인했고, 현 Stage2 변경분은 커밋한 뒤 11쪽 overflow를 새 Stage3에서 처리하라고 지시했다.
+- 2026-05-31: 커밋 전 전체 검증으로 `cargo test --tests` 통과. Stage2는 12쪽/17쪽/19쪽 보정과 11쪽 overflow 잔여 기록을 포함해 커밋 대상으로 확정한다.

--- a/mydocs/working/task_m100_1189_stage3.md
+++ b/mydocs/working/task_m100_1189_stage3.md
@@ -1,0 +1,45 @@
+# Task M100 #1189 Stage 3
+
+## 목적
+
+Stage2 커밋 이후 남은 `3-11월_실전_통합_2022.hwp` 11쪽 overflow를 한컴 기준으로 재분석하고 보정한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 작업 브랜치: `local/task_m100_1189`
+- 선행 커밋: `6cb2fd55` (`task 1189: 미주 수식 흐름 후속 보정`)
+- 대상 문서: `samples/3-11월_실전_통합_2022.hwp`
+- 대상 페이지: 11쪽
+- 사용자 시각 판정: 11쪽 하단에서 미주 문단/수식이 한컴보다 아래로 overflow 된다.
+
+## 초기 판단
+
+1. Stage2에서는 12쪽 시작 누락, 12쪽 문19) 변화표 화살표, 17쪽 문28 수식 줄 밀림을 보정했다.
+2. Stage2 검증 로그에도 `pi=553 lines=0..8` 주변 11쪽 overflow가 남아 있었고, 작업지시자가 실제 화면으로 이를 확인했다.
+3. Stage3 재분석 결과 실제 overflow 지점은 오른쪽 단 `문14)` 꼬리 흐름(`pi=553`)이며, 새 미주 제목(`문13`/`문14`)이 직전 큰 수식 줄의 trailing 간격 뒤로 과도하게 밀린 것이었다.
+4. Stage3에서는 11쪽 하단 `문14)` 흐름을 PDF/한컴 기준과 다시 비교하고, Stage2에서 도입한 internal rewind split/수식 높이 보정과 충돌하지 않는 좁은 조건을 찾는다.
+
+## 진행 계획
+
+1. 11쪽 PDF 기준 이미지와 현재 rhwp SVG/PNG를 같은 배율로 다시 생성한다.
+2. `dump-pages -p 10` 기준 `pi=553` 분할 범위와 하단 overflow 지점을 확인한다.
+3. 10~12쪽 전체 흐름이 유지되는 최소 보정 조건을 찾는다.
+4. 수정 후 `tests/issue_1139_inline_picture_duplicate.rs` 단일 테스트와 10~12쪽 시각 산출물을 재검증한다.
+
+## 현재 상태
+
+- 2026-05-31: 작업지시자가 Stage2 커밋 후 11쪽 overflow를 새 스테이지에서 처리하라고 지시했다.
+- 2026-05-31: `output/task1189_stage3_3-11_page11/current/`에 11쪽 비교 산출물을 생성했다. 수정 전 로그는 `pi=553` line 5~7에서 최대 55.7px 하단 overflow.
+- 2026-05-31: PDF bbox 기준 현재 `문13`/`문14` 제목 baseline이 한컴보다 약 57px 낮음을 확인했다. lazy-base compact 미주 흐름에서 큰 display 수식 줄 뒤 새 문제 제목만 직전 내용 하단 + 10px로 붙도록 보정했다. page-base 흐름은 기존 7mm 미주 간격을 유지하도록 제외했다.
+- 2026-05-31: `output/task1189_stage3_3-11_page11/fixed/`에 수정 후 11쪽 SVG/PNG/dump를 생성했다. `export-svg` 로그에서 `LAYOUT_OVERFLOW_DRAW`가 사라졌고, `문13` baseline 412.77px / `문14` baseline 628.56px로 PDF 환산 좌표와 정합.
+- 2026-06-01: 작업지시자가 Stage3 결과를 승인했다. 커밋 전 전체 테스트를 진행한다.
+
+## 검증 기록
+
+- `cargo test --test issue_1139_inline_picture_duplicate issue_1139_page12_question15_keeps_hancom_endnote_gap -- --nocapture` 통과.
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(31 passed).
+- `cargo test --lib compact_endnote_question_title_after_tall_line_uses_content_bottom_gap` 통과.
+- `wasm-pack build --target web --out-dir pkg` 통과.
+- `cargo test --tests` 통과.
+- `rsvg-convert` 기준 수정 후 11쪽 PNG: `output/task1189_stage3_3-11_page11/fixed/page11/rhwp_page11.png`.

--- a/mydocs/working/task_m100_1189_stage4.md
+++ b/mydocs/working/task_m100_1189_stage4.md
@@ -1,0 +1,45 @@
+# Task M100 #1189 Stage 4
+
+## 목적
+
+Stage3 커밋 이후 `3-10월_교육_통합_2022.hwp` 17쪽 미주 영역에서 한컴오피스 기준 드래그 선택이 되지 않는 문제를 보정한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 작업 브랜치: `local/task_m100_1189`
+- 선행 커밋: `decee292` (`task 1189: 11쪽 미주 제목 간격 보정`)
+- 대상 문서: `samples/3-10월_교육_통합_2022.hwp`
+- 대상 페이지: 17쪽
+- 사용자 시각 판정: 한컴오피스에서는 17쪽 하단 미주 `문27)` 부근을 드래그 선택할 수 있으나 rhwp 기준 드래그 선택 동작이 맞지 않는다.
+- 작업지시자 승인: 자동 승인. Stage4 문서 생성 후 분석/수정/검증/커밋까지 진행한다.
+
+## 초기 판단
+
+1. 화면상 대상은 본문이 아니라 페이지 하단 미주 흐름이다.
+2. 드래그 선택은 `rhwp-studio`의 mouse hit-test와 Rust `get_selection_rects*` 계열 API가 함께 관여한다.
+3. Stage31 이후 미주 편집/선택용 가상 문단 인덱스가 도입되었으므로, 17쪽의 미주 가상 문단 좌표가 hit-test 또는 selection rect 계산에서 누락되는지 먼저 확인한다.
+
+## 진행 계획
+
+1. `3-10월_교육_통합_2022.hwp` 17쪽의 미주 문단 배치와 가상 문단 인덱스를 덤프한다.
+2. 대상 좌표에서 `hitTest`, `hitTestInFootnote`, `getSelectionRects`, `getSelectionRectsInFootnote` 계열 동작을 재현한다.
+3. 한컴처럼 같은 페이지 미주 문단을 드래그 선택할 수 있도록 가장 좁은 경로를 수정한다.
+4. 전용 회귀 테스트와 `issue_1139_inline_picture_duplicate` 단일 테스트를 수행하고, 자동 승인에 따라 커밋한다.
+
+## 현재 상태
+
+- 2026-06-01: 작업지시자가 한컴오피스 기준 드래그 선택 불일치를 보고하고 Stage4 자동 승인을 지시했다.
+- 2026-06-01: `dump-pages` 기준 대상은 `3-10월_교육_통합_2022.hwp` 17쪽 좌측 단 미주 `문27)` 흐름(`pi=915..921`)으로 확인했다.
+- 2026-06-01: `get_selection_rects(0, 915, 0, 921, 3)` 진단 결과 수정 전에는 `pi=915`, `pi=916`, `pi=921` 3줄만 selection rect가 생성되고, 수식 컨트롤이 줄 끝에 섞인 `pi=917..920` 4줄이 빠졌다.
+- 2026-06-01: 원인은 선택 끝 커서를 TextRun 기준으로만 찾는 경로였다. 수식 꼬리 때문에 `range_end`와 `range_end - 1`이 TextRun에 걸리지 않으면 해당 줄 전체 rect 생성이 생략됐다.
+- 2026-06-01: 본문/미주 가상 문단 선택에서 trailing TextRun 커서를 못 찾는 경우 같은 `TextLine`의 오른쪽 끝을 fallback cursor로 사용하도록 보정했다. 셀 내부 선택 경로는 기존 동작을 유지했다.
+
+## 검증 기록
+
+- `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_oct_page17_endnote_drag_selection_covers_equation_tail_lines -- --nocapture` 통과.
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(32 passed).
+- `cargo fmt --all --check` 통과.
+- `git diff --check` 통과.
+- `wasm-pack build --target web --out-dir pkg` 통과.
+- `cargo test --tests` 통과.

--- a/mydocs/working/task_m100_1189_stage5.md
+++ b/mydocs/working/task_m100_1189_stage5.md
@@ -1,0 +1,48 @@
+# Task M100 #1189 Stage 5
+
+## 목적
+
+Stage4 커밋 이후 `3-11월_실전_통합_2022.hwp` 10쪽 하단 미주 영역에서 문단이 겹쳐 보이는 문제를 한컴오피스 기준으로 재분석하고 보정한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 작업 브랜치: `local/task_m100_1189`
+- 선행 커밋: `71c02d4e` (`task 1189: 17쪽 미주 드래그 선택 보정`)
+- 대상 문서: `samples/3-11월_실전_통합_2022.hwp`
+- 대상 페이지: 10쪽
+- 사용자 시각 판정: 10쪽 하단 왼쪽 단 `문6)` 부근에서 텍스트가 겹치거나 페이지 하단에 눌려 보인다.
+
+## 초기 판단
+
+1. `dump-pages -p 9` 기준 10쪽 왼쪽 단 끝은 `pi=475`이고, Stage2 잔여 기록의 10쪽 `pi=475` overflow와 같은 지점으로 보인다.
+2. 같은 문서 11쪽/12쪽은 Stage2/Stage3에서 수식 줄 되감기와 미주 제목 간격을 보정했으므로, 이번 수정은 10쪽 하단 왼쪽 단의 남은 overflow만 좁게 다룬다.
+3. 10쪽 미주 흐름은 page-base 미주 흐름의 첫 페이지에 가까워, lazy-base compact 미주 제목 보정과 충돌하지 않도록 확인한다.
+4. 재확인 결과 `pi=475`는 빈 줄이 아니라 `text="" + controls=1`인 수식 전용 미주 문단이었다. 숨김 처리가 아니라 직전 새 문제 제목(`문6)`)의 하단 간격을 줄여 꼬리 수식이 본문 하단 안에 들어오게 해야 한다.
+
+## 진행 계획
+
+1. 10쪽/11쪽 `dump-pages`와 SVG 내보내기 로그로 실제 overflow 문단과 줄 범위를 확정한다.
+2. `pi=475` 주변 LINE_SEG/수식/문단 높이를 확인해 겹침 원인이 줄 내부 높이 부족인지, 다음 단 시작 위치 계산 문제인지 분리한다.
+3. 가장 좁은 조건으로 레이아웃 보정을 적용하고, 10~12쪽 기존 회귀 테스트가 유지되는지 확인한다.
+4. 수정 후 `tests/issue_1139_inline_picture_duplicate.rs` 단일 테스트와 필요한 단일 케이스를 재검증한다.
+
+## 현재 상태
+
+- 2026-06-01: 작업지시자가 10쪽 하단 미주 오버랩을 보고했다. Stage5 문서를 만들고 분석을 시작한다.
+- 2026-06-01: `dump-pages -p 9`와 `export-svg -p 9` 로그 기준 오버랩 지점은 왼쪽 단 마지막 `pi=475` 한 줄이다. 현재 `LAYOUT_OVERFLOW_DRAW: section=0 pi=475 line=0 ... overflow=7.6px`가 발생한다.
+- 2026-06-01: `RHWP_VPOS_DEBUG=1` 기준 `pi=470..475`는 lazy base 역산이 음수가 되어 VPOS 보정이 건너뛰어지고 있다. 그 결과 paginator의 fit 판정은 통과하지만 실제 렌더 line box는 body 하단을 넘는다.
+- 2026-06-01: 보정 방향은 `pi=475`를 왼쪽 단 하단에 억지로 남기는 것이 아니라, compact 미주 다단 흐름에서 하단 safety margin을 적용해 다음 단 시작으로 넘기는 쪽으로 판단했다.
+- 2026-06-01: `pi=475`를 다음 단으로 넘기면 오른쪽 단 시작 흐름이 달라질 수 있어, 실제 구현은 `HeightCursor`의 compact 미주 하단 새 문제 제목 간격 보정으로 좁혔다. lazy base 역산이 음수인 경우에도 하단 85% 이후의 새 문제 제목은 직전 내용 하단 + 10px로 제한한다.
+- 2026-06-01: 수정 후 `export-svg -p 9` 로그에서 `LAYOUT_OVERFLOW_DRAW`가 사라졌다. `rsvg-convert` 산출물은 `output/task1189_stage5_3-11_page10/fixed/rhwp_page10.png`.
+
+## 검증 기록
+
+- `cargo run --quiet --bin rhwp -- export-svg samples/3-11월_실전_통합_2022.hwp -p 9 -o output/task1189_stage5_3-11_page10/fixed --show-control-codes --debug-overlay` 통과. `LAYOUT_OVERFLOW_DRAW` 없음.
+- `rsvg-convert output/task1189_stage5_3-11_page10/fixed/3-11월_실전_통합_2022_010.svg -o output/task1189_stage5_3-11_page10/fixed/rhwp_page10.png` 통과.
+- `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf -- --nocapture` 통과.
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과(32 passed).
+- `cargo fmt --all --check` 통과.
+- `git diff --check` 통과.
+- `cargo test --tests` 통과.
+- `wasm-pack build --target web --out-dir pkg` 통과.

--- a/mydocs/working/task_m100_1189_stage6.md
+++ b/mydocs/working/task_m100_1189_stage6.md
@@ -1,0 +1,54 @@
+# Task M100 #1189 Stage 6
+
+## 목적
+
+Stage5 커밋 이후 `3-11월_실전_통합_2022.hwp` 1쪽 `문1)`과 첫 수식 사이의 가로 간격이 한컴오피스 기준과 다르게 보이는 문제를 PDF/한컴 기준 산출물과 비교해 보정한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- 작업 브랜치: `local/task_m100_1189`
+- 선행 커밋: `6f192f01` (`task 1189: 10쪽 미주 하단 오버랩 보정`)
+- 대상 문서: `samples/3-11월_실전_통합_2022.hwp`
+- 대상 페이지: 1쪽
+- 사용자 시각 판정: `문1)` 뒤 첫 수식이 한컴오피스 표시보다 오른쪽으로 멀거나 시작 간격이 다르다.
+
+## 초기 판단
+
+1. 문제는 미주 본문 흐름이 아니라 일반 본문 1쪽 첫 문항의 인라인 수식 배치이다.
+2. `문1)` 텍스트 뒤 inline equation TAC의 x 위치, control 앞 공백 처리, 수식 bbox 원점 보정 중 하나가 원인일 가능성이 높다.
+3. 같은 문서 10~17쪽 미주 후속 보정과 섞이지 않도록 1쪽 `문1)` 인라인 수식만 좁게 확인한다.
+
+## 진행 계획
+
+1. PDF 1쪽과 현재 SVG 1쪽을 각각 PNG로 변환해 `문1)` 수식 위치를 비교한다.
+2. `dump`/`dump-pages`로 `문1)` 문단의 텍스트, 컨트롤, char offset, line segment, equation bbox를 확인한다.
+3. 원인이 수식 전체 배치인지 수식 내부 좌측 여백인지 분리한다.
+4. 좁은 보정과 회귀 테스트를 추가하고, `issue_1139_inline_picture_duplicate` 대상 테스트로 확인한다.
+
+## 현재 상태
+
+- 2026-06-01: 작업지시자가 1쪽 `문1)`과 수식 사이 간격 불일치를 보고했다. Stage6 문서를 만들고 PDF/한컴 기준 비교를 시작한다.
+- 2026-06-01: PDF 1쪽과 현재 SVG/PNG를 비교했다. `문1)` 문단의 본문 텍스트 앞에 HWP5 인라인 컨트롤 placeholder `U+FFFC`가 2개 포함되어 있었고, SVG 출력에서는 이 문자가 보이지 않지만 텍스트 폭 측정에는 포함되어 첫 수식 x 좌표가 `95.0px`대로 밀렸다.
+- 2026-06-01: `U+FFFC`를 텍스트 측정 경로에서 0폭으로 처리하도록 보정했다. 수정 후 `문1)` 첫 수식 x 좌표는 `71.0px`대로 이동해 PDF/한컴 기준의 문항 번호 뒤 간격에 맞아졌다.
+
+## 검증 기록
+
+- PDF 기준 PNG:
+  - `output/task1189_stage6_3-11_page1/pdf/pdf_page-01.png`
+- 수정 후 rhwp PNG:
+  - `output/task1189_stage6_3-11_page1/fixed/rhwp_page1.png`
+- 수정 전 debug:
+  - `TAC_LINE pi=0 ... run_tacs=[(4, 61.013333333333335, 4)]`
+  - paragraph base x를 포함한 첫 수식 bbox x가 약 `95.0px`.
+- 수정 후 검증:
+  - `cargo fmt --all --check` 통과.
+  - `cargo test test_inline_object_placeholder_has_zero_advance -- --nocapture` 통과.
+  - `cargo test --test issue_1139_inline_picture_duplicate issue_1189_2022_nov_page1_question1_marker_gap_matches_pdf -- --nocapture` 통과.
+  - `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 통과 (`33 passed`).
+  - 커밋 전 `cargo test --tests` 통과.
+  - 커밋 전 `wasm-pack build --target web --out-dir pkg` 통과.
+
+## 커밋 전 남은 검증
+
+- 작업지시자 시각 확인 완료 후 커밋 진행.

--- a/mydocs/working/task_m100_1189_stage7.md
+++ b/mydocs/working/task_m100_1189_stage7.md
@@ -1,0 +1,50 @@
+# Task M100 #1189 Stage 7
+
+## 목적
+
+PR #1194 생성 이후 `3-10월_교육_통합_2022.hwp` 11쪽에서 미주 간격이 한컴오피스/PDF 기준과 다르게 보이는 문제를 다시 확인하고 보정한다.
+
+## 시작 기준
+
+- 이슈: [#1189](https://github.com/edwardkim/rhwp/issues/1189)
+- PR: [#1194](https://github.com/edwardkim/rhwp/pull/1194)
+- 작업 브랜치: `local/task_m100_1189`
+- 선행 커밋: `334addcd` (`task 1189: 1쪽 인라인 수식 간격 보정`)
+- 대상 문서: `samples/3-10월_교육_통합_2022.hwp`
+- 대상 PDF: `pdf/3-10월_교육_통합_2022.pdf`
+- 대상 페이지: 11쪽
+- 사용자 시각 판정: 페이지 하단 미주 문항 간격이 이상하게 보인다.
+
+## 초기 판단
+
+1. `3-10월_교육_통합_2022.hwp` 11쪽의 미주 영역에서 `문15)` 이후와 오른쪽 단 `문16)`~`문19)` 사이의 문항 간격 또는 줄 간격이 PDF/한컴 기준과 어긋난 것으로 보인다.
+2. Stage5/6의 compact 미주 하단 fit 및 HWP5 placeholder 폭 보정이 다른 미주 페이지에 영향을 주었는지 확인한다.
+3. PDF 11쪽과 현재 SVG/PNG 11쪽을 같은 기준으로 뽑아 문항 제목 y 좌표와 미주 본문 줄 간격을 비교한다.
+
+## 진행 계획
+
+1. PDF 11쪽 PNG와 현재 SVG 11쪽 PNG를 생성한다. SVG 변환은 `rsvg-convert`를 사용한다.
+2. `dump-pages`/debug 로그로 11쪽에 배치된 미주 문단 index, y 좌표, overflow 여부를 확인한다.
+3. 한컴/PDF 기준과 다른 간격 원인을 좁혀 최소 보정을 적용한다.
+4. `tests/issue_1139_inline_picture_duplicate.rs`에 회귀 테스트를 추가하거나 기존 테스트를 강화한다.
+5. PR #1194 브랜치에 추가 커밋으로 보정한다.
+
+## 현재 상태
+
+- 2026-06-01: 작업지시자가 `3-10월_교육_통합_2022.hwp` 11쪽 미주 간격 이상을 보고했다. Stage7 문서를 생성하고 PDF 비교를 시작한다.
+- 2026-06-01: PDF 11쪽과 현재 SVG/PNG를 비교했다. `문18)` 위치는 거의 맞지만, `문19)` 이후가 약 40px 아래로 밀려 `문18)`~`문19)` 사이 미주 간격이 과대해졌다.
+- 2026-06-01: 원인은 compact 미주 새 문항 제목 보정에서, 직전 문단이 빈 문단이어도 중간 단 기본 완충분 40px을 추가하는 흐름이었다. 빈 문단은 이미 시각 spacer 역할을 하므로 추가 완충을 생략하도록 보정했다.
+- 2026-06-01: `tests/issue_1139_inline_picture_duplicate.rs`에 `3-10월_교육_통합_2022.hwp` 11쪽 `문18)`→`문19)`→`문20)` 간격 회귀 테스트를 추가했다.
+
+## 검증 기록
+
+- PDF 기준 산출물:
+  - `output/task1189_stage7_3-10_page11/pdf96/pdf_page-11.png`
+- 보정 후 SVG/PNG:
+  - `output/task1189_stage7_3-10_page11/fixed/3-10월_교육_통합_2022_011.svg`
+  - `output/task1189_stage7_3-10_page11/fixed/rhwp_page11.png`
+- `RHWP_VPOS_DEBUG=1 cargo run --quiet --bin rhwp -- export-svg samples/3-10월_교육_통합_2022.hwp -p 10 -o output/task1189_stage7_3-10_page11/fixed_debug 2>&1 | rg "VPOS_CORR: path=.*pi=5(69|70|71|72|73|74|82)|LAYOUT_OVERFLOW"`: `문19)` 보정 후 해당 페이지 overflow 없음.
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture`: 통과, 34개 테스트 성공.
+- `cargo fmt --all --check`: 통과.
+- `cargo test --tests`: 통과.
+- `wasm-pack build --target web --out-dir pkg`: 통과.

--- a/src/document_core/queries/cursor_nav.rs
+++ b/src/document_core/queries/cursor_nav.rs
@@ -1441,6 +1441,41 @@ impl DocumentCore {
             best.map(|(_, hit)| hit)
         }
 
+        fn find_body_line_end_cursor(
+            node: &RenderNode,
+            sec: usize,
+            para: usize,
+            line_idx: usize,
+            page: u32,
+        ) -> Option<CursorHit> {
+            fn visit(
+                node: &RenderNode,
+                sec: usize,
+                para: usize,
+                line_idx: usize,
+                page: u32,
+            ) -> Option<CursorHit> {
+                if let RenderNodeType::TextLine(ref line) = node.node_type {
+                    if line.section_index == Some(sec)
+                        && line.para_index == Some(para)
+                        && line.line_index.map(|idx| idx as usize) == Some(line_idx)
+                    {
+                        return Some(CursorHit {
+                            page,
+                            x: node.bbox.x + node.bbox.width,
+                            y: node.bbox.y,
+                            h: node.bbox.height,
+                        });
+                    }
+                }
+                node.children
+                    .iter()
+                    .find_map(|child| visit(child, sec, para, line_idx, page))
+            }
+
+            visit(node, sec, para, line_idx, page)
+        }
+
         // ── 페이지별 렌더 트리 캐시 (최대 2페이지) ──
         let mut tree_cache: Vec<(u32, crate::renderer::render_tree::PageRenderTree)> = Vec::new();
 
@@ -1572,10 +1607,25 @@ impl DocumentCore {
 
                 let left_hit = find_cursor!(para_idx, range_start, CursorBias::Leading);
                 // range_end가 줄바꿈 등 비렌더링 문자 위치이면 한 칸 앞으로 재시도
-                let right_hit =
-                    find_cursor!(para_idx, range_end, CursorBias::Trailing).or_else(|| {
+                let right_hit = find_cursor!(para_idx, range_end, CursorBias::Trailing)
+                    .or_else(|| {
                         if range_end > range_start {
                             find_cursor!(para_idx, range_end - 1, CursorBias::Trailing)
+                        } else {
+                            None
+                        }
+                    })
+                    .or_else(|| {
+                        if cell_ctx.is_none() {
+                            tree_cache.iter().find_map(|(pn, tree)| {
+                                find_body_line_end_cursor(
+                                    &tree.root,
+                                    section_idx,
+                                    para_idx,
+                                    line_idx,
+                                    *pn,
+                                )
+                            })
                         } else {
                             None
                         }

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -138,6 +138,28 @@ fn synthesize_marker_paragraph(para: &Paragraph) -> Option<Paragraph> {
         return None;
     }
 
+    // HWP3 정답지의 미주 수식 문단은 본문 텍스트 없이 줄바꿈/탭과
+    // TAC 수식만으로 LINE_SEG를 구성한다. 이 경우 char_offsets와 line_seg
+    // text_start가 이미 컨트롤 줄 위치를 표현하므로 HWP5 누락 마커 보정을 적용하면
+    // 수식이 뒤 줄로 밀린다.
+    let text_has_only_layout_space = para
+        .text
+        .chars()
+        .all(|ch| matches!(ch, '\n' | '\r' | '\t' | ' ' | '\u{2007}'));
+    let controls_are_tac_objects = para.controls.iter().all(|ctrl| {
+        matches!(
+            ctrl,
+            Control::Equation(_)
+                | Control::Picture(_)
+                | Control::Shape(_)
+                | Control::Table(_)
+                | Control::Form(_)
+        )
+    });
+    if text_has_only_layout_space && controls_are_tac_objects {
+        return None;
+    }
+
     let existing_markers = para.text.chars().filter(|c| *c == '\u{FFFC}').count();
     if existing_markers >= inline_ctrl_count {
         // HWP3 path — 이미 마커 충분

--- a/src/renderer/equation/symbols.rs
+++ b/src/renderer/equation/symbols.rs
@@ -350,6 +350,11 @@ static ARROWS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(|| 
         ("nearrow", "↗"),
         ("swarrow", "↙"),
         ("searrow", "↘"),
+        // HWP 변화표 수식은 대문자 대각 화살표 토큰을 사용한다.
+        ("NWARROW", "↖"),
+        ("NEARROW", "↗"),
+        ("SWARROW", "↙"),
+        ("SEARROW", "↘"),
         // 특수
         ("mapsto", "↦"),
         ("hookleft", "↩"),
@@ -690,6 +695,8 @@ mod tests {
     fn test_arrows() {
         assert_eq!(lookup_symbol("rarrow"), Some("→"));
         assert_eq!(lookup_symbol("RARROW"), Some("⇒"));
+        assert_eq!(lookup_symbol("NEARROW"), Some("↗"));
+        assert_eq!(lookup_symbol("SEARROW"), Some("↘"));
     }
 
     #[test]

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -186,6 +186,25 @@ impl HeightCursor {
                         item_para, prev_pi, y_offset, prev_vpos_end, lazy_base_corrected, lazy_base,
                     );
                 }
+                let compact_endnote_question_title = self.suppress_large_forward_jump
+                    && paragraphs
+                        .get(item_para)
+                        .map(|p| p.text.trim_start().starts_with('문'))
+                        .unwrap_or(false)
+                    && seg.line_spacing > 1000;
+                if compact_endnote_question_title
+                    && y_offset > self.col_area_y + self.col_area_height * 0.85
+                {
+                    let prev_line_spacing_px = (seg.line_spacing.max(0) as f64) / 7200.0 * self.dpi;
+                    let prev_content_bottom_y = y_offset - prev_line_spacing_px;
+                    let capped_y = prev_content_bottom_y + 10.0;
+                    if capped_y < y_offset
+                        && y_offset - capped_y <= 24.0
+                        && capped_y >= self.col_area_y
+                    {
+                        return capped_y;
+                    }
+                }
                 return y_offset;
             } else {
                 self.vpos_lazy_base = Some(lazy_base);

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -288,7 +288,11 @@ impl HeightCursor {
                     // of after that full trailing gap (3-11월_실전_통합_2022 p11 문13/문14).
                     // Page-base flows already carry the correct 7mm note gap and must keep it.
                     prev_content_bottom_y + 10.0
-                } else if y_offset > self.col_area_y + self.col_area_height * 0.75 {
+                } else if y_offset > self.col_area_y + self.col_area_height * 0.75
+                    || prev_para.text.trim().is_empty()
+                {
+                    // Empty paragraphs before the next compact endnote title already carry the
+                    // visual spacer. Adding the mid-column buffer again pushes later notes down.
                     y_offset + prev_line_spacing_px
                 } else {
                     y_offset + prev_line_spacing_px + 40.0
@@ -650,10 +654,31 @@ mod tests {
             para(0, 100000, 900, 1984, 5000),
             para(0, 108025, 900, 452, 5000),
         ];
+        ps[0].text = "따라서".to_string();
         ps[1].text = "문29)".to_string();
 
         let got = c.vpos_adjust(650.0, 1, &ps, &styles(0.0));
         let expected = 650.0 + 1984.0 / 75.0 + 40.0;
+
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "got={got}, expected={expected}"
+        );
+    }
+
+    /// 빈 문단이 새 미주 제목 앞의 시각 간격을 이미 만들었다면 추가 40px 완충은 넣지 않는다.
+    #[test]
+    fn compact_endnote_question_title_after_empty_spacer_keeps_stored_gap_only() {
+        let mut c = compact_endnote_cursor(None);
+        c.prev_layout_para = Some(0);
+        let mut ps = vec![
+            para(0, 100000, 900, 1984, 5000),
+            para(0, 108025, 900, 452, 5000),
+        ];
+        ps[1].text = "문19)".to_string();
+
+        let got = c.vpos_adjust(650.0, 1, &ps, &styles(0.0));
+        let expected = 650.0 + 1984.0 / 75.0;
 
         assert!(
             (got - expected).abs() < 1e-6,

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -248,6 +248,8 @@ impl HeightCursor {
             self.dpi,
         );
         let prev_line_spacing_px = (seg.line_spacing.max(0) as f64) / 7200.0 * self.dpi;
+        let prev_content_bottom_y = y_offset - prev_line_spacing_px;
+        let follows_tall_inline_item = self.suppress_large_forward_jump && seg.line_height > 1500;
         let compact_endnote_question_title = self.suppress_large_forward_jump
             && paragraphs
                 .get(item_para)
@@ -259,12 +261,20 @@ impl HeightCursor {
             && (y_offset > self.col_area_y + self.col_area_height * 0.75
                 || compact_endnote_question_title)
         {
-            let preserved_gap_px = if y_offset > self.col_area_y + self.col_area_height * 0.75 {
-                prev_line_spacing_px
-            } else {
-                prev_line_spacing_px + 40.0
-            };
-            Some((y_offset + preserved_gap_px).min(end_y))
+            let preserved_gap_y =
+                if compact_endnote_question_title && follows_tall_inline_item && !is_page_path {
+                    // Display-style equation lines in compact endnotes already include a large
+                    // trailing line_spacing in some lazy-base flows. Hancom places the next
+                    // red question title shortly after the visible equation bottom instead
+                    // of after that full trailing gap (3-11월_실전_통합_2022 p11 문13/문14).
+                    // Page-base flows already carry the correct 7mm note gap and must keep it.
+                    prev_content_bottom_y + 10.0
+                } else if y_offset > self.col_area_y + self.col_area_height * 0.75 {
+                    y_offset + prev_line_spacing_px
+                } else {
+                    y_offset + prev_line_spacing_px + 40.0
+                };
+            Some(preserved_gap_y.min(end_y))
         } else {
             None
         };
@@ -290,8 +300,6 @@ impl HeightCursor {
                 .get(prev_pi)
                 .map(|p| p.text.trim_start().starts_with('문'))
                 .unwrap_or(false);
-        let follows_tall_inline_item = self.suppress_large_forward_jump && seg.line_height > 1500;
-        let prev_content_bottom_y = y_offset - prev_line_spacing_px;
         let compact_endnote_deep_backtrack = self.suppress_large_forward_jump
             && !is_page_path
             && !vpos_rewind
@@ -627,6 +635,28 @@ mod tests {
 
         let got = c.vpos_adjust(650.0, 1, &ps, &styles(0.0));
         let expected = 650.0 + 1984.0 / 75.0 + 40.0;
+
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "got={got}, expected={expected}"
+        );
+    }
+
+    /// 큰 디스플레이 수식 줄 뒤 새 문제 제목은 trailing 줄간격 전체 뒤가 아니라
+    /// 보이는 수식 바닥 직후로 붙는다.
+    #[test]
+    fn compact_endnote_question_title_after_tall_line_uses_content_bottom_gap() {
+        let mut c = compact_endnote_cursor(None);
+        c.prev_layout_para = Some(0);
+        let mut ps = vec![
+            para(0, 100000, 2690, 1984, 5000),
+            para(0, 109174, 900, 452, 5000),
+        ];
+        ps[0].text = "따라서".to_string();
+        ps[1].text = "문13)".to_string();
+
+        let got = c.vpos_adjust(500.0, 1, &ps, &styles(0.0));
+        let expected = 500.0 - 1984.0 / 75.0 + 10.0;
 
         assert!(
             (got - expected).abs() < 1e-6,

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -248,23 +248,31 @@ impl HeightCursor {
             self.dpi,
         );
         let prev_line_spacing_px = (seg.line_spacing.max(0) as f64) / 7200.0 * self.dpi;
-        let bottom_new_note_gap_cap = if self.suppress_large_forward_jump
-            && y_offset > self.col_area_y + self.col_area_height * 0.75
-            && end_y <= self.col_area_y + self.col_area_height
-        {
-            Some((y_offset + prev_line_spacing_px).min(end_y))
-        } else {
-            None
-        };
-        let compact_endnote_new_note_jump = self.suppress_large_forward_jump
+        let compact_endnote_question_title = self.suppress_large_forward_jump
             && paragraphs
                 .get(item_para)
                 .map(|p| p.text.trim_start().starts_with('문'))
                 .unwrap_or(false)
-            && seg.line_height > 1500
-            && seg.line_spacing > 1000
+            && seg.line_spacing > 1000;
+        let bottom_new_note_gap_cap = if self.suppress_large_forward_jump
+            && end_y <= self.col_area_y + self.col_area_height
+            && (y_offset > self.col_area_y + self.col_area_height * 0.75
+                || compact_endnote_question_title)
+        {
+            let preserved_gap_px = if y_offset > self.col_area_y + self.col_area_height * 0.75 {
+                prev_line_spacing_px
+            } else {
+                prev_line_spacing_px + 40.0
+            };
+            Some((y_offset + preserved_gap_px).min(end_y))
+        } else {
+            None
+        };
+        let compact_endnote_new_note_jump = self.suppress_large_forward_jump
+            && compact_endnote_question_title
+            && (seg.line_height > 1500 || bottom_new_note_gap_cap.is_some())
             && end_y > y_offset + 32.0
-            && end_y < y_offset + 80.0;
+            && end_y < y_offset + 120.0;
         let compact_endnote_tac_picture_gap = self.suppress_large_forward_jump
             && !is_page_path
             && end_y > y_offset
@@ -602,6 +610,28 @@ mod tests {
 
         let got = c.vpos_adjust(980.0, 1, &ps, &styles(0.0));
         assert!(got < 980.0, "got={got}");
+    }
+
+    /// 기본 미주 사이 간격을 가진 새 문제 제목이 단 중간에서 과도하게 전진하면
+    /// 뒤쪽 TAC 그림/문단이 단 하단을 넘는다. 제목 자체는 유지하되 저장된 간격에
+    /// 완충분만 더해 forward jump를 제한한다.
+    #[test]
+    fn compact_endnote_question_title_caps_large_forward_gap() {
+        let mut c = compact_endnote_cursor(None);
+        c.prev_layout_para = Some(0);
+        let mut ps = vec![
+            para(0, 100000, 900, 1984, 5000),
+            para(0, 108025, 900, 452, 5000),
+        ];
+        ps[1].text = "문29)".to_string();
+
+        let got = c.vpos_adjust(650.0, 1, &ps, &styles(0.0));
+        let expected = 650.0 + 1984.0 / 75.0 + 40.0;
+
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "got={got}, expected={expected}"
+        );
     }
 
     /// 새 미주 제목 바로 다음 문단도 제목 위로 되감기면 미주 사이 간격과 제목이 깨진다.

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -3034,12 +3034,7 @@ impl LayoutEngine {
                                 };
                                 // 수식 baseline을 텍스트 baseline에 맞춤
                                 // HWP 높이와 레이아웃 높이가 다르면 baseline도 비례 조정
-                                let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
-                                    let scale = hwp_eq_h / layout_box.height;
-                                    (y + baseline - layout_box.baseline * scale).max(y)
-                                } else {
-                                    (y + baseline - layout_box.baseline).max(y)
-                                };
+                                let eq_y = (y + baseline - layout_box.baseline).max(y);
                                 let (eq_cell_idx, eq_cell_para_idx) =
                                     if let Some(ref ctx) = cell_ctx {
                                         (
@@ -3618,12 +3613,7 @@ impl LayoutEngine {
                             } else {
                                 layout_box.height
                             };
-                            let eq_y = if hwp_eq_h > 0.0 && layout_box.height > 0.0 {
-                                let scale = hwp_eq_h / layout_box.height;
-                                (y + baseline - layout_box.baseline * scale).max(y)
-                            } else {
-                                (y + baseline - layout_box.baseline).max(y)
-                            };
+                            let eq_y = (y + baseline - layout_box.baseline).max(y);
                             let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                 (
                                     Some(ctx.path[0].cell_index),

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -303,6 +303,10 @@ impl TextMeasurer for EmbeddedTextMeasurer {
             if c == '\u{2007}' {
                 return font_size * 0.5 * ratio + style.letter_spacing + style.extra_char_spacing;
             }
+            // 인라인 객체 placeholder 는 실제 control node 가 따로 그리므로 텍스트 폭은 0.
+            if c == '\u{FFFC}' {
+                return 0.0;
+            }
             // [Issue #677] HWP PUA 채움 문자 (U+F081C) — 시각 폭 0
             // 한컴이 인라인 TAC 표/도형 앞에 삽입하는 placeholder 채움 문자.
             // 한컴 PDF 정합 — 폭 0 으로 라인 inline x 에 영향 없음. fillers 가
@@ -515,6 +519,10 @@ impl TextMeasurer for EmbeddedTextMeasurer {
             let c = chars[i];
             if c == '\u{2007}' {
                 return font_size * 0.5 * ratio + style.letter_spacing + style.extra_char_spacing;
+            }
+            // 인라인 객체 placeholder 는 실제 control node 가 따로 그리므로 텍스트 폭은 0.
+            if c == '\u{FFFC}' {
+                return 0.0;
             }
             // [Issue #677] HWP PUA 채움 문자 (U+F081C) — 시각 폭 0
             // 한컴이 인라인 TAC 표/도형 앞에 삽입하는 placeholder 채움 문자.
@@ -1021,6 +1029,10 @@ impl TextMeasurer for WasmTextMeasurer {
             if c == '\u{2007}' {
                 return font_size * 0.5 * ratio + style.letter_spacing + style.extra_char_spacing;
             }
+            // 인라인 객체 placeholder 는 실제 control node 가 따로 그리므로 텍스트 폭은 0.
+            if c == '\u{FFFC}' {
+                return 0.0;
+            }
             // [Issue #677] HWP PUA 채움 문자 (U+F081C) — 시각 폭 0
             // 한컴이 인라인 TAC 표/도형 앞에 삽입하는 placeholder 채움 문자.
             // 한컴 PDF 정합 — 폭 0 으로 라인 inline x 에 영향 없음. fillers 가
@@ -1216,6 +1228,10 @@ impl TextMeasurer for WasmTextMeasurer {
             let c = chars[i];
             if c == '\u{2007}' {
                 return font_size * 0.5 * ratio + style.letter_spacing + style.extra_char_spacing;
+            }
+            // 인라인 객체 placeholder 는 실제 control node 가 따로 그리므로 텍스트 폭은 0.
+            if c == '\u{FFFC}' {
+                return 0.0;
             }
             // [Issue #677] HWP PUA 채움 문자 (U+F081C) — 시각 폭 0
             // 한컴이 인라인 TAC 표/도형 앞에 삽입하는 placeholder 채움 문자.
@@ -1660,6 +1676,10 @@ pub(crate) fn estimate_text_width_unrounded(text: &str, style: &TextStyle) -> f6
         let c = chars[i];
         if c == '\u{2007}' {
             return font_size * 0.5 * ratio + style.letter_spacing + style.extra_char_spacing;
+        }
+        // 인라인 객체 placeholder 는 실제 control node 가 따로 그리므로 텍스트 폭은 0.
+        if c == '\u{FFFC}' {
+            return 0.0;
         }
         // [Issue #677] HWP PUA 채움 문자 (U+F081C) — 시각 폭 0
         if c == '\u{F081C}' {
@@ -2161,6 +2181,26 @@ mod tests {
         for (a, b) in free_fn_result.iter().zip(trait_result.iter()) {
             assert!((a - b).abs() < 0.01, "position mismatch: {} != {}", a, b);
         }
+    }
+
+    #[test]
+    fn test_inline_object_placeholder_has_zero_advance() {
+        let style = TextStyle {
+            font_family: "Haansoft Dotum".to_string(),
+            font_size: 12.0,
+            ..Default::default()
+        };
+
+        assert_eq!(estimate_text_width("\u{FFFC}", &style), 0.0);
+        assert_eq!(
+            estimate_text_width("\u{FFFC}\u{FFFC}A", &style),
+            estimate_text_width("A", &style),
+            "U+FFFC placeholder 는 실제 TAC 노드가 따로 폭을 차지하므로 텍스트 폭에 더하면 안 됨"
+        );
+
+        let positions = compute_char_positions("\u{FFFC}A", &style);
+        assert_eq!(positions[0], positions[1]);
+        assert!(positions[2] > positions[1]);
     }
 
     // ── 오버플로우 압축 회귀 테스트 (Task #229) ──

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -438,17 +438,14 @@ impl SvgRenderer {
             RenderNodeType::Equation(eq) => {
                 // 수식 SVG 조각을 bbox 위치에 배치
                 // HWP 저장 영역(bbox)과 레이아웃 산출 크기(layout_box)가 다를 수 있으므로
-                // bbox 너비에 맞춰 스케일링
+                // bbox 너비에 맞춰 스케일링한다. 높이는 줄 높이/여백을 포함한 영역이라
+                // 식 자체를 세로로 늘리면 한컴보다 글자가 찌그러진다.
                 let scale_x = if eq.layout_box.width > 0.0 && node.bbox.width > 0.0 {
                     node.bbox.width / eq.layout_box.width
                 } else {
                     1.0
                 };
-                let scale_y = if eq.layout_box.height > 0.0 && node.bbox.height > 0.0 {
-                    node.bbox.height / eq.layout_box.height
-                } else {
-                    1.0
-                };
+                let scale_y = 1.0_f64;
                 let needs_scale = (scale_x - 1.0).abs() > 0.01 || (scale_y - 1.0).abs() > 0.01;
                 if needs_scale {
                     self.output.push_str(&format!(

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2202,25 +2202,33 @@ impl TypesetEngine {
                                             && hwpunit_to_px(first - prev, self.dpi)
                                                 > available * 0.75
                                 );
-                            let internal_vpos_rewind = en_para
+                            let internal_rewind_position = en_para
                                 .line_segs
                                 .windows(2)
-                                .any(|w| w[1].vertical_pos < w[0].vertical_pos);
+                                .position(|w| w[1].vertical_pos < w[0].vertical_pos)
+                                .map(|idx| idx + 1)
+                                .filter(|split| {
+                                    *split > 0
+                                        && *split < en_para.line_segs.len()
+                                        && *split < fmt.line_heights.len()
+                                });
+                            let internal_vpos_rewind = internal_rewind_position.is_some();
+                            let saved_page_reset_rewind = internal_rewind_position
+                                .and_then(|split| {
+                                    en_para.line_segs.get(split).map(|seg| (split, seg))
+                                })
+                                .map(|(split, seg)| {
+                                    split >= 4
+                                        && seg.vertical_pos <= 0
+                                        && st.current_height > available * 0.65
+                                })
+                                .unwrap_or(false);
                             let internal_rewind_split = if compact_endnote_separator_profile
                                 && st.col_count > 1
-                                && st.current_height > available * 0.75
+                                && (st.current_height > available * 0.75 || saved_page_reset_rewind)
                                 && para_has_visible_text_or_equation(en_para)
                             {
-                                en_para
-                                    .line_segs
-                                    .windows(2)
-                                    .position(|w| w[1].vertical_pos < w[0].vertical_pos)
-                                    .map(|idx| idx + 1)
-                                    .filter(|split| {
-                                        *split > 0
-                                            && *split < en_para.line_segs.len()
-                                            && *split < fmt.line_heights.len()
-                                    })
+                                internal_rewind_position
                             } else {
                                 None
                             };
@@ -2442,7 +2450,17 @@ impl TypesetEngine {
                             // advance 후 재평가 — 새 단 첫 미주는 prev=None → 자체 높이.
                             let (_, en_advance) = compute_en_metrics(prev_en_bottom_vpos);
                             let mut split_endnote_emitted = false;
-                            if let Some(split_line) = split_endnote_to_fit.or(internal_rewind_split)
+                            let tall_line_internal_rewind_split =
+                                internal_rewind_split.filter(|split| {
+                                    split
+                                        .checked_sub(1)
+                                        .and_then(|idx| en_para.line_segs.get(idx))
+                                        .map(|seg| seg.line_height >= 2000)
+                                        .unwrap_or(false)
+                                });
+                            if let Some(split_line) = tall_line_internal_rewind_split
+                                .or(split_endnote_to_fit)
+                                .or(internal_rewind_split)
                             {
                                 let first_h = fmt.line_advances_sum(0..split_line);
                                 st.current_items.push(PageItem::PartialParagraph {

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -799,19 +799,14 @@ impl WebCanvasRenderer {
                 self.ctx.clip();
             }
             RenderNodeType::Equation(eq) => {
-                // SVG 경로 (svg.rs 의 Equation 분기) 와 동일하게 bbox 크기에 맞춰
-                // X/Y 스케일링 적용. HWP 저장 영역(bbox)과 레이아웃 산출 크기(layout_box)
-                // 가 다를 때 수식이 정확한 영역에 그려지도록 한다.
+                // SVG/Skia 경로와 동일하게 bbox 너비만 맞춘다. bbox 높이는 줄 높이와
+                // 여백을 포함한 배치 영역이라 세로 스케일을 걸면 식 글자가 찌그러진다.
                 let scale_x = if eq.layout_box.width > 0.0 && node.bbox.width > 0.0 {
                     node.bbox.width / eq.layout_box.width
                 } else {
                     1.0
                 };
-                let scale_y = if eq.layout_box.height > 0.0 && node.bbox.height > 0.0 {
-                    node.bbox.height / eq.layout_box.height
-                } else {
-                    1.0
-                };
+                let scale_y = 1.0_f64;
                 self.ctx.save();
                 let _ = self.ctx.translate(node.bbox.x, node.bbox.y);
                 let needs_scale = (scale_x - 1.0).abs() > 0.01 || (scale_y - 1.0).abs() > 0.01;

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -143,6 +143,21 @@ fn collect_equation_bboxes_containing(node: &RenderNode, needle: &str, out: &mut
     }
 }
 
+fn find_equation_bbox(
+    node: &RenderNode,
+    para_index: usize,
+    control_index: usize,
+) -> Option<BoundingBox> {
+    if let RenderNodeType::Equation(eq) = &node.node_type {
+        if eq.para_index == Some(para_index) && eq.control_index == Some(control_index) {
+            return Some(node.bbox.clone());
+        }
+    }
+    node.children
+        .iter()
+        .find_map(|child| find_equation_bbox(child, para_index, control_index))
+}
+
 fn count_table_nodes(node: &RenderNode, para_index: usize, control_index: usize) -> usize {
     let own = match &node.node_type {
         RenderNodeType::Table(table)
@@ -201,6 +216,23 @@ fn max_para_content_bottom(node: &RenderNode, para_index: usize) -> Option<f64> 
                 .filter_map(|child| max_para_content_bottom(child, para_index)),
         )
         .max_by(|a, b| a.partial_cmp(b).unwrap())
+}
+
+#[test]
+fn issue_1189_2022_nov_page1_question1_marker_gap_matches_pdf() {
+    let bytes = std::fs::read("samples/3-11월_실전_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let tree = doc.build_page_render_tree(0).expect("page 1 render tree");
+
+    let question1_eq = find_equation_bbox(&tree.root, 0, 4).expect("문1 수식");
+    assert!(
+        question1_eq.x <= 72.0,
+        "문1 본문 미주 마커 앞 HWP5 placeholder가 0폭이어야 수식이 한컴/PDF처럼 문항 번호 바로 뒤에 붙음: {question1_eq:?}"
+    );
+    assert!(
+        question1_eq.x >= 68.0,
+        "문1 수식이 문항 번호와 겹치면 안 됨: {question1_eq:?}"
+    );
 }
 
 #[test]

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -968,6 +968,31 @@ fn issue_1189_2022_nov_page17_internal_rewind_keeps_formula_tail_on_next_page() 
 }
 
 #[test]
+fn issue_1189_2022_oct_page17_endnote_drag_selection_covers_equation_tail_lines() {
+    let bytes = std::fs::read("samples/3-10월_교육_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let tree = doc.build_page_render_tree(16).expect("page 17 render tree");
+
+    let rects = doc
+        .get_selection_rects(0, 915, 0, 921, 3)
+        .unwrap_or_else(|e| panic!("17쪽 문27 미주 드래그 선택 사각형 조회 실패: {e:?}"));
+    let rects: Value = serde_json::from_str(&rects).expect("selection rects json");
+    let rects = rects.as_array().expect("selection rect array");
+
+    for para_idx in 915..=921 {
+        let para_y = min_para_text_y(&tree.root, para_idx).expect("문27 미주 문단 text y");
+        assert!(
+            rects.iter().any(|rect| {
+                rect["pageIndex"].as_u64() == Some(16)
+                    && (rect["y"].as_f64().unwrap_or_default() - para_y).abs() < 0.8
+                    && rect["width"].as_f64().unwrap_or_default() > 1.0
+            }),
+            "한컴오피스처럼 문27 미주 드래그 선택이 수식 꼬리 문단까지 연속으로 덮어야 함: para_idx={para_idx}, para_y={para_y}, rects={rects:?}"
+        );
+    }
+}
+
+#[test]
 fn issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf() {
     let bytes = std::fs::read("samples/3-11월_실전_통합_2022.hwp").expect("sample");
     let doc = HwpDocument::from_bytes(&bytes).expect("parse");

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -1005,6 +1005,13 @@ fn issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf() {
             && page10.contains("FullParagraph[미주]  pi=476"),
         "PDF 기준 10쪽 하단/우측 시작 미주 흐름을 유지해야 함\n{page10}"
     );
+    let page10_tree = doc.build_page_render_tree(9).expect("page 10 render tree");
+    let question6_tail_bottom =
+        max_para_content_bottom(&page10_tree.root, 475).expect("문6 꼬리 수식");
+    assert!(
+        question6_tail_bottom <= 1092.8,
+        "10쪽 문6 꼬리 수식은 본문 하단을 넘겨 문단끼리 겹치면 안 됨: bottom={question6_tail_bottom}"
+    );
     assert!(
         page11.contains("PartialParagraph  pi=553  lines=0..8")
             && !page11.contains("FullParagraph[미주]  pi=553"),

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -132,6 +132,17 @@ fn find_image_bbox(
         .find_map(|child| find_image_bbox(child, para_index, control_index))
 }
 
+fn collect_equation_bboxes_containing(node: &RenderNode, needle: &str, out: &mut Vec<BoundingBox>) {
+    if let RenderNodeType::Equation(eq) = &node.node_type {
+        if eq.svg_content.contains(needle) {
+            out.push(node.bbox.clone());
+        }
+    }
+    for child in &node.children {
+        collect_equation_bboxes_containing(child, needle, out);
+    }
+}
+
 fn count_table_nodes(node: &RenderNode, para_index: usize, control_index: usize) -> usize {
     let own = match &node.node_type {
         RenderNodeType::Table(table)
@@ -869,6 +880,139 @@ fn issue_1139_2023_pages12_13_endnote_boundary_matches_pdf() {
     assert!(
         graph < q15_title,
         "PDF 기준 13쪽은 문15 제목 전에 문14 그래프가 먼저 보여야 함\n{page13}"
+    );
+}
+
+#[test]
+fn issue_1189_2023_page19_question29_tail_matches_pdf() {
+    let bytes = std::fs::read("samples/3-09월_교육_통합_2023.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+
+    let page19 = doc.dump_page_items(Some(18));
+    assert!(
+        page19.contains("PartialParagraph  pi=935  lines=0..2")
+            && page19.contains("PartialParagraph  pi=935  lines=2..3")
+            && page19.contains("FullParagraph[미주]  pi=946")
+            && page19.contains("FullParagraph[미주]  pi=952")
+            && page19.contains("PartialParagraph  pi=953  lines=0..1"),
+        "PDF 기준 19쪽 우측 단에는 문29 제목, 첫 그림, 그림 아래 첫 문단이 함께 남고, 앞쪽 pi=935 분배는 기존 위치를 유지해야 함\n{page19}"
+    );
+
+    let tree = doc.build_page_render_tree(18).expect("page 19 render tree");
+    let q29_title_y = min_para_text_y(&tree.root, 946).expect("문29 제목");
+    let first_case_picture = find_image_bbox(&tree.root, 951, 0).expect("문29 첫 경우 그림");
+    let picture_tail_y = min_para_text_y(&tree.root, 952).expect("문29 그림 아래 본문");
+
+    assert!(
+        q29_title_y < 725.0,
+        "문29 제목이 PDF 기준보다 아래로 밀리면 뒤쪽 그림/본문이 페이지 하단에서 잘림: y={q29_title_y}"
+    );
+    assert!(
+        first_case_picture.y < 880.0 && first_case_picture.y + first_case_picture.height < 1075.0,
+        "문29 첫 그림이 PDF 기준 위치보다 아래로 밀리면 안 됨: {first_case_picture:?}"
+    );
+    assert!(
+        picture_tail_y < 1080.0,
+        "문29 그림 아래 첫 문단은 19쪽 하단 안쪽에 보여야 함: y={picture_tail_y}"
+    );
+}
+
+#[test]
+fn issue_1189_2022_nov_page17_internal_rewind_keeps_formula_tail_on_next_page() {
+    let bytes = std::fs::read("samples/3-11월_실전_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+
+    let page14 = doc.dump_page_items(Some(13));
+    let page16 = doc.dump_page_items(Some(15));
+    let page17 = doc.dump_page_items(Some(16));
+    assert!(
+        page14.contains("FullParagraph[미주]  pi=632")
+            && page14.contains("FullParagraph[미주]  pi=650")
+            && page14.contains("FullParagraph[미주]  pi=669")
+            && page14.contains("PartialParagraph  pi=671  lines=0..2"),
+        "PDF 기준 14쪽은 문22~문27 시작 흐름이 같은 페이지에 유지되어야 함\n{page14}"
+    );
+    assert!(
+        page16.contains("PartialParagraph  pi=786  lines=0..1")
+            && !page16.contains("PartialParagraph  pi=786  lines=0..2"),
+        "한컴/PDF 기준 16쪽 하단에는 문26 수식 문단의 첫 줄만 남아야 함\n{page16}"
+    );
+    assert!(
+        page17.contains("PartialParagraph  pi=786  lines=1..5")
+            && page17.contains("FullParagraph[미주]  pi=787")
+            && page17.contains("FullParagraph[미주]  pi=801"),
+        "한컴/PDF 기준 17쪽은 문26 수식 나머지 줄 뒤에 문27/문28이 이어져야 함\n{page17}"
+    );
+
+    let tree = doc.build_page_render_tree(16).expect("page 17 render tree");
+    let mut cqrt_lines = Vec::new();
+    collect_equation_bboxes_containing(&tree.root, "CQRT", &mut cqrt_lines);
+    let cqrt_line = cqrt_lines
+        .into_iter()
+        .find(|bbox| bbox.x > 400.0 && bbox.y > 430.0 && bbox.y < 460.0)
+        .expect("문28 CQRT line");
+    let mut g_theta_candidates = Vec::new();
+    collect_equation_bboxes_containing(&tree.root, ">g</text>", &mut g_theta_candidates);
+    let g_theta = g_theta_candidates
+        .into_iter()
+        .find(|bbox| {
+            (bbox.y - cqrt_line.y).abs() < 2.0
+                && bbox.x < cqrt_line.x
+                && cqrt_line.x - bbox.x < 40.0
+        })
+        .expect("문28 g(theta)");
+    assert!(
+        (g_theta.y - cqrt_line.y).abs() < 2.0 && cqrt_line.x > g_theta.x,
+        "문28의 g(theta)와 =□CQRT-△CST는 같은 줄에서 좌→우로 이어져야 함: g={g_theta:?}, cqrt={cqrt_line:?}"
+    );
+}
+
+#[test]
+fn issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf() {
+    let bytes = std::fs::read("samples/3-11월_실전_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+
+    let page10 = doc.dump_page_items(Some(9));
+    let page11 = doc.dump_page_items(Some(10));
+    let page12 = doc.dump_page_items(Some(11));
+    assert!(
+        page10.contains("FullParagraph[미주]  pi=475")
+            && page10.contains("FullParagraph[미주]  pi=476"),
+        "PDF 기준 10쪽 하단/우측 시작 미주 흐름을 유지해야 함\n{page10}"
+    );
+    assert!(
+        page11.contains("PartialParagraph  pi=553  lines=0..8")
+            && !page11.contains("FullParagraph[미주]  pi=553"),
+        "문14 tail은 11쪽에서 내부 vpos 리셋 직전까지만 렌더되어야 함\n{page11}"
+    );
+    assert!(
+        page12.contains("PartialParagraph  pi=553  lines=8..11")
+            && page12.contains("Shape          pi=554 ci=0  그림 tac=true")
+            && page12.contains("FullParagraph[미주]  pi=555"),
+        "12쪽은 문14 tail 텍스트 뒤 그래프와 문15가 이어져야 함\n{page12}"
+    );
+
+    let svg = doc.render_page_svg_native(11).expect("page 12 svg");
+    assert!(
+        !svg.contains(">SEARROW</text>") && !svg.contains(">NEARROW</text>"),
+        "문19 변화표의 HWP 대문자 화살표 토큰이 문자열 그대로 렌더되면 안 됨"
+    );
+    assert!(
+        svg.contains(">↘</text>") && svg.contains(">↗</text>"),
+        "문19 변화표의 감소/증가 방향은 한컴처럼 대각 화살표 기호로 렌더되어야 함"
+    );
+    let bad_eq_text = svg.find(">배수</text>").expect("문15 배수 수식");
+    let group_start = svg[..bad_eq_text]
+        .rfind("<g transform=")
+        .expect("배수 수식 group");
+    let group_end = bad_eq_text
+        + svg[bad_eq_text..]
+            .find("</g>")
+            .expect("배수 수식 group end");
+    let group = &svg[group_start..group_end];
+    assert!(
+        group.contains(",1.0000)"),
+        "수식 bbox 높이로 Y축을 확대하면 12쪽 하단 주석 수식이 찌그러짐\n{group}"
     );
 }
 

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -1025,6 +1025,28 @@ fn issue_1189_2022_oct_page17_endnote_drag_selection_covers_equation_tail_lines(
 }
 
 #[test]
+fn issue_1189_2022_oct_page11_endnote_question_gaps_match_pdf() {
+    let bytes = std::fs::read("samples/3-10월_교육_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let tree = doc.build_page_render_tree(10).expect("page 11 render tree");
+
+    let question18_y = min_para_text_y(&tree.root, 569).expect("문18 title");
+    let question19_y = min_para_text_y(&tree.root, 574).expect("문19 title");
+    let question20_y = min_para_text_y(&tree.root, 582).expect("문20 title");
+    let gap18_to_19 = question19_y - question18_y;
+    let gap19_to_20 = question20_y - question19_y;
+
+    assert!(
+        (205.0..235.0).contains(&gap18_to_19),
+        "11쪽 문18→문19 미주 간격이 PDF보다 넓어지면 안 됨: q18={question18_y}, q19={question19_y}, gap={gap18_to_19}"
+    );
+    assert!(
+        (180.0..210.0).contains(&gap19_to_20),
+        "11쪽 문19→문20 미주 간격도 한컴/PDF 흐름을 유지해야 함: q19={question19_y}, q20={question20_y}, gap={gap19_to_20}"
+    );
+}
+
+#[test]
 fn issue_1189_2022_nov_pages10_12_rewind_tail_and_equation_scale_match_pdf() {
     let bytes = std::fs::read("samples/3-11월_실전_통합_2022.hwp").expect("sample");
     let doc = HwpDocument::from_bytes(&bytes).expect("parse");


### PR DESCRIPTION
## 변경 내용

- `3-09월_교육_통합_2023.hwp` 19쪽 미주 흐름에서 문29) 꼬리 내용이 페이지 하단으로 밀리는 문제를 보정했습니다.
- `3-11월_실전_통합_2022.hwp` 10~12쪽, 14쪽, 17쪽의 미주 수식 흐름과 문28)/문19) 정합 문제를 후속 보정했습니다.
- 미주 영역 드래그 선택이 한컴오피스 기준과 맞도록 선택 rect 계산을 보완했습니다.
- `3-11월_실전_통합_2022.hwp` 1쪽 문1) 앞의 보이지 않는 `U+FFFC` 인라인 객체 placeholder가 텍스트 폭에 포함되어 첫 수식이 오른쪽으로 밀리던 문제를 수정했습니다.

## 원인

- HWP5 인라인 컨트롤 placeholder가 SVG 출력에서는 보이지 않지만 일부 텍스트 측정 경로에서는 폭을 차지했습니다.
- compact 미주 흐름에서 하단 fit, 큰 수식 줄 되감기, 수식-only 미주 문단 marker 합성 조건이 한컴/PDF 기준과 일부 달랐습니다.
- 변화표 수식 안의 `SEARROW`/`NEARROW` 토큰이 화살표 기호로 매핑되지 않는 케이스가 있었습니다.

## 검증

- `cargo fmt --all --check`
- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture`
- `cargo test --tests`
- `wasm-pack build --target web --out-dir pkg`
- PDF 비교 산출물은 `output/task1189_*` 아래에 생성해 확인했습니다. SVG→PNG 변환은 `rsvg-convert` 기준입니다.

Closes edwardkim/rhwp#1189
