### PR TITLE
Task #1795: 필드 직렬화 갭 채우기에서 FIELD_END 공간 예약 (글상자 줄바꿈 이탈 수정, #1803 스택)

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -7,6 +7,7 @@
 | #1692 | SO-SUEOP HWP3/HWPX 구조적 렌더링 보정 | PR merge 완료 / 관련 이슈 close 처리 | PR #1743 merge commit `f50aa4ef7a011817d8ae0ae0e41b817d42f4b030`. 글색, Outline/개요번호, 페이지 수 46쪽, p22 관계도, p43~p46 미주 범위 보정. #1699 폰트 fallback은 open 유지 |
 | #1801 | visual sweep 일반 파일 입력 및 overlay 검토 산출물 개선 | PR #1802 생성 / CI 대기 | 일반 HWP/HWPX 경로 입력, 특정 페이지 비교, overlay metric, review PNG 생성, Codex 보고 규칙 문서화 |
 | #1793 | HWPX→HWP 특수문자 렌더 손상 ('-'→NUL, NBSP→'-') | 수정 완료 / 검증 완료 / 승인 대기 | 원인 2건: ① serialize_bullet 이 문단 머리 정보 char_shape_id 4바이트 누락 → 재파싱 시 bullet_char 오프셋 어긋나 NUL ② NBSP 를 코드 24(하이픈)로 직렬화하는 오기 → 코드 30 으로 정정. admrul_0072/seoul_0505 재변환 렌더 원본 완전 일치, big_hwpx 2,500 중 bullet 보유 30건 전부 보존. 보고서: `mydocs/report/task_m100_1793_report.md` |
+| #1795 | 글상자 줄바꿈 (seoul_0043) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: serialize_para_text 갭 채우기가 FIELD_END 공간 미예약 → 다음 FIELD_BEGIN이 갭 선점 → char_offsets 시프트 → lineseg 매핑 어긋남. 공간 예약으로 수정. seoul_0043 PASS(0.00), big_hwpx 개선 7건(seoul_0978 150→0 포함)·회귀 0, big_hwp 변화 0. 보고서: `mydocs/report/task_m100_1795_report.md` |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1795.md
+++ b/mydocs/plans/task_m100_1795.md
@@ -1,0 +1,48 @@
+# 수행 계획서 — Task M100 #1795
+
+## 이슈
+
+HWPX→HWP 라운드트립: 글상자 내부 줄바꿈 지점 차이 (텍스트 폭 계측 불일치)
+
+- 재현: seoul_0043 (`rhwp render-diff <hwpx> --via hwp`) → OVER 101px, page 2
+  Rect/TextBox의 줄 1~3만 다른 지점에서 꺾이고(3번째 줄은 글상자 우변 100px 초과)
+  4번째 줄부터 재일치.
+
+## 조사 경로 (소거 기록)
+
+1. #1793 수정 후 재검: 무관 확정 (OVER 101px 동일)
+2. 렌더 트리 대조: 같은 텍스트 런의 폭이 다름 → 그러나 줄 전체 폭 동일 = **justify
+   분배 차이 = 줄바꿈 문자 범위 차이**로 재해석
+3. 글상자 문단 IR 프로브(tests/tmp_1795_probe.rs, 임시): char_shapes·CharShape 정의·
+   폰트 정의 전부 동일 — "폭 계측 불일치" 가설 기각
+4. **char_offsets 대조에서 확정**: A는 idx35에서 +9(FIELD_END 1블록), B는 +17(2블록).
+   field_ranges: A [31..35], [101..105] / B [31..35], **[61..105]** — 이후 offsets 전부 시프트
+5. ir-diff는 Shape 글상자 문단을 재귀하지 않아(controls는 common만 비교) 소거망을
+   빠져나갔음 — 도구 개선 후보
+
+## 원인
+
+`serialize_para_text`(src/serializer/body_text.rs)의 갭 채우기 while문이 각 문자
+인덱스에서 **그 인덱스에 삽입될 FIELD_END(8 cu)의 공간을 예약하지 않고** 갭을 다음
+컨트롤로 채운다. FIELD_END 전용 갭(+8)을 다음 필드의 FIELD_BEGIN이 선점하면:
+
+- 스트림 컨트롤 위치가 원본과 달라져 재파싱 char_offsets 가 뒤로 시프트
+- lineseg text_start(보존값)의 utf16→문자 인덱스 매핑이 어긋남
+- compose_lines 의 줄 경계가 이동 → 글상자 줄바꿈 이탈 (박스 초과 렌더 포함)
+
+## 수정
+
+갭 채우기 전에 해당 인덱스의 FIELD_END 개수 × 8 cu 를 예약:
+`while prev_end + 8 + pending_field_end_cus <= offset && ...`
+
+회귀 테스트: `test_field_end_gap_not_stolen_by_next_control` (serializer/body_text.rs) —
+필드 2개 문단 직렬화→재파싱에서 char_offsets/field_ranges 보존 검증.
+
+## 검증 계획 및 결과
+
+1. seoul_0043 render-diff --via hwp: **OVER 101 → PASS 0.00** ✔
+2. big_hwpx 2,500 배치 vs #1794 시점 결과: **개선 7건, 회귀 0** ✔
+   (seoul_0043 101→0, seoul_0978 150→0, STRUCT 해소: admrul_0262/1077, seoul_0950,
+   STRUCT 완화: admrul_1078 293→118, admrul_1080 631→527)
+3. big_hwp 2,500 배치(identity): **변화 0건** ✔
+4. cargo test --release 전수 (진행 중 — #1775 기대 실패 외 통과 예정)

--- a/mydocs/report/task_m100_1795_report.md
+++ b/mydocs/report/task_m100_1795_report.md
@@ -1,0 +1,57 @@
+# 최종 결과 보고서 — Task M100 #1795
+
+## 이슈
+
+HWPX→HWP 라운드트립: 글상자 내부 줄바꿈 지점 차이 (seoul_0043, OVER 101px)
+
+## 결론
+
+이슈 등록 시 가설(텍스트 폭 계측 불일치)은 기각. 실제 원인은 **HWP5 직렬화기의
+필드 컨트롤 배치 버그**다. `serialize_para_text` 의 갭 채우기 루프가 각 문자
+인덱스에 삽입될 FIELD_END(8 code unit)의 공간을 예약하지 않아, FIELD_END 전용
+갭을 다음 컨트롤(다음 필드의 FIELD_BEGIN)이 선점했다. 그 결과 재파싱 시
+char_offsets 가 시프트되고, 보존된 lineseg text_start 의 utf16→문자 매핑이
+어긋나 줄바꿈 경계가 이동했다 (3번째 줄이 글상자 우변을 100px 초과하는 렌더 포함).
+
+## 원인 상세 (seoul_0043 글상자 p[1], 필드 2개 + 컨트롤 1개)
+
+| | A (HWPX 직파스) | B (변환본 재파스) |
+|---|---|---|
+| char_offsets idx35 점프 | +9 (FIELD_END 1블록) | **+17 (2블록 — FIELD_BEGIN이 선점)** |
+| field_ranges[1] | 101..105 | **61..105** |
+| lineseg text_start | [0,60,112,173,217] (동일) | 동일 — 매핑만 어긋남 |
+
+char_shapes/CharShape 정의/폰트 정의는 완전 동일 (프로브 대조). 렌더 트리에서
+줄 1~3만 경계 이동, 4번째 줄부터 재일치 — offsets 시프트 패턴과 정합.
+
+ir-diff 가 Shape 글상자 문단을 재귀 비교하지 않아(controls 는 common 속성만)
+이전 소거에서 빠져나갔다 — **도구 개선 후보**로 기록.
+
+## 수정 내역
+
+| 파일 | 수정 |
+|------|------|
+| `src/serializer/body_text.rs` | 갭 채우기 전 해당 인덱스 FIELD_END 공간(개수×8cu) 예약: `while prev_end + 8 + pending_field_end_cus <= offset` |
+
+회귀 테스트: `test_field_end_gap_not_stolen_by_next_control` — 필드 2개 문단
+직렬화→재파싱 char_offsets/field_ranges 보존.
+
+## 검증 결과
+
+1. **seoul_0043**: render-diff --via hwp OVER 101px → **PASS 0.00px**
+2. **big_hwpx 2,500 배치** (--via hwp, #1794 시점 대비): 변화 7건 전부 개선, **회귀 0** —
+   seoul_0043(101→0), **seoul_0978(150→0)**, STRUCT_MISMATCH 해소 3건
+   (admrul_0262, admrul_1077, seoul_0950), STRUCT 완화 2건 (admrul_1078 293→118,
+   admrul_1080 631→527). 누적 분포: PASS 2453 / OVER 10 / STRUCT 29 / PAGE 4 / LOAD 4.
+3. **big_hwp 2,500 배치** (identity): 변화 0건 (HWP5 raw 보존 경로 무영향).
+4. **cargo test --release** 전수: 통과 (유일 실패 = #1775 Windows 경로 구분자 기대 실패).
+
+## 세션 누적 효과 (#1793 + #1794 + #1795)
+
+big_hwpx 라운드트립 게이트: 기준선(v3fix) OVER 24 / STRUCT 32 → **OVER 10 / STRUCT 29**
+(OVER 19건 해소·신규 0, seoul_0765/0505/0043/0978 포함), PASS 2429 → 2453.
+
+## 후속
+
+- ir-diff 에 Shape 글상자 문단 재귀 비교 추가 (도구 개선, 별도 이슈 후보)
+- HWPX→HWP 변환 셀 field_name 소실 (#1794 조사 중 발견, 별도 이슈 후보)

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -482,7 +482,15 @@ fn serialize_para_text(para: &Paragraph) -> Vec<u8> {
         }
 
         // 갭에 컨트롤 문자 배치 (각 컨트롤 = 8 code unit)
-        while prev_end + 8 <= offset && ctrl_idx < para.controls.len() {
+        // [#1795] 이 인덱스에 삽입될 FIELD_END(각 8 cu)의 공간을 먼저 예약한다.
+        // 예약 없이 갭을 컨트롤로 채우면 FIELD_END 전용 갭(8 cu)을 다음 컨트롤이
+        // 선점하여 이후 모든 char_offsets 가 시프트되고, 재파싱 시 lineseg
+        // text_start 매핑이 어긋나 줄바꿈 위치가 이동한다 (seoul_0043 글상자).
+        let pending_field_end_cus = field_ends
+            .get(&i)
+            .map(|markers| markers.len() as u32 * 8)
+            .unwrap_or(0);
+        while prev_end + 8 + pending_field_end_cus <= offset && ctrl_idx < para.controls.len() {
             let (ctrl_code, ctrl_id) = control_char_code_and_id(&para.controls[ctrl_idx]);
             push_extended_ctrl(&mut code_units, ctrl_code, ctrl_id);
             ctrl_idx += 1;
@@ -1187,6 +1195,72 @@ mod tests {
         assert!(bytes
             .windows(expected_field_end.len())
             .any(|window| window == expected_field_end));
+    }
+
+    /// [#1795] FIELD_END 전용 갭(8 cu)을 다음 컨트롤(FIELD_BEGIN)이 선점하면
+    /// 이후 char_offsets 가 시프트되어 lineseg text_start 매핑이 어긋난다.
+    /// 필드 2개 문단에서 스트림 배치와 offsets 가 라운드트립 보존되는지 검증.
+    #[test]
+    fn test_field_end_gap_not_stolen_by_next_control() {
+        let make_field = || {
+            Control::Field(Field {
+                field_type: FieldType::Hyperlink,
+                ctrl_id: tags::FIELD_HYPERLINK,
+                ..Default::default()
+            })
+        };
+        let para = Paragraph {
+            char_count: 38,
+            text: "ab cd".to_string(),
+            // [FB0 0..8] a=8 b=9 [FE0 10..18] ' '=18 [FB1 19..27] c=27 d=28 [FE1] 0x0D
+            char_offsets: vec![8, 9, 18, 27, 28],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            controls: vec![make_field(), make_field()],
+            field_ranges: vec![
+                crate::model::paragraph::FieldRange {
+                    start_char_idx: 0,
+                    end_char_idx: 2,
+                    control_idx: 0,
+                },
+                crate::model::paragraph::FieldRange {
+                    start_char_idx: 3,
+                    end_char_idx: 5,
+                    control_idx: 1,
+                },
+            ],
+            ..Default::default()
+        };
+
+        let section = Section {
+            paragraphs: vec![para],
+            raw_stream: None,
+            ..Default::default()
+        };
+
+        let bytes = serialize_section(&section);
+        let parsed = parse_body_text_section(&bytes).unwrap();
+
+        assert_eq!(parsed.paragraphs.len(), 1);
+        let p = &parsed.paragraphs[0];
+        assert_eq!(p.text, "ab cd");
+        assert_eq!(
+            p.char_offsets,
+            vec![8, 9, 18, 27, 28],
+            "FIELD_END 갭 선점으로 char_offsets 가 시프트되면 안 된다"
+        );
+        assert_eq!(p.field_ranges.len(), 2);
+        assert_eq!(
+            (p.field_ranges[1].start_char_idx, p.field_ranges[1].end_char_idx),
+            (3, 5),
+            "두 번째 필드 범위가 앞으로 당겨지면 안 된다"
+        );
     }
 
     /// 확장 컨트롤 포함 문단 라운드트립

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -1257,10 +1257,10 @@ mod tests {
         );
         assert_eq!(p.field_ranges.len(), 2);
         assert_eq!(
-            (p.field_ranges[1].start_char_idx, p.field_ranges[1].end_char_idx),
-            (3, 5),
+            p.field_ranges[1].start_char_idx, 3,
             "두 번째 필드 범위가 앞으로 당겨지면 안 된다"
         );
+        assert_eq!(p.field_ranges[1].end_char_idx, 5);
     }
 
     /// 확장 컨트롤 포함 문단 라운드트립


### PR DESCRIPTION
## 개요 (#1795) — pr/devel-1793 스택

HWPX→HWP 저장본 재파싱에서 글상자 내부 줄바꿈 지점이 이동하는 문제(seoul_0043,
OVER 101px — 3번째 줄이 글상자 우변을 100px 초과 렌더)를 수정한다.

이슈 등록 시 가설(텍스트 폭 계측 불일치)은 기각 — char_shapes/CharShape 정의/폰트
정의 전부 동일 확인. 실원인은 **`serialize_para_text`의 필드 컨트롤 배치 버그**:
갭 채우기 루프가 각 문자 인덱스에 삽입될 FIELD_END(8 cu)의 공간을 예약하지 않아,
FIELD_END 전용 갭을 다음 필드의 FIELD_BEGIN이 선점했다. 재파싱 시 char_offsets가
시프트(idx35 점프 A +9 vs B +17, field_ranges[1] 101..105 → 61..105)되고, 보존된
lineseg text_start의 utf16→문자 매핑이 어긋나 줄 경계가 이동했다.

## 수정

- 갭 채우기 전 해당 인덱스 FIELD_END 공간 예약:
  `while prev_end + 8 + pending_field_end_cus <= offset && ...`
- 회귀 테스트 `test_field_end_gap_not_stolen_by_next_control` 추가

## 검증

- seoul_0043: OVER 101px → **PASS 0.00px**
- big_hwpx 2,500 배치: 변화 7건 전부 개선, **회귀 0** — seoul_0978 150→0 동반 해소,
  STRUCT_MISMATCH 해소 3건(admrul_0262/1077, seoul_0950), 완화 2건
- big_hwp 2,500 배치(identity): 변화 0
- cargo test --release 전수 통과 (#1775 기대 실패 외), 본 스택 lib 2058 passed

부수 발견(별도 이슈 후보): ir-diff가 Shape 글상자 문단을 재귀 비교하지 않아
(controls는 common만) 이런 유형이 소거망을 빠져나간다.

보고서: `mydocs/report/task_m100_1795_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
