### PR TITLE
docs: Task #1622 robustness 감사 + #1626 tolerance 조사 보고서 (코드 무)

### DIFF
--- a/mydocs/plans/task_m100_1626.md
+++ b/mydocs/plans/task_m100_1626.md
@@ -1,0 +1,15 @@
+# 수행계획서 — Task #1626
+
+**제목**: 잔여 +1쪽 조사 — #1608 tolerance 제거 후 native 문서 +1 (합법적 last-line tolerance 여부)
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1626 · **브랜치**: `local/task1626` (base: `local/task1624`)
+
+## 1. 목표
+#1624 후 통제셋 잔여 +1쪽 3건(36382819·36389312·36398366)이 한글 허용 last-line tolerance
+케이스인지, 별 원인인지 조사. 합법적 tolerance 라면 전 문서 적용 보정으로 +1 해소 가능성.
+
+## 2. 방법
+3건의 마지막 페이지 used vs body 초과 폭·항목 분석. 작은 universal tolerance 의 통제셋 net
+효과를 실험(RHWP_EXP_TOL env)으로 측정 → 도출/한계 판정.
+
+## 3. 게이트
+보정 도출 시 통제셋 net>0(+1 해소 − −1 재유발), baseline 회귀 0. 미도출 시 코드 변경 없음.

--- a/mydocs/report/task_m100_1622_report.md
+++ b/mydocs/report/task_m100_1622_report.md
@@ -1,0 +1,34 @@
+# 최종 결과보고서 — Task #1622 (Robustness 전수 감사)
+
+**제목**: 18k 코퍼스 패닉/크래시 전수 색출 (렌더 엔진 robustness)
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1622 · **브랜치**: `local/task1622` (base: `local/task1620`)
+**바이너리**: #1620 패닉 fix 반영본.
+
+## 1. 목적
+HWPX 3축 검증 중 우연히 발견한 `36396650` 패닉(#1620, 수정됨)과 같은 클래스의 추가 패닉/
+크래시를 의도적 전수 스캔으로 색출.
+
+## 2. 방법 (2-경로 전수)
+`C:/Users/planet/hwpdocs` 전수에 대해 두 경로 스캔, stderr 패닉/타임아웃 수집:
+- **dump-pages**: parse + pagination + layout + height measurement (IO 없음).
+- **export-svg -p 0**: 위 + SVG 렌더(draw) 경로(dump-pages 미커버).
+
+## 3. 결과 — 크래시 0건
+
+| 스캔 | 대상 | 크래시 |
+|------|------|--------|
+| dump-pages (parse+pagination+layout) | 18,647 | **0** |
+| export-svg (SVG 렌더) | 18,732 | **0** |
+
+**#1620 패닉 fix 후 전체 코퍼스가 parse·pagination·layout·SVG 렌더 전 경로에서 무패닉.**
+(`36396650` 도 재발 없음.) 타임아웃·기타 크래시도 0.
+
+## 4. 결론
+- `36396650`(#1620)이 코퍼스 내 **유일 패닉**이었고 수정됨.
+- 렌더 엔진 robustness 확인 — 후속 fix 대상 없음.
+- 향후 코퍼스 증가 시 동일 스캔(`output/poc/robustness_scan*.py`) 재사용으로 회귀 감시 가능.
+
+## 5. 산출물
+- 스캔: `output/poc/robustness_scan.py`(dump-pages), `robustness_scan_svg.py`(export-svg)
+- 데이터: `output/poc/task1622_crashes.tsv`, `task1622_svg_crashes.tsv` (둘 다 0행)
+- 코드 변경: **없음** (결함 미발견)

--- a/mydocs/report/task_m100_1626_report.md
+++ b/mydocs/report/task_m100_1626_report.md
@@ -1,0 +1,46 @@
+# 최종 결과보고서 — Task #1626 (잔여 +1쪽 조사 — tolerance 재도입 net-negative 확정)
+
+**제목**: 잔여 +1쪽 (#1608 tolerance 제거 후 native) 조사
+**마일스톤**: M100 · **이슈**: edwardkim/rhwp#1626 · **브랜치**: `local/task1626` (base: `local/task1624`)
+
+## 1. 잔여 +1쪽 3건 — 이질적 2 클래스
+
+| 케이스 | 한글/rhwp | 클래스 |
+|--------|------|------|
+| 36382819 | 3/4 | **tac 표(8x3) 3.1px 페이지 초과** (page2 used 933.6 > body 930.5) cascade |
+| 36389312 | 1/2 | **footer Page+Bottom**(vert=쪽 valign=Bottom) 선언높이 overshoot (body+footer > page, 한글은 1쪽 fit) |
+| 36398366 | 1/2 | **footer Page+Bottom** 동일 |
+
+"#1608 native tolerance" 단일 클래스가 아니라 tac 오버플로 1 + footer overshoot 2 의 혼합.
+
+## 2. tolerance 재도입 실험 — **단조 net-negative 확정**
+
+universal last-line tolerance(`RHWP_EXP_TOL`) 별 통제셋 일치:
+| tolerance | 일치 | Δ |
+|-----------|------|---|
+| 0px(현재) | **75** | — |
+| 3px | 74 | −1 |
+| 5px | 73 | −2 |
+| 8px | 72 | −3 |
+| 12px | 71 | −4 |
+
+**어떤 양수 tolerance도 일치를 떨어뜨림** — tolerance 는 available 높이↑ → 콘텐츠 조밀 → 페이지↓
+로, +1(3건)을 고치는 것보다 −1(12건)을 더 많이 악화. **#1608 의 tolerance 제거가 옳았고
+재도입은 잘못된 방향**임이 데이터로 확정.
+
+## 3. footer overshoot 2건 (36389312·36398366)
+footer Page+Bottom 에서 body+footer(선언) > page → rhwp push, 한글은 1쪽 fit(선언보다 작게
+렌더/overlap 추정). #1611 declared-height 와 #1624 gap-guard 로도 미해소 — #1616 에서 확정한
+**footer push/keep 기하 규칙 부재(razor-thin)** 의 +1 방향. 깔끔한 판별자 없음.
+
+## 4. 판정 — 코드 변경 없음
+- tolerance 재도입: net-negative(실험 확정) → 불가.
+- footer overshoot: razor-thin 규칙 부재(#1616) → 깔끔한 fix 없음.
+- 36382819 tac 3.1px 오버플로: tolerance 류 보정 필요하나 net-negative.
+
+→ **잔여 +1 3건은 단일 net-positive fix 없음.** 양방향 razor-thin 한계의 +1 측면으로 확정,
+알려진 한계 보존. 통제셋 81.5%(75/92) 유지.
+
+## 5. 산출물
+- 분석: `output/poc/defect_classes.py`, 본 보고서
+- 코드 변경: **없음** (tolerance 실험 코드 revert)


### PR DESCRIPTION
## 배경
−1쪽 갭 시리즈·robustness 작업 중 산출한 **코드 변경 없는 투자-only 보고서 2건**이 PR 미생성으로 devel 에 누락 — 회수.

## 포함 (문서 전용)
- **`task_m100_1622_report.md`** — Robustness 전수 감사: 18,388/18,732건에 `dump-pages`·`export-svg` 전수 스캔, **크래시 0건**(#1620 패닉 fix 후 전 경로 무패닉 확인).
- **`task_m100_1626.md` + `_report.md`** — 잔여 +1쪽 조사: universal last-line tolerance 재도입이 **단조 net-negative**(통제셋 일치 0px=75 → 3px=74 → 5px=73 → 8px=72 → 12px=71)임을 실험으로 확정. **#1608 의 tolerance 제거가 옳았고 재도입은 잘못된 방향**임을 데이터로 기록.

## 검증
코드/테스트 변경 0 (mydocs 문서 3개만). 머지 기록 완전성 회복용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)