### PR TITLE
fix(studio): 빈 글머리표 줄 caret 위치 보정 (squash 통합, #1331/#1329)

### DIFF
--- a/mydocs/pr/pr_1331_review.md
+++ b/mydocs/pr/pr_1331_review.md
@@ -1,0 +1,44 @@
+# PR #1331 검토 — 빈 글머리표 줄 caret 위치 보정
+
+- PR: edwardkim/rhwp#1331 (author: postmelee)
+- 연결 이슈: #1329 (글머리표 Enter 직후 빈 줄 caret이 글머리표 앞에 표시됨)
+- base ← head: `devel` ← `issue-1329-bullet-caret`
+- 규모: +1189 / −11, 9 files (단, **기능 코드는 2 files**)
+- mergeable: MERGEABLE / CLEAN, CI 전부 pass
+
+## 1. 문제
+
+번호/글머리표 문단에서 Enter 로 만든 빈 줄의 caret 이 marker(글머리표) **앞쪽** x 에
+표시됨. body anchor TextRun(char_start=None)의 bbox.x 가 marker 왼쪽이라 발생.
+
+## 2. 기능 변경 (검토 surface)
+
+### `src/document_core/queries/cursor_rect.rs` (+178)
+- 문단이 list(Outline/Number/Bullet head_type)인지 판정 + marker char_shape_id 취득.
+- `ParaLineHit` 구조 도입: `line_x`/`first_body_x`/`marker_end_x` 수집 후
+  `cursor_x(is_list_para, char_offset)` 로 caret x 결정 — 빈 list 문단 offset 0 은
+  `marker_end_x`(marker 오른쪽 끝) 우선, 없으면 first_body_x, 그래도 없으면 line_x.
+- marker 폭은 `estimate_text_width` + marker char_shape 로 산출(렌더 bbox 폴백).
+- exact_only 경로에 `empty_list_anchor` 예외 추가, TextRun 폴백 보존.
+
+### `tests/issue_1329_bullet_caret.rs` (신규)
+- bullet/number Enter 빈 줄 caret 이 marker 뒤에 오는지 + 일반 빈 문단은 기존 동작
+  유지 회귀 3건.
+
+## 3. 로컬 검증
+
+- `cargo fmt --all -- --check`: 클린
+- `cargo test --test issue_1329_bullet_caret`: **3 passed**
+- `cargo clippy --release` (cursor_rect): 무경고
+- `cargo test --lib cursor`: 52 passed (회귀 없음)
+- CI 전부 pass
+
+## 4. 평가
+
+- 기능 변경은 정확하고 잘 격리됨(폴백 경로 보존, 일반 문단 영향 없음). 테스트로 가드.
+- **이슈(통합 시 제외 필요)**: PR 에 `mydocs/plans|working|report` 7개 + **`mydocs/orders/20260608.md`** 포함. orders 는 메인테이너 영역으로 외부 기여가 편집하면 안 됨(선례 #1324/#1325: 기능 코드만 반영, 작업 문서 제외).
+
+## 5. 판단
+
+**기능 코드 Merge 권장** — 단, `mydocs/` 전체(특히 orders)는 통합에서 **제외**.
+권한 제약상 #1338 과 동일하게 기능 코드만 담은 squash 통합 PR 로 제출 권장.

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -208,7 +208,9 @@ impl DocumentCore {
         para_idx: usize,
         char_offset: usize,
     ) -> Result<String, HwpError> {
-        use crate::renderer::layout::compute_char_positions;
+        use crate::renderer::layout::{
+            compute_char_positions, estimate_text_width, resolved_to_text_style,
+        };
         use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
         // 문단이 포함된 페이지 찾기
@@ -557,6 +559,33 @@ impl DocumentCore {
             stops.get(&offset).copied()
         }
 
+        let (is_list_para, list_marker_char_shape_id) = self
+            .get_render_paragraph_ref(section_idx, para_idx)
+            .ok()
+            .map(|para| {
+                let is_list = self
+                    .styles
+                    .para_styles
+                    .get(para.para_shape_id as usize)
+                    .map(|ps| {
+                        matches!(
+                            ps.head_type,
+                            crate::model::style::HeadType::Outline
+                                | crate::model::style::HeadType::Number
+                                | crate::model::style::HeadType::Bullet
+                        )
+                    })
+                    .unwrap_or(false);
+                let marker_style_id = para.char_shapes.first().map(|cs| cs.char_shape_id);
+                (is_list, marker_style_id)
+            })
+            .unwrap_or((false, None));
+        let list_marker_char_shape_id = if is_list_para {
+            list_marker_char_shape_id
+        } else {
+            None
+        };
+
         // 렌더 트리에서 커서 위치를 찾는 재귀 함수
         // exact_only: true이면 정확한 매칭(zero-width 앵커)만 반환
         fn find_cursor_in_node(
@@ -566,6 +595,7 @@ impl DocumentCore {
             offset: usize,
             page_index: u32,
             exact_only: bool,
+            is_list_para: bool,
             footnote_marker_positions: &[(usize, usize)],
         ) -> Option<CursorHit> {
             if let RenderNodeType::FootnoteMarker(ref marker) = node.node_type {
@@ -602,8 +632,15 @@ impl DocumentCore {
                         // 커서가 이 TextRun 범위 안에 있는지 확인
                         // char_start <= offset <= char_start + char_count
                         if offset >= char_start && offset <= char_start + char_count {
+                            let empty_list_anchor = is_list_para
+                                && char_count == 0
+                                && offset == char_start
+                                && text_run.text.is_empty();
                             // exact_only 모드: zero-width 앵커(bbox.width==0)만 허용
-                            if exact_only
+                            if empty_list_anchor {
+                                // 빈 번호/글머리표 문단의 body anchor 는 marker 앞쪽 x 에
+                                // 놓일 수 있으므로 fallback 에서 marker 오른쪽 끝으로 보정한다.
+                            } else if exact_only
                                 && !(char_count == 0
                                     && offset == char_start
                                     && node.bbox.width == 0.0)
@@ -682,6 +719,7 @@ impl DocumentCore {
                     offset,
                     page_index,
                     exact_only,
+                    is_list_para,
                     footnote_marker_positions,
                 ) {
                     return Some(hit);
@@ -718,6 +756,7 @@ impl DocumentCore {
                 char_offset,
                 page_num,
                 true,
+                is_list_para,
                 &footnote_marker_positions,
             );
             let hit_result = exact_hit.or_else(|| {
@@ -728,6 +767,7 @@ impl DocumentCore {
                     char_offset,
                     page_num,
                     false,
+                    is_list_para,
                     &footnote_marker_positions,
                 )
             });
@@ -801,33 +841,149 @@ impl DocumentCore {
         let first_page = pages[0];
         let tree = self.build_page_tree(first_page)?;
 
-        // 해당 문단의 첫 TextRun 또는 TextLine 노드를 찾아 y/height 반환
-        fn find_para_line(node: &RenderNode, sec: usize, para: usize) -> Option<(f64, f64, f64)> {
-            // TextRun 매칭 (일반 문단, 번호/글머리표 TextRun 제외)
+        #[derive(Clone, Copy)]
+        struct ParaLineHit {
+            line_x: f64,
+            y: f64,
+            height: f64,
+            first_body_x: Option<f64>,
+            marker_end_x: Option<f64>,
+        }
+
+        impl ParaLineHit {
+            fn cursor_x(self, is_list_para: bool, char_offset: usize) -> f64 {
+                if is_list_para && char_offset == 0 {
+                    self.marker_end_x
+                        .or(self.first_body_x)
+                        .unwrap_or(self.line_x)
+                } else if is_list_para {
+                    self.first_body_x
+                        .or(self.marker_end_x)
+                        .unwrap_or(self.line_x)
+                } else {
+                    self.line_x
+                }
+            }
+        }
+
+        fn collect_para_line_text_runs(
+            node: &RenderNode,
+            sec: usize,
+            para: usize,
+            is_list_para: bool,
+            list_marker_char_shape_id: Option<u32>,
+            styles: &crate::renderer::style_resolver::ResolvedStyleSet,
+            hit: &mut ParaLineHit,
+        ) {
+            if let RenderNodeType::TextRun(ref text_run) = node.node_type {
+                if text_run.section_index == Some(sec)
+                    && text_run.para_index == Some(para)
+                    && text_run.cell_context.is_none()
+                {
+                    if text_run.char_start.is_some() {
+                        hit.first_body_x.get_or_insert(node.bbox.x);
+                    } else if is_list_para
+                        && text_run.field_marker
+                            == crate::renderer::render_tree::FieldMarkerType::None
+                    {
+                        let marker_width = list_marker_char_shape_id
+                            .map(|cs_id| {
+                                let marker_style = resolved_to_text_style(styles, cs_id, 0);
+                                estimate_text_width(&text_run.text, &marker_style)
+                            })
+                            .unwrap_or(node.bbox.width);
+                        hit.marker_end_x.get_or_insert(node.bbox.x + marker_width);
+                    }
+                }
+            }
+
+            for child in &node.children {
+                collect_para_line_text_runs(
+                    child,
+                    sec,
+                    para,
+                    is_list_para,
+                    list_marker_char_shape_id,
+                    styles,
+                    hit,
+                );
+            }
+        }
+
+        // 해당 문단의 첫 TextLine을 찾아 빈 list 문단이면 marker 뒤 본문 시작 x까지 수집한다.
+        fn find_para_line(
+            node: &RenderNode,
+            sec: usize,
+            para: usize,
+            is_list_para: bool,
+            list_marker_char_shape_id: Option<u32>,
+            styles: &crate::renderer::style_resolver::ResolvedStyleSet,
+        ) -> Option<ParaLineHit> {
+            if let RenderNodeType::TextLine(ref line) = node.node_type {
+                if line.section_index == Some(sec) && line.para_index == Some(para) {
+                    let mut hit = ParaLineHit {
+                        line_x: node.bbox.x,
+                        y: node.bbox.y,
+                        height: node.bbox.height,
+                        first_body_x: None,
+                        marker_end_x: None,
+                    };
+                    collect_para_line_text_runs(
+                        node,
+                        sec,
+                        para,
+                        is_list_para,
+                        list_marker_char_shape_id,
+                        styles,
+                        &mut hit,
+                    );
+                    return Some(hit);
+                }
+            }
+
+            // TextLine을 찾지 못하는 예외적인 렌더 트리에서는 기존 TextRun fallback을 보존한다.
             if let RenderNodeType::TextRun(ref text_run) = node.node_type {
                 if text_run.section_index == Some(sec)
                     && text_run.para_index == Some(para)
                     && text_run.cell_context.is_none()
                     && text_run.char_start.is_some()
                 {
-                    return Some((node.bbox.x, node.bbox.y, node.bbox.height));
+                    return Some(ParaLineHit {
+                        line_x: node.bbox.x,
+                        y: node.bbox.y,
+                        height: node.bbox.height,
+                        first_body_x: Some(node.bbox.x),
+                        marker_end_x: None,
+                    });
                 }
             }
-            // TextLine 매칭 (빈 문단 — TextRun이 없을 때 폴백)
-            if let RenderNodeType::TextLine(ref line) = node.node_type {
-                if line.section_index == Some(sec) && line.para_index == Some(para) {
-                    return Some((node.bbox.x, node.bbox.y, node.bbox.height));
-                }
-            }
+
             for child in &node.children {
-                if let Some(r) = find_para_line(child, sec, para) {
+                if let Some(r) = find_para_line(
+                    child,
+                    sec,
+                    para,
+                    is_list_para,
+                    list_marker_char_shape_id,
+                    styles,
+                ) {
                     return Some(r);
                 }
             }
             None
         }
 
-        if let Some((x, y, h)) = find_para_line(&tree.root, section_idx, para_idx) {
+        if let Some(line_hit) = find_para_line(
+            &tree.root,
+            section_idx,
+            para_idx,
+            is_list_para,
+            list_marker_char_shape_id,
+            &self.styles,
+        ) {
+            let x = line_hit.cursor_x(is_list_para, char_offset);
+            let y = line_hit.y;
+            let h = line_hit.height;
             // 인라인 도형 컨트롤이 있는 경우: char_offset에 따라 x 위치 조정
             let adjusted_x = if char_offset > 0 {
                 // 해당 문단의 인라인 Shape/Picture/Table 노드 bbox를 수집

--- a/tests/issue_1329_bullet_caret.rs
+++ b/tests/issue_1329_bullet_caret.rs
@@ -1,0 +1,91 @@
+//! Issue #1329: 글머리표/번호 문단에서 Enter 직후 빈 list 줄의 caret 이
+//! marker 앞쪽으로 되감기지 않아야 한다.
+//!
+//! 번호/글머리표 marker 는 문서 문자 좌표에 포함되지 않는 `char_start: None`
+//! TextRun 이다. 문단 끝 Enter 로 생성된 빈 list 문단에서도 offset 0 caret 은
+//! marker 시작점이 아니라 marker 뒤 본문 시작점에 있어야 한다.
+
+use std::path::Path;
+
+use rhwp::wasm_api::HwpDocument;
+use serde_json::Value;
+
+fn load_doc(rel: &str) -> HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {rel}: {e:?}"))
+}
+
+fn cursor_x(doc: &HwpDocument, para: usize, offset: usize) -> f64 {
+    let json = doc
+        .get_cursor_rect_native(0, para, offset)
+        .unwrap_or_else(|e| panic!("cursor rect para={para} offset={offset}: {e:?}"));
+    let rect: Value =
+        serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse cursor rect `{json}`: {e}"));
+    rect["x"].as_f64().expect("cursor x")
+}
+
+fn paragraph_len(doc: &HwpDocument, para: usize) -> usize {
+    doc.get_paragraph_length_native(0, para)
+        .unwrap_or_else(|e| panic!("paragraph length para={para}: {e:?}"))
+}
+
+fn assert_caret_x_matches_body_start(actual: f64, expected: f64, context: &str) {
+    assert!(
+        (actual - expected).abs() <= 1.0,
+        "{context}: empty list caret x must stay at body start, expected {expected:.1}, got {actual:.1}"
+    );
+}
+
+#[test]
+fn issue_1329_bullet_enter_empty_line_caret_stays_after_marker() {
+    let mut doc = load_doc("rhwp-studio/public/samples/number-bullet.hwp");
+    let split_para = 1;
+    let split_offset = paragraph_len(&doc, split_para);
+
+    doc.split_paragraph_native(0, split_para, split_offset)
+        .expect("split bullet paragraph");
+
+    let new_para = split_para + 1;
+    let empty_caret_x = cursor_x(&doc, new_para, 0);
+    doc.insert_text_native(0, new_para, 0, "가")
+        .expect("insert text into empty bullet paragraph");
+    let typed_body_start_x = cursor_x(&doc, new_para, 0);
+    assert_caret_x_matches_body_start(empty_caret_x, typed_body_start_x, "bullet paragraph split");
+}
+
+#[test]
+fn issue_1329_number_enter_empty_line_caret_stays_after_marker() {
+    let mut doc = load_doc("rhwp-studio/public/samples/para-head-num-2.hwp");
+    let split_para = 1;
+    let split_offset = paragraph_len(&doc, split_para);
+
+    doc.split_paragraph_native(0, split_para, split_offset)
+        .expect("split numbered paragraph");
+
+    let new_para = split_para + 1;
+    let empty_caret_x = cursor_x(&doc, new_para, 0);
+    doc.insert_text_native(0, new_para, 0, "가")
+        .expect("insert text into empty numbered paragraph");
+    let typed_body_start_x = cursor_x(&doc, new_para, 0);
+    assert_caret_x_matches_body_start(empty_caret_x, typed_body_start_x, "number paragraph split");
+}
+
+#[test]
+fn issue_1329_plain_empty_paragraph_caret_keeps_original_start() {
+    let mut doc = load_doc("saved/blank2010.hwp");
+    doc.convert_to_editable_native()
+        .expect("convert blank document to editable");
+    doc.insert_text_native(0, 0, 0, "테스트")
+        .expect("insert text");
+
+    let expected_x = cursor_x(&doc, 0, 0);
+    doc.split_paragraph_native(0, 0, 3)
+        .expect("split plain paragraph");
+    let actual_x = cursor_x(&doc, 1, 0);
+
+    assert!(
+        (actual_x - expected_x).abs() <= 1.0,
+        "plain empty paragraph caret should keep the normal paragraph start, expected {expected_x:.1}, got {actual_x:.1}"
+    );
+}


### PR DESCRIPTION
## 개요

**PR #1331 (@postmelee) 의 검토·검증을 마친 기능-only squash 통합본**입니다. 번호/글머리표 문단에서 Enter 로 만든 빈 줄의 caret 이 marker 앞쪽에 표시되던 결함(#1329)을 정정합니다.

> 메인테이너 세션이 upstream 직접 merge 권한이 없어 squash 통합 PR 로 제출합니다. **원작성자 attribution 은 커밋 author(@postmelee)로 보존**합니다. 원 PR #1331 은 `mydocs/`(plans/working/report + `orders/20260608.md`)를 포함하므로, 기능 코드 2파일만 추려 통합했습니다. 본 PR merge 시 #1331 close 처리 바랍니다.

## 변경 (기능 2 files)

- `src/document_core/queries/cursor_rect.rs`: list 문단 판정 + `ParaLineHit`(marker_end_x/first_body_x) 수집으로 빈 list 문단 caret 을 marker 오른쪽 끝으로 보정(폴백/일반 문단 동작 보존).
- `tests/issue_1329_bullet_caret.rs`: 회귀 3건.

## 검토 / 검증

- 검토 기록: `mydocs/pr/pr_1331_review.md` (Merge 권장)
- `cargo fmt --all -- --check` 클린, `cargo clippy` 무경고
- `cargo test --test issue_1329_bullet_caret` 3 passed, `cargo test --lib cursor` 52 passed
- 원 PR #1331 CI 전부 pass

Credit: @postmelee — PR #1331
closes #1329