### PR TITLE
Task #1246: 미주 between-notes margin min-gap (HeightCursor) — closes #1238, #1246

### DIFF
--- a/mydocs/plans/task_m100_1238.md
+++ b/mydocs/plans/task_m100_1238.md
@@ -1,0 +1,68 @@
+# 수행 계획서 — Task #1238: 미주 between-notes margin 누락 (다줄 문단 다음 제목)
+
+- **이슈**: #1238 (M100 / v1.0.0)
+- **브랜치**: `feature/issue-1238-between-notes-margin` (base: `stream/devel`)
+- **대상**: `samples/3-11월_실전_통합_2022.hwpx` 14쪽 문22(외 문21·23·27·28·29)
+- **작성일**: 2026-06-02
+
+## 1. 증상
+
+미주(답안) 영역에서 **다줄 풀이 문단으로 끝나는 문제** 다음의 **문제 제목**이 이전 줄에 붙는다.
+문22 제목 above-gap 11.3px (정상 문제-경계 ~29~38px). 문23·21·27·28·29 동일.
+
+## 2. 1차 가설 (코드 확인)
+
+`src/renderer/typeset.rs:2031-2061` between-notes margin:
+
+```rust
+let prev_spacing = prev_para.line_segs.last().line_spacing.max(0);   // 직전 문단 마지막 seg
+let extra_gap = (between_notes - prev_spacing).max(0);
+if extra_gap > 0 { vpos_offset += pagination_gap; last_seg.line_spacing = between_notes; }
+```
+
+- `prev_spacing` 이 직전 문단 **마지막 LINE_SEG 의 line_spacing**(문단 내 줄간격) 이다.
+- 직전 문단이 **다줄**이면 마지막 seg 의 line_spacing 이 이미 between_notes(7mm) 이상 →
+  `extra_gap = 0` → **두 메커니즘 모두 미적용** → 제목이 앞 줄에 붙음.
+- 직전 문단이 단일줄(또는 마지막 seg spacing 이 작음)인 일반 문제-경계는 정상 작동.
+
+→ `prev_spacing` 을 "직전 문단의 trailing 여백" 으로 본 전제가 **다줄 문단에서 깨진다**.
+   (문단 내부 마지막 줄의 line_spacing 은 trailing 이 아니라 줄 사이 간격 값일 수 있음.)
+
+## 3. 난도/제약 (기존 시도 회귀)
+
+- last_seg 주입값을 render 에서 trailing 으로 쓰면 issue_1139(3-09월 문15 7mm)·issue_1189
+  4건 **이중 가산 회귀** (확인됨).
+- between-notes 가 **vpos_offset(위치 누적)** 과 **last_seg.line_spacing(문단 속성)** 2경로로
+  적용되고, 문서별로 효과 경로가 달라 단순 수정이 회귀를 부른다.
+- 단일줄 미주 문단 render 경로가 paragraph_layout 예상 분기(4156·4179)를 안 타(진단 count=0)
+  → **회귀 없는 수정 지점 미특정** 상태.
+
+## 4. 단계 구성 (3단계, 코드 무변경 조사 우선)
+
+### Stage 1 — 정확한 미적용 지점·조건 특정 (코드 무변경)
+- 문22 직전 문단(문21 풀이 마지막 다줄)의 `line_segs.last().line_spacing` 실측 →
+  `between_notes` 와 비교해 extra_gap=0 성립 확인.
+- 정상 문제-경계(단일줄 끝)와 비정상(다줄 끝)의 prev_spacing 차이를 수치 대조.
+- between-notes 가 실제 화면 gap 으로 반영되는 **render 경로**(vpos_offset vs last_seg) 추적 —
+  3-11월 / 3-09월(issue_1139) 각각 어느 경로가 효과를 내는지.
+- **산출**: `tech/between_notes_multiline_1238.md` (실측 표 + 정확한 분기).
+- **게이트**: 원인·회귀 안전 조건 확정 후 수정.
+
+### Stage 2 — 회귀 없는 게이트 수정
+- prev_spacing 산정을 "다줄 문단 마지막 줄의 내부 줄간격" 이 아닌 **실제 trailing 여백**으로
+  보정하거나, 다줄-끝 조건에서만 between_notes 를 보장하는 **조건 게이트**.
+- issue_1139·1189 4건 + 3-11월 문22 **동시 통과** 목표.
+- **검증**: 문22 above-gap ~29~38px, 골든 스냅샷, 전체 cargo test.
+
+### Stage 3 — 시각·회귀·문서화
+- 문22·23·21·27·28·29 above-gap PDF(한글 2022) 14쪽 정합.
+- issue_1139 문15 gap 비회귀(이중가산 0).
+- 골든 + 전체 cargo test + 최종 보고서 `report/task_m100_1238_report.md`.
+
+## 5. 검증 도구
+
+| 항목 | 명령 |
+|------|------|
+| 시각 | `rhwp export-svg samples/3-11월_실전_통합_2022.hwpx -p 13` ↔ `pdf/…2022.pdf` 14쪽 |
+| 배치 수치 | `rhwp dump-pages -p 13` (above-gap), `dump -s -p` (line_segs spacing) |
+| 회귀 | 골든 스냅샷, `cargo test` (issue_1139·1189 포함) |

--- a/mydocs/plans/task_m100_1238_impl.md
+++ b/mydocs/plans/task_m100_1238_impl.md
@@ -1,0 +1,56 @@
+# 구현 계획서 — Task #1238: 미주 between-notes margin 누락
+
+- **이슈**: #1238 (M100 / v1.0.0)
+- **브랜치**: `feature/issue-1238-between-notes-margin` (base: `stream/devel`)
+- **수행계획서**: `plans/task_m100_1238.md`
+- **Stage 1 조사**: `tech/between_notes_multiline_1238.md`
+- **작성일**: 2026-06-02
+
+## 설계 요지 (Stage 1 확정)
+
+between-notes(미주 사이 7mm=1984HU)는 `typeset.rs:2055` 에서 **직전 미주 마지막 문단의
+`last_seg.line_spacing = 1984`** 주입으로만 적용된다(pagination_gap=0). 그러나
+`paragraph_layout.rs:4156` 다줄 미주 문단(`endnote_line_vpos_base`) 경로가 **마지막 줄 trailing 을
+0.0 으로 버려** 주입값을 무시 → 다줄로 끝나는 미주 다음 제목이 붙는다(문22 11.3px). 단일줄
+경로(L4173)는 line_spacing 을 포함하므로 정상.
+
+**수정**: 다줄 경로 마지막 줄 trailing 을, **다른 미주가 뒤따르는 마지막 문단**(=주입 위치)에서만
+`line_spacing_px` 로 복원. 단일줄 경로·같은 미주 내부·문서 마지막 미주는 무영향 → 이중가산 없음.
+
+## 단계 구성 (3단계)
+
+### Stage 1 — 원인 특정 (완료, 코드 무변경)
+- 산출: `tech/between_notes_multiline_1238.md`, `working/task_m100_1238_stage1.md`.
+
+### Stage 2 — 회귀 없는 게이트 수정
+- `layout.rs` 에 헬퍼 `endnote_para_has_different_endnote_successor(para_index) -> bool` 추가:
+  `endnote_para_sources` 의 local idx 기준, 다음 문단의 (section_index, para_index, control_index)
+  가 현재와 **다르면** true(다음 local 없으면 false = 문서 마지막 미주).
+- `paragraph_layout.rs:4156` 다줄 경로 trailing 분기:
+  ```rust
+  let trailing = if line_idx + 1 < end {
+      line_spacing_px
+  } else if self.endnote_para_has_different_endnote_successor(para_index) {
+      line_spacing_px   // #1238 between-notes margin (주입된 last_seg.line_spacing)
+  } else {
+      0.0
+  };
+  ```
+- **검증**: 문22 above-gap ~27~38px, 골든 스냅샷, 전체 `cargo test` (issue_1139/1189 포함) 무회귀.
+
+### Stage 3 — 시각·회귀·문서화
+- **시각**: 문22(외 다줄로 끝나는 미주) above-gap PDF(한글 2022) 14쪽 정합 + 단일줄 경계 비회귀.
+- **회귀**: 골든 + 전체 `cargo test`, 특히 issue_1139(3-09월 7mm/20mm)·1189 페이지 수 불변.
+- **산출**: `report/task_m100_1238_report.md`.
+
+## 단계별 커밋 정책
+
+각 Stage 소스 + `working/task_m100_1238_stage{N}.md` 동반 커밋. 무관 rustfmt diff 금지.
+
+## 회귀 가드
+
+| 위험 | 방어 |
+|------|------|
+| 3-09월 between-notes 이중가산 | 게이트가 주입 위치(=다른 미주 successor)와 정확 일치, 단일줄 경로 불변 |
+| 페이지 수 변동 | issue_1139 page-count 테스트 + 골든 스냅샷 |
+| #1236(PR#1240) 머지 충돌 | L4156 의미 직교(미주 내부 vs 미주 사이) → OR 결합 |

--- a/mydocs/plans/task_m100_1238_impl_v2.md
+++ b/mydocs/plans/task_m100_1238_impl_v2.md
@@ -1,0 +1,67 @@
+# 구현 계획서 v2 — Task #1238: 미주 between-notes margin 누락 (min-gap 모델)
+
+- **이슈**: #1238 (M100 / v1.0.0)
+- **브랜치**: `feature/issue-1238-between-notes-margin`
+- **선행**: `plans/task_m100_1238_impl.md`(v1, 가산 모델 — **반증·폐기**), `tech/between_notes_multiline_1238.md` §7
+- **작성일**: 2026-06-02
+
+## 배경 — v1 폐기 사유
+
+v1 의 "다줄 마지막 줄 trailing 복원"(가산) 접근은 두 변형(blanket / `pagination_gap==0` 게이트)
+모두 회귀 가드 4건(issue_1139·1189)을 **동일하게** 깨뜨려 반증됨. 세 문서 모두 경계에서
+`pagination_gap==0` → 해당 판별자는 무효. 실측(tech §7.1)으로 between-notes 는 **가산이 아니라
+min-gap(클램프)** 임이 확정됨.
+
+## 설계 — min-gap 클램프
+
+미주 사이 간격을 **최소 between_notes(7mm≈26.5px) 로 보장**하되, 자연 간격이 이미 그 이상이면
+변경하지 않는다.
+
+```
+새 미주의 첫 문단 시작 y := max(incoming_y, prev_endnote_last_content_bottom + between_notes_px)
+```
+
+| 문서 | natural gap | max(·, 26.5) | 효과 |
+|------|-------------|--------------|------|
+| 3-11월 문22 (target) | 0.0 | 26.5 | ✅ 수정 |
+| 3-09월 문15 (guard) | 26.5 | 26.5 | 무변경 ✅ |
+| 3-10월 문19 (guard) | 52.9 | 52.9 | 무변경 ✅ |
+
+가산이 깨뜨린 지점(이미 ≥7mm 인 경계 과대가산)을 정확히 회피한다.
+
+## 단계 구성 (3단계)
+
+### Stage 1 — 재개 완료 (코드 무변경)
+- 산출: `tech/between_notes_multiline_1238.md` §7 (실측 표 + min-gap 모델 + 잔여 리스크).
+
+### Stage 2 — min-gap 클램프 구현
+1. **typeset.rs**: between-notes 가 적용되는 **새 미주의 첫 문단**의 렌더 para_index(=`paragraphs.len()
+   + local`)와 적용할 `between_notes_px` 를 수집 → `PaginationResult` 신규 필드로 전달
+   (v1 (B)의 배선 패턴 재사용. 단 의미는 "첫 문단 + 마진값").
+2. **layout.rs**: 세터 + 조회 헬퍼. `endnote_para_base` 기반 절대 인덱스 맵
+   `para_index -> between_notes_px`.
+3. **paragraph_layout.rs**: 미주 문단 진입부에
+   - "직전 미주 마지막 content bottom"을 상태로 추적(미주 흐름 한정),
+   - 현재 문단이 "새 미주 첫 문단" 집합에 속하면 시작 y 를
+     `max(y, prev_endnote_last_bottom + between_notes_px)` 로 클램프.
+   - **가산 아님** — 이미 충분하면 no-op.
+- **검증**: 전체 `cargo test`(가드 4건 + 골든 포함) 통과, 문22 gap 0→~26.5px.
+
+### Stage 3 — 시각·회귀·문서화
+- **시각**: 3-11월 14쪽 문22(외 다줄로 끝나는 미주) above-gap PDF(한글 2022) 정합 + 3-09·10월 비회귀.
+- **회귀**: 골든 + 전체 `cargo test`. 특히 issue_1139(문15 [24,32]), 1189(q18→q19 [205,235],
+  q19→q20 [180,210]) 와 페이지 수 불변.
+- **산출**: `report/task_m100_1238_report.md`.
+
+## 회귀 가드
+
+| 위험 | 방어 |
+|------|------|
+| 이미 ≥7mm 경계 과대 (v1 실패 원인) | max() no-op — 가산 아님 |
+| 3-10월 문18(gap=0) 클램프 → q간격/overflow (tech §7.3) | 가드 4건 + 골든이 PDF 캘리브레이션값으로 직접 검출. 위반 시 즉시 보고·재설계 |
+| 누적 밀림 페이지 수 변동 | issue_1139 page-count + 골든 스냅샷 |
+| #1236(PR#1240) 머지 | 클램프는 미주-**사이** 진입부, #1236 은 미주-**내부** trailing → 직교 |
+
+## 단계별 커밋 정책
+
+각 Stage 소스 + `working/task_m100_1238_stage{N}.md` 동반 커밋. 무관 rustfmt diff 금지.

--- a/mydocs/plans/task_m100_1246.md
+++ b/mydocs/plans/task_m100_1246.md
@@ -1,0 +1,107 @@
+# 수행 계획서 — Task #1246: render 미주 문단 좌표를 절대 vpos 앵커로 전환
+
+- **이슈**: #1246 (M100 / v1.0.0) — #1238(미주 between-notes margin) 흡수
+- **브랜치**: `feature/issue-1246-endnote-vpos-anchor` (base: `stream/devel`, #1238 브랜치에서 분기)
+- **대상**: 미주(답안) 영역 렌더 — `samples/3-11월_실전_통합_2022.hwp`(문22 외), 3-09·10·24월 회귀군
+- **선행 검증(흡수)**: `tech/between_notes_multiline_1238.md §7`, `working/task_m100_1238_stage2.md`
+- **작성일**: 2026-06-02
+
+## 1. 배경 — 왜 이 리팩터가 필요한가
+
+#1238 에서 미주 사이 between-notes margin(7mm) 누락(다줄 풀이 다음 제목이 붙음, 문22 외)을
+조사·구현했고 다음이 **확정**되었다:
+
+- between-notes 는 **가산(additive)이 아니라 min-gap(max 클램프)** 모델 — 한컴 2022 PDF
+  (`pdf/3-11월_실전_통합_2022.pdf` page10)로 검증.
+- **render-only 클램프는 머지 불가**: 새 미주 첫 문단을 `prev_bottom + between_notes` 로 강제하나,
+  한컴/렌더러는 미주를 **stored vpos 기반**으로 배치(#1209 safe-vpos-backtrack, rewind-tail) →
+  클램프가 vpos 위치를 침범 → 클린 stream/devel 통과 테스트 2건 회귀
+  (`issue_1189_2022_nov_pages10_12`, `issue_1209_2022_sep_page10_question12`).
+- pagination 동기화 5개 접근(en_fit/full-gap/deficit 누적, vpos extra_gap, rewind 게이트) 전부
+  타 문서 회귀 → **단순 보정 불가**.
+
+근본 원인은 **render 와 pagination 의 미주 vpos 좌표 불일치**다.
+
+## 2. 문제 정의 — render vs pagination 좌표 불일치
+
+| | 미주 문단 위치 산정 |
+|--|--|
+| **pagination** (`typeset.rs` 미주 루프) | 절대 stored vpos 기반: `this_first_offset = first_seg.vpos + endnote_start`, `compute_en_metrics` 의 vpos-delta advance, `current_height` 누적 |
+| **render** (`paragraph_layout.rs`) | 다줄 미주: `endnote_line_vpos_base = (first_seg.vpos, incoming_y)` → `y = base_y + (seg.vpos − base_vpos)`. **base_y = 누적 incoming y** (build 루프 누적값) |
+
+- render 의 문단 **앵커(base_y)가 누적 incoming y** 이므로, 미주 흐름을 따라 pagination 의 절대
+  vpos 위치와 **~수 px 단위로 drift** 한다(#1238 pi=475 +7.6px overflow 의 원인).
+- between-notes gap 을 어디에 넣어도(render 클램프 / typeset vpos / 누적) 두 좌표가 어긋나
+  한쪽이 깨진다.
+
+## 3. 목표
+
+render 의 미주 문단 위치 산정을 **pagination 과 동일한 절대(컬럼-상대) stored vpos 앵커**로
+전환하여 drift 를 **원천 제거**한다. 그러면:
+
+- between-notes min-gap 은 **stored vpos 차원에서 한 번만** 실현되면 render·pagination 양쪽이
+  동일하게 본다 → 클램프 hack 불필요, 이중가산 없음.
+- #1209 safe-vpos-backtrack / rewind-tail 도 같은 vpos 좌표를 쓰므로 양립.
+- #1238 문22(외) 누락이 회귀 없이 해소된다.
+
+## 4. 난도·제약 (반드시 인지)
+
+- 미주 렌더 위치 산정은 **약 30개 미주 테스트**(3-09·10·11·24월, 문29/30, rewind, 2024 미주모양,
+  TAC 그림, 다단 등)가 의존하는 핵심 경로. **무조건 적용/제거 둘 다 회귀** 가능
+  (메모리 룰 `tech_lazy_base_trailing_ls_gate` 경고 영역 = VPOS_CORR/lazy_base).
+- pagination 의 `compute_en_metrics` 는 `capped_new_endnote_advance`·`inline_object_overestimate`·
+  `local_vpos_rewind` 등 **문서별 특례가 밀집**. render 좌표를 바꾸면 이들과의 정합을 재확인해야 함.
+- 따라서 **조사 우선 + 작은 게이트 + 단계별 전체 회귀** 원칙을 엄격히 적용한다.
+
+## 5. 단계 구성 (코드 무변경 조사 우선, 4단계)
+
+### Stage 1 — render/pagination vpos 좌표 정합 실측 (코드 무변경)
+- render 의 미주 문단 base_y 산정 경로(`endnote_line_vpos_base`, build 루프 incoming y 누적)와
+  pagination 의 절대 vpos(`endnote_start`, `this_first_offset`, `compute_en_metrics`) 를 코드로 추적.
+- 3-11월 page10/14, 3-09월 page10(문12), 3-10월 page11 의 **문단별 render y vs pagination 예상 y**
+  를 실측해 drift 발생 지점·크기·누적 패턴을 표로 정리.
+- 단일줄/다줄/rewind/backtrack/TAC 각 경로가 base_y 를 어떻게 잡는지 분류.
+- **산출**: `tech/endnote_vpos_anchor_1246.md` (좌표 정합표 + 전환 가능 지점 + 리스크 매핑).
+- **게이트**: 전환 설계가 회귀 안전함을 확인 후 구현계획서 승인.
+
+### Stage 2 — 절대 vpos 앵커 전환 (핵심 구현)
+- render 미주 문단 base_y 를 **컬럼-상대 절대 vpos**(pagination 과 동일 기준)로 산정하도록 전환.
+- between-notes gap 은 stored vpos 에 일관 반영(#1238 의 injection/extra_gap 로직 재정비)되어
+  render·pagination 양쪽이 동일하게 소비.
+- 단일줄 경로·rewind·backtrack·TAC 그림 경로 각각 정합 유지.
+- **검증**: 문22(외) 0→~26.5px, 전체 `cargo test`, 특히 `issue_1189`·`issue_1209`·`issue_1139`
+  미주군 무회귀.
+
+### Stage 3 — 특례 정합·회귀 수렴
+- `compute_en_metrics` 특례(capped/rewind/inline-object)와 새 좌표의 정합 재확인·보정.
+- 문29/30 late-question tail, 2024 미주모양, 다단 흐름 비회귀.
+- 골든 스냅샷 + 전체 `cargo test` 수렴.
+
+### Stage 4 — 시각·문서화·PR
+- 한컴 2022 PDF 시각 정합: 3-11월 page10/14/17, 3-09·10월 미주 경계.
+- **산출**: `report/task_m100_1246_report.md`. stream/devel 기준 squash PR.
+
+## 6. 검증 도구
+
+| 항목 | 명령 |
+|------|------|
+| 좌표 실측 | `build_page_render_tree` + `min_para_text_y`/`max_para_content_bottom` (테스트 헬퍼) |
+| 배치 수치 | `rhwp dump-pages -p N`, `rhwp dump -s -p` |
+| 시각 | `rhwp export-svg ... -p N` ↔ `pdf/*-2022.pdf`, `pdftoppm` 크롭 대조 |
+| 회귀 | 골든 스냅샷, 전체 `cargo test` (issue_1139/1189/1209 미주군) |
+
+## 7. 회귀 가드
+
+| 위험 | 방어 |
+|------|------|
+| 미주 30개 테스트 광범위 회귀 | Stage 1 코드 무변경 정합 실측 선행, 단계별 전체 cargo test 게이트 |
+| #1209 backtrack/rewind 침범 (render-클램프 재발) | 새 좌표가 1209 와 동일 vpos 기준 → 침범 구조 자체 제거 |
+| between-notes 이중가산 | gap 을 stored vpos 한 곳에만 반영, render·pagination 동일 소비 |
+| `compute_en_metrics` 특례 충돌 | Stage 3 특례 정합 전용 단계 |
+
+## 8. #1238 흡수 처리
+
+- #1238 의 render-only 클램프 구현(`feature/issue-1238-...` dcaf1bff)은 **머지하지 않음**.
+  본 브랜치가 그 docs·레퍼런스를 상속하나, Stage 2 에서 클램프 코드는 **제거하고** 절대 vpos
+  앵커 방식으로 대체한다(클램프 hack 잔존 금지).
+- #1238 의 검증된 모델·PDF 근거·조사는 `tech §7`·`stage2` 로 보존되어 본 타스크 출발점이 된다.

--- a/mydocs/plans/task_m100_1246_impl.md
+++ b/mydocs/plans/task_m100_1246_impl.md
@@ -1,0 +1,67 @@
+# 구현 계획서 — Task #1246: HeightCursor 미주 min-gap + pagination 정합
+
+- **이슈**: #1246 (M100 / v1.0.0) — #1238 흡수
+- **브랜치**: `feature/issue-1246-endnote-vpos-anchor`
+- **수행계획서**: `plans/task_m100_1246.md`
+- **Stage 1 조사**: `tech/endnote_vpos_anchor_1246.md`, `working/task_m100_1246_stage1.md`
+- **작성일**: 2026-06-02
+
+## 설계 요지 (Stage 1 확정)
+
+전면 좌표 재작성 불필요. render 는 이미 `HeightCursor.vpos_adjust` 로 vpos→y 매핑하며
+compact endnote between-notes 특례(forward-cap/backtrack/safe-vpos-backtrack #1209)를 보유한다.
+**유일한 사각지대 = gap 이 부족할 때(stored vpos gap < between_notes, 특히 0=문22) 끌어올리는
+min-gap 로직 부재.** 수정은 이 한 케이스 추가 + pagination 동일 예약(국소).
+
+핵심 불변식:
+- min-gap 은 **forward 흐름 & gap 부족 & 비-backtrack/비-rewind/비-stale-forward** 에만 적용.
+  기존 분기(backtrack/forward-cap)가 **우선** → `issue_1209`(문12)·`issue_1189` 무회귀.
+- render 가 gap 만큼 end_y 를 늘리면 pagination 도 같은 gap 을 예약해야 pi=475 overflow 가 없다.
+
+## 단계 구성 (3단계: Stage 2~4)
+
+### Stage 2 — HeightCursor min-gap (render)
+1. `HeightCursor` 에 `endnote_between_notes_hu: i32` 필드 + 생성자 인자 추가. `build_single_column`
+   에서 현재 섹션 미주 shape 의 between-notes 마진(HU)을 주입(미주 흐름 컬럼만, 그 외 0).
+2. `vpos_adjust` compact endnote 분기(`suppress_large_forward_jump`)에 **min-gap 케이스** 추가:
+   - 조건: 새 미주 제목(`compact_endnote_question_title` 재사용) & forward(`end_y >= y_offset`) &
+     `end_y − prev_content_bottom_y < between_notes_px` & **기존 backtrack/rewind/stale-forward/
+     forward-cap 케이스 미해당**.
+   - 동작: `end_y = prev_content_bottom_y + between_notes_px`.
+   - `shift_vpos_base_for_rendered_delta` 정합(후속 줄이 gap 복원 안 하도록 base 이동).
+3. **신규 단위테스트**: stored gap 0/부족 → between_notes 로 확대, backtrack/forward-cap 우선 확인.
+4. **검증**: HeightCursor 단위테스트(28+) 무회귀, 문22 0→~26.5px, `issue_1209_2022_sep_page10_q12`·
+   `issue_1139` 미주군 무회귀.
+
+### Stage 3 — pagination 정합 (compute_en_metrics)
+1. `typeset.rs` 새 미주 첫 문단(forward & 비-rewind) fit/advance 에 동일 min-gap deficit 예약 —
+   render 의 end_y 확대와 동일 위치·크기. (#1238 §5.2 에서 실패한 full-gap/blanket 방식이 아니라,
+   render 와 정확히 같은 조건·deficit 으로 한정.)
+2. **검증**: `issue_1189_2022_nov_pages10_12`(pi=475) overflow 해소, 전체 `cargo test` 무회귀
+   (특히 issue_1209·1189·1139 미주군, 페이지 수 불변).
+
+### Stage 4 — 시각·회귀·문서화·PR
+- **시각**: 한컴 2022 PDF 정합 — 3-11월 page10/14/17, 3-09·10월 미주 경계 (`pdftoppm` 크롭 대조).
+- **회귀**: 골든 스냅샷 + 전체 `cargo test`.
+- **산출**: `report/task_m100_1246_report.md`. stream/devel 기준 squash PR.
+
+## 단계별 커밋 정책
+
+각 Stage 소스 + `working/task_m100_1246_stage{N}.md` 동반 커밋. 무관 rustfmt diff 금지.
+#1238 render-클램프 코드는 본 브랜치에 잔존(레퍼런스)하므로, Stage 2 착수 시 **제거**하고
+HeightCursor min-gap 으로 대체한다(클램프 hack 잔존 금지 — 수행계획서 §8).
+
+## 회귀 가드
+
+| 위험 | 방어 |
+|------|------|
+| #1209 backtrack(문12) 침범 | min-gap 은 비-backtrack & forward & gap부족 에만, 기존 분기 우선 |
+| pi=475 overflow | render+pagination 동일 deficit 예약 (Stage 2+3 동시) |
+| HeightCursor 단위테스트 회귀 | 신규 케이스 좁은 조건 + 신규 단위테스트, 28+ 기존 무영향 |
+| 문29/30 late-tail, 2024 미주모양, 다단 | issue_1139/1189/1209 전체 + 골든 |
+| between_notes_hu 주입 누락(미주 외 컬럼) | 미주 흐름 컬럼만 주입, 그 외 0 → 본문 무영향 |
+
+## #1238 와의 관계
+
+#1238 의 render-클램프(별 접근)는 폐기·제거. 본 타스크가 동일 목표(문22 외 between-notes)를
+HeightCursor min-gap 으로 회귀 없이 달성하며 #1238 을 종결한다(closes #1238 후보).

--- a/mydocs/report/task_m100_1246_report.md
+++ b/mydocs/report/task_m100_1246_report.md
@@ -1,0 +1,63 @@
+# 최종 결과 보고서 — Task #1246: 미주 between-notes margin (HeightCursor min-gap)
+
+- **이슈**: #1246 (M100 / v1.0.0) — #1238(미주 between-notes margin 누락) 흡수
+- **브랜치**: `feature/issue-1246-endnote-vpos-anchor` (base: `stream/devel`)
+- **작성일**: 2026-06-02
+- **결과**: 완료 (closes #1238, #1246)
+
+## 1. 문제
+
+미주(답안) 영역에서 **다줄 풀이로 끝나는 문제 다음의 제목**이 직전 줄에 붙었다(문22 외 문21·23·
+27·28·29). 한컴 2022 기준 미주 사이 7mm(between-notes) 간격이 누락(문22 above-gap 0px).
+
+## 2. 원인 (조사 경과)
+
+#1238 → #1246 으로 이어진 조사로 확정:
+
+- between-notes 는 **가산(additive)이 아니라 min-gap(max)** 모델 (한컴 2022 PDF 검증).
+- render 는 미주 문단을 `HeightCursor.vpos_adjust`(#1027 Stage C)로 **vpos→y 매핑**하며, compact
+  endnote 사이 gap 특례(forward-cap/backtrack/safe-vpos-backtrack #1209)를 이미 보유.
+- **유일한 사각지대**: stored vpos gap 이 거의 0 인 경우(다줄 풀이 마지막 줄 trailing 이 render
+  에서 누락 → gap≈0, 문22) 끌어올리는 **min-gap 로직 부재**.
+- #1238 의 render-클램프 시도는 vpos 위치 시스템(#1209 backtrack 등)과 충돌해 폐기.
+
+## 3. 해결
+
+`HeightCursor.vpos_adjust` 말미에 **min-gap 케이스** 추가:
+
+- 조건: 새 미주 제목 & forward 흐름 & 다줄 prev & **stored vpos gap ∈ [-0.5, 4.0)px**.
+- 동작: `y_offset + prev_line_spacing_px`(직전 문단에 주입된 between-notes 줄간격)로 끌어올림.
+- 의도적 소-gap(문13 ~10px)·backtrack(문12 #1209)·단일줄 prev 는 **제외** → over-lift/회귀 회피.
+- 보정값이 `prev_line_spacing_px`(= pagination `compute_en_metrics` 가 `bottom_with_spacing` 으로
+  이미 예약한 trailing)와 동일 → render·pagination 정합, overflow 없음.
+
+배선: `typeset` 이 섹션 between-notes 마진(HU)을 `PaginationResult` 로 전달 → `layout` 셋업 시
+HeightCursor 에 주입(미주 흐름 컬럼만).
+
+## 4. 검증
+
+| 항목 | 결과 |
+|------|------|
+| **문22 above-gap** (3-11월 page14) | **0 → 26.5px (=7mm)** — 한컴 2022 PDF 시각 정합 확인 |
+| `issue_1189_2022_nov_pages10_12` (pi=475 overflow) | ✅ |
+| `issue_1189_2022_nov_page17` (문28 수식) | ✅ |
+| `issue_1209_2022_sep_page10_question12` (문12 safe-vpos-backtrack) | ✅ |
+| `issue_1139` 미주군, 3-09·10·24월 회귀군 | ✅ |
+| HeightCursor 단위테스트 (신규 3 + 기존 26) | ✅ 29 |
+| **전체 `cargo test`** | ✅ **1945 passed, 0 failed** |
+
+시각: `pdf/3-11월_실전_통합_2022.pdf` page14 ↔ `rhwp export-svg -p 13` 크롭 대조 — 문22 위 7mm
+gap 동일, 붙음 해소.
+
+## 5. #1238 흡수 종결
+
+#1238 의 검증된 모델(min-gap)·PDF 근거·전면 조사를 #1246 에서 회귀 없이 구현 완료. #1238 의
+render-클램프(별 접근)는 폐기. 본 PR 로 #1238, #1246 동시 종결.
+
+## 6. 산출물
+
+- 소스: `height_cursor.rs`(min-gap + 단위테스트 3), `layout.rs`/`typeset.rs`/`pagination.rs`/
+  `pagination/engine.rs`/`rendering.rs`/`paragraph_layout.rs`(배선·클램프 제거).
+- 문서: `plans/task_m100_1246{,_impl}.md`, `tech/endnote_vpos_anchor_1246.md`,
+  `working/task_m100_1246_stage{1,2}.md`, `tech/between_notes_multiline_1238.md §7`,
+  `working/task_m100_1238_stage2.md`.

--- a/mydocs/tech/between_notes_multiline_1238.md
+++ b/mydocs/tech/between_notes_multiline_1238.md
@@ -1,0 +1,139 @@
+# 조사 보고서 — Task #1238 Stage 1: 미주 between-notes margin 누락 원인
+
+작성일: 2026-06-02
+대상: #1238 — 14쪽 문22 제목이 직전 다줄 풀이에 붙음
+
+## 1. 증상 (실측)
+
+SVG 텍스트 y좌표를 열(2단) 분리해 제목 above-gap 측정:
+
+| 제목 | 직전 줄 | above-gap | 정상? |
+|------|---------|-----------|-------|
+| 문22 | 문21 풀이 마지막(다줄) "…합은 이다." | **11.3px** | ✗ (붙음) |
+| 문24 | "이다."(단일줄) | 37.8px | ✓ |
+| 문25 | (단일줄) | 26.9px | ✓ |
+| 문23 | (단일줄) | 35.3px | ✓ |
+
+between_notes(미주 사이) = 1984 HWPUNIT ≈ 26px. 정상 제목은 line_height + 26px 확보,
+문22 만 26px 누락(11.3px) → 직전이 **다줄 문단**일 때만 발생.
+
+## 2. between-notes 적용 메커니즘 (진단 로그 실측)
+
+`typeset.rs:2031-2061`. 임시 로그(`DBG_BN1238`)로 전 경계 실측:
+
+```
+between_notes=1984  prev_spacing=452  extra_gap=1532  pag_base=1984
+```
+
+- `pagination_gap = between_notes - BASE_FLOW_HU = 1984 - 1984 = 0` → **vpos_offset 미증가**.
+- 즉 between-notes 는 **오직 `prev_para.line_segs.last_mut().line_spacing = 1984`** 주입으로만 적용.
+  (직전 미주의 마지막 문단, 마지막 LINE_SEG 의 line_spacing 을 1984 로 덮어씀.)
+- 모든 문제-경계가 이 한 메커니즘에 의존한다(단일/다줄 무관 주입은 동일).
+
+→ **가설(extra_gap=0) 은 반증**. 주입은 항상 일어난다. 문제는 **render 가 주입값을 무시**하는 것.
+
+## 3. 근본 원인 (특정)
+
+`src/renderer/layout/paragraph_layout.rs`:
+
+- `endnote_line_vpos_base`(L1372-1389): **다줄 미주 문단**(`end > start_line + 1`)에서만 설정.
+  줄 위치를 stored LINE_SEG vpos 델타로 배치.
+- 줄 advance(L4152-4167, 이 경로):
+
+```rust
+let trailing = if line_idx + 1 < end { line_spacing_px } else { 0.0 };  // ← 마지막 줄 trailing 버림
+y + line_height + trailing + tac_picture_label_extra;
+```
+
+- **다줄 문단의 마지막 줄은 trailing = 0.0** → 주입된 last_seg.line_spacing(=1984) 이
+  다음 문단(문22 제목) 시작 y 에 **반영되지 않음**.
+- 단일줄 미주 문단은 이 경로를 타지 않고(L4173) `y += line_height + line_spacing_px` 로
+  line_spacing(=주입 1984)을 포함 → between-notes 정상 확보.
+
+→ **다줄 문단으로 끝나는 미주만 between-notes 가 누락**된다. (단일줄 끝은 정상.)
+
+## 4. stored vpos 무관 확인
+
+dump-pages: pi=631(문21 마지막) vpos=…400228, pi=632(문22) vpos=444925 (stored gap 큼).
+그러나 render 는 다줄 경로에서 stored vpos 를 para 내부 델타로만 쓰고 **다음 문단 시작 y 는
+이전 문단 마지막 줄 bottom(trailing 제외)** 으로 잡으므로 stored gap 은 반영 안 됨 → 11.3px.
+
+## 5. 회귀 안전 게이트 (Stage 2 방향)
+
+- 기존 시도(last_seg 무조건 trailing)는 issue_1139(3-09월)·1189 **이중 가산 회귀**.
+- between_notes 주입은 typeset.rs 에서 **"다음 미주가 존재할 때 직전 미주의 마지막 문단"**
+  에만 발생(`emitted_endnote_count > 0`). 따라서 **정확히 그 경우에만** trailing 복원:
+  - 신규 헬퍼 `endnote_para_has_different_endnote_successor(para_index)` —
+    `endnote_para_sources` 의 (section_index, para_index, control_index) 가 다음 local 과 다르면 true.
+  - L4156: `else if 헬퍼 { line_spacing_px } else { 0.0 }`.
+- 이 게이트는 **다른 미주가 뒤따르는 마지막 문단**(=주입 발생 위치)에만 trailing 을 복원 →
+  같은 미주 내 문단·문서 마지막 미주는 무영향. 단일줄 경로(L4173)는 손대지 않음 → 이중가산 없음.
+
+## 6. #1236(PR #1240) 와의 관계
+
+- 본 건은 stream/devel 분기(아직 #1236 미머지). L4156 는 현재 `line_idx + 1 < end`.
+- #1236 머지 시 같은 라인이 `... || same_endnote_successor` 로 바뀜(미주 **내부** 문단 trailing).
+- 본 건 게이트는 **다른 미주 successor**(미주 **사이**) 로 의미가 직교 → 머지 시 OR 결합 가능.
+  충돌 시 두 조건을 `||` 로 병합.
+
+---
+
+## 7. Stage 1 재개 (2026-06-02) — §5 가산 모델 반증 + min-gap 모델 특정
+
+§5 의 "trailing 복원" 가산(additive) 접근은 **두 변형 모두 회귀 가드 4건을 깨뜨려 반증됨**:
+
+| 시도 | 결과 |
+|------|------|
+| (A) blanket `endnote_para_has_different_endnote_successor` | 가드 4건 실패 |
+| (B) `pagination_gap == 0` 집합 게이트 | **(A)와 완전 동일한 실패값** |
+
+(B)가 (A)와 한 글자도 다르지 않은 결과 → **세 문서 모두 해당 경계에서 `pagination_gap == 0`**.
+즉 `pagination_gap` 은 "수정 대상"과 "회귀 금지"를 **구분 못 하는 판별자**다. §2 의 단일 메커니즘
+전제가 불완전했다.
+
+### 7.1 실제 렌더 y 실측 (baseline, 코드 무변경)
+
+`build_page_render_tree` + `min_para_text_y`/`max_para_content_bottom` (가드 테스트와 동일 측정):
+
+| 문서 | 경계 (prev→문N) | prev_bottom | 문N top | **rendered gap** | 판정 |
+|------|----------------|-------------|---------|------------------|------|
+| 3-11월 (target) | 631(다줄)→632 문22 | 457.9 | 457.9 | **0.0** | 버그 (7mm 필요) |
+| 3-09월 (guard) | 664(다줄)→665 문15 | 872.6 | 899.0 | **26.5** | 정상 (≈7mm) |
+| 3-10월 (guard) | 573→574 문19 | 678.5 | 731.4 | **52.9** | 정상 (>7mm) |
+| 3-10월 (guard) | 568(다줄)→569 문18 | 512.4 | 512.4 | **0.0** | §7.3 참조 |
+
+7mm = 1984 HU ≈ **26.5px** (96dpi).
+
+### 7.2 결론 — 가산(additive) 이 아니라 min-gap(클램프) 모델
+
+between-notes 는 "마지막 줄에 trailing 을 **더한다**"가 아니라 **"미주 사이 간격을 최소 7mm 로
+보장한다"**(자연 간격이 이미 7mm 이상이면 변경 없음). 가산 모델이 회귀한 이유:
+
+- 3-09월: 26.5 + 26.5 = 53 → 과대 (테스트 [24,32] 위반).
+- 3-10월: 52.9 + … = 누적 → overflow / q간격 과대.
+
+min-gap 모델 = **`gap := max(natural_gap, 7mm)`**:
+
+| 문서 | natural gap | max(·, 26.5) | 효과 |
+|------|-------------|--------------|------|
+| 3-11월 문22 | 0.0 | **26.5** | ✅ 수정 |
+| 3-09월 문15 | 26.5 | 26.5 | 변경 없음 ✅ |
+| 3-10월 문19 | 52.9 | 52.9 | 변경 없음 ✅ |
+
+세 케이스 동시 정합. 가산이 실패한 지점을 정확히 회피한다.
+
+### 7.3 잔여 리스크 — 3-10월 문18 (gap=0.0) + 누적 overflow
+
+- 문18(pi=569)은 실제 미주-사이 경계인데 baseline gap=0.0. **문18 풀이가 빈 문단 4개
+  (pi=570~573)뿐**이라, 3-10월 테스트는 인접 gap 이 아니라 **제목간 거리**(q18→q19 ∈ [205,235])
+  만 검사 → 문18 블록 전체가 균일히 아래로 밀리면 거리 보존.
+- 그러나 (a) min-gap 이 문18 을 7mm 밀 때 **한컴 PDF 에 실제 그 간격이 있는지**, (b) 결손 경계가
+  여러 개면 **누적 밀림이 페이지 하단 overflow** 를 일으키는지 — **Stage 2 검증에서 가드 4건 +
+  골든으로 직접 확인**해야 한다. 가드가 PDF 캘리브레이션값([205,235] 등)을 담고 있어 self-validating.
+
+### 7.4 구현 지점 후보
+
+가산 trailing(L4156)이 아니라, **새 미주의 첫 문단 진입 시** 시작 y 를
+`max(incoming_y, prev_endnote_last_content_bottom + between_notes_px)` 로 클램프.
+→ render(`paragraph_layout`)에 "직전 미주 마지막 content bottom" 상태 + "새 미주 첫 문단" 신호 필요.
+typeset 이 새 미주 첫 문단 local idx 집합을 넘기는 방식(§5 (B)의 배선 재사용 가능). 상세는 impl v2.

--- a/mydocs/tech/endnote_vpos_anchor_1246.md
+++ b/mydocs/tech/endnote_vpos_anchor_1246.md
@@ -1,0 +1,85 @@
+# 조사 보고서 — Task #1246 Stage 1: render/pagination 미주 vpos 좌표 정합
+
+작성일: 2026-06-02
+대상: #1246 (render 미주 좌표 정합) — #1238(미주 between-notes margin) 흡수
+선행: `tech/between_notes_multiline_1238.md §7`, `working/task_m100_1238_stage2.md`
+
+## 1. 핵심 발견 — 수행계획서 프레이밍 정정
+
+수행계획서(`plans/task_m100_1246.md`)는 "render 가 누적 incoming y 로 앵커 → 절대 vpos 앵커로
+전환"으로 프레이밍했으나, 코드 정독 결과 **부정확**했다. 실제:
+
+- **render 는 이미 vpos→y 매핑을 수행**한다. `build_single_column` 이 `HeightCursor`
+  (`src/renderer/height_cursor.rs`, Task #1027 Stage C)를 통해 항목마다 `vpos_adjust()` 로
+  `end_y = col_anchor_y + (vpos_end − base)` 를 계산한다(page_base/lazy_base 경로).
+- 따라서 "누적 y vs 절대 vpos" 라는 단순 대립이 아니다. **render·pagination 모두 vpos 기반**이되,
+  **서로 다른 코드 경로**로 계산해 어긋난다.
+
+## 2. 진짜 구조 — 두 개의 분리된 vpos 측정기
+
+| | 미주 문단 위치 산정 | 비고 |
+|--|--|--|
+| **render** | `HeightCursor.vpos_adjust` (`height_cursor.rs`) | compact endnote(`suppress_large_forward_jump`) 특례 **다수 보유** |
+| **pagination** | `typeset.rs` `compute_en_metrics` | vpos-delta advance + capped/rewind 특례, **별도 구현** |
+
+- Stage C 주석(`height_cursor.rs` L8): *"Stage D 에서 페이지네이터(typeset)가 동일 커서로
+  height-only 패스를 수행하여 두 측정 공간을 일치시킨다."* → **Stage D 미완**. 즉 pagination 이
+  HeightCursor 를 쓰지 않고 자체 `compute_en_metrics` 로 측정 → **두 공간 불일치 = drift 원천**.
+
+## 3. HeightCursor 는 이미 between-notes 를 처리한다
+
+`vpos_adjust` 의 compact endnote(`suppress_large_forward_jump=true`) 분기는 미주 사이 gap 을
+이미 광범위하게 다룬다(단위테스트로 고정):
+
+| 케이스 | 동작 | 테스트 |
+|--------|------|--------|
+| `compact_endnote_question_title_caps_large_forward_gap` | 큰 forward 점프를 `stored_gap+40` 으로 cap | L712 (`1984`=7mm 사용) |
+| `..preserves_spacing_on_stale_forward_jump` | stale 절대 vpos 버리고 직전 ls(1984)만 보존 | L734 |
+| `..after_empty_spacer_keeps_stored_gap_only` | 빈 spacer 뒤 +40 완충 생략 | L755 |
+| `..after_tall_line_uses_content_bottom_gap` | 큰 수식 뒤 제목은 내용 바닥+10 | L776 |
+| `compact_endnote_safe_vpos_backtrack` (L362) | 단 중간 backtrack 허용(내용 바닥 위) | **= #1209 문12 케이스** |
+| `compact_endnote_deep_backtrack`/`title_tail_backtrack` | 하단부 제한적 backtrack(overflow 완화) | L335/L346 |
+
+→ #1238 의 render-클램프가 깨뜨린 `issue_1209_2022_sep_page10_question12` 는 바로
+`compact_endnote_safe_vpos_backtrack`(L362). **render 클램프는 이 분기를 우회·침범**했다.
+
+## 4. 무엇이 빠졌나 — 문22(다줄-prev gap=0)
+
+HeightCursor 는 **forward 점프 cap / backtrack** 은 풍부하나, **"stored vpos 가 between_notes
+보다 작은 gap(특히 0)을 주는 경우 min-gap 으로 끌어올리는"** 케이스가 없다. 문22(다줄 풀이
+다음 제목, 직전 다줄 last seg trailing=0 → vpos gap≈0)가 정확히 이 사각지대다.
+
+- `vpos_end` 산정(L237-243): curr_first_vpos 가 prev seg.vpos 보다 크면 그 값 사용 → gap 이
+  stored vpos 그대로. stored gap=0 이면 end_y≈y_offset → 제목이 직전 줄에 붙음(문22 버그).
+- forward-cap/ backtrack 분기는 gap 이 **과도할 때** 줄이는 방향만 다룸 → **부족할 때 늘리는
+  로직 부재**.
+
+## 5. 수정 위치 결론 (Stage 2 방향)
+
+**전면 좌표 재작성 불필요.** 수정 위치는 `HeightCursor.vpos_adjust` 의 compact endnote 분기:
+
+1. **min-gap 케이스 추가**: compact endnote 에서 새 미주 첫 문단(제목)이 forward 흐름이고
+   `end_y − prev_content_bottom_y < between_notes_px` 면 `end_y = prev_content_bottom_y +
+   between_notes_px` 로 끌어올린다. **단**, backtrack(`safe_vpos_backtrack`/`deep_backtrack`)·
+   rewind·stale-forward 케이스는 **제외**(기존 분기 우선) → #1209 문12 무회귀.
+2. **pagination 정합**: render 에서 min-gap 으로 end_y 를 늘리면 `shift_vpos_base_for_rendered_delta`
+   (L419)로 base 를 이동해 후속 줄이 gap 을 복원하지 않게 함(기존 패턴). 단 pagination 의
+   `compute_en_metrics` 도 같은 gap 을 예약해야 overflow(pi=475) 가 없다 → **Stage D 부분 정합**
+   (between-notes 한정) 또는 compute_en_metrics 에 동일 min-gap 반영.
+
+`between_notes_px` 는 HeightCursor 가 알아야 하므로 셋업 시 주입(현재 미보유 — Stage 2 에서 추가).
+
+## 6. 잔여 리스크 / Stage 2 게이트
+
+| 위험 | 방어 |
+|------|------|
+| backtrack/forward-cap 케이스 침범 (문12 등) | min-gap 은 **forward & gap 부족 & 비-backtrack** 에만. 기존 분기 우선순위 유지 |
+| pi=475 overflow (pagination 미예약) | render min-gap + compute_en_metrics 동일 예약 동시 적용, 전체 cargo test 게이트 |
+| HeightCursor 단위테스트(28+개) 회귀 | 신규 케이스는 기존 테스트 입력에 영향 없도록 좁은 조건. 신규 단위테스트 추가 |
+| 문29/30 late-tail, 2024 미주모양 | 골든 + issue_1139/1189/1209 전체 통과 |
+
+## 7. Stage 2 착수 전 — 구현계획서 필요
+
+본 조사로 수정 위치(`HeightCursor.vpos_adjust` compact endnote min-gap + pagination 정합)와
+회귀 게이트가 특정되었다. **수행계획서의 "전면 절대 vpos 앵커" 단계 구성은 본 발견에 맞게
+구현계획서에서 재구성**한다(국소 HeightCursor 수정 중심). 구현계획서 승인 후 Stage 2 착수.

--- a/mydocs/working/task_m100_1238_stage1.md
+++ b/mydocs/working/task_m100_1238_stage1.md
@@ -1,0 +1,28 @@
+# Stage 1 완료 보고서 — Task #1238: between-notes margin 누락 원인 특정
+
+- **이슈**: #1238 (M100)
+- **브랜치**: `feature/issue-1238-between-notes-margin`
+- **단계**: Stage 1 / 3 (코드 무변경, 조사)
+- **작성일**: 2026-06-02
+
+## 핵심 결론
+
+1. **증상 실측**: 문22 above-gap 11.3px (정상 제목 27~38px). 직전이 **다줄 문단**일 때만 발생.
+2. **between-notes 적용**: `pagination_gap = 1984-1984 = 0`(vpos 미증가). between-notes 는
+   **오직 직전 미주 마지막 문단의 `last_seg.line_spacing = 1984` 주입**으로만 적용됨(진단 실측).
+   → 가설(extra_gap=0)은 반증. 주입은 항상 발생, render 가 무시가 진짜 원인.
+3. **근본 원인**: `paragraph_layout.rs:4156` — 다줄 미주 문단(`endnote_line_vpos_base`) 경로에서
+   **마지막 줄 trailing 을 `0.0` 으로 버림** → 주입된 line_spacing(between-notes) 미반영.
+   단일줄 경로(L4173)는 line_spacing 포함 → 정상.
+
+## 산출물
+
+- `mydocs/tech/between_notes_multiline_1238.md` (실측 표 + 분기 + 회귀 게이트 설계).
+
+## Stage 2 방향 (승인 요청)
+
+`endnote_para_has_different_endnote_successor()` 헬퍼로 **다른 미주가 뒤따르는 마지막 문단**
+(=between_notes 주입 위치)에만 다줄 경로 마지막 줄 trailing 복원. 단일줄 경로·같은 미주 내부·
+문서 마지막 미주 무영향 → issue_1139/1189 이중가산 회피.
+
+원인과 Stage 2 게이트 방향 확정 시 착수.

--- a/mydocs/working/task_m100_1238_stage2.md
+++ b/mydocs/working/task_m100_1238_stage2.md
@@ -1,0 +1,141 @@
+# Stage 2 진행 보고서 — Task #1238: min-gap 클램프 (pagination 동기화 미완)
+
+- **이슈**: #1238 (M100)
+- **브랜치**: `feature/issue-1238-between-notes-margin`
+- **단계**: Stage 2 / 3 (구현 + 검증, **부분 성공·미완**)
+- **작성일**: 2026-06-02
+- **선행**: `plans/task_m100_1238_impl_v2.md` (min-gap 모델), `tech/between_notes_multiline_1238.md` §7
+
+## 1. 구현 내용 (render 측 min-gap 클램프)
+
+- **typeset.rs**: between-notes(`between_notes > 0`) 경계마다 **새 미주 첫 문단의 local idx +
+  마진 HU** 를 `endnote_between_notes_min_gap` 에 수집 → `PaginationResult` 로 전달.
+- **layout.rs**: 세터 `set_endnote_between_notes_min_gap`(base+local→마진맵), 조회
+  `endnote_between_notes_min_gap_px`, 직전 미주 content bottom 추적 `endnote_prev_content_bottom`.
+- **paragraph_layout.rs**: `layout_composed_paragraph` 진입부에서 새 미주 첫 문단(start_line==0)의
+  시작 y 를 `max(y, prev_endnote_bottom + between_notes_px)` 로 클램프(가산 아닌 **max**).
+  같은 단 연속 흐름(`y_start + 0.5 >= prev_bottom`)에서만 — 컬럼 상단 신규 진입 제외.
+- **rendering.rs**: 세터 배선.
+
+## 2. 검증 결과 — 회귀 4건 → 2건
+
+| 테스트 | v1(가산) | v2(min-gap) |
+|--------|---------|-------------|
+| issue_1139 문15 [24,32] (3-09월) | ✗ (52.9) | **✅ 통과** |
+| issue_1189 oct q18→19 [205,235] (3-10월) | ✗ (192.6) | **✅ 통과** |
+| issue_1189 oct 기타 | ✗ | **✅ 통과** |
+| **issue_1189 nov pages10_12 (3-11월 pi=475)** | — | ✗ overflow +7.6px |
+| **issue_1189 nov page17 (3-11월 문28 수식)** | — | ✗ 수식 y 이탈 |
+
+- **min-gap 모델 자체는 정답**: 외부 가드(3-09·10월) 전부 통과, no-op 동작 확인.
+- 남은 2건은 **모두 타깃 파일 3-11월 내부**.
+
+## 3. 잔여 블로커 — render/pagination seg-vs-line vpos drift
+
+- render 클램프는 새 미주 첫 문단을 gap 만큼 아래로 밀어 **실제 콘텐츠 변위**로 만든다.
+- 그러나 pagination 의 **페이지 fit 판정**(`typeset.rs` `compute_en_metrics` 의 `en_fit`)은
+  between-notes 를 **직전 문단의 trailing**(overflow 허용, `fit = advance - trailing_ls_px`,
+  HeightMeasurer L141 "마지막 줄 line_spacing 제외")으로 처리 → gap 을 "무시 가능 공간"으로 봄.
+- 결과: render 가 gap 자리에 콘텐츠를 넣으면 pagination 이 계획한 페이지 하단을 초과(pi=475 +7.6px).
+- 더 정밀히는 pagination 예약치 = 마지막 **LINE_SEG**(`vpos+lh+ls`) vs render 클램프 기준 =
+  마지막 **그려진 LINE**(`y+line_height`)+gap → 되감김/빈 trailing seg 케이스에서 ~7.6px 어긋남.
+
+## 4. 동기화의 난점 (왜 단순 en_fit 가산이 안 되나)
+
+- `en_fit` 에 gap 을 더하면 **이미 gap 이 예약된 문서(3-09·10월)는 이중 예약** → 통과 중인
+  doc-specific 테스트 회귀. (3-09·10월은 baseline render 가 이미 26.5/52.9 표시 = pagination 이
+  이미 예약했다는 증거. 3-11월 文22·pi=475 만 미예약.)
+- "예약됨/미예약" 을 typeset 에서 깔끔히 구분하려면 render 의 정확한 위치 산정(seg-vs-line,
+  되감김)을 재현해야 함. `compact_endnote_separator_profile`/문29·30/`inline_object_overestimate`/
+  `new_endnote_between_notes_px` 등 문서별 특례가 밀집한 구간.
+
+## 5. pagination en_fit 예약 시도 — 반증 (blocker 는 예약이 아니라 drift)
+
+`compute_en_metrics` 직후 새-미주-첫-문단 `en_fit` 에 between_notes_px 를 더해(같은 단 연속,
+문29/30 제외) 페이지가 일찍 넘어가도록 시도 → **실패 2건 변화 없음**. 동시에 3-09·10월 가드는
+계속 통과(이중예약 회귀 없음).
+
+해석: pagination 의 **누적(acc=vpos-delta)은 이미 gap 을 포함**(`bottom_with_spacing` L2155)하므로
+페이지 패킹은 이미 gap 을 반영한다. 문제는 **render 가 같은 흐름을 pagination 측정보다 ~7.6px
+낮게 그리는 drift**(마지막 LINE_SEG vs 마지막 그려진 LINE). pi=475 는 새 미주 첫 문단이 아니라
+문6 꼬리 continuation 이며, 위쪽 경계 클램프가 전체 흐름을 밀어 누적 drift 가 페이지 하단을 넘김.
+
+→ **blocker 는 pagination 예약 부족이 아니라 render/pagination VPOS drift**
+(`[[tech_lazy_base_trailing_ls_gate]]` 가 경고한 회귀 민감 영역). en_fit 예약 시도는 revert 함.
+
+## 5.1 한컴 2022 PDF 시각 대조 (결정적) — gap 은 정답, 잔여는 drift
+
+`pdf/3-11월_실전_통합_2022.pdf` page 10 (한글 2022, Linux 1차 정답지) 실측:
+
+- 좌측 단에서 **문4→문5→문6 각 제목 앞에 균일한 between-notes gap 이 명확히 존재**. → min-gap
+  모델이 PDF 권위로 **검증됨**(외부 테스트뿐 아니라 정답지 일치).
+- 문6 본문은 좌측 단을 채우고 **우측 단으로 자연스럽게 이어짐(overflow 없음)**.
+
+결론: 남은 2건은 **모델 오류가 아니라** render/pagination **acc 근사 drift(~7.6px)**. 올바른 gap
+추가가 단-넘김 지점에서 기존 drift 를 가시화했을 뿐. 즉 **gap 은 그대로 두고, 단-넘김 정밀도
+(acc↔render 정합)만 보정**하면 된다.
+
+## 5.2 pagination 동기화 3차 시도 — 모두 회귀 (dense 영역 한계)
+
+drift 보정(승인)으로 pagination 누적을 render 클램프와 정합하려 3가지 조건부 게이트 시도:
+
+| 시도 | 변경 | 결과 |
+|------|------|------|
+| en_fit 가산 | 새-첫문단 fit 에 +gap | **무효** (overflow 변화 없음; pi=475 는 body 문단) |
+| en_advance +full gap | 누적에 +between_notes | **5+ 회귀** (3-09월 등 이미 예약된 문서 이중가산) |
+| en_advance +deficit | +max(0, gap − stored_vpos_gap) | **8 회귀** (prev_en_bottom_vpos 가 이미 bottom_with_spacing → 이중 차감, `capped_new_endnote_advance` 와 충돌) |
+| **(구조) vpos_offset += extra_gap** | 새 미주 stored vpos 를 부족분만큼 하향 | **7 회귀** (extra_gap>0 인 많은 경계에서 gap 이 이미 vpos/렌더에 존재 → 과다 이동; question29/30·oct·2023) |
+
+**판정**: pagination 누적부(`compute_en_metrics`)는 `capped_new_endnote_advance`·vpos-delta·
+trailing_ls 관례로 **이미 between-notes 를 조건부 처리**한다. 단순 가산/차감은 그 불변식과
+충돌해 다른 문서를 깬다. 안전한 정합은 이 서브시스템 불변식에 대한 깊은 이해(또는 render 가
+자체 클램프 대신 pagination 이 계산한 정확 위치를 그대로 쓰도록 하는 구조 변경)가 필요하다.
+3가지 시도 모두 revert 함.
+
+## 6. 현재 상태 / 최종 평가 (승인 필요)
+
+- **달성**: render 측 min-gap 클램프. 회귀 **4→2**, 외부 가드(3-09·10·23월) 전부 통과,
+  타깃 문22 메커니즘 작동, **한컴 2022 PDF 로 모델 검증**(§5.1).
+- **미해결**: 3-11월 내부 2건 — render/pagination **acc 근사 drift(~7.6px)** 로 인한
+  page10 overflow·page17 수식 위치. pagination 동기화 3차 시도 모두 회귀(§5.2).
+- 코드: **uncommitted WIP** (2건 실패 → 머지 불가).
+
+### 구조 변경(승인) 시도 결과
+- **간단 버전(vpos_offset += extra_gap)**: §5.2 마지막 행 — 7 회귀. 다수 경계에서 gap 이 이미
+  vpos/렌더에 존재해 과다 이동. → 단순 stored-vpos 하향으로는 불가.
+- **남은 구조 경로(대규모)**: render 의 미주 문단 base_y 를 "누적 incoming y" 대신 **절대 stored
+  vpos 앵커**로 전환(pagination 과 동일 좌표). 미주 렌더 위치 산정 전반을 바꾸므로 ~30개 미주
+  테스트에 광범위 영향 → 회귀 위험 큼, 신중한 단계적 작업 필요.
+
+### 결론 / 선택지 (총 5개 동기화 접근 모두 회귀 — 단순 보정 불가 확정)
+1. **현 render-only WIP 커밋 + 2건 known-issue**: 모델·PDF 검증 가치 보존, drift 후속 분리.
+2. **대규모 구조 리팩터**(render 미주 좌표를 절대 vpos 앵커로): 깊은 작업, 별도 타스크 권장.
+   → **후속 이슈 생성됨: #1246** (render 미주 좌표 절대 vpos 앵커 전환).
+3. **baseline revert**: 모델/PDF/시도 기록만 문서 보존, 구현은 후속 재착수.
+
+## 7. stream/devel 리베이스 후 결정 — #1238 을 #1246 에 흡수
+
+현 stream/devel(914ee139, task 1209 미주 VPOS 되감김 포함) 기준으로 squash·rebase 후 재검증:
+
+- **호재**: 1209 의 미주 VPOS 보정으로 기존 known-issue 중 `nov_page17` 가 **자동 해소**.
+- **악재**: render 클램프가 **devel 의 기존 통과 테스트 2건을 회귀**시킴(클린 devel 에서 둘 다 통과 확인):
+  - `issue_1189_2022_nov_pages10_12` (pi=475): page10 overflow +7.6px (cascade)
+  - `issue_1209_2022_sep_page10_question12` (문12): 클램프가 1209 safe-vpos-backtrack 위치(396)를
+    418.69 로 강제. rewind 게이트(local/internal_vpos_rewind, large_vpos_jump)로도 미검출.
+
+**근본 결론**: render min-gap 클램프는 새 미주 첫 문단을 `prev_bottom + between_notes` 로 강제하나,
+한컴/렌더러는 미주를 **stored vpos 기반**(1209 backtrack, rewind-tail)으로 배치 → 클램프가 vpos
+위치를 침범. **render 클램프 접근 자체가 vpos 위치 시스템과 양립 불가**. 단독 머지 시 기존 테스트 회귀.
+
+**결정(작업지시자)**: #1238 을 **#1246 에 흡수**. render 클램프 구현은 머지하지 않고, #1246
+(render 미주 좌표 절대 vpos 앵커 전환)에서 클램프 hack 없이 vpos 차원에서 gap 을 실현 →
+1209 backtrack 과 양립. 본 브랜치(`feature/issue-1238-between-notes-margin`)는 **검증된 모델 + PDF
+근거 + 5개 시도 + render-클램프 레퍼런스**로 #1246 의 출발점이 된다.
+
+- 코드: **uncommitted WIP** (2건 실패 → 머지 불가). render 측 min-gap 은 검증됨, en_fit 시도는 제거.
+- 다음 후보:
+  1. **render 측 drift 정합**: 클램프 기준을 render 의 drift 된 `prev_content_bottom` 대신
+     pagination 의 예약 위치(마지막 LINE_SEG bottom 기반)와 일치시켜 ~7.6px 오버슈트 제거.
+     VPOS_CORR/lazy_base 영역이라 조건부 게이트 필수(무조건 적용/제거 둘 다 회귀 위험).
+  2. **한컴 PDF 시각 판정**: page17 수식·pi=475 의 현재 이동 결과를 한글 2022 PDF 와 대조해
+     정답/회귀를 작업지시자가 판정 → drift 정합 방향(어느 위치가 옳은지) 확정.

--- a/mydocs/working/task_m100_1246_stage1.md
+++ b/mydocs/working/task_m100_1246_stage1.md
@@ -1,0 +1,40 @@
+# Stage 1 완료 보고서 — Task #1246: render/pagination 미주 vpos 좌표 정합 (코드 무변경)
+
+- **이슈**: #1246 (M100) — #1238 흡수
+- **브랜치**: `feature/issue-1246-endnote-vpos-anchor`
+- **단계**: Stage 1 / 4 (코드 무변경, 조사)
+- **작성일**: 2026-06-02
+
+## 핵심 결론
+
+1. **수행계획서 프레이밍 정정**: "render 가 누적 incoming y 로 앵커한다"는 부정확. render 는 이미
+   `HeightCursor.vpos_adjust`(Task #1027 Stage C)로 **vpos→y 매핑**을 수행한다. → 전면 좌표
+   재작성 불필요.
+2. **drift 진짜 원인**: render(`HeightCursor`)와 pagination(`compute_en_metrics`)이 **분리된 두
+   vpos 측정기**다(Stage D 미완 — pagination 이 공유 커서를 안 씀). 두 공간 불일치가 #1238
+   pi=475 +7.6px drift 의 근원.
+3. **HeightCursor 는 이미 between-notes 처리**: compact endnote 분기에 forward-cap(1984=7mm),
+   stale-forward, backtrack, **`compact_endnote_safe_vpos_backtrack`(=#1209 문12)** 등 다수 특례
+   보유(단위테스트 28+). #1238 render 클램프는 이 분기를 침범해 문12 회귀를 냈다.
+4. **사각지대**: HeightCursor 는 gap 이 **과도할 때 줄이는** 로직만 있고, **부족할 때(stored
+   vpos gap < between_notes, 특히 0=문22) 끌어올리는 min-gap 로직이 없다**. 이것이 #1238 문22 버그.
+
+## 수정 위치 (Stage 2 방향, 국소)
+
+`HeightCursor.vpos_adjust` compact endnote 분기에 **min-gap 케이스 추가**:
+- 새 미주 첫 문단이 forward 흐름 & `end_y − prev_content_bottom < between_notes_px` & **비-backtrack**
+  이면 `end_y = prev_content_bottom + between_notes_px`.
+- backtrack/rewind/stale-forward 기존 분기 우선 → #1209 무회귀.
+- `between_notes_px` 셋업 주입 + `shift_vpos_base_for_rendered_delta` 로 base 이동.
+- pagination(`compute_en_metrics`) 도 동일 gap 예약 → pi=475 overflow 방지.
+
+## 산출물
+
+- `mydocs/tech/endnote_vpos_anchor_1246.md` (좌표 구조 + HeightCursor 특례표 + 수정 위치 + 게이트).
+
+## Stage 2 방향 (승인 요청)
+
+전면 좌표 재작성이 아니라 **HeightCursor.vpos_adjust 의 compact endnote min-gap 추가 + pagination
+정합**(국소). 수행계획서의 단계 구성은 본 발견에 맞춰 **구현계획서에서 재구성**한다.
+
+원인·수정 위치·게이트 확정 시, 구현계획서 작성 → 승인 후 Stage 2 착수.

--- a/mydocs/working/task_m100_1246_stage2.md
+++ b/mydocs/working/task_m100_1246_stage2.md
@@ -1,0 +1,55 @@
+# Stage 2 완료 보고서 — Task #1246: HeightCursor 미주 min-gap (render)
+
+- **이슈**: #1246 (M100) — #1238 흡수
+- **브랜치**: `feature/issue-1246-endnote-vpos-anchor`
+- **단계**: Stage 2 / 4 (구현)
+- **작성일**: 2026-06-02
+
+## 구현 내용
+
+### 1. #1238 render-클램프 제거
+`paragraph_layout.rs` 의 `layout_composed_paragraph` 진입부 min-gap 클램프 + `last_item_content_bottom`
+병행 추적(`endnote_prev_content_bottom`) 제거. vpos 위치 시스템과 충돌하던 hack 폐기.
+
+### 2. between-notes 마진 배선 (스칼라화)
+- `typeset.rs`: 섹션 미주 between-notes 마진(HU)을 `endnote_between_notes_hu` 스칼라로 수집 →
+  `PaginationResult` 전달 (#1238 의 `Vec<(local,hu)>` 맵 → 스칼라로 단순화).
+- `layout.rs`: `set_endnote_between_notes_hu(hu)` 세터 + `endnote_between_notes_hu` Cell.
+- `rendering.rs`: 섹션 렌더 셋업에서 전달.
+
+### 3. HeightCursor min-gap (핵심)
+- `HeightCursor` 에 `endnote_between_notes_hu: i32` 필드. `build_single_column` 이 미주 흐름
+  컬럼에만 주입(본문 0).
+- `vpos_adjust` 말미: 결과 y 계산 후, **새 미주 제목 & forward & 다줄 prev & stored vpos gap≈0
+  (`[-0.5,4.0)`px)** 이면 `y_offset + prev_line_spacing_px`(직전 주입 between-notes)로 끌어올림.
+  - **핵심 게이트**: stored gap 이 거의 0 일 때만(다줄 마지막 줄 trailing 누락=문22). 의도적
+    소-gap(문13 ~10px, backtrack)은 존중 → over-lift 회피.
+  - backtrack/rewind 류(result < y_offset)·단일줄 prev 제외 → #1209 무회귀.
+
+## 검증
+
+| 항목 | 결과 |
+|------|------|
+| **문22 gap** (3-11월 page14, 원래 버그) | **0 → 26.5px** ✅ |
+| `issue_1189_2022_nov_pages10_12` (pi=475 overflow) | ✅ 통과 (이전 미해결분 해소) |
+| `issue_1189_2022_nov_page17` (문28 수식) | ✅ 통과 |
+| `issue_1209_2022_sep_page10_question12` (문12 backtrack) | ✅ 통과 (over-lift 회피) |
+| HeightCursor 단위테스트 (신규 3 + 기존 26) | ✅ 29 통과 |
+| **전체 `cargo test`** | ✅ **1945 passed, 0 failed** |
+
+신규 단위테스트: `compact_endnote_min_gap_lifts_zero_gap_question_title`(gap≈0 → lift),
+`..respects_existing_vpos_gap`(gap 10px → 무보정), `..skips_single_line_prev`(단일줄 → 무보정).
+
+## Stage 3(pagination 정합) — Stage 2 에서 동시 달성
+
+#1238 에서 pi=475 overflow 는 render-클램프가 pagination 과 desync 해 발생했다. Stage 2 의
+min-gap 은 보정값으로 **`prev_line_spacing_px`(=pagination 의 `compute_en_metrics` 가 이미
+`bottom_with_spacing` 으로 예약한 trailing)** 를 사용하므로 render·pagination 이 정합한다.
+→ pi=475 overflow 가 별도 pagination 수정 없이 해소(전체 overflow/page-count 테스트 통과로 확인).
+**구현계획서 Stage 3 의 목표(pagination 정합)는 Stage 2 설계로 충족.** 별도 `compute_en_metrics`
+변경 불요.
+
+## 다음 (Stage 4)
+
+- 한컴 2022 PDF 시각 정합 확인(3-11월 page10/14/17, 3-09·10월), 골든 스냅샷 최종 점검.
+- 최종 보고서 `report/task_m100_1246_report.md` + stream/devel 기준 squash PR. (closes #1238, #1246)

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1929,6 +1929,7 @@ impl DocumentCore {
                 endnotes: Vec::new(),
                 endnote_paragraphs: Vec::new(),
                 endnote_para_sources: Vec::new(),
+                endnote_between_notes_hu: 0,
             });
         }
         self.pagination.truncate(sec_count);
@@ -3117,6 +3118,9 @@ impl DocumentCore {
                 .set_hidden_empty_paras(&pr.hidden_empty_paras);
             self.layout_engine
                 .set_endnote_para_sources(paragraphs.len(), &pr.endnote_para_sources);
+            // [Task #1246] 섹션 미주 between-notes 마진(HU) 전달 → HeightCursor min-gap 보정.
+            self.layout_engine
+                .set_endnote_between_notes_hu(pr.endnote_between_notes_hu);
         }
 
         // [Task #836] 미주 paragraphs를 본문 paragraphs 뒤에 합쳐서 전달

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -55,6 +55,10 @@ pub(crate) struct HeightCursor {
     pub allow_start_height_backtrack: bool,
     /// 미주 흐름의 큰 forward vpos 점프는 단/쪽 재배치 흔적일 수 있어 순차 배치를 유지한다.
     pub suppress_large_forward_jump: bool,
+    /// [Task #1246] 현재 섹션 미주의 between-notes 마진(HU, 0=미적용). 새 미주 제목이 forward
+    /// 흐름에서 이 마진보다 작은 간격을 가지면(다줄 풀이 끝 trailing 누락=문22) 끌어올린다.
+    /// 생성자는 0 으로 두고 호출자(build_single_column)가 미주 흐름 컬럼에서만 설정한다.
+    pub endnote_between_notes_hu: i32,
 }
 
 impl HeightCursor {
@@ -83,6 +87,7 @@ impl HeightCursor {
             allow_vpos_rewind,
             allow_start_height_backtrack,
             suppress_large_forward_jump,
+            endnote_between_notes_hu: 0,
         }
     }
 
@@ -397,7 +402,7 @@ impl HeightCursor {
                 }
             }
         }
-        if compact_endnote_title_tail_backtrack {
+        let result = if compact_endnote_title_tail_backtrack {
             y_offset - (y_offset - end_y).min(16.0)
         } else if (applied || compact_endnote_deep_backtrack || compact_endnote_safe_vpos_backtrack)
             && !stale_forward
@@ -411,7 +416,29 @@ impl HeightCursor {
             y
         } else {
             y_offset
+        };
+        // [Task #1246] 미주 사이 min-gap: 새 미주 제목이 forward 흐름인데 between-notes 간격을
+        // 확보하지 못하면(다줄 풀이로 끝나는 미주 → 직전 다줄 문단 마지막 줄 trailing 이 render
+        // 에서 누락 → gap≈0, 문22) 직전 줄간격(주입된 between_notes)만큼 끌어올린다.
+        // - 다줄 prev 한정: 단일줄 prev 는 trailing 이 이미 sequential y(y_offset)에 포함되어
+        //   이중가산 위험 → 제외.
+        // - 이미 충분한 간격(result >= y_offset + prev_ls, 3-09월 문15 등)은 무변경(max 의미).
+        // - backtrack/rewind 류(result < y_offset)는 위 분기가 의도 선택한 값이므로 제외.
+        // #1238 render-클램프가 침범하던 #1209 safe-vpos-backtrack 과 양립(여기선 forward 만).
+        // 핵심: stored vpos 가 gap 을 거의 안 주는 경우(≈0)만 보정한다. 다줄 풀이로 끝나는 미주의
+        // 마지막 줄 trailing 이 render 에서 누락되어 gap≈0 이 된 케이스(문22)가 대상.
+        // stored vpos 가 의도적으로 작은 gap(예: 문13 ~12px)을 인코딩한 경우는 존중(over-lift 방지).
+        let prev_is_multiline = prev_para.line_segs.len() > 1;
+        let stored_gap_px = result - y_offset;
+        if self.endnote_between_notes_hu > 0
+            && compact_endnote_question_title
+            && !vpos_rewind
+            && prev_is_multiline
+            && (-0.5..4.0).contains(&stored_gap_px)
+        {
+            return y_offset + prev_line_spacing_px;
         }
+        result
     }
 
     /// 이미 계산된 vpos 기준 y보다 실제 렌더 y를 아래로 밀었을 때, 후속 항목도
@@ -881,5 +908,71 @@ mod tests {
 
         assert!((got - expected_end_y).abs() < 1e-6, "got={got}");
         assert_eq!(c.vpos_page_base, Some(0));
+    }
+
+    fn multiline_prev_with_injected_gap() -> Paragraph {
+        // 다줄(2 seg) 미주 문단, 마지막 seg ls=1984(typeset 가 주입한 between-notes).
+        let mut p = para(0, 1000, 900, 0, 5000);
+        p.line_segs.push(LineSeg {
+            vertical_pos: 1900,
+            line_height: 900,
+            line_spacing: 1984,
+            segment_width: 5000,
+            ..Default::default()
+        });
+        p
+    }
+
+    /// [Task #1246] 다줄 풀이로 끝나는 미주 다음 제목이 stored vpos gap≈0(마지막 줄 trailing
+    /// 누락=문22)이면 between-notes(직전 주입 줄간격)만큼 끌어올린다.
+    #[test]
+    fn compact_endnote_min_gap_lifts_zero_gap_question_title() {
+        let mut c = compact_endnote_cursor(Some(0));
+        c.endnote_between_notes_hu = 1984;
+        c.prev_layout_para = Some(0);
+        let mut curr = para(0, 2800, 900, 0, 5000); // prev 내용 바닥(1900+900) → stored gap≈0
+        curr.text = "문11)".to_string();
+        let ps = vec![multiline_prev_with_injected_gap(), curr];
+        let y_in = 100.0 + 2800.0 / 75.0; // page_path end_y 와 동일 → stored gap 0
+        let got = c.vpos_adjust(y_in, 1, &ps, &styles(0.0));
+        let expected = y_in + 1984.0 / 75.0;
+        assert!(
+            (got - expected).abs() < 1e-6,
+            "got={got} expected={expected}"
+        );
+    }
+
+    /// stored vpos 가 의도적 gap(>4px)을 인코딩하면 over-lift 하지 않는다(문13 류 backtrack/소gap).
+    #[test]
+    fn compact_endnote_min_gap_respects_existing_vpos_gap() {
+        let mut c = compact_endnote_cursor(Some(0));
+        c.endnote_between_notes_hu = 1984;
+        c.prev_layout_para = Some(0);
+        let mut curr = para(0, 3550, 900, 0, 5000); // 2800 + 750(=10px) → stored gap 10px
+        curr.text = "문13)".to_string();
+        let ps = vec![multiline_prev_with_injected_gap(), curr];
+        let y_in = 100.0 + 2800.0 / 75.0;
+        let got = c.vpos_adjust(y_in, 1, &ps, &styles(0.0));
+        let expected_end = 100.0 + 3550.0 / 75.0; // 보정 없이 vpos 위치 유지
+        assert!(
+            (got - expected_end).abs() < 1e-6,
+            "got={got} expected={expected_end}"
+        );
+    }
+
+    /// 단일줄 prev 는 trailing 이 이미 sequential y 에 포함되므로 min-gap 보정 대상이 아니다.
+    #[test]
+    fn compact_endnote_min_gap_skips_single_line_prev() {
+        let mut c = compact_endnote_cursor(Some(0));
+        c.endnote_between_notes_hu = 1984;
+        c.prev_layout_para = Some(0);
+        let prev = para(0, 1900, 900, 1984, 5000); // 단일줄, ls=1984
+        let mut curr = para(0, 2800, 900, 0, 5000);
+        curr.text = "문11)".to_string();
+        let ps = vec![prev, curr];
+        let y_in = 100.0 + 2800.0 / 75.0;
+        let got = c.vpos_adjust(y_in, 1, &ps, &styles(0.0));
+        // 단일줄 prev → 보정 없음 (stored gap 0 이어도 lift 안 함)
+        assert!((got - y_in).abs() < 1e-6, "got={got} expected={y_in}");
     }
 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -506,6 +506,9 @@ pub struct LayoutEngine {
     endnote_para_base: std::cell::Cell<usize>,
     /// 가상 미주 문단별 원본 위치
     endnote_para_sources: std::cell::RefCell<Vec<EndnoteParaSource>>,
+    /// [Task #1246] 현재 섹션 미주의 between-notes 마진(HWPUNIT, 0=미적용). HeightCursor 가 미주
+    /// 사이 min-gap 보정(gap 부족 시 끌어올림)에 사용한다. 섹션 렌더 셋업마다 갱신.
+    endnote_between_notes_hu: std::cell::Cell<i32>,
     /// 현재 활성 필드 위치 — 안내문 렌더링 스킵용
     /// (section_idx, para_idx, control_idx, cell_path)
     /// cell_path: 셀 내 필드일 경우 Some(Vec<(ctrl, cell, para)>)
@@ -578,6 +581,7 @@ impl LayoutEngine {
             hidden_empty_paras: std::cell::RefCell::new(std::collections::HashSet::new()),
             endnote_para_base: std::cell::Cell::new(usize::MAX),
             endnote_para_sources: std::cell::RefCell::new(Vec::new()),
+            endnote_between_notes_hu: std::cell::Cell::new(0),
             active_field: std::cell::RefCell::new(None),
             show_control_codes: std::cell::Cell::new(false),
             current_paper_width: std::cell::Cell::new(0.0),
@@ -613,6 +617,12 @@ impl LayoutEngine {
     pub fn set_endnote_para_sources(&self, base: usize, sources: &[EndnoteParaSource]) {
         self.endnote_para_base.set(base);
         *self.endnote_para_sources.borrow_mut() = sources.to_vec();
+    }
+
+    /// [Task #1246] 현재 섹션 미주의 between-notes 마진(HU)을 설정한다(섹션 렌더 셋업마다 호출).
+    /// HeightCursor 가 미주 사이 min-gap 보정에 사용. 0 = 미적용.
+    pub fn set_endnote_between_notes_hu(&self, between_notes_hu: i32) {
+        self.endnote_between_notes_hu.set(between_notes_hu.max(0));
     }
 
     fn note_ref_for_endnote_equation(
@@ -2702,6 +2712,11 @@ impl LayoutEngine {
             col_content.endnote_flow && col_content.start_height < -0.5,
             col_content.endnote_flow,
         );
+        // [Task #1246] 미주 흐름 컬럼에만 between-notes 마진(HU)을 주입 → HeightCursor 가 새 미주
+        // 제목 forward 흐름의 min-gap 보정에 사용. 본문 컬럼은 0 (무영향).
+        if col_content.endnote_flow {
+            hcursor.endnote_between_notes_hu = self.endnote_between_notes_hu.get();
+        }
 
         // 1차 패스: 표, 문단, 텍스트 렌더링 (글상자 제외)
         for (item_ordinal, item) in col_content.items.iter().enumerate() {

--- a/src/renderer/pagination.rs
+++ b/src/renderer/pagination.rs
@@ -58,6 +58,9 @@ pub struct PaginationResult {
     pub endnote_paragraphs: Vec<crate::model::paragraph::Paragraph>,
     /// `endnote_paragraphs` 각 항목의 원본 Endnote 내부 위치.
     pub endnote_para_sources: Vec<EndnoteParaSource>,
+    /// [Task #1246] 현재 섹션 미주의 between-notes 마진(HU, 0=미적용). HeightCursor 가 미주 사이
+    /// min-gap 보정에 사용.
+    pub endnote_between_notes_hu: i32,
 }
 
 /// 한 페이지에 배치될 콘텐츠

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -920,6 +920,7 @@ impl Paginator {
             endnotes: Vec::new(),
             endnote_paragraphs: Vec::new(),
             endnote_para_sources: Vec::new(),
+            endnote_between_notes_hu: 0,
         }
     }
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -197,6 +197,9 @@ struct TypesetState {
     endnotes: Vec<EndnoteRef>,
     endnote_paragraphs: Vec<Paragraph>,
     endnote_para_sources: Vec<EndnoteParaSource>,
+    /// [Task #1246] 현재 섹션 미주의 between-notes 마진(HU, 0=미적용). HeightCursor 가 미주 사이
+    /// min-gap 보정에 사용. 모든 경계에서 동일한 섹션 설정값이므로 스칼라로 보관.
+    endnote_between_notes_hu: i32,
     /// [Task #362] Square wrap 표의 column_start (HU). -1 = 비활성. 후속 같은 cs/sw paragraph 흡수용.
     wrap_around_cs: i32,
     /// [Task #362] Square wrap 표의 segment_width (HU). -1 = 비활성.
@@ -639,6 +642,7 @@ impl TypesetState {
             endnotes: Vec::new(),
             endnote_paragraphs: Vec::new(),
             endnote_para_sources: Vec::new(),
+            endnote_between_notes_hu: 0,
             wrap_around_cs: -1,
             wrap_around_sw: -1,
             wrap_around_table_para: 0,
@@ -2199,6 +2203,9 @@ impl TypesetEngine {
                             {
                                 let between_notes = endnote_between_notes_margin(shape) as i32;
                                 if between_notes > 0 {
+                                    // [Task #1246] 섹션 미주 between-notes 마진(HU)을 보관 →
+                                    // HeightCursor 가 미주 사이 min-gap 보정에 사용. 모든 경계 동일값.
+                                    st.endnote_between_notes_hu = between_notes;
                                     let prev_spacing = st
                                         .endnote_paragraphs
                                         .get(prev_local_idx)
@@ -2728,6 +2735,7 @@ impl TypesetEngine {
             endnotes: st.endnotes,
             endnote_paragraphs: st.endnote_paragraphs,
             endnote_para_sources: st.endnote_para_sources,
+            endnote_between_notes_hu: st.endnote_between_notes_hu,
         }
     }
 
@@ -2777,6 +2785,7 @@ impl TypesetEngine {
             allow_vpos_rewind: false,
             allow_start_height_backtrack: false,
             suppress_large_forward_jump: false,
+            endnote_between_notes_hu: 0,
         };
         let y = hc.vpos_adjust(st.current_height, para_idx, paragraphs, styles);
         // lazy_base 는 지연 산출 시 갱신될 수 있으므로 회수.


### PR DESCRIPTION
## 문제
미주(답안) 영역에서 **다줄 풀이로 끝나는 문제 다음 제목**이 직전 줄에 붙음(문22 외 문21·23·27·28·29). 한컴 2022 기준 미주 사이 7mm(between-notes) gap 누락(문22 above-gap 0px).

## 원인
- between-notes 는 **가산이 아니라 min-gap(max) 모델** (한컴 2022 PDF 검증).
- render 는 `HeightCursor.vpos_adjust`(#1027 Stage C)로 미주 vpos→y 매핑하며 compact endnote gap 특례(forward-cap/backtrack/#1209 safe-vpos-backtrack)를 보유. **유일한 사각지대**: stored vpos gap≈0(다줄 마지막 줄 trailing 누락=문22)을 끌어올리는 min-gap 부재.

## 해결
`HeightCursor.vpos_adjust` 에 **min-gap 케이스** 추가:
- 새 미주 제목 & forward & 다줄 prev & `stored vpos gap ∈ [-0.5,4.0)px` → `y_offset + prev_line_spacing_px` 로 보정.
- 의도적 소-gap(문13 ~10px)·backtrack(문12 #1209)·단일줄 prev 는 **제외** → over-lift/회귀 회피.
- 보정값 = pagination(`compute_en_metrics`)이 이미 예약한 trailing → render·pagination 정합(pi=475 overflow 별도 수정 없이 해소).

## 검증
| 항목 | 결과 |
|------|------|
| 문22 above-gap (3-11월 page14) | **0 → 26.5px(=7mm)**, 한컴 2022 PDF 시각 정합 |
| `issue_1189` (pi=475 overflow, page17 수식) | ✅ |
| `issue_1209` (문12 safe-vpos-backtrack) | ✅ |
| `issue_1139` 미주군 + HeightCursor 단위테스트(신규 3) | ✅ |
| 전체 `cargo test` | ✅ **1946 passed, 0 failed** |

## #1238 흡수
#1238 의 render-클램프(별 접근, vpos 위치 시스템 충돌)는 폐기. 검증된 min-gap 모델·PDF 근거를 본 PR 에서 회귀 없이 구현. **closes #1238, #1246**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)