### PR TITLE
Task #1583: PageDef 0/손상 방어 폴백 — 본문높이 0 전면 overflow·PDF 실패 방지

### DIFF
--- a/mydocs/plans/task_m100_1583.md
+++ b/mydocs/plans/task_m100_1583.md
@@ -1,0 +1,24 @@
+﻿# Task #1583 수행계획서 — PageDef 0/손상 방어 폴백 (PDF 변환 실패)
+
+## 배경
+특정 HWP(외부 리포트, 샘플 미첨부·sha256 만)에서 전 페이지 LAYOUT_OVERFLOW bottom=0.0
+→ PDF 변환 "SVG has an invalid size" 실패 (이슈 #1583).
+
+## 원인 계층 (코드 판독)
+`PageAreas::from_page_def_for_page`: `content_bottom = page_height − margin_footer −
+margin_bottom`. PageDef 가 0(구역정의 누락/손상 → Default)이면 content_bottom=0 →
+본문높이 0 → 전 블록 overflow(bottom=0.0 로그와 정확 일치) + 페이지 px 0 → SVG 크기
+무효. HwpUnit(u32) 뺄셈이라 여백>용지 시 debug underflow panic 위험도 병존.
+
+## 수정 (렌더링측 방어 — IR 불변으로 라운드트립 보존)
+1. `model/page.rs PageAreas::from_page_def_for_page`: 용지 0 → A4 폴백, 여백 차감 후
+   본문 소멸(상하/좌우) → 용지의 5% 기본 여백 폴백. 뺄셈 saturating 화.
+2. `renderer/page_layout.rs from_page_def_for_page`: 페이지 px ≤0 → A4 px 폴백
+   (SVG 크기 무효 차단).
+3. 단위테스트: PageDef::default()(전부 0) → 본문 양수 + 페이지 px 양수.
+
+## 게이트
+- 신규 단위테스트 + `cargo test --lib` 무회귀 (정상 PageDef 경로 불변 — 폴백 조건은
+  기존에 이미 깨져 있던 입력에서만 발동).
+- 원 리포트 샘플 미보유 — 합성 재현(PageDef zeros)으로 게이트. 이슈에 샘플 확보 시
+  재검 요청 코멘트.

--- a/src/model/page.rs
+++ b/src/model/page.rs
@@ -208,6 +208,14 @@ impl PageAreas {
         } else {
             (page_def.width, page_def.height)
         };
+        // [Task #1583] 손상/미설정 PageDef 방어 — 용지 크기가 0(구역정의 누락 등)이면
+        // A4 로 폴백. 렌더링측 방어이며 IR 은 불변(라운드트립 보존). 방치 시 본문높이
+        // 0 → 전 블록 LAYOUT_OVERFLOW(bottom=0.0) + "SVG has an invalid size" PDF 실패.
+        let (page_width, page_height) = if page_width == 0 || page_height == 0 {
+            (59528, 84188) // A4 210×297mm
+        } else {
+            (page_width, page_height)
+        };
 
         let is_even_page = page_number != 0 && page_number.is_multiple_of(2);
         let (effective_left, effective_right) =
@@ -223,12 +231,24 @@ impl PageAreas {
                 )
             };
 
-        let content_left = effective_left;
-        let content_right = page_width - effective_right;
+        let mut content_left = effective_left;
+        let mut content_right = page_width.saturating_sub(effective_right);
         // HWP 본문 시작 = margin_header + margin_top (한컴 도움말 기준)
-        let content_top = page_def.margin_header + page_def.margin_top;
+        let mut content_top = page_def.margin_header + page_def.margin_top;
         // HWP 본문 끝 = height - margin_footer - margin_bottom
-        let content_bottom = page_height - page_def.margin_footer - page_def.margin_bottom;
+        let mut content_bottom = page_height
+            .saturating_sub(page_def.margin_footer)
+            .saturating_sub(page_def.margin_bottom);
+        // [Task #1583] 여백 과대(합 ≥ 용지)로 본문이 소멸하면 용지의 5% 기본 여백으로
+        // 폴백 — 본문 영역이 항상 양수가 되도록 보장.
+        if content_bottom <= content_top {
+            content_top = page_height / 20;
+            content_bottom = page_height - page_height / 20;
+        }
+        if content_right <= content_left {
+            content_left = page_width / 20;
+            content_right = page_width - page_width / 20;
+        }
 
         let header_area = Rect {
             left: content_left as i32,
@@ -264,6 +284,39 @@ impl PageAreas {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [Task #1583] 손상/미설정 PageDef(전부 0) — 본문 영역이 항상 양수로 폴백.
+    #[test]
+    fn test_page_areas_zero_page_def_falls_back() {
+        let areas = PageAreas::from_page_def_for_page(&PageDef::default(), 1);
+        let body = &areas.body_area;
+        assert!(
+            body.bottom > body.top && body.right > body.left,
+            "PageDef 0 이어도 본문 영역은 양수여야 한다: {body:?}"
+        );
+    }
+
+    /// [Task #1583] 여백 합이 용지를 초과해도 본문 영역이 양수로 폴백.
+    #[test]
+    fn test_page_areas_oversized_margins_fall_back() {
+        let page = PageDef {
+            width: 59528,
+            height: 84188,
+            margin_top: 50000,
+            margin_bottom: 50000,
+            margin_header: 10000,
+            margin_footer: 10000,
+            margin_left: 40000,
+            margin_right: 40000,
+            ..Default::default()
+        };
+        let areas = PageAreas::from_page_def_for_page(&page, 1);
+        let body = &areas.body_area;
+        assert!(
+            body.bottom > body.top && body.right > body.left,
+            "여백 과대여도 본문 영역은 양수여야 한다: {body:?}"
+        );
+    }
 
     #[test]
     fn test_page_def_a4() {

--- a/src/renderer/page_layout.rs
+++ b/src/renderer/page_layout.rs
@@ -72,6 +72,13 @@ impl PageLayoutInfo {
         } else {
             (page_def.width, page_def.height)
         };
+        // [Task #1583] 손상/미설정 PageDef(용지 0) 방어 — A4 폴백 (PageAreas 와 동일
+        // 규칙). 방치 시 0-크기 SVG 캔버스로 PDF 변환이 "SVG has an invalid size" 실패.
+        let (width_hwp, height_hwp) = if width_hwp == 0 || height_hwp == 0 {
+            (59528, 84188)
+        } else {
+            (width_hwp, height_hwp)
+        };
         let page_width = hwpunit_to_px(width_hwp as i32, dpi);
         let page_height = hwpunit_to_px(height_hwp as i32, dpi);
 


### PR DESCRIPTION
## 배경
특정 HWP(외부 리포트 @younghai)에서 전 페이지 LAYOUT_OVERFLOW bottom=0.0 → PDF 변환 \SVG has an invalid size\ 실패. closes #1583

## 원인 (코드 판독)
PageDef가 0(구역정의 누락/손상 → Default)이면 \content_bottom = height − margin_footer − margin_bottom = 0\ → 본문높이 0 → **전 블록 overflow(로그의 bottom=0.0과 정확 일치)** + 페이지 px 0 → SVG 크기 무효. HwpUnit(u32) 뺄셈이라 여백>용지 시 debug underflow panic 위험 병존.

## 수정 (렌더링측 방어 — IR 불변, 라운드트립 보존)
- \model/page.rs\ PageAreas: 용지 0 → **A4 폴백**, 여백 과대로 본문 소멸(상하/좌우) → 용지 5% 기본 여백 폴백, 뺄셈 saturating화
- \enderer/page_layout.rs\: 페이지 px 계산 동일 A4 폴백 (0-크기 SVG 차단)
- 단위테스트 2 (PageDef 전부 0 / 여백 과대 → 본문 양수)

## 검증
lib **2050 passed / 0 failed** (신규 2 포함), fmt 정합. 정상 PageDef 경로 불변 — 폴백은 기존에 이미 깨져 있던 입력에서만 발동. 원 리포트 샘플은 미첨부(sha256만)라 합성 재현으로 게이트 — 샘플 확보 시 재검 예정 (이슈 코멘트).

🤖 Generated with [Claude Code](https://claude.com/claude-code)