### PR TITLE
Task #1515: Add shared download observer state machine

### DIFF
--- a/mydocs/orders/20260624.md
+++ b/mydocs/orders/20260624.md
@@ -6,5 +6,6 @@
 |------|--------|------|------|
 | #1498 | 확장 0.2.6 과거 다운로드 기록 접근 → 미사용 문서 창 다발 | 완료 | seen 게이트(onCreated 관측 id), SW 테스트 8 pass |
 | #1498 후속 | Chrome 확장 0.2.7 핫픽스 후에도 과거 다운로드 기록 게이트웨이가 탭을 여는 회귀 | 완료 | PR #1513 merge 완료, merge commit `f54756c4`, startTime/endTime 기반 fresh 가드 v2 |
+| #1515 | 공통 다운로드 상태 머신 도입 및 Chrome 적용 | 완료 | shared 상태 머신 + Chrome storage.session adapter, 완료: 00:03 |
 | #1486 | HWPX sample2 분할 표/TAC 배치와 validation 경고 보정 | PR 대기 | PR #1508 Open, review 문서 PR head 포함, GitHub Actions 완료 대기 |
 | #1499/#1501/#1505/#1506 | PR #1500/#1502/#1507 시리즈 통합 cherry-pick | CI 대기 | PR #1511 생성. `pr1500-series-integration` 로컬 검증 완료, review 문서 `mydocs/pr/archives/pr_1500_review*.md` 포함, 시리즈 외 foundation 후보는 GitHub 코멘트 없이 보류 |

--- a/mydocs/plans/task_m100_1515.md
+++ b/mydocs/plans/task_m100_1515.md
@@ -1,0 +1,120 @@
+# Task M100 #1515 수행계획서 — 공통 다운로드 상태 머신 도입 및 Chrome 적용
+
+- 이슈: #1515 "[Shared/Chrome] 다운로드 관찰자 상태 머신 도입 및 Chrome 적용"
+- 후속 이슈: #1516 "[Firefox] 공통 다운로드 관찰자 상태 머신 적용"
+- 관련: #1471, #1480, #1498, #1513
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `codex/1515-download-state-machine`
+- 작성일: 2026-06-24
+
+## 1. 배경
+
+#1471 / PR #1480에서 Chrome `downloads.onDeterminingFilename` 리스너 등록 자체가 다른
+확장의 `chrome.downloads.download({ filename })` 하위폴더 저장을 무효화하는 문제가 확인되어,
+Chrome 확장은 `onDeterminingFilename`을 제거하고 `downloads.onCreated` /
+`downloads.onChanged` 관찰자 방식으로 전환했다.
+
+이후 #1498 계열에서 Chrome 재시작 또는 확장 service worker 재기동 후 과거 HWP 다운로드
+항목이 다시 관측되어 rhwp 뷰어 탭이 여러 개 자동으로 열리는 문제가 확인되었다. #1513은
+긴급 배포용 완화 패치로, 메모리 `seen`/`handled` Set과 `startTime`/`endTime` 기반 신선도
+가드를 추가해 과거 항목 재오픈을 줄인다.
+
+다만 #1513의 메모리 Set 기반 가드는 최종 구조로 보기 어렵다. `onDeterminingFilename` 시절과
+가까운 사용자 체감 동작을 유지하려면, `onCreated` / `onChanged` 관찰자 방식 위에 명시적인
+다운로드 상태 머신과 세션 저장 기반 중복 방지가 필요하다.
+
+## 2. 문제 정의
+
+`onDeterminingFilename`은 filename 결정 단계에서 새 다운로드에 대해 사실상 한 번 판단했기
+때문에 다음 성질을 자연스럽게 가졌다.
+
+- 과거 다운로드 기록에는 반응하지 않는다.
+- 한 다운로드에 대해 뷰어 열기 경로가 단일하다.
+- filename/MIME/finalUrl이 결정되는 시점에 HWP/HWPX 여부를 판단한다.
+- service worker 메모리 상태에 크게 의존하지 않는다.
+
+반면 현재 `onCreated` / `onChanged` 관찰자 방식은 다음 상태를 직접 모델링해야 한다.
+
+- 이 download id가 새로 관측된 다운로드인지.
+- filename/finalUrl이 아직 미확정이라 나중에 재판정해야 하는지.
+- 이미 뷰어를 연 다운로드인지.
+- service worker가 `onCreated`와 `onChanged` 사이에 재시작되어도 같은 다운로드를 이어서
+  처리할 수 있는지.
+- 과거 완료 항목이 `onCreated` 또는 `onChanged`로 들어와도 무시할 수 있는지.
+
+현재 구현은 이 상태를 메모리 Set과 시간 가드로 관리하므로, service worker 재시작 시 상태가
+사라지고 정상 다운로드 누락 또는 과거 항목 재처리의 경계가 남는다.
+
+## 3. 목표
+
+브라우저 API에 직접 의존하지 않는 다운로드 관찰자 상태 머신을 `rhwp-shared`에 도입하고,
+Chrome/Edge 다운로드 관찰자에 먼저 적용한다.
+
+핵심 불변식:
+
+- `onDeterminingFilename`은 재도입하지 않는다.
+- 과거 완료 다운로드 항목은 뷰어를 열지 않는다.
+- 새 HWP/HWPX 다운로드는 정확히 한 번만 뷰어를 연다.
+- filename이 나중에 `.hwp/.hwpx`로 확정되는 새 다운로드도 놓치지 않는다.
+- service worker 재시작 후에도 추적 중인 새 다운로드 상태를 이어서 처리한다.
+
+## 4. 범위
+
+포함:
+
+- `rhwp-shared/sw/download-observer-state.js` 또는 동등한 공통 상태 머신 모듈
+- 공통 상태 머신 단위 테스트
+- `rhwp-chrome/sw/download-interceptor.js`
+- `rhwp-chrome/sw/download-interceptor.test.mjs`
+- 필요 시 Chrome용 storage/downloads adapter 모듈
+
+제외:
+
+- Firefox 적용: #1516에서 처리
+- Safari 적용: downloads API가 없어 직접 대상 아님
+- `onDeterminingFilename` 재도입
+- WASM/Rust 렌더링/파서
+- 릴리스 버전 bump 및 스토어 재배포
+
+## 5. 설계 방향
+
+상태 머신은 브라우저 API를 직접 호출하지 않는 순수 모듈로 둔다. 입력은 download item, delta,
+현재 시각, 저장된 상태이며, 출력은 `track`, `recheck`, `open`, `ignore`, `cleanup` 같은 결정이다.
+
+Chrome 쪽 adapter는 다음을 담당한다.
+
+- `chrome.downloads.onCreated` / `onChanged` 이벤트 수신
+- 필요 시 `chrome.downloads.search({ id })` 재조회
+- `chrome.storage.session`에 TTL 상태 저장
+- 상태 머신 결정에 따라 `shouldInterceptDownload(item)` 판정과 `openViewer()` 호출
+- `autoOpen=false` 확인
+- `file://` HWP의 `cancel` / `erase` best-effort 억제 유지
+
+## 6. 검증 기준
+
+1. #1471 재현용 비-HWP blob PDF 다운로드에서 다른 확장의 filename/subdirectory가 유지된다.
+2. Chrome 시작 또는 확장 reload 시 과거 완료 HWP 다운로드가 다시 열리지 않는다.
+3. 직접 `.hwp/.hwpx` URL 다운로드는 뷰어 탭을 정확히 1개 연다.
+4. `/download?id=...`처럼 URL 확장자가 없고 filename만 `.hwp`로 확정되는 새 다운로드도 열린다.
+5. 동일 download id에 `onCreated`, filename 변경, finalUrl 변경, complete 이벤트가 모두 와도 탭은 1개만 열린다.
+6. service worker 재시작 시뮬레이션 후 추적 중인 새 다운로드가 누락 없이 처리된다.
+7. `autoOpen=false`이면 다운로드 관찰자 경로로 뷰어가 열리지 않는다.
+8. `file://` HWP suppress 동작이 유지된다.
+9. Chrome 확장 빌드 산출물에 `chrome.downloads.onDeterminingFilename.addListener`가 없다.
+
+## 7. 산출물
+
+- 수행계획서: `mydocs/plans/task_m100_1515.md`
+- 구현계획서: `mydocs/plans/task_m100_1515_impl.md`
+- 단계 보고서: `mydocs/working/task_m100_1515_stage1.md`
+- 최종 보고서: `mydocs/report/task_m100_1515_report.md`
+
+## 8. 참조
+
+- #1515: 공통 다운로드 상태 머신 + Chrome 적용
+- #1516: Firefox follow-up
+- #1513: 긴급 배포용 완화 PR
+- #1471 / PR #1480: `onDeterminingFilename` 제거 배경
+- #1498: 과거 다운로드 재오픈 회귀
+- 확장 개발 가이드: `mydocs/manual/browser_extension_dev_guide.md`
+

--- a/mydocs/plans/task_m100_1515_impl.md
+++ b/mydocs/plans/task_m100_1515_impl.md
@@ -1,0 +1,145 @@
+# Task M100 #1515 구현계획서 — 공통 다운로드 상태 머신과 Chrome adapter
+
+- 이슈: #1515
+- 브랜치: `codex/1515-download-state-machine`
+- 작성일: 2026-06-24
+- 수행계획서: `mydocs/plans/task_m100_1515.md`
+
+## 구현 개요
+
+#1513의 긴급 완화 로직을 단순히 확장하지 않고, 다운로드 관찰자 생명주기를 공통 상태 머신으로
+분리한다. Chrome은 이 상태 머신을 먼저 소비하는 adapter가 된다. Firefox는 #1516에서 같은
+상태 머신을 재사용한다.
+
+핵심 원칙:
+
+- 브라우저 API 의존은 adapter에만 둔다.
+- 상태 전이와 중복 방지 판단은 `rhwp-shared` 순수 모듈에서 테스트한다.
+- `onDeterminingFilename`은 계속 사용하지 않는다.
+- service worker 재시작을 견디도록 임시 상태는 `chrome.storage.session`에 둔다.
+
+## 1단계 — 공통 상태 머신 설계와 단위 테스트
+
+대상:
+
+- `rhwp-shared/sw/download-observer-state.js`
+- `rhwp-shared/sw/download-observer-state.test.js`
+
+구현:
+
+1. 다운로드 상태 구조를 정의한다.
+   - `id`
+   - `firstSeenAt`
+   - `itemStartTime`
+   - `itemEndTime`
+   - `handledAt`
+   - `terminalAt`
+   - `lastReason`
+2. 시간 파싱 유틸을 상태 머신 내부 또는 별도 순수 함수로 둔다.
+3. `onCreated` 항목을 평가하는 함수를 만든다.
+   - 과거 완료 항목이면 `ignore`.
+   - 새 다운로드 후보이면 `track`.
+   - 즉시 HWP 판정이 가능한 경우 adapter가 `open` 판단을 수행할 수 있도록 후보 item을 유지한다.
+4. `onChanged` + 재조회 항목을 평가하는 함수를 만든다.
+   - 저장 상태가 없고 과거 항목으로 보이면 `ignore`.
+   - 저장 상태가 있고 아직 처리 전이면 재판정 후보로 반환한다.
+5. `markHandled`, `markTerminal`, `expireOldStates` 계열 함수를 둔다.
+
+테스트:
+
+- 과거 완료 항목 `onCreated`는 무시.
+- 새 항목 `onCreated`는 추적.
+- 저장 상태가 없는 과거 `onChanged`는 무시.
+- 저장 상태가 있는 새 다운로드는 filename 확정 후 처리 후보.
+- 이미 handled인 download id는 다시 open 후보가 되지 않음.
+- TTL 지난 상태는 정리.
+
+완료 기준:
+
+- `node --test rhwp-shared/sw/download-observer-state.test.js` 통과.
+
+## 2단계 — Chrome storage/downloads adapter 적용
+
+대상:
+
+- `rhwp-chrome/sw/download-interceptor.js`
+- 필요 시 `rhwp-chrome/sw/download-state-storage.js`
+
+구현:
+
+1. 현재 파일의 메모리 `seen`, `handled`, `workerStartedAt`, `isFreshDownloadItem()` 의존을 제거하거나
+   공통 상태 머신 호출로 대체한다.
+2. `chrome.storage.session` 기반 상태 저장 helper를 만든다.
+   - key prefix 예: `rhwpDownloadState:${id}`
+   - 저장/조회/삭제/TTL 정리 함수 제공
+   - `storage.session` 부재 시 테스트 가능한 메모리 fallback은 adapter 내부에 제한적으로 둔다.
+3. `onCreated` 흐름:
+   - 상태 머신으로 새 항목 여부 평가
+   - 추적 상태 저장
+   - `shouldInterceptDownload(item)` true이고 `autoOpen` true이면 한 번만 open
+4. `onChanged` 흐름:
+   - 상태 조회
+   - 필요한 경우 `downloads.search({ id })`
+   - 상태 머신 재판정
+   - `shouldInterceptDownload(item)` true이고 아직 handled가 아니면 open
+5. terminal delta에서 `markTerminal` 후 TTL 정리 예약.
+6. `file://` HWP의 `cancel` / `erase` 유지.
+
+완료 기준:
+
+- Chrome 다운로드 감시기 mock 테스트 통과.
+- `node --check rhwp-chrome/sw/download-interceptor.js` 통과.
+
+## 3단계 — Chrome 회귀 테스트 강화
+
+대상:
+
+- `rhwp-chrome/sw/download-interceptor.test.mjs`
+
+추가/수정 테스트:
+
+- 기존 10개 케이스 유지.
+- `onCreated` 후 모듈 재로드, 이후 `onChanged` filename 확정 시 새 HWP가 정확히 1회 열림.
+- 동일 download id에 `onCreated`, filename 변경, finalUrl 변경, complete 이벤트가 모두 와도 탭 1개.
+- `storage.session`에 handled 상태가 있으면 worker 재시작 후 중복 open 없음.
+- `state: complete`와 과거 `endTime`이 있는 `onCreated` 항목은 무시.
+- `startTime`이 없는 `onChanged` 단독 항목은 저장 상태 없으면 보수적으로 무시.
+- 비-HWP blob PDF는 탭/cancel/erase/search 부작용 없음.
+
+완료 기준:
+
+- `node --test rhwp-chrome/sw/download-interceptor.test.mjs` 통과.
+- #1471 `onDeterminingFilename` 미등록 검증 유지.
+
+## 4단계 — 빌드와 수동 검증 준비
+
+검증:
+
+- `node --test rhwp-shared/sw/download-observer-state.test.js`
+- `node --test rhwp-chrome/sw/download-interceptor.test.mjs`
+- `node --check rhwp-chrome/sw/download-interceptor.js`
+- `npm run build` in `rhwp-chrome`
+
+수동 검증:
+
+- #1471 blob PDF 재현 확장으로 filename/subdirectory 유지 확인.
+- 기존 HWP 다운로드 기록이 있는 상태에서 Chrome 재시작/확장 reload 후 자동 재오픈 없음.
+- direct `.hwp/.hwpx` 다운로드 1회당 탭 1개.
+- extensionless `/download?id=...`가 filename 확정 후 탭 1개.
+- `autoOpen=false`에서 자동 open 없음.
+
+문서:
+
+- `mydocs/working/task_m100_1515_stage1.md`
+- `mydocs/report/task_m100_1515_report.md`
+- `mydocs/orders/20260624.md` 상태 갱신
+
+## 위험 / 주의
+
+- `storage.session`은 적절한 임시 상태 저장소지만, 브라우저별 지원 차이는 adapter에서 감춘다.
+- `startTime`이 없는 항목을 무조건 새 다운로드로 보면 과거 항목 재오픈이 재발할 수 있으므로,
+  저장 상태 없는 `onChanged` 단독 경로는 보수적으로 처리한다.
+- #1513은 긴급 배포용이므로, #1515 브랜치는 #1513 위에 쌓인 상태다. #1513 병합 후 base를
+  `devel`로 rebase하는 것을 전제로 한다.
+- Firefox는 #1516에서 별도 적용한다. #1515에서 Firefox 파일을 직접 수정하지 않는다.
+

--- a/mydocs/report/task_m100_1515_report.md
+++ b/mydocs/report/task_m100_1515_report.md
@@ -1,0 +1,67 @@
+# Task M100 #1515 최종 보고서 — 공통 다운로드 상태 머신 도입 및 Chrome 적용
+
+- 이슈: #1515
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task1515-download-state-machine`
+- 작성일: 2026-06-24
+
+## 1. 결론
+
+#1513의 메모리 `seen` / `handled` 기반 긴급 완화 로직을 공통 다운로드 상태 머신과
+`chrome.storage.session` 기반 adapter로 대체했다. 이제 Chrome/Edge 다운로드 관찰자는
+service worker 재시작 후에도 저장된 download id 상태를 이어서 사용하고, 과거 다운로드 기록은
+공통 상태 머신에서 보수적으로 무시한다.
+
+`onDeterminingFilename`은 재도입하지 않았다. 따라서 #1471의 다른 확장 filename/subdirectory 훼손
+회귀를 피하면서, #1498 계열의 과거 항목 재오픈과 동일 download id 중복 open을 더 강하게 막는다.
+
+## 2. 변경 파일
+
+| 파일 | 변경 |
+|---|---|
+| `rhwp-shared/sw/download-observer-state.js` | 브라우저 API 비의존 다운로드 상태 머신 추가 |
+| `rhwp-shared/sw/download-observer-state.test.js` | 상태 머신 단위 테스트 14건 추가 |
+| `rhwp-chrome/sw/download-observer-state.js` | shared 상태 머신 심볼릭 링크 |
+| `rhwp-chrome/sw/download-interceptor.js` | `storage.session` 기반 Chrome adapter로 전환 |
+| `rhwp-chrome/sw/download-interceptor.test.mjs` | storage mock, worker 재시작, 중복 이벤트 회귀 테스트 추가 |
+| `mydocs/orders/20260624.md` | #1515 작업 기록 |
+| `mydocs/plans/task_m100_1515*.md` | 수행/구현 계획서 |
+| `mydocs/working/task_m100_1515_stage1.md` | 단계 완료보고서 |
+
+## 3. 검증
+
+| 명령 | 결과 |
+|---|---|
+| `node --test rhwp-shared/sw/download-observer-state.test.js` | 14 passed |
+| `node --test rhwp-shared/sw/download-interceptor-common.test.js` | 26 passed |
+| `node --test rhwp-chrome/sw/download-interceptor.test.mjs` | 13 passed |
+| `node --check rhwp-shared/sw/download-observer-state.js` | 통과 |
+| `node --check rhwp-chrome/sw/download-interceptor.js` | 통과 |
+| `npm run build` (`rhwp-chrome`) | 통과 |
+| `rg "onDeterminingFilename\\.addListener|chrome\\.downloads\\.onDeterminingFilename" rhwp-chrome/dist rhwp-chrome/sw` | 결과 없음 |
+
+## 4. 수동 검증
+
+작업지시자 환경에서 unpacked Chrome 확장으로 다음 케이스가 통과했다.
+
+| 케이스 | 결과 |
+|---|---|
+| Kangnam `download.do?...` 링크 | URL 확장자 없는 다운로드 핸들러가 filename 확정 후 정상 처리 |
+| GitHub raw `.hwp` 링크 | 직접 `.hwp` URL 정상 처리 |
+| Chrome 재시작/확장 reload | 과거 HWP 탭 자동 재오픈 없음 |
+| `autoOpen=false` | 다운로드 관찰자 경로 자동 열림 없음 |
+| 같은 링크 반복 클릭 | 클릭 1회당 탭 1개 |
+
+## 5. 영향
+
+- Chrome/Edge 확장에서 새 HWP/HWPX 다운로드는 `onCreated` 또는 filename 확정 `onChanged` 경로로 정확히 1회 열린다.
+- service worker 재시작 후에도 `chrome.storage.session`에 남은 추적 상태로 filename 확정 이벤트를 이어서 처리한다.
+- 과거 완료 항목, storage 상태 없는 `onChanged` 단독 항목, 이미 handled인 download id는 뷰어를 열지 않는다.
+- 비-HWP blob PDF 다운로드는 `onDeterminingFilename` 없이 관찰자 경로만 타므로 filename 결정 단계에 개입하지 않는다.
+- `autoOpen=false`, `file://` HWP suppress, 대용량 경고 동작은 유지된다.
+
+## 6. 후속
+
+- Firefox 적용은 #1516에서 진행한다.
+- #1471 blob PDF 재현 확장은 PR 리뷰/릴리스 전 필요 시 추가 확인한다.
+- PR 생성 전 #1513 긴급 패치 배포 상태와 base branch를 다시 확인한다.

--- a/mydocs/working/task_m100_1515_stage1.md
+++ b/mydocs/working/task_m100_1515_stage1.md
@@ -1,0 +1,67 @@
+# Task M100 #1515 1단계 완료보고서 — 공통 다운로드 상태 머신과 Chrome adapter
+
+- 이슈: #1515
+- 브랜치: `local/task1515-download-state-machine`
+- 작성일: 2026-06-24
+- 단계: 1/1
+
+## 1. 변경
+
+### `rhwp-shared/sw/download-observer-state.js`
+
+- 브라우저 API에 의존하지 않는 다운로드 관찰자 상태 머신을 추가했다.
+- `evaluateDownloadCreated()`:
+  - 과거 완료 항목 무시.
+  - fresh 항목 추적 상태 생성.
+  - 만료된 handled 상태는 새 다운로드를 영구 차단하지 않도록 TTL 처리.
+- `evaluateDownloadChanged()`:
+  - 저장 상태 없는 `onChanged` 단독 항목 무시.
+  - 추적 상태가 있는 항목만 filename/finalUrl 확정 후 후보로 반환.
+  - 과거 항목으로 재조회되면 무시.
+- `markDownloadHandled()`, `markDownloadTerminal()`, `isDownloadStateExpired()` 추가.
+
+### `rhwp-chrome/sw/download-interceptor.js`
+
+- 메모리 `seen` / `handled` / `workerStartedAt` 기반 로직을 제거했다.
+- `chrome.storage.session` 기반 TTL 상태 저장 helper를 추가했다.
+- `storage.session`이 없는 테스트/호환 환경에는 adapter 내부 메모리 fallback을 둔다.
+- `onCreated`는 공통 상태 머신으로 track 여부를 판단한 뒤 상태를 저장한다.
+- `onChanged`는 저장 상태가 있는 download id만 `downloads.search({ id })`로 재조회한다.
+- `autoOpen=false`, `file://` HWP cancel/erase, 대용량 경고, `openViewer()` 동작은 유지했다.
+- terminal delta는 상태에 `terminalAt`을 기록한 뒤 30초 후 정리한다.
+
+### `rhwp-chrome/sw/download-interceptor.test.mjs`
+
+- `chrome.storage.session` mock을 추가했다.
+- service worker 재시작을 모사해 `onCreated` 후 모듈 재로드, 이후 `onChanged` filename 확정 시 새 HWP가 1회 열리는지 검증했다.
+- storage에 handled 상태가 남아 있으면 재시작 후에도 중복 open이 막히는지 검증했다.
+- 동일 download id에 filename/finalUrl/complete 이벤트가 여러 번 와도 탭은 1개만 열리는지 검증했다.
+
+## 2. 검증
+
+| 명령 | 결과 |
+|---|---|
+| `node --test rhwp-shared/sw/download-observer-state.test.js` | 통과: 14 passed |
+| `node --test rhwp-shared/sw/download-interceptor-common.test.js` | 통과: 26 passed |
+| `node --test rhwp-chrome/sw/download-interceptor.test.mjs` | 통과: 13 passed |
+| `node --check rhwp-shared/sw/download-observer-state.js` | 통과 |
+| `node --check rhwp-chrome/sw/download-interceptor.js` | 통과 |
+| `npm run build` (`rhwp-chrome`) | 통과 |
+| dist `sw/download-observer-state.js` 포함 확인 | 통과 |
+| dist/source `onDeterminingFilename.addListener` 잔여 검색 | 결과 없음 |
+
+## 3. 비고
+
+- Firefox 파일은 수정하지 않았다. Firefox 적용은 #1516에서 같은 shared 상태 머신을 재사용해 진행한다.
+- Safari는 downloads API가 없어 이번 상태 머신 직접 적용 대상이 아니다.
+- #1513 긴급 완화 패치 위에서 구조 개선을 수행했으며, #1513 merge 후 최신 `upstream/devel` 기준 브랜치로 재생성했다.
+
+## 4. 수동 검증
+
+작업지시자 환경의 unpacked Chrome 확장에서 다음 케이스를 확인했다.
+
+- Kangnam `download.do?...` 링크: URL 확장자가 없는 다운로드 핸들러가 filename 확정 후 정상 처리됨.
+- GitHub raw `.hwp` 링크: 직접 `.hwp` URL이 정상 처리됨.
+- Chrome 재시작/확장 reload 후 과거 HWP 탭 자동 재오픈 없음.
+- `autoOpen=false`에서 다운로드 관찰자 경로 자동 열림 없음.
+- 같은 링크 반복 클릭 시 클릭 1회당 탭 1개.

--- a/rhwp-chrome/sw/download-interceptor.js
+++ b/rhwp-chrome/sw/download-interceptor.js
@@ -12,49 +12,24 @@
 
 import { openViewer } from './viewer-launcher.js';
 import { shouldInterceptDownload } from './download-interceptor-common.js';
+import {
+  DEFAULT_STATE_TTL_MS,
+  evaluateDownloadChanged,
+  evaluateDownloadCreated,
+  isDownloadStateExpired,
+  isTerminalDelta,
+  markDownloadHandled,
+  markDownloadTerminal,
+  shouldRecheckDownload,
+} from './download-observer-state.js';
 
-const handled = new Set();
-const workerStartedAt = Date.now();
-const DOWNLOAD_FRESH_GRACE_MS = 5_000;
-// #1498: onCreated 로 관측한 다운로드 id (= service worker 기동 이후 새로 시작된 다운로드).
-// onChanged 는 과거 다운로드 기록에도 발화할 수 있으므로, seen 에 있는 id 에 한해서만 재판정한다.
-// SW 재기동 후 과거 항목이 뷰어로 다발 열리던 회귀를 막는다 (#1471/#1480 회귀 정정).
-const seen = new Set();
+const STORAGE_PREFIX = 'rhwpDownloadState:';
+const TERMINAL_CLEANUP_MS = 30_000;
+const memoryStateFallback = new Map();
 
 /** 다운로드 항목이 로컬 file:// 인지 판별. */
 function isLocalFileDownload(item) {
   return typeof item?.url === 'string' && item.url.startsWith('file:');
-}
-
-function isTerminalDelta(delta) {
-  return delta?.state?.current === 'complete' || delta?.state?.current === 'interrupted' || Boolean(delta?.error);
-}
-
-function shouldRecheckDownload(delta) {
-  return Boolean(delta?.filename?.current || delta?.finalUrl?.current || delta?.state?.current === 'complete');
-}
-
-function parseDownloadTime(value) {
-  if (typeof value !== 'string' || value.length === 0) return null;
-  const ms = Date.parse(value);
-  return Number.isFinite(ms) ? ms : null;
-}
-
-/**
- * #1498 v2: onCreated 로 들어온 항목도 과거 다운로드 기록일 수 있다.
- * startTime/endTime 이 service worker 기동 시각보다 충분히 오래 전이면 재시작/복원된 과거 항목으로 보고 무시한다.
- */
-function isFreshDownloadItem(item) {
-  if (!item) return false;
-  const startMs = parseDownloadTime(item.startTime);
-  if (startMs === null) return true;
-  const freshBoundary = workerStartedAt - DOWNLOAD_FRESH_GRACE_MS;
-  if (startMs < freshBoundary) return false;
-
-  const endMs = parseDownloadTime(item.endTime);
-  if (endMs !== null && endMs < freshBoundary) return false;
-
-  return true;
 }
 
 /**
@@ -66,43 +41,67 @@ function isFreshDownloadItem(item) {
  */
 export function setupDownloadInterceptor() {
   chrome.downloads.onCreated.addListener((item) => {
-    if (item && isFreshDownloadItem(item)) seen.add(item.id);
-    processDownloadItem(item);
+    void handleCreated(item);
   });
 
   chrome.downloads.onChanged.addListener(async (delta) => {
-    // #1498: onCreated 로 관측한(= 새로 시작된) 다운로드만 재판정한다. onChanged 단독으로
-    // 들어온 과거 기록 항목은 seen 에 없으므로 뷰어를 열지 않는다.
-    if (seen.has(delta.id) && !handled.has(delta.id) && shouldRecheckDownload(delta)) {
-      try {
-        const [item] = await chrome.downloads.search({ id: delta.id });
-        if (isFreshDownloadItem(item)) {
-          processDownloadItem(item);
-        }
-      } catch (err) {
-        console.error('[rhwp] 다운로드 항목 재조회 오류:', err);
-      }
-    }
-
-    if (isTerminalDelta(delta)) {
-      setTimeout(() => {
-        handled.delete(delta.id);
-        seen.delete(delta.id);
-      }, 30000);
-    }
+    await handleChanged(delta);
   });
 }
 
-function processDownloadItem(item) {
-  if (!item || handled.has(item.id)) return;
-  if (!isFreshDownloadItem(item)) return;
+async function handleCreated(item) {
+  const now = Date.now();
+  const previousState = await getDownloadState(item?.id, now);
+  const decision = evaluateDownloadCreated(item, previousState, now);
+
+  if (decision.action !== 'track') return;
+  await setDownloadState(decision.state);
+  await processDownloadCandidate(item, decision.state);
+}
+
+async function handleChanged(delta) {
+  const now = Date.now();
+  const state = await getDownloadState(delta?.id, now);
+
+  if (state && !state.handledAt && shouldRecheckDownload(delta)) {
+    try {
+      const [item] = await chrome.downloads.search({ id: delta.id });
+      const decision = evaluateDownloadChanged(delta, item, state, now);
+      if (decision.action === 'candidate') {
+        await setDownloadState(decision.state);
+        await processDownloadCandidate(item, decision.state);
+      }
+    } catch (err) {
+      console.error('[rhwp] 다운로드 항목 재조회 오류:', err);
+    }
+  }
+
+  if (isTerminalDelta(delta)) {
+    const terminalState = markDownloadTerminal(state, now);
+    if (terminalState) {
+      await setDownloadState(terminalState);
+    }
+    scheduleRemoveDownloadState(delta.id);
+  }
+}
+
+async function processDownloadCandidate(item, state) {
+  if (!item || state?.handledAt) return;
   if (!shouldInterceptDownload(item)) return;
 
-  handled.add(item.id);
-  handleHwpDownload(item);
+  try {
+    const settings = await chrome.storage.sync.get({ autoOpen: true });
+    const reason = settings.autoOpen ? 'opened' : 'auto-open-disabled';
+    await setDownloadState(markDownloadHandled(state, Date.now(), reason));
+    if (!settings.autoOpen) return;
 
-  if (isLocalFileDownload(item)) {
-    suppressLocalDownload(item);
+    handleHwpDownload(item);
+
+    if (isLocalFileDownload(item)) {
+      void suppressLocalDownload(item);
+    }
+  } catch (err) {
+    console.error('[rhwp] 다운로드 인터셉터 오류:', err);
   }
 }
 
@@ -125,21 +124,83 @@ async function suppressLocalDownload(item) {
   }
 }
 
-async function handleHwpDownload(item) {
-  try {
-    const settings = await chrome.storage.sync.get({ autoOpen: true });
-    if (!settings.autoOpen) return;
-
-    // 대용량 파일 경고 (50MB 초과)
-    if (item.fileSize > 50 * 1024 * 1024) {
-      console.warn(`[rhwp] 대용량 파일: ${item.filename} (${(item.fileSize / 1024 / 1024).toFixed(1)}MB)`);
-    }
-
-    openViewer({
-      url: item.url,
-      filename: item.filename,
-    });
-  } catch (err) {
-    console.error('[rhwp] 다운로드 인터셉터 오류:', err);
+function handleHwpDownload(item) {
+  // 대용량 파일 경고 (50MB 초과)
+  if (item.fileSize > 50 * 1024 * 1024) {
+    console.warn(`[rhwp] 대용량 파일: ${item.filename} (${(item.fileSize / 1024 / 1024).toFixed(1)}MB)`);
   }
+
+  openViewer({
+    url: item.url,
+    filename: item.filename,
+  });
+}
+
+function stateKey(id) {
+  return `${STORAGE_PREFIX}${id}`;
+}
+
+function getSessionStorage() {
+  return chrome.storage?.session || null;
+}
+
+async function getDownloadState(id, now = Date.now()) {
+  if (typeof id !== 'number') return null;
+
+  const key = stateKey(id);
+  const session = getSessionStorage();
+  let state = null;
+
+  if (session) {
+    const result = await session.get(key);
+    state = result?.[key] || null;
+  } else {
+    state = memoryStateFallback.get(id) || null;
+  }
+
+  if (state && isDownloadStateExpired(state, now, DEFAULT_STATE_TTL_MS)) {
+    await removeDownloadState(id);
+    return null;
+  }
+
+  return state;
+}
+
+async function setDownloadState(state) {
+  if (!state || typeof state.id !== 'number') return;
+
+  const session = getSessionStorage();
+  if (session) {
+    await session.set({ [stateKey(state.id)]: state });
+    return;
+  }
+
+  memoryStateFallback.set(state.id, state);
+}
+
+async function removeDownloadState(id) {
+  if (typeof id !== 'number') return;
+
+  const session = getSessionStorage();
+  if (session) {
+    await session.remove(stateKey(id));
+    return;
+  }
+
+  memoryStateFallback.delete(id);
+}
+
+function scheduleRemoveDownloadState(id) {
+  if (typeof id !== 'number') return;
+
+  const session = getSessionStorage();
+  const key = stateKey(id);
+  const timer = setTimeout(() => {
+    if (session) {
+      void session.remove(key);
+      return;
+    }
+    memoryStateFallback.delete(id);
+  }, TERMINAL_CLEANUP_MS);
+  if (typeof timer?.unref === 'function') timer.unref();
 }

--- a/rhwp-chrome/sw/download-interceptor.test.mjs
+++ b/rhwp-chrome/sw/download-interceptor.test.mjs
@@ -13,9 +13,32 @@ function createChromeMock(options = {}) {
     cancel: [],
     erase: [],
     search: [],
+    sessionGet: [],
+    sessionRemove: [],
+    sessionSet: [],
     tabsCreate: [],
   };
   const searchItems = new Map();
+  const sessionItems = new Map(Object.entries(options.session || {}));
+
+  function getSessionValues(query) {
+    if (query == null) return Object.fromEntries(sessionItems);
+    if (typeof query === 'string') {
+      return { [query]: sessionItems.get(query) };
+    }
+    if (Array.isArray(query)) {
+      return Object.fromEntries(query.map((key) => [key, sessionItems.get(key)]));
+    }
+    if (typeof query === 'object') {
+      return Object.fromEntries(
+        Object.entries(query).map(([key, fallback]) => [
+          key,
+          sessionItems.has(key) ? sessionItems.get(key) : fallback,
+        ]),
+      );
+    }
+    return {};
+  }
 
   const chrome = {
     downloads: {
@@ -52,6 +75,25 @@ function createChromeMock(options = {}) {
       },
     },
     storage: {
+      session: {
+        async get(query) {
+          calls.sessionGet.push(query);
+          return getSessionValues(query);
+        },
+        async set(items) {
+          calls.sessionSet.push(items);
+          for (const [key, value] of Object.entries(items)) {
+            sessionItems.set(key, value);
+          }
+        },
+        async remove(query) {
+          calls.sessionRemove.push(query);
+          const keys = Array.isArray(query) ? query : [query];
+          for (const key of keys) {
+            sessionItems.delete(key);
+          }
+        },
+      },
       sync: {
         async get(defaults) {
           return { ...defaults, ...(options.settings || {}) };
@@ -66,7 +108,7 @@ function createChromeMock(options = {}) {
     },
   };
 
-  return { chrome, listeners, calls, searchItems };
+  return { chrome, listeners, calls, searchItems, sessionItems };
 }
 
 async function importFreshInterceptor() {
@@ -93,6 +135,12 @@ async function withChromeMock(env, run) {
 async function flushAsyncWork() {
   await Promise.resolve();
   await new Promise((resolve) => setImmediate(resolve));
+  await Promise.resolve();
+  await new Promise((resolve) => setImmediate(resolve));
+}
+
+function lastListener(list) {
+  return list[list.length - 1];
 }
 
 test('Chrome interceptor registers observers, not onDeterminingFilename', async () => {
@@ -335,5 +383,118 @@ test('new download seen via onCreated is opened on onChanged recheck', async () 
 
     assert.deepEqual(calls.search, [{ id: 901 }]);
     assert.equal(calls.tabsCreate.length, 1, '새 다운로드는 정상 오픈되어야 함');
+  });
+});
+
+test('download tracked before service worker restart opens on onChanged recheck', async () => {
+  const env = createChromeMock();
+
+  await withChromeMock(env, async ({ listeners, calls }) => {
+    listeners.onCreated[0]({
+      id: 904,
+      url: 'https://example.com/download?id=904',
+      filename: 'download',
+      mime: 'application/octet-stream',
+      startTime: new Date().toISOString(),
+    });
+    await flushAsyncWork();
+
+    assert.equal(calls.tabsCreate.length, 0);
+    assert.equal(calls.sessionSet.length, 1);
+  });
+
+  await withChromeMock(env, async ({ listeners, calls, searchItems }) => {
+    searchItems.set(904, {
+      id: 904,
+      url: 'https://example.com/download?id=904',
+      filename: 'restart-fresh.hwp',
+      mime: 'application/octet-stream',
+      startTime: new Date().toISOString(),
+    });
+    await lastListener(listeners.onChanged)({
+      id: 904,
+      filename: { current: '/Users/melee/Downloads/restart-fresh.hwp' },
+    });
+    await flushAsyncWork();
+
+    assert.equal(calls.tabsCreate.length, 1, '재시작 후 filename 확정 항목은 1회 열려야 함');
+    assert.match(calls.tabsCreate[0].url, /filename=restart-fresh\.hwp/);
+  });
+});
+
+test('handled state in storage prevents duplicate open after restart', async () => {
+  const env = createChromeMock();
+
+  await withChromeMock(env, async ({ listeners, calls }) => {
+    listeners.onCreated[0]({
+      id: 905,
+      url: 'https://example.com/already-opened.hwp',
+      filename: 'already-opened.hwp',
+      mime: 'application/x-hwp',
+      startTime: new Date().toISOString(),
+    });
+    await flushAsyncWork();
+
+    assert.equal(calls.tabsCreate.length, 1);
+  });
+
+  await withChromeMock(env, async ({ listeners, calls, searchItems }) => {
+    searchItems.set(905, {
+      id: 905,
+      url: 'https://example.com/already-opened.hwp',
+      filename: 'already-opened.hwp',
+      mime: 'application/x-hwp',
+      startTime: new Date().toISOString(),
+    });
+    await lastListener(listeners.onChanged)({
+      id: 905,
+      filename: { current: '/Users/melee/Downloads/already-opened.hwp' },
+    });
+    await flushAsyncWork();
+
+    assert.equal(calls.tabsCreate.length, 1, 'handled 상태는 재시작 후에도 중복 open을 막아야 함');
+  });
+});
+
+test('same download id with multiple changed events opens once', async () => {
+  const env = createChromeMock();
+
+  await withChromeMock(env, async ({ listeners, calls, searchItems }) => {
+    listeners.onCreated[0]({
+      id: 906,
+      url: 'https://example.com/download?id=906',
+      filename: 'download',
+      mime: 'application/octet-stream',
+      startTime: new Date().toISOString(),
+    });
+    await flushAsyncWork();
+
+    searchItems.set(906, {
+      id: 906,
+      url: 'https://example.com/download?id=906',
+      finalUrl: 'https://cdn.example.com/fresh-multi.hwp',
+      filename: 'fresh-multi.hwp',
+      mime: 'application/octet-stream',
+      startTime: new Date().toISOString(),
+    });
+
+    await listeners.onChanged[0]({
+      id: 906,
+      filename: { current: '/Users/melee/Downloads/fresh-multi.hwp' },
+    });
+    await flushAsyncWork();
+    await listeners.onChanged[0]({
+      id: 906,
+      finalUrl: { current: 'https://cdn.example.com/fresh-multi.hwp' },
+    });
+    await flushAsyncWork();
+    await listeners.onChanged[0]({
+      id: 906,
+      state: { current: 'complete' },
+    });
+    await flushAsyncWork();
+
+    assert.equal(calls.tabsCreate.length, 1);
+    assert.deepEqual(calls.search, [{ id: 906 }]);
   });
 });

--- a/rhwp-chrome/sw/download-observer-state.js
+++ b/rhwp-chrome/sw/download-observer-state.js
@@ -1,0 +1,1 @@
+../../rhwp-shared/sw/download-observer-state.js

--- a/rhwp-shared/sw/download-observer-state.js
+++ b/rhwp-shared/sw/download-observer-state.js
@@ -1,0 +1,135 @@
+// 다운로드 관찰자 상태 머신 (Chrome / Firefox 공용)
+//
+// 브라우저 API 호출 없이 DownloadItem/DownloadDelta와 저장 상태만으로
+// 새 다운로드 추적, 과거 항목 무시, 중복 처리 방지를 판정한다.
+
+export const DEFAULT_FRESH_GRACE_MS = 5_000;
+export const DEFAULT_STATE_TTL_MS = 10 * 60 * 1000;
+
+export function parseDownloadTime(value) {
+  if (typeof value !== 'string' || value.length === 0) return null;
+  const ms = Date.parse(value);
+  return Number.isFinite(ms) ? ms : null;
+}
+
+export function isTerminalDelta(delta) {
+  return delta?.state?.current === 'complete' || delta?.state?.current === 'interrupted' || Boolean(delta?.error);
+}
+
+export function shouldRecheckDownload(delta) {
+  return Boolean(delta?.filename?.current || delta?.finalUrl?.current || delta?.state?.current === 'complete');
+}
+
+export function isDownloadStateExpired(state, now = Date.now(), ttlMs = DEFAULT_STATE_TTL_MS) {
+  if (!state) return false;
+  const latest = Math.max(
+    state.firstSeenAt || 0,
+    state.handledAt || 0,
+    state.terminalAt || 0,
+  );
+  return latest > 0 && latest < now - ttlMs;
+}
+
+function downloadIdOf(itemOrDelta) {
+  return typeof itemOrDelta?.id === 'number' ? itemOrDelta.id : null;
+}
+
+function isPastDownloadItem(item, referenceTime, options = {}) {
+  if (!item) return true;
+
+  const graceMs = options.freshGraceMs ?? DEFAULT_FRESH_GRACE_MS;
+  const boundary = referenceTime - graceMs;
+  const startMs = parseDownloadTime(item.startTime);
+  const endMs = parseDownloadTime(item.endTime);
+
+  if (startMs !== null && startMs < boundary) return true;
+  if (endMs !== null && endMs < boundary) return true;
+
+  // 완료 상태인데 시간 정보가 전혀 없으면 새 다운로드로 증명할 수 없다.
+  if (item.state === 'complete' && startMs === null && endMs === null) return true;
+
+  return false;
+}
+
+function buildState(item, now, previous = null, reason = 'track') {
+  return {
+    ...(previous || {}),
+    id: downloadIdOf(item),
+    firstSeenAt: previous?.firstSeenAt || now,
+    itemStartTime: parseDownloadTime(item?.startTime),
+    itemEndTime: parseDownloadTime(item?.endTime),
+    handledAt: previous?.handledAt || null,
+    terminalAt: previous?.terminalAt || null,
+    lastReason: reason,
+  };
+}
+
+export function evaluateDownloadCreated(item, previousState = null, now = Date.now(), options = {}) {
+  const id = downloadIdOf(item);
+  if (id === null) return { action: 'ignore', reason: 'missing-id', state: previousState };
+
+  if (isDownloadStateExpired(previousState, now, options.stateTtlMs)) {
+    previousState = null;
+  }
+
+  if (previousState?.handledAt) {
+    return { action: 'ignore', reason: 'already-handled', state: previousState };
+  }
+
+  if (isPastDownloadItem(item, now, options)) {
+    return { action: 'ignore', reason: 'past-created', state: previousState };
+  }
+
+  return {
+    action: 'track',
+    reason: 'fresh-created',
+    item,
+    state: buildState(item, now, previousState, 'fresh-created'),
+  };
+}
+
+export function evaluateDownloadChanged(delta, item, previousState = null, now = Date.now(), options = {}) {
+  const id = downloadIdOf(delta);
+  if (id === null) return { action: 'ignore', reason: 'missing-id', state: previousState };
+
+  if (!previousState || isDownloadStateExpired(previousState, now, options.stateTtlMs)) {
+    return { action: 'ignore', reason: 'untracked-changed', state: previousState };
+  }
+
+  if (previousState.handledAt) {
+    return { action: 'ignore', reason: 'already-handled', state: previousState };
+  }
+
+  if (!item) {
+    return { action: 'ignore', reason: 'missing-item', state: previousState };
+  }
+
+  if (isPastDownloadItem(item, previousState.firstSeenAt || now, options)) {
+    return { action: 'ignore', reason: 'past-changed', state: previousState };
+  }
+
+  return {
+    action: 'candidate',
+    reason: 'tracked-changed',
+    item,
+    state: buildState(item, now, previousState, 'tracked-changed'),
+  };
+}
+
+export function markDownloadHandled(state, now = Date.now(), reason = 'handled') {
+  if (!state) return state;
+  return {
+    ...state,
+    handledAt: state.handledAt || now,
+    lastReason: reason,
+  };
+}
+
+export function markDownloadTerminal(state, now = Date.now(), reason = 'terminal') {
+  if (!state) return state;
+  return {
+    ...state,
+    terminalAt: state.terminalAt || now,
+    lastReason: reason,
+  };
+}

--- a/rhwp-shared/sw/download-observer-state.test.js
+++ b/rhwp-shared/sw/download-observer-state.test.js
@@ -1,0 +1,196 @@
+import { test } from 'node:test';
+import { strict as assert } from 'node:assert';
+
+import {
+  DEFAULT_FRESH_GRACE_MS,
+  evaluateDownloadChanged,
+  evaluateDownloadCreated,
+  isDownloadStateExpired,
+  markDownloadHandled,
+  markDownloadTerminal,
+  parseDownloadTime,
+  shouldRecheckDownload,
+} from './download-observer-state.js';
+
+const NOW = Date.parse('2026-06-24T12:00:00.000Z');
+
+test('parseDownloadTime returns milliseconds for valid ISO time', () => {
+  assert.equal(parseDownloadTime('2026-06-24T12:00:00.000Z'), NOW);
+});
+
+test('parseDownloadTime returns null for invalid values', () => {
+  assert.equal(parseDownloadTime(''), null);
+  assert.equal(parseDownloadTime('not-a-date'), null);
+  assert.equal(parseDownloadTime(undefined), null);
+});
+
+test('created past completed item is ignored', () => {
+  const decision = evaluateDownloadCreated({
+    id: 1,
+    url: 'https://example.com/old.hwp',
+    filename: 'old.hwp',
+    state: 'complete',
+    startTime: '2000-01-01T00:00:00.000Z',
+    endTime: '2000-01-01T00:00:01.000Z',
+  }, null, NOW);
+
+  assert.equal(decision.action, 'ignore');
+  assert.equal(decision.reason, 'past-created');
+});
+
+test('created complete item without time is ignored conservatively', () => {
+  const decision = evaluateDownloadCreated({
+    id: 2,
+    url: 'https://example.com/old-no-time.hwp',
+    filename: 'old-no-time.hwp',
+    state: 'complete',
+  }, null, NOW);
+
+  assert.equal(decision.action, 'ignore');
+  assert.equal(decision.reason, 'past-created');
+});
+
+test('fresh created item is tracked', () => {
+  const decision = evaluateDownloadCreated({
+    id: 3,
+    url: 'https://example.com/fresh.hwp',
+    filename: 'fresh.hwp',
+    startTime: new Date(NOW).toISOString(),
+  }, null, NOW);
+
+  assert.equal(decision.action, 'track');
+  assert.equal(decision.state.id, 3);
+  assert.equal(decision.state.firstSeenAt, NOW);
+  assert.equal(decision.state.itemStartTime, NOW);
+});
+
+test('fresh created item within grace window is tracked', () => {
+  const decision = evaluateDownloadCreated({
+    id: 4,
+    url: 'https://example.com/fresh-grace.hwp',
+    filename: 'fresh-grace.hwp',
+    startTime: new Date(NOW - DEFAULT_FRESH_GRACE_MS + 1).toISOString(),
+  }, null, NOW);
+
+  assert.equal(decision.action, 'track');
+});
+
+test('changed event without stored state is ignored', () => {
+  const decision = evaluateDownloadChanged(
+    { id: 5, filename: { current: '/Downloads/new.hwp' } },
+    { id: 5, filename: 'new.hwp', url: 'https://example.com/new.hwp' },
+    null,
+    NOW,
+  );
+
+  assert.equal(decision.action, 'ignore');
+  assert.equal(decision.reason, 'untracked-changed');
+});
+
+test('tracked changed item becomes candidate', () => {
+  const created = evaluateDownloadCreated({
+    id: 6,
+    url: 'https://example.com/download?id=6',
+    filename: 'download',
+    startTime: new Date(NOW).toISOString(),
+  }, null, NOW);
+
+  const changed = evaluateDownloadChanged(
+    { id: 6, filename: { current: '/Downloads/fresh.hwp' } },
+    { id: 6, url: 'https://example.com/download?id=6', filename: 'fresh.hwp' },
+    created.state,
+    NOW + 1000,
+  );
+
+  assert.equal(changed.action, 'candidate');
+  assert.equal(changed.state.firstSeenAt, NOW);
+  assert.equal(changed.state.lastReason, 'tracked-changed');
+});
+
+test('tracked changed item with old startTime is ignored', () => {
+  const created = evaluateDownloadCreated({
+    id: 7,
+    url: 'https://example.com/download?id=7',
+    filename: 'download',
+  }, null, NOW);
+
+  const changed = evaluateDownloadChanged(
+    { id: 7, filename: { current: '/Downloads/old.hwp' } },
+    {
+      id: 7,
+      url: 'https://example.com/old.hwp',
+      filename: 'old.hwp',
+      startTime: '2000-01-01T00:00:00.000Z',
+      endTime: '2000-01-01T00:00:01.000Z',
+    },
+    created.state,
+    NOW + 1000,
+  );
+
+  assert.equal(changed.action, 'ignore');
+  assert.equal(changed.reason, 'past-changed');
+});
+
+test('handled state is not returned as candidate again', () => {
+  const created = evaluateDownloadCreated({
+    id: 8,
+    url: 'https://example.com/fresh.hwp',
+    filename: 'fresh.hwp',
+  }, null, NOW);
+  const handled = markDownloadHandled(created.state, NOW + 100);
+  const changed = evaluateDownloadChanged(
+    { id: 8, filename: { current: '/Downloads/fresh.hwp' } },
+    { id: 8, filename: 'fresh.hwp', url: 'https://example.com/fresh.hwp' },
+    handled,
+    NOW + 1000,
+  );
+
+  assert.equal(changed.action, 'ignore');
+  assert.equal(changed.reason, 'already-handled');
+});
+
+test('expired handled state does not block new created item forever', () => {
+  const oldHandled = {
+    id: 81,
+    firstSeenAt: NOW - 120_000,
+    handledAt: NOW - 120_000,
+    terminalAt: null,
+    lastReason: 'opened',
+  };
+
+  const created = evaluateDownloadCreated({
+    id: 81,
+    url: 'https://example.com/new-after-expired.hwp',
+    filename: 'new-after-expired.hwp',
+    startTime: new Date(NOW).toISOString(),
+  }, oldHandled, NOW, { stateTtlMs: 30_000 });
+
+  assert.equal(created.action, 'track');
+  assert.equal(created.state.firstSeenAt, NOW);
+});
+
+test('terminal state keeps firstSeenAt and stores terminalAt', () => {
+  const created = evaluateDownloadCreated({
+    id: 9,
+    url: 'https://example.com/fresh.hwp',
+    filename: 'fresh.hwp',
+  }, null, NOW);
+  const terminal = markDownloadTerminal(created.state, NOW + 2000);
+
+  assert.equal(terminal.firstSeenAt, NOW);
+  assert.equal(terminal.terminalAt, NOW + 2000);
+});
+
+test('old stored state is expired', () => {
+  const state = { id: 10, firstSeenAt: NOW - 60_000, handledAt: null, terminalAt: null };
+
+  assert.equal(isDownloadStateExpired(state, NOW, 30_000), true);
+  assert.equal(isDownloadStateExpired(state, NOW, 120_000), false);
+});
+
+test('shouldRecheckDownload matches filename finalUrl or complete state', () => {
+  assert.equal(shouldRecheckDownload({ filename: { current: '/Downloads/a.hwp' } }), true);
+  assert.equal(shouldRecheckDownload({ finalUrl: { current: 'https://example.com/a.hwp' } }), true);
+  assert.equal(shouldRecheckDownload({ state: { current: 'complete' } }), true);
+  assert.equal(shouldRecheckDownload({ state: { current: 'in_progress' } }), false);
+});


### PR DESCRIPTION
## 개요

Closes #1515
Refs #1471, #1480, #1498, #1513, #1516

#1513은 Chrome 확장 0.2.7에서 과거 다운로드 항목이 다시 열리는 문제를 긴급 완화했습니다. 이 PR은 그 후속 구조 개선으로, `onCreated` / `onChanged` 다운로드 관찰자 흐름을 명시적인 상태 머신으로 정리하고 Chrome/Edge adapter에 먼저 적용합니다.

`onDeterminingFilename`은 재도입하지 않습니다. #1471의 원인이 리스너 등록 자체였기 때문에, filename 결정 단계에는 계속 개입하지 않고 다운로드 관찰자 경로만 사용합니다.

## 문제 원인

`onDeterminingFilename` 제거 후 Chrome 확장은 `downloads.onCreated` / `downloads.onChanged` 이벤트를 조합해 HWP/HWPX 다운로드를 감지합니다. 이 방식은 filename 결정 이벤트와 달리 다음 상태를 직접 관리해야 합니다.

- 새로 관측한 download id인지
- filename/finalUrl 확정을 기다리는 중인지
- 이미 rhwp 뷰어를 연 download id인지
- service worker 재시작 후에도 추적 상태를 이어갈 수 있는지
- 과거 완료 다운로드 항목을 다시 열지 않을 수 있는지

#1513의 `seen` / `handled` 메모리 Set과 `startTime` 가드는 긴급 완화에는 충분하지만, MV3 service worker 재시작 시 상태가 사라지는 한계가 있습니다.

## 변경 내용

- `rhwp-shared/sw/download-observer-state.js`
  - 브라우저 API에 의존하지 않는 다운로드 관찰자 상태 머신 추가
  - `evaluateDownloadCreated()` / `evaluateDownloadChanged()`로 새 항목 추적, 과거 항목 무시, 재조회 후보 판정 분리
  - `markDownloadHandled()` / `markDownloadTerminal()` / TTL 만료 판정 추가

- `rhwp-chrome/sw/download-interceptor.js`
  - 메모리 `seen` / `handled` / `workerStartedAt` 기반 흐름 제거
  - `chrome.storage.session` 기반 TTL 상태 저장 도입
  - `onCreated`는 상태 머신으로 track 여부 판단 후 저장
  - `onChanged`는 저장 상태가 있는 download id만 `downloads.search({ id })` 재조회
  - `autoOpen=false`, `file://` HWP cancel/erase, 대용량 경고, `openViewer()` 동작 유지

- `rhwp-chrome/sw/download-interceptor.test.mjs`
  - `chrome.storage.session` mock 추가
  - service worker 재시작 시뮬레이션 추가
  - handled 상태가 재시작 후에도 중복 open을 막는지 검증
  - 같은 download id에 여러 changed 이벤트가 와도 탭 1개만 열리는지 검증

- 문서
  - #1515 수행/구현 계획서, 단계 보고서, 최종 보고서 추가
  - 오늘 할일 문서 갱신

## 검증

자동 검증:

```text
node --test rhwp-shared/sw/download-observer-state.test.js
→ 14 passed

node --test rhwp-shared/sw/download-interceptor-common.test.js
→ 26 passed

node --test rhwp-chrome/sw/download-interceptor.test.mjs
→ 13 passed

node --check rhwp-shared/sw/download-observer-state.js
→ passed

node --check rhwp-chrome/sw/download-interceptor.js
→ passed

git diff --check
→ passed

npm run build (rhwp-chrome)
→ passed
```

빌드 산출물 확인:

```text
rhwp-chrome/dist/sw/download-observer-state.js 포함 확인
rg "onDeterminingFilename\.addListener|chrome\.downloads\.onDeterminingFilename" rhwp-chrome/dist rhwp-chrome/sw
→ 결과 없음
```

수동 검증:

- `download.do?...` 링크: URL 확장자 없는 다운로드 핸들러가 filename 확정 후 정상 처리됨
- GitHub raw `.hwp` 링크: 직접 `.hwp` URL 정상 처리됨
- Chrome 재시작/확장 reload 후 과거 HWP 탭 자동 재오픈 없음
- `autoOpen=false`에서 다운로드 관찰자 경로 자동 열림 없음
- 같은 링크 반복 클릭 시 클릭 1회당 탭 1개

## 리뷰 포인트

- 공통 상태 머신의 과거 항목 판정이 충분히 보수적인지
- `chrome.storage.session` 기반 상태 저장/만료 흐름이 MV3 service worker 재시작에 적절한지
- `onChanged` 단독 이벤트를 저장 상태 없이 처리하지 않는 정책이 #1498 재발 방지에 맞는지
- #1471 회귀 방지를 위해 `onDeterminingFilename` 미등록이 계속 유지되는지
- Firefox 적용은 #1516에서 follow-up으로 분리한 것이 적절한지

## 범위 밖

- Firefox 적용은 #1516 에서 진행합니다.
- Safari는 downloads API가 없어 이번 상태 머신의 직접 적용 대상이 아닙니다.
- 릴리스 버전 bump와 스토어 배포는 포함하지 않습니다.
