### PR TITLE
Task #1529: HWPX 직렬화 — OLE 개체(<hp:ole>) 데이터 참조 보존

### DIFF
--- a/mydocs/pr/archives/pr_1530_report.md
+++ b/mydocs/pr/archives/pr_1530_report.md
@@ -1,0 +1,196 @@
+# PR #1530 사전 처리 판단 보고서 — HWPX OLE 개체 데이터 참조 보존
+
+- PR: https://github.com/edwardkim/rhwp/pull/1530
+- 제목: `Task #1529: HWPX 직렬화 — OLE 개체(<hp:ole>) 데이터 참조 보존`
+- 작성자: `planet6897` (Jaeuk Ryu)
+- 관련 이슈: #1529
+- 검토일: 2026-06-26
+- 검증 head: `d52a165c4e3d0c899b88de47ac38efecb7119a99`
+- 검증 worktree: `/private/tmp/rhwp-pr1530-head`
+- 처리 경로: collaborator-mediated 외부 PR 처리 경로
+- 문서 경로: `mydocs/pr/archives/pr_1530_review.md`, `mydocs/pr/archives/pr_1530_report.md`
+
+## 1. 사전 판단
+
+**수용 가능. Blocking finding 없음.**
+
+PR #1530은 HWPX roundtrip에서 `<hp:ole>`의 `binaryItemIDRef`가 누락되어
+`samples/hwpx/143E433F503322BD33.hwpx`의 차트 OLE가 `RawSvg`에서 placeholder로 강등되던
+문제를 좁은 범위에서 정정한다.
+
+검토 결과, 변경은 `ShapeObject::Ole` serializer dispatch와 `write_ole()` 추가, visual baseline 승격에
+한정된다. 로컬 테스트, 대상 샘플 `render-diff`, roundtrip 패키지 직접 검사, rhwp-studio 로드 확인 모두
+통과했다.
+
+작업지시자 시각 검증에서도 PR head roundtrip 파일은 차트가 정상 표시되고, PR 반영 전
+`upstream/devel` roundtrip 파일은 OLE 데이터 참조 누락으로 placeholder 강등이 재현됨을 확인했다.
+
+## 2. PR 상태
+
+| 항목 | 값 |
+|---|---|
+| state | open |
+| draft | false |
+| mergeable | `MERGEABLE` |
+| head SHA | `d52a165c4e3d0c899b88de47ac38efecb7119a99` |
+| 변경량 | 3 files, +85 / -10 |
+| GitHub review threads | 없음 |
+| `closingIssuesReferences` | 비어 있음. PR body는 `closes #1529`를 언급하므로 merge 후 #1529 상태 확인 필요 |
+
+GitHub Actions:
+
+| 체크 | 결과 |
+|---|---|
+| Build & Test | success |
+| Analyze (rust) | success |
+| Analyze (javascript-typescript) | success |
+| Analyze (python) | success |
+| CodeQL | success |
+| WASM Build | skipped |
+
+## 3. 변경 검토
+
+| 파일 | 변경 | 판단 |
+|---|---|---|
+| `src/serializer/hwpx/section.rs` | `ShapeObject::Ole`를 공용 shape XML 경로 대신 `write_ole()`로 dispatch | 타당 |
+| `src/serializer/hwpx/shape.rs` | `<hp:ole>` 전용 writer 추가. 공통 attr, `binaryItemIDRef`, shape attr block, extent, lineShape, sz/pos/outMargin/caption 방출 | 타당 |
+| `tests/visual_roundtrip_baseline.rs` | `143E433F503322BD33.hwpx`를 `VISUAL_XFAIL`에서 제거 | head 검증에서 PASS하므로 타당 |
+
+핵심 확인:
+
+- 원본 143E 샘플은 `<hp:ole binaryItemIDRef="ole3">`와 `BinData/ole3.ole`을 가진다.
+- PR head roundtrip 결과는 manifest id를 재생성해 `binaryItemIDRef="image3"`로 쓰지만,
+  `content.hpf id="image3"`와 `BinData/image3.OLE`가 함께 생성되어 3-way 참조가 맞다.
+- SVG 원본/roundtrip 모두 `hwp-ole-chart hwp-ole-chart-rust-svg` 그룹을 포함했고, `OLE 개체`
+  placeholder 문자열은 나오지 않았다.
+
+비차단 잔여:
+
+- 기존 HWPX parser/IR 범위상 `<hp:ole>` 원본 XML의 `id`, `numberingType="PICTURE"`,
+  manifest id 문자열 `ole3` 자체는 그대로 보존되지 않고 재생성된다. 이번 PR의 목표인 OLE 데이터 참조
+  보존과 시각 회귀 해소에는 영향이 없으며, 별도 무손실 XML 보존 범위로 분리하는 것이 맞다.
+
+## 4. 로컬 검증
+
+| 명령 | 결과 |
+|---|---|
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `cargo fmt --check` | 통과 |
+| `cargo test --lib serializer::hwpx::shape` | 통과, 14 passed |
+| `cargo test --test hwpx_roundtrip_baseline` | 통과, 4 passed |
+| `cargo test --test visual_roundtrip_baseline` | 통과, 3 passed |
+| `cargo test --test issue_1156_chart_column_flow` | 통과, 2 passed |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| `rhwp render-diff samples/hwpx/143E433F503322BD33.hwpx --via hwpx --max-disp 0.5` | PASS, page 1→1, max_disp 0.00px, struct mismatch 0 |
+| `rhwp hwpx-roundtrip samples/hwpx/143E433F503322BD33.hwpx -o output/poc/pr1530-roundtrip` | PASS, diff=0, r2=0 |
+
+PR 반영 전 `upstream/devel` 비교:
+
+| 항목 | 결과 |
+|---|---|
+| roundtrip 생성 | `hwpx-roundtrip` 자체는 PASS, diff=0, r2=0 |
+| `<hp:ole>` XML | `binaryItemIDRef` 없음 |
+| `render-diff --via hwpx` | `STRUCT_MISMATCH`, `Placeholder: 0→1`, `RawSvg: 1→0` |
+
+따라서 기존 `hwpx-roundtrip` PASS만으로는 OLE 시각 회귀를 검출할 수 없고,
+이번 PR의 `visual_roundtrip_baseline` 승격과 `render-diff` 구조 검증이 필요한 회귀 게이트다.
+
+Roundtrip 직접 검사:
+
+```text
+<hp:ole ... binaryItemIDRef="image3" ...>
+<hc:extent x="7200" y="7200"/>
+```
+
+```text
+content.hpf: <opf:item id="image3" href="BinData/image3.OLE" media-type="application/octet-stream" isEmbeded="1"/>
+ZIP:         BinData/image3.OLE
+```
+
+## 5. 시각 검증 산출물
+
+생성 위치:
+
+- `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx`
+- `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-ole-visual/original/143E433F503322BD33.svg`
+- `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-ole-visual/roundtrip/143E433F503322BD33.rt.svg`
+- `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-ole-visual/debug-original/143E433F503322BD33.svg`
+- `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-ole-visual/debug-roundtrip/143E433F503322BD33.rt.svg`
+
+확인 결과:
+
+- 원본/roundtrip SVG 모두 1페이지 우측 상단 차트가 Rust SVG OLE chart로 렌더된다.
+- `render-diff`는 구조 불일치 0, 최대 변위 0.00px다.
+- roundtrip SVG 크기는 원본 대비 36 bytes 차이가 있으나, OLE chart 그룹과 좌표는 동일하다.
+
+## 6. rhwp-studio 직접 검증 준비
+
+dev server:
+
+- URL: http://127.0.0.1:7700/
+- worktree: `/private/tmp/rhwp-pr1530-head`
+- 실행 명령: `cd /private/tmp/rhwp-pr1530-head/rhwp-studio && npm run dev -- --host 127.0.0.1 --port 7700`
+
+파일 선택용 경로:
+
+- 원본: `/private/tmp/rhwp-pr1530-head/samples/hwpx/143E433F503322BD33.hwpx`
+- roundtrip: `/private/tmp/rhwp-pr1530-head/output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx`
+
+URL 자동 로드:
+
+- 원본: http://127.0.0.1:7700/?url=%2Fsamples%2Fpr1530%2Foriginal-143E433F503322BD33.hwpx&filename=original-143E433F503322BD33.hwpx
+- roundtrip: http://127.0.0.1:7700/?url=%2Fsamples%2Fpr1530%2Froundtrip-143E433F503322BD33.rt.hwpx&filename=roundtrip-143E433F503322BD33.rt.hwpx
+
+브라우저 확인:
+
+- rhwp-studio 첫 화면 로드 성공, 콘솔 error/warn 없음.
+- 원본 URL 자동 로드 성공, 1페이지 canvas 렌더, 차트 표시.
+- roundtrip URL 자동 로드 성공, 1페이지 canvas 렌더, 차트 표시.
+- 두 파일 모두 `파일 로드 실패` 상태가 아니다.
+- 작업지시자가 PR head roundtrip 파일과 PR 반영 전 roundtrip 파일을 직접 열어 차이를 확인했다.
+
+주의:
+
+- Docker daemon이 실행 중이 아니어서 표준 `docker-compose --env-file .env.docker run --rm wasm` 빌드는 실패했다.
+- rhwp-studio 직접 검증을 위해 임시 worktree에서만 로컬 `wasm-pack build --target web` fallback을 사용했고,
+  생성된 `pkg/` 산출물을 `rhwp-studio/public/`에 복사했다. PR 반영 대상이 아니다.
+
+## 7. 권장 처리
+
+권고: **Approve 가능**.
+
+merge 전 확인:
+
+1. review 문서 커밋이 PR head diff에 포함되는지 확인한다.
+2. 문서 커밋 push 후 GitHub Actions 최신 상태 또는 review 문서 전용 fast-pass 결과를 확인한다.
+3. merge 전 최신 `mergeable` 상태를 다시 확인한다.
+4. merge 후 #1529가 자동 close되지 않으면 수동 close comment를 남긴다.
+
+GitHub review 코멘트 초안:
+
+```text
+PR #1530 head d52a165c 기준으로 검토했습니다.
+
+이번 변경은 HWPX serializer의 OLE 경로에 좁게 한정되어 있고, 확인한 원인과 직접 맞습니다. 기존 공용 shape writer 경로로 빠지면서 <hp:ole>의 데이터 참조가 빠지던 문제를, OLE 전용 writer에서 resolved binaryItemIDRef와 shape_attr/extent/line/size/position 정보를 함께 방출하도록 정정합니다.
+
+로컬 검증은 모두 통과했습니다.
+
+- cargo fmt --check
+- git diff --check
+- cargo test --lib serializer::hwpx::shape
+- cargo test --test hwpx_roundtrip_baseline
+- cargo test --test visual_roundtrip_baseline
+- cargo test --test issue_1156_chart_column_flow
+- cargo clippy --all-targets -- -D warnings
+
+대상 샘플 samples/hwpx/143E433F503322BD33.hwpx에 대해 render-diff는 page count 1->1, max displacement 0.00px, structure mismatch 0으로 통과했습니다. PR head roundtrip 패키지도 section0.xml의 binaryItemIDRef="image3", content.hpf의 id="image3", ZIP entry BinData/image3.OLE가 3-way로 정합합니다. rhwp-studio에서도 원본과 PR head roundtrip 파일 모두 OLE 차트가 placeholder가 아니라 차트로 표시됨을 확인했습니다.
+
+추가로 PR 반영 전 upstream/devel roundtrip 결과도 같은 샘플로 확인했습니다. 해당 파일은 <hp:ole>에서 binaryItemIDRef가 빠지고, render-diff가 RawSvg -> Placeholder 구조 불일치를 보고합니다. 따라서 이 PR은 의도한 회귀를 실제로 해소합니다.
+
+작업지시자 시각 검증 캡처 첨부 위치:
+
+- PR 반영 전 roundtrip 캡처: [여기에 placeholder로 강등된 화면 캡처 첨부 예정]
+- PR 반영 후 roundtrip 캡처: [여기에 OLE 차트가 정상 표시된 화면 캡처 첨부 예정]
+
+Blocking finding 없습니다. Approve합니다.
+```

--- a/mydocs/pr/archives/pr_1530_review.md
+++ b/mydocs/pr/archives/pr_1530_review.md
@@ -1,0 +1,222 @@
+# PR #1530 검토 기록 — HWPX OLE 개체 데이터 참조 보존
+
+- PR: https://github.com/edwardkim/rhwp/pull/1530
+- 제목: `Task #1529: HWPX 직렬화 — OLE 개체(<hp:ole>) 데이터 참조 보존`
+- 작성자: `planet6897` (Jaeuk Ryu)
+- 관련 이슈: #1529
+- 작성일: 2026-06-26
+- 처리 경로: collaborator-mediated 외부 PR 처리 경로. `maintainerCanModify=true`이므로 review 문서를
+  PR head의 `mydocs/pr/archives/`에 직접 포함한다.
+- base/head: `edwardkim/rhwp:devel` `48e9670` <- `planet6897/rhwp:pr-task-ole` `d52a165c`
+- 규모: 3 files, +85 / -10
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 변하는 값이므로 최종 판단 전 최신 상태를 다시 확인한다.
+
+## 1. 목적
+
+PR #1530은 HWPX roundtrip serializer에서 OLE 개체가 데이터 참조를 잃고 placeholder로 강등되는
+문제를 다룬다.
+
+대상 증상:
+
+- `samples/hwpx/143E433F503322BD33.hwpx`
+- roundtrip 후 1페이지 차트/OLE가 `RawSvg`에서 `Placeholder`로 바뀌는 구조 불일치
+- 연결 이슈: #1529 `HWPX 직렬화: OLE 개체(<hp:ole>) 데이터 참조 미보존 — placeholder 강등`
+
+이 문서는 코드 리뷰에서 확인할 축, 검증 순서, 최종 확인 결과를 함께 기록한다.
+
+## 2. 현재 PR 메타
+
+| 항목 | 내용 |
+|---|---|
+| state | open |
+| draft | false |
+| mergeable | `MERGEABLE` |
+| base | `devel` |
+| head branch | `planet6897:pr-task-ole` |
+| head SHA | `d52a165c4e3d0c899b88de47ac38efecb7119a99` |
+| commit 수 | 3 (`e6598e6a`, devel merge 2건) |
+| 변경 파일 | `src/serializer/hwpx/section.rs`, `src/serializer/hwpx/shape.rs`, `tests/visual_roundtrip_baseline.rs` |
+| GitHub comments/review threads | 작성 시점 없음 |
+| 연결 이슈 | PR body는 `closes #1529`를 언급하지만 GitHub API `closingIssuesReferences=[]`; merge 후 이슈 상태 수동 확인 필요 |
+
+PR body는 원래 "#1527 위에 쌓인 PR"이라고 설명한다. 최신 확인 기준 #1527은
+2026-06-25 04:02 UTC에 merge되었으므로, #1530 검토에서는 다음을 확인한다.
+
+1. #1527 변경이 base에 이미 들어온 뒤에도 #1530 고유 diff만 남는지.
+2. `VISUAL_XFAIL` 잔여 목록이 `k-water-rfp.hwpx`만 남는 방향이 맞는지.
+3. `143E433F503322BD33.hwpx` 승격이 #1530 OLE serializer 변경과 직접 연결되는지.
+
+## 3. 커밋별 검토 범위
+
+| 커밋 | 내용 | 주요 검토 축 |
+|---|---|---|
+| `e6598e6a` | `write_ole` 신설, OLE dispatch 연결, visual baseline 승격 | `<hp:ole>` XML 구조, binData 참조, extent/shape_attr 보존, 기존 shape serializer 영향 |
+| `639a75a` | `devel` merge | #1527 merge 이후 diff 오염 여부 |
+| `d52a165` | `devel` merge | 최신 base 정합, CI 재실행 상태 |
+
+## 4. 코드 리뷰 체크리스트
+
+### 4.1 OLE serializer 구조
+
+- `section.rs`가 `ShapeObject::Ole`를 기존 공용 shape writer가 아니라 `write_ole()`로 보내는지 확인한다.
+- `<hp:ole>`에 필요한 공통 속성과 OLE 전용 속성이 원본/IR과 맞게 직렬화되는지 확인한다.
+- `objectType`, `drawAspect`, `binaryItemIDRef`, `<hc:extent>`, shape attr 블록, lineShape,
+  size/position/outMargin/caption 방출 순서가 HWPX 관찰값과 호환되는지 확인한다.
+- picture writer와 공통 helper를 공유하는 경우 OLE에 맞지 않는 picture 전용 속성이 섞이지 않는지 확인한다.
+- caption이나 lineShape가 없는 OLE에서 빈 XML 또는 잘못된 기본값을 만들지 않는지 확인한다.
+
+### 4.2 binData 3-way 정합
+
+- `OleShape.bin_data_id`가 `SerializeContext::resolve_bin_id()`를 통해 `content.hpf` manifest id로 변환되는지 확인한다.
+- roundtrip 결과의 `binaryItemIDRef`가 `Contents/content.hpf`와 `BinData/*` ZIP entry에 모두 대응하는지 확인한다.
+- `bin_data_id`가 0이거나 미등록일 때 잘못된 `image0`/빈 참조가 생기지 않는지 확인한다.
+- parser가 roundtrip 결과를 다시 읽었을 때 `OleShape.bin_data_id`가 0으로 떨어지지 않는지 확인한다.
+- OLE 데이터 보존이 chart RawSvg 렌더 경로까지 이어져 `RawSvg -> Placeholder` 구조 손실이 사라지는지 확인한다.
+
+### 4.3 serializer 영향 범위
+
+- 변경이 HWPX serializer의 OLE 경로에만 국한되는지 확인한다.
+- picture/shape/group/table writer의 공통 helper 변경으로 다른 객체 직렬화가 바뀌지 않는지 확인한다.
+- `write_ole()`가 기존 `render_common_shape_xml` 경로에서 얻던 size/position/outMargin/caption 정보를 빠뜨리지 않는지 확인한다.
+- XML namespace와 element 이름이 `hp`, `hc` 기대 위치와 일치하는지 확인한다.
+
+### 4.4 visual baseline 승격
+
+- `tests/visual_roundtrip_baseline.rs`에서 `143E433F503322BD33.hwpx`가 `VISUAL_XFAIL`에서 제거되는지 확인한다.
+- 제거 후 `cargo test --test visual_roundtrip_baseline` 전체가 통과하는지 확인한다.
+- `visual_xfail_entries_still_fail` 기준으로 잔여 `k-water-rfp.hwpx`는 여전히 실패해야 한다.
+- 승격 이유가 PR body의 `RawSvg -> Placeholder` 해소와 직접 대응하는지 `render-diff` 구조 delta로 확인한다.
+
+### 4.5 이슈/운영
+
+- #1529가 open 상태인지 최종 merge 전 다시 확인한다.
+- PR body의 `closes #1529`가 자동 close로 잡히지 않는 경우 merge 후 수동 확인 절차를 남긴다.
+- contributor commit은 rewrite/squash하지 않고 보존하는 방향을 기본으로 검토한다.
+- PR head에 maintainer merge commit 2건이 있으므로 최종 review 문서에서 author/merge 이력을 명확히 기록한다.
+
+## 5. 로컬 검증 계획
+
+검증은 현재 작업트리를 직접 오염시키지 않도록 `/private/tmp` 분리 worktree에서 수행한다.
+현재 로컬 작업트리에는 별도 수정이 있으므로 #1530 검증과 섞지 않는다.
+
+권장 worktree:
+
+| 구분 | 위치 | 커밋 |
+|---|---|---|
+| head | `/private/tmp/rhwp-pr1530-head` | `d52a165c` |
+| merge simulation | `/private/tmp/rhwp-pr1530-merge` | 최신 `upstream/devel` + PR head |
+
+준비 명령:
+
+```bash
+git fetch upstream pull/1530/head:codex/pr-1530
+git worktree add -B pr1530-head /private/tmp/rhwp-pr1530-head codex/pr-1530
+```
+
+필수 검증:
+
+```bash
+cargo fmt --check
+git diff --check upstream/devel..HEAD
+cargo test --lib serializer::hwpx::shape
+cargo test --test hwpx_roundtrip_baseline
+cargo test --test visual_roundtrip_baseline
+cargo test --test issue_1156_chart_column_flow
+cargo clippy --all-targets -- -D warnings
+```
+
+OLE 대상 샘플 집중 검증:
+
+```bash
+cargo run --bin rhwp -- render-diff samples/hwpx/143E433F503322BD33.hwpx --via hwpx --max-disp 0.5
+cargo run --bin rhwp -- hwpx-roundtrip samples/hwpx/143E433F503322BD33.hwpx -o output/poc/pr1530-roundtrip
+```
+
+roundtrip 산출물 직접 검사:
+
+```bash
+unzip -p output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx Contents/section0.xml | rg '<hp:ole|binaryItemIDRef|hc:extent'
+unzip -p output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx Contents/content.hpf | rg 'BinData|binaryItem'
+unzip -l output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx | rg 'BinData/'
+```
+
+## 6. 작업지시자 시각 검증 방법
+
+검증 산출물은 승인 후 다음 경로에 만든다.
+
+- `output/poc/pr1530-ole-visual/original/`
+- `output/poc/pr1530-ole-visual/roundtrip/`
+- `output/poc/pr1530-ole-visual/debug-original/`
+- `output/poc/pr1530-ole-visual/debug-roundtrip/`
+
+생성 명령:
+
+```bash
+cargo run --bin rhwp -- export-svg samples/hwpx/143E433F503322BD33.hwpx \
+  -o output/poc/pr1530-ole-visual/original
+
+cargo run --bin rhwp -- export-svg output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx \
+  -o output/poc/pr1530-ole-visual/roundtrip
+
+cargo run --bin rhwp -- export-svg samples/hwpx/143E433F503322BD33.hwpx \
+  -p 0 --debug-overlay -o output/poc/pr1530-ole-visual/debug-original
+
+cargo run --bin rhwp -- export-svg output/poc/pr1530-roundtrip/143E433F503322BD33.rt.hwpx \
+  -p 0 --debug-overlay -o output/poc/pr1530-ole-visual/debug-roundtrip
+```
+
+작업지시자 확인 포인트:
+
+1. `original`과 `roundtrip`의 1페이지 SVG를 나란히 연다.
+2. 차트/OLE 영역이 roundtrip 후 회색 placeholder 또는 `OLE 개체`/`차트` 텍스트로 바뀌지 않는지 확인한다.
+3. 차트 위치, 크기, 본문 흐름, 페이지 수가 원본과 눈에 띄게 달라지지 않는지 확인한다.
+4. debug overlay에서 OLE 주변 문단/표 경계가 원본과 roundtrip 사이에 크게 이동하지 않는지 확인한다.
+5. 가능하면 한컴 2022 편집기에서 원본 HWPX와 roundtrip HWPX를 열어 1페이지 차트 영역을 비교한다.
+
+주의: `render-diff`와 SVG 비교는 rhwp 내부 roundtrip 회귀 게이트다. 한컴 편집기 직접 출력이 가능하면
+그 결과가 시각 판정의 1차 권위 자료다.
+
+## 7. 예상 리스크 분류
+
+### Blocking 후보
+
+- `binaryItemIDRef`가 `content.hpf` manifest 또는 ZIP `BinData` entry와 불일치하는 경우.
+- roundtrip 후 `OleShape.bin_data_id`가 0으로 떨어져 placeholder가 계속 발생하는 경우.
+- `visual_roundtrip_baseline`에서 `143E433F503322BD33.hwpx` 승격 후 실패하는 경우.
+- `write_ole()`가 기존 공통 writer의 size/position/outMargin/caption을 누락해 배치가 바뀌는 경우.
+- picture/shape serializer가 함께 회귀하는 경우.
+
+### Non-blocking 후보
+
+- OLE 내부 데이터 자체의 완전한 의미 해석은 이번 PR 범위 밖이다.
+- 한컴 정답지 대비 차트 내부 그래픽 충실도 문제는 기존 OLE chart renderer 범위와 분리한다.
+- `k-water-rfp.hwpx` visual xfail은 대형 복합 잔여 이슈로 이번 PR blocker로 보지 않는다.
+- GitHub API가 #1529 자동 close 연결을 잡지 못하면 merge 후 수동 확인 대상으로 둔다.
+
+## 8. review 문서 작성 계획
+
+최종 code review 문서에는 다음을 포함한다.
+
+1. PR 메타와 #1527 스택 해소 상태.
+2. #1529 원인과 PR 수정 지점의 대응 관계.
+3. `write_ole()` 코드 리뷰 결과.
+4. binData/content.hpf/BinData ZIP entry 3-way 정합 확인.
+5. 로컬 테스트와 `render-diff` 결과.
+6. 작업지시자 시각 검증 결과.
+7. blocking findings 유무.
+8. merge 전 조건과 merge 후 #1529 close 확인 계획.
+
+문서 커밋 push, GitHub Actions 확인, merge, PR merge comment, #1529 close comment는 2026-06-26
+작업지시자 요청에 따라 진행한다.
+
+## 9. 현재 결론
+
+현재까지의 PR 메타와 검증 결과 기준으로 변경 방향은 #1529 원인과 직접 맞는다.
+최종 review 전 확인 항목은 다음과 같이 완료했다.
+
+1. `<hp:ole>`의 `binaryItemIDRef`가 PR head roundtrip 결과에서 보존됨을 확인했다.
+2. `content.hpf`와 ZIP `BinData` entry가 참조와 3-way로 정합함을 확인했다.
+3. `143E433F503322BD33.hwpx`가 `visual_roundtrip_baseline`에서 PASS로 승격됨을 확인했다.
+4. 작업지시자 시각 검증에서 PR head roundtrip 후 OLE 차트가 placeholder로 강등되지 않음을 확인했다.
+5. PR 반영 전 `upstream/devel` roundtrip 파일은 `RawSvg -> Placeholder` 구조 불일치가 발생함을 확인했다.

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1179,7 +1179,15 @@ fn render_shape(shape: &ShapeObject, ctx: &mut SerializeContext) -> String {
             };
         }
         ShapeObject::Chart(ch) => ("chart", &ch.common, &ch.caption, None),
-        ShapeObject::Ole(o) => ("ole", &o.common, &o.caption, None),
+        ShapeObject::Ole(o) => {
+            return match writer_to_string(|w| super::shape::write_ole(w, o, ctx)) {
+                Ok(xml) => xml,
+                Err(e) => {
+                    eprintln!("[hwpx] Shape::Ole 직렬화 실패: {e}");
+                    String::new()
+                }
+            };
+        }
     };
     render_common_shape_xml(tag, c, caption, sa, ctx)
 }

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -20,7 +20,8 @@ use quick_xml::Writer;
 
 use crate::model::shape::{
     CommonObjAttr, DrawingObjAttr, HorzAlign, HorzRelTo, LineShape, ObjectNumberingType,
-    RectangleShape, ShapeComponentAttr, TextBox, TextFlow, TextWrap, VertAlign, VertRelTo,
+    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, TextBox, TextFlow, TextWrap,
+    VertAlign, VertRelTo,
 };
 use crate::model::style::{Fill, FillType, ImageFillMode, ShapeBorderLine, SolidFill};
 use crate::model::ColorRef;
@@ -233,6 +234,76 @@ pub fn write_container_close<W: Write>(
     // 설명 (#1392) — caption 직후
     write_shape_comment(w, common)?;
     end_tag(w, "hp:container")
+}
+
+// =====================================================================
+// <hp:ole> — OLE 개체 (차트 등 포함)
+//
+// 종전 직렬화는 OLE 를 legacy 공용 경로(sz/pos/outMargin 만)로 내보내 binaryItemIDRef·
+// extent·shape_attr 를 빠뜨렸다. 그 결과 라운드트립에서 OLE 데이터 참조가 소실되어
+// 렌더가 placeholder 로 강등됐다(143E: RawSvg→Placeholder). picture 패턴으로 복원한다.
+// =====================================================================
+pub(crate) fn write_ole<W: Write>(
+    w: &mut Writer<W>,
+    ole: &OleShape,
+    ctx: &mut SerializeContext,
+) -> Result<(), SerializeError> {
+    let c = &ole.common;
+    let id_str = c.instance_id.to_string();
+    let z_order = c.z_order.to_string();
+    let tw = text_wrap_str(c.text_wrap);
+    let tf = text_flow_str(c.text_flow);
+    // owned 으로 변환해 ctx 불변 borrow 를 즉시 해제(이후 write_caption 의 &mut 사용).
+    let bidref = ctx
+        .resolve_bin_id(ole.bin_data_id as u16)
+        .unwrap_or("")
+        .to_string();
+    let draw_aspect = match ole.drawing_aspect {
+        OleDrawingAspect::Icon => "ICON",
+        OleDrawingAspect::Thumbnail => "THUMBNAIL",
+        OleDrawingAspect::DocPrint => "DOCPRINT",
+        OleDrawingAspect::Content => "CONTENT",
+    };
+
+    start_tag_attrs(
+        w,
+        "hp:ole",
+        &[
+            ("id", &id_str),
+            ("zOrder", &z_order),
+            ("numberingType", numbering_type_str(c.numbering_type)),
+            ("textWrap", tw),
+            ("textFlow", tf),
+            ("lock", "0"),
+            ("dropcapstyle", "None"),
+            ("href", ""),
+            ("groupLevel", "0"),
+            ("instid", &id_str),
+            ("objectType", "UNKNOWN"),
+            ("binaryItemIDRef", &bidref),
+            ("hasMoniker", "0"),
+            ("drawAspect", draw_aspect),
+            ("eqBaseLine", "0"),
+        ],
+    )?;
+
+    // shape_attr 블록 (offset/orgSz/curSz/flip/rotationInfo/renderingInfo)
+    write_shape_component_block(w, &ole.drawing.shape_attr)?;
+    // 개체 영역
+    let ex = ole.extent_x.to_string();
+    let ey = ole.extent_y.to_string();
+    empty_tag(w, "hc:extent", &[("x", &ex), ("y", &ey)])?;
+    write_line_shape(w, &ole.drawing.border_line)?;
+    write_sz(w, c)?;
+    write_pos(w, c)?;
+    write_out_margin(w, c)?;
+    if let Some(cap) = &ole.caption {
+        write_caption(w, cap, ctx)?;
+    }
+    write_shape_comment(w, c)?;
+
+    end_tag(w, "hp:ole")?;
+    Ok(())
 }
 
 // =====================================================================

--- a/tests/visual_roundtrip_baseline.rs
+++ b/tests/visual_roundtrip_baseline.rs
@@ -30,14 +30,10 @@ const MAX_DISP: f64 = 0.5;
 /// 측정 기준: `rhwp render-diff --batch samples/hwpx` (2026-06-24).
 /// 이들 드리프트의 본질 정정은 별도 이슈(직렬화/레이아웃 회귀 위험으로 분리).
 const VISUAL_XFAIL: &[(&str, &str)] = &[
-    // 승격 이력: 514.12px 그룹 자식(보도자료 ×3 + hwpx-h-01) — 컨테이너 shape_attr + pic
-    // renderingInfo. 도형 회전 전치(shape-001) — 레거시 도형 shape_attr 블록. 쪽 테두리
-    // (expense_report) — pageBorderFill borderFillIDRef. 바탕쪽(exam 6종 + 온새미로) —
-    // masterPage 직렬화. 잔여는 아래 (차트/표/각주/이미지 등 별개 원인).
-    // (승격) header 글머리표(bullet) 정의 직렬화 → hy-002/footnote-01/2026_oss_rst PASS.
-    // (승격) borderFill 이미지 채움(imgBrush<hc:img>) 직렬화 → el-school-001/aift PASS.
-    // 잔여: 차트(객체 직렬화), k-water-rfp(대형 복합).
-    ("143E433F503322BD33.hwpx", "차트 RawSvg→Placeholder 1페이지"),
+    // 승격 이력: 그룹 자식/도형 회전(shape_attr) · 쪽 테두리(pageBorderFill) · 바탕쪽
+    // (masterPage) · 글머리표(bullet) · borderFill 이미지 채움(imgBrush) · 차트=OLE
+    // (<hp:ole binaryItemIDRef>) 직렬화 정정으로 다수 PASS 승격됨.
+    // 잔여: k-water-rfp(대형 복합).
     ("k-water-rfp.hwpx", "구조 불일치 2페이지(대형, 복합)"),
 ];
 


### PR DESCRIPTION
> ⚠️ **Stacked on #1527** — #1527 머지 후 머지하세요. 머지 전 diff 에 #1527 변경이 함께
> 표시되며, #1527 머지 후 본 PR 고유분(OLE)만 남습니다.

## 개요
OLE 개체(차트 등 포함)가 HWPX 라운드트립에서 placeholder 로 강등되던 문제를 정정한다.
(closes #1529)

## 원인
OLE 직렬화가 legacy 공용 경로(sz/pos/outMargin 만)를 타 `binaryItemIDRef`·`<hc:extent>`·
shape_attr 블록을 빠뜨려, 재파싱 시 OLE 데이터 참조가 없어 placeholder 로 렌더된다.
IR(`OleShape`)·파서·렌더러·BinData 보존은 정상이며 직렬화 element 만 누락.

## 변경
- `src/serializer/hwpx/shape.rs`: `write_ole` 신설(picture 패턴) — 공통 attr +
  objectType/drawAspect + binaryItemIDRef(ctx 매핑) + shape_attr 블록 + extent +
  lineShape + sz/pos/outMargin + caption. bin_data_id 미등록 시 빈 ref(3-way 단언 보호).
- `src/serializer/hwpx/section.rs`: Ole 디스패치 → `write_ole`.
- `tests/visual_roundtrip_baseline.rs`: 143E 승격.

## 검증 (render-diff 시각 게이트)
- 143E STRUCT(RawSvg→Placeholder) → PASS. OLE 단독 변경, PASS 회귀 0.
- `cargo test --test visual_roundtrip_baseline` — 3 passed (잔여 xfail: k-water-rfp).
- `cargo test --test hwpx_roundtrip_baseline` — 4 passed (check_package/3-way 정합).
- fmt / clippy 통과.

🤖 Generated with [Claude Code](https://claude.com/claude-code)