### PR TITLE
Task #1298 (#1289 후속 작업) - fix: HWPX 시리얼라이저 0-length field range fieldBegin/fieldEnd 인터리빙 수정

### DIFF
--- a/mydocs/plans/task_m100_1298.md
+++ b/mydocs/plans/task_m100_1298.md
@@ -1,0 +1,55 @@
+# 수행 계획서 — Task M100 #1298
+
+## 개요
+
+**이슈**: #1298 — HWPX 시리얼라이저: 빈 필드(0-length field range)에서 fieldBegin/fieldEnd 인터리빙 오류  
+**브랜치**: `local/task1298`  
+**마일스톤**: M100
+
+## 배경
+
+PR #1289에서 HWPX 시리얼라이저의 Bookmark/Field dispatcher를 연결했다. 리뷰에서 "빈 필드(0-length field range)에서 fieldBegin/fieldEnd 인터리빙을 더 정교하게 보완할 여지가 있음"이 지적됐고, 후속 이슈 #1298로 처리하기로 합의됐다.
+
+## 문제 요약
+
+`src/serializer/hwpx/section.rs`의 `render_run_content` 함수에서 fieldEnd 방출 위치 결정 로직에 다음 결함이 있다.
+
+### 결함 1: `end_char_idx == 0`일 때 fieldEnd가 텍스트 뒤로 밀림
+
+fieldEnd 방출 조건이 `fr.end_char_idx == next_idx` (next_idx = idx + 1)이므로, `end_char_idx == 0`인 경우 루프 내에서 절대 매칭되지 않는다. 루프 후 처리(post-loop)에서 방출되어 문단 전체 텍스트가 출력된 후에 fieldEnd가 나온다.
+
+**기대값 (빈 필드)**:
+```
+<fieldBegin/> <fieldEnd/>
+```
+**실제 출력 (잘못됨)**:
+```
+<fieldBegin/> 텍스트 전체 <fieldEnd/>
+```
+
+### 결함 2: 0-length mid-text 필드 (`start_char_idx == end_char_idx == N`, N > 0)에서 텍스트 끼어듦
+
+fieldBegin은 슬롯 시스템으로 인덱스 N 앞에 방출되지만, fieldEnd는 인덱스 N의 문자를 처리한 직후에 방출된다. 0-length 필드임에도 인덱스 N의 문자가 fieldBegin/fieldEnd 사이에 끼어든다.
+
+## 수행 범위
+
+- `src/serializer/hwpx/section.rs` — `render_run_content` 함수 내 fieldEnd 방출 로직 보완
+- 신규 단위 테스트 추가:
+  - `end_char_idx == 0` 케이스 (문단 시작에 빈 필드)
+  - `start_char_idx == end_char_idx == N` (mid-text 빈 필드) 케이스
+
+## 수행 방법 (방향 A — 최소 패치)
+
+1. 루프 진입 전(pre-loop) 단계에서 `end_char_idx == 0`인 필드의 fieldEnd를 방출
+2. 루프 내부에서 `end_char_idx == idx` (현재 문자 인덱스와 동일한 end)인 경우를 추가 처리하여 0-length mid-text 필드를 대응
+
+방향 B(fieldBegin/fieldEnd 모두 field_ranges 직접 구동)는 별도 이슈로 분리한다.
+
+## 예상 작업량
+
+- 구현: 소 (section.rs 20~40줄 수정)
+- 테스트 추가: 소 (테스트 케이스 2~3개)
+
+## 단계 구성 (구현 계획서에서 구체화)
+
+최소 2단계, 최대 3단계로 구성 예정.

--- a/mydocs/plans/task_m100_1298_impl.md
+++ b/mydocs/plans/task_m100_1298_impl.md
@@ -1,0 +1,169 @@
+# 구현 계획서 — Task M100 #1298
+
+## 개요
+
+**이슈**: #1298 — HWPX 시리얼라이저: 빈 필드(0-length field range) fieldBegin/fieldEnd 인터리빙 오류  
+**브랜치**: `local/task1298`  
+**수정 파일**: `src/serializer/hwpx/section.rs`
+
+---
+
+## 문제 구조 정밀 분석
+
+### 현재 fieldEnd 방출 흐름
+
+`render_run_content`의 메인 문자 루프:
+
+```
+for (idx, c) in para.text.chars().enumerate() {
+    [1] 슬롯 방출 (fieldBegin 등): char_pos >= expected + 8 이면 flush → render_control_slot
+    [2] text_buf.push(c)
+    [3] expected_utf16_pos 갱신
+    [4] fieldEnd 방출: fr.end_char_idx == (idx + 1) 이면 flush → fieldEnd 방출
+}
+// 루프 후
+[5] flush
+[6] 미방출 fieldEnd post-loop 처리
+[7] 남은 슬롯 post-loop 처리
+```
+
+### 결함 1: `end_char_idx == 0` → fieldEnd가 텍스트 뒤로 밀림
+
+0-length 필드 at position 0 (`start=0, end=0`):
+- `char_offsets[0]` = 16 (fieldBegin 8cu + fieldEnd 8cu 갭)
+- `inferred_control_slot_count` = 갭 2개 − field_ranges 1개 = 1 슬롯 (fieldBegin)
+- **[1]**: idx=0에서 char_pos=16 ≥ 0+8 → fieldBegin 방출 ✓
+- **[4]**: `end_char_idx=0 == next_idx(1,2,...)`는 **영원히 성립 안 됨** → 루프 내 방출 불가
+- **[6]**: post-loop에서 방출 → 모든 텍스트 **뒤**에 fieldEnd 나옴 ✗
+
+### 결함 2: 0-length mid-text 필드 (`start=N, end=N, N>0`) → 순서 역전
+
+예) `text="ABCDE"`, `start=3, end=3`:
+- `char_offsets` = [0, 1, 2, **19**, 20] (3번 문자 앞에 16cu 갭)
+- **[4]** idx=2 (문자 C), next_idx=3, end_char_idx=3 → **매칭! fieldEnd가 C 뒤에 방출**
+- **[1]** idx=3 (문자 D), char_pos=19 ≥ expected+8 → **fieldBegin 방출**
+- 결과: `ABC` **fieldEnd** fieldBegin `DE` → fieldEnd가 fieldBegin 앞에! ✗
+
+### 필요한 수정 요약
+
+| 케이스 | 기대 출력 | 현재 오동작 |
+|--------|----------|-----------|
+| start=0, end=0 | `<fieldBegin/><fieldEnd/>` text | `<fieldBegin/>` text `<fieldEnd/>` |
+| start=N, end=N | text[0..N] `<fieldBegin/><fieldEnd/>` text[N..] | text[0..N] `<fieldEnd/>` `<fieldBegin/>` text[N..] |
+
+---
+
+## 구현 단계
+
+### Stage 1 — fieldEnd 방출 로직 수정 (section.rs)
+
+**변경 위치**: `render_run_content` 함수 (section.rs 209~327)
+
+#### 변경 1: 루프 내 — 문자 push 전에 0-length fieldEnd 방출
+
+슬롯 방출([1]) 직후, `text_buf.push(c)` 직전에 다음 검사 추가:
+
+```rust
+// [NEW] 0-length 필드: start == end == idx → fieldBegin 방출 직후 fieldEnd 방출
+for (i, fr) in para.field_ranges.iter().enumerate() {
+    if fr.start_char_idx == fr.end_char_idx
+        && fr.end_char_idx == idx
+        && !field_end_emitted[i]
+    {
+        flush_text_fragment(&mut out, &mut text_buf, &para.tab_extended, &mut tab_idx);
+        if let Some(Control::Field(f)) = para.controls.get(fr.control_idx) {
+            if let Ok(xml) = writer_to_string(|w| write_field_end(w, f.field_id)) {
+                out.push_str("<hp:ctrl>");
+                out.push_str(&xml);
+                out.push_str("</hp:ctrl>");
+            }
+        }
+        field_end_emitted[i] = true;
+    }
+}
+```
+
+#### 변경 2: 기존 post-char fieldEnd 검사에 guard 추가
+
+기존 [4] 검사에 0-length 필드를 건너뛰는 조건 추가:
+
+```rust
+// 기존: fr.end_char_idx == next_idx
+// 수정: start < end 인 경우에만 (0-length 필드는 변경 1에서 처리)
+if fr.end_char_idx == next_idx
+    && !field_end_emitted[i]
+    && fr.start_char_idx < fr.end_char_idx  // ← 추가
+{
+    ...
+}
+```
+
+#### 수정 전후 흐름 비교
+
+**0-length 필드 at 0 (`start=0, end=0`, text="hello"):**
+
+```
+수정 전: <fieldBegin/> <hp:t>hello</hp:t> <fieldEnd/>   ✗
+수정 후: <fieldBegin/> <fieldEnd/> <hp:t>hello</hp:t>   ✓
+```
+
+**0-length mid-text 필드 (`start=3, end=3`, text="ABCDE"):**
+
+```
+수정 전: <hp:t>ABC</hp:t> <fieldEnd/> <fieldBegin/> <hp:t>DE</hp:t>   ✗
+수정 후: <hp:t>ABC</hp:t> <fieldBegin/> <fieldEnd/> <hp:t>DE</hp:t>   ✓
+```
+
+**기존 정상 필드 (start=0, end=5, text="hello"):**
+
+```
+수정 전: <fieldBegin/> <hp:t>hello</hp:t> <fieldEnd/>   ✓
+수정 후: <fieldBegin/> <hp:t>hello</hp:t> <fieldEnd/>   ✓ (불변)
+```
+
+---
+
+### Stage 2 — 단위 테스트 추가 (section.rs)
+
+다음 테스트 케이스를 `section.rs`의 `#[cfg(test)] mod tests`에 추가:
+
+#### 테스트 1: `task1298_zero_length_field_at_para_start`
+
+- `start=0, end=0`, text="hello"
+- 검증: fieldBegin이 fieldEnd보다 앞에 위치하고, 두 마커가 텍스트보다 앞에 위치
+- `begin_pos < end_pos < text_pos` 순서 검증
+
+#### 테스트 2: `task1298_zero_length_field_mid_text`
+
+- `start=3, end=3`, text="ABCDE", char_offsets=[0,1,2,19,20]
+- 검증: `ABC`가 fieldBegin 앞, fieldBegin이 fieldEnd 앞, `DE`가 fieldEnd 뒤
+- `text_abc_pos < begin_pos < end_pos < text_de_pos` 순서 검증
+
+#### 테스트 3: 기존 비-0-length 필드 회귀 검증
+
+- `task1289_field_begin_end_roundtrip` (기존) 통과 유지 확인
+- 별도 추가 케이스: `start=0, end=3`, text="hello" → 필드 내 텍스트 포함 케이스
+
+---
+
+## 예외 케이스 (이번 범위 외)
+
+**빈 문단(text == "") + 0-length 필드**: 루프 자체가 실행되지 않아 fieldBegin/fieldEnd 모두 post-loop 처리. 현재 post-loop 순서가 fieldEnd → fieldBegin으로 역전되는 기존 결함이 있으나, 이는 별도 이슈로 처리한다.
+
+---
+
+## 검증 방법
+
+```bash
+cargo test -p rhwp -- section::tests 2>&1 | grep -E "ok|FAILED"
+cargo clippy -- -D warnings
+```
+
+---
+
+## 단계별 커밋 계획
+
+| 단계 | 커밋 내용 |
+|------|----------|
+| Stage 1 | fix: 0-length field range fieldEnd 방출 위치 수정 (#1298) |
+| Stage 2 | test: 0-length field range 인터리빙 회귀 테스트 추가 (#1298) |

--- a/mydocs/report/task_m100_1298_report.md
+++ b/mydocs/report/task_m100_1298_report.md
@@ -1,0 +1,83 @@
+# 최종 결과 보고서 — Task M100 #1298
+
+## 개요
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #1298 — HWPX 시리얼라이저: 빈 필드(0-length field range) fieldBegin/fieldEnd 인터리빙 오류 |
+| 브랜치 | `local/task1298` |
+| 마일스톤 | M100 |
+| 커밋 | `1f25588f` (수정+테스트), `273dbc1f` (보고서) |
+
+---
+
+## 배경
+
+PR #1289에서 HWPX 시리얼라이저의 Bookmark/Field dispatcher를 연결했다. 리뷰에서 "빈 필드(0-length field range)에서 fieldBegin/fieldEnd 인터리빙을 더 정교하게 보완할 여지가 있음"이 지적됐고, 이번 이슈 #1298에서 처리했다.
+
+---
+
+## 수정 내용
+
+**파일**: `src/serializer/hwpx/section.rs` — `render_run_content` 함수
+
+### 결함 1: `end_char_idx == 0` → fieldEnd가 텍스트 뒤로 밀림
+
+기존 post-char fieldEnd 방출 조건 `fr.end_char_idx == next_idx`는 `next_idx = idx + 1 ≥ 1`이므로 `end_char_idx == 0`을 루프 내에서 영원히 잡지 못했다. 결과적으로 fieldEnd가 post-loop에서 모든 텍스트 뒤에 방출됐다.
+
+### 결함 2: 0-length mid-text 필드 (`start == end == N > 0`) → fieldEnd/fieldBegin 순서 역전
+
+기존 post-char 검사가 idx=N-1 시점(문자 N-1 처리 후)에 fieldEnd를 방출하고, fieldBegin은 idx=N 시점(슬롯 시스템)에 방출됐다. 결과: `...text[N-1] fieldEnd fieldBegin text[N]...` — 순서 역전.
+
+### 수정
+
+**변경 1**: 슬롯 방출(fieldBegin) 직후, `text_buf.push(c)` **직전**에 0-length 필드 전용 pre-char 검사 추가.
+
+```rust
+// 0-length 필드(start == end == idx): fieldBegin 방출 직후, 문자 push 전에 fieldEnd 방출.
+for (i, fr) in para.field_ranges.iter().enumerate() {
+    if fr.start_char_idx == fr.end_char_idx
+        && fr.end_char_idx == idx
+        && !field_end_emitted[i]
+    {
+        flush_text_fragment(...);
+        // emit fieldEnd
+        field_end_emitted[i] = true;
+    }
+}
+```
+
+**변경 2**: 기존 post-char 검사에 `fr.start_char_idx < fr.end_char_idx` guard 추가 — 0-length 필드가 idx-1 시점에 역순 방출되는 것 차단.
+
+---
+
+## 수정 전후 비교
+
+| 케이스 | 수정 전 | 수정 후 |
+|--------|---------|---------|
+| `start=0, end=0` | `<fieldBegin/>` text `<fieldEnd/>` | `<fieldBegin/><fieldEnd/>` text |
+| `start=N, end=N` (N>0) | text[N-1] `<fieldEnd/>` `<fieldBegin/>` text[N] | text[0..N] `<fieldBegin/><fieldEnd/>` text[N..] |
+| `start=0, end=5` (정상) | `<fieldBegin/>` text `<fieldEnd/>` | `<fieldBegin/>` text `<fieldEnd/>` (불변) |
+
+---
+
+## 테스트
+
+신규 테스트 2개 추가, 기존 테스트 12개 전부 회귀 없음.
+
+| 테스트 | 내용 |
+|--------|------|
+| `task1298_zero_length_field_at_para_start` | start=0, end=0: fieldBegin < fieldEnd < text 순서 검증 |
+| `task1298_zero_length_field_mid_text` | start=3, end=3: ABC < fieldBegin < fieldEnd < DE 순서 검증 |
+
+```
+test result: ok. 14 passed; 0 failed
+```
+
+`cargo clippy --lib -- -D warnings`: 경고 0건
+
+---
+
+## 범위 외 사항
+
+빈 문단(`text == ""`) + 0-length 필드 조합에서는 루프 자체가 실행되지 않아 post-loop에서 fieldEnd → fieldBegin 역순 방출이 발생하는 기존 결함이 남아 있다. 이 케이스는 실사용에서 발생 빈도가 매우 낮고 별도 분석이 필요하므로 후속 이슈로 처리한다.

--- a/mydocs/working/task_m100_1298_stage1.md
+++ b/mydocs/working/task_m100_1298_stage1.md
@@ -1,0 +1,69 @@
+# 단계별 완료 보고서 — Task M100 #1298 Stage 1
+
+## 개요
+
+구현 계획서의 Stage 1(수정) + Stage 2(테스트)를 단일 커밋으로 완료했다.
+
+**커밋**: `1f25588f`  
+**변경 파일**: `src/serializer/hwpx/section.rs`
+
+---
+
+## 수행 내용
+
+### 수정 1: 0-length fieldEnd pre-char 방출 추가
+
+`render_run_content` 내 메인 문자 루프에서, 슬롯 방출(fieldBegin) 직후 `text_buf.push(c)` 직전에 0-length 필드 검사를 추가했다.
+
+```rust
+// 0-length 필드(start == end == idx): fieldBegin 방출 직후, 문자 push 전에 fieldEnd 방출.
+for (i, fr) in para.field_ranges.iter().enumerate() {
+    if fr.start_char_idx == fr.end_char_idx
+        && fr.end_char_idx == idx
+        && !field_end_emitted[i]
+    {
+        flush_text_fragment(...);
+        // emit fieldEnd
+        field_end_emitted[i] = true;
+    }
+}
+```
+
+### 수정 2: 기존 post-char fieldEnd 검사에 guard 추가
+
+0-length 필드가 idx-1 시점의 post-char 검사에서 역순 방출되는 것을 차단했다.
+
+```rust
+if fr.end_char_idx == next_idx
+    && !field_end_emitted[i]
+    && fr.start_char_idx < fr.end_char_idx  // 추가
+```
+
+### 테스트 추가 (Stage 2)
+
+| 테스트명 | 검증 내용 |
+|---------|----------|
+| `task1298_zero_length_field_at_para_start` | start=0, end=0: fieldBegin < fieldEnd < text 순서 |
+| `task1298_zero_length_field_mid_text` | start=3, end=3: ABC < fieldBegin < fieldEnd < DE 순서 |
+
+---
+
+## 검증 결과
+
+```
+running 14 tests
+... (all 14 passed)
+test result: ok. 14 passed; 0 failed
+```
+
+`cargo clippy --lib -- -D warnings`: 경고 0건
+
+---
+
+## 수정 전후 비교
+
+| 케이스 | 수정 전 | 수정 후 |
+|--------|---------|---------|
+| start=0, end=0 | `<fieldBegin/>` text `<fieldEnd/>` | `<fieldBegin/><fieldEnd/>` text |
+| start=3, end=3 | AB `<fieldEnd/>` `<fieldBegin/>` CDE | ABC `<fieldBegin/><fieldEnd/>` DE |
+| start=0, end=5 (정상) | `<fieldBegin/>` text `<fieldEnd/>` | `<fieldBegin/>` text `<fieldEnd/>` (불변) |

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -274,6 +274,26 @@ fn render_run_content(para: &Paragraph, ctx: &mut SerializeContext) -> String {
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
         }
 
+        // 0-length 필드(start == end == idx): fieldBegin 방출 직후, 문자 push 전에 fieldEnd 방출.
+        // post-char 검사(next_idx 기준)는 end-1 번째 문자 처리 후 방출하므로 0-length 필드에서
+        // fieldEnd가 fieldBegin 앞에 나오거나 텍스트 뒤로 밀리는 문제가 생긴다.
+        for (i, fr) in para.field_ranges.iter().enumerate() {
+            if fr.start_char_idx == fr.end_char_idx
+                && fr.end_char_idx == idx
+                && !field_end_emitted[i]
+            {
+                flush_text_fragment(&mut out, &mut text_buf, &para.tab_extended, &mut tab_idx);
+                if let Some(Control::Field(f)) = para.controls.get(fr.control_idx) {
+                    if let Ok(xml) = writer_to_string(|w| write_field_end(w, f.field_id)) {
+                        out.push_str("<hp:ctrl>");
+                        out.push_str(&xml);
+                        out.push_str("</hp:ctrl>");
+                    }
+                }
+                field_end_emitted[i] = true;
+            }
+        }
+
         text_buf.push(c);
         let width = char_utf16_width(c);
         if char_pos >= expected_utf16_pos {
@@ -282,10 +302,14 @@ fn render_run_content(para: &Paragraph, ctx: &mut SerializeContext) -> String {
             expected_utf16_pos = expected_utf16_pos.saturating_add(width);
         }
 
-        // end_char_idx는 미포함(exclusive): 현재 문자가 필드 범위의 마지막이면 fieldEnd 삽입
+        // end_char_idx는 미포함(exclusive): 현재 문자가 필드 범위의 마지막이면 fieldEnd 삽입.
+        // 0-length 필드(start == end)는 위의 pre-char 검사에서 처리하므로 제외한다.
         let next_idx = idx + 1;
         for (i, fr) in para.field_ranges.iter().enumerate() {
-            if fr.end_char_idx == next_idx && !field_end_emitted[i] {
+            if fr.end_char_idx == next_idx
+                && !field_end_emitted[i]
+                && fr.start_char_idx < fr.end_char_idx
+            {
                 flush_text_fragment(&mut out, &mut text_buf, &para.tab_extended, &mut tab_idx);
                 if let Some(Control::Field(f)) = para.controls.get(fr.control_idx) {
                     if let Ok(xml) = writer_to_string(|w| write_field_end(w, f.field_id)) {
@@ -1080,5 +1104,95 @@ mod tests {
             "fieldEnd must be emitted even when end_char_idx == text.len(): {}",
             &xml[..400.min(xml.len())]
         );
+    }
+
+    // ---------- #1298: 0-length field range fieldBegin/fieldEnd 인터리빙 ----------
+
+    #[test]
+    fn task1298_zero_length_field_at_para_start() {
+        // 0-length 필드 at position 0 (start=0, end=0):
+        // HWP stream: fieldBegin(8cu) fieldEnd(8cu) "hello"(5cu) para_end(1cu) = 22cu
+        // char_offsets: [16, 17, 18, 19, 20] (fieldBegin+fieldEnd 갭 16 이후 텍스트)
+        let mut f = Field::default();
+        f.field_type = FieldType::ClickHere;
+        f.field_id = 55;
+
+        let mut para = Paragraph::default();
+        para.text = "hello".to_string();
+        para.char_count = 22;
+        para.char_offsets = vec![16, 17, 18, 19, 20];
+        para.controls.push(Control::Field(f));
+        para.field_ranges.push(FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 0, // 0-length
+            control_idx: 0,
+        });
+
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:ctrl><hp:fieldBegin id="55""#),
+            "fieldBegin must be emitted: {}",
+            &xml[..500.min(xml.len())]
+        );
+        assert!(
+            xml.contains(r#"<hp:ctrl><hp:fieldEnd beginIDRef="55"/></hp:ctrl>"#),
+            "fieldEnd must be emitted: {}",
+            &xml[..500.min(xml.len())]
+        );
+        assert!(xml.contains("hello"), "text must still be present");
+
+        // 순서 검증: fieldBegin < fieldEnd < "hello"
+        let begin_pos = xml.find("fieldBegin").expect("fieldBegin");
+        let end_pos = xml.find("fieldEnd").expect("fieldEnd");
+        let hello_pos = xml.find("hello").expect("hello");
+        assert!(begin_pos < end_pos, "fieldBegin must precede fieldEnd");
+        assert!(end_pos < hello_pos, "fieldEnd must precede text for 0-length field");
+    }
+
+    #[test]
+    fn task1298_zero_length_field_mid_text() {
+        // 0-length 필드 at position 3 (start=3, end=3), text="ABCDE":
+        // HWP stream: A B C fieldBegin(8cu) fieldEnd(8cu) D E para_end
+        // char_offsets: [0,1,2, 19,20] (D 앞에 16cu 갭)
+        let mut f = Field::default();
+        f.field_type = FieldType::ClickHere;
+        f.field_id = 77;
+
+        let mut para = Paragraph::default();
+        para.text = "ABCDE".to_string();
+        para.char_count = 5 + 8 + 8 + 1; // text + fieldBegin + fieldEnd + para_end
+        para.char_offsets = vec![0, 1, 2, 19, 20];
+        para.controls.push(Control::Field(f));
+        para.field_ranges.push(FieldRange {
+            start_char_idx: 3,
+            end_char_idx: 3, // 0-length mid-text
+            control_idx: 0,
+        });
+
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(xml.contains("ABCDE") || (xml.contains("ABC") && xml.contains("DE")),
+            "all text must be present: {}", &xml[..500.min(xml.len())]);
+
+        // 순서 검증: "ABC" < fieldBegin < fieldEnd < "DE"
+        let begin_pos = xml.find("fieldBegin").expect("fieldBegin");
+        let end_pos = xml.find("fieldEnd").expect("fieldEnd");
+        // ABC는 fieldBegin 앞에
+        let abc_pos = xml.find('A').expect("A");
+        // DE는 fieldEnd 뒤에 (fieldEnd 태그 닫힘 이후)
+        let field_end_close = xml.find("fieldEnd").unwrap()
+            + xml[xml.find("fieldEnd").unwrap()..].find('>').unwrap();
+        let de_pos = xml[field_end_close..].find('D')
+            .map(|p| p + field_end_close)
+            .expect("D after fieldEnd");
+
+        assert!(abc_pos < begin_pos, "ABC must precede fieldBegin");
+        assert!(begin_pos < end_pos, "fieldBegin must precede fieldEnd");
+        assert!(end_pos < de_pos, "fieldEnd must precede DE");
     }
 }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1149,7 +1149,10 @@ mod tests {
         let end_pos = xml.find("fieldEnd").expect("fieldEnd");
         let hello_pos = xml.find("hello").expect("hello");
         assert!(begin_pos < end_pos, "fieldBegin must precede fieldEnd");
-        assert!(end_pos < hello_pos, "fieldEnd must precede text for 0-length field");
+        assert!(
+            end_pos < hello_pos,
+            "fieldEnd must precede text for 0-length field"
+        );
     }
 
     #[test]
@@ -1176,8 +1179,11 @@ mod tests {
         let mut ctx = SerializeContext::collect_from_document(&doc);
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
 
-        assert!(xml.contains("ABCDE") || (xml.contains("ABC") && xml.contains("DE")),
-            "all text must be present: {}", &xml[..500.min(xml.len())]);
+        assert!(
+            xml.contains("ABCDE") || (xml.contains("ABC") && xml.contains("DE")),
+            "all text must be present: {}",
+            &xml[..500.min(xml.len())]
+        );
 
         // 순서 검증: "ABC" < fieldBegin < fieldEnd < "DE"
         let begin_pos = xml.find("fieldBegin").expect("fieldBegin");
@@ -1185,9 +1191,10 @@ mod tests {
         // ABC는 fieldBegin 앞에
         let abc_pos = xml.find('A').expect("A");
         // DE는 fieldEnd 뒤에 (fieldEnd 태그 닫힘 이후)
-        let field_end_close = xml.find("fieldEnd").unwrap()
-            + xml[xml.find("fieldEnd").unwrap()..].find('>').unwrap();
-        let de_pos = xml[field_end_close..].find('D')
+        let field_end_close =
+            xml.find("fieldEnd").unwrap() + xml[xml.find("fieldEnd").unwrap()..].find('>').unwrap();
+        let de_pos = xml[field_end_close..]
+            .find('D')
             .map(|p| p + field_end_close)
             .expect("D after fieldEnd");
 


### PR DESCRIPTION
## 변경 요약

 ### Summary

  - PR #1289에서 지적된 후속 과제: 빈 필드(0-length field range)에서 <hp:fieldBegin>/<hp:fieldEnd> 인터리빙 오류 수정
  - start_char_idx == end_char_idx인 0-length 필드에서 발생하는 두 가지 결함 수정

  ### 문제

  #### 결함 1: end_char_idx == 0 → fieldEnd가 텍스트 뒤로 밀림

  기존 방출 조건 fr.end_char_idx == next_idx는 next_idx ≥ 1이므로 end_char_idx == 0을 루프 내에서 잡지 못했다.
  결과적으로 fieldEnd가 모든 텍스트 뒤에 방출됐다.

  수정 전: <fieldBegin/> 텍스트 전체 <fieldEnd/>
  수정 후: <fieldBegin/> <fieldEnd/> 텍스트 전체

  #### 결함 2: start == end == N > 0 → fieldEnd/fieldBegin 순서 역전

  기존 post-char 검사가 idx=N-1 시점에 fieldEnd를 방출하고, fieldBegin은 idx=N 시점(슬롯 시스템)에 방출됐다.

  수정 전: text[0..N-1] <fieldEnd/> <fieldBegin/> text[N..]
  수정 후: text[0..N-1] <fieldBegin/> <fieldEnd/> text[N..]

  수정 방법 (src/serializer/hwpx/section.rs)

  1. 슬롯 방출(fieldBegin) 직후, text_buf.push(c) 직전에 0-length 필드 전용 pre-char 검사 추가 — start == end == idx이면
  즉시 fieldEnd 방출
  2. 기존 post-char 검사에 start_char_idx < end_char_idx guard 추가 — 0-length 필드가 idx-1 시점에 역순 방출되는 것 차단

  ### Test plan

  - [x] task1298_zero_length_field_at_para_start — start=0, end=0: fieldBegin < fieldEnd < text 순서 검증
  - [x] task1298_zero_length_field_mid_text — start=3, end=3: ABC < fieldBegin < fieldEnd < DE 순서 검증
  - [x] 기존 테스트 12개 회귀 없음 (cargo test --lib -- serializer::hwpx::section::tests: 14 passed)
  - [x] cargo clippy --lib -- -D warnings: 경고 0건

## 관련 이슈

closes #1298 

## 테스트

- [X] `cargo test` 통과
- [X] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷

변경 전후 비교가 필요한 경우 첨부해주세요.
