### PR TITLE
docs: PR 1743 이슈 close 후속 기록

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -4,7 +4,7 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #1692 | SO-SUEOP HWP3/HWPX 구조적 렌더링 보정 | PR merge 완료 / 후속 이슈 close 확인 필요 | PR #1743 merge commit `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`. 글색, Outline/개요번호, 페이지 수 46쪽, p22 관계도, p43~p46 미주 범위 보정. #1699 폰트 fallback은 open 유지 |
+| #1692 | SO-SUEOP HWP3/HWPX 구조적 렌더링 보정 | PR merge 완료 / 관련 이슈 close 처리 | PR #1743 merge commit `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`. 글색, Outline/개요번호, 페이지 수 46쪽, p22 관계도, p43~p46 미주 범위 보정. #1699 폰트 fallback은 open 유지 |
 
 ## PR 처리
 
@@ -19,4 +19,8 @@
 - #1743 issue mapping comment: https://github.com/edwardkim/rhwp/pull/1743#issuecomment-4864611550
 - 로컬 검증: `cargo clippy --all-targets -- -D warnings`, `env CARGO_INCREMENTAL=0 cargo test --all-targets`, `env CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과
 - 시각 검증: `visual_sweep_guide.md` 기준 SO-SUEOP HWP3/HWPX/PDF 46쪽, p22 관계도와 p43~p46 미주 범위 확인
-- issue close 확인: `devel`이 default branch가 아니어서 #1692 포함 관련 이슈는 자동 close되지 않음. #1692/#1693/#1694/#1696/#1697/#1698 close 후보, #1695 별도 판단, #1699 open 유지
+- issue close 확인: `devel`이 default branch가 아니어서 자동 close되지 않아 #1692/#1693/#1694/#1696/#1697/#1698 수동 close 완료
+- open 유지: #1689, #1695, #1699
+- #1695 판단: #1743에서 페이지 수와 p43~p46 미주 흐름은 해결됐지만 LINE_SEG vpos reset/rewind 일반 규칙 검증은 남아 open 유지
+- #1699 판단: 구조적 레이아웃 보정 뒤 폰트 fallback 조건별 비교가 아직 필요해 open 유지
+- close comment: #1692 https://github.com/edwardkim/rhwp/issues/1692#issuecomment-4864806076, #1693 https://github.com/edwardkim/rhwp/issues/1693#issuecomment-4864806208, #1694 https://github.com/edwardkim/rhwp/issues/1694#issuecomment-4864806357, #1696 https://github.com/edwardkim/rhwp/issues/1696#issuecomment-4864806486, #1697 https://github.com/edwardkim/rhwp/issues/1697#issuecomment-4864806638, #1698 https://github.com/edwardkim/rhwp/issues/1698#issuecomment-4864806850

--- a/mydocs/pr/archives/pr_1743_review.md
+++ b/mydocs/pr/archives/pr_1743_review.md
@@ -107,12 +107,21 @@ SO-SUEOP HWP3/HWPX/PDF 기준 페이지 수와 주요 시각 차이를 재검증
 - PR #1743 admin merge 완료: `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`
 - merge 시각: 2026-07-02 19:32 KST
 - `devel`이 default branch가 아니어서 `Closes #1692` auto-close는 동작하지 않았다.
-- 확인 시점 기준 #1689, #1692, #1693, #1694, #1695, #1696, #1697, #1698, #1699는 모두 open 상태다.
+- #1692, #1693, #1694, #1696, #1697, #1698은 수동 close 완료.
+- #1689, #1695, #1699는 open 유지.
+- #1695는 #1743에서 페이지 수와 미주 흐름 관련 증상이 상당 부분 줄었지만, 본문 6/23/28쪽 및 미주 42/44쪽의
+  원본 LINE_SEG vpos reset/rewind 힌트 해석 규칙까지 검증한 것은 아니므로 open 유지.
+- #1699는 구조적 레이아웃 보정 뒤에도 폰트 fallback 조건별 줄 높이/폭 비교가 별도로 필요하므로 open 유지.
 
 ## 후속 처리 계획
 
-- #1692, #1693, #1694, #1696, #1697, #1698 close 후보를 작업지시자 승인 후 처리
-- #1695는 close 또는 open 유지 판단을 별도 확인
-- #1699는 font fallback 후속으로 open 유지
+- #1692 close comment: https://github.com/edwardkim/rhwp/issues/1692#issuecomment-4864806076
+- #1693 close comment: https://github.com/edwardkim/rhwp/issues/1693#issuecomment-4864806208
+- #1694 close comment: https://github.com/edwardkim/rhwp/issues/1694#issuecomment-4864806357
+- #1696 close comment: https://github.com/edwardkim/rhwp/issues/1696#issuecomment-4864806486
+- #1697 close comment: https://github.com/edwardkim/rhwp/issues/1697#issuecomment-4864806638
+- #1698 close comment: https://github.com/edwardkim/rhwp/issues/1698#issuecomment-4864806850
+- #1695는 LINE_SEG vpos reset/rewind 일반 규칙 검증 후 별도 close 판단.
+- #1699는 font fallback 후속으로 open 유지.
 - #1689 parent 이슈는 하위 이슈 처리 상태 확인 후 별도 판단
 - PR 감사/후속 코멘트와 오늘할일은 문서-only PR로 반영

--- a/mydocs/pr/archives/pr_1743_review_impl.md
+++ b/mydocs/pr/archives/pr_1743_review_impl.md
@@ -120,12 +120,38 @@
 1. merge 직전 최신 GitHub Actions와 head SHA 재확인: 완료
 2. PR #1743 admin merge: 완료, `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`
 3. `upstream/devel` fetch: 완료
-4. 자동 close 여부 확인: #1692 포함 관련 이슈 모두 open
-5. #1692/#1693/#1694/#1696/#1697/#1698 close 누락 시 수동 close 판단 필요
-6. #1695는 실제 close 여부 별도 판단
+4. 자동 close 여부 확인: #1692 포함 관련 이슈 모두 open 상태였음
+5. #1692/#1693/#1694/#1696/#1697/#1698 수동 close 완료
+6. #1695는 실제 close 여부 확인 결과 open 유지
 7. #1699는 font fallback 후속으로 open 유지
 8. #1689 parent 이슈는 하위 이슈 상태를 본 뒤 별도 판단
 9. PR 후속 코멘트와 오늘할일 갱신은 문서-only PR로 반영
+
+## 수동 close 결과
+
+- #1692: https://github.com/edwardkim/rhwp/issues/1692#issuecomment-4864806076
+- #1693: https://github.com/edwardkim/rhwp/issues/1693#issuecomment-4864806208
+- #1694: https://github.com/edwardkim/rhwp/issues/1694#issuecomment-4864806357
+- #1696: https://github.com/edwardkim/rhwp/issues/1696#issuecomment-4864806486
+- #1697: https://github.com/edwardkim/rhwp/issues/1697#issuecomment-4864806638
+- #1698: https://github.com/edwardkim/rhwp/issues/1698#issuecomment-4864806850
+
+close 시 최초 코멘트의 브랜치명 표기가 shell quoting 문제로 깨져, 위 정정 코멘트를 추가로 남겼다.
+
+## open 유지 판단
+
+- #1695
+  - #1743에서 페이지 수 46쪽, p43~p46 미주 범위, p45 footer 겹침은 해결됐다.
+  - 하지만 #1695 본문 확인 기준은 일반 본문 6/23/28쪽과 미주 42/44/47쪽의 원본 LINE_SEG vpos reset/rewind가
+    페이지 또는 단 경계 힌트인지 검증하고, 반영 가능한 최소 규칙을 정의하는 것이다.
+  - 현재 회귀 테스트는 미주 내부 vpos=0 normalize와 페이지/미주 범위를 고정하지만, LINE_SEG reset/rewind 일반
+    규칙 검증까지 포함하지 않는다.
+  - 따라서 #1695는 부분 반영으로 보고 open 유지한다.
+- #1699
+  - #1743은 구조적 레이아웃 차이를 우선 해소했다.
+  - #1699의 확인 기준인 로컬 폰트 설치 여부, fallback 결과, `--font-style`, `--embed-fonts`, `--font-path`
+    옵션별 차이 비교는 아직 별도 검증하지 않았다.
+  - 따라서 #1699는 font fallback 후속 검증 이슈로 open 유지한다.
 
 ## 후속 코멘트 요지
 
@@ -134,4 +160,5 @@
 - 로컬 검증은 `clippy --all-targets`, `test --all-targets`, `release-test --tests`, issue 전용 테스트, 시각 sweep까지 통과했다.
 - SO-SUEOP 기준 PDF/HWP/HWPX 모두 46쪽이며, p22 관계도와 p43~p46 미주 흐름을 확인했다.
 - PR #1743은 `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`으로 merge 완료됐다.
-- #1699 폰트 fallback은 별도 후속으로 남긴다.
+- #1692/#1693/#1694/#1696/#1697/#1698은 수동 close 완료됐다.
+- #1695 LINE_SEG reset/rewind 일반 규칙과 #1699 폰트 fallback은 별도 후속으로 남긴다.


### PR DESCRIPTION
## 개요

PR #1743 merge 이후 자동 close되지 않은 관련 이슈의 수동 close 결과를 문서에 반영합니다.

## 변경 내용

- `mydocs/pr/archives/pr_1743_review.md`에 #1692/#1693/#1694/#1696/#1697/#1698 수동 close 결과 기록
- `mydocs/pr/archives/pr_1743_review_impl.md`에 close comment URL과 #1695/#1699 open 유지 판단 기록
- `mydocs/orders/20260702.md`에 후속 상태 갱신

## 확인

- 문서-only diff: 3 files
- `git diff --check` 통과
- #1692/#1693/#1694/#1696/#1697/#1698 closed 확인
- #1689/#1695/#1699 open 유지 확인
