### PR TITLE
fix(eqn): bind trailing scripts to LEFT-RIGHT delimiter group (|x|^3)

### DIFF
--- a/src/renderer/equation/parser.rs
+++ b/src/renderer/equation/parser.rs
@@ -367,7 +367,10 @@ impl EqParser {
 
         // LEFT-RIGHT 괄호
         if cu == "LEFT" {
-            return self.parse_left_right();
+            // ★ KeepGong fix: 구분기호 그룹(left|...right| 등) 뒤 첨자(^/_)를 그룹 전체에 부착.
+            //   기존엔 try_parse_scripts 를 안 거쳐 |x|^3 의 ^3 가 base 없는 고아 첨자가 됐다.
+            let node = self.parse_left_right();
+            return self.try_parse_scripts(node);
         }
 
         if cu == "RIGHT" {


### PR DESCRIPTION
## Problem

A superscript/subscript following a sized delimiter group is not bound to the group. For example `left | x right | ^3` (i.e. `|x|³`) renders the `3` at **subscript height** in the SVG output instead of as a superscript, while `x^2` renders correctly.

## Cause

In `parse_command` (`src/renderer/equation/parser.rs`), the `LEFT` branch returns the `parse_left_right()` Paren node **directly**, bypassing `try_parse_scripts`:

```rust
if cu == "LEFT" {
    return self.parse_left_right();   // <- no try_parse_scripts
}
```

Every other primary (number / text / brace-group / symbol) routes its result through `try_parse_scripts`, so the trailing `^`/`_` attaches to the base. For the LEFT-RIGHT group the trailing script instead becomes an orphan empty-base `Superscript{ base: Empty, sup }`.

## Fix

Wrap the result the same way as other primaries:

```rust
if cu == "LEFT" {
    let node = self.parse_left_right();
    return self.try_parse_scripts(node);
}
```

## Effect

```
before:  |x|^3  ->  \left|x\right|{}^{3}   (orphan; 3 drops low in SVG layout)
after:   |x|^3  ->  {\left|x\right|}^{3}   (3 is a proper superscript)
```

Verified end-to-end: the `|x|³` in a KICE exam paper now renders the exponent as a superscript in the native SVG. `x^2` and other cases are unaffected.

Thanks for rhwp — it's a great library. 🙏