### PR TITLE
닫힌 후속 문서 PR

### DIFF
--- a/mydocs/orders/20260622.md
+++ b/mydocs/orders/20260622.md
@@ -111,6 +111,17 @@
   - `mydocs/pr/archives/pr_1477_review.md`
   - `mydocs/pr/archives/pr_1477_review_impl.md`
 - [x] review 문서와 오늘할일 문서 commit + PR head remote push
-- [ ] GitHub Actions 최신 head 기준 통과 확인
-- [ ] merge
-- [ ] 이슈 #1476 close 확인 및 후속 코멘트
+- [x] GitHub Actions 최신 head 기준 통과 확인
+  - head: `7a68d3ea97f754036524ae0b49543d6769d6e345`
+  - Build & Test: pass
+  - Canvas visual diff: pass
+  - Analyze (javascript-typescript): pass
+  - Analyze (python): pass
+  - Analyze (rust): pass
+  - CodeQL: pass
+  - WASM Build: skipped
+- [x] merge
+  - merge commit: `2045f926f0985140758a9f6f5a71cfe4574b514b`
+- [x] 이슈 #1476 close 확인 및 후속 코멘트
+  - 이슈 #1476: closed
+  - PR 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1477#issuecomment-4767601788


### PR DESCRIPTION
## 요약

- merge 후속 문서 기록을 별도 PR로 올리려던 문서-only 후속 PR입니다.
- 후속 기록 방식 재검토로 PR을 닫고 head 브랜치를 제거했습니다.

## 검증

- `git diff --check`
- 문서-only 변경이며 `mydocs/**` path-ignore 대상입니다.