### PR TITLE
Task #1773: render-diff TextRun ±1 조성 노이즈 WARN_TEXTRUN 등급 분리

### DIFF
--- a/mydocs/plans/task_m100_1773.md
+++ b/mydocs/plans/task_m100_1773.md
@@ -11,3 +11,17 @@
   경미(15/5,600건) 노이즈 대비 위험이 커서 본 태스크에서는 판별 기록만.
 - 이슈에 원인·수정 방향 코멘트. 게이트 노이즈 완화 대안: render-diff 의 TextRun ±1 을
   WARN 등급 분리(도구 측) 검토 병기.
+
+## 후속 구현 (2026-07-03, 대안 ② WARN 등급 분리)
+
+`src/diagnostics/render_geom_diff.rs`:
+
+1. `walk()` 구조 불일치 이벤트에 삽입/삭제 노드 타입 기록 (`struct_inserts`/`struct_deletes`)
+2. `is_textrun_pm1()`: 이벤트가 TextRun 만 + 삽입·삭제 각 ≤1 → `PageGeomDiff.struct_textrun_pm1`
+3. status: TextRun ±1 로 설명되지 않는 구조 불일치 페이지만 STRUCT_MISMATCH.
+   TextRun ±1 뿐이면 변위 임계 이내 **WARN_TEXTRUN**(하드 실패 아님), 임계 초과는 종전 OVER
+4. 배치 요약 WARN_TEXTRUN 행, 단일 보고 `[STRUCT:TextRun±1]` 마커
+
+보수성: 삽입 서브트리는 최상위 노드 타입만 기록 — TextLine 삽입(내부 TextRun 포함)은
+TextRun 이벤트가 아니므로 종전대로 하드 실패. 같은 방향 2개 이상도 하드 유지.
+원 인코딩 보존(①)은 별도 설계 과제로 이슈 open 유지.

--- a/mydocs/report/task_m100_1773_report.md
+++ b/mydocs/report/task_m100_1773_report.md
@@ -1,0 +1,49 @@
+# Task #1773 최종 보고 — render-diff TextRun ±1 WARN 등급 분리
+
+## 개요
+
+#1773 판별(레거시 무-컨트롤문자 구역정의의 직렬화 정규화 → 재파스 조성 차이 → TextRun ±1)의
+후속 처리로, 판별된 두 방향 중 저위험 안인 **② render-diff 게이트 WARN 등급 분리**를 구현했다.
+① 원 인코딩 보존(파서 attachment-mode 플래그 + 직렬화 분기)은 별도 설계 과제로 이슈 open 유지.
+
+## 구현
+
+`src/diagnostics/render_geom_diff.rs`:
+
+- `walk()` 의 LCS 삽입/삭제 이벤트에 노드 타입을 기록 (`PageAccum.struct_inserts/struct_deletes`)
+- `is_textrun_pm1()`: 이벤트 전부 TextRun + 삽입·삭제 각 ≤1 → `PageGeomDiff.struct_textrun_pm1`
+- status 판정 재구성:
+  - `hard_struct_pages`(TextRun ±1 로 설명 안 되는 구조 불일치) > 0 → STRUCT_MISMATCH (종전 유지)
+  - 변위 임계 초과 → OVER (조성 노이즈 있어도 하드 유지)
+  - TextRun ±1 뿐 + 변위 임계 이내 → **WARN_TEXTRUN** (신설, 하드 실패 아님)
+- `status_is_hard_failure`: PASS | WARN_TEXTRUN 통과
+- 배치 요약에 WARN_TEXTRUN 카운트, 단일 보고에 `[STRUCT:TextRun±1]` 마커, 종료코드는
+  `status_is_hard_failure` 공통 사용
+
+### 보수성 설계
+
+- 삽입/삭제 서브트리는 **최상위 노드 타입만** 기록 — TextLine 삽입(내부에 TextRun 포함)은
+  TextRun 이벤트가 아니므로 종전대로 하드 실패
+- 같은 방향(삽입 또는 삭제) 2개 이상이면 하드 유지 — 페이지당 ±1 만 완화
+- 페이지 수 불일치(PAGE_MISMATCH)는 완화 대상 아님
+
+## 검증
+
+- 단위 테스트 6종 추가 (predicate 경계, WARN 강등, 비-TextRun 하드 유지, OVER 우선,
+  혼재 페이지 하드 우선, 게이트 판정) — `diagnostics::render_geom_diff` 13/13 통과
+- 케이스 문서 2912837(sample_hwp/admrul_072.hwp) 재검: `[STRUCT:TextRun±1]` 마커 정확 검출,
+  변위 168px 로 **OVER 유지** (조성 노이즈여도 대변위는 하드 실패 — 설계 의도)
+- 코퍼스 스팟 (TextRun-only struct_delta 전수):
+  - big_hwp admrul_0644 (104px) / admrul_0645 (465px): `[STRUCT:TextRun±1]` 검출 + OVER 유지
+  - big_hwpx seoul_0620 (23px): TextRun:-1 — OVER 대상
+  - 일반 구조 붕괴(admrul_0020 Cell:-9;Line:-6): STRUCT_MISMATCH 유지 — 부당 강등 없음
+
+**관찰**: 현 코퍼스의 TextRun ±1 케이스는 전부 대변위 동반이라 WARN_TEXTRUN 실사례는 0건 —
+본 수정의 즉효는 STRUCT(구조 붕괴) 분류에서 조성 노이즈를 분리(`[STRUCT:TextRun±1]` 마커 +
+STRUCT→OVER 재분류)하는 triage 정밀화이며, WARN 강등은 향후 소변위 케이스에 대비한 안전망이다.
+근본 해소는 ① 원 인코딩 보존 설계(별도 태스크)로 남는다.
+
+## 잔여
+
+- ① 원 인코딩 보존 설계 (#1773 open 유지 사유): 파서가 "레코드 전용 구역 컨트롤"을
+  플래그로 보존하고 직렬화기가 컨트롤 문자 합성을 생략하는 왕복 계약 — 위험 평가 후 별도 태스크

--- a/src/diagnostics/render_geom_diff.rs
+++ b/src/diagnostics/render_geom_diff.rs
@@ -79,6 +79,10 @@ pub struct PageGeomDiff {
     pub top_deltas: Vec<NodeDelta>,
     /// 노드 타입별 개수 증감 (개수가 다른 타입만). 구조 불일치 원인 국소화용.
     pub type_deltas: Vec<TypeDelta>,
+    /// 구조 불일치가 TextRun ±1 (삽입·삭제 각 최대 1개, 다른 타입 없음) 뿐인지.
+    /// 레거시 무-컨트롤문자 구역정의 정규화가 유발하는 경미 조성 노이즈 (#1773) —
+    /// 게이트에서 WARN_TEXTRUN 으로 분리한다.
+    pub struct_textrun_pm1: bool,
 }
 
 /// 문서 전체 기하 차이.
@@ -175,6 +179,10 @@ struct PageAccum {
     count: usize,
     max_disp: f64,
     structure_mismatch: bool,
+    /// 구조 불일치로 기록된 삽입(b 전용) 노드 타입들.
+    struct_inserts: Vec<&'static str>,
+    /// 구조 불일치로 기록된 삭제(a 전용) 노드 타입들.
+    struct_deletes: Vec<&'static str>,
     top: Vec<NodeDelta>,
 }
 
@@ -185,6 +193,8 @@ impl PageAccum {
             count: 0,
             max_disp: 0.0,
             structure_mismatch: false,
+            struct_inserts: Vec::new(),
+            struct_deletes: Vec::new(),
             top: Vec::new(),
         }
     }
@@ -282,9 +292,31 @@ fn walk(a: &RenderNode, b: &RenderNode, path: &str, acc: &mut PageAccum) {
                 walk(&a.children[i], &b.children[j], &child_path, acc);
             }
             // 한쪽에만 있는 노드 = 삽입/삭제 → 구조 불일치(변위 아님).
-            _ => acc.structure_mismatch = true,
+            (Some(i), None) => {
+                acc.structure_mismatch = true;
+                acc.struct_deletes.push(sa[i]);
+            }
+            (None, Some(j)) => {
+                acc.structure_mismatch = true;
+                acc.struct_inserts.push(sb[j]);
+            }
+            (None, None) => unreachable!("lcs_align 은 (None, None) 을 내지 않는다"),
         }
     }
+}
+
+/// 구조 불일치 이벤트가 "TextRun ±1" 뿐인지 — 삽입·삭제 모두 TextRun 타입이고
+/// 각각 최대 1개일 때만 true. 컨트롤문자-무 구역정의 정규화가 유발하는 run 조성
+/// 차이(#1773)를 하드 실패에서 분리하기 위한 판별.
+fn is_textrun_pm1(inserts: &[&'static str], deletes: &[&'static str]) -> bool {
+    let only_textrun = inserts
+        .iter()
+        .chain(deletes.iter())
+        .all(|t| *t == "TextRun");
+    (!inserts.is_empty() || !deletes.is_empty())
+        && only_textrun
+        && inserts.len() <= 1
+        && deletes.len() <= 1
 }
 
 /// 한 페이지의 루트 노드 쌍을 비교한다.
@@ -307,6 +339,8 @@ pub fn diff_page(page: u32, root_a: &RenderNode, root_b: &RenderNode) -> PageGeo
     } else {
         0.0
     };
+    let struct_textrun_pm1 =
+        acc.structure_mismatch && is_textrun_pm1(&acc.struct_inserts, &acc.struct_deletes);
     PageGeomDiff {
         page,
         node_count_a,
@@ -316,6 +350,7 @@ pub fn diff_page(page: u32, root_a: &RenderNode, root_b: &RenderNode) -> PageGeo
         mean_disp,
         top_deltas: acc.top,
         type_deltas: compute_type_deltas(root_a, root_b),
+        struct_textrun_pm1,
     }
 }
 
@@ -450,6 +485,8 @@ struct DiffSummary {
     worst_page: Option<u32>,
     max_disp: f64,
     struct_pages: usize,
+    /// TextRun ±1 로 설명되지 않는 구조 불일치 페이지 수 (하드 실패 기준).
+    hard_struct_pages: usize,
     over_pages: usize,
 }
 
@@ -458,10 +495,14 @@ fn summarize(diff: &DocGeomDiff, page: Option<u32>, threshold: f64) -> DiffSumma
     let mut worst_page = None;
     let mut max_disp = 0.0_f64;
     let mut struct_pages = 0;
+    let mut hard_struct_pages = 0;
     let mut over_pages = 0;
     for p in &pages {
         if p.structure_mismatch {
             struct_pages += 1;
+            if !p.struct_textrun_pm1 {
+                hard_struct_pages += 1;
+            }
         }
         if p.max_disp > threshold {
             over_pages += 1;
@@ -475,6 +516,7 @@ fn summarize(diff: &DocGeomDiff, page: Option<u32>, threshold: f64) -> DiffSumma
         worst_page,
         max_disp,
         struct_pages,
+        hard_struct_pages,
         over_pages,
     }
 }
@@ -482,17 +524,20 @@ fn summarize(diff: &DocGeomDiff, page: Option<u32>, threshold: f64) -> DiffSumma
 fn status_str(diff: &DocGeomDiff, sum: &DiffSummary, threshold: f64) -> &'static str {
     if diff.page_count_mismatch() {
         "PAGE_MISMATCH"
-    } else if sum.struct_pages > 0 {
+    } else if sum.hard_struct_pages > 0 {
         "STRUCT_MISMATCH"
     } else if sum.max_disp > threshold {
         "OVER"
+    } else if sum.struct_pages > 0 {
+        // 구조 차이가 TextRun ±1 뿐이고 변위도 임계 이내 — 경미 조성 노이즈 (#1773).
+        "WARN_TEXTRUN"
     } else {
         "PASS"
     }
 }
 
 fn status_is_hard_failure(status: &str) -> bool {
-    status != "PASS"
+    !matches!(status, "PASS" | "WARN_TEXTRUN")
 }
 
 /// `.hwp`/`.hwpx` 파일을 재귀 수집(정렬).
@@ -674,6 +719,7 @@ fn print_batch_summary(rows: &[BatchRow]) {
     println!("=== render-diff 요약 ===");
     println!("  총 파일         : {}", rows.len());
     println!("  PASS            : {}", count("PASS"));
+    println!("  WARN_TEXTRUN    : {}", count("WARN_TEXTRUN"));
     println!("  OVER            : {}", count("OVER"));
     println!("  STRUCT_MISMATCH : {}", count("STRUCT_MISMATCH"));
     println!("  PAGE_MISMATCH   : {}", count("PAGE_MISMATCH"));
@@ -761,7 +807,9 @@ fn run_single(opts: &CliOptions) -> i32 {
                 p.mean_disp,
                 p.node_count_a,
                 p.node_count_b,
-                if p.structure_mismatch {
+                if p.struct_textrun_pm1 {
+                    "  [STRUCT:TextRun±1]"
+                } else if p.structure_mismatch {
                     "  [STRUCT]"
                 } else {
                     ""
@@ -792,9 +840,10 @@ fn run_single(opts: &CliOptions) -> i32 {
     }
     println!("status: {status}");
 
-    match status {
-        "PASS" => 0,
-        _ => 1,
+    if status_is_hard_failure(status) {
+        1
+    } else {
+        0
     }
 }
 
@@ -925,11 +974,89 @@ mod tests {
     #[test]
     fn non_pass_statuses_are_hard_failures() {
         assert!(!status_is_hard_failure("PASS"));
+        // TextRun ±1 경미 조성 노이즈는 게이트 하드 실패에서 제외 (#1773).
+        assert!(!status_is_hard_failure("WARN_TEXTRUN"));
         for status in ["OVER", "STRUCT_MISMATCH", "PAGE_MISMATCH", "LOAD_FAIL"] {
             assert!(
                 status_is_hard_failure(status),
                 "{status} must fail the gate"
             );
         }
+    }
+
+    #[test]
+    fn textrun_pm1_predicate() {
+        // 삽입/삭제 각 1개 이하 + TextRun 만 → true.
+        assert!(is_textrun_pm1(&["TextRun"], &[]));
+        assert!(is_textrun_pm1(&[], &["TextRun"]));
+        assert!(is_textrun_pm1(&["TextRun"], &["TextRun"]));
+        // 이벤트 없음 → false (구조 불일치가 아님).
+        assert!(!is_textrun_pm1(&[], &[]));
+        // 다른 타입 혼입 → false.
+        assert!(!is_textrun_pm1(&["TextLine"], &[]));
+        assert!(!is_textrun_pm1(&["TextRun"], &["Line"]));
+        // 같은 방향 2개 이상 → false.
+        assert!(!is_textrun_pm1(&["TextRun", "TextRun"], &[]));
+    }
+
+    fn page_diff(
+        structure_mismatch: bool,
+        struct_textrun_pm1: bool,
+        max_disp: f64,
+    ) -> PageGeomDiff {
+        PageGeomDiff {
+            page: 0,
+            node_count_a: 1,
+            node_count_b: 1,
+            structure_mismatch,
+            max_disp,
+            mean_disp: 0.0,
+            top_deltas: Vec::new(),
+            type_deltas: Vec::new(),
+            struct_textrun_pm1,
+        }
+    }
+
+    fn doc_diff(pages: Vec<PageGeomDiff>) -> DocGeomDiff {
+        let max_disp = pages.iter().map(|p| p.max_disp).fold(0.0_f64, f64::max);
+        DocGeomDiff {
+            page_count_a: pages.len() as u32,
+            page_count_b: pages.len() as u32,
+            pages,
+            max_disp,
+        }
+    }
+
+    #[test]
+    fn textrun_pm1_struct_downgrades_to_warn() {
+        let d = doc_diff(vec![page_diff(true, true, 0.5)]);
+        let sum = summarize(&d, None, 1.0);
+        assert_eq!(status_str(&d, &sum, 1.0), "WARN_TEXTRUN");
+    }
+
+    #[test]
+    fn non_textrun_struct_stays_hard() {
+        let d = doc_diff(vec![page_diff(true, false, 0.5)]);
+        let sum = summarize(&d, None, 1.0);
+        assert_eq!(status_str(&d, &sum, 1.0), "STRUCT_MISMATCH");
+    }
+
+    #[test]
+    fn textrun_pm1_with_over_disp_is_over() {
+        // 조성 노이즈가 있어도 변위가 임계를 넘으면 OVER 로 하드 실패 유지.
+        let d = doc_diff(vec![page_diff(true, true, 5.0)]);
+        let sum = summarize(&d, None, 1.0);
+        assert_eq!(status_str(&d, &sum, 1.0), "OVER");
+    }
+
+    #[test]
+    fn mixed_pages_hard_struct_wins() {
+        // 한 페이지는 TextRun ±1, 다른 페이지는 일반 구조 불일치 → STRUCT_MISMATCH.
+        let d = doc_diff(vec![
+            page_diff(true, true, 0.0),
+            page_diff(true, false, 0.0),
+        ]);
+        let sum = summarize(&d, None, 1.0);
+        assert_eq!(status_str(&d, &sum, 1.0), "STRUCT_MISMATCH");
     }
 }


### PR DESCRIPTION
## 개요

이슈 #1773 판별의 후속 처리 — 두 방향 중 저위험 안인 **② render-diff 게이트에서 TextRun ±1 조성 노이즈를 WARN 등급으로 분리**를 구현합니다. ① 원 인코딩 보존(파서 attachment-mode 플래그 + 직렬화 분기)은 별도 설계 과제로 이슈 open 유지.

## 구현 (`src/diagnostics/render_geom_diff.rs`)

- `walk()` 의 LCS 삽입/삭제 이벤트에 노드 타입 기록
- `is_textrun_pm1()`: 이벤트가 TextRun 만 + 삽입·삭제 각 ≤1 → `struct_textrun_pm1`
- status 재구성: TextRun ±1 로 설명 안 되는 구조 불일치만 STRUCT_MISMATCH / 변위 초과는 종전대로 OVER / TextRun ±1 뿐 + 변위 임계 이내면 신설 **WARN_TEXTRUN** (하드 실패 아님)
- 단일 보고 `[STRUCT:TextRun±1]` 마커, 배치 요약 WARN_TEXTRUN 카운트

보수성: 삽입 서브트리는 최상위 노드 타입만 기록(TextLine 삽입은 하드 유지), 같은 방향 2개 이상 하드 유지, PAGE_MISMATCH 완화 없음.

## 검증

- 모듈 단위 테스트 13/13 (신규 6종: predicate 경계, WARN 강등, 비-TextRun 하드, OVER 우선, 혼재 하드 우선, 게이트)
- 케이스/코퍼스 (TextRun-only struct_delta 전수):

| 파일 | 변위 | 결과 |
|------|------|------|
| sample_hwp admrul_072 (2912837, 이슈 케이스) | 168px | `[STRUCT:TextRun±1]` 검출, OVER 유지 |
| big_hwp admrul_0644 / 0645 | 104 / 465px | 마커 검출, OVER 유지 |
| big_hwpx admrul_0020 (구조 붕괴 Cell:-9) | 1037px | STRUCT_MISMATCH 유지 — 부당 강등 없음 |

**정직한 관찰**: 현 코퍼스의 TextRun ±1 케이스는 전부 대변위 동반이라 WARN_TEXTRUN 실사례는 아직 0건입니다. 본 PR 의 즉효는 STRUCT(구조 붕괴) 분류에서 조성 노이즈를 기계 판별로 분리하는 triage 정밀화이고, WARN 강등은 소변위 케이스에 대비한 안전망입니다.

이슈 #1773 은 ① 설계 과제가 남아 open 유지 권장.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
