### PR TITLE
task 1245: 어울림 그림 및 미주 수식 배치 보정

### DIFF
--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -5,6 +5,7 @@
 | 이슈 | 제목 | 상태 | 비고 |
 |---|---|---|---|
 | [#1237](https://github.com/edwardkim/rhwp/issues/1237) | HWP 저장 계약: 문단 헤더와 LINE_SEG 필드 의미 정리 | 완료 | #1183 후속 감사. `LineSeg`/`PARA_HEADER` 저장 계약, 코드 주석, `hwp_save_guide.md` 보강 |
+| [#1245](https://github.com/edwardkim/rhwp/issues/1245) | task 1139 후속 보정: `3-09월_교육_통합_2022` 7쪽 문25-26 하단 그림 배치 불일치 | 진행중 | `local/task_m100_1245` 브랜치. 7쪽 하단 그림/도형 객체와 문단 흐름을 한컴/PDF 기준으로 비교 |
 
 ## Task #1209 — task 1139 후속 보정
 

--- a/mydocs/plans/task_m100_1245.md
+++ b/mydocs/plans/task_m100_1245.md
@@ -1,0 +1,59 @@
+# Task M100 #1245 — 3-09월_교육_통합_2022 7쪽 하단 그림 배치 보정
+
+## 1. 이슈
+
+- GitHub Issue: [#1245](https://github.com/edwardkim/rhwp/issues/1245)
+- Milestone: M100
+- Branch: `local/task_m100_1245`
+- 대상 문서: `samples/3-09월_교육_통합_2022.hwp`
+- 비교 대상: `pdf/3-09월_교육_통합_2022.pdf`, 한컴오피스 렌더링
+
+## 2. 배경
+
+작업지시자가 RHWP Studio에서 `3-09월_교육_통합_2022.hwp` 7쪽을 확인하던 중, 하단 `문25)`/`문26)` 주변의 그림/도형 객체와 문단 흐름이 한컴오피스/PDF 기준과 다르게 배치되는 문제를 보고했다.
+
+최근 task 1139, task 1189, task 1209에서 다음 영역을 보정했다.
+
+- 미주/해설 문단의 `LINE_SEG.vertical_pos` 기반 배치
+- `TopAndBottom`/`Square` 그림 흐름
+- 단 바깥 그림의 문단 흐름 영향 제외
+- HWP5 `CommonObjAttr`의 `text_wrap` 실측 정정
+
+이번 이슈는 같은 흐름의 후속 보정으로, 기존 보정이 2022년 9월 교육 통합 문서 7쪽 하단 그림 배치에 미치는 영향을 확인한다.
+
+## 3. 확인 대상
+
+1. 7쪽 하단 `문25)` 영역의 본문/선택지 위치
+2. 7쪽 하단 `문26)` 영역의 본문 위치
+3. `문26)` 주변 그림/도형 객체의 wrap, treat-as-char, 기준 좌표, outer margin
+4. 해당 문단의 `LINE_SEG.vertical_pos`, segment width, paragraph height
+5. 페이지 하단 경계와 다음 페이지 이월 여부
+
+## 4. 관련 위험
+
+- 현재 열린 PR 중 다음 항목은 레이아웃/수식/미주 흐름과 겹칠 수 있다.
+  - [#1240](https://github.com/edwardkim/rhwp/pull/1240): 미주 다줄 문단 줄간격
+  - [#1241](https://github.com/edwardkim/rhwp/pull/1241): 미주 연속 인라인 수식 다행 병합
+  - [#1235](https://github.com/edwardkim/rhwp/pull/1235): 수식 큰 연산자 간격
+- `src/renderer/layout.rs`, `src/renderer/layout/paragraph_layout.rs`, `src/renderer/height_cursor.rs`, `src/renderer/typeset.rs`는 task 1209에서 이미 민감하게 조정된 파일이다.
+- 케이스별 예외를 늘리기보다, `LINE_SEG`와 객체 wrap 의미를 공통 로직으로 해석할 수 있는지 먼저 확인한다.
+
+## 5. 비범위
+
+- 한컴오피스와 무관한 미관 개선은 하지 않는다.
+- PDF만 기준으로 한 보정은 하지 않는다. PDF는 보조 비교 대상으로 사용하고, 한컴오피스 시각 판정을 우선한다.
+- 미주 삽입/미주 모양 UI 기능 변경은 이번 이슈 범위가 아니다.
+- HWPX 변환 저장 로직은 동일 증상과 직접 연결될 때만 건드린다.
+
+## 6. 수행 순서
+
+1. `dump-pages`와 `dump`로 7쪽 하단 문단/그림 배치 구조를 확인한다.
+2. `export-svg`로 7쪽만 렌더링하고 `rsvg-convert`로 PNG 비교 자료를 만든다.
+3. PDF 7쪽과 RHWP SVG/PNG를 비교해 하단 객체와 문단의 상대 위치를 기록한다.
+4. 원인이 `LINE_SEG` 해석, 객체 wrap 해석, 페이지 하단 overflow 판정 중 어디인지 분리한다.
+5. 필요한 최소 수정 범위를 구현 계획서에 따라 진행한다.
+6. `tests/issue_1139_inline_picture_duplicate.rs`에 1245 회귀 가드를 추가하거나 기존 가드를 보강한다.
+
+## 7. 승인 게이트
+
+소스 수정 전 Stage0 분석 결과와 구현 범위를 작업지시자에게 보고하고 승인을 받는다.

--- a/mydocs/plans/task_m100_1245_impl.md
+++ b/mydocs/plans/task_m100_1245_impl.md
@@ -1,0 +1,63 @@
+# Task M100 #1245 구현 계획 — 7쪽 하단 그림 배치 보정
+
+## 1. 목표
+
+`3-09월_교육_통합_2022.hwp` 7쪽 하단 `문25)`/`문26)` 주변의 그림/도형 객체와 문단 흐름을 한컴오피스 기준에 맞춘다.
+
+## 2. 초기 가설
+
+현재 증상은 다음 중 하나일 가능성이 높다.
+
+1. 하단 그림/도형이 현재 단의 가로 영역과 교차하지 않는데도 문단 흐름을 밀거나, 반대로 교차하는데 충분히 반영하지 않는 경우
+2. `Square`/`TopAndBottom` 객체의 `vertical_pos` 되감김 또는 하단 overflow 판정이 문단 경계 근처에서 과하거나 부족한 경우
+3. `LINE_SEG.segment_width`가 좁은 wrap 줄을 표현하지만, 페이지 항목 배치에서 그림 높이와 문단 높이의 결합 방식이 한컴과 다른 경우
+4. 그림/도형 컨트롤의 anchor paragraph와 실제 영향 paragraph가 분리되어 있는데 현재 로직이 anchor paragraph만 기준으로 판단하는 경우
+
+## 3. 분석 명령
+
+```bash
+cargo run -- dump-pages samples/3-09월_교육_통합_2022.hwp -p 6
+cargo run -- dump samples/3-09월_교육_통합_2022.hwp -s 0 -p <문제 문단>
+cargo run -- export-svg samples/3-09월_교육_통합_2022.hwp -p 6 -o output/task1245_stage0 --show-control-codes --debug-overlay
+rsvg-convert output/task1245_stage0/page_007.svg -o output/task1245_stage0/page_007.png
+```
+
+PDF 비교는 `pdf/3-09월_교육_통합_2022.pdf`의 7쪽을 사용한다.
+
+## 4. 수정 후보
+
+분석 결과에 따라 다음 중 하나를 선택한다.
+
+- `src/renderer/layout.rs`: 페이지 항목 배치, 그림/도형 흐름 영향, 하단 overflow 판정
+- `src/renderer/layout/paragraph_layout.rs`: 문단 내부 line segment와 wrap 줄 재배치
+- `src/renderer/height_cursor.rs`: `LINE_SEG.vertical_pos` 기반 위치 되감김/보정
+- `src/renderer/typeset.rs`: 그림/도형 선택 rect 또는 render tree 좌표가 배치 결과와 불일치할 때만 확인
+
+## 5. 회귀 가드
+
+우선 `tests/issue_1139_inline_picture_duplicate.rs`에 다음 검증을 추가한다.
+
+- `3-09월_교육_통합_2022.hwp` 7쪽 page count 유지
+- 7쪽 하단 `문25)`/`문26)` 관련 문단이 같은 페이지에 유지되는지
+- 문제 그림/도형의 page item 위치와 문단 흐름 영향이 한컴/PDF 기준 범위에 들어오는지
+
+## 6. 검증 계획
+
+수정 직후:
+
+```bash
+cargo test --test issue_1139_inline_picture_duplicate -- --nocapture
+```
+
+PR 직전:
+
+```bash
+cargo test --tests
+wasm-pack build --target web --out-dir pkg
+```
+
+필요 시 Studio 시각 확인은 작업지시자의 한컴 비교 판단을 받는다.
+
+## 7. 승인 요청 범위
+
+Stage0 분석 후, 위 수정 후보 중 실제로 건드릴 파일과 회귀 가드 내용을 확정해 작업지시자 승인 후 소스 수정한다.

--- a/mydocs/report/task_m100_1245_report.md
+++ b/mydocs/report/task_m100_1245_report.md
@@ -1,0 +1,51 @@
+# Task M100 #1245 최종 보고서
+
+## 작업 개요
+
+- 이슈: [#1245](https://github.com/edwardkim/rhwp/issues/1245)
+- 브랜치: `local/task_m100_1245`
+- 대상 문서:
+  - `samples/3-09월_교육_통합_2022.hwp`
+  - `samples/3-09월_교육_통합_2023.hwp`
+
+## 해결 내용
+
+1. `3-09월_교육_통합_2022.hwp` 7쪽 하단 그림 객체가 페이지 밖으로 밀리는 문제를 보정했다.
+   - `Square/어울림` 그림 위치 계산에서 raw `LINE_SEG.vertical_pos`를 그대로 더하지 않고, 첫 줄 기준 상대 delta를 사용하도록 수정했다.
+
+2. `3-09월_교육_통합_2022.hwp` 10쪽 `문12)` 우측 단 수식 배치 문제를 보정했다.
+   - 본문/미주 수식-only 문단이 불필요한 margin/alignment 보정을 다시 받지 않도록 분리했다.
+   - TAC가 없는 선행 guide 줄을 수식 앞 세로 예약으로 쓰지 않도록 처리했다.
+
+3. `3-09월_교육_통합_2023.hwp` 4쪽 `문26)` 미주 선두 번호가 중복 표시되는 문제를 보정했다.
+   - 선두 미주 번호가 prefix `TextRun`으로 이미 렌더된 경우 같은 위치의 `FootnoteMarker`를 건너뛰도록 했다.
+
+4. PR #1241 병합 후 `문12)` 첫 수식이 다시 `따라서`와 겹칠 수 있는 회귀를 보정했다.
+   - 수식-only TAC 줄 배정에서 TAC가 없는 선행 guide 줄을 후보에서 제외했다.
+
+## 회귀 검증
+
+추가 또는 보강한 테스트:
+
+- `issue_1245_2022_page7_square_pictures_use_relative_line_vpos`
+- `issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack`
+- `issue_1245_2023_page4_question26_endnote_marker_not_duplicated`
+
+Stage별 지정 검증:
+
+```bash
+cargo test --test issue_1139_inline_picture_duplicate -- --nocapture
+```
+
+최종 PR 전 전체 검증은 PR 생성 직전에 수행한다.
+
+## 충돌 및 회귀 확인
+
+- PR #1240, #1241이 반영된 `upstream/devel` 기준으로 rebase를 완료했다.
+- PR #1247이 반영된 `upstream/devel` 기준으로 다시 rebase를 완료했다.
+- #1247의 미주 간격 처리(`endnote_between_notes_hu`)와 #1245의 TAC guide 보정 로직이 함께 유지되는 것을 확인했다.
+
+## 남은 사항
+
+- PR 전 `cargo test --tests` 전체 테스트를 수행한다.
+- PR 본문에는 #1245 자동 종료 키워드를 포함한다.

--- a/mydocs/working/task_m100_1245_stage0.md
+++ b/mydocs/working/task_m100_1245_stage0.md
@@ -1,0 +1,102 @@
+# Task M100 #1245 Stage0 — 착수 및 원인 분석
+
+## 작업 지시
+
+- 2026-06-02: 작업지시자가 [#1245](https://github.com/edwardkim/rhwp/issues/1245) 해결 착수를 지시했다.
+- 대상은 `3-09월_교육_통합_2022.hwp` 7쪽 하단 `문25)`/`문26)` 주변 그림/도형 객체와 문단 흐름 불일치다.
+
+## 현재 상태
+
+- 기준 브랜치: `upstream/devel` `914ee139`
+- 작업 브랜치: `local/task_m100_1245`
+- 오늘할일: `mydocs/orders/20260602.md`에 #1245 진행 항목 추가
+- 수행 계획서: `mydocs/plans/task_m100_1245.md`
+- 구현 계획서: `mydocs/plans/task_m100_1245_impl.md`
+
+## 열린 PR 확인
+
+착수 시점의 열린 PR:
+
+- #1242 `Task #1201: HWPX masterpage idRef 연결 보강`
+- #1241 `미주 연속 인라인 수식 다행 병합 해소`
+- #1240 `미주(해설) 다줄 문단 줄간격 간헐적 좁음 수정`
+- #1235 `수식 큰 연산자(Σ/∏/∫) 피연산자 간격 추가`
+- #1234 `폰트 충실도: 한컴 돋움 폴백을 Noto Sans KR ExtraLight로`
+- #1170 `chore: harden repo hygiene`
+
+레이아웃/미주/수식 관련 PR과의 회귀 가능성을 이후 검증에서 고려한다.
+
+## 초기 판단
+
+이번 문제는 `Square`/`TopAndBottom` 그림 흐름, `LINE_SEG.vertical_pos`, 페이지 하단 overflow 판정의 결합 문제일 가능성이 있다.
+
+Stage0에서는 소스 수정 없이 다음을 먼저 확인한다.
+
+1. `dump-pages`로 7쪽 page item 목록과 하단 항목 위치 확인
+2. `dump`로 `문25)`/`문26)` 주변 paragraph, line segment, picture/shape common attr 확인
+3. `export-svg`와 `rsvg-convert`로 7쪽 비교 PNG 생성
+4. PDF 7쪽과 RHWP 결과의 하단 객체 위치 차이 기록
+
+## Stage0 확인 결과
+
+### 7쪽 덤프
+
+명령:
+
+```bash
+cargo run --bin rhwp -- dump-pages samples/3-09월_교육_통합_2022.hwp -p 6
+```
+
+확인된 주요 문단:
+
+- 왼쪽 단 `문25)` host: `pi=386`
+  - 그림: `ci=11`, `wrap=Square/어울림`, `tac=false`, `vert=문단`, `align=Right`
+  - line segment:
+    - `ls[0].vertical_pos=31648`, `sw=26788`
+    - `ls[1].vertical_pos=34470`, `sw=26788`
+    - `ls[2].vertical_pos=36227`, `sw=26788`
+    - `ls[3].vertical_pos=37804`, `sw=13166`
+- 오른쪽 단 `문28)` host: `pi=420`
+  - 그림: `ci=9`, `wrap=Square/어울림`, `tac=false`, `vert=문단`, `align=Right`
+  - line segment 후반부에서 좁은 줄이 시작한다.
+
+### 시각 비교 자료
+
+RHWP SVG/PNG:
+
+```bash
+cargo run --bin rhwp -- export-svg samples/3-09월_교육_통합_2022.hwp -p 6 -o output/task1245_stage0 --show-control-codes --debug-overlay
+rsvg-convert output/task1245_stage0/3-09월_교육_통합_2022_007.svg -o output/task1245_stage0/3-09월_교육_통합_2022_007.png
+```
+
+PDF 보조 비교:
+
+```bash
+pdftoppm -f 7 -l 7 -png -r 144 pdf/3-09월_교육_통합_2022.pdf output/task1245_stage0/pdf/page
+```
+
+비교 결과:
+
+- PDF 7쪽에서는 `문25)` 타원 그림이 `문25)` 본문 옆 중간 높이에 배치된다.
+- RHWP debug PNG에서는 같은 `pi=386 ci=11` 그림이 페이지 하단 밖으로 내려간다.
+- `pi=420 ci=9` 그림도 페이지 하단 쪽으로 과하게 내려가며, 오른쪽 단 하단 흐름이 PDF와 달라진다.
+
+## 원인 후보
+
+`src/renderer/layout.rs`의 `square_wrap_first_narrow_line_vpos_px`는 `Square/어울림` 그림이 문단 중간부터 본문을 감싸는 경우, 처음 좁아지는 `LINE_SEG.vertical_pos`를 그림 상단 보정값으로 사용한다.
+
+현재 구현은 좁아지는 줄의 `vertical_pos` 값을 그대로 px로 변환해 `para_base_y`에 더한다.
+
+하지만 `3-09월_교육_통합_2022.hwp` 7쪽 `pi=386`에서는 `LINE_SEG.vertical_pos`가 문단 내부 상대값이 아니라 이미 페이지/구역 흐름 기준 값처럼 저장되어 있다. 이 값을 `para_base_y`에 그대로 더하면 `para_base_y + absolute_vpos`가 되어 그림이 페이지 하단 밖으로 밀린다.
+
+따라서 후보 수정은 다음이다.
+
+- `Square/어울림` 그림 상단 보정은 `first_narrow.vertical_pos` 자체가 아니라 `first_narrow.vertical_pos - first_line.vertical_pos`를 우선 사용한다.
+- 다만 기존 task 1209의 page 8 `문29)` 회귀 가드처럼 `first_line.vertical_pos=0`인 문서는 현재 동작을 유지해야 하므로, 기준 line segment를 명확히 분리한다.
+- 수정 후 `issue_1209_2022_page8_question29_square_picture_starts_at_wrap_line`, `issue_1209_2022_sep_page13_question19_square_picture_wraps_following_text`, 이번 #1245 신규 가드가 함께 통과해야 한다.
+
+## 승인 대기
+
+2026-06-02: 작업지시자가 Stage0 분석 후 수정 진행을 승인했다.
+
+이후 구현/검증 기록은 `mydocs/working/task_m100_1245_stage1.md`에 남긴다.

--- a/mydocs/working/task_m100_1245_stage1.md
+++ b/mydocs/working/task_m100_1245_stage1.md
@@ -1,0 +1,70 @@
+# Task M100 #1245 Stage1 — Square 그림 상대 LINE_SEG 보정
+
+## 작업 범위
+
+Stage0에서 확인한 원인 후보에 따라 `Square/어울림` 그림의 세로 위치 보정 방식을 수정했다.
+
+대상 파일:
+
+- `src/renderer/layout.rs`
+- `tests/issue_1139_inline_picture_duplicate.rs`
+
+## 원인
+
+`src/renderer/layout.rs`의 `square_wrap_first_narrow_line_vpos_px`는 `Square/어울림` 그림이 문단 중간부터 본문을 감싸는 경우, 처음 좁아지는 `LINE_SEG.vertical_pos`를 그림 상단 위치로 사용한다.
+
+기존 구현은 좁아지는 줄의 raw `vertical_pos`를 px로 변환해 `para_base_y`에 더했다.
+
+`3-09월_교육_통합_2022.hwp` 7쪽 `pi=386` 같은 문단은 첫 줄 `vertical_pos`가 이미 `31648`처럼 누적 흐름값이다. 따라서 좁아지는 줄의 raw `vertical_pos=37804`를 그대로 더하면 `para_base_y + absolute_vpos`가 되어 그림이 페이지 하단 밖으로 밀렸다.
+
+## 수정
+
+`Square/어울림` 그림 상단 위치 보정에 raw `vertical_pos`가 아니라 문단 첫 줄 대비 상대 delta를 사용하도록 바꾸었다.
+
+```text
+delta = first_narrow_line.vertical_pos - first_line.vertical_pos
+```
+
+첫 줄 `vertical_pos=0`인 기존 page8 `문29)` 유형은 delta가 기존 raw 값과 같으므로 기존 동작을 유지한다.
+
+## 회귀 가드
+
+`tests/issue_1139_inline_picture_duplicate.rs`에 다음 테스트를 추가했다.
+
+- `issue_1245_2022_page7_square_pictures_use_relative_line_vpos`
+
+검증 내용:
+
+- 7쪽 `문25)` 타원 그림 `pi=386 ci=11`이 `pi=386`의 첫 좁은 줄과 같은 y에 붙는지 확인
+- 7쪽 `문28)` 포물선 그림 `pi=420 ci=9`도 같은 방식으로 확인
+- `문25)` 그림이 페이지 하단 밖으로 밀리지 않는지 확인
+
+## 검증
+
+명령:
+
+```bash
+cargo test --test issue_1139_inline_picture_duplicate -- --nocapture
+cargo fmt --all --check
+```
+
+결과:
+
+- `issue_1139_inline_picture_duplicate`: 42개 통과
+- `cargo fmt --all --check`: 통과
+
+## 시각 확인 자료
+
+수정 전:
+
+- `output/task1245_stage0/3-09월_교육_통합_2022_007.png`
+
+수정 후:
+
+- `output/task1245_stage0_after/3-09월_교육_통합_2022_007.png`
+
+수정 후 `pi=386 ci=11`, `pi=420 ci=9` 그림이 페이지 하단 밖으로 밀리지 않고 각 문항의 어울림 줄 옆에 배치되는 것을 확인했다.
+
+## 남은 확인
+
+작업지시자의 한컴오피스/PDF 기준 시각 확인을 기다린다.

--- a/mydocs/working/task_m100_1245_stage2.md
+++ b/mydocs/working/task_m100_1245_stage2.md
@@ -1,0 +1,60 @@
+# Task M100 #1245 Stage2 — 10쪽 문12 우측 수식 배치 보정
+
+## 작업 지시
+
+- 2026-06-02: 작업지시자가 Stage1 시각 판단을 확인하고 커밋을 지시했다.
+- Stage1 커밋: `ba8080a6` (`task 1245: Stage1 어울림 그림 상대 vpos 보정`)
+- 이후 `3-09월_교육_통합_2022.hwp` 10쪽 `문12)` 우측 단 수식 배치가 한컴/PDF 기준과 다르게 보이는 문제를 새 스테이지에서 해결하라고 지시했다.
+
+## 대상
+
+- 문서: `samples/3-09월_교육_통합_2022.hwp`
+- 페이지: 10쪽 / 23쪽
+- 위치: 우측 단 `문12)` 본문과 수식 블록
+- 증상: 우측 단 하단의 긴 수식/분수식이 단 경계 또는 페이지 외곽선 기준과 다르게 배치된다.
+
+## 초기 확인 계획
+
+1. `dump-pages`로 10쪽 우측 단의 `문12)` 관련 page item과 문단 번호를 확인한다.
+2. `dump`로 `문12)` 관련 문단의 `LINE_SEG`, 수식 컨트롤 크기, paragraph style을 확인한다.
+3. `export-svg` + `rsvg-convert`로 10쪽 수정 전 비교 PNG를 생성한다.
+4. `pdf/3-09월_교육_통합_2022.pdf` 10쪽과 RHWP 결과를 비교한다.
+5. 원인이 수식 bbox 폭/정렬, line segment 폭, column clipping, 또는 수식 line-height 중 어디인지 분리한다.
+
+## 승인 상태
+
+작업지시자가 Stage2 진행을 지시했으므로 분석 후 필요한 최소 소스 수정과 회귀 가드를 진행한다.
+
+## 분석 결과
+
+- `dump-pages samples/3-09월_교육_통합_2022.hwp -p 9` 기준 10쪽 우측 단 `문12)`는 `pi=567..574`, `문13)`은 `pi=575`로 배치된다.
+- 문제 수식 블록은 `pi=574`의 텍스트가 없는 TAC 수식-only 문단이다.
+- 수정 전 SVG에서 `따라서` 텍스트는 `x=402.52`에서 시작하지만, 바로 뒤 첫 `lim` 수식은 `x=442.88`에서 시작했다.
+- 원인은 `paragraph_layout.rs`의 빈 runs + TAC 수식 fallback이 본문/미주 수식-only 문단에도 `effective_margin_left`와 alignment offset을 다시 적용한 것이다.
+- Task #490에서 필요한 셀 내부 수식 alignment 보정은 유지해야 하므로, 셀 문단과 일반 본문/미주 문단을 분리해 처리한다.
+- 작업지시자가 x 보정 뒤에도 `따라서`와 수식 사이 간격이 한컴보다 크다고 지적했다.
+- `RHWP_DEBUG_PARA_TAC=1` 확인 결과 `pi=574`는 선행 `LINE_SEG`가 `char_start=0, char_end=0`, TAC 없음인 퇴화 안내 줄이고, 실제 첫 수식은 다음 줄 `char_start=0..1`에 매핑되어 있었다. 이 안내 줄 높이 때문에 첫 수식이 `y=610.09`로 밀렸다.
+- 한컴은 이 수식-only 미주 문단의 선행 안내 줄을 첫 수식 앞 세로 예약으로 쓰지 않으므로, 다음 줄과 `char_start`가 같고 현재 줄에는 TAC가 없으며 다음 줄에 수식 TAC가 있는 빈 run 줄은 안내 줄로 취급한다.
+
+## 수정 내용
+
+- `src/renderer/layout/paragraph_layout.rs`
+  - 셀 내부 수식-only 문단은 기존처럼 paragraph alignment와 margin을 적용한다.
+  - 본문/미주 수식-only 문단은 저장된 LINE_SEG 흐름을 따르도록 `effective_col_x` 기준으로 배치한다.
+  - 수식-only 문단의 선행 퇴화 안내 `LINE_SEG`를 기준 vpos와 y advance에서 제외해 첫 수식이 한컴처럼 `따라서` 바로 뒤에 붙도록 했다.
+- `tests/issue_1139_inline_picture_duplicate.rs`
+  - `issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack`에 `문12)` 첫 수식 x 위치 회귀 검증을 추가했다.
+  - 같은 테스트에 `따라서`와 첫 수식 사이 y 간격이 20px 이하로 유지되는 회귀 검증을 추가했다.
+  - 주석 문단의 render node `para_index`가 원 문단 번호와 그대로 대응하지 않는 경우가 있어, 수식 SVG 내용과 y 범위로 대상 수식을 찾도록 했다.
+
+## 검증
+
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture`
+  - 42개 통과
+- `cargo fmt --all -- --check`
+  - 통과
+- SVG/PNG 확인
+  - `output/task1245_stage2_after/3-09월_교육_통합_2022_010.svg`
+  - `output/task1245_stage2_after/3-09월_교육_통합_2022_010.png`
+  - 첫 `lim` 수식 시작 x가 `442.88`에서 `402.52`로 이동해 우측 단 왼쪽 흐름과 정렬됨.
+  - `따라서` y=`564.88`, 첫 `lim` 수식 y=`572.71`로 조정되어 한컴/PDF처럼 간격이 촘촘해짐.

--- a/mydocs/working/task_m100_1245_stage3.md
+++ b/mydocs/working/task_m100_1245_stage3.md
@@ -1,0 +1,45 @@
+# Task #1245 Stage3: 2023 4쪽 `문26)` 중복 표시 보정
+
+## 배경
+
+- 2026-06-02: Stage2 커밋 `2a392639` 이후 새 스테이지를 시작했다.
+- 작업지시자가 `samples/3-09월_교육_통합_2023.hwp` 4쪽에서 `문26)`이 두 번 보인다고 보고했다.
+- 비교 기준 PDF는 `pdf/3-09월_교육_통합_2023.pdf`이다.
+
+## 증상
+
+- 대상 문서: `samples/3-09월_교육_통합_2023.hwp`
+- 대상 페이지: 4쪽, 렌더러 페이지 인덱스 `3`
+- 관찰 증상:
+  - 왼쪽 단의 `문26)` 제목이 정상 위치에 보인다.
+  - 같은 영역에 작은 `문26)` 표기가 한 번 더 나타나 본문 첫 줄 부근과 겹쳐 보인다.
+
+## 초기 분석 계획
+
+1. 4쪽 SVG/PDF 비교 산출물을 만든다.
+2. SVG의 `문26)` 텍스트 노드 개수와 좌표를 확인한다.
+3. 렌더 트리에서 중복이 텍스트 런 복제인지, 미주 제목/본문 조합인지, 또는 inline object/TAC 처리의 중복 배치인지 구분한다.
+4. 원인 범위를 좁힌 뒤 `tests/issue_1139_inline_picture_duplicate.rs`에 회귀 테스트를 추가한다.
+
+## 원인
+
+- `pi=258` 문단 원문에는 `문26)`이 포함되어 있지 않고, 첫 control이 미주(`Endnote`)이다.
+- `layout_composed_paragraph`는 미주 선두 번호를 본문 크기의 일반 `TextRun`으로 먼저 렌더링한다.
+- 이후 같은 `Endnote` control의 `FootnoteMarker`가 같은 줄에 위첨자로 한 번 더 생성되어 조판부호 표시 상태에서 `문26)`이 중복 표시되었다.
+
+## 수정
+
+- 선두 미주 번호가 prefix `TextRun`으로 이미 렌더된 경우, 같은 위치의 `FootnoteMarker` 생성은 건너뛰도록 했다.
+- 각주용 `FootnoteMarker`는 유지하고, 미주 선두 번호 중복만 제외한다.
+- `3-09월_교육_통합_2023.hwp` 4쪽 렌더 트리에서 `문26`이 한 번만 나타나는 회귀 테스트를 추가했다.
+
+## 산출물
+
+- `output/task1245_stage3_after/svg/3-09월_교육_통합_2023_004.svg`
+- `output/task1245_stage3_after/png/page4.png`
+
+## 검증 대기
+
+- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture`: 통과, 43개 테스트.
+- `cargo fmt --all -- --check`: 통과.
+- `rsvg-convert output/task1245_stage3_after/svg/3-09월_교육_통합_2023_004.svg -o output/task1245_stage3_after/png/page4.png`: 통과.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -57,6 +57,11 @@ struct ColumnItemCtx<'a> {
 /// `LINE_SEG`에서 그림 옆으로 좁아지는 첫 줄의 `vertical_pos`를 저장한다.
 /// 개체 자체도 그 줄의 top에 맞춰야 한컴의 “서로 자리를 침범하지 않는”
 /// 어울림 배치가 된다.
+///
+/// 일부 HWP5 원본은 문단 첫 줄의 `vertical_pos`가 0이 아니라 페이지/구역
+/// 흐름 기준 누적값이다. 이때 좁아지는 줄의 raw vpos를 그대로 문단 y에
+/// 더하면 `para_y + absolute_vpos`가 되어 그림이 페이지 하단 밖으로 밀린다.
+/// 따라서 그림 배치에는 문단 첫 줄 대비 상대 delta만 사용한다.
 fn square_wrap_first_narrow_line_vpos_px(
     para: &Paragraph,
     col_area: &LayoutRect,
@@ -79,10 +84,12 @@ fn square_wrap_first_narrow_line_vpos_px(
     if !has_full_width_before {
         return None;
     }
-    Some(hwpunit_to_px(
-        para.line_segs[first_wrap_idx].vertical_pos,
-        dpi,
-    ))
+    let base_vpos = para.line_segs.first()?.vertical_pos;
+    let narrow_vpos = para.line_segs[first_wrap_idx].vertical_pos;
+    if narrow_vpos < base_vpos {
+        return None;
+    }
+    Some(hwpunit_to_px(narrow_vpos - base_vpos, dpi))
 }
 
 type ParaFloatLanes = std::collections::HashMap<usize, FloatLaneSet>;

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -220,6 +220,65 @@ fn equation_only_tac_line_assignment(
     Some(assign)
 }
 
+fn line_has_strict_tac_control(
+    comp: &ComposedParagraph,
+    tac_offsets_px: &[(usize, f64, usize)],
+    line_idx: usize,
+) -> bool {
+    let Some(line) = comp.lines.get(line_idx) else {
+        return false;
+    };
+    let start = line.char_start;
+    let end = composed_line_char_end(comp, line_idx);
+    end > start
+        && tac_offsets_px
+            .iter()
+            .any(|(pos, _, _)| *pos >= start && *pos < end)
+}
+
+fn line_has_strict_equation_tac_control(
+    para: Option<&Paragraph>,
+    comp: &ComposedParagraph,
+    tac_offsets_px: &[(usize, f64, usize)],
+    line_idx: usize,
+) -> bool {
+    let Some(para) = para else {
+        return false;
+    };
+    let Some(line) = comp.lines.get(line_idx) else {
+        return false;
+    };
+    let start = line.char_start;
+    let end = composed_line_char_end(comp, line_idx);
+    end > start
+        && tac_offsets_px.iter().any(|(pos, _, ci)| {
+            *pos >= start
+                && *pos < end
+                && para
+                    .controls
+                    .get(*ci)
+                    .is_some_and(|ctrl| matches!(ctrl, Control::Equation(_)))
+        })
+}
+
+fn line_is_leading_empty_equation_tac_guide(
+    para: Option<&Paragraph>,
+    comp: &ComposedParagraph,
+    tac_offsets_px: &[(usize, f64, usize)],
+    line_idx: usize,
+) -> bool {
+    let Some(line) = comp.lines.get(line_idx) else {
+        return false;
+    };
+    let Some(next) = comp.lines.get(line_idx + 1) else {
+        return false;
+    };
+    line.runs.is_empty()
+        && line.char_start == next.char_start
+        && !line_has_strict_tac_control(comp, tac_offsets_px, line_idx)
+        && line_has_strict_equation_tac_control(para, comp, tac_offsets_px, line_idx + 1)
+}
+
 fn tac_offsets_for_line(
     comp: &ComposedParagraph,
     tac_offsets_px: &[(usize, f64, usize)],
@@ -1510,7 +1569,17 @@ impl LayoutEngine {
             let base = self.endnote_para_base.get();
             if cell_ctx.is_none() && para_index >= base && end > start_line + 1 {
                 para.and_then(|p| {
-                    let range = p.line_segs.get(start_line..end)?;
+                    let base_line_idx = if line_is_leading_empty_equation_tac_guide(
+                        Some(p),
+                        composed,
+                        &tac_offsets_px,
+                        start_line,
+                    ) {
+                        start_line + 1
+                    } else {
+                        start_line
+                    };
+                    let range = p.line_segs.get(base_line_idx..end)?;
                     if range
                         .windows(2)
                         .all(|w| w[1].vertical_pos >= w[0].vertical_pos)
@@ -3210,9 +3279,17 @@ impl LayoutEngine {
                                 } else {
                                     layout_box.height
                                 };
-                                // 수식 baseline을 텍스트 baseline에 맞춤
-                                // HWP 높이와 레이아웃 높이가 다르면 baseline도 비례 조정
-                                let eq_y = (y + baseline - layout_box.baseline).max(y);
+                                // 텍스트와 섞인 인라인 수식은 baseline을 맞춘다. 단,
+                                // 본문/미주에서 공백 run 안에 TAC 수식만 있는 줄은 한컴처럼
+                                // 저장된 LINE_SEG y 흐름에 직접 붙인다.
+                                let eq_y = if cell_ctx.is_none()
+                                    && comp_line.runs.iter().all(|r| {
+                                        !r.text.chars().any(|c| c > '\u{001F}' && c != '\u{FFFC}')
+                                    }) {
+                                    y
+                                } else {
+                                    (y + baseline - layout_box.baseline).max(y)
+                                };
                                 let (eq_cell_idx, eq_cell_para_idx) =
                                     if let Some(ref ctx) = cell_ctx {
                                         (
@@ -3758,10 +3835,9 @@ impl LayoutEngine {
                         pos >= line_start_char && pos < line_end_char
                     }
                 };
-                // [Task #490] paragraph alignment 적용. 셀에 텍스트 없이 수식만 있을 때
-                // (text_len=0 + ctrls=1+) 정렬이 무시되어 좌측 고정되던 결함 수정.
-                // exam_science p1 3번 표 (이온 결합 화합물) 셀 7/11 의 28/36 수식이
-                // 좌측 정렬 → 셀 ParaShape align 따라 중앙/우측 정렬 적용.
+                // [Task #490] 셀에 텍스트 없이 수식만 있을 때는 셀 ParaShape alignment 를
+                // 따라야 한다. 단, [Task #1245] 본문/미주 수식-only 줄은 저장된 LINE_SEG
+                // 흐름을 따라야 하며 문단 alignment 를 다시 적용하면 열 안에서 중앙으로 밀린다.
                 // [Task #489] effective_col_x 적용 (Picture+Square wrap LINE_SEG cs/sw 좁은 영역).
                 let line_tac_width: f64 = tac_offsets_px
                     .iter()
@@ -3769,14 +3845,23 @@ impl LayoutEngine {
                     .filter(|(k, (pos, _, _))| tac_on_line(*k, *pos))
                     .map(|(_, (_, w, _))| *w)
                     .sum();
-                let align_offset = match alignment {
-                    Alignment::Center | Alignment::Distribute => {
-                        (available_width - line_tac_width).max(0.0) / 2.0
+                let align_offset = if cell_ctx.is_some() {
+                    match alignment {
+                        Alignment::Center | Alignment::Distribute => {
+                            (available_width - line_tac_width).max(0.0) / 2.0
+                        }
+                        Alignment::Right => (available_width - line_tac_width).max(0.0),
+                        _ => 0.0,
                     }
-                    Alignment::Right => (available_width - line_tac_width).max(0.0),
-                    _ => 0.0,
+                } else {
+                    0.0
                 };
-                let mut inline_x = effective_col_x + effective_margin_left + align_offset;
+                let tac_base_x = if cell_ctx.is_some() {
+                    effective_col_x + effective_margin_left
+                } else {
+                    effective_col_x
+                };
+                let mut inline_x = tac_base_x + align_offset;
                 for (tac_k, &(tac_pos, tac_w, tac_ci)) in tac_offsets_px.iter().enumerate() {
                     if !tac_on_line(tac_k, tac_pos) {
                         continue;
@@ -3804,7 +3889,11 @@ impl LayoutEngine {
                             } else {
                                 layout_box.height
                             };
-                            let eq_y = (y + baseline - layout_box.baseline).max(y);
+                            let eq_y = if cell_ctx.is_some() {
+                                (y + baseline - layout_box.baseline).max(y)
+                            } else {
+                                y
+                            };
                             let (eq_cell_idx, eq_cell_para_idx) = if let Some(ref ctx) = cell_ctx {
                                 (
                                     Some(ctx.path[0].cell_index),
@@ -4279,12 +4368,25 @@ impl LayoutEngine {
             let skip_advance_empty_wrap = has_picture_shape_square_wrap
                 && runs_all_whitespace
                 && !line_has_tac_control(composed, line_idx);
+            // 촘촘한 미주 수식 문단에는 다음 줄과 char_start가 같은 선행
+            // 퇴화 LINE_SEG가 들어오는 경우가 있다. 해당 줄 자체에는 TAC가
+            // 없으며, 한컴은 첫 수식 앞에 이 안내 줄 높이를 예약하지 않는다.
+            let skip_advance_empty_tac_lead = cell_ctx.is_none()
+                && !tac_offsets_px.is_empty()
+                && line_is_leading_empty_equation_tac_guide(
+                    para,
+                    composed,
+                    &tac_offsets_px,
+                    line_idx,
+                );
             let skip_advance_empty_tac_picture = runs_all_whitespace
                 && current_line_reserved_tac_picture_height.is_none()
                 && prev_line_reserved_tac_picture_height
                     .map(|pic_h| (raw_lh - pic_h).abs() <= 4.0)
                     .unwrap_or(false);
-            let skip_advance_empty_line = skip_advance_empty_wrap || skip_advance_empty_tac_picture;
+            let skip_advance_empty_line = skip_advance_empty_wrap
+                || skip_advance_empty_tac_picture
+                || skip_advance_empty_tac_lead;
             if std::env::var("RHWP_DEBUG_PARA_TAC").is_ok()
                 && (para_index == 651 || para_index == 652)
             {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -362,6 +362,23 @@ fn note_marker_text_from_control(ctrl: Option<&Control>, fallback_number: u16) -
     }
 }
 
+fn is_leading_endnote_marker_rendered_as_prefix(
+    para: Option<&Paragraph>,
+    control_index: usize,
+    line_idx: usize,
+    start_line: usize,
+    marker_pos: usize,
+    line_char_start: usize,
+) -> bool {
+    line_idx == start_line
+        && start_line == 0
+        && marker_pos == line_char_start
+        && matches!(
+            para.and_then(|p| p.controls.get(control_index)),
+            Some(Control::Endnote(_))
+        )
+}
+
 fn line_tac_picture_or_shape_height(
     para: Option<&Paragraph>,
     comp: &ComposedParagraph,
@@ -2897,6 +2914,19 @@ impl LayoutEngine {
                             .iter()
                             .enumerate()
                             .filter_map(|(fni, &(fpos, fnum, ctrl_idx))| {
+                                if is_leading_endnote_marker_rendered_as_prefix(
+                                    para,
+                                    ctrl_idx,
+                                    line_idx,
+                                    start_line,
+                                    fpos,
+                                    comp_line.char_start,
+                                ) {
+                                    // 미주는 첫 줄 앞에 본문 크기 번호를 별도 TextRun으로 이미 그린다.
+                                    // 같은 위치의 위첨자 마커를 다시 만들면 `문26)`처럼 제목이 중복된다.
+                                    fn_marker_inserted[fni] = true;
+                                    return None;
+                                }
                                 let in_range = fpos >= run_char_pos
                                     && (fpos < run_char_end || (is_last && fpos == run_char_end));
                                 if !fn_marker_inserted[fni] && in_range {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -169,6 +169,7 @@ fn line_has_tac_control(comp: &ComposedParagraph, line_idx: usize) -> bool {
 ///
 /// `tac_offsets_px` 는 호출부에서 pos 오름차순 정렬되어 있다고 가정한다.
 fn equation_only_tac_line_assignment(
+    para: Option<&Paragraph>,
     comp: &ComposedParagraph,
     tac_offsets_px: &[(usize, f64, usize)],
 ) -> Option<Vec<usize>> {
@@ -208,12 +209,28 @@ fn equation_only_tac_line_assignment(
             li += 1;
         }
         let line_count = li - line_start;
+        let line_candidates: Vec<usize> = (line_start..li).collect();
+        let filtered_candidates: Vec<usize> = line_candidates
+            .iter()
+            .copied()
+            .filter(|idx| {
+                !line_is_leading_empty_equation_tac_guide(para, comp, tac_offsets_px, *idx)
+            })
+            .collect();
+        let line_targets = if filtered_candidates.is_empty() {
+            &line_candidates
+        } else {
+            &filtered_candidates
+        };
         for t in 0..tac_count {
             assign[tac_start + t] = if line_count == 0 {
                 line_start.min(n_lines - 1)
+            } else if line_targets.is_empty() {
+                line_start.min(n_lines - 1)
             } else {
                 // TAC 수가 줄 수보다 많으면 나머지는 마지막 줄에 모음(예: "S =∫₀³" 1줄 2TAC).
-                line_start + t.min(line_count - 1)
+                // 단, 미주 수식 문단의 선행 guide 줄처럼 TAC가 없는 빈 줄은 후보에서 제외한다.
+                line_targets[t.min(line_targets.len() - 1)]
             };
         }
     }
@@ -3857,7 +3874,7 @@ impl LayoutEngine {
                 // char 범위로는 tac→줄 매핑이 깨진다(빈 줄 흡수/행 겹침). 같은 char_start 줄들에
                 // 같은 position 의 연속 TAC 를 순서대로 분배한다(#1221 1:1 의 m:n 일반화).
                 let eq_tac_assignment =
-                    equation_only_tac_line_assignment(composed, &tac_offsets_px);
+                    equation_only_tac_line_assignment(para, composed, &tac_offsets_px);
                 let tac_on_line = |k: usize, pos: usize| -> bool {
                     if let Some(ref assign) = eq_tac_assignment {
                         assign.get(k).copied() == Some(line_idx)

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -994,6 +994,33 @@ fn issue_1209_2022_page8_question29_square_picture_starts_at_wrap_line() {
 }
 
 #[test]
+fn issue_1245_2022_page7_square_pictures_use_relative_line_vpos() {
+    let bytes = std::fs::read("samples/3-09월_교육_통합_2022.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let tree = doc.build_page_render_tree(6).expect("page 7 render tree");
+
+    let question25_picture = find_image_bbox(&tree.root, 386, 11).expect("문25 타원 그림");
+    let question25_wrap_line =
+        find_text_line_bbox(&tree.root, 386, 3).expect("문25 그림 옆 첫 좁은 줄");
+    assert!(
+        (question25_picture.y - question25_wrap_line.y).abs() <= 2.0,
+        "문25 어울림 그림은 누적 LINE_SEG vpos를 중복 적용하지 않고 좁아지는 줄에 붙어야 함: picture={question25_picture:?}, wrap_line={question25_wrap_line:?}"
+    );
+    assert!(
+        question25_picture.y + question25_picture.height < 920.0,
+        "문25 그림이 페이지 하단 밖으로 밀리면 안 됨: picture={question25_picture:?}"
+    );
+
+    let question28_picture = find_image_bbox(&tree.root, 420, 9).expect("문28 포물선 그림");
+    let question28_wrap_line =
+        find_text_line_bbox(&tree.root, 420, 3).expect("문28 그림 옆 첫 좁은 줄");
+    assert!(
+        (question28_picture.y - question28_wrap_line.y).abs() <= 2.0,
+        "문28 어울림 그림도 문단 첫 줄 대비 상대 LINE_SEG vpos로 배치되어야 함: picture={question28_picture:?}, wrap_line={question28_wrap_line:?}"
+    );
+}
+
+#[test]
 fn issue_1139_2023_page4_question26_square_table_uses_anchor_line() {
     let bytes = std::fs::read("samples/3-09월_교육_통합_2023.hwp").expect("sample");
     let doc = HwpDocument::from_bytes(&bytes).expect("parse");

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -1348,7 +1348,15 @@ fn issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack() {
 
     let question12_y = min_para_text_y(&tree.root, 567).expect("문12 title");
     let question12_body_y = min_para_text_y(&tree.root, 568).expect("문12 body");
+    let question12_tail_y = min_para_text_y(&tree.root, 573).expect("문12 따라서");
     let question13_y = min_para_text_y(&tree.root, 575).expect("문13 title");
+    let mut ah_formulas = Vec::new();
+    collect_equation_bboxes_containing(&tree.root, ">AH</text>", &mut ah_formulas);
+    let question12_formula = ah_formulas
+        .into_iter()
+        .filter(|bbox| bbox.y > question12_tail_y && bbox.y < question13_y)
+        .min_by(|a, b| a.x.partial_cmp(&b.x).unwrap_or(std::cmp::Ordering::Equal))
+        .expect("문12 첫 수식");
 
     assert!(
         (390.0..=406.0).contains(&question12_y),
@@ -1361,6 +1369,16 @@ fn issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack() {
     assert!(
         question13_y <= 724.0,
         "문12 수식 블록이 아래로 밀려 문13을 늦게 시작시키면 안 됨: q13_y={question13_y}"
+    );
+    assert!(
+        (398.0..=408.0).contains(&question12_formula.x),
+        "문12 수식-only 문단은 배분 정렬 오프셋으로 중앙에 밀리면 안 됨: x={}",
+        question12_formula.x
+    );
+    assert!(
+        question12_formula.y - question12_tail_y <= 20.0,
+        "문12 '따라서'와 수식-only 문단 사이 간격은 한컴/PDF처럼 촘촘해야 함: tail_y={question12_tail_y}, formula_y={}",
+        question12_formula.y
     );
 }
 

--- a/tests/issue_1139_inline_picture_duplicate.rs
+++ b/tests/issue_1139_inline_picture_duplicate.rs
@@ -46,6 +46,19 @@ fn render_tree_contains_text(node: &RenderNode, needle: &str) -> bool {
         .any(|child| render_tree_contains_text(child, needle))
 }
 
+fn count_render_text_occurrences(node: &RenderNode, needle: &str) -> usize {
+    let here = match &node.node_type {
+        RenderNodeType::TextRun(run) => run.text.matches(needle).count(),
+        RenderNodeType::FootnoteMarker(marker) => marker.text.matches(needle).count(),
+        _ => 0,
+    };
+    here + node
+        .children
+        .iter()
+        .map(|child| count_render_text_occurrences(child, needle))
+        .sum::<usize>()
+}
+
 fn svg_attr_f64(tag: &str, name: &str) -> Option<f64> {
     let pattern = format!("{name}=\"");
     let start = tag.find(&pattern)? + pattern.len();
@@ -1032,6 +1045,19 @@ fn issue_1139_2023_page4_question26_square_table_uses_anchor_line() {
     assert!(
         table.y > first_text_y + 70.0 && table.y < first_text_y + 120.0,
         "문26 Square wrap 표는 문단 첫 줄이 아니라 LineSeg가 좁아지는 후반 줄에 붙어야 함: table={table:?}, first_text_y={first_text_y}"
+    );
+}
+
+#[test]
+fn issue_1245_2023_page4_question26_endnote_marker_not_duplicated() {
+    let bytes = std::fs::read("samples/3-09월_교육_통합_2023.hwp").expect("sample");
+    let doc = HwpDocument::from_bytes(&bytes).expect("parse");
+    let tree = doc.build_page_render_tree(3).expect("page 4 render tree");
+
+    let count = count_render_text_occurrences(&tree.root, "문26");
+    assert_eq!(
+        count, 1,
+        "미주 선두 번호는 일반 TextRun으로 한 번만 렌더되어야 하며 위첨자 마커로 중복되면 안 됨"
     );
 }
 


### PR DESCRIPTION
## 작업 범위

이 PR은 #1245에서 보고된 `3-09월_교육_통합_2022.hwp` 및 후속 확인 중 발견된 `3-09월_교육_통합_2023.hwp` 렌더링 불일치를 단계별로 보정합니다.

대상 문서:

- `samples/3-09월_교육_통합_2022.hwp`
- `samples/3-09월_교육_통합_2023.hwp`

주요 영역:

- `Square/어울림` 그림 객체의 line segment 기반 세로 배치
- 미주/본문 수식-only 문단의 TAC 배정 및 guide 줄 처리
- 미주 선두 번호와 marker 중복 렌더링
- PR #1241, #1247 병합 이후 회귀 방지

## Stage1: 2022년 9월 문서 7쪽 그림 객체 위치 보정

대상:

- 문서: `3-09월_교육_통합_2022.hwp`
- 페이지: 7쪽
- 위치: `문25)`, `문28)` 주변 `Square/어울림` 그림 객체

원인:

- `square_wrap_first_narrow_line_vpos_px`는 어울림 그림이 문단 중간부터 본문을 감싸는 경우 처음 좁아지는 `LINE_SEG.vertical_pos`를 그림 상단 보정값으로 사용합니다.
- 기존 구현은 좁아지는 줄의 raw `vertical_pos`를 px로 변환해 `para_base_y`에 그대로 더했습니다.
- 하지만 문제 문단의 첫 줄 `vertical_pos`는 `31648`처럼 이미 누적 흐름값입니다.
- 이 상태에서 좁아지는 줄의 raw `vertical_pos=37804`를 다시 더하면 `para_base_y + absolute_vpos`가 되어 그림이 페이지 하단 밖으로 밀립니다.

수정:

- 어울림 그림 상단 보정값을 raw `vertical_pos`가 아니라 첫 줄 대비 상대 delta로 계산했습니다.

```text
delta = first_narrow_line.vertical_pos - first_line.vertical_pos
```

- 첫 줄 `vertical_pos=0`인 기존 문서 유형은 delta가 기존 raw 값과 같으므로 기존 동작을 유지합니다.

회귀 가드:

- `issue_1245_2022_page7_square_pictures_use_relative_line_vpos`

검증한 내용:

- 7쪽 `문25)` 타원 그림 `pi=386 ci=11`이 첫 좁은 줄과 같은 y에 붙는지 확인했습니다.
- 7쪽 `문28)` 포물선 그림 `pi=420 ci=9`도 같은 방식으로 확인했습니다.
- `문25)` 그림이 페이지 하단 밖으로 밀리지 않는지 확인했습니다.

## Stage2: 2022년 9월 문서 10쪽 `문12)` 수식 배치 보정

대상:

- 문서: `3-09월_교육_통합_2022.hwp`
- 페이지: 10쪽
- 위치: 우측 단 `문12)` 본문과 수식 블록

초기 증상:

- 우측 단 하단의 긴 수식/분수식이 한컴/PDF 기준보다 오른쪽 또는 아래쪽으로 밀렸습니다.
- 수정 전 SVG 기준 `따라서` 텍스트는 `x=402.52`에서 시작하지만, 바로 뒤 첫 `lim` 수식은 `x=442.88`에서 시작했습니다.
- x 보정 이후에도 `따라서`와 첫 수식 사이 y 간격이 한컴보다 크게 남았습니다.

원인:

- 문제 수식 블록은 `pi=574`의 텍스트 없는 TAC 수식-only 문단입니다.
- 빈 runs + TAC 수식 fallback이 본문/미주 수식-only 문단에도 `effective_margin_left`와 alignment offset을 다시 적용했습니다.
- `RHWP_DEBUG_PARA_TAC=1`로 확인한 결과, `pi=574`에는 TAC가 없는 선행 `LINE_SEG`가 존재했습니다.
- 이 선행 줄은 `char_start=0, char_end=0`인 퇴화 guide 줄이고, 실제 첫 수식은 다음 줄 `char_start=0..1`에 매핑되어 있었습니다.
- 한컴은 이 guide 줄을 첫 수식 앞 세로 예약으로 쓰지 않지만, 기존 RHWP는 guide 줄 높이를 y advance에 포함해 첫 수식을 아래로 밀었습니다.

수정:

- 셀 내부 수식-only 문단은 Task #490 계열 회귀를 막기 위해 기존처럼 paragraph alignment와 margin을 적용합니다.
- 본문/미주 수식-only 문단은 저장된 `LINE_SEG` 흐름을 따르도록 `effective_col_x` 기준으로 배치합니다.
- TAC가 없는 선행 guide 줄을 기준 vpos와 y advance에서 제외해 첫 수식이 한컴처럼 앞 문장 바로 뒤에 붙도록 했습니다.

회귀 가드:

- `issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack`

검증한 내용:

- `문12)` 첫 수식 x 위치가 우측 단 왼쪽 흐름과 정렬되는지 확인했습니다.
- `따라서`와 첫 수식 사이 y 간격이 20px 이하로 유지되는지 확인했습니다.
- 주석 문단의 render node `para_index`가 원 문단 번호와 직접 대응하지 않는 경우가 있어, 수식 SVG 내용과 y 범위로 대상 수식을 찾도록 테스트를 보강했습니다.

수정 후 확인값:

- 첫 `lim` 수식 시작 x: `442.88`에서 `402.52`로 이동
- `따라서` y: `564.88`
- 첫 `lim` 수식 y: `572.71`

## Stage3: 2023년 9월 문서 4쪽 `문26)` 중복 표시 보정

대상:

- 문서: `3-09월_교육_통합_2023.hwp`
- 페이지: 4쪽
- 위치: 왼쪽 단 `문26)`

증상:

- 왼쪽 단 `문26)` 제목이 정상 위치에 보이지만, 같은 영역에 작은 `문26)` 표기가 한 번 더 나타나 본문 첫 줄 부근과 겹쳤습니다.

원인:

- `pi=258` 원문 문단에는 `문26)` 텍스트가 직접 들어 있지 않고, 첫 control이 미주(`Endnote`)입니다.
- `layout_composed_paragraph`는 미주 선두 번호를 본문 크기의 일반 `TextRun`으로 먼저 렌더링합니다.
- 이후 같은 `Endnote` control의 `FootnoteMarker`가 같은 줄에 위첨자로 다시 생성되어 조판부호 표시 상태에서 `문26)`이 중복 표시되었습니다.

수정:

- 선두 미주 번호가 prefix `TextRun`으로 이미 렌더된 경우, 같은 위치의 `FootnoteMarker` 생성을 건너뛰도록 했습니다.
- 각주용 `FootnoteMarker`는 유지하고, 미주 선두 번호 중복만 제외했습니다.

회귀 가드:

- `issue_1245_2023_page4_question26_endnote_marker_not_duplicated`

검증한 내용:

- `3-09월_교육_통합_2023.hwp` 4쪽 렌더 트리에서 `문26`이 한 번만 나타나는지 확인했습니다.

## PR #1241 병합 후 문12 수식 배정 회귀 보정

배경:

- `upstream/devel`에 PR #1241이 반영된 뒤 task1245 브랜치를 rebase했습니다.
- rebase 후 `문12)` 첫 수식이 다시 `따라서`와 겹칠 수 있는 회귀가 발견되었습니다.

원인:

- PR #1241의 수식-only TAC 줄 배정 로직이 같은 위치 후보 중 TAC가 없는 선행 guide 줄을 첫 수식 후보로 선택할 수 있었습니다.
- 이 경우 Stage2에서 의도한 실제 TAC 줄 기준 배치가 무너질 수 있었습니다.

수정:

- `equation_only_tac_line_assignment`가 문단 정보를 함께 받아, TAC가 없는 선행 guide 줄을 후보에서 제외하도록 했습니다.
- 기존 PR #1241의 연속 인라인 수식 병합 해소 로직은 유지했습니다.

확인:

- 진단에서 첫 `AH` 수식이 `따라서` 꼬리와 겹치지 않는 위치로 이동한 것을 확인했습니다.
- `issue_1209_2022_sep_page10_question12_uses_safe_vpos_backtrack`가 다시 통과했습니다.

## PR #1247 병합 후 회귀 확인

- `upstream/devel`에 PR #1247이 반영된 뒤 다시 rebase했습니다.
- #1247의 미주 사이 간격 처리(`endnote_between_notes_hu`)와 task1245의 TAC guide 보정 로직이 함께 유지되는 것을 확인했습니다.
- `cargo test --test issue_1139_inline_picture_duplicate -- --nocapture` 기준 43개 테스트가 통과했습니다.

## 최종 보고서

- `mydocs/report/task_m100_1245_report.md`를 추가했습니다.
- Stage1부터 Stage3, PR #1241/#1247 rebase 후 회귀 확인, 최종 검증 내용을 정리했습니다.

## 변경 파일

- `src/renderer/layout.rs`
  - 어울림 그림의 line segment 기반 세로 위치 계산 보정
- `src/renderer/layout/paragraph_layout.rs`
  - 수식-only TAC guide 줄 처리
  - 본문/미주 수식-only 문단 정렬 기준 분리
  - 미주 선두 번호 중복 marker 억제
- `tests/issue_1139_inline_picture_duplicate.rs`
  - #1245 및 관련 회귀 테스트 추가/보강
- `mydocs/plans/task_m100_1245.md`
- `mydocs/plans/task_m100_1245_impl.md`
- `mydocs/working/task_m100_1245_stage0.md`
- `mydocs/working/task_m100_1245_stage1.md`
- `mydocs/working/task_m100_1245_stage2.md`
- `mydocs/working/task_m100_1245_stage3.md`
- `mydocs/report/task_m100_1245_report.md`

## 검증

최종 PR 전 수행한 검증:

```bash
cargo test --tests
cargo test --test issue_1139_inline_picture_duplicate -- --nocapture
cargo fmt --all -- --check
git diff --check
```

결과:

- `cargo test --tests`: 통과
- `issue_1139_inline_picture_duplicate`: 43개 통과
- `cargo fmt --all -- --check`: 통과
- `git diff --check`: 통과

## 관련 이슈

Closes #1245
