### PR TITLE
fix: replay web canvas planes in paint order

### DIFF
--- a/mydocs/pr/archives/pr_1497_review.md
+++ b/mydocs/pr/archives/pr_1497_review.md
@@ -1,0 +1,108 @@
+# PR #1497 검토 기록 - Web Canvas paint plane replay 순서 보정
+
+## PR 메타
+
+| 항목 | 내용 |
+|---|---|
+| 번호 | #1497 |
+| 제목 | `fix: replay web canvas planes in paint order` |
+| 작성자 | `humdrum00001010` |
+| 작성자 상태 | 외부 contributor |
+| base | `devel` |
+| head | `humdrum00001010/codex/web-canvas-replay-order-devel` |
+| 관련 이슈 | 없음. #1496 리뷰 피드백 반영 재제출 |
+| 규모 | 문서 작성 시점 참고값: 2 files, +70 / -4 |
+| PR 원 커밋 | `355c5e980aad0895e4b71ff1a76e4c67a9da252f` |
+| maintainer can modify | 문서 작성 시점 참고값: true |
+| review request | 문서 작성 시점 참고값: `postmelee` |
+| labels / milestone | 문서 작성 시점 참고값: 없음 / 없음 |
+| merge 상태 | 문서 작성 시점 참고값: 원 PR head는 `BEHIND`, 최신 `upstream/devel` merge commit 반영 후 재확인 필요 |
+| CI 상태 | 문서 작성 시점 참고값: 원 PR head 기준 GitHub Actions 통과, 문서/merge commit push 후 최신 head 기준 재확인 필요 |
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 확정 사실로 기록하지 않는다.
+최종 merge 판단은 PR head 최신 커밋 기준 GitHub Actions 통과와 작업지시자 승인 후에만 수행한다.
+
+## 배경
+
+이 PR은 #1496에서 지적한 base branch 문제를 정리해 `devel` 기준으로 다시 제출한 PR이다.
+#1496은 base가 `main`이어서 `upstream/devel..upstream/pr/1496` 비교에 실제 수정 외 main-only 커밋이 섞였다.
+#1497은 base가 `devel`이고, PR diff는 Web Canvas 렌더러와 계약 테스트 2파일로 제한되어 있다.
+
+PR 본문에 따르면 재현 문서는 page 4에서 behind-text full-page group이 body text보다 raw layer tree 뒤쪽에 나타나는
+케이스다. Web Canvas `LayerFilter::All`이 raw child 순서 그대로 layer tree를 순회하면 behind-text group이
+본문 텍스트 위에 그려져 TOC text가 가려질 수 있다. Skia 렌더러는 이미 `PaintReplayPlane::ORDERED` 순서로
+replay하므로, Web Canvas도 같은 logical paint-plane 순서를 따르게 하는 것이 수정의 핵심이다.
+
+## 변경 범위 분석
+
+### `src/renderer/web_canvas.rs`
+
+- `WebCanvasRenderer`에 `active_replay_plane: Option<PaintReplayPlane>` 상태를 추가했다.
+- `LayerFilter::All`일 때 `PaintReplayPlane::ORDERED`를 순회하면서 layer tree를 plane별로 replay한다.
+- 각 pass 전에 `layer_node_has_replay_plane`으로 해당 plane에 그릴 내용이 있는지 확인해 불필요한 replay를 건너뛴다.
+- `should_render_op`에서 active plane이 있으면 `paint_op_replay_plane_with_layer` 결과와 일치하는 PaintOp만 그린다.
+- replay 후 이전 `active_replay_plane`을 복원하므로, 다른 `LayerFilter` 경로나 이후 렌더 호출에 상태가 남지 않는다.
+
+### `show_control_codes` group label 보정
+
+#1496 검토에서 `show_control_codes`가 켜진 경우 `[표]`, `[글상자]`, `[머리말]` 같은 group label은 `PaintOp`가 아니어서
+plane별 replay pass마다 중복 출력될 수 있다는 우려가 있었다.
+
+#1497은 이 부분을 추가로 보정했다.
+
+- `group_label_matches_replay_plane`을 추가해 inherited layer metadata에서 계산한 `render_layer_replay_plane`과
+  active plane을 비교한다.
+- `should_render_group_label`을 통해 `show_control_codes` 조건과 replay plane 조건을 함께 적용한다.
+- `render_layer_node`의 group label 출력 지점이 `self.show_control_codes` 직접 확인에서
+  `self.should_render_group_label(active_layer)` 호출로 바뀌었다.
+
+따라서 일반 PaintOp뿐 아니라 control-code group label도 active replay plane에 맞는 pass에서만 출력된다.
+
+### `tests/render_p22_web_canvas_contract.rs`
+
+기존 Web Canvas 계약 테스트에 다음 확인이 추가되었다.
+
+- `LayerFilter::All`에서 `active_replay_plane`을 추적하는지 확인
+- `PaintReplayPlane::ORDERED` 순회가 존재하는지 확인
+- 각 pass에서 active plane을 설정하는지 확인
+- group label 출력이 별도 gate를 통과하는지 확인
+
+테스트는 현재 source 문자열 기반 계약 테스트다. 구현 의도와 핵심 구조를 고정하는 데는 도움이 되지만, 실제 paint 결과나
+시각 순서 회귀를 강하게 막는 테스트는 아니다. PR 본문의 Canvas2D 비교와 Render Diff CI는 긍정적인 보조 근거이며,
+장기적으로는 재현 fixture나 `PageLayerTree` 기반 순서 검증이 더 강한 회귀 테스트가 된다.
+
+## 로컬 검증 결과
+
+검증은 2026-06-24 KST 기준 최신 `upstream/devel`(`b1024f6b`)을 PR head에 merge commit으로 반영한 임시
+worktree에서 수행했다.
+
+- 최신 `devel` merge: 충돌 없음
+- `git diff --check upstream/devel...HEAD`: passed
+- `cargo fmt --check`: passed
+- `cargo test --test render_p22_web_canvas_contract`: passed, 3 passed
+- `cargo check --target wasm32-unknown-unknown --lib`: passed
+
+## 주요 문제점 / 리스크
+
+- 관련 이슈가 PR 본문에 명시되어 있지 않다. 다만 본 PR은 #1496 리뷰 피드백을 반영한 `devel` 기준 재제출이고,
+  PR 본문에 재현 HWPX와 Canvas2D 비교 근거가 포함되어 있다. 변경 범위가 작고 Web Canvas replay order 결함에 직접
+  대응하므로, 연결 이슈 부재는 merge blocker로 보지 않는다. 자동 close 대상 issue는 없다.
+- 추가 테스트는 source 문자열 검사다. 현재 변경처럼 구조적 계약을 고정하는 용도에는 맞지만, 실제 canvas paint 결과,
+  plane 순서, label 중복 출력을 픽셀 또는 render tree 수준에서 검증하지는 않는다.
+- `show_control_codes` group label은 active layer metadata에 의존해 replay plane을 판단한다. 현재
+  `render_layer_node`의 inherited `active_layer` 흐름과 맞지만, 향후 layer metadata가 없는 label 유형이 추가되면
+  같은 관점의 재검토가 필요하다.
+- 수정은 Web Canvas `LayerFilter::All` 경로를 건드린다. Skia 렌더러와 개별 `LayerFilter` 경로는 의도상 기존
+  동작을 유지한다.
+
+## 최종 권고
+
+조건부 merge 후보로 본다.
+
+최종 merge 조건:
+
+- PR head 최신 커밋 기준 GitHub Actions 통과
+- 이 review 문서와 `pr_1497_review_impl.md`가 PR diff에 포함됨
+- GitHub review 또는 PR comment로 검토 결과를 contributor에게 남김
+- merge 전 최신 `mergeable` / `mergeStateStatus` 재확인
+- 작업지시자 승인

--- a/mydocs/pr/archives/pr_1497_review_impl.md
+++ b/mydocs/pr/archives/pr_1497_review_impl.md
@@ -1,0 +1,80 @@
+# PR #1497 처리 계획
+
+## 커밋 목록
+
+문서 작성 시점 PR 원 커밋:
+
+- `355c5e98` `fix: replay web canvas planes in paint order`
+
+collaborator-mediated 처리 커밋:
+
+- 최신 `upstream/devel` merge commit: PR #1495까지 반영하여 `BEHIND` 상태 해소
+- review 문서 커밋:
+  - `mydocs/pr/archives/pr_1497_review.md`
+  - `mydocs/pr/archives/pr_1497_review_impl.md`
+
+## Stage 구성
+
+### Stage A: PR head 최신화
+
+1. `upstream/devel`을 최신화한다.
+2. PR #1497 head를 별도 worktree에서 checkout한다.
+3. 원 contributor 커밋을 rewrite하지 않고 `upstream/devel`을 merge commit으로 반영한다.
+4. merge 충돌 여부를 확인한다.
+
+### Stage B: review 문서 포함
+
+1. `mydocs/pr/archives/pr_1497_review.md` 작성
+2. `mydocs/pr/archives/pr_1497_review_impl.md` 작성
+3. `git diff --check`
+4. 문서 커밋 작성
+5. contributor fork의 `codex/web-canvas-replay-order-devel` 브랜치로 push
+
+### Stage C: 최신 GitHub Actions 재확인
+
+push 후 PR head가 바뀌므로 다음 상태를 최신 head 기준으로 다시 확인한다.
+
+- PR 상태: open, draft 아님
+- merge 상태: merge 가능한 상태
+- Build & Test: pass
+- Canvas visual diff: pass
+- CodeQL: pass
+- Analyze (javascript-typescript): pass
+- Analyze (python): pass
+- Analyze (rust): pass
+- WASM Build: skipped 또는 pass
+
+### Stage D: review 및 merge
+
+최신 GitHub Actions 통과와 작업지시자 승인 확인 후 merge한다.
+
+우선 일반 merge를 사용한다.
+
+```bash
+gh pr merge 1497 --repo edwardkim/rhwp --merge
+```
+
+branch protection 또는 권한 문제로 일반 merge가 막히는 경우에만 작업지시자에게 확인 후 admin merge를 검토한다.
+
+merge 후에는 `pr_review_workflow.md` 7장 후속 처리를 따른다.
+
+- PR merge 결과 확인
+- 관련 이슈 없음 기록 유지
+- PR comment 또는 GitHub review에 검증 결과와 처리 사실을 과장 없이 기록
+- 로컬 `devel`을 `upstream/devel`과 동기화
+
+## merge 전 체크리스트
+
+- [ ] review 문서 2건이 PR diff에 포함됨
+- [ ] 최신 PR head SHA 확인
+- [ ] 최신 GitHub Actions 통과 확인
+- [ ] merge 가능한 상태 확인
+- [ ] PR comment 또는 GitHub review로 검토 결과 공유
+- [ ] 작업지시자 승인 확인
+- [ ] 자동 close 대상 issue 없음 확인
+
+## 작업지시자 확인 필요 사항
+
+- 현재 로컬 병합본 검증 결과로는 blocking 문제가 없다.
+- 최종 merge 판단은 PR head 최신 커밋 기준 GitHub Actions 통과 후 수행한다.
+- PR comment는 사실 중심으로 작성한다.

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -30,8 +30,8 @@ use crate::model::style::ImageFillMode;
 use crate::model::style::UnderlineType;
 use crate::paint::replay_order::layer_node_has_replay_plane;
 use crate::paint::{
-    paint_op_replay_plane_with_layer, ClipKind, GroupKind, LayerNode, LayerNodeKind, PageLayerTree,
-    PaintOp, PaintReplayPlane,
+    paint_op_replay_plane_with_layer, render_layer_replay_plane, ClipKind, GroupKind, LayerNode,
+    LayerNodeKind, PageLayerTree, PaintOp, PaintReplayPlane,
 };
 
 const TEXT_MARK_CLIP_RIGHT_PAD: f64 = 48.0;
@@ -50,6 +50,16 @@ fn expand_pua_old_hangul_canvas(text: &str) -> String {
         }
     }
     out
+}
+
+fn group_label_matches_replay_plane(
+    active_replay_plane: Option<PaintReplayPlane>,
+    layer: Option<RenderLayerInfo>,
+) -> bool {
+    match active_replay_plane {
+        Some(active) => render_layer_replay_plane(layer) == active,
+        None => true,
+    }
 }
 use super::composer::{
     decode_pua_overlap_number, expand_pua_render_text, pua_to_display_text, CharOverlapInfo,
@@ -270,6 +280,9 @@ pub struct WebCanvasRenderer {
     /// BehindText plane 을 별도 canvas layer 로 합성할 때 flow Canvas 의 페이지 배경을
     /// 투명하게 둘지 여부.
     transparent_page_background: bool,
+    /// `LayerFilter::All` renders the layer tree in logical replay-plane order,
+    /// independent of raw tree child order.
+    active_replay_plane: Option<PaintReplayPlane>,
 }
 
 #[cfg(target_arch = "wasm32")]
@@ -290,6 +303,7 @@ impl WebCanvasRenderer {
             scale: 1.0,
             layer_filter: LayerFilter::All,
             transparent_page_background: false,
+            active_replay_plane: None,
         })
     }
 
@@ -312,6 +326,9 @@ impl WebCanvasRenderer {
     fn should_render_op(&self, op: &PaintOp, layer: Option<RenderLayerInfo>) -> bool {
         use crate::model::shape::TextWrap;
         let replay_plane = paint_op_replay_plane_with_layer(op, layer);
+        if let Some(active) = self.active_replay_plane {
+            return replay_plane == active;
+        }
         match self.layer_filter {
             LayerFilter::All => true,
             LayerFilter::BackgroundOnly => replay_plane == PaintReplayPlane::Background,
@@ -333,6 +350,10 @@ impl WebCanvasRenderer {
         !self.transparent_page_background
     }
 
+    fn should_render_group_label(&self, layer: Option<RenderLayerInfo>) -> bool {
+        self.show_control_codes && group_label_matches_replay_plane(self.active_replay_plane, layer)
+    }
+
     /// 렌더 트리를 Canvas에 렌더링
     pub fn render_tree(&mut self, tree: &PageRenderTree) {
         self.render_node(&tree.root);
@@ -351,7 +372,19 @@ impl WebCanvasRenderer {
             LayerFilter::WrapOnly(_) => true,
         };
         self.begin_page(tree.page_width, tree.page_height);
-        self.render_layer_node(&tree.root, None);
+        if self.layer_filter == LayerFilter::All {
+            let prev = self.active_replay_plane;
+            for replay_plane in PaintReplayPlane::ORDERED {
+                if !layer_node_has_replay_plane(&tree.root, replay_plane) {
+                    continue;
+                }
+                self.active_replay_plane = Some(replay_plane);
+                self.render_layer_node(&tree.root, None);
+            }
+            self.active_replay_plane = prev;
+        } else {
+            self.render_layer_node(&tree.root, None);
+        }
         self.transparent_page_background = false;
     }
 
@@ -1029,7 +1062,7 @@ impl WebCanvasRenderer {
                 for child in children {
                     self.render_layer_node(child, active_layer);
                 }
-                if self.show_control_codes {
+                if self.should_render_group_label(active_layer) {
                     let label = match group_kind {
                         GroupKind::Table(_) => Some("[표]"),
                         GroupKind::TextBox => Some("[글상자]"),

--- a/tests/render_p22_web_canvas_contract.rs
+++ b/tests/render_p22_web_canvas_contract.rs
@@ -15,3 +15,36 @@ fn web_canvas_layer_leaf_replay_does_not_rebuild_render_nodes() {
         "WebCanvas layer replay must not rebuild temporary RenderNode wrappers"
     );
 }
+
+#[test]
+fn web_canvas_all_filter_replays_logical_planes_in_order() {
+    assert!(
+        WEB_CANVAS_SOURCE.contains("active_replay_plane: Option<PaintReplayPlane>"),
+        "WebCanvas should track the currently replayed plane"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("for replay_plane in PaintReplayPlane::ORDERED"),
+        "LayerFilter::All should replay planes in logical paint order"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("self.active_replay_plane = Some(replay_plane)"),
+        "WebCanvas should filter each tree pass to the active replay plane"
+    );
+}
+
+#[test]
+fn web_canvas_control_code_group_labels_follow_active_replay_plane() {
+    assert!(
+        WEB_CANVAS_SOURCE.contains("fn should_render_group_label("),
+        "WebCanvas should gate group labels separately from PaintOp replay"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE
+            .contains("group_label_matches_replay_plane(self.active_replay_plane, layer)"),
+        "group labels should be filtered against the active replay plane"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("if self.should_render_group_label(active_layer)"),
+        "layer group labels should use the replay-plane gate"
+    );
+}


### PR DESCRIPTION
## What

Fix the Web Canvas renderer so `LayerFilter::All` replays page layer trees in logical paint-plane order instead of raw tree-child order.

The Skia renderer already iterates `PaintReplayPlane::ORDERED`; this makes Web Canvas follow the same ordering and filters each replay pass to the active plane.

This resubmits the previous `main`-based PR against `devel`, as requested in review.

## Why

A behind-text full-page group can appear later in the raw layer tree than the body text. Web Canvas previously traversed that raw order for `LayerFilter::All`, so the behind-text group could cover text that should remain visible.

The issue is visible on page 4 of the linked repro HWPX ([download HWPX](https://raw.githubusercontent.com/humdrum00001010/rhwp/a22724946e642d2560d182710dab193476d775c7/pr-evidence/2025-admin-work-manual.hwpx)): upstream `devel` renders the page body blank/covered, while the patched renderer shows the TOC text.

![Canvas2D render comparison](https://raw.githubusercontent.com/humdrum00001010/rhwp/a22724946e642d2560d182710dab193476d775c7/pr-evidence/comparison-upstream-devel-vs-patched-devel-page-4-scale2.png)

## Reviewer follow-up handled

`show_control_codes` group labels (`[표]`, `[글상자]`, `[머리말]`, etc.) are not `PaintOp`s, so replaying the layer tree once per paint plane could draw the same label in multiple passes. This PR now gates those labels against the active replay plane using their inherited layer metadata, so they render once on the matching pass.

## Scope

This PR intentionally only changes:

- `src/renderer/web_canvas.rs`
- `tests/render_p22_web_canvas_contract.rs`

It does not include any NIF/API/binding-surface changes.

## Validation

- `cargo fmt --check`
- `cargo test --test render_p22_web_canvas_contract` (`3 passed`)
- `cargo check --target wasm32-unknown-unknown --lib`
- `wasm-pack build --target web --out-dir /tmp/rhwp_pr_devel_pkg`
- Browser Canvas2D proof against page 4 at scale 2:
  - upstream `devel` `04b58a4b`: dark pixels `132010`
  - patched devel branch: dark pixels `175451`
  - both builds report `pageCount=438`, canvas `1481x2010`
