### PR TITLE
Task #1786: golden SVG eol=lf 고정 — Windows autocrlf svg_snapshot 7/8 실패 수정

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,3 +3,6 @@
 # 본질: 50 MB 초과 PDF 영역 영역 git history 영역 영역 직접 진입을 차단
 # 다른 PDF 폴더 (pdf/, pdf-2020/, pdf-2010/) 영역 영역 일반 git 영역 영역 보존
 pdf-large/**/*.pdf filter=lfs diff=lfs merge=lfs -text
+
+# SVG 골든 스냅샷 — 렌더러 생성물(LF)과 바이트 비교하므로 CRLF 변환 금지 (#1786)
+tests/golden_svg/**/*.svg text eol=lf


### PR DESCRIPTION
## 개요

Windows + `core.autocrlf=true` 체크아웃에서 `cargo test --test svg_snapshot` 이 8건 중 7건 실패하는 문제(#1786)를 `.gitattributes` 로 수정합니다.

## 원인·수정

골든 SVG(`tests/golden_svg/**/*.svg`)의 인덱스 blob 은 이미 LF 인데(`git ls-files --eol` 확인: `i/lf w/crlf`), autocrlf 체크아웃이 워킹트리를 CRLF 로 변환해 렌더러 생성물(LF)과의 바이트 비교가 전 라인 불일치합니다.

`.gitattributes` 에 `tests/golden_svg/**/*.svg text eol=lf` 1줄 추가 — 인덱스가 이미 LF 이므로 renormalize 불필요, 체크아웃 EOL 만 고정됩니다. CI(Linux, LF 체크아웃)는 무영향.

기존 Windows 체크아웃은 아래로 복원:

```
Remove-Item -Recurse tests\golden_svg; git checkout -- tests/golden_svg
```

## 검증

- `git ls-files --eol`: 7개 골든 전부 `i/lf w/lf attr/text eol=lf`
- 통합 스택(devel+열린 PR 5건)에서 `cargo test --release` 가 svg_snapshot 7건 실패로 중단되는 것을 재현 → 본 수정 적용 후 svg_snapshot 8/8 통과 (별도 코멘트로 확인 예정)

closes #1786

🤖 Generated with [Claude Code](https://claude.com/claude-code)
