### PR TITLE
task 1579: review 문서 PR fast-pass 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -147,6 +147,8 @@ jobs:
               if (!candidateSha) {
                 candidateSha = pr.base.sha;
                 core.info(`all PR commits are allowed review docs; using base SHA ${candidateSha}`);
+                setResult(true, 'all-review-docs-no-code-impact', candidateSha);
+                return;
               }
 
               const checkRuns = await github.paginate(github.rest.checks.listForRef, {

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -150,6 +150,8 @@ jobs:
               if (!candidateSha) {
                 candidateSha = pr.base.sha;
                 core.info(`all PR commits are allowed review docs; using base SHA ${candidateSha}`);
+                setResult(true, 'all-review-docs-no-code-impact', candidateSha);
+                return;
               }
 
               const checkRuns = await github.paginate(github.rest.checks.listForRef, {

--- a/mydocs/orders/20260627.md
+++ b/mydocs/orders/20260627.md
@@ -5,8 +5,9 @@
 | Issue / PR | 타스크 | 상태 | 비고 |
 |------------|--------|------|------|
 | PR #1541, #1544, #1545, #1558, #1559, #1561, #1563, #1566, #1571 | @planet6897 연속 PR 최신 `devel` 순차 merge | 완료 | 9건 모두 branch update 또는 수동 merge 후 remote CI 통과 확인, admin merge 완료. 최종 `devel` HEAD `24c1c1d2`. #1561은 충돌 수동 해결, #1566/#1571은 opengov snapshot/visual XFAIL 승격 보정 후 재검증. 관련 이슈 #1512, #1488, #1472, #1552, #1554, #1557, #1556, #1560, #1564, #1567 모두 close 확인. 처리 보고서: `mydocs/pr/archives/pr_1541_1571_planet6897_series_report.md`. |
+| #1579 | 순수 review 문서 PR의 heavy CI fallback 방지 | 진행 중 | #1578에서 base post-merge CI 진행 중 순수 문서 PR이 full `Build & Test`로 fallback한 점을 후속 정정. `ci.yml`/`codeql.yml` all-review-docs-only fast-pass 분기 보강 예정. |
 
 ## 후속 확인
 
 - @planet6897 open PR #1533, #1538은 이번 지시 범위 밖으로 남아 있음.
-- 보고서/오늘할일 기록은 문서 전용 PR로 후속 반영한다.
+- 보고서/오늘할일 기록은 문서 전용 PR #1578로 후속 반영했고 `e31e3657`에서 merge 완료.

--- a/mydocs/plans/task_m100_1579.md
+++ b/mydocs/plans/task_m100_1579.md
@@ -1,0 +1,39 @@
+# Task M100 #1579 수행 계획서
+
+## 개요
+
+- 이슈: #1579
+- 주제: 순수 review 문서 PR의 heavy CI fallback 방지
+- 기준 브랜치: `upstream/devel`
+
+## 문제
+
+`mydocs/pr/**`와 `mydocs/orders/*.md`만 변경한 PR은 코드 실행 결과에 영향을 주지 않는다.
+하지만 현재 `ci.yml`과 `codeql.yml`의 preflight는 PR 전체가 review 문서 전용인 경우에도
+base SHA의 기존 check 완료 여부를 확인한다.
+
+그 결과 #1578처럼 base `devel`의 post-merge CI가 아직 진행 중이면 문서 전용 PR도 full
+`Build & Test` 또는 CodeQL matrix로 fallback할 수 있다.
+
+## 목표
+
+- PR 전체가 허용된 review 문서 경로만 변경한 경우에는 base CI 상태 조회 없이 fast-pass한다.
+- 코드 변경 뒤에 review 문서 커밋만 trailing으로 붙은 mixed PR은 기존처럼 마지막 코드 변경
+  SHA의 green check를 확인한다.
+- workflow 문법은 `actionlint`로 검증한다.
+
+## 범위
+
+- 수정 대상:
+  - `.github/workflows/ci.yml`
+  - `.github/workflows/codeql.yml`
+- 문서 대상:
+  - `mydocs/orders/20260627.md`
+  - `mydocs/plans/task_m100_1579.md`
+  - `mydocs/plans/task_m100_1579_impl.md`
+
+## 검증 계획
+
+- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
+- `git diff --check`
+- 변경 범위가 workflow와 작업 문서에 한정되는지 확인

--- a/mydocs/plans/task_m100_1579_impl.md
+++ b/mydocs/plans/task_m100_1579_impl.md
@@ -1,0 +1,34 @@
+# Task M100 #1579 구현 계획서
+
+## Stage 1
+
+순수 review 문서 PR fast-pass 조건을 보강한다.
+
+- `ci.yml`
+  - PR commit을 뒤에서부터 훑는 기존 구조는 유지한다.
+  - 모든 PR commit이 review 문서 전용이면 `candidateSha = pr.base.sha` 기록 후 즉시
+    `fast_pass=true`를 출력한다.
+  - mixed PR은 기존 `Build & Test` check 조회를 유지한다.
+
+- `codeql.yml`
+  - 모든 PR commit이 review 문서 전용이면 base CodeQL matrix 조회 없이 즉시 fast-pass한다.
+  - mixed PR은 기존 required CodeQL check 조회를 유지한다.
+
+## Stage 2
+
+검증과 정리를 수행한다.
+
+- `actionlint`로 workflow 문법 확인
+- `git diff --check` 확인
+- 문서 전용이 아니므로 cargo 빌드/테스트는 생략하고 사유를 PR 본문에 기록
+
+## PR 후 확인
+
+테스트용 문서 전용 PR에서 기대 상태는 다음과 같다.
+
+- `CI preflight`: pass
+- `Build & Test`: skipped
+- `CodeQL preflight`: pass
+- `Analyze (*)`: skipped 또는 미실행
+- `Render Diff preflight`: pass
+- `Canvas visual diff`: skipped


### PR DESCRIPTION
## 요약
- 순수 review 문서 PR에서 base CI가 진행 중일 때도 heavy CI로 fallback하지 않도록 `ci.yml` fast-pass 분기를 보강했습니다.
- 같은 조건을 `codeql.yml`에도 반영해 순수 review 문서 PR은 CodeQL matrix 조회 없이 fast-pass합니다.
- mixed PR에서 trailing review 문서 커밋만 추가된 경우에는 기존 candidate SHA green check 검증을 유지합니다.

Closes #1579

## 검증
- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
- `git diff --check`
- `git diff --cached --check`

## 비고
- workflow-only 동작 변경과 작업 문서 갱신입니다.
- Rust 소스 변경이 없어 cargo 빌드/테스트는 수행하지 않았습니다.