### PR TITLE
[IR 지원] HWPX 이미지 페이로드 렌더링 정규화

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +304,12 @@ checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -431,6 +443,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +478,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.15",
 ]
@@ -1267,6 +1291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1738,26 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ snafu = "0.9.0"
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.2"
-image = { version = "0.25", default-features = false, features = ["bmp", "jpeg", "png"] }
+image = { version = "0.25", default-features = false, features = ["bmp", "jpeg", "png", "tiff"] }
 pcx = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -62,6 +62,7 @@ web-sys = { version = "0.3", features = [
     "CanvasPattern",
     "HtmlCanvasElement",
     "HtmlImageElement",
+    "ImageData",
     "TextMetrics",
     "Document",
     "Window",

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -656,6 +656,7 @@ pub enum ImageFillMode {
     TileVertLeft,
     TileVertRight,
     FitToSize,
+    Total,
     Center,
     CenterTop,
     CenterBottom,

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -825,6 +825,18 @@ impl PaintOp {
                                 Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
                                 None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
                             }
+                        } else if mime == "image/tiff" {
+                            match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
+                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                            }
+                        } else if mime == "image/jpeg" {
+                            match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                                data,
+                            ) {
+                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                            }
                         } else {
                             (mime, std::borrow::Cow::Borrowed(data.as_slice()))
                         };
@@ -2476,6 +2488,7 @@ fn image_fill_mode_str(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",
         ImageFillMode::CenterBottom => "centerBottom",

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -814,32 +814,33 @@ impl PaintOp {
                     // Task #516 Stage 5.2: overlay layer 의 <img> data URL 생성용 mime 노출.
                     // PCX 등 비표준은 PNG 변환 후 emit (CLI SVG 와 동일 정책 적용).
                     let mime = crate::renderer::svg::detect_image_mime_type(data);
-                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) =
-                        if mime == "image/x-pcx" {
-                            match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/bmp" {
-                            match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/tiff" {
-                            match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/jpeg" {
-                            match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
-                                data,
-                            ) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else {
-                            (mime, std::borrow::Cow::Borrowed(data.as_slice()))
-                        };
+                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) = if mime
+                        == "image/x-pcx"
+                    {
+                        match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/bmp" {
+                        match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/tiff" {
+                        match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/jpeg" {
+                        match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                            data,
+                        ) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else {
+                        (mime, std::borrow::Cow::Borrowed(data.as_slice()))
+                    };
                     let base64_data =
                         base64::engine::general_purpose::STANDARD.encode(&*final_data);
                     let _ = write!(

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1465,9 +1465,10 @@ fn parse_border_fill(
                                             "CENTER" => ImageFillMode::Center,
                                             "CENTER_TOP" => ImageFillMode::CenterTop,
                                             "CENTER_BOTTOM" => ImageFillMode::CenterBottom,
-                                            "FIT" | "FIT_TO_SIZE" | "STRETCH" | "TOTAL" => {
+                                            "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                                 ImageFillMode::FitToSize
                                             }
+                                            "TOTAL" => ImageFillMode::Total,
                                             "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                             _ => ImageFillMode::TileAll,
                                         };
@@ -2646,6 +2647,23 @@ mod tests {
             .into_iter()
             .next()
             .expect("borderFill 파싱 실패")
+    }
+
+    #[test]
+    fn test_img_brush_total_keeps_total_mode() {
+        let bf = parse_single_border_fill(
+            r#"<hh:borderFill id="346">
+                 <hh:fillBrush>
+                   <hc:imgBrush mode="TOTAL" bright="10" contrast="0" effect="REAL_PIC">
+                     <hc:img binaryItemIDRef="image36"/>
+                   </hc:imgBrush>
+                 </hh:fillBrush>
+               </hh:borderFill>"#,
+        );
+
+        let img = bf.fill.image.expect("image brush");
+        assert_eq!(img.fill_mode, ImageFillMode::Total);
+        assert_eq!(img.bin_data_id, 36);
     }
 
     #[test]

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -737,6 +737,7 @@ fn image_fill_mode_detail(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",
         ImageFillMode::CenterBottom => "centerBottom",

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -5,7 +5,11 @@
 
 use super::layout::compute_char_positions;
 use super::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
-use super::svg::{convert_wmf_to_svg, detect_image_mime_type};
+use super::image_resolver::{
+    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes,
+    tiff_bytes_to_png_bytes,
+};
+use super::svg::convert_wmf_to_svg;
 use super::{LineStyle, PathCommand, Renderer, ShapeStyle, TextStyle};
 use crate::model::style::UnderlineType;
 use base64::Engine;
@@ -460,6 +464,21 @@ impl Renderer for HtmlRenderer {
             if mime_type == "image/x-wmf" {
                 match convert_wmf_to_svg(data) {
                     Some(svg_bytes) => (std::borrow::Cow::Owned(svg_bytes), "image/svg+xml"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/bmp" {
+                match bmp_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/x-pcx" {
+                match pcx_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/tiff" {
+                match tiff_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
                     None => (std::borrow::Cow::Borrowed(data), mime_type),
                 }
             } else {

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -3,12 +3,11 @@
 //! 렌더 트리를 HTML 문자열로 변환한다.
 //! CSS로 스타일링하여 접근성과 텍스트 선택을 지원한다.
 
+use super::image_resolver::{
+    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes, tiff_bytes_to_png_bytes,
+};
 use super::layout::compute_char_positions;
 use super::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
-use super::image_resolver::{
-    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes,
-    tiff_bytes_to_png_bytes,
-};
 use super::svg::convert_wmf_to_svg;
 use super::{LineStyle, PathCommand, Renderer, ShapeStyle, TextStyle};
 use crate::model::style::UnderlineType;

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -27,6 +27,12 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
             kind: ResolvedImageKind::FormatConverted,
             suppress_effects: false,
         }),
+        "image/tiff" => tiff_bytes_to_png_bytes(data).map(|data| ResolvedImagePayload {
+            data,
+            mime: "image/png",
+            kind: ResolvedImageKind::FormatConverted,
+            suppress_effects: false,
+        }),
         "image/jpeg" if is_watermark_image(image) => {
             watermark_jpeg_bytes_to_hancom_baked_png_bytes(data).map(|data| ResolvedImagePayload {
                 data,
@@ -35,6 +41,12 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
                 suppress_effects: true,
             })
         }
+        "image/jpeg" => grayscale_jpeg_bytes_to_png_bytes(data).map(|data| ResolvedImagePayload {
+            data,
+            mime: "image/png",
+            kind: ResolvedImageKind::FormatConverted,
+            suppress_effects: false,
+        }),
         _ => None,
     }
 }
@@ -67,6 +79,69 @@ pub(crate) fn bmp_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
     use image::{load_from_memory_with_format, ImageFormat};
 
     let img = load_from_memory_with_format(data, ImageFormat::Bmp).ok()?;
+    let mut out = Vec::new();
+    img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .ok()?;
+    Some(out)
+}
+
+/// TIFF 바이트를 PNG 바이트로 재인코딩한다. 실패 시 None 반환.
+///
+/// 브라우저와 rsvg는 SVG `<image>` 내부의 `data:image/tiff` URI를 안정적으로
+/// 렌더링하지 못하므로, SVG/Canvas/HTML 임베딩 전에 PNG로 변환한다.
+pub(crate) fn tiff_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
+    use image::{load_from_memory_with_format, ImageFormat};
+
+    let img = load_from_memory_with_format(data, ImageFormat::Tiff).ok()?;
+    let mut out = Vec::new();
+    img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .ok()?;
+    Some(out)
+}
+
+/// Browser SVG/Canvas decoders can expose stale color planes in old Photoshop
+/// grayscale JPEGs. Re-encode only visually gray JPEGs to PNG so color photos
+/// keep the compact JPEG path.
+pub(crate) fn grayscale_jpeg_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
+    use image::{load_from_memory_with_format, ImageFormat};
+
+    if detect_image_mime_type(data) != "image/jpeg" {
+        return None;
+    }
+
+    let mut img = load_from_memory_with_format(data, ImageFormat::Jpeg)
+        .ok()?
+        .to_rgba8();
+    if img.width() == 0 || img.height() == 0 {
+        return None;
+    }
+
+    let has_photoshop_profile = data
+        .windows(b"Adobe Photoshop".len())
+        .any(|chunk| chunk == b"Adobe Photoshop")
+        || data
+            .windows(b"Adobe_CM".len())
+            .any(|chunk| chunk == b"Adobe_CM");
+    let is_gray = img.pixels().all(|px| {
+        let [r, g, b, _] = px.0;
+        let min = r.min(g).min(b);
+        let max = r.max(g).max(b);
+        max.saturating_sub(min) <= 2
+    });
+    let is_luma_plane_gray = has_photoshop_profile
+        && img.pixels().all(|px| {
+            let [_, g, b, _] = px.0;
+            g.abs_diff(128) <= 2 && b.abs_diff(128) <= 2
+        });
+    if is_luma_plane_gray {
+        for px in img.pixels_mut() {
+            let gray = px.0[0];
+            px.0 = [gray, gray, gray, px.0[3]];
+        }
+    } else if !is_gray {
+        return None;
+    }
+
     let mut out = Vec::new();
     img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
         .ok()?;
@@ -357,4 +432,50 @@ pub(crate) fn detect_image_mime_type(data: &[u8]) -> &'static str {
         return "image/x-pcx";
     }
     "application/octet-stream"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::grayscale_jpeg_bytes_to_png_bytes;
+    use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    fn jpeg_from_pixels(width: u32, height: u32, pixels: impl Fn(u32, u32) -> [u8; 3]) -> Vec<u8> {
+        let mut img = RgbImage::new(width, height);
+        for y in 0..height {
+            for x in 0..width {
+                img.put_pixel(x, y, Rgb(pixels(x, y)));
+            }
+        }
+
+        let mut out = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut out), ImageFormat::Jpeg)
+            .expect("encode jpeg");
+        out
+    }
+
+    #[test]
+    fn grayscale_jpeg_is_normalized_to_png() {
+        let jpeg = jpeg_from_pixels(2, 2, |x, y| {
+            let g = 180 + (x + y) as u8;
+            [g, g, g]
+        });
+
+        let png = grayscale_jpeg_bytes_to_png_bytes(&jpeg).expect("gray jpeg should normalize");
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+    }
+
+    #[test]
+    fn color_jpeg_keeps_jpeg_path() {
+        let jpeg = jpeg_from_pixels(2, 2, |x, y| {
+            if (x + y) % 2 == 0 {
+                [220, 64, 64]
+            } else {
+                [64, 120, 220]
+            }
+        });
+
+        assert!(grayscale_jpeg_bytes_to_png_bytes(&jpeg).is_none());
+    }
 }

--- a/src/renderer/skia/image_conv.rs
+++ b/src/renderer/skia/image_conv.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::model::image::ImageEffect;
 use crate::model::style::ImageFillMode;
+use crate::renderer::image_resolver::{detect_image_mime_type, grayscale_jpeg_bytes_to_png_bytes};
 
 const MAX_SVG_FRAGMENT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_SVG_RASTER_PIXELS: u64 = 67_108_864;
@@ -146,7 +147,14 @@ pub fn draw_image_bytes(
     if !is_valid_destination_rect(x, y, width, height) {
         return;
     }
-    let Some(image) = Image::from_encoded(Data::new_copy(bytes)) else {
+    let normalized_bytes = if detect_image_mime_type(bytes) == "image/jpeg" {
+        grayscale_jpeg_bytes_to_png_bytes(bytes)
+    } else {
+        None
+    };
+    let encoded_bytes = normalized_bytes.as_deref().unwrap_or(bytes);
+
+    let Some(image) = Image::from_encoded(Data::new_copy(encoded_bytes)) else {
         draw_missing_image_placeholder(x, y, width, height);
         return;
     };
@@ -227,6 +235,7 @@ pub fn draw_image_bytes(
     if matches!(
         mode,
         ImageFillMode::TileAll
+            | ImageFillMode::Total
             | ImageFillMode::TileHorzTop
             | ImageFillMode::TileHorzBottom
             | ImageFillMode::TileVertLeft
@@ -276,7 +285,9 @@ pub fn draw_image_bytes(
             true
         };
 
-        if matches!(mode, ImageFillMode::TileAll) && draw_tiled_shader(dst, x, y) {
+        if matches!(mode, ImageFillMode::TileAll | ImageFillMode::Total)
+            && draw_tiled_shader(dst, x, y)
+        {
             canvas.restore();
             return;
         }

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2168,6 +2168,7 @@ fn serialize_shape_fill(w: &mut ByteWriter, fill: &Fill) {
                 ImageFillMode::TileHorzBottom => 2,
                 ImageFillMode::TileVertLeft => 3,
                 ImageFillMode::TileVertRight => 4,
+                ImageFillMode::Total => 0,
                 ImageFillMode::FitToSize => 5,
                 ImageFillMode::Center => 6,
                 ImageFillMode::CenterTop => 7,

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -290,6 +290,7 @@ fn image_fill_mode_to_u8(mode: ImageFillMode) -> u8 {
         ImageFillMode::TileHorzBottom => 2,
         ImageFillMode::TileVertLeft => 3,
         ImageFillMode::TileVertRight => 4,
+        ImageFillMode::Total => 0,
         ImageFillMode::FitToSize => 5,
         ImageFillMode::Center => 6,
         ImageFillMode::CenterTop => 7,

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -735,6 +735,7 @@ pub(crate) fn write_fill_brush<W: Write>(
             let img = fill.image.clone().unwrap_or_default();
             let mode = match img.fill_mode {
                 ImageFillMode::FitToSize => "FIT",
+                ImageFillMode::Total => "TOTAL",
                 ImageFillMode::Center => "CENTER",
                 _ => "TILE",
             };


### PR DESCRIPTION
## 범위

upstream `devel` 위에 독립 브랜치로 재구성했습니다.

관련 없는 레이아웃 동작은 바꾸지 않고 HWPX 이미지 페이로드 렌더링을 정규화합니다.

- `TOTAL` 이미지 fill mode를 `FIT`으로 접지 않고 별도 모드로 보존합니다.
- TIFF, BMP, PCX, 시각적으로 grayscale인 JPEG처럼 브라우저/SVG 호스트가 다루기 어려운 페이로드를 임베드 전에 PNG로 변환합니다.
- 새로 구분된 `TOTAL` 모드가 HWP/HWPX serializer roundtrip에서 보존되도록 합니다.

## 근거 분류

**Ghidra 의존 렌더링 증거가 아니라 Format/IR 복원 지원입니다.** 이 PR은 이미지 페이로드/직렬화 배관으로 제한하며, 단독 페이지 시각 수정이라고 주장하지 않습니다.

## 근거

이 PR은 단독 page-render 시각 delta를 주장하지 않습니다. 이미지 페이로드와 직렬화 지원 slice입니다.

- `TOTAL` 이미지 fill은 다른 fit mode로 직렬화되지 않고 `TOTAL`로 roundtrip됩니다.
- TIFF/BMP/PCX/grayscale JPEG 정규화는 resolver 중심 테스트로 다룹니다.
- fixture 파일, 로컬 경로, 스크린샷 바이너리는 커밋하지 않았습니다.

## 테스트

- `cargo check --tests`

## devel 검증

- `devel` 기준 브랜치에서 `cargo test --profile release-test --tests`가 통과했습니다.
- PNG/SVG truth 파일은 커밋하지 않았고, 시각 증거는 PR/release asset에만 둡니다.
