### PR TITLE
Task #1201: HWPX masterpage idRef 연결 보강

### DIFF
--- a/mydocs/plans/task_m100_1201.md
+++ b/mydocs/plans/task_m100_1201.md
@@ -1,0 +1,180 @@
+# 수행계획서 — Task M100-1201: HWPX masterpage XML 바탕쪽 파싱/연결
+
+## 1. 이슈
+
+- GitHub Issue: [#1201](https://github.com/edwardkim/rhwp/issues/1201)
+- 제목: `HWPX: masterpage XML의 바탕쪽 EVEN/ODD가 파싱·연결되지 않음`
+- 대상 마일스톤: M100 / v1.0.0 편집 기반
+- 브랜치: `task-1201-hwpx-masterpage`
+- 부모 이슈: [#1210](https://github.com/edwardkim/rhwp/issues/1210)
+- 관련 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196), [#1197](https://github.com/edwardkim/rhwp/issues/1197), [#1205](https://github.com/edwardkim/rhwp/issues/1205)
+
+## 2. 문제 요약
+
+대상 HWPX 패키지는 `Contents/masterpage*.xml` 파일을 포함하고, 섹션 XML은 `<hp:masterPage idRef="...">`로 해당 바탕쪽을 참조한다.
+그러나 현재 HWPX 파서 경로는 이 외부 masterpage XML을 `SectionDef.master_pages`로 materialize하지 못하는 것으로 보인다.
+
+렌더러는 이미 `SectionDef.master_pages`가 채워져 있으면 페이지 번호의 홀짝에 따라 바탕쪽을 선택할 수 있다.
+따라서 이번 작업의 핵심은 HWPX 파서가 masterpage manifest, section reference, masterpage XML 본문을 읽어 공통 IR에 연결하도록 만드는 것이다.
+
+## 3. 원본 및 정답 구조
+
+대상 샘플:
+
+```text
+원본 HWPX: /Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx
+정답 PDF:  /Users/melee/Downloads/[2027] 온새미로 1 본교재.pdf
+```
+
+샘플 구조:
+
+```text
+section0 -> masterpage0(EVEN), masterpage1(ODD)
+section1 -> masterpage2(EVEN), masterpage3(ODD)
+section2 -> masterpage4(EVEN), masterpage5(ODD)
+section3 -> masterpage6(EVEN), masterpage7(ODD)
+section4 -> masterpage8(EVEN), masterpage9(ODD)
+```
+
+PDF 기준으로는 짝수쪽에 왼쪽 하단/헤더 계열 바탕쪽 텍스트가, 홀수쪽에 오른쪽 하단/헤더 계열 바탕쪽 텍스트가 적용된다.
+예를 들어 4쪽, 6쪽, 8쪽은 짝수쪽 바탕쪽이 보이고 5쪽, 7쪽은 홀수쪽 바탕쪽이 보인다.
+
+공식 문서상 HWPX/HWPML masterpage는 `Type` 값으로 `Both`, `Even`, `Odd` 등을 가진다.
+따라서 HWPX 구현은 HWP5 바이너리 raw parser의 LIST_HEADER 순서 규칙을 재사용하지 않고, masterpage XML의 명시적 `type` 속성을 기준으로 매핑해야 한다.
+
+## 4. 작업 범위
+
+이번 이슈의 범위:
+
+- `content.hpf` 또는 패키지 manifest에서 masterpage 항목을 수집한다.
+- 섹션 XML의 `<hp:masterPage idRef="...">` 참조를 수집한다.
+- `Contents/masterpage*.xml`을 읽어 `MasterPage` IR로 변환한다.
+- HWPX masterpage root의 `type` 속성을 명시적으로 해석한다.
+- `BOTH`/`Both`, `EVEN`/`Even`, `ODD`/`Odd`를 기존 `HeaderFooterApply` 의미에 맞게 연결한다.
+- 필요한 경우 `LAST_PAGE`/`LastPage`, `OPTIONAL_PAGE`/`OptionalPage`는 확장 가능성을 보존한다.
+- 변환된 masterpage를 해당 섹션의 `SectionDef.master_pages`에 연결한다.
+
+이번 이슈의 비범위:
+
+- 맞쪽 여백/제본 방향 이상: #1196
+- 4쪽 이미지 및 텍스트 겹침: #1197
+- 문단 테두리 `NONE` 처리: #1205
+- 로컬 폰트 미설치로 인한 PDF/뷰어 폰트 차이
+
+## 5. 수정 후보 파일
+
+| 파일 | 변경 후보 |
+|------|-----------|
+| `src/parser/hwpx/content.rs` | HWPX package manifest의 masterpage 항목 보존 또는 id-to-href map 추가 |
+| `src/parser/hwpx/mod.rs` | masterpage XML 로드, section 참조와 연결, `SectionDef.master_pages` populate |
+| `src/parser/hwpx/section.rs` | 섹션의 `<hp:masterPage idRef>` 수집, masterpage XML root 및 본문 파싱 보조 함수 추가 |
+| `src/model/header_footer.rs` | 기존 `MasterPage`/`HeaderFooterApply`로 충분한지 확인, 부족한 확장 타입이 있으면 최소 보강 검토 |
+| `tests/` | HWPX masterpage manifest/ref/type 매핑 회귀 테스트 추가 |
+| `mydocs/working/task_m100_1201_stage*.md` | 단계별 조사 및 구현 결과 기록 |
+
+## 6. 구현 방향 후보
+
+### 후보 A: HWPX 전용 masterpage parser 추가
+
+`section.rs`의 기존 문단/컨트롤 파싱 함수를 재사용하여 `masterpage*.xml` 내부의 문단과 컨트롤을 `MasterPage`로 변환한다.
+
+장점:
+
+- HWPX XML 구조를 명시적으로 처리한다.
+- HWP5 raw parser의 순서 기반 규칙과 섞이지 않는다.
+
+위험:
+
+- masterpage XML 내부의 문단/그리기/이미지 구조가 일반 section XML과 조금 다르면 재사용 지점 조정이 필요하다.
+
+### 후보 B: section parse 결과에 masterpage ref 보존
+
+섹션 파싱 시 `<hp:masterPage idRef>`를 수집하고, `mod.rs`에서 패키지 manifest와 masterpage 파일을 읽은 뒤 해당 섹션에 연결한다.
+
+장점:
+
+- masterpage 파일 로드 책임과 section XML 해석 책임이 분리된다.
+- section별 참조 순서와 id를 보존할 수 있다.
+
+위험:
+
+- 현재 `parse_hwpx_section()` 반환 타입이 `Section` 중심이면, 참조 정보를 넘기는 보조 구조체가 필요할 수 있다.
+
+### 후보 C: manifest 기반 선파싱 후 section 연결
+
+`content.hpf`에서 masterpage id/href를 먼저 수집하고 전체 masterpage를 파싱한 다음, 섹션의 idRef와 매칭한다.
+
+장점:
+
+- 누락된 masterpage 파일이나 id 불일치를 진단하기 쉽다.
+
+위험:
+
+- 실제로 section에서 참조하지 않는 masterpage까지 파싱할 수 있다.
+
+## 7. 기본안
+
+기본안은 B + C를 결합하되, masterpage 본문 파싱은 A의 HWPX 전용 함수를 작게 추가하는 방식으로 진행한다.
+
+```text
+1. package manifest에서 masterpage id/href를 수집한다.
+2. section XML에서 masterPage idRef 목록을 수집한다.
+3. 참조된 masterpage XML만 읽어 HWPX 전용 parser로 MasterPage를 만든다.
+4. masterpage root의 type 속성을 HeaderFooterApply로 매핑한다.
+5. SectionDef.master_pages에 연결한다.
+6. 렌더러의 기존 odd/even 선택 경로가 동작하는지 검증한다.
+```
+
+## 8. 검증 계획
+
+최소 검증:
+
+```text
+cargo fmt --check
+cargo test --lib
+관련 HWPX masterpage 회귀 테스트
+```
+
+구조 검증:
+
+```text
+rhwp dump 대상.hwpx
+```
+
+확인 포인트:
+
+```text
+1. section별 SectionDef.master_pages가 비어 있지 않은가
+2. EVEN masterpage가 짝수쪽, ODD masterpage가 홀수쪽으로 매핑되는가
+3. HWP5 raw parser의 [Both, Odd, Even] 순서 기반 해석은 변경되지 않는가
+```
+
+시각 검증:
+
+```text
+rhwp export-svg 대상.hwpx -p 3
+rhwp export-svg 대상.hwpx -p 4
+```
+
+확인 포인트:
+
+```text
+1. PDF 4쪽 기준 짝수쪽 바탕쪽 텍스트가 rhwp 4쪽에도 표시되는가
+2. PDF 5쪽 기준 홀수쪽 바탕쪽 텍스트가 rhwp 5쪽에도 표시되는가
+3. 홀짝이 반전되지 않는가
+```
+
+## 9. 완료 기준
+
+```text
+1. HWPX masterpage manifest와 section idRef가 파싱된다.
+2. masterpage XML의 명시적 type 속성이 HeaderFooterApply로 매핑된다.
+3. 대상 샘플의 section별 master_pages가 채워진다.
+4. 4쪽/5쪽 등 PDF 기준 홀짝 바탕쪽 표시가 일치한다.
+5. HWP5 바탕쪽 파싱 순서 규칙에는 회귀가 없다.
+6. 수행 결과와 검증 결과가 단계별 보고서에 기록된다.
+```
+
+## 10. 승인 요청
+
+위 계획에 따라 구현계획서 작성 단계로 진행한다.

--- a/mydocs/plans/task_m100_1201_impl.md
+++ b/mydocs/plans/task_m100_1201_impl.md
@@ -1,0 +1,196 @@
+# 구현계획서 — Task M100-1201: HWPX masterpage idRef 기반 연결
+
+## 설계 요약
+
+현재 코드에는 HWPX masterpage 처리의 일부가 이미 들어 있다.
+
+```text
+src/parser/hwpx/content.rs
+  - section_master_page_files를 manifest 순서 기반으로 추정
+
+src/parser/hwpx/mod.rs
+  - section index별 section_master_page_files를 읽어 SectionDef.master_pages에 push
+
+src/parser/hwpx/section.rs
+  - parse_hwpx_master_page() 존재
+  - masterPage@type 일부 값(EVEN/ODD/LAST_PAGE/OPTIONAL_PAGE) 파싱
+```
+
+하지만 #1201의 본질은 HWPX section XML의 `<hp:masterPage idRef="...">`와 `content.hpf` manifest item id/href를 연결하는 것이다.
+현재 방식은 section XML의 `idRef`를 읽지 않고 manifest 순서로 그룹을 추정하므로, manifest 순서가 달라지거나 masterpage가 section 앞뒤에 섞이면 잘못 연결될 수 있다.
+
+이번 구현은 기존 masterpage parser를 살리되, 연결 방식을 `idRef -> manifest id -> href -> masterpage XML`로 바꾸는 데 집중한다.
+
+## Stage 1 — manifest id map과 section idRef 수집
+
+**목표**: HWPX masterpage 연결에 필요한 식별자 정보를 파서가 보존하게 한다.
+
+변경 후보:
+
+- `src/parser/hwpx/content.rs`
+  - `PackageInfo`에 masterpage manifest 항목을 id와 href가 함께 보존되는 형태로 추가한다.
+  - 후보 필드:
+
+```rust
+pub master_page_items: Vec<PackageItem>
+```
+
+  - 판별 기준은 기존과 같이 XML 항목 중 href가 `masterpage`를 포함하는 항목을 우선한다.
+  - 기존 `section_master_page_files`는 fallback 또는 기존 테스트 호환 용도로 남긴다.
+
+- `src/parser/hwpx/section.rs`
+  - section XML에서 `<hp:masterPage idRef="...">`를 수집하는 read-only helper를 추가한다.
+  - 후보 함수:
+
+```rust
+pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError>
+```
+
+  - 네임스페이스 접두사 유무와 `Start`/`Empty` 이벤트를 모두 처리한다.
+  - `idRef`가 없는 masterpage root는 수집하지 않는다.
+
+테스트:
+
+- `content.rs`
+  - manifest의 `masterpage0 -> Contents/masterpage0.xml` id/href 보존 테스트
+  - 기존 manifest 순서 기반 fallback 테스트 유지
+- `section.rs`
+  - `<hp:masterPage idRef="masterpage0"/>`, `<masterPage idRef="masterpage1"/>` 수집 테스트
+  - 일반 section 문단 파싱과 독립적으로 동작하는지 확인
+
+보고서:
+
+- `mydocs/working/task_m100_1201_stage1.md`
+
+## Stage 2 — idRef 기반 masterpage 연결
+
+**목표**: `parse_hwpx()`가 section별 masterpage를 manifest 순서 추정이 아니라 section의 `idRef` 기준으로 연결하게 한다.
+
+변경 후보:
+
+- `src/parser/hwpx/mod.rs`
+  - `PackageInfo.master_page_items`로 id-to-href map을 만든다.
+  - section XML을 읽은 뒤 `collect_hwpx_section_master_page_refs()`로 참조 id 목록을 얻는다.
+  - 각 `idRef`를 manifest id에 매칭해 해당 masterpage XML을 읽고 `parse_hwpx_master_page()`로 변환한다.
+  - 변환 결과를 `section.section_def.master_pages`에 push한다.
+  - 같은 href가 중복 연결되지 않도록 section 단위 dedup을 적용한다.
+  - `idRef`가 없거나 모두 resolve되지 않을 때만 기존 `section_master_page_files` fallback을 사용한다.
+
+주의:
+
+- HWP5 raw parser의 `[Both, Odd, Even]` 순서 해석은 건드리지 않는다.
+- HWPX에서는 XML root의 `type` 속성을 신뢰한다.
+- 누락된 idRef나 masterpage 파일은 기존처럼 warning으로 처리하고 문서 전체 파싱은 계속한다.
+
+테스트:
+
+- pure helper를 추가할 수 있으면 `idRef -> href` resolve 테스트를 단위 테스트로 둔다.
+- full HWPX ZIP fixture가 과해지면 작은 내부 helper 중심으로 테스트하고, 실제 샘플 검증은 Stage 4에서 수행한다.
+
+보고서:
+
+- `mydocs/working/task_m100_1201_stage2.md`
+
+## Stage 3 — masterPage@type 파싱 정합성 보강
+
+**목표**: 공식 문서 표기와 실제 샘플 표기를 모두 안정적으로 해석한다.
+
+변경 후보:
+
+- `src/parser/hwpx/section.rs`
+  - `parse_master_page_start()`의 `type` 해석을 보조 함수로 분리한다.
+  - `BOTH`, `Both`, `both` -> `HeaderFooterApply::Both`
+  - `EVEN`, `Even`, `even` -> `HeaderFooterApply::Even`
+  - `ODD`, `Odd`, `odd` -> `HeaderFooterApply::Odd`
+  - `LAST_PAGE`, `LastPage`, `lastPage` -> extension + `Both`
+  - `OPTIONAL_PAGE`, `OptionalPage`, `optionalPage` -> extension + `Both`
+
+주의:
+
+- `LAST_PAGE pageDuplicate="0"`의 `replace_base` 및 `overlap` 보정은 유지한다.
+- `raw_list_header` 생성 방식은 기존 저장 contract와 충돌하지 않게 유지한다.
+
+테스트:
+
+- `parse_hwpx_master_page()`에 mixed-case type 테스트 추가
+- 기존 `LAST_PAGE`/`OPTIONAL_PAGE` 테스트 유지
+
+보고서:
+
+- `mydocs/working/task_m100_1201_stage3.md`
+
+## Stage 4 — 대상 샘플 구조/시각 검증
+
+**목표**: 실제 #1201 샘플에서 section별 바탕쪽이 채워지고 홀짝이 반전되지 않는지 확인한다.
+
+대상:
+
+```text
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.pdf
+```
+
+검증 후보:
+
+```text
+cargo run -- dump "/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx"
+cargo run -- export-svg "/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1201_masterpage -p 3
+cargo run -- export-svg "/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1201_masterpage -p 4
+```
+
+확인 항목:
+
+- section0~section4의 `master_pages`가 기대 개수로 채워지는가
+- `masterpage0/2/4/6/8`의 EVEN이 짝수쪽에 적용되는가
+- `masterpage1/3/5/7/9`의 ODD가 홀수쪽에 적용되는가
+- PDF 기준 4쪽과 5쪽에서 바탕쪽 위치와 텍스트 방향이 반전되지 않는가
+
+보고서:
+
+- `mydocs/working/task_m100_1201_stage4.md`
+
+## Stage 5 — 회귀 검증과 최종 보고
+
+필수 검증:
+
+```text
+cargo fmt --all --check
+cargo test --lib hwpx
+cargo test --test issue_1100_exam_social_hwpx_header
+cargo test --test issue_1113_header_autonum_placeholder
+```
+
+필요 시 확장 검증:
+
+```text
+cargo test --lib
+cargo test --test hwpx_roundtrip_integration
+```
+
+최종 보고:
+
+- `mydocs/report/task_m100_1201_report.md`
+
+## 제외 범위
+
+- #1196 맞쪽/제본 여백 문제
+- #1197 4쪽 이미지와 텍스트 겹침
+- #1205 문단 박스 borderFill `NONE` 처리
+- 렌더러의 홀짝 선택 알고리즘 전면 변경
+- 대상 원본 HWPX/PDF 파일의 저장소 커밋 포함
+
+## 완료 판정
+
+완료 조건:
+
+- section XML의 `masterPage idRef`가 파싱된다.
+- manifest id/href와 `idRef`가 연결된다.
+- `SectionDef.master_pages`가 대상 샘플의 section별 바탕쪽을 보존한다.
+- masterpage `type`은 HWPX XML의 명시값을 기준으로 매핑된다.
+- 실제 샘플 4쪽/5쪽에서 PDF 기준 홀짝 바탕쪽이 반전되지 않는다.
+- 기존 HWP5 바탕쪽 파싱과 HWPX header/footer 관련 회귀 테스트가 통과한다.
+
+## 작업지시자 승인 요청
+
+본 구현계획이 승인되면 Stage 1부터 소스 수정을 시작한다.
+첫 수정 범위는 `src/parser/hwpx/content.rs`와 `src/parser/hwpx/section.rs`의 read-only 수집 경로로 제한한다.

--- a/mydocs/report/task_m100_1201_report.md
+++ b/mydocs/report/task_m100_1201_report.md
@@ -1,0 +1,88 @@
+# Task M100-1201 최종 보고서 — HWPX masterpage idRef 기반 연결
+
+## 대상
+
+- Issue: #1201
+- 작업: HWPX masterpage XML의 EVEN/ODD 바탕쪽 파싱 및 section 연결
+- 브랜치: `task-1201-hwpx-masterpage`
+
+## 변경 요약
+
+### `src/parser/hwpx/content.rs`
+
+- `PackageInfo`에 `master_page_items`를 추가해 masterpage manifest 항목의 `id`와 `href`를 함께 보존했다.
+- 기존 `section_master_page_files`는 fallback 및 기존 호환 경로로 유지했다.
+
+### `src/parser/hwpx/section.rs`
+
+- section XML에서 `<hp:masterPage idRef="...">`를 수집하는 helper를 추가했다.
+- HWPX `masterPage@type` 해석을 helper로 분리하고 공식 문서식 표기와 실제 샘플식 표기를 함께 지원했다.
+- 지원 표기:
+
+```text
+BOTH / Both / both
+EVEN / Even / even
+ODD / Odd / odd
+LAST_PAGE / LastPage / lastPage
+OPTIONAL_PAGE / OptionalPage / optionalPage
+```
+
+### `src/parser/hwpx/mod.rs`
+
+- `parse_hwpx()`에서 section XML의 `idRef`를 먼저 수집한 뒤 `manifest id -> href -> masterpage XML` 순서로 연결하도록 변경했다.
+- section 단위로 동일 href가 중복 연결되지 않도록 처리했다.
+- `idRef`가 없거나 resolve되지 않을 때만 기존 manifest 순서 기반 fallback을 사용한다.
+
+## 샘플 검증
+
+대상 파일:
+
+```text
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.pdf
+```
+
+확인 결과:
+
+- section 0부터 section 4까지 모두 `바탕쪽: 2개`가 채워진다.
+- section 0:
+  - `[0] Even`: `2027 온새미로 II`
+  - `[1] Odd`: `독서 · 문학`
+- section 1부터 section 4:
+  - `[0] Even`: `2027학년도 수능 대비`
+  - `[1] Odd`: `독서 · 문학`
+- PDF 4/5/6/7쪽 기준의 짝수/홀수 바탕쪽 방향과 rhwp SVG의 masterpage 적용 방향이 구조적으로 반전되지 않는다.
+
+주의:
+
+- rhwp 파싱 결과는 47쪽, 원본 PDF는 49쪽이다. 전체 pagination 차이는 #1201 범위 밖의 기존 layout 차이로 남긴다.
+- SVG footer 텍스트가 DOM에는 존재하지만 일부 PNG 렌더에서 극소 크기로 보이는 현상은 #1201의 idRef 연결 문제와 별도 이슈로 분리하는 것이 타당하다.
+- 대상 원본 HWPX/PDF 파일은 PR에 포함하지 않는다.
+
+## 검증
+
+통과:
+
+```text
+cargo fmt --all --check
+cargo test --lib hwpx
+cargo test --test issue_1100_exam_social_hwpx_header
+cargo test --test issue_1113_header_autonum_placeholder
+```
+
+추가 확인:
+
+```text
+rhwp-studio dev server: http://127.0.0.1:5177/
+```
+
+`rhwp-studio` 페이지 제목과 주요 UI 텍스트가 브라우저에서 로드되는 것을 확인했다.
+
+## 완료 판정
+
+- section XML의 `masterPage@idRef`가 파싱된다.
+- manifest id/href와 `idRef`가 연결된다.
+- `SectionDef.master_pages`가 대상 샘플의 section별 바탕쪽을 보존한다.
+- masterpage `type`은 HWPX XML의 명시값을 기준으로 매핑된다.
+- 실제 샘플에서 홀짝 바탕쪽이 구조적으로 반전되지 않는다.
+- 지정 회귀 테스트가 모두 통과했다.

--- a/mydocs/working/task_m100_1201_stage1.md
+++ b/mydocs/working/task_m100_1201_stage1.md
@@ -1,0 +1,52 @@
+# Task M100-1201 Stage 1 완료 보고 — manifest id map과 section idRef 수집
+
+## 작업 범위
+
+구현계획서 Stage 1 범위에 따라 HWPX masterpage 연결에 필요한 식별자 수집 경로만 추가했다.
+
+## 변경 내용
+
+### `src/parser/hwpx/content.rs`
+
+- `PackageInfo`에 `master_page_items: Vec<PackageItem>` 필드를 추가했다.
+- `content.hpf` manifest의 XML 항목 중 href가 `masterpage`를 포함하는 항목을 id/href/media-type과 함께 보존한다.
+- 기존 `section_master_page_files`는 Stage 2 fallback 및 기존 테스트 호환을 위해 유지했다.
+- 기존 manifest 순서 기반 테스트에 masterpage id/href 보존 검증을 추가했다.
+
+### `src/parser/hwpx/section.rs`
+
+- section XML의 `<hp:masterPage idRef="...">`를 문서 순서대로 수집하는 helper를 추가했다.
+
+```rust
+pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError>
+```
+
+- 네임스페이스 접두사가 있는 `<hp:masterPage>`와 없는 `<masterPage>`를 모두 처리한다.
+- `idRef`가 없는 masterpage root는 section 참조로 보지 않고 무시한다.
+- 수집 helper의 정상 케이스와 root masterpage 무시 케이스 테스트를 추가했다.
+
+## 검증
+
+통과:
+
+```text
+cargo test --lib test_parse_content_hpf_master_pages_by_manifest_order
+cargo test --lib test_collect_hwpx_section_master_page_refs
+cargo fmt --all --check
+```
+
+## 확인 결과
+
+- manifest의 `masterpage0 -> Contents/masterpage0.xml` 같은 id/href 관계를 보존할 수 있게 됐다.
+- section XML의 `masterPage idRef`를 파싱할 수 있게 됐다.
+- 아직 `parse_hwpx()`의 연결 로직은 변경하지 않았다. 현재 Stage 1은 수집 경로까지만 완료했다.
+
+## 다음 단계
+
+Stage 2에서는 `src/parser/hwpx/mod.rs`에서 다음 연결 흐름을 구현한다.
+
+```text
+section XML idRef -> PackageInfo.master_page_items id -> href -> parse_hwpx_master_page()
+```
+
+Stage 2 착수 전 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m100_1201_stage2.md
+++ b/mydocs/working/task_m100_1201_stage2.md
@@ -1,0 +1,77 @@
+# Task M100-1201 Stage 2 완료 보고 — idRef 기반 masterpage 연결
+
+## 작업 범위
+
+구현계획서 Stage 2 범위에 따라 `parse_hwpx()`의 masterpage 연결 방식을 section XML의 `idRef` 기준으로 변경했다.
+
+## 변경 내용
+
+### `src/parser/hwpx/mod.rs`
+
+- `resolve_master_page_hrefs()` helper를 추가했다.
+
+```text
+section masterPage idRef 목록
+-> content.hpf manifest master_page_items id 매칭
+-> masterpage href 목록
+```
+
+- resolve 결과는 section XML의 `idRef` 순서를 보존한다.
+- 같은 masterpage href가 중복 참조되면 section 단위로 한 번만 연결한다.
+- resolve되지 않은 `idRef`는 warning만 출력하고 문서 파싱은 계속한다.
+
+### `parse_hwpx()` 연결 순서
+
+새 연결 순서:
+
+```text
+1. section XML 로드
+2. collect_hwpx_section_master_page_refs(section_xml)
+3. parse_hwpx_section(section_xml)
+4. idRef -> manifest id -> href resolve
+5. href 파일을 읽어 parse_hwpx_master_page()
+6. SectionDef.master_pages에 push
+```
+
+fallback:
+
+```text
+idRef가 없거나 idRef 기반 masterpage 연결이 하나도 성공하지 못한 경우
+-> 기존 section_master_page_files 기반 manifest 순서 fallback 사용
+```
+
+이 fallback은 기존 샘플/기존 동작 호환을 위해 유지했다.
+
+## 테스트
+
+추가:
+
+- `parser::hwpx::tests::test_resolve_master_page_hrefs_uses_id_ref_order_and_dedups`
+  - manifest 순서와 관계없이 section `idRef` 순서대로 href가 resolve되는지 확인
+  - 중복 href dedup 확인
+  - 누락 idRef 보고 확인
+
+## 검증
+
+통과:
+
+```text
+cargo fmt --all --check
+cargo test --lib test_resolve_master_page_hrefs_uses_id_ref_order_and_dedups
+cargo test --lib test_collect_hwpx_section_master_page_refs
+cargo test --lib test_parse_content_hpf_master_pages_by_manifest_order
+cargo test --lib hwpx
+```
+
+## 확인 결과
+
+- `parse_hwpx()`가 더 이상 masterpage 연결의 1차 기준을 manifest 순서 추정에만 두지 않는다.
+- HWPX section XML의 명시적 `masterPage idRef`를 우선 사용한다.
+- HWP5 raw parser의 `[Both, Odd, Even]` 순서 해석은 변경하지 않았다.
+- masterpage XML 내부 `type` 해석은 아직 Stage 3 범위로 남아 있다.
+
+## 다음 단계
+
+Stage 3에서는 `src/parser/hwpx/section.rs`의 `masterPage@type` 파싱을 공식 문서 표기와 실제 샘플 표기를 모두 수용하도록 보강한다.
+
+Stage 3 착수 전 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m100_1201_stage3.md
+++ b/mydocs/working/task_m100_1201_stage3.md
@@ -1,0 +1,68 @@
+# Task M100-1201 Stage 3 완료 보고 — masterPage@type 파싱 정합성 보강
+
+## 작업 범위
+
+구현계획서 Stage 3 범위에 따라 HWPX `masterPage@type` 값 해석을 보강했다.
+
+## 변경 내용
+
+### `src/parser/hwpx/section.rs`
+
+- `HwpxMasterPageType` 내부 enum을 추가했다.
+- `parse_hwpx_master_page_type()` helper를 추가했다.
+- type 문자열은 ASCII 영숫자만 남긴 뒤 대문자로 정규화한다.
+
+지원 표기:
+
+```text
+BOTH / Both / both
+EVEN / Even / even
+ODD / Odd / odd
+LAST_PAGE / LastPage / lastPage
+OPTIONAL_PAGE / OptionalPage / optionalPage
+```
+
+기존 의미 유지:
+
+- `LAST_PAGE pageDuplicate="0"`는 기존처럼 `is_extension=true`, `overlap=true`, `replace_base=true`로 처리한다.
+- `OPTIONAL_PAGE` 계열은 기존처럼 `is_extension=true`, `overlap=true`, `ext_flags=0x0007`로 처리한다.
+- 알 수 없는 type 값은 기존 동작과 같이 `Both`로 닫힌다.
+
+## 테스트
+
+추가:
+
+- `parser::hwpx::section::tests::test_parse_hwpx_master_page_type_accepts_official_and_sample_spellings`
+  - 공식 문서식 CamelCase와 실제 샘플식 uppercase/underscore 표기를 함께 검증
+- `parser::hwpx::section::tests::test_parse_master_page_mixed_case_type_attrs`
+  - 실제 `parse_hwpx_master_page()` 경로에서 mixed-case type이 `MasterPage` 필드로 반영되는지 검증
+
+기존 유지:
+
+- `test_parse_master_page_last_page_extension`
+- `test_parse_master_page_optional_page_extension`
+
+## 검증
+
+통과:
+
+```text
+cargo fmt --all --check
+cargo test --lib test_parse_hwpx_master_page_type_accepts_official_and_sample_spellings
+cargo test --lib test_parse_master_page_mixed_case_type_attrs
+cargo test --lib test_parse_master_page_last_page_extension
+cargo test --lib test_parse_master_page_optional_page_extension
+cargo test --lib hwpx
+```
+
+## 확인 결과
+
+- HWPX masterpage type은 XML의 명시값을 기준으로 매핑한다.
+- HWP5 raw parser의 `[Both, Odd, Even]` 순서 기반 해석은 변경하지 않았다.
+- #1201 샘플의 `EVEN`/`ODD` 표기와 공식 문서의 `Even`/`Odd` 표기 모두 같은 결과로 해석된다.
+
+## 다음 단계
+
+Stage 4에서는 실제 #1201 샘플을 대상으로 구조 및 시각 검증을 수행한다.
+
+Stage 4 착수 전 작업지시자 승인이 필요하다.

--- a/mydocs/working/task_m100_1201_stage4.md
+++ b/mydocs/working/task_m100_1201_stage4.md
@@ -1,0 +1,99 @@
+# Task M100-1201 Stage 4 완료 보고 — 대상 샘플 구조/시각 검증
+
+## 작업 범위
+
+구현계획서 Stage 4 범위에 따라 #1201 대상 HWPX/PDF 샘플에서 바탕쪽 masterpage가 section에 연결되고, EVEN/ODD가 반대로 적용되지 않는지 확인했다.
+
+대상 파일:
+
+```text
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx
+/Users/melee/Downloads/[2027] 온새미로 1 본교재.pdf
+```
+
+## 구조 검증
+
+명령:
+
+```text
+cargo run --bin rhwp -- dump "/Users/melee/Downloads/[2027] 온새미로 1 본교재.hwpx" | rg "=== 구역|바탕쪽:|\[[0-9]+\] (Even|Odd|Both)|p\[[0-9]+\]: cc=.*text="
+```
+
+확인 결과:
+
+- HWPX는 rhwp 기준 47쪽으로 파싱된다.
+- section 0부터 section 4까지 모두 `바탕쪽: 2개`가 채워진다.
+- section 0:
+  - `[0] Even` 텍스트: `2027 온새미로 II`
+  - `[1] Odd` 텍스트: `독서 · 문학`
+- section 1부터 section 4:
+  - `[0] Even` 텍스트: `2027학년도 수능 대비`
+  - `[1] Odd` 텍스트: `독서 · 문학`
+
+해석:
+
+- `content.hpf` manifest item id/href와 section XML의 `masterPage@idRef` 연결이 동작한다.
+- `SectionDef.master_pages`가 비어 있지 않고, 각 section에 EVEN/ODD 바탕쪽이 들어간다.
+- XML root의 `type="EVEN"`/`type="ODD"`가 각각 `HeaderFooterApply::Even`/`Odd`로 매핑된다.
+
+## 시각 검증
+
+생성물:
+
+```text
+output/poc/task1201_masterpage/stage4/[2027] 온새미로 1 본교재_004.svg
+output/poc/task1201_masterpage/stage4/[2027] 온새미로 1 본교재_005.svg
+output/poc/task1201_masterpage/stage4/[2027] 온새미로 1 본교재_006.svg
+output/poc/task1201_masterpage/stage4/[2027] 온새미로 1 본교재_007.svg
+output/poc/task1201_masterpage/stage4/png/[2027] 온새미로 1 본교재_004.png
+output/poc/task1201_masterpage/stage4/png/[2027] 온새미로 1 본교재_005.png
+output/poc/task1201_masterpage/stage4/png/[2027] 온새미로 1 본교재_006.png
+output/poc/task1201_masterpage/stage4/png/[2027] 온새미로 1 본교재_007.png
+tmp/pdfs/task1201/pdf_page_004.png
+tmp/pdfs/task1201/pdf_page_005.png
+tmp/pdfs/task1201/pdf_page_006.png
+tmp/pdfs/task1201/pdf_page_007.png
+```
+
+PDF 기준 확인:
+
+- PDF 4쪽: 짝수쪽 바탕쪽. 좌측 하단 `4 2027학년도 수능 대비`.
+- PDF 5쪽: 홀수쪽 바탕쪽. 우측 상단 회색 bar, 우측 하단 `독서 · 문학 5`.
+- PDF 6쪽: 짝수쪽 바탕쪽. 좌측 계열 머리말/꼬리말.
+- PDF 7쪽: 홀수쪽 바탕쪽. 우측 계열 머리말/꼬리말.
+
+rhwp SVG/PNG 확인:
+
+- rhwp 5쪽은 홀수쪽 바탕쪽 형태인 우측 상단 회색 bar가 보인다.
+- rhwp 6쪽은 `dump-pages` 기준 `page_num=6`이며 짝수쪽 바탕쪽 형태인 좌측 계열 머리말이 적용된다.
+- rhwp 7쪽은 `dump-pages` 기준 `page_num=7`이며 홀수쪽 바탕쪽 형태인 우측 상단 회색 bar가 적용된다.
+- SVG DOM에는 6쪽 하단 `6 2027학년도 수능 대비`, 7쪽 하단 `독서 7 문학` 텍스트가 존재한다.
+
+주의:
+
+- rhwp 파싱 결과는 47쪽, 원본 PDF는 49쪽이라 전체 쪽 번호의 1:1 비교는 아직 불안정하다. 이는 #1201의 masterpage 연결 문제와 별개인 기존 pagination/layout 차이로 본다.
+- rhwp SVG의 footer 텍스트는 DOM에는 있으나 일부 PNG 렌더에서 매우 작거나 보이지 않는다. 해당 텍스트는 `font-size`가 극소값으로 출력되는 경향이 있어, #1201의 idRef 연결 문제보다는 별도 텍스트 metric/textbox 렌더링 이슈로 분리하는 것이 타당하다.
+
+## 결론
+
+Stage 4 범위에서 #1201의 핵심 완료 조건은 충족했다.
+
+- section XML의 `masterPage@idRef`가 실제 샘플에서 수집된다.
+- manifest id/href와 idRef가 연결되어 section별 `master_pages`가 채워진다.
+- EVEN/ODD type은 XML 명시값 기준으로 매핑된다.
+- 대상 페이지에서 홀짝 바탕쪽이 구조적으로 반전되지 않는다.
+
+## 다음 단계
+
+Stage 5에서는 회귀 검증과 최종 보고서를 작성한다.
+
+예정 검증:
+
+```text
+cargo fmt --all --check
+cargo test --lib hwpx
+cargo test --test issue_1100_exam_social_hwpx_header
+cargo test --test issue_1113_header_autonum_placeholder
+```
+
+Stage 5 착수 전 작업지시자 승인이 필요하다.

--- a/src/parser/hwpx/content.rs
+++ b/src/parser/hwpx/content.rs
@@ -32,6 +32,11 @@ pub struct PackageInfo {
     /// HWPX manifest는 masterpage 항목을 section 항목 앞에 배치하는 형태가 관찰된다.
     /// 예: masterpage0..2, section0, masterpage3..5, section1 ...
     pub section_master_page_files: Vec<Vec<String>>,
+    /// 바탕쪽 XML manifest 항목 목록 (id/href 보존).
+    ///
+    /// section XML의 `<hp:masterPage idRef="...">`와 manifest item id를 매칭해
+    /// 명시적으로 연결하기 위한 원본 정보다.
+    pub master_page_items: Vec<PackageItem>,
     /// BinData 항목 목록
     pub bin_data_items: Vec<PackageItem>,
 }
@@ -115,6 +120,7 @@ pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError> {
     }
 
     info.section_master_page_files = collect_section_master_pages(&all_items, &info.section_files);
+    info.master_page_items = collect_master_page_items(&all_items);
 
     // BinData 항목 추출
     // [Task #873] 기존: BinData/ 폴더 내 항목만 수집 → isEmbeded="0" (외부 file 참조)
@@ -134,6 +140,21 @@ pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError> {
     }
 
     Ok(info)
+}
+
+fn collect_master_page_items(all_items: &[(String, String, String, bool)]) -> Vec<PackageItem> {
+    all_items
+        .iter()
+        .filter(|(_, href, media_type, _)| {
+            media_type == "application/xml" && href.to_ascii_lowercase().contains("masterpage")
+        })
+        .map(|(id, href, media_type, is_embedded)| PackageItem {
+            href: href.clone(),
+            media_type: media_type.clone(),
+            id: id.clone(),
+            is_embedded: *is_embedded,
+        })
+        .collect()
 }
 
 fn collect_section_master_pages(
@@ -283,6 +304,13 @@ mod tests {
 </opf:package>"#;
 
         let info = parse_content_hpf(xml).unwrap();
+        assert_eq!(info.master_page_items.len(), 3);
+        assert_eq!(info.master_page_items[0].id, "masterpage0");
+        assert_eq!(info.master_page_items[0].href, "Contents/masterpage0.xml");
+        assert_eq!(info.master_page_items[1].id, "masterpage1");
+        assert_eq!(info.master_page_items[1].href, "Contents/masterpage1.xml");
+        assert_eq!(info.master_page_items[2].id, "masterpage2");
+        assert_eq!(info.master_page_items[2].href, "Contents/masterpage2.xml");
         assert_eq!(
             info.section_master_page_files,
             vec![

--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -17,6 +17,8 @@ pub mod reader;
 pub mod section;
 pub mod utils;
 
+use std::collections::{HashMap, HashSet};
+
 use crate::model::bin_data::{BinData, BinDataContent, BinDataType};
 use crate::model::document::{Document, FileHeader, HwpVersion, Section};
 
@@ -55,6 +57,52 @@ impl From<zip::result::ZipError> for HwpxError {
 impl From<quick_xml::Error> for HwpxError {
     fn from(e: quick_xml::Error) -> Self {
         HwpxError::XmlError(e.to_string())
+    }
+}
+
+fn resolve_master_page_hrefs<'a, 'b>(
+    id_refs: &'b [String],
+    master_page_items: &'a [content::PackageItem],
+) -> (Vec<&'a str>, Vec<&'b str>) {
+    let href_by_id: HashMap<&str, &str> = master_page_items
+        .iter()
+        .map(|item| (item.id.as_str(), item.href.as_str()))
+        .collect();
+    let mut seen_hrefs = HashSet::new();
+    let mut hrefs = Vec::new();
+    let mut missing_refs = Vec::new();
+
+    for id_ref in id_refs {
+        match href_by_id.get(id_ref.as_str()).copied() {
+            Some(href) if seen_hrefs.insert(href) => hrefs.push(href),
+            Some(_) => {}
+            None => missing_refs.push(id_ref.as_str()),
+        }
+    }
+
+    (hrefs, missing_refs)
+}
+
+fn attach_hwpx_master_page(
+    reader: &mut reader::HwpxReader,
+    section: &mut Section,
+    master_page_href: &str,
+) -> bool {
+    match reader.read_file(master_page_href) {
+        Ok(master_page_xml) => match section::parse_hwpx_master_page(&master_page_xml) {
+            Ok(master_page) => {
+                section.section_def.master_pages.push(master_page);
+                true
+            }
+            Err(e) => {
+                eprintln!("경고: {} 파싱 실패: {}", master_page_href, e);
+                false
+            }
+        },
+        Err(e) => {
+            eprintln!("경고: {} 읽기 실패: {}", master_page_href, e);
+            false
+        }
     }
 }
 
@@ -101,25 +149,43 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
     let mut sections = Vec::new();
     for (section_idx, section_href) in package_info.section_files.iter().enumerate() {
         let section_xml = reader.read_file(section_href)?;
+        let master_page_refs = match section::collect_hwpx_section_master_page_refs(&section_xml) {
+            Ok(refs) => refs,
+            Err(e) => {
+                eprintln!("경고: {} masterPage 참조 파싱 실패: {}", section_href, e);
+                Vec::new()
+            }
+        };
         match section::parse_hwpx_section(&section_xml) {
             Ok(mut section) => {
-                if let Some(master_page_files) =
-                    package_info.section_master_page_files.get(section_idx)
-                {
-                    for master_page_href in master_page_files {
-                        match reader.read_file(master_page_href) {
-                            Ok(master_page_xml) => {
-                                match section::parse_hwpx_master_page(&master_page_xml) {
-                                    Ok(master_page) => {
-                                        section.section_def.master_pages.push(master_page);
-                                    }
-                                    Err(e) => {
-                                        eprintln!("경고: {} 파싱 실패: {}", master_page_href, e);
-                                    }
-                                }
-                            }
-                            Err(e) => {
-                                eprintln!("경고: {} 읽기 실패: {}", master_page_href, e);
+                let (master_page_hrefs, missing_master_page_refs) =
+                    resolve_master_page_hrefs(&master_page_refs, &package_info.master_page_items);
+                for missing_ref in missing_master_page_refs {
+                    eprintln!(
+                        "경고: {} masterPage idRef '{}' manifest 항목 없음",
+                        section_href, missing_ref
+                    );
+                }
+
+                let mut attached_master_page_count = 0usize;
+                for master_page_href in master_page_hrefs {
+                    if attach_hwpx_master_page(&mut reader, &mut section, master_page_href) {
+                        attached_master_page_count += 1;
+                    }
+                }
+
+                if attached_master_page_count == 0 {
+                    if let Some(master_page_files) =
+                        package_info.section_master_page_files.get(section_idx)
+                    {
+                        let mut fallback_seen = HashSet::new();
+                        for master_page_href in master_page_files {
+                            if fallback_seen.insert(master_page_href.as_str()) {
+                                attach_hwpx_master_page(
+                                    &mut reader,
+                                    &mut section,
+                                    master_page_href,
+                                );
                             }
                         }
                     }
@@ -241,5 +307,37 @@ mod tests {
         // CFB/HWP 데이터로 시도
         let result = parse_hwpx(&[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_resolve_master_page_hrefs_uses_id_ref_order_and_dedups() {
+        let items = vec![
+            content::PackageItem {
+                id: "masterpage1".to_string(),
+                href: "Contents/masterpage1.xml".to_string(),
+                media_type: "application/xml".to_string(),
+                is_embedded: true,
+            },
+            content::PackageItem {
+                id: "masterpage0".to_string(),
+                href: "Contents/masterpage0.xml".to_string(),
+                media_type: "application/xml".to_string(),
+                is_embedded: true,
+            },
+        ];
+        let id_refs = vec![
+            "masterpage0".to_string(),
+            "missing".to_string(),
+            "masterpage1".to_string(),
+            "masterpage0".to_string(),
+        ];
+
+        let (hrefs, missing_refs) = resolve_master_page_hrefs(&id_refs, &items);
+
+        assert_eq!(
+            hrefs,
+            vec!["Contents/masterpage0.xml", "Contents/masterpage1.xml"]
+        );
+        assert_eq!(missing_refs, vec!["missing"]);
     }
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -69,6 +69,45 @@ pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError> {
     Ok(section)
 }
 
+/// section XML의 `<hp:masterPage idRef="...">` 참조를 문서 순서대로 수집한다.
+pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError> {
+    let mut reader = Reader::from_str(xml);
+    let mut refs = Vec::new();
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) | Ok(Event::Empty(ref e)) => {
+                if local_name(e.name().as_ref()) == b"masterPage" {
+                    push_master_page_id_ref(e, &mut refs);
+                }
+            }
+            Ok(Event::Eof) => break,
+            Err(e) => {
+                return Err(HwpxError::XmlError(format!(
+                    "section masterPage refs: {}",
+                    e
+                )))
+            }
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(refs)
+}
+
+fn push_master_page_id_ref(e: &quick_xml::events::BytesStart, refs: &mut Vec<String>) {
+    for attr in e.attributes().flatten() {
+        if attr.key.as_ref() == b"idRef" {
+            let id_ref = attr_str(&attr);
+            if !id_ref.is_empty() {
+                refs.push(id_ref);
+            }
+        }
+    }
+}
+
 /// masterpage*.xml을 파싱하여 기존 HWP 바탕쪽 모델로 변환한다.
 pub fn parse_hwpx_master_page(xml: &str) -> Result<MasterPage, HwpxError> {
     let mut master_page = MasterPage::default();
@@ -120,27 +159,55 @@ pub fn parse_hwpx_master_page(xml: &str) -> Result<MasterPage, HwpxError> {
     Ok(master_page)
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum HwpxMasterPageType {
+    Both,
+    Even,
+    Odd,
+    LastPage,
+    OptionalPage,
+}
+
+fn parse_hwpx_master_page_type(value: &str) -> HwpxMasterPageType {
+    let normalized: String = value
+        .chars()
+        .filter(|c| c.is_ascii_alphanumeric())
+        .map(|c| c.to_ascii_uppercase())
+        .collect();
+
+    match normalized.as_str() {
+        "EVEN" => HwpxMasterPageType::Even,
+        "ODD" => HwpxMasterPageType::Odd,
+        "LASTPAGE" => HwpxMasterPageType::LastPage,
+        "OPTIONALPAGE" => HwpxMasterPageType::OptionalPage,
+        _ => HwpxMasterPageType::Both,
+    }
+}
+
 fn parse_master_page_start(e: &quick_xml::events::BytesStart, master_page: &mut MasterPage) {
     let mut is_last_page = false;
     let mut is_optional_page = false;
     let mut page_duplicate: Option<bool> = None;
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
-            b"type" => match attr_str(&attr).as_str() {
-                "EVEN" => master_page.apply_to = HeaderFooterApply::Even,
-                "ODD" => master_page.apply_to = HeaderFooterApply::Odd,
-                "LAST_PAGE" => {
-                    is_last_page = true;
-                    master_page.apply_to = HeaderFooterApply::Both;
-                    master_page.is_extension = true;
+            b"type" => {
+                let value = attr_str(&attr);
+                match parse_hwpx_master_page_type(&value) {
+                    HwpxMasterPageType::Even => master_page.apply_to = HeaderFooterApply::Even,
+                    HwpxMasterPageType::Odd => master_page.apply_to = HeaderFooterApply::Odd,
+                    HwpxMasterPageType::LastPage => {
+                        is_last_page = true;
+                        master_page.apply_to = HeaderFooterApply::Both;
+                        master_page.is_extension = true;
+                    }
+                    HwpxMasterPageType::OptionalPage => {
+                        is_optional_page = true;
+                        master_page.apply_to = HeaderFooterApply::Both;
+                        master_page.is_extension = true;
+                    }
+                    HwpxMasterPageType::Both => master_page.apply_to = HeaderFooterApply::Both,
                 }
-                "OPTIONAL_PAGE" => {
-                    is_optional_page = true;
-                    master_page.apply_to = HeaderFooterApply::Both;
-                    master_page.is_extension = true;
-                }
-                _ => master_page.apply_to = HeaderFooterApply::Both,
-            },
+            }
             b"pageDuplicate" => {
                 let duplicate = attr_str(&attr) != "0";
                 page_duplicate = Some(duplicate);
@@ -5823,6 +5890,127 @@ mod tests {
             }
             buf.clear();
         }
+    }
+
+    #[test]
+    fn test_collect_hwpx_section_master_page_refs() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:masterPage idRef="masterpage0"/>
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0"><hp:t>body</hp:t></hp:run>
+  </hp:p>
+  <masterPage idRef="masterpage1"/>
+</hs:sec>"#;
+
+        let refs = collect_hwpx_section_master_page_refs(xml).unwrap();
+        assert_eq!(refs, vec!["masterpage0", "masterpage1"]);
+    }
+
+    #[test]
+    fn test_collect_hwpx_section_master_page_refs_ignores_root_masterpage_without_id_ref() {
+        let xml = r#"<masterPage xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+            id="masterpage0" type="EVEN">
+  <hp:subList textWidth="1000" textHeight="2000"/>
+</masterPage>"#;
+
+        let refs = collect_hwpx_section_master_page_refs(xml).unwrap();
+        assert!(refs.is_empty());
+    }
+
+    #[test]
+    fn test_parse_hwpx_master_page_type_accepts_official_and_sample_spellings() {
+        assert_eq!(
+            parse_hwpx_master_page_type("BOTH"),
+            HwpxMasterPageType::Both
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("Both"),
+            HwpxMasterPageType::Both
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("both"),
+            HwpxMasterPageType::Both
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("EVEN"),
+            HwpxMasterPageType::Even
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("Even"),
+            HwpxMasterPageType::Even
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("even"),
+            HwpxMasterPageType::Even
+        );
+        assert_eq!(parse_hwpx_master_page_type("ODD"), HwpxMasterPageType::Odd);
+        assert_eq!(parse_hwpx_master_page_type("Odd"), HwpxMasterPageType::Odd);
+        assert_eq!(parse_hwpx_master_page_type("odd"), HwpxMasterPageType::Odd);
+        assert_eq!(
+            parse_hwpx_master_page_type("LAST_PAGE"),
+            HwpxMasterPageType::LastPage
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("LastPage"),
+            HwpxMasterPageType::LastPage
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("lastPage"),
+            HwpxMasterPageType::LastPage
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("OPTIONAL_PAGE"),
+            HwpxMasterPageType::OptionalPage
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("OptionalPage"),
+            HwpxMasterPageType::OptionalPage
+        );
+        assert_eq!(
+            parse_hwpx_master_page_type("optionalPage"),
+            HwpxMasterPageType::OptionalPage
+        );
+    }
+
+    #[test]
+    fn test_parse_master_page_mixed_case_type_attrs() {
+        fn parse_type(type_value: &str) -> MasterPage {
+            let xml = format!(
+                r#"<masterPage xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+            type="{type_value}" pageNumber="4" pageDuplicate="0">
+  <hp:subList textWidth="1000" textHeight="2000" hasTextRef="0" hasNumRef="0"/>
+</masterPage>"#
+            );
+            parse_hwpx_master_page(&xml).unwrap()
+        }
+
+        let both = parse_type("Both");
+        assert_eq!(both.apply_to, HeaderFooterApply::Both);
+        assert!(!both.is_extension);
+
+        let even = parse_type("Even");
+        assert_eq!(even.apply_to, HeaderFooterApply::Even);
+        assert!(!even.is_extension);
+
+        let odd = parse_type("odd");
+        assert_eq!(odd.apply_to, HeaderFooterApply::Odd);
+        assert!(!odd.is_extension);
+
+        let last_page = parse_type("LastPage");
+        assert_eq!(last_page.apply_to, HeaderFooterApply::Both);
+        assert!(last_page.is_extension);
+        assert!(last_page.overlap);
+        assert!(last_page.replace_base);
+        assert_eq!(last_page.ext_flags, 0x0003);
+
+        let optional_page = parse_type("optionalPage");
+        assert_eq!(optional_page.apply_to, HeaderFooterApply::Both);
+        assert!(optional_page.is_extension);
+        assert!(optional_page.overlap);
+        assert!(!optional_page.replace_base);
+        assert_eq!(optional_page.ext_flags, 0x0007);
     }
 
     #[test]


### PR DESCRIPTION
## 변경 내용

- HWPX `content.hpf`에서 masterpage manifest 항목의 `id`와 `href`를 함께 보존합니다.
- section XML의 `<hp:masterPage idRef="...">`를 수집하고, `idRef -> manifest id -> href -> masterpage XML` 순서로 `SectionDef.master_pages`에 연결합니다.
- 같은 section 안에서 동일 masterpage href가 중복 연결되지 않도록 처리했습니다.
- HWPX `masterPage@type` 표기를 정규화해 `EVEN`/`ODD`뿐 아니라 `Even`/`Odd`, `LastPage`, `OptionalPage` 계열도 안정적으로 해석합니다.
- 기존 manifest 순서 기반 `section_master_page_files` 경로는 `idRef` 연결이 실패한 경우의 fallback으로 유지했습니다.

## 원인

기존 HWPX 파서는 section XML의 `masterPage@idRef`를 직접 따라가지 않고 manifest 순서 기반으로 masterpage 파일을 추정했습니다.

이 방식은 샘플에 따라 우연히 맞을 수는 있지만, manifest 순서가 section 참조 순서와 달라지면 section별 바탕쪽이 잘못 연결되거나 홀짝 바탕쪽이 반대로 보일 수 있습니다. HWPX에서는 HWP5 raw parser의 순서 기반 규칙이 아니라 XML에 명시된 `idRef`와 `type`을 우선해야 합니다.

## 범위와 주의

- 이 PR은 HWPX masterpage의 파싱 및 section 연결 정합성을 보강합니다.
- HWP5 raw parser의 기존 바탕쪽 LIST_HEADER 순서 해석은 변경하지 않았습니다.
- 대상 샘플에서 PDF 기준 4쪽 바탕쪽이 rhwp 출력에서는 5쪽부터 보이는 현상은 section0 pagination/layout 차이로 남아 있습니다. 즉 이 PR은 해당 페이지 밀림 자체를 해결하지 않습니다.
- 원본 재현 HWPX/PDF 파일은 커밋에 포함하지 않았고, PR 첨부로 별도 제공할 예정입니다.

## 관련 이슈

Closes edwardkim/rhwp#1201

## 테스트

- [x] `cargo fmt --all --check`
- [x] `cargo test`
- [x] `cargo clippy -- -D warnings`
- [x] `cargo test --lib hwpx`
- [x] `cargo test --test issue_1100_exam_social_hwpx_header`
- [x] `cargo test --test issue_1113_header_autonum_placeholder`
- [x] 대상 HWPX 샘플 `dump`로 section별 `Even`/`Odd` 바탕쪽 연결 확인
- [x] 대상 HWPX 샘플 `export-svg` 및 PDF 4~7쪽 참고 비교

## 스크린샷

이번 PR은 parser/IR 연결 보강이 주 범위라 변경 전후 스크린샷 차이는 제한적입니다.
대상 샘플의 시각적 pagination 차이는 별도 layout 이슈에서 다루는 것이 적절합니다.
