### PR TITLE
[렌더러 보정] 브라우저 캔버스 이미지 리플레이 안정화

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -62,6 +62,7 @@ web-sys = { version = "0.3", features = [
     "CanvasPattern",
     "HtmlCanvasElement",
     "HtmlImageElement",
+    "ImageData",
     "TextMetrics",
     "Document",
     "Window",

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -77,6 +77,45 @@ thread_local! {
         std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static DECODED_CANVAS_CACHE: std::cell::RefCell<
+        std::collections::HashMap<u64, Option<HtmlCanvasElement>>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+#[cfg(target_arch = "wasm32")]
+fn decode_image_to_canvas(data: &[u8]) -> Option<HtmlCanvasElement> {
+    let dynimg = image::load_from_memory(data).ok()?;
+    let rgba = dynimg.to_rgba8();
+    let (iw, ih) = (rgba.width(), rgba.height());
+    if iw == 0 || ih == 0 {
+        return None;
+    }
+
+    let buf = rgba.into_raw();
+    let image_data =
+        web_sys::ImageData::new_with_u8_clamped_array_and_sh(wasm_bindgen::Clamped(&buf), iw, ih)
+            .ok()?;
+
+    let document = web_sys::window()?.document()?;
+    let canvas: HtmlCanvasElement = document
+        .create_element("canvas")
+        .ok()?
+        .dyn_into::<HtmlCanvasElement>()
+        .ok()?;
+    canvas.set_width(iw);
+    canvas.set_height(ih);
+
+    let ctx = canvas
+        .get_context("2d")
+        .ok()??
+        .dyn_into::<CanvasRenderingContext2d>()
+        .ok()?;
+    ctx.put_image_data(&image_data, 0.0, 0.0).ok()?;
+    Some(canvas)
+}
+
 /// 빠른 해시 (FNV-1a 64비트)
 #[cfg(target_arch = "wasm32")]
 fn hash_bytes(data: &[u8]) -> u64 {
@@ -2541,6 +2580,25 @@ impl Renderer for WebCanvasRenderer {
     fn draw_image(&mut self, data: &[u8], x: f64, y: f64, w: f64, h: f64) {
         let key = hash_bytes(data);
 
+        let decoded = DECODED_CANVAS_CACHE.with(|cache| {
+            let mut c = cache.borrow_mut();
+            if let Some(slot) = c.get(&key) {
+                return slot.clone();
+            }
+            if c.len() > 200 {
+                c.clear();
+            }
+            let canvas = decode_image_to_canvas(data);
+            c.insert(key, canvas.clone());
+            canvas
+        });
+        if let Some(canvas) = decoded {
+            let _ = self
+                .ctx
+                .draw_image_with_html_canvas_element_and_dw_and_dh(&canvas, x, y, w, h);
+            return;
+        }
+
         // 캐시에서 이미 로드된 이미지를 찾는다
         let cached = IMAGE_CACHE.with(|cache| {
             let c = cache.borrow();
@@ -2631,6 +2689,27 @@ impl WebCanvasRenderer {
         dh: f64,
     ) {
         let key = hash_bytes(data);
+
+        let decoded = DECODED_CANVAS_CACHE.with(|cache| {
+            let mut c = cache.borrow_mut();
+            if let Some(slot) = c.get(&key) {
+                return slot.clone();
+            }
+            if c.len() > 200 {
+                c.clear();
+            }
+            let canvas = decode_image_to_canvas(data);
+            c.insert(key, canvas.clone());
+            canvas
+        });
+        if let Some(canvas) = decoded {
+            let _ = self
+                .ctx
+                .draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+                    &canvas, sx, sy, sw, sh, dx, dy, dw, dh,
+                );
+            return;
+        }
 
         let cached = IMAGE_CACHE.with(|cache| {
             let c = cache.borrow();

--- a/tests/render_p22_web_canvas_contract.rs
+++ b/tests/render_p22_web_canvas_contract.rs
@@ -48,3 +48,25 @@ fn web_canvas_control_code_group_labels_follow_active_replay_plane() {
         "layer group labels should use the replay-plane gate"
     );
 }
+
+#[test]
+fn web_canvas_decodes_bitmap_bytes_before_html_image_fallback() {
+    assert!(
+        WEB_CANVAS_SOURCE.contains("fn decode_image_to_canvas(data: &[u8])"),
+        "WebCanvas should have a synchronous bitmap decode path"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("put_image_data(&image_data, 0.0, 0.0)"),
+        "decoded image bytes should be copied into an offscreen canvas"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("draw_image_with_html_canvas_element_and_dw_and_dh"),
+        "full-image drawing should paint the decoded canvas before HtmlImage fallback"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains(
+            "draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh"
+        ),
+        "cropped-image drawing should paint the decoded canvas before HtmlImage fallback"
+    );
+}


### PR DESCRIPTION
## 범위

upstream `devel` 위에 독립 브랜치로 재구성했습니다.

`HtmlImageElement` 로딩으로 fallback하기 전에 이미지 바이트를 offscreen canvas로 디코드해서 browser canvas 이미지 페인팅을 안정화합니다.

- WebCanvas에 bitmap bytes용 동기 `image::load_from_memory` 경로를 추가합니다.
- 첫 render pass에서 full/cropped 이미지를 `drawImage(canvas, ...)`로 페인트합니다.
- WMF/PCX/SVG fallback은 기존 `HtmlImageElement` 경로에 그대로 둡니다.

## 근거 분류

**Ghidra/Frida 근거가 아닌 렌더러 구현 보정입니다.** HWPX 포맷 직렬화 규칙이 아니라 browser canvas first-paint 동작입니다.

## 근거

이 PR은 단독 static PNG 시각 delta를 주장하지 않습니다. 문제는 one-shot render 중 `HtmlImageElement.set_src(data URL)`가 아직 complete되지 않을 수 있는 browser-canvas 경로입니다.

- 집중 커버리지는 `tests/render_p22_web_canvas_contract.rs`에 있습니다.
- 변경이 `web-sys` canvas/image API에 의존하므로 WASM library build를 검증에 포함했습니다.
- fixture 파일, 로컬 경로, 스크린샷 바이너리는 커밋하지 않았습니다.

## 테스트

- `cargo fmt --all -- --check`
- `cargo build --lib --target wasm32-unknown-unknown`
- `cargo test --profile release-test --tests`
