### PR TITLE
docs: PR #1602 #1603 fast-pass 처리 기록

### DIFF
--- a/mydocs/orders/20260628.md
+++ b/mydocs/orders/20260628.md
@@ -4,4 +4,4 @@
 
 | Issue / PR | 타스크 | 상태 | 비고 |
 |------------|--------|------|------|
-| #1601 | `mydocs/**` 전용 PR fast-pass 확장 | 진행 중 | #1580에서 `mydocs/pr/**`, `mydocs/orders/*.md`에 한정했던 allowlist를 `mydocs/**`로 확장한다. workflow 변경 PR이므로 이번 PR 자체는 full CI 대상이며, merge 후 문서 전용 PR에서 preflight pass + heavy job skipped 상태를 기대한다. |
+| #1601 / #1602 / #1603 | `mydocs/**` 전용 PR fast-pass 확장 및 검증 | 완료 | #1602에서 allowlist를 `mydocs/**`로 확장하고 full CI green 후 `d1b7c6683`로 merge. #1603에서 `mydocs/manual/pr_review_workflow.md` 단독 변경으로 fast-pass 검증: preflight 3종 pass, `Build & Test`/CodeQL analyze/`Canvas visual diff` skipped. #1603은 `edc4e6351`로 merge. #1601은 자동 close 실패로 수동 close 완료. |

--- a/mydocs/pr/archives/pr_1602_1603_mydocs_fast_pass_review.md
+++ b/mydocs/pr/archives/pr_1602_1603_mydocs_fast_pass_review.md
@@ -1,0 +1,74 @@
+# PR #1602 / #1603 검토 기록
+
+## 메타
+
+| 항목 | 내용 |
+|------|------|
+| 대상 PR | #1602 `task 1601: mydocs 문서 PR fast-pass 확장`, #1603 `docs: PR 작업트리 정리 절차 명시` |
+| 관련 이슈 | #1601 |
+| 작성자 / merge 수행 | @jangster77 |
+| base | `devel` |
+| 처리 결과 | #1602 merge commit `d1b7c6683`, #1603 merge commit `edc4e6351` |
+
+## 변경 범위
+
+### PR #1602
+
+- CI / CodeQL / Render Diff preflight의 문서 전용 fast-pass allowlist를 `mydocs/**` 기준으로 확장했다.
+- `render-diff.yml`도 `mydocs/**` 변경 시 preflight check가 생성되도록 trigger path를 맞췄다.
+- `pr_review_workflow.md`에 `mydocs/**` fast-pass 기준과 영어 요청 contributor 응답 시 한영 문단 병기 규칙을 기록했다.
+- `mydocs/orders/20260628.md`, `mydocs/plans/task_m100_1601*.md`를 추가했다.
+
+### PR #1603
+
+- `pr_review_workflow.md`의 로컬/원격 PR 작업 브랜치 정리 절차에 worktree 제거 순서를 명시했다.
+- 별도 worktree가 남아 있으면 브랜치 삭제 전에 `git worktree remove`를 먼저 수행하도록 안내했다.
+- #1602 merge 후 `mydocs/manual/**` 단독 변경이 fast-pass 되는지 검증하는 테스트 PR 역할을 수행했다.
+
+## 검증 결과
+
+### PR #1602
+
+workflow 파일 변경이 포함되어 full CI 대상이었다.
+
+- `CI preflight`: pass
+- `Build & Test`: pass (`20m37s`)
+- `CodeQL preflight`: pass
+- `Analyze (javascript-typescript)`: pass
+- `Analyze (python)`: pass
+- `Analyze (rust)`: pass
+- `Render Diff preflight`: pass
+- `Canvas visual diff`: pass
+- `WASM Build`: skipped
+
+로컬 검증:
+
+- `actionlint .github/workflows/ci.yml .github/workflows/codeql.yml .github/workflows/render-diff.yml`: pass
+- `git diff --check`: pass
+
+### PR #1603
+
+`mydocs/manual/pr_review_workflow.md` 단독 변경으로 #1602의 fast-pass 동작을 확인했다.
+
+- `CI preflight`: pass
+- `Build & Test`: skipped
+- `CodeQL preflight`: pass
+- `Analyze (${{ matrix.language }})`: skipped
+- `Render Diff preflight`: pass
+- `Canvas visual diff`: skipped
+- `WASM Build`: skipped
+
+로컬 검증:
+
+- `git diff --check upstream/devel...HEAD`: pass
+- 변경 파일: `mydocs/manual/pr_review_workflow.md` 단일 파일
+
+## 후속 처리
+
+- #1602 merge 후 `Closes #1601` 자동 close가 동작하지 않아 #1601을 수동 close했다.
+- #1602 / #1603 원격 작업 브랜치는 merge 시 삭제했고, fetch/prune 후 원격 head가 남지 않는 것을 확인했다.
+- 로컬 `devel`은 `upstream/devel`로 fast-forward 동기화했다.
+
+## 판단
+
+`mydocs/**` 전용 PR에서 preflight pass + heavy job skipped 상태가 확인되었으므로 #1601 목표는 충족되었다.

--- a/mydocs/pr/archives/pr_1602_1603_mydocs_fast_pass_review_impl.md
+++ b/mydocs/pr/archives/pr_1602_1603_mydocs_fast_pass_review_impl.md
@@ -1,0 +1,27 @@
+# PR #1602 / #1603 처리 계획 및 수행 기록
+
+## Stage 1 — #1602 생성 및 merge
+
+- 이슈 #1601을 생성했다.
+- `task_m100_1601_mydocs_fast_pass` 브랜치에서 workflow allowlist를 `mydocs/**`로 확장했다.
+- #1602를 `devel` 대상으로 생성했다.
+- remote CI green 확인 후 #1602를 merge했다.
+- merge commit: `d1b7c668380f8c3930a70b3074adffaf563d84f4`
+- #1601은 자동 close되지 않아 수동 close했다.
+
+## Stage 2 — #1603 fast-pass 테스트
+
+- #1602 merge 후 `devel`을 동기화했다.
+- `task_m100_1603_pr_worktree_cleanup` 브랜치에서 `pr_review_workflow.md` 단독 변경을 준비했다.
+- #1603을 `devel` 대상으로 생성했다.
+- #1602에서 도입한 fast-pass 동작을 확인했다.
+  - preflight 3종 pass
+  - `Build & Test`, CodeQL analyze, `Canvas visual diff` skipped
+- #1603을 merge했다.
+- merge commit: `edc4e6351c93981142da4f055f0a3efe853dcab9`
+
+## Stage 3 — 기록 PR
+
+- #1602 / #1603 처리 결과를 archives review 문서에 기록한다.
+- `mydocs/orders/20260628.md`를 완료 상태로 갱신한다.
+- 기록 PR은 `mydocs/**` 전용 변경이므로 fast-pass 동작을 다시 확인한다.


### PR DESCRIPTION
## 요약

- PR #1602 / #1603 처리 결과를 archives review 문서로 기록했습니다.
- `mydocs/orders/20260628.md`의 #1601 작업 상태를 완료로 갱신했습니다.
- #1602 merge 후 #1603에서 확인한 `mydocs/**` fast-pass 동작 결과를 남겼습니다.

## 검증

- `git diff --check`
- 변경 범위 확인: `mydocs/**` 전용 변경

## 기대 CI 상태

이 PR 자체도 `mydocs/**` 전용 변경이므로 다음 상태를 기대합니다.

- `CI preflight`: pass
- `Build & Test`: skipped
- `CodeQL preflight`: pass
- `Analyze (*)`: skipped
- `Render Diff preflight`: pass
- `Canvas visual diff`: skipped
