### PR TITLE
[경험적 렌더링] HWPX PUA 글리프와 줄바꿈 매핑

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -1665,6 +1665,12 @@ fn pua_enclosed_border_type(ch: char) -> Option<u8> {
 fn pua_plain_text_display(ch: char) -> Option<&'static str> {
     match ch as u32 {
         0xF012B => Some("(인)"),
+        // 2025 행정업무운영 편람 p08 TOC bullet. Hancom PDF renders this
+        // private-use marker as a filled square bullet.
+        0xF031C => Some("■"),
+        // 2025 행정업무운영 편람 p15 callout bullet. Hancom PDF renders this
+        // private-use marker as a filled right-pointing pointer, not tofu.
+        0xF02FC => Some("►"),
         // [Task #1001] 한컴 변환본 (HWP3→HWP5) 의 글머리표 PUA. 한컴 viewer 는
         // 빈 체크박스 모양으로 표시. "□" (U+25A1 WHITE SQUARE) 매핑.
         // 실제 sample16-hwp5 의 PUA codepoint 는 U+F03C5 (글자 분석 결과).

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -222,9 +222,11 @@ pub(crate) fn tokenize_paragraph(
             continue;
         }
 
-        // 한글 어절 또는 글자
+        // 한글 어절 또는 글자.
+        // HWPX breakNonLatinWord="KEEP_WORD" is preserved as attr1 bit 7,
+        // which resolves to korean_break_unit == 1.
         if is_hangul(ch) {
-            if korean_break_unit == 0 {
+            if korean_break_unit == 1 {
                 // 어절 모드: 연속 한글 + 후행 금칙 문자를 하나의 토큰으로
                 let start = i;
                 let mut max_fs = 0.0f64;
@@ -577,6 +579,34 @@ fn to_hwp(px: f64) -> i32 {
     (px * 75.0) as i32
 }
 
+fn condense_space_savings_hwp(space_width_hwp: i32, condense_min_space: u8) -> i32 {
+    if condense_min_space == 0 || space_width_hwp <= 0 {
+        return 0;
+    }
+    let shrink_percent = condense_min_space.min(75) as i32;
+    space_width_hwp * shrink_percent / 100
+}
+
+fn condensed_line_width_hwp(width_hwp: i32, space_savings_hwp: i32) -> i32 {
+    width_hwp - space_savings_hwp
+}
+
+fn condense_fit_can_pull_next_token(
+    current_width_hwp: i32,
+    current_space_savings_hwp: i32,
+    effective_width_hwp: i32,
+    max_font_size: f64,
+) -> bool {
+    let current_condensed_width =
+        condensed_line_width_hwp(current_width_hwp, current_space_savings_hwp);
+    let remaining_hwp = effective_width_hwp - current_condensed_width;
+    // Hancom uses condense to rescue a line that still has a meaningful
+    // natural gap, but it does not pull the next word into an already tight
+    // line. The p03 PDF preface is sensitive to that distinction.
+    let min_remaining_hwp = to_hwp((max_font_size * 2.5).max(20.0));
+    remaining_hwp >= min_remaining_hwp
+}
+
 /// 토큰을 줄에 배치하는 Greedy 알고리즘
 /// 한컴과 동일한 결과를 위해 HWPUNIT 정수로 폭을 누적한다.
 fn fill_lines(
@@ -586,6 +616,7 @@ fn fill_lines(
     indent_px: f64,
     default_tab_width: f64,
     korean_break_unit: u8,
+    condense_min_space: u8,
 ) -> Vec<LineBreakResult> {
     if tokens.is_empty() {
         return vec![LineBreakResult {
@@ -609,12 +640,14 @@ fn fill_lines(
     let mut results = Vec::new();
     let mut line_start_idx = 0usize;
     let mut lw = 0i32; // HWPUNIT 정수 누적
+    let mut line_space_savings = 0i32;
     let mut line_max_fs = 0.0f64;
     let mut is_first_line = true;
 
     let mut last_break_token_idx: Option<usize> = None;
     let mut last_break_char_idx: usize = 0;
     let mut width_at_last_break = 0i32;
+    let mut space_savings_at_last_break = 0i32;
     let mut fs_at_last_break = 0.0f64;
 
     let eff_w = |first: bool| -> i32 {
@@ -646,6 +679,7 @@ fn fill_lines(
                 });
                 line_start_idx = *idx + 1;
                 lw = 0;
+                line_space_savings = 0;
                 line_max_fs = 0.0;
                 is_first_line = false;
                 last_break_token_idx = None;
@@ -669,6 +703,7 @@ fn fill_lines(
                         });
                         line_start_idx = last_break_char_idx;
                         lw = lw - width_at_last_break;
+                        line_space_savings -= space_savings_at_last_break;
                     } else {
                         results.push(LineBreakResult {
                             start_idx: line_start_idx,
@@ -678,6 +713,7 @@ fn fill_lines(
                         });
                         line_start_idx = *idx;
                         lw = 0;
+                        line_space_savings = 0;
                         line_max_fs = *max_font_size;
                     }
                     is_first_line = false;
@@ -689,6 +725,7 @@ fn fill_lines(
                     last_break_token_idx = Some(ti);
                     last_break_char_idx = *idx;
                     width_at_last_break = lw;
+                    space_savings_at_last_break = line_space_savings;
                     fs_at_last_break = line_max_fs;
                     lw = next_tab_hwp;
                 }
@@ -704,8 +741,11 @@ fn fill_lines(
                 last_break_token_idx = Some(ti);
                 last_break_char_idx = *idx;
                 width_at_last_break = lw;
+                space_savings_at_last_break = line_space_savings;
                 fs_at_last_break = line_max_fs;
-                lw += to_hwp(*width);
+                let space_hwp = to_hwp(*width);
+                lw += space_hwp;
+                line_space_savings += condense_space_savings_hwp(space_hwp, condense_min_space);
             }
             BreakToken::Text {
                 start_idx,
@@ -726,22 +766,43 @@ fn fill_lines(
                 if *end_idx - *start_idx == 1 && *start_idx > line_start_idx {
                     let c = text_chars[*start_idx];
                     let allow_break = if is_hangul(c) {
-                        korean_break_unit == 1
+                        korean_break_unit == 0
                     } else {
                         is_cjk_ideograph(c)
                     };
+                    let candidate_w = lw + w_hwp;
                     // 이 글자가 줄에 들어가는 경우에만 break point 갱신
-                    if allow_break && lw + w_hwp <= eff_w(is_first_line) + LINE_BREAK_TOLERANCE {
+                    if allow_break
+                        && condensed_line_width_hwp(candidate_w, line_space_savings)
+                            <= eff_w(is_first_line) + LINE_BREAK_TOLERANCE
+                    {
                         last_break_token_idx = Some(ti);
                         last_break_char_idx = *end_idx; // 이 글자 다음 (이 글자 포함)
-                        width_at_last_break = lw + w_hwp; // 이 글자 폭 포함
+                        width_at_last_break = candidate_w; // 이 글자 폭 포함
+                        space_savings_at_last_break = line_space_savings;
                         fs_at_last_break = line_max_fs;
                     }
                 }
                 // 한컴은 HWPUNIT 정수 양자화 시 미세한 반올림 차이를 허용
                 // 12 HU(~0.17mm) 이내의 초과는 줄에 포함 (경험적 허용 오차)
                 const LINE_BREAK_TOLERANCE: i32 = 15;
-                if lw + w_hwp > eff_w(is_first_line) + LINE_BREAK_TOLERANCE {
+                let effective_width = eff_w(is_first_line);
+                let natural_candidate = lw + w_hwp;
+                let condensed_candidate =
+                    condensed_line_width_hwp(natural_candidate, line_space_savings);
+                let needs_condense_to_fit = natural_candidate
+                    > effective_width + LINE_BREAK_TOLERANCE
+                    && condensed_candidate <= effective_width + LINE_BREAK_TOLERANCE;
+                let condense_pull_allowed = !needs_condense_to_fit
+                    || condense_fit_can_pull_next_token(
+                        lw,
+                        line_space_savings,
+                        effective_width,
+                        *max_font_size,
+                    );
+                if condensed_candidate > effective_width + LINE_BREAK_TOLERANCE
+                    || !condense_pull_allowed
+                {
                     if *start_idx > line_start_idx {
                         if let Some(_) = last_break_token_idx {
                             results.push(LineBreakResult {
@@ -756,6 +817,12 @@ fn fill_lines(
                             }
                             line_start_idx = next_start;
                             lw = recalc_width_hwp(tokens, ti, next_start);
+                            line_space_savings = recalc_space_savings_hwp(
+                                tokens,
+                                ti,
+                                next_start,
+                                condense_min_space,
+                            );
                             lw += w_hwp;
                             line_max_fs = *max_font_size;
                             is_first_line = false;
@@ -782,6 +849,7 @@ fn fill_lines(
                         is_first_line = false;
                     }
                     lw = remaining_w;
+                    line_space_savings = 0;
                     line_max_fs = remaining_fs;
                     last_break_token_idx = None;
                     continue;
@@ -835,6 +903,30 @@ fn recalc_width_hwp(tokens: &[BreakToken], current_token_idx: usize, new_line_st
             }
             BreakToken::Space { idx, width, .. } if *idx >= new_line_start => {
                 w += to_hwp(*width);
+            }
+            _ => {}
+        }
+    }
+    w
+}
+
+/// 줄 바꿈 지점 이후 공백 압축 가능 폭 재계산 (HWPUNIT)
+fn recalc_space_savings_hwp(
+    tokens: &[BreakToken],
+    current_token_idx: usize,
+    new_line_start: usize,
+    condense_min_space: u8,
+) -> i32 {
+    let mut w = 0i32;
+    for t in &tokens[..current_token_idx] {
+        match t {
+            BreakToken::Space {
+                idx,
+                width,
+                max_font_size,
+            } if *idx >= new_line_start => {
+                let space_hwp = to_hwp(*width);
+                w += condense_space_savings_hwp(space_hwp, condense_min_space);
             }
             _ => {}
         }
@@ -1083,6 +1175,7 @@ pub(crate) fn reflow_line_segs(
     let indent_px = para_style.map(|s| s.indent).unwrap_or(0.0);
     let english_break_unit = para_style.map(|s| s.english_break_unit).unwrap_or(0);
     let korean_break_unit = para_style.map(|s| s.korean_break_unit).unwrap_or(0);
+    let condense_min_space = para_style.map(|s| s.condense_min_space).unwrap_or(0);
     let tab_width = para_style.map(|s| s.default_tab_width).unwrap_or(0.0);
 
     // 토큰화 → 줄 채움 → LineSeg 생성
@@ -1101,8 +1194,8 @@ pub(crate) fn reflow_line_segs(
         indent_px,
         tab_width,
         korean_break_unit,
+        condense_min_space,
     );
-
     let mut new_line_segs: Vec<LineSeg> = Vec::new();
     for lb in &line_breaks {
         let utf16_start = if new_line_segs.is_empty() {

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -759,6 +759,32 @@ fn test_reflow_english_word_wrap() {
     assert_eq!(para.line_segs[1].text_start, 6); // "World" 시작
 }
 
+#[test]
+fn test_reflow_condense_shrinks_measured_space_width() {
+    let mut styles = make_styles_with_font_size(10.0);
+    styles.para_styles[0].condense_min_space = 20;
+
+    let mut para = Paragraph {
+        text: "A B ABCDEF".to_string(),
+        char_offsets: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        char_count: 10,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Natural width is 50px: 8 latin chars at 5px + 2 spaces at 5px.
+    // condense=20 allows each measured space to shrink by 20%, saving 2px.
+    reflow_line_segs(&mut para, 48.0, &styles, 96.0);
+    assert_eq!(para.line_segs.len(), 1);
+}
+
 /// 강제 줄 바꿈: \n에서 즉시 줄 바꿈
 #[test]
 fn test_reflow_forced_line_break() {
@@ -816,7 +842,7 @@ fn test_tokenize_korean_eojeol() {
         char_shape_id: 0,
     }];
 
-    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 0);
+    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 1);
     // "가나" (Text) + " " (Space) + "다라" (Text) = 3 tokens
     assert_eq!(tokens.len(), 3);
     assert!(matches!(
@@ -833,6 +859,37 @@ fn test_tokenize_korean_eojeol() {
         BreakToken::Text {
             start_idx: 3,
             end_idx: 5,
+            ..
+        }
+    ));
+}
+
+/// 토크나이저: 한국어 글자 단위 토큰화
+#[test]
+fn test_tokenize_korean_break_word_chars() {
+    let styles = make_styles_with_font_size(16.0);
+    let text: Vec<char> = "가나".chars().collect();
+    let offsets: Vec<u32> = (0..text.len() as u32).collect();
+    let shapes = vec![CharShapeRef {
+        start_pos: 0,
+        char_shape_id: 0,
+    }];
+
+    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 0);
+    assert_eq!(tokens.len(), 2);
+    assert!(matches!(
+        tokens[0],
+        BreakToken::Text {
+            start_idx: 0,
+            end_idx: 1,
+            ..
+        }
+    ));
+    assert!(matches!(
+        tokens[1],
+        BreakToken::Text {
+            start_idx: 1,
+            end_idx: 2,
             ..
         }
     ));

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -181,9 +181,12 @@ pub struct ResolvedParaStyle {
     pub tab_stops: Vec<TabStop>,
     /// 문단 오른쪽 끝 자동 탭 여부
     pub auto_tab_right: bool,
+    /// HWPX paraPr condense / HWP ParaShape attr1 bits 9..15.
+    /// Spec name: minimum spacing value, 0..75%.
+    pub condense_min_space: u8,
     /// 줄 나눔 기준 영어 단위 (0=단어, 1=하이픈, 2=글자) — attr1 bit 5-6
     pub english_break_unit: u8,
-    /// 줄 나눔 기준 한글 단위 (0=어절, 1=글자) — attr1 bit 7
+    /// 줄 나눔 기준 한글 단위 (0=글자, 1=어절/KEEP_WORD) — attr1 bit 7
     pub korean_break_unit: u8,
     /// 외톨이줄 보호 — attr1 bit 16
     pub widow_orphan: bool,
@@ -214,6 +217,7 @@ impl Default for ResolvedParaStyle {
             default_tab_width: 0.0,
             tab_stops: Vec::new(),
             auto_tab_right: false,
+            condense_min_space: 0,
             english_break_unit: 0,
             korean_break_unit: 0,
             widow_orphan: false,
@@ -830,6 +834,7 @@ fn resolve_single_para_style(
         default_tab_width,
         tab_stops,
         auto_tab_right,
+        condense_min_space: ((ps.attr1 >> 9) & 0x7f).min(75) as u8,
         english_break_unit: ((ps.attr1 >> 5) & 0x03) as u8,
         korean_break_unit: ((ps.attr1 >> 7) & 0x01) as u8,
         widow_orphan: (ps.attr1 >> 16) & 1 != 0 || (ps.attr2 >> 5) & 1 != 0,

--- a/tests/issue_937.rs
+++ b/tests/issue_937.rs
@@ -130,6 +130,34 @@ fn issue_937_f081c_filler_should_not_render_as_text() {
 }
 
 #[test]
+fn issue_937_f02fc_callout_bullet_should_render_as_pointer() {
+    assert_eq!(
+        expand_pua_render_text("\u{F02FC} 전자서명"),
+        "► 전자서명",
+        "U+F02FC 한컴 PUA callout bullet 는 missing glyph 대신 right pointer 로 표시되어야 함",
+    );
+    assert_eq!(
+        pua_to_display_text('\u{F02FC}').as_deref(),
+        Some("►"),
+        "CharOverlap/display helper 도 같은 U+F02FC 표시 문자열을 반환해야 함",
+    );
+}
+
+#[test]
+fn issue_937_f031c_toc_bullet_should_render_as_square() {
+    assert_eq!(
+        expand_pua_render_text("\u{F031C} 행정업무"),
+        "■ 행정업무",
+        "U+F031C 한컴 PUA TOC bullet 는 missing glyph 대신 black square 로 표시되어야 함",
+    );
+    assert_eq!(
+        pua_to_display_text('\u{F031C}').as_deref(),
+        Some("■"),
+        "CharOverlap/display helper 도 같은 U+F031C 표시 문자열을 반환해야 함",
+    );
+}
+
+#[test]
 fn issue_937_svg_renders_f012b_as_signature_seal() {
     let bytes = read_bokhakwonseo();
     let doc = HwpDocument::from_bytes(&bytes).expect("parse samples/복학원서.hwp");


### PR DESCRIPTION
## 범위

upstream `devel` 위에 독립 브랜치로 재구성했습니다.

HWPX private-use glyph를 매핑하고 해당 run 주변의 line-break 처리를 개선합니다.

- fixture에서 쓰이는 알려진 PUA codepoint를 표시 글리프로 변환합니다.
- filler PUA codepoint가 visible text로 나오지 않도록 합니다.
- 이 치환과 paragraph condense spacing 주변의 line-break composition 동작을 보존합니다.

## 근거 분류

**경험적 렌더링/레이아웃 보정입니다.** 이 PR은 Ghidra/Frida 근거가 아니며, canonical 출력과 대조하는 text layout fitting으로 검토해야 합니다.

## 시각 증거

실제 HWPX fixture 시각 증거는 release asset으로만 첨부했습니다. fixture 파일, 로컬 경로, 스크린샷 바이너리는 커밋하지 않았습니다.

<img src="https://github.com/humdrum00001010/rhwp/releases/download/split-pr1573-page-proof-20260630-004707/p15-body_callout_box.png" alt="PUA and line-break proof" width="720">

## 테스트

- `cargo check --tests`

## devel 검증

- `devel` 기준 브랜치에서 `cargo test --profile release-test --tests`가 통과했습니다.
- PNG/SVG truth 파일은 커밋하지 않았고, 시각 증거는 PR/release asset에만 둡니다.
