### PR TITLE
Task #1620: clear_initial_field_texts 다중 removal 빈 문단 슬라이스 패닉 수정

### DIFF
--- a/mydocs/plans/task_m100_1620.md
+++ b/mydocs/plans/task_m100_1620.md
@@ -1,0 +1,26 @@
+# 수행계획서 — Task #1620
+
+**제목**: `clear_initial_field_texts` 다중 removal 빈 문단 슬라이스 패닉 수정
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1620 · **브랜치**: `local/task1620` (base: `devel`)
+**발견**: HWPX 3축 전수 재검증(18,388건)에서 `36396650` `rhwp info` 패닉.
+
+## 1. 문제
+`document.rs:927` 패닉 `range start index 23 out of range for slice of length 0`.
+손상 아닌 정상 ZIP = 실제 버그.
+
+## 2. 근본 원인
+`clear_initial_field_texts`(ClickHere 안내문 제거):
+- 수집 루프는 `fr.end_char_idx <= chars.len()` 가드 후 removals 수집.
+- 제거 루프(924~)는 앞선 removal 이 `para.text` 를 축소한 뒤 이후 removal 의 수집-시점
+  `(start,end)` 를 **재검증하지 않음**. 같은 범위를 가리키는 중첩 field_range 2개 처리 시 첫
+  removal 이 텍스트를 비우면(len 0) 다음 removal 의 `chars[end..]` 가 범위 초과 → 패닉.
+
+## 3. 수정
+제거 루프에서 현재 `chars.len()` 기준 `start <= end <= len` 범위 가드(초과 시 skip). 안내문
+제거는 정규화이므로 드문 무효 케이스 skip 은 안전(패닉 방지 우선).
+
+## 4. 단계 (1단계)
+- RED 단위테스트(중첩 removal 2개 → 패닉) → 범위 가드 추가 → GREEN + 실파일 비패닉 + 회귀 게이트.
+
+## 5. 게이트
+합성 단위테스트 RED→GREEN, 36396650 비패닉, `cargo test --lib`/clippy/fmt 회귀 0.

--- a/mydocs/report/task_m100_1620_report.md
+++ b/mydocs/report/task_m100_1620_report.md
@@ -1,0 +1,33 @@
+# 최종 결과보고서 — Task #1620
+
+**제목**: `clear_initial_field_texts` 다중 removal 빈 문단 슬라이스 패닉 수정
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1620 · **브랜치**: `local/task1620` (base: `devel`)
+
+## 1. 문제
+HWPX 3축 전수 재검증(18,388건)에서 `36396650`(정상 ZIP) `rhwp info` 패닉:
+`document.rs:927: range start index 23 out of range for slice of length 0`.
+
+## 2. 근본 원인
+`clear_initial_field_texts` 의 제거 루프가 앞선 removal 의 `para.text` 축소를 반영하지 않아,
+같은 텍스트 범위를 가리키는 중첩 field_range 다중 removal 시 stale `(start,end)` 로 빈 문단을
+슬라이스 → 패닉.
+
+## 3. 수정 (`src/document_core/commands/document.rs`)
+제거 루프에서 현재 `chars.len()` 기준 `start <= end <= len` 범위 가드 추가(초과 시 skip).
+```rust
+let chars: Vec<char> = para.text.chars().collect();
+if start > end || end > chars.len() { continue; } // [Task #1620]
+```
+
+## 4. 검증
+| 게이트 | 결과 |
+|--------|------|
+| 합성 단위테스트 (중첩 removal 2개 → no panic) | RED(패닉 재현)→**GREEN** |
+| 실파일 36396650 `rhwp info` | 패닉→**페이지 수: 2** (정상) |
+| `cargo test --lib` | 1976 passed / 0 failed |
+| clippy / fmt | 무경고 / 0 diff |
+
+## 5. 산출물
+- 소스: `src/document_core/commands/document.rs`
+- 테스트: `validate_linesegs_tests::clear_initial_field_texts_no_panic_on_overlapping_removals`
+- 문서: 본 보고서, `_plan`

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -922,8 +922,14 @@ impl DocumentCore {
             }
             // 뒤에서부터 삭제 (인덱스 안정성 유지)
             for &(fri, start, end) in removals.iter().rev() {
-                let removed_len = end - start;
                 let chars: Vec<char> = para.text.chars().collect();
+                // [Task #1620] 다중 removal 처리 중 앞선 removal 이 para.text 를 축소하면(특히
+                // 같은 범위를 가리키는 중첩 field_range) 이후 removal 의 수집-시점 (start,end) 가
+                // 현재 길이를 초과해 슬라이스 패닉(36396650). 현재 길이 기준 범위를 재검증해 skip.
+                if start > end || end > chars.len() {
+                    continue;
+                }
+                let removed_len = end - start;
                 let new_text: String = chars[..start].iter().chain(chars[end..].iter()).collect();
                 para.text = new_text;
                 para.field_ranges[fri].end_char_idx = start;
@@ -975,6 +981,54 @@ mod validate_linesegs_tests {
     use super::*;
     use crate::model::document::{Document, Section};
     use crate::model::paragraph::{LineSeg, Paragraph};
+
+    /// [Task #1620] `clear_initial_field_texts`: 같은 텍스트 범위를 가리키는 다중 ClickHere
+    /// field_range 처리 시, 첫 removal 이 `para.text` 를 비우면 이후 removal 이 stale 인덱스로
+    /// 슬라이스해 패닉(36396650, `document.rs:927` range out of range). 범위 가드 추가로
+    /// 패닉 없이 정규화돼야 함.
+    #[test]
+    fn clear_initial_field_texts_no_panic_on_overlapping_removals() {
+        use crate::model::control::{Control, Field, FieldType};
+        use crate::model::paragraph::FieldRange;
+
+        let field = Field {
+            field_type: FieldType::ClickHere,
+            command: "Clickhere:set:48:Direction:wstring:6:여기에 입력 HelpState:wstring:0:  "
+                .to_string(),
+            properties: 0, // bit15 == 0 (초기 상태 → 안내문 제거 대상)
+            ..Default::default()
+        };
+        // 같은 텍스트 범위 [0,6) 를 가리키는 field_range 2개(중첩) → 다중 removal.
+        let para = Paragraph {
+            text: "여기에 입력".to_string(),
+            controls: vec![Control::Field(field)],
+            field_ranges: vec![
+                FieldRange {
+                    start_char_idx: 0,
+                    end_char_idx: 6,
+                    control_idx: 0,
+                },
+                FieldRange {
+                    start_char_idx: 0,
+                    end_char_idx: 6,
+                    control_idx: 0,
+                },
+            ],
+            ..Default::default()
+        };
+        let mut doc = Document::default();
+        let mut section = Section::default();
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        // 수정 전: document.rs 제거 루프에서 stale 인덱스 슬라이스 패닉.
+        // 수정 후: 패닉 없이 안내문 제거(빈 텍스트).
+        DocumentCore::clear_initial_field_texts(&mut doc);
+        assert!(
+            doc.sections[0].paragraphs[0].text.is_empty(),
+            "안내문이 제거돼 빈 텍스트여야 함"
+        );
+    }
 
     /// 텍스트는 있는데 line_segs 가 비어있는 문단 — LinesegArrayEmpty 감지
     #[test]


### PR DESCRIPTION
## 증상
HWPX 전수 검증(18,388건)에서 `36396650`(정상 ZIP) `rhwp info` **패닉**:
```
document.rs: range start index 23 out of range for slice of length 0
```
손상 ZIP 아님 = 실제 rhwp 버그(1/18,388, 큰 코퍼스가 드러낸 엣지케이스).

## 근본 원인
`clear_initial_field_texts`(ClickHere 안내문 제거):
- 수집 루프는 `fr.end_char_idx <= chars.len()` 가드 후 removals 수집.
- **제거 루프는 앞선 removal 이 `para.text` 를 축소한 뒤 이후 removal 의 수집-시점 `(start,end)` 를 재검증하지 않음.** 같은 텍스트 범위를 가리키는 중첩 field_range 다중 removal 시, 첫 removal 이 텍스트를 비우면(len 0) 다음 removal 의 `chars[end..]` 가 범위 초과 → 패닉.

## 수정 (`src/document_core/commands/document.rs`)
제거 루프에서 현재 `chars.len()` 기준 `start <= end <= len` 범위 가드(초과 시 skip). 안내문 제거는 정규화이므로 드문 무효 케이스 skip 은 안전(패닉 방지 우선).

## 검증
| 게이트 | 결과 |
|--------|------|
| 합성 단위테스트 (중첩 removal 2개 → no panic) | RED(패닉 재현)→**GREEN** |
| 실파일 36396650 `rhwp info` | 패닉→**페이지 수: 2** |
| `cargo test --lib` / clippy / fmt | 1976 passed / 무경고 / 0 diff |

## 참고
독립 수정(document.rs) — −1쪽 갭 시리즈 PR과 무관, devel 직접 기반 단일 커밋.

Closes #1620

🤖 Generated with [Claude Code](https://claude.com/claude-code)