### PR TITLE
fix: replay web canvas planes in paint order

### DIFF
--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -270,6 +270,9 @@ pub struct WebCanvasRenderer {
     /// BehindText plane 을 별도 canvas layer 로 합성할 때 flow Canvas 의 페이지 배경을
     /// 투명하게 둘지 여부.
     transparent_page_background: bool,
+    /// `LayerFilter::All` renders the layer tree in logical replay-plane order,
+    /// independent of raw tree child order.
+    active_replay_plane: Option<PaintReplayPlane>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -290,6 +293,7 @@ impl WebCanvasRenderer {
             scale: 1.0,
             layer_filter: LayerFilter::All,
             transparent_page_background: false,
+            active_replay_plane: None,
         })
     }
 
@@ -312,6 +316,9 @@ impl WebCanvasRenderer {
     fn should_render_op(&self, op: &PaintOp, layer: Option<RenderLayerInfo>) -> bool {
         use crate::model::shape::TextWrap;
         let replay_plane = paint_op_replay_plane_with_layer(op, layer);
+        if let Some(active) = self.active_replay_plane {
+            return replay_plane == active;
+        }
         match self.layer_filter {
             LayerFilter::All => true,
             LayerFilter::BackgroundOnly => replay_plane == PaintReplayPlane::Background,
@@ -351,7 +358,19 @@ impl WebCanvasRenderer {
             LayerFilter::WrapOnly(_) => true,
         };
         self.begin_page(tree.page_width, tree.page_height);
-        self.render_layer_node(&tree.root, None);
+        if self.layer_filter == LayerFilter::All {
+            let prev = self.active_replay_plane;
+            for replay_plane in PaintReplayPlane::ORDERED {
+                if !layer_node_has_replay_plane(&tree.root, replay_plane) {
+                    continue;
+                }
+                self.active_replay_plane = Some(replay_plane);
+                self.render_layer_node(&tree.root, None);
+            }
+            self.active_replay_plane = prev;
+        } else {
+            self.render_layer_node(&tree.root, None);
+        }
         self.transparent_page_background = false;
     }
 

--- a/tests/render_p22_web_canvas_contract.rs
+++ b/tests/render_p22_web_canvas_contract.rs
@@ -15,3 +15,19 @@ fn web_canvas_layer_leaf_replay_does_not_rebuild_render_nodes() {
         "WebCanvas layer replay must not rebuild temporary RenderNode wrappers"
     );
 }
+
+#[test]
+fn web_canvas_all_filter_replays_logical_planes_in_order() {
+    assert!(
+        WEB_CANVAS_SOURCE.contains("active_replay_plane: Option<PaintReplayPlane>"),
+        "WebCanvas should track the currently replayed plane"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("for replay_plane in PaintReplayPlane::ORDERED"),
+        "LayerFilter::All should replay planes in logical paint order"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("self.active_replay_plane = Some(replay_plane)"),
+        "WebCanvas should filter each tree pass to the active replay plane"
+    );
+}


### PR DESCRIPTION
## What

Fix the Web Canvas renderer so `LayerFilter::All` replays page layer trees in logical paint-plane order instead of raw tree-child order.

The Skia renderer already iterates `PaintReplayPlane::ORDERED`; this makes Web Canvas follow the same ordering and filters each replay pass to the active plane.

## Why

A behind-text full-page group can appear later in the raw layer tree than the body text. Web Canvas previously traversed that raw order for `LayerFilter::All`, so the behind-text group could cover text that should remain visible.

The issue is visible on page 4 of the repro HWPX used for the proof ([download HWPX](https://raw.githubusercontent.com/humdrum00001010/rhwp/b3c843a6ad3883a19d8ea68b5ab20baaea9f86a7/pr-evidence/2025-admin-work-manual.hwpx)): upstream renders the page body blank/covered, while the patched renderer shows the TOC text.

![Canvas2D render comparison](https://raw.githubusercontent.com/humdrum00001010/rhwp/b3c843a6ad3883a19d8ea68b5ab20baaea9f86a7/pr-evidence/comparison-upstream-vs-patched-page-4-scale2.png)

## Scope

This PR intentionally only changes:

- `src/renderer/web_canvas.rs`
- `tests/render_p22_web_canvas_contract.rs`

It does not include any NIF/API/binding-surface changes.

## Validation

- `cargo fmt --check`
- `cargo test --test render_p22_web_canvas_contract`
- `cargo check --target wasm32-unknown-unknown --lib`
- `wasm-pack build --target web`
- Browser Canvas2D proof against the same page:
  - upstream `e99c93be`: page 4 rendered visually blank/covered, dark pixels `20467`
  - patched build: page 4 TOC text visible, dark pixels `58719`
