### PR TITLE
Task #1627: HWPX roundtrip bookmark in-order 방출 (empty-text 컨트롤 순서 보존)

### DIFF
--- a/examples/diag_1627.rs
+++ b/examples/diag_1627.rs
@@ -1,0 +1,50 @@
+//! Issue #1627 진단 — HWPX roundtrip 첫 문단 char_shapes 오프셋 shift 원인 분석.
+//! 사용: cargo run --release --example diag_1627 -- <file.hwpx> [para_idx]
+
+use rhwp::model::control::Control;
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+use std::env;
+use std::fs;
+
+fn dump_para(tag: &str, doc: &rhwp::model::document::Document, pi: usize) {
+    let p = &doc.sections[0].paragraphs[pi];
+    let nchars = p.text.chars().count();
+    let cs: Vec<(u32, u32)> = p
+        .char_shapes
+        .iter()
+        .map(|c| (c.start_pos, c.char_shape_id))
+        .collect();
+    let ctrls: Vec<String> = p
+        .controls
+        .iter()
+        .map(|c| {
+            let s = format!("{c:?}");
+            s.chars().take(22).collect::<String>()
+        })
+        .collect();
+    println!("[{tag}] p[{pi}] text_chars={nchars} controls={ctrls:?}");
+    println!("       char_shapes={cs:?}");
+}
+
+fn main() {
+    let args: Vec<String> = env::args().skip(1).collect();
+    let file = &args[0];
+    let pi: usize = args.get(1).and_then(|s| s.parse().ok()).unwrap_or(0);
+    let data = fs::read(file).expect("read");
+
+    let doc1 = parse_hwpx(&data).expect("parse1");
+    dump_para("parse ", &doc1, pi);
+
+    let out = serialize_hwpx(&doc1).expect("serialize");
+    let doc2 = parse_hwpx(&out).expect("reparse");
+    dump_para("reparse", &doc2, pi);
+
+    // 첫 문단 text 의 char 별 코드포인트(앞 40자) — 객체 치환문자 위치 확인
+    let p1 = &doc1.sections[0].paragraphs[pi];
+    let p2 = &doc2.sections[0].paragraphs[pi];
+    let cps1: Vec<u32> = p1.text.chars().take(40).map(|c| c as u32).collect();
+    let cps2: Vec<u32> = p2.text.chars().take(40).map(|c| c as u32).collect();
+    println!("parse   text cp[..40]={cps1:?}");
+    println!("reparse text cp[..40]={cps2:?}");
+}

--- a/mydocs/report/task_m100_1627_report.md
+++ b/mydocs/report/task_m100_1627_report.md
@@ -1,0 +1,66 @@
+# 최종 결과보고서 — Task #1627 (HWPX roundtrip: bookmark in-order 방출 + char_shape IR_DIFF 분석)
+
+**제목**: HWPX roundtrip 첫 문단 char_shapes 오프셋 shift (4건) 조사 및 bookmark 위치 보존
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1627 · **브랜치**: `local/task1627` (base: `upstream/devel`)
+
+## 1. 대상
+HWPX parse→serialize→reparse char_shapes 오프셋 불일치 4건(18,387 중, 증가에도 불변):
+36384689·36385445(+8) · 36388711(−16/−8) · 36399822(표 셀). 전부 **빈-text(객체-only) 문단**.
+
+## 2. 근원 (진단 `examples/diag_1627.rs`)
+대표 36384689 p[0](text 비어있음)에서 두 증상 확인:
+1. **컨트롤 재정렬**: parse `[SectionDef,ColumnDef,Table,PageNumberPos,Bookmark]` →
+   reparse `[…,Bookmark,Table,PageNumberPos]`. 직렬화기가 bookmark 를 문단 시작으로 강제
+   (`section.rs`: "IR 에 위치 정보 없음")해 원본 순서 깨짐.
+2. **char_shape +8**: parse `(24,10)` → reparse `(32,10)`. slot 카운트 회계 차(parse 3 slot=24
+   vs reparse 4 slot=32) — `inferred_control_slot_count` 와 실제 slot 방출의 mismatch("위치
+   추정 불가") 경로에서 발생.
+
+## 3. 수정 — bookmark in-order 방출 (저위험, 옵션 2)
+빈-text 문단의 bookmark 를 문단 시작 강제 대신 **para.controls 순서대로 slot 사이에 in-order
+방출**(zero-width 라 char-position 불변). 비-empty 문단은 종전(문단 시작) 유지 — slot
+char-position 정밀 경로 보호.
+- `src/serializer/hwpx/section.rs`: slot 수집에 `slot_ctrl_indices` 병행, `emit_inorder_bookmarks`
+  헬퍼로 mismatch 경로에서 slot 사이 interleave. empty-text 한정.
+
+**결과**: **컨트롤 순서 round-trip 해소**(parse==reparse 순서 일치). 단위 테스트
+`task1627_empty_para_bookmark_serialized_after_preceding_table` 가드.
+
+## 4. char_shape IR_DIFF — 근본 원인 완전 규명 + 보류 (작업지시자 결정)
+
+### 완전 규명된 근본 원인
+char_count 는 parse=reparse **동일(33)** — 문자/내용 손실 0. 차이는 char_shape **경계 위치만**
+(parse 24 = 3 slot vs reparse 32 = 4 slot, 순수 cosmetic·렌더 무영향).
+
+근원: `is_hwpx_inline_slot`(section.rs:755)이 **SectionDef·ColumnDef 를 slot 에서 제외**하나,
+HWPX char_count 는 이들의 `secPr`/`colPr` 를 **8유닛 위치로 집계**한다. 객체-only 첫 문단
+(secPr+colPr+표+pagenum)에서 `inferred_control_slot_count`(char_count 기반)=4 ≠
+`slots.len()`(inline-only)=2 → **mismatch "위치 추정 불가" 경로** → char_shape 경계 부정확(+8).
+
+### 수정에 필요한 변경 (고위험, 보류 사유)
+precise(main) 경로 진입에 SectionDef/ColumnDef 를 위치-점유 slot 으로 라우팅 필요:
+- `is_hwpx_inline_slot`/slot 수집에 포함 + `render_control_slot` 에 secPr/colPr arm 추가.
+- **그러나 secPr/colPr 는 섹션 템플릿/secPr 작성기로 이미 방출 → 이중 방출 위험.**
+- **#1584 의 ColumnDef 템플릿 흡수 억제 로직과 정면 충돌**(첫 ColumnDef 를 slot 에서 빼는
+  delicate 처리 존재). 전 코퍼스 HWPX roundtrip(99.98% PASS) 위협.
+
+### 판정 (작업지시자 결정: 보류)
+char_count 보존(내용 손실 0)인 cosmetic char_shape 경계 차 4건을 위해 secPr/colPr slot
+라우팅 + #1584 재작업의 corpus-wide 고위험 변경은 비례하지 않음. **알려진 한계로 보존.**
+근본 원인이 완전 규명됐으므로, 향후 secPr/colPr 의 char-position 모델을 정합하는 저위험
+재설계(예: slot 추상화에 zero-emit position-slot 도입) 착수 시 본 분석을 출발점으로 사용.
+(IR_DIFF 4건 잔존 = 빈-text 문단 char_shape 경계.)
+
+## 5. 검증
+| 게이트 | 결과 |
+|--------|------|
+| bookmark in-order 단위 테스트 | RED(시작 강제)→**GREEN** |
+| `cargo test --lib` | 1975 passed / 0 failed |
+| hwpx_roundtrip baseline | 4 passed |
+| clippy / fmt | 무경고 / 0 diff |
+
+## 6. 산출물
+- 소스: `src/serializer/hwpx/section.rs` (bookmark in-order, empty-text 한정)
+- 테스트: `task1627_empty_para_bookmark_serialized_after_preceding_table`
+- 진단: `examples/diag_1627.rs`
+- 보류: char_shape IR_DIFF (slot 회계 고위험)

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -426,52 +426,67 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
 
     let mut splitter = RunSplitter::new(para);
 
-    // Bookmark는 IR에 위치 정보가 없어 문단 시작(첫 run)에 배치한다.
-    // (HWPX 파서가 char_count에 포함하지 않아 slot 시스템이 위치를 추적할 수 없음)
-    for ctrl in &para.controls {
-        if let Control::Bookmark(bm) = ctrl {
-            if let Ok(xml) = writer_to_string(|w| write_bookmark(w, bm)) {
-                splitter.content.push_str("<hp:ctrl>");
-                splitter.content.push_str(&xml);
-                splitter.content.push_str("</hp:ctrl>");
+    // Bookmark는 zero-width 라 slot char-position 축에 안 잡힌다.
+    // - 비-empty 문단: 종전대로 문단 시작(첫 run)에 배치(슬롯 char-position 정밀 경로 보호).
+    // - [Task #1627] empty-text(객체-only) 문단: 문단 시작 강제는 원본 컨트롤 순서(예:
+    //   Table·PageNumberPos 뒤의 Bookmark)를 깨고 roundtrip char_shape 오프셋을 shift시킨다.
+    //   → para.controls 순서대로 slot 사이에 in-order 방출(아래 emit_bookmarks_before).
+    let bm_inorder = para.text.is_empty();
+    if !bm_inorder {
+        for ctrl in &para.controls {
+            if let Control::Bookmark(bm) = ctrl {
+                if let Ok(xml) = writer_to_string(|w| write_bookmark(w, bm)) {
+                    splitter.content.push_str("<hp:ctrl>");
+                    splitter.content.push_str(&xml);
+                    splitter.content.push_str("</hp:ctrl>");
+                }
             }
         }
     }
 
     let slot_count = inferred_control_slot_count(para);
-    let slots: Vec<&Control> = if slot_count == para.controls.len() {
-        // 전 컨트롤이 위치 슬롯인 경로. 본문 첫 문단의 첫 ColumnDef 도 슬롯으로 남겨
-        // char-offset 정합을 보존하고, 그 XML 만 render_control_slot 의 consume-once
-        // 플래그로 억제한다(템플릿이 이미 방출 — 중복 방지). 2번째+ 는 인라인 방출.
-        para.controls.iter().collect()
-    } else {
-        // [Task #1379] 셀·글상자 subList(depth>0) 경로에서는 ColumnDef 도 인라인 슬롯으로
-        // 취급한다 (원본 XML 에 <hp:ctrl><hp:colPr/></hp:ctrl> 인라인 존재).
-        // [Task #1584] 본문(depth 0) 경로에서도 ColumnDef 를 인라인 슬롯에 포함하되,
-        // 첫 문단의 첫 ColumnDef(섹션 템플릿 흡수분)는 슬롯에서 제외한다 — 이 분기는
-        // slot_count 가 char-offset 추정과 어긋나는 케이스로, 템플릿 흡수분은 위치 슬롯을
-        // 점유하지 않으므로(추정 카운트에서 제외됨) 슬롯에 넣으면 위치가 어긋난다.
-        // 2번째+ 본문 ColumnDef 는 포함하여 드롭을 방지한다.
-        let suppress_first_col = ctx.sub_list_depth == 0 && ctx.body_coldef_template_pending;
-        let mut col_seen = 0u32;
-        let collected: Vec<&Control> = para
-            .controls
-            .iter()
-            .filter(|c| {
-                if matches!(c, Control::ColumnDef(_)) {
+    // slots 와 각 slot 의 para.controls 인덱스(slot_ctrl_indices)를 병행 수집 —
+    // [Task #1627] empty-text 문단의 bookmark in-order 방출에서 slot 사이 위치 계산에 사용.
+    let (slots, slot_ctrl_indices): (Vec<&Control>, Vec<usize>) =
+        if slot_count == para.controls.len() {
+            // 전 컨트롤이 위치 슬롯인 경로. 본문 첫 문단의 첫 ColumnDef 도 슬롯으로 남겨
+            // char-offset 정합을 보존하고, 그 XML 만 render_control_slot 의 consume-once
+            // 플래그로 억제한다(템플릿이 이미 방출 — 중복 방지). 2번째+ 는 인라인 방출.
+            (
+                para.controls.iter().collect(),
+                (0..para.controls.len()).collect(),
+            )
+        } else {
+            // [Task #1379] 셀·글상자 subList(depth>0) 경로에서는 ColumnDef 도 인라인 슬롯으로
+            // 취급한다 (원본 XML 에 <hp:ctrl><hp:colPr/></hp:ctrl> 인라인 존재).
+            // [Task #1584] 본문(depth 0) 경로에서도 ColumnDef 를 인라인 슬롯에 포함하되,
+            // 첫 문단의 첫 ColumnDef(섹션 템플릿 흡수분)는 슬롯에서 제외한다 — 이 분기는
+            // slot_count 가 char-offset 추정과 어긋나는 케이스로, 템플릿 흡수분은 위치 슬롯을
+            // 점유하지 않으므로(추정 카운트에서 제외됨) 슬롯에 넣으면 위치가 어긋난다.
+            // 2번째+ 본문 ColumnDef 는 포함하여 드롭을 방지한다.
+            let suppress_first_col = ctx.sub_list_depth == 0 && ctx.body_coldef_template_pending;
+            let mut col_seen = 0u32;
+            let mut s: Vec<&Control> = Vec::new();
+            let mut si: Vec<usize> = Vec::new();
+            for (i, c) in para.controls.iter().enumerate() {
+                let keep = if matches!(c, Control::ColumnDef(_)) {
                     col_seen += 1;
-                    return !(suppress_first_col && col_seen == 1);
+                    !(suppress_first_col && col_seen == 1)
+                } else {
+                    is_hwpx_inline_slot(c)
+                };
+                if keep {
+                    s.push(c);
+                    si.push(i);
                 }
-                is_hwpx_inline_slot(c)
-            })
-            .collect();
-        if suppress_first_col {
-            // 템플릿 흡수분을 슬롯에서 이미 제외했으므로, render_control_slot 의
-            // consume-once 억제가 2번째 ColumnDef 를 잘못 건너뛰지 않도록 플래그 해제.
-            ctx.body_coldef_template_pending = false;
-        }
-        collected
-    };
+            }
+            if suppress_first_col {
+                // 템플릿 흡수분을 슬롯에서 이미 제외했으므로, render_control_slot 의
+                // consume-once 억제가 2번째 ColumnDef 를 잘못 건너뛰지 않도록 플래그 해제.
+                ctx.body_coldef_template_pending = false;
+            }
+            (s, si)
+        };
 
     let mut tab_idx = 0usize;
 
@@ -489,8 +504,22 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
     // mismatch 경로: 슬롯 위치 추정 불가 — 텍스트(경계 분할 포함) 후 슬롯 일괄 방출
     if slot_count != slots.len() {
         split_text_into(&mut splitter, para, &mut tab_idx);
-        for slot in &slots {
+        let mut bm_done = vec![false; para.controls.len()];
+        for (si, slot) in slots.iter().enumerate() {
+            // [Task #1627] empty-text 문단: 이 slot 앞(controls 순서)의 bookmark 를 먼저 방출.
+            if bm_inorder {
+                emit_inorder_bookmarks(
+                    &mut splitter.content,
+                    para,
+                    &mut bm_done,
+                    slot_ctrl_indices[si],
+                );
+            }
             render_control_slot(&mut splitter.content, slot, ctx);
+        }
+        if bm_inorder {
+            // 마지막 slot 뒤에 오는 trailing bookmark.
+            emit_inorder_bookmarks(&mut splitter.content, para, &mut bm_done, usize::MAX);
         }
         // [Task #1556] 위치 추정 불가 경로에서도 고아 fieldEnd 의 8유닛 슬롯은 복원한다
         // (정확한 위치 대신 말미 일괄 — 최소한 char_count 보존).
@@ -783,6 +812,33 @@ fn flush_text_fragment(
     if !text_buf.is_empty() {
         out.push_str(&render_hp_t_content(text_buf, tab_extended, tab_idx));
         text_buf.clear();
+    }
+}
+
+/// [Task #1627] empty-text 문단에서 bookmark 를 para.controls 순서대로 in-order 방출한다.
+/// `upto_ctrl_idx` 미만 인덱스의 미방출 bookmark 만 방출(usize::MAX = 나머지 전부).
+/// bookmark 는 zero-width 라 char-position 을 점유하지 않으므로 slot 사이에 끼워도 위치 불변.
+fn emit_inorder_bookmarks(
+    content: &mut String,
+    para: &Paragraph,
+    bm_done: &mut [bool],
+    upto_ctrl_idx: usize,
+) {
+    for (i, ctrl) in para.controls.iter().enumerate() {
+        if i >= upto_ctrl_idx {
+            break;
+        }
+        if bm_done[i] {
+            continue;
+        }
+        if let Control::Bookmark(bm) = ctrl {
+            if let Ok(xml) = writer_to_string(|w| write_bookmark(w, bm)) {
+                content.push_str("<hp:ctrl>");
+                content.push_str(&xml);
+                content.push_str("</hp:ctrl>");
+            }
+            bm_done[i] = true;
+        }
     }
 }
 
@@ -1801,6 +1857,39 @@ fn render_page_border_fill(ty: &str, pbf: &crate::model::page::PageBorderFill) -
 mod tests {
     use super::*;
     use crate::model::paragraph::{CharShapeRef, Paragraph};
+
+    /// [Task #1627] empty-text(객체-only) 문단에서 bookmark 는 문단 시작으로 끌려가지 않고
+    /// para.controls 순서대로 in-order 방출되어야 한다(원본 컨트롤 순서 보존).
+    #[test]
+    fn task1627_empty_para_bookmark_serialized_after_preceding_table() {
+        use crate::model::control::{Bookmark, Control};
+        use crate::model::table::Table;
+
+        let mut para = Paragraph::default();
+        // empty text, controls 순서 = [Table, Bookmark]
+        para.controls = vec![
+            Control::Table(Box::new(Table::default())),
+            Control::Bookmark(Bookmark {
+                name: "BM_AFTER_TBL".to_string(),
+            }),
+        ];
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        let tbl_pos = xml.find("<hp:tbl");
+        let bm_pos = xml.find("BM_AFTER_TBL");
+        assert!(
+            tbl_pos.is_some(),
+            "table 직렬화 필요: {}",
+            &xml[..400.min(xml.len())]
+        );
+        assert!(bm_pos.is_some(), "bookmark 직렬화 필요");
+        assert!(
+            tbl_pos < bm_pos,
+            "bookmark 가 table 뒤(원본 순서)에 와야 함 — 문단 시작 강제 회귀 (#1627)"
+        );
+    }
 
     fn make_doc_with_paragraph(para: Paragraph) -> (Document, Section) {
         let mut section = Section::default();


### PR DESCRIPTION
## 배경
HWPX parse→serialize→reparse 시 빈-text(객체-only) 문단에서 직렬화기가 **bookmark 를 문단 시작으로 강제**(`section.rs`: "IR 에 위치 정보 없음")해 원본 컨트롤 순서를 깬다. 전수 검증(18,387건)에서 발견.

진단(`examples/diag_1627.rs`, 36384689 p[0]):
- parse: `[SectionDef, ColumnDef, Table, PageNumberPos, Bookmark]`
- reparse(수정 전): `[…, Bookmark, Table, PageNumberPos]` ← bookmark 가 앞으로 끌려감

## 수정 (`src/serializer/hwpx/section.rs`)
빈-text 문단의 bookmark 를 문단 시작 강제 대신 **para.controls 순서대로 slot 사이에 in-order 방출**(zero-width 라 char-position 불변). 비-empty 문단은 종전(문단 시작) 유지 — slot char-position 정밀 경로 보호.
- slot 수집에 `slot_ctrl_indices` 병행, `emit_inorder_bookmarks` 헬퍼로 mismatch 경로 interleave.

**결과**: 컨트롤 순서 round-trip 정합(parse==reparse). 단위 테스트 가드.

## 참고 — char_shape IR_DIFF 는 별개 (보류)
같은 문단의 char_shape 오프셋 +8(24→32)은 bookmark 무관 — slot 카운트 회계(`inferred_control_slot_count` mismatch "위치 추정 불가" 경로) 문제. slot 시스템(UTF-16 위치축) 재작업이 필요한 **고위험·corpus-wide** 변경이며 빈-text 구조-only 차(내용·시각 손실 0)라 보류. (IR_DIFF 4건 잔존.)

## 검증
lib 1975 passed · hwpx_roundtrip baseline 4 passed · clippy 무경고 · fmt 0 diff.

## 참고
독립 수정(serializer), devel 직접 기반 단일 커밋.

Closes #1627

🤖 Generated with [Claude Code](https://claude.com/claude-code)