### PR TITLE
docs: PR #1395/#1371 처리 기록

### DIFF
--- a/mydocs/orders/20260612.md
+++ b/mydocs/orders/20260612.md
@@ -13,6 +13,7 @@
 | #1392 | hp:shapeComment 미직렬화 | 등록 완료 | #1380 1단계 발견 ② 분리 |
 | #1393 | 표 pageBreak 속성 미보존 (일괄 TABLE 방출) | 등록 완료 | #1380 4단계 발견 ③ 분리 |
 | PR #1395 / #1394 | 미주 덤프와 sweep 검증 인프라 분리 | 완료 (CI 통과 + merge + close) | merge `ef14397a`, 리뷰 문서 archives 이동 |
+| PR #1371 / #1363 | 미주 높이 모델 측정 SSOT A3 opt-in | 완료 (CI·로컬 검증 통과 + merge + close 확인) | merge `0f0c7319`, trailing whitespace 직접 정리 `36a474ed`, 리뷰 문서 archives 이동 |
 
 ## #1379 — HWPX serializer: subList 내부 컨트롤 보존 (표 셀·글상자 내 이미지)
 

--- a/mydocs/orders/20260612.md
+++ b/mydocs/orders/20260612.md
@@ -12,6 +12,7 @@
 | #1391 | MEMO 필드(fieldBegin) subList 미직렬화 | 등록 완료 | #1380 1단계 발견 ① 분리 |
 | #1392 | hp:shapeComment 미직렬화 | 등록 완료 | #1380 1단계 발견 ② 분리 |
 | #1393 | 표 pageBreak 속성 미보존 (일괄 TABLE 방출) | 등록 완료 | #1380 4단계 발견 ③ 분리 |
+| PR #1395 / #1394 | 미주 덤프와 sweep 검증 인프라 분리 | 완료 (CI 통과 + merge + close) | merge `ef14397a`, 리뷰 문서 archives 이동 |
 
 ## #1379 — HWPX serializer: subList 내부 컨트롤 보존 (표 셀·글상자 내 이미지)
 

--- a/mydocs/pr/archives/pr_1371_review.md
+++ b/mydocs/pr/archives/pr_1371_review.md
@@ -1,0 +1,146 @@
+# PR #1371 리뷰 - 미주 높이 모델 측정 SSOT A3 opt-in
+
+- PR: https://github.com/edwardkim/rhwp/pull/1371
+- 제목: Task #1363: 미주 높이 모델 측정 SSOT - scratch 전-단 순차 렌더 (A3 opt-in)
+- 작성일: 2026-06-12
+- 작성자: `planet6897`
+- 관련 이슈: #1363
+- base: `devel`
+- head: `planet6897:task1363`
+- 상태: merged, draft 아님
+- merge commit: `0f0c7319cd88ecd2b78136df1907f1d541ed180c`
+
+## 1. 요약 판단
+
+GitHub 상태와 로컬 빌드/테스트 기준으로 merge 가능한 상태까지 회복됐다.
+
+메인터너 코멘트에서 지적한 `git diff --check` trailing whitespace 1건은
+`36a474ed`에서 직접 정리했고, 최신 head 기준 `git diff --check`도 통과했다.
+GitHub Actions와 로컬 사전 검증도 모두 통과했다.
+
+PR #1374가 이 PR 위에 쌓인 스택 PR이므로, #1374를 안전하게 처리하려면 #1371을 먼저
+처리하는 순서가 맞다.
+
+## 2. PR 정보
+
+| 항목 | 값 |
+|---|---|
+| 상태 | merged |
+| draft | false |
+| base | `devel` |
+| head | `planet6897:task1363` |
+| head SHA | `36a474ed6479f66a02bdd59a2605f24027874115` |
+| mergeable | `MERGEABLE` |
+| merge state | `CLEAN` |
+| merge commit | `0f0c7319cd88ecd2b78136df1907f1d541ed180c` |
+| 변경량 | 23 files, +8865 / -15 |
+| 연결 이슈 | #1363 |
+
+커밋:
+
+- `251b4c5a` - Task #1363: 미주 높이 모델 측정 SSOT - scratch 전-단 순차 렌더 (A3 opt-in)
+- `670b6a29` - Merge branch 'devel' into task1363
+- `36a474ed` - Task #1363: trailing whitespace 정리
+
+## 3. 메인터너 코멘트 확인
+
+메인터너 코멘트: https://github.com/edwardkim/rhwp/pull/1371#issuecomment-4677470193
+
+요청 사항과 현재 확인 결과:
+
+| 요청 | 현재 상태 |
+|---|---|
+| 최신 `devel` 기준으로 rebase/update | `670b6a29`에서 `devel` merge 반영, GitHub `CLEAN` |
+| `src/renderer/typeset.rs` 충돌 해소 | GitHub `MERGEABLE`, merge-tree 충돌 0 |
+| `EnSsotLevel` 기본값 `B` 유지 | diff상 `_ => EnSsotLevel::B`, `A3`는 env opt-in |
+| archive 문서 재도입 주의 | active `mydocs/plans/report/working` 문서 추가가 남아 있어 merge 후 archive 정리 필요 |
+| trailing whitespace 제거 | `36a474ed`에서 정리, `git diff --check` 통과 |
+| A3 기본 승격 금지 | PR 본문/코드 모두 `RHWP_EN_SSOT=A3` opt-in 유지 |
+
+inline review thread는 없다.
+
+## 4. 변경 범위
+
+### 4.1 `src/renderer/layout.rs`
+
+`LayoutEngine::measure_endnote_column_bottom` 경로를 추가해 미주 단 전체 items를 scratch
+`build_single_column`으로 렌더하고, 실제 렌더와 같은 단 bottom을 측정한다.
+
+목적:
+
+- per-para 고립 측정의 누적 오차를 줄인다.
+- 미주 단 전체 흐름을 렌더러와 같은 경로로 측정한다.
+- `RHWP_EN_SSOT=A3` opt-in에서 sim==render 확인 경로를 마련한다.
+
+### 4.2 `src/renderer/typeset.rs`
+
+`EnSsotLevel::A3`를 추가하고 `RHWP_EN_SSOT=A3`일 때만 scratch 전-단 측정을 사용한다.
+
+확인한 방향:
+
+- 기본값은 `B`로 유지된다.
+- `A3`는 opt-in이며 기본 렌더 경로를 바꾸지 않는다.
+- `issue_1082` 계열 overflow 확인용으로 A3 경로를 분리한다.
+
+### 4.3 문서
+
+Task #1363 계획서, 단계 문서, 보고서, 측정 TSV가 추가된다.
+
+주의:
+
+- 현재 PR diff에는 active `mydocs/plans`, `mydocs/report`, `mydocs/working` 문서가 포함된다.
+- 일부 archive 경로 문서도 함께 포함되어 있다.
+- merge 후 `mydocs/pr` 리뷰 문서와 함께 archive 정리 대상이다.
+
+## 5. 검증 결과
+
+### 5.1 GitHub Actions
+
+최신 head `36a474ed` 기준 전체 통과.
+
+| 체크 | 결과 |
+|---|---|
+| Build & Test | pass, 14m 58s |
+| Analyze (javascript-typescript) | pass |
+| Analyze (python) | pass |
+| Analyze (rust) | pass |
+| Canvas visual diff | pass |
+| CodeQL | pass |
+| WASM Build | skipped |
+
+### 5.2 로컬 사전 검증
+
+검증 worktree: `/tmp/rhwp-pr1371-fix`
+
+| 항목 | 결과 |
+|---|---|
+| `git merge upstream/devel --no-commit --no-ff` | `Already up to date`, 충돌 없음 |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `cargo build --lib` | 통과 |
+| `cargo test --lib` | 통과, 1724 passed / 0 failed / 6 ignored |
+| `cargo clippy -- -D warnings` | 통과 |
+| `cargo test --doc` | 통과, 0 passed / 0 failed / 1 ignored |
+| `cargo test --test svg_snapshot` | 통과, 8 passed / 0 failed |
+
+## 6. 리스크
+
+| 리스크 | 평가 |
+|---|---|
+| 기본 렌더 회귀 | 낮음. A3는 env opt-in |
+| A3 경로 품질 | 중간. PR 본문에서도 13건 hancom 배치 재보정은 후속 #1370 범위로 분리 |
+| 문서 정리 | 중간. active 작업 문서와 archive 문서가 함께 들어오므로 merge 후 정리 필요 |
+| whitespace | 해소됨. `36a474ed`와 `git diff --check`로 확인 |
+| #1374 스택 | 중요. #1374가 #1371 위에 있으므로 #1371 선처리가 필요 |
+
+## 7. 최종 권고
+
+merge 완료.
+
+후속 처리:
+
+1. #1371은 `0f0c7319`로 merge됐다.
+2. #1363은 closed 상태를 확인했다.
+3. `local/devel`은 `upstream/devel` 기준으로 rebase해 #1396 누락 문서 커밋을 보존했다.
+4. PR #1371 리뷰 문서는 `mydocs/pr/archives/`로 이동했다.
+5. 닫힌 PR #1396에 들어갔던 PR #1395 처리 문서도 같은 devel 문서 처리 흐름에 포함했다.
+6. 이후 #1374를 다시 검토한다.

--- a/mydocs/pr/archives/pr_1371_review_impl.md
+++ b/mydocs/pr/archives/pr_1371_review_impl.md
@@ -1,0 +1,133 @@
+# PR #1371 리뷰 처리 구현 계획서
+
+## 현재 상태
+
+| 항목 | 값 |
+|---|---|
+| PR | https://github.com/edwardkim/rhwp/pull/1371 |
+| 이슈 | #1363 |
+| base | `devel` |
+| head | `planet6897:task1363` |
+| head SHA | `36a474ed6479f66a02bdd59a2605f24027874115` |
+| mergeable | `MERGEABLE` |
+| merge state | `CLEAN` |
+| GitHub CI | 전체 통과 |
+| 로컬 사전 검증 | 빌드/테스트/Clippy/Doc-test/svg snapshot/`diff --check` 통과 |
+| merge commit | `0f0c7319cd88ecd2b78136df1907f1d541ed180c` |
+| 이슈 상태 | #1363 closed 확인 |
+
+## PR 커밋
+
+| # | SHA | 내용 |
+|---|---|---|
+| 1 | `251b4c5a` | Task #1363: 미주 높이 모델 측정 SSOT - scratch 전-단 순차 렌더 (A3 opt-in) |
+| 2 | `670b6a29` | Merge branch 'devel' into task1363 |
+| 3 | `36a474ed` | Task #1363: trailing whitespace 정리 |
+
+## Stage 구성
+
+### Stage 1 - 리뷰 문서 작성 - 완료
+
+- `mydocs/pr/pr_1371_review.md` 작성
+- `mydocs/pr/pr_1371_review_impl.md` 작성
+- 메인터너 코멘트, GitHub CI, 로컬 사전 검증 결과 기록
+- 메인터너 코멘트의 trailing whitespace 지적을 `36a474ed`로 직접 정리
+
+### Stage 2 - 로컬 사전 검증 - 완료
+
+임시 worktree:
+
+```bash
+git worktree add -B pr1371-whitespace-fix /tmp/rhwp-pr1371-fix local/pr1371
+```
+
+검증:
+
+```bash
+git merge upstream/devel --no-commit --no-ff
+git diff --check upstream/devel...HEAD
+cargo build --lib
+cargo test --lib
+cargo clippy -- -D warnings
+cargo test --doc
+cargo test --test svg_snapshot
+```
+
+결과:
+
+- merge 시뮬레이션: `Already up to date`
+- `git diff --check`: 통과
+- `cargo build --lib`: 통과
+- `cargo test --lib`: 1724 passed, 0 failed, 6 ignored
+- `cargo clippy -- -D warnings`: 통과
+- `cargo test --doc`: 통과
+- `cargo test --test svg_snapshot`: 8 passed, 0 failed
+
+### Stage 3 - GitHub Actions 최종 확인
+
+최종 확인:
+
+- `Build & Test`: 통과, 14m 58s
+- `Analyze (javascript-typescript)`: 통과
+- `Analyze (python)`: 통과
+- `Analyze (rust)`: 통과
+- `Canvas visual diff`: 통과
+- `CodeQL`: 통과
+- `WASM Build`: skipped
+
+### Stage 4 - merge
+
+작업지시자가 GitHub Actions와 local test 완료 후 merge를 지시했고, 두 조건을 모두
+충족했으므로 진행한다.
+
+```bash
+gh pr merge 1371 --repo edwardkim/rhwp --merge
+```
+
+결과:
+
+- `gh pr merge --admin`은 사용하지 않고 일반 merge로 처리했다.
+- merge commit: `0f0c7319cd88ecd2b78136df1907f1d541ed180c`
+- #1363 closed 상태를 확인했다.
+
+### Stage 5 - 후속 문서 정리
+
+merge 후 처리:
+
+```bash
+git fetch upstream
+git checkout local/devel
+git rebase upstream/devel
+```
+
+정리 대상:
+
+- `mydocs/pr/pr_1371_review.md` -> `mydocs/pr/archives/`
+- `mydocs/pr/pr_1371_review_impl.md` -> `mydocs/pr/archives/`
+- task #1363 active 문서 중 archive 정리 대상
+- `git diff --check`에서 잡힌 trailing whitespace
+- 닫힌 PR #1396의 누락 문서:
+  - `mydocs/orders/20260612.md`
+  - `mydocs/pr/archives/pr_1395_review.md`
+  - `mydocs/pr/archives/pr_1395_review_impl.md`
+
+결과:
+
+- `local/devel`을 `upstream/devel` 위로 rebase하면서 #1396 누락 문서 커밋을 보존했다.
+- `mydocs/pr/pr_1371_review.md`와 `mydocs/pr/pr_1371_review_impl.md`를 archives로 이동했다.
+- `mydocs/orders/20260612.md`에 PR #1371 처리 내역을 추가했다.
+
+## 위험 요소 요약
+
+| 위험 | 판단 |
+|---|---|
+| GitHub CI | 통과 |
+| 로컬 빌드/테스트 | 통과 |
+| trailing whitespace | 해소됨 |
+| 문서 중복/active 재도입 | merge 후 정리 필요 |
+| #1374 스택 | #1371 선처리 후 재검토 필요 |
+
+## 권고
+
+#1371은 GitHub Actions, 로컬 테스트, 메인터너 코멘트 반영을 모두 통과해 merge 완료됐다.
+문서 정리와 #1396 누락 문서 반영도 같은 후속 처리 흐름에 포함했다.

--- a/mydocs/pr/archives/pr_1395_review.md
+++ b/mydocs/pr/archives/pr_1395_review.md
@@ -1,0 +1,153 @@
+# PR #1395 검토 - 미주 덤프와 sweep 검증 인프라 분리
+
+- PR: https://github.com/edwardkim/rhwp/pull/1395
+- 제목: task 1394: 미주 덤프와 sweep 검증 인프라 분리
+- 작성일: 2026-06-12
+- 작성자: `jangster77`
+- 관련 이슈: #1394 "task 1293 후속: 미주 덤프와 sweep 검증 인프라 분리 제출"
+- base: `devel`
+- head: `jangster77:task_m100_1394`
+- 상태: open, draft 아님
+
+## 1. 요약 판단
+
+**작업지시자 승인 후 merge 가능**으로 판단한다.
+
+이번 PR은 Task 1293의 미주 pagination 구현 수정이 아니라, 후속 분석과 회귀 검증에 필요한
+덤프 CLI, sweep 분석 보강, 한컴 기준 샘플/PDF만 분리 제출한다. 렌더링 본체 파일인
+`typeset.rs`, `height_cursor.rs`, `layout.rs`는 변경하지 않는다.
+
+주의 사항은 변경량이 크다는 점이다. GitHub 기준 `+1641 / -16`, 29 files이며, 대부분은
+한컴 기준 샘플과 PDF 바이너리 추가다. 코드 변경은 `src/main.rs`의 덤프 CLI와
+`scripts/task1274_visual_sweep.py`의 분석 스크립트에 한정된다.
+
+## 2. PR 정보
+
+| 항목 | 값 |
+|---|---|
+| 상태 | open |
+| draft | false |
+| base | `devel` |
+| head | `jangster77:task_m100_1394` |
+| mergeable | `MERGEABLE` |
+| 변경량 | 29 files, +1641 / -16 |
+| assignee | `jangster77` |
+| 연결 이슈 | #1394, PR 본문 `Closes #1394` 포함 |
+
+커밋:
+
+- `40a33271` - task 1394: 미주 덤프 검증 인프라 분리
+- `47c25529` - Merge branch 'devel' into task_m100_1394
+- `0ead213a` - task 1394: clippy counter loop 수정
+
+## 3. 변경 범위
+
+### 3.1 `src/main.rs`
+
+덤프 보조 CLI 2개를 추가했다.
+
+- `dump-note-shape <파일.hwp|파일.hwpx>`
+  - 구역별 `footnoteShape`, `endnoteShape` raw 값을 JSON으로 출력한다.
+  - 한컴 UI 의미값인 구분선 위, 미주 사이, 구분선 아래 환산값을 함께 출력한다.
+- `dump-endnote-lines <파일.hwp> <section> <para> <control> [note-para]`
+  - 특정 미주 원본 문단의 `line_seg`, `TextRun`, 컨트롤 위치, TAC 수식 정보를 함께 출력한다.
+  - Task 1293에서 문제가 된 "문단 내 lineSegArray / line_seg / 글자처럼 취급해야 하는 수식" 추적용이다.
+
+### 3.2 `scripts/task1274_visual_sweep.py`
+
+미주/문항 흐름 sweep 검출을 보강했다.
+
+- frame overflow, column drift, question flow 후보를 분석 결과로 좁힐 수 있도록 확장
+- PDF/PNG/render tree 기반 비교에서 후속 구현 PR의 회귀 후보를 추적할 수 있도록 보강
+- Task 1274/1284에서 쌓인 수동 시각 검증 항목을 자동 후보 검출 쪽으로 일부 이관
+
+### 3.3 샘플과 한컴 기준 PDF
+
+한컴 미주 모양 설정별 샘플과 기준 PDF를 추가했다.
+
+- `3-11월_실전_통합_2024-*`
+  - 구분선 없음/있음
+  - 구분선 위 0/9/20
+  - 미주 사이 0/7/8/20
+  - 구분선 아래 0/2/7/20
+- `수식-문자처럼취급-아님`
+  - 수식이 무조건 글자처럼 취급되는 것은 아님을 확인하는 별도 샘플
+
+## 4. 제외 범위
+
+이번 PR은 다음을 포함하지 않는다.
+
+- 미주 pagination 구현 수정
+- `typeset.rs`, `height_cursor.rs`, `layout.rs` 렌더링 동작 변경
+- 실제 문제집 overflow/overlap 해결
+- golden SVG 갱신
+
+즉, 문제집 렌더링을 직접 고치는 PR이 아니라 후속 구현을 위한 관측/검증 인프라 PR이다.
+
+## 5. 검증 결과
+
+### 5.1 GitHub Actions
+
+최종 CI는 모두 통과했다.
+
+| 체크 | 결과 |
+|---|---|
+| Build & Test | pass |
+| Analyze (javascript-typescript) | pass |
+| Analyze (python) | pass |
+| Analyze (rust) | pass |
+| CodeQL | pass |
+| WASM Build | skipped (PR 조건상 skip) |
+
+### 5.2 로컬 사전 확인
+
+이번 PR 준비 중 확인한 항목:
+
+| 명령 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | 통과 |
+| `cargo build --verbose` | 통과 |
+| `cargo check --target wasm32-unknown-unknown --lib` | 통과 |
+| `cargo test --features native-skia skia --lib --verbose` | 통과 |
+
+참고:
+
+- 전체 `cargo test --verbose`는 상당 구간 통과 후 작업지시자 지시에 따라 중단했다.
+- `cargo nextest run`은 이 저장소에서 테스트 바이너리 `--list` 단계가 0% CPU로 오래 남아 완료 판정까지 가지 못했다.
+- 로컬 `cargo clippy -- -D warnings`도 macOS 로컬 환경에서 `clippy-driver` 대기 문제가 있었으나,
+  GitHub Actions의 `cargo clippy -- -D warnings`는 최종 통과했다.
+
+### 5.3 Merge 시뮬레이션
+
+`git merge-tree --write-tree upstream/devel HEAD` 결과 `rc=0`으로 충돌 없음.
+
+## 6. 리스크
+
+| 리스크 | 평가 |
+|---|---|
+| 렌더링 회귀 | 낮음. 렌더링 본체 변경 없음 |
+| 샘플/PDF 용량 증가 | 있음. 한컴 기준 회귀 검증용으로 의도된 추가 |
+| sweep 오탐/미탐 | 있음. 자동 판정이 아니라 후보 좁히기 도구로 봐야 함 |
+| `src/main.rs` CLI 충돌 | 중간. PR #1366, #1359도 `src/main.rs`를 건드리나 현재 #1395 자체는 mergeable |
+| 후속 구현 오해 | 낮음. PR 본문과 이 리뷰에서 구현 수정 제외 범위를 명시 |
+
+## 7. 최종 권고
+
+작업지시자 승인 후 merge 가능하다.
+
+권고 순서:
+
+1. 작업지시자에게 merge 승인 확인
+2. 승인 시 PR #1395 merge
+3. #1394 auto-close 여부 확인
+4. `local/devel` sync
+5. 본 리뷰 문서와 구현 계획서를 archives로 이동
+
+## 8. 후속 처리 결과
+
+- 작업지시자 승인: 2026-06-12 "진행"
+- merge 완료: PR #1395, merge commit `ef14397a1800aa897521f31fb62c04b2350ea21b`
+- 이슈 #1394: GitHub auto-close가 동작하지 않아 수동 close
+- PR 코멘트: merge 완료와 검증 결과 요약 등록
+- `local/devel`: `upstream/devel` 기준 rebase 완료
+- 리뷰 문서: archives 이동

--- a/mydocs/pr/archives/pr_1395_review_impl.md
+++ b/mydocs/pr/archives/pr_1395_review_impl.md
@@ -1,0 +1,129 @@
+# PR #1395 리뷰 처리 구현 계획서
+
+## PR 커밋 3개
+
+| # | SHA | 내용 |
+|---|---|---|
+| 1 | `40a33271` | task 1394: 미주 덤프 검증 인프라 분리 |
+| 2 | `47c25529` | Merge branch 'devel' into task_m100_1394 |
+| 3 | `0ead213a` | task 1394: clippy counter loop 수정 |
+
+## 현재 상태
+
+| 항목 | 값 |
+|---|---|
+| PR | https://github.com/edwardkim/rhwp/pull/1395 |
+| 이슈 | #1394 |
+| base | `devel` |
+| head | `jangster77:task_m100_1394` |
+| mergeable | `MERGEABLE` |
+| CI | Build & Test, CodeQL 모두 통과 |
+| assignee | PR/이슈 모두 `jangster77` 지정 완료 |
+
+## Stage 구성
+
+### Stage 1 - 리뷰 문서 작성 - 완료
+
+- `mydocs/pr/pr_1395_review.md` 작성
+- `mydocs/pr/pr_1395_review_impl.md` 작성
+- PR 메타, 변경 범위, CI, merge 시뮬레이션 결과 기록
+
+### Stage 2 - 작업지시자 승인 대기 - 완료
+
+머지는 별도 명시 승인이 필요하다. 2026-06-12 작업지시자가 "진행"으로 승인했다.
+
+확인 요청 포맷:
+
+```text
+PR #1395 검토 결과 merge 준비 완료.
+
+- base: devel
+- mergeable: MERGEABLE
+- CI: Build & Test / CodeQL 통과
+- 충돌 시뮬레이션: 0건
+- 리뷰 문서: mydocs/pr/pr_1395_review.md
+
+merge 진행할까요?
+```
+
+### Stage 3 - 승인 시 merge - 완료
+
+작업지시자가 명시적으로 merge를 승인한 경우에만 진행한다.
+
+```bash
+gh pr merge 1395 --repo edwardkim/rhwp --merge
+```
+
+주의:
+
+- `gh pr merge --admin`, auto-merge 활성화, GitHub UI merge는 작업지시자의 명시 지시 없이는 수행하지 않는다.
+- 현재 세션은 PR 작성자 계정 `jangster77`로 로그인되어 있으므로, merge 지시는 반드시 별도로 확인한다.
+
+처리 결과:
+
+- `gh pr merge 1395 --repo edwardkim/rhwp --merge`
+- merge commit: `ef14397a1800aa897521f31fb62c04b2350ea21b`
+
+### Stage 4 - 이슈 close 확인 - 완료
+
+PR 본문에 `Closes #1394`가 포함되어 있으므로 auto-close가 기대된다.
+merge 후 반드시 확인한다.
+
+```bash
+gh issue view 1394 --repo edwardkim/rhwp --json state,closedAt
+```
+
+열려 있으면 작업지시자 승인 후 수동 close한다.
+
+처리 결과:
+
+- #1394는 merge 직후에도 OPEN
+- `gh issue close 1394 --repo edwardkim/rhwp --comment ...`로 수동 close
+
+### Stage 5 - devel sync - 완료
+
+merge 후 로컬 `local/devel`을 원본 `devel`에 맞춘다.
+
+```bash
+git fetch upstream
+git checkout local/devel
+git rebase upstream/devel
+```
+
+처리 결과:
+
+- `local/devel`을 `upstream/devel` merge commit까지 rebase 완료
+
+### Stage 6 - 리뷰 문서 archives 이동 - 완료
+
+merge 완료 후 처리 기록을 archives로 이동한다.
+
+```bash
+mv mydocs/pr/pr_1395_review.md mydocs/pr/archives/
+mv mydocs/pr/pr_1395_review_impl.md mydocs/pr/archives/
+```
+
+### Stage 7 - 후속 작업
+
+- Task 1293 본 구현 PR에서 #1395의 샘플/덤프 CLI/sweep 지표를 기준으로 미주 공통 로직을 재분석한다.
+- #1366 또는 #1359가 먼저 병합되면 `src/main.rs` CLI 영역 rebase 충돌 여부를 재확인한다.
+
+## 작업지시자 확인 필요 사항
+
+| 항목 | 제안 |
+|---|---|
+| merge 여부 | 승인 후 진행 |
+| merge 방식 | 일반 merge |
+| 후속 sync | merge 후 `local/devel` rebase |
+| 이슈 #1394 | auto-close 확인, 실패 시 수동 close 승인 요청 |
+| 리뷰 문서 | merge 후 archives 이동 |
+
+## 위험 요소 요약
+
+| 위험 | 평가 |
+|---|---|
+| 코드 충돌 | 낮음. 현재 merge-tree 충돌 0 |
+| CI 회귀 | 낮음. GitHub Actions 통과 |
+| 렌더링 회귀 | 낮음. 렌더링 본체 변경 없음 |
+| 샘플 용량 증가 | 의도된 검증 fixture 추가 |
+| 실제 미주 문제 미해결 | 의도된 제외 범위. 후속 Task 1293 구현에서 처리 |


### PR DESCRIPTION
## 내용

- 닫힌 PR #1396에 포함되지 못한 PR #1395 처리 기록을 다시 포함합니다.
- PR #1371 처리 기록과 로컬/GitHub 검증 결과를 archives에 추가합니다.
- 2026-06-12 작업 기록에 PR #1371 merge 결과를 추가합니다.

## 확인

- PR #1371 merge commit: `0f0c7319cd88ecd2b78136df1907f1d541ed180c`
- PR #1371 GitHub Actions 통과 확인
- PR #1371 로컬 사전 검증 통과 확인
- PR #1396은 closed 상태라 재사용하지 않고, 원본 저장소 브랜치에서 새 PR로 처리합니다.