### PR TITLE
render: widen strict bitmap/svg glyph payload corpus

### DIFF
--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -232,6 +232,9 @@ the default public replay path.
   identity and appends the interned resource's `blake3` key when bytes are
   available. Two exports that reuse `imageRef: 0` or `svgRef: 0` for different
   producer bytes therefore do not share a strict glyph cache slot.
+- The schema minor version and feature arrays advertise the P24 additions:
+  `text.glyphOutline.payloadResourceDigestKey` and
+  `text.glyphOutline.svgGlyph.vectorResourceId`.
 - `BitmapGlyph` remains strict only for a single producer-selected strike with
   deterministic alpha, scaling, filtering, finite placement, non-empty text and
   glyph ranges, and no `backendDefault` scaling policy.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -220,6 +220,29 @@ resource identity and native font-construction blockers explicit.
 - The public compatibility path is unchanged: unsupported or unconstructed
   glyph variants continue to use the `TextRun` fallback.
 
+## P24 Strict Bitmap/SVG Glyph Producer Corpus
+
+P24 widens the advanced glyph payload corpus without making bitmap or SVG glyphs
+the default public replay path.
+
+- `ResourceArena` can now intern image bytes and static SVG fragments alongside
+  font blobs, giving producer-output fixtures a concrete resource path instead
+  of only hand-authored numeric ids.
+- `payloadResourceKey` keeps the existing payload-family/source/placement
+  identity and appends the interned resource's `blake3` key when bytes are
+  available. Two exports that reuse `imageRef: 0` or `svgRef: 0` for different
+  producer bytes therefore do not share a strict glyph cache slot.
+- `BitmapGlyph` remains strict only for a single producer-selected strike with
+  deterministic alpha, scaling, filtering, finite placement, non-empty text and
+  glyph ranges, and no `backendDefault` scaling policy.
+- `SvgGlyph` remains strict only for a static sanitized vector resource with a
+  required finite positive `viewBox`; script, animation, external resources, and
+  interactivity flags must all stay false. JSON keeps the compatibility `svgRef`
+  field and also exposes `vectorResourceId` as the clearer static-vector alias.
+- Even when a backend explicitly enables the bitmap or SVG glyph family, invalid
+  strict payloads still reject and the schema-v1 compatibility export keeps the
+  `TextRun` fallback.
+
 Every overlay removal requires a Canvas2D-vs-CanvasKit fixture. Rasterizer
 output can use fuzzy PNG comparison, but semantic decisions must be exact:
 selected variant id, fallback reason, resource resolution, effect preprocessing

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -63,7 +63,7 @@ impl PageLayerTree {
         write_text_source_entries(&mut buf, &self.text_sources);
         buf.push_str(",\"fontResources\":");
         write_font_resources(&mut buf, self.resources.font_resources());
-        write_text_export_metadata(&mut buf, &self.root);
+        write_text_export_metadata(&mut buf, &self.root, &self.resources);
         buf.push_str(",\"textV2\":");
         TextV2Diagnostics::from_layer_tree(self).write_json(&mut buf);
         buf.push('}');
@@ -71,9 +71,9 @@ impl PageLayerTree {
     }
 }
 
-fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
+fn write_text_export_metadata(buf: &mut String, root: &LayerNode, resources: &ResourceArena) {
     let externalized_visuals = externalized_text_visuals(root);
-    let text_variant_features = collect_text_variant_features(root);
+    let text_variant_features = collect_text_variant_features(root, resources);
     let has_variant_groups = text_variant_features.has_variant_groups();
     let has_glyph_runs = text_variant_features.has_glyph_runs;
     let has_glyph_outlines = text_variant_features.has_glyph_outlines;
@@ -82,6 +82,8 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     let has_glyph_outline_svg = text_variant_features.has_glyph_outline_svg;
     let has_glyph_outline_payload_resource_keys =
         text_variant_features.has_glyph_outline_payload_resource_keys;
+    let has_glyph_outline_payload_resource_digest_keys =
+        text_variant_features.has_glyph_outline_payload_resource_digest_keys;
     let has_display_text = text_variant_features.has_display_text;
     buf.push_str(",\"usedFeatures\":[\"text.paintStyle\",\"text.sourceTable\",\"text.sourceSpan\",\"text.v2.placement\",\"text.v2.clusters\",\"text.v2.diagnostics\",\"text.projectionKind\",\"text.legacyVisuals\",\"layer.optionMetadata\"");
     if has_display_text {
@@ -101,9 +103,13 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     }
     if has_glyph_outline_svg {
         buf.push_str(",\"text.glyphOutline.svgGlyph\"");
+        buf.push_str(",\"text.glyphOutline.svgGlyph.vectorResourceId\"");
     }
     if has_glyph_outline_payload_resource_keys {
         buf.push_str(",\"text.glyphOutline.payloadResourceKey\"");
+    }
+    if has_glyph_outline_payload_resource_digest_keys {
+        buf.push_str(",\"text.glyphOutline.payloadResourceDigestKey\"");
     }
     if has_variant_groups {
         buf.push_str(",\"text.variantGroups\"");
@@ -137,9 +143,13 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
     }
     if has_glyph_outline_svg {
         optional_features.push("text.glyphOutline.svgGlyph");
+        optional_features.push("text.glyphOutline.svgGlyph.vectorResourceId");
     }
     if has_glyph_outline_payload_resource_keys {
         optional_features.push("text.glyphOutline.payloadResourceKey");
+    }
+    if has_glyph_outline_payload_resource_digest_keys {
+        optional_features.push("text.glyphOutline.payloadResourceDigestKey");
     }
     buf.push_str("],\"optionalFeatures\":[");
     for (idx, feature) in optional_features.iter().enumerate() {
@@ -148,7 +158,7 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode) {
         }
         buf.push_str(&json_escape(feature));
     }
-    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.glyphOutline.colorLayers\",\"text.glyphOutline.colorLayers.colrV0\",\"text.glyphOutline.colorLayers.colrV1\",\"text.glyphOutline.bitmapGlyph\",\"text.glyphOutline.svgGlyph\",\"text.glyphOutline.payloadResourceKey\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.glyphOutline.colorLayers\",\"text.glyphOutline.colorLayers.colrV0\",\"text.glyphOutline.colorLayers.colrV1\",\"text.glyphOutline.bitmapGlyph\",\"text.glyphOutline.svgGlyph\",\"text.glyphOutline.svgGlyph.vectorResourceId\",\"text.glyphOutline.payloadResourceKey\",\"text.glyphOutline.payloadResourceDigestKey\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
         buf.push_str(",\"glyphRun\"");
     }
@@ -173,6 +183,7 @@ struct TextVariantFeatureFlags {
     has_glyph_outline_bitmap: bool,
     has_glyph_outline_svg: bool,
     has_glyph_outline_payload_resource_keys: bool,
+    has_glyph_outline_payload_resource_digest_keys: bool,
     has_display_text: bool,
 }
 
@@ -182,7 +193,10 @@ impl TextVariantFeatureFlags {
     }
 }
 
-fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
+fn collect_text_variant_features(
+    root: &LayerNode,
+    resources: &ResourceArena,
+) -> TextVariantFeatureFlags {
     let mut features = TextVariantFeatureFlags::default();
     let mut stack = vec![root];
     while let Some(node) = stack.pop() {
@@ -214,6 +228,9 @@ fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
                                 matches!(outline.payload_kind, GlyphOutlinePayloadKind::SvgGlyph);
                             features.has_glyph_outline_payload_resource_keys |=
                                 outline.has_payload_resource_key();
+                            features.has_glyph_outline_payload_resource_digest_keys |= outline
+                                .payload_resource_key_with_resources(Some(resources))
+                                .is_some_and(|key| key.contains(":resource:"));
                         }
                         _ => {}
                     }
@@ -226,6 +243,7 @@ fn collect_text_variant_features(root: &LayerNode) -> TextVariantFeatureFlags {
             && features.has_glyph_outline_bitmap
             && features.has_glyph_outline_svg
             && features.has_glyph_outline_payload_resource_keys
+            && features.has_glyph_outline_payload_resource_digest_keys
             && features.has_display_text
         {
             return features;
@@ -3405,13 +3423,17 @@ mod tests {
             &resource_digest_hex(svg_fragment.as_bytes()),
         );
 
+        assert!(json.contains("\"schemaMinorVersion\":17"));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
         assert!(json.contains(&format!(":resource:{image_resource_key}\"")));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:svgGlyph:svgRef:0"));
         assert!(json.contains(&format!(":resource:{svg_resource_key}\"")));
+        assert!(json.contains("\"vectorResourceId\":0"));
         assert!(json.contains("\"strictVisualContract\":true"));
         assert!(json.contains("\"staticSanitizedContract\":true"));
         assert!(json.contains("\"text.glyphOutline.payloadResourceKey\""));
+        assert!(json.contains("\"text.glyphOutline.payloadResourceDigestKey\""));
+        assert!(json.contains("\"text.glyphOutline.svgGlyph.vectorResourceId\""));
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -228,9 +228,8 @@ fn collect_text_variant_features(
                                 matches!(outline.payload_kind, GlyphOutlinePayloadKind::SvgGlyph);
                             features.has_glyph_outline_payload_resource_keys |=
                                 outline.has_payload_resource_key();
-                            features.has_glyph_outline_payload_resource_digest_keys |= outline
-                                .payload_resource_key_with_resources(Some(resources))
-                                .is_some_and(|key| key.contains(":resource:"));
+                            features.has_glyph_outline_payload_resource_digest_keys |=
+                                has_payload_resource_digest_key(outline, resources);
                         }
                         _ => {}
                     }
@@ -250,6 +249,25 @@ fn collect_text_variant_features(
         }
     }
     features
+}
+
+fn has_payload_resource_digest_key(
+    outline: &crate::paint::LayerGlyphOutlinePaint,
+    resources: &ResourceArena,
+) -> bool {
+    match outline.payload_kind {
+        GlyphOutlinePayloadKind::BitmapGlyph => outline
+            .bitmap_glyph
+            .as_ref()
+            .is_some_and(|payload| resources.image_bytes(payload.image_ref).is_some()),
+        GlyphOutlinePayloadKind::SvgGlyph => outline
+            .svg_glyph
+            .as_ref()
+            .is_some_and(|payload| resources.svg_fragment(payload.svg_ref).is_some()),
+        GlyphOutlinePayloadKind::ColorLayers
+        | GlyphOutlinePayloadKind::MonochromeFill
+        | GlyphOutlinePayloadKind::MonochromeFillStroke => false,
+    }
 }
 
 fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {
@@ -3152,7 +3170,7 @@ mod tests {
                 color_layers: Some(ColorLayersPayload {
                     color_format: ColorGlyphFormat::ColrV1,
                     source_font_ref: Some(FontColorGlyphRef {
-                        face_key: Some("fixture-face".to_string()),
+                        face_key: Some("fixture:resource:face".to_string()),
                         glyph_id: Some(42),
                         palette_index: Some(0),
                         color_format: Some(ColorGlyphFormat::ColrV1),
@@ -3185,7 +3203,7 @@ mod tests {
                             source_range_utf8: Some(TextSourceRange::new(0, 1)),
                             glyph_range: Some(GlyphRange::new(0, 1)),
                             source_font_ref: Some(FontColorGlyphRef {
-                                face_key: Some("fixture-face".to_string()),
+                                face_key: Some("fixture:resource:face".to_string()),
                                 glyph_id: Some(42),
                                 palette_index: Some(0),
                                 color_format: Some(ColorGlyphFormat::ColrV1),
@@ -3246,6 +3264,12 @@ mod tests {
         assert!(json.contains("\"text.glyphOutline.colorLayers\""));
         assert!(json.contains("\"text.glyphOutline.colorLayers.colrV1\""));
         assert!(json.contains("\"text.glyphOutline.payloadResourceKey\""));
+        assert_eq!(
+            json.matches("\"text.glyphOutline.payloadResourceDigestKey\"")
+                .count(),
+            1,
+            "color-layer metadata containing ':resource:' must not advertise a resource digest payload feature"
+        );
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -295,6 +295,9 @@ fn has_payload_resource_digest_key(
     outline: &crate::paint::LayerGlyphOutlinePaint,
     resources: &ResourceArena,
 ) -> bool {
+    if !outline.has_payload_resource_key() {
+        return false;
+    }
     match outline.payload_kind {
         GlyphOutlinePayloadKind::BitmapGlyph => outline
             .bitmap_glyph
@@ -3384,6 +3387,18 @@ mod tests {
         };
         assert!(!incomplete_bitmap_outline.has_payload_resource_key());
         assert!(incomplete_bitmap_outline.payload_resource_key().is_none());
+        let mut resources = ResourceArena::default();
+        let invalid_image_id = resources.intern_image_bytes(&[1, 2, 3, 4]);
+        let mut invalid_bitmap_with_resource = incomplete_bitmap_outline.clone();
+        invalid_bitmap_with_resource
+            .bitmap_glyph
+            .as_mut()
+            .unwrap()
+            .image_ref = invalid_image_id;
+        assert!(!has_payload_resource_digest_key(
+            &invalid_bitmap_with_resource,
+            &resources
+        ));
         let bitmap_outline = PaintOp::GlyphOutline {
             bbox: BoundingBox::new(0.0, 0.0, 20.0, 20.0),
             outline: Box::new(LayerGlyphOutlinePaint {

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -27,6 +27,39 @@ use crate::renderer::{
     ShadowStyle, ShapeStyle, StrokeDash, TabLeaderInfo, TextStyle,
 };
 
+const KNOWN_TEXT_FEATURES: &[&str] = &[
+    "fontResources",
+    "fontResources.blobFaceSplit",
+    "text.variantGroups",
+    "text.shapeDiagnostics",
+    "text.v2.diagnostics",
+    "text.v2.slotDiagnostics",
+    "text.v2.validationIssues",
+    "text.lineBreakRiskTelemetry",
+    "text.fallbackFreeStrictProfile",
+    "text.glyphRun",
+    "text.outlineGlyph",
+    "text.glyphOutline",
+    "text.glyphOutline.strictSidecar",
+    "text.glyphOutline.monochromeFill",
+    "text.glyphOutline.monochromeFillStroke",
+    "text.glyphOutline.colorLayers",
+    "text.glyphOutline.colorLayers.colrV0",
+    "text.glyphOutline.colorLayers.colrV1",
+    "text.glyphOutline.bitmapGlyph",
+    "text.glyphOutline.svgGlyph",
+    "text.glyphOutline.svgGlyph.vectorResourceId",
+    "text.glyphOutline.payloadResourceKey",
+    "text.glyphOutline.payloadResourceDigestKey",
+    "text.specialVisualOps",
+    "text.charOverlapOp",
+    "text.controlMarkOp",
+    "text.tabLeaderOp",
+    "text.decorationOp",
+    "text.displayText",
+    "text.vertical.mixedPerGlyph",
+];
+
 impl PageLayerTree {
     pub fn to_json(&self) -> String {
         let mut buf = String::with_capacity(32_768);
@@ -158,7 +191,14 @@ fn write_text_export_metadata(buf: &mut String, root: &LayerNode, resources: &Re
         }
         buf.push_str(&json_escape(feature));
     }
-    buf.push_str("],\"knownFeatures\":[\"fontResources\",\"fontResources.blobFaceSplit\",\"text.variantGroups\",\"text.shapeDiagnostics\",\"text.v2.diagnostics\",\"text.v2.slotDiagnostics\",\"text.v2.validationIssues\",\"text.lineBreakRiskTelemetry\",\"text.fallbackFreeStrictProfile\",\"text.glyphRun\",\"text.outlineGlyph\",\"text.glyphOutline\",\"text.glyphOutline.strictSidecar\",\"text.glyphOutline.monochromeFill\",\"text.glyphOutline.monochromeFillStroke\",\"text.glyphOutline.colorLayers\",\"text.glyphOutline.colorLayers.colrV0\",\"text.glyphOutline.colorLayers.colrV1\",\"text.glyphOutline.bitmapGlyph\",\"text.glyphOutline.svgGlyph\",\"text.glyphOutline.svgGlyph.vectorResourceId\",\"text.glyphOutline.payloadResourceKey\",\"text.glyphOutline.payloadResourceDigestKey\",\"text.specialVisualOps\",\"text.charOverlapOp\",\"text.controlMarkOp\",\"text.tabLeaderOp\",\"text.decorationOp\",\"text.displayText\",\"text.vertical.mixedPerGlyph\"],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
+    buf.push_str("],\"knownFeatures\":[");
+    for (idx, feature) in KNOWN_TEXT_FEATURES.iter().enumerate() {
+        if idx > 0 {
+            buf.push(',');
+        }
+        buf.push_str(&json_escape(feature));
+    }
+    buf.push_str("],\"requiredFeatures\":[],\"text\":{\"defaultVariant\":\"textRun\",\"variants\":[\"textRun\"");
     if has_glyph_runs {
         buf.push_str(",\"glyphRun\"");
     }
@@ -2509,18 +2549,18 @@ mod tests {
     use super::*;
     use crate::model::shape::TextWrap;
     use crate::paint::{
-        image_resource_key, resource_digest_hex, svg_resource_key, BitmapGlyphFiltering,
-        BitmapGlyphPayload, BitmapGlyphScalingPolicy, CacheHint, ClipKind, ColorGlyphFormat,
-        ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind, ColorPaintGraphPayload,
-        ColorPaintSolidPathNode, FontColorGlyphRef, FontFaceKey, FontFallbackPolicyId,
-        FontInstanceKey, GlyphCluster, GlyphOutlineFillRule, GlyphOutlinePayloadKind,
-        GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange,
-        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
-        ImageResourceId, LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath,
-        LayerGlyphRunPaint, LayerNode, LayerPoint, LayerVector, PageLayerTree, PaintTextStyle,
-        PaintVariantMeta, ResolvedColor, ScriptTag, ShapeKey, ShapingEngineId, SvgGlyphPayload,
-        SvgResourceId, TextDecorationKind, TextDirection, TextSourceId, TextSourceRange,
-        TextSourceSpan, TextVariantKind, TextVariantQuality, WritingMode,
+        BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, CacheHint, ClipKind,
+        ColorGlyphFormat, ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind,
+        ColorPaintGraphPayload, ColorPaintSolidPathNode, FontColorGlyphRef, FontFaceKey,
+        FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
+        GlyphOutlinePayloadKind, GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin,
+        GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
+        GlyphRunReplayEligibility, GroupKind, ImageResourceId, LayerAffineTransform,
+        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
+        LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta, ResolvedColor, ScriptTag,
+        ShapeKey, ShapingEngineId, SvgGlyphPayload, SvgResourceId, TextDecorationKind,
+        TextDirection, TextSourceId, TextSourceRange, TextSourceSpan, TextVariantKind,
+        TextVariantQuality, WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -3430,22 +3470,18 @@ mod tests {
         );
         let image_bytes = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
         let svg_fragment = "<path d=\"M0 0H10V10Z\"/>";
-        assert_eq!(
-            tree.resources.intern_image_bytes(&image_bytes),
-            ImageResourceId(0)
-        );
-        assert_eq!(
-            tree.resources.intern_svg_fragment(svg_fragment),
-            SvgResourceId(0)
-        );
+        let image_id = tree.resources.intern_image_bytes(&image_bytes);
+        let svg_id = tree.resources.intern_svg_fragment(svg_fragment);
+        assert_eq!(image_id, ImageResourceId(0));
+        assert_eq!(svg_id, SvgResourceId(0));
+        let image_resource_key = tree
+            .resources
+            .image_resource_key(image_id)
+            .unwrap()
+            .to_string();
+        let svg_resource_key = tree.resources.svg_resource_key(svg_id).unwrap().to_string();
 
         let json = tree.to_json();
-        let image_resource_key =
-            image_resource_key(image_bytes.len(), &resource_digest_hex(image_bytes));
-        let svg_resource_key = svg_resource_key(
-            svg_fragment.len(),
-            &resource_digest_hex(svg_fragment.as_bytes()),
-        );
 
         assert!(json.contains("\"schemaMinorVersion\":17"));
         assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
@@ -3458,6 +3494,14 @@ mod tests {
         assert!(json.contains("\"text.glyphOutline.payloadResourceKey\""));
         assert!(json.contains("\"text.glyphOutline.payloadResourceDigestKey\""));
         assert!(json.contains("\"text.glyphOutline.svgGlyph.vectorResourceId\""));
+    }
+
+    #[test]
+    fn known_text_features_are_unique() {
+        let mut seen = std::collections::BTreeSet::new();
+        for feature in KNOWN_TEXT_FEATURES {
+            assert!(seen.insert(*feature), "duplicate known feature: {feature}");
+        }
     }
 
     #[test]

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -6,6 +6,7 @@ use crate::document_core::helpers::{color_ref_to_css, json_escape as raw_json_es
 use crate::model::control::FormType;
 use crate::model::image::ImageEffect;
 use crate::model::style::{ImageFillMode, UnderlineType};
+use crate::paint::ResourceArena;
 use crate::paint::{
     BitmapGlyphPayload, CacheHint, ClipKind, ColorLayerNode, ColorLayersPayload,
     ColorPaintGraphNode, ColorPaintGraphPayload, FontColorGlyphRef, FontResourceTable,
@@ -56,7 +57,8 @@ impl PageLayerTree {
             self.page_height
         );
         let mut text_source_state = TextSourceExportState::default();
-        self.root.write_json(&mut buf, &mut text_source_state);
+        self.root
+            .write_json(&mut buf, &mut text_source_state, &self.resources);
         buf.push_str(",\"textSources\":");
         write_text_source_entries(&mut buf, &self.text_sources);
         buf.push_str(",\"fontResources\":");
@@ -277,7 +279,12 @@ fn externalized_text_visuals(root: &LayerNode) -> Vec<&'static str> {
 }
 
 impl LayerNode {
-    fn write_json(&self, buf: &mut String, text_sources: &mut TextSourceExportState) {
+    fn write_json(
+        &self,
+        buf: &mut String,
+        text_sources: &mut TextSourceExportState,
+        resources: &ResourceArena,
+    ) {
         buf.push('{');
         buf.push_str("\"bounds\":");
         write_bbox(buf, self.bounds);
@@ -306,7 +313,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    child.write_json(buf, text_sources);
+                    child.write_json(buf, text_sources, resources);
                 }
                 buf.push(']');
             }
@@ -323,7 +330,7 @@ impl LayerNode {
                     json_escape(clip_kind_str(*clip_kind))
                 );
                 buf.push_str(",\"child\":");
-                child.write_json(buf, text_sources);
+                child.write_json(buf, text_sources, resources);
             }
             LayerNodeKind::Leaf { ops } => {
                 buf.push_str(",\"kind\":\"leaf\",\"ops\":[");
@@ -332,7 +339,7 @@ impl LayerNode {
                     if idx > 0 {
                         buf.push(',');
                     }
-                    op.write_json(buf, text_sources, &leaf_visuals);
+                    op.write_json(buf, text_sources, &leaf_visuals, resources);
                 }
                 buf.push(']');
             }
@@ -347,6 +354,7 @@ impl PaintOp {
         buf: &mut String,
         text_sources: &mut TextSourceExportState,
         leaf_visuals: &LeafTextVisualOps,
+        resources: &ResourceArena,
     ) {
         match self {
             PaintOp::PageBackground { bbox, background } => {
@@ -504,7 +512,9 @@ impl PaintOp {
                     ",\"payloadKind\":{}",
                     json_escape(outline.payload_kind.as_str())
                 );
-                if let Some(payload_resource_key) = outline.payload_resource_key() {
+                if let Some(payload_resource_key) =
+                    outline.payload_resource_key_with_resources(Some(resources))
+                {
                     let _ = write!(
                         buf,
                         ",\"payloadResourceKey\":{}",
@@ -2008,8 +2018,8 @@ fn write_bitmap_glyph_payload(buf: &mut String, payload: &BitmapGlyphPayload) {
 fn write_svg_glyph_payload(buf: &mut String, payload: &SvgGlyphPayload) {
     let _ = write!(
         buf,
-        "{{\"svgRef\":{},\"sourceRangeUtf8\":",
-        payload.svg_ref.0
+        "{{\"svgRef\":{},\"vectorResourceId\":{},\"sourceRangeUtf8\":",
+        payload.svg_ref.0, payload.svg_ref.0
     );
     write_text_source_range(buf, payload.source_range_utf8);
     let _ = write!(
@@ -2463,18 +2473,18 @@ mod tests {
     use super::*;
     use crate::model::shape::TextWrap;
     use crate::paint::{
-        BitmapGlyphFiltering, BitmapGlyphPayload, BitmapGlyphScalingPolicy, CacheHint, ClipKind,
-        ColorGlyphFormat, ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind,
-        ColorPaintGraphPayload, ColorPaintSolidPathNode, FontColorGlyphRef, FontFaceKey,
-        FontFallbackPolicyId, FontInstanceKey, GlyphCluster, GlyphOutlineFillRule,
-        GlyphOutlinePayloadKind, GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin,
-        GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics, GlyphRunOrientation,
-        GlyphRunReplayEligibility, GroupKind, ImageResourceId, LayerAffineTransform,
-        LayerGlyphOutlinePaint, LayerGlyphOutlinePath, LayerGlyphRunPaint, LayerNode, LayerPoint,
-        LayerVector, PageLayerTree, PaintTextStyle, PaintVariantMeta, ResolvedColor, ScriptTag,
-        ShapeKey, ShapingEngineId, SvgGlyphPayload, SvgResourceId, TextDecorationKind,
-        TextDirection, TextSourceId, TextSourceRange, TextSourceSpan, TextVariantKind,
-        TextVariantQuality, WritingMode,
+        image_resource_key, resource_digest_hex, svg_resource_key, BitmapGlyphFiltering,
+        BitmapGlyphPayload, BitmapGlyphScalingPolicy, CacheHint, ClipKind, ColorGlyphFormat,
+        ColorLayersPayload, ColorPaintGraphNode, ColorPaintGraphNodeKind, ColorPaintGraphPayload,
+        ColorPaintSolidPathNode, FontColorGlyphRef, FontFaceKey, FontFallbackPolicyId,
+        FontInstanceKey, GlyphCluster, GlyphOutlineFillRule, GlyphOutlinePayloadKind,
+        GlyphOutlineStrokeCap, GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange,
+        GlyphRunDiagnostics, GlyphRunOrientation, GlyphRunReplayEligibility, GroupKind,
+        ImageResourceId, LayerAffineTransform, LayerGlyphOutlinePaint, LayerGlyphOutlinePath,
+        LayerGlyphRunPaint, LayerNode, LayerPoint, LayerVector, PageLayerTree, PaintTextStyle,
+        PaintVariantMeta, ResolvedColor, ScriptTag, ShapeKey, ShapingEngineId, SvgGlyphPayload,
+        SvgResourceId, TextDecorationKind, TextDirection, TextSourceId, TextSourceRange,
+        TextSourceSpan, TextVariantKind, TextVariantQuality, WritingMode,
     };
     use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
@@ -3311,7 +3321,7 @@ mod tests {
                 payload_kind: GlyphOutlinePayloadKind::BitmapGlyph,
                 color_layers: None,
                 bitmap_glyph: Some(BitmapGlyphPayload {
-                    image_ref: ImageResourceId(7),
+                    image_ref: ImageResourceId(0),
                     source_range_utf8: TextSourceRange::new(0, 1),
                     glyph_range: GlyphRange::new(0, 1),
                     placement: BoundingBox::new(0.0, 0.0, 10.0, 10.0),
@@ -3348,7 +3358,7 @@ mod tests {
                 color_layers: None,
                 bitmap_glyph: None,
                 svg_glyph: Some(SvgGlyphPayload {
-                    svg_ref: SvgResourceId(7),
+                    svg_ref: SvgResourceId(0),
                     source_range_utf8: TextSourceRange::new(0, 1),
                     glyph_range: GlyphRange::new(0, 1),
                     view_box: BoundingBox::new(0.0, 0.0, 10.0, 10.0),
@@ -3367,7 +3377,7 @@ mod tests {
                 diagnostics,
             }),
         };
-        let tree = PageLayerTree::new(
+        let mut tree = PageLayerTree::new(
             120.0,
             80.0,
             LayerNode::leaf(
@@ -3376,11 +3386,29 @@ mod tests {
                 vec![bitmap_outline, svg_outline],
             ),
         );
+        let image_bytes = [0x89, b'P', b'N', b'G', 0x0d, 0x0a, 0x1a, 0x0a];
+        let svg_fragment = "<path d=\"M0 0H10V10Z\"/>";
+        assert_eq!(
+            tree.resources.intern_image_bytes(&image_bytes),
+            ImageResourceId(0)
+        );
+        assert_eq!(
+            tree.resources.intern_svg_fragment(svg_fragment),
+            SvgResourceId(0)
+        );
 
         let json = tree.to_json();
+        let image_resource_key =
+            image_resource_key(image_bytes.len(), &resource_digest_hex(image_bytes));
+        let svg_resource_key = svg_resource_key(
+            svg_fragment.len(),
+            &resource_digest_hex(svg_fragment.as_bytes()),
+        );
 
-        assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:7"));
-        assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:svgGlyph:svgRef:7"));
+        assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:bitmapGlyph:imageRef:0"));
+        assert!(json.contains(&format!(":resource:{image_resource_key}\"")));
+        assert!(json.contains("\"payloadResourceKey\":\"glyphPayload:svgGlyph:svgRef:0"));
+        assert!(json.contains(&format!(":resource:{svg_resource_key}\"")));
         assert!(json.contains("\"strictVisualContract\":true"));
         assert!(json.contains("\"staticSanitizedContract\":true"));
         assert!(json.contains("\"text.glyphOutline.payloadResourceKey\""));

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -2,10 +2,7 @@ use crate::model::style::UnderlineType;
 use crate::model::ColorRef;
 use crate::paint::font::{GlyphRunReplayEligibility, ShapeKey, TextDirection, WritingMode};
 use crate::paint::layer_tree::{TextSourceRange, TextSourceSpan};
-use crate::paint::resources::{
-    image_resource_key, resource_digest_hex, svg_resource_key, ImageResourceId, ResourceArena,
-    SvgResourceId,
-};
+use crate::paint::resources::{ImageResourceId, ResourceArena, SvgResourceId};
 use crate::renderer::render_tree::{
     BoundingBox, EllipseNode, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
     LineNode, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode,
@@ -372,13 +369,11 @@ fn bitmap_glyph_payload_resource_key(
         payload.filtering.as_str(),
         optional_affine_key(payload.transform_to_run),
     );
-    if let Some(resource_key) = resources.and_then(|resources| {
-        resources
-            .image_bytes(payload.image_ref)
-            .map(|bytes| image_resource_key(bytes.len(), resource_digest_hex(bytes).as_str()))
-    }) {
+    if let Some(resource_key) =
+        resources.and_then(|resources| resources.image_resource_key(payload.image_ref))
+    {
         key.push_str(":resource:");
-        key.push_str(&resource_key);
+        key.push_str(resource_key);
     }
     key
 }
@@ -404,13 +399,11 @@ fn svg_glyph_payload_resource_key(
         payload.interactivity_allowed,
         optional_affine_key(payload.transform_to_run),
     );
-    if let Some(resource_key) = resources.and_then(|resources| {
-        resources
-            .svg_fragment(payload.svg_ref)
-            .map(|svg| svg_resource_key(svg.len(), resource_digest_hex(svg.as_bytes()).as_str()))
-    }) {
+    if let Some(resource_key) =
+        resources.and_then(|resources| resources.svg_resource_key(payload.svg_ref))
+    {
         key.push_str(":resource:");
-        key.push_str(&resource_key);
+        key.push_str(resource_key);
     }
     key
 }

--- a/src/paint/paint_op.rs
+++ b/src/paint/paint_op.rs
@@ -2,7 +2,10 @@ use crate::model::style::UnderlineType;
 use crate::model::ColorRef;
 use crate::paint::font::{GlyphRunReplayEligibility, ShapeKey, TextDirection, WritingMode};
 use crate::paint::layer_tree::{TextSourceRange, TextSourceSpan};
-use crate::paint::resources::{ImageResourceId, SvgResourceId};
+use crate::paint::resources::{
+    image_resource_key, resource_digest_hex, svg_resource_key, ImageResourceId, ResourceArena,
+    SvgResourceId,
+};
 use crate::renderer::render_tree::{
     BoundingBox, EllipseNode, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
     LineNode, PageBackgroundNode, PathNode, PlaceholderNode, RawSvgNode, RectangleNode,
@@ -241,10 +244,18 @@ impl LayerGlyphOutlinePaint {
     }
 
     /// Stable, export-local identity for payload resources that sit behind a
-    /// GlyphOutline sidecar. This is not a binary digest; it is the replay
-    /// decision key that keeps color/bitmap/SVG payload families from sharing a
-    /// cache slot merely because a producer reused the same numeric resource id.
+    /// GlyphOutline sidecar. The key starts with replay decision metadata and
+    /// may append an interned resource digest when bytes are available, so
+    /// color/bitmap/SVG payload families do not share a cache slot merely
+    /// because a producer reused the same numeric resource id.
     pub fn payload_resource_key(&self) -> Option<String> {
+        self.payload_resource_key_with_resources(None)
+    }
+
+    pub fn payload_resource_key_with_resources(
+        &self,
+        resources: Option<&ResourceArena>,
+    ) -> Option<String> {
         if !self.has_payload_resource_key() {
             return None;
         }
@@ -258,10 +269,11 @@ impl LayerGlyphOutlinePaint {
             GlyphOutlinePayloadKind::BitmapGlyph => self
                 .bitmap_glyph
                 .as_ref()
-                .map(bitmap_glyph_payload_resource_key),
-            GlyphOutlinePayloadKind::SvgGlyph => {
-                self.svg_glyph.as_ref().map(svg_glyph_payload_resource_key)
-            }
+                .map(|payload| bitmap_glyph_payload_resource_key(payload, resources)),
+            GlyphOutlinePayloadKind::SvgGlyph => self
+                .svg_glyph
+                .as_ref()
+                .map(|payload| svg_glyph_payload_resource_key(payload, resources)),
         }
     }
 
@@ -345,8 +357,11 @@ fn color_paint_graph_key(graph: &ColorPaintGraphPayload) -> String {
     key
 }
 
-fn bitmap_glyph_payload_resource_key(payload: &BitmapGlyphPayload) -> String {
-    format!(
+fn bitmap_glyph_payload_resource_key(
+    payload: &BitmapGlyphPayload,
+    resources: Option<&ResourceArena>,
+) -> String {
+    let mut key = format!(
         "glyphPayload:bitmapGlyph:imageRef:{}:range:{}:glyphRange:{}:placement:{}:alphaPremultiplied:{}:scaling:{}:filtering:{}:transform:{}",
         payload.image_ref.0,
         text_range_key(payload.source_range_utf8),
@@ -356,11 +371,23 @@ fn bitmap_glyph_payload_resource_key(payload: &BitmapGlyphPayload) -> String {
         payload.scaling_policy.as_str(),
         payload.filtering.as_str(),
         optional_affine_key(payload.transform_to_run),
-    )
+    );
+    if let Some(resource_key) = resources.and_then(|resources| {
+        resources
+            .image_bytes(payload.image_ref)
+            .map(|bytes| image_resource_key(bytes.len(), resource_digest_hex(bytes).as_str()))
+    }) {
+        key.push_str(":resource:");
+        key.push_str(&resource_key);
+    }
+    key
 }
 
-fn svg_glyph_payload_resource_key(payload: &SvgGlyphPayload) -> String {
-    format!(
+fn svg_glyph_payload_resource_key(
+    payload: &SvgGlyphPayload,
+    resources: Option<&ResourceArena>,
+) -> String {
+    let mut key = format!(
         "glyphPayload:svgGlyph:svgRef:{}:range:{}:glyphRange:{}:viewBox:{}:intrinsicSize:{}:staticSanitized:{}:script:{}:animation:{}:external:{}:interactive:{}:transform:{}",
         payload.svg_ref.0,
         text_range_key(payload.source_range_utf8),
@@ -376,7 +403,16 @@ fn svg_glyph_payload_resource_key(payload: &SvgGlyphPayload) -> String {
         payload.external_resources_allowed,
         payload.interactivity_allowed,
         optional_affine_key(payload.transform_to_run),
-    )
+    );
+    if let Some(resource_key) = resources.and_then(|resources| {
+        resources
+            .svg_fragment(payload.svg_ref)
+            .map(|svg| svg_resource_key(svg.len(), resource_digest_hex(svg.as_bytes()).as_str()))
+    }) {
+        key.push_str(":resource:");
+        key.push_str(&resource_key);
+    }
+    key
 }
 
 fn font_color_glyph_ref_key(value: Option<&FontColorGlyphRef>) -> String {

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -19,6 +19,14 @@ pub const RESOURCE_KEY_ALGORITHM: &str = "blake3";
 /// identity는 glyph replay contract에서 참조할 수 있게 한다.
 #[derive(Debug, Clone, Default)]
 pub struct ResourceArena {
+    image_bytes: Vec<Vec<u8>>,
+    image_hashes: Vec<u64>,
+    image_fingerprints: Vec<[u8; 16]>,
+    image_lookup: HashMap<u64, Vec<ImageResourceId>>,
+    svg_fragments: Vec<String>,
+    svg_hashes: Vec<u64>,
+    svg_fingerprints: Vec<[u8; 16]>,
+    svg_lookup: HashMap<u64, Vec<SvgResourceId>>,
     font_blob_bytes: Vec<Vec<u8>>,
     font_blob_hashes: Vec<u64>,
     font_blob_fingerprints: Vec<[u8; 16]>,
@@ -28,6 +36,88 @@ pub struct ResourceArena {
 }
 
 impl ResourceArena {
+    pub fn intern_image_bytes(&mut self, bytes: &[u8]) -> ImageResourceId {
+        let hash = resource_hash(bytes);
+        if let Some(candidates) = self.image_lookup.get(&hash) {
+            for id in candidates {
+                if self.image_bytes[id.0].as_slice() == bytes {
+                    return *id;
+                }
+            }
+        }
+
+        let id = ImageResourceId(self.image_bytes.len());
+        self.image_bytes.push(bytes.to_vec());
+        self.image_hashes.push(hash);
+        self.image_fingerprints.push(resource_fingerprint(bytes));
+        self.image_lookup.entry(hash).or_default().push(id);
+        id
+    }
+
+    pub fn image_bytes(&self, id: ImageResourceId) -> Option<&[u8]> {
+        self.image_bytes.get(id.0).map(Vec::as_slice)
+    }
+
+    pub fn image_count(&self) -> usize {
+        self.image_bytes.len()
+    }
+
+    pub fn image_hash(&self, id: ImageResourceId) -> Option<u64> {
+        self.image_hashes.get(id.0).copied()
+    }
+
+    pub fn image_fingerprint(&self, id: ImageResourceId) -> Option<[u8; 16]> {
+        self.image_fingerprints.get(id.0).copied()
+    }
+
+    pub fn image_resources(&self) -> impl Iterator<Item = (ImageResourceId, &[u8])> + '_ {
+        self.image_bytes
+            .iter()
+            .enumerate()
+            .map(|(index, bytes)| (ImageResourceId(index), bytes.as_slice()))
+    }
+
+    pub fn intern_svg_fragment(&mut self, svg: &str) -> SvgResourceId {
+        let hash = resource_hash(svg);
+        if let Some(candidates) = self.svg_lookup.get(&hash) {
+            for id in candidates {
+                if self.svg_fragments[id.0].as_str() == svg {
+                    return *id;
+                }
+            }
+        }
+
+        let id = SvgResourceId(self.svg_fragments.len());
+        self.svg_fragments.push(svg.to_string());
+        self.svg_hashes.push(hash);
+        self.svg_fingerprints.push(resource_fingerprint(svg));
+        self.svg_lookup.entry(hash).or_default().push(id);
+        id
+    }
+
+    pub fn svg_fragment(&self, id: SvgResourceId) -> Option<&str> {
+        self.svg_fragments.get(id.0).map(String::as_str)
+    }
+
+    pub fn svg_count(&self) -> usize {
+        self.svg_fragments.len()
+    }
+
+    pub fn svg_hash(&self, id: SvgResourceId) -> Option<u64> {
+        self.svg_hashes.get(id.0).copied()
+    }
+
+    pub fn svg_fingerprint(&self, id: SvgResourceId) -> Option<[u8; 16]> {
+        self.svg_fingerprints.get(id.0).copied()
+    }
+
+    pub fn svg_resources(&self) -> impl Iterator<Item = (SvgResourceId, &str)> + '_ {
+        self.svg_fragments
+            .iter()
+            .enumerate()
+            .map(|(index, svg)| (SvgResourceId(index), svg.as_str()))
+    }
+
     pub fn intern_font_blob_bytes(&mut self, bytes: &[u8]) -> FontBlobResourceId {
         let hash = resource_hash(bytes);
         if let Some(candidates) = self.font_blob_lookup.get(&hash) {
@@ -136,14 +226,49 @@ fn resource_key(kind: &str, byte_len: usize, digest: &str) -> String {
 mod tests {
     use super::{
         font_blob_resource_key, image_resource_key, resource_digest_hex, resource_fingerprint,
-        svg_resource_key, BinaryResourceKind, BinaryResourceRef, FontBlobResourceId, ResourceArena,
+        svg_resource_key, BinaryResourceKind, BinaryResourceRef, FontBlobResourceId,
+        ImageResourceId, ResourceArena, SvgResourceId,
     };
 
     #[test]
-    fn interns_duplicate_font_blobs_once() {
+    fn interns_duplicate_resources_once() {
         let mut arena = ResourceArena::default();
+        let image_a = arena.intern_image_bytes(&[1, 2, 3, 4]);
+        let image_b = arena.intern_image_bytes(&[1, 2, 3, 4]);
+        let svg_a = arena.intern_svg_fragment("<svg/>");
+        let svg_b = arena.intern_svg_fragment("<svg/>");
         let font_a = arena.intern_font_blob_bytes(&[5, 6, 7, 8]);
         let font_b = arena.intern_font_blob_bytes(&[5, 6, 7, 8]);
+
+        assert_eq!(image_a, ImageResourceId(0));
+        assert_eq!(image_b, ImageResourceId(0));
+        assert_eq!(arena.image_count(), 1);
+        assert_eq!(arena.image_bytes(image_a), Some(&[1, 2, 3, 4][..]));
+        assert_eq!(arena.image_hash(image_a), arena.image_hash(image_b));
+        assert!(arena.image_hash(image_a).is_some());
+        assert_eq!(
+            arena.image_fingerprint(image_a),
+            Some(resource_fingerprint([1, 2, 3, 4]))
+        );
+        assert_eq!(
+            arena.image_resources().collect::<Vec<_>>(),
+            vec![(ImageResourceId(0), &[1, 2, 3, 4][..])]
+        );
+
+        assert_eq!(svg_a, SvgResourceId(0));
+        assert_eq!(svg_b, SvgResourceId(0));
+        assert_eq!(arena.svg_count(), 1);
+        assert_eq!(arena.svg_fragment(svg_a), Some("<svg/>"));
+        assert_eq!(arena.svg_hash(svg_a), arena.svg_hash(svg_b));
+        assert!(arena.svg_hash(svg_a).is_some());
+        assert_eq!(
+            arena.svg_fingerprint(svg_a),
+            Some(resource_fingerprint("<svg/>"))
+        );
+        assert_eq!(
+            arena.svg_resources().collect::<Vec<_>>(),
+            vec![(SvgResourceId(0), "<svg/>")]
+        );
 
         assert_eq!(font_a, FontBlobResourceId(0));
         assert_eq!(font_b, FontBlobResourceId(0));

--- a/src/paint/resources.rs
+++ b/src/paint/resources.rs
@@ -22,10 +22,12 @@ pub struct ResourceArena {
     image_bytes: Vec<Vec<u8>>,
     image_hashes: Vec<u64>,
     image_fingerprints: Vec<[u8; 16]>,
+    image_resource_keys: Vec<String>,
     image_lookup: HashMap<u64, Vec<ImageResourceId>>,
     svg_fragments: Vec<String>,
     svg_hashes: Vec<u64>,
     svg_fingerprints: Vec<[u8; 16]>,
+    svg_resource_keys: Vec<String>,
     svg_lookup: HashMap<u64, Vec<SvgResourceId>>,
     font_blob_bytes: Vec<Vec<u8>>,
     font_blob_hashes: Vec<u64>,
@@ -47,9 +49,14 @@ impl ResourceArena {
         }
 
         let id = ImageResourceId(self.image_bytes.len());
+        let digest = blake3::hash(bytes);
+        let mut fingerprint = [0; 16];
+        fingerprint.copy_from_slice(&digest.as_bytes()[..16]);
+        let resource_key = image_resource_key(bytes.len(), digest.to_hex().as_str());
         self.image_bytes.push(bytes.to_vec());
         self.image_hashes.push(hash);
-        self.image_fingerprints.push(resource_fingerprint(bytes));
+        self.image_fingerprints.push(fingerprint);
+        self.image_resource_keys.push(resource_key);
         self.image_lookup.entry(hash).or_default().push(id);
         id
     }
@@ -70,6 +77,10 @@ impl ResourceArena {
         self.image_fingerprints.get(id.0).copied()
     }
 
+    pub fn image_resource_key(&self, id: ImageResourceId) -> Option<&str> {
+        self.image_resource_keys.get(id.0).map(String::as_str)
+    }
+
     pub fn image_resources(&self) -> impl Iterator<Item = (ImageResourceId, &[u8])> + '_ {
         self.image_bytes
             .iter()
@@ -88,9 +99,14 @@ impl ResourceArena {
         }
 
         let id = SvgResourceId(self.svg_fragments.len());
+        let digest = blake3::hash(svg.as_bytes());
+        let mut fingerprint = [0; 16];
+        fingerprint.copy_from_slice(&digest.as_bytes()[..16]);
+        let resource_key = svg_resource_key(svg.len(), digest.to_hex().as_str());
         self.svg_fragments.push(svg.to_string());
         self.svg_hashes.push(hash);
-        self.svg_fingerprints.push(resource_fingerprint(svg));
+        self.svg_fingerprints.push(fingerprint);
+        self.svg_resource_keys.push(resource_key);
         self.svg_lookup.entry(hash).or_default().push(id);
         id
     }
@@ -109,6 +125,10 @@ impl ResourceArena {
 
     pub fn svg_fingerprint(&self, id: SvgResourceId) -> Option<[u8; 16]> {
         self.svg_fingerprints.get(id.0).copied()
+    }
+
+    pub fn svg_resource_key(&self, id: SvgResourceId) -> Option<&str> {
+        self.svg_resource_keys.get(id.0).map(String::as_str)
     }
 
     pub fn svg_resources(&self) -> impl Iterator<Item = (SvgResourceId, &str)> + '_ {
@@ -250,6 +270,8 @@ mod tests {
             arena.image_fingerprint(image_a),
             Some(resource_fingerprint([1, 2, 3, 4]))
         );
+        let image_key = image_resource_key(4, &resource_digest_hex([1, 2, 3, 4]));
+        assert_eq!(arena.image_resource_key(image_a), Some(image_key.as_str()));
         assert_eq!(
             arena.image_resources().collect::<Vec<_>>(),
             vec![(ImageResourceId(0), &[1, 2, 3, 4][..])]
@@ -265,6 +287,8 @@ mod tests {
             arena.svg_fingerprint(svg_a),
             Some(resource_fingerprint("<svg/>"))
         );
+        let svg_key = svg_resource_key(6, &resource_digest_hex("<svg/>"));
+        assert_eq!(arena.svg_resource_key(svg_a), Some(svg_key.as_str()));
         assert_eq!(
             arena.svg_resources().collect::<Vec<_>>(),
             vec![(SvgResourceId(0), "<svg/>")]

--- a/src/paint/schema.rs
+++ b/src/paint/schema.rs
@@ -15,7 +15,7 @@ pub struct LayerTreeSchema {
 
 pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema {
     schema_version: 1,
-    schema_minor_version: 16,
+    schema_minor_version: 17,
     resource_table_version: 1,
     resource_table_minor_version: 4,
     unit: "px",

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -3,7 +3,7 @@ use crate::model::ColorRef;
 use crate::paint::{
     GlyphOutlinePayloadKind, GlyphRunOrientation, GlyphRunReplayEligibility,
     LayerGlyphOutlinePaint, LayerGlyphRunPaint, LayerNode, LayerNodeKind, PageLayerTree, PaintOp,
-    TextVariantKind, TextVariantQuality,
+    ResourceArena, TextVariantKind, TextVariantQuality,
 };
 use std::collections::{BTreeMap, BTreeSet};
 
@@ -144,6 +144,7 @@ pub enum VariantRejectReason {
     UnsupportedColorGlyph,
     UnsupportedBitmapGlyph,
     UnsupportedSvgGlyph,
+    MissingGlyphPayloadResource,
     PositionAdjustedNotAllowed,
     PositionAdjustedResidualTooLarge,
 }
@@ -170,6 +171,7 @@ impl VariantRejectReason {
             Self::UnsupportedColorGlyph => "unsupportedColorGlyph",
             Self::UnsupportedBitmapGlyph => "unsupportedBitmapGlyph",
             Self::UnsupportedSvgGlyph => "unsupportedSvgGlyph",
+            Self::MissingGlyphPayloadResource => "missingGlyphPayloadResource",
             Self::PositionAdjustedNotAllowed => "positionAdjustedNotAllowed",
             Self::PositionAdjustedResidualTooLarge => "positionAdjustedResidualTooLarge",
         }
@@ -248,7 +250,7 @@ pub fn analyze_text_variant_selection(
     collect_text_variant_groups(&tree.root, &mut groups, &mut next_order);
     groups
         .into_iter()
-        .map(|(equivalence_group, group)| group.finish(equivalence_group, options))
+        .map(|(equivalence_group, group)| group.finish(equivalence_group, options, &tree.resources))
         .collect()
 }
 
@@ -263,12 +265,13 @@ impl TextVariantGroupState {
         self,
         equivalence_group: String,
         options: TextVariantSelectionOptions,
+        resources: &ResourceArena,
     ) -> TextVariantSelectionReport {
         let mut evaluated = self
             .variants
             .into_values()
             .map(|candidate| {
-                let reasons = candidate.reject_reasons(options);
+                let reasons = candidate.reject_reasons(options, resources);
                 EvaluatedTextVariantCandidate { candidate, reasons }
             })
             .collect::<Vec<_>>();
@@ -387,7 +390,11 @@ impl TextVariantCandidate {
         self.glyph_outlines.push(outline.clone());
     }
 
-    fn reject_reasons(&self, options: TextVariantSelectionOptions) -> Vec<VariantRejectReason> {
+    fn reject_reasons(
+        &self,
+        options: TextVariantSelectionOptions,
+        resources: &ResourceArena,
+    ) -> Vec<VariantRejectReason> {
         let mut reasons = BTreeSet::<VariantRejectReason>::new();
         self.collect_structure_reasons(&mut reasons);
         match self.variant_kind {
@@ -410,7 +417,7 @@ impl TextVariantCandidate {
                     reasons.insert(VariantRejectReason::BackendDoesNotSupportVariant);
                 }
                 for outline in &self.glyph_outlines {
-                    collect_glyph_outline_reject_reasons(outline, options, &mut reasons);
+                    collect_glyph_outline_reject_reasons(outline, options, resources, &mut reasons);
                 }
             }
         }
@@ -524,6 +531,7 @@ fn collect_glyph_run_reject_reasons(
 fn collect_glyph_outline_reject_reasons(
     outline: &LayerGlyphOutlinePaint,
     options: TextVariantSelectionOptions,
+    resources: &ResourceArena,
     reasons: &mut BTreeSet<VariantRejectReason>,
 ) {
     if !outline.has_exclusive_payload_family() {
@@ -566,16 +574,32 @@ fn collect_glyph_outline_reject_reasons(
             }
         },
         GlyphOutlinePayloadKind::BitmapGlyph => match outline.bitmap_glyph.as_ref() {
-            Some(bitmap_glyph)
-                if bitmap_glyph.has_strict_visual_contract() && options.allow_bitmap_glyph => {}
-            _ => {
+            Some(bitmap_glyph) if !bitmap_glyph.has_strict_visual_contract() => {
+                reasons.insert(VariantRejectReason::UnsupportedBitmapGlyph);
+            }
+            Some(_) if !options.allow_bitmap_glyph => {
+                reasons.insert(VariantRejectReason::UnsupportedBitmapGlyph);
+            }
+            Some(bitmap_glyph) if resources.image_bytes(bitmap_glyph.image_ref).is_none() => {
+                reasons.insert(VariantRejectReason::MissingGlyphPayloadResource);
+            }
+            Some(_) => {}
+            None => {
                 reasons.insert(VariantRejectReason::UnsupportedBitmapGlyph);
             }
         },
         GlyphOutlinePayloadKind::SvgGlyph => match outline.svg_glyph.as_ref() {
-            Some(svg_glyph)
-                if svg_glyph.has_static_sanitized_contract() && options.allow_svg_glyph => {}
-            _ => {
+            Some(svg_glyph) if !svg_glyph.has_static_sanitized_contract() => {
+                reasons.insert(VariantRejectReason::UnsupportedSvgGlyph);
+            }
+            Some(_) if !options.allow_svg_glyph => {
+                reasons.insert(VariantRejectReason::UnsupportedSvgGlyph);
+            }
+            Some(svg_glyph) if resources.svg_fragment(svg_glyph.svg_ref).is_none() => {
+                reasons.insert(VariantRejectReason::MissingGlyphPayloadResource);
+            }
+            Some(_) => {}
+            None => {
                 reasons.insert(VariantRejectReason::UnsupportedSvgGlyph);
             }
         },
@@ -640,8 +664,9 @@ mod tests {
         GlyphOutlineStrokeJoin, GlyphOutlineStrokeStyle, GlyphRange, GlyphRunDiagnostics,
         GlyphRunOrientation, ImageResourceId, LayerAffineTransform, LayerGlyphOutlinePath,
         LayerNode, LayerPoint, LayerVector, PaintTextStyle, PaintVariantMeta, ResolvedColor,
-        ScriptTag, ShapeKey, ShapingEngineId, SvgGlyphPayload, SvgResourceId, TextDirection,
-        TextRunPlacement, TextSourceId, TextSourceRange, TextSourceSpan, WritingMode,
+        ResourceArena, ScriptTag, ShapeKey, ShapingEngineId, SvgGlyphPayload, SvgResourceId,
+        TextDirection, TextRunPlacement, TextSourceId, TextSourceRange, TextSourceSpan,
+        WritingMode,
     };
     use crate::renderer::render_tree::{BoundingBox, FieldMarkerType, TextRunNode};
     use crate::renderer::{PathCommand, TextStyle};
@@ -1042,6 +1067,19 @@ mod tests {
             .unwrap()
     }
 
+    fn first_report_with_resource_setup(
+        ops: Vec<PaintOp>,
+        options: TextVariantSelectionOptions,
+        setup: impl FnOnce(&mut ResourceArena),
+    ) -> TextVariantSelectionReport {
+        let mut tree = tree(ops);
+        setup(&mut tree.resources);
+        analyze_text_variant_selection(&tree, options)
+            .into_iter()
+            .next()
+            .unwrap()
+    }
+
     #[test]
     fn canvaskit_selects_strict_glyph_run() {
         let report = first_report(
@@ -1284,7 +1322,7 @@ mod tests {
     }
 
     #[test]
-    fn advanced_bitmap_and_svg_glyph_payloads_select_only_when_explicitly_allowed() {
+    fn advanced_bitmap_and_svg_glyph_payloads_reject_missing_resources_when_allowed() {
         let bitmap_report = first_report(
             vec![text_op(), bitmap_glyph_outline()],
             TextVariantSelectionOptions {
@@ -1294,15 +1332,57 @@ mod tests {
         );
         assert_eq!(
             bitmap_report.selected_variant_kind,
-            Some(TextVariantKind::GlyphOutline)
+            Some(TextVariantKind::TextRun)
         );
-        assert!(bitmap_report.rejected_variants.is_empty());
+        assert!(bitmap_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::MissingGlyphPayloadResource));
 
         let svg_report = first_report(
             vec![text_op(), svg_glyph_outline()],
             TextVariantSelectionOptions {
                 allow_svg_glyph: true,
                 ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(
+            svg_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(svg_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::MissingGlyphPayloadResource));
+    }
+
+    #[test]
+    fn advanced_bitmap_and_svg_glyph_payloads_select_only_with_resources() {
+        let bitmap_report = first_report_with_resource_setup(
+            vec![text_op(), bitmap_glyph_outline()],
+            TextVariantSelectionOptions {
+                allow_bitmap_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+            |resources| {
+                assert_eq!(
+                    resources.intern_image_bytes(&[1, 2, 3, 4]),
+                    ImageResourceId(0)
+                );
+            },
+        );
+        assert_eq!(
+            bitmap_report.selected_variant_kind,
+            Some(TextVariantKind::GlyphOutline)
+        );
+        assert!(bitmap_report.rejected_variants.is_empty());
+
+        let svg_report = first_report_with_resource_setup(
+            vec![text_op(), svg_glyph_outline()],
+            TextVariantSelectionOptions {
+                allow_svg_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+            |resources| {
+                assert_eq!(resources.intern_svg_fragment("<path/>"), SvgResourceId(0));
             },
         );
         assert_eq!(

--- a/src/renderer/layer_renderer.rs
+++ b/src/renderer/layer_renderer.rs
@@ -1284,6 +1284,81 @@ mod tests {
     }
 
     #[test]
+    fn advanced_bitmap_and_svg_glyph_payloads_select_only_when_explicitly_allowed() {
+        let bitmap_report = first_report(
+            vec![text_op(), bitmap_glyph_outline()],
+            TextVariantSelectionOptions {
+                allow_bitmap_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(
+            bitmap_report.selected_variant_kind,
+            Some(TextVariantKind::GlyphOutline)
+        );
+        assert!(bitmap_report.rejected_variants.is_empty());
+
+        let svg_report = first_report(
+            vec![text_op(), svg_glyph_outline()],
+            TextVariantSelectionOptions {
+                allow_svg_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(
+            svg_report.selected_variant_kind,
+            Some(TextVariantKind::GlyphOutline)
+        );
+        assert!(svg_report.rejected_variants.is_empty());
+    }
+
+    #[test]
+    fn invalid_advanced_glyph_payloads_fallback_even_when_family_is_allowed() {
+        let mut backend_default_bitmap = bitmap_glyph_outline();
+        if let PaintOp::GlyphOutline { outline, .. } = &mut backend_default_bitmap {
+            outline.bitmap_glyph.as_mut().unwrap().scaling_policy =
+                BitmapGlyphScalingPolicy::BackendDefault;
+        }
+        let bitmap_report = first_report(
+            vec![text_op(), backend_default_bitmap],
+            TextVariantSelectionOptions {
+                allow_bitmap_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(
+            bitmap_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(bitmap_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedBitmapGlyph));
+
+        let mut unsafe_svg = svg_glyph_outline();
+        if let PaintOp::GlyphOutline { outline, .. } = &mut unsafe_svg {
+            outline
+                .svg_glyph
+                .as_mut()
+                .unwrap()
+                .external_resources_allowed = true;
+        }
+        let svg_report = first_report(
+            vec![text_op(), unsafe_svg],
+            TextVariantSelectionOptions {
+                allow_svg_glyph: true,
+                ..TextVariantSelectionOptions::canvaskit_strict_outline()
+            },
+        );
+        assert_eq!(
+            svg_report.selected_variant_kind,
+            Some(TextVariantKind::TextRun)
+        );
+        assert!(svg_report.rejected_variants[0]
+            .reasons
+            .contains(&VariantRejectReason::UnsupportedSvgGlyph));
+    }
+
+    #[test]
     fn colrv1_graph_supported_gradient_gate_can_select_gradient_subset() {
         for kind in [
             ColorPaintGraphNodeKind::LinearGradientPath,


### PR DESCRIPTION
## What

- `ResourceArena`에서 이미지 바이트와 static SVG fragment를 font blob과 같이 intern할 수 있게 했습니다.
- bitmap/SVG glyph payload의 `payloadResourceKey`가 실제 resource digest를 포함하도록 보강했습니다.
- SVG glyph JSON에는 기존 `svgRef`와 함께 명확한 static vector alias인 `vectorResourceId`를 같이 내보냅니다.
- bitmap/SVG glyph payload는 backend option이 켜져 있어도 실제 resource가 없으면 selection에서 reject하도록 했습니다.
- strict bitmap/SVG glyph producer corpus와 JSON/selection 회귀 테스트를 추가했습니다.

## Why

P19/P20에서 advanced glyph payload vocabulary와 resource proof 방향은 열었지만, bitmap/SVG payload가 숫자 id만으로 strict cache/resource identity를 주장하면 같은 `imageRef` 또는 `svgRef`가 다른 payload bytes를 가리키는 경우를 구분하기 어렵습니다.

이 PR은 bitmap/SVG glyph replay를 기본 경로로 여는 것이 아니라, 나중에 backend replay를 열 때 필요한 resource identity와 strict payload 조건을 먼저 고정합니다.

## Compatibility

- 기본 `TextRun` fallback 경로는 유지됩니다.
- bitmap/SVG glyph payload는 여전히 opt-in backend gate 뒤에 있습니다.
- backend option이 켜져 있어도 resource bytes 또는 static SVG fragment가 없으면 strict variant로 선택하지 않습니다.
- schema는 minor feature로 확장됩니다.

## Non-goals

- CanvasKit/native Skia에서 bitmap/SVG glyph를 직접 replay하지 않습니다.
- document font/image extraction 전체 경로를 완성하지 않습니다.
- fallback-free text profile을 기본값으로 바꾸지 않습니다.

## Checks

- `cargo fmt --check`
- `git diff --check upstream/devel...HEAD`
- `CARGO_INCREMENTAL=0 cargo test --lib paint::json -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo test --lib renderer::layer_renderer -- --nocapture`
- `CARGO_INCREMENTAL=0 cargo check --lib`
