### PR TITLE
Task #1793: BULLET 직렬화 char_shape_id 누락 + NBSP 코드 24 오기 수정

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -6,6 +6,7 @@
 |------|--------|------|------|
 | #1692 | SO-SUEOP HWP3/HWPX 구조적 렌더링 보정 | PR merge 완료 / 관련 이슈 close 처리 | PR #1743 merge commit `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`. 글색, Outline/개요번호, 페이지 수 46쪽, p22 관계도, p43~p46 미주 범위 보정. #1699 폰트 fallback은 open 유지 |
 | #1801 | visual sweep 일반 파일 입력 및 overlay 검토 산출물 개선 | PR #1802 생성 / CI 대기 | 일반 HWP/HWPX 경로 입력, 특정 페이지 비교, overlay metric, review PNG 생성, Codex 보고 규칙 문서화 |
+| #1793 | HWPX→HWP 특수문자 렌더 손상 ('-'→NUL, NBSP→'-') | 수정 완료 / 검증 완료 / 승인 대기 | 원인 2건: ① serialize_bullet 이 문단 머리 정보 char_shape_id 4바이트 누락 → 재파싱 시 bullet_char 오프셋 어긋나 NUL ② NBSP 를 코드 24(하이픈)로 직렬화하는 오기 → 코드 30 으로 정정. admrul_0072/seoul_0505 재변환 렌더 원본 완전 일치, big_hwpx 2,500 중 bullet 보유 30건 전부 보존. 보고서: `mydocs/report/task_m100_1793_report.md` |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1793.md
+++ b/mydocs/plans/task_m100_1793.md
@@ -1,0 +1,59 @@
+# 수행 계획서 — Task M100 #1793
+
+## 이슈
+
+HWPX→HWP 라운드트립: 특수문자(하이픈/묶음빈칸) 렌더 문자 손상 — '-'→NUL, NBSP→'-' 오매핑
+
+- 재현물 A: `output/poc/hwpdocs_renderdiff/big_hwpx/admrul_0072.hwpx` (정상)
+- 재현물 B: `output/poc/hwpdocs_renderdiff/tmp_admrul_0072.hwp` (HWPX→HWP 저장본, 손상)
+- 증상: `export-text` 페이지 2/3에서 줄 머리 '-' 가 U+0000(NUL)으로 렌더 (총 4곳)
+- 역방향 증상: seoul_0505 에서 NBSP→'-' 손상
+
+## 조사 경과 (이슈 코멘트 기록 요약)
+
+1. IR 전수 비교(문단 166개 재귀, text/char_offsets/char_shapes/line_segs/field_ranges/doc_info
+   char_shapes·font_faces): 완전 동일 → 파스 산출물 축 소거
+2. `RHWP_FORCE_HWPX_SOURCE` 강제 플립: 무관 → is_hwpx_source 게이트 축 기각
+3. 전 문단 Debug 비교 유일 차이 = control_mask → 코드 24/30 인코딩 비대칭 가설
+
+## 최종 원인 (본 세션 확정)
+
+control_mask 는 red herring. 손상된 '-' 는 **본문 텍스트가 아니라 글머리표(Bullet) 문자**였다.
+(`diag` 로 확인: A bullet[0] char='-' U+002D, B bullet[0] char=U+0000)
+
+### 원인 1 — BULLET 레코드 직렬화 레이아웃 비대칭 ('-'→NUL)
+
+- `parse_bullet` (src/parser/doc_info.rs): 문단 머리 정보 **12바이트**
+  (attr 4 + width_adjust 2 + text_distance 2 + **char_shape_id 4**) 후 offset 12 에서
+  bullet_char 를 읽는다. 한컴 원본 HWP5 코퍼스에서 올바른 문자(○/-/PUA) 파싱 확인 — 파서가 정답.
+- `serialize_bullet` (src/serializer/doc_info.rs): char_shape_id 4바이트를 **누락**하고
+  offset 8 에 bullet_char 를 썼다. 재파싱 시 bullet_char 자리에서 image_bullet 하위 2바이트(0)를
+  읽어 '\0' 이 되고, 글머리표가 NUL 로 렌더된다.
+- HWP5→HWP5 는 raw_data 보존 경로라 무증상. **HWPX→HWP 저장(raw_data=None)에서만 발현.**
+- 이전 소거에서 doc_info 는 char_shapes/font_faces 만 비교해 bullets 차이가 빠져나갔다.
+
+### 원인 2 — NBSP 직렬화 코드 오기 (NBSP→'-')
+
+- `serialize_para_text` (src/serializer/body_text.rs): U+00A0(묶음 빈칸)을 코드 **24(0x18,
+  하이픈)** 로 기록 (초기 커밋부터의 오기). 파서 역매핑은 24→'-', 30(0x1E)→NBSP 이므로
+  재파싱 시 NBSP 가 '-' 로 손상된다. 올바른 코드는 **30(0x1E)**.
+
+## 수정 내용
+
+| 파일 | 수정 |
+|------|------|
+| `src/model/style.rs` | `Bullet` 에 `char_shape_id: u32` 필드 추가 (문단 머리 정보 12바이트 정합) |
+| `src/parser/doc_info.rs` | `parse_bullet` 이 char_shape_id 를 버리지 않고 보존 |
+| `src/serializer/doc_info.rs` | `serialize_bullet` 이 char_shape_id 4바이트를 기록 (레코드 24바이트) |
+| `src/serializer/body_text.rs` | NBSP → 0x001E (코드 30) 로 수정 |
+
+회귀 테스트:
+- `test_serialize_bullet_layout_and_roundtrip` (serializer/doc_info/tests.rs) — 레이아웃 + 전체 doc_info 라운드트립
+- `test_nbsp_serializes_as_code_30` (serializer/body_text.rs) — NBSP 코드 유닛 검증
+
+## 검증 계획
+
+1. `cargo test --release` 전수 (기대 실패: #1775 Windows 1건 외 전부 통과)
+2. admrul_0072: HWPX→HWP 재변환 후 4페이지 export-text 가 HWPX 원본과 **완전 일치**, NUL 0개 — 확인 완료
+3. seoul_0505: 재변환 후 2페이지 완전 일치 (기존 변환본은 p1 에서 8자 차이) — 확인 완료
+4. sample_hwpx 코퍼스 표본: 변환→재파싱 bullet 문자 보존 스윕

--- a/mydocs/report/task_m100_1793_report.md
+++ b/mydocs/report/task_m100_1793_report.md
@@ -1,0 +1,62 @@
+# 최종 결과 보고서 — Task M100 #1793
+
+## 이슈
+
+HWPX→HWP 라운드트립: 특수문자(하이픈/묶음빈칸) 렌더 문자 손상 — '-'→NUL, NBSP→'-' 오매핑
+
+## 결론
+
+두 개의 독립 버그를 각각 수정했다. 손상은 본문 텍스트가 아니라 **doc_info 직렬화 결함**
+(글머리표)과 **본문 특수문자 코드 오기**(NBSP)였다. 이전 세션의 control_mask 차이 가설은
+무관한 것으로 판명 (HWPX 로드 경로만 mask 를 재계산하는 기존 정상 동작).
+
+### 원인 1 — '-'→NUL: BULLET 레코드 직렬화 레이아웃 비대칭
+
+손상된 '-' 는 본문 문자가 아니라 **글머리표(Bullet) 문자**였다. admrul_0072 의 셀 문단
+(ps_id=34, HeadType::Bullet)은 본문 text 에 '-' 가 없고 렌더 시 bullet[0].bullet_char 를
+그린다. `diag` 확인: HWPX 원본 bullet[0]='-'(U+002D), HWP 저장본 bullet[0]=U+0000.
+
+- `parse_bullet`(src/parser/doc_info.rs)은 문단 머리 정보 **12바이트**(attr 4 +
+  width_adjust 2 + text_distance 2 + char_shape_id 4) 뒤 offset 12 에서 bullet_char 를
+  읽는다. 한컴 원본 HWP5 코퍼스(big_hwp)에서 ○/-/PUA 문자가 올바로 파싱됨 — 파서가 정답.
+- `serialize_bullet`(src/serializer/doc_info.rs)은 char_shape_id 4바이트를 **누락**하고
+  offset 8 에 bullet_char 를 기록했다. 재파싱 시 bullet_char 자리에서 image_bullet
+  하위 2바이트(0)를 읽어 '\0' 이 된다.
+- HWP5→HWP5 는 raw_data 보존 경로여서 무증상. **HWPX→HWP 저장(raw_data=None)에서만 발현.**
+- 이전 소거 조사에서 doc_info 는 char_shapes/font_faces 만 비교해 bullets 가 누락됐었다.
+
+### 원인 2 — NBSP→'-': 본문 직렬화 코드 오기
+
+`serialize_para_text`(src/serializer/body_text.rs)가 U+00A0(묶음 빈칸)을 코드
+**24(0x18, 하이픈)** 로 기록 (초기 커밋부터의 오기). 파서 역매핑은 24→'-', 30(0x1E)→NBSP.
+올바른 코드 **30(0x1E)** 으로 수정.
+
+## 수정 내역
+
+| 파일 | 수정 |
+|------|------|
+| `src/model/style.rs` | `Bullet.char_shape_id: u32` 필드 추가 (레코드 24바이트 정합) |
+| `src/parser/doc_info.rs` | `parse_bullet` 이 char_shape_id 보존 (기존: 읽고 버림) |
+| `src/serializer/doc_info.rs` | `serialize_bullet` 이 char_shape_id 4바이트 기록 |
+| `src/serializer/body_text.rs` | NBSP → 0x001E (코드 30) |
+
+회귀 테스트 2개 추가:
+- `serializer::doc_info::tests::test_serialize_bullet_layout_and_roundtrip` — 레이아웃(offset 12) + doc_info 전체 라운드트립
+- `serializer::body_text::tests::test_nbsp_serializes_as_code_30`
+
+## 검증 결과
+
+1. **cargo test --release 전수**: 2,053 lib + 통합 스위트 전부 통과. 유일 실패
+   `form_01_keeps_nine_cfb_streams` 은 경로 구분자(`/BodyText/Section0` vs
+   `\BodyText\Section0`) Windows 기대 실패 (#1775, 본 수정과 무관).
+2. **admrul_0072** ('-'→NUL 재현물): HWPX→HWP 재변환 후 4페이지 export-text 가
+   HWPX 원본과 **완전 일치**, NUL 0개 (수정 전: 페이지 2·3 에서 NUL 4개).
+3. **seoul_0505** (NBSP→'-' 재현물): 재변환 후 2페이지 **완전 일치**
+   (수정 전 변환본은 p1 에서 8자 차이).
+4. **코퍼스 스윕**: sample_hwpx 300 중 bullet 보유 3건, big_hwpx 2,500 중 30건 —
+   변환→재파싱 bullet 문자 **전부 보존, 불일치 0**.
+
+## 후속
+
+- #1795 (글상자 줄바꿈, seoul_0043): 본 수정 후 재검 예정 (같은 원인 가능성).
+- #1794 (표 앵커 95px, seoul_0765): 미조사.

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -316,7 +316,7 @@ pub struct NumberingHead {
     pub number_format: u8,
 }
 
-/// 글머리표 정의 (HWPTAG_BULLET, 표 44, 20바이트)
+/// 글머리표 정의 (HWPTAG_BULLET, 표 44, 24바이트)
 #[derive(Debug, Clone, Default)]
 pub struct Bullet {
     /// 원본 레코드 바이트 (라운드트립 보존용)
@@ -327,6 +327,8 @@ pub struct Bullet {
     pub width_adjust: i16,
     /// 본문과의 거리
     pub text_distance: i16,
+    /// 글자 모양 아이디 참조 (문단 머리 정보 12바이트의 마지막 4바이트)
+    pub char_shape_id: u32,
     /// 글머리표 문자 (●, ■, ▶ 등)
     pub bullet_char: char,
     /// 이미지 글머리표 여부 (0=문자, ID=이미지)

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -813,7 +813,7 @@ fn parse_bullet(data: &[u8]) -> Result<Bullet, DocInfoError> {
     let attr = r.read_u32().unwrap_or(0);
     let width_adjust = r.read_i16().unwrap_or(0);
     let text_distance = r.read_i16().unwrap_or(0);
-    let _char_shape_id = r.read_u32().unwrap_or(0);
+    let char_shape_id = r.read_u32().unwrap_or(0);
 
     // 글머리표 문자 (WCHAR, 2바이트)
     let bullet_char_u16 = r.read_u16().unwrap_or(0x2022); // 기본: ●(U+2022)
@@ -837,6 +837,7 @@ fn parse_bullet(data: &[u8]) -> Result<Bullet, DocInfoError> {
         attr,
         width_adjust,
         text_distance,
+        char_shape_id,
         bullet_char,
         image_bullet,
         image_data,

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -520,7 +520,9 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
                 prev_end = offset + 1;
             }
             '\u{00A0}' => {
-                code_units.push(0x0018);
+                // 묶음 빈칸 (HWP 5.0 표 7: 코드 30). 코드 24(0x18)는 하이픈으로
+                // 재파싱 시 '-' 가 되므로 쓰면 안 된다 (#1793).
+                code_units.push(0x001E);
                 prev_end = offset + 1;
             }
             '\u{2007}' => {
@@ -1116,6 +1118,22 @@ mod tests {
 
         assert_eq!(&bytes[8..10], &0x001F_u16.to_le_bytes());
         assert_ne!(compute_control_mask(&para) & (1u32 << 0x001f), 0);
+    }
+
+    /// [#1793] 묶음 빈칸(NBSP, U+00A0)은 코드 30(0x1E)으로 직렬화되어야 한다.
+    /// 코드 24(0x18)는 하이픈이라 재파싱 시 '-' 로 손상된다.
+    #[test]
+    fn test_nbsp_serializes_as_code_30() {
+        let para = Paragraph {
+            char_count: 4,
+            text: "가\u{00A0}나".to_string(),
+            char_offsets: vec![0, 1, 2],
+            ..Default::default()
+        };
+
+        let bytes = test_serialize_para_text(&para);
+
+        assert_eq!(&bytes[2..4], &0x001E_u16.to_le_bytes());
     }
 
     /// 컨트롤 문자 코드 매핑 테스트

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -569,14 +569,19 @@ fn serialize_numbering(numbering: &Numbering) -> Vec<u8> {
     w.into_bytes()
 }
 
-/// HWPTAG_BULLET 직렬화 (표 44: 글머리표, 20바이트)
+/// HWPTAG_BULLET 직렬화 (표 44: 글머리표)
+///
+/// 문단 머리 정보는 12바이트(attr 4 + width_adjust 2 + text_distance 2 +
+/// char_shape_id 4)다. char_shape_id 4바이트를 누락하면 재파싱 시
+/// bullet_char 오프셋이 어긋나 글머리표 문자가 NUL 로 손상된다 (#1793).
 fn serialize_bullet(bullet: &Bullet) -> Vec<u8> {
     let mut w = ByteWriter::new();
 
-    // 문단 머리 정보 (8바이트)
+    // 문단 머리 정보 (12바이트)
     w.write_u32(bullet.attr).unwrap();
     w.write_i16(bullet.width_adjust).unwrap();
     w.write_i16(bullet.text_distance).unwrap();
+    w.write_u32(bullet.char_shape_id).unwrap();
 
     // 글머리표 문자 (WCHAR)
     w.write_u16(bullet.bullet_char as u16).unwrap();

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -593,3 +593,56 @@ fn test_serialize_numbering_roundtrip() {
     let len = r.read_u16().unwrap();
     assert_eq!(len, 3);
 }
+
+/// [#1793] BULLET 레코드 직렬화 레이아웃 — 문단 머리 정보는 char_shape_id 포함
+/// 12바이트. char_shape_id 4바이트 누락 시 재파싱에서 bullet_char 오프셋이
+/// 어긋나 글머리표 문자가 NUL 로 손상된다 (HWPX→HWP 저장 후 렌더 손상).
+#[test]
+fn test_serialize_bullet_layout_and_roundtrip() {
+    let bullet = crate::model::style::Bullet {
+        raw_data: None,
+        attr: 0,
+        width_adjust: 0,
+        text_distance: 50,
+        char_shape_id: 2,
+        bullet_char: '-',
+        image_bullet: 0,
+        image_data: [0; 4],
+        check_bullet_char: '\0',
+    };
+
+    // 레이아웃: 문단 머리 정보 12바이트 후 offset 12 에 bullet_char
+    let data = serialize_bullet(&bullet);
+    assert_eq!(data.len(), 24);
+    let mut r = crate::parser::byte_reader::ByteReader::new(&data);
+    assert_eq!(r.read_u32().unwrap(), 0); // attr
+    assert_eq!(r.read_i16().unwrap(), 0); // width_adjust
+    assert_eq!(r.read_i16().unwrap(), 50); // text_distance
+    assert_eq!(r.read_u32().unwrap(), 2); // char_shape_id
+    assert_eq!(r.read_u16().unwrap(), '-' as u16); // bullet_char
+
+    // 전체 doc_info 라운드트립에서도 bullet_char 가 보존되어야 한다
+    let doc_props = DocProperties {
+        section_count: 1,
+        page_start_num: 1,
+        footnote_start_num: 1,
+        endnote_start_num: 1,
+        picture_start_num: 1,
+        table_start_num: 1,
+        equation_start_num: 1,
+        raw_data: None,
+        caret_list_id: 0,
+        caret_para_id: 0,
+        caret_char_pos: 0,
+    };
+    let mut doc_info = DocInfo::default();
+    doc_info.font_faces = vec![Vec::new(); 7];
+    doc_info.bullets.push(bullet);
+
+    let stream = serialize_doc_info(&doc_info, &doc_props);
+    let (parsed_info, _) = parse_doc_info(&stream).unwrap();
+    assert_eq!(parsed_info.bullets.len(), 1);
+    assert_eq!(parsed_info.bullets[0].bullet_char, '-');
+    assert_eq!(parsed_info.bullets[0].char_shape_id, 2);
+    assert_eq!(parsed_info.bullets[0].text_distance, 50);
+}


### PR DESCRIPTION
## 개요 (#1793)

HWPX→HWP 저장본 재파싱 시 특수문자 렌더가 손상되는 두 버그를 수정한다.

- **'-'→NUL (admrul_0072)**: 손상된 '-'는 본문이 아니라 **글머리표(Bullet) 문자**.
  `serialize_bullet`이 문단 머리 정보의 char_shape_id 4바이트를 누락하고 offset 8에
  bullet_char를 기록 → `parse_bullet`(offset 12에서 읽음, 한컴 원본 코퍼스로 검증된 정답
  레이아웃)과 어긋나 재파싱 시 '\0'을 읽고 글머리표가 NUL로 렌더. HWP5→HWP5는 raw_data
  보존 경로라 무증상, HWPX→HWP 저장에서만 발현.
- **NBSP→'-' (seoul_0505)**: `serialize_para_text`가 U+00A0(묶음 빈칸)을 코드 24(0x18,
  하이픈)로 기록하는 초기 커밋부터의 오기. 파서 역매핑(24→'-', 30→NBSP)에 맞춰
  코드 30(0x1E)으로 정정.

## 수정

- `Bullet` 모델에 `char_shape_id: u32` 추가 (파서 보존 + 직렬화 기록, 레코드 24바이트)
- NBSP → 0x001E
- 회귀 테스트 2개: `test_serialize_bullet_layout_and_roundtrip`, `test_nbsp_serializes_as_code_30`

## 검증

- admrul_0072: 재변환 후 4페이지 export-text가 HWPX 원본과 완전 일치 (NUL 4→0)
- seoul_0505: 재변환 후 2페이지 완전 일치 (기존 변환본 p1 8자 차이 → 0)
- 코퍼스 스윕: sample_hwpx 300 중 bullet 보유 3건 + big_hwpx 2,500 중 30건 — 변환→재파싱 bullet 문자 전부 보존
- big_hwpx 2,500 render-diff 게이트: seoul_0505 OVER 9→PASS 포함 개선만, 회귀 0
- cargo test --release 전수 통과 (#1775 Windows 기대 실패 1건 외)

보고서: `mydocs/report/task_m100_1793_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
