### PR TITLE
docs: #1704/#1709 후속 처리 기록

### DIFF
--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -13,10 +13,11 @@
 | PR | 내용 | 처리 |
 |----|------|------|
 | #1691 | `task 1672: 행정업무 편람 페이지 수를 PDF 기준과 맞춤` | collaborator self-merge 후보. `mydocs/pr/archives/pr_1691_review.md`, `mydocs/pr/archives/pr_1691_review_impl.md` 작성 후 PR head push |
+| #1704 | `humdrum PR #1676~#1683 일괄 통합` | Build & Test / CodeQL / Canvas visual diff 통과 후 merge. 원 PR #1676~#1683은 superseded close 처리 |
 | #1709 | `task 1707: 행/열 바꿈 복사 붙여넣기 명칭 정리` | 최신 head 기준 Build & Test / CodeQL / Canvas visual diff 통과 후 merge. #1707 자동 close 미동작으로 수동 close |
 
 ## 확인 필요
 
 - PR #1691 최신 head 기준 GitHub Actions 통과 확인
-- 겹침 PR #1690/#1688/#1683/#1170과 merge 순서 확인
+- 겹침 PR #1690/#1688/#1170과 merge 순서 확인
 - 작업지시자 merge 승인 후 #1672 자동 close 여부 확인

--- a/mydocs/orders/20260630.md
+++ b/mydocs/orders/20260630.md
@@ -6,12 +6,14 @@
 |------|--------|------|------|
 | #1664 | Actions cache quota/read-only 해소 및 PR cache 저장 정책 정리 | 진행중 | Stage 3 및 최종 보고서 작성, 최종 승인 대기 |
 | #1672 | 2025 행정업무운영 편람 전체 페이지 수를 PDF 기준과 정합 | PR review 문서 작성 | PR #1691 생성 완료. HWP/HWPX/PDF 383쪽 정합 확인, review 문서와 오늘할일을 PR head 에 포함해 remote push 진행 |
+| #1707 | #1634 후속: 전치 복사/붙여넣기 명칭을 행/열 바꿈 복사/붙여넣기로 정리 | 완료 | PR #1709 merge 완료, merge commit `8461b0ad2`, 이슈 수동 close 완료 |
 
 ## PR 처리
 
 | PR | 내용 | 처리 |
 |----|------|------|
 | #1691 | `task 1672: 행정업무 편람 페이지 수를 PDF 기준과 맞춤` | collaborator self-merge 후보. `mydocs/pr/archives/pr_1691_review.md`, `mydocs/pr/archives/pr_1691_review_impl.md` 작성 후 PR head push |
+| #1709 | `task 1707: 행/열 바꿈 복사 붙여넣기 명칭 정리` | 최신 head 기준 Build & Test / CodeQL / Canvas visual diff 통과 후 merge. #1707 자동 close 미동작으로 수동 close |
 
 ## 확인 필요
 

--- a/mydocs/report/task_m100_1707_report.md
+++ b/mydocs/report/task_m100_1707_report.md
@@ -34,3 +34,14 @@
 ## 4. 결론
 
 기능 동작은 유지하고, 사용자에게 노출되는 명칭을 #1707 기준으로 정리했다.
+
+## 5. PR 및 후속 처리
+
+- PR: edwardkim/rhwp#1709
+- merge commit: `8461b0ad2b257163266eac9ece3f30dc70f5073c`
+- merge 시각: 2026-06-30 23:38 KST
+- 최신 head `61cd8adc29a8266e1fc3f5aa1ba76475313ea958` 기준 GitHub Actions 통과
+  - Build & Test
+  - CodeQL
+  - Canvas visual diff / Render Diff preflight
+- #1707은 `Closes #1707` 자동 close가 동작하지 않아 수동 close 처리했다.


### PR DESCRIPTION
## 개요

#1704, #1709 merge 이후 후속 처리 기록을 보강합니다.

## 변경 내용

- 오늘할일에 #1704 통합 merge 및 #1676~#1683 superseded close 처리 기록 추가
- 오늘할일의 확인 필요 목록에서 이미 close 처리된 #1683 제거
- #1707 최종 보고서에 PR #1709 merge commit, CI 통과, 수동 close 결과 기록
- 오늘할일에 #1707/#1709 처리 결과 추가

## 검증

- `git diff --check`

문서 전용 변경입니다.
