### PR TITLE
fix(hwpx): 표 셀 탭/줄바꿈 인라인 직렬화

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -177,7 +177,11 @@ fn render_paragraph_parts_for_text(text: &str, vert_start: u32) -> (String, Stri
 ///
 /// `tab_extended`: IR의 탭 확장 정보 목록. `tab_idx`를 통해 탭 문자마다 순서대로 참조.
 /// 항목이 없으면 폴백(width=TAB_DEFAULT_WIDTH, leader=0, type=1)을 사용.
-fn render_hp_t_content(text: &str, tab_extended: &[[u16; 7]], tab_idx: &mut usize) -> String {
+pub(crate) fn render_hp_t_content(
+    text: &str,
+    tab_extended: &[[u16; 7]],
+    tab_idx: &mut usize,
+) -> String {
     let mut t_xml = String::from("<hp:t>");
     let mut buf = String::new();
     for c in text.chars() {

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -35,6 +35,7 @@ use crate::model::shape::{
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
 
 use super::context::SerializeContext;
+use super::section::render_hp_t_content;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
 
@@ -277,8 +278,7 @@ fn write_sub_list<W: Write>(
             .unwrap_or(0);
         let cs_str = cs.to_string();
         start_tag_attrs(w, "hp:run", &[("charPrIDRef", &cs_str)])?;
-        // 텍스트만 출력 (탭·소프트브레이크는 Stage 3 범위에서 제외 — section.rs 와 동일 방식으로 단순화)
-        write_cell_text(w, &para.text)?;
+        write_cell_text(w, &para.text, &para.tab_extended)?;
         end_tag(w, "hp:run")?;
 
         // <hp:linesegarray> 최소 1개 lineseg
@@ -308,16 +308,15 @@ fn write_sub_list<W: Write>(
     Ok(())
 }
 
-fn write_cell_text<W: Write>(w: &mut Writer<W>, text: &str) -> Result<(), SerializeError> {
-    use quick_xml::events::{BytesEnd, BytesStart, BytesText, Event};
-    // <hp:t>text</hp:t>
-    w.write_event(Event::Start(BytesStart::new("hp:t")))
-        .map_err(|e| SerializeError::XmlError(e.to_string()))?;
-    if !text.is_empty() {
-        w.write_event(Event::Text(BytesText::new(text)))
-            .map_err(|e| SerializeError::XmlError(e.to_string()))?;
-    }
-    w.write_event(Event::End(BytesEnd::new("hp:t")))
+fn write_cell_text<W: Write>(
+    w: &mut Writer<W>,
+    text: &str,
+    tab_extended: &[[u16; 7]],
+) -> Result<(), SerializeError> {
+    let mut tab_idx = 0usize;
+    let xml = render_hp_t_content(text, tab_extended, &mut tab_idx);
+    w.get_mut()
+        .write_all(xml.as_bytes())
         .map_err(|e| SerializeError::XmlError(e.to_string()))?;
     Ok(())
 }
@@ -683,5 +682,23 @@ mod tests {
                 expected_id
             );
         }
+    }
+
+    #[test]
+    fn cell_text_serializes_tab_and_line_break_as_hwpx_inline_elements() {
+        let mut t = empty_table(1, 1);
+        let para = &mut t.cells[0].paragraphs[0];
+        para.text = "A\tB\nC".to_string();
+        para.tab_extended = vec![[2000, 0, 0x0100, 0, 0, 0, 0]];
+
+        let xml = serialize(&t);
+
+        assert!(
+            xml.contains(
+                r#"<hp:t>A<hp:tab width="2000" leader="0" type="1"/>B<hp:lineBreak/>C</hp:t>"#
+            ),
+            "cell text must emit hp:tab/hp:lineBreak instead of raw control chars: {}",
+            xml
+        );
     }
 }


### PR DESCRIPTION
## 변경 요약

HWPX serializer가 표 셀 문단 텍스트의 탭/소프트브레이크를 raw 문자로 `hp:t`에 기록하던 문제를 수정했습니다.

- 본문 문단 경로의 `render_hp_t_content()`를 표 셀 직렬화에서도 재사용
- 셀 문단의 `tab_extended`를 사용해 `hp:tab width/leader/type` 출력
- 표 셀 텍스트의 `\t`/`\n`이 `hp:tab`/`hp:lineBreak`로 직렬화되는 회귀 테스트 추가

## 관련 이슈

관련: #1353

## 테스트

- [x] `cargo test` 통과
- [x] `cargo clippy -- -D warnings` 통과
- [x] 관련 샘플 파일로 SVG 내보내기 확인: 해당 없음 (HWPX XML serializer 변경)
- [x] 웹(WASM) 렌더링 확인: 해당 없음 (HWPX XML serializer 변경)

## 스크린샷

변경 전후 비교가 필요한 렌더링/UI 변경이 아니므로 첨부하지 않았습니다.