### PR TITLE
Task #1525 #1526: HWPX 직렬화 충실도 — 글머리표 + borderFill 이미지 채움

### DIFF
--- a/mydocs/pr/pr_1527_review.md
+++ b/mydocs/pr/pr_1527_review.md
@@ -1,0 +1,161 @@
+# PR #1527 최종 code review
+
+- PR: https://github.com/edwardkim/rhwp/pull/1527
+- 제목: `Task #1525 #1526: HWPX 직렬화 충실도 - 글머리표 + borderFill 이미지 채움`
+- 작성자: `planet6897` (Jaeuk Ryu)
+- 관련 이슈: #1525, #1526
+- 작성일: 2026-06-25
+- base/head: `edwardkim/rhwp:devel` `0ec4b976` <- `planet6897/rhwp:pr-task1525` `cc7c60c8`
+- 변경 규모: 3 files, +125 / -21
+- 처리 범위: code review, 로컬 검증, 수동 시각 검증 follow-up 문서화.
+
+## 1. 최종 판단
+
+**수용 권고. Blocking finding 없음.**
+
+PR #1527은 #1525와 #1526에서 확인된 HWPX serializer 누락을 좁은 범위에서 보완한다.
+
+1. `doc_info.bullets`를 `<hh:bullets>`로 직렬화해 글머리표 정의와 마커 글리프 소실을 막는다.
+2. `borderFill` image fill의 `<hc:img binaryItemIDRef=...>`를 직렬화해 셀/쪽 배경 이미지 소실을 막는다.
+3. 해당 수정으로 visual baseline의 기존 XFAIL 5건을 PASS로 승격한다.
+
+코드 변경은 parser/IR이 이미 보존하던 값의 serializer 누락을 메우는 형태라 방향이 타당하다. 로컬 검증과 GitHub CI 모두 PR head `cc7c60c8` 기준으로 통과했다.
+
+단, PR은 최신 `devel` 기준 `BEHIND` 상태다. 최신 `devel`과 merge-tree 수준의 충돌은 관찰되지 않았지만, 실제 merge 전에는 PR head update 또는 maintainer merge 정책을 확정해야 한다.
+
+수동 시각 검증 중 `2026_oss_rst.hwpx` 1페이지 제목 영역에 원본에는 없는 사각형 테두리가 roundtrip 후 생기는 별도 문제가 발견됐다. base/head roundtrip 모두에서 재현되므로 #1527 regression으로 보지 않고, 기존 roundtrip 잔존 버그로 #1531에 분리했다.
+
+## 2. GitHub 상태
+
+| 항목 | 상태 |
+|---|---|
+| PR state | `OPEN` |
+| Draft | false |
+| Mergeable | `MERGEABLE` |
+| Merge state | `BEHIND` |
+| Maintainer can modify | true |
+| Review decision | 비어 있음 |
+| Closing issues | GitHub API 기준 `closingIssuesReferences=[]` |
+| GitHub checks | Build & Test 성공, CodeQL 계열 성공, WASM Build skipped |
+
+`closingIssuesReferences`가 비어 있으므로, PR 본문에 이슈 닫힘 문구가 있더라도 merge 후 #1525/#1526 상태를 수동으로 확인하는 편이 안전하다.
+
+## 3. 변경 범위 검토
+
+| 파일 | 변경 | 판단 |
+|---|---|---|
+| `src/serializer/hwpx/header.rs` | `write_header()`에서 `write_bullets()` 호출 추가, `write_bullets()`/`write_bullet()` 구현, `borderFill` 직렬화에 `SerializeContext` 전달 | 타당 |
+| `src/serializer/hwpx/shape.rs` | `write_fill_brush()`가 `SerializeContext`를 받아 image fill의 manifest id를 해석하고 `<hc:img>` 방출 | 타당 |
+| `tests/visual_roundtrip_baseline.rs` | bullet 3건, imgBrush 2건을 `VISUAL_XFAIL`에서 제거 | head 검증에서 PASS하므로 타당 |
+
+## 4. 코드 리뷰 결과
+
+### 4.1 Bullet serializer
+
+`write_header()`의 refList 순서는 `fontfaces -> borderFills -> charProperties -> tabProperties -> numberings -> bullets -> paraProperties -> styles`로 유지된다. PR이 추가한 `<hh:bullets>` 위치는 기존 numbering 뒤, paraProperties 앞이라 schema 관찰 순서와 맞다.
+
+`write_bullets()`는 `doc_info.bullets.len()`을 `itemCnt`로 쓰고, 각 bullet을 1-based `id`로 직렬화한다. `char`는 `Bullet.bullet_char`, `useImage`는 `image_bullet > 0` 기준의 `"0"`/`"1"`로 방출한다. 현재 parser가 보존하는 핵심 값과 writer가 방출하는 값의 범위가 일치한다.
+
+`hh:paraHead level="0"`은 schema의 `positiveInteger` 표현과는 긴장이 있지만, PR 대상 샘플(`hy-002`, `footnote-01`, `2026_oss_rst`) 원본도 bullet paraHead에서 `level="0"`을 사용한다. 한컴 호환 관찰값을 따른 것으로 보이며 blocker로 보지 않는다.
+
+현재 parser/IR은 bullet의 자식 이미지나 `checkedChar` 전체를 보존하지 않는다. 따라서 image bullet의 실제 이미지 참조와 checked character까지 무손실로 다루는 것은 이번 PR 범위 밖이다.
+
+### 4.2 `borderFill` image fill serializer
+
+기존 `write_fill_brush()`의 `FillType::Image` 경로는 빈 `<hc:imgBrush>`만 쓰고 `binaryItemIDRef`를 누락했다. PR은 `SerializeContext::resolve_bin_id(img.bin_data_id)`가 성공할 때만 `<hc:img binaryItemIDRef=...>`를 방출한다.
+
+이 방식은 세 가지 점에서 안전하다.
+
+1. parser가 이미 `BorderFill.fill.image.bin_data_id`에 읽어 둔 값을 serializer가 역매핑한다.
+2. `content.hpf` manifest id를 `SerializeContext`에서 해석하므로 ZIP `BinData`와 manifest 사이의 3-way 정합을 깨지 않는다.
+3. 미등록 `bin_data_id`는 기존처럼 빈 `<hc:imgBrush mode=.../>`로 남겨 잘못된 `image0` 참조를 만들지 않는다.
+
+`bright`, `contrast`, `effect`도 현재 `ImageFill` 모델 값에서 직렬화된다. `alpha`는 항상 `"0"`으로 쓰이는데, header borderFill image alpha를 별도로 보존하는 IR이 현재 없으므로 이번 PR의 목적에는 부합한다. 향후 alpha까지 보존하려면 parser/IR 확장이 먼저 필요하다.
+
+### 4.3 공용 `write_fill_brush()` 영향
+
+`write_fill_brush()`는 `header.rs`의 `borderFill`과 `shape.rs`의 `write_rect()`가 공유한다. PR로 `write_rect()`에도 `ctx`가 전달되지만, 현재 body shape fill parser는 내부 `<hc:img>`의 `binaryItemIDRef`를 image fill의 `bin_data_id`로 캡처하지 않는 경로가 주된 상태다. 이 경우 `resolve_bin_id()`가 실패해 기존 빈 `imgBrush` fallback이 유지된다.
+
+따라서 이번 변경의 실질 효과는 PR 설명처럼 header `borderFill` image fill 보존에 집중된다. 공용 함수 변경으로 컴파일/테스트 회귀는 관찰되지 않았다.
+
+### 4.4 Visual baseline 승격
+
+`VISUAL_XFAIL`에서 제거된 5건은 head에서 `visual_roundtrip_baseline` 전체 테스트가 통과했다.
+
+| 샘플 | 기존 실패 원인 | PR 대응 |
+|---|---|---|
+| `hy-002.hwpx` | bullet definition 누락 | `<hh:bullets>` 직렬화 |
+| `footnote-01.hwpx` | bullet definition 누락 | `<hh:bullets>` 직렬화 |
+| `2026_oss_rst.hwpx` | bullet definition 누락 | `<hh:bullets>` 직렬화 |
+| `el-school-001.hwpx` | borderFill image fill 누락 | `<hc:img binaryItemIDRef>` 직렬화 |
+| `aift.hwpx` | borderFill image fill 누락 | `<hc:img binaryItemIDRef>` 직렬화 |
+
+잔여 XFAIL은 `143E433F503322BD33.hwpx`, `k-water-rfp.hwpx` 두 건으로 남아 있으며 이번 PR 범위와 분리된다.
+
+### 4.5 수동 시각 검증에서 발견한 별도 이슈
+
+PR #1527 수동 시각 검증 중 `2026_oss_rst.hwpx` 1페이지 상단 `< 결과보고서 작성 안내 >` 제목 영역에 원본에는 없는 사각형 테두리가 roundtrip 결과에 생기는 현상을 확인했다.
+
+이 현상은 PR base `0ec4b976`에서 생성한 `2026_oss_rst.rt.hwpx`와 PR head `cc7c60c8`에서 생성한 `2026_oss_rst.rt.hwpx` 양쪽에서 동일하게 재현된다. 따라서 #1527이 새로 만든 regression이 아니라 기존 HWPX roundtrip의 border/style 보존 문제로 판단한다.
+
+또한 기존 `render-diff`/`visual_roundtrip_baseline`은 이 1페이지 차이를 잡지 못했다. 해당 게이트가 주로 RenderNode 구조와 bbox 변위를 비교하기 때문에, 원본에 없던 선/테두리/stroke 스타일이 생겨도 bbox나 구조가 크게 변하지 않으면 통과할 수 있다. 이 한계와 기존 roundtrip 버그는 #1531로 분리 추적한다.
+
+## 5. 로컬 검증 결과
+
+검증 worktree: `/private/tmp/rhwp-pr1527-head`
+
+검증 head: `cc7c60c8`
+
+| 명령 | 결과 |
+|---|---|
+| `cargo fmt --check` | PASS |
+| `git diff --check 0ec4b976..HEAD` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --lib serializer::hwpx::header` | PASS, 25 passed |
+| `cargo test --lib serializer::hwpx::shape` | PASS, 14 passed |
+| `cargo test --lib serializer::hwpx::picture` | PASS, 18 passed |
+| `cargo test --lib serializer::hwpx::package_check` | PASS, 8 passed |
+| `cargo test --test issue_1058_textbox_list_header` | PASS, 10 passed |
+| `cargo test --test hwpx_roundtrip_baseline` | PASS, 4 passed |
+| `cargo test --test visual_roundtrip_baseline` | PASS, 3 passed |
+
+로컬 검증 중 `/private/tmp` worktree 생성 시 `pdf-large/hwpx/2026_oss_rst.pdf`에 대해 Git LFS pointer 경고가 한 번 출력됐다. PR 변경 파일이나 HWPX serializer 동작과 직접 관련 없는 기존 LFS 상태로 판단한다.
+
+## 6. 최신 devel 반영
+
+현재 `upstream/devel`은 `87959e46`까지 진행되어 PR base `0ec4b976` 이후 #1524가 추가로 merge되어 있다. GitHub도 PR #1527을 `BEHIND`로 표시한다.
+
+사전 merge-tree 확인에서는 충돌이 관찰되지 않았고, #1524 변경과 #1527 변경 영역은 분리되어 있다. 그래도 최종 merge 전에는 다음 중 하나를 선택해야 한다.
+
+1. PR head에 최신 `devel` merge commit을 올리고 CI를 다시 확인한다.
+2. 저장소 정책상 허용된다면 `BEHIND` 상태를 유지한 채 maintainer merge를 진행한다.
+
+외부 contributor의 contribution 보존 관점에서는 원 contributor의 두 commit을 rewrite/squash하지 않는 방식이 가장 명확하다. 리뷰 문서 커밋이나 최신화 커밋이 필요하다면 maintainer의 별도 commit으로 추가하고, 원 contributor commit의 author/commit message는 유지하는 편이 좋다.
+
+## 7. GitHub review 권고
+
+GitHub review는 **Approve 가능**으로 판단한다. Inline blocking comment는 남길 필요가 없다.
+
+리뷰 코멘트에 남길 핵심은 다음 정도면 충분하다.
+
+```text
+Reviewed the serializer changes for #1525/#1526. The patch fills the missing HWPX round-trip pieces in a narrow way: bullets are emitted in the expected header order, and borderFill image fills now resolve binData through SerializeContext before writing hc:img.
+
+Local checks passed on cc7c60c8: fmt, clippy, focused serializer tests, package_check, hwpx_roundtrip_baseline, and visual_roundtrip_baseline. No blocking findings.
+
+While doing manual visual comparison, I noticed an existing roundtrip issue in `2026_oss_rst.hwpx`: page 1 gets an extra rectangle border around the title area in both base and head roundtrip outputs. Since it reproduces before this PR, I do not consider it a #1527 regression; I filed it separately in #1531. It also highlights a limitation of the current geometry-based visual gate for stroke/style-only differences.
+
+The PR is still behind devel, so please update/merge with latest devel or confirm maintainer merge policy before final merge. I would preserve the contributor-authored commits rather than rewriting them.
+```
+
+## 8. Merge 전 체크리스트
+
+- [ ] 최신 `devel` 반영 방식을 결정한다.
+- [ ] 최신화 커밋을 올린다면 새 CI 완료 후 merge한다.
+- [ ] contributor commit 보존을 위해 squash/rebase rewrite 여부를 명시적으로 피한다.
+- [ ] merge 후 #1525/#1526이 자동 close되지 않으면 수동 comment/close 여부를 확인한다.
+- [ ] #1531은 base/head 모두 재현되는 기존 roundtrip 버그이므로 #1527 blocker로 처리하지 않는다.
+
+## 9. 결론
+
+PR #1527은 변경 범위, 코드 구조, 테스트 결과 모두 이슈 #1525/#1526 해결 방향과 맞다. 남은 결정은 코드 품질 문제가 아니라 merge 운영 문제다. 최신 `devel` 반영과 CI 확인만 정리되면 merge 준비가 된 PR로 판단한다.

--- a/mydocs/pr/pr_1527_review_impl.md
+++ b/mydocs/pr/pr_1527_review_impl.md
@@ -1,0 +1,210 @@
+# PR #1527 code review 계획서
+
+- PR: https://github.com/edwardkim/rhwp/pull/1527
+- 제목: `Task #1525 #1526: HWPX 직렬화 충실도 - 글머리표 + borderFill 이미지 채움`
+- 작성자: `planet6897` (Jaeuk Ryu)
+- 관련 이슈: #1525, #1526
+- 작성일: 2026-06-25
+- 처리 경로: 외부 contributor PR 일반 검토. 본 계획서 작성 당시 요청 범위는 로컬 review 계획서 작성이었으며 PR head push는 수행하지 않았다.
+- base/head: `edwardkim/rhwp:devel` `0ec4b976` <- `planet6897/rhwp:pr-task1525` `cc7c60c8`
+- 작성 시점 참고값: `MERGEABLE` / `BEHIND`, `maintainerCanModify=true`
+- 규모: 3 files, +125 / -21
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 최종 판단 전 최신 상태를 다시 확인한다.
+
+## 1. 목적
+
+PR #1527은 HWPX roundtrip serializer에서 누락되던 두 리소스를 보존하는 변경이다.
+
+1. #1525: `doc_info.bullets`를 `<hh:bullets>`로 직렬화해 글머리표 마커 글리프 소실을 막는다.
+2. #1526: `borderFill`의 image fill을 `<hc:imgBrush><hc:img binaryItemIDRef=.../></hc:imgBrush>`로 직렬화해 셀/쪽 배경 이미지 소실을 막는다.
+
+이 계획서는 최종 review 문서가 아니라, 코드 리뷰에서 확인할 축과 검증 순서를 정리한다. 계획서 작성 단계에서는 문서 push, PR head 수정, GitHub review 제출을 하지 않았다.
+
+## 2. 현재 PR 메타
+
+| 항목 | 내용 |
+|---|---|
+| base | `devel` |
+| head branch | `planet6897:pr-task1525` |
+| head SHA | `cc7c60c8c4939cb7dfec8316ff309752cc538187` |
+| commit 수 | 2 |
+| 변경 파일 | `src/serializer/hwpx/header.rs`, `src/serializer/hwpx/shape.rs`, `tests/visual_roundtrip_baseline.rs` |
+| GitHub CI | 작성 시점 head 기준 Build & Test, CodeQL 계열 통과. WASM Build skipped |
+| merge 상태 | `MERGEABLE`이나 `BEHIND` |
+| 연결 이슈 | #1525, #1526 둘 다 open. PR body는 `closes`를 쓰지만 API `closingIssuesReferences`는 비어 있어 merge 후 수동 확인 필요 |
+
+현재 `upstream/devel`은 `87959e46`까지 진행되어 PR base `0ec4b976` 이후 #1524 변경이 추가돼 있다. 최종 review 전 최신 devel과의 merge simulation이 필요하다.
+
+## 3. 커밋별 검토 범위
+
+| 커밋 | 내용 | 주요 검토 축 |
+|---|---|---|
+| `bfb2bf8b` | `write_bullets` / `write_bullet` 추가, `write_header`에서 `numberings -> bullets -> paraProperties` 순서로 방출 | header schema 순서, bullet id/char/useImage/paraHead 값, 기존 parser 보존 범위와 일치 여부 |
+| `cc7c60c8` | `write_fill_brush`에 `SerializeContext` 전달, `FillType::Image`에서 등록된 binData 참조 방출 | `borderFill` image fill의 3-way 정합, body shape fill call site 영향, 미등록 binData fallback |
+
+`tests/visual_roundtrip_baseline.rs`는 위 두 변경으로 PASS 승격된 샘플을 `VISUAL_XFAIL`에서 제거한다. baseline 목록 변경은 코드 변경의 결과로 타당한지 별도 검증한다.
+
+## 4. 코드 리뷰 체크리스트
+
+### 4.1 HWPX header 순서와 schema 정합
+
+- `write_header()`의 refList 방출 순서가 OWPML schema의 `numberings -> bullets -> paraProperties` 순서와 일치하는지 확인한다.
+- `<hh:bullets itemCnt=...>`가 `doc_info.bullets.len()`과 일치하는지 확인한다.
+- `<hh:bullet id=...>`가 실제 HWPX 관찰값과 같은 1-based id를 쓰는지 확인한다.
+- `char` 속성이 `Bullet.bullet_char`를 정확히 보존하는지 확인한다.
+- `useImage`가 schema boolean이지만 원본 샘플처럼 `"0"` / `"1"` 형식으로 허용되는지 확인한다.
+- `paraHead level="0"`은 schema의 positiveInteger와는 어긋나지만, `hy-002`, `footnote-01`, `2026_oss_rst` 원본 HWPX도 bullet paraHead에서 `level="0"`을 사용한다. 따라서 blocker로 단정하지 말고 원본 호환값으로 기록한다.
+
+### 4.2 Bullet serializer의 보존 범위
+
+- 현재 HWPX parser `parse_bullet_hwpx`는 `char`와 `useImage`만 읽고 자식 `paraHead`, `img`, `checkedChar`는 skip한다.
+- PR writer도 현재 IR이 보존하는 `char`와 `useImage` 중심으로 방출한다.
+- `checkedChar`와 image bullet의 실제 이미지 참조는 현재 parser/IR이 보존하지 않으므로 이번 PR 범위 밖으로 분류한다.
+- 다만 `useImage=1`이 들어왔을 때 `<hh:bullet useImage="1">`만 쓰고 자식 `<hh:img>`를 쓰지 않는 구조가 한컴/HWPX 소비자에게 어떤 의미인지 리스크로 기록한다.
+- 기존 #1058 parser 회귀 테스트와 충돌하지 않는지 확인한다.
+
+### 4.3 `imgBrush` / `binaryItemIDRef` 정합
+
+- `write_border_fills()`가 `SerializeContext`를 `write_border_fill()`로 전달하고, `write_border_fill()`이 `write_fill_brush()`에 전달하는 흐름을 확인한다.
+- `FillType::Image`에서 `ctx.resolve_bin_id(img.bin_data_id)`가 성공할 때만 `<hc:img>`를 방출하는지 확인한다.
+- 방출되는 `binaryItemIDRef`가 `content.hpf` manifest id와 ZIP `BinData/imageN.ext` entry에 대응하는지 확인한다.
+- `bright`, `contrast`, `effect`가 parser의 `ImageFill` 값과 역매핑되는지 확인한다.
+- 미등록 `bin_data_id`일 때 기존처럼 빈 `<hc:imgBrush mode=.../>`를 유지해 잘못된 참조를 만들지 않는지 확인한다.
+
+### 4.4 `write_fill_brush` 공용 함수의 blast radius
+
+- `write_fill_brush` call site는 `header.rs`의 `borderFill`과 `shape.rs`의 `write_rect`다.
+- `write_rect`도 `ctx`를 전달받게 되었으므로 body shape fill의 `FillType::Image` 동작이 바뀔 수 있다.
+- 현재 `parse_shape_fill_brush`는 `imgBrush`의 mode만 읽고 내부 `<hc:img>`의 `binaryItemIDRef`를 `Fill.image.bin_data_id`로 캡처하지 않는다. 따라서 body shape fill은 대체로 `bin_data_id=0`이고 `ctx.resolve_bin_id(0)` 실패로 기존 빈 `imgBrush` fallback을 유지할 가능성이 높다.
+- 이 전제를 실샘플 또는 unit test로 재확인한다. 만약 body shape image fill에서 `bin_data_id`가 들어오는 경로가 있으면 PR 설명 범위보다 동작 변화가 넓어지므로 별도 검토한다.
+
+### 4.5 Visual baseline 승격의 타당성
+
+- `VISUAL_XFAIL`에서 제거된 샘플 5개가 실제로 head에서 PASS하는지 확인한다.
+- 제거 사유가 두 변경과 직접 연결되는지 확인한다.
+  - `hy-002`, `footnote-01`, `2026_oss_rst`: bullet definition 누락 해소.
+  - `el-school-001`, `aift`: borderFill image fill 누락 해소.
+- 잔여 `VISUAL_XFAIL`이 `143E433F503322BD33.hwpx`, `k-water-rfp.hwpx` 두 건으로 남는 것이 현재 기준과 맞는지 확인한다.
+- baseline 목록을 줄이는 변경이므로 반드시 head에서 `visual_xfail_entries_still_fail`까지 같이 확인한다.
+
+## 5. 로컬 검증 계획
+
+검증은 현재 작업트리를 직접 오염시키지 않도록 `/private/tmp` 분리 worktree에서 수행한다.
+
+권장 worktree:
+
+| 구분 | 위치 | 커밋 |
+|---|---|---|
+| base | `/private/tmp/rhwp-pr1527-base` | `0ec4b976` |
+| head | `/private/tmp/rhwp-pr1527-head` | `cc7c60c8` |
+| latest merge simulation | `/private/tmp/rhwp-pr1527-merge` | `refs/remotes/codex/pr-1527` + `upstream/devel` |
+
+필수 명령:
+
+```bash
+cargo fmt --check
+git diff --check 0ec4b976..HEAD
+cargo test --test visual_roundtrip_baseline
+cargo test --test hwpx_roundtrip_baseline
+cargo test --test issue_1058_textbox_list_header
+cargo test --lib serializer::hwpx::header
+cargo test --lib serializer::hwpx::shape
+cargo clippy --all-targets -- -D warnings
+```
+
+상황에 따라 추가:
+
+```bash
+cargo test --lib serializer::hwpx::package_check
+cargo test --lib serializer::hwpx::picture
+cargo test --release --test visual_roundtrip_baseline
+```
+
+대형 샘플 포함 테스트는 시간이 걸릴 수 있으므로, 첫 검증은 debug profile로 수행하고 최종 merge 전에는 release 또는 CI 결과와 함께 판단한다.
+
+## 6. 직접 산출물 검사 계획
+
+대표 샘플을 roundtrip serialize한 뒤 `Contents/header.xml`, `content.hpf`, `BinData/`를 직접 확인한다.
+
+### Bullet 대표 샘플
+
+- `samples/hwpx/hy-002.hwpx`
+- `samples/hwpx/footnote-01.hwpx`
+- `samples/hwpx/2026_oss_rst.hwpx`
+
+확인 항목:
+
+- roundtrip output header에 `<hh:bullets itemCnt=...>`가 존재한다.
+- bullet chars가 원본과 동일하다. 예: `❏`, `※`, soft-hyphen, `❍`.
+- `ParaShape`의 `heading type="BULLET" idRef=...`가 참조하는 bullet id가 존재한다.
+- reparse 후 `doc_info.bullets.len()`과 `bullet_char`가 보존된다.
+- render geometry diff에서 구조 불일치가 사라진다.
+
+### imgBrush 대표 샘플
+
+- `samples/hwpx/el-school-001.hwpx`
+- `samples/hwpx/aift.hwpx`
+
+확인 항목:
+
+- roundtrip output header의 image borderFill에 `<hc:imgBrush mode=...>` 내부 `<hc:img binaryItemIDRef="imageN">`가 존재한다.
+- `imageN`이 `content.hpf` manifest에 존재한다.
+- `BinData/imageN.ext` ZIP entry가 존재한다.
+- `bright`, `contrast`, `effect`가 원본/IR과 일치한다.
+- reparse 후 `BorderFill.fill.image.bin_data_id`가 0으로 떨어지지 않는다.
+
+## 7. 최신 devel 반영 계획
+
+PR은 작성 시점 `BEHIND`다. 현재 `upstream/devel`에는 #1524 merge가 포함되어 있다.
+
+검토 단계:
+
+1. `git merge-tree 0ec4b976 refs/remotes/codex/pr-1527 upstream/devel`로 충돌 여부를 확인한다.
+2. 충돌이 없으면 review 문서에는 "최신 devel과 충돌 가능성 낮음"으로 기록하되, 실제 PR head update는 작업지시자 승인 전 수행하지 않는다.
+3. 최종 merge 준비 단계에서 `BEHIND`를 해소할지, admin merge로 처리할지 별도 승인받는다.
+
+사전 관찰: merge-tree는 충돌을 보고하지 않았고 #1524 변경과 #1527 변경 영역이 분리되어 있다. 단, 최종 판단 전 최신 upstream을 다시 fetch해야 한다.
+
+## 8. 예상 리스크 분류
+
+### Blocking 후보
+
+- roundtrip output에 `<hh:bullets>`가 나오지만 referenced bullet id와 실제 bullet id가 어긋나는 경우.
+- `<hc:img binaryItemIDRef>`가 manifest 또는 ZIP entry와 불일치하는 경우.
+- `visual_roundtrip_baseline`에서 새 PASS 승격 샘플이 여전히 실패하는 경우.
+- `write_fill_brush` signature 변경으로 다른 serializer call site가 누락되어 컴파일 또는 동작이 깨지는 경우.
+- 최신 devel merge에서 serializer/header/baseline 영역 충돌이 발생하는 경우.
+
+### Non-blocking 후보
+
+- `checkedChar`, image bullet의 자식 `<hh:img>` 미보존. 현재 parser/IR이 보존하지 않는 범위다.
+- bullet `paraHead`의 세부 속성은 원본 그대로가 아니라 최소 뼈대다. parser가 현재 무시하는 범위다.
+- body shape fill의 image reference는 여전히 미캡처로 빈 `imgBrush` fallback을 유지할 가능성이 높다. 이번 PR 목적은 borderFill image fill이다.
+- `imgBrush`의 `alpha`를 항상 `"0"`으로 쓰는 점. 기존 parser가 header borderFill image alpha를 별도 보존하지 않는다면 현재 범위에서는 허용 가능하지만 확인 필요하다.
+- PR body는 `closes #1525`, `closes #1526`를 쓰지만 GitHub API `closingIssuesReferences`가 비어 있다. merge 후 issue state 확인이 필요하다.
+
+## 9. review 문서 작성 계획
+
+최종 code review 문서(`mydocs/pr/pr_1527_review.md`)에는 다음을 포함한다.
+
+1. PR 메타와 변경 범위.
+2. #1525/#1526 원인과 PR 수정 지점의 대응 관계.
+3. 코드 리뷰 결과.
+4. 로컬 검증 결과.
+5. 최신 devel 반영 필요 여부.
+6. blocking findings 유무.
+7. merge 전 조건.
+8. merge 후 #1525/#1526 close 확인 계획.
+9. contributor contribution 보존 관점의 merge 방식 권고. 원 contributor 2 commits는 rewrite/squash하지 않고 유지하는 방향을 기본으로 한다.
+
+문서 push는 이 계획서와 최종 review 문서 검토 후, 작업지시자 승인 전에는 수행하지 않는다.
+
+## 10. 현재 결론
+
+현재까지의 1차 코드 독해 기준으로 변경 방향은 이슈 원인과 직접 맞는다. 다만 최종 review 전에는 다음 네 가지를 반드시 확인해야 한다.
+
+1. bullet id/char/useImage가 roundtrip 후 참조와 함께 보존되는지.
+2. `imgBrush`의 `binaryItemIDRef`가 manifest와 ZIP entry에 3-way로 정합하는지.
+3. visual baseline 승격 5건이 실제 head에서 PASS하는지.
+4. 최신 `upstream/devel`과의 merge 결과가 충돌 없이 유지되는지.

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -79,6 +79,7 @@ pub fn write_header(doc: &Document, ctx: &SerializeContext) -> Result<Vec<u8>, S
     write_char_properties(&mut w, &doc.doc_info, ctx)?;
     write_tab_properties(&mut w, &doc.doc_info)?;
     write_numberings(&mut w, &doc.doc_info)?;
+    write_bullets(&mut w, &doc.doc_info)?;
     write_para_properties(&mut w, &doc.doc_info, ctx)?;
     write_styles(&mut w, &doc.doc_info, ctx)?;
     end_tag(&mut w, "hh:refList")?;
@@ -827,6 +828,63 @@ fn write_numbering<W: Write>(
         )?;
     }
     end_tag(w, "hh:numbering")?;
+    Ok(())
+}
+
+// =====================================================================
+// <hh:bullets> — 글머리표 정의
+//
+// 종전 직렬화는 bullets 를 전혀 쓰지 않아 라운드트립에서 글머리표 정의(❏/※/❍ 등)가
+// 소실되고, 글머리표 문단의 마커 글리프가 렌더에서 사라졌다. 파서(parse_bullet_hwpx)는
+// `char`/`useImage` 만 읽으므로 그 둘 + paraHead 뼈대를 방출하면 round-trip 무손실이다.
+// =====================================================================
+fn write_bullets<W: Write>(w: &mut Writer<W>, doc_info: &DocInfo) -> Result<(), SerializeError> {
+    if doc_info.bullets.is_empty() {
+        return Ok(());
+    }
+    start_tag_attrs(
+        w,
+        "hh:bullets",
+        &[("itemCnt", &doc_info.bullets.len().to_string())],
+    )?;
+    for (idx, b) in doc_info.bullets.iter().enumerate() {
+        write_bullet(w, idx as u16, b)?;
+    }
+    end_tag(w, "hh:bullets")?;
+    Ok(())
+}
+
+fn write_bullet<W: Write>(
+    w: &mut Writer<W>,
+    id: u16,
+    b: &crate::model::style::Bullet,
+) -> Result<(), SerializeError> {
+    let id_s = (id + 1).to_string(); // 관찰: 1-based, ParaShape.numbering_id 참조와 정합
+    let char_s = b.bullet_char.to_string();
+    let use_image = if b.image_bullet > 0 { "1" } else { "0" };
+    start_tag_attrs(
+        w,
+        "hh:bullet",
+        &[("id", &id_s), ("char", &char_s), ("useImage", use_image)],
+    )?;
+    // paraHead 뼈대 (파서는 무시하나 OWPML 유효성/한컴 호환 위해 방출).
+    empty_tag(
+        w,
+        "hh:paraHead",
+        &[
+            ("level", "0"),
+            ("align", "LEFT"),
+            ("useInstWidth", "0"),
+            ("autoIndent", "1"),
+            ("widthAdjust", &b.width_adjust.to_string()),
+            ("textOffsetType", "PERCENT"),
+            ("textOffset", "50"),
+            ("numFormat", "DIGIT"),
+            ("charPrIDRef", &u32::MAX.to_string()),
+            ("checkable", "0"),
+        ],
+    )?;
+    end_tag(w, "hh:bullet")?;
     Ok(())
 }
 

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -270,7 +270,6 @@ fn write_border_fills<W: Write>(
     doc_info: &DocInfo,
     ctx: &SerializeContext,
 ) -> Result<(), SerializeError> {
-    let _ = ctx;
     if doc_info.border_fills.is_empty() {
         return Ok(());
     }
@@ -282,7 +281,7 @@ fn write_border_fills<W: Write>(
     // HWPX borderFill의 id는 1부터 시작 (관찰값: ref_empty.hwpx).
     // 그러나 rhwp parser는 인덱스 기반으로 저장하므로 id는 배열 인덱스 그대로 사용.
     for (idx, bf) in doc_info.border_fills.iter().enumerate() {
-        write_border_fill(w, idx as u16, bf)?;
+        write_border_fill(w, idx as u16, bf, ctx)?;
     }
     end_tag(w, "hh:borderFills")?;
     Ok(())
@@ -292,6 +291,7 @@ fn write_border_fill<W: Write>(
     w: &mut Writer<W>,
     id: u16,
     bf: &BorderFill,
+    ctx: &SerializeContext,
 ) -> Result<(), SerializeError> {
     // 속성 순서 (BorderFillType.cpp:64-68): id, threeD, shadow, centerLine, breakCellSeparateLine
     start_tag_attrs(
@@ -327,7 +327,7 @@ fn write_border_fill<W: Write>(
     // fillBrush: 도형과 동일한 fillBrush 구조를 공유한다.
     // 종전 Stage 1 은 빈 래퍼만 출력해 winBrush(배경색)/gradation/imgBrush 를
     // 전부 잃었다. 파서가 채운 Fill 을 shape 의 검증된 역매핑으로 직렬화한다.
-    super::shape::write_fill_brush(w, &bf.fill)?;
+    super::shape::write_fill_brush(w, &bf.fill, ctx)?;
 
     end_tag(w, "hh:borderFill")?;
     Ok(())
@@ -1464,7 +1464,13 @@ mod tests {
         bf.attr = (0b010 << 2) | (0b011 << 5);
 
         let mut writer = Writer::new(Vec::new());
-        write_border_fill(&mut writer, 0, &bf).expect("write borderFill");
+        write_border_fill(
+            &mut writer,
+            0,
+            &bf,
+            &SerializeContext::collect_from_document(&Default::default()),
+        )
+        .expect("write borderFill");
         let xml = String::from_utf8(writer.into_inner()).unwrap();
 
         assert!(
@@ -1495,7 +1501,13 @@ mod tests {
         };
 
         let mut writer = Writer::new(Vec::new());
-        write_border_fill(&mut writer, 5, &bf).expect("write borderFill");
+        write_border_fill(
+            &mut writer,
+            5,
+            &bf,
+            &SerializeContext::collect_from_document(&Default::default()),
+        )
+        .expect("write borderFill");
         let xml = String::from_utf8(writer.into_inner()).unwrap();
 
         assert!(
@@ -1511,7 +1523,13 @@ mod tests {
         // FillType::None + solid 없음 = 원본에 fillBrush 부재 → 미출력.
         let bf = BorderFill::default();
         let mut writer = Writer::new(Vec::new());
-        write_border_fill(&mut writer, 0, &bf).expect("write borderFill");
+        write_border_fill(
+            &mut writer,
+            0,
+            &bf,
+            &SerializeContext::collect_from_document(&Default::default()),
+        )
+        .expect("write borderFill");
         let xml = String::from_utf8(writer.into_inner()).unwrap();
         assert!(
             !xml.contains("fillBrush"),
@@ -1538,7 +1556,13 @@ mod tests {
         };
 
         let mut writer = Writer::new(Vec::new());
-        write_border_fill(&mut writer, 1, &bf).expect("write borderFill");
+        write_border_fill(
+            &mut writer,
+            1,
+            &bf,
+            &SerializeContext::collect_from_document(&Default::default()),
+        )
+        .expect("write borderFill");
         let xml = String::from_utf8(writer.into_inner()).unwrap();
 
         assert!(

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -86,7 +86,7 @@ pub fn write_rect<W: Write>(
     write_rotation_info(w, sa)?;
     write_rendering_info(w, sa)?;
     write_line_shape(w, &rect.drawing.border_line)?;
-    write_fill_brush(w, &rect.drawing.fill)?;
+    write_fill_brush(w, &rect.drawing.fill, ctx)?;
     write_shadow(w, &rect.drawing)?;
 
     // drawText: 글상자 내부 문단
@@ -604,6 +604,7 @@ fn write_win_brush<W: Write>(
 pub(crate) fn write_fill_brush<W: Write>(
     w: &mut Writer<W>,
     fill: &Fill,
+    ctx: &SerializeContext,
 ) -> Result<(), SerializeError> {
     match fill.fill_type {
         // FillType::None 이지만 solid 데이터가 보존돼 있으면(원본 winBrush 가
@@ -661,7 +662,36 @@ pub(crate) fn write_fill_brush<W: Write>(
                 _ => "TILE",
             };
             start_tag(w, "hc:fillBrush")?;
-            empty_tag(w, "hc:imgBrush", &[("mode", mode)])?;
+            // bin_data_id 가 ctx 에 등록돼 있으면 <hc:img> 참조를 방출(셀/쪽 배경 이미지
+            // 보존). 미등록(예: body shape 의 fill 파서가 bin_data_id 미캡처)이면 종전대로
+            // 빈 imgBrush — 잘못된 image0 참조로 3-way 단언을 깨지 않는다.
+            match ctx.resolve_bin_id(img.bin_data_id) {
+                Some(manifest_id) => {
+                    start_tag_attrs(w, "hc:imgBrush", &[("mode", mode)])?;
+                    let bright = img.brightness.to_string();
+                    let contrast = img.contrast.to_string();
+                    let effect = match img.effect {
+                        1 => "GRAY_SCALE",
+                        2 => "BLACK_WHITE",
+                        _ => "REAL_PIC",
+                    };
+                    empty_tag(
+                        w,
+                        "hc:img",
+                        &[
+                            ("binaryItemIDRef", manifest_id),
+                            ("bright", &bright),
+                            ("contrast", &contrast),
+                            ("effect", effect),
+                            ("alpha", "0"),
+                        ],
+                    )?;
+                    end_tag(w, "hc:imgBrush")?;
+                }
+                None => {
+                    empty_tag(w, "hc:imgBrush", &[("mode", mode)])?;
+                }
+            }
             end_tag(w, "hc:fillBrush")
         }
     }

--- a/tests/visual_roundtrip_baseline.rs
+++ b/tests/visual_roundtrip_baseline.rs
@@ -34,19 +34,15 @@ const VISUAL_XFAIL: &[(&str, &str)] = &[
     // renderingInfo. 도형 회전 전치(shape-001) — 레거시 도형 shape_attr 블록. 쪽 테두리
     // (expense_report) — pageBorderFill borderFillIDRef. 바탕쪽(exam 6종 + 온새미로) —
     // masterPage 직렬화. 잔여는 아래 (차트/표/각주/이미지 등 별개 원인).
+    // (승격) header 글머리표(bullet) 정의 직렬화 정정으로 hy-002 / footnote-01 /
+    // 2026_oss_rst 가 PASS 로 승격됨(❏/※/❍/soft-hyphen 마커 글리프 보존).
     ("143E433F503322BD33.hwpx", "차트 RawSvg→Placeholder 1페이지"),
     (
-        "2026_oss_rst.hwpx",
-        "459px 변위 + 구조 불일치 1페이지(TextRun)",
-    ),
-    (
         "el-school-001.hwpx",
-        "구조 불일치 1페이지(도형 변위는 #shape 정정으로 0)",
+        "구조 불일치 1페이지(셀 배경 이미지 imgBrush)",
     ),
-    ("hy-002.hwpx", "603px 변위 + 구조 불일치 1페이지"),
-    ("footnote-01.hwpx", "613px 변위 + 구조 불일치 4페이지(각주)"),
-    ("aift.hwpx", "621px 변위 + 구조 불일치 5페이지(대형)"),
-    ("k-water-rfp.hwpx", "622px 변위 + 구조 불일치 2페이지(대형)"),
+    ("aift.hwpx", "구조 불일치 5페이지(대형, 복합)"),
+    ("k-water-rfp.hwpx", "구조 불일치 2페이지(대형, 복합)"),
 ];
 
 /// 검사 제외 — 샘플 자체가 HWPX 패키지가 아님(HWP5 가 .hwpx 확장자로 저장됨).

--- a/tests/visual_roundtrip_baseline.rs
+++ b/tests/visual_roundtrip_baseline.rs
@@ -34,14 +34,10 @@ const VISUAL_XFAIL: &[(&str, &str)] = &[
     // renderingInfo. 도형 회전 전치(shape-001) — 레거시 도형 shape_attr 블록. 쪽 테두리
     // (expense_report) — pageBorderFill borderFillIDRef. 바탕쪽(exam 6종 + 온새미로) —
     // masterPage 직렬화. 잔여는 아래 (차트/표/각주/이미지 등 별개 원인).
-    // (승격) header 글머리표(bullet) 정의 직렬화 정정으로 hy-002 / footnote-01 /
-    // 2026_oss_rst 가 PASS 로 승격됨(❏/※/❍/soft-hyphen 마커 글리프 보존).
+    // (승격) header 글머리표(bullet) 정의 직렬화 → hy-002/footnote-01/2026_oss_rst PASS.
+    // (승격) borderFill 이미지 채움(imgBrush<hc:img>) 직렬화 → el-school-001/aift PASS.
+    // 잔여: 차트(객체 직렬화), k-water-rfp(대형 복합).
     ("143E433F503322BD33.hwpx", "차트 RawSvg→Placeholder 1페이지"),
-    (
-        "el-school-001.hwpx",
-        "구조 불일치 1페이지(셀 배경 이미지 imgBrush)",
-    ),
-    ("aift.hwpx", "구조 불일치 5페이지(대형, 복합)"),
     ("k-water-rfp.hwpx", "구조 불일치 2페이지(대형, 복합)"),
 ];
 


### PR DESCRIPTION
## 개요
HWPX 라운드트립에서 직렬화 누락으로 소실되던 두 요소를 보존한다(둘 다 IR·파서·렌더러는
정상, 직렬화만 누락). render-diff 게이트로 검출·승격 검증.

### 1. 글머리표(bullet) 정의 — closes #1525
header 가 `<hh:bullets>` 를 전혀 쓰지 않아 글머리표 정의(❏/※/❍/soft-hyphen)가 소실되고
마커 글리프가 렌더에서 사라졌다. `write_bullets`/`write_bullet` 추가(numbering 패턴 동형,
numberings→bullets→paraProperties 순서). 파서가 char/useImage 만 읽으므로 그 둘 +
paraHead 뼈대로 round-trip 무손실.

### 2. borderFill 이미지 채움(imgBrush) — closes #1526
`write_fill_brush` FillType::Image 가 빈 `<hc:imgBrush>` 만 출력하고 `<hc:img
binaryItemIDRef>` 를 빠뜨려 셀·쪽 배경 이미지가 소실됐다. ctx 를 전달해 bin_data_id 등록
시 `<hc:img>` 방출(picture write_img 와 동일 매핑), 미등록이면 종전 빈 출력 유지(3-way
단언 보호).

## 검증 (render-diff 시각 게이트)
- 글머리표: hy-002 / footnote-01 / 2026_oss_rst STRUCT → PASS.
- 이미지: el-school-001 / aift STRUCT → PASS. 합계 **+5 승격**.
- `cargo test --test visual_roundtrip_baseline` — 3 passed.
- `cargo test --test hwpx_roundtrip_baseline` — 4 passed (check_package/3-way 정합, IR 회귀 없음).
- 전수 게이트 PASS 회귀 0. fmt / clippy 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)