### PR TITLE
Task #1520: 브라우저 확장: GitHub 비파일 HWP URL 후보 차단

### DIFF
--- a/mydocs/orders/20260625.md
+++ b/mydocs/orders/20260625.md
@@ -5,3 +5,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1510 | 같은 문단 co-anchored float 표의 순서/페이지네이션/PDF 정합 보정 | PR 대기 | PR #1518 Open. review 문서 `mydocs/pr/archives/pr_1518_review*.md`와 오늘할일을 PR head에 포함. GitHub Actions 최신 head 통과와 작업지시자 승인 후 merge 가능 |
+| #1520 | 브라우저 확장 GitHub 비파일 HWP URL 배지/호버 오탐 정정 | 검증완료 | `local/task1520-upstream` 브랜치. 최신 `upstream/devel` 기준으로 포팅. #1521 hover lifecycle 버그는 별도 후속 |

--- a/mydocs/plans/task_m100_1520.md
+++ b/mydocs/plans/task_m100_1520.md
@@ -1,0 +1,191 @@
+# 수행계획서: 브라우저 확장 GitHub 비파일 HWP URL 배지/호버 오탐 정정
+
+- **타스크**: [#1520](https://github.com/edwardkim/rhwp/issues/1520)
+- **마일스톤**: M100 (v1.0.0)
+- **브랜치**: `local/task1520-upstream`
+- **작성일**: 2026-06-25
+- **선행 자료**:
+  - 사용자 보고: GitHub `edit`/`commits` HWP 경로에 rhwp 배지와 hover card가 생성됨
+  - 기존 작업: #432 / PR #437 — URL 해석 계층과 응답 바이트 검증 계층 도입
+  - 후속 분리: [#1521](https://github.com/edwardkim/rhwp/issues/1521) — hover card 지연 표시 lifecycle 버그
+
+## 1. 배경
+
+Task #432에서 GitHub `blob` HWP/HWPX URL을 raw URL로 변환하는 공통 resolver와,
+viewer가 HTML/오류 페이지 응답을 HWP 파서에 넘기지 않는 바이트 검증 게이트가 도입되었다.
+
+그러나 content-script의 초기 배지 후보 판정은 여전히 `anchor.href`가 `.hwp`/`.hwpx`로
+끝나는지만 확인한다. 이 때문에 GitHub에서 실제 파일 바이트를 반환하지 않는 다음 URL에도
+배지와 hover card가 생성된다.
+
+- `https://github.com/edwardkim/rhwp/edit/main/samples/2010-01-06.hwp`
+- `https://github.com/edwardkim/rhwp/commits/main/samples/2010-01-06.hwp`
+
+이 URL들은 경로가 `.hwp`로 끝나지만 실제 응답은 GitHub HTML 페이지다. 배지 또는 hover card를
+클릭하면 viewer로 이동한 뒤 다음 오류가 표시된다.
+
+```text
+파일 로드 실패: 실제 HWP/HWPX 파일이 아닙니다. 파일 미리보기/오류 페이지가 반환되었습니다.
+```
+
+## 2. 문제 정의
+
+현재 구조는 세 계층이 서로 다른 기준을 사용한다.
+
+| 계층 | 현재 기준 | 문제 |
+|---|---|---|
+| content-script 배지/호버 | href 전체 문자열의 `.hwp/.hwpx` suffix | GitHub `edit`, `commits`, `blame` HTML 페이지가 후보로 통과 |
+| service worker URL 해석 | GitHub `blob`만 raw로 변환 | `edit`/`commits`는 원본 HTML URL 그대로 viewer에 전달 |
+| viewer 바이트 검증 | HWP/HWPX magic 또는 HTML 감지 | 마지막 단계에서야 오류 표시 |
+
+이번 타스크의 핵심은 viewer 오류 메시지를 개선하는 것이 아니라, 명확히 문서가 아닌 provider
+URL을 content-script 후보 단계에서 제외하는 것이다.
+
+## 3. 목표
+
+1. GitHub `blob/{ref}/{path}.hwp[x]`와 raw 파일 URL은 기존처럼 배지/hover/viewer 동작을 유지한다.
+2. GitHub `edit`, `commits`, `blame`, `tree` 등 실제 파일 바이트가 아닌 페이지 URL에는 배지와 hover card를 생성하지 않는다.
+3. URL 판정 로직을 호출부에 흩어진 GitHub 전용 조건문으로 만들지 않고, 기존 `document-url-resolver` 계층과 정합되게 확장한다.
+4. Chrome/Firefox/Safari의 배지 후보 판정이 가능한 한 같은 의미를 갖도록 정리한다.
+5. #432에서 도입한 응답 바이트 검증과 #1307의 fetch 보안 정책을 약화하지 않는다.
+
+## 4. 범위
+
+### 포함
+
+- GitHub provider URL의 정적 문서 후보 분류
+- content-script 배지/hover/prefetch 후보 판정에 새 분류 기준 적용
+- Chrome/Firefox/Safari content-script 영향 확인
+- resolver 또는 classifier 순수 함수 테스트 추가
+- 기존 GitHub `blob`/raw/일반 직접 파일 URL 회귀 방지
+
+### 제외
+
+- hover card 표시/숨김 타이머 lifecycle 정정 — #1521에서 별도 처리
+- 모든 파일 호스팅 서비스의 완전 지원
+- 인증이 필요한 GitHub private 파일 처리
+- GitHub branch/tag 이름에 `/`가 포함된 ambiguous ref의 완전 해결
+- 공공기관 POST/세션 의존 다운로드의 완전 재요청 지원
+- WASM HWP/HWPX 파서 변경
+
+## 5. 접근 방향
+
+### 5.1 URL classifier 도입 검토
+
+기존 `resolveDocumentUrl(url)`은 매칭 provider가 없으면 원본 URL을 반환한다. 이는 fetch 대상
+정규화에는 유용하지만, content-script가 "배지를 만들어도 되는가"를 판단하기에는 정보가 부족하다.
+
+따라서 다음 중 하나를 구현계획서에서 확정한다.
+
+1. `rhwp-shared/sw/document-url-resolver.js`에 정적 classifier 추가
+   - 예: `classifyDocumentUrl(url) -> { status, resolvedUrl, reason }`
+2. 기존 resolver 내부 helper를 보강하고 content-script에서 사용할 경량 wrapper 추가
+
+분류 상태는 최소한 다음 의미를 가져야 한다.
+
+| 상태 | 의미 |
+|---|---|
+| `openable` | 정적으로 문서 후보로 판단 가능 |
+| `not-document` | 정적으로 문서가 아닌 provider 페이지로 판단 가능 |
+| `unknown` | provider 규칙은 없지만 일반 직접 파일 URL 후보로 허용 가능 |
+
+`unknown`은 일반 웹의 직접 `.hwp/.hwpx` 파일 URL 호환성을 위해 자동 차단하지 않는다.
+GitHub처럼 provider 구조를 알고 있는 경우에만 `not-document`로 명시 차단한다.
+
+### 5.2 GitHub provider 규칙
+
+GitHub에서 허용할 후보:
+
+- `https://github.com/{owner}/{repo}/blob/{ref}/{path}.hwp[x]`
+- `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}.hwp[x]`
+
+GitHub에서 명시 차단할 후보:
+
+- `https://github.com/{owner}/{repo}/edit/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/commits/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/blame/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/tree/{ref}/...`
+
+GitHub의 다른 URL은 보수적으로 기존 동작과 충돌하지 않게 처리한다.
+
+### 5.3 네트워크 검증은 자동 후보 판정에 넣지 않음
+
+모든 링크에 대해 content-script가 사전 fetch를 수행하면 성능, 개인정보, 내부망 접근,
+서버 부하 문제가 생긴다. 이번 타스크는 네트워크 없는 정적 분류를 우선하고, 실제 응답 검증은
+기존 viewer/service worker 게이트에 맡긴다.
+
+## 6. 예상 단계
+
+구체적인 파일별 변경과 단계 수는 구현계획서에서 확정한다.
+
+### Stage 1 — 현재 판정 흐름 및 테스트 지점 확정
+
+- Chrome/Firefox/Safari content-script의 `isHwpLink` 계열 흐름 정리
+- `document-url-resolver`의 기존 테스트와 한계 확인
+- GitHub `blob`/`edit`/`commits`/`blame` 케이스를 순수 함수 테스트로 고정
+
+### Stage 2 — classifier/resolver 확장
+
+- provider URL 분류 helper 추가
+- GitHub 비파일 action URL을 `not-document`로 분류
+- 기존 `resolveDocumentUrl()` 동작 보존
+
+### Stage 3 — content-script 후보 판정 적용
+
+- Chrome/Firefox content-script에서 배지/hover/prefetch 후보 판정에 classifier 적용
+- Safari content-script에 동일 의미의 판정 적용 또는 공유 가능한 범위 검토
+- `data-hwp="true"` 명시 링크 정책 보존
+
+### Stage 4 — 검증 및 보고
+
+- 순수 함수 테스트
+- content-script 문법 체크
+- Chrome/Firefox 확장 빌드
+- 필요 시 수동 브라우저 검증
+- 단계별 보고서와 최종 보고서 작성
+
+## 7. 회귀 위험
+
+| 위험 | 완화 |
+|---|---|
+| GitHub 정상 `blob` 링크 배지 제거 | `blob` HWP/HWPX 허용 테스트 고정 |
+| raw URL 누락 | `raw.githubusercontent.com` 직접 URL 허용 테스트 추가 |
+| 일반 웹 직접 파일 링크 차단 | provider 미매칭 `.hwp/.hwpx` URL은 기존처럼 후보 유지 |
+| `data-hwp="true"` 다운로드 링크 회귀 | #1307 Stage 2 정책을 명시적으로 보존 |
+| Chrome/Firefox/Safari 동작 차이 | 각 content-script의 동일 케이스 문법/수동 확인 |
+| 보안 정책 약화 | 자동 네트워크 검증 미도입, 기존 fetch 보안 게이트 유지 |
+
+## 8. 검증 방법
+
+필수 자동 검증 후보:
+
+```bash
+node --test rhwp-shared/sw/document-url-resolver.test.js
+node rhwp-chrome/sw/fetch-security.test.mjs
+node --check rhwp-chrome/content-script.js
+node --check rhwp-firefox/content-script.js
+```
+
+확장 빌드 후보:
+
+```bash
+cd rhwp-chrome && npm run build
+cd rhwp-firefox && npm run build
+```
+
+수동 검증 후보:
+
+- GitHub `blob/main/samples/2010-01-06.hwp`에는 배지/hover 표시
+- GitHub `edit/main/samples/2010-01-06.hwp`에는 배지/hover 미표시
+- GitHub `commits/main/samples/2010-01-06.hwp`에는 배지/hover 미표시
+- raw URL과 일반 직접 `.hwp` 링크 동작 유지
+
+## 9. 승인 요청
+
+본 수행계획서 승인 후 구현계획서 `mydocs/plans/task_m100_1520_impl.md`를 작성한다.
+
+### 확인 필요 사항
+
+1. `resolveDocumentUrl()`과 별도로 정적 classifier를 도입하는 방향이 적절한지
+2. GitHub provider에서 `edit`/`commits`/`blame`/`tree`를 명시 차단하는 범위가 적절한지
+3. #1521 hover lifecycle 버그를 본 타스크 범위 밖으로 유지하는 데 동의하는지

--- a/mydocs/plans/task_m100_1520_impl.md
+++ b/mydocs/plans/task_m100_1520_impl.md
@@ -1,0 +1,260 @@
+# 구현계획서: 브라우저 확장 GitHub 비파일 HWP URL 후보 차단
+
+- **타스크**: [#1520](https://github.com/edwardkim/rhwp/issues/1520)
+- **브랜치**: `local/task1520-upstream`
+- **작성일**: 2026-06-25
+- **선행**: `mydocs/plans/task_m100_1520.md` (수행계획서, 승인됨)
+
+## 0. 작업지시자 결정 사항
+
+수행계획서 승인 지시에 따라 다음 방향으로 진행한다.
+
+| 질문 | 결정 |
+|---|---|
+| 정적 classifier 도입 | 도입. 기존 `resolveDocumentUrl()`은 보존하고 후보 판정용 분류 API를 추가 |
+| GitHub 비파일 URL 차단 범위 | `edit`, `commits`, `blame`, `tree` 우선 차단 |
+| #1521 hover lifecycle | 본 타스크 범위 밖으로 유지 |
+
+## 1. 핵심 설계
+
+### 1.1 두 기준을 분리한다
+
+기존 `resolveDocumentUrl(url)`은 "viewer가 실제로 fetch할 URL"을 반환한다. 매칭 provider가 없으면
+원본 URL을 반환해야 하므로, 이 함수만으로 content-script가 배지 생성 여부를 결정할 수 없다.
+
+이번 작업에서는 별도의 후보 분류 함수를 추가한다.
+
+```javascript
+classifyDocumentUrl(url)
+```
+
+예상 반환값:
+
+```javascript
+{
+  status: 'openable' | 'not-document' | 'unknown',
+  resolvedUrl?: string,
+  reason?: string
+}
+```
+
+상태 의미:
+
+| 상태 | 의미 | content-script 처리 |
+|---|---|---|
+| `openable` | 정적으로 HWP/HWPX 후보가 맞음 | 배지/hover 허용 |
+| `not-document` | 정적으로 문서가 아닌 provider 페이지 | 배지/hover 차단 |
+| `unknown` | provider 규칙은 없지만 일반 URL 후보 | 기존 확장자 정책 유지 |
+
+### 1.2 GitHub provider 정책
+
+허용:
+
+- `https://github.com/{owner}/{repo}/blob/{ref}/{path}.hwp[x]`
+- `https://raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}.hwp[x]`
+
+차단:
+
+- `https://github.com/{owner}/{repo}/edit/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/commits/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/blame/{ref}/{path}.hwp[x]`
+- `https://github.com/{owner}/{repo}/tree/{ref}/...`
+
+주의:
+
+- slash 포함 ref는 기존 #432와 동일하게 완전 지원하지 않는다.
+- `resolveDocumentUrl()`의 기존 동작은 깨지지 않아야 한다.
+- provider 미매칭 일반 `.hwp/.hwpx` 직접 링크는 계속 허용한다.
+
+### 1.3 content-script 적용 방식
+
+Chrome/Firefox/Safari content-script는 현재 manifest의 일반 스크립트로 로드되며 ESM import를 직접
+사용하지 않는다. 따라서 구현은 다음 원칙으로 진행한다.
+
+1. `rhwp-shared/sw/document-url-resolver.js`에 테스트 가능한 classifier를 추가한다.
+2. Chrome/Firefox/Safari content-script에는 같은 정책의 경량 후보 판정 helper를 적용한다.
+3. 중복을 최소화하되, content-script 모듈화/번들링 전환은 이번 타스크 범위에 포함하지 않는다.
+
+추후 별도 리팩터링에서 content-script 공통 helper를 UMD 또는 번들 기반으로 공유할 수 있다.
+
+### 1.4 `data-hwp="true"` 정책
+
+명시적 통합 링크는 기존 정책을 유지한다.
+
+- `data-hwp="true"`가 있으면 확장자 없는 공공기관 다운로드 URL도 후보로 허용한다.
+- 단, GitHub의 명시적 비파일 URL에 `data-hwp="true"`가 붙는 예외는 이번 타스크에서 별도로 다루지 않는다.
+  일반 웹페이지가 의도적으로 명시한 링크는 기존 통합 계약을 존중한다.
+
+## 2. 파일 변경 계획
+
+| 파일 | 변경 |
+|---|---|
+| `rhwp-shared/sw/document-url-resolver.js` | `classifyDocumentUrl()` 추가, GitHub provider 분류 helper 추가 |
+| `rhwp-shared/sw/document-url-resolver.test.js` | GitHub `edit`/`commits`/`blame`/`tree` 차단, `blob`/raw/일반 URL 허용 테스트 추가 |
+| `rhwp-chrome/content-script.js` | `isHwpLink()`에서 GitHub 비파일 URL 제외, hover/prefetch 후보 판정에 동일 기준 적용 |
+| `rhwp-firefox/content-script.js` | Chrome과 동일 |
+| `rhwp-safari/src/content-script.js` | Safari 후보 판정에 동일 기준 적용 |
+| `rhwp-chrome/dist/`, `rhwp-firefox/dist/`, `rhwp-safari/dist/` | 빌드 산출물은 빌드 결과에 따라 갱신 여부 결정 |
+| `mydocs/working/task_m100_1520_stage*.md` | 단계별 완료 보고서 |
+| `mydocs/report/task_m100_1520_report.md` | 최종 보고서 |
+| `mydocs/orders/20260625.md` | 진행 상태 갱신 |
+
+## 3. 단계 분할
+
+### Stage 1 — classifier 순수 함수와 테스트
+
+**변경 파일**:
+
+- `rhwp-shared/sw/document-url-resolver.js`
+- `rhwp-shared/sw/document-url-resolver.test.js`
+- `mydocs/working/task_m100_1520_stage1.md`
+
+**구현**:
+
+- `classifyDocumentUrl(url)` 추가
+- GitHub `blob`은 `openable` + raw resolved URL 반환
+- `raw.githubusercontent.com` 직접 HWP/HWPX는 `openable`
+- GitHub `edit`, `commits`, `blame`, `tree`는 `not-document`
+- 일반 직접 파일 URL은 `unknown` 또는 `openable` 중 구현계획 내에서 최종 선택
+  - content-script 호환성 관점에서는 "차단하지 않음"이 핵심이다.
+
+**테스트 케이스**:
+
+- `github.com/.../blob/.../sample.hwp` → `openable`
+- `github.com/.../blob/.../sample.hwpx` → `openable`
+- `raw.githubusercontent.com/.../sample.hwp` → `openable`
+- `github.com/.../edit/.../sample.hwp` → `not-document`
+- `github.com/.../commits/.../sample.hwp` → `not-document`
+- `github.com/.../blame/.../sample.hwp` → `not-document`
+- `github.com/.../tree/...` → `not-document`
+- `github.com/.../blob/.../README.md?file=sample.hwp` → 기존처럼 변환하지 않음
+- `https://example.com/files/sample.hwp` → 차단하지 않음
+
+**검증**:
+
+```bash
+node --test rhwp-shared/sw/document-url-resolver.test.js
+```
+
+**완료 기준**:
+
+- resolver 기존 12개 테스트 보존
+- 신규 classifier 테스트 통과
+
+### Stage 2 — Chrome/Firefox content-script 후보 판정 적용
+
+**변경 파일**:
+
+- `rhwp-chrome/content-script.js`
+- `rhwp-firefox/content-script.js`
+- `mydocs/working/task_m100_1520_stage2.md`
+
+**구현**:
+
+- `isHwpLink(anchor)`에서 GitHub 비파일 URL을 제외한다.
+- `processLinks()` 배지 생성 경로가 같은 판정을 사용한다.
+- `prefetchThumbnails()`가 같은 판정을 사용해 GitHub HTML 페이지 prefetch를 만들지 않는다.
+- `data-hwp="true"` 명시 링크 정책은 기존대로 보존한다.
+
+**검증**:
+
+```bash
+node --check rhwp-chrome/content-script.js
+node --check rhwp-firefox/content-script.js
+node --test rhwp-shared/sw/document-url-resolver.test.js
+```
+
+**완료 기준**:
+
+- Chrome/Firefox content-script 문법 체크 통과
+- GitHub 비파일 URL은 후보에서 제외되는 로직 확인
+
+### Stage 3 — Safari content-script 반영 및 확장 빌드
+
+**변경 파일**:
+
+- `rhwp-safari/src/content-script.js`
+- `mydocs/working/task_m100_1520_stage3.md`
+
+**구현**:
+
+- Safari의 `isHwpLink(anchor)`에도 동일한 GitHub 비파일 제외 정책을 적용한다.
+- Safari의 `autoOpen`, `showBadges`, `hoverPreview` 흐름이 Chrome/Firefox와 같은 의미가 되도록 맞춘다.
+
+**검증**:
+
+```bash
+node --check rhwp-safari/src/content-script.js
+cd rhwp-chrome && npm run build
+cd rhwp-firefox && npm run build
+```
+
+Safari 전체 `build.sh`는 Xcode 환경 의존성이 크므로, 이번 단계에서는 문법 체크와 소스 반영을 우선한다.
+필요 시 작업지시자 환경에서 별도 Safari 빌드/수동 검증을 진행한다.
+
+**완료 기준**:
+
+- Chrome/Firefox 확장 빌드 통과
+- Safari content-script 문법 체크 통과
+
+### Stage 4 — 수동 재현 확인과 최종 보고
+
+**변경 파일**:
+
+- `mydocs/working/task_m100_1520_stage4.md`
+- `mydocs/report/task_m100_1520_report.md`
+- `mydocs/orders/20260625.md`
+
+**검증 후보**:
+
+자동:
+
+```bash
+node --test rhwp-shared/sw/document-url-resolver.test.js
+node rhwp-chrome/sw/fetch-security.test.mjs
+node --check rhwp-chrome/content-script.js
+node --check rhwp-firefox/content-script.js
+node --check rhwp-safari/src/content-script.js
+cd rhwp-chrome && npm run build
+cd rhwp-firefox && npm run build
+```
+
+수동:
+
+- GitHub `blob/main/samples/2010-01-06.hwp` 배지/hover 표시
+- GitHub `edit/main/samples/2010-01-06.hwp` 배지/hover 미표시
+- GitHub `commits/main/samples/2010-01-06.hwp` 배지/hover 미표시
+- raw URL 또는 일반 직접 `.hwp` 링크 동작 유지
+
+**완료 기준**:
+
+- 자동 검증 통과
+- 수동 검증 가능 범위 기록
+- 최종 보고서 작성
+- 오늘할일 상태 갱신
+
+## 4. 회귀 방지 체크리스트
+
+| 항목 | 기대 |
+|---|---|
+| GitHub `blob` HWP/HWPX | 배지/hover 유지, raw 변환 유지 |
+| GitHub `edit` HWP/HWPX | 배지/hover 없음 |
+| GitHub `commits` HWP/HWPX | 배지/hover 없음 |
+| GitHub `blame` HWP/HWPX | 배지/hover 없음 |
+| `raw.githubusercontent.com` HWP/HWPX | 배지/hover 유지 |
+| 일반 `https://example.com/file.hwp` | 배지/hover 유지 |
+| query에만 `.hwp` 존재 | 자동 감지 없음 |
+| `data-hwp="true"` 명시 링크 | 기존 통합 동작 유지 |
+| 내부망/private URL fetch | #1307 정책 유지 |
+
+## 5. 비목표
+
+- #1521 hover card 지연 표시 타이머 취소 누락 수정
+- content-script 전체 모듈화 또는 번들링 전환
+- GitHub slash 포함 ref 완전 파싱
+- GitLab/Bitbucket provider 구현
+- 확장자 없는 다운로드 URL의 일반 자동 감지
+
+## 6. 승인 요청
+
+본 구현계획서 승인 후 Stage 1 구현을 시작한다.

--- a/mydocs/report/task_m100_1520_report.md
+++ b/mydocs/report/task_m100_1520_report.md
@@ -1,0 +1,57 @@
+# Task M100 #1520 최종 보고서
+
+## 요약
+
+GitHub의 실제 문서 파일 URL이 아닌 `edit`, `commits`, `blame`, `tree` 라우팅 URL에 rhwp 배지와 hover 미리보기가 붙는 오탐을 정정했다.
+
+기존 content script는 `anchor.href` 전체가 `.hwp`/`.hwpx`로 끝나는지만 검사했다. GitHub의 `https://github.com/{owner}/{repo}/edit/{branch}/path/file.hwp` 같은 URL은 파일 다운로드 URL이 아니라 HTML 페이지인데도 후보로 잡혔고, 클릭 후 viewer에서야 "실제 HWP/HWPX 파일이 아닙니다" 오류가 발생했다.
+
+## 변경 내용
+
+- `rhwp-shared/sw/document-url-resolver.js`
+  - GitHub 문서 URL 분류 함수 추가
+  - `blob`/raw 문서 URL은 `openable`
+  - `edit`, `commits`, `blame`, `tree`는 `not-document`
+  - 일반 직접 `.hwp/.hwpx` pathname은 `openable`
+  - query 문자열에만 `.hwp/.hwpx`가 있는 경우는 후보에서 제외
+
+- `rhwp-shared/sw/document-url-resolver.test.js`
+  - GitHub `blob`, raw, `edit`, `commits`, `blame`, `tree`, query 위장 케이스 테스트 추가
+
+- `rhwp-chrome/content-script.js`
+- `rhwp-firefox/content-script.js`
+- `rhwp-safari/src/content-script.js`
+  - 배지/hover/prefetch/autoOpen 후보가 같은 `isHwpLink()` 판정을 사용하도록 URL pathname 기반 분류 적용
+  - `data-hwp="true"` 명시 링크는 기존 동작 유지
+
+## 해결되는 문제
+
+- GitHub `edit/main/.../*.hwp`에서 배지와 hover 미리보기가 생성되지 않는다.
+- GitHub `commits/main/.../*.hwp`에서 배지와 hover 미리보기가 생성되지 않는다.
+- 같은 계열의 `blame`, `tree` URL도 문서 후보에서 제외된다.
+- HTML 오류 페이지를 HWP 파일로 열려고 해서 viewer 오류 모달이 뜨는 흐름을 사전에 줄인다.
+- 실제 GitHub `blob` 문서 URL과 raw 문서 URL은 계속 rhwp로 열 수 있다.
+
+## 검증
+
+통과:
+
+- `node --test rhwp-shared/sw/document-url-resolver.test.js`
+- `node rhwp-chrome/sw/fetch-security.test.mjs`
+- `node --test rhwp-shared/sw/download-interceptor-common.test.js`
+- `node --check rhwp-chrome/content-script.js`
+- `node --check rhwp-firefox/content-script.js`
+- `node --check rhwp-safari/src/content-script.js`
+- `npm run build` (`rhwp-chrome`)
+- `npm run build` (`rhwp-firefox`)
+
+참고:
+
+- 초기 작업은 오래된 `local/devel` 기준에서 시작됐으나, 최종 변경은 최신 `upstream/devel` 기준 `local/task1520-upstream` 브랜치로 포팅해 검증했다.
+- Safari 전체 `build.sh`/Xcode 빌드는 이번 범위에서 제외했다.
+- Chrome `rhwp-chrome/dist`와 Firefox `rhwp-firefox/dist`를 실제 로드해 GitHub #1520 재현 페이지에서 수동 확인했다.
+- 수동 확인 결과 `edit`/`commits` 링크에는 배지가 없고, `blob`/raw 링크에는 배지가 표시됐다.
+
+## 남은 후속
+
+- hover 카드 지연 표시 타이머 취소 누락 문제는 별도 이슈 #1521에서 처리한다.

--- a/mydocs/working/task_m100_1520_stage1.md
+++ b/mydocs/working/task_m100_1520_stage1.md
@@ -1,0 +1,78 @@
+# Stage 1 완료보고서: URL classifier 순수 함수와 테스트
+
+- **타스크**: [#1520](https://github.com/edwardkim/rhwp/issues/1520)
+- **브랜치**: `local/task1520-upstream`
+- **작성일**: 2026-06-25
+- **단계**: Stage 1 — classifier 순수 함수와 테스트
+
+## 1. 범위
+
+이번 단계에서는 content-script 동작을 아직 변경하지 않고, 공통 URL resolver에 정적 후보 분류 API와
+회귀 테스트를 추가했다.
+
+변경 파일:
+
+| 파일 | 변경 |
+|---|---|
+| `rhwp-shared/sw/document-url-resolver.js` | `classifyDocumentUrl()`, `classifyGithubDocumentUrl()` 추가 |
+| `rhwp-shared/sw/document-url-resolver.test.js` | GitHub 비파일 URL 차단 및 정상 URL 허용 테스트 추가 |
+
+## 2. 구현 내용
+
+### 2.1 `classifyDocumentUrl(url)`
+
+content-script 후보 판정에 사용할 수 있도록 URL을 다음 상태로 분류한다.
+
+| 상태 | 의미 |
+|---|---|
+| `openable` | 정적으로 HWP/HWPX 문서 후보로 판단 가능 |
+| `not-document` | 정적으로 문서가 아닌 provider 페이지로 판단 가능 |
+| `unknown` | 문서 후보로 확정할 수 없음 |
+
+기존 `resolveDocumentUrl(url)` 동작은 변경하지 않았다. viewer/thumbnail fetch 대상 정규화는 기존
+흐름을 유지하고, 후보 표시 여부 판단만 별도 classifier로 분리했다.
+
+### 2.2 GitHub provider 분류
+
+정상 후보:
+
+- `github.com/{owner}/{repo}/blob/{ref}/{path}.hwp[x]`
+- `raw.githubusercontent.com/{owner}/{repo}/{ref}/{path}.hwp[x]`
+- 일반 직접 파일 URL `https://example.com/files/sample.hwp`
+
+비파일 페이지:
+
+- `github.com/{owner}/{repo}/edit/{ref}/{path}.hwp[x]`
+- `github.com/{owner}/{repo}/commits/{ref}/{path}.hwp[x]`
+- `github.com/{owner}/{repo}/blame/{ref}/{path}.hwp[x]`
+- `github.com/{owner}/{repo}/tree/{ref}/...`
+- `github.com/{owner}/{repo}/blob/{ref}/README.md?file=sample.hwp`
+
+## 3. 검증
+
+실행:
+
+```bash
+node --test rhwp-shared/sw/document-url-resolver.test.js
+```
+
+결과:
+
+```text
+tests 23
+pass 23
+fail 0
+```
+
+기존 12개 resolver 테스트와 신규 11개 classifier 테스트가 모두 통과했다.
+
+## 4. 다음 단계
+
+Stage 2에서 Chrome/Firefox content-script의 `isHwpLink()`와 thumbnail prefetch 후보 판정에
+이번 classifier와 같은 정책을 적용한다.
+
+주의:
+
+- `data-hwp="true"` 명시 링크 정책은 유지한다.
+- content-script는 현재 일반 스크립트로 로드되므로 Stage 2에서는 import 구조 변경 없이 경량 helper를 적용한다.
+- #1521 hover lifecycle 버그는 본 타스크에서 수정하지 않는다.

--- a/mydocs/working/task_m100_1520_stage2.md
+++ b/mydocs/working/task_m100_1520_stage2.md
@@ -1,0 +1,20 @@
+# Task M100 #1520 Stage 2 완료 기록
+
+## 범위
+
+- Chrome content script의 링크 후보 판정 로직을 `anchor.href` 전체 정규식에서 URL pathname 기반 분류로 변경했다.
+- Firefox content script에도 동일한 후보 판정 로직을 적용했다.
+- GitHub `blob` 문서 URL은 후보로 유지하고, `edit`, `commits`, `blame`, `tree` 라우팅 URL은 후보에서 제외한다.
+- 명시적 `data-hwp="true"` 링크는 기존처럼 배지 대상으로 유지한다.
+
+## 검증
+
+- `node --check rhwp-chrome/content-script.js`
+- `node --check rhwp-firefox/content-script.js`
+- `node --test rhwp-shared/sw/document-url-resolver.test.js`
+
+결과: 모두 통과.
+
+## 다음 단계
+
+- Stage 3: Safari content script에 동일한 후보 판정 로직을 적용하고 브라우저 확장 빌드/검사를 실행한다.

--- a/mydocs/working/task_m100_1520_stage3.md
+++ b/mydocs/working/task_m100_1520_stage3.md
@@ -1,0 +1,26 @@
+# Task M100 #1520 Stage 3 완료 기록
+
+## 범위
+
+- Safari content script의 링크 후보 판정을 Chrome/Firefox와 동일하게 URL pathname 기반 분류로 변경했다.
+- GitHub `blob` 문서 URL과 `raw.githubusercontent.com` 직접 문서 URL은 후보로 유지했다.
+- GitHub `edit`, `commits`, `blame`, `tree` 라우팅 URL은 후보에서 제외했다.
+- 명시적 `data-hwp="true"` 링크는 기존처럼 배지/미리보기 대상으로 유지했다.
+
+## 검증
+
+- `node --check rhwp-safari/src/content-script.js`
+- `node --test rhwp-shared/sw/document-url-resolver.test.js`
+- `npm run build` (`rhwp-chrome`)
+- `npm run build` (`rhwp-firefox`)
+
+결과: 모두 통과.
+
+## 비고
+
+- Safari 전체 `build.sh`/Xcode 빌드는 이번 구현계획서 범위 밖으로 두었다.
+- Chrome/Firefox 빌드 산출물은 추적 변경으로 남지 않았다.
+
+## 다음 단계
+
+- Stage 4: 최종 diff와 테스트 결과를 정리하고 스테이징 전 변경 범위를 점검한다.

--- a/mydocs/working/task_m100_1520_stage4.md
+++ b/mydocs/working/task_m100_1520_stage4.md
@@ -1,0 +1,44 @@
+# Task M100 #1520 Stage 4 완료 기록
+
+## 범위
+
+- 최종 자동 검증을 실행했다.
+- 수동 재현 확인 가능 범위를 기록했다.
+- 오늘 할일 상태를 `검증완료`로 갱신했다.
+- 최종 보고서를 작성했다.
+
+## 자동 검증 결과
+
+통과:
+
+- `node --test rhwp-shared/sw/document-url-resolver.test.js`
+- `node rhwp-chrome/sw/fetch-security.test.mjs`
+- `node --test rhwp-shared/sw/download-interceptor-common.test.js`
+- `node --check rhwp-chrome/content-script.js`
+- `node --check rhwp-firefox/content-script.js`
+- `node --check rhwp-safari/src/content-script.js`
+- `npm run build` (`rhwp-chrome`)
+- `npm run build` (`rhwp-firefox`)
+
+초기 작업은 오래된 `local/devel` 기준에서 시작되어 `rhwp-chrome/sw/fetch-security.test.mjs`가 없었다. 이후 최신 `upstream/devel` 기준의 `local/task1520-upstream` 브랜치로 포팅했고, 해당 테스트를 포함해 다시 검증했다.
+
+## 수동 검증 기록
+
+이번 Stage 4에서는 브라우저 확장을 실제 로드한 GitHub 화면 수동 확인은 수행하지 않았다.
+
+수동 확인 시나리오:
+
+- `https://github.com/edwardkim/rhwp/blob/main/samples/2010-01-06.hwp`: 배지/hover 표시 유지
+- `https://github.com/edwardkim/rhwp/edit/main/samples/2010-01-06.hwp`: 배지/hover 미표시
+- `https://github.com/edwardkim/rhwp/commits/main/samples/2010-01-06.hwp`: 배지/hover 미표시
+- `raw.githubusercontent.com` 직접 `.hwp/.hwpx` URL: rhwp 열기 유지
+- 일반 직접 `.hwp/.hwpx` URL: rhwp 열기 유지
+
+## 변경 상태
+
+- 스테이징 전 상태로 유지했다.
+- Chrome/Firefox 빌드 산출물은 추적 변경으로 남지 않았다.
+
+## 다음 단계
+
+- 변경 범위 승인 후 `git add`로 스테이징한다.

--- a/mydocs/working/task_m100_1520_stage5.md
+++ b/mydocs/working/task_m100_1520_stage5.md
@@ -1,0 +1,37 @@
+# Task M100 #1520 Stage 5 완료 기록
+
+## 배경
+
+초기 구현 브랜치 `local/task1520`은 오래된 `local/devel` 기준이었다. 최신 `upstream/devel`에는 #1307 계열의 `fetch-security` 모듈과 Chrome/Firefox content script 보안 보강이 포함되어 있어, 최신 기준으로 포팅해 재검증했다.
+
+## 수행
+
+- `upstream/devel`을 `42d7f6bc`로 갱신했다.
+- 새 브랜치 `local/task1520-upstream`을 최신 `upstream/devel`에서 생성했다.
+- 기존 작업 변경을 stash로 보관한 뒤 새 브랜치에 적용했다.
+- Chrome/Firefox content script의 upstream 변경(Shadow DOM hover card, `isTrusted`, `allowDownloadUrl`)을 유지한 상태로 URL 후보 판정을 병합했다.
+- 최신 upstream의 `mydocs/orders/20260625.md`에 #1520 행을 병합했다.
+
+## 검증
+
+통과:
+
+- `node --test rhwp-shared/sw/document-url-resolver.test.js`
+- `node rhwp-chrome/sw/fetch-security.test.mjs`
+- `node --test rhwp-shared/sw/download-interceptor-common.test.js`
+- `node --check rhwp-chrome/content-script.js`
+- `node --check rhwp-firefox/content-script.js`
+- `node --check rhwp-safari/src/content-script.js`
+- `npm run build` (`rhwp-chrome`)
+- `npm run build` (`rhwp-firefox`)
+
+수동 확인:
+
+- Chrome `rhwp-chrome/dist` 로드 후 GitHub #1520 재현 링크에서 확인했다.
+- Firefox `rhwp-firefox/dist` 로드 후 GitHub #1520 재현 링크에서 확인했다.
+- `edit/main/samples/2010-01-06.hwp`와 `commits/main/samples/2010-01-06.hwp`에는 배지가 생성되지 않았다.
+- `blob/main/samples/2010-01-06.hwp`와 raw URL에는 배지가 생성됐다.
+
+## 비고
+
+- `pdf-large/hwpx/2026_oss_rst.pdf`는 최신 upstream checkout 시 LFS 필터와 저장 blob 불일치로 modified로 표시된다. 이번 작업 범위에 포함하지 않는다.

--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -5,6 +5,8 @@
   'use strict';
 
   const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';
   const PROCESSED_ATTR = 'data-rhwp-processed';
@@ -185,10 +187,58 @@
 
   // ─── 링크 감지 ───
 
+  function hasDocumentPath(pathname) {
+    if (typeof pathname !== 'string') return false;
+    try {
+      return DOCUMENT_PATH_EXTENSIONS.test(decodeURIComponent(pathname).toLowerCase());
+    } catch {
+      return DOCUMENT_PATH_EXTENSIONS.test(pathname.toLowerCase());
+    }
+  }
+
+  function classifyDocumentHref(href) {
+    let parsed;
+    try {
+      parsed = new URL(href);
+    } catch {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.hostname === 'raw.githubusercontent.com') {
+      return hasDocumentPath(parsed.pathname)
+        ? { status: 'openable' }
+        : { status: 'not-document' };
+    }
+
+    if (parsed.hostname === 'github.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (segments.length >= 3) {
+        const marker = segments[2];
+        if (marker === 'blob') {
+          const pathParts = segments.slice(4);
+          return pathParts.length > 0 && hasDocumentPath(pathParts.join('/'))
+            ? { status: 'openable' }
+            : { status: 'not-document' };
+        }
+        if (GITHUB_NON_DOCUMENT_MARKERS.has(marker)) {
+          return { status: 'not-document' };
+        }
+      }
+    }
+
+    return hasDocumentPath(parsed.pathname)
+      ? { status: 'openable' }
+      : { status: 'unknown' };
+  }
+
   function isHwpLink(anchor) {
     if (!anchor.href) return false;
     if (anchor.getAttribute('data-hwp') === 'true') return true;
-    return HWP_EXTENSIONS.test(anchor.href);
+    return classifyDocumentHref(anchor.href).status === 'openable';
   }
 
   function isExplicitHwpLink(anchor) {

--- a/rhwp-firefox/content-script.js
+++ b/rhwp-firefox/content-script.js
@@ -5,6 +5,8 @@
   'use strict';
 
   const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';
   const PROCESSED_ATTR = 'data-rhwp-processed';
@@ -188,10 +190,58 @@
 
   // ─── 링크 감지 ───
 
+  function hasDocumentPath(pathname) {
+    if (typeof pathname !== 'string') return false;
+    try {
+      return DOCUMENT_PATH_EXTENSIONS.test(decodeURIComponent(pathname).toLowerCase());
+    } catch {
+      return DOCUMENT_PATH_EXTENSIONS.test(pathname.toLowerCase());
+    }
+  }
+
+  function classifyDocumentHref(href) {
+    let parsed;
+    try {
+      parsed = new URL(href);
+    } catch {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.hostname === 'raw.githubusercontent.com') {
+      return hasDocumentPath(parsed.pathname)
+        ? { status: 'openable' }
+        : { status: 'not-document' };
+    }
+
+    if (parsed.hostname === 'github.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (segments.length >= 3) {
+        const marker = segments[2];
+        if (marker === 'blob') {
+          const pathParts = segments.slice(4);
+          return pathParts.length > 0 && hasDocumentPath(pathParts.join('/'))
+            ? { status: 'openable' }
+            : { status: 'not-document' };
+        }
+        if (GITHUB_NON_DOCUMENT_MARKERS.has(marker)) {
+          return { status: 'not-document' };
+        }
+      }
+    }
+
+    return hasDocumentPath(parsed.pathname)
+      ? { status: 'openable' }
+      : { status: 'unknown' };
+  }
+
   function isHwpLink(anchor) {
     if (!anchor.href) return false;
     if (anchor.getAttribute('data-hwp') === 'true') return true;
-    return HWP_EXTENSIONS.test(anchor.href);
+    return classifyDocumentHref(anchor.href).status === 'openable';
   }
 
   function isExplicitHwpLink(anchor) {

--- a/rhwp-safari/src/content-script.js
+++ b/rhwp-safari/src/content-script.js
@@ -6,6 +6,8 @@
   'use strict';
 
   const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';
   const PROCESSED_ATTR = 'data-rhwp-processed';
@@ -67,10 +69,58 @@
 
   // ─── 링크 감지 ───
 
+  function hasDocumentPath(pathname) {
+    if (typeof pathname !== 'string') return false;
+    try {
+      return DOCUMENT_PATH_EXTENSIONS.test(decodeURIComponent(pathname).toLowerCase());
+    } catch {
+      return DOCUMENT_PATH_EXTENSIONS.test(pathname.toLowerCase());
+    }
+  }
+
+  function classifyDocumentHref(href) {
+    let parsed;
+    try {
+      parsed = new URL(href);
+    } catch {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+      return { status: 'unknown' };
+    }
+
+    if (parsed.hostname === 'raw.githubusercontent.com') {
+      return hasDocumentPath(parsed.pathname)
+        ? { status: 'openable' }
+        : { status: 'not-document' };
+    }
+
+    if (parsed.hostname === 'github.com') {
+      const segments = parsed.pathname.split('/').filter(Boolean);
+      if (segments.length >= 3) {
+        const marker = segments[2];
+        if (marker === 'blob') {
+          const pathParts = segments.slice(4);
+          return pathParts.length > 0 && hasDocumentPath(pathParts.join('/'))
+            ? { status: 'openable' }
+            : { status: 'not-document' };
+        }
+        if (GITHUB_NON_DOCUMENT_MARKERS.has(marker)) {
+          return { status: 'not-document' };
+        }
+      }
+    }
+
+    return hasDocumentPath(parsed.pathname)
+      ? { status: 'openable' }
+      : { status: 'unknown' };
+  }
+
   function isHwpLink(anchor) {
     if (!anchor.href) return false;
     if (anchor.getAttribute('data-hwp') === 'true') return true;
-    return HWP_EXTENSIONS.test(anchor.href);
+    return classifyDocumentHref(anchor.href).status === 'openable';
   }
 
   function createBadge(anchor) {

--- a/rhwp-shared/sw/document-url-resolver.js
+++ b/rhwp-shared/sw/document-url-resolver.js
@@ -4,6 +4,13 @@
 // 호출부에서 직접 분기하지 않도록 이 모듈에서 정규화한다.
 
 const DOCUMENT_EXTENSION_RE = /\.(hwp|hwpx)$/i;
+const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
+
+function classification(status, reason, resolvedUrl) {
+  const result = { status, reason };
+  if (resolvedUrl) result.resolvedUrl = resolvedUrl;
+  return result;
+}
 
 /**
  * rhwp가 직접 열 수 있는 문서 경로인지 확인한다.
@@ -53,6 +60,90 @@ export function resolveGithubBlobUrl(parsed) {
   if (!isDocumentPath(encodedPath)) return null;
 
   return `https://raw.githubusercontent.com/${owner}/${repo}/${ref}/${encodedPath}`;
+}
+
+/**
+ * GitHub 계열 URL이 실제 문서 후보인지 정적으로 분류한다.
+ *
+ * `blob` 페이지는 raw URL로 변환 가능하므로 openable이고, `edit`,
+ * `commits`, `blame`, `tree`는 `.hwp` 경로처럼 보여도 HTML 페이지이므로
+ * not-document로 분류한다.
+ *
+ * @param {URL} parsed
+ * @returns {{status: 'openable'|'not-document'|'unknown', reason: string, resolvedUrl?: string}|null}
+ */
+export function classifyGithubDocumentUrl(parsed) {
+  if (!(parsed instanceof URL)) return null;
+  if (parsed.protocol !== 'https:') return null;
+
+  if (parsed.hostname === 'raw.githubusercontent.com') {
+    return isDocumentPath(parsed.pathname)
+      ? classification('openable', 'github-raw-document', parsed.href)
+      : classification('not-document', 'github-raw-non-document');
+  }
+
+  if (parsed.hostname !== 'github.com') return null;
+
+  const segments = parsed.pathname.split('/').filter(Boolean);
+  if (segments.length < 3) {
+    return classification('unknown', 'github-unrecognized');
+  }
+
+  const [owner, repo, marker, ref, ...pathParts] = segments;
+  if (!owner || !repo || !marker) {
+    return classification('unknown', 'github-unrecognized');
+  }
+
+  if (marker === 'blob') {
+    if (!ref || pathParts.length === 0) {
+      return classification('not-document', 'github-blob-missing-path');
+    }
+
+    const resolvedUrl = resolveGithubBlobUrl(parsed);
+    if (resolvedUrl) {
+      return classification('openable', 'github-blob-document', resolvedUrl);
+    }
+    return classification('not-document', 'github-blob-non-document');
+  }
+
+  if (GITHUB_NON_DOCUMENT_MARKERS.has(marker)) {
+    return classification('not-document', `github-${marker}-page`);
+  }
+
+  return classification('unknown', 'github-unrecognized');
+}
+
+/**
+ * URL을 content-script 후보 판정에 사용할 수 있는 형태로 분류한다.
+ *
+ * - provider가 실제 문서 URL로 정규화 가능한 경우: openable
+ * - provider가 명확한 HTML/도구 페이지인 경우: not-document
+ * - 일반 직접 HWP/HWPX 경로: openable
+ * - 그 외: unknown
+ *
+ * @param {string} url
+ * @returns {{status: 'openable'|'not-document'|'unknown', reason: string, resolvedUrl?: string}}
+ */
+export function classifyDocumentUrl(url) {
+  if (!url || typeof url !== 'string') {
+    return classification('unknown', 'invalid-url');
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return classification('unknown', 'invalid-url');
+  }
+
+  const githubResult = classifyGithubDocumentUrl(parsed);
+  if (githubResult) return githubResult;
+
+  if (isDocumentPath(parsed.pathname)) {
+    return classification('openable', 'document-path', parsed.href);
+  }
+
+  return classification('unknown', 'no-document-path');
 }
 
 /**

--- a/rhwp-shared/sw/document-url-resolver.test.js
+++ b/rhwp-shared/sw/document-url-resolver.test.js
@@ -6,6 +6,8 @@ import { test } from 'node:test';
 import { strict as assert } from 'node:assert';
 
 import {
+  classifyDocumentUrl,
+  classifyGithubDocumentUrl,
   isDocumentPath,
   resolveDocumentUrl,
   resolveGithubBlobUrl,
@@ -86,4 +88,96 @@ test('malformed URL은 원본 반환', () => {
 
 test('resolveGithubBlobUrl은 URL 객체만 처리', () => {
   assert.equal(resolveGithubBlobUrl('https://github.com/edwardkim/rhwp/blob/devel/a.hwp'), null);
+});
+
+// ─── 문서 후보 분류 ───────────────────────────────────
+
+test('classifyDocumentUrl은 GitHub blob HWP URL을 openable로 분류하고 raw URL을 제공', () => {
+  const input = 'https://github.com/edwardkim/rhwp/blob/main/samples/2010-01-06.hwp';
+  const result = classifyDocumentUrl(input);
+
+  assert.equal(result.status, 'openable');
+  assert.equal(result.reason, 'github-blob-document');
+  assert.equal(
+    result.resolvedUrl,
+    'https://raw.githubusercontent.com/edwardkim/rhwp/main/samples/2010-01-06.hwp',
+  );
+});
+
+test('classifyDocumentUrl은 GitHub blob HWPX URL도 openable로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/blob/main/samples/hwpx/sample.hwpx');
+
+  assert.equal(result.status, 'openable');
+  assert.equal(result.reason, 'github-blob-document');
+  assert.equal(
+    result.resolvedUrl,
+    'https://raw.githubusercontent.com/edwardkim/rhwp/main/samples/hwpx/sample.hwpx',
+  );
+});
+
+test('classifyDocumentUrl은 raw.githubusercontent HWP URL을 openable로 분류', () => {
+  const raw = 'https://raw.githubusercontent.com/edwardkim/rhwp/main/samples/2010-01-06.hwp';
+  const result = classifyDocumentUrl(raw);
+
+  assert.equal(result.status, 'openable');
+  assert.equal(result.reason, 'github-raw-document');
+  assert.equal(result.resolvedUrl, raw);
+});
+
+test('classifyDocumentUrl은 GitHub edit HWP URL을 not-document로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/edit/main/samples/2010-01-06.hwp');
+
+  assert.equal(result.status, 'not-document');
+  assert.equal(result.reason, 'github-edit-page');
+});
+
+test('classifyDocumentUrl은 GitHub commits HWP URL을 not-document로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/commits/main/samples/2010-01-06.hwp');
+
+  assert.equal(result.status, 'not-document');
+  assert.equal(result.reason, 'github-commits-page');
+});
+
+test('classifyDocumentUrl은 GitHub blame HWP URL을 not-document로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/blame/main/samples/2010-01-06.hwp');
+
+  assert.equal(result.status, 'not-document');
+  assert.equal(result.reason, 'github-blame-page');
+});
+
+test('classifyDocumentUrl은 GitHub tree URL을 not-document로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/tree/main/samples');
+
+  assert.equal(result.status, 'not-document');
+  assert.equal(result.reason, 'github-tree-page');
+});
+
+test('classifyDocumentUrl은 GitHub blob의 query 위장 HWP를 not-document로 분류', () => {
+  const result = classifyDocumentUrl('https://github.com/edwardkim/rhwp/blob/main/README.md?file=sample.hwp');
+
+  assert.equal(result.status, 'not-document');
+  assert.equal(result.reason, 'github-blob-non-document');
+});
+
+test('classifyDocumentUrl은 일반 직접 HWP URL을 openable로 분류', () => {
+  const url = 'https://example.com/files/sample.hwp';
+  const result = classifyDocumentUrl(url);
+
+  assert.equal(result.status, 'openable');
+  assert.equal(result.reason, 'document-path');
+  assert.equal(result.resolvedUrl, url);
+});
+
+test('classifyDocumentUrl은 query에만 HWP가 있는 일반 URL을 unknown으로 분류', () => {
+  const result = classifyDocumentUrl('https://example.com/download?file=sample.hwp');
+
+  assert.equal(result.status, 'unknown');
+  assert.equal(result.reason, 'no-document-path');
+});
+
+test('classifyGithubDocumentUrl은 URL 객체만 처리', () => {
+  assert.equal(
+    classifyGithubDocumentUrl('https://github.com/edwardkim/rhwp/blob/main/a.hwp'),
+    null,
+  );
 });


### PR DESCRIPTION
## 요약

GitHub의 실제 HWP/HWPX 파일 다운로드 URL이 아닌 `edit`, `commits`, `blame`, `tree` 페이지 URL에 rhwp 배지와 hover 미리보기가 생성되는 오탐을 정정합니다.

## 변경 내용

- `document-url-resolver`에 정적 URL classifier를 추가했습니다.
  - GitHub `blob` HWP/HWPX URL과 `raw.githubusercontent.com` 직접 문서 URL은 `openable`
  - GitHub `edit`, `commits`, `blame`, `tree` URL은 `not-document`
  - 일반 직접 `.hwp/.hwpx` pathname URL은 기존처럼 허용
  - query 문자열에만 `.hwp/.hwpx`가 있는 경우는 후보에서 제외
- Chrome/Firefox/Safari content script의 배지/hover/prefetch 후보 판정을 URL pathname 기반으로 좁혔습니다.
- `data-hwp="true"` 명시 링크 정책은 유지했습니다.
- 최신 `upstream/devel` 기준으로 포팅해 `fetch-security` 및 최신 content script 보강과 함께 검증했습니다.

## 검증

- [x] `node --test rhwp-shared/sw/document-url-resolver.test.js`
- [x] `node rhwp-chrome/sw/fetch-security.test.mjs`
- [x] `node --test rhwp-shared/sw/download-interceptor-common.test.js`
- [x] `node --check rhwp-chrome/content-script.js`
- [x] `node --check rhwp-firefox/content-script.js`
- [x] `node --check rhwp-safari/src/content-script.js`
- [x] `npm run build` (`rhwp-chrome`)
- [x] `npm run build` (`rhwp-firefox`)

## 수동 확인
| Chrome | Firefox |
|---|---|
|<img width="500" alt="image" src="https://github.com/user-attachments/assets/86a0e577-a005-4e47-b25c-79d94ae996a8" />|<img width="500" alt="image" src="https://github.com/user-attachments/assets/11208e03-9b9f-463d-ac81-3c06ce908e9c" />|

- [x] Chrome `rhwp-chrome/dist` 로드 후 GitHub #1520 재현 페이지 확인
- [x] Firefox `rhwp-firefox/dist` 로드 후 GitHub #1520 재현 페이지 확인
- [x] `edit/main/samples/2010-01-06.hwp` 배지 미생성
- [x] `commits/main/samples/2010-01-06.hwp` 배지 미생성
- [x] `blob/main/samples/2010-01-06.hwp` 배지 생성
- [x] raw URL 배지 생성

Closes #1520
