### PR TITLE
Task #1809(부분): 셀 측정 aim 정합 2건 수정 (admrul_1066/0296) + 조사 기록

### DIFF
--- a/mydocs/orders/20260702.md
+++ b/mydocs/orders/20260702.md
@@ -9,6 +9,7 @@
 | #1793 | HWPX→HWP 특수문자 렌더 손상 ('-'→NUL, NBSP→'-') | 수정 완료 / 검증 완료 / 승인 대기 | 원인 2건: ① serialize_bullet 이 문단 머리 정보 char_shape_id 4바이트 누락 → 재파싱 시 bullet_char 오프셋 어긋나 NUL ② NBSP 를 코드 24(하이픈)로 직렬화하는 오기 → 코드 30 으로 정정. admrul_0072/seoul_0505 재변환 렌더 원본 완전 일치, big_hwpx 2,500 중 bullet 보유 30건 전부 보존. 보고서: `mydocs/report/task_m100_1793_report.md` |
 | #1795 | 글상자 줄바꿈 (seoul_0043) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: serialize_para_text 갭 채우기가 FIELD_END 공간 미예약 → 다음 FIELD_BEGIN이 갭 선점 → char_offsets 시프트 → lineseg 매핑 어긋남. 공간 예약으로 수정. seoul_0043 PASS(0.00), big_hwpx 개선 7건(seoul_0978 150→0 포함)·회귀 0, big_hwp 변화 0. 보고서: `mydocs/report/task_m100_1795_report.md` |
 | #1794 | 표 앵커 95px (seoul_0765) | 수정 완료 / 검증 완료 / 승인 대기 | 원인: 자리차지 표 exclusion 잉크-겹침 프로브의 is_hwpx_source 게이트 → HWP5 재파스에서 텍스트가 표에 겹침. 게이트 제거. seoul_0765 PASS(0.00), big_hwpx 개선 21건(OVER 12건 해소)·회귀 0, big_hwp 개선 1건·회귀 0. 보고서: `mydocs/report/task_m100_1794_report.md` |
+| #1809 | 잔여 소수 px 셀 기하 군집 | 부분 수정(1066·0296 해소) / 조사 8차 / 판정 대기 | 측정 축: aim 일괄 세트(micro-grid 계약) × height_measurer aim 직접 분기 불일치 → 병합 셀·셀 분할 측정 단일 출처 통일(**admrul_1066 해소**) + 컨버터가 aim 세트 시 유효 안 여백 물질화(**admrul_0296 해소**). 잔여 0556/0072 는 c7dbe8a2 도입 게이트(rowbreak_top_pad / cell-unit extra) 특정 완료 — 한글 편집기 시각 판정 대기. big_hwpx PASS 2455/OVER 8·회귀 0. 계획서: `mydocs/plans/task_m100_1809.md` |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1809.md
+++ b/mydocs/plans/task_m100_1809.md
@@ -1,0 +1,173 @@
+# 수행 계획서 — Task M100 #1809 (조사 1차)
+
+## 이슈
+
+HWPX↔HWP 라운드트립 잔여 소수 px 셀 기하 차이 군집 (admrul_0296/1066/0556/0072)
+
+## 조사 결과 (1차 — 군집 분해)
+
+RHWP_FORCE_HWPX_SOURCE 강제 플립(렌더 2사이트 + 로드 3게이트 임시 오버라이드, 원복됨)과
+DocumentCore 성분 주입 프로브로 군집을 두 그룹으로 분해:
+
+### 그룹 1 — admrul_0556(1.88px), admrul_0072(16px): is_hwpx_source 렌더 게이트 축
+
+강제 플립(FORCE=1/0 모두)에서 **소멸(PASS)** — 렌더 단계의 is_hwpx_source 분기 중
+하나가 원인. 잔여 후보: typeset.rs(9345 exclusion_probe_height, 10017, 11116/11143,
+11840대 landscape 허용치), table_layout.rs(4856/4984/5058/5946), layout.rs(5863/6012),
+paragraph_layout.rs(1887). 개별 게이트 이등분은 미수행 (재개 지점 1).
+
+### 그룹 2 — admrul_0296(3.87px), admrul_1066(6.14px): 미특정 코어 상태 축
+
+- ir-diff(글상자 재귀 포함) 0건, 전 문단 Debug 대조(raw 포함): SectionDef
+  raw_ctrl_extra([] vs 0×10)와 p0 control_mask 뿐 — 문서 데이터 축 소거
+- doc_info 의미 차이 4종 발견했으나 **개별 주입 시 기하 무영향** 확인:
+  ① ParaShape attr1 10240→10252 ② fill_type=None 인 BorderFill 의 solid 소실
+  ③ 폰트 subst_font(원본대체) 소실 ④ Numbering raw_para_heads 소실
+  → 기하 무관하나 **직렬화 충실도 손실로 별도 이슈 등록 후보** (재개 지점 2)
+- 결정 실험: B-doc을 A-코어에 set_document → **A와 동일 렌더(0.00)**,
+  A-doc을 B-코어에 → 3.87. **코어 상태 축 확정.**
+- 단, 알려진 두 flag 사이트(rendering.rs 2149/3349) + 로드 3게이트를 모두
+  강제해도 3.87 유지 — **미발견 상태 의존 경로 존재** (재개 지점 3: 플래그
+  해석 지점에 per-call 로그를 넣어 두 코어의 실제 해석값 대조부터)
+
+## 조사 2차 (그룹 2 — admrul_0296 층별 국소화)
+
+- **갈림 층 확정**: from_bytes(B) vs B-doc-in-A-core(set_document) 대조에서
+  styles(26,541B)·composed 완전 동일, **pagination 만 차이** —
+  `used_height: 933.92(B) vs 936.4267(A)` (Δ2.51px → 렌더 3.87px 로 증폭).
+- doc_info 성분 통째 스왑(전체 doc_info / sections / header / para_shapes /
+  border_fills / font_faces / numberings): **전부 기하 무영향** (set_document 경유,
+  새니티 = 문단 제거 시 구조 불일치 검출로 하니스 유효성 확인).
+- 페이지네이션 측 잉크-겹침 프로브(typeset.rs 1449 `use_overlap_probe`,
+  9345 `exclusion_probe_height`)를 #1794 대칭으로 un-gate 하는 실험:
+  **대상 4건 전부 무효과 — 기각, 원복.**
+- 미해결 모순: paginate_pass(rendering.rs 2146)의 is_hwpx_source 를 env 로
+  강제 균등화해도 used_height 933.92/936.43 갈림 유지 — used_height 를 만드는
+  실제 분기가 2146 파라미터 경로 밖에 있거나 오버라이드가 해당 호출에 닿지 않음.
+
+## 조사 3차 (그룹 2 — 렌더 갈림 아이템 특정)
+
+- typeset per-item 트레이스: 표 예약(929.92)·post-table(937.92)까지 A/B **완전 동일** —
+  used_height 차이(-1.49/-4.0)는 fit 안전마진(layout_drift_safety_px, #1672 술어) 계열
+  북키핑이며 렌더와 무관 (술어 env 강제 플립도 렌더 무효과 — #1672 축 기각).
+- **렌더 갈림 아이템 특정**: `RHWP_DEBUG_TAC_CURSOR` 로 page 0 의 유일한 아이템
+  (TAC 표, pi=0 ci=2)이 y_in=56.7 동일에서 **전진량만 A dy=940.4 vs B dy=937.9
+  (Δ=2.507px)** — was_tac=true 경로.
+- is_hwpx_source 5개 사이트 env 균등화가 이 Δ 에 무효했으므로, TAC 표 전진량의
+  입력 차이 = **measured_tables(MeasuredTable.total_height 등) 또는 TAC 라인
+  메트릭 보정의 비플래그 입력**으로 좁혀짐.
+
+## 조사 4차 — 측정 축 확정 + admrul_1066 수정
+
+- measured_tables 대조(임시 접근자): **total_height A=932.43 vs B=928.56 (Δ=3.867 =
+  렌더 max)**, 특정 행들만 32.37 vs 31.60 — 측정값 자체가 갈림을 확정.
+- 셀 aim 대조: A aim=true 3/149 vs **B 149/149** — hwpx_to_hwp micro-grid 계약
+  (col≥30 → width_ref bit0 일괄 세트)이 aim 을 뒤집고, height_measurer 의
+  **aim 직접 분기**가 #1785 단일 규칙과 불일치해 측정이 갈림.
+- **수정**: height_measurer 병합 셀 2-c(1077/1089)와 셀 분할 측정(measured_cells,
+  1300대)의 직접 분기를 `Cell::effective_padding` 단일 출처로 통일
+  → **admrul_1066 (6.14px) OVER→PASS**.
+- row_span=1 경로(849)의 완전 통일(aim=true && pad 0 → 표 폴백)은
+  `vertical_shift_local_height_keeps_unrelated_cells_stable`(#493) 회귀로 원복 —
+  #1785 주석의 의존성 그대로. admrul_0296 (3.87px) 은 이 경로가 아닌
+  **p0 내부 셀 필드의 미열거 차이 축**으로 잔존 (이전 Debug 대조가 문단당
+  첫 차이만 출력해 control_mask 뒤의 셀 필드 차이가 가려졌음).
+- 검증: cargo test 전수 통과(#1775 기대 실패만), big_hwpx 2,500 배치 —
+  admrul_1066 OVER→PASS + admrul_0766 미세개선, 회귀 0
+  (seoul_1023 PASS 내 0.017px 변동). big_hwp identity 배치 확인 중.
+
+## 조사 5차 (admrul_0296 셀 전 필드 열거)
+
+- p0 표 셀 전 필드 diff (aim/width_ref 제외): **차이 0개** — 셀 데이터 완전 동일.
+- 유일한 표 레벨 차이: **`table.attr` A=0x1 vs B=0x82a2311** — 변환본 재파싱의
+  attr 가 비정상 값. #1793 BULLET 과 동일한 **표 레코드 직렬화/파서 오프셋
+  비대칭** 패턴 의심 (serialize_table 이 쓰는 레이아웃과 parse_table 이 읽는
+  레이아웃 불일치 → attr 위치가 어긋나면 인접 필드 오독 가능 — 행높이 측정을
+  가르는 미확인 입력의 유력 후보).
+
+## 조사 6차 — admrul_0296 해소 (컨버터 padding 물질화)
+
+- 5차의 table.attr 차이는 파서별 의미 차이(HWP5=CommonObjAttr 전체 워드, bit0 일치)로
+  red herring — 표 레코드 serialize/parse 레이아웃은 필드 단위 정합 확인.
+- 실원인: micro-grid 계약이 width_ref bit0(=aim)을 켠 셀은 재파싱 시 측정/레이아웃의
+  **aim=true 원값 존중 경로(#493 시멘틱)** 가 raw cell padding(0)을 그대로 사용 —
+  원본(HWPX, aim=false → 표 기본 여백 폴백)과 행높이가 어긋남.
+- **수정**: `materialize_cell_list_header_contract` 가 bit0 을 켤 때 aim=false 셀의
+  `effective_padding`(표 기본 폴백 포함)을 셀 padding 에 물질화 — 한컴 계약과
+  rhwp 렌더 모두에서 시각 보존.
+- 검증: **admrul_0296 OVER→PASS**, cargo test 전수(#1775 기대 실패만),
+  big_hwpx 2,500 배치 — **개선만 7건**(0296 + PASS 내 미세오차 6건 0 수렴), 회귀 0.
+  누적 분포 PASS 2455 / OVER 8. big_hwp identity 는 컨버터 no-op 경로라 무영향.
+
+## 조사 7차 — 그룹 1 게이트 특정 완료
+
+게이트별 env 킬스위치(RHWP_1809_GATE_OFF, 후보 8곳 일괄 계측 — 원복됨)로 이등분:
+
+- **admrul_0556 (1.88px) = 게이트 4**: table_layout.rs `hwpx_rowbreak_top_pad`
+  (HWPX RowBreak 표 첫 행 top pad 주입 — HWP5 재파스에는 미적용이라 갈림)
+- **admrul_0072 (16px) = 게이트 7**: table_layout.rs cell-unit extra 계산이
+  `is_hwpx_source` 면 0 반환 (HWP5 전용 보정 — HWPX 직파스에는 미적용이라 갈림)
+- 게이트 4+7 동시 오프 시 두 파일 모두 PASS 확인.
+
+두 게이트 모두 도입 당시 한컴 대비 검증된 정합 규칙이므로, 단순 un-gate 가 아니라
+**각 도입 이슈의 검증 근거(어느 쪽이 한컴 정답인지) 확인 후 소스 무관화 방향 결정**
+이 필요 — git blame 으로 도입 커밋/이슈 추적부터.
+
+## 조사 8차 — 게이트 도입 커밋 특정, 판정 대기로 전환
+
+- 게이트 4(hwpx_rowbreak_top_pad)·게이트 7(mixed_nested_flow_extra_from_cut 의
+  hwpx 조기 0 반환) **둘 다 외부 기여자(postmelee) 커밋 c7dbe8a2
+  "fix: stabilize rowbreak continuation layout" (2026-06-26, devel merge 됨)에서
+  도입** — 게이트 5/6(suppress_hwpx_mixed_nested_gap)도 동일 커밋.
+- 킬스위치 실험의 PASS 는 "A(HWPX 직파스)를 B(재파스)에 맞춘" 방향 — 정답 축은
+  A 이므로 실제 수정은 반대 방향(게이트를 HWP5 재파스에도 적용 = 소스 무관화)
+  이 후보이나, native HWP5 코퍼스가 현 게이트 방향(HWP5 에 extra 적용/pad 미적용)
+  으로 한컴과 맞춰져 있을 가능성이 있어 **단순 무관화는 native 회귀 위험**.
+- **판정 필요**: admrul_0556/0072 (한컴 원본 HWPX)의 한글 편집기 렌더 대조
+  (tools/verify_pi_page_vs_hangul.py, Windows) 또는 작업지시자 시각 판정으로
+  "RowBreak continuation 의 top pad / cell-unit extra" 정답 방향 확정 후 수정.
+
+## 재개 지점 (9차 — 판정 후)
+
+1. 판정 결과에 따라 게이트 4/7 소스 무관화 또는 대칭 보정 → 코퍼스 재검증
+2. row_span=1 측정 aim=true && pad 0 정합 (#493 시멘틱 충돌 — 별도 규칙 설계)
+
+1. **serialize_table vs 표 레코드 파서 레이아웃 필드-바이-필드 대조** (#1793 수법).
+   attr=0x82a2311 이 어느 인접 필드의 바이트인지 특정 → 직렬화기 수정.
+   재파싱 attr 정상화 후 admrul_0296 행높이(32.37/31.60) 재확인.
+2. row_span=1 측정의 aim=true && pad 0 정합 — #493 시멘틱과 충돌, 별도 규칙 설계.
+3. 그룹 1(0556/0072): layout_engine 플래그 게이트 이등분.
+
+## (구) 재개 지점 (5차)
+
+1. admrul_0296: p0 표 셀 전 필드 diff 열거(첫-diff 마스킹 제거 프로브) →
+   행높이 32.37/31.60 을 가르는 셀 필드 특정. 유력: 변환 시 셀 list_attr/
+   width_ref 재구성 손실 또는 aim 소비처 중 미통일 지점(shape_layout.rs 3346,
+   table_layout.rs 2402).
+2. row_span=1 측정의 aim=true && pad 0 정합은 #493 시멘틱과 충돌 —
+   별도 규칙 설계 필요 (#1785 후속 항목 지속).
+3. 그룹 1(0556/0072): layout_engine 플래그 게이트 이등분 (기존 후보 목록).
+
+## (구) 재개 지점 (4차)
+
+1. self.measured_tables[0] (MeasuredTable) 의 total_height/row_heights 를 A/B 대조
+   (임시 debug 접근자) — 측정값 자체가 2.507 다른지 판정.
+2. 측정 동일이면 layout 의 TAC 표 라인 전진(corrected_lh/trailing spacing 경로,
+   paragraph_layout 의 has_tac_shape/tac line 보정)에 per-line 트레이스.
+3. 그룹 1(0556/0072): layout_engine 플래그 축 — layout.rs 5863/6012,
+   suppress_hwpx_stale_forward(3617), table_layout.rs 4856/4984/5058/5946 이등분.
+
+## (구) 재개 지점 (3차)
+
+1. typeset 의 used_height 산출 입력을 admrul_0296 페이지 0 에 한정해 per-item
+   트레이스 (아이템별 y/높이/safety/exclusion 적용값 A/B 대조) — Δ2.51 의
+   발생 아이템과 분기 직접 특정. `st.is_hwpx_source` 소비처 전수(1449/9345 외
+   10017/11116/11143/11840대/8975)도 같은 트레이스에서 판별 가능.
+2. 그룹 1(0556/0072)은 layout_engine 플래그 축 확정 상태 — layout.rs 5863/6012,
+   suppress_hwpx_stale_forward(3617), table_layout.rs 4856/4984/5058/5946 이등분.
+
+## 재현물
+
+- output/poc/task1809/admrul_0296.hwp (변환본)
+- 프로브 패턴: tests/tmp_1809_probe{,2,3}.rs, tmp_1809_layer{,2}.rs, tmp_1809_swap.rs
+  (세션 산출물 — 삭제됨, 이슈 코멘트에 요지 기록)

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1407,9 +1407,10 @@ fn adapt_table_with_context(
 
     // 셀별 보강 + 내부 문단 재귀 (중첩 표 대응)
     let use_cell_width_ref = table_requires_cell_width_ref_contract(table);
+    let table_padding = table.padding;
     for cell in &mut table.cells {
         adapt_cell_list_attr(cell, report);
-        materialize_cell_list_header_contract(cell, use_cell_width_ref, report);
+        materialize_cell_list_header_contract(cell, use_cell_width_ref, &table_padding, report);
         for cpara in &mut cell.paragraphs {
             adapt_paragraph_with_context(cpara, report, context);
         }
@@ -1429,10 +1430,20 @@ fn table_requires_cell_width_ref_contract(table: &Table) -> bool {
 fn materialize_cell_list_header_contract(
     cell: &mut Cell,
     use_width_ref: bool,
+    table_padding: &crate::model::Padding,
     report: &mut AdapterReport,
 ) {
     let before_width_ref = cell.list_header_width_ref;
     let before_extra_len = cell.raw_list_extra.len();
+
+    // [#1809] micro-grid 계약으로 width_ref bit0(=aim)을 켤 때, aim=false 셀의
+    // 유효 안 여백(effective_padding — 표 기본 폴백 포함)을 셀 padding 에 물질화한다.
+    // 재파싱 시 aim=true 가 되면 측정/레이아웃의 aim=true 원값 존중 경로(#493 시멘틱)가
+    // raw cell padding 을 그대로 쓰므로, 물질화 없이는 padding 0 셀의 행높이가
+    // 원본(HWPX, 표 기본 여백)과 어긋난다 (admrul_0296 행 32.37→31.60, 표 3.87px).
+    if use_width_ref && !cell.apply_inner_margin {
+        cell.padding = cell.effective_padding(table_padding);
+    }
 
     if use_width_ref || cell.apply_inner_margin {
         cell.list_header_width_ref |= 0x0001;
@@ -1789,7 +1800,12 @@ mod tests {
         };
         let mut report = AdapterReport::new();
 
-        materialize_cell_list_header_contract(&mut cell, true, &mut report);
+        materialize_cell_list_header_contract(
+            &mut cell,
+            true,
+            &crate::model::Padding::default(),
+            &mut report,
+        );
 
         assert_eq!(cell.list_header_width_ref & 0x0001, 0x0001);
         assert_eq!(cell.raw_list_extra.len(), 13);
@@ -1800,7 +1816,12 @@ mod tests {
         assert!(cell.raw_list_extra[4..].iter().all(|&byte| byte == 0));
         assert_eq!(report.cells_list_header_contract_materialized, 1);
 
-        materialize_cell_list_header_contract(&mut cell, true, &mut report);
+        materialize_cell_list_header_contract(
+            &mut cell,
+            true,
+            &crate::model::Padding::default(),
+            &mut report,
+        );
         assert_eq!(report.cells_list_header_contract_materialized, 1);
     }
 
@@ -1814,7 +1835,12 @@ mod tests {
         };
         let mut report = AdapterReport::new();
 
-        materialize_cell_list_header_contract(&mut cell, false, &mut report);
+        materialize_cell_list_header_contract(
+            &mut cell,
+            false,
+            &crate::model::Padding::default(),
+            &mut report,
+        );
 
         assert_eq!(cell.list_header_width_ref & 0x0001, 0);
         assert_eq!(cell.raw_list_extra.len(), 13);

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -845,7 +845,8 @@ impl HeightMeasurer {
                 // micro-grid 결재란 라운드트립 9.3px). aim=true 는 기존대로 cell.padding
                 // 을 0 포함 그대로 존중 — layout 의 `!= 0 → 표 기본 폴백`과 다르지만,
                 // #493 세로 Shift 리사이즈(셀보호2.hwp 셀[20] aim=true pad top/bottom=0)가
-                // 이 의미에 의존한다. aim=true && 0 의 레이아웃-측정 정합은 후속 항목.
+                // 이 의미에 의존한다 (#1809 완전 통일 시도는 해당 테스트 회귀로 원복 —
+                // vertical_shift_local_height_keeps_unrelated_cells_stable).
                 let eff_pad = if cell.apply_inner_margin {
                     cell.padding
                 } else {
@@ -1116,29 +1117,21 @@ impl HeightMeasurer {
             let r = cell.row as usize;
             let span = cell.row_span as usize;
             if span > 1 && r + span <= row_count {
-                let (pad_top, pad_bottom) = if cell.apply_inner_margin {
-                    (
-                        hwpunit_to_px(cell.padding.top as i32, self.dpi),
-                        hwpunit_to_px(cell.padding.bottom as i32, self.dpi),
-                    )
-                } else {
-                    (
-                        hwpunit_to_px(table.padding.top as i32, self.dpi),
-                        hwpunit_to_px(table.padding.bottom as i32, self.dpi),
-                    )
-                };
+                // [#1809] aim 직접 분기 → 단일 출처(Cell::effective_padding) 통일.
+                // aim=true 인데 cell padding 이 0 인 셀은 표 기본으로 폴백해야
+                // 레이아웃(resolve_cell_padding)과 정합한다. 직접 분기가 남으면
+                // HWPX→HWP 변환의 micro-grid 계약(aim 일괄 세트)만으로 병합 셀
+                // 행높이 측정이 갈린다 (admrul_0296 행 32.37→31.60, 표 3.87px).
+                let eff_pad = cell.effective_padding(&table.padding);
+                let (pad_top, pad_bottom) = (
+                    hwpunit_to_px(eff_pad.top as i32, self.dpi),
+                    hwpunit_to_px(eff_pad.bottom as i32, self.dpi),
+                );
                 // [Task #671] 좌우 패딩 (recompose_for_cell_width inner_width 계산용)
-                let (pad_left, pad_right) = if cell.apply_inner_margin {
-                    (
-                        hwpunit_to_px(cell.padding.left as i32, self.dpi),
-                        hwpunit_to_px(cell.padding.right as i32, self.dpi),
-                    )
-                } else {
-                    (
-                        hwpunit_to_px(table.padding.left as i32, self.dpi),
-                        hwpunit_to_px(table.padding.right as i32, self.dpi),
-                    )
-                };
+                let (pad_left, pad_right) = (
+                    hwpunit_to_px(eff_pad.left as i32, self.dpi),
+                    hwpunit_to_px(eff_pad.right as i32, self.dpi),
+                );
                 let cell_w_px = if cell.width < 0x80000000 {
                     hwpunit_to_px(cell.width as i32, self.dpi)
                 } else {
@@ -1347,16 +1340,10 @@ impl HeightMeasurer {
                 .iter()
                 .filter(|cell| (cell.row as usize) < row_count)
                 .map(|cell| {
-                    let pad_top = if cell.apply_inner_margin {
-                        hwpunit_to_px(cell.padding.top as i32, self.dpi)
-                    } else {
-                        hwpunit_to_px(table.padding.top as i32, self.dpi)
-                    };
-                    let pad_bottom = if cell.apply_inner_margin {
-                        hwpunit_to_px(cell.padding.bottom as i32, self.dpi)
-                    } else {
-                        hwpunit_to_px(table.padding.bottom as i32, self.dpi)
-                    };
+                    // [#1809] aim 직접 분기 → 단일 출처 통일 (위 2-c단계와 동일 근거)
+                    let eff_pad = cell.effective_padding(&table.padding);
+                    let pad_top = hwpunit_to_px(eff_pad.top as i32, self.dpi);
+                    let pad_bottom = hwpunit_to_px(eff_pad.bottom as i32, self.dpi);
 
                     let mut line_heights = Vec::new();
                     let mut para_line_counts = Vec::new();


### PR DESCRIPTION
## 개요 (#1809 부분 — 4개 대상 중 2건 해소 + 조사 기록)

HWPX↔HWP5 라운드트립 잔여 소수 px 셀 기하 군집(admrul_0296/1066/0556/0072) 중
**admrul_1066(6.14px)·admrul_0296(3.87px)을 해소**하고, 잔여 2건의 원인 게이트를
특정한 조사 기록(1~8차)을 포함한다.

## 수정 1 — 측정의 aim 직접 분기 단일 출처 통일 (admrul_1066)

height_measurer 의 병합 셀 2-c 확장과 셀 분할 측정(measured_cells)이
`cell.apply_inner_margin` 을 직접 분기하여 #1785 단일 규칙(`Cell::effective_padding`)과
어긋남 — HWPX→HWP 변환의 micro-grid 계약(col≥30, width_ref bit0 일괄 세트)만으로
행높이 측정이 갈렸다. 단일 출처로 통일. (row_span=1 경로의 aim=true 원값 존중은
#493 테스트 의존으로 유지 — 완전 통일은 별도 규칙 설계 필요)

## 수정 2 — 컨버터 aim 세트 시 유효 안 여백 물질화 (admrul_0296)

micro-grid 계약이 width_ref bit0(=aim)을 켠 셀은 재파싱 시 aim=true 원값 존중
경로(#493 시멘틱)가 raw cell padding(0)을 그대로 사용 — 원본(HWPX, aim=false →
표 기본 여백 폴백)과 행높이가 어긋났다. `materialize_cell_list_header_contract` 가
bit0 세트 시 `effective_padding` 을 셀 padding 에 물질화 — 한컴 계약(줄나눔 폭)과
rhwp 렌더 모두 시각 보존.

## 검증

- admrul_1066: 6.14px OVER → **PASS 0.00** / admrul_0296: 3.87px OVER → **PASS 0.00**
- cargo test --release 전수 통과 (#1775 기대 실패만, #493 테스트 포함)
- big_hwpx 2,500 배치: 수정 1 = 개선 2건·회귀 0, 수정 2 = **개선만 7건**
  (PASS 내 미세오차 6건 0 수렴 포함)·회귀 0 — 누적 **PASS 2455 / OVER 8**
- big_hwp 2,500 identity: 변화 0 (수정 1) / 컨버터 no-op 경로 (수정 2)

## 잔여 (이슈 open 유지)

admrul_0556(1.88px)/admrul_0072(16px)는 c7dbe8a2("stabilize rowbreak continuation
layout") 도입 게이트(hwpx_rowbreak_top_pad / cell-unit extra)로 특정 완료 —
한글 편집기 시각 판정 후 수정 방향 결정 (계획서 9차 재개 지점).

계획서(조사 1~8차 기록): `mydocs/plans/task_m100_1809.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
