### PR TITLE
Task #1809 v2: RowBreak top pad·컷 이월 flow extra 소스 무관화 (한글 판정, admrul_0556/0072 해소)

### DIFF
--- a/mydocs/plans/task_m100_1809_v2.md
+++ b/mydocs/plans/task_m100_1809_v2.md
@@ -1,0 +1,44 @@
+# Task #1809 v2 수행 계획 — 잔여 admrul_0556/0072 게이트 정답 방향 판정·수정
+
+## 배경
+
+#1809 조사 7~8차에서 잔여 2건의 원인 게이트를 특정 완료:
+
+- **admrul_0556 (1.88px)** = `table_layout.rs` `hwpx_rowbreak_top_pad` — RowBreak 표 첫 행 top pad 차감이 HWPX 직파스에만 적용
+- **admrul_0072 (16px)** = `table_layout.rs` `mixed_nested_flow_extra_from_cut` — 컷 이월 flow extra 가 HWP5 에만 적용 (is_hwpx_source 조기 0 반환)
+
+두 게이트 모두 외부 기여자 커밋 c7dbe8a2 (RowBreak continuation 안정화) 도입. 킬스위치 실험은 "A(HWPX)를 B(재파스)에 맞춘" 방향이라 정답 축 판정이 필요했음 (조사 8차에서 작업지시자 판정 대기로 전환, 이후 진행 지시 수령).
+
+## 판정 방법
+
+Windows + 한글 2022 편집기(pyhwpx) 환경 — 원본 HWPX 를 한글 편집기로 열어 PDF 저장(권위), rhwp A(HWPX 직파스)·B(HWP5 재파스) PDF 와 **내용 앵커 기준 기하 대조**:
+
+1. 한글 PDF 생성: `Hwp(visible=False).open(...).save_as(format="PDF")` (hangul_pdf_baseline.py 패턴)
+2. PyMuPDF 로 텍스트 baseline + 표 경계선(수평선) y 좌표 추출
+3. A/B 가 갈리는 요소를 특정하고, 같은 내용 앵커(텍스트 줄)와 경계선의 상대 거리로 3자 비교
+
+## 판정 결과
+
+| 케이스 | 측정 | 한글 | A (게이트 ON) | B (게이트 OFF/ON 반대) | 정답 |
+|--------|------|------|----|----|------|
+| admrul_0556 p1 | RowBreak 조각 하단 컷 y | 808.8pt | **808.7pt** | 810.1pt | **A (pad 적용)** |
+| admrul_0072 p4 | 서명 셀 '성명' 줄→하단 경계 | 25.5pt | 13.9pt | **25.9pt** | **B (extra 적용)** |
+
+두 게이트의 정답 방향이 서로 반대 — 0556 은 pad **적용**이, 0072 는 extra **적용**이 한글 정합. 공통 결론: **두 보정 모두 소스 무관 기하** — HWPX 한정/HWP5 한정 게이트가 각각 반대편 경로에서 한글과 어긋남.
+
+## 수정 계획
+
+1. `hwpx_rowbreak_top_pad`: `is_hwpx_source` 조건 제거 → `is_block_rowbreak && !has_internal_line_reset` 만으로 적용 (HWP5 재파스·네이티브에도 적용)
+2. `mixed_nested_flow_extra_from_cut`: `is_hwpx_source` 조기 0 반환 제거 (HWPX 에도 적용)
+
+### 네이티브 회귀 리스크와 검증
+
+- 게이트 4 소스 무관화는 네이티브 HWP5 의 RowBreak mixed-nested 경로에도 pad 차감을 적용 — 시각 회귀 가능성은 golden(svg_snapshot 등 전체 테스트) + big_hwp 2,500 배치로 검증
+- big_hwp identity 배치는 A=B 대칭 적용이라 항상 identity — **golden 테스트가 네이티브 시각 변화 검출 축**
+- big_hwpx 2,500 배치로 HWPX↔HWP 게이트 개선/회귀 집계
+
+## 산출물
+
+- 수정: `src/renderer/layout/table_layout.rs` 2곳
+- 보고서: `mydocs/report/task_m100_1809_v2_report.md`
+- 판정 재현물: `output/poc/task1809/` (한글 PDF, A/B PDF)

--- a/mydocs/report/task_m100_1809_v2_report.md
+++ b/mydocs/report/task_m100_1809_v2_report.md
@@ -1,0 +1,35 @@
+# Task #1809 v2 최종 보고 — 잔여 admrul_0556/0072 한글 판정·게이트 소스 무관화
+
+## 판정 (조사 9차)
+
+Windows + 한글 2022(pyhwpx)로 원본 HWPX 의 편집기 PDF(권위)를 생성, rhwp A(HWPX 직파스)/B(HWP5 재파스) PDF 와 내용 앵커 기준 기하 3자 대조 (PyMuPDF 텍스트 baseline + 표 경계선 y):
+
+| 케이스 | 측정 앵커 | 한글 | A (현행) | B (재파스) | 정답 |
+|--------|----------|------|----|----|------|
+| admrul_0556 p1 | RowBreak 조각 하단 컷 y | 808.8pt | **808.7** (pad ON) | 810.1 (pad 없음) | **pad 적용** |
+| admrul_0072 p4 | 서명 셀 '성명' 줄→하단 경계 | 25.5pt | 13.9 (extra 없음) | **25.9** (extra ON) | **extra 적용** |
+
+두 게이트(c7dbe8a2 도입)의 정답 방향이 **서로 반대** — 공통 결론은 두 보정 모두 소스 무관 기하라는 것. 각각 반대편 파스 경로에서 한글과 어긋나 있었다.
+
+## 수정 (`src/renderer/layout/table_layout.rs` 2곳)
+
+1. `hwpx_rowbreak_top_pad`: `is_hwpx_source` 조건 제거 → `is_block_rowbreak && !has_internal_line_reset` 만으로 적용
+   - 합성 seg 태그(#1811 TAG_IMPLEMENTATION_PROPERTY) 기반 증거 판별도 시도 — B 의 seg 는 HWPX linesegarray 유래 원본 태그라 판별 불가, 소스 무관화가 정공 (시도·기각 기록)
+2. `mixed_nested_flow_extra_from_cut`: `is_hwpx_source` 조기 0 반환 제거
+
+## 검증
+
+- **대상 케이스**: admrul_0556 OVER 1.88 → **PASS 0.00** / admrul_0072 OVER 16.00 → **PASS 0.00**
+- **한글 절대 기하 재확인**: 0556 B 컷 위치 808.7 = 한글 808.8 / 0072 A 서명 셀 gap 25.9pt = 한글 25.5pt
+- **cargo test --release 전수 (통합 스택 + 본 수정)**: 80개 타깃 전부 통과 (svg_snapshot 골든 포함 — 네이티브 시각 회귀 검출 축)
+- **big_hwpx 2,500 배치**: PASS 2470 / OVER 6 / STRUCT 20 / PAGE 4 (직전 기록 2455/8 대비 순개선). 파일 단위 rd_big_hwpx 기준선 대비 개선 103 / 회귀 2
+- **회귀 2건(seoul_0776/1006) 귀속 이등분 완료**: 게이트 수정 **미포함** 빌드들에서 동일 재현 — **본 수정 무관**.
+  - seoul_1006: devel PASS / devel+PR#1826(#1811) 단독 재현 → **PR #1826 기인** (PR 코멘트로 보고)
+  - seoul_0776: **devel 자체에서 재현** (기병합 커밋 기인, 과거 devel 스냅샷 TSV 는 PASS) → 신규 이슈 **#1836** 등록
+- **big_hwp 2,500 네이티브 배치**: PASS 2494 / OVER 4 / STRUCT 2, rd_big_hwp 기준선 대비 **상태 회귀 0**. OVER 내 변위 변화 2건(0593 개선 9→6.7 / 0646 증가 152→247)은 게이트 수정 미포함 빌드에서도 동일 — 본 수정 무관
+- **devel + 본 수정 단독 (PR 브랜치)**: admrul_0556/0072 모두 PASS 0.00, cargo test --release --lib 2067 통과
+
+## 잔여
+
+- row_span=1 측정의 aim=true && pad 0 정합 (#493 시멘틱 충돌) — 별도 규칙 설계 (v1 보고서부터 이월)
+- 회귀 2건은 본 태스크 밖(스택 기인) — 귀속 확정 후 해당 이슈/PR 에 보고

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4890,33 +4890,35 @@ impl LayoutEngine {
                             }
                         } else {
                             let current_h: f64 = fragment_heights.iter().map(|(h, _, _)| *h).sum();
-                            let hwpx_rowbreak_top_pad = if self.is_hwpx_source.get()
-                                && is_block_rowbreak
-                                && !has_internal_line_reset
-                            {
-                                p.controls
-                                    .iter()
-                                    .filter_map(|ctrl| {
-                                        if let Control::Table(t) = ctrl {
-                                            let top_pad = t
-                                                .cells
-                                                .iter()
-                                                .filter(|cell| cell.row == 0)
-                                                .map(|cell| {
-                                                    let (_, _, pad_top, _) =
-                                                        self.resolve_cell_padding(cell, t);
-                                                    pad_top
-                                                })
-                                                .fold(0.0f64, f64::max);
-                                            Some(top_pad)
-                                        } else {
-                                            None
-                                        }
-                                    })
-                                    .sum::<f64>()
-                            } else {
-                                0.0
-                            };
+                            // [Task #1809] top pad 차감(c7dbe8a2, 종전 HWPX 한정)을 소스
+                            // 무관화 — 한글 편집기 대조에서 pad 적용 컷 위치가 정답
+                            // (admrul_0556 p1 조각 하단: 한글 808.8 = pad 적용 808.7,
+                            // 미적용 810.1). HWP5 재파스에도 동일 적용해야 정합.
+                            let hwpx_rowbreak_top_pad =
+                                if is_block_rowbreak && !has_internal_line_reset {
+                                    p.controls
+                                        .iter()
+                                        .filter_map(|ctrl| {
+                                            if let Control::Table(t) = ctrl {
+                                                let top_pad = t
+                                                    .cells
+                                                    .iter()
+                                                    .filter(|cell| cell.row == 0)
+                                                    .map(|cell| {
+                                                        let (_, _, pad_top, _) =
+                                                            self.resolve_cell_padding(cell, t);
+                                                        pad_top
+                                                    })
+                                                    .fold(0.0f64, f64::max);
+                                                Some(top_pad)
+                                            } else {
+                                                None
+                                            }
+                                        })
+                                        .sum::<f64>()
+                                } else {
+                                    0.0
+                                };
                             let top_up = (target_h - current_h).max(0.0);
                             let target_h = target_h - hwpx_rowbreak_top_pad.min(top_up);
                             if target_h > current_h + 0.5 {
@@ -6002,10 +6004,9 @@ impl LayoutEngine {
         start_unit: usize,
         end_unit: usize,
     ) -> f64 {
-        if self.is_hwpx_source.get() {
-            return 0.0;
-        }
-
+        // [Task #1809] 종전 is_hwpx_source 조기 0 반환 제거 — 컷 이월 조각의 flow
+        // extra 는 소스 무관 기하다. 한글 편집기 대조(admrul_0072 서명 셀: 텍스트→
+        // 하단 경계 한글 25.5pt = extra 적용 25.9pt, 미적용 13.9pt)로 적용이 정답.
         let units = self.cell_units(cell, table, styles);
         let lo = start_unit.min(units.len());
         let hi = end_unit.min(units.len()).max(lo);


### PR DESCRIPTION
## 개요

#1809 잔여 2건(admrul_0556 1.88px / admrul_0072 16px)의 정답 방향을 **한글 2022 편집기 PDF 대조로 판정**하고, 원인 게이트 2곳(c7dbe8a2 도입)을 소스 무관화하여 해소합니다. 조사 9차 코멘트(이슈 #1809) 및 `mydocs/plans/task_m100_1809_v2.md` 참조.

## 판정 (내용 앵커 기하 3자 비교: 한글 vs A=HWPX 직파스 vs B=HWP5 재파스)

| 케이스 | 측정 앵커 | 한글 | A | B | 정답 |
|--------|----------|------|----|----|------|
| admrul_0556 p1 | RowBreak 조각 하단 컷 y | 808.8pt | **808.7** (pad ON) | 810.1 | **pad 적용** |
| admrul_0072 p4 | 서명 셀 '성명' 줄→하단 경계 | 25.5pt | 13.9 | **25.9** (extra ON) | **extra 적용** |

두 게이트의 정답 방향이 **서로 반대** — 공통 결론: 두 보정 모두 소스 무관 기하이며, 각각 반대편 파스 경로에서 한글과 어긋나 있었습니다.

## 수정 (`table_layout.rs` 2곳, 1커밋)

1. `hwpx_rowbreak_top_pad`: `is_hwpx_source` 조건 제거
2. `mixed_nested_flow_extra_from_cut`: `is_hwpx_source` 조기 0 반환 제거

## 검증

- 대상: admrul_0556 OVER 1.88 → **PASS 0.00** / admrul_0072 OVER 16.00 → **PASS 0.00** (devel+본 수정 단독으로도 동일)
- 한글 절대좌표 재확인: 0556 B 컷 808.7 = 한글 808.8 / 0072 A gap 25.9pt = 한글 25.5pt
- cargo test: 통합 스택 전수 80타깃 통과, 본 브랜치 lib 2067 통과
- big_hwpx 2,500: PASS 2470 / OVER 6 / STRUCT 20 / PAGE 4 — 개선 103 / **본 수정 기인 회귀 0**
- big_hwp 2,500 (네이티브): PASS 2494, **상태 회귀 0**

### 배치에서 발견된 별개 회귀 (본 PR 무관, 이등분 완료)

- seoul_1006: PR #1826(#1811) 기인 → PR 코멘트로 보고
- seoul_0776: devel 기병합 커밋 기인 → 이슈 #1836 등록

## 잔여

- row_span=1 측정 aim=true && pad 0 정합 (#493 시멘틱 충돌) — 별도 규칙 설계 (v1 이월)

판별 재현물: `output/poc/task1809/` (한글 PDF + A/B PDF). PR #1825(1809 부분 수정)와 독립 — 순서 무관 merge 가능.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
