### PR TITLE
Task #1342: 수식 집합연산자(∩/∪) 1.5배 확대 렌더 수정

### DIFF
--- a/mydocs/plans/archives/task_m100_1342.md
+++ b/mydocs/plans/archives/task_m100_1342.md
@@ -1,0 +1,51 @@
+# 수행계획서 — 수식 집합연산자(∩/∪) 1.5배 확대 렌더 수정 (M100 #1342)
+
+## 1. 배경
+
+16페이지 문24 `P(A∩B)` 등에서 교집합(∩)/합집합(∪) 기호가 본문 글자보다 1.5배 크게 렌더되고 뒤쪽에 불필요한 가로 간격이 생긴다. 한글2022 PDF(정답지)에서는 ∩/∪가 본문과 동일 크기로 좁게 붙는다.
+
+- 샘플: `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx` 16페이지
+- 정답지: `pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf` 16페이지
+
+## 2. 근본 원인 (조사 확정)
+
+| 위치 | 내용 |
+|------|------|
+| `src/renderer/equation/symbols.rs:286-293` | `CUP`,`UNION`,`SMALLUNION`,`INTER`,`CAP`,`SMALLINTER` 가 **BIG_OPERATORS** 에 등록 |
+| `src/renderer/equation/parser.rs:337,342` | 토큰 대문자 변환(`cap`→`CAP`) 후 `is_big_operator()` → `parse_big_op()` 진입 |
+| `src/renderer/equation/layout.rs:705` | `op_fs = fs * BIG_OP_SCALE(=1.5)` → ∩/∪ 1.5배 확대 + trailing 박스폭 부가 |
+
+SVG 글리프 추출 검증: ∩ `font-size=18` (주변 글자 12) → 정확히 1.5배.
+
+소문자 `cup`/`cap` 은 이미 `OPERATORS`(symbols.rs:250-251)에 존재하나, 파서가 대문자 변환 후 BIG_OPERATORS 를 먼저 조회하여 무력화됨.
+
+## 3. 수정 방향
+
+진짜 큰 형태(`BIG*` 접두 — `BIGCUP`,`BIGCAP`,`BIGSQCUP`,`BIGSQCAP`,`BIGUPLUS`,`BIGWEDGE`,`BIGVEE`,`BIGOPLUS` 등)만 BIG_OPERATORS 에 남기고, 소형 이항 집합/논리 연산자는 OPERATORS 로 이동하여 **본문 크기**로 렌더.
+
+대상 (BIG_OPERATORS → OPERATORS 이동, 본 문서가 사용하는 ∩/∪ 중심):
+- `UNION`, `SMALLUNION`, `CUP` → ∪
+- `INTER`, `SMALLINTER`, `CAP` → ∩
+
+추가 검토 대상(같은 오분류 가능성, 회귀 안전 범위 내에서만):
+- `SQCUP`/`SQCAP`/`UPLUS` 등 비-BIG 소형 연산자
+
+## 4. 범위 및 제약
+
+- HWP3 전용 분기 추가 금지(해당 없음 — 공통 수식 렌더러).
+- ∑/∏/∫ 등 진짜 큰 연산자 및 행렬/첨자/극한 회귀 없어야 함.
+- 부수 발견된 U+E04D 조건부 막대 두부 문제는 **별도 이슈 #1343** 으로 분리, 본 타스크 범위 외.
+- 포맷 변경과 기능 변경 혼합 금지. 수정 파일만 정리.
+
+## 5. 검증 방법
+
+1. `export-svg -p 15` → ∩/∪ font-size 가 본문과 동일(확대 없음)한지 글리프 좌표로 확인
+2. PDF 16페이지 대비 시각 정합(∩/∪ 크기·간격) 비교
+3. `cargo test` (equation layout/symbol 테스트 포함) 통과
+4. 회귀: ∑/∏/∫ 큰연산자, 행렬, 첨자 정상 — 기존 테스트 + 시각 확인
+
+## 6. 산출물
+
+- 구현계획서: `mydocs/plans/task_m100_1342_impl.md`
+- 단계별 보고서: `mydocs/working/task_m100_1342_stage{N}.md`
+- 최종 보고서: `mydocs/report/task_m100_1342_report.md`

--- a/mydocs/plans/archives/task_m100_1342_impl.md
+++ b/mydocs/plans/archives/task_m100_1342_impl.md
@@ -1,0 +1,57 @@
+# 구현계획서 — 수식 집합연산자(∩/∪) 1.5배 확대 렌더 수정 (M100 #1342)
+
+## 설계 결론
+
+파서 경로 분석:
+- `parser.rs:337` `is_big_operator(cu)` 가 true 면 `parse_big_op()` → `layout_big_op()` → `op_fs = fs*1.5`.
+- false 로 떨어지면 `parser.rs:544` `lookup_symbol(cmd)` → `EqNode::MathSymbol` → `layout_math_symbol()` → 본문 크기(fs), 패딩 없음. **이것이 원하는 결과.**
+
+`lookup_symbol` 은 case-sensitive HashMap 조회(1차 원본 case, 2차 대문자)를 한다. 따라서 BIG_OPERATORS 에서 제거만 하면 대문자 키(`CUP`,`INTER` 등)는 어디서도 매핑되지 않아 `Text("CUP")` 로 깨진다.
+
+**∴ 단순 제거가 아니라 BIG_OPERATORS → OPERATORS 로 키를 이동**해야 `is_big_operator()=false` 이면서 `lookup_symbol()` 정상 매핑이 동시에 성립한다.
+
+## 대상 키 (BIG_OPERATORS → OPERATORS 이동)
+
+| 키 | 기호 |
+|----|------|
+| `UNION` | ∪ |
+| `SMALLUNION` | ∪ |
+| `CUP` | ∪ |
+| `INTER` | ∩ |
+| `SMALLINTER` | ∩ |
+| `CAP` | ∩ |
+
+- `BIGCUP`/`BIGCAP` 및 lowercase `bigcup`/`bigcap` 은 **BIG_OPERATORS 유지** (진짜 큰 형태).
+- lowercase `cup`/`cap` 은 이미 OPERATORS(symbols.rs:250-251)에 존재 → 변경 없음. (이동 후 대문자 변환 경로가 BIG 를 먼저 잡지 않으므로 자연 정상화)
+- 본 PDF/샘플이 사용하지 않는 `SQCUP`/`SQCAP`/`UPLUS`/`OPLUS`/`OTIMES` 등은 동일 오분류 가능성이 있으나 **정답지 근거 부재로 본 타스크 범위 외** (보고서에 후속 검토 기록).
+
+## 단계별 구현
+
+### Stage 1 — 소스 수정 + 단위 테스트
+1. `src/renderer/equation/symbols.rs`
+   - BIG_OPERATORS 에서 위 6개 키 제거
+   - OPERATORS 의 「집합/논리」섹션에 위 6개 키 추가 (∪/∩)
+2. 단위 테스트 추가 (`symbols.rs` tests 모듈)
+   - `assert!(!is_big_operator("CAP"))`, `!is_big_operator("CUP")`, `!is_big_operator("SMALLINTER")`
+   - `assert_eq!(lookup_symbol("CUP"), Some("∪"))`, `lookup_symbol("CAP")==Some("∩")`, `lookup_symbol("SMALLINTER")==Some("∩")`
+   - 회귀: `assert!(is_big_operator("BIGCUP"))`, `is_big_operator("SUM")`
+3. `layout.rs` tests 에 ∩ 크기 회귀 테스트 추가 (선택)
+   - `A{cap}B` 레이아웃에서 ∩ MathSymbol box 높이가 fs(확대 없음) 인지 확인
+
+### Stage 2 — 빌드/렌더 검증
+1. `cargo build --release`
+2. `export-svg -p 15` → ∩/∪ `font-size` 가 본문(12)과 동일한지 글리프 좌표 추출 확인
+3. PDF 16페이지 대비 ∩/∪ 크기·간격 시각 정합 (crop 비교)
+4. `cargo test` 전체 통과 (회귀: ∑/∏/∫/행렬/첨자)
+5. 단계 완료보고서 `mydocs/working/task_m100_1342_stage2.md`
+
+### Stage 3 — 최종 보고서
+1. `mydocs/report/task_m100_1342_report.md` 작성 (원인/수정/검증/회귀/후속(#1343, 비-BIG 기타 연산자))
+2. 계획서 `plans/archives/` 이동
+3. `git status` 확인 후 커밋
+
+## 검증 기준 (완료 정의)
+
+- ∩/∪ `font-size` == 본문 글자 크기 (확대 0)
+- PDF 16페이지와 ∩/∪ 크기·간격 시각 정합
+- `cargo test` 전부 통과, ∑/∏/∫ 큰연산자 회귀 없음

--- a/mydocs/report/task_m100_1342_report.md
+++ b/mydocs/report/task_m100_1342_report.md
@@ -1,0 +1,52 @@
+# 최종 결과보고서 — 수식 집합연산자(∩/∪) 1.5배 확대 렌더 수정 (M100 #1342)
+
+## 1. 개요
+
+| 항목 | 내용 |
+|------|------|
+| 이슈 | #1342 |
+| 브랜치 | `local/task1342` |
+| 증상 | 16페이지 문24 `P(A∩B)` 등에서 ∩/∪이 본문 1.5배로 확대되고 뒤 공백 발생 |
+| 정답지 | `pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf` 16페이지 (한글2022) |
+| 샘플 | `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx` |
+
+## 2. 근본 원인
+
+수식 파서는 토큰을 대문자 변환(`cap`→`CAP`) 후 `is_big_operator()` 로 큰 연산자 여부를 판정한다. 소형 이항 집합연산자 키(`UNION`,`SMALLUNION`,`CUP`,`INTER`,`SMALLINTER`,`CAP`)가 **`BIG_OPERATORS` 테이블에 잘못 등록**되어 있어, ∑·∏·∫ 처럼 `parse_big_op()` → `layout_big_op()` 의 `op_fs = fs * BIG_OP_SCALE(1.5)` 경로를 타고 1.5배 확대 + 큰연산자 trailing 박스폭이 부가되었다.
+
+SVG 글리프 좌표 추출로 확정: ∩ `font-size=18` (주변 본문 12) = 정확히 1.5배.
+
+소문자 `cup`/`cap` 은 이미 OPERATORS 에 있었으나, 파서의 대문자 변환 경로가 BIG_OPERATORS 를 먼저 조회하여 무력화되었다.
+
+## 3. 수정 내용
+
+`src/renderer/equation/symbols.rs` (단일 파일):
+
+1. BIG_OPERATORS 에서 6개 키 제거: `UNION`,`SMALLUNION`,`CUP`,`INTER`,`SMALLINTER`,`CAP`
+2. OPERATORS 「집합/논리」섹션에 동일 6개 추가 (∪/∩)
+3. `BIGCUP`/`BIGCAP` 은 BIG_OPERATORS 유지 (진짜 큰 형태)
+4. 회귀 테스트 `test_set_operators_not_big` 추가
+
+**설계 근거**: `lookup_symbol` 은 case-sensitive 조회이므로 BIG 에서 단순 제거 시 대문자 키가 어디서도 매핑되지 않아 `Text("CUP")` 로 깨진다. 따라서 **BIG → OPERATORS 키 이동**으로 `is_big_operator()=false` 와 정상 기호 매핑을 동시 달성. OPERATORS 매핑 → `EqNode::MathSymbol` → `layout_math_symbol()` → 본문 크기·무패딩 렌더.
+
+## 4. 검증
+
+| 검증 | 결과 |
+|------|------|
+| ∩/∪ font-size | 18 → 12 (본문 동일), 6개 전부 정규화 |
+| 글리프 정렬 | y 21.24→17.64, A∩B 밀착 |
+| PDF 시각 정합 | 16페이지 정답지와 일치 |
+| `cargo test --release` | 1614+49 passed, 0 failed |
+| `cargo clippy --lib` | symbols.rs 경고 없음 |
+| 회귀 (∑/∏/∫/행렬/첨자) | 무결 |
+
+## 5. 후속 과제
+
+| 항목 | 처리 |
+|------|------|
+| `P(A\|B)` 조건부 막대 U+E04D(PUA) 두부(▦) 렌더 | 별도 이슈 **#1343** 등록 |
+| `SQCUP`/`SQCAP`/`UPLUS`/`OPLUS`/`OTIMES` 등 비-BIG 소형 연산자 동일 오분류 가능성 | 정답지 근거 확보 시 후속 검토 (본 타스크 범위 외) |
+
+## 6. 결론
+
+집합연산자 ∩/∪ 의 1.5배 확대 버그를 BIG_OPERATORS 오분류 교정으로 해소. PDF 정답지와 시각 정합하며 전체 회귀 무결. 이슈 #1342 종료 가능.

--- a/mydocs/working/task_m100_1342_stage2.md
+++ b/mydocs/working/task_m100_1342_stage2.md
@@ -1,0 +1,50 @@
+# Stage 2 완료보고서 — 빌드/렌더 검증 (M100 #1342)
+
+## 변경 요약 (Stage 1 산출물)
+
+`src/renderer/equation/symbols.rs` 단일 파일:
+- BIG_OPERATORS 에서 소형 집합연산자 6개 제거: `UNION`, `SMALLUNION`, `CUP`, `INTER`, `SMALLINTER`, `CAP`
+- OPERATORS 「집합/논리」섹션에 동일 6개 추가 (∪/∩ 매핑)
+- `BIGCUP`/`BIGCAP` 은 BIG_OPERATORS 유지 (진짜 큰 형태)
+- 회귀 테스트 `test_set_operators_not_big` 추가
+
+## 검증 결과
+
+### 1. 글리프 크기 정합 (핵심)
+
+16페이지 `P(A∩B)` 의 ∩ 글리프 좌표 추출:
+
+| | 수정 전 | 수정 후 |
+|---|---|---|
+| ∩ font-size | **18.00** (본문의 1.5배) | **12.00** (본문과 동일) |
+| ∩ y좌표 | 21.24 (아래로 처짐) | 17.64 (본문 정렬) |
+| A→∩→B 배치 | A∩ B (뒤 공백) | A∩B (밀착) |
+
+페이지 전체 ∩/∪ 6개 모두 `font-size=12.00` 으로 정규화 확인 (수정 전 18.00).
+
+### 2. PDF 시각 정합
+
+`pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf` 16페이지 대비:
+- `P(A∩B)`, `P(A∪B)`, `P(A∩B)/P(B)` 모두 본문 크기·밀착 간격으로 PDF 정답지와 일치
+- 잔여 `P(A▦B)` 두부는 U+E04D 조건부 막대(별건 #1343)
+
+### 3. 회귀 테스트
+
+```
+cargo test --release  → 1614 passed; 0 failed (lib)
+                         49 passed; 0 failed (통합)
+                         0 failed (전체, exit 0)
+cargo clippy --release --lib  → symbols.rs 경고 없음
+```
+
+- ∑/∏/∫ 큰연산자, 행렬, 첨자, 극한 관련 기존 테스트 전부 통과 (회귀 없음)
+- 신규 `test_set_operators_not_big` 통과
+
+## 범위 외 (기록)
+
+- `SQCUP`/`SQCAP`/`UPLUS`/`OPLUS`/`OTIMES` 등 비-BIG 소형 연산자도 동일 오분류 가능성. 정답지 근거 부재로 본 타스크 미포함 — 최종 보고서 후속 항목.
+- U+E04D 조건부 막대 두부 → 이슈 #1343.
+
+## 결론
+
+근본 원인(BIG_OPERATORS 오분류 → 1.5배 확대) 해소. PDF 정합·회귀 무결. Stage 3(최종 보고서) 진행 가능.

--- a/src/renderer/equation/symbols.rs
+++ b/src/renderer/equation/symbols.rs
@@ -168,6 +168,13 @@ static OPERATORS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::new(
         ("DOTEQ", "≐"),
         ("PROPTO", "∝"),
         // 집합/논리
+        // 소형 이항 집합연산자 — 본문 크기로 렌더(#1342, BIG_OPERATORS 오분류 → 1.5배 확대 버그 수정)
+        ("UNION", "∪"),
+        ("SMALLUNION", "∪"),
+        ("CUP", "∪"),
+        ("INTER", "∩"),
+        ("SMALLINTER", "∩"),
+        ("CAP", "∩"),
         ("SUBSET", "⊂"),
         ("SUPERSET", "⊃"),
         ("SUBSETEQ", "⊆"),
@@ -282,15 +289,10 @@ static BIG_OPERATORS: LazyLock<HashMap<&'static str, &'static str>> = LazyLock::
         ("COPROD", "∐"),
         ("SMCOPROD", "∐"),
         ("AMALG", "∐"),
-        // 집합
-        ("UNION", "∪"),
+        // 집합 — 소형 이항 연산자(UNION/CUP/INTER/CAP 등)는 본문 크기 OPERATORS 로 분리(#1342).
+        //         여기에는 위/아래 첨자를 받아 1.5배 확대되는 진짜 큰 형태(BIG*)만 남긴다.
         ("BIGCUP", "∪"),
-        ("SMALLUNION", "∪"),
-        ("CUP", "∪"),
-        ("INTER", "∩"),
         ("BIGCAP", "∩"),
-        ("SMALLINTER", "∩"),
-        ("CAP", "∩"),
         ("SQCUP", "⊔"),
         ("BIGSQCUP", "⊔"),
         ("SQCAP", "⊓"),
@@ -689,6 +691,29 @@ mod tests {
         assert!(is_big_operator("SUM"));
         assert!(is_big_operator("PROD"));
         assert!(!is_big_operator("alpha"));
+    }
+
+    /// #1342: 소형 집합연산자(∩/∪)는 큰 연산자가 아니어야 한다(1.5배 확대 방지).
+    /// 큰 형태(BIG*)만 big operator 로 유지.
+    #[test]
+    fn test_set_operators_not_big() {
+        // 소형 — 본문 크기로 렌더되어야 하므로 big 이 아님
+        assert!(!is_big_operator("CAP"));
+        assert!(!is_big_operator("CUP"));
+        assert!(!is_big_operator("UNION"));
+        assert!(!is_big_operator("INTER"));
+        assert!(!is_big_operator("SMALLINTER"));
+        assert!(!is_big_operator("SMALLUNION"));
+        // 큰 형태는 유지
+        assert!(is_big_operator("BIGCUP"));
+        assert!(is_big_operator("BIGCAP"));
+        // 제거 후에도 기호 매핑은 정상(OPERATORS 로 이동)
+        assert_eq!(lookup_symbol("CAP"), Some("∩"));
+        assert_eq!(lookup_symbol("CUP"), Some("∪"));
+        assert_eq!(lookup_symbol("SMALLINTER"), Some("∩"));
+        assert_eq!(lookup_symbol("SMALLUNION"), Some("∪"));
+        assert_eq!(lookup_symbol("cap"), Some("∩"));
+        assert_eq!(lookup_symbol("cup"), Some("∪"));
     }
 
     #[test]


### PR DESCRIPTION
## 배경
16페이지 문24 `P(A∩B)` 등에서 교집합(∩)/합집합(∪)이 본문 글자보다 1.5배 크게 렌더되고 뒤쪽에 불필요한 가로 간격이 발생. 한글2022 PDF(정답지)에서는 본문과 같은 크기로 좁게 붙음.

- 샘플: `samples/3-09월_교육_통합_2024-구분선아래20구분선위20.hwpx` 16페이지
- 정답지: `pdf/3-09월_교육_통합_2024-구분선아래20구분선위20.pdf` 16페이지

## 근본 원인
소형 이항 집합연산자(`UNION`/`SMALLUNION`/`CUP`/`INTER`/`SMALLINTER`/`CAP`)가 `BIG_OPERATORS` 테이블에 오분류되어, 파서가 대문자 변환 후 `is_big_operator()` → `parse_big_op()` → `op_fs = fs * BIG_OP_SCALE(1.5)` 경로를 타고 1.5배 확대 + trailing 박스폭이 부가됨. SVG 글리프 추출로 ∩ `font-size=18`(본문 12) 확인.

## 수정
`src/renderer/equation/symbols.rs` 단일 파일:
- `BIG_OPERATORS` → `OPERATORS` 로 6개 키 이동 (본문 크기 `MathSymbol` 렌더)
- `BIGCUP`/`BIGCAP` 등 진짜 큰 형태만 `BIG_OPERATORS` 유지
- 회귀 테스트 `test_set_operators_not_big` 추가

`lookup_symbol` 이 case-sensitive 조회이므로 단순 제거가 아니라 **키 이동**으로 `is_big_operator()=false` 와 기호 매핑을 동시 보장.

## 검증
- ∩/∪ font-size 18→12 (본문 동일), 6개 전부 정규화 / y정렬·밀착 간격 PDF 정합
- `cargo test --release`: 1614+49 passed, 0 failed
- `cargo clippy --lib`: 경고 없음
- ∑/∏/∫·행렬·첨자 회귀 무결

## 범위 외 (후속)
- `P(A|B)` 조건부 막대 U+E04D(PUA) 두부(▦) 렌더 → 별도 이슈 #1343
- `SQCUP`/`SQCAP`/`UPLUS`/`OPLUS`/`OTIMES` 등 비-BIG 소형 연산자 동일 오분류 가능성 → 정답지 근거 확보 시 후속

closes #1342