### PR TITLE
Task #1196: HWPX 맞쪽 편집 여백 교대 보정

### DIFF
--- a/mydocs/orders/20260604.md
+++ b/mydocs/orders/20260604.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 6월 4일
+
+## M100 — v1.0.0 editing foundation stage
+
+| Issue | 타스크 | 상태 | 비고 |
+|------|--------|------|------|
+| #1196 | HWPX gutterType=LEFT_RIGHT 맞쪽 편집 여백 교대 미적용 | 완료 | `local/task1196`, PR 준비 완료 |

--- a/mydocs/plans/task_m100_1196.md
+++ b/mydocs/plans/task_m100_1196.md
@@ -1,0 +1,251 @@
+# 수행계획서 — Task M100-1196: HWPX gutterType=LEFT_RIGHT 맞쪽 편집 여백 교대
+
+## 1. 이슈
+
+- GitHub Issue: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 제목: `HWPX gutterType=LEFT_RIGHT 맞쪽 편집 여백 교대 미적용`
+- 대상 마일스톤: M100 / v1.0.0 editing foundation stage
+- 브랜치: `local/task1196`
+- 기준 커밋: `62f3bf74` (`upstream/devel`, #1276 및 후속 바탕쪽 번호 배치 보정 반영)
+
+## 2. 문제 요약
+
+HWPX 문서의 `pagePr gutterType="LEFT_RIGHT"`는 맞쪽 편집을 뜻한다. 대상 샘플은 좌우 여백이 비대칭이다.
+
+```xml
+<hp:pagePr landscape="WIDELY" width="59527" height="84189" gutterType="LEFT_RIGHT">
+<hp:margin header="4251" footer="4251" gutter="0" left="7086" right="14173" top="4251" bottom="4251"/>
+```
+
+정답 PDF에서는 홀짝 페이지에 따라 본문 시작 x 좌표가 좌우로 교대된다.
+
+```text
+PDF page 4: 본문 시작 x ≈ 150.2pt
+PDF page 5: 본문 시작 x ≈ 79.4pt
+PDF page 6: 본문 시작 x ≈ 153.0pt
+```
+
+현재 rhwp는 `PageAreas::from_page_def()`가 페이지 홀짝 정보를 받지 않고 항상 다음 방식으로 영역을 계산한다.
+
+```text
+content_left  = margin_left + margin_gutter
+content_right = page_width - margin_right
+```
+
+따라서 `BindingMethod::DuplexSided`가 설정되어도 짝수 페이지에서 좌우 여백이 교대되지 않는다.
+
+## 3. 최신 upstream 기준 확인 사항
+
+`upstream/devel` 최신화 후 확인한 현재 상태:
+
+- #1276은 원 PR 커밋 그대로 merge되지는 않았지만 `f2292883`으로 동일 내용이 반영되었다.
+- 후속 `62f3bf74`에서 HWPX 바탕쪽 글상자 번호 배치 보정도 반영되었다.
+- `src/parser/hwpx/section.rs`는 이미 `gutterType="LEFT_RIGHT"`를 `BindingMethod::DuplexSided`로 파싱한다.
+- #1196의 남은 핵심은 파서가 아니라 페이지별 레이아웃 계산과 해당 layout을 Typeset/Paginator 결과 페이지에 반영하는 것이다.
+
+## 4. 재현 자산
+
+```text
+원본 HWPX: samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+기준 PDF:  pdf-large/hwpx/[2027] 온새미로 1 본교재.pdf
+```
+
+#1276 반영 후 앞부분 페이지 대응은 다음 기준을 전제로 한다.
+
+```text
+page 2: MEMO
+page 3: 1주차 표지
+page 4: section 1 본문 시작, page_num=4
+page 5: 홀수쪽
+```
+
+## 5. 작업 범위
+
+이번 이슈의 범위:
+
+- HWPX `LEFT_RIGHT`가 `PageDef.binding == DuplexSided`로 보존되는 상태 재검증
+- `PageAreas` / `PageLayoutInfo` 계산에 최종 쪽번호 또는 홀짝 컨텍스트를 전달하는 API 설계
+- `DuplexSided` 짝수 페이지에서 좌우 여백 교대 적용
+- 기본 TypesetEngine 경로의 `PageContent.layout`을 페이지별 쪽번호 기준으로 갱신
+- fallback `Paginator` 경로에도 동일 정책 적용
+- 다단 영역, 머리말, 꼬리말, 바탕쪽 기준 layout이 동일한 페이지별 body/header/footer 좌표를 사용하도록 확인
+- 대상 샘플의 `dump-pages` 및 SVG 좌표 검증
+
+비범위:
+
+- #1276의 글뒤로 표 분할/바탕쪽 홀짝 보정 재작업
+- HWPX `gutterType` 파서 중복 구현
+- 모든 shape anchor 좌표계 재설계
+- PDF와 전체 페이지 픽셀 단위 완전 일치
+- HWP5 raw parser의 PAGE_DEF 제책 비트 해석 변경
+
+## 6. 수정 후보 파일
+
+| 파일 | 변경 후보 |
+|------|-----------|
+| `src/model/page.rs` | `PageAreas` 계산에 페이지 홀짝 컨텍스트 추가, 기존 기본 API 호환 유지 |
+| `src/renderer/page_layout.rs` | `PageLayoutInfo`의 페이지별 생성 API 추가 |
+| `src/renderer/typeset.rs` | 페이지 생성/쪽번호 finalize 이후 layout을 최종 page_number 기준으로 재계산 |
+| `src/renderer/pagination/engine.rs` | fallback Paginator 경로의 페이지별 layout 재계산 |
+| `src/document_core/queries/rendering.rs` | 측정용 layout과 dump 검증 경로 영향 확인 |
+| `tests/issue_1196_hwpx_gutter_left_right.rs` | 대상 샘플 및 synthetic layout 회귀 테스트 추가 |
+
+## 7. 구현 방향 후보
+
+### 후보 A: API에 page_number를 직접 전달
+
+`PageAreas::from_page_def_for_page(page_def, page_number)`와 `PageLayoutInfo::from_page_def_for_page(page_def, column_def, dpi, page_number)`를 추가한다.
+
+장점:
+
+- 호출부에서 실제 최종 쪽번호를 명시하므로 의미가 분명하다.
+- #1276의 “최종 page_number 기준 홀짝” 정책과 맞다.
+
+주의:
+
+- 페이지네이션 중에는 쪽번호가 아직 확정되지 않을 수 있으므로, 초기 측정 layout과 최종 page layout의 역할을 분리해야 한다.
+
+### 후보 B: 홀짝 enum/context 전달
+
+`PageSide::Odd/Even` 또는 `LayoutPageContext`를 만들어 layout 계산에 전달한다.
+
+장점:
+
+- page_number 외에 향후 쪽 기준 옵션을 넣기 쉽다.
+
+주의:
+
+- 현재 이슈에는 page_number만으로 충분할 수 있어 과한 구조가 될 수 있다.
+
+기본안은 A다. 기존 호출부 호환을 위해 현재 `from_page_def()`는 1쪽 또는 단면 기본 layout으로 유지하고, 페이지별 계산이 필요한 경로에 새 API를 사용한다.
+
+## 8. 단계 계획
+
+### Stage 1 — 재현과 현재 상태 고정
+
+목표:
+
+- 최신 `local/task1196`에서 #1276 반영 상태와 #1196 재현 상태를 고정한다.
+- `gutterType` 파서가 이미 동작한다는 사실을 테스트/덤프로 확인한다.
+
+검증 후보:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo test --lib test_parse_page_pr_gutter_type_materializes_hwp5_binding_attr
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage1.md`
+
+### Stage 2 — 페이지별 layout API와 단위 테스트
+
+목표:
+
+- `DuplexSided` 짝수 페이지에서 좌우 여백이 교대되는 최소 단위 테스트를 추가한다.
+- 단면 편집과 `TopFlip` 기본 동작은 기존 결과를 유지한다.
+
+검증 후보:
+
+```text
+cargo test --lib page_layout
+cargo test --lib page_areas
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage2.md`
+
+### Stage 3 — TypesetEngine/Paginator 페이지별 layout 반영
+
+목표:
+
+- `PageContent.page_number` 확정 후 `PageContent.layout`을 최종 쪽번호 기준으로 재계산한다.
+- 새 ColumnDef가 적용되는 페이지/zone 전환 경로에서도 같은 정책을 유지한다.
+- fallback `RHWP_USE_PAGINATOR=1` 경로도 같은 결과를 내도록 한다.
+
+검증 후보:
+
+```text
+cargo test --lib typeset
+cargo test --lib pagination
+RHWP_USE_PAGINATOR=1 cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage3.md`
+
+### Stage 4 — 대상 샘플 구조/SVG 검증
+
+목표:
+
+- 대상 HWPX의 page 4/5/6 body_area x 좌표가 PDF 기준 홀짝 방향과 일치하는지 확인한다.
+- 바탕쪽/머리말/꼬리말도 동일 layout 기준을 사용하는지 SVG 좌표로 확인한다.
+
+검증 후보:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 5
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 3
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 4
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 5
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage4.md`
+
+### Stage 5 — 회귀 검증과 최종 보고
+
+목표:
+
+- 레이아웃 API 변경이 기존 단면 문서, 다단, 바탕쪽, HWPX 파서 회귀를 만들지 않는지 확인한다.
+
+필수 검증 후보:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+집중 검증 후보:
+
+```text
+cargo test --test issue_1271_hwpx_behind_text_table
+cargo test --test issue_1196_hwpx_gutter_left_right
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage5.md`
+- `mydocs/report/task_m100_1196_report.md`
+- `mydocs/orders/20260604.md` 상태 갱신
+
+## 9. 위험과 대응
+
+- 측정 단계의 column width와 최종 짝수 페이지 column width가 달라질 수 있다. 대상 샘플은 좌우 여백 교대라 본문 폭은 동일해야 하지만, gutter가 있는 문서는 폭도 달라질 수 있으므로 단위 테스트로 고정한다.
+- 페이지네이션 중 layout을 바꾸면 줄바꿈/표 분할 결과가 흔들릴 수 있다. 우선 page finalization 이후 layout 재계산으로 접근하고, 실제 분할에 필요한 width 변화가 확인되면 별도 보정 단계로 분리한다.
+- 바탕쪽/shape anchor가 paper 기준인지 body 기준인지에 따라 교대 적용 범위가 다르다. 이번 이슈는 body/header/footer/page layout 기준 교대에 한정하고, paper 기준 개체 자체를 움직이는 변경은 하지 않는다.
+- #1276이 고정한 앞부분 페이지 대응을 회귀시키지 않도록 `issue_1271_hwpx_behind_text_table` 테스트를 집중 검증에 포함한다.
+
+## 10. 완료 기준
+
+```text
+1. HWPX gutterType="LEFT_RIGHT" 문서가 DuplexSided layout으로 해석된다.
+2. 짝수 페이지에서 좌우 여백이 교대되어 body_area.x가 PDF 기준 방향과 일치한다.
+3. 대상 샘플 page 4/5/6의 본문 시작 좌표가 홀짝에 따라 교대된다.
+4. page 4는 section 1 본문 시작 page_num=4 상태를 유지한다.
+5. 기본 TypesetEngine과 fallback Paginator의 layout 정책이 일관된다.
+6. 기존 #1271 회귀 테스트와 전체 Rust 회귀 검증이 통과한다.
+7. 단계별 보고서와 최종 보고서가 작성된다.
+```
+
+## 11. 승인 요청
+
+위 수행계획에 따라 구현계획서 `mydocs/plans/task_m100_1196_impl.md` 작성 단계로 진행한다.

--- a/mydocs/plans/task_m100_1196_impl.md
+++ b/mydocs/plans/task_m100_1196_impl.md
@@ -1,0 +1,313 @@
+# 구현계획서 — Task M100-1196: HWPX 맞쪽 편집 여백 교대
+
+## 설계 요약
+
+대상 결함은 파서 결함과 레이아웃 결함을 분리해 본다.
+
+```text
+1. 파서
+   최신 upstream 기준으로 HWPX pagePr@gutterType="LEFT_RIGHT"는 이미
+   PageDef.binding = BindingMethod::DuplexSided 로 materialize 된다.
+
+2. 레이아웃
+   PageAreas::from_page_def() / PageLayoutInfo::from_page_def() 가
+   최종 쪽번호 홀짝을 받지 않으므로, DuplexSided 짝수쪽에서도
+   좌우 여백을 교대하지 않는다.
+```
+
+이번 구현은 2번만 처리한다. #1276에서 확정한 앞쪽 페이지 대응과 최종 `page_number` 기준 홀짝 정책을 유지하기 위해, 페이지네이션 중 임시 layout이 아니라 최종 쪽번호 carry 이후의 `PageContent.layout`을 보정한다.
+
+## 설계 원칙
+
+- `SingleSided`는 기존 결과를 바꾸지 않는다.
+- `DuplexSided`는 홀수쪽에서 기존 방향을 유지하고, 짝수쪽에서 좌우 여백을 교대한다.
+- `TopFlip`은 이번 이슈에서 좌우 교대 대상으로 다루지 않고 기존 좌표를 유지한다.
+- 페이지네이션 중 layout 폭을 흔들지 않는다. 좌우 교대는 같은 body width에서 x 좌표만 이동하는 보정으로 처리한다.
+- 최종 쪽번호 기준을 사용한다. 구역 간 page number carry 전의 section-local 홀짝을 기준으로 삼지 않는다.
+- body/header/footer/column/footnote 영역은 같은 x delta를 적용해 한 페이지 안에서 일관된 레이아웃을 유지한다.
+
+## Stage 1 — 재현 고정과 baseline 기록
+
+**목표**: #1276 반영 상태에서 #1196만 남아 있음을 구조적으로 확인한다.
+
+변경 후보:
+
+- 소스 수정 없음.
+- `mydocs/working/task_m100_1196_stage1.md` 작성.
+
+진단 명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 5
+cargo test --lib test_parse_page_pr_gutter_type_materializes_hwp5_binding_attr
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+확인 항목:
+
+```text
+1. page 4 가 section 1 본문 시작, page_num=4 상태를 유지한다.
+2. page 4/5/6 의 body_area.x 가 현재는 같은 값인지 확인한다.
+3. HWPX gutterType 파서 테스트가 이미 통과한다.
+4. #1271 회귀 테스트가 통과한다.
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage1.md`
+
+## Stage 2 — PageAreas/PageLayoutInfo 페이지별 여백 계산 API
+
+**목표**: 페이지 홀짝을 반영할 수 있는 최소 레이아웃 API를 추가하고 단위 테스트로 고정한다.
+
+변경 파일:
+
+- `src/model/page.rs`
+- `src/renderer/page_layout.rs`
+
+변경 방향:
+
+1. `PageAreas`에 페이지 번호를 받는 API를 추가한다.
+
+```rust
+impl PageAreas {
+    pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self
+}
+```
+
+2. 기존 `PageAreas::from_page_def(page_def)`는 호환을 위해 유지하고, 내부에서 `from_page_def_for_page(page_def, 1)` 또는 기존 단면 기본 계산으로 위임한다.
+
+3. `DuplexSided` 계산 규칙:
+
+```text
+홀수쪽:
+  effective_left  = margin_left + margin_gutter
+  effective_right = margin_right
+
+짝수쪽:
+  effective_left  = margin_right
+  effective_right = margin_left + margin_gutter
+```
+
+4. `PageLayoutInfo`에도 페이지 번호를 받는 생성 API를 추가한다.
+
+```rust
+impl PageLayoutInfo {
+    pub fn from_page_def_for_page(
+        page_def: &PageDef,
+        column_def: &ColumnDef,
+        dpi: f64,
+        page_number: u32,
+    ) -> Self
+}
+```
+
+5. 기존 `from_page_def()`와 `from_page_def_default()`는 호환 유지한다.
+
+테스트 후보:
+
+- `PageAreas::from_page_def_for_page()` synthetic test:
+  - `BindingMethod::SingleSided`: page 1/2 좌표 동일
+  - `BindingMethod::DuplexSided`: page 1은 기존 방향, page 2는 좌우 교대
+  - `margin_gutter > 0`에서도 body width가 유지되는지 확인
+- `PageLayoutInfo::from_page_def_for_page()` test:
+  - HWPUNIT → px 변환 후 page 1/2 `body_area.x`가 기대 방향인지 확인
+  - 다단 column area가 body x 이동을 따라가는지 확인
+
+검증 명령:
+
+```text
+cargo test --lib page_areas
+cargo test --lib page_layout
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage2.md`
+
+## Stage 3 — 최종 page_number 기준 PageContent.layout 갱신
+
+**목표**: 페이지네이션 결과의 `PageContent.layout`이 최종 쪽번호 홀짝을 반영하도록 한다.
+
+변경 파일:
+
+- `src/renderer/page_layout.rs`
+- `src/document_core/queries/rendering.rs`
+- 필요 시 `src/renderer/typeset.rs`
+- 필요 시 `src/renderer/pagination/engine.rs`
+
+기본 구현 방향:
+
+1. `PageLayoutInfo`에 기존 layout을 최종 page number 기준으로 이동시키는 helper를 추가한다.
+
+후보 형태:
+
+```rust
+impl PageLayoutInfo {
+    pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32)
+}
+```
+
+이 helper는 현재 layout의 column 구성은 보존하고, `PageAreas::from_page_def_for_page()`가 계산한 body/header/footer x와 기존 기본 x의 차이만큼 x 좌표를 이동한다.
+
+2. `DocumentCore::paginate()`에서 구역 간 page number carry 보정 이후, `assign_master_pages_for_section()` 호출 전에 section result 전체 layout을 갱신한다.
+
+후보 흐름:
+
+```text
+1. section-local pagination 수행
+2. page_number_pos 상속
+3. 구역 간 page_number carry 보정
+4. PageContent.layout 을 최종 page.page_number 기준으로 갱신
+5. assign_master_pages_for_section()
+6. header/footer 상속 보정
+```
+
+3. 이 방식을 기본으로 삼는 이유:
+
+- TypesetEngine과 fallback Paginator 모두 `DocumentCore::paginate()` 결과를 거치므로 한 곳에서 정책을 맞출 수 있다.
+- #1276의 masterpage 선택도 같은 위치에서 최종 `page_number` 기준으로 수행된다.
+- ColumnDef 변경이 있는 페이지도 기존 `PageContent.layout.column_areas`의 상대 배치를 보존하면서 x만 이동할 수 있다.
+
+4. 필요 시 추가 보정:
+
+- 직접 `TypesetEngine` 또는 `Paginator`를 호출하는 테스트/외부 경로가 있으면 finalize 단계에 같은 helper를 적용한다.
+- 다만 첫 구현은 DocumentCore 경로에 집중하고, 직접 호출 경로는 테스트 실패 시 좁게 확장한다.
+
+검증 명령:
+
+```text
+cargo test --lib master_page_selection_uses_final_carried_page_number_parity
+cargo test --lib page_layout
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 5
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage3.md`
+
+## Stage 4 — #1196 통합 회귀 테스트 추가
+
+**목표**: 실제 대상 샘플에서 page 4/5/6의 본문 영역이 홀짝에 따라 교대됨을 회귀 테스트로 고정한다.
+
+변경 파일:
+
+- `tests/issue_1196_hwpx_gutter_left_right.rs`
+
+테스트 구조:
+
+```rust
+#[test]
+fn onsaemiro_left_right_gutter_alternates_body_area_by_page_parity() {
+    // samples/hwpx/[2027] 온새미로 1 본교재.hwpx 로드
+    // dump_page_items(Some(3/4/5)) 또는 DocumentCore pagination 접근
+    // page 4: section=1, page_num=4 유지
+    // page 4 body_area.x > page 5 body_area.x
+    // page 6 body_area.x > page 5 body_area.x
+}
+```
+
+테스트 기준:
+
+- 정확한 px 수치 대신 방향성을 우선 검증한다.
+- page 4가 section 1 본문 시작이라는 #1276 전제도 같이 확인한다.
+- page 4/5/6 body width는 동일해야 한다.
+
+검증 명령:
+
+```text
+cargo test --test issue_1196_hwpx_gutter_left_right -- --nocapture
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage4.md`
+
+## Stage 5 — SVG/좌표 수동 검증과 회귀 검증
+
+**목표**: dump 기준뿐 아니라 SVG 좌표에서도 본문/바탕쪽 좌표 방향이 PDF 기준과 맞는지 확인한다.
+
+검증 명령:
+
+```text
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 3
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 4
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 5
+```
+
+확인 항목:
+
+```text
+1. page 4 본문 시작 x 가 page 5 보다 오른쪽에 있다.
+2. page 6 본문 시작 x 가 page 5 보다 오른쪽에 있다.
+3. page 4/5 바탕쪽 쪽번호 방향은 #1276 후속 보정 상태를 유지한다.
+4. paper 기준 배경성 개체가 불필요하게 좌우 교대되지 않는다.
+```
+
+회귀 검증:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+필요 시 확장:
+
+```text
+cargo clippy -- -D warnings
+```
+
+산출물:
+
+- `mydocs/working/task_m100_1196_stage5.md`
+
+## Stage 6 — 최종 보고와 orders 갱신
+
+**목표**: 작업 결과와 검증 결과를 문서화하고 오늘 할일 상태를 완료로 갱신한다.
+
+변경 파일:
+
+- `mydocs/report/task_m100_1196_report.md`
+- `mydocs/orders/20260604.md`
+
+최종 보고 포함 항목:
+
+- 원인:
+  - parser는 이미 `DuplexSided`를 보존했으나 layout이 page parity를 쓰지 않음
+- 수정:
+  - 페이지별 여백 계산 API
+  - 최종 `page_number` 기준 `PageContent.layout` 갱신
+- 검증:
+  - #1196 전용 테스트
+  - #1271 회귀 테스트
+  - 전체 회귀 테스트 결과
+  - SVG 좌표 확인 결과
+
+완료 전 확인:
+
+```text
+git status --short --branch
+```
+
+산출물:
+
+- `mydocs/report/task_m100_1196_report.md`
+- `mydocs/orders/20260604.md` #1196 상태 완료 갱신
+
+## 제외 범위
+
+- HWPX `gutterType` 파서 중복 수정
+- `BindingMethod::TopFlip`의 상하 여백 교대 정책 구현
+- 페이지네이션 중 reflow 폭 변경
+- paper 기준 배경/전경 shape anchor 좌표 교대
+- #1276의 글뒤로 표 분할 정책 재조정
+
+## 작업지시자 승인 요청
+
+본 구현계획이 승인되면 Stage 1부터 진행한다. 첫 단계는 소스 수정 없이 재현 dump, 기존 파서 테스트, #1271 회귀 테스트 확인 및 `mydocs/working/task_m100_1196_stage1.md` 작성이다.

--- a/mydocs/report/task_m100_1196_report.md
+++ b/mydocs/report/task_m100_1196_report.md
@@ -1,0 +1,145 @@
+# 최종 보고 — Task M100-1196
+
+## 이슈
+
+- GitHub: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 제목: HWPX `gutterType="LEFT_RIGHT"` 맞쪽 편집 여백 교대 미적용
+
+## 원인
+
+대상 HWPX 샘플 `samples/hwpx/[2027] 온새미로 1 본교재.hwpx` 는 `pagePr`의
+`gutterType="LEFT_RIGHT"`를 사용한다.
+
+최신 upstream 기준 파서는 이미 이 값을 `PageDef.binding = BindingMethod::DuplexSided`로
+materialize하고 있었다. 문제는 layout 계산 경로가 최종 쪽번호 홀짝을 받지 않아,
+짝수쪽에서도 `margin_left + margin_gutter`가 계속 왼쪽에 적용된다는 점이었다.
+
+#1276 이후 page 4는 section 1 본문 시작이자 최종 `page_num=4`로 정리되었지만,
+본문 영역 x 좌표는 page 4/5/6 모두 같은 값으로 남아 PDF 기준 맞쪽 편집 방향과 어긋났다.
+
+## 변경
+
+- `src/model/page.rs`
+  - `PageAreas::from_page_def_for_page(page_def, page_number)`를 추가했다.
+  - 기존 `from_page_def()`는 page 1 기준 계산으로 위임해 호환성을 유지했다.
+  - `BindingMethod::DuplexSided`에서 홀수쪽은 기존 방향, 짝수쪽은 좌우 여백을 교대하도록 했다.
+  - `SingleSided`와 `TopFlip`은 기존 좌우 여백 정책을 유지했다.
+
+- `src/renderer/page_layout.rs`
+  - `PageLayoutInfo::from_page_def_for_page(...)`를 추가했다.
+  - `PageLayoutInfo::apply_page_number_margins(page_def, page_number)`를 추가했다.
+  - 기존 layout의 column 구성은 보존하고, 최종 page number 기준 body/header/footer/footnote/column x 좌표만 이동하도록 했다.
+
+- `src/document_core/queries/rendering.rs`
+  - `apply_page_number_layouts_for_section()` helper를 추가했다.
+  - 구역 간 page number carry 보정 이후, 바탕쪽 선택 전에 최종 `page.page_number` 기준 layout 보정을 적용했다.
+  - TypesetEngine과 fallback Paginator 모두 `DocumentCore::paginate()` 결과 경로에서 같은 보정을 받는다.
+
+- `tests/issue_1196_hwpx_gutter_left_right.rs`
+  - 대상 HWPX 샘플에서 page 4/5/6의 맞쪽 편집 여백 교대를 고정하는 통합 회귀 테스트를 추가했다.
+  - page 4가 `section=1, page_num=4` 본문 시작이라는 #1276 전제도 함께 검증한다.
+
+## 주요 확인
+
+`dump-pages` 기준:
+
+```text
+page 4: body_area: x=189.0 y=113.4 w=510.2 h=895.8
+page 5: body_area: x=94.5  y=113.4 w=510.2 h=895.8
+page 6: body_area: x=189.0 y=113.4 w=510.2 h=895.8
+```
+
+판정:
+
+- 최종 쪽번호 기준 짝수쪽 page 4/6의 body x가 홀수쪽 page 5보다 오른쪽으로 교대된다.
+- body width는 모두 `510.2`로 유지된다.
+- page 4는 `section=1, page_num=4`이고 `"강의 01."` 본문 시작을 유지한다.
+
+## 시각 검증
+
+SVG/debug overlay 산출물:
+
+```text
+output/poc/task1196/[2027] 온새미로 1 본교재_004.svg
+output/poc/task1196/[2027] 온새미로 1 본교재_005.svg
+output/poc/task1196/[2027] 온새미로 1 본교재_006.svg
+output/poc/task1196/index.html
+```
+
+SVG 좌표 확인:
+
+```text
+page 4 body-clip x=188.973
+page 5 body-clip x=94.480
+page 6 body-clip x=188.973
+```
+
+WASM/rhwp-studio 검증:
+
+- `wasm-pack build --target web`로 `pkg/`를 최신 소스 기준으로 갱신했다.
+- `rhwp-studio` 서버를 `http://127.0.0.1:7700/`에서 실행했다.
+- 작업지시자가 rhwp-studio에서 대상 문서를 직접 로드해 수정 적용을 확인했다.
+
+참고:
+
+- Docker daemon이 실행 중이 아니어서 Docker 기반 WASM 빌드는 수행하지 못했다.
+- 로컬 `wasm-pack 0.15.0`과 `wasm32-unknown-unknown` target으로 WASM 빌드를 완료했다.
+- `pkg/`와 `output/`은 `.gitignore` 대상이므로 PR에는 포함하지 않는다.
+
+## 검증
+
+기여자 체크리스트 기준 통과:
+
+```text
+cargo fmt --all -- --check
+cargo test
+cargo clippy -- -D warnings
+```
+
+결과:
+
+```text
+cargo fmt --all -- --check
+통과
+
+cargo test
+종료 코드 0. lib/unit/integration/doc-test 통과
+
+cargo clippy -- -D warnings
+Finished `dev` profile [unoptimized + debuginfo] target(s)
+```
+
+추가로 Stage 5에서 먼저 확인한 명령:
+
+```text
+cargo test --lib
+test result: ok. 1565 passed; 0 failed; 6 ignored
+
+cargo test --tests
+종료 코드 0. 전체 integration test 통과
+```
+
+주요 회귀:
+
+```text
+tests/issue_1196_hwpx_gutter_left_right.rs
+test result: ok. 1 passed; 0 failed
+
+tests/issue_1271_hwpx_behind_text_table.rs
+test result: ok. 3 passed; 0 failed
+```
+
+## PR 판단
+
+PR 생성 가능 상태다.
+
+- PR 대상 브랜치: `upstream/devel`
+- push 대상: fork `origin`
+- `pr/` 폴더 문서는 작성하지 않는다.
+- `pkg/`, `output/` 산출물은 포함하지 않는다.
+- 기존 #1142~#1144 관련 untracked 문서는 이번 PR 범위에서 제외한다.
+
+## 남은 작업
+
+- 작업지시자 승인 후 #1196 관련 파일만 선별 stage/commit 한다.
+- fork `origin`에 브랜치를 push하고 `devel` 대상으로 PR을 생성한다.

--- a/mydocs/working/task_m100_1196_stage1.md
+++ b/mydocs/working/task_m100_1196_stage1.md
@@ -1,0 +1,110 @@
+# Stage 1 보고 — Task M100-1196
+
+## 범위
+
+- 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 단계: 재현 고정과 baseline 기록
+- 브랜치: `local/task1196`
+- 기준 커밋: `62f3bf74`
+
+## 목적
+
+#1276 및 후속 바탕쪽 번호 배치 보정이 반영된 최신 기준에서, #1196 결함이 여전히 남아 있는지 확인했다.
+
+확인 대상:
+
+- 대상 HWPX가 46페이지로 페이지네이션되는지
+- page 4가 section 1 본문 시작 `page_num=4` 상태를 유지하는지
+- page 4/5/6의 `body_area.x`가 아직 동일해 맞쪽 편집 여백 교대가 미적용인지
+- HWPX `gutterType="LEFT_RIGHT"` 파서는 이미 `DuplexSided`로 동작하는지
+- #1271 회귀 테스트가 통과하는지
+
+## dump-pages 결과
+
+대상 문서:
+
+```text
+samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+```
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 5
+```
+
+결과 요약:
+
+```text
+문서 로드: 46페이지
+
+page 4: global_idx=3, section=1, page_num=4
+  body_area: x=94.5 y=113.4 w=510.2 h=895.8
+  첫 문단: "강의 01."
+
+page 5: global_idx=4, section=1, page_num=5
+  body_area: x=94.5 y=113.4 w=510.2 h=895.8
+
+page 6: global_idx=5, section=1, page_num=6
+  body_area: x=94.5 y=113.4 w=510.2 h=895.8
+```
+
+판단:
+
+- #1276 이후 앞부분 페이지 대응은 유지된다.
+- page 4가 section 1 본문 시작이며 `page_num=4`로 잡힌다.
+- page 4/5/6의 `body_area.x`가 모두 `94.5`로 동일하다.
+- 따라서 #1196의 핵심 증상인 `LEFT_RIGHT` 맞쪽 편집 여백 교대 미적용이 재현된다.
+
+## 파서 테스트
+
+명령:
+
+```text
+cargo test --lib test_parse_page_pr_gutter_type_materializes_hwp5_binding_attr
+```
+
+결과:
+
+```text
+test parser::hwpx::section::tests::test_parse_page_pr_gutter_type_materializes_hwp5_binding_attr ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+판단:
+
+- HWPX `pagePr@gutterType="LEFT_RIGHT"`를 `BindingMethod::DuplexSided`로 materialize하는 파서 경로는 이미 통과한다.
+- 이번 이슈의 구현 범위는 파서가 아니라 레이아웃 적용 쪽이다.
+
+## #1271 회귀 테스트
+
+명령:
+
+```text
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+결과:
+
+```text
+running 3 tests
+test onsaemiro_front_matter_is_not_shifted_by_behind_text_table_fragment ... ok
+test onsaemiro_odd_master_page_number_stays_after_title_text ... ok
+test onsaemiro_master_page_bottom_textbox_is_not_microscopic ... ok
+
+test result: ok. 3 passed; 0 failed
+```
+
+판단:
+
+- #1271에서 고정한 글뒤로 표 분할/바탕쪽 홀짝 관련 회귀는 없다.
+- #1196 구현은 이 상태를 유지해야 한다.
+
+## Stage 1 결론
+
+- baseline 재현 완료.
+- `gutterType` 파서는 동작한다.
+- `PageContent.layout.body_area.x`는 최종 page 4/5/6에서 아직 교대되지 않는다.
+- Stage 2에서는 `PageAreas` / `PageLayoutInfo`의 페이지별 여백 계산 API와 단위 테스트를 추가한다.

--- a/mydocs/working/task_m100_1196_stage2.md
+++ b/mydocs/working/task_m100_1196_stage2.md
@@ -1,0 +1,106 @@
+# Stage 2 보고 — Task M100-1196
+
+## 범위
+
+- 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 단계: 페이지별 여백 계산 API와 단위 테스트
+- 브랜치: `local/task1196`
+
+## 변경 파일
+
+```text
+src/model/page.rs
+src/renderer/page_layout.rs
+```
+
+## 구현 내용
+
+### PageAreas 페이지별 계산 API 추가
+
+`src/model/page.rs`에 다음 API를 추가했다.
+
+```rust
+pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self
+```
+
+기존 `PageAreas::from_page_def(page_def)`는 호환을 위해 유지하고, 내부에서 page 1 기준 계산으로 위임한다.
+
+`BindingMethod::DuplexSided` 처리 규칙:
+
+```text
+홀수쪽:
+  effective_left  = margin_left + margin_gutter
+  effective_right = margin_right
+
+짝수쪽:
+  effective_left  = margin_right
+  effective_right = margin_left + margin_gutter
+```
+
+`page_number=0`은 아직 최종 쪽번호가 확정되지 않은 상태로 보고 기존 방향을 유지하도록 했다.
+
+### PageLayoutInfo 페이지별 계산 API 추가
+
+`src/renderer/page_layout.rs`에 다음 API를 추가했다.
+
+```rust
+pub fn from_page_def_for_page(
+    page_def: &PageDef,
+    column_def: &ColumnDef,
+    dpi: f64,
+    page_number: u32,
+) -> Self
+```
+
+기존 `PageLayoutInfo::from_page_def()`는 page 1 기준으로 위임해 기존 호출부 결과를 유지한다.
+
+## 추가 테스트
+
+`src/model/page.rs`:
+
+- `page_areas_single_sided_keeps_horizontal_margins_on_even_pages`
+- `page_areas_duplex_sided_swaps_horizontal_margins_on_even_pages`
+- `page_areas_top_flip_keeps_left_right_margins_for_now`
+
+`src/renderer/page_layout.rs`:
+
+- `page_layout_duplex_sided_even_page_swaps_body_and_columns`
+- `page_layout_from_page_def_matches_page_one_layout`
+
+테스트 의도:
+
+- `SingleSided`는 page 1/2 좌표가 동일하다.
+- `DuplexSided`는 짝수쪽에서 좌우 여백이 교대된다.
+- `TopFlip`은 이번 이슈 범위에서 좌우 교대하지 않는다.
+- `PageLayoutInfo`의 다단 column 영역이 body x 이동을 따라간다.
+- 기존 `from_page_def()`는 page 1 layout과 동일하다.
+
+## 검증
+
+명령:
+
+```text
+cargo test --lib page_areas
+cargo test --lib page_layout
+cargo fmt --check
+```
+
+결과:
+
+```text
+cargo test --lib page_areas
+test result: ok. 4 passed; 0 failed
+
+cargo test --lib page_layout
+test result: ok. 5 passed; 0 failed
+
+cargo fmt --check
+통과
+```
+
+## 판단
+
+- 페이지별 여백 교대 계산 API가 추가됐다.
+- 기존 `from_page_def()` 호출부는 page 1 기준 결과를 유지한다.
+- Stage 2는 아직 실제 `PageContent.layout`에 최종 page number를 반영하지 않는다.
+- Stage 3에서 `DocumentCore::paginate()` 결과의 각 페이지 layout을 최종 `page.page_number` 기준으로 갱신한다.

--- a/mydocs/working/task_m100_1196_stage3.md
+++ b/mydocs/working/task_m100_1196_stage3.md
@@ -1,0 +1,168 @@
+# Stage 3 보고 — Task M100-1196
+
+## 범위
+
+- 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 단계: 최종 `page_number` 기준 `PageContent.layout` 갱신
+- 브랜치: `local/task1196`
+
+## 변경 파일
+
+```text
+src/document_core/queries/rendering.rs
+src/renderer/page_layout.rs
+```
+
+Stage 2에서 변경한 `src/model/page.rs`, `src/renderer/page_layout.rs`의 페이지별 계산 API를 실제 pagination 결과에 연결했다.
+
+## 구현 내용
+
+### PageLayoutInfo x 이동 helper 추가
+
+`src/renderer/page_layout.rs`에 다음 helper를 추가했다.
+
+```rust
+pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32)
+```
+
+동작:
+
+- `PageAreas::from_page_def_for_page(page_def, page_number)`로 최종 page number 기준 body/header/footer 영역을 계산한다.
+- 현재 layout의 `body_area.x`와 목표 `body_area.x`의 차이(`delta_x`)를 계산한다.
+- `body_area`, `header_area`, `footer_area`의 x/width를 목표 영역으로 갱신한다.
+- `footnote_area`가 존재하면 같은 x delta를 적용한다.
+- `column_areas`는 ColumnDef가 다른 zone layout일 수 있으므로 너비/간격을 재계산하지 않고 x만 이동한다.
+
+추가 테스트:
+
+```text
+apply_page_number_margins_moves_existing_zone_layout_without_rebuilding_columns
+```
+
+### DocumentCore pagination 결과에 적용
+
+`src/document_core/queries/rendering.rs`에 다음 helper를 추가했다.
+
+```rust
+fn apply_page_number_layouts_for_section(result: &mut PaginationResult, section: &Section)
+```
+
+동작:
+
+- 각 `PageContent.layout`에 `apply_page_number_margins()`를 적용한다.
+- 각 `ColumnContent.zone_layout`에도 같은 page number 기준 보정을 적용한다.
+
+호출 시점:
+
+```text
+1. section-local pagination 수행
+2. page_number_pos 상속
+3. 구역 간 page_number carry 보정
+4. apply_page_number_layouts_for_section()
+5. assign_master_pages_for_section()
+6. header/footer 상속 보정
+```
+
+이 순서로 둔 이유:
+
+- #1276의 바탕쪽 선택과 같은 “최종 page_number 기준”을 사용한다.
+- TypesetEngine과 fallback Paginator 모두 `DocumentCore::paginate()` 결과를 통과하므로 한 곳에서 정책을 맞출 수 있다.
+- 페이지네이션 중 layout 폭을 바꾸지 않아 줄바꿈/표 분할 결과를 흔들지 않는다.
+
+## 단위/회귀 검증
+
+명령:
+
+```text
+cargo test --lib page_layout
+cargo test --lib page_areas
+cargo test --lib master_page_selection_uses_final_carried_page_number_parity
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+cargo fmt --check
+```
+
+결과:
+
+```text
+cargo test --lib page_layout
+test result: ok. 6 passed; 0 failed
+
+cargo test --lib page_areas
+test result: ok. 4 passed; 0 failed
+
+cargo test --lib master_page_selection_uses_final_carried_page_number_parity
+test result: ok. 1 passed; 0 failed
+
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+test result: ok. 3 passed; 0 failed
+
+cargo fmt --check
+통과
+```
+
+## 대상 샘플 dump-pages 검증
+
+대상 문서:
+
+```text
+samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+```
+
+명령:
+
+```text
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 5
+```
+
+결과 요약:
+
+```text
+문서 로드: 46페이지
+
+page 4: global_idx=3, section=1, page_num=4
+  body_area: x=189.0 y=113.4 w=510.2 h=895.8
+  첫 문단: "강의 01."
+
+page 5: global_idx=4, section=1, page_num=5
+  body_area: x=94.5 y=113.4 w=510.2 h=895.8
+
+page 6: global_idx=5, section=1, page_num=6
+  body_area: x=189.0 y=113.4 w=510.2 h=895.8
+```
+
+판단:
+
+- Stage 1 baseline의 `x=94.5 / 94.5 / 94.5`가 `189.0 / 94.5 / 189.0`으로 교대된다.
+- page 4는 여전히 section 1 본문 시작이며 `page_num=4`이다.
+- body width는 `510.2`로 유지된다.
+
+## fallback Paginator 확인
+
+명령:
+
+```text
+env RHWP_USE_PAGINATOR=1 cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 3
+env RHWP_USE_PAGINATOR=1 cargo run --quiet --bin rhwp -- dump-pages "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -p 4
+```
+
+결과 요약:
+
+```text
+page 4: body_area.x=189.0
+page 5: body_area.x=94.5
+```
+
+판단:
+
+- fallback Paginator 결과에도 최종 page number 기준 layout 교대 정책이 적용된다.
+- fallback 경로는 이 샘플에서 47페이지로 로드되며, 이는 #1196 layout 적용과 별개인 기존 fallback 페이지네이션 차이다.
+
+## Stage 3 결론
+
+- `PageContent.layout`이 최종 `page.page_number` 기준으로 갱신된다.
+- 기본 TypesetEngine 경로에서 page 4/5/6 body_area x 좌표가 PDF 기준 홀짝 방향으로 교대된다.
+- fallback Paginator 경로에도 같은 layout 정책이 적용된다.
+- #1271 회귀 테스트와 master page 최종 page number 테스트는 통과했다.
+- Stage 4에서는 #1196 전용 통합 회귀 테스트를 추가한다.

--- a/mydocs/working/task_m100_1196_stage4.md
+++ b/mydocs/working/task_m100_1196_stage4.md
@@ -1,0 +1,68 @@
+# Stage 4 보고 — Task M100-1196
+
+## 범위
+
+- 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 단계: #1196 전용 통합 회귀 테스트 추가
+- 브랜치: `local/task1196`
+
+## 변경 파일
+
+```text
+tests/issue_1196_hwpx_gutter_left_right.rs
+```
+
+## 구현 내용
+
+대상 샘플 문서:
+
+```text
+samples/hwpx/[2027] 온새미로 1 본교재.hwpx
+```
+
+추가 테스트:
+
+```text
+onsaemiro_left_right_gutter_alternates_body_area_by_page_parity
+```
+
+검증 항목:
+
+- page 4가 `section=1, page_num=4`를 유지한다.
+- page 4가 `"강의 01."` 본문 시작 위치를 유지한다.
+- page 5/6이 각각 최종 `page_num=5`, `page_num=6`을 유지한다.
+- `gutterType="LEFT_RIGHT"` 맞쪽 편집에 따라 짝수쪽 page 4/6의 `body_area.x`가 홀수쪽 page 5보다 오른쪽에 있다.
+- page 4와 page 6의 `body_area.x`가 동일 계열이다.
+- 좌우 여백 교대는 body width를 변경하지 않는다.
+
+테스트는 `wasm_api::HwpDocument::dump_page_items()` 출력에서 `body_area` 라인을 파싱해 x 좌표와 width를 직접 비교한다. 숫자 비교는 dump 출력의 소수점 반올림을 고려해 0.1pt 허용 오차를 둔다.
+
+## 검증
+
+명령:
+
+```text
+cargo fmt --check
+cargo test --test issue_1196_hwpx_gutter_left_right -- --nocapture
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+```
+
+결과:
+
+```text
+cargo fmt --check
+통과
+
+cargo test --test issue_1196_hwpx_gutter_left_right -- --nocapture
+test result: ok. 1 passed; 0 failed
+
+cargo test --test issue_1271_hwpx_behind_text_table -- --nocapture
+test result: ok. 3 passed; 0 failed
+```
+
+## Stage 4 결론
+
+- #1196 재현 샘플을 직접 사용하는 통합 회귀 테스트를 추가했다.
+- 테스트는 #1271의 page 4 본문 시작 보정과 #1196의 좌우 여백 교대를 함께 고정한다.
+- 기존 #1271 회귀 테스트도 계속 통과한다.
+- Stage 5에서는 SVG/debug overlay export로 시각 검증 산출물을 만들고, 작업지시자가 직접 확인할 수 있는 시점을 정한다.

--- a/mydocs/working/task_m100_1196_stage5.md
+++ b/mydocs/working/task_m100_1196_stage5.md
@@ -1,0 +1,146 @@
+# Stage 5 보고 — Task M100-1196
+
+## 범위
+
+- 이슈: [#1196](https://github.com/edwardkim/rhwp/issues/1196)
+- 단계: SVG/debug overlay export, 좌표 수동 검증, 전체 회귀 검증
+- 브랜치: `local/task1196`
+
+## 산출물
+
+SVG/debug overlay export:
+
+```text
+output/poc/task1196/[2027] 온새미로 1 본교재_004.svg
+output/poc/task1196/[2027] 온새미로 1 본교재_005.svg
+output/poc/task1196/[2027] 온새미로 1 본교재_006.svg
+```
+
+비교용 HTML:
+
+```text
+output/poc/task1196/index.html
+```
+
+`output/`은 `.gitignore` 대상이므로 PR에는 포함되지 않는다.
+
+## 실행 명령
+
+```text
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 3
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 4
+cargo run --quiet --bin rhwp -- export-svg "samples/hwpx/[2027] 온새미로 1 본교재.hwpx" -o output/poc/task1196 --debug-overlay -p 5
+```
+
+결과:
+
+```text
+문서 로드 완료: samples/hwpx/[2027] 온새미로 1 본교재.hwpx (46페이지)
+→ output/poc/task1196/[2027] 온새미로 1 본교재_004.svg
+→ output/poc/task1196/[2027] 온새미로 1 본교재_005.svg
+→ output/poc/task1196/[2027] 온새미로 1 본교재_006.svg
+```
+
+## SVG 좌표 확인
+
+SVG에서 `body-clip`과 첫 debug overlay 좌표를 추출했다.
+
+```text
+[2027] 온새미로 1 본교재_004.svg
+  body-clip x=188.973 w=510.240
+  first-overlay x=188.973 w=510.240 label=s1:pi=0 y=113.4
+  footer-first-text x=60.453 text=4
+  first-background-cell x=37.787 w=5.960
+
+[2027] 온새미로 1 본교재_005.svg
+  body-clip x=94.480 w=515.067
+  first-overlay x=105.813 w=487.573 label=s1:pi=9 y=113.4
+  footer-first-text x=642.240 text=독
+  first-background-cell x=0.053 w=560.933
+
+[2027] 온새미로 1 본교재_006.svg
+  body-clip x=188.973 w=516.067
+  first-overlay x=188.973 w=510.240 label=s1:pi=19 y=113.4
+  footer-first-text x=60.453 text=6
+  first-background-cell x=37.787 w=5.960
+```
+
+판정:
+
+- page 4 `body-clip.x=188.973`은 page 5 `body-clip.x=94.480`보다 오른쪽이다.
+- page 6 `body-clip.x=188.973`도 page 5보다 오른쪽이다.
+- debug overlay의 첫 본문 경계도 page 4/6은 `x=188.973`, page 5는 `x=105.813`로 같은 방향성을 보인다.
+- page 4/6의 쪽번호 첫 글자는 `x=60.453` 쪽에 있고, page 5의 하단 바탕쪽 텍스트는 오른쪽 영역에서 시작한다. #1276의 홀짝 바탕쪽 방향이 유지된다.
+- page 4/6의 첫 배경성 cell clip은 `x=37.787`로 동일하다. body 여백 교대 보정이 같은 parity의 paper 기준 배경성 개체를 불필요하게 이동시키지 않는다.
+
+SVG `body-clip` width는 페이지별 실제 clip/content 구성 차이가 섞이므로, width 보존 여부는 `dump-pages`의 `body_area` 값을 기준으로 함께 확인했다.
+
+## dump-pages 교차 확인
+
+```text
+page 4: body_area: x=189.0 y=113.4 w=510.2 h=895.8
+page 5: body_area: x=94.5  y=113.4 w=510.2 h=895.8
+page 6: body_area: x=189.0 y=113.4 w=510.2 h=895.8
+```
+
+판정:
+
+- 최종 `page_num` 기준으로 짝수쪽 page 4/6의 body x가 홀수쪽 page 5보다 오른쪽으로 교대된다.
+- body width는 dump 기준 모두 `510.2`로 유지된다.
+
+## 회귀 검증
+
+명령:
+
+```text
+cargo fmt --check
+cargo test --lib
+cargo test --tests
+```
+
+결과:
+
+```text
+cargo fmt --check
+통과
+
+cargo test --lib
+test result: ok. 1565 passed; 0 failed; 6 ignored
+
+cargo test --tests
+종료 코드 0. 전체 integration test 통과
+```
+
+`cargo test --tests` 실행 중 #1196 전용 테스트와 #1271 회귀 테스트도 통과했다.
+
+```text
+tests/issue_1196_hwpx_gutter_left_right.rs
+test result: ok. 1 passed; 0 failed
+
+tests/issue_1271_hwpx_behind_text_table.rs
+test result: ok. 3 passed; 0 failed
+```
+
+## 직접 시각 검증 시점
+
+작업지시자의 직접 시각 검증은 이 단계 직후 진행하면 된다.
+
+권장 확인 파일:
+
+```text
+output/poc/task1196/index.html
+```
+
+확인 포인트:
+
+- page 4와 page 6의 debug overlay 본문 시작선이 page 5보다 오른쪽에 있는지 확인한다.
+- page 4의 `"강의 01."` 시작 위치가 오른쪽 여백 교대 방향에 맞는지 확인한다.
+- page 4/6의 하단 쪽번호와 바탕쪽 텍스트가 #1276 후속 상태를 유지하는지 확인한다.
+- page 4/6의 상단 배경성 회색 표/텍스트가 body 여백 보정 때문에 좌우로 흔들리지 않는지 확인한다.
+
+## Stage 5 결론
+
+- SVG/debug overlay 산출물에서 page 4/6과 page 5의 본문 시작 x 방향성이 기대와 맞다.
+- dump-pages 기준 body width는 유지된다.
+- 전체 lib/integration 회귀 테스트가 통과했다.
+- Stage 6에서는 최종 보고서를 작성하고 오늘 할일 상태를 완료로 갱신한다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -219,6 +219,19 @@ fn assign_master_pages_for_section(
     }
 }
 
+fn apply_page_number_layouts_for_section(result: &mut PaginationResult, section: &Section) {
+    let page_def = &section.section_def.page_def;
+    for page in &mut result.pages {
+        page.layout
+            .apply_page_number_margins(page_def, page.page_number);
+        for column in &mut page.column_contents {
+            if let Some(zone_layout) = &mut column.zone_layout {
+                zone_layout.apply_page_number_margins(page_def, page.page_number);
+            }
+        }
+    }
+}
+
 impl DocumentCore {
     /// 페이지 렌더 트리를 생성하여 반환한다 (native bridge / 외부 렌더러용).
     pub fn build_page_render_tree(&self, page_num: u32) -> Result<PageRenderTree, HwpError> {
@@ -2341,6 +2354,9 @@ impl DocumentCore {
                     }
                 }
             }
+
+            // 맞쪽 편집 layout 은 구역 간 쪽번호 carry 이후 최종 page_number 기준으로 갱신한다.
+            apply_page_number_layouts_for_section(&mut result, section);
 
             // 바탕쪽 선택은 구역 간 쪽번호 carry 보정 이후 최종 page_number 기준으로 수행한다.
             assign_master_pages_for_section(&mut result, idx, section);

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -174,6 +174,15 @@ impl PageAreas {
     ///
     /// landscape=true이면 width와 height를 교환하여 가로 방향으로 렌더링
     pub fn from_page_def(page_def: &PageDef) -> Self {
+        Self::from_page_def_for_page(page_def, 1)
+    }
+
+    /// PageDef와 최종 쪽번호로부터 페이지 영역을 계산한다.
+    ///
+    /// `BindingMethod::DuplexSided`에서는 홀수쪽은 기존 좌우 여백 방향을 유지하고,
+    /// 짝수쪽은 좌우 여백을 교대한다. `page_number=0`은 아직 최종 쪽번호가
+    /// 확정되지 않은 상태로 보고 기존 방향을 유지한다.
+    pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self {
         // landscape=true면 width/height 교환
         let (page_width, page_height) = if page_def.landscape {
             (page_def.height, page_def.width)
@@ -181,8 +190,22 @@ impl PageAreas {
             (page_def.width, page_def.height)
         };
 
-        let content_left = page_def.margin_left + page_def.margin_gutter;
-        let content_right = page_width - page_def.margin_right;
+        let is_even_page = page_number != 0 && page_number.is_multiple_of(2);
+        let (effective_left, effective_right) =
+            if page_def.binding == BindingMethod::DuplexSided && is_even_page {
+                (
+                    page_def.margin_right,
+                    page_def.margin_left + page_def.margin_gutter,
+                )
+            } else {
+                (
+                    page_def.margin_left + page_def.margin_gutter,
+                    page_def.margin_right,
+                )
+            };
+
+        let content_left = effective_left;
+        let content_right = page_width - effective_right;
         // HWP 본문 시작 = margin_header + margin_top (한컴 도움말 기준)
         let content_top = page_def.margin_header + page_def.margin_top;
         // HWP 본문 끝 = height - margin_footer - margin_bottom
@@ -261,6 +284,79 @@ mod tests {
         assert!(areas.body_area.width() > 0);
         assert!(areas.body_area.height() > 0);
         assert!(areas.header_area.height() >= 0);
+    }
+
+    #[test]
+    fn page_areas_single_sided_keeps_horizontal_margins_on_even_pages() {
+        let page_def = PageDef {
+            width: 1000,
+            height: 1400,
+            margin_left: 100,
+            margin_right: 200,
+            margin_gutter: 30,
+            margin_top: 10,
+            margin_header: 20,
+            margin_bottom: 40,
+            margin_footer: 50,
+            binding: BindingMethod::SingleSided,
+            ..Default::default()
+        };
+
+        let odd = PageAreas::from_page_def_for_page(&page_def, 1);
+        let even = PageAreas::from_page_def_for_page(&page_def, 2);
+
+        assert_eq!(odd.body_area.left, 130);
+        assert_eq!(odd.body_area.right, 800);
+        assert_eq!(even.body_area.left, odd.body_area.left);
+        assert_eq!(even.body_area.right, odd.body_area.right);
+        assert_eq!(even.body_area.width(), odd.body_area.width());
+    }
+
+    #[test]
+    fn page_areas_duplex_sided_swaps_horizontal_margins_on_even_pages() {
+        let page_def = PageDef {
+            width: 1000,
+            height: 1400,
+            margin_left: 100,
+            margin_right: 200,
+            margin_gutter: 30,
+            margin_top: 10,
+            margin_header: 20,
+            margin_bottom: 40,
+            margin_footer: 50,
+            binding: BindingMethod::DuplexSided,
+            ..Default::default()
+        };
+
+        let odd = PageAreas::from_page_def_for_page(&page_def, 1);
+        let even = PageAreas::from_page_def_for_page(&page_def, 2);
+
+        assert_eq!(odd.body_area.left, 130);
+        assert_eq!(odd.body_area.right, 800);
+        assert_eq!(even.body_area.left, 200);
+        assert_eq!(even.body_area.right, 870);
+        assert_eq!(even.body_area.width(), odd.body_area.width());
+        assert_eq!(even.header_area.left, even.body_area.left);
+        assert_eq!(even.footer_area.left, even.body_area.left);
+    }
+
+    #[test]
+    fn page_areas_top_flip_keeps_left_right_margins_for_now() {
+        let page_def = PageDef {
+            width: 1000,
+            height: 1400,
+            margin_left: 100,
+            margin_right: 200,
+            margin_gutter: 30,
+            binding: BindingMethod::TopFlip,
+            ..Default::default()
+        };
+
+        let odd = PageAreas::from_page_def_for_page(&page_def, 1);
+        let even = PageAreas::from_page_def_for_page(&page_def, 2);
+
+        assert_eq!(even.body_area.left, odd.body_area.left);
+        assert_eq!(even.body_area.right, odd.body_area.right);
     }
 
     #[test]

--- a/src/renderer/page_layout.rs
+++ b/src/renderer/page_layout.rs
@@ -56,6 +56,16 @@ impl LayoutRect {
 impl PageLayoutInfo {
     /// PageDef와 ColumnDef로부터 페이지 레이아웃을 계산한다.
     pub fn from_page_def(page_def: &PageDef, column_def: &ColumnDef, dpi: f64) -> Self {
+        Self::from_page_def_for_page(page_def, column_def, dpi, 1)
+    }
+
+    /// PageDef, ColumnDef, 최종 쪽번호로부터 페이지 레이아웃을 계산한다.
+    pub fn from_page_def_for_page(
+        page_def: &PageDef,
+        column_def: &ColumnDef,
+        dpi: f64,
+        page_number: u32,
+    ) -> Self {
         // landscape=true이면 width/height 교환
         let (width_hwp, height_hwp) = if page_def.landscape {
             (page_def.height, page_def.width)
@@ -65,7 +75,7 @@ impl PageLayoutInfo {
         let page_width = hwpunit_to_px(width_hwp as i32, dpi);
         let page_height = hwpunit_to_px(height_hwp as i32, dpi);
 
-        let areas = PageAreas::from_page_def(page_def);
+        let areas = PageAreas::from_page_def_for_page(page_def, page_number);
 
         let header_area = LayoutRect::from_hwpunit_rect(&areas.header_area, dpi);
         let body_area = LayoutRect::from_hwpunit_rect(&areas.body_area, dpi);
@@ -97,6 +107,40 @@ impl PageLayoutInfo {
     /// 기본 DPI(96)로 계산
     pub fn from_page_def_default(page_def: &PageDef, column_def: &ColumnDef) -> Self {
         Self::from_page_def(page_def, column_def, DEFAULT_DPI)
+    }
+
+    /// 기존 레이아웃을 최종 쪽번호 기준 좌우 여백으로 이동한다.
+    ///
+    /// ColumnDef가 다른 zone layout일 수 있으므로 단 너비/간격은 보존하고, page body의
+    /// 기준 x 이동량만 각 영역에 적용한다.
+    pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32) {
+        let target_areas = PageAreas::from_page_def_for_page(page_def, page_number);
+        let target_header = LayoutRect::from_hwpunit_rect(&target_areas.header_area, self.dpi);
+        let target_body = LayoutRect::from_hwpunit_rect(&target_areas.body_area, self.dpi);
+        let target_footer = LayoutRect::from_hwpunit_rect(&target_areas.footer_area, self.dpi);
+
+        let delta_x = target_body.x - self.body_area.x;
+        if delta_x.abs() < f64::EPSILON
+            && (target_body.width - self.body_area.width).abs() < f64::EPSILON
+        {
+            return;
+        }
+
+        self.header_area.x = target_header.x;
+        self.header_area.width = target_header.width;
+        self.body_area.x = target_body.x;
+        self.body_area.width = target_body.width;
+        self.footer_area.x = target_footer.x;
+        self.footer_area.width = target_footer.width;
+
+        if self.footnote_area.width > 0.0 || self.footnote_area.height > 0.0 {
+            self.footnote_area.x += delta_x;
+            self.footnote_area.width = target_body.width;
+        }
+
+        for column_area in &mut self.column_areas {
+            column_area.x += delta_x;
+        }
     }
 
     /// 본문 영역의 사용 가능한 높이 (각주 영역 제외 + 페이지네이션 허용치 포함)
@@ -214,7 +258,7 @@ fn calculate_column_areas(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::model::page::{ColumnDef, PageDef};
+    use crate::model::page::{BindingMethod, ColumnDef, PageDef};
 
     fn a4_page_def() -> PageDef {
         PageDef {
@@ -273,5 +317,94 @@ mod tests {
         let layout = PageLayoutInfo::from_page_def_default(&page_def, &col_def);
 
         assert!(layout.available_body_height() > 0.0);
+    }
+
+    #[test]
+    fn page_layout_duplex_sided_even_page_swaps_body_and_columns() {
+        let page_def = PageDef {
+            width: 1000,
+            height: 1400,
+            margin_left: 100,
+            margin_right: 200,
+            margin_gutter: 30,
+            margin_top: 10,
+            margin_header: 20,
+            margin_bottom: 40,
+            margin_footer: 50,
+            binding: BindingMethod::DuplexSided,
+            ..Default::default()
+        };
+        let col_def = ColumnDef {
+            column_count: 2,
+            spacing: 60,
+            ..Default::default()
+        };
+
+        let odd = PageLayoutInfo::from_page_def_for_page(&page_def, &col_def, DEFAULT_DPI, 1);
+        let even = PageLayoutInfo::from_page_def_for_page(&page_def, &col_def, DEFAULT_DPI, 2);
+
+        assert!(even.body_area.x > odd.body_area.x);
+        assert!((even.body_area.width - odd.body_area.width).abs() < 0.01);
+        assert_eq!(odd.column_areas.len(), 2);
+        assert_eq!(even.column_areas.len(), 2);
+        assert!((even.column_areas[0].x - even.body_area.x).abs() < 0.01);
+        assert!((even.column_areas[0].width - odd.column_areas[0].width).abs() < 0.01);
+        assert!(
+            (even.column_areas[1].x
+                - even.column_areas[0].x
+                - (odd.column_areas[1].x - odd.column_areas[0].x))
+                .abs()
+                < 0.01
+        );
+    }
+
+    #[test]
+    fn page_layout_from_page_def_matches_page_one_layout() {
+        let page_def = PageDef {
+            binding: BindingMethod::DuplexSided,
+            ..a4_page_def()
+        };
+        let col_def = ColumnDef::default();
+
+        let default_layout = PageLayoutInfo::from_page_def(&page_def, &col_def, DEFAULT_DPI);
+        let page_one_layout =
+            PageLayoutInfo::from_page_def_for_page(&page_def, &col_def, DEFAULT_DPI, 1);
+
+        assert!((default_layout.body_area.x - page_one_layout.body_area.x).abs() < 0.01);
+        assert!((default_layout.body_area.width - page_one_layout.body_area.width).abs() < 0.01);
+    }
+
+    #[test]
+    fn apply_page_number_margins_moves_existing_zone_layout_without_rebuilding_columns() {
+        let page_def = PageDef {
+            width: 1000,
+            height: 1400,
+            margin_left: 100,
+            margin_right: 200,
+            margin_gutter: 30,
+            binding: BindingMethod::DuplexSided,
+            ..Default::default()
+        };
+        let col_def = ColumnDef {
+            column_count: 2,
+            same_width: false,
+            widths: vec![200, 300],
+            gaps: vec![40],
+            ..Default::default()
+        };
+
+        let mut layout =
+            PageLayoutInfo::from_page_def_for_page(&page_def, &col_def, DEFAULT_DPI, 1);
+        let original_col_delta = layout.column_areas[1].x - layout.column_areas[0].x;
+
+        layout.apply_page_number_margins(&page_def, 2);
+
+        let expected = PageLayoutInfo::from_page_def_for_page(&page_def, &col_def, DEFAULT_DPI, 2);
+        assert!((layout.body_area.x - expected.body_area.x).abs() < 0.01);
+        assert!((layout.body_area.width - expected.body_area.width).abs() < 0.01);
+        assert!((layout.column_areas[0].x - expected.body_area.x).abs() < 0.01);
+        assert!(
+            (layout.column_areas[1].x - layout.column_areas[0].x - original_col_delta).abs() < 0.01
+        );
     }
 }

--- a/tests/issue_1196_hwpx_gutter_left_right.rs
+++ b/tests/issue_1196_hwpx_gutter_left_right.rs
@@ -1,0 +1,104 @@
+//! Issue #1196: HWPX `pagePr gutterType="LEFT_RIGHT"` 맞쪽 편집 문서에서
+//! 최종 쪽번호 홀짝에 따라 좌우 여백이 교대되어야 한다.
+//!
+//! 재현 문서: `samples/hwpx/[2027] 온새미로 1 본교재.hwpx`.
+//! #1271 이후 page 4 는 section 1 본문 시작이며, 정답 PDF 기준 짝수쪽인 page 4/6
+//! 본문은 홀수쪽 page 5 보다 오른쪽에서 시작해야 한다.
+
+use std::fs;
+use std::path::Path;
+
+#[derive(Debug)]
+struct BodyArea {
+    x: f64,
+    width: f64,
+}
+
+fn load_doc() -> rhwp::wasm_api::HwpDocument {
+    let rel = "samples/hwpx/[2027] 온새미로 1 본교재.hwpx";
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {rel}: {e:?}"))
+}
+
+fn parse_body_area(dump: &str) -> BodyArea {
+    let line = dump
+        .lines()
+        .find(|line| line.trim_start().starts_with("body_area:"))
+        .unwrap_or_else(|| panic!("body_area line not found:\n{dump}"));
+
+    let mut x = None;
+    let mut width = None;
+    for token in line.split_whitespace() {
+        if let Some(value) = token.strip_prefix("x=") {
+            x = Some(
+                value
+                    .parse::<f64>()
+                    .unwrap_or_else(|e| panic!("parse body_area x from {line:?}: {e}")),
+            );
+        } else if let Some(value) = token.strip_prefix("w=") {
+            width = Some(
+                value
+                    .parse::<f64>()
+                    .unwrap_or_else(|e| panic!("parse body_area width from {line:?}: {e}")),
+            );
+        }
+    }
+
+    BodyArea {
+        x: x.unwrap_or_else(|| panic!("body_area x not found: {line}")),
+        width: width.unwrap_or_else(|| panic!("body_area width not found: {line}")),
+    }
+}
+
+#[test]
+fn onsaemiro_left_right_gutter_alternates_body_area_by_page_parity() {
+    let doc = load_doc();
+
+    let page4 = doc.dump_page_items(Some(3));
+    assert!(
+        page4.contains("section=1, page_num=4"),
+        "page 4 must remain section 1 body start after #1271:\n{page4}"
+    );
+    assert!(
+        page4.contains("\"강의 01.\""),
+        "page 4 should start the main body content:\n{page4}"
+    );
+
+    let page5 = doc.dump_page_items(Some(4));
+    assert!(
+        page5.contains("section=1, page_num=5"),
+        "page 5 should keep final page_num=5:\n{page5}"
+    );
+
+    let page6 = doc.dump_page_items(Some(5));
+    assert!(
+        page6.contains("section=1, page_num=6"),
+        "page 6 should keep final page_num=6:\n{page6}"
+    );
+
+    let page4_body = parse_body_area(&page4);
+    let page5_body = parse_body_area(&page5);
+    let page6_body = parse_body_area(&page6);
+
+    assert!(
+        page4_body.x > page5_body.x + 40.0,
+        "Duplex even page 4 should start to the right of odd page 5. \
+         page4={page4_body:?}, page5={page5_body:?}"
+    );
+    assert!(
+        page6_body.x > page5_body.x + 40.0,
+        "Duplex even page 6 should start to the right of odd page 5. \
+         page6={page6_body:?}, page5={page5_body:?}"
+    );
+    assert!(
+        (page4_body.x - page6_body.x).abs() < 0.1,
+        "even pages should share the same body x. page4={page4_body:?}, page6={page6_body:?}"
+    );
+    assert!(
+        (page4_body.width - page5_body.width).abs() < 0.1
+            && (page6_body.width - page5_body.width).abs() < 0.1,
+        "left/right gutter swap should preserve body width. \
+         page4={page4_body:?}, page5={page5_body:?}, page6={page6_body:?}"
+    );
+}


### PR DESCRIPTION
## 문제

관련 이슈: #1196

HWPX `pagePr gutterType="LEFT_RIGHT"` 문서에서 맞쪽 편집 여백이 페이지 번호 홀짝에 따라 교대되지 않았다. 재현 문서 `samples/hwpx/[2027] 온새미로 1 본교재.hwpx` 기준으로 4쪽과 6쪽은 짝수 페이지인데도 5쪽과 같은 본문 x 좌표로 렌더링되어, 한컴의 맞쪽 편집 결과와 다르게 보였다.

## 원인

파서는 HWPX `LEFT_RIGHT`를 이미 `BindingMethod::DuplexSided`로 변환하고 있었다. 하지만 페이지 영역 계산은 최종 페이지 번호를 받지 못하고 1쪽 기준 여백만 사용했다.

특히 섹션 간 페이지 번호 이월이 끝난 뒤의 실제 `page_num`이 레이아웃에 반영되지 않아, 짝수 페이지에서 좌우 여백과 제본 여백이 교대되지 않았다.

## 해결

- `PageAreas`와 `PageLayoutInfo`에 페이지 번호 기반 계산 API를 추가했다.
- 페이지네이션 후 섹션 간 페이지 번호 이월이 완료된 시점에 `PageContent.layout`과 각 zone layout의 x 좌표를 최종 `page.page_number` 기준으로 보정했다.
- 페이지 분할과 리플로우에 영향을 주지 않도록 본문 폭과 column 설정은 유지하고, 맞쪽 편집에 필요한 x 위치만 이동했다.
- #1276에서 보정된 바탕쪽 글상자 번호 배치와 글뒤 표 흐름은 유지되도록 기존 회귀 테스트 범위를 함께 확인했다.

## 핵심 변경 파일

| 파일 | 변경 요지 |
|---|---|
| `src/model/page.rs` | `DuplexSided` 여백을 페이지 번호 홀짝 기준으로 계산하는 API 추가 |
| `src/renderer/page_layout.rs` | 페이지 번호 기반 `PageLayoutInfo` 생성 및 사후 x 좌표 보정 API 추가 |
| `src/document_core/queries/rendering.rs` | 최종 페이지 번호 확정 후 페이지/zone layout 보정 적용 |
| `tests/issue_1196_hwpx_gutter_left_right.rs` | 온새미로 HWPX 샘플의 4/5/6쪽 맞쪽 편집 회귀 테스트 추가 |

## 시각 검증

| 페이지 | Before | After | PDF 정답지 | 확인 포인트 |
|---|-----|-----|-----|---|
| 4쪽 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/28fdcb4e-6452-451b-82d4-bbc509ce8cc1" />| <img width="300" alt="image" src="https://github.com/user-attachments/assets/846a1968-4c93-40b2-8c39-14561f508105" />|<img width="300" alt="image" src="https://github.com/user-attachments/assets/8c9a97c6-9466-40da-ac17-b700174d21ea" /> | `section=1, page_num=4`, `"강의 01."`, 5쪽보다 오른쪽으로 이동 |
| 5쪽 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/4c2dd415-f561-43a9-8cee-590d1a72ec05" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/3b535caa-4111-4a9c-a0b1-fd90b4c8827b" /> |<img width="300" alt="image" src="https://github.com/user-attachments/assets/62211071-605e-4930-a70b-e0d5125bbeb6" />| 홀수 페이지 기준 위치 유지 |
| 6쪽 | <img width="300" alt="image" src="https://github.com/user-attachments/assets/70d5c32a-fb5b-4505-8ccf-298a0efedf29" /> | <img width="300" alt="image" src="https://github.com/user-attachments/assets/34da88d4-f48d-492b-a3ca-0db33f74fe68" /> |<img width="300" alt="image" src="https://github.com/user-attachments/assets/9bf292ac-5c5e-452f-aa7e-86e75a05daa4" />| 4쪽과 같은 짝수 페이지 위치 |

## 자동 검증

| 항목 | 결과 | 비고 |
|---|---|---|
| `cargo fmt --all -- --check` | 통과 | formatting clean |
| `cargo test` | 통과 | 전체 테스트 통과 |
| `cargo clippy -- -D warnings` | 통과 | warning 없음 |
| `wasm-pack build --target web` | 통과 | 로컬 WASM 산출물 갱신 |
| rhwp-studio 수동 시각 확인 | 통과 | 작업지시자 확인 완료 |

Docker 기반 WASM 빌드는 로컬 Docker daemon 미실행으로 사용할 수 없었고, 같은 목적의 로컬 `wasm-pack build --target web` 경로로 검증했다. `pkg/`와 `output/`은 빌드/진단 산출물이라 PR에 포함하지 않았다.

## 작업 기록

- 브랜치: `local/task1196`
- 기준 브랜치: upstream `devel`
- 커밋: `fe9fc2a6 fix: HWPX 맞쪽 편집 여백 교대 보정`
- Hyper-Waterfall 기록:
  - `mydocs/plans/task_m100_1196.md`
  - `mydocs/plans/task_m100_1196_impl.md`
  - `mydocs/working/task_m100_1196_stage1.md` ~ `task_m100_1196_stage5.md`
  - `mydocs/report/task_m100_1196_report.md`

## 남은 사항

- 이 PR은 #1196의 HWPX 맞쪽 편집 여백 교대 보정에 한정한다.
- 이슈 자동 종료 키워드는 사용하지 않는다. 최종 이슈 close 여부는 리뷰와 작업지시자 승인 후 별도로 처리한다.
- 작업 중 발견된 unrelated #1142~#1144 문서는 기존 로컬 미추적 파일로 남겨 두고 PR에 포함하지 않았다.
