### PR TITLE
Task #1748: 컷 걸침 rowspan 셀 높이 기반 유닛 컷 — scattered RowBreak 표 p6 하단 over-fill 수정

### DIFF
--- a/mydocs/plans/task_m100_1748.md
+++ b/mydocs/plans/task_m100_1748.md
@@ -1,0 +1,61 @@
+# Task #1748 수행계획서 — scattered header RowBreak 표 continuation 하단 over-fill (p6 +13px, 1행 과다)
+
+## 배경
+
+#1728(RowBreak 표 continuation 5~6쪽 PDF 시각 차이)의 남은 갈래. 두 갈래는 해결 완료:
+
+- footer 쪽번호 위치 → 부분 PR #1744
+- giant 셀-내 continuation 상단 space-before 복원 → Task #1728 v2 (`e7bea15f`)
+
+남은 갈래인 **scattered header RowBreak 표(260×9, 행 단위 분할)의 하단 over-fill**을 본 타스크에서 처리한다. #1728 v2 에서 회귀 위험이 높아 의도적으로 비범위로 분리했던 영역이다.
+
+## 증상 (이슈 #1748 관찰, 96 DPI PNG dark-pixel bbox vs 한글 2024 PDF)
+
+샘플: `samples/table_scattered_header_rowbreak.hwp` / 비교: `pdf/table_scattered_header_rowbreak-2024.pdf`
+
+| 페이지 | PDF top/bot | rhwp top/bot | Δtop | Δbot |
+|--------|-------------|--------------|-----:|-----:|
+| p5 (idx4) | 77 / 1081 | 75 / 1076 | −2 | −5 (행 컷 소차) |
+| p6 (idx5) | 77 / 1081 | 75 / 1094 | −2 | **+13** |
+
+- p6 배치: `PartialTable pi=9 ci=0 rows=100..140 end_cut=[1,2]`, p7 `start_cut=[1,2]`.
+- 행 높이 ≈ `lh=1000`(13.3px) — **rhwp 가 페이지 하단에 1행을 더 담아** 다음 행이 과다 노출된다.
+
+## 원인 가설
+
+Task #1718 grace(over-fill/under-pagination) 계열의 **행 컷 경계 판정** 문제.
+
+- 이 표는 `RowBreak` + `col_count=9, row_count=260 > 5` → `advance_row_cut`/`advance_row_block_cut`(`src/renderer/layout/table_layout.rs`)의 `relaxed_hard_break=true` 경로.
+- 후보 1: `ROWBREAK_VISIBLE_TAIL_OVERFLOW_TOLERANCE_PX=120` grace (`grace_visible_tail_before_spacer`)가 마지막 유닛/행을 avail 초과에도 수용.
+- 후보 2: 행 단위(inter-row) 적재 판정에서 페이지 잔여 높이(avail) 계산 또는 행 높이 누적(`consumed_height`)의 오차·관용이 마지막 1행을 초과 수용.
+- 후보 3: 페이지네이터 측(typeset.rs)의 PartialTable 행 범위 산정에서 하단 안전마진/tolerance 차이.
+
+정확한 원인은 1단계 조사에서 `dump-pages` + 셀 유닛/행높이 추적으로 확정한다.
+
+## 수정 방향
+
+행 컷 경계 판정이 한글과 같은 지점에서 끊도록 초과 수용 경로를 좁힌다. #1718 전례에 따라 **grace 는 구조적 예외(진짜 꼬리줄)에만 유지**하고, 연속 본문 행에는 정상 capacity break 를 적용하는 방향. 단, 이 영역은 회귀 위험이 높으므로 기존 grace 수혜 케이스(별표1/별표4, 13쪽 caption, giant 등)의 무회귀를 게이트로 강제한다.
+
+## 단계 개요 (구현계획서에서 상세화, 3~6단계)
+
+1. **재현·조사**: p6 행 컷 시점의 avail/행높이/유닛 시퀀스 추적 → 초과 수용 경로(후보 1~3) 확정
+2. **수정 구현**: 확정 경로의 판정 보정 + 단위테스트
+3. **회귀 게이트 검증**: 아래 게이트 전체 + 최종 보고
+
+## 회귀 게이트 (필수)
+
+1. **본 건 목표**: scattered p6 Δbot +13 → **≤ ~5px** (PDF 기준 과다 노출 1행 제거), p5 Δbot −5 무회귀, Δtop −2 불변(전역 오프셋).
+2. **giant**(`samples/task1718/table_giant_cell_overfill.hwp`): 페이지 수 42 불변, p5/p6 Δtop −4 불변 (#1728 v2 결과 유지).
+3. **별표 샘플**(`samples/byeolpyo1`, `samples/byeolpyo4`): 쪽수 4/27 무회귀 (#1658 검증 게이트).
+4. `cargo test` 전체 무회귀 (advance_row_cut 단위테스트 포함), `cargo fmt --check`.
+
+## 산출물
+
+- 소스: `src/renderer/layout/table_layout.rs` (및 조사 결과에 따라 `src/renderer/typeset.rs`)
+- 단위테스트: 행 컷 경계(초과 1행 거부) 케이스
+- 문서: 구현계획서(`task_m100_1748_impl.md`), 단계별 보고, 최종 보고(`task_m100_1748_report.md`)
+
+## 작업 브랜치
+
+- `local/task1748` — upstream/devel 위에 제출 열린 PR 19건 선적용(병합 충돌 2건 해결: typeset.rs #1753/#1755 인접, #1755/#1763 마진) 후 분기.
+- 완료 시 upstream/devel 기준 rebase → squash(1커밋) → `pr/devel-1748` push → PR.

--- a/mydocs/plans/task_m100_1748_impl.md
+++ b/mydocs/plans/task_m100_1748_impl.md
@@ -1,0 +1,71 @@
+# Task #1748 구현계획서 — scattered header RowBreak 표 continuation 하단 over-fill
+
+## 전제 (재현 확정)
+
+통합 베이스(`local/task1748` = upstream/devel + 제출 열린 PR 19건)에서 재현 확인:
+
+- `dump-pages -p 5`: `PartialTable pi=9 ci=0 rows=100..140 end_cut=[1,2]`, p7 `start_cut=[1,2]` — 이슈 관찰과 동일.
+- 96 DPI dark-pixel bbox (pymupdf, rhwp `export-pdf` vs `pdf/table_scattered_header_rowbreak-2024.pdf`):
+  p5 Δtop −1 / Δbot −6, **p6 Δtop −1 / Δbot +13** — 이슈 관찰(rsvg 기준 −2/−5, −2/+13)과 동등.
+- 측정 스크립트는 `tools/compare_page_bbox.py` 로 커밋한다 (pymupdf 96 DPI, thresh<160 — 리뷰어 재현용).
+
+## 구조 이해
+
+p6 은 rows 100..140 의 행 범위 PartialTable 이며, 마지막 행(139)은 셀 유닛 단위로
+부분 소비(`end_cut=[1,2]`)된다. 행 컷의 단일 권위는
+`src/renderer/layout/table_layout.rs` 의 `advance_row_cut`/`advance_row_block_cut`.
+이 표는 RowBreak + `row_count=260 > 5` → `relaxed_hard_break=true` 경로이고,
+초과 수용 후보는:
+
+- ① `ROWBREAK_VISIBLE_TAIL_OVERFLOW_TOLERANCE_PX=120` grace — `grace_visible_tail_before_spacer` 가 true 면 avail 초과 유닛도 수용 (`h + u.height <= avail + 120`)
+- ② 행 적재 판정(typeset.rs 페이지네이터)의 잔여높이(avail) 산정 오차
+- ③ `tiny_fragment_waste`/`HARD_BREAK_REMAINING_TOLERANCE_PX=32` 등 인접 관용 경로
+
+## 단계 구성 (3단계)
+
+### 1단계 — 원인 조사·확정
+
+- p6 행 컷 시점의 avail_height, 마지막 행(139) 셀 유닛 시퀀스(`empty_spacer`/`vis_start..vis_end`/height), grace 발동 여부를 로그/일회성 eprintln 계측으로 추적.
+- 한글 PDF 기준 p6 마지막 가시 행과 rhwp 마지막 행을 대조해 "초과 1행"이 어느 판정에서 들어왔는지 확정 (후보 ①~③).
+- end_cut=[1,2] 의 의미(셀별 유닛 수) 해석 포함.
+- 계측 코드는 커밋하지 않는다 (조사 후 제거). 산출: `mydocs/working/task_m100_1748_stage1.md` (조사 보고).
+
+### 2단계 — 수정 구현 + 단위테스트
+
+> **[1단계 조사 후 갱신]** 가설 ①~③ 기각. 행 컷·페이지네이터 회계는 정확
+> (consumed=981.1 ≤ avail=988.3, render tree 표 박스도 일치). 결함은 **컷 행에
+> 걸친(straddling) rowspan 셀의 렌더 처리** — 컷 페이지에서 가시범위 제한·클리핑
+> 없이 전체 렌더(+13px 잉크), 연속 페이지에서 처음부터 재렌더(중복+아래 행 침범).
+> 상세: `mydocs/working/task_m100_1748_stage1.md`.
+
+- `src/renderer/layout/table_partial.rs` 비블록 분할 경로에서 걸친 rowspan 셀
+  (`cell_end_row > end_row` / `cell_row < start_row`)에 높이 기반 유닛 컷을 적용:
+  `cell_units` 를 프래그먼트-가시 높이 예산으로 잘라 su/eu 산출 →
+  `cell_line_ranges_from_cut` 재사용 + `clip:true`. 연속분 su 는 이전 프래그먼트
+  소비 높이의 결정적 재계산(`row_cut_content_height`, p6 의 end_cut 계산과 동일 식)으로
+  p6.eu == p7.su 를 보장.
+- 페이지네이션(typeset.rs, advance_row_cut)은 불변.
+- 단위/통합 테스트: 걸친 rowspan 셀의 컷 페이지 줄 제한 + 연속 페이지 이어그리기
+  (중복 없음) 검증.
+- 산출: 소스 커밋 + `mydocs/working/task_m100_1748_stage2.md`.
+
+### 3단계 — 회귀 게이트 검증 + 최종 보고
+
+| 게이트 | 기준 |
+|--------|------|
+| 본 건 | p6 Δbot +13 → **≤ ~5px**, p5 Δbot −6/Δtop −1 무회귀, 전체 53쪽 유지 여부 확인(행 밀림 cascade 점검) |
+| giant (`samples/task1718/table_giant_cell_overfill.hwp`) | 42쪽 불변, p5/p6 Δtop −4 불변 (#1728 v2) |
+| 별표 (`samples/byeolpyo1.hwp`, `samples/byeolpyo4.hwp`) | 쪽수 4/27 무회귀 (#1658 게이트) |
+| 테스트 | `cargo test` 전체 무회귀, `cargo fmt --check` |
+
+- cascade 주의: p6 에서 1행이 빠지면 p7 이후 행 배분이 전부 이동한다. 한글 PDF 와 총
+  쪽수(53)·후반 페이지 bbox 를 함께 대조해 개선이 국소가 아닌 전역 정합인지 확인.
+- 산출: `mydocs/report/task_m100_1748_report.md`, 필요 시 재현 샘플은 이미
+  `samples/table_scattered_header_rowbreak.hwp` 존재 (PR 포함 규칙 충족).
+
+## 리스크
+
+- grace 축소는 #1718 이 겪은 대로 별표류(over-pagination 방지) 회귀와 상충 위험 —
+  게이트 3종(giant/별표1/별표4)으로 방어.
+- 120px tolerance 자체를 줄이는 방식은 광범위 회귀 우려 → 판정 조건(구조 판별)을
+  좁히는 방식을 우선한다.

--- a/mydocs/report/task_m100_1748_report.md
+++ b/mydocs/report/task_m100_1748_report.md
@@ -1,0 +1,90 @@
+# Task #1748 최종 보고서 — scattered header RowBreak 표 continuation 하단 over-fill 수정
+
+## 요약
+
+#1728 잔여 갈래였던 scattered header RowBreak 표(260×9)의 p6 하단 +13px(1행 과다
+노출)를 수정. 원인은 이슈의 추정(#1718 grace 계열 행 컷 판정)이 아니라 **컷 행에
+걸친(straddling) rowspan 셀의 렌더 처리 결함**이었다. 행 컷·페이지네이터 회계는
+정확했고, 걸친 rowspan 셀만 가시범위 제한 없이 전체 렌더(컷 페이지)·전체
+재렌더(연속 페이지, 중복)되고 있었다. 높이 기반 유닛 컷 도입으로
+**p6 Δbot +13 → −4px** (게이트 ≤~5px 달성), p7 중복 재렌더·아래 행 침범도 해소.
+
+- 이슈: #1748 / 브랜치: `local/task1748` (upstream/devel + 제출 열린 PR 19건 선적용)
+- 수정: `src/renderer/layout/table_partial.rs`, `table_layout.rs` (헬퍼 1개) —
+  **페이지네이션(typeset.rs) 불변**
+- 테스트: `tests/issue_1748_rowbreak_straddle_rowspan.rs` 3건 신규
+
+## 원인 (1단계 조사, `mydocs/working/task_m100_1748_stage1.md`)
+
+- p6 = `PartialTable pi=9 rows=100..140 end_cut=[1,2]` — `RHWP_TABLE_DRIFT` 회계는
+  `consumed=981.1 ≤ avail=988.3` 정상, render tree 표 박스도 회계와 일치(1002.0px).
+  그러나 래스터 잉크는 표 하단(1077.6px)을 넘어 1094px — **셀 박스 밖 텍스트**.
+- 페이지 경계가 rowspan 블록 내부를 per-row 분할할 때(#1022 경로) 컷
+  부기(start_cut/end_cut)는 컷 행의 `row_span==1` 셀만 담는다. 경계에 걸친
+  rowspan 셀(row 138~, span이 컷 행 139 포함)은
+  `is_split_end_row(cell_row == end_row-1)` 판별 밖 → `clip:false`,
+  `cut_units:None` → 전체 줄 무제한 렌더(3줄 초과, +44.9px). 연속 페이지 p7은
+  같은 이유로 **처음부터 재렌더** → 중복 + 아래 행 침범(+61.9px).
+- 한글 2024 PDF는 컷 페이지에 들어가는 줄까지만 렌더하고 나머지를 연속 페이지에
+  이어그린다.
+
+## 수정 (2단계, `mydocs/working/task_m100_1748_stage2.md`)
+
+- `table_layout.rs`: `cell_units_fitting_height` — 유닛 누적높이가 예산에 들어가는
+  선두 유닛 수 (EPS 0.1px).
+- `table_partial.rs`: RowBreak 표 비블록 분할에서 걸친 rowspan 셀 판별
+  (`is_rowbreak_straddle`: 시작 걸침 `cell_row < start_row < cell_end_row`,
+  끝 걸침 span이 프래그먼트 끝 초과 또는 마지막 span 행이 분할 행) → 높이 기반
+  유닛 컷 `su = fit(prior_h − pad_top)`, `eu = fit(prior_h + cell_h − pad_top)`.
+  prior_h는 2b 행높이 오버라이드와 동일 식으로 결정적 재계산되어 컷 페이지 eu ==
+  연속 페이지 su 가 산술적으로 일치(상태 전달 불필요). 줄 범위 변환은 기존
+  `cell_line_ranges_from_cut` 재사용, `clip:true` + Top 정렬 강제.
+- 한계(문서화): 한 셀 span이 3개 이상 프래그먼트에 걸치며 중간 span 행 자체가
+  또 분할되는 극단 케이스는 prior_h의 pad 중복으로 경계 줄이 ±1줄 어긋날 수 있다
+  (이번 샘플 포함 일반 케이스는 정확).
+
+## 검증 (3단계)
+
+### 본 건 (96 DPI dark-pixel bbox vs `pdf/table_scattered_header_rowbreak-2024.pdf`)
+
+| 항목 | 수정 전 | 수정 후 | 게이트 |
+|------|--------:|--------:|--------|
+| p6 Δbot | **+13** | **−4** | ≤ ~5px ✅ |
+| p5 Δtop/Δbot | −1/−6 | −1/−6 | 무회귀 ✅ |
+| 전체 쪽수 | 53 | 53 | 불변 ✅ |
+| p7 걸친 셀 | 전체 재렌더(중복) | 잔여 줄 이어그리기 | 한글 정합 ✅ |
+
+- 문서 후반부(p8~)는 한글 52쪽 vs rhwp 53쪽의 기존 전역 표류(#1772/#1774 계열)가
+  있으며 본 타스크 범위 밖 (수정 전후 페이지네이션 동일하므로 악화 없음).
+
+### 회귀 게이트
+
+| 게이트 | 결과 |
+|--------|------|
+| 신규 테스트 3건 (`issue_1748_rowbreak_straddle_rowspan`) | 통과 (수정 전 실측 +44.9/+61.9px 초과였던 단언) ✅ |
+| `cargo test --release` 전체 | **2748 passed / 실질 실패 0** ✅ |
+| svg_snapshot 골든 | 내용 기준 8/8 불변 — 7건 "실패"는 Windows autocrlf CRLF 노이즈, **이슈 #1786 등록** ✅ |
+| giant (`task1718/table_giant_cell_overfill.hwp`) | 42쪽 불변, p5/p6 Δtop −3/Δbot −2 (#1728 v2 수준) ✅ |
+| byeolpyo1 / byeolpyo4 (#1658 게이트) | 4쪽 / 26쪽 무회귀 ✅ |
+| `tools/clipping_gate.py` (controlset 92) | 검사 92 / 회귀 0 / baseline 이탈 0 ✅ |
+| `tools/render_page_gate.py` (대형 오라클 452) | **443 일치(98.0%)** — #1658 기록 442 대비 +1 ✅ |
+| `tools/render_page_gate.py` (소형 92) | 73 일치 — 통합 베이스(선적용 PR 19건) 상태이며, 본 diff는 렌더 트리 전용(`layout_partial_table`)이라 쪽수 산정 표면 없음 |
+| `rustfmt --check` (변경 파일) | 통과 |
+
+## 산출물
+
+- 소스: `src/renderer/layout/table_partial.rs`, `src/renderer/layout/table_layout.rs`
+- 테스트: `tests/issue_1748_rowbreak_straddle_rowspan.rs`
+- 검증 도구: `tools/compare_page_bbox.py` — 페이지 dark-pixel bbox 비교
+  (rhwp export-pdf vs 한글 PDF). 본 건 게이트 재현:
+  `python tools/compare_page_bbox.py <out.pdf> pdf/table_scattered_header_rowbreak-2024.pdf --pages 6 --max-dbot 5`
+- 문서: 수행·구현 계획서, stage1·2 보고, 본 보고서
+- 재현 샘플: `samples/table_scattered_header_rowbreak.hwp` (기존 커밋,
+  PR 재현 자료 규칙 충족) / 비교: `pdf/table_scattered_header_rowbreak-2024.pdf`
+- 부수 산출: 이슈 #1786 (svg_snapshot 골든 CRLF Windows 환경 실패)
+
+## 후속 제안
+
+- p5 시점부터 한글 대비 1행 선행하는 행높이 미세 표류(밀집 행 누적)는
+  #1759/#1760/#1772 추적 프로그램 범위.
+- 3+ 프래그먼트 걸침 극단 케이스의 pad 중복 보정은 실사례 확보 시 후속.

--- a/mydocs/working/task_m100_1748_stage1.md
+++ b/mydocs/working/task_m100_1748_stage1.md
@@ -1,0 +1,81 @@
+# Task #1748 1단계 완료 보고 — 원인 조사·확정
+
+## 결론 (요약)
+
+p6 하단 +13px 의 원인은 수행계획서의 가설 ①~③(행 컷/grace 판정)이 **아니다**.
+행 컷과 페이지네이터 회계는 이미 정확하다. 결함은 **컷 행에 걸친(straddling)
+rowspan 셀의 렌더 처리**다:
+
+- 컷 페이지(p6): 걸친 rowspan 셀이 **가시범위 제한·클리핑 없이 전체 줄을 렌더** →
+  셀 박스 아래로 3줄 흘러넘침 (+13px 잉크).
+- 연속 페이지(p7): 같은 셀이 **처음부터 전체 재렌더** → 내용 중복 + 아래 행 영역 침범.
+- 한글 2024 PDF 는 컷 페이지에 들어가는 줄까지만 보여주고 나머지를 연속 페이지에
+  **이어그리기** 한다 (중복·넘침 없음).
+
+## 조사 경로 (계측 코드 추가 없음 — 기존 진단·CLI 만 사용)
+
+1. **재현**: `dump-pages -p 5` → `PartialTable pi=9 rows=100..140 end_cut=[1,2]` (이슈와 동일).
+   pymupdf 96 DPI dark-pixel bbox: p6 Δbot **+13** (rhwp 1094 vs 한글 1081), p5 Δbot −6.
+2. **회계 확인**: `RHWP_TABLE_DRIFT=1` →
+   `cursor_row=100 end_row=140 consumed=981.1 avail_for_rows=988.3 partial_h=1002.0 fits=true`
+   — 페이지네이터는 예산 내. **가설 ①~③ 기각** (grace/tolerance 는 발동 자체가 문제가 아님).
+3. **render tree 대조**: 표 박스 h=1002.0(회계와 일치), bottom=1077.6. 그런데 래스터
+   잉크는 1094 — **셀 박스 밖 텍스트**.
+4. **초과 잉크의 정체**: x=466.7 셀(y=1001.4, h=76.2, bot=1077.6, rowspan)의 TextLine 이
+   y=1074.5/1091.8/1109.2 (bot 1087.8/1105.1/1122.5)까지 렌더. row_span==1 셀 2개는
+   end_cut=[1,2] 대로 1줄/2줄만 렌더(정상).
+5. **p7 대조**: 같은 셀이 y=96.5 h=59.1 박스에서 **전체 7줄을 처음부터 재렌더**
+   (텍스트 bot 217.5 > 셀 bot 155.6 — 아래 행 침범). 한글 p7 은 p6 마지막 줄
+   ("세제곱미터 미만인 경우") **다음 줄부터** 4줄만 렌더.
+
+## 근본 원인 (코드)
+
+`src/renderer/layout/table_partial.rs` 셀 루프(비블록 분할 경로):
+
+```rust
+let is_split_end_row = !end_cut.is_empty() && cell_row == end_row.saturating_sub(1);
+```
+
+- 컷 행(139)에 **걸쳐 있기만 한** rowspan 셀(cell_row=138, span 이 139 를 포함)은
+  `cell_row != end_row-1` → `is_in_split_row=false` → `clip:false`, `cut_units=None`
+  → 전체 줄 무제한 렌더.
+- 컷 부기(end_cut)는 `advance_row_cut` 이 컷 행의 `row_span==1` 셀만 담으므로
+  걸친 rowspan 셀에는 애초에 컷 항목이 없다.
+- 연속 페이지에서도 같은 이유로 컷 없음 → 전체 재렌더(중복).
+- 페이지 경계가 rowspan 블록 내부를 per-row 분할하는 경로(#1022,
+  `rowbreak_rowspan_row_splittable`)에서만 발생. 블록 분할(`is_block_split`) 경로는
+  rowspan 셀도 `block_cut_index` 로 컷 부기가 있어 정상.
+
+## 수정 설계 (2단계에서 구현)
+
+페이지네이션(행 컷·회계)은 불변. **렌더러(table_partial.rs)만** 수정:
+
+1. **걸친 rowspan 셀 판별**: 비블록 경로에서 `cell_end_row > end_row`(끝 걸침) /
+   `cell_row < start_row`(시작 걸침, 연속분).
+2. **높이 기반 유닛 컷**: 셀의 `cell_units` 를 프래그먼트-가시 높이 예산으로 잘라
+   su/eu 산출 → 기존 `cell_line_ranges_from_cut` 재사용으로 줄 범위 제한 + `clip:true`.
+   - 끝 걸침(p6): 예산 = 프래그먼트 내 span 행 높이 합(=셀 박스 h) − 패딩.
+   - 시작 걸침(p7): 이전 프래그먼트 소비 높이를 **결정적으로 재계산** — 온전 행은
+     `row_cut_content_height(r, &[], &[])`, 분할 행(139)은
+     `row_cut_content_height(r, &[], start_cut)` (p6 이 end_cut 으로 계산한 값과 동일 식)
+     → su. 이로써 p6.eu == p7.su 가 산술적으로 일치(상태 전달 불필요).
+3. 컷 적용 셀은 top-flow 로 배치(기존 분할 셀 줄범위 렌더와 동일 경로) —
+   현재 걸친 셀은 valign 이 전체 콘텐츠 기준이라 첫 줄도 어긋난다.
+
+### 예상 효과
+
+- p6: rowspan 셀이 박스 안 줄까지만 렌더 → 잉크 bottom ≈ 표 경계(1078) → **Δbot ≈ −3**.
+- p7: 이어그리기 (중복 제거 + 아래 행 침범 해소) — 한글 정합.
+
+## 게이트 영향 재평가
+
+행 컷·페이지네이션 불변이므로 쪽수 게이트(giant 42, byeolpyo 4/27) 회귀 위험은
+수행계획서 예상보다 낮다. 다만 rowspan 걸침 렌더는 블록 분할·중첩 표와 인접하므로
+`issue_rowbreak_chart_overlap` 등 분할 표 시각 테스트 전체를 게이트에 유지한다.
+
+## 계획 대비 변경
+
+- 수행계획서의 "수정 방향(grace 축소)" 폐기 → 구현계획서 2단계를 본 설계로 갱신
+  (`task_m100_1748_impl.md` v2 수정).
+- 수정 대상 파일: `src/renderer/layout/table_partial.rs` (+ 필요 시
+  `table_layout.rs` 헬퍼 추가). `typeset.rs` 는 손대지 않는다.

--- a/mydocs/working/task_m100_1748_stage2.md
+++ b/mydocs/working/task_m100_1748_stage2.md
@@ -1,0 +1,70 @@
+# Task #1748 2단계 완료 보고 — 컷 걸침 rowspan 셀 높이 기반 유닛 컷 구현
+
+## 구현 내용
+
+### `src/renderer/layout/table_layout.rs`
+
+- `cell_units_fitting_height(cell, table, styles, budget)` 헬퍼 추가 — 셀 유닛
+  누적높이가 budget(패딩 제외 콘텐츠 예산) 안에 들어가는 선두 유닛 수 (EPS 0.1px).
+  컷 페이지의 eu 와 연속 페이지의 su 가 같은 예산 식으로 계산되어 경계 유닛
+  인덱스가 산술적으로 일치한다.
+
+### `src/renderer/layout/table_partial.rs`
+
+1. **걸침 판별** (`is_rowbreak_straddle`): 비블록 분할 + `row_span > 1` +
+   RowBreak 표 + 기존 컷 부기 밖(`!is_in_split_row`) + 반복 제목행 셀 제외에서
+   - 시작 걸침: `cell_row < start_row < cell_end_row` (연속 페이지)
+   - 끝 걸침: span 이 프래그먼트 끝을 넘거나(`cell_end_row > render_range_end`)
+     마지막 span 행이 분할 행(`cell_end_row == render_range_end && !end_cut.is_empty()`)
+2. **높이 기반 유닛 컷**: 시작 걸침의 이전 소비 높이(prior_h)는 2b 행높이
+   오버라이드와 동일한 식으로 재계산 — 온전 행 `row_cut_content_height(r, [], [])`
+   (0 이면 resolve 값), 분할 행 `row_cut_content_height(start_row, [], start_cut)`.
+   `su = fit(prior_h − pad_top)`, `eu = 끝 걸침 ? fit(prior_h + cell_h − pad_top) : MAX`.
+   기존 `cell_line_ranges_from_cut` 로 줄 범위 변환 (기존 분할 셀과 동일 경로).
+3. `clip: is_in_split_row || is_rowbreak_straddle`, Top 정렬 강제 조건에도 동일 반영.
+4. `resolved_row_heights`(2b 오버라이드 이전 원본) 클론 보관 — prior_h 재계산용.
+
+페이지네이션(typeset.rs / advance_row_cut)은 **불변** (p6 회계 981.1 ≤ 988.3 정상이었음).
+
+### 신규 테스트 `tests/issue_1748_rowbreak_straddle_rowspan.rs` (3건)
+
+| 테스트 | 가드 | 수정 전 실측 |
+|--------|------|--------------|
+| `cut_page_straddling_rowspan_cell_text_stays_inside_cells` | p6 셀 하단 초과 TextLine 없음 | +44.9px 초과 |
+| `cut_page_no_text_ink_below_table_fragment` | p6 표 프래그먼트 아래 텍스트 잉크 없음 | 1122.5 vs 1077.6 |
+| `continuation_page_straddling_rowspan_cell_text_stays_inside_cells` | p7 중복 재렌더 없음 | +61.9px 초과 |
+
+## 검증 결과
+
+### 본 건 (96 DPI dark-pixel bbox, pymupdf, vs 한글 2024 PDF)
+
+| 페이지 | 수정 전 | 수정 후 | 게이트 |
+|--------|--------:|--------:|--------|
+| p6 Δbot | **+13** | **−4** | ≤ ~5px ✅ |
+| p6 Δtop | −1 | −1 | 불변 ✅ |
+| p5 Δtop/Δbot | −1/−6 | −1/−6 | 무회귀 ✅ |
+
+- 전체 53쪽 불변 (페이지네이션 무변경).
+- p7 이어그리기: 한글 p7과 같은 잔여 줄 렌더("콘크리트 1일 타설량이 120 /
+  세제곱미터 이상인 경우 / : 120세제곱미터마다"), 중복·아래 행 침범 해소.
+  (rhwp 는 p5 시점부터 1행 선행하는 별개 표류(#1772/#1774 계열)가 있어 줄 단위
+  완전 일치는 본 타스크 범위 밖 — 기하 게이트는 충족.)
+
+### 회귀 게이트
+
+| 게이트 | 결과 |
+|--------|------|
+| giant (`samples/task1718/table_giant_cell_overfill.hwp`) | 42쪽 불변, p5/p6 Δtop −3 / Δbot −2 (#1728 v2 의 −4 수준 유지) ✅ |
+| byeolpyo1 / byeolpyo4 | 4쪽 / 26쪽 무회귀 (#1718 이후 26 이 현행 기준) ✅ |
+| `cargo test --release` 전체 | **2748 passed / 실질 실패 0** ✅ |
+| svg_snapshot 골든 | 내용 기준 8/8 불변 ✅ (아래 참고) |
+| `rustfmt --check` (변경 파일) | 통과 (newline 경고는 autocrlf 환경 노이즈) |
+
+**참고 — svg_snapshot 7건 "실패"는 Windows 환경 노이즈**: `core.autocrlf=true`
+체크아웃이 골든 SVG 를 CRLF 로 변환해 LF 생성물과 바이트 불일치. CR 제거 비교 시
+7건 모두 diff 0줄 (CI Linux 무영향). #1775(CFB 경로 구분자)와 같은 부류의 Windows
+개발환경 이슈 — 별도 이슈 등록 예정.
+
+## 다음 단계
+
+3단계 — 잔여 게이트(클리핑 게이트, 캐스케이드 후반부 페이지 대조) + 최종 보고.

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -5749,6 +5749,28 @@ impl LayoutEngine {
         }
     }
 
+    /// [Task #1748] 셀 유닛 누적높이가 `budget`(패딩 제외 콘텐츠 예산) 안에
+    /// 들어가는 선두 유닛 수를 반환한다. 컷 행에 걸친(straddling) rowspan 셀의
+    /// 높이 기반 가시 유닛 컷 산출용 — 컷 페이지의 eu 와 연속 페이지의 su 가
+    /// 같은 예산 식으로 계산되어 경계 줄 인덱스가 산술적으로 일치한다.
+    pub(crate) fn cell_units_fitting_height(
+        &self,
+        cell: &crate::model::table::Cell,
+        table: &crate::model::table::Table,
+        styles: &ResolvedStyleSet,
+        budget: f64,
+    ) -> usize {
+        const EPS: f64 = 0.1;
+        let units = self.cell_units(cell, table, styles);
+        let mut n = 0usize;
+        let mut h = 0.0f64;
+        while n < units.len() && h + units[n].height <= budget + EPS {
+            h += units[n].height;
+            n += 1;
+        }
+        n
+    }
+
     /// [Task #993] 한 셀의 유닛 범위 `[start_unit, end_unit)`를 문단별 줄 범위로
     /// 변환한다. `layout_partial_table`이 `RowCut`으로 가시 범위를 렌더할 때
     /// 사용 — 결과는 종전 `compute_cell_line_ranges`와 같은

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -152,6 +152,9 @@ impl LayoutEngine {
         let col_widths = self.resolve_column_widths(table, col_count);
         let mut row_heights =
             self.resolve_row_heights(table, col_count, row_count, measured_table, styles);
+        // [Task #1748] 컷 걸침 rowspan 셀의 이전 프래그먼트 소비 높이 재계산용 —
+        // 2b 컷 오버라이드 이전의 원본 행 높이 (프래그먼트 무관 값).
+        let resolved_row_heights = row_heights.clone();
 
         // ── 2b. 행 높이 오버라이드 (Task #993: 컷 기반) ──
         // 렌더 대상 모든 행의 높이를 페이지네이터와 동일한 컷 측정
@@ -515,6 +518,25 @@ impl LayoutEngine {
             };
             let is_in_split_row = is_split_start_row || is_split_end_row;
 
+            // [Task #1748] RowBreak 표에서 페이지 경계가 rowspan 블록 내부를 per-row
+            // 분할할 때(#1022 경로), 컷 부기(start_cut/end_cut)는 컷 행의 row_span==1
+            // 셀만 담아 경계에 걸친 rowspan 셀은 컷 없이 전체 렌더된다 — 컷 페이지에선
+            // 셀 박스 아래로 흘러넘치고(+13px 잉크), 연속 페이지에선 처음부터
+            // 재렌더(중복)된다. 높이 기반 유닛 컷으로 가시 줄 범위를 제한한다.
+            let straddles_fragment_start = cell_row < start_row && cell_end_row > start_row;
+            let straddles_fragment_end = cell_row < render_range_end
+                && (cell_end_row > render_range_end
+                    || (cell_end_row == render_range_end && !end_cut.is_empty()));
+            let is_rowbreak_straddle = !is_block_split
+                && !is_in_split_row
+                && cell.row_span > 1
+                && !is_repeated_header_cell
+                && matches!(
+                    table.page_break,
+                    crate::model::table::TablePageBreak::RowBreak
+                )
+                && (straddles_fragment_start || straddles_fragment_end);
+
             let cell_id = tree.next_id();
             let mut cell_node = RenderNode::new(
                 cell_id,
@@ -525,7 +547,7 @@ impl LayoutEngine {
                     row_span: cell.row_span,
                     border_fill_id: cell.border_fill_id,
                     text_direction: cell.text_direction,
-                    clip: is_in_split_row,
+                    clip: is_in_split_row || is_rowbreak_straddle,
                     model_cell_index: Some(cell_idx as u32),
                 }),
                 BoundingBox::new(cell_x, cell_y, cell_w, cell_h),
@@ -628,6 +650,48 @@ impl LayoutEngine {
                     (su, eu)
                 };
                 Some(pair)
+            } else if is_rowbreak_straddle {
+                // [Task #1748] 높이 기반 유닛 컷. 이전 프래그먼트 소비 높이(prior_h)는
+                // 2b 오버라이드와 동일한 식으로 재계산 — 온전 행은 컷 측정
+                // (row_cut_content_height), 분할 행(start_row)은 start_cut 이전 유닛
+                // 높이. 컷 페이지가 end_cut 으로 계산한 값과 같은 식이라 경계 유닛
+                // 인덱스(컷 페이지 eu == 연속 페이지 su)가 산술적으로 일치한다.
+                let mut prior_h = 0.0f64;
+                if straddles_fragment_start {
+                    for r in cell_row..start_row {
+                        let has_single_row_cells = table
+                            .cells
+                            .iter()
+                            .any(|c| c.row as usize == r && c.row_span == 1);
+                        let h = if has_single_row_cells {
+                            let h = self.row_cut_content_height(table, r, &[], &[], styles);
+                            if h > 0.0 {
+                                h
+                            } else {
+                                resolved_row_heights.get(r).copied().unwrap_or(0.0)
+                            }
+                        } else {
+                            resolved_row_heights.get(r).copied().unwrap_or(0.0)
+                        };
+                        prior_h += h + cell_spacing;
+                    }
+                    if !start_cut.is_empty() {
+                        prior_h +=
+                            self.row_cut_content_height(table, start_row, &[], start_cut, styles);
+                    }
+                }
+                let su = if prior_h > 0.0 {
+                    self.cell_units_fitting_height(cell, table, styles, prior_h - pad_top)
+                } else {
+                    0
+                };
+                let eu = if straddles_fragment_end {
+                    self.cell_units_fitting_height(cell, table, styles, prior_h + cell_h - pad_top)
+                        .max(su)
+                } else {
+                    usize::MAX
+                };
+                Some((su, eu))
             } else {
                 None
             };
@@ -755,7 +819,7 @@ impl LayoutEngine {
             } else {
                 false
             };
-            let effective_align = if is_in_split_row && cell_was_split {
+            let effective_align = if (is_in_split_row || is_rowbreak_straddle) && cell_was_split {
                 VerticalAlign::Top
             } else {
                 cell.vertical_align

--- a/tests/issue_1748_rowbreak_straddle_rowspan.rs
+++ b/tests/issue_1748_rowbreak_straddle_rowspan.rs
@@ -1,0 +1,125 @@
+//! [Task #1748] scattered header RowBreak 표 — 컷 행에 걸친 rowspan 셀 렌더 회귀 가드.
+//!
+//! `samples/table_scattered_header_rowbreak.hwp`(260×9 RowBreak 표)의 p6/p7 경계에서
+//! 페이지 경계가 rowspan 블록 내부를 per-row 분할한다(p6 rows=100..140 end_cut=[1,2]).
+//! 컷 부기(end_cut/start_cut)는 컷 행의 row_span==1 셀만 담으므로, 경계에 걸친
+//! rowspan 셀은 수정 전:
+//! - 컷 페이지(p6): 전체 줄을 무제한 렌더 → 셀/표 박스 아래로 3줄 흘러넘침
+//!   (표 경계 1077.6px 대비 잉크 1122.5px, 한글 2024 PDF 대비 Δbot +13px)
+//! - 연속 페이지(p7): 처음부터 전체 재렌더 → 중복 + 아래 행 영역 침범
+//!   (셀 박스 155.6px 대비 잉크 217.5px)
+//!
+//! 수정 후 걸친 rowspan 셀은 높이 기반 유닛 컷으로 컷 페이지에 들어가는 줄까지만
+//! 렌더하고 연속 페이지는 다음 줄부터 이어그린다 (한글 정합).
+
+use rhwp::renderer::render_tree::RenderNode;
+use rhwp::renderer::render_tree::RenderNodeType;
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str = "samples/table_scattered_header_rowbreak.hwp";
+/// p6/p7 (0-based 페이지 인덱스). p6 rows=100..140 end_cut=[1,2], p7 start_cut=[1,2].
+const CUT_PAGE: u32 = 5;
+const CONT_PAGE: u32 = 6;
+
+fn load_doc() -> rhwp::wasm_api::HwpDocument {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let sample_path = Path::new(repo_root).join(SAMPLE);
+    let bytes = fs::read(&sample_path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {SAMPLE}: {e:?}"))
+}
+
+/// 모든 TableCell 하위 TextLine 이 셀 bbox 하단을 넘지 않는지 수집.
+/// (초과량, 셀 bottom, 라인 bottom) 목록 반환.
+fn collect_cell_text_overflows(root: &RenderNode, cell_bottom: Option<f64>, out: &mut Vec<f64>) {
+    let cell_bottom = if matches!(root.node_type, RenderNodeType::TableCell(_)) {
+        Some(root.bbox.y + root.bbox.height)
+    } else {
+        cell_bottom
+    };
+    if matches!(root.node_type, RenderNodeType::TextLine(_)) {
+        if let Some(cb) = cell_bottom {
+            let over = root.bbox.y + root.bbox.height - cb;
+            if over > 0.5 {
+                out.push(over);
+            }
+        }
+    }
+    for child in &root.children {
+        collect_cell_text_overflows(child, cell_bottom, out);
+    }
+}
+
+fn find_table_bbox(root: &RenderNode) -> Option<(f64, f64)> {
+    if matches!(root.node_type, RenderNodeType::Table(_)) {
+        return Some((root.bbox.y, root.bbox.y + root.bbox.height));
+    }
+    root.children.iter().find_map(find_table_bbox)
+}
+
+fn max_text_line_bottom(root: &RenderNode) -> f64 {
+    let own = if matches!(root.node_type, RenderNodeType::TextLine(_)) {
+        root.bbox.y + root.bbox.height
+    } else {
+        f64::MIN
+    };
+    root.children
+        .iter()
+        .map(max_text_line_bottom)
+        .fold(own, f64::max)
+}
+
+/// 컷 페이지(p6): 걸친 rowspan 셀의 텍스트가 셀 박스를 넘지 않는다.
+/// 수정 전 최대 44.9px 초과(잉크 1122.5 vs 셀 1077.6).
+#[test]
+fn cut_page_straddling_rowspan_cell_text_stays_inside_cells() {
+    let doc = load_doc();
+    let tree = doc
+        .build_page_render_tree(CUT_PAGE)
+        .unwrap_or_else(|e| panic!("render page {}: {e}", CUT_PAGE + 1));
+    let mut overflows = Vec::new();
+    collect_cell_text_overflows(&tree.root, None, &mut overflows);
+    assert!(
+        overflows.is_empty(),
+        "p{} 셀 하단 초과 TextLine {}건 (최대 {:.1}px) — 컷 걸침 rowspan 셀 가시범위 미적용 회귀",
+        CUT_PAGE + 1,
+        overflows.len(),
+        overflows.iter().cloned().fold(0.0, f64::max),
+    );
+}
+
+/// 컷 페이지(p6): 표 프래그먼트 하단 아래에 텍스트 잉크가 없다 (Δbot +13px 의 직접 형상).
+#[test]
+fn cut_page_no_text_ink_below_table_fragment() {
+    let doc = load_doc();
+    let tree = doc
+        .build_page_render_tree(CUT_PAGE)
+        .unwrap_or_else(|e| panic!("render page {}: {e}", CUT_PAGE + 1));
+    let (_, table_bottom) = find_table_bbox(&tree.root).expect("p6 table should render");
+    let max_bottom = max_text_line_bottom(&tree.root);
+    assert!(
+        max_bottom <= table_bottom + 0.5,
+        "p{} 표 하단({table_bottom:.1}) 아래 텍스트 잉크({max_bottom:.1}) — 컷 페이지 over-fill 회귀",
+        CUT_PAGE + 1,
+    );
+}
+
+/// 연속 페이지(p7): 걸친 rowspan 셀이 처음부터 재렌더되지 않고(중복 없음)
+/// 텍스트가 셀 박스 안에 머문다. 수정 전 최대 61.9px 초과(잉크 217.5 vs 셀 155.6).
+#[test]
+fn continuation_page_straddling_rowspan_cell_text_stays_inside_cells() {
+    let doc = load_doc();
+    let tree = doc
+        .build_page_render_tree(CONT_PAGE)
+        .unwrap_or_else(|e| panic!("render page {}: {e}", CONT_PAGE + 1));
+    let mut overflows = Vec::new();
+    collect_cell_text_overflows(&tree.root, None, &mut overflows);
+    assert!(
+        overflows.is_empty(),
+        "p{} 셀 하단 초과 TextLine {}건 (최대 {:.1}px) — 걸친 rowspan 셀 전체 재렌더(중복) 회귀",
+        CONT_PAGE + 1,
+        overflows.len(),
+        overflows.iter().cloned().fold(0.0, f64::max),
+    );
+}

--- a/tools/compare_page_bbox.py
+++ b/tools/compare_page_bbox.py
@@ -1,0 +1,82 @@
+"""페이지 dark-pixel bbox 비교 — rhwp export-pdf 산출물 vs 한글 편집기 PDF 정답지.
+
+Task #1748 검증 도구. 두 PDF 를 같은 DPI 로 래스터화해 페이지별 잉크 bbox
+(top/bottom) 를 비교한다. 쪽 경계 over-fill(하단 잉크 초과) 회귀 검증용.
+
+사용:
+    rhwp export-pdf samples/table_scattered_header_rowbreak.hwp -o out.pdf
+    python tools/compare_page_bbox.py out.pdf pdf/table_scattered_header_rowbreak-2024.pdf --pages 5,6
+
+    # Task #1748 게이트 (p6 Δbot ≤ 5px; p5 는 기존 행 컷 소차 −6 이라 게이트 제외):
+    python tools/compare_page_bbox.py out.pdf pdf/table_scattered_header_rowbreak-2024.pdf \
+        --pages 6 --max-dbot 5
+
+의존: pymupdf, Pillow  (pip install pymupdf pillow)
+- --pages 는 1-기반 페이지 번호(콤마 구분). 생략 시 공통 페이지 전체.
+- --max-dbot N 지정 시 |Δbot| > N 인 페이지가 있으면 exit 1 (게이트 모드).
+"""
+from __future__ import annotations
+
+import argparse
+import io
+import sys
+
+import fitz  # pymupdf
+from PIL import Image
+
+
+def page_bbox(doc: "fitz.Document", page_idx: int, dpi: int, thresh: int):
+    """페이지의 dark-pixel (top, bottom) y 좌표. 잉크 없으면 (None, None)."""
+    pix = doc[page_idx].get_pixmap(dpi=dpi)
+    img = Image.open(io.BytesIO(pix.tobytes("png"))).convert("L")
+    w, h = img.size
+    px = img.load()
+    top = bot = None
+    for y in range(h):
+        if any(px[x, y] < thresh for x in range(w)):
+            if top is None:
+                top = y
+            bot = y
+    return top, bot
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser(description=__doc__)
+    ap.add_argument("rhwp_pdf", help="rhwp export-pdf 산출 PDF")
+    ap.add_argument("hancom_pdf", help="한글 편집기 PDF 정답지")
+    ap.add_argument("--pages", default=None, help="1-기반 페이지 번호 콤마 구분 (예: 5,6)")
+    ap.add_argument("--dpi", type=int, default=96)
+    ap.add_argument("--thresh", type=int, default=160, help="dark-pixel 임계 (grayscale)")
+    ap.add_argument("--max-dbot", type=float, default=None, help="|Δbot| 게이트 (px, 초과 시 exit 1)")
+    a = ap.parse_args()
+
+    rd = fitz.open(a.rhwp_pdf)
+    hd = fitz.open(a.hancom_pdf)
+    print(f"pages: rhwp={rd.page_count} hancom={hd.page_count}")
+    if a.pages:
+        idxs = [int(p) - 1 for p in a.pages.split(",")]
+    else:
+        idxs = list(range(min(rd.page_count, hd.page_count)))
+
+    fail = False
+    for i in idxs:
+        if i >= rd.page_count or i >= hd.page_count:
+            print(f"p{i + 1}: (범위 밖)")
+            continue
+        ht, hb = page_bbox(hd, i, a.dpi, a.thresh)
+        rt, rb = page_bbox(rd, i, a.dpi, a.thresh)
+        if None in (ht, hb, rt, rb):
+            print(f"p{i + 1}: hancom={ht}/{hb} rhwp={rt}/{rb} (빈 페이지)")
+            continue
+        dt, db = rt - ht, rb - hb
+        mark = ""
+        if a.max_dbot is not None and abs(db) > a.max_dbot:
+            mark = "  << GATE FAIL"
+            fail = True
+        print(f"p{i + 1}: hancom top/bot={ht}/{hb}  rhwp top/bot={rt}/{rb}  dTop={dt:+d} dBot={db:+d}{mark}")
+
+    return 1 if fail else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 요약

#1728 잔여 갈래인 scattered header RowBreak 표(260×9, `samples/table_scattered_header_rowbreak.hwp`)의 p6 하단 +13px(1행 과다 노출)를 수정합니다. **p6 Δbot +13 → −4px** (한글 2024 PDF 기준, 96 DPI dark-pixel bbox).

Closes #1748

## 원인 — 이슈 추정과 다름

이슈는 #1718 grace 계열 행 컷 판정을 추정했으나, 조사 결과 **행 컷·페이지네이터 회계는 정확**했습니다 (`RHWP_TABLE_DRIFT`: consumed=981.1 ≤ avail=988.3, render tree 표 박스도 회계와 일치). 진짜 결함은 **컷 행에 걸친(straddling) rowspan 셀의 렌더 처리**:

- 페이지 경계가 rowspan 블록 내부를 per-row 분할할 때(#1022 경로) 컷 부기(start_cut/end_cut)는 컷 행의 `row_span==1` 셀만 담습니다.
- 경계에 걸친 rowspan 셀은 `is_split_end_row(cell_row == end_row-1)` 판별 밖 → `clip:false`, 컷 없음 → **컷 페이지에서 전체 줄 무제한 렌더** (셀 박스 +44.9px 초과, 표 경계 아래 3줄 잉크)
- **연속 페이지에선 처음부터 전체 재렌더** (중복 + 아래 행 침범 +61.9px)
- 한글은 컷 페이지에 들어가는 줄까지만 렌더하고 나머지를 연속 페이지에 이어그립니다.

## 수정 — 렌더러 한정, 페이지네이션 불변

- `table_layout.rs`: `cell_units_fitting_height` 헬퍼 (예산 내 선두 유닛 수, EPS 0.1px)
- `table_partial.rs`: RowBreak 표 비블록 분할에서 걸친 rowspan 셀 판별 → 높이 기반 유닛 컷. 연속 페이지의 su는 이전 프래그먼트 소비 높이를 2b 행높이 오버라이드와 **동일 식으로 결정적 재계산** → 컷 페이지 eu == 연속 페이지 su 가 산술적으로 일치 (상태 전달 불필요). 줄 범위 변환은 기존 `cell_line_ranges_from_cut` 재사용 + `clip:true` + Top 정렬 강제.

## 검증

| 게이트 | 결과 |
|--------|------|
| 본 건 p6 Δbot | **+13 → −4px** (p5 −6 무회귀, 53쪽 불변, p7 이어그리기 한글 정합) |
| 신규 테스트 3건 (`issue_1748_rowbreak_straddle_rowspan`) | 통과 — 수정 전 실측 +44.9/+61.9px 초과였던 단언 |
| `cargo test --release` 전체 | 2748 passed / 실질 실패 0 |
| svg_snapshot 골든 | 내용 기준 8/8 불변 (7건 로컬 실패는 Windows autocrlf CRLF 노이즈 → #1786) |
| giant(#1728 v2) / byeolpyo1 / byeolpyo4(#1658) | 42쪽·Δtop 유지 / 4쪽 / 26쪽 무회귀 |
| clipping_gate (92) | 회귀 0 / baseline 이탈 0 |
| render_page_gate 대형 오라클 (452) | 443 일치(98.0%) — #1658 기록 442 대비 +1 |

## 재현

```bash
rhwp dump-pages samples/table_scattered_header_rowbreak.hwp -p 5   # rows=100..140 end_cut=[1,2]
rhwp export-pdf samples/table_scattered_header_rowbreak.hwp -o out.pdf
# p6(idx5) vs pdf/table_scattered_header_rowbreak-2024.pdf p6 하단 비교
```

상세: `mydocs/report/task_m100_1748_report.md` (stage1 조사: `mydocs/working/task_m100_1748_stage1.md`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)