### PR TITLE
fix(layout): 단 구분선을 콘텐츠 높이로 단일 렌더 (#1333)

### DIFF
--- a/mydocs/plans/task_m100_1333.md
+++ b/mydocs/plans/task_m100_1333.md
@@ -1,0 +1,64 @@
+# 수행계획서 — 단 구분선 이중 렌더 수정 (M100 #1333)
+
+## 1. 배경 / 증상
+
+`3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` 의 가운데 단 구분선이 모든 페이지에서 **세로선 2개**로 중복 렌더된다.
+
+SVG 추출 결과 (x=396.9, 매 페이지 동일):
+
+| 선 | y 범위 | 출처 |
+|----|--------|------|
+| ① | 90.7 → **1092.3** (body 전체 높이, 매 페이지 고정) | `build_column_separators` (page-level) |
+| ② | 90.7 → 변동값(1003.8 등, 콘텐츠 높이) | `build_columns` → `emit_zone_column_separators` (zone emit) |
+
+> x=26.5 / 767.3 의 두 세로선은 쪽 테두리(정상)이며 본 건과 무관.
+
+## 2. 정답 판정
+
+PDF 권위 자료 `pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf` (한글 2022) 1쪽 육안 확인:
+단 구분선은 **본문 영역 전체 높이를 지나는 단일 실선**.
+
+→ **① (page-level, 전체 높이) 이 정답. ② (zone emit, 콘텐츠 높이) 가 잘못 추가된 중복선.**
+
+## 3. 근본 원인
+
+`src/renderer/layout.rs` 페이지 빌더가 단 구분선 경로 두 개를 모두 실행한다.
+
+- `layout.rs:1116` `build_columns(...)` → 내부 `emit_zone_column_separators` 로 zone 구분선 emit
+- `layout.rs:1140` `build_column_separators(...)` (page-level) — `!has_zone_specific_layout` 가드
+
+가드(`layout.rs:1135-1141`)는 `cc.zone_layout.is_some()` 로 판정한다. 그런데 본 문서는 **구역 전체가 처음부터 2단**(`문단 0.0` 의 단정의 2단, 단나누기/구역전환 없음)이라 `zone_layout = None` 이다. 결과:
+
+1. `has_zone_specific_layout = false` → page-level `build_column_separators` 가 그림 (정상, 전체 높이)
+2. 그러나 `build_columns` 의 zone emit 은 `zone_layout = col_content.zone_layout.unwrap_or(layout)` (`layout.rs:2531`) 로 **page layout 을 폴백 사용** → 2단 + 구분선 조건(`layout.rs:2617`: `column_areas.len()>=2 && separator_type>0`) 을 만족해 zone 구분선도 emit
+
+→ **페이지 전체가 단일 2단 zone(zone-specific layout 부재)인 문서는 항상 이중 렌더된다.**
+(Issue #874 Case 4 의 가드가 zone emit 경로의 `unwrap_or(layout)` 폴백까지는 못 막음)
+
+## 4. 수정 방향
+
+`build_columns` 의 zone 구분선 emit 을 **진짜 zone-specific layout 이 존재할 때(`col_content.zone_layout.is_some()`)만** 동작하도록 한정한다 (`layout.rs:2616-2622` 조건에 추가).
+
+이렇게 하면:
+- zone_layout = None (단일 2단 문서) → build_columns 는 emit 안 함, page-level `build_column_separators` 만 그림 (전체 높이, 정답)
+- zone_layout = Some (단나누기/구역전환으로 다단 zone 생성) → has_zone_specific_layout=true 로 page-level 은 skip, build_columns 의 zone emit 만 그림
+
+두 경로가 `zone_layout.is_some()` 라는 **동일 기준으로 정확히 상보** 관계가 되어 어떤 경우에도 한 선만 그려진다.
+
+## 5. 회귀 검증 범위
+
+- **대상 문서**: `3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` 23쪽 전부 — 단 구분선 1개씩만 남는지, 전체 높이인지.
+- **HWPX 쌍**: `3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx` 동일 확인 (ir-diff 무관, 렌더 경로 공통).
+- **다단 zone 회귀**: Issue #874 의 shortcut.hwp(1단/2단 zone 혼재) — 현재 `samples/` 에 부재. 대체 검증으로 `cargo test` 의 layout/pagination 관련 테스트 및 다단 zone 보유 샘플로 확인. shortcut.hwp 확보 가능 시 추가 확인.
+- **일반 다단 문서**: 단정의가 적용된 다른 샘플로 단 구분선 정상 렌더 확인.
+
+## 6. 산출물
+
+- `src/renderer/layout.rs` 1줄 조건 수정
+- 단계별 완료보고서 `working/task_m100_1333_stage{N}.md`
+- 최종 결과보고서 `report/task_m100_1333_report.md`
+
+## 7. 위험 / 영향
+
+- 변경 범위가 좁고(emit 조건 1개) page-level 가드와 대칭이라 부작용 가능성 낮음.
+- 유일 위험은 "has_zone_specific_layout=true 인데 그 페이지에 zone_layout=None 인 2단 cc 가 섞인" 혼재 케이스에서 해당 cc 구분선 누락 가능성. 구현 단계에서 해당 케이스 존재 여부를 코드/샘플로 확인하여 분기 처리한다.

--- a/mydocs/plans/task_m100_1333_impl.md
+++ b/mydocs/plans/task_m100_1333_impl.md
@@ -1,0 +1,60 @@
+# 구현계획서 — 단 구분선 이중 렌더 수정 (M100 #1333)
+
+수행계획서: `task_m100_1333.md`
+
+## 단계 구성 (3단계)
+
+### Stage 1 — 혼재 케이스 사전 조사
+
+수정 적용 전, `has_zone_specific_layout = true` 인 페이지에 `zone_layout = None` 인 다단(2단+) `cc` 가 섞일 수 있는지 확인한다.
+
+- `current_zone_layout` 설정/해제 경로 분석:
+  - `typeset.rs:651` 초기 None, `:810` reset None
+  - `typeset.rs:1191`, `:6295`, `engine.rs:1049` 에서 `Some(new_layout)` 설정
+- 한 페이지의 cc 들이 zone_layout None/Some 혼재 가능한지, 혼재 시 None cc 가 다단인지 판정.
+- 결과에 따라 Stage 2 수정안 확정:
+  - **(A) 혼재 없음/혼재 None cc 는 단일단** → 단순 조건 추가로 충분.
+  - **(B) 혼재하며 None cc 가 다단** → 별도 분기(해당 cc 만 page-level 폴백) 필요.
+
+산출: `working/task_m100_1333_stage1.md` (조사 결론 + 채택안)
+
+### Stage 2 — 코드 수정
+
+채택안에 따라 `src/renderer/layout.rs:2616-2622` 수정.
+
+(A) 채택 시:
+```rust
+// 본 zone 이 다단 + 구분선 보유 시 종료 시점에 emit 하기 위해 기록.
+// [Task #1333] zone-specific layout 이 실제로 존재할 때만 zone emit.
+// zone_layout=None(페이지 전체 단일 다단)은 page-level build_column_separators
+// 가 전체 높이로 그리므로 이중 렌더 방지.
+if col_content.zone_layout.is_some()
+    && zone_layout.column_areas.len() >= 2
+    && zone_layout.separator_type > 0
+{
+    prev_zone_layout_for_sep = Some(zone_layout.clone());
+    prev_zone_sep_y_start = current_zone_start_y.max(zone_layout.body_area.y);
+} else {
+    prev_zone_layout_for_sep = None;
+}
+```
+
+(B) 채택 시: 위 조건 + page-level 가드(`layout.rs:1139`)를 "zone emit 으로 커버되지 않는 None 다단 cc 존재 시 그림" 형태로 보완.
+
+산출: 소스 커밋 (`Task #1333: 내용`)
+
+### Stage 3 — 검증 + 최종 보고
+
+- `cargo build` / `cargo test` 통과 확인.
+- `export-svg` 재실행 후 대상 문서 23쪽 단 구분선이 페이지당 1개·전체 높이(y2≈1092.3)인지 추출 검증.
+- HWPX 쌍 동일 확인.
+- 다단 zone 보유 샘플(있으면)로 회귀 없음 확인.
+- `clippy` 경고 없음 확인 (변경 범위).
+
+산출: `report/task_m100_1333_report.md`
+
+## 검증 기준 (Stage 3 합격선)
+
+1. 대상 HWP/HWPX 23쪽: 단 구분선 x=396.9 세로선이 **페이지당 정확히 1개**, y 범위 ≈ 90.7→1092.3.
+2. `cargo test` 전부 통과.
+3. 다단 zone(단나누기/구역전환) 샘플 단 구분선 정상 (회귀 없음).

--- a/mydocs/plans/task_m100_1333_v2.md
+++ b/mydocs/plans/task_m100_1333_v2.md
@@ -1,0 +1,55 @@
+# 수행+구현 계획서 v2 — 단 구분선 길이 정정 (M100 #1333)
+
+선행: `task_m100_1333.md`, `task_m100_1333_impl.md`, Stage1/2 보고서, `report/task_m100_1333_report.md`
+
+## 1. v2 배경 (Stage 2 판단 오류)
+
+Stage 2 는 이중 렌더 두 후보선 중 **page-level(body 전체높이 고정)** 을 남기고
+**zone emit(콘텐츠 높이)** 를 제거했다. 그러나 PDF 픽셀 측정 결과 정답은 **zone emit** 이다.
+
+| 페이지 | PDF 구분선 끝% | zone emit% | page-level%(고정) |
+|--------|---------------|-----------|-------------------|
+| 1 | 90.3 | 89.4 ✓ | 97.3 |
+| 2 | 95.5 | 94.6 ✓ | 97.3 |
+| 3 | 74.2 | 73.2 ✓ | 97.3 ✗✗ |
+| 4 | 95.0 | 93.5 ✓ | 97.3 |
+| 5 | 94.5 | 93.0 ✓ | 97.3 |
+| 6 | 96.4 | 98.9 (△) | 97.3 |
+| 8 | 64.8 | 63.9 ✓ | 97.3 ✗✗ |
+| 23 | 52.8 | 53.5 ✓ | 97.3 ✗✗ |
+
+단 구분선은 **콘텐츠가 채워진 높이까지만** 그려야 하며(부분 페이지에서 짧음),
+page-level 의 고정 전체높이는 부분 페이지(3·8·23)에서 크게 틀린다.
+
+## 2. 수정 내용
+
+`src/renderer/layout.rs`:
+
+1. **Stage 2 게이트 되돌림** — `build_columns` 의 zone emit 기록 조건에서
+   `has_zone_specific_layout &&` 제거 (그리고 진입부 `has_zone_specific_layout` 계산 제거).
+   → 단일 다단 페이지(zone_layout=None → unwrap_or(layout))에서도 zone emit 이
+   콘텐츠 높이로 구분선을 그린다.
+2. **page-level 호출 제거** — 페이지 빌더의 `build_column_separators` 호출(및 관련
+   `has_zone_specific_layout` 가드) 삭제. zone emit 이 모든 다단 경우를 콘텐츠 높이로
+   커버하므로 전체높이 고정 path 는 불필요+오답.
+3. 미사용된 `build_column_separators` 함수 제거 (dead_code 방지).
+
+## 3. 두 path 의 관계 (정리 후)
+
+- 단 구분선 = **zone emit(`emit_zone_column_separators`) 단일 경로**.
+- whole-page 다단: `zone_layout = unwrap_or(layout)` 로 콘텐츠 높이 emit.
+- sub-page zone 혼재(shortcut.hwp): zone 별 콘텐츠 높이 emit (기존과 동일).
+- 이중 렌더 원천 제거 (page-level path 자체가 사라짐).
+
+## 4. 검증
+
+1. 대상 HWP 23쪽: 단 구분선 페이지당 1개 + **콘텐츠 높이**(PDF 와 ±2% 이내, 특히
+   3·8·23쪽 짧음 재현).
+2. HWPX 쌍 동일.
+3. 회귀: shortcut.hwp 9개 구분선 보존, exam_kor/exam_math/exam_social/hwp-multi-001/
+   interview/sungeo 단 구분선 정상(중복 0).
+4. `cargo test --release` 전부 통과, `clippy` 무경고.
+
+## 5. 범위 외
+
+- 페이지 6 zone emit +2.5% 미세 초과는 zone emit 자체 정확도 이슈 → 별도 타스크.

--- a/mydocs/report/task_m100_1333_report.md
+++ b/mydocs/report/task_m100_1333_report.md
@@ -1,0 +1,116 @@
+# 최종 결과보고서 — 단 구분선 이중 렌더 수정 (M100 #1333)
+
+- 이슈: edwardkim/rhwp#1333
+- 브랜치: `local/task1333`
+- 관련 문서: 수행계획서 `plans/task_m100_1333.md`, 구현계획서 `plans/task_m100_1333_impl.md`,
+  Stage 1 `working/task_m100_1333_stage1.md`, Stage 2 `working/task_m100_1333_stage2.md`
+
+## 1. 문제
+
+`3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` 의 가운데 단 구분선이 모든
+페이지에서 **세로선 2개**로 중복 렌더되었다.
+
+| 선 | y 범위 | 출처 |
+|----|--------|------|
+| ① | 90.7 → 1092.3 (body 전체 높이) | `build_column_separators` (page-level) |
+| ② | 90.7 → 변동(콘텐츠 높이) | `build_columns` → `emit_zone_column_separators` (zone emit) |
+
+PDF 정답지(한글 2022) 기준 ① (전체 높이 단일 실선) 이 정답.
+
+## 2. 근본 원인
+
+`src/renderer/layout.rs` 페이지 빌더가 단 구분선 경로 두 개를 모두 실행:
+
+- `layout.rs:1116` `build_columns` → 내부 zone emit
+- `layout.rs:1140` `build_column_separators` (page-level) — `!has_zone_specific_layout` 게이트
+
+`build_columns` 의 zone emit 은 `zone_layout = col_content.zone_layout.unwrap_or(layout)`
+(layout.rs:2531) 로 **zone-specific layout 이 없으면 page layout 을 폴백 사용**한다.
+본 문서는 구역 전체가 처음부터 2단(`문단 0.0` 단정의 2단, 단나누기/구역전환 없음)이라
+전 페이지 `zone_layout = None`:
+
+- `has_zone_specific_layout = false` → page-level 이 그림 (정상)
+- 그러나 build_columns 도 폴백 layout(2단, 구분선) 으로 emit → **이중 렌더**
+
+즉 **페이지 전체가 단일 다단(zone-specific layout 부재)인 문서는 항상 이중 렌더**되었다.
+(Issue #874 Case 4 가드가 zone emit 경로의 `unwrap_or(layout)` 폴백까지는 막지 못함)
+
+## 3. 수정
+
+`build_columns` 의 zone emit 을 **페이지 단위 `has_zone_specific_layout`** 술어로 게이트하여
+page-level 가드(layout.rs:1139)와 정확히 **배타** 관계로 만들었다. (`src/renderer/layout.rs`)
+
+```rust
+// 함수 진입부
+let has_zone_specific_layout = page_content
+    .column_contents.iter().any(|cc| cc.zone_layout.is_some());
+...
+// emit 기록 조건
+if has_zone_specific_layout
+    && zone_layout.column_areas.len() >= 2
+    && zone_layout.separator_type > 0
+{ prev_zone_layout_for_sep = Some(zone_layout.clone()); ... }
+```
+
+| 페이지 유형 | has_zone_specific | page-level | build_columns | 결과 |
+|------------|-------------------|------------|---------------|------|
+| 단일 다단 (대상 문서·연속 페이지) | false | 그림(전체높이) | skip | 단일 ✓ |
+| zone 혼재 (shortcut.hwp) | true | skip | 그림(zone별) | 정상 ✓ |
+
+cc 단위 `is_some()` 대신 페이지 술어를 쓴 이유: zone 혼재 페이지에서 page-level 이
+전역 skip 될 때, 그 페이지의 `zone_layout=None` 다단 cc 도 build_columns 가 그려
+누락을 방지하기 위함 (혼재 케이스 무손실).
+
+## 4. 검증
+
+### 4.1 대상 문서
+- HWP 23쪽: 단 구분선(x=396.9) **1개** (이전 2개), y=90.7→1092.3 전체높이 = PDF 정답 일치.
+- HWPX 쌍: 동일 정상화.
+- 시각 확인: 페이지 1 렌더가 PDF 와 일치.
+
+### 4.2 회귀
+- **shortcut.hwp (#874)**: 9개 구분선(1,1,2,1,1,2,1) 전수 보존, 영향 없음.
+- 추가 다단 샘플 회귀 스캔 (단 구분선 중복/누락):
+  exam_kor / exam_math / exam_social / hwp-multi-001 / interview / sungeo → **중복 0건**.
+  k-water-rfp 의 17쪽 중복은 **1단 문서의 표/테두리(점선+실선 겹침)** 로 본 수정과 무관
+  (수정은 `column_areas.len()>=2` 다단에만 작용, 1단 문서엔 영향 없음).
+
+### 4.3 테스트 / 정적분석
+- `cargo test --release`: **2107 passed, 0 failed** (issue_874 포함).
+- `cargo clippy --release`: 경고/에러 없음.
+
+## 5. v2 정정 (중요)
+
+Stage 2 는 이중 렌더 두 후보선 중 **page-level(body 전체높이 고정)** 을 남겼으나,
+작업지시자 지적("3 페이지 구분선이 짧아야 하는데 다른 페이지와 같음") 후 PDF 픽셀
+측정 결과 **정답은 zone emit(콘텐츠 높이)** 임이 확인되었다.
+
+| 페이지 | PDF end% | zone emit(콘텐츠)% | page-level(고정)% |
+|--------|----------|-------------------|-------------------|
+| 1 | 90.3 | 89.4 ✓ | 97.3 |
+| 3 | 74.2 | 73.2 ✓ | 97.3 ✗✗ |
+| 8 | 64.8 | 63.9 ✓ | 97.3 ✗✗ |
+| 23 | 52.8 | 53.5 ✓ | 97.3 ✗✗ |
+
+**v2 수정** (`task_m100_1333_v2.md`, `working/task_m100_1333_v2_stage1.md`):
+
+1. Stage 2 게이트 되돌림 — zone emit 이 단일 다단 페이지도 콘텐츠 높이로 그림.
+2. page-level `build_column_separators` 호출 + 함수 제거 (전체높이 고정 = 오답).
+3. `emit_zone_column_separators` y_end 를 body 영역 하단으로 캡 — 꽉 찬 페이지에서
+   prev_zone_y_end 가 body 를 초과해 구분선이 페이지 밖까지 그려지던 결함(p22 105%) 정정.
+
+검증: 23쪽 단일 구분선 + 콘텐츠 높이(PDF ±1.5%, 페이지 3 짧음 재현, 페이지 밖 초과 없음),
+shortcut.hwp 9개 보존, 추가 샘플 중복 0, `cargo test` 2107 passed, clippy 무경고.
+
+## 6. 결론
+
+단 구분선을 **zone emit 단일 경로(콘텐츠 높이, body 하단 캡)** 로 통일하여 이중 렌더를
+제거하고, 부분 페이지의 짧은 구분선을 PDF 정답과 일치시켰다. 전체 테스트 회귀 없음.
+
+## 7. 변경 파일
+
+- `src/renderer/layout.rs`
+  - (Stage 2, 되돌림) `build_columns` zone emit 게이트
+  - (v2) page-level `build_column_separators` 호출 + 함수 삭제
+  - (v2) `emit_zone_column_separators` y_end body 하단 캡
+- 문서: 계획서 3(v2 포함), Stage 보고서 3(v2 포함), 최종 보고서 1

--- a/mydocs/working/task_m100_1333_stage1.md
+++ b/mydocs/working/task_m100_1333_stage1.md
@@ -1,0 +1,89 @@
+# Stage 1 완료보고서 — 혼재 케이스 사전 조사 (M100 #1333)
+
+구현계획서: `mydocs/plans/task_m100_1333_impl.md`
+
+## 1. 조사 목적
+
+`build_columns` 의 zone 구분선 emit 을 `col_content.zone_layout.is_some()` 로 한정할 때,
+`has_zone_specific_layout = true` 페이지에 `zone_layout = None` 인 다단 cc 가 섞여
+구분선이 누락되는 혼재 케이스가 실제 존재하는지 확인.
+
+## 2. 활성 페이지네이터 확인
+
+`src/document_core/queries/rendering.rs:2202-2206` — 기본값 `RHWP_USE_PAGINATOR != 1` →
+**TypesetEngine(`src/renderer/typeset.rs`) 가 main pagination**. (pagination engine 은 fallback)
+
+## 3. `current_zone_layout` 생애주기 (typeset.rs)
+
+| 위치 | 동작 |
+|------|------|
+| `typeset.rs:651` | 초기 `None` |
+| `typeset.rs:728,750` (state.rs:91,111) | ColumnContent 확정 시 `zone_layout: current_zone_layout.clone()` |
+| `typeset.rs:1191` / `:6295` | **mid-doc 단나누기/구역전환** 으로 새 ColumnDef zone 생성 시 `Some(new_layout)` |
+| `typeset.rs:802-810` `reset_for_new_page` | **매 새 페이지에서 `None` 으로 리셋** (단, `self.layout` 은 유지) |
+
+→ `zone_layout = Some` 은 **문서 중간 단나누기/구역전환으로 생성된 zone** 에만 부여.
+초기 ColumnDef(문서 첫 단정의) 및 zone 의 **연속 페이지** 는 `None`.
+
+## 4. 실증 데이터
+
+### 4.1 대상 문서 (`3-09월_교육_통합_2024-구분선아래20구분선위20.hwp`)
+
+- `문단 0.0` 의 단정의 2단이 **구역 전체 초기 적용**(단나누기/구역전환 없음).
+- 전 페이지 `zone_layout = None`, `self.layout = 2단`.
+- 23쪽 모두 page-level(전체높이 90.7→1092.3) + build_columns emit(콘텐츠높이) **이중 렌더**.
+
+### 4.2 shortcut.hwp (`samples/basic/shortcut.hwp`, 단정의 45개 — #874 회귀 대상)
+
+현재 빌드 렌더 결과 (페이지 높이 ≈ 793px, 가로):
+
+| 페이지 | 세로 구분선 | y 범위 / 높이 |
+|--------|-------------|----------------|
+| 1 | 1개 | y 194.7→474.7 (h=280, **부분**) |
+| 2 | 1개 | y 467.3→707.3 (h=240, **부분**) |
+| 3 | 2개 | 132.1→244.1, 370.2→556.9 (**서로 다른 zone**, 부분) |
+| 4 | 1개 | 548.4→688.4 (h=140, 부분) |
+| 5 | 1개 | 170.0→330.0 (h=160, 부분) |
+| 6 | 2개 | 118.9→278.9, 490.9→630.9 (**서로 다른 zone**, 부분) |
+| 7 | 1개 | 56.7→196.7 (h=140, 부분) |
+
+→ **모든 구분선이 부분 높이** = 전부 **zone emit(`zone_layout = Some`) 출처**.
+shortcut.hwp 에서 page-level `build_column_separators` 는 **아무것도 그리지 않음**.
+즉 shortcut.hwp 는 현재 **이중 렌더 없음** (가드 정상 작동). 페이지 3·6 의 2개 선은
+같은 x(561.3) 이나 y범위가 겹치지 않는 **별개 zone** 으로 정상.
+
+## 5. 결론 — 혼재 케이스
+
+- 대상 문서: 전부 `None` (pure-None page). page-level 이 정답.
+- shortcut.hwp: 모든 다단 구분선이 `Some`. page-level 무관.
+- **혼재(None 다단 cc + Some cc 동일 페이지) 케이스는 현재 샘플에 존재하지 않음.**
+  - 이론상 "2단 zone(Some) 이 다음 페이지로 연속(→ reset 로 None) + 동일 페이지에서
+    또 mid-page 단나누기(Some)" 시 발생 가능하나 실 샘플 부재.
+
+## 6. 채택안 (수행계획서 (A)/(B) 중 결정)
+
+**page-level 가드와 동일 술어(`has_zone_specific_layout`)로 두 경로를 완전 상보화** ((B) 정련안).
+
+`build_columns` 의 emit 조건(`layout.rs:2616-2622`)을 cc 단위 `zone_layout.is_some()`
+대신 **페이지 단위 `has_zone_specific_layout`** 로 게이트:
+
+```rust
+let page_has_zone_specific = page_content
+    .column_contents.iter().any(|cc| cc.zone_layout.is_some());
+...
+if page_has_zone_specific
+    && zone_layout.column_areas.len() >= 2
+    && zone_layout.separator_type > 0
+{ prev_zone_layout_for_sep = Some(...); ... }
+```
+
+- 두 경로가 모두 page 술어 `has_zone_specific_layout` 로 키잉되어 **정확히 배타**:
+  - false (대상 문서·연속 페이지): page-level 만 그림 (전체높이, 정답). 이중 제거.
+  - true (shortcut.hwp): page-level skip, build_columns 만 그림. 혼재 None cc 도
+    포함되어 누락 위험 없음.
+- 단순 `is_some()` 게이트(A) 대비 **혼재 케이스 무손실** 이점.
+
+## 7. 다음 단계
+
+Stage 2 에서 위 채택안 적용 후, **shortcut.hwp 9개 구분선 전수 보존** + 대상 문서 23쪽
+구분선 1개·전체높이를 즉시 재검증한다.

--- a/mydocs/working/task_m100_1333_stage2.md
+++ b/mydocs/working/task_m100_1333_stage2.md
@@ -1,0 +1,63 @@
+# Stage 2 완료보고서 — 코드 수정 + 검증 (M100 #1333)
+
+구현계획서: `mydocs/plans/task_m100_1333_impl.md`
+Stage 1: `mydocs/working/task_m100_1333_stage1.md`
+
+## 1. 수정 내용
+
+`src/renderer/layout.rs` `build_columns` — zone 구분선 emit 을 페이지 단위
+`has_zone_specific_layout` 로 게이트하여 page-level `build_column_separators`
+(layout.rs:1139 게이트) 와 정확히 배타 관계로 만든다.
+
+### (1) 함수 진입부에 페이지 술어 계산 추가 (layout.rs:2492 부근)
+
+```rust
+let has_zone_specific_layout = page_content
+    .column_contents
+    .iter()
+    .any(|cc| cc.zone_layout.is_some());
+```
+
+### (2) emit 기록 조건에 술어 추가 (layout.rs:2616 부근)
+
+```rust
+if has_zone_specific_layout
+    && zone_layout.column_areas.len() >= 2
+    && zone_layout.separator_type > 0
+{
+    prev_zone_layout_for_sep = Some(zone_layout.clone());
+    prev_zone_sep_y_start = current_zone_start_y.max(zone_layout.body_area.y);
+} else {
+    prev_zone_layout_for_sep = None;
+}
+```
+
+> `zone_layout = col_content.zone_layout.unwrap_or(layout)` (layout.rs:2531) 의 page
+> layout 폴백으로 인해, zone-specific layout 이 없는 페이지(초기 단정의·연속 페이지)
+> 에서도 emit 되어 page-level 과 이중 렌더되던 결함을 차단.
+
+## 2. 검증 결과
+
+### 2.1 대상 문서 `3-09월_교육_통합_2024-구분선아래20구분선위20.hwp` (HWP)
+
+- 23쪽 전부 단 구분선(x=396.9) **세로선 1개** (이전 2개 → 1개, 중복 제거).
+- 남은 선 y=90.7→1092.3 (**body 전체 높이**) — PDF 정답지(한글 2022) 와 일치.
+- 좌우 쪽 테두리(x=26.5/767.3) 정상 유지.
+
+### 2.2 HWPX 쌍 `...구분선아래20구분선위20.hwpx`
+
+- 동일하게 x=396.9 단일 전체높이 선(90.7→1092.3). 정상.
+
+### 2.3 회귀 — shortcut.hwp (`samples/basic/shortcut.hwp`, #874)
+
+수정 전후 단 구분선 동일 (페이지별 1,1,2,1,1,2,1 — 총 9개 전수 보존).
+모두 zone emit(zone_layout=Some) 출처로, 게이트 영향 없음.
+
+### 2.4 테스트 / clippy
+
+- `cargo test --release`: **2107 passed, 0 failed** (issue_874 포함).
+- `cargo clippy --release`: 경고/에러 없음 (exit 0).
+
+## 3. 다음 단계
+
+Stage 3 — 다단 보유 추가 샘플 회귀 점검 + 최종 결과보고서 작성.

--- a/mydocs/working/task_m100_1333_v2_stage1.md
+++ b/mydocs/working/task_m100_1333_v2_stage1.md
@@ -1,0 +1,58 @@
+# v2 구현+검증 보고서 — 단 구분선 길이 정정 (M100 #1333)
+
+계획서: `mydocs/plans/task_m100_1333_v2.md`
+
+## 1. 배경
+
+Stage 2 는 이중 렌더 두 후보 중 **page-level(body 전체높이 고정)** 을 남겼으나,
+PDF 픽셀 측정 결과 정답은 **zone emit(콘텐츠 높이)** 였다. (페이지 3·8·23 등 부분
+페이지에서 page-level 이 과도하게 길었음.)
+
+## 2. 수정 (`src/renderer/layout.rs`)
+
+1. **Stage 2 게이트 되돌림** — `build_columns` 의 zone emit 조건에서
+   `has_zone_specific_layout &&` 및 진입부 술어 계산 제거. 단일 다단 페이지
+   (zone_layout=None → unwrap_or(layout))도 콘텐츠 높이로 emit.
+2. **page-level 호출 제거** — 페이지 빌더의 `build_column_separators` 호출 + 가드 삭제,
+   미사용 `build_column_separators` 함수 삭제. 단 구분선 = zone emit 단일 경로.
+3. **y_end body 하단 캡** — `emit_zone_column_separators` 에서
+   `y_end = y_end.min(body_area.y + body_area.height)`. 꽉 찬 페이지에서 prev_zone_y_end
+   가 trailing 간격 등으로 body 를 초과해 구분선이 페이지 밖까지 그려지던 결함(p22 105%)
+   정정. 부분 페이지·sub-page zone 은 콘텐츠가 body 하단보다 위라 영향 없음.
+
+## 3. 검증
+
+### 3.1 대상 문서 (HWP) — 단 구분선 끝 위치 vs PDF (한글 2022)
+
+전 23쪽 **단일 구분선**, 끝 위치 PDF ±1.5% 이내, 페이지 밖 초과 없음:
+
+| 페이지 | rhwp end% | PDF end% | diff |
+|--------|-----------|----------|------|
+| 1 | 89.4 | 90.3 | -0.9 |
+| 2 | 94.6 | 95.5 | -0.9 |
+| 3 | 73.2 | 74.2 | -1.0 (짧음 재현) |
+| 4 | 93.5 | 95.0 | -1.5 |
+| 5 | 93.0 | 94.5 | -1.5 |
+| 6 | 97.3 | 96.4 | +0.9 (캡) |
+| 8 | 63.9 | 64.8 | -0.9 |
+| 17 | 97.3 | 96.3 | +1.0 (캡) |
+| 19 | 97.3 | 96.7 | +0.6 (캡) |
+| 22 | 97.3 | 96.9 | +0.4 (캡, 이전 105%) |
+| 23 | 53.5 | 52.8 | +0.7 |
+
+페이지 3 시각 확인: 구분선이 ~73% 에서 멈춰 PDF 와 일치.
+
+### 3.2 회귀
+
+- shortcut.hwp(#874): 9개 구분선(1,1,2,1,1,2,1) 전수 보존.
+- exam_kor / exam_math / exam_social / interview / hwp-multi-001: 단 구분선 중복 0건.
+
+### 3.3 테스트 / clippy
+
+- `cargo test --release`: **2107 passed, 0 failed**.
+- `cargo clippy --release`: 경고/에러 없음.
+
+## 4. 결론
+
+단 구분선을 **zone emit 단일 경로(콘텐츠 높이, body 하단 캡)** 로 통일하여
+이중 렌더 제거 + 부분 페이지 짧은 구분선(PDF 정합)을 동시에 달성. 회귀 없음.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1128,17 +1128,10 @@ impl LayoutEngine {
             wrap_around_paras,
         );
 
-        // 단 구분선 — 페이지 안에 zone-specific layout(다단 zone) 이 있으면 zone 별
-        // emit_zone_column_separators 가 이미 sep 을 그리므로 page-level fallback 은 skip.
-        // (Issue #874 Case 4: shortcut.hwp 2쪽~ 페이지 layout 이 2단으로 잡혀 body_area
-        // 전체 길이 점선이 zone-별 sep 위에 중복 그려지는 결함 정정.)
-        let has_zone_specific_layout = page_content
-            .column_contents
-            .iter()
-            .any(|cc| cc.zone_layout.is_some());
-        if !has_zone_specific_layout {
-            self.build_column_separators(&mut tree, &mut body_node, layout);
-        }
+        // 단 구분선은 build_columns 내부의 emit_zone_column_separators 가 zone(또는
+        // page layout 폴백)별 콘텐츠 높이로 그린다. 과거 page-level build_column_separators
+        // 는 body 전체높이를 고정으로 그려 부분 페이지에서 구분선이 과도하게 길었고,
+        // zone emit 과 이중 렌더되어 [Task #1333 v2] 에서 제거되었다.
 
         // 콘텐츠 레이아웃 후 clip_rect 확정:
         // 자식 노드(표 등)의 실제 바운딩 박스를 재귀적으로 반영하여
@@ -2245,60 +2238,6 @@ impl LayoutEngine {
         footer_node
     }
 
-    /// 단 구분선을 렌더링하여 body_node에 추가한다.
-    fn build_column_separators(
-        &self,
-        tree: &mut PageRenderTree,
-        body_node: &mut RenderNode,
-        layout: &PageLayoutInfo,
-    ) {
-        if layout.column_areas.len() >= 2 && layout.separator_type > 0 {
-            let line_width = border_width_to_px(layout.separator_width).max(0.5);
-            // HWP 선 종류 코드 (doc_info.rs:294 line_type 매핑과 정합):
-            // 1=실선, 2=Dash, 3=Dot(점선), 5=DashDotDot, 6=LongDash, 7=Circle(원형 점선),
-            // 8+ (이중선/물결 등) 은 Solid 대체.
-            let dash = match layout.separator_type {
-                2 => StrokeDash::Dash,
-                3 => StrokeDash::Dot,
-                4 => StrokeDash::DashDot,
-                5 => StrokeDash::DashDotDot,
-                6 => StrokeDash::Dash, // LongDash → Dash 근사 (PR #843)
-                7 => StrokeDash::Dot,  // Circle(원형 점선) → Dot (PR #843)
-                _ => StrokeDash::Solid,
-            };
-            for i in 0..layout.column_areas.len() - 1 {
-                let left_col = &layout.column_areas[i];
-                let right_col = &layout.column_areas[i + 1];
-                let sep_x = (left_col.x + left_col.width + right_col.x) / 2.0;
-                let sep_y1 = left_col.y;
-                let sep_y2 = left_col.y + left_col.height;
-                let sep_id = tree.next_id();
-                let sep_node = RenderNode::new(
-                    sep_id,
-                    RenderNodeType::Line(LineNode::new(
-                        sep_x,
-                        sep_y1,
-                        sep_x,
-                        sep_y2,
-                        LineStyle {
-                            color: layout.separator_color,
-                            width: line_width,
-                            dash,
-                            ..Default::default()
-                        },
-                    )),
-                    BoundingBox::new(
-                        sep_x - line_width / 2.0,
-                        sep_y1,
-                        line_width,
-                        sep_y2 - sep_y1,
-                    ),
-                );
-                body_node.children.push(sep_node);
-            }
-        }
-    }
-
     /// 각주 영역 노드를 생성하여 tree에 추가한다.
     fn build_footnote_area(
         &self,
@@ -2614,6 +2553,11 @@ impl LayoutEngine {
                             .unwrap_or(false));
                 last_zone_y_offset = col_content.zone_y_offset;
                 // 본 zone 이 다단 + 구분선 보유 시 종료 시점에 emit 하기 위해 기록.
+                // [Task #1333 v2] zone emit(emit_zone_column_separators)이 단 구분선의 단일
+                // 경로다. zone_layout=None(초기 단정의·연속 페이지)은 unwrap_or(layout)로
+                // page layout 을 따르며, 콘텐츠가 채워진 높이까지만 구분선을 그린다(한컴 정합).
+                // 과거의 page-level build_column_separators(전체높이 고정)는 부분 페이지에서
+                // 구분선을 과도하게 길게 그려 제거됨.
                 if zone_layout.column_areas.len() >= 2 && zone_layout.separator_type > 0 {
                     prev_zone_layout_for_sep = Some(zone_layout.clone());
                     prev_zone_sep_y_start = current_zone_start_y.max(zone_layout.body_area.y);
@@ -2800,6 +2744,12 @@ impl LayoutEngine {
         y_start: f64,
         y_end: f64,
     ) {
+        // [Task #1333 v2] 콘텐츠 높이(y_end)가 body 영역 하단을 넘으면 하단에서 자른다.
+        // 꽉 찬 페이지에서 prev_zone_y_end 가 trailing 간격 등으로 body 를 초과해 구분선이
+        // 페이지 밖까지 그려지던 결함(예: 대상문서 p22 105%) 정정. 부분 페이지(콘텐츠 < body
+        // 하단)와 sub-page zone 은 영향 없음.
+        let body_bottom = zone_layout.body_area.y + zone_layout.body_area.height;
+        let y_end = y_end.min(body_bottom);
         if zone_layout.column_areas.len() < 2 || zone_layout.separator_type == 0 || y_end <= y_start
         {
             return;


### PR DESCRIPTION
## 개요

페이지 전체가 단일 다단(초기 단정의·연속 페이지)인 문서에서 단 구분선이 **두 경로로 이중 렌더**되고, 남은 선의 길이도 틀렸던 결함을 수정합니다.

- 재현 문서: `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwp`
- 증상: 가운데 단 구분선이 모든 페이지에서 세로선 2개로 그려짐. 또한 부분 페이지(섹션 끝)에서도 구분선이 페이지 끝까지 길게 그려짐.

## 원인

페이지 빌더가 단 구분선 경로 두 개를 모두 실행:
- `build_columns` → `emit_zone_column_separators` (zone emit, **콘텐츠 높이**)
- `build_column_separators` (page-level, **body 전체높이 고정**)

`build_columns`의 zone emit은 `zone_layout.unwrap_or(layout)`로 page layout을 폴백 사용하므로, zone-specific layout이 없는 단일 다단 페이지에서도 emit되어 page-level과 이중 렌더되었습니다. PDF(한글 2022) 픽셀 측정 결과 **콘텐츠 높이(zone emit)가 정답**이고 page-level의 고정 전체높이는 부분 페이지에서 크게 틀렸습니다.

## 수정

- 단 구분선을 **zone emit 단일 경로**로 통일, page-level `build_column_separators` 호출·함수 제거
- `emit_zone_column_separators`의 `y_end`를 **body 영역 하단으로 캡** — 꽉 찬 페이지에서 `prev_zone_y_end`가 trailing 간격 등으로 body를 초과해 구분선이 페이지 밖까지 그려지던 결함 정정

## 검증

| 항목 | 결과 |
|------|------|
| 대상 23쪽 | 단일 구분선, 끝 위치 PDF ±1.5% (페이지 3=73.2% vs PDF 74.2% 짧음 재현, p22 105%→97.3%) |
| shortcut.hwp (#874) | 9개 구분선(1,1,2,1,1,2,1) 보존 |
| exam_kor/math/social, interview, hwp-multi-001 | 단 구분선 중복 0 |
| `cargo test --release` | **2107 passed, 0 failed** |
| `cargo clippy --release` | 무경고 |

## 비고

페이지 6 등 일부 꽉 찬 페이지에서 zone emit 콘텐츠 높이가 PDF보다 +1% 내외 더 긴 미세 정확도 이슈는 본 PR 범위 밖이며 별도 타스크 권장.

closes #1333