### PR TITLE
Fix double transform for matrix-positioned group children

### DIFF
--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -500,6 +500,7 @@ impl LayoutEngine {
             overflow_map,
             &[],
             None, // [Task #1138] 본문 도형 — 셀 정보 없음
+            false,
         );
 
         // 캡션 렌더링
@@ -742,6 +743,7 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     None, // [Task #1138] TODO: layout_group_child_affine 에 cell ctx propagate (별도 후속)
+                    true,
                 );
             }
         }
@@ -769,11 +771,18 @@ impl LayoutEngine {
         parent_cell_path: &[CellPathEntry],
         // [Task #1138] 표 셀 내 도형인 경우: (cell_idx, cell_para_idx, outer_table_ctrl_idx)
         table_cell_ref: Option<(usize, usize, usize)>,
+        // 그룹 자식은 renderingInfo 행렬로 이미 위치/대칭이 반영되어 있으므로
+        // ShapeComponentAttr의 flip/rotation을 다시 SVG transform으로 적용하지 않는다.
+        matrix_positioned: bool,
     ) {
         use crate::model::shape::ShapeObject;
 
         // 공통: 회전/대칭 정보 추출
-        let transform = extract_shape_transform(shape.shape_attr());
+        let transform = if matrix_positioned {
+            ShapeTransform::default()
+        } else {
+            extract_shape_transform(shape.shape_attr())
+        };
 
         // [Task #1138] 표 셀 내 도형 식별을 위한 cell 정보 추출 (helper)
         let cell_index = table_cell_ref.map(|(ci, _, _)| ci);
@@ -1393,18 +1402,18 @@ impl LayoutEngine {
                             parent_cell_path,
                         );
                     } else {
-                        // render_tx/ty와 render_sx/sy에는 이미 그룹 스케일이 반영되어 있으므로
-                        // group_sx/sy를 추가 적용하지 않음
-                        let child_x = base_x + hwpunit_to_px(sa.render_tx as i32, self.dpi);
-                        let child_y = base_y + hwpunit_to_px(sa.render_ty as i32, self.dpi);
-                        let child_w = hwpunit_to_px(
-                            (sa.original_width as f64 * sa.render_sx.abs()) as i32,
-                            self.dpi,
-                        );
-                        let child_h = hwpunit_to_px(
-                            (sa.original_height as f64 * sa.render_sy.abs()) as i32,
-                            self.dpi,
-                        );
+                        // render_tx/ty와 render_sx/sy에는 이미 그룹 스케일과 flip이 반영되어
+                        // 있으므로 group_sx/sy나 ShapeComponentAttr의 flip을 추가 적용하지
+                        // 않는다. 음수 scale이면 tx는 오른쪽/아래쪽 모서리일 수 있으므로
+                        // 두 변환 모서리의 min/max로 실제 bbox를 만든다.
+                        let x0 = sa.render_tx;
+                        let y0 = sa.render_ty;
+                        let x1 = sa.render_tx + sa.original_width as f64 * sa.render_sx;
+                        let y1 = sa.render_ty + sa.original_height as f64 * sa.render_sy;
+                        let child_x = base_x + hwpunit_to_px(x0.min(x1) as i32, self.dpi);
+                        let child_y = base_y + hwpunit_to_px(y0.min(y1) as i32, self.dpi);
+                        let child_w = hwpunit_to_px((x1 - x0).abs() as i32, self.dpi);
+                        let child_h = hwpunit_to_px((y1 - y0).abs() as i32, self.dpi);
                         let empty_map = std::collections::HashMap::new();
                         self.layout_shape_object(
                             tree,
@@ -1422,6 +1431,7 @@ impl LayoutEngine {
                             &empty_map,
                             parent_cell_path,
                             table_cell_ref, // [Task #1138] 그룹 자식 — 부모와 같은 셀 컨텍스트
+                            true,
                         );
                     }
                 }
@@ -2263,6 +2273,7 @@ impl LayoutEngine {
                             &empty_map,
                             &nested_parent_path,
                             None, // [Task #1138] TODO: layout_textbox_content 에 cell ctx propagate (별도 후속)
+                            false,
                         );
                     }
                     Control::Picture(pic) => {

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -406,6 +406,7 @@ impl LayoutEngine {
             &empty_map,
             &[],
             shape_table_cell_ref,
+            false,
         );
     }
 


### PR DESCRIPTION
## Summary

Fix rendering for group child shapes whose `renderingInfo` matrix already positions and flips the child.

For these children, the layout path was using the matrix-derived position/scale and then applying `ShapeComponentAttr` flip/rotation again when emitting the child shape. That double transform can push a textbox off-page and mirror it.

## Evidence

This uses the same repro HWPX document from [PR #1497](https://github.com/edwardkim/rhwp/pull/1497), linked there as [2025-admin-work-manual.hwpx](https://raw.githubusercontent.com/humdrum00001010/rhwp/a22724946e642d2560d182710dab193476d775c7/pr-evidence/2025-admin-work-manual.hwpx).

Before/after crop from two clean worktrees:

- before: `upstream/devel` at `4538a02c`
- after: `upstream/devel` plus this PR fix, current head `10a45954`

![before-after group child textbox render](https://raw.githubusercontent.com/humdrum00001010/rhwp/3df5efe645e1a549842101633620939d5e8f848c/docs/pr-evidence/group-child-matrix-positioning/before-after-header.png)

SVG evidence from the same render:

- before: `textbox-clip-102` is emitted at `x="809.2666666666667"` and the child has `scale(-1,1)`
- after: `textbox-clip-102` is emitted at `x="128.53333333333333"` and the extra flip transform is gone

Full-page renders:

- [before full page](https://raw.githubusercontent.com/humdrum00001010/rhwp/3df5efe645e1a549842101633620939d5e8f848c/docs/pr-evidence/group-child-matrix-positioning/before-full.png)
- [after full page](https://raw.githubusercontent.com/humdrum00001010/rhwp/3df5efe645e1a549842101633620939d5e8f848c/docs/pr-evidence/group-child-matrix-positioning/after-full.png)

## Changes

- Treat matrix-positioned group children as already transformed for layout, so `ShapeComponentAttr` flip/rotation is not applied a second time.
- When group child scale is negative, compute the layout box from transformed corner min/max instead of treating `render_tx`/`render_ty` as the top-left corner.
- Preserve the existing truncating HWPUNIT-to-pixel conversion for positive-scale children to avoid unrelated golden snapshot churn.

## Validation

- `git diff --check upstream/devel...HEAD`
- `cargo fmt --check`
- `cargo test --lib layout`
- `cargo test --test svg_snapshot issue_267_ktx_toc_page -- --exact --nocapture`
- `cargo test --test issue_874_ktx_toc_page_number_right_align -- --nocapture`
- rendered page 4 from a clean `upstream/devel` worktree and from a separate `upstream/devel` + cherry-pick worktree, then compared emitted SVG coordinates/transforms and PNG output
