### PR TITLE
docs: PR #1714 후속 처리 기록

### DIFF
--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1658 | 페이지네이션 정밀화 round 2/3 통합 반영 | 코드 merge 완료 / 후속 문서 PR 처리 | 외부 PR #1688/#1690을 `upstream/devel` 기준 통합 cherry-pick 브랜치 `codex/m100-1658-pr1688-1690`에 반영 후 #1712로 merge. 원 PR #1688/#1690은 supersede comment 후 close 완료 |
+| #1706 | block/tac 표 사이·뒤 빈 문단 누락(rhwp_pNone) 수정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1714 merge 완료. auto-close 실패로 #1706 수동 close |
 
 ## PR 처리
 
@@ -12,6 +13,7 @@
 |----|------|------|
 | #1688 | #1658 round 2: continuation cut 정합 + COM 행높이/클리핑 게이트 | #1690과 함께 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1688_review.md` |
 | #1690 | #1658 round 3: 중첩 표 셀 세로정렬 over-count 정정 | #1688 선행 후 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1690_review.md` |
+| #1714 | #1706 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수 | CI 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1714_review.md` |
 
 ## 후속 확인
 
@@ -19,3 +21,6 @@
 - #1688 후속 comment: https://github.com/edwardkim/rhwp/pull/1688#issuecomment-4845818362
 - #1690 후속 comment: https://github.com/edwardkim/rhwp/pull/1690#issuecomment-4845818372
 - #1658은 후속 block-continuation 정합 작업이 남아 있으므로 자동 close 대상 아님
+- #1714 merge commit: `1314b90f0e51fb38464bfd9216a8c615eec72be8`
+- #1714 후속 comment: https://github.com/edwardkim/rhwp/pull/1714#issuecomment-4851436454
+- #1706 close comment: https://github.com/edwardkim/rhwp/issues/1706#issuecomment-4851434898

--- a/mydocs/pr/archives/pr_1714_review.md
+++ b/mydocs/pr/archives/pr_1714_review.md
@@ -1,0 +1,92 @@
+# PR #1714 리뷰 — #1706 표 직후 빈 문단 rhwp_pNone 수정
+
+- PR: #1714 `Task #1706: 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수`
+- 작성자: @planet6897
+- 기준: `devel`
+- 검토 대상 head: `352713dce4c4d97cbbefb7965f60dc049412dccd` (문서 작성 시점 참고값)
+- 규모: 5 files, +97/-2
+- 관련 이슈: #1706
+- 처리 결과: merge 완료, merge commit `1314b90f0e51fb38464bfd9216a8c615eec72be8`
+- 관련 이슈 처리: #1706 수동 close 완료 (`2026-07-01T07:22:43Z`)
+
+## 변경 요약
+
+블록 표(`treat_as_char`/TopAndBottom) 직후 또는 쪽나누기 직전의 빈 문단이 `TypesetEngine`에서
+fit 실패 시 `continue`로 드롭되어 `dump-pages` 문단→페이지 매핑에서 `rhwp_pNone`으로 남던 문제를
+수정한다.
+
+핵심 변경은 `src/renderer/typeset.rs`의 빈 문단 fit 실패 분기 2곳이다.
+
+- `next_will_vpos_reset` 경로: `!(height_fits && vpos_fits)`일 때 빈 문단을 드롭하지 않음
+- Task #967 force-break 경로: `empty_h_px > avail`일 때 빈 문단을 드롭하지 않음
+
+두 경로 모두 `hidden_empty_paras`에 문단을 등록하고 `PageItem::FullParagraph`를 현재 페이지에 추가한다.
+`layout.rs`의 기존 hidden empty paragraph 처리에 의해 높이 증가는 0으로 유지되므로, 페이지 advance 없이
+문단 매핑만 보존하는 방향이다.
+
+## 변경 범위
+
+- 코드: `src/renderer/typeset.rs`
+- 검증 샘플:
+  - `samples/task1706/empty_para_between_tac_tables.hwp`
+  - `samples/task1706/empty_para_before_pagebreak.hwpx`
+  - `samples/task1706/README.md`
+- 보고서: `mydocs/report/task_m100_1706_report.md`
+
+## 로컬 검증
+
+임시 worktree `/tmp/rhwp-pr1714-review`에서 PR head를 가져와 검증했다.
+
+- `git merge upstream/devel --no-commit --no-ff`: 충돌 없음 (`Already up to date`)
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp`: 통과
+- `rhwp dump-pages samples/task1706/empty_para_between_tac_tables.hwp`: 2 pages, `FullParagraph pi=3 "(빈)"` 확인
+- `rhwp dump-pages samples/task1706/empty_para_before_pagebreak.hwpx`: 3 pages, `FullParagraph pi=3 "(빈)"` 확인
+- 관련 회귀 subset:
+  - `issue_1488_rowbreak_empty_overlay_pages`
+  - `issue_1549`
+  - `issue_676_trailing_empty_para`
+  - `issue_703`
+  - `issue_1070_tac_table_post_text_overflow`
+  - `issue_rowbreak_chart_overlap`
+  - 결과: 32 passed
+- `cargo fmt --check`: 통과
+- `git diff --check upstream/devel...HEAD`: 통과
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --tests`: 통과
+  - `real 334.90`
+
+## GitHub Actions
+
+PR head `352713dce4c4d97cbbefb7965f60dc049412dccd` 기준:
+
+- CI preflight: success
+- Render Diff preflight: success
+- Canvas visual diff: success
+- CodeQL preflight / Analyze: success
+- Build & Test: success (`2026-07-01T07:20:44Z`)
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+코드 변경은 문제 경로 2곳에 국한되어 있고, 기존 hidden empty paragraph 레이아웃 시맨틱을 재사용한다.
+동봉 샘플 2건에서 `pi=3` 빈 문단이 페이지 매핑에 복구되는 것을 확인했으며, 관련 빈 문단·TAC·rowbreak
+회귀 subset과 전체 integration test도 통과했다.
+
+## 리스크 / 후속 확인
+
+- PR에 Rust 자동 회귀 테스트 파일은 추가되지 않았다. 대신 실제 HWP/HWPX 샘플과 로컬 `dump-pages`
+  검증으로 동작을 확인했다.
+- `gh pr view --json closingIssuesReferences`에서는 #1706 auto-close 참조가 비어 있었다. PR 본문과 커밋에는
+  `closes #1706`가 있었지만 merge 후에도 이슈가 open 상태라 수동 close 처리했다.
+
+## 최종 판단
+
+수용 완료. GitHub `Build & Test`가 최신 head 기준 성공했고, 로컬 검증도 통과했으므로 #1714를 merge했다.
+
+최종 처리 결과:
+
+- PR #1714 merge 완료: `1314b90f0e51fb38464bfd9216a8c615eec72be8`
+- merge 시각: `2026-07-01T07:22:13Z`
+- PR 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1714#issuecomment-4851436454
+- #1706 auto-close 실패 확인 후 수동 close 완료
+- #1706 close comment: https://github.com/edwardkim/rhwp/issues/1706#issuecomment-4851434898

--- a/mydocs/pr/archives/pr_1714_review_impl.md
+++ b/mydocs/pr/archives/pr_1714_review_impl.md
@@ -1,0 +1,123 @@
+# PR #1714 처리 계획 — #1706 빈 문단 0-높이 흡수 반영
+
+## 대상
+
+- PR: #1714
+- 작성자: @planet6897
+- Base: `devel`
+- Head: `task/m100-1706`
+- 검토 head: `352713dce4c4d97cbbefb7965f60dc049412dccd` (문서 작성 시점 참고값)
+- 관련 이슈: #1706
+- 처리 결과: #1714 merge 완료, #1706 수동 close 완료
+
+## 대상 커밋
+
+| 커밋 | 내용 |
+|---|---|
+| `761e20b15153` | #1706 코드 수정, 샘플, 보고서 추가 |
+| `352713dce4c4` | `devel` 최신화 merge commit |
+
+## 처리 단계
+
+1. PR head fetch
+   - `git fetch upstream pull/1714/head:local/pr1714`
+2. 임시 worktree 생성
+   - `/tmp/rhwp-pr1714-review`
+3. merge 시뮬레이션
+   - `git merge upstream/devel --no-commit --no-ff`
+   - 결과: 충돌 없음
+4. 로컬 동작 검증
+   - release-test binary build
+   - 동봉 샘플 2건 `dump-pages` 확인
+   - 관련 회귀 subset 실행
+   - 전체 integration test 실행
+5. 리뷰 문서 작성
+   - `mydocs/pr/pr_1714_review.md`
+   - `mydocs/pr/pr_1714_review_impl.md`
+6. merge 전 최종 확인
+   - GitHub Actions `Build & Test` 완료 확인
+   - 최신 head SHA 변동 여부 확인
+7. 승인 후 merge
+   - `gh pr merge 1714 --repo edwardkim/rhwp --merge --admin`
+8. 후속 처리
+   - #1706 close 상태 확인
+   - 필요 시 수동 close + 감사 코멘트
+   - PR #1714 감사 코멘트
+   - 리뷰 문서 `mydocs/pr/archives/` 이동
+
+## 최종 처리 기록
+
+- PR #1714 merge: 완료
+- merge commit: `1314b90f0e51fb38464bfd9216a8c615eec72be8`
+- merge 시각: `2026-07-01T07:22:13Z`
+- merged by: @jangster77
+- PR 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1714#issuecomment-4851436454
+- #1706 상태: auto-close 실패 후 수동 close 완료
+- #1706 close 시각: `2026-07-01T07:22:43Z`
+- #1706 close comment: https://github.com/edwardkim/rhwp/issues/1706#issuecomment-4851434898
+
+## 검증 기록
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp
+```
+
+- 결과: 통과
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1706/empty_para_between_tac_tables.hwp
+```
+
+- 결과: 2 pages, `FullParagraph pi=3 "(빈)"` 확인
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1706/empty_para_before_pagebreak.hwpx
+```
+
+- 결과: 3 pages, `FullParagraph pi=3 "(빈)"` 확인
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test \
+  --test issue_1488_rowbreak_empty_overlay_pages \
+  --test issue_1549 \
+  --test issue_676_trailing_empty_para \
+  --test issue_703 \
+  --test issue_1070_tac_table_post_text_overflow \
+  --test issue_rowbreak_chart_overlap \
+  -- --nocapture
+```
+
+- 결과: 32 passed
+
+```text
+cargo fmt --check
+git diff --check upstream/devel...HEAD
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --tests
+```
+
+- 결과: 모두 통과
+- 전체 integration test 시간: `real 334.90`
+
+## Merge 전 조건
+
+- 완료: PR head 최신 SHA 재확인 (`352713dce4c4d97cbbefb7965f60dc049412dccd`)
+- 완료: GitHub Actions `Build & Test` success 확인
+- 완료: 작업지시자 지시에 따라 merge 진행
+
+## 게시한 후속 코멘트
+
+```text
+@planet6897 감사합니다. PR #1714 머지 완료했습니다.
+
+검증 결과 요약:
+- 최신 head `352713dce4c4d97cbbefb7965f60dc049412dccd` 기준 GitHub Actions 통과 확인
+- merge simulation 충돌 없음
+- 동봉 샘플 2건에서 `FullParagraph pi=3 "(빈)"` 복구 확인
+- 관련 빈 문단/TAC/rowbreak 회귀 subset 32건 통과
+- `cargo test --profile release-test --tests` 통과
+
+#1706은 auto-close가 되지 않아 merge 후 수동으로 close 처리했습니다.
+merge commit: 1314b90f0e51fb38464bfd9216a8c615eec72be8
+
+감사합니다.
+```


### PR DESCRIPTION
## 개요

PR #1714 머지 후 `mydocs` 후속 문서를 반영합니다.

## 변경

- `mydocs/pr/archives/pr_1714_review.md` 추가
- `mydocs/pr/archives/pr_1714_review_impl.md` 추가
- `mydocs/orders/20260701.md`에 #1714/#1706 처리 내역 추가

## 처리 기록

- 대상 PR: #1714
- 관련 이슈: #1706
- merge commit: `1314b90f0e51fb38464bfd9216a8c615eec72be8`
- #1706: auto-close 실패 확인 후 수동 close 완료
- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1714#issuecomment-4851436454
- issue close comment: https://github.com/edwardkim/rhwp/issues/1706#issuecomment-4851434898

## 검증

- `git diff --check`
- 변경 범위: `mydocs/**` 문서-only

## CI

문서-only 후속 PR이므로 `mydocs/**` fast-pass 대상입니다. preflight 결과와 merge 가능 상태를 확인한 뒤 merge합니다.
