### PR TITLE
fix(hwpx): 그림 effects/shadow roundtrip 보존

### DIFF
--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -38,6 +38,8 @@ pub struct Picture {
     pub instance_id: u32,
     /// SHAPE_PICTURE 레코드의 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_picture_extra: Vec<u8>,
+    /// HWPX `<hp:effects>` 그림 효과 정보.
+    pub effects: PictureEffects,
     /// 캡션
     pub caption: Option<super::shape::Caption>,
 }
@@ -67,6 +69,52 @@ pub struct ImageAttr {
     /// HWP3 외부 link 그림이고 binary 데이터 부재 시 placeholder 표시용.
     /// `None` = 내부 임베드 그림 (binary 데이터 사용).
     pub external_path: Option<String>,
+}
+
+/// HWPX 그림 효과 (`hp:effects`).
+#[derive(Debug, Clone, Default)]
+pub struct PictureEffects {
+    pub shadow: Option<PictureShadow>,
+}
+
+/// HWPX 그림 그림자 효과 (`hp:shadow`).
+#[derive(Debug, Clone, Default)]
+pub struct PictureShadow {
+    pub style: Option<String>,
+    pub alpha: Option<String>,
+    pub radius: Option<String>,
+    pub direction: Option<String>,
+    pub distance: Option<String>,
+    pub align_style: Option<String>,
+    pub rotation_style: Option<String>,
+    pub skew: Option<EffectPoint>,
+    pub scale: Option<EffectPoint>,
+    pub color: Option<EffectColor>,
+}
+
+/// HWPX 효과의 x/y 좌표성 값 (`hp:skew`, `hp:scale`).
+#[derive(Debug, Clone, Default)]
+pub struct EffectPoint {
+    pub x: Option<String>,
+    pub y: Option<String>,
+}
+
+/// HWPX 효과 색상 (`hp:effectsColor`).
+#[derive(Debug, Clone, Default)]
+pub struct EffectColor {
+    pub color_type: Option<String>,
+    pub scheme_idx: Option<String>,
+    pub system_idx: Option<String>,
+    pub preset_idx: Option<String>,
+    pub rgb: Option<EffectRgb>,
+}
+
+/// HWPX 효과 RGB 색상 (`hp:rgb`).
+#[derive(Debug, Clone, Default)]
+pub struct EffectRgb {
+    pub r: Option<String>,
+    pub g: Option<String>,
+    pub b: Option<String>,
 }
 
 impl ImageAttr {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -13,7 +13,10 @@ use crate::model::control::{
 use crate::model::document::{Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
 use crate::model::header_footer::{Footer, Header, HeaderFooterApply, MasterPage};
-use crate::model::image::{CropInfo, ImageAttr, ImageEffect};
+use crate::model::image::{
+    CropInfo, EffectColor, EffectPoint, EffectRgb, ImageAttr, ImageEffect, PictureEffects,
+    PictureShadow,
+};
 use crate::model::page::{
     BindingMethod, ColumnDef, ColumnDirection, ColumnType, PageBorderBasis, PageBorderFill,
     PageBorderUiBasis, PageDef,
@@ -2133,6 +2136,7 @@ fn parse_picture(
     let mut border_y = [0i32; 4];
     let mut href: Option<String> = None;
     let mut picture_instance_id = 0;
+    let mut effects = PictureEffects::default();
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
@@ -2180,6 +2184,9 @@ fn parse_picture(
             }
             Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"shapeComment" => {
                 common.description = read_dutmal_text(reader, b"shapeComment")?;
+            }
+            Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"effects" => {
+                effects = parse_picture_effects(reader)?;
             }
             Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce)) => {
                 let cname = ce.name();
@@ -2431,8 +2438,142 @@ fn parse_picture(
     pic.border_x = border_x;
     pic.border_y = border_y;
     pic.instance_id = picture_instance_id;
+    pic.effects = effects;
 
     Ok(Control::Picture(Box::new(pic)))
+}
+
+fn parse_picture_effects(reader: &mut Reader<&[u8]>) -> Result<PictureEffects, HwpxError> {
+    let mut effects = PictureEffects::default();
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Start(ref e)) if local_name(e.name().as_ref()) == b"shadow" => {
+                effects.shadow = Some(parse_picture_shadow(e, reader)?);
+            }
+            Ok(Event::Empty(ref e)) if local_name(e.name().as_ref()) == b"shadow" => {
+                effects.shadow = Some(parse_picture_shadow_attrs(e));
+            }
+            Ok(Event::End(ref e)) if local_name(e.name().as_ref()) == b"effects" => break,
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(HwpxError::XmlError(format!("effects: {}", e))),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(effects)
+}
+
+fn parse_picture_shadow(
+    e: &quick_xml::events::BytesStart<'_>,
+    reader: &mut Reader<&[u8]>,
+) -> Result<PictureShadow, HwpxError> {
+    let mut shadow = parse_picture_shadow_attrs(e);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Empty(ref e)) => match local_name(e.name().as_ref()) {
+                b"skew" => shadow.skew = Some(parse_effect_point(e)),
+                b"scale" => shadow.scale = Some(parse_effect_point(e)),
+                b"effectsColor" => {
+                    shadow.color = Some(parse_effect_color_attrs(e));
+                }
+                _ => {}
+            },
+            Ok(Event::Start(ref e)) if local_name(e.name().as_ref()) == b"effectsColor" => {
+                shadow.color = Some(parse_effect_color(e, reader)?);
+            }
+            Ok(Event::End(ref e)) if local_name(e.name().as_ref()) == b"shadow" => break,
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(HwpxError::XmlError(format!("shadow: {}", e))),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(shadow)
+}
+
+fn parse_picture_shadow_attrs(e: &quick_xml::events::BytesStart<'_>) -> PictureShadow {
+    let mut shadow = PictureShadow::default();
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"style" => shadow.style = Some(attr_str(&attr)),
+            b"alpha" => shadow.alpha = Some(attr_str(&attr)),
+            b"radius" => shadow.radius = Some(attr_str(&attr)),
+            b"direction" => shadow.direction = Some(attr_str(&attr)),
+            b"distance" => shadow.distance = Some(attr_str(&attr)),
+            b"alignStyle" => shadow.align_style = Some(attr_str(&attr)),
+            b"rotationStyle" => shadow.rotation_style = Some(attr_str(&attr)),
+            _ => {}
+        }
+    }
+    shadow
+}
+
+fn parse_effect_point(e: &quick_xml::events::BytesStart<'_>) -> EffectPoint {
+    let mut point = EffectPoint::default();
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"x" => point.x = Some(attr_str(&attr)),
+            b"y" => point.y = Some(attr_str(&attr)),
+            _ => {}
+        }
+    }
+    point
+}
+
+fn parse_effect_color(
+    e: &quick_xml::events::BytesStart<'_>,
+    reader: &mut Reader<&[u8]>,
+) -> Result<EffectColor, HwpxError> {
+    let mut color = parse_effect_color_attrs(e);
+    let mut buf = Vec::new();
+
+    loop {
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Empty(ref e)) if local_name(e.name().as_ref()) == b"rgb" => {
+                color.rgb = Some(parse_effect_rgb(e));
+            }
+            Ok(Event::End(ref e)) if local_name(e.name().as_ref()) == b"effectsColor" => break,
+            Ok(Event::Eof) => break,
+            Err(e) => return Err(HwpxError::XmlError(format!("effectsColor: {}", e))),
+            _ => {}
+        }
+        buf.clear();
+    }
+
+    Ok(color)
+}
+
+fn parse_effect_color_attrs(e: &quick_xml::events::BytesStart<'_>) -> EffectColor {
+    let mut color = EffectColor::default();
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"type" => color.color_type = Some(attr_str(&attr)),
+            b"schemeIdx" => color.scheme_idx = Some(attr_str(&attr)),
+            b"systemIdx" => color.system_idx = Some(attr_str(&attr)),
+            b"presetIdx" => color.preset_idx = Some(attr_str(&attr)),
+            _ => {}
+        }
+    }
+    color
+}
+
+fn parse_effect_rgb(e: &quick_xml::events::BytesStart<'_>) -> EffectRgb {
+    let mut rgb = EffectRgb::default();
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"r" => rgb.r = Some(attr_str(&attr)),
+            b"g" => rgb.g = Some(attr_str(&attr)),
+            b"b" => rgb.b = Some(attr_str(&attr)),
+            _ => {}
+        }
+    }
+    rgb
 }
 
 // ─── 그리기 객체 공통 속성 파싱 ───

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -698,6 +698,67 @@ mod tests {
     }
 
     #[test]
+    fn issue_1345_picture_effects_shadow_roundtrip() {
+        use crate::model::control::Control;
+        use crate::model::shape::ShapeObject;
+
+        fn count_shape_picture_shadows(shape: &ShapeObject) -> usize {
+            match shape {
+                ShapeObject::Picture(pic) => usize::from(pic.effects.shadow.is_some()),
+                ShapeObject::Group(group) => {
+                    group.children.iter().map(count_shape_picture_shadows).sum()
+                }
+                _ => 0,
+            }
+        }
+
+        fn count_picture_shadows(control: &Control) -> usize {
+            match control {
+                Control::Picture(pic) => usize::from(pic.effects.shadow.is_some()),
+                Control::Shape(shape) => count_shape_picture_shadows(shape),
+                _ => 0,
+            }
+        }
+
+        let bytes = std::fs::read("samples/hwpx/aift.hwpx")
+            .expect("samples/hwpx/aift.hwpx must be readable");
+        let original = parse_hwpx(&bytes).expect("parse original");
+        let parsed_shadow_count: usize = original
+            .sections
+            .iter()
+            .flat_map(|section| &section.paragraphs)
+            .flat_map(|para| &para.controls)
+            .map(count_picture_shadows)
+            .sum();
+        assert!(
+            parsed_shadow_count > 0,
+            "parser must preserve at least one picture shadow effect"
+        );
+
+        let serialized = serialize_hwpx(&original).expect("serialize roundtrip");
+
+        let mut archive =
+            zip::ZipArchive::new(std::io::Cursor::new(serialized)).expect("roundtrip zip");
+        let section_names: Vec<String> = archive
+            .file_names()
+            .filter(|name| name.starts_with("Contents/section") && name.ends_with(".xml"))
+            .map(String::from)
+            .collect();
+        let mut section_xml = String::new();
+        for name in section_names {
+            let mut section = archive.by_name(&name).expect("roundtrip section");
+            std::io::Read::read_to_string(&mut section, &mut section_xml).expect("read section");
+        }
+
+        for needle in ["<hp:shadow ", "<hp:scale ", "<hp:effectsColor ", "<hp:rgb "] {
+            assert!(
+                section_xml.contains(needle),
+                "roundtrip section XML must preserve {needle}"
+            );
+        }
+    }
+
+    #[test]
     fn table_control_roundtrip() {
         use crate::model::control::Control;
         use crate::model::table::Table;

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -27,7 +27,9 @@ use std::io::Write;
 
 use quick_xml::Writer;
 
-use crate::model::image::{ImageEffect, Picture};
+use crate::model::image::{
+    EffectColor, EffectPoint, EffectRgb, ImageEffect, Picture, PictureShadow,
+};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, ShapeComponentAttr, TextFlow, TextWrap, VertAlign,
     VertRelTo,
@@ -86,7 +88,7 @@ pub fn write_picture<W: Write>(
     write_in_margin(w, pic)?;
     write_img_dim(w, pic)?;
     write_img(w, pic, ctx)?; // 3-way 단언 지점
-    write_effects(w)?;
+    write_effects(w, pic)?;
     write_sz(w, &pic.common)?;
     write_pos(w, &pic.common)?;
     write_out_margin(w, &pic.common)?;
@@ -247,11 +249,90 @@ fn write_img<W: Write>(
     )
 }
 
-fn write_effects<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError> {
-    // Stage 4 에선 빈 effects 출력 (필요시 확장).
+fn write_effects<W: Write>(w: &mut Writer<W>, pic: &Picture) -> Result<(), SerializeError> {
     start_tag(w, "hp:effects")?;
+    if let Some(shadow) = &pic.effects.shadow {
+        write_shadow(w, shadow)?;
+    }
     end_tag(w, "hp:effects")?;
     Ok(())
+}
+
+fn write_shadow<W: Write>(w: &mut Writer<W>, shadow: &PictureShadow) -> Result<(), SerializeError> {
+    let mut attrs = Vec::new();
+    push_opt_attr(&mut attrs, "style", shadow.style.as_deref());
+    push_opt_attr(&mut attrs, "alpha", shadow.alpha.as_deref());
+    push_opt_attr(&mut attrs, "radius", shadow.radius.as_deref());
+    push_opt_attr(&mut attrs, "direction", shadow.direction.as_deref());
+    push_opt_attr(&mut attrs, "distance", shadow.distance.as_deref());
+    push_opt_attr(&mut attrs, "alignStyle", shadow.align_style.as_deref());
+    push_opt_attr(
+        &mut attrs,
+        "rotationStyle",
+        shadow.rotation_style.as_deref(),
+    );
+
+    start_tag_attrs(w, "hp:shadow", &attrs)?;
+    if let Some(skew) = &shadow.skew {
+        write_effect_point(w, "hp:skew", skew)?;
+    }
+    if let Some(scale) = &shadow.scale {
+        write_effect_point(w, "hp:scale", scale)?;
+    }
+    if let Some(color) = &shadow.color {
+        write_effect_color(w, color)?;
+    }
+    end_tag(w, "hp:shadow")?;
+    Ok(())
+}
+
+fn write_effect_point<W: Write>(
+    w: &mut Writer<W>,
+    name: &str,
+    point: &EffectPoint,
+) -> Result<(), SerializeError> {
+    let mut attrs = Vec::new();
+    push_opt_attr(&mut attrs, "x", point.x.as_deref());
+    push_opt_attr(&mut attrs, "y", point.y.as_deref());
+    empty_tag(w, name, &attrs)
+}
+
+fn write_effect_color<W: Write>(
+    w: &mut Writer<W>,
+    color: &EffectColor,
+) -> Result<(), SerializeError> {
+    let mut attrs = Vec::new();
+    push_opt_attr(&mut attrs, "type", color.color_type.as_deref());
+    push_opt_attr(&mut attrs, "schemeIdx", color.scheme_idx.as_deref());
+    push_opt_attr(&mut attrs, "systemIdx", color.system_idx.as_deref());
+    push_opt_attr(&mut attrs, "presetIdx", color.preset_idx.as_deref());
+
+    if let Some(rgb) = &color.rgb {
+        start_tag_attrs(w, "hp:effectsColor", &attrs)?;
+        write_effect_rgb(w, rgb)?;
+        end_tag(w, "hp:effectsColor")?;
+    } else {
+        empty_tag(w, "hp:effectsColor", &attrs)?;
+    }
+    Ok(())
+}
+
+fn write_effect_rgb<W: Write>(w: &mut Writer<W>, rgb: &EffectRgb) -> Result<(), SerializeError> {
+    let mut attrs = Vec::new();
+    push_opt_attr(&mut attrs, "r", rgb.r.as_deref());
+    push_opt_attr(&mut attrs, "g", rgb.g.as_deref());
+    push_opt_attr(&mut attrs, "b", rgb.b.as_deref());
+    empty_tag(w, "hp:rgb", &attrs)
+}
+
+fn push_opt_attr<'a>(
+    attrs: &mut Vec<(&'static str, &'a str)>,
+    key: &'static str,
+    value: Option<&'a str>,
+) {
+    if let Some(value) = value {
+        attrs.push((key, value));
+    }
 }
 
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
@@ -392,7 +473,9 @@ mod tests {
     use super::*;
     use crate::model::bin_data::BinDataContent;
     use crate::model::document::Document;
-    use crate::model::image::{ImageAttr, Picture};
+    use crate::model::image::{
+        EffectColor, EffectPoint, EffectRgb, ImageAttr, Picture, PictureEffects, PictureShadow,
+    };
     use crate::serializer::hwpx::context::SerializeContext;
 
     fn make_picture(bin_data_id: u16) -> Picture {
@@ -532,5 +615,47 @@ mod tests {
         assert_eq!(image_effect_str(ImageEffect::RealPic), "REAL_PIC");
         assert_eq!(image_effect_str(ImageEffect::GrayScale), "GRAY_SCALE");
         assert_eq!(image_effect_str(ImageEffect::BlackWhite), "BLACK_WHITE");
+    }
+
+    #[test]
+    fn picture_effects_shadow_are_serialized() {
+        let doc = make_doc_with_bin(1, "png");
+        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.effects = PictureEffects {
+            shadow: Some(PictureShadow {
+                style: Some("OUTSIDE".to_string()),
+                alpha: Some("0.8".to_string()),
+                radius: Some("400".to_string()),
+                direction: Some("45".to_string()),
+                distance: Some("1000".to_string()),
+                align_style: Some("TOP_LEFT".to_string()),
+                rotation_style: Some("0".to_string()),
+                skew: None,
+                scale: Some(EffectPoint {
+                    x: Some("1".to_string()),
+                    y: Some("1".to_string()),
+                }),
+                color: Some(EffectColor {
+                    color_type: Some("RGB".to_string()),
+                    scheme_idx: Some("-1".to_string()),
+                    system_idx: Some("-1".to_string()),
+                    preset_idx: Some("-1".to_string()),
+                    rgb: Some(EffectRgb {
+                        r: Some("0".to_string()),
+                        g: Some("0".to_string()),
+                        b: Some("0".to_string()),
+                    }),
+                }),
+            }),
+        };
+
+        let xml = serialize(&pic, &ctx);
+        assert!(xml.contains(r#"<hp:shadow style="OUTSIDE" alpha="0.8" radius="400" direction="45" distance="1000" alignStyle="TOP_LEFT" rotationStyle="0">"#));
+        assert!(xml.contains(r#"<hp:scale x="1" y="1"/>"#));
+        assert!(xml.contains(
+            r#"<hp:effectsColor type="RGB" schemeIdx="-1" systemIdx="-1" presetIdx="-1">"#
+        ));
+        assert!(xml.contains(r#"<hp:rgb r="0" g="0" b="0"/>"#));
     }
 }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -489,13 +489,30 @@ fn render_shape(shape: &ShapeObject, ctx: &SerializeContext) -> String {
             }
         };
     }
+    if let ShapeObject::Group(g) = shape {
+        let mut xml = match writer_to_string(|w| super::shape::write_container_open(w, &g.common)) {
+            Ok(xml) => xml,
+            Err(e) => {
+                eprintln!("[hwpx] Shape::Group 직렬화 실패: {e}");
+                String::new()
+            }
+        };
+        for child in &g.children {
+            xml.push_str(&render_shape(child, ctx));
+        }
+        match writer_to_string(super::shape::write_container_close) {
+            Ok(close) => xml.push_str(&close),
+            Err(e) => eprintln!("[hwpx] Shape::Group 닫기 실패: {e}"),
+        }
+        return xml;
+    }
     let (tag, c) = match shape {
         ShapeObject::Rectangle(_) | ShapeObject::Line(_) => unreachable!(),
         ShapeObject::Ellipse(e) => ("ellipse", &e.common),
         ShapeObject::Arc(a) => ("arc", &a.common),
         ShapeObject::Polygon(p) => ("polygon", &p.common),
         ShapeObject::Curve(cv) => ("curve", &cv.common),
-        ShapeObject::Group(g) => ("container", &g.common),
+        ShapeObject::Group(_) => unreachable!(),
         ShapeObject::Picture(pic) => {
             return match writer_to_string(|w| picture::write_picture(w, pic, ctx)) {
                 Ok(xml) => xml,

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -13303,6 +13303,7 @@ fn test_save_picture() {
         border_opacity: ref_pic.border_opacity,
         instance_id: ref_pic.instance_id,
         raw_picture_extra: ref_pic.raw_picture_extra.clone(),
+        effects: ref_pic.effects.clone(),
         caption: None,
     };
 
@@ -14489,6 +14490,7 @@ fn test_save_pic_in_table() {
         border_opacity: ref_pic.border_opacity,
         instance_id: ref_pic.instance_id,
         raw_picture_extra: ref_pic.raw_picture_extra.clone(),
+        effects: ref_pic.effects.clone(),
         caption: None,
     };
 


### PR DESCRIPTION
## 변경 요약

HWPX 그림의 `hp:effects`/`hp:shadow` 정보가 parse → serialize_hwpx roundtrip 중 사라지는 문제를 수정했습니다.

- `Picture` IR에 HWPX 그림 효과 모델(`PictureEffects`, `PictureShadow`, `EffectColor` 등)을 추가했습니다.
- HWPX 파서가 `hp:effects > hp:shadow > hp:scale/effectsColor/rgb` 값을 보존하도록 했습니다.
- HWPX 그림 serializer가 저장된 shadow/effects 값을 다시 출력하도록 했습니다.
- `hp:container` 안의 그룹 자식 그림도 직렬화되도록 그룹 자식 루프를 연결했습니다.
- `samples/hwpx/aift.hwpx` 기반 roundtrip 회귀 테스트를 추가했습니다.

## 관련 이슈

closes #1345

## 테스트

- [x] `git diff --check` 통과
- [x] `cargo fmt --all -- --check` 통과
- [x] `cargo test --lib issue_1345_picture_effects_shadow_roundtrip` 통과
- [x] `cargo test --lib picture_effects_shadow_are_serialized` 통과
- [x] `cargo clippy --lib -- -D warnings` 통과
- [x] `cargo test` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

## 스크린샷

XML roundtrip 데이터 보존 수정이라 스크린샷은 첨부하지 않았습니다.