### PR TITLE
Task #1268: legacy HWP OLE 차트 Contents 렌더링

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -43,10 +43,12 @@ console_error_panic_hook = { version = "0.1", optional = true }
 
 [features]
 default = ["console_error_panic_hook"]
+charming-renderer = ["dep:charming"]
 native-skia = ["dep:resvg", "dep:skia-safe"]
 
 # PDF 내보내기 (네이티브 전용, Task #21)
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+charming = { version = "0.6", optional = true, default-features = false, features = ["ssr"] }
 svg2pdf = "0.13"
 usvg = "0.45"
 resvg = { version = "0.47", optional = true }

--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -6,3 +6,4 @@
 |---|---|---|---|
 | [#1186](https://github.com/edwardkim/rhwp/issues/1186) | chore: cargo clippy --all-targets -- -D warnings baseline 정리 | 검증 완료 | `local/task_m100_1186` 브랜치. `cargo clippy --all-targets -- -D warnings`, `cargo test --tests` 통과 |
 | [#1261](https://github.com/edwardkim/rhwp/issues/1261) | 3-10월 5쪽 문28 조건 박스 내부 겹침 | Stage4 자동 검증 완료 | `local/task_m100_1261` 브랜치. 문28 수정 커밋 `b64e5afb`, Stage2 커밋 `6aa638c6`, Stage3 커밋 `de8424e1` 완료. 문8 미주 경계는 실제 콘텐츠 하단 + `미주 사이` 간격을 적용했고, 문12 overflow는 확장 `미주 사이` 단일줄 경계에서 page-path vpos forward를 공통 억제해 자동 검증 통과. WASM/Studio 수동 시각 검증 대기 |
+| [#1251](https://github.com/edwardkim/rhwp/issues/1251) | HWP OLE/차트 객체 정합성 개선: 143E433F503322BD33.hwp | PR 초안 완료 | `task-1251-ole-chart` 브랜치. Stage 8 완료, 공식 문서/결정 배경/분석 문서를 포함한 PR 초안 작성 |

--- a/mydocs/plans/task_m100_1251.md
+++ b/mydocs/plans/task_m100_1251.md
@@ -1,0 +1,182 @@
+# Task M100-1251 수행 계획서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251) — HWP OLE/차트 객체 정합성 개선: `143E433F503322BD33.hwp`
+- **작성일**: 2026-06-03
+- **브랜치**: `task-1251-ole-chart`
+- **마일스톤**: M100
+- **상태**: 수행 계획 작성
+
+## 1. 배경
+
+`samples/143E433F503322BD33.hwp`에는 표와 함께 배치된 차트형 OLE 객체가 있다. 현재 레이아웃 자체는 #1156에서 2단 이동과 back-fill 정합성이 개선되었지만, 차트 그림은 여전히 `OLE 개체 (BinData #2)` placeholder로 렌더링된다.
+
+이번 작업의 목표는 차트 객체가 모호하게 손실되지 않도록 core 동작을 안정화하는 것이다. 가능하면 실제 차트 렌더링을 생성하고, 불가능하면 fallback 사유를 회귀 테스트로 확인 가능한 형태로 노출한다.
+
+작업지시자 추가 요구:
+
+- 메인테이너가 [`yuankunzhang/charming`](https://github.com/yuankunzhang/charming) 라이브러리를 활용한 차트 렌더링을 지시했다.
+- 구현 전 `charming` 적용 가능성을 조사하고 계획에 반영한다.
+
+## 2. 현재 확인 결과
+
+대상 fixture는 저장소에 이미 포함되어 있고 이슈 본문과 일치한다.
+
+- 파일: `samples/143E433F503322BD33.hwp`
+- 크기: `73,216 bytes`
+- SHA-256: `1bcdc7a2de38680cdb715556f40c8477f8242131d28de949b09e945022bf35fa`
+
+`dump` 확인 결과:
+
+- 문단 `0.7`에 표 1개와 OLE 1개가 있다.
+- OLE는 `bin_data_id=2`, 크기 `80.0mm x 80.0mm`, `wrap=TopAndBottom`, `tac=false`이다.
+- `export-svg` 결과는 현재 다음 placeholder를 출력한다.
+
+```text
+OLE 개체 (BinData #2)
+```
+
+BinData 확인 결과:
+
+- `/BinData/BIN0002.OLE`는 CFB 매직으로 시작한다.
+- 내부 CFB entry는 `/Contents` 스트림 하나뿐이다.
+- 현재 `parse_ole_container` 기준 추출 결과:
+  - `OOXMLChartContents`: 없음
+  - `OlePres000` EMF preview: 없음
+  - native image: 없음
+  - `Contents`: `9,876 bytes`
+
+따라서 이 fixture는 기존 OOXML 차트 XML 경로 또는 EMF/native image preview 경로로 해결되지 않는다. 핵심은 구버전/Neo 계열 HWP 차트 `Contents` 스트림을 구조화된 차트 데이터로 해석하는 것이다.
+
+## 3. `charming` 적용 가능성
+
+조사 기준:
+
+- `charming` 최신 문서: <https://docs.rs/crate/charming/latest>
+- `ImageRenderer`: <https://docs.rs/charming/latest/charming/renderer/image_renderer/struct.ImageRenderer.html>
+- `Cargo.toml` feature 정의: <https://docs.rs/crate/charming/latest/source/Cargo.toml.orig>
+
+확인한 사실:
+
+- 현재 문서 기준 최신 버전은 `0.6.0`이다.
+- `charming`은 Apache ECharts 기반 Rust 시각화 라이브러리이며, bar/line/pie 등 다양한 차트 타입을 지원한다.
+- `ImageRenderer`는 `ssr` feature 전용이고 SVG 문자열을 반환할 수 있다.
+- `ssr` feature는 `deno_core`와 `serde_v8`에 의존한다.
+- `wasm` feature는 WebAssembly 런타임에서 DOM target id에 차트를 렌더링하는 용도다.
+- 문서상 `ssr`와 `wasm` feature는 상호 배타적이다.
+- crate의 `rust-version`은 `1.85`이다.
+
+적용 판단:
+
+| 항목 | 판단 |
+|---|---|
+| HWP `/Contents` 파싱 대체 | 불가. `charming`은 렌더러/옵션 빌더이며 HWP OLE `Contents` 파서는 아니다. |
+| 네이티브 `export-svg`에서 SVG 생성 | 가능성 있음. `charming` `ssr` + `ImageRenderer::render`로 SVG 문자열 생성 가능. |
+| WASM core에서 기존 `RawSvg` 문자열로 직접 생성 | 직접 적용 어려움. `wasm` renderer는 DOM id 렌더 경로이고 SVG 문자열 반환 경로가 아니다. |
+| 의존성 위험 | 큼. `deno_core` 도입, MSRV 1.85, `ssr`/`wasm` feature 분리, 빌드 시간 증가를 검증해야 한다. |
+| 이번 fixture 해결 가능성 | 조건부 가능. 먼저 `/Contents`에서 차트 타입/카테고리/시리즈/제목/범례를 추출해야 한다. |
+
+결론:
+
+`charming`은 **파싱 후 렌더링 단계에는 사용할 수 있지만**, 이슈의 1차 난점인 HWP OLE `/Contents` 해석을 해결하지 않는다. 따라서 구현 계획은 `Contents` 파서 스파이크와 `charming` 렌더링 스파이크를 분리해야 한다.
+
+## 4. 작업 범위
+
+### 포함
+
+1. `143E433F503322BD33.hwp`의 `BinData #2` OLE `/Contents` 스트림 구조 조사
+2. 최소한 이 fixture에서 필요한 차트 데이터 추출 가능 여부 판단
+3. 추출 가능한 경우 내부 차트 IR을 만들고 `charming::Chart`로 변환
+4. 네이티브 SVG 렌더 경로에서 `charming` 출력 SVG를 `RawSvg`로 연결하는 방안 검증
+5. 추출 불가 또는 WASM 미지원 경로는 명시적 fallback 사유를 안정적으로 노출
+6. 회귀 테스트 추가
+
+### 제외
+
+- 모든 HWP 차트 종류의 완전 파서 구현
+- HWP OLE 편집 기능
+- 한컴과 1:1 시각 parity 보장
+- WASM DOM 기반 ECharts/Charming 프런트엔드 통합의 전면 구현
+
+## 5. 단계 계획
+
+### Stage 1 — OLE `/Contents` 구조 분석
+
+- `BinData #2`의 `/Contents` 헤더와 반복 구조를 분석한다.
+- 표 데이터와 차트 데이터의 대응 여부를 확인한다.
+- 최소 추출 후보:
+  - 차트 종류
+  - 제목
+  - 카테고리
+  - 시리즈 이름
+  - 값 목록
+  - 범례 표시 여부
+- 결과 문서: `mydocs/working/task_m100_1251_stage1.md`
+
+### Stage 2 — `charming` 의존성/렌더링 스파이크
+
+- `charming 0.6.x`를 네이티브 SSR 용도로 빌드 가능한지 확인한다.
+- `cargo build`, `cargo test`, WASM 빌드 영향 가능성을 확인한다.
+- 임의의 bar/line 샘플을 `ImageRenderer::render`로 SVG 문자열 생성 가능한지 검증한다.
+- `ssr`가 네이티브 전용이면 WASM 경로의 fallback/대체 방안을 확정한다.
+- 결과 문서: `mydocs/working/task_m100_1251_stage2.md`
+
+### Stage 3 — 최소 차트 IR 및 adapter
+
+- 기존 `src/ooxml_chart` 모델과 충돌하지 않도록 OLE `Contents`용 최소 IR을 정의한다.
+- 추출된 IR을 `charming::Chart`로 변환하는 adapter를 작성한다.
+- `charming`을 사용할 수 없는 target에서는 deterministic fallback을 유지한다.
+- 결과 문서: `mydocs/working/task_m100_1251_stage3.md`
+
+### Stage 4 — 렌더 통합 및 fallback 명시화
+
+- `src/renderer/layout/shape_layout.rs`의 OLE 렌더 우선순위에 `Contents` 차트 경로를 추가한다.
+- 성공 시 `RawSvg`로 렌더한다.
+- 실패 시 placeholder 라벨 또는 diagnostics에 안정적인 사유를 남긴다.
+  - 예: `OLE 차트 미지원: Contents 파싱 실패 (BinData #2)`
+- 결과 문서: `mydocs/working/task_m100_1251_stage4.md`
+
+### Stage 5 — 회귀 검증
+
+- fixture 기반 테스트를 추가한다.
+- 최소 검증:
+  - `BinData #2`가 OLE로 식별됨
+  - `/Contents`만 존재하는 fixture임을 확인
+  - 성공 경로면 SVG에 `OLE 개체 (BinData #2)` placeholder가 사라지고 차트 SVG 요소가 존재
+  - 실패 경로면 명시적 fallback 사유가 안정적으로 존재
+- 기존 #1156 레이아웃 회귀 테스트를 유지한다.
+- 결과 문서: `mydocs/working/task_m100_1251_stage5.md`
+
+## 6. 검증 명령 후보
+
+```text
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ooxml_chart
+cargo build
+target/debug/rhwp dump samples/143E433F503322BD33.hwp -s 0 -p 7
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+```
+
+WASM 영향이 있는 경우:
+
+```text
+docker compose --env-file .env.docker run --rm wasm
+```
+
+## 7. 위험 및 대응
+
+| 위험 | 대응 |
+|---|---|
+| `/Contents` 포맷이 공식 문서만으로 부족 | fixture 실측 + 공개 스펙 정오표 + raw 보존, 미확정 필드는 파싱하지 않음 |
+| `charming` SSR 의존성 과대 | Stage 2에서 빌드/크기/타깃 영향을 먼저 판정하고, 승인 후 적용 |
+| WASM에서 SVG 문자열 렌더 불가 | 네이티브와 WASM 경로를 분리하거나, 명시적 fallback으로 고정 |
+| 시각 parity 과도 요구 | 1차 목표는 차트 데이터 손실 방지와 deterministic 렌더/fallback |
+| 기존 OOXML 차트 경로 회귀 | `src/ooxml_chart` 기존 테스트와 HWPX chart 경로를 함께 검증 |
+
+## 8. 승인 필요 사항
+
+다음 단계는 구현 계획서 작성이다. 구현 계획서에서는 다음 결정을 확정해야 한다.
+
+1. `charming`을 네이티브 전용 dependency로 먼저 도입할지 여부
+2. WASM 경로에서 placeholder/fallback을 유지해도 되는지 여부
+3. `/Contents` 파싱 실패 시 명시적 fallback 고정만으로 #1251을 부분 완료 처리할 수 있는지 여부

--- a/mydocs/plans/task_m100_1251_impl.md
+++ b/mydocs/plans/task_m100_1251_impl.md
@@ -1,0 +1,300 @@
+# Task M100-1251 구현 계획서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **수행 계획서**: `mydocs/plans/task_m100_1251.md`
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+- **상태**: Stage 8 PR 초안 완료
+
+## 1. 구현 원칙
+
+1. `charming`은 HWP OLE `/Contents` 파서를 대체하지 않는다. 먼저 `/Contents`를 rhwp 내부 차트 IR로 파싱한다.
+2. 기본 렌더링 경로는 Rust `OleChart` SVG renderer로 통일한다. native `export-svg`와 WASM Studio는 같은 SVG fragment를 `RawSvg`로 소비한다.
+3. `charming`은 native 고품질 export/비교용 optional adapter로 유지한다. 기본 빌드에서는 `charming-renderer` feature를 켜지 않으면 컴파일하지 않는다.
+4. WASM core는 DOM id 기반 `WasmRenderer`를 직접 호출하지 않는다. Stage 5의 Studio 전용 TS chart overlay도 canonical 경로에서 제거한다.
+5. 기존 `src/ooxml_chart`의 OOXML 차트 파서/자체 SVG 렌더러는 건드리지 않는다. 새 경로는 OLE `/Contents` 전용으로 좁힌다.
+6. `/Contents` 파싱이 실패해도 기존 generic placeholder로 묻히지 않게 실패 사유를 안정적인 문자열로 노출한다.
+
+## 2. 대상 파일
+
+### 신규 후보
+
+| 파일 | 목적 |
+|---|---|
+| `src/ole_chart/mod.rs` | OLE `/Contents` 기반 차트 IR과 public API |
+| `src/ole_chart/parser.rs` | `Contents` 스트림 최소 파서 |
+| `src/ole_chart/ir.rs` | renderer-neutral IR JSON/base64 payload |
+| `src/ole_chart/svg_renderer.rs` | canonical Rust `OleChart` SVG renderer |
+| `src/ole_chart/charming_renderer.rs` | optional `OleChart` → `charming::Chart` → SVG 문자열 변환 |
+| `tests/issue_1251_ole_chart_contents.rs` | fixture 기반 회귀 테스트 |
+| `mydocs/working/task_m100_1251_stage{N}.md` | 단계별 완료 보고 |
+
+### 수정 후보
+
+| 파일 | 변경 |
+|---|---|
+| `Cargo.toml` | `charming` 네이티브 target 전용 dependency 후보 추가 |
+| `Cargo.lock` | `charming` 도입 시 갱신 |
+| `src/lib.rs` | `pub mod ole_chart;` 추가 |
+| `src/parser/ole_container.rs` | `/Contents` 스트림 전달/진단 helper 보강 |
+| `src/renderer/layout/shape_layout.rs` | OLE render 우선순위에 `/Contents` 차트 경로 추가 |
+| `rhwp-studio/src/view/page-renderer.ts` | Stage 5 임시 OLE chart DOM overlay 합성 제거 |
+
+## 3. Dependency 계획
+
+최종 적용:
+
+```toml
+[features]
+default = ["console_error_panic_hook"]
+charming-renderer = ["dep:charming"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+charming = { version = "0.6", optional = true, default-features = false, features = ["ssr"] }
+```
+
+근거:
+
+- `charming 0.6.0`의 `ImageRenderer`는 `ssr` feature에서만 사용 가능하며 SVG 문자열을 반환한다.
+- `ssr` feature는 `html`, `deno_core`, `serde_v8`를 포함한다.
+- `wasm` feature는 DOM id 렌더 API이며 `RawSvg` 문자열 렌더 경로가 아니다.
+- 현재 로컬 `rustc`는 `1.93.1`이므로 `charming`의 `rust-version=1.85` 자체는 로컬 빌드에는 문제가 없다.
+
+검증 후 결정:
+
+- `charming` dependency는 기본 native 빌드에서도 항상 컴파일하지 않고 `charming-renderer` feature 뒤로 분리했다.
+- WASM 기본 빌드는 `charming`에 의존하지 않는다.
+
+## 4. 렌더 우선순위
+
+현재 OLE 경로:
+
+```text
+HWPX ooxml_chart 직접 XML
+→ nested OLE OOXMLChartContents
+→ OlePres000 EMF preview
+→ native image
+→ generic OLE placeholder
+```
+
+변경 후보:
+
+```text
+HWPX ooxml_chart 직접 XML
+→ nested OLE OOXMLChartContents
+→ nested OLE Contents + ole_chart parser + Rust SVG RawSvg
+→ OlePres000 EMF preview
+→ native image
+→ explicit OLE chart fallback
+→ generic OLE placeholder
+```
+
+주의:
+
+- `/Contents`가 존재한다고 항상 차트로 단정하지 않는다.
+- `SHAPE_COMPONENT_OLE`의 `bin_data_id=2`와 fixture 특성을 우선 회귀 대상으로 삼고, 일반 OLE에는 기존 fallback을 유지한다.
+
+## 5. Stage별 구현
+
+### Stage 1 — `/Contents` 스트림 진단과 최소 파서 골격
+
+목표:
+
+- `src/ole_chart/parser.rs`에 `parse_ole_chart_contents(bytes: &[u8]) -> Result<OleChart, OleChartParseError>`를 추가한다.
+- 첫 단계에서는 헤더, magic 후보, record boundary, 문자열/숫자 후보를 안전하게 스캔한다.
+- 파싱 실패 시 오류 enum을 안정화한다.
+
+완료 조건:
+
+- `BinData #2`가 `/Contents` only OLE임을 테스트로 확인
+- 파싱 실패도 `UnsupportedContentsLayout`처럼 안정적인 오류로 떨어짐
+- `mydocs/working/task_m100_1251_stage1.md` 작성
+
+### Stage 2 — `charming` 네이티브 SSR 스파이크
+
+목표:
+
+- `Cargo.toml`에 target-specific `charming` 후보를 추가한다.
+- 임의의 최소 `OleChart` 값을 `charming::Chart`로 변환하고 `ImageRenderer::render`가 SVG 문자열을 반환하는지 확인한다.
+- 빌드 영향과 WASM 영향 가능성을 기록한다.
+
+완료 조건:
+
+- `cargo build` 성공
+- `cargo test --test issue_1251_ole_chart_contents -- --nocapture`에서 sample chart SVG 생성 smoke test 통과
+- WASM 빌드 필요 시 `docker compose --env-file .env.docker run --rm wasm` 결과 기록
+- `mydocs/working/task_m100_1251_stage2.md` 작성
+
+### Stage 3 — fixture 최소 데이터 추출
+
+목표:
+
+- `/Contents`에서 이 fixture에 필요한 최소 차트 데이터를 추출한다.
+- 추출 가능 후보는 다음 순서로 확정한다.
+  1. 차트 종류
+  2. 카테고리 라벨
+  3. 시리즈 값
+  4. 시리즈 이름/범례
+  5. 제목
+- 불명확한 필드는 파싱하지 않고 `None` 또는 기본값으로 둔다.
+
+완료 조건:
+
+- fixture에서 `OleChart`가 생성되거나, 불가능 사유가 오류 enum으로 고정됨
+- 파싱 성공 시 최소 bar/line 렌더용 값 목록이 비어 있지 않음
+- `mydocs/working/task_m100_1251_stage3.md` 작성
+
+### Stage 3.5 — 한컴 차트 사양 기반 legacy Contents parser 보강
+
+목표:
+
+- `한글문서파일형식_차트_revision1.2.pdf`의 `ChartOBJ` 기본 구조를 현재 `/Contents` parser에 반영한다.
+- `Contents` 첫 16바이트 probe에서 `ChartOBJ` 시작 오프셋을 기록한다.
+- `VtDataGrid`, `VtChartTitle` marker 존재 여부를 probe에 고정한다.
+- grid 값 추출은 무조건적인 `f64` 후보 누적이 아니라 dense run 우선, 실패 시 기대 개수와 정확히 일치하는 sparse 후보만 허용한다.
+
+완료 조건:
+
+- #1251 fixture에서 기존 추출 결과가 유지됨
+- synthetic unit test로 marker probe와 dense/sparse value extraction 정책을 고정함
+- `mydocs/working/task_m100_1251_stage3_5.md` 작성
+
+### Stage 4 — renderer 통합
+
+목표:
+
+- `shape_layout.rs`에서 `container.raw_contents`가 존재할 때 `ole_chart` 경로를 호출한다.
+- Stage 4 당시에는 native `charming` SVG와 WASM browser IR overlay를 연결했다.
+- Stage 6 이후 최종 경로는 native/WASM 모두 Rust SVG `RawSvg` fragment를 삽입한다.
+- 실패 경로에서는 안정적인 fallback label을 생성한다.
+
+fallback label 후보:
+
+```text
+OLE 차트 미지원: Contents 파싱 실패 (BinData #2)
+```
+
+완료 조건:
+
+- 성공 경로면 `export-svg` 결과에서 `OLE 개체 (BinData #2)`가 사라짐
+- Studio 성공 경로면 `charming SSR unavailable on wasm` 문구가 사라지고 `PageLayerTree`의 `rawSvg`에 `hwp-ole-chart-rust-svg`가 존재함
+- 실패 경로면 위 fallback label 중 하나가 SVG에 존재함
+- 기존 EMF/native image fallback 경로 회귀 없음
+- `mydocs/working/task_m100_1251_stage4.md` 작성
+
+### Stage 5 — 검증과 보고
+
+목표:
+
+- 신규 fixture 테스트와 기존 레이아웃 테스트를 실행한다.
+- `charming` 도입이 clippy baseline을 깨지 않는지 확인한다.
+- 최종 보고서를 작성한다.
+
+검증 명령:
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+cargo build
+cargo check --target wasm32-unknown-unknown --lib
+cargo clippy --all-targets -- -D warnings
+npm run build
+wasm-pack build --target web
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+node /private/tmp/rhwp_issue_1251_qa.mjs
+```
+
+Docker compose는 로컬 Docker daemon 미실행으로 사용할 수 없어, 로컬 `wasm-pack build --target web`로 `pkg/`를 재생성했다.
+
+완료 산출물:
+
+- `mydocs/working/task_m100_1251_stage5.md`
+- `mydocs/report/task_m100_1251_report.md`
+
+### Stage 6 — Rust SVG canonical renderer 전환
+
+목표:
+
+- Stage 5의 Studio TypeScript overlay를 제거한다.
+- native와 WASM 모두 `src/ole_chart/svg_renderer.rs`의 Rust SVG renderer를 사용한다.
+- `charming`은 `charming-renderer` feature 뒤 optional adapter로 분리한다.
+- PageLayerTree/Skia/CanvasKit 확장 방향에 맞춰 차트가 DOM side effect가 아니라 `RawSvg` paint op로 남게 한다.
+
+완료 조건:
+
+- 기본 `cargo test --test issue_1251_ole_chart_contents`에서 Rust SVG fragment/standalone SVG 경로가 통과함
+- `cargo test --features charming-renderer --test issue_1251_ole_chart_contents`에서 charming adapter smoke가 통과함
+- `cargo check --target wasm32-unknown-unknown --lib`, `wasm-pack build --target web`, `npm run build` 통과
+- Studio QA에서 `.rhwp-ole-chart-overlay-layer`와 `.hwp-ole-chart-browser`가 0개이며, `PageLayerTree`의 `rawSvg`에 `hwp-ole-chart-rust-svg`가 존재함
+
+### Stage 7 — 정답 PDF 대비 시각 차이 분석과 결정 문서화
+
+목표:
+
+- `pdf-large/hwpx/143E433F503322BD33.pdf`를 정답지로 삼아 현재 Rust SVG chart와의 시각 차이를 분석한다.
+- 이번 PR에서 pixel-level 정합성 보강까지 진행할지, 또는 known gap을 문서화하고 후속 이슈로 분리할지 결정한다.
+- maintainer에게 공유할 renderer 선택 이유와 `charming` 사용 범위를 별도 기술 문서로 남긴다.
+
+완료 조건:
+
+- `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md` 작성
+- `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md` 작성
+- `mydocs/working/task_m100_1251_stage7.md` 작성
+- 최종 보고서에 known visual gap과 후속 작업 후보 반영
+
+### Stage 8 — PR 초안 작성과 공유 자료 정리
+
+목표:
+
+- PR 본문에 포함할 공식 문서, 결정 배경, 결정한 것과 이유, 분석 문서 링크를 정리한다.
+- `charming`을 기본 WASM renderer로 쓰지 않은 이유와 Rust SVG canonical renderer를 선택한 이유를 reviewer가 바로 확인할 수 있게 한다.
+- PR 생성 전 rebase 필요성과 staging 제외 대상을 기록한다.
+
+완료 조건:
+
+- `mydocs/report/task_m100_1251_pr_draft.md` 작성
+- `mydocs/working/task_m100_1251_stage8.md` 작성
+- 최종 보고서에 PR 초안 산출물 반영
+
+## 6. 테스트 설계
+
+`tests/issue_1251_ole_chart_contents.rs`
+
+1. `fixture_has_bin_data_2_ole_contents_only`
+   - `parse_document` 후 `bin_data_content`에서 id `2`, extension `OLE` 확인
+   - `parse_ole_container` 결과 `raw_contents.is_some()`
+   - `ooxml_chart`, `preview_emf`, `native_image`가 없음
+
+2. `ole_chart_contents_parse_result_is_stable`
+   - `parse_ole_chart_contents(raw_contents)` 호출
+   - 성공이면 `series`/`categories`가 기대 최소 조건을 만족
+   - 실패이면 오류 code 문자열이 기대값과 일치
+
+3. `issue_1251_svg_does_not_use_ambiguous_placeholder`
+   - `render_page_svg(0)` 호출
+   - `OLE 개체 (BinData #2)` generic placeholder가 남지 않는지 확인
+   - 성공 렌더면 `hwp-ole-chart` 또는 `echarts` SVG marker 확인
+   - fallback이면 `OLE 차트 미지원:` 사유 marker 확인
+
+## 7. 중단 조건
+
+다음 중 하나가 발생하면 구현을 멈추고 작업지시자 승인을 다시 받는다.
+
+- `charming` dependency가 WASM 빌드를 깨는 경우
+- `deno_core` 도입으로 CI 빌드 시간이 과도하게 증가하는 경우
+- `/Contents` 포맷에서 차트 데이터 구조를 안정적으로 특정할 수 없는 경우
+- fallback-only 처리만 가능한데 이슈 완료로 인정할지 판단이 필요한 경우
+
+## 8. 승인 요청 범위
+
+승인 후 Stage 1부터 진행한다. Stage 1은 소스 변경을 포함한다.
+
+승인 대상:
+
+1. `src/ole_chart/*` 신규 모듈 추가
+2. fixture 기반 테스트 추가
+3. Stage 2에서 `charming` 네이티브 target 전용 dependency 추가 및 검증
+4. 실패 시 명시적 fallback으로 회귀 테스트를 고정하는 방향

--- a/mydocs/report/task_m100_1251_pr_draft.md
+++ b/mydocs/report/task_m100_1251_pr_draft.md
@@ -1,0 +1,151 @@
+# Task M100-1251 PR 초안
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+- **상태**: 초안
+
+## 1. PR 제목 후보
+
+```text
+Render legacy HWP OLE chart Contents with Rust SVG fallback
+```
+
+## 2. PR 본문 초안
+
+````markdown
+## Summary
+
+This PR adds a first legacy HWP OLE chart `/Contents` rendering path for #1251.
+
+- Detects nested OLE chart data that only has a legacy `Contents` stream.
+- Parses the fixture's chart title, categories, series labels, and numeric data into a renderer-neutral `OleChart` IR.
+- Renders the chart through the canonical Rust SVG path as a `RawSvg` page layer, so native export and WASM Studio use the same renderer.
+- Keeps `yuankunzhang/charming` as an optional native SSR adapter behind the `charming-renderer` feature.
+
+## Background
+
+The sample `samples/143E433F503322BD33.hwp` stores its chart as `BinData #2`.
+That nested OLE object does not contain `OOXMLChartContents`, `OlePres000`, or a native image preview.
+The only useful chart payload found for this fixture is the legacy `Contents` stream, so the previous renderer fell back to a generic OLE placeholder.
+
+The maintainer asked to investigate `yuankunzhang/charming`.
+The conclusion from this work is that `charming` is useful as a chart rendering adapter, but it does not parse Hancom legacy OLE chart data.
+The HWP/OLE `/Contents` parser therefore has to live in rhwp.
+
+## Official References
+
+- Hancom HWP/OWPML format download center: https://www.hancom.co.kr/support/downloadCenter/hwpOwpml
+- Hancom HWP 5.0 file format revision 1.3: https://cdn.hancom.com/link/docs/%ED%95%9C%EA%B8%80%EB%AC%B8%EC%84%9C%ED%8C%8C%EC%9D%BC%ED%98%95%EC%8B%9D_5.0_revision1.3.pdf
+- Hancom chart file format revision 1.2: https://cdn.hancom.com/link/docs/%ED%95%9C%EA%B8%80%EB%AC%B8%EC%84%9C%ED%8C%8C%EC%9D%BC%ED%98%95%EC%8B%9D_%EC%B0%A8%ED%8A%B8_revision1.2.pdf
+- Microsoft Compound File Binary File Format, MS-CFB: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/53989ce4-7b05-4f8d-829b-d08d6148375b
+- Microsoft OLE Data Structures, MS-OLEDS: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleds/85583d21-c1cf-4afe-a35f-d6701c5fbb6f
+- charming upstream repository: https://github.com/yuankunzhang/charming
+
+## Design Decisions
+
+### Parser ownership
+
+The parser is implemented in rhwp, not in `charming`.
+The Hancom chart format stores legacy chart objects such as `VtDataGrid` and `VtChartTitle` inside the OLE `Contents` stream, while `charming` expects an already structured chart model.
+
+### Default renderer
+
+The default renderer is the Rust SVG renderer in `src/ole_chart/svg_renderer.rs`.
+This keeps native export and WASM Studio on the same rendering path and fits the upstream direction toward `PageLayerTree`, Skia, CanvasKit, and other backend renderers.
+
+### charming usage
+
+`charming` remains as an optional native SSR adapter:
+
+```toml
+charming-renderer = ["dep:charming"]
+```
+
+The browser/WASM `charming::WasmRenderer` path was not selected as the default because it requires a DOM element id and a browser global ECharts runtime.
+That would make chart rendering a browser-side DOM side effect instead of a renderer-owned page layer.
+It would also add a JavaScript ECharts runtime dependency to Studio.
+
+## Implementation Notes
+
+- `src/ole_chart/parser.rs`
+  - Probes legacy `ChartOBJ` layout.
+  - Detects `VtDataGrid` and `VtChartTitle`.
+  - Extracts dense numeric `f64` runs first and only falls back to exact sparse candidates.
+- `src/ole_chart/ir.rs`
+  - Provides renderer-neutral chart IR serialization helpers.
+- `src/ole_chart/svg_renderer.rs`
+  - Emits `hwp-ole-chart-rust-svg` SVG fragments for `RawSvg`.
+- `src/ole_chart/charming_renderer.rs`
+  - Provides optional native `charming` SVG export smoke coverage.
+- `src/renderer/layout/shape_layout.rs`
+  - Adds `nested OLE Contents -> ole_chart parser -> Rust SVG RawSvg` before preview/native-image/generic-placeholder fallback.
+
+## Validation
+
+Passed locally:
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
+cargo build
+cargo check --target wasm32-unknown-unknown --lib
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+cargo clippy --all-targets -- -D warnings
+npm run build
+wasm-pack build --target web
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+headless Chrome Studio QA
+```
+
+The Studio QA confirmed:
+
+- one chart `RawSvg` layer is generated;
+- `data-rhwp-ole-chart-renderer="rust-svg"` is present;
+- the previous `charming SSR unavailable on wasm` text is gone;
+- the generic `OLE object (BinData #2)` placeholder is gone;
+- no browser overlay layer is used.
+
+## Known Limitations
+
+The chart data is recovered, but visual fidelity is not yet identical to the Hancom PDF reference.
+
+Current known gaps:
+
+- y-axis nice scale is not parsed yet, so the current Rust SVG renderer uses data max instead of the Hancom-like 0-2000 / 500-step axis;
+- palette, legend location, title spacing, plot margin, border, and bar gap still use renderer defaults;
+- broader page layout/text differences also exist outside this chart work.
+
+I intentionally did not add fixture-specific heuristics to match the PDF.
+Pixel-level chart fidelity should be handled in follow-up work by parsing more of the legacy chart object graph, especially axis, legend, style, and layout objects.
+
+## Additional Analysis Documents
+
+- Renderer decision record: `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md`
+- Hancom PDF visual diff analysis: `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md`
+- Final task report: `mydocs/report/task_m100_1251_report.md`
+
+## Review Notes
+
+The main review point is whether upstream wants to keep the default browser/WASM path renderer-owned as implemented here, or whether it prefers a browser ECharts runtime path through `charming::WasmRenderer`.
+Given the current multi-backend renderer direction, this PR chooses the renderer-owned Rust SVG path and keeps `charming` optional.
+````
+
+## 3. PR 생성 전 확인 사항
+
+1. 현재 브랜치는 `upstream/devel` 대비 뒤처져 있으므로, PR 생성 전 rebase 또는 merge 최신화가 필요하다.
+2. #1251과 무관한 로컬 문서(`task_m100_1142`, `task_m100_1143`, `task_m100_1144`)는 PR에 포함하지 않는다.
+3. `AGENTS.md`는 upstream에 없는 로컬 편의 파일이므로 PR에 포함하지 않는다.
+4. PR 생성 전 마지막으로 다음 검증을 다시 실행한다.
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
+cargo check --target wasm32-unknown-unknown --lib
+cargo clippy --all-targets -- -D warnings
+npm run build
+```

--- a/mydocs/report/task_m100_1251_report.md
+++ b/mydocs/report/task_m100_1251_report.md
@@ -1,0 +1,111 @@
+# Task M100-1251 최종 보고서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **일자**: 2026-06-03
+- **상태**: 구현, 검증, PR 초안 완료
+
+## 1. 요약
+
+`samples/143E433F503322BD33.hwp`의 `BinData #2` OLE chart object는 nested OLE 안에 `OOXMLChartContents`, `OlePres000`, native image가 없고 legacy `Contents` 스트림만 가진다.
+
+이번 작업에서 해당 `Contents`를 최소 차트 IR로 파싱하고, 기본 렌더링 경로는 Rust SVG renderer로 통일했다. native export와 rhwp-studio WASM 모두 같은 `hwp-ole-chart-rust-svg` `RawSvg` fragment를 사용한다.
+
+`yuankunzhang/charming`은 maintainer 지시를 반영해 native 고품질 export/비교용 optional adapter로 유지하되, 기본 빌드에서는 `charming-renderer` feature를 켜지 않으면 컴파일하지 않도록 분리했다.
+
+## 2. 주요 산출물
+
+- `src/ole_chart/parser.rs`: legacy HWP chart `Contents` probe/parser
+- `src/ole_chart/ir.rs`: renderer-neutral IR JSON/base64 payload
+- `src/ole_chart/svg_renderer.rs`: canonical Rust SVG renderer
+- `src/ole_chart/charming_renderer.rs`: optional native `charming::ImageRenderer` SVG adapter
+- `src/renderer/layout/shape_layout.rs`: OLE render priority에 legacy `/Contents` chart 경로 추가
+- `rhwp-studio/src/view/page-renderer.ts`: Stage 5 임시 OLE chart DOM overlay 제거
+- `tests/issue_1251_ole_chart_contents.rs`: fixture 기반 회귀 테스트
+- `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md`: 정답 PDF 대비 시각 차이 분석
+- `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md`: Rust SVG canonical renderer와 `charming` optional adapter 결정 기록
+- `mydocs/report/task_m100_1251_pr_draft.md`: 공식 문서, 결정 배경, 구현 결정, known gap을 포함한 PR 본문 초안
+
+## 3. 검증
+
+모든 핵심 검증을 통과했다.
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
+cargo build
+cargo check --target wasm32-unknown-unknown --lib
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+cargo clippy --all-targets -- -D warnings
+npm run build
+wasm-pack build --target web
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+headless Chrome Studio QA
+```
+
+native SVG 결과:
+
+- `hwp-ole-chart hwp-ole-chart-rust-svg` 존재
+- `연금 재정 전망`, `적립금` 존재
+- `OLE 개체 (BinData #2)`, `OLE 차트 미지원` 없음
+
+rhwp-studio 결과:
+
+- `PageLayerTree`의 `rawSvg` 차트 op 1개 생성
+- `data-rhwp-ole-chart-renderer="rust-svg"` 존재
+- `.hwp-ole-chart-browser` 0개
+- `.rhwp-ole-chart-overlay-layer` 0개
+- `charming SSR unavailable on wasm` 없음
+- `OLE 개체 (BinData #2)` 없음
+- 차트 bbox 내 saturated pixel 11283개 확인
+- console warning 1개는 QA 스크립트의 `getImageData` readback 경고이며 앱 렌더 오류가 아님
+
+## 4. 후속 제안
+
+1. 다른 legacy chart fixture를 추가해 `VtDataGrid` 외 object graph와 chart type parsing을 확장한다.
+2. Rust SVG renderer를 장기적으로 `Line`/`Rectangle`/`Path`/`TextRun` paint op lowering으로 확장해 `RawSvg` 의존을 줄인다.
+3. maintainer가 browser에서도 ECharts/charming runtime을 요구하는지 PR 설명에서 확인하되, 기본 방향은 Rust/WASM + multi-backend 친화 경로로 제안한다.
+
+## 5. 정답 PDF 대비 known visual gap
+
+정답 PDF(`pdf-large/hwpx/143E433F503322BD33.pdf`)와 비교한 결과, 차트 데이터는 안정적으로 추출되지만 시각 차이는 남아 있다.
+
+핵심 원인:
+
+- 현재 `OleChart` IR은 title, categories, series 중심이며 axis/style/layout object graph를 아직 담지 않는다.
+- y축 nice scale이 없어 현재 tick은 `0, 425.5, 851, 1276, 1702`로 생성된다. 정답 PDF는 `0, 500, 1000, 1500, 2000`이다.
+- series palette, legend 위치, title spacing, plot margin, border, bar gap은 renderer 기본값이다.
+
+이번 PR에서는 이 차이를 휴리스틱으로 보정하지 않는다. 정답 수준의 chart fidelity는 `VtChart`/axis/legend/style object graph parser 확장 후 후속 작업으로 진행한다.
+
+상세 문서:
+
+- `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md`
+- `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md`
+- `mydocs/report/task_m100_1251_pr_draft.md`
+
+## 6. PR 공유 메모
+
+메인테이너에게 공유할 핵심 내용:
+
+1. #1251 fixture의 `BinData #2`는 nested OLE 내부에 `OOXMLChartContents`, `OlePres000`, native image preview가 없고 legacy `Contents` 스트림만 가진다.
+2. 이번 PR은 해당 `Contents`를 `VtDataGrid`/`VtChartTitle` 중심으로 파싱해 chart data를 복원하고, generic OLE placeholder 대신 최소 차트를 렌더한다.
+3. `charming`은 parser가 아니므로 HWP OLE `/Contents` 해석은 rhwp 내부 parser가 담당한다.
+4. `charming` native SSR은 유효하지만 WASM renderer는 DOM element id와 browser global `echarts` runtime이 필요하다.
+5. upstream이 `PageLayerTree`, Skia, CanvasKit 등 multi-backend renderer로 확장 중이므로, 기본 경로는 Rust SVG `RawSvg`로 두고 `charming`은 optional native adapter로 분리했다.
+6. 정답 PDF와의 시각 차이는 알려진 제한이다. 데이터는 맞지만 axis scale, palette, legend/title/layout style object graph는 아직 파싱하지 않는다.
+7. pixel-level chart fidelity는 후속 작업으로 분리하는 것이 안전하다. 단기 휴리스틱으로 정답 PDF에 맞추면 #1251 fixture에 과적합될 위험이 있다.
+
+## 7. PR 초안
+
+PR 본문 초안은 `mydocs/report/task_m100_1251_pr_draft.md`에 별도로 정리했다.
+
+초안에는 다음 항목을 포함했다.
+
+1. 참고한 한컴 공식 문서와 Microsoft OLE/CFB 공식 문서
+2. #1251 fixture가 legacy OLE `Contents` only chart인 배경
+3. `charming`을 parser가 아닌 optional native SSR adapter로 둔 이유
+4. Rust SVG `RawSvg` renderer를 canonical path로 선택한 이유
+5. 정답 PDF 대비 visual gap과 후속 작업 제안

--- a/mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md
+++ b/mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md
@@ -1,0 +1,115 @@
+# Task M100-1251 렌더러 선택 결정 기록
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **작성일**: 2026-06-03
+- **결정**: Rust SVG renderer를 canonical path로 두고, `charming`은 optional native adapter로 유지한다.
+
+## 1. 배경
+
+maintainer는 `yuankunzhang/charming` 라이브러리 활용을 지시했다. 조사 결과 `charming`은 Rust에서 Apache ECharts option을 구성하고 렌더러에 넘기는 라이브러리다.
+
+렌더러는 크게 두 종류다.
+
+1. native SSR `ImageRenderer`
+   - `ssr` feature 필요
+   - Deno/V8 기반으로 ECharts JS를 실행해 SVG 문자열을 반환
+   - CLI `export-svg`나 native 검증에는 적합
+
+2. WASM `WasmRenderer`
+   - `wasm` feature 필요
+   - SVG 문자열 반환 API가 아니라 DOM element id에 ECharts instance를 붙임
+   - 브라우저에 global `echarts` JS가 필요
+   - rhwp의 `PageLayerTree`/Skia/CanvasKit replay 흐름과 직접 맞지 않음
+
+## 2. 검토한 선택지
+
+### 선택지 A: charming WASM renderer를 Studio에 연결
+
+구조:
+
+```text
+OleChart IR
+→ charming::Chart
+→ WasmRenderer.render(dom_id, chart)
+→ browser ECharts DOM/canvas/svg side effect
+```
+
+장점:
+
+- maintainer의 “charming 활용”을 가장 직접적으로 충족한다.
+- 복잡한 차트 feature를 ECharts에 맡길 수 있다.
+
+단점:
+
+- browser global `echarts` JS dependency가 추가된다.
+- DOM lifecycle, resize, z-order, clipping, overlay 관리를 Studio가 알아야 한다.
+- native Skia/PDF/CanvasKit downstream에서 같은 경로를 재사용하기 어렵다.
+- `PageLayerTree` 밖의 side effect가 되어 multi-backend renderer 방향과 충돌한다.
+
+### 선택지 B: Rust SVG renderer를 canonical path로 사용
+
+구조:
+
+```text
+OleChart IR
+→ Rust SVG renderer
+→ RawSvg PaintOp
+→ native SVG / WASM Canvas / Skia / CanvasKit 경로가 소비
+```
+
+장점:
+
+- Rust/WASM 공유 코드라는 프로젝트 철학에 맞다.
+- downstream renderer는 DOM/ECharts를 몰라도 된다.
+- `PageLayerTree` 안의 paint op로 남아 z-order/clipping/profile 정책을 통합하기 쉽다.
+- 향후 `Line`/`Rectangle`/`Path`/`TextRun` lowering으로 발전시킬 수 있다.
+
+단점:
+
+- ECharts 수준의 복잡한 chart feature를 직접 구현해야 한다.
+- 초기 시각 품질은 한컴 chart engine과 차이가 난다.
+
+## 3. 최종 결정
+
+기본 경로는 선택지 B로 결정했다.
+
+```text
+HWP OLE Contents
+→ Rust parser
+→ OleChart IR
+→ Rust SVG renderer
+→ RawSvg
+→ native/WASM 공통 소비
+```
+
+`charming`은 다음 용도로 유지한다.
+
+- native 고품질 export/비교용 adapter
+- maintainer 지시를 반영한 Rust chart adapter 검증 경로
+- 후속 논의에서 ECharts backend가 필요한 downstream을 위한 optional feature
+
+이를 위해 `Cargo.toml`에는 다음 구조를 사용한다.
+
+```toml
+[features]
+charming-renderer = ["dep:charming"]
+
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+charming = { version = "0.6", optional = true, default-features = false, features = ["ssr"] }
+```
+
+## 4. PR에서 설명할 점
+
+- `charming`은 parser가 아니므로 HWP OLE `/Contents` 해석은 rhwp가 직접 수행해야 한다.
+- `charming` native SSR은 유효하지만 WASM renderer는 DOM/ECharts runtime dependency가 필요하다.
+- rhwp upstream은 `PageLayerTree`, Skia, CanvasKit 등 multi-backend renderer로 확장 중이므로 chart도 renderer-neutral path에 올리는 것이 장기적으로 낫다.
+- 따라서 `charming`을 기본 renderer로 강제하지 않고 optional adapter로 둔다.
+
+## 5. 후속 판단 지점
+
+maintainer가 “browser Studio에서도 반드시 charming/ECharts runtime으로 렌더하라”고 명시하면 선택지 A를 재검토해야 한다. 다만 그 경우에도 다음 비용을 PR에 명확히 적어야 한다.
+
+- `echarts` JS asset 또는 npm dependency 추가
+- WASM/JS bridge 및 DOM lifecycle 관리
+- Skia/PDF/CanvasKit backend와의 재사용성 저하
+- PageLayerTree 밖 overlay side effect 증가

--- a/mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md
+++ b/mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md
@@ -1,0 +1,107 @@
+# Task M100-1251 정답 PDF 대비 시각 차이 분석
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **대상 HWP**: `samples/143E433F503322BD33.hwp`
+- **정답 PDF**: `pdf-large/hwpx/143E433F503322BD33.pdf`
+- **현재 출력**: `output/poc/task1251/hwp/143E433F503322BD33.svg`
+- **작성일**: 2026-06-03
+
+## 1. 결론
+
+현재 구현은 `BinData #2` legacy OLE chart object를 generic placeholder 대신 실제 차트로 렌더한다. 그러나 정답 PDF와의 시각 차이는 남아 있다.
+
+주요 원인은 데이터 추출 실패가 아니라 **차트 속성/스타일/object graph를 아직 파싱하지 않는 최소 renderer**라는 점이다. 현재 `OleChart` IR은 title, categories, series values/name만 담고 있으며, 축 scale, tick interval, 색상, plot area, legend 위치, font/spacing, chart border 같은 시각 속성은 복원하지 않는다.
+
+따라서 이번 PR의 완료 기준은 “legacy OLE chart를 감지하고 최소 데이터 기반 차트로 표시한다”로 두고, 정답 PDF 수준의 pixel-level chart fidelity는 후속 이슈로 분리하는 것이 안전하다.
+
+## 2. 비교 방법
+
+정답 PDF를 PNG로 렌더링하고 현재 SVG도 PNG로 변환해 비교했다.
+
+```text
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pdfinfo pdf-large/hwpx/143E433F503322BD33.pdf
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pdftoppm -png -r 144 pdf-large/hwpx/143E433F503322BD33.pdf tmp/pdfs/task1251/answer
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/node/bin/node --input-type=module -e "... sharp SVG to PNG ..."
+```
+
+분석 시 생성한 임시 산출물 경로:
+
+```text
+tmp/pdfs/task1251/answer-1.png
+tmp/pdfs/task1251/current-svg.png
+tmp/pdfs/task1251/side-by-side.png
+tmp/pdfs/task1251/answer-chart.png
+tmp/pdfs/task1251/current-chart.png
+tmp/pdfs/task1251/diff-amplified.png
+```
+
+이 임시 산출물은 PR에 포함하지 않고 작업 후 제거했다. 필요하면 위 절차로 재생성한다.
+
+## 3. 관찰된 주요 차이
+
+| 항목 | 정답 PDF | 현재 Rust SVG renderer | 원인 |
+|---|---|---|---|
+| y축 범위 | 0-2000 | 0-1702 | `svg_renderer.rs`가 최대값을 그대로 축 상한으로 사용 |
+| y축 tick | 0, 500, 1000, 1500, 2000 | 0, 425.5, 851, 1276, 1702 | nice scale/tick interval 미구현 |
+| 시리즈 색상 | 하늘색, 붉은색, 노란색 | 파랑, 빨강, 초록 | chart style/palette 미파싱, renderer 기본 팔레트 사용 |
+| title | 자간 넓은 일반 weight | 굵은 sans-serif, 상단 밀착 | chart title style/spacing 미파싱 |
+| plot area | 좌우 여백과 legend 배치가 한컴 출력에 맞음 | 일반 SVG renderer 기본 margin | chart layout box 미파싱 |
+| legend | 하단 중앙, 넓은 spacing | 좌측 기준 고정 spacing | legend style/position 미파싱 |
+| border | 얇은 회색 chart frame | `#cbd5e1` 기본 frame | chart area stroke style 미파싱 |
+| bar width/placement | 한컴 chart engine 기준 | 간단한 grouped bar 계산 | series gap/category gap 미파싱 |
+
+데이터 자체는 다음 값으로 안정적으로 추출된다.
+
+```text
+title: 연금 재정 전망
+categories: 2010년, 2020년, 2030년, 2040년
+적립금: 328, 812, 1702, 1477
+수입: 50, 70, 189, 191
+지출: 11, 15, 201, 289
+```
+
+## 4. 코드상 직접 원인
+
+- `src/ole_chart/parser.rs`
+  - `OleChart` IR은 `chart_type`, `title`, `categories`, `series`만 보유한다.
+  - parser는 `VtDataGrid` 구간에서 label과 f64 run을 추출한다.
+  - `VtChart`, axis, legend, palette, plot area, text style object는 아직 해석하지 않는다.
+
+- `src/ole_chart/svg_renderer.rs`
+  - y축 상한은 `series.values`의 최대값이다.
+  - tick은 4등분 고정이다.
+  - 팔레트는 renderer 상수 배열이다.
+  - margin, title, legend, frame은 모두 renderer 기본값이다.
+
+즉, 현재 차트는 “추출된 데이터의 시각화”이지 “한컴 chart object의 full fidelity replay”가 아니다.
+
+## 5. 이번 PR에서 보강하지 않는 이유
+
+정답 PDF에 맞춰 축 상한을 2000으로 반올림하거나 팔레트를 맞추는 작은 보정은 가능하다. 그러나 이것만 넣으면 #1251 fixture에 과적합된 휴리스틱이 되기 쉽다.
+
+정답 수준의 시각 정합성을 안정적으로 올리려면 다음 정보가 parser/IR로 들어와야 한다.
+
+1. axis min/max/major unit 또는 nice scale 규칙
+2. series palette/style
+3. chart area/plot area/legend bbox
+4. title/font/spacing 속성
+5. category/series gap
+6. chart object graph record 구조
+
+이는 “placeholder 제거 + 최소 chart 렌더”보다 큰 범위이며, 이번 PR의 리뷰 포인트를 흐릴 수 있다.
+
+## 6. 후속 이슈 후보
+
+1. `VtChart`/axis/legend/style object graph parser 확장
+2. `OleChart` IR에 `OleChartStyle`, `OleAxisStyle`, `OleLegendStyle`, `OlePlotArea` 추가
+3. axis nice scale 정책 추가 및 fixture별 expected ticks 고정
+4. series palette 파싱 또는 한컴 기본 palette fallback 정의
+5. chart visual model을 `RawSvg`에서 PageLayerTree `PaintOp` lowering으로 전환
+6. PDF/SVG visual comparison harness 추가
+
+## 7. PR 설명에 포함할 요지
+
+- #1251의 직접 문제는 nested OLE에 preview가 없는 legacy `Contents` chart가 generic placeholder로 표시되는 것이다.
+- 이번 PR은 해당 chart를 감지하고 데이터 기반 최소 차트로 렌더한다.
+- 정답 PDF와의 pixel-level 시각 정합성은 아직 목표가 아니다.
+- 차트 데이터는 안정적으로 추출되지만 style/object graph 파싱은 후속 작업으로 분리한다.

--- a/mydocs/working/task_m100_1251_stage1.md
+++ b/mydocs/working/task_m100_1251_stage1.md
@@ -1,0 +1,91 @@
+# Task M100-1251 Stage 1 완료 보고서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **단계**: Stage 1 — OLE `/Contents` 구조 진단과 최소 파서 골격
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+
+## 1. 변경 내용
+
+OLE `/Contents` 전용 차트 모듈 골격을 추가했다.
+
+- `src/ole_chart/mod.rs`
+- `src/ole_chart/parser.rs`
+
+추가한 public API:
+
+- `probe_ole_chart_contents(bytes)`
+- `parse_ole_chart_contents(bytes)`
+- `OleChartContentsProbe`
+- `OleChartParseError`
+- `OleChart`, `OleChartType`, `OleChartSeries`
+
+Stage 1의 `parse_ole_chart_contents`는 아직 실제 차트 IR 생성을 하지 않는다. 대신 #1251 fixture의 legacy HWP chart `Contents` 레이아웃을 안정적으로 감지하고, 다음 오류 코드로 고정한다.
+
+```text
+UNSUPPORTED_CONTENTS_LAYOUT
+```
+
+## 2. Fixture 확인
+
+`samples/143E433F503322BD33.hwp`의 `BinData #2` 확인 결과:
+
+- DocInfo BinData #2: `Storage`, `storage_id=2`, extension `OLE`
+- `/BinData/BIN0002.OLE`: CFB magic으로 시작
+- nested OLE 내부 stream: `Contents`만 존재
+- `Contents` 길이: `9,876 bytes`
+- `Contents` 첫 16바이트:
+
+```text
+00 00 01 00 ec 2e 00 00 ec 2e 00 00 60 00 00 00
+```
+
+현재 추출되지 않는 항목:
+
+- `OOXMLChartContents`
+- `OlePres000` EMF preview
+- native image preview
+
+## 3. 테스트
+
+신규 테스트:
+
+- `tests/issue_1251_ole_chart_contents.rs`
+
+검증 항목:
+
+1. `BinData #2`가 OLE storage이고 nested OLE에서 `Contents`만 존재함
+2. `probe_ole_chart_contents`가 길이, 첫 u32 words, legacy layout 후보를 안정적으로 반환함
+3. `parse_ole_chart_contents`가 Stage 1 기준 안정적인 `UNSUPPORTED_CONTENTS_LAYOUT` 오류를 반환함
+
+## 4. 실행 결과
+
+```text
+cargo fmt --check
+```
+
+통과.
+
+```text
+cargo test --lib ole_chart -- --nocapture
+```
+
+통과: 3 passed.
+
+```text
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+```
+
+통과: 3 passed.
+
+```text
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+```
+
+통과: 2 passed.
+
+## 5. 다음 단계
+
+Stage 2에서는 `charming` 네이티브 SSR 도입 가능성을 실제 dependency 빌드와 SVG smoke test로 검증한다.
+
+주의: Stage 2는 `Cargo.toml`/`Cargo.lock` 변경과 dependency 다운로드 가능성이 있으므로 작업지시자 승인 후 진행한다.

--- a/mydocs/working/task_m100_1251_stage2.md
+++ b/mydocs/working/task_m100_1251_stage2.md
@@ -1,0 +1,109 @@
+# Task M100-1251 Stage 2 완료 보고서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **단계**: Stage 2 — `charming` 네이티브 SSR 스파이크
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+
+## 1. 변경 내용
+
+네이티브 빌드에서만 `charming` SSR renderer를 사용할 수 있도록 target-specific dependency를 추가했다.
+
+```toml
+[target.'cfg(not(target_arch = "wasm32"))'.dependencies]
+charming = { version = "0.6", default-features = false, features = ["ssr"] }
+```
+
+추가 파일:
+
+- `src/ole_chart/charming_renderer.rs`
+
+추가 public API:
+
+- `render_smoke_chart_svg(width, height)`
+- `OleChartRenderError`
+
+`render_smoke_chart_svg`는 최소 pie chart를 `charming::Chart`로 구성하고 `ImageRenderer::render`를 호출해 SVG 문자열을 반환한다.
+
+참고: `Cargo.lock`는 이 저장소의 `.gitignore` 대상이므로 PR 변경 범위에 포함하지 않는다.
+
+## 2. `charming` 적용 가능성
+
+적용 가능 범위:
+
+- 네이티브 `export-svg`/테스트 경로에서 `charming` `ImageRenderer`를 사용해 SVG 문자열을 생성할 수 있다.
+- `charming 0.6.0`의 `ssr` feature는 native target에서 동작했고, smoke test에서 SVG 문자열을 안정적으로 반환했다.
+- `Cargo.toml` target-specific dependency로 추가했기 때문에 `wasm32-unknown-unknown` 라이브러리 체크에는 포함되지 않았다.
+
+제한:
+
+- `charming`은 chart option builder와 renderer이며, HWP OLE `/Contents` 스트림 파서는 아니다.
+- #1251 fixture의 `/Contents`는 legacy HWP chart binary로 보이며, `charming`을 사용하려면 먼저 rhwp 내부에서 `OleChart` IR로 파싱해야 한다.
+- `wasm` feature는 DOM id 기반 renderer라 현재 `export-svg`의 문자열 생성 경로에는 직접 맞지 않는다.
+- `ssr` feature는 `deno_core`/`serde_v8`/`v8` 의존성을 끌어와 native 빌드 의존성이 크게 증가한다.
+
+참조한 upstream 문서:
+
+- `charming` Cargo feature 정의: <https://docs.rs/crate/charming/latest/source/Cargo.toml.orig>
+- `ImageRenderer`: <https://docs.rs/charming/latest/charming/renderer/image_renderer/struct.ImageRenderer.html>
+- `WasmRenderer`: <https://docs.rs/charming/latest/charming/renderer/wasm_renderer/struct.WasmRenderer.html>
+
+## 3. 테스트
+
+신규 smoke test:
+
+- `charming_ssr_smoke_renders_svg_string`
+
+검증 내용:
+
+- `render_smoke_chart_svg(420, 320)` 호출
+- 반환값이 `<svg`로 시작함
+- sample label `alpha`가 SVG에 포함됨
+
+## 4. 실행 결과
+
+```text
+cargo fmt --check
+```
+
+통과.
+
+```text
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+```
+
+통과: 4 passed.
+
+최초 실행은 sandbox DNS 제한으로 crates.io index 접근에 실패했고, 네트워크 허용 후 재실행하여 `charming v0.6.0`과 관련 dependency를 resolve했다.
+
+```text
+cargo test --lib ole_chart -- --nocapture
+```
+
+통과: 3 passed.
+
+```text
+cargo build
+```
+
+통과.
+
+```text
+cargo check --target wasm32-unknown-unknown --lib
+```
+
+통과. native-only `charming` dependency가 wasm library check를 깨지 않는 것을 확인했다.
+
+## 5. 다음 단계
+
+Stage 3에서는 `samples/143E433F503322BD33.hwp`의 `BinData #2` `/Contents`에서 실제 차트 데이터를 추출할 수 있는지 조사한다.
+
+우선순위:
+
+1. 차트 종류 후보
+2. 카테고리 라벨 후보
+3. 시리즈 값 후보
+4. 시리즈 이름/범례 후보
+5. 제목 후보
+
+안정적인 구조를 특정하지 못하면 파싱 성공으로 처리하지 않고 오류 enum과 fallback 사유를 고정한다.

--- a/mydocs/working/task_m100_1251_stage3.md
+++ b/mydocs/working/task_m100_1251_stage3.md
@@ -1,0 +1,98 @@
+# Task M100-1251 Stage 3 완료 보고서
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **단계**: Stage 3 — fixture 최소 데이터 추출
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+
+## 1. 변경 내용
+
+`src/ole_chart/parser.rs`의 legacy HWP chart `Contents` 파서가 #1251 fixture에서 `OleChart` IR을 생성하도록 보강했다.
+
+추출 방식:
+
+1. `VtDataGrid` marker를 찾는다.
+2. `VtBackdrop` 또는 `VtChartSection` 직전까지를 data grid 범위로 본다.
+3. data grid 범위에서 CP949 문자열 payload를 추출한다.
+4. 같은 범위에서 정수형 f64 값 후보를 추출한다.
+5. 라벨은 첫 숫자 라벨 전까지를 series 이름, 숫자 라벨을 category로 분리한다.
+6. 값 배열은 row-major로 읽고 series-major `OleChartSeries`로 전치한다.
+
+제목은 `VtChartTitle`부터 `VtList` 전까지의 문자열 후보 중 가장 긴 라벨을 사용한다. CP949 full-width space는 일반 공백으로 정규화한다.
+
+## 2. Fixture 추출 결과
+
+`samples/143E433F503322BD33.hwp`의 `BinData #2` `/Contents`에서 다음 데이터를 추출했다.
+
+- 제목: `연금 재정 전망`
+- 차트 종류: `Unknown`
+- 카테고리: `2010년`, `2020년`, `2030년`, `2040년`
+- 시리즈:
+  - `적립금`: `328`, `812`, `1702`, `1477`
+  - `수입`: `50`, `70`, `189`, `191`
+  - `지출`: `11`, `15`, `201`, `289`
+
+차트 종류는 아직 `VtSeries`/plot 레코드에서 안정적으로 식별하지 못했다. Stage 3에서는 임의로 column/bar/line을 단정하지 않고 `OleChartType::Unknown`으로 둔다.
+
+## 3. 제한 사항
+
+- 공개 스펙이 확인되지 않아 legacy HWP chart object graph 전체를 해석하지 않는다.
+- f64 값 추출은 data grid 범위 안의 `>= 1.0` 정수형 값으로 제한했다. #1251 fixture에는 0 또는 소수 값이 없어 안정적으로 동작한다.
+- 다른 legacy chart fixture에서는 값 범위나 레코드 shape가 다를 수 있으므로, shape가 맞지 않으면 성공 파싱하지 않고 `UNSUPPORTED_CONTENTS_LAYOUT`으로 실패한다.
+- 차트 종류와 세부 스타일은 아직 렌더링에 반영하지 않는다.
+
+## 4. 테스트
+
+수정한 테스트:
+
+- `tests/issue_1251_ole_chart_contents.rs`
+  - 기존 stable error 검증을 성공 파싱 검증으로 변경
+  - 제목, 카테고리, 시리즈 이름, 시리즈 값 검증 추가
+
+추가한 단위 테스트:
+
+- CP949 payload가 null pair 전까지 올바르게 디코딩되는지 확인
+- CP949 full-width space가 일반 공백으로 정규화되는지 확인
+
+## 5. 실행 결과
+
+```text
+cargo fmt --check
+```
+
+통과.
+
+```text
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+```
+
+통과: 4 passed.
+
+```text
+cargo test --lib ole_chart -- --nocapture
+```
+
+통과: 5 passed.
+
+```text
+cargo build
+```
+
+통과.
+
+```text
+cargo check --target wasm32-unknown-unknown --lib
+```
+
+통과.
+
+## 6. 다음 단계
+
+Stage 4에서는 renderer 통합을 진행한다.
+
+목표:
+
+1. nested OLE `raw_contents`가 있을 때 `ole_chart` parser를 호출한다.
+2. native target에서는 `OleChart`를 `charming` chart로 변환해 SVG 문자열을 생성한다.
+3. wasm 또는 실패 경로에서는 구체적인 fallback label을 유지한다.
+4. #1251 fixture의 export-svg 결과에서 generic `OLE 개체 (BinData #2)` placeholder를 제거한다.

--- a/mydocs/working/task_m100_1251_stage3_5.md
+++ b/mydocs/working/task_m100_1251_stage3_5.md
@@ -1,0 +1,79 @@
+# Task M100-1251 Stage 3.5 — 한컴 차트 사양 기반 parser 보강
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **기준 문서**: `/Users/melee/Downloads/한글문서파일형식_차트_revision1.2.pdf`
+- **상태**: 구현 및 1차 검증 완료
+
+## 1. 공식 문서 확인 결과
+
+한컴 차트 사양 revision 1.2의 `Chart Object의 기본 구조`는 차트 바이너리 데이터가 `ChartOBJ`의 순차 나열이라고 설명한다.
+
+`ChartOBJ` 기본 필드:
+
+| 필드 | 자료형 | 비고 |
+|---|---|---|
+| `id` | `long` | 객체 id |
+| `StoredtypeId` | `long` | 객체 type id |
+| `StoredName` | `char*` | variable data |
+| `StoredVersion` | `int` | variable data |
+| `ChartObjData` | `chartObject` | payload |
+
+중요한 제약:
+
+- `StoredName`과 `StoredVersion`은 variable data이다.
+- 동일한 `StoredtypeID`가 앞에 나온 경우 뒤 객체에서는 variable data가 제외될 수 있다.
+- 차트 tree는 `VtChart` 아래 `BackDrop`, `DataGrid`, `Footnote`, `Legend`, `Plot`, `PrintInformation`, `Title` 계열 object를 가진다.
+- `DataGrid Object`는 `ColumnCount`, `ColumnLabel`, `RowCount`, `RowLabel` 등을 정의한다.
+- `Title Object`는 `Text`를 기본 속성으로 갖는다.
+- `ChartType Constants`는 0-26 값을 정의하지만, 현재 fixture의 `/Contents`에서 해당 property 위치는 아직 안정적으로 특정하지 못했다.
+
+## 2. parser 반영 내용
+
+`src/ole_chart/parser.rs` 변경:
+
+- `OleChartContentsProbe`에 legacy chart 진단 필드 추가
+  - `legacy_chart_object_start`
+  - `has_vt_chart_marker`
+  - `has_vt_data_grid_marker`
+  - `has_vt_chart_title_marker`
+- `Contents` 첫 16바이트의 네 번째 little-endian word를 `ChartOBJ` 시작 오프셋 후보로 기록
+- legacy 판정은 `ChartOBJ` 시작 오프셋과 `VtDataGrid` marker 존재로 고정
+- `VtDataGrid` marker 뒤의 `StoredVersion(int)` 4바이트를 건너뛰고 grid data 범위를 시작
+- `VtBackdrop`, `VtBackDrop`, `VtChartSection`, `VtLegend`, `VtPlot`, `VtPrintInformation`, `VtChartTitle`, `VtTitle` 등을 grid boundary 후보로 사용
+- grid value extraction은 dense f64 run을 우선 선택하고, 실패 시 기대 개수와 정확히 일치하는 sparse 후보만 허용
+
+## 3. 현재 한계
+
+- 공식 PDF는 object/property 표를 제공하지만, property serialization의 바이트 단위 레이아웃을 완전히 설명하지 않는다.
+- `ChartType` property의 실제 offset/context는 #1251 fixture 하나만으로 확정하지 않았다.
+- `VtChart` marker는 fixture probe의 필드로 노출하지만 legacy 판정 필수 조건으로 두지 않았다. 공식 문서의 variable data 생략 규칙 때문에 일부 object name은 stream에 직접 나타나지 않을 수 있다.
+
+## 4. 검증 결과
+
+통과:
+
+```text
+cargo fmt --check
+cargo test --lib ole_chart -- --nocapture
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+```
+
+fixture 유지 결과:
+
+- title: `연금 재정 전망`
+- categories: `2010년`, `2020년`, `2030년`, `2040년`
+- series:
+  - `적립금`: `328`, `812`, `1702`, `1477`
+  - `수입`: `50`, `70`, `189`, `191`
+  - `지출`: `11`, `15`, `201`, `289`
+
+## 5. 다음 단계
+
+Stage 4에서 renderer 통합을 진행한다.
+
+렌더 통합 전 유지할 정책:
+
+- `OOXMLChartContents`는 기존처럼 우선한다.
+- legacy `Contents` parsing 성공 시 `OleChart`를 `charming` chart로 변환한다.
+- parsing 실패 시 generic OLE placeholder로 조용히 묻지 않고 명시적인 `OLE 차트 미지원:` fallback을 유지한다.

--- a/mydocs/working/task_m100_1251_stage4.md
+++ b/mydocs/working/task_m100_1251_stage4.md
@@ -1,0 +1,64 @@
+# Task M100-1251 Stage 4 — renderer 통합
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **상태**: 구현 및 검증 완료
+
+## 1. 구현 내용
+
+`src/ole_chart/charming_renderer.rs`
+
+- `render_ole_chart_svg(&OleChart, width, height)` 추가
+- parsed `OleChart`를 `charming::Chart`로 변환
+- 현재 parser가 `chart_type=Unknown`을 반환하는 #1251 fixture는 기본 column/bar 계열로 렌더
+- `Line` type은 line series로 분기할 수 있도록 유지
+
+`src/renderer/layout/shape_layout.rs`
+
+- OLE CFB 렌더 우선순위에 legacy `Contents` chart 경로 추가
+- 우선순위:
+  1. HWPX direct `ooxml_chart`
+  2. nested OLE `OOXMLChartContents`
+  3. nested OLE legacy `Contents` + `ole_chart` parser + `charming` SSR SVG
+  4. `OlePres000` EMF preview
+  5. native image
+  6. generic OLE placeholder
+- legacy `Contents` parsing/rendering 실패 시 generic placeholder로 묻지 않고 `OLE 차트 미지원:` 라벨을 노출
+- native SSR 결과는 `hwp-ole-chart hwp-ole-chart-charming` class를 가진 RawSvg fragment로 삽입
+- wasm target에서는 parsing 성공 시 `charming SSR unavailable on wasm` fallback 라벨을 사용
+
+`tests/issue_1251_ole_chart_contents.rs`
+
+- parsed fixture chart가 `charming` SVG로 렌더되는지 테스트 추가
+- `render_page_svg_native(0)` 결과가 `hwp-ole-chart`를 포함하고 generic `OLE 개체 (BinData #2)` placeholder를 포함하지 않는지 회귀 테스트 추가
+
+## 2. 검증 결과
+
+통과:
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo build
+cargo check --target wasm32-unknown-unknown --lib
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+```
+
+출력 확인:
+
+- `output/poc/task1251/hwp/143E433F503322BD33.svg`
+- 포함 marker:
+  - `hwp-ole-chart hwp-ole-chart-charming`
+  - `연금 재정 전망`
+  - `적립금`
+- 미포함 marker:
+  - `OLE 개체 (BinData #2)`
+  - `OLE 차트 미지원`
+
+## 3. 남은 범위
+
+- Stage 5에서 전체 검증/보고서 작성
+- `ChartType` property의 byte-level 위치가 확정되면 `OleChartType::Unknown`을 실제 type으로 승격
+- `charming` dependency가 CI에서 과도하면 feature gate나 renderer 분리 여부 재평가

--- a/mydocs/working/task_m100_1251_stage5.md
+++ b/mydocs/working/task_m100_1251_stage5.md
@@ -1,0 +1,76 @@
+# Task M100-1251 Stage 5 완료 보고
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **일자**: 2026-06-03
+- **상태**: 완료
+
+> 후속 Stage 6에서 이 단계의 Studio TypeScript overlay 경로는 제거되었다. 현재 canonical 경로는 Rust SVG renderer가 native/WASM 모두에 같은 `RawSvg` fragment를 제공하는 구조다.
+
+## 1. 목표
+
+Stage 4까지 구현한 native `charming` SSR 경로를 유지하면서, rhwp-studio WASM 경로에서 보이던 `charming SSR unavailable on wasm` fallback을 제거한다.
+
+장기 방향은 다음 구조로 고정했다.
+
+```text
+OLE Contents
+→ OleChart renderer-neutral IR
+→ native charming SSR adapter
+→ Studio browser SVG overlay adapter
+→ downstream renderer adapter 후보
+```
+
+## 2. 구현 내용
+
+1. `OleChart`, `OleChartSeries`, `OleChartType`에 `serde::Serialize`를 추가했다.
+2. `src/ole_chart/browser_ir.rs`를 추가해 다음 API를 제공했다.
+   - `ole_chart_ir_json`
+   - `ole_chart_ir_base64`
+   - `render_ole_chart_ir_svg_fragment`
+3. WASM target의 OLE `/Contents` 성공 경로를 placeholder에서 IR SVG fragment로 변경했다.
+4. `rhwp-studio/src/view/ole-chart-renderer.ts`를 추가해 `data-rhwp-ole-chart-ir` payload를 DOM overlay SVG로 렌더한다.
+5. `rhwp-studio/src/view/page-renderer.ts`에서 page layer tree의 `rawSvg` op를 읽어 `.rhwp-ole-chart-overlay-layer`를 합성한다.
+
+## 3. 검증 결과
+
+통과:
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo build
+cargo check --target wasm32-unknown-unknown --lib
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+cargo clippy --all-targets -- -D warnings
+npm run build
+wasm-pack build --target web
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+node /private/tmp/rhwp_issue_1251_qa.mjs
+```
+
+rhwp-studio QA 결과:
+
+```text
+pageCount: 1
+chartCount: 1
+overlayLayerCount: 1
+hasUnavailableText: false
+hasGenericOlePlaceholder: false
+hasTitle: true
+hasSeries: true
+consoleMessages: []
+```
+
+스크린샷:
+
+```text
+/private/tmp/rhwp-studio-issue-1251-chart.png
+```
+
+## 4. 잔여 리스크
+
+- Studio adapter는 현재 외부 의존성 없는 SVG renderer다. ECharts/charming browser renderer로 교체하려면 `OleChartIrPayload`를 그대로 소비하는 adapter만 교체하면 된다.
+- legacy `/Contents` parser는 #1251 fixture에 필요한 `VtDataGrid`/`VtChartTitle` 중심 최소 parser다. 다른 legacy chart object graph는 추가 fixture로 확장해야 한다.
+- issue close 및 PR 생성은 작업지시자 승인 후 진행한다.

--- a/mydocs/working/task_m100_1251_stage6.md
+++ b/mydocs/working/task_m100_1251_stage6.md
@@ -1,0 +1,65 @@
+# Task M100-1251 Stage 6 완료 보고
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **일자**: 2026-06-03
+- **상태**: 완료
+
+## 1. 목표
+
+Stage 5의 Studio TypeScript chart overlay를 장기 경로로 유지하지 않고, Rust/WASM 프로젝트 철학과 PageLayerTree/Skia/CanvasKit 확장 방향에 맞춰 OLE chart 기본 렌더링을 Rust SVG renderer로 통일한다.
+
+## 2. 구현 내용
+
+1. `src/ole_chart/ir.rs`를 추가해 renderer-neutral IR JSON/base64 export만 담당하게 했다.
+2. `src/ole_chart/svg_renderer.rs`를 추가해 `OleChart`를 SVG body, standalone SVG, positioned RawSvg fragment로 렌더한다.
+3. `src/renderer/layout/shape_layout.rs`의 legacy OLE `/Contents` 성공 경로에서 native/WASM 분기를 제거하고 `render_ole_chart_svg_fragment`를 공통 호출한다.
+4. `rhwp-studio/src/view/ole-chart-renderer.ts`를 제거하고 `page-renderer.ts`의 `.rhwp-ole-chart-overlay-layer` 합성 경로를 삭제했다.
+5. `charming` dependency를 `charming-renderer` feature 뒤 optional adapter로 분리했다.
+
+## 3. 검증 결과
+
+통과:
+
+```text
+cargo fmt --check
+cargo test --test issue_1251_ole_chart_contents -- --nocapture
+cargo test --lib ole_chart -- --nocapture
+cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
+cargo check --target wasm32-unknown-unknown --lib
+cargo build
+cargo clippy --all-targets -- -D warnings
+cargo test --test issue_1156_chart_column_flow -- --nocapture
+npm run build
+wasm-pack build --target web
+target/debug/rhwp export-svg samples/143E433F503322BD33.hwp -o output/poc/task1251/hwp
+headless Chrome Studio QA
+```
+
+Studio QA 결과:
+
+```text
+pageCount: 1
+chartRawSvgCount: 1
+hasRustSvgMarker: true
+hasIrPayloadAttr: false
+hasTitleInLayerTree: true
+hasSeriesInLayerTree: true
+browserOverlayCount: 0
+overlayLayerCount: 0
+hasUnavailableText: false
+hasGenericOlePlaceholder: false
+saturatedChartPixels: 11283
+```
+
+스크린샷:
+
+```text
+/private/tmp/rhwp-studio-issue-1251-rust-svg.png
+```
+
+## 4. 잔여 리스크
+
+- 현재 canonical renderer는 SVG fragment 기반이다. PageLayerTree/Skia/CanvasKit 친화성을 더 높이려면 후속 단계에서 chart visual model을 `Line`/`Rectangle`/`Path`/`TextRun` paint op로 낮추는 작업이 필요하다.
+- `charming` adapter는 optional feature로 컴파일 검증했지만 기본 렌더 경로에서는 사용하지 않는다. PR 설명에서 maintainer 지시를 “기본 renderer”가 아니라 “optional adapter”로 해석한 이유를 명확히 적어야 한다.
+- legacy `/Contents` parser는 #1251 fixture에 필요한 `VtDataGrid`/`VtChartTitle` 중심 최소 parser다. 다른 legacy chart object graph는 추가 fixture로 확장해야 한다.

--- a/mydocs/working/task_m100_1251_stage7.md
+++ b/mydocs/working/task_m100_1251_stage7.md
@@ -1,0 +1,55 @@
+# Task M100-1251 Stage 7 완료 보고
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **일자**: 2026-06-03
+- **상태**: 완료
+
+## 1. 목표
+
+정답 PDF(`pdf-large/hwpx/143E433F503322BD33.pdf`) 대비 현재 렌더링의 시각 차이를 분석하고, 이번 PR에서 정합성 보강까지 진행할지 또는 추적 가능한 문서화에 집중할지 결정한다.
+
+## 2. 분석 결과
+
+차트 데이터 추출은 안정적이다.
+
+```text
+title: 연금 재정 전망
+categories: 2010년, 2020년, 2030년, 2040년
+적립금: 328, 812, 1702, 1477
+수입: 50, 70, 189, 191
+지출: 11, 15, 201, 289
+```
+
+시각 차이는 주로 다음 원인에서 발생한다.
+
+1. y축 nice scale 미구현: 정답은 0-2000/500 tick, 현재는 0-1702/4등분 tick
+2. chart palette 미복원: 정답은 한컴 기본색, 현재는 Rust renderer 기본 palette
+3. chart object style 미파싱: title spacing, legend 위치, plot margin, border, bar gap
+4. parser IR 범위 제한: `OleChart`가 아직 데이터 중심 필드만 포함
+5. 일반 문서 layout 차이: chart 외에도 일부 column/text flow 차이가 존재
+
+## 3. 결정
+
+이번 PR에서는 정답 PDF 수준의 시각 정합성 보강을 추가로 진행하지 않는다.
+
+이유:
+
+- 이번 PR의 핵심은 preview가 없는 legacy OLE chart를 generic placeholder 대신 렌더하는 것이다.
+- 시각 정합성 보강은 axis/style/object graph parser 확장까지 포함하는 별도 큰 작업이다.
+- 단기 휴리스틱으로 정답 PDF에 맞추면 #1251 fixture에 과적합될 위험이 있다.
+- 업스트림 리뷰에서는 기능 추가 범위, renderer 선택 이유, known visual gap을 명확히 공유하는 편이 더 추적 가능하다.
+
+## 4. 산출물
+
+- `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md`
+- `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md`
+
+## 5. 후속 작업 후보
+
+1. legacy OLE chart style/object graph parser 확장
+2. axis nice scale 및 tick interval 복원
+3. palette/series style 복원
+4. legend/title/plot area 복원
+5. chart visual model의 PageLayerTree `PaintOp` lowering
+6. PDF/SVG visual comparison harness 추가

--- a/mydocs/working/task_m100_1251_stage8.md
+++ b/mydocs/working/task_m100_1251_stage8.md
@@ -1,0 +1,42 @@
+# Task M100-1251 Stage 8 완료 보고
+
+- **이슈**: [#1251](https://github.com/edwardkim/rhwp/issues/1251)
+- **브랜치**: `task-1251-ole-chart`
+- **작성일**: 2026-06-03
+- **단계**: PR 초안 작성 및 공유 자료 정리
+
+## 1. 수행 내용
+
+PR 초안에 포함할 공식 문서, 결정 배경, 구현 결정, 검증 결과, known visual gap을 하나의 보고서로 정리했다.
+
+신규 문서:
+
+- `mydocs/report/task_m100_1251_pr_draft.md`
+
+## 2. 참고 문서 정리
+
+PR 초안에는 다음 문서를 명시했다.
+
+- 한컴 HWP/OWPML 형식 다운로드 센터
+- 한컴 HWP 5.0 문서 형식 revision 1.3
+- 한컴 차트 문서 형식 revision 1.2
+- Microsoft MS-CFB
+- Microsoft MS-OLEDS
+- `yuankunzhang/charming`
+
+## 3. 결정 배경 정리
+
+PR 초안에 다음 판단을 포함했다.
+
+1. `charming`은 HWP OLE `/Contents` parser가 아니므로 parser는 rhwp 내부에 둔다.
+2. 기본 렌더링 경로는 Rust SVG `RawSvg`로 유지한다.
+3. `charming`은 `charming-renderer` feature 뒤 native SSR optional adapter로 유지한다.
+4. browser/WASM `WasmRenderer` 기본 경로는 DOM id와 ECharts global runtime이 필요하므로 채택하지 않는다.
+5. 정답 PDF 대비 visual gap은 후속 object graph parser 확장으로 다룬다.
+
+## 4. PR 생성 전 주의 사항
+
+현재 브랜치는 fetch된 `upstream/devel` 기준 뒤처져 있다. PR 생성 전 최신 `upstream/devel`로 rebase 또는 merge가 필요하다.
+
+작업 트리에는 #1251 외에 `task_m100_1142`, `task_m100_1143`, `task_m100_1144` 문서가 untracked 상태로 존재한다. PR에 포함할 파일을 staging할 때 #1251 범위만 명시적으로 선택해야 한다.
+

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,7 @@ pub mod document_core;
 pub mod emf;
 pub mod error;
 pub mod model;
+pub mod ole_chart;
 pub mod ooxml_chart;
 pub mod paint;
 pub mod parser;

--- a/src/ole_chart/charming_renderer.rs
+++ b/src/ole_chart/charming_renderer.rs
@@ -1,0 +1,118 @@
+//! `charming` SSR renderer for OLE chart work.
+
+use std::fmt;
+
+use charming::{
+    component::{Axis, Grid, Legend, Title},
+    element::AxisType,
+    series::{Bar, Line, Pie, PieRoseType},
+    Chart, ImageRenderer,
+};
+
+use super::{OleChart, OleChartType};
+
+/// OLE chart rendering error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OleChartRenderError {
+    EmptyChart,
+    CharmingSsr(String),
+}
+
+impl OleChartRenderError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::EmptyChart => "EMPTY_OLE_CHART",
+            Self::CharmingSsr(_) => "CHARMING_SSR_RENDER_FAILED",
+        }
+    }
+}
+
+impl fmt::Display for OleChartRenderError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::EmptyChart => f.write_str("empty OLE chart"),
+            Self::CharmingSsr(message) => write!(f, "charming SSR render failed: {message}"),
+        }
+    }
+}
+
+impl std::error::Error for OleChartRenderError {}
+
+/// Renders a parsed OLE chart through `charming` SSR and returns a standalone SVG document.
+pub fn render_ole_chart_charming_svg(
+    chart: &OleChart,
+    width: u32,
+    height: u32,
+) -> Result<String, OleChartRenderError> {
+    if chart.categories.is_empty() || chart.series.is_empty() {
+        return Err(OleChartRenderError::EmptyChart);
+    }
+
+    let chart_option = build_charming_chart(chart);
+    ImageRenderer::new(width.max(1), height.max(1))
+        .render(&chart_option)
+        .map_err(|error| OleChartRenderError::CharmingSsr(error.to_string()))
+}
+
+/// Renders a minimal chart through `charming` SSR and returns SVG text.
+pub fn render_smoke_chart_svg(width: u32, height: u32) -> Result<String, OleChartRenderError> {
+    let chart = Chart::new().legend(Legend::new().top("bottom")).series(
+        Pie::new()
+            .name("RHWP OLE Chart Smoke")
+            .rose_type(PieRoseType::Radius)
+            .radius(vec!["30", "70"])
+            .center(vec!["50%", "45%"])
+            .data(vec![
+                (40.0, "alpha"),
+                (32.0, "beta"),
+                (24.0, "gamma"),
+                (16.0, "delta"),
+            ]),
+    );
+
+    ImageRenderer::new(width, height)
+        .render(&chart)
+        .map_err(|error| OleChartRenderError::CharmingSsr(error.to_string()))
+}
+
+fn build_charming_chart(ole_chart: &OleChart) -> Chart {
+    let mut chart = Chart::new()
+        .legend(Legend::new().top("bottom"))
+        .grid(
+            Grid::new()
+                .left("8%")
+                .right("6%")
+                .top(if ole_chart.title.is_some() {
+                    "18%"
+                } else {
+                    "10%"
+                })
+                .bottom("18%")
+                .contain_label(true),
+        )
+        .x_axis(
+            Axis::new()
+                .type_(AxisType::Category)
+                .data(ole_chart.categories.clone()),
+        )
+        .y_axis(Axis::new().type_(AxisType::Value));
+
+    if let Some(title) = ole_chart.title.as_ref() {
+        chart = chart.title(Title::new().text(title.clone()).left("center").top("2%"));
+    }
+
+    for series in &ole_chart.series {
+        let name = series.name.clone().unwrap_or_default();
+        chart = match ole_chart.chart_type {
+            OleChartType::Line => chart.series(
+                Line::new()
+                    .name(name)
+                    .show_symbol(true)
+                    .data(series.values.clone()),
+            ),
+            _ => chart.series(Bar::new().name(name).data(series.values.clone())),
+        };
+    }
+
+    chart
+}

--- a/src/ole_chart/ir.rs
+++ b/src/ole_chart/ir.rs
@@ -1,0 +1,72 @@
+//! Renderer-neutral OLE chart IR export helpers.
+
+use base64::Engine;
+use serde::Serialize;
+
+use super::OleChart;
+
+pub const OLE_CHART_IR_SCHEMA: &str = "rhwp.oleChartIr";
+pub const OLE_CHART_IR_VERSION: u32 = 1;
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OleChartIrPayload<'a> {
+    pub schema: &'static str,
+    pub version: u32,
+    pub chart: &'a OleChart,
+}
+
+impl<'a> OleChartIrPayload<'a> {
+    pub fn new(chart: &'a OleChart) -> Self {
+        Self {
+            schema: OLE_CHART_IR_SCHEMA,
+            version: OLE_CHART_IR_VERSION,
+            chart,
+        }
+    }
+}
+
+pub fn ole_chart_ir_json(chart: &OleChart) -> Result<String, serde_json::Error> {
+    serde_json::to_string(&OleChartIrPayload::new(chart))
+}
+
+pub fn ole_chart_ir_base64(chart: &OleChart) -> Result<String, serde_json::Error> {
+    Ok(base64::engine::general_purpose::STANDARD.encode(ole_chart_ir_json(chart)?))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ole_chart::{OleChartSeries, OleChartType};
+
+    fn sample_chart() -> OleChart {
+        OleChart {
+            chart_type: OleChartType::Unknown,
+            title: Some("연금 재정 전망".to_string()),
+            categories: vec!["2010년".to_string(), "2020년".to_string()],
+            series: vec![OleChartSeries {
+                name: Some("적립금".to_string()),
+                values: vec![328.0, 812.0],
+            }],
+        }
+    }
+
+    #[test]
+    fn serializes_renderer_neutral_ir_payload() {
+        let json = ole_chart_ir_json(&sample_chart()).expect("serialize chart ir");
+
+        assert!(json.contains("\"schema\":\"rhwp.oleChartIr\""));
+        assert!(json.contains("\"version\":1"));
+        assert!(json.contains("\"chartType\":\"unknown\""));
+        assert!(json.contains("연금 재정 전망"));
+        assert!(json.contains("적립금"));
+    }
+
+    #[test]
+    fn serializes_renderer_neutral_ir_payload_as_base64() {
+        let encoded = ole_chart_ir_base64(&sample_chart()).expect("serialize chart ir");
+
+        assert!(!encoded.is_empty());
+        assert!(!encoded.contains("연금 재정 전망"));
+    }
+}

--- a/src/ole_chart/mod.rs
+++ b/src/ole_chart/mod.rs
@@ -1,0 +1,27 @@
+//! HWP OLE `Contents` 기반 차트 파싱 골격.
+//!
+//! 구버전/Neo 계열 HWP 차트 OLE는 `OOXMLChartContents`나 `OlePres000`
+//! 미리보기 없이 `Contents` 스트림만 담는 경우가 있다. 이 모듈은 해당
+//! 스트림을 차트 IR로 해석하기 위한 전용 진입점이다.
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "charming-renderer"))]
+pub mod charming_renderer;
+pub mod ir;
+pub mod parser;
+pub mod svg_renderer;
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "charming-renderer"))]
+pub use charming_renderer::{
+    render_ole_chart_charming_svg, render_smoke_chart_svg, OleChartRenderError,
+};
+pub use ir::{
+    ole_chart_ir_base64, ole_chart_ir_json, OleChartIrPayload, OLE_CHART_IR_SCHEMA,
+    OLE_CHART_IR_VERSION,
+};
+pub use parser::{
+    parse_ole_chart_contents, probe_ole_chart_contents, OleChart, OleChartContentsProbe,
+    OleChartParseError, OleChartSeries, OleChartType,
+};
+pub use svg_renderer::{
+    render_ole_chart_standalone_svg, render_ole_chart_svg_body, render_ole_chart_svg_fragment,
+};

--- a/src/ole_chart/parser.rs
+++ b/src/ole_chart/parser.rs
@@ -1,0 +1,568 @@
+//! HWP OLE `Contents` 차트 스트림 최소 파서.
+//!
+//! 한컴 차트 사양(revision 1.2)의 `ChartOBJ` 기본 구조를 기준으로 legacy
+//! HWP chart payload를 식별한다. 전체 object graph는 아직 해석하지 않고,
+//! `VtDataGrid` 구간에서 라벨과 연속된 f64 값 배열만 추출한다.
+
+use std::fmt;
+
+use encoding_rs::EUC_KR;
+use serde::Serialize;
+
+/// OLE `Contents`에서 추출한 차트 IR.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OleChart {
+    pub chart_type: OleChartType,
+    pub title: Option<String>,
+    pub categories: Vec<String>,
+    pub series: Vec<OleChartSeries>,
+}
+
+/// OLE `Contents` 차트 종류.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub enum OleChartType {
+    Column,
+    Bar,
+    Line,
+    Pie,
+    #[default]
+    Unknown,
+}
+
+/// OLE `Contents` 차트 시리즈.
+#[derive(Debug, Clone, PartialEq, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct OleChartSeries {
+    pub name: Option<String>,
+    pub values: Vec<f64>,
+}
+
+/// OLE `Contents` 스트림 진단 정보.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct OleChartContentsProbe {
+    pub len: usize,
+    pub signature: [u8; 16],
+    pub first_words_le: [u32; 4],
+    pub has_cfb_magic: bool,
+    pub has_ooxml_chart_marker: bool,
+    pub legacy_chart_object_start: Option<usize>,
+    pub has_vt_chart_marker: bool,
+    pub has_vt_data_grid_marker: bool,
+    pub has_vt_chart_title_marker: bool,
+    pub likely_legacy_hwp_chart_contents: bool,
+}
+
+/// OLE `Contents` 차트 파싱 오류.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum OleChartParseError {
+    Empty,
+    TooShort {
+        len: usize,
+    },
+    UnsupportedContentsLayout {
+        len: usize,
+        signature: [u8; 16],
+        reason: &'static str,
+    },
+}
+
+impl OleChartParseError {
+    pub fn code(&self) -> &'static str {
+        match self {
+            Self::Empty => "EMPTY_CONTENTS",
+            Self::TooShort { .. } => "CONTENTS_TOO_SHORT",
+            Self::UnsupportedContentsLayout { .. } => "UNSUPPORTED_CONTENTS_LAYOUT",
+        }
+    }
+
+    pub fn stable_message(&self) -> String {
+        match self {
+            Self::Empty => "OLE 차트 미지원: Contents 스트림이 비어 있음".to_string(),
+            Self::TooShort { len } => {
+                format!("OLE 차트 미지원: Contents 스트림이 너무 짧음 (len={len})")
+            }
+            Self::UnsupportedContentsLayout { reason, .. } => {
+                format!("OLE 차트 미지원: {reason}")
+            }
+        }
+    }
+}
+
+impl fmt::Display for OleChartParseError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(&self.stable_message())
+    }
+}
+
+impl std::error::Error for OleChartParseError {}
+
+/// OLE `Contents` 스트림을 차트 IR로 파싱한다.
+pub fn parse_ole_chart_contents(bytes: &[u8]) -> Result<OleChart, OleChartParseError> {
+    let probe = probe_ole_chart_contents(bytes)?;
+
+    if probe.likely_legacy_hwp_chart_contents {
+        return parse_legacy_hwp_chart_contents(bytes, &probe);
+    }
+
+    Err(OleChartParseError::UnsupportedContentsLayout {
+        len: probe.len,
+        signature: probe.signature,
+        reason: "unknown OLE Contents layout",
+    })
+}
+
+fn parse_legacy_hwp_chart_contents(
+    bytes: &[u8],
+    probe: &OleChartContentsProbe,
+) -> Result<OleChart, OleChartParseError> {
+    let grid_marker_start = find_bytes(bytes, b"VtDataGrid\0").ok_or_else(|| {
+        unsupported_legacy_layout(probe, "legacy HWP chart data grid marker not found")
+    })?;
+    let grid_start = legacy_chart_object_data_start(bytes, grid_marker_start, b"VtDataGrid\0");
+    let grid_end = find_next_legacy_object_marker(bytes, grid_start).ok_or_else(|| {
+        unsupported_legacy_layout(probe, "legacy HWP chart data grid boundary not found")
+    })?;
+
+    let labels = extract_string_labels(bytes, grid_start, grid_end);
+    let mut series_names = Vec::new();
+    let mut categories = Vec::new();
+    let mut saw_category = false;
+
+    for label in labels {
+        if label.text.chars().any(|ch| ch.is_ascii_digit()) {
+            saw_category = true;
+            categories.push(label.text);
+        } else if !saw_category {
+            series_names.push(label.text);
+        }
+    }
+
+    series_names.dedup();
+    categories.dedup();
+
+    if series_names.is_empty() || categories.is_empty() {
+        return Err(unsupported_legacy_layout(
+            probe,
+            "legacy HWP chart data grid labels are incomplete",
+        ));
+    }
+
+    let series_count = series_names.len();
+    let expected_values = series_count * categories.len();
+    let values = extract_grid_values(bytes, grid_start, grid_end, expected_values);
+    if values.len() != expected_values {
+        return Err(unsupported_legacy_layout(
+            probe,
+            "legacy HWP chart data grid shape not recognized",
+        ));
+    }
+
+    let mut series = Vec::with_capacity(series_count);
+    for (series_idx, name) in series_names.into_iter().enumerate() {
+        let mut series_values = Vec::with_capacity(categories.len());
+        for category_idx in 0..categories.len() {
+            series_values.push(values[category_idx * series_count + series_idx]);
+        }
+        series.push(OleChartSeries {
+            name: Some(name),
+            values: series_values,
+        });
+    }
+
+    Ok(OleChart {
+        chart_type: OleChartType::Unknown,
+        title: extract_chart_title(bytes),
+        categories,
+        series,
+    })
+}
+
+fn unsupported_legacy_layout(
+    probe: &OleChartContentsProbe,
+    reason: &'static str,
+) -> OleChartParseError {
+    OleChartParseError::UnsupportedContentsLayout {
+        len: probe.len,
+        signature: probe.signature,
+        reason,
+    }
+}
+
+/// OLE `Contents` 스트림의 안정적인 진단 정보를 만든다.
+pub fn probe_ole_chart_contents(bytes: &[u8]) -> Result<OleChartContentsProbe, OleChartParseError> {
+    if bytes.is_empty() {
+        return Err(OleChartParseError::Empty);
+    }
+    if bytes.len() < 16 {
+        return Err(OleChartParseError::TooShort { len: bytes.len() });
+    }
+
+    let mut signature = [0u8; 16];
+    signature.copy_from_slice(&bytes[..16]);
+
+    let mut first_words_le = [0u32; 4];
+    for (i, chunk) in bytes[..16].chunks_exact(4).enumerate() {
+        first_words_le[i] = u32::from_le_bytes([chunk[0], chunk[1], chunk[2], chunk[3]]);
+    }
+
+    let has_cfb_magic = bytes.starts_with(&[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+    let has_ooxml_chart_marker = bytes
+        .windows(b"chartSpace".len())
+        .any(|w| w == b"chartSpace");
+    let legacy_chart_object_start = if first_words_le[0] == 0x0001_0000
+        && first_words_le[1] == first_words_le[2]
+        && first_words_le[3] >= 0x20
+        && (first_words_le[3] as usize) < bytes.len()
+    {
+        Some(first_words_le[3] as usize)
+    } else {
+        None
+    };
+    let has_vt_chart_marker = find_bytes(bytes, b"VtChart\0").is_some();
+    let has_vt_data_grid_marker = find_bytes(bytes, b"VtDataGrid\0").is_some();
+    let has_vt_chart_title_marker = find_title_marker(bytes, 0).map(|_| ()).is_some();
+    let likely_legacy_hwp_chart_contents =
+        legacy_chart_object_start.is_some() && has_vt_data_grid_marker;
+
+    Ok(OleChartContentsProbe {
+        len: bytes.len(),
+        signature,
+        first_words_le,
+        has_cfb_magic,
+        has_ooxml_chart_marker,
+        legacy_chart_object_start,
+        has_vt_chart_marker,
+        has_vt_data_grid_marker,
+        has_vt_chart_title_marker,
+        likely_legacy_hwp_chart_contents,
+    })
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct LabelCandidate {
+    text: String,
+    end: usize,
+}
+
+fn extract_string_labels(bytes: &[u8], start: usize, end: usize) -> Vec<LabelCandidate> {
+    let mut labels = Vec::new();
+    let mut offset = start;
+    while offset + 4 <= end {
+        let len = read_u16(bytes, offset) as usize;
+        if (2..=128).contains(&len) && offset + 2 + len <= end {
+            if let Some(text) = decode_legacy_text_payload(&bytes[offset + 2..offset + 2 + len]) {
+                if !labels
+                    .iter()
+                    .any(|label: &LabelCandidate| label.text == text)
+                {
+                    labels.push(LabelCandidate {
+                        text,
+                        end: offset + 2 + len,
+                    });
+                }
+                offset += 2 + len;
+                continue;
+            }
+        }
+        offset += 1;
+    }
+    labels
+}
+
+fn decode_legacy_text_payload(payload: &[u8]) -> Option<String> {
+    let text_end = payload.windows(2).position(|w| w == [0, 0])?;
+    if text_end < 2 {
+        return None;
+    }
+
+    let (text, _, had_errors) = EUC_KR.decode(&payload[..text_end]);
+    if had_errors {
+        return None;
+    }
+
+    let normalized = text.replace('\u{3000}', " ");
+    let text = normalized.trim().to_string();
+    if !is_plausible_chart_label(&text) {
+        return None;
+    }
+
+    Some(text)
+}
+
+fn is_plausible_chart_label(text: &str) -> bool {
+    if text.is_empty() || text.starts_with("Vt") || text.len() > 64 {
+        return false;
+    }
+
+    let mut has_data_char = false;
+    for ch in text.chars() {
+        if ch.is_control() {
+            return false;
+        }
+        if ch.is_ascii_digit() || ('가'..='힣').contains(&ch) {
+            has_data_char = true;
+            continue;
+        }
+        if matches!(ch, ' ' | ',' | '.' | '-' | '_' | '(' | ')' | '/' | '%') {
+            continue;
+        }
+        if ch.is_ascii_alphabetic() {
+            continue;
+        }
+        return false;
+    }
+
+    has_data_char
+}
+
+fn extract_grid_values(bytes: &[u8], start: usize, end: usize, expected_count: usize) -> Vec<f64> {
+    if expected_count == 0 || start >= end || end > bytes.len() {
+        return Vec::new();
+    }
+
+    let mut best = Vec::new();
+    let scan_end = end.saturating_sub(8);
+    for offset in start..=scan_end {
+        let value = read_f64(bytes, offset);
+        if !is_plausible_grid_value(value) {
+            continue;
+        }
+
+        let mut run = Vec::new();
+        let mut cursor = offset;
+        while cursor + 8 <= end {
+            let value = read_f64(bytes, cursor);
+            if !is_plausible_grid_value(value) {
+                break;
+            }
+            run.push(value);
+            cursor += 8;
+        }
+
+        if run.len() == expected_count {
+            return run;
+        }
+        if run.len() > best.len() {
+            best = run;
+        }
+    }
+
+    if best.len() >= expected_count {
+        best.truncate(expected_count);
+        best
+    } else {
+        extract_sparse_grid_values(bytes, start, end, expected_count)
+    }
+}
+
+fn extract_sparse_grid_values(
+    bytes: &[u8],
+    start: usize,
+    end: usize,
+    expected_count: usize,
+) -> Vec<f64> {
+    let mut values = Vec::new();
+    let mut offset = start;
+    while offset + 8 <= end {
+        let value = read_f64(bytes, offset);
+        if is_plausible_grid_value(value) {
+            values.push(value);
+            offset += 8;
+            continue;
+        }
+        offset += 1;
+    }
+
+    if values.len() == expected_count {
+        values
+    } else {
+        Vec::new()
+    }
+}
+
+fn is_plausible_grid_value(value: f64) -> bool {
+    value.is_finite()
+        && value >= 1.0
+        && value <= 1_000_000.0
+        && (value.fract().abs() < 1e-9 || (1.0 - value.fract()).abs() < 1e-9)
+}
+
+fn extract_chart_title(bytes: &[u8]) -> Option<String> {
+    let title_marker = find_title_marker(bytes, 0)?;
+    let title_start =
+        legacy_chart_object_data_start(bytes, title_marker.start, title_marker.marker);
+    let title_end = find_next_legacy_object_marker(bytes, title_start)
+        .or_else(|| find_bytes_from(bytes, b"VtList\0", title_start))
+        .unwrap_or(bytes.len());
+    extract_string_labels(bytes, title_start, title_end)
+        .into_iter()
+        .max_by_key(|label| label.text.chars().count())
+        .map(|label| label.text)
+}
+
+struct MarkerMatch {
+    start: usize,
+    marker: &'static [u8],
+}
+
+fn legacy_chart_object_data_start(bytes: &[u8], marker_start: usize, marker: &[u8]) -> usize {
+    // 한컴 차트 사양의 ChartOBJ는 StoredName(char*) 다음 StoredVersion(int)을 둔다.
+    // StoredName은 marker 문자열의 NUL까지 포함하므로, 최초 선언 객체에서는 4바이트
+    // version 뒤부터 ChartObjData가 시작된다.
+    let data_start = marker_start.saturating_add(marker.len()).saturating_add(4);
+    if data_start <= bytes.len() {
+        data_start
+    } else {
+        marker_start
+    }
+}
+
+fn find_title_marker(bytes: &[u8], start: usize) -> Option<MarkerMatch> {
+    find_first_marker(bytes, start, &[b"VtChartTitle\0", b"VtTitle\0"])
+}
+
+fn find_next_legacy_object_marker(bytes: &[u8], start: usize) -> Option<usize> {
+    const MARKERS: &[&[u8]] = &[
+        b"VtBackdrop\0",
+        b"VtBackDrop\0",
+        b"VtChartSection\0",
+        b"VtFootnote\0",
+        b"VtLegend\0",
+        b"VtPlot\0",
+        b"VtPrintInformation\0",
+        b"VtChartTitle\0",
+        b"VtTitle\0",
+    ];
+
+    find_first_marker(bytes, start, MARKERS).map(|marker| marker.start)
+}
+
+fn find_first_marker(bytes: &[u8], start: usize, markers: &[&'static [u8]]) -> Option<MarkerMatch> {
+    markers
+        .iter()
+        .filter_map(|marker| {
+            find_bytes_from(bytes, marker, start).map(|pos| MarkerMatch { start: pos, marker })
+        })
+        .min_by_key(|marker| marker.start)
+}
+
+fn find_bytes(haystack: &[u8], needle: &[u8]) -> Option<usize> {
+    find_bytes_from(haystack, needle, 0)
+}
+
+fn find_bytes_from(haystack: &[u8], needle: &[u8], start: usize) -> Option<usize> {
+    if needle.is_empty() || start >= haystack.len() || needle.len() > haystack.len() {
+        return None;
+    }
+    haystack[start..]
+        .windows(needle.len())
+        .position(|window| window == needle)
+        .map(|offset| start + offset)
+}
+
+fn read_u16(bytes: &[u8], offset: usize) -> u16 {
+    u16::from_le_bytes([bytes[offset], bytes[offset + 1]])
+}
+
+fn read_f64(bytes: &[u8], offset: usize) -> f64 {
+    f64::from_le_bytes(bytes[offset..offset + 8].try_into().unwrap())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn probe_rejects_empty_contents() {
+        let err = probe_ole_chart_contents(&[]).expect_err("empty contents should fail");
+        assert_eq!(err.code(), "EMPTY_CONTENTS");
+    }
+
+    #[test]
+    fn probe_rejects_too_short_contents() {
+        let err = probe_ole_chart_contents(&[0u8; 8]).expect_err("short contents should fail");
+        assert_eq!(err.code(), "CONTENTS_TOO_SHORT");
+    }
+
+    #[test]
+    fn probe_detects_legacy_hwp_chart_contents_shape() {
+        let mut bytes = vec![0u8; 0x80];
+        bytes[0..4].copy_from_slice(&0x0001_0000u32.to_le_bytes());
+        bytes[4..8].copy_from_slice(&0x0000_0020u32.to_le_bytes());
+        bytes[8..12].copy_from_slice(&0x0000_0020u32.to_le_bytes());
+        bytes[12..16].copy_from_slice(&0x0000_0060u32.to_le_bytes());
+
+        let probe = probe_ole_chart_contents(&bytes).expect("probe");
+        assert!(!probe.likely_legacy_hwp_chart_contents);
+
+        let err =
+            parse_ole_chart_contents(&bytes).expect_err("minimal legacy bytes should fail stable");
+        assert_eq!(err.code(), "UNSUPPORTED_CONTENTS_LAYOUT");
+    }
+
+    #[test]
+    fn probe_detects_legacy_hwp_chart_object_markers() {
+        let mut bytes = vec![0u8; 0x100];
+        bytes[0..4].copy_from_slice(&0x0001_0000u32.to_le_bytes());
+        bytes[4..8].copy_from_slice(&0x0000_0020u32.to_le_bytes());
+        bytes[8..12].copy_from_slice(&0x0000_0020u32.to_le_bytes());
+        bytes[12..16].copy_from_slice(&0x0000_0060u32.to_le_bytes());
+        bytes[0x60..0x68].copy_from_slice(b"VtChart\0");
+        bytes[0x80..0x8b].copy_from_slice(b"VtDataGrid\0");
+
+        let probe = probe_ole_chart_contents(&bytes).expect("probe");
+        assert_eq!(probe.legacy_chart_object_start, Some(0x60));
+        assert!(probe.has_vt_chart_marker);
+        assert!(probe.has_vt_data_grid_marker);
+        assert!(probe.likely_legacy_hwp_chart_contents);
+    }
+
+    #[test]
+    fn legacy_text_payload_decodes_cp949_until_null_pair() {
+        let payload = [
+            0xC0, 0xFB, 0xB8, 0xB3, 0xB1, 0xDD, 0x00, 0x00, 0x01, 0xC8, 0xBD, 0xB9,
+        ];
+
+        let text = decode_legacy_text_payload(&payload).expect("decode payload");
+        assert_eq!(text, "적립금");
+    }
+
+    #[test]
+    fn legacy_text_payload_normalizes_full_width_spaces() {
+        let payload = [
+            0xBF, 0xAC, 0xB1, 0xDD, 0xA1, 0xA1, 0xC0, 0xE7, 0xC1, 0xA4, 0xA1, 0xA1, 0xC0, 0xFC,
+            0xB8, 0xC1, 0x00, 0x00,
+        ];
+
+        let text = decode_legacy_text_payload(&payload).expect("decode payload");
+        assert_eq!(text, "연금 재정 전망");
+    }
+
+    #[test]
+    fn legacy_grid_values_require_dense_f64_run() {
+        let mut bytes = vec![0u8; 96];
+        bytes[4..12].copy_from_slice(&999.0f64.to_le_bytes());
+        bytes[17..25].copy_from_slice(&1.0f64.to_le_bytes());
+        bytes[25..33].copy_from_slice(&2.0f64.to_le_bytes());
+        bytes[33..41].copy_from_slice(&3.0f64.to_le_bytes());
+
+        let values = extract_grid_values(&bytes, 0, bytes.len(), 3);
+        assert_eq!(values, [1.0, 2.0, 3.0]);
+    }
+
+    #[test]
+    fn legacy_grid_values_fall_back_to_exact_sparse_candidates() {
+        let mut bytes = vec![0u8; 96];
+        bytes[7..15].copy_from_slice(&1.0f64.to_le_bytes());
+        bytes[29..37].copy_from_slice(&2.0f64.to_le_bytes());
+        bytes[53..61].copy_from_slice(&3.0f64.to_le_bytes());
+
+        let values = extract_grid_values(&bytes, 0, bytes.len(), 3);
+        assert_eq!(values, [1.0, 2.0, 3.0]);
+
+        let values = extract_grid_values(&bytes, 0, bytes.len(), 2);
+        assert!(values.is_empty());
+    }
+}

--- a/src/ole_chart/svg_renderer.rs
+++ b/src/ole_chart/svg_renderer.rs
@@ -1,0 +1,328 @@
+//! Canonical Rust SVG renderer for parsed OLE charts.
+
+use super::ir::{OLE_CHART_IR_SCHEMA, OLE_CHART_IR_VERSION};
+use super::{OleChart, OleChartType};
+
+pub fn render_ole_chart_svg_fragment(
+    chart: &OleChart,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+    bin_data_id: u32,
+) -> String {
+    let safe_x = finite_or(x, 0.0);
+    let safe_y = finite_or(y, 0.0);
+    let safe_w = positive_finite_or(width, 1.0);
+    let safe_h = positive_finite_or(height, 1.0);
+    let body = render_ole_chart_svg_body(chart, safe_w, safe_h);
+
+    format!(
+        "<g class=\"hwp-ole-chart hwp-ole-chart-rust-svg\" \
+         data-rhwp-ole-chart-renderer=\"rust-svg\" \
+         data-rhwp-ole-chart-schema=\"{}\" data-rhwp-ole-chart-version=\"{}\" \
+         data-rhwp-bin-data-id=\"{}\" transform=\"translate({:.2} {:.2})\">{}</g>",
+        OLE_CHART_IR_SCHEMA, OLE_CHART_IR_VERSION, bin_data_id, safe_x, safe_y, body,
+    )
+}
+
+pub fn render_ole_chart_standalone_svg(chart: &OleChart, width: u32, height: u32) -> String {
+    let width = width.max(1);
+    let height = height.max(1);
+    let body = render_ole_chart_svg_body(chart, width as f64, height as f64);
+    format!(
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\">{}</svg>",
+        width, height, width, height, body
+    )
+}
+
+pub fn render_ole_chart_svg_body(chart: &OleChart, width: f64, height: f64) -> String {
+    let width = positive_finite_or(width, 1.0);
+    let height = positive_finite_or(height, 1.0);
+
+    if chart.categories.is_empty() || chart.series.is_empty() {
+        return format!(
+            "<rect x=\"0\" y=\"0\" width=\"{width:.2}\" height=\"{height:.2}\" fill=\"#fff7ed\" \
+             stroke=\"#b45309\" stroke-width=\"1\" stroke-dasharray=\"6 3\"/>\
+             <text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"12\" \
+             fill=\"#92400e\" text-anchor=\"middle\" dominant-baseline=\"central\">OLE chart</text>",
+            width / 2.0,
+            height / 2.0,
+        );
+    }
+
+    let title_h = if chart.title.is_some() { 24.0 } else { 8.0 };
+    let legend_h = if chart.series.len() > 1 { 24.0 } else { 8.0 };
+    let left = 42.0f64.min(width * 0.18).max(28.0);
+    let right = 16.0f64.min(width * 0.08).max(8.0);
+    let top = title_h;
+    let bottom = 30.0 + legend_h;
+    let plot_w = (width - left - right).max(1.0);
+    let plot_h = (height - top - bottom).max(1.0);
+    let max_value = chart
+        .series
+        .iter()
+        .flat_map(|series| series.values.iter())
+        .copied()
+        .filter(|value| value.is_finite() && *value > 0.0)
+        .fold(0.0, f64::max)
+        .max(1.0);
+
+    let mut svg = String::new();
+    svg.push_str(&format!(
+        "<rect x=\"0\" y=\"0\" width=\"{width:.2}\" height=\"{height:.2}\" fill=\"#ffffff\"/>\
+         <rect x=\"0.5\" y=\"0.5\" width=\"{:.2}\" height=\"{:.2}\" fill=\"none\" stroke=\"#cbd5e1\" stroke-width=\"1\"/>",
+        (width - 1.0).max(0.0),
+        (height - 1.0).max(0.0),
+    ));
+
+    if let Some(title) = chart.title.as_ref() {
+        svg.push_str(&format!(
+            "<text x=\"{:.2}\" y=\"16\" font-family=\"sans-serif\" font-size=\"13\" \
+             font-weight=\"600\" fill=\"#111827\" text-anchor=\"middle\">{}</text>",
+            width / 2.0,
+            escape_xml_text(title),
+        ));
+    }
+
+    for i in 0..=4 {
+        let ratio = i as f64 / 4.0;
+        let y = top + plot_h - plot_h * ratio;
+        let value = max_value * ratio;
+        svg.push_str(&format!(
+            "<line x1=\"{left:.2}\" y1=\"{y:.2}\" x2=\"{:.2}\" y2=\"{y:.2}\" stroke=\"#e5e7eb\" stroke-width=\"1\"/>\
+             <text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"9\" fill=\"#64748b\" \
+             text-anchor=\"end\">{}</text>",
+            left + plot_w,
+            left - 4.0,
+            y + 3.0,
+            format_axis_value(value),
+        ));
+    }
+
+    svg.push_str(&format!(
+        "<line x1=\"{left:.2}\" y1=\"{top:.2}\" x2=\"{left:.2}\" y2=\"{:.2}\" stroke=\"#94a3b8\" stroke-width=\"1\"/>\
+         <line x1=\"{left:.2}\" y1=\"{:.2}\" x2=\"{:.2}\" y2=\"{:.2}\" stroke=\"#94a3b8\" stroke-width=\"1\"/>",
+        top + plot_h,
+        top + plot_h,
+        left + plot_w,
+        top + plot_h,
+    ));
+
+    match chart.chart_type {
+        OleChartType::Line => {
+            render_line_series(&mut svg, chart, left, top, plot_w, plot_h, max_value)
+        }
+        _ => render_bar_series(&mut svg, chart, left, top, plot_w, plot_h, max_value),
+    }
+
+    render_category_labels(&mut svg, chart, left, top, plot_w, plot_h);
+    render_legend(&mut svg, chart, left, top + plot_h + 28.0, plot_w);
+    svg
+}
+
+fn render_bar_series(
+    svg: &mut String,
+    chart: &OleChart,
+    left: f64,
+    top: f64,
+    plot_w: f64,
+    plot_h: f64,
+    max_value: f64,
+) {
+    let cat_count = chart.categories.len().max(1);
+    let series_count = chart.series.len().max(1);
+    let cat_w = plot_w / cat_count as f64;
+    let bar_w = (cat_w * 0.72 / series_count as f64).max(1.0);
+    let group_pad = (cat_w - bar_w * series_count as f64) / 2.0;
+
+    for (cat_idx, _) in chart.categories.iter().enumerate() {
+        for (series_idx, series) in chart.series.iter().enumerate() {
+            let value = series.values.get(cat_idx).copied().unwrap_or(0.0).max(0.0);
+            let bar_h = plot_h * (value / max_value).clamp(0.0, 1.0);
+            let x = left + cat_w * cat_idx as f64 + group_pad + bar_w * series_idx as f64;
+            let y = top + plot_h - bar_h;
+            svg.push_str(&format!(
+                "<rect x=\"{x:.2}\" y=\"{y:.2}\" width=\"{:.2}\" height=\"{bar_h:.2}\" \
+                 fill=\"{}\"/>",
+                (bar_w - 1.0).max(1.0),
+                chart_color(series_idx),
+            ));
+        }
+    }
+}
+
+fn render_line_series(
+    svg: &mut String,
+    chart: &OleChart,
+    left: f64,
+    top: f64,
+    plot_w: f64,
+    plot_h: f64,
+    max_value: f64,
+) {
+    let cat_count = chart.categories.len().max(1);
+    let step = if cat_count > 1 {
+        plot_w / (cat_count - 1) as f64
+    } else {
+        0.0
+    };
+
+    for (series_idx, series) in chart.series.iter().enumerate() {
+        let mut points = Vec::new();
+        for cat_idx in 0..cat_count {
+            let value = series.values.get(cat_idx).copied().unwrap_or(0.0).max(0.0);
+            let x = left + step * cat_idx as f64;
+            let y = top + plot_h - plot_h * (value / max_value).clamp(0.0, 1.0);
+            points.push((x, y));
+        }
+        if points.is_empty() {
+            continue;
+        }
+        let mut d = format!("M {:.2} {:.2}", points[0].0, points[0].1);
+        for (x, y) in points.iter().skip(1) {
+            d.push_str(&format!(" L {x:.2} {y:.2}"));
+        }
+        let color = chart_color(series_idx);
+        svg.push_str(&format!(
+            "<path d=\"{d}\" fill=\"none\" stroke=\"{color}\" stroke-width=\"2\"/>"
+        ));
+        for (x, y) in points {
+            svg.push_str(&format!(
+                "<circle cx=\"{x:.2}\" cy=\"{y:.2}\" r=\"2.4\" fill=\"{color}\"/>"
+            ));
+        }
+    }
+}
+
+fn render_category_labels(
+    svg: &mut String,
+    chart: &OleChart,
+    left: f64,
+    top: f64,
+    plot_w: f64,
+    plot_h: f64,
+) {
+    let cat_count = chart.categories.len().max(1);
+    let cat_w = plot_w / cat_count as f64;
+    for (idx, label) in chart.categories.iter().enumerate() {
+        let x = left + cat_w * (idx as f64 + 0.5);
+        svg.push_str(&format!(
+            "<text x=\"{x:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"9\" \
+             fill=\"#334155\" text-anchor=\"middle\">{}</text>",
+            top + plot_h + 14.0,
+            escape_xml_text(label),
+        ));
+    }
+}
+
+fn render_legend(svg: &mut String, chart: &OleChart, left: f64, y: f64, plot_w: f64) {
+    if chart.series.is_empty() {
+        return;
+    }
+    let mut x = left + 4.0;
+    let max_x = left + plot_w;
+    for (idx, series) in chart.series.iter().enumerate() {
+        let name = series.name.as_deref().unwrap_or("Series");
+        if x > max_x - 38.0 {
+            break;
+        }
+        svg.push_str(&format!(
+            "<rect x=\"{x:.2}\" y=\"{:.2}\" width=\"9\" height=\"9\" fill=\"{}\"/>\
+             <text x=\"{:.2}\" y=\"{:.2}\" font-family=\"sans-serif\" font-size=\"9\" \
+             fill=\"#334155\">{}</text>",
+            y - 8.0,
+            chart_color(idx),
+            x + 13.0,
+            y,
+            escape_xml_text(name),
+        ));
+        x += 58.0;
+    }
+}
+
+fn chart_color(idx: usize) -> &'static str {
+    const COLORS: &[&str] = &[
+        "#2563eb", "#dc2626", "#16a34a", "#9333ea", "#ea580c", "#0891b2",
+    ];
+    COLORS[idx % COLORS.len()]
+}
+
+fn format_axis_value(value: f64) -> String {
+    if value >= 1000.0 {
+        format!("{value:.0}")
+    } else if value.fract().abs() < 1e-9 {
+        format!("{}", value as i64)
+    } else {
+        format!("{value:.1}")
+    }
+}
+
+fn escape_xml_text(value: &str) -> String {
+    let mut escaped = String::with_capacity(value.len());
+    for ch in value.chars() {
+        match ch {
+            '&' => escaped.push_str("&amp;"),
+            '<' => escaped.push_str("&lt;"),
+            '>' => escaped.push_str("&gt;"),
+            '"' => escaped.push_str("&quot;"),
+            '\'' => escaped.push_str("&apos;"),
+            _ => escaped.push(ch),
+        }
+    }
+    escaped
+}
+
+fn positive_finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() && value > 0.0 {
+        value
+    } else {
+        fallback
+    }
+}
+
+fn finite_or(value: f64, fallback: f64) -> f64 {
+    if value.is_finite() {
+        value
+    } else {
+        fallback
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::ole_chart::{OleChartSeries, OleChartType};
+
+    fn sample_chart() -> OleChart {
+        OleChart {
+            chart_type: OleChartType::Unknown,
+            title: Some("연금 재정 전망".to_string()),
+            categories: vec!["2010년".to_string(), "2020년".to_string()],
+            series: vec![OleChartSeries {
+                name: Some("적립금".to_string()),
+                values: vec![328.0, 812.0],
+            }],
+        }
+    }
+
+    #[test]
+    fn renders_svg_fragment() {
+        let svg = render_ole_chart_svg_fragment(&sample_chart(), 10.0, 20.0, 300.0, 200.0, 2);
+
+        assert!(svg.contains("hwp-ole-chart-rust-svg"));
+        assert!(svg.contains("data-rhwp-ole-chart-renderer=\"rust-svg\""));
+        assert!(svg.contains("transform=\"translate(10.00 20.00)\""));
+        assert!(svg.contains("연금 재정 전망"));
+        assert!(svg.contains("적립금"));
+    }
+
+    #[test]
+    fn renders_standalone_svg() {
+        let svg = render_ole_chart_standalone_svg(&sample_chart(), 300, 200);
+
+        assert!(svg.starts_with("<svg"));
+        assert!(svg.contains("연금 재정 전망"));
+        assert!(svg.contains("적립금"));
+    }
+}

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -22,6 +22,46 @@ use crate::model::shape::CommonObjAttr;
 use crate::model::shape::{HorzAlign, HorzRelTo, VertAlign, VertRelTo};
 use crate::model::style::Alignment;
 
+fn push_placeholder_render_node(
+    tree: &mut PageRenderTree,
+    parent: &mut RenderNode,
+    bbox: BoundingBox,
+    fill_color: u32,
+    stroke_color: u32,
+    label: String,
+) {
+    let node_id = tree.next_id();
+    let node = RenderNode::new(
+        node_id,
+        RenderNodeType::Placeholder(crate::renderer::render_tree::PlaceholderNode {
+            fill_color,
+            stroke_color,
+            label,
+        }),
+        bbox,
+    );
+    parent.children.push(node);
+}
+
+fn push_raw_svg_render_node(
+    tree: &mut PageRenderTree,
+    parent: &mut RenderNode,
+    bbox: BoundingBox,
+    svg: String,
+) {
+    let node_id = tree.next_id();
+    let node = RenderNode::new(
+        node_id,
+        RenderNodeType::RawSvg(crate::renderer::render_tree::RawSvgNode { svg }),
+        bbox,
+    );
+    parent.children.push(node);
+}
+
+fn ole_chart_fallback_label(message: impl AsRef<str>, bin_data_id: u32) -> String {
+    format!("{} (BinData #{bin_data_id})", message.as_ref())
+}
+
 fn measure_composed_text_range_width(
     composed: &ComposedParagraph,
     styles: &ResolvedStyleSet,
@@ -1454,18 +1494,57 @@ impl LayoutEngine {
                                 {
                                     let svg_fragment =
                                         chart.render_svg(render_x, render_y, render_w, render_h);
-                                    let node_id = tree.next_id();
-                                    let node = RenderNode::new(
-                                        node_id,
-                                        RenderNodeType::RawSvg(
-                                            crate::renderer::render_tree::RawSvgNode {
-                                                svg: svg_fragment,
-                                            },
-                                        ),
+                                    push_raw_svg_render_node(
+                                        tree,
+                                        parent,
                                         BoundingBox::new(render_x, render_y, render_w, render_h),
+                                        svg_fragment,
                                     );
-                                    parent.children.push(node);
                                     rendered = true;
+                                }
+                            }
+
+                            // Issue #1251: legacy HWP chart `Contents` stream.
+                            if !rendered {
+                                if let Some(raw_contents) = container.raw_contents.as_ref() {
+                                    match crate::ole_chart::parse_ole_chart_contents(raw_contents) {
+                                        Ok(ole_chart) => {
+                                            let svg_fragment =
+                                                crate::ole_chart::render_ole_chart_svg_fragment(
+                                                    &ole_chart,
+                                                    render_x,
+                                                    render_y,
+                                                    render_w,
+                                                    render_h,
+                                                    ole.bin_data_id,
+                                                );
+                                            push_raw_svg_render_node(
+                                                tree,
+                                                parent,
+                                                BoundingBox::new(
+                                                    render_x, render_y, render_w, render_h,
+                                                ),
+                                                svg_fragment,
+                                            );
+                                            rendered = true;
+                                        }
+                                        Err(error) => {
+                                            push_placeholder_render_node(
+                                                tree,
+                                                parent,
+                                                BoundingBox::new(
+                                                    render_x, render_y, render_w, render_h,
+                                                ),
+                                                0xFFFFF4E5,
+                                                0xFFB45F06,
+                                                ole_chart_fallback_label(
+                                                    error.stable_message(),
+                                                    ole.bin_data_id,
+                                                ),
+                                            );
+                                            rendered = true;
+                                        }
+                                    }
                                 }
                             }
 

--- a/tests/issue_1251_ole_chart_contents.rs
+++ b/tests/issue_1251_ole_chart_contents.rs
@@ -1,0 +1,191 @@
+//! Issue #1251: `143E433F503322BD33.hwp` has a chart-like OLE object whose
+//! nested OLE container exposes only a legacy `Contents` stream.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::model::bin_data::BinDataType;
+use rhwp::ole_chart::{
+    ole_chart_ir_json, parse_ole_chart_contents, probe_ole_chart_contents,
+    render_ole_chart_standalone_svg, render_ole_chart_svg_fragment, OleChartType,
+};
+#[cfg(all(not(target_arch = "wasm32"), feature = "charming-renderer"))]
+use rhwp::ole_chart::{render_ole_chart_charming_svg, render_smoke_chart_svg};
+use rhwp::parser::ole_container::parse_ole_container;
+
+fn read_fixture() -> Vec<u8> {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/143E433F503322BD33.hwp");
+    fs::read(&path).unwrap_or_else(|e| panic!("read fixture {}: {}", path.display(), e))
+}
+
+fn bin_data_2_raw_contents() -> Vec<u8> {
+    let doc = rhwp::parse_document(&read_fixture()).expect("parse fixture");
+    let bin_data = doc
+        .doc_info
+        .bin_data_list
+        .get(1)
+        .expect("DocInfo BinData #2");
+
+    assert_eq!(bin_data.data_type, BinDataType::Storage);
+    assert_eq!(bin_data.storage_id, 2);
+    assert_eq!(bin_data.extension.as_deref(), Some("OLE"));
+
+    let content = doc
+        .bin_data_content
+        .iter()
+        .find(|content| content.id == 2)
+        .expect("loaded BinData #2 content");
+    assert_eq!(content.extension, "OLE");
+    assert!(content.data.starts_with(&[0xD0, 0xCF, 0x11, 0xE0]));
+
+    let container = parse_ole_container(&content.data).expect("nested OLE container");
+    assert!(
+        container.ooxml_chart.is_none(),
+        "fixture has no OOXMLChartContents"
+    );
+    assert!(
+        container.preview_emf.is_none(),
+        "fixture has no OlePres000 EMF preview"
+    );
+    assert!(
+        container.native_image.is_none(),
+        "fixture has no native image preview"
+    );
+    container.raw_contents.expect("fixture Contents stream")
+}
+
+#[test]
+fn fixture_has_bin_data_2_ole_contents_only() {
+    let raw_contents = bin_data_2_raw_contents();
+
+    assert_eq!(raw_contents.len(), 9876);
+    assert_eq!(
+        &raw_contents[..16],
+        &[
+            0x00, 0x00, 0x01, 0x00, 0xEC, 0x2E, 0x00, 0x00, 0xEC, 0x2E, 0x00, 0x00, 0x60, 0x00,
+            0x00, 0x00
+        ]
+    );
+}
+
+#[test]
+fn ole_chart_contents_probe_is_stable() {
+    let raw_contents = bin_data_2_raw_contents();
+    let probe = probe_ole_chart_contents(&raw_contents).expect("probe contents");
+
+    assert_eq!(probe.len, 9876);
+    assert_eq!(
+        probe.first_words_le,
+        [0x0001_0000, 0x0000_2EEC, 0x0000_2EEC, 0x0000_0060]
+    );
+    assert!(!probe.has_cfb_magic);
+    assert!(!probe.has_ooxml_chart_marker);
+    assert_eq!(probe.legacy_chart_object_start, Some(0x60));
+    assert!(probe.has_vt_data_grid_marker);
+    assert!(probe.has_vt_chart_title_marker);
+    assert!(probe.likely_legacy_hwp_chart_contents);
+}
+
+#[test]
+fn ole_chart_contents_parse_result_is_stable() {
+    let raw_contents = bin_data_2_raw_contents();
+    let chart = parse_ole_chart_contents(&raw_contents).expect("parse legacy chart contents");
+
+    assert_eq!(chart.chart_type, OleChartType::Unknown);
+    assert_eq!(chart.title.as_deref(), Some("연금 재정 전망"));
+    assert_eq!(chart.categories, ["2010년", "2020년", "2030년", "2040년"]);
+    assert_eq!(chart.series.len(), 3);
+    assert_eq!(chart.series[0].name.as_deref(), Some("적립금"));
+    assert_eq!(chart.series[0].values, [328.0, 812.0, 1702.0, 1477.0]);
+    assert_eq!(chart.series[1].name.as_deref(), Some("수입"));
+    assert_eq!(chart.series[1].values, [50.0, 70.0, 189.0, 191.0]);
+    assert_eq!(chart.series[2].name.as_deref(), Some("지출"));
+    assert_eq!(chart.series[2].values, [11.0, 15.0, 201.0, 289.0]);
+}
+
+#[test]
+fn ole_chart_contents_exposes_renderer_neutral_ir() {
+    let raw_contents = bin_data_2_raw_contents();
+    let chart = parse_ole_chart_contents(&raw_contents).expect("parse legacy chart contents");
+    let json = ole_chart_ir_json(&chart).expect("serialize chart ir");
+
+    assert!(json.contains("\"schema\":\"rhwp.oleChartIr\""));
+    assert!(json.contains("\"chartType\":\"unknown\""));
+    assert!(json.contains("연금 재정 전망"));
+    assert!(json.contains("적립금"));
+}
+
+#[test]
+fn ole_chart_contents_renders_rust_svg_fragment() {
+    let raw_contents = bin_data_2_raw_contents();
+    let chart = parse_ole_chart_contents(&raw_contents).expect("parse legacy chart contents");
+    let svg = render_ole_chart_svg_fragment(&chart, 10.0, 20.0, 420.0, 320.0, 2);
+
+    assert!(svg.contains("hwp-ole-chart-rust-svg"));
+    assert!(svg.contains("data-rhwp-ole-chart-renderer=\"rust-svg\""));
+    assert!(svg.contains("연금 재정 전망"));
+    assert!(svg.contains("적립금"));
+    assert!(!svg.contains("charming SSR unavailable"));
+}
+
+#[test]
+fn ole_chart_contents_renders_standalone_rust_svg() {
+    let raw_contents = bin_data_2_raw_contents();
+    let chart = parse_ole_chart_contents(&raw_contents).expect("parse legacy chart contents");
+    let svg = render_ole_chart_standalone_svg(&chart, 420, 320);
+
+    assert!(svg.starts_with("<svg"), "unexpected SVG prefix: {svg}");
+    assert!(svg.contains("연금 재정 전망"));
+    assert!(svg.contains("적립금"));
+    assert!(!svg.contains("charming SSR unavailable"));
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "charming-renderer"))]
+#[test]
+fn ole_chart_contents_renders_charming_svg_adapter() {
+    let raw_contents = bin_data_2_raw_contents();
+    let chart = parse_ole_chart_contents(&raw_contents).expect("parse legacy chart contents");
+    let svg = render_ole_chart_charming_svg(&chart, 420, 320).expect("render parsed chart");
+
+    assert!(
+        svg.starts_with("<svg"),
+        "unexpected charming SVG prefix: {svg}"
+    );
+    assert!(
+        svg.contains("연금"),
+        "rendered SVG should include chart title"
+    );
+    assert!(
+        svg.contains("적립금"),
+        "rendered SVG should include series name"
+    );
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+#[test]
+fn issue_1251_svg_uses_legacy_ole_chart_renderer() {
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&read_fixture()).expect("parse fixture");
+    let svg = doc.render_page_svg_native(0).expect("render page svg");
+
+    assert!(svg.contains("hwp-ole-chart"));
+    assert!(svg.contains("hwp-ole-chart-rust-svg"));
+    assert!(svg.contains("연금 재정 전망"));
+    assert!(svg.contains("적립금"));
+    assert!(!svg.contains("OLE 개체 (BinData #2)"));
+    assert!(!svg.contains("OLE 차트 미지원"));
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "charming-renderer"))]
+#[test]
+fn charming_ssr_smoke_renders_svg_string() {
+    let svg = render_smoke_chart_svg(420, 320).expect("charming SSR SVG render");
+
+    assert!(
+        svg.starts_with("<svg"),
+        "unexpected charming SVG prefix: {svg}"
+    );
+    assert!(
+        svg.contains("alpha"),
+        "charming SVG should include sample data labels"
+    );
+}


### PR DESCRIPTION
## 요약

Refs #1251.

이 PR은 legacy HWP OLE 차트의 `/Contents` 스트림을 파싱하고 렌더링하는 첫 경로를 추가합니다.

- legacy `Contents` 스트림만 가진 nested OLE 차트 데이터를 감지합니다.
- fixture의 차트 제목, 카테고리, 시리즈 이름, 숫자 데이터를 renderer-neutral `OleChart` IR로 파싱합니다.
- native export와 WASM Studio가 같은 경로를 쓰도록 Rust SVG renderer 결과를 `RawSvg` page layer로 렌더링합니다.
- `yuankunzhang/charming`은 `charming-renderer` feature 뒤의 optional native SSR adapter로 유지합니다.

## 배경

`samples/143E433F503322BD33.hwp`의 차트는 `BinData #2`에 저장되어 있습니다.
이 nested OLE 객체에는 `OOXMLChartContents`, `OlePres000`, native image preview가 없고, 이 fixture에서 사용할 수 있는 payload는 legacy `Contents` 스트림뿐입니다.
기존 렌더러는 이 경우 generic OLE placeholder로 떨어졌습니다.

maintainer가 `yuankunzhang/charming` 활용 가능성을 검토하라고 지시했습니다.
검토 결과, `charming`은 chart rendering adapter로는 유효하지만 Hancom legacy OLE chart data parser는 아닙니다.
따라서 HWP/OLE `/Contents` parser는 rhwp 내부에 두는 방향으로 구현했습니다.

## 참고한 공식 문서

- 한컴 HWP/OWPML 형식 다운로드 센터: https://www.hancom.co.kr/support/downloadCenter/hwpOwpml
- 한컴 HWP 5.0 문서 형식 revision 1.3: https://cdn.hancom.com/link/docs/%ED%95%9C%EA%B8%80%EB%AC%B8%EC%84%9C%ED%8C%8C%EC%9D%BC%ED%98%95%EC%8B%9D_5.0_revision1.3.pdf
- 한컴 차트 문서 형식 revision 1.2: https://cdn.hancom.com/link/docs/%ED%95%9C%EA%B8%80%EB%AC%B8%EC%84%9C%ED%8C%8C%EC%9D%BC%ED%98%95%EC%8B%9D_%EC%B0%A8%ED%8A%B8_revision1.2.pdf
- Microsoft Compound File Binary File Format, MS-CFB: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-cfb/53989ce4-7b05-4f8d-829b-d08d6148375b
- Microsoft OLE Data Structures, MS-OLEDS: https://learn.microsoft.com/en-us/openspecs/windows_protocols/ms-oleds/85583d21-c1cf-4afe-a35f-d6701c5fbb6f
- charming upstream repository: https://github.com/yuankunzhang/charming

## 결정 사항

### parser는 rhwp 내부에 둠

`charming`은 이미 구조화된 chart model을 받아 렌더링하는 라이브러리입니다.
한컴 차트 형식의 `VtDataGrid`, `VtChartTitle` 같은 legacy chart object는 OLE `Contents` 스트림 안에 있으므로, 이 바이너리 해석은 rhwp 내부 parser가 담당해야 합니다.

### 기본 렌더러는 Rust SVG renderer로 둠

기본 렌더링 경로는 `src/ole_chart/svg_renderer.rs`의 Rust SVG renderer입니다.
이 방식은 native export와 WASM Studio가 같은 renderer를 사용하게 하며, upstream에서 진행 중인 `PageLayerTree`, Skia, CanvasKit 등 multi-backend renderer 방향과도 맞습니다.

### charming은 optional native adapter로 유지

`charming`은 다음 feature 뒤에 둔 optional native SSR adapter입니다.

```toml
charming-renderer = ["dep:charming"]
```

browser/WASM의 `charming::WasmRenderer`를 기본 경로로 선택하지 않은 이유는 DOM element id와 browser global ECharts runtime이 필요하기 때문입니다.
그 경로를 기본으로 삼으면 chart rendering이 renderer-owned page layer가 아니라 browser-side DOM side effect가 됩니다.
또한 Studio에 JavaScript ECharts runtime dependency를 추가하게 됩니다.

## 구현 내용

- `src/ole_chart/parser.rs`
  - legacy `ChartOBJ` layout을 probe합니다.
  - `VtDataGrid`, `VtChartTitle` marker를 감지합니다.
  - dense numeric `f64` run을 우선 추출하고, 실패할 때만 기대 개수와 정확히 맞는 sparse candidate를 fallback으로 허용합니다.
- `src/ole_chart/ir.rs`
  - renderer-neutral chart IR serialization helper를 제공합니다.
- `src/ole_chart/svg_renderer.rs`
  - `RawSvg`용 `hwp-ole-chart-rust-svg` SVG fragment를 생성합니다.
- `src/ole_chart/charming_renderer.rs`
  - optional native `charming` SVG export smoke coverage를 제공합니다.
- `src/renderer/layout/shape_layout.rs`
  - 기존 preview/native-image/generic-placeholder fallback 전에 `nested OLE Contents -> ole_chart parser -> Rust SVG RawSvg` 경로를 추가합니다.

## 검증

`upstream/devel` 최신 기준으로 rebase한 뒤 아래 검증을 통과했습니다.

```text
cargo fmt --all -- --check
cargo test
cargo clippy -- -D warnings
cargo test --features charming-renderer --test issue_1251_ole_chart_contents -- --nocapture
cargo check --target wasm32-unknown-unknown --lib
cd rhwp-studio && npm run build
```

## 알려진 제한

차트 데이터는 복원하지만, 한컴 PDF reference와 시각적으로 완전히 같지는 않습니다.

현재 알려진 차이는 다음과 같습니다.

- y-axis nice scale을 아직 파싱하지 않으므로, 현재 Rust SVG renderer는 한컴처럼 `0-2000 / 500 step` 축을 쓰지 않고 데이터 최댓값 기준 축을 사용합니다.
- palette, legend 위치, title spacing, plot margin, border, bar gap은 아직 renderer 기본값입니다.
- 차트 외부의 본문 layout/text 차이도 별도로 존재합니다.

이번 PR에서는 fixture-specific heuristic으로 PDF에 맞추지 않았습니다.
pixel-level chart fidelity는 axis, legend, style, layout object graph를 더 파싱하는 후속 작업으로 다루는 편이 안전합니다.

## 추가 분석 문서

- renderer 결정 기록: `mydocs/tech/hwp_ole_chart_renderer_architecture_decision_1251.md`
- 한컴 PDF 대비 visual diff 분석: `mydocs/tech/hwp_ole_chart_visual_diff_against_hancom_pdf_1251.md`
- 최종 보고서: `mydocs/report/task_m100_1251_report.md`
- PR 초안 보고서: `mydocs/report/task_m100_1251_pr_draft.md`

## 리뷰 포인트

핵심 리뷰 포인트는 기본 browser/WASM 경로를 현재처럼 renderer-owned page layer로 유지할지, 아니면 `charming::WasmRenderer`를 통해 browser ECharts runtime 경로를 선호할지입니다.
현재 upstream의 multi-backend renderer 방향을 고려해, 이 PR은 Rust SVG `RawSvg` 경로를 기본으로 선택하고 `charming`은 optional adapter로 유지했습니다.
