### PR TITLE
docs: PR #1656 후속 처리 기록

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -11,6 +11,7 @@
 | PR | 내용 | 처리 |
 |----|------|------|
 | #1743 | #1692 SO-SUEOP HWP3/HWPX 렌더링 정합 보정 | GitHub Actions 통과 후 admin merge 완료. 리뷰 문서: `mydocs/pr/archives/pr_1743_review.md` |
+| #1656 | CanvasKit replay diagnostics 정합 (@seo-rii) | GitHub Actions 통과 후 admin merge 완료. merge commit `220923692bdb60b8c9c3537ac3a07321eb58c88e`. #536은 전체 트래킹 이슈라 open 유지. 리뷰 문서: `mydocs/pr/archives/pr_1656_review.md` |
 
 ## 후속 확인
 
@@ -24,3 +25,12 @@
 - #1695 판단: #1743에서 페이지 수와 p43~p46 미주 흐름은 해결됐지만 LINE_SEG vpos reset/rewind 일반 규칙 검증은 남아 open 유지
 - #1699 판단: 구조적 레이아웃 보정 뒤 폰트 fallback 조건별 비교가 아직 필요해 open 유지
 - close comment: #1692 https://github.com/edwardkim/rhwp/issues/1692#issuecomment-4864806076, #1693 https://github.com/edwardkim/rhwp/issues/1693#issuecomment-4864806208, #1694 https://github.com/edwardkim/rhwp/issues/1694#issuecomment-4864806357, #1696 https://github.com/edwardkim/rhwp/issues/1696#issuecomment-4864806486, #1697 https://github.com/edwardkim/rhwp/issues/1697#issuecomment-4864806638, #1698 https://github.com/edwardkim/rhwp/issues/1698#issuecomment-4864806850
+
+## PR #1656 후속 확인
+
+- PR head: `f7632d306b6df86ad2407b9f920874875b963af4`
+- merge commit: `220923692bdb60b8c9c3537ac3a07321eb58c88e`
+- 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1656#issuecomment-4864959740
+- 로컬 검증: `cargo fmt --all -- --check`, `env CARGO_INCREMENTAL=0 cargo test renderer::canvaskit_policy::tests --lib`, `npm run e2e:renderer-contract`, `npm run build`, `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`, `git diff --check` 통과
+- GitHub Actions: CI/CodeQL/Render Diff preflight, Canvas visual diff, Analyze rust/python/javascript-typescript, Build & Test 통과
+- 관련 이슈: #536은 전체 멀티 렌더러/CanvasKit parity 트래킹 이슈라 open 유지

--- a/mydocs/pr/archives/pr_1656_review.md
+++ b/mydocs/pr/archives/pr_1656_review.md
@@ -1,0 +1,96 @@
+# PR #1656 리뷰 — CanvasKit replay diagnostics 정합
+
+- PR: #1656 `render: align CanvasKit replay diagnostics`
+- 작성자: @seo-rii
+- 기준 브랜치: `devel`
+- PR head: `f7632d306b6df86ad2407b9f920874875b963af4` (문서 작성 시점 참고값)
+- merge commit: `220923692bdb60b8c9c3537ac3a07321eb58c88e`
+- 규모: 4 files, +180/-25
+- 관련 이슈: #536
+- 처리 결과: GitHub Actions 통과 후 admin merge 완료
+- 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1656#issuecomment-4864959740
+- 관련 이슈 처리: #536은 전체 멀티 렌더러/CanvasKit parity 트래킹 이슈라 open 유지
+
+## 변경 요약
+
+CanvasKit replay plan의 Rust 진단 결과와 Studio CanvasKit runtime이 실제로 직접 그리는 branch를 맞추는 PR이다.
+
+핵심 변경:
+
+- `src/renderer/canvaskit_policy.rs`
+  - `footnoteMarker`를 direct replay로 분류
+  - `formObject`, `placeholder`를 `basicStaticReplay` direct 항목으로 분류
+  - plain rotated `TextRun`을 direct path에 남기고 `rotatedText` transition detail에서 제외
+  - vertical/decoration/emphasis/outline/shadow/emboss/engrave/superscript/subscript/shade/ratio TextRun 효과는 policy-visible detail로 유지
+- `rhwp-studio/src/view/canvaskit-renderer.ts`
+  - `recordTextRunCoverageGaps`를 추가해 runtime에서 TextRun compatibility gap을 `unsupportedOps`에 기록
+  - rotation은 기존 `canvas.rotate` direct replay path로 유지
+- `rhwp-studio/src/core/types.ts`
+  - LayerTextStyle에 TextRun diagnostics parity에 필요한 style 필드 추가
+- `rhwp-studio/e2e/renderer-contract.test.mjs`
+  - renderer contract guard에 TextRun diagnostics와 rotation replay drift 방지 assertion 추가
+
+## 로컬 merge 검증
+
+`upstream/devel`은 PR head `f7632d306b6df86ad2407b9f920874875b963af4`의 조상이다.
+
+```bash
+git merge-base --is-ancestor upstream/devel HEAD
+```
+
+결과: exit code 0. 작성 시점 기준 PR head는 최신 `devel`을 포함한다.
+
+## 로컬 검증
+
+새 PR review 지침에 따라 cargo 검증 전 `target` 하위 항목을 삭제한 뒤 수행했다.
+
+- `cargo fmt --all -- --check`: 통과, real 2.47s
+- `env CARGO_INCREMENTAL=0 cargo test renderer::canvaskit_policy::tests --lib`: 16 passed, real 38.20s
+- `node --check e2e/renderer-contract.test.mjs`: 통과, real 0.05s
+- `npm run e2e:renderer-contract`: 통과, real 0.22s
+- `npm run build`: 통과, real 3.13s
+- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과, real 28.14s
+- `git diff --check`: 통과
+
+## GitHub Actions
+
+최신 PR head `f7632d306b6df86ad2407b9f920874875b963af4` 기준:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Render Diff preflight: success
+- WASM Build: skipped
+- Analyze (javascript-typescript): success
+- Analyze (python): success
+- Canvas visual diff: success
+- CodeQL: success
+- Analyze (rust): success
+- Build & Test: success
+
+GitHub Actions 완료 후 `MERGEABLE` + `CLEAN` 상태를 확인했다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+소스 대조와 contract 검증 기준으로 Rust policy와 Studio runtime이 같은 방향으로 정리되어 있다. PR은 새로운 CanvasKit
+렌더링 coverage를 크게 넓히는 변경이라기보다, Studio runtime에 이미 존재하는 direct branch와 Rust replay plan
+diagnostics를 맞추는 변경이다. TextRun effect 계열은 화면 정밀 구현 완료가 아니라 `unsupportedOps`/policy detail에
+남기는 진단 정합 작업으로 확인했다.
+
+브라우저 수동 시각 검증은 수행하지 않았으며, 이번 판단은 코드 대조, `renderer-contract`, build, Rust unit/clippy 검증
+범위다.
+
+## 비차단 확인 사항
+
+- `recordTextRunCoverageGaps`는 `renderTextRun`에서 실제 drawText 전에 호출되므로, CJK typeface 부재로 조기 return되는
+  경우에도 TextRun 효과 gap은 먼저 기록된다. 이후 `textRunFont`가 추가로 기록되는 구조라 진단 중복은 의도된 것으로
+  보인다.
+- `LayerTextStyle`에 추가된 필드는 JSON emission(`src/paint/json.rs`)에서 이미 내려오는 이름과 맞는다.
+
+## 최종 처리
+
+최신 head 기준 GitHub Actions가 통과했고 `MERGEABLE` + `CLEAN` 상태를 확인한 뒤 admin merge 완료.
+
+#536은 전체 remaining CanvasKit parity 범위를 닫지 않고 open 유지했다. PR 후속 코멘트에는 이번 PR이
+diagnostics 정합 단계라는 점과 로컬/CI 검증 결과를 남겼다.

--- a/mydocs/pr/archives/pr_1656_review_impl.md
+++ b/mydocs/pr/archives/pr_1656_review_impl.md
@@ -1,0 +1,88 @@
+# PR #1656 처리 계획 — CanvasKit replay diagnostics 정합
+
+## 대상
+
+- PR: #1656
+- 작성자: @seo-rii
+- 관련 이슈: #536
+- 문서 작성 시점 PR head: `f7632d306b6df86ad2407b9f920874875b963af4`
+- merge commit: `220923692bdb60b8c9c3537ac3a07321eb58c88e`
+- 처리 결과: GitHub Actions 통과 후 admin merge 완료
+
+## 커밋
+
+1. `780b00d050047b4c82c62b0a8a848aae2712a9cd`
+   - `fix(render): align CanvasKit replay diagnostics`
+   - 실제 기능 변경 커밋
+2. `0e18f1f54af0c247608763746ae57767e8c1104f`
+   - `Merge branch 'devel' into render-p31`
+   - Draft 해제 전 base 동기화 merge
+3. `f7632d306b6df86ad2407b9f920874875b963af4`
+   - `Merge branch 'devel' into render-p31`
+   - 최신 `devel` 동기화 merge
+
+## 검토 단계
+
+### Stage 1. PR 메타 확인
+
+- base branch: `devel`
+- draft: false (작성 시점 참고값)
+- maintainerCanModify: true
+- mergeable: `MERGEABLE` (작성 시점 참고값)
+- mergeStateStatus: `CLEAN`
+- 규모: 4 files, +180/-25
+
+이 PR은 이전에 Draft 상태라 정식 검토 대상이 아니었고, 해당 안내 코멘트를 남긴 바 있다. 현재는 Draft가 해제되어
+정식 리뷰 대상으로 전환됐다.
+
+### Stage 2. 변경 내용 검토
+
+완료.
+
+- 소스 기준 대조 완료: Rust policy의 direct/detail 분류와 Studio CanvasKit runtime branch를 변경부 기준으로 비교했다.
+- `TextRun` rotation은 Studio `renderTextRun`의 `canvas.rotate` direct path에 남고, Rust policy에서는 `rotatedText` transition detail에서 제외된 것을 확인했다.
+- vertical/effect 계열은 Rust `text_run_transition_detail`과 Studio `recordTextRunCoverageGaps` 양쪽에서 diagnostics로 남는 것을 확인했다.
+- `formObject`/`placeholder`는 Rust replay plan에서 `basicStaticReplay` direct로 분류되고, Studio runtime에는 `renderFormObject`/`renderPlaceholder` branch가 있는 것을 확인했다.
+- `renderer-contract`는 switch coverage에 더해 TextRun diagnostics 문자열과 rotation replay 구조를 정적 contract로 guard한다.
+- 한계: 브라우저에서 실제 CanvasKit 화면을 수동 시각 검증한 것은 아니며, 이번 확인은 소스 대조 + contract/e2e/build 검증 범위다.
+
+### Stage 3. 로컬 검증
+
+완료.
+
+새 PR review 지침에 따라 cargo 검증 전 `target` 하위 항목을 삭제했다.
+
+- `cargo fmt --all -- --check`: 통과
+- `env CARGO_INCREMENTAL=0 cargo test renderer::canvaskit_policy::tests --lib`: 통과
+- `node --check e2e/renderer-contract.test.mjs`: 통과
+- `npm run e2e:renderer-contract`: 통과
+- `npm run build`: 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과
+- `git diff --check`: 통과
+
+### Stage 4. GitHub Actions 확인
+
+완료.
+
+최신 PR head `f7632d306b6df86ad2407b9f920874875b963af4` 기준으로 GitHub Actions required checks가 통과했다.
+
+- GitHub Actions required checks 전체 통과
+- `MERGEABLE` + `CLEAN`
+- 작업지시자 merge 승인
+
+## merge 후 후속 처리 결과
+
+`mydocs/manual/pr_review_workflow.md` 기준으로 처리한다.
+
+1. merge 직전 최신 head SHA와 GitHub Actions 확인 완료
+2. PR #1656 admin merge 완료: `220923692bdb60b8c9c3537ac3a07321eb58c88e`
+3. `devel` fast-forward sync 완료
+4. PR 감사 코멘트 작성 완료: https://github.com/edwardkim/rhwp/pull/1656#issuecomment-4864959740
+5. #536은 전체 CanvasKit parity parent 성격이므로 open 유지 확인
+6. 리뷰 문서 archive 이동 및 오늘할일 갱신은 별도 문서-only PR로 반영
+
+## 후속 코멘트 요지
+
+- Draft 해제 후 다시 검토했고, 로컬 검증과 CI 통과를 확인했다.
+- 이번 PR은 CanvasKit runtime이 이미 직접 처리하는 branch와 replay diagnostics를 맞추는 변경으로 수용했다.
+- 남은 CanvasKit parity 항목은 #536 후속 단계에서 계속 추적한다.


### PR DESCRIPTION
## 요약

PR #1656 `render: align CanvasKit replay diagnostics` merge 후속 기록을 문서-only PR로 반영합니다.

## 대상

- 대상 PR: #1656
- 관련 이슈: #536
- PR head: `f7632d306b6df86ad2407b9f920874875b963af4`
- merge commit: `220923692bdb60b8c9c3537ac3a07321eb58c88e`
- 후속 코멘트: https://github.com/edwardkim/rhwp/pull/1656#issuecomment-4864959740

## 변경 내용

- `mydocs/pr/archives/pr_1656_review.md` 추가
- `mydocs/pr/archives/pr_1656_review_impl.md` 추가
- `mydocs/orders/20260702.md`에 #1656 처리 내역 추가

## 이슈 처리

#536은 전체 멀티 렌더러/CanvasKit parity 트래킹 이슈이므로 close하지 않고 open 유지했습니다.

## 검증

- `git diff --check` 통과
- 변경 범위는 `mydocs/**` 문서만 포함합니다.
- 후속 기록 PR fast-pass 조건에 맞는 문서-only 변경입니다.
