### PR TITLE
task 1487: 외부 웹폰트 사용 안 함 옵션 추가

### DIFF
--- a/mydocs/orders/20260623.md
+++ b/mydocs/orders/20260623.md
@@ -11,5 +11,13 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
+| #1487 | 확장 옵션에 외부 웹폰트 사용 안 함 설정 추가 | PR 문서화/CI 확인 중 | PR #1490, self-merge 후보. Advanced Security URL 검사 권고는 URL 파싱 기반 비교로 반영 |
 | #1484 | 확장 build.mjs 폴백 폰트 누락 (404) | 완료 | web/fonts 전체 복사로 변경 |
 | #1483 | 표 줄/칸 지우기 후 커서 cellIndex 미보정 | 완료 | clamp+bbox 역조회 보정, 단위 테스트 126 pass |
+
+## PR 처리
+
+- [x] PR #1490 review 문서 작성: `mydocs/pr/archives/pr_1490_review.md`
+- [x] PR #1490 self-merge 실행 계획 작성: `mydocs/pr/archives/pr_1490_review_impl.md`
+- [ ] PR #1490 최신 head 기준 GitHub Actions 전체 통과 확인
+- [ ] 작업지시자 merge 승인 확인

--- a/mydocs/pr/archives/pr_1490_review.md
+++ b/mydocs/pr/archives/pr_1490_review.md
@@ -1,0 +1,104 @@
+# PR #1490 리뷰 기록 - 외부 웹폰트 사용 안 함 옵션
+
+- PR: https://github.com/edwardkim/rhwp/pull/1490
+- 작성일: 2026-06-23
+- 경로: collaborator self-merge 후보
+- base/head: `devel` <- `task_m100_1487`
+- 문서 작성 시점 참고 head: `01eeacf7` (본 review 문서/오늘할일 커밋 전)
+
+## 1. PR 메타
+
+| 항목 | 확인 내용 |
+|------|-----------|
+| 작성자 | `jangster77` |
+| PR 상태 | 문서 작성 시점 참고값: open, draft 아님 |
+| base | `devel` |
+| 관련 이슈 | `Closes #1487` |
+| 규모 | 문서 작성 시점 참고값: 27 files, +681/-38 |
+| merge 상태 | 문서 작성 시점 참고값: `MERGEABLE`, `BLOCKED`; 최종 merge 전 최신 상태 재확인 필요 |
+| CI 상태 | 문서 작성 시점 참고값: JS/Python CodeQL 및 Canvas visual diff 통과, Build & Test와 Rust CodeQL 진행 중 |
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 확정 사실로 기록하지 않는다.
+최종 merge 판단은 PR head 최신 커밋 기준 GitHub Actions 통과와 작업지시자 승인 후에만 수행한다.
+
+## 2. 변경 범위
+
+### 2.1 확장 옵션 추가
+
+- Chrome/Firefox/Safari options 페이지에 `외부 웹폰트 사용 안 함` 체크박스를 추가했다.
+- 기본값은 off로 유지했다.
+- 안내 문구는 내부망/오프라인 권장과 렌더링 차이 가능성을 명시한다.
+- 확장별 설정 저장소 차이를 반영했다.
+  - Chrome/Firefox: `storage.sync`
+  - Safari: `storage.local`
+
+### 2.2 viewer 폰트 로딩 경로
+
+- `rhwp-studio/src/core/extension-settings.ts`를 추가해 확장 설정을 viewer 초기화 전에 읽는다.
+- `loadWebFonts()`에 `disableExternalWebFonts` 옵션을 전달한다.
+- 옵션이 켜진 경우 외부 `http(s)` 웹폰트는 CSS `@font-face` 등록과 `FontFace.load()` 대상에서 제외한다.
+- 옵션이 꺼진 기본 모드에서는 기존 외부 CDN 폰트 사용 경로를 유지한다.
+
+### 2.3 로컬 글꼴 감지 모달 문구 정리
+
+- `웹 대체` 표현을 `대체 글꼴`로 바꿔 외부 웹폰트 옵션과의 혼선을 줄였다.
+- `외부 웹폰트 사용 안 함` 옵션이 켜진 경우 모달에 해당 상태를 표시한다.
+- 모달은 외부 CDN 로딩 여부가 아니라 로컬 원본 글꼴 감지 권한을 묻는 기능이므로 유지한다.
+
+### 2.4 빈 viewer 클릭 오류 방지
+
+- 문서가 로드되지 않은 빈 viewer에서 클릭할 때 `hitTest` 경로로 들어가지 않도록 방어했다.
+- Chrome 확장 오류 목록에 불필요한 `[InputHandler] hitTest 실패`가 남지 않도록 했다.
+
+### 2.5 CodeQL 권고 반영
+
+- GitHub Advanced Security가 테스트 코드의 URL 부분 문자열 검사에 대해
+  `Incomplete URL substring sanitization` 경고를 제기했다.
+- 테스트 assertion의 `includes('https://cdn.jsdelivr.net/')` 기반 검사를 제거했다.
+- CSS/FontFace source에서 `url(...)` 값을 추출해 `new URL()`로 파싱하고,
+  `protocol`과 `hostname`을 비교하도록 변경했다.
+
+## 3. 리스크
+
+| 리스크 | 판단 |
+|--------|------|
+| 온라인 렌더링 정합성 저하 | 기본값 off로 유지해 일반 온라인 환경에서는 기존 외부 웹폰트 경로를 유지한다. |
+| 오프라인 모드에서 PDF 기준 시각 차이 | 안내 문구에 글꼴, 줄바꿈, 페이지 배치 차이 가능성을 명시했다. |
+| 로컬 글꼴 감지 모달 혼선 | `대체 글꼴` 표현과 외부 웹폰트 비활성 상태 안내로 구분했다. |
+| 확장별 설정 저장소 차이 | Chrome/Firefox/Safari 별도 저장소를 공통 helper에서 흡수했다. |
+| CodeQL URL 검사 경고 재발 | URL 부분 문자열 검사 대신 `URL.hostname` 비교로 assertion을 변경했다. |
+
+## 4. 로컬 검증
+
+단계별 작업 중 확인된 로컬 검증은 다음과 같다.
+
+- `cd rhwp-studio && npm test`: 통과 (최종 130 passed)
+- `cd rhwp-studio && npm run build`: 통과
+- `cd rhwp-chrome && npm ci`: 통과
+- `cd rhwp-chrome && node build.mjs`: 통과
+- 확장 JS `node --check`: 통과
+- Chrome/Firefox locale JSON parse: 통과
+- `git diff --check`: 통과
+
+Stage 4 CodeQL 대응 후 추가 검증:
+
+- `cd rhwp-studio && npm test`: 통과 (130 passed)
+- `cd rhwp-studio && npm run build`: 통과
+- `git diff --check`: 통과
+
+## 5. 판단
+
+PR #1490은 #1487의 내부망/오프라인 피드백에 대응해 확장 옵션 기반으로 외부 웹폰트 로딩을 차단할 수 있게 한다.
+기본값을 off로 둬 온라인 환경의 기존 렌더링 정합성을 유지하고, 옵션 on 상태에서는 내부망 생존성을 우선한다.
+
+GitHub Advanced Security의 URL 부분 문자열 검사 권고는 최신 코드에서 URL 파싱 기반 비교로 반영했다.
+추가 dismiss나 보안 경고 무시는 필요하지 않다.
+
+최종 merge 조건:
+
+1. 본 review 문서 2건과 오늘할일 문서가 PR diff에 포함된다.
+2. PR head 최신 커밋 기준 GitHub Actions가 통과한다.
+3. 작업지시자 승인 상태가 유지된다.
+4. merge 전 `mergeable` / `mergeStateStatus` / 관련 이슈 상태를 최신으로 재확인한다.
+
+위 조건 충족 시 collaborator self-merge 후보로 merge 수용 가능하다.

--- a/mydocs/pr/archives/pr_1490_review_impl.md
+++ b/mydocs/pr/archives/pr_1490_review_impl.md
@@ -1,0 +1,86 @@
+# PR #1490 self-merge 실행 계획
+
+- PR: https://github.com/edwardkim/rhwp/pull/1490
+- 작성일: 2026-06-23
+- 경로: collaborator self-merge 후보
+- 문서 작성 시점 참고 head: `01eeacf7` (본 review 문서/오늘할일 커밋 전)
+
+## 1. 목적
+
+PR #1490은 #1487 내부망/오프라인 확장 사용 피드백에 대응해
+확장 옵션에서 외부 웹폰트 사용을 끌 수 있도록 하는 collaborator self-merge 후보 PR이다.
+
+`mydocs/manual/pr_review_workflow.md` 8장에 따라 review 문서와 오늘할일 문서를 PR head에 포함해,
+merge 후 별도 문서 커밋을 만들지 않도록 한다.
+
+## 2. 커밋 목록
+
+문서 작성 시점 로컬/원격 head 기준 커밋:
+
+| 순서 | SHA | 제목 |
+|------|-----|------|
+| 1 | `32da0761` | `task 1487: 외부 웹폰트 비활성 옵션 추가` |
+| 2 | `de77297f` | `task 1487: 빈 뷰어 클릭 오류 방지` |
+| 3 | `31d2483a` | `task 1487: 로컬 글꼴 모달 문구 정리` |
+| 4 | `f7577932` | `task 1487: PR 검증 공백 정리` |
+| 5 | `01eeacf7` | `task 1487: CodeQL 테스트 URL 검사 경고 수정` |
+
+최종 문서 커밋 예정:
+
+- `mydocs/pr/archives/pr_1490_review.md`
+- `mydocs/pr/archives/pr_1490_review_impl.md`
+- `mydocs/orders/20260623.md`
+
+## 3. 진행 단계
+
+### Stage A - 작업 범위 확정
+
+1. #1487 이슈와 PR #1490 메타를 확인한다.
+2. PR diff가 확장 옵션, viewer 설정, font loader, 로컬 글꼴 모달, 빈 viewer 클릭 방어, 회귀 테스트와 stage 문서로 구성되어 있음을 확인한다.
+3. GitHub Advanced Security 코멘트가 URL 부분 문자열 검사 권고였고, 최신 코드에서 URL 파싱 기반 비교로 반영되었음을 확인한다.
+
+### Stage B - review 문서 작성
+
+1. `mydocs/pr/archives/pr_1490_review.md`를 작성한다.
+2. `mydocs/pr/archives/pr_1490_review_impl.md`를 작성한다.
+3. `mydocs/orders/20260623.md`에 #1487 PR 문서화와 merge 전 조건을 기록한다.
+
+### Stage C - 문서 검증과 push
+
+문서만 수정하므로 cargo 빌드/테스트는 기계적으로 반복하지 않는다.
+다음 검증을 수행한다.
+
+```bash
+git diff --check
+git status --short
+```
+
+검증 후 다음 커밋으로 기존 PR head 브랜치에 push한다.
+
+```bash
+git add mydocs/pr/archives/pr_1490_review.md \
+        mydocs/pr/archives/pr_1490_review_impl.md \
+        mydocs/orders/20260623.md
+git commit -m "task 1487: PR 검토 문서와 오늘할일 갱신"
+git push upstream task_m100_1487
+```
+
+### Stage D - GitHub Actions 및 merge 준비
+
+push 후 다음을 최신 PR head 기준으로 확인한다.
+
+- GitHub Actions 전체 통과
+- review 문서 2건과 오늘할일 문서가 PR diff에 포함됨
+- GitHub Advanced Security의 기존 코멘트가 최신 코드에서 재발하지 않음
+- merge 가능한 상태
+- 작업지시자 승인
+
+## 4. merge 후 후속 처리
+
+- PR #1490 merge 결과 확인
+- 이슈 #1487 close 여부 확인
+- 필요 시 이슈 close + 코멘트
+- PR에 merge 완료 및 검증 결과 코멘트
+- `upstream/devel` 동기화
+- `upstream/task_m100_1487` 원격 작업 브랜치 삭제
+- 로컬 작업 브랜치 정리

--- a/mydocs/working/task_m100_1487_stage1.md
+++ b/mydocs/working/task_m100_1487_stage1.md
@@ -1,0 +1,68 @@
+# Task M100 #1487 Stage 1
+
+- 이슈: #1487 확장 옵션에 외부 웹폰트 사용 안 함 설정 추가
+- 브랜치: `task_m100_1487`
+- 작성일: 2026-06-23
+- 상태: 구현/검증 완료
+
+## 배경
+
+내부망/오프라인 환경에서 CRX로 확장을 설치한 사용자가 viewer 진입 시
+`웹폰트 로딩 중...` 상태에서 오래 대기한다는 피드백이 있었다.
+
+현재 rhwp-studio의 font loader는 함초롬/한컴 계열 폰트를 `cdn.jsdelivr.net`
+웹폰트로 등록하고, 초기 로딩에서 critical font로 로드한다. 인터넷 접근이
+차단된 환경에서는 이 외부 웹폰트 요청이 viewer 초기 진입을 지연시킬 수 있다.
+
+## 구현 방향
+
+- 확장 options 페이지에 `외부 웹폰트 사용 안 함` 옵션을 추가한다.
+- 기본값은 off로 유지하여 온라인 환경의 기존 렌더링 정합성을 보존한다.
+- 옵션 안내에는 다음 문구를 포함한다.
+  - `내부망/오프라인 환경에서 권장합니다. 일부 문서의 글꼴, 줄바꿈, 페이지 배치가 달라질 수 있습니다`
+- 옵션이 켜진 viewer에서는 외부 웹폰트 `@font-face` 등록과 `FontFace.load()`를 모두 건너뛴다.
+- 로컬 번들 폰트와 시스템 글꼴 사용은 유지한다.
+- Chrome/Firefox/Safari 확장 설정 저장소 차이를 흡수하되, 일반 web/PWA 환경에서는 기본값 off로 동작한다.
+
+## 검토 대상
+
+- `rhwp-studio/src/core/font-loader.ts`
+- `rhwp-studio/src/main.ts`
+- Chrome/Firefox/Safari options 페이지와 설정 저장 기본값
+- 확장 content/service worker의 `get-settings` 기본값
+- i18n 메시지
+
+## 검증 계획
+
+```bash
+cd rhwp-studio && npm run build
+cd rhwp-studio && npm test
+cd rhwp-chrome && npm ci
+cd rhwp-chrome && node build.mjs
+node --check rhwp-chrome/options.js && node --check rhwp-chrome/background.js && node --check rhwp-chrome/sw/message-router.js && node --check rhwp-firefox/options.js && node --check rhwp-firefox/background.js && node --check rhwp-firefox/sw/message-router.js && node --check rhwp-safari/src/options.js && node --check rhwp-safari/src/background.js
+node -e "for (const p of ['rhwp-chrome/_locales/ko/messages.json','rhwp-chrome/_locales/en/messages.json','rhwp-firefox/_locales/ko/messages.json','rhwp-firefox/_locales/en/messages.json']) JSON.parse(require('fs').readFileSync(p, 'utf8')); console.log('locale json ok')"
+git diff --check
+```
+
+필요 시 확장 빌드까지 추가로 확인한다.
+
+## 구현 내용
+
+- Chrome/Firefox/Safari options 페이지에 `외부 웹폰트 사용 안 함` 옵션을 추가했다.
+- Chrome/Firefox locale에 옵션 라벨과 안내 문구를 추가했다.
+- 확장 설치 기본값과 `get-settings` 응답 기본값에 `disableExternalWebFonts: false`를 추가했다.
+- viewer 공통 설정 브리지 `extension-settings.ts`를 추가해 Chrome/Firefox `storage.sync`, Safari `storage.local`을 읽도록 했다.
+- `loadWebFonts()`에 옵션을 추가하고, 옵션이 켜진 경우 외부 URL 폰트의 `@font-face` 등록과 `FontFace.load()`를 모두 건너뛰도록 했다.
+- viewer 초기화와 문서 로드 시 같은 설정을 font loader에 전달하도록 했다.
+- 오프라인 옵션이 CDN `@font-face`와 `FontFace.load()`를 막는 회귀 테스트를 추가했다.
+
+## 검증 결과
+
+- `cd rhwp-studio && npm run build`: 통과
+- `cd rhwp-studio && npm test`: 통과 (127 passed)
+- `cd rhwp-chrome && npm ci`: 통과
+  - 기존 의존성 기준 npm audit 경고 2건 표시
+- `cd rhwp-chrome && node build.mjs`: 통과
+- 확장 JS `node --check`: 통과
+- Chrome/Firefox locale JSON parse: 통과
+- `git diff --check`: 통과

--- a/mydocs/working/task_m100_1487_stage2.md
+++ b/mydocs/working/task_m100_1487_stage2.md
@@ -1,0 +1,46 @@
+# Task M100 #1487 Stage 2
+
+- 이슈: #1487 확장 옵션에 외부 웹폰트 사용 안 함 설정 추가
+- 브랜치: `task_m100_1487`
+- 작성일: 2026-06-23
+- 상태: 구현/검증 완료
+
+## 배경
+
+Stage 1 구현 후 Chrome 확장 시각 검증 과정에서 빈 viewer 탭을 클릭하면
+Chrome 확장 오류 목록에 다음 경고가 기록되는 것을 확인했다.
+
+```text
+[InputHandler] hitTest 실패: Error: 문서가 로드되지 않았습니다
+```
+
+`viewer.html` 자체는 정상 로드되지만, 문서가 없는 초기 화면에서도
+`InputHandler`의 `mousedown` 핸들러가 `wasm.hitTest()`까지 진입하면서
+불필요한 오류 기록을 남긴다.
+
+## 구현 방향
+
+- 문서가 로드되지 않은 상태(`wasm.pageCount <= 0`)에서는 container 클릭 입력을 무시한다.
+- 빈 viewer 클릭이 Chrome 확장 오류 목록에 기록되지 않도록 한다.
+- 실제 문서가 로드된 뒤의 클릭/드래그/객체 선택 동작은 유지한다.
+
+## 검증 계획
+
+```bash
+cd rhwp-studio && npm run build
+cd rhwp-studio && npm test
+cd rhwp-chrome && node build.mjs
+git diff --check
+```
+
+## 구현 내용
+
+- `input-handler-mouse.ts`의 `onClick` 진입점에서 `wasm.pageCount <= 0`이면 즉시 반환하도록 했다.
+- 빈 viewer 클릭이 `wasm.hitTest()`까지 진입하지 않도록 소스 기반 회귀 테스트를 추가했다.
+
+## 검증 결과
+
+- `cd rhwp-studio && npm test`: 통과 (128 passed)
+- `cd rhwp-studio && npm run build`: 통과
+- `cd rhwp-chrome && node build.mjs`: 통과
+- `git diff --check`: 통과

--- a/mydocs/working/task_m100_1487_stage3.md
+++ b/mydocs/working/task_m100_1487_stage3.md
@@ -1,0 +1,49 @@
+# Task M100 #1487 Stage 3
+
+- 이슈: #1487 확장 옵션에 외부 웹폰트 사용 안 함 설정 추가
+- 브랜치: `task_m100_1487`
+- 작성일: 2026-06-23
+- 상태: 구현/검증 완료
+
+## 배경
+
+Stage 1 구현 후 시각 검증 중 `외부 웹폰트 사용 안 함` 옵션이 켜져 있어도
+문서 로드 시 `로컬 글꼴 감지` 모달이 표시되는 것을 확인했다.
+
+이 모달은 외부 CDN 웹폰트 로드 여부가 아니라, 사용자 PC에 설치된 원본 글꼴을
+감지할지 묻는 기능이다. 하지만 버튼/설명에 `웹 대체`라는 표현이 있어
+`외부 웹폰트 사용 안 함` 옵션과 혼동될 수 있다.
+
+## 구현 방향
+
+- 로컬 글꼴 감지 모달은 유지한다.
+- 사용자에게 보이는 `웹 대체` 표현을 `대체 글꼴`로 바꾼다.
+- `외부 웹폰트 사용 안 함` 옵션이 켜진 상태에서는 모달 본문에 해당 상태를 표시한다.
+- 실제 외부 웹폰트 차단 동작은 Stage 1의 `disableExternalWebFonts` 경로를 유지한다.
+
+## 검증 계획
+
+```bash
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+cd rhwp-chrome && node build.mjs
+git diff --check
+```
+
+## 구현 내용
+
+- 로컬 글꼴 감지 모달의 사용자 노출 문구를 `웹 대체`에서 `대체 글꼴`로 변경했다.
+  - 버튼: `웹 대체로 보기` → `대체 글꼴로 보기`
+  - 상태/요약: `웹 대체 사용` → `대체 글꼴 사용`
+  - 안내 문장: `웹 대체 글꼴` → `대체 글꼴`
+- `showLocalFontsModalIfNeeded()`에 options 인자를 추가했다.
+- viewer의 `extensionViewerSettings.disableExternalWebFonts` 값을 로컬 글꼴 감지 모달에 전달했다.
+- `외부 웹폰트 사용 안 함`이 켜진 상태에서는 모달 본문에 `외부 웹폰트 사용 안 함: 켜짐` 안내를 표시하도록 했다.
+- 문구/상태 표시 회귀 테스트를 추가했다.
+
+## 검증 결과
+
+- `cd rhwp-studio && npm test`: 통과 (130 passed)
+- `cd rhwp-studio && npm run build`: 통과
+- `cd rhwp-chrome && node build.mjs`: 통과
+- `git diff --check`: 통과

--- a/mydocs/working/task_m100_1487_stage4.md
+++ b/mydocs/working/task_m100_1487_stage4.md
@@ -1,0 +1,44 @@
+# Task M100 #1487 Stage 4
+
+- 이슈: #1487 확장 옵션에 외부 웹폰트 사용 안 함 설정 추가
+- PR: #1490
+- 브랜치: `task_m100_1487`
+- 작성일: 2026-06-23
+- 상태: 구현/검증 완료
+
+## 배경
+
+PR CodeQL 집계 체크에서 테스트 코드의 URL 부분 문자열 검사에 대해
+`Incomplete URL substring sanitization` 경고가 발생했다.
+
+문제 지점은 제품 코드가 아니라 `font-loader-offline-mode.test.ts`의 assertion이며,
+`includes('https://cdn.jsdelivr.net/')`로 CDN URL 포함 여부를 확인한 것이 원인이다.
+
+## 구현 방향
+
+- 제품 코드는 변경하지 않는다.
+- 테스트 assertion에서 URL 부분 문자열 검사를 제거한다.
+- CSS/FontFace source의 `url(...)` 값을 추출한 뒤 `URL` 객체로 파싱한다.
+- CDN 여부는 `protocol`과 `hostname`을 정확히 비교해 판단한다.
+
+## 검증 계획
+
+```bash
+cd rhwp-studio && npm test
+cd rhwp-studio && npm run build
+git diff --check
+```
+
+## 구현 내용
+
+- 테스트 코드의 `includes('https://cdn.jsdelivr.net/')` 기반 URL 부분 문자열 검사를 제거했다.
+- CSS/FontFace source의 `url(...)` 값을 추출하는 helper를 추가했다.
+- 추출한 URL은 `new URL(...)`로 파싱하고 `protocol`, `hostname`을 비교해 CDN/외부 URL 여부를 판단하도록 변경했다.
+- 제품 코드와 런타임 동작은 변경하지 않았다.
+
+## 검증 결과
+
+- `cd rhwp-studio && npm test`: 통과 (130 passed)
+- `cd rhwp-studio && npm run build`: 통과
+  - 기존과 동일한 CanvasKit browser compatibility/chunk size 경고만 출력됨
+- `git diff --check`: 통과

--- a/rhwp-chrome/_locales/en/messages.json
+++ b/rhwp-chrome/_locales/en/messages.json
@@ -34,6 +34,12 @@
   "optionsHoverPreview": {
     "message": "Show preview when hovering over HWP links"
   },
+  "optionsDisableExternalWebFonts": {
+    "message": "Do not use external web fonts"
+  },
+  "optionsDisableExternalWebFontsDesc": {
+    "message": "Recommended for intranet/offline environments. Some documents may show different fonts, line breaks, or page layout."
+  },
   "optionsSaved": {
     "message": "Saved"
   },

--- a/rhwp-chrome/_locales/ko/messages.json
+++ b/rhwp-chrome/_locales/ko/messages.json
@@ -34,6 +34,12 @@
   "optionsHoverPreview": {
     "message": "HWP 링크에 마우스를 올리면 미리보기 표시"
   },
+  "optionsDisableExternalWebFonts": {
+    "message": "외부 웹폰트 사용 안 함"
+  },
+  "optionsDisableExternalWebFontsDesc": {
+    "message": "내부망/오프라인 환경에서 권장합니다. 일부 문서의 글꼴, 줄바꿈, 페이지 배치가 달라질 수 있습니다"
+  },
   "optionsSaved": {
     "message": "저장됨"
   },

--- a/rhwp-chrome/background.js
+++ b/rhwp-chrome/background.js
@@ -16,7 +16,8 @@ chrome.runtime.onInstalled.addListener((details) => {
     chrome.storage.sync.set({
       autoOpen: true,
       showBadges: true,
-      hoverPreview: true
+      hoverPreview: true,
+      disableExternalWebFonts: false
     });
   }
 });

--- a/rhwp-chrome/options.html
+++ b/rhwp-chrome/options.html
@@ -7,7 +7,10 @@
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 40px auto; padding: 0 20px; color: #333; }
     h1 { font-size: 20px; margin-bottom: 24px; }
     .option { margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+    .option.with-desc { align-items: flex-start; }
     .option label { cursor: pointer; }
+    .option-text { display: flex; flex-direction: column; gap: 3px; }
+    .option-desc { color: #6b7280; font-size: 12px; line-height: 1.45; }
     .saved { color: #16a34a; font-size: 13px; opacity: 0; transition: opacity 0.3s; }
     .saved.show { opacity: 1; }
     hr { border: none; border-top: 1px solid #e5e7eb; margin: 24px 0; }
@@ -30,6 +33,14 @@
   <div class="option">
     <input type="checkbox" id="hoverPreview" checked>
     <label for="hoverPreview" id="labelHoverPreview"></label>
+  </div>
+
+  <div class="option with-desc">
+    <input type="checkbox" id="disableExternalWebFonts">
+    <div class="option-text">
+      <label for="disableExternalWebFonts" id="labelDisableExternalWebFonts"></label>
+      <span class="option-desc" id="descDisableExternalWebFonts"></span>
+    </div>
   </div>
 
   <span class="saved" id="saved"></span>

--- a/rhwp-chrome/options.js
+++ b/rhwp-chrome/options.js
@@ -6,15 +6,17 @@
   document.getElementById('labelAutoOpen').textContent = chrome.i18n.getMessage('optionsAutoOpen');
   document.getElementById('labelShowBadges').textContent = chrome.i18n.getMessage('optionsShowBadges');
   document.getElementById('labelHoverPreview').textContent = chrome.i18n.getMessage('optionsHoverPreview');
+  document.getElementById('labelDisableExternalWebFonts').textContent = chrome.i18n.getMessage('optionsDisableExternalWebFonts');
+  document.getElementById('descDisableExternalWebFonts').textContent = chrome.i18n.getMessage('optionsDisableExternalWebFontsDesc');
   document.getElementById('saved').textContent = chrome.i18n.getMessage('optionsSaved');
   document.getElementById('privacy').textContent = chrome.i18n.getMessage('optionsPrivacy');
   document.getElementById('version').textContent = chrome.runtime.getManifest().version;
 
-  const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+  const inputs = ['autoOpen', 'showBadges', 'hoverPreview', 'disableExternalWebFonts'];
 
   // 설정 로드
   chrome.storage.sync.get(
-    { autoOpen: true, showBadges: true, hoverPreview: true },
+    { autoOpen: true, showBadges: true, hoverPreview: true, disableExternalWebFonts: false },
     (settings) => {
       for (const id of inputs) {
         document.getElementById(id).checked = settings[id];

--- a/rhwp-chrome/sw/message-router.js
+++ b/rhwp-chrome/sw/message-router.js
@@ -84,7 +84,8 @@ const messageHandlers = {
     const settings = await chrome.storage.sync.get({
       autoOpen: true,
       showBadges: true,
-      hoverPreview: true
+      hoverPreview: true,
+      disableExternalWebFonts: false
     });
     return settings;
   }

--- a/rhwp-firefox/_locales/en/messages.json
+++ b/rhwp-firefox/_locales/en/messages.json
@@ -34,6 +34,12 @@
   "optionsHoverPreview": {
     "message": "Show preview when hovering over HWP links"
   },
+  "optionsDisableExternalWebFonts": {
+    "message": "Do not use external web fonts"
+  },
+  "optionsDisableExternalWebFontsDesc": {
+    "message": "Recommended for intranet/offline environments. Some documents may show different fonts, line breaks, or page layout."
+  },
   "optionsSaved": {
     "message": "Saved"
   },

--- a/rhwp-firefox/_locales/ko/messages.json
+++ b/rhwp-firefox/_locales/ko/messages.json
@@ -34,6 +34,12 @@
   "optionsHoverPreview": {
     "message": "HWP 링크에 마우스를 올리면 미리보기 표시"
   },
+  "optionsDisableExternalWebFonts": {
+    "message": "외부 웹폰트 사용 안 함"
+  },
+  "optionsDisableExternalWebFontsDesc": {
+    "message": "내부망/오프라인 환경에서 권장합니다. 일부 문서의 글꼴, 줄바꿈, 페이지 배치가 달라질 수 있습니다"
+  },
   "optionsSaved": {
     "message": "저장됨"
   },

--- a/rhwp-firefox/background.js
+++ b/rhwp-firefox/background.js
@@ -17,7 +17,8 @@ browser.runtime.onInstalled.addListener((details) => {
     browser.storage.sync.set({
       autoOpen: true,
       showBadges: true,
-      hoverPreview: true
+      hoverPreview: true,
+      disableExternalWebFonts: false
     }).catch((err) => {
       console.error('[rhwp] 초기 설정 저장 오류:', err);
     });

--- a/rhwp-firefox/options.html
+++ b/rhwp-firefox/options.html
@@ -7,7 +7,10 @@
     body { font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif; max-width: 480px; margin: 40px auto; padding: 0 20px; color: #333; }
     h1 { font-size: 20px; margin-bottom: 24px; }
     .option { margin-bottom: 16px; display: flex; align-items: center; gap: 8px; }
+    .option.with-desc { align-items: flex-start; }
     .option label { cursor: pointer; }
+    .option-text { display: flex; flex-direction: column; gap: 3px; }
+    .option-desc { color: #6b7280; font-size: 12px; line-height: 1.45; }
     .saved { color: #16a34a; font-size: 13px; opacity: 0; transition: opacity 0.3s; }
     .saved.show { opacity: 1; }
     hr { border: none; border-top: 1px solid #e5e7eb; margin: 24px 0; }
@@ -30,6 +33,14 @@
   <div class="option">
     <input type="checkbox" id="hoverPreview" checked>
     <label for="hoverPreview" id="labelHoverPreview"></label>
+  </div>
+
+  <div class="option with-desc">
+    <input type="checkbox" id="disableExternalWebFonts">
+    <div class="option-text">
+      <label for="disableExternalWebFonts" id="labelDisableExternalWebFonts"></label>
+      <span class="option-desc" id="descDisableExternalWebFonts"></span>
+    </div>
   </div>
 
   <span class="saved" id="saved"></span>

--- a/rhwp-firefox/options.js
+++ b/rhwp-firefox/options.js
@@ -5,17 +5,20 @@ document.getElementById('title').textContent = browser.i18n.getMessage('optionsT
 document.getElementById('labelAutoOpen').textContent = browser.i18n.getMessage('optionsAutoOpen');
 document.getElementById('labelShowBadges').textContent = browser.i18n.getMessage('optionsShowBadges');
 document.getElementById('labelHoverPreview').textContent = browser.i18n.getMessage('optionsHoverPreview');
+document.getElementById('labelDisableExternalWebFonts').textContent = browser.i18n.getMessage('optionsDisableExternalWebFonts');
+document.getElementById('descDisableExternalWebFonts').textContent = browser.i18n.getMessage('optionsDisableExternalWebFontsDesc');
 document.getElementById('saved').textContent = browser.i18n.getMessage('optionsSaved');
 document.getElementById('privacy').textContent = browser.i18n.getMessage('optionsPrivacy');
 document.getElementById('version').textContent = browser.runtime.getManifest().version;
 
-const inputs = ['autoOpen', 'showBadges', 'hoverPreview'];
+const inputs = ['autoOpen', 'showBadges', 'hoverPreview', 'disableExternalWebFonts'];
 
 async function loadSettings() {
   const settings = await browser.storage.sync.get({
     autoOpen: true,
     showBadges: true,
-    hoverPreview: true
+    hoverPreview: true,
+    disableExternalWebFonts: false
   });
   for (const id of inputs) {
     document.getElementById(id).checked = settings[id];

--- a/rhwp-firefox/sw/message-router.js
+++ b/rhwp-firefox/sw/message-router.js
@@ -84,7 +84,8 @@ const messageHandlers = {
     const settings = await browser.storage.sync.get({
       autoOpen: true,
       showBadges: true,
-      hoverPreview: true
+      hoverPreview: true,
+      disableExternalWebFonts: false
     });
     return settings;
   }

--- a/rhwp-safari/src/background.js
+++ b/rhwp-safari/src/background.js
@@ -317,10 +317,15 @@ browser.runtime.onMessage.addListener((message, sender, sendResponse) => {
 
     case 'get-settings': {
       browser.storage.local.get({
-        autoOpen: true, showBadges: true, hoverPreview: true,
+        autoOpen: true, showBadges: true, hoverPreview: true, disableExternalWebFonts: false,
         allowHttp: true, httpWarning: true, devMode: false,
         allowedDomains: DEFAULT_ALLOWED_DOMAINS, allSitesEnabled: false,
-      }).then(s => sendResponse(s)).catch(() => sendResponse({ autoOpen: true, showBadges: true, hoverPreview: true }));
+      }).then(s => sendResponse(s)).catch(() => sendResponse({
+        autoOpen: true,
+        showBadges: true,
+        hoverPreview: true,
+        disableExternalWebFonts: false,
+      }));
       return true;
     }
 
@@ -475,7 +480,7 @@ browser.runtime.onInstalled.addListener((details) => {
   setupContextMenus();
   if (details.reason === 'install') {
     browser.storage.local.set({
-      autoOpen: true, showBadges: true, hoverPreview: true,
+      autoOpen: true, showBadges: true, hoverPreview: true, disableExternalWebFonts: false,
       allowHttp: true, httpWarning: true, devMode: false, securityLog: false,
       allowedDomains: DEFAULT_ALLOWED_DOMAINS, allSitesEnabled: false,
       maxFileSize: 20,

--- a/rhwp-safari/src/options.html
+++ b/rhwp-safari/src/options.html
@@ -270,6 +270,13 @@
           <div class="row-left"><div class="row-label">호버 시 미리보기 카드</div></div>
           <label class="toggle"><input type="checkbox" id="hoverPreview"><span class="slider"></span></label>
         </div>
+        <div class="row">
+          <div class="row-left">
+            <div class="row-label">외부 웹폰트 사용 안 함</div>
+            <div class="row-desc">내부망/오프라인 환경에서 권장합니다. 일부 문서의 글꼴, 줄바꿈, 페이지 배치가 달라질 수 있습니다</div>
+          </div>
+          <label class="toggle"><input type="checkbox" id="disableExternalWebFonts"><span class="slider"></span></label>
+        </div>
       </div>
     </div>
 

--- a/rhwp-safari/src/options.js
+++ b/rhwp-safari/src/options.js
@@ -14,13 +14,24 @@ document.querySelectorAll('.tab-btn').forEach(btn => {
 // ─── 설정 ───
 
 const DEFAULT_DOMAINS = ['.go.kr', '.or.kr', '.ac.kr', '.mil.kr', '.korea.kr', '.sc.kr'];
-const TOGGLE_KEYS = ['allSitesEnabled', 'autoOpen', 'showBadges', 'hoverPreview', 'allowHttp', 'httpWarning', 'devMode', 'securityLog'];
+const TOGGLE_KEYS = [
+  'allSitesEnabled',
+  'autoOpen',
+  'showBadges',
+  'hoverPreview',
+  'disableExternalWebFonts',
+  'allowHttp',
+  'httpWarning',
+  'devMode',
+  'securityLog',
+];
 const DEFAULTS = {
   allowedDomains: DEFAULT_DOMAINS,
   allSitesEnabled: false,
   autoOpen: true,
   showBadges: true,
   hoverPreview: true,
+  disableExternalWebFonts: false,
   allowHttp: true,
   httpWarning: true,
   maxFileSize: 20,

--- a/rhwp-studio/src/core/extension-settings.ts
+++ b/rhwp-studio/src/core/extension-settings.ts
@@ -1,0 +1,132 @@
+/**
+ * 확장 페이지에서 공유하는 viewer 설정을 읽는다.
+ *
+ * 일반 web/PWA 환경에서는 확장 storage API가 없으므로 기본값을 반환한다.
+ */
+
+export interface ExtensionViewerSettings {
+  disableExternalWebFonts: boolean;
+}
+
+const DEFAULT_SETTINGS: ExtensionViewerSettings = {
+  disableExternalWebFonts: false,
+};
+
+type StorageItems = Record<string, unknown>;
+
+const DEFAULT_STORAGE_ITEMS: StorageItems = {
+  disableExternalWebFonts: DEFAULT_SETTINGS.disableExternalWebFonts,
+};
+
+interface StorageAreaLike {
+  get(
+    keys?: string | string[] | StorageItems | null,
+    callback?: (items: StorageItems) => void,
+  ): Promise<StorageItems> | void;
+}
+
+interface BrowserLike {
+  storage?: {
+    sync?: StorageAreaLike;
+    local?: StorageAreaLike;
+  };
+  runtime?: {
+    lastError?: {
+      message?: string;
+    };
+  };
+}
+
+function getChromeApi(): BrowserLike | null {
+  return (globalThis as typeof globalThis & { chrome?: BrowserLike }).chrome ?? null;
+}
+
+function getBrowserApi(): BrowserLike | null {
+  return (globalThis as typeof globalThis & { browser?: BrowserLike }).browser ?? null;
+}
+
+function chromeLastErrorMessage(): string | null {
+  return getChromeApi()?.runtime?.lastError?.message ?? null;
+}
+
+function isThenable<T>(value: unknown): value is Promise<T> {
+  return !!value && typeof (value as { then?: unknown }).then === 'function';
+}
+
+function chromeStorageGet(storage: StorageAreaLike, defaults: StorageItems): Promise<StorageItems> {
+  return new Promise((resolve, reject) => {
+    let settled = false;
+    const settle = (fn: () => void) => {
+      if (settled) return;
+      settled = true;
+      fn();
+    };
+    try {
+      const result = storage.get(defaults, (items) => {
+        const err = chromeLastErrorMessage();
+        if (err) {
+          settle(() => reject(new Error(err)));
+        } else {
+          settle(() => resolve(items ?? {}));
+        }
+      });
+      if (isThenable<StorageItems>(result)) {
+        result.then(
+          (items) => settle(() => resolve(items ?? {})),
+          (error) => settle(() => reject(error)),
+        );
+      }
+    } catch (error) {
+      settle(() => reject(error));
+    }
+  });
+}
+
+async function promiseStorageGet(storage: StorageAreaLike, defaults: StorageItems): Promise<StorageItems> {
+  const result = storage.get(defaults);
+  if (isThenable<StorageItems>(result)) {
+    return result ?? {};
+  }
+  return {};
+}
+
+function normalizeSettings(value: StorageItems): ExtensionViewerSettings {
+  return {
+    disableExternalWebFonts: value.disableExternalWebFonts === true,
+  };
+}
+
+async function readStorage(
+  storage: StorageAreaLike | undefined,
+  mode: 'chrome-callback' | 'promise',
+): Promise<ExtensionViewerSettings | null> {
+  if (!storage) return null;
+  try {
+    const items = mode === 'chrome-callback'
+      ? await chromeStorageGet(storage, DEFAULT_STORAGE_ITEMS)
+      : await promiseStorageGet(storage, DEFAULT_STORAGE_ITEMS);
+    return normalizeSettings(items);
+  } catch (error) {
+    console.warn('[extension-settings] 확장 설정 로드 실패:', error);
+    return null;
+  }
+}
+
+/**
+ * 확장 viewer 설정을 읽는다.
+ *
+ * Chrome/Firefox는 기존 options가 storage.sync를 사용하고, Safari는 storage.local을
+ * 사용한다. sync를 먼저 확인하고 local을 fallback으로 둔다.
+ */
+export async function loadExtensionViewerSettings(): Promise<ExtensionViewerSettings> {
+  const chromeStorage = getChromeApi()?.storage;
+  const browserStorage = getBrowserApi()?.storage;
+
+  return (
+    await readStorage(chromeStorage?.sync, 'chrome-callback') ??
+    await readStorage(browserStorage?.sync, 'promise') ??
+    await readStorage(browserStorage?.local, 'promise') ??
+    await readStorage(chromeStorage?.local, 'chrome-callback') ??
+    DEFAULT_SETTINGS
+  );
+}

--- a/rhwp-studio/src/core/font-loader.ts
+++ b/rhwp-studio/src/core/font-loader.ts
@@ -15,6 +15,11 @@ interface FontEntry {
   unicodeRange?: string;
 }
 
+export interface WebFontLoadOptions {
+  /** true면 CDN 등 외부 URL 웹폰트 등록/로드를 건너뛴다. */
+  disableExternalWebFonts?: boolean;
+}
+
 // 함초롬체 CDN (눈누 jsdelivr — 비상업적 사용 허용, 한컴 라이선스)
 const CDN_HAMCHOB_R = 'https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2104@1.0/HANBatang.woff';
 const CDN_HAMCHOB_B = 'https://cdn.jsdelivr.net/gh/projectnoonnu/noonfonts_2104@1.0/HANBatangB.woff';
@@ -125,10 +130,39 @@ export const REGISTERED_FONTS = new Set(FONT_LIST.map(f => f.name));
 const CRITICAL_FONTS = new Set(['함초롬바탕', '함초롬돋움']);
 
 /** CSS @font-face 등록 여부 (중복 등록 방지) */
-let fontFaceRegistered = false;
+let fontFaceRegistrationMode: 'all' | 'local-only' | null = null;
 
 /** 이미 로드 완료된 woff2 파일 (중복 네트워크 요청 방지) */
 const loadedFiles = new Set<string>();
+
+function isExternalFontFile(file: string): boolean {
+  return /^https?:\/\//i.test(file);
+}
+
+function selectableFontList(options?: WebFontLoadOptions): FontEntry[] {
+  if (options?.disableExternalWebFonts !== true) return FONT_LIST;
+  return FONT_LIST.filter(f => !isExternalFontFile(f.file));
+}
+
+function registerFontFaces(options?: WebFontLoadOptions): void {
+  const disableExternal = options?.disableExternalWebFonts === true;
+  const mode = disableExternal ? 'local-only' : 'all';
+  if (fontFaceRegistrationMode === mode) return;
+
+  const styleId = 'rhwp-web-font-faces';
+  let style = document.getElementById(styleId) as HTMLStyleElement | null;
+  if (!style) {
+    style = document.createElement('style');
+    style.id = styleId;
+    document.head.appendChild(style);
+  }
+  style.textContent = selectableFontList(options).map(f => {
+    const fmt = f.format ?? 'woff2';
+    const ur = f.unicodeRange ? ` unicode-range: ${f.unicodeRange};` : '';
+    return `@font-face { font-family: "${f.name}"; src: url("${f.file}") format("${fmt}"); font-display: swap;${ur} }`;
+  }).join('\n');
+  fontFaceRegistrationMode = mode;
+}
 
 /**
  * OS에 설치된 폰트인지 감지한다 (document.fonts.check 기반).
@@ -166,37 +200,30 @@ export function getDetectedOSFonts(): ReadonlySet<string> {
 
 /**
  * 웹폰트를 선별 로드한다.
- *   1단계(동기): CSS @font-face 전체 등록 (최초 1회, 네트워크 미발생)
+ *   1단계(동기): CSS @font-face 등록
  *   2단계: 대상 폰트 로드 (이미 로드된 파일은 건너뜀)
  *
  * @param docFonts 문서에서 사용하는 폰트 이름 목록 (있으면 해당 폰트 + CRITICAL만 로드, 없으면 전체)
  * @param onProgress 폰트 로드 진행률 콜백 (loaded, total)
+ * @param options 외부 웹폰트 사용 여부 등 로드 옵션
  */
 export async function loadWebFonts(
   docFonts?: string[],
   onProgress?: (loaded: number, total: number) => void,
+  options?: WebFontLoadOptions,
 ): Promise<void> {
   // 0) OS 폰트 감지 (@font-face 등록 전에 실행해야 정확)
-  if (!fontFaceRegistered) {
+  if (!fontFaceRegistrationMode) {
     detectOSFonts();
   }
 
-  // 1) CSS @font-face 규칙 전체 등록 (네트워크 미발생, 최초 1회만)
-  if (!fontFaceRegistered) {
-    const style = document.createElement('style');
-    style.textContent = FONT_LIST.map(f => {
-      const fmt = f.format ?? 'woff2';
-      const ur = f.unicodeRange ? ` unicode-range: ${f.unicodeRange};` : '';
-      return `@font-face { font-family: "${f.name}"; src: url("${f.file}") format("${fmt}"); font-display: swap;${ur} }`;
-    }).join('\n');
-    document.head.appendChild(style);
-    fontFaceRegistered = true;
-  }
+  // 1) CSS @font-face 규칙 등록. 오프라인 옵션이면 외부 URL 폰트는 제외한다.
+  registerFontFaces(options);
 
   // 2) 로드 대상 결정: docFonts에 포함된 폰트 + CRITICAL만 로드
   //    OS에 설치된 폰트는 웹폰트 로딩 건너뜀
   const targetSet = new Set([...(docFonts ?? []), ...CRITICAL_FONTS]);
-  const toLoad = FONT_LIST.filter(f => {
+  const toLoad = selectableFontList(options).filter(f => {
     if (!targetSet.has(f.name)) return false;
     // OS에 동일 이름 폰트가 있으면 웹폰트 로딩 불필요
     if (detectedOSFonts.has(f.name)) return false;

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -215,6 +215,10 @@ function promoteCellSelectionDragCandidate(this: any, e: MouseEvent): boolean {
 }
 
 export function onClick(this: any, e: MouseEvent): void {
+  if ((this.wasm?.pageCount ?? 0) <= 0) {
+    return;
+  }
+
   // 연결선 드로잉 모드: 연결점 클릭으로 시작/끝
   if (this.connectorDrawingMode && e.button === 0) {
     const target = e.target as HTMLElement;

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -703,7 +703,9 @@ async function promptLocalFontsIfNeeded(docInfo: DocumentInfo, displayName: stri
     const report = analyzeDocumentFonts(docInfo.fontsUsed);
     if (!report.shouldPromptLocalAccess) return;
 
-    const choice = await showLocalFontsModalIfNeeded(report);
+    const choice = await showLocalFontsModalIfNeeded(report, {
+      disableExternalWebFonts: extensionViewerSettings.disableExternalWebFonts,
+    });
     if (choice !== 'detect') return;
 
     msg.textContent = '로컬 글꼴 감지 중...';

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -6,6 +6,7 @@ import { InputHandler } from '@/engine/input-handler';
 import { Toolbar } from '@/ui/toolbar';
 import { MenuBar } from '@/ui/menu-bar';
 import { loadWebFonts } from '@/core/font-loader';
+import { loadExtensionViewerSettings, type ExtensionViewerSettings } from '@/core/extension-settings';
 import { CommandRegistry } from '@/command/registry';
 import { CommandDispatcher } from '@/command/dispatcher';
 import type { EditorContext, CommandServices, EditorEditMode } from '@/command/types';
@@ -73,6 +74,9 @@ let inputHandler: InputHandler | null = null;
 let toolbar: Toolbar | null = null;
 let ruler: Ruler | null = null;
 let editMode: EditorEditMode = 'normal';
+let extensionViewerSettings: ExtensionViewerSettings = {
+  disableExternalWebFonts: false,
+};
 
 
 // ─── 커맨드 시스템 ─────────────────────────────
@@ -148,8 +152,14 @@ const sbZoomVal = () => document.getElementById('sb-zoom-val')!;
 async function initialize(): Promise<void> {
   const msg = sbMessage();
   try {
-    msg.textContent = '웹폰트 로딩 중...';
-    await loadWebFonts([]);  // CSS @font-face 등록 + CRITICAL 폰트만 로드
+    extensionViewerSettings = await loadExtensionViewerSettings();
+    if (extensionViewerSettings.disableExternalWebFonts) {
+      console.info('[main] 외부 웹폰트 사용 안 함 옵션이 켜져 있습니다.');
+    }
+    msg.textContent = extensionViewerSettings.disableExternalWebFonts
+      ? '로컬 폰트 준비 중...'
+      : '웹폰트 로딩 중...';
+    await loadWebFonts([], undefined, extensionViewerSettings);  // CSS @font-face 등록 + CRITICAL 폰트만 로드
     msg.textContent = 'WASM 로딩 중...';
     await wasm.initialize();
     if (import.meta.env.DEV) {
@@ -631,7 +641,7 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
     if (docInfo.fontsUsed?.length) {
       await loadWebFonts(docInfo.fontsUsed, (loaded, total) => {
         msg.textContent = `폰트 로딩 중... (${loaded}/${total})`;
-      });
+      }, extensionViewerSettings);
     }
     console.log('[initDoc] 2. 폰트 로딩 완료');
     msg.textContent = displayName;

--- a/rhwp-studio/src/ui/local-fonts-modal.ts
+++ b/rhwp-studio/src/ui/local-fonts-modal.ts
@@ -10,10 +10,14 @@ import { enableDialogDrag } from './dialog-drag';
 
 export type LocalFontsChoice = 'detect' | 'web-substitute' | 'cancel';
 
+export interface LocalFontsModalOptions {
+  disableExternalWebFonts?: boolean;
+}
+
 const STATUS_LABEL: Record<DocumentFontStatusItem['status'], string> = {
   available: '사용 가능',
   'needs-local-check': '로컬 확인 필요',
-  'web-substitute': '웹 대체 사용',
+  'web-substitute': '대체 글꼴 사용',
   missing: '누락',
 };
 
@@ -22,7 +26,10 @@ export class LocalFontsModal {
   private captureHandler: ((e: KeyboardEvent) => void) | null = null;
   private resolver: ((choice: LocalFontsChoice) => void) | null = null;
 
-  constructor(private readonly report: DocumentFontStatusReport) {}
+  constructor(
+    private readonly report: DocumentFontStatusReport,
+    private readonly options: LocalFontsModalOptions = {},
+  ) {}
 
   async showAsync(): Promise<LocalFontsChoice> {
     return new Promise((resolve) => {
@@ -74,9 +81,21 @@ export class LocalFontsModal {
     privacy.style.fontSize = '13px';
     privacy.style.color = 'var(--color-text-secondary)';
     privacy.textContent = this.report.detectionMethod === 'font-presence-probe'
-      ? '이 브라우저에서는 설치된 모든 글꼴 목록을 가져오지 않고, 현재 문서에 필요한 글꼴만 확인합니다. 확인 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 웹 대체 글꼴로 계속 표시합니다.'
-      : '감지 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 웹 대체 글꼴로 계속 표시합니다.';
+      ? '이 브라우저에서는 설치된 모든 글꼴 목록을 가져오지 않고, 현재 문서에 필요한 글꼴만 확인합니다. 확인 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 대체 글꼴로 계속 표시합니다.'
+      : '감지 결과는 이 브라우저/확장 로컬 저장소에만 보관되며 서버로 전송하지 않습니다. 감지를 건너뛰면 대체 글꼴로 계속 표시합니다.';
     body.appendChild(privacy);
+
+    if (this.options.disableExternalWebFonts) {
+      const offlineNotice = document.createElement('div');
+      offlineNotice.style.margin = '0 0 12px 0';
+      offlineNotice.style.padding = '8px 10px';
+      offlineNotice.style.border = '1px solid var(--color-border)';
+      offlineNotice.style.borderRadius = '4px';
+      offlineNotice.style.fontSize = '13px';
+      offlineNotice.style.color = 'var(--color-text-secondary)';
+      offlineNotice.textContent = '외부 웹폰트 사용 안 함: 켜짐. 대체 글꼴은 외부 CDN 폰트를 요청하지 않고 번들/시스템 글꼴 기준으로 표시됩니다.';
+      body.appendChild(offlineNotice);
+    }
 
     const summary = document.createElement('ul');
     summary.style.margin = '0 0 12px 16px';
@@ -86,7 +105,7 @@ export class LocalFontsModal {
     const rows: Array<[string, number]> = [
       ['사용 가능', this.report.summary.available],
       ['로컬 확인 필요', this.report.summary.needsLocalCheck],
-      ['웹 대체 사용', this.report.summary.webSubstitute],
+      ['대체 글꼴 사용', this.report.summary.webSubstitute],
       ['누락', this.report.summary.missing],
     ];
     for (const [label, count] of rows) {
@@ -145,7 +164,7 @@ export class LocalFontsModal {
 
     const webBtn = document.createElement('button');
     webBtn.className = 'dialog-btn';
-    webBtn.textContent = '웹 대체로 보기';
+    webBtn.textContent = '대체 글꼴로 보기';
     webBtn.addEventListener('click', () => this.resolve('web-substitute'));
 
     footer.appendChild(detectBtn);
@@ -190,7 +209,8 @@ export class LocalFontsModal {
 
 export async function showLocalFontsModalIfNeeded(
   report: DocumentFontStatusReport,
+  options: LocalFontsModalOptions = {},
 ): Promise<LocalFontsChoice> {
   if (!report.shouldPromptLocalAccess) return 'web-substitute';
-  return new LocalFontsModal(report).showAsync();
+  return new LocalFontsModal(report, options).showAsync();
 }

--- a/rhwp-studio/tests/font-loader-offline-mode.test.ts
+++ b/rhwp-studio/tests/font-loader-offline-mode.test.ts
@@ -1,0 +1,80 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { loadWebFonts } from '../src/core/font-loader.ts';
+
+test('외부 웹폰트 사용 안 함 옵션은 CDN @font-face와 FontFace.load를 건너뛴다', async () => {
+  const styles: Array<{ id: string; textContent: string }> = [];
+  const fontFaceRequests: Array<{ family: string; source: string }> = [];
+  const previousDocument = (globalThis as typeof globalThis & { document?: unknown }).document;
+  const previousFontFace = (globalThis as typeof globalThis & { FontFace?: unknown }).FontFace;
+
+  const fakeDocument = {
+    head: {
+      appendChild(element: { id: string; textContent: string }) {
+        styles.push(element);
+      },
+    },
+    createElement(tagName: string) {
+      assert.equal(tagName, 'style');
+      return { id: '', textContent: '' };
+    },
+    getElementById(id: string) {
+      return styles.find(style => style.id === id) ?? null;
+    },
+    fonts: {
+      check() {
+        return false;
+      },
+      add() {
+        // 테스트에서는 등록 호출 여부만 FontFace 생성 기록으로 확인한다.
+      },
+    },
+  };
+
+  class FakeFontFace {
+    family: string;
+    source: string;
+
+    constructor(family: string, source: string) {
+      this.family = family;
+      this.source = source;
+      fontFaceRequests.push({ family, source });
+    }
+
+    async load(): Promise<FakeFontFace> {
+      return this;
+    }
+  }
+
+  Object.defineProperty(globalThis, 'document', {
+    configurable: true,
+    value: fakeDocument,
+  });
+  Object.defineProperty(globalThis, 'FontFace', {
+    configurable: true,
+    value: FakeFontFace,
+  });
+
+  try {
+    await loadWebFonts([], undefined, { disableExternalWebFonts: true });
+
+    assert.equal(styles.length, 1);
+    assert.equal(styles[0].textContent.includes('https://cdn.jsdelivr.net/'), false);
+    assert.equal(fontFaceRequests.some(request => request.source.includes('https://')), false);
+
+    fontFaceRequests.length = 0;
+    await loadWebFonts([]);
+
+    assert.equal(styles[0].textContent.includes('https://cdn.jsdelivr.net/'), true);
+    assert.equal(fontFaceRequests.some(request => request.source.includes('https://cdn.jsdelivr.net/')), true);
+  } finally {
+    Object.defineProperty(globalThis, 'document', {
+      configurable: true,
+      value: previousDocument,
+    });
+    Object.defineProperty(globalThis, 'FontFace', {
+      configurable: true,
+      value: previousFontFace,
+    });
+  }
+});

--- a/rhwp-studio/tests/font-loader-offline-mode.test.ts
+++ b/rhwp-studio/tests/font-loader-offline-mode.test.ts
@@ -2,6 +2,33 @@ import assert from 'node:assert/strict';
 import test from 'node:test';
 import { loadWebFonts } from '../src/core/font-loader.ts';
 
+const JSDELIVR_HOSTNAME = 'cdn.jsdelivr.net';
+const CSS_URL_PATTERN = /url\((?:"([^"]+)"|'([^']+)'|([^'")]+))\)/g;
+
+function extractFontUrls(source: string): URL[] {
+  return Array.from(source.matchAll(CSS_URL_PATTERN), match => (
+    match[1] ?? match[2] ?? match[3] ?? ''
+  ).trim()).flatMap(rawUrl => {
+    try {
+      return [new URL(rawUrl)];
+    } catch {
+      return [];
+    }
+  });
+}
+
+function usesJsDelivrFontUrl(source: string): boolean {
+  return extractFontUrls(source).some(url => (
+    url.protocol === 'https:' && url.hostname === JSDELIVR_HOSTNAME
+  ));
+}
+
+function usesExternalFontUrl(source: string): boolean {
+  return extractFontUrls(source).some(url => (
+    url.protocol === 'http:' || url.protocol === 'https:'
+  ));
+}
+
 test('외부 웹폰트 사용 안 함 옵션은 CDN @font-face와 FontFace.load를 건너뛴다', async () => {
   const styles: Array<{ id: string; textContent: string }> = [];
   const fontFaceRequests: Array<{ family: string; source: string }> = [];
@@ -59,14 +86,14 @@ test('외부 웹폰트 사용 안 함 옵션은 CDN @font-face와 FontFace.load�
     await loadWebFonts([], undefined, { disableExternalWebFonts: true });
 
     assert.equal(styles.length, 1);
-    assert.equal(styles[0].textContent.includes('https://cdn.jsdelivr.net/'), false);
-    assert.equal(fontFaceRequests.some(request => request.source.includes('https://')), false);
+    assert.equal(usesJsDelivrFontUrl(styles[0].textContent), false);
+    assert.equal(fontFaceRequests.some(request => usesExternalFontUrl(request.source)), false);
 
     fontFaceRequests.length = 0;
     await loadWebFonts([]);
 
-    assert.equal(styles[0].textContent.includes('https://cdn.jsdelivr.net/'), true);
-    assert.equal(fontFaceRequests.some(request => request.source.includes('https://cdn.jsdelivr.net/')), true);
+    assert.equal(usesJsDelivrFontUrl(styles[0].textContent), true);
+    assert.equal(fontFaceRequests.some(request => usesJsDelivrFontUrl(request.source)), true);
   } finally {
     Object.defineProperty(globalThis, 'document', {
       configurable: true,

--- a/rhwp-studio/tests/input-handler-empty-viewer.test.ts
+++ b/rhwp-studio/tests/input-handler-empty-viewer.test.ts
@@ -1,0 +1,28 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('빈 viewer 클릭은 hitTest 전에 문서 로드 여부를 확인한다', () => {
+  const mouse = source('src/engine/input-handler-mouse.ts');
+  const onClickStart = mouse.indexOf('export function onClick');
+  const onClickEnd = mouse.indexOf('export function onDblClick', onClickStart);
+  assert.notEqual(onClickStart, -1, 'onClick function not found');
+  assert.notEqual(onClickEnd, -1, 'onClick function end not found');
+
+  const onClick = mouse.slice(onClickStart, onClickEnd);
+  const pageCountGuard = onClick.indexOf('this.wasm?.pageCount');
+  const firstHitTest = onClick.indexOf('this.wasm.hitTest');
+
+  assert.notEqual(pageCountGuard, -1, 'pageCount guard not found');
+  assert.notEqual(firstHitTest, -1, 'hitTest call not found');
+  assert.ok(pageCountGuard < firstHitTest, 'empty viewer guard must run before hitTest');
+});
+

--- a/rhwp-studio/tests/input-handler-empty-viewer.test.ts
+++ b/rhwp-studio/tests/input-handler-empty-viewer.test.ts
@@ -25,4 +25,3 @@ test('빈 viewer 클릭은 hitTest 전에 문서 로드 여부를 확인한다',
   assert.notEqual(firstHitTest, -1, 'hitTest call not found');
   assert.ok(pageCountGuard < firstHitTest, 'empty viewer guard must run before hitTest');
 });
-

--- a/rhwp-studio/tests/local-fonts-modal-copy.test.ts
+++ b/rhwp-studio/tests/local-fonts-modal-copy.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('로컬 글꼴 감지 모달은 사용자에게 대체 글꼴 표현을 사용한다', () => {
+  const modal = source('src/ui/local-fonts-modal.ts');
+
+  assert.match(modal, /대체 글꼴로 보기/);
+  assert.match(modal, /대체 글꼴 사용/);
+  assert.doesNotMatch(modal, /웹 대체로 보기/);
+  assert.doesNotMatch(modal, /웹 대체 사용/);
+});
+
+test('외부 웹폰트 비활성 상태는 로컬 글꼴 감지 모달에 표시된다', () => {
+  const modal = source('src/ui/local-fonts-modal.ts');
+  const main = source('src/main.ts');
+
+  assert.match(modal, /외부 웹폰트 사용 안 함: 켜짐/);
+  assert.match(modal, /외부 CDN 폰트를 요청하지 않고/);
+  assert.match(main, /disableExternalWebFonts:\s*extensionViewerSettings\.disableExternalWebFonts/);
+});
+

--- a/rhwp-studio/tests/local-fonts-modal-copy.test.ts
+++ b/rhwp-studio/tests/local-fonts-modal-copy.test.ts
@@ -27,4 +27,3 @@ test('외부 웹폰트 비활성 상태는 로컬 글꼴 감지 모달에 표시
   assert.match(modal, /외부 CDN 폰트를 요청하지 않고/);
   assert.match(main, /disableExternalWebFonts:\s*extensionViewerSettings\.disableExternalWebFonts/);
 });
-


### PR DESCRIPTION
## 요약

- 확장 옵션에 `외부 웹폰트 사용 안 함` 설정을 추가했습니다.
- 옵션이 켜진 경우 외부 `http(s)` 웹폰트 로딩을 건너뛰고 번들/시스템 대체 글꼴 기준으로 표시합니다.
- 로컬 글꼴 감지 모달 문구를 `웹 대체`에서 `대체 글꼴`로 정리하고, 외부 웹폰트 비활성 상태 안내를 표시합니다.
- 빈 viewer 클릭 시 문서 미로드 상태에서 `hitTest` 오류가 발생하지 않도록 방어했습니다.

## 검증

- `git diff --check upstream/devel...HEAD`
- `cd rhwp-studio && npm test`
- `cd rhwp-studio && npm run build`
- `cd rhwp-chrome && npm run build`
- `cd rhwp-firefox && npm run build`

Closes #1487