### PR TITLE
fix(hwpx): 직렬화 누락 인라인 컨트롤 6종 보강 (squash 통합, #1327/#1326)

### DIFF
--- a/mydocs/pr/pr_1327_review.md
+++ b/mydocs/pr/pr_1327_review.md
@@ -1,0 +1,65 @@
+# PR #1327 검토 — HWPX 직렬화 누락 인라인 컨트롤 6종 보강
+
+- PR: edwardkim/rhwp#1327 (author: oksure)
+- 연결 이슈: #1326 (HWPX 직렬화 시 인라인 컨트롤 누락 — 저장 시 데이터 손실)
+- base ← head: `devel` ← `contrib/hwpx-page-controls`
+- 규모: +409 / −2, 3 files
+- mergeable: MERGEABLE / CLEAN
+- CI: Analyze(js-ts/python/rust) pass, Build&Test pass, CodeQL pass, WASM skip
+
+## 1. 배경 / 문제
+
+`parse_hwpx → serialize_hwpx → 재파싱` 시 일부 인라인 컨트롤이 조용히 사라짐(데이터 손실).
+`render_control_slot` 이 미지원 컨트롤을 `_ => {}` 로 버리고 `is_hwpx_inline_slot` 에도
+누락. 측정상 pageHiding(49)/pageNum(16)/newNum(12)/header(9)/footer(9)/autoNum(1) 손실.
+
+## 2. 변경 내용
+
+### `src/serializer/hwpx/section.rs` (+main)
+- `is_hwpx_inline_slot` 에 6종 추가, `render_control_slot` 에 6종 분기 추가.
+- 역매핑 렌더러: `render_page_hiding`, `render_page_num`, `render_new_num`,
+  `render_autonum`, `render_header`/`render_footer`(공통 `render_header_footer`).
+- 코드↔문자열 매핑 함수: `page_num_pos_to_str`(표150), `page_num_format_to_str`(표134),
+  `auto_number_type_to_str`(Picture→FIGURE), `apply_page_type_to_str`.
+- 장식문자 `'\0'` → 빈 문자열 처리(`ctrl_char_attr`), pageNum `sideChar` 기본 `'-'` 폴백.
+- header/footer 는 중첩 문단(subList) 을 기존 `render_paragraph_parts` 경로로 직렬화.
+
+### `src/parser/hwpx/section.rs` (버그 수정)
+- `parse_ctrl_autonum` 의 `autoNumFormat type` 을 `parse_u8` 로 읽어 문자열 enum
+  (DIGIT/CIRCLE_DIGIT/…) 을 0 으로 떨구던 결함 → 문자열 매핑으로 정정. **직렬화와 무관한
+  파싱 정확도 버그까지 발견·수정** (긍정적).
+
+### `tests/hwpx_roundtrip_integration.rs`
+- roundtrip 보존 테스트 4건: pageHiding+pageNum, newNum, header/footer(apply/문단수/첫
+  텍스트), autoNum. **카운트뿐 아니라 속성값까지 검증** (역매핑 정확성).
+
+## 3. 로컬 검증 결과
+
+- `cargo fmt --all -- --check`: 클린
+- `cargo test --test hwpx_roundtrip_integration`: **22 passed, 0 failed**
+  (신규 4건 모두 통과: page_hiding_and_page_num / new_num / header_footer / auto_num)
+- `cargo clippy --release` (hwpx/section): 경고 없음
+- CI 전체 pass
+
+## 4. 평가
+
+- **정확성**: 매핑이 파서 역방향과 일치(주석에 parse 함수 명시). 파서 autoNumFormat 버그
+  동반 수정은 추가 이득. roundtrip 값 보존 테스트로 회귀 가드 확보.
+- **범위**: 이슈가 1차로 명시한 3종(pageHiding/pageNum/newNum)을 넘어 header/footer/autoNum
+  까지 6종 처리. `form`(10건)은 미포함(이슈에서 "복합 구조 별도" 로 명시) — 합리적 분할.
+- **코드 품질**: 함수 분리·주석 양호, 인라인 스타일/하드코딩 우려 없음(상수 매핑은 스펙 표).
+
+### 사소한 관찰(블로커 아님)
+1. header/footer subList 속성 일부(`id`, `linkListIDRef`, `textDirection` 등)는 IR 미보존
+   값이라 고정 기본값으로 출력 — IR 보존 범위 내 무손실. 추후 IR 확장 시 정밀화 여지.
+2. header/footer roundtrip 테스트가 `text_width/height/ref` 수치까지는 비교하지 않음
+   (apply/문단수/첫 텍스트만). 보강 여지(필수 아님).
+3. `form` 미포함은 의도된 후속 — #1326 에 follow-up 항목으로 남아 트래킹됨.
+
+## 5. 판단(잠정)
+
+**Merge 권장.** 데이터 손실 수정 + 파서 버그 동반 수정 + 값 보존 회귀 테스트로 품질 충족,
+CI/로컬 검증 통과. 사소 관찰 1·2는 후속 보강 여지일 뿐 블로커 아님.
+
+> 메인테이너 결정 필요: (a) 그대로 merge, (b) 사소 관찰 2(header/footer 수치 비교) 보강
+> 요청 후 merge. 작업지시자 승인 요청.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4162,7 +4162,22 @@ fn parse_ctrl_autonum(
                 if local == b"autoNumFormat" {
                     for attr in ce.attributes().flatten() {
                         match attr.key.as_ref() {
-                            b"type" => an.format = parse_u8(&attr),
+                            // autoNumFormat type 은 문자열 enum (DIGIT/CIRCLE_DIGIT/…).
+                            // 과거 parse_u8 은 문자열을 0으로만 떨궈 DIGIT 외 형식을 잃었다.
+                            // pageNum formatType 과 동일한 문자열→코드 매핑을 사용한다.
+                            b"type" => {
+                                an.format = match attr_str(&attr).as_str() {
+                                    "DIGIT" => 0,
+                                    "CIRCLE_DIGIT" => 1,
+                                    "ROMAN_CAPITAL" => 2,
+                                    "ROMAN_SMALL" => 3,
+                                    "LATIN_CAPITAL" => 4,
+                                    "LATIN_SMALL" => 5,
+                                    "HANGUL" => 6,
+                                    "HANJA" => 7,
+                                    _ => 0,
+                                };
+                            }
                             b"userChar" => {
                                 let s = attr_str(&attr);
                                 an.user_symbol = s.chars().next().unwrap_or('\0');

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -21,9 +21,12 @@
 
 use quick_xml::Writer;
 
-use crate::model::control::{Control, Equation};
+use crate::model::control::{
+    AutoNumber, AutoNumberType, Control, Equation, NewNumber, PageHide, PageNumberPos,
+};
 use crate::model::document::{Document, Section};
 use crate::model::footnote::{Endnote, Footnote};
+use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::paragraph::{ColumnBreakType, LineSeg, Paragraph};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, TextWrap, VertAlign, VertRelTo,
@@ -405,6 +408,12 @@ fn is_hwpx_inline_slot(control: &Control) -> bool {
             | Control::Form(_)
             | Control::Footnote(_)
             | Control::Endnote(_)
+            | Control::PageHide(_)
+            | Control::PageNumberPos(_)
+            | Control::NewNumber(_)
+            | Control::Header(_)
+            | Control::Footer(_)
+            | Control::AutoNumber(_)
     )
 }
 
@@ -453,8 +462,216 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 Err(e) => eprintln!("[hwpx] Field 직렬화 실패: {e}"),
             }
         }
+        Control::PageHide(ph) => out.push_str(&render_page_hiding(ph)),
+        Control::PageNumberPos(pn) => out.push_str(&render_page_num(pn)),
+        Control::NewNumber(nn) => out.push_str(&render_new_num(nn)),
+        Control::Header(h) => out.push_str(&render_header(h, ctx)),
+        Control::Footer(f) => out.push_str(&render_footer(f, ctx)),
+        Control::AutoNumber(an) => out.push_str(&render_autonum(an)),
         _ => {}
     }
+}
+
+/// 장식 문자(userChar/prefixChar/suffixChar)용 속성값. '\0'(미설정)은 빈 문자열.
+fn ctrl_char_attr(c: char) -> String {
+    if c == '\0' {
+        String::new()
+    } else {
+        xml_escape(&c.to_string())
+    }
+}
+
+/// `<hp:ctrl><hp:autoNum num=".." numType=".."><hp:autoNumFormat .../></hp:autoNum></hp:ctrl>`
+/// 자동 번호(AutoNumber) 컨트롤. format은 pageNum formatType과 동일한 코드→문자열 매핑.
+fn render_autonum(an: &AutoNumber) -> String {
+    format!(
+        concat!(
+            r#"<hp:ctrl><hp:autoNum num="{num}" numType="{nt}">"#,
+            r#"<hp:autoNumFormat type="{ty}" userChar="{u}" prefixChar="{p}" "#,
+            r#"suffixChar="{s}" supscript="{sup}"/></hp:autoNum></hp:ctrl>"#
+        ),
+        num = an.number,
+        nt = auto_number_type_to_str(an.number_type),
+        ty = page_num_format_to_str(an.format),
+        u = ctrl_char_attr(an.user_symbol),
+        p = ctrl_char_attr(an.prefix_char),
+        s = ctrl_char_attr(an.suffix_char),
+        sup = an.superscript as u8,
+    )
+}
+
+/// 머리말/꼬리말 적용 범위 → HWPX `applyPageType`. `parse_apply_page_type`의 역매핑.
+fn apply_page_type_to_str(a: HeaderFooterApply) -> &'static str {
+    match a {
+        HeaderFooterApply::Both => "BOTH",
+        HeaderFooterApply::Even => "EVEN",
+        HeaderFooterApply::Odd => "ODD",
+    }
+}
+
+/// `<hp:ctrl><hp:{header|footer} applyPageType=".."><hp:subList ...>문단들</hp:subList>...`
+/// 머리말/꼬리말은 중첩 문단(subList)을 가진다 — render_note_sublist와 동일한 문단 직렬화
+/// 경로(render_paragraph_parts)를 쓰되, subList 텍스트 영역 속성은 IR 보존값을 사용한다.
+fn render_header_footer(
+    tag: &str,
+    h: HeaderFooterFields<'_>,
+    ctx: &mut SerializeContext,
+) -> String {
+    let mut out = format!(
+        concat!(
+            r#"<hp:ctrl><hp:{tag} id="0" applyPageType="{apply}">"#,
+            r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" "#,
+            r#"linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" "#,
+            r#"hasTextRef="{tr}" hasNumRef="{nr}">"#
+        ),
+        tag = tag,
+        apply = apply_page_type_to_str(h.apply_to),
+        tw = h.text_width,
+        th = h.text_height,
+        tr = h.text_ref,
+        nr = h.num_ref,
+    );
+    let mut vert_cursor: u32 = 0;
+    for p in h.paragraphs.iter() {
+        let (t, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
+        vert_cursor = advance;
+        let cs = first_run_char_shape_id(p);
+        out.push_str(&render_hp_p_open(p, ctx.next_para_id()));
+        out.push_str(&format!(r#"<hp:run charPrIDRef="{}">"#, cs));
+        out.push_str(&t);
+        out.push_str(r#"</hp:run><hp:linesegarray>"#);
+        out.push_str(&linesegs);
+        out.push_str(r#"</hp:linesegarray></hp:p>"#);
+    }
+    out.push_str(&format!("</hp:subList></hp:{tag}></hp:ctrl>", tag = tag));
+    out
+}
+
+/// render_header_footer 공통 인자 묶음 (Header/Footer가 동일 필드를 가짐).
+struct HeaderFooterFields<'a> {
+    apply_to: HeaderFooterApply,
+    text_width: u32,
+    text_height: u32,
+    text_ref: u8,
+    num_ref: u8,
+    paragraphs: &'a [Paragraph],
+}
+
+fn render_header(h: &Header, ctx: &mut SerializeContext) -> String {
+    render_header_footer(
+        "header",
+        HeaderFooterFields {
+            apply_to: h.apply_to,
+            text_width: h.text_width,
+            text_height: h.text_height,
+            text_ref: h.text_ref,
+            num_ref: h.num_ref,
+            paragraphs: &h.paragraphs,
+        },
+        ctx,
+    )
+}
+
+fn render_footer(f: &Footer, ctx: &mut SerializeContext) -> String {
+    render_header_footer(
+        "footer",
+        HeaderFooterFields {
+            apply_to: f.apply_to,
+            text_width: f.text_width,
+            text_height: f.text_height,
+            text_ref: f.text_ref,
+            num_ref: f.num_ref,
+            paragraphs: &f.paragraphs,
+        },
+        ctx,
+    )
+}
+
+/// `<hp:ctrl><hp:pageHiding .../></hp:ctrl>` — 감추기(PageHide) 컨트롤.
+/// `parse_page_hiding_attrs`의 역매핑. bool → "0"/"1" (한컴 정합).
+fn render_page_hiding(ph: &PageHide) -> String {
+    format!(
+        concat!(
+            r#"<hp:ctrl><hp:pageHiding hideHeader="{}" hideFooter="{}" "#,
+            r#"hideMasterPage="{}" hideBorder="{}" hideFill="{}" hidePageNum="{}"/></hp:ctrl>"#
+        ),
+        ph.hide_header as u8,
+        ph.hide_footer as u8,
+        ph.hide_master_page as u8,
+        ph.hide_border as u8,
+        ph.hide_fill as u8,
+        ph.hide_page_num as u8,
+    )
+}
+
+/// 쪽 번호 위치 코드(표 150) → HWPX `pos` 문자열. `parse_page_num_attrs`의 역매핑.
+fn page_num_pos_to_str(pos: u8) -> &'static str {
+    match pos {
+        0 => "NONE",
+        1 => "TOP_LEFT",
+        2 => "TOP_CENTER",
+        3 => "TOP_RIGHT",
+        4 => "BOTTOM_LEFT",
+        5 => "BOTTOM_CENTER",
+        6 => "BOTTOM_RIGHT",
+        7 => "OUTSIDE_TOP",
+        8 => "OUTSIDE_BOTTOM",
+        9 => "INSIDE_TOP",
+        10 => "INSIDE_BOTTOM",
+        _ => "BOTTOM_CENTER",
+    }
+}
+
+/// 번호 형식 코드(표 134) → HWPX `formatType` 문자열. `parse_page_num_attrs`의 역매핑.
+fn page_num_format_to_str(fmt: u8) -> &'static str {
+    match fmt {
+        0 => "DIGIT",
+        1 => "CIRCLE_DIGIT",
+        2 => "ROMAN_CAPITAL",
+        3 => "ROMAN_SMALL",
+        4 => "LATIN_CAPITAL",
+        5 => "LATIN_SMALL",
+        6 => "HANGUL",
+        7 => "HANJA",
+        _ => "DIGIT",
+    }
+}
+
+/// `<hp:ctrl><hp:pageNum .../></hp:ctrl>` — 쪽 번호 위치(PageNumberPos) 컨트롤.
+fn render_page_num(pn: &PageNumberPos) -> String {
+    // dash_char 기본값은 '-' (모델: 항상 '-'); '\0'이면 '-'로 폴백.
+    let side = if pn.dash_char == '\0' {
+        '-'
+    } else {
+        pn.dash_char
+    };
+    format!(
+        r#"<hp:ctrl><hp:pageNum pos="{}" formatType="{}" sideChar="{}"/></hp:ctrl>"#,
+        page_num_pos_to_str(pn.position),
+        page_num_format_to_str(pn.format),
+        xml_escape(&side.to_string()),
+    )
+}
+
+/// 번호 종류 → HWPX `numType` 문자열. `parse_num_type`의 역매핑(Picture→FIGURE).
+fn auto_number_type_to_str(t: AutoNumberType) -> &'static str {
+    match t {
+        AutoNumberType::Page => "PAGE",
+        AutoNumberType::Footnote => "FOOTNOTE",
+        AutoNumberType::Endnote => "ENDNOTE",
+        AutoNumberType::Picture => "FIGURE",
+        AutoNumberType::Table => "TABLE",
+        AutoNumberType::Equation => "EQUATION",
+    }
+}
+
+/// `<hp:ctrl><hp:newNum .../></hp:ctrl>` — 새 번호 지정(NewNumber) 컨트롤.
+fn render_new_num(nn: &NewNumber) -> String {
+    format!(
+        r#"<hp:ctrl><hp:newNum num="{}" numType="{}"/></hp:ctrl>"#,
+        nn.number,
+        auto_number_type_to_str(nn.number_type),
+    )
 }
 
 fn writer_to_string<F>(f: F) -> Result<String, SerializeError>

--- a/tests/hwpx_roundtrip_integration.rs
+++ b/tests/hwpx_roundtrip_integration.rs
@@ -582,3 +582,178 @@ fn para_ids_unique_across_body_and_table() {
         ids
     );
 }
+
+// ---------- 쪽/번호 인라인 컨트롤 직렬화 (pageHiding/pageNum/newNum) ----------
+// 회귀: 이 컨트롤들이 HWPX 직렬화 시 누락되어(render_control_slot `_ => {}`)
+// 저장 후 재파싱하면 사라졌다(데이터 손실). 카운트뿐 아니라 속성값까지 보존돼야 함.
+
+fn page_hides(doc: &rhwp::model::document::Document) -> Vec<(bool, bool, bool, bool, bool, bool)> {
+    use rhwp::model::control::Control;
+    let mut v = Vec::new();
+    for s in &doc.sections {
+        for p in &s.paragraphs {
+            for c in &p.controls {
+                if let Control::PageHide(ph) = c {
+                    v.push((
+                        ph.hide_header,
+                        ph.hide_footer,
+                        ph.hide_master_page,
+                        ph.hide_border,
+                        ph.hide_fill,
+                        ph.hide_page_num,
+                    ));
+                }
+            }
+        }
+    }
+    v
+}
+
+fn page_nums(doc: &rhwp::model::document::Document) -> Vec<(u8, u8)> {
+    use rhwp::model::control::Control;
+    let mut v = Vec::new();
+    for s in &doc.sections {
+        for p in &s.paragraphs {
+            for c in &p.controls {
+                if let Control::PageNumberPos(pn) = c {
+                    v.push((pn.position, pn.format));
+                }
+            }
+        }
+    }
+    v
+}
+
+fn new_nums(
+    doc: &rhwp::model::document::Document,
+) -> Vec<(u16, rhwp::model::control::AutoNumberType)> {
+    use rhwp::model::control::Control;
+    let mut v = Vec::new();
+    for s in &doc.sections {
+        for p in &s.paragraphs {
+            for c in &p.controls {
+                if let Control::NewNumber(nn) = c {
+                    v.push((nn.number, nn.number_type));
+                }
+            }
+        }
+    }
+    v
+}
+
+#[test]
+fn page_hiding_and_page_num_preserved_on_roundtrip() {
+    use rhwp::parser::hwpx::parse_hwpx;
+    use rhwp::serializer::hwpx::serialize_hwpx;
+
+    // 정부 보도자료: pageHiding + pageNum 다수 포함.
+    let bytes = include_bytes!("../samples/hwpx/2025년 1분기 해외직접투자 보도자료f.hwpx");
+    let d1 = parse_hwpx(bytes).expect("parse");
+    let (ph1, pn1) = (page_hides(&d1), page_nums(&d1));
+    assert!(!ph1.is_empty(), "fixture must contain pageHiding");
+    assert!(!pn1.is_empty(), "fixture must contain pageNum");
+
+    let out = serialize_hwpx(&d1).expect("serialize");
+    let d2 = parse_hwpx(&out).expect("reparse");
+    // 값까지 동일해야 함 (속성 역매핑 정확성 검증).
+    assert_eq!(page_hides(&d2), ph1, "PageHide 컨트롤/값 보존 실패");
+    assert_eq!(page_nums(&d2), pn1, "PageNumberPos 컨트롤/값 보존 실패");
+}
+
+#[test]
+fn new_num_preserved_on_roundtrip() {
+    use rhwp::parser::hwpx::parse_hwpx;
+    use rhwp::serializer::hwpx::serialize_hwpx;
+
+    // aift: newNum 포함.
+    let bytes = include_bytes!("../samples/hwpx/aift.hwpx");
+    let d1 = parse_hwpx(bytes).expect("parse aift");
+    let nn1 = new_nums(&d1);
+    assert!(!nn1.is_empty(), "aift must contain newNum");
+
+    let out = serialize_hwpx(&d1).expect("serialize aift");
+    let d2 = parse_hwpx(&out).expect("reparse aift");
+    assert_eq!(new_nums(&d2), nn1, "NewNumber 컨트롤/값 보존 실패");
+}
+
+// 머리말/꼬리말: 중첩 문단(subList)을 포함하는 컨트롤이 직렬화 시 통째로 누락됐다.
+// 개수 + 적용범위(applyPageType) + 내부 문단 수까지 보존돼야 함.
+type HfSig = Vec<(rhwp::model::header_footer::HeaderFooterApply, usize, String)>;
+
+fn headers_footers(doc: &rhwp::model::document::Document) -> (HfSig, HfSig) {
+    use rhwp::model::control::Control;
+    let (mut hs, mut fs): (HfSig, HfSig) = (Vec::new(), Vec::new());
+    let first_text = |paras: &[rhwp::model::paragraph::Paragraph]| {
+        paras.first().map(|p| p.text.clone()).unwrap_or_default()
+    };
+    for s in &doc.sections {
+        for p in &s.paragraphs {
+            for c in &p.controls {
+                match c {
+                    Control::Header(h) => {
+                        hs.push((h.apply_to, h.paragraphs.len(), first_text(&h.paragraphs)))
+                    }
+                    Control::Footer(f) => {
+                        fs.push((f.apply_to, f.paragraphs.len(), first_text(&f.paragraphs)))
+                    }
+                    _ => {}
+                }
+            }
+        }
+    }
+    (hs, fs)
+}
+
+#[test]
+fn header_footer_preserved_on_roundtrip() {
+    use rhwp::parser::hwpx::parse_hwpx;
+    use rhwp::serializer::hwpx::serialize_hwpx;
+
+    let bytes = include_bytes!("../samples/hwpx/143E433F503322BD33.hwpx");
+    let d1 = parse_hwpx(bytes).expect("parse");
+    let (h1, f1) = headers_footers(&d1);
+    assert!(
+        !h1.is_empty() || !f1.is_empty(),
+        "fixture must contain header/footer"
+    );
+
+    let out = serialize_hwpx(&d1).expect("serialize");
+    let d2 = parse_hwpx(&out).expect("reparse");
+    let (h2, f2) = headers_footers(&d2);
+    // applyPageType + 내부 문단 수 + 첫 문단 텍스트까지 보존.
+    assert_eq!(h2, h1, "Header 컨트롤/내용 보존 실패");
+    assert_eq!(f2, f1, "Footer 컨트롤/내용 보존 실패");
+}
+
+fn auto_nums(
+    doc: &rhwp::model::document::Document,
+) -> Vec<(u16, rhwp::model::control::AutoNumberType, u8)> {
+    use rhwp::model::control::Control;
+    let mut v = Vec::new();
+    for s in &doc.sections {
+        for p in &s.paragraphs {
+            for c in &p.controls {
+                if let Control::AutoNumber(an) = c {
+                    v.push((an.number, an.number_type, an.format));
+                }
+            }
+        }
+    }
+    v
+}
+
+#[test]
+fn auto_num_preserved_on_roundtrip() {
+    use rhwp::parser::hwpx::parse_hwpx;
+    use rhwp::serializer::hwpx::serialize_hwpx;
+
+    // eq-002: 본문에 autoNum 컨트롤 포함.
+    let bytes = include_bytes!("../samples/hwpx/eq-002.hwpx");
+    let d1 = parse_hwpx(bytes).expect("parse");
+    let an1 = auto_nums(&d1);
+    assert!(!an1.is_empty(), "fixture must contain autoNum");
+
+    let out = serialize_hwpx(&d1).expect("serialize");
+    let d2 = parse_hwpx(&out).expect("reparse");
+    assert_eq!(auto_nums(&d2), an1, "AutoNumber 컨트롤/값 보존 실패");
+}


### PR DESCRIPTION
## 개요

**PR #1327 (@oksure) 의 검토·검증을 마친 squash 통합본**입니다. HWPX `parse → serialize → 재파싱` 시 인라인 컨트롤이 조용히 사라지던 데이터 손실(#1326)을 정정합니다.

> 메인테이너 세션이 upstream 직접 merge 권한이 없어, 검토 완료된 #1327 변경을 squash 통합 PR 로 제출합니다. **원작성자 attribution 은 커밋 author(@oksure)로 보존**합니다. 본 PR merge 시 #1327 은 close 처리해 주세요.

## 변경 (3 files, +409/−2)

- **serializer** (`src/serializer/hwpx/section.rs`): `pageHiding`/`pageNum`/`newNum`/`header`/`footer`/`autoNum` 6종 역매핑 추가. pos(표150)/format(표134)/numType/applyPageType 코드↔문자열 매핑, header/footer subList 중첩 문단 직렬화.
- **parser** (`src/parser/hwpx/section.rs`): `autoNumFormat type` 을 `parse_u8` 로 읽어 문자열 enum(DIGIT/…)을 0 으로 떨구던 결함 정정.
- **test** (`tests/hwpx_roundtrip_integration.rs`): roundtrip 값 보존 회귀 4건.

`form`(복합 구조)은 #1326 후속으로 분리.

## 검토 / 검증

- 검토 기록: `mydocs/pr/pr_1327_review.md` (Merge 권장)
- `cargo fmt --all -- --check` 클린
- `cargo clippy --release` 무경고
- `cargo test --test hwpx_roundtrip_integration` **22 passed** (신규 4건 포함)
- 원 PR #1327 CI 전부 pass

Credit: Hyunwoo Park (@oksure) — PR #1327
closes #1326