### PR TITLE
[경험적 렌더링] 렌더러 폰트 메트릭과 굵기 보존

### DIFF
--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -306,10 +306,8 @@ impl Renderer for HtmlRenderer {
             x, draw_y, font_family, draw_size, color,
         );
 
-        if style.is_visually_bold() {
-            css.push_str("font-weight:bold;");
-        } else if style.is_medium_weight() {
-            css.push_str("font-weight:500;");
+        if let Some(weight) = style.css_font_weight() {
+            css.push_str(&format!("font-weight:{};", weight));
         }
         if style.italic {
             css.push_str("font-style:italic;");

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -916,7 +916,10 @@ mod wasm_internals {
 
     /// 1000pt 측정용 CSS font 문자열 생성
     pub(super) fn build_1000pt_font_string(style: &TextStyle) -> String {
-        let font_weight = if style.bold { "bold " } else { "" };
+        let font_weight = style
+            .css_font_weight()
+            .map(|weight| format!("{} ", weight))
+            .unwrap_or_default();
         let font_style = if style.italic { "italic " } else { "" };
         let font_family = if style.font_family.is_empty() {
             "sans-serif".to_string()
@@ -1581,10 +1584,54 @@ fn is_monospace_metric(metric: &font_metrics_data::FontMetric) -> bool {
     count >= 16
 }
 
+/// 요청 폰트의 내장 메트릭 DB 등록 여부.
+///
+/// `compute_char_positions` 의 advance 가 실제 글리프 폭(메트릭 DB)에서
+/// 나온 값인지, 아니면 DB 미등록 폰트의 휴리스틱 폴백(`font_size * 0.5`
+/// 등)인지 구분하는 데 쓴다. WASM 캔버스 렌더러는 메트릭이 없는(=브라우저
+/// 대체 폰트로 치환되는) 폰트에 대해 글리프별 가로 스케일링(per-glyph
+/// x-scale)을 적용하면 안 된다 — 치환 폰트의 실제 advance 와 어긋나
+/// l/i/t 같은 좁은 글리프가 과도하게 늘어나기 때문이다 (한컴 바겐세일 M
+/// → Pretendard 치환 시 Vocabulary 열 왜곡).
+pub(crate) fn font_family_has_metrics(font_family: &str, bold: bool, italic: bool) -> bool {
+    let primary_name = font_family.split(',').next().unwrap_or(font_family).trim();
+    font_metrics_data::find_metric(primary_name, bold, italic).is_some()
+}
+
 /// 내장 폰트 메트릭으로 문자 폭 측정 (em 단위 → px 변환)
 ///
 /// 내장 메트릭이 있으면 JS 브릿지 호출 없이 즉시 반환.
 /// 없으면 None을 반환하여 폴백 경로를 사용하게 한다.
+fn quantize_hwp_px(px: f64) -> f64 {
+    let hwp = (px * 75.0) as i32;
+    hwp as f64 / 75.0
+}
+
+fn kopub_char_width(primary_name: &str, c: char, font_size: f64) -> Option<f64> {
+    let lower = primary_name.to_lowercase();
+    let is_dotum = primary_name.contains("KoPub돋움체") || lower.contains("kopub dotum");
+    let is_batang = primary_name.contains("KoPub바탕체") || lower.contains("kopub batang");
+    if !is_dotum && !is_batang {
+        return None;
+    }
+
+    if c == ' ' {
+        return Some(quantize_hwp_px(font_size * 0.5));
+    }
+    if is_narrow_punctuation(c) {
+        return Some(quantize_hwp_px(font_size * 0.3));
+    }
+    if c.is_ascii() {
+        return Some(quantize_hwp_px(font_size * 0.5));
+    }
+    if is_cjk_char(c) || is_fullwidth_symbol(c) {
+        let factor = if is_dotum { 0.84 } else { 0.94 };
+        return Some(quantize_hwp_px(font_size * factor));
+    }
+
+    None
+}
+
 fn measure_char_width_embedded(
     font_family: &str,
     bold: bool,
@@ -1594,6 +1641,9 @@ fn measure_char_width_embedded(
 ) -> Option<f64> {
     // CSS font-family 체인에서 첫 번째 폰트명으로 메트릭 조회
     let primary_name = font_family.split(',').next().unwrap_or(font_family).trim();
+    if let Some(w) = kopub_char_width(primary_name, c, font_size) {
+        return Some(w);
+    }
     let mm = font_metrics_data::find_metric(primary_name, bold, italic)?;
     // HWP 반각 처리: space 및 한컴이 반각으로 처리하는 구두점/기호
     let w = if c == ' ' {
@@ -1645,8 +1695,7 @@ fn measure_char_width_embedded(
 
     // 한컴과 동일한 HWPUNIT 정수 변환: w * base_size / em (내림)
     // round가 아닌 truncate (as i32)로 처리하여 한컴 정수 나눗셈과 일치
-    let hwp = (actual_px * 75.0) as i32;
-    Some(hwp as f64 / 75.0)
+    Some(quantize_hwp_px(actual_px))
 }
 
 // ── 호환 래퍼 (기존 호출부 변경 없음) ──────────────────────────────
@@ -1821,6 +1870,7 @@ fn is_fullwidth_symbol(c: char) -> bool {
         '\u{00A3}' |                   // £ POUND SIGN
         '\u{00A5}'                     // ¥ YEN SIGN
     )
+    || ('\u{2190}'..='\u{21FF}').contains(&c) // Arrows (→, ⇨, ⇒ 등)
     || ('\u{2460}'..='\u{24FF}').contains(&c) // Enclosed Alphanumerics (①②③ 등)
     || ('\u{25A0}'..='\u{25FF}').contains(&c) // Geometric Shapes (□■▲◆○ 등, 섹션 머리 기호)
     || ('\u{2600}'..='\u{26FF}').contains(&c) // Miscellaneous Symbols (☆★ 등)
@@ -2080,6 +2130,22 @@ mod tests {
     }
 
     #[test]
+    fn test_unicode_arrow_uses_symbol_advance() {
+        let style = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            font_size: 10.0,
+            ..Default::default()
+        };
+
+        let arrow = estimate_text_width("⇒", &style);
+        let ascii = estimate_text_width("A", &style);
+        assert!(
+            arrow > ascii,
+            "arrow should use symbol advance, arrow={arrow}, ascii={ascii}"
+        );
+    }
+
+    #[test]
     fn test_mock_measurer_tab() {
         let m = MockTextMeasurer { char_width: 10.0 };
         let style = TextStyle {
@@ -2133,6 +2199,19 @@ mod tests {
             "expected 32.0 (2*16.0 heuristic), got {}",
             w
         );
+    }
+
+    #[test]
+    fn test_kopub_dotum_uses_narrow_publication_metrics() {
+        let m = EmbeddedTextMeasurer;
+        let style = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            font_size: 14.0,
+            ..Default::default()
+        };
+
+        let w = m.estimate_text_width("가나", &style);
+        assert_eq!(w, 24.0);
     }
 
     #[test]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -204,12 +204,27 @@ impl TextStyle {
     /// 시각 bold 소실을 보완하기 위해 SVG 출력 시 font-weight="bold" 강제에
     /// 사용된다.
     pub fn is_visually_bold(&self) -> bool {
-        self.bold || crate::renderer::style_resolver::is_heavy_display_face(&self.font_family)
+        self.bold
+            || crate::renderer::style_resolver::is_heavy_display_face(&self.font_family)
+            || crate::renderer::style_resolver::is_bold_weight_face(&self.font_family)
     }
 
     /// 중고딕 계열(font-weight 500) 여부. SVG/HTML 출력 시 `font-weight: 500` 힌트 삽입에 사용.
     pub fn is_medium_weight(&self) -> bool {
         !self.bold && crate::renderer::style_resolver::is_medium_weight_face(&self.font_family)
+    }
+
+    /// CSS/SVG font-weight hint for fallback rendering.
+    pub fn css_font_weight(&self) -> Option<&'static str> {
+        if self.is_visually_bold() {
+            Some("bold")
+        } else if crate::renderer::style_resolver::is_light_weight_face(&self.font_family) {
+            Some("300")
+        } else if self.is_medium_weight() {
+            Some("500")
+        } else {
+            None
+        }
     }
 }
 
@@ -705,6 +720,16 @@ pub fn generic_fallback(font_family: &str) -> &'static str {
     }
     // 고정폭 키워드
     let lower = font_family.to_ascii_lowercase();
+    if (font_family.contains("KoPub돋움체") || lower.contains("kopub dotum"))
+        && (font_family.contains("Light") || lower.contains("light"))
+    {
+        return "'Noto Sans KR ExtraLight','Malgun Gothic','맑은 고딕','Apple SD Gothic Neo','Noto Sans KR','Pretendard','HCR Batang Ext-B','함초롬바탕 확장B','HCR Batang Ext','함초롬바탕 확장','HCR Batang','함초롬바탕','Source Han Serif K Old Hangul',sans-serif";
+    }
+    // KoPub Batang uses "바탕체" in the family name, but it is a proportional
+    // serif publication face, not the Windows fixed-width BatangChe face.
+    if font_family.contains("KoPub바탕체") || lower.contains("kopub batang") {
+        return "'Batang','바탕','Nanum Myeongjo','AppleMyungjo','Noto Serif KR','Noto Serif CJK KR','HCR Batang Ext-B','함초롬바탕 확장B','HCR Batang Ext','함초롬바탕 확장','HCR Batang','함초롬바탕','Source Han Serif K Old Hangul',serif";
+    }
     if font_family.contains("굴림체")
         || font_family.contains("바탕체")
         || lower.contains("gulimche")
@@ -1141,12 +1166,21 @@ mod tests {
         assert_eq!(generic_fallback("HY견명조"), serif);
         assert_eq!(generic_fallback("Times New Roman"), serif);
         assert_eq!(generic_fallback("Palatino Linotype"), serif);
+        // KoPub바탕체는 이름에 "바탕체"가 들어가지만 고정폭 BatangChe가 아니라
+        // 비례폭 본문/제목용 세리프 계열이다.
+        assert_eq!(generic_fallback("KoPub바탕체 Light"), serif);
+        assert_eq!(generic_fallback("KoPub바탕체 Medium"), serif);
+        assert_eq!(generic_fallback("KoPub Batang Medium"), serif);
         // 산세리프 계열
         assert_eq!(generic_fallback("함초롬돋움"), sans);
         assert_eq!(generic_fallback("돋움"), sans);
         assert_eq!(generic_fallback("굴림"), sans);
         assert_eq!(generic_fallback("Arial"), sans);
         assert_eq!(generic_fallback("맑은 고딕"), sans);
+        assert!(generic_fallback("KoPub돋움체 Light")
+            .starts_with("'Noto Sans KR ExtraLight','Malgun Gothic'"));
+        assert!(generic_fallback("KoPub Dotum Light")
+            .starts_with("'Noto Sans KR ExtraLight','Malgun Gothic'"));
         // 고정폭 계열
         assert_eq!(generic_fallback("굴림체"), mono);
         assert_eq!(generic_fallback("바탕체"), mono);
@@ -1177,6 +1211,22 @@ mod tests {
         assert!(!is_medium_weight_face("바탕"));
         assert!(!is_medium_weight_face("맑은 고딕"));
         assert!(!is_medium_weight_face(""));
+    }
+
+    #[test]
+    fn test_explicit_face_weight_hints() {
+        let light = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(light.css_font_weight(), Some("300"));
+
+        let bold = TextStyle {
+            font_family: "KoPub바탕체 Bold".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(bold.css_font_weight(), Some("bold"));
+        assert!(bold.is_visually_bold());
     }
 
     #[test]

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -728,18 +728,40 @@ pub(crate) fn is_heavy_display_face(font_family: &str) -> bool {
     )
 }
 
-/// 중고딕/태고딕 계열 (CSS font-weight 500) 폰트 판별.
-///
-/// HWP 에서 중고딕 계열은 Regular(400)과 Bold(700) 사이의 Medium(500) weight.
-/// Fallback 폰트 매칭 시 weight 500 힌트를 주어 선명도를 유지한다.
-pub(crate) fn is_medium_weight_face(font_family: &str) -> bool {
-    let primary = font_family
+fn primary_font_face(font_family: &str) -> &str {
+    font_family
         .split(',')
         .next()
         .unwrap_or(font_family)
         .trim()
         .trim_matches('\'')
-        .trim_matches('"');
+        .trim_matches('"')
+}
+
+/// Face name explicitly carries a bold weight.
+pub(crate) fn is_bold_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
+    let lower = primary.to_lowercase();
+    lower.contains("bold") || lower.contains("볼드")
+}
+
+/// Face name explicitly carries a light weight.
+pub(crate) fn is_light_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
+    let lower = primary.to_lowercase();
+    !is_bold_weight_face(font_family)
+        && (lower.contains("light")
+            || lower.contains("extralight")
+            || lower.contains("thin")
+            || lower.contains("ultralight"))
+}
+
+/// 중고딕/태고딕 계열 (CSS font-weight 500) 폰트 판별.
+///
+/// HWP 에서 중고딕 계열은 Regular(400)과 Bold(700) 사이의 Medium(500) weight.
+/// Fallback 폰트 매칭 시 weight 500 힌트를 주어 선명도를 유지한다.
+pub(crate) fn is_medium_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
     let lower = primary.to_lowercase();
     lower.contains("중고딕")
         || lower.contains("태고딕")


### PR DESCRIPTION
## 범위

upstream `devel` 위에 독립 브랜치로 재구성했습니다.

한국어 텍스트 레이아웃에 쓰이는 renderer font metric과 weight 값을 보존합니다.

- renderer font hint를 style resolution과 measurement 경로까지 전달합니다.
- 모든 굵은 글씨를 generic bold로 접지 않고 구체적인 CSS font weight를 내보냅니다.
- paragraph condense와 pagination 동작은 이 PR 범위 밖으로 둡니다.

## 근거 분류

**경험적 렌더링 보정입니다.** 이 PR은 Ghidra/Frida 근거가 아니라 시각/text-metric 맞춤이며, canonical editor/PDF 출력과 대조해서 검토해야 합니다.

## 시각 증거

실제 HWPX fixture 시각 증거는 release asset으로만 첨부했습니다. fixture 파일, 로컬 경로, 스크린샷 바이너리는 커밋하지 않았습니다.

<img src="https://github.com/humdrum00001010/rhwp/releases/download/split-pr1573-page-proof-20260630-004707/p09-chapter_divider.png" alt="chapter divider font proof" width="720">

<img src="https://github.com/humdrum00001010/rhwp/releases/download/split-pr1573-page-proof-20260630-004707/p15-body_callout_box.png" alt="bold text and arrow spacing proof" width="720">

## 테스트

- `cargo check --tests`

## devel 검증

- `devel` 기준 브랜치에서 `cargo test --profile release-test --tests`가 통과했습니다.
- PNG/SVG truth 파일은 커밋하지 않았고, 시각 증거는 PR/release asset에만 둡니다.
