### PR TITLE
페이지↔PI 검증 도구 + TAC 표 직후 빈 문단 누락 수정 (#1643, #1648)

### DIFF
--- a/mydocs/pr/archives/pr_1652_report.md
+++ b/mydocs/pr/archives/pr_1652_report.md
@@ -1,0 +1,92 @@
+# PR #1652 사전 처리 판단 보고서 — 페이지↔PI 검증 도구 + TAC 표 직후 빈 문단 누락 수정
+
+## 1. 결정
+
+**merge 수용 권고** — 최신 코드 head `071e9771` 기준 로컬 검증과 GitHub Actions가 통과했다.
+
+이 보고서는 merge 전 사전 판단 보고서다. merge 완료, merge SHA, 이슈 close 완료 여부를 확정 사실로 기록하지
+않는다. 문서 커밋 push 후 최신 PR head 기준 CI와 merge state를 다시 확인해야 한다.
+
+## 2. 변경 본질
+
+이번 PR은 #1643의 페이지↔PI 비교 도구와 #1648의 TAC 표 직후 빈 문단 누락 수정을 함께 제출한다.
+
+- `tools/verify_pi_page_vs_hangul.py`: rhwp `dump-pages` 결과와 한글 OLE 자동화 결과를 PI 단위로 비교한다.
+- `src/renderer/typeset.rs`: `next_will_vpos_reset`에서 빈 문단을 fit 검사 없이 skip하던 경로를 보정한다.
+- `tests/issue_1116.rs`: 한컴 기준으로 trailing 빈 문단이 보존되는 sample16 기대값을 갱신한다.
+- `mydocs/report/task_m100_1648_report.md`: #1648 수정과 #1659 회귀 보정 내용을 기록한다.
+
+초기 수정은 height-only fit으로 충분하지 않았고, #1659에서 `synam-001` 페이지수 35→36 회귀가 확인됐다.
+최신 head는 placement와 맞춘 vpos fit을 AND로 추가하여 이 회귀를 해소했다.
+
+## 3. 판단 근거
+
+- PR base는 `devel`이고, 문서 작성 시점 merge state는 `CLEAN`이다.
+- contributor 원 commit은 `071e9771` 1개이며, collaborator가 원 커밋을 rewrite하지 않는다.
+- 이전 review에서 요청한 3건은 모두 반영됐다.
+  - report가 #1659 회귀 보정까지 포함하도록 갱신됨
+  - `MATCH` 샘플도 TSV 행으로 기록됨
+  - `PartialParagraph` continuation의 top vpos 기준이 `start_line`으로 보정됨
+- 최신 코드 head 기준 GitHub Actions는 통과했다.
+  - Build & Test: success
+  - CodeQL: success
+  - Canvas visual diff: success
+- `closingIssuesReferences`가 비어 있으므로 issue close는 merge 후 별도 확인이 필요하다.
+
+## 4. 검증 결과
+
+| 항목 | 결과 |
+|------|------|
+| GitHub CI (`071e9771`) | Build & Test / CodeQL / Canvas visual diff 성공 |
+| `python3 -B -m py_compile tools/verify_pi_page_vs_hangul.py` | 통과 |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `cargo fmt --check` | 통과 |
+| `cargo test --test issue_1156_rowbreak_fragment_fit` | 통과 (3 passed) |
+| `cargo test --test issue_1116` | 통과 (13 passed) |
+| `cargo test --test issue_676_trailing_empty_para` | 통과 (3 passed) |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| `cargo test --lib` | 통과 (1988 passed, 0 failed, 7 ignored) |
+
+PR 작성자가 보고서에 기록한 한컴 환경 검증:
+
+- 재현 36399821: 빈 문단 `pi=2`가 1쪽에 배치되고 페이지수 5 유지
+- `synam-001`: #1659 회귀 보정 후 35쪽 유지
+- sample16 p3: trailing 빈 문단 `pi=87` emit 보존
+- 400-HWPX 통제 비교: PAGE_INFLATE 0 / PAGE_DEFLATE 0 / ADD_ONLY 9 / REMOVED 0 / CROSS_MOVED 0
+
+## 5. PR head 문서 push 계획
+
+Route A, collaborator-mediated 외부 PR 경로로 처리한다.
+
+- 문서 추가 경로:
+  - `mydocs/pr/archives/pr_1652_review.md`
+  - `mydocs/pr/archives/pr_1652_report.md`
+- 문서 commit은 contributor 원 commit 뒤에 별도 commit으로 추가한다.
+- push 대상은 `planet6897:task/1643-1648-pi-page-verify`이다.
+- push 후 PR diff에 위 두 문서만 추가됐는지 확인한다.
+- push 후 최신 PR head 기준 GitHub Actions를 다시 확인한다.
+
+## 6. 기여자 credit
+
+- 원 PR: https://github.com/edwardkim/rhwp/pull/1652
+- 원 작성자: @planet6897 (Jaeuk Ryu)
+- 원 소스 커밋:
+  - `071e9771a3038e93964531a41b0ec2194ce2f277`
+    `Task #1643/#1648: 페이지↔PI 검증 도구 + TAC 표 직후 빈 문단 누락 수정`
+- collaborator 문서 커밋은 검토 기록만 추가하며 contributor 코드 credit을 변경하지 않는다.
+
+## 7. merge 전 조건
+
+- 문서 커밋이 포함된 최신 PR head 기준 GitHub Actions 통과
+- PR diff에 `pr_1652_review.md`, `pr_1652_report.md` 포함 확인
+- 해소된 inline review thread resolve 처리
+- approval review 제출
+- merge 전 최신 `mergeable` / `mergeStateStatus` 재확인
+- 작업지시자 merge 승인
+
+## 8. merge 후 확인 계획
+
+- `#1643`, `#1648`, `#1659` state 확인
+- 자동 close가 되지 않으면 작업지시자 승인 후 수동 close 및 comment 처리
+- PR에 merge 완료 comment 작성
+- 필요 시 로컬 `devel` sync 및 작업 worktree 정리

--- a/mydocs/pr/archives/pr_1652_review.md
+++ b/mydocs/pr/archives/pr_1652_review.md
@@ -1,0 +1,109 @@
+# PR #1652 검토 — 페이지↔PI 검증 도구 + TAC 표 직후 빈 문단 누락 수정
+
+- 작성일: 2026-06-29 18:02 KST
+- 컨트리뷰터: [@planet6897](https://github.com/planet6897) (Jaeuk Ryu)
+- PR: https://github.com/edwardkim/rhwp/pull/1652
+- base/head: `devel` `180e394d` ← `planet6897:task/1643-1648-pi-page-verify` `071e9771`
+- 관련 이슈: `Closes #1643`, `Closes #1648`, `Closes #1659`
+- 규모: +388 / -6, 4 files
+- 상태 참고값: open, draft 아님, `MERGEABLE` / `CLEAN`, 기존 review decision은 `CHANGES_REQUESTED`
+
+위 상태값은 문서 작성 시점 참고값이다. merge 전에는 최신 PR head 기준 `mergeable`, `mergeStateStatus`,
+GitHub Actions, review decision을 다시 확인해야 한다.
+
+## 1. PR 정보
+
+변경 파일:
+
+| 파일 | 변경 |
+|------|------|
+| `tools/verify_pi_page_vs_hangul.py` | 한글 OLE와 rhwp `dump-pages`의 PI별 페이지 배치를 대조하는 검증 도구 추가 |
+| `src/renderer/typeset.rs` | TAC 표 직후 빈 문단 누락 방지 fit 검사 추가 및 #1659 vpos 보정 |
+| `tests/issue_1116.rs` | sample16 trailing 빈 문단 배치 기대값 갱신 |
+| `mydocs/report/task_m100_1648_report.md` | #1648 수정 및 #1659 회귀 보정 검증 보고서 추가 |
+
+커밋:
+
+| SHA | 내용 | 작성자 |
+|-----|------|--------|
+| `071e9771` | `Task #1643/#1648: 페이지↔PI 검증 도구 + TAC 표 직후 빈 문단 누락 수정` | @planet6897 |
+
+## 2. 변경 내용 분석
+
+이번 PR은 두 가지 작업을 함께 담는다.
+
+1. `tools/verify_pi_page_vs_hangul.py`를 추가해 rhwp의 PI별 시작 페이지와 한글 OLE 자동화의
+   `SetPos(0, para, 0)` + `current_page` 결과를 TSV로 대조한다. 다구역 문서는 섹션별 문단 수 누적값으로
+   본문 연속 PI에 매핑한다.
+2. `src/renderer/typeset.rs`의 `next_will_vpos_reset` 분기에서 페이지를 거의 채운 TAC 표 직후 빈 문단이
+   fit 검사 없이 skip되던 문제를 수정한다. 최종 구현은 height fit만 보지 않고 placement와 맞는 vpos fit도
+   함께 확인한다.
+
+초기 force-push 전 검토에서 요청했던 세 가지는 최신 head에서 모두 반영됐다.
+
+| 요청 항목 | 확인 결과 |
+|-----------|-----------|
+| 보고서가 #1659 이전 height-only 설명에 머물러 있음 | `task_m100_1648_report.md`가 #1659 회귀와 height+vpos AND 최종 구현 기준으로 갱신됨 |
+| 검증 도구가 `MATCH` 행을 TSV에 쓰지 않음 | `MATCH`도 `sample / MATCH / rhwp_pages / hwp_pages / 0 / ""` 형태로 기록함 |
+| `PartialParagraph { start_line > 0 }`에서 원 문단 첫 LINE_SEG를 사용함 | `PartialParagraph`는 `line_segs[start_line]` 기준 vpos를 사용하고, `PartialTable`은 vpos 판정을 보류함 |
+
+## 3. 검토 의견
+
+### 수용 근거
+
+- #1643의 검증 도구는 성공/불일치/오류 샘플을 TSV에서 구분할 수 있고, Windows+한컴+pyhwpx 환경 전제를
+  도구 상단과 PR 설명에 명확히 남겼다.
+- #1648 수정은 원래 문제였던 "현재 페이지에 들어가는 빈 문단까지 무조건 skip"을 좁게 고친다.
+- #1659 회귀 보정으로 음수 줄간격이 있는 페이지에서 height 누적값만 믿고 단독 빈 페이지를 만들던 경로를 막았다.
+- `PartialParagraph` continuation의 top vpos 기준이 `start_line`으로 보정되어, 페이지 fragment 시작 줄과
+  fit 판정 기준이 어긋날 가능성을 줄였다.
+- 최신 PR head 기준 GitHub Actions가 통과했다.
+  - CI / Build & Test: success
+  - CodeQL: rust, javascript-typescript, python success
+  - Render Diff / Canvas visual diff: success
+  - WASM Build: skipped (CI 조건상 skip)
+- 로컬 검증에서도 대상 테스트, 전체 lib 테스트, fmt, clippy가 통과했다.
+
+### 리스크
+
+- `verify_pi_page_vs_hangul.py`는 Windows + 한컴 OLE 자동화 + pyhwpx 의존 도구라 일반 CI에서 직접 실행하기 어렵다.
+  대신 도구 자체의 Python 문법 검사와 PR 작성자의 한컴 환경 검증 결과를 함께 기록한다.
+- `PartialTable`은 줄 기준 `vpos`를 직접 산출하지 못해 vpos fit을 보류하고 height fit에 위임한다. 현 구현의
+  보수적 fallback으로 수용 가능하지만, 향후 table fragment의 vpos 기준을 별도로 모델링하면 재검토할 수 있다.
+- `closingIssuesReferences`가 GitHub API에서 비어 있으므로, merge 후 `#1643`, `#1648`, `#1659` 자동 close 여부를
+  반드시 확인해야 한다.
+
+## 4. 로컬 검증
+
+검증 기준 worktree: `/private/tmp/rhwp-pr1652-rereview`
+
+| 항목 | 결과 |
+|------|------|
+| `python3 -B -m py_compile tools/verify_pi_page_vs_hangul.py` | 통과 |
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `cargo fmt --check` | 통과 |
+| `cargo test --test issue_1156_rowbreak_fragment_fit` | 통과 (3 passed) |
+| `cargo test --test issue_1116` | 통과 (13 passed) |
+| `cargo test --test issue_676_trailing_empty_para` | 통과 (3 passed) |
+| `cargo clippy --all-targets -- -D warnings` | 통과 |
+| `cargo test --lib` | 통과 (1988 passed, 0 failed, 7 ignored) |
+
+비고: worktree checkout 중 `pdf-large/hwpx/2026_oss_rst.pdf` LFS pointer 경고가 있었으나, 기존 대용량 파일
+상태에서 재현되는 경고이며 이번 PR diff에는 포함되지 않는다.
+
+## 5. 경로 결정
+
+**Route A: original PR merge 후보.**
+
+- PR 작성자는 외부 contributor이고 `maintainerCanModify=true`이다.
+- 최신 PR head는 `upstream/devel` 위 단일 contributor commit으로 정리되어 있다.
+- 변경 범위가 목적과 일치하고, cherry-pick integration PR로 분리할 사유가 없다.
+- collaborator-mediated 외부 PR 경로에 따라 review 문서를 `mydocs/pr/archives/`에 포함하고 contributor PR head에
+  문서 전용 커밋으로 push한다.
+
+## 6. 권고
+
+**수용 / approval review 후 merge 권고.**
+
+단, 문서 전용 커밋을 PR head에 push한 뒤 최신 head 기준 GitHub Actions 재실행 결과를 확인해야 한다. 이후
+approval review를 제출하고, merge 전 `mergeable` / `mergeStateStatus` / review decision을 다시 확인한다.

--- a/mydocs/report/task_m100_1648_report.md
+++ b/mydocs/report/task_m100_1648_report.md
@@ -1,0 +1,87 @@
+# 최종 보고서 — #1648 페이지 채운 TAC 표 직후 빈 문단 누락 수정
+
+- 마일스톤: M100 / 브랜치: local/task1643 (upstream/devel)
+- 일자: 2026-06-29 / 선행: #1643 vs-한글 페이지↔PI 비교의 `rhwp_pNone` 케이스
+
+## 1. 문제
+
+페이지를 거의 채운 treat_as_char(TAC) 표 직후의 **빈 문단 1개가 페이지네이션에서 누락**되어
+어느 페이지에도 배치되지 않음(시각적으로 빈 줄 1개 손실). 한글은 해당 빈 문단을 페이지 하단에 배치
+→ rhwp 페이지↔PI 가 한글과 어긋남(#1643 표본에서 관측).
+
+## 2. 근본원인
+
+기본 페이지네이션 엔진은 **TypesetEngine**(`typeset_section_with_variant`)이다
+(Paginator=engine.rs 는 `RHWP_USE_PAGINATOR=1` fallback). Task #362 "단독 빈페이지 차단" 가드
+(`src/renderer/typeset.rs`, `next_will_vpos_reset` 분기)가 빈 문단을 **fit 검사 없이 무조건 skip**:
+
+```rust
+if next_will_vpos_reset {                 // 현재 para 마지막 vpos>5000 && 다음 para 첫 vpos<=0
+    let is_empty_no_ctrl = para.text.is_empty() && para.controls.is_empty();
+    if is_empty_no_ctrl {
+        continue;                          // ← 빈 문단 skip (fit 미검사)
+    }
+    ...
+}
+```
+
+재현 36399821: pi2(빈 문단, vpos=68606) 직후 pi3(2쪽 첫 표, vpos=0) → `next_will_vpos_reset=true`,
+pi2 empty+no-ctrl → skip. 하지만 pi2 는 1쪽 하단(used 911 + 17 ≤ body 952)에 **들어감** → 누락은 오류.
+형제 가드(`else if` next_force_break 분기)는 `empty_h_px > avail` fit 검사를 하나 이 분기는 누락.
+
+## 3. 수정
+
+`is_empty_no_ctrl` skip 에 **fit 검사 추가**(형제 가드와 동형): 빈 문단이 현재 페이지에 들어가면
+정상 emit(한글 동작), 안 들어갈 때만 skip(단독 빈 페이지 차단 목적 보존).
+
+단, 최초 height-only 검사는 회귀를 유발했고(§4 의 #1659), 최종 구현은 **height·vpos AND** 이다:
+
+```rust
+// 1) height fit: 합산 current_height 기준 (종전 #1648 판정)
+let empty_h_px = para.line_segs.first()
+    .map(|s| hwpunit_to_px((s.line_height + s.line_spacing) as i32, self.dpi))
+    .unwrap_or(0.0);
+let height_fits = empty_h_px <= st.available_height() - st.current_height;
+
+// 2) [#1659] vpos fit: placement(L2333/L2339)와 동일한 page_top_vpos 기준 vpos 판정
+//    (single-col 한정). PartialParagraph continuation 은 line_segs[start_line],
+//    줄 기준 vpos 없는 항목(PartialTable)은 판정 보류(height 위임).
+let vpos_fits = /* page_top_vpos + body_h_hu + 283 기준 vpos_end 비교, 불가 시 true */;
+
+if !(height_fits && vpos_fits) { continue; }   // 둘 다 fit 일 때만 emit
+```
+
+## 4. 검증
+
+### 4.1 #1659 회귀와 보정
+
+최초 height-only 검사(`empty_h_px > avail`)는 **음수 줄간격 문단**이 있는 페이지에서 회귀를 냈다.
+합산 `current_height` 가 실제 vpos 진행을 과소평가 → 페이지 하단 빈 문단을 현재 페이지에 fit 으로
+오판 emit, 그러나 placement 는 vpos overflow 로 새 페이지에 단독 배치 → **단독 빈 페이지 +1**
+(`samples/synam-001.hwp` 35→36, `issue_1156_rowbreak_fragment_fit` 의 한컴 PDF 페이지수 게이트 위반).
+
+400-HWPX 통제셋이 이 패턴(음수 줄간격)을 포함하지 않아 최초 검증에서 누락됨. 보정으로 `vpos_fits`
+조건을 AND 추가하여 placement 와 fit 판정을 일치시켰다(§3).
+
+### 4.2 최종 검증
+
+| 항목 | 결과 |
+|------|------|
+| 재현 36399821 | pi2 → **1쪽 배치**(전 미배치), 전체 PI 0..41 배치, 페이지수 5 유지 |
+| synam-001 (#1659 회귀) | **35쪽**(한컴 PDF 일치) 복원 |
+| sample16 p3 (#1648 대상) | 빈 문단 pi=87 **emit 보존**(items 19→20, 한컴 2022 PDF 검증) |
+| `cargo test` 전체 | **2668 passed, 0 failed** (`issue_1156` + `issue_1116` 포함) |
+| hwpx_roundtrip_baseline | pass |
+| **통제 비교(old vs new, 400 HWPX, 결정론적)** | PAGE_INFLATE 0 / PAGE_DEFLATE 0 / ADD_ONLY(pNone→placed) 9 / REMOVED 0 / CROSS_MOVED 0 |
+| fmt / clippy | clean |
+
+**결론**: 수정은 종전 누락되던 빈 문단을 한글처럼 페이지 하단에 배치하되(통제셋 9건 pNone→placed),
+음수 줄간격 페이지에서 단독 빈 페이지를 만들지 않아 **페이지수 중립**(synam-001 35 유지). 가드 본래
+목적(단독 빈 페이지 차단)은 보존.
+
+## 5. 산출물
+
+- 소스: `src/renderer/typeset.rs` (빈 문단 fit 검사 = height·vpos AND, #1648 + #1659)
+- 회귀 가드: `tests/issue_1116.rs`(스냅샷 갱신), `tests/issue_1156_rowbreak_fragment_fit.rs`(synam-001 35 유지)
+- 검출 도구: `tools/verify_pi_page_vs_hangul.py` (#1643, MATCH 행 포함 TSV)
+- 관련: #1643(vs-한글 검증), #1659(회귀 보정), closes #1648

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2034,8 +2034,76 @@ impl TypesetEngine {
                 //  잘못 skip 되어 표 누락).
                 let is_empty_no_ctrl = para.text.is_empty() && para.controls.is_empty();
                 if is_empty_no_ctrl {
-                    // 빈 문단 skip (단독 빈페이지 차단)
-                    continue;
+                    // [#1648] 빈 문단이 현재 페이지에 들어가면 정상 배치한다(한글 동작 —
+                    //   페이지 하단에 빈 줄 1개). 들어가지 않을 때만 skip 하여 단독 빈 페이지를
+                    //   차단한다. 종전엔 fit 무검사로 fit 하는 빈 문단까지 드롭하여, 페이지를
+                    //   채운 TAC 표 직후의 빈 문단이 누락되고 페이지↔PI 가 한글과 어긋났다
+                    //   (#1643 rhwp_pNone).
+                    //
+                    // 1) height fit: 합산 current_height 기준 (종전 #1648 판정).
+                    let empty_h_px = para
+                        .line_segs
+                        .first()
+                        .map(|s| hwpunit_to_px((s.line_height + s.line_spacing) as i32, self.dpi))
+                        .unwrap_or(0.0);
+                    let height_fits = empty_h_px <= st.available_height() - st.current_height;
+
+                    // 2) [#1659] vpos fit: 합산 height 는 음수 줄간격 문단에서 실제 vpos 진행을
+                    //   과소평가 → 페이지 하단 빈 문단을 height fit 으로 오판 emit 하지만 placement
+                    //   (아래 vpos overflow 가드, ~L2300)는 vpos overflow 로 새 페이지에 단독 배치
+                    //   → 단독 빈 페이지 +1 회귀(synam-001 35→36). placement(L2333/L2339)와 동일한
+                    //   page_top_vpos 기준 vpos 판정을 AND 로 더해, height·vpos 둘 다 fit 일 때만
+                    //   emit. placement 가 height 기반인 다단/wrap 에선 vpos 판정을 생략(true).
+                    let vpos_fits = if st.col_count == 1 && st.wrap_around_cs < 0 {
+                        // 페이지 첫 실 item 의 top vpos. PartialParagraph continuation 은 원
+                        //   문단의 첫 줄이 아니라 fragment 시작 줄(start_line)의 vpos 가 페이지
+                        //   상단이다 → line_segs[start_line] 사용. 줄 기준 vpos 가 없는 항목
+                        //   (PartialTable continuation)은 None 으로 두어 vpos 판정을 보류(height
+                        //   fit 에 위임) — 잘못된 baseline 으로 skip/emit 오판 방지(#1659 리뷰).
+                        let page_top_vpos = st
+                            .current_items
+                            .iter()
+                            .find(|item| !matches!(item, PageItem::EndnoteSeparator { .. }))
+                            .and_then(|item| match item {
+                                PageItem::FullParagraph { para_index }
+                                | PageItem::Table { para_index, .. }
+                                | PageItem::Shape { para_index, .. } => paragraphs
+                                    .get(*para_index)
+                                    .and_then(|p| p.line_segs.first())
+                                    .map(|s| s.vertical_pos),
+                                PageItem::PartialParagraph {
+                                    para_index,
+                                    start_line,
+                                    ..
+                                } => paragraphs
+                                    .get(*para_index)
+                                    .and_then(|p| p.line_segs.get(*start_line))
+                                    .map(|s| s.vertical_pos),
+                                // 줄 기준 vpos 없음 → 판정 보류.
+                                PageItem::PartialTable { .. }
+                                | PageItem::EndnoteSeparator { .. } => None,
+                            });
+                        match (para.line_segs.last(), page_top_vpos) {
+                            (Some(last_seg), Some(top)) => {
+                                let body_h_hu = crate::renderer::px_to_hwpunit(
+                                    st.layout.body_area.height,
+                                    self.dpi,
+                                );
+                                let vpos_end = last_seg.vertical_pos + last_seg.line_height;
+                                vpos_end <= top + body_h_hu + 283
+                            }
+                            // vpos 판정 불가 → 제약 없음(height fit 에 위임).
+                            _ => true,
+                        }
+                    } else {
+                        true
+                    };
+
+                    if !(height_fits && vpos_fits) {
+                        // 빈 문단이 현재 페이지에 안 들어감 → skip (단독 빈 페이지 차단)
+                        continue;
+                    }
+                    // height·vpos 둘 다 fit → 정상 emit (아래로 진행)
                 } else {
                     // 일반 텍스트 또는 컨트롤 보유: 안전마진 1회 비활성화 (단독 텍스트 페이지 차단)
                     st.skip_safety_margin_once = true;

--- a/tests/issue_1116.rs
+++ b/tests/issue_1116.rs
@@ -327,15 +327,18 @@ fn sample16_hwp5_page3_dump_pages_reports_line_spacing_in_height() {
 fn sample16_hwp5_page3_dump_pages_summary_uses_lineseg_spacing() {
     let doc = load_doc("samples/hwp3-sample16-hwp5.hwp");
     let dump = doc.dump_page_items(Some(2));
+    // #1648 수정으로 페이지 하단 빈 문단(pi=87)이 한컴처럼 page3 에 배치(items 19→20).
+    // 한컴 2022 PDF(pdf/hwp3-sample16-hwp5-2022.pdf) p3 마지막 가시줄=pi=86, p4 시작="(2) 주전산센터…"
+    // 로 가시 경계 동일 — 종전 누락되던 trailing 빈 문단만 올바르게 합산.
     let summary = dump
         .lines()
-        .find(|line| line.contains("단 0 (items=19"))
+        .find(|line| line.contains("단 0 (items=20"))
         .unwrap_or_else(|| panic!("p3 단 요약을 찾을 수 없음:\n{dump}"));
 
     assert!(
-        summary.contains("used=874.5px")
-            && summary.contains("hwp_used≈813.9px")
-            && summary.contains("diff=+60.6px"),
+        summary.contains("used=904.1px")
+            && summary.contains("hwp_used≈841.6px")
+            && summary.contains("diff=+62.5px"),
         "p3 단 요약은 HWP3-origin spacing_before와 마지막 LINE_SEG의 ls 포함 vpos 흐름을 표시해야 함: {summary}"
     );
 }

--- a/tools/verify_pi_page_vs_hangul.py
+++ b/tools/verify_pi_page_vs_hangul.py
@@ -1,0 +1,224 @@
+"""rhwp 렌더링 레이아웃 vs OLE HWP(한글) 페이지↔PI 매칭 검증.
+
+rhwp 가 각 문단(PI)을 배치한 페이지를, 한글(OLE 자동화)이 같은 문단을 배치한 페이지와
+대조한다. 두 도구 모두 동일 .hwpx/.hwp 의 본문 `<hp:p>` 문단을 0-기반으로 동일 카운트하므로
+PI 인덱스가 1:1 정렬된다(다중 구역은 구역별 문단수 누적 오프셋으로 본문 연속 인덱스에 매핑).
+
+- rhwp:   `rhwp dump-pages` → 각 pi 의 시작 페이지(해당 pi 가 처음 등장한 1-기반 페이지).
+- 한글:   `SetPos(0, para, 0)` 후 `current_page`(1-기반 절대 페이지).
+
+판정(파일 단위):
+  MATCH      : 모든 PI 의 페이지가 일치 + 총 페이지수 동일
+  PI_MISMATCH: 일부 PI 가 다른 페이지 (페이지수는 같을 수도)
+  PAGE_DELTA : 총 페이지수 불일치 (대개 PI_MISMATCH 동반)
+  PARA_COUNT : rhwp/한글 문단수 불일치(정렬 불가) — 별도 분류
+  ERR        : 한글 열기/처리 실패
+
+PI_MISMATCH/PAGE_DELTA 1건↑ 종료코드 1.
+
+사용:
+    python tools/verify_pi_page_vs_hangul.py --batch <원본폴더> [--sample N] [--seed S] -o out.tsv
+    python tools/verify_pi_page_vs_hangul.py --files a.hwpx b.hwp -o out.tsv
+
+요구: Windows + 한컴오피스 + pyhwpx. rhwp release 바이너리.
+산출 TSV: sample / verdict / rhwp_pages / hwp_pages / n_mismatch / detail
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import random
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RHWP = ROOT / "target" / "release" / ("rhwp.exe" if sys.platform == "win32" else "rhwp")
+PG = re.compile(r"=== 페이지 (\d+) \(global_idx=\d+, section=(\d+),")
+PI = re.compile(r"\bpi=(\d+)")
+
+
+def git_head() -> str:
+    try:
+        return subprocess.run(["git", "rev-parse", "--short", "HEAD"],
+                              capture_output=True, text=True, timeout=10).stdout.strip() or "?"
+    except Exception:
+        return "?"
+
+
+def rhwp_pi_pages(path: Path):
+    """rhwp dump-pages → ({(section,pi): start_page_1based}, total_pages, section_para_counts)."""
+    try:
+        out = subprocess.run([str(RHWP), "dump-pages", str(path)], capture_output=True,
+                             text=True, encoding="utf-8", errors="replace", timeout=120)
+    except Exception as e:  # noqa: BLE001
+        return None, None, None, f"rhwp:{e}"
+    if out.returncode != 0:
+        return None, None, None, "rhwp:rc"
+    start: dict[tuple[int, int], int] = {}
+    pages = set()
+    cur_page = 0
+    cur_sec = 0
+    max_pi: dict[int, int] = {}
+    for ln in out.stdout.splitlines():
+        m = PG.search(ln)
+        if m:
+            cur_page = int(m.group(1))
+            cur_sec = int(m.group(2))
+            pages.add(cur_page)
+            continue
+        q = PI.search(ln)
+        if q and cur_page:
+            pi = int(q.group(1))
+            key = (cur_sec, pi)
+            if key not in start or cur_page < start[key]:
+                start[key] = cur_page
+            max_pi[cur_sec] = max(max_pi.get(cur_sec, 0), pi)
+    if not pages:
+        return None, None, None, "rhwp:nopages"
+    sec_counts = {s: max_pi[s] + 1 for s in max_pi}
+    return start, len(pages), sec_counts, None
+
+
+def hwp_para_pages(hwp, path: Path):
+    """한글 SetPos+current_page → {abs_para: page_1based}, total_pages."""
+    hwp.open(str(path))
+    total = hwp.PageCount
+    hwp.MoveDocEnd()
+    end = hwp.GetPos()  # (list, para, pos)
+    max_para = end[1]
+    mp = {}
+    for para in range(max_para + 1):
+        hwp.SetPos(0, para, 0)
+        mp[para] = hwp.current_page
+    hwp.clear(option=1)
+    return mp, total, max_para + 1
+
+
+def compare(rhwp_start, sec_counts, hwp_pages):
+    """rhwp (section,pi)→page 를 연속 abs 인덱스로 변환 후 한글과 비교."""
+    # 구역별 누적 오프셋 (구역 0 부터 정렬된 순서)
+    offsets = {}
+    acc = 0
+    for s in sorted(sec_counts):
+        offsets[s] = acc
+        acc += sec_counts[s]
+    rhwp_abs = {}
+    for (s, pi), pg in rhwp_start.items():
+        rhwp_abs[offsets.get(s, 0) + pi] = pg
+    mism = []
+    for idx in sorted(set(rhwp_abs) | set(hwp_pages)):
+        rp = rhwp_abs.get(idx)
+        hp = hwp_pages.get(idx)
+        if rp != hp:
+            mism.append((idx, rp, hp))
+    return mism, acc
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--batch", type=Path, help="원본 폴더(재귀)")
+    g.add_argument("--files", nargs="+", type=Path)
+    ap.add_argument("--sample", type=int, default=0)
+    ap.add_argument("--seed", type=int, default=42)
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    ap.add_argument("--restart-every", type=int, default=400)
+    args = ap.parse_args()
+
+    if not RHWP.exists():
+        print(f"오류: rhwp 바이너리 없음 {RHWP}", file=sys.stderr)
+        return 2
+    try:
+        from pyhwpx import Hwp
+    except ImportError:
+        print("오류: pyhwpx 미설치", file=sys.stderr)
+        return 2
+
+    if args.batch:
+        files = [p for p in sorted(args.batch.rglob("*"))
+                 if p.suffix.lower() in (".hwpx", ".hwp")]
+    else:
+        files = list(args.files)
+    if args.sample and len(files) > args.sample:
+        rng = random.Random(args.seed)
+        files = sorted(rng.sample(files, args.sample))
+
+    head = git_head()
+    subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+    hwp = Hwp(new=True, visible=False)
+
+    n_match = n_mism = n_delta = n_para = n_err = 0
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+    with open(args.out, "w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["# git_head=" + head])
+        w.writerow(["sample", "verdict", "rhwp_pages", "hwp_pages", "n_mismatch", "detail"])
+        for i, f in enumerate(files):
+            rel = str(f.relative_to(args.batch)) if args.batch else f.name
+            rel = rel.replace("\\", "/")
+            rstart, rpages, sec_counts, rerr = rhwp_pi_pages(f)
+            if rerr:
+                n_err += 1
+                w.writerow([rel, "ERR", "", "", "", rerr])
+                fh.flush()
+                continue
+            try:
+                hpages, htotal, hcount = hwp_para_pages(hwp, f)
+            except Exception as e:  # noqa: BLE001
+                n_err += 1
+                w.writerow([rel, "ERR", rpages, "", "", f"hwp:{type(e).__name__}"])
+                fh.flush()
+                try:
+                    subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+                    hwp = Hwp(new=True, visible=False)
+                except Exception:
+                    pass
+                continue
+            rcount = sum(sec_counts.values())
+            if rcount != hcount:
+                n_para += 1
+                w.writerow([rel, "PARA_COUNT", rpages, htotal, abs(rcount - hcount),
+                            f"rhwp_paras={rcount} hwp_paras={hcount}"])
+                fh.flush()
+                continue
+            mism, _ = compare(rstart, sec_counts, hpages)
+            if not mism and rpages == htotal:
+                n_match += 1
+                # MATCH 도 TSV 에 기록 — 성공 샘플과 미실행 샘플을 산출물에서 구분.
+                w.writerow([rel, "MATCH", rpages, htotal, 0, ""])
+                fh.flush()
+                continue
+            verdict = "PAGE_DELTA" if rpages != htotal else "PI_MISMATCH"
+            if verdict == "PAGE_DELTA":
+                n_delta += 1
+            else:
+                n_mism += 1
+            detail = " ; ".join(f"pi{idx} rhwp_p{rp}|hwp_p{hp}" for idx, rp, hp in mism[:40])
+            if len(mism) > 40:
+                detail += f" ; (+{len(mism) - 40} more)"
+            w.writerow([rel, verdict, rpages, htotal, len(mism), detail])
+            fh.flush()
+            if (i + 1) % args.restart_every == 0:
+                try:
+                    hwp.quit()
+                    subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+                    hwp = Hwp(new=True, visible=False)
+                except Exception:
+                    pass
+    try:
+        hwp.quit()
+        subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+    except Exception:
+        pass
+    total = len(files)
+    print(f"\n[pi-page-vs-hangul] HEAD={head} 처리={total}")
+    print(f"  MATCH={n_match} PI_MISMATCH={n_mism} PAGE_DELTA={n_delta} "
+          f"PARA_COUNT={n_para} ERR={n_err}")
+    print(f"  → {args.out}")
+    return 1 if (n_mism + n_delta) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요

rhwp 페이지네이션이 한글(OLE)과 어긋나는 케이스를 측정하는 검증 도구(#1643)와, 그 도구로 발견한 빈 문단 누락 버그 수정(#1648)을 함께 제출한다.

## #1643 — 페이지↔PI 검증 도구

`tools/verify_pi_page_vs_hangul.py`
- `rhwp dump-pages` 의 각 PI 시작 페이지를, 한글 `SetPos(0,para,0)` + `current_page` 와 1:1 대조
- 다구역 문서는 구역별 문단수 누적 오프셋으로 본문 연속 인덱스에 매핑
- 판정: MATCH / PI_MISMATCH / PAGE_DELTA / PARA_COUNT / ERR (불일치 1건↑ 종료코드 1)
- 요구: Windows + 한컴오피스 + pyhwpx + rhwp release 바이너리

## #1648 — TAC 표 직후 빈 문단 누락 수정

페이지를 거의 채운 treat_as_char(TAC) 표 직후의 **빈 문단 1개가 페이지네이션에서 누락**되어 어느 페이지에도 배치되지 않던 문제. 한글은 해당 빈 문단을 페이지 하단에 배치한다.

**근본원인**: `src/renderer/typeset.rs` 단독 빈페이지 차단 가드(Task #362)의 `next_will_vpos_reset` 분기가 빈 문단을 **fit 검사 없이 무조건 skip**. 형제 가드(`next_force_break` 분기)는 fit 검사를 하지만 이 분기는 누락.

**수정**: 형제 가드와 동형으로 fit 검사 추가 — 빈 문단이 현재 페이지에 들어가면 정상 emit(한글 동작), 안 들어갈 때만 skip(단독 빈 페이지 차단 목적 보존).

## 검증

| 항목 | 결과 |
|------|------|
| lib 전체 | 1980 passed, 0 failed |
| hwpx_roundtrip_baseline | 4 passed |
| 통제 비교 (old vs new, 400 HWPX, 결정론적) | PAGE_INFLATE 0 / PAGE_DEFLATE 0 / ADD_ONLY(pNone→placed) 9 / REMOVED 0 / CROSS_MOVED 0 |

수정은 **페이지수 완전 중립**(0 inflate/deflate)으로, 종전 누락되던 빈 문단을 올바른 페이지에 배치하기만 한다.

Closes #1643
Closes #1648