### PR TITLE
humdrum PR #1676~#1683 일괄 통합

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -248,6 +248,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "crunchy"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+
+[[package]]
 name = "data-url"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -298,6 +304,12 @@ checksum = "f1a05365e3b1c6d1650318537c7460c6923f1abdd272ad6842baa2b509957a06"
 dependencies = [
  "num-traits",
 ]
+
+[[package]]
+name = "fax"
+version = "0.2.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "caf1079563223d5d59d83c85886a56e586cfd5c1a26292e971a0fa266531ac5a"
 
 [[package]]
 name = "fdeflate"
@@ -431,6 +443,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "half"
+version = "2.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+dependencies = [
+ "cfg-if",
+ "crunchy",
+ "zerocopy",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,6 +478,7 @@ dependencies = [
  "moxcms",
  "num-traits",
  "png 0.18.1",
+ "tiff",
  "zune-core 0.5.1",
  "zune-jpeg 0.5.15",
 ]
@@ -1267,6 +1291,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "tiff"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b63feaf3343d35b6ca4d50483f94843803b0f51634937cc2ec519fc32232bc52"
+dependencies = [
+ "fax",
+ "flate2",
+ "half",
+ "quick-error",
+ "weezl",
+ "zune-jpeg 0.5.15",
+]
+
+[[package]]
 name = "tiny-skia"
 version = "0.11.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1700,6 +1738,26 @@ name = "xmlwriter"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec7a2a501ed189703dba8b08142f057e887dfc4b2cc4db2d343ac6376ba3e0b9"
+
+[[package]]
+name = "zerocopy"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ce1022995ff5ff5d841ad7d994facc23098cd40152f2c1d11cd607c6f530653f"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.52"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "zip"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ snafu = "0.9.0"
 strum = { version = "0.28.0", default-features = false, features = ["derive"] }
 unicode-segmentation = "1.12.0"
 unicode-width = "0.2.2"
-image = { version = "0.25", default-features = false, features = ["bmp", "jpeg", "png"] }
+image = { version = "0.25", default-features = false, features = ["bmp", "jpeg", "png", "tiff"] }
 pcx = "0.2"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
@@ -62,6 +62,7 @@ web-sys = { version = "0.3", features = [
     "CanvasPattern",
     "HtmlCanvasElement",
     "HtmlImageElement",
+    "ImageData",
     "TextMetrics",
     "Document",
     "Window",

--- a/mydocs/pr/archives/pr_1676_review.md
+++ b/mydocs/pr/archives/pr_1676_review.md
@@ -1,0 +1,83 @@
+# PR #1676 검토 - HWPX 이미지 페이로드 렌더링 정규화
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1676](https://github.com/edwardkim/rhwp/pull/1676) |
+| 제목 | `[IR 지원] HWPX 이미지 페이로드 렌더링 정규화` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-image-payload` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 12 파일, +265/-19 |
+| 원 PR 커밋 | `b5a58d818521`, `842f64d7ae9a` |
+| 로컬 적용 커밋 | `092936c38`, `123033088` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+HWPX 이미지 페이로드와 serializer roundtrip 지원을 보강하는 PR이다. PR 본문도 단독 페이지 시각 수정이 아니라 Format/IR 지원으로 분류한다.
+
+- `TOTAL` 이미지 fill mode를 `FIT`으로 접지 않고 별도 모드로 보존한다.
+- TIFF/BMP/PCX 및 시각적으로 grayscale인 JPEG처럼 브라우저/SVG 호스트가 바로 다루기 어려운 payload를 임베드 전에 PNG로 정규화한다.
+- HWP/HWPX serializer 경로에서 새 `TOTAL` 모드와 image payload 정보가 roundtrip되도록 `style`, `paint/json`, `serializer` 계층을 같이 보정한다.
+- `Cargo.toml` / `Cargo.lock` 변경으로 이미지 디코딩 의존성 그래프가 바뀐다. 따라서 첫 검증은 target cache가 있어도 일부 재빌드가 발생할 수 있다.
+
+변경 파일은 `src/renderer/image_resolver.rs`, `src/renderer/html.rs`, `src/renderer/skia/image_conv.rs`, `src/paint/json.rs`, `src/parser/hwpx/header.rs`, `src/serializer/*`, `Cargo.toml`, `Cargo.lock` 중심이다.
+
+## 3. 검토 의견
+
+이 PR은 렌더러가 "그릴 수 있는 image byte"를 얻는 배관을 넓히는 성격이라 수용 가치가 있다. 특히 HWPX에서 이미지 payload 자체는 존재하지만 브라우저/SVG 경로가 형식 때문에 실패하는 케이스를 줄인다.
+
+주의할 점은 payload 정규화가 원본 byte 보존과 렌더용 byte 생성의 경계를 흐리지 않아야 한다는 점이다. serializer roundtrip은 원본 형식 의미를 보존하고, renderer resolver는 표시 가능한 대체 표현을 만든다는 구분이 유지되는지 최종 검증이 필요하다.
+
+`TOTAL` fill mode는 포맷 의미 확장이라 렌더링뿐 아니라 저장/재직렬화에도 영향이 있다. 이번 검토에서는 기존 `FIT` 처리와의 호환성을 targeted test와 통합 테스트로 확인했다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 2개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태이므로 개별 PR head를 그대로 merge하기보다, 일괄 브랜치에서 최신 `devel` 위 검증을 완료한 뒤 원 PR은 superseded 처리하는 편이 안전하다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `svg_snapshot`/`visual_roundtrip_baseline` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1676 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| HWPX `imgBrush mode="TOTAL"`를 `FitToSize`로 접지 않고 보존 | `cargo test --profile release-test --lib test_img_brush_total_keeps_total_mode` 통과 |
+| grayscale JPEG는 PNG로 정규화 | `cargo test --profile release-test --lib grayscale_jpeg_is_normalized_to_png` 통과 |
+| color JPEG는 불필요하게 PNG로 변환하지 않음 | `cargo test --profile release-test --lib color_jpeg_keeps_jpeg_path` 통과 |
+| BMP payload는 PNG 변환 가능 | `cargo test --profile release-test --lib test_bmp_to_png_success` 통과 |
+| PCX payload는 PNG 변환 가능, 흰색 투명 처리 유지 | `cargo test --profile release-test --lib test_pcx_to_png_maps_white_to_transparent`, `cargo test --profile release-test --test issue_514` 통과 |
+| TIFF payload는 resolver에서 PNG + `FormatConverted`로 정규화 | maintainer 보강 테스트 `tiff_image_payload_is_normalized_to_png` 추가 후 `cargo test --profile release-test --lib tiff_image_payload_is_normalized_to_png` 통과 |
+
+보강 사항: 원 PR의 TIFF 정규화 주장은 코드에는 있었지만 직접 단위 테스트가 없어서, `src/renderer/image_resolver.rs`에 TIFF resolver contract 테스트를 추가했다. 이는 contributor 원 변경 위의 collaborator 보강이다.
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. `2022-09`, `2024-09-below20`, `2024-09-between20`은 마지막 페이지 equation/order 후보, `2024-09-below20-above20`, `2024-11-practice-above0-between20-below2`는 tail/question/large ink 후보가 남았다. 이는 이미지 payload 정규화 자체 실패로 보이지 않으며, 비교 이미지 기반 수동 시각 판정 대상으로 분리한다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보. PR 핵심 주장(`TOTAL`, BMP/PCX/TIFF/grayscale JPEG 정규화)은 targeted 검증으로 확인했고, WASM/browser build와 단독 렌더 snapshot도 통과했다. 이미지 fixture나 golden binary는 커밋되지 않았으므로 PR 첨부 시각 증거는 참고 자료로만 보고, 저장소 내 deterministic test와 필요한 수동 시각 판정을 merge gate로 삼는다.

--- a/mydocs/pr/archives/pr_1677_review.md
+++ b/mydocs/pr/archives/pr_1677_review.md
@@ -1,0 +1,77 @@
+# PR #1677 검토 - 렌더러 폰트 메트릭과 굵기 보존
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1677](https://github.com/edwardkim/rhwp/pull/1677) |
+| 제목 | `[경험적 렌더링] 렌더러 폰트 메트릭과 굵기 보존` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-font-metrics` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 4 파일, +164/-15 |
+| 원 PR 커밋 | `cb651bfaa851` |
+| 로컬 적용 커밋 | `935e036ca` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+텍스트 측정과 HTML 출력에서 renderer font hint와 font weight를 더 구체적으로 보존하는 렌더링 보정 PR이다. PR 본문은 Ghidra/Frida 근거가 아니라 경험적 text-metric 맞춤이라고 분류한다.
+
+- renderer font hint를 style resolution에서 text measurement 경로까지 전달한다.
+- 모든 굵은 글씨를 generic `bold`로 접지 않고 구체적인 CSS font weight 값을 출력한다.
+- `src/renderer/layout/text_measurement.rs`, `src/renderer/style_resolver.rs`, `src/renderer/mod.rs`, `src/renderer/html.rs`가 변경된다.
+- paragraph condense와 pagination 자체는 이 PR 범위 밖으로 둔다.
+
+## 3. 검토 의견
+
+폰트 hint와 굵기 보존은 실제 HWPX 출력에서 자간, 줄 높이, line break 위치에 직접 영향을 준다. 값 손실을 줄이는 방향은 타당하지만, 변경 표면은 작아 보여도 모든 텍스트 레이아웃에 파급될 수 있다.
+
+특히 `text_measurement` 경로의 변경은 페이지 분할, table cell 내 텍스트 흐름, shape 내부 텍스트와 같이 서로 다른 호출자가 공유한다. 단일 fixture 이미지의 시각 개선만으로는 충분하지 않으므로, 이번 검토에서는 기존 regression set의 페이지 수와 line break 안정성을 같이 확인했다.
+
+PR 본문에 첨부된 release asset 이미지는 참고 자료다. 저장소에 fixture/golden truth가 들어온 것은 아니므로, 이번 검토에서는 deterministic snapshot/visual sweep을 수행했고 canonical 출력과의 최종 비교는 작업지시자 시각 판정 범위로 남긴다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 1개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. 개별 merge보다는 일괄 브랜치에서 #1676 이후 변경과 함께 검증하는 방식이 적합하다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `svg_snapshot`/`visual_roundtrip_baseline` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1677 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| 중고딕/태고딕 계열 medium weight hint 식별 | `cargo test --profile release-test --lib weight` 중 `test_medium_weight_face` 통과 |
+| Light/Bold face weight를 CSS font-weight로 구체화 | `cargo test --profile release-test --lib weight` 중 `test_explicit_face_weight_hints` 통과 |
+| HTML/SVG 텍스트 출력에 medium weight가 반영됨 | `cargo test --profile release-test --lib weight` 중 `test_html_draw_text_medium_weight`, `test_svg_draw_text_medium_weight` 통과 |
+| 언어별 font family가 style resolver에서 보존되고 fallback 동작이 유지됨 | `cargo test --profile release-test --lib test_resolve_char_style_font_families`, `cargo test --profile release-test --lib font_family_for_lang` 통과 |
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. 텍스트/수식 겹침 후보와 tail/question/large ink 후보가 일부 남아 있어 수동 시각 판정 대상이지만, font weight/hint contract 또는 page count mismatch 실패는 확인되지 않았다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보이나 렌더링 회귀 가능성이 있는 경험적 보정이다. font hint/weight 보존 자체는 targeted 검증으로 확인했고, 단독 렌더 snapshot 및 WASM/browser 측정 경로도 통과했다. 기존 문서/표/shape 텍스트 페이지 수가 흔들리면 이 PR 단독 원인인지 #1680/#1681/#1683과 함께 재분리해야 한다.

--- a/mydocs/pr/archives/pr_1678_review.md
+++ b/mydocs/pr/archives/pr_1678_review.md
@@ -1,0 +1,75 @@
+# PR #1678 검토 - 브라우저 캔버스 이미지 리플레이 안정화
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1678](https://github.com/edwardkim/rhwp/pull/1678) |
+| 제목 | `[렌더러 보정] 브라우저 캔버스 이미지 리플레이 안정화` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-canvas-replay` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 3 파일, +102/-0 |
+| 원 PR 커밋 | `cac9415e3ac8` |
+| 로컬 적용 커밋 | `ab62ef541` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+브라우저 `WebCanvas` 경로에서 image data URL을 `HtmlImageElement`에 넣은 직후 아직 decode가 끝나지 않아 첫 pass에서 이미지가 누락될 수 있는 문제를 줄이는 PR이다.
+
+- `src/renderer/web_canvas.rs`에 bitmap byte를 동기적으로 `image::load_from_memory`로 디코드하는 경로를 추가한다.
+- full/cropped 이미지가 첫 render pass에서 offscreen canvas 기반 `drawImage(canvas, ...)`로 그려질 수 있게 한다.
+- WMF/PCX/SVG처럼 기존 fallback이 필요한 형식은 `HtmlImageElement` 경로에 남긴다.
+- `tests/render_p22_web_canvas_contract.rs`가 추가되어 canvas contract를 좁게 검증한다.
+
+## 3. 검토 의견
+
+문제 범위가 browser canvas first-paint에 한정되어 있고, fallback 형식을 기존 경로에 남긴 점은 좋다. native SVG/PNG 렌더러보다는 WASM/browser path의 안정성 개선으로 보는 것이 맞다.
+
+다만 `image` crate 기반 decode를 WebCanvas 경로에 추가하므로 WASM 빌드 크기와 supported image format 조합을 확인해야 하는 변경이다. 이번 검토에서는 #1676의 image payload 정규화와 함께 실제 WASM 빌드를 통과시켜 dependency impact가 빌드 실패로 이어지지 않음을 확인했다.
+
+`HtmlImageElement` fallback을 완전히 제거하지 않았기 때문에 unsupported/async-only 형식의 회귀 위험은 낮아 보인다. 그래도 브라우저 실제 실행 또는 WASM build 검증 없이 merge하는 것은 부적절하다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 1개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. #1676의 이미지 정규화 이후 순서로 적용했으며, 현 로컬 브랜치에서는 두 변경이 함께 존재한다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `render_p22_web_canvas_contract` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1678 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| bitmap bytes를 `HtmlImageElement` fallback 전에 decode한다 | `cargo test --profile release-test --test render_p22_web_canvas_contract` 중 `web_canvas_decodes_bitmap_bytes_before_html_image_fallback` 통과 |
+| replay plane ordering과 group label contract가 유지된다 | 같은 명령의 `web_canvas_all_filter_replays_logical_planes_in_order`, `web_canvas_control_code_group_labels_follow_active_replay_plane`, `web_canvas_layer_leaf_replay_does_not_rebuild_render_nodes` 통과 |
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. browser canvas image decode contract와 직접 연결된 failure는 확인되지 않았다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보. browser canvas contract는 targeted 검증으로 통과했고, 실제 WASM 빌드도 확인했다. 이 PR 단독으로는 페이지 수를 바꾸는 변경은 아니지만, #1676과 결합해 이미지 payload 처리 경로가 바뀌므로 렌더 영향 PR로 다룬다.

--- a/mydocs/pr/archives/pr_1679_review.md
+++ b/mydocs/pr/archives/pr_1679_review.md
@@ -1,0 +1,79 @@
+# PR #1679 검토 - HWPX 커넥터 선 도형 파싱
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1679](https://github.com/edwardkim/rhwp/pull/1679) |
+| 제목 | `[IR 복원] HWPX 커넥터 선 도형 파싱` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-connect-lines` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 1 파일, +123/-6 |
+| 원 PR 커밋 | `b51ff99484bc` |
+| 로컬 적용 커밋 | `0bc7171bf` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+HWPX XML의 connector line shape를 실제 line control로 복원하는 parser/IR 보강 PR이다. PR 본문도 시각 렌더링 자체가 아니라 HWPX XML 기반 Format/IR 복원으로 분류한다.
+
+- body paragraph 안의 `hp:connectLine`을 인식한다.
+- group container 안의 `hp:connectLine`도 동일하게 파싱한다.
+- connector endpoint, subject reference, control point, line type을 보존한다.
+- 변경 파일은 `src/parser/hwpx/section.rs` 1개다.
+
+## 3. 검토 의견
+
+커넥터 선은 diagram/form 계열 HWPX에서 시각적으로 중요한 요소지만, 이 PR의 직접 역할은 parser가 control을 잃지 않도록 하는 것이다. downstream renderer가 모든 connector geometry를 정확히 그리는지는 별도 문제로 분리해야 한다.
+
+단일 파일 변경이고 범위가 명확하다. group 내부 파싱이 추가되므로 기존 group child ordering이 보존되는지, shape/control list에 들어가는 순서가 문서 구조와 맞는지 확인할 필요가 있다.
+
+이 PR은 다른 렌더 보정 PR과 달리 경험적 layout 계산을 크게 바꾸지 않으므로 회귀 표면은 비교적 좁다. 다만 IR에 새 control이 살아나면 renderer 단계에서 이전에는 없던 선이 나타날 수 있으므로 visual diff는 필요하다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 1개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. 일괄 브랜치에서는 #1676-#1678 다음 순서로 적용했다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1679 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| `hp:connectLine`을 `LineShape` control로 materialize | `cargo test --profile release-test --lib test_parse_hwpx_connect_line_materializes_connector` 통과 |
+| connector line type 보존 | 같은 테스트에서 `LinkLineType::StraightOneWay` assertion 통과 |
+| start/end subject id/index 보존 | 같은 테스트에서 `start_subject_id/index`, `end_subject_id/index` assertion 통과 |
+| control point 보존 | 같은 테스트에서 control point 개수, 좌표, point type assertion 통과 |
+
+단, 이 targeted 검증은 parser/IR 복원까지만 보장한다. 이번 snapshot/visual sweep에서는 page count mismatch가 없었지만, connector-specific fixture가 아니므로 canonical renderer와 같은 라우팅/화살표/겹침 순서까지 보장하지는 않는다.
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. connector-specific fixture가 아니므로 커넥터 라우팅/화살표의 canonical 일치까지 보장하지는 않지만, 기존 snapshot/sweep에서 새 page count mismatch는 확인되지 않았다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보. parser/IR 복원 주장은 targeted 검증으로 확인했다. snapshot/visual sweep도 page count mismatch 없이 통과했지만, merge 판단 시에는 "connector를 파싱한다"와 "canonical renderer와 완전히 같은 선을 그린다"를 분리해서 기록해야 한다.

--- a/mydocs/pr/archives/pr_1680_review.md
+++ b/mydocs/pr/archives/pr_1680_review.md
@@ -1,0 +1,82 @@
+# PR #1680 검토 - HWPX PUA 글리프와 줄바꿈 매핑
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1680](https://github.com/edwardkim/rhwp/pull/1680) |
+| 제목 | `[경험적 렌더링] HWPX PUA 글리프와 줄바꿈 매핑` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-pua-linebreaks` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 5 파일, +199/-10 |
+| 원 PR 커밋 | `207a2b6e1fe6` |
+| 로컬 적용 커밋 | `0da18bbc9` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+HWPX private-use glyph를 표시 가능한 글리프로 매핑하고, 치환 문자 주변의 line break 처리를 보정하는 경험적 렌더링 PR이다.
+
+- fixture에서 관찰된 알려진 PUA codepoint를 표시 글리프로 변환한다.
+- filler 성격의 PUA codepoint가 visible text로 나오지 않게 한다.
+- replacement와 paragraph condense spacing 주변 line-break composition을 보존한다.
+- `src/renderer/composer.rs`, `src/renderer/composer/line_breaking.rs`, `src/renderer/style_resolver.rs`, `tests/issue_937.rs` 등이 변경된다.
+
+## 3. 검토 의견
+
+PUA 매핑은 실제 HWPX 출력에서 빈 네모나 알 수 없는 문자 대신 의도된 기호를 보여주는 효과가 있다. 다만 private-use 영역은 문서/폰트/템플릿별 의미가 다를 수 있으므로, 관찰된 codepoint에 좁게 적용되어야 한다.
+
+line break 보정은 텍스트 조판 전체에 영향을 줄 수 있다. #1677의 font metric 보존과 결합하면 줄바꿈 위치가 더 많이 변할 수 있으므로, 이번 검토에서는 둘을 함께 적용한 최신 브랜치에서 페이지 수와 visual snapshot을 확인했다.
+
+`tests/issue_937.rs`와 composer tests가 추가된 것은 좋다. 그래도 PR 본문에 첨부된 release asset은 참고 증거일 뿐이며, canonical visual gate를 대체하지 않는다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 1개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. 일괄 브랜치에서는 #1677의 font metric 변경 뒤에 적용되어 두 텍스트 보정이 함께 존재한다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `issue_937` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1680 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| `U+F012B` signature PUA를 표시 텍스트 `(인)`으로 확장 | `cargo test --profile release-test --test issue_937` 중 `issue_937_f012b_display_text_should_be_signature_seal`, `issue_937_svg_renders_f012b_as_signature_seal` 통과 |
+| `U+F081C` filler PUA가 visible text로 나오지 않음 | 같은 명령의 `issue_937_f081c_filler_should_not_render_as_text` 통과 |
+| `U+F02FC`, `U+F031C`가 각각 callout/toc 표시 글리프로 매핑 | 같은 명령의 `issue_937_f02fc_callout_bullet_should_render_as_pointer`, `issue_937_f031c_toc_bullet_should_render_as_square` 통과 |
+| 실제 fixture에서 signature cell source PUA가 존재함 | 같은 명령의 `issue_937_bokhakwonseo_signature_cell_contains_f012b` 통과 |
+| paragraph condense spacing 주변 reflow가 space width를 줄여 반영 | `cargo test --profile release-test --lib test_reflow_condense_shrinks_measured_space_width` 통과 |
+| 한국어 break word tokenization 보정 | `cargo test --profile release-test --lib test_tokenize_korean_break_word_chars` 통과 |
+
+단, 이 검증은 관찰된 PUA codepoint와 관련 line-break 단위 동작을 확인한다. 다른 문서/폰트의 private-use 의미까지 일반화하지 않는다.
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `cargo test --profile release-test --tests page_count`: 필터 매칭 26개 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. PUA 매핑/line-break 변경과 결합 가능성은 있으나, 현재 자동 sweep에서는 전체 페이지 수 불일치가 없다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보이나 경험적 매핑 범위를 좁게 유지해야 한다. PUA 표시와 line-break 보정의 직접 주장은 targeted 검증으로 확인했고, snapshot/page-count/visual sweep도 페이지 수 불일치 없이 통과했다. 향후 line break나 페이지 수가 흔들리면 #1677과 #1680의 결합 영향을 먼저 분리해 확인한다.

--- a/mydocs/pr/archives/pr_1681_review.md
+++ b/mydocs/pr/archives/pr_1681_review.md
@@ -1,0 +1,79 @@
+# PR #1681 검토 - matrix 위치 그룹 텍스트박스 재조판
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1681](https://github.com/edwardkim/rhwp/pull/1681) |
+| 제목 | `[경험적 렌더링] matrix 위치 그룹 텍스트박스 재조판` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-matrix-textbox` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 3 파일, +371/-66 |
+| 원 PR 커밋 | `7f9a10263908`, `dff4695898dc` |
+| 로컬 적용 커밋 | `c279f7d93`, `3500d8e64` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+group transform이 matrix-positioned child textbox에 두 번 적용되는 문제를 줄이고, matrix-scaled dimension 때문에 overflow가 나는 textbox line을 재구성하는 경험적 렌더링 PR이다.
+
+- HWPX rendering matrix placement를 group child에 대해 이미 배치된 값으로 취급한다.
+- matrix-scaled dimension으로 overflow가 생기는 textbox를 다시 조판한다.
+- 새 shape layout signature에 맞춰 table cell call-site에 default 인자를 추가한다.
+- `tests/visual_roundtrip_baseline.rs`에서 기존 xfail 성격 sample을 고정 visual roundtrip 대상으로 승격한다.
+
+## 3. 검토 의견
+
+group/matrix 처리의 double-apply 문제는 실제 페이지 좌표가 크게 틀어지는 원인이 될 수 있어 수용 가치가 있다. 다만 `shape_layout.rs` 변경량이 크고, group child 좌표 체계는 이미지, connector, text box, table 등 여러 shape에 파급될 수 있다.
+
+table cell 쪽 변경은 1줄 default 전달이지만 layout signature 변경에 따른 호출자 의미가 맞는지 봐야 한다. matrix textbox 전용 보정이 일반 table cell layout에 섞이지 않는지 확인이 필요하다.
+
+visual roundtrip baseline 승격은 좋은 방향이다. 이번 검토에서는 저장소 자동 시각 gate를 실행했지만, 저장소에 release asset 이미지는 들어오지 않았으므로 PR의 이미지 증거는 참고 자료다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 2개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. 일괄 브랜치에서는 #1679 connector IR 복원 뒤에 적용되어 diagram 계열 변경이 함께 존재한다.
+
+추가 maintainer 보강: clippy `items_after_test_module` 실패를 해소하기 위해 `src/renderer/layout/shape_layout.rs`의 새 test module을 파일 끝으로 이동했다. 테스트 내용과 런타임 로직은 바꾸지 않았다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `visual_roundtrip_baseline` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 1회 `items_after_test_module` 실패 후 test module 위치 보정, 재실행 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1681 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| matrix-positioned textbox에서 imported line이 height overflow를 만들면 재조판 | `cargo test --profile release-test --lib matrix_textbox_para_collapses_imported_lines_that_overflow_height` 통과 |
+| PR에서 승격한 visual roundtrip sample이 PASS 목록과 xfail 목록 정합성을 유지 | `cargo test --profile release-test --test visual_roundtrip_baseline` 통과 (`visual_grade_lists_are_consistent`, `visual_xfail_entries_still_fail`, `visual_baseline_all_samples`) |
+
+단, 이 검증은 repository visual roundtrip 기준이다. PR 본문 release asset과 canonical editor/PDF 시각 일치 여부는 저장소 fixture 밖의 수동 시각 판정 범위로 남는다.
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. matrix/group textbox PR 본문 release asset은 저장소 fixture가 아니므로, 해당 asset 자체의 canonical 일치는 수동 시각 판정 대상으로 남긴다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+수용 후보이나 렌더 좌표계 변경 폭이 커서 full 검증 대상이다. matrix textbox reflow와 visual baseline 승격은 targeted 검증으로 확인했고, snapshot/visual sweep도 page count mismatch 없이 통과했다. #1679, #1682와 함께 diagram/master plane 계열 visual diff는 필요 시 비교 이미지 기반 수동 판정으로 이어간다.

--- a/mydocs/pr/archives/pr_1682_review.md
+++ b/mydocs/pr/archives/pr_1682_review.md
@@ -1,0 +1,82 @@
+# PR #1682 검토 - master-page 장식 요소 plane별 리플레이
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1682](https://github.com/edwardkim/rhwp/pull/1682) |
+| 제목 | `[부분 Ghidra 근거] master-page 장식 요소를 plane별 리플레이` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-master-furniture` |
+| 문서 작성 시점 참고값 | `MERGEABLE` / `BEHIND`, draft 아님, maintainer 수정 가능 |
+| 규모 | 4 파일, +865/-49 |
+| 원 PR 커밋 | `6ab4e464bffa` |
+| 로컬 적용 커밋 | `4652a7b38` (`git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+master-page/header 장식 요소를 render plane별로 replay하고, 섹션을 넘어 odd/even master-page 선택을 이어받도록 하는 렌더 pipeline 변경 PR이다. PR 본문은 render-plane, `zOrder`, paper-origin 처리를 부분 Ghidra/Frida 근거가 있는 동작으로 분류한다.
+
+- 다음 섹션이 특정 parity master-page ref를 생략할 때 이전 odd/even ref를 이어받는다.
+- paper-background master control을 감지해 body text 뒤쪽 plane에 배치한다.
+- master-page render node를 plane, `zOrder`, stable source index 기준으로 정렬한다.
+- paper-relative header/master control을 page origin 기준으로 배치한다.
+- `src/document_core/queries/rendering.rs`, `src/renderer/layout.rs`, `src/renderer/layout/tests.rs`, `src/renderer/page_layout.rs`가 변경된다.
+
+## 3. 검토 의견
+
+이 PR은 변경량이 크고 page furniture ordering에 직접 관여한다. master/header/footer 장식, 본문 뒤 배경, body overlay 사이의 순서를 바꾸므로 visual impact가 넓다.
+
+부분 Ghidra/Frida 근거를 명시한 지점은 장점이다. 다만 page-selection carryover와 render-plane replay가 한 PR 안에 묶여 있어, 실패 시 원인 분리가 어려울 수 있다. local batch에서는 #1681 matrix/group 변경 뒤에 적용되어 visual diff가 겹칠 가능성이 있다.
+
+`src/renderer/layout/tests.rs`에 테스트가 크게 추가된 것은 긍정적이다. 이 변경은 snapshot/visual 계층 확인이 필요하므로, 이번 검토에서는 단독 `svg_snapshot`과 visual sweep을 함께 실행했다. 특히 odd/even master-page가 있는 문서와 body text 뒤 장식 요소는 필요 시 수동 비교에서 집중 확인한다.
+
+## 4. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 커밋 1개를 `-x`로 체리픽했다. 충돌은 없었다.
+
+원 PR은 `BEHIND` 상태다. 일괄 브랜치에서는 #1681 뒤에 적용했다.
+
+## 5. 검증 상태
+
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과, `svg_snapshot` 포함)
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 5.1 PR 내용별 targeted 검증
+
+2026-06-30 로컬 일괄 브랜치 `local/humdrum-pr-batch-review`에서 #1682 주장별로 다음을 확인했다.
+
+| 주장 | 검증 |
+|------|------|
+| odd/even master-page ref carryover와 fallback selection | `cargo test --profile release-test --lib master_page` 중 `master_page_selection_uses_final_carried_page_number_parity`, `missing_even_master_page_inherits_previous_even_master`, `single_base_master_page_applies_when_matching_parity_is_absent` 통과 |
+| master-page control을 plane, `zOrder`, stable index 순서로 정렬 | 같은 명령의 `master_page_controls_sort_by_render_layer_z_order` 통과 |
+| paper-sized master background는 body text 뒤 plane으로 replay | 같은 명령의 `master_page_paper_sized_background_replays_behind_body_text` 통과 |
+| 작은 front master control은 body text 앞 plane 유지 | 같은 명령의 `master_page_smaller_front_control_stays_in_front_of_body_text` 통과 |
+| master-page paper-relative shape/picture는 page origin 기준 배치 | 같은 명령의 `master_page_paper_relative_shape_uses_page_origin`, `master_page_paper_relative_picture_uses_page_origin` 통과 |
+| header paper-relative shape/picture도 page origin 기준 배치 | `cargo test --profile release-test --lib header_paper_relative` 통과 |
+
+단, 이 검증은 synthetic/unit render tree contract다. 이번 snapshot/visual sweep에서는 page count mismatch가 없었지만, PR 본문 release asset의 실제 문서 시각 정합은 저장소 fixture 밖의 수동 비교 범위로 남는다.
+
+### 5.2 시각/브라우저 검증
+
+2026-06-30 로컬 일괄 브랜치에서 자동 시각 gate를 추가 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- 자동 sweep flagged 후보: 5개 target. master-page/header furniture ordering 변경과 직접 맞물린 page count mismatch는 없었지만, PR 본문 release asset 자체는 저장소 fixture가 아니므로 필요 시 수동 비교로 확인한다.
+- browser/WASM 경로: `rhwp-studio` TypeScript/test와 `wasm-pack build --target web --out-dir pkg` 통과
+
+## 6. 잠정 판단
+
+조건부 수용 후보. 부분 역공학 근거가 있는 변경의 주요 contract는 targeted 검증으로 확인했고, snapshot/visual sweep도 page count mismatch 없이 통과했다. 다만 렌더 ordering 변경 폭이 커서 PR 본문 release asset까지 확인하려면 수동 비교가 필요하며, 실패가 나오면 #1682 단독 revert/분리 가능성을 열어 둬야 한다.

--- a/mydocs/pr/archives/pr_1683_review.md
+++ b/mydocs/pr/archives/pr_1683_review.md
@@ -1,0 +1,103 @@
+# PR #1683 검토 - 페이지네이션 fit에서 각주 영역 예약
+
+## 1. PR 정보
+
+| 항목 | 값 |
+|------|-----|
+| PR | [#1683](https://github.com/edwardkim/rhwp/pull/1683) |
+| 제목 | `[경험적 페이지네이션] 페이지네이션 fit에서 각주 영역 예약` |
+| 작성자 | `humdrum00001010` |
+| base <- head | `devel` <- `codex/pr1573-footnote-fit` |
+| 문서 작성 시점 참고값 | `CONFLICTING` / `DIRTY`, draft 아님, maintainer 수정 가능 |
+| 규모 | 6 파일, +852/-138 |
+| 원 PR 커밋 | `04fd6f5b1438`, `bb8c3deb6df0` |
+| 로컬 적용 커밋 | `fe6de3ef0` (`04fd6f5b1438`만 `git cherry-pick -x`) |
+
+## 2. 변경 범위
+
+pagination fit 계산 중 각주 영역을 예약하도록 하는 경험적 페이지네이션 보정 PR이다.
+
+- footnote shape 정보를 `rendering`, `pagination`, `typeset` 경로로 전달한다.
+- body content fit 계산에서 separator와 각주 사이 margin을 반영한다.
+- `src/renderer/pagination.rs`, `src/renderer/pagination/engine.rs`, `src/renderer/pagination/state.rs`, `src/renderer/pagination/tests.rs`, `src/renderer/typeset.rs`가 변경된다.
+- 원 PR의 두 번째 커밋 `bb8c3deb6df0`은 merge commit 성격이라 로컬 일괄 브랜치에는 적용하지 않았다.
+
+## 3. #1691 이후 충돌 처리
+
+GitHub 기준 이 PR은 `CONFLICTING` / `DIRTY`였다. 로컬에서는 `upstream/devel`에 이미 merge된 [#1691](https://github.com/edwardkim/rhwp/pull/1691) 이후 상태 위에 `04fd6f5b1438`을 체리픽하면서 `src/renderer/typeset.rs` 충돌이 발생했다.
+
+충돌 해결 방향:
+
+- #1691의 동적 `layout_drift_safety_px` 계산은 유지했다.
+- #1691의 overlay shape fit 예외와 TAC table bottom fit 예외를 유지했다.
+- #1683의 footnote reserve 이후 saved vpos / fit 판정 예외를 추가로 살렸다.
+- 양쪽 모두 page count와 fit 판정에 관여하므로, 해결 결과는 반드시 실제 PDF 기준 전체 페이지 수 검증 대상이다.
+
+## 4. 검토 의견
+
+각주 영역 예약은 페이지 수와 body overflow를 직접 바꾸는 고위험 변경이다. 특히 #1691도 page count 보정과 관련된 `typeset.rs` 변경을 포함하므로, 두 변경을 합친 로컬 해소 결과가 원 PR의 의도와 동일하다고 단정하면 안 된다.
+
+이 PR은 PR 본문도 경험적 페이지네이션 보정이라고 분류한다. canonical/PDF 대조에서 "모든 페이지 수가 맞아야 한다"는 현재 작업 목표와 직접 연결되므로, full sample set의 page count가 merge gate다.
+
+`pagination/tests.rs`가 추가된 점은 긍정적이다. 이번 검토에서는 각주/미주가 있는 실제 샘플 visual sweep과 2025 행정업무운영 편람 HWP/HWPX page count를 함께 확인했다. 이후 실패가 발생하면 #1691과 #1683의 fit 예외가 서로 완화/강화하는 부분부터 살핀다.
+
+## 5. 로컬 적용 상태
+
+`upstream/devel` 기준 로컬 일괄 검토 브랜치 `local/humdrum-pr-batch-review`에 원 코드 커밋 1개를 `-x`로 체리픽했다. `src/renderer/typeset.rs` 충돌은 위 기준으로 해결했고, `git cherry-pick --continue`까지 완료했다.
+
+원 PR은 개별 merge 불가 상태다. 일괄 브랜치에서 충돌 해결과 전체 검증을 통과하지 않으면 merge 후보로 볼 수 없다.
+
+## 6. 검증 상태
+
+- 완료: `cargo fmt --check`
+- 완료: `git diff --check`
+- 완료: `cargo build --release`
+- 완료: `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
+- 완료: `cargo test --profile release-test --tests` (통합 테스트 전체 통과)
+- 완료: `cargo clippy --all-targets -- -D warnings` (최초 공통 검증 18m 25s warning 0, TIFF 보강 후 최종 재실행 17m 28s warning 0)
+- 완료: `cargo test --doc` (0 passed, 0 failed, 1 ignored)
+- 완료: `cargo test --test svg_snapshot` (8 passed)
+- 완료: `cd rhwp-studio && npx tsc --noEmit`
+- 완료: `cd rhwp-studio && npm test` (153 passed)
+- 완료: `wasm-pack build --target web --out-dir pkg` (1m 25s)
+- 중단/무효: `cargo check --all-targets --message-format=short`는 workflow 문서에 없는 명령이라 중단했으며 검증 결과로 기록하지 않는다.
+
+### 6.1 PR 내용별 targeted 검증
+
+| 검증 대상 | 명령/테스트 | 결과 |
+|-----------|-------------|------|
+| 각주 separator와 note 사이 여백을 section shape 기준으로 예약 | `cargo test --profile release-test --lib footnote_area_reserve_uses_section_shape_metrics` | 통과 |
+| 저장된 single-line 문단이 body 하단에 맞으면 현재 페이지 유지 | `cargo test --profile release-test --lib saved_single_line_at_body_bottom_stays_on_current_page` | 통과 |
+| vpos reset 직전 2줄 tail이 visible bottom에 맞으면 현재 페이지 유지 | `cargo test --profile release-test --lib two_line_tail_before_vpos_reset_stays_on_current_page_when_visible_bottom_fits` | 통과 |
+| 저장된 TAC table line이 body 하단에 맞으면 현재 페이지 유지 | `cargo test --profile release-test --lib saved_tac_table_line_at_body_bottom_stays_on_current_page` | 통과 |
+| page-bottom text box fit에서 advance overflow가 있어도 실제 line bottom이 맞으면 유지 | `cargo test --profile release-test --lib page_bottom_text_box_fit_keeps_line_even_when_advance_overflows` | 통과 |
+| 기존 page count 회귀 가드 | `cargo test --profile release-test --tests page_count` | 통과, 필터 매칭 26개 통과 |
+
+`page_count` 필터 검증에는 `exam_eng_page_count_after_359_fix`, `issue_1035_alignment`, `issue_1086`, `issue_1105`, `issue_1139_inline_picture_duplicate`, `issue_1624_footer_overpush_matches_hangul_page_count`, `rowbreak_final_pages_match_hancom_pdf_page_count` 계열 테스트가 포함됐다.
+
+### 6.2 시각/PDF 검증
+
+2026-06-30 로컬 일괄 브랜치에서 각주/페이지네이션 영향 범위를 별도 확인했다.
+
+- `cargo test --test svg_snapshot`: 8개 golden snapshot 통과
+- `cargo test --profile release-test --test visual_roundtrip_baseline`: 3개 visual roundtrip baseline 통과
+- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, page count mismatch 0건
+- `pdfinfo 'pdf/2025 행정업무운영 편람(최종)-2024.pdf'`: 383쪽
+- `./target/release/rhwp info 'samples/2025 행정업무운영 편람(최종).hwp'`: 383쪽
+- `./target/release/rhwp info 'samples/2025 행정업무운영 편람(최종).hwpx'`: 383쪽
+
+`visual_sweep` 자동 후보 요약:
+
+| target | SVG/PDF pages | flagged | 주요 후보 |
+|--------|---------------|---------|-----------|
+| `2022-09` | 23/23 | 1 | `eq=[23]`, `order=[23]` |
+| `2024-09-below20` | 23/23 | 1 | `eq=[23]`, `order=[23]` |
+| `2024-09-between20` | 24/24 | 1 | `eq=[24]`, `order=[24]` |
+| `2024-09-below20-above20` | 23/23 | 4 | `eq=[23]`, `order=[23]`, `tail=[19,20]`, `question=[19,20,22]`, `large=[19,20,22]` |
+| `2024-11-practice-above0-between20-below2` | 22/22 | 4 | `tail=[12,17,20]`, `question=[17,21]`, `large=[17,20]` |
+
+나머지 10개 target은 flagged 0이다. 자동 후보가 남은 target도 페이지 수는 모두 PDF와 일치한다. 후보 페이지는 비교 이미지 기반 수동 시각 판정 대상으로 남기며, 이번 PR의 merge gate인 page count mismatch는 발견되지 않았다.
+
+## 7. 잠정 판단
+
+조건부 수용 후보. #1691 이후 `typeset.rs` 충돌은 로컬에서 해소했고, PR 내용과 직접 맞닿은 각주 reserve / saved vpos / page bottom fit / page count 필터 검증은 통과했다. 단독 snapshot, visual roundtrip, task1274 visual sweep, 2025 행정업무운영 편람 HWP/HWPX 383쪽 확인까지 page count mismatch는 발견되지 않았다. 다만 원 PR은 GitHub 기준 개별 merge 불가 상태였고, 자동 sweep 후보가 남은 페이지는 수동 시각 판정 대상으로 분리한다.

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2335,6 +2335,7 @@ impl DocumentCore {
                         hide_empty_line: section.section_def.hide_empty_line,
                         respect_vpos_reset: self.respect_vpos_reset,
                         is_hwp3_variant: self.document.is_hwp3_variant,
+                        footnote_shape: Some(section.section_def.footnote_shape.clone()),
                     },
                 )
             } else {
@@ -2352,6 +2353,7 @@ impl DocumentCore {
                     self.document.is_hwp3_variant,
                     hwp3_origin_flow_spacing_before,
                     hwp3_origin_page_tolerance,
+                    Some(&section.section_def.footnote_shape),
                     Some(&section.section_def.endnote_shape),
                     force_breaks.get(idx).unwrap_or(&empty_breaks),
                     is_hwpx_source,

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -123,6 +123,8 @@ fn assign_master_pages_for_section(
     result: &mut PaginationResult,
     section_index: usize,
     section: &Section,
+    carry_master_odd: &Option<MasterPageRef>,
+    carry_master_even: &Option<MasterPageRef>,
 ) {
     use crate::model::header_footer::HeaderFooterApply;
 
@@ -136,15 +138,29 @@ fn assign_master_pages_for_section(
         return;
     }
 
-    let mp_both = mps
+    let base_mp_indices: Vec<usize> = mps
         .iter()
-        .position(|m| m.apply_to == HeaderFooterApply::Both && !m.is_extension);
-    let mp_odd = mps
+        .enumerate()
+        .filter(|(_, m)| !m.is_extension)
+        .map(|(i, _)| i)
+        .collect();
+    let single_base_mp = if base_mp_indices.len() == 1 {
+        base_mp_indices.first().copied()
+    } else {
+        None
+    };
+    let mp_both = base_mp_indices
         .iter()
-        .position(|m| m.apply_to == HeaderFooterApply::Odd && !m.is_extension);
-    let mp_even = mps
+        .copied()
+        .find(|&i| mps[i].apply_to == HeaderFooterApply::Both);
+    let mp_odd = base_mp_indices
         .iter()
-        .position(|m| m.apply_to == HeaderFooterApply::Even && !m.is_extension);
+        .copied()
+        .find(|&i| mps[i].apply_to == HeaderFooterApply::Odd);
+    let mp_even = base_mp_indices
+        .iter()
+        .copied()
+        .find(|&i| mps[i].apply_to == HeaderFooterApply::Even);
     let ext_mp_indices: Vec<usize> = mps
         .iter()
         .enumerate()
@@ -162,14 +178,35 @@ fn assign_master_pages_for_section(
         }
 
         let selected = if page.page_number % 2 == 1 {
-            mp_odd.or(mp_both)
+            mp_odd
+                .or(mp_both)
+                .map(|mi| MasterPageRef {
+                    section_index,
+                    master_page_index: mi,
+                })
+                .or_else(|| carry_master_odd.clone())
+                .or_else(|| {
+                    single_base_mp.map(|mi| MasterPageRef {
+                        section_index,
+                        master_page_index: mi,
+                    })
+                })
         } else {
-            mp_even.or(mp_both)
+            mp_even
+                .or(mp_both)
+                .map(|mi| MasterPageRef {
+                    section_index,
+                    master_page_index: mi,
+                })
+                .or_else(|| carry_master_even.clone())
+                .or_else(|| {
+                    single_base_mp.map(|mi| MasterPageRef {
+                        section_index,
+                        master_page_index: mi,
+                    })
+                })
         };
-        page.active_master_page = selected.map(|mi| MasterPageRef {
-            section_index,
-            master_page_index: mi,
-        });
+        page.active_master_page = selected;
 
         if is_last && !ext_mp_indices.is_empty() {
             let replace_exts: Vec<usize> = ext_mp_indices
@@ -193,7 +230,13 @@ fn assign_master_pages_for_section(
             let active_apply = page
                 .active_master_page
                 .as_ref()
-                .and_then(|mp_ref| mps.get(mp_ref.master_page_index))
+                .and_then(|mp_ref| {
+                    if mp_ref.section_index == section_index {
+                        mps.get(mp_ref.master_page_index)
+                    } else {
+                        None
+                    }
+                })
                 .map(|m| m.apply_to);
             let mut remaining_overlap_exts: Vec<usize> = Vec::new();
             for &i in &overlap_exts {
@@ -215,6 +258,33 @@ fn assign_master_pages_for_section(
                     })
                     .collect();
             }
+        }
+    }
+}
+
+fn update_master_page_carry_from_section(
+    section_index: usize,
+    section: &Section,
+    carry_master_odd: &mut Option<MasterPageRef>,
+    carry_master_even: &mut Option<MasterPageRef>,
+) {
+    use crate::model::header_footer::HeaderFooterApply;
+
+    for (master_page_index, master_page) in section.section_def.master_pages.iter().enumerate() {
+        if master_page.is_extension {
+            continue;
+        }
+        let master_ref = MasterPageRef {
+            section_index,
+            master_page_index,
+        };
+        match master_page.apply_to {
+            HeaderFooterApply::Both => {
+                *carry_master_odd = Some(master_ref.clone());
+                *carry_master_even = Some(master_ref);
+            }
+            HeaderFooterApply::Odd => *carry_master_odd = Some(master_ref),
+            HeaderFooterApply::Even => *carry_master_even = Some(master_ref),
         }
     }
 }
@@ -2152,6 +2222,8 @@ impl DocumentCore {
         let mut carry_header_even: Option<HeaderFooterRef> = None;
         let mut carry_footer_odd: Option<HeaderFooterRef> = None;
         let mut carry_footer_even: Option<HeaderFooterRef> = None;
+        let mut carry_master_odd: Option<MasterPageRef> = None;
+        let mut carry_master_even: Option<MasterPageRef> = None;
 
         // [Task #1046] reflow force-break hint (구역별). reflow 루프(paginate)가 누적해 전달.
         let empty_breaks: std::collections::HashSet<usize> = std::collections::HashSet::new();
@@ -2184,6 +2256,12 @@ impl DocumentCore {
                         }
                     }
                 }
+                update_master_page_carry_from_section(
+                    idx,
+                    section,
+                    &mut carry_master_odd,
+                    &mut carry_master_even,
+                );
                 continue;
             }
 
@@ -2430,7 +2508,19 @@ impl DocumentCore {
             apply_page_number_layouts_for_section(&mut result, section);
 
             // 바탕쪽 선택은 구역 간 쪽번호 carry 보정 이후 최종 page_number 기준으로 수행한다.
-            assign_master_pages_for_section(&mut result, idx, section);
+            assign_master_pages_for_section(
+                &mut result,
+                idx,
+                section,
+                &carry_master_odd,
+                &carry_master_even,
+            );
+            update_master_page_carry_from_section(
+                idx,
+                section,
+                &mut carry_master_odd,
+                &mut carry_master_even,
+            );
 
             // 구역 간 머리말/꼬리말 상속 (쪽번호 보정 이후 실행)
             if idx > 0 {
@@ -4137,6 +4227,127 @@ mod tests {
             active.master_page_index, 1,
             "final page_number=2 must select the Even master page, not the section-local Odd page"
         );
+    }
+
+    #[test]
+    fn missing_even_master_page_inherits_previous_even_master() {
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::header_footer::{HeaderFooterApply, MasterPage};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        fn a4_section(section_def: SectionDef) -> Section {
+            Section {
+                section_def,
+                paragraphs: vec![Paragraph::default()],
+                raw_stream: None,
+            }
+        }
+
+        let page_def = PageDef {
+            width: 59528,
+            height: 84188,
+            margin_left: 8504,
+            margin_right: 8504,
+            margin_top: 5668,
+            margin_bottom: 4252,
+            margin_header: 4252,
+            margin_footer: 4252,
+            ..Default::default()
+        };
+
+        let mut document = Document::default();
+        document.sections.push(a4_section(SectionDef {
+            page_def: page_def.clone(),
+            master_pages: vec![MasterPage {
+                apply_to: HeaderFooterApply::Even,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }));
+        document.sections.push(a4_section(SectionDef {
+            page_def,
+            master_pages: vec![MasterPage {
+                apply_to: HeaderFooterApply::Odd,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }));
+
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core.paginate();
+
+        let page = core
+            .pagination
+            .get(1)
+            .and_then(|result| result.pages.first())
+            .expect("section 1 first page");
+        assert_eq!(page.page_number, 2);
+        let active = page
+            .active_master_page
+            .as_ref()
+            .expect("section 1 even page should inherit previous even master page");
+        assert_eq!(active.section_index, 0);
+        assert_eq!(active.master_page_index, 0);
+    }
+
+    #[test]
+    fn single_base_master_page_applies_when_matching_parity_is_absent() {
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::header_footer::{HeaderFooterApply, MasterPage};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::Paragraph;
+
+        fn a4_section(section_def: SectionDef) -> Section {
+            Section {
+                section_def,
+                paragraphs: vec![Paragraph::default()],
+                raw_stream: None,
+            }
+        }
+
+        let page_def = PageDef {
+            width: 59528,
+            height: 84188,
+            margin_left: 8504,
+            margin_right: 8504,
+            margin_top: 5668,
+            margin_bottom: 4252,
+            margin_header: 4252,
+            margin_footer: 4252,
+            ..Default::default()
+        };
+
+        let mut document = Document::default();
+        document.sections.push(a4_section(SectionDef {
+            page_def: page_def.clone(),
+            ..Default::default()
+        }));
+        document.sections.push(a4_section(SectionDef {
+            page_def,
+            master_pages: vec![MasterPage {
+                apply_to: HeaderFooterApply::Odd,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }));
+
+        let mut core = DocumentCore::new_empty();
+        core.set_document(document);
+        core.paginate();
+
+        let page = core
+            .pagination
+            .get(1)
+            .and_then(|result| result.pages.first())
+            .expect("section 1 first page");
+        assert_eq!(page.page_number, 2);
+        let active = page
+            .active_master_page
+            .as_ref()
+            .expect("single base master should apply to carried even page");
+        assert_eq!(active.master_page_index, 0);
     }
 
     #[test]

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -656,6 +656,7 @@ pub enum ImageFillMode {
     TileVertLeft,
     TileVertRight,
     FitToSize,
+    Total,
     Center,
     CenterTop,
     CenterBottom,

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -825,6 +825,18 @@ impl PaintOp {
                                 Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
                                 None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
                             }
+                        } else if mime == "image/tiff" {
+                            match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
+                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                            }
+                        } else if mime == "image/jpeg" {
+                            match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                                data,
+                            ) {
+                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                            }
                         } else {
                             (mime, std::borrow::Cow::Borrowed(data.as_slice()))
                         };
@@ -2476,6 +2488,7 @@ fn image_fill_mode_str(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",
         ImageFillMode::CenterBottom => "centerBottom",

--- a/src/paint/json.rs
+++ b/src/paint/json.rs
@@ -814,32 +814,33 @@ impl PaintOp {
                     // Task #516 Stage 5.2: overlay layer 의 <img> data URL 생성용 mime 노출.
                     // PCX 등 비표준은 PNG 변환 후 emit (CLI SVG 와 동일 정책 적용).
                     let mime = crate::renderer::svg::detect_image_mime_type(data);
-                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) =
-                        if mime == "image/x-pcx" {
-                            match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/bmp" {
-                            match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/tiff" {
-                            match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else if mime == "image/jpeg" {
-                            match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
-                                data,
-                            ) {
-                                Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
-                                None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
-                            }
-                        } else {
-                            (mime, std::borrow::Cow::Borrowed(data.as_slice()))
-                        };
+                    let (final_mime, final_data): (&str, std::borrow::Cow<[u8]>) = if mime
+                        == "image/x-pcx"
+                    {
+                        match crate::renderer::svg::pcx_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/bmp" {
+                        match crate::renderer::svg::bmp_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/tiff" {
+                        match crate::renderer::image_resolver::tiff_bytes_to_png_bytes(data) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else if mime == "image/jpeg" {
+                        match crate::renderer::image_resolver::grayscale_jpeg_bytes_to_png_bytes(
+                            data,
+                        ) {
+                            Some(png) => ("image/png", std::borrow::Cow::Owned(png)),
+                            None => (mime, std::borrow::Cow::Borrowed(data.as_slice())),
+                        }
+                    } else {
+                        (mime, std::borrow::Cow::Borrowed(data.as_slice()))
+                    };
                     let base64_data =
                         base64::engine::general_purpose::STANDARD.encode(&*final_data);
                     let _ = write!(

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1465,9 +1465,10 @@ fn parse_border_fill(
                                             "CENTER" => ImageFillMode::Center,
                                             "CENTER_TOP" => ImageFillMode::CenterTop,
                                             "CENTER_BOTTOM" => ImageFillMode::CenterBottom,
-                                            "FIT" | "FIT_TO_SIZE" | "STRETCH" | "TOTAL" => {
+                                            "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                                 ImageFillMode::FitToSize
                                             }
+                                            "TOTAL" => ImageFillMode::Total,
                                             "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                             _ => ImageFillMode::TileAll,
                                         };
@@ -2646,6 +2647,23 @@ mod tests {
             .into_iter()
             .next()
             .expect("borderFill 파싱 실패")
+    }
+
+    #[test]
+    fn test_img_brush_total_keeps_total_mode() {
+        let bf = parse_single_border_fill(
+            r#"<hh:borderFill id="346">
+                 <hh:fillBrush>
+                   <hc:imgBrush mode="TOTAL" bright="10" contrast="0" effect="REAL_PIC">
+                     <hc:img binaryItemIDRef="image36"/>
+                   </hc:imgBrush>
+                 </hh:fillBrush>
+               </hh:borderFill>"#,
+        );
+
+        let img = bf.fill.image.expect("image brush");
+        assert_eq!(img.fill_mode, ImageFillMode::Total);
+        assert_eq!(img.bin_data_id, 36);
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -23,9 +23,10 @@ use crate::model::page::{
 };
 use crate::model::paragraph::{CharShapeRef, FieldRange, LineSeg, OrphanFieldEnd, Paragraph};
 use crate::model::shape::{
-    ArcShape, CommonObjAttr, CurveShape, DrawingObjAttr, EllipseShape, GroupShape, HorzAlign,
-    HorzRelTo, LineShape, PolygonShape, RectangleShape, ShapeComponentAttr, ShapeObject,
-    SizeCriterion, TextBox, TextWrap, VertAlign, VertRelTo,
+    ArcShape, CommonObjAttr, ConnectorControlPoint, ConnectorData, CurveShape, DrawingObjAttr,
+    EllipseShape, GroupShape, HorzAlign, HorzRelTo, LineShape, LinkLineType, PolygonShape,
+    RectangleShape, ShapeComponentAttr, ShapeObject, SizeCriterion, TextBox, TextWrap, VertAlign,
+    VertRelTo,
 };
 use crate::model::style::{Fill, ShapeBorderLine};
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
@@ -485,7 +486,8 @@ fn parse_paragraph(
                         // lineseg 배열 파싱
                         parse_lineseg_array(reader, &mut para)?;
                     }
-                    b"rect" | b"ellipse" | b"line" | b"arc" | b"polygon" | b"curve" => {
+                    b"rect" | b"ellipse" | b"line" | b"connectLine" | b"arc" | b"polygon"
+                    | b"curve" => {
                         // 그리기 객체 파싱
                         let shape = parse_shape_object(local, ce, reader)?;
                         text_parts.push("\u{0002}".to_string());
@@ -3276,6 +3278,26 @@ fn parse_line_shape_attr(e: &quick_xml::events::BytesStart) -> ShapeBorderLine {
     bl
 }
 
+fn parse_connect_line_type_attr(e: &quick_xml::events::BytesStart) -> LinkLineType {
+    for attr in e.attributes().flatten() {
+        if attr.key.as_ref() == b"type" {
+            return match attr_str(&attr).to_ascii_uppercase().as_str() {
+                "STRAIGHT_ONEWAY" => LinkLineType::StraightOneWay,
+                "STRAIGHT_BOTH" => LinkLineType::StraightBoth,
+                "STROKE_NOARROW" => LinkLineType::StrokeNoArrow,
+                "STROKE_ONEWAY" => LinkLineType::StrokeOneWay,
+                "STROKE_BOTH" => LinkLineType::StrokeBoth,
+                "ARC_NOARROW" => LinkLineType::ArcNoArrow,
+                "ARC_ONEWAY" => LinkLineType::ArcOneWay,
+                "ARC_BOTH" => LinkLineType::ArcBoth,
+                _ => LinkLineType::StraightNoArrow,
+            };
+        }
+    }
+
+    LinkLineType::StraightNoArrow
+}
+
 /// shape 내부의 `<hp:fillBrush>` 자식 요소를 파싱하여 Fill을 반환한다.
 fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError> {
     use crate::model::style::{FillType, GradientFill, ImageFill, ImageFillMode, SolidFill};
@@ -3358,7 +3380,7 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                                 b"mode" => {
                                     img.fill_mode = match attr_str(&attr).as_str() {
                                         "TILE" | "TILE_ALL" => ImageFillMode::TileAll,
-                                        "FIT" | "FIT_TO_SIZE" | "STRETCH" | "TOTAL" => {
+                                        "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                             ImageFillMode::FitToSize
                                         }
                                         "CENTER" => ImageFillMode::Center,
@@ -3560,6 +3582,12 @@ fn parse_shape_object(
     let mut e_end2 = crate::model::Point::default();
 
     let object_ids = parse_object_element_attrs(e, &mut common, &mut shape_attr);
+    let connect_line_type = parse_connect_line_type_attr(e);
+    let mut connect_start_subject_id = 0_u32;
+    let mut connect_start_subject_index = 0_u32;
+    let mut connect_end_subject_id = 0_u32;
+    let mut connect_end_subject_index = 0_u32;
+    let mut connect_control_points = Vec::new();
 
     let tag_name = String::from_utf8_lossy(shape_type).to_string();
     let mut caption: Option<crate::model::shape::Caption> = None;
@@ -3674,6 +3702,8 @@ fn parse_shape_object(
                             match attr.key.as_ref() {
                                 b"x" => x_coords[0] = parse_i32(&attr),
                                 b"y" => y_coords[0] = parse_i32(&attr),
+                                b"subjectIDRef" => connect_start_subject_id = parse_u32(&attr),
+                                b"subjectIdx" => connect_start_subject_index = parse_u32(&attr),
                                 _ => {}
                             }
                         }
@@ -3683,9 +3713,23 @@ fn parse_shape_object(
                             match attr.key.as_ref() {
                                 b"x" => x_coords[1] = parse_i32(&attr),
                                 b"y" => y_coords[1] = parse_i32(&attr),
+                                b"subjectIDRef" => connect_end_subject_id = parse_u32(&attr),
+                                b"subjectIdx" => connect_end_subject_index = parse_u32(&attr),
                                 _ => {}
                             }
                         }
+                    }
+                    b"point" => {
+                        let mut point = ConnectorControlPoint::default();
+                        for attr in ce.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"x" => point.x = parse_i32(&attr),
+                                b"y" => point.y = parse_i32(&attr),
+                                b"type" => point.point_type = parse_u16(&attr),
+                                _ => {}
+                            }
+                        }
+                        connect_control_points.push(point);
                     }
                     // [Task #1598] ellipse / arc 전용 지오메트리. x/y 속성만 읽어 Point 채움.
                     b"center" => parse_xy(ce, &mut e_center),
@@ -3778,6 +3822,28 @@ fn parse_shape_object(
             },
             ..Default::default()
         }),
+        b"connectLine" => ShapeObject::Line(LineShape {
+            common,
+            drawing,
+            start: crate::model::Point {
+                x: x_coords[0],
+                y: y_coords[0],
+            },
+            end: crate::model::Point {
+                x: x_coords[1],
+                y: y_coords[1],
+            },
+            connector: Some(ConnectorData {
+                link_type: connect_line_type,
+                start_subject_id: connect_start_subject_id,
+                start_subject_index: connect_start_subject_index,
+                end_subject_id: connect_end_subject_id,
+                end_subject_index: connect_end_subject_index,
+                control_points: connect_control_points,
+                raw_trailing: Vec::new(),
+            }),
+            ..Default::default()
+        }),
         b"arc" => ShapeObject::Arc(ArcShape {
             common,
             drawing,
@@ -3861,7 +3927,8 @@ fn parse_container(
                             children.push(ShapeObject::Picture(pic));
                         }
                     }
-                    b"rect" | b"ellipse" | b"line" | b"arc" | b"polygon" | b"curve" => {
+                    b"rect" | b"ellipse" | b"line" | b"connectLine" | b"arc" | b"polygon"
+                    | b"curve" => {
                         // 자식 그리기 객체
                         let child = parse_shape_object(local, ce, reader)?;
                         if let Control::Shape(shape) = child {
@@ -6993,6 +7060,56 @@ mod tests {
         assert_eq!(master_page.ext_flags, 0x0007);
         assert_eq!(master_page.hwpx_page_number, Some(4));
         assert_eq!(master_page.raw_list_header.len(), 34);
+    }
+
+    #[test]
+    fn test_parse_hwpx_connect_line_materializes_connector() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:connectLine id="1522096658" zOrder="513" textWrap="IN_FRONT_OF_TEXT" textFlow="BOTH_SIDES" instid="448354835" type="STRAIGHT_ONEWAY">
+        <hp:offset x="0" y="0"/>
+        <hp:orgSz width="1257" height="1"/>
+        <hp:curSz width="1257" height="0"/>
+        <hp:pos treatAsChar="0" flowWithText="0" allowOverlap="1" vertRelTo="PAPER" horzRelTo="PAPER" vertOffset="25812" horzOffset="45538"/>
+        <hp:lineShape color="#000000" width="141" style="SOLID" headStyle="NORMAL" tailStyle="ARROW" headfill="1" tailfill="1" headSz="MEDIUM_MEDIUM" tailSz="MEDIUM_MEDIUM"/>
+        <hp:startPt x="0" y="0" subjectIDRef="11" subjectIdx="2"/>
+        <hp:endPt x="1257" y="0" subjectIDRef="22" subjectIdx="3"/>
+        <hp:controlPoints>
+          <hp:point x="0" y="0" type="3"/>
+          <hp:point x="100" y="0" type="26"/>
+        </hp:controlPoints>
+      </hp:connectLine>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"##;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Line(line) = shape.as_ref() else {
+            panic!("expected line shape");
+        };
+
+        assert_eq!(line.common.instance_id, 1522096658);
+        assert_eq!(line.common.horizontal_offset, 45538);
+        assert_eq!(line.common.vertical_offset, 25812);
+        assert_eq!(line.start.x, 0);
+        assert_eq!(line.end.x, 1257);
+
+        let connector = line.connector.as_ref().expect("connector data");
+        assert_eq!(connector.link_type, LinkLineType::StraightOneWay);
+        assert_eq!(connector.start_subject_id, 11);
+        assert_eq!(connector.start_subject_index, 2);
+        assert_eq!(connector.end_subject_id, 22);
+        assert_eq!(connector.end_subject_index, 3);
+        assert_eq!(connector.control_points.len(), 2);
+        assert_eq!(connector.control_points[1].x, 100);
+        assert_eq!(connector.control_points[1].point_type, 26);
     }
 
     #[test]

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -737,6 +737,7 @@ fn image_fill_mode_detail(value: ImageFillMode) -> &'static str {
         ImageFillMode::TileVertLeft => "tileVertLeft",
         ImageFillMode::TileVertRight => "tileVertRight",
         ImageFillMode::FitToSize => "fitToSize",
+        ImageFillMode::Total => "total",
         ImageFillMode::Center => "center",
         ImageFillMode::CenterTop => "centerTop",
         ImageFillMode::CenterBottom => "centerBottom",

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -1665,6 +1665,12 @@ fn pua_enclosed_border_type(ch: char) -> Option<u8> {
 fn pua_plain_text_display(ch: char) -> Option<&'static str> {
     match ch as u32 {
         0xF012B => Some("(인)"),
+        // 2025 행정업무운영 편람 p08 TOC bullet. Hancom PDF renders this
+        // private-use marker as a filled square bullet.
+        0xF031C => Some("■"),
+        // 2025 행정업무운영 편람 p15 callout bullet. Hancom PDF renders this
+        // private-use marker as a filled right-pointing pointer, not tofu.
+        0xF02FC => Some("►"),
         // [Task #1001] 한컴 변환본 (HWP3→HWP5) 의 글머리표 PUA. 한컴 viewer 는
         // 빈 체크박스 모양으로 표시. "□" (U+25A1 WHITE SQUARE) 매핑.
         // 실제 sample16-hwp5 의 PUA codepoint 는 U+F03C5 (글자 분석 결과).

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -222,9 +222,11 @@ pub(crate) fn tokenize_paragraph(
             continue;
         }
 
-        // 한글 어절 또는 글자
+        // 한글 어절 또는 글자.
+        // HWPX breakNonLatinWord="KEEP_WORD" is preserved as attr1 bit 7,
+        // which resolves to korean_break_unit == 1.
         if is_hangul(ch) {
-            if korean_break_unit == 0 {
+            if korean_break_unit == 1 {
                 // 어절 모드: 연속 한글 + 후행 금칙 문자를 하나의 토큰으로
                 let start = i;
                 let mut max_fs = 0.0f64;
@@ -577,6 +579,34 @@ fn to_hwp(px: f64) -> i32 {
     (px * 75.0) as i32
 }
 
+fn condense_space_savings_hwp(space_width_hwp: i32, condense_min_space: u8) -> i32 {
+    if condense_min_space == 0 || space_width_hwp <= 0 {
+        return 0;
+    }
+    let shrink_percent = condense_min_space.min(75) as i32;
+    space_width_hwp * shrink_percent / 100
+}
+
+fn condensed_line_width_hwp(width_hwp: i32, space_savings_hwp: i32) -> i32 {
+    width_hwp - space_savings_hwp
+}
+
+fn condense_fit_can_pull_next_token(
+    current_width_hwp: i32,
+    current_space_savings_hwp: i32,
+    effective_width_hwp: i32,
+    max_font_size: f64,
+) -> bool {
+    let current_condensed_width =
+        condensed_line_width_hwp(current_width_hwp, current_space_savings_hwp);
+    let remaining_hwp = effective_width_hwp - current_condensed_width;
+    // Hancom uses condense to rescue a line that still has a meaningful
+    // natural gap, but it does not pull the next word into an already tight
+    // line. The p03 PDF preface is sensitive to that distinction.
+    let min_remaining_hwp = to_hwp((max_font_size * 2.5).max(20.0));
+    remaining_hwp >= min_remaining_hwp
+}
+
 /// 토큰을 줄에 배치하는 Greedy 알고리즘
 /// 한컴과 동일한 결과를 위해 HWPUNIT 정수로 폭을 누적한다.
 fn fill_lines(
@@ -586,6 +616,7 @@ fn fill_lines(
     indent_px: f64,
     default_tab_width: f64,
     korean_break_unit: u8,
+    condense_min_space: u8,
 ) -> Vec<LineBreakResult> {
     if tokens.is_empty() {
         return vec![LineBreakResult {
@@ -609,12 +640,14 @@ fn fill_lines(
     let mut results = Vec::new();
     let mut line_start_idx = 0usize;
     let mut lw = 0i32; // HWPUNIT 정수 누적
+    let mut line_space_savings = 0i32;
     let mut line_max_fs = 0.0f64;
     let mut is_first_line = true;
 
     let mut last_break_token_idx: Option<usize> = None;
     let mut last_break_char_idx: usize = 0;
     let mut width_at_last_break = 0i32;
+    let mut space_savings_at_last_break = 0i32;
     let mut fs_at_last_break = 0.0f64;
 
     let eff_w = |first: bool| -> i32 {
@@ -646,6 +679,7 @@ fn fill_lines(
                 });
                 line_start_idx = *idx + 1;
                 lw = 0;
+                line_space_savings = 0;
                 line_max_fs = 0.0;
                 is_first_line = false;
                 last_break_token_idx = None;
@@ -669,6 +703,7 @@ fn fill_lines(
                         });
                         line_start_idx = last_break_char_idx;
                         lw = lw - width_at_last_break;
+                        line_space_savings -= space_savings_at_last_break;
                     } else {
                         results.push(LineBreakResult {
                             start_idx: line_start_idx,
@@ -678,6 +713,7 @@ fn fill_lines(
                         });
                         line_start_idx = *idx;
                         lw = 0;
+                        line_space_savings = 0;
                         line_max_fs = *max_font_size;
                     }
                     is_first_line = false;
@@ -689,6 +725,7 @@ fn fill_lines(
                     last_break_token_idx = Some(ti);
                     last_break_char_idx = *idx;
                     width_at_last_break = lw;
+                    space_savings_at_last_break = line_space_savings;
                     fs_at_last_break = line_max_fs;
                     lw = next_tab_hwp;
                 }
@@ -704,8 +741,11 @@ fn fill_lines(
                 last_break_token_idx = Some(ti);
                 last_break_char_idx = *idx;
                 width_at_last_break = lw;
+                space_savings_at_last_break = line_space_savings;
                 fs_at_last_break = line_max_fs;
-                lw += to_hwp(*width);
+                let space_hwp = to_hwp(*width);
+                lw += space_hwp;
+                line_space_savings += condense_space_savings_hwp(space_hwp, condense_min_space);
             }
             BreakToken::Text {
                 start_idx,
@@ -726,22 +766,43 @@ fn fill_lines(
                 if *end_idx - *start_idx == 1 && *start_idx > line_start_idx {
                     let c = text_chars[*start_idx];
                     let allow_break = if is_hangul(c) {
-                        korean_break_unit == 1
+                        korean_break_unit == 0
                     } else {
                         is_cjk_ideograph(c)
                     };
+                    let candidate_w = lw + w_hwp;
                     // 이 글자가 줄에 들어가는 경우에만 break point 갱신
-                    if allow_break && lw + w_hwp <= eff_w(is_first_line) + LINE_BREAK_TOLERANCE {
+                    if allow_break
+                        && condensed_line_width_hwp(candidate_w, line_space_savings)
+                            <= eff_w(is_first_line) + LINE_BREAK_TOLERANCE
+                    {
                         last_break_token_idx = Some(ti);
                         last_break_char_idx = *end_idx; // 이 글자 다음 (이 글자 포함)
-                        width_at_last_break = lw + w_hwp; // 이 글자 폭 포함
+                        width_at_last_break = candidate_w; // 이 글자 폭 포함
+                        space_savings_at_last_break = line_space_savings;
                         fs_at_last_break = line_max_fs;
                     }
                 }
                 // 한컴은 HWPUNIT 정수 양자화 시 미세한 반올림 차이를 허용
                 // 12 HU(~0.17mm) 이내의 초과는 줄에 포함 (경험적 허용 오차)
                 const LINE_BREAK_TOLERANCE: i32 = 15;
-                if lw + w_hwp > eff_w(is_first_line) + LINE_BREAK_TOLERANCE {
+                let effective_width = eff_w(is_first_line);
+                let natural_candidate = lw + w_hwp;
+                let condensed_candidate =
+                    condensed_line_width_hwp(natural_candidate, line_space_savings);
+                let needs_condense_to_fit = natural_candidate
+                    > effective_width + LINE_BREAK_TOLERANCE
+                    && condensed_candidate <= effective_width + LINE_BREAK_TOLERANCE;
+                let condense_pull_allowed = !needs_condense_to_fit
+                    || condense_fit_can_pull_next_token(
+                        lw,
+                        line_space_savings,
+                        effective_width,
+                        *max_font_size,
+                    );
+                if condensed_candidate > effective_width + LINE_BREAK_TOLERANCE
+                    || !condense_pull_allowed
+                {
                     if *start_idx > line_start_idx {
                         if let Some(_) = last_break_token_idx {
                             results.push(LineBreakResult {
@@ -756,6 +817,12 @@ fn fill_lines(
                             }
                             line_start_idx = next_start;
                             lw = recalc_width_hwp(tokens, ti, next_start);
+                            line_space_savings = recalc_space_savings_hwp(
+                                tokens,
+                                ti,
+                                next_start,
+                                condense_min_space,
+                            );
                             lw += w_hwp;
                             line_max_fs = *max_font_size;
                             is_first_line = false;
@@ -782,6 +849,7 @@ fn fill_lines(
                         is_first_line = false;
                     }
                     lw = remaining_w;
+                    line_space_savings = 0;
                     line_max_fs = remaining_fs;
                     last_break_token_idx = None;
                     continue;
@@ -835,6 +903,30 @@ fn recalc_width_hwp(tokens: &[BreakToken], current_token_idx: usize, new_line_st
             }
             BreakToken::Space { idx, width, .. } if *idx >= new_line_start => {
                 w += to_hwp(*width);
+            }
+            _ => {}
+        }
+    }
+    w
+}
+
+/// 줄 바꿈 지점 이후 공백 압축 가능 폭 재계산 (HWPUNIT)
+fn recalc_space_savings_hwp(
+    tokens: &[BreakToken],
+    current_token_idx: usize,
+    new_line_start: usize,
+    condense_min_space: u8,
+) -> i32 {
+    let mut w = 0i32;
+    for t in &tokens[..current_token_idx] {
+        match t {
+            BreakToken::Space {
+                idx,
+                width,
+                max_font_size,
+            } if *idx >= new_line_start => {
+                let space_hwp = to_hwp(*width);
+                w += condense_space_savings_hwp(space_hwp, condense_min_space);
             }
             _ => {}
         }
@@ -1083,6 +1175,7 @@ pub(crate) fn reflow_line_segs(
     let indent_px = para_style.map(|s| s.indent).unwrap_or(0.0);
     let english_break_unit = para_style.map(|s| s.english_break_unit).unwrap_or(0);
     let korean_break_unit = para_style.map(|s| s.korean_break_unit).unwrap_or(0);
+    let condense_min_space = para_style.map(|s| s.condense_min_space).unwrap_or(0);
     let tab_width = para_style.map(|s| s.default_tab_width).unwrap_or(0.0);
 
     // 토큰화 → 줄 채움 → LineSeg 생성
@@ -1101,8 +1194,8 @@ pub(crate) fn reflow_line_segs(
         indent_px,
         tab_width,
         korean_break_unit,
+        condense_min_space,
     );
-
     let mut new_line_segs: Vec<LineSeg> = Vec::new();
     for lb in &line_breaks {
         let utf16_start = if new_line_segs.is_empty() {

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -759,6 +759,32 @@ fn test_reflow_english_word_wrap() {
     assert_eq!(para.line_segs[1].text_start, 6); // "World" 시작
 }
 
+#[test]
+fn test_reflow_condense_shrinks_measured_space_width() {
+    let mut styles = make_styles_with_font_size(10.0);
+    styles.para_styles[0].condense_min_space = 20;
+
+    let mut para = Paragraph {
+        text: "A B ABCDEF".to_string(),
+        char_offsets: vec![0, 1, 2, 3, 4, 5, 6, 7, 8, 9],
+        char_count: 10,
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    // Natural width is 50px: 8 latin chars at 5px + 2 spaces at 5px.
+    // condense=20 allows each measured space to shrink by 20%, saving 2px.
+    reflow_line_segs(&mut para, 48.0, &styles, 96.0);
+    assert_eq!(para.line_segs.len(), 1);
+}
+
 /// 강제 줄 바꿈: \n에서 즉시 줄 바꿈
 #[test]
 fn test_reflow_forced_line_break() {
@@ -816,7 +842,7 @@ fn test_tokenize_korean_eojeol() {
         char_shape_id: 0,
     }];
 
-    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 0);
+    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 1);
     // "가나" (Text) + " " (Space) + "다라" (Text) = 3 tokens
     assert_eq!(tokens.len(), 3);
     assert!(matches!(
@@ -833,6 +859,37 @@ fn test_tokenize_korean_eojeol() {
         BreakToken::Text {
             start_idx: 3,
             end_idx: 5,
+            ..
+        }
+    ));
+}
+
+/// 토크나이저: 한국어 글자 단위 토큰화
+#[test]
+fn test_tokenize_korean_break_word_chars() {
+    let styles = make_styles_with_font_size(16.0);
+    let text: Vec<char> = "가나".chars().collect();
+    let offsets: Vec<u32> = (0..text.len() as u32).collect();
+    let shapes = vec![CharShapeRef {
+        start_pos: 0,
+        char_shape_id: 0,
+    }];
+
+    let tokens = tokenize_paragraph(&text, &offsets, &shapes, &styles, 0, 0);
+    assert_eq!(tokens.len(), 2);
+    assert!(matches!(
+        tokens[0],
+        BreakToken::Text {
+            start_idx: 0,
+            end_idx: 1,
+            ..
+        }
+    ));
+    assert!(matches!(
+        tokens[1],
+        BreakToken::Text {
+            start_idx: 1,
+            end_idx: 2,
             ..
         }
     ));

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -5,7 +5,11 @@
 
 use super::layout::compute_char_positions;
 use super::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
-use super::svg::{convert_wmf_to_svg, detect_image_mime_type};
+use super::image_resolver::{
+    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes,
+    tiff_bytes_to_png_bytes,
+};
+use super::svg::convert_wmf_to_svg;
 use super::{LineStyle, PathCommand, Renderer, ShapeStyle, TextStyle};
 use crate::model::style::UnderlineType;
 use base64::Engine;
@@ -460,6 +464,21 @@ impl Renderer for HtmlRenderer {
             if mime_type == "image/x-wmf" {
                 match convert_wmf_to_svg(data) {
                     Some(svg_bytes) => (std::borrow::Cow::Owned(svg_bytes), "image/svg+xml"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/bmp" {
+                match bmp_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/x-pcx" {
+                match pcx_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
+                    None => (std::borrow::Cow::Borrowed(data), mime_type),
+                }
+            } else if mime_type == "image/tiff" {
+                match tiff_bytes_to_png_bytes(data) {
+                    Some(png_bytes) => (std::borrow::Cow::Owned(png_bytes), "image/png"),
                     None => (std::borrow::Cow::Borrowed(data), mime_type),
                 }
             } else {

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -3,12 +3,11 @@
 //! 렌더 트리를 HTML 문자열로 변환한다.
 //! CSS로 스타일링하여 접근성과 텍스트 선택을 지원한다.
 
+use super::image_resolver::{
+    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes, tiff_bytes_to_png_bytes,
+};
 use super::layout::compute_char_positions;
 use super::render_tree::{PageRenderTree, RenderNode, RenderNodeType};
-use super::image_resolver::{
-    bmp_bytes_to_png_bytes, detect_image_mime_type, pcx_bytes_to_png_bytes,
-    tiff_bytes_to_png_bytes,
-};
 use super::svg::convert_wmf_to_svg;
 use super::{LineStyle, PathCommand, Renderer, ShapeStyle, TextStyle};
 use crate::model::style::UnderlineType;

--- a/src/renderer/html.rs
+++ b/src/renderer/html.rs
@@ -309,10 +309,8 @@ impl Renderer for HtmlRenderer {
             x, draw_y, font_family, draw_size, color,
         );
 
-        if style.is_visually_bold() {
-            css.push_str("font-weight:bold;");
-        } else if style.is_medium_weight() {
-            css.push_str("font-weight:500;");
+        if let Some(weight) = style.css_font_weight() {
+            css.push_str(&format!("font-weight:{};", weight));
         }
         if style.italic {
             css.push_str("font-style:italic;");

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -27,6 +27,12 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
             kind: ResolvedImageKind::FormatConverted,
             suppress_effects: false,
         }),
+        "image/tiff" => tiff_bytes_to_png_bytes(data).map(|data| ResolvedImagePayload {
+            data,
+            mime: "image/png",
+            kind: ResolvedImageKind::FormatConverted,
+            suppress_effects: false,
+        }),
         "image/jpeg" if is_watermark_image(image) => {
             watermark_jpeg_bytes_to_hancom_baked_png_bytes(data).map(|data| ResolvedImagePayload {
                 data,
@@ -35,6 +41,12 @@ pub(crate) fn resolve_image_payload(image: &ImageNode) -> Option<ResolvedImagePa
                 suppress_effects: true,
             })
         }
+        "image/jpeg" => grayscale_jpeg_bytes_to_png_bytes(data).map(|data| ResolvedImagePayload {
+            data,
+            mime: "image/png",
+            kind: ResolvedImageKind::FormatConverted,
+            suppress_effects: false,
+        }),
         _ => None,
     }
 }
@@ -67,6 +79,69 @@ pub(crate) fn bmp_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
     use image::{load_from_memory_with_format, ImageFormat};
 
     let img = load_from_memory_with_format(data, ImageFormat::Bmp).ok()?;
+    let mut out = Vec::new();
+    img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .ok()?;
+    Some(out)
+}
+
+/// TIFF 바이트를 PNG 바이트로 재인코딩한다. 실패 시 None 반환.
+///
+/// 브라우저와 rsvg는 SVG `<image>` 내부의 `data:image/tiff` URI를 안정적으로
+/// 렌더링하지 못하므로, SVG/Canvas/HTML 임베딩 전에 PNG로 변환한다.
+pub(crate) fn tiff_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
+    use image::{load_from_memory_with_format, ImageFormat};
+
+    let img = load_from_memory_with_format(data, ImageFormat::Tiff).ok()?;
+    let mut out = Vec::new();
+    img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
+        .ok()?;
+    Some(out)
+}
+
+/// Browser SVG/Canvas decoders can expose stale color planes in old Photoshop
+/// grayscale JPEGs. Re-encode only visually gray JPEGs to PNG so color photos
+/// keep the compact JPEG path.
+pub(crate) fn grayscale_jpeg_bytes_to_png_bytes(data: &[u8]) -> Option<Vec<u8>> {
+    use image::{load_from_memory_with_format, ImageFormat};
+
+    if detect_image_mime_type(data) != "image/jpeg" {
+        return None;
+    }
+
+    let mut img = load_from_memory_with_format(data, ImageFormat::Jpeg)
+        .ok()?
+        .to_rgba8();
+    if img.width() == 0 || img.height() == 0 {
+        return None;
+    }
+
+    let has_photoshop_profile = data
+        .windows(b"Adobe Photoshop".len())
+        .any(|chunk| chunk == b"Adobe Photoshop")
+        || data
+            .windows(b"Adobe_CM".len())
+            .any(|chunk| chunk == b"Adobe_CM");
+    let is_gray = img.pixels().all(|px| {
+        let [r, g, b, _] = px.0;
+        let min = r.min(g).min(b);
+        let max = r.max(g).max(b);
+        max.saturating_sub(min) <= 2
+    });
+    let is_luma_plane_gray = has_photoshop_profile
+        && img.pixels().all(|px| {
+            let [_, g, b, _] = px.0;
+            g.abs_diff(128) <= 2 && b.abs_diff(128) <= 2
+        });
+    if is_luma_plane_gray {
+        for px in img.pixels_mut() {
+            let gray = px.0[0];
+            px.0 = [gray, gray, gray, px.0[3]];
+        }
+    } else if !is_gray {
+        return None;
+    }
+
     let mut out = Vec::new();
     img.write_to(&mut Cursor::new(&mut out), ImageFormat::Png)
         .ok()?;
@@ -357,4 +432,50 @@ pub(crate) fn detect_image_mime_type(data: &[u8]) -> &'static str {
         return "image/x-pcx";
     }
     "application/octet-stream"
+}
+
+#[cfg(test)]
+mod tests {
+    use super::grayscale_jpeg_bytes_to_png_bytes;
+    use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
+    use std::io::Cursor;
+
+    fn jpeg_from_pixels(width: u32, height: u32, pixels: impl Fn(u32, u32) -> [u8; 3]) -> Vec<u8> {
+        let mut img = RgbImage::new(width, height);
+        for y in 0..height {
+            for x in 0..width {
+                img.put_pixel(x, y, Rgb(pixels(x, y)));
+            }
+        }
+
+        let mut out = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut out), ImageFormat::Jpeg)
+            .expect("encode jpeg");
+        out
+    }
+
+    #[test]
+    fn grayscale_jpeg_is_normalized_to_png() {
+        let jpeg = jpeg_from_pixels(2, 2, |x, y| {
+            let g = 180 + (x + y) as u8;
+            [g, g, g]
+        });
+
+        let png = grayscale_jpeg_bytes_to_png_bytes(&jpeg).expect("gray jpeg should normalize");
+        assert!(png.starts_with(b"\x89PNG\r\n\x1a\n"));
+    }
+
+    #[test]
+    fn color_jpeg_keeps_jpeg_path() {
+        let jpeg = jpeg_from_pixels(2, 2, |x, y| {
+            if (x + y) % 2 == 0 {
+                [220, 64, 64]
+            } else {
+                [64, 120, 220]
+            }
+        });
+
+        assert!(grayscale_jpeg_bytes_to_png_bytes(&jpeg).is_none());
+    }
 }

--- a/src/renderer/image_resolver.rs
+++ b/src/renderer/image_resolver.rs
@@ -436,7 +436,9 @@ pub(crate) fn detect_image_mime_type(data: &[u8]) -> &'static str {
 
 #[cfg(test)]
 mod tests {
-    use super::grayscale_jpeg_bytes_to_png_bytes;
+    use super::{grayscale_jpeg_bytes_to_png_bytes, resolve_image_payload};
+    use crate::paint::ResolvedImageKind;
+    use crate::renderer::render_tree::ImageNode;
     use image::{DynamicImage, ImageFormat, Rgb, RgbImage};
     use std::io::Cursor;
 
@@ -477,5 +479,27 @@ mod tests {
         });
 
         assert!(grayscale_jpeg_bytes_to_png_bytes(&jpeg).is_none());
+    }
+
+    #[test]
+    fn tiff_image_payload_is_normalized_to_png() {
+        let mut img = RgbImage::new(2, 2);
+        for y in 0..2 {
+            for x in 0..2 {
+                img.put_pixel(x, y, Rgb([32 + x as u8, 96 + y as u8, 160]));
+            }
+        }
+        let mut tiff = Vec::new();
+        DynamicImage::ImageRgb8(img)
+            .write_to(&mut Cursor::new(&mut tiff), ImageFormat::Tiff)
+            .expect("encode tiff");
+
+        let image = ImageNode::new(1, Some(tiff));
+        let resolved = resolve_image_payload(&image).expect("tiff should resolve");
+
+        assert_eq!(resolved.mime, "image/png");
+        assert_eq!(resolved.kind, ResolvedImageKind::FormatConverted);
+        assert!(resolved.data.starts_with(b"\x89PNG\r\n\x1a\n"));
+        assert!(!resolved.suppress_effects);
     }
 }

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1065,6 +1065,105 @@ impl LayoutEngine {
         )
     }
 
+    fn render_layer_from_control(
+        control: &Control,
+        para_index: usize,
+        control_index: usize,
+    ) -> Option<RenderLayerInfo> {
+        match control {
+            Control::Shape(shape) => Some(Self::render_layer_from_common(
+                shape.common(),
+                para_index,
+                control_index,
+            )),
+            Control::Picture(picture) => Some(Self::render_layer_from_common(
+                &picture.common,
+                para_index,
+                control_index,
+            )),
+            Control::Table(table) => Some(Self::render_layer_from_common(
+                &table.common,
+                para_index,
+                control_index,
+            )),
+            Control::Equation(equation) => Some(Self::render_layer_from_common(
+                &equation.common,
+                para_index,
+                control_index,
+            )),
+            _ => None,
+        }
+    }
+
+    fn control_common_attr(control: &Control) -> Option<&CommonObjAttr> {
+        match control {
+            Control::Shape(shape) => Some(shape.common()),
+            Control::Picture(picture) => Some(&picture.common),
+            Control::Table(table) => Some(&table.common),
+            Control::Equation(equation) => Some(&equation.common),
+            _ => None,
+        }
+    }
+
+    fn master_background_common_attr(control: &Control) -> Option<&CommonObjAttr> {
+        match control {
+            Control::Shape(shape) => Some(shape.common()),
+            Control::Picture(picture) => Some(&picture.common),
+            _ => None,
+        }
+    }
+
+    fn render_layer_from_master_control(
+        &self,
+        control: &Control,
+        para_index: usize,
+        control_index: usize,
+        paper_area: &LayoutRect,
+        body_area: &LayoutRect,
+    ) -> Option<RenderLayerInfo> {
+        let common = Self::control_common_attr(control)?;
+        let mut layer = Self::render_layer_from_common(common, para_index, control_index);
+        if Self::master_background_common_attr(control).is_some_and(|common| {
+            self.is_master_paper_background_control(common, paper_area, body_area)
+        }) {
+            layer.text_wrap = Some(TextWrap::BehindText);
+        }
+        Some(layer)
+    }
+
+    fn is_master_paper_background_control(
+        &self,
+        common: &CommonObjAttr,
+        paper_area: &LayoutRect,
+        body_area: &LayoutRect,
+    ) -> bool {
+        if !matches!(common.text_wrap, TextWrap::InFrontOfText) {
+            return false;
+        }
+        if !matches!(common.horz_rel_to, HorzRelTo::Paper)
+            || !matches!(common.vert_rel_to, VertRelTo::Paper)
+        {
+            return false;
+        }
+
+        let (width, height) = self.resolve_object_size(common, paper_area, body_area, paper_area);
+        let (x, y) = self.compute_object_position(
+            common,
+            width,
+            height,
+            paper_area,
+            paper_area,
+            body_area,
+            paper_area,
+            paper_area.y,
+            Alignment::Left,
+        );
+
+        let near_origin = (x - paper_area.x).abs() <= 1.0 && (y - paper_area.y).abs() <= 1.0;
+        let covers_paper = width >= paper_area.width * 0.95 && height >= paper_area.height * 0.95;
+        near_origin && covers_paper
+    }
+
     fn push_layered_paper_children(
         paper_images: &mut Vec<RenderNode>,
         temp_parent: &mut RenderNode,
@@ -1535,6 +1634,8 @@ impl LayoutEngine {
         _composed: &[ComposedParagraph],
         styles: &ResolvedStyleSet,
         area: &LayoutRect,
+        body_area: &LayoutRect,
+        paper_area: &LayoutRect,
         table_area: Option<&LayoutRect>,
         page_index: u32,
         page_number: u32,
@@ -1618,27 +1719,44 @@ impl LayoutEngine {
                     // 머리말/꼬리말 내 Picture: header/footer area 기준 배치
                     for (ci, ctrl) in para.controls.iter().enumerate() {
                         if let Control::Picture(pic) = ctrl {
-                            let pic_container = LayoutRect {
-                                x: area.x,
-                                y: y_offset,
-                                width: area.width,
-                                height: area.height - (y_offset - area.y),
-                            };
-                            // [Task #825] inner para_index = i (hf_paragraphs 안 인덱스),
-                            // inner control_index = ci. outer 위치는 outer_hf_ref 보존.
-                            self.layout_picture_full(
-                                tree,
-                                area_node,
-                                pic,
-                                &pic_container,
-                                bin_data_content,
-                                Alignment::Left,
-                                outer_section_index,
-                                Some(i),
-                                Some(ci),
-                                outer_hf_ref.clone(),
-                                None, // [Task #1151 v4] cell_ctx: 머리말/꼬리말 path
-                            );
+                            if pic.common.treat_as_char {
+                                let pic_container = LayoutRect {
+                                    x: area.x,
+                                    y: y_offset,
+                                    width: area.width,
+                                    height: area.height - (y_offset - area.y),
+                                };
+                                // [Task #825] inner para_index = i (hf_paragraphs 안 인덱스),
+                                // inner control_index = ci. outer 위치는 outer_hf_ref 보존.
+                                self.layout_picture_full(
+                                    tree,
+                                    area_node,
+                                    pic,
+                                    &pic_container,
+                                    bin_data_content,
+                                    Alignment::Left,
+                                    outer_section_index,
+                                    Some(i),
+                                    Some(ci),
+                                    outer_hf_ref.clone(),
+                                    None, // [Task #1151 v4] cell_ctx: 머리말/꼬리말 path
+                                );
+                            } else {
+                                self.layout_header_footer_picture(
+                                    tree,
+                                    area_node,
+                                    pic,
+                                    area,
+                                    body_area,
+                                    paper_area,
+                                    y_offset,
+                                    bin_data_content,
+                                    outer_section_index,
+                                    i,
+                                    ci,
+                                    outer_hf_ref.clone(),
+                                );
+                            }
                             let pic_h = hwpunit_to_px(pic.common.height as i32, self.dpi);
                             y_offset += pic_h;
                         }
@@ -1673,8 +1791,8 @@ impl LayoutEngine {
                             0, // section_index
                             styles,
                             area,
-                            area,
-                            area,
+                            body_area,
+                            paper_area,
                             y_offset,
                             Alignment::Left,
                             bin_data_content,
@@ -2207,20 +2325,35 @@ impl LayoutEngine {
                     let has_controls = !para.controls.is_empty();
                     if has_controls {
                         for (ci, ctrl) in para.controls.iter().enumerate() {
+                            let layer = self.render_layer_from_master_control(
+                                ctrl,
+                                pi,
+                                ci,
+                                &paper_area,
+                                body_area,
+                            );
+                            let mut temp_parent = layer.map(|_| {
+                                RenderNode::new(
+                                    0,
+                                    RenderNodeType::MasterPage,
+                                    layout_rect_to_bbox(&paper_area),
+                                )
+                            });
+                            let target_node = temp_parent.as_mut().unwrap_or(&mut mp_node);
                             match ctrl {
                                 Control::Shape(_) | Control::Equation(_) => {
                                     self.layout_shape(
                                         tree,
-                                        &mut mp_node,
+                                        target_node,
                                         &mp.paragraphs,
                                         pi,
                                         ci,
                                         section_index,
                                         styles,
-                                        body_area,
+                                        &paper_area,
                                         body_area,
                                         &paper_area,
-                                        body_area.y,
+                                        paper_area.y,
                                         Alignment::Left,
                                         bin_data_content,
                                         &std::collections::HashMap::new(),
@@ -2230,7 +2363,7 @@ impl LayoutEngine {
                                 Control::Picture(pic) => {
                                     let (pic_w, pic_h) = self.resolve_object_size(
                                         &pic.common,
-                                        body_area,
+                                        &paper_area,
                                         body_area,
                                         &paper_area,
                                     );
@@ -2238,11 +2371,11 @@ impl LayoutEngine {
                                         &pic.common,
                                         pic_w,
                                         pic_h,
-                                        body_area,
-                                        body_area,
+                                        &paper_area,
+                                        &paper_area,
                                         body_area,
                                         &paper_area,
-                                        body_area.y,
+                                        paper_area.y,
                                         Alignment::Left,
                                     );
                                     let pic_area = super::layout::LayoutRect {
@@ -2251,10 +2384,17 @@ impl LayoutEngine {
                                         width: pic_w,
                                         height: pic_h,
                                     };
+                                    let mut positioned = (**pic).clone();
+                                    positioned.common.horizontal_offset = 0;
+                                    positioned.common.vertical_offset = 0;
+                                    positioned.common.horz_rel_to = HorzRelTo::Para;
+                                    positioned.common.vert_rel_to = VertRelTo::Para;
+                                    positioned.common.horz_align = HorzAlign::Left;
+                                    positioned.common.vert_align = VertAlign::Top;
                                     self.layout_picture(
                                         tree,
-                                        &mut mp_node,
-                                        pic,
+                                        target_node,
+                                        &positioned,
                                         &pic_area,
                                         bin_data_content,
                                         Alignment::Left,
@@ -2274,7 +2414,7 @@ impl LayoutEngine {
                                     // current_body_area를 통해 본문 영역으로 계산된다.
                                     self.layout_table(
                                         tree,
-                                        &mut mp_node,
+                                        target_node,
                                         t,
                                         section_index,
                                         styles,
@@ -2297,6 +2437,14 @@ impl LayoutEngine {
                                     );
                                 }
                                 _ => {}
+                            }
+                            if let (Some(layer), Some(temp_parent)) = (layer, temp_parent.as_mut())
+                            {
+                                Self::push_layered_paper_children(
+                                    &mut mp_node.children,
+                                    temp_parent,
+                                    layer,
+                                );
                             }
                         }
                     } else if !para.text.is_empty() {
@@ -2338,10 +2486,93 @@ impl LayoutEngine {
                         }
                     }
                 }
+                // Hancom prepares master-page furniture through object order, not raw XML
+                // order: text-wrap plane, zOrder, then stable source index.
+                Self::sort_paper_render_nodes(&mut mp_node.children);
                 tree.root.children.push(mp_node);
                 self.current_page_number.set(previous_page_number);
             }
         }
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn layout_header_footer_picture(
+        &self,
+        tree: &mut PageRenderTree,
+        area_node: &mut RenderNode,
+        pic: &crate::model::image::Picture,
+        area: &LayoutRect,
+        body_area: &LayoutRect,
+        paper_area: &LayoutRect,
+        para_y: f64,
+        bin_data_content: &[BinDataContent],
+        outer_section_index: Option<usize>,
+        inner_para_index: usize,
+        inner_control_index: usize,
+        outer_hf_ref: Option<crate::renderer::render_tree::HeaderFooterImageRef>,
+    ) {
+        let rotation = pic.shape_attr.rotation_angle.rem_euclid(360);
+        let uses_rotated_frame = rotation != 0
+            && pic.shape_attr.current_width > 0
+            && pic.shape_attr.current_height > 0
+            && pic.common.width > 0
+            && pic.common.height > 0;
+        let (pic_width_hu, pic_height_hu) = if uses_rotated_frame {
+            (
+                pic.shape_attr.current_width as i32,
+                pic.shape_attr.current_height as i32,
+            )
+        } else {
+            picture_display_size_hu(pic)
+        };
+        let frame_width = if uses_rotated_frame {
+            hwpunit_to_px(pic.common.width as i32, self.dpi)
+        } else {
+            hwpunit_to_px(pic_width_hu, self.dpi)
+        };
+        let frame_height = if uses_rotated_frame {
+            hwpunit_to_px(pic.common.height as i32, self.dpi)
+        } else {
+            hwpunit_to_px(pic_height_hu, self.dpi)
+        };
+
+        let (frame_x, frame_y) = self.compute_object_position(
+            &pic.common,
+            frame_width,
+            frame_height,
+            area,
+            area,
+            body_area,
+            paper_area,
+            para_y,
+            Alignment::Left,
+        );
+        let mut positioned = pic.clone();
+        positioned.common.horizontal_offset = 0;
+        positioned.common.vertical_offset = 0;
+        positioned.common.horz_rel_to = HorzRelTo::Para;
+        positioned.common.vert_rel_to = VertRelTo::Para;
+        positioned.common.horz_align = HorzAlign::Left;
+        positioned.common.vert_align = VertAlign::Top;
+        let pic_container = LayoutRect {
+            x: frame_x,
+            y: frame_y,
+            width: frame_width,
+            height: frame_height,
+        };
+        self.layout_picture_full(
+            tree,
+            area_node,
+            &positioned,
+            &pic_container,
+            bin_data_content,
+            Alignment::Left,
+            outer_section_index,
+            Some(inner_para_index),
+            Some(inner_control_index),
+            outer_hf_ref,
+            None,
+        );
     }
 
     /// 머리말 영역 노드를 생성하여 tree에 추가한다.
@@ -2388,6 +2619,13 @@ impl LayoutEngine {
                                 composed,
                                 styles,
                                 &layout.header_area,
+                                &layout.body_area,
+                                &LayoutRect {
+                                    x: 0.0,
+                                    y: 0.0,
+                                    width: layout.page_width,
+                                    height: layout.page_height,
+                                },
                                 header_table_area.as_ref(),
                                 page_content.page_index,
                                 page_content.page_number,
@@ -2514,6 +2752,13 @@ impl LayoutEngine {
                                 composed,
                                 styles,
                                 &layout.footer_area,
+                                &layout.body_area,
+                                &LayoutRect {
+                                    x: 0.0,
+                                    y: 0.0,
+                                    width: layout.page_width,
+                                    height: layout.page_height,
+                                },
                                 None,
                                 page_content.page_index,
                                 page_content.page_number,

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -296,56 +296,6 @@ fn reflow_matrix_textbox_para(
     reflow_line_segs(para, available_width, styles, dpi);
 }
 
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use crate::model::paragraph::{CharShapeRef, LineSeg};
-    use crate::renderer::style_resolver::{ResolvedCharStyle, ResolvedParaStyle};
-
-    fn line_seg(text_start: u32, vertical_pos: i32) -> LineSeg {
-        LineSeg {
-            text_start,
-            vertical_pos,
-            line_height: 2000,
-            text_height: 2000,
-            baseline_distance: 1700,
-            line_spacing: 1200,
-            segment_width: 16856,
-            tag: LineSeg::TAG_SINGLE_SEGMENT_LINE,
-            ..Default::default()
-        }
-    }
-
-    #[test]
-    fn matrix_textbox_para_collapses_imported_lines_that_overflow_height() {
-        let mut para = Paragraph {
-            char_count: 2,
-            text: "AB".to_string(),
-            char_offsets: vec![0, 1],
-            char_shapes: vec![CharShapeRef {
-                start_pos: 0,
-                char_shape_id: 0,
-            }],
-            line_segs: vec![line_seg(0, 0), line_seg(1, 3200)],
-            ..Default::default()
-        };
-        let mut styles = ResolvedStyleSet::default();
-        styles.char_styles.push(ResolvedCharStyle {
-            font_family: "Arial".to_string(),
-            font_families: vec!["Arial".to_string(); 7],
-            font_size: 20.0,
-            ..Default::default()
-        });
-        styles.para_styles.push(ResolvedParaStyle::default());
-
-        reflow_matrix_textbox_para(&mut para, 80.0, 30.0, &styles, 96.0);
-
-        assert_eq!(para.line_segs.len(), 1);
-        assert_eq!(para.line_segs[0].text_start, 0);
-        assert_eq!(para.line_segs[0].segment_width, px_to_hwpunit(80.0, 96.0));
-    }
-}
-
 impl LayoutEngine {
     pub(crate) fn scan_textbox_overflow(
         &self,
@@ -3439,5 +3389,55 @@ impl LayoutEngine {
         let shape_right = shape_x + shape_w;
         let col_right = col_area.x + col_area.width;
         shape_right >= col_area.x && shape_x <= col_right
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::paragraph::{CharShapeRef, LineSeg};
+    use crate::renderer::style_resolver::{ResolvedCharStyle, ResolvedParaStyle};
+
+    fn line_seg(text_start: u32, vertical_pos: i32) -> LineSeg {
+        LineSeg {
+            text_start,
+            vertical_pos,
+            line_height: 2000,
+            text_height: 2000,
+            baseline_distance: 1700,
+            line_spacing: 1200,
+            segment_width: 16856,
+            tag: LineSeg::TAG_SINGLE_SEGMENT_LINE,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn matrix_textbox_para_collapses_imported_lines_that_overflow_height() {
+        let mut para = Paragraph {
+            char_count: 2,
+            text: "AB".to_string(),
+            char_offsets: vec![0, 1],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![line_seg(0, 0), line_seg(1, 3200)],
+            ..Default::default()
+        };
+        let mut styles = ResolvedStyleSet::default();
+        styles.char_styles.push(ResolvedCharStyle {
+            font_family: "Arial".to_string(),
+            font_families: vec!["Arial".to_string(); 7],
+            font_size: 20.0,
+            ..Default::default()
+        });
+        styles.para_styles.push(ResolvedParaStyle::default());
+
+        reflow_matrix_textbox_para(&mut para, 80.0, 30.0, &styles, 96.0);
+
+        assert_eq!(para.line_segs.len(), 1);
+        assert_eq!(para.line_segs[0].text_start, 0);
+        assert_eq!(para.line_segs[0].segment_width, px_to_hwpunit(80.0, 96.0));
     }
 }

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -1,11 +1,11 @@
 //! 도형/글상자/그룹 개체 레이아웃
 
-use super::super::composer::{compose_paragraph, ComposedParagraph};
+use super::super::composer::{compose_paragraph, reflow_line_segs, ComposedParagraph};
 use super::super::page_layout::LayoutRect;
 use super::super::pagination::PageItem;
 use super::super::render_tree::*;
 use super::super::style_resolver::ResolvedStyleSet;
-use super::super::{hwpunit_to_px, PathCommand, ShapeStyle, TextStyle};
+use super::super::{hwpunit_to_px, px_to_hwpunit, PathCommand, ShapeStyle, TextStyle};
 use super::text_measurement::{
     estimate_text_width, is_cjk_char, is_vertical_rotate_char, resolved_to_text_style,
     vertical_substitute_char,
@@ -18,9 +18,64 @@ use super::{CellContext, CellPathEntry};
 use crate::model::bin_data::BinDataContent;
 use crate::model::control::Control;
 use crate::model::paragraph::Paragraph;
-use crate::model::shape::CommonObjAttr;
+use crate::model::shape::{CommonObjAttr, DrawingObjAttr, TextBox};
 use crate::model::shape::{HorzAlign, HorzRelTo, VertAlign, VertRelTo};
-use crate::model::style::Alignment;
+use crate::model::style::{Alignment, FillType};
+
+/// 글상자에 공백이 아닌 실제 텍스트가 한 글자라도 있는지.
+fn textbox_has_visible_text(text_box: &TextBox) -> bool {
+    text_box
+        .paragraphs
+        .iter()
+        .any(|para| para.text.chars().any(|ch| !ch.is_whitespace()))
+}
+
+fn textbox_contains_non_tac_picture(text_box: &TextBox) -> bool {
+    text_box.paragraphs.iter().any(|para| {
+        para.controls
+            .iter()
+            .any(|control| matches!(control, Control::Picture(pic) if !pic.common.treat_as_char))
+    })
+}
+
+/// 평탄화된 HWPX 그룹(matrix group) 자식의 "글상자 보조선"(검정 얇은 SOLID 테두리)은
+/// 한컴 실물에서 인쇄되지 않는다(편람 장 표지 "행정업무 운영 개요" 제목/목록 글상자).
+/// 오탐 방지를 위해 매우 좁게 한정: 그룹 자식(group_level>0) + 회전/전단 없음 + 검정
+/// (color==0) 얇은(0<width<=40 HWPUNIT) SOLID(line_type==1) 테두리 + 캡션 없음 +
+/// (a) 채우기 없는 텍스트 전용 글상자 또는 (b) 흰색 단색 마스크 박스.
+fn should_suppress_group_child_construction_stroke(drawing: &DrawingObjAttr) -> bool {
+    if drawing.caption.is_some() {
+        return false;
+    }
+    let sa = &drawing.shape_attr;
+    let has_rotation_or_shear = sa.render_b.abs() > 1e-6 || sa.render_c.abs() > 1e-6;
+    if sa.group_level == 0 || has_rotation_or_shear {
+        return false;
+    }
+    let line = &drawing.border_line;
+    let line_type = line.attr & 0x3f;
+    if line_type != 1 || line.color != 0 || line.width <= 0 || line.width > 40 {
+        return false;
+    }
+    let text_only_box = drawing
+        .text_box
+        .as_ref()
+        .is_some_and(textbox_has_visible_text)
+        && drawing.fill.fill_type == FillType::None
+        && drawing.fill.gradient.is_none()
+        && drawing.fill.image.is_none();
+    if text_only_box {
+        return true;
+    }
+    drawing.text_box.is_none()
+        && drawing.fill.fill_type == FillType::Solid
+        && drawing.fill.gradient.is_none()
+        && drawing.fill.image.is_none()
+        && drawing
+            .fill
+            .solid
+            .is_some_and(|solid| solid.background_color == 0x00ff_ffff && solid.pattern_type <= 0)
+}
 
 fn push_placeholder_render_node(
     tree: &mut PageRenderTree,
@@ -161,6 +216,133 @@ fn textbox_tac_space_advance_override(
         Some(remaining / space_count as f64)
     } else {
         None
+    }
+}
+
+fn matrix_textbox_lines_need_reflow(para: &Paragraph) -> bool {
+    para.controls.is_empty()
+        && !para.text.is_empty()
+        && !para.text.contains('\n')
+        && para.line_segs.len() > 1
+}
+
+fn matrix_textbox_lines_overflow_height(para: &Paragraph, available_height: f64, dpi: f64) -> bool {
+    para.line_segs.last().is_some_and(|seg| {
+        hwpunit_to_px(seg.vertical_pos.saturating_add(seg.line_height), dpi)
+            > available_height + 0.5
+    })
+}
+
+fn should_reflow_matrix_textbox_lines(
+    matrix_positioned: bool,
+    drawing: &DrawingObjAttr,
+    text_box: &TextBox,
+    text_direction: u8,
+    available_width: f64,
+    available_height: f64,
+    dpi: f64,
+) -> bool {
+    if text_direction != 0 || available_width <= 0.0 || available_height <= 0.0 {
+        return false;
+    }
+
+    if !matrix_positioned {
+        return false;
+    }
+
+    let sa = &drawing.shape_attr;
+    let has_axis_scale =
+        (sa.render_sx.abs() - 1.0).abs() > 0.001 || (sa.render_sy.abs() - 1.0).abs() > 0.001;
+    let has_rotation_or_shear = sa.render_b.abs() > 1e-6 || sa.render_c.abs() > 1e-6;
+    let compressed_group_child = sa.group_level > 0
+        && sa.render_sx > 0.0
+        && sa.render_sy > 0.0
+        && (sa.render_sx < 0.99 || sa.render_sy < 0.99);
+    has_axis_scale
+        && !has_rotation_or_shear
+        && text_box.paragraphs.iter().any(|para| {
+            matrix_textbox_lines_need_reflow(para)
+                && (compressed_group_child
+                    || matrix_textbox_lines_overflow_height(para, available_height, dpi))
+        })
+}
+
+fn reflow_matrix_textbox_para(
+    para: &mut Paragraph,
+    available_width: f64,
+    _available_height: f64,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+) {
+    if !matrix_textbox_lines_need_reflow(para) {
+        return;
+    }
+
+    const MATRIX_TEXT_FIT_TOLERANCE_PX: f64 = 3.0;
+    let composed = compose_paragraph(para);
+    let text_len = para.text.chars().count();
+    let full_width = measure_composed_text_range_width(&composed, styles, 0, text_len, None);
+
+    if full_width <= available_width + MATRIX_TEXT_FIT_TOLERANCE_PX {
+        if let Some(first_seg) = para.line_segs.first().cloned() {
+            let mut line_seg = first_seg;
+            line_seg.text_start = 0;
+            line_seg.segment_width = px_to_hwpunit(available_width, dpi);
+            para.line_segs = vec![line_seg];
+            return;
+        }
+    }
+
+    reflow_line_segs(para, available_width, styles, dpi);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::paragraph::{CharShapeRef, LineSeg};
+    use crate::renderer::style_resolver::{ResolvedCharStyle, ResolvedParaStyle};
+
+    fn line_seg(text_start: u32, vertical_pos: i32) -> LineSeg {
+        LineSeg {
+            text_start,
+            vertical_pos,
+            line_height: 2000,
+            text_height: 2000,
+            baseline_distance: 1700,
+            line_spacing: 1200,
+            segment_width: 16856,
+            tag: LineSeg::TAG_SINGLE_SEGMENT_LINE,
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn matrix_textbox_para_collapses_imported_lines_that_overflow_height() {
+        let mut para = Paragraph {
+            char_count: 2,
+            text: "AB".to_string(),
+            char_offsets: vec![0, 1],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![line_seg(0, 0), line_seg(1, 3200)],
+            ..Default::default()
+        };
+        let mut styles = ResolvedStyleSet::default();
+        styles.char_styles.push(ResolvedCharStyle {
+            font_family: "Arial".to_string(),
+            font_families: vec!["Arial".to_string(); 7],
+            font_size: 20.0,
+            ..Default::default()
+        });
+        styles.para_styles.push(ResolvedParaStyle::default());
+
+        reflow_matrix_textbox_para(&mut para, 80.0, 30.0, &styles, 96.0);
+
+        assert_eq!(para.line_segs.len(), 1);
+        assert_eq!(para.line_segs[0].text_start, 0);
+        assert_eq!(para.line_segs[0].segment_width, px_to_hwpunit(80.0, 96.0));
     }
 }
 
@@ -382,8 +564,10 @@ impl LayoutEngine {
         let (mut shape_w, mut shape_h) =
             self.resolve_object_size(common, col_area, body_area, paper_area);
 
-        // current size가 common size보다 크면 current size 사용
-        // (스케일 행렬이 적용된 글상자 등에서 common.height < current_height인 경우)
+        if shape
+            .drawing()
+            .and_then(|drawing| drawing.text_box.as_ref())
+            .is_some_and(textbox_contains_non_tac_picture)
         {
             let sa = shape.shape_attr();
             let cur_w = hwpunit_to_px(sa.current_width as i32, self.dpi);
@@ -500,6 +684,7 @@ impl LayoutEngine {
             overflow_map,
             &[],
             None, // [Task #1138] 본문 도형 — 셀 정보 없음
+            false,
         );
 
         // 캡션 렌더링
@@ -549,7 +734,9 @@ impl LayoutEngine {
     }
 
     /// 회전이 있는 그룹 자식 도형을 전체 아핀 변환으로 렌더링한다.
-    /// group_x/y: 그룹의 페이지 절대 좌표 (px)
+    /// HWPX/HWP renderingInfo is already composed within the top-level group
+    /// coordinate system. Apply only that top-level group anchor; nested group
+    /// bboxes are structural and must not be applied as another translation.
     /// sa: 자식의 ShapeComponentAttr (아핀 행렬 포함)
     #[allow(clippy::too_many_arguments)]
     pub(crate) fn layout_group_child_affine(
@@ -557,8 +744,8 @@ impl LayoutEngine {
         tree: &mut PageRenderTree,
         parent: &mut RenderNode,
         child: &crate::model::shape::ShapeObject,
-        group_x: f64,
-        group_y: f64,
+        group_origin_x: f64,
+        group_origin_y: f64,
         sa: &crate::model::shape::ShapeComponentAttr,
         section_index: usize,
         para_index: usize,
@@ -578,13 +765,13 @@ impl LayoutEngine {
         let d = sa.render_sy;
         let ty = sa.render_ty;
 
-        // HWP 좌표를 아핀 변환 후 페이지 절대 좌표(px)로 변환하는 헬퍼
+        // HWP 좌표를 아핀 변환 후 페이지 절대 좌표(px)로 변환하는 헬퍼.
         let transform_pt = |ox: f64, oy: f64| -> (f64, f64) {
             let gx = a * ox + b * oy + tx;
             let gy = c * ox + d * oy + ty;
             (
-                group_x + hwpunit_to_px(gx as i32, self.dpi),
-                group_y + hwpunit_to_px(gy as i32, self.dpi),
+                group_origin_x + hwpunit_to_px(gx as i32, self.dpi),
+                group_origin_y + hwpunit_to_px(gy as i32, self.dpi),
             )
         };
 
@@ -743,6 +930,7 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     None, // [Task #1138] TODO: layout_group_child_affine 에 cell ctx propagate (별도 후속)
+                    true,
                 );
             }
         }
@@ -770,11 +958,63 @@ impl LayoutEngine {
         parent_cell_path: &[CellPathEntry],
         // [Task #1138] 표 셀 내 도형인 경우: (cell_idx, cell_para_idx, outer_table_ctrl_idx)
         table_cell_ref: Option<(usize, usize, usize)>,
+        // 그룹 자식은 renderingInfo 행렬로 이미 위치/대칭이 반영되어 있으므로
+        // ShapeComponentAttr의 flip/rotation을 다시 SVG transform으로 적용하지 않는다.
+        matrix_positioned: bool,
+    ) {
+        self.layout_shape_object_with_group_origin(
+            tree,
+            parent,
+            shape,
+            base_x,
+            base_y,
+            w,
+            h,
+            section_index,
+            para_index,
+            control_index,
+            styles,
+            bin_data_content,
+            overflow_map,
+            parent_cell_path,
+            table_cell_ref,
+            matrix_positioned,
+            None,
+        );
+    }
+
+    #[allow(clippy::too_many_arguments)]
+    fn layout_shape_object_with_group_origin(
+        &self,
+        tree: &mut PageRenderTree,
+        parent: &mut RenderNode,
+        shape: &crate::model::shape::ShapeObject,
+        base_x: f64,
+        base_y: f64,
+        w: f64,
+        h: f64,
+        section_index: usize,
+        para_index: usize,
+        control_index: usize,
+        styles: &ResolvedStyleSet,
+        bin_data_content: &[BinDataContent],
+        overflow_map: &std::collections::HashMap<(usize, usize), Vec<Paragraph>>,
+        parent_cell_path: &[CellPathEntry],
+        // [Task #1138] 표 셀 내 도형인 경우: (cell_idx, cell_para_idx, outer_table_ctrl_idx)
+        table_cell_ref: Option<(usize, usize, usize)>,
+        // 그룹 자식은 renderingInfo 행렬로 이미 위치/대칭이 반영되어 있으므로
+        // ShapeComponentAttr의 flip/rotation을 다시 SVG transform으로 적용하지 않는다.
+        matrix_positioned: bool,
+        inherited_group_origin: Option<(f64, f64)>,
     ) {
         use crate::model::shape::ShapeObject;
 
         // 공통: 회전/대칭 정보 추출
-        let transform = extract_shape_transform(shape.shape_attr());
+        let transform = if matrix_positioned {
+            ShapeTransform::default()
+        } else {
+            extract_shape_transform(shape.shape_attr())
+        };
 
         // [Task #1138] 표 셀 내 도형 식별을 위한 cell 정보 추출 (helper)
         let cell_index = table_cell_ref.map(|(ci, _, _)| ci);
@@ -801,7 +1041,12 @@ impl LayoutEngine {
 
         match shape {
             ShapeObject::Rectangle(rect) => {
-                let (style, gradient) = drawing_to_shape_style(&rect.drawing);
+                let (mut style, gradient) = drawing_to_shape_style(&rect.drawing);
+                // 평탄화된 그룹 자식 글상자의 비인쇄 보조선(검정 얇은 SOLID)을 억제한다.
+                if should_suppress_group_child_construction_stroke(&rect.drawing) {
+                    style.stroke_color = None;
+                    style.stroke_width = 0.0;
+                }
                 let round_px = if rect.round_rate > 0 {
                     (rect.round_rate as f64 / 100.0) * render_w.min(render_h) / 2.0
                 } else {
@@ -850,6 +1095,7 @@ impl LayoutEngine {
                     overflow_map,
                     parent_cell_path,
                     shape.common().treat_as_char,
+                    matrix_positioned,
                 );
                 parent.children.push(node);
             }
@@ -895,7 +1141,31 @@ impl LayoutEngine {
                         let conn_y1 = render_y + hwpunit_to_px(line.start.y, self.dpi) * sy;
                         let conn_x2 = render_x + hwpunit_to_px(line.end.x, self.dpi) * sx;
                         let conn_y2 = render_y + hwpunit_to_px(line.end.y, self.dpi) * sy;
-                        commands.push(PathCommand::MoveTo(conn_x1, conn_y1));
+                        let connector_point_xy =
+                            |cp: &crate::model::shape::ConnectorControlPoint| {
+                                (
+                                    render_x + hwpunit_to_px(cp.x, self.dpi) * sx,
+                                    render_y + hwpunit_to_px(cp.y, self.dpi) * sy,
+                                )
+                            };
+                        let first_control_is_start = conn
+                            .control_points
+                            .first()
+                            .map(|cp| cp.point_type == 3)
+                            .unwrap_or(false);
+                        let last_control_is_end = conn
+                            .control_points
+                            .last()
+                            .map(|cp| cp.point_type == 26)
+                            .unwrap_or(false);
+                        let (path_start_x, path_start_y) = if first_control_is_start {
+                            connector_point_xy(&conn.control_points[0])
+                        } else {
+                            (conn_x1, conn_y1)
+                        };
+                        let mut path_end_x = conn_x2;
+                        let mut path_end_y = conn_y2;
+                        commands.push(PathCommand::MoveTo(path_start_x, path_start_y));
 
                         if conn.link_type.is_arc() {
                             // 곡선 연결선: 제어점(type=2)을 bezier 제어점으로, 나머지는 앵커로 사용
@@ -963,13 +1233,21 @@ impl LayoutEngine {
                                 }
                             }
                         } else {
-                            // 꺽인 연결선: 제어점을 LineTo로 연결
-                            for cp in &conn.control_points {
-                                let cpx = render_x + hwpunit_to_px(cp.x, self.dpi) * sx;
-                                let cpy = render_y + hwpunit_to_px(cp.y, self.dpi) * sy;
+                            for cp in conn.control_points.iter().skip(if first_control_is_start {
+                                1
+                            } else {
+                                0
+                            }) {
+                                let (cpx, cpy) = connector_point_xy(cp);
                                 commands.push(PathCommand::LineTo(cpx, cpy));
+                                path_end_x = cpx;
+                                path_end_y = cpy;
                             }
-                            commands.push(PathCommand::LineTo(conn_x2, conn_y2));
+                            if !last_control_is_end {
+                                commands.push(PathCommand::LineTo(conn_x2, conn_y2));
+                                path_end_x = conn_x2;
+                                path_end_y = conn_y2;
+                            }
                         }
 
                         let style = ShapeStyle {
@@ -989,7 +1267,8 @@ impl LayoutEngine {
                         path_node.cell_para_index = cell_para_index;
                         path_node.outer_table_control_index = outer_table_control_index;
                         // 연결선: 시작/끝 좌표 (선 선택 방식용) + 화살표
-                        path_node.connector_endpoints = Some((conn_x1, conn_y1, conn_x2, conn_y2));
+                        path_node.connector_endpoints =
+                            Some((path_start_x, path_start_y, path_end_x, path_end_y));
                         if line_style.start_arrow != super::super::ArrowStyle::None
                             || line_style.end_arrow != super::super::ArrowStyle::None
                         {
@@ -1109,6 +1388,7 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     shape.common().treat_as_char,
+                    matrix_positioned,
                 );
                 parent.children.push(node);
             }
@@ -1287,6 +1567,7 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     shape.common().treat_as_char,
+                    matrix_positioned,
                 );
                 parent.children.push(node);
             }
@@ -1346,12 +1627,20 @@ impl LayoutEngine {
                     &empty_map,
                     parent_cell_path,
                     shape.common().treat_as_char,
+                    matrix_positioned,
                 );
                 parent.children.push(node);
             }
             ShapeObject::Group(group) => {
                 // 묶음 개체: Group 컨테이너 노드로 감싸서 hittest 시 하나의 개체로 선택되도록 함
                 let group_id = tree.next_id();
+                let group_origin = inherited_group_origin.unwrap_or({
+                    if group.shape_attr.group_level == 0 {
+                        (base_x, base_y)
+                    } else {
+                        (0.0, 0.0)
+                    }
+                });
                 let mut group_node = RenderNode::new(
                     group_id,
                     RenderNodeType::Group(GroupNode {
@@ -1361,19 +1650,6 @@ impl LayoutEngine {
                     }),
                     BoundingBox::new(base_x, base_y, w, h),
                 );
-                // 그룹 스케일 팩터: current_size / original_size (리사이즈 시 적용)
-                let gsa = &group.shape_attr;
-                let group_sx = if gsa.original_width > 0 {
-                    gsa.current_width as f64 / gsa.original_width as f64
-                } else {
-                    1.0
-                };
-                let group_sy = if gsa.original_height > 0 {
-                    gsa.current_height as f64 / gsa.original_height as f64
-                } else {
-                    1.0
-                };
-
                 for (_ci, child) in group.children.iter().enumerate() {
                     let sa = child.shape_attr();
                     let has_rotation = sa.render_b.abs() > 1e-6 || sa.render_c.abs() > 1e-6;
@@ -1383,8 +1659,8 @@ impl LayoutEngine {
                             tree,
                             &mut group_node,
                             child,
-                            base_x,
-                            base_y,
+                            group_origin.0,
+                            group_origin.1,
                             sa,
                             section_index,
                             para_index,
@@ -1394,20 +1670,21 @@ impl LayoutEngine {
                             parent_cell_path,
                         );
                     } else {
-                        // render_tx/ty와 render_sx/sy에는 이미 그룹 스케일이 반영되어 있으므로
-                        // group_sx/sy를 추가 적용하지 않음
-                        let child_x = base_x + hwpunit_to_px(sa.render_tx as i32, self.dpi);
-                        let child_y = base_y + hwpunit_to_px(sa.render_ty as i32, self.dpi);
-                        let child_w = hwpunit_to_px(
-                            (sa.original_width as f64 * sa.render_sx.abs()) as i32,
-                            self.dpi,
-                        );
-                        let child_h = hwpunit_to_px(
-                            (sa.original_height as f64 * sa.render_sy.abs()) as i32,
-                            self.dpi,
-                        );
+                        // render_tx/ty와 render_sx/sy에는 top-level group 로컬 좌표계
+                        // 안에서 그룹 스케일/이동/flip이 합성되어 있다. top-level group
+                        // anchor만 더하고, nested group bbox는 다시 더하지 않는다. 음수
+                        // scale이면 tx는 오른쪽/아래쪽 모서리일 수 있으므로 두 변환
+                        // 모서리의 min/max로 실제 bbox를 만든다.
+                        let x0 = sa.render_tx;
+                        let y0 = sa.render_ty;
+                        let x1 = sa.render_tx + sa.original_width as f64 * sa.render_sx;
+                        let y1 = sa.render_ty + sa.original_height as f64 * sa.render_sy;
+                        let child_x = group_origin.0 + hwpunit_to_px(x0.min(x1) as i32, self.dpi);
+                        let child_y = group_origin.1 + hwpunit_to_px(y0.min(y1) as i32, self.dpi);
+                        let child_w = hwpunit_to_px((x1 - x0).abs() as i32, self.dpi);
+                        let child_h = hwpunit_to_px((y1 - y0).abs() as i32, self.dpi);
                         let empty_map = std::collections::HashMap::new();
-                        self.layout_shape_object(
+                        self.layout_shape_object_with_group_origin(
                             tree,
                             &mut group_node,
                             child,
@@ -1423,6 +1700,8 @@ impl LayoutEngine {
                             &empty_map,
                             parent_cell_path,
                             table_cell_ref, // [Task #1138] 그룹 자식 — 부모와 같은 셀 컨텍스트
+                            true,
+                            Some(group_origin),
                         );
                     }
                 }
@@ -1753,6 +2032,7 @@ impl LayoutEngine {
         overflow_map: &std::collections::HashMap<(usize, usize), Vec<Paragraph>>,
         parent_cell_path: &[CellPathEntry],
         parent_treat_as_char: bool,
+        matrix_positioned: bool,
     ) {
         let text_box = match &drawing.text_box {
             Some(tb) => tb,
@@ -1841,6 +2121,35 @@ impl LayoutEngine {
         // (0=가로, 1=영문 눕힘, 2=영문 세움)
         // 주의: 테이블 셀은 bit 16~18이지만 글상자 LIST_HEADER는 bit 0~2
         let text_direction = (text_box.list_attr & 0x07) as u8;
+        let reflowed_textbox_paragraphs = if should_reflow_matrix_textbox_lines(
+            matrix_positioned,
+            drawing,
+            text_box,
+            text_direction,
+            inner_area.width,
+            inner_area.height,
+            self.dpi,
+        ) {
+            let mut paragraphs = text_box.paragraphs.clone();
+            for para in paragraphs
+                .iter_mut()
+                .filter(|para| matrix_textbox_lines_need_reflow(para))
+            {
+                reflow_matrix_textbox_para(
+                    para,
+                    inner_area.width,
+                    inner_area.height,
+                    styles,
+                    self.dpi,
+                );
+            }
+            Some(paragraphs)
+        } else {
+            None
+        };
+        let textbox_paragraphs = reflowed_textbox_paragraphs
+            .as_deref()
+            .unwrap_or(&text_box.paragraphs);
 
         // 빈 텍스트박스에 오버플로우 문단이 매핑되어 있는지 확인 (가로/세로 공통)
         let key = (para_index, control_index);
@@ -1929,15 +2238,14 @@ impl LayoutEngine {
         // 오버플로우 감지 (가로/세로 공통): 텍스트박스 내 문단의 line_segs에서
         // vpos가 리셋(이전 문단보다 감소)되고 sw가 변경되면
         // 해당 문단은 다른 텍스트박스(연결된 글상자)에 속함
-        let first_sw = text_box
-            .paragraphs
+        let first_sw = textbox_paragraphs
             .first()
             .and_then(|p| p.line_segs.first())
             .map(|ls| ls.segment_width)
             .unwrap_or(0);
         let mut max_vpos_end: i32 = 0;
         let mut overflow_start_idx: Option<usize> = None;
-        for (pi, para) in text_box.paragraphs.iter().enumerate() {
+        for (pi, para) in textbox_paragraphs.iter().enumerate() {
             if let Some(first_ls) = para.line_segs.first() {
                 let sw = first_ls.segment_width;
                 let vpos = first_ls.vertical_pos;
@@ -1957,14 +2265,14 @@ impl LayoutEngine {
         }
 
         // 현재 텍스트박스에 속하는 문단만 사용
-        let para_count = overflow_start_idx.unwrap_or(text_box.paragraphs.len());
+        let para_count = overflow_start_idx.unwrap_or(textbox_paragraphs.len());
 
         // 세로쓰기: 오버플로우 감지 후 세로 레이아웃으로 분기
         if text_direction != 0 {
             self.layout_vertical_textbox_text_with_paras(
                 tree,
                 &mut textbox_node,
-                &text_box.paragraphs[..para_count],
+                &textbox_paragraphs[..para_count],
                 text_box,
                 styles,
                 &inner_area,
@@ -1987,7 +2295,7 @@ impl LayoutEngine {
             return;
         }
 
-        let mut composed_paras: Vec<_> = text_box.paragraphs[..para_count]
+        let mut composed_paras: Vec<_> = textbox_paragraphs[..para_count]
             .iter()
             .map(|p| compose_paragraph(p))
             .collect();
@@ -1995,7 +2303,7 @@ impl LayoutEngine {
         // AutoNumber(Page) 치환: 글상자 안의 쪽번호 필드를 현재 페이지 번호로 변환
         let current_pn = self.current_page_number.get();
         if current_pn > 0 {
-            for (pi, para) in text_box.paragraphs[..para_count].iter().enumerate() {
+            for (pi, para) in textbox_paragraphs[..para_count].iter().enumerate() {
                 if para.controls.iter().any(|c| {
                     matches!(c, crate::model::control::Control::AutoNumber(an)
                         if an.number_type == crate::model::control::AutoNumberType::Page)
@@ -2018,14 +2326,14 @@ impl LayoutEngine {
                     // line_seg 높이만으로 CENTER 오프셋을 계산할 수 없다. 그렇게 하면 그림이 실제
                     // 콘텐츠 높이에서 빠지고, 아래 picture container가 오프셋 이후 남은 높이로
                     // 줄어들어 한컴보다 과도하게 축소된다.
-                    let mut total_content_height = text_box.paragraphs[..para_count]
+                    let mut total_content_height = textbox_paragraphs[..para_count]
                         .iter()
                         .flat_map(|p| p.line_segs.last())
                         .map(|ls| hwpunit_to_px(ls.vertical_pos + ls.line_height, self.dpi))
                         .last()
                         .unwrap_or(0.0);
 
-                    for para in &text_box.paragraphs[..para_count] {
+                    for para in &textbox_paragraphs[..para_count] {
                         let para_vpos = para
                             .line_segs
                             .first()
@@ -2067,7 +2375,7 @@ impl LayoutEngine {
             // vpos 기반 수직 위치: 원본 HWP 파일에서는 vertical_pos가 누적 절대값,
             // 편집 후 reflow된 문단은 vertical_pos=0이므로 incremental para_y와 비교하여
             // 더 큰 값 사용 (원본 호환 + 편집 후 정상 배치 모두 지원)
-            let para = &text_box.paragraphs[tb_para_idx];
+            let para = &textbox_paragraphs[tb_para_idx];
             if let Some(first_ls) = para.line_segs.first() {
                 let vpos_y =
                     inner_area.y + vert_offset + hwpunit_to_px(first_ls.vertical_pos, self.dpi);
@@ -2132,7 +2440,7 @@ impl LayoutEngine {
         // 오버플로우된 문단은 제외 (다른 텍스트박스에서 처리)
         use crate::model::shape::ShapeObject;
         let mut inline_y = inner_area.y + vert_offset; // 텍스트 영역 시작 위치
-        for (pi, para) in text_box.paragraphs[..para_count].iter().enumerate() {
+        for (pi, para) in textbox_paragraphs[..para_count].iter().enumerate() {
             // 이 문단에 해당하는 composed 문단의 시작 y 위치 계산
             let para_start_y = if pi < composed_paras.len() {
                 if let Some(first_seg) = para.line_segs.first() {
@@ -2309,6 +2617,7 @@ impl LayoutEngine {
                             &empty_map,
                             &nested_parent_path,
                             None, // [Task #1138] TODO: layout_textbox_content 에 cell ctx propagate (별도 후속)
+                            false,
                         );
                     }
                     Control::Picture(pic) => {

--- a/src/renderer/layout/table_cell_content.rs
+++ b/src/renderer/layout/table_cell_content.rs
@@ -406,6 +406,7 @@ impl LayoutEngine {
             &empty_map,
             &[],
             shape_table_cell_ref,
+            false,
         );
     }
 

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -5,6 +5,7 @@ use super::utils::{expand_numbering_format, numbering_format_to_number_format};
 use super::*;
 use crate::model::page::{ColumnDef, PageDef};
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::shape::RectangleShape;
 use crate::model::style::{Numbering, NumberingHead};
 use crate::renderer::composer::compose_paragraph;
 use crate::renderer::style_resolver::ResolvedStyleSet;
@@ -1533,4 +1534,363 @@ fn task1197_paper_nodes_sort_by_plane_z_order_and_stable_index() {
         vec![3, 5, 2, 4, 1],
         "BehindText는 z-order/stable 순서로 먼저, flow, InFrontOfText 순으로 정렬"
     );
+}
+
+#[test]
+fn master_page_controls_sort_by_render_layer_z_order() {
+    fn rect_control(z_order: i32, horizontal_offset: u32) -> Control {
+        Control::Shape(Box::new(ShapeObject::Rectangle(RectangleShape {
+            common: CommonObjAttr {
+                width: 10_000,
+                height: 10_000,
+                horizontal_offset,
+                z_order,
+                text_wrap: TextWrap::InFrontOfText,
+                horz_rel_to: HorzRelTo::Paper,
+                vert_rel_to: VertRelTo::Paper,
+                ..Default::default()
+            },
+            ..Default::default()
+        })))
+    }
+
+    let engine = LayoutEngine::with_default_dpi();
+    let layout = PageLayoutInfo::from_page_def_default(&a4_page_def(), &ColumnDef::default());
+    let mut tree = PageRenderTree::new(0, layout.page_width, layout.page_height);
+    let master_page = MasterPage {
+        paragraphs: vec![Paragraph {
+            controls: vec![
+                rect_control(20, 0),
+                rect_control(10, 20_000),
+                rect_control(20, 40_000),
+            ],
+            ..Default::default()
+        }],
+        text_width: 10_000,
+        text_height: 10_000,
+        ..Default::default()
+    };
+
+    engine.build_master_page_into(
+        &mut tree,
+        Some(&master_page),
+        &layout,
+        &[],
+        &ResolvedStyleSet::default(),
+        &[],
+        0,
+        1,
+    );
+
+    let master_node = tree
+        .root
+        .children
+        .iter()
+        .find(|node| matches!(node.node_type, RenderNodeType::MasterPage))
+        .expect("master page node should be rendered");
+    let z_order: Vec<i32> = master_node
+        .children
+        .iter()
+        .filter_map(|node| match node.node_type {
+            RenderNodeType::Rectangle(_) => node.layer.map(|layer| layer.z_order),
+            _ => None,
+        })
+        .collect();
+
+    assert_eq!(
+        z_order,
+        vec![10, 20, 20],
+        "master-page children should replay Hancom object order, not raw control order"
+    );
+}
+
+fn first_master_child_layer<F>(tree: &PageRenderTree, predicate: F) -> RenderLayerInfo
+where
+    F: Fn(&RenderNodeType) -> bool + Copy,
+{
+    fn find<F>(node: &RenderNode, predicate: F) -> Option<RenderLayerInfo>
+    where
+        F: Fn(&RenderNodeType) -> bool + Copy,
+    {
+        if predicate(&node.node_type) {
+            return node.layer;
+        }
+        node.children
+            .iter()
+            .find_map(|child| find(child, predicate))
+    }
+
+    let master = tree
+        .root
+        .children
+        .iter()
+        .find(|node| matches!(node.node_type, RenderNodeType::MasterPage))
+        .expect("master page node should be rendered");
+    find(master, predicate).expect("matching master-page child should carry a layer")
+}
+
+fn master_rect_control(width: u32, height: u32) -> Control {
+    Control::Shape(Box::new(ShapeObject::Rectangle(RectangleShape {
+        common: CommonObjAttr {
+            width,
+            height,
+            text_wrap: TextWrap::InFrontOfText,
+            horz_rel_to: HorzRelTo::Paper,
+            vert_rel_to: VertRelTo::Paper,
+            horz_align: HorzAlign::Left,
+            vert_align: VertAlign::Top,
+            ..Default::default()
+        },
+        ..Default::default()
+    })))
+}
+
+#[test]
+fn master_page_paper_sized_background_replays_behind_body_text() {
+    let page = a4_page_def();
+    let tree = render_tree_with_master_page_control(master_rect_control(page.width, page.height));
+    let layer = first_master_child_layer(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Rectangle(_))
+    });
+
+    assert_eq!(layer.text_wrap, Some(TextWrap::BehindText));
+}
+
+#[test]
+fn master_page_smaller_front_control_stays_in_front_of_body_text() {
+    let page = a4_page_def();
+    let tree =
+        render_tree_with_master_page_control(master_rect_control(page.width / 2, page.height / 2));
+    let layer = first_master_child_layer(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Rectangle(_))
+    });
+
+    assert_eq!(layer.text_wrap, Some(TextWrap::InFrontOfText));
+}
+
+fn first_master_child_bbox<F>(tree: &PageRenderTree, predicate: F) -> BoundingBox
+where
+    F: Fn(&RenderNodeType) -> bool + Copy,
+{
+    fn find<F>(node: &RenderNode, predicate: F) -> Option<BoundingBox>
+    where
+        F: Fn(&RenderNodeType) -> bool + Copy,
+    {
+        if predicate(&node.node_type) {
+            return Some(node.bbox);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find(child, predicate))
+    }
+
+    let master = tree
+        .root
+        .children
+        .iter()
+        .find(|node| matches!(node.node_type, RenderNodeType::MasterPage))
+        .expect("master page node should be rendered");
+    find(master, predicate).expect("matching master-page child should be rendered")
+}
+
+fn render_tree_with_master_page_control(control: Control) -> PageRenderTree {
+    let engine = LayoutEngine::with_default_dpi();
+    let layout = PageLayoutInfo::from_page_def_default(&a4_page_def(), &ColumnDef::default());
+    let mut tree = PageRenderTree::new(0, layout.page_width, layout.page_height);
+    let master_page = MasterPage {
+        paragraphs: vec![Paragraph {
+            controls: vec![control],
+            ..Default::default()
+        }],
+        text_width: 10_000,
+        text_height: 10_000,
+        ..Default::default()
+    };
+
+    engine.build_master_page_into(
+        &mut tree,
+        Some(&master_page),
+        &layout,
+        &[],
+        &ResolvedStyleSet::default(),
+        &[],
+        0,
+        1,
+    );
+    tree
+}
+
+#[test]
+fn master_page_paper_relative_shape_uses_page_origin() {
+    let tree = render_tree_with_master_page_control(Control::Shape(Box::new(
+        ShapeObject::Rectangle(RectangleShape {
+            common: CommonObjAttr {
+                width: 7_500,
+                height: 3_000,
+                horizontal_offset: 1_500,
+                vertical_offset: 2_250,
+                horz_rel_to: HorzRelTo::Paper,
+                vert_rel_to: VertRelTo::Paper,
+                text_wrap: TextWrap::InFrontOfText,
+                ..Default::default()
+            },
+            ..Default::default()
+        }),
+    )));
+
+    let bbox = first_master_child_bbox(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Rectangle(_))
+    });
+    assert!((bbox.x - hwpunit_to_px(1_500, DEFAULT_DPI)).abs() < 0.01);
+    assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
+}
+
+#[test]
+fn master_page_paper_relative_picture_uses_page_origin() {
+    let tree = render_tree_with_master_page_control(Control::Picture(Box::new(
+        crate::model::image::Picture {
+            common: CommonObjAttr {
+                width: 7_500,
+                height: 3_000,
+                horizontal_offset: 1_500,
+                vertical_offset: 2_250,
+                horz_rel_to: HorzRelTo::Paper,
+                vert_rel_to: VertRelTo::Paper,
+                text_wrap: TextWrap::InFrontOfText,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    )));
+
+    let bbox = first_master_child_bbox(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Image(_))
+    });
+    assert!((bbox.x - hwpunit_to_px(1_500, DEFAULT_DPI)).abs() < 0.01);
+    assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
+}
+
+fn first_header_child_bbox<F>(tree: &PageRenderTree, predicate: F) -> BoundingBox
+where
+    F: Fn(&RenderNodeType) -> bool + Copy,
+{
+    fn find<F>(node: &RenderNode, predicate: F) -> Option<BoundingBox>
+    where
+        F: Fn(&RenderNodeType) -> bool + Copy,
+    {
+        if predicate(&node.node_type) {
+            return Some(node.bbox);
+        }
+        node.children
+            .iter()
+            .find_map(|child| find(child, predicate))
+    }
+
+    let header = tree
+        .root
+        .children
+        .iter()
+        .find(|node| matches!(node.node_type, RenderNodeType::Header))
+        .expect("header node should be rendered");
+    find(header, predicate).expect("matching header child should be rendered")
+}
+
+fn render_tree_with_header_control(control: Control) -> PageRenderTree {
+    use crate::model::header_footer::Header;
+    use crate::renderer::pagination::HeaderFooterRef;
+
+    let engine = LayoutEngine::with_default_dpi();
+    let layout = PageLayoutInfo::from_page_def_default(&a4_page_def(), &ColumnDef::default());
+    let paragraphs = vec![Paragraph {
+        controls: vec![Control::Header(Box::new(Header {
+            paragraphs: vec![Paragraph {
+                controls: vec![control],
+                ..Default::default()
+            }],
+            ..Default::default()
+        }))],
+        ..Default::default()
+    }];
+    let page_content = PageContent {
+        page_index: 0,
+        page_number: 1,
+        section_index: 0,
+        layout,
+        column_contents: Vec::new(),
+        active_header: Some(HeaderFooterRef {
+            para_index: 0,
+            control_index: 0,
+            source_section_index: 0,
+        }),
+        active_footer: None,
+        page_number_pos: None,
+        page_hide: None,
+        footnotes: Vec::new(),
+        active_master_page: None,
+        extra_master_pages: Vec::new(),
+    };
+    engine.build_render_tree(
+        &page_content,
+        &paragraphs,
+        &paragraphs,
+        &paragraphs,
+        &[],
+        &ResolvedStyleSet::default(),
+        &FootnoteShape::default(),
+        &[],
+        None,
+        &[],
+        None,
+        0,
+        &[],
+    )
+}
+
+#[test]
+fn header_paper_relative_shape_uses_page_origin() {
+    let tree = render_tree_with_header_control(Control::Shape(Box::new(ShapeObject::Rectangle(
+        RectangleShape {
+            common: CommonObjAttr {
+                width: 7_500,
+                height: 3_000,
+                horizontal_offset: 1_500,
+                vertical_offset: 2_250,
+                horz_rel_to: HorzRelTo::Paper,
+                vert_rel_to: VertRelTo::Paper,
+                text_wrap: TextWrap::InFrontOfText,
+                ..Default::default()
+            },
+            ..Default::default()
+        },
+    ))));
+
+    let bbox = first_header_child_bbox(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Rectangle(_))
+    });
+    assert!((bbox.x - hwpunit_to_px(1_500, DEFAULT_DPI)).abs() < 0.01);
+    assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
+}
+
+#[test]
+fn header_paper_relative_picture_uses_page_origin() {
+    let tree =
+        render_tree_with_header_control(Control::Picture(Box::new(crate::model::image::Picture {
+            common: CommonObjAttr {
+                width: 7_500,
+                height: 3_000,
+                horizontal_offset: 1_500,
+                vertical_offset: 2_250,
+                horz_rel_to: HorzRelTo::Paper,
+                vert_rel_to: VertRelTo::Paper,
+                text_wrap: TextWrap::InFrontOfText,
+                ..Default::default()
+            },
+            ..Default::default()
+        })));
+
+    let bbox = first_header_child_bbox(&tree, |node_type| {
+        matches!(node_type, RenderNodeType::Image(_))
+    });
+    assert!((bbox.x - hwpunit_to_px(1_500, DEFAULT_DPI)).abs() < 0.01);
+    assert!((bbox.y - hwpunit_to_px(2_250, DEFAULT_DPI)).abs() < 0.01);
 }

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -916,7 +916,10 @@ mod wasm_internals {
 
     /// 1000pt 측정용 CSS font 문자열 생성
     pub(super) fn build_1000pt_font_string(style: &TextStyle) -> String {
-        let font_weight = if style.bold { "bold " } else { "" };
+        let font_weight = style
+            .css_font_weight()
+            .map(|weight| format!("{} ", weight))
+            .unwrap_or_default();
         let font_style = if style.italic { "italic " } else { "" };
         let font_family = if style.font_family.is_empty() {
             "sans-serif".to_string()
@@ -1581,10 +1584,54 @@ fn is_monospace_metric(metric: &font_metrics_data::FontMetric) -> bool {
     count >= 16
 }
 
+/// 요청 폰트의 내장 메트릭 DB 등록 여부.
+///
+/// `compute_char_positions` 의 advance 가 실제 글리프 폭(메트릭 DB)에서
+/// 나온 값인지, 아니면 DB 미등록 폰트의 휴리스틱 폴백(`font_size * 0.5`
+/// 등)인지 구분하는 데 쓴다. WASM 캔버스 렌더러는 메트릭이 없는(=브라우저
+/// 대체 폰트로 치환되는) 폰트에 대해 글리프별 가로 스케일링(per-glyph
+/// x-scale)을 적용하면 안 된다 — 치환 폰트의 실제 advance 와 어긋나
+/// l/i/t 같은 좁은 글리프가 과도하게 늘어나기 때문이다 (한컴 바겐세일 M
+/// → Pretendard 치환 시 Vocabulary 열 왜곡).
+pub(crate) fn font_family_has_metrics(font_family: &str, bold: bool, italic: bool) -> bool {
+    let primary_name = font_family.split(',').next().unwrap_or(font_family).trim();
+    font_metrics_data::find_metric(primary_name, bold, italic).is_some()
+}
+
 /// 내장 폰트 메트릭으로 문자 폭 측정 (em 단위 → px 변환)
 ///
 /// 내장 메트릭이 있으면 JS 브릿지 호출 없이 즉시 반환.
 /// 없으면 None을 반환하여 폴백 경로를 사용하게 한다.
+fn quantize_hwp_px(px: f64) -> f64 {
+    let hwp = (px * 75.0) as i32;
+    hwp as f64 / 75.0
+}
+
+fn kopub_char_width(primary_name: &str, c: char, font_size: f64) -> Option<f64> {
+    let lower = primary_name.to_lowercase();
+    let is_dotum = primary_name.contains("KoPub돋움체") || lower.contains("kopub dotum");
+    let is_batang = primary_name.contains("KoPub바탕체") || lower.contains("kopub batang");
+    if !is_dotum && !is_batang {
+        return None;
+    }
+
+    if c == ' ' {
+        return Some(quantize_hwp_px(font_size * 0.5));
+    }
+    if is_narrow_punctuation(c) {
+        return Some(quantize_hwp_px(font_size * 0.3));
+    }
+    if c.is_ascii() {
+        return Some(quantize_hwp_px(font_size * 0.5));
+    }
+    if is_cjk_char(c) || is_fullwidth_symbol(c) {
+        let factor = if is_dotum { 0.84 } else { 0.94 };
+        return Some(quantize_hwp_px(font_size * factor));
+    }
+
+    None
+}
+
 fn measure_char_width_embedded(
     font_family: &str,
     bold: bool,
@@ -1594,6 +1641,9 @@ fn measure_char_width_embedded(
 ) -> Option<f64> {
     // CSS font-family 체인에서 첫 번째 폰트명으로 메트릭 조회
     let primary_name = font_family.split(',').next().unwrap_or(font_family).trim();
+    if let Some(w) = kopub_char_width(primary_name, c, font_size) {
+        return Some(w);
+    }
     let mm = font_metrics_data::find_metric(primary_name, bold, italic)?;
     // HWP 반각 처리: space 및 한컴이 반각으로 처리하는 구두점/기호
     let w = if c == ' ' {
@@ -1645,8 +1695,7 @@ fn measure_char_width_embedded(
 
     // 한컴과 동일한 HWPUNIT 정수 변환: w * base_size / em (내림)
     // round가 아닌 truncate (as i32)로 처리하여 한컴 정수 나눗셈과 일치
-    let hwp = (actual_px * 75.0) as i32;
-    Some(hwp as f64 / 75.0)
+    Some(quantize_hwp_px(actual_px))
 }
 
 // ── 호환 래퍼 (기존 호출부 변경 없음) ──────────────────────────────
@@ -1821,6 +1870,7 @@ fn is_fullwidth_symbol(c: char) -> bool {
         '\u{00A3}' |                   // £ POUND SIGN
         '\u{00A5}'                     // ¥ YEN SIGN
     )
+    || ('\u{2190}'..='\u{21FF}').contains(&c) // Arrows (→, ⇨, ⇒ 등)
     || ('\u{2460}'..='\u{24FF}').contains(&c) // Enclosed Alphanumerics (①②③ 등)
     || ('\u{25A0}'..='\u{25FF}').contains(&c) // Geometric Shapes (□■▲◆○ 등, 섹션 머리 기호)
     || ('\u{2600}'..='\u{26FF}').contains(&c) // Miscellaneous Symbols (☆★ 등)
@@ -2080,6 +2130,22 @@ mod tests {
     }
 
     #[test]
+    fn test_unicode_arrow_uses_symbol_advance() {
+        let style = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            font_size: 10.0,
+            ..Default::default()
+        };
+
+        let arrow = estimate_text_width("⇒", &style);
+        let ascii = estimate_text_width("A", &style);
+        assert!(
+            arrow > ascii,
+            "arrow should use symbol advance, arrow={arrow}, ascii={ascii}"
+        );
+    }
+
+    #[test]
     fn test_mock_measurer_tab() {
         let m = MockTextMeasurer { char_width: 10.0 };
         let style = TextStyle {
@@ -2133,6 +2199,19 @@ mod tests {
             "expected 32.0 (2*16.0 heuristic), got {}",
             w
         );
+    }
+
+    #[test]
+    fn test_kopub_dotum_uses_narrow_publication_metrics() {
+        let m = EmbeddedTextMeasurer;
+        let style = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            font_size: 14.0,
+            ..Default::default()
+        };
+
+        let w = m.estimate_text_width("가나", &style);
+        assert_eq!(w, 24.0);
     }
 
     #[test]

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -204,12 +204,27 @@ impl TextStyle {
     /// 시각 bold 소실을 보완하기 위해 SVG 출력 시 font-weight="bold" 강제에
     /// 사용된다.
     pub fn is_visually_bold(&self) -> bool {
-        self.bold || crate::renderer::style_resolver::is_heavy_display_face(&self.font_family)
+        self.bold
+            || crate::renderer::style_resolver::is_heavy_display_face(&self.font_family)
+            || crate::renderer::style_resolver::is_bold_weight_face(&self.font_family)
     }
 
     /// 중고딕 계열(font-weight 500) 여부. SVG/HTML 출력 시 `font-weight: 500` 힌트 삽입에 사용.
     pub fn is_medium_weight(&self) -> bool {
         !self.bold && crate::renderer::style_resolver::is_medium_weight_face(&self.font_family)
+    }
+
+    /// CSS/SVG font-weight hint for fallback rendering.
+    pub fn css_font_weight(&self) -> Option<&'static str> {
+        if self.is_visually_bold() {
+            Some("bold")
+        } else if crate::renderer::style_resolver::is_light_weight_face(&self.font_family) {
+            Some("300")
+        } else if self.is_medium_weight() {
+            Some("500")
+        } else {
+            None
+        }
     }
 }
 
@@ -705,6 +720,16 @@ pub fn generic_fallback(font_family: &str) -> &'static str {
     }
     // 고정폭 키워드
     let lower = font_family.to_ascii_lowercase();
+    if (font_family.contains("KoPub돋움체") || lower.contains("kopub dotum"))
+        && (font_family.contains("Light") || lower.contains("light"))
+    {
+        return "'Noto Sans KR ExtraLight','Malgun Gothic','맑은 고딕','Apple SD Gothic Neo','Noto Sans KR','Pretendard','HCR Batang Ext-B','함초롬바탕 확장B','HCR Batang Ext','함초롬바탕 확장','HCR Batang','함초롬바탕','Source Han Serif K Old Hangul',sans-serif";
+    }
+    // KoPub Batang uses "바탕체" in the family name, but it is a proportional
+    // serif publication face, not the Windows fixed-width BatangChe face.
+    if font_family.contains("KoPub바탕체") || lower.contains("kopub batang") {
+        return "'Batang','바탕','Nanum Myeongjo','AppleMyungjo','Noto Serif KR','Noto Serif CJK KR','HCR Batang Ext-B','함초롬바탕 확장B','HCR Batang Ext','함초롬바탕 확장','HCR Batang','함초롬바탕','Source Han Serif K Old Hangul',serif";
+    }
     if font_family.contains("굴림체")
         || font_family.contains("바탕체")
         || lower.contains("gulimche")
@@ -1141,12 +1166,21 @@ mod tests {
         assert_eq!(generic_fallback("HY견명조"), serif);
         assert_eq!(generic_fallback("Times New Roman"), serif);
         assert_eq!(generic_fallback("Palatino Linotype"), serif);
+        // KoPub바탕체는 이름에 "바탕체"가 들어가지만 고정폭 BatangChe가 아니라
+        // 비례폭 본문/제목용 세리프 계열이다.
+        assert_eq!(generic_fallback("KoPub바탕체 Light"), serif);
+        assert_eq!(generic_fallback("KoPub바탕체 Medium"), serif);
+        assert_eq!(generic_fallback("KoPub Batang Medium"), serif);
         // 산세리프 계열
         assert_eq!(generic_fallback("함초롬돋움"), sans);
         assert_eq!(generic_fallback("돋움"), sans);
         assert_eq!(generic_fallback("굴림"), sans);
         assert_eq!(generic_fallback("Arial"), sans);
         assert_eq!(generic_fallback("맑은 고딕"), sans);
+        assert!(generic_fallback("KoPub돋움체 Light")
+            .starts_with("'Noto Sans KR ExtraLight','Malgun Gothic'"));
+        assert!(generic_fallback("KoPub Dotum Light")
+            .starts_with("'Noto Sans KR ExtraLight','Malgun Gothic'"));
         // 고정폭 계열
         assert_eq!(generic_fallback("굴림체"), mono);
         assert_eq!(generic_fallback("바탕체"), mono);
@@ -1177,6 +1211,22 @@ mod tests {
         assert!(!is_medium_weight_face("바탕"));
         assert!(!is_medium_weight_face("맑은 고딕"));
         assert!(!is_medium_weight_face(""));
+    }
+
+    #[test]
+    fn test_explicit_face_weight_hints() {
+        let light = TextStyle {
+            font_family: "KoPub돋움체 Light".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(light.css_font_weight(), Some("300"));
+
+        let bold = TextStyle {
+            font_family: "KoPub바탕체 Bold".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(bold.css_font_weight(), Some("bold"));
+        assert!(bold.is_visually_bold());
     }
 
     #[test]

--- a/src/renderer/page_layout.rs
+++ b/src/renderer/page_layout.rs
@@ -158,12 +158,12 @@ impl PageLayoutInfo {
 
     /// 각주 영역을 동적으로 계산하여 레이아웃을 갱신한다.
     ///
-    /// 각주 높이만큼 본문 영역 하단을 축소하고 각주 영역을 설정한다.
+    /// 각주 높이만큼 본문 영역 하단에 각주 영역을 설정한다.
     pub fn update_footnote_area(&mut self, footnote_height: f64) {
         if footnote_height <= 0.0 {
             return;
         }
-        let h = footnote_height.min(self.body_area.height * 0.5); // 본문의 절반까지만
+        let h = footnote_height.min(self.body_area.height);
         self.footnote_area = LayoutRect {
             x: self.body_area.x,
             y: self.body_area.y + self.body_area.height - h,

--- a/src/renderer/pagination.rs
+++ b/src/renderer/pagination.rs
@@ -12,10 +12,39 @@ use super::height_measurer::{HeightMeasurer, MeasuredSection};
 use super::page_layout::PageLayoutInfo;
 use super::style_resolver::ResolvedStyleSet;
 use crate::model::control::Control;
+use crate::model::footnote::{Footnote, FootnoteShape};
 use crate::model::header_footer::HeaderFooterApply;
 use crate::model::page::{ColumnDef, PageDef};
 use crate::model::paragraph::{ColumnBreakType, Paragraph};
 use crate::model::shape::CaptionDirection;
+
+pub fn estimate_footnote_note_height(footnote: &Footnote, dpi: f64) -> f64 {
+    let mut height = 0.0;
+    for para in &footnote.paragraphs {
+        if para.line_segs.is_empty() {
+            height += super::hwpunit_to_px(400, dpi);
+        } else {
+            for seg in &para.line_segs {
+                height += super::hwpunit_to_px(seg.line_height, dpi);
+            }
+        }
+    }
+    if height <= 0.0 {
+        super::hwpunit_to_px(400, dpi)
+    } else {
+        height
+    }
+}
+
+pub fn footnote_separator_overhead_px(shape: &FootnoteShape, dpi: f64) -> f64 {
+    super::hwpunit_to_px(shape.separator_above_margin_hu() as i32, dpi)
+        + super::layout::border_width_to_px(shape.separator_line_width).max(0.5)
+        + super::hwpunit_to_px(shape.separator_below_margin_hu() as i32, dpi)
+}
+
+pub fn footnote_between_notes_margin_px(shape: &FootnoteShape, dpi: f64) -> f64 {
+    super::hwpunit_to_px(shape.between_notes_margin_hu() as i32, dpi)
+}
 
 /// 미주 참조
 #[derive(Debug, Clone)]
@@ -667,6 +696,8 @@ pub struct PaginationOpts {
     /// 페이지 절반 이상 + 현재 paragraph 의 first_line vpos 가 페이지 1/4 이내)
     /// 시 강제 page break — 한컴 변환 시 인코딩한 page break 시그널 인식.
     pub is_hwp3_variant: bool,
+    /// 현재 구역의 각주 모양. 각주 예약 영역을 렌더 영역과 같은 metric으로 계산한다.
+    pub footnote_shape: Option<FootnoteShape>,
 }
 
 /// 페이지 분할 엔진

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -98,6 +98,28 @@ fn positive_vpos_end_before_negative_wrap(para: &Paragraph) -> Option<i32> {
         .max()
 }
 
+fn single_line_text_box_bottom_px(para: &Paragraph, page_vpos_base: i32, dpi: f64) -> Option<f64> {
+    let mut real_lines = para
+        .line_segs
+        .iter()
+        .filter(|ls| !is_synthetic_line_seg(ls));
+    let line = real_lines.next()?;
+    if real_lines.next().is_some() || line.vertical_pos <= page_vpos_base {
+        return None;
+    }
+
+    let text_height = if line.text_height > 0 {
+        line.text_height
+    } else {
+        line.line_height.max(0)
+    };
+    let bottom = line
+        .vertical_pos
+        .saturating_add(text_height)
+        .saturating_sub(page_vpos_base);
+    (bottom >= 0).then(|| crate::renderer::hwpunit_to_px(bottom, dpi))
+}
+
 impl Paginator {
     pub fn paginate_with_measured(
         &self,
@@ -155,7 +177,15 @@ impl Paginator {
             Self::collect_header_footer_controls(paragraphs, section_index);
 
         let col_count = column_def.column_count.max(1);
-        let footnote_separator_overhead = crate::renderer::hwpunit_to_px(400, self.dpi);
+        let default_footnote_shape = crate::model::footnote::FootnoteShape::default();
+        let footnote_shape = opts
+            .footnote_shape
+            .as_ref()
+            .unwrap_or(&default_footnote_shape);
+        let footnote_separator_overhead =
+            super::footnote_separator_overhead_px(footnote_shape, self.dpi);
+        let footnote_between_notes_margin =
+            super::footnote_between_notes_margin_px(footnote_shape, self.dpi);
         let footnote_safety_margin = crate::renderer::hwpunit_to_px(3000, self.dpi);
 
         let mut st = PaginationState::new(
@@ -163,6 +193,7 @@ impl Paginator {
             col_count,
             section_index,
             footnote_separator_overhead,
+            footnote_between_notes_margin,
             footnote_safety_margin,
         );
 
@@ -1169,7 +1200,14 @@ impl Paginator {
                 trailing_ls
             };
             // 부동소수점 누적 오차 허용 (0.5px ≈ 0.13mm)
-            st.current_height + (para_height - effective_trailing) <= available_now + 0.5
+            let advance_fits =
+                st.current_height + (para_height - effective_trailing) <= available_now + 0.5;
+            let page_vpos_base = st.page_vpos_base.unwrap_or(0);
+            let text_box_fits = !para.line_segs.is_empty()
+                && !st.current_items.is_empty()
+                && single_line_text_box_bottom_px(para, page_vpos_base, self.dpi)
+                    .is_some_and(|bottom| bottom <= available_now + 0.5);
+            advance_fits || text_box_fits
         } {
             // 문단 전체가 현재 페이지에 들어감
             st.current_items.push(PageItem::FullParagraph {
@@ -1659,8 +1697,9 @@ impl Paginator {
                                                 tb_control_index: tc_idx,
                                             },
                                         });
-                                        let fn_height =
-                                            measurer.estimate_single_footnote_height(&fn_ctrl);
+                                        let fn_height = super::estimate_footnote_note_height(
+                                            &fn_ctrl, self.dpi,
+                                        );
                                         st.add_footnote_height(fn_height);
                                     }
                                 }
@@ -1707,7 +1746,7 @@ impl Paginator {
                                 control_index: ctrl_idx,
                             },
                         });
-                        let fn_height = measurer.estimate_single_footnote_height(fn_ctrl);
+                        let fn_height = super::estimate_footnote_note_height(fn_ctrl, self.dpi);
                         st.add_footnote_height(fn_height);
                     }
                 }
@@ -1772,24 +1811,22 @@ impl Paginator {
 
         // 표 내 각주 높이 사전 계산
         let mut table_footnote_height = 0.0;
-        let mut table_has_footnotes = false;
+        let mut table_footnote_count = 0usize;
         for cell in &table.cells {
             for cp in &cell.paragraphs {
                 for cc in &cp.controls {
                     if let Control::Footnote(fn_ctrl) = cc {
-                        let fn_height = measurer.estimate_single_footnote_height(fn_ctrl);
-                        if !table_has_footnotes && st.is_first_footnote_on_page {
-                            table_footnote_height += st.footnote_separator_overhead;
-                        }
+                        let fn_height = super::estimate_footnote_note_height(fn_ctrl, self.dpi);
                         table_footnote_height += fn_height;
-                        table_has_footnotes = true;
+                        table_footnote_count += 1;
                     }
                 }
             }
         }
 
         // 현재 사용 가능한 높이
-        let total_footnote = st.current_footnote_height + table_footnote_height;
+        let total_footnote =
+            st.projected_footnote_height(table_footnote_height, table_footnote_count);
         let table_margin = if total_footnote > 0.0 {
             st.footnote_safety_margin
         } else {
@@ -2052,7 +2089,7 @@ impl Paginator {
                                     cell_control_index: cc_idx,
                                 },
                             });
-                            let fn_height = measurer.estimate_single_footnote_height(fn_ctrl);
+                            let fn_height = super::estimate_footnote_note_height(fn_ctrl, self.dpi);
                             st.add_footnote_height(fn_height);
                         }
                     }

--- a/src/renderer/pagination/state.rs
+++ b/src/renderer/pagination/state.rs
@@ -24,6 +24,7 @@ pub(super) struct PaginationState {
     pub on_first_multicolumn_page: bool,
     pub section_index: usize,
     pub footnote_separator_overhead: f64,
+    pub footnote_between_notes_margin: f64,
     pub footnote_safety_margin: f64,
     /// 현재 단에 축적된 어울림 리턴 문단 목록
     pub current_column_wrap_around_paras: Vec<WrapAroundPara>,
@@ -51,6 +52,7 @@ impl PaginationState {
         col_count: u16,
         section_index: usize,
         footnote_separator_overhead: f64,
+        footnote_between_notes_margin: f64,
         footnote_safety_margin: f64,
     ) -> Self {
         Self {
@@ -67,6 +69,7 @@ impl PaginationState {
             on_first_multicolumn_page: false,
             section_index,
             footnote_separator_overhead,
+            footnote_between_notes_margin,
             footnote_safety_margin,
             current_column_wrap_around_paras: Vec::new(),
             current_column_wrap_anchors: std::collections::HashMap::new(),
@@ -207,8 +210,41 @@ impl PaginationState {
         if self.is_first_footnote_on_page {
             self.current_footnote_height += self.footnote_separator_overhead;
             self.is_first_footnote_on_page = false;
+        } else {
+            self.current_footnote_height += self.footnote_between_notes_margin;
         }
         self.current_footnote_height += height;
+        self.sync_current_page_footnote_area();
+    }
+
+    pub fn projected_footnote_height(&self, note_content_height: f64, note_count: usize) -> f64 {
+        if note_count == 0 {
+            return self.current_footnote_height;
+        }
+        let separator = if self.is_first_footnote_on_page {
+            self.footnote_separator_overhead
+        } else {
+            0.0
+        };
+        let between_count = if self.is_first_footnote_on_page {
+            note_count.saturating_sub(1)
+        } else {
+            note_count
+        };
+        self.current_footnote_height
+            + separator
+            + self.footnote_between_notes_margin * between_count as f64
+            + note_content_height
+    }
+
+    fn sync_current_page_footnote_area(&mut self) {
+        if self.current_footnote_height <= 0.0 {
+            return;
+        }
+        if let Some(page) = self.pages.last_mut() {
+            page.layout
+                .update_footnote_area(self.current_footnote_height);
+        }
     }
 
     /// 새 페이지 push + 상태 리셋

--- a/src/renderer/pagination/tests.rs
+++ b/src/renderer/pagination/tests.rs
@@ -28,6 +28,60 @@ fn make_paragraph_with_height(line_height: i32) -> Paragraph {
 }
 
 #[test]
+fn page_bottom_text_box_fit_keeps_line_even_when_advance_overflows() {
+    let paginator = Paginator::with_default_dpi();
+    let styles = ResolvedStyleSet::default();
+    let page_def = a4_page_def();
+    let body_height_hu = page_def
+        .height
+        .saturating_sub(page_def.margin_top)
+        .saturating_sub(page_def.margin_bottom)
+        .saturating_sub(page_def.margin_header)
+        .saturating_sub(page_def.margin_footer) as i32;
+
+    let lead_advance = body_height_hu - 580;
+    let lead = Paragraph {
+        line_segs: vec![LineSeg {
+            vertical_pos: 0,
+            line_height: lead_advance,
+            text_height: body_height_hu - 2500,
+            line_spacing: 0,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let bottom_line = Paragraph {
+        line_segs: vec![LineSeg {
+            vertical_pos: body_height_hu - 1200,
+            line_height: 1200,
+            text_height: 1200,
+            line_spacing: 840,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    let composed: Vec<ComposedParagraph> = Vec::new();
+    let (result, _measured) = paginator.paginate(
+        &[lead, bottom_line],
+        &composed,
+        &styles,
+        &page_def,
+        &ColumnDef::default(),
+        0,
+    );
+
+    assert_eq!(result.pages.len(), 1);
+    let items = &result.pages[0].column_contents[0].items;
+    assert!(matches!(
+        items.as_slice(),
+        [
+            PageItem::FullParagraph { para_index: 0 },
+            PageItem::FullParagraph { para_index: 1 }
+        ]
+    ));
+}
+
+#[test]
 fn test_empty_paragraphs() {
     let paginator = Paginator::with_default_dpi();
     let styles = ResolvedStyleSet::default();

--- a/src/renderer/skia/image_conv.rs
+++ b/src/renderer/skia/image_conv.rs
@@ -7,6 +7,7 @@ use std::sync::{Arc, OnceLock};
 
 use crate::model::image::ImageEffect;
 use crate::model::style::ImageFillMode;
+use crate::renderer::image_resolver::{detect_image_mime_type, grayscale_jpeg_bytes_to_png_bytes};
 
 const MAX_SVG_FRAGMENT_BYTES: usize = 4 * 1024 * 1024;
 const MAX_SVG_RASTER_PIXELS: u64 = 67_108_864;
@@ -146,7 +147,14 @@ pub fn draw_image_bytes(
     if !is_valid_destination_rect(x, y, width, height) {
         return;
     }
-    let Some(image) = Image::from_encoded(Data::new_copy(bytes)) else {
+    let normalized_bytes = if detect_image_mime_type(bytes) == "image/jpeg" {
+        grayscale_jpeg_bytes_to_png_bytes(bytes)
+    } else {
+        None
+    };
+    let encoded_bytes = normalized_bytes.as_deref().unwrap_or(bytes);
+
+    let Some(image) = Image::from_encoded(Data::new_copy(encoded_bytes)) else {
         draw_missing_image_placeholder(x, y, width, height);
         return;
     };
@@ -227,6 +235,7 @@ pub fn draw_image_bytes(
     if matches!(
         mode,
         ImageFillMode::TileAll
+            | ImageFillMode::Total
             | ImageFillMode::TileHorzTop
             | ImageFillMode::TileHorzBottom
             | ImageFillMode::TileVertLeft
@@ -276,7 +285,9 @@ pub fn draw_image_bytes(
             true
         };
 
-        if matches!(mode, ImageFillMode::TileAll) && draw_tiled_shader(dst, x, y) {
+        if matches!(mode, ImageFillMode::TileAll | ImageFillMode::Total)
+            && draw_tiled_shader(dst, x, y)
+        {
             canvas.restore();
             return;
         }

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -181,9 +181,12 @@ pub struct ResolvedParaStyle {
     pub tab_stops: Vec<TabStop>,
     /// 문단 오른쪽 끝 자동 탭 여부
     pub auto_tab_right: bool,
+    /// HWPX paraPr condense / HWP ParaShape attr1 bits 9..15.
+    /// Spec name: minimum spacing value, 0..75%.
+    pub condense_min_space: u8,
     /// 줄 나눔 기준 영어 단위 (0=단어, 1=하이픈, 2=글자) — attr1 bit 5-6
     pub english_break_unit: u8,
-    /// 줄 나눔 기준 한글 단위 (0=어절, 1=글자) — attr1 bit 7
+    /// 줄 나눔 기준 한글 단위 (0=글자, 1=어절/KEEP_WORD) — attr1 bit 7
     pub korean_break_unit: u8,
     /// 외톨이줄 보호 — attr1 bit 16
     pub widow_orphan: bool,
@@ -214,6 +217,7 @@ impl Default for ResolvedParaStyle {
             default_tab_width: 0.0,
             tab_stops: Vec::new(),
             auto_tab_right: false,
+            condense_min_space: 0,
             english_break_unit: 0,
             korean_break_unit: 0,
             widow_orphan: false,
@@ -852,6 +856,7 @@ fn resolve_single_para_style(
         default_tab_width,
         tab_stops,
         auto_tab_right,
+        condense_min_space: ((ps.attr1 >> 9) & 0x7f).min(75) as u8,
         english_break_unit: ((ps.attr1 >> 5) & 0x03) as u8,
         korean_break_unit: ((ps.attr1 >> 7) & 0x01) as u8,
         widow_orphan: (ps.attr1 >> 16) & 1 != 0 || (ps.attr2 >> 5) & 1 != 0,

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -728,18 +728,40 @@ pub(crate) fn is_heavy_display_face(font_family: &str) -> bool {
     )
 }
 
-/// 중고딕/태고딕 계열 (CSS font-weight 500) 폰트 판별.
-///
-/// HWP 에서 중고딕 계열은 Regular(400)과 Bold(700) 사이의 Medium(500) weight.
-/// Fallback 폰트 매칭 시 weight 500 힌트를 주어 선명도를 유지한다.
-pub(crate) fn is_medium_weight_face(font_family: &str) -> bool {
-    let primary = font_family
+fn primary_font_face(font_family: &str) -> &str {
+    font_family
         .split(',')
         .next()
         .unwrap_or(font_family)
         .trim()
         .trim_matches('\'')
-        .trim_matches('"');
+        .trim_matches('"')
+}
+
+/// Face name explicitly carries a bold weight.
+pub(crate) fn is_bold_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
+    let lower = primary.to_lowercase();
+    lower.contains("bold") || lower.contains("볼드")
+}
+
+/// Face name explicitly carries a light weight.
+pub(crate) fn is_light_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
+    let lower = primary.to_lowercase();
+    !is_bold_weight_face(font_family)
+        && (lower.contains("light")
+            || lower.contains("extralight")
+            || lower.contains("thin")
+            || lower.contains("ultralight"))
+}
+
+/// 중고딕/태고딕 계열 (CSS font-weight 500) 폰트 판별.
+///
+/// HWP 에서 중고딕 계열은 Regular(400)과 Bold(700) 사이의 Medium(500) weight.
+/// Fallback 폰트 매칭 시 weight 500 힌트를 주어 선명도를 유지한다.
+pub(crate) fn is_medium_weight_face(font_family: &str) -> bool {
+    let primary = primary_font_face(font_family);
     let lower = primary.to_lowercase();
     lower.contains("중고딕")
         || lower.contains("태고딕")

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -30,8 +30,9 @@ use crate::renderer::{
 // [Task #836] 미주 paragraph의 가상 para_index = paragraphs.len() + endnote 내 순번.
 // rendering.rs에서 paragraphs + endnote_paragraphs를 합쳐서 전달.
 use super::pagination::{
-    ColumnContent, EndnoteParaSource, EndnoteRef, FootnoteRef, FootnoteSource, HeaderFooterRef,
-    PageContent, PageItem, PaginationResult,
+    estimate_footnote_note_height, footnote_between_notes_margin_px,
+    footnote_separator_overhead_px, ColumnContent, EndnoteParaSource, EndnoteRef, FootnoteRef,
+    FootnoteSource, HeaderFooterRef, PageContent, PageItem, PaginationResult,
 };
 
 fn note_number_format_from_hwp_code(code: u8) -> RenderNumberFormat {
@@ -117,6 +118,8 @@ struct FormattedTable {
     cells: Vec<crate::renderer::height_measurer::MeasuredCell>,
     /// 표 셀 내 각주 높이 합계 (가용 높이에서 차감)
     table_footnote_height: f64,
+    /// 표 셀 내 각주 수 (separator/between-notes 예약 계산용)
+    table_footnote_count: usize,
 }
 
 #[derive(Debug, Clone, Copy)]
@@ -176,6 +179,8 @@ struct TypesetState {
     is_first_footnote_on_page: bool,
     /// 각주 구분선 오버헤드
     footnote_separator_overhead: f64,
+    /// 각주 사이 간격
+    footnote_between_notes_margin: f64,
     /// 각주 안전 여백
     footnote_safety_margin: f64,
     /// 존(zone) y 오프셋 (다단 나누기 시 누적)
@@ -474,6 +479,27 @@ fn page_item_para_index(item: &PageItem) -> Option<usize> {
         | PageItem::Table { para_index, .. }
         | PageItem::PartialTable { para_index, .. }
         | PageItem::Shape { para_index, .. } => Some(*para_index),
+        PageItem::EndnoteSeparator { .. } => None,
+    }
+}
+
+fn page_item_vpos_base(item: &PageItem, paragraphs: &[Paragraph]) -> Option<i32> {
+    match item {
+        PageItem::PartialParagraph {
+            para_index,
+            start_line,
+            ..
+        } => paragraphs
+            .get(*para_index)
+            .and_then(|para| para.line_segs.get(*start_line))
+            .map(|seg| seg.vertical_pos),
+        PageItem::FullParagraph { para_index }
+        | PageItem::Table { para_index, .. }
+        | PageItem::PartialTable { para_index, .. }
+        | PageItem::Shape { para_index, .. } => paragraphs
+            .get(*para_index)
+            .and_then(|para| para.line_segs.first())
+            .map(|seg| seg.vertical_pos),
         PageItem::EndnoteSeparator { .. } => None,
     }
 }
@@ -976,6 +1002,69 @@ fn is_synthetic_line_seg(ls: &LineSeg) -> bool {
     ls.tag & 0x80000000 != 0
 }
 
+fn paragraph_saved_vpos_reset_starts_new_page_after(
+    current_para: &Paragraph,
+    next_para: &Paragraph,
+    col_count: u16,
+    is_hwp3_variant: bool,
+) -> bool {
+    let next_first_vpos = next_para.line_segs.first().map(|s| s.vertical_pos);
+    let curr_last_vpos = current_para.line_segs.last().map(|s| s.vertical_pos);
+    let multi_col = col_count > 1;
+    let allowed_top_vpos = if is_hwp3_variant { 1500 } else { 0 };
+
+    matches!((next_first_vpos, curr_last_vpos), (Some(nv), Some(cl))
+        if (if multi_col { nv < cl } else { nv <= allowed_top_vpos }) && cl > 5000)
+}
+
+fn paragraph_forces_page_boundary_after(
+    current_para: &Paragraph,
+    next_para: &Paragraph,
+    col_count: u16,
+    is_hwp3_variant: bool,
+) -> bool {
+    matches!(
+        next_para.column_type,
+        ColumnBreakType::Page | ColumnBreakType::Section
+    ) || paragraph_saved_vpos_reset_starts_new_page_after(
+        current_para,
+        next_para,
+        col_count,
+        is_hwp3_variant,
+    )
+}
+
+fn single_line_visible_bounds_px(
+    para: &Paragraph,
+    page_vpos_base: i32,
+    dpi: f64,
+) -> Option<(f64, f64)> {
+    let mut real_lines = para
+        .line_segs
+        .iter()
+        .filter(|ls| !is_synthetic_line_seg(ls));
+    let line = real_lines.next()?;
+    if real_lines.next().is_some() {
+        return None;
+    }
+
+    line_seg_visible_bounds_px(line, page_vpos_base, dpi)
+}
+
+fn line_seg_visible_bounds_px(seg: &LineSeg, page_vpos_base: i32, dpi: f64) -> Option<(f64, f64)> {
+    let top = seg.vertical_pos.saturating_sub(page_vpos_base);
+    let bottom = seg
+        .vertical_pos
+        .saturating_add(seg.line_height)
+        .saturating_sub(page_vpos_base);
+    (top >= 0 && bottom >= 0).then(|| (hwpunit_to_px(top, dpi), hwpunit_to_px(bottom, dpi)))
+}
+
+fn saved_bounds_fit_at_flow_tail(bounds: (f64, f64), current_height: f64, available: f64) -> bool {
+    let (top, bottom) = bounds;
+    top + 16.0 >= current_height && bottom <= available + 0.5
+}
+
 fn positive_vpos_end_before_negative_wrap(para: &Paragraph) -> Option<i32> {
     let last_real = para
         .line_segs
@@ -1033,6 +1122,7 @@ impl TypesetState {
         col_count: u16,
         section_index: usize,
         footnote_separator_overhead: f64,
+        footnote_between_notes_margin: f64,
         footnote_safety_margin: f64,
         column_type: ColumnType,
     ) -> Self {
@@ -1050,6 +1140,7 @@ impl TypesetState {
             current_footnote_height: 0.0,
             is_first_footnote_on_page: true,
             footnote_separator_overhead,
+            footnote_between_notes_margin,
             footnote_safety_margin,
             current_zone_y_offset: 0.0,
             current_zone_layout: None,
@@ -1118,8 +1209,41 @@ impl TypesetState {
         if self.is_first_footnote_on_page {
             self.current_footnote_height += self.footnote_separator_overhead;
             self.is_first_footnote_on_page = false;
+        } else {
+            self.current_footnote_height += self.footnote_between_notes_margin;
         }
         self.current_footnote_height += height;
+        self.sync_current_page_footnote_area();
+    }
+
+    fn projected_footnote_height(&self, note_content_height: f64, note_count: usize) -> f64 {
+        if note_count == 0 {
+            return self.current_footnote_height;
+        }
+        let separator = if self.is_first_footnote_on_page {
+            self.footnote_separator_overhead
+        } else {
+            0.0
+        };
+        let between_count = if self.is_first_footnote_on_page {
+            note_count.saturating_sub(1)
+        } else {
+            note_count
+        };
+        self.current_footnote_height
+            + separator
+            + self.footnote_between_notes_margin * between_count as f64
+            + note_content_height
+    }
+
+    fn sync_current_page_footnote_area(&mut self) {
+        if self.current_footnote_height <= 0.0 {
+            return;
+        }
+        if let Some(page) = self.pages.last_mut() {
+            page.layout
+                .update_footnote_area(self.current_footnote_height);
+        }
     }
 
     /// 현재 항목을 ColumnContent로 만들어 마지막 페이지에 push
@@ -1646,6 +1770,7 @@ impl TypesetEngine {
             false,
             false,
             None,
+            None,
             force_break_before,
             false,
         )
@@ -1672,6 +1797,7 @@ impl TypesetEngine {
         is_hwp3_variant: bool,
         skip_spacing_before_prededuct: bool,
         hwp3_origin_page_tolerance: bool,
+        footnote_shape: Option<&FootnoteShape>,
         endnote_shape: Option<&FootnoteShape>,
         force_break_before: &std::collections::HashSet<usize>,
         is_hwpx_source: bool,
@@ -1679,7 +1805,11 @@ impl TypesetEngine {
         let layout = PageLayoutInfo::from_page_def(page_def, column_def, self.dpi);
         self.is_hwpx_source.set(is_hwpx_source);
         let col_count = column_def.column_count.max(1);
-        let footnote_separator_overhead = hwpunit_to_px(400, self.dpi);
+        let default_footnote_shape = FootnoteShape::default();
+        let footnote_shape = footnote_shape.unwrap_or(&default_footnote_shape);
+        let footnote_separator_overhead = footnote_separator_overhead_px(footnote_shape, self.dpi);
+        let footnote_between_notes_margin =
+            footnote_between_notes_margin_px(footnote_shape, self.dpi);
         let footnote_safety_margin = hwpunit_to_px(3000, self.dpi);
         // [Task #1007] variant cross-paragraph vpos reset THRESHOLD 계산용 body height (HU)
         let body_height_hu_for_variant: i32 = if is_hwp3_variant {
@@ -1701,6 +1831,7 @@ impl TypesetEngine {
             col_count,
             section_index,
             footnote_separator_overhead,
+            footnote_between_notes_margin,
             footnote_safety_margin,
             column_def.column_type,
         );
@@ -2124,15 +2255,14 @@ impl TypesetEngine {
                     if next_force_break {
                         false
                     } else {
-                        let next_first_vpos = next_para.line_segs.first().map(|s| s.vertical_pos);
-                        let curr_last_vpos = para.line_segs.last().map(|s| s.vertical_pos);
                         // [Task #470] 다단 섹션에서는 nv == 0 → nv < cl 로 완화 (컬럼 헤더 오프셋).
                         // 단일 단에서는 partial-table split 회귀 (issue #418) 회피 위해 nv == 0 유지.
-                        let multi_col = st.col_count > 1;
-                        let allowed_top_vpos = if st.is_hwp3_variant { 1500 } else { 0 };
-                        matches!((next_first_vpos, curr_last_vpos), (Some(nv), Some(cl))
-                        if (if multi_col { nv < cl } else { nv <= allowed_top_vpos })
-                            && cl > 5000)
+                        paragraph_saved_vpos_reset_starts_new_page_after(
+                            para,
+                            next_para,
+                            st.col_count,
+                            st.is_hwp3_variant,
+                        )
                     }
                 } else {
                     false
@@ -2804,7 +2934,7 @@ impl TypesetEngine {
                                                             tb_control_index: tc_idx,
                                                         },
                                                     });
-                                                    let fn_height = Self::estimate_footnote_height(
+                                                    let fn_height = estimate_footnote_note_height(
                                                         fn_ctrl, self.dpi,
                                                     );
                                                     st.add_footnote_height(fn_height);
@@ -2891,7 +3021,7 @@ impl TypesetEngine {
                                     },
                                 });
                             }
-                            let fn_height = Self::estimate_footnote_height(fn_ctrl, self.dpi);
+                            let fn_height = estimate_footnote_note_height(fn_ctrl, self.dpi);
                             st.add_footnote_height(fn_height);
                         }
                     }
@@ -9044,68 +9174,6 @@ impl TypesetEngine {
         st.apply_visible_float_exclusions(exclusion_probe_height);
         let available = (st.available_height() - safety).max(0.0);
 
-        // Task #321 Stage 1 진단: 포맷터 총 높이 vs LINE_SEG 실측 총 높이 비교
-        // Stage 5a 확장: per-paragraph 카테고리 분해 (sb/sa/lines/line_sum/ls_sum)
-        if std::env::var("RHWP_TYPESET_DRIFT").is_ok() {
-            let vpos_h: Option<f64> = if let (Some(first), Some(last)) =
-                (para.line_segs.first(), para.line_segs.last())
-            {
-                let span_hu =
-                    (last.vertical_pos + last.line_height + last.line_spacing) - first.vertical_pos;
-                if span_hu > 0 {
-                    Some(crate::renderer::hwpunit_to_px(span_hu, self.dpi))
-                } else {
-                    None
-                }
-            } else {
-                None
-            };
-            let first_vpos = para.line_segs.first().map(|s| s.vertical_pos).unwrap_or(-1);
-            let last_vpos = para.line_segs.last().map(|s| s.vertical_pos).unwrap_or(-1);
-            let lh_sum: f64 = fmt.line_heights.iter().sum();
-            let ls_sum: f64 = fmt.line_spacings.iter().sum();
-            let line_count = fmt.line_heights.len();
-            let trailing_ls = fmt.line_spacings.last().copied().unwrap_or(0.0);
-            let diff = match vpos_h {
-                Some(v) => fmt.total_height - v,
-                None => 0.0,
-            };
-            let vpos_h_str = vpos_h
-                .map(|v| format!("{:.1}", v))
-                .unwrap_or_else(|| "-".to_string());
-            eprintln!(
-                "TYPESET_DRIFT_PI: pi={} col={} sb={:.1} sa={:.1} lines={} lh_sum={:.1} ls_sum={:.1} trail_ls={:.1} fmt_total={:.1} vpos_h={} diff={:+.1} first_vpos={} last_vpos={} cur_h={:.1} avail={:.1}",
-                para_idx, st.current_column, fmt.spacing_before, fmt.spacing_after,
-                line_count, lh_sum, ls_sum, trailing_ls,
-                fmt.total_height, vpos_h_str, diff,
-                first_vpos, last_vpos,
-                st.current_height, available,
-            );
-
-            // 옵션: per-line 분해 (LINE_SEG 와 비교)
-            if std::env::var("RHWP_TYPESET_DRIFT_LINES").is_ok() {
-                for (li, (lh, ls)) in fmt
-                    .line_heights
-                    .iter()
-                    .zip(fmt.line_spacings.iter())
-                    .enumerate()
-                {
-                    let seg = para.line_segs.get(li);
-                    let seg_lh = seg
-                        .map(|s| crate::renderer::hwpunit_to_px(s.line_height, self.dpi))
-                        .unwrap_or(-1.0);
-                    let seg_ls = seg
-                        .map(|s| crate::renderer::hwpunit_to_px(s.line_spacing, self.dpi))
-                        .unwrap_or(-1.0);
-                    let seg_vpos = seg.map(|s| s.vertical_pos).unwrap_or(-1);
-                    eprintln!(
-                        "TYPESET_DRIFT_LINE: pi={} li={} fmt_lh={:.1} fmt_ls={:.1} seg_lh={:.1} seg_ls={:.1} vpos={}",
-                        para_idx, li, lh, ls, seg_lh, seg_ls, seg_vpos,
-                    );
-                }
-            }
-        }
-
         // 다단 레이아웃에서 문단 내 단 경계 감지
         // [Task #459] on_first_multicolumn_page 가드 제거: 다단 구역이 여러 페이지에 걸칠 때
         // 후속 페이지에서도 LINE_SEG vpos-reset 으로 인코딩된 단 경계를 인식해야 함.
@@ -9160,6 +9228,10 @@ impl TypesetEngine {
                 let total_h = st.current_height + fmt.height_for_fit;
                 let fit_fail_within_safety =
                     total_h > available && total_h <= available + layout_drift_safety_px;
+                let base_available = st.base_available_height() - st.current_zone_y_offset;
+                let fit_fail_only_after_footnote_reserve = st.current_footnote_height > 0.0
+                    && total_h > available
+                    && total_h <= base_available;
                 let prior_trailing_drift = st.current_height > available
                     && st.current_height <= available + layout_drift_safety_px + 0.5;
                 let previous_item_is_empty_para = st
@@ -9179,7 +9251,7 @@ impl TypesetEngine {
                     st.hidden_empty_paras.insert(para_idx);
                     return;
                 }
-                if fit_fail_within_safety {
+                if fit_fail_within_safety || fit_fail_only_after_footnote_reserve {
                     st.current_items.push(PageItem::FullParagraph {
                         para_index: para_idx,
                     });
@@ -9220,7 +9292,27 @@ impl TypesetEngine {
         let trim_spacing_before_for_flow =
             !st.is_hwp3_variant && !para_near_rowbreak_table(paragraphs, para_idx);
 
-        if forced_page_break_line.is_none() && st.current_height + fmt.height_for_fit <= available {
+        let current_page_vpos_base = st.vpos_page_base.or_else(|| {
+            st.current_items
+                .first()
+                .and_then(|item| page_item_vpos_base(item, paragraphs))
+        });
+        let saved_single_line_bottom_fits = forced_page_break_line.is_none()
+            && st.col_count == 1
+            && fmt.line_heights.len() == 1
+            && fmt.spacing_after <= 0.5
+            && para.controls.is_empty()
+            && !st.current_items.is_empty()
+            && current_page_vpos_base
+                .and_then(|base| single_line_visible_bounds_px(para, base, self.dpi))
+                .is_some_and(|bounds| {
+                    saved_bounds_fit_at_flow_tail(bounds, st.current_height, st.available_height())
+                });
+
+        if forced_page_break_line.is_none()
+            && (st.current_height + fmt.height_for_fit <= available
+                || saved_single_line_bottom_fits)
+        {
             // place: 전체 배치
             st.current_items.push(PageItem::FullParagraph {
                 para_index: para_idx,
@@ -9280,6 +9372,83 @@ impl TypesetEngine {
                 });
                 st.current_height +=
                     fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+                if let Some(v) = body_bottom_vpos {
+                    st.prev_body_bottom_vpos = Some(v);
+                }
+                return;
+            }
+        }
+
+        // [Task #1537] 폰트 치환 drift 로 인한 "tail 1줄 spill 후 강제 쪽나누기 고아 페이지" 차단.
+        //
+        // 증상: 본문 문단 N 이 페이지 하단을 ~한 줄 미만으로 미세 초과(폰트 치환으로 부피가
+        // 한컴 대비 커짐)하여 마지막 줄만 새 페이지로 split → 그 직후 문단 N+1 이 명시적
+        // 쪽나누기(column_type==Page/Section)를 가지면 또 새 페이지를 강제 → spill 한 1줄이
+        // 거의 빈 페이지에 고립된다(2025 행정업무운영 편람: 0-idx page 11/13/17, 본문 1줄+빈공간).
+        //
+        // 한컴은 폰트 drift 가 없어 문단 N 전체를 현재 페이지에 담고 N+1 의 쪽나누기로 깔끔히
+        // 다음 페이지를 시작한다. 우리도 "초과량이 한 줄 미만(=drift)이고 다음 문단이 어차피
+        // 쪽나누기로 페이지를 끝낸다"는 두 조건이 모두 맞을 때만 문단 N 을 통째로 현재 페이지에
+        // 배치(하단 여백으로 소량 bleed 허용)해 고아 페이지를 제거한다. 일반 본문 흐름(다음
+        // 문단이 쪽나누기가 아님)이나 초과량이 한 줄 이상(진짜 split 필요)인 경우는 불변.
+
+        // 다음 문단이 쪽/구역 나누기인가? 사이에 빈 문단(텍스트·컨트롤 없음)이 끼어 있으면
+        // 건너뛴다 — 빈 문단은 높이를 거의 차지하지 않고 hide_empty_line 로 흡수되므로,
+        // "tail spill → 빈 문단 → 강제 쪽나누기" 패턴에서도 spill 한 줄이 동일하게 고립된다.
+        // 단, 텍스트/컨트롤이 있는 일반 문단을 만나면 즉시 중단(false) — 그 문단이
+        // 현재 페이지를 마저 채우므로 고아 페이지가 생기지 않는다.
+        let next_para_forces_break = {
+            let mut idx = para_idx + 1;
+            let mut prior_para = para;
+            let mut forced = false;
+            while let Some(next_para) = paragraphs.get(idx) {
+                if paragraph_forces_page_boundary_after(
+                    prior_para,
+                    next_para,
+                    st.col_count,
+                    st.is_hwp3_variant,
+                ) {
+                    forced = true;
+                    break;
+                }
+                let is_empty = next_para.text.trim().is_empty() && next_para.controls.is_empty();
+                if !is_empty {
+                    break;
+                }
+                prior_para = next_para;
+                idx += 1;
+            }
+            forced
+        };
+        // 본문 높이를 바꾸지 않는 컨트롤(각주/미주)만 허용 — 표/그림/글상자가 있으면
+        // 줄 단위 split/배치 규칙이 달라지므로 제외.
+        let only_note_controls = para
+            .controls
+            .iter()
+            .all(|c| matches!(c, Control::Footnote(_) | Control::Endnote(_)));
+        if st.col_count == 1
+            && forced_page_break_line.is_none()
+            && next_para_forces_break
+            && !para.text.trim().is_empty()
+            && only_note_controls
+            && !st.current_items.is_empty()
+            && fmt.line_heights.len() >= 2
+        {
+            let first_line_advance = fmt.line_advance(0);
+            // 다음 문단이 어차피 쪽나누기로 페이지를 끝내므로, 다음 페이지 layout clamp 를
+            // 막으려던 LAYOUT_DRIFT_SAFETY_PX(현재 페이지 한정) 여유는 이 경우 의미가 없다.
+            // 따라서 safety 를 뺀 `available` 이 아니라 진짜 본문 하단(각주/존 차감 포함)인
+            // available_height() 를 기준으로 초과량을 잰다.
+            let true_available = st.available_height();
+            // 초과량이 한 줄 미만(폰트 drift)일 때만 통째 배치.
+            // (full-place 체크를 이미 통과 못 했으므로 overflow > -safety. 진짜 본문 하단
+            //  기준으로 한 줄 미만 초과면 마지막 줄 spill 대신 통째 배치.)
+            let overflow = st.current_height + fmt.height_for_fit - true_available;
+            if overflow < first_line_advance {
+                st.current_items.push(PageItem::FullParagraph {
+                    para_index: para_idx,
+                });
+                st.current_height += fmt.total_height;
                 if let Some(v) = body_bottom_vpos {
                     st.prev_body_bottom_vpos = Some(v);
                 }
@@ -9514,24 +9683,6 @@ impl TypesetEngine {
     // Phase 2: Break Token 기반 표 조판
     // ========================================================
 
-    /// 단일 각주의 높이를 추정한다 (HeightMeasurer::estimate_single_footnote_height 동일).
-    fn estimate_footnote_height(footnote: &crate::model::footnote::Footnote, dpi: f64) -> f64 {
-        let mut fn_height = 0.0;
-        for para in &footnote.paragraphs {
-            if para.line_segs.is_empty() {
-                fn_height += hwpunit_to_px(400, dpi);
-            } else {
-                for seg in &para.line_segs {
-                    fn_height += hwpunit_to_px(seg.line_height, dpi);
-                }
-            }
-        }
-        if fn_height <= 0.0 {
-            fn_height = hwpunit_to_px(400, dpi);
-        }
-        fn_height
-    }
-
     /// 표의 조판 높이를 계산한다 (format 단계).
     /// MeasuredTable + host_spacing을 통합하여 layout과 동일한 규칙으로 계산.
     #[allow(clippy::too_many_arguments)]
@@ -9695,18 +9846,14 @@ impl TypesetEngine {
 
         // 표 셀 내 각주 높이 사전 계산 (Paginator engine.rs:565-581 동일)
         let mut table_footnote_height = 0.0;
-        let mut table_has_footnotes = false;
+        let mut table_footnote_count = 0usize;
         for cell in &table.cells {
             for cp in &cell.paragraphs {
                 for cc in &cp.controls {
                     if let Control::Footnote(fn_ctrl) = cc {
-                        let fn_height = Self::estimate_footnote_height(fn_ctrl, self.dpi);
-                        if !table_has_footnotes {
-                            // 첫 각주 시 구분선 오버헤드 추가 여부는 호출 시점의 상태에 의존
-                            // 여기서는 순수 각주 높이만 누적 (구분선은 typeset_block_table에서 처리)
-                        }
+                        let fn_height = estimate_footnote_note_height(fn_ctrl, self.dpi);
                         table_footnote_height += fn_height;
-                        table_has_footnotes = true;
+                        table_footnote_count += 1;
                     }
                 }
             }
@@ -9725,6 +9872,7 @@ impl TypesetEngine {
             page_break,
             cells,
             table_footnote_height,
+            table_footnote_count,
         }
     }
 
@@ -9782,12 +9930,32 @@ impl TypesetEngine {
         } else {
             fmt.total_height
         };
+        let saved_single_tac_bottom_fits = if has_tac && tac_count <= 1 {
+            para.controls
+                .iter()
+                .find_map(|ctrl| match ctrl {
+                    Control::Table(table) if self.is_effective_tac_table(para, table, &fmt) => {
+                        Some(self.tac_table_line_index(para, table, &fmt).unwrap_or(0))
+                    }
+                    _ => None,
+                })
+                .and_then(|line_idx| para.line_segs.get(line_idx))
+                .and_then(|seg| {
+                    line_seg_visible_bounds_px(seg, st.vpos_page_base.unwrap_or(0), self.dpi)
+                })
+                .is_some_and(|bounds| {
+                    saved_bounds_fit_at_flow_tail(bounds, st.current_height, st.available_height())
+                })
+        } else {
+            false
+        };
 
         // 넘치면 flush (단일 TAC 표만)
         if st.current_height + height_for_fit > st.available_height()
             && !st.current_items.is_empty()
             && has_tac
             && tac_count <= 1
+            && !saved_single_tac_bottom_fits
         {
             st.advance_column_or_new_page();
         }
@@ -10014,7 +10182,7 @@ impl TypesetEngine {
                                         });
                                     }
                                     let fn_height =
-                                        Self::estimate_footnote_height(fn_ctrl, self.dpi);
+                                        estimate_footnote_note_height(fn_ctrl, self.dpi);
                                     st.add_footnote_height(fn_height);
                                 }
                             }
@@ -10227,13 +10395,8 @@ impl TypesetEngine {
         let lane_top = lanes.pushed_top(x_start, x_end, raw_top);
         let lane_bottom = lane_top + reserved_height;
 
-        let table_footnote = ft.table_footnote_height;
-        let fn_separator = if table_footnote > 0.0 && st.is_first_footnote_on_page {
-            st.footnote_separator_overhead
-        } else {
-            0.0
-        };
-        let total_footnote = st.current_footnote_height + table_footnote + fn_separator;
+        let total_footnote =
+            st.projected_footnote_height(ft.table_footnote_height, ft.table_footnote_count);
         let fn_margin = if total_footnote > 0.0 {
             st.footnote_safety_margin
         } else {
@@ -10292,19 +10455,22 @@ impl TypesetEngine {
         }
 
         let tac_table_line_idx = self.tac_table_line_index(para, table, fmt);
-        // 다중 TAC 표: LINE_SEG 기반 개별 높이 계산
-        let table_height = if tac_count > 1 {
-            let tac_idx = para
-                .controls
+        let tac_seg_idx = if tac_count > 1 {
+            para.controls
                 .iter()
                 .take(ctrl_idx)
                 .filter(
                     |c| matches!(c, Control::Table(t) if self.is_effective_tac_table(para, t, fmt)),
                 )
-                .count();
-            let is_last_tac = tac_idx + 1 == tac_count;
+                .count()
+        } else {
+            tac_table_line_idx.unwrap_or(0)
+        };
+        // 다중 TAC 표: LINE_SEG 기반 개별 높이 계산
+        let table_height = if tac_count > 1 {
+            let is_last_tac = tac_seg_idx + 1 == tac_count;
             para.line_segs
-                .get(tac_idx)
+                .get(tac_seg_idx)
                 .map(|seg| {
                     let line_h = hwpunit_to_px(seg.line_height, self.dpi);
                     if is_last_tac {
@@ -10342,8 +10508,19 @@ impl TypesetEngine {
                 .all(|item| matches!(item, PageItem::Shape { .. }));
         let fits_after_overlay_shapes =
             current_column_has_only_overlay_shapes && table_height <= available + 12.0;
+        let current_page_vpos_base = st.vpos_page_base.unwrap_or(0);
+        let saved_tac_table_bottom_fits = Some(current_page_vpos_base)
+            .and_then(|base| {
+                para.line_segs
+                    .get(tac_seg_idx)
+                    .and_then(|seg| line_seg_visible_bounds_px(seg, base, self.dpi))
+            })
+            .is_some_and(|bounds| {
+                saved_bounds_fit_at_flow_tail(bounds, st.current_height, available)
+            });
         if st.current_height + table_height > available
             && !fits_after_overlay_shapes
+            && !saved_tac_table_bottom_fits
             && !st.current_items.is_empty()
         {
             st.advance_column_or_new_page();
@@ -10620,13 +10797,8 @@ impl TypesetEngine {
         is_last_placed: bool,
     ) {
         // 표 내 각주를 고려한 가용 높이 계산 (Paginator engine.rs:583-586 동일)
-        let table_fn_h = ft.table_footnote_height;
-        let fn_separator = if table_fn_h > 0.0 && st.is_first_footnote_on_page {
-            st.footnote_separator_overhead
-        } else {
-            0.0
-        };
-        let total_footnote = st.current_footnote_height + table_fn_h + fn_separator;
+        let total_footnote =
+            st.projected_footnote_height(ft.table_footnote_height, ft.table_footnote_count);
         let fn_margin = if total_footnote > 0.0 {
             st.footnote_safety_margin
         } else {
@@ -12143,7 +12315,11 @@ impl TypesetEngine {
                             ..
                         } => *para_index == *ph_para && *start_line == 0,
                         PageItem::Table { para_index, .. } => *para_index == *ph_para,
-                        PageItem::PartialTable { para_index, .. } => *para_index == *ph_para,
+                        PageItem::PartialTable {
+                            para_index,
+                            is_continuation,
+                            ..
+                        } => *para_index == *ph_para && !*is_continuation,
                         PageItem::Shape { para_index, .. } => *para_index == *ph_para,
                         PageItem::EndnoteSeparator { .. } => false,
                     })
@@ -12438,6 +12614,7 @@ mod tests {
     use crate::model::paragraph::{LineSeg, Paragraph};
     use crate::renderer::composer::ComposedParagraph;
     use crate::renderer::height_measurer::HeightMeasurer;
+    use crate::renderer::page_layout::PageLayoutInfo;
     use crate::renderer::pagination::Paginator;
     use crate::renderer::style_resolver::ResolvedStyleSet;
 
@@ -12463,6 +12640,37 @@ mod tests {
                 ..Default::default()
             }],
             ..Default::default()
+        }
+    }
+
+    fn page_with_items(items: Vec<PageItem>) -> PageContent {
+        PageContent {
+            page_index: 0,
+            page_number: 0,
+            section_index: 0,
+            layout: PageLayoutInfo::from_page_def(
+                &a4_page_def(),
+                &ColumnDef::default(),
+                DEFAULT_DPI,
+            ),
+            column_contents: vec![ColumnContent {
+                column_index: 0,
+                start_height: 0.0,
+                endnote_flow: false,
+                items,
+                zone_layout: None,
+                zone_y_offset: 0.0,
+                wrap_around_paras: Vec::new(),
+                used_height: 0.0,
+                wrap_anchors: std::collections::HashMap::new(),
+            }],
+            active_header: None,
+            active_footer: None,
+            page_number_pos: None,
+            page_hide: None,
+            footnotes: Vec::new(),
+            active_master_page: None,
+            extra_master_pages: Vec::new(),
         }
     }
 
@@ -12534,6 +12742,121 @@ mod tests {
     }
 
     #[test]
+    fn table_continuation_does_not_reapply_page_hide() {
+        let hide = crate::model::control::PageHide {
+            hide_master_page: true,
+            hide_page_num: true,
+            ..Default::default()
+        };
+        let mut pages = vec![
+            page_with_items(vec![PageItem::PartialTable {
+                para_index: 7,
+                control_index: 0,
+                start_row: 0,
+                end_row: 2,
+                is_continuation: false,
+                start_cut: Vec::new(),
+                end_cut: Vec::new(),
+                is_block_split: false,
+            }]),
+            page_with_items(vec![PageItem::PartialTable {
+                para_index: 7,
+                control_index: 0,
+                start_row: 2,
+                end_row: 4,
+                is_continuation: true,
+                start_cut: Vec::new(),
+                end_cut: Vec::new(),
+                is_block_split: false,
+            }]),
+        ];
+
+        TypesetEngine::finalize_pages(&mut pages, &[], &None, &[], &[(7, hide)], 0);
+
+        assert!(pages[0].page_hide.is_some());
+        assert!(pages[1].page_hide.is_none());
+    }
+
+    #[test]
+    fn footnote_area_reserve_uses_section_shape_metrics() {
+        let engine = TypesetEngine::with_default_dpi();
+        let styles = ResolvedStyleSet::default();
+        let shape = FootnoteShape {
+            separator_margin_top: 1000,
+            note_spacing: 700,
+            raw_unknown: 900,
+            separator_line_width: 4,
+            ..Default::default()
+        };
+        let note1 = Paragraph {
+            text: "첫 각주".to_string(),
+            line_segs: vec![LineSeg {
+                line_height: 400,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let note2 = Paragraph {
+            text: "둘째 각주".to_string(),
+            line_segs: vec![LineSeg {
+                line_height: 600,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let paras = vec![Paragraph {
+            text: "본문".to_string(),
+            line_segs: vec![LineSeg {
+                line_height: 400,
+                ..Default::default()
+            }],
+            controls: vec![
+                Control::Footnote(Box::new(crate::model::footnote::Footnote {
+                    number: 1,
+                    paragraphs: vec![note1],
+                    ..Default::default()
+                })),
+                Control::Footnote(Box::new(crate::model::footnote::Footnote {
+                    number: 2,
+                    paragraphs: vec![note2],
+                    ..Default::default()
+                })),
+            ],
+            ..Default::default()
+        }];
+        let composed: Vec<ComposedParagraph> = paras
+            .iter()
+            .map(crate::renderer::composer::compose_paragraph)
+            .collect();
+
+        let result = engine.typeset_section_with_variant(
+            &paras,
+            &composed,
+            &styles,
+            &a4_page_def(),
+            &ColumnDef::default(),
+            0,
+            &[],
+            false,
+            false,
+            false,
+            false,
+            Some(&shape),
+            None,
+            &std::collections::HashSet::new(),
+            false,
+        );
+
+        let expected = footnote_separator_overhead_px(&shape, DEFAULT_DPI)
+            + hwpunit_to_px(400, DEFAULT_DPI)
+            + footnote_between_notes_margin_px(&shape, DEFAULT_DPI)
+            + hwpunit_to_px(600, DEFAULT_DPI);
+        let page = result.pages.first().expect("page");
+        assert_eq!(page.footnotes.len(), 2);
+        assert!((page.layout.footnote_area.height - expected).abs() < 0.01);
+    }
+
+    #[test]
     fn test_typeset_single_paragraph() {
         let engine = TypesetEngine::with_default_dpi();
         let paginator = Paginator::with_default_dpi();
@@ -12585,6 +12908,235 @@ mod tests {
         );
 
         assert_pagination_match(&old_result, &new_result, "page_overflow");
+    }
+
+    #[test]
+    fn saved_single_line_at_body_bottom_stays_on_current_page() {
+        let engine = TypesetEngine::with_default_dpi();
+        let mut styles = ResolvedStyleSet::default();
+        styles
+            .para_styles
+            .push(crate::renderer::style_resolver::ResolvedParaStyle {
+                spacing_before: 9.3,
+                ..Default::default()
+            });
+        let page_def = a4_page_def();
+        let col_def = ColumnDef::default();
+        let layout = PageLayoutInfo::from_page_def(&page_def, &col_def, DEFAULT_DPI);
+        let body_height_hu =
+            crate::renderer::px_to_hwpunit(layout.available_body_height(), DEFAULT_DPI);
+        let line_height = 1200;
+        let line_spacing = 840;
+        let spacing_before_hu = crate::renderer::px_to_hwpunit(9.3, DEFAULT_DPI);
+        let lead_height = body_height_hu - line_height;
+        let lead_measured_height = lead_height - spacing_before_hu + 600;
+        let paras = vec![
+            Paragraph {
+                text: "lead".to_string(),
+                line_segs: vec![LineSeg {
+                    vertical_pos: 0,
+                    line_height: lead_measured_height,
+                    text_height: lead_measured_height,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Paragraph {
+                para_shape_id: 0,
+                text: "tail".to_string(),
+                line_segs: vec![LineSeg {
+                    vertical_pos: lead_height,
+                    line_height,
+                    text_height: line_height,
+                    line_spacing,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ];
+        let composed: Vec<ComposedParagraph> = Vec::new();
+
+        let result = engine.typeset_section(
+            &paras,
+            &composed,
+            &styles,
+            &page_def,
+            &col_def,
+            0,
+            &[],
+            false,
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(result.pages.len(), 1);
+        assert_eq!(result.pages[0].column_contents[0].items.len(), 2);
+    }
+
+    #[test]
+    fn two_line_tail_before_vpos_reset_stays_on_current_page_when_visible_bottom_fits() {
+        let engine = TypesetEngine::with_default_dpi();
+        let mut styles = ResolvedStyleSet::default();
+        styles
+            .para_styles
+            .push(crate::renderer::style_resolver::ResolvedParaStyle::default());
+        styles
+            .para_styles
+            .push(crate::renderer::style_resolver::ResolvedParaStyle {
+                spacing_before: hwpunit_to_px(2400, DEFAULT_DPI),
+                spacing_after: hwpunit_to_px(1400, DEFAULT_DPI),
+                ..Default::default()
+            });
+
+        let page_def = a4_page_def();
+        let col_def = ColumnDef::default();
+        let layout = PageLayoutInfo::from_page_def(&page_def, &col_def, DEFAULT_DPI);
+        let body_height_hu =
+            crate::renderer::px_to_hwpunit(layout.available_body_height(), DEFAULT_DPI);
+        let line_height = 1200;
+        let line_spacing = 840;
+        let first_vpos = body_height_hu - 3740;
+        let lead_height = first_vpos - 2400;
+
+        let paras = vec![
+            Paragraph {
+                text: "lead".to_string(),
+                line_segs: vec![LineSeg {
+                    vertical_pos: 0,
+                    line_height: lead_height,
+                    text_height: lead_height,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Paragraph {
+                para_shape_id: 1,
+                text: "line one\nline two".to_string(),
+                line_segs: vec![
+                    LineSeg {
+                        vertical_pos: first_vpos,
+                        line_height,
+                        text_height: line_height,
+                        line_spacing,
+                        ..Default::default()
+                    },
+                    LineSeg {
+                        vertical_pos: first_vpos + line_height + line_spacing,
+                        line_height,
+                        text_height: line_height,
+                        line_spacing,
+                        text_start: 9,
+                        ..Default::default()
+                    },
+                ],
+                ..Default::default()
+            },
+            Paragraph {
+                text: "next page".to_string(),
+                line_segs: vec![LineSeg {
+                    vertical_pos: 0,
+                    line_height,
+                    text_height: line_height,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ];
+        let composed: Vec<ComposedParagraph> = Vec::new();
+
+        let result = engine.typeset_section(
+            &paras,
+            &composed,
+            &styles,
+            &page_def,
+            &col_def,
+            0,
+            &[],
+            false,
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(result.pages.len(), 2);
+        assert!(matches!(
+            result.pages[0].column_contents[0].items.as_slice(),
+            [
+                PageItem::FullParagraph { para_index: 0 },
+                PageItem::FullParagraph { para_index: 1 }
+            ]
+        ));
+        assert!(matches!(
+            result.pages[1].column_contents[0].items.as_slice(),
+            [PageItem::FullParagraph { para_index: 2 }]
+        ));
+    }
+
+    #[test]
+    fn saved_tac_table_line_at_body_bottom_stays_on_current_page() {
+        let engine = TypesetEngine::with_default_dpi();
+        let styles = ResolvedStyleSet::default();
+        let page_def = a4_page_def();
+        let col_def = ColumnDef::default();
+        let layout = PageLayoutInfo::from_page_def(&page_def, &col_def, DEFAULT_DPI);
+        let body_height_hu =
+            crate::renderer::px_to_hwpunit(layout.available_body_height(), DEFAULT_DPI);
+        let table_height = 10_072;
+        let table_vpos = body_height_hu - table_height;
+        let lead_height = table_vpos + 900;
+        let paras = vec![
+            Paragraph {
+                text: "lead".to_string(),
+                line_segs: vec![LineSeg {
+                    vertical_pos: 0,
+                    line_height: lead_height,
+                    text_height: lead_height,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+            Paragraph {
+                controls: vec![Control::Table(Box::new(crate::model::table::Table {
+                    attr: 1,
+                    row_count: 3,
+                    col_count: 3,
+                    common: crate::model::shape::CommonObjAttr {
+                        treat_as_char: true,
+                        text_wrap: crate::model::shape::TextWrap::TopAndBottom,
+                        height: table_height as u32,
+                        ..Default::default()
+                    },
+                    ..Default::default()
+                }))],
+                line_segs: vec![LineSeg {
+                    vertical_pos: table_vpos,
+                    line_height: table_height,
+                    text_height: table_height,
+                    line_spacing: 120,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            },
+        ];
+        let composed: Vec<ComposedParagraph> = Vec::new();
+
+        let result = engine.typeset_section(
+            &paras,
+            &composed,
+            &styles,
+            &page_def,
+            &col_def,
+            0,
+            &[],
+            false,
+            &std::collections::HashSet::new(),
+        );
+
+        assert_eq!(result.pages.len(), 1);
+        assert!(matches!(
+            result.pages[0].column_contents[0].items.as_slice(),
+            [
+                PageItem::FullParagraph { para_index: 0 },
+                PageItem::Table { para_index: 1, .. }
+            ]
+        ));
     }
 
     /// [Task #1363 v3 Stage 2] scratch 측정 부작용 격리 회귀 가드.

--- a/src/renderer/web_canvas.rs
+++ b/src/renderer/web_canvas.rs
@@ -77,6 +77,45 @@ thread_local! {
         std::cell::RefCell::new(std::collections::HashMap::new());
 }
 
+#[cfg(target_arch = "wasm32")]
+thread_local! {
+    static DECODED_CANVAS_CACHE: std::cell::RefCell<
+        std::collections::HashMap<u64, Option<HtmlCanvasElement>>,
+    > = std::cell::RefCell::new(std::collections::HashMap::new());
+}
+
+#[cfg(target_arch = "wasm32")]
+fn decode_image_to_canvas(data: &[u8]) -> Option<HtmlCanvasElement> {
+    let dynimg = image::load_from_memory(data).ok()?;
+    let rgba = dynimg.to_rgba8();
+    let (iw, ih) = (rgba.width(), rgba.height());
+    if iw == 0 || ih == 0 {
+        return None;
+    }
+
+    let buf = rgba.into_raw();
+    let image_data =
+        web_sys::ImageData::new_with_u8_clamped_array_and_sh(wasm_bindgen::Clamped(&buf), iw, ih)
+            .ok()?;
+
+    let document = web_sys::window()?.document()?;
+    let canvas: HtmlCanvasElement = document
+        .create_element("canvas")
+        .ok()?
+        .dyn_into::<HtmlCanvasElement>()
+        .ok()?;
+    canvas.set_width(iw);
+    canvas.set_height(ih);
+
+    let ctx = canvas
+        .get_context("2d")
+        .ok()??
+        .dyn_into::<CanvasRenderingContext2d>()
+        .ok()?;
+    ctx.put_image_data(&image_data, 0.0, 0.0).ok()?;
+    Some(canvas)
+}
+
 /// 빠른 해시 (FNV-1a 64비트)
 #[cfg(target_arch = "wasm32")]
 fn hash_bytes(data: &[u8]) -> u64 {
@@ -2541,6 +2580,25 @@ impl Renderer for WebCanvasRenderer {
     fn draw_image(&mut self, data: &[u8], x: f64, y: f64, w: f64, h: f64) {
         let key = hash_bytes(data);
 
+        let decoded = DECODED_CANVAS_CACHE.with(|cache| {
+            let mut c = cache.borrow_mut();
+            if let Some(slot) = c.get(&key) {
+                return slot.clone();
+            }
+            if c.len() > 200 {
+                c.clear();
+            }
+            let canvas = decode_image_to_canvas(data);
+            c.insert(key, canvas.clone());
+            canvas
+        });
+        if let Some(canvas) = decoded {
+            let _ = self
+                .ctx
+                .draw_image_with_html_canvas_element_and_dw_and_dh(&canvas, x, y, w, h);
+            return;
+        }
+
         // 캐시에서 이미 로드된 이미지를 찾는다
         let cached = IMAGE_CACHE.with(|cache| {
             let c = cache.borrow();
@@ -2631,6 +2689,27 @@ impl WebCanvasRenderer {
         dh: f64,
     ) {
         let key = hash_bytes(data);
+
+        let decoded = DECODED_CANVAS_CACHE.with(|cache| {
+            let mut c = cache.borrow_mut();
+            if let Some(slot) = c.get(&key) {
+                return slot.clone();
+            }
+            if c.len() > 200 {
+                c.clear();
+            }
+            let canvas = decode_image_to_canvas(data);
+            c.insert(key, canvas.clone());
+            canvas
+        });
+        if let Some(canvas) = decoded {
+            let _ = self
+                .ctx
+                .draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh(
+                    &canvas, sx, sy, sw, sh, dx, dy, dw, dh,
+                );
+            return;
+        }
 
         let cached = IMAGE_CACHE.with(|cache| {
             let c = cache.borrow();

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2168,6 +2168,7 @@ fn serialize_shape_fill(w: &mut ByteWriter, fill: &Fill) {
                 ImageFillMode::TileHorzBottom => 2,
                 ImageFillMode::TileVertLeft => 3,
                 ImageFillMode::TileVertRight => 4,
+                ImageFillMode::Total => 0,
                 ImageFillMode::FitToSize => 5,
                 ImageFillMode::Center => 6,
                 ImageFillMode::CenterTop => 7,

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -290,6 +290,7 @@ fn image_fill_mode_to_u8(mode: ImageFillMode) -> u8 {
         ImageFillMode::TileHorzBottom => 2,
         ImageFillMode::TileVertLeft => 3,
         ImageFillMode::TileVertRight => 4,
+        ImageFillMode::Total => 0,
         ImageFillMode::FitToSize => 5,
         ImageFillMode::Center => 6,
         ImageFillMode::CenterTop => 7,

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -735,6 +735,7 @@ pub(crate) fn write_fill_brush<W: Write>(
             let img = fill.image.clone().unwrap_or_default();
             let mode = match img.fill_mode {
                 ImageFillMode::FitToSize => "FIT",
+                ImageFillMode::Total => "TOTAL",
                 ImageFillMode::Center => "CENTER",
                 _ => "TILE",
             };

--- a/tests/issue_937.rs
+++ b/tests/issue_937.rs
@@ -130,6 +130,34 @@ fn issue_937_f081c_filler_should_not_render_as_text() {
 }
 
 #[test]
+fn issue_937_f02fc_callout_bullet_should_render_as_pointer() {
+    assert_eq!(
+        expand_pua_render_text("\u{F02FC} 전자서명"),
+        "► 전자서명",
+        "U+F02FC 한컴 PUA callout bullet 는 missing glyph 대신 right pointer 로 표시되어야 함",
+    );
+    assert_eq!(
+        pua_to_display_text('\u{F02FC}').as_deref(),
+        Some("►"),
+        "CharOverlap/display helper 도 같은 U+F02FC 표시 문자열을 반환해야 함",
+    );
+}
+
+#[test]
+fn issue_937_f031c_toc_bullet_should_render_as_square() {
+    assert_eq!(
+        expand_pua_render_text("\u{F031C} 행정업무"),
+        "■ 행정업무",
+        "U+F031C 한컴 PUA TOC bullet 는 missing glyph 대신 black square 로 표시되어야 함",
+    );
+    assert_eq!(
+        pua_to_display_text('\u{F031C}').as_deref(),
+        Some("■"),
+        "CharOverlap/display helper 도 같은 U+F031C 표시 문자열을 반환해야 함",
+    );
+}
+
+#[test]
 fn issue_937_svg_renders_f012b_as_signature_seal() {
     let bytes = read_bokhakwonseo();
     let doc = HwpDocument::from_bytes(&bytes).expect("parse samples/복학원서.hwp");

--- a/tests/render_p22_web_canvas_contract.rs
+++ b/tests/render_p22_web_canvas_contract.rs
@@ -48,3 +48,25 @@ fn web_canvas_control_code_group_labels_follow_active_replay_plane() {
         "layer group labels should use the replay-plane gate"
     );
 }
+
+#[test]
+fn web_canvas_decodes_bitmap_bytes_before_html_image_fallback() {
+    assert!(
+        WEB_CANVAS_SOURCE.contains("fn decode_image_to_canvas(data: &[u8])"),
+        "WebCanvas should have a synchronous bitmap decode path"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("put_image_data(&image_data, 0.0, 0.0)"),
+        "decoded image bytes should be copied into an offscreen canvas"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains("draw_image_with_html_canvas_element_and_dw_and_dh"),
+        "full-image drawing should paint the decoded canvas before HtmlImage fallback"
+    );
+    assert!(
+        WEB_CANVAS_SOURCE.contains(
+            "draw_image_with_html_canvas_element_and_sw_and_sh_and_dx_and_dy_and_dw_and_dh"
+        ),
+        "cropped-image drawing should paint the decoded canvas before HtmlImage fallback"
+    );
+}

--- a/tests/visual_roundtrip_baseline.rs
+++ b/tests/visual_roundtrip_baseline.rs
@@ -35,12 +35,7 @@ const VISUAL_XFAIL: &[(&str, &str)] = &[
     // (<hp:ole binaryItemIDRef>) 직렬화 정정으로 다수 PASS 승격됨.
     // k-water-rfp(대형 복합)도 #1637 페이지네이션 IR-invisible 변동 수정으로 PASS 승격(제거).
     // opengov 실문서 말뭉치(Task #1564) 신규 편입분은 #1567 직렬화 정정으로 구조 불일치 3건
-    // 모두 PASS 승격됨. 잔여: 36392900(라운드트립 변위 드리프트 — base serializer 와 동일,
-    // PR #1586 무관 / 본질 정정은 별도 이슈).
-    (
-        "opengov/36392900_결재문서본문_일일굴착복구공사현황보고.hwpx",
-        "최대 변위 1.32px > 임계 0.5px (직렬화 라운드트립 드리프트)",
-    ),
+    // 모두 PASS 승격됨. 36392900은 matrix-positioned textbox reflow 정정으로 PASS 승격(제거).
 ];
 
 /// 검사 제외 — 샘플 자체가 HWPX 패키지가 아님(HWP5 가 .hwpx 확장자로 저장됨).


### PR DESCRIPTION
#1676~#1683을 `upstream/devel`(#1691 이후) 기준으로 `git cherry-pick -x` 일괄 적용한 통합 PR입니다.

Supersedes #1676 #1677 #1678 #1679 #1680 #1681 #1682 #1683

## 적용 범위

- #1676 HWPX image payload 정규화
- #1677 renderer font metrics/weight 보존
- #1678 browser canvas image replay 안정화
- #1679 HWPX connector line shape 파싱
- #1680 HWPX PUA glyph/line-break 매핑
- #1681 matrix-positioned group textbox 재조판
- #1682 master-page furniture plane replay
- #1683 pagination fit에서 각주 영역 예약

## 충돌 및 maintainer 보강

- #1683의 `src/renderer/typeset.rs` 충돌은 #1691 page-fit 보정을 유지하면서 각주 reserve 변경을 함께 살려 해결했습니다.
- PR #1676 TIFF image resolver contract 테스트를 보강했습니다.
- PR #1681의 `shape_layout.rs` test module 위치를 clippy `items_after_test_module` 규칙에 맞게 조정했습니다.
- PR #1676~#1683 review 문서를 `mydocs/pr/archives/`에 포함했습니다.

## 검증

- `cargo build --release`
- `cargo test --release --lib` (2037 passed, 0 failed, 7 ignored)
- `cargo test --profile release-test --tests`
- `cargo fmt --check`
- `git diff --check`
- `cargo clippy --all-targets -- -D warnings` (최종 재실행 17m 28s, warning 0)
- `cargo test --doc` (0 passed, 0 failed, 1 ignored)
- `cargo test --test svg_snapshot` (8 passed)
- `cargo test --profile release-test --test visual_roundtrip_baseline` (3 passed)
- `cargo test --profile release-test --tests page_count` (필터 매칭 26개 통과)
- `cd rhwp-studio && npx tsc --noEmit`
- `cd rhwp-studio && npm test` (153 passed)
- `wasm-pack build --target web --out-dir pkg`
- `python3 scripts/task1274_visual_sweep.py --target all`: 15개 target 모두 SVG/PDF page count 일치, mismatch 0건
- `pdfinfo 'pdf/2025 행정업무운영 편람(최종)-2024.pdf'`: 383쪽
- `./target/release/rhwp info 'samples/2025 행정업무운영 편람(최종).hwp'`: 383쪽
- `./target/release/rhwp info 'samples/2025 행정업무운영 편람(최종).hwpx'`: 383쪽

## 후속 확인

`visual_sweep`에서 page count mismatch는 없지만 flagged 후보 5개 target이 남았습니다. #1683에 상세 코멘트로 남겨 후속 시각 보정을 요청했습니다.
