### PR TITLE
Task #1278: HWPX slash/backSlash type 보존

### DIFF
--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -212,8 +212,16 @@ fn write_border_fill<W: Write>(
 
     // 자식 순서 (BorderFillType.cpp:51-58):
     // slash, backSlash, leftBorder, rightBorder, topBorder, bottomBorder, diagonal, fillBrush
-    write_diag_line(w, "hh:slash")?;
-    write_diag_line(w, "hh:backSlash")?;
+    write_diag_line(
+        w,
+        "hh:slash",
+        diagonal_shape_type(((bf.attr >> 2) & 0x07) as u8),
+    )?;
+    write_diag_line(
+        w,
+        "hh:backSlash",
+        diagonal_shape_type(((bf.attr >> 5) & 0x07) as u8),
+    )?;
     write_border_line(w, "hh:leftBorder", &bf.borders[0])?;
     write_border_line(w, "hh:rightBorder", &bf.borders[1])?;
     write_border_line(w, "hh:topBorder", &bf.borders[2])?;
@@ -232,12 +240,26 @@ fn write_border_fill<W: Write>(
     Ok(())
 }
 
-fn write_diag_line<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError> {
+fn write_diag_line<W: Write>(
+    w: &mut Writer<W>,
+    name: &str,
+    type_str: &str,
+) -> Result<(), SerializeError> {
     empty_tag(
         w,
         name,
-        &[("type", "NONE"), ("Crooked", "0"), ("isCounter", "0")],
+        &[("type", type_str), ("Crooked", "0"), ("isCounter", "0")],
     )
+}
+
+fn diagonal_shape_type(code: u8) -> &'static str {
+    match code & 0x07 {
+        0 => "NONE",
+        0b010 => "CENTER",
+        0b011 => "CENTER_BELOW",
+        0b110 => "CENTER_ABOVE",
+        _ => "ALL",
+    }
 }
 
 fn write_border_line<W: Write>(
@@ -981,5 +1003,33 @@ mod tests {
         let sm = snippet.find("symMark=").unwrap();
         let bf = snippet.find("borderFillIDRef=").unwrap();
         assert!(ip < hp && hp < tc && tc < sc && sc < uf && uf < uk && uk < sm && sm < bf);
+    }
+
+    #[test]
+    fn write_border_fill_preserves_slash_and_backslash_shape_types() {
+        let mut bf = BorderFill::default();
+        bf.attr = (0b010 << 2) | (0b011 << 5);
+
+        let mut writer = Writer::new(Vec::new());
+        write_border_fill(&mut writer, 0, &bf).expect("write borderFill");
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hh:slash type="CENTER" Crooked="0" isCounter="0"/>"#),
+            "slash 방향 비트가 CENTER로 보존되어야 함: {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hh:backSlash type="CENTER_BELOW" Crooked="0" isCounter="0"/>"#),
+            "backSlash 방향 비트가 CENTER_BELOW로 보존되어야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn diagonal_shape_type_matches_hwpx_parser_codes() {
+        assert_eq!(diagonal_shape_type(0), "NONE");
+        assert_eq!(diagonal_shape_type(0b010), "CENTER");
+        assert_eq!(diagonal_shape_type(0b011), "CENTER_BELOW");
+        assert_eq!(diagonal_shape_type(0b110), "CENTER_ABOVE");
+        assert_eq!(diagonal_shape_type(0b111), "ALL");
     }
 }


### PR DESCRIPTION
## 요약

- HWPX `header.xml` 직렬화에서 `BorderFill.attr`의 slash/backSlash 방향 비트를 보존하도록 수정했습니다.
- `attr` bits 2..4는 `hh:slash type`, bits 5..7은 `hh:backSlash type`으로 역매핑합니다.
- `NONE`, `CENTER`, `CENTER_BELOW`, `CENTER_ABOVE`, `ALL` 매핑 회귀 테스트를 추가했습니다.

## 수정 코드

`src/serializer/hwpx/header.rs`의 `write_border_fill`에서 기존에는 `hh:slash`와 `hh:backSlash`를 항상 `type="NONE"`으로 출력했습니다. 이번 수정에서는 `BorderFill.attr`에 저장된 방향 비트를 읽어 HWPX type enum으로 복원합니다.

```rust
write_diag_line(
    w,
    "hh:slash",
    diagonal_shape_type(((bf.attr >> 2) & 0x07) as u8),
)?;
write_diag_line(
    w,
    "hh:backSlash",
    diagonal_shape_type(((bf.attr >> 5) & 0x07) as u8),
)?;
```

역매핑 함수는 parser의 slash/backSlash 코드와 대응되도록 추가했습니다.

```rust
fn diagonal_shape_type(code: u8) -> &'static str {
    match code & 0x07 {
        0 => "NONE",
        0b010 => "CENTER",
        0b011 => "CENTER_BELOW",
        0b110 => "CENTER_ABOVE",
        _ => "ALL",
    }
}
```

회귀 테스트는 `BorderFill.attr = (0b010 << 2) | (0b011 << 5)`일 때 `hh:slash type="CENTER"`, `hh:backSlash type="CENTER_BELOW"`가 출력되는지 확인합니다.

## 검증

- `cargo test diagonal_shape_type_matches_hwpx_parser_codes`
- `cargo test write_border_fill_preserves_slash_and_backslash_shape_types`
- `cargo test --test issue_1267_hwpx_tab_and_diagonal issue_1267`
- `cargo fmt --all -- --check`
- `git diff --check`
- `cargo test`
- `cargo clippy -- -D warnings`

## 관련 이슈

- closes #1278
