### PR TITLE
fix: 글상자/셀 중첩 그림 마우스 드래그 조작(리사이즈·회전·이동) 실패 + floating 리사이즈 이탈 (#1273)

### DIFF
--- a/mydocs/plans/task_m100_1273.md
+++ b/mydocs/plans/task_m100_1273.md
@@ -1,0 +1,72 @@
+# 수행계획서 — 글상자/셀 중첩 그림 마우스 드래그 조작 실패 수정 (M100 #1273)
+
+- **이슈**: #1273 (글상자/셀 중첩 그림 마우스 드래그 리사이즈·회전·이동 실패 — 드래그 상태 ref가 cellPath 소실)
+- **브랜치**: `local/task1273` (`local/devel`에서 분기)
+- **분류**: 버그 수정 (프런트엔드 TS 전용)
+- **선행/관계**: #1171(hit-test 선택, CLOSED 완료), #1229(글상자 선택·복사), #1231(키보드 크기조절), PR #1254(`47cd32dd`), 메인테이너 보완 커밋 `5453b254`(`local/devel` 병합 완료)
+
+## 1. 배경
+
+#1171로 글상자(Shape text_box) 내부 picture를 1급 개체로 선택·조작할 수 있게 작업했고,
+PR #1254와 메인테이너 보완 커밋 `5453b254`까지 진행되었다. 그 결과 **속성 대화상자**와
+**키보드** 경로의 중첩 그림 조작은 동작하지만, **마우스 핸들 드래그**로 리사이즈·회전·이동하면
+아래 오류가 반복 발생한다.
+
+```
+[InputHandler] 개체 리사이즈 실패: 렌더링 오류: 컨트롤 인덱스 1 범위 초과
+[InputHandler] 개체 리사이즈 실패: 렌더링 오류: 지정된 Shape 컨트롤이 그림이 아닙니다
+[InputHandler] 개체 회전 드래그 실패: 렌더링 오류: 컨트롤 인덱스 1 범위 초과
+```
+
+## 2. 근본 원인 (확정)
+
+중첩 그림의 선택 ref(`cursor.selectedPictureRef`)는 `cellPath`(또는 `headerFooter`)를 담는다.
+조작 헬퍼 `get/setObjectProperties`(`input-handler-picture.ts`)는 이 path 유무로 **by-path WASM
+API**와 **body-level scalar API**를 분기한다.
+
+그러나 **단일 개체 마우스 드래그 시작** 시 드래그 상태 객체(`pictureResizeState` /
+`pictureRotateState` / `pictureMoveState`)의 `ref`를 `{ sec, ppi, ci, type }` 리터럴로
+재구성하면서 `cellPath`/`headerFooter`를 **떨어뜨린다**(`input-handler-mouse.ts` L307/L323/L369).
+결과적으로 드래그 중/종료 시 path가 없어 scalar API로 폴백 → 중첩 그림을 본문 문단으로
+오해석 → 위 오류.
+
+메인테이너의 `5453b254`는 선택 ref 생성·조작 헬퍼·리사이즈 커맨드 타깃 등 **양 끝**에
+`cellPath`를 배선했으나, 그 사이에서 ref를 재조립하는 **드래그 상태 staging 객체**는 감사에서
+누락되었다(`input-handler-mouse.ts`는 +2줄만 변경). 이는
+`mydocs/troubleshootings/nested_picture_selection_ref_consumers_1171.md`의 "공유 ref 소비처
+grep 감사" 교훈이 한 단계 더 적용됐어야 했던 경우다.
+
+추가로 이동(move)의 undo/redo는 `MovePictureCommand`/`MoveShapeCommand`가 scalar API만
+호출하므로, 드래그 상태 ref를 고쳐 실시간 이동이 되더라도 되돌리기/다시실행에서 동일 결함이
+재현된다.
+
+## 3. HWP5 스펙 정합
+
+`mydocs/tech/한글문서파일형식_5.0_revision1.3.md` 검토 결과:
+- HWP5 중첩은 `LIST_HEADER`(표 65)로 재귀적이며(글상자·셀·캡션(표 71)·각주/미주·묶음 개체 `$con`(표 67)),
+  레코드 Level(depth) 계층상 scalar `(sec,ppi,ci)`로는 중첩 개체를 지정할 수 없다 →
+  **path 기반 식별(cellPath/by-path API)이 구조적으로 옳음**을 확인.
+- 리사이즈(너비/높이 표 69)·회전(회전각 표 83)·이동(offset 표 70)은 모두 개체 공통/요소 속성
+  편집이므로 **기존 by-path setter 재사용**으로 해결 가능 → **Rust/WASM 변경 불필요**.
+
+## 4. 수정 범위 (작업지시자 승인: 전체 매트릭스)
+
+마우스 단일 드래그의 **리사이즈 + 회전 + 이동(undo/redo 포함)** 경로를 일괄 정정한다.
+전부 TypeScript 한정이며, 필요한 by-path WASM 함수는 이미 번들에 존재(대화상자 리사이즈가 이미
+동작)하므로 **Docker/WASM 재빌드 불필요**.
+
+**범위 외**: 직선/연결선 끝점 드래그(`moveLineEndpoint` by-path API 미존재), 캡션/묶음 중첩 개체
+선택(후속 감사 대상).
+
+## 5. 검증 방침
+
+1. `cd rhwp-studio && npx tsc --noEmit` + `npm run lint`
+2. 수동 시각 확인: 글상자/머리말꼬리말 그림 선택 → 리사이즈·회전·이동·이동후 undo/redo, 콘솔 오류 0건
+3. E2E lifecycle 테스트(select→resize/rotate/move(+undo)) 추가
+4. WASM 무변경 → 기존 `tests/issue_1171_*` 회귀 없음 확인
+
+## 6. 산출물
+
+- `mydocs/plans/task_m100_1273_impl.md` (구현계획서)
+- `mydocs/working/task_m100_1273_stage{1..3}.md` (단계 보고)
+- `mydocs/report/task_m100_1273_report.md` (최종 보고)

--- a/mydocs/plans/task_m100_1273_impl.md
+++ b/mydocs/plans/task_m100_1273_impl.md
@@ -1,0 +1,50 @@
+# 구현계획서 — 글상자/셀 중첩 그림 마우스 드래그 조작 실패 수정 (M100 #1273)
+
+- **이슈**: #1273 / **브랜치**: `local/task1273`
+- **수행계획서**: `mydocs/plans/task_m100_1273.md`
+- **원칙**: TypeScript 전용, 기존 by-path WASM API 재사용, 다중 선택 spread 패턴과 의미 일치
+
+## Stage 1 — 드래그 상태 ref 타입 확장 + path 보존
+
+**목표**: 리사이즈·회전 완전 해결 + 이동 실시간 드래그 해결.
+
+1. `rhwp-studio/src/engine/input-handler.ts`
+   - `@/core/types`에서 `CellPathLike` import 추가.
+   - `pictureResizeState`(L175)·`pictureMoveState`(L191)·`pictureRotateState`(L208)의 `ref` 필드
+     타입에 선택 필드 `cellPath?: CellPathLike`, `headerFooter?: { kind: 'header'|'footer';
+     outerParaIdx: number; outerControlIdx: number }` 추가(가산적).
+2. `rhwp-studio/src/engine/input-handler-mouse.ts`
+   - L307(회전)·L323(리사이즈)·L369(이동)의 `ref: { sec, ppi, ci, type }` 리터럴에
+     `cellPath: ref.cellPath, headerFooter: ref.headerFooter` 복사 추가.
+
+**검증**: `npx tsc --noEmit`, `npm run lint`. (리사이즈·회전은 이 단계로 종결)
+
+## Stage 2 — 이동 커맨드 by-path 지원
+
+**목표**: 중첩 그림 이동의 undo/redo 정상화.
+
+1. `rhwp-studio/src/engine/command.ts`
+   - `MovePictureCommand`/`MoveShapeCommand` 생성자에 선택적 `cellPath?: CellPathLike` 추가.
+   - `execute`/`undo`에서 `cellPath` 존재 시 `getCell{Picture,Shape}PropertiesByPath` +
+     `setCell{Picture,Shape}PropertiesByPath`로 분기, 없으면 기존 scalar 유지.
+   - `mergeWith` 가드에 `cellPath` 동일성 비교 추가.
+   - 선례: `ResizeObjectCommand.setProps`(L830-844).
+2. `rhwp-studio/src/engine/input-handler-picture.ts`
+   - `finishPictureMoveDrag`(L774-783)에서 커맨드 생성 시 `r.cellPath` 전달.
+
+**검증**: `npx tsc --noEmit`, `npm run lint`.
+
+## Stage 3 — E2E lifecycle 테스트 + 수동 확인 + 문서 보완
+
+**목표**: 사용자 연산 표면 검증 + 재발 방지 기록.
+
+1. `rhwp-studio/e2e/`에 글상자 그림 대상 "select→resize", "select→rotate",
+   "select→move(+undo)" 시나리오 추가(기존 `text-flow.test.mjs` 패턴). 단일·다중 선택.
+2. 수동 시각 확인(글상자 + 머리말/꼬리말 그림) — 콘솔 오류 0건.
+3. `mydocs/troubleshootings/nested_picture_selection_ref_consumers_1171.md`에
+   "드래그 상태 staging ref 소비처 누락" 사례 추가(교훈 #2 확장).
+
+## 단계 게이트
+
+각 Stage 완료 후 `mydocs/working/task_m100_1273_stage{N}.md` 보고서 작성 + 소스와 함께 커밋,
+승인 후 다음 Stage 진행.

--- a/mydocs/report/task_m100_1273_report.md
+++ b/mydocs/report/task_m100_1273_report.md
@@ -1,0 +1,62 @@
+# 최종 결과보고서 — 글상자/셀 중첩 그림 마우스 드래그 조작 실패 수정 (M100 #1273)
+
+- **이슈**: #1273 / **브랜치**: `local/task1273` (`local/devel` 분기)
+- **선행/관계**: #1171(hit-test, CLOSED)·PR #1254·보완 커밋 `5453b254`, #1229, #1231, #1230
+- **성격**: 버그 수정 (TypeScript 전용, WASM/Rust 무변경)
+- **커밋**: `f4ae3bf2`(S1) · `d6f4d9ad`(S2) · `2a22849a`(S3) · `41c6465d`(S4)
+
+## 1. 문제
+
+글상자(Shape text_box)·셀 안의 **중첩 그림**을 마우스 핸들 드래그로 리사이즈/회전/이동하면
+다음 오류가 발생(보고): `컨트롤 인덱스 1 범위 초과` / `지정된 Shape 컨트롤이 그림이 아닙니다` /
+`개체 회전 드래그 실패`. 추가로, 글자처럼취급 해제(floating) 후 리사이즈 시 그림이 글상자 밖으로
+이탈하는 현상.
+
+## 2. 근본 원인
+
+1. **드래그 상태 ref의 cellPath 소실**: 단일 개체 마우스 드래그 시작 시 드래그 상태 객체
+   (`pictureResizeState`/`pictureRotateState`/`pictureMoveState`)의 `ref`를 `{sec,ppi,ci,type}`
+   리터럴로 재구성하며 `cellPath`/`headerFooter`를 떨어뜨림 → 조작 헬퍼가 body-level scalar API로
+   폴백 → 중첩 그림을 본문으로 오해석. (PR #1254/`5453b254`가 양 끝은 배선했으나 드래그 staging은 누락)
+2. **이동 커맨드 body-level**: `MovePictureCommand`/`MoveShapeCommand`가 scalar API만 호출 →
+   undo/redo 시 동일 결함 재현.
+3. **리사이즈 offset 페이지절대값**: 단일 선택 리사이즈(라이브+확정)가 offset을 페이지 절대좌표로
+   기록 → 중첩 그림(offset이 컨테이너 상대, HWP5 표69/70 VertRelTo/HorzRelTo)은 글상자 밖으로 이탈.
+
+## 3. 수정 (Stage)
+
+| Stage | 내용 | 파일 |
+|------|------|------|
+| 1 | 드래그 상태 ref 타입에 `cellPath?`/`headerFooter?` 추가 + 3개 생성 지점(L307/323/369)에서 복사 | `input-handler.ts`, `input-handler-mouse.ts` |
+| 2 | `MovePicture/MoveShapeCommand`에 cellPath by-path 지원(execute/undo/mergeWith) + 종료 전달 | `command.ts`, `input-handler-picture.ts` |
+| 3 | 드래그 lifecycle E2E 추가(실제 onClick→drag 경로) + 재발방지 문서 | `e2e/textbox-picture-ops-1273.test.mjs`, troubleshootings |
+| 4 | 리사이즈 offset을 (저장값 + 페이지좌표 델타)로 — 라이브+확정 모두 | `input-handler-picture.ts` |
+
+전부 TypeScript 한정. 필요한 by-path WASM 함수는 이미 번들에 존재(무변경).
+
+## 4. 검증
+
+- `npx tsc --noEmit`: 편집 파일 신규 오류 0건(기존 무관 오류 `canvaskit-renderer.ts`만 base와 동일).
+- E2E `textbox-picture-ops-1273` (실제 InputHandler 드래그 경로, tac-img-02):
+  - 리사이즈 by-path + cellPath 보존 + undo 원복, 회전 각도 반영, floating 리사이즈 글상자 유지 +
+    라이브 추적, 조작 중 콘솔 오류 0건.
+  - **red-green 검증**: Stage1 되돌리면 보고와 동일 오류(`지정된 Shape 컨트롤이 그림이 아닙니다`)로 FAIL,
+    Stage4 되돌리면 글상자 이탈(offset 페이지절대값)로 FAIL. 적용 시 전부 PASS.
+- 기존 `textbox-picture-1171` / `textbox-picture-insert-1171` E2E 회귀 없음.
+
+## 5. 해결 결과 (당초 보고 항목)
+
+- ✅ 글상자/셀 중첩 그림 드래그 **리사이즈·회전·이동** 정상화 (+ 이동 undo/redo).
+- ✅ floating 해제 후 리사이즈 시 **글상자 이탈** 정상화.
+
+## 6. 세션 중 발견된 별개 이슈 (#1273 범위 밖)
+
+1. **그림을 글상자보다 크게 리사이즈 → 글상자가 렌더 이미지를 클리핑(컨테이너 미확장) → 선택 박스 >
+   보이는 이미지**. HWP 동작도 애매(컨테이너 lazy 확장). 검증에 #2 선행 필요(새 문서 작성 차단) →
+   **보류**.
+2. **새로 만든 글상자에 커서 진입/붙여넣기 실패** (`글상자 없음` — paste-into-shape가 `text_box`
+   미발견, `clipboard.rs:512`; 셀 커서 위치 실패). #1229(글상자 이미지 선택·복사, 읽기)와 **같은 영역
+   형제이나 메커니즘은 별개(쓰기/커서 진입)**. → #1229 연관 또는 신규 이슈. 근본원인(글상자 생성 시
+   text_box 누락 vs 커서 control 오지정) 별도 조사 필요.
+
+> 별개 이슈 등록·`local/devel` merge·#1273 close 는 작업지시자 결정에 따른다.

--- a/mydocs/troubleshootings/textbox_picture_drag_ops_cellpath_1273.md
+++ b/mydocs/troubleshootings/textbox_picture_drag_ops_cellpath_1273.md
@@ -1,0 +1,65 @@
+# 글상자/셀 중첩 그림 마우스 드래그 조작 실패 — 드래그 상태 staging ref 소비처 누락 (#1273)
+
+- **작성일**: 2026-06-03
+- **관련**: #1273, 선행 #1171(hit-test, CLOSED)·PR #1254·보완 커밋 `5453b254`,
+  메인테이너 사후분석 `nested_picture_selection_ref_consumers_1171.md`
+- **분류**: 재발 방지 (공유 ref 소비처 감사 누락 — 한 단계 심화)
+
+## 현상
+
+글상자(Shape text_box)·셀 안 picture 를 **마우스 핸들 드래그**로 리사이즈/회전/이동하면:
+
+```
+[InputHandler] 개체 리사이즈 실패: 렌더링 오류: 컨트롤 인덱스 1 범위 초과
+[InputHandler] 개체 리사이즈 실패: 렌더링 오류: 지정된 Shape 컨트롤이 그림이 아닙니다
+[InputHandler] 개체 회전 드래그 실패: 렌더링 오류: 컨트롤 인덱스 1 범위 초과
+```
+
+선택·대화상자·키보드는 정상. 마우스 드래그만 실패(단일 선택 한정, 다중 선택은 정상).
+
+## 근본 원인 — 선택 ref 와 소비처 사이의 "드래그 상태 staging 객체"가 cellPath 를 떨어뜨림
+
+`5453b254`(메인테이너)는 선택 ref 생성 → 조작 헬퍼(`get/setObjectProperties`) →
+리사이즈 커맨드 타깃까지 **양 끝**에 cellPath 를 배선했다. 그러나 마우스 드래그는 선택 ref 를
+곧장 쓰지 않고, **중간에 드래그 상태 객체**(`pictureResizeState`/`pictureRotateState`/
+`pictureMoveState`)를 새로 만들어 그것을 소비한다. 그 객체를 만들 때
+`ref: { sec, ppi, ci, type }` 리터럴로 재조립하면서 `cellPath`/`headerFooter` 를 누락
+(`input-handler-mouse.ts` L307/L323/L369).
+
+→ 드래그 중/종료 시 path 가 없어 scalar API(`setPictureProperties(sec,ppi,ci)`)로 폴백 →
+중첩 picture 를 본문 문단으로 오해석 → 위 오류.
+
+즉, **하류(소비처)는 cellPath 를 받을 준비를 끝냈는데 상류(드래그 상태 생성)가 흘려버려**
+연결이 끊긴 것. `5453b254` 의 `input-handler-mouse.ts` 변경은 +2줄(선택 호출만)이고,
+**드래그 상태 staging 객체는 감사 범위 밖**이었다.
+
+## 메인테이너 1171 사후분석과의 관계
+
+`nested_picture_selection_ref_consumers_1171.md` 의 교훈 #2("공유 ref 소비처 grep 감사")가
+**한 단계 더** 적용됐어야 했다. 그 문서는 *조작 엔드포인트*(delete/resize 커맨드/dialog)를
+감사 대상으로 봤지만, 그 사이에서 ref 를 **재materialize 하는 드래그 staging 객체**(resize/
+rotate/move 3곳)는 목록에 없었다. → "공유 ref 의 소비처"에는 **최종 연산뿐 아니라 중간
+staging 도 포함**해야 한다.
+
+## 해결 (#1273, TypeScript 전용)
+
+- `input-handler.ts`: 3개 드래그 상태 `ref` 타입에 `cellPath?`/`headerFooter?` 가산.
+- `input-handler-mouse.ts` L307/L323/L369: 리터럴에 `cellPath: ref.cellPath, headerFooter: ref.headerFooter` 복사.
+- `command.ts`: `MovePictureCommand`/`MoveShapeCommand` 에 cellPath by-path 지원(undo/redo) + `finishPictureMoveDrag` 전달.
+
+## 재발 방지 — 검증 공백도 동시 해소
+
+기존 E2E(`textbox-picture-1171`)는 `wasm.setCellPicturePropertiesByPath` 를 **직접** 불러
+드래그 staging 경로를 **우회**했기에 버그가 있어도 통과했다(교훈 #3 그대로). 신규
+`e2e/textbox-picture-ops-1273.test.mjs` 는 **InputHandler 의 실제 드래그 경로**(onClick →
+mousemove → mouseup, 실제 핸들 좌표 + 스크롤 진입)를 구동하여:
+- `pictureResizeState.ref.cellPath`/`pictureRotateState.ref.cellPath` 보존을 직접 검증,
+- 리사이즈 by-path 반영 + undo 원복, 회전 각도 반영, 조작 중 콘솔 오류 0건 확인.
+
+**red-green 검증 완료**: Stage1 수정을 되돌리면 동일 콘솔 오류로 FAIL, 적용 시 PASS.
+
+## 체크리스트 (다음에 위치 개체를 1급화할 때)
+
+1. 공유 ref 의 **모든 소비처**를 grep — 최종 연산뿐 아니라 **드래그/이동 staging 객체**까지.
+2. ref 를 리터럴로 재조립하는 지점은 `cellPath`/`headerFooter`/`noteRef` 등 위치 식별자를 **전부 spread/복사**.
+3. 검증은 WASM API 직접 호출이 아니라 **사용자 연산 표면(InputHandler 드래그 경로)** 으로.

--- a/mydocs/working/task_m100_1273_stage1.md
+++ b/mydocs/working/task_m100_1273_stage1.md
@@ -1,0 +1,40 @@
+# Task M100 #1273 Stage 1 완료 보고서
+
+드래그 상태 ref 타입 확장 + `cellPath`/`headerFooter` 보존 — 리사이즈·회전·이동 실시간 경로 정정.
+
+## 1. 변경 내용
+
+### (1) `rhwp-studio/src/engine/input-handler.ts`
+- L20: `@/core/types`에서 `CellPathLike` import 추가.
+- 단일 드래그 상태 3종(`pictureResizeState`·`pictureMoveState`·`pictureRotateState`)의 `ref` 필드
+  타입에 선택 필드 추가(가산적·안전, 기존 동작 영향 없음):
+  ```ts
+  ref: { sec; ppi; ci; type: 'image'|'shape'|'equation'|'group';
+         cellPath?: CellPathLike;
+         headerFooter?: { kind: 'header'|'footer'; outerParaIdx: number; outerControlIdx: number } };
+  ```
+  (`lineEndpointState.ref`(`type: string`)는 변경 대상 아님 — 범위 외.)
+
+### (2) `rhwp-studio/src/engine/input-handler-mouse.ts`
+- L307(회전)·L323(리사이즈)·L369(이동) 드래그 상태 생성 시 ref 리터럴에
+  `cellPath: ref.cellPath, headerFooter: ref.headerFooter`를 추가로 복사.
+  (다중 선택 경로의 spread `{ ...r }` 와 동일한 path 보존 의미.)
+
+## 2. 효과
+
+- 드래그 시작 시 선택 ref의 `cellPath`/`headerFooter`가 staging 객체로 보존됨 →
+  `updatePictureResizeDrag`/`updatePictureRotateDrag`/`updatePictureMoveDrag` 및
+  `finishPictureResizeDrag`가 `setObjectProperties`에서 **by-path WASM API**로 정상 분기.
+- 이로써 **리사이즈·회전은 완전 해결**(회전은 undo 커맨드 없음), **이동 실시간 드래그 해결**.
+- 이동 undo/redo는 Move 커맨드가 아직 scalar이므로 Stage 2에서 처리.
+
+## 3. 검증
+
+- `npx tsc --noEmit`: 편집 파일에서 신규 오류 **0건**. 기존 3건은 무관 파일
+  (`src/view/canvaskit-renderer.ts`, 누락 모듈 `canvaskit-wasm`)로 base와 동일(diff 없음).
+- rhwp-studio에는 lint 스크립트/eslint 설정이 없어 정적 검사는 `tsc`가 기준.
+- 수동/E2E 시각 검증은 Stage 3에서 일괄 수행.
+
+## 4. 다음 단계
+
+Stage 2 — `MovePictureCommand`/`MoveShapeCommand` by-path 지원 + `finishPictureMoveDrag` cellPath 전달.

--- a/mydocs/working/task_m100_1273_stage2.md
+++ b/mydocs/working/task_m100_1273_stage2.md
@@ -1,0 +1,44 @@
+# Task M100 #1273 Stage 2 완료 보고서
+
+이동 커맨드 by-path 지원 — 중첩 그림 이동의 undo/redo 정상화.
+
+## 1. 배경
+
+Stage 1로 드래그 상태 ref에 `cellPath`가 보존되어 **이동 실시간 드래그**는 해결되었으나,
+이동 종료 시 기록되는 `MovePictureCommand`/`MoveShapeCommand`가 scalar
+`get/setPictureProperties`(`get/setShapeProperties`)만 호출하여, **undo/redo 시점에 중첩 그림을
+본문으로 오해석** → 동일 오류 재현 위험이 남아 있었다.
+
+## 2. 변경 내용
+
+### `rhwp-studio/src/engine/command.ts`
+- 모듈 헬퍼 3종 추가(파일의 `do*` 헬퍼 idiom과 일치):
+  - `sameCellPath(a, b)`: `JSON.stringify(?? [])` 비교 — undefined/빈배열은 본문 동일 취급.
+  - `moveGetProps(wasm, kind, sec, ppi, ci, cellPath?)`: cellPath 존재 시
+    `getCell{Picture,Shape}PropertiesByPath`, 없으면 scalar getter.
+  - `moveSetProps(wasm, kind, sec, ppi, ci, cellPath, props)`: 동일 분기로 setter.
+- `MovePictureCommand`/`MoveShapeCommand`:
+  - 생성자에 선택적 `cellPath?: CellPathLike` 추가(8번째, `timestamp?` 앞 — 기존 7-인자 호출 호환).
+  - `execute`/`undo`를 `moveGetProps`/`moveSetProps`(kind `'image'`/`'shape'`)로 교체.
+  - `mergeWith` 가드에 `sameCellPath` 비교 추가 + 재생성 시 `this.cellPath` 전달.
+
+### `rhwp-studio/src/engine/input-handler-picture.ts`
+- `finishPictureMoveDrag`(L778): `new CmdClass(...)` 8번째 인자로 `r.cellPath` 전달.
+  단일 경로(`pictureMoveState.ref`, Stage 1)·다중 경로(`multiMoveRefs` spread) 모두 `r.cellPath` 보유.
+
+## 3. 효과
+
+- 중첩 그림 이동의 **undo/redo가 by-path API로 정상 동작**. body-level 그림은 기존 scalar 경로 유지(무변경).
+- `mergeWith`가 cellPath까지 구분 → 서로 다른 위치 개체의 이동이 잘못 병합되지 않음.
+
+## 4. 검증
+
+- `npx tsc --noEmit`: 편집 파일(`command.ts`, `input-handler-picture.ts`) 신규 오류 **0건**.
+  전체 출력이 base와 **완전 동일**(기존 무관 오류 3건 `canvaskit-renderer.ts`만 존재).
+- `MovePictureCommand`/`MoveShapeCommand` 호출처는 내부 `mergeWith` 2곳 + `finishPictureMoveDrag`
+  1곳뿐 — 모두 갱신 완료. WASM by-path getter/setter는 기존 번들에 존재(무변경).
+
+## 5. 다음 단계
+
+Stage 3 — E2E lifecycle 테스트(select→resize/rotate/move(+undo)) + 수동 시각 확인 +
+`nested_picture_selection_ref_consumers_1171.md`에 "드래그 상태 staging ref 소비처 누락" 사례 추가.

--- a/mydocs/working/task_m100_1273_stage3.md
+++ b/mydocs/working/task_m100_1273_stage3.md
@@ -1,0 +1,55 @@
+# Task M100 #1273 Stage 3 완료 보고서
+
+E2E lifecycle 테스트 + 테스트 커버리지 감사 + 재발 방지 문서.
+
+## 1. 테스트 커버리지 감사 (선행)
+
+우리가 수정한 영역(InputHandler 드래그 경로·Move/Resize 커맨드 by-path)을 기존 테스트와 매핑한 결과 **명확한 공백** 확인:
+
+| 레이어 | 기존 테스트 | 커버 |
+|--------|-------------|------|
+| WASM by-path API **직접 호출** | `textbox-picture-1171.test.mjs`, Rust `issue_1171_textbox_picture_cellpath.rs` | round-trip·hit-test |
+| 삽입 | `textbox-picture-insert-1171.test.mjs` | 본문 sibling 삽입 |
+| **InputHandler 드래그 lifecycle** | **없음** | — |
+| **Move/Resize 커맨드 by-path·undo/redo** | **없음** | — |
+
+기존 E2E 는 `wasm.setCellPicturePropertiesByPath` 를 **직접** 호출하여 드래그 staging 경로를 우회 → 버그가 있어도 통과(교훈 #3).
+
+## 2. 신규 E2E — `rhwp-studio/e2e/textbox-picture-ops-1273.test.mjs`
+
+InputHandler 의 **실제 드래그 경로**를 구동(onClick → mousemove → mouseup, 실제 핸들 좌표).
+대상: `tac-img-02.hwp` 섹션0 문단25 글상자 picture(cellPath sentinel, 페이지5).
+
+검증 항목:
+- **리사이즈**: se 핸들 드래그 → `pictureResizeState.ref.cellPath` 보존(핵심 회귀) + 폭 15040→18038 by-path 반영 + **undo 원복**(→15040).
+- **회전**: rotate 핸들 드래그 → `pictureRotateState.ref.cellPath` 보존 + 각도 0°→29° 반영.
+- **공통**: 조작 중 콘솔 오류('실패/범위 초과/그림이 아님') **0건**.
+- 대상 picture 는 `treat_as_char=true`(글상자 내 인라인)이라 이동 드래그는 N/A — 이동 by-path(Stage 2)는 리사이즈 undo 의 `setCellPicturePropertiesByPath` 동일 경로로 간접 커버.
+
+### 구현 메모 (하니스 특이점)
+- 합성 MouseEvent 에 `target`(=container) 명시 — `onClick` 의 `e.target.closest('#menu-bar')` 가드 대응.
+- 대상 picture 가 페이지5(오프스크린)라 `onClick` 의 스크롤바영역 가드(`localY >= clientHeight`)에 막힘 → `ih.container.scrollTop` 으로 핸들을 뷰포트 안으로 스크롤 후 클릭.
+
+## 3. red-green 검증
+
+- **green**: 현재 코드(Stage1+2)로 신규 테스트 전 항목 PASS.
+- **red**: Stage1 의 리사이즈 ref 보존을 임시로 되돌리면, `stateCellPath: null` + 폭 미변경 +
+  콘솔 `개체 리사이즈 실패: 렌더링 오류: 지정된 Shape 컨트롤이 그림이 아닙니다`(사용자 보고와 동일)로 FAIL.
+- 즉 본 테스트는 회귀를 실제로 잡는다. 복원 후 재실행 PASS 확인.
+- **회귀 안전**: 기존 `textbox-picture-1171`/`textbox-picture-insert-1171` E2E 모두 PASS 유지.
+
+## 4. 재발 방지 문서
+
+`mydocs/troubleshootings/textbox_picture_drag_ops_cellpath_1273.md` 신설 —
+"드래그 상태 staging ref 소비처 누락" 사례 + 체크리스트(공유 ref 소비처에 staging 포함, 위치 식별자 전부 복사, 검증은 연산 표면으로). 메인테이너 `nested_picture_selection_ref_consumers_1171.md` 교훈 #2/#3 의 심화.
+
+## 5. 실행 방법
+
+```bash
+cd rhwp-studio
+npx vite --host 127.0.0.1 --port 7700 &
+CHROME_PATH="<chrome>" VITE_URL=http://127.0.0.1:7700 \
+  node e2e/textbox-picture-ops-1273.test.mjs --mode=headless
+```
+
+수동 시각 확인(글상자/머리말꼬리말 picture 드래그)은 작업지시자 환경에서 권장.

--- a/mydocs/working/task_m100_1273_stage4.md
+++ b/mydocs/working/task_m100_1273_stage4.md
@@ -1,0 +1,67 @@
+# Task M100 #1273 Stage 4 완료 보고서
+
+floating(글자처럼취급 해제) 중첩 picture 리사이즈 시 글상자 이탈 수정 — offset 페이지절대값 → 델타 기반.
+
+## 1. 배경 (Stage 1~3 후 노출된 잠재 결함)
+
+Stage 1 이전에는 중첩 picture 리사이즈가 아예 실패했으나, 수정 후 리사이즈가 동작하면서
+**단일 선택 리사이즈의 offset 좌표계 버그**가 드러났다. "개체 속성에서 글자처럼 취급 해제(floating)
+후 축소하면 글상자 밖으로 벗어나 이동"하는 현상(작업지시자 보고).
+
+## 2. 근본 원인 (코드 + 런타임 확정)
+
+`finishPictureResizeDrag` 단일 선택 경로(`input-handler-picture.ts`)가 offset 을
+**페이지 절대 좌표**로 기록:
+- `before['horzOffset'] = state.origHorzOffset`(실제 저장값, 컨테이너 상대)
+- `updated['horzOffset'] = newBbox.x * PX2HWP`(페이지 절대) ← 좌표계 불일치
+
+본문 그림(보통 HorzRelTo=page)은 저장값≈페이지좌표라 우연히 맞지만, 글상자/셀 중첩 picture 는
+offset 이 **컨테이너 상대(작은 값)** 이라 페이지 절대값으로 덮으면 글상자 밖으로 튕긴다.
+바로 위 **다중 선택 경로는 이미 델타 기반**(`origHorzOffset + deltaH`)으로 올바름.
+
+**런타임 증거(probe/E2E)**: floating 전환 후 nw 축소 시 vertOffset 59925 → **122100**(페이지절대 ≈119850),
+bbox y 1598 → **2427**(829px 점프, 글상자 이탈). 수정 후: 59925 → 62175(델타 2250), bbox 1598 → 1628(30px).
+
+## 3. HWP5 스펙 정합 (한글문서파일형식_5.0_revision1.3.md)
+
+- **표 69 개체 공통 속성**: "세로 오프셋 값"/"가로 오프셋 값"(각 HWPUNIT) 저장.
+- **표 70 개체 공통 속성의 속성**: bit 3~4 `VertRelTo`(paper/page/para), bit 8~9 `HorzRelTo`
+  (page/column/para). → **offset 은 기준(RelTo) 프레임에 대한 상대값**이며 페이지 절대 픽셀이 아니다.
+- **표 83 개체 요소**: "개체가 속한 그룹 내에서의 X/Y offset" — 컨테이너 상대 좌표.
+
+→ 리사이즈 코드는 객체의 RelTo 프레임을 알지 못하므로 **페이지 절대값으로 변환해 기록하면 스펙 위반**
+(특히 RelTo=para 인 중첩 객체). **저장된 상대 offset 을 유지하고 드래그 델타만 더하는** 본 수정은
+RelTo 값과 무관하게 항상 스펙에 정합한다(프레임 불가지). 본문 그림이 버그 코드에서도 우연히 동작한
+이유(page 상대) 와, 중첩/para 상대 객체가 깨진 이유를 모두 설명한다.
+
+## 4. 변경
+
+`rhwp-studio/src/engine/input-handler-picture.ts` — **동일 버그가 2곳**에 있어 모두 델타 기반으로 수정:
+- `finishPictureResizeDrag`(드래그 종료/확정) 단일 선택
+- `updatePictureResizeDrag`(라이브 드래그) 단일 선택 ← 작업지시자 추가 보고
+  ("리사이즈 중 검정 예비박스가 이미지 축소와 정합하지 않음")의 원인
+
+```ts
+const newHorzOffset = Math.round(newBbox.x * PX_TO_HWP);   // 페이지좌표
+const origHorzOffset = Math.round(state.bbox.x * PX_TO_HWP);
+const beforeHorzOffset = state.origHorzOffset ?? origHorzOffset; // 저장 offset
+// before(저장 offset) + 페이지좌표 델타
+updated['horzOffset'] = ((beforeHorzOffset + (newHorzOffset - origHorzOffset)) >>> 0);
+```
+다중 선택 경로와 동일한 델타 방식. 본문 그림은 before≈orig 이므로 동작 불변.
+
+라이브 드래그(`updatePictureResizeDrag`)도 페이지 절대값을 쓰면, `renderDragPreview` 가 그린
+예비 테두리(검정 박스)는 올바른 위치인데 **이미지만 페이지 절대 offset 으로 이동**해 드래그 중
+박스와 이미지가 어긋났다. finishPictureResizeDrag(Stage4 초안)만 고치면 최종 결과는 맞지만
+**드래그 중 프레임은 계속 어긋난다** → 라이브 경로도 동일 수정 필요.
+
+## 5. 검증 (red-green)
+
+`e2e/textbox-picture-ops-1273.test.mjs` 에 FLOATING 리사이즈 시나리오 추가:
+글자처럼취급 해제 → nw 축소 → (a) vertOffset 변화가 델타 크기(<20000, 페이지절대 아님),
+(b) bbox y 점프 <300px(글상자 유지), (c) **라이브 드래그 중(mouseup 전) 이미지 bbox 가
+예비박스 추적**(bbYMid 점프 <300px) — `updatePictureResizeDrag` 라이브 fix 커버.
+- **green**(수정): vertOffset 59925→62175, bbox 1598→1628, bbYMid 799→829(델타 30px) PASS.
+- **red**(finish 되돌림): vertOffset 59925→122100, bbox 1598→2427 FAIL.
+- **red**(live 되돌림): bbYMid 799→1628(829px 점프) → 라이브 추적 assertion FAIL(검정박스 어긋남 재현).
+- tsc 신규 오류 0건. 기존 리사이즈/회전 시나리오 및 textbox-picture-1171 E2E 회귀 없음.

--- a/rhwp-studio/e2e/textbox-picture-ops-1273.test.mjs
+++ b/rhwp-studio/e2e/textbox-picture-ops-1273.test.mjs
@@ -65,8 +65,8 @@ runTest('글상자 안 picture 마우스 드래그 조작 lifecycle (#1273)', as
         select(); // 스크롤 후 핸들 재배치
         await nextFrame();
       };
-      // 선택 → 핸들 dir 로 드래그 1회. 반환: { stateCellPath, dragging }
-      const drag = async (stateName, dirPick, mdx, mdy) => {
+      // 선택 → 핸들 dir 로 드래그 1회. onMid 는 mousemove 후 mouseup 전(라이브 드래그 중) 실행.
+      const drag = async (stateName, dirPick, mdx, mdy, onMid) => {
         select();
         let h = (ih.pictureObjectRenderer.handles || []).find(dirPick);
         if (!h) return { handleDir: null };
@@ -80,6 +80,7 @@ runTest('글상자 안 picture 마우스 드래그 조작 lifecycle (#1273)', as
         const info = { handleDir: h.dir, stateCellPath: st?.ref?.cellPath ?? null, dragging: !!st };
         ih.onMouseMoveBound(me('mousemove', dx + mdx, dy + mdy));
         await nextFrame();
+        if (onMid) info.mid = onMid();
         ih.onMouseUpBound(me('mouseup', dx + mdx, dy + mdy));
         return info;
       };
@@ -94,17 +95,36 @@ runTest('글상자 안 picture 마우스 드래그 조작 lifecycle (#1273)', as
         out.resize.wUndo = getProps().width;
       }
 
+      // ───────── FLOATING 리사이즈 (글자처럼취급 해제 후 축소 → 글상자 이탈 회귀, Stage4) ─────────
+      {
+        const PX2HWP = 7200 / 96;
+        select();
+        ih.setObjectProperties(cursor.getSelectedPictureRef(), { treatAsChar: false });
+        await nextFrame();
+        const pB = getProps();
+        const bbB = ih.findPictureBbox(cursor.getSelectedPictureRef());
+        // onMid: 라이브 드래그 중(mouseup 전) 이미지 위치 캡처 — 예비박스 추적 확인
+        const info = await drag('pictureResizeState', (x) => x.dir === 'nw', 30, 30,
+          () => { const bb = ih.findPictureBbox(cursor.getSelectedPictureRef()); return bb ? Math.round(bb.y) : null; });
+        const pA = getProps();
+        const bbA = ih.findPictureBbox(cursor.getSelectedPictureRef());
+        out.floating = {
+          handleDir: info.handleDir, stateCellPath: info.stateCellPath,
+          treatAsChar: pB.treatAsChar,
+          vBefore: pB.vertOffset, vAfter: pA.vertOffset,
+          hBefore: pB.horzOffset, hAfter: pA.horzOffset,
+          pageAbsV: bbB ? Math.round(bbB.y * PX2HWP) : null,
+          bbYBefore: bbB ? Math.round(bbB.y) : null,
+          bbYMid: info.mid ?? null,
+          bbYAfter: bbA ? Math.round(bbA.y) : null,
+        };
+      }
+
       // ───────── ROTATE (rotate 핸들) ─────────
       {
         const a0 = getProps().rotationAngle ?? 0;
         const info = await drag('pictureRotateState', (x) => x.dir === 'rotate', 60, 30);
         out.rotate = { ...info, a0, a1: getProps().rotationAngle ?? 0 };
-      }
-
-      // ───────── MOVE (treat_as_char 이면 N/A) ─────────
-      {
-        const p0 = getProps();
-        out.move = { treatAsChar: !!p0.treatAsChar };
       }
     } finally {
       console.warn = origWarn;
@@ -135,7 +155,20 @@ runTest('글상자 안 picture 마우스 드래그 조작 lifecycle (#1273)', as
   assert(result.rotate.a1 !== result.rotate.a0,
     `회전 각도 미반영: ${result.rotate.a0} → ${result.rotate.a1}`);
 
-  console.log(`ℹ️ MOVE: treat_as_char=${result.move.treatAsChar} (인라인 picture → 이동 드래그 N/A; ` +
-    `by-path 이동은 리사이즈 undo 의 setCellPicturePropertiesByPath 로 간접 커버)`);
-  console.log('✅ #1273 글상자 picture: 리사이즈·회전 lifecycle + cellPath 보존 + undo 통과');
+  // FLOATING 리사이즈 — Stage 4: offset 이 페이지 절대값이 아니라 델타(컨테이너 상대)로 적용
+  //  (글자처럼취급 해제 후 축소 시 글상자 밖으로 이탈하지 않아야 함)
+  assert(result.floating?.handleDir === 'nw', 'floating 리사이즈 nw 핸들 실패');
+  assert(result.floating.treatAsChar === false, 'floating 전환 실패 (treatAsChar≠false)');
+  assert(Array.isArray(result.floating.stateCellPath) && result.floating.stateCellPath.length > 0,
+    `floating 리사이즈 stateCellPath 누락: ${JSON.stringify(result.floating.stateCellPath)}`);
+  assert(Math.abs(result.floating.vAfter - result.floating.vBefore) < 20000,
+    `floating vertOffset 페이지절대값 점프(Stage4 회귀): ${result.floating.vBefore} → ${result.floating.vAfter} ` +
+    `(page-abs≈${result.floating.pageAbsV})`);
+  assert(Math.abs(result.floating.bbYAfter - result.floating.bbYBefore) < 300,
+    `floating picture 가 글상자 밖으로 이탈(세로 점프): bbY ${result.floating.bbYBefore} → ${result.floating.bbYAfter}`);
+  // 라이브 드래그 중 이미지가 예비박스를 추적해야 함(updatePictureResizeDrag offset 도 델타 기반)
+  assert(result.floating.bbYMid != null && Math.abs(result.floating.bbYMid - result.floating.bbYBefore) < 300,
+    `라이브 드래그 중 이미지가 예비박스에서 이탈(어긋남): bbY ${result.floating.bbYBefore} → mid ${result.floating.bbYMid}`);
+
+  console.log('✅ #1273 글상자 picture: 리사이즈·회전·floating리사이즈 lifecycle + cellPath 보존 + undo 통과');
 });

--- a/rhwp-studio/e2e/textbox-picture-ops-1273.test.mjs
+++ b/rhwp-studio/e2e/textbox-picture-ops-1273.test.mjs
@@ -1,0 +1,141 @@
+/**
+ * E2E 테스트 (Issue #1273): 사각형 글상자(Shape text_box) 안 picture 의
+ * 마우스 드래그 조작(리사이즈·회전·이동) lifecycle.
+ *
+ * #1171 의 hit-test/속성 round-trip 테스트(textbox-picture-1171)는 WASM by-path API 를
+ * **직접** 호출하여, 드래그 상태(pictureResizeState 등) 구성이 cellPath 를 떨어뜨리는
+ * 결함을 우회했다. 본 테스트는 그 공백을 메운다 — InputHandler 의 실제 드래그 경로
+ * (onClick → mousemove → mouseup, 실제 핸들 좌표)를 구동하여:
+ *   1) 드래그 상태 ref 에 cellPath 가 보존되는지 (Stage 1, 핵심 회귀 검증)
+ *   2) 리사이즈가 by-path API 로 실제 반영되고 undo 로 원복되는지 (+ 콘솔 오류 0건)
+ *   3) 회전이 by-path 로 반영되는지
+ *
+ * 대상: samples/tac-img-02.hwp 섹션0 문단25 글상자 안 picture (cellPath sentinel, 페이지5).
+ * 대상 picture 는 treat_as_char=true(글상자 내 인라인)이므로 이동 드래그는 N/A —
+ * 이동 by-path(Stage 2)는 리사이즈 undo(동일 setCell*PropertiesByPath 경로)로 간접 커버.
+ */
+import { runTest, loadHwpFile, assert } from './helpers.mjs';
+
+runTest('글상자 안 picture 마우스 드래그 조작 lifecycle (#1273)', async ({ page }) => {
+  await loadHwpFile(page, 'tac-img-02.hwp');
+
+  const result = await page.evaluate(async () => {
+    const wasm = window.__wasm;
+    const ih = window.__inputHandler;
+    const cursor = ih.cursor;
+
+    // 조작 중 '실패/범위 초과/그림이 아님' 콘솔 오류 감지
+    const warnings = [];
+    const origWarn = console.warn;
+    console.warn = (...a) => { warnings.push(a.map(String).join(' ')); origWarn.apply(console, a); };
+
+    const nextFrame = () => new Promise((r) => requestAnimationFrame(() => requestAnimationFrame(r)));
+    const out = { warnings };
+
+    try {
+      // 1) 글상자 picture(paraIdx=25, cellPath) 탐색
+      let found = null;
+      for (let p = 0; p < wasm.pageCount; p++) {
+        let layout; try { layout = wasm.getPageControlLayout(p); } catch { continue; }
+        for (const c of layout.controls || []) {
+          if (c.type === 'image' && c.paraIdx === 25 && c.controlIdx === 0 && c.cellPath) { found = c; break; }
+        }
+        if (found) break;
+      }
+      if (!found) { out.error = 'paraIdx=25 글상자 picture 를 찾지 못함'; return out; }
+      const cellPath = found.cellPath;
+      out.cellPath = cellPath;
+
+      const getProps = () => wasm.getCellPicturePropertiesByPath(0, 25, cellPath, 0);
+      const sc = ih.container.querySelector('#scroll-content');
+      const select = () => {
+        cursor.enterPictureObjectSelectionDirect(0, 25, 0, 'image', undefined, undefined, undefined, undefined, cellPath);
+        ih.renderPictureObjectSelection();
+      };
+      // target 명시: 직접 핸들러 호출 시 e.target.closest 가드 통과용 (container 는 툴바 밖)
+      const me = (type, x, y) => {
+        const ev = new MouseEvent(type, { button: 0, clientX: x, clientY: y, bubbles: true });
+        Object.defineProperty(ev, 'target', { value: ih.container, configurable: true });
+        return ev;
+      };
+      // 핸들(content 좌표)을 뷰포트 안으로 스크롤 — onClick 의 스크롤바영역 가드 통과
+      const ensureVisible = async (contentY) => {
+        ih.container.scrollTop = Math.max(0, contentY - ih.container.clientHeight / 2);
+        await nextFrame();
+        select(); // 스크롤 후 핸들 재배치
+        await nextFrame();
+      };
+      // 선택 → 핸들 dir 로 드래그 1회. 반환: { stateCellPath, dragging }
+      const drag = async (stateName, dirPick, mdx, mdy) => {
+        select();
+        let h = (ih.pictureObjectRenderer.handles || []).find(dirPick);
+        if (!h) return { handleDir: null };
+        await ensureVisible(h.cy);
+        h = (ih.pictureObjectRenderer.handles || []).find(dirPick);
+        if (!h) return { handleDir: null };
+        const r = sc.getBoundingClientRect();
+        const dx = r.left + h.cx, dy = r.top + h.cy;
+        ih.onClickBound(me('mousedown', dx, dy));
+        const st = ih[stateName];
+        const info = { handleDir: h.dir, stateCellPath: st?.ref?.cellPath ?? null, dragging: !!st };
+        ih.onMouseMoveBound(me('mousemove', dx + mdx, dy + mdy));
+        await nextFrame();
+        ih.onMouseUpBound(me('mouseup', dx + mdx, dy + mdy));
+        return info;
+      };
+
+      // ───────── RESIZE (se 핸들 +40,+40) + undo ─────────
+      {
+        const w0 = getProps().width;
+        // se(우하단) 핸들 + (+40,+40) → 가로/세로 확대 (방향 결정적)
+        const info = await drag('pictureResizeState', (x) => x.dir === 'se', 40, 40);
+        out.resize = { ...info, w0, w1: getProps().width };
+        ih.handleUndo();
+        out.resize.wUndo = getProps().width;
+      }
+
+      // ───────── ROTATE (rotate 핸들) ─────────
+      {
+        const a0 = getProps().rotationAngle ?? 0;
+        const info = await drag('pictureRotateState', (x) => x.dir === 'rotate', 60, 30);
+        out.rotate = { ...info, a0, a1: getProps().rotationAngle ?? 0 };
+      }
+
+      // ───────── MOVE (treat_as_char 이면 N/A) ─────────
+      {
+        const p0 = getProps();
+        out.move = { treatAsChar: !!p0.treatAsChar };
+      }
+    } finally {
+      console.warn = origWarn;
+    }
+    return out;
+  });
+
+  assert(!result.error, `검증 실패: ${result.error}`);
+  console.log('결과:', JSON.stringify(result, null, 2));
+
+  // 공통: 조작 중 오류 경고 0건
+  const fails = result.warnings.filter((w) => /실패|범위 초과|그림이 아닙니다/.test(w));
+  assert(fails.length === 0, `조작 중 오류 경고 발생: ${JSON.stringify(fails)}`);
+
+  // RESIZE — Stage 1 핵심 회귀: 드래그 상태 ref 에 cellPath 보존 + by-path 반영 + undo 원복
+  assert(result.resize?.handleDir, '리사이즈 핸들을 찾지 못함 (선택/렌더/스크롤 실패)');
+  assert(Array.isArray(result.resize.stateCellPath) && result.resize.stateCellPath.length > 0,
+    `pictureResizeState.ref.cellPath 누락 — Stage1 회귀: ${JSON.stringify(result.resize.stateCellPath)}`);
+  assert(result.resize.w1 > result.resize.w0,
+    `리사이즈 미반영: ${result.resize.w0} → ${result.resize.w1}`);
+  assert(result.resize.wUndo === result.resize.w0,
+    `리사이즈 undo 원복 실패: ${result.resize.w0} → ${result.resize.w1} → ${result.resize.wUndo}`);
+
+  // ROTATE — Stage 1: 회전 드래그 상태 ref 에 cellPath 보존 + 각도 반영
+  assert(result.rotate?.handleDir === 'rotate', '회전 핸들을 찾지 못함');
+  assert(Array.isArray(result.rotate.stateCellPath) && result.rotate.stateCellPath.length > 0,
+    `pictureRotateState.ref.cellPath 누락 — Stage1 회귀: ${JSON.stringify(result.rotate.stateCellPath)}`);
+  assert(result.rotate.a1 !== result.rotate.a0,
+    `회전 각도 미반영: ${result.rotate.a0} → ${result.rotate.a1}`);
+
+  console.log(`ℹ️ MOVE: treat_as_char=${result.move.treatAsChar} (인라인 picture → 이동 드래그 N/A; ` +
+    `by-path 이동은 리사이즈 undo 의 setCellPicturePropertiesByPath 로 간접 커버)`);
+  console.log('✅ #1273 글상자 picture: 리사이즈·회전 lifecycle + cellPath 보존 + undo 통과');
+});

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -699,6 +699,39 @@ export class MoveTableCommand implements EditCommand {
 
 // ─── 그림 이동 명령 ─────────────────────────────────────
 
+/** 두 cellPath 가 동일한지 비교 (undefined/빈배열은 본문(body-level)로 동일 취급) */
+function sameCellPath(a?: CellPathLike, b?: CellPathLike): boolean {
+  return JSON.stringify(a ?? []) === JSON.stringify(b ?? []);
+}
+
+/** 개체 이동 명령용 속성 조회 — cellPath 존재 시 by-path API 로 분기 */
+function moveGetProps(
+  wasm: WasmBridge, kind: 'image' | 'shape',
+  sec: number, ppi: number, ci: number, cellPath?: CellPathLike,
+): { horzOffset: number; vertOffset: number } {
+  const nested = !!cellPath && cellPath.length > 0;
+  if (kind === 'shape') {
+    return nested ? wasm.getCellShapePropertiesByPath(sec, ppi, cellPath!, ci) : wasm.getShapeProperties(sec, ppi, ci);
+  }
+  return nested ? wasm.getCellPicturePropertiesByPath(sec, ppi, cellPath!, ci) : wasm.getPictureProperties(sec, ppi, ci);
+}
+
+/** 개체 이동 명령용 속성 변경 — cellPath 존재 시 by-path API 로 분기 */
+function moveSetProps(
+  wasm: WasmBridge, kind: 'image' | 'shape',
+  sec: number, ppi: number, ci: number, cellPath: CellPathLike | undefined,
+  props: Record<string, unknown>,
+): void {
+  const nested = !!cellPath && cellPath.length > 0;
+  if (kind === 'shape') {
+    if (nested) { wasm.setCellShapePropertiesByPath(sec, ppi, cellPath!, ci, props); return; }
+    wasm.setShapeProperties(sec, ppi, ci, props);
+    return;
+  }
+  if (nested) { wasm.setCellPicturePropertiesByPath(sec, ppi, cellPath!, ci, props); return; }
+  wasm.setPictureProperties(sec, ppi, ci, props);
+}
+
 export class MovePictureCommand implements EditCommand {
   readonly type = 'movePicture';
   readonly timestamp: number;
@@ -711,14 +744,15 @@ export class MovePictureCommand implements EditCommand {
     private deltaV: number,
     private origHorzOffset: number,
     private origVertOffset: number,
+    private cellPath?: CellPathLike,
     timestamp?: number,
   ) {
     this.timestamp = timestamp ?? Date.now();
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    const props = wasm.getPictureProperties(this.sec, this.ppi, this.ci);
-    wasm.setPictureProperties(this.sec, this.ppi, this.ci, {
+    const props = moveGetProps(wasm, 'image', this.sec, this.ppi, this.ci, this.cellPath);
+    moveSetProps(wasm, 'image', this.sec, this.ppi, this.ci, this.cellPath, {
       horzOffset: ((props.horzOffset + this.deltaH) >>> 0),
       vertOffset: ((props.vertOffset + this.deltaV) >>> 0),
     });
@@ -726,7 +760,7 @@ export class MovePictureCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    wasm.setPictureProperties(this.sec, this.ppi, this.ci, {
+    moveSetProps(wasm, 'image', this.sec, this.ppi, this.ci, this.cellPath, {
       horzOffset: this.origHorzOffset,
       vertOffset: this.origVertOffset,
     });
@@ -736,6 +770,7 @@ export class MovePictureCommand implements EditCommand {
   mergeWith(other: EditCommand): EditCommand | null {
     if (!(other instanceof MovePictureCommand)) return null;
     if (other.sec !== this.sec || other.ppi !== this.ppi || other.ci !== this.ci) return null;
+    if (!sameCellPath(other.cellPath, this.cellPath)) return null;
     if (other.timestamp - this.timestamp > 500) return null;
 
     return new MovePictureCommand(
@@ -744,6 +779,7 @@ export class MovePictureCommand implements EditCommand {
       this.deltaV + other.deltaV,
       this.origHorzOffset,
       this.origVertOffset,
+      this.cellPath,
       this.timestamp,
     );
   }
@@ -761,14 +797,15 @@ export class MoveShapeCommand implements EditCommand {
     private deltaV: number,
     private origHorzOffset: number,
     private origVertOffset: number,
+    private cellPath?: CellPathLike,
     timestamp?: number,
   ) {
     this.timestamp = timestamp ?? Date.now();
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    const props = wasm.getShapeProperties(this.sec, this.ppi, this.ci);
-    wasm.setShapeProperties(this.sec, this.ppi, this.ci, {
+    const props = moveGetProps(wasm, 'shape', this.sec, this.ppi, this.ci, this.cellPath);
+    moveSetProps(wasm, 'shape', this.sec, this.ppi, this.ci, this.cellPath, {
       horzOffset: ((props.horzOffset + this.deltaH) >>> 0),
       vertOffset: ((props.vertOffset + this.deltaV) >>> 0),
     });
@@ -776,7 +813,7 @@ export class MoveShapeCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    wasm.setShapeProperties(this.sec, this.ppi, this.ci, {
+    moveSetProps(wasm, 'shape', this.sec, this.ppi, this.ci, this.cellPath, {
       horzOffset: this.origHorzOffset,
       vertOffset: this.origVertOffset,
     });
@@ -786,6 +823,7 @@ export class MoveShapeCommand implements EditCommand {
   mergeWith(other: EditCommand): EditCommand | null {
     if (!(other instanceof MoveShapeCommand)) return null;
     if (other.sec !== this.sec || other.ppi !== this.ppi || other.ci !== this.ci) return null;
+    if (!sameCellPath(other.cellPath, this.cellPath)) return null;
     if (other.timestamp - this.timestamp > 500) return null;
 
     return new MoveShapeCommand(
@@ -794,6 +832,7 @@ export class MoveShapeCommand implements EditCommand {
       this.deltaV + other.deltaV,
       this.origHorzOffset,
       this.origVertOffset,
+      this.cellPath,
       this.timestamp,
     );
   }

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -304,7 +304,7 @@ export function onClick(this: any, e: MouseEvent): void {
                 const startAngle = Math.atan2(cy - objCy, cx - objCx);
                 this.isPictureRotateDragging = true;
                 this.pictureRotateState = {
-                  ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
+                  ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type, cellPath: ref.cellPath, headerFooter: ref.headerFooter },
                   origAngle,
                   centerX: objCx,
                   centerY: objCy,
@@ -320,7 +320,7 @@ export function onClick(this: any, e: MouseEvent): void {
               this.isPictureResizeDragging = true;
               this.pictureResizeState = {
                 dir,
-                ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
+                ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type, cellPath: ref.cellPath, headerFooter: ref.headerFooter },
                 origWidth: props.width,
                 origHeight: props.height,
                 origHorzOffset: props.horzOffset,
@@ -366,7 +366,7 @@ export function onClick(this: any, e: MouseEvent): void {
                   e.preventDefault();
                   this.isPictureMoveDragging = true;
                   this.pictureMoveState = {
-                    ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
+                    ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type, cellPath: ref.cellPath, headerFooter: ref.headerFooter },
                     origHorzOffset: props.horzOffset,
                     origVertOffset: props.vertOffset,
                     startPageX: px, startPageY: py,

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -558,14 +558,21 @@ export function updatePictureResizeDrag(this: any, e: MouseEvent): void {
   if (!state.multiRefs && state.ref.type !== 'line') {
     const newW = Math.max(Math.round(newBbox.width * PX_TO_HWP), MIN_SIZE_HWP);
     const newH = Math.max(Math.round(newBbox.height * PX_TO_HWP), MIN_SIZE_HWP);
+    // offset 은 페이지 절대값이 아니라 "저장 offset + 페이지좌표 델타"로 적용한다.
+    // (중첩 picture 의 offset 은 컨테이너 상대 — 페이지 절대값이면 라이브 드래그 중
+    //  이미지가 예비 테두리에서 벗어나 어긋난다. finishPictureResizeDrag 와 동일 방식.)
     const newHorzOffset = Math.round(newBbox.x * PX_TO_HWP);
     const newVertOffset = Math.round(newBbox.y * PX_TO_HWP);
+    const origHorzOffset = Math.round(state.bbox.x * PX_TO_HWP);
+    const origVertOffset = Math.round(state.bbox.y * PX_TO_HWP);
+    const beforeHorzOffset = state.origHorzOffset ?? origHorzOffset;
+    const beforeVertOffset = state.origVertOffset ?? origVertOffset;
     try {
       setObjectProperties.call(this, state.ref, {
         width: newW,
         height: newH,
-        horzOffset: (newHorzOffset >>> 0),
-        vertOffset: (newVertOffset >>> 0),
+        horzOffset: ((beforeHorzOffset + (newHorzOffset - origHorzOffset)) >>> 0),
+        vertOffset: ((beforeVertOffset + (newVertOffset - origVertOffset)) >>> 0),
       });
       this.eventBus.emit('document-changed');
     } catch { /* ignore */ }
@@ -652,12 +659,17 @@ export function finishPictureResizeDrag(this: any, e: MouseEvent): void {
     }
     const beforeHorzOffset = state.origHorzOffset ?? origHorzOffset;
     const beforeVertOffset = state.origVertOffset ?? origVertOffset;
-    if (newHorzOffset !== origHorzOffset) {
-      updated['horzOffset'] = (newHorzOffset >>> 0);
+    // offset 은 페이지 절대값이 아니라 "저장된 offset + 페이지좌표 델타"로 적용한다.
+    // (글상자/셀 중첩 picture 는 offset 이 컨테이너 상대라, 페이지 절대값을 쓰면 밖으로 튕김.
+    //  다중 선택 리사이즈 경로와 동일한 델타 방식 — 본문 그림은 before≈orig 이므로 동작 불변.)
+    const deltaHorz = newHorzOffset - origHorzOffset;
+    const deltaVert = newVertOffset - origVertOffset;
+    if (deltaHorz !== 0) {
+      updated['horzOffset'] = ((beforeHorzOffset + deltaHorz) >>> 0);
       before['horzOffset'] = beforeHorzOffset;
     }
-    if (newVertOffset !== origVertOffset) {
-      updated['vertOffset'] = (newVertOffset >>> 0);
+    if (deltaVert !== 0) {
+      updated['vertOffset'] = ((beforeVertOffset + deltaVert) >>> 0);
       before['vertOffset'] = beforeVertOffset;
     }
     if (Object.keys(updated).length > 0) {

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -779,6 +779,7 @@ export function finishPictureMoveDrag(this: any): void {
             r.sec, r.ppi, r.ci,
             totalDeltaH, totalDeltaV,
             r.origHorzOffset, r.origVertOffset,
+            r.cellPath,
           ),
         );
       }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -17,7 +17,7 @@ import type { CommandPalette } from '@/ui/command-palette';
 import type { CellSelectionRenderer } from './cell-selection-renderer';
 import type { TableObjectRenderer } from './table-object-renderer';
 import type { TableResizeRenderer, BorderEdge } from './table-resize-renderer';
-import type { CellBbox } from '@/core/types';
+import type { CellBbox, CellPathLike } from '@/core/types';
 import * as _mouse from './input-handler-mouse';
 import * as _table from './input-handler-table';
 import * as _keyboard from './input-handler-keyboard';
@@ -172,7 +172,7 @@ export class InputHandler {
   private isPictureResizeDragging = false;
   private pictureResizeState: {
     dir: string;
-    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' };
+    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group'; cellPath?: CellPathLike; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } };
     origWidth: number;
     origHeight: number;
     origHorzOffset?: number;
@@ -188,7 +188,7 @@ export class InputHandler {
   // 그림/글상자 이동 드래그 상태
   private isPictureMoveDragging = false;
   private pictureMoveState: {
-    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' };
+    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group'; cellPath?: CellPathLike; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } };
     origHorzOffset: number;
     origVertOffset: number;
     startPageX: number;
@@ -205,7 +205,7 @@ export class InputHandler {
   // 그림/글상자 회전 드래그 상태
   private isPictureRotateDragging = false;
   private pictureRotateState: {
-    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group' };
+    ref: { sec: number; ppi: number; ci: number; type: 'image' | 'shape' | 'equation' | 'group'; cellPath?: CellPathLike; headerFooter?: { kind: 'header' | 'footer'; outerParaIdx: number; outerControlIdx: number } };
     origAngle: number;      // 드래그 시작 시 원래 회전각 (도)
     centerX: number;        // 도형 중심 (scroll-content 좌표, px)
     centerY: number;


### PR DESCRIPTION
## 변경 요약

글상자(Shape text_box)·표 셀 안의 **중첩 그림**을 마우스 핸들 드래그로
**리사이즈·회전·이동(+ undo/redo)** 할 수 있게 됩니다.

기존에는 이 조작들이 `컨트롤 인덱스 범위 초과` / `지정된 Shape 컨트롤이 그림이
아닙니다` 오류로 **실패**했고, 글자처럼취급 해제(floating) 후 리사이즈하면 그림이
**글상자 밖으로 튕겨** 나갔습니다. (선택·속성 대화상자·키보드는 #1171/#1254로
동작했으나 마우스 드래그 경로가 빠져 있었음)

### 원인 및 수정

1. **드래그 상태 ref의 위치 식별자 소실** — 단일 개체 드래그 시작 시 드래그 상태
   (pictureResizeState/RotateState/MoveState)의 ref를 `{sec,ppi,ci,type}` 리터럴로
   재구성하며 `cellPath`/`headerFooter`를 떨어뜨려 body-level scalar API로 폴백 →
   위 오류. → 드래그 상태 3종에 path 보존. **(리사이즈·회전·이동 실시간 동작 복원)**
2. **이동 커맨드 body-level** — MovePicture/MoveShapeCommand가 scalar API만 호출 →
   cellPath by-path 지원 추가. **(중첩 그림 이동 undo/redo 정상화)**
3. **리사이즈 offset 페이지 절대좌표** — 단일 선택 리사이즈(라이브+확정)가 offset을
   페이지 절대값으로 기록 → 컨테이너 상대 offset(HWP5 표69/70 VertRelTo/HorzRelTo)인
   중첩 그림이 이탈. → (저장값 + 페이지좌표 델타) 방식으로 수정.
   **(floating 리사이즈 시 글상자 내 유지, 드래그 중 예비박스 정합)**

모두 **TypeScript 한정**(rhwp-studio). 필요한 by-path WASM 함수는 이미 존재 →
**WASM/Rust 무변경**.

## 관련 이슈

closes #1273

## 테스트

- [ ] `cargo test` — 해당 없음 (Rust 변경 0; CI 회귀에 위임)
- [ ] `cargo clippy -- -D warnings` — 해당 없음 (Rust 변경 0)
- [ ] 샘플 SVG 내보내기 — 해당 없음 (렌더 무변경)
- [x] 웹(WASM) 렌더링 확인 — 신규 E2E `e2e/textbox-picture-ops-1273.test.mjs`
      (실제 InputHandler onClick→드래그 경로): 리사이즈 by-path + cellPath 보존 + undo,
      회전, floating 리사이즈 글상자 유지 + 라이브 추적, 콘솔 오류 0건 — 모두 통과.
      red-green 검증(수정 되돌리면 보고와 동일 오류·이탈로 FAIL). `tsc --noEmit` 0건.

## 비고

세션 중 발견된 별개 이슈 2건(① 글상자 초과 리사이즈 시 컨테이너 미확장 클리핑,
② 글상자 붙여넣기·커서 진입 실패 `글상자 없음`)은 본 PR 범위 밖 — 별도 추적 예정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
