### PR TITLE
docs: PR #1717 후속 처리 기록

### DIFF
--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -5,6 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1658 | 페이지네이션 정밀화 round 2/3 통합 반영 | 코드 merge 완료 / 후속 문서 PR 처리 | 외부 PR #1688/#1690을 `upstream/devel` 기준 통합 cherry-pick 브랜치 `codex/m100-1658-pr1688-1690`에 반영 후 #1712로 merge. 원 PR #1688/#1690은 supersede comment 후 close 완료 |
+| #1716 | 반복 제목행 overhead 상단 연속 제목행 블록 제한 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1717 merge 완료. auto-close 실패로 #1716 수동 close |
 | #1705 | 어울림 표 트레일링 빈 문단 앵커/끝 페이지 귀속 정정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1715 merge 완료. auto-close 실패로 #1705 수동 close |
 | #1706 | block/tac 표 사이·뒤 빈 문단 누락(rhwp_pNone) 수정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1714 merge 완료. auto-close 실패로 #1706 수동 close |
 
@@ -14,6 +15,7 @@
 |----|------|------|
 | #1688 | #1658 round 2: continuation cut 정합 + COM 행높이/클리핑 게이트 | #1690과 함께 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1688_review.md` |
 | #1690 | #1658 round 3: 중첩 표 셀 세로정렬 over-count 정정 | #1688 선행 후 통합 cherry-pick PR #1712로 반영 완료. 리뷰 문서: `mydocs/pr/archives/pr_1690_review.md` |
+| #1717 | #1716 반복 제목행 overhead 를 상단 연속 제목행 블록으로 제한 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1717_review.md` |
 | #1715 | #1705 어울림 표 트레일링 빈 문단 sw 기반 앵커/끝 페이지 귀속 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1715_review.md` |
 | #1714 | #1706 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수 | CI 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1714_review.md` |
 
@@ -23,6 +25,9 @@
 - #1688 후속 comment: https://github.com/edwardkim/rhwp/pull/1688#issuecomment-4845818362
 - #1690 후속 comment: https://github.com/edwardkim/rhwp/pull/1690#issuecomment-4845818372
 - #1658은 후속 block-continuation 정합 작업이 남아 있으므로 자동 close 대상 아님
+- #1717 merge commit: `5e3b1ec652fda14a74af7cf9afd77962e3bb7903`
+- #1717 후속 comment: https://github.com/edwardkim/rhwp/pull/1717#issuecomment-4852334183
+- #1716 close comment: https://github.com/edwardkim/rhwp/issues/1716#issuecomment-4852331846
 - #1715 merge commit: `3f22b8dd0919d82dbd9c89a8ade73249fe7a04b9`
 - #1715 후속 comment: https://github.com/edwardkim/rhwp/pull/1715#issuecomment-4851883890
 - #1705 close comment: https://github.com/edwardkim/rhwp/issues/1705#issuecomment-4851881453

--- a/mydocs/pr/archives/pr_1717_review.md
+++ b/mydocs/pr/archives/pr_1717_review.md
@@ -1,0 +1,84 @@
+# PR #1717 리뷰 — #1716 반복 제목행 overhead 누적 폭주 수정
+
+- PR: #1717 `Task #1716: 반복 제목행 overhead 를 상단 연속 제목행 블록으로 제한 (페이지당 1행 폭주 수정)`
+- 작성자: @planet6897
+- 기준: `devel`
+- 검토 대상 head: `3c449d3935b0d2e3b79f3c9367656e313712cb85` (문서 작성 시점 참고값)
+- 규모: 13 files, +406/-23
+- 관련 이슈: #1716
+- 문서 작성 시점 상태: `MERGEABLE`, `mergeStateStatus=BLOCKED` (`Build & Test` 진행 중)
+- 처리 결과: 2026-07-01 `5e3b1ec652fda14a74af7cf9afd77962e3bb7903` merge 완료
+- 후속 처리: #1716 수동 close 완료, PR 감사 코멘트 완료
+
+## 변경 요약
+
+다수 행에 `header="1"`이 흩어진 RowBreak 표에서 반복 제목행 overhead가 cursor 전진마다 누적되어
+페이지당 1행만 배치되는 폭주를 정정한다. 대표 샘플은 173쪽에서 53쪽으로 줄어 한글 52쪽에 근접한다.
+
+핵심 변경은 반복 제목행을 `is_header` 전체가 아니라 표 상단부터 연속된 제목행 블록으로 제한하는 것이다.
+
+- `src/model/table.rs`: `Table::leading_header_rows()` 추가
+- `src/model/table/tests.rs`: 상단 연속 제목행, 흩어진 본문 header, rowspan header 단위테스트 추가
+- `src/renderer/typeset.rs`: `header_overhead` 계산을 `leading_header_rows()` 기반으로 변경
+- `src/renderer/layout/table_partial.rs`: 렌더러 반복 제목행도 같은 helper 사용
+- `samples/task1716/`: 재현 샘플과 README 추가
+
+## 로컬 검증
+
+임시 worktree `/private/tmp/rhwp-pr1717-review`에서 PR head를 가져와 검증했다.
+
+- `git merge upstream/devel --no-commit --no-ff`: 충돌 없음 (`Already up to date`)
+- cargo 검증 전 `/Users/tsjang/rhwp/target` 하위 항목 삭제
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp`: 통과
+- `/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1716/table_scattered_header_rowbreak.hwpx`: 53 pages 확인
+- 같은 dump에서 `pi=12` RowBreak 표 분할 확인:
+  - page 10: rows `0..6`
+  - page 11: rows `6..40`
+  - page 12: rows `40..86`
+  - page 13: rows `86..132`
+  - page 14: rows `132..176`
+  - page 15: rows `176..183`
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --lib leading_header_rows -- --nocapture`: 4 passed
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --test issue_rowbreak_chart_overlap -- --nocapture`: 20 passed
+- `CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo fmt --check`: 통과
+- `git diff --check upstream/devel...HEAD`: 통과
+
+## GitHub Actions
+
+최신 head `3c449d3935b0d2e3b79f3c9367656e313712cb85` 기준 문서 작성 시점:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Render Diff preflight: success
+- CodeQL: success
+- Analyze (javascript-typescript): success
+- Analyze (python): success
+- Analyze (rust): success
+- Canvas visual diff: success
+- WASM Build: skipped
+- Build & Test: success
+
+최종 merge 전 최신 head 기준 GitHub Actions 통과를 확인했다. `Build & Test`는 23분 1초 소요됐다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+페이지네이터와 렌더러가 같은 `leading_header_rows()` helper를 사용하므로 반복 제목행 계산의 양쪽 정합이
+맞는다. 본문 중간의 흩어진 `is_header` 행을 반복 제목행에서 제외하면서도, 상단 연속 다중 제목행과
+rowspan 제목행은 단위테스트로 보존했다.
+
+## 리스크 / 후속 확인
+
+- `closingIssuesReferences`가 비어 있어 #1716 auto-close가 실패했다. merge 후 수동 close 처리했다.
+- 최신 GitHub Actions `Build & Test`까지 통과 확인 후 merge했다.
+- 임시 worktree `/private/tmp/rhwp-pr1717-review`는 작업지시자 승인 후 제거 완료했다.
+
+## 최종 판단
+
+수용 및 merge 완료.
+
+- PR merge: https://github.com/edwardkim/rhwp/pull/1717
+- merge commit: `5e3b1ec652fda14a74af7cf9afd77962e3bb7903`
+- #1716 close comment: https://github.com/edwardkim/rhwp/issues/1716#issuecomment-4852331846
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1717#issuecomment-4852334183

--- a/mydocs/pr/archives/pr_1717_review_impl.md
+++ b/mydocs/pr/archives/pr_1717_review_impl.md
@@ -1,0 +1,125 @@
+# PR #1717 처리 계획 — #1716 반복 제목행 overhead 누적 폭주 수정
+
+## 대상
+
+- PR: #1717
+- 작성자: @planet6897
+- Base: `devel`
+- Head: `pr/devel-1716`
+- 검토 head: `3c449d3935b0d2e3b79f3c9367656e313712cb85` (문서 작성 시점 참고값)
+- 관련 이슈: #1716
+
+## 대상 커밋
+
+| 커밋 | 내용 |
+|---|---|
+| `7f6c770b84ad` | #1716 코드 수정, 단위테스트, 샘플, 작업 문서 추가 |
+| `8d259161e781` | `devel` 최신화 merge commit |
+| `3c449d3935b0` | `devel` 최신화 merge commit |
+
+## 처리 단계
+
+1. PR head fetch — 완료
+   - `git fetch upstream devel pull/1717/head:local/pr1717 --prune`
+2. 임시 worktree 생성 — 완료
+   - `/private/tmp/rhwp-pr1717-review`
+3. merge 시뮬레이션 — 완료
+   - `git merge upstream/devel --no-commit --no-ff`
+   - 결과: 충돌 없음 (`Already up to date`)
+4. 로컬 동작 검증 — 완료
+   - release-test binary build
+   - 재현 샘플 `dump-pages` 페이지 수 및 `pi=12` 분할 확인
+   - `leading_header_rows` 단위테스트
+   - 기존 rowbreak 통합 테스트
+   - `cargo fmt --check`
+   - `git diff --check`
+5. 리뷰 문서 작성 — 완료
+   - `mydocs/pr/pr_1717_review.md`
+   - `mydocs/pr/pr_1717_review_impl.md`
+6. merge 전 최종 확인 — 완료
+   - GitHub Actions `Build & Test` 완료 확인
+   - 최신 head SHA 변동 여부 확인
+7. 승인 후 merge — 완료
+   - `gh pr merge 1717 --repo edwardkim/rhwp --merge --admin`
+8. 후속 처리 — 완료
+   - #1716 close 상태 확인
+   - 필요 시 수동 close + 감사 코멘트
+   - PR #1717 감사 코멘트
+   - 리뷰 문서 `mydocs/pr/archives/` 이동
+   - 오늘할일 갱신
+9. worktree 정리 — 완료
+   - `/private/tmp/rhwp-pr1717-review` 제거는 작업지시자 승인 후 진행
+
+## 검증 기록
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo build --profile release-test --bin rhwp
+```
+
+- 결과: 통과
+
+```text
+/Users/tsjang/rhwp/target/release-test/rhwp dump-pages samples/task1716/table_scattered_header_rowbreak.hwpx
+```
+
+- 결과: 53 pages
+- `pi=12` 분할:
+  - page 10 rows `0..6`
+  - page 11 rows `6..40`
+  - page 12 rows `40..86`
+  - page 13 rows `86..132`
+  - page 14 rows `132..176`
+  - page 15 rows `176..183`
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --lib leading_header_rows -- --nocapture
+```
+
+- 결과: 4 passed
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo test --profile release-test --test issue_rowbreak_chart_overlap -- --nocapture
+```
+
+- 결과: 20 passed
+
+```text
+CARGO_INCREMENTAL=0 CARGO_TARGET_DIR=/Users/tsjang/rhwp/target cargo fmt --check
+git diff --check upstream/devel...HEAD
+```
+
+- 결과: 통과
+
+## Merge 전 조건
+
+- PR head 최신 SHA 재확인: `3c449d3935b0d2e3b79f3c9367656e313712cb85`
+- GitHub Actions `Build & Test` success 확인: 완료
+- 작업지시자 merge 승인: 완료
+
+## Merge 및 후속 처리 기록
+
+- merge 시각: 2026-07-01 08:49:02Z
+- merge commit: `5e3b1ec652fda14a74af7cf9afd77962e3bb7903`
+- #1716 close 시각: 2026-07-01 08:49:33Z
+- #1716 close comment: https://github.com/edwardkim/rhwp/issues/1716#issuecomment-4852331846
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1717#issuecomment-4852334183
+- `/private/tmp/rhwp-pr1717-review`: 작업지시자 승인 후 제거 완료
+
+## 게시한 PR 후속 코멘트
+
+```text
+@planet6897 감사합니다. PR #1717 머지 완료했습니다.
+
+검증 결과 요약:
+- 최신 head `3c449d3935b0d2e3b79f3c9367656e313712cb85` 기준 GitHub Actions 통과 확인
+- merge simulation 충돌 없음
+- `table_scattered_header_rowbreak.hwpx`: 53 pages 확인
+- `pi=12` RowBreak 표가 page 10~15에 정상 분할되는 것 확인
+- `leading_header_rows` 단위테스트 4건 통과
+- 기존 rowbreak 통합 테스트 20건 통과
+
+#1716은 auto-close가 되지 않아 merge 후 수동으로 close 처리했습니다.
+merge commit: 5e3b1ec652fda14a74af7cf9afd77962e3bb7903
+
+감사합니다.
+```


### PR DESCRIPTION
## 요약
- #1717 리뷰 문서를 `mydocs/pr/archives/`로 보관했습니다.
- 2026-07-01 오늘할일 문서에 #1717 merge, #1716 수동 close, 후속 코멘트 링크를 기록했습니다.
- 코드 변경 없이 문서만 반영하는 후속 PR입니다.

## 연결
- 원 PR: #1717
- 원 이슈: #1716
- #1717 merge commit: 5e3b1ec652fda14a74af7cf9afd77962e3bb7903
- #1717 후속 comment: https://github.com/edwardkim/rhwp/pull/1717#issuecomment-4852334183
- #1716 close comment: https://github.com/edwardkim/rhwp/issues/1716#issuecomment-4852331846

## 검증
- `git diff --cached --check` 통과
- 변경 범위가 `mydocs/**` 문서에 한정되어 cargo 검증은 생략했습니다.
