### PR TITLE
Task #1198: exam_social.hwp 중첩 표 셀 붙여넣기 경로 보존

### DIFF
--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -1,5 +1,15 @@
 # 2026-06-01 — 오늘 할일
 
+## Task #1198 — `exam_social.hwp` 중첩 표 셀 붙여넣기 경로 보존
+
+- [x] 이슈 생성: #1198 `rhwp-studio: exam_social.hwp 중첩 표 셀에서 내부 클립보드 붙여넣기 시 바깥 셀에 삽입됨`.
+- [x] 브랜치 생성/정리: `task-1198`.
+- [x] 수행계획서/구현계획서 작성: `mydocs/plans/task_m100_1198.md`, `mydocs/plans/task_m100_1198_impl.md`.
+- [x] 업스트림 반영: `upstream/devel` `c884205d`, `Cargo.toml` `0.7.13`, `HEAD...upstream/devel = 0 0`.
+- [x] 구현: 중첩 표 `cellPath` 기반 내부/HTML 붙여넣기 native/WASM API와 Studio 라우팅 추가.
+- [x] 검증: #1198 신규 테스트, #850 회귀 테스트, `cargo test --lib`, `npm test`, `npm run build` 통과.
+- [ ] PR 준비 및 리뷰 요청.
+
 ## PR #1193 (Fix mac window resizing, @chkwon — rhwp 첫 기여자) — 완료
 
 - PR #1193 → **MERGED** (devel `8a2e60ca`). 연결 이슈 #1191 → CLOSED (`closes #1191`, cross-repo `--no-ff` 라 수동 클로즈).

--- a/mydocs/plans/task_m100_1198.md
+++ b/mydocs/plans/task_m100_1198.md
@@ -1,0 +1,148 @@
+# 수행계획서 — Task M100-1198: `exam_social.hwp` 중첩 표 셀 붙여넣기 위치 보존
+
+## 1. 이슈
+
+- GitHub Issue: [#1198](https://github.com/edwardkim/rhwp/issues/1198)
+- 제목: `rhwp-studio: exam_social.hwp 중첩 표 셀에서 내부 클립보드 붙여넣기 시 바깥 셀에 삽입됨`
+- 마일스톤: M100 / v1.0.0 편집 기반
+- 브랜치: `task-1198`
+
+## 2. 문제 요약
+
+`samples/exam_social.hwp` 1쪽 상단 답안지 영역의 `성명` 입력칸은 바깥 표 안에 들어 있는 중첩 표 셀이다.
+해당 칸을 클릭하면 hit-test는 전체 경로를 `cellPath`로 반환하지만, 내부 클립보드 붙여넣기 경로는
+`cellPath`를 사용하지 않고 바깥 표의 `controlIndex/cellIndex/cellParaIndex`만 WASM에 전달한다.
+
+그 결과 붙여넣기 대상이 실제 `성명` 내부 셀이 아니라 바깥 표 셀로 해석되어, 영상처럼 표 밖 또는 의도하지 않은 위치에 텍스트가 삽입된다.
+
+## 3. 진단 결과
+
+이미 존재하는 #850 회귀 테스트가 `exam_social.hwp`의 `성명` 칸 hit-test 경로를 검증한다.
+
+```text
+tests/issue_850_answer_sheet_name_hit_test.rs
+  exam_social.hwp: [(4, 0, 3), (0, 1, 0)]
+```
+
+일반 텍스트 입력은 다음 path 기반 API를 사용하므로 중첩 셀에 정상 삽입된다.
+
+```text
+rhwp-studio/src/engine/input-handler-text.ts
+  insertTextInCellByPath(...)
+
+src/document_core/commands/text_editing.rs
+  insert_text_in_cell_by_path(...)
+```
+
+반면 붙여넣기는 얕은 셀 좌표만 사용하는 API로 빠진다.
+
+```text
+rhwp-studio/src/engine/input-handler-keyboard.ts
+  pasteInternalInCell(...)
+  pasteHtmlInCell(...)
+
+src/document_core/commands/clipboard.rs
+  paste_internal_in_cell_native(...)
+
+src/document_core/commands/html_import.rs
+  paste_html_in_cell_native(...)
+```
+
+추가로 WASM의 셀 붙여넣기 결과는 `cellParaIdx`를 반환하지만, TypeScript 커서 갱신 경로는 일부 구간에서
+`parsed.paraIdx`를 읽고 있어 붙여넣기 후 커서 위치도 중첩 셀 경로를 보존하지 못한다.
+
+## 4. 구현 방향
+
+샘플 전용 분기 없이 “셀 위치가 `cellPath`를 가지면 전체 경로로 편집한다”는 규칙으로 정리한다.
+
+### 4.1 path 기반 붙여넣기 API 추가
+
+다음 WASM/native API를 추가한다.
+
+```text
+pasteInternalInCellByPath(section, parentPara, pathJson, charOffset)
+pasteHtmlInCellByPath(section, parentPara, pathJson, charOffset, html)
+```
+
+Rust 쪽은 기존 `resolve_paragraph_by_path` / `get_cell_paragraph_mut_by_path` 계열을 재사용하고,
+붙여넣기 본문 로직은 기존 얕은 셀 API와 중복되지 않도록 공통 헬퍼로 분리한다.
+
+### 4.2 rhwp-studio 붙여넣기 라우팅 정리
+
+`DocumentPosition.cellPath.length > 1`이면 내부 클립보드와 HTML 붙여넣기 모두 path 기반 API를 호출한다.
+
+반환값 처리도 셀 전용 결과 이름에 맞춘다.
+
+```text
+cellParaIndex = parsed.cellParaIdx ?? p.cellParaIndex
+cellPath 마지막 엔트리의 cellParaIndex도 동일하게 갱신
+```
+
+본문/얕은 표 셀 붙여넣기는 기존 API를 유지해 회귀 범위를 줄인다.
+
+### 4.3 복사/export 경로 점검
+
+이번 재현의 핵심은 붙여넣기 대상이지만, 같은 `input-handler-keyboard.ts` 안의 복사/export도 중첩 셀에서
+얕은 `copySelectionInCell` / `exportSelectionInCellHtml` 경로를 사용한다.
+
+구현계획서 단계에서 다음 두 옵션 중 최소 안전 범위를 확정한다.
+
+```text
+1. 이번 이슈는 paste target 경로 보존으로 제한하고, copy source path API는 후속 이슈로 분리
+2. copySelectionInCellByPath / exportSelectionInCellHtmlByPath까지 함께 추가해 클립보드 경로를 대칭화
+```
+
+현 단계의 기본안은 1번이다. 다만 구현 중 테스트가 중첩 셀 내부 복사까지 같은 문제를 재현하면 2번으로 확장한다.
+
+## 5. 수정 후보 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/document_core/commands/clipboard.rs` | 내부 클립보드 셀 붙여넣기 공통 헬퍼 및 path 기반 native API 추가 |
+| `src/document_core/commands/html_import.rs` | HTML 셀 붙여넣기 공통 헬퍼 및 path 기반 native API 추가 |
+| `src/wasm_api.rs` | `pasteInternalInCellByPath`, `pasteHtmlInCellByPath` 바인딩 추가 |
+| `rhwp-studio/src/core/wasm-bridge.ts` | 신규 WASM API 래퍼 추가 |
+| `rhwp-studio/src/engine/input-handler-keyboard.ts` | `cellPath` 기반 paste 라우팅과 커서 갱신 수정 |
+| `pkg/rhwp*.d.ts` | 로컬 WASM 빌드 산출 타입 확인 대상. Git 추적 대상이 아니므로 PR에는 포함하지 않음 |
+| `tests/issue_1198_*.rs` | `exam_social.hwp` 중첩 셀 붙여넣기 회귀 테스트 추가 |
+
+## 6. 검증 계획
+
+최소 자동 검증:
+
+```text
+cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture
+cargo test --test issue_1198_nested_cell_paste -- --nocapture
+```
+
+rhwp-studio 변경 검증:
+
+```text
+cd rhwp-studio
+npm test
+npm run build
+```
+
+필요 시 추가 확인:
+
+```text
+cargo fmt --check
+cargo test --lib
+```
+
+업스트림 반영 후 `cargo test --lib`까지 통과 여부를 확인한다. 로컬 `pkg/`는 WASM 타입 확인과
+`rhwp-studio` 빌드 검증용 산출물이며, Git 추적 대상이 아니므로 PR 범위에는 포함하지 않는다.
+
+## 7. 완료 기준
+
+```text
+1. exam_social.hwp 상단 `성명` 입력칸에서 내부 클립보드 붙여넣기가 실제 중첩 셀에 삽입된다.
+2. 붙여넣기 후 커서가 같은 중첩 셀 안에 유지된다.
+3. 본문과 얕은 표 셀 붙여넣기 동작은 기존과 동일하다.
+4. 수정은 샘플명/좌표/특정 controlIndex에 의존하지 않고 `cellPath` 유무로 동작한다.
+5. #850의 hit-test/일반 입력 회귀 테스트가 계속 통과한다.
+```
+
+## 8. 승인 요청
+
+위 방향으로 구현계획서 작성 및 구현 준비를 진행한다.

--- a/mydocs/plans/task_m100_1198_impl.md
+++ b/mydocs/plans/task_m100_1198_impl.md
@@ -1,0 +1,112 @@
+# 구현계획서 — Task M100-1198: 중첩 표 셀 붙여넣기 `cellPath` 보존
+
+## 설계 요약
+
+- 중첩 표에서는 `DocumentPosition.controlIndex/cellIndex/cellParaIndex`가 하위 호환을 위해 최외곽 표 좌표를 유지한다.
+- 실제 편집 대상은 `DocumentPosition.cellPath`의 마지막 엔트리로 판단한다.
+- 기존 얕은 셀 API(`pasteInternalInCell`, `pasteHtmlInCell`)는 유지하고, 중첩 표 전용 path API를 추가한다.
+- 구현은 `exam_social.hwp`나 특정 좌표/컨트롤 번호에 의존하지 않고 `cellPath.length > 1` 조건으로 라우팅한다.
+
+## Stage 1 — Rust native path 기반 내부 클립보드 붙여넣기
+
+**목표**: 내부 클립보드 붙여넣기를 최종 중첩 셀 문단 벡터에 적용하는 native API를 만든다.
+
+변경 대상:
+
+- `src/document_core/commands/text_editing.rs`
+  - `get_cell_paragraphs_mut_by_path(...) -> &mut Vec<Paragraph>` 헬퍼 추가.
+  - 기존 `get_cell_paragraph_mut_by_path(...)`와 동일한 path 순회 규칙을 사용하되, 마지막 셀의 문단 목록을 반환한다.
+- `src/document_core/commands/clipboard.rs`
+  - 셀 문단 목록에 클립보드 문단을 삽입하는 공통 헬퍼 추가.
+  - 기존 `paste_internal_in_cell_native(...)`는 얕은 셀 조회 후 공통 헬퍼를 호출하도록 정리한다.
+  - 신규 `paste_internal_in_cell_by_path_native(section, parentPara, path, charOffset)` 추가.
+  - path API는 최외곽 표를 dirty 처리하고 `raw_stream` 무효화, section dirty, pagination 갱신을 수행한다.
+- `src/wasm_api.rs`
+  - `pasteInternalInCellByPath(section, parentPara, pathJson, charOffset)` 바인딩 추가.
+
+회귀 테스트:
+
+- `tests/issue_1198_nested_cell_paste.rs` 신규 추가.
+- `samples/exam_social.hwp`에서 `성명` 칸 hit-test path `[(4,0,3),(0,1,0)]`를 사용한다.
+- 문서 안의 첫 유효 텍스트 1글자를 내부 클립보드에 복사한 뒤, 신규 path API로 `성명` 칸에 붙여넣고 `get_text_in_cell_by_path`로 실제 삽입 위치를 검증한다.
+- 기존 #850 테스트도 함께 실행해 일반 입력 path 회귀를 확인한다.
+
+검증:
+
+```text
+cargo test --test issue_1198_nested_cell_paste -- --nocapture
+cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture
+```
+
+보고서:
+
+```text
+mydocs/working/task_m100_1198_stage1.md
+```
+
+## Stage 2 — HTML 붙여넣기 path API와 rhwp-studio 라우팅
+
+**목표**: 내부 클립보드와 HTML 붙여넣기 모두 중첩 표에서는 path API를 사용하게 한다.
+
+변경 대상:
+
+- `src/document_core/commands/html_import.rs`
+  - HTML 파싱 결과 문단을 셀 문단 목록에 삽입하는 공통 헬퍼 추가.
+  - 신규 `paste_html_in_cell_by_path_native(section, parentPara, path, charOffset, html)` 추가.
+- `src/wasm_api.rs`
+  - `pasteHtmlInCellByPath(section, parentPara, pathJson, charOffset, html)` 바인딩 추가.
+- `rhwp-studio/src/core/wasm-bridge.ts`
+  - `pasteInternalInCellByPath(...)`, `pasteHtmlInCellByPath(...)` 래퍼 추가.
+- `rhwp-studio/src/engine/input-handler-keyboard.ts`
+  - `cellPath.length > 1`이면 내부 클립보드 붙여넣기에서 `pasteInternalInCellByPath` 호출.
+  - 외부 HTML 붙여넣기도 중첩 셀에서는 `pasteHtmlInCellByPath` 호출.
+  - 붙여넣기 결과의 `cellParaIdx`를 읽어 `cellParaIndex`와 `cellPath` 마지막 엔트리를 함께 갱신한다.
+  - 본문과 얕은 표 셀 경로는 기존 API를 그대로 유지한다.
+
+생성 산출물:
+
+- `pkg/`는 로컬 WASM 빌드 산출물이다.
+- `wasm-pack build --target web --out-dir pkg`로 타입 선언을 최신 API에 맞춰 확인하되, Git 추적 대상이 아니므로 PR에는 포함하지 않는다.
+
+검증:
+
+```text
+cd rhwp-studio
+npm test
+npm run build
+```
+
+보고서:
+
+```text
+mydocs/working/task_m100_1198_stage2.md
+```
+
+## Stage 3 — 통합 검증과 최종 보고
+
+**목표**: path 기반 붙여넣기와 기존 얕은 셀/본문 붙여넣기 회귀를 함께 확인한다.
+
+검증 항목:
+
+- 신규 #1198 테스트 GREEN.
+- #850 `exam_social.hwp` hit-test/일반 입력 테스트 GREEN.
+- `cargo fmt --check`.
+- 가능하면 `cargo test --lib`.
+- `cargo test --lib` 통과 여부를 확인한다.
+- rhwp-studio `npm test`, `npm run build`.
+
+최종 보고서:
+
+```text
+mydocs/report/task_m100_1198_report.md
+```
+
+## 제외 범위
+
+- `copySelectionInCellByPath`, `exportSelectionInCellHtmlByPath`는 이번 기본 범위에서 제외한다.
+- 이번 재현은 붙여넣기 대상 경로 손실이 핵심이며, 복사 source가 중첩 표인 경우까지 같은 PR에 확장하면 API 표면과 검증 범위가 커진다.
+- 구현 중 중첩 셀 source 복사가 동일 결함으로 확인되면 별도 이슈 또는 v2 계획으로 분리한다.
+
+## 승인 요청
+
+위 구현계획으로 소스 수정을 시작한다.

--- a/mydocs/report/task_m100_1198_report.md
+++ b/mydocs/report/task_m100_1198_report.md
@@ -1,0 +1,56 @@
+# 최종 보고서 — Task M100-1198: `exam_social.hwp` 중첩 표 셀 붙여넣기 위치 보존
+
+## 요약
+
+`samples/exam_social.hwp` 상단 `성명` 입력칸은 바깥 표 안의 중첩 표 셀이다.
+hit-test는 전체 `cellPath`를 반환하지만 붙여넣기 경로가 얕은 셀 좌표만 사용해, 내부 클립보드/HTML 붙여넣기가 바깥 셀에 삽입됐다.
+
+이번 수정은 샘플 전용 좌표나 컨트롤 번호를 사용하지 않고, `DocumentPosition.cellPath.length > 1`이면 전체 경로 기반 API로 붙여넣는 일반 규칙을 추가했다.
+
+## 변경 파일
+
+| 파일 | 변경 |
+|------|------|
+| `src/document_core/commands/text_editing.rs` | `cellPath`가 가리키는 최종 셀의 문단 목록을 얻는 공통 헬퍼 추가 |
+| `src/document_core/commands/clipboard.rs` | 내부 클립보드 셀 붙여넣기 공통 헬퍼와 `paste_internal_in_cell_by_path_native(...)` 추가 |
+| `src/document_core/commands/html_import.rs` | HTML 셀 붙여넣기 공통 헬퍼와 `paste_html_in_cell_by_path_native(...)` 추가 |
+| `src/wasm_api.rs` | `pasteInternalInCellByPath`, `pasteHtmlInCellByPath` WASM 바인딩 추가 |
+| `rhwp-studio/src/core/wasm-bridge.ts` | 신규 WASM API 래퍼 추가 |
+| `rhwp-studio/src/engine/input-handler-keyboard.ts` | 중첩 셀 붙여넣기 라우팅과 붙여넣기 후 커서 `cellPath` 갱신 보정 |
+| `tests/issue_1198_nested_cell_paste.rs` | `exam_social.hwp` 기반 내부/HTML 붙여넣기 회귀 테스트 추가 |
+
+## 검증
+
+```text
+cargo fmt --check
+cargo test --test issue_1198_nested_cell_paste -- --nocapture
+cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture
+cargo test --lib
+cd rhwp-studio && npm test
+wasm-pack build --target web --out-dir pkg
+cd rhwp-studio && npm run build
+```
+
+결과:
+
+```text
+cargo fmt --check: success
+issue_1198_nested_cell_paste: 2 passed
+issue_850_answer_sheet_name_hit_test: 1 passed
+cargo test --lib: 1491 passed, 0 failed, 6 ignored
+npm test: 49 passed
+wasm-pack build: success, rhwp v0.7.13
+npm run build: success
+```
+
+## 업스트림 상태
+
+- 브랜치: `task-1198`
+- 업스트림 기준: `upstream/devel` `c884205d`
+- 버전: `0.7.13`
+- `HEAD...upstream/devel`: `0 0`
+
+## 제외
+
+- 중첩 셀 source 복사용 `copySelectionInCellByPath` / `exportSelectionInCellHtmlByPath`는 이번 범위에서 제외했다.
+- 이번 재현은 붙여넣기 대상 경로 손실이 핵심이므로, 복사 source path 대칭화는 별도 이슈로 분리하는 편이 안전하다.

--- a/mydocs/working/task_m100_1198_stage1.md
+++ b/mydocs/working/task_m100_1198_stage1.md
@@ -1,0 +1,78 @@
+# Stage 1 보고서 — Task M100-1198: Rust native path 기반 내부 붙여넣기
+
+## 목표
+
+중첩 표 셀에서 내부 클립보드 붙여넣기 대상이 바깥 셀로 해석되지 않도록, Rust native/WASM API에 `cellPath` 기반 내부 붙여넣기 경로를 추가한다.
+
+## 변경
+
+### `src/document_core/commands/text_editing.rs`
+
+- `get_cell_paragraphs_mut_by_path(...)` 추가.
+- 기존 `get_cell_paragraph_mut_by_path(...)`는 새 문단 목록 헬퍼를 재사용하도록 정리.
+- `mark_cell_control_dirty(...)`를 `pub(crate)`로 변경해 clipboard 명령에서도 기존 path 편집 API와 같은 dirty 처리를 사용할 수 있게 했다.
+
+### `src/document_core/commands/clipboard.rs`
+
+- 셀 문단 목록에 클립보드 문단을 삽입하는 공통 헬퍼 `paste_paragraphs_into_cell_paragraphs(...)` 추가.
+- 기존 `paste_internal_in_cell_native(...)`는 얕은 표/글상자/캡션 경로를 유지하면서 공통 헬퍼를 사용하도록 정리.
+- 신규 `paste_internal_in_cell_by_path_native(...)` 추가.
+  - `cellPath`가 가리키는 최종 중첩 셀 문단 목록에 삽입.
+  - 최외곽 표 dirty, `raw_stream` 무효화, section dirty, pagination 갱신 수행.
+  - 반환 JSON은 기존 셀 붙여넣기와 같은 `cellParaIdx`, `charOffset` 형식.
+
+### `src/wasm_api.rs`
+
+- `pasteInternalInCellByPath(section, parentPara, pathJson, charOffset)` 바인딩 추가.
+
+### `tests/issue_1198_nested_cell_paste.rs` (신규)
+
+- `samples/exam_social.hwp`의 상단 `성명` 입력칸 hit-test 경로가 `[(4,0,3),(0,1,0)]`임을 확인.
+- 문서 본문의 첫 유효 글자를 내부 클립보드에 복사.
+- 신규 path API로 `성명` 중첩 셀에 붙여넣고, `get_text_in_cell_by_path`로 실제 중첩 셀 삽입을 검증.
+
+## 검증
+
+```text
+cargo test --test issue_1198_nested_cell_paste -- --nocapture
+```
+
+결과:
+
+```text
+1 passed
+```
+
+```text
+cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture
+```
+
+결과:
+
+```text
+1 passed
+```
+
+```text
+cargo fmt --check
+git diff --check
+cargo test --lib
+```
+
+결과:
+
+```text
+cargo fmt --check: success
+```
+
+업스트림 반영 전 1차 검증에서는 `cargo test --lib`가 통과했다. 이후 `upstream/devel` `c884205d`
+기준으로 재동기화하고 Stage 2/최종 검증에서 전체 결과를 다시 확인했다.
+
+## 남은 작업
+
+Stage 2에서 다음을 진행한다.
+
+- HTML 붙여넣기용 `pasteHtmlInCellByPath` 추가.
+- `rhwp-studio/src/core/wasm-bridge.ts` 신규 API 래퍼 추가.
+- `rhwp-studio/src/engine/input-handler-keyboard.ts`에서 `cellPath.length > 1`일 때 path 기반 붙여넣기 라우팅.
+- 붙여넣기 후 `cellParaIdx`와 `cellPath` 마지막 엔트리 갱신.

--- a/mydocs/working/task_m100_1198_stage2.md
+++ b/mydocs/working/task_m100_1198_stage2.md
@@ -1,0 +1,93 @@
+# Stage 2 보고서 — Task M100-1198: Studio 붙여넣기 라우팅과 HTML path API
+
+## 목표
+
+내부 클립보드뿐 아니라 외부 HTML 붙여넣기도 중첩 표 셀에서는 `cellPath`를 사용하게 한다.
+붙여넣기 후 커서가 같은 중첩 셀 경로에 남도록 `DocumentPosition` 갱신도 함께 보정한다.
+
+## 변경
+
+### `src/document_core/commands/html_import.rs`
+
+- HTML 파싱 결과 문단을 셀 문단 목록에 삽입하는 공통 헬퍼를 추가했다.
+- 기존 `paste_html_in_cell_native(...)`는 얕은 표 셀 경로를 유지하면서 공통 헬퍼를 사용한다.
+- 신규 `paste_html_in_cell_by_path_native(...)`를 추가했다.
+  - `cellPath`가 가리키는 최종 중첩 셀 문단 목록에 삽입한다.
+  - 최외곽 표 dirty, `raw_stream` 무효화, section dirty, pagination 갱신을 수행한다.
+
+### `src/wasm_api.rs`
+
+- `pasteHtmlInCellByPath(section, parentPara, pathJson, charOffset, html)` 바인딩을 추가했다.
+- Stage 1의 `pasteInternalInCellByPath(...)`와 같은 `DocumentCore::parse_cell_path(...)` 계약을 사용한다.
+
+### `rhwp-studio/src/core/wasm-bridge.ts`
+
+- `pasteInternalInCellByPath(...)`, `pasteHtmlInCellByPath(...)` 래퍼를 추가했다.
+
+### `rhwp-studio/src/engine/input-handler-keyboard.ts`
+
+- `DocumentPosition.cellPath.length > 1`이면 내부 클립보드 붙여넣기에서 `pasteInternalInCellByPath(...)`를 호출한다.
+- HTML 붙여넣기도 중첩 셀에서는 `pasteHtmlInCellByPath(...)`를 호출한다.
+- 붙여넣기 결과의 `cellParaIdx`를 `cellParaIndex`와 `cellPath` 마지막 엔트리에 반영한다.
+- 업스트림의 navigation shortcut helper와 충돌한 위치는 두 helper를 모두 유지하도록 병합했다.
+
+### `tests/issue_1198_nested_cell_paste.rs`
+
+- 내부 클립보드 path 붙여넣기 테스트에 더해 HTML path 붙여넣기 테스트를 추가했다.
+
+## 업스트림 반영
+
+- `upstream/devel` `c884205d`로 fast-forward했다.
+- `Cargo.toml` 버전은 `0.7.13`이다.
+- `HEAD...upstream/devel`은 `0 0`이다.
+- 업스트림이 새로 추적하게 된 기존 로컬 미추적 파일은 보존 stash로 분리했다.
+
+## 검증
+
+```text
+cargo test --test issue_1198_nested_cell_paste -- --nocapture
+```
+
+결과:
+
+```text
+2 passed
+```
+
+```text
+cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture
+```
+
+결과:
+
+```text
+1 passed
+```
+
+```text
+cd rhwp-studio && npm test
+```
+
+결과:
+
+```text
+49 passed
+```
+
+```text
+wasm-pack build --target web --out-dir pkg
+cd rhwp-studio && npm run build
+```
+
+결과:
+
+```text
+wasm-pack: success, rhwp v0.7.13
+npm run build: success
+```
+
+## 메모
+
+첫 `npm run build`는 로컬 `pkg/` 타입 선언이 최신 업스트림 API(`getShapeBBox`)와 맞지 않아 실패했다.
+`pkg/`를 `wasm-pack build --target web --out-dir pkg`로 `0.7.13` 기준 재생성한 뒤 빌드는 통과했다.
+`pkg/`는 Git 추적 대상이 아니므로 PR에는 포함하지 않는다.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1263,6 +1263,11 @@ export class WasmBridge {
     return this.doc.pasteInternalInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset);
   }
 
+  pasteInternalInCellByPath(sec: number, parentPara: number, pathJson: string, charOffset: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).pasteInternalInCellByPath(sec, parentPara, pathJson, charOffset);
+  }
+
   hasInternalClipboard(): boolean {
     if (!this.doc) return false;
     return this.doc.hasInternalClipboard();
@@ -1321,6 +1326,11 @@ export class WasmBridge {
   pasteHtmlInCell(sec: number, parentPara: number, controlIdx: number, cellIdx: number, cellParaIdx: number, charOffset: number, html: string): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.pasteHtmlInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset, html);
+  }
+
+  pasteHtmlInCellByPath(sec: number, parentPara: number, pathJson: string, charOffset: number, html: string): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).pasteHtmlInCellByPath(sec, parentPara, pathJson, charOffset, html);
   }
 
   // ─── CharShape (서식) API ──────────────────────────────

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -118,6 +118,31 @@ function handleNavigationShortcut(this: any, e: KeyboardEvent): boolean {
   return false;
 }
 
+function positionAfterPasteResult(pos: DocumentPosition, parsed: any): DocumentPosition {
+  const newPos: DocumentPosition = {
+    sectionIndex: pos.sectionIndex,
+    paragraphIndex: parsed.paraIdx ?? pos.paragraphIndex,
+    charOffset: parsed.charOffset ?? pos.charOffset,
+  };
+
+  if (pos.parentParaIndex !== undefined) {
+    const nextCellParaIndex = parsed.cellParaIdx ?? parsed.cellParaIndex ?? pos.cellParaIndex;
+    newPos.parentParaIndex = pos.parentParaIndex;
+    newPos.controlIndex = pos.controlIndex;
+    newPos.cellIndex = pos.cellIndex;
+    newPos.cellParaIndex = nextCellParaIndex;
+    if (pos.cellPath) {
+      newPos.cellPath = pos.cellPath.map((entry, index) =>
+        index === pos.cellPath!.length - 1
+          ? { ...entry, cellParaIndex: nextCellParaIndex ?? entry.cellParaIndex }
+          : entry,
+      );
+    }
+  }
+
+  return newPos;
+}
+
 function pastePlainText(this: any, text: string, hasSelection: boolean): void {
   if (hasSelection) {
     this.deleteSelection();
@@ -1427,7 +1452,11 @@ export function onPaste(this: any, e: ClipboardEvent): void {
       if (hasSelection) this.deleteSelection();
       const p = this.cursor.getPosition();
       let result: string;
-      if (p.parentParaIndex !== undefined) {
+      if (isNestedCellPosition(p)) {
+        result = wasm.pasteInternalInCellByPath(
+          p.sectionIndex, p.parentParaIndex!, JSON.stringify(p.cellPath), p.charOffset,
+        );
+      } else if (p.parentParaIndex !== undefined) {
         result = wasm.pasteInternalInCell(
           p.sectionIndex, p.parentParaIndex, p.controlIndex!,
           p.cellIndex!, p.cellParaIndex!, p.charOffset,
@@ -1437,18 +1466,7 @@ export function onPaste(this: any, e: ClipboardEvent): void {
       }
       const parsed = JSON.parse(result);
       if (parsed.ok) {
-        const newPos: DocumentPosition = {
-          sectionIndex: p.sectionIndex,
-          paragraphIndex: parsed.paraIdx ?? p.paragraphIndex,
-          charOffset: parsed.charOffset ?? p.charOffset,
-        };
-        if (p.parentParaIndex !== undefined) {
-          newPos.parentParaIndex = p.parentParaIndex;
-          newPos.controlIndex = p.controlIndex;
-          newPos.cellIndex = p.cellIndex;
-          newPos.cellParaIndex = parsed.paraIdx ?? p.cellParaIndex;
-        }
-        return newPos;
+        return positionAfterPasteResult(p, parsed);
       }
       return p;
     }});
@@ -1472,16 +1490,15 @@ export function onPaste(this: any, e: ClipboardEvent): void {
 
   // 외부 클립보드: HTML이 있으면 pasteHtml로 표/서식 보존 붙여넣기
   if (html) {
-    if (isNestedCellPosition(this.cursor.getPosition()) && text) {
-      pastePlainText.call(this, text, hasSelection);
-      return;
-    }
-
     this.executeOperation({ kind: 'snapshot', operationType: 'pasteHtml', operation: (wasm: WasmBridge) => {
       if (hasSelection) this.deleteSelection();
       const p = this.cursor.getPosition();
       let result: string;
-      if (p.parentParaIndex !== undefined) {
+      if (isNestedCellPosition(p)) {
+        result = wasm.pasteHtmlInCellByPath(
+          p.sectionIndex, p.parentParaIndex!, JSON.stringify(p.cellPath), p.charOffset, html,
+        );
+      } else if (p.parentParaIndex !== undefined) {
         result = wasm.pasteHtmlInCell(
           p.sectionIndex, p.parentParaIndex, p.controlIndex!,
           p.cellIndex!, p.cellParaIndex!, p.charOffset, html,
@@ -1491,18 +1508,7 @@ export function onPaste(this: any, e: ClipboardEvent): void {
       }
       const parsed = JSON.parse(result);
       if (parsed.ok) {
-        const newPos: DocumentPosition = {
-          sectionIndex: p.sectionIndex,
-          paragraphIndex: parsed.paraIdx ?? p.paragraphIndex,
-          charOffset: parsed.charOffset ?? p.charOffset,
-        };
-        if (p.parentParaIndex !== undefined) {
-          newPos.parentParaIndex = p.parentParaIndex;
-          newPos.controlIndex = p.controlIndex;
-          newPos.cellIndex = p.cellIndex;
-          newPos.cellParaIndex = parsed.paraIdx ?? p.cellParaIndex;
-        }
-        return newPos;
+        return positionAfterPasteResult(p, parsed);
       }
       return p;
     }});

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -425,6 +425,53 @@ impl DocumentCore {
         )))
     }
 
+    fn paste_paragraphs_into_cell_paragraphs(
+        cell_paras: &mut Vec<Paragraph>,
+        cell_para_idx: usize,
+        char_offset: usize,
+        clip_paras: &[Paragraph],
+    ) -> Result<(usize, usize), HwpError> {
+        if cell_para_idx >= cell_paras.len() {
+            return Err(HwpError::RenderError(format!(
+                "셀 문단 {} 범위 초과",
+                cell_para_idx
+            )));
+        }
+
+        let clip_count = clip_paras.len();
+        if clip_count == 1 && clip_paras[0].controls.is_empty() {
+            let clip_text = clip_paras[0].text.clone();
+            let new_chars = clip_text.chars().count();
+
+            cell_paras[cell_para_idx].insert_text_at(char_offset, &clip_text);
+
+            let clip_char_shapes = clip_paras[0].char_shapes.clone();
+            let clip_char_offsets = clip_paras[0].char_offsets.clone();
+            Self::apply_clipboard_char_shapes_to_para(
+                &mut cell_paras[cell_para_idx],
+                char_offset,
+                &clip_char_shapes,
+                &clip_char_offsets,
+                new_chars,
+            );
+
+            return Ok((cell_para_idx, char_offset + new_chars));
+        }
+
+        let right_half = cell_paras[cell_para_idx].split_at(char_offset);
+        cell_paras[cell_para_idx].merge_from(&clip_paras[0]);
+
+        let mut insert_idx = cell_para_idx + 1;
+        for clip_para in clip_paras.iter().skip(1) {
+            cell_paras.insert(insert_idx, clip_para.clone());
+            insert_idx += 1;
+        }
+
+        let last_para_idx = insert_idx - 1;
+        let merge_point = cell_paras[last_para_idx].merge_from(&right_half);
+        Ok((last_para_idx, merge_point))
+    }
+
     /// 내부 클립보드의 내용을 표 셀 내부에 붙여넣는다.
     pub fn paste_internal_in_cell_native(
         &mut self,
@@ -440,134 +487,51 @@ impl DocumentCore {
             _ => return Ok("{\"ok\":false,\"error\":\"clipboard empty\"}".to_string()),
         };
 
-        // 셀 접근 검증
-        let cell_para_count = {
+        let (last_para_idx, merge_point) = {
             let section =
-                self.document.sections.get(section_idx).ok_or_else(|| {
+                self.document.sections.get_mut(section_idx).ok_or_else(|| {
                     HwpError::RenderError(format!("구역 {} 범위 초과", section_idx))
                 })?;
-            let para = section.paragraphs.get(parent_para_idx).ok_or_else(|| {
+            section.raw_stream = None;
+            let para = section.paragraphs.get_mut(parent_para_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("문단 {} 범위 초과", parent_para_idx))
             })?;
-            match para.controls.get(control_idx) {
-                Some(Control::Table(t)) => {
-                    let cell = t.cells.get(cell_idx).ok_or_else(|| {
-                        HwpError::RenderError(format!("셀 {} 범위 초과", cell_idx))
-                    })?;
-                    cell.paragraphs.len()
-                }
-                Some(Control::Shape(s)) => {
-                    let tb = super::super::helpers::get_textbox_from_shape(s)
-                        .ok_or_else(|| HwpError::RenderError("글상자 없음".to_string()))?;
-                    tb.paragraphs.len()
-                }
-                Some(Control::Picture(p)) => {
-                    let cap = p
-                        .caption
-                        .as_ref()
-                        .ok_or_else(|| HwpError::RenderError("캡션 없음".to_string()))?;
-                    cap.paragraphs.len()
-                }
-                _ => return Err(HwpError::RenderError("표/글상자/캡션이 아님".to_string())),
-            }
-        };
-        if cell_para_idx >= cell_para_count {
-            return Err(HwpError::RenderError(format!(
-                "셀 문단 {} 범위 초과",
-                cell_para_idx
-            )));
-        }
-
-        self.document.sections[section_idx].raw_stream = None;
-
-        let clip_count = clip_paras.len();
-
-        // 셀 문단에 대한 가변 참조 얻기
-        let cell_paras = {
-            let section = &mut self.document.sections[section_idx];
-            let para = &mut section.paragraphs[parent_para_idx];
-            match &mut para.controls[control_idx] {
-                Control::Table(t) => &mut t.cells[cell_idx].paragraphs,
-                Control::Shape(s) => {
-                    &mut super::super::helpers::get_textbox_from_shape_mut(s)
-                        .unwrap()
+            let control = para.controls.get_mut(control_idx).ok_or_else(|| {
+                HwpError::RenderError(format!("컨트롤 {} 범위 초과", control_idx))
+            })?;
+            let cell_paras = match control {
+                Control::Table(t) => {
+                    &mut t
+                        .cells
+                        .get_mut(cell_idx)
+                        .ok_or_else(|| HwpError::RenderError(format!("셀 {} 범위 초과", cell_idx)))?
                         .paragraphs
                 }
-                Control::Picture(p) => &mut p.caption.as_mut().unwrap().paragraphs,
-                _ => unreachable!(),
-            }
+                Control::Shape(s) => {
+                    &mut super::super::helpers::get_textbox_from_shape_mut(s)
+                        .ok_or_else(|| HwpError::RenderError("글상자 없음".to_string()))?
+                        .paragraphs
+                }
+                Control::Picture(p) => {
+                    &mut p
+                        .caption
+                        .as_mut()
+                        .ok_or_else(|| HwpError::RenderError("캡션 없음".to_string()))?
+                        .paragraphs
+                }
+                _ => return Err(HwpError::RenderError("표/글상자/캡션이 아님".to_string())),
+            };
+            Self::paste_paragraphs_into_cell_paragraphs(
+                cell_paras,
+                cell_para_idx,
+                char_offset,
+                &clip_paras,
+            )?
         };
 
-        if clip_count == 1 && clip_paras[0].controls.is_empty() {
-            // 단일 문단 텍스트 붙여넣기
-            let clip_text = clip_paras[0].text.clone();
-            let new_chars = clip_text.chars().count();
-
-            cell_paras[cell_para_idx].insert_text_at(char_offset, &clip_text);
-
-            // 클립보드 글자 모양 적용
-            let clip_char_shapes = clip_paras[0].char_shapes.clone();
-            let clip_char_offsets = clip_paras[0].char_offsets.clone();
-            Self::apply_clipboard_char_shapes_to_para(
-                &mut cell_paras[cell_para_idx],
-                char_offset,
-                &clip_char_shapes,
-                &clip_char_offsets,
-                new_chars,
-            );
-
-            // 셀 리플로우
-            let _ = cell_paras;
-            self.reflow_cell_paragraph(
-                section_idx,
-                parent_para_idx,
-                control_idx,
-                cell_idx,
-                cell_para_idx,
-            );
-            // 부모 컨트롤 dirty 마킹 + 재페이지네이션
-            match self.document.sections[section_idx].paragraphs[parent_para_idx]
-                .controls
-                .get_mut(control_idx)
-            {
-                Some(Control::Table(t)) => {
-                    t.dirty = true;
-                }
-                _ => {}
-            }
-            self.mark_section_dirty(section_idx);
-            self.paginate_if_needed();
-
-            let new_offset = char_offset + new_chars;
-            self.event_log.push(DocumentEvent::ContentPasted {
-                section: section_idx,
-                para: parent_para_idx,
-            });
-            return Ok(super::super::helpers::json_ok_with(&format!(
-                "\"cellParaIdx\":{},\"charOffset\":{}",
-                cell_para_idx, new_offset
-            )));
-        }
-
-        // 다중 문단 붙여넣기
-        let right_half = cell_paras[cell_para_idx].split_at(char_offset);
-        cell_paras[cell_para_idx].merge_from(&clip_paras[0]);
-
-        let mut insert_idx = cell_para_idx + 1;
-        for i in 1..clip_count {
-            cell_paras.insert(insert_idx, clip_paras[i].clone());
-            insert_idx += 1;
-        }
-
-        let last_para_idx = insert_idx - 1;
-        let merge_point = cell_paras[last_para_idx].merge_from(&right_half);
-
-        // 셀 리플로우 (모든 영향받는 문단)
-        let _ = cell_paras;
         for i in cell_para_idx..=last_para_idx {
             self.reflow_cell_paragraph(section_idx, parent_para_idx, control_idx, cell_idx, i);
         }
-        // 부모 컨트롤 dirty 마킹 + 재페이지네이션
         match self.document.sections[section_idx].paragraphs[parent_para_idx]
             .controls
             .get_mut(control_idx)
@@ -577,6 +541,50 @@ impl DocumentCore {
             }
             _ => {}
         }
+        self.mark_section_dirty(section_idx);
+        self.paginate_if_needed();
+
+        self.event_log.push(DocumentEvent::ContentPasted {
+            section: section_idx,
+            para: parent_para_idx,
+        });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"cellParaIdx\":{},\"charOffset\":{}",
+            last_para_idx, merge_point
+        )))
+    }
+
+    /// 내부 클립보드의 내용을 cellPath가 가리키는 중첩 표 셀에 붙여넣는다.
+    pub fn paste_internal_in_cell_by_path_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        char_offset: usize,
+    ) -> Result<String, HwpError> {
+        let clip_paras = match &self.clipboard {
+            Some(c) if !c.paragraphs.is_empty() => c.paragraphs.clone(),
+            _ => return Ok("{\"ok\":false,\"error\":\"clipboard empty\"}".to_string()),
+        };
+        if path.is_empty() {
+            return Err(HwpError::RenderError("경로가 비어있습니다".to_string()));
+        }
+
+        let cell_para_idx = path[path.len() - 1].2;
+        let (last_para_idx, merge_point) = {
+            let cell_paras =
+                self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)?;
+            Self::paste_paragraphs_into_cell_paragraphs(
+                cell_paras,
+                cell_para_idx,
+                char_offset,
+                &clip_paras,
+            )?
+        };
+
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[section_idx].raw_stream = None;
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -183,60 +183,13 @@ impl DocumentCore {
         ))
     }
 
-    /// HTML 문자열을 파싱하여 셀 내부 캐럿 위치에 삽입한다.
-    pub fn paste_html_in_cell_native(
-        &mut self,
-        section_idx: usize,
-        parent_para_idx: usize,
-        control_idx: usize,
-        cell_idx: usize,
-        cell_para_idx: usize,
-        char_offset: usize,
-        html: &str,
-    ) -> Result<String, HwpError> {
-        // 셀 접근 검증
-        let cell_para_count = {
-            let section =
-                self.document.sections.get(section_idx).ok_or_else(|| {
-                    HwpError::RenderError(format!("구역 {} 범위 초과", section_idx))
-                })?;
-            let para = section.paragraphs.get(parent_para_idx).ok_or_else(|| {
-                HwpError::RenderError(format!("문단 {} 범위 초과", parent_para_idx))
-            })?;
-            let table = match para.controls.get(control_idx) {
-                Some(Control::Table(t)) => t,
-                _ => return Err(HwpError::RenderError("표가 아님".to_string())),
-            };
-            let cell = table
-                .cells
-                .get(cell_idx)
-                .ok_or_else(|| HwpError::RenderError(format!("셀 {} 범위 초과", cell_idx)))?;
-            cell.paragraphs.len()
-        };
-        if cell_para_idx >= cell_para_count {
-            return Err(HwpError::RenderError(format!(
-                "셀 문단 {} 범위 초과",
-                cell_para_idx
-            )));
-        }
-
-        let parsed_paras = self.parse_html_to_paragraphs(html);
-        if parsed_paras.is_empty() {
-            return Ok("{\"ok\":false,\"error\":\"empty html\"}".to_string());
-        }
-
-        self.document.sections[section_idx].raw_stream = None;
-
-        let clip_count = parsed_paras.len();
-
+    fn normalize_html_paragraphs_for_cell_paste(parsed_paras: Vec<Paragraph>) -> Vec<Paragraph> {
         // 셀 내부에는 Table Control 중첩 불가 → 컨트롤 포함 문단은 텍스트만 추출
-        let parsed_paras: Vec<Paragraph> = parsed_paras
+        parsed_paras
             .into_iter()
             .map(|mut p| {
                 if !p.controls.is_empty() {
-                    // 컨트롤 문단은 텍스트로 대체
                     let text = if p.text.is_empty() || p.text == "\u{0002}" {
-                        // Table/Picture 등 컨트롤 → 셀 텍스트 추출
                         match p.controls.first() {
                             Some(Control::Table(tbl)) => tbl
                                 .cells
@@ -270,19 +223,23 @@ impl DocumentCore {
                 }
                 p
             })
-            .collect();
+            .collect()
+    }
+
+    fn paste_html_paragraphs_into_cell_paragraphs(
+        cell_paras: &mut Vec<Paragraph>,
+        cell_para_idx: usize,
+        char_offset: usize,
+        parsed_paras: &[Paragraph],
+    ) -> Result<(usize, usize), HwpError> {
+        if cell_para_idx >= cell_paras.len() {
+            return Err(HwpError::RenderError(format!(
+                "셀 문단 {} 범위 초과",
+                cell_para_idx
+            )));
+        }
+
         let clip_count = parsed_paras.len();
-
-        let cell_paras = {
-            let section = &mut self.document.sections[section_idx];
-            let para = &mut section.paragraphs[parent_para_idx];
-            let table = match &mut para.controls[control_idx] {
-                Control::Table(t) => t,
-                _ => unreachable!(),
-            };
-            &mut table.cells[cell_idx].paragraphs
-        };
-
         if clip_count == 1 && parsed_paras[0].controls.is_empty() {
             let clip_text = parsed_paras[0].text.clone();
             let new_chars = clip_text.chars().count();
@@ -299,54 +256,72 @@ impl DocumentCore {
                 new_chars,
             );
 
-            let _ = cell_paras;
-            self.reflow_cell_paragraph(
-                section_idx,
-                parent_para_idx,
-                control_idx,
-                cell_idx,
-                cell_para_idx,
-            );
-            // 부모 표 dirty 마킹 + 재페이지네이션 (셀 편집 → composed 불변)
-            if let Some(Control::Table(t)) = self.document.sections[section_idx].paragraphs
-                [parent_para_idx]
-                .controls
-                .get_mut(control_idx)
-            {
-                t.dirty = true;
-            }
-            self.mark_section_dirty(section_idx);
-            self.paginate_if_needed();
-
-            let new_offset = char_offset + new_chars;
-            self.event_log.push(DocumentEvent::HtmlImported {
-                section: section_idx,
-                para: parent_para_idx,
-            });
-            return Ok(format!(
-                "{{\"ok\":true,\"cellParaIdx\":{},\"charOffset\":{}}}",
-                cell_para_idx, new_offset
-            ));
+            return Ok((cell_para_idx, char_offset + new_chars));
         }
 
-        // 다중 문단
         let right_half = cell_paras[cell_para_idx].split_at(char_offset);
         cell_paras[cell_para_idx].merge_from(&parsed_paras[0]);
 
         let mut insert_idx = cell_para_idx + 1;
-        for i in 1..clip_count {
-            cell_paras.insert(insert_idx, parsed_paras[i].clone());
+        for parsed_para in parsed_paras.iter().skip(1) {
+            cell_paras.insert(insert_idx, parsed_para.clone());
             insert_idx += 1;
         }
 
         let last_para_idx = insert_idx - 1;
         let merge_point = cell_paras[last_para_idx].merge_from(&right_half);
+        Ok((last_para_idx, merge_point))
+    }
 
-        let _ = cell_paras;
+    /// HTML 문자열을 파싱하여 셀 내부 캐럿 위치에 삽입한다.
+    pub fn paste_html_in_cell_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        cell_idx: usize,
+        cell_para_idx: usize,
+        char_offset: usize,
+        html: &str,
+    ) -> Result<String, HwpError> {
+        let parsed_paras = self.parse_html_to_paragraphs(html);
+        if parsed_paras.is_empty() {
+            return Ok("{\"ok\":false,\"error\":\"empty html\"}".to_string());
+        }
+        let parsed_paras = Self::normalize_html_paragraphs_for_cell_paste(parsed_paras);
+
+        let (last_para_idx, merge_point) = {
+            let section =
+                self.document.sections.get_mut(section_idx).ok_or_else(|| {
+                    HwpError::RenderError(format!("구역 {} 범위 초과", section_idx))
+                })?;
+            section.raw_stream = None;
+            let para = section.paragraphs.get_mut(parent_para_idx).ok_or_else(|| {
+                HwpError::RenderError(format!("문단 {} 범위 초과", parent_para_idx))
+            })?;
+            let control = para.controls.get_mut(control_idx).ok_or_else(|| {
+                HwpError::RenderError(format!("컨트롤 {} 범위 초과", control_idx))
+            })?;
+            let table = match control {
+                Control::Table(t) => t,
+                _ => return Err(HwpError::RenderError("표가 아님".to_string())),
+            };
+            let cell_paras = &mut table
+                .cells
+                .get_mut(cell_idx)
+                .ok_or_else(|| HwpError::RenderError(format!("셀 {} 범위 초과", cell_idx)))?
+                .paragraphs;
+            Self::paste_html_paragraphs_into_cell_paragraphs(
+                cell_paras,
+                cell_para_idx,
+                char_offset,
+                &parsed_paras,
+            )?
+        };
+
         for i in cell_para_idx..=last_para_idx {
             self.reflow_cell_paragraph(section_idx, parent_para_idx, control_idx, cell_idx, i);
         }
-        // 부모 표 dirty 마킹 + 재페이지네이션 (셀 편집 → composed 불변)
         if let Some(Control::Table(t)) = self.document.sections[section_idx].paragraphs
             [parent_para_idx]
             .controls
@@ -354,6 +329,53 @@ impl DocumentCore {
         {
             t.dirty = true;
         }
+        self.mark_section_dirty(section_idx);
+        self.paginate_if_needed();
+
+        self.event_log.push(DocumentEvent::HtmlImported {
+            section: section_idx,
+            para: parent_para_idx,
+        });
+        Ok(format!(
+            "{{\"ok\":true,\"cellParaIdx\":{},\"charOffset\":{}}}",
+            last_para_idx, merge_point
+        ))
+    }
+
+    /// HTML 문자열을 파싱하여 cellPath가 가리키는 중첩 표 셀에 삽입한다.
+    pub fn paste_html_in_cell_by_path_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        char_offset: usize,
+        html: &str,
+    ) -> Result<String, HwpError> {
+        if path.is_empty() {
+            return Err(HwpError::RenderError("경로가 비어있습니다".to_string()));
+        }
+
+        let parsed_paras = self.parse_html_to_paragraphs(html);
+        if parsed_paras.is_empty() {
+            return Ok("{\"ok\":false,\"error\":\"empty html\"}".to_string());
+        }
+        let parsed_paras = Self::normalize_html_paragraphs_for_cell_paste(parsed_paras);
+
+        let cell_para_idx = path[path.len() - 1].2;
+        let (last_para_idx, merge_point) = {
+            let cell_paras =
+                self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)?;
+            Self::paste_html_paragraphs_into_cell_paragraphs(
+                cell_paras,
+                cell_para_idx,
+                char_offset,
+                &parsed_paras,
+            )?
+        };
+
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[section_idx].raw_stream = None;
         self.mark_section_dirty(section_idx);
         self.paginate_if_needed();
 

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -463,7 +463,7 @@ impl DocumentCore {
     }
 
     /// 부모 컨트롤(표 또는 글상자)의 dirty를 마킹한다.
-    fn mark_cell_control_dirty(
+    pub(crate) fn mark_cell_control_dirty(
         &mut self,
         section_idx: usize,
         parent_para_idx: usize,
@@ -2609,14 +2609,14 @@ fn find_text_y(node: &crate::renderer::render_tree::RenderNode, text: &str) -> O
 // ─── 중첩 표 path 기반 편집 API ──────────────────────────────────
 
 impl DocumentCore {
-    /// cellPath를 따라가서 최종 셀의 문단에 대한 가변 참조를 얻는다.
+    /// cellPath를 따라가서 최종 셀의 문단 목록에 대한 가변 참조를 얻는다.
     /// path: [(control_index, cell_index, cell_para_index), ...]
-    pub(crate) fn get_cell_paragraph_mut_by_path(
+    pub(crate) fn get_cell_paragraphs_mut_by_path(
         &mut self,
         section_idx: usize,
         parent_para_idx: usize,
         path: &[(usize, usize, usize)],
-    ) -> Result<&mut Paragraph, HwpError> {
+    ) -> Result<&mut Vec<Paragraph>, HwpError> {
         if path.is_empty() {
             return Err(HwpError::RenderError("경로가 비어있습니다".to_string()));
         }
@@ -2644,20 +2644,36 @@ impl DocumentCore {
                 HwpError::RenderError(format!("경로[{}]: 셀 {} 범위 초과", i, cell_idx))
             })?;
             if i == path.len() - 1 {
-                // 마지막 레벨: 이 셀의 문단 반환
-                return cell.paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
-                    HwpError::RenderError(format!(
-                        "경로[{}]: 셀문단 {} 범위 초과",
-                        i, cell_para_idx
-                    ))
-                });
+                return Ok(&mut cell.paragraphs);
             }
-            // 중간 레벨: 이 셀의 문단으로 진입 후 다음 표 탐색
             para = cell.paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("경로[{}]: 셀문단 {} 범위 초과", i, cell_para_idx))
             })?;
         }
         unreachable!()
+    }
+
+    /// cellPath를 따라가서 최종 셀의 문단에 대한 가변 참조를 얻는다.
+    /// path: [(control_index, cell_index, cell_para_index), ...]
+    pub(crate) fn get_cell_paragraph_mut_by_path(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+    ) -> Result<&mut Paragraph, HwpError> {
+        if path.is_empty() {
+            return Err(HwpError::RenderError("경로가 비어있습니다".to_string()));
+        }
+        let last_path_index = path.len() - 1;
+        let cell_para_idx = path[last_path_index].2;
+        let cell_paragraphs =
+            self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)?;
+        cell_paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
+            HwpError::RenderError(format!(
+                "경로[{}]: 셀문단 {} 범위 초과",
+                last_path_index, cell_para_idx
+            ))
+        })
     }
 
     /// path 기반 셀 텍스트 삽입 (중첩 표 지원)

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -5404,6 +5404,27 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    /// 내부 클립보드의 내용을 cellPath가 가리키는 중첩 표 셀에 붙여넣는다.
+    ///
+    /// 반환값: JSON `{"ok":true,"cellParaIdx":<idx>,"charOffset":<offset>}`
+    #[wasm_bindgen(js_name = pasteInternalInCellByPath)]
+    pub fn paste_internal_in_cell_by_path(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        char_offset: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.paste_internal_in_cell_by_path_native(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            char_offset as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 선택 영역을 HTML 문자열로 변환한다 (본문).
     #[wasm_bindgen(js_name = exportSelectionHtml)]
     pub fn export_selection_html(
@@ -5534,6 +5555,27 @@ impl HwpDocument {
             control_idx as usize,
             cell_idx as usize,
             cell_para_idx as usize,
+            char_offset as usize,
+            html,
+        )
+        .map_err(|e| e.into())
+    }
+
+    /// HTML 문자열을 파싱하여 cellPath가 가리키는 중첩 표 셀에 삽입한다.
+    #[wasm_bindgen(js_name = pasteHtmlInCellByPath)]
+    pub fn paste_html_in_cell_by_path(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        char_offset: u32,
+        html: &str,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.paste_html_in_cell_by_path_native(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
             char_offset as usize,
             html,
         )

--- a/tests/issue_1198_nested_cell_paste.rs
+++ b/tests/issue_1198_nested_cell_paste.rs
@@ -1,0 +1,156 @@
+//! Issue #1198: 중첩 표 셀 내부 클립보드 붙여넣기 대상 경로 보존.
+//!
+//! 재현 문서: `samples/exam_social.hwp`
+//! 대상: 1쪽 상단 답안지 영역의 `성명` 오른쪽 빈 입력칸.
+
+use std::path::Path;
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+fn load_sample(name: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR"))
+        .join("samples")
+        .join(name);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {name}: {e}"))
+}
+
+fn hit_json(doc: &HwpDocument, page: u32, x: f64, y: f64) -> Value {
+    let json = doc
+        .hit_test_native(page, x, y)
+        .unwrap_or_else(|e| panic!("hit_test_native({page}, {x}, {y}): {e}"));
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse hit json `{json}`: {e}"))
+}
+
+fn path_tuples(hit: &Value) -> Vec<(usize, usize, usize)> {
+    hit["cellPath"]
+        .as_array()
+        .expect("cellPath array")
+        .iter()
+        .map(|entry| {
+            (
+                entry["controlIndex"].as_u64().expect("controlIndex") as usize,
+                entry["cellIndex"].as_u64().expect("cellIndex") as usize,
+                entry["cellParaIndex"].as_u64().expect("cellParaIndex") as usize,
+            )
+        })
+        .collect()
+}
+
+fn first_copyable_char(doc: &HwpDocument) -> (u32, u32, String) {
+    let para_count = doc
+        .get_paragraph_count(0)
+        .unwrap_or_else(|e| panic!("get_paragraph_count: {e:?}"));
+    for para_idx in 0..para_count {
+        let len = doc
+            .get_paragraph_length(0, para_idx)
+            .unwrap_or_else(|e| panic!("get_paragraph_length({para_idx}): {e:?}"));
+        for offset in 0..len {
+            let text = doc
+                .get_text_range(0, para_idx, offset, 1)
+                .unwrap_or_default();
+            if text
+                .chars()
+                .any(|ch| !ch.is_whitespace() && !ch.is_control())
+            {
+                return (para_idx, offset, text);
+            }
+        }
+    }
+    panic!("copyable source character not found");
+}
+
+#[test]
+fn issue_1198_exam_social_internal_paste_uses_nested_cell_path() {
+    let mut doc = load_sample("exam_social.hwp");
+
+    // 1쪽 상단 답안지 `성명` 오른쪽 빈 입력칸 내부 좌표.
+    let hit = hit_json(&doc, 0, 250.0, 210.0);
+    let path = path_tuples(&hit);
+    assert_eq!(
+        path,
+        vec![(4, 0, 3), (0, 1, 0)],
+        "exam_social.hwp name field must remain a nested cell path: {hit}"
+    );
+
+    let path_json = serde_json::to_string(&hit["cellPath"]).expect("cellPath json");
+    let char_offset = hit["charOffset"].as_u64().unwrap_or(0) as usize;
+    let (source_para, source_offset, expected) = first_copyable_char(&doc);
+    let expected_chars = expected.chars().count();
+
+    doc.copy_selection(
+        0,
+        source_para,
+        source_offset,
+        source_para,
+        source_offset + expected_chars as u32,
+    )
+    .unwrap_or_else(|e| panic!("copy_selection failed: {e:?}"));
+    assert_eq!(doc.get_clipboard_text(), expected);
+
+    let result_json = doc
+        .paste_internal_in_cell_by_path(0, 0, &path_json, char_offset as u32)
+        .unwrap_or_else(|e| panic!("paste_internal_in_cell_by_path failed: {e:?}"));
+    let result: Value = serde_json::from_str(&result_json)
+        .unwrap_or_else(|e| panic!("parse paste result `{result_json}`: {e}"));
+    assert_eq!(result["ok"].as_bool(), Some(true), "{result_json}");
+    assert_eq!(
+        result["cellParaIdx"].as_u64(),
+        Some(path[path.len() - 1].2 as u64),
+        "{result_json}"
+    );
+    assert_eq!(
+        result["charOffset"].as_u64(),
+        Some((char_offset + expected_chars) as u64),
+        "{result_json}"
+    );
+
+    let inserted = doc
+        .get_text_in_cell_by_path(0, 0, &path, char_offset, expected_chars)
+        .unwrap_or_else(|e| panic!("get_text_in_cell_by_path failed: {e}"));
+    assert_eq!(inserted, expected);
+}
+
+#[test]
+fn issue_1198_exam_social_html_paste_uses_nested_cell_path() {
+    let mut doc = load_sample("exam_social.hwp");
+
+    let hit = hit_json(&doc, 0, 250.0, 210.0);
+    let path = path_tuples(&hit);
+    assert_eq!(
+        path,
+        vec![(4, 0, 3), (0, 1, 0)],
+        "exam_social.hwp name field must remain a nested cell path: {hit}"
+    );
+
+    let path_json = serde_json::to_string(&hit["cellPath"]).expect("cellPath json");
+    let char_offset = hit["charOffset"].as_u64().unwrap_or(0) as usize;
+    let expected = "붙여넣기";
+    let html = format!(
+        "<html><body><!--StartFragment--><p>{}</p><!--EndFragment--></body></html>",
+        expected
+    );
+
+    let result_json = doc
+        .paste_html_in_cell_by_path(0, 0, &path_json, char_offset as u32, &html)
+        .unwrap_or_else(|e| panic!("paste_html_in_cell_by_path failed: {e:?}"));
+    let result: Value = serde_json::from_str(&result_json)
+        .unwrap_or_else(|e| panic!("parse paste result `{result_json}`: {e}"));
+    assert_eq!(result["ok"].as_bool(), Some(true), "{result_json}");
+    assert_eq!(
+        result["cellParaIdx"].as_u64(),
+        Some(path[path.len() - 1].2 as u64),
+        "{result_json}"
+    );
+    assert_eq!(
+        result["charOffset"].as_u64(),
+        Some((char_offset + expected.chars().count()) as u64),
+        "{result_json}"
+    );
+
+    let inserted = doc
+        .get_text_in_cell_by_path(0, 0, &path, char_offset, expected.chars().count())
+        .unwrap_or_else(|e| panic!("get_text_in_cell_by_path failed: {e}"));
+    assert_eq!(inserted, expected);
+}


### PR DESCRIPTION
## 변경 요약

- 중첩 표 셀에서 붙여넣기 대상이 바깥 셀로 해석되지 않도록 `cellPath` 기반 붙여넣기 native/WASM API를 추가했습니다.
- `rhwp-studio` 붙여넣기 라우팅에서 `cellPath.length > 1`이면 내부 클립보드와 HTML 붙여넣기 모두 path 기반 API를 사용하도록 수정했습니다.
- 붙여넣기 후 커서 위치가 같은 중첩 셀 경로를 유지하도록 `cellParaIdx`/`cellPath` 갱신을 보정했습니다.
- `samples/exam_social.hwp`의 상단 `성명` 입력칸을 대상으로 내부/HTML 붙여넣기 회귀 테스트를 추가했습니다.

## 관련 이슈

Related: #1198

## 테스트

- [x] `cargo fmt --check`
- [x] `cargo test --test issue_1198_nested_cell_paste -- --nocapture`
- [x] `cargo test --test issue_850_answer_sheet_name_hit_test issue_850_exam_social_answer_sheet_name_cell_keeps_outer_path -- --nocapture`
- [x] `cargo test --lib`
- [x] `wasm-pack build --target web --out-dir pkg`
- [x] `cd rhwp-studio && npm test`
- [x] `cd rhwp-studio && npm run build`

## 메모

- 기여자 규칙에 따라 이 PR은 이슈를 자동 종료하지 않습니다.
- PR base는 `devel`입니다.