### PR TITLE
Task #1271: HWPX 글뒤로 표 분할로 인한 바탕쪽 홀짝 밀림 수정

### DIFF
--- a/mydocs/orders/20260603.md
+++ b/mydocs/orders/20260603.md
@@ -6,3 +6,4 @@
 |---|---|---|---|
 | [#1186](https://github.com/edwardkim/rhwp/issues/1186) | chore: cargo clippy --all-targets -- -D warnings baseline 정리 | 검증 완료 | `local/task_m100_1186` 브랜치. `cargo clippy --all-targets -- -D warnings`, `cargo test --tests` 통과 |
 | [#1261](https://github.com/edwardkim/rhwp/issues/1261) | 3-10월 5쪽 문28 조건 박스 내부 겹침 | Stage4 자동 검증 완료 | `local/task_m100_1261` 브랜치. 문28 수정 커밋 `b64e5afb`, Stage2 커밋 `6aa638c6`, Stage3 커밋 `de8424e1` 완료. 문8 미주 경계는 실제 콘텐츠 하단 + `미주 사이` 간격을 적용했고, 문12 overflow는 확장 `미주 사이` 단일줄 경계에서 page-path vpos forward를 공통 억제해 자동 검증 통과. WASM/Studio 수동 시각 검증 대기 |
+| [#1271](https://github.com/edwardkim/rhwp/issues/1271) | HWPX 글뒤로 표 분할로 인한 바탕쪽 홀짝 밀림 수정 | 검증 완료 | Stage 5 전체 회귀 검증 완료. rhwp-studio 시각검증 서버 실행 중 |

--- a/mydocs/plans/task_m100_1271.md
+++ b/mydocs/plans/task_m100_1271.md
@@ -1,0 +1,238 @@
+# 수행계획서 — Task M100-1271: HWPX 글뒤로 표 분할로 인한 바탕쪽 홀짝 밀림 수정
+
+## 1. 이슈
+
+- GitHub Issue: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 제목: `HWPX: paper-anchored BehindText RowBreak table shifts masterpage parity`
+- 대상 마일스톤: M100 / v1.0.0 편집 기반
+- 브랜치: `local/task1271`
+- 관련 이슈: [#1201](https://github.com/edwardkim/rhwp/issues/1201)
+- 관련 PR: [#1242](https://github.com/edwardkim/rhwp/pull/1242)
+
+## 2. 문제 요약
+
+#1201 작업으로 HWPX masterpage `idRef` 연결과 `EVEN`/`ODD` 타입 보존은 보강되었다.
+그러나 `[2027] 온새미로 1 본교재.hwpx`에서는 바탕쪽이 여전히 PDF 정답지와 반대로 적용되는 것처럼 보인다.
+
+이번 조사에서 확인된 직접 원인은 masterpage 연결 실패가 아니라 앞쪽 페이지네이션 오프셋이다.
+정답 PDF는 46쪽인데 현재 기본 TypesetEngine은 같은 HWPX를 47쪽으로 페이지네이션한다.
+section0의 큰 `BEHIND_TEXT` 표가 `PartialTable` continuation으로 분할되어 PDF에는 없는 페이지가 하나 생기고, 이후 본문 시작 쪽번호가 PDF 기준 4쪽에서 rhwp 기준 5쪽으로 밀린다.
+
+이 때문에 이후 페이지의 실제 홀짝이 한 쪽씩 뒤집혀 보이고, masterpage `Even`/`Odd` 적용도 정답지와 어긋난다.
+
+## 3. 재현 구조
+
+대상 샘플:
+
+```text
+원본 HWPX: samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+정답 PDF:  pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf
+```
+
+PDF 기준:
+
+```text
+PDF 1쪽: 표지
+PDF 2쪽: MEMO
+PDF 3쪽: 1주차 표지
+PDF 4쪽: 본문 시작, 쪽번호 4
+총 46쪽
+```
+
+현재 rhwp 기본 TypesetEngine 기준:
+
+```text
+rhwp 1쪽: 표지
+rhwp 2쪽: section0 pi=3 PartialTable continuation
+rhwp 3쪽: MEMO
+rhwp 4쪽: 1주차 표지
+rhwp 5쪽: 본문 시작, page_num=5
+총 47쪽
+```
+
+`RHWP_USE_PAGINATOR=1` fallback 기준:
+
+```text
+rhwp 1쪽: 표지
+rhwp 2쪽: MEMO
+rhwp 3쪽: 1주차 표지
+rhwp 4쪽: 본문 시작, page_num=4
+```
+
+따라서 기본 TypesetEngine 경로의 표 처리 차이가 우선 분석 대상이다.
+
+## 4. 원인 후보
+
+### 4.1 paper-anchored BehindText 다행 표가 flow table로 분할됨
+
+section0 `pi=3`에는 다음 성격의 표가 있다.
+
+```text
+textWrap=BEHIND_TEXT
+treatAsChar=false
+vertRelTo=PAPER
+horzRelTo=PAPER
+pageBreak=CELL -> TablePageBreak::RowBreak
+2행 x 1열
+크기 약 168.0mm x 247.0mm
+```
+
+현재 `src/renderer/typeset.rs`는 `InFrontOfText`/`BehindText` 표를 Shape처럼 out-of-flow로 처리하는 shortcut을 갖고 있다.
+하지만 `row_count > 1`이고 측정 높이가 본문 가용 높이보다 큰 경우 `oversized_multirow`로 판단해 shortcut에서 제외한다.
+대상 표는 이 조건 때문에 `typeset_block_table` 경로를 타고 `PartialTable`로 분할된다.
+
+이 표는 문서 앞쪽 표지/목차 배경성 개체로 보이며, PDF 정답지와 fallback Paginator 모두 별도 continuation 페이지를 만들지 않는다.
+따라서 TypesetEngine의 `oversized_multirow` 예외를 더 정교하게 좁힐 필요가 있다.
+
+### 4.2 masterpage 선택 순서가 최종 쪽번호 보정 전임
+
+`src/document_core/queries/rendering.rs`의 현재 흐름은 다음과 같다.
+
+```text
+1. section-local page.page_number 기준으로 active_master_page 선택
+2. 구역 간 page_number carry 보정
+3. header/footer 상속은 보정 후 처리
+```
+
+이번 현상의 1차 원인은 페이지 수 오프셋이지만, 구역 경계 이후 masterpage 홀짝 선택은 최종 쪽번호 기준이어야 한다.
+페이지네이션 오프셋을 해결한 뒤에도 masterpage 선택 순서가 남아 있으면 다른 구역 연속 번호 문서에서 유사 회귀가 발생할 수 있다.
+
+## 5. 작업 범위
+
+이번 이슈의 범위:
+
+- 대상 샘플의 앞부분 페이지네이션 오프셋 원인 확정
+- TypesetEngine의 `BehindText`/`InFrontOfText` 표 out-of-flow 처리 조건 보강
+- paper-anchored 배경성 표와 본문 flow 표를 구분하는 조건 검토
+- 구역 간 최종 쪽번호 기준 masterpage 홀짝 선택 보정 검토
+- 대상 샘플 및 기존 BehindText/InFrontOfText 표 회귀 테스트 추가 또는 보강
+
+이번 이슈의 비범위:
+
+- #1201의 HWPX masterpage `idRef` 연결 재구현
+- HWP5 raw parser의 바탕쪽 LIST_HEADER 순서 규칙 변경
+- 전체 표 분할 알고리즘 재작성
+- 폰트 차이, 이미지 품질, 텍스트 줄바꿈 정밀 정합
+- 한컴 PDF와 모든 페이지의 픽셀 단위 완전 일치
+
+## 6. 수정 후보 파일
+
+| 파일 | 변경 후보 |
+|------|-----------|
+| `src/renderer/typeset.rs` | `BehindText`/`InFrontOfText` 다행 표의 out-of-flow 판단 조건 보강, 회귀 테스트 추가 |
+| `src/document_core/queries/rendering.rs` | masterpage 선택을 최종 쪽번호 보정 이후 기준으로 맞추는 보정 검토 |
+| `tests/` 또는 `src/renderer/typeset.rs` 테스트 모듈 | #1271 대상 구조 회귀 테스트 추가 |
+| `mydocs/working/task_m100_1271_stage*.md` | 단계별 조사 및 구현 결과 기록 |
+
+## 7. 구현 방향 후보
+
+### 후보 A: paper-anchored BehindText 표를 out-of-flow로 우선 처리
+
+`TextWrap::BehindText` 또는 `TextWrap::InFrontOfText`이고 `VertRelTo::Paper`인 비-TAC 표는, 다행 표라도 Shape처럼 `PageItem::Shape`로 배치해 본문 흐름과 페이지 분할에서 제외한다.
+
+장점:
+
+- 대상 샘플의 직접 원인에 가장 좁게 접근한다.
+- fallback Paginator 및 PDF 관찰 결과와 맞는다.
+
+위험:
+
+- 실제 본문 내용 표인데 paper anchor와 BehindText를 가진 대형 표가 있을 경우 분할이 사라질 수 있다.
+- #992에서 의도한 “본문보다 큰 다행 표는 분할 필요” 조건과 충돌할 수 있다.
+
+### 후보 B: 배경성 표 판별 조건을 추가한다
+
+paper anchor, BehindText/InFrontOfText, host paragraph의 명시 pageBreak, page background image/표지성 section 패턴 등을 조합해 표지/배경성 개체만 out-of-flow로 처리한다.
+
+장점:
+
+- 회귀 범위를 더 좁힐 수 있다.
+
+위험:
+
+- 조건이 과하게 샘플 특화될 수 있다.
+- 한컴의 일반 규칙보다 ad hoc 규칙이 늘어날 수 있다.
+
+### 후보 C: masterpage 선택 순서만 보정한다
+
+구역 간 쪽번호 보정 이후에 active masterpage를 다시 선택하도록 바꾼다.
+
+장점:
+
+- 구역 연속 번호 문서에서 논리적으로 더 맞는 처리다.
+
+위험:
+
+- 이번 샘플의 47쪽 페이지네이션 자체는 해결하지 못한다.
+- PDF와 페이지 대응이 계속 어긋나면 시각 증상은 남는다.
+
+## 8. 기본안
+
+기본안은 A와 C를 결합하되, A의 조건은 과도하게 넓히지 않고 paper-anchored 비-TAC `BehindText`/`InFrontOfText` 표에 한정해 검토한다.
+
+```text
+1. 대상 표가 현재 shortcut에서 제외되는 경로를 테스트로 고정한다.
+2. paper-anchored BehindText/InFrontOfText 표의 out-of-flow 조건을 보강한다.
+3. #703, #775, #992 계열 기존 테스트 영향 여부를 확인한다.
+4. 구역 간 page_number carry 이후 masterpage 선택 기준을 재검토한다.
+5. 대상 샘플 dump-pages가 46쪽이고 2/3/4쪽 대응이 PDF와 맞는지 확인한다.
+```
+
+## 9. 검증 계획
+
+구조 검증:
+
+```text
+rhwp dump-pages samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+RHWP_USE_PAGINATOR=1 rhwp dump-pages samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+```
+
+확인 포인트:
+
+```text
+1. 기본 TypesetEngine 총 페이지 수가 46쪽인가
+2. 2쪽이 MEMO인가
+3. 3쪽이 1주차 표지인가
+4. 4쪽이 section1 본문 시작이고 page_num=4인가
+5. 4쪽 이후 Even/Odd masterpage가 PDF 정답지와 같은 홀짝으로 선택되는가
+```
+
+단위/회귀 검증:
+
+```text
+cargo test --lib typeset
+cargo test --test issue_1197_svg_object_zorder
+cargo test --lib hwpx
+```
+
+전체 검증 후보:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+시각 검증 후보:
+
+```text
+rhwp export-svg samples/hwpx/[2027] 온새미로 1 본교재.hwpx -p 1 --debug-overlay
+rhwp export-svg samples/hwpx/[2027] 온새미로 1 본교재.hwpx -p 2 --debug-overlay
+rhwp export-svg samples/hwpx/[2027] 온새미로 1 본교재.hwpx -p 3 --debug-overlay
+rhwp export-svg samples/hwpx/[2027] 온새미로 1 본교재.hwpx -p 4 --debug-overlay
+```
+
+## 10. 완료 기준
+
+```text
+1. 대상 HWPX의 기본 TypesetEngine 페이지 수가 PDF와 같은 46쪽이다.
+2. section0 앞부분 페이지 대응이 PDF와 일치한다.
+3. section1 본문 시작이 page_num=4로 잡힌다.
+4. masterpage Even/Odd 선택이 최종 쪽번호 기준으로 정합하다.
+5. 기존 BehindText/InFrontOfText 표 회귀 테스트가 통과한다.
+6. 단계별 완료 보고서에 변경 내용과 검증 결과가 기록된다.
+```
+
+## 11. 승인 요청
+
+위 계획에 따라 구현계획서 작성 단계로 진행한다.

--- a/mydocs/plans/task_m100_1271_impl.md
+++ b/mydocs/plans/task_m100_1271_impl.md
@@ -1,0 +1,239 @@
+# 구현계획서 — Task M100-1271: HWPX 글뒤로 표 분할과 바탕쪽 홀짝 보정
+
+## 설계 요약
+
+대상 증상은 두 층으로 분리한다.
+
+```text
+1. 페이지네이션 오프셋
+   section0 pi=3 의 paper-anchored BEHIND_TEXT RowBreak 표가
+   TypesetEngine 에서 PartialTable 로 분할되어 PDF에 없는 1쪽을 만든다.
+
+2. masterpage 선택 순서
+   active_master_page 선택이 구역 간 page_number carry 보정 전에 수행되어,
+   최종 쪽번호 기준 Even/Odd 재선택이 보장되지 않는다.
+```
+
+이번 구현은 1번을 우선 해결하고, 2번은 같은 이슈 안에서 구조적 회귀 방지 보정으로 처리한다.
+단, HWP5 raw parser의 바탕쪽 순서 규칙과 HWPX masterpage `idRef` 연결 로직은 변경하지 않는다.
+
+## Stage 1 — 회귀 재현 테스트와 진단 고정
+
+**목표**: 대상 결함을 재현 가능한 테스트와 dump 기준으로 고정한다.
+
+변경 후보:
+
+- `tests/issue_1271_hwpx_behind_text_table.rs` 또는 `src/renderer/typeset.rs` 테스트 모듈
+  - 대상 샘플 기반 smoke test:
+    - `samples/hwpx/[2027] 온새미로 1 본교재.hwpx` 로드
+    - 기본 TypesetEngine 페이지 수와 앞 4쪽 배치 확인
+  - synthetic unit test:
+    - `TextWrap::BehindText`
+    - `VertRelTo::Paper`
+    - `treat_as_char=false`
+    - `row_count > 1`
+    - `page_break=RowBreak`
+    - 본문 가용 높이보다 큰 measured height
+    - 기대: 후속 명시 쪽나누기 문단이 PDF 대응처럼 다음 페이지로 오고, 중간 `PartialTable` 페이지가 생기지 않음
+
+진단 명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 1
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 2
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+env RHWP_USE_PAGINATOR=1 cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 1
+```
+
+주의:
+
+- 테스트가 너무 무거우면 sample 전체 페이지 수 테스트는 `#[ignore]` 또는 문서화된 smoke로 두고, synthetic unit test를 필수 회귀 테스트로 둔다.
+- `pdf-large` PDF는 테스트 입력으로 직접 쓰지 않는다. PDF는 시각 기준과 수동 검증 자료로만 사용한다.
+
+보고서:
+
+- `mydocs/working/task_m100_1271_stage1.md`
+
+## Stage 2 — TypesetEngine paper-anchored BehindText 표 out-of-flow 보정
+
+**목표**: paper-anchored 배경성 `BehindText`/`InFrontOfText` 표가 본문 흐름과 페이지 분할을 밀지 않게 한다.
+
+변경 후보:
+
+- `src/renderer/typeset.rs`
+  - 현재 `oversized_multirow` 조건은 다행 표가 본문보다 크면 out-of-flow shortcut에서 제외한다.
+  - 이 조건을 보강해 다음 조건을 만족하는 표는 `PageItem::Shape` 경로로 유지한다.
+
+후보 조건:
+
+```text
+!table.common.treat_as_char
+text_wrap in {BehindText, InFrontOfText}
+st.col_count == 1
+vert_rel_to == Paper
+horz_rel_to == Paper 또는 Absolute/Paper 계열 검토
+```
+
+설계 의도:
+
+- paper-anchored `BehindText`/`InFrontOfText`는 본문 흐름의 높이 계산 대상이 아니라 페이지 위 절대 배치 개체로 본다.
+- `TopAndBottom` 표, para-relative flow 표, 다단 분배가 필요한 표는 기존 `typeset_block_table` 경로를 유지한다.
+- #992에서 의도한 “본문보다 큰 다행 표는 분할 필요” 정책은 paper-anchored 배경성 표를 제외한 나머지에 유지한다.
+
+검증:
+
+```text
+cargo test --lib typeset_703
+cargo test --lib issue_1271
+cargo test --lib typeset
+```
+
+필요 시 명령은 실제 테스트명에 맞춰 조정한다.
+
+보고서:
+
+- `mydocs/working/task_m100_1271_stage2.md`
+
+## Stage 3 — 최종 쪽번호 기준 masterpage 선택 보정
+
+**목표**: 구역 간 쪽번호 carry 보정 이후에도 `active_master_page`가 최종 쪽번호의 홀짝 기준으로 선택되게 한다.
+
+변경 후보:
+
+- `src/document_core/queries/rendering.rs`
+  - masterpage 선택 블록을 helper로 분리한다.
+  - helper 입력:
+
+```rust
+fn assign_master_pages_for_section(
+    result: &mut PaginationResult,
+    section_index: usize,
+    section: &Section,
+)
+```
+
+  - 기존 동작 보존:
+    - 기본 `Odd`/`Even`/`Both` 선택
+    - `hide_master_page` 첫 쪽 감추기
+    - 마지막 쪽 확장 바탕쪽 처리
+    - overlap/replace_base 처리
+  - 호출 시점:
+    - 구역 간 `page_number` carry 보정 이후 최종 쪽번호 기준으로 한 번 호출
+    - 기존 선행 호출은 제거하거나, carry 후 재호출로 덮어써 중복 상태를 피한다.
+
+주의:
+
+- `is_first_page`와 `is_last`는 구역 내부 페이지 인덱스 기준을 유지한다.
+- `is_odd`만 최종 `page.page_number` 기준이어야 한다.
+- extra master pages는 재호출 전에 clear하여 중복 push를 막는다.
+
+테스트 후보:
+
+- 작은 synthetic document:
+  - section0이 3쪽 또는 4쪽으로 끝나는 케이스
+  - section1에 Even/Odd masterpage가 있고 NewNumber가 없음
+  - section1 첫 페이지 active masterpage가 carry 후 최종 쪽번호 홀짝과 일치하는지 확인
+
+보고서:
+
+- `mydocs/working/task_m100_1271_stage3.md`
+
+## Stage 4 — 대상 샘플 구조/시각 검증
+
+**목표**: 실제 #1271 샘플에서 PDF와 같은 앞부분 페이지 대응과 바탕쪽 홀짝을 확인한다.
+
+검증 명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx"
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 1
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 2
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+```
+
+확인 항목:
+
+```text
+1. 총 페이지 수: 46쪽
+2. 2쪽: MEMO
+3. 3쪽: 1주차 표지
+4. 4쪽: section1 본문 시작, page_num=4
+5. 5쪽 이후에도 PDF와 페이지 대응이 1쪽 밀리지 않음
+```
+
+시각 검증 후보:
+
+```text
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271 --debug-overlay -p 1
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271 --debug-overlay -p 2
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271 --debug-overlay -p 3
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271 --debug-overlay -p 4
+```
+
+PDF 참고:
+
+```text
+pdfinfo "pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf"
+```
+
+보고서:
+
+- `mydocs/working/task_m100_1271_stage4.md`
+
+## Stage 5 — 회귀 검증과 최종 보고
+
+**목표**: 대상 수정이 기존 표 조판, masterpage, HWPX 파서 회귀를 만들지 않는지 확인한다.
+
+필수 검증:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+집중 검증:
+
+```text
+cargo test --lib typeset
+cargo test --lib hwpx
+cargo test --test issue_1197_svg_object_zorder
+```
+
+필요 시 확장 검증:
+
+```text
+cargo clippy -- -D warnings
+```
+
+최종 산출물:
+
+- `mydocs/working/task_m100_1271_stage5.md`
+- `mydocs/report/task_m100_1271_report.md`
+- `mydocs/orders/20260603.md` 상태 갱신
+
+## 제외 범위
+
+- HWPX masterpage `idRef` 연결 로직 재작성
+- HWP5 raw 바탕쪽 순서 규칙 변경
+- 모든 `BehindText` 다행 표의 일괄 out-of-flow 처리
+- 다단 문서의 `BehindText`/`InFrontOfText` 표 분배 정책 변경
+- PDF 파일을 자동 테스트 fixture로 직접 사용하는 검증
+
+## 완료 판정
+
+완료 조건:
+
+```text
+1. 대상 HWPX의 기본 TypesetEngine 페이지 수가 46쪽이다.
+2. section0 앞부분 페이지 대응이 PDF와 일치한다.
+3. section1 본문 시작이 page_num=4로 잡힌다.
+4. masterpage Even/Odd 선택이 최종 쪽번호 기준으로 정합하다.
+5. 기존 #703/#775/#992 계열 표 조판 회귀가 없다.
+6. 단계별 완료 보고서와 최종 보고서가 작성된다.
+```
+
+## 작업지시자 승인 요청
+
+본 구현계획이 승인되면 Stage 1부터 소스 수정과 회귀 테스트 작성을 시작한다.
+첫 수정 범위는 `src/renderer/typeset.rs` 및 #1271 회귀 테스트로 제한한다.

--- a/mydocs/report/task_m100_1271_report.md
+++ b/mydocs/report/task_m100_1271_report.md
@@ -1,0 +1,73 @@
+# 최종 보고 — Task M100-1271
+
+## 이슈
+
+- GitHub: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 제목: HWPX 글뒤로 표 분할로 인한 바탕쪽 홀짝 밀림 수정
+
+## 원인
+
+대상 샘플 `samples/hwpx/[2027] 온새미로 1 본교재.hwpx` 의 앞부분에서
+`Paper` 기준으로 배치된 `BehindText` 표가 본문 흐름 표처럼 분할되어 PDF 기준본에 없는
+`PartialTable` 페이지를 만들었다.
+
+그 결과 2쪽 MEMO, 3쪽 1주차 간지, 4쪽 본문 시작 대응이 한 쪽씩 밀릴 수 있었고,
+구역 간 쪽번호 carry 전에 바탕쪽을 선택하던 기존 순서와 결합해 홀수/짝수 바탕쪽 선택이
+최종 쪽번호와 달라질 수 있었다.
+
+## 변경
+
+- `src/renderer/typeset.rs`
+  - `Paper` 기준의 배경성 `BehindText`/`InFrontOfText` 표는 본문 흐름을 밀지 않는
+    shape 경로로 유지하도록 보정했다.
+  - #992 성격의 oversized multirow table 분할 정책은 paper-anchored overlay table 을
+    제외한 나머지에 유지했다.
+
+- `src/document_core/queries/rendering.rs`
+  - 바탕쪽 선택 로직을 `assign_master_pages_for_section` helper 로 분리했다.
+  - 구역 간 page number carry 보정 이후 최종 `page_number` 기준으로 `Odd`/`Even`
+    바탕쪽을 선택하도록 호출 시점을 변경했다.
+  - 기존 첫 쪽 바탕쪽 감추기, 마지막 쪽 확장 바탕쪽, `overlap`/`replace_base` 처리는 유지했다.
+
+- `tests/issue_1271_hwpx_behind_text_table.rs`
+  - 대상 HWPX 샘플의 앞부분 페이지 대응을 고정하는 통합 테스트를 추가했다.
+
+## 검증
+
+통과:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+주요 확인:
+
+- 기준 PDF와 HWPX 렌더가 모두 46쪽이다.
+- 2쪽은 `MEMO`, 3쪽은 `1주차`, 4쪽은 `section=1, page_num=4` 본문 시작이다.
+- 4쪽은 짝수쪽 바탕쪽, 5쪽은 홀수쪽 바탕쪽 방향과 일치한다.
+- `issue_703`, `issue_775`, `issue_1156_rowbreak_fragment_fit`, `issue_1197_svg_object_zorder`
+  등 관련 회귀 테스트가 통과했다.
+
+## rhwp-studio 시각검증
+
+현재 수정본을 반영한 WASM 을 빌드했고, rhwp-studio 서버를 실행했다.
+
+```text
+http://127.0.0.1:7700/
+```
+
+대상 샘플 자동 로드 URL:
+
+```text
+http://127.0.0.1:7700/?url=/samples/hwpx/%5B2027%5D%20%EC%98%A8%EC%83%88%EB%AF%B8%EB%A1%9C%201%20%EB%B3%B8%EA%B5%90%EC%9E%AC.hwpx&filename=%5B2027%5D%20%EC%98%A8%EC%83%88%EB%AF%B8%EB%A1%9C%201%20%EB%B3%B8%EA%B5%90%EC%9E%AC.hwpx
+```
+
+## 남은 판단
+
+- 로컬 테스트와 대상 샘플 검증 기준에서는 수정이 유효하다.
+- Docker daemon 이 실행 중이 아니어서 Docker 기반 WASM 빌드는 수행하지 못했고,
+  시각검증용 WASM 은 로컬 `wasm-pack build --target web` 으로 갱신했다.
+- 작업지시자 시각검증 후 PR 작성/푸시 단계로 진행하면 된다.

--- a/mydocs/working/task_m100_1271_stage1.md
+++ b/mydocs/working/task_m100_1271_stage1.md
@@ -1,0 +1,58 @@
+# Stage 1 보고 — Task M100-1271
+
+## 범위
+
+- 이슈: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 단계: 회귀 재현 테스트와 진단 고정
+- 대상 샘플: `samples/hwpx/[2027] 온새미로 1 본교재.hwpx`
+
+## 변경
+
+- `tests/issue_1271_hwpx_behind_text_table.rs` 추가
+  - 한컴 PDF 기준 앞쪽 페이지 대응을 테스트로 고정한다.
+  - 기대 배치:
+    - page 2: `MEMO`
+    - page 3: 1주차 표지 도형
+    - page 4: section 1 본문 시작, `page_num=4`
+  - 회귀 원인으로 관찰된 `PartialTable pi=3 ci=0` 이 page 2 에 나타나지 않아야 함을 검증한다.
+
+## 재현 결과
+
+명령:
+
+```text
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+결과:
+
+```text
+test onsaemiro_front_matter_is_not_shifted_by_behind_text_table_fragment ... FAILED
+```
+
+핵심 실패 출력:
+
+```text
+PDF 기준 page 2 는 MEMO 쪽이어야 한다.
+
+=== 페이지 2 (global_idx=1, section=0, page_num=2) ===
+  단 0 (items=2, used=116.0px)
+    PartialTable   pi=3 ci=0  rows=0..2  cont=true  2x1  vpos=5868  start_cut=[32] end_cut=[]
+    Shape          pi=3 ci=1    vpos=5868
+```
+
+## 판단
+
+- 현재 기본 TypesetEngine 은 section 0 paragraph 3 의 글뒤로 표를 본문 흐름의 `PartialTable` 로 분할한다.
+- 이 때문에 PDF 기준 page 2 에 있어야 할 `MEMO`가 page 3 으로 밀리고, page 4 에 있어야 할 section 1 본문 시작도 뒤로 밀린다.
+- Stage 2 에서는 `src/renderer/typeset.rs` 의 paper-anchored `BehindText`/`InFrontOfText` 표 out-of-flow 판정을 보정한다.
+
+## 검증
+
+```text
+cargo fmt
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+- `cargo fmt`: 통과
+- `cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture`: 의도한 재현 실패 확인

--- a/mydocs/working/task_m100_1271_stage2.md
+++ b/mydocs/working/task_m100_1271_stage2.md
@@ -1,0 +1,85 @@
+# Stage 2 보고 — Task M100-1271
+
+## 범위
+
+- 이슈: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 단계: TypesetEngine paper-anchored `BehindText`/`InFrontOfText` 표 out-of-flow 보정
+- 수정 파일: `src/renderer/typeset.rs`
+
+## 변경
+
+`src/renderer/typeset.rs` 의 글뒤로/글앞으로 표 단축 분기에서 `oversized_multirow` 예외를 좁혔다.
+
+기존 동작:
+
+```text
+row_count > 1 && measured_height > base_available_height
+```
+
+이면 `BehindText`/`InFrontOfText` 표라도 데코레이션 단축 분기에서 제외하고 `typeset_block_table` 로 넘겼다.
+
+변경 후:
+
+```text
+row_count > 1
+&& measured_height > base_available_height
+&& !(treat_as_char=false && vert_rel_to=Paper && horz_rel_to=Paper)
+```
+
+즉, 종이 기준 절대좌표의 배경/전경 표는 크기가 본문 가용 높이를 넘더라도 본문 흐름을 차지하지 않는 `PageItem::Shape` 로 유지한다.
+
+## 대상 샘플 확인
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 1
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 2
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+```
+
+결과:
+
+```text
+문서 로드: samples/hwpx/[2027] 온새미로 1 본교재.hwpx (46페이지)
+
+page 2:
+  FullParagraph pi=4 "MEMO"
+
+page 3:
+  Shape pi=5 ci=0
+
+page 4:
+  section=1, page_num=4
+  FullParagraph pi=0 "강의 01."
+```
+
+Stage 1 에서 재현된 page 2 의 `PartialTable pi=3 ci=0` 은 사라졌다.
+
+## 검증
+
+```text
+cargo fmt --check
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+cargo test --test issue_703 -- --nocapture
+cargo test --test issue_775 -- --nocapture
+cargo test --test issue_1156_rowbreak_fragment_fit -- --nocapture
+cargo test --lib test_typeset_703_behind_text_table_no_flow_advance -- --nocapture
+cargo test --test exam_eng_multicolumn -- --nocapture
+```
+
+결과:
+
+- `cargo fmt --check`: 통과
+- `issue_1271_hwpx_behind_text_table`: 1 passed
+- `issue_703`: 3 passed
+- `issue_775`: 1 passed
+- `issue_1156_rowbreak_fragment_fit`: 3 passed
+- `test_typeset_703_behind_text_table_no_flow_advance`: 1 passed
+- `exam_eng_multicolumn`: 1 passed
+
+## 판단
+
+- #1271 의 직접 원인인 paper-anchored 글뒤로 표의 `PartialTable` 분할은 해결됐다.
+- #703 단일 컬럼 데코레이션 표, #775 다단 표 위치, RowBreak 분할 표 회귀는 집중 테스트에서 깨지지 않았다.
+- Stage 3 에서는 구현계획서대로 구역 간 쪽번호 carry 이후 최종 `page_number` 기준 바탕쪽 홀짝 선택을 보정한다.

--- a/mydocs/working/task_m100_1271_stage3.md
+++ b/mydocs/working/task_m100_1271_stage3.md
@@ -1,0 +1,96 @@
+# Stage 3 보고 — Task M100-1271
+
+## 범위
+
+- 이슈: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 단계: 최종 쪽번호 기준 masterpage 선택 보정
+- 수정 파일: `src/document_core/queries/rendering.rs`
+
+## 변경
+
+기존 바탕쪽 선택 블록을 `assign_master_pages_for_section` helper 로 분리했다.
+
+호출 시점을 다음처럼 변경했다.
+
+```text
+기존:
+  section-local page_number 기준 바탕쪽 선택
+  -> 구역 간 page_number carry 보정
+
+변경:
+  구역 간 page_number carry 보정
+  -> 최종 page_number 기준 바탕쪽 선택
+```
+
+helper 는 재호출 가능하도록 각 페이지의 `active_master_page` 와 `extra_master_pages` 를 먼저 초기화한다.
+기존 선택 규칙은 유지했다.
+
+- 기본 바탕쪽: `Odd`/`Even` > `Both`
+- 첫 쪽 바탕쪽 감추기 유지
+- 마지막 쪽 확장 바탕쪽 처리 유지
+- `overlap`/`replace_base` 처리 유지
+
+## 회귀 테스트
+
+`src/document_core/queries/rendering.rs` 에 synthetic 문서 테스트를 추가했다.
+
+```text
+master_page_selection_uses_final_carried_page_number_parity
+```
+
+검증 내용:
+
+- section 0 이 1쪽으로 끝난다.
+- section 1 은 `NewNumber(Page)` 없이 이어진다.
+- section 1 첫 페이지는 section-local 로는 1쪽이지만 carry 후 최종 `page_number=2` 가 된다.
+- 기대: section 1 첫 페이지는 Odd 바탕쪽이 아니라 Even 바탕쪽을 선택해야 한다.
+
+## 대상 샘플 확인
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 1
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+```
+
+결과:
+
+```text
+문서 로드: samples/hwpx/[2027] 온새미로 1 본교재.hwpx (46페이지)
+
+page 2:
+  FullParagraph pi=4 "MEMO"
+
+page 4:
+  section=1, page_num=4
+  FullParagraph pi=0 "강의 01."
+```
+
+## 검증
+
+```text
+cargo fmt --check
+cargo test --lib master_page_selection_uses_final_carried_page_number_parity -- --nocapture
+cargo test --lib test_1098_hwpx_last_page_master_replaces_base_master -- --nocapture
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+cargo test --test issue_703 -- --nocapture
+cargo test --test issue_775 -- --nocapture
+```
+
+결과:
+
+- `cargo fmt --check`: 통과
+- `master_page_selection_uses_final_carried_page_number_parity`: 1 passed
+- `test_1098_hwpx_last_page_master_replaces_base_master`: 1 passed
+- `issue_1271_hwpx_behind_text_table`: 1 passed
+- `issue_703`: 3 passed
+- `issue_775`: 1 passed
+
+참고: `issue_775` 실행 중 기존 overflow 진단 로그가 출력되지만 테스트는 통과했다.
+
+## 판단
+
+- section-local 홀짝으로 선선택한 바탕쪽이 carry 후 최종 홀짝과 달라지는 구조적 위험을 제거했다.
+- Stage 2 로 맞춘 #1271 앞부분 페이지 대응은 유지된다.
+- Stage 4 에서는 대상 샘플의 구조/시각 검증을 진행한다.

--- a/mydocs/working/task_m100_1271_stage4.md
+++ b/mydocs/working/task_m100_1271_stage4.md
@@ -1,0 +1,132 @@
+# Stage 4 보고 — Task M100-1271
+
+## 범위
+
+- 이슈: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 단계: 대상 샘플 구조/시각 검증
+- 대상 HWPX: `samples/hwpx/[2027] 온새미로 1 본교재.hwpx`
+- 기준 PDF: `pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf`
+
+## 산출물
+
+```text
+output/poc/task1271_stage4/pdf/page-01.png
+output/poc/task1271_stage4/pdf/page-02.png
+output/poc/task1271_stage4/pdf/page-03.png
+output/poc/task1271_stage4/pdf/page-04.png
+output/poc/task1271_stage4/pdf/page-05.png
+
+output/poc/task1271_stage4/svg/[2027] 온새미로 1 본교재_001.svg
+output/poc/task1271_stage4/svg/[2027] 온새미로 1 본교재_002.svg
+output/poc/task1271_stage4/svg/[2027] 온새미로 1 본교재_003.svg
+output/poc/task1271_stage4/svg/[2027] 온새미로 1 본교재_004.svg
+output/poc/task1271_stage4/svg/[2027] 온새미로 1 본교재_005.svg
+```
+
+SVG 시각 확인용 PNG 는 `qlmanage` 로 생성했다. `export-png` 는 현재 빌드가 `native-skia`
+feature 없이 동작 중이라 사용할 수 없었다.
+
+## PDF 기준 확인
+
+명령:
+
+```text
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pdfinfo "pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf"
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pdftoppm -png -r 96 -f 1 -l 4 "pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf" output/poc/task1271_stage4/pdf/page
+/Users/melee/.cache/codex-runtimes/codex-primary-runtime/dependencies/bin/pdftoppm -png -r 96 -f 5 -l 5 "pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf" output/poc/task1271_stage4/pdf/page
+```
+
+결과:
+
+- PDF 기준본은 46쪽이다.
+- 1쪽: 표지
+- 2쪽: MEMO
+- 3쪽: 1주차 간지
+- 4쪽: 본문 시작, 하단 쪽번호 4가 왼쪽에 위치
+- 5쪽: 다음 본문, 하단 쪽번호 5가 오른쪽에 위치
+
+참고: Poppler 렌더 중 `Adobe-Korea1` language pack 과 일부 폰트 관련 경고가 출력되었다.
+그래도 이번 검증 대상인 페이지 흐름, MEMO/간지/본문 위치, 홀짝 바탕쪽 방향은 확인 가능했다.
+
+## HWPX 구조 확인
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx"
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" | rg -n "문서 로드|=== 페이지 1 |=== 페이지 2 |=== 페이지 3 |=== 페이지 4 |=== 페이지 45 |=== 페이지 46 |PartialTable"
+```
+
+결과:
+
+```text
+문서 로드: samples/hwpx/[2027] 온새미로 1 본교재.hwpx (46페이지)
+=== 페이지 1 (global_idx=0, section=0, page_num=1) ===
+=== 페이지 2 (global_idx=1, section=0, page_num=2) ===
+=== 페이지 3 (global_idx=2, section=0, page_num=3) ===
+=== 페이지 4 (global_idx=3, section=1, page_num=4) ===
+=== 페이지 45 (global_idx=44, section=3, page_num=45) ===
+=== 페이지 46 (global_idx=45, section=4, page_num=46) ===
+```
+
+확인:
+
+- HWPX 렌더 결과도 46쪽이다.
+- 앞 4쪽에 `PartialTable` 조각 페이지가 끼지 않는다.
+- 2쪽은 `MEMO` 문단이다.
+- 3쪽은 1주차 간지 shape 페이지다.
+- 4쪽은 `section=1, page_num=4` 이고 첫 본문 문단은 `강의 01.` 이다.
+
+## HWPX 시각/바탕쪽 확인
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271_stage4/svg -p 0
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271_stage4/svg -p 1
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271_stage4/svg -p 2
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271_stage4/svg -p 3
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1271_stage4/svg -p 4
+```
+
+확인:
+
+- 1쪽 표지는 기준 PDF와 같은 내용과 하단 곡선 배치를 보인다.
+- 2쪽은 MEMO 단독쪽으로 유지된다.
+- 3쪽은 1주차 간지로 유지된다.
+- 4쪽은 본문 시작쪽이며 상단 장식과 하단 쪽번호가 짝수쪽 방향이다.
+- 5쪽은 상단 장식과 하단 쪽번호가 홀수쪽 방향이다.
+
+쪽번호 위치는 SVG 좌표로도 확인했다.
+
+```text
+4쪽: textbox-clip-4 x=60.453333..., text "4" x=60.453333...
+5쪽: textbox-clip-4 x=495.120000..., text "5" x=733.240021...
+```
+
+즉 4쪽은 왼쪽 하단, 5쪽은 오른쪽 하단으로 기준 PDF의 홀짝 방향과 일치한다.
+
+참고: `qlmanage` 썸네일은 일부 페이지에서 하단이 잘려 보일 수 있어, 하단 쪽번호 위치는
+SVG 텍스트 좌표를 함께 사용해 확인했다.
+
+## 회귀 테스트
+
+명령:
+
+```text
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+결과:
+
+```text
+test onsaemiro_front_matter_is_not_shifted_by_behind_text_table_fragment ... ok
+test result: ok. 1 passed
+```
+
+## 판단
+
+- #1271 대상 샘플에서 PDF 기준본과 HWPX 렌더 결과의 총 페이지 수가 46쪽으로 일치한다.
+- 원래 문제였던 2-3쪽 앞부분 밀림은 해소되어, 2쪽 MEMO와 3쪽 1주차 간지가 기준 PDF와 같은 위치에 있다.
+- 4쪽이 최종 `page_num=4` 로 본문을 시작하고, 4쪽/5쪽의 바탕쪽 방향도 기준 PDF의 짝수/홀수 방향과 일치한다.
+- Stage 5 에서는 전체 회귀 검증과 최종 보고서를 진행한다.

--- a/mydocs/working/task_m100_1271_stage5.md
+++ b/mydocs/working/task_m100_1271_stage5.md
@@ -1,0 +1,103 @@
+# Stage 5 보고 — Task M100-1271
+
+## 범위
+
+- 이슈: [#1271](https://github.com/edwardkim/rhwp/issues/1271)
+- 단계: 전체 회귀 검증, WASM 갱신, rhwp-studio 시각검증 서버 실행
+
+## Rust 회귀 검증
+
+명령:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+결과:
+
+- `cargo fmt --check`: 통과
+- `cargo test --lib`: 통과
+  - `1538 passed; 0 failed; 6 ignored`
+- `cargo test --tests`: 통과
+  - 라이브러리 유닛 테스트와 전체 `tests/` 통합 테스트 통과
+  - #1271 전용 테스트 `onsaemiro_front_matter_is_not_shifted_by_behind_text_table_fragment` 통과
+  - 집중 회귀 테스트 `issue_1197_svg_object_zorder` 통과
+
+## WASM 갱신
+
+`rhwp-studio` 가 현재 Rust 수정본을 사용하도록 WASM 패키지를 갱신했다.
+
+처음에는 저장소 문서의 권장 절차인 Docker WASM 빌드를 시도했다.
+
+```text
+docker-compose --env-file .env.docker run --rm wasm
+```
+
+결과:
+
+```text
+Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?
+```
+
+Docker daemon 이 실행 중이 아니어서, 시각검증 서버용 산출물 갱신은 로컬 `wasm-pack` 으로 수행했다.
+
+```text
+wasm-pack build --target web
+```
+
+결과:
+
+```text
+Your wasm pkg is ready to publish at /Users/melee/Documents/projects/forks/rhwp/pkg.
+```
+
+확인:
+
+```text
+pkg/rhwp_bg.wasm
+Jun  3 18:55:53 2026
+```
+
+즉 `src/renderer/typeset.rs`, `src/document_core/queries/rendering.rs` 변경 이후의 WASM 이다.
+
+## rhwp-studio 서버
+
+명령:
+
+```text
+cd rhwp-studio
+npm run dev -- --host 127.0.0.1 --port 7700
+```
+
+서버:
+
+```text
+http://127.0.0.1:7700/
+```
+
+대상 샘플 자동 로드 URL:
+
+```text
+http://127.0.0.1:7700/?url=/samples/hwpx/%5B2027%5D%20%EC%98%A8%EC%83%88%EB%AF%B8%EB%A1%9C%201%20%EB%B3%B8%EA%B5%90%EC%9E%AC.hwpx&filename=%5B2027%5D%20%EC%98%A8%EC%83%88%EB%AF%B8%EB%A1%9C%201%20%EB%B3%B8%EA%B5%90%EC%9E%AC.hwpx
+```
+
+응답 확인:
+
+```text
+curl -I http://127.0.0.1:7700/
+curl -I "http://127.0.0.1:7700/samples/hwpx/%5B2027%5D%20%EC%98%A8%EC%83%88%EB%AF%B8%EB%A1%9C%201%20%EB%B3%B8%EA%B5%90%EC%9E%AC.hwpx"
+```
+
+결과:
+
+- 루트 페이지: `HTTP/1.1 200 OK`
+- 대상 HWPX 샘플: `HTTP/1.1 200 OK`
+
+## 판단
+
+- Stage 1-4 에서 추가/수정한 로직은 전체 Rust 회귀 검증을 통과했다.
+- #1271 대상 샘플은 전용 통합 테스트와 Stage 4 구조/시각 검증 기준을 모두 만족한다.
+- rhwp-studio 서버는 현재 수정본 WASM 으로 실행 중이며, 사용자가 직접 대상 샘플을 열어 시각검증할 수 있다.
+- 이슈 클로즈는 작업지시자 승인 전에는 수행하지 않는다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -15,7 +15,7 @@ use crate::renderer::html::HtmlRenderer;
 use crate::renderer::layer_renderer::LayerRenderer;
 use crate::renderer::layout::LayoutEngine;
 use crate::renderer::page_layout::PageLayoutInfo;
-use crate::renderer::pagination::{PageContent, PaginationResult, Paginator};
+use crate::renderer::pagination::{MasterPageRef, PageContent, PaginationResult, Paginator};
 use crate::renderer::render_tree::PageRenderTree;
 use crate::renderer::style_resolver::resolve_styles;
 use crate::renderer::svg::SvgRenderer;
@@ -117,6 +117,106 @@ fn insert_hwp3_title_filler_page(result: &mut PaginationResult, section_index: u
         page.page_number = page.page_number.saturating_add(1);
     }
     result.pages.insert(0, blank);
+}
+
+fn assign_master_pages_for_section(
+    result: &mut PaginationResult,
+    section_index: usize,
+    section: &Section,
+) {
+    use crate::model::header_footer::HeaderFooterApply;
+
+    for page in &mut result.pages {
+        page.active_master_page = None;
+        page.extra_master_pages.clear();
+    }
+
+    let mps = &section.section_def.master_pages;
+    if mps.is_empty() {
+        return;
+    }
+
+    let mp_both = mps
+        .iter()
+        .position(|m| m.apply_to == HeaderFooterApply::Both && !m.is_extension);
+    let mp_odd = mps
+        .iter()
+        .position(|m| m.apply_to == HeaderFooterApply::Odd && !m.is_extension);
+    let mp_even = mps
+        .iter()
+        .position(|m| m.apply_to == HeaderFooterApply::Even && !m.is_extension);
+    let ext_mp_indices: Vec<usize> = mps
+        .iter()
+        .enumerate()
+        .filter(|(_, m)| m.is_extension)
+        .map(|(i, _)| i)
+        .collect();
+
+    let section_page_count = result.pages.len();
+    for (page_idx_in_section, page) in result.pages.iter_mut().enumerate() {
+        let is_last = page_idx_in_section + 1 == section_page_count;
+        let is_first_page = page_idx_in_section == 0;
+
+        if is_first_page && section.section_def.hide_master_page {
+            continue;
+        }
+
+        let selected = if page.page_number % 2 == 1 {
+            mp_odd.or(mp_both)
+        } else {
+            mp_even.or(mp_both)
+        };
+        page.active_master_page = selected.map(|mi| MasterPageRef {
+            section_index,
+            master_page_index: mi,
+        });
+
+        if is_last && !ext_mp_indices.is_empty() {
+            let replace_exts: Vec<usize> = ext_mp_indices
+                .iter()
+                .filter(|&&i| !mps[i].overlap || mps[i].replace_base)
+                .copied()
+                .collect();
+            let overlap_exts: Vec<usize> = ext_mp_indices
+                .iter()
+                .filter(|&&i| mps[i].overlap && !mps[i].replace_base)
+                .copied()
+                .collect();
+
+            if let Some(&replace_idx) = replace_exts.last() {
+                page.active_master_page = Some(MasterPageRef {
+                    section_index,
+                    master_page_index: replace_idx,
+                });
+            }
+
+            let active_apply = page
+                .active_master_page
+                .as_ref()
+                .and_then(|mp_ref| mps.get(mp_ref.master_page_index))
+                .map(|m| m.apply_to);
+            let mut remaining_overlap_exts: Vec<usize> = Vec::new();
+            for &i in &overlap_exts {
+                if Some(mps[i].apply_to) == active_apply {
+                    page.active_master_page = Some(MasterPageRef {
+                        section_index,
+                        master_page_index: i,
+                    });
+                } else {
+                    remaining_overlap_exts.push(i);
+                }
+            }
+            if !remaining_overlap_exts.is_empty() {
+                page.extra_master_pages = remaining_overlap_exts
+                    .iter()
+                    .map(|&mi| MasterPageRef {
+                        section_index,
+                        master_page_index: mi,
+                    })
+                    .collect();
+            }
+        }
+    }
 }
 
 impl DocumentCore {
@@ -2167,109 +2267,6 @@ impl DocumentCore {
                 }
             }
 
-            // 바탕쪽 선택 (기본 + 확장)
-            if !section.section_def.master_pages.is_empty() {
-                use crate::model::header_footer::HeaderFooterApply;
-                use crate::renderer::pagination::MasterPageRef;
-
-                let mps = &section.section_def.master_pages;
-                // 기본 바탕쪽 (비확장 Both/Odd/Even)
-                let mp_both = mps
-                    .iter()
-                    .position(|m| m.apply_to == HeaderFooterApply::Both && !m.is_extension);
-                let mp_odd = mps
-                    .iter()
-                    .position(|m| m.apply_to == HeaderFooterApply::Odd && !m.is_extension);
-                let mp_even = mps
-                    .iter()
-                    .position(|m| m.apply_to == HeaderFooterApply::Even && !m.is_extension);
-                // 확장 바탕쪽 (is_extension=true, 마지막 쪽/임의 쪽)
-                let ext_mp_indices: Vec<usize> = mps
-                    .iter()
-                    .enumerate()
-                    .filter(|(_, m)| m.is_extension)
-                    .map(|(i, _)| i)
-                    .collect();
-
-                // 구역 내 페이지 수 (마지막 쪽 판별용)
-                let section_page_count = result.pages.len();
-
-                for (page_idx_in_section, page) in result.pages.iter_mut().enumerate() {
-                    let is_odd = page.page_number % 2 == 1;
-                    let is_last = page_idx_in_section + 1 == section_page_count;
-                    let is_first_page = page_idx_in_section == 0;
-
-                    // 첫 쪽 감추기: hide_master_page가 true이면 첫 쪽에서 바탕쪽 미적용
-                    if is_first_page && section.section_def.hide_master_page {
-                        continue;
-                    }
-
-                    // 1. 기본 바탕쪽 선택: Odd/Even > Both
-                    let selected = if is_odd {
-                        mp_odd.or(mp_both)
-                    } else {
-                        mp_even.or(mp_both)
-                    };
-                    page.active_master_page = selected.map(|mi| MasterPageRef {
-                        section_index: idx,
-                        master_page_index: mi,
-                    });
-
-                    // 2. 확장 바탕쪽: 마지막 쪽에 적용
-                    // 겹치기(overlap): 기존 바탕쪽 위에 추가
-                    // 비겹치기: 기존 바탕쪽 대체
-                    if is_last && !ext_mp_indices.is_empty() {
-                        let replace_exts: Vec<usize> = ext_mp_indices
-                            .iter()
-                            .filter(|&&i| !mps[i].overlap || mps[i].replace_base)
-                            .copied()
-                            .collect();
-                        let overlap_exts: Vec<usize> = ext_mp_indices
-                            .iter()
-                            .filter(|&&i| mps[i].overlap && !mps[i].replace_base)
-                            .copied()
-                            .collect();
-
-                        // 대체형 확장이 있으면 active를 대체
-                        if let Some(&replace_idx) = replace_exts.last() {
-                            page.active_master_page = Some(MasterPageRef {
-                                section_index: idx,
-                                master_page_index: replace_idx,
-                            });
-                        }
-                        // 겹침형 확장:
-                        // - apply_to 가 active 와 동일: 같은 위치(헤더/푸터/배경) 컨텐츠가 충돌 → active 대체
-                        //   (HWP 작성자가 마지막 쪽 전용 헤더로 의도. 한컴 PDF 출력 동작과 일치)
-                        // - apply_to 가 다름(예: active=Odd, 확장=Both): 보조 컨텐츠 추가 → extra
-                        let active_apply = page
-                            .active_master_page
-                            .as_ref()
-                            .and_then(|mp_ref| mps.get(mp_ref.master_page_index))
-                            .map(|m| m.apply_to);
-                        let mut remaining_overlap_exts: Vec<usize> = Vec::new();
-                        for &i in &overlap_exts {
-                            if Some(mps[i].apply_to) == active_apply {
-                                page.active_master_page = Some(MasterPageRef {
-                                    section_index: idx,
-                                    master_page_index: i,
-                                });
-                            } else {
-                                remaining_overlap_exts.push(i);
-                            }
-                        }
-                        if !remaining_overlap_exts.is_empty() {
-                            page.extra_master_pages = remaining_overlap_exts
-                                .iter()
-                                .map(|&mi| MasterPageRef {
-                                    section_index: idx,
-                                    master_page_index: mi,
-                                })
-                                .collect();
-                        }
-                    }
-                }
-            }
-
             // 머리말/꼬리말 carry 업데이트:
             // 페이지 active_header뿐 아니라 구역에 정의된 머리말 컨트롤도 carry에 반영
             // (짝수 페이지가 없어도 Even 머리말이 다음 구역에 상속되어야 함)
@@ -2344,6 +2341,9 @@ impl DocumentCore {
                     }
                 }
             }
+
+            // 바탕쪽 선택은 구역 간 쪽번호 carry 보정 이후 최종 page_number 기준으로 수행한다.
+            assign_master_pages_for_section(&mut result, idx, section);
 
             // 구역 간 머리말/꼬리말 상속 (쪽번호 보정 이후 실행)
             if idx > 0 {
@@ -3752,6 +3752,76 @@ mod tests {
         assert_eq!(core.get_bin_data(0), Some(&[0x01, 0x02, 0x03][..]));
         assert_eq!(core.get_bin_data(1), Some(&[0xAA, 0xBB][..]));
         assert_eq!(core.get_bin_data(2), None);
+    }
+
+    #[test]
+    fn master_page_selection_uses_final_carried_page_number_parity() {
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::header_footer::{HeaderFooterApply, MasterPage};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        fn a4_section(section_def: SectionDef) -> Section {
+            Section {
+                section_def,
+                paragraphs: vec![Paragraph::default()],
+                raw_stream: None,
+            }
+        }
+
+        let page_def = PageDef {
+            width: 59528,
+            height: 84188,
+            margin_left: 8504,
+            margin_right: 8504,
+            margin_top: 5668,
+            margin_bottom: 4252,
+            margin_header: 4252,
+            margin_footer: 4252,
+            ..Default::default()
+        };
+
+        let mut document = Document::default();
+        document.sections.push(a4_section(SectionDef {
+            page_def: page_def.clone(),
+            ..Default::default()
+        }));
+        document.sections.push(a4_section(SectionDef {
+            page_def,
+            master_pages: vec![
+                MasterPage {
+                    apply_to: HeaderFooterApply::Odd,
+                    ..Default::default()
+                },
+                MasterPage {
+                    apply_to: HeaderFooterApply::Even,
+                    ..Default::default()
+                },
+            ],
+            ..Default::default()
+        }));
+
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core.paginate();
+
+        let page = core
+            .pagination
+            .get(1)
+            .and_then(|result| result.pages.first())
+            .expect("section 1 first page");
+        assert_eq!(
+            page.page_number, 2,
+            "section 1 first page should carry section 0 page number"
+        );
+        let active = page
+            .active_master_page
+            .as_ref()
+            .expect("section 1 page should have an active master page");
+        assert_eq!(
+            active.master_page_index, 1,
+            "final page_number=2 must select the Even master page, not the section-local Odd page"
+        );
     }
 
     #[test]

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -3814,22 +3814,38 @@ impl TypesetEngine {
                     // 표라도 cur_h 누적이 컬럼 분배에 필요 (exam_eng.hwp p4 27번 보기 그림 위
                     // 데코레이션 표 회귀 차단).
                     //
-                    // [Task #992] 페이지 본문보다 큰 다행(多行) 표는 데코레이션이 아니라
+                    // [Task #992] 페이지 본문보다 큰 다행(多行) 표는 대개 데코레이션이 아니라
                     // 쪽 분할이 필요한 본문 표다. 데코레이션 단축 분기에서 제외해 정상
                     // 페이지네이션(format_table → typeset_block_table)을 타게 한다.
                     // 제외하지 않으면 페이지보다 큰 표가 한 페이지에 통째로 그려져
                     // 본문 영역을 넘는다.
+                    //
+                    // [Issue #1271] 단, HWPX paper-anchored BehindText/InFrontOfText 표는
+                    // rowBreak/repeatHeader 가 있어도 본문 흐름을 밀지 않는 페이지 배경/전경
+                    // 개체일 수 있다. 특히 cover/background 라벨 표처럼 종이 기준 절대좌표인
+                    // 표를 oversized_multirow 로 본문 분할하면 PDF에 없는 PartialTable 쪽이
+                    // 생겨 이후 바탕쪽 홀짝까지 한 쪽씩 밀린다.
                     // 워터마크/배경 데코레이션(글뒤로 1×1 래퍼 등, Issue #703)은
                     // 본문보다 작아 단축 분기를 그대로 탄다 — page_break/repeat_header
                     // 만으로는 구분 불가(calendar_year.hwp 1×1 래퍼도 RowBreak +
                     // repeat_header 비트를 가짐).
+                    let paper_anchored_overlay_table = !table.common.treat_as_char
+                        && matches!(
+                            table.common.vert_rel_to,
+                            crate::model::shape::VertRelTo::Paper
+                        )
+                        && matches!(
+                            table.common.horz_rel_to,
+                            crate::model::shape::HorzRelTo::Paper
+                        );
                     let table_measured_h = measured_tables
                         .iter()
                         .find(|mt| mt.para_index == para_idx && mt.control_index == ctrl_idx)
                         .map(|mt| mt.total_height)
                         .unwrap_or(0.0);
-                    let oversized_multirow =
-                        table.row_count > 1 && table_measured_h > st.base_available_height();
+                    let oversized_multirow = table.row_count > 1
+                        && table_measured_h > st.base_available_height()
+                        && !paper_anchored_overlay_table;
                     if matches!(
                         table.common.text_wrap,
                         crate::model::shape::TextWrap::InFrontOfText

--- a/tests/issue_1271_hwpx_behind_text_table.rs
+++ b/tests/issue_1271_hwpx_behind_text_table.rs
@@ -1,0 +1,55 @@
+//! Issue #1271: HWPX 글뒤로 paper-anchored RowBreak 표가 본문 흐름을 밀어
+//! 앞쪽 페이지와 바탕쪽 홀짝 적용을 함께 어긋나게 하는 회귀 가드.
+//!
+//! 재현 문서: `samples/hwpx/[2027] 온새미로 1 본교재.hwpx`.
+//! 한컴 PDF 기준 앞쪽 페이지 배치는 page 2 = MEMO, page 3 = 1주차 표지,
+//! page 4 = 본문 시작이다. 현재 TypesetEngine 은 section 0 paragraph 3 의
+//! 글뒤로 표를 `PartialTable` 로 분할해 page 2 를 차지시키므로, 이후 페이지가
+//! 한 쪽씩 밀리고 Odd/Even 바탕쪽 적용도 반대로 보인다.
+
+use std::fs;
+use std::path::Path;
+
+fn load_doc() -> rhwp::wasm_api::HwpDocument {
+    let rel = "samples/hwpx/[2027] 온새미로 1 본교재.hwpx";
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {rel}: {e:?}"))
+}
+
+#[test]
+fn onsaemiro_front_matter_is_not_shifted_by_behind_text_table_fragment() {
+    let doc = load_doc();
+
+    let page2 = doc.dump_page_items(Some(1));
+    assert!(
+        page2.contains("\"MEMO\""),
+        "PDF 기준 page 2 는 MEMO 쪽이어야 한다. 글뒤로 표 조각이 끼어 있으면 \
+         이후 page_num 과 바탕쪽 홀짝이 밀린다.\n{page2}"
+    );
+    assert!(
+        !page2.contains("PartialTable   pi=3 ci=0"),
+        "section 0 paragraph 3 의 글뒤로 표는 본문 흐름을 차지하는 \
+         PartialTable 로 분할되면 안 된다.\n{page2}"
+    );
+
+    let page3 = doc.dump_page_items(Some(2));
+    assert!(
+        page3.contains("Shape          pi=5 ci=0"),
+        "PDF 기준 page 3 은 1주차 표지 도형들이 있는 쪽이어야 한다.\n{page3}"
+    );
+    assert!(
+        !page3.contains("\"MEMO\""),
+        "MEMO 쪽이 page 3 으로 밀리면 바탕쪽 홀짝 적용도 함께 어긋난다.\n{page3}"
+    );
+
+    let page4 = doc.dump_page_items(Some(3));
+    assert!(
+        page4.contains("section=1, page_num=4"),
+        "PDF 기준 page 4 에서 section 1 본문이 page_num=4 로 시작해야 한다.\n{page4}"
+    );
+    assert!(
+        page4.contains("\"강의 01.\""),
+        "PDF 기준 page 4 는 강의 01 본문 시작 쪽이어야 한다.\n{page4}"
+    );
+}


### PR DESCRIPTION
## 개요

관련 이슈: #1271

이 PR은 #1275를 `devel` 기준으로 다시 생성한 clean PR입니다. #1275는 실수로 `main`을 base로 열려 `devel` 누적 커밋이 모두 포함된 것처럼 표시되어 close 예정입니다.

HWPX 문서에서 `Paper` 기준으로 배치된 `BehindText`/`InFrontOfText` 표가 본문 흐름 표처럼 분할되어, PDF 기준본에 없는 `PartialTable` 페이지가 생기던 문제를 수정했습니다. 이로 인해 앞쪽 페이지가 밀리고 최종 쪽번호 기준 Odd/Even 바탕쪽이 반대로 적용될 수 있었습니다.

## 변경 사항

- `Paper` 기준 배경성 표는 oversized multirow 분할 예외로 보고 shape 경로를 유지하도록 보정
- 바탕쪽 선택 로직을 `assign_master_pages_for_section` helper로 분리
- 구역 간 쪽번호 carry 보정 이후 최종 `page_number` 기준으로 Odd/Even 바탕쪽 선택
- #1271 대상 샘플 회귀 테스트 추가

## 시각 검증 PNG

아래 표의 before / after / PDF 기준 PNG로 앞쪽 페이지 대응과 바탕쪽 홀짝 적용을 비교합니다.

| 구분 | 2쪽: MEMO | 3쪽: 1주차 | 4쪽: 본문 시작 / 짝수쪽 | 5쪽: 홀수쪽 |
|---|---|---|---|---|
| Before | <img width="300" alt="image" src="https://github.com/user-attachments/assets/02bdc8b0-f05f-4fcf-92c9-323363a729a9" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/61c2df7f-7be8-42c3-98f2-14a749245330" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/2edac81f-0a00-4930-b540-935de89b0ce1" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/ccd02666-aee1-45f9-9bc2-94dc37e91efc" /> |
| After | <img width="300" alt="image" src="https://github.com/user-attachments/assets/ac8738ba-8e39-458f-ba9f-d1be02416dbf" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4bc76642-a6fd-414c-9d18-f5e00d353530" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/95f26653-18f4-436c-b117-85a4642321e6" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/24f0e624-5d22-40f1-ac8d-e756c61d7ae3" /> |
| PDF 기준 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/8abfaeb1-3354-4df1-94af-bce142e2200a" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/f023e1e8-9e7c-495f-8d48-da68863c93cc" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/dd98f400-2432-4718-83c4-3838232b55a5" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/08ea7bb0-0b75-4351-94f6-789d3eaedeed" /> |

## 검증

- [x] `cargo fmt --check`
- [x] `cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture`
- [x] `cargo test --lib`
- [x] `cargo test --tests`
- [x] `cargo clippy -- -D warnings`
- [x] rhwp-studio 직접 시각검증

## 참고

- 대상 샘플: `samples/hwpx/[2027] 온새미로 1 본교재.hwpx`
- 기준 PDF: `pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf`
- #1266의 문단 `borderFill NONE` side 렌더링 변경은 아직 미머지 상태라 이 PR의 after에는 포함되어 있지 않습니다.
- Docker daemon이 실행 중이 아니어서 rhwp-studio 시각검증용 WASM은 로컬 `wasm-pack build --target web`으로 갱신했습니다.
