### PR TITLE
docs: PR #1736 후속 기록

### DIFF
--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -13,6 +13,7 @@
 | #1706 | block/tac 표 사이·뒤 빈 문단 누락(rhwp_pNone) 수정 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1714 merge 완료. auto-close 실패로 #1706 수동 close |
 | #1664 | 최종 measurement mydocs 반영 문서 PR | 완료 | #1702 merge 후 cleanup/devel save/exact-hit 관측값 보존. 완료: 19:24 |
 | #1725 | 흐름 텍스트 각주 tail 문단 over-pagination 완화 | PR merge 완료 / 이슈 close 완료 / 후속 #1733 등록 | 외부 PR #1730 merge 완료. PDF 기준 242쪽 대비 258→250쪽 개선, 잔여 +8쪽은 #1733으로 분리 |
+| #1733 | 흐름 텍스트 국제고속선기준 잔여 over-pagination 다중 원인 추적 | 부분 PR merge 완료 / 이슈 open 유지 | 외부 PR #1736 merge 완료. HWPX 샘플 250→245쪽으로 추가 완화, PDF 기준 242쪽 대비 잔여 +3쪽은 계속 추적 |
 
 ## PR 처리
 
@@ -27,6 +28,7 @@
 | #1715 | #1705 어울림 표 트레일링 빈 문단 sw 기반 앵커/끝 페이지 귀속 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1715_review.md` |
 | #1714 | #1706 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수 | CI 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1714_review.md` |
 | #1730 | #1725 흐름 텍스트 각주 tail 문단 over-pagination 수정 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1730_review.md` |
+| #1736 | #1733 tail-before-vpos-reset over-pagination 추가 완화 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1736_review.md` |
 
 ## 후속 확인
 
@@ -62,3 +64,8 @@
 - #1733 후속 이슈: 흐름 텍스트 국제고속선기준 잔여 over-pagination(+8쪽) 다중 원인 추적
 - #1730 로컬 검증: PDF 기준 242쪽, 수정 전 258쪽, PR head 250쪽, near-empty 26→18, `cargo test --lib` 2044 passed
 - #1730 후속 기준 파일: `pdf/text_footnote_tail_overpagination-2024.pdf`, `samples/task1725/text_footnote_tail_overpagination.hwp`
+- #1736 merge commit: `342199af1be055f573f65aca3a48e3579feea726`
+- #1736 후속 comment: https://github.com/edwardkim/rhwp/pull/1736#issuecomment-4854743131
+- #1736 CI: Build & Test 18분 43초 통과, CodeQL / Render Diff / Canvas visual diff 통과
+- #1736 로컬 검증: HWPX 샘플 245쪽, HWP 기준 파일 244쪽, byeolpyo1 4쪽, byeolpyo4 26쪽, #1718 샘플 42쪽, `cargo test --lib` 2044 passed, `clippy --all-targets` 통과, `svg_snapshot` 8 passed
+- #1733은 부분 해결 이슈로 open 유지. PDF 기준 242쪽 대비 HWPX 잔여 +3쪽 계속 추적

--- a/mydocs/pr/archives/pr_1736_review.md
+++ b/mydocs/pr/archives/pr_1736_review.md
@@ -1,0 +1,110 @@
+# PR #1736 리뷰 — #1733 tail-before-vpos-reset over-pagination 추가 완화
+
+- PR: #1736 `Task #1733 (부분): 흐름 텍스트 tail-before-vpos-reset over-pagination 추가 완화 (250→245)`
+- 작성자: @planet6897
+- 기준 브랜치: `devel`
+- PR head: `9f541df2b48b8c5899267f7237e835710c853d3e` (문서 작성 시점 참고값)
+- 규모: 2 files, +88/-1
+- 관련 이슈: #1733
+- 문서 작성 시점 상태: `MERGEABLE`, `BLOCKED` (GitHub required check `Build & Test` 대기)
+- 처리 결과: 2026-07-01 `342199af1be055f573f65aca3a48e3579feea726` merge 완료
+- 후속 처리: #1733은 부분 해결 이슈이므로 open 유지, PR 감사 코멘트 완료
+
+## 변경 요약
+
+#1730 merge 후에도 국제고속선기준 HWPX 샘플이 기준 PDF 242쪽 대비 250쪽으로 남아 있던 문제 중,
+tail-before-vpos-reset 계열 일부를 추가 완화한다.
+
+핵심 변경은 `src/renderer/typeset.rs`에 한정된다.
+
+- tail 문단과 vpos-reset 문단 사이에 컨트롤 없는 빈 문단 1개가 끼어도 tail-before-vpos-reset으로 인식
+- tail-before-vpos-reset 일반 텍스트 문단에 한해 `TAIL_BREAK_OVERFLOW_TOLERANCE_PX=20.0`을 1회 적용
+- 기존 각주 안전마진 1회 완화와 함께, 각주가 없는 page-full tail over-fill 케이스도 좁게 완화
+
+문서 변경은 `mydocs/report/task_m100_1733_report.md` 추가다.
+
+## 변경 범위
+
+- 코드: `src/renderer/typeset.rs`
+- 보고서: `mydocs/report/task_m100_1733_report.md`
+
+PR에는 실제 기능 커밋 1개와 `devel` 동기화 merge commit 1개가 포함되어 있다.
+
+## 로컬 merge 검증
+
+`upstream/devel` 기준 merge 시뮬레이션 결과 충돌 없음.
+
+```bash
+git checkout -B local/pr1736-merge-test upstream/devel
+git merge local/pr1736 --no-commit --no-ff
+```
+
+결과: automatic merge 성공.
+
+## 페이지 수 검증
+
+PR head merge-test 코드 기준 `target/debug/rhwp dump-pages ... | grep -c global_idx` 결과:
+
+| 샘플 | 결과 |
+|------|------|
+| `samples/task1725/text_footnote_tail_overpagination.hwpx` | 245쪽 |
+| `samples/task1725/text_footnote_tail_overpagination.hwp` | 244쪽 |
+| `samples/byeolpyo1.hwp` | 4쪽 |
+| `samples/byeolpyo4.hwp` | 26쪽 |
+| `samples/task1718/table_giant_cell_overfill.hwp` | 42쪽 |
+
+PR 본문 재현 명령의 기준인 HWPX 샘플은 245쪽으로 확인됐다. 같은 기준 자료의 HWP 파일은 244쪽으로
+측정되어, 리뷰 문서에서는 HWPX와 HWP 결과를 구분해 기록한다.
+
+## 로컬 검증
+
+새 PR review 지침에 따라 cargo 검증 전 `target` 하위 항목을 삭제한 뒤 수행했다.
+
+- `CARGO_INCREMENTAL=0 cargo test --lib`: 2044 passed, 0 failed, 7 ignored, real 171.90s
+- `CARGO_INCREMENTAL=0 cargo build --bin rhwp`: 통과, real 18.30s
+- 샘플 page count 검증: 위 표와 같음
+- `cargo fmt --check`: 통과
+- `git diff --check`: 통과
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과, real 27.70s
+- `CARGO_INCREMENTAL=0 cargo test --test svg_snapshot`: 8 passed, 0 failed, real 17.15s
+
+## GitHub Actions
+
+문서 작성 시점 PR head `9f541df2b48b8c5899267f7237e835710c853d3e` 기준 참고값 및 merge 직전 재확인 결과:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Render Diff preflight: success
+- Canvas visual diff: success
+- Analyze (javascript-typescript): success
+- Analyze (python): success
+- Analyze (rust): success
+- CodeQL: success
+- WASM Build: skipped
+- Build & Test: success, 18m43s
+
+merge 직전 `MERGEABLE`, `CLEAN`, GitHub Actions 전부 성공을 확인했다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+완화 조건은 "현재 페이지에 이미 항목이 있고, 현재 문단이 visible text이며, 다음 또는 그 다음 문단이
+vpos-reset으로 새 페이지를 시작하는 tail"에 묶여 있다. `tail_overflow_tolerance_once`도 fit 계산에서
+소비되며 즉시 0으로 리셋되므로 지속 상태 누수 위험은 낮다.
+
+## 비차단 리스크
+
+- 기능 변경에 대응하는 새 단위 테스트는 추가되지 않았다. 다만 PR 본문이 의도한 대표 샘플 page count,
+  기존 `cargo test --lib`, `clippy --all-targets`, `svg_snapshot`은 로컬에서 통과했다.
+- #1733 전체 목표인 PDF 기준 242쪽에는 아직 도달하지 않는다. 본 PR은 250쪽에서 245쪽으로 줄이는
+  부분 완화이며, 잔여 +3쪽은 #1733 후속 범위로 남는다.
+
+## 최종 판단
+
+수용 및 merge 완료.
+
+- PR merge: https://github.com/edwardkim/rhwp/pull/1736
+- merge commit: `342199af1be055f573f65aca3a48e3579feea726`
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1736#issuecomment-4854743131
+- #1733: 부분 해결 이슈로 open 유지

--- a/mydocs/pr/archives/pr_1736_review_impl.md
+++ b/mydocs/pr/archives/pr_1736_review_impl.md
@@ -1,0 +1,105 @@
+# PR #1736 처리 계획 — #1733 tail-before-vpos-reset over-pagination 추가 완화
+
+## 대상
+
+- PR: #1736
+- 작성자: @planet6897
+- 관련 이슈: #1733
+- 문서 작성 시점 PR head: `9f541df2b48b8c5899267f7237e835710c853d3e`
+- 처리 판단: 수용 및 merge 완료
+- merge commit: `342199af1be055f573f65aca3a48e3579feea726`
+- PR 후속 comment: https://github.com/edwardkim/rhwp/pull/1736#issuecomment-4854743131
+
+## 커밋
+
+1. `4eba6367fca7913b8d73384e74b21b3179bff1a7`
+   - `Task #1733 (부분): tail-before-vpos-reset over-pagination 추가 완화 (250→245)`
+   - 실제 기능/보고서 변경 커밋
+2. `9f541df2b48b8c5899267f7237e835710c853d3e`
+   - `Merge branch 'devel' into pr/devel-1733`
+   - 최신 `devel` 동기화용 merge commit
+
+## 검토 단계
+
+### Stage 1. PR 메타 확인
+
+- base branch: `devel`
+- draft: false (작성 시점 참고값)
+- mergeable: `MERGEABLE` (작성 시점 참고값)
+- mergeStateStatus: `BLOCKED` (GitHub required check `Build & Test` 진행 중인 작성 시점 참고값)
+- maintainerCanModify: `true`
+- 규모: 2 files, +88/-1
+
+### Stage 2. merge 시뮬레이션
+
+완료.
+
+- `upstream/devel` 기준 `local/pr1736` 병합 시뮬레이션
+- 충돌 없음
+- 검증 후 merge-test 브랜치와 staged merge 상태 정리 완료
+
+### Stage 3. 변경 내용 검토
+
+완료.
+
+- `src/renderer/typeset.rs`에 tail-before-vpos-reset 빈 문단 관통 가드 추가
+- tail-before-vpos-reset fit 판정에서 20px overflow tolerance를 1회만 적용
+- `mydocs/report/task_m100_1733_report.md` 추가
+
+### Stage 4. 로컬 검증
+
+완료.
+
+- cargo 검증 전 `target` 하위 항목 삭제
+- `CARGO_INCREMENTAL=0 cargo test --lib`: 2044 passed, 0 failed, 7 ignored
+- `CARGO_INCREMENTAL=0 cargo build --bin rhwp`: 통과
+- `cargo fmt --check`: 통과
+- `git diff --check`: 통과
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과
+- `CARGO_INCREMENTAL=0 cargo test --test svg_snapshot`: 8 passed
+
+### Stage 5. 페이지 수 검증
+
+완료.
+
+- `samples/task1725/text_footnote_tail_overpagination.hwpx`: 245쪽
+- `samples/task1725/text_footnote_tail_overpagination.hwp`: 244쪽
+- `samples/byeolpyo1.hwp`: 4쪽
+- `samples/byeolpyo4.hwp`: 26쪽
+- `samples/task1718/table_giant_cell_overfill.hwp`: 42쪽
+
+### Stage 6. merge 전 대기 조건
+
+- GitHub Actions `Build & Test` 최종 success 확인 완료
+- 작업지시자 승인 완료
+
+### Stage 7. merge 및 후속 코멘트
+
+완료.
+
+- `gh pr merge 1736 --repo edwardkim/rhwp --merge --admin`
+- merge commit: `342199af1be055f573f65aca3a48e3579feea726`
+- `git merge --ff-only upstream/devel` 로 로컬 `devel` 동기화 완료
+- PR 후속 comment 완료: https://github.com/edwardkim/rhwp/pull/1736#issuecomment-4854743131
+- #1733은 부분 해결 이슈이므로 close하지 않고 open 유지
+
+## merge 후 필수 후속 처리
+
+`mydocs/manual/pr_review_workflow.md` 기준으로 처리한다.
+
+1. merge 직전 최신 GitHub Actions와 head SHA 재확인: 완료
+2. `gh pr merge 1736 --repo edwardkim/rhwp --merge --admin`: 완료
+3. `git checkout devel && git pull --ff-only upstream devel`: 완료
+4. 리뷰 문서를 `mydocs/pr/archives/`로 이동: 후속 문서 PR에 포함
+5. `mydocs/orders/20260701.md` 오늘할일에 #1736 처리 내용 반영: 후속 문서 PR에 포함
+6. #1733 이슈는 부분 해결이므로 close하지 않고 잔여 +3쪽 후속 범위 유지: 완료
+7. PR 감사 코멘트에는 250→245 확인, HWPX/HWP page count 구분, 잔여 #1733 계속 추적을 기록: 완료
+8. 리뷰 문서/오늘할일은 문서-only PR로 처리 후 merge: 진행 예정
+
+## 후속 코멘트 요지
+
+- PR head 기준 HWPX 샘플 245쪽 확인
+- 기준 HWP 파일은 244쪽으로 별도 확인
+- byeolpyo1/byeolpyo4/#1718 대표 샘플 무회귀 확인
+- 로컬 `test --lib`, `clippy --all-targets`, `svg_snapshot` 통과
+- #1733은 부분 해결이며 잔여 +3쪽은 계속 추적


### PR DESCRIPTION
## 요약

- PR #1736 merge 후속 기록을 반영합니다.
- `mydocs/pr/archives/pr_1736_review.md`와 `pr_1736_review_impl.md`를 추가합니다.
- `mydocs/orders/20260701.md`에 #1736 처리 내역을 기록합니다.

## 대상

- 대상 PR: #1736
- 관련 이슈: #1733
- merge commit: `342199af1be055f573f65aca3a48e3579feea726`
- #1733 상태: 부분 해결 이슈로 open 유지
- 후속 comment: https://github.com/edwardkim/rhwp/pull/1736#issuecomment-4854743131

## 검증

- `git diff --check`
- 문서-only 변경입니다.
