### PR TITLE
Task #1667: Render Diff before measurement 기록 보강

### DIFF
--- a/mydocs/orders/20260703.md
+++ b/mydocs/orders/20260703.md
@@ -5,7 +5,7 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1849 | `devel` push profile 배치 재조정 착수 | 완료 | 문서 PR #1854 merge 및 이슈 close 완료: 18:32 |
-| #1667 | Rust cache 전략 개선 착수 | 진행중 | #1859 merge 후 Render Diff 후속 계획 PR 준비 |
+| #1667 | Rust cache 전략 개선 착수 | 진행중 | #1861 merge 후 Render Diff before 표본 수집/문서화 진행 |
 
 ## PR 처리
 

--- a/mydocs/report/task_m100_1667_measurement.md
+++ b/mydocs/report/task_m100_1667_measurement.md
@@ -6,8 +6,8 @@
 측정 원천 기록이다.
 
 #1667 전체 범위에는 Build & Test cargo cache, CodeQL Rust cache, Render Diff cargo cache, stale PR ref
-cleanup, `Swatinem/rust-cache` 검토가 모두 포함된다. 이 문서의 1차 기록 범위는 PR #1857에서 수행한
-CodeQL Rust cache restore/save 분리다.
+cleanup, `Swatinem/rust-cache` 검토가 모두 포함된다. 이 문서에는 PR #1857에서 수행한 CodeQL Rust
+cache restore/save 분리 관측과, 후속 Render Diff cargo cache 정책 변경 전 before 관측을 함께 기록한다.
 
 부모 추적 문서 `mydocs/report/task_m100_1668_ci_pipeline_tracking.md`에는 요약과 후속 판단만 반영하고,
 run별 raw 값과 해석은 이 문서를 기준으로 보존한다.
@@ -65,6 +65,167 @@ save-only 표면으로 바뀌었는지 확인하는 것이다.
 
 #1857은 `.github/workflows/ci.yml`을 변경하지 않았다. 따라서 Build & Test 값은 #1857의 직접 성과가 아니라,
 #1849 이후 현재 CI 기준선 유지 여부를 보는 참고값이다.
+
+## Render Diff before 관측: #1861 merge 후 표본 수집
+
+- 기준 계획서 PR: #1861 `Task #1667: Render Diff cache 후속 계획 수립`
+- merge commit: `8ea6f3f5e6e5446a8312d59e58eb81c70f8c80c4`
+- merge 시각: 2026-07-03 19:57:41 KST
+- 표본 수집 시각: 2026-07-03 20:11 KST 전후
+- 변경하지 않은 파일: `.github/workflows/render-diff.yml`, `.github/workflows/ci.yml`, `tests/**`, `tests/golden_svg/**`
+
+이 절은 Render Diff cargo cache 코드 변경 전 before 기준선이다. 여러 PR의 최근 successful
+`Render Diff` workflow run을 사용했으므로, 전체 PR checks 완료 시간은 PR별 다른 workflow 상황과 섞인다.
+따라서 이 절에서는 `Render Diff` workflow 완료 시간을 해당 check의 PR checks 완료 시간 proxy로 기록하고,
+후속 코드 PR에서는 해당 PR의 전체 checks 완료 시간을 별도로 기록한다.
+
+### 표본 분리
+
+| 구분 | 표본 | 판단 |
+|------|------|------|
+| full Render Diff | 20개 successful `Canvas visual diff` 실행 run | P50/P90 참고 가능 |
+| fast-pass | 9개 preflight success + `Canvas visual diff` skipped run | full run과 분리 집계 |
+| cancelled / in-progress | 제외 | P50/P90에서 제외 |
+
+fast-pass 표본은 7-11초 안에 끝났고, 모두 `Render Diff preflight` success 후 `Canvas visual diff`가 skipped
+됐다. full Render Diff와 섞으면 실제 render/cache 비용이 왜곡되므로 별도 지표로만 둔다.
+
+### full Render Diff P50/P90
+
+| 항목 | n | P50 | P90 | min | max |
+|------|---|-----|-----|-----|-----|
+| `Render Diff` workflow 완료 시간 | 20 | 4m00s | 4m14s | 3m54s | 8m45s |
+| `Canvas visual diff` job | 20 | 3m47s | 3m57s | 3m41s | 4m09s |
+| `Cache cargo registry & build` | 20 | 1s | 1s | 0s | 2s |
+| `Build WASM package` | 20 | 1m15s | 1m18s | 1m12s | 1m19s |
+| `Build native CLI for PDF report` | 20 | 1m04s | 1m09s | 1m01s | 1m14s |
+| `Setup Node.js` | 20 | 1s | 1s | 0s | 5s |
+| `Install Studio dependencies` | 20 | 6s | 7s | 5s | 7s |
+| `Install Chromium` | 20 | 7s | 7s | 6s | 7s |
+| `Check render diff script syntax` | 20 | 0s | 1s | 0s | 1s |
+| `Run canvas visual diff and PDF report` | 20 | 26s | 27s | 25s | 27s |
+| `Upload render diff artifacts` | 20 | 1s | 2s | 0s | 2s |
+| `Post Cache cargo registry & build` | 20 | 7s | 8s | 6s | 8s |
+
+`Render Diff` workflow 완료 시간의 max 8m45s와 그 다음 outlier 6m03s는 job 자체 시간보다 workflow
+created/updated 구간이 긴 경우다. concurrency / queue 영향이 섞일 수 있으므로 runner-minutes proxy는
+`Canvas visual diff` job wall time을 중심으로 본다.
+
+### full Render Diff 표본
+
+| run | branch | workflow | `Canvas visual diff` | WASM build | native CLI build | visual diff | post cache | URL |
+|-----|--------|----------|----------------------|------------|------------------|-------------|------------|-----|
+| `28655648394` | `task1853-float-stack-overcapture-fix` | 8m45s | 3m53s | 1m17s | 1m08s | 25s | 8s | <https://github.com/edwardkim/rhwp/actions/runs/28655648394> |
+| `28654634119` | `task1853-float-stack-overcapture-fix` | 4m03s | 3m52s | 1m19s | 1m09s | 27s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28654634119> |
+| `28652708185` | `task-1667-rust-cache-strategy` | 4m06s | 3m53s | 1m12s | 1m07s | 27s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28652708185> |
+| `28652234615` | `task1853-float-stack-overcapture-fix` | 4m04s | 3m51s | 1m18s | 1m07s | 26s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28652234615> |
+| `28651915212` | `task/m100-1733-residual-overpagination` | 6m03s | 4m09s | 1m18s | 1m12s | 27s | 8s | <https://github.com/edwardkim/rhwp/actions/runs/28651915212> |
+| `28651721938` | `task1853-float-stack-overcapture-fix` | 3m56s | 3m43s | 1m13s | 1m04s | 26s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28651721938> |
+| `28648923163` | `task-1849-ci-profile-policy` | 4m00s | 3m47s | 1m16s | 1m05s | 25s | 6s | <https://github.com/edwardkim/rhwp/actions/runs/28648923163> |
+| `28646705382` | `task/pr1850-review-followup` | 4m11s | 3m57s | 1m16s | 1m06s | 27s | 8s | <https://github.com/edwardkim/rhwp/actions/runs/28646705382> |
+| `28645898070` | `task-1849-ci-profile-policy` | 3m59s | 3m46s | 1m15s | 1m05s | 27s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28645898070> |
+| `28645764974` | `pr/devel-1841` | 3m54s | 3m41s | 1m14s | 1m03s | 26s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28645764974> |
+| `28645144211` | `pr/devel-1841` | 4m06s | 3m47s | 1m15s | 1m04s | 27s | 8s | <https://github.com/edwardkim/rhwp/actions/runs/28645144211> |
+| `28642075330` | `pr/devel-1831` | 4m14s | 4m03s | 1m17s | 1m14s | 25s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28642075330> |
+| `28641500202` | `pr/devel-1831` | 3m58s | 3m46s | 1m15s | 1m05s | 27s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28641500202> |
+| `28640393193` | `pr/devel-1831` | 4m01s | 3m48s | 1m13s | 1m03s | 25s | 8s | <https://github.com/edwardkim/rhwp/actions/runs/28640393193> |
+| `28639826638` | `batch-pr1823-1840-review` | 3m54s | 3m43s | 1m15s | 1m03s | 25s | 6s | <https://github.com/edwardkim/rhwp/actions/runs/28639826638> |
+| `28636401511` | `pr/devel-1811` | 4m02s | 3m49s | 1m15s | 1m04s | 26s | 6s | <https://github.com/edwardkim/rhwp/actions/runs/28636401511> |
+| `28634205697` | `pr/devel-1809-v2` | 3m59s | 3m47s | 1m14s | 1m03s | 25s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28634205697> |
+| `28632916505` | `pr/devel-1773` | 3m55s | 3m44s | 1m12s | 1m01s | 25s | 6s | <https://github.com/edwardkim/rhwp/actions/runs/28632916505> |
+| `28631050240` | `pr/devel-1829` | 3m56s | 3m46s | 1m16s | 1m04s | 26s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28631050240> |
+| `28629296615` | `pr/devel-1827` | 4m00s | 3m48s | 1m14s | 1m04s | 26s | 7s | <https://github.com/edwardkim/rhwp/actions/runs/28629296615> |
+
+### cache hit/miss/save 관측
+
+| 항목 | 관측 |
+|------|------|
+| Render Diff cargo restore | full run 20/20 miss |
+| Render Diff cargo save | full run 20/20 post-step save 시도 후 실패 |
+| cargo save 실패 원인 | cache budget read-only / reservation failure |
+| npm restore | full run 20/20 miss |
+| npm save | full run 20/20 reservation failure |
+| cargo key | `Linux-render-diff-cargo-6a1af67968af2b829f31637cb42371573b1fc279c0b7634dc63557a90d4227c2` |
+| npm key | `node-cache-Linux-x64-npm-7e28cd65a573ec1b710bb86f9d35a17472974475ef7e02421a6fbf68f2971390` |
+
+대표 로그 위치:
+
+- run `28655648394`, `Canvas visual diff` job
+- cargo restore miss: line 456
+- npm restore miss: line 723
+- npm save reservation failure: line 875
+- cargo save budget/read-only warning: line 878
+- cargo save failure: line 879
+
+즉 현재 `actions/cache@v5` 단일 step은 PR run에서 cache를 복원하지 못하고, 종료 시점에는 큰 PR ref cache
+save를 시도하다가 실패 로그를 남기는 상태다.
+
+### cache inventory
+
+2026-07-03 20:11 KST 전후 GitHub Actions cache API 기준:
+
+| prefix | 개수 | 합산 크기 | ref 판단 |
+|--------|------|-----------|----------|
+| 전체 | 30 | 11,131,139,002 B | cache budget 10GB 초과 상태 |
+| `Linux-render-diff-cargo-*` | 9 | 4,685,680,935 B | 모두 `refs/pull/*` |
+| `node-cache-*` | 9 | 427,401,927 B | 모두 `refs/pull/*` |
+| `Linux-cargo-*` | 3 | 3,611,679,991 B | Build & Test 중심 |
+| `Linux-codeql-rust-*` | 5 | 2,216,797,926 B | CodeQL Rust |
+| `codeql-overlay-*` | 4 | 189,578,223 B | CodeQL overlay |
+
+Render Diff cargo cache 9개는 모두 같은 cargo key지만 ref가 다르다. 각 항목은 약 520 MB이고,
+해당 PR은 모두 merged 상태다.
+
+| PR ref | PR 상태 | cargo cache | npm cache |
+|--------|---------|-------------|-----------|
+| `refs/pull/1656/merge` | merged | 520,527,402 B | 47,488,200 B |
+| `refs/pull/1741/merge` | merged | 520,655,103 B | 47,491,813 B |
+| `refs/pull/1739/merge` | merged | 520,741,478 B | 47,490,287 B |
+| `refs/pull/1738/merge` | merged | 520,739,196 B | 47,489,021 B |
+| `refs/pull/1736/merge` | merged | 520,636,087 B | 47,490,104 B |
+| `refs/pull/1732/merge` | merged | 520,613,504 B | 47,488,340 B |
+| `refs/pull/1730/merge` | merged | 520,642,639 B | 47,487,031 B |
+| `refs/pull/1731/merge` | merged | 520,610,270 B | 47,488,490 B |
+| `refs/pull/1729/merge` | merged | 520,515,256 B | 47,488,641 B |
+
+해석:
+
+- 현재 남아 있는 Render Diff cargo/npm cache는 closed/merged PR ref에 묶여 있다.
+- 최신 PR run들은 이 cache를 복원하지 못한다.
+- 새 PR run은 cache miss 후 save를 시도하지만, 이미 budget 초과 상태라 저장에 실패한다.
+- 따라서 현행 Render Diff cache는 관측 범위에서는 PR wall time을 줄이지 못하고, cache quota와 실패 로그만 만든다.
+
+### branch protection / required check 영향
+
+- 이번 관측 문서 PR은 workflow 변경이 아니므로 branch protection / required check를 변경하지 않는다.
+- `devel` branch는 protected 상태다.
+- required status checks 세부 API는 404로 노출되지 않았다. 기존 #1667 기록의 `Build & Test` required
+  context 판단은 유지하되, Render Diff 후속 코드 PR에서는 check 이름 변경이 없는지 PR checks 화면으로 다시 확인한다.
+
+### 회귀 가드 추적성
+
+이 before 관측과 문서 PR은 `tests/**`, `tests/golden_svg/**`, 통합 테스트 파일, 회귀 가드 명명 규칙을
+변경하지 않는다. Render Diff workflow의 preflight/full-run 분리도 그대로 유지한다. 따라서 회귀 가드 1:1
+추적성에는 영향이 없다.
+
+### Render Diff before 해석
+
+현재 Render Diff의 full run 시간 자체는 짧다.
+
+- `Canvas visual diff` job P50은 3m47s, P90은 3m57s다.
+- 가장 큰 step은 `Build WASM package` P50 1m15s와 `Build native CLI for PDF report` P50 1m04s다.
+- 실제 visual diff 실행은 P50 26s다.
+
+하지만 cache 관점의 효율은 낮다.
+
+- 최신 full run 20개 모두 cargo/npm cache miss다.
+- 최신 full run 20개 모두 post-save가 reservation/read-only 실패를 남긴다.
+- 현재 남아 있는 Render Diff cargo/npm cache는 모두 merged PR ref cache이며, 최신 PR run에는 재사용되지 않았다.
+- cache 총량은 11.13GB로 다시 10GB budget을 초과했다.
+
+따라서 후속 구현계획서에서는 최소한 PR run의 Render Diff cargo/npm save 표면을 제거하는 방향을 우선 검토하는
+것이 합리적이다. 다만 Render Diff는 PR 중심 workflow라 trusted seed가 실제 PR restore로 이어지는지,
+또는 `target` 제외 path 축소가 시간 대비 quota에 더 유리한지는 구현계획서에서 별도 후보로 확정해야 한다.
 
 ## after 관측 1: #1857 PR run
 

--- a/mydocs/report/task_m100_1668_ci_pipeline_tracking.md
+++ b/mydocs/report/task_m100_1668_ci_pipeline_tracking.md
@@ -44,6 +44,11 @@ save-only 구조로 정렬됐음을 확인했다. PR #1857에서는 `refs/pull/1
 merge 후 `devel` push에서는 CodeQL Rust exact-hit restore 후 save skipped, cache reservation/read-only/save
 failure 경고 없음이 확인됐다.
 
+2026-07-03 #1667 후속 Render Diff before 관측에서는 최근 full `Canvas visual diff` 20개가 모두 cargo/npm
+cache miss였고, post-save는 cache budget read-only / reservation failure로 실패했음을 확인했다. 현재
+`Linux-render-diff-cargo-*` 9개와 `node-cache-*` 9개는 모두 merged PR ref에 묶여 있으며, 최신 PR run에는
+재사용되지 않았다.
+
 ## 메인테이너 결정사항
 
 ### 회귀 가드 1:1 추적성 보존
@@ -82,7 +87,7 @@ CI 단축은 회귀 가드 구조를 보존하면서 프로필, 캐시, 병렬�
 | 1 | #1664 | 캐시 정책 정리 | 코드 PR #1702 merge 완료. PR save 차단, cleanup 후 trusted branch save, 후속 exact-hit 확인 완료. 순수 #1664 구간 P50/P90 보강 완료 |
 | 2 | #1666 | PR `release-test` 프로필 전환 | 코드 PR #1739 merge 완료. PR `Build & Test`는 10m49s로 개선, merge 후 `devel` push는 release integration 비용으로 50분대 확인 |
 | 3 | #1849 | `devel` push profile 배치 재조정 | 코드 PR #1851 merge 완료. `devel` push는 release build smoke + `release-test` 전체 회귀로 전환됐고, `Build & Test`는 14m13s로 감소 |
-| 4 | #1667 | Rust 캐시 전략 검토 | 1차 CodeQL Rust restore/save 분리 PR #1857 merge 완료. PR cache save 표면 제거 확인. exact-hit 이후 남는 `Dirty rhwp` / `Compiling rhwp`, Render Diff cargo cache, stale PR ref cleanup은 후속 판단 |
+| 4 | #1667 | Rust 캐시 전략 검토 | 1차 CodeQL Rust restore/save 분리 PR #1857 merge 완료. Render Diff before 표본 수집 완료. 최신 Render Diff PR run은 cache miss + save failure 상태라 PR save 차단 / trusted seed / path 축소 후보를 구현계획서에서 선택해야 함 |
 | 5 | #1665 | Build & Test job 병렬 분리 | #1849에서 `devel` push profile 정책을 먼저 확정한 뒤 병렬화 효과와 runner-minutes를 재산정 |
 
 ## 공통 측정 기준
@@ -460,6 +465,44 @@ Build & Test 참고값:
   `Dirty rhwp`는 cache fingerprint, checkout timestamp, test target 산출물 관점의 후속 분석 대상이다.
 - branch protection / required check 변경은 없고, `devel` required status check context는 `Build & Test` 그대로다.
 
+### Render Diff before
+
+- 기준 계획서 PR: #1861
+- merge commit: `8ea6f3f5e6e5446a8312d59e58eb81c70f8c80c4`
+- 표본: 최근 successful full `Canvas visual diff` 20개, fast-pass 9개 별도 분리
+- 원천 기록: `mydocs/report/task_m100_1667_measurement.md`
+
+시간:
+
+| 항목 | n | P50 | P90 | 판단 |
+|------|---|-----|-----|------|
+| `Render Diff` workflow 완료 시간 | 20 | 4m00s | 4m14s | PR check proxy. 일부 queue/concurrency outlier 존재 |
+| `Canvas visual diff` job | 20 | 3m47s | 3m57s | runner-minutes proxy |
+| `Build WASM package` | 20 | 1m15s | 1m18s | 가장 큰 build step |
+| `Build native CLI for PDF report` | 20 | 1m04s | 1m09s | 두 번째 build step |
+| `Run canvas visual diff and PDF report` | 20 | 26s | 27s | 실제 diff 실행 |
+
+cache:
+
+| 항목 | 관측 |
+|------|------|
+| Render Diff cargo restore | 20/20 miss |
+| Render Diff cargo save | 20/20 save 시도 후 실패 |
+| npm restore | 20/20 miss |
+| npm save | 20/20 reservation failure |
+| 실패 가시성 | 대표 run `28655648394`: cargo restore miss line 456, npm save failure line 875, cargo read-only warning line 878, cargo save failure line 879 |
+| cache inventory | 전체 30개 / 11,131,139,002 B. `Linux-render-diff-cargo-*` 9개 / 4,685,680,935 B, `node-cache-*` 9개 / 427,401,927 B |
+| stale 판단 | Render Diff cargo/npm cache 18개는 모두 merged PR ref |
+
+판단:
+
+- 현행 Render Diff cache는 관측된 최신 PR run에서 복원 이득을 주지 못하고, post-save 실패 로그와 cache quota
+  부담을 만든다.
+- Render Diff full run 자체는 P50 3m47s로 짧으므로, PR ref별 520 MB cargo cache를 계속 저장할 비용 대비
+  이득이 낮아 보인다.
+- 후속 구현계획서에서는 PR save 차단을 기본 후보로 두고, trusted seed 또는 `target` 제외 path 축소가 필요한지
+  별도 판단한다.
+
 ## P50/P90 상태
 
 | 구간 | 대상 | 샘플 수 | 판단 |
@@ -480,11 +523,15 @@ Build & Test 참고값:
 | #1667 변경 후 | PR #1857 관측값 | 1 | PR P50/P90 산출 보류. CodeQL `Analyze (rust)` 8m18s, PR cache save skipped |
 | #1667 merge 후 | trusted branch CodeQL `Analyze (rust)` job 시간 | 1 | 단일 관측값 8m17s. exact hit라 save skipped |
 | #1667 merge 후 | trusted branch `Build & Test` job 시간 | 1 | 참고값 14m08s. #1857은 Build & Test workflow 변경 없음 |
+| #1667 Render Diff before | `Render Diff` workflow 완료 시간 | 20 | P50 4m00s, P90 4m14s. full run만 집계, fast-pass 제외 |
+| #1667 Render Diff before | `Canvas visual diff` job 시간 | 20 | P50 3m47s, P90 3m57s. runner-minutes proxy |
+| #1667 Render Diff before | Render Diff cargo/npm cache | 20 | cargo/npm restore 20/20 miss, save 20/20 실패 |
 
 ## 다음 확인 항목
 
 1. #1667에서는 exact cache hit 이후에도 `Dirty rhwp` / `Compiling rhwp`가 남는 원인을 Build & Test cargo cache와
    CodeQL Rust analyze cache 범위를 분리해 판단한다.
-2. Render Diff cargo cache는 PR ref 누적 규모가 크므로 #1667 후속 PR에서 정책을 별도로 결정한다.
+2. Render Diff cargo cache는 before 표본상 최신 PR run에서 hit가 없고 save failure만 남으므로, 후속
+   구현계획서에서 PR save 차단 / trusted seed / `target` 제외 path 축소 중 하나를 선택한다.
 3. #1665에서는 #1849 이후에도 남는 `devel` push wall time과 runner-minutes를 병렬화 효과 산정의 주요 입력으로 사용한다.
 4. OPEN PR cache는 계속 생성될 수 있으므로, cleanup은 closed/merged PR ref만 대상으로 유지한다.


### PR DESCRIPTION
## 요약

#1861 merge 후 Render Diff cargo cache 정책 변경 전 before 관측값을 문서화합니다.

- `mydocs/report/task_m100_1667_measurement.md`에 Render Diff before 원천 기록 추가
- `mydocs/report/task_m100_1668_ci_pipeline_tracking.md`에 부모 이슈 롤업 추가
- `mydocs/orders/20260703.md`의 #1667 진행 상태 갱신

## 핵심 관측

- full Render Diff 20개와 fast-pass 9개를 분리했습니다.
- full `Canvas visual diff` job: P50 3m47s, P90 3m57s
- `Render Diff` workflow 완료 시간: P50 4m00s, P90 4m14s
- `Build WASM package`: P50 1m15s, P90 1m18s
- `Build native CLI for PDF report`: P50 1m04s, P90 1m09s
- cargo/npm cache restore: 20/20 miss
- cargo/npm cache save: 20/20 reservation/read-only 계열 실패
- cache inventory: 전체 30개 / 11,131,139,002 B
- `Linux-render-diff-cargo-*` 9개 / 4,685,680,935 B, `node-cache-*` 9개 / 427,401,927 B
- Render Diff cargo/npm cache 18개는 모두 merged PR ref에 묶여 최신 PR run에 재사용되지 않았습니다.

## 해석

현행 Render Diff cache는 관측된 최신 PR run에서 복원 이득을 주지 못하고, post-save 실패 로그와 cache quota 부담을 만들고 있습니다. 후속 구현계획서에서는 PR save 차단을 기본 후보로 두고, trusted seed 또는 `target` 제외 path 축소가 필요한지 별도 판단합니다.

## 범위 제외

- `.github/workflows/render-diff.yml` 변경 없음
- `.github/workflows/ci.yml` 변경 없음
- `tests/**`, `tests/golden_svg/**` 변경 없음
- cache 삭제/cleanup 수행 없음

## 검증

- `git diff --check`

Refs #1667, #1668
