### PR TITLE
task 1654: HWPX hideFirstEmptyLine HWP flags 동기화

### DIFF
--- a/mydocs/plans/task_m100_1654.md
+++ b/mydocs/plans/task_m100_1654.md
@@ -1,0 +1,23 @@
+# task m100 #1654 계획
+
+## 이슈
+
+- GitHub: https://github.com/edwardkim/rhwp/issues/1654
+- 주제: HWPX -> HWP 변환에서 `hideFirstEmptyLine` 값이 HWP5 `SectionDef.flags` bit 19로 반영되는지 검증 및 보정
+
+## 원인
+
+- HWPX 파서는 `<hp:visibility hideFirstEmptyLine="1">`를 `SectionDef.hide_empty_line` bool에는 저장하지만, HWP5 저장 경로가 쓰는 `SectionDef.flags`의 bit 19(`0x0008_0000`)는 갱신하지 않는다.
+- HWPX -> HWP 어댑터는 `section.section_def`를 `Control::SectionDef`에 복사하므로, flags가 stale이면 HWP 직렬화 결과도 stale 값으로 저장된다.
+
+## 처리 방침
+
+1. HWPX 파서 `parse_visibility`에서 `hideFirstEmptyLine`을 파싱할 때 bool과 flags bit 19를 함께 동기화한다.
+2. HWPX -> HWP 어댑터에서 `SectionDef.hide_empty_line` 기준으로 flags bit 19를 저장 직전 보정한다.
+3. 파서 단위 테스트와 어댑터 단위 테스트로 재발을 막는다.
+
+## 검증
+
+- `task1654` 관련 focused cargo test
+- `cargo fmt --check`
+- 필요 시 clippy는 PR 준비 단계에서 추가 수행

--- a/mydocs/plans/task_m100_1654_impl.md
+++ b/mydocs/plans/task_m100_1654_impl.md
@@ -1,0 +1,16 @@
+# task m100 #1654 구현 계획
+
+## Stage 1
+
+- `src/parser/hwpx/section.rs`
+  - `hideFirstEmptyLine` 파싱 시 `SectionDef.flags`의 `0x0008_0000` bit를 set/clear한다.
+  - minimal HWPX section fixture로 `section.section_def`와 `Control::SectionDef`가 모두 동기화되는지 확인한다.
+
+- `src/document_core/converters/hwpx_to_hwp.rs`
+  - HWPX -> HWP 어댑터에서 `SectionDef.hide_empty_line` 기준으로 flags bit 19를 동기화한다.
+  - 기존 컨트롤이 없거나 오래된 경우에도 `insert_section_def_control` 이후 저장 가능한 값이 유지되는지 확인한다.
+
+## 비범위
+
+- HWPX serializer의 visibility 보존은 #1637/#1642에서 처리된 영역이므로 변경하지 않는다.
+- 렌더러 pagination 의미는 변경하지 않는다.

--- a/mydocs/report/task_m100_1654_pr_body.md
+++ b/mydocs/report/task_m100_1654_pr_body.md
@@ -1,0 +1,19 @@
+## 변경 내용
+
+- HWPX `<hp:visibility hideFirstEmptyLine="...">` 파싱 시 `SectionDef.hide_empty_line`과 HWP5 `SectionDef.flags` bit 19(`0x0008_0000`)를 함께 동기화했습니다.
+- HWPX -> HWP 어댑터에서 저장 직전 `hide_empty_line` 기준으로 bit 19를 materialize하도록 보강했습니다.
+- 파서 단위 테스트와 HWP 직렬화 후 재로드 통합 테스트를 추가했습니다.
+
+## 원인
+
+기존 HWPX 파서는 `hideFirstEmptyLine="1"`을 bool 필드에는 저장했지만, HWP5 저장 경로가 실제로 쓰는 `SectionDef.flags`에는 반영하지 않았습니다. 그 결과 HWPX -> HWP 변환 시 `Control::SectionDef`로 복사되는 flags가 stale 상태일 수 있었습니다.
+
+## 검증
+
+- `cargo fmt --check`
+- `git diff --check`
+- `env CARGO_INCREMENTAL=0 cargo test task1654 --lib`
+- `env CARGO_INCREMENTAL=0 cargo test --test hwpx_to_hwp_adapter task1654_hide_empty_line_flag_preserved_after_hwp_export_reload`
+- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
+
+Closes #1654

--- a/mydocs/report/task_m100_1654_report.md
+++ b/mydocs/report/task_m100_1654_report.md
@@ -1,0 +1,43 @@
+# Task m100 #1654 최종 보고서
+
+## 개요
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/1654
+- 주제: HWPX -> HWP 변환에서 `hideFirstEmptyLine` 값을 HWP5 `SectionDef.flags` bit 19로 동기화
+- 브랜치: `local/task_m100_1654`
+- 기준: `upstream/devel`
+
+## 원인
+
+HWPX 파서의 `<hp:visibility>` 처리에서 `hideFirstEmptyLine="1"`은 `SectionDef.hide_empty_line` bool에는 저장됐지만, HWP5 저장 경로가 직렬화하는 `SectionDef.flags` bit 19(`0x0008_0000`)에는 반영되지 않았다.
+
+HWPX -> HWP 어댑터는 `section.section_def`를 `Control::SectionDef`에 복사하므로, flags가 stale이면 HWP 저장 결과도 stale 값으로 남을 수 있었다.
+
+## 변경
+
+- `src/parser/hwpx/section.rs`
+  - `hideFirstEmptyLine` 파싱 시 `SectionDef.hide_empty_line`과 `SectionDef.flags & 0x0008_0000`을 함께 set/clear한다.
+  - 파서 단위 테스트로 `Section.section_def`와 첫 문단 `Control::SectionDef` 양쪽 동기화를 검증한다.
+
+- `src/document_core/converters/hwpx_to_hwp.rs`
+  - HWPX -> HWP 어댑터에서 `SectionDef.hide_empty_line` 기준으로 HWP5 flags bit 19를 저장 직전 materialize한다.
+  - 보정 횟수를 `AdapterReport.section_def_hide_empty_line_flag_materialized`에 기록하고 `changed_anything()` 판정에 포함한다.
+
+- `tests/hwpx_to_hwp_adapter.rs`
+  - 어댑터 적용 후 실제 HWP 직렬화와 재로드를 수행해 `hide_empty_line`과 flags bit 19가 함께 보존되는지 검증한다.
+
+## 검증
+
+- `cargo fmt --check` 통과
+- `git diff --check` 통과
+- `env CARGO_INCREMENTAL=0 cargo test task1654 --lib` 통과
+- `env CARGO_INCREMENTAL=0 cargo test --test hwpx_to_hwp_adapter task1654_hide_empty_line_flag_preserved_after_hwp_export_reload` 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings` 통과
+
+## PR 준비
+
+- PR base: `devel`
+- PR head 예정: `task_m100_1654`
+- PR 본문: `mydocs/report/task_m100_1654_pr_body.md`
+- 자동 종료 키워드: `Closes #1654`
+

--- a/mydocs/working/task_m100_1654_stage1.md
+++ b/mydocs/working/task_m100_1654_stage1.md
@@ -1,0 +1,22 @@
+# task m100 #1654 stage 1
+
+## 변경
+
+- `src/parser/hwpx/section.rs`
+  - `<hp:visibility hideFirstEmptyLine="...">` 파싱 시 `SectionDef.hide_empty_line`과 HWP5 `SectionDef.flags` bit 19(`0x0008_0000`)를 함께 동기화했다.
+  - 파서 단위 테스트로 `section.section_def`와 첫 문단 `Control::SectionDef`가 모두 동기화되는지 검증했다.
+
+- `src/document_core/converters/hwpx_to_hwp.rs`
+  - HWPX -> HWP 어댑터에서 `SectionDef.hide_empty_line` 기준으로 flags bit 19를 materialize한다.
+  - 보정 횟수를 `AdapterReport.section_def_hide_empty_line_flag_materialized`에 기록하고 `changed_anything()`에 포함했다.
+
+- `tests/hwpx_to_hwp_adapter.rs`
+  - 어댑터 적용 후 실제 HWP 직렬화와 재로드까지 수행해 `hide_empty_line`과 flags bit 19가 보존되는지 검증했다.
+
+## 검증
+
+- `cargo fmt --check` 통과
+- `git diff --check` 통과
+- `env CARGO_INCREMENTAL=0 cargo test task1654 --lib` 통과
+- `env CARGO_INCREMENTAL=0 cargo test --test hwpx_to_hwp_adapter task1654_hide_empty_line_flag_preserved_after_hwp_export_reload` 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings` 통과

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -91,6 +91,8 @@ pub struct AdapterReport {
     pub section_def_single_master_page_flags_materialized: u32,
     /// HWPX SectionDef masterPageCnt=2 flags 를 한컴 HWP 저장 관례로 보정한 횟수
     pub section_def_multi_master_page_flags_materialized: u32,
+    /// HWPX SectionDef hide_empty_line bool 을 HWP5 flags bit 19로 동기화한 횟수
+    pub section_def_hide_empty_line_flag_materialized: u32,
     /// HWPX AutoNumber 뒤 fixed-width space 문단의 HWP5 PARA_RANGE_TAG materialize 횟수
     pub autonum_fwspace_range_tag_materialized: u32,
     /// HWPX AutoNumber 뒤 fixed-width space 문단의 char shape start_pos 보정 횟수
@@ -143,6 +145,7 @@ impl AdapterReport {
                 + self.following_section_break_type_materialized
                 + self.section_def_single_master_page_flags_materialized
                 + self.section_def_multi_master_page_flags_materialized
+                + self.section_def_hide_empty_line_flag_materialized
                 + self.autonum_fwspace_range_tag_materialized
                 + self.autonum_fwspace_char_shape_offsets_materialized
                 + self.header_footer_fwspace_control_materialized
@@ -985,6 +988,7 @@ fn materialize_para_header_tail(para: &mut Paragraph, report: &mut AdapterReport
 }
 
 fn adapt_section_def(section_def: &mut SectionDef, report: &mut AdapterReport) {
+    materialize_section_def_hide_empty_line_flag(section_def, report);
     materialize_single_master_page_flags(section_def, report);
     materialize_multi_master_page_flags(section_def, report);
     materialize_section_def_master_page_tail(section_def, report);
@@ -995,6 +999,24 @@ fn adapt_section_def(section_def: &mut SectionDef, report: &mut AdapterReport) {
             report,
             ParagraphContext::MasterPage,
         );
+    }
+}
+
+fn materialize_section_def_hide_empty_line_flag(
+    section_def: &mut SectionDef,
+    report: &mut AdapterReport,
+) {
+    const HIDE_EMPTY_LINE_FLAG: u32 = 0x0008_0000;
+
+    let old_flags = section_def.flags;
+    if section_def.hide_empty_line {
+        section_def.flags |= HIDE_EMPTY_LINE_FLAG;
+    } else {
+        section_def.flags &= !HIDE_EMPTY_LINE_FLAG;
+    }
+
+    if section_def.flags != old_flags {
+        report.section_def_hide_empty_line_flag_materialized += 1;
     }
 }
 
@@ -2015,6 +2037,29 @@ mod tests {
         let mut second = AdapterReport::new();
         adapt_section_def(&mut section_def, &mut second);
         assert_eq!(second.section_def_multi_master_page_flags_materialized, 0);
+    }
+
+    #[test]
+    fn task1654_hide_empty_line_flag_materializes_before_section_def_control_copy() {
+        let mut section = Section::default();
+        section.section_def.hide_empty_line = true;
+        section.section_def.flags &= !0x0008_0000;
+        section.paragraphs.push(Paragraph::default());
+
+        let mut doc = Document {
+            sections: vec![section],
+            ..Default::default()
+        };
+
+        let report = convert_hwpx_to_hwp_ir(&mut doc);
+        assert_eq!(report.section_def_hide_empty_line_flag_materialized, 1);
+        assert_ne!(doc.sections[0].section_def.flags & 0x0008_0000, 0);
+
+        let Control::SectionDef(section_def) = &doc.sections[0].paragraphs[0].controls[0] else {
+            panic!("SectionDef 컨트롤이 삽입되어야 함");
+        };
+        assert!(section_def.hide_empty_line);
+        assert_ne!(section_def.flags & 0x0008_0000, 0);
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1273,7 +1273,14 @@ fn parse_visibility(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef)
                     sec_def.flags &= !0x0010;
                 }
             }
-            b"hideFirstEmptyLine" => sec_def.hide_empty_line = attr_str(&attr) == "1",
+            b"hideFirstEmptyLine" => {
+                sec_def.hide_empty_line = attr_str(&attr) == "1";
+                if sec_def.hide_empty_line {
+                    sec_def.flags |= 0x0008_0000;
+                } else {
+                    sec_def.flags &= !0x0008_0000;
+                }
+            }
             _ => {}
         }
     }
@@ -5910,6 +5917,34 @@ mod tests {
             vec![(0, 10), (9, 11)],
             "run2 경계는 offsets 축 9"
         );
+    }
+
+    #[test]
+    fn task1654_hide_first_empty_line_sets_hwp5_section_flag() {
+        // HWPX visibility 값은 HWP 저장 경로가 읽는 SectionDef.flags bit 19와
+        // 함께 동기화되어야 한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:secPr id="" textDirection="HORIZONTAL" spaceColumns="1134" tabStop="8000" tabStopVal="4000" tabStopUnit="HWPUNIT" outlineShapeIDRef="1" memoShapeIDRef="0" textVerticalWidthHead="0" masterPageCnt="0">
+        <hp:visibility hideFirstHeader="0" hideFirstFooter="0" hideFirstMasterPage="0" border="SHOW_ALL" fill="SHOW_ALL" hideFirstPageNum="0" hideFirstEmptyLine="1" showLineNumber="0"/>
+      </hp:secPr>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        assert!(section.section_def.hide_empty_line);
+        assert_ne!(section.section_def.flags & 0x0008_0000, 0);
+
+        let Control::SectionDef(section_def) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 SectionDef 여야 함");
+        };
+        assert!(section_def.hide_empty_line);
+        assert_ne!(section_def.flags & 0x0008_0000, 0);
     }
 
     #[test]

--- a/tests/hwpx_to_hwp_adapter.rs
+++ b/tests/hwpx_to_hwp_adapter.rs
@@ -9,7 +9,7 @@ use rhwp::document_core::converters::hwpx_to_hwp::{
 };
 use rhwp::document_core::DocumentCore;
 use rhwp::model::control::Control;
-use rhwp::model::document::Document;
+use rhwp::model::document::{Document, Section};
 use rhwp::model::paragraph::Paragraph;
 use rhwp::model::shape::{CommonObjAttr, ShapeObject};
 use rhwp::model::style::FillType;
@@ -631,6 +631,29 @@ fn stage4_page_def_preserved_after_roundtrip() {
         orig_pd.margin_bottom, reload_pd.margin_bottom,
         "margin_bottom 보존"
     );
+}
+
+#[test]
+fn task1654_hide_empty_line_flag_preserved_after_hwp_export_reload() {
+    let mut section = Section::default();
+    section.section_def.hide_empty_line = true;
+    section.section_def.flags &= !0x0008_0000;
+    section.paragraphs.push(Paragraph::default());
+
+    let mut doc = Document {
+        sections: vec![section],
+        ..Default::default()
+    };
+
+    let report = convert_hwpx_to_hwp_ir(&mut doc);
+    assert_eq!(report.section_def_hide_empty_line_flag_materialized, 1);
+
+    let hwp_bytes = rhwp::serializer::serialize_hwp(&doc).expect("HWP 직렬화 실패");
+    let reloaded = DocumentCore::from_bytes(&hwp_bytes).expect("HWP 재로드 실패");
+    let section_def = &reloaded.document().sections[0].section_def;
+
+    assert!(section_def.hide_empty_line);
+    assert_ne!(section_def.flags & 0x0008_0000, 0);
 }
 
 /// Stage 4 핵심 게이트: 어댑터 적용 → 직렬화 → 재로드 시 페이지 수가 HWP 저장 기준과 일치.


### PR DESCRIPTION
## 변경 내용

- HWPX `<hp:visibility hideFirstEmptyLine="...">` 파싱 시 `SectionDef.hide_empty_line`과 HWP5 `SectionDef.flags` bit 19(`0x0008_0000`)를 함께 동기화했습니다.
- HWPX -> HWP 어댑터에서 저장 직전 `hide_empty_line` 기준으로 bit 19를 materialize하도록 보강했습니다.
- 파서 단위 테스트와 HWP 직렬화 후 재로드 통합 테스트를 추가했습니다.

## 원인

기존 HWPX 파서는 `hideFirstEmptyLine="1"`을 bool 필드에는 저장했지만, HWP5 저장 경로가 실제로 쓰는 `SectionDef.flags`에는 반영하지 않았습니다. 그 결과 HWPX -> HWP 변환 시 `Control::SectionDef`로 복사되는 flags가 stale 상태일 수 있었습니다.

## 검증

- `cargo fmt --check`
- `git diff --check`
- `env CARGO_INCREMENTAL=0 cargo test task1654 --lib`
- `env CARGO_INCREMENTAL=0 cargo test --test hwpx_to_hwp_adapter task1654_hide_empty_line_flag_preserved_after_hwp_export_reload`
- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`

Closes #1654
