### PR TITLE
Task #1667: Render Diff cache 후속 계획 수립

### DIFF
--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1849 | `devel` push profile 배치 재조정 착수 | 완료 | 문서 PR #1854 merge 및 이슈 close 완료: 18:32 |
-| #1667 | Rust cache 전략 개선 착수 | 진행중 | #1857 merge 후 measurement 문서 PR 준비 |
+| #1667 | Rust cache 전략 개선 착수 | 진행중 | #1859 merge 후 Render Diff 후속 계획 PR 준비 |
 
 ## PR 처리
 

--- a/mydocs/plans/task_m100_1667_v2.md
+++ b/mydocs/plans/task_m100_1667_v2.md
@@ -1,0 +1,237 @@
+# Task M100 #1667 v2 수행 계획서
+
+## 개요
+
+- 이슈: #1667 `[CI] Rust cache 전략 개선: actions/cache 유지 vs Swatinem/rust-cache 검토`
+- 부모 이슈: #1668 `[Tracking/RFC] CI Build & Test 실행 시간 단계별 단축`
+- 선행 완료:
+  - #1664: Build & Test cargo cache PR restore-only / trusted branch save 정책 정착
+  - #1666: PR `release-test` profile 전환
+  - #1849: `devel` push release smoke + `release-test` 전체 회귀로 profile 배치 재조정
+  - #1857: CodeQL Rust cache restore/save 분리
+  - #1859: #1667 1차 measurement 문서화
+- 마일스톤: M100 / v1.0.0 조판 엔진 체계화
+- 작업 브랜치: `task-1667-render-diff-plan`
+- 작업 성격: Render Diff cargo cache 정책 재검토 계획
+
+## 착수 판단
+
+#1667 1차 작업에서는 CodeQL Rust cache를 #1664 정책과 같은 PR restore-only / trusted branch save-only
+구조로 정렬했다. 다음 후속 범위는 Render Diff cargo cache로 잡는 것이 적절하다.
+
+이유:
+
+- 현재 cache inventory에서 `Linux-render-diff-cargo-*`가 key prefix 기준 가장 큰 누적 요인이다.
+- Render Diff workflow는 `pull_request` 중심이라 PR ref cache가 반복 생성된다.
+- GitHub Actions cache scope 특성상 `refs/pull/<PR>/merge` cache는 base branch나 다른 PR에서 재사용되지 않는다.
+- 단순히 PR save를 끄면 Render Diff의 warm source가 사라질 수 있으므로, Build & Test나 CodeQL과 같은 정책을
+  그대로 복사하기 전에 before 측정과 후보 비교가 필요하다.
+
+## 현재 상태
+
+workflow:
+
+- 파일: `.github/workflows/render-diff.yml`
+- workflow 이름: `Render Diff`
+- 주요 job: `Canvas visual diff`
+- trigger:
+  - `pull_request` on `main`, `devel`
+  - `workflow_dispatch`
+- cargo cache step:
+  - name: `Cache cargo registry & build`
+  - action: `actions/cache@v5`
+  - path:
+    - `~/.cargo/registry`
+    - `~/.cargo/git`
+    - `target`
+  - key: `Linux-render-diff-cargo-${Cargo.lock hash}`
+  - restore key: `Linux-render-diff-cargo-`
+- node cache:
+  - `actions/setup-node@v4`
+  - `cache: npm`
+  - `cache-dependency-path: rhwp-studio/package-lock.json`
+
+Render Diff 주요 step:
+
+1. Install Rust toolchain
+2. Install PDF raster tools
+3. Install wasm-pack
+4. Cache cargo registry & build
+5. Build WASM package
+6. Build native CLI for PDF report
+7. Setup Node.js
+8. Install Studio dependencies
+9. Install Chromium
+10. Check render diff script syntax
+11. Run canvas visual diff and PDF report
+12. Upload render diff artifacts
+
+## 최신 cache inventory
+
+2026-07-03 19:53 KST 전후 GitHub Actions cache API 기준:
+
+| 구분 | 개수 | 합산 크기 |
+|------|------|-----------|
+| 전체 | 30 | 11,131,139,002 B |
+| branch ref | 11 | 5,488,562,104 B |
+| pull ref | 19 | 5,642,576,898 B |
+
+key prefix별:
+
+| prefix | 개수 | 합산 크기 | 판단 |
+|--------|------|-----------|------|
+| `Linux-render-diff-cargo-*` | 9 | 4,685,680,935 B | 가장 큰 누적 요인. 모두 `refs/pull/*`에 존재 |
+| `node-cache-*` | 9 | 427,401,927 B | Render Diff PR ref 부수 cache |
+| `Linux-cargo-*` | 3 | 3,611,679,991 B | Build & Test 중심 |
+| `Linux-codeql-rust-*` | 5 | 2,216,797,926 B | CodeQL Rust. #1857 이후 PR save 표면 정리 |
+| `codeql-overlay-*` | 4 | 189,578,223 B | CodeQL overlay |
+
+현재 Render Diff cargo cache는 9개 모두 같은 cargo key
+`Linux-render-diff-cargo-6a1af...d4227c2`이지만, ref가 서로 달라 PR 간 재사용되지 않는 상태다.
+각 항목은 약 520 MB이며, 같은 key가 PR ref별로 반복 저장된 것이 quota 사용량의 핵심이다.
+
+## 정책 질문
+
+이번 후속 작업은 다음 질문에 답하는 것을 목표로 한다.
+
+1. Render Diff cargo cache를 현행 `actions/cache@v5` 단일 step으로 유지할 이유가 있는가?
+2. PR run에서 `target`까지 저장하는 cache가 Render Diff wall time을 충분히 줄이는가?
+3. PR save를 차단하면 cold build 비용이 어느 정도 증가하는가?
+4. `workflow_dispatch`나 trusted branch seed run으로 Render Diff cargo cache를 공급할 수 있는가?
+5. `target`을 제외하고 registry/git 중심으로 줄이면 quota와 시간의 균형이 좋아지는가?
+6. Render Diff node cache도 PR ref 누적 관점에서 별도 정책이 필요한가?
+
+## 정책 후보
+
+| 후보 | 내용 | 장점 | 단점 / 확인 필요 |
+|------|------|------|------------------|
+| A. 현행 유지 + 수동 cleanup | Render Diff cache step 유지, closed PR ref cleanup 운영 | cold build 방지, workflow 변경 없음 | PR ref별 520 MB cargo cache가 계속 누적됨 |
+| B. PR save 차단 + trusted seed | `restore@v5` / `save@v5` 분리, PR은 restore-only, trusted seed run에서만 save | #1664 정책과 일관, PR ref cache 누적 억제 | seed run 설계 필요. PR에서 exact hit가 가능한지 확인 필요 |
+| C. PR save 차단 + cold build 수용 | PR은 restore-only, 별도 seed 없이 miss/fallback 허용 | quota 효과가 가장 단순 | Render Diff wall time 증가 가능 |
+| D. path 축소 | `target` 제외, registry/git 중심 cache | cache 크기 대폭 감소 기대 | WASM/native CLI build 시간이 늘 수 있음 |
+| E. workflow_dispatch seed 명시 | `workflow_dispatch`에서 full-suite 또는 지정 input으로 trusted seed cache 생성 | PR 중심 workflow의 warm source 보완 가능 | 운영 절차가 늘고, seed cache가 PR ref와 실제로 공유되는지 검증 필요 |
+
+## 권장 진행
+
+바로 코드 변경을 넣기보다 다음 순서로 진행한다.
+
+1. Render Diff before 표본 수집
+   - 최근 successful `Canvas visual diff` run을 5개 이상 수집한다.
+   - fast-pass run과 full Render Diff run을 분리한다.
+   - `Cache cargo registry & build`, `Build WASM package`, `Build native CLI for PDF report`, Node/npm, visual diff step 시간을 기록한다.
+
+2. cache scope 확인
+   - 각 run의 `ref`, cache key, cache size, hit/miss/save 여부를 확인한다.
+   - `refs/pull/*` cache가 closed/merged PR에 남는지, OPEN PR cache인지 분류한다.
+   - Render Diff PR ref cache가 base branch 또는 다른 PR에서 재사용되지 않는다는 관측을 최신 run으로 재확인한다.
+
+3. 2차 구현계획서 작성
+   - before 표본과 cache inventory를 기준으로 후보 B/C/D/E 중 하나를 선택한다.
+   - 구현 대상은 `.github/workflows/render-diff.yml` 하나로 제한한다.
+   - Build & Test, CodeQL Rust, `Swatinem/rust-cache`, cleanup 자동화는 같은 PR에 섞지 않는다.
+
+4. 코드 PR 진행
+   - 구현계획서 승인 후 별도 코드 PR로 진행한다.
+   - PR run에서 Render Diff after 값을 관측한다.
+   - merge 후에는 trusted seed 또는 `devel`/manual run 관측이 필요한지 정책에 따라 결정한다.
+
+5. measurement 문서화
+   - `mydocs/report/task_m100_1667_measurement.md`에 Render Diff before/after 표를 추가한다.
+   - `mydocs/report/task_m100_1668_ci_pipeline_tracking.md`에는 핵심 롤업만 반영한다.
+
+## 포함 범위
+
+- `.github/workflows/render-diff.yml`의 cargo cache 정책 분석
+- Render Diff cargo cache key / ref / size / hit-miss-save 관측
+- Render Diff 주요 step 시간 측정 기준 수립
+- Render Diff node cache 누적 여부 참고 관측
+- 후속 구현 후보 선택 기준 정리
+
+## 제외 범위
+
+- `.github/workflows/ci.yml` Build & Test cache 변경
+- `.github/workflows/codeql.yml` CodeQL Rust cache 변경
+- `Swatinem/rust-cache` 도입
+- `pull_request.closed` 또는 scheduled cleanup 자동화
+- 승인 없는 GitHub Actions cache 삭제
+- 회귀 가드 파일 통합
+- `tests/golden_svg/**` 구조 변경
+- branch protection / required check 변경
+
+## 측정 기준
+
+공통 기준은 #1668의 메인테이너 요청을 따른다. Render Diff는 `CI / Build & Test`와 별도 workflow이므로
+아래처럼 별도 표로 기록한다.
+
+### Render Diff 필수 측정
+
+- PR checks 완료 시간
+- `Render Diff / Canvas visual diff` job 시간
+- 주요 step 시간
+  - Cache cargo registry & build
+  - Build WASM package
+  - Build native CLI for PDF report
+  - Setup Node.js
+  - Install Studio dependencies
+  - Install Chromium
+  - Check render diff script syntax
+  - Run canvas visual diff and PDF report
+- cache hit/miss/save 성공 여부
+- cache 크기
+  - `Linux-render-diff-cargo-*`
+  - `node-cache-*`
+- 실패 시 원인 가시성
+  - cache reservation/read-only/save failure line
+  - wasm-pack build failure line
+  - npm / Chromium install failure line
+  - visual diff mismatch summary 위치
+- runner-minutes proxy
+  - `Canvas visual diff` job wall time
+- branch protection / required check 변경 여부
+- 회귀 가드 1:1 추적성 보존 여부
+  - Render Diff 작업은 `tests/**`와 `tests/golden_svg/**`를 변경하지 않는 것이 기본 전제다.
+
+### P50/P90 기준
+
+- 표본 1-4개: 단일/소수 관측값. P50/P90 판단 보류
+- 표본 5-9개: 참고값. 방향성만 관찰
+- 표본 10개 이상: 제한적 P50/P90 참고 가능
+- fast-pass run은 full Render Diff run과 분리해 집계한다.
+
+## 구현 후보별 성공 기준
+
+### 후보 B: PR save 차단 + trusted seed
+
+- PR run에서 Render Diff cargo save가 skipped 된다.
+- `refs/pull/*`에 신규 `Linux-render-diff-cargo-*` cache가 생성되지 않는다.
+- trusted seed run에서 cache save가 성공한다.
+- 후속 PR run에서 seed cache restore가 가능한지 확인한다.
+- Render Diff full run wall time이 허용 가능한 범위에 남는다.
+
+### 후보 C: PR save 차단 + cold build 수용
+
+- PR ref cargo cache 누적이 중단된다.
+- Render Diff wall time 증가가 허용 가능한 수준인지 확인한다.
+- cache quota 안정성 개선이 wall time 증가보다 큰 이득인지 판단한다.
+
+### 후보 D: path 축소
+
+- cache 크기가 현재 약 520 MB/PR보다 유의미하게 줄어든다.
+- Build WASM package와 native CLI build 시간이 허용 가능한 수준인지 확인한다.
+- `target` 제외로 인한 반복 compile 비용이 과도하면 중단한다.
+
+## 리스크
+
+- Render Diff는 PR 중심 workflow라 trusted branch seed cache가 기대만큼 공유되지 않을 수 있다.
+- `target` 제외는 cache 크기를 줄일 수 있지만, WASM package build와 native CLI build를 느리게 만들 수 있다.
+- Node/npm cache도 PR ref별로 남으므로 cargo cache만 줄여도 전체 quota 문제가 완전히 사라지지 않을 수 있다.
+- `workflow_dispatch` seed 방식은 운영 절차가 늘어난다.
+- Render Diff는 시각 회귀 확인 성격이 있으므로, fast-pass / skipped 판단과 cache 정책을 혼동하면 안 된다.
+
+## 완료 기준
+
+- Render Diff before 표본과 cache inventory가 정리된다.
+- Render Diff cache 정책 후보 중 하나가 구현계획서에서 선택된다.
+- 문서 / 코드 PR 분리 원칙이 유지된다.
+- 코드 변경 전 rollback 기준과 after 측정표가 준비된다.
+- #1667 이슈에는 Render Diff 정책 선택 이유와 측정 기준이 코멘트로 남는다.


### PR DESCRIPTION
## 요약

- #1667 1차 CodeQL Rust cache 정리 이후 다음 후속 범위를 Render Diff cargo cache로 잡는 수행계획서를 추가했습니다.
- 최신 cache inventory 기준 `Linux-render-diff-cargo-*`가 9개 / 4,685,680,935 B로 가장 큰 누적 요인임을 계획서에 반영했습니다.
- Render Diff는 PR 중심 workflow라 바로 restore-only로 바꾸지 않고, before 측정 후 구현계획서를 확정하는 흐름으로 정리했습니다.

## 포함 내용

- Render Diff workflow의 현재 cache 구조 정리
- Render Diff cargo cache / node cache inventory 기준값
- 후보 정책 비교
  - 현행 유지 + 수동 cleanup
  - PR save 차단 + trusted seed
  - PR save 차단 + cold build 수용
  - `target` 제외 path 축소
  - `workflow_dispatch` seed 명시
- Render Diff 전용 측정 기준
- 구현 후보별 성공 기준과 리스크

## 범위

- 문서 변경만 포함합니다.
- `.github/workflows/**`, `Cargo.toml`, `tests/**` 변경은 없습니다.
- 후속 코드 변경은 별도 구현계획서 승인 후 별도 PR로 진행합니다.

## 검증

- `git diff --cached --check` 통과
