### PR TITLE
ci: 문서-only PR fast-pass 판정 보강

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,18 @@ jobs:
               }
 
               const pr = context.payload.pull_request;
+              const prFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+              if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
+                core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);
+                setResult(true, 'all-review-only-no-code-impact', pr.base.sha);
+                return;
+              }
+
               const commits = await github.paginate(github.rest.pulls.listCommits, {
                 owner,
                 repo,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -124,6 +124,18 @@ jobs:
               }
 
               const pr = context.payload.pull_request;
+              const prFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+              if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
+                core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);
+                setResult(true, 'all-review-only-no-code-impact', pr.base.sha);
+                return;
+              }
+
               const commits = await github.paginate(github.rest.pulls.listCommits, {
                 owner,
                 repo,

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -124,6 +124,18 @@ jobs:
               }
 
               const pr = context.payload.pull_request;
+              const prFiles = await github.paginate(github.rest.pulls.listFiles, {
+                owner,
+                repo,
+                pull_number: pr.number,
+                per_page: 100,
+              });
+              if (prFiles.length > 0 && prFiles.every((file) => isAllowedReviewPath(file))) {
+                core.info(`all PR files are review-only; using base SHA ${pr.base.sha}`);
+                setResult(true, 'all-review-only-no-render-impact', pr.base.sha);
+                return;
+              }
+
               const commits = await github.paginate(github.rest.pulls.listCommits, {
                 owner,
                 repo,


### PR DESCRIPTION
## 변경 내용

- CI / CodeQL / Render Diff preflight 초반에 PR 최종 파일 목록(`pulls.listFiles`) 기반 review-only 판정을 추가했습니다.
- PR 최종 diff가 `mydocs/**` 또는 새로 추가된 review reference 파일(`samples/*.hwp|hwpx|pdf`, `pdf/*.pdf`)만 포함하면 merge commit 이력과 무관하게 heavy job을 fast-pass 합니다.
- 최종 PR diff에 코드/테스트/workflow 변경이 남아 있으면 기존 trailing review-only commit 판정 로직으로 fallback 합니다.

## 배경

#1776처럼 실제 PR diff는 문서-only인데 head history에 `devel` merge commit이 포함된 경우, 기존 preflight는 merge commit의 파일 목록을 보고 `no-trailing-review-only-commits`로 판단해 full CI를 실행했습니다.

이번 변경은 최종 PR diff가 문서-only임이 명확한 경우 heavy CI를 skip하도록 보강합니다.

## 검증

- `git diff --check`
- `ruby -e 'require "yaml"; ... YAML.load_file(...)'` 로 `ci.yml`, `codeql.yml`, `render-diff.yml` 파싱 확인
- #1776의 `pulls.listFiles` 결과가 `mydocs/plans/task_m100_1769.md`, `mydocs/report/task_m100_1769_report.md` 2개뿐임을 확인
