### PR TITLE
fix(model): merge_from 컨트롤 병합 보강 — 글상자/표 셀 이미지 붙여넣기 무음 누락 수정 (#1323)

### DIFF
--- a/mydocs/plans/task_m100_1323.md
+++ b/mydocs/plans/task_m100_1323.md
@@ -1,0 +1,124 @@
+# 수행 계획서 — Task M100-1323: 글상자/표 셀 안 이미지(컨트롤) 붙여넣기 무음 누락 수정
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/1323
+- 제목: 글상자/표 셀 안 이미지(컨트롤) 붙여넣기가 조용히 누락 — merge_from 컨트롤 미병합·빈 텍스트 early-return
+- 작성일: 2026-06-10
+- 브랜치: `local/task1323`
+
+## 1. 문제 요약
+
+rhwp-studio에서 본문 이미지를 복사(Ctrl+C)해 글상자 또는 표 셀 안에 붙여넣으면(Ctrl+V)
+에러 없이 조용히 누락된다. 텍스트 붙여넣기는 정상(#1280에서 정상화)이며, 본 건은
+이미지(그림 컨트롤) 붙여넣기만의 별개 결함이다. 글상자와 표 셀 양쪽에서 동일하게 발생한다.
+
+## 2. 근본 원인 (코드 검증 완료)
+
+붙여넣기 경로: `paste_internal_in_cell_native`(`clipboard.rs:476`) →
+`paste_paragraphs_into_cell_paragraphs`(`clipboard.rs:428`) →
+`Paragraph::merge_from`(`paragraph.rs:716`).
+
+`copy_control_native`(`clipboard.rs:226`)는 그림을 `text="" + controls=[Picture]`
+문단으로 클립보드에 적재하는데, `merge_from`의 두 한계가 컨트롤을 드롭한다.
+
+1. **빈 텍스트 early-return** (`paragraph.rs:717-719`) — `other.text`가 비면 즉시
+   반환하여 아무것도 병합되지 않는다.
+2. **controls 미병합** — `merge_from` 본문(`paragraph.rs:716-805`)은
+   text/char_offsets/char_shapes/line_segs/range_tags/field_ranges/char_count만
+   결합하며, `other.controls`·`ctrl_data_records`·`control_mask`를 병합하는 코드가
+   없다. (L792 `ctrl_offset = self.controls.len()`은 field_ranges의 control_idx
+   보정용으로 self만 읽음 — `other.controls`는 함수 어디서도 읽지 않는다.)
+
+프론트 게이트(`input-handler-keyboard.ts:1450`)는 컨트롤 붙여넣기를 본문
+(`parentParaIndex === undefined`)에서만 `pasteControl`로 분기하므로, 셀/글상자 안에서는
+`pasteInternalInCell`로 떨어져 위 `merge_from` 경로를 탄다. 백엔드 수정으로 기존 라우팅이
+그대로 동작하므로 **프론트엔드 변경은 불필요 예상**이다.
+
+## 3. 호출처 전수 감사 — 동일 잠재 결함의 증거
+
+`merge_from`은 셀 붙여넣기 외에도 광범위하게 사용되며, 병합 대상(`other`)이 컨트롤을
+보유할 수 있는 경로에서 동일한 무음 소실이 잠재한다 (전 체인 가드 부재 코드 확인):
+
+| 호출처 | 시나리오 | 가드 |
+|---|---|---|
+| `clipboard.rs:462` | **본건** — 셀/글상자 이미지 paste | 없음 |
+| `text_editing.rs:1137` `merge_paragraph_native` | 본문 문단 시작 Backspace → 컨트롤 보유 문단 병합. 프론트 체인(`input-handler-text.ts:189-191` → `command.ts:322-327`)에도 가드 없음 | 없음 |
+| `text_editing.rs:1465/1471/1481` `merge_paragraph_in_cell_native`, `2442` by_path | 셀/글상자/캡션·중첩 셀 문단 시작 Backspace — `removed` 문단을 가드 없이 merge_from | 없음 |
+| `text_editing.rs:654/719` `delete_range` | 다중 문단 선택 삭제 시 마지막 문단을 첫 문단에 병합. `delete_text_at`은 controls를 건드리지 않으므로 선택 끝 이후의 컨트롤이 소실 | 없음 |
+| `footnote_ops.rs:653/664`, `header_footer_ops.rs:457` | 각주/미주/머리말/꼬리말 내 문단 병합 | 없음 |
+| `clipboard.rs:390` `paste_internal_native` | API 수준 잠재 결함. studio UI에서는 프론트 게이트(`clipboard_has_control_native`가 첫 문단만 검사)가 본문에선 pasteControl로 우회하여 도달 어려움. 셀에서는 우회가 없어 본건 발생 | 게이트가 우회 |
+
+**html_import는 잠재 결함 아님**: `html_import.rs:76-80`에 `has_controls` 검사 +
+"컨트롤 포함 문단은 merge 불가 → 직접 삽입" 주석으로 merge_from을 우회하는 분기가 이미
+존재한다. 셀 경로는 L191-211에서 표를 텍스트로 변환 후 `controls.clear()`. 이 우회 주석
+자체가 merge_from이 컨트롤을 병합하지 못함을 인지한 코드베이스 내 명시적 증거다.
+`object_ops.rs:8772-8774`의 "별개 결함" 주석도 동일.
+
+안전한 호출처(참고): right_half(split_at 산물, controls 없음)를 병합하는
+`clipboard.rs:404/471`, `html_import.rs:163/272`.
+
+## 4. 수정 방향 (작업지시자 확인 완료)
+
+이슈에 제시된 두 옵션 중 **(a) merge_from 보강**으로 진행한다 (작업지시자 선택).
+
+- `merge_from`이 텍스트가 비어도 컨트롤만 있는 문단을 처리하도록 early-return 조건을
+  `other.text.is_empty() && other.controls.is_empty()`로 수정.
+- `other.controls`/`ctrl_data_records`/`control_mask`를 self로 병합 (컨트롤 위치/오프셋
+  보정 포함: char_count 컨트롤당 8 code unit, char_offsets 갭 인코딩이
+  `control_text_positions()`의 갭 분석과 정합하도록 설계).
+- model 계층에서 근본 원인을 수정하므로 3절의 백스페이스 병합·선택 삭제 등 잠재 결함도
+  함께 해소된다.
+
+(b) paste 경로 분기는 클립보드 경로에만 한정되어 다른 경로의 컨트롤 드롭이 그대로
+남으므로 채택하지 않는다.
+
+## 5. 목표
+
+- 글상자/표 셀(중첩 셀 포함) 안 이미지 copy→paste 시 그림 컨트롤이 보존된다.
+- `ctrl_data_records`(CTRL_DATA)도 컨트롤과 정렬을 유지한 채 보존된다.
+- 본문 붙여넣기(텍스트·컨트롤)와 텍스트 붙여넣기는 무회귀.
+- 백스페이스 문단 병합 등 merge_from 경유 경로에서 컨트롤 보유 문단 병합 시 컨트롤 보존.
+
+## 6. 비목표
+
+- 셀 안 붙여넣기에 본문 `paste_control_native`의 cascade 오프셋(Task #1161) 도입.
+- 프론트 게이트(`clipboard_has_control_native` 첫 문단만 검사)의 다중 문단 클립보드
+  처리 개선 — 별도 이슈 영역.
+- html_import의 merge_from 우회 분기 단순화 — 수정 후 가능해지나 본 타스크 범위 밖.
+- HWP5/HWPX 직렬화 포맷 변경.
+
+## 7. 구현 단계 (구현계획서에서 상세화, 3단계)
+
+1. **Stage 1**: `merge_from` 컨트롤 병합 보강 (`src/model/paragraph.rs`) + 단위 테스트
+   (`src/model/paragraph/tests.rs`)
+2. **Stage 2**: 셀/글상자/캡션·중첩 셀 paste round-trip 통합 테스트 + 백스페이스 병합
+   컨트롤 보존 테스트 + `object_ops.rs:8772` 주석 갱신 + 필요 시 보정
+3. **Stage 3**: `cargo test` 전체 회귀 + `cargo clippy` + WASM 빌드 + rhwp-studio
+   시각 확인 + 최종 보고서
+
+## 8. 리스크
+
+- **char_count 의미론**: 기존 merge_from은 self.controls의 8 code unit도 미반영(잠재
+  버그). 수정 시 직렬화 등 소비처 영향을 구현계획서에서 상세 설계.
+- **떠 있는 개체(treat_as_char=false)**: 셀 문단에 anchor된 부동 그림의 렌더링은
+  Stage 3 시각 검증으로 확인.
+- **merge_from 동작 변화**: 컨트롤 보존은 올바른 방향이나 호출처가 광범위하므로 전체
+  테스트로 부작용 확인.
+
+## 9. 검증 계획
+
+자동 검증:
+
+- `cargo test` (paragraph 단위 + wasm_api/object_ops 통합 전체)
+- `cargo clippy`
+
+수동 검증:
+
+- `docker compose --env-file .env.docker run --rm wasm` 후 rhwp-studio에서
+  본문 이미지 복사 → 글상자/표 셀 붙여넣기 → 이미지 렌더 확인
+- 텍스트 붙여넣기(본문/셀/글상자) 무회귀 확인
+- 본문 이미지 붙여넣기(기존 pasteControl 경로) 무회귀 확인
+
+## 10. 승인 요청
+
+위 범위와 수정 방향으로 구현계획서 작성에 들어간다. 작업지시자 승인 후 다음 단계
+(구현계획서)를 진행한다.

--- a/mydocs/plans/task_m100_1323_impl.md
+++ b/mydocs/plans/task_m100_1323_impl.md
@@ -1,0 +1,157 @@
+# 구현 계획서 — Task M100-1323
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/1323
+- 수행계획서: `mydocs/plans/task_m100_1323.md`
+- 브랜치: `local/task1323`
+
+## 1. 구현 방향
+
+`Paragraph::merge_from`(`src/model/paragraph.rs:716`)을 model 계층에서 보강하여
+컨트롤 보유 문단 병합 시 `controls`/`ctrl_data_records`/`control_mask`를 보존한다.
+클립보드/편집 명령 계층(`document_core/commands/`)은 수정하지 않는다(라우팅은 기존
+그대로 동작). 프론트엔드도 수정하지 않는다.
+
+### 설계 근거 (직렬화·렌더링 계약)
+
+병합 후 문단이 올바르게 렌더링·직렬화되려면 다음 계약을 지켜야 한다 (코드 확인 완료):
+
+1. **컨트롤 위치 = char_offsets 갭**: 렌더링(`control_text_positions()`,
+   `paragraph.rs:856`)과 HWP5 직렬화(`serialize_para_text`, `body_text.rs:485`
+   `while prev_end + 8 <= offset`) 모두 인라인 컨트롤 위치를 char_offsets의
+   8 code unit 갭으로 복원한다. 텍스트 뒤(trailing) 컨트롤은 갭 없이 문단 끝에
+   배치된다(`body_text.rs:547`, `paragraph.rs:932` 폴백).
+2. **char_count는 컨트롤당 8 유닛 포함**: `split_at`은 이미
+   `split_pos + controls.len()*8 + 1`로 계산(`paragraph.rs:678-679`)하며, HWPX
+   직렬화는 `(char_count - 1 - text_units) / 8`로 컨트롤 수를 역산
+   (`serializer/hwpx/section.rs:379`). 현 merge_from은 컨트롤 유닛 미반영(잠재
+   불일치) — 본 수정에서 정합화한다.
+3. **ctrl_data_records[i] ↔ controls[i] 인덱스 정렬**: HWP5 직렬화가
+   `ctrl_data_records.get(ctrl_idx)`로 소비(`body_text.rs:282-288`). 길이가
+   짧으면 None 취급되므로, 병합 시 self 쪽을 None 패딩 후 other를 이어 붙여
+   정렬을 유지한다.
+4. **control_mask**: HWP5 직렬화는 재계산(`compute_control_mask`,
+   `body_text.rs:302`)하지만, `hwpx_to_hwp.rs:952` 등 model 소비처가 있으므로
+   OR 병합으로 일관성을 유지한다.
+
+### 병합 위치 의미론
+
+paste 흐름(`split_at(char_offset)` → left.merge_from(클립 문단) →
+last.merge_from(right_half))에서:
+
+- **1차 병합** (left + 컨트롤 문단): 컨트롤은 left 텍스트 끝의 trailing 컨트롤이
+  된다 (갭 인코딩 불필요 — 뒤따르는 텍스트가 없음).
+- **2차 병합** (위 결과 + right_half): `utf16_end` 계산이 **trailing 컨트롤의
+  8유닛을 포함**해야 right_half의 char_offsets가 컨트롤 갭 뒤로 이동되어, 갭
+  분석이 컨트롤을 병합 지점(커서 위치)에 복원한다.
+
+trailing 컨트롤 수는 `control_text_positions()`에서 `position >= self_text_len`인
+컨트롤 수로 구한다 (중간 컨트롤의 갭은 이미 char_offsets에 인코딩되어 있어 마지막
+문자 offset에 반영됨). self/other 양쪽에 boundary 컨트롤이 있어도 controls 배열
+순서(self → other)와 갭 분석의 순차 배정이 일치하므로 정합하다.
+
+## 2. 세부 단계
+
+### Stage 1 — `merge_from` 컨트롤 병합 보강 + 단위 테스트
+
+**파일**: `src/model/paragraph.rs`, `src/model/paragraph/tests.rs`
+
+`merge_from` 수정 (기존 단계 번호 기준):
+
+1. **early-return** (L717-719):
+   `if other.text.is_empty() && other.controls.is_empty() { return ...; }`
+2. **utf16_end 계산 보강** (L724-730): 기존 계산값에
+   `8 × (self의 trailing 컨트롤 수)` 가산.
+   `let trailing = self.control_text_positions().iter().filter(|&&p| p >= self_text_len).count()`
+3. **(기존 유지)** 텍스트/char_offsets/char_shapes/line_segs/range_tags 결합 —
+   other의 offsets에 보강된 utf16_end가 가산되므로 컨트롤 갭이 자동 인코딩됨.
+4. **field_ranges 결합** (L791-799): `ctrl_offset = self.controls.len()` 캡처는
+   **controls 병합 전** 위치 유지 (현 위치 그대로 두고 controls 병합을 그 뒤에
+   배치).
+5. **controls / ctrl_data_records / control_mask 병합** (신규):
+   ```rust
+   if !other.controls.is_empty() {
+       // 인덱스 정렬: self 쪽 None 패딩 후 other 이어붙이기
+       while self.ctrl_data_records.len() < self.controls.len() {
+           self.ctrl_data_records.push(None);
+       }
+       for i in 0..other.controls.len() {
+           self.ctrl_data_records
+               .push(other.ctrl_data_records.get(i).cloned().flatten());
+       }
+       self.controls.extend(other.controls.iter().cloned());
+       self.control_mask |= other.control_mask;
+   }
+   ```
+   (other에 컨트롤이 없으면 기존 동작 — ctrl_data_records 불필요 패딩 안 함)
+6. **char_count** (L802): 텍스트 part 의미는 기존 유지(chars().count()),
+   `+ 8 × self.controls.len()`(병합 후 총수) 가산 — split_at L678-679와 정합.
+7. **has_para_text**: 병합 후 텍스트 또는 컨트롤이 있으면 `true`로 갱신
+   (split_at L682-687의 역방향 정합).
+
+**단위 테스트** (`src/model/paragraph/tests.rs`, 기존 merge_from 테스트군 L476~ 옆):
+
+- `merge_from_empty_text_with_control`: `text=""+controls=[Picture]` 병합 →
+  controls 1개 보존, char_count = self_text + 8 + 1, has_para_text 유지
+- `merge_from_control_then_right_half`: paste 3단 흐름 재현(split→merge컨트롤→
+  merge right_half) → `control_text_positions() == [커서 위치]`, right 텍스트
+  offsets가 +8 시프트
+- `merge_from_ctrl_data_alignment`: self 컨트롤(레코드 없음) + other 컨트롤
+  (CTRL_DATA 있음) 병합 → `ctrl_data_records[i]` 정렬 검증
+- `merge_from_text_with_mid_control`: 중간 갭 컨트롤 보유 문단끼리 병합 →
+  위치 보존
+- `merge_from_field_ranges_ctrl_offset`: other의 field_ranges control_idx 보정이
+  컨트롤 병합과 함께 정확한지
+- 기존 텍스트 전용 테스트(`test_merge_from_basic/different_styles/empty`) 무회귀
+
+### Stage 2 — 셀/글상자 paste 경로 통합 테스트 + 주석 갱신
+
+**파일**: `src/wasm_api/tests.rs`, `src/document_core/commands/object_ops.rs`
+(필요 시 `clipboard.rs` 보정)
+
+- round-trip 통합 테스트 (기존 paste 테스트군 `wasm_api/tests.rs:2064~` 옆):
+  - 본문 그림 `copy_control_native` → 표 셀 `paste_internal_in_cell_native` →
+    셀 문단에 Picture 컨트롤 + ctrl_data 보존 검증
+  - 글상자(Shape text_box) 동일 검증 — `object_ops.rs:8776`
+    `paste_text_into_textbox` 옆에 이미지 버전 추가, L8772-8774 "별개 결함"
+    주석을 해소 사실로 갱신
+  - 중첩 셀 `paste_internal_in_cell_by_path_native` 동일 검증
+- 부수 해소 잠재 결함 회귀 테스트:
+  - `merge_paragraph_native`(본문 백스페이스 병합): 컨트롤 보유 문단 병합 시
+    컨트롤 보존
+  - `merge_paragraph_in_cell_native`(셀 백스페이스 병합): 동일
+- 본문 무회귀: 기존 `paste_control_native` 테스트(L2064-2082),
+  `paste_internal_native` 텍스트 테스트(L1890-1946) 통과 확인
+- HWP5 저장 round-trip: 병합 문단을 포함한 문서 serialize→parse 시 컨트롤
+  보존(셀 paste 후 저장 시나리오) — 기존 re_sample/serializer 테스트 패턴 활용
+- 필요 시 보정: `reflow_cell_paragraph`가 셀 문단 line_segs에 컨트롤 치수를
+  반영하지 못하면 paste 경로에서 보정 (Stage 2에서 실측 후 결정)
+
+### Stage 3 — 전체 검증 + 시각 확인 + 최종 보고서
+
+- `cargo test` 전체 (merge_from 호출처 광범위 — 백스페이스/HTML import/각주/
+  머리말 경로 회귀 확인)
+- `cargo clippy`
+- `docker compose --env-file .env.docker run --rm wasm` → rhwp-studio에서 수동
+  검증:
+  - 본문 이미지 복사 → 글상자 안 붙여넣기 → 이미지 렌더 확인
+  - 본문 이미지 복사 → 표 셀 안 붙여넣기 → 이미지 렌더 확인
+  - 텍스트 붙여넣기(본문/셀/글상자), 본문 이미지 붙여넣기(pasteControl) 무회귀
+  - 셀 안 백스페이스 문단 병합 시 그림 보존 확인
+- 떠 있는 개체(treat_as_char=false) 셀 anchor 렌더링 시각 확인 (리스크 항목)
+- 최종 보고서 `mydocs/report/task_m100_1323_report.md` 작성
+
+## 3. 범위 밖 관찰 (별도 이슈 후보)
+
+- `merge_from`이 `tab_extended`를 병합하지 않음 — other 텍스트에 탭이 있으면
+  탭 확장 데이터(너비/종류) 소실. 본 타스크 범위 밖, 최종 보고서에 기록.
+- 프론트 `clipboard_has_control_native`가 클립보드 첫 문단만 검사 — 다중 문단
+  클립보드의 컨트롤 처리(본문 pasteControl이 첫 문단만 붙여넣는 문제 포함)는
+  별도 이슈 영역.
+
+## 4. 완료 기준
+
+- 글상자/표 셀(중첩 포함) 이미지 copy→paste에서 그림 컨트롤·CTRL_DATA 보존
+- `control_text_positions()`가 병합 지점에 컨트롤 위치 복원
+- HWP5/HWPX 직렬화 정합 (char_count 역산 포함)
+- `cargo test` 전체 통과, clippy 무경고
+- 작업지시자 시각 판정 통과

--- a/mydocs/report/task_m100_1323_report.md
+++ b/mydocs/report/task_m100_1323_report.md
@@ -62,7 +62,12 @@
 
 ### 4.4 작업지시자 시각 판정
 
-- rhwp-studio 수동 검증 대기 (Stage 3 보고서 5절 체크리스트 참조)
+rhwp-studio 수동 검증 4항목 통과 (2026-06-11 작업지시자 확인):
+
+1. 본문 이미지 복사 → 글상자 안 붙여넣기 → 렌더 정상
+2. 본문 이미지 복사 → 표 셀 안 붙여넣기 → 렌더 정상
+3. 텍스트 붙여넣기(본문/셀/글상자), 본문 이미지 붙여넣기 무회귀
+4. 셀 안 백스페이스 문단 병합 시 그림 보존
 
 ## 5. 범위 밖 관찰 (별도 이슈 후보)
 
@@ -74,7 +79,10 @@
 - html_import의 merge_from 우회 분기(`has_controls` 검사)는 본 수정으로 단순화
   가능해졌으나 본 타스크 범위 밖.
 
-## 6. 후속 절차
+## 6. 후속 절차 (CONTRIBUTING.md 컨트리뷰터 워크플로우)
 
-- 작업지시자 시각 판정 통과 후: `local/devel` no-ff 병합 → `devel` 병합·push →
-  Issue #1323 close (작업지시자 승인 후 수행).
+- PR 전 체크리스트: `cargo fmt --all -- --check` / `cargo test` /
+  `cargo clippy -- -D warnings` 통과 확인
+- Fork(`johndoekim/rhwp`)에 작업 브랜치 push → `edwardkim/rhwp` `devel` 대상
+  PR 생성
+- CI 통과 + 메인테이너 리뷰 승인 후 merge, Issue #1323 close는 메인테이너 수행

--- a/mydocs/report/task_m100_1323_report.md
+++ b/mydocs/report/task_m100_1323_report.md
@@ -1,0 +1,80 @@
+# 최종 보고서 — Task M100-1323
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/1323
+- 제목: 글상자/표 셀 안 이미지(컨트롤) 붙여넣기가 조용히 누락 — merge_from 컨트롤 미병합·빈 텍스트 early-return
+- 브랜치: `local/task1323`
+- 작성일: 2026-06-11
+
+## 1. 결과 요약
+
+`Paragraph::merge_from`(model 계층)을 보강하여 컨트롤 보유 문단 병합 시
+`controls`/`ctrl_data_records`/`control_mask`가 보존되도록 했다. 이로써:
+
+- 글상자/표 셀(중첩·캡션 포함)에 이미지 copy→paste 시 그림 컨트롤과 CTRL_DATA가
+  보존되고 SVG에 실제 렌더된다.
+- 본문/셀 백스페이스 문단 병합, 다중 문단 선택 삭제 등 merge_from을 경유하는
+  모든 경로의 동일 잠재 결함이 함께 해소됐다.
+- 클립보드/편집 명령 계층과 프론트엔드는 수정하지 않았다(기존 라우팅 그대로 동작).
+
+## 2. 변경 내역
+
+| 파일 | 변경 |
+|---|---|
+| `src/model/paragraph.rs` | `merge_from` 컨트롤 병합 보강 (early-return 조건, utf16_end 갭 인코딩, controls/ctrl_data_records/control_mask 병합, char_count·has_para_text 정합) |
+| `src/model/paragraph/tests.rs` | merge_from 컨트롤 단위 테스트 5건 + 헬퍼 |
+| `src/wasm_api/tests.rs` | 통합 테스트 7건(셀/path 셀/캡션 paste, 본문·셀 백스페이스 병합, HWP5 round-trip, SVG 렌더링) + `find_table_pos` 헬퍼 |
+| `src/document_core/commands/object_ops.rs` | `paste_picture_into_textbox` 테스트 추가, "별개 결함" 주석을 해소 사실로 갱신 |
+| `mydocs/plans/task_m100_1323.md` | 수행 계획서 |
+| `mydocs/plans/task_m100_1323_impl.md` | 구현 계획서 |
+| `mydocs/working/task_m100_1323_stage{1,2,3}.md` | 단계별 보고서 |
+
+## 3. 설계 요점 (직렬화·렌더링 계약 정합)
+
+1. **컨트롤 위치 = char_offsets 갭**: 2차 병합(right_half) 시 trailing 컨트롤의
+   8 code unit을 utf16_end에 가산하여, 렌더링(`control_text_positions`)과 HWP5
+   직렬화(`serialize_para_text` 갭 분석)가 병합 지점(커서 위치)에 컨트롤을 복원한다.
+2. **char_count**: 텍스트 + 8×컨트롤 수 + 1 — `split_at` 및 HWPX 직렬화의
+   컨트롤 수 역산(`serializer/hwpx/section.rs`)과 정합.
+3. **ctrl_data_records[i] ↔ controls[i] 정렬**: self 쪽 None 패딩 후 other 이어붙임 —
+   HWP5 직렬화의 인덱스 기반 소비와 정합.
+4. **control_mask**: OR 병합.
+
+## 4. 검증
+
+### 4.1 단위·통합 테스트
+
+- `cargo test` 전체 — **2139 passed, 0 failed**, 6 ignored
+- 신규 테스트 13건: 단위 5(모델 병합 의미론) + 통합 7(paste/병합/round-trip) +
+  SVG 렌더링 1
+- HWP5 저장 round-trip: 셀에 붙여넣은 그림이 serialize→parse 후 보존
+  (char_count 역산·갭 인코딩 정합 실증)
+- SVG 렌더링: 셀/글상자에 붙여넣은 **부동(treat_as_char=false)** 그림이 실제
+  `<image>` 요소로 방출 — 리스크 항목(떠 있는 개체 셀 anchor) 자동 검증
+
+### 4.2 정적 검사
+
+- `cargo clippy --all-targets` — 무경고
+- `rustfmt --check` (변경 파일 한정) — 통과
+
+### 4.3 WASM 빌드
+
+- `docker compose --env-file .env.docker run --rm wasm` — 통과, `pkg/` 갱신
+
+### 4.4 작업지시자 시각 판정
+
+- rhwp-studio 수동 검증 대기 (Stage 3 보고서 5절 체크리스트 참조)
+
+## 5. 범위 밖 관찰 (별도 이슈 후보)
+
+- `merge_from`이 `tab_extended`를 병합하지 않음 — other 텍스트에 탭이 있으면
+  탭 확장 데이터(너비/종류) 소실 가능.
+- 프론트 `clipboard_has_control_native`가 클립보드 첫 문단만 검사 — 다중 문단
+  클립보드의 컨트롤 처리(본문 pasteControl이 첫 문단만 붙여넣는 문제 포함)는
+  별도 이슈 영역.
+- html_import의 merge_from 우회 분기(`has_controls` 검사)는 본 수정으로 단순화
+  가능해졌으나 본 타스크 범위 밖.
+
+## 6. 후속 절차
+
+- 작업지시자 시각 판정 통과 후: `local/devel` no-ff 병합 → `devel` 병합·push →
+  Issue #1323 close (작업지시자 승인 후 수행).

--- a/mydocs/working/task_m100_1323_stage1.md
+++ b/mydocs/working/task_m100_1323_stage1.md
@@ -1,0 +1,71 @@
+# Stage 1 보고서 — Task M100-1323
+
+- 이슈: #1323
+- 작성일: 2026-06-10
+- 브랜치: `local/task1323`
+
+## 1. 작업 요약
+
+`Paragraph::merge_from`(`src/model/paragraph.rs`)을 보강하여 컨트롤 보유 문단 병합 시
+`controls`/`ctrl_data_records`/`control_mask`가 보존되도록 했다. TDD 방식으로 실패
+테스트(컨트롤 드롭 재현) 4건을 먼저 작성·확인한 뒤 구현했다.
+
+## 2. 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `src/model/paragraph.rs` | `merge_from` 컨트롤 병합 보강 (5개 변경점) |
+| `src/model/paragraph/tests.rs` | merge_from 컨트롤 단위 테스트 5건 + 헬퍼 추가 |
+
+## 3. 구현 세부 (구현계획서 Stage 1 항목별)
+
+1. **early-return 조건 수정**: `other.text.is_empty() && other.controls.is_empty()`일
+   때만 반환. 텍스트 없이 컨트롤만 있는 문단(그림 복사 클립보드)도 병합 진행.
+2. **utf16_end 계산 보강**: `control_text_positions()`로 trailing 컨트롤
+   (`position >= self_text_len`) 수를 구해 `8 × n`을 가산. 이로써 2차 병합
+   (right_half) 시 컨트롤 갭이 char_offsets에 자동 인코딩되어, 렌더링
+   (`control_text_positions`)과 HWP5 직렬화(`serialize_para_text` 갭 분석)가
+   병합 지점에 컨트롤을 복원한다.
+3. **controls/ctrl_data_records/control_mask 병합 (신규 5-2절)**:
+   `ctrl_data_records[i] ↔ controls[i]` 인덱스 정렬을 위해 self 쪽을 None 패딩 후
+   other를 이어붙임. `control_mask`는 OR 병합. other에 컨트롤이 없으면 기존 동작
+   유지(불필요 패딩 없음).
+4. **field_ranges ctrl_offset**: 병합 전 `self.controls.len()` 캡처 위치를 5-2절
+   앞으로 유지 — 기존 보정 의미 불변 (테스트로 고정).
+5. **char_count**: `텍스트 + 8 × 병합 후 controls.len() + 1`로 갱신. `split_at`의
+   `ctrl_code_units` 계산 및 HWPX 직렬화의 컨트롤 수 역산
+   (`serializer/hwpx/section.rs:379`)과 정합.
+6. **has_para_text**: 병합 후 텍스트/컨트롤이 있으면 `true` (split_at L682-687
+   역방향 정합).
+
+## 4. 추가된 단위 테스트
+
+| 테스트 | 검증 내용 |
+|--------|----------|
+| `test_merge_from_empty_text_with_control` | `text=""+controls` 병합 → 컨트롤·mask·char_count(11)·has_para_text 보존 |
+| `test_merge_from_control_then_right_half` | paste 3단 흐름(split→merge컨트롤→merge right_half) → `control_text_positions()==[2]`(커서 위치), char_offsets `[0,1,10,11]` 갭 인코딩 |
+| `test_merge_from_ctrl_data_alignment` | self None 패딩 + other CTRL_DATA 인덱스 정렬 `[None, Some([1,2,3])]` |
+| `test_merge_from_text_with_mid_control` | 양쪽 중간 갭 컨트롤 → 위치 `[1,3]` 보존, char_count 21 |
+| `test_merge_from_field_ranges_ctrl_offset` | other field_ranges의 control_idx +1 보정 (병합 전 캡처 고정) |
+
+구현 전 실측: 신규 5건 중 4건 실패(컨트롤 드롭 재현), `field_ranges_ctrl_offset`은
+기존 동작 고정용으로 통과. 구현 후 5건 전체 통과.
+
+## 5. 검증
+
+통과:
+
+- `cargo test --lib model::paragraph::tests` — 50 passed (기존 merge_from/split
+  round-trip 테스트 무회귀 포함)
+- `cargo test` 전체 — **1627 passed, 0 failed**, 6 ignored + 통합 테스트 전부 통과
+  (merge_from 호출처: 백스페이스 병합, deleteRange, 각주/머리말, HTML import,
+  본문/셀 paste 경로 회귀 없음)
+- `cargo clippy --all-targets` — 무경고
+- `cargo fmt --check` (변경 파일 한정) — 통과
+
+## 6. 비고
+
+- char_count 의미 변화(컨트롤당 8 code unit 포함)는 파서가 생성하는 char_count와
+  동일한 의미론으로의 정합이며, 전체 테스트에서 부작용 미검출.
+- Stage 2에서 셀/글상자/중첩 셀 paste round-trip 및 백스페이스 병합 컨트롤 보존
+  통합 테스트로 end-to-end 검증 예정.

--- a/mydocs/working/task_m100_1323_stage2.md
+++ b/mydocs/working/task_m100_1323_stage2.md
@@ -1,0 +1,63 @@
+# Stage 2 보고서 — Task M100-1323
+
+- 이슈: #1323
+- 작성일: 2026-06-10
+- 브랜치: `local/task1323`
+
+## 1. 작업 요약
+
+Stage 1의 `merge_from` 보강이 실제 붙여넣기·병합 경로에서 end-to-end로 동작함을
+통합 테스트로 고정했다. 표 셀/글상자/캡션/path 기반 셀의 그림 붙여넣기, 본문/셀
+백스페이스 병합의 컨트롤 보존, HWP5 직렬화 round-trip을 검증한다. 소스 수정은
+테스트·주석 한정이며 런타임 코드 변경은 없다.
+
+## 2. 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `src/wasm_api/tests.rs` | #1323 통합 테스트 6건 + `find_table_pos` 헬퍼 추가 |
+| `src/document_core/commands/object_ops.rs` | `paste_picture_into_textbox` 테스트 추가, L8772 "별개 결함" 주석을 해소 사실로 갱신 |
+
+## 3. 추가된 통합 테스트
+
+| 테스트 | 경로 | 검증 내용 |
+|--------|------|----------|
+| `test_paste_picture_into_table_cell` | `paste_internal_in_cell_native` (표 셀) | 그림 컨트롤 보존 + CTRL_DATA 인덱스 정렬 보존 |
+| `test_paste_picture_into_cell_by_path` | `paste_internal_in_cell_by_path_native` | path 기반 셀 경로 동일 보존 |
+| `test_paste_picture_into_picture_caption` | `paste_internal_in_cell_native` (Picture 캡션 분기) | 캡션 문단 그림 보존 |
+| `paste_picture_into_textbox` (object_ops) | `paste_internal_in_cell_native` (글상자 분기) | `insert_picture_native`(BinData 등록)→복사→글상자 붙여넣기 보존. #1280 텍스트 테스트와 나란히 배치 |
+| `test_merge_paragraph_preserves_controls` | `merge_paragraph_native` (본문 백스페이스) | 컨트롤 보유 문단 병합 시 그림 보존 + `control_text_positions()==[0]` 위치 유지 |
+| `test_merge_paragraph_in_cell_preserves_controls` | `merge_paragraph_in_cell_native` (셀 백스페이스) | 셀 문단 병합 시 그림 보존 |
+| `test_paste_picture_into_table_cell_hwp5_roundtrip` | `export_hwp_native` → `from_bytes` | 셀에 붙여넣은 그림이 HWP5 직렬화·재파싱 후 보존 (char_count 역산·갭 인코딩 정합 실증) |
+
+## 4. 구현계획서 항목별 처리
+
+- ✅ 표 셀/글상자/캡션 round-trip — 위 테스트로 고정
+- ✅ 중첩(path 기반) 셀 — `by_path` 경로 테스트 (단일 레벨 path로
+  `get_cell_paragraphs_mut_by_path` + 동일 병합 함수 경유 검증)
+- ✅ 백스페이스 병합 부수 해소 — 본문/셀 2건
+- ✅ 본문 무회귀 — 기존 `test_paste_cascade_floating_picture`,
+  `test_paste_inline_picture_no_cascade` 등 paste 테스트 15건 통과
+- ✅ HWP5 저장 round-trip — 통과 (직렬화 계약 정합 실증)
+- ✅ object_ops.rs:8772 주석 갱신 — "별개 결함" 인지 주석을 해소 사실 + 회귀
+  테스트 참조로 교체
+- ☑️ `reflow_cell_paragraph` 보정 — **보정 불필요로 판단**:
+  `reflow_line_segs`(`renderer/composer/line_breaking.rs:902`)는 폰트 크기
+  기반으로 line_segs를 계산하고, 셀 내부의 인라인 컨트롤 치수는 렌더 시점의
+  셀 레이아웃이 처리한다(파싱 문서의 셀 내 그림이 정상 렌더되는 기존 동작과
+  동일 경로). Stage 3 시각 검증으로 최종 확인한다.
+
+## 5. 검증
+
+통과:
+
+- `cargo test --lib paste_picture` — 5 passed (신규)
+- `cargo test --lib test_merge_paragraph` — 2 passed (신규)
+- `cargo test` 전체 — **2138 passed, 0 failed** (lib + 통합 + doctest)
+- `cargo clippy --all-targets` — 무경고
+- `cargo fmt --check` (변경 파일 한정) — 통과
+
+## 6. 비고
+
+- Stage 3에서 WASM 빌드 후 rhwp-studio 실 UI(이미지 복사→글상자/표 셀 붙여넣기)
+  시각 검증과 떠 있는 개체(treat_as_char=false) 셀 anchor 렌더링을 확인한다.

--- a/mydocs/working/task_m100_1323_stage3.md
+++ b/mydocs/working/task_m100_1323_stage3.md
@@ -1,0 +1,53 @@
+# Stage 3 보고서 — Task M100-1323
+
+- 이슈: #1323
+- 작성일: 2026-06-11
+- 브랜치: `local/task1323`
+
+## 1. 작업 요약
+
+전체 회귀 검증(cargo test/clippy)과 WASM 빌드를 수행하고, 작업지시자 시각 판정을
+보조하는 SVG 렌더링 자동 검증 테스트를 추가했다. 셀/글상자에 붙여넣은 그림이
+렌더 트리를 거쳐 실제 SVG `<image>` 요소로 방출되는 것까지 자동으로 고정하여,
+Stage 2의 모델 수준 검증(컨트롤 보존)과 수동 시각 판정 사이의 간극을 줄였다.
+
+## 2. 변경 파일
+
+| 파일 | 내용 |
+|------|------|
+| `src/wasm_api/tests.rs` | `test_paste_picture_into_cell_and_textbox_renders_in_svg` 추가 (+106줄) |
+
+## 3. SVG 렌더링 자동 검증 테스트
+
+`test_paste_picture_into_cell_and_textbox_renders_in_svg` (`src/wasm_api/tests.rs:2335`):
+
+1. `insert_picture_native`로 실제 PNG(BinData 등록)를 본문에 삽입 — 기본 속성이
+   **`treat_as_char: false`(부동, Para anchor)** 이므로 수행계획서 리스크 항목
+   "떠 있는 개체 셀 anchor 렌더링"을 그대로 재현한다.
+2. 기준 SVG 렌더에서 `<image>` 수 확인 (본문 그림 ≥ 1).
+3. `copy_control_native` → 표 셀 `paste_internal_in_cell_native` → SVG 재렌더 →
+   `<image>` +1 검증.
+4. 글상자(`create_shape_control_native` textbox) → 동일 paste → SVG 재렌더 →
+   `<image>` +1 추가 검증.
+
+데이터 URI 이미지 방출 경로(BinData → base64)를 실 렌더러 그대로 사용하므로,
+컨트롤이 모델에 남아 있어도 렌더에서 누락되는 회귀를 잡을 수 있다.
+
+## 4. 검증
+
+통과:
+
+- `cargo test --lib test_paste_picture_into_cell_and_textbox_renders_in_svg` — 1 passed
+- `cargo test` 전체 — **2139 passed, 0 failed** (Stage 2 대비 +1 = 신규 SVG 테스트)
+- `cargo clippy --all-targets` — 무경고
+- `rustfmt --check` (변경 파일 한정) — 통과
+- `docker compose --env-file .env.docker run --rm wasm` — WASM 빌드 통과 (`pkg/rhwp_bg.wasm` 생성)
+
+## 5. 작업지시자 시각 판정 대기 항목
+
+WASM 빌드 산출물(`pkg/`)로 rhwp-studio에서 다음을 확인 부탁드립니다:
+
+1. 본문 이미지 복사 → 글상자 안 붙여넣기 → 이미지 렌더 확인
+2. 본문 이미지 복사 → 표 셀 안 붙여넣기 → 이미지 렌더 확인
+3. 텍스트 붙여넣기(본문/셀/글상자), 본문 이미지 붙여넣기(pasteControl) 무회귀
+4. 셀 안 백스페이스 문단 병합 시 그림 보존 확인

--- a/src/document_core/commands/object_ops.rs
+++ b/src/document_core/commands/object_ops.rs
@@ -8769,9 +8769,9 @@ mod issue_1280_textbox_creation_tests {
     /// 본문 텍스트를 copy_selection 으로 복사한 뒤 글상자 안에 paste_internal_in_cell 로 붙여넣는다.
     /// 수정 전(text_box 없는 Rectangle)이면 이 경로가 "글상자 없음"(clipboard.rs:512)으로 실패한다.
     ///
-    /// 주의: 이미지/컨트롤 붙여넣기는 paste_paragraphs_into_cell_paragraphs 가 merge_from 으로 처리하는데
-    /// merge_from 이 controls 를 병합하지 않아 컨트롤이 조용히 누락되는 **별개 결함**의 영향을 받는다.
-    /// 따라서 본 테스트는 텍스트 붙여넣기(컨트롤 없음 경로)만 검증한다.
+    /// 이미지/컨트롤 붙여넣기는 merge_from 이 controls 를 병합하지 않아 조용히 누락되던
+    /// 별개 결함(#1323)이 있었으며, merge_from 보강으로 해소되었다.
+    /// 회귀 테스트는 `paste_picture_into_textbox` 참고.
     #[test]
     fn paste_text_into_textbox() {
         let mut core = make_test_core();
@@ -8794,6 +8794,62 @@ mod issue_1280_textbox_creation_tests {
         assert!(
             tb.paragraphs.iter().any(|p| p.text.contains("복사원본")),
             "붙여넣기 후 글상자 내부 문단에 복사한 텍스트가 있어야 한다"
+        );
+    }
+
+    /// #1323: 글상자 안 이미지(그림 컨트롤) 붙여넣기 회귀 테스트.
+    /// 본문 그림을 copy_control 로 복사한 뒤 글상자 안에 paste_internal_in_cell 로
+    /// 붙여넣는다. merge_from 이 controls 를 병합하지 않던 수정 전에는 그림이
+    /// 에러 없이 조용히 누락되었다.
+    #[test]
+    fn paste_picture_into_textbox() {
+        let mut core = make_test_core();
+
+        // 1. 본문에 그림 삽입 (BinData 등록 포함)
+        let res = core
+            .insert_picture_native(
+                0,
+                0,
+                0,
+                &[],
+                &minimal_png(),
+                5000,
+                5000,
+                1,
+                1,
+                "png",
+                "",
+                None,
+                None,
+            )
+            .expect("본문 그림 삽입");
+        let pic_para = parse_idx(&res, "paraIdx");
+        let pic_ctrl = parse_idx(&res, "controlIdx");
+
+        // 2. 그림 복사 → 내부 클립보드
+        core.copy_control_native(0, pic_para, &[], pic_ctrl)
+            .expect("그림 복사");
+
+        // 3. 글상자 생성 + 안에 붙여넣기 (cell_idx=0 무시, cell_para_idx=0, char_offset=0)
+        let (tb_para, tb_ctrl) = create_shape(&mut core, "textbox");
+        core.paste_internal_in_cell_native(0, tb_para, tb_ctrl, 0, 0, 0)
+            .expect("글상자에 그림 붙여넣기");
+
+        // 4. 글상자 내부 문단에 그림 컨트롤 보존 확인
+        let tb = textbox_of(&core, tb_para, tb_ctrl).expect("글상자 text_box 존재");
+        let pic_count: usize = tb
+            .paragraphs
+            .iter()
+            .map(|p| {
+                p.controls
+                    .iter()
+                    .filter(|c| matches!(c, Control::Picture(_)))
+                    .count()
+            })
+            .sum();
+        assert_eq!(
+            pic_count, 1,
+            "글상자 안에 붙여넣은 그림 컨트롤이 보존되어야 한다 (#1323)"
         );
     }
 }

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -714,20 +714,29 @@ impl Paragraph {
     /// 병합 후 other 문단의 내용은 현재 문단에 포함된다.
     /// 반환값: 병합 지점의 char offset (원래 텍스트의 길이).
     pub fn merge_from(&mut self, other: &Paragraph) -> usize {
-        if other.text.is_empty() {
+        // 텍스트 없이 컨트롤만 있는 문단(예: 그림 복사 클립보드)도 병합 대상 (#1323)
+        if other.text.is_empty() && other.controls.is_empty() {
             return self.text.chars().count();
         }
 
         let self_text_len = self.text.chars().count();
 
-        // 현재 문단 끝의 UTF-16 위치
+        // 현재 문단 끝의 UTF-16 위치.
+        // 마지막 문자 뒤(trailing) 컨트롤은 char_offsets에 갭이 인코딩되어 있지 않으므로
+        // 컨트롤당 8 code unit을 가산해야 other 텍스트가 컨트롤 갭 뒤로 이어진다 (#1323).
+        let trailing_ctrl_units: u32 = self
+            .control_text_positions()
+            .iter()
+            .filter(|&&p| p >= self_text_len)
+            .count() as u32
+            * 8;
         let utf16_end: u32 = if !self.char_offsets.is_empty() {
             let last = self.char_offsets.len() - 1;
             let text_chars: Vec<char> = self.text.chars().collect();
             self.char_offsets[last] + Self::char_utf16_len(text_chars[last])
         } else {
             0
-        };
+        } + trailing_ctrl_units;
 
         // 1. 텍스트 결합
         self.text.push_str(&other.text);
@@ -789,6 +798,7 @@ impl Paragraph {
         }
 
         // 5-1. field_ranges 결합 (other의 char 인덱스에 self_text_len 추가)
+        //      ctrl_offset은 병합 전 self.controls.len() — 5-2의 controls 병합보다 먼저 캡처
         let ctrl_offset = self.controls.len();
         for fr in &other.field_ranges {
             self.field_ranges.push(FieldRange {
@@ -798,8 +808,31 @@ impl Paragraph {
             });
         }
 
-        // 6. char_count 갱신 (-1 because merge removes one paragraph end)
-        self.char_count = (self_text_len + other.text.chars().count()) as u32 + 1;
+        // 5-2. controls / ctrl_data_records / control_mask 병합 (#1323)
+        //      ctrl_data_records[i]는 controls[i] 대응이므로 self 쪽을 None 패딩 후 이어붙인다.
+        if !other.controls.is_empty() {
+            while self.ctrl_data_records.len() < self.controls.len() {
+                self.ctrl_data_records.push(None);
+            }
+            for i in 0..other.controls.len() {
+                self.ctrl_data_records
+                    .push(other.ctrl_data_records.get(i).cloned().flatten());
+            }
+            self.controls.extend(other.controls.iter().cloned());
+            self.control_mask |= other.control_mask;
+        }
+
+        // 6. char_count 갱신: 텍스트 + 컨트롤(각 8 code unit) + 문단끝(1)
+        //    split_at의 ctrl_code_units 계산과 정합. HWPX 직렬화가 char_count에서
+        //    컨트롤 수를 역산하므로 컨트롤 유닛 포함 필수.
+        self.char_count = (self_text_len + other.text.chars().count()) as u32
+            + self.controls.len() as u32 * 8
+            + 1;
+
+        // 7. has_para_text: 병합 후 텍스트/컨트롤이 있으면 PARA_TEXT 필요
+        if !self.text.is_empty() || !self.controls.is_empty() {
+            self.has_para_text = true;
+        }
 
         self_text_len
     }

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -580,6 +580,225 @@ fn test_merge_from_empty() {
     assert_eq!(para1.text, "안녕");
 }
 
+/// 그림 컨트롤 테스트 헬퍼 (treat_as_char=true 인라인)
+fn make_picture_control() -> Control {
+    use crate::model::image::Picture;
+    use crate::model::shape::CommonObjAttr;
+    Control::Picture(Box::new(Picture {
+        common: CommonObjAttr {
+            treat_as_char: true,
+            width: 5000,
+            height: 5000,
+            ..Default::default()
+        },
+        ..Default::default()
+    }))
+}
+
+#[test]
+fn test_merge_from_empty_text_with_control() {
+    // copy_control_native가 만드는 text="" + controls=[Picture] 문단 병합 (#1323)
+    let mut para1 = Paragraph {
+        text: "안녕".to_string(),
+        char_count: 3,
+        char_offsets: vec![0, 1],
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 1,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let pic_para = Paragraph {
+        text: String::new(),
+        char_count: 9, // 확장 제어문자(8) + 문단끝(1)
+        control_mask: 1u32 << 0x000B,
+        controls: vec![make_picture_control()],
+        ctrl_data_records: vec![None],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let merge_pos = para1.merge_from(&pic_para);
+
+    assert_eq!(merge_pos, 2, "병합 지점은 원래 텍스트 길이");
+    assert_eq!(para1.text, "안녕", "텍스트는 불변");
+    assert_eq!(
+        para1.controls.len(),
+        1,
+        "그림 컨트롤이 병합되어야 한다 (#1323)"
+    );
+    assert_eq!(
+        para1.char_count, 11,
+        "char_count = 텍스트(2) + 컨트롤(8) + 문단끝(1)"
+    );
+    assert_ne!(
+        para1.control_mask & (1u32 << 0x000B),
+        0,
+        "control_mask 병합"
+    );
+    assert!(para1.has_para_text);
+}
+
+#[test]
+fn test_merge_from_control_then_right_half() {
+    // 셀 paste 3단 흐름 재현: split_at → merge(컨트롤 문단) → merge(right_half)
+    let mut para = Paragraph {
+        text: "ABCD".to_string(),
+        char_count: 5,
+        char_offsets: vec![0, 1, 2, 3],
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 1,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let right_half = para.split_at(2);
+
+    let pic_para = Paragraph {
+        text: String::new(),
+        char_count: 9,
+        control_mask: 1u32 << 0x000B,
+        controls: vec![make_picture_control()],
+        ctrl_data_records: vec![None],
+        has_para_text: true,
+        ..Default::default()
+    };
+    para.merge_from(&pic_para);
+    para.merge_from(&right_half);
+
+    assert_eq!(para.text, "ABCD");
+    assert_eq!(para.controls.len(), 1);
+    assert_eq!(
+        para.control_text_positions(),
+        vec![2],
+        "컨트롤은 병합 지점(커서 위치)에 복원되어야 한다"
+    );
+    assert_eq!(
+        para.char_offsets,
+        vec![0, 1, 10, 11],
+        "right_half 텍스트는 컨트롤 갭(8유닛) 뒤로 인코딩"
+    );
+    assert_eq!(
+        para.char_count, 13,
+        "char_count = 텍스트(4) + 컨트롤(8) + 문단끝(1)"
+    );
+}
+
+#[test]
+fn test_merge_from_ctrl_data_alignment() {
+    // ctrl_data_records[i] ↔ controls[i] 인덱스 정렬 유지
+    let mut para1 = Paragraph {
+        text: "A".to_string(),
+        char_count: 10,        // 1 + 8 + 1
+        char_offsets: vec![8], // 선두 갭 8 = 컨트롤 1개
+        controls: vec![make_picture_control()],
+        ctrl_data_records: vec![], // 레코드 없음 (길이 < controls)
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let para2 = Paragraph {
+        text: String::new(),
+        char_count: 9,
+        controls: vec![make_picture_control()],
+        ctrl_data_records: vec![Some(vec![1, 2, 3])],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    para1.merge_from(&para2);
+
+    assert_eq!(para1.controls.len(), 2);
+    assert_eq!(
+        para1.ctrl_data_records,
+        vec![None, Some(vec![1, 2, 3])],
+        "self는 None 패딩, other의 CTRL_DATA는 인덱스 정렬 유지"
+    );
+}
+
+#[test]
+fn test_merge_from_text_with_mid_control() {
+    // 양쪽 모두 중간 갭 컨트롤 보유 → 위치 보존
+    let mut para1 = Paragraph {
+        text: "AB".to_string(),
+        char_count: 11,           // 2 + 8 + 1
+        char_offsets: vec![0, 9], // A(0) [컨트롤 갭 8] B(9)
+        controls: vec![make_picture_control()],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let para2 = Paragraph {
+        text: "CD".to_string(),
+        char_count: 11,
+        char_offsets: vec![0, 9], // C(0) [컨트롤 갭 8] D(9)
+        controls: vec![make_picture_control()],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    para1.merge_from(&para2);
+
+    assert_eq!(para1.text, "ABCD");
+    assert_eq!(para1.controls.len(), 2);
+    assert_eq!(para1.char_offsets, vec![0, 9, 10, 19]);
+    assert_eq!(
+        para1.control_text_positions(),
+        vec![1, 3],
+        "양쪽 중간 컨트롤 위치가 보존되어야 한다"
+    );
+    assert_eq!(para1.char_count, 21, "4 + 16 + 1");
+}
+
+#[test]
+fn test_merge_from_field_ranges_ctrl_offset() {
+    // other의 field_ranges.control_idx가 병합된 controls 인덱스로 보정되는지
+    let mut para1 = Paragraph {
+        text: "AB".to_string(),
+        char_count: 11,
+        char_offsets: vec![0, 9],
+        controls: vec![make_picture_control()],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let para2 = Paragraph {
+        text: "CD".to_string(),
+        char_count: 11,
+        char_offsets: vec![0, 9],
+        controls: vec![make_picture_control()],
+        field_ranges: vec![FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 1,
+            control_idx: 0,
+        }],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    para1.merge_from(&para2);
+
+    assert_eq!(para1.field_ranges.len(), 1);
+    assert_eq!(
+        para1.field_ranges[0].control_idx, 1,
+        "control_idx는 병합 전 self.controls.len()만큼 보정"
+    );
+    assert_eq!(para1.field_ranges[0].start_char_idx, 2);
+    assert_eq!(para1.field_ranges[0].end_char_idx, 3);
+}
+
 #[test]
 fn test_split_and_merge_roundtrip() {
     let mut para = Paragraph {

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2089,6 +2089,245 @@ fn test_paste_inline_picture_no_cascade() {
     );
 }
 
+/// 섹션 0에서 첫 번째 표 컨트롤의 (para_idx, ctrl_idx)를 찾는다.
+fn find_table_pos(doc: &HwpDocument) -> (usize, usize) {
+    use crate::model::control::Control;
+    for (pi, p) in doc.document.sections[0].paragraphs.iter().enumerate() {
+        for (ci, c) in p.controls.iter().enumerate() {
+            if matches!(c, Control::Table(_)) {
+                return (pi, ci);
+            }
+        }
+    }
+    panic!("표 컨트롤 없음");
+}
+
+/// #1323: 표 셀 안 이미지 붙여넣기 — merge_from 컨트롤 병합으로 그림·CTRL_DATA가
+/// 보존되어야 한다. 수정 전에는 에러 없이 조용히 누락되었다.
+#[test]
+fn test_paste_picture_into_table_cell() {
+    use crate::model::control::Control;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    // CTRL_DATA 인덱스 정렬 검증용 레코드 부여
+    doc.document.sections[0].paragraphs[0].ctrl_data_records = vec![Some(vec![7, 7, 7])];
+    doc.copy_control_native(0, 0, &[], 0).expect("그림 복사");
+
+    doc.create_table_ex_native(0, 1, 0, 2, 2, true, None)
+        .expect("표 생성");
+    let (t_para, t_ctrl) = find_table_pos(&doc);
+
+    doc.paste_internal_in_cell_native(0, t_para, t_ctrl, 0, 0, 0)
+        .expect("셀에 그림 붙여넣기");
+
+    let table = match &doc.document.sections[0].paragraphs[t_para].controls[t_ctrl] {
+        Control::Table(t) => t,
+        other => panic!("표가 아님: {other:?}"),
+    };
+    let mut found = None;
+    for p in &table.cells[0].paragraphs {
+        for (i, c) in p.controls.iter().enumerate() {
+            if matches!(c, Control::Picture(_)) {
+                found = Some((p, i));
+            }
+        }
+    }
+    let (cell_para, pic_idx) = found.expect("셀 안에 그림 컨트롤이 보존되어야 한다 (#1323)");
+    assert_eq!(
+        cell_para.ctrl_data_records.get(pic_idx).cloned().flatten(),
+        Some(vec![7, 7, 7]),
+        "CTRL_DATA가 controls 인덱스 정렬을 유지한 채 보존되어야 한다"
+    );
+}
+
+/// #1323: path 기반 셀 붙여넣기(paste_internal_in_cell_by_path)도 동일하게 그림을 보존한다.
+#[test]
+fn test_paste_picture_into_cell_by_path() {
+    use crate::model::control::Control;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    doc.copy_control_native(0, 0, &[], 0).expect("그림 복사");
+
+    doc.create_table_ex_native(0, 1, 0, 2, 2, true, None)
+        .expect("표 생성");
+    let (t_para, t_ctrl) = find_table_pos(&doc);
+
+    // path = [(ctrl_idx, cell_idx, cell_para_idx)] — 셀 1의 문단 0에 붙여넣기
+    doc.paste_internal_in_cell_by_path_native(0, t_para, &[(t_ctrl, 1, 0)], 0)
+        .expect("path 기반 셀 붙여넣기");
+
+    let table = match &doc.document.sections[0].paragraphs[t_para].controls[t_ctrl] {
+        Control::Table(t) => t,
+        other => panic!("표가 아님: {other:?}"),
+    };
+    let pic_count: usize = table.cells[1]
+        .paragraphs
+        .iter()
+        .map(|p| {
+            p.controls
+                .iter()
+                .filter(|c| matches!(c, Control::Picture(_)))
+                .count()
+        })
+        .sum();
+    assert_eq!(
+        pic_count, 1,
+        "path 기반 붙여넣기에서도 그림 컨트롤이 보존되어야 한다 (#1323)"
+    );
+}
+
+/// #1323: 그림 캡션 안 붙여넣기(Control::Picture 분기)도 컨트롤을 보존한다.
+#[test]
+fn test_paste_picture_into_picture_caption() {
+    use crate::model::control::Control;
+    use crate::model::shape::Caption;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    doc.copy_control_native(0, 0, &[], 0).expect("그림 복사");
+
+    // 본문 그림에 캡션 부여
+    match &mut doc.document.sections[0].paragraphs[0].controls[0] {
+        Control::Picture(p) => {
+            p.caption = Some(Caption {
+                paragraphs: vec![Paragraph::default()],
+                ..Default::default()
+            });
+        }
+        other => panic!("그림이 아님: {other:?}"),
+    }
+
+    doc.paste_internal_in_cell_native(0, 0, 0, 0, 0, 0)
+        .expect("캡션에 그림 붙여넣기");
+
+    let caption = match &doc.document.sections[0].paragraphs[0].controls[0] {
+        Control::Picture(p) => p.caption.as_ref().expect("캡션 존재"),
+        other => panic!("그림이 아님: {other:?}"),
+    };
+    let pic_count: usize = caption
+        .paragraphs
+        .iter()
+        .map(|p| {
+            p.controls
+                .iter()
+                .filter(|c| matches!(c, Control::Picture(_)))
+                .count()
+        })
+        .sum();
+    assert_eq!(
+        pic_count, 1,
+        "캡션 안에 붙여넣은 그림 컨트롤이 보존되어야 한다 (#1323)"
+    );
+}
+
+/// #1323 부수 해소: 본문 문단 시작 Backspace 병합 시 병합 대상 문단의 컨트롤이
+/// 보존되어야 한다 (수정 전에는 merge_from이 controls를 드롭).
+#[test]
+fn test_merge_paragraph_preserves_controls() {
+    use crate::model::control::Control;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    // 문단 1에 텍스트 입력 후 문단 0(그림 문단)으로 병합
+    doc.insert_text_native(0, 1, 0, "가나")
+        .expect("텍스트 입력");
+    doc.merge_paragraph_native(0, 1).expect("문단 병합");
+
+    let para = &doc.document.sections[0].paragraphs[0];
+    assert_eq!(para.text, "가나");
+    assert_eq!(
+        para.controls
+            .iter()
+            .filter(|c| matches!(c, Control::Picture(_)))
+            .count(),
+        1,
+        "백스페이스 병합 시 그림 컨트롤이 보존되어야 한다 (#1323)"
+    );
+    assert_eq!(
+        para.control_text_positions(),
+        vec![0],
+        "그림은 병합된 텍스트 앞 위치를 유지해야 한다"
+    );
+}
+
+/// #1323 부수 해소: 셀 문단 시작 Backspace 병합(merge_paragraph_in_cell) 시
+/// 병합 대상 셀 문단의 컨트롤이 보존되어야 한다.
+#[test]
+fn test_merge_paragraph_in_cell_preserves_controls() {
+    use crate::model::control::Control;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    doc.create_table_ex_native(0, 1, 0, 2, 2, true, None)
+        .expect("표 생성");
+    let (t_para, t_ctrl) = find_table_pos(&doc);
+
+    // 셀 0에 그림 문단을 두 번째 문단으로 구성
+    let pic_para = doc.document.sections[0].paragraphs[0].clone();
+    match &mut doc.document.sections[0].paragraphs[t_para].controls[t_ctrl] {
+        Control::Table(t) => t.cells[0].paragraphs.push(pic_para),
+        other => panic!("표가 아님: {other:?}"),
+    }
+
+    doc.merge_paragraph_in_cell_native(0, t_para, t_ctrl, 0, 1)
+        .expect("셀 문단 병합");
+
+    let table = match &doc.document.sections[0].paragraphs[t_para].controls[t_ctrl] {
+        Control::Table(t) => t,
+        other => panic!("표가 아님: {other:?}"),
+    };
+    assert_eq!(
+        table.cells[0].paragraphs.len(),
+        1,
+        "셀 문단이 병합되어야 한다"
+    );
+    assert_eq!(
+        table.cells[0].paragraphs[0]
+            .controls
+            .iter()
+            .filter(|c| matches!(c, Control::Picture(_)))
+            .count(),
+        1,
+        "셀 백스페이스 병합 시 그림 컨트롤이 보존되어야 한다 (#1323)"
+    );
+}
+
+/// #1323: 셀에 그림을 붙여넣은 문서가 HWP5 직렬화 → 재파싱 후에도 그림을 보존한다.
+/// (char_count 역산·char_offsets 갭 인코딩이 직렬화 계약과 정합함을 검증)
+#[test]
+fn test_paste_picture_into_table_cell_hwp5_roundtrip() {
+    use crate::model::control::Control;
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    doc.copy_control_native(0, 0, &[], 0).expect("그림 복사");
+    doc.create_table_ex_native(0, 1, 0, 2, 2, true, None)
+        .expect("표 생성");
+    let (t_para, t_ctrl) = find_table_pos(&doc);
+    doc.paste_internal_in_cell_native(0, t_para, t_ctrl, 0, 0, 0)
+        .expect("셀에 그림 붙여넣기");
+
+    let bytes = doc.export_hwp_native().expect("HWP5 직렬화");
+    let doc2 = HwpDocument::from_bytes(&bytes).expect("재파싱");
+
+    let mut found = false;
+    for p in &doc2.document.sections[0].paragraphs {
+        for c in &p.controls {
+            if let Control::Table(t) = c {
+                for cell_para in t.cells.iter().flat_map(|cl| cl.paragraphs.iter()) {
+                    if cell_para
+                        .controls
+                        .iter()
+                        .any(|cc| matches!(cc, Control::Picture(_)))
+                    {
+                        found = true;
+                    }
+                }
+            }
+        }
+    }
+    assert!(
+        found,
+        "HWP5 round-trip 후에도 셀 안 그림 컨트롤이 보존되어야 한다 (#1323)"
+    );
+}
+
 #[test]
 fn test_clipboard_clear() {
     let mut doc = HwpDocument::create_empty();

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2328,6 +2328,112 @@ fn test_paste_picture_into_table_cell_hwp5_roundtrip() {
     );
 }
 
+/// #1323 시각 검증 보조: 표 셀/글상자에 붙여넣은 그림이 SVG 렌더링에 실제
+/// `<image>` 요소로 나타나는지 검증한다. BinData를 실제 등록(insert_picture)하여
+/// 렌더러가 data URI 이미지를 방출하는 경로를 그대로 사용한다.
+#[test]
+fn test_paste_picture_into_cell_and_textbox_renders_in_svg() {
+    fn minimal_png() -> Vec<u8> {
+        vec![
+            0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48,
+            0x44, 0x52, 0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00,
+            0x00, 0x1F, 0x15, 0xC4, 0x89, 0x00, 0x00, 0x00, 0x0A, 0x49, 0x44, 0x41, 0x54, 0x78,
+            0x9C, 0x63, 0x00, 0x01, 0x00, 0x00, 0x05, 0x00, 0x01, 0x0D, 0x0A, 0x00, 0x00, 0x00,
+            0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE, 0x42, 0x60, 0x82,
+        ]
+    }
+    fn parse_idx(res: &str, key: &str) -> usize {
+        res.split(&format!("\"{}\":", key))
+            .nth(1)
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("missing {key} in {res}"))
+    }
+    fn count_images(svg: &str) -> usize {
+        svg.matches("<image").count()
+    }
+
+    let mut doc = create_doc_with_floating_picture(true, 0, 0);
+    // 헬퍼의 기본 그림은 BinData가 없으므로 실제 그림을 별도 삽입해 사용한다
+    let res = doc
+        .insert_picture_native(
+            0,
+            1,
+            0,
+            &[],
+            &minimal_png(),
+            5000,
+            5000,
+            1,
+            1,
+            "png",
+            "",
+            None,
+            None,
+        )
+        .expect("본문 그림 삽입");
+    let pic_para = parse_idx(&res, "paraIdx");
+    let pic_ctrl = parse_idx(&res, "controlIdx");
+
+    let svg_before = doc.render_page_svg_native(0).expect("기준 SVG 렌더");
+    let base = count_images(&svg_before);
+    assert!(base >= 1, "본문 그림이 SVG에 렌더되어야 한다: {base}");
+
+    doc.copy_control_native(0, pic_para, &[], pic_ctrl)
+        .expect("그림 복사");
+
+    // 표 셀에 붙여넣기 → <image> 1개 증가
+    // (기존 문단은 모두 그림 컨트롤을 보유하므로 표 전용 빈 문단을 추가)
+    doc.document.sections[0]
+        .paragraphs
+        .push(Paragraph::default());
+    let empty_para = doc.document.sections[0].paragraphs.len() - 1;
+    doc.create_table_ex_native(0, empty_para, 0, 2, 2, true, None)
+        .expect("표 생성");
+    let (t_para, t_ctrl) = find_table_pos(&doc);
+    doc.paste_internal_in_cell_native(0, t_para, t_ctrl, 0, 0, 0)
+        .expect("셀에 그림 붙여넣기");
+
+    let svg_cell = doc.render_page_svg_native(0).expect("셀 paste 후 SVG 렌더");
+    assert_eq!(
+        count_images(&svg_cell),
+        base + 1,
+        "셀에 붙여넣은 그림이 SVG에 렌더되어야 한다 (#1323)"
+    );
+
+    // 글상자에 붙여넣기 → <image> 1개 더 증가
+    let tb_res = doc
+        .create_shape_control_native(
+            0,
+            t_para,
+            0,
+            21600,
+            7200,
+            0,
+            0,
+            true,
+            "TopAndBottom",
+            "textbox",
+            false,
+            false,
+            &[],
+        )
+        .expect("글상자 생성");
+    let tb_para = parse_idx(&tb_res, "paraIdx");
+    let tb_ctrl = parse_idx(&tb_res, "controlIdx");
+    doc.paste_internal_in_cell_native(0, tb_para, tb_ctrl, 0, 0, 0)
+        .expect("글상자에 그림 붙여넣기");
+
+    let svg_tb = doc
+        .render_page_svg_native(0)
+        .expect("글상자 paste 후 SVG 렌더");
+    assert_eq!(
+        count_images(&svg_tb),
+        base + 2,
+        "글상자에 붙여넣은 그림이 SVG에 렌더되어야 한다 (#1323)"
+    );
+}
+
 #[test]
 fn test_clipboard_clear() {
     let mut doc = HwpDocument::create_empty();


### PR DESCRIPTION
## 요약

본문 이미지를 복사해 글상자/표 셀 안에 붙여넣으면 에러 없이 조용히 누락되는 결함(#1323)을 model 계층 `Paragraph::merge_from` 보강으로 수정합니다.

Closes #1323

## 근본 원인

`copy_control_native`는 그림을 `text="" + controls=[Picture]` 문단으로 클립보드에 적재하는데, `merge_from`의 두 한계가 컨트롤을 드롭했습니다.

1. 빈 텍스트 early-return — `other.text`가 비면 즉시 반환
2. controls 미병합 — `controls`/`ctrl_data_records`/`control_mask`를 병합하는 코드 부재

## 변경 내역

| 파일 | 변경 |
|---|---|
| `src/model/paragraph.rs` | `merge_from` 보강: early-return 조건, utf16_end 컨트롤 갭 인코딩, controls/ctrl_data_records/control_mask 병합, char_count·has_para_text 정합 |
| `src/model/paragraph/tests.rs` | 단위 테스트 5건 (병합 의미론) |
| `src/wasm_api/tests.rs` | 통합 테스트 7건 (셀/path 셀/캡션 paste, 본문·셀 백스페이스 병합, HWP5 round-trip, SVG `<image>` 방출) |
| `src/document_core/commands/object_ops.rs` | `paste_picture_into_textbox` 테스트 추가, "별개 결함" 주석을 해소 사실로 갱신 |
| `mydocs/` | 수행·구현 계획서, stage1–3 보고서, 최종 보고서 |

클립보드/편집 명령 계층과 프론트엔드는 무변경(기존 라우팅 그대로 동작). model 계층 수정이므로 백스페이스 문단 병합·다중 문단 선택 삭제 등 merge_from 경유 경로의 동일 잠재 결함도 함께 해소됩니다.

## 직렬화·렌더링 계약 정합

- 컨트롤 위치 = char_offsets 8 code unit 갭 — 렌더링(`control_text_positions`)·HWP5 직렬화(`serialize_para_text` 갭 분석)가 병합 지점에 컨트롤 복원
- `char_count` = 텍스트 + 8×컨트롤 + 1 — `split_at`·HWPX 컨트롤 수 역산과 정합
- `ctrl_data_records[i] ↔ controls[i]` 인덱스 정렬 유지 (self None 패딩)
- HWP5 저장 round-trip 테스트로 실증

## 검증

- `cargo test` — 2150 passed / 0 failed (devel 430d5edc rebase 후)
- `cargo clippy -- -D warnings` — 무경고
- `cargo fmt --all -- --check` — 통과
- WASM 빌드 (`docker compose run wasm`) — 통과
- 시각 검증 (macOS, rhwp-studio): 글상자/표 셀 이미지 붙여넣기 렌더 정상, 텍스트 붙여넣기·본문 이미지 붙여넣기 무회귀, 셀 안 백스페이스 병합 그림 보존 — 4항목 확인 완료

## 범위 밖 관찰 (별도 이슈 후보)

- `merge_from`이 `tab_extended` 미병합 (탭 확장 데이터 소실 가능)
- `clipboard_has_control_native`가 클립보드 첫 문단만 검사 (다중 문단 컨트롤 처리)

🤖 Generated with [Claude Code](https://claude.com/claude-code)