### PR TITLE
fix: HWPX render fidelity vs canonical PDF (pp.1–20) — matrix-group decorations + pagination

### DIFF
--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -1386,7 +1386,35 @@ impl LayoutEngine {
                     let sa = child.shape_attr();
                     let has_rotation = sa.render_b.abs() > 1e-6 || sa.render_c.abs() > 1e-6;
 
-                    if has_rotation {
+                    if let ShapeObject::Group(_) = child {
+                        // 중첩 그룹: HWPX renderingInfo 행렬은 모든 자손(leaf)에 대해
+                        // 최상위 그룹 좌표계로 평탄화(flatten)되어 저장된다. 즉 손자
+                        // 도형의 render_tx/ty 도 이미 base_x/base_y(최상위 그룹 원점)
+                        // 기준 절대값이다. 따라서 중첩 그룹의 자식을 배치할 때 그 그룹의
+                        // render_tx/ty 만큼 원점을 이동하면 손자에서 같은 오프셋이 한 번 더
+                        // 더해져 이중 변환된다(제목/목록이 페이지 밖으로 밀려남).
+                        // 중첩 그룹은 원점(base_x/base_y)을 그대로 전달해 손자들이 동일한
+                        // 최상위 프레임에서 자기 행렬로 직접 배치되도록 한다.
+                        let empty_map = std::collections::HashMap::new();
+                        self.layout_shape_object(
+                            tree,
+                            &mut group_node,
+                            child,
+                            base_x,
+                            base_y,
+                            w,
+                            h,
+                            section_index,
+                            para_index,
+                            control_index,
+                            styles,
+                            bin_data_content,
+                            &empty_map,
+                            parent_cell_path,
+                            table_cell_ref,
+                            true,
+                        );
+                    } else if has_rotation {
                         self.layout_group_child_affine(
                             tree,
                             &mut group_node,

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -500,6 +500,7 @@ impl LayoutEngine {
             overflow_map,
             &[],
             None, // [Task #1138] 본문 도형 — 셀 정보 없음
+            false,
         );
 
         // 캡션 렌더링
@@ -742,6 +743,7 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     None, // [Task #1138] TODO: layout_group_child_affine 에 cell ctx propagate (별도 후속)
+                    true,
                 );
             }
         }
@@ -769,11 +771,18 @@ impl LayoutEngine {
         parent_cell_path: &[CellPathEntry],
         // [Task #1138] 표 셀 내 도형인 경우: (cell_idx, cell_para_idx, outer_table_ctrl_idx)
         table_cell_ref: Option<(usize, usize, usize)>,
+        // 그룹 자식은 renderingInfo 행렬로 이미 위치/대칭이 반영되어 있으므로
+        // ShapeComponentAttr의 flip/rotation을 다시 SVG transform으로 적용하지 않는다.
+        matrix_positioned: bool,
     ) {
         use crate::model::shape::ShapeObject;
 
         // 공통: 회전/대칭 정보 추출
-        let transform = extract_shape_transform(shape.shape_attr());
+        let transform = if matrix_positioned {
+            ShapeTransform::default()
+        } else {
+            extract_shape_transform(shape.shape_attr())
+        };
 
         // [Task #1138] 표 셀 내 도형 식별을 위한 cell 정보 추출 (helper)
         let cell_index = table_cell_ref.map(|(ci, _, _)| ci);
@@ -1393,18 +1402,18 @@ impl LayoutEngine {
                             parent_cell_path,
                         );
                     } else {
-                        // render_tx/ty와 render_sx/sy에는 이미 그룹 스케일이 반영되어 있으므로
-                        // group_sx/sy를 추가 적용하지 않음
-                        let child_x = base_x + hwpunit_to_px(sa.render_tx as i32, self.dpi);
-                        let child_y = base_y + hwpunit_to_px(sa.render_ty as i32, self.dpi);
-                        let child_w = hwpunit_to_px(
-                            (sa.original_width as f64 * sa.render_sx.abs()) as i32,
-                            self.dpi,
-                        );
-                        let child_h = hwpunit_to_px(
-                            (sa.original_height as f64 * sa.render_sy.abs()) as i32,
-                            self.dpi,
-                        );
+                        // render_tx/ty와 render_sx/sy에는 이미 그룹 스케일과 flip이 반영되어
+                        // 있으므로 group_sx/sy나 ShapeComponentAttr의 flip을 추가 적용하지
+                        // 않는다. 음수 scale이면 tx는 오른쪽/아래쪽 모서리일 수 있으므로
+                        // 두 변환 모서리의 min/max로 실제 bbox를 만든다.
+                        let x0 = sa.render_tx;
+                        let y0 = sa.render_ty;
+                        let x1 = sa.render_tx + sa.original_width as f64 * sa.render_sx;
+                        let y1 = sa.render_ty + sa.original_height as f64 * sa.render_sy;
+                        let child_x = base_x + hwpunit_to_px(x0.min(x1).round() as i32, self.dpi);
+                        let child_y = base_y + hwpunit_to_px(y0.min(y1).round() as i32, self.dpi);
+                        let child_w = hwpunit_to_px((x1 - x0).abs().round() as i32, self.dpi);
+                        let child_h = hwpunit_to_px((y1 - y0).abs().round() as i32, self.dpi);
                         let empty_map = std::collections::HashMap::new();
                         self.layout_shape_object(
                             tree,
@@ -1422,6 +1431,7 @@ impl LayoutEngine {
                             &empty_map,
                             parent_cell_path,
                             table_cell_ref, // [Task #1138] 그룹 자식 — 부모와 같은 셀 컨텍스트
+                            true,
                         );
                     }
                 }
@@ -2308,6 +2318,7 @@ impl LayoutEngine {
                             &empty_map,
                             &nested_parent_path,
                             None, // [Task #1138] TODO: layout_textbox_content 에 cell ctx propagate (별도 후속)
+                            false,
                         );
                     }
                     Control::Picture(pic) => {

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -406,6 +406,7 @@ impl LayoutEngine {
             &empty_map,
             &[],
             shape_table_cell_ref,
+            false,
         );
     }
 

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -9003,7 +9003,20 @@ impl TypesetEngine {
             .last()
             .map(|s| s.vertical_pos + s.line_height + s.line_spacing);
 
-        if forced_page_break_line.is_none() && st.current_height + fmt.height_for_fit <= available {
+        // height_for_fit already excludes the last line's trailing line_spacing (the
+        // paragraph's true content bottom), so it is already conservative. Subtracting
+        // LAYOUT_DRIFT_SAFETY_PX from `available` on top double-counts and rejects a last
+        // line Hancom fits -> ~1-line/page early split that accumulates into page drift.
+        // Judge single-column whole-paragraph fit against the un-shaved body height; keep
+        // the safety margin on the multi-column (vpos-stacked) path.
+        let whole_fit_available = if st.col_count > 1 {
+            available
+        } else {
+            st.available_height()
+        };
+        if forced_page_break_line.is_none()
+            && st.current_height + fmt.height_for_fit <= whole_fit_available
+        {
             // place: 전체 배치
             st.current_items.push(PageItem::FullParagraph {
                 para_index: para_idx,


### PR DESCRIPTION
## Summary
HWPX render-fidelity fixes found by auditing the `2025 행정업무운영 편람` HWPX **page-by-page
against its canonical PDF (pp.1–20)**. Rebased onto the latest `devel`. Three commits:

1. `fix: avoid double-transforming matrix-positioned group children` (leaf child)
2. `fix: stop double-counting layout safety margin in whole-paragraph page fit`
3. `fix: avoid double-transforming NESTED matrix-positioned group children`

## pp.1–20 contrast — Canonical PDF (left) vs HWPX with these fixes (right)
![pp.1–5](https://raw.githubusercontent.com/humdrum00001010/rhwp/evidence/hwpx-1-20-render/shots/pp01-05.png)
![pp.6–10](https://raw.githubusercontent.com/humdrum00001010/rhwp/evidence/hwpx-1-20-render/shots/pp06-10.png)
![pp.11–15](https://raw.githubusercontent.com/humdrum00001010/rhwp/evidence/hwpx-1-20-render/shots/pp11-15.png)
![pp.16–20](https://raw.githubusercontent.com/humdrum00001010/rhwp/evidence/hwpx-1-20-render/shots/pp16-20.png)

## Clearest restore — TOC "차 례" header band (p4)
Missing on `devel`, placed correctly with the matrix-group transform fix (Canonical | devel | this PR):
![p4 차례 band](https://raw.githubusercontent.com/humdrum00001010/rhwp/evidence/hwpx-1-20-render/shots/p4-tocband-canon-before-after.png)

## Remaining cracks (honest — not all in this PR's scope)
- **p3** — intro mosaic strip + title placement still differ.
- **p9 divider** — title + sub-list now render, but textbox/group **construction rectangle strokes are
  still visible** and the title underline is missing → needs the matrix-group *stroke-suppression* fix
  (separate). The chunky "1" is **font substitution**, not geometry.
- **p13–20** — pagination still drifts ~1 page. Commit 2 removes a genuine double-count (it only ever
  *reduces* pages), but other drift sources remain on the newer `devel`, so this doc isn't fully aligned yet.
- **Font weight throughout = font substitution**: the HWPX embeds no fonts and the requested faces
  (KoPub돋움체 / 휴먼명조 / 한컴바탕 …) aren't installed, so everything falls back to Apple SD Gothic Neo.
  Environmental, not an engine bug.

## Verification
- `cargo test --features native-skia --lib` → **1984 passed, 0 failed**, 6 ignored.
- Rendered with `rhwp export-png --features native-skia`; the comparison sheets above are reproducible.
- Matrix-group rationale: HWPX flattens each shape's `renderingInfo` matrix into the **outermost** group
  frame, so a nested `Group` child must recurse with the unchanged group origin (else grandchildren
  double-add their already-absolute offset).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
