### PR TITLE
fix(hwpx): 그림/도형/묶음 캡션(hp:caption) 파싱·직렬화 누락 — roundtrip 캡션 소실 (#1403)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1868,7 +1868,7 @@ fn pack_hwpx_common_obj_attr(common: &CommonObjAttr) -> u32 {
     attr
 }
 
-/// 표 캡션 파싱
+/// `<hp:caption>` 파싱 — 표(#1387)·그림/도형/묶음(#1403) 공유.
 fn parse_table_caption(
     e: &quick_xml::events::BytesStart,
     reader: &mut Reader<&[u8]>,
@@ -2172,6 +2172,7 @@ fn parse_picture(
 
     // 이미지 속성 읽기
     let mut has_pos = false; // <pos> 파싱 여부 — <offset>이 덮어쓰지 않도록 방지
+    let mut caption: Option<crate::model::shape::Caption> = None;
     let mut buf = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
@@ -2183,6 +2184,10 @@ fn parse_picture(
             }
             Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"effects" => {
                 effects = parse_picture_effects(reader)?;
+            }
+            // 그림 캡션 (#1403) — 미적재 시 roundtrip 에서 캡션 subList 소실
+            Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"caption" => {
+                caption = Some(parse_table_caption(ce, reader)?);
             }
             Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce)) => {
                 let cname = ce.name();
@@ -2435,6 +2440,7 @@ fn parse_picture(
     pic.border_y = border_y;
     pic.instance_id = picture_instance_id;
     pic.effects = effects;
+    pic.caption = caption;
 
     Ok(Control::Picture(Box::new(pic)))
 }
@@ -3451,11 +3457,16 @@ fn parse_shape_object(
     let object_ids = parse_object_element_attrs(e, &mut common, &mut shape_attr);
 
     let tag_name = String::from_utf8_lossy(shape_type).to_string();
+    let mut caption: Option<crate::model::shape::Caption> = None;
     let mut buf = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"shapeComment" => {
                 common.description = read_dutmal_text(reader, b"shapeComment")?;
+            }
+            // 도형 캡션 (#1403) — 미적재 시 roundtrip 에서 캡션 subList 소실
+            Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"caption" => {
+                caption = Some(parse_table_caption(ce, reader)?);
             }
             Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce)) => {
                 let cname = ce.name();
@@ -3617,7 +3628,7 @@ fn parse_shape_object(
         shadow_alpha,
         inst_id: object_ids.instid,
         text_box,
-        ..Default::default()
+        caption,
     };
 
     let shape = match shape_type {
@@ -3692,9 +3703,14 @@ fn parse_container(
 
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
 
+    let mut caption: Option<crate::model::shape::Caption> = None;
     let mut buf = Vec::new();
     loop {
         match reader.read_event_into(&mut buf) {
+            // 묶음 개체 캡션 (#1403) — 미적재 시 roundtrip 에서 캡션 subList 소실
+            Ok(Event::Start(ref ce)) if local_name(ce.name().as_ref()) == b"caption" => {
+                caption = Some(parse_table_caption(ce, reader)?);
+            }
             Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce)) => {
                 let cname = ce.name();
                 let local = local_name(cname.as_ref());
@@ -3755,7 +3771,7 @@ fn parse_container(
         common,
         shape_attr,
         children,
-        caption: None,
+        caption,
     };
 
     Ok(Control::Shape(Box::new(ShapeObject::Group(group))))

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -36,14 +36,18 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
+use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
 
 /// `<hp:pic>` 직렬화 진입점.
+///
+/// ctx 가 `&mut` 인 이유: 캡션 subList 문단 직렬화(#1403)가 para id 발급과
+/// para_shape/style 참조 수집을 수행한다 (표 캡션 #1387 과 동일 경로).
 pub fn write_picture<W: Write>(
     w: &mut Writer<W>,
     pic: &Picture,
-    ctx: &SerializeContext,
+    ctx: &mut SerializeContext,
 ) -> Result<(), SerializeError> {
     // --- <hp:pic> 속성 ---
     // 속성 순서 (PictureType + 부모 AbstractShapeObjectType):
@@ -92,6 +96,10 @@ pub fn write_picture<W: Write>(
     write_sz(w, &pic.common)?;
     write_pos(w, &pic.common)?;
     write_out_margin(w, &pic.common)?;
+    // 캡션 (#1403) — 한컴 실물(aift.hwpx) 자식 순서: outMargin 뒤, 마지막 자식
+    if let Some(cap) = &pic.caption {
+        write_caption(w, cap, ctx)?;
+    }
 
     end_tag(w, "hp:pic")?;
     Ok(())
@@ -502,7 +510,7 @@ mod tests {
         doc
     }
 
-    fn serialize(pic: &Picture, ctx: &SerializeContext) -> String {
+    fn serialize(pic: &Picture, ctx: &mut SerializeContext) -> String {
         let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
         write_picture(&mut w, pic, ctx).expect("write_picture");
         String::from_utf8(w.into_inner()).unwrap()
@@ -511,9 +519,9 @@ mod tests {
     #[test]
     fn pic_root_attrs_in_canonical_order() {
         let doc = make_doc_with_bin(1, "png");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let pic = make_picture(1);
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(xml.contains("<hp:pic "));
         let ip = xml.find("id=").unwrap();
         let zp = xml.find("zOrder=").unwrap();
@@ -527,9 +535,9 @@ mod tests {
     #[test]
     fn img_uses_manifest_id() {
         let doc = make_doc_with_bin(5, "jpg");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let pic = make_picture(5);
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(
             xml.contains(r#"binaryItemIDRef="image1""#),
             "binaryItemIDRef must resolve to manifest id image1: {}",
@@ -540,7 +548,7 @@ mod tests {
     #[test]
     fn shape_component_attrs_are_serialized() {
         let doc = make_doc_with_bin(1, "png");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let mut pic = make_picture(1);
         pic.shape_attr.original_width = 23456;
         pic.shape_attr.original_height = 12345;
@@ -551,7 +559,7 @@ mod tests {
         pic.shape_attr.rotation_center.y = 14794;
         pic.shape_attr.rotate_image = true;
 
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(
             xml.contains(r#"<hp:orgSz width="23456" height="12345"/>"#),
             "orgSz must use ShapeComponentAttr values: {}",
@@ -574,10 +582,10 @@ mod tests {
     #[test]
     fn unresolved_bin_data_id_errors() {
         let doc = Document::default(); // bin_data 없음
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let pic = make_picture(99); // 미등록 id
         let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
-        let err = write_picture(&mut w, &pic, &ctx).unwrap_err();
+        let err = write_picture(&mut w, &pic, &mut ctx).unwrap_err();
         let msg = format!("{}", err);
         assert!(msg.contains("binaryItemIDRef"), "error msg: {}", msg);
         assert!(
@@ -590,9 +598,9 @@ mod tests {
     #[test]
     fn rendering_info_has_three_matrices() {
         let doc = make_doc_with_bin(1, "png");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let pic = make_picture(1);
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(xml.contains("<hc:transMatrix "));
         assert!(xml.contains("<hc:scaMatrix "));
         assert!(xml.contains("<hc:rotMatrix "));
@@ -601,9 +609,9 @@ mod tests {
     #[test]
     fn img_rect_has_four_points() {
         let doc = make_doc_with_bin(1, "png");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let pic = make_picture(1);
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(xml.contains("<hc:pt0 "));
         assert!(xml.contains("<hc:pt1 "));
         assert!(xml.contains("<hc:pt2 "));
@@ -620,7 +628,7 @@ mod tests {
     #[test]
     fn picture_effects_shadow_are_serialized() {
         let doc = make_doc_with_bin(1, "png");
-        let ctx = SerializeContext::collect_from_document(&doc);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
         let mut pic = make_picture(1);
         pic.effects = PictureEffects {
             shadow: Some(PictureShadow {
@@ -650,12 +658,56 @@ mod tests {
             }),
         };
 
-        let xml = serialize(&pic, &ctx);
+        let xml = serialize(&pic, &mut ctx);
         assert!(xml.contains(r#"<hp:shadow style="OUTSIDE" alpha="0.8" radius="400" direction="45" distance="1000" alignStyle="TOP_LEFT" rotationStyle="0">"#));
         assert!(xml.contains(r#"<hp:scale x="1" y="1"/>"#));
         assert!(xml.contains(
             r#"<hp:effectsColor type="RGB" schemeIdx="-1" systemIdx="-1" presetIdx="-1">"#
         ));
         assert!(xml.contains(r#"<hp:rgb r="0" g="0" b="0"/>"#));
+    }
+
+    // ---------- #1403: 그림 캡션 직렬화 ----------
+
+    #[test]
+    fn task1403_pic_caption_is_serialized() {
+        // 캡션 유실(#1403) 회귀 고정 — 한컴 실물(aift.hwpx) 순서: outMargin 뒤 마지막 자식.
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "그림 캡션".to_string();
+        let mut cap = crate::model::shape::Caption::default();
+        cap.width = 8504;
+        cap.spacing = 850;
+        cap.max_width = 48081;
+        cap.paragraphs.push(para);
+        pic.caption = Some(cap);
+
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(
+                r#"<hp:caption side="BOTTOM" fullSz="0" width="8504" gap="850" lastWidth="48081">"#
+            ),
+            "caption 속성이 IR 값으로 방출되어야 함: {}",
+            xml
+        );
+        assert!(
+            xml.contains("<hp:t>그림 캡션</hp:t>"),
+            "캡션 subList 문단 텍스트가 방출되어야 함: {}",
+            xml
+        );
+        let om = xml.find("<hp:outMargin").unwrap();
+        let cp = xml.find("<hp:caption").unwrap();
+        assert!(om < cp, "caption 은 outMargin 뒤 (한컴 실물 순서)");
+    }
+
+    #[test]
+    fn task1403_pic_without_caption_emits_none() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let pic = make_picture(1);
+        let xml = serialize(&pic, &mut ctx);
+        assert!(!xml.contains("<hp:caption"), "캡션 부재 시 미방출: {}", xml);
     }
 }

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -37,6 +37,11 @@
 //! - 표 캡션 비교 (`diff_table_caption`) 를 `TableCaption` 으로 게이트 동승 —
 //!   존재 비대칭/속성 5종/문단 수. 캡션 내부 문단은 char_shapes·controls·linesegs
 //!   재귀에 `tbl.caption.p[k]` 경로로 동승한다.
+//!
+//! #1403 확장:
+//! - 그림/도형/묶음 캡션을 `ObjectCaption` 으로 게이트 동승 — Picture 컨트롤은
+//!   `pic.caption`, ShapeObject 는 `shape_caption` 접근자(그리기 도형 `drawing.caption`
+//!   + Group/Chart/Ole/Picture 전용 필드) 경유. 비교·재귀는 #1387 경로 공유.
 
 #![allow(dead_code)]
 
@@ -162,6 +167,16 @@ pub enum IrDifference {
         path: String,
         detail: String,
     },
+    /// 그림/도형/묶음 캡션 불일치 — 캡션 보존 게이트 (#1403).
+    ///
+    /// `path` 는 `…pic.caption` / `…shape.caption` 등 중첩 경로. `detail` 형식은
+    /// `TableCaption` 과 동일 (`diff_table_caption` 공유).
+    ObjectCaption {
+        section: usize,
+        paragraph: usize,
+        path: String,
+        detail: String,
+    },
 }
 
 impl std::fmt::Display for IrDifference {
@@ -247,6 +262,16 @@ impl std::fmt::Display for IrDifference {
                 write!(f, "section[{}] page_def: {}", section, detail)
             }
             TableCaption {
+                section,
+                paragraph,
+                path,
+                detail,
+            } => write!(
+                f,
+                "section[{}] paragraph[{}]{} caption: {}",
+                section, paragraph, path, detail
+            ),
+            ObjectCaption {
                 section,
                 paragraph,
                 path,
@@ -383,6 +408,7 @@ pub fn diff_documents(a: &Document, b: &Document) -> IrDiff {
 
 /// 표 캡션 비교 (#1387). 존재 비대칭/속성/문단 수 불일치를 "field: expected=..
 /// actual=.." 세미콜론 연결로 돌려준다. 일치하면 `None`.
+/// 그림/도형/묶음 캡션(#1403)도 동일 비교를 공유한다 (`ObjectCaption` 으로 보고).
 ///
 /// `vert_align` 은 비교 제외 — HWPX `hp:caption` 에 대응 속성이 없는 HWP5 유래
 /// 필드라(#1387 1단계 전수 측정) serializer 가 방출하지 않으며, HWP5 출발 플로우
@@ -772,6 +798,24 @@ fn diff_paragraph_char_shapes(
                     }
                 }
             }
+            // 그림 캡션 비교 (#1403) — 존재/속성/문단 수 + 내부 문단 재귀.
+            (Control::Picture(pia), Control::Picture(pib)) => {
+                if let Some(detail) = diff_table_caption(&pia.caption, &pib.caption) {
+                    diff.push(IrDifference::ObjectCaption {
+                        section,
+                        paragraph,
+                        path: format!("{path}/ctrl[{ci}]pic.caption"),
+                        detail,
+                    });
+                }
+                if let (Some(ca), Some(cb)) = (&pia.caption, &pib.caption) {
+                    for (k, (qa, qb)) in ca.paragraphs.iter().zip(cb.paragraphs.iter()).enumerate()
+                    {
+                        let p = format!("{path}/ctrl[{ci}]pic.caption.p[{k}]");
+                        diff_paragraph_char_shapes(diff, section, paragraph, &p, qa, qb);
+                    }
+                }
+            }
             (Control::Shape(sa), Control::Shape(sb)) => {
                 let p = format!("{path}/ctrl[{ci}]shape");
                 diff_shape_char_shapes(diff, section, paragraph, &p, sa, sb);
@@ -809,6 +853,22 @@ fn diff_shape_char_shapes(
             diff_paragraph_char_shapes(diff, section, paragraph, &p, qa, qb);
         }
     }
+    // 도형/묶음 캡션 비교 (#1403) — 존재/속성/문단 수 + 내부 문단 재귀.
+    let (capa, capb) = (shape_caption(sa), shape_caption(sb));
+    if let Some(detail) = diff_table_caption(capa, capb) {
+        diff.push(IrDifference::ObjectCaption {
+            section,
+            paragraph,
+            path: format!("{path}.caption"),
+            detail,
+        });
+    }
+    if let (Some(ca), Some(cb)) = (capa, capb) {
+        for (k, (qa, qb)) in ca.paragraphs.iter().zip(cb.paragraphs.iter()).enumerate() {
+            let p = format!("{path}.caption.p[{k}]");
+            diff_paragraph_char_shapes(diff, section, paragraph, &p, qa, qb);
+        }
+    }
     if let (ShapeObject::Group(ga), ShapeObject::Group(gb)) = (sa, sb) {
         for (k, (c1, c2)) in ga.children.iter().zip(gb.children.iter()).enumerate() {
             let p = format!("{path}.child[{k}]");
@@ -830,6 +890,24 @@ fn shape_text_box(s: &crate::model::shape::ShapeObject) -> Option<&crate::model:
         Chart(x) => x.drawing.text_box.as_ref(),
         Ole(x) => x.drawing.text_box.as_ref(),
         Group(_) | Picture(_) => None,
+    }
+}
+
+/// ShapeObject 에서 캡션 필드 참조를 꺼낸다 (#1403).
+/// 그리기 도형은 `drawing.caption`, 묶음/그림/차트/OLE 는 각자의 caption 필드.
+fn shape_caption(s: &crate::model::shape::ShapeObject) -> &Option<crate::model::shape::Caption> {
+    use crate::model::shape::ShapeObject::*;
+    match s {
+        Line(x) => &x.drawing.caption,
+        Rectangle(x) => &x.drawing.caption,
+        Ellipse(x) => &x.drawing.caption,
+        Arc(x) => &x.drawing.caption,
+        Polygon(x) => &x.drawing.caption,
+        Curve(x) => &x.drawing.caption,
+        Chart(x) => &x.caption,
+        Ole(x) => &x.caption,
+        Group(x) => &x.caption,
+        Picture(x) => &x.caption,
     }
 }
 
@@ -1602,5 +1680,105 @@ mod tests {
         let doc2 = parse_hwpx(&out).expect("reparse");
         let diff = diff_documents(&doc1, &doc2);
         assert!(diff.is_empty(), "{:?}", diff.differences);
+    }
+
+    // ---------- #1403: 그림/도형/묶음 캡션 (게이트 동승) ----------
+
+    #[test]
+    fn task1403_pic_caption_loss_in_gate() {
+        // #1403 결함 본체였던 그림 캡션 소실(원본 유 → RT 무)을 게이트가 검출하는지 고정.
+        let mut pa = crate::model::image::Picture::default();
+        pa.caption = Some(caption_with_paras(1));
+        let pb = crate::model::image::Picture::default();
+        let a = doc_with_control(crate::model::control::Control::Picture(Box::new(pa)));
+        let b = doc_with_control(crate::model::control::Control::Picture(Box::new(pb)));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::ObjectCaption { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]pic.caption");
+                assert_eq!(detail, "missing: expected=Some actual=None");
+            }
+            other => panic!("ObjectCaption 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task1403_line_caption_loss_in_gate() {
+        // 그리기 도형(drawing.caption) 경로 — line 캡션 소실 검출.
+        let mut la = crate::model::shape::LineShape::default();
+        la.drawing.caption = Some(caption_with_paras(1));
+        let lb = crate::model::shape::LineShape::default();
+        let a = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Line(la),
+        )));
+        let b = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Line(lb),
+        )));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::ObjectCaption { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]shape.caption");
+                assert_eq!(detail, "missing: expected=Some actual=None");
+            }
+            other => panic!("ObjectCaption 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task1403_legacy_shape_caption_roundtrips() {
+        // legacy 문자열 경로(ellipse/arc/polygon/curve/chart/ole)의 캡션 방출 검증 —
+        // HWP5 파서는 모든 도형 캡션을 적재하므로(parser/control/shape.rs) 미방출 시
+        // HWP5→HWPX 변환에서 소실된다. serialize→reparse 후 게이트 차이 0 이어야 한다.
+        let mut cap = caption_with_paras(1);
+        cap.width = 8504;
+        cap.paragraphs[0].text = "타원 캡션".to_string();
+        // 빈 char_shapes 는 reparse 시 [(0,0)] 으로 돌아오므로(픽스처 노이즈) 명시한다.
+        cap.paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let mut el = crate::model::shape::EllipseShape::default();
+        el.drawing.caption = Some(cap);
+        let mut a = roundtrip_doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Ellipse(el),
+        )));
+        a.sections[0].paragraphs[0].char_shapes = to_refs(&[(0, 0)]);
+        let out = serialize_hwpx(&a).expect("serialize");
+        let b = parse_hwpx(&out).expect("reparse");
+        let diff = diff_documents(&a, &b);
+        assert!(diff.is_empty(), "{:?}", diff.differences);
+        // 텍스트 보존 직접 확인
+        match &b.sections[0].paragraphs[1].controls[0] {
+            crate::model::control::Control::Shape(s) => match s.as_ref() {
+                crate::model::shape::ShapeObject::Ellipse(e2) => {
+                    let c2 = e2.drawing.caption.as_ref().expect("캡션 보존");
+                    assert_eq!(c2.paragraphs[0].text, "타원 캡션");
+                }
+                other => panic!("Ellipse 여야 함: {other:?}"),
+            },
+            other => panic!("Shape 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task1403_group_caption_loss_in_gate() {
+        // 묶음 개체(GroupShape.caption) 경로 — container 캡션 소실 검출.
+        let mut ga = crate::model::shape::GroupShape::default();
+        ga.caption = Some(caption_with_paras(1));
+        let gb = crate::model::shape::GroupShape::default();
+        let a = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Group(ga),
+        )));
+        let b = doc_with_control(crate::model::control::Control::Shape(Box::new(
+            crate::model::shape::ShapeObject::Group(gb),
+        )));
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::ObjectCaption { path, detail, .. } => {
+                assert_eq!(path, "/ctrl[0]shape.caption");
+                assert_eq!(detail, "missing: expected=Some actual=None");
+            }
+            other => panic!("ObjectCaption 여야 함: {other:?}"),
+        }
     }
 }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -967,7 +967,7 @@ fn render_shape(shape: &ShapeObject, ctx: &mut SerializeContext) -> String {
     }
     // Line: Writer-based serializer
     if let ShapeObject::Line(l) = shape {
-        return match writer_to_string(|w| super::shape::write_line(w, l)) {
+        return match writer_to_string(|w| super::shape::write_line(w, l, ctx)) {
             Ok(xml) => xml,
             Err(e) => {
                 eprintln!("[hwpx] Shape::Line 직렬화 실패: {e}");
@@ -986,18 +986,20 @@ fn render_shape(shape: &ShapeObject, ctx: &mut SerializeContext) -> String {
         for child in &g.children {
             xml.push_str(&render_shape(child, ctx));
         }
-        match writer_to_string(super::shape::write_container_close) {
+        // 캡션 (#1403) 은 자식 도형 뒤에 방출 — 한컴 실물(aift.hwpx) 순서
+        match writer_to_string(|w| super::shape::write_container_close(w, g.caption.as_ref(), ctx))
+        {
             Ok(close) => xml.push_str(&close),
             Err(e) => eprintln!("[hwpx] Shape::Group 닫기 실패: {e}"),
         }
         return xml;
     }
-    let (tag, c) = match shape {
+    let (tag, c, caption) = match shape {
         ShapeObject::Rectangle(_) | ShapeObject::Line(_) => unreachable!(),
-        ShapeObject::Ellipse(e) => ("ellipse", &e.common),
-        ShapeObject::Arc(a) => ("arc", &a.common),
-        ShapeObject::Polygon(p) => ("polygon", &p.common),
-        ShapeObject::Curve(cv) => ("curve", &cv.common),
+        ShapeObject::Ellipse(e) => ("ellipse", &e.common, &e.drawing.caption),
+        ShapeObject::Arc(a) => ("arc", &a.common, &a.drawing.caption),
+        ShapeObject::Polygon(p) => ("polygon", &p.common, &p.drawing.caption),
+        ShapeObject::Curve(cv) => ("curve", &cv.common, &cv.drawing.caption),
         ShapeObject::Group(_) => unreachable!(),
         ShapeObject::Picture(pic) => {
             return match writer_to_string(|w| picture::write_picture(w, pic, ctx)) {
@@ -1008,20 +1010,24 @@ fn render_shape(shape: &ShapeObject, ctx: &mut SerializeContext) -> String {
                 }
             };
         }
-        ShapeObject::Chart(ch) => ("chart", &ch.common),
-        ShapeObject::Ole(o) => ("ole", &o.common),
+        ShapeObject::Chart(ch) => ("chart", &ch.common, &ch.caption),
+        ShapeObject::Ole(o) => ("ole", &o.common, &o.caption),
     };
-    render_common_shape_xml(tag, c)
+    render_common_shape_xml(tag, c, caption, ctx)
 }
 
-fn render_common_shape_xml(tag: &str, c: &CommonObjAttr) -> String {
-    format!(
+fn render_common_shape_xml(
+    tag: &str,
+    c: &CommonObjAttr,
+    caption: &Option<crate::model::shape::Caption>,
+    ctx: &mut SerializeContext,
+) -> String {
+    let mut out = format!(
         concat!(
             r#"<hp:{tag} id="{id}" zOrder="{zo}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="0">"#,
             r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
             r#"<hp:pos treatAsChar="{tac}" vertRelTo="{vr}" vertAlign="{va}" horzRelTo="{hr}" horzAlign="{ha}" vertOffset="{vo}" horzOffset="{ho}"/>"#,
             r#"<hp:outMargin left="{ml}" right="{mr}" top="{mt}" bottom="{mb}"/>"#,
-            r#"</hp:{tag}>"#,
         ),
         tag = tag,
         id = c.instance_id,
@@ -1040,7 +1046,17 @@ fn render_common_shape_xml(tag: &str, c: &CommonObjAttr) -> String {
         mr = c.margin.right,
         mt = c.margin.top,
         mb = c.margin.bottom,
-    )
+    );
+    // 캡션 (#1403) — HWP5 파서는 모든 도형의 캡션을 적재하므로(parser/control/shape.rs)
+    // legacy 경로(ellipse/arc/polygon/curve/chart/ole)도 방출해야 소실되지 않는다.
+    if let Some(cap) = caption {
+        match writer_to_string(|w| super::table::write_caption(w, cap, ctx)) {
+            Ok(xml) => out.push_str(&xml),
+            Err(e) => eprintln!("[hwpx] Shape({tag}) 캡션 직렬화 실패: {e}"),
+        }
+    }
+    out.push_str(&format!("</hp:{tag}>"));
+    out
 }
 
 fn render_note_sublist(

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -27,6 +27,7 @@ use crate::model::ColorRef;
 
 use super::context::SerializeContext;
 use super::section::{render_hp_p_open, render_paragraph_parts};
+use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs, text};
 use super::SerializeError;
 
@@ -101,6 +102,10 @@ pub fn write_rect<W: Write>(
     write_sz(w, c)?;
     write_pos(w, c)?;
     write_out_margin(w, c)?;
+    // 캡션 (#1403) — OWPML AbstractShapeObjectType 순서: outMargin 과 shapeComment 사이
+    if let Some(cap) = &rect.drawing.caption {
+        write_caption(w, cap, ctx)?;
+    }
     write_shape_comment(w, c)?;
 
     end_tag(w, "hp:rect")?;
@@ -112,7 +117,11 @@ pub fn write_rect<W: Write>(
 // =====================================================================
 
 /// `<hp:line>` 직렬화 진입점. LineShape IR → XML.
-pub fn write_line<W: Write>(w: &mut Writer<W>, line: &LineShape) -> Result<(), SerializeError> {
+pub fn write_line<W: Write>(
+    w: &mut Writer<W>,
+    line: &LineShape,
+    ctx: &mut SerializeContext,
+) -> Result<(), SerializeError> {
     let c = &line.common;
     let id_str = c.instance_id.to_string();
     let z_order = c.z_order.to_string();
@@ -149,6 +158,10 @@ pub fn write_line<W: Write>(w: &mut Writer<W>, line: &LineShape) -> Result<(), S
     write_sz(w, c)?;
     write_pos(w, c)?;
     write_out_margin(w, c)?;
+    // 캡션 (#1403) — OWPML AbstractShapeObjectType 순서: outMargin 뒤
+    if let Some(cap) = &line.drawing.caption {
+        write_caption(w, cap, ctx)?;
+    }
 
     end_tag(w, "hp:line")?;
     Ok(())
@@ -192,7 +205,16 @@ pub fn write_container_open<W: Write>(
     Ok(())
 }
 
-pub fn write_container_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError> {
+/// `<hp:container>` 닫기 — 캡션(#1403)은 자식 도형 뒤에 방출한다.
+/// 한컴 실물(aift.hwpx) 자식 순서: [자식 도형들] → sz → pos → outMargin → caption.
+pub fn write_container_close<W: Write>(
+    w: &mut Writer<W>,
+    caption: Option<&crate::model::shape::Caption>,
+    ctx: &mut SerializeContext,
+) -> Result<(), SerializeError> {
+    if let Some(cap) = caption {
+        write_caption(w, cap, ctx)?;
+    }
     end_tag(w, "hp:container")
 }
 
@@ -842,7 +864,8 @@ mod tests {
 
     fn serialize_line(line: &LineShape) -> String {
         let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
-        write_line(&mut w, line).expect("write_line");
+        let mut ctx = SerializeContext::collect_from_document(&Default::default());
+        write_line(&mut w, line, &mut ctx).expect("write_line");
         String::from_utf8(w.into_inner()).unwrap()
     }
 
@@ -1150,5 +1173,62 @@ mod tests {
         let mut xml = String::new();
         std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read section0");
         assert!(xml.contains("1.579917"), "scaMatrix 비정수 값 보존");
+    }
+
+    // ---------- #1403: 도형 캡션 직렬화 ----------
+
+    fn caption_with_text(text: &str) -> crate::model::shape::Caption {
+        let mut para = Paragraph::default();
+        para.text = text.to_string();
+        let mut caption = crate::model::shape::Caption::default();
+        caption.width = 8504;
+        caption.spacing = 850;
+        caption.max_width = 47624;
+        caption.paragraphs.push(para);
+        caption
+    }
+
+    #[test]
+    fn task1403_rect_caption_is_serialized() {
+        // OWPML AbstractShapeObjectType 순서: outMargin → caption → shapeComment.
+        let mut rect = RectangleShape::default();
+        rect.common.description = "설명".to_string();
+        rect.drawing.caption = Some(caption_with_text("사각형 캡션"));
+        let xml = serialize_rect(&rect);
+        assert!(
+            xml.contains("<hp:t>사각형 캡션</hp:t>"),
+            "캡션 subList 문단 텍스트가 방출되어야 함: {}",
+            xml
+        );
+        let om = xml.find("<hp:outMargin").unwrap();
+        let cp = xml.find("<hp:caption").unwrap();
+        let sc = xml.find("<hp:shapeComment").unwrap();
+        assert!(
+            om < cp && cp < sc,
+            "caption 은 outMargin 과 shapeComment 사이"
+        );
+    }
+
+    #[test]
+    fn task1403_line_caption_is_serialized() {
+        let mut line = LineShape::default();
+        line.drawing.caption = Some(caption_with_text("선 캡션"));
+        let xml = serialize_line(&line);
+        assert!(
+            xml.contains("<hp:t>선 캡션</hp:t>"),
+            "캡션 subList 문단 텍스트가 방출되어야 함: {}",
+            xml
+        );
+        let om = xml.find("<hp:outMargin").unwrap();
+        let cp = xml.find("<hp:caption").unwrap();
+        assert!(om < cp, "caption 은 outMargin 뒤");
+    }
+
+    #[test]
+    fn task1403_shape_without_caption_emits_none() {
+        let xml = serialize_rect(&RectangleShape::default());
+        assert!(!xml.contains("<hp:caption"), "캡션 부재 시 미방출: {}", xml);
+        let xml = serialize_line(&LineShape::default());
+        assert!(!xml.contains("<hp:caption"), "캡션 부재 시 미방출: {}", xml);
     }
 }

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -290,7 +290,8 @@ fn write_sub_list_paragraphs<W: Write>(
 /// 속성 순서는 한컴 실물(ta-pic-001-r) 기준: side, fullSz, width, gap, lastWidth.
 /// 캡션 subList 속성은 파서가 적재하지 않으며 samples/hwpx 전수 17건 동일
 /// (vertAlign=TOP lineWrap=BREAK textDirection=HORIZONTAL — 1단계 측정) — 실물 고정값 방출.
-fn write_caption<W: Write>(
+/// 그림/도형/묶음 캡션(#1403)도 동일 경로를 공유한다 (pub(super)).
+pub(super) fn write_caption<W: Write>(
     w: &mut Writer<W>,
     caption: &crate::model::shape::Caption,
     ctx: &mut SerializeContext,

--- a/tests/issue_1403_pic_shape_caption_roundtrip.rs
+++ b/tests/issue_1403_pic_shape_caption_roundtrip.rs
@@ -1,0 +1,140 @@
+//! #1403 회귀 — 그림/도형/묶음 캡션(hp:caption)이 HWPX roundtrip 에서 보존되는지 검증.
+//!
+//! aift.hwpx section2 실측(코퍼스 전수 중 비표 캡션 보유 유일 샘플):
+//! pic 캡션 9건 + container(묶음) 캡션 2건. 수정 전에는 파서가 캡션을 적재하지
+//! 않고 serializer 도 방출하지 않아 roundtrip 후 전량 소실되었다.
+
+use rhwp::model::control::Control;
+use rhwp::model::document::Document;
+use rhwp::model::paragraph::Paragraph;
+use rhwp::model::shape::{Caption, ShapeObject};
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+fn caption_text(cap: &Caption) -> String {
+    cap.paragraphs
+        .iter()
+        .map(|p| p.text.as_str())
+        .collect::<Vec<_>>()
+        .join("")
+}
+
+/// (종류, 캡션 텍스트) 수집 — 본문/표 셀/글상자/묶음 자식까지 재귀.
+fn collect_object_captions(doc: &Document) -> Vec<(&'static str, String)> {
+    let mut out = Vec::new();
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            walk_para(para, &mut out);
+        }
+    }
+    out
+}
+
+fn walk_para(para: &Paragraph, out: &mut Vec<(&'static str, String)>) {
+    for ctrl in &para.controls {
+        match ctrl {
+            Control::Table(t) => {
+                for cell in &t.cells {
+                    for p in &cell.paragraphs {
+                        walk_para(p, out);
+                    }
+                }
+            }
+            Control::Picture(pic) => {
+                if let Some(cap) = &pic.caption {
+                    out.push(("pic", caption_text(cap)));
+                }
+            }
+            Control::Shape(shape) => walk_shape(shape, out),
+            _ => {}
+        }
+    }
+}
+
+fn walk_shape(shape: &ShapeObject, out: &mut Vec<(&'static str, String)>) {
+    let (kind, cap): (&'static str, &Option<Caption>) = match shape {
+        ShapeObject::Line(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Rectangle(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Ellipse(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Arc(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Polygon(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Curve(x) => ("shape", &x.drawing.caption),
+        ShapeObject::Chart(x) => ("shape", &x.caption),
+        ShapeObject::Ole(x) => ("shape", &x.caption),
+        ShapeObject::Group(x) => ("group", &x.caption),
+        ShapeObject::Picture(x) => ("pic", &x.caption),
+    };
+    if let Some(c) = cap {
+        out.push((kind, caption_text(c)));
+    }
+    if let Some(tb) = shape_text_box(shape) {
+        for p in &tb.paragraphs {
+            walk_para(p, out);
+        }
+    }
+    if let ShapeObject::Group(g) = shape {
+        for child in &g.children {
+            walk_shape(child, out);
+        }
+    }
+}
+
+fn shape_text_box(s: &ShapeObject) -> Option<&rhwp::model::shape::TextBox> {
+    match s {
+        ShapeObject::Line(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Rectangle(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Ellipse(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Arc(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Polygon(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Curve(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Chart(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Ole(x) => x.drawing.text_box.as_ref(),
+        ShapeObject::Group(_) | ShapeObject::Picture(_) => None,
+    }
+}
+
+fn count_kind(caps: &[(&'static str, String)], kind: &str) -> usize {
+    caps.iter().filter(|(k, _)| *k == kind).count()
+}
+
+#[test]
+fn issue_1403_captions_roundtrip_aift() {
+    let bytes = std::fs::read("samples/hwpx/aift.hwpx").expect("샘플 읽기");
+    let doc1 = parse_hwpx(&bytes).expect("parse 원본");
+
+    // 1) 파서 적재 — section2 실측 분포: pic 9 + container 2
+    let caps1 = collect_object_captions(&doc1);
+    assert_eq!(count_kind(&caps1, "pic"), 9, "pic 캡션 적재: {caps1:?}");
+    assert_eq!(count_kind(&caps1, "group"), 2, "묶음 캡션 적재: {caps1:?}");
+    let texts1: Vec<&str> = caps1.iter().map(|(_, t)| t.as_str()).collect();
+    assert!(
+        texts1
+            .iter()
+            .any(|t| t.contains("주관기관이 보유한 오케스트레이션 아키텍처")),
+        "실물 pic 캡션 텍스트 적재: {texts1:?}"
+    );
+    assert!(
+        texts1
+            .iter()
+            .any(|t| t.contains("서울소방재난본부 인공지능 건축허가 시스템 화면")),
+        "실물 묶음 캡션 텍스트 적재: {texts1:?}"
+    );
+
+    // 2) roundtrip 보존 — serialize → reparse 후 종류별 개수 + 텍스트 multiset 동일
+    let out = serialize_hwpx(&doc1).expect("serialize");
+    let doc2 = parse_hwpx(&out).expect("reparse");
+    let caps2 = collect_object_captions(&doc2);
+    assert_eq!(count_kind(&caps2, "pic"), 9, "pic 캡션 보존: {caps2:?}");
+    assert_eq!(count_kind(&caps2, "group"), 2, "묶음 캡션 보존: {caps2:?}");
+    let mut t1: Vec<String> = caps1.iter().map(|(_, t)| t.clone()).collect();
+    let mut t2: Vec<String> = caps2.iter().map(|(_, t)| t.clone()).collect();
+    t1.sort();
+    t2.sort();
+    assert_eq!(t1, t2, "캡션 텍스트 보존");
+
+    // 3) 2-round 안정성 — 재직렬화 후에도 동일
+    let out2 = serialize_hwpx(&doc2).expect("2-round serialize");
+    let doc3 = parse_hwpx(&out2).expect("2-round reparse");
+    let caps3 = collect_object_captions(&doc3);
+    assert_eq!(caps2.len(), caps3.len(), "2-round 캡션 개수 안정");
+}


### PR DESCRIPTION
## 배경 (#1403)

aift.hwpx 의 그림/도형 캡션이 roundtrip 에서 전량 소실되는 문제의 수정입니다. 코퍼스 전수(54파일, Contents XML 162파트)에서 비표(非表) 캡션 보유 샘플은 aift.hwpx 가 유일했고, 실측 분포는 캡션의 부모 요소 기준 **pic 9건 + container 2건** (+#1387 해소분 tbl 2건) 이었습니다 — 이슈 본문의 "pic 8 + line 3" 과 총량 11건은 동일하고 분류 기준만 다른 것으로 보입니다 (`hp:line` 요소 자체가 코퍼스에 0건이라, line 3건은 container 내부 선 그리기를 가리키는 것으로 추정).

## 원인 — 3중 누락

1. **파서**: `parse_picture`/`parse_shape_object`/`parse_container` 모두 `hp:caption` arm 부재 — 파스 시점에 소실 (모델 필드 `Picture.caption`/`DrawingObjAttr.caption`/`GroupShape.caption` 은 존재하나 HWPX 경로는 미적재; HWP5 파서는 `parser/control/shape.rs` 에서 전 도형 적재 중이므로 비대칭)
2. **serializer**: 그림/도형/묶음 writer 가 caption 미방출
3. **게이트**: Picture 컨트롤 arm 자체가 없고, Shape arm 도 caption 미방문 — 대칭 소실이라 차이 0 으로 통과

## 수정

**파서** — `parse_table_caption`(#1387, 범용) 공유:
- `parse_picture` / `parse_shape_object`(rect·ellipse·line·arc·polygon·curve 공통) / `parse_container` 에 `b"caption"` Start-guard arm 추가

**serializer** — `write_caption`(#1387) 을 `pub(super)` 로 공유:
- `write_picture`: outMargin 뒤 마지막 자식 (한컴 실물 aift.hwpx 순서)
- `write_rect`: outMargin 과 shapeComment 사이 (OWPML AbstractShapeObjectType 순서)
- `write_line`: outMargin 뒤 (+ `ctx` 파라미터 추가)
- `write_container_close`: 자식 도형 뒤 (한컴 실물 순서: [자식들] → sz → pos → outMargin → caption)
- `render_common_shape_xml`(legacy 문자열 경로): **ellipse/arc/polygon/curve/chart/ole 도 caption 방출** — HWP5 파서가 전 도형 캡션을 적재하므로 미방출 시 HWP5→HWPX 변환에서 소실되는 기존 결함도 함께 해소
- `write_picture`/`write_line`/`write_container_close` 의 `ctx` 가 `&mut` 로 변경 (캡션 subList 문단 직렬화가 para id 발급·참조 수집을 수행 — 표 캡션과 동일 경로)

**게이트** — #1387 패턴 동승:
- `IrDifference::ObjectCaption` 신설 (표기 형식은 `TableCaption` 과 동일, `diff_table_caption` 공유)
- `Control::Picture` arm 신설: 캡션 비교 + 내부 문단 재귀 (`pic.caption.p[k]`)
- `diff_shape_char_shapes`: `shape_caption` 접근자(그리기 6종 `drawing.caption` + Group/Chart/Ole/Picture 전용 필드) 경유 비교 + 재귀 — Group 자식은 기존 재귀로 자동 동승

## 검증

- 신규 테스트 10건:
  - 게이트 4 (pic/line/group 소실 검출 + legacy ellipse serialize→reparse 왕복)
  - 방출 5 (pic/rect/line XML 배치 + 캡션 부재 시 미방출 2)
  - 통합 1 (`tests/issue_1403_pic_shape_caption_roundtrip.rs`): aift.hwpx 파스 적재(9+2, 실물 캡션 텍스트 확인) → serialize → reparse 보존(개수+텍스트 multiset) → 2-round 안정
- `hwpx_roundtrip_baseline` 전수 + `xfail_entries_still_fail` 가드 그린 (aift 는 신설 캡션 비교가 켜진 상태로 통과)
- `cargo fmt --check` / `cargo clippy --all-targets -- -D warnings` / `cargo test` 전체 그린 (1742 + 통합 전부)

## 범위 한정

- HWPX 파서의 chart/ole 요소 파싱은 본 PR 범위 밖 (HWP5 유래 IR 의 방출만 보강). 
- 캡션 subList 속성은 #1387 1단계 측정대로 실물 고정값 방출 경로를 그대로 공유합니다.

Closes #1403
