### PR TITLE
Task #1211: rhwp-studio 입력 편집 재렌더 비용 축소

### DIFF
--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -13,7 +13,7 @@
 - [x] PR 본문에 선택안 A+C와 근거를 명시할 항목 문서화.
 - [x] 커밋 및 PR 생성: #1212.
 - [x] Stage 5 보완: 한글 IME 조합 입력의 raw 편집 경로도 page-local invalidation으로 연결.
-- [ ] Stage 5 커밋 및 PR 브랜치 업데이트.
+- [x] Stage 5 커밋 및 PR 브랜치 업데이트.
 
 ## M100 — v1.0.0 editing foundation stage
 

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -1,5 +1,24 @@
 # 2026-06-01 — 오늘 할일
 
+## Task #1211 — rhwp-studio 입력 편집 재렌더 비용 축소
+
+- [x] 이슈 생성: #1211 `rhwp-studio: 텍스트 입력 시 document-changed 기반 전체 visible page 재렌더로 입력 지연 발생`.
+- [x] 브랜치 생성: `task-1211` (`upstream/devel` 기준).
+- [x] 수행계획서 작성: `mydocs/plans/task_m100_1211.md`.
+- [x] 구현계획서 작성: `mydocs/plans/task_m100_1211_impl.md`.
+- [x] Stage 1 조사: `document-changed` full refresh 비용과 #865 이후 잔여 병목 정리.
+- [x] Stage 2 구현: page-local canvas refresh 경로 추가.
+- [x] Stage 3 구현: 셀 내부 단일 insert/delete 텍스트 편집만 narrow invalidation으로 연결.
+- [x] Stage 4 검증: `npm test`, `npm run build`, `exam_social.hwp` 수동 입력 확인.
+- [x] PR 본문에 선택안 A+C와 근거를 명시할 항목 문서화.
+- [ ] 커밋 및 PR 생성.
+
+## M100 — v1.0.0 editing foundation stage
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #1201 | HWPX masterpage XML의 EVEN/ODD 바탕쪽 파싱 및 section 연결 | 진행중 | 브랜치 `task-1201-hwpx-masterpage`, 구현계획서 작성 완료, 다음 단계: Stage 1 승인 |
+
 ## PR #1193 (Fix mac window resizing, @chkwon — rhwp 첫 기여자) — 완료
 
 - PR #1193 → **MERGED** (devel `8a2e60ca`). 연결 이슈 #1191 → CLOSED (`closes #1191`, cross-repo `--no-ff` 라 수동 클로즈).

--- a/mydocs/orders/20260601.md
+++ b/mydocs/orders/20260601.md
@@ -11,7 +11,9 @@
 - [x] Stage 3 구현: 셀 내부 단일 insert/delete 텍스트 편집만 narrow invalidation으로 연결.
 - [x] Stage 4 검증: `npm test`, `npm run build`, `exam_social.hwp` 수동 입력 확인.
 - [x] PR 본문에 선택안 A+C와 근거를 명시할 항목 문서화.
-- [ ] 커밋 및 PR 생성.
+- [x] 커밋 및 PR 생성: #1212.
+- [x] Stage 5 보완: 한글 IME 조합 입력의 raw 편집 경로도 page-local invalidation으로 연결.
+- [ ] Stage 5 커밋 및 PR 브랜치 업데이트.
 
 ## M100 — v1.0.0 editing foundation stage
 

--- a/mydocs/plans/task_m100_1211.md
+++ b/mydocs/plans/task_m100_1211.md
@@ -1,0 +1,160 @@
+# 수행계획서 — Task M100-1211: rhwp-studio 입력 편집 재렌더 비용 축소
+
+## 1. 이슈
+
+- GitHub Issue: [#1211](https://github.com/edwardkim/rhwp/issues/1211)
+- 제목: `rhwp-studio: 텍스트 입력 시 document-changed 기반 전체 visible page 재렌더로 입력 지연 발생`
+- 대상 마일스톤: M100 / v1.0.0 편집 기반
+- 브랜치: `task-1211`
+- 참고 PR: [#865](https://github.com/edwardkim/rhwp/pull/865), [#1207](https://github.com/edwardkim/rhwp/pull/1207)
+
+## 2. 문제 요약
+
+`samples/exam_social.hwp` 1쪽 상단 답안지 영역의 `성명` 입력칸에서 텍스트를 연속 입력하면 입력 반영이 느리게 느껴진다.
+
+#1207은 중첩 표 붙여넣기 대상 경로를 보존하는 correctness 수정이며, 텍스트 입력 경로에 새 렌더 호출을 추가하지 않는다.
+다만 붙여넣기 후 커서가 실제 중첩 셀 경로에 남게 되면서 기존 입력 편집 렌더 비용이 체감되기 쉬워졌다.
+
+## 3. 기존 최적화와 남은 비용
+
+#865 계열의 `getPageOverlayImages`는 overlay 이미지 목록과 `imageCount`만 필요할 때 전체 `PageLayerTree` JSON을 받지 않도록 만든 최적화다.
+현재 `PageRenderer.getOverlayImages()`도 이 API를 우선 사용하므로, overlay 추출용 대형 JSON 왕복 비용은 이미 줄어든 상태다.
+
+남은 비용 후보는 다음과 같다.
+
+```text
+InputHandler.afterEdit()
+  -> document-mutated
+  -> document-changed
+  -> CanvasView.refreshPages()
+  -> pageCount / getPageInfo 전체 재수집
+  -> recalcLayout()
+  -> releaseAllRenderedPages()
+  -> resetImageRetryState()
+  -> canvasPool.releaseAll()
+  -> updateVisiblePages()
+  -> visible page 전체 재렌더
+  -> imageCount > 0 이면 scheduleReRender / prefetchFlowImages
+```
+
+즉 문제의 본질은 `getPageOverlayImages` 부재가 아니라, 일반 텍스트 입력과 구조 변경이 모두 `document-changed` 하나로 묶여 full refresh를 타는 점이다.
+
+## 4. 접근 원칙
+
+- #1207의 붙여넣기 correctness와 독립된 성능 개선으로 진행한다.
+- `document-changed` 의미를 한 번에 대규모로 바꾸지 않는다. 기존 명령/다이얼로그/페이지 구조 변경 경로가 넓게 의존하고 있기 때문이다.
+- 먼저 일반 입력 편집 경로만 좁은 invalidation으로 분리한다.
+- 이미지/오버레이 정합성은 유지한다. `getPageOverlayImages` 최적화도 유지한다.
+- 성능 개선이 렌더 누락, 오버레이 잔상, 페이지 수/크기 갱신 누락을 만들지 않도록 보수적으로 적용한다.
+
+## 5. 수정 후보 파일
+
+| 파일 | 변경 후보 |
+|------|-----------|
+| `rhwp-studio/src/engine/input-handler.ts` | 일반 입력 편집 후 full `document-changed` 대신 좁은 페이지 invalidation 이벤트 발행 검토 |
+| `rhwp-studio/src/view/canvas-view.ts` | `refreshPages()`와 별도로 current/affected page 재렌더 메서드 추가 |
+| `rhwp-studio/src/view/page-renderer.ts` | 텍스트 입력 시 image retry state 초기화 조건 축소, 기존 retry timer 유지/취소 정책 점검 |
+| `rhwp-studio/src/core/event-bus.ts` | 필요한 경우 새 이벤트 타입 또는 payload 문서화 |
+| `rhwp-studio/tests/*.test.ts` | 새 invalidation 라우팅/렌더 호출 범위 단위 테스트 추가 |
+| `mydocs/working/task_m100_1211_stage*.md` | 단계별 완료 보고 |
+
+## 6. 구현 방향 후보
+
+### 후보 A: narrow invalidation 이벤트 추가
+
+일반 텍스트 입력 성공 후 `document-content-edited` 또는 `document-page-invalidated` 같은 좁은 이벤트를 발행한다.
+`CanvasView`는 이 이벤트를 받아 해당 page만 다시 렌더한다.
+
+장점:
+
+- full refresh와 입력 refresh의 의미가 분리된다.
+- 구조 변경성 작업의 기존 `document-changed` 계약은 유지된다.
+
+위험:
+
+- 입력으로 페이지 수/행 높이/문단 흐름이 바뀔 수 있으므로 affected page 판단을 보수적으로 해야 한다.
+
+### 후보 B: `refreshPages()` 내부 최적화
+
+`refreshPages()`는 유지하되, 단순 입력 편집 reason을 받으면 page info 재수집과 image retry reset을 생략한다.
+
+장점:
+
+- 이벤트 표면 변경이 적다.
+
+위험:
+
+- `document-changed`의 의미가 reason 문자열에 의존해 암묵적으로 갈라진다.
+
+### 후보 C: image retry reset 조건 축소
+
+텍스트 입력에서는 `resetImageRetryState()`를 호출하지 않는다.
+
+장점:
+
+- 이미지가 있는 페이지에서 불필요한 재시도 루프를 줄일 수 있다.
+
+위험:
+
+- 이미지 payload/topology가 바뀌는 작업에서는 반드시 reset이 필요하므로 호출 경로 분류가 필요하다.
+
+## 7. 기본안
+
+기본안은 A + C를 작게 적용한다.
+
+```text
+1. 일반 입력 편집 후에는 좁은 invalidation 이벤트를 발행한다.
+2. CanvasView는 해당 page 또는 현재 visible page 범위 중 최소 범위만 재렌더한다.
+3. 단순 텍스트 입력에서는 image retry state를 전체 초기화하지 않는다.
+4. 구조 변경/페이지 설정/이미지 삽입/삭제/줌/문서 로드 경로는 기존 full refresh를 유지한다.
+```
+
+다만 Stage 1 측정에서 `prefetchFlowImages()`의 전체 `PageLayerTree` 호출이 주된 병목으로 확인되면, flow image 전용 좁은 API 또는 캐시를 후속 Stage로 분리한다.
+
+## 8. 검증 계획
+
+최소 검증:
+
+```text
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+```
+
+성능/동작 확인:
+
+```text
+samples/exam_social.hwp 1쪽 성명 입력칸 연속 입력
+이미지 포함 페이지에서 overlay/flow 이미지 렌더 유지
+텍스트 입력 후 caret 위치 유지
+```
+
+필요 시:
+
+```text
+wasm-pack build --target web --out-dir pkg
+cargo test --lib
+```
+
+## 9. 완료 기준
+
+```text
+1. 일반 텍스트 입력 1회가 보이는 모든 페이지의 full refresh와 image retry reset을 매번 유발하지 않는다.
+2. exam_social.hwp 성명 칸에서 연속 입력 반응성이 개선된다.
+3. 이미지/오버레이 렌더 정합성은 유지된다.
+4. 페이지 수/크기 변경 가능성이 있는 작업은 기존 full refresh를 유지한다.
+5. rhwp-studio 테스트와 빌드가 통과한다.
+```
+
+## 10. 승인 요청
+
+위 방향으로 구현계획서 작성 및 Stage 1 착수를 진행한다.
+
+## 11. PR 본문 필수 명시 사항
+
+추후 PR에는 다음 판단을 별도 섹션으로 명시한다.
+
+- 선택안: 후보 A + C.
+- 후보 A 선택 이유: `document-changed`가 구조 변경과 단순 입력 편집을 모두 대표해 full refresh를 강제하므로, 텍스트 입력에는 별도 `document-page-invalidated` 경로를 두어 의미를 분리한다.
+- 후보 C 선택 이유: 단순 텍스트 입력은 이미지 payload/topology를 바꾸지 않으므로, 매 입력마다 `resetImageRetryState()`와 flow image 재시도 예약을 반복할 필요가 없다.
+- #865와의 관계: #865의 `getPageOverlayImages`는 overlay JSON 왕복 비용을 줄인 기존 최적화이며, 이번 작업은 그 이후에도 남는 `document-changed -> refreshPages() -> resetImageRetryState()` 비용을 줄이는 별도 개선이다.
+- 제외/보수 범위: 이번 PR은 셀 내부 단일 insert/delete 텍스트 편집만 narrow invalidation에 태우고, 본문 문단 편집/붙여넣기/문단 분할·병합/객체·표 구조 변경은 기존 full refresh를 유지한다.

--- a/mydocs/plans/task_m100_1211_impl.md
+++ b/mydocs/plans/task_m100_1211_impl.md
@@ -1,0 +1,158 @@
+# 구현계획서 — Task M100-1211: 입력 편집 narrow invalidation
+
+## 설계 요약
+
+현재 `InputHandler.afterEdit()`는 모든 편집 후 `document-changed`를 발행한다.
+`CanvasView`는 이 이벤트를 full refresh로 해석해 page info 전체 재수집, 모든 visible canvas release, image retry state reset을 수행한다.
+
+이번 작업은 일반 텍스트 입력처럼 변경 범위가 좁은 편집을 별도 invalidation 경로로 분리한다.
+구조 변경 가능성이 큰 작업은 기존 `document-changed` full refresh 경로를 유지한다.
+
+선택안은 후보 A + C이다. 이벤트 의미를 분리하는 A를 기본 축으로 삼고, 이 경로에서는 full refresh에 포함된 `resetImageRetryState()`를 호출하지 않아 C의 효과를 함께 얻는다. 후보 B처럼 `document-changed`에 reason을 추가하는 방식은 호출 계약이 계속 넓고 모호해질 수 있어 이번 PR의 기본안에서 제외한다. 후보 D의 flow image 전용 API는 WASM API 표면을 늘리므로 A+C 적용 후에도 병목이 남을 때 후속 이슈로 검토한다.
+
+## Stage 1 — 기준 비용 확인과 이벤트 경계 정리
+
+**목표**: 실제 입력 경로에서 어떤 이벤트와 렌더 호출이 반복되는지 코드/간단 계측으로 확인하고, 소스 변경 범위를 확정한다.
+
+작업:
+
+- `InputHandler.executeOperation()`의 `command` 경로와 `snapshot` 경로를 분리해 확인한다.
+- `afterEdit()` 호출자가 어떤 작업인지 분류한다.
+- `CanvasView.refreshPages()`가 수행하는 full refresh 항목을 확정한다.
+- `PageRenderer.scheduleReRender()` / `prefetchFlowImages()`가 입력 중 반복 예약되는 조건을 확인한다.
+- 필요한 경우 개발용 계측 로그를 임시로 사용하되, PR에는 남기지 않는다.
+
+산출:
+
+- `mydocs/working/task_m100_1211_stage1.md`
+- 구현 범위 확정:
+  - 일반 `InsertTextCommand` / `DeleteTextCommand` / IME 확정 입력을 narrow invalidation 대상으로 볼지
+  - snapshot/paste는 Stage 1에서는 full refresh 유지할지
+
+검증:
+
+```text
+cd rhwp-studio && npm test
+```
+
+## Stage 2 — `CanvasView` narrow page refresh 추가
+
+**목표**: full `refreshPages()`와 별도로 현재 page만 재렌더하는 API를 추가한다.
+
+변경 후보:
+
+- `rhwp-studio/src/view/canvas-view.ts`
+  - `document-page-invalidated` 이벤트 처리 추가.
+  - 기존 canvas를 유지한 채 다시 그리는 `renderCanvas(pageIdx, canvas)` 분리.
+  - page info 전체 재수집과 `recalcLayout()`은 full refresh에만 유지한다.
+  - 단일 page refresh에서는 해당 page canvas와 overlay/grid만 갱신한다.
+  - 단순 텍스트 입력 경로에서는 `resetImageRetryState()` 전체 초기화를 피한다.
+
+- `rhwp-studio/src/view/page-renderer.ts`
+  - 특정 page retry state만 유지/취소할 수 있는 메서드가 필요한지 점검한다.
+  - 기존 `cancelReRender(pageIdx)`는 유지하되, full reset과 page-local reset을 분리할 수 있는지 확인한다.
+
+테스트:
+
+- `CanvasView`를 직접 테스트하기 어렵다면 `PageRenderer` 또는 event routing 단위 테스트를 우선 추가한다.
+- DOM 의존성이 커서 단위 테스트가 과도하면, 최소한 TypeScript 빌드와 수동 검증으로 제한하고 보고서에 남긴다.
+
+보고서:
+
+- `mydocs/working/task_m100_1211_stage2.md`
+
+## Stage 3 — 입력 편집 경로를 narrow invalidation으로 연결
+
+**목표**: 일반 텍스트 입력 후 full `document-changed` 대신 좁은 invalidation을 사용한다.
+
+변경 후보:
+
+- `rhwp-studio/src/engine/input-handler.ts`
+  - `afterEdit()`는 기본 full refresh로 유지한다.
+  - 새 메서드 `afterPageLocalEdit()`를 추가한다.
+  - `executeOperation({ kind: 'command' })` 중 셀 내부 `insertText` / `deleteText`처럼 범위가 좁은 명령은 새 메서드를 호출한다.
+  - snapshot/paste/object/table/page 설정 등은 기존 `afterEdit()` 유지.
+
+- `rhwp-studio/src/engine/input-edit-invalidation.ts`
+  - page-local text edit 판정 helper를 순수 함수로 분리한다.
+  - 단위 테스트에서 narrow/full refresh 분기 조건을 검증한다.
+
+- 이벤트 이름 후보:
+
+```text
+document-page-invalidated
+payload: { pageIndex?: number; reason: 'text-edit' | ... }
+```
+
+pageIndex는 현재 cursor rect 또는 command 실행 후 cursor rect에서 얻는다.
+pageIndex를 얻지 못하면 안전하게 기존 `document-changed` full refresh로 fallback한다.
+
+주의:
+
+- 문단 분할/병합, 표 행 높이 변화, 페이지 넘어감 가능성이 큰 명령은 Stage 3 기본 범위에서 full refresh로 유지한다.
+- 단일 텍스트 삽입/삭제도 페이지 흐름을 바꿀 수 있으므로, affected page 단일 갱신이 충분하지 않은지 Stage 1/수동 검증에서 확인한다.
+- 이번 1차 적용은 표 셀 내부 동일 cellPath의 insert/delete에 한정한다. 본문 문단 입력은 같은 텍스트 명령이라도 page flow 변동 가능성이 커서 full refresh를 유지한다.
+
+보고서:
+
+- `mydocs/working/task_m100_1211_stage3.md`
+
+## Stage 4 — flow image prefetch 비용 후속 보정 여부 판단
+
+**목표**: Stage 2~3 적용 후에도 이미지 페이지 입력 지연이 남는지 확인하고, `prefetchFlowImages()`의 전체 `getPageLayerTree()` 호출을 다룰지 결정한다.
+
+선택지:
+
+1. 지연이 충분히 개선되면 Stage 4는 조사 보고만 하고 구현 생략.
+2. 여전히 큰 비용이면 작은 API를 추가한다.
+
+API 후보:
+
+```text
+getPageFlowImages(pageIdx) -> { imageCount, dataUrls? }
+```
+
+또는 `getPageOverlayImages` 응답 확장은 기존 의미가 흐려질 수 있으므로 우선 별도 API를 선호한다.
+
+보고서:
+
+- `mydocs/working/task_m100_1211_stage4.md`
+
+## Stage 5 — 최종 검증과 보고
+
+검증:
+
+```text
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+```
+
+필요 시:
+
+```text
+wasm-pack build --target web --out-dir pkg
+cargo test --lib
+```
+
+수동 확인:
+
+```text
+samples/exam_social.hwp
+1쪽 성명 입력칸 연속 입력
+이미지/오버레이 표시 유지
+caret 위치 유지
+```
+
+최종 보고:
+
+- `mydocs/report/task_m100_1211_report.md`
+
+## 제외 범위
+
+- 모든 `document-changed` 발행 지점을 한 PR에서 전면 교체하지 않는다.
+- 페이지네이션/레이아웃 엔진 자체 최적화는 이번 범위가 아니다.
+- #1207의 중첩 표 붙여넣기 path correctness는 이 PR에 포함하지 않는다.
+
+## 승인 요청
+
+위 구현계획에 따라 Stage 1을 시작한다.

--- a/mydocs/report/task_m100_1211_report.md
+++ b/mydocs/report/task_m100_1211_report.md
@@ -25,7 +25,12 @@
 
 - `rhwp-studio/src/engine/input-handler.ts`
   - command 실행 전/후 위치를 비교해 셀 내부 단일 text insert/delete만 page-local 경로로 보냄.
+  - command를 거치지 않는 IME/iOS raw 텍스트 입력용 `afterTextInputEdit()` 라우터 추가.
   - header/footer, footnote, snapshot/paste, 문단/표/객체 구조 변경은 기존 `afterEdit()` full refresh 유지.
+
+- `rhwp-studio/src/engine/input-handler-text.ts`
+  - 한글 IME 조합 중 `insertTextAtRaw()` / `deleteTextAt()` 후에도 page-local 라우터를 사용.
+  - iOS composition fallback의 debounce 렌더도 같은 라우터를 사용.
 
 - `rhwp-studio/src/engine/input-edit-invalidation.ts`
   - page-local text edit 판정 helper를 순수 함수로 분리.
@@ -47,6 +52,7 @@ cd rhwp-studio && npm run build
 - `http://127.0.0.1:7700/?url=/samples/exam_social.hwp&filename=exam_social.hwp`
 - 1쪽 상단 `성명` 칸에 `테스트` 입력.
 - 입력 반영 확인, 브라우저 console error 없음.
+- Stage 5 보완 후 한글 입력 경로에서도 browser console error 없음.
 
 ## 잔여 범위
 

--- a/mydocs/report/task_m100_1211_report.md
+++ b/mydocs/report/task_m100_1211_report.md
@@ -1,0 +1,53 @@
+# Task M100-1211 최종 보고 — rhwp-studio 입력 편집 재렌더 비용 축소
+
+## 요약
+
+`rhwp-studio`의 셀 내부 텍스트 입력이 매 키 입력마다 `document-changed -> refreshPages()` full refresh를 타면서 visible page 전체 재렌더와 `resetImageRetryState()`를 반복하던 비용을 줄였다.
+
+## 선택안과 근거
+
+선택안은 후보 A + C이다.
+
+- 후보 A: 텍스트 입력 전용 `document-page-invalidated` 이벤트를 추가해 구조 변경용 `document-changed`와 의미를 분리했다.
+- 후보 C: 이 narrow invalidation 경로에서는 `refreshPages()`를 호출하지 않으므로 `resetImageRetryState()`도 매 입력마다 반복하지 않는다.
+
+이 선택은 #865의 `getPageOverlayImages`와 별개다. #865는 overlay 이미지 목록 추출 시 대형 `PageLayerTree` JSON 왕복을 줄였고, 이번 작업은 그 이후에도 남아 있던 full `document-changed` refresh 비용을 줄인다.
+
+후보 B는 `document-changed`에 reason을 붙이는 방식이라 이벤트 계약이 계속 모호해질 수 있어 제외했다. 후보 D의 flow image 전용 API는 WASM API 표면을 늘리므로, A+C 적용 후에도 병목이 남는 경우 후속 이슈로 다루는 것이 낫다.
+
+## 구현
+
+- `rhwp-studio/src/view/canvas-view.ts`
+  - `document-page-invalidated` 이벤트 처리 추가.
+  - 기존 canvas를 유지한 채 해당 page만 다시 그리는 `renderCanvas()` 분리.
+  - narrow 경로에서는 page info 재수집, layout 재계산, 전체 canvas release, image retry reset을 생략.
+  - page count 변동 또는 유효하지 않은 page index는 기존 full refresh로 fallback.
+
+- `rhwp-studio/src/engine/input-handler.ts`
+  - command 실행 전/후 위치를 비교해 셀 내부 단일 text insert/delete만 page-local 경로로 보냄.
+  - header/footer, footnote, snapshot/paste, 문단/표/객체 구조 변경은 기존 `afterEdit()` full refresh 유지.
+
+- `rhwp-studio/src/engine/input-edit-invalidation.ts`
+  - page-local text edit 판정 helper를 순수 함수로 분리.
+
+- `rhwp-studio/tests/input-edit-invalidation.test.ts`
+  - 셀 내부 insert/delete 허용, 본문/구조 변경/full refresh fallback 조건 검증.
+
+## 검증
+
+```text
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+```
+
+모두 통과.
+
+수동 확인:
+
+- `http://127.0.0.1:7700/?url=/samples/exam_social.hwp&filename=exam_social.hwp`
+- 1쪽 상단 `성명` 칸에 `테스트` 입력.
+- 입력 반영 확인, 브라우저 console error 없음.
+
+## 잔여 범위
+
+본문 문단 입력까지 narrow invalidation을 확장하는 일은 이번 PR에서 제외한다. 본문 입력은 페이지 flow 변동 가능성이 크므로, affected page 범위 계산이나 layout invalidation 정책을 더 분명히 한 후 별도 개선으로 진행하는 것이 안전하다.

--- a/mydocs/working/task_m100_1211_stage1.md
+++ b/mydocs/working/task_m100_1211_stage1.md
@@ -1,0 +1,25 @@
+# Task M100-1211 Stage 1 완료 보고 — 입력 편집 렌더 비용 원인 정리
+
+## 범위
+
+`samples/exam_social.hwp` 1쪽 상단 `성명` 입력칸에서 텍스트 입력이 느리게 반영되는 원인을 코드 기준으로 재확인했다.
+
+## 확인 내용
+
+- #1207의 중첩 표 붙여넣기 수정은 텍스트 입력마다 새 render 호출을 추가하지 않는다.
+- 입력 지연의 직접 경로는 기존 `InputHandler.afterEdit() -> document-changed -> CanvasView.refreshPages()`이다.
+- `refreshPages()`는 page info 재수집, layout 재계산, visible canvas release, `resetImageRetryState()`, visible page 재렌더를 매 입력마다 수행한다.
+- #865의 `getPageOverlayImages`는 overlay 이미지 목록 추출 시 대형 `PageLayerTree` JSON 왕복을 줄이는 최적화다. 그러나 full `document-changed` 자체가 반복되는 비용, 그리고 full refresh에 딸린 image retry reset 비용은 별도로 남아 있다.
+
+## 선택안
+
+후보 A + C를 선택한다.
+
+- A: 텍스트 입력용 narrow invalidation 이벤트를 추가해 `document-changed`의 구조 변경 의미와 분리한다.
+- C: narrow invalidation 경로에서는 `refreshPages()`를 호출하지 않으므로 `resetImageRetryState()`도 매 입력마다 반복하지 않는다.
+
+후보 B는 `document-changed`에 reason을 붙여 내부 분기하는 방식이라 기존 이벤트 의미가 계속 넓어질 위험이 있다. 후보 D는 새 WASM API를 늘리는 작업이므로 A+C 이후에도 flow image prefetch 비용이 남을 때 후속 이슈로 분리한다.
+
+## 다음 단계
+
+`CanvasView`에 page-local refresh 경로를 추가하고, 입력 라우터는 보수적으로 셀 내부 단일 insert/delete 텍스트 편집만 새 경로로 연결한다.

--- a/mydocs/working/task_m100_1211_stage2.md
+++ b/mydocs/working/task_m100_1211_stage2.md
@@ -1,0 +1,18 @@
+# Task M100-1211 Stage 2 완료 보고 — CanvasView page-local refresh
+
+## 변경 내용
+
+- `CanvasView`가 `document-page-invalidated` 이벤트를 구독하도록 추가했다.
+- 기존 `renderPage()`의 실제 렌더 로직을 `renderCanvas(pageIdx, canvas)`로 분리했다.
+- narrow invalidation에서는 page info 전체 재수집, `recalcLayout()`, `releaseAllRenderedPages()`, `resetImageRetryState()`를 수행하지 않고 기존 canvas를 유지한 채 해당 page만 다시 그린다.
+- page index가 유효하지 않거나 page count가 달라진 경우에는 기존 `refreshPages()` full refresh로 fallback한다.
+
+## 보수 장치
+
+- 렌더 실패 시 해당 canvas를 release하고 visible page 갱신으로 fallback한다.
+- 페이지 수가 바뀌는 경우 narrow 경로를 사용하지 않는다.
+- overlay/grid는 `PageRenderer.applyOverlays()`와 `renderGridOverlay()`가 기존 page 단위 제거/갱신 로직을 재사용한다.
+
+## 다음 단계
+
+입력 명령 라우터에서 셀 내부 단일 텍스트 insert/delete만 `document-page-invalidated`로 연결한다.

--- a/mydocs/working/task_m100_1211_stage3.md
+++ b/mydocs/working/task_m100_1211_stage3.md
@@ -1,0 +1,26 @@
+# Task M100-1211 Stage 3 완료 보고 — 입력 라우팅 연결
+
+## 변경 내용
+
+- `InputHandler.executeOperation()`의 command 경로에서 실행 전/후 `DocumentPosition`을 비교한다.
+- `afterEdit()`는 full refresh 기본 경로로 유지했다.
+- `afterPageLocalEdit()`를 추가해 dirty 상태 갱신용 `document-mutated`는 유지하면서, 렌더 갱신은 `document-page-invalidated`로 보낸다.
+- page-local 판정은 `input-edit-invalidation.ts`의 순수 helper로 분리하고 단위 테스트를 추가했다.
+
+## narrow invalidation 대상
+
+- `insertText`
+- `deleteText`
+- 실행 전/후가 같은 section, parent paragraph, control, cell, cell paragraph, cellPath에 남아 있는 표 셀 내부 편집
+
+## full refresh 유지 대상
+
+- 본문 문단 텍스트 입력
+- header/footer, footnote
+- 붙여넣기, snapshot 기반 작업
+- 문단 분할/병합, 선택 삭제
+- 표/객체/페이지/서식 대화상자 등 구조 변경 가능 작업
+
+## PR 명시 필요 사항
+
+PR 본문에는 이번 선택이 #865 대체가 아니라 #865 이후에도 남는 full `document-changed` 비용을 줄이는 작업임을 적는다. 또한 A+C 선택 이유와 후보 B/D를 이번 PR에서 제외한 이유를 명시한다.

--- a/mydocs/working/task_m100_1211_stage4.md
+++ b/mydocs/working/task_m100_1211_stage4.md
@@ -1,0 +1,41 @@
+# Task M100-1211 Stage 4 완료 보고 — 검증
+
+## 자동 검증
+
+```text
+cd rhwp-studio && npm test
+```
+
+결과: 통과.
+
+```text
+tests 52
+pass 52
+fail 0
+```
+
+```text
+cd rhwp-studio && npm run build
+```
+
+결과: 통과.
+
+Vite 빌드 중 `fs`/`path` browser externalization 및 500 kB 이상 chunk 경고가 출력되었으나, 기존 CanvasKit/Vite 빌드 경고이며 이번 변경의 실패는 아니다.
+
+## 수동 검증
+
+브라우저에서 다음 URL로 `samples/exam_social.hwp`를 로드했다.
+
+```text
+http://127.0.0.1:7700/?url=/samples/exam_social.hwp&filename=exam_social.hwp
+```
+
+확인:
+
+- 1쪽 상단 `성명` 칸에 `테스트` 입력.
+- 입력 텍스트가 셀 내부에 반영됨.
+- 브라우저 console error 없음.
+
+## 검증 결론
+
+이번 변경은 `exam_social.hwp`의 셀 내부 단일 텍스트 입력에 대해 full `document-changed` refresh 대신 page-local invalidation을 사용한다. 빌드/테스트/수동 입력 확인 기준으로 기능 회귀는 발견되지 않았다.

--- a/mydocs/working/task_m100_1211_stage5.md
+++ b/mydocs/working/task_m100_1211_stage5.md
@@ -1,0 +1,47 @@
+# Task M100-1211 Stage 5 완료 보고 — IME 조합 입력 경로 보완
+
+## 배경
+
+PR #1212 생성 후 로컬 확인에서 한글 텍스트 입력이 여전히 느리게 느껴진다는 피드백이 있었다.
+
+기존 Stage 2~3 구현은 `executeOperation({ kind: 'command' })`를 타는 일반 `insertText` / `deleteText` 명령만 narrow invalidation으로 보냈다. 하지만 한글 IME 조합 중 입력은 `input-handler-text.ts`에서 `insertTextAtRaw()` / `deleteTextAt()`로 WASM을 직접 갱신한 뒤 `afterEdit()`를 호출한다.
+
+따라서 IME 조합 중에는 여전히 다음 full refresh 경로가 반복되었다.
+
+```text
+raw insert/delete
+  -> afterEdit()
+  -> document-changed
+  -> CanvasView.refreshPages()
+  -> resetImageRetryState()
+  -> visible page 재렌더
+```
+
+## 변경 내용
+
+- `InputHandler.afterTextInputEdit(beforePos, afterPos)`를 추가했다.
+  - command를 거치지 않는 raw 텍스트 입력도 `isPageLocalTextEditCommand()` 판정을 재사용한다.
+  - 셀 내부 같은 `cellPath`에 남아 있으면 `afterPageLocalEdit()`를 호출한다.
+  - header/footer, footnote, 본문 문단 등은 기존 `afterEdit()` full refresh를 유지한다.
+
+- `input-handler-text.ts`
+  - IME 조합 중 raw insert/delete 후 `afterEdit()` 대신 `afterTextInputEdit(anchor, currentPosition)`를 호출한다.
+  - iOS composition fallback의 debounce 후 렌더도 같은 라우터를 사용한다.
+
+## 검증
+
+```text
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+```
+
+결과: 모두 통과.
+
+브라우저 수동 확인:
+
+- `http://127.0.0.1:7700/?url=/samples/exam_social.hwp&filename=exam_social.hwp`
+- 한글 텍스트 입력 후 browser console error 없음.
+
+## 결론
+
+Stage 5 보완으로 일반 command 입력뿐 아니라 한글 IME 조합 중 raw 텍스트 편집도 같은 narrow invalidation 정책을 사용한다. 사용자가 체감한 한글 입력 지연의 직접 원인이던 `afterEdit()` full refresh 반복을 셀 내부 입력 경로에서 제거했다.

--- a/rhwp-studio/src/engine/input-edit-invalidation.ts
+++ b/rhwp-studio/src/engine/input-edit-invalidation.ts
@@ -1,0 +1,39 @@
+import type { CellPathEntry, DocumentPosition } from '@/core/types';
+
+const PAGE_LOCAL_TEXT_COMMANDS = new Set(['insertText', 'deleteText']);
+
+function sameCellPath(a: CellPathEntry[] | undefined, b: CellPathEntry[] | undefined): boolean {
+  const left = a ?? [];
+  const right = b ?? [];
+  if (left.length !== right.length) return false;
+  return left.every((value, index) => {
+    const other = right[index];
+    return (
+      value.controlIndex === other.controlIndex &&
+      value.cellIndex === other.cellIndex &&
+      value.cellParaIndex === other.cellParaIndex
+    );
+  });
+}
+
+/**
+ * 페이지 단위 canvas 재렌더만으로 처리할 수 있는 보수적인 텍스트 편집인지 판정한다.
+ *
+ * 현재는 표 셀 내부의 단일 insert/delete 텍스트 편집만 허용한다. 본문 문단 편집,
+ * 문단 병합/분할, 붙여넣기, 객체/표 구조 변경은 page flow 변동 가능성이 크므로
+ * 기존 full document refresh 경로를 유지한다.
+ */
+export function isPageLocalTextEditCommand(
+  commandType: string,
+  beforePos: DocumentPosition,
+  afterPos: DocumentPosition,
+): boolean {
+  if (!PAGE_LOCAL_TEXT_COMMANDS.has(commandType)) return false;
+  if (beforePos.parentParaIndex === undefined || afterPos.parentParaIndex === undefined) return false;
+  if (beforePos.sectionIndex !== afterPos.sectionIndex) return false;
+  if (beforePos.parentParaIndex !== afterPos.parentParaIndex) return false;
+  if (beforePos.controlIndex !== afterPos.controlIndex) return false;
+  if (beforePos.cellIndex !== afterPos.cellIndex) return false;
+  if (beforePos.cellParaIndex !== afterPos.cellParaIndex) return false;
+  return sameCellPath(beforePos.cellPath, afterPos.cellPath);
+}

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -374,7 +374,7 @@ export function onInput(this: any, e?: InputEvent): void {
       }
     }
 
-    this.afterEdit();
+    this.afterTextInputEdit(anchor, this.cursor.getPosition());
     return;
   }
 
@@ -426,8 +426,9 @@ export function onInput(this: any, e?: InputEvent): void {
     // 렌더링 디바운스: 빠른 연속 입력 중에는 렌더링 생략,
     // 마지막 입력 후 100ms 뒤에 한 번만 렌더링
     clearTimeout(this._iosInputTimer);
+    const iosAnchor = this._iosAnchor;
     this._iosInputTimer = setTimeout(() => {
-      this.afterEdit();
+      this.afterTextInputEdit(iosAnchor, this.cursor.getPosition());
       // 렌더링 후 div 포커스 복원 (afterEdit가 포커스를 뺏을 수 있음)
       this.textarea.focus();
     }, 100);

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -23,6 +23,7 @@ import * as _table from './input-handler-table';
 import * as _keyboard from './input-handler-keyboard';
 import * as _text from './input-handler-text';
 import * as _picture from './input-handler-picture';
+import { isPageLocalTextEditCommand } from './input-edit-invalidation';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const DRAG_SCROLL_EDGE_PX = 48;
@@ -1598,13 +1599,18 @@ export class InputHandler {
   executeOperation(desc: OperationDescriptor): void {
     switch (desc.kind) {
       case 'command': {
+        const beforePos = this.cursor.getPosition();
         const newPos = this.history.execute(desc.command, this.wasm);
         // 글자 서식 변경은 문서 구조 불변 → 선택 영역 유지
         if (desc.command.type !== 'applyCharFormat') {
           this.cursor.moveTo(newPos);
           this.cursor.resetPreferredX();
         }
-        this.afterEdit();
+        if (this.shouldUsePageLocalRefresh(desc.command.type, beforePos, newPos)) {
+          this.afterPageLocalEdit();
+        } else {
+          this.afterEdit();
+        }
         break;
       }
       case 'snapshot': {
@@ -1674,6 +1680,24 @@ export class InputHandler {
     this.eventBus.emit('document-mutated', 'input-handler-edit');
     this.eventBus.emit('document-changed');
     this.updateCaret();
+  }
+
+  /** 셀 내부 단일 텍스트 편집 후 처리: 현재 페이지 canvas만 갱신한다. */
+  private afterPageLocalEdit(): void {
+    this.lastCellKey = null;
+    this.eventBus.emit('document-mutated', 'input-handler-edit');
+    const pageIndex = this.cursor.getRect()?.pageIndex;
+    if (typeof pageIndex === 'number' && Number.isInteger(pageIndex) && pageIndex >= 0) {
+      this.eventBus.emit('document-page-invalidated', { pageIndex, reason: 'text-edit' });
+    } else {
+      this.eventBus.emit('document-changed');
+    }
+    this.updateCaret();
+  }
+
+  private shouldUsePageLocalRefresh(commandType: string, beforePos: DocumentPosition, afterPos: DocumentPosition): boolean {
+    if (this.cursor.isInHeaderFooter() || this.cursor.isInFootnote()) return false;
+    return isPageLocalTextEditCommand(commandType, beforePos, afterPos);
   }
 
   /**

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1695,6 +1695,15 @@ export class InputHandler {
     this.updateCaret();
   }
 
+  /** raw IME/iOS 텍스트 입력처럼 command를 거치지 않는 경로의 갱신 라우터. */
+  private afterTextInputEdit(beforePos: DocumentPosition, afterPos: DocumentPosition): void {
+    if (this.shouldUsePageLocalRefresh('insertText', beforePos, afterPos)) {
+      this.afterPageLocalEdit();
+    } else {
+      this.afterEdit();
+    }
+  }
+
   private shouldUsePageLocalRefresh(commandType: string, beforePos: DocumentPosition, afterPos: DocumentPosition): boolean {
     if (this.cursor.isInHeaderFooter() || this.cursor.isInFootnote()) return false;
     return isPageLocalTextEditCommand(commandType, beforePos, afterPos);

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -45,6 +45,7 @@ export class CanvasView {
       eventBus.on('viewport-scroll', () => this.updateVisiblePages()),
       eventBus.on('viewport-resize', () => this.onViewportResize()),
       eventBus.on('zoom-changed', (zoom) => this.onZoomChanged(zoom as number)),
+      eventBus.on('document-page-invalidated', (payload) => this.refreshInvalidatedPage(payload)),
       eventBus.on('document-changed', () => this.refreshPages()),
       eventBus.on('document-view-changed', () => this.refreshPages()),
       eventBus.on('grid-view-changed', () => this.refreshGridOverlays()),
@@ -143,14 +144,23 @@ export class CanvasView {
   /** 단일 페이지를 렌더링한다 */
   private renderPage(pageIdx: number): void {
     const canvas = this.canvasPool.acquire(pageIdx);
+    if (!canvas.parentElement) {
+      this.scrollContent.appendChild(canvas);
+    }
+    if (!this.renderCanvas(pageIdx, canvas)) {
+      this.canvasPool.release(pageIdx);
+    }
+  }
+
+  /** 기존 canvas를 유지한 채 페이지 내용을 다시 그린다. */
+  private renderCanvas(pageIdx: number, canvas: HTMLCanvasElement): boolean {
     const zoom = this.viewportManager.getZoom();
     const rawDpr = window.devicePixelRatio || 1;
 
     const pageInfo = this.pages[pageIdx];
     if (!pageInfo) {
       console.error(`[CanvasView] 페이지 ${pageIdx} 정보가 없습니다`);
-      this.canvasPool.release(pageIdx);
-      return;
+      return false;
     }
     // iOS/WebKit과 GPU surface가 감당하기 어려운 물리 픽셀 수를 중앙 정책으로 제한한다.
     const renderScale = clampRenderScale(pageInfo, zoom * rawDpr);
@@ -169,8 +179,6 @@ export class CanvasView {
       canvas.style.transform = 'translateX(-50%)';
     }
 
-    this.scrollContent.appendChild(canvas);
-
     // WASM이 Canvas 크기를 자동 설정한다 (물리 픽셀 = 페이지크기 × zoom × DPR)
     try {
       this.pageRenderer.renderPage(pageIdx, canvas, renderScale, zoom, dpr);
@@ -178,14 +186,14 @@ export class CanvasView {
       console.error(`[CanvasView] 페이지 ${pageIdx} 렌더링 실패:`, e);
       this.pageRenderer.removePageLayers(this.scrollContent, pageIdx);
       this.removeGridOverlay(pageIdx);
-      this.canvasPool.release(pageIdx);
-      return;
+      return false;
     }
 
     // CSS 표시 크기 = 물리 픽셀 / DPR (= 페이지크기 × zoom)
     canvas.style.width = `${canvas.width / dpr}px`;
     canvas.style.height = `${canvas.height / dpr}px`;
     this.renderGridOverlay(pageIdx, canvas);
+    return true;
   }
 
   /** 뷰포트 리사이즈 처리 */
@@ -260,6 +268,38 @@ export class CanvasView {
     this.releaseAllRenderedPages();
     this.pageRenderer.cancelAll();
     this.updateVisiblePages();
+  }
+
+  /** 텍스트 입력처럼 좁은 변경은 page info 재수집 없이 해당 페이지 canvas만 다시 그린다. */
+  private refreshInvalidatedPage(payload: unknown): void {
+    if (this.pages.length === 0) return;
+
+    const pageIndex =
+      typeof payload === 'object' && payload !== null && 'pageIndex' in payload
+        ? Number((payload as { pageIndex?: unknown }).pageIndex)
+        : Number(payload);
+
+    if (!Number.isInteger(pageIndex) || pageIndex < 0) {
+      this.refreshPages();
+      return;
+    }
+
+    const pageCount = this.wasm.pageCount;
+    if (pageCount !== this.pages.length || pageIndex >= pageCount) {
+      this.refreshPages();
+      return;
+    }
+
+    const canvas = this.canvasPool.getCanvas(pageIndex);
+    if (!canvas) {
+      this.updateVisiblePages();
+      return;
+    }
+
+    if (!this.renderCanvas(pageIndex, canvas)) {
+      this.canvasPool.release(pageIndex);
+      this.updateVisiblePages();
+    }
   }
 
   /** 리소스를 정리한다 */

--- a/rhwp-studio/tests/input-edit-invalidation.test.ts
+++ b/rhwp-studio/tests/input-edit-invalidation.test.ts
@@ -1,0 +1,54 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isPageLocalTextEditCommand } from '../src/engine/input-edit-invalidation.ts';
+import type { DocumentPosition } from '../src/core/types.ts';
+
+const baseCellPos: DocumentPosition = {
+  sectionIndex: 0,
+  paragraphIndex: 2,
+  charOffset: 3,
+  parentParaIndex: 2,
+  controlIndex: 0,
+  cellIndex: 1,
+  cellParaIndex: 0,
+  cellPath: [{ controlIndex: 0, cellIndex: 1, cellParaIndex: 0 }],
+};
+
+test('isPageLocalTextEditCommand는 같은 셀 내부 insert/delete만 허용한다', () => {
+  assert.equal(
+    isPageLocalTextEditCommand('insertText', baseCellPos, { ...baseCellPos, charOffset: 4 }),
+    true,
+  );
+  assert.equal(
+    isPageLocalTextEditCommand('deleteText', baseCellPos, baseCellPos),
+    true,
+  );
+});
+
+test('isPageLocalTextEditCommand는 본문 텍스트와 구조 변경 명령을 full refresh로 남긴다', () => {
+  const bodyPos: DocumentPosition = {
+    sectionIndex: 0,
+    paragraphIndex: 2,
+    charOffset: 3,
+  };
+
+  assert.equal(isPageLocalTextEditCommand('insertText', bodyPos, { ...bodyPos, charOffset: 4 }), false);
+  assert.equal(isPageLocalTextEditCommand('splitParagraphInCell', baseCellPos, baseCellPos), false);
+  assert.equal(isPageLocalTextEditCommand('deleteSelection', baseCellPos, baseCellPos), false);
+});
+
+test('isPageLocalTextEditCommand는 셀 경로가 바뀌면 full refresh를 요구한다', () => {
+  assert.equal(
+    isPageLocalTextEditCommand('insertText', baseCellPos, {
+      ...baseCellPos,
+      cellPath: [{ controlIndex: 0, cellIndex: 2, cellParaIndex: 0 }],
+      charOffset: 4,
+    }),
+    false,
+  );
+  assert.equal(
+    isPageLocalTextEditCommand('insertText', baseCellPos, { ...baseCellPos, cellParaIndex: 1, charOffset: 4 }),
+    false,
+  );
+});


### PR DESCRIPTION
## Summary

Related: #1211

`rhwp-studio`에서 표 셀 내부 텍스트 입력이 매 키 입력마다 `document-changed -> CanvasView.refreshPages()` full refresh를 타며 visible page 전체 재렌더와 image retry state reset을 반복하던 비용을 줄입니다.

이번 PR은 `samples/exam_social.hwp`의 `성명` 칸처럼 표 셀 내부에서 발생하는 단일 `insertText` / `deleteText` 편집과 한글 IME 조합 중 raw 텍스트 편집을 좁은 invalidation 경로로 보냅니다. 본문 문단 입력, 붙여넣기, 문단 분할/병합, 객체/표/페이지 구조 변경은 기존 full refresh 경로를 유지합니다.

## 범위

이 PR은 모든 텍스트 입력 경로를 최적화하지 않습니다. narrow invalidation 경로는 보수적으로 page-local 편집이라고 판단할 수 있는 경우에만 사용합니다.

- 같은 표 셀 / 같은 `cellPath` 안에 머무르는 편집
- 단일 `insertText` / `deleteText`
- command를 거치지 않는 한글 IME/iOS raw 텍스트 입력 중, 편집 전/후 위치가 같은 셀에 남아 있는 경우

본문 문단 입력, 붙여넣기, 문단 분할/병합, 표/객체/페이지 구조 변경, header/footer, footnote 편집은 기존 full refresh 경로를 유지합니다.

## 선택안: 후보 A + C

이슈 #1211의 개선 후보 중 A + C를 선택했습니다.

- 후보 A: 단순 텍스트 입력용 `document-page-invalidated` 이벤트를 추가해 구조 변경용 `document-changed`와 의미를 분리했습니다.
- 후보 C: 이 narrow invalidation 경로에서는 `refreshPages()`를 호출하지 않으므로, full refresh에 포함된 `resetImageRetryState()`도 매 입력마다 반복하지 않습니다.

후보 A를 선택한 이유는 `document-changed`가 현재 구조 변경과 단순 입력 편집을 모두 대표하면서 full refresh를 강제하기 때문입니다. 이벤트 의미를 분리하면 구조 변경성 작업은 기존 안전한 경로에 남겨두고, 입력 편집만 더 좁은 repaint로 처리할 수 있습니다.

후보 C를 함께 적용한 이유는 단순 텍스트 입력이 이미지 payload/topology를 바꾸지 않기 때문입니다. 기존 full refresh는 입력마다 image retry state를 초기화해 이미지가 있는 페이지에서 재시도 예약과 prefetch 비용이 반복될 수 있었습니다.

후보 B처럼 `document-changed`에 reason을 붙여 내부 분기하는 방식은 기존 이벤트 계약이 계속 모호해질 수 있어 제외했습니다. 후보 D의 flow image 전용 WASM API는 API 표면을 늘리는 작업이므로, A+C 적용 후에도 병목이 남을 때 후속 이슈로 다루는 편이 낫다고 판단했습니다.

## #865와의 관계

PR #865의 `getPageOverlayImages`는 overlay 이미지 목록과 `imageCount`만 필요할 때 대형 `PageLayerTree` JSON을 받지 않도록 하는 최적화입니다. 현재 `PageRenderer.getOverlayImages()`도 해당 API를 우선 사용하므로 overlay 추출 비용은 이미 줄어든 상태입니다.

이번 PR은 그 최적화와 별개로 남아 있던 비용을 줄입니다. 즉, 문제의 본질은 `getPageOverlayImages` 부재가 아니라 일반 텍스트 입력까지 `document-changed -> refreshPages() -> releaseAllRenderedPages() -> resetImageRetryState()` full refresh를 매번 타는 점입니다.

## Changes

- `CanvasView`
  - `document-page-invalidated` 이벤트 처리 추가
  - 기존 canvas를 유지한 채 해당 page만 다시 그리는 `renderCanvas()` 분리
  - page-local refresh에서는 page info 재수집, layout 재계산, 전체 canvas release, image retry reset을 생략
  - page count 변경 또는 invalid page index는 기존 full refresh로 fallback

- `InputHandler`
  - command 실행 전/후 `DocumentPosition`을 비교
  - 표 셀 내부의 같은 `cellPath`에 남아 있는 단일 `insertText` / `deleteText`만 page-local refresh로 라우팅
  - command를 거치지 않는 IME/iOS raw 텍스트 입력도 같은 page-local 라우터로 연결
  - header/footer, footnote, snapshot/paste, 문단/표/객체 구조 변경은 기존 full refresh 유지

- `InputHandlerText`
  - 한글 IME 조합 중 `insertTextAtRaw()` / `deleteTextAt()` 후 `afterEdit()` full refresh를 직접 호출하지 않고 `afterTextInputEdit()`를 사용
  - iOS composition fallback의 debounce 렌더도 같은 라우터를 사용

- Tests
  - `input-edit-invalidation` helper 단위 테스트 추가

## Validation

```text
cd rhwp-studio && npm test
cd rhwp-studio && npm run build
```

수동 확인:

```text
http://127.0.0.1:7700/?url=/samples/exam_social.hwp&filename=exam_social.hwp
```

- 1쪽 상단 `성명` 칸에 `테스트` 입력 확인
- Stage 5 보완 후 한글 입력 경로에서 browser console error 없음
- 브라우저 console error 없음

## Measurement

임시 계측 코드를 로컬 worktree에만 넣어 비교했습니다. 계측 코드는 PR 소스에 포함하지 않았습니다.

환경:

- OS: macOS 26.3.1 (25D771280a), arm64
- Node.js: v24.15.0
- Browser: Google Chrome 148.0.7778.215, headless mode
- Runner: `puppeteer-core`
- before: `upstream/devel` (`c884205d`)
- after: `task-1211` (`b47f4f4`)
- sample: `samples/exam_social.hwp`
- 위치: 1쪽 상단 `성명` 셀
- viewport: `1280x900`, UI zoom `140%`
- input: `가나다라마바사아자차` 10자
- trials: 5
- 측정 대상: `EventBus.emit`, `CanvasView.refreshPages()`, `CanvasView.refreshInvalidatedPage()`, `PageRenderer.renderPage()`, `PageRenderer.resetImageRetryState()`

측정 절차:

- `/private/tmp/rhwp-measure-before` worktree에서 `upstream/devel`을 Vite dev server로 실행 (`127.0.0.1:7711`)
- `/private/tmp/rhwp-measure-after` worktree에서 이 PR branch를 Vite dev server로 실행 (`127.0.0.1:7712`)
- 두 서버 모두 실제 `rhwp-studio` 화면으로 `/?url=/samples/exam_social.hwp&filename=exam_social.hwp`를 로드
- headless Chrome에서 문서 로드 완료 후 page canvas의 상대 좌표로 1쪽 상단 `성명` 셀을 클릭
- `page.keyboard.type()`로 10자 문자열을 입력하고 같은 과정을 5회 반복
- 임시 계측으로 이벤트 emit 횟수, refresh entrypoint 호출 횟수, `PageRenderer.renderPage()` 호출 수와 누적 시간을 수집

| Metric (10 chars / trial) | before | after | change |
|---|---:|---:|---:|
| `document-changed` events | 10 | 0 | -100% |
| `document-page-invalidated` events | 0 | 10 | +10 |
| `CanvasView.refreshPages()` | 10 | 0 | -100% |
| `CanvasView.refreshInvalidatedPage()` | 0 | 10 | +10 |
| `resetImageRetryState()` | 10 | 0 | -100% |
| `PageRenderer.renderPage()` calls | 20 | 10 | -50% |
| `PageRenderer.renderPage()` total avg | 188.28 ms | 65.42 ms | -65.3% |
| `PageRenderer.renderPage()` total p95 | 193.30 ms | 67.10 ms | -65.3% |
| scripted input elapsed avg | 1830.60 ms | 1383.00 ms | -24.5% |

`scripted input elapsed`는 puppeteer typing delay와 fixed wait를 포함하므로 보조 지표입니다. PR의 핵심 개선값은 full refresh / image retry reset 제거와 renderPage 누적 시간 감소입니다.

주의: 이 측정은 함수만 직접 호출한 microbenchmark가 아니라 실제 dev server와 browser input을 사용한 end-to-end 경로 측정입니다. 다만 headless Chrome의 scripted keyboard input은 macOS 네이티브 한글 IME 조합 입력과 완전히 동일하지 않을 수 있으므로, 사용자 체감 시간 자체보다 render/invalidation 경로 변화와 렌더 누적 시간 감소를 주 근거로 봅니다.
