### PR TITLE
docs: PR #1738 후속 기록

### DIFF
--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -44,6 +44,42 @@ gh pr view N --repo edwardkim/rhwp --json additions,deletions,files,commits
 - **FIRST_TIME_CONTRIBUTOR**: 환영 인사 + 세심한 피드백 톤
 - **기존 기여자**: 이전 PR 컨텍스트 참고
 
+### 2.4 update branch 이후 이전 SHA CI 강제 취소
+
+PR 검토 중 contributor 또는 maintainer 가 `Update branch` / `devel` merge 로 PR head 를 갱신하면, 이전 head
+SHA 에서 시작된 GitHub Actions run 이 그대로 남아 새 head 의 required check 와 섞여 보일 수 있다. 이 경우
+다음 순서로 **이전 SHA run 만** 정리한다. 최신 PR head 의 CI 는 취소하지 않는다.
+
+1. 최신 PR head SHA 를 확인한다.
+
+```bash
+gh pr view N --repo edwardkim/rhwp --json headRefOid
+```
+
+2. 취소 대상이 되는 이전 SHA 의 run 을 확인한다.
+
+```bash
+gh run list --repo edwardkim/rhwp --commit <old-sha> \
+  --json databaseId,workflowName,status,conclusion,headSha,url --limit 20
+```
+
+3. `queued` / `pending` / `in_progress` run 은 일반 cancel 을 시도하지 않고, 처음부터 GitHub Actions
+   **force-cancel API** 로 취소한다.
+
+```bash
+gh api --method POST repos/edwardkim/rhwp/actions/runs/<run-id>/force-cancel
+```
+
+4. 최종 상태가 `status: completed`, `conclusion: cancelled` 인지 확인한다.
+
+```bash
+gh run list --repo edwardkim/rhwp --commit <old-sha> \
+  --json databaseId,workflowName,status,conclusion,headSha,url --limit 20
+```
+
+기록 예시: PR #1738 검토 중 이전 SHA `00bc0428173c9f413171f3b070c923089320d050` 의 CI/CodeQL run 은
+처음부터 `force-cancel` API 로 최종 `cancelled` 처리했다.
+
 ## 3. 리뷰 문서 작성
 
 maintainer 일반 경로에서는 각 PR 마다 리뷰 문서 2건을 active 경로에 작성한다.

--- a/mydocs/orders/20260701.md
+++ b/mydocs/orders/20260701.md
@@ -14,6 +14,7 @@
 | #1664 | 최종 measurement mydocs 반영 문서 PR | 완료 | #1702 merge 후 cleanup/devel save/exact-hit 관측값 보존. 완료: 19:24 |
 | #1725 | 흐름 텍스트 각주 tail 문단 over-pagination 완화 | PR merge 완료 / 이슈 close 완료 / 후속 #1733 등록 | 외부 PR #1730 merge 완료. PDF 기준 242쪽 대비 258→250쪽 개선, 잔여 +8쪽은 #1733으로 분리 |
 | #1733 | 흐름 텍스트 국제고속선기준 잔여 over-pagination 다중 원인 추적 | 부분 PR merge 완료 / 이슈 open 유지 | 외부 PR #1736 merge 완료. HWPX 샘플 250→245쪽으로 추가 완화, PDF 기준 242쪽 대비 잔여 +3쪽은 계속 추적 |
+| #1735 | 방점(U+302E/U+302F) dotted-circle 아티팩트 제거 | PR merge 완료 / 이슈 close 완료 / 후속 문서 PR 처리 | 외부 PR #1738 merge 완료. 한컴 기준 PDF와 rhwp PDF에서 선두 방점 독립 점 및 dotted-circle 제거 확인. `mydocs/manual/pr_review_workflow.md` force-cancel 절차 명문화 동반 |
 
 ## PR 처리
 
@@ -29,6 +30,7 @@
 | #1714 | #1706 표 직후 빈 문단 누락(rhwp_pNone) 수정 — drop 대신 0-높이 흡수 | CI 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1714_review.md` |
 | #1730 | #1725 흐름 텍스트 각주 tail 문단 over-pagination 수정 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1730_review.md` |
 | #1736 | #1733 tail-before-vpos-reset over-pagination 추가 완화 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1736_review.md` |
+| #1738 | #1735 방점(U+302E/U+302F) dotted-circle 아티팩트 제거 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1738_review.md`. 후속 문서-only PR에는 리뷰 문서/오늘할일/`pr_review_workflow.md` force-cancel 절차 변경을 함께 포함 |
 
 ## 후속 확인
 
@@ -69,3 +71,8 @@
 - #1736 CI: Build & Test 18분 43초 통과, CodeQL / Render Diff / Canvas visual diff 통과
 - #1736 로컬 검증: HWPX 샘플 245쪽, HWP 기준 파일 244쪽, byeolpyo1 4쪽, byeolpyo4 26쪽, #1718 샘플 42쪽, `cargo test --lib` 2044 passed, `clippy --all-targets` 통과, `svg_snapshot` 8 passed
 - #1733은 부분 해결 이슈로 open 유지. PDF 기준 242쪽 대비 HWPX 잔여 +3쪽 계속 추적
+- #1738 merge commit: `18720d08a63da6fb396a9ad1effbd01833cca300`
+- #1738 후속 comment: https://github.com/edwardkim/rhwp/pull/1738#issuecomment-4855097960
+- #1738 CI: Build & Test 19분 9초 통과, CodeQL / Render Diff / Canvas visual diff 통과
+- #1738 로컬 검증: `cargo test --lib` 2046 passed, `clippy --all-targets` 통과, `svg_snapshot` 8 passed, HWP 1쪽 확인, 한컴 기준 PDF/rhwp PDF 모두 dotted-circle 미출현
+- #1735 close comment: https://github.com/edwardkim/rhwp/issues/1735#issuecomment-4855097451

--- a/mydocs/pr/archives/pr_1738_review.md
+++ b/mydocs/pr/archives/pr_1738_review.md
@@ -1,0 +1,135 @@
+# PR #1738 리뷰 — #1735 방점(U+302E/U+302F) dotted-circle 아티팩트 제거
+
+- PR: #1738 `방점(U+302E/U+302F) 렌더 정합: dotted-circle 아티팩트 제거 (Refs #1735)`
+- 작성자: @johndoekim
+- 기준 브랜치: `devel`
+- PR head: `00dc17ef962b39e1248297e8c80e8dc7ddeb2da1` (문서 작성 시점 참고값)
+- 규모: 10 files, +258/-2
+- 관련 이슈: #1735
+- 검토 중 상태: `MERGEABLE`, `BLOCKED` (GitHub required check 진행 중)
+- 최종 처리: GitHub Actions 통과 후 admin merge 완료
+- merge commit: `18720d08a63da6fb396a9ad1effbd01833cca300`
+
+## 변경 요약
+
+한컴 기준 PDF에서는 선두 방점 `〮`(U+302E)이 독립된 가운데 점처럼 보이지만, rhwp 렌더링에서는 유니코드
+combining mark 특성 때문에 dotted-circle(U+25CC) placeholder가 함께 보이는 문제를 고친다.
+
+핵심 변경:
+
+- `src/renderer/composer.rs`
+  - 렌더 전용 `expand_pua_display_text` 경로에 `tone_mark_display` 추가
+  - U+302E → U+00B7, U+302F → U+205A로 표시용 치환
+- `src/renderer/layout/text_measurement.rs`
+  - U+302E/U+302F를 `is_narrow_punctuation`에 추가해 narrow advance로 측정
+- `src/renderer/composer/tests.rs`
+  - 렌더 치환 단위 테스트 추가
+- `samples/unicode/`
+  - 재현 HWP와 한컴 기준 PDF 추가
+- `mydocs/plans`, `mydocs/working`, `mydocs/report`
+  - #1735 작업 계획/단계/결과 기록 추가
+
+## 로컬 merge 검증
+
+`upstream/devel` 기준 merge 시뮬레이션 결과 충돌 없음.
+
+```bash
+git checkout -B local/pr1738-merge-test upstream/devel
+git merge local/pr1738 --no-commit --no-ff
+```
+
+결과: automatic merge 성공.
+
+## 로컬 검증
+
+새 PR review 지침에 따라 cargo 검증 전 `target` 하위 항목을 삭제한 뒤 수행했다.
+
+- `CARGO_INCREMENTAL=0 cargo test --lib`: 2046 passed, 0 failed, 7 ignored, real 162.48s
+- `cargo fmt --check`: 통과
+- `git diff --check`: 통과
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과, real 28.65s
+- `CARGO_INCREMENTAL=0 cargo test --test svg_snapshot`: 8 passed, 0 failed, real 17.51s
+- `CARGO_INCREMENTAL=0 cargo build --bin rhwp`: 통과, real 19.01s
+- `target/debug/rhwp info samples/unicode/각 항목에 명시되어 있는_유니코드.hwp`: 1페이지, 문단 2개
+- `target/debug/rhwp dump-pages samples/unicode/각 항목에 명시되어 있는_유니코드.hwp`: 1페이지
+
+## 시각 검증
+
+검증 산출물은 repo 밖 `/tmp/rhwp-pr1738/`에 생성했다.
+
+```bash
+target/debug/rhwp export-svg "samples/unicode/각 항목에 명시되어 있는_유니코드.hwp" -o /tmp/rhwp-pr1738/svg
+target/debug/rhwp export-pdf "samples/unicode/각 항목에 명시되어 있는_유니코드.hwp" -o /tmp/rhwp-pr1738/rhwp_unicode.pdf
+pdftoppm -png -f 1 -singlefile "samples/unicode/각 항목에 명시되어 있는_유니코드.pdf" /tmp/rhwp-pr1738/png/oracle
+pdftoppm -png -f 1 -singlefile /tmp/rhwp-pr1738/rhwp_unicode.pdf /tmp/rhwp-pr1738/png/rhwp
+```
+
+확인 결과:
+
+- SVG에 U+302E, U+302F, U+25CC 없음
+- 선두 방점은 `<circle>` 1개로 렌더됨(Task #257 middle-dot vector 경로)
+- 기준 PDF와 rhwp 생성 PDF 모두 선두에 독립 점이 보이고 dotted-circle 아티팩트는 보이지 않음
+- `pdftotext` 기준 PDF는 원문 U+302E를 보존하지만, rhwp PDF는 vector circle이라 텍스트로 추출되지 않는다. 이번
+  결함은 렌더 아티팩트 문제이므로 PNG 시각 확인을 기준으로 판단한다.
+
+## GitHub Actions
+
+merge 직전 PR head `00dc17ef962b39e1248297e8c80e8dc7ddeb2da1` 기준:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Render Diff preflight: success
+- Canvas visual diff: success
+- WASM Build: skipped
+- Analyze (javascript-typescript): success
+- Analyze (python): success
+- Analyze (rust): success, 8m21s
+- Build & Test: success, 19m9s
+- CodeQL: success
+
+최종 merge 직전 `MERGEABLE` + `CLEAN` 상태를 확인했다.
+
+## 이전 SHA run 정리
+
+PR branch update 이후 이전 SHA `00bc0428173c9f413171f3b070c923089320d050`의 run이 남아 있었다.
+
+- Render Diff: 이미 cancelled
+- CI: `force-cancel` API 적용 후 `cancelled`
+- CodeQL: `force-cancel` API 적용 후 `cancelled`
+- 최종 결과: 이전 SHA의 CI/CodeQL/Render Diff 모두 `completed` + `cancelled`
+
+이 경험을 `mydocs/manual/pr_review_workflow.md`에 반영했다. 앞으로 update branch 이후 이전 SHA run 정리는
+처음부터 force-cancel API를 사용한다.
+
+후속 문서-only PR에는 이 리뷰 문서, 오늘할일 갱신, `mydocs/manual/pr_review_workflow.md`의 force-cancel 절차
+명문화 변경을 함께 포함한다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+렌더 치환은 기존 PUA 표시 확장 경로에만 들어가고, 측정은 U+302E/U+302F 2자만 narrow punctuation으로
+추가해 범위가 좁다. 로컬 테스트와 실제 SVG/PDF 시각 확인에서도 dotted-circle 제거가 재현됐다.
+
+## 비차단 확인 사항
+
+- `src/renderer/composer.rs`의 새 주석에는 "측정 폭 정합은 text_measurement 의 전각 분류로 맞춘다"는 표현이
+  남아 있지만, 최종 구현은 `is_narrow_punctuation` 기반이다. 동작에는 영향이 없지만 merge 전 또는 후속
+  정리에서 "narrow 분류"로 문구를 맞추는 편이 좋다.
+- U+302F는 샘플 부재로 기준 PDF 시각 검증은 되지 않았다. PR 본문도 best-effort 한계로 명시하고 있다.
+
+## merge 후 후속 처리
+
+- PR #1738 admin merge 완료: `18720d08a63da6fb396a9ad1effbd01833cca300`
+- PR 감사 코멘트: https://github.com/edwardkim/rhwp/pull/1738#issuecomment-4855097960
+- #1735 자동 close 실패 확인 후 수동 close 완료
+- #1735 close comment: https://github.com/edwardkim/rhwp/issues/1735#issuecomment-4855097451
+- `devel` fast-forward sync 완료
+
+## 최종 판단
+
+수용 및 merge 완료.
+
+U+302E dotted-circle 아티팩트는 한컴 기준 PDF와 rhwp 생성 PDF 비교에서 제거된 것으로 확인했다. U+302F는 기준
+샘플 부재로 best-effort 한계가 남아 있으나, 구현 범위가 좁고 로컬/CI 검증을 통과했으므로 후속 샘플이 생기면
+별도 검증한다.

--- a/mydocs/pr/archives/pr_1738_review_impl.md
+++ b/mydocs/pr/archives/pr_1738_review_impl.md
@@ -1,0 +1,111 @@
+# PR #1738 처리 계획 — #1735 방점 dotted-circle 아티팩트 제거
+
+## 대상
+
+- PR: #1738
+- 작성자: @johndoekim
+- 관련 이슈: #1735
+- 문서 작성 시점 PR head: `00dc17ef962b39e1248297e8c80e8dc7ddeb2da1`
+- 처리 판단: admin merge 완료
+- merge commit: `18720d08a63da6fb396a9ad1effbd01833cca300`
+
+## 커밋
+
+1. `4da146a3a4af2e8ca0443ff5e7fb3af3f304892f`
+   - `Task #1735: 방점(U+302E/U+302F) 렌더 치환으로 dotted-circle 아티팩트 제거 (Stage 1)`
+   - 렌더 치환 및 composer 테스트 추가
+2. `d6cbe5c5265204beb574c9bb3ee37ce1ae6abf3b`
+   - `Task #1735: 방점 측정 폭을 narrow(0.3em)로 정합 (Stage 2)`
+   - 측정 폭 분류 및 text measurement 테스트 추가
+3. `5dfc9a230d23938e13cc91bd36cd242940b678cf`
+   - `Task #1735: 최종 결과보고서`
+   - 결과 보고서 추가
+4. `00bc0428173c9f413171f3b070c923089320d050`
+   - `Task #1735: 방점 렌더 회귀 샘플 + 한컴 정답지 PDF 추가`
+   - 샘플 HWP/PDF 추가
+5. `00dc17ef962b39e1248297e8c80e8dc7ddeb2da1`
+   - `Merge branch 'devel' into local/task1735`
+   - 최신 `devel` 동기화용 merge commit
+
+## 검토 단계
+
+### Stage 1. PR 메타 확인
+
+- base branch: `devel`
+- draft: false (작성 시점 참고값)
+- mergeable: `MERGEABLE` (작성 시점 참고값)
+- mergeStateStatus: `BLOCKED` (GitHub required check 일부 진행 중인 작성 시점 참고값)
+- maintainerCanModify: `true`
+- 규모: 10 files, +258/-2
+
+### Stage 2. 이전 SHA run 강제 취소
+
+완료.
+
+- 대상 이전 SHA: `00bc0428173c9f413171f3b070c923089320d050`
+- CI run `28517498819`: force-cancel 후 `cancelled`
+- CodeQL run `28517498979`: force-cancel 후 `cancelled`
+- Render Diff run `28517498850`: `cancelled`
+- `mydocs/manual/pr_review_workflow.md`에 update branch 이후 이전 SHA run은 처음부터 force-cancel API를 쓰도록 반영
+
+### Stage 3. merge 시뮬레이션
+
+완료.
+
+- `upstream/devel` 기준 `local/pr1738` 병합 시뮬레이션
+- 충돌 없음
+
+### Stage 4. 변경 내용 검토
+
+완료.
+
+- 렌더 전용 display 확장 경로에서만 U+302E/U+302F를 spacing glyph로 치환
+- U+302E/U+302F 측정 폭을 narrow punctuation으로 정합
+- 재현 HWP와 한컴 PDF 기준 파일 포함
+- 새 코드 주석의 "전각 분류" 표현은 최종 구현과 맞지 않으므로 비차단 정리 후보로 기록
+
+### Stage 5. 로컬 검증
+
+완료.
+
+- cargo 검증 전 `target` 하위 항목 삭제
+- `CARGO_INCREMENTAL=0 cargo test --lib`: 2046 passed, 0 failed, 7 ignored
+- `cargo fmt --check`: 통과
+- `git diff --check`: 통과
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과
+- `CARGO_INCREMENTAL=0 cargo test --test svg_snapshot`: 8 passed
+- `CARGO_INCREMENTAL=0 cargo build --bin rhwp`: 통과
+
+### Stage 6. 시각 검증
+
+완료.
+
+- `export-svg`: U+302E/U+302F/U+25CC 미출현, 선두 방점은 `<circle>` 1개로 렌더
+- `export-pdf`: 기준 PDF와 동일하게 독립 점이 보이고 dotted-circle 아티팩트 없음
+- `dump-pages`: 1페이지 유지
+
+### Stage 7. merge 전 대기 조건
+
+- GitHub Actions `Build & Test`, `Analyze (rust)` 최종 success 확인 완료
+- 작업지시자 승인 완료
+
+## merge 후 필수 후속 처리
+
+`mydocs/manual/pr_review_workflow.md` 기준으로 처리한다.
+
+1. merge 직전 최신 GitHub Actions와 head SHA 재확인: 완료
+2. `gh pr merge 1738 --repo edwardkim/rhwp --merge --admin`: 완료
+3. `git checkout devel && git pull --ff-only upstream devel`: fast-forward sync 완료
+4. #1735 이슈 close 여부 확인: 자동 close 실패 확인, 수동 close 완료
+5. PR 감사 코멘트: 완료
+6. 리뷰 문서를 `mydocs/pr/archives/`로 이동: 후속 문서 PR에서 반영
+7. `mydocs/orders/20260701.md` 오늘할일에 #1735/#1738 처리 내용 반영: 후속 문서 PR에서 반영
+8. `mydocs/manual/pr_review_workflow.md` force-cancel 절차 변경을 같은 후속 문서-only PR에 포함: 후속 문서 PR에서 반영
+
+## 후속 코멘트 요지
+
+- U+302E dotted-circle 아티팩트 제거를 SVG/PDF로 확인
+- 한컴 기준 PDF와 rhwp PDF 모두 선두 독립 점으로 보임
+- 로컬 `test --lib`, `clippy --all-targets`, `svg_snapshot` 통과
+- 이전 SHA run은 force-cancel로 정리 완료
+- U+302F는 best-effort이며 기준 샘플 부재 한계는 유지


### PR DESCRIPTION
## 요약

PR #1738 merge 후속 기록을 반영합니다.

- #1738 리뷰 문서와 처리 계획 문서를 archive 경로에 추가
- `mydocs/orders/20260701.md`에 #1735/#1738 merge, close, 검증 결과 기록
- `mydocs/manual/pr_review_workflow.md`에 update branch 이후 이전 SHA run은 처음부터 force-cancel API를 사용하도록 명문화

## 처리 기준

- 대상 PR: #1738
- 관련 이슈: #1735
- merge commit: 18720d08a63da6fb396a9ad1effbd01833cca300
- #1735 close comment: https://github.com/edwardkim/rhwp/issues/1735#issuecomment-4855097451
- #1738 후속 comment: https://github.com/edwardkim/rhwp/pull/1738#issuecomment-4855097960

## 검증

- `git diff --check`
- `git diff --cached --check`

문서-only 후속 PR입니다.
