### PR TITLE
feat: HWPX 양식 개체 직렬화 + 표 열 폭 제어

### DIFF
--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -835,6 +835,128 @@ impl DocumentCore {
         Ok("{\"ok\":true}".to_string())
     }
 
+    /// 표의 열별 폭(HWPUNIT)을 절대값으로 설정한다 (네이티브).
+    ///
+    /// `widths.len()` 은 표의 열 수와 같아야 한다. `insert_table_column` 과 달리
+    /// 표 전체 폭이 입력한 폭들의 합이 되므로, 페이지를 넘지 않게 하려면
+    /// 합을 본문 폭 이하로 전달하거나 `fit_table_to_page_native` 를 쓴다.
+    pub fn set_table_column_widths_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        widths: Vec<u32>,
+    ) -> Result<String, HwpError> {
+        let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+        table
+            .set_column_widths(&widths)
+            .map_err(HwpError::RenderError)?;
+        table.dirty = true;
+        let col_count = table.col_count;
+        let total: u32 = table.get_column_widths().iter().sum();
+
+        // 폭이 바뀐 셀의 모든 문단을 재배치(line_segs 재계산)한다.
+        let reflow: Vec<(usize, usize)> = {
+            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
+            if let Some(Control::Table(t)) = para.controls.get(control_idx) {
+                t.cells
+                    .iter()
+                    .enumerate()
+                    .map(|(i, c)| (i, c.paragraphs.len()))
+                    .collect()
+            } else {
+                Vec::new()
+            }
+        };
+        for (cell_idx, para_count) in reflow {
+            for cell_para_idx in 0..para_count {
+                self.reflow_cell_paragraph(
+                    section_idx,
+                    parent_para_idx,
+                    control_idx,
+                    cell_idx,
+                    cell_para_idx,
+                );
+            }
+        }
+
+        self.document.sections[section_idx].raw_stream = None;
+        self.recompose_section(section_idx);
+        self.paginate_if_needed();
+
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"colCount\":{},\"tableWidth\":{}",
+            col_count, total
+        )))
+    }
+
+    /// 표를 본문(페이지 텍스트) 폭에 맞춰 비례 축소한다 (네이티브).
+    ///
+    /// 표의 열 폭 합이 본문 폭(페이지 본문 영역 폭 − 표 바깥 좌우 여백)을 넘으면
+    /// 각 열을 같은 비율로 줄여 표가 페이지를 넘지 않게 한다. 이미 본문 폭 이하이면
+    /// 변경하지 않는다(축소 전용).
+    pub fn fit_table_to_page_native(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) -> Result<String, HwpError> {
+        const MIN_COL: u32 = 200; // 최소 열 폭 (HWPUNIT)
+
+        // 현재 열 폭과 표 바깥 좌우 여백을 읽는다.
+        let (widths, outer_lr) = {
+            let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+            let outer = table.outer_margin_left as i64 + table.outer_margin_right as i64;
+            (table.get_column_widths(), outer.max(0) as u32)
+        };
+        let total: u32 = widths.iter().sum();
+
+        // 본문(텍스트) 폭 = 페이지 본문 영역 폭 − 표 바깥 좌우 여백.
+        let page_def = &self.document.sections[section_idx].section_def.page_def;
+        let body = crate::model::page::PageAreas::from_page_def(page_def).body_area;
+        let body_w = (body.right - body.left).max(0) as u32;
+        let target = body_w.saturating_sub(outer_lr);
+
+        if total == 0 || target == 0 || total <= target {
+            // 이미 페이지 폭 안에 들어옴 — 변경 없음.
+            return Ok(super::super::helpers::json_ok_with(&format!(
+                "\"colCount\":{},\"tableWidth\":{},\"pageContentWidth\":{},\"changed\":false",
+                widths.len(),
+                total,
+                target
+            )));
+        }
+
+        // 비례 축소(내림) 후 잔여분을 마지막 열에 더해 합이 정확히 target 이 되게 한다.
+        let mut new_w: Vec<u32> = widths
+            .iter()
+            .map(|&w| ((w as u64 * target as u64) / total as u64) as u32)
+            .collect();
+        let assigned: u64 = new_w.iter().map(|&w| w as u64).sum();
+        let remainder = target as u64 - assigned; // 내림이므로 항상 >= 0
+        if let Some(last) = new_w.last_mut() {
+            *last = (*last as u64 + remainder) as u32;
+        }
+        for w in &mut new_w {
+            if *w < MIN_COL {
+                *w = MIN_COL;
+            }
+        }
+
+        self.set_table_column_widths_native(section_idx, parent_para_idx, control_idx, new_w)?;
+
+        let new_total: u32 = {
+            let table = self.get_table_mut(section_idx, parent_para_idx, control_idx)?;
+            table.get_column_widths().iter().sum()
+        };
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"colCount\":{},\"tableWidth\":{},\"pageContentWidth\":{},\"changed\":true",
+            widths.len(),
+            new_total,
+            target
+        )))
+    }
+
     /// JSON 객체 내 정수 키 값을 파싱하는 헬퍼.
     pub(crate) fn parse_json_i32(json: &str, key: &str) -> Option<i32> {
         let pattern = format!("\"{}\":", key);

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -296,6 +296,36 @@ impl Table {
         widths
     }
 
+    /// 열별 폭(HWPUNIT)을 절대값으로 설정한다.
+    ///
+    /// `widths.len()` 은 `col_count` 와 같아야 한다. 병합 셀(`col_span > 1`)은
+    /// 걸친 열들의 폭 합으로 설정된다. 설정 후 표 전체 크기
+    /// (`update_ctrl_dimensions`)와 그리드 인덱스(`rebuild_grid`)를 갱신한다.
+    ///
+    /// `insert_column` 이 기준 열 폭을 복제해 표를 넓히는 것과 달리, 이 메서드는
+    /// 입력한 폭들의 합이 그대로 표 전체 폭이 된다. 페이지 폭에 맞추려면
+    /// 합이 본문 폭 이하가 되도록 전달한다.
+    pub fn set_column_widths(&mut self, widths: &[HwpUnit]) -> Result<(), String> {
+        if widths.len() != self.col_count as usize {
+            return Err(format!(
+                "열 폭 개수 {} 가 표의 열 수 {} 와 다릅니다",
+                widths.len(),
+                self.col_count
+            ));
+        }
+        for cell in &mut self.cells {
+            let c = cell.col as usize;
+            if c >= widths.len() {
+                continue;
+            }
+            let end = (c + cell.col_span as usize).min(widths.len());
+            cell.width = widths[c..end].iter().sum();
+        }
+        self.update_ctrl_dimensions();
+        self.rebuild_grid();
+        Ok(())
+    }
+
     /// 행별 높이를 추출한다 (row_span==1인 셀 기준).
     /// 높이가 0인 행은 기본값 400으로 대체 (새 셀 생성용).
     pub fn get_row_heights(&self) -> Vec<HwpUnit> {

--- a/src/model/table/tests.rs
+++ b/src/model/table/tests.rs
@@ -222,6 +222,48 @@ fn test_insert_column_out_of_bounds() {
     assert!(table.insert_column(5, true).is_err());
 }
 
+// === set_column_widths 테스트 ===
+
+#[test]
+fn test_set_column_widths_basic() {
+    let mut table = make_table(2, 3);
+    table.set_column_widths(&[2000, 3000, 1000]).unwrap();
+    assert_eq!(table.get_column_widths(), vec![2000, 3000, 1000]);
+    // 모든 col_span==1 셀이 자기 열 폭으로 설정된다.
+    for cell in &table.cells {
+        let expected = [2000u32, 3000, 1000][cell.col as usize];
+        assert_eq!(cell.width, expected, "col {} 셀 폭", cell.col);
+    }
+}
+
+#[test]
+fn test_set_column_widths_merged_cell() {
+    let mut table = make_table(2, 3);
+    // (0,0) 셀을 col_span=2로 병합하고 병합된 (1,0) 셀 제거
+    table.cells[0].col_span = 2;
+    table.cells[0].width = 7200;
+    table.cells.retain(|c| !(c.col == 1 && c.row == 0));
+    table.rebuild_grid();
+
+    table.set_column_widths(&[2000, 3000, 1000]).unwrap();
+
+    // 병합 셀(col0, span2)은 걸친 두 열 폭의 합(2000+3000)이 된다.
+    let merged = table
+        .cells
+        .iter()
+        .find(|c| c.col == 0 && c.row == 0 && c.col_span == 2)
+        .unwrap();
+    assert_eq!(merged.width, 5000);
+    // 열 폭은 col_span==1 셀(행 1) 기준으로 정확히 반영된다.
+    assert_eq!(table.get_column_widths(), vec![2000, 3000, 1000]);
+}
+
+#[test]
+fn test_set_column_widths_wrong_len() {
+    let mut table = make_table(2, 3);
+    assert!(table.set_column_widths(&[1000, 2000]).is_err());
+}
+
 // === merge_cells 테스트 ===
 
 #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4846,6 +4846,52 @@ fn parse_form_object(
                 form.properties
                     .insert("Command".to_string(), attr_str(&attr));
             }
+            // 버튼류 전용 속성 (라운드트립 보존; writer 가 동일 키로 읽음)
+            b"radioGroupName" => {
+                form.properties
+                    .insert("RadioGroupName".to_string(), attr_str(&attr));
+            }
+            b"triState" => {
+                form.properties
+                    .insert("TriState".to_string(), attr_str(&attr));
+            }
+            b"backStyle" => {
+                form.properties
+                    .insert("BackStyle".to_string(), attr_str(&attr));
+            }
+            // Edit 전용 속성 (라운드트립 보존)
+            b"multiLine" => {
+                form.properties
+                    .insert("MultiLine".to_string(), attr_str(&attr));
+            }
+            b"passwordChar" => {
+                form.properties
+                    .insert("PasswordChar".to_string(), attr_str(&attr));
+            }
+            b"maxLength" => {
+                form.properties
+                    .insert("MaxLength".to_string(), attr_str(&attr));
+            }
+            b"scrollBars" => {
+                form.properties
+                    .insert("ScrollBars".to_string(), attr_str(&attr));
+            }
+            b"tabKeyBehavior" => {
+                form.properties
+                    .insert("TabKeyBehavior".to_string(), attr_str(&attr));
+            }
+            b"numOnly" => {
+                form.properties
+                    .insert("Number".to_string(), attr_str(&attr));
+            }
+            b"readOnly" => {
+                form.properties
+                    .insert("ReadOnly".to_string(), attr_str(&attr));
+            }
+            b"alignText" => {
+                form.properties
+                    .insert("AlignText".to_string(), attr_str(&attr));
+            }
             _ => {}
         }
     }
@@ -4853,7 +4899,8 @@ fn parse_form_object(
     // 자식 요소 순회
     let end_tag = local_name(e.name().as_ref()).to_vec();
     let mut buf = Vec::new();
-    let mut list_items: Vec<String> = Vec::new();
+    // (value, displayText) 쌍으로 보존 — comboBox 항목
+    let mut list_items: Vec<(String, String)> = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -4891,22 +4938,72 @@ fn parse_form_object(
                 let local = local_name(cname.as_ref());
                 match local {
                     b"sz" => {
-                        // <hp:sz width="..." height="..."/>
+                        // <hp:sz width="..." widthRelTo="..." height="..." heightRelTo="..." protect="..."/>
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
                                 b"width" => form.width = parse_u32(&attr),
                                 b"height" => form.height = parse_u32(&attr),
+                                b"widthRelTo" => {
+                                    form.properties
+                                        .insert("SzWidthRelTo".to_string(), attr_str(&attr));
+                                }
+                                b"heightRelTo" => {
+                                    form.properties
+                                        .insert("SzHeightRelTo".to_string(), attr_str(&attr));
+                                }
+                                b"protect" => {
+                                    form.properties
+                                        .insert("SzProtect".to_string(), attr_str(&attr));
+                                }
                                 _ => {}
                             }
                         }
                     }
-                    b"listItem" => {
-                        // <hp:listItem value="..."/> (comboBox 항목)
+                    b"pos" => {
+                        // <hp:pos .../> 앵커링 (표준 ShapePositionType 11속성) — 라운드트립 보존
                         for attr in ce.attributes().flatten() {
-                            if attr.key.as_ref() == b"value" {
-                                list_items.push(attr_str(&attr));
+                            let key = match attr.key.as_ref() {
+                                b"treatAsChar" => "PosTreatAsChar",
+                                b"affectLSpacing" => "PosAffectLSpacing",
+                                b"flowWithText" => "PosFlowWithText",
+                                b"allowOverlap" => "PosAllowOverlap",
+                                b"holdAnchorAndSO" => "PosHoldAnchorAndSO",
+                                b"vertRelTo" => "PosVertRelTo",
+                                b"horzRelTo" => "PosHorzRelTo",
+                                b"vertAlign" => "PosVertAlign",
+                                b"horzAlign" => "PosHorzAlign",
+                                b"vertOffset" => "PosVertOffset",
+                                b"horzOffset" => "PosHorzOffset",
+                                _ => continue,
+                            };
+                            form.properties.insert(key.to_string(), attr_str(&attr));
+                        }
+                    }
+                    b"outMargin" => {
+                        // <hp:outMargin left=".." right=".." top=".." bottom=".."/> — 라운드트립 보존
+                        for attr in ce.attributes().flatten() {
+                            let key = match attr.key.as_ref() {
+                                b"left" => "OutMarginLeft",
+                                b"right" => "OutMarginRight",
+                                b"top" => "OutMarginTop",
+                                b"bottom" => "OutMarginBottom",
+                                _ => continue,
+                            };
+                            form.properties.insert(key.to_string(), attr_str(&attr));
+                        }
+                    }
+                    b"listItem" => {
+                        // <hp:listItem displayText="..." value="..."/> (comboBox 항목)
+                        let mut value = String::new();
+                        let mut display = String::new();
+                        for attr in ce.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"value" => value = attr_str(&attr),
+                                b"displayText" => display = attr_str(&attr),
+                                _ => {}
                             }
                         }
+                        list_items.push((value, display));
                     }
                     b"formCharPr" => {
                         // <hp:formCharPr charPrIDRef="0" followContext="0" autoSz="1" wordWrap="0"/>
@@ -4948,11 +5045,13 @@ fn parse_form_object(
         buf.clear();
     }
 
-    // comboBox 항목 목록을 properties에 저장
+    // comboBox 항목 목록(값 + 표시 텍스트)을 properties에 저장
     if !list_items.is_empty() {
-        for (i, item) in list_items.iter().enumerate() {
+        for (i, (value, display)) in list_items.iter().enumerate() {
             form.properties
-                .insert(format!("listItem{}", i), item.clone());
+                .insert(format!("listItem{}", i), value.clone());
+            form.properties
+                .insert(format!("listItemDisplay{}", i), display.clone());
         }
     }
 

--- a/src/serializer/hwpx/form.rs
+++ b/src/serializer/hwpx/form.rs
@@ -7,26 +7,29 @@
 //!
 //! ## 보존 범위
 //!
-//! 파서가 읽어 모델에 보존하는 값은 모두 충실히 재현한다:
+//! 파서가 읽어 모델에 보존하는 값은 모두 충실히 재현한다. 스칼라 필드:
 //! - 요소명(폼 타입), `name`, `caption`(버튼류), `value`(체크 상태), `selectedValue`/
-//!   `<hp:text>`(콤보/에디트 텍스트), `<hp:listItem>`(콤보 항목), `foreColor`/`backColor`,
-//!   `<hp:sz>` 폭·높이, `enabled`, 그리고 `properties` 에 보존된 공통 속성
-//!   (`GroupName`/`TabStop`/`Editable`/`TabOrder`/`BorderType`/`DrawFrame`/`Printable`/
-//!   `Command`/`ListBoxRows`/`ListBoxWidth`/`EditEnable`/`CharShapeID`/`FollowContext`/
-//!   `AutoSize`/`WordWrap`).
+//!   `<hp:text>`(콤보/에디트 텍스트), `foreColor`/`backColor`, `<hp:sz>` 폭·높이, `enabled`.
 //!
-//! ## 알려진 손실 (파서가 읽지 않아 모델에 없는 값 → 기본값으로 출력)
+//! `properties` 에 키-값으로 보존되어 round-trip 하는 속성:
+//! - 공통: `GroupName`/`TabStop`/`Editable`/`TabOrder`/`BorderType`/`DrawFrame`/`Printable`/
+//!   `Command`/`CharShapeID`/`FollowContext`/`AutoSize`/`WordWrap`
+//! - 버튼류: `RadioGroupName`/`TriState`/`BackStyle`
+//! - 콤보: `ListBoxRows`/`ListBoxWidth`/`EditEnable`, 항목 `listItem{N}`+`listItemDisplay{N}`
+//! - 에디트: `MultiLine`/`PasswordChar`/`MaxLength`/`ScrollBars`/`TabKeyBehavior`/`Number`/
+//!   `ReadOnly`/`AlignText`
+//! - `<hp:sz>`: `SzWidthRelTo`/`SzHeightRelTo`/`SzProtect`
+//! - `<hp:pos>`(앵커링 11속성): `PosTreatAsChar`/`PosAffectLSpacing`/`PosFlowWithText`/
+//!   `PosAllowOverlap`/`PosHoldAnchorAndSO`/`PosVertRelTo`/`PosHorzRelTo`/`PosVertAlign`/
+//!   `PosHorzAlign`/`PosVertOffset`/`PosHorzOffset`
+//! - `<hp:outMargin>`: `OutMarginLeft`/`OutMarginRight`/`OutMarginTop`/`OutMarginBottom`
 //!
-//! 파서(`parse_form_object`)가 읽지 않는 다음 속성은 라운드트립되지 않고 한컴 기본값으로
-//! 출력된다. 모두 폼의 표시/동작 세부일 뿐 사용자 콘텐츠가 아니며, 샘플 문서가 쓰는 값과
-//! 일치한다. 라운드트립 충실도를 더 높이려면 파서가 이들을 `properties` 에 보존하도록
-//! 확장해야 한다(후속 과제):
-//! - `<hp:pos>`(앵커링; treatAsChar=1 인라인 기본), `<hp:outMargin>`(0 기본)
-//! - 버튼류 `backStyle`/`triState`/`radioGroupName`
-//! - `<hp:sz>` 의 `widthRelTo`/`heightRelTo`/`protect`
-//! - `<hp:listItem>` 의 `displayText`
-//! - `edit` 전용 `multiLine`/`passwordChar`/`maxLength`/`scrollBars`/`tabKeyBehavior`/
-//!   `numOnly`/`readOnly`/`alignText`
+//! 위 키가 `properties` 에 없으면(예: 새로 생성한 폼) 각 속성은 한컴 기본값으로 출력된다.
+//!
+//! ## 알려진 손실
+//!
+//! 위에 열거한 표준 스키마 속성만 보존한다. `parse_form_object` 가 디스패치/열거하지 않는
+//! 비표준·확장 속성(있다면)은 모델에 들어오지 않아 출력 시 누락된다.
 
 use std::io::Write;
 
@@ -149,8 +152,14 @@ pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), 
 
     match form.form_type {
         FormType::ComboBox => {
-            for item in combo_items(form) {
-                empty_tag(w, "hp:listItem", &[("displayText", ""), ("value", item)])?;
+            for (i, item) in combo_items(form).into_iter().enumerate() {
+                let display_key = format!("listItemDisplay{}", i);
+                let display = prop(form, &display_key, "");
+                empty_tag(
+                    w,
+                    "hp:listItem",
+                    &[("displayText", display), ("value", item)],
+                )?;
             }
         }
         FormType::Edit => {
@@ -171,36 +180,42 @@ pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), 
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", prop(form, "SzWidthRelTo", "ABSOLUTE")),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", prop(form, "SzHeightRelTo", "ABSOLUTE")),
+            ("protect", prop(form, "SzProtect", "0")),
         ],
     )?;
 
-    // <hp:pos> — 인라인(treatAsChar=1) 기본. 파서가 pos 를 읽지 않으므로 모델에 없다.
+    // <hp:pos> — 파서가 보존한 앵커링 값(`Pos*`)을 그대로 출력. 없으면 인라인
+    // (treatAsChar=1) 기본값으로 떨어진다.
     empty_tag(
         w,
         "hp:pos",
         &[
-            ("treatAsChar", "1"),
-            ("affectLSpacing", "0"),
-            ("flowWithText", "1"),
-            ("allowOverlap", "1"),
-            ("holdAnchorAndSO", "0"),
-            ("vertRelTo", "PARA"),
-            ("horzRelTo", "COLUMN"),
-            ("vertAlign", "TOP"),
-            ("horzAlign", "LEFT"),
-            ("vertOffset", "0"),
-            ("horzOffset", "0"),
+            ("treatAsChar", prop(form, "PosTreatAsChar", "1")),
+            ("affectLSpacing", prop(form, "PosAffectLSpacing", "0")),
+            ("flowWithText", prop(form, "PosFlowWithText", "1")),
+            ("allowOverlap", prop(form, "PosAllowOverlap", "1")),
+            ("holdAnchorAndSO", prop(form, "PosHoldAnchorAndSO", "0")),
+            ("vertRelTo", prop(form, "PosVertRelTo", "PARA")),
+            ("horzRelTo", prop(form, "PosHorzRelTo", "COLUMN")),
+            ("vertAlign", prop(form, "PosVertAlign", "TOP")),
+            ("horzAlign", prop(form, "PosHorzAlign", "LEFT")),
+            ("vertOffset", prop(form, "PosVertOffset", "0")),
+            ("horzOffset", prop(form, "PosHorzOffset", "0")),
         ],
     )?;
 
     empty_tag(
         w,
         "hp:outMargin",
-        &[("left", "0"), ("right", "0"), ("top", "0"), ("bottom", "0")],
+        &[
+            ("left", prop(form, "OutMarginLeft", "0")),
+            ("right", prop(form, "OutMarginRight", "0")),
+            ("top", prop(form, "OutMarginTop", "0")),
+            ("bottom", prop(form, "OutMarginBottom", "0")),
+        ],
     )?;
 
     end_tag(w, tag)?;
@@ -281,5 +296,35 @@ mod tests {
         let xml = to_string(|w| write_form(w, &form));
         assert!(xml.starts_with("<hp:edit"), "{xml}");
         assert!(xml.contains("<hp:text>입력값</hp:text>"), "{xml}");
+    }
+
+    #[test]
+    fn nondefault_pos_outmargin_sz_listdisplay_are_emitted_from_props() {
+        // 파서가 보존한 비기본값(`Pos*`/`OutMargin*`/`Sz*`/`listItemDisplay*`)이
+        // 하드코딩 기본이 아니라 properties 에서 출력되는지 확인.
+        let mut props = HashMap::new();
+        props.insert("PosVertOffset".to_string(), "1234".to_string());
+        props.insert("PosVertRelTo".to_string(), "PAPER".to_string());
+        props.insert("OutMarginLeft".to_string(), "283".to_string());
+        props.insert("SzWidthRelTo".to_string(), "RELATIVE".to_string());
+        props.insert("SzProtect".to_string(), "1".to_string());
+        props.insert("listItem0".to_string(), "v0".to_string());
+        props.insert("listItemDisplay0".to_string(), "표시0".to_string());
+        let form = FormObject {
+            form_type: FormType::ComboBox,
+            name: "ComboBox".to_string(),
+            properties: props,
+            ..Default::default()
+        };
+        let xml = to_string(|w| write_form(w, &form));
+        assert!(xml.contains(r#"vertOffset="1234""#), "{xml}");
+        assert!(xml.contains(r#"vertRelTo="PAPER""#), "{xml}");
+        assert!(xml.contains(r#"left="283""#), "{xml}");
+        assert!(xml.contains(r#"widthRelTo="RELATIVE""#), "{xml}");
+        assert!(xml.contains(r#"protect="1""#), "{xml}");
+        assert!(
+            xml.contains(r#"<hp:listItem displayText="표시0" value="v0"/>"#),
+            "{xml}"
+        );
     }
 }

--- a/src/serializer/hwpx/form.rs
+++ b/src/serializer/hwpx/form.rs
@@ -1,0 +1,285 @@
+//! 양식 개체(FormObject) 직렬화 — `<hp:btn>` / `<hp:checkBtn>` / `<hp:radioBtn>` /
+//! `<hp:comboBox>` / `<hp:edit>`.
+//!
+//! `parser::hwpx::section::parse_form_object` 의 역방향이다. 폼 컨트롤은 `<hp:run>` 의
+//! 직접 자식으로 위치하므로 (Table/Picture 와 동일, Field 처럼 `<hp:ctrl>` 로 감싸지 않음)
+//! `render_control_slot` 에서 이 결과를 그대로 run 안에 출력한다.
+//!
+//! ## 보존 범위
+//!
+//! 파서가 읽어 모델에 보존하는 값은 모두 충실히 재현한다:
+//! - 요소명(폼 타입), `name`, `caption`(버튼류), `value`(체크 상태), `selectedValue`/
+//!   `<hp:text>`(콤보/에디트 텍스트), `<hp:listItem>`(콤보 항목), `foreColor`/`backColor`,
+//!   `<hp:sz>` 폭·높이, `enabled`, 그리고 `properties` 에 보존된 공통 속성
+//!   (`GroupName`/`TabStop`/`Editable`/`TabOrder`/`BorderType`/`DrawFrame`/`Printable`/
+//!   `Command`/`ListBoxRows`/`ListBoxWidth`/`EditEnable`/`CharShapeID`/`FollowContext`/
+//!   `AutoSize`/`WordWrap`).
+//!
+//! ## 알려진 손실 (파서가 읽지 않아 모델에 없는 값 → 기본값으로 출력)
+//!
+//! 파서(`parse_form_object`)가 읽지 않는 다음 속성은 라운드트립되지 않고 한컴 기본값으로
+//! 출력된다. 모두 폼의 표시/동작 세부일 뿐 사용자 콘텐츠가 아니며, 샘플 문서가 쓰는 값과
+//! 일치한다. 라운드트립 충실도를 더 높이려면 파서가 이들을 `properties` 에 보존하도록
+//! 확장해야 한다(후속 과제):
+//! - `<hp:pos>`(앵커링; treatAsChar=1 인라인 기본), `<hp:outMargin>`(0 기본)
+//! - 버튼류 `backStyle`/`triState`/`radioGroupName`
+//! - `<hp:sz>` 의 `widthRelTo`/`heightRelTo`/`protect`
+//! - `<hp:listItem>` 의 `displayText`
+//! - `edit` 전용 `multiLine`/`passwordChar`/`maxLength`/`scrollBars`/`tabKeyBehavior`/
+//!   `numOnly`/`readOnly`/`alignText`
+
+use std::io::Write;
+
+use quick_xml::Writer;
+
+use crate::model::control::{FormObject, FormType};
+
+use super::utils::{empty_tag, end_tag, start_tag_attrs, text};
+use super::SerializeError;
+
+/// 폼 타입 → HWPX 요소명 (parser 디스패치와 정확히 일치해야 함).
+fn form_tag(form_type: FormType) -> &'static str {
+    match form_type {
+        FormType::PushButton => "hp:btn",
+        FormType::CheckBox => "hp:checkBtn",
+        FormType::RadioButton => "hp:radioBtn",
+        FormType::ComboBox => "hp:comboBox",
+        FormType::Edit => "hp:edit",
+    }
+}
+
+/// 모델 색(`0x00BBGGRR`) → HWPX `#RRGGBB`. `parse_color_str` 의 역방향.
+fn color_to_hex(color: u32) -> String {
+    let r = color & 0xFF;
+    let g = (color >> 8) & 0xFF;
+    let b = (color >> 16) & 0xFF;
+    format!("#{:02X}{:02X}{:02X}", r, g, b)
+}
+
+fn prop<'a>(form: &'a FormObject, key: &str, default: &'a str) -> &'a str {
+    form.properties
+        .get(key)
+        .map(|s| s.as_str())
+        .unwrap_or(default)
+}
+
+/// 콤보박스 항목(`properties["listItem0"]`, `"listItem1"`, …)을 순서대로 수집한다.
+fn combo_items(form: &FormObject) -> Vec<&str> {
+    let mut items = Vec::new();
+    let mut i = 0;
+    while let Some(v) = form.properties.get(&format!("listItem{}", i)) {
+        items.push(v.as_str());
+        i += 1;
+    }
+    items
+}
+
+/// `<hp:btn>` / `<hp:checkBtn>` / `<hp:radioBtn>` / `<hp:comboBox>` / `<hp:edit>` 를 출력한다.
+pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), SerializeError> {
+    let tag = form_tag(form.form_type);
+    let fore = color_to_hex(form.fore_color);
+    let back = color_to_hex(form.back_color);
+    let enabled = if form.enabled { "1" } else { "0" };
+    let checked = if form.value == 1 {
+        "CHECKED"
+    } else {
+        "UNCHECKED"
+    };
+
+    // 공통 속성 (모든 폼 타입). 순서는 한컴 산출물을 따른다.
+    let mut attrs: Vec<(&str, &str)> = Vec::new();
+
+    // 타입별 선두 속성
+    match form.form_type {
+        FormType::PushButton | FormType::CheckBox | FormType::RadioButton => {
+            attrs.push(("caption", &form.caption));
+            attrs.push(("value", checked));
+            attrs.push(("radioGroupName", prop(form, "RadioGroupName", "")));
+            attrs.push(("triState", prop(form, "TriState", "0")));
+            attrs.push(("backStyle", prop(form, "BackStyle", "OPAQUE")));
+        }
+        FormType::ComboBox => {
+            attrs.push(("listBoxRows", prop(form, "ListBoxRows", "4")));
+            attrs.push(("listBoxWidth", prop(form, "ListBoxWidth", "0")));
+            attrs.push(("editEnable", prop(form, "EditEnable", "1")));
+            attrs.push(("selectedValue", &form.text));
+        }
+        FormType::Edit => {
+            attrs.push(("multiLine", prop(form, "MultiLine", "0")));
+            attrs.push(("passwordChar", prop(form, "PasswordChar", "")));
+            attrs.push(("maxLength", prop(form, "MaxLength", "2147483647")));
+            attrs.push(("scrollBars", prop(form, "ScrollBars", "NONE")));
+            attrs.push((
+                "tabKeyBehavior",
+                prop(form, "TabKeyBehavior", "NEXT_OBJECT"),
+            ));
+            attrs.push(("numOnly", prop(form, "Number", "0")));
+            attrs.push(("readOnly", prop(form, "ReadOnly", "0")));
+            attrs.push(("alignText", prop(form, "AlignText", "LEFT")));
+        }
+    }
+
+    // 공통 속성 (AbstractFormObjectType)
+    attrs.push(("name", &form.name));
+    attrs.push(("foreColor", &fore));
+    attrs.push(("backColor", &back));
+    attrs.push(("groupName", prop(form, "GroupName", "")));
+    attrs.push(("tabStop", prop(form, "TabStop", "1")));
+    attrs.push(("editable", prop(form, "Editable", "1")));
+    attrs.push(("tabOrder", prop(form, "TabOrder", "0")));
+    attrs.push(("enabled", enabled));
+    attrs.push(("borderTypeIDRef", prop(form, "BorderType", "0")));
+    attrs.push(("drawFrame", prop(form, "DrawFrame", "1")));
+    attrs.push(("printable", prop(form, "Printable", "1")));
+    attrs.push(("command", prop(form, "Command", "")));
+
+    start_tag_attrs(w, tag, &attrs)?;
+
+    // 자식: formCharPr → (listItem*/text) → sz → pos → outMargin (한컴 순서)
+    empty_tag(
+        w,
+        "hp:formCharPr",
+        &[
+            ("charPrIDRef", prop(form, "CharShapeID", "0")),
+            ("followContext", prop(form, "FollowContext", "0")),
+            ("autoSz", prop(form, "AutoSize", "0")),
+            ("wordWrap", prop(form, "WordWrap", "0")),
+        ],
+    )?;
+
+    match form.form_type {
+        FormType::ComboBox => {
+            for item in combo_items(form) {
+                empty_tag(w, "hp:listItem", &[("displayText", ""), ("value", item)])?;
+            }
+        }
+        FormType::Edit => {
+            // 항상 <hp:text> 자식을 둔다 (비어 있어도). 파서가 텍스트 내용을 여기서 읽는다.
+            start_tag_attrs(w, "hp:text", &[])?;
+            if !form.text.is_empty() {
+                text(w, &form.text)?;
+            }
+            end_tag(w, "hp:text")?;
+        }
+        _ => {}
+    }
+
+    let width = form.width.to_string();
+    let height = form.height.to_string();
+    empty_tag(
+        w,
+        "hp:sz",
+        &[
+            ("width", &width),
+            ("widthRelTo", "ABSOLUTE"),
+            ("height", &height),
+            ("heightRelTo", "ABSOLUTE"),
+            ("protect", "0"),
+        ],
+    )?;
+
+    // <hp:pos> — 인라인(treatAsChar=1) 기본. 파서가 pos 를 읽지 않으므로 모델에 없다.
+    empty_tag(
+        w,
+        "hp:pos",
+        &[
+            ("treatAsChar", "1"),
+            ("affectLSpacing", "0"),
+            ("flowWithText", "1"),
+            ("allowOverlap", "1"),
+            ("holdAnchorAndSO", "0"),
+            ("vertRelTo", "PARA"),
+            ("horzRelTo", "COLUMN"),
+            ("vertAlign", "TOP"),
+            ("horzAlign", "LEFT"),
+            ("vertOffset", "0"),
+            ("horzOffset", "0"),
+        ],
+    )?;
+
+    empty_tag(
+        w,
+        "hp:outMargin",
+        &[("left", "0"), ("right", "0"), ("top", "0"), ("bottom", "0")],
+    )?;
+
+    end_tag(w, tag)?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::collections::HashMap;
+
+    fn to_string<F: FnOnce(&mut Writer<Vec<u8>>) -> Result<(), SerializeError>>(f: F) -> String {
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        f(&mut w).expect("write");
+        String::from_utf8(w.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn color_inverts_parse_color_str() {
+        // parse_color_str("#1A2B3C") = 0x003C2B1A. 역변환은 "#1A2B3C".
+        assert_eq!(color_to_hex(0x003C2B1A), "#1A2B3C");
+        assert_eq!(color_to_hex(0x00F0F0F0), "#F0F0F0");
+    }
+
+    #[test]
+    fn checkbox_emits_checked_value_and_caption() {
+        let form = FormObject {
+            form_type: FormType::CheckBox,
+            name: "CheckBox".to_string(),
+            caption: "선택 상자".to_string(),
+            value: 1,
+            enabled: true,
+            ..Default::default()
+        };
+        let xml = to_string(|w| write_form(w, &form));
+        assert!(xml.starts_with("<hp:checkBtn"), "{xml}");
+        assert!(xml.contains(r#"caption="선택 상자""#), "{xml}");
+        assert!(xml.contains(r#"value="CHECKED""#), "{xml}");
+        assert!(xml.contains(r#"name="CheckBox""#), "{xml}");
+        assert!(xml.contains("</hp:checkBtn>"), "{xml}");
+    }
+
+    #[test]
+    fn combobox_emits_list_items_and_selected_value() {
+        let mut props = HashMap::new();
+        props.insert("listItem0".to_string(), "계절 선택".to_string());
+        props.insert("listItem1".to_string(), "봄".to_string());
+        let form = FormObject {
+            form_type: FormType::ComboBox,
+            name: "ComboBox".to_string(),
+            text: "봄".to_string(),
+            enabled: true,
+            properties: props,
+            ..Default::default()
+        };
+        let xml = to_string(|w| write_form(w, &form));
+        assert!(xml.starts_with("<hp:comboBox"), "{xml}");
+        assert!(xml.contains(r#"selectedValue="봄""#), "{xml}");
+        assert!(
+            xml.contains(r#"<hp:listItem displayText="" value="계절 선택"/>"#),
+            "{xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:listItem displayText="" value="봄"/>"#),
+            "{xml}"
+        );
+    }
+
+    #[test]
+    fn edit_emits_text_child() {
+        let form = FormObject {
+            form_type: FormType::Edit,
+            name: "Edit".to_string(),
+            text: "입력값".to_string(),
+            enabled: true,
+            ..Default::default()
+        };
+        let xml = to_string(|w| write_form(w, &form));
+        assert!(xml.starts_with("<hp:edit"), "{xml}");
+        assert!(xml.contains("<hp:text>입력값</hp:text>"), "{xml}");
+    }
+}

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -13,6 +13,7 @@ pub mod content;
 pub mod context;
 pub mod field;
 pub mod fixtures;
+pub mod form;
 pub mod header;
 pub mod picture;
 pub mod roundtrip;

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -432,6 +432,11 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                 Err(e) => eprintln!("[hwpx] Field 직렬화 실패: {e}"),
             }
         }
+        Control::Form(form) => match writer_to_string(|w| super::form::write_form(w, form)) {
+            // 폼은 <hp:run> 직접 자식 (Table/Picture와 동일, <hp:ctrl> 비포장)
+            Ok(xml) => out.push_str(&xml),
+            Err(e) => eprintln!("[hwpx] Form 직렬화 실패: {e}"),
+        },
         _ => {}
     }
 }

--- a/tests/hwpx_form_roundtrip.rs
+++ b/tests/hwpx_form_roundtrip.rs
@@ -5,15 +5,17 @@
 //! (5개 폼: btn/checkBtn/radioBtn/comboBox/edit 각 1개)를 열어 저장·재파싱한 뒤
 //! 폼 개수와 파서가 보존하는 핵심 필드가 유지되는지 단언한다.
 
-use std::collections::HashMap;
+use std::collections::{BTreeMap, HashMap};
 
 use rhwp::document_core::DocumentCore;
 use rhwp::model::control::{Control, FormObject, FormType};
 use rhwp::model::document::Document;
 use rhwp::model::paragraph::Paragraph;
 
-/// 폼의 라운드트립 비교용 정규화 투영. 파서가 모델에 보존하는 값만 담는다.
-/// `FormType` 이 `Eq` 를 파생하지 않으므로 `PartialEq` 만 둔다.
+/// 폼의 라운드트립 비교용 정규화 투영. 파서가 모델에 보존하는 값을 전부 담는다.
+/// `properties` 전체를 비교하므로 Tier A(`BackStyle` 등) + Tier B(`Pos*`/`OutMargin*`/
+/// `Sz*`/`listItemDisplay*`) 보존이 그대로 단언된다. `FormType` 이 `Eq` 를 파생하지
+/// 않으므로 `PartialEq` 만 둔다. `properties` 는 정렬해 실패 시 diff 가독성을 높인다.
 #[derive(Debug, PartialEq)]
 struct FormProjection {
     form_type: FormType,
@@ -26,17 +28,11 @@ struct FormProjection {
     height: u32,
     fore_color: u32,
     back_color: u32,
-    list_items: Vec<String>,
+    properties: BTreeMap<String, String>,
 }
 
 impl FormProjection {
     fn from(form: &FormObject) -> Self {
-        let mut list_items = Vec::new();
-        let mut i = 0;
-        while let Some(v) = form.properties.get(&format!("listItem{}", i)) {
-            list_items.push(v.clone());
-            i += 1;
-        }
         FormProjection {
             form_type: form.form_type,
             name: form.name.clone(),
@@ -48,7 +44,11 @@ impl FormProjection {
             height: form.height,
             fore_color: form.fore_color,
             back_color: form.back_color,
-            list_items,
+            properties: form
+                .properties
+                .iter()
+                .map(|(k, v)| (k.clone(), v.clone()))
+                .collect(),
         }
     }
 }
@@ -104,19 +104,33 @@ fn form_objects_survive_hwpx_roundtrip() {
         assert!(types.contains(&t), "원본에 {:?} 폼 없음: {:?}", t, types);
     }
 
+    let original_len = original.len();
+
+    // 샘플 전제: PushButton 의 backStyle 은 비기본값(TRANSPARENT, writer 기본은 OPAQUE).
+    // 이 값이 round-trip 후에도 살아야 Tier A 보존이 의미 있게 검증된다 — 전부 기본값이면
+    // "보존했다"와 "버리고 기본값 냈다"가 구분되지 않는다.
+    let before_map = by_name(original);
+    assert_eq!(
+        before_map["PushButton"]
+            .properties
+            .get("BackStyle")
+            .map(String::as_str),
+        Some("TRANSPARENT"),
+        "원본 PushButton backStyle 이 비기본값(TRANSPARENT)이어야 라운드트립 검증이 의미 있다"
+    );
+
     let saved = core.export_hwpx_native().expect("HWPX 직렬화 실패");
     let reloaded = DocumentCore::from_bytes(&saved).expect("저장본 재파싱 실패");
     let after = collect_forms(reloaded.document());
 
     assert_eq!(
         after.len(),
-        original.len(),
+        original_len,
         "라운드트립 후 폼 개수 불일치: 원본 {} → 저장본 {}",
-        original.len(),
+        original_len,
         after.len()
     );
 
-    let before_map = by_name(original);
     let after_map = by_name(after);
     for (name, before) in &before_map {
         let after = after_map

--- a/tests/hwpx_form_roundtrip.rs
+++ b/tests/hwpx_form_roundtrip.rs
@@ -1,0 +1,127 @@
+//! 양식 개체(FormObject) HWPX 라운드트립 통합 테스트.
+//!
+//! `serializer::hwpx::form::write_form` 가 추가되기 전에는 `export_hwpx_native` 가
+//! 양식 개체를 전부 누락시켰다(5개 → 0개). 이 테스트는 `samples/hwpx/form-01.hwpx`
+//! (5개 폼: btn/checkBtn/radioBtn/comboBox/edit 각 1개)를 열어 저장·재파싱한 뒤
+//! 폼 개수와 파서가 보존하는 핵심 필드가 유지되는지 단언한다.
+
+use std::collections::HashMap;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::{Control, FormObject, FormType};
+use rhwp::model::document::Document;
+use rhwp::model::paragraph::Paragraph;
+
+/// 폼의 라운드트립 비교용 정규화 투영. 파서가 모델에 보존하는 값만 담는다.
+/// `FormType` 이 `Eq` 를 파생하지 않으므로 `PartialEq` 만 둔다.
+#[derive(Debug, PartialEq)]
+struct FormProjection {
+    form_type: FormType,
+    name: String,
+    caption: String,
+    text: String,
+    value: i32,
+    enabled: bool,
+    width: u32,
+    height: u32,
+    fore_color: u32,
+    back_color: u32,
+    list_items: Vec<String>,
+}
+
+impl FormProjection {
+    fn from(form: &FormObject) -> Self {
+        let mut list_items = Vec::new();
+        let mut i = 0;
+        while let Some(v) = form.properties.get(&format!("listItem{}", i)) {
+            list_items.push(v.clone());
+            i += 1;
+        }
+        FormProjection {
+            form_type: form.form_type,
+            name: form.name.clone(),
+            caption: form.caption.clone(),
+            text: form.text.clone(),
+            value: form.value,
+            enabled: form.enabled,
+            width: form.width,
+            height: form.height,
+            fore_color: form.fore_color,
+            back_color: form.back_color,
+            list_items,
+        }
+    }
+}
+
+/// 문단의 컨트롤(표 셀 내부 포함)을 재귀적으로 훑어 폼을 수집한다.
+fn collect_forms_in_paragraphs(paras: &[Paragraph], out: &mut Vec<FormProjection>) {
+    for para in paras {
+        for control in &para.controls {
+            match control {
+                Control::Form(form) => out.push(FormProjection::from(form)),
+                Control::Table(table) => {
+                    for cell in &table.cells {
+                        collect_forms_in_paragraphs(&cell.paragraphs, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+}
+
+fn collect_forms(doc: &Document) -> Vec<FormProjection> {
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        collect_forms_in_paragraphs(&section.paragraphs, &mut out);
+    }
+    out
+}
+
+/// 이름 → 투영 맵으로 정렬해 순서 무관 비교를 가능케 한다.
+fn by_name(forms: Vec<FormProjection>) -> HashMap<String, FormProjection> {
+    forms.into_iter().map(|f| (f.name.clone(), f)).collect()
+}
+
+#[test]
+fn form_objects_survive_hwpx_roundtrip() {
+    let bytes = std::fs::read("samples/hwpx/form-01.hwpx").expect("form-01.hwpx 로드 실패");
+
+    let core = DocumentCore::from_bytes(&bytes).expect("HWPX 파싱 실패");
+    let original = collect_forms(core.document());
+
+    // 샘플 전제: 5개 폼이 모든 타입을 한 번씩 덮는다. 0개로 떨어지면 비교가
+    // 무의미하게 통과하므로 원본 자체를 단언한다.
+    assert_eq!(original.len(), 5, "원본 폼 개수: {:?}", original);
+    let types: Vec<FormType> = original.iter().map(|f| f.form_type).collect();
+    for t in [
+        FormType::PushButton,
+        FormType::CheckBox,
+        FormType::RadioButton,
+        FormType::ComboBox,
+        FormType::Edit,
+    ] {
+        assert!(types.contains(&t), "원본에 {:?} 폼 없음: {:?}", t, types);
+    }
+
+    let saved = core.export_hwpx_native().expect("HWPX 직렬화 실패");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("저장본 재파싱 실패");
+    let after = collect_forms(reloaded.document());
+
+    assert_eq!(
+        after.len(),
+        original.len(),
+        "라운드트립 후 폼 개수 불일치: 원본 {} → 저장본 {}",
+        original.len(),
+        after.len()
+    );
+
+    let before_map = by_name(original);
+    let after_map = by_name(after);
+    for (name, before) in &before_map {
+        let after = after_map
+            .get(name)
+            .unwrap_or_else(|| panic!("저장본에서 폼 '{}' 소실", name));
+        assert_eq!(before, after, "폼 '{}' 필드 불일치", name);
+    }
+}


### PR DESCRIPTION
hangul-mcp(HWPX 편집 MCP)에서 필요한 rhwp 기능 세 가지를 추가했습니다.

- **양식 개체 writer** (`serializer/hwpx/form.rs`): `serialize_hwpx`가 폼(btn/checkBtn/radioBtn/comboBox/edit)을 모두 누락하던 문제를 해결했습니다. 저장 시 폼이 보존됩니다(이전에는 5개 → 0개로 사라졌습니다).
- **양식 개체 속성 round-trip**: 파서가 읽지 않던 표준 속성(backStyle / pos / outMargin / sz relTo / listItem displayText / edit 전용 속성)을 파서와 writer 양쪽에서 대칭으로 보존하도록 했습니다.
- **표 열 폭 제어**: `Table::set_column_widths`와 `set_table_column_widths_native` / `fit_table_to_page_native`(본문 폭에 맞춘 비례 축소, 축소 전용)를 추가했습니다.