### PR TITLE
Task #1807: ir-diff 에 Shape 글상자 내부 문단 재귀 비교 추가

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -9,6 +9,7 @@
 | #1793 | HWPX→HWP 특수문자 렌더 손상 ('-'→NUL, NBSP→'-') | 수정 완료 / 검증 완료 / 승인 대기 | 원인 2건: ① serialize_bullet 이 문단 머리 정보 char_shape_id 4바이트 누락 → 재파싱 시 bullet_char 오프셋 어긋나 NUL ② NBSP 를 코드 24(하이픈)로 직렬화하는 오기 → 코드 30 으로 정정. admrul_0072/seoul_0505 재변환 렌더 원본 완전 일치, big_hwpx 2,500 중 bullet 보유 30건 전부 보존. 보고서: `mydocs/report/task_m100_1793_report.md` |
 | #1795 | 글상자 줄바꿈 (seoul_0043) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: serialize_para_text 갭 채우기가 FIELD_END 공간 미예약 → 다음 FIELD_BEGIN이 갭 선점 → char_offsets 시프트 → lineseg 매핑 어긋남. 공간 예약으로 수정. seoul_0043 PASS(0.00), big_hwpx 개선 7건(seoul_0978 150→0 포함)·회귀 0, big_hwp 변화 0. 보고서: `mydocs/report/task_m100_1795_report.md` |
 | #1794 | 표 앵커 95px (seoul_0765) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: 자리차지 표 exclusion 잉크-겹침 프로브의 is_hwpx_source 게이트 → HWP5 재파스에서 텍스트가 표에 겹침. 게이트 제거. seoul_0765 PASS(0.00), big_hwpx 개선 21건(OVER 12건 해소)·회귀 0, big_hwp 개선 1건·회귀 0. 보고서: `mydocs/report/task_m100_1794_report.md` |
+| #1807 | ir-diff 글상자 내부 문단 재귀 비교 | 구현 완료 / 검증 완료 | #1795 유형 소거망 구멍 보강. pre-#1795 변환본에서 char_offsets/field_ranges 시프트 정확 검출, 수정본 무소음, 코퍼스 스팟 노이즈 0. 보고서: `mydocs/report/task_m100_1807_report.md` |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1807.md
+++ b/mydocs/plans/task_m100_1807.md
@@ -1,0 +1,31 @@
+# 수행 계획서 — Task M100 #1807
+
+## 이슈
+
+ir-diff: Shape 글상자 내부 문단 재귀 비교 부재 (#1795 유형 소거망 구멍)
+
+## 배경
+
+#1795 조사에서 seoul_0043 글상자 문단의 char_offsets/field_ranges 가 직렬화 결함으로
+크게 달랐는데도 ir-diff 는 검출하지 못했다. `Control::Shape` 비교가 common 속성만
+보고 text_box 내부 문단을 재귀하지 않기 때문 (Table 은 diff_table 존재하나 Shape 는
+diff_common_obj 뿐).
+
+## 구현
+
+`src/main.rs` ir-diff 에 3개 헬퍼 추가:
+
+- `diff_textbox_paragraph_fields` — 글상자 문단 한 쌍의 핵심 필드 비교
+  (text / cc / char_offsets / char_shapes / line_segs(ts·vpos) / field_ranges)
+- `diff_textbox_paragraph_lists` — 문단 목록 비교 + 중첩 글상자(Shape in Shape) 재귀
+- `diff_shape_textbox` — text_box 유무 비교 + 진입점, Shape 매치 암에서 호출
+
+출력 접두어 `ctrl[N] shape tb_p[K]` — 기존 --summary 카테고리 규칙과 호환.
+
+## 검증 계획
+
+1. **#1795 유형 검출 확인**: pre-#1795 빌드 변환본(output/poc/task1795/seoul_0043.hwp,
+   글상자 char_offsets 시프트 보유) vs 원본 HWPX → tb_p 차이 보고되어야 함
+2. **수정 후 무소음 확인**: 현재 빌드 변환본 → 글상자 차이 0
+3. 코퍼스 표본 스팟체크 (seoul_0765, admrul_0072 등) — 크래시/과다 노이즈 없음
+4. cargo test --release --lib

--- a/mydocs/report/task_m100_1807_report.md
+++ b/mydocs/report/task_m100_1807_report.md
@@ -1,0 +1,33 @@
+# 최종 결과 보고서 — Task M100 #1807
+
+## 이슈
+
+ir-diff: Shape 글상자 내부 문단 재귀 비교 부재 (#1795 유형 소거망 구멍)
+
+## 결론
+
+ir-diff 에 글상자(text_box) 내부 문단 재귀 비교를 추가했다. #1795 유형(글상자 내부
+직렬화 결함)이 이제 render-diff 시각 이탈 단계가 아니라 ir-diff 단계에서 즉시 검출된다.
+
+## 구현 내역
+
+| 파일 | 내용 |
+|------|------|
+| `src/main.rs` | `diff_textbox_paragraph_fields`(문단 쌍 핵심 필드 비교: text/cc/char_offsets/char_shapes/line_segs/field_ranges) + `diff_textbox_paragraph_lists`(목록 비교, 중첩 글상자 재귀) + `diff_shape_textbox`(유무 비교 + 진입점) 추가, Shape 매치 암에서 호출 |
+
+출력 접두어 `ctrl[N] shape tb_p[K]` — 기존 `--summary` 카테고리 집계와 호환.
+
+## 검증 결과
+
+1. **#1795 결함 검출 확인** (pre-#1795 빌드 변환본 seoul_0043.hwp):
+   `ctrl[0] shape tb_p[1] char_offsets[35]: A=51 vs B=59`,
+   `field_ranges[1]: A=(101..105,c2) vs B=(61..105,c2)` — 결함 시그니처 정확 검출 ✔
+2. **수정 후 무소음**: 현재 빌드 변환본 → 글상자 차이 0 (기존 무관 cc 1건만) ✔
+3. **코퍼스 스팟체크** (seoul_0765/admrul_0072/seoul_0505/seoul_0978 변환→비교):
+   신규 노이즈 0, 크래시 없음 ✔
+4. cargo test --release --lib 통과 (도구는 bin 전용 — lib 무영향) ✔
+
+## 비고
+
+- CLAUDE.md 의 ir-diff 비교 항목 문구는 별도 문서 정리 시 갱신 후보
+  (그림/도형 항목에 "글상자 내부 문단 재귀" 추가)

--- a/src/main.rs
+++ b/src/main.rs
@@ -4624,6 +4624,173 @@ fn diff_common_obj(
     }
 }
 
+/// [#1807] 글상자 문단 한 쌍의 핵심 필드 비교 — 본문 문단 비교의 축약판.
+/// 직렬화 결함(#1795: FIELD_END 갭 선점 → char_offsets 시프트)이 글상자 안에서
+/// 발생해도 ir-diff 가 검출하도록 text/cc/char_offsets/char_shapes/line_segs/
+/// field_ranges 를 비교한다.
+fn diff_textbox_paragraph_fields(
+    diffs: &mut Vec<String>,
+    prefix: &str,
+    pa: &rhwp::model::paragraph::Paragraph,
+    pb: &rhwp::model::paragraph::Paragraph,
+) {
+    if pa.text != pb.text {
+        diffs.push(format!(
+            "{} text: A={:?} vs B={:?}",
+            prefix,
+            pa.text.chars().take(30).collect::<String>(),
+            pb.text.chars().take(30).collect::<String>()
+        ));
+    }
+    if pa.char_count != pb.char_count {
+        diffs.push(format!(
+            "{} cc: A={} vs B={}",
+            prefix, pa.char_count, pb.char_count
+        ));
+    }
+    if pa.char_offsets != pb.char_offsets {
+        if pa.char_offsets.len() != pb.char_offsets.len() {
+            diffs.push(format!(
+                "{} char_offsets len: A={} vs B={}",
+                prefix,
+                pa.char_offsets.len(),
+                pb.char_offsets.len()
+            ));
+        } else if let Some((idx, (a, b))) = pa
+            .char_offsets
+            .iter()
+            .zip(pb.char_offsets.iter())
+            .enumerate()
+            .find(|(_, (a, b))| a != b)
+        {
+            diffs.push(format!(
+                "{} char_offsets[{}]: A={} vs B={}",
+                prefix, idx, a, b
+            ));
+        }
+    }
+    if pa.char_shapes.len() != pb.char_shapes.len() {
+        diffs.push(format!(
+            "{} char_shapes count: A={} vs B={}",
+            prefix,
+            pa.char_shapes.len(),
+            pb.char_shapes.len()
+        ));
+    } else if let Some((idx, (ca, cb))) = pa
+        .char_shapes
+        .iter()
+        .zip(pb.char_shapes.iter())
+        .enumerate()
+        .find(|(_, (ca, cb))| ca.start_pos != cb.start_pos || ca.char_shape_id != cb.char_shape_id)
+    {
+        diffs.push(format!(
+            "{} cs[{}]: A=({},{}) vs B=({},{})",
+            prefix, idx, ca.start_pos, ca.char_shape_id, cb.start_pos, cb.char_shape_id
+        ));
+    }
+    if pa.line_segs.len() != pb.line_segs.len() {
+        diffs.push(format!(
+            "{} line_segs count: A={} vs B={}",
+            prefix,
+            pa.line_segs.len(),
+            pb.line_segs.len()
+        ));
+    } else if let Some((idx, (la, lb))) = pa
+        .line_segs
+        .iter()
+        .zip(pb.line_segs.iter())
+        .enumerate()
+        .find(|(_, (la, lb))| la.text_start != lb.text_start || la.vertical_pos != lb.vertical_pos)
+    {
+        diffs.push(format!(
+            "{} ls[{}]: A=(ts={},vpos={}) vs B=(ts={},vpos={})",
+            prefix, idx, la.text_start, la.vertical_pos, lb.text_start, lb.vertical_pos
+        ));
+    }
+    if pa.field_ranges.len() != pb.field_ranges.len() {
+        diffs.push(format!(
+            "{} field_ranges count: A={} vs B={}",
+            prefix,
+            pa.field_ranges.len(),
+            pb.field_ranges.len()
+        ));
+    } else if let Some((idx, (fa, fb))) = pa
+        .field_ranges
+        .iter()
+        .zip(pb.field_ranges.iter())
+        .enumerate()
+        .find(|(_, (fa, fb))| {
+            fa.start_char_idx != fb.start_char_idx
+                || fa.end_char_idx != fb.end_char_idx
+                || fa.control_idx != fb.control_idx
+        })
+    {
+        diffs.push(format!(
+            "{} field_ranges[{}]: A=({}..{},c{}) vs B=({}..{},c{})",
+            prefix,
+            idx,
+            fa.start_char_idx,
+            fa.end_char_idx,
+            fa.control_idx,
+            fb.start_char_idx,
+            fb.end_char_idx,
+            fb.control_idx
+        ));
+    }
+}
+
+/// [#1807] 글상자 문단 목록 재귀 비교. 중첩 글상자(Shape in Shape)도 재귀한다.
+fn diff_textbox_paragraph_lists(
+    diffs: &mut Vec<String>,
+    prefix: &str,
+    pas: &[rhwp::model::paragraph::Paragraph],
+    pbs: &[rhwp::model::paragraph::Paragraph],
+) {
+    use rhwp::model::control::Control;
+    if pas.len() != pbs.len() {
+        diffs.push(format!(
+            "{} tb 문단 수: A={} vs B={}",
+            prefix,
+            pas.len(),
+            pbs.len()
+        ));
+    }
+    for (k, (pa, pb)) in pas.iter().zip(pbs.iter()).enumerate() {
+        let p = format!("{} tb_p[{}]", prefix, k);
+        diff_textbox_paragraph_fields(diffs, &p, pa, pb);
+        for (cj, (ca, cb)) in pa.controls.iter().zip(pb.controls.iter()).enumerate() {
+            if let (Control::Shape(sa), Control::Shape(sb)) = (ca, cb) {
+                diff_shape_textbox(diffs, &format!("{}.ctrl[{}]", p, cj), sa, sb);
+            }
+        }
+    }
+}
+
+/// [#1807] Shape 글상자 유무 + 내부 문단 재귀 비교 진입점.
+fn diff_shape_textbox(
+    diffs: &mut Vec<String>,
+    prefix: &str,
+    sa: &rhwp::model::shape::ShapeObject,
+    sb: &rhwp::model::shape::ShapeObject,
+) {
+    let ta = sa.drawing().and_then(|d| d.text_box.as_ref());
+    let tb = sb.drawing().and_then(|d| d.text_box.as_ref());
+    match (ta, tb) {
+        (Some(ta), Some(tb)) => {
+            diff_textbox_paragraph_lists(diffs, prefix, &ta.paragraphs, &tb.paragraphs);
+        }
+        (Some(_), None) | (None, Some(_)) => {
+            diffs.push(format!(
+                "{} text_box 유무: A={} vs B={}",
+                prefix,
+                ta.is_some(),
+                tb.is_some()
+            ));
+        }
+        (None, None) => {}
+    }
+}
+
 /// `tab_extended`(`[u16; 7]`) 두 인라인 탭 레코드가 **의미 있는** 필드에서 다른지 판정.
 ///
 /// HWPX 파서(`parse_tab_extension`)는 인라인 탭을 `ext[0]`=width,
@@ -4972,6 +5139,9 @@ fn ir_diff(args: &[String]) {
                         }
                         (Control::Shape(sa), Control::Shape(sb)) => {
                             diff_common_obj(&mut diffs, ci, "shape", sa.common(), sb.common());
+                            // [#1807] 글상자 내부 문단 재귀 비교 — 직렬화 결함이
+                            // 글상자 안에서 발생해도 검출되도록 (#1795 소거망 구멍)
+                            diff_shape_textbox(&mut diffs, &format!("ctrl[{}] shape", ci), sa, sb);
                         }
                         _ if control_tag(ca) != control_tag(cb) => {
                             diffs.push(format!(


### PR DESCRIPTION
## 개요 (#1807)

ir-diff 의 `Control::Shape` 비교가 common 속성만 보고 **글상자(text_box) 내부 문단을
재귀하지 않아**, #1795 유형(글상자 내부 직렬화 결함 — char_offsets/field_ranges 시프트)이
소거망을 빠져나가던 도구 구멍을 보강한다.

## 구현

- `diff_textbox_paragraph_fields`: text / cc / char_offsets / char_shapes /
  line_segs(ts·vpos) / field_ranges 비교
- `diff_textbox_paragraph_lists`: 문단 수 비교 + 중첩 글상자(Shape in Shape) 재귀
- `diff_shape_textbox`: text_box 유무 비교 + 진입점 (Shape 매치 암에서 호출)
- 출력 접두어 `ctrl[N] shape tb_p[K]` — 기존 `--summary` 카테고리 집계와 호환

## 검증

- #1795 결함 시그니처 검출 확인 (pre-#1795 빌드 변환본 seoul_0043):
  `ctrl[0] shape tb_p[1] char_offsets[35]: A=51 vs B=59`,
  `field_ranges[1]: A=(101..105,c2) vs B=(61..105,c2)` — 정확 검출
- #1795 수정 빌드 변환본: 글상자 차이 0 (무소음)
- 코퍼스 스팟체크 (seoul_0765/admrul_0072/seoul_0505/seoul_0978): 신규 노이즈 0
- 도구(bin 전용) 변경 — lib 무영향

보고서: `mydocs/report/task_m100_1807_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
