### PR TITLE
docs: PR #1715 후속 처리 기록

### DIFF
--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1658 | 페이지네이션 정밀화 round 2/3 통합 반영 | 코드 merge 완료 / 후속 문서 PR 처리 | 외부 PR #1688/#1690을 `upstream/devel` 기준 통합 cherry-pick 브랜치 `codex/m100-1658-pr1688-1690`에 반영 후 #1712로 merge. 원 PR #1688/#1690은 supersede comment 후 close 완료 |
+| #1705 | 어울림 표 트레일링 빈 문단 앵커/끝 페이지 귀속 정정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1715 merge 완료. auto-close 실패로 #1705 수동 close |
 | #1706 | block/tac 표 사이·뒤 빈 문단 누락(rhwp_pNone) 수정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1714 merge 완료. auto-close 실패로 #1706 수동 close |
 
 ## PR 처리
@@ -13,6 +14,7 @@
 |----|------|------|
 | #1688 | #1658 round 2: continuation cut 정합 + COM 행높이/클리핑 게이트 | #1690과 함께 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1688_review.md` |
 | #1690 | #1658 round 3: 중첩 표 셀 세로정렬 over-count 정정 | #1688 선행 후 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1690_review.md` |
+| #1715 | #1705 어울림 표 트레일링 빈 문단 sw 기반 앵커/끝 페이지 귀속 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1715_review.md` |
 | #1714 | #1706 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수 | CI 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1714_review.md` |
 
 ## 후속 확인
@@ -21,6 +23,9 @@
 - #1688 후속 comment: https://github.com/edwardkim/rhwp/pull/1688#issuecomment-4845818362
 - #1690 후속 comment: https://github.com/edwardkim/rhwp/pull/1690#issuecomment-4845818372
 - #1658은 후속 block-continuation 정합 작업이 남아 있으므로 자동 close 대상 아님
+- #1715 merge commit: `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9`
+- #1715 후속 comment: https://github.com/edwardkim/rhwp/pull/1715#issuecomment-4851883890
+- #1705 close comment: https://github.com/edwardkim/rhwp/issues/1705#issuecomment-4851881453
 - #1714 merge commit: `1314b90f0e51fb38464bfd9216a8c615eec72be8`
 - #1714 후속 comment: https://github.com/edwardkim/rhwp/pull/1714#issuecomment-4851436454
 - #1706 close comment: https://github.com/edwardkim/rhwp/issues/1706#issuecomment-4851434898

--- a/mydocs/pr/archives/pr_1715_review.md
+++ b/mydocs/pr/archives/pr_1715_review.md
@@ -1,0 +1,96 @@
+# PR #1715 리뷰 — #1705 어울림 표 트레일링 빈 문단 페이지 귀속 정정
+
+- PR: #1715 `Task #1705: 어울림 표 트레일링 빈 문단을 sw 기반으로 앵커/끝 페이지에 귀속`
+- 작성자: @planet6897
+- 기준: `devel`
+- 검토 대상 head: `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4` (문서 작성 시점 참고값)
+- 규모: 4 files, +98/-5
+- 관련 이슈: #1705
+- 문서 작성 시점 상태: `MERGEABLE`, GitHub `Build & Test` / CodeQL 진행 중
+- 처리 결과: 2026-07-01 `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9` merge 완료
+- 후속 처리: #1705 수동 close 완료, PR 감사 코멘트 완료
+
+## 변경 요약
+
+당초 #1705는 작은 표가 한글보다 과대분할된다는 이슈였지만, 후속 조사에서 실제 불일치는
+어울림(floating) 표 직후 빈 문단의 문단→페이지 귀속 문제로 재정의됐다. #1700은
+`wrap_around_paras`를 표의 마지막 페이지에 귀속했으나, 한글은 표 옆 wrap zone의 좁은 폭 빈 문단을
+표의 첫(앵커) 페이지에 둔다.
+
+이번 PR은 `src/document_core/queries/rendering.rs`의 `dump_page_items()` 표면화 로직을 수정한다.
+
+- 표 문단의 첫 출현 페이지 `item_first_page` 매핑 추가
+- wrap 문단의 첫 `line_seg.segment_width`를 px로 변환
+- `segment_width < body_area.width * 0.9`이면 wrap zone으로 보고 표의 첫 페이지에 귀속
+- 그 외 전체폭 문단은 기존처럼 표의 마지막 페이지에 귀속
+
+레이아웃/페이지네이션 변경이 아니라 `dump-pages` / `dump_page_items()` 쿼리 출력의 페이지 매핑 정정이다.
+
+## 변경 범위
+
+- 코드: `src/document_core/queries/rendering.rs`
+- 검증 샘플:
+  - `samples/task1705/wrap_empty_para_anchor_page.hwp`
+  - `samples/task1705/README.md`
+  - 기존 대비 케이스: `samples/task1700/myeonjeok_wrap_10page.hwp`
+- 보고서: `mydocs/report/task_m100_1705_report.md`
+
+## 로컬 검증
+
+임시 worktree `/private/tmp/rhwp-pr1715-review`에서 PR head를 가져와 검증했다.
+
+- `git merge upstream/devel --no-commit --no-ff`: 충돌 없음 (`Already up to date`)
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp`: 통과
+- `rhwp dump-pages samples/task1705/wrap_empty_para_anchor_page.hwp`: 2 pages, page 1에 `WrapAroundPara pi=2 table_pi=1 "(빈)"` 확인
+- `rhwp dump-pages samples/task1700/myeonjeok_wrap_10page.hwp`: 10 pages, page 10에 `WrapAroundPara pi=2 table_pi=1 "(빈)"` 유지 확인
+- `rhwp dump-pages samples/task1700/byeolpyo1_uujeong_wrap_singlepage.hwp`: 1 page, 단일 페이지 표의 `WrapAroundPara pi=2` 유지 확인
+- 관련 회귀 subset:
+  - `issue_1139_inline_picture_duplicate`
+  - `issue_1488_rowbreak_empty_overlay_pages`
+  - `issue_643`
+  - `page_number_propagation`
+  - 결과: 89 passed
+- `cargo fmt --check`: 통과
+- `git diff --check upstream/devel...HEAD`: 통과
+
+## GitHub Actions
+
+최종 merge 전 PR head `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4` 기준:
+
+- Render Diff preflight: success
+- Canvas visual diff: success
+- CodeQL preflight: success
+- CodeQL Analyze: success
+- CI preflight: success
+- Build & Test: success (`28500953207`)
+- WASM Build: skipped
+
+중간 커밋 `9d0b98b1da4cb4c296ee4c5e2d76f9d890419198`의 오래된 Actions run은 취소 처리했다.
+
+- Render Diff: cancelled
+- CodeQL: cancelled
+- CI: cancelled
+
+최종 merge 전 최신 head 기준 GitHub Actions 통과를 확인했다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+변경은 `dump_page_items()`의 표면화 페이지 선택에 한정되어 있고, 동봉 샘플에서 앵커 페이지 귀속과
+기존 표-끝 페이지 귀속이 모두 확인됐다. 관련 wrap/query 회귀 subset도 통과했다.
+
+## 리스크 / 후속 확인
+
+- PR에 Rust 자동 회귀 테스트 파일은 추가되지 않았다. 실제 HWP 샘플과 로컬 `dump-pages` 검증으로 동작을 확인했다.
+- `closingIssuesReferences`가 비어 있어 #1705 auto-close가 실패했다. merge 후 수동 close 처리했다.
+- 최신 head의 GitHub `Build & Test`와 CodeQL 통과 확인 후 merge했다.
+
+## 최종 판단
+
+수용 및 merge 완료.
+
+- PR merge: https://github.com/edwardkim/rhwp/pull/1715
+- merge commit: `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9`
+- #1705 close comment: https://github.com/edwardkim/rhwp/issues/1705#issuecomment-4851881453
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1715#issuecomment-4851883890

--- a/mydocs/pr/archives/pr_1715_review_impl.md
+++ b/mydocs/pr/archives/pr_1715_review_impl.md
@@ -1,0 +1,138 @@
+# PR #1715 처리 계획 — #1705 wrap 빈 문단 first/last 페이지 귀속 정정
+
+## 대상
+
+- PR: #1715
+- 작성자: @planet6897
+- Base: `devel`
+- Head: `task/m100-1705`
+- 검토 head: `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4` (문서 작성 시점 참고값)
+- 관련 이슈: #1705
+
+## 대상 커밋
+
+| 커밋 | 내용 |
+|---|---|
+| `dcb37eef178f` | #1705 코드 수정, 샘플, 보고서 추가 |
+| `e0c740d6c10c` | `devel` 최신화 merge commit |
+| `9d0b98b1da4c` | `devel` 최신화 merge commit |
+| `17fee877b0de` | `devel` 최신화 merge commit |
+
+## 처리 단계
+
+1. PR head fetch — 완료
+   - `git fetch upstream pull/1715/head:local/pr1715`
+2. 임시 worktree 생성 — 완료
+   - `/private/tmp/rhwp-pr1715-review`
+3. merge 시뮬레이션 — 완료
+   - `git merge upstream/devel --no-commit --no-ff`
+   - 결과: 충돌 없음
+4. 로컬 동작 검증 — 완료
+   - release-test binary build
+   - 동봉 샘플과 #1700 대비 샘플 `dump-pages` 확인
+   - 관련 query/wrap 회귀 subset 실행
+5. 중간 커밋 Actions 정리 — 완료
+   - `9d0b98b1da4cb4c296ee4c5e2d76f9d890419198`의 stale Actions run cancel/force-cancel
+6. 리뷰 문서 작성 — 완료
+   - `mydocs/pr/pr_1715_review.md`
+   - `mydocs/pr/pr_1715_review_impl.md`
+7. merge 전 최종 확인 — 완료
+   - GitHub Actions `Build & Test` / CodeQL 완료 확인
+   - 최신 head SHA 변동 여부 확인
+8. 승인 후 merge — 완료
+   - `gh pr merge 1715 --repo edwardkim/rhwp --merge --admin`
+9. 후속 처리 — 완료
+   - #1705 close 상태 확인
+   - 필요 시 수동 close + 감사 코멘트
+   - PR #1715 감사 코멘트
+   - 리뷰 문서 `mydocs/pr/archives/` 이동
+   - 오늘할일 갱신
+
+## 검증 기록
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp
+```
+
+- 결과: 통과
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1705/wrap_empty_para_anchor_page.hwp
+```
+
+- 결과: 2 pages, page 1에 `WrapAroundPara pi=2 table_pi=1 "(빈)"` 확인
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1700/myeonjeok_wrap_10page.hwp
+```
+
+- 결과: 10 pages, page 10에 `WrapAroundPara pi=2 table_pi=1 "(빈)"` 유지 확인
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1700/byeolpyo1_uujeong_wrap_singlepage.hwp
+```
+
+- 결과: 1 page, 단일 페이지 표의 `WrapAroundPara pi=2` 유지 확인
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test \
+  --test issue_1139_inline_picture_duplicate \
+  --test issue_1488_rowbreak_empty_overlay_pages \
+  --test issue_643 \
+  --test page_number_propagation \
+  -- --nocapture
+```
+
+- 결과: 89 passed
+
+```text
+cargo fmt --check
+git diff --check upstream/devel...HEAD
+```
+
+- 결과: 통과
+
+## Actions 정리 기록
+
+`9d0b98b1da4cb4c296ee4c5e2d76f9d890419198` 기준 stale run:
+
+| Workflow | Run ID | 처리 |
+|---|---:|---|
+| Render Diff | `28500880064` | cancelled |
+| CodeQL | `28500880275` | cancelled |
+| CI | `28500880237` | force-cancel 후 cancelled |
+
+최신 head `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4`의 CI run `28500953207`은 rerun 처리했다.
+
+## Merge 전 조건
+
+- PR head 최신 SHA 재확인: `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4`
+- GitHub Actions `Build & Test` / CodeQL success 확인: 완료
+- 작업지시자 merge 승인: 완료
+
+## Merge 및 후속 처리 기록
+
+- merge 시각: 2026-07-01 08:01:47Z
+- merge commit: `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9`
+- #1705 close 시각: 2026-07-01 08:04:08Z
+- #1705 close comment: https://github.com/edwardkim/rhwp/issues/1705#issuecomment-4851881453
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1715#issuecomment-4851883890
+
+## 게시한 PR 후속 코멘트
+
+```text
+@planet6897 감사합니다. PR #1715 머지 완료했습니다.
+
+검증 결과 요약:
+- 최신 head `17fee877b0deed7c4c5d72c9d63fd4527c67c4c4` 기준 GitHub Actions 통과 확인
+- merge simulation 충돌 없음
+- `wrap_empty_para_anchor_page.hwp`: `WrapAroundPara pi=2`가 page 1에 귀속 확인
+- `myeonjeok_wrap_10page.hwp`: 전체폭 대비 케이스가 page 10 유지 확인
+- 관련 query/wrap 회귀 subset 89건 통과
+
+중간 커밋 `9d0b98b1da4cb4c296ee4c5e2d76f9d890419198`의 stale Actions run은 모두 cancel 처리했습니다.
+#1705는 auto-close가 되지 않아 merge 후 수동으로 close 처리했습니다.
+merge commit: 3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9
+
+감사합니다.
+```


### PR DESCRIPTION
## 변경 내용
- PR #1715 리뷰 문서를 `mydocs/pr/archives/`에 보관했습니다.
- #1715 merge 결과, #1705 수동 close, PR 후속 코멘트 URL을 기록했습니다.
- `mydocs/orders/20260701.md`에 #1705/#1715 처리 내역을 추가했습니다.

## 대상
- 원 PR: #1715
- 관련 이슈: #1705
- merge commit: `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9`
- #1705 close comment: https://github.com/edwardkim/rhwp/issues/1705#issuecomment-4851881453
- #1715 후속 comment: https://github.com/edwardkim/rhwp/pull/1715#issuecomment-4851883890

## 검증
- 문서 전용 변경: `mydocs/**` only
- `git diff --cached --check`: 통과
- cargo 빌드/테스트: 문서-only 후속 처리라 생략