### PR TITLE
docs: review 문서 fast-pass 검증 기록 추가

### DIFF
--- a/mydocs/orders/20260627.md
+++ b/mydocs/orders/20260627.md
@@ -5,7 +5,7 @@
 | Issue / PR | 타스크 | 상태 | 비고 |
 |------------|--------|------|------|
 | PR #1541, #1544, #1545, #1558, #1559, #1561, #1563, #1566, #1571 | @planet6897 연속 PR 최신 `devel` 순차 merge | 완료 | 9건 모두 branch update 또는 수동 merge 후 remote CI 통과 확인, admin merge 완료. 최종 `devel` HEAD `24c1c1d2`. #1561은 충돌 수동 해결, #1566/#1571은 opengov snapshot/visual XFAIL 승격 보정 후 재검증. 관련 이슈 #1512, #1488, #1472, #1552, #1554, #1557, #1556, #1560, #1564, #1567 모두 close 확인. 처리 보고서: `mydocs/pr/archives/pr_1541_1571_planet6897_series_report.md`. |
-| #1579 | 순수 review 문서 PR의 heavy CI fallback 방지 | 진행 중 | #1578에서 base post-merge CI 진행 중 순수 문서 PR이 full `Build & Test`로 fallback한 점을 후속 정정. `ci.yml`/`codeql.yml` all-review-docs-only fast-pass 분기 보강 예정. |
+| #1579 | 순수 review 문서 PR의 heavy CI fallback 방지 | 검증 중 | #1580에서 `ci.yml`/`codeql.yml` all-review-docs-only fast-pass 분기 보강 후 remote CI 통과, `ec05f73a`로 merge. 후속 문서 전용 PR에서 heavy job skip 여부 확인 예정. |
 
 ## 후속 확인
 

--- a/mydocs/orders/20260627.md
+++ b/mydocs/orders/20260627.md
@@ -5,7 +5,7 @@
 | Issue / PR | 타스크 | 상태 | 비고 |
 |------------|--------|------|------|
 | PR #1541, #1544, #1545, #1558, #1559, #1561, #1563, #1566, #1571 | @planet6897 연속 PR 최신 `devel` 순차 merge | 완료 | 9건 모두 branch update 또는 수동 merge 후 remote CI 통과 확인, admin merge 완료. 최종 `devel` HEAD `24c1c1d2`. #1561은 충돌 수동 해결, #1566/#1571은 opengov snapshot/visual XFAIL 승격 보정 후 재검증. 관련 이슈 #1512, #1488, #1472, #1552, #1554, #1557, #1556, #1560, #1564, #1567 모두 close 확인. 처리 보고서: `mydocs/pr/archives/pr_1541_1571_planet6897_series_report.md`. |
-| #1579 | 순수 review 문서 PR의 heavy CI fallback 방지 | 검증 중 | #1580에서 `ci.yml`/`codeql.yml` all-review-docs-only fast-pass 분기 보강 후 remote CI 통과, `ec05f73a`로 merge. 후속 문서 전용 PR에서 heavy job skip 여부 확인 예정. |
+| #1579 | 순수 review 문서 PR의 heavy CI fallback 방지 | 완료 | #1580에서 `ci.yml`/`codeql.yml` all-review-docs-only fast-pass 분기 보강 후 remote CI 통과, `ec05f73a`로 merge. 후속 문서 전용 PR #1581에서 `Build & Test`, `Analyze`, `Canvas visual diff` skipped 및 preflight fast-pass 확인. |
 
 ## 후속 확인
 

--- a/mydocs/pr/archives/pr_1580_review_doc_fast_pass_report.md
+++ b/mydocs/pr/archives/pr_1580_review_doc_fast_pass_report.md
@@ -1,0 +1,43 @@
+# PR #1580 review 문서 fast-pass 검증 보고
+
+## 메타
+
+- 대상 PR: #1580
+- 관련 이슈: #1579
+- 처리일: 2026-06-27
+- merge commit: `ec05f73afd19aadad9fdee36a4dedf563d13a418`
+
+## 배경
+
+#1578은 review 문서 전용 PR이었지만, PR 생성 시점의 base `devel` post-merge CI가 아직
+완료되지 않아 `Build & Test` full job으로 fallback했다. #1580은 이 문제를 막기 위해
+`ci.yml`과 `codeql.yml`에서 PR 전체가 review 문서 전용인 경우 base check 조회 없이
+fast-pass하도록 보강했다.
+
+## #1580 검증
+
+- 로컬:
+  - `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml`
+  - `git diff --check`
+  - `git diff --cached --check`
+- 원격:
+  - `CI preflight`: pass
+  - `Build & Test`: pass
+  - `CodeQL preflight`: pass
+  - `Analyze (javascript-typescript)`: pass
+  - `Analyze (python)`: pass
+  - `Analyze (rust)`: pass
+  - `Render Diff preflight`: pass
+  - `Canvas visual diff`: pass
+  - `WASM Build`: skipped
+
+## 후속 fast-pass 확인 대상
+
+이 보고서 PR은 `mydocs/pr/**`와 `mydocs/orders/*.md`만 변경한다. 기대 결과는 다음과 같다.
+
+- `CI preflight`: `all-review-docs-no-code-impact` fast-pass
+- `Build & Test`: skipped
+- `CodeQL preflight`: `all-review-docs-no-code-impact` fast-pass
+- `Analyze (*)`: skipped
+- `Render Diff preflight`: review 문서 전용 fast-pass
+- `Canvas visual diff`: skipped

--- a/mydocs/pr/archives/pr_1580_review_doc_fast_pass_report.md
+++ b/mydocs/pr/archives/pr_1580_review_doc_fast_pass_report.md
@@ -41,3 +41,15 @@ fast-pass하도록 보강했다.
 - `Analyze (*)`: skipped
 - `Render Diff preflight`: review 문서 전용 fast-pass
 - `Canvas visual diff`: skipped
+
+## 후속 fast-pass 확인 결과
+
+PR #1581 최초 head 기준으로 기대 동작을 확인했다.
+
+- `CI preflight`: pass, `fast_pass=true reason=all-review-docs-no-code-impact`
+- `Build & Test`: skipped
+- `CodeQL preflight`: pass, `fast_pass=true reason=all-review-docs-no-code-impact`
+- `Analyze (${{ matrix.language }})`: skipped
+- `Render Diff preflight`: pass, `fast_pass=true reason=all-review-docs-no-render-impact`
+- `Canvas visual diff`: skipped
+- `WASM Build`: skipped


### PR DESCRIPTION
## 요약
- #1580 merge 후 review 문서 전용 PR fast-pass 동작을 검증하기 위한 기록을 추가합니다.
- 변경 범위는 `mydocs/pr/**`와 `mydocs/orders/*.md`로 제한했습니다.

## 검증
- `git diff --check`
- `git diff --cached --check`

## 기대 원격 동작
- `CI preflight`, `CodeQL preflight`, `Render Diff preflight`는 pass
- `Build & Test`, `Analyze (*)`, `Canvas visual diff`는 skipped