### PR TITLE
Task #1808: 셀 field_name 을 한컴 raw_list_extra 계약으로 직렬화

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -9,6 +9,7 @@
 | #1793 | HWPX→HWP 특수문자 렌더 손상 ('-'→NUL, NBSP→'-') | 수정 완료 / 검증 완료 / 승인 대기 | 원인 2건: ① serialize_bullet 이 문단 머리 정보 char_shape_id 4바이트 누락 → 재파싱 시 bullet_char 오프셋 어긋나 NUL ② NBSP 를 코드 24(하이픈)로 직렬화하는 오기 → 코드 30 으로 정정. admrul_0072/seoul_0505 재변환 렌더 원본 완전 일치, big_hwpx 2,500 중 bullet 보유 30건 전부 보존. 보고서: `mydocs/report/task_m100_1793_report.md` |
 | #1795 | 글상자 줄바꿈 (seoul_0043) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: serialize_para_text 갭 채우기가 FIELD_END 공간 미예약 → 다음 FIELD_BEGIN이 갭 선점 → char_offsets 시프트 → lineseg 매핑 어긋남. 공간 예약으로 수정. seoul_0043 PASS(0.00), big_hwpx 개선 7건(seoul_0978 150→0 포함)·회귀 0, big_hwp 변화 0. 보고서: `mydocs/report/task_m100_1795_report.md` |
 | #1794 | 표 앵커 95px (seoul_0765) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: 자리차지 표 exclusion 잉크-겹침 프로브의 is_hwpx_source 게이트 → HWP5 재파스에서 텍스트가 표에 겹침. 게이트 제거. seoul_0765 PASS(0.00), big_hwpx 개선 21건(OVER 12건 해소)·회귀 0, big_hwp 개선 1건·회귀 0. 보고서: `mydocs/report/task_m100_1794_report.md` |
+| #1808 | HWPX→HWP 셀 field_name 소실 | 수정 완료 / 검증 완료 | 한컴 필드 셀 raw_list_extra 계약(원본 admrul_0039/0045 대조 확정)으로 직렬화. seoul_0765 필드 40개 완전 보존, 네이티브 80개 무영향, 기하 PASS 유지. 보고서: `mydocs/report/task_m100_1808_report.md` |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1808.md
+++ b/mydocs/plans/task_m100_1808.md
@@ -1,0 +1,44 @@
+# 수행 계획서 — Task M100 #1808
+
+## 이슈
+
+HWPX→HWP 변환 시 표 셀 field_name 소실 (누름틀/필드 충실도)
+
+## 원인
+
+- HWP5 파서(`parse_cell_field_name`)는 셀 LIST_HEADER 34바이트 이후 추가 바이트
+  (raw_list_extra)의 offset 15..17(name_len) + 17..(UTF-16LE)에서 필드명을 추출한다.
+- HWPX 파서는 `<hp:tc name>` 속성에서 `cell.field_name` 을 채우지만, HWP5 직렬화기는
+  raw_list_extra 를 **원본 그대로만** 기록한다. HWPX 출처 셀은 raw 가 없어
+  hwpx_to_hwp 어댑터가 13바이트(width+0×9)로 materialize → 필드명이 스트림에
+  기록되지 않고 재파싱 시 소실.
+
+## 한컴 계약 확인 (원본 대조 — admrul_0039/0045)
+
+필드 셀 raw_list_extra 레이아웃 (3개 샘플 정합, 총 25+2n 바이트):
+
+```
+[0..4]   width (u32 LE)
+[4..8]   ff 1b 02 01 (필드 속성 마커)
+[8..12]  00 ×4
+[12..15] 40 01 00
+[15..17] name_len (u16 LE)
+[17..]   UTF-16LE 필드 이름
+[+8]     00 ×8
+```
+
+필드 없는 셀: width(4) + 0×9 = 13바이트 (기존 default 와 동일).
+
+## 구현
+
+- `parser::control::parse_cell_field_name` → pub(crate) (직렬화 대칭 검사용)
+- `serializer/control.rs serialize_cell`: raw 인코딩과 모델 field_name 이 일치하면
+  원본 보존(네이티브 라운드트립 무영향), 불일치면 `build_cell_list_extra` 로
+  한컴 계약 레이아웃 재구성 (원본 extra 선두 4바이트 폭 참조는 보존)
+
+## 검증 계획
+
+1. seoul_0765 변환→재파싱: field="틀"/"발신명의" 보존 (기존: 소실)
+2. 네이티브 필드 셀(admrul_0039/0045) HWP5→HWP5 라운드트립: 바이트/필드 보존
+3. big_hwpx 코퍼스 render-diff 게이트 회귀 없음 (기하 무영향 예상 — 스팟체크)
+4. cargo test --release 전수

--- a/mydocs/report/task_m100_1808_report.md
+++ b/mydocs/report/task_m100_1808_report.md
@@ -1,0 +1,43 @@
+# 최종 결과 보고서 — Task M100 #1808
+
+## 이슈
+
+HWPX→HWP 변환 시 표 셀 field_name 소실 (누름틀/필드 충실도)
+
+## 결론
+
+셀 LIST_HEADER 추가 바이트(raw_list_extra)의 한컴 필드 셀 계약 레이아웃을 원본
+HWP5 대조(admrul_0039/0045, 필드 3개 샘플 정합)로 확정하고, 직렬화기가 모델
+`field_name` 을 이 레이아웃으로 기록하도록 수정했다. HWPX 출처 셀 필드가 HWP 저장
+후에도 보존된다.
+
+## 한컴 계약 (원본 대조로 확정)
+
+```
+[0..4]   width (u32 LE)
+[4..8]   ff 1b 02 01 (필드 속성 마커)
+[8..12]  00 ×4
+[12..15] 40 01 00
+[15..17] name_len (u16 LE)
+[17..]   UTF-16LE 필드 이름
+[+8]     00 ×8            (총 25 + 2n 바이트)
+```
+
+필드 없는 셀 = width(4)+0×9 = 13바이트 (기존 default 동일).
+
+## 수정 내역
+
+| 파일 | 내용 |
+|------|------|
+| `src/parser/control.rs` | `parse_cell_field_name` pub(crate) 승격 (직렬화 대칭 검사용) |
+| `src/serializer/control.rs` | `serialize_cell`: raw 인코딩과 모델 field_name 일치 시 원본 보존, 불일치 시 `build_cell_list_extra` 로 계약 레이아웃 재구성 (선두 4바이트 폭 참조 보존) |
+
+회귀 테스트: `test_cell_field_name_extra_roundtrip` (serializer/control/tests.rs)
+
+## 검증 결과
+
+1. **seoul_0765**: HWPX→HWP 변환 후 셀 필드 40개 목록 **완전 일치** (수정 전: 전부 소실)
+2. **네이티브 라운드트립**: admrul_0039 HWP5→HWP5 필드 80개 완전 일치
+   (raw 일치 경로는 원본 바이트 보존 — 네이티브 무영향)
+3. **기하 회귀**: seoul_0765 render-diff --via hwp PASS 0.00px 유지
+4. **cargo test --release** 전수: 통과 (유일 실패 = #1775 기대 실패), 신규 테스트 포함

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -388,8 +388,9 @@ fn parse_cell(records: &[Record]) -> Cell {
 }
 
 /// 셀의 raw_list_extra에서 필드 이름을 추출한다.
-/// 구조: raw_list_extra[14..16] = name_len (u16), [16..16+name_len*2] = UTF-16LE 문자열
-fn parse_cell_field_name(extra: &[u8]) -> Option<String> {
+/// 구조: raw_list_extra[15..17] = name_len (u16 LE), [17..17+name_len*2] = UTF-16LE 문자열
+/// (직렬화 대칭: serializer::control::build_cell_list_extra — #1808)
+pub(crate) fn parse_cell_field_name(extra: &[u8]) -> Option<String> {
     if extra.len() < 18 {
         return None;
     }

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -593,11 +593,13 @@ fn serialize_cell(cell: &Cell, level: u16, records: &mut Vec<Record>) {
 
     // 원본 추가 바이트 복원. HWPX/신규 생성 셀에는 원본이 없으므로
     // 한컴 저장본의 셀 LIST_HEADER 47바이트 contract에 맞춰 폭 참조를 보강한다.
-    if !cell.raw_list_extra.is_empty() {
+    // [#1808] 모델의 field_name 과 raw_list_extra 인코딩이 일치하면 원본 보존,
+    // 불일치(HWPX 출처 셀 필드, 편집기 변경)면 한컴 계약대로 재구성한다.
+    let raw_field = crate::parser::control::parse_cell_field_name(&cell.raw_list_extra);
+    if !cell.raw_list_extra.is_empty() && raw_field.as_deref() == cell.field_name.as_deref() {
         w.write_bytes(&cell.raw_list_extra).unwrap();
     } else {
-        w.write_u32(cell.width).unwrap();
-        w.write_bytes(&[0; 9]).unwrap();
+        w.write_bytes(&build_cell_list_extra(cell)).unwrap();
     }
 
     records.push(Record {
@@ -609,6 +611,48 @@ fn serialize_cell(cell: &Cell, level: u16, records: &mut Vec<Record>) {
 
     // 셀 내부 문단 (원본 HWP에서는 LIST_HEADER와 같은 레벨)
     serialize_paragraph_list(&cell.paragraphs, level, records);
+}
+
+/// [#1808] 셀 LIST_HEADER 추가 바이트(34바이트 이후) 재구성 — 한컴 계약.
+///
+/// 필드 없는 셀: width(4) + 0×9 = 13바이트.
+/// 필드 셀 (한컴 원본 admrul_0039/0045 대조로 확정한 레이아웃):
+///   [0..4]   width (u32 LE)
+///   [4..8]   ff 1b 02 01 (필드 속성 마커)
+///   [8..12]  00 ×4
+///   [12..15] 40 01 00
+///   [15..17] name_len (u16 LE)
+///   [17..]   UTF-16LE 필드 이름
+///   [+8]     00 ×8
+/// 파서 대칭: parser::control::parse_cell_field_name (offset 15/17).
+fn build_cell_list_extra(cell: &Cell) -> Vec<u8> {
+    // 원본 extra 가 있으면 선두 4바이트(폭 참조 계약값)를 보존한다.
+    let width_bytes: [u8; 4] = if cell.raw_list_extra.len() >= 4 {
+        cell.raw_list_extra[0..4].try_into().unwrap()
+    } else {
+        cell.width.to_le_bytes()
+    };
+    match cell.field_name.as_deref() {
+        Some(name) if !name.is_empty() => {
+            let utf16: Vec<u16> = name.encode_utf16().collect();
+            let mut v = Vec::with_capacity(25 + utf16.len() * 2);
+            v.extend_from_slice(&width_bytes);
+            v.extend_from_slice(&[0xff, 0x1b, 0x02, 0x01, 0x00, 0x00, 0x00, 0x00]);
+            v.extend_from_slice(&[0x40, 0x01, 0x00]);
+            v.extend_from_slice(&(utf16.len() as u16).to_le_bytes());
+            for cu in &utf16 {
+                v.extend_from_slice(&cu.to_le_bytes());
+            }
+            v.extend_from_slice(&[0u8; 8]);
+            v
+        }
+        _ => {
+            let mut v = Vec::with_capacity(13);
+            v.extend_from_slice(&width_bytes);
+            v.extend_from_slice(&[0u8; 9]);
+            v
+        }
+    }
 }
 
 fn serialize_caption(caption: &Caption, level: u16, records: &mut Vec<Record>) {

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -505,3 +505,33 @@ fn issue1452_picture_transparency_updates_hwp_extra_byte() {
         "원본 raw_picture_extra가 있어도 마지막 alpha byte는 현재 투명도와 동기화되어야 한다"
     );
 }
+
+/// [#1808] 셀 field_name 이 raw_list_extra 한컴 계약 레이아웃으로 기록되고
+/// 파서 추출(parse_cell_field_name)과 대칭인지 검증.
+#[test]
+fn test_cell_field_name_extra_roundtrip() {
+    let cell = crate::model::table::Cell {
+        width: 23984,
+        field_name: Some("발신명의".to_string()),
+        ..Default::default()
+    };
+    let extra = build_cell_list_extra(&cell);
+    // 레이아웃: width(4) + 마커(8) + 40 01 00(3) + name_len(2) + UTF-16LE(2n) + 0×8
+    let n = "발신명의".encode_utf16().count();
+    assert_eq!(extra.len(), 25 + n * 2);
+    assert_eq!(&extra[0..4], &23984u32.to_le_bytes());
+    assert_eq!(&extra[4..8], &[0xff, 0x1b, 0x02, 0x01]);
+    assert_eq!(
+        crate::parser::control::parse_cell_field_name(&extra).as_deref(),
+        Some("발신명의")
+    );
+
+    // 필드 없는 셀은 기존 13바이트 default 유지
+    let plain = crate::model::table::Cell {
+        width: 100,
+        ..Default::default()
+    };
+    let extra = build_cell_list_extra(&plain);
+    assert_eq!(extra.len(), 13);
+    assert_eq!(crate::parser::control::parse_cell_field_name(&extra), None);
+}


### PR DESCRIPTION
## 개요 (#1808)

HWPX→HWP 변환 시 표 셀의 필드 이름(`Cell.field_name`, 누름틀 "틀"/"발신명의" 등)이
소실되던 문제를 수정한다. 직렬화기가 raw_list_extra 원본 바이트만 기록하고 모델
field_name 을 반영하지 않아, HWPX 출처 셀(raw 는 어댑터가 13바이트로 materialize)은
필드명이 스트림에 기록되지 않았다.

## 한컴 계약 (원본 HWP5 admrul_0039/0045, 필드 3개 샘플 대조로 확정)

```
[0..4] width | [4..8] ff 1b 02 01 | [8..12] 00×4 | [12..15] 40 01 00
[15..17] name_len(u16 LE) | [17..] UTF-16LE | [+8] 00×8   (총 25+2n)
```
파서(`parse_cell_field_name`, offset 15/17)와 대칭.

## 수정

- `parse_cell_field_name` pub(crate) 승격 (직렬화 대칭 검사용)
- `serialize_cell`: raw 인코딩과 모델 field_name 일치 시 원본 바이트 보존
  (네이티브 라운드트립 무영향), 불일치 시 `build_cell_list_extra` 로 계약 레이아웃
  재구성 (선두 4바이트 폭 참조 보존)
- 회귀 테스트 `test_cell_field_name_extra_roundtrip`

## 검증

- seoul_0765: HWPX→HWP 변환 후 셀 필드 40개 목록 **완전 일치** (수정 전 전부 소실)
- 네이티브 admrul_0039 라운드트립: 필드 80개 무영향
- seoul_0765 render-diff --via hwp: PASS 0.00px 유지 (기하 무영향)
- cargo test --release 전수 통과 (#1775 기대 실패 외)

보고서: `mydocs/report/task_m100_1808_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
