### PR TITLE
Task #1134: HWPX 본문·표 셀 문단 id 전역 유니크 처리

### DIFF
--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -87,6 +87,8 @@ pub struct SerializeContext {
     pub style_ids: IdPool<u16>,
     /// `bin_data_id` (IR) → manifest 엔트리 매핑
     pub bin_data_map: HashMap<u16, BinDataEntry>,
+    /// 문서 전역 문단 ID 카운터 — `<hp:p id="...">` 에 발급한다.
+    para_id_counter: u32,
 }
 
 impl SerializeContext {
@@ -210,6 +212,13 @@ impl SerializeContext {
                 missing.join("; ")
             )))
         }
+    }
+
+    /// 문서 전역 문단 ID를 하나 발급하고 카운터를 증가시킨다.
+    pub fn next_para_id(&mut self) -> u32 {
+        let id = self.para_id_counter;
+        self.para_id_counter += 1;
+        id
     }
 }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -74,7 +74,7 @@ pub fn write_section(
 
     // 첫 문단 `<hp:p>` 태그를 IR 기반 속성으로 교체
     if let Some(p) = first_para {
-        let new_p_tag = render_hp_p_open(p, 0);
+        let new_p_tag = render_hp_p_open(p, ctx.next_para_id());
         out = out.replacen(TEMPLATE_FIRST_P_TAG, &new_p_tag, 1);
 
         // 첫 문단의 텍스트용 <hp:run> 의 charPrIDRef 를 IR 기반으로 교체
@@ -92,11 +92,11 @@ pub fn write_section(
     // 추가 문단: `</hp:p></hs:sec>` 직전에 `<hp:p>` 요소를 삽입.
     if section.paragraphs.len() > 1 {
         let mut extra = String::new();
-        for (idx, p) in section.paragraphs.iter().enumerate().skip(1) {
+        for p in section.paragraphs.iter().skip(1) {
             let (t, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
             vert_cursor = advance;
             let cs = first_run_char_shape_id(p);
-            extra.push_str(&render_hp_p_open(p, idx as u32));
+            extra.push_str(&render_hp_p_open(p, ctx.next_para_id()));
             extra.push_str(&format!(r#"<hp:run charPrIDRef="{}">"#, cs));
             extra.push_str(&t);
             extra.push_str(r#"</hp:run><hp:linesegarray>"#);
@@ -419,11 +419,11 @@ fn render_note_sublist(
         num = number,
     );
     let mut vert_cursor: u32 = 0;
-    for (idx, p) in paragraphs.iter().enumerate() {
+    for p in paragraphs.iter() {
         let (t, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
         vert_cursor = advance;
         let cs = first_run_char_shape_id(p);
-        out.push_str(&render_hp_p_open(p, idx as u32));
+        out.push_str(&render_hp_p_open(p, ctx.next_para_id()));
         out.push_str(&format!(r#"<hp:run charPrIDRef="{}">"#, cs));
         out.push_str(&t);
         out.push_str(r#"</hp:run><hp:linesegarray>"#);

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -572,4 +572,81 @@ mod tests {
             );
         }
     }
+
+    #[test]
+    fn cell_para_ids_continue_from_context_counter() {
+        // 컨텍스트 카운터를 5 앞당긴 뒤 직렬화하면 셀 문단 id가 5부터 시작해야 함.
+        // 본문 문단이 먼저 id 0~4를 소비한 상황을 모사한다.
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        for _ in 0..5 {
+            ctx.next_para_id();
+        }
+        let t = empty_table(1, 2); // 셀 2개 × 문단 1개 → id=5, id=6 이어야 함
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_table(&mut w, &t, &mut ctx).unwrap();
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(
+            xml.contains(r#"<hp:p id="5""#),
+            "첫 셀 문단은 id=5 여야 함 (카운터 오프셋 5): {}",
+            &xml[..xml.len().min(600)]
+        );
+        assert!(
+            xml.contains(r#"<hp:p id="6""#),
+            "두 번째 셀 문단은 id=6 여야 함"
+        );
+    }
+
+    #[test]
+    fn two_sequential_tables_have_no_para_id_collision() {
+        // 같은 ctx로 표 두 개를 연달아 직렬화 — 두 번째 표가 카운터를 초기화하면
+        // id=0 이 2번 나타나므로 회귀를 탐지할 수 있다.
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_table(&mut w, &empty_table(2, 2), &mut ctx).unwrap(); // id 0-3
+        write_table(&mut w, &empty_table(2, 2), &mut ctx).unwrap(); // id 4-7
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+
+        assert_eq!(
+            xml.matches(r#"<hp:p id="0""#).count(),
+            1,
+            "id=0 이 중복 — 두 번째 표가 카운터를 재사용했을 가능성"
+        );
+        for expected_id in 0..8u32 {
+            assert!(
+                xml.contains(&format!(r#"<hp:p id="{}""#, expected_id)),
+                "id={} 가 없음 (총 8개 문단이어야 함)",
+                expected_id
+            );
+        }
+    }
+
+    #[test]
+    fn multi_para_cells_all_get_unique_ids() {
+        // 셀당 문단 3개, 2×2 표 → 총 12개 문단, id=0..11 전부 1회씩
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut t = empty_table(2, 2);
+        for cell in &mut t.cells {
+            cell.paragraphs.push(Paragraph::default());
+            cell.paragraphs.push(Paragraph::default());
+        }
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_table(&mut w, &t, &mut ctx).unwrap();
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+
+        let p_count = xml.matches("<hp:p ").count();
+        assert_eq!(p_count, 12, "문단 수가 12여야 함: {}", p_count);
+
+        for expected_id in 0..12u32 {
+            assert_eq!(
+                xml.matches(&format!(r#"<hp:p id="{}""#, expected_id))
+                    .count(),
+                1,
+                "id={} 가 없거나 중복됨",
+                expected_id
+            );
+        }
+    }
 }

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -244,14 +244,14 @@ fn write_sub_list<W: Write>(
     )?;
 
     // 셀 내부 문단 재귀 — 각 문단은 간단한 <hp:p><hp:run><hp:t>텍스트</hp:t></hp:run></hp:p> 구조
-    for (pi, para) in cell.paragraphs.iter().enumerate() {
+    for para in cell.paragraphs.iter() {
         ctx.para_shape_ids.reference(para.para_shape_id);
         ctx.style_ids.reference(para.style_id as u16);
         if let Some(cs_ref) = para.char_shapes.first() {
             ctx.char_shape_ids.reference(cs_ref.char_shape_id);
         }
 
-        let pi_str = pi.to_string();
+        let pi_str = ctx.next_para_id().to_string();
         let ppr = para.para_shape_id.to_string();
         let sp = para.style_id.to_string();
         start_tag_attrs(
@@ -551,5 +551,25 @@ mod tests {
         write_table(&mut w, &t, &mut ctx).unwrap();
         // 99 는 등록되지 않은 borderFill → unresolved
         assert!(ctx.border_fill_ids.unresolved().contains(&99u16));
+    }
+
+    #[test]
+    fn cell_paragraph_ids_are_globally_unique() {
+        // 2×2 표 = 셀 4개, 각 셀에 문단 1개 → id="0", id="1", id="2", id="3"
+        let t = empty_table(2, 2);
+        let xml = serialize(&t);
+        assert_eq!(
+            xml.matches(r#"<hp:p id="0""#).count(),
+            1,
+            "셀 문단 id=0 이 중복됨: {}",
+            &xml[..xml.len().min(400)]
+        );
+        for expected_id in 0..4u32 {
+            assert!(
+                xml.contains(&format!(r#"<hp:p id="{}""#, expected_id)),
+                "id={} 가 없음",
+                expected_id
+            );
+        }
     }
 }

--- a/tests/hwpx_roundtrip_integration.rs
+++ b/tests/hwpx_roundtrip_integration.rs
@@ -536,3 +536,49 @@ fn task177_false_positive_measurement() {
 
     // assertion 없음 — 측정 결과는 기술문서에 기록
 }
+
+#[test]
+fn para_ids_unique_across_body_and_table() {
+    use rhwp::parser::hwpx::parse_hwpx;
+    use rhwp::serializer::hwpx::serialize_hwpx;
+    use std::collections::HashSet;
+    use std::io::Read;
+
+    let bytes = include_bytes!("../samples/hwpx/basic-table-01.hwpx");
+    let doc = parse_hwpx(bytes).expect("parse");
+    let zip_bytes = serialize_hwpx(&doc).expect("serialize");
+
+    let cursor = std::io::Cursor::new(zip_bytes);
+    let mut zip = zip::ZipArchive::new(cursor).expect("zip open");
+    let mut section_xml = String::new();
+    for i in 0..zip.len() {
+        let mut entry = zip.by_index(i).expect("zip entry");
+        let name = entry.name().to_string();
+        if name.contains("section") && name.ends_with(".xml") {
+            entry
+                .read_to_string(&mut section_xml)
+                .expect("read section xml");
+            break;
+        }
+    }
+    assert!(
+        !section_xml.is_empty(),
+        "section XML not found in serialized zip"
+    );
+
+    let ids: Vec<&str> = section_xml
+        .split(r#"<hp:p id=""#)
+        .skip(1)
+        .map(|s| s.split('"').next().unwrap_or(""))
+        .collect();
+
+    assert!(!ids.is_empty(), "직렬화 결과에 <hp:p> 요소가 없음");
+
+    let unique: HashSet<&str> = ids.iter().copied().collect();
+    assert_eq!(
+        ids.len(),
+        unique.len(),
+        "본문+셀 문단 id 중복 발견: {:?}",
+        ids
+    );
+}


### PR DESCRIPTION
## 변경 요약

HWPX 직렬화 시 본문 문단과 표 셀 내부 문단의 `<hp:p id>`가 같은 번호 공간을 공유하지 않아 전역 중복이 발생할 수 있는 문제(#1134)를 수정했습니다.

- `SerializeContext`에 문서 전역 문단 id 카운터(`next_para_id()`)를 추가
- 본문 문단·각주 sublist·표 셀 문단이 모두 전역 카운터에서 단조 증가 id를 발급받도록 정리 (기존 루프 인덱스 기반 id 제거)
- 본문 문단과 표 셀 문단 id가 전역으로 유니크한지 검증하는 회귀 테스트 추가
  - 단위 테스트: 셀 문단 전역 유니크 / 카운터 오프셋 연속 / 연속 표 충돌 없음 / 셀당 복수 문단
  - 통합 테스트: `basic-table-01.hwpx` 라운드트립에서 본문+셀 id 전역 유니크 검증

## 분리 안내 (PR #1206 후속)

닫힌 PR #1206 검토 의견에 따라, **fillBrush 직렬화 변경(`serializer/hwpx/header.rs`)을 제외**하고 문단 id 충돌 수정만 분리하여 재제출합니다. fillBrush는 HWPX 쓰기 모듈 정비 일정에 맞춰 별도로 다루는 것으로 이해했습니다.

변경 파일은 4개입니다: `serializer/hwpx/context.rs`, `serializer/hwpx/section.rs`, `serializer/hwpx/table.rs`, `tests/hwpx_roundtrip_integration.rs`.

## 관련 이슈

closes #1134

## 테스트

- [x] `cargo fmt --all -- --check` 통과
- [x] `cargo test` 통과 (#1134 단위 11종 + 통합 1종 포함)
- [x] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — 해당 없음 (HWPX 직렬화 XML id 변경, SVG 출력 경로 무관)
- [ ] 웹(WASM) 렌더링 확인 — 해당 없음 (렌더링 비관여)

## 스크린샷

직렬화 XML의 `<hp:p id>` 발급 로직 변경이라 시각적 변경이 없어 스크린샷 비교는 생략합니다.