### PR TITLE
render: document CanvasKit parity plan and guard drift

### DIFF
--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -11,6 +11,8 @@ on:
       - 'src/document_core/queries/rendering.rs'
       - 'src/wasm_api.rs'
       - 'src/main.rs'
+      - 'docs/canvaskit-parity-implementation.md'
+      - 'docs/text-ir-v2.md'
       - 'rhwp-studio/**'
       - '.github/workflows/render-diff.yml'
   workflow_dispatch:

--- a/docs/canvaskit-parity-implementation.md
+++ b/docs/canvaskit-parity-implementation.md
@@ -1,0 +1,143 @@
+# CanvasKit Parity Implementation Plan
+
+This document records the implementation plan for closing CanvasKit parity gaps
+without treating Canvas2D as a hidden runtime fallback. It is intentionally a
+plan, not a claim that every paint family already has complete direct replay.
+
+## Goal
+
+CanvasKit should replay the same user-visible `PageLayerTree` behavior that the
+current Canvas2D path can render in the web canvas view. Canvas2D remains the
+compatibility reference for behavior, paint order, and HWP-compatible layout,
+but CanvasKit direct replay must not depend on Canvas2D drawing, DOM image
+objects, or SVG DOM parsing to cover unsupported operations.
+
+The target contract is:
+
+1. Keep `PageLayerTree` as the frontend/backend boundary.
+2. Prefer direct replay over approximation.
+3. Ensure unsupported operations stay visible through deterministic diagnostics,
+   explicit fallback policy, or strict payload rejection.
+4. Keep browser-only preprocessing out of CanvasKit unless the data has first
+   become a native-ready payload, resource, or pure helper.
+
+## Current Baseline
+
+The current implementation already has a guarded CanvasKit replay path with
+explicit `default` and `compat` policy modes. It dispatches the core layer node
+kinds, clips, basic page backgrounds, vector primitives, simple raster images,
+basic form objects, root `TextRun` compatibility payloads, and the currently
+supported `GlyphOutline` color-layer subset. It still treats several text,
+image-effect, page-background fill, and document-object families as fallback or
+diagnostic work until their payload contract is strict enough for direct replay.
+
+`TextRun compatibility` remains the replay baseline for normal text. `GlyphRun`
+and `GlyphOutline` are additive sidecars, not a replacement authority by
+themselves. The browser CanvasKit runtime currently keeps `GlyphOutline` direct
+replay behind `glyph-outline-payload-status.ts`; Rust-side replay planning and
+future strict selection work should keep reporting why a sidecar was selected
+or rejected.
+
+Schema-v1 text variants are exported as ordinary `glyphRun` and `glyphOutline`
+paint ops with variant metadata plus `text.variantGroups`. Those sidecar ops
+must be treated as part of the same leaf-local selection set as the anchored
+fallback `TextRun`. Cache keys, replay-plane detection, and backend diagnostics
+should include sidecars whenever they can affect output.
+
+`ResourceArena` is the resource identity boundary for future widening. When
+new image, font, bitmap glyph, SVG glyph, or PDF/vector resources become
+replay-critical, they should move through that resource table instead of
+through backend-local browser objects.
+
+## Guardrails
+
+- CanvasKit source must not import `canvas2d-layer-renderer` or depend on
+  browser Canvas2D APIs such as `CanvasRenderingContext2D`, `Path2D`,
+  `OffscreenCanvas`, `ImageBitmap`, DOM image elements, `DOMParser`, or object
+  URLs.
+- `renderOp` must explicitly mention every `LayerPaintOp` variant exported by
+  `rhwp-studio/src/core/types.ts`.
+- `renderNode` must explicitly handle `group`, `clipRect`, and `leaf`.
+- Fallback groups for text and special visual operations must remain explicit
+  until a phase changes the policy and adds proof fixtures.
+- `GlyphOutline` direct replay must remain guarded by
+  `glyph-outline-payload-status.ts` before it reaches CanvasKit drawing code.
+- The renderer contract guard and render-diff CI should catch drift before a
+  PR changes public rendering behavior.
+
+## Implementation Touchpoints
+
+These paths are the first files to check when the CanvasKit parity contract
+changes:
+
+- `src/paint/text_v2.rs`
+- `src/renderer/canvaskit_policy.rs`
+- `rhwp-studio/src/core/types.ts`
+- `rhwp-studio/src/view/canvaskit-renderer.ts`
+- `rhwp-studio/src/view/canvaskit/`
+- `rhwp-studio/src/view/glyph-outline-payload-status.ts`
+- `rhwp-studio/e2e/renderer-contract.test.mjs`
+- `.github/workflows/render-diff.yml`
+
+The contract test keeps this list alive so a future rename or split has to
+update the plan at the same time.
+
+## Work Batches
+
+### 1. Contract And Plan Guards
+
+Pin the current dispatch surface and document the next parity boundaries before
+widening runtime behavior. This batch should be docs and static contract checks
+only. It should not change the public canvas default or hide unsupported work
+behind an overlay.
+
+### 2. Paint Family Parity Closures
+
+Close the remaining paint-op families one at a time. Each family should include
+a Canvas2D behavior audit, a direct CanvasKit implementation or deterministic
+unsupported diagnostic, and at least one focused fixture.
+
+Likely families:
+
+- path command and line style branches;
+- gradients, pattern fills, and image fills;
+- raster image effects and crop preprocessing;
+- equation and form-object bounds;
+- placeholder and raw-SVG preview payloads;
+- root `TextRun` effects such as rotation, vertical text, tab leaders, control
+  marks, decorations, shadow, outline, and emphasis.
+
+### 3. Strict Text Variant Replay
+
+Keep `GlyphRun` and `GlyphOutline` behind explicit payload-status and selection
+diagnostics until the payload family has a proof fixture. Do not let CanvasKit
+select glyph ids against an arbitrary local font by family name. Do not allow
+color, bitmap, SVG, and stroke payload families to mix in one strict outline
+payload.
+
+This batch should widen strict variant replay only when the fallback behavior
+and reject reasons are exact.
+
+### 4. Resource And Cache Proofs
+
+Move replay-relevant bytes through `ResourceArena` before treating them as
+strict payloads. Cache keys should include resource identity, output options,
+sidecar payloads, and replay-plane choices that can change pixels.
+
+This is the right place for image resource identity, static SVG resource
+identity, exact font blob proof, and cache invalidation fixtures.
+
+### 5. Visual And Artifact Diff Widening
+
+Use render-diff CI to compare Canvas2D and CanvasKit output on focused
+fixtures before broadening default behavior. Full-corpus or PDF artifact
+comparison can be added as report-only first, then promoted only after the
+noise floor is understood.
+
+## Non-Goals
+
+- This plan does not switch the public canvas default.
+- This plan does not add a hidden Canvas2D overlay fallback.
+- This plan does not enable CanvasKit `GlyphRun` or `GlyphOutline` selection
+  without proof resources and deterministic diagnostics.
+- This plan does not claim native Skia or PDF export parity is complete.

--- a/docs/text-ir-v2.md
+++ b/docs/text-ir-v2.md
@@ -321,6 +321,16 @@ default path.
 - The public compatibility path is unchanged: when proof is missing, the backend
   keeps the `TextRun` fallback.
 
+## CanvasKit Parity Plan Link
+
+CanvasKit replay widening is tracked in
+`docs/canvaskit-parity-implementation.md`. That plan keeps Text IR v2 sidecars
+as guarded alternatives to the `TextRun` compatibility path, and it keeps
+CanvasKit direct replay separate from hidden Canvas2D overlay behavior. Text IR
+v2 changes that affect `GlyphRun`, `GlyphOutline`, `text.variantGroups`,
+`ResourceArena`, or fallback-free profiles should update that plan when they
+also change CanvasKit selection, cache, or render-diff expectations.
+
 Every overlay removal requires a Canvas2D-vs-CanvasKit fixture. Rasterizer
 output can use fuzzy PNG comparison, but semantic decisions must be exact:
 selected variant id, fallback reason, resource resolution, effect preprocessing

--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -4,12 +4,18 @@ import path from 'node:path';
 import { fileURLToPath } from 'node:url';
 
 const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
+const repoRoot = path.resolve(studioRoot, '..');
 const canvaskitPath = path.join(studioRoot, 'src/view/canvaskit-renderer.ts');
 const canvaskitDirectory = path.join(studioRoot, 'src/view/canvaskit');
 const layerTypesPath = path.join(studioRoot, 'src/core/types.ts');
+const textIrV2DocPath = path.join(repoRoot, 'docs/text-ir-v2.md');
+const canvaskitParityPlanDocPath = path.join(repoRoot, 'docs/canvaskit-parity-implementation.md');
 
 const canvaskitSource = fs.readFileSync(canvaskitPath, 'utf8');
 const layerTypesSource = fs.readFileSync(layerTypesPath, 'utf8');
+const textIrV2DocSource = fs.readFileSync(textIrV2DocPath, 'utf8');
+const canvaskitParityPlanDocSource = fs.readFileSync(canvaskitParityPlanDocPath, 'utf8');
+const normalizedCanvaskitParityPlanDocSource = canvaskitParityPlanDocSource.replace(/\s+/g, ' ');
 
 function extractBlockBody(source, signatureIndex, blockName) {
   let bodyStart = -1;
@@ -152,6 +158,56 @@ const forbiddenCanvas2dApiPatterns = [
   [/\bFileReader\b/, 'FileReader'],
   [/\bCanvas2DLayerRenderer\b/, 'Canvas2DLayerRenderer'],
   [/canvas2d-layer-renderer/, 'canvas2d-layer-renderer import'],
+];
+const canvaskitParityPlanTouchpoints = [
+  { token: 'src/paint/text_v2.rs', path: path.join(repoRoot, 'src/paint/text_v2.rs'), kind: 'file' },
+  {
+    token: 'src/renderer/canvaskit_policy.rs',
+    path: path.join(repoRoot, 'src/renderer/canvaskit_policy.rs'),
+    kind: 'file',
+  },
+  {
+    token: 'rhwp-studio/src/core/types.ts',
+    path: path.join(studioRoot, 'src/core/types.ts'),
+    kind: 'file',
+  },
+  {
+    token: 'rhwp-studio/src/view/canvaskit-renderer.ts',
+    path: canvaskitPath,
+    kind: 'file',
+  },
+  {
+    token: 'rhwp-studio/src/view/canvaskit/',
+    path: canvaskitDirectory,
+    kind: 'directory',
+  },
+  {
+    token: 'rhwp-studio/src/view/glyph-outline-payload-status.ts',
+    path: path.join(studioRoot, 'src/view/glyph-outline-payload-status.ts'),
+    kind: 'file',
+  },
+  {
+    token: 'rhwp-studio/e2e/renderer-contract.test.mjs',
+    path: fileURLToPath(import.meta.url),
+    kind: 'file',
+  },
+  {
+    token: '.github/workflows/render-diff.yml',
+    path: path.join(repoRoot, '.github/workflows/render-diff.yml'),
+    kind: 'file',
+  },
+];
+const canvaskitParityPlanRequiredTokens = [
+  'PageLayerTree',
+  'CanvasKit direct replay',
+  'must not depend on Canvas2D',
+  'unsupported operations stay visible',
+  'TextRun compatibility',
+  'GlyphRun',
+  'GlyphOutline',
+  'text.variantGroups',
+  'ResourceArena',
+  'render-diff CI',
 ];
 
 assert.deepEqual(
@@ -303,5 +359,31 @@ for (const { label, source } of canvaskitSourceFiles) {
     );
   }
 }
+
+for (const { token, path: touchpointPath, kind } of canvaskitParityPlanTouchpoints) {
+  assert.ok(
+    canvaskitParityPlanDocSource.includes(token),
+    `CanvasKit parity plan should mention touchpoint ${token}`,
+  );
+
+  const stat = fs.statSync(touchpointPath);
+  if (kind === 'directory') {
+    assert.ok(stat.isDirectory(), `CanvasKit parity plan touchpoint ${token} should be a directory`);
+  } else {
+    assert.ok(stat.isFile(), `CanvasKit parity plan touchpoint ${token} should be a file`);
+  }
+}
+
+for (const token of canvaskitParityPlanRequiredTokens) {
+  assert.ok(
+    normalizedCanvaskitParityPlanDocSource.includes(token),
+    `CanvasKit parity plan should keep guard token: ${token}`,
+  );
+}
+
+assert.ok(
+  textIrV2DocSource.includes('docs/canvaskit-parity-implementation.md'),
+  'Text IR v2 contract should link to the CanvasKit parity implementation plan',
+);
 
 console.log('renderer backend contract guard passed');


### PR DESCRIPTION
## What

- Add `docs/canvaskit-parity-implementation.md` as the current CanvasKit parity plan.
- Link the Text IR v2 contract to that plan so text sidecar changes update the CanvasKit replay expectations together.
- Extend the renderer contract guard so the plan keeps the live CanvasKit touchpoints, required replay concepts, and `render-diff` CI hook in sync.
- Include the renderer docs in the `render-diff` PR path filter so doc-only contract drift still runs the guard.

## Why

P28/P29 pinned the CanvasKit replay contract in code. This phase makes the next widening work explicit before changing runtime behavior again: CanvasKit remains a direct replay backend, Canvas2D is still the compatibility reference, and unsupported work should stay visible through diagnostics or guarded fallback policy.

## Non-goals

- No public canvas default change.
- No CanvasKit runtime replay widening in this PR.
- No hidden Canvas2D overlay fallback.
- No new Text IR v2 schema field; this uses the current `text.variantGroups` terminology.

## Validation

- `node --check rhwp-studio/e2e/renderer-contract.test.mjs`
- `npm run e2e:renderer-contract`
- `npm run build`
- `git diff --check upstream/devel..HEAD`

Refs #536.
