### PR TITLE
사각형 글상자 안 picture 클릭 hit-test / 속성 / 삽입 지원 (#1171)

### DIFF
--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -5,6 +5,7 @@
 | 이슈 | 제목 | 상태 | 비고 |
 |---|---|---|---|
 | [#1237](https://github.com/edwardkim/rhwp/issues/1237) | HWP 저장 계약: 문단 헤더와 LINE_SEG 필드 의미 정리 | 완료 | #1183 후속 감사. `LineSeg`/`PARA_HEADER` 저장 계약, 코드 주석, `hwp_save_guide.md` 보강 |
+| [#1171](https://github.com/edwardkim/rhwp/issues/1171) | 사각형 글상자 안 picture click hit-test / 속성 지원 | 계획 승인, 구현 대기 | `local/task1171`. cellPath 일반화(✓) + picture 우선 UX(✓) 확정. 수행/구현계획서 작성. tac-img-02.hwp p6/p7 |
 
 ## Task #1209 — task 1139 후속 보정
 

--- a/mydocs/orders/20260602.md
+++ b/mydocs/orders/20260602.md
@@ -5,7 +5,6 @@
 | 이슈 | 제목 | 상태 | 비고 |
 |---|---|---|---|
 | [#1237](https://github.com/edwardkim/rhwp/issues/1237) | HWP 저장 계약: 문단 헤더와 LINE_SEG 필드 의미 정리 | 완료 | #1183 후속 감사. `LineSeg`/`PARA_HEADER` 저장 계약, 코드 주석, `hwp_save_guide.md` 보강 |
-| [#1171](https://github.com/edwardkim/rhwp/issues/1171) | 사각형 글상자 안 picture click hit-test / 속성 지원 | 계획 승인, 구현 대기 | `local/task1171`. cellPath 일반화(✓) + picture 우선 UX(✓) 확정. 수행/구현계획서 작성. tac-img-02.hwp p6/p7 |
 
 ## Task #1209 — task 1139 후속 보정
 

--- a/mydocs/plans/task_m100_1171.md
+++ b/mydocs/plans/task_m100_1171.md
@@ -1,0 +1,100 @@
+# 수행 계획서 — Task #1171: 사각형 글상자 안 picture click hit-test / 속성 지원
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171) (M100 / v1.0.0)
+- **브랜치**: `local/task1171` (base: `local/devel`)
+- **대상**: `samples/tac-img-02.hwp` p6/p7 — 사각형(Shape, InFrontOfText) → 글상자(text_box) → paragraph → picture 이중 중첩
+- **선행**: #1151 v4(셀 안 inline picture hit-test, 완료) 진단 중 분리된 별개 결함
+- **작성일**: 2026-06-02
+
+## 1. 배경 — 왜 필요한가
+
+`samples/tac-img-02.hwp` 6/7 페이지의 picture(bin_id 3·4·5)가 rhwp-studio에서 클릭되지 않는다.
+구조는 **사각형(Shape, 배치=InFrontOfText) → 글상자(text_box) → p[0] → ctrl(picture)** 의 이중 중첩이다.
+클릭 시 picture select 진입이 안 되거나 바깥 사각형 Shape가 select된다.
+
+Task #1151 v4(표 셀 안 inline picture)에서 셀 안 picture는 해소되었으나, **Shape 글상자 안 picture는
+hit_test 단락 경로와 property 식별 경로가 모두 다른** 별개 결함으로 확인되었다.
+
+## 2. 문제 정의 — 두 개의 독립 하위 문제
+
+### (A) hit-test/dispatch 단락
+- `rhwp-studio/src/engine/input-handler-mouse.ts:744` — 글상자 내부 클릭(`hit.isTextBox=true`)이
+  즉시 caret 텍스트 편집으로 진입하며 `return`. 그 결과 762행 `findPictureAtClick`이 호출되지 않음.
+- 표 셀 picture는 `hit_test_native`가 `isTextBox=false`라 762행까지 fall-through 되지만,
+  Shape text_box는 `isTextBox=true`라 744행에서 단락된다 — 이것이 셀과 다른 점.
+
+### (B) property 식별 불가
+- `src/renderer/layout/shape_layout.rs:2204-2237` — 글상자 안 picture의 `layout_picture` 호출이
+  **outer 좌표**(본문 섹션 / Shape를 담은 본문 문단 / Shape의 control 인덱스)만 넘기고
+  `cell_ctx`로 `None`을 넘긴다. 즉 picture의 controls JSON `secIdx/paraIdx/controlIdx`가
+  바깥 Shape와 동일해 inner picture를 식별할 수 없다.
+
+## 3. 핵심 발견 — picture만 cellPath 일반화에서 누락
+
+picture를 **제외한** 모든 글상자 콘텐츠(text/equation/table)는 이미 cellPath 일반화로 통합돼 있다:
+
+- `shape_layout.rs:1963-1975`(text-run), 2253행(equation), 2322행(table)은 글상자를
+  "cell_index=0인 단일 셀 표"로 취급하는 `CellPathEntry { control_index, cell_index:0,
+  cell_para_index, text_direction:0 }` sentinel을 빌드해 `CellContext`로 전달한다.
+  **picture(2204/2226행)만 `None`을 넘긴다.**
+- 백엔드 immutable resolver `resolve_paragraph_by_path`(`cursor_nav.rs:584`)는 `Control::Shape`
+  arm을 가져 글상자 path를 이미 해석한다.
+- `rendering.rs:1539-1558`은 `ImageNode.cell_context.path`를 자동으로 `cellPath` JSON으로 직렬화.
+- 프론트엔드는 cellPath를 끝까지 보존: `findPictureAtClick`(`input-handler-picture.ts:86`) →
+  dispatch(`input-handler-mouse.ts:846`) → `cursor.ts` 저장 → dialog(`picture-props-dialog.ts:264`)의
+  `getCellPicturePropertiesByPath`.
+
+**유일한 공백 2곳:**
+1. shape_layout.rs의 picture가 `CellContext`를 못 받음(`None`).
+2. by_path picture getter/setter가 **비대칭으로 글상자를 거부**: getter(`object_ops.rs:3112`)는
+   `resolve_cell_by_path`(마지막 세그먼트=Table 셀 요구), setter(`object_ops.rs:3179`)는
+   `resolve_cell_paragraph_mut`(Table 전용)를 사용.
+
+## 4. 목표 / 접근 (작업지시자 확정)
+
+- **(B) cellPath 일반화로 구현 (✓ 확정)**: shape_layout picture에 CellContext 전달 + 백엔드
+  by_path getter/setter가 글상자 path도 해석하도록 교체. 신규 WASM API 0개, 프론트엔드 거의
+  무변경, 표→글상자→표 깊은 중첩도 자동 대응.
+- **(A) picture 우선 UX (✓ 확정)**: 글상자 안 picture 위 클릭은 항상 picture 객체선택
+  (표 셀 picture와 동작 일관). 텍스트 편집은 picture 없는 글상자 영역 클릭으로.
+
+### HWP 5.0 스펙 정합 확인 (`mydocs/tech/한글문서파일형식_5.0_revision1.3.md`)
+- 글상자 = 문단 리스트(표 89/90, spec 1728-1745행) → cellPath "cell_index=0 단일 셀 컨테이너"
+  모델과 정확히 일치.
+- 글상자 안 picture = 자체 개체 공통 속성(z-order/위치/크기)을 가진 1급 개체(표 68/69,
+  spec 1442-1458행) → 직접 선택 1급 개체로 취급(picture 우선)과 정합.
+- z-order는 같은 컨테이너 내 형제 stacking(표 69, spec 1452행) → 바깥 Shape와 안쪽 picture는
+  다른 문단 리스트라 형제 아님, picture는 항상 글상자 위 자식 layer.
+- 스펙은 클릭 UX를 규정하지 않으나 위 사항 모두 접근 B + picture 우선과 충돌 없음.
+
+## 5. 단계 구성 (5단계) — 상세는 구현계획서
+
+1. **Stage 1** — shape_layout picture에 CellContext 전달(백엔드 식별자 생성).
+2. **Stage 2** — 백엔드 by_path getter/setter 글상자 지원(속성 read/write).
+3. **Stage 3** — 프론트엔드 picture 우선 hit-test (A).
+4. **Stage 4** — dialog cellPath 정합(insert.ts).
+5. **Stage 5** — 통합 + tac-img-02.hwp p6/p7 수동 검증.
+
+## 6. 검증 도구
+
+| 항목 | 명령 |
+|------|------|
+| 백엔드 | `cargo test`(round-trip + 표 셀 회귀), `cargo clippy` |
+| 구조/좌표 | `rhwp export-svg samples/tac-img-02.hwp -p 5 -p 6 --debug-overlay`, `rhwp dump -s0 -p<문단>` |
+| 프론트엔드 | `npx tsc --noEmit`, `npm run build`, E2E(puppeteer, `rhwp-studio/e2e/`) |
+| 수동 | 호스트 Chrome CDP(`--remote-debugging-port=9222`)로 p6/p7 직접 클릭 |
+
+## 7. 회귀 가드
+
+| 위험 | 방어 |
+|------|------|
+| 표 셀 picture by_path 해석 회귀 | getter/setter를 글상자·표 양쪽 처리하는 resolver로 교체, Stage 2 전체 cargo test 게이트, 기존 셀 테스트(object_ops.rs:7525 등) 무회귀 확인 |
+| setter mut resolver 공유 영향 | 신규 `resolve_paragraph_by_path_mut`로 격리(기존 `resolve_cell_paragraph_mut` 불변) |
+| 프론트엔드 표 셀 picture dispatch 회귀 | insert.ts에 기존 스칼라 재구성 fallback 안전망 유지 |
+| 글상자 텍스트 편집 UX 손상 | picture 없는 글상자 영역 클릭은 기존대로 텍스트 편집, 선제 분기는 picture hit일 때만 |
+
+## 8. 범위 밖 (후속)
+
+- 글상자 안 picture의 이동/리사이즈/삭제 커맨드(MovePictureCommand 등)의 cellPath 정합.
+- 글상자 안 중첩 **Shape**(picture 아닌 도형) setter 비대칭(`set_cell_shape_properties_by_path_native`
+  동일 문제) — 동일 헬퍼 교체로 부수 해결 가능하나 본 이슈는 picture로 한정.

--- a/mydocs/plans/task_m100_1171_impl.md
+++ b/mydocs/plans/task_m100_1171_impl.md
@@ -1,0 +1,130 @@
+# 구현 계획서 — Task #1171: 사각형 글상자 안 picture click hit-test / 속성 지원
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171) (M100 / v1.0.0)
+- **브랜치**: `local/task1171` (base: `local/devel`)
+- **수행계획서**: `mydocs/plans/task_m100_1171.md`
+- **작성일**: 2026-06-02
+
+각 단계 완료 후 `mydocs/working/task_m100_1171_stage{N}.md` 보고서 작성 + 해당 단계 소스 커밋,
+승인 후 다음 단계 진행.
+
+---
+
+## Stage 1 — shape_layout picture에 CellContext 전달 (백엔드 식별자 생성)
+
+**목적**: 글상자 안 picture의 ImageNode가 `cell_context`(cell_index=0 sentinel path)를 갖도록 하여
+controls JSON에 `cellPath`가 직렬화되게 한다. (B)의 식별 공백 #1 해소.
+
+**변경**:
+- `src/renderer/layout/shape_layout.rs:2204-2215`(inline), `2226-2237`(absolute):
+  `layout_picture(..., None)` → text-run 경로(1963-1975행) 패턴을 복제한 `pic_cell_ctx` 빌드 후
+  `Some(&pic_cell_ctx)` 전달.
+  ```rust
+  let pic_cell_ctx = CellContext {
+      parent_para_index: para_index,
+      path: { let mut p = parent_cell_path.to_vec();
+              p.push(CellPathEntry { control_index, cell_index: 0,
+                                     cell_para_index: pi, text_direction: 0 }); p },
+  };
+  ```
+  - 주의: cellPath sentinel의 `control_index`는 **바깥 Shape**의 본문 control 인덱스(현 scope의
+    `control_index` 변수), ImageNode의 `control_index`(JSON `controlIdx` = inner ctrl)는 기존
+    `Some(ctrl_idx_in_para)` 유지. 두 값을 혼동하지 않는다.
+
+**검증**:
+- `cargo build`.
+- `rhwp export-svg samples/tac-img-02.hwp -p 5 -p 6 --debug-overlay`로 picture 렌더 위치 회귀 없음 확인.
+- 단위 테스트 신규: 글상자→paragraph→picture fixture를 `build_page_render_tree` 후 해당 ImageNode의
+  `cell_context.path` 마지막 엔트리가 `{control_index: Shape, cell_index:0, cell_para_index: 글상자문단}`
+  인지 검증. (셀 안 picture cell_context 테스트 패턴 참조.)
+
+**게이트**: picture 렌더 위치 무회귀 + cell_context 정상 생성 확인.
+
+---
+
+## Stage 2 — 백엔드 by_path getter/setter 글상자 지원 (속성 read/write)
+
+**목적**: by_path picture getter/setter가 마지막 세그먼트가 글상자인 path도 해석. (B)의 공백 #2 해소.
+
+**변경**:
+- `src/document_core/commands/object_ops.rs:3104-3129` `get_cell_picture_properties_by_path_native`:
+  `resolve_cell_by_path` + `cell.paragraphs[last.2]` → `resolve_paragraph_by_path`(글상자/셀 양쪽
+  지원, `cursor_nav.rs:584`)로 paragraph를 직접 얻은 뒤 `cell_para.controls[inner_control_idx]`.
+- `src/document_core/commands/object_ops.rs:3166-3208` `set_cell_picture_properties_by_path_native`:
+  `resolve_cell_paragraph_mut`(Table 전용) → 신규 `resolve_paragraph_by_path_mut`(immutable
+  `resolve_paragraph_by_path`의 mut 미러, 회귀 격리)로 교체.
+- 신규 헬퍼 `resolve_paragraph_by_path_mut`(`cursor_nav.rs` 또는 `object_ops.rs`): `Control::Table`
+  + `Control::Shape`(get_textbox_from_shape mut) arm을 모두 처리.
+- `src/document_core/queries/rendering.rs:1539-1558`: **무변경**(Stage 1 cell_context로 자동 직렬화).
+
+**검증**:
+- `cargo test` 신규 round-trip 테스트 `picture_in_textbox_get_set_by_path`: 글상자 picture를 path로
+  조회 → 속성 변경(width/height) → 재조회 일치.
+- 기존 표 셀 picture 테스트(`object_ops.rs:7525` 등) + 전체 `cargo test` 회귀 0.
+- `cargo clippy`.
+
+**게이트**: round-trip 성공 + 표 셀 회귀 0.
+
+---
+
+## Stage 3 — 프론트엔드 picture 우선 hit-test (A)
+
+**목적**: 글상자 내부 클릭이 텍스트 편집으로 단락되기 전에 글상자 안 picture를 선제 선택.
+
+**변경**:
+- `rhwp-studio/src/engine/input-handler-mouse.ts`: 글상자 경계선 검사(705-720) 직후, 텍스트 편집
+  진입(744) 직전에 분기 추가 —
+  `if (hit.isTextBox)` 일 때 `findPictureAtClick(pageIdx, pageX, pageY)`를 선제 호출하여
+  반환 picHit이 `type==='image'|'equation'`이고 `cellPath`(글상자 sentinel 포함) 동반이면
+  760-857의 picture dispatch 로직(enterPictureObjectSelectionDirect)으로 보내고 `return`.
+  - 외곽 경계선은 위 705 블록이 이미 Shape 선택 처리 → 본 분기는 내부 picture만.
+  - picHit이 없거나 picture가 아니면 기존 744행 텍스트 편집 fall-through 유지.
+
+**검증**:
+- `cd rhwp-studio && npx tsc --noEmit`.
+- E2E 신규 시나리오: tac-img-02.hwp 로드 → 글상자 안 picture 클릭 → `picture-object-selection-changed`
+  true + 선택 ref가 글상자 picture(cellPath 보유) 확인.
+- 표 셀 picture 클릭, picture 없는 글상자 텍스트 편집 진입 회귀 확인.
+
+**게이트**: 글상자 picture 객체선택 진입 + 기존 클릭 동작 무회귀.
+
+---
+
+## Stage 4 — dialog cellPath 정합 (insert.ts)
+
+**목적**: 선택된 글상자 picture의 속성 대화상자가 올바른 by_path API를 호출하도록 cellPath 전달.
+
+**변경**:
+- `rhwp-studio/src/command/commands/insert.ts:272-287`: cellPath 소스를 스칼라
+  (`outerTableControlIdx/cellIdx/cellParaIdx`) 재구성 대신 `ref.cellPath`(findPictureAtClick이 준
+  full array) 우선 사용. `innerControlIdx=ref.ci` 유지. `ref.cellPath` 부재 시 기존 스칼라
+  재구성으로 fallback(표 셀 단일 레벨 안전망).
+- `picture-props-dialog.ts` / `cursor.ts` / `input-handler-picture.ts`: **무변경**(정합 확인만).
+
+**검증**:
+- tsc.
+- E2E: 글상자 picture 선택 → 개체 속성 dialog open → width/height read 일치 → 변경 적용 후
+  재렌더 반영.
+- 표 셀 picture 속성 dialog read/write 회귀 확인.
+
+**게이트**: 글상자 picture 속성 read/write 정상 + 표 셀 dialog 무회귀.
+
+---
+
+## Stage 5 — 통합 + 수동 검증 (tac-img-02.hwp p6/p7)
+
+**목적**: 전체 정합 및 작업지시자 시각 판정.
+
+**변경**: 없음(검증·문서화·최종 보고서).
+
+**검증**:
+- 전체 `cargo test`, `cargo clippy`, studio `npx tsc --noEmit` + `npm run build`.
+- (필요 시) WASM 빌드(Docker) 후 studio 로드.
+- 수동(호스트 Chrome CDP, `--remote-debugging-port=9222`): tac-img-02.hwp p6/p7 —
+  ① 글상자 안 picture 클릭 → picture 객체선택
+  ② 속성 dialog 크기 변경 → 반영
+  ③ 글상자 외곽 클릭 → Shape 선택(기존 유지)
+  ④ picture 없는 글상자 영역 클릭 → 텍스트 편집 진입(기존 유지).
+- **산출**: `mydocs/report/task_m100_1171_report.md`.
+
+**게이트**: 4개 수동 시나리오 통과 + 전체 회귀 0.

--- a/mydocs/report/task_m100_1171_report.md
+++ b/mydocs/report/task_m100_1171_report.md
@@ -1,0 +1,72 @@
+# 최종 결과보고서 — Task #1171: 사각형 글상자 안 picture 클릭 hit-test / 속성 / 삽입
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171) (M100 / v1.0.0)
+- **브랜치**: `local/task1171` (base: `local/devel`)
+- **기간**: 2026-06-02 ~ 2026-06-03
+- **결과**: 완료 (작업지시자 실환경 + 한컴 정합 확인)
+
+## 1. 문제
+
+`samples/tac-img-02.hwp` 6/7쪽의 "사각형(Shape, InFrontOfText) → 글상자(text_box) → paragraph
+→ picture" 이중 중첩 picture 가 rhwp-studio 에서 클릭/선택/속성편집 되지 않았다. 작업 중
+글상자 위 **이미지 삽입** 실패(별개 결함)도 발견되어 함께 처리했다.
+
+## 2. 접근 — cellPath 일반화 (작업지시자 확정)
+
+글상자를 "cell_index=0 sentinel 단일 셀 컨테이너"로 취급하여, 기존 표 셀 picture 의 cellPath
+메커니즘을 글상자까지 확장했다(신규 평행 메커니즘 없음). text/equation/table 은 이미 이 방식을
+쓰고 있었고 **picture 만 누락**되어 있었다.
+
+## 3. 변경 요약 (단계별)
+
+| 단계 | 영역 | 변경 |
+|------|------|------|
+| Stage 1 | `shape_layout.rs` | 글상자 picture 의 `layout_picture` 에 `CellContext`(sentinel) 전달 (None→Some) |
+| Stage 1 | `rendering.rs` `collect_controls` | 사각형(Rectangle) 노드 조기 `return` 제거 → Table 처럼 자식 재귀하여 글상자 내부 picture 수집 (★ 진단 중 발견) |
+| Stage 2 | `object_ops.rs` getter | `resolve_cell_by_path` → `resolve_paragraph_by_path`(표/글상자 모두) |
+| Stage 2 | `object_ops.rs` `resolve_cell_paragraph_mut` | Shape arm 추가 (immutable 짝과 대칭화) → setter 글상자 지원 |
+| Stage 3 | `input-handler-mouse.ts` | 글상자 내부 클릭이 텍스트 편집으로 단락되기 전 picture 선제 hit-test (picture 우선) |
+| Stage 3 | `input-handler-picture.ts` `findPictureAtClick` | 클릭이 컨테이너 Shape + nested picture 둘 다 hit 시 picture 우선 반환 (★ E2E 중 발견) |
+| Stage 4 | `insert.ts` | **무변경** — 기존 depth-1 cellPath 재구성이 글상자에 그대로 동작(E2E 확정) |
+| Stage 6 | `input-handler-table.ts` `finishImagePlacement` | 글상자 위 이미지 드롭은 cellPath 없이 본문 para(parentParaIndex)에 floating 삽입 → 한컴처럼 본문 sibling (★ 작업지시자 실환경 발견) |
+
+> 계획 대비 편차 3건(★)은 모두 진단/검증 과정에서 발견되어 문서화했다(stage1/stage3/stage6 보고서).
+> 핵심 통찰: 셀과 "다른 방식"이 아니라, 셀이 이미 하던 cellPath 재귀/resolver 를 글상자에 동일
+> 적용 — 통합. (작업지시자 질의 "셀이랑 완전 다른 방식?" → 아니오, 동일 메커니즘 확장.)
+
+## 4. 검증
+
+- **백엔드**: `cargo test` 전체 **1948 passed / 0 failed**. 신규 round-trip 테스트
+  `tests/issue_1171_textbox_picture_cellpath.rs`(cellPath sentinel 노출 + by_path get/set
+  width 15040→20040). 표 셀 by_path 회귀 0.
+- **프런트엔드**: `npx tsc --noEmit` 변경 파일 에러 0. E2E(headless, WASM 재빌드):
+  - `e2e/textbox-picture-1171.test.mjs`: cellPath 노출 + findPictureAtClick=image + 속성 round-trip.
+  - `e2e/textbox-picture-insert-1171.test.mjs`: TDD red→green, 글상자 위 드롭 → 본문 floating
+    sibling(treat_as_char=false, shape 독립).
+- **한컴 정합(데이터 모델 + z-order)**: 삽입 이미지 = 본문 floating Picture(글상자 sibling,
+  control 1 vs Shape control 0), `wrap=Square` → InFrontOfText 글상자 **뒤**에 렌더. 작업지시자
+  실환경 + 한컴 직접 비교 **정합 확인**.
+- **빌드 메모**: studio 프로덕션 `npm run build` 는 무관한 기존 환경 결함(`canvaskit-wasm`
+  미설치)으로 막힘 — 변경 파일 tsc 0 에러, dev 서버 정상 동작으로 대체 검증.
+
+## 5. 커밋 (local/task1171)
+
+```
+20fd6e16 Stage6 글상자 위 이미지 드롭 → 본문 sibling 삽입
+70bd6389 Stage3 보강 findPictureAtClick picture 우선 + E2E
+00d1ab77 Stage3 프런트엔드 picture 우선 hit-test
+0bc8e327 Stage2 백엔드 by_path picture getter/setter 글상자 지원
+62b58e80 Stage1 글상자 안 picture cellPath 노출
+d013b721 수행/구현 계획서 작성
+```
+
+## 6. 범위 밖 (후속 권고)
+
+- 글상자 안 **중첩 Shape(도형)** 의 get(`get_cell_shape_properties_by_path_native` 는 아직 표 전용
+  resolver) — setter 는 Stage 2 로 부수 지원됨. get 정합은 후속.
+- 다단계 중첩(표→글상자→표→picture) 의 insert.ts cellPath 견고화(`ref.cellPath` 직접 사용 + 키 변환).
+- 글상자 **내부 콘텐츠로서** 이미지 삽입(글상자 텍스트 편집 상태) 경로.
+
+## 7. 다음
+
+`local/task1171` → `local/devel` merge 후보. 작업지시자 승인 시 진행.

--- a/mydocs/working/task_m100_1171_stage1.md
+++ b/mydocs/working/task_m100_1171_stage1.md
@@ -1,0 +1,61 @@
+# Stage 1 완료보고서 — Task #1171
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171)
+- **브랜치**: `local/task1171`
+- **단계 목표**: 사각형 글상자(Shape text_box) 안 picture 가 controls JSON 에 cellPath
+  (cell_index=0 sentinel)로 노출되도록 백엔드 식별자 생성. (B)의 식별 공백 해소.
+- **작성일**: 2026-06-02
+
+## 변경 내용
+
+### 1. shape_layout.rs — picture 에 CellContext 전달 (계획대로)
+`src/renderer/layout/shape_layout.rs` `layout_textbox_content` 의 `Control::Picture` 분기:
+- text-run(1963행)/equation/table 경로와 동일한 `pic_cell_ctx` 빌드 추가:
+  `CellContext { parent_para_index: para_index, path: parent_cell_path + CellPathEntry
+  { control_index(바깥 Shape), cell_index: 0, cell_para_index: pi(글상자 문단), text_direction: 0 } }`
+- inline/absolute 두 `layout_picture` 호출의 마지막 인자를 `None` → `Some(&pic_cell_ctx)` 로 교체.
+- inner picture 인덱스는 기존 `control_index` 인자(= `ctrl_idx_in_para`)로 별도 전달(불변).
+
+### 2. rendering.rs — collect_controls 사각형 자식 재귀 (★ 계획 외 추가 — 아래 "편차" 참조)
+`src/document_core/queries/rendering.rs` `get_page_control_layout_native::collect_controls`:
+- `RenderNodeType::Rectangle` (유효 좌표) 핸들러에서 "shape" 컨트롤 push 후의 `return;` 제거.
+- Table 핸들러와 동일하게 자식으로 재귀 → 글상자 내부 picture/도형이 수집됨.
+- 장식 노드(picture 테두리 등)는 `RectangleNode::new` 가 section/para/control 좌표를 `None`
+  으로 두므로 좌표 가드(`if let Some`)에 의해 컨트롤로 방출되지 않음(회귀 안전).
+
+## ★ 계획 대비 편차 (작업지시자 인지 필요)
+
+수행/구현계획서는 rendering.rs 를 **"무변경(자동 직렬화 확인만)"** 으로 예상했다. 이는
+"shape_layout 이 picture 에 cell_context 를 넣으면 rendering.rs 가 자동으로 cellPath 를
+직렬화한다"는 전제였고, 직렬화 코드(rendering.rs:1539) 자체는 실제로 그대로다.
+
+그러나 Stage 1 구현 중 진단으로 **collect_controls 가 사각형(Rectangle) 노드에서 조기
+`return` 하여 글상자 내부로 재귀하지 않는 비대칭**을 발견했다(표 Table 노드는 이미 재귀).
+이 때문에 cell_context 를 넣어도 picture 노드가 **수집 단계에서 누락**되어 JSON 에
+나타나지 않았다. 즉 picture 직렬화 로직은 무변경이 맞으나, 그 직전의 **트리 순회(수집)**
+한 줄(`return` 제거)이 추가로 필요했다.
+
+- 영향 범위: 유효 좌표를 가진 모든 Rectangle(Shape) 노드의 controls 수집 — 글상자 안
+  중첩 picture/도형이 새로 노출된다(기존 컨트롤은 불변, 누락분만 추가).
+- 회귀 검증: 전체 `cargo test` 1947 passed / 0 failed 로 회귀 없음 확인.
+- 셀 방식과의 정합: 이 수정은 "셀과 다른 방식"이 아니라 **표 셀 수집이 이미 하던 재귀를
+  글상자에도 동일 적용**한 것이다(접근 B 통합 원칙 그대로).
+
+## 검증
+
+- `cargo build` 통과, `cargo clippy --tests` 변경 파일/라인 경고 0(나머지는 기존 경고).
+- 신규 테스트 `tests/issue_1171_textbox_picture_cellpath.rs`
+  (`textbox_picture_emits_cellpath_sentinel`) 통과:
+  - 섹션0 문단25 picture 2개(inner ctrl 0,1) + 문단44 picture 1개(inner ctrl 0)가
+    `cellPath=[{controlIndex:0, cellIndex:0, cellParaIndex:0}]` + `parentParaIdx`=각 25/44
+    로 노출됨을 단정.
+  - 렌더 위치: 문단25 → page index 5(6쪽), 문단44 → page index 6(7쪽) — 이슈의 p6/p7 일치.
+- **전체 `cargo test`: 1947 passed, 0 failed.**
+- 타깃 회귀: issue_1161_image_cellpath(1), issue_1139_inline_picture_duplicate(41),
+  issue_717_table_cell_hit_test(3), issue_919_textbox_hit_test(5) 전부 통과.
+
+## 다음 단계 (Stage 2)
+
+백엔드 by_path picture getter/setter 가 글상자 path(마지막 세그먼트=Shape)도 해석하도록
+`resolve_cell_by_path`/`resolve_cell_paragraph_mut` → 글상자 지원 resolver 로 교체.
+이제 controls JSON 의 cellPath 가 올바르므로, 그 cellPath 로 속성 read/write 가 가능해야 한다.

--- a/mydocs/working/task_m100_1171_stage2.md
+++ b/mydocs/working/task_m100_1171_stage2.md
@@ -1,0 +1,51 @@
+# Stage 2 완료보고서 — Task #1171
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171)
+- **브랜치**: `local/task1171`
+- **단계 목표**: 백엔드 by_path picture getter/setter 가 글상자(Shape text_box) path
+  (마지막 세그먼트=Shape, cell_index=0 sentinel)도 해석하여 속성 read/write 가능하게.
+- **작성일**: 2026-06-02
+
+## 변경 내용 (`src/document_core/commands/object_ops.rs`)
+
+### 1. 글상자 mut 헬퍼 import
+- `use super::super::helpers::{get_textbox_from_shape, get_textbox_from_shape_mut};`
+
+### 2. getter `get_cell_picture_properties_by_path_native`
+- `resolve_cell_by_path`(마지막 세그먼트=표 셀 요구) + 수동 `cell.paragraphs[last.2]` 접근을
+  → `resolve_paragraph_by_path`(cursor_nav.rs:584, 표 셀과 글상자 모두 처리, 최종 문단 직접 반환)
+  한 줄로 교체. 이후 `cell_para.controls[inner_control_idx]` 의 Picture 조회는 동일.
+- 표 셀 동작 불변(resolve_paragraph_by_path 의 Table arm 이 기존과 동일 navigation).
+
+### 3. setter 공통 헬퍼 `resolve_cell_paragraph_mut` 에 Shape arm 추가
+- 기존 Table 전용(비-Table 거부) → immutable 짝 `resolve_paragraph_by_path` 와 동일하게
+  `Control::Table` + `Control::Shape`(cell_index=0 검증 + `get_textbox_from_shape_mut`) 모두 처리.
+- 헬퍼 doc 주석에 "[Task #1171] 이후 표 셀과 글상자를 모두 처리(immutable 짝과 동일)" 명시.
+- picture setter `set_cell_picture_properties_by_path_native` 가 이 헬퍼를 통해 글상자 path 처리.
+
+## 범위 메모 (Shape setter 부수 효과)
+
+`resolve_cell_paragraph_mut` 는 picture setter 와 shape setter
+(`set_cell_shape_properties_by_path_native`) 가 **공유**한다. Shape arm 추가로 shape setter 도
+글상자 안 (중첩) 도형 path 를 처리할 수 있게 되었다(부수 효과, 회귀 아님 — 기존 표 셀 동작
+불변, 능력만 추가). 단 shape **getter**(`get_cell_shape_properties_by_path_native`)는 여전히
+`resolve_cell_by_path`(표 전용)를 사용하므로, 글상자 안 도형의 get/set 은 완전히 배선되지
+않았다. 본 이슈 범위(picture)에서는 프런트가 글상자 안 도형 path 를 보내지 않으므로 무해하며,
+글상자 안 도형 편집은 후속(수행계획서 §8 범위 밖)으로 남긴다.
+
+## 검증
+
+- `cargo build` 통과.
+- 신규 테스트 `picture_in_textbox_get_set_by_path` (tests/issue_1171_textbox_picture_cellpath.rs):
+  - 섹션0 문단25 글상자 picture(inner ctrl 0) 조회 → width+12345 변경 set → 재조회 반영 확인.
+  - 두번째 picture(inner ctrl 1) 분리 조회 확인(inner_control_idx 정합).
+- **`cargo test --lib`: 1527 passed, 0 failed** (object_ops by_path 셀 테스트 포함 — getter/setter
+  교체 회귀 0).
+- 셀 by_path/이미지 통합 회귀: issue_1161_image_cellpath, issue_1198_nested_cell_paste,
+  issue_717_table_cell_hit_test, issue_table_vpos_01_page5_cell_hit_test 전부 통과.
+- `cargo clippy --lib` 변경 파일/라인 경고 0.
+
+## 다음 단계 (Stage 3)
+
+프런트엔드 hit-test: 글상자 내부 클릭이 텍스트 편집으로 단락(input-handler-mouse.ts:744)되기
+전에 글상자 안 picture 를 선제 hit-test 하여 picture 객체선택으로 보낸다(picture 우선).

--- a/mydocs/working/task_m100_1171_stage3.md
+++ b/mydocs/working/task_m100_1171_stage3.md
@@ -30,17 +30,43 @@
   Stage 1-2 의 Rust 변경(cellPath 노출)을 포함한 새 WASM 빌드를 필요로 한다(현재 pkg/ 는
   Stage 1-2 미반영). Stage 5 에서 WASM 재빌드 후 E2E/수동 검증.
 
-## Stage 4 사전 분석 (insert.ts)
+## Stage 3 보강 — findPictureAtClick 우선순위 (★ 행위 검증 중 추가)
+
+WASM 재빌드(Stage 1-2 반영) 후 E2E 검증에서 **findPictureAtClick 이 글상자 picture bbox
+중심 클릭에서 'shape' 를 반환**(image 아님)함을 확인했다. 원인: 사각형(Shape, InFrontOfText)
+bbox 가 내부 picture 를 덮고, collect_controls 가 Shape 를 자식 picture 보다 먼저 방출하므로
+findPictureAtClick 1차 패스가 Shape 를 먼저 hit 한다(이슈 작업범위 #1 "findPictureAtClick
+hit-test 우선순위 조정"이 가리킨 결함). 위 mouse handler 선제 분기는 findPictureAtClick 이
+image 를 반환해야 작동하므로, 이 우선순위 수정이 필수다.
+
+**수정** (`rhwp-studio/src/engine/input-handler-picture.ts` `findPictureAtClick` 선두):
+- 1차 패스 이전에 우선 패스 추가 — 클릭이 **컨테이너 Shape 와 cellPath 동반 nested
+  image/equation 둘 다**에 들어가면 picture 를 우선 반환. `shapeHit && nestedPic` 일 때만
+  동작하므로 겹치는 Shape 가 없는 표 셀 picture 는 영향 없음. BehindText 제외(기존 정책 유지).
+
+## Stage 4 결론 — insert.ts 코드 변경 불필요 (검증으로 확정)
 
 `insert.ts:272-283` 의 cellPath 재구성은 스칼라(`outerTableControlIdx`/`cellIdx`/`cellParaIdx`)
-로 depth-1 경로 `[{controlIdx, cellIdx, cellParaIdx}]` 를 만들며, 키 이름이 백엔드
-`parse_cell_path_json` 규약(`controlIdx`/`cellIdx`/`cellParaIdx`)과 일치한다. 글상자 picture 는
-depth-1 이고 Stage 1 의 sentinel 로 세 스칼라가 모두 (0,0,0) 으로 채워지므로, **기존 재구성이
-글상자 picture 에도 그대로 올바른 cellPath 를 생성할 가능성이 높다.** Stage 4 에서 WASM 빌드
-후 실측하여, 기존 코드로 충분하면 무변경(또는 ref.cellPath 우선 + fallback 의 견고화만),
-부족하면 보정한다.
+로 depth-1 경로 `[{controlIdx, cellIdx, cellParaIdx}]` 를 만들며 키가 백엔드
+`parse_cell_path_json` 규약과 일치한다. 글상자 picture 는 depth-1 이고 Stage 1 sentinel 로 세
+스칼라가 (0,0,0) 으로 채워지므로 기존 재구성이 그대로 올바른 cellPath 를 생성한다. E2E 에서
+`getCellPicturePropertiesByPath/setCellPicturePropertiesByPath` 를 동일 cellPath 형식으로 호출한
+round-trip(width 15040→20040)이 성공하여 확정. **Stage 4 는 무변경**(다단계 중첩 견고화는
+수행계획서 §8 후속).
 
-## 다음 단계 (Stage 4 / 5)
+## 검증 (E2E, headless Chrome + WASM 재빌드)
 
-- Stage 4: WASM 빌드 후 글상자 picture 속성 dialog read/write 실측 → insert.ts 보정 필요성 판단.
-- Stage 5: 통합 검증 + tac-img-02.hwp p6/p7 수동 클릭(객체선택/속성/외곽 Shape 선택/텍스트 편집).
+신규 E2E `rhwp-studio/e2e/textbox-picture-1171.test.mjs` (tac-img-02.hwp 로드):
+- 글상자 picture(섹션0 문단25, page index 5)가 controls 에 cellPath sentinel
+  `[{controlIndex:0,cellIndex:0,cellParaIndex:0}]` 로 노출 (Stage 1).
+- **findPictureAtClick(bbox 중심) → type='image' + cellPath 동반** (Stage 3 우선순위 수정 후).
+- by_path round-trip: `getCellPicturePropertiesByPath`(width=15040) → `set`(20040) → 재조회 20040
+  (Stage 2 + bridge + insert.ts cellPath 형식, Stage 4).
+- 기존 hit-test E2E(shape-inline, body-outside-click-fallback) 예외 없이 완료(회귀 없음 —
+  우선 패스는 shape+nested-picture 동시 hit 시에만 동작).
+- `npx tsc --noEmit`: 변경 파일(input-handler-mouse.ts, input-handler-picture.ts) 에러 0.
+
+## 다음 단계 (Stage 5)
+
+통합 검증: 전체 cargo test/clippy, studio tsc/build, tac-img-02.hwp p6/p7 수동 클릭
+(객체선택/속성 dialog/외곽 Shape 선택/picture 없는 영역 텍스트 편집).

--- a/mydocs/working/task_m100_1171_stage3.md
+++ b/mydocs/working/task_m100_1171_stage3.md
@@ -1,0 +1,46 @@
+# Stage 3 완료보고서 — Task #1171
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171)
+- **브랜치**: `local/task1171`
+- **단계 목표**: 프런트엔드 picture 우선 hit-test — 글상자 내부 클릭이 텍스트 편집으로
+  단락되기 전에 글상자 안 picture 를 선제 선택.
+- **작성일**: 2026-06-02
+
+## 변경 내용 (`rhwp-studio/src/engine/input-handler-mouse.ts`)
+
+글상자 경계선 검사(705-720) 직후, 텍스트 편집 진입(`if (hit.isTextBox)` 캐럿 배치) 직전에
+선제 hit-test 분기 추가:
+- `hit.isTextBox` 일 때 `findPictureAtClick(pageIdx, pageX, pageY)` 선제 호출.
+- 반환 picHit 이 `type==='image'|'equation'` 이고 `cellPath`(글상자/셀 sentinel) 동반이면
+  → 기존 picture dispatch(`enterPictureObjectSelectionDirect`, 842-848 호출과 동일 인자)로
+  객체선택 진입 + `return`.
+- picHit 없거나 picture 아니거나 cellPath 없으면 → 아래 기존 텍스트 편집으로 fall-through
+  (picture 없는 글상자 영역 클릭은 기존대로 텍스트 편집).
+
+설계 근거: 표 셀 picture 는 `hit_test_native` 가 `isTextBox=false` 라 기존 picture 처리
+(762행)까지 fall-through 되지만, Shape text_box 는 `isTextBox=true` 라 744행 텍스트 편집에서
+단락되어 762행에 도달하지 못했다. 본 선제 분기가 그 단락 이전에 글상자 picture 를 가로챈다.
+
+## 검증
+
+- `npx tsc --noEmit`: **변경 파일(input-handler-mouse.ts) 에러 0**. (전체 에러는
+  canvaskit-renderer.ts 의 `canvaskit-wasm` 모듈 미설치 — 본 변경과 무관한 기존 문제.)
+- 디스패치 인자는 기존 picture 선택 경로(842-848)와 동일하므로 select 상태/렌더 정합.
+- **행위 검증(클릭→객체선택)은 Stage 5 통합 검증에서 수행** — findPictureAtClick 이
+  Stage 1-2 의 Rust 변경(cellPath 노출)을 포함한 새 WASM 빌드를 필요로 한다(현재 pkg/ 는
+  Stage 1-2 미반영). Stage 5 에서 WASM 재빌드 후 E2E/수동 검증.
+
+## Stage 4 사전 분석 (insert.ts)
+
+`insert.ts:272-283` 의 cellPath 재구성은 스칼라(`outerTableControlIdx`/`cellIdx`/`cellParaIdx`)
+로 depth-1 경로 `[{controlIdx, cellIdx, cellParaIdx}]` 를 만들며, 키 이름이 백엔드
+`parse_cell_path_json` 규약(`controlIdx`/`cellIdx`/`cellParaIdx`)과 일치한다. 글상자 picture 는
+depth-1 이고 Stage 1 의 sentinel 로 세 스칼라가 모두 (0,0,0) 으로 채워지므로, **기존 재구성이
+글상자 picture 에도 그대로 올바른 cellPath 를 생성할 가능성이 높다.** Stage 4 에서 WASM 빌드
+후 실측하여, 기존 코드로 충분하면 무변경(또는 ref.cellPath 우선 + fallback 의 견고화만),
+부족하면 보정한다.
+
+## 다음 단계 (Stage 4 / 5)
+
+- Stage 4: WASM 빌드 후 글상자 picture 속성 dialog read/write 실측 → insert.ts 보정 필요성 판단.
+- Stage 5: 통합 검증 + tac-img-02.hwp p6/p7 수동 클릭(객체선택/속성/외곽 Shape 선택/텍스트 편집).

--- a/mydocs/working/task_m100_1171_stage4.md
+++ b/mydocs/working/task_m100_1171_stage4.md
@@ -1,0 +1,32 @@
+# Stage 4 완료보고서 — Task #1171
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171)
+- **브랜치**: `local/task1171`
+- **단계 목표**: 그림 속성 대화상자가 글상자 picture 의 cellPath 로 by_path API 를 호출하도록 정합.
+- **작성일**: 2026-06-02
+
+## 결론 — 코드 변경 불필요 (검증으로 확정)
+
+`rhwp-studio/src/command/commands/insert.ts:272-287` 의 기존 cellPath 재구성이 글상자 picture
+(depth-1)에 그대로 올바르게 동작함을 확인했다. 따라서 **insert.ts / picture-props-dialog.ts /
+cursor.ts 는 무변경**.
+
+### 근거
+- 재구성 조건: `ref.cellIdx !== undefined && ref.cellParaIdx !== undefined &&
+  ref.outerTableControlIdx !== undefined && (type image/shape/line)`. JS 에서 `0 !== undefined`
+  는 참이므로 sentinel 값 0 에도 조건 성립.
+- Stage 1 의 `last_image_indices()` 가 글상자 sentinel `{control_index:0, cell_index:0,
+  cell_para_index:0}` 에서 (cellIdx=0, cellParaIdx=0, outerTableControlIdx=0) 을 채우므로,
+  재구성 결과 = `[{controlIdx:0, cellIdx:0, cellParaIdx:0}]`, innerControlIdx=`ref.ci`(inner picture).
+- 키 이름(`controlIdx`/`cellIdx`/`cellParaIdx`)이 백엔드 `parse_cell_path_json` 규약과 일치.
+- E2E(Stage 3 보고서)에서 동일 cellPath 형식의 `getCellPicturePropertiesByPath`/
+  `setCellPicturePropertiesByPath` round-trip(width 15040→20040) 성공으로 확정.
+
+### 후속 (범위 밖)
+다단계 중첩(표→글상자→표→picture) 은 스칼라 재구성이 depth-1 만 만들어 부족하다. 그 경우
+`ref.cellPath`(findPictureAtClick 이 주는 full array) 직접 사용 + 키 변환이 필요하나, 본 이슈
+(depth-1 글상자)에서는 불요. 수행계획서 §8 후속으로 남긴다.
+
+## 검증
+- 행위 검증은 Stage 3 보고서의 E2E(`textbox-picture-1171.test.mjs`) round-trip 으로 통합 수행.
+- `npx tsc --noEmit`: 프런트 변경 파일(input-handler-mouse.ts, input-handler-picture.ts) 에러 0.

--- a/mydocs/working/task_m100_1171_stage6.md
+++ b/mydocs/working/task_m100_1171_stage6.md
@@ -1,0 +1,52 @@
+# Stage 6 완료보고서 — Task #1171 (후속)
+
+- **이슈**: [#1171](https://github.com/edwardkim/rhwp/issues/1171)
+- **브랜치**: `local/task1171`
+- **단계 목표**: 글상자(Shape text_box) **위에 이미지 드롭** 시 삽입 실패 결함 수정 —
+  한컴처럼 본문(body) 레벨 떠있는 개체(글상자 sibling)로 삽입.
+- **작성일**: 2026-06-03
+- **발견 경위**: 작업지시자 실환경 수동 테스트 중 발견. 본 이슈의 hit-test/속성 범위와는
+  다른 **이미지 삽입** 경로의 별개 결함이나, 같은 "글상자 경로 → 표 전용 resolver" 계열이라
+  후속으로 흡수(작업지시자 승인).
+
+## 현상 / 근본 원인 (pre-existing, #1171 변경과 무관)
+
+- 현상: 글상자 위에 이미지를 넣으면 삽입 실패. 콘솔
+  `그림 삽입 실패: 렌더링 오류: 경로[0]: controls[N]가 표가 아닙니다`.
+- 한컴: 글상자 위 이미지는 본문 레벨 독립 떠있는 개체(글상자 sibling). 글상자 이동과 무관.
+- 원인 사슬:
+  1. `finishImagePlacement`(input-handler-table.ts)가 드롭 지점 `hitTestFromEvent` 조회.
+  2. 글상자 내부 hit 은 기존(Task #919/#1151)대로 `cellPath`(글상자 sentinel)를 반환 →
+     `inCell=true` 로 판정되어 `cellPathJson` 에 글상자 경로가 들어감.
+  3. `insertPicture` 네이티브(`insert_picture_native`, object_ops.rs:1855)가
+     `resolve_cell_by_path`(**표 전용**)로 경로 검증 → 글상자라서 거부 → 삽입 실패.
+- **회귀 아님 확인**: 본 브랜치 diff 에 `cursor_rect.rs`(글상자 cellPath hit)·
+  `insert_picture_native`(라인 1813~) 모두 없음. 둘 다 local/devel 선재 코드.
+
+## 수정 (`rhwp-studio/src/engine/input-handler-table.ts` `finishImagePlacement`)
+
+드롭 hit 이 글상자(`hit.isTextBox`)면 표 셀과 달리 cellPath 를 쓰지 않고 본문
+para(`parentParaIndex` = 글상자를 소유한 본문 문단)에 floating 으로 삽입:
+- `isTextBoxHit = hit.isTextBox === true`
+- `inCell = cellPath.length>0 && parentParaIndex!=undefined && !isTextBoxHit`
+- `paraIdx = (inCell || isTextBoxHit) ? parentParaIndex : paragraphIndex`
+- `cellPathJson = inCell ? JSON.stringify(cellPath) : ''`
+
+→ 글상자: 본문 분기(`insert_picture_native` 본문 floating, paper-offset 위치)로 삽입되어
+한컴처럼 본문 sibling. 실제 표 셀(#1151)·본문 클릭은 기존 동작 유지.
+
+## 검증 (TDD)
+
+신규 E2E `rhwp-studio/e2e/textbox-picture-insert-1171.test.mjs`:
+- 가짜 글상자 hit(parentParaIdx=25, isTextBox, cellPath sentinel) 주입 후
+  `finishImagePlacement` 호출 → 본문 para25 의 cellPath 없는 image 증가 검증.
+- **수정 전(red)**: before=0 → after=0 (삽입 실패, 콘솔 warn). FAIL.
+- **수정 후(green)**: before=0 → after=1 (본문 sibling 삽입). PASS.
+- 회귀: `textbox-picture-1171.test.mjs`(Stage1-4 select/속성) 통과 유지.
+- `npx tsc --noEmit`: input-handler-table.ts 에러 0.
+
+## 범위 메모
+
+- 본 수정은 **드롭 제스처**에 한정. 표 셀 안 이미지 삽입(#1151)은 불변.
+- 글상자 **내부 콘텐츠로서** 이미지를 편집 중 삽입하는 경로(글상자 텍스트 편집 상태)는
+  별도이며 본 이슈 범위 밖.

--- a/rhwp-studio/e2e/textbox-picture-1171.test.mjs
+++ b/rhwp-studio/e2e/textbox-picture-1171.test.mjs
@@ -1,0 +1,76 @@
+/**
+ * E2E 테스트 (Issue #1171): 사각형 글상자(Shape text_box) 안 picture
+ *
+ * samples/tac-img-02.hwp 의 섹션0 문단25(글상자 안 picture 2개)/문단44(1개) 검증:
+ * 1. getPageControlLayout 에 글상자 picture 가 cellPath(sentinel) 로 노출 (Stage 1)
+ * 2. findPictureAtClick 이 글상자 picture bbox 중심 클릭에서 picture 반환 (Stage 1+3 hit-test 진입)
+ * 3. by_path API round-trip — getCellPicturePropertiesByPath/setCellPicturePropertiesByPath
+ *    가 글상자 cellPath 로 속성 read/write (Stage 2 + bridge + insert.ts cellPath 형식, Stage 4)
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+runTest('글상자 안 picture cellPath 노출 + 속성 round-trip (#1171)', async ({ page }) => {
+  await loadHwpFile(page, 'tac-img-02.hwp');
+
+  const result = await page.evaluate(async () => {
+    const wasm = window.__wasm;
+    const ih = window.__inputHandler;
+    const pageCount = wasm.pageCount;
+
+    // 1) 글상자 picture(paraIdx=25) 를 페이지 레이아웃에서 탐색
+    let found = null;
+    for (let p = 0; p < pageCount; p++) {
+      let layout;
+      try { layout = wasm.getPageControlLayout(p); } catch { continue; }
+      for (const c of layout.controls || []) {
+        if (c.type === 'image' && c.paraIdx === 25 && c.controlIdx === 0 && c.cellPath) {
+          found = { page: p, ctrl: c };
+          break;
+        }
+      }
+      if (found) break;
+    }
+    if (!found) return { error: 'paraIdx=25 글상자 picture 를 controls 에서 못 찾음' };
+
+    // 2) findPictureAtClick: bbox 중심 클릭
+    const cx = found.ctrl.x + found.ctrl.w / 2;
+    const cy = found.ctrl.y + found.ctrl.h / 2;
+    const hit = ih.findPictureAtClick(found.page, cx, cy);
+
+    // 3) by_path round-trip (insert.ts 재구성과 동일 cellPath 형식)
+    const cellPath = [{ controlIdx: 0, cellIdx: 0, cellParaIdx: 0 }];
+    const before = wasm.getCellPicturePropertiesByPath(0, 25, cellPath, 0);
+    const w0 = before.width;
+    wasm.setCellPicturePropertiesByPath(0, 25, cellPath, 0, { width: w0 + 5000 });
+    const after = wasm.getCellPicturePropertiesByPath(0, 25, cellPath, 0);
+
+    return {
+      page: found.page,
+      cellPath: found.ctrl.cellPath,
+      hitType: hit?.type ?? null,
+      hitHasCellPath: !!(hit && hit.cellPath),
+      w0,
+      w1: after.width,
+    };
+  });
+
+  assert(!result.error, `검증 실패: ${result.error}`);
+  console.log('결과:', JSON.stringify(result));
+
+  // Stage 1: cellPath sentinel 노출
+  assert(Array.isArray(result.cellPath) && result.cellPath.length === 1,
+    `글상자 picture cellPath 비정상: ${JSON.stringify(result.cellPath)}`);
+  assert(result.cellPath[0].cellIndex === 0,
+    `글상자 sentinel(cellIndex=0) 아님: ${JSON.stringify(result.cellPath)}`);
+
+  // Stage 1+3: findPictureAtClick 이 글상자 picture(cellPath 동반 image) 반환
+  assert(result.hitType === 'image', `findPictureAtClick type=${result.hitType} (image 기대)`);
+  assert(result.hitHasCellPath, 'findPictureAtClick 결과에 cellPath 부재 (hit-test 진입 실패)');
+
+  // Stage 2+4: by_path 속성 round-trip
+  assert(result.w0 > 0, `초기 width 비정상: ${result.w0}`);
+  assert(result.w1 === result.w0 + 5000,
+    `width 변경 미반영: ${result.w0} → ${result.w1} (기대 ${result.w0 + 5000})`);
+
+  console.log('✅ #1171 글상자 picture: cellPath 노출 + hit-test + 속성 round-trip 통과');
+});

--- a/rhwp-studio/e2e/textbox-picture-insert-1171.test.mjs
+++ b/rhwp-studio/e2e/textbox-picture-insert-1171.test.mjs
@@ -1,0 +1,104 @@
+/**
+ * E2E 테스트 (Issue #1171 v2): 사각형 글상자 위에 이미지 드롭 → 본문(body) sibling 삽입
+ *
+ * 한컴: 글상자 위에 이미지를 넣으면 글상자의 sibling 으로 본문 레벨 떠있는 개체가 된다
+ * (글상자를 움직여도 이미지는 독립적으로 남음). rhwp 는 글상자 hit 의 cellPath(글상자
+ * sentinel)를 그대로 insertPicture 에 넘겨, 표 전용 resolver 가 "controls[N]가 표가
+ * 아닙니다" 로 거부 → 삽입 실패(이미지 안 생김).
+ *
+ * 수정: finishImagePlacement 가 글상자(isTextBox) hit 은 cellPath 를 쓰지 않고 본문
+ * para(parentParaIndex)에 floating 으로 삽입한다.
+ *
+ * 검증: 가짜 글상자 hit 을 주입하고 finishImagePlacement 를 호출하여, 본문 para 25 에
+ * cellPath 없는 image(= 본문 sibling)가 추가되는지 확인.
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+// 1x1 투명 PNG
+const PNG_1x1 =
+  'iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAQAAAC1HAwCAAAAC0lEQVR42mNk+M8AAAMBAQDJ/pLvAAAAAElFTkSuQmCC';
+
+runTest('글상자 위 이미지 드롭 → 본문 sibling 삽입 (#1171 v2)', async ({ page }) => {
+  await loadHwpFile(page, 'tac-img-02.hwp');
+
+  const result = await page.evaluate(async (b64) => {
+    const wasm = window.__wasm;
+    const ih = window.__inputHandler;
+
+    // 삽입 전: 본문 para 25 의 cellPath 없는 image 개수 (page 5)
+    const countBodyImages = () => {
+      let n = 0;
+      const layout = wasm.getPageControlLayout(5);
+      for (const c of layout.controls || []) {
+        if (c.type === 'image' && c.paraIdx === 25 && !c.cellPath) n++;
+      }
+      return n;
+    };
+    const before = countBodyImages();
+
+    // 이미지 placement 모드 진입 + 가짜 글상자 hit 주입
+    const data = Uint8Array.from(atob(b64), (ch) => ch.charCodeAt(0));
+    ih.enterImagePlacementMode(data, 'png', 1, 1, 'test.png');
+    // 글상자(isTextBox) hit — parentParaIndex=25(본문), cellPath=글상자 sentinel
+    ih.hitTestFromEvent = () => ({
+      sectionIndex: 0,
+      paragraphIndex: 0,
+      parentParaIndex: 25,
+      controlIndex: 0,
+      charOffset: 0,
+      isTextBox: true,
+      cellPath: [{ controlIndex: 0, cellIndex: 0, cellParaIndex: 0 }],
+    });
+    ih.imagePlacementDrag = {
+      startClientX: 200, startClientY: 200,
+      currentClientX: 260, currentClientY: 260,
+      isDragging: true,
+    };
+
+    let err = null;
+    try {
+      ih.finishImagePlacement(new MouseEvent('mouseup', { clientX: 230, clientY: 230 }));
+    } catch (e) {
+      err = e?.message || String(e);
+    }
+    await new Promise((r) => setTimeout(r, 400));
+
+    const after = countBodyImages();
+
+    // 한컴 정합: 삽입된 본문 image 의 모델 표현 확인 — 글상자(Shape)의 sibling 으로
+    // 본문 para 25 에 들어있고, floating(treat_as_char=false)이어야 한다.
+    let shapeStillPresent = false;
+    let newImgCtrlIdx = null;
+    {
+      const layout = wasm.getPageControlLayout(5);
+      for (const c of layout.controls || []) {
+        if (c.type === 'shape' && c.paraIdx === 25) shapeStillPresent = true;
+        if (c.type === 'image' && c.paraIdx === 25 && !c.cellPath) newImgCtrlIdx = c.controlIdx;
+      }
+    }
+    let newImgTreatAsChar = null;
+    if (newImgCtrlIdx !== null) {
+      try {
+        const props = wasm.getPictureProperties(0, 25, newImgCtrlIdx);
+        newImgTreatAsChar = props.treatAsChar;
+      } catch (e) { /* ignore */ }
+    }
+
+    return { before, after, err, shapeStillPresent, newImgCtrlIdx, newImgTreatAsChar };
+  }, PNG_1x1);
+
+  console.log('결과:', JSON.stringify(result));
+  // finishImagePlacement 내부는 try/catch 로 에러를 삼키므로(콘솔 warn), 성공 판정은
+  // 본문 sibling image 증가로 한다.
+  assert(result.after === result.before + 1,
+    `본문 para25 sibling image 가 1 증가해야 함 (before=${result.before}, after=${result.after}) — ` +
+    `글상자 cellPath 라우팅으로 삽입 실패 시 증가하지 않음`);
+
+  // 한컴 정합: 글상자(Shape)는 그대로 남고(독립), 삽입 image 는 본문 floating sibling.
+  assert(result.shapeStillPresent,
+    '글상자(Shape)가 그대로 남아있어야 함 (이미지와 독립)');
+  assert(result.newImgTreatAsChar === false,
+    `삽입 image 는 floating(treat_as_char=false)이어야 함 — 한컴 정합 (관측: ${result.newImgTreatAsChar})`);
+
+  console.log('✅ #1171 v2: 글상자 위 이미지 드롭 → 본문 floating sibling 삽입 (한컴 정합) 통과');
+});

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -739,6 +739,33 @@ export function onClick(this: any, e: MouseEvent): void {
       }
     }
 
+    // [Task #1171] 글상자(Shape text_box) 내부 클릭이 아래 텍스트 편집 진입으로 단락되기
+    // 전에 글상자 안 picture 를 선제 hit-test 한다. picture 우선(작업지시자 확정): 글상자
+    // 안 picture 위 클릭은 항상 picture 객체선택 (표 셀 안 picture 와 동작 일관).
+    // cellPath 동반(글상자/셀 중첩) image/equation 만 가로채고, picture 없는 글상자 영역
+    // 클릭은 아래 텍스트 편집으로 fall-through.
+    if (hit.isTextBox) {
+      const tbPic = this.findPictureAtClick(pageIdx, pageX, pageY);
+      if (tbPic && (tbPic.type === 'image' || tbPic.type === 'equation') && (tbPic as any).cellPath) {
+        this.cursor.clearSelection();
+        this.exitPictureObjectSelectionIfNeeded();
+        this.cursor.enterPictureObjectSelectionDirect(
+          tbPic.sec, tbPic.ppi, tbPic.ci, tbPic.type,
+          tbPic.cellIdx, tbPic.cellParaIdx, (tbPic as any).headerFooter,
+          (tbPic as any).outerTableControlIdx,
+          (tbPic as any).cellPath,
+          (tbPic as any).noteRef,
+        );
+        this.active = true;
+        this.caret.hide();
+        this.selectionRenderer.clear();
+        this.renderPictureObjectSelection();
+        this.eventBus.emit('picture-object-selection-changed', true);
+        this.textarea.focus();
+        return;
+      }
+    }
+
     // 글상자 내부 텍스트/빈 영역 직접 히트 → 바로 캐럿 진입 (한컴 UX).
     // [Task #919] hit_test_native 가 글상자 안 빈 영역에서도 isTextBox=true 반환.
     if (hit.isTextBox) {

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -19,6 +19,29 @@ export function findPictureAtClick(this: any,
 ): { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' | 'line'; cellIdx?: number; cellParaIdx?: number; outerTableControlIdx?: number; cellPath?: Array<{ controlIndex: number; cellIndex: number; cellParaIndex: number }>; noteRef?: any; x1?: number; y1?: number; x2?: number; y2?: number; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } } | null {
   try {
     const layout = this.wasm.getPageControlLayout(pageIdx);
+    // [Task #1171] picture 우선: 클릭이 컨테이너 Shape(글상자) 와 그 안의 nested picture
+    // (cellPath 동반 image/equation) 둘 다에 들어가면 picture 를 우선 선택한다.
+    // collect_controls 가 Shape 를 자식 picture 보다 먼저 방출하므로, 이 우선 패스가 없으면
+    // 아래 1차 패스가 Shape 를 먼저 hit 한다(이슈의 핵심 결함). Shape 와 picture 가 함께
+    // hit 될 때만 동작하므로, 겹치는 Shape 가 없는 표 셀 picture 는 영향 없음.
+    // BehindText 는 기존 2차 패스 정책 유지로 제외.
+    {
+      let shapeHit = false;
+      let nestedPic: any = null;
+      for (const ctrl of layout.controls) {
+        if (ctrl.secIdx === undefined || ctrl.wrap === 'behindText') continue;
+        const inBox = pageX >= ctrl.x && pageX <= ctrl.x + ctrl.w &&
+          pageY >= ctrl.y && pageY <= ctrl.y + ctrl.h;
+        if (!inBox) continue;
+        if (ctrl.type === 'shape') shapeHit = true;
+        else if ((ctrl.type === 'image' || ctrl.type === 'equation') && ctrl.cellPath && !nestedPic) {
+          nestedPic = ctrl;
+        }
+      }
+      if (shapeHit && nestedPic) {
+        return { sec: nestedPic.secIdx, ppi: nestedPic.paraIdx, ci: nestedPic.controlIdx, type: nestedPic.type, cellIdx: nestedPic.cellIdx, cellParaIdx: nestedPic.cellParaIdx, outerTableControlIdx: nestedPic.outerTableControlIdx, cellPath: nestedPic.cellPath, noteRef: nestedPic.noteRef, headerFooter: nestedPic.headerFooter };
+      }
+    }
     // Task #516 결함 3 (옵션 3-C): BehindText 그림은 텍스트 영역 위에서는 후순위.
     // 1차 패스: BehindText 가 아닌 그림 우선 hit-test.
     // 2차 패스: BehindText 그림은 텍스트 hit-test 결과가 비어 있을 때만 hit.

--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -267,8 +267,17 @@ export function finishImagePlacement(this: any, e: MouseEvent): void {
   // 표 셀 안 클릭 (#1151): floating picture 분기를 위해 cellPath 와
   // parentParaIndex (= 표가 들어있는 outer paragraph) 사용. 본문 클릭은
   // 기존 paragraphIndex 그대로.
-  const inCell = (hit.cellPath?.length ?? 0) > 0 && hit.parentParaIndex !== undefined;
-  const paraIdx = inCell ? hit.parentParaIndex! : hit.paragraphIndex;
+  // [Task #1171 v2] 글상자(Shape text_box) 위에 드롭한 이미지는 한컴처럼 본문(body) 레벨
+  // 떠있는 개체(글상자의 sibling)로 삽입한다. 글상자 hit 은 cellPath(글상자 sentinel,
+  // cellIndex=0)를 반환하지만, insertPicture 의 cell 경로 검증(resolve_cell_by_path)은 표
+  // 전용이라 글상자 경로를 "표가 아닙니다" 로 거부 → 삽입 실패. 따라서 글상자(isTextBox)는
+  // 표 셀과 달리 cellPath 를 쓰지 않고 본문 para(parentParaIndex = 글상자를 소유한 본문 문단)에
+  // floating 으로 삽입한다. 실제 표 셀(#1151)은 기존대로 cellPath 사용.
+  const isTextBoxHit = hit.isTextBox === true;
+  const inCell = (hit.cellPath?.length ?? 0) > 0 && hit.parentParaIndex !== undefined && !isTextBoxHit;
+  // 표 셀: 외곽 표 소유 본문 para, 글상자: 글상자 소유 본문 para, 본문: 클릭 문단.
+  const useParentPara = (inCell || isTextBoxHit) && hit.parentParaIndex !== undefined;
+  const paraIdx = useParentPara ? hit.parentParaIndex! : hit.paragraphIndex;
   const charOffset = hit.charOffset;
   const cellPathJson = inCell ? JSON.stringify(hit.cellPath) : '';
 

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -1,6 +1,6 @@
 //! 그림 속성/삽입/삭제 + 표 생성 + 셀 bbox 관련 native 메서드
 
-use super::super::helpers::get_textbox_from_shape;
+use super::super::helpers::{get_textbox_from_shape, get_textbox_from_shape_mut};
 use crate::document_core::DocumentCore;
 use crate::error::HwpError;
 use crate::model::control::Control;
@@ -708,7 +708,9 @@ impl DocumentCore {
 
     /// [Task #1151 v7] section + parent_para_idx + path → target paragraph (mut).
     /// 2 개 set_cell_*_by_path_native (Picture / Shape) 의 공통 traversal.
-    /// immutable 버전은 cursor_nav.rs 의 `resolve_paragraph_by_path` 가 담당.
+    /// immutable 버전은 cursor_nav.rs 의 `resolve_paragraph_by_path` 가 담당하며,
+    /// [Task #1171] 이후 표 셀과 글상자(Shape text_box, cell_index=0 sentinel) 를 모두
+    /// 처리하도록 immutable 짝과 동일하게 맞춘다.
     fn resolve_cell_paragraph_mut<'a>(
         section: &'a mut crate::model::document::Section,
         parent_para_idx: usize,
@@ -721,24 +723,46 @@ impl DocumentCore {
             let ctrl = current_para.controls.get_mut(ctrl_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("경로[{}]: controls[{}] 범위 초과", i, ctrl_idx))
             })?;
-            let table = match ctrl {
-                crate::model::control::Control::Table(t) => t,
+            current_para = match ctrl {
+                crate::model::control::Control::Table(t) => {
+                    let cell = t.cells.get_mut(cell_idx).ok_or_else(|| {
+                        HwpError::RenderError(format!("경로[{}]: cells[{}] 범위 초과", i, cell_idx))
+                    })?;
+                    cell.paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
+                        HwpError::RenderError(format!(
+                            "경로[{}]: paragraphs[{}] 범위 초과",
+                            i, cell_para_idx
+                        ))
+                    })?
+                }
+                // [Task #1171] 글상자(Shape text_box) — cell_index=0 sentinel.
+                crate::model::control::Control::Shape(shape) => {
+                    if cell_idx != 0 {
+                        return Err(HwpError::RenderError(format!(
+                            "경로[{}]: 글상자의 cell_index는 0이어야 합니다 ({})",
+                            i, cell_idx
+                        )));
+                    }
+                    let text_box = get_textbox_from_shape_mut(shape).ok_or_else(|| {
+                        HwpError::RenderError(format!(
+                            "경로[{}]: controls[{}]가 텍스트 글상자가 아닙니다",
+                            i, ctrl_idx
+                        ))
+                    })?;
+                    text_box.paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
+                        HwpError::RenderError(format!(
+                            "경로[{}]: 글상자문단 {} 범위 초과",
+                            i, cell_para_idx
+                        ))
+                    })?
+                }
                 _ => {
                     return Err(HwpError::RenderError(format!(
-                        "경로[{}]: controls[{}] 가 표가 아닙니다",
+                        "경로[{}]: controls[{}] 가 표/글상자가 아닙니다",
                         i, ctrl_idx
                     )))
                 }
             };
-            let cell = table.cells.get_mut(cell_idx).ok_or_else(|| {
-                HwpError::RenderError(format!("경로[{}]: cells[{}] 범위 초과", i, cell_idx))
-            })?;
-            current_para = cell.paragraphs.get_mut(cell_para_idx).ok_or_else(|| {
-                HwpError::RenderError(format!(
-                    "경로[{}]: paragraphs[{}] 범위 초과",
-                    i, cell_para_idx
-                ))
-            })?;
         }
         Ok(current_para)
     }
@@ -3109,11 +3133,9 @@ impl DocumentCore {
         inner_control_idx: usize,
     ) -> Result<String, HwpError> {
         let path = Self::parse_cell_path_json(cell_path_json)?;
-        let cell = self.resolve_cell_by_path(section_idx, parent_para_idx, &path)?;
-        let last_cell_para_idx = path.last().unwrap().2;
-        let cell_para = cell.paragraphs.get(last_cell_para_idx).ok_or_else(|| {
-            HwpError::RenderError(format!("셀 내 문단 {} 범위 초과", last_cell_para_idx))
-        })?;
+        // [Task #1171] 표 셀과 글상자(Shape text_box) 를 모두 처리하는 resolver 사용.
+        // (기존 resolve_cell_by_path 는 마지막 세그먼트가 표 셀이어야 했음.)
+        let cell_para = self.resolve_paragraph_by_path(section_idx, parent_para_idx, &path)?;
         let ctrl = cell_para.controls.get(inner_control_idx).ok_or_else(|| {
             HwpError::RenderError(format!("셀 내 컨트롤 {} 범위 초과", inner_control_idx))
         })?;

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -1600,7 +1600,10 @@ impl DocumentCore {
                             node.bbox.x, node.bbox.y, node.bbox.width, node.bbox.height,
                             si, pi, ci, cell_str, outer_table_str
                         ));
-                        return;
+                        // [Task #1171] return 하지 않고 자식으로 재귀 — 사각형 글상자(text_box)
+                        // 안 중첩 picture/도형이 cellPath(cell_index=0 sentinel)로 수집되도록 한다.
+                        // 장식 노드(테두리 등)는 section/para/control 좌표가 None 이라 컨트롤로
+                        // 방출되지 않는다(좌표 가드). Table 핸들러와 동일하게 자식 탐색.
                     }
                 }
                 RenderNodeType::Line(line_node) => {

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -2181,6 +2181,23 @@ impl LayoutEngine {
                         );
                     }
                     Control::Picture(pic) => {
+                        // [Task #1171] 글상자 내부 picture — cellPath sentinel(cell_index=0)을
+                        // 빌드해 ImageNode.cell_context 로 전달. text-run(1963행)/표 경로와 동일 패턴.
+                        // 식별자: (바깥 Shape control_index, cell_index=0, 글상자 문단 pi). innerControlIdx 는
+                        // layout_picture 의 control_index 인자(= ctrl_idx_in_para)로 별도 전달된다.
+                        let pic_cell_ctx = CellContext {
+                            parent_para_index: para_index,
+                            path: {
+                                let mut p = parent_cell_path.to_vec();
+                                p.push(CellPathEntry {
+                                    control_index,
+                                    cell_index: 0,
+                                    cell_para_index: pi,
+                                    text_direction: 0,
+                                });
+                                p
+                            },
+                        };
                         if pic.common.treat_as_char {
                             // 인라인 이미지: 텍스트 내 삽입 위치까지의 advance를 반영하여 배치
                             advance_to_control(&mut inline_x);
@@ -2211,7 +2228,7 @@ impl LayoutEngine {
                                 Some(section_index),
                                 Some(para_index),
                                 Some(ctrl_idx_in_para),
-                                None, // 글상자 내부는 cell_ctx 미적용 (TODO: 셀 안 글상자는 후속)
+                                Some(&pic_cell_ctx),
                             );
                             inline_x += clamped_w;
                         } else {
@@ -2233,7 +2250,7 @@ impl LayoutEngine {
                                 Some(section_index),
                                 Some(para_index),
                                 Some(ctrl_idx_in_para),
-                                None,
+                                Some(&pic_cell_ctx),
                             );
                             let pic_h = hwpunit_to_px(pic.common.height as i32, self.dpi);
                             max_inline_height = max_inline_height.max(pic_h);

--- a/tests/issue_1171_textbox_picture_cellpath.rs
+++ b/tests/issue_1171_textbox_picture_cellpath.rs
@@ -83,3 +83,52 @@ fn textbox_picture_emits_cellpath_sentinel() {
         "문단44 picture0 의 sentinel cellPath 불일치 (관측: {found:?})"
     );
 }
+
+/// Stage 2: 글상자 안 picture 속성을 by_path API 로 조회/변경(round-trip)할 수 있는지.
+/// getter `resolve_paragraph_by_path` + setter `resolve_cell_paragraph_mut`(Shape arm)
+/// 가 글상자 path(마지막 세그먼트=Shape)를 해석하는지 검증.
+#[test]
+fn picture_in_textbox_get_set_by_path() {
+    let mut doc = load_sample();
+    // 섹션0 문단25 글상자(사각형 control 0, 글상자 문단 0) 안 picture.
+    // cell_path_json 키는 parse_cell_path_json 규약(controlIdx/cellIdx/cellParaIdx).
+    let cell_path = r#"[{"controlIdx":0,"cellIdx":0,"cellParaIdx":0}]"#;
+
+    // 첫 picture (inner ctrl 0) 조회
+    let before = doc
+        .get_cell_picture_properties_by_path_native(0, 25, cell_path, 0)
+        .expect("글상자 picture 속성 조회 실패");
+    let bv: serde_json::Value = serde_json::from_str(&before).unwrap();
+    let w0 = bv["width"].as_u64().expect("width 부재");
+    let h0 = bv["height"].as_u64().expect("height 부재");
+    assert!(w0 > 0 && h0 > 0, "조회된 크기가 0: {before}");
+
+    // width 변경 → set
+    let new_w = w0 + 12345;
+    let props = format!(r#"{{"width":{new_w}}}"#);
+    let ok = doc
+        .set_cell_picture_properties_by_path_native(0, 25, cell_path, 0, &props)
+        .expect("글상자 picture 속성 변경 실패");
+    assert!(ok.contains("\"ok\":true"), "set 응답 비정상: {ok}");
+
+    // 재조회 — 변경 반영 확인
+    let after = doc
+        .get_cell_picture_properties_by_path_native(0, 25, cell_path, 0)
+        .expect("변경 후 재조회 실패");
+    let av: serde_json::Value = serde_json::from_str(&after).unwrap();
+    assert_eq!(
+        av["width"].as_u64(),
+        Some(new_w),
+        "width 변경 미반영: {after}"
+    );
+
+    // 두 번째 picture(inner ctrl 1)도 분리 조회되는지 (inner_control_idx 정합 회귀)
+    let p1 = doc
+        .get_cell_picture_properties_by_path_native(0, 25, cell_path, 1)
+        .expect("글상자 두번째 picture 조회 실패");
+    let p1v: serde_json::Value = serde_json::from_str(&p1).unwrap();
+    assert!(
+        p1v["width"].as_u64().unwrap_or(0) > 0,
+        "두번째 picture 크기 0: {p1}"
+    );
+}

--- a/tests/issue_1171_textbox_picture_cellpath.rs
+++ b/tests/issue_1171_textbox_picture_cellpath.rs
@@ -1,0 +1,85 @@
+//! Issue #1171 Stage 1: 사각형 글상자(Shape text_box) 안 picture 가 cellPath
+//! (cell_index=0 sentinel) 로 렌더 컨트롤 레이아웃에 노출되는지 검증.
+//!
+//! `samples/tac-img-02.hwp` 의 섹션0 문단 25 (사각형→글상자→picture 2개) / 문단 44
+//! (picture 1개) 는 "사각형(Shape, InFrontOfText) → 글상자 → p[0] → picture" 이중 중첩
+//! 구조다. 이전에는 collect_controls 가 사각형(Rectangle) 노드에서 return 하여 글상자
+//! 내부 picture 를 수집하지 않았고, layout_picture 호출도 cell_ctx=None 이라 식별자가
+//! 없었다. Stage 1 이후 해당 image 컨트롤이 글상자 sentinel cellPath 로 노출되어야
+//! 프런트가 by_path API 로 속성을 조회/변경할 수 있다.
+
+use rhwp::document_core::DocumentCore;
+
+fn load_sample() -> DocumentCore {
+    let bytes = std::fs::read("samples/tac-img-02.hwp").expect("read tac-img-02.hwp");
+    DocumentCore::from_bytes(&bytes).expect("parse tac-img-02.hwp")
+}
+
+/// 섹션0 문단 25/44 의 글상자 안 picture 가 cellPath(cellIndex=0 sentinel) 로
+/// 노출되는지 — paraIdx + cellPath 마지막 엔트리 구조를 검증한다.
+#[test]
+fn textbox_picture_emits_cellpath_sentinel() {
+    let doc = load_sample();
+    let pages = doc.page_count();
+
+    // (paraIdx, controlIdx) → cellPath 마지막 엔트리 (controlIndex, cellIndex, cellParaIndex)
+    let mut found: std::collections::HashMap<(u64, u64), (u64, u64, u64)> =
+        std::collections::HashMap::new();
+
+    for p in 0..pages {
+        let Ok(json) = doc.get_page_control_layout_native(p) else {
+            continue;
+        };
+        let v: serde_json::Value = serde_json::from_str(&json).expect("layout JSON 파싱");
+        let Some(controls) = v["controls"].as_array() else {
+            continue;
+        };
+        for c in controls {
+            if c["type"] != "image" {
+                continue;
+            }
+            let (Some(para), Some(ctrl)) = (c["paraIdx"].as_u64(), c["controlIdx"].as_u64()) else {
+                continue;
+            };
+            if para != 25 && para != 44 {
+                continue;
+            }
+            let path = c["cellPath"]
+                .as_array()
+                .unwrap_or_else(|| panic!("문단 {para} image 에 cellPath 부재: {c}"));
+            let last = path.last().expect("cellPath 비어 있음");
+            // parentParaIdx 도 함께 방출되어야 by_path native 의 parent_para 인자가 됨.
+            assert_eq!(
+                c["parentParaIdx"].as_u64(),
+                Some(para),
+                "문단 {para} image parentParaIdx 불일치: {c}"
+            );
+            found.insert(
+                (para, ctrl),
+                (
+                    last["controlIndex"].as_u64().expect("controlIndex"),
+                    last["cellIndex"].as_u64().expect("cellIndex"),
+                    last["cellParaIndex"].as_u64().expect("cellParaIndex"),
+                ),
+            );
+        }
+    }
+
+    // 문단 25: picture 2개(inner ctrl 0,1), 문단 44: picture 1개(inner ctrl 0).
+    // 모두 글상자 sentinel = (Shape control_index 0, cell_index 0, cell_para_index 0).
+    assert_eq!(
+        found.get(&(25, 0)),
+        Some(&(0, 0, 0)),
+        "문단25 picture0 의 sentinel cellPath 불일치 (관측: {found:?})"
+    );
+    assert_eq!(
+        found.get(&(25, 1)),
+        Some(&(0, 0, 0)),
+        "문단25 picture1 의 sentinel cellPath 불일치 (관측: {found:?})"
+    );
+    assert_eq!(
+        found.get(&(44, 0)),
+        Some(&(0, 0, 0)),
+        "문단44 picture0 의 sentinel cellPath 불일치 (관측: {found:?})"
+    );
+}


### PR DESCRIPTION
## 배경

`samples/tac-img-02.hwp` 6/7쪽의 "사각형(Shape, InFrontOfText) → 글상자(text_box) → paragraph → picture" 이중 중첩 picture가 rhwp-studio에서 클릭·선택·속성편집되지 않았습니다 (#1171). 작업 중 발견된 "글상자 위 이미지 드롭 시 삽입 실패"(별개 결함)도 함께 처리했습니다.

## 접근 — cellPath 일반화

글상자를 "cell_index=0 sentinel 단일 셀 컨테이너"로 취급하여, 표 셀 picture가 이미 쓰던 cellPath 메커니즘을 글상자까지 확장했습니다. text/equation/table은 이미 이 방식을 사용하고 있었고 **picture만 누락**되어 있었습니다 (신규 평행 메커니즘 없음).

## 변경 요약

**백엔드**
- `src/renderer/layout/shape_layout.rs`: 글상자 picture의 `layout_picture` 에 `CellContext`(sentinel) 전달.
- `src/document_core/queries/rendering.rs` `collect_controls`: 사각형(Rectangle) 노드 조기 `return` 제거 → Table 처럼 자식 재귀하여 글상자 내부 picture 수집.
- `src/document_core/commands/object_ops.rs`: by_path picture getter/setter 가 글상자 path도 해석 (resolver 를 immutable 짝과 대칭화).

**프런트엔드 (rhwp-studio)**
- `input-handler-mouse.ts`: 글상자 내부 클릭이 텍스트 편집으로 단락되기 전 picture 선제 hit-test (picture 우선).
- `input-handler-picture.ts` `findPictureAtClick`: 컨테이너 Shape + nested picture 동시 hit 시 picture 우선 반환.
- `input-handler-table.ts`: 글상자 위 이미지 드롭은 본문(body) floating sibling 으로 삽입 (한컴 정합).

## 검증

- `cargo fmt --all -- --check` ✓
- `cargo clippy --lib -- -D warnings` ✓ (경고 0건)
- `cargo test` ✓ (**1948 passed / 0 failed**) — 신규 `tests/issue_1171_textbox_picture_cellpath.rs`(cellPath 노출 + by_path get/set round-trip) 포함, 표 셀 by_path 회귀 0.
- E2E (headless Chrome): `rhwp-studio/e2e/textbox-picture-1171.test.mjs`(선택/속성), `textbox-picture-insert-1171.test.mjs`(드롭→본문 sibling, TDD red→green).
- 시각/한컴 정합: 글상자 picture 선택·속성, 글상자 위 이미지 = 본문 floating sibling(글상자 뒤). **검증 환경: macOS, 한컴 직접 비교 확인.** (본 시나리오는 편집 중 동작이라 권위 PDF 대상 아님.)

## 범위 밖 (후속)

- 글상자 안 중첩 도형(shape) get 정합, 다단계 중첩 insert.ts 견고화, 글상자 내부 콘텐츠로서 이미지 삽입.

Closes #1171

🤖 Generated with [Claude Code](https://claude.com/claude-code)
