### PR TITLE
Task #1523: 문서 개요/조문 구조 추출 (export-structure)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -58,6 +58,14 @@ HWP/HWPX → PDF (svg2pdf + pdf-writer).
 - `-o`, `-p`, `--show-para-marks`, `--show-control-codes`, `--respect-vpos-reset`
 - JSON: `{type, bbox:{x,y,w,h}, children:[...]}` (Page → PageBg/Line/TextRun/Image/Table/Shape …)
 
+### `export-structure <파일> [--mode auto|outline|clause] [-o out.json]`
+문서 **개요/조문 계층**을 중첩 JSON 트리로 추출 (조문 DB화·목차 생성용). 파서/렌더 무변경 읽기 질의.
+- `--mode outline`: IR 개요 수준(`ParaShape.para_level`/head_type) 기반.
+- `--mode clause`: 법률 조문 텍스트 패턴(편·장·절·관·조 / 항①②③ / 호1. / 목가.) 기반.
+- `--mode auto`(기본): 개요 head_type 있으면 outline, 없으면 clause.
+- JSON: `{mode, node_count, preamble, roots:[{level,kind,marker,heading,section,paragraph,body,children}]}`.
+  비제목 문단은 직전 제목 노드의 `body` 에 귀속. `-o` 생략 시 stdout.
+
 ---
 
 ## 2. 구조 덤프·진단 (Debug)

--- a/mydocs/pr/archives/pr_1524_review.md
+++ b/mydocs/pr/archives/pr_1524_review.md
@@ -1,0 +1,226 @@
+# PR #1524 검토 — 문서 개요/조문 구조 추출 (`export-structure`)
+
+- PR: https://github.com/edwardkim/rhwp/pull/1524
+- 관련 이슈: #1523 `feat: 문서 개요/조문 구조 추출 명령 (export-structure)`
+- 작성자: `planet6897` (Jaeuk Ryu)
+- 작성일: 2026-06-25
+- 처리 경로: collaborator-mediated 외부 PR
+- base/head: `edwardkim/rhwp:devel` <- `planet6897/rhwp:pr-task1523`
+- 문서 작성 시점 참고 head: `c65b467fedc3eaad56e6b87a34e6139afa724c0e`
+- 규모: 4 files, +394 / -0
+- label/milestone: `enhancement` / `v1.0.0`
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 최종 merge 전 최신 상태를 다시 확인한다.
+
+## 1. 요약 판단
+
+**코드 변경은 수용 가능. 문서 커밋을 PR head에 포함하고, 새 head 기준 CI 통과 후 approve 및 merge 진행 권고.**
+
+PR #1524는 파서, 렌더러, 레이아웃, 직렬화 경로를 변경하지 않고 `Document` IR을 읽어 문서 개요/조문 구조를
+JSON 트리로 추출하는 조회 기능을 추가한다. 변경 범위는 `document_core::queries`의 신규 structure query,
+CLI 서브커맨드, 매뉴얼에 한정된다.
+
+1차 리뷰에서 발견한 CLI 계약 문제는 `c65b467f`에서 해소됐다. 최신 head 기준으로 help 문구, `-o` 값 누락
+오류, 미지원 `--output` 거부 동작을 재확인했고, 로컬 검증과 GitHub Actions도 통과했다.
+
+남는 위험은 주로 구조 추출 휴리스틱의 범위와 JSON/API 계약의 향후 호환성이다. 현재 PR 목적이 "읽기 전용
+초기 구조 추출 질의"라는 점을 고려하면 blocker는 아니다.
+
+## 2. 변경 범위
+
+| 파일 | 내용 |
+|---|---|
+| `src/document_core/queries/structure.rs` | `StructureMode`, `StructureDoc`, `StructureNode`, `build_structure()` 추가. `outline`/`clause`/`auto` 모드 지원 |
+| `src/document_core/queries/mod.rs` | `structure` 모듈 공개 |
+| `src/main.rs` | `export-structure` 서브커맨드와 CLI 옵션 처리 추가 |
+| `mydocs/manual/cli_commands.md` | `export-structure` 매뉴얼 추가 |
+
+커밋별 역할:
+
+| 커밋 | 내용 |
+|---|---|
+| `2d9370f5` | 구조 추출 쿼리, CLI, 매뉴얼, 단위 테스트 추가 |
+| `c65b467f` | `export-structure` help 블록 분리, `-o` 값 누락 오류 처리 추가 |
+
+## 3. 관련 이슈와 메타 판단
+
+이 PR은 #1523의 요구인 "문서 개요/조문 구조 추출 명령"을 직접 구현한다. 기능 추가 성격이므로 label은
+`enhancement`, milestone은 `v1.0.0`이 적절하다. 코드 변경은 파서/렌더 품질 개선이라기보다 사용자와 분석
+도구가 사용할 신규 조회 기능에 가깝다.
+
+PR 본문과 첫 커밋 메시지에는 `closes #1523`가 있으나, 문서 작성 시점 GitHub `closingIssuesReferences`는
+비어 있다. `devel` 대상 PR에서 자동 close가 실패할 수 있으므로 merge 후 #1523 상태 확인이 필요하다.
+
+## 4. 1차 리뷰 지적사항 재검증
+
+### 4.1 해결됨 - `rhwp --help` 옵션 블록 정합
+
+기존 문제는 `export-structure` help가 `export-render-tree`의 옵션 블록과 붙어 있어 `--output`, `-p`,
+`--show-para-marks` 같은 미지원 옵션을 안내하는 것이었다.
+
+최신 head에서는 `src/main.rs:85`부터 `export-render-tree` 옵션 블록이 끝난 뒤, `src/main.rs:94`부터
+`export-structure` 전용 블록이 분리되어 있다. 전용 안내는 다음 두 옵션만 포함한다.
+
+- `--mode <방식>`
+- `-o, --out <파일>`
+
+로컬 `rhwp --help` 출력에서도 `export-structure` 아래에 `--mode`, `-o/--out`만 표시되는 것을 확인했다.
+
+### 4.2 해결됨 - `-o` 값 누락 오류 처리
+
+기존 문제는 `export-structure FILE -o`가 오류 없이 stdout JSON 출력으로 진행되는 것이었다.
+
+최신 head에서는 `src/main.rs:657`부터 `-o | --out` 처리 시 다음 인자가 없으면
+`오류: -o 뒤에 출력 파일 경로가 필요합니다.`를 출력하고 return한다. 로컬 smoke에서도 동일 메시지를
+확인했다.
+
+### 4.3 의도된 동작 - `--output` 미지원
+
+`export-structure`는 파일 하나를 직접 쓰는 명령이고, 기존 `export-svg`/`export-render-tree`의 `--output`은
+출력 폴더 의미다. 최신 help와 매뉴얼은 `-o/--out`으로 통일되어 있다. 따라서 `--output`이
+`알 수 없는 옵션: --output`으로 거부되는 현재 동작은 문서와 구현이 일치한다.
+
+다만 명령군 전체 UX 관점에서는 장기적으로 `-o`의 long option 명명 규칙을 통일할지 별도 논의할 수 있다.
+이번 PR의 blocker는 아니다.
+
+## 5. 코드 검토
+
+### 5.1 구조 추출 모델
+
+`StructureDoc`은 `mode`, `node_count`, `preamble`, `roots`를 제공한다. `StructureNode`는 `level`, `kind`,
+`marker`, `heading`, `section`, `paragraph`, `body`, `children`을 제공한다. 비어 있는 `marker`, `body`,
+`children`, `preamble`은 `serde(skip_serializing_if = ...)`로 생략된다.
+
+이 JSON shape는 PR 설명과 매뉴얼의 `{mode, node_count, preamble, roots:[...]}` 계약과 맞다. 새 기능이 CLI로
+노출되므로 field 이름과 생략 정책은 사실상 외부 계약으로 간주해야 한다.
+
+### 5.2 outline 모드
+
+`classify_outline()`은 `ParaShape.head_type`이 `Outline` 또는 `Number`이면 heading으로 분류하고,
+`para_level + 1`을 JSON level로 내보낸다. `para_shape_id`가 범위를 벗어나면 `None`으로 처리한다.
+
+범위를 벗어난 `para_shape_id`를 오류로 만들지 않는 것은 조회 명령에서 안전하지만, 깨진 문서를 진단하려는
+사용자에게는 누락으로 보일 수 있다. 현재 PR 범위에서는 허용 가능한 선택이다.
+
+### 5.3 clause 모드
+
+`classify_clause()`는 문단 선두에서 다음 패턴을 인식한다.
+
+- 원문자 `①`부터 `⑳`
+- `제` + ASCII 숫자 + `편|장|절|관|조`
+- ASCII 숫자 + `.`
+- `가~하` + `.`
+
+초기 법령형 문서 구조 추출에는 충분한 최소 휴리스틱이다. 다만 한자 숫자, `1)`, `가)`, 로마자, 영문 목록,
+다단계 가지번호를 넓게 처리하지는 않는다. `제1조의2`는 heading으로는 검출되지만 marker는 `제1조`까지만
+저장된다.
+
+### 5.4 auto 모드
+
+`has_outline()`은 문서 전체에서 `HeadType::Outline | HeadType::Number`가 하나라도 있으면 effective mode를
+`outline`으로 선택한다. 이 정책은 문서가 한컴 개요/문단번호를 구조 제목으로 일관되게 사용하는 경우
+효율적이다.
+
+잔여 위험은 있다. 본문 중 일반 번호 문단이 `HeadType::Number`로 들어온 문서에서는 `auto`가 clause 검출을
+포기하고 outline mode로 전체 문서를 처리할 수 있다. 이는 기능의 의미상 한계로 문서화 또는 후속 개선 대상이지,
+읽기 전용 신규 명령의 merge blocker는 아니다.
+
+### 5.5 트리 attach 로직
+
+`build_structure()`는 heading을 만나면 stack top의 level이 새 heading level 이상인 동안 pop하여 부모에 붙이고,
+그 뒤 새 heading을 push한다. 문서 순서 기반 outline tree를 구성하는 일반적인 방식이다.
+
+비제목 문단은 첫 heading 이전이면 `preamble`, 이후면 현재 stack top의 `body`에 붙는다. "본문을 직전 제목에
+귀속"한다는 PR 설명과 일치한다. 다만 하위 heading 이후에 다시 상위 heading으로 돌아가기 전까지의 본문은
+가장 깊은 현재 heading에 붙으므로, 사용자가 기대하는 법령 본문 소속과 문서 패턴에 따라 다르게 느낄 수 있다.
+
+### 5.6 CLI 처리
+
+`export_structure()`는 `--mode`, `-o|--out`, positional file만 처리한다. 알 수 없는 option은 stderr 메시지 후
+return한다. 출력 파일을 지정하면 JSON을 파일에 쓰고 완료 메시지를 stdout에 출력한다. 출력 파일을 지정하지
+않으면 stdout에는 JSON만 출력한다.
+
+주의할 점:
+
+- positional file을 여러 개 넘기면 마지막 값이 사용된다.
+- 오류 경로에서 process exit code는 별도 설정하지 않는다. 기존 단순 CLI 스타일과 크게 다르지 않지만,
+  automation 사용자는 stderr 메시지를 확인해야 한다.
+
+## 6. 로컬 검증
+
+검증 worktree: `/private/tmp/rhwp-pr1524-latest`
+
+| 항목 | 결과 |
+|---|---|
+| `cargo fmt --check` | 통과 |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `cargo test --lib document_core::queries::structure -- --nocapture` | 통과, 3 passed |
+| `cargo build --release` | 통과 |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| `cargo test --release --lib` | 통과, 1937 passed / 6 ignored |
+| `rhwp --help` | `export-structure` 전용 옵션 블록 확인 |
+| `export-structure samples/basic/KTX.hwp --mode clause -o ...` | 통과, JSON 파일 생성 |
+| `export-structure samples/basic/KTX.hwp -o` | 명시 오류 확인 |
+| `export-structure samples/basic/KTX.hwp --output ...` | `알 수 없는 옵션: --output` 확인 |
+
+GitHub Actions는 문서 작성 시점 최신 PR head 기준으로 Build & Test, Canvas visual diff, CodeQL 계열이
+성공했다. WASM Build는 workflow 조건상 skipped 상태다. 문서 커밋을 PR head에 push하면 새 head 기준 CI를 다시
+기다려야 한다.
+
+## 7. Side Effect 평가
+
+- 파서, 렌더러, 레이아웃, 직렬화 경로는 변경하지 않는다.
+- `build_structure()`는 `&Document`를 읽기만 하며 문서 상태를 mutation하지 않는다.
+- 새 모듈은 `src/document_core/queries/mod.rs`에서 `pub mod structure`로 공개된다. crate API surface와 JSON
+  output schema가 새 계약이 된다.
+- stdout JSON 출력 경로와 file output 완료 메시지 경로는 분리되어 있다.
+- `serde_json::to_string_pretty()` 실패 가능성은 낮고, 실패 시 명시 오류를 출력한다.
+- 렌더 영향이 없으므로 golden snapshot 재생성은 필요하지 않다.
+- 변경량은 신규 파일 중심이라 기존 기능 회귀 가능성은 낮다.
+
+## 8. 잔여 위험 분류
+
+### Non-blocking
+
+- `auto` mode가 outline 하나만 발견해도 전체 문서를 outline으로 처리하는 정책.
+- `HeadType::Number`를 heading으로 간주해 일반 번호 문단을 과검출할 가능성.
+- `clause` 휴리스틱이 일부 법령/목록 표기 변형을 놓칠 가능성.
+- `1.` 일반 번호 목록을 `호`로 과검출할 가능성.
+- `제1조의2` marker가 `제1조`까지만 저장되는 제한.
+- 여러 positional input을 넘겼을 때 마지막 파일만 사용하는 단순 parser 정책.
+- 오류 시 exit code가 0일 수 있는 CLI 일관성 문제.
+
+### Follow-up 후보
+
+- 실제 법령 샘플 기반 `build_structure()` 통합 테스트 추가.
+- `auto` mode의 outline confidence 개선.
+- `--mode clause`에서 `제1조의2`, `1)`, `가)` 등 패턴 확장.
+- JSON schema를 문서화하고 backward compatibility 규칙 정리.
+- CLI 오류 경로의 exit code 정책 정리.
+
+## 9. 권고
+
+현재 코드 변경은 merge 수용 가능하다. 단, collaborator-mediated 외부 PR 처리 경로상 review 문서를 PR head에
+포함하는 문서 커밋이 아직 필요하다.
+
+권장 진행:
+
+1. 이 review 문서와 실행 계획서를 PR head에 별도 문서 커밋으로 추가한다.
+2. 문서 커밋 push 후 새 head 기준 GitHub Actions를 기다린다.
+3. CI 통과 후 최신 head 기준 GitHub review `Approve`를 남긴다.
+4. merge 전 `mergeable` / `mergeStateStatus`를 재확인한다.
+5. `BEHIND` 상태 처리 방식과 최종 merge는 작업지시자 승인 후 수행한다.
+
+## 10. merge 전 조건
+
+- PR head 최신 커밋 기준 GitHub Actions 통과.
+- review 문서가 PR diff에 포함됨.
+- GitHub review 또는 PR comment로 검토 결과를 contributor에게 남김.
+- merge 전 최신 `mergeable` / `mergeStateStatus` 재확인.
+- 작업지시자 승인.
+
+## 11. merge 후 확인
+
+PR 본문과 커밋 메시지에는 `closes #1523`가 있지만 GitHub `closingIssuesReferences`는 비어 있다.
+`devel` 대상 PR에서 자동 close가 실패할 수 있으므로, merge 후 #1523 상태를 확인하고 open이면 작업지시자
+승인 후 수동 close한다.

--- a/mydocs/pr/archives/pr_1524_review_impl.md
+++ b/mydocs/pr/archives/pr_1524_review_impl.md
@@ -1,0 +1,152 @@
+# PR #1524 검토 실행 계획서
+
+- PR: https://github.com/edwardkim/rhwp/pull/1524
+- 관련 이슈: #1523 `feat: 문서 개요/조문 구조 추출 명령 (export-structure)`
+- 작성일: 2026-06-25
+- 처리 경로: collaborator-mediated 외부 PR 처리 경로
+- base/head: `edwardkim/rhwp:devel` <- `planet6897/rhwp:pr-task1523`
+- 문서 작성 시점 참고 head: `c65b467fedc3eaad56e6b87a34e6139afa724c0e`
+- 문서 작성 범위: 최신 PR head 기준 review 계획 및 검토 문서 작성
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 최종 merge 전 최신 상태를 다시 확인한다.
+
+## 1. 적용 경로 판단
+
+PR #1524는 외부 contributor의 fork PR이며 `maintainerCanModify=true`이다. repository collaborator가 리뷰,
+문서화, merge 준비를 담당하므로 `mydocs/manual/pr_review_workflow.md` 9장의 collaborator-mediated 외부 PR
+처리 경로를 적용한다.
+
+이 경로에서는 review 문서를 해당 PR head에 직접 포함할 수 있다. contributor의 원 코드 커밋은 rewrite하지
+않고, 검토 기록은 별도 문서 커밋으로 분리한다.
+
+이번 요청 범위에서는 오늘할일(`mydocs/orders/{yyyymmdd}.md`)을 갱신하지 않는다.
+
+## 2. 현재까지의 사실 관계
+
+| 항목 | 내용 |
+|---|---|
+| PR 제목 | `Task #1523: 문서 개요/조문 구조 추출 (export-structure)` |
+| 작성자 | `planet6897` |
+| 관련 이슈 | #1523 |
+| label / milestone | `enhancement` / `v1.0.0` |
+| 변경 규모 | 4 files, +394 / -0 |
+| 커밋 수 | 2 commits |
+| 문서 작성 시점 참고 mergeability | `MERGEABLE`, `BEHIND` |
+| 문서 작성 시점 참고 CI | Build & Test, Canvas visual diff, CodeQL 계열 통과; WASM Build skipped |
+| 자동 close 참조 | GitHub `closingIssuesReferences`는 비어 있음 |
+
+커밋 구성:
+
+1. `2d9370f5` - `Task #1523: 문서 개요/조문 구조 추출 (export-structure)`
+2. `c65b467f` - `Task #1523: export-structure CLI 계약 정정 (help 정합 + -o 값 누락 오류)`
+
+두 번째 커밋은 1차 리뷰에서 지적한 CLI help 정합성과 `-o` 값 누락 처리 문제를 정정한다.
+
+## 3. 단계 계획
+
+### Stage 1 - 메타 및 범위 재확인
+
+- PR base가 `devel`인지 확인한다.
+- head branch와 head SHA를 확인한다.
+- `maintainerCanModify=true`인지 확인한다.
+- label/milestone이 이슈 #1523과 일치하는지 확인한다.
+- 변경 파일이 `document_core` 쿼리, CLI, 매뉴얼 범위를 벗어나지 않는지 확인한다.
+- `closingIssuesReferences`가 비어 있으므로 merge 후 이슈 상태 확인 필요성을 기록한다.
+
+### Stage 2 - 1차 리뷰 지적사항 재검증
+
+1차 리뷰에서 발견한 문제:
+
+- `rhwp --help`에서 `export-structure` 아래에 실제 없는 옵션이 노출됨.
+- `-o` 뒤 출력 경로가 빠져도 오류 없이 stdout JSON 출력으로 진행됨.
+
+재검증 항목:
+
+- `src/main.rs` help 출력에서 `export-render-tree`와 `export-structure` 옵션 블록이 분리됐는지 확인한다.
+- `export-structure` help가 `--mode`, `-o/--out`만 안내하는지 확인한다.
+- `export-structure FILE -o`가 명시 오류를 출력하는지 확인한다.
+- `export-structure FILE --output path`가 문서화되지 않은 옵션으로 거부되는지 확인한다.
+- `mydocs/manual/cli_commands.md`가 실제 구현과 같은 `-o/--out` 계약을 설명하는지 확인한다.
+
+### Stage 3 - 코드 구조 검토
+
+- `StructureMode::parse()`가 허용 mode를 `auto|outline|clause`로 제한하는지 확인한다.
+- `StructureDoc` / `StructureNode` JSON shape가 PR 설명과 일치하는지 확인한다.
+- `outline` 모드가 `ParaShape.head_type`과 `para_level`을 이용하는지 확인한다.
+- `clause` 모드가 조문형 heading 휴리스틱만 검사하는지 확인한다.
+- `auto` 모드가 outline 존재 여부로 effective mode를 결정하는 정책을 검토한다.
+- stack 기반 attach 로직이 같은 레벨/상위 레벨 전환 시 부모-자식 관계를 보존하는지 확인한다.
+- 비제목 문단이 첫 heading 이전에는 `preamble`, 이후에는 직전 heading의 `body`에 들어가는지 확인한다.
+- 함수가 `&Document`만 읽고 문서 모델을 mutation하지 않는지 확인한다.
+
+### Stage 4 - 로컬 검증
+
+실행한 검증:
+
+```bash
+cargo fmt --check
+git diff --check upstream/devel...HEAD
+cargo test --lib document_core::queries::structure -- --nocapture
+cargo build --release
+cargo clippy --all-targets -- -D warnings
+cargo test --release --lib
+```
+
+CLI smoke 검증:
+
+```bash
+rhwp --help
+rhwp export-structure samples/basic/KTX.hwp --mode clause -o /private/tmp/rhwp-pr1524-latest-ktx.json
+rhwp export-structure samples/basic/KTX.hwp -o
+rhwp export-structure samples/basic/KTX.hwp --output /private/tmp/rhwp-pr1524-latest-output.json
+```
+
+렌더러, 레이아웃, 파서, 직렬화 경로를 변경하지 않는 읽기 전용 질의이므로 `svg_snapshot`은 필수 검증에서
+제외한다. GitHub Actions의 Canvas visual diff가 통과했는지는 최신 head 기준으로 별도 확인한다.
+
+### Stage 5 - 잔여 위험 및 side effect 평가
+
+다음 항목을 review 문서에 명시한다.
+
+- `auto` 모드는 outline이 하나라도 있으면 전체 문서를 outline mode로 처리한다.
+- `HeadType::Number`를 outline heading으로 포함하므로 일반 번호 문단을 제목으로 과검출할 수 있다.
+- `clause` 모드는 법령형 텍스트 선두 패턴 휴리스틱이며, 한자 숫자/괄호형 번호/영문 목록 등은 제한적이다.
+- `제1조의2` 같은 가지번호는 heading으로는 잡히지만 marker는 `제1조`까지만 저장된다.
+- `1.` 일반 번호 목록은 `호`로 과검출될 수 있다.
+- 여러 positional file argument를 넘기면 마지막 값을 사용한다.
+- 오류 경로는 stderr 메시지 후 함수 return이며, process exit code는 기존 단순 CLI 스타일과 같이 0일 수 있다.
+- `pub mod structure`와 JSON field는 신규 외부 계약이 될 수 있다.
+- stdout mode에서는 JSON만 출력하고, file output mode에서만 완료 메시지를 출력한다.
+
+위 항목은 현재 PR의 merge blocker가 아니라 후속 개선 또는 사용 문서상 한계 고지 항목으로 분류한다.
+
+### Stage 6 - 문서 커밋 및 GitHub review 순서
+
+권장 순서:
+
+1. 최신 head 기준 review 문서 작성.
+2. review 문서만 별도 커밋으로 묶기.
+3. contributor fork의 PR head branch에 문서 커밋 push.
+4. 새 head 기준 GitHub Actions 완료 대기.
+5. 새 head 기준 검토 결과를 GitHub review `Approve`로 남기기.
+6. merge 전 최신 `mergeable` / `mergeStateStatus` 재확인.
+7. 작업지시자 승인 후 merge.
+
+문서 커밋 전 또는 문서 커밋 push 전 approval을 남기면 approval이 이전 head에 걸리므로 피한다.
+
+## 4. merge 전 최종 조건
+
+- PR head 최신 커밋 기준 GitHub Actions 통과.
+- review 문서가 PR diff에 포함됨.
+- GitHub review 또는 PR comment로 검토 결과를 contributor에게 남김.
+- merge 전 최신 `mergeable` / `mergeStateStatus` 재확인.
+- `BEHIND` 상태를 update branch로 해소할지, admin merge로 처리할지 작업지시자 승인.
+- 작업지시자 승인.
+
+## 5. merge 후 확인 항목
+
+- PR 본문과 첫 커밋 메시지에는 `closes #1523`가 있으나, GitHub `closingIssuesReferences`는 비어 있다.
+- merge 후 #1523 상태를 확인한다.
+- #1523이 open이면 작업지시자 승인 후 수동 close한다.
+- contributor 감사 코멘트와 검증 요약을 남긴다.
+- 필요 시 collaborator-mediated PR 처리 기록만 정리하고 별도 사후 문서 PR은 만들지 않는다.

--- a/src/document_core/queries/mod.rs
+++ b/src/document_core/queries/mod.rs
@@ -6,3 +6,4 @@ pub(crate) mod field_query;
 mod form_query;
 pub mod rendering;
 mod search_query;
+pub mod structure;

--- a/src/document_core/queries/structure.rs
+++ b/src/document_core/queries/structure.rs
@@ -1,0 +1,296 @@
+//! 문서 구조(개요/조문) 구조화 추출 — 조문 DB화용.
+//!
+//! 문단을 순회해 **개요 계층(ParaShape.para_level/head_type)** 또는 **법률 조문 패턴
+//! (편/장/절/관/조/항/호/목)** 으로 분류하여 중첩 트리(JSON)로 내보낸다. 본문(비제목) 문단은
+//! 직전 제목 노드의 `body` 에 귀속된다.
+//!
+//! 파서/렌더 무변경의 읽기 전용 질의(추가 기능). 자기 라운드트립·시각 충실도와 무관.
+
+use serde::Serialize;
+
+use crate::model::document::Document;
+use crate::model::style::HeadType;
+
+/// 분류 방식.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StructureMode {
+    /// 개요(Outline/Number head_type) 있으면 개요, 없으면 조문 패턴.
+    Auto,
+    /// IR 개요 수준(para_level)만 사용.
+    Outline,
+    /// 법률 조문 텍스트 패턴(제N조/①/1./가.)만 사용.
+    Clause,
+}
+
+impl StructureMode {
+    pub fn parse(s: &str) -> Option<Self> {
+        match s {
+            "auto" => Some(Self::Auto),
+            "outline" => Some(Self::Outline),
+            "clause" => Some(Self::Clause),
+            _ => None,
+        }
+    }
+}
+
+/// 구조 트리 노드.
+#[derive(Debug, Clone, Serialize)]
+pub struct StructureNode {
+    /// 계층 깊이(1=최상위).
+    pub level: u8,
+    /// 종류: "outline" | "편"|"장"|"절"|"관"|"조"|"항"|"호"|"목".
+    pub kind: &'static str,
+    /// 검출된 번호 마커(예: "제1조", "①", "1.", "가."). 개요(자동번호)는 빈 문자열.
+    #[serde(skip_serializing_if = "String::is_empty")]
+    pub marker: String,
+    /// 제목 문단 텍스트.
+    pub heading: String,
+    pub section: usize,
+    pub paragraph: usize,
+    /// 이 제목에 귀속된 본문(비제목) 문단들(비어있지 않은 것만).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub body: Vec<String>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub children: Vec<StructureNode>,
+}
+
+/// 문서 구조 추출 결과.
+#[derive(Debug, Clone, Serialize)]
+pub struct StructureDoc {
+    pub mode: &'static str,
+    pub node_count: usize,
+    /// 첫 제목 이전의 본문(서문).
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    pub preamble: Vec<String>,
+    pub roots: Vec<StructureNode>,
+}
+
+/// 제목 분류 결과.
+struct Heading {
+    level: u8,
+    kind: &'static str,
+    marker: String,
+}
+
+/// 개요(IR) 기반 제목 판정.
+fn classify_outline(doc: &Document, para_shape_id: u16) -> Option<Heading> {
+    let ps = doc.doc_info.para_shapes.get(para_shape_id as usize)?;
+    match ps.head_type {
+        HeadType::Outline | HeadType::Number => Some(Heading {
+            level: ps.para_level + 1, // 0~6 → 1~7
+            kind: "outline",
+            marker: String::new(),
+        }),
+        _ => None,
+    }
+}
+
+/// 법률 조문 텍스트 패턴 기반 제목 판정. 문단 텍스트 선두를 검사한다.
+fn classify_clause(text: &str) -> Option<Heading> {
+    let t = text.trim_start();
+    if t.is_empty() {
+        return None;
+    }
+    let chars: Vec<char> = t.chars().collect();
+
+    // 항: 원문자 ①(U+2460)~⑳(U+2473) 로 시작.
+    if let Some(&c0) = chars.first() {
+        if ('\u{2460}'..='\u{2473}').contains(&c0) {
+            return Some(Heading {
+                level: 6,
+                kind: "항",
+                marker: c0.to_string(),
+            });
+        }
+    }
+
+    // 편/장/절/관/조: "제" + 숫자 + 단위.
+    if chars[0] == '제' {
+        let mut i = 1;
+        while i < chars.len() && chars[i].is_ascii_digit() {
+            i += 1;
+        }
+        if i > 1 && i < chars.len() {
+            // 숫자와 단위 사이 공백 허용
+            let mut j = i;
+            while j < chars.len() && chars[j] == ' ' {
+                j += 1;
+            }
+            if let Some(&unit) = chars.get(j) {
+                let (kind, level) = match unit {
+                    '편' => ("편", 1u8),
+                    '장' => ("장", 2),
+                    '절' => ("절", 3),
+                    '관' => ("관", 4),
+                    '조' => ("조", 5),
+                    _ => ("", 0),
+                };
+                if level > 0 {
+                    let marker: String = chars[..=j].iter().collect();
+                    return Some(Heading {
+                        level,
+                        kind,
+                        marker,
+                    });
+                }
+            }
+        }
+    }
+
+    // 호: 숫자 + "." 로 시작 (예: "1.").
+    if chars[0].is_ascii_digit() {
+        let mut i = 0;
+        while i < chars.len() && chars[i].is_ascii_digit() {
+            i += 1;
+        }
+        if chars.get(i) == Some(&'.') {
+            let marker: String = chars[..=i].iter().collect();
+            return Some(Heading {
+                level: 7,
+                kind: "호",
+                marker,
+            });
+        }
+    }
+
+    // 목: 가~하 + "." 로 시작 (예: "가.").
+    const MOK: &str = "가나다라마바사아자차카타파하";
+    if MOK.contains(chars[0]) && chars.get(1) == Some(&'.') {
+        return Some(Heading {
+            level: 8,
+            kind: "목",
+            marker: chars[..=1].iter().collect(),
+        });
+    }
+
+    None
+}
+
+/// 문서가 개요(Outline/Number) head_type 을 하나라도 쓰는지.
+fn has_outline(doc: &Document) -> bool {
+    doc.sections.iter().any(|s| {
+        s.paragraphs.iter().any(|p| {
+            doc.doc_info
+                .para_shapes
+                .get(p.para_shape_id as usize)
+                .is_some_and(|ps| matches!(ps.head_type, HeadType::Outline | HeadType::Number))
+        })
+    })
+}
+
+/// 문서 구조 트리를 구성한다.
+pub fn build_structure(doc: &Document, mode: StructureMode) -> StructureDoc {
+    let effective = match mode {
+        StructureMode::Auto => {
+            if has_outline(doc) {
+                StructureMode::Outline
+            } else {
+                StructureMode::Clause
+            }
+        }
+        m => m,
+    };
+
+    let mut roots: Vec<StructureNode> = Vec::new();
+    let mut stack: Vec<StructureNode> = Vec::new();
+    let mut preamble: Vec<String> = Vec::new();
+    let mut node_count = 0usize;
+
+    // 스택 top(=부모)에 노드를 귀속.
+    fn attach(node: StructureNode, stack: &mut Vec<StructureNode>, roots: &mut Vec<StructureNode>) {
+        match stack.last_mut() {
+            Some(parent) => parent.children.push(node),
+            None => roots.push(node),
+        }
+    }
+
+    for (sec_idx, section) in doc.sections.iter().enumerate() {
+        for (para_idx, para) in section.paragraphs.iter().enumerate() {
+            let heading = match effective {
+                StructureMode::Outline => classify_outline(doc, para.para_shape_id),
+                StructureMode::Clause => classify_clause(&para.text),
+                StructureMode::Auto => unreachable!(),
+            };
+
+            match heading {
+                Some(h) => {
+                    // 같은/더 깊은 레벨은 닫고 부모에 귀속.
+                    while stack.last().is_some_and(|t| t.level >= h.level) {
+                        let n = stack.pop().unwrap();
+                        attach(n, &mut stack, &mut roots);
+                    }
+                    stack.push(StructureNode {
+                        level: h.level,
+                        kind: h.kind,
+                        marker: h.marker,
+                        heading: para.text.clone(),
+                        section: sec_idx,
+                        paragraph: para_idx,
+                        body: Vec::new(),
+                        children: Vec::new(),
+                    });
+                    node_count += 1;
+                }
+                None => {
+                    let text = para.text.trim().to_string();
+                    if text.is_empty() {
+                        continue;
+                    }
+                    match stack.last_mut() {
+                        Some(top) => top.body.push(text),
+                        None => preamble.push(text),
+                    }
+                }
+            }
+        }
+    }
+
+    while let Some(n) = stack.pop() {
+        attach(n, &mut stack, &mut roots);
+    }
+
+    StructureDoc {
+        mode: match effective {
+            StructureMode::Outline => "outline",
+            StructureMode::Clause => "clause",
+            StructureMode::Auto => "auto",
+        },
+        node_count,
+        preamble,
+        roots,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn clause_detects_jo_hang_ho_mok() {
+        let cases = [
+            ("제1조(목적)", "조", 5u8),
+            ("제12장 보칙", "장", 2),
+            ("①사업자는", "항", 6),
+            ("1. 첫째 호", "호", 7),
+            ("가. 첫째 목", "목", 8),
+        ];
+        for (text, kind, level) in cases {
+            let h = classify_clause(text).unwrap_or_else(|| panic!("미검출: {text}"));
+            assert_eq!(h.kind, kind, "{text}");
+            assert_eq!(h.level, level, "{text}");
+        }
+    }
+
+    #[test]
+    fn clause_ignores_plain_text() {
+        assert!(classify_clause("일반 문장입니다").is_none());
+        assert!(classify_clause("").is_none());
+        assert!(classify_clause("제목 없음").is_none()); // "제"+비숫자
+    }
+
+    #[test]
+    fn clause_marker_extracted() {
+        assert_eq!(classify_clause("제3조 적용범위").unwrap().marker, "제3조");
+        assert_eq!(classify_clause("②다음").unwrap().marker, "②");
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -84,14 +84,18 @@ fn print_help() {
     println!();
     println!("  export-render-tree <파일.hwp> [옵션]");
     println!("      페이지별 render tree bbox JSON을 내보내기 (레이아웃 시각 분석용)");
-    println!("  export-structure <파일> [--mode auto|outline|clause] [-o out.json]");
-    println!("      문서 개요/조문(편·장·절·관·조·항·호·목) 계층을 중첩 JSON 트리로 추출");
     println!();
     println!("      -o, --output <폴더>     출력 폴더 (기본: output/)");
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
     println!("      --show-para-marks       문단부호(↵/↓) 표시 상태의 트리 생성");
     println!("      --show-control-codes    조판부호 보이기 상태의 트리 생성");
     println!("      --respect-vpos-reset    LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리");
+    println!();
+    println!("  export-structure <파일> [--mode auto|outline|clause] [-o out.json]");
+    println!("      문서 개요/조문(편·장·절·관·조·항·호·목) 계층을 중첩 JSON 트리로 추출");
+    println!();
+    println!("      --mode <방식>           분류 방식 auto|outline|clause (기본: auto)");
+    println!("      -o, --out <파일>        출력 JSON 파일 경로 (생략 시 stdout)");
     println!();
     println!("  export-png <파일.hwp> [옵션]   (native-skia feature 필요)");
     println!("      HWP 파일을 PNG로 내보내기 (Skia raster backend, AI 파이프라인 + VLM 연동)");
@@ -652,7 +656,13 @@ fn export_structure(args: &[String]) {
         match args[i].as_str() {
             "-o" | "--out" => {
                 i += 1;
-                out_path = args.get(i).cloned();
+                match args.get(i) {
+                    Some(p) => out_path = Some(p.clone()),
+                    None => {
+                        eprintln!("오류: -o 뒤에 출력 파일 경로가 필요합니다.");
+                        return;
+                    }
+                }
             }
             "--mode" => {
                 i += 1;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,6 +10,7 @@ fn main() {
         Some("--version") | Some("-V") => println!("rhwp v{}", rhwp::version()),
         Some("export-svg") => export_svg(&args[2..]),
         Some("export-render-tree") => export_render_tree(&args[2..]),
+        Some("export-structure") => export_structure(&args[2..]),
         Some("export-png") => export_png(&args[2..]),
         Some("export-pdf") => export_pdf(&args[2..]),
         Some("export-text") => export_text(&args[2..]),
@@ -83,6 +84,8 @@ fn print_help() {
     println!();
     println!("  export-render-tree <파일.hwp> [옵션]");
     println!("      페이지별 render tree bbox JSON을 내보내기 (레이아웃 시각 분석용)");
+    println!("  export-structure <파일> [--mode auto|outline|clause] [-o out.json]");
+    println!("      문서 개요/조문(편·장·절·관·조·항·호·목) 계층을 중첩 JSON 트리로 추출");
     println!();
     println!("      -o, --output <폴더>     출력 폴더 (기본: output/)");
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
@@ -635,6 +638,82 @@ fn export_render_tree(args: &[String]) {
         pages.len(),
         output_dir
     );
+}
+
+/// `export-structure` — 문서 개요/조문 계층을 중첩 JSON 트리로 추출 (조문 DB화용).
+fn export_structure(args: &[String]) {
+    use rhwp::document_core::queries::structure::{build_structure, StructureMode};
+
+    let mut file_path: Option<&str> = None;
+    let mut out_path: Option<String> = None;
+    let mut mode = StructureMode::Auto;
+    let mut i = 0;
+    while i < args.len() {
+        match args[i].as_str() {
+            "-o" | "--out" => {
+                i += 1;
+                out_path = args.get(i).cloned();
+            }
+            "--mode" => {
+                i += 1;
+                match args.get(i).and_then(|s| StructureMode::parse(s)) {
+                    Some(m) => mode = m,
+                    None => {
+                        eprintln!("오류: --mode 는 auto|outline|clause");
+                        return;
+                    }
+                }
+            }
+            other if other.starts_with('-') => {
+                eprintln!("알 수 없는 옵션: {other}");
+                return;
+            }
+            other => file_path = Some(other),
+        }
+        i += 1;
+    }
+
+    let Some(file_path) = file_path else {
+        eprintln!(
+            "사용법: rhwp export-structure <파일> [--mode auto|outline|clause] [-o out.json]"
+        );
+        return;
+    };
+
+    let data = match fs::read(file_path) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
+            return;
+        }
+    };
+    let doc = match rhwp::wasm_api::HwpDocument::from_bytes(&data) {
+        Ok(d) => d,
+        Err(e) => {
+            eprintln!("오류: HWP 파싱 실패 - {}", e);
+            return;
+        }
+    };
+
+    let st = build_structure(doc.document(), mode);
+    let json = match serde_json::to_string_pretty(&st) {
+        Ok(j) => j,
+        Err(e) => {
+            eprintln!("오류: JSON 직렬화 실패 - {}", e);
+            return;
+        }
+    };
+
+    match out_path {
+        Some(p) => match fs::write(&p, &json) {
+            Ok(_) => println!(
+                "구조 추출 완료: mode={} 노드={} → {}",
+                st.mode, st.node_count, p
+            ),
+            Err(e) => eprintln!("오류: 출력 쓰기 실패 - {}: {}", p, e),
+        },
+        None => println!("{json}"),
+    }
 }
 
 fn parse_grid_mm(value: &str) -> Option<f64> {


### PR DESCRIPTION
## 개요
문서의 **개요/조문 계층**(목차·장·절·조·항·호·목)을 중첩 JSON 트리로 추출하는 읽기 전용
질의를 신설한다. 기존 `export-text`/`export-markdown` 의 페이지 단위 평문과 달리 논리 구조를
보존한다. 목차 생성·조문 단위 DB화·문서 분석에 활용. (closes #1523)

## 변경
| 파일 | 내용 |
|------|------|
| `src/document_core/queries/structure.rs` | `build_structure(doc, mode)` + 조문 패턴 검출 + 단위 테스트 |
| `src/document_core/queries/mod.rs` | 모듈 등록 |
| `src/main.rs` | `export-structure` CLI |
| `mydocs/manual/cli_commands.md` | 매뉴얼 |

## 동작
- `--mode outline`: IR 개요 수준(`ParaShape.para_level`/head_type) 기반.
- `--mode clause`: 텍스트 패턴(편·장·절·관·조 / 항①②③ / 호1. / 목가.) 검출.
- `--mode auto`(기본): 개요 head_type 있으면 outline, 없으면 clause.
- 비제목 문단은 직전 제목 노드 `body` 에 귀속. 출력 `{mode,node_count,preamble,roots[{level,kind,marker,heading,section,paragraph,body,children}]}`.

## 검증
- `cargo test --lib document_core::queries::structure` — 3 passed (조/장/항/호/목 검출, 마커 추출, 일반문장 무시).
- 실문서 clause 모드로 호>목>항 중첩 트리 추출 확인. fmt/clippy/build 통과.
- 파서·렌더 무변경(추가 기능) → 라운드트립 회귀 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)