### PR TITLE
한글 PDF baseline 인프라 + 별표4 잔여 over 분석 (#1658 후속)

### DIFF
--- a/mydocs/manual/hangul_pdf_baseline.md
+++ b/mydocs/manual/hangul_pdf_baseline.md
@@ -1,0 +1,54 @@
+# 한글 PDF baseline 인프라 (`tools/hangul_pdf_baseline.py`)
+
+- 도입: #1658 / 목적: cut↔render↔한글 3자 줄높이 fidelity 의 **한글 권위 기준** 제공.
+  한글이 그린 각 텍스트 줄의 baseline Y 를 PDF 에서 추출하고, rhwp render(SVG)와 줄 pitch 대조.
+
+## 원리
+- 한글 baseline: pyhwpx `save_as(PDF)`(또는 기존 PDF) → PyMuPDF(fitz) span origin.y. pt→px(×96/72).
+- 다단 표 보정: 같은 행의 여러 셀 baseline 을 tol(3px) 로 **행 클러스터링** 후 행 pitch 계산.
+- rhwp baseline: `rhwp export-svg` 의 `<text y>`.
+- `--compare`: 페이지별 한글/rhwp 줄수·median pitch·pitch diff.
+
+## 사용
+```
+python tools/hangul_pdf_baseline.py <file.hwp> [-o out.tsv]          # 한글 baseline
+python tools/hangul_pdf_baseline.py <file.hwp> --compare --exe <rhwp>  # rhwp render 대조
+python tools/hangul_pdf_baseline.py <file> --pdf pdf/xxx-2022.pdf --compare  # 권위 PDF 사용
+```
+
+## 중요 — 자동 생성 PDF 의 권위성 (PageCount 가드)
+`save_as(PDF)` 는 문서의 **인쇄 설정(맞춰찍기/배율)** 을 적용할 수 있어 편집기 레이아웃과 다른
+**압축 PDF** 를 만든다(예: 산업통상부 별표4 = 편집기 25쪽 vs 생성 PDF 13쪽, 배율 축소로 줄 pitch 과소).
+→ 도구는 **생성 PDF 쪽수 ≠ 편집기 PageCount 시 경고**한다. 권위 비교에는:
+- **`pdf/` 권위 PDF(한글 2022 편집기 내보내기)** 를 `--pdf` 로 지정(샘플), 또는
+- 배율 100%·맞춰찍기 OFF 로 생성된 PDF 사용.
+PageCount 일치(무경고) 시에만 baseline/pitch 를 권위로 신뢰한다.
+
+## 검증·발견 (도입 시)
+- **byeolpyo1**(국토부 별표1, 거대 셀 표): 생성 PDF 4쪽 = 편집기 4쪽(무경고, 권위).
+  → **한글 줄 pitch 28.80px = rhwp 28.80px — 줄높이 drift 없음.** (이 문서는 cut 로직 문제였고
+  #1658 행분할 수정으로 페이지수도 4=4 일치 완료.)
+- **byeolpyo4**(산업통상부 별표4): 생성 PDF 13쪽 ≠ 25쪽(경고) → 인쇄 배율 축소로 비권위. pitch
+  비교 불가(권위 PDF 또는 배율 100% 생성 필요).
+
+## 시사점 (fidelity 재평가)
+- 거대 표 문서(byeolpyo1)에서 **한글·rhwp 줄높이가 일치**한다는 것은, #1658 의 잔여 over/클리핑이
+  **줄높이 fidelity drift 가 아니라 cut 로직/인쇄배율 아티팩트** 쪽임을 시사한다(앞선 가설 정정).
+- byeolpyo4 의 정확한 진단은 **배율 100% 권위 PDF** 가 선행되어야 한다.
+
+## 배율 100% 권위 PDF 생성 시도 — 차단 (탐색 결과)
+byeolpyo4 의 권위 PDF(편집기 25쪽) 자동 생성을 시도했으나 차단:
+- `hwp.HParameterSet.HPrint`: `ZoomX/Y=100`(배율 100%)이나 `PrintMethod=4`(맞춰찍기류 추정).
+- `save_as(path, format="PDF")` 는 **HPrint 설정을 반영하지 않고**, doc 저장 배율을 적용해 일관되게
+  **13쪽**(≈ 50% area, pitch≈14px) 생성. `PrintMethod=0` 설정 후 `Execute("Print")` 도 save_as 에
+  영향 없음. `save_as(arg=...)` 의 PDF 옵션 키는 미문서화.
+- → 탐색한 pyhwpx/COM API 로 PDF export 배율 100% 강제 불가. (또는 한글 자체의 편집기↔PDF export
+  레이아웃 불일치 가능성.)
+
+## 결론·후속
+- **권위 PDF 자동 생성은 본 환경 API 로 차단.** 신뢰 비교는 (a) `pdf/` 권위 PDF(샘플) `--pdf`, 또는
+  (b) save_as 가 PageCount 와 일치하는 문서(무경고)에 한정.
+- **확정 발견(byeolpyo1, 무경고 권위)**: 한글·rhwp 줄높이 일치(28.8=28.8) → #1658 잔여(별표4 Δ+3,
+  클리핑)는 **줄높이 fidelity 가 아니라 cut 로직/한글 PDF 배율 아티팩트** 쪽(가설 정정).
+- 후속 정공법: 한글 PDF export 배율 100% 강제 방법(HWP COM PDF 액션 파라미터 추가 연구) 또는
+  pdf/ 권위 PDF 확보 후 per-행 baseline diff.

--- a/mydocs/report/task_m100_1658_report.md
+++ b/mydocs/report/task_m100_1658_report.md
@@ -1,63 +1,61 @@
-# 최종 보고서 — #1658 페이지네이션 엔진 개선 (라운드 1)
+# 최종 보고서 — #1658 페이지네이션 엔진 개선 (라운드 1) / PR #1670
 
-- 마일스톤: M100 / 브랜치: local/task1658 (upstream/devel 기준) / 일자: 2026-06-29
-- 성격: 다세션 연구·개선 프로젝트의 **라운드 1**. 실질 수정 1건 landing + 대규모 측정 기반 구축.
-- 선행: #1643(검증 도구), #1648(경계 빈 문단), #1653(RCA·통제 하네스, closed). #1658 은 **존속**(잔여 연구).
-- 오라클: OLE 한글 PageCount (Windows+한컴) — 모든 변경의 심판.
+- 마일스톤: M100 / 브랜치: local/task1658 (upstream/devel) / PR: edwardkim/rhwp#1670
+- 일자: 2026-06-30 / 성격: 다세션 연구·개선 프로젝트 **라운드 1 완결**.
+- 선행: #1643(검증 도구), #1648(경계 빈 문단), #1653(RCA·통제 하네스, closed). #1658 **존속**.
+- 오라클: OLE 한글(Windows+한컴) — 페이지수·줄 baseline·클리핑의 권위 기준.
 
-## 1. 목표
-rhwp TypesetEngine 페이지네이션을 OLE 한글 기준에 수렴(정합률↑), **무회귀**.
-
-## 2. 구축한 측정 기반 (재사용 자산)
-- `tools/build_page_oracle.py` → `tests/fixtures/render_page_oracle_1658.tsv`:
-  hwpdocs 랜덤 452개 한글 PageCount 정답지. **rhwp 실제 정합 97.6%**(controlset 81.5%는 난케이스 집합).
-- `tools/render_page_gate.py --fixture <oracle>`: 소형(92)·대형(452) 양 게이트로 수정 전/후 결정론 비교.
-- 합격 기준: over↓ & under/일치 무회귀(신규 −1=0) + lib/hwpx_roundtrip 통과.
-
-## 3. LANDED 수정 — 법령 표 행분할 미세 fragment 낭비 페이지
-`src/renderer/layout/table_layout.rs` `advance_row_cut`/`advance_row_block_cut` (`tiny_fragment_waste`, +11줄):
-- 거대 셀이 페이지를 가로질러 분할될 때, 셀 내용 vpos reset(hard_break_before)이 촘촘하면 잔여공간이
-  충분한데도 reset 마다 페이지를 끊어 ≤2줄짜리 낭비 페이지 양산 → over-pagination.
-- 현재 fragment 가 ≤2 유닛이고 잔여공간이 tolerance 초과면 그 reset break 를 흡수.
-- #1488(가시 문단 사이 reset 을 3 유닛 소비 후 보존, rowbreak-problem-pages.hwpx 회귀 방지)은
-  j>start+2 라 무영향.
+## 1. LANDED 수정 (소스: table_layout.rs +11줄)
+`advance_row_cut`/`advance_row_block_cut` `tiny_fragment_waste` 가드:
+거대 표 셀이 페이지를 가로질러 분할될 때, 셀 내용 vpos reset 이 촘촘하면 잔여공간 충분에도 reset
+마다 페이지를 끊어 ≤2줄 낭비 페이지 양산 → over-pagination. 현재 fragment 가 ≤2 유닛이고 잔여공간이
+tolerance 초과면 그 reset break 를 흡수. #1488(가시 문단 reset 3유닛 후 보존)은 j>start+2 라 무영향.
 
 ### 검증
-| 항목 | 베이스 | 수정 후 |
-|------|--------|---------|
-| 별표1(국토부) | 5쪽(Δ+1) | **4쪽 일치** ✅ |
-| 별표4(산업통상부) | 33쪽(Δ+8) | **28쪽(Δ+3)** |
-| 소형 controlset | 75 | **75 무회귀** |
-| 대형 오라클(452) | 441 | **442 (+1)** |
-| 신규 −1(under) | — | **0** |
-| lib / hwpx_roundtrip | 1984 / 4 | **1984 / 4 passed**(#1488 보존) |
-| 소스 변경 | — | table_layout.rs **+11줄**(국소) |
+| 항목 | before | after |
+|------|--------|-------|
+| 별표1(국토부 주차장법) | 5쪽(Δ+1) | **4쪽 일치** |
+| 별표4(산업통상부 LPG) | 33쪽(Δ+8) | **28쪽(Δ+3)** |
+| 대형 오라클(랜덤 452) | 97.6% | **97.8%**(신규 −1=0) |
+| 소형 controlset(92) | 75 | **75 무회귀** |
+| lib / hwpx_roundtrip | — | **1984 / 4 passed**(#1488 보존) |
 
-## 4. 조사하여 배제한 접근 (근거 자료)
-- **하단 고정 표(vert=Page·valign=Bottom) over** — Phase 0~2, 8종 시도 전부 회귀.
-  px-level close-call + 페이지 배정 fixpoint(예약↔앵커 진동). 스케일 저ROI(controlset 집중, 대형 무영향).
-  `task_m100_1658_phase1/2.md`.
-- **vpos-snap 이식** — Paginator snap 은 증가 전용(max)이라 over 못 고침. 하단표 out-of-flow 는
-  단일표 −1 회귀. `phase1`.
-- **구조적 reset 판별자** — reset 의 vis_start 혼재 → #1488 과 구별 불가(음성). `task_m100_1658_reset_discriminator.md`.
-- **(b) reset-snap** — 안전 tolerance(32px)로는 2~4유닛 orphan 못 닿고, 대형 게이트 442→440 회귀 → 비채택.
+## 2. 측정·검증 인프라 3종 (재사용 자산)
+| 도구 | 역할 | 비고 |
+|------|------|------|
+| `tools/build_page_oracle.py` + `tests/fixtures/render_page_oracle_1658.tsv` | 한글 PageCount 정답지(랜덤 452) | 92건 과적합 방지 |
+| `tools/detect_table_clipping.py` | 본문 클리핑(시각 손실) 검출 (SVG body-clip 초과) | 페이지수 게이트가 못 잡는 시각 회귀 |
+| `tools/hangul_pdf_baseline.py` | 한글 줄 baseline/pitch 권위 기준(PDF+fitz) | PageCount 가드 |
+가이드: `mydocs/manual/visual_clipping_detector.md`, `hangul_pdf_baseline.md`.
 
-## 5. 잔여 (후속 라운드)
-- **별표4 Δ+3**: 3~4유닛 orphan = per-page 용량 결손(rhwp 가 한글보다 페이지당 ~2~4유닛 적게 적재;
-  pagination_tolerance + px 누적). 페이지수 게이트만으로는 안전 해결 불가 → **시각(클리핑) 검증 인프라
-  동반 정밀 작업** 필요(별도 라운드).
-- **하단 고정 표 over / under(−1) 7건**: 별도 메커니즘. fixpoint·시각 검증 영역.
+## 3. 규명·정정한 것
+- **줄높이 fidelity 정상**: byeolpyo1(권위 PDF 4=4) 한글 줄 pitch **28.80 = rhwp 28.80** → drift 없음.
+  → #1658 잔여(별표4 Δ+3, 클리핑)는 **줄높이 아니라 cut 로직 / 한글 PDF 배율 아티팩트** (가설 정정).
+- **클리핑 ≡ capacity 동일 뿌리·상충**: 별표4 23.5px 클리핑(render>cut)과 capacity 결손(rhwp<한글)은
+  같은 cut↔render↔한글 적재량 차이의 양면. 클리핑 수정↔페이지수 상충 → 단일 조정 불가.
+- **별표4 over 성격**: avail=full body(tolerance 0). 잔여는 행 전환 tail fragment(선행 행 누적으로
+  tail 부족). reset 분류 판별자 없음(vis_start 혼재).
+
+## 4. 배제·차단 (근거 자료)
+- 하단 고정 표 over: Phase 0~2, 8종 시도 전부 회귀(fixpoint·진동). 저ROI.
+- vpos-snap 이식 / reset-snap: 회귀(증가전용·32px 게이트 회귀).
+- 한글 행높이 레퍼런스: COM(CellShape/TableLowerCell) 차단, PDF 배율 100% 강제도 차단(save_as
+  PrintMethod 무시, 별표4 13≠25쪽 압축).
+
+## 5. 잔여 (후속 라운드) — 단일 선결 과제로 수렴
+- 별표4 Δ+3·클리핑·하단표 모두 **한글 권위 레이아웃 레퍼런스(배율 100% PDF / COM 표 API)** 가
+  선행되어야 진척. → 한글 COM PDF 배율 제어 연구가 다음 라운드의 정공법.
+- 별표4 23.5px 클리핑은 capacity 와 상충하므로 3자(cut↔render↔한글) 적재량 정합으로만 동시 해결.
 
 ## 6. 결론
-- 페이지수 정합 **97.6→97.8%**(대형 오라클), 법령 표 행분할 1·2유닛 낭비 페이지를 **무회귀로 실제 수정**
-  (별표1 완전 일치, 별표4 Δ+8→Δ+3).
-- 남은 over 의 성격(용량 결손, reset 분류 아님)을 규명하고, 안전 ceiling(유닛수 가드 ≤2)을 확정.
-- 측정 기반(대형 오라클+양 게이트)과 8+종 실패 분석이 후속 라운드의 토대.
-- **#1658 은 존속**(잔여 연구 항목). 본 라운드 수정은 landed·무회귀.
+- 법령 표 행분할 over 의 1·2유닛 낭비 페이지를 **무회귀로 실제 수정**(별표1 일치, 별표4 대폭 개선),
+  대형 오라클 정합 97.6→97.8%.
+- 페이지네이션 작업의 **측정·검증 삼각대(페이지수+클리핑+baseline)** 구축.
+- 잔여의 성격(줄높이 아님, 한글 레퍼런스 선결)을 데이터로 규명. **#1658 존속**, 본 라운드 landed·무회귀.
 
 ## 7. 산출물
 - 소스: `src/renderer/layout/table_layout.rs`(+11)
-- 도구/오라클: `tools/build_page_oracle.py`, `tests/fixtures/render_page_oracle_1658.tsv`
-- 설계·단계: `tech/task_m100_1658_design.md`, `working/task_m100_1658_phase1/2/3.md`,
-  `tech/task_m100_1658_rca_table.md`, `tech/task_m100_1658_rca_rowsplit.md`,
-  `tech/task_m100_1658_reset_discriminator.md`
+- 도구/오라클: `tools/{build_page_oracle,detect_table_clipping,hangul_pdf_baseline}.py`,
+  `tests/fixtures/render_page_oracle_1658.tsv`
+- 분석: `mydocs/tech/task_m100_1658_*.md`, `working/task_m100_1658_phase1/2/3.md`,
+  `manual/{visual_clipping_detector,hangul_pdf_baseline}.md`

--- a/mydocs/tech/task_m100_1658_capacity.md
+++ b/mydocs/tech/task_m100_1658_capacity.md
@@ -1,0 +1,52 @@
+# 조사 — #1658 별표4 Δ+3 per-page 용량 정합 (clean lever 없음)
+
+- 일자: 2026-06-29 / 대상: 산업통상부 별표4(80×15 표, 한글 25 / rhwp 28쪽, Δ+3).
+- 도구: RHWP_TABLE_DRIFT(TABLE_SPLIT_AVAIL), detect_table_clipping, RHWP_UNIT_DEBUG.
+
+## 1. 계측 결과
+- **avail_for_rows = 1009.1px = 전체 body** (이 문서 pagination_tolerance = 0).
+  → **tolerance 차감 문제 아님.** 용량은 한글과 동일한 body 전체.
+- 페이지당 fragment 는 셀 내용 **vpos reset(=한글 페이지 경계)으로 경계**되며 ~34~35유닛/쪽으로
+  한글과 정렬(full page 는 일치).
+- 잔여 over 는 **행 전환 tail fragment**: 예) row31 cell page8 = 유닛 3..6(3유닛). 이전 페이지가
+  rows24~30 + row31 앞부분으로 채워져 tail 에 row31 을 3유닛만 담음(한글은 reset 6 까지 6유닛).
+  → 다음 페이지에 3유닛 orphan(Δ+1). 유사 transition 누적 = Δ+3.
+
+## 2. 근인
+- **선행 행(소행들)의 누적 높이가 한글보다 미세하게 커서 tail 가용이 부족** → row 시작 cell 이
+  reset 까지 못 닿고 capacity-break → orphan. 다요인 px 누적(행높이 측정 미세차).
+- tolerance 도, reset 분류도, 단일 cut 버그도 아님 — **measurement-fidelity(행높이 정합) 영역.**
+
+## 3. clean lever 부재 (모두 배제)
+| lever | 결과 |
+|------|------|
+| tolerance 차감 제거 | 별표4 avail 이미 full body(tolerance 0) → 무효 |
+| reset-snap(다음 reset 까지 overflow 흡수) | 32px 로 대형 게이트 442→440 회귀(입증). 별표4 deficit 3유닛(~86px)≫32px → 못 닿음 |
+| tiny_fragment_waste ≤3 확장 | #1488(가시 문단 reset 3유닛 후 보존) 단위테스트 위반 |
+
+## 4. detect_table_clipping 발견 (별도 버그)
+- 별표4 1페이지 **기존 클리핑 23.5px**(upstream 동일). 행분할 수정 무관. 렌더 측 fragment 높이
+  과대(≈0.8유닛)로, Δ+3(3유닛 deficit)과는 별개 규모. 별도 render-fidelity 수정 대상.
+
+## 5. 결론
+- 별표4 Δ+3 은 **선행 행높이 누적 정합(measurement fidelity)** 문제로, page-count·clipping 게이트로
+  안전하게 좁힐 clean lever 가 없다(3종 배제). 한글 행높이와의 미세 정합은 깊은 별도 작업.
+- 현 안전 ceiling(별표1 일치, 별표4 Δ+8→Δ+3, 무회귀, 클리핑 불변) 유지.
+- 후속: (a) 행높이 측정 정합(한글 대비 행 단위 diff 도구 필요), (b) 별표4 23.5px 클리핑 render 수정.
+  둘 다 detect_table_clipping + render_page_gate 양 게이트로 검증.
+
+## 6. 행높이 diff 도구 — 한글 레퍼런스 차단 (COM)
+별표4의 어느 행이 한글보다 과대 측정되는지 규명하려면 **한글 per-row 행높이 레퍼런스**가 필요.
+COM(pyhwpx) 경로 탐색 결과 차단:
+- `hwp.CellShape` → 셀 진입/선택 후에도 **None**(ParameterSet 미획득).
+- `hwp.TableLowerCell()` → 첫 셀에서 즉시 falsy(행 하향 이동 불가).
+- `hwp.get_row_height()` → 0.
+→ 경량 COM 으로 한글 행높이/행위치 추출 불가(이 환경 API 한계).
+
+**viable 경로(무거움)**: `hwp.FileSaveAs(PDF)` 로 한글 권위 PDF 생성 후 PDF 표선 검출(PyMuPDF/cv)로
+행높이 측정. 별도 도구·의존성 필요 → 본 라운드 범위 밖.
+
+## 7. 상태
+- 소스 무변경(조사만). PR #1670(행분할 수정 + 오라클 + 클리핑 검출기) 유지.
+- **별표4 Δ+3 capacity 정합은 한글 행높이 레퍼런스 차단으로 본 라운드 보류.** viable 경로 = PDF 기반
+  측정(무거움) 또는 COM API 추가 연구. 현 ceiling(별표1 일치/별표4 Δ3/무회귀) 유지.

--- a/mydocs/tech/task_m100_1658_clipping_capacity_unified.md
+++ b/mydocs/tech/task_m100_1658_clipping_capacity_unified.md
@@ -1,0 +1,36 @@
+# 통합 진단 — #1658 별표4 클리핑 ≡ capacity 결손 (cut↔render↔한글 줄높이 fidelity)
+
+- 일자: 2026-06-30 / 대상: 산업통상부 별표4 / 도구: detect_table_clipping, export-svg SVG 분석, RHWP_TABLE_DRIFT.
+
+## 1. 클리핑 위치 (detect_table_clipping → SVG 정밀)
+- 페이지 2: 마지막 표 행 전체가 baseline **y=1118.2** 에 렌더, body_bottom **1094.7** → **over 23.5px**.
+- 행 pitch = 28.8px(baseline 간격 일정). 마지막 행이 **1행 초과 포함**되어 본문 밖(하단 여백)으로 그려짐 → body-clip 에 잘림(데이터 손실).
+
+## 2. 근인 분해 (≈23.5px)
+| 성분 | 크기 | 설명 |
+|------|------|------|
+| cut↔render 유닛높이 drift | ~0.4px/유닛 × ~28유닛 ≈ **11px** | `advance_row_cut` 셀유닛(≈28.4px) < 렌더 줄 pitch(28.8px). cut 이 과소측정 → 페이지네이션이 1행 초과 포함 |
+| 페이지네이션 body ↔ render body | **~10px** | pagination avail_for_rows=1009.1 vs SVG body height=1019.1 |
+| 합 | ≈21~23px | 관측 23.5px 와 정합 |
+
+## 3. 핵심 통찰 — 클리핑과 capacity 는 같은 뿌리·상충 방향
+- **클리핑**(render 가 cut 보다 큼) 과 **capacity 결손**(rhwp 가 한글보다 적게 적재) 은
+  모두 **cut↔render↔한글 3자 간 sub-px 줄높이 fidelity 차이**의 다른 발현이다.
+- **방향 상충**:
+  - 클리핑 수정 = cut 을 render 만큼 크게 측정 → 더 일찍 끊음 → **페이지수↑(Δ 악화)**.
+  - capacity 수정 = 더 채움(cut 작게/avail 크게) → **클리핑↑**.
+  - 한글은 셋 중 가장 많이 적재(가장 작은 유효 줄높이 또는 tolerance) → cut/render 양쪽과 다름.
+- ∴ 단일 조정으로 클리핑·capacity·한글정합을 동시 만족 불가. **3자 줄높이 정합(cell_units ↔
+  layout_partial_table ↔ 한글)** 이 본질 과제.
+
+## 4. 결론
+- 별표4 23.5px 클리핑은 **국소 render 버그가 아니라** cut↔render 줄높이 drift(≈0.4px/유닛) + body
+  영역 10px 불일치의 누적 → capacity 결손과 **동일 뿌리**.
+- 안전한 단독 수정 불가(클리핑↔capacity 상충, 한글 3자 정합 필요). page-count·clipping 게이트만으론
+  방향을 못 정한다 → **한글 권위 줄높이 레퍼런스(PDF 측정 등)** 가 선행되어야 3자 정합 가능.
+- 현 ceiling(별표1 일치 / 별표4 Δ8→Δ3 / 무회귀 / 클리핑 23.5px 불변=기존) 유지.
+
+## 5. 권고 (후속 라운드)
+1. **한글 줄높이 레퍼런스 인프라**(한글 PDF 표선/텍스트 baseline 측정, PyMuPDF) — 3자 정합의 기준.
+2. 그 위에서 cell_units(cut) ↔ layout_partial_table(render) 줄높이 통일 + 한글 baseline 정합.
+3. 모든 변경은 render_page_gate(페이지수) + detect_table_clipping(클리핑) 양 게이트 무회귀 + 한글 baseline diff 로 검증.

--- a/tools/hangul_pdf_baseline.py
+++ b/tools/hangul_pdf_baseline.py
@@ -1,0 +1,153 @@
+"""#1658 한글 PDF baseline 인프라 — 한글 권위 줄 위치(baseline) 추출 + rhwp render 대조.
+
+cut↔render↔한글 3자 줄높이 fidelity 작업의 **기준(한글)** 을 제공한다. 한글이 그린 각 텍스트 줄의
+baseline Y 를 권위 PDF 에서 추출하고, rhwp export-svg 의 baseline 과 줄 pitch(줄간격)를 비교한다.
+
+- 한글 baseline: pyhwpx 로 PDF 생성(또는 기존 PDF) → PyMuPDF(fitz) span origin.y. pt→px(×96/72).
+- rhwp baseline: `rhwp export-svg` → `<text y=...>`.
+- 출력(--compare): 페이지별 한글/rhwp 줄수·median pitch·pitch diff. fidelity drift 정량화.
+
+사용:
+    # 한글 baseline 만 (PDF 자동 생성)
+    python tools/hangul_pdf_baseline.py <file.hwp> [--pdf existing.pdf] [-o out.tsv]
+    # rhwp render 와 줄 pitch 대조
+    python tools/hangul_pdf_baseline.py <file.hwp> --compare --exe <rhwp>
+요구: Windows + 한컴 + pyhwpx + PyMuPDF.
+"""
+from __future__ import annotations
+
+import argparse
+import re
+import statistics
+import subprocess
+import sys
+import tempfile
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+PT_TO_PX = 96.0 / 72.0
+SVG_NS = "{http://www.w3.org/2000/svg}"
+
+
+def hangul_pdf_baselines(src: Path, pdf: Path | None) -> list[list[float]]:
+    """페이지별 한글 텍스트 baseline Y (px @96dpi). pdf 없으면 pyhwpx 로 생성."""
+    import fitz
+
+    expect_pages: int | None = None
+    if pdf is None:
+        from pyhwpx import Hwp
+
+        subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+        hwp = Hwp(new=True, visible=False)
+        hwp.open(str(src))
+        expect_pages = int(hwp.PageCount)
+        tmp = Path(tempfile.gettempdir()) / (src.stem + "_hangul.pdf")
+        hwp.save_as(str(tmp), format="PDF")
+        hwp.clear(option=1)
+        hwp.quit()
+        subprocess.run(["taskkill", "/F", "/IM", "Hwp.exe"], capture_output=True)
+        pdf = tmp
+
+    doc = fitz.open(str(pdf))
+    if expect_pages is not None and doc.page_count != expect_pages:
+        print(
+            f"경고: 생성 PDF {doc.page_count}쪽 != 편집기 PageCount {expect_pages}쪽. "
+            f"인쇄 설정(맞춰찍기/배율)으로 비권위 레이아웃일 수 있음 — pdf/ 권위 PDF 사용 권장.",
+            file=sys.stderr,
+        )
+    pages: list[list[float]] = []
+    for page in doc:
+        ys: set[float] = set()
+        for block in page.get_text("dict")["blocks"]:
+            for line in block.get("lines", []):
+                for span in line.get("spans", []):
+                    ys.add(round(span["origin"][1] * PT_TO_PX, 1))
+        pages.append(sorted(ys))
+    return pages
+
+
+def rhwp_svg_baselines(src: Path, exe: str) -> list[list[float]]:
+    """페이지별 rhwp 텍스트 baseline Y (px)."""
+    with tempfile.TemporaryDirectory() as td:
+        subprocess.run([exe, "export-svg", str(src), "-o", td],
+                       capture_output=True, timeout=180)
+        pages: list[list[float]] = []
+        for svg in sorted(Path(td).glob("*.svg")):
+            root = ET.parse(svg).getroot()
+            ys = {round(float(t.get("y")), 1) for t in root.iter(f"{SVG_NS}text") if t.get("y")}
+            pages.append(sorted(ys))
+        return pages
+
+
+def _cluster_rows(baselines: list[float], tol: float = 3.0) -> list[float]:
+    """근접 baseline(같은 행의 다단 셀)을 한 행으로 병합 → 행 중심 목록.
+
+    다단 표는 한 행의 여러 셀이 거의 같은 Y 에 baseline 을 가져, flatten 하면 가짜 작은 간격이
+    생긴다. tol(px) 이내를 한 클러스터로 묶어 행 단위 pitch 를 정확히 한다.
+    """
+    if not baselines:
+        return []
+    bl = sorted(baselines)
+    rows = [[bl[0]]]
+    for y in bl[1:]:
+        if y - rows[-1][-1] <= tol:
+            rows[-1].append(y)
+        else:
+            rows.append([y])
+    return [statistics.mean(r) for r in rows]
+
+
+def median_pitch(baselines: list[float]) -> float | None:
+    """행 클러스터 후 연속 행 간격의 median (줄 pitch). 다단 셀 오염 제거."""
+    rows = _cluster_rows(baselines)
+    if len(rows) < 2:
+        return None
+    diffs = [b - a for a, b in zip(rows, rows[1:]) if 5.0 < (b - a) < 60.0]
+    return statistics.median(diffs) if diffs else None
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("src", type=Path)
+    ap.add_argument("--pdf", type=Path, default=None, help="기존 한글 PDF(없으면 pyhwpx 생성)")
+    ap.add_argument("--compare", action="store_true", help="rhwp render 와 줄 pitch 대조")
+    ap.add_argument("--exe", default="C:/Users/planet/rhwp/target/release/rhwp.exe"
+                    if sys.platform == "win32" else "target/release/rhwp")
+    ap.add_argument("-o", "--out", type=Path, default=None)
+    a = ap.parse_args()
+
+    hg = hangul_pdf_baselines(a.src, a.pdf)
+    print(f"한글: {len(hg)}쪽")
+
+    if not a.compare:
+        rows = [("page", "n_lines", "median_pitch", "first", "last")]
+        for i, bl in enumerate(hg):
+            mp = median_pitch(bl)
+            rows.append((str(i + 1), str(len(bl)),
+                         f"{mp:.2f}" if mp else "-",
+                         f"{bl[0]:.1f}" if bl else "-",
+                         f"{bl[-1]:.1f}" if bl else "-"))
+        for r in rows:
+            print("\t".join(r))
+        if a.out:
+            a.out.write_text("\n".join("\t".join(r) for r in rows), encoding="utf-8")
+        return 0
+
+    rh = rhwp_svg_baselines(a.src, a.exe)
+    print(f"rhwp: {len(rh)}쪽")
+    print(f"{'page':>4} {'hg_lines':>8} {'rh_lines':>8} {'hg_pitch':>9} {'rh_pitch':>9} {'pitch_d':>8}")
+    n = max(len(hg), len(rh))
+    for i in range(n):
+        hb = hg[i] if i < len(hg) else []
+        rb = rh[i] if i < len(rh) else []
+        hp = median_pitch(hb)
+        rp = median_pitch(rb)
+        d = (rp - hp) if (hp and rp) else None
+        print(f"{i+1:>4} {len(hb):>8} {len(rb):>8} "
+              f"{(f'{hp:.2f}' if hp else '-'):>9} {(f'{rp:.2f}' if rp else '-'):>9} "
+              f"{(f'{d:+.2f}' if d is not None else '-'):>8}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요
PR #1670(법령 표 행분할 over 수정 + 한글 오라클 + 클리핑 검출기, **merged**)의 후속. 페이지네이션 측정 인프라를 보강하고, 잔여 over(별표4 Δ+3)·클리핑의 성격을 한글 권위 기준으로 규명한다. **Rust 소스 변경 없음**(분석 + Python 도구).

## 추가 인프라
`tools/hangul_pdf_baseline.py` — cut↔render↔한글 3자 줄높이 fidelity 의 **한글 기준** 제공.
- pyhwpx `save_as(PDF)` + PyMuPDF(fitz) 로 한글 텍스트 baseline 추출(pt→px, 다단 행 클러스터링).
- `rhwp export-svg` baseline 과 줄 pitch 대조(`--compare`).
- **PageCount 가드**: 생성 PDF 쪽수 ≠ 편집기 PageCount 시 경고(인쇄 배율로 비권위 레이아웃 검출).

## 규명·정정 (데이터 기반)
- **줄높이 fidelity 정상**: byeolpyo1(권위 PDF 4쪽 = 편집기 4쪽) 한글 줄 pitch **28.80 = rhwp 28.80** → drift 없음.
  → #1658 잔여(별표4 Δ+3, 클리핑)는 **줄높이 fidelity 가 아니라 cut 로직 / 한글 PDF 배율 아티팩트** (앞선 가설 정정).
- **클리핑 ≡ capacity**: 별표4 23.5px 클리핑(render>cut)과 capacity 결손(rhwp<한글)은 같은 적재량 차이의 양면, 수정 방향 상충 → 단일 조정 불가.
- **차단 기록**: 한글 행높이 COM(CellShape/TableLowerCell 미동작), PDF 배율 100% 강제(save_as 가 doc PrintMethod 무시, 별표4 13≠25쪽 압축).

## 잔여 (후속 라운드)
별표4 Δ+3·클리핑·하단 고정 표 over 는 모두 **한글 권위 레이아웃 레퍼런스(배율 100% PDF / COM 표 API)** 가 선결되어야 진척. #1658 존속.

## 문서
- `mydocs/tech/task_m100_1658_capacity.md`, `task_m100_1658_clipping_capacity_unified.md`
- `mydocs/manual/hangul_pdf_baseline.md`
- `mydocs/report/task_m100_1658_report.md` (라운드 1 최종 보고서)

🤖 Generated with [Claude Code](https://claude.com/claude-code)