### PR TITLE
fix(studio): 빈 글머리표 줄 marker/caret 크기 보정 (squash 통합, #1332/#1330)

### DIFF
--- a/mydocs/pr/pr_1332_review.md
+++ b/mydocs/pr/pr_1332_review.md
@@ -1,0 +1,45 @@
+# PR #1332 검토 — 빈 글머리표 줄 marker/caret 크기 보정
+
+- PR: edwardkim/rhwp#1332 (author: postmelee)
+- 연결 이슈: #1330 (빈 글머리표 줄에 입력 시 marker와 caret 크기가 커짐)
+- base ← head: `devel` ← `issue-1330-bullet-marker-caret-size`
+- 규모: +1168 / −21, 9 files (단, **기능 코드는 1 file**)
+- mergeable: MERGEABLE / CLEAN, CI 전부 pass (Canvas visual diff 포함)
+
+## 1. 문제
+
+빈 글머리표 문단의 caret/marker TextRun 이 `resolved_to_text_style(styles, 0, 0)`
+(기본 char shape id 0) 으로 생성되어 문단 실제 글꼴 크기와 달라 marker/caret 이 커짐.
+
+## 2. 기능 변경 (검토 surface)
+
+### `src/renderer/layout/paragraph_layout.rs` (+66/−21)
+- 헬퍼 도입:
+  - `paragraph_active_text_style(styles, para, char_offset)` — 문단의 `char_shape_id_at`
+    (없으면 first char_shape) 로 실제 스타일 + id 반환.
+  - `numbering_marker_text_style(styles, para, first_run)` — numbering 마커 스타일 통합.
+- 빈 문단/분할 빈 줄의 caret TextRun 을 default(0) 대신 **문단 실제 char_shape** 로 생성
+  (`char_shape_id: None` → 실제 id). numbering 마커 폭 계산도 동일 헬퍼로 일원화.
+
+### `tests/issue_1330_bullet_marker_caret_size.rs` (신규)
+- 빈 글머리표 줄이 입력 전/후 active char shape 를 쓰는지 회귀 1건.
+
+## 3. 로컬 검증
+
+- `cargo fmt --all -- --check`: 클린
+- `cargo test --test issue_1330_bullet_marker_caret_size`: **1 passed**
+- `cargo clippy --release` (paragraph_layout): 무경고
+- `cargo test --release` 전체: **2108 passed, 0 failed** (layout 핵심부 변경 회귀 없음)
+- CI 전부 pass (Canvas visual diff 통과)
+
+## 4. 평가
+
+- `paragraph_layout.rs` 는 모든 문단 렌더 공통 경로이나, 변경은 "빈/분할 빈 줄 TextRun
+  스타일을 default→문단 실제" 로 의미가 명확하고 전체 테스트 + Canvas diff 로 회귀 없음 확인.
+- #1331 과 파일 비중복(이쪽은 renderer, #1331 은 document_core)·독립.
+- **이슈(통합 시 제외 필요)**: `mydocs/plans|working|report` 6개 + **`mydocs/orders/20260608.md`** 포함 — #1331 과 동일하게 통합에서 제외.
+
+## 5. 판단
+
+**기능 코드 Merge 권장** — `mydocs/` 제외. #1338 과 동일 방식의 squash 통합 PR 권장.
+#1331 과 독립이므로 순서 무관하게 통합 가능.

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1,6 +1,8 @@
 //! 문단 레이아웃 (인라인 표, 문단 전체/부분, composed/raw) + 번호 매기기
 
-use super::super::composer::{compose_paragraph, effective_text_for_metrics, ComposedParagraph};
+use super::super::composer::{
+    compose_paragraph, effective_text_for_metrics, ComposedParagraph, ComposedTextRun,
+};
 use super::super::height_measurer::MeasuredTable;
 use super::super::page_layout::LayoutRect;
 use super::super::render_tree::*;
@@ -43,6 +45,34 @@ pub(crate) fn ensure_min_baseline(raw_baseline: f64, max_font_size: f64) -> f64 
     }
     let min_baseline = max_font_size * 0.8;
     raw_baseline.max(min_baseline)
+}
+
+fn paragraph_active_text_style(
+    styles: &ResolvedStyleSet,
+    para: Option<&Paragraph>,
+    char_offset: usize,
+) -> (TextStyle, Option<u32>) {
+    let char_shape_id = para
+        .and_then(|p| p.char_shape_id_at(char_offset))
+        .or_else(|| para.and_then(|p| p.char_shapes.first().map(|cs| cs.char_shape_id)));
+
+    if let Some(id) = char_shape_id {
+        (resolved_to_text_style(styles, id, 0), Some(id))
+    } else {
+        (resolved_to_text_style(styles, 0, 0), None)
+    }
+}
+
+fn numbering_marker_text_style(
+    styles: &ResolvedStyleSet,
+    para: Option<&Paragraph>,
+    first_run: Option<&ComposedTextRun>,
+) -> TextStyle {
+    if let Some(run) = first_run {
+        resolved_to_text_style(styles, run.char_style_id, run.lang_index)
+    } else {
+        paragraph_active_text_style(styles, para, 0).0
+    }
 }
 
 fn para_float_horz_intersects_column(
@@ -1437,12 +1467,11 @@ impl LayoutEngine {
         // 개요 번호/글머리표 마커 폭 사전 계산 (첫 줄 가용폭 차감용)
         let numbering_width = if start_line == 0 {
             if let Some(ref num_text) = composed.numbering_text {
-                let num_style = composed
-                    .lines
-                    .first()
-                    .and_then(|l| l.runs.first())
-                    .map(|r| resolved_to_text_style(styles, r.char_style_id, r.lang_index))
-                    .unwrap_or_else(|| resolved_to_text_style(styles, 0, 0));
+                let num_style = numbering_marker_text_style(
+                    styles,
+                    para,
+                    composed.lines.first().and_then(|l| l.runs.first()),
+                );
                 estimate_text_width(num_text, &num_style)
             } else {
                 0.0
@@ -2575,15 +2604,8 @@ impl LayoutEngine {
             // 개요 번호/글머리표: 첫 줄에서 별도 TextRunNode로 렌더링 (char_start: None)
             if line_idx == start_line && start_line == 0 {
                 if let Some(ref num_text) = composed.numbering_text {
-                    let num_style = if let Some(first_run) = comp_line.runs.first() {
-                        resolved_to_text_style(
-                            styles,
-                            first_run.char_style_id,
-                            first_run.lang_index,
-                        )
-                    } else {
-                        resolved_to_text_style(styles, 0, 0)
-                    };
+                    let num_style =
+                        numbering_marker_text_style(styles, para, comp_line.runs.first());
                     let num_width = estimate_text_width(num_text, &num_style);
                     let num_id = tree.next_id();
                     let num_node = RenderNode::new(
@@ -3989,13 +4011,14 @@ impl LayoutEngine {
                 }
 
                 let run_id = tree.next_id();
-                let text_style = resolved_to_text_style(styles, 0, 0);
+                let (text_style, char_shape_id) =
+                    paragraph_active_text_style(styles, para, char_offset);
                 let run_node = RenderNode::new(
                     run_id,
                     RenderNodeType::TextRun(TextRunNode {
                         text: String::new(),
                         style: text_style,
-                        char_shape_id: None,
+                        char_shape_id,
                         para_shape_id: Some(composed.para_style_id),
                         section_index: Some(section_index),
                         para_index: Some(para_index),
@@ -4207,7 +4230,7 @@ impl LayoutEngine {
                     let marker_x = row_inline_x[marker_row];
                     let marker_y = y + marker_row as f64 * (line_height + line_spacing_px);
                     let marker_id = tree.next_id();
-                    let marker_style = resolved_to_text_style(styles, 0, 0);
+                    let marker_style = paragraph_active_text_style(styles, para, char_offset).0;
                     let marker_node = RenderNode::new(
                         marker_id,
                         RenderNodeType::TextRun(TextRunNode {
@@ -4800,13 +4823,14 @@ impl LayoutEngine {
 
             // 빈 문단에도 TextRun 노드를 생성하여 캐럿 위치 제공
             let run_id = tree.next_id();
-            let text_style = resolved_to_text_style(styles, 0, 0);
+            let (text_style, char_shape_id) =
+                paragraph_active_text_style(styles, para, char_offset);
             let run_node = RenderNode::new(
                 run_id,
                 RenderNodeType::TextRun(TextRunNode {
                     text: String::new(),
                     style: text_style,
-                    char_shape_id: None,
+                    char_shape_id,
                     para_shape_id: Some(composed.para_style_id),
                     section_index: Some(section_index),
                     para_index: Some(para_index),

--- a/tests/issue_1330_bullet_marker_caret_size.rs
+++ b/tests/issue_1330_bullet_marker_caret_size.rs
@@ -1,0 +1,170 @@
+//! Issue #1330: Enter로 생성한 빈 글머리표 줄에 입력하면 marker/caret 크기가 커짐.
+//!
+//! `Paragraph::split_at()`은 새 빈 문단의 활성 CharShape를 보존하지만, 렌더러의
+//! 빈 runs fallback 이 기본 CharShape(0)를 사용하면 빈 상태 marker/caret 만 작게
+//! 보이다가 입력 후 실제 run 스타일로 커진다.
+
+use serde_json::Value;
+
+fn parse_json(json: String, label: &str) -> Value {
+    serde_json::from_str(&json).unwrap_or_else(|e| panic!("parse {label}: {e}"))
+}
+
+fn text_layout(doc: &rhwp::wasm_api::HwpDocument) -> Value {
+    parse_json(
+        doc.get_page_text_layout_native(0)
+            .unwrap_or_else(|e| panic!("text layout: {e:?}")),
+        "text layout",
+    )
+}
+
+fn cursor_rect(doc: &rhwp::wasm_api::HwpDocument, para_idx: usize, char_offset: usize) -> Value {
+    parse_json(
+        doc.get_cursor_rect_native(0, para_idx, char_offset)
+            .unwrap_or_else(|e| panic!("cursor para={para_idx} offset={char_offset}: {e:?}")),
+        "cursor rect",
+    )
+}
+
+fn run_font_size(run: &Value, label: &str) -> f64 {
+    run["fontSize"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("{label} fontSize missing: {run}"))
+}
+
+fn cursor_height(rect: &Value, label: &str) -> f64 {
+    rect["height"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("{label} height missing: {rect}"))
+}
+
+fn para_runs(layout: &Value, para_idx: u64) -> Vec<&Value> {
+    layout["runs"]
+        .as_array()
+        .expect("runs")
+        .iter()
+        .filter(|run| run["paraIdx"].as_u64() == Some(para_idx))
+        .collect()
+}
+
+fn empty_anchor_run<'a>(runs: &'a [&'a Value], label: &str) -> &'a Value {
+    runs.iter()
+        .copied()
+        .find(|run| run["charStart"].as_u64() == Some(0) && run["text"].as_str() == Some(""))
+        .unwrap_or_else(|| panic!("{label} empty anchor run missing: {runs:?}"))
+}
+
+fn body_run<'a>(runs: &'a [&'a Value], text: &str, label: &str) -> &'a Value {
+    runs.iter()
+        .copied()
+        .find(|run| run["charStart"].as_u64() == Some(0) && run["text"].as_str() == Some(text))
+        .unwrap_or_else(|| panic!("{label} body run missing: {runs:?}"))
+}
+
+fn marker_font_size_near_y(layout: &Value, anchor_y: f64, label: &str) -> f64 {
+    let run = layout["runs"]
+        .as_array()
+        .expect("runs")
+        .iter()
+        .filter(|run| {
+            run.get("charStart").is_none() && run["text"].as_str().is_some_and(|s| !s.is_empty())
+        })
+        .min_by(|a, b| {
+            let ay = (a["y"].as_f64().unwrap_or(f64::INFINITY) - anchor_y).abs();
+            let by = (b["y"].as_f64().unwrap_or(f64::INFINITY) - anchor_y).abs();
+            ay.partial_cmp(&by).unwrap()
+        })
+        .unwrap_or_else(|| panic!("{label} marker run missing: {}", layout["runs"]));
+
+    let marker_y = run["y"]
+        .as_f64()
+        .unwrap_or_else(|| panic!("{label} marker y missing: {run}"));
+    assert!(
+        (marker_y - anchor_y).abs() <= 1.0,
+        "{label} marker is not on the target line: marker_y={marker_y:.1}, anchor_y={anchor_y:.1}, run={run}"
+    );
+    run_font_size(run, label)
+}
+
+fn assert_close(actual: f64, expected: f64, label: &str) {
+    assert!(
+        (actual - expected).abs() <= 0.1,
+        "{label}: actual={actual:.3}, expected={expected:.3}"
+    );
+}
+
+#[test]
+fn split_empty_bullet_line_uses_active_char_shape_before_and_after_typing() {
+    let mut doc = rhwp::wasm_api::HwpDocument::create_empty();
+    doc.create_blank_document_native()
+        .unwrap_or_else(|e| panic!("create blank document: {e:?}"));
+    let bullet_id = doc.ensure_default_bullet("□");
+
+    doc.insert_text_native(0, 0, 0, "개념")
+        .unwrap_or_else(|e| panic!("insert seed text: {e:?}"));
+    doc.apply_char_format_native(0, 0, 0, 2, r#"{"fontSize":1800}"#)
+        .unwrap_or_else(|e| panic!("apply char format: {e:?}"));
+    doc.apply_para_format_native(
+        0,
+        0,
+        &format!(r#"{{"headType":"Bullet","paraLevel":0,"numberingId":{bullet_id}}}"#),
+    )
+    .unwrap_or_else(|e| panic!("apply bullet format: {e:?}"));
+
+    let split_result = parse_json(
+        doc.split_paragraph_native(0, 0, 2)
+            .unwrap_or_else(|e| panic!("split paragraph: {e:?}")),
+        "split result",
+    );
+    assert_eq!(split_result["paraIdx"].as_u64(), Some(1));
+
+    let empty_layout = text_layout(&doc);
+    let empty_runs = para_runs(&empty_layout, 1);
+    let empty_anchor = empty_anchor_run(&empty_runs, "empty");
+    let empty_anchor_size = run_font_size(empty_anchor, "empty anchor");
+    let empty_anchor_y = empty_anchor["y"].as_f64().expect("empty anchor y");
+    let empty_marker_size = marker_font_size_near_y(&empty_layout, empty_anchor_y, "empty marker");
+    let empty_caret_height = cursor_height(&cursor_rect(&doc, 1, 0), "empty caret");
+
+    assert!(
+        empty_marker_size > 20.0,
+        "빈 글머리표 marker가 기본 크기로 떨어지면 안 됨: size={empty_marker_size}"
+    );
+    assert_close(
+        empty_anchor_size,
+        empty_marker_size,
+        "empty anchor font size",
+    );
+    assert_close(
+        empty_caret_height,
+        empty_marker_size,
+        "empty caret height follows active char shape",
+    );
+
+    doc.insert_text_native(0, 1, 0, "가")
+        .unwrap_or_else(|e| panic!("insert typed text: {e:?}"));
+
+    let typed_layout = text_layout(&doc);
+    let typed_runs = para_runs(&typed_layout, 1);
+    let typed_body = body_run(&typed_runs, "가", "typed");
+    let typed_body_size = run_font_size(typed_body, "typed body");
+    let typed_body_y = typed_body["y"].as_f64().expect("typed body y");
+    let typed_marker_size = marker_font_size_near_y(&typed_layout, typed_body_y, "typed marker");
+    let typed_caret_height = cursor_height(&cursor_rect(&doc, 1, 0), "typed caret");
+
+    assert_close(
+        typed_marker_size,
+        empty_marker_size,
+        "marker size must not jump after typing",
+    );
+    assert_close(
+        typed_body_size,
+        empty_anchor_size,
+        "typed body should inherit split active char shape",
+    );
+    assert_close(
+        typed_caret_height,
+        empty_caret_height,
+        "caret height must not jump after typing",
+    );
+}


### PR DESCRIPTION
## 개요

**PR #1332 (@postmelee) 의 검토·검증을 마친 기능-only squash 통합본**입니다. 빈 글머리표 줄에 입력 시 marker/caret 크기가 커지던 결함(#1330)을 정정합니다.

> 메인테이너 세션이 upstream 직접 merge 권한이 없어 squash 통합 PR 로 제출합니다. **원작성자 attribution 은 커밋 author(@postmelee)로 보존**. 원 PR #1332 는 `mydocs/`(+`orders/20260608.md`)를 포함하므로 기능 코드 2파일만 추려 통합했습니다. 본 PR merge 시 #1332 close 처리 바랍니다.

## 변경 (기능 2 files)

- `src/renderer/layout/paragraph_layout.rs`: `paragraph_active_text_style`/`numbering_marker_text_style` 헬퍼로 빈/분할 빈 줄 TextRun·numbering 마커 스타일을 default(0) 대신 문단 실제 char_shape 로 산출(`char_shape_id` None→실제 id).
- `tests/issue_1330_bullet_marker_caret_size.rs`: 회귀 1건.

## 검토 / 검증

- 검토 기록: `mydocs/pr/pr_1332_review.md` (Merge 권장)
- `cargo fmt --all -- --check` 클린, `cargo clippy` 무경고
- `cargo test --test issue_1330_bullet_marker_caret_size` 1 passed, `cargo test --release` 전체 2108 passed
- 원 PR #1332 CI 전부 pass (Canvas visual diff 포함)

#1331(#1339) 과 파일 비중복·독립.

Credit: @postmelee — PR #1332
closes #1330