### PR TITLE
task 1870: devel merge 이슈 자동 close 보정

### DIFF
--- a/.github/workflows/close-issues-on-devel-push.yml
+++ b/.github/workflows/close-issues-on-devel-push.yml
@@ -22,8 +22,7 @@ jobs:
             const { owner, repo } = context.repo;
             const payload = context.payload;
 
-            const closingKeyword = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*/gi;
-            const issueRef = /(?:https:\/\/github\.com\/([^/\s#]+)\/([^/\s#]+)\/issues\/(\d+)|(?:(\w[\w.-]*)\/([\w.-]+))?#(\d+))/gi;
+            const closingIssueRef = /\b(?:close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*(?:https:\/\/github\.com\/([^/\s#]+)\/([^/\s#]+)\/issues\/(\d+)|(?:(\w[\w.-]*)\/([\w.-]+))?#(\d+))/gi;
 
             function collectIssueNumbers(text) {
               const numbers = new Set();
@@ -31,26 +30,20 @@ jobs:
               const lines = source.split(/\r?\n/);
 
               for (const line of lines) {
-                closingKeyword.lastIndex = 0;
-                let keywordMatch;
+                closingIssueRef.lastIndex = 0;
+                let refMatch;
 
-                while ((keywordMatch = closingKeyword.exec(line)) !== null) {
-                  const clause = line.slice(keywordMatch.index + keywordMatch[0].length);
-                  issueRef.lastIndex = 0;
-                  let refMatch;
+                while ((refMatch = closingIssueRef.exec(line)) !== null) {
+                  const refOwner = refMatch[1] || refMatch[4] || owner;
+                  const refRepo = refMatch[2] || refMatch[5] || repo;
+                  const number = Number(refMatch[3] || refMatch[6]);
 
-                  while ((refMatch = issueRef.exec(clause)) !== null) {
-                    const refOwner = refMatch[1] || refMatch[4] || owner;
-                    const refRepo = refMatch[2] || refMatch[5] || repo;
-                    const number = Number(refMatch[3] || refMatch[6]);
-
-                    if (
-                      Number.isInteger(number) &&
-                      refOwner.toLowerCase() === owner.toLowerCase() &&
-                      refRepo.toLowerCase() === repo.toLowerCase()
-                    ) {
-                      numbers.add(number);
-                    }
+                  if (
+                    Number.isInteger(number) &&
+                    refOwner.toLowerCase() === owner.toLowerCase() &&
+                    refRepo.toLowerCase() === repo.toLowerCase()
+                  ) {
+                    numbers.add(number);
                   }
                 }
               }

--- a/.github/workflows/close-issues-on-devel-push.yml
+++ b/.github/workflows/close-issues-on-devel-push.yml
@@ -1,0 +1,174 @@
+name: Close Issues on devel Push
+
+on:
+  push:
+    branches: [devel]
+
+permissions:
+  contents: read
+  issues: write
+  pull-requests: read
+
+jobs:
+  close-issues:
+    name: Close linked issues
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Close issues referenced by merged PRs
+        uses: actions/github-script@v8
+        with:
+          script: |
+            const { owner, repo } = context.repo;
+            const payload = context.payload;
+
+            const closingKeyword = /\b(close[sd]?|fix(?:e[sd])?|resolve[sd]?)\b\s*:?\s*/gi;
+            const issueRef = /(?:https:\/\/github\.com\/([^/\s#]+)\/([^/\s#]+)\/issues\/(\d+)|(?:(\w[\w.-]*)\/([\w.-]+))?#(\d+))/gi;
+
+            function collectIssueNumbers(text) {
+              const numbers = new Set();
+              const source = String(text || '');
+              const lines = source.split(/\r?\n/);
+
+              for (const line of lines) {
+                closingKeyword.lastIndex = 0;
+                let keywordMatch;
+
+                while ((keywordMatch = closingKeyword.exec(line)) !== null) {
+                  const clause = line.slice(keywordMatch.index + keywordMatch[0].length);
+                  issueRef.lastIndex = 0;
+                  let refMatch;
+
+                  while ((refMatch = issueRef.exec(clause)) !== null) {
+                    const refOwner = refMatch[1] || refMatch[4] || owner;
+                    const refRepo = refMatch[2] || refMatch[5] || repo;
+                    const number = Number(refMatch[3] || refMatch[6]);
+
+                    if (
+                      Number.isInteger(number) &&
+                      refOwner.toLowerCase() === owner.toLowerCase() &&
+                      refRepo.toLowerCase() === repo.toLowerCase()
+                    ) {
+                      numbers.add(number);
+                    }
+                  }
+                }
+              }
+
+              return numbers;
+            }
+
+            async function collectPrTexts(prNumber) {
+              const texts = [];
+              const { data: pr } = await github.rest.pulls.get({
+                owner,
+                repo,
+                pull_number: prNumber,
+              });
+
+              if (pr.base.ref !== 'devel' || !pr.merged_at) {
+                core.info(`Skip PR #${prNumber}: base=${pr.base.ref}, merged_at=${pr.merged_at}`);
+                return texts;
+              }
+
+              texts.push(pr.title, pr.body);
+
+              const commits = await github.paginate(github.rest.pulls.listCommits, {
+                owner,
+                repo,
+                pull_number: prNumber,
+                per_page: 100,
+              });
+              for (const commit of commits) {
+                texts.push(commit.commit.message);
+              }
+
+              return texts;
+            }
+
+            async function collectAssociatedPrNumbers(commitSha) {
+              const numbers = new Set();
+
+              const associated = await github.paginate(
+                github.rest.repos.listPullRequestsAssociatedWithCommit,
+                {
+                  owner,
+                  repo,
+                  commit_sha: commitSha,
+                  per_page: 100,
+                },
+              );
+              for (const pr of associated) {
+                numbers.add(pr.number);
+              }
+
+              const { data: commit } = await github.rest.repos.getCommit({
+                owner,
+                repo,
+                ref: commitSha,
+              });
+              const mergeMatch = commit.commit.message.match(/^Merge pull request #(\d+)\b/m);
+              if (mergeMatch) {
+                numbers.add(Number(mergeMatch[1]));
+              }
+
+              return numbers;
+            }
+
+            const issueSources = new Map();
+
+            for (const commit of payload.commits || []) {
+              const sha = commit.id;
+              for (const number of collectIssueNumbers(commit.message)) {
+                if (!issueSources.has(number)) {
+                  issueSources.set(number, `commit ${sha.slice(0, 7)}`);
+                }
+              }
+
+              const prNumbers = await collectAssociatedPrNumbers(sha);
+              for (const prNumber of prNumbers) {
+                const texts = await collectPrTexts(prNumber);
+                for (const text of texts) {
+                  for (const number of collectIssueNumbers(text)) {
+                    if (!issueSources.has(number)) {
+                      issueSources.set(number, `PR #${prNumber}`);
+                    }
+                  }
+                }
+              }
+            }
+
+            if (issueSources.size === 0) {
+              core.info('No closing issue references found in this devel push.');
+              return;
+            }
+
+            for (const [issue_number, source] of [...issueSources].sort((a, b) => a[0] - b[0])) {
+              const { data: issue } = await github.rest.issues.get({
+                owner,
+                repo,
+                issue_number,
+              });
+
+              if (issue.state === 'closed') {
+                core.info(`Issue #${issue_number} is already closed.`);
+                continue;
+              }
+
+              await github.rest.issues.createComment({
+                owner,
+                repo,
+                issue_number,
+                body: `${source} was merged into \`devel\` and referenced this issue with a closing keyword. Closing this issue automatically.`,
+              });
+
+              await github.rest.issues.update({
+                owner,
+                repo,
+                issue_number,
+                state: 'closed',
+                state_reason: 'completed',
+              });
+
+              core.info(`Closed issue #${issue_number} from ${source}.`);
+            }

--- a/mydocs/pr/archives/pr_1871_report.md
+++ b/mydocs/pr/archives/pr_1871_report.md
@@ -1,0 +1,117 @@
+# PR #1871 사전 처리 판단 보고서
+
+## 개요
+
+| 항목 | 내용 |
+|---|---|
+| PR | #1871 |
+| 제목 | `task 1870: devel merge 이슈 자동 close 보정` |
+| 작성자 | `jangster77` |
+| 관련 이슈 | #1870 |
+| 문서 작성일 | 2026-07-04 |
+| 문서 작성 시점 head | `8413e28a6eceaefd6f159c321eb74373677baef8` |
+| route decision | 원 PR merge 후보 |
+| 권고 | merge 수용 |
+
+이 문서는 merge 전 사전 판단 보고서다. 아직 merge 완료, merge commit, 이슈 close 완료를 확정 사실로
+기록하지 않는다.
+
+## 변경 요약
+
+PR #1871은 `devel` merge 후 GitHub native closing keyword가 issue를 자동 close하지 못하는 문제를 보정하기
+위해 `.github/workflows/close-issues-on-devel-push.yml`을 추가한다.
+
+workflow는 `push` to `devel` 이벤트에서 실행되며, pushed commit과 associated PR의 title/body/commit message를
+조회해 같은 저장소 issue에 대한 closing keyword reference를 수집한다. open issue가 있으면 comment를 남긴 뒤
+`state_reason: completed`로 close한다.
+
+## 원인과 해결 방향
+
+현재 저장소 default branch는 `main`이고 운영 merge 기준은 `devel`이다. GitHub native closing keyword는
+default branch 기준으로 동작하므로, `devel` 대상 PR이 merge되어도 PR description의 `Closes #N`이 issue
+auto-close로 연결되지 않는 사례가 있었다.
+
+PR #1871은 GitHub native auto-close를 대체하는 것이 아니라, `devel` push 이후 같은 저장소 issue에 한정해
+closing keyword를 보정 처리하는 workflow를 추가한다.
+
+## 리뷰 중 발견된 문제와 수정 결과
+
+1차 head `3ed3ed5f51ed00e117ede6daad4a754d83a1a8c5`에서는 closing keyword 뒤 같은 줄에 있는 모든 issue
+reference를 수집하는 문제가 있었다. 이 경우 `Fixes #1, related follow-up #2 remains open` 같은 문장에서
+`#2`까지 자동 close될 수 있어 Request changes로 재작업을 요청했다.
+
+최신 head `8413e28a6eceaefd6f159c321eb74373677baef8`에서는 `closingIssueRef` 패턴으로 closing keyword와
+직접 연결된 issue reference만 수집한다. 로컬 재현 결과 최초 지적한 과잉 close 사례는 해소됐다.
+
+## 검증 결과
+
+로컬 검증:
+
+- `git diff --check upstream/devel...HEAD`: 통과
+- Ruby YAML parse: 통과
+- `upstream/devel` merge 시뮬레이션: 충돌 없음 (`Already up to date`)
+- Node 기반 closing keyword 경계 사례 재현: 통과
+
+GitHub Actions:
+
+- `Build & Test`: success
+- `CI preflight`: success
+- `CodeQL preflight`: success
+- `Analyze (javascript-typescript)`: success
+- `Analyze (python)`: success
+- `Analyze (rust)`: success
+- `CodeQL`: success
+- `WASM Build`: skipped
+
+리뷰 문서 push 후에는 새 docs-only head가 생기므로, 해당 head의 check 상태와 approval 상태를 다시 확인해야 한다.
+
+## PR-head 문서 push 계획
+
+작업지시자 승인에 따라 다음 문서를 PR #1871 head 브랜치에 별도 docs-only 커밋으로 추가한다.
+
+- `mydocs/pr/archives/pr_1871_review.md`
+- `mydocs/pr/archives/pr_1871_report.md`
+
+push 대상은 `upstream` remote의 `task/m100-1870-devel-auto-close` 브랜치다. contributor 코드 커밋은 rewrite하지
+않고, review 문서만 별도 커밋으로 추가한다.
+
+문서 push 후 확인할 항목:
+
+- PR head SHA가 문서 커밋으로 갱신됐는지 확인
+- PR diff에 review/report 문서 2건이 포함됐는지 확인
+- 새 커밋의 변경 범위가 `mydocs/pr/archives/` 문서 2건으로 제한됐는지 확인
+- 최신 PR head 기준 GitHub Actions 또는 fast-pass 상태 확인
+- 기존 approval이 유지되는지, stale 처리되는지 확인
+
+## contributor credit
+
+원 contributor 커밋:
+
+- `3ed3ed5f51ed00e117ede6daad4a754d83a1a8c5` - Taesup Jang `<tsjang@gmail.com>`
+- `8413e28a6eceaefd6f159c321eb74373677baef8` - Taesup Jang `<tsjang@gmail.com>`
+
+문서 커밋은 collaborator review 기록 커밋으로 분리한다. 원 contributor author identity와 PR credit은 유지한다.
+
+## merge 전 조건
+
+merge 전에는 다음을 다시 확인해야 한다.
+
+- latest head SHA
+- `mergeable` / `mergeStateStatus`
+- latest head relevant checks
+- PR diff에 review/report 문서 포함 여부
+- latest head 기준 approval 상태
+- 작업지시자 merge 승인
+
+## merge 후 확인 계획
+
+PR #1871 merge 후에는 다음을 확인한다.
+
+1. PR metadata에서 merge commit SHA와 merged timestamp를 확인한다.
+2. Issue #1870 state를 확인한다.
+3. 새 workflow가 `devel` push에서 Issue #1870을 자동 close했는지 확인한다.
+4. 자동 close가 실패해 Issue #1870이 여전히 open이면, workflow run 로그를 확인하고 작업지시자 승인 후 수동
+   close/comment 여부를 결정한다.
+5. PR에 contributor 감사 코멘트와 검증 요약을 남긴다.
+
+Issue #1870 close는 작업지시자 승인 또는 직접 지시 없이는 수동 수행하지 않는다.

--- a/mydocs/pr/archives/pr_1871_review.md
+++ b/mydocs/pr/archives/pr_1871_review.md
@@ -1,0 +1,128 @@
+# PR #1871 Review - devel merge 이슈 자동 close 보정
+
+## 메타
+
+| 항목 | 내용 |
+|---|---|
+| PR | #1871 |
+| 제목 | `task 1870: devel merge 이슈 자동 close 보정` |
+| 작성자 | `jangster77` |
+| base | `devel` |
+| head | `task/m100-1870-devel-auto-close` |
+| 관련 이슈 | #1870 |
+| 문서 작성일 | 2026-07-04 |
+| 문서 작성 시점 head | `8413e28a6eceaefd6f159c321eb74373677baef8` |
+| 문서 작성 시점 mergeable 참고값 | `MERGEABLE` / `CLEAN` |
+| 문서 작성 시점 review decision | `APPROVED` |
+| maintainerCanModify | `false` |
+| PR head 문서 push 경로 | `upstream`의 `task/m100-1870-devel-auto-close` 브랜치 |
+
+`draft`, `mergeable`, `head SHA`, `CI 상태`는 volatile 값이다. merge 전에는 최신 PR head 기준으로
+GitHub Actions, merge state, review 문서 포함 여부, approval 상태를 다시 확인해야 한다.
+
+## 관련 이슈 요약
+
+Issue #1870은 저장소 default branch가 `main`이고 운영 merge 기준이 `devel`인 구조에서, GitHub native
+closing keyword가 `devel` 대상 PR merge 후 이슈를 자동 close하지 못하는 문제를 다룬다.
+
+확인된 사례는 PR #1863이다. PR 본문에 `closes #1836`이 있었지만 `closingIssuesReferences`가 비어 있었고,
+`devel` merge 후 issue auto-close가 동작하지 않았다. contributor는 `jangster77/rhwp` fork에서
+`push` to `devel` 기반 workflow가 테스트 issue를 자동 close하는 것을 검증했다고 PR 본문에 기록했다.
+
+문서 작성 시점 기준 Issue #1870은 `OPEN` 상태이며 milestone은 없다.
+
+## 변경 범위
+
+- `.github/workflows/close-issues-on-devel-push.yml`
+  - `devel` push 이벤트에서 동작하는 workflow를 추가한다.
+  - merge commit 및 associated PR을 조회한다.
+  - PR title/body/commit message에 포함된 `Closes #N`, `Fixes #N`, `Resolves #N` 계열 closing keyword를
+    파싱한다.
+  - 같은 저장소의 open issue에 comment를 남긴 뒤 `state_reason: completed`로 close한다.
+
+Rust 소스, 테스트 코드, 렌더링 경로, 샘플 파일 변경은 없다.
+
+## 커밋 목록과 contributor credit
+
+| SHA | 작성자 | 내용 |
+|---|---|---|
+| `3ed3ed5f51ed00e117ede6daad4a754d83a1a8c5` | Taesup Jang `<tsjang@gmail.com>` | `task 1870: devel 이슈 자동 close workflow 추가` |
+| `8413e28a6eceaefd6f159c321eb74373677baef8` | Taesup Jang `<tsjang@gmail.com>` | `task 1870: closing keyword 직접 참조만 수집` |
+
+원 contributor 커밋은 rewrite하지 않았다. Co-authored-by trailer는 없다.
+
+## 리뷰 이력
+
+1차 검토에서 `collectIssueNumbers`가 closing keyword 뒤 같은 줄에 나오는 모든 issue reference를 수집하는
+문제를 확인했다. 예를 들어 `Fixes #1, related follow-up #2 remains open`이 `#1,#2`를 반환해 follow-up
+issue까지 자동 close 대상이 될 수 있었다. 이 workflow는 `issues: write` 권한으로 실제 issue를 닫기 때문에
+2026-07-03에 Request changes review를 제출했다.
+
+contributor는 두 번째 커밋에서 `closingIssueRef` 단일 패턴으로 수정했다. 수정 후에는 closing keyword와
+issue reference가 직접 연결된 경우만 수집한다. 로컬 재현에서 이전 문제 문장은 `#1`만 반환했다.
+
+## 로컬 검증
+
+검증은 `/private/tmp/rhwp-pr1871-review` worktree에서 최신 PR head 기준으로 수행했다.
+
+| 항목 | 결과 |
+|---|---|
+| `git diff --check upstream/devel...HEAD` | 통과 |
+| `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/close-issues-on-devel-push.yml')"` | 통과 |
+| `git merge --no-commit --no-ff upstream/devel` | `Already up to date` |
+| closing keyword 경계 사례 Node 재현 | 통과 |
+
+경계 사례 재현 결과:
+
+| 입력 | 수집 결과 |
+|---|---|
+| `Closes #1870` | `1870` |
+| `Fixes #1, related follow-up #2 remains open` | `1` |
+| `Resolves #3; follow-up issue #4 tracks remaining work` | `3` |
+| `Related #5 only` | 없음 |
+| `Fixes edwardkim/rhwp#6 and external/repo#7` | `6` |
+| `Resolves #10, resolves #123, resolves octo-org/octo-repo#100` | `10`, `123` |
+| `Closes: https://github.com/edwardkim/rhwp/issues/11` | `11` |
+
+`octo-org/octo-repo#100`은 다른 저장소 reference라 close 대상에서 제외되는 것이 맞다.
+
+## GitHub Actions
+
+문서 작성 시점 기준 최신 head `8413e28a6eceaefd6f159c321eb74373677baef8`에서 확인한 check 상태:
+
+| Check | 결과 |
+|---|---|
+| CI preflight | success |
+| Build & Test | success |
+| WASM Build | skipped |
+| CodeQL preflight | success |
+| Analyze (javascript-typescript) | success |
+| Analyze (python) | success |
+| Analyze (rust) | success |
+| CodeQL | success |
+
+리뷰 문서 push 후에는 head SHA가 바뀌므로, latest head 기준 check 상태를 다시 확인해야 한다.
+
+## 위험 요소와 판단
+
+핵심 위험은 자동 close 대상의 과잉 수집이었다. contributor의 두 번째 커밋으로 closing keyword와 직접 연결된
+issue reference만 수집하도록 좁혀져, 최초 지적한 과잉 close 문제는 해소됐다.
+
+이 workflow는 `devel` push에서만 실행되고 `contents: read`, `issues: write`, `pull-requests: read` 권한만
+요청한다. 같은 저장소 issue만 닫도록 owner/repo 비교도 수행한다.
+
+남은 주의점은 GitHub native auto-close와 달리 이 workflow가 merge 후 comment를 남기고 issue를 닫는 별도
+자동화라는 점이다. PR #1871이 merge된 뒤 Issue #1870이 자동 close되는지 확인해야 하며, 동작하지 않으면
+workflow run 로그와 issue state를 확인한 뒤 수동 close 여부를 작업지시자에게 다시 승인받아야 한다.
+
+## 최종 권고
+
+PR #1871은 merge 후보로 판단한다.
+
+merge 전 조건:
+
+- 최신 PR head 기준 GitHub Actions relevant checks 통과 또는 문서-only 후속 커밋 fast-pass 조건 확인
+- PR diff에 `mydocs/pr/archives/pr_1871_review.md`와 `mydocs/pr/archives/pr_1871_report.md` 포함 확인
+- 최신 `mergeable` / `mergeStateStatus` 재확인
+- latest head 기준 approval 상태 확인
+- 작업지시자 merge 승인


### PR DESCRIPTION
## 요약

`devel` 운영 브랜치에 PR이 merge될 때 GitHub native closing keyword가 issue를 자동 close하지 못하는 문제를 보정합니다.

- `push` to `devel` 이벤트에서 동작하는 workflow 추가
- merge commit 및 연결 PR을 조회해 PR title/body/commit message의 `Closes #N`, `Fixes #N`, `Resolves #N`를 파싱
- 같은 저장소 issue만 대상으로 comment 후 close

Closes #1870

## fork 검증

`jangster77/rhwp`에서 먼저 검증했습니다.

- 테스트 PR: https://github.com/jangster77/rhwp/pull/6
- 테스트 issue: https://github.com/jangster77/rhwp/issues/5
- 성공 run: https://github.com/jangster77/rhwp/actions/runs/28666964306
- 결과: PR #6이 `devel`에 merge된 뒤 `Close Issues on devel Push` workflow가 issue #5를 자동 close했습니다.

## 로컬 검증

- `git diff --check`
- workflow 필수 키워드 확인 스크립트
- Ruby YAML parse

Rust 소스 변경은 없으므로 cargo 검증은 생략했습니다.
