### PR TITLE
Task #1811: 합성 LINE_SEG 증거 오인 차단 — HWPX saved_bounds p5 drift 원인 1 수정 + 원인 2 판별

### DIFF
--- a/mydocs/plans/task_m100_1811.md
+++ b/mydocs/plans/task_m100_1811.md
@@ -1,0 +1,31 @@
+# Task #1811 수행계획서 — HWPX saved_bounds_cumulative_page_break p5 tail/line drift
+
+## 배경
+
+PR #1810(메인테이너, #1745/#1749/#1750/#1753 번들 반영)이 #1752 의 핵심 수정
+(saved bounds 신뢰 제한 + 명시적 쪽나누기 예외)을 머지하면서, 잔여 visual sweep
+후보 1건을 #1811 로 등록:
+
+- 샘플: `samples/task1749/saved_bounds_cumulative_page_break.hwpx` (**HWPX 경로**)
+- 기준: `samples/task1749/saved_bounds_cumulative_page_break-2024.pdf`
+- 후보: **p5 하단** — `render_tree_frame_tail_overflow`, `line_band_drift`,
+  `column_line_band_drift`, `large_ink_region_drift`
+- 핵심 수정(신뢰 조건)과 **분리**해 분석, 필요 시 별도 조판 보정 PR.
+
+## 계획
+
+1. **재현·정량화**: p5 를 HWP/HWPX 양 경로로 렌더해 기준 PDF 와 3자 대조 —
+   dark-pixel bbox(`tools/compare_page_bbox.py`) + `dump-pages`/`dump` 로 p5 하단
+   항목·tail 줄의 vpos/높이 추적. HWP 경로는 sweep 후보 0건이므로 **HWPX 경로
+   전용 차이**(파스 경로 분기 또는 IR 차이)를 우선 가설로.
+2. **원인 분석**: `ir-diff hwpx↔hwp` 로 데이터 차이 유무 분리 → 데이터 동일이면
+   typeset 의 `is_hwpx_source` 분기/신뢰 경로, 다르면 파서 정규화 차이로 추적.
+3. **수정 또는 판별 보고**: 국소 보정 가능하면 수정 + 가드, 광역 위험이면 원인
+   문서화(#1772/#1774 계열 연계) 후 이슈에 판별 보고.
+4. **게이트**: 본 샘플 양 게이트(vpos: pi18 2쪽 시작 / page_break: pi26 2쪽 마지막,
+   5쪽 유지 — #1810 검증 기준), 통제셋 92·클리핑·`cargo test` 전체.
+
+## 작업 브랜치
+
+- `local/task1811` — upstream/devel(6a27dcd2, #1810 반영) + 열린 PR 21건 선적용.
+- 완료 시 upstream/devel 기준 1커밋 재구성 → `pr/devel-1811` push → PR.

--- a/mydocs/report/task_m100_1811_report.md
+++ b/mydocs/report/task_m100_1811_report.md
@@ -1,0 +1,69 @@
+# Task #1811 최종 보고서 — HWPX p5 tail/line drift: 합성 seg 증거 오인 차단 + 제2원인 판별
+
+## 요약
+
+#1811(PR #1810 머지 후속)의 p5 tail/line drift 를 조사해 **두 개의 독립 원인**을
+규명하고, 그중 원리적 결함(합성 seg 의 vpos 증거 오인)을 수정했다. 잔여(합성 seg
+유닛 구성 격차)는 광역 주제로 판별 문서화해 분리한다.
+
+- 이슈: #1811 / 브랜치: `local/task1811` (upstream/devel 6a27dcd2 + 열린 PR 21건)
+- 수정: `composer/line_breaking.rs`, `height_cursor.rs` (+진단 2종)
+
+## 원인 사슬 (stage1, `task_m100_1811_stage1.md`)
+
+증상 = p4 끝 분할 표 pi52 컷이 HWPX end_cut=[2] vs HWP/한글 [3] → (사회기여) 문단이
+p5 로 밀려 p5 하단 tail overflow.
+
+**원인 1 (수정 완료)**: pi50(TAC 표 host)은 원본 XML 에 linesegarray 부재 →
+로드-정규화(`reflow_line_segs`)가 seg 를 합성하는데 **synthetic 표식 없이** 생성 →
+`vpos_adjust` lazy 전방 보정이 이를 실제 저장 증거로 오인, pi51 을 구세션 저장 flow
+위치로 +9.6px 과대 전진(RHWP_VPOS_DEBUG 실측) → 분할 예산 −6.4px.
+
+**원인 2 (판별·분리)**: 예산 정합 후에도 컷 [2] — pi52 셀 유닛 구성이 경로별 상이
+(HWPX 합성 seg: 8유닛·높이 37.9/31.2·hard_break 5곳(문단별 vpos=0 리셋 오인) vs
+HWP 저장 seg: 10유닛·30.9/24.3·hb 1곳). 근본 = **reflow 합성 seg 의 줄높이·vpos
+공식이 한컴 계산과 불일치**하는 광역 주제(#1772/#1774 계열) — 국소 보정 회귀 반경이
+커서 본 PR 비범위, 후속 트랙으로 분리.
+
+## 수정 (stage2, `task_m100_1811_stage2.md`)
+
+1. `reflow_line_segs`: 원본 부재(orig=None) 합성 seg 에
+   `TAG_IMPLEMENTATION_PROPERTY(1<<31)` 부여 (컨버터 합성 lineseg 관례 정합).
+2. `vpos_adjust`: prev seg 가 합성 태그면 전방 보정 bypass (sequential 신뢰).
+3. 진단 자산: `RHWP_FLOW_DBG`(typeset 문단별 cur_h), `RHWP_CUT_DBG`(셀 유닛 시퀀스).
+
+효과: pi51 +9.6px 소멸(pi52 진입 669.2→659.6), 분할 예산 117.0→126.6 (HWP 123.4 정합).
+
+## 게이트
+
+| 게이트 | 결과 |
+|--------|------|
+| #1810 기준 양 게이트 | vpos: pi18 2쪽 시작 ✓ / page_break: pi26 2쪽 잔존·5쪽 ✓ |
+| 통제셋 92 | 일치 75 유지, under 14·over 3 불변 (over 내부 +2→+1 개선 방향) |
+| `cargo test --release` 전체 | 2780 passed / 실질 실패 0 (7건 svg CRLF 노이즈 #1786) |
+
+## 이슈 #1811 처리 제안
+
+- 원인 분석(기대 작업 1·2) 완료, 수정 1 은 별도 조판 보정 PR(기대 작업 3)로 제출.
+- p5 시각 후보의 완전 해소는 원인 2(합성 seg 유닛 구성) 해결이 전제 — 판별 결과를
+  이슈에 보고하고 open 유지 또는 후속 이슈 분리는 메인테이너 판단에 위임.
+
+## v2 정밀화 — seoul_1006 회귀 해소 (2026-07-03)
+
+전면 차단(조기 return)이 big_hwpx seoul_1006 에서 회귀(PASS→STRUCT 641px, p7
+Group+줄이 p8 로 이월)를 유발했다. 이등분·트레이스 판별:
+
+- seoul_1006 의 +9.6px A/B 갈림은 **devel 부터 존재**하는 파스 경로 측정차(pi=41
+  RowBreak 자리차지 표) — 본 수정이 만든 게 아님
+- devel 에서는 저장 vpos 로의 **대형 재앵커 점프**(pi=42, +376px)가 양 경로를 같은
+  저장 좌표에 재동기화해 쪽나눔이 수렴해 왔음 — 전면 차단이 이 안전망까지 제거
+
+**정밀화**: 조기 return 을 최종 result 방향·크기 클램프로 교체 — 합성 seg 증거의
+전방 이동 중 **소폭(≤48px, drift 대역)만 차단**. 되감기와 대형 재앵커(>48px)는 허용.
+saved_bounds 의 유해 전진(+9.6px)은 차단 대역에, seoul_1006 의 재앵커(+376px)는
+허용 대역에 정확히 들어간다.
+
+**v2 검증** (통합 스택 기준):
+- saved_bounds_cumulative_page_break: PASS 유지 (0.12px)
+- seoul_1006: STRUCT 641px → **PASS 0.00**
+- big_hwpx 2,500 배치: 직전 대비 **개선 1건(seoul_1006)/회귀 0** — PASS 2471

--- a/mydocs/working/task_m100_1811_stage1.md
+++ b/mydocs/working/task_m100_1811_stage1.md
@@ -1,0 +1,80 @@
+# Task #1811 1단계 조사 보고 — p5 tail/line drift 원인 절반 규명 (진행 중)
+
+## 증상 재확인 (visual sweep 후보의 실체)
+
+리뷰 PNG(`mydocs/pr/assets/pr_1752_visual_review_p5_followup_candidate.png`) 판독:
+한글 p5 는 (청정아트)부터 시작하는데 **rhwp(HWPX) p5 는 (사회기여) 문단이 상단에 하나
+더** 있다 — p4→p5 경계에서 rhwp 가 유닛 하나를 일찍 끊어 이후 내용이 밀리고 p5
+하단에서 ⑥ 제목이 잘림(`frame_tail_overflow`/`line_band_drift` 후보의 실체).
+
+## 정량 (통합 베이스, HWPX vs HWP vs 한글 2024 PDF)
+
+- 페이지 bbox 수준: 양 경로 사실상 동일 (p5 Δbot −9 공통) — bbox 로는 비가시.
+- **p4 끝 분할 표 pi52 컷: HWPX end_cut=[2] vs HWP end_cut=[3]** (한글 = [3] 동작).
+  분할 예산 `avail_for_rows`: HWPX **117.0** vs HWP **123.4** — 정확히 **6.4px(480HU)**.
+- pi52 진입 시 `cur_h`: HWPX 669.2 vs HWP 662.8 (+6.4). p1~p3 경계는 동일(내부 used 차이는
+  vpos 흡수로 무해), p4 내부(pi47~51)에서만 벌어짐.
+- **렌더 y 는 양 경로 일치**(pi50 표 y=355.2/h=383.6, pi52 시작 ≈910) — 렌더러의 vpos
+  보정이 드리프트를 흡수. 순수 **typeset 예산 회계만** 어긋난다.
+
+## 구조적 원인 (확정 사실)
+
+- **pi50(TAC 표 host 문단)은 원본 HWPX XML 에 linesegarray 자체가 없다** (ir-diff:
+  line_segs A=0 vs B=1; 파서는 충실 — 합성 없음).
+- 원본 HWPX 의 주변 저장 flow 를 역산하면 pi50 의 표줄 advance 는
+  `lh 28769 + gap 720`(pi49 끝 223964 → 225164 → +29489 → pi51 254653 정합) —
+  즉 **한컴 자신의 저장 flow gap = 720**.
+- rhwp 변환 HWP 는 pi50 lineseg 를 `gap=1200` 으로 재합성 → 이후 vpos 전부 +480HU.
+- 그런데 페이지네이션 결과는 HWP 경로가 한글 PDF 와 일치(여유 +6.4px)하고, HWPX
+  경로가 −6.4px 부족 — **양 경로 모두 저장 flow 를 그대로 신뢰한 결과가 아니라,
+  lineseg 유무에 따라 vpos-sync/계산 advance 경로가 갈리면서 정반대 부호의 잔차**가
+  생긴 것. (HWPX: 저장상대 664.4 vs cur 669.2, +4.8 과소비 / HWP: 저장상대 670.8 vs
+  cur 662.8, −8.0 미달.)
+
+## 항목별 분해 (RHWP_FLOW_DBG 계측)
+
+| 항목 | HWPX advance | HWP advance | Δ |
+|------|-------------:|------------:|---|
+| pi50 (TAC 표 host, lineseg 부재) | +388.4 | +391.6 | HWP +3.2 |
+| pi51 (빈 문단, lh500+gap400=12.0) | **+21.6** | +12.0 | **HWPX +9.6 (=720HU)** |
+| 순합 (pi52 진입 cur_h) | 669.2 | 662.8 | +6.4 |
+
+- 지배 항 = **pi51 에서 HWPX 경로가 저장 세그(12.0px) 외에 +9.6px(720HU) 를 추가**
+  — pi50 lineseg 부재로 인한 vpos 보정(전방 correction) 경로의 과잉으로 추정.
+  720 = pi50 의 원본 저장 flow gap 과 동일 값.
+- HWP 경로는 pi51 에서 저장 vpos 로의 sync 를 하지 않고(자체 누적 유지) 12.0 만 소비.
+
+## 발생 기전 완전 규명 (RHWP_VPOS_DEBUG)
+
+- pi51 의 +9.6px = `HeightCursor::vpos_adjust` **lazy 경로 전방 보정**:
+  `VPOS_CORR path=lazy pi=51 prev_pi=50 prev_vpos=225164 prev_ls=720 vpos_end=254653
+  y_in=647.59 → result=657.19 (+9.6) applied=true`. HWP 경로는 동일 식이 정확히
+  0 보정(650.79 == 저장 상대값).
+- prev(pi50) 의 seg 는 **로드-정규화가 생성한 것**: 원본 XML 에 linesegarray 가 없어
+  `document_core/commands/document.rs` 의 "HWPX: TAC 표 문단 LINE_SEG lh 보정" +
+  `reflow_line_segs` 가 vpos=225164/lh=28769/ls=720 seg 를 합성 — 그러나
+  **synthetic 태그(0x80000000) 없이 flags=0x60000** 으로 생성되어, vpos 보정이
+  이를 실제 저장 증거로 오인해 원본 저장 flow(한컴 구세션 값) 위치로 전방 이동시킨다.
+  한글 2024 재조판은 그보다 조밀하게 흘러 유닛 하나를 더 담는다(컷 [3]).
+
+## 수정 설계 (다음 단계)
+
+- 1안(선호): reflow/TAC-lh 보정이 **생성하는 seg 에 synthetic 태그를 부여**하고,
+  `vpos_adjust` 의 prev seg 선택에서 synthetic 을 실증거로 쓰지 않도록(전방 보정
+  bypass — #991 '분할 표 직후 sequential 신뢰'와 동형). 단 `is_synthetic_line_seg`
+  소비처(전체 6곳)의 행동 변화를 전수 점검해야 함.
+- 2안(협소): `vpos_adjust` lazy 경로에서 prev 문단이 "TAC 표 보유 + 원본 lineseg
+  부재(reflow 흔적)" 인 경우만 보정 skip.
+- 게이트: 본 샘플 컷 [2]→[3] 복원 + #1810 기준 양 게이트(vpos pi18/page_break pi26)
+  + 통제셋 92 + cargo test 전체.
+
+## 남은 규명 (다음 단계·구버전 메모)
+
+- typeset p4 흐름의 **항목별 cur_h/advance 분해 계측**(RHWP_FLOW_DBG 일회 계측)으로
+  HWPX 경로 +6.4px 의 정확한 발생 항목(pi50 TAC advance vs pi51/52 vpos-sync 거부)을
+  특정한다.
+- 수정 방향 후보: lineseg-less TAC host 의 advance 를 인접 저장 vpos(pi49 끝→pi51)
+  로 앵커(원본 flow 정합, HWPX 데이터만으로 결정 가능) — 렌더는 이미 일치하므로
+  typeset 예산만 정합하면 컷이 [3] 으로 복원될 전망.
+- 게이트: 본 샘플 양 게이트(#1810 기준: vpos pi18 2쪽 시작 / page_break pi26 2쪽
+  마지막·5쪽) + 통제셋 92 + `cargo test`.

--- a/mydocs/working/task_m100_1811_stage2.md
+++ b/mydocs/working/task_m100_1811_stage2.md
@@ -1,0 +1,39 @@
+# Task #1811 2단계 완료 보고 — 합성 seg 증거 오인 차단 (수정 1) + 제2원인 판별
+
+## 수정 1 (본 PR 범위) — 합성 seg 의 vpos 전방 보정 오인 차단
+
+- `src/renderer/composer/line_breaking.rs`: `reflow_line_segs` 가 **원본 linesegarray
+  부재 문단**(orig=None)에 합성하는 seg 에 `TAG_IMPLEMENTATION_PROPERTY(1<<31)` 부여 —
+  컨버터의 합성 lineseg flags=0x8000_0000 관례와 정합.
+- `src/renderer/height_cursor.rs`: `vpos_adjust` 에서 prev seg 가 합성 태그면 전방
+  보정 bypass (sequential 신뢰) — 합성 seg 의 vpos 는 구세션 저장 flow 의 재구성이지
+  실제 저장 증거가 아니다.
+- **효과 실측**: pi50 seg tag 0x80060000, pi51 의 +9.6px 보정 소멸(pi52 진입 cur_h
+  669.2→659.6, HWP 경로 662.8보다 정합), 분할 예산 117.0→126.6.
+
+## 제2원인 판별 (별도 트랙 — 본 PR 비범위)
+
+예산 정합 후에도 컷은 [2] 유지 (한글/HWP 경로 [3]). `RHWP_CUT_DBG`(신규 진단) 유닛
+덤프로 규명:
+
+| 경로 | pi52 셀 유닛 | 높이 | hard_break |
+|------|-------------|------|-----------|
+| HWPX (reflow 합성 seg) | 8개 | **37.9/31.2px** | **5곳** (합성 seg 가 문단마다 vpos=0 → 리셋 오인) |
+| HWP (저장 seg) | 10개 | 30.9/24.3px (=lh1600+ls720) | 1곳 |
+
+- 컷 [2] 의 직접 원인 = hb 오인 정지 + **합성 줄높이 과대(+23%)** 의 결합
+  (31.2+37.9+37.9=107 > 예산 96.2 vs HWP 86.1 ≤ 93.0).
+- 근본 = **reflow 합성 seg 의 줄높이·vpos 공식이 한컴 계산과 불일치** — 셀 내부
+  문단 전반에 걸친 광역 주제(#1772/#1774 계열). 국소 보정은 회귀 반경이 커서 본
+  PR 에서 분리, 판별 결과를 이슈에 보고.
+
+## 게이트 (수정 1)
+
+| 게이트 | 결과 |
+|--------|------|
+| #1810 기준 양 게이트 | vpos: pi18 2쪽 시작 ✓ / page_break: pi26 2쪽 잔존·5쪽 ✓ (hwpx/hwp 모두 2/5쪽) |
+| 통제셋 92 | **일치 75 유지**, under 14 불변, over 3 불변 (내부 +2→+1 개선 방향 이동) |
+| `cargo test --release` 전체 | **2780 passed / 실질 실패 0** (7건 svg_snapshot CRLF 노이즈 #1786, 내용 diff 0) |
+
+산출: 신규 진단 `RHWP_FLOW_DBG`(typeset 흐름)·`RHWP_CUT_DBG`(셀 유닛) — env-gated,
+RHWP_TABLE_DRIFT 관례.

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1080,10 +1080,13 @@ pub(crate) fn reflow_line_segs(
         let text_height_hwp = line_height_hwp;
         let baseline_distance_hwp = (line_height_hwp as f64 * 0.85) as i32;
         let line_spacing_hwp = compute_line_spacing_hwp(ls_type, ls_value, line_height_hwp, dpi);
+        // [Task #1811] 원본 linesegarray 부재(orig=None) 시 합성 seg 에 구현속성
+        // 태그를 부여 — vpos 보정 등에서 실제 저장 증거와 구분한다 (컨버터의
+        // 합성 lineseg flags=0x8000_0000 관례와 정합).
         let orig_tag = orig
             .as_ref()
             .map(|ls| ls.tag)
-            .unwrap_or(LineSeg::TAG_SINGLE_SEGMENT_LINE);
+            .unwrap_or(LineSeg::TAG_SINGLE_SEGMENT_LINE | LineSeg::TAG_IMPLEMENTATION_PROPERTY);
         LineSeg {
             text_start: utf16_start,
             line_height: line_height_hwp,

--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -189,6 +189,16 @@ impl HeightCursor {
         let Some(seg) = prev_seg else {
             return y_offset;
         };
+        // [Task #1811] 합성 seg(원본 linesegarray 부재 — reflow/컨버터 생성,
+        // TAG_IMPLEMENTATION_PROPERTY)는 저장 증거가 아니다. **전방(forward)** 보정
+        // 근거로 쓰면 구세션 저장 flow 위치로 과대 전진해(+9.6px) 후속 분할 표 예산이
+        // 부족해진다 (saved_bounds_cumulative_page_break p4 컷 [2]→[3] 결손).
+        // [Task #1811 v2] 단, 되감기와 대형 재앵커 점프는 허용한다 — 전면 차단하면
+        // 파스 경로별 미세 측정차가 재동기화를 잃고 누적되어 라운드트립 쪽나눔이
+        // 갈린다 (seoul_1006 p7→p8 Group+줄 이월 회귀). 판정은 최종 result 산출 후
+        // 방향·크기로 한다 (함수 끝 SYNTH_FORWARD_REANCHOR_MIN_PX 클램프).
+        let synthetic_prev_seg =
+            seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY != 0;
         if seg.vertical_pos == 0 && prev_pi > 0 {
             return y_offset;
         }
@@ -1256,6 +1266,27 @@ impl HeightCursor {
             && (-0.5..4.0).contains(&stored_gap_px)
         {
             return y_offset + prev_line_spacing_px;
+        }
+        // [Task #1811 v2] 합성 seg 증거의 **소폭(drift형) 전방 이동**만 차단한다.
+        // - 되감기(result < y_offset): 허용 — sequential 이 앞서 나갔을 때의 재동기화.
+        // - 대형 전방 점프(> SYNTH_FORWARD_REANCHOR_MIN_PX): 허용 — 저장 vpos 로의
+        //   구조적 재앵커. 파스 경로별 미세 측정차(예: seoul_1006 pi=41 표 +9.6px)가
+        //   누적되어도 양 경로가 같은 저장 좌표에 재앵커되어 쪽나눔 결정이 수렴한다.
+        //   전면 차단하면 누적차가 쪽 경계에서 발현해 라운드트립 pagination 이 갈린다.
+        // - 소폭 전방(≤ 임계): 차단 — 구세션 저장 flow 위치로의 과대 전진(+9.6px,
+        //   saved_bounds_cumulative_page_break p4 분할 예산 결손)이 이 대역이다.
+        const SYNTH_FORWARD_REANCHOR_MIN_PX: f64 = 48.0;
+        if synthetic_prev_seg
+            && result > y_offset + 0.5
+            && result - y_offset <= SYNTH_FORWARD_REANCHOR_MIN_PX
+        {
+            if std::env::var("RHWP_VPOS_DEBUG").is_ok() {
+                eprintln!(
+                    "VPOS_SYNTH_FWD_SKIP: pi={} prev_pi={} y_in={:.2} result={:.2}",
+                    item_para, prev_pi, y_offset, result,
+                );
+            }
+            return y_offset;
         }
         result
     }

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -5220,6 +5220,25 @@ impl LayoutEngine {
         let rewind_internal_hard_break_orphan = Self::row_has_prior_rowspan_cover(table, row);
         for (i, cell) in row_cells.iter().enumerate() {
             let units = self.cell_units(cell, table, styles);
+            if std::env::var("RHWP_CUT_DBG").is_ok() {
+                let desc: Vec<String> = units
+                    .iter()
+                    .map(|u| {
+                        format!(
+                            "h={:.1}{}{}v{}..{}",
+                            u.height,
+                            if u.empty_spacer { " sp" } else { "" },
+                            if u.hard_break_before { " hb " } else { " " },
+                            u.vis_start,
+                            u.vis_end,
+                        )
+                    })
+                    .collect();
+                eprintln!(
+                    "CUT_DBG row={row} cell={i} avail={avail_height:.1} units=[{}]",
+                    desc.join(" | ")
+                );
+            }
             let start = start_cut.get(i).copied().unwrap_or(0).min(units.len());
             let mut j = start;
             let mut h = 0.0f64;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2004,6 +2004,14 @@ impl TypesetEngine {
             if st.prefilled_paras.contains(&para_idx) {
                 continue;
             }
+            if std::env::var("RHWP_FLOW_DBG").is_ok() {
+                eprintln!(
+                    "FLOW_DBG pi={} page={} cur_h={:.1}",
+                    para_idx,
+                    st.pages.len(),
+                    st.current_height
+                );
+            }
             // 표 컨트롤 감지
             let has_table = self.paragraph_has_table(para);
 


### PR DESCRIPTION
## 요약

#1811(PR #1810 후속, `saved_bounds_cumulative_page_break.hwpx` p5 tail/line drift)을 조사해 **독립 원인 2개**를 규명했습니다. 원리적 결함(합성 seg 의 vpos 증거 오인)을 본 PR 로 수정하고, 잔여(합성 seg 유닛 구성 격차)는 광역 주제로 판별 문서화했습니다.

Part of #1811 (원인 2 잔존 — close 여부는 메인테이너 판단 위임)

## 증상의 실체

리뷰 PNG(`pr_1752_visual_review_p5_followup_candidate.png`) 판독 — p4 끝 분할 표 pi52 컷이 **HWPX end_cut=[2] vs HWP/한글 [3]**: (사회기여) 문단이 p5 로 밀려 이후 내용이 한 블록씩 지연되고 p5 하단에서 ⑥ 제목이 잘림.

## 원인 1 (본 PR 수정) — 합성 seg 의 vpos 전방 보정 오인

- pi50(글자처럼 표 host)은 **원본 XML 에 linesegarray 부재** → 로드-정규화 `reflow_line_segs` 가 seg 를 합성하는데 synthetic 표식 없이 생성(flags=0x60000).
- `HeightCursor::vpos_adjust` lazy 전방 보정이 이를 실제 저장 증거로 오인 → pi51 을 구세션 저장 flow 위치로 **+9.6px 과대 전진**(RHWP_VPOS_DEBUG 실측: 647.59→657.19) → 분할 예산 −6.4px.
- **수정**: ① 원본 부재(orig=None) 합성 seg 에 `TAG_IMPLEMENTATION_PROPERTY(1<<31)` 부여(컨버터 합성 lineseg 관례 정합) ② `vpos_adjust` 에서 합성 태그 prev seg 는 보정 근거로 쓰지 않음(sequential 신뢰).
- 효과: pi52 진입 cur_h 669.2→659.6(HWP 662.8 정합), 분할 예산 117.0→**126.6**(HWP 123.4 초과).

## 원인 2 (판별·분리) — 합성 seg 유닛 구성 격차

예산 정합 후에도 컷 [2] 유지. `RHWP_CUT_DBG`(신규 진단) 유닛 덤프:

| 경로 | pi52 셀 유닛 | 높이 | hard_break |
|---|---|---|---|
| HWPX (reflow 합성) | 8개 | 37.9/31.2px | **5곳** (문단별 vpos=0 → 리셋 오인) |
| HWP (저장 seg) | 10개 | 30.9/24.3px | 1곳 |

근본 = reflow 합성 seg 의 **줄높이(+23%)·vpos 공식이 한컴 계산과 불일치** — 셀 내부 문단 전반의 광역 주제(#1772/#1774 계열)로 국소 보정 회귀 반경이 커서 본 PR 에서 분리. 상세: `mydocs/working/task_m100_1811_stage1.md`.

## 검증 (plain devel)

| 게이트 | 결과 |
|---|---|
| #1810 기준 양 게이트 | vpos: pi18 2쪽 시작 ✓ / page_break: pi26 2쪽 잔존·**5쪽 유지** ✓ |
| 통제셋 92 | 일치 75 유지, under 14·over 3 불변 (over 내부 +2→+1 개선 방향) |
| `cargo test --release` 전체 | 2780 passed / 실질 실패 0 (7건 svg_snapshot Windows autocrlf 노이즈 — #1786) |
| `--lib` (plain devel) | 2067 passed |
| 1749/1750 통합 테스트 | 통과 |

## 재현·진단

```bash
RHWP_VPOS_DEBUG=1 rhwp dump-pages samples/task1749/saved_bounds_cumulative_page_break.hwpx -p 3   # pi51 보정 소멸 확인
RHWP_TABLE_DRIFT=1 rhwp dump-pages ... | grep pi=52   # avail_for_rows 126.6
```

신규 진단(env-gated, RHWP_TABLE_DRIFT 관례): `RHWP_FLOW_DBG`(typeset 문단별 cur_h), `RHWP_CUT_DBG`(advance_row_cut 셀 유닛 시퀀스).

상세: `mydocs/report/task_m100_1811_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)