### PR TITLE
HWPX roundtrip IR-invisible 페이지네이션 변동 수정 + 페이지↔PI 검증 도구 (#1636, #1637)

### DIFF
--- a/mydocs/plans/task_m100_1636.md
+++ b/mydocs/plans/task_m100_1636.md
@@ -1,0 +1,66 @@
+# 수행계획서 — HWPX/HWP 불러오기·저장·렌더링 레이아웃 무손실 전수 재검증 v3 (#1636)
+
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task1636` (devel d3627f55 분기)
+- 일자: 2026-06-29
+
+## 1. 배경
+
+직전 v2 검증(2026-06-26, `output/poc/fidelity2/`)은 HWPX 1,135건 대상이었다.
+이후 말뭉치가 `C:\Users\planet\hwpdocs` 로 대폭 확대되었다:
+
+| 포맷 | 위치 | 건수 |
+|------|------|-----:|
+| HWPX | `hwpdocs/samples` (서울 열린데이터 결재문서) | 25,802 |
+| HWP5 | `hwpdocs/law_downloads` (법제처 별표·서식) | 26,346 |
+| 합계 | | **52,148** |
+
+또한 그 사이 페이지붕괴 지배원인(#1594 holdAnchorAndSO / #1595 ClickHere /
+#1596 generic-shape / #1598 ellipse·arc)이 모두 devel에 머지되었다.
+→ **fresh devel 바이너리로 전수 재측정**이 필요하다.
+
+## 2. 바이너리 (stale-binary 함정 회피)
+
+- `devel`(d3627f55)에서 release 빌드. v0.7.17, 빌드 2026-06-29 09:05.
+- ⚠️ 작업 시작 시점 `local/task1627` 바이너리는 #1594/#1595/#1596/#1598 **누락** →
+  붕괴율 거짓 상승. 사용 금지. (v1의 06/12 stale-binary 교훈 재적용.)
+
+## 3. 검증 단계
+
+| 단계 | 내용 | 도구 | 범위 |
+|------|------|------|------|
+| **T1** 불러오기·저장 IR/구조 | parse→serialize→reparse: IR diff + 패키지/CFB + 2-round | `hwpx-roundtrip --batch` / `hwp5-roundtrip --batch` | **전수 52k** |
+| **T2** 텍스트 | 원본 vs 저장본 정규화 텍스트 비교 | export-text | 표본 |
+| **T-PI** 🆕 렌더링 레이아웃 페이지↔PI | 원본 `{(sec,pi):page}` vs 재저장본 비교 → PI가 다른 페이지로 이동 시 보고 | `tools/verify_pi_page_roundtrip.py` (신규) | 표본(IR_DIFF + PASS 무작위) |
+| **T3** 한글 재열림·페이지수 | 저장본 한글 오라클, COLLAPSE 검출 | `tools/verify_hangul_pages.py` | 표본(COM 한계) |
+| **T4** 시각 | 대표 붕괴/차이 케이스 PDF/PNG 육안 | export-pdf/png | 대표 소수 |
+
+### T-PI 설계 (신규 요구사항)
+
+작업지시자 지시: "랜더링 레이아웃 조사 시 페이지와 PI가 매칭되는지 확인, 다른 페이지에
+PI가 랜더링되면 보고." → 저장 전후(roundtrip) 기준 채택.
+
+- 원본 파싱·페이지네이션 → `{(section, pi): {global_page,...}}`
+- 재저장본(rt) 동일 맵 → 비교
+- 판정: SAME / PI_MOVED(같은 PI 다른 페이지) / PAGE_DELTA(총 페이지수 변동) / ERR
+- `dump-pages` 텍스트 출력을 파싱(소스 무수정). PartialParagraph 로 한 PI가 여러
+  페이지에 걸치는 경우는 페이지 **집합** 비교로 처리.
+
+## 4. 산출물 — `output/poc/fidelity3/`
+
+- `hwpx/inventory.tsv`, `hwp5/inventory.tsv` — T1 전수 결과 + 재조립본
+- `pi_page_diff_hwpx.tsv`, `pi_page_diff_hwp5.tsv` — T-PI 페이지↔PI 이동 목록
+- `hangul_pages.tsv` — T3 한글 페이지 오라클
+- `t3t4/` — 시각 대표
+- `report.md` — 종합 보고
+- 스크립트: `tools/verify_pi_page_roundtrip.py`
+
+## 5. 소스 무수정
+
+전 과정 진단/하니스만. 발견된 결함은 후속 이슈 후보로 정리(본 타스크에서 수정하지 않음).
+
+## 6. 주의
+
+- 수집기(collector) 가동 중 → 일부 파일 mid-write 로 PARSE_FAIL 가능(rhwp 결함 아님, 재확인).
+- T1 은 전수, T-PI/T3/T4 는 비용상 표본.
+- IR diff=0 ≠ 무손실 ≠ 시각정합 (v2 교훈) — 한글 오라클(T3) 병행 필수.

--- a/mydocs/pr/archives/pr_1642_report.md
+++ b/mydocs/pr/archives/pr_1642_report.md
@@ -1,0 +1,115 @@
+# PR #1642 사전 처리 판단 보고서
+
+- 작성일: 2026-06-29
+- PR: https://github.com/edwardkim/rhwp/pull/1642
+- 작성자: @planet6897
+- 대상 이슈: #1636, #1637
+- 판단: 문서 보정 및 리뷰 기록 push 후, 최신 CI 확인을 조건으로 approval/merge 가능
+
+## 1. Route 판단
+
+이 PR은 외부 contributor가 fork branch에서 작성한 PR이며, `maintainerCanModify=true`로 확인되었다.
+따라서 collaborator-mediated 외부 PR 경로(Route A)를 적용한다.
+
+적용 결과:
+
+- 원본 PR을 그대로 merge 후보로 유지한다.
+- contributor commit은 rewrite하지 않는다.
+- collaborator의 문서 보정과 리뷰 기록은 PR head에 후속 커밋으로 추가한다.
+- 별도 문서 PR은 만들지 않는다.
+
+## 2. Source PR / commit provenance
+
+문서 작성 직전 PR head 참고값:
+
+- `0bc9a633c1c8466b570d408f4c974d620874d52f`
+
+`upstream/devel..HEAD` 참고 commit list:
+
+| SHA | 내용 |
+|-----|------|
+| `0bc9a633` | Merge branch `devel` into `task/1636-1637-pagination-fidelity` |
+| `e658ee8e` | Merge branch `devel` into `task/1636-1637-pagination-fidelity` |
+| `76738f98` | HWPX roundtrip IR-invisible 페이지네이션 변동 수정 + 페이지↔PI 검증 도구 (#1636, #1637) |
+
+실제 기능 변경은 contributor commit `76738f98489920431132cf279944018dd2afef88`에 포함되어 있다.
+후속 collaborator 커밋은 문서 보정과 리뷰 기록만 포함한다.
+
+## 3. 검토 요약
+
+PR은 HWPX roundtrip에서 IR diff가 0이어도 페이지네이션이 바뀌는 문제를 두 원인으로 나누어 수정한다.
+
+- 원인 A: secPr visibility `hideFirstEmptyLine`이 템플릿 기본값으로 드롭됨
+- 원인 B: table `hp:pos@flowWithText`가 `1`로 하드코딩되어 원본 `0`이 보존되지 않음
+
+수정은 직렬화 출력 보존과 roundtrip diff 게이트 보강을 같이 포함한다. 검토 결과 코드 변경 자체에서
+blocking 수준의 문제는 발견하지 못했다.
+
+## 4. 검증 결과
+
+로컬 worktree `/private/tmp/rhwp-pr1642-latest`에서 수행한 검증:
+
+| 명령 | 결과 |
+|------|------|
+| `cargo test task1637 --lib` | pass |
+| `cargo fmt --all --check` | pass |
+| `python3 -m py_compile tools/verify_pi_page_roundtrip.py` | pass |
+| `cargo test --test hwpx_roundtrip_baseline baseline_large_samples_roundtrip -- --nocapture` | pass |
+| `cargo test --test hwpx_roundtrip_baseline baseline_all_samples_roundtrip -- --nocapture` | pass |
+| `cargo test --test visual_roundtrip_baseline visual_baseline_all_samples -- --nocapture` | pass |
+| `cargo clippy --all-targets -- -D warnings` | pass |
+
+수동 시각 검증 산출물:
+
+- `/private/tmp/rhwp-pr1642-review/output/pr1642_visual/compare.html`
+
+자동 비교 기준:
+
+- PR 전 roundtrip: `STRUCT_MISMATCH`, page 3 max displacement `622.00px`
+- PR head roundtrip: `PASS`, page count `27 -> 27`, max displacement `0.00px`
+
+## 5. Follow-up 분리
+
+다음 두 항목은 별도 이슈로 등록하고 #1637의 sub-issue로 연결했다.
+
+| 이슈 | 내용 | PR #1642 blocking 여부 |
+|------|------|------------------------|
+| #1654 | HWPX -> HWP 변환에서 `hideFirstEmptyLine` flags 동기화 검증 | non-blocking |
+| #1655 | HWPX 수식 `flowWithText` roundtrip 보존 | non-blocking |
+
+#1654는 HWPX roundtrip이 아니라 HWPX를 HWP로 내보낼 때의 `SectionDef.flags` 동기화 검증이다.
+#1655는 수식 개체의 `flowWithText` 하드코딩 잔여 가능성으로, PR #1642의 표 cause B와 같은 속성 계열이지만
+현재 보고된 페이지네이션 회귀의 직접 원인은 아니다.
+
+## 6. GitHub 상태와 merge 전 조건
+
+문서 작성 직전 PR metadata:
+
+- `maintainerCanModify=true`
+- `mergeable=MERGEABLE`
+- `draft=false`
+- label/assignee/review request 정렬 완료
+
+GitHub Actions는 최신 head 기준으로 approval/merge 전 다시 확인해야 한다. 문서 전용 후속 커밋이 추가된 뒤에는
+다음 중 하나가 필요하다.
+
+- 최신 PR head 기준 relevant check 통과
+- 또는 후속 커밋이 `mydocs/**` 문서만 변경하는 single-parent commit이고, 직전 코드 head의 relevant check가
+  success/skipped/neutral인 fast-pass 조건 충족
+
+## 7. Issue close 계획
+
+PR body에 `Closes #1636`, `Closes #1637`가 있더라도 base가 `devel`이라 GitHub auto-close가 실패할 수 있다.
+merge 후에는 다음을 확인한다.
+
+- #1636 state
+- #1637 state
+- auto-close 실패 시 작업지시자 승인 후 수동 close comment 작성 및 close
+
+## 8. 권고
+
+문서 보정 커밋과 리뷰 기록 커밋을 PR head에 push한 뒤, PR comment로 검토 결과와 follow-up 분리 내용을 남긴다.
+그 다음 최신 CI 또는 fast-pass 조건을 확인하고, 작업지시자 승인 후 approval review를 작성하는 순서가 적절하다.
+
+현 시점 판단은 **merge 수용 가능**이다. 다만 approval review, merge, issue close는 이 보고서 작성 이후의
+별도 명시 승인 단계로 남긴다.

--- a/mydocs/pr/archives/pr_1642_review.md
+++ b/mydocs/pr/archives/pr_1642_review.md
@@ -1,0 +1,120 @@
+# PR #1642 리뷰 기록 — HWPX roundtrip IR-invisible 페이지네이션 변동 수정
+
+- 작성일: 2026-06-29
+- PR: https://github.com/edwardkim/rhwp/pull/1642
+- 작성자: @planet6897
+- base: `edwardkim/rhwp:devel`
+- head: `planet6897/rhwp:task/1636-1637-pagination-fidelity`
+- 검토 경로: collaborator-mediated 외부 PR 원본 head 문서 동반(Route A)
+
+## 1. PR 메타 확인
+
+| 항목 | 내용 |
+|------|------|
+| PR 유형 | 외부 contributor PR |
+| maintainer modify | `true` |
+| draft | 문서 작성 직전 기준 `false` |
+| mergeable | 문서 작성 직전 기준 `MERGEABLE` |
+| label | `hwpx`, `serialization`, `roundtrip`, `layout` |
+| assignee | @planet6897 |
+| review request | @postmelee |
+
+`draft`, `mergeable`, `head SHA`, GitHub Actions 상태는 변동 가능하므로 approval/merge 직전에 다시 확인한다.
+
+## 2. 변경 범위
+
+PR의 코드 변경은 HWPX roundtrip 후 IR diff가 0인데도 페이지네이션이 변하는 문제를 줄이기 위한
+직렬화 보존과 게이트 보강이다.
+
+핵심 변경:
+
+- `src/serializer/hwpx/section.rs`
+  - secPr `hp:visibility`를 템플릿 고정값 대신 `SectionDef` IR 값으로 치환해
+    `hideFirstEmptyLine` 등 visibility 계열 값을 보존한다.
+- `src/serializer/hwpx/table.rs`
+  - table `hp:pos@flowWithText` 하드코딩을 제거하고 `c.flow_with_text`를 방출한다.
+- `src/serializer/hwpx/roundtrip.rs`
+  - section visibility와 object `flowWithText` 차이를 `diff_documents` 게이트에 편입한다.
+- `tools/verify_pi_page_roundtrip.py`
+  - 같은 PI가 roundtrip 전후 다른 페이지에 배치되는지 확인하는 검증 도구를 추가한다.
+- `tests/visual_roundtrip_baseline.rs`
+  - 시각 roundtrip baseline 설명과 gate를 보강한다.
+- `mydocs/plans/task_m100_1636.md`
+- `mydocs/report/task_m100_1637_report.md`
+- `mydocs/tech/task1637_pagination_hidefirstemptyline.md`
+
+리뷰 중 확인한 문서 불일치:
+
+- `mydocs/report/task_m100_1637_report.md`는 원인 B를 표 `flowWithText` 드롭으로 규명·수정 완료했다고 기록한다.
+- 반면 `mydocs/tech/task1637_pagination_hidefirstemptyline.md`는 초기 조사 상태인 "미규명/추가 조사" 표현이 남아 있었다.
+- 이 불일치는 코드 동작 문제는 아니며, PR head에 별도 문서 보정 커밋으로 정리한다.
+
+## 3. 원인과 수정 타당성
+
+원인 A는 secPr visibility의 `hideFirstEmptyLine`이 HWPX 직렬화 과정에서 `1 -> 0`으로 드롭되는 문제다.
+파서는 값을 읽고 렌더러는 레이아웃에 반영하지만, 직렬화기는 템플릿 기본값을 방출했고 기존 roundtrip
+게이트는 해당 필드를 비교하지 않았다. PR은 visibility 치환 방출과 section visibility diff를 추가해
+이 누락을 봉인한다.
+
+원인 B는 table `hp:pos@flowWithText`가 `0 -> 1`로 드롭되는 문제다. 원본 treatAsChar 표의
+`flow_with_text=false`가 저장 후 true처럼 방출되면서 표 partial-split 임계가 바뀌고 페이지네이션이
+변했다. PR은 table 직렬화가 IR 값을 사용하도록 바꾸고, object `flowWithText` 비교를 roundtrip
+게이트에 추가한다.
+
+코드 검토 결과, 위 두 수정은 기존 HWPX 직렬화의 속성 보존 누락을 좁게 보정하는 형태이며,
+roundtrip 게이트가 같은 계열의 재발을 잡도록 확장되어 있다.
+
+## 4. 로컬 검증
+
+최신 PR head 기준 별도 worktree에서 다음 검증을 수행했다.
+
+| 검증 | 결과 |
+|------|------|
+| `cargo test task1637 --lib` | pass, 4 tests |
+| `cargo fmt --all --check` | pass |
+| `python3 -m py_compile tools/verify_pi_page_roundtrip.py` | pass |
+| `cargo test --test hwpx_roundtrip_baseline baseline_large_samples_roundtrip -- --nocapture` | pass |
+| `cargo test --test hwpx_roundtrip_baseline baseline_all_samples_roundtrip -- --nocapture` | pass |
+| `cargo test --test visual_roundtrip_baseline visual_baseline_all_samples -- --nocapture` | pass |
+| `cargo clippy --all-targets -- -D warnings` | pass |
+
+## 5. 수동 시각 검증 산출물
+
+외부 재현 파일 접근이 불가능한 상황을 대비해 비교 HTML을 별도 생성했다.
+
+- 산출물: `/private/tmp/rhwp-pr1642-review/output/pr1642_visual/compare.html`
+- 비교 컬럼: Original / Before PR roundtrip / PR roundtrip
+- 확인 대상: Page 1, Page 3
+
+자동 비교 요약:
+
+- PR 전 roundtrip: `STRUCT_MISMATCH`, page 3 max displacement `622.00px`
+- PR head roundtrip: `PASS`, page count `27 -> 27`, max displacement `0.00px`
+
+육안으로는 Page 1 하단의 얇은 선 제거가 가장 보기 쉬운 차이며, Page 3 차이는 주로 구조/배치 안정성
+측면에서 자동 diff가 드러내는 변화다.
+
+## 6. 추가 검토 결과
+
+PR 자체의 blocking 문제는 발견하지 못했다. 다만 본 PR 범위 밖 follow-up 후보는 두 가지다.
+
+- #1654: HWPX -> HWP 변환 경로에서 `hideFirstEmptyLine` 관련 flags 동기화 검증
+- #1655: HWPX 수식 `flowWithText` roundtrip 보존
+
+두 항목은 현재 PR의 수정 범위를 막는 문제는 아니다. 각각 별도 이슈로 등록하고 #1637의 sub-issue로 연결했다.
+
+## 7. 처리 계획
+
+1. 문서 불일치 보정을 별도 커밋으로 PR head에 추가한다.
+2. 본 리뷰 기록과 사전 판단 보고서를 별도 커밋으로 PR head에 추가한다.
+3. PR comment로 로컬 검증, 수동 시각 산출물, follow-up 분리 내용을 공유한다.
+4. GitHub Actions가 최신 head 기준 통과하거나, 문서 전용 후속 커밋 fast-pass 조건을 만족하는지 확인한다.
+5. approval review와 merge는 작업지시자 승인 및 최신 상태 재확인 후 별도 단계로 수행한다.
+
+## 8. 결론
+
+코드 변경은 문제 원인 A/B를 모두 직접 겨냥하고, 회귀 게이트를 함께 보강하고 있다. 로컬 검증과 수동
+시각 산출물 기준으로는 merge 수용 가능하다.
+
+단, 이 문서는 사전 리뷰 기록이다. 최종 approval/merge 전에는 최신 PR head SHA, GitHub Actions,
+mergeable 상태, PR diff에 review 문서가 포함되었는지 다시 확인해야 한다.

--- a/mydocs/report/task_m100_1637_report.md
+++ b/mydocs/report/task_m100_1637_report.md
@@ -1,0 +1,74 @@
+# 최종 보고서 — #1637 HWPX roundtrip 페이지네이션 변동 수정 (원인 A+B 완전 해소)
+
+- 마일스톤: M100 / 브랜치: local/task1637 (devel d3627f55 분기)
+- 일자: 2026-06-29
+- 선행: Task #1636 v3 전수 검증에서 발견(T-PI), 근본원인 조사 `mydocs/tech/task1637_pagination_hidefirstemptyline.md`
+
+## 1. 문제
+
+HWPX parse→serialize→reparse 후 일부 PASS(IR diff=0) 문서의 페이지네이션이 달라져
+PI가 다른 페이지로 렌더링됨(0.77% 표본). IR 게이트·lineseg 게이트 모두 미검출(IR-invisible).
+
+## 2. 지배원인 A (19/23 = 83%)
+
+직렬화기가 secPr `<hp:visibility>` 를 정적 템플릿(`empty_section0.xml`, `hideFirstEmptyLine="0"`)으로
+방출하고 파싱된 `SectionDef`(hide_empty_line 등 6필드)를 무시 → 원본 `hideFirstEmptyLine="1"`
+(첫 빈줄 숨김)이 "0"으로 드롭 → 선두 빈줄 가시화 → 본문 하향 → 페이지 확장/PI 이동.
+`diff_documents` 가 visibility 미비교라 IR diff=0(3중 사각).
+
+## 3. 수정 (소스 2파일)
+
+### (1) 직렬화기 — visibility IR 치환 (`src/serializer/hwpx/section.rs`)
+- `TEMPLATE_VISIBILITY` 상수 + `render_visibility(&SectionDef)` + `replace_visibility()` 추가.
+- `write_section` 에서 page_border_fill 치환 직후 `out = replace_visibility(&out, &section.section_def)`.
+- IR 보존 6필드(hideFirstHeader/Footer/MasterPage·border·fill·hideFirstEmptyLine)를 방출.
+  IR 미보존 2필드(hideFirstPageNum·showLineNumber)는 템플릿 기본값 "0" 유지. (#1388 secPr 치환 동형)
+
+### (2) 게이트 — visibility IR-visible 화 (`src/serializer/hwpx/roundtrip.rs`)
+- `IrDifference::SectionVisibility { section, detail }` 변형 + Display 추가.
+- `diff_visibility(&SectionDef, &SectionDef)` (6필드 비교) 추가, `diff_documents` 루프에 동승.
+- 재발 가드 단위테스트 3건(`task1637_visibility_in_gate` / `_equal_is_empty` / `_roundtrip_preserves_hide_empty_line`).
+
+## 4. 검증
+
+| 항목 | 결과 |
+|------|------|
+| 재현 파일 36374808 | page0 8 → **10** (orig 일치), hideFirstEmptyLine="1" 보존, PASS |
+| 재현 파일 36373372(한글 EXPAND) | page0 9 → **11** (orig 일치), 보존, PASS |
+| 신규 단위테스트 3건 | 전부 ok |
+| lib 전체 테스트 | **1983 passed, 0 failed** |
+| hwpx_roundtrip_baseline | **4 passed** (samples/hwpx 회귀 0) |
+| 전수 IR_DIFF (25,817→26,145) | **5 → 5** (신규 IR 회귀 0; 게이트 추가가 PASS 깨지 않음) |
+| **통제 비교(T-PI shift 23건)** | **SAME 19 / 잔여 4** = hideFirstEmptyLine 케이스 **19/19 전부 해소** |
+| **회귀(T-PI 3,005 표본)** | 23 → 7. 잔여 7 전부 **선존 cause B**: hfel=0 5건은 old-rt와 **바이트 동일**(미변경), hfel=1 1건은 hfel 보존됨(잔여 partial-split), 1건은 기존 23 소속. **신규 회귀 0** |
+| fmt(`cargo fmt --all --check`) | 변경 2파일만, Diff 0 |
+
+**통제 비교 결론(개선−회귀)**: 개선 19, 회귀 0 → 순 +19. 채택 기준 충족.
+
+## 5. 잔여원인 B (4/23 = 17%) — 표 flowWithText 드롭 (규명·수정 완료)
+
+cause A 수정 후 잔여 4건(hfel=0)을 추가 조사 → **section0.xml → table region → table5 →
+`<hp:pos@flowWithText>` 0→1** 로 이진탐색 수렴.
+
+**근본원인**: `src/serializer/hwpx/table.rs:147` `write_pos` 가 `flowWithText="1"` **하드코딩**
+(shape writer `section.rs:1507` 은 `c.flow_with_text` 사용·정상). 원본 표가 `flowWithText="0"`
+(treatAsChar=1)일 때 roundtrip 이 "1"로 드롭 → 표 partial-split 임계 변동 → 페이지네이션 변동.
+#1594 holdAnchorAndSO(같은 함수 직상단) 와 **동형 IR-invisible 결함**.
+
+**수정**:
+- `table.rs:147`: `("flowWithText", "1")` → `("flowWithText", bool01(c.flow_with_text))`.
+- `roundtrip.rs`: `IrDifference::ObjectFlowWithText` + `diff_flow_with_text` 게이트(표 site 동승, #1594 동형) + 단위테스트 `task1637_table_flow_with_text_in_gate`.
+
+**검증**: cause B 4건(36384855·36390819·36400485·36385069) + 복합 1건(36381640, A+B 동반) **전부 SAME**.
+lib **1984 passed**, baseline 4 passed, IR_DIFF 5→5(신규 회귀 0), fmt/clippy clean.
+
+## 6. 잔여 (본 타스크 범위 밖)
+
+- 한글 페이지 붕괴 ~0.5%(#1589), char_shape +8(#1591/#1593).
+- equation `flowWithText` 도 하드코딩(section.rs:1608)이나 cause B 무관 — 별도.
+
+## 6. 산출물
+
+- 소스: `src/serializer/hwpx/section.rs`, `src/serializer/hwpx/roundtrip.rs`
+- 근본원인: `mydocs/tech/task1637_pagination_hidefirstemptyline.md`
+- 검증 데이터: `output/poc/fidelity3/pi_page_fixed_shift23.tsv`, `pi_page_fixed_full.tsv`, `hwpx_fixed/`

--- a/mydocs/tech/task1637_pagination_hidefirstemptyline.md
+++ b/mydocs/tech/task1637_pagination_hidefirstemptyline.md
@@ -1,0 +1,84 @@
+# #1637 근본원인 조사 — HWPX roundtrip IR-invisible 페이지네이션 변동
+
+- 일자: 2026-06-29 / 브랜치: local/task1637 (devel d3627f55)
+- 발견 경위: Task #1636 v3 전수 검증의 T-PI(페이지↔PI roundtrip) — HWPX PASS 표본 3,000 중
+  23건(0.77%)이 IR diff=0·lineseg diff=0 인데도 저장 후 PI가 다른 페이지로 이동.
+
+## 1. 결론 (요약)
+
+| 원인 | 비중 | 성격 | 상태 |
+|------|-----:|------|------|
+| **A. `hideFirstEmptyLine` 직렬화 드롭** | 19/23 (83%) | secPr visibility 1→0 | **규명·검증 완료** |
+| **B. 표 `flowWithText` 직렬화 드롭** | 4/23 (17%) | table pos 0→1 | **규명·검증 완료** |
+
+두 원인 모두 **IR-invisible**: `diff_documents`(roundtrip 게이트)가 해당 필드를 비교하지 않는다.
+HWP5 는 0건 — HWPX serializer 고유.
+
+> 참고: 이 문서는 원인 A 규명 직후의 기술 조사 기록으로 시작되었으나, PR #1642 최종 변경에서
+> 잔여 원인 B도 표 `hp:pos@flowWithText` 드롭으로 규명·수정되었다. 최종 검증 수치는
+> `mydocs/report/task_m100_1637_report.md` 를 기준으로 한다.
+
+## 2. 원인 A — `hideFirstEmptyLine` 드롭 (지배원인, 83%)
+
+### 메커니즘
+- 원본 secPr 의 `<hp:visibility … hideFirstEmptyLine="1" …/>` (첫 빈 줄 숨김)이
+  저장 후 **항상 `hideFirstEmptyLine="0"`** 으로 바뀐다.
+- → 문서 선두의 빈 줄이 보이게 되어 **본문 전체가 아래로 밀리고**, 페이지 하단 항목이
+  다음 페이지로 넘어간다(페이지 확장/PI 이동).
+
+### 3중 사각지대
+1. **파서는 읽는다**: `src/parser/hwpx/section.rs:1274`
+   `b"hideFirstEmptyLine" => sec_def.hide_empty_line = attr_str(&attr) == "1"`
+   → 값은 IR(`SectionDef.hide_empty_line`, `src/model/document.rs:235`)에 보존됨.
+2. **렌더러는 쓴다(레이아웃 영향)**: `src/document_core/queries/rendering.rs:1036`
+   `set_bit(flags, 0x00080000, sd.hide_empty_line)` (bit 19) 등 — 레이아웃에 반영.
+3. **직렬화기는 무시한다**: secPr 는 템플릿 보존 방식(`src/serializer/hwpx/section.rs:4` 주석
+   "secPr/pagePr/grid 등 섹션 정의는 템플릿 보존"). visibility 요소는
+   `src/serializer/hwpx/templates/empty_section0.xml` 의 **정적 문자열**
+   (`hideFirstEmptyLine="0"`)로 그대로 방출되며, `sec_def.hide_empty_line` 로 치환하는 코드가 없다
+   (grep `hideFirstEmptyLine`/`visibility` in serializer → 치환부 0건).
+   기본 상수 `src/serializer/hwpx/canonical_defaults.rs:60`
+   `VISIBILITY_HIDE_FIRST_EMPTY_LINE: bool = false`.
+4. **게이트는 안 본다**: `diff_documents` 가 `hide_empty_line` 미비교 → IR diff=0.
+
+### 검증 (XML 단일필드 revert)
+`zip` 미설치 환경 → `output/poc/fidelity3/_repack.py`(python zipfile, mimetype 무압축 선두)로 재포장.
+
+| 파일 | orig hfel | orig/rt page0 items | rt 에서 hfel 0→1 revert |
+|------|:---:|:---:|:---:|
+| 36374808(농업기술센터 물품검사조서) | 1 | 10 / 8 | **→ 10 (복원)** |
+| 36373372(수난구조대 물품검수조서, 한글 EXPAND) | 1 | 11 / 9 | **→ 11 (복원)** |
+
+대조: 무작위 SAME/PASS 60건 전부 `hideFirstEmptyLine="0"`(roundtrip 무변→SAME). shift 23건 중 19건 `="1"`.
+다른 secPr 필드(outlineShapeIDRef 0→1·noteLine NONE→SOLID·noteSpacing ±1) revert 는 **무효** = 원인 아님.
+
+### 수정 방향 (PR #1642 반영)
+1. **직렬화기**: visibility 의 `hideFirstEmptyLine`(이상적으로 visibility 전 필드: hideFirstHeader/
+   Footer/MasterPage/PageNum/showLineNumber 등)를 템플릿 상수 대신 `sec_def` IR 값으로 치환 방출.
+   secPr 템플릿 치환부(#1388 page margin·#1388 colPr 동형) 패턴 재사용.
+2. **게이트**: `diff_documents` 에 `hide_empty_line`(및 visibility 계열) 비교 추가 → IR-visible 화
+   (단위 테스트로 회귀 가드). #1595 ClickHere·#1594 holdAnchorAndSO 와 동형의 "IR-invisible→게이트 편입" 처리.
+
+## 3. 원인 B — 표 `flowWithText` 드롭 (잔여 17%, 규명·수정 완료)
+
+`hideFirstEmptyLine="0"` 인 4건(36390819·36400485·36385069·36384855)은 A 와 무관.
+대표 36384855(구로소방서 당직상황근무일지): orig 은 9×4 표(pi11)를 page0 하단에 **1행 partial-split**,
+rt 는 split 없이 표 전체를 다음 페이지로. 표 총높이(412.3px)·선행 items used(920.9px) 동일.
+
+- **secPr 원인 아님**: rt body + orig secPr swap → 변화 없음(11 유지).
+- 개별 body 필드(lineWrap SQUEEZE→BREAK·empty run `<hp:t/>`→`<hp:t></hp:t>` 32 vs 8·id 재번호) revert 무효.
+- 추가 이진탐색 결과 table region 의 `hp:pos@flowWithText` 가 원본 `0`에서 roundtrip `1`로 바뀌는
+  지점에 수렴했다.
+- **근본원인**: `src/serializer/hwpx/table.rs` 의 table `write_pos`가 `flowWithText="1"`을
+  하드코딩해, 원본 treatAsChar 표의 `flow_with_text=false`를 보존하지 못했다.
+- **수정**: table 직렬화는 `bool01(c.flow_with_text)`를 사용하고, `diff_documents`에
+  `ObjectFlowWithText` 비교를 추가해 표 `flowWithText` 차이를 IR-visible 게이트로 편입했다.
+- **검증**: cause B 4건과 A+B 복합 1건이 모두 SAME으로 복원되었고, 최종 검증은
+  `mydocs/report/task_m100_1637_report.md`의 수치를 기준으로 한다.
+
+## 4. 산출물·재현 도구
+
+- 검출: `tools/verify_pi_page_roundtrip.py` (#1636)
+- 재포장 디버그: `output/poc/fidelity3/_repack.py`
+- prevalence 스캔: `output/poc/fidelity3/_scan_hfel.py`
+- 재현: `36374808`, `36373372`(원인 A) / `36384855`(원인 B)

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -157,6 +157,15 @@ pub enum IrDifference {
         section: usize,
         detail: String,
     },
+    /// 섹션 `<hp:visibility>`(첫쪽 머리말/꼬리말/바탕쪽 숨김·테두리·배경·첫 빈줄 숨김)
+    /// 불일치 — secPr visibility 보존 게이트 (#1637).
+    ///
+    /// 직렬화기가 visibility 를 IR 대신 템플릿 고정값으로 방출하면 hideFirstEmptyLine 등이
+    /// 드롭되어 페이지네이션이 달라진다(IR-invisible 결함). `detail` 형식은 `diff_page_def` 동형.
+    SectionVisibility {
+        section: usize,
+        detail: String,
+    },
     /// 표 캡션 불일치 — 캡션 보존 게이트 (#1387).
     ///
     /// `path` 는 `…tbl.caption` 까지의 중첩 경로. `detail` 은 존재 비대칭 또는
@@ -219,6 +228,14 @@ pub enum IrDifference {
     /// 개체 `holdAnchorAndSO`(IR `prevent_page_break`) 불일치 — 페이지 하단 앵커
     /// 개체에서 1→0 드롭 시 한글 페이지 붕괴를 유발(#1594). IR-invisible 였던 갭을 봉인.
     ObjectHoldAnchor {
+        section: usize,
+        paragraph: usize,
+        path: String,
+        detail: String,
+    },
+    /// 개체 `flowWithText`(IR `flow_with_text`) 불일치 — 표(treatAsChar)에서 0→1 드롭 시
+    /// partial-split 임계가 흔들려 페이지네이션이 달라진다(#1637). IR-invisible 였던 갭을 봉인.
+    ObjectFlowWithText {
         section: usize,
         paragraph: usize,
         path: String,
@@ -308,6 +325,9 @@ impl std::fmt::Display for IrDifference {
             SectionPageDef { section, detail } => {
                 write!(f, "section[{}] page_def: {}", section, detail)
             }
+            SectionVisibility { section, detail } => {
+                write!(f, "section[{}] visibility: {}", section, detail)
+            }
             TableCaption {
                 section,
                 paragraph,
@@ -378,6 +398,16 @@ impl std::fmt::Display for IrDifference {
                 "section[{}] paragraph[{}]{} holdAnchorAndSO: {}",
                 section, paragraph, path, detail
             ),
+            ObjectFlowWithText {
+                section,
+                paragraph,
+                path,
+                detail,
+            } => write!(
+                f,
+                "section[{}] paragraph[{}]{} flowWithText: {}",
+                section, paragraph, path, detail
+            ),
         }
     }
 }
@@ -443,6 +473,21 @@ fn diff_hold_anchor(
     }
 }
 
+/// 두 개체의 `flow_with_text`(flowWithText) 비교 (#1637). 다르면 detail, 같으면 None.
+fn diff_flow_with_text(
+    a: &crate::model::shape::CommonObjAttr,
+    b: &crate::model::shape::CommonObjAttr,
+) -> Option<String> {
+    if a.flow_with_text == b.flow_with_text {
+        None
+    } else {
+        Some(format!(
+            "expected={} actual={}",
+            a.flow_with_text, b.flow_with_text
+        ))
+    }
+}
+
 /// HWPX 바이트 → parse → serialize → parse → 원본 IR과 비교.
 pub fn roundtrip_ir_diff(hwpx_bytes: &[u8]) -> Result<IrDiff, SerializeError> {
     let doc1 = parse_hwpx(hwpx_bytes)
@@ -487,6 +532,13 @@ pub fn diff_documents(a: &Document, b: &Document) -> IrDiff {
             &b.sections[i].section_def.page_def,
         ) {
             diff.push(IrDifference::SectionPageDef { section: i, detail });
+        }
+
+        // 섹션 visibility(hideFirstEmptyLine 등) 비교 (#1637) — secPr visibility 보존 게이트.
+        if let Some(detail) =
+            diff_visibility(&a.sections[i].section_def, &b.sections[i].section_def)
+        {
+            diff.push(IrDifference::SectionVisibility { section: i, detail });
         }
 
         // 문단별 char_shapes 시퀀스 비교 (#1378) — run 분할 보존 게이트.
@@ -660,6 +712,41 @@ fn diff_page_def(
             a.binding, b.binding
         ));
     }
+    if parts.is_empty() {
+        None
+    } else {
+        Some(parts.join("; "))
+    }
+}
+
+/// 섹션 `<hp:visibility>` 플래그 비교 (#1637) — secPr visibility 보존 게이트.
+///
+/// IR(SectionDef)에 보존되는 6필드만 비교한다(hideFirstPageNum·showLineNumber 는
+/// 파서가 IR 에 적재하지 않으므로 제외). 직렬화기가 visibility 를 IR 로 방출하지 않으면
+/// (특히 hide_empty_line) 페이지네이션이 달라지는 IR-invisible 결함을 게이트화한다.
+fn diff_visibility(
+    a: &crate::model::document::SectionDef,
+    b: &crate::model::document::SectionDef,
+) -> Option<String> {
+    let mut parts: Vec<String> = Vec::new();
+    macro_rules! cmp_field {
+        ($field:ident) => {
+            if a.$field != b.$field {
+                parts.push(format!(
+                    "{}: expected={} actual={}",
+                    stringify!($field),
+                    a.$field,
+                    b.$field
+                ));
+            }
+        };
+    }
+    cmp_field!(hide_header);
+    cmp_field!(hide_footer);
+    cmp_field!(hide_master_page);
+    cmp_field!(hide_border);
+    cmp_field!(hide_fill);
+    cmp_field!(hide_empty_line);
     if parts.is_empty() {
         None
     } else {
@@ -972,6 +1059,15 @@ fn diff_paragraph_char_shapes(
                 // [#1594] holdAnchorAndSO 보존 게이트 — 페이지 하단 앵커 개체 붕괴 봉인.
                 if let Some(detail) = diff_hold_anchor(&ta.common, &tb.common) {
                     diff.push(IrDifference::ObjectHoldAnchor {
+                        section,
+                        paragraph,
+                        path: format!("{path}/ctrl[{ci}]tbl"),
+                        detail,
+                    });
+                }
+                // [#1637] flowWithText 보존 게이트 — 표 partial-split 임계 변동 봉인.
+                if let Some(detail) = diff_flow_with_text(&ta.common, &tb.common) {
+                    diff.push(IrDifference::ObjectFlowWithText {
                         section,
                         paragraph,
                         path: format!("{path}/ctrl[{ci}]tbl"),
@@ -2000,6 +2096,86 @@ mod tests {
         let doc2 = parse_hwpx(&out).expect("reparse");
         let diff = diff_documents(&doc1, &doc2);
         assert!(diff.is_empty(), "{:?}", diff.differences);
+    }
+
+    // ---------- #1637: secPr visibility (hideFirstEmptyLine 등 게이트 동승) ----------
+
+    fn doc_with_visibility(hide_empty_line: bool, hide_header: bool) -> Document {
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        section.section_def.hide_empty_line = hide_empty_line;
+        section.section_def.hide_header = hide_header;
+        doc.sections.push(section);
+        doc
+    }
+
+    #[test]
+    fn task1637_visibility_in_gate() {
+        // hideFirstEmptyLine 등 visibility 차이는 diff_documents(게이트)에서 검출되어야 한다.
+        let a = doc_with_visibility(true, false);
+        let b = doc_with_visibility(false, false);
+        let diff = diff_documents(&a, &b);
+        assert_eq!(diff.differences.len(), 1, "{:?}", diff.differences);
+        match &diff.differences[0] {
+            IrDifference::SectionVisibility { section, detail } => {
+                assert_eq!(*section, 0);
+                assert_eq!(detail, "hide_empty_line: expected=true actual=false");
+            }
+            other => panic!("SectionVisibility 여야 함: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn task1637_visibility_equal_is_empty() {
+        // 동일 visibility 는 차이 0.
+        let diff = diff_documents(
+            &doc_with_visibility(true, true),
+            &doc_with_visibility(true, true),
+        );
+        assert!(diff.is_empty(), "{:?}", diff.differences);
+    }
+
+    #[test]
+    fn task1637_roundtrip_preserves_hide_empty_line() {
+        // hideFirstEmptyLine="1" 문서의 roundtrip 에서 값 보존 + 게이트 0 (직렬화기
+        // visibility IR 치환 검증). 종전엔 템플릿 고정값 "0" 으로 드롭되어 페이지네이션 변동.
+        // serialize_hwpx 는 HWPX 패키지(ZIP)를 반환하므로 reparse 로 값 보존을 검증한다.
+        let doc = doc_with_visibility(true, true);
+        let out = serialize_hwpx(&doc).expect("serialize");
+        let doc2 = parse_hwpx(&out).expect("reparse");
+        assert!(
+            doc2.sections[0].section_def.hide_empty_line,
+            "hide_empty_line=1 이 roundtrip 에서 보존되어야 한다"
+        );
+        assert!(
+            doc2.sections[0].section_def.hide_header,
+            "hide_header=1 이 roundtrip 에서 보존되어야 한다"
+        );
+        // visibility 축의 게이트 0 (다른 축의 near-empty-doc 직렬화 산물은 본 테스트 범위 밖).
+        assert!(
+            diff_visibility(&doc.sections[0].section_def, &doc2.sections[0].section_def).is_none(),
+            "visibility roundtrip 차이가 없어야 한다"
+        );
+    }
+
+    #[test]
+    fn task1637_table_flow_with_text_in_gate() {
+        // 표 flowWithText 차이는 diff_documents(게이트)에서 ObjectFlowWithText 로 검출.
+        use crate::model::table::Table;
+        let mut ta = Table::default();
+        ta.common.flow_with_text = false;
+        let mut tb = Table::default();
+        tb.common.flow_with_text = true;
+        let a = doc_with_control(crate::model::control::Control::Table(Box::new(ta)));
+        let b = doc_with_control(crate::model::control::Control::Table(Box::new(tb)));
+        let diff = diff_documents(&a, &b);
+        assert!(
+            diff.differences
+                .iter()
+                .any(|d| matches!(d, IrDifference::ObjectFlowWithText { .. })),
+            "표 flowWithText 차이는 게이트에서 검출되어야 한다: {:?}",
+            diff.differences
+        );
     }
 
     // ---------- #1403: 그림/도형/묶음 캡션 (게이트 동승) ----------

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -25,7 +25,7 @@ use crate::model::control::{
     AutoNumber, AutoNumberType, CharOverlap, Control, Equation, Field, NewNumber, PageHide,
     PageNumberPos, Ruby,
 };
-use crate::model::document::{Document, Section};
+use crate::model::document::{Document, Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
 use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType};
@@ -59,6 +59,35 @@ const TEMPLATE_SECPR_RUN_OPEN: &str = r#"<hp:run charPrIDRef="0"><hp:secPr "#;
 // [#1407] 템플릿의 하드코딩 본문 colPr(단 정의) — 단일 단 기본값. 첫 문단 IR 에
 // ColumnDef 가 있으면 이 anchor 를 IR 값으로 치환한다 (#1388 secPr 동형).
 const TEMPLATE_BODY_COL_PR: &str = r#"<hp:ctrl><hp:colPr id="" type="NEWSPAPER" layout="LEFT" colCount="1" sameSz="1" sameGap="0"/></hp:ctrl>"#;
+
+// [#1637] 템플릿의 하드코딩 secPr visibility — 전부 기본값(미숨김/SHOW_ALL). 원본의
+// visibility 를 IR(SectionDef) 값으로 치환하지 않으면 hideFirstEmptyLine 등이 드롭되어
+// (특히 ="1" → "0") 선두 빈줄이 가시화되며 본문이 밀려 페이지네이션이 달라진다 (#1388 동형).
+const TEMPLATE_VISIBILITY: &str = r#"<hp:visibility hideFirstHeader="0" hideFirstFooter="0" hideFirstMasterPage="0" border="SHOW_ALL" fill="SHOW_ALL" hideFirstPageNum="0" hideFirstEmptyLine="0" showLineNumber="0"/>"#;
+
+/// SectionDef 의 visibility 플래그를 `<hp:visibility>` 요소로 직렬화.
+///
+/// 파서가 IR 에 보존하는 6필드(hideFirstHeader/Footer/MasterPage·border·fill·
+/// hideFirstEmptyLine)만 치환하고, IR 미보존 필드(hideFirstPageNum·showLineNumber)는
+/// 템플릿 기본값("0")을 유지한다.
+fn render_visibility(sd: &SectionDef) -> String {
+    let b = |v: bool| if v { "1" } else { "0" };
+    let bf = |v: bool| if v { "HIDE_ALL" } else { "SHOW_ALL" };
+    format!(
+        r#"<hp:visibility hideFirstHeader="{}" hideFirstFooter="{}" hideFirstMasterPage="{}" border="{}" fill="{}" hideFirstPageNum="0" hideFirstEmptyLine="{}" showLineNumber="0"/>"#,
+        b(sd.hide_header),
+        b(sd.hide_footer),
+        b(sd.hide_master_page),
+        bf(sd.hide_border),
+        bf(sd.hide_fill),
+        b(sd.hide_empty_line),
+    )
+}
+
+/// 템플릿의 visibility 고정 문자열을 IR 기반 값으로 1회 치환.
+fn replace_visibility(xml: &str, sd: &SectionDef) -> String {
+    xml.replacen(TEMPLATE_VISIBILITY, &render_visibility(sd), 1)
+}
 
 /// 레퍼런스 기준 줄 레이아웃 파라미터.
 const VERT_STEP: u32 = 1600; // vertsize(1000) + spacing(600)
@@ -94,6 +123,8 @@ pub fn write_section(
     // 쪽 테두리/배경 — 템플릿의 하드코딩 borderFillIDRef="1"(테두리 없음)을 IR 값으로
     // 치환한다. 누락 시 문서의 쪽 테두리가 소실되어 외곽 4선 노드가 사라진다(#1388 동형).
     out = replace_page_border_fill(&out, &section.section_def);
+    // [#1637] secPr visibility — 템플릿 고정값을 IR 값으로 치환(hideFirstEmptyLine 등 보존).
+    out = replace_visibility(&out, &section.section_def);
 
     // 바탕쪽(masterPage) — secPr 의 masterPageCnt 치환 + secPr 내부 끝에 idRef 참조 삽입.
     // 누락 시 라운드트립에서 바탕쪽 전체(그 안의 그림/표/문단 노드 포함)가 소실된다.

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -144,7 +144,10 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         &[
             ("treatAsChar", treat),
             ("affectLSpacing", "0"),
-            ("flowWithText", "1"),
+            // [#1637] flowWithText 는 IR(flow_with_text)을 보존한다. 종전 "1" 하드코딩은
+            // treatAsChar 표의 1→0 케이스에서 0→1 드롭으로 표 partial-split 임계를 흔들어
+            // 페이지네이션이 달라졌다(IR-invisible). #1594 holdAnchorAndSO 와 동형.
+            ("flowWithText", bool01(c.flow_with_text)),
             ("allowOverlap", "0"),
             ("holdAnchorAndSO", hold),
             ("vertRelTo", vert_rel_to_str(c.vert_rel_to)),

--- a/tests/visual_roundtrip_baseline.rs
+++ b/tests/visual_roundtrip_baseline.rs
@@ -33,8 +33,7 @@ const VISUAL_XFAIL: &[(&str, &str)] = &[
     // 승격 이력: 그룹 자식/도형 회전(shape_attr) · 쪽 테두리(pageBorderFill) · 바탕쪽
     // (masterPage) · 글머리표(bullet) · borderFill 이미지 채움(imgBrush) · 차트=OLE
     // (<hp:ole binaryItemIDRef>) 직렬화 정정으로 다수 PASS 승격됨.
-    // 잔여: k-water-rfp(대형 복합).
-    ("k-water-rfp.hwpx", "구조 불일치 2페이지(대형, 복합)"),
+    // k-water-rfp(대형 복합)도 #1637 페이지네이션 IR-invisible 변동 수정으로 PASS 승격(제거).
     // opengov 실문서 말뭉치(Task #1564) 신규 편입분은 #1567 직렬화 정정으로 구조 불일치 3건
     // 모두 PASS 승격됨. 잔여: 36392900(라운드트립 변위 드리프트 — base serializer 와 동일,
     // PR #1586 무관 / 본질 정정은 별도 이슈).

--- a/tools/verify_pi_page_roundtrip.py
+++ b/tools/verify_pi_page_roundtrip.py
@@ -1,0 +1,249 @@
+"""페이지↔PI 매칭 오라클 — 저장 전후(원본 ↔ rt) rhwp 페이지네이션의 PI→페이지 배치 비교.
+
+IR 게이트(hwpx-roundtrip/hwp5-roundtrip)는 IR 뼈대 diff 만 본다. 이 도구는 한 단계
+더 들어가 **렌더링 레이아웃(페이지네이션) 충실도**를 본다: 원본을 파싱·페이지네이션해
+얻은 `{(section, pi): {global_page,...}}` 맵과, 재저장본(rt)의 동일 맵을 비교해
+**같은 PI(문단/표)가 다른 페이지로 이동**하면 손실로 보고한다.
+
+판정(파일 단위):
+  - SAME      : 모든 (section,pi) 의 페이지 집합 동일 + 총 페이지수 동일
+  - PI_MOVED  : 일부 (section,pi) 가 다른 페이지에 배치 (페이지수는 같을 수도)
+  - PAGE_DELTA: 총 페이지수 변동 (대개 PI_MOVED 동반; 페이지붕괴/확장)
+  - ERR       : dump-pages 실패(파싱/렌더 오류)
+
+PI_MOVED 또는 PAGE_DELTA 가 1건 이상이면 종료 코드 1.
+
+사용:
+    # inventory 기준 표본 (IR_DIFF 전건 + PASS 무작위 N)
+    python tools/verify_pi_page_roundtrip.py \
+        --inventory output/poc/fidelity3/hwpx/inventory.tsv \
+        --orig-root C:/Users/planet/hwpdocs --rt-root output/poc/fidelity3/hwpx \
+        --status IR_DIFF --pass-sample 300 --seed 42 \
+        -o output/poc/fidelity3/pi_page_diff_hwpx.tsv
+
+    # 폴더 배치(원본↔rt 재귀 매칭)
+    python tools/verify_pi_page_roundtrip.py --batch <원본_폴더> <rt_폴더> -o out.tsv
+
+산출 TSV 컬럼:
+    sample / verdict / orig_pages / rt_pages / n_moved / moved (세부: sec:pi orig{..}→rt{..} ; ...)
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RHWP = ROOT / "target" / "release" / ("rhwp.exe" if sys.platform == "win32" else "rhwp")
+
+PAGE_HDR = re.compile(r"=== 페이지 \d+ \(global_idx=(\d+), section=(\d+), page_num=")
+PI_RE = re.compile(r"\bpi=(\d+)")
+
+
+def git_head() -> str:
+    try:
+        out = subprocess.run(
+            ["git", "rev-parse", "--short", "HEAD"],
+            capture_output=True, text=True, timeout=10,
+        )
+        return out.stdout.strip() or "unknown"
+    except Exception:
+        return "unknown"
+
+
+def dump_pages_map(path: Path, timeout: int = 120):
+    """rhwp dump-pages 출력을 파싱해 {(section, pi): set(global_page)} 와 페이지수를 반환.
+
+    실패 시 (None, None, error_message).
+    """
+    try:
+        proc = subprocess.run(
+            [str(RHWP), "dump-pages", str(path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace",
+            timeout=timeout,
+        )
+    except subprocess.TimeoutExpired:
+        return None, None, "TIMEOUT"
+    except Exception as e:  # noqa: BLE001
+        return None, None, f"EXC:{e}"
+    if proc.returncode != 0:
+        msg = (proc.stderr or proc.stdout or "").strip().splitlines()
+        return None, None, "RC=%d %s" % (proc.returncode, msg[-1] if msg else "")
+
+    mapping: dict[tuple[int, int], set[int]] = {}
+    pages: set[int] = set()
+    cur_section = 0
+    cur_global = -1
+    for line in proc.stdout.splitlines():
+        m = PAGE_HDR.search(line)
+        if m:
+            cur_global = int(m.group(1))
+            cur_section = int(m.group(2))
+            pages.add(cur_global)
+            continue
+        pm = PI_RE.search(line)
+        if pm and cur_global >= 0:
+            key = (cur_section, int(pm.group(1)))
+            mapping.setdefault(key, set()).add(cur_global)
+    if not pages:
+        # 파싱은 됐으나 페이지가 없음(빈 문서/예외) — 오류로 취급
+        return None, None, "NO_PAGES"
+    return mapping, len(pages), None
+
+
+def compare(orig_map, rt_map):
+    """두 맵을 비교해 페이지 집합이 다른 (section,pi) 목록을 반환."""
+    moved = []
+    for key in sorted(set(orig_map) | set(rt_map)):
+        o = orig_map.get(key, set())
+        r = rt_map.get(key, set())
+        if o != r:
+            sec, pi = key
+            moved.append((sec, pi, sorted(o), sorted(r)))
+    return moved
+
+
+def find_rt(rt_root: Path, rel: Path):
+    stem = rel.with_suffix("")
+    for suffix in (".rt.hwpx", ".rt.hwp"):
+        cand = rt_root / (str(stem) + suffix)
+        if cand.exists():
+            return cand
+    return None
+
+
+def collect_inventory(inv: Path, orig_root: Path, rt_root: Path,
+                      status_filter: set[str] | None, pass_sample: int, seed: int):
+    rows = []
+    with open(inv, encoding="utf-8") as fh:
+        reader = csv.DictReader(fh, delimiter="\t")
+        for r in reader:
+            rows.append(r)
+    selected = []
+    pass_pool = []
+    for r in rows:
+        status = r.get("status", "")
+        sample = r.get("sample", "")
+        if status == "PARSE_FAIL":
+            continue
+        rel = Path(sample)
+        # inventory sample 컬럼은 확장자 없는 stem 일 수 있으므로 원본 후보를 탐색
+        orig = None
+        for suffix in (".hwpx", ".hwp"):
+            cand = orig_root / (str(rel.with_suffix("")) + suffix)
+            if cand.exists():
+                orig = cand
+                break
+        if orig is None and (orig_root / rel).exists():
+            orig = orig_root / rel
+        if orig is None:
+            continue
+        rt = find_rt(rt_root, rel)
+        if rt is None:
+            continue
+        relkey = str(rel).replace("\\", "/")
+        if status_filter and status in status_filter:
+            selected.append((orig, rt, relkey))
+        elif status == "PASS":
+            pass_pool.append((orig, rt, relkey))
+    if pass_sample > 0 and pass_pool:
+        random.Random(seed).shuffle(pass_pool)
+        selected.extend(pass_pool[:pass_sample])
+    return selected
+
+
+def collect_batch(orig_root: Path, rt_root: Path):
+    pairs = []
+    for orig in sorted(orig_root.rglob("*")):
+        if orig.suffix.lower() not in (".hwpx", ".hwp"):
+            continue
+        rel = orig.relative_to(orig_root)
+        rt = find_rt(rt_root, rel)
+        if rt is not None:
+            pairs.append((orig, rt, str(rel).replace("\\", "/")))
+    return pairs
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--batch", nargs=2, metavar=("ORIG_ROOT", "RT_ROOT"))
+    ap.add_argument("--inventory", type=Path)
+    ap.add_argument("--orig-root", type=Path)
+    ap.add_argument("--rt-root", type=Path)
+    ap.add_argument("--status", default="IR_DIFF",
+                    help="inventory 모드에서 전건 포함할 status (콤마구분, 기본 IR_DIFF)")
+    ap.add_argument("--pass-sample", type=int, default=0,
+                    help="PASS 중 무작위 표본 수 (기본 0)")
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("--limit", type=int, default=0, help="총 처리 상한(디버그)")
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    if not RHWP.exists():
+        print(f"오류: rhwp 바이너리 없음 — {RHWP}", file=sys.stderr)
+        return 2
+
+    if args.batch:
+        pairs = collect_batch(Path(args.batch[0]), Path(args.batch[1]))
+    elif args.inventory:
+        if not (args.orig_root and args.rt_root):
+            print("오류: --inventory 모드는 --orig-root, --rt-root 필요", file=sys.stderr)
+            return 2
+        status_filter = {s for s in args.status.split(",") if s}
+        pairs = collect_inventory(args.inventory, args.orig_root, args.rt_root,
+                                  status_filter, args.pass_sample, args.seed)
+    else:
+        print("오류: --batch 또는 --inventory 중 하나 필요", file=sys.stderr)
+        return 2
+
+    if args.limit > 0:
+        pairs = pairs[:args.limit]
+
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    n_same = n_moved = n_delta = n_err = 0
+    head = git_head()
+    with open(args.out, "w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["sample", "verdict", "orig_pages", "rt_pages", "n_moved", "moved"])
+        for idx, (orig, rt, relkey) in enumerate(pairs):
+            omap, opages, oerr = dump_pages_map(orig)
+            if oerr:
+                n_err += 1
+                w.writerow([relkey, "ERR", "", "", "", f"orig:{oerr}"])
+                continue
+            rmap, rpages, rerr = dump_pages_map(rt)
+            if rerr:
+                n_err += 1
+                w.writerow([relkey, "ERR", opages, "", "", f"rt:{rerr}"])
+                continue
+            moved = compare(omap, rmap)
+            if not moved and opages == rpages:
+                n_same += 1
+                continue  # SAME 는 TSV 생략(노이즈 절감)
+            verdict = "PAGE_DELTA" if opages != rpages else "PI_MOVED"
+            if verdict == "PAGE_DELTA":
+                n_delta += 1
+            else:
+                n_moved += 1
+            detail = " ; ".join(
+                f"s{sec}:pi{pi} {o}->{r}" for sec, pi, o, r in moved[:40]
+            )
+            if len(moved) > 40:
+                detail += f" ; (+{len(moved) - 40} more)"
+            w.writerow([relkey, verdict, opages, rpages, len(moved), detail])
+            if (idx + 1) % 100 == 0:
+                print(f"  ... {idx + 1}/{len(pairs)} 처리", file=sys.stderr)
+
+    total = len(pairs)
+    print(f"\n[pi-page-roundtrip] HEAD={head} 처리={total}")
+    print(f"  SAME={n_same}  PI_MOVED={n_moved}  PAGE_DELTA={n_delta}  ERR={n_err}")
+    print(f"  → {args.out}")
+    return 1 if (n_moved + n_delta) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요

HWPX parse→serialize→reparse 후 일부 **IR diff=0(PASS)** 문서의 rhwp 페이지네이션이 달라져 PI가 다른 페이지로 렌더링되는 **IR-invisible 결함**을 검출·규명·수정한다. 기존 IR 게이트(`hwpx-roundtrip`)·lineseg 게이트로는 원천 검출 불가였다.

커밋 2건:
- **#1636**: 페이지↔PI roundtrip 검증 도구 + 전수 재검증(하니스·계획)
- **#1637**: 페이지네이션 변동 수정(원인 A+B)

## #1636 — 페이지↔PI 검증 도구

`tools/verify_pi_page_roundtrip.py`: 원본 `{(section,pi):page}` vs 재저장본 비교로 저장 전후 PI 페이지 이동을 검출(소스 무수정 진단). 전수 재검증(HWPX 25.8k+HWP5 26.6k)에서 HWPX 0.77% 표본의 페이지 이동을 발견 → #1637.

## #1637 — 수정 (원인 A+B, 둘 다 #1594 holdAnchorAndSO 동형)

**원인 A (지배, 83%)**: 직렬화기가 secPr `<hp:visibility>` 를 정적 템플릿(`hideFirstEmptyLine=0`)으로 방출하고 파싱된 `SectionDef`(6필드)를 무시 → 원본 `hideFirstEmptyLine=1`(첫 빈줄 숨김)이 `0` 으로 드롭 → 선두 빈줄 가시화 → 본문 하향.

**원인 B (잔여, 17%)**: `table.rs` `write_pos` 가 `flowWithText=1` 하드코딩 → 원본 표 `flowWithText=0`(treatAsChar)가 `1` 로 드롭 → 표 partial-split 임계 변동.

### 변경
- `section.rs`: `render_visibility`/`replace_visibility` — visibility 6필드 IR 치환
- `table.rs`: `flowWithText` 를 `c.flow_with_text` 에서 방출
- `roundtrip.rs`: `IrDifference::SectionVisibility`/`ObjectFlowWithText` + `diff_visibility`/`diff_flow_with_text` 게이트(IR-visible화) + 단위테스트 4건

## 검증
- 재현 6건 전부 SAME, lib **1984 passed / 0 failed**, `hwpx_roundtrip_baseline` **4 passed**
- 전수 IR_DIFF **5→5**(신규 회귀 0), fmt/clippy clean
- **통제비교 T-PI 3,005 표본 이동: 23(무수정) → 7(원인 A) → 0(원인 A+B)**

closes #1636
closes #1637

🤖 Generated with [Claude Code](https://claude.com/claude-code)