### PR TITLE
#1873 후속 기록 보강

### DIFF
--- a/mydocs/orders/20260704.md
+++ b/mydocs/orders/20260704.md
@@ -4,5 +4,4 @@
 
 | PR | 내용 | 처리 |
 |----|------|------|
-| #1873 | #1695 HWP3 `LINE_SEG` rewind 페이지 경계 반영 | PR 생성 및 option 1 review 문서/visual asset/오늘할일 준비. `upstream/devel` update branch 후 head `6fd39bb70076fc85e7d7445f357edcc7a478d147` 로 갱신했고, 이전 SHA Actions run 은 force-cancel 완료. 로컬 검증(`issue_1695`, 영향권 회귀, full release-test, clippy, `git diff --check`) 통과. `SO-SUEOP.hwp` vs `SO-SUEOP-2024.pdf` visual sweep 46/46쪽, 자동 후보 0/46 확인. 대표 review PNG 4건을 `mydocs/pr/assets/`에 반영 후 최신 CI 대기 |
-
+| #1873 | #1695 HWP3 `LINE_SEG` rewind 페이지 경계 반영 | merge 완료. merge commit `e5ff8ab9311ff0a22c127f5a5081c4f1cacc421d`. `upstream/devel` update branch 후 option 1 review 문서/visual asset/오늘할일을 PR head 에 포함. 최종 head `3e64bbbfdc1fb3d378ae398906880ca76dc91941` 기준 GitHub Actions 통과. 로컬 검증(`issue_1695`, 영향권 회귀, full release-test, clippy, `git diff --check`) 통과. `SO-SUEOP.hwp` vs `SO-SUEOP-2024.pdf` visual sweep 46/46쪽, 자동 후보 0/46 확인. 대표 review PNG 4건을 `mydocs/pr/assets/`에 반영. #1695 auto-close 완료 |

--- a/mydocs/pr/archives/pr_1873_review.md
+++ b/mydocs/pr/archives/pr_1873_review.md
@@ -12,7 +12,10 @@
 | 관련 이슈 | #1695 |
 | review 방식 | 옵션 1: 현재 PR 에 review 문서, visual asset, 오늘할일 포함 |
 | update branch 후 코드 head | `6fd39bb70076fc85e7d7445f357edcc7a478d147` |
-| CI 상태 | 문서 작성 시점 새 head CI queued |
+| 최종 PR head | `3e64bbbfdc1fb3d378ae398906880ca76dc91941` |
+| CI 상태 | 통과 |
+| merge commit | `e5ff8ab9311ff0a22c127f5a5081c4f1cacc421d` |
+| 관련 이슈 close | #1695 auto-close 완료 (`2026-07-03T16:32:57Z`) |
 
 ## 변경 범위
 
@@ -95,7 +98,8 @@ SO-SUEOP 전체는 폰트/래스터 차이 때문에 값이 낮지만, 자동 fl
 - 최초 PR head `e937e29ec1ce98539752cd2d73b8128e2ea3c291` 은 base 대비 `BEHIND` 상태였다.
 - `upstream/devel` 기준 rebase 후 `6fd39bb70076fc85e7d7445f357edcc7a478d147` 로 force-with-lease push 했다.
 - 이전 SHA 의 `CI`, `CodeQL`, `Render Diff` run 은 force-cancel 로 `completed/cancelled` 확인했다.
-- 최신 SHA 의 CI 는 문서 작성 시점 queued 상태다.
+- option 1 문서/asset/오늘할일 커밋 후 최종 head 는 `3e64bbbfdc1fb3d378ae398906880ca76dc91941` 이다.
+- 최종 head 기준 `CI`, `CodeQL`, `Render Diff` 모두 통과했다.
 
 ## 오늘할일 기록
 
@@ -105,4 +109,5 @@ SO-SUEOP 전체는 폰트/래스터 차이 때문에 값이 낮지만, 자동 fl
 ## 판단
 
 로컬 검증과 visual sweep 기준으로 #1695 의 핵심 문제인 HWP3 `LINE_SEG` vpos rewind 경계 반영은 의도대로
-수정됐다. 최신 head CI 가 통과하면 merge 가능한 후보로 판단한다.
+수정됐다. 최종 head CI 통과 후 PR #1873 은 `e5ff8ab9311ff0a22c127f5a5081c4f1cacc421d` 로 merge 완료됐고,
+관련 이슈 #1695 는 auto-close 완료됐다.

--- a/mydocs/pr/archives/pr_1873_review_impl.md
+++ b/mydocs/pr/archives/pr_1873_review_impl.md
@@ -78,7 +78,7 @@ python3 scripts/task1274_visual_sweep.py \
 
 ## Stage 6. Option 1 문서/asset 준비
 
-진행 중.
+완료.
 
 - `mydocs/pr/archives/pr_1873_review.md`
 - `mydocs/pr/archives/pr_1873_review_impl.md`
@@ -88,9 +88,20 @@ python3 scripts/task1274_visual_sweep.py \
 - `mydocs/pr/assets/pr_1873_issue1695_so_sueop_review_p029.png`
 - `mydocs/pr/assets/pr_1873_issue1695_so_sueop_review_p044.png`
 
+## Stage 7. CI 및 merge 후속 확인
+
+완료.
+
+- option 1 문서/asset/오늘할일 커밋: `3e64bbbfdc1fb3d378ae398906880ca76dc91941`
+- 최종 head 기준 GitHub Actions:
+  - `CI`: 통과
+  - `CodeQL`: 통과
+  - `Render Diff`: 통과
+- PR #1873 merge 완료: `e5ff8ab9311ff0a22c127f5a5081c4f1cacc421d`
+- #1695 auto-close 완료: `2026-07-03T16:32:57Z`
+
 ## 남은 작업
 
-- review 문서/asset 커밋
-- 같은 PR branch 에 remote push
-- 최신 head CI 모니터링
-- CI 통과 후 merge 및 #1695 close 여부 확인
+- 후속 기록 fast-pass PR 생성 및 merge
+- #1873 PR comment 작성
+- `task/m100-1695-vpos-reset`, `task/m100-1695-post-merge-docs` 브랜치 정리


### PR DESCRIPTION
## 요약

- PR #1873 merge 후 확정값을 review 문서와 오늘할일에 반영합니다.
- merge commit `e5ff8ab9311ff0a22c127f5a5081c4f1cacc421d` 를 기록합니다.
- #1695 auto-close 완료 상태를 기록합니다.

## fast-pass 범위

- 문서만 변경합니다.
- 변경 파일:
  - `mydocs/pr/archives/pr_1873_review.md`
  - `mydocs/pr/archives/pr_1873_review_impl.md`
  - `mydocs/orders/20260704.md`

## 검증

- `git diff --check`
