### PR TITLE
Task #1498: Fix stale download observer items after #1498

### DIFF
--- a/mydocs/orders/20260624.md
+++ b/mydocs/orders/20260624.md
@@ -5,5 +5,6 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1498 | 확장 0.2.6 과거 다운로드 기록 접근 → 미사용 문서 창 다발 | 완료 | seen 게이트(onCreated 관측 id), SW 테스트 8 pass |
+| #1498 | 확장 0.2.7 과거 다운로드 onCreated 재오픈 후속 | 완료 | startTime 기반 신선도 가드 v2, 완료: 22:22 |
 | #1486 | HWPX sample2 분할 표/TAC 배치와 validation 경고 보정 | PR 대기 | PR #1508 Open, review 문서 PR head 포함, GitHub Actions 완료 대기 |
 | #1499/#1501/#1505/#1506 | PR #1500/#1502/#1507 시리즈 통합 cherry-pick | CI 대기 | PR #1511 생성. `pr1500-series-integration` 로컬 검증 완료, review 문서 `mydocs/pr/archives/pr_1500_review*.md` 포함, 시리즈 외 foundation 후보는 GitHub 코멘트 없이 보류 |

--- a/mydocs/plans/task_m100_1498_v2.md
+++ b/mydocs/plans/task_m100_1498_v2.md
@@ -1,0 +1,74 @@
+# Task M100 #1498 v2 수행계획서 — 확장 0.2.7 onCreated 과거 항목 재오픈 방지
+
+- 이슈: #1498 후속 "[Bug] 확장 다운로드 관찰자 과거 항목 재오픈"
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task1498-v2`
+- 작성일: 2026-06-24
+
+## 1. 배경
+
+확장 0.2.7에는 #1498 핫픽스로 `seen` 집합이 들어갔다. 이 수정은 service worker 재기동 후
+`onChanged` 단독으로 들어오는 과거 다운로드 항목을 막는다. 그러나 사용자가 Chrome 재시작 후
+닫아둔 과거 HWP/HWPX 문서가 다시 열린다고 보고했다.
+
+스토어 0.2.7 CRX를 확인한 결과 `seen` 코드는 배포본에 포함되어 있었다. 따라서 미배포 문제가
+아니라 신선도 판정 자체가 충분하지 않은 문제로 본다.
+
+## 2. 원인
+
+`rhwp-chrome/sw/download-interceptor.js`의 현재 흐름:
+
+1. `onCreated`에서 `seen.add(item.id)` 후 즉시 `processDownloadItem(item)`를 호출한다.
+2. `processDownloadItem`은 `shouldInterceptDownload(item)`이 true이면 바로 `openViewer`를 호출한다.
+3. `shouldInterceptDownload`는 파일명/URL/MIME만 검사하고 `startTime`, `endTime`, `state`를 보지 않는다.
+
+따라서 Chrome이 과거 다운로드 기록 또는 복원된 완료 항목을 `onCreated` 이벤트로 전달하면,
+0.2.7의 `seen` 가드는 오히려 그 항목을 "새 항목"으로 인정한다. 기존 테스트도 `onChanged`
+단독 과거 항목만 검증하고, `onCreated`로 들어온 오래된 완료 항목은 검증하지 않았다.
+
+스토어 배포본 모의 실행에서 `state: "complete"`, 며칠 전 `startTime`을 가진 `.hwp` 항목을
+`onCreated`로 전달하면 뷰어 탭이 생성되는 것을 확인했다.
+
+## 3. 목표
+
+다운로드 관찰자가 service worker 기동 이후 실제로 새로 시작된 다운로드만 처리하도록,
+`onCreated`와 `onChanged` 재조회 양쪽에 시간 기반 신선도 가드를 추가한다.
+
+## 4. 수정 방향
+
+- service worker 로드 시각을 `workerStartedAt = Date.now()`로 기록한다.
+- `DownloadItem.startTime`/`endTime`을 파싱해 `workerStartedAt` 이전의 오래된 다운로드 항목을 무시한다.
+- service worker 기동 직후 정상 다운로드 지연을 고려해 5초 grace window를 둔다.
+- `onChanged`에서 `downloads.search({ id })`로 가져온 항목에도 동일한 신선도 검사를 적용한다.
+- `seen` 가드는 유지한다. 단, `seen`은 "새 다운로드 후보"일 뿐이며 최종 신선도 판정은
+  시간/상태 가드가 담당한다.
+- chrome/firefox 양쪽에 동일한 방어선을 둔다.
+
+## 5. 범위
+
+- 포함:
+  - `rhwp-chrome/sw/download-interceptor.js`
+  - `rhwp-firefox/sw/download-interceptor.js`
+  - `rhwp-chrome/sw/download-interceptor.test.mjs`
+- 제외:
+  - WASM/Rust 렌더링/파서
+  - `shouldInterceptDownload`의 확장자/MIME 판정
+  - viewer URL 로딩 로직
+  - 릴리스 버전 bump 및 스토어 재배포
+
+## 6. 검증 기준
+
+1. 과거 완료 HWP 항목이 `onCreated`로 들어와도 뷰어를 열지 않는다.
+2. service worker 기동 이후 생성된 새 HWP/HWPX 다운로드는 기존처럼 열린다.
+3. `onCreated`에서 판정 불가였고 `onChanged`에서 filename이 확정되는 정상 다운로드도 열린다.
+4. `onChanged` 재조회 결과가 과거 항목이면 열지 않는다.
+5. chrome SW 테스트 통과.
+6. chrome/firefox download-interceptor 구문 체크 통과.
+7. chrome/firefox 확장 빌드 통과.
+
+## 7. 참조
+
+- 기존 수행계획서: `mydocs/plans/task_m100_1498.md`
+- 기존 구현계획서: `mydocs/plans/task_m100_1498_impl.md`
+- 확장 개발 가이드: `mydocs/manual/browser_extension_dev_guide.md`
+- 보안 감사 보고서: `mydocs/report/archives/browser_extension_security_audit.md`

--- a/mydocs/plans/task_m100_1498_v2_impl.md
+++ b/mydocs/plans/task_m100_1498_v2_impl.md
@@ -1,0 +1,82 @@
+# Task M100 #1498 v2 구현계획서 — startTime 기반 다운로드 신선도 가드
+
+- 이슈: #1498 후속
+- 브랜치: `local/task1498-v2`
+- 작성일: 2026-06-24
+- 수행계획서: `mydocs/plans/task_m100_1498_v2.md`
+
+## 구현 개요
+
+0.2.7의 `seen` 집합은 유지하되, `onCreated`와 `onChanged` 재조회 결과 모두에 `DownloadItem`
+신선도 검사를 추가한다. 핵심은 `onCreated`로 들어온 항목도 과거 기록일 수 있다는 전제를 코드에
+반영하는 것이다.
+
+핵심 불변식:
+
+- `onChanged` 단독으로는 열지 않는다.
+- `onCreated`로 들어와도 service worker 기동 이전의 완료/종료 항목은 열지 않는다.
+- service worker 기동 이후 시작된 새 다운로드는 기존처럼 열린다.
+
+## 1단계 — chrome 신선도 함수와 테스트
+
+대상:
+
+- `rhwp-chrome/sw/download-interceptor.js`
+- `rhwp-chrome/sw/download-interceptor.test.mjs`
+
+구현:
+
+1. 모듈 로드 시 `const workerStartedAt = Date.now();` 추가.
+2. `isFreshDownloadItem(item)` 함수 추가.
+   - `item.startTime`이 유효하고 `Date.parse(item.startTime) < workerStartedAt - graceMs`이면 false.
+   - `item.endTime`이 유효하고 `Date.parse(item.endTime) < workerStartedAt - graceMs`이면 false.
+   - `startTime`이 없거나 파싱 불가한 경우는 새 다운로드 호환성을 위해 true로 둔다.
+3. `onCreated`에서 fresh가 아니면 `seen.add`와 `processDownloadItem` 모두 수행하지 않는다.
+4. `onChanged`의 `downloads.search` 결과도 fresh 검사 후 `processDownloadItem` 호출.
+
+테스트 추가:
+
+- `past completed download delivered through onCreated does not open the viewer`
+- `past download returned from onChanged search does not open the viewer`
+- 기존 새 다운로드 케이스에 `startTime: new Date().toISOString()`을 명시하거나, 없는 경우 호환 경로로 통과 확인.
+
+완료 기준:
+
+- `node --test rhwp-chrome/sw/download-interceptor.test.mjs` 통과.
+
+## 2단계 — firefox 동일 적용
+
+대상:
+
+- `rhwp-firefox/sw/download-interceptor.js`
+
+구현:
+
+- chrome과 동형의 `workerStartedAt`, `isFreshDownloadItem` 가드 추가.
+- `onCreated`, `onChanged` 재조회 결과 모두 fresh 검사.
+
+검증:
+
+- `node --check rhwp-firefox/sw/download-interceptor.js`
+
+## 3단계 — 빌드와 보고서
+
+검증:
+
+- `node --check rhwp-chrome/sw/download-interceptor.js`
+- `node --test rhwp-chrome/sw/download-interceptor.test.mjs`
+- `npm run build` in `rhwp-chrome`
+- `npm run build` in `rhwp-firefox`
+
+문서:
+
+- `mydocs/working/task_m100_1498_v2_stage1.md`
+- `mydocs/report/task_m100_1498_v2_report.md`
+- `mydocs/orders/20260624.md` 상태 갱신
+
+## 위험 / 주의
+
+- `startTime`이 없는 브라우저/환경에서 정상 다운로드를 막지 않도록 파싱 실패는 허용한다.
+- 너무 짧은 시간 기준은 service worker 기동 직후 시작된 정상 다운로드를 오탐할 수 있으므로,
+  `workerStartedAt` 기준에 5초 grace window를 둔다.
+- `shouldInterceptDownload`는 문서 판정 전용으로 유지하고, 신선도 판단을 관찰자 레이어에 둔다.

--- a/mydocs/report/task_m100_1498_v2_report.md
+++ b/mydocs/report/task_m100_1498_v2_report.md
@@ -1,0 +1,50 @@
+# Task M100 #1498 v2 최종 보고서 — 확장 0.2.7 과거 다운로드 onCreated 재오픈 방지
+
+- 이슈: #1498 후속
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task1498-v2`
+- 작성일: 2026-06-24
+
+## 1. 결론
+
+0.2.7 배포본에는 #1498의 `seen` 가드가 포함되어 있었지만, `onCreated`로 전달되는 과거 완료
+다운로드 항목을 막지 못했다. `seen`은 `onChanged` 단독 경로만 막았고, `onCreated` 자체를
+"새 다운로드"로 신뢰한 것이 원인이다.
+
+이번 수정으로 `DownloadItem.startTime`이 service worker/event page 기동 시각보다 충분히 오래 전인
+항목은 `onCreated`와 `onChanged` 재조회 양쪽에서 무시한다. 기존 새 다운로드 동작은 유지한다.
+
+## 2. 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `rhwp-chrome/sw/download-interceptor.js` | `workerStartedAt`/`isFreshDownloadItem` 추가, onCreated/onChanged/process 최종 fresh 가드 |
+| `rhwp-firefox/sw/download-interceptor.js` | Chrome과 동일한 startTime 기반 fresh 가드 |
+| `rhwp-chrome/sw/download-interceptor.test.mjs` | onCreated 과거 완료 항목, onChanged 재조회 과거 항목 회귀 테스트 추가 |
+| `mydocs/orders/20260624.md` | #1498 v2 후속 작업 기록 |
+| `mydocs/plans/task_m100_1498_v2*.md` | 수행/구현 계획서 |
+| `mydocs/working/task_m100_1498_v2_stage1.md` | 단계 완료보고서 |
+
+## 3. 검증
+
+| 명령 | 결과 |
+|---|---|
+| `node --test rhwp-chrome/sw/download-interceptor.test.mjs` | 10 passed |
+| `node --check rhwp-chrome/sw/download-interceptor.js` | 통과 |
+| `node --check rhwp-firefox/sw/download-interceptor.js` | 통과 |
+| `npm run build` (`rhwp-chrome`) | 통과 |
+| `npm ci` (`rhwp-firefox`) | 통과, 기존 dependency audit high 1건 |
+| `npm run build` (`rhwp-firefox`) | 통과 |
+
+## 4. 영향
+
+- Chrome/Edge/Firefox 확장에서 service worker 재기동 또는 브라우저 재시작 후 과거 다운로드 완료
+  항목이 `onCreated`로 들어와도 뷰어를 열지 않는다.
+- service worker 기동 직후의 정상 다운로드 지연을 고려해 5초 grace window를 둔다.
+- `startTime`이 없는 브라우저/환경은 기존 호환성을 위해 fresh로 처리한다.
+- `shouldInterceptDownload`와 WASM/viewer 로직은 변경하지 않았다.
+
+## 5. 후속
+
+- 확장 재배포 시 0.2.8 또는 0.2.7 재패키징 여부를 릴리스 단계에서 결정한다.
+- 실제 Chrome에서 닫은 과거 문서가 재시작 후 다시 열리지 않는지 작업지시자 환경에서 최종 확인한다.

--- a/mydocs/working/task_m100_1498_v2_stage1.md
+++ b/mydocs/working/task_m100_1498_v2_stage1.md
@@ -1,0 +1,61 @@
+# Task M100 #1498 v2 1단계 완료보고서 — onCreated 과거 항목 신선도 가드
+
+- 이슈: #1498 후속
+- 브랜치: `local/task1498-v2`
+- 작성일: 2026-06-24
+- 단계: 1/1
+
+## 1. 재현
+
+스토어 0.2.7 배포본은 #1498의 `seen` 가드를 포함하고 있었지만, 다음 조건에서는 여전히
+뷰어 탭을 열었다.
+
+- `chrome.downloads.onCreated`로 들어온 항목
+- `filename`/`url`/`mime`은 HWP로 판정 가능
+- `state: "complete"`, 과거 `startTime`/`endTime`
+
+기존 테스트는 `onChanged` 단독 과거 항목만 검증해서 이 케이스를 잡지 못했다.
+
+## 2. 변경
+
+### `rhwp-chrome/sw/download-interceptor.js`
+
+- `workerStartedAt = Date.now()` 기록.
+- `DOWNLOAD_FRESH_GRACE_MS = 5_000` 도입.
+- `isFreshDownloadItem(item)` 추가:
+  - `startTime`이 없거나 파싱 불가하면 호환성을 위해 fresh로 처리.
+  - `startTime` 또는 `endTime`이 `workerStartedAt - 5초`보다 오래 전이면 과거/복원 항목으로 보고 무시.
+- `onCreated`에서 fresh 항목만 `seen`에 등록하고 처리.
+- `onChanged` 재조회 결과도 fresh 검사 후 처리.
+- `processDownloadItem`에 최종 fresh 가드 추가.
+
+### `rhwp-firefox/sw/download-interceptor.js`
+
+- Chrome과 동일하게 `workerStartedAt`, `DOWNLOAD_FRESH_GRACE_MS`, `isFreshDownloadItem` 적용.
+- `onCreated`, `onChanged` 재조회 경로 모두 fresh 검사.
+
+### `rhwp-chrome/sw/download-interceptor.test.mjs`
+
+신규 테스트 2건 추가:
+
+- 과거 완료 항목이 `onCreated`로 들어와도 뷰어 미오픈.
+- `onChanged` 재조회 결과가 과거 항목이면 `seen`에 있어도 뷰어 미오픈.
+
+## 3. 검증
+
+| 항목 | 결과 |
+|---|---|
+| 기존 코드 + 신규 테스트 | 실패 재현: 신규 2건 fail |
+| `node --test rhwp-chrome/sw/download-interceptor.test.mjs` | 통과: 10 passed |
+| `node --check rhwp-chrome/sw/download-interceptor.js` | 통과 |
+| `node --check rhwp-firefox/sw/download-interceptor.js` | 통과 |
+| `npm run build` (`rhwp-chrome`) | 통과 |
+| `npm ci` (`rhwp-firefox`) | 통과, 기존 dependency audit high 1건 |
+| `npm run build` (`rhwp-firefox`) | 통과 |
+| dist 반영 확인 | chrome/firefox dist `sw/download-interceptor.js`에 fresh 가드 포함 |
+
+## 4. 비고
+
+Firefox 빌드 전 `rhwp-firefox/node_modules/vite`가 없어 최초 빌드가 실패했다. `npm ci` 후
+잠금파일 기준 의존성을 설치하고 빌드를 재실행해 통과했다. `npm audit`의 high 1건은 기존
+의존성 상태이며 이번 수정 범위 밖이다.

--- a/rhwp-chrome/sw/download-interceptor.js
+++ b/rhwp-chrome/sw/download-interceptor.js
@@ -14,6 +14,8 @@ import { openViewer } from './viewer-launcher.js';
 import { shouldInterceptDownload } from './download-interceptor-common.js';
 
 const handled = new Set();
+const workerStartedAt = Date.now();
+const DOWNLOAD_FRESH_GRACE_MS = 5_000;
 // #1498: onCreated 로 관측한 다운로드 id (= service worker 기동 이후 새로 시작된 다운로드).
 // onChanged 는 과거 다운로드 기록에도 발화할 수 있으므로, seen 에 있는 id 에 한해서만 재판정한다.
 // SW 재기동 후 과거 항목이 뷰어로 다발 열리던 회귀를 막는다 (#1471/#1480 회귀 정정).
@@ -32,6 +34,29 @@ function shouldRecheckDownload(delta) {
   return Boolean(delta?.filename?.current || delta?.finalUrl?.current || delta?.state?.current === 'complete');
 }
 
+function parseDownloadTime(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * #1498 v2: onCreated 로 들어온 항목도 과거 다운로드 기록일 수 있다.
+ * startTime/endTime 이 service worker 기동 시각보다 충분히 오래 전이면 재시작/복원된 과거 항목으로 보고 무시한다.
+ */
+function isFreshDownloadItem(item) {
+  if (!item) return false;
+  const startMs = parseDownloadTime(item.startTime);
+  if (startMs === null) return true;
+  const freshBoundary = workerStartedAt - DOWNLOAD_FRESH_GRACE_MS;
+  if (startMs < freshBoundary) return false;
+
+  const endMs = parseDownloadTime(item.endTime);
+  if (endMs !== null && endMs < freshBoundary) return false;
+
+  return true;
+}
+
 /**
  * 다운로드 관찰자를 설정한다.
  *
@@ -41,7 +66,7 @@ function shouldRecheckDownload(delta) {
  */
 export function setupDownloadInterceptor() {
   chrome.downloads.onCreated.addListener((item) => {
-    if (item) seen.add(item.id);
+    if (item && isFreshDownloadItem(item)) seen.add(item.id);
     processDownloadItem(item);
   });
 
@@ -51,7 +76,9 @@ export function setupDownloadInterceptor() {
     if (seen.has(delta.id) && !handled.has(delta.id) && shouldRecheckDownload(delta)) {
       try {
         const [item] = await chrome.downloads.search({ id: delta.id });
-        processDownloadItem(item);
+        if (isFreshDownloadItem(item)) {
+          processDownloadItem(item);
+        }
       } catch (err) {
         console.error('[rhwp] 다운로드 항목 재조회 오류:', err);
       }
@@ -68,6 +95,7 @@ export function setupDownloadInterceptor() {
 
 function processDownloadItem(item) {
   if (!item || handled.has(item.id)) return;
+  if (!isFreshDownloadItem(item)) return;
   if (!shouldInterceptDownload(item)) return;
 
   handled.add(item.id);

--- a/rhwp-chrome/sw/download-interceptor.test.mjs
+++ b/rhwp-chrome/sw/download-interceptor.test.mjs
@@ -250,6 +250,64 @@ test('past download (onChanged only, no onCreated) does not open the viewer', as
   });
 });
 
+// #1498 v2: Chrome 이 과거 완료 항목을 onCreated 로 전달해도 뷰어를 열지 않는다.
+test('past completed download delivered through onCreated does not open the viewer', async () => {
+  const env = createChromeMock();
+
+  await withChromeMock(env, async ({ listeners, calls }) => {
+    listeners.onCreated[0]({
+      id: 902,
+      url: 'https://example.com/old-created.hwp',
+      finalUrl: 'https://example.com/old-created.hwp',
+      filename: 'old-created.hwp',
+      mime: 'application/x-hwp',
+      state: 'complete',
+      startTime: '2000-01-01T00:00:00.000Z',
+      endTime: '2000-01-01T00:00:01.000Z',
+      fileSize: 1024,
+    });
+    await flushAsyncWork();
+
+    assert.deepEqual(calls.tabsCreate, [], '과거 완료 항목 onCreated 는 뷰어를 열지 않아야 함');
+    assert.deepEqual(calls.cancel, []);
+    assert.deepEqual(calls.erase, []);
+  });
+});
+
+// #1498 v2: onChanged 재조회 결과가 과거 항목이면 seen 에 있어도 뷰어를 열지 않는다.
+test('past download returned from onChanged search does not open the viewer', async () => {
+  const env = createChromeMock();
+
+  await withChromeMock(env, async ({ listeners, calls, searchItems }) => {
+    listeners.onCreated[0]({
+      id: 903,
+      url: 'https://example.com/download?id=903',
+      filename: 'download',
+      mime: 'application/octet-stream',
+    });
+    await flushAsyncWork();
+
+    searchItems.set(903, {
+      id: 903,
+      url: 'https://example.com/old-search.hwp',
+      filename: 'old-search.hwp',
+      mime: 'application/x-hwp',
+      state: 'complete',
+      startTime: '2000-01-01T00:00:00.000Z',
+      endTime: '2000-01-01T00:00:01.000Z',
+    });
+    await listeners.onChanged[0]({
+      id: 903,
+      filename: { current: '/Users/melee/Downloads/old-search.hwp' },
+      state: { current: 'complete' },
+    });
+    await flushAsyncWork();
+
+    assert.deepEqual(calls.search, [{ id: 903 }]);
+    assert.deepEqual(calls.tabsCreate, [], '재조회된 과거 항목은 뷰어를 열지 않아야 함');
+  });
+});
+
 // #1498: onCreated 로 관측한 새 다운로드는 onChanged 재판정으로 정상 오픈된다.
 test('new download seen via onCreated is opened on onChanged recheck', async () => {
   const env = createChromeMock();

--- a/rhwp-firefox/sw/download-interceptor.js
+++ b/rhwp-firefox/sw/download-interceptor.js
@@ -11,15 +11,41 @@ import { openViewer } from './viewer-launcher.js';
 import { shouldInterceptDownload } from './download-interceptor-common.js';
 
 const handled = new Set();     // 이미 처리된 downloadId
+const workerStartedAt = Date.now();
+const DOWNLOAD_FRESH_GRACE_MS = 5_000;
 // #1498: onCreated 로 관측한 다운로드 id (= service worker 기동 이후 새로 시작된 다운로드).
 // onChanged 는 과거 다운로드 기록에도 발화할 수 있으므로, seen 에 있는 id 에 한해서만 재판정한다.
 // SW 재기동 후 과거 항목이 뷰어로 다발 열리던 회귀를 막는다 (#1471/#1480 회귀 정정).
 const seen = new Set();
 
+function parseDownloadTime(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+/**
+ * #1498 v2: onCreated 로 들어온 항목도 과거 다운로드 기록일 수 있다.
+ * startTime/endTime 이 event page 기동 시각보다 충분히 오래 전이면 재시작/복원된 과거 항목으로 보고 무시한다.
+ */
+function isFreshDownloadItem(item) {
+  if (!item) return false;
+  const startMs = parseDownloadTime(item.startTime);
+  if (startMs === null) return true;
+  const freshBoundary = workerStartedAt - DOWNLOAD_FRESH_GRACE_MS;
+  if (startMs < freshBoundary) return false;
+
+  const endMs = parseDownloadTime(item.endTime);
+  if (endMs !== null && endMs < freshBoundary) return false;
+
+  return true;
+}
+
 export function setupDownloadInterceptor() {
   // 1차: 다운로드 시작 시 url/mime/referrer 로 즉시 판정
   browser.downloads.onCreated.addListener((item) => {
-    if (item) seen.add(item.id);
+    if (!isFreshDownloadItem(item)) return;
+    seen.add(item.id);
     if (handled.has(item.id)) return;
 
     if (shouldInterceptDownload(item)) {
@@ -36,7 +62,7 @@ export function setupDownloadInterceptor() {
     if (seen.has(delta.id) && !handled.has(delta.id) && delta.filename?.current) {
       try {
         const [item] = await browser.downloads.search({ id: delta.id });
-        if (item && shouldInterceptDownload(item)) {
+        if (isFreshDownloadItem(item) && shouldInterceptDownload(item)) {
           handled.add(delta.id);
           handleHwpDownload(item);
         }


### PR DESCRIPTION
## 요약

- 확장 0.2.7에서 과거 다운로드 완료 항목이 `onCreated`로 전달될 때 뷰어가 다시 열리는 #1498 후속 회귀를 수정했습니다.
- Chrome/Firefox 다운로드 관찰자에 `DownloadItem.startTime`/`endTime` 기반 fresh 가드를 추가했습니다.
- Chrome SW mock 테스트에 `onCreated` 과거 완료 항목 및 `onChanged` 재조회 과거 항목 회귀 케이스를 추가했습니다.

## 원인

#1498의 0.2.7 핫픽스는 `seen` 집합으로 `onChanged` 단독 과거 항목을 막았습니다. 하지만 `onCreated`로 들어온 항목은 무조건 service worker 기동 이후 새 다운로드로 간주했습니다. Chrome이 재시작/복원 과정에서 과거 완료 다운로드 항목을 `onCreated`로 전달하면, `filename`/`url`/`mime` 판정만으로 `openViewer`가 호출될 수 있었습니다.

## 변경

- `rhwp-chrome/sw/download-interceptor.js`
  - `workerStartedAt`과 5초 grace window 도입
  - `isFreshDownloadItem()`으로 `startTime`/`endTime`이 오래된 항목 무시
  - `onCreated`, `onChanged` 재조회, 최종 처리 경로에 fresh 가드 적용
- `rhwp-firefox/sw/download-interceptor.js`
  - Chrome과 동일한 fresh 가드 적용
- `rhwp-chrome/sw/download-interceptor.test.mjs`
  - 과거 완료 항목이 `onCreated`로 들어와도 뷰어 미오픈
  - `onChanged` 재조회 결과가 과거 항목이면 뷰어 미오픈
- 작업 문서
  - #1498 v2 수행/구현 계획서, 단계 보고서, 최종 보고서, 오늘할일 갱신

## 검증

- `node --test rhwp-chrome/sw/download-interceptor.test.mjs` → 10 passed
- `node --check rhwp-chrome/sw/download-interceptor.js`
- `node --check rhwp-firefox/sw/download-interceptor.js`
- `npm run build` (`rhwp-chrome`)
- `npm ci` (`rhwp-firefox`)
- `npm run build` (`rhwp-firefox`)
- 작업지시자 로컬 Chrome unpacked 확장으로 재현 확인

## 비고

- `dist/` 산출물은 PR에 포함하지 않았습니다.
- `npm ci` 중 `rhwp-firefox` dependency audit high 1건이 표시됐지만 기존 의존성 상태이며 이번 수정 범위 밖입니다.
