### PR TITLE
Task #1665: Build & Test Native Skia 병렬 분리

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -218,8 +218,8 @@ jobs:
               setResult(false, 'preflight-error');
             }
 
-  build-and-test:
-    name: Build & Test
+  build-default-feature-tests:
+    name: Build default-feature tests
     runs-on: ubuntu-latest
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
@@ -290,6 +290,57 @@ jobs:
       - name: Check WASM target
         run: cargo check --target wasm32-unknown-unknown --lib
 
+      - name: Clippy
+        run: cargo clippy -- -D warnings
+
+      - name: Save cargo registry & build cache
+        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') && steps.cargo_cache_restore.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+
+  native-skia-tests:
+    name: Native Skia tests
+    runs-on: ubuntu-latest
+    needs: preflight
+    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
+    permissions:
+      contents: read
+
+    steps:
+      - uses: actions/checkout@v5
+
+      # [Task #1109 / #1192 C] ubuntu-latest runner 의 미사용 사전 설치 toolchain 제거하여
+      # 테스트 빌드 시 디스크 한도 초과를 줄인다.
+      # [#1192] 캐시 정상 작동 확인 후 "크고 빠른" 항목(android/dotnet)만 남기고 축소.
+      # 느린 docker prune --all / apt clean / ghc / CodeQL 정리는 제거. df -h 로 여유 확인.
+      - name: Free disk space (remove unused pre-installed toolchains)
+        run: |
+          sudo rm -rf /usr/local/lib/android
+          sudo rm -rf /usr/share/dotnet
+          df -h
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          toolchain: 1.93.1
+
+      - name: Restore cargo registry & build cache
+        id: cargo_cache_restore
+        uses: actions/cache/restore@v5
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-cargo-
+
       - name: Install native Skia runtime packages
         run: |
           sudo apt-get update
@@ -308,18 +359,45 @@ jobs:
             cargo test --release --features native-skia skia --lib --verbose
           fi
 
-      - name: Clippy
-        run: cargo clippy -- -D warnings
+  build-and-test:
+    name: Build & Test
+    runs-on: ubuntu-latest
+    needs:
+      - preflight
+      - build-default-feature-tests
+      - native-skia-tests
+    if: ${{ always() }}
+    permissions:
+      contents: read
 
-      - name: Save cargo registry & build cache
-        if: ${{ github.event_name == 'push' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') && steps.cargo_cache_restore.outputs.cache-hit != 'true' }}
-        uses: actions/cache/save@v5
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
+    steps:
+      - name: Check Build & Test worker results
+        run: |
+          echo "preflight=${{ needs.preflight.result }}"
+          echo "fast_pass=${{ needs.preflight.outputs.fast_pass }}"
+          echo "build_default=${{ needs['build-default-feature-tests'].result }}"
+          echo "native_skia=${{ needs['native-skia-tests'].result }}"
+
+          if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+            echo "::error::CI preflight did not succeed: ${{ needs.preflight.result }}"
+            exit 1
+          fi
+
+          if [[ "${{ needs.preflight.outputs.fast_pass }}" == "true" ]]; then
+            echo "CI preflight fast-pass accepted."
+            exit 0
+          fi
+
+          failed=0
+          if [[ "${{ needs['build-default-feature-tests'].result }}" != "success" ]]; then
+            echo "::error::Build default-feature tests result: ${{ needs['build-default-feature-tests'].result }}"
+            failed=1
+          fi
+          if [[ "${{ needs['native-skia-tests'].result }}" != "success" ]]; then
+            echo "::error::Native Skia tests result: ${{ needs['native-skia-tests'].result }}"
+            failed=1
+          fi
+          exit "${failed}"
 
   wasm-build:
     name: WASM Build

--- a/mydocs/orders/20260704.md
+++ b/mydocs/orders/20260704.md
@@ -11,4 +11,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1667 | Build & Test `Dirty rhwp` / target cache 실효성 분석 코드 PR 보강 | 완료 | #1876 merge 및 issue close 완료: 03:24 |
-| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | 구현계획서 작성 완료, 구현 승인 대기 |
+| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | workflow 구현 및 정적 검증 완료 |

--- a/mydocs/orders/20260704.md
+++ b/mydocs/orders/20260704.md
@@ -11,4 +11,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1667 | Build & Test `Dirty rhwp` / target cache 실효성 분석 코드 PR 보강 | 완료 | #1876 merge 및 issue close 완료: 03:24 |
-| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | 수행계획서 작성 후 구현 승인 대기 |
+| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | 구현계획서 작성 완료, 구현 승인 대기 |

--- a/mydocs/orders/20260704.md
+++ b/mydocs/orders/20260704.md
@@ -11,4 +11,4 @@
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
 | #1667 | Build & Test `Dirty rhwp` / target cache 실효성 분석 코드 PR 보강 | 완료 | #1876 merge 및 issue close 완료: 03:24 |
-| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | workflow 구현 및 정적 검증 완료 |
+| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | #1877 PR CI 통과, review 문서 작성 및 merge 승인 대기 |

--- a/mydocs/orders/20260704.md
+++ b/mydocs/orders/20260704.md
@@ -10,4 +10,5 @@
 
 | Issue | 타스크 | 상태 | 비고 |
 |------|--------|------|------|
-| #1667 | Build & Test `Dirty rhwp` / target cache 실효성 분석 코드 PR 보강 | 진행중 | `Run lib tests` 중복 제거 반영 및 PR CI 재관측 |
+| #1667 | Build & Test `Dirty rhwp` / target cache 실효성 분석 코드 PR 보강 | 완료 | #1876 merge 및 issue close 완료: 03:24 |
+| #1665 | Build & Test job 병렬 분리 설계 착수 | 진행중 | 수행계획서 작성 후 구현 승인 대기 |

--- a/mydocs/plans/task_m100_1665.md
+++ b/mydocs/plans/task_m100_1665.md
@@ -1,0 +1,208 @@
+# Task M100 #1665 수행계획서
+
+## 개요
+
+- 이슈: #1665 `[CI] Build & Test job 병렬 분리 설계`
+- 부모 이슈: #1668 `[Tracking/RFC] CI Build & Test 실행 시간 단계별 단축`
+- 현재 브랜치: `task-1665-build-test-parallel-plan`
+- 작업 성격: #1664 / #1666 / #1849 / #1667 완료 후 남은 `Build & Test` wall time을 줄일 수 있는지
+  제한적 병렬화로 검증한다.
+
+## 착수 조건 확인
+
+선행 이슈 상태:
+
+| 이슈 | 상태 | #1665에 주는 의미 |
+|------|------|-------------------|
+| #1664 | 완료 | PR restore-only, trusted branch save, cleanup 후 cache 정책 안정화 |
+| #1666 | 완료 | PR 경로 `release-test` 전환 완료 |
+| #1849 | 완료 | `devel` push full release integration 비용을 release build smoke + `release-test` 회귀로 재조정 |
+| #1667 | 완료 | CodeQL / Render Diff cache save 표면 정리, stale cache cleanup, `Dirty rhwp` 원인 분류 완료 |
+
+따라서 메인테이너가 #1668에서 제시한 “#1666 + #1664 + #1667 결과 측정 후 #1665 재평가” 조건은 충족됐다.
+
+## 메인테이너 결정사항 반영
+
+#1668 결정사항 중 #1665에 직접 적용되는 항목:
+
+- 처음부터 많은 job으로 나누지 않고 2-3개 job부터 제한적으로 실험한다.
+- 통합 테스트 파일 통합, 회귀 가드 명명 규칙 변경, `tests/golden_svg/issue-NNN/` 구조 변경은 하지 않는다.
+- 162개 통합 테스트의 1:1 추적성을 유지한다. 현재 저장소 기준 test executable 수가 늘어난 경우에도 파일 단위
+  회귀 가드 구조 보존을 확인한다.
+- runner-minutes 증가는 보수적으로 본다.
+- branch protection / required check 변경 여부를 before/after에 명시한다.
+- cache는 PR restore-only, trusted branch save 원칙을 유지한다.
+
+## 현재 기준선
+
+최신 원천 기준은 #1667 최종 보고와 부모 추적 문서다.
+
+### #1872 merge 후 `devel` push 기준
+
+- run: <https://github.com/edwardkim/rhwp/actions/runs/28676046470>
+- `Build & Test` job: <https://github.com/edwardkim/rhwp/actions/runs/28676046470/job/85049578280>
+- cache: exact hit `Linux-cargo-6a1af...`, 1,637,296,893 B, save skipped
+- cache reservation / read-only / save failure 경고 없음
+- branch protection / required check 변경 없음
+
+| 항목 | 시간 |
+|------|------|
+| CI run 완료 시간 | 12m57s |
+| `CI / Build & Test` job | 12m45s |
+| Build | 3m29s |
+| Run default-feature tests | 5m03s |
+| Check WASM target | 15s |
+| Install native Skia runtime packages | 9s |
+| Native Skia tests | 2m15s |
+| Clippy | 22s |
+
+회귀 가드:
+
+- `Run default-feature tests`: `running 2081 tests`, `2075 passed; 0 failed; 6 ignored`
+- `Native Skia tests`: `running 48 tests`, `48 passed`
+- 최신 `devel` 기준 `tests/*.rs` integration executable 182개, `tests/issue*.rs` 151개 유지
+
+## 1차 설계 판단
+
+### 채택 후보: Native Skia 분리 + aggregate `Build & Test` gate
+
+1차 실험은 기존 단일 `Build & Test` job을 과하게 쪼개지 않고, 다음 구조를 검토한다.
+
+| job | 역할 | 비고 |
+|-----|------|------|
+| `CI preflight` | 기존 fast-pass 판정 | 유지 |
+| `Build default-feature tests` | checkout, disk cleanup, Rust toolchain, cargo restore, fmt, Build, Run default-feature tests, WASM check, Clippy | 기존 기본 feature 회귀 경로 유지 |
+| `Native Skia tests` | checkout, disk cleanup, Rust toolchain, cargo restore, native package install, native-skia tests | feature set이 달라 별도 산출물이 필요한 영역 |
+| `Build & Test` | aggregate gate | 기존 required check 이름 보존 후보 |
+
+기대 효과:
+
+- `Run default-feature tests` 경로와 `Native Skia tests` 경로가 병렬 실행되어 wall time이 1-2분대 줄 가능성이 있다.
+- Native Skia는 feature set이 달라 기본 feature 산출물 재사용성이 낮으므로 병렬 분리 후보로 적합하다.
+- 기존 required check context인 `CI / Build & Test`를 aggregate gate에 유지하면 branch protection 변경을 피할 수 있다.
+
+예상 비용:
+
+- `checkout`, disk cleanup, Rust toolchain 설치, cache restore가 Native Skia job에서 한 번 더 실행된다.
+- runner-minutes는 증가할 수 있다.
+- cache save writer를 여러 job에 두면 같은 key 저장 경합이 생길 수 있다.
+
+### 이번 1차에서 하지 않는 것
+
+- Build와 default-feature tests를 서로 다른 job으로 분리하지 않는다.
+  - PR에서는 cache save가 없으므로 Build job 산출물을 test job이 안정적으로 재사용하기 어렵다.
+  - 분리하면 `rhwp` local crate compile이 오히려 늘 수 있다.
+- fmt / wasm check / clippy를 별도 job으로 나누지 않는다.
+  - 각 step 자체가 짧아 setup 비용이 더 클 가능성이 높다.
+- `cargo nextest`를 바로 도입하지 않는다.
+  - 도입 자체가 test runner 변경이므로 별도 판단이 필요하다.
+- `Swatinem/rust-cache` 또는 cache key/path 변경을 섞지 않는다.
+- cleanup 자동화 workflow를 섞지 않는다.
+
+## cache 설계 원칙
+
+1차 구현 후보에서는 cache 정책을 다음처럼 보수적으로 둔다.
+
+- PR worker jobs는 restore-only를 유지한다.
+- trusted branch save는 단일 writer job만 담당하도록 설계한다.
+- Native Skia job은 우선 restore-only로 둔다.
+- 같은 key를 여러 job이 동시에 save하지 않게 한다.
+- cache key/path는 기존 `Linux-cargo-${Cargo.lock hash}`와 `~/.cargo/registry`, `~/.cargo/git`, `target`를 유지한다.
+
+단일 writer를 어디에 둘지는 구현계획서에서 최종 결정한다. 기본 후보는 `Build default-feature tests` job이다.
+
+## aggregate gate 설계 원칙
+
+branch protection 변경을 피하기 위해 기존 `Build & Test` check 이름은 aggregate gate가 맡는 방향을 우선 검토한다.
+
+요구사항:
+
+- preflight fast-pass가 `true`이면 worker jobs는 skipped, aggregate `Build & Test`는 success가 되어야 한다.
+- preflight fast-pass가 `false`이면 모든 worker job success를 확인해야 한다.
+- worker job 중 failure/cancelled/timed_out이 있으면 aggregate `Build & Test`가 fail해야 한다.
+- aggregate job은 실패 시 어떤 worker가 실패했는지 job summary 또는 로그에서 드러나야 한다.
+
+리스크:
+
+- 기존 `build-and-test` job 이름을 aggregate gate로 옮기면 job 실행 내용이 직접 빌드/테스트에서 판정 job으로 바뀐다.
+- GitHub branch protection이 check context를 어떻게 매칭하는지 PR에서 확인해야 한다.
+- worker job들이 새 check로 노출되어 CI 화면은 더 복잡해질 수 있다.
+
+## 측정 기준
+
+#1668 공통 기준을 그대로 따른다.
+
+| 항목 | 측정 방법 |
+|------|-----------|
+| PR checks 완료 시간 | PR run별 전체 checks 완료 시간. 표본 누적 후 P50/P90 |
+| `CI / Build & Test` job 시간 | aggregate gate 시간과 worker job 시간을 분리 기록 |
+| 주요 step 시간 | Build, Run default-feature tests, Native Skia tests, Check WASM target, Clippy |
+| cache hit/miss/save | 각 worker job의 restore hit/miss, save skipped/success/failure |
+| cache 크기 | restore 로그의 cache size |
+| 실패 시 원인 가시성 | aggregate failure 메시지, worker job stderr 위치 |
+| runner-minutes 변화 | worker job wall time 합산 proxy와 기존 단일 job wall time 비교 |
+| branch protection / required check 변경 | `CI / Build & Test` required check 유지 여부 확인 |
+| 회귀 가드 1:1 추적성 | `Run default-feature tests`와 Native Skia test count, `tests/*.rs` / `tests/issue*.rs` executable 수 확인 |
+
+## 성공 기준
+
+1차 실험은 다음 조건을 모두 만족해야 성공으로 본다.
+
+- PR 경로에서 `CI / Build & Test` required check가 유지된다.
+- PR run에서 cache save는 skipped 상태를 유지한다.
+- cache reservation / read-only / save failure 경고가 새로 생기지 않는다.
+- `Run default-feature tests`의 2081 tests와 integration executable 수가 유지된다.
+- Native Skia tests 48개가 유지된다.
+- wall time이 의미 있게 줄어든다. 1차 기준은 `Build & Test` 계열 완료 시간이 최소 1분 이상 줄어드는지 본다.
+- runner-minutes proxy 증가가 wall time 감소 대비 과도하지 않다. 1차 판단 기준은 +40% 이상 증가하면 재검토다.
+
+## 중단 / 롤백 기준
+
+다음 중 하나라도 발생하면 1차 구현을 재검토하거나 되돌린다.
+
+- branch protection required check가 깨진다.
+- aggregate `Build & Test`가 skipped/fail 상태를 잘못 전달한다.
+- worker job 분리로 cache save 경합이나 reservation 실패가 재발한다.
+- wall time 개선이 1분 미만인데 runner-minutes만 크게 증가한다.
+- 회귀 가드 실행 수 또는 test executable 추적성이 줄어든다.
+- Native Skia 분리로 실패 원인 가시성이 오히려 나빠진다.
+
+## 진행 순서
+
+1. 이슈 본문과 부모 추적 문서 기준으로 착수 계획 확정
+2. 오늘 할일 문서와 이 수행계획서 작성
+3. 작업지시자 승인 후 구현계획서 작성
+4. 구현 PR에서 `.github/workflows/ci.yml`과 운영 문서만 변경
+5. PR CI 관측
+6. merge 후 `devel` push 관측
+7. measurement / tracking 문서는 after 관측까지 모은 뒤 별도 문서 PR로 반영
+8. #1665 최종 보고 및 close 판단
+
+## 문서 / 코드 PR 분리
+
+운영 문서 방침:
+
+- 수행계획서, 구현계획서, stage 보고서는 코드 PR에 포함할 수 있다.
+- measurement / tracking / 최종 보고 문서는 코드 merge와 after 관측 이후 별도 문서 PR로 반영한다.
+
+1차 코드 PR 예상 범위:
+
+- `.github/workflows/ci.yml`
+- `mydocs/plans/task_m100_1665.md`
+- `mydocs/plans/task_m100_1665_impl.md`
+- `mydocs/working/task_m100_1665_stage1.md`
+- `mydocs/orders/20260704.md`
+
+최종 measurement PR 예상 범위:
+
+- `mydocs/report/task_m100_1665_measurement.md`
+- `mydocs/report/task_m100_1665_report.md`
+- `mydocs/report/task_m100_1668_ci_pipeline_tracking.md`
+
+## 현재 판단
+
+#1665는 착수 가능하다. 다만 1차 구현은 Native Skia 분리 중심의 제한적 병렬화로 시작하는 것이 맞다.
+
+Build/default-feature tests를 분리하거나 clippy/wasm/fmt를 별도 job으로 쪼개는 것은 setup/cache restore 비용과
+required check 복잡도가 커서 1차 범위로는 과하다. 먼저 Native Skia 분리가 wall time과 runner-minutes의
+균형을 맞출 수 있는지 확인한 뒤, 필요할 때 #1665 후속 단계로 확장한다.

--- a/mydocs/plans/task_m100_1665_impl.md
+++ b/mydocs/plans/task_m100_1665_impl.md
@@ -1,0 +1,354 @@
+# Task M100 #1665 구현계획서
+
+## 개요
+
+- 이슈: #1665 `[CI] Build & Test job 병렬 분리 설계`
+- 부모 이슈: #1668 `[Tracking/RFC] CI Build & Test 실행 시간 단계별 단축`
+- 수행계획서: `mydocs/plans/task_m100_1665.md`
+- 구현 대상: `.github/workflows/ci.yml`
+- 구현 원칙: Native Skia tests만 1차로 분리하고, 기존 required check 후보인 `Build & Test` 이름은 aggregate
+  gate로 보존한다.
+
+## 구현 목표
+
+현재 `CI / Build & Test`는 단일 job에서 다음을 순차 실행한다.
+
+1. checkout / disk cleanup / Rust toolchain / cargo restore
+2. Format check
+3. Build
+4. Run default-feature tests
+5. Check WASM target
+6. Install native Skia runtime packages
+7. Native Skia tests
+8. Clippy
+9. trusted branch cache save
+
+1차 구현은 Native Skia tests를 별도 worker job으로 분리해, default-feature 회귀 경로와 native-skia feature
+경로를 병렬 실행할 수 있게 한다.
+
+## 변경 요약
+
+### 기존 job
+
+| job id | name | 변경 |
+|--------|------|------|
+| `preflight` | `CI preflight` | 유지 |
+| `build-and-test` | `Build & Test` | aggregate gate로 역할 변경 |
+| `wasm-build` | `WASM Build` | 유지 |
+
+### 신규 worker job
+
+| job id | name | 역할 |
+|--------|------|------|
+| `build-default-feature-tests` | `Build default-feature tests` | fmt, Build, default-feature tests, WASM check, Clippy, 단일 cache save writer |
+| `native-skia-tests` | `Native Skia tests` | native package install, `cargo test --features native-skia skia --lib` |
+
+## 세부 구현
+
+### 1. `build-default-feature-tests` job 추가
+
+기존 `build-and-test` job에서 Native Skia 관련 step만 제외한 기본 feature 검증 job을 만든다.
+
+구성:
+
+- `runs-on: ubuntu-latest`
+- `needs: preflight`
+- `if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}`
+- `permissions: contents: read`
+- steps:
+  - `actions/checkout@v5`
+  - `Free disk space (remove unused pre-installed toolchains)`
+  - `dtolnay/rust-toolchain@stable`
+    - toolchain: `1.93.1`
+    - components: `clippy, rustfmt`
+    - targets: `wasm32-unknown-unknown`
+  - `Restore cargo registry & build cache`
+    - id: `cargo_cache_restore`
+    - 기존 key/path 유지
+  - `Format check`
+  - `Build`
+    - pull_request: `cargo build --profile release-test --verbose`
+    - push devel/main/tag/manual: 기존 분기 유지
+  - `Run default-feature tests`
+    - pull_request / `refs/heads/devel`: `cargo test --profile release-test --tests --verbose`
+    - main/tag/manual: `cargo test --release --tests --verbose`
+  - `Check WASM target`
+  - `Clippy`
+  - `Save cargo registry & build cache`
+    - 기존 조건 유지
+    - 이 job만 save writer 역할 수행
+
+Native Skia 관련 step은 이 job에서 제거한다.
+
+### 2. `native-skia-tests` job 추가
+
+Native Skia feature set은 기본 feature test 산출물과 다르므로 별도 worker job으로 둔다.
+
+구성:
+
+- `runs-on: ubuntu-latest`
+- `needs: preflight`
+- `if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}`
+- `permissions: contents: read`
+- steps:
+  - `actions/checkout@v5`
+  - `Free disk space (remove unused pre-installed toolchains)`
+  - `dtolnay/rust-toolchain@stable`
+    - toolchain: `1.93.1`
+  - `Restore cargo registry & build cache`
+    - 기존 key/path 유지
+    - id는 이 job 안에서만 쓰므로 `cargo_cache_restore` 재사용 가능
+  - `Install native Skia runtime packages`
+  - `Native Skia tests`
+    - pull_request / `refs/heads/devel`: `cargo test --profile release-test --features native-skia skia --lib --verbose`
+    - main/tag/manual: `cargo test --release --features native-skia skia --lib --verbose`
+
+이 job에는 cache save step을 두지 않는다.
+
+이유:
+
+- 같은 cache key를 여러 job이 동시에 save하면 reservation 경합이 생길 수 있다.
+- #1664 / #1667에서 정리한 PR restore-only 원칙을 유지한다.
+- trusted branch에서도 단일 writer만 save하게 해 원인 추적성을 유지한다.
+
+### 3. `build-and-test` job을 aggregate gate로 변경
+
+기존 `build-and-test` job id와 `name: Build & Test`를 유지하되, 실제 build/test step은 worker job으로 옮긴다.
+
+구성 후보:
+
+```yaml
+build-and-test:
+  name: Build & Test
+  runs-on: ubuntu-latest
+  needs:
+    - preflight
+    - build-default-feature-tests
+    - native-skia-tests
+  if: ${{ always() }}
+  permissions:
+    contents: read
+  steps:
+    - name: Check Build & Test worker results
+      run: |
+        echo "preflight=${{ needs.preflight.result }}"
+        echo "fast_pass=${{ needs.preflight.outputs.fast_pass }}"
+        echo "build_default=${{ needs['build-default-feature-tests'].result }}"
+        echo "native_skia=${{ needs['native-skia-tests'].result }}"
+
+        if [[ "${{ needs.preflight.result }}" != "success" ]]; then
+          echo "::error::CI preflight did not succeed: ${{ needs.preflight.result }}"
+          exit 1
+        fi
+
+        if [[ "${{ needs.preflight.outputs.fast_pass }}" == "true" ]]; then
+          echo "CI preflight fast-pass accepted."
+          exit 0
+        fi
+
+        failed=0
+        if [[ "${{ needs['build-default-feature-tests'].result }}" != "success" ]]; then
+          echo "::error::Build default-feature tests result: ${{ needs['build-default-feature-tests'].result }}"
+          failed=1
+        fi
+        if [[ "${{ needs['native-skia-tests'].result }}" != "success" ]]; then
+          echo "::error::Native Skia tests result: ${{ needs['native-skia-tests'].result }}"
+          failed=1
+        fi
+        exit "${failed}"
+```
+
+동작 기대:
+
+- fast-pass PR: worker jobs는 skipped, aggregate `Build & Test`는 success.
+- 일반 PR / push: 두 worker가 모두 success여야 aggregate `Build & Test` success.
+- worker failure: aggregate `Build & Test` failure. 로그에 실패 worker 이름이 남는다.
+
+## branch protection / check 표면
+
+목표:
+
+- 기존 required check context로 쓰이던 `Build & Test` 이름을 유지한다.
+- 새 worker check는 추가로 보이지만 required check로 요구하지 않는다.
+- PR에서 `CI / Build & Test`가 aggregate 결과를 대표한다.
+
+확인할 점:
+
+- GitHub check-run name은 job `name`을 기준으로 노출된다.
+- 기존 preflight의 trailing review-only fast-pass 검사는 candidate SHA의 `Build & Test` check-run을 조회한다.
+- 따라서 aggregate job 이름이 `Build & Test`이면 preflight의 기존 조회 로직과도 맞는다.
+
+리스크:
+
+- 기존 `Build & Test` check가 직접 build/test job에서 aggregate job으로 의미가 바뀐다.
+- PR에서 required check가 새 worker job을 요구하지 않는지 확인해야 한다.
+- fast-pass PR에서 기존에는 `Build & Test`가 skipped였을 수 있으나, 변경 후 aggregate가 success가 될 수 있다.
+  이는 failure를 숨기는 것이 아니라 preflight가 성공적으로 fast-pass를 승인했다는 명시 결과다.
+
+## cache 정책
+
+| job | restore | save |
+|-----|---------|------|
+| `Build default-feature tests` | 기존 key/path restore | trusted branch exact miss/fallback일 때만 save |
+| `Native Skia tests` | 기존 key/path restore | 없음 |
+| `Build & Test` aggregate | 없음 | 없음 |
+
+cache key/path:
+
+- key: `${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}`
+- restore key: `${{ runner.os }}-cargo-`
+- path:
+  - `~/.cargo/registry`
+  - `~/.cargo/git`
+  - `target`
+
+보존하는 정책:
+
+- PR은 restore-only.
+- trusted branch save는 `devel` / `main` push에서만 허용.
+- save writer는 하나만 둔다.
+- `Swatinem/rust-cache` 도입 없음.
+- cache key/path 변경 없음.
+
+## 예상 효과
+
+### wall time
+
+#1872 merge 후 `devel` push 기준:
+
+| 항목 | 기존 |
+|------|------|
+| `Build & Test` job | 12m45s |
+| Build | 3m29s |
+| Run default-feature tests | 5m03s |
+| Native Skia tests | 2m15s |
+| Clippy | 22s |
+
+Native Skia를 별도 job으로 분리하면 기존 직렬 경로에서 native package install 9s + Native Skia tests 2m15s가
+기본 feature 경로와 겹칠 수 있다.
+
+예상:
+
+- wall time 개선: 약 1m30s-2m30s
+- runner-minutes 증가: Native Skia worker의 checkout/toolchain/cache restore/setup 비용 때문에 약 3-4분 증가 가능
+- 실제 판단은 GitHub Actions run time 기준으로 한다.
+
+### 실패 가시성
+
+개선:
+
+- Native Skia 실패가 별도 job으로 분리되어 더 빨리 보일 수 있다.
+- aggregate 로그에서 실패 worker가 명시된다.
+
+주의:
+
+- 최종 required check는 aggregate `Build & Test`가 대표한다.
+- 상세 원인은 worker job 로그를 따라가야 한다.
+
+## 검증 계획
+
+### 로컬 정적 검증
+
+- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
+- `actionlint .github/workflows/ci.yml`
+- `git diff --check`
+
+`actionlint`가 로컬에 없으면 설치하지 않고 실행 불가를 기록한다.
+
+### PR CI 관측
+
+PR run에서 확인할 항목:
+
+- `CI preflight` 성공
+- `Build default-feature tests` 성공
+- `Native Skia tests` 성공
+- aggregate `Build & Test` 성공
+- `WASM Build` 기존 조건 유지
+- `Build default-feature tests` cache restore hit/miss와 cache 크기
+- `Native Skia tests` cache restore hit/miss와 cache 크기
+- PR에서 save step은 `Build default-feature tests`에서도 skipped
+- `Native Skia tests`에는 save step 없음
+- cache reservation / read-only / save failure 경고 없음
+- `Run default-feature tests`: 2081 tests 유지
+- `Native Skia tests`: 48 tests 유지
+- `tests/*.rs`, `tests/issue*.rs` executable 추적성 유지
+
+### merge 후 `devel` push 관측
+
+merge 후 run에서 확인할 항목:
+
+- aggregate `Build & Test` 성공
+- trusted branch에서 save writer가 하나뿐인지 확인
+- exact hit이면 save skipped가 정상
+- miss/fallback이면 `Build default-feature tests`에서만 save 시도
+- `Native Skia tests`는 restore-only
+- runner-minutes proxy:
+  - aggregate gate wall time
+  - `Build default-feature tests` wall time
+  - `Native Skia tests` wall time
+  - worker 합산 wall time
+  - 전체 CI wall time
+
+## measurement 기록 계획
+
+코드 PR에는 implementation/stage 운영 문서까지만 포함한다.
+
+코드 PR merge 후 별도 measurement 문서 PR에서 다음을 반영한다.
+
+- `mydocs/report/task_m100_1665_measurement.md`
+- `mydocs/report/task_m100_1665_report.md`
+- `mydocs/report/task_m100_1668_ci_pipeline_tracking.md`
+
+## 구현 단계
+
+### Stage 1: workflow 구조 변경
+
+- 기존 `build-and-test`의 build/test step을 `build-default-feature-tests`로 이동
+- Native Skia 관련 step을 `native-skia-tests`로 이동
+- 기존 `build-and-test`는 aggregate gate로 변경
+- `wasm-build`는 변경하지 않음
+
+### Stage 2: 문서와 PR 설명 보강
+
+- `mydocs/working/task_m100_1665_stage1.md` 작성
+- PR body에 중요 변경점 명시
+  - `Build & Test`가 aggregate gate가 됨
+  - 실제 build/test worker가 2개로 분리됨
+  - Native Skia는 restore-only
+  - save writer는 `Build default-feature tests` 하나
+  - required check 변경 여부는 PR CI에서 확인 필요
+
+### Stage 3: 검증과 관측
+
+- 로컬 YAML/actionlint/diff 검증
+- PR CI 관측
+- Ready for review 전 branch protection / required check 영향 확인
+- merge 후 `devel` push 관측
+
+## 성공 기준
+
+- PR과 `devel` push에서 aggregate `Build & Test`가 성공한다.
+- worker job 실패가 aggregate failure로 전달된다.
+- fast-pass PR에서 aggregate `Build & Test`가 잘못 fail하지 않는다.
+- cache save 경합이 없다.
+- PR save skipped 정책이 유지된다.
+- `Run default-feature tests`와 Native Skia test count가 유지된다.
+- wall time이 기존 #1872 after 기준보다 최소 1분 줄어든다.
+- worker wall time 합산 proxy가 기존 단일 job 대비 +40% 이상 늘면 성공으로 보지 않고 재검토한다.
+
+## 롤백 기준
+
+- branch protection required check가 깨진다.
+- aggregate가 worker 실패를 success로 잘못 전달한다.
+- worker job skipped/cancelled 상태를 잘못 해석한다.
+- cache save failure / reservation 경고가 재발한다.
+- wall time 개선이 거의 없고 runner-minutes만 증가한다.
+- CI 화면 복잡도가 과도하거나 maintainer가 required check 의미 변경을 수용하기 어렵다고 판단한다.
+
+## 현재 구현 판단
+
+1차 구현은 진행 가능하다.
+
+다만 이 변경은 workflow required check 표면과 GitHub Actions result propagation에 영향을 주므로, 구현 후 바로 merge하지
+않고 PR CI에서 aggregate 동작을 먼저 검증해야 한다. 특히 `Build & Test`가 aggregate gate로 바뀐다는 점을 PR 본문
+상단에 중요 변경으로 명시한다.

--- a/mydocs/pr/archives/pr_1877_review.md
+++ b/mydocs/pr/archives/pr_1877_review.md
@@ -1,0 +1,197 @@
+# PR #1877 리뷰 - #1665 Build & Test Native Skia 병렬 분리
+
+## 메타
+
+| 항목 | 내용 |
+|------|------|
+| PR | #1877 |
+| 제목 | `Task #1665: Build & Test Native Skia 병렬 분리` |
+| 작성자 | @postmelee |
+| base | `devel` |
+| head | `postmelee:task-1665-build-test-parallel-plan` |
+| 검토 경로 | collaborator self-merge 후보 예외 경로 |
+| 관련 이슈 | #1665, #1668 |
+| labels | `enhancement`, `ci` |
+| milestone | `v1.0.0` |
+| assignee | @postmelee |
+| review request | @edwardkim |
+| 코드 검증 기준 SHA | `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5` |
+| 규모 | 문서 작성 시점 참고값: 5 files, +810 / -14 |
+| 상태 | 문서 작성 시점 참고값: draft false, `MERGEABLE`, `CLEAN` |
+
+이 문서는 merge 완료 보고서가 아니라 self-merge 후보의 merge 전 검토 기록이다. 이 문서와
+`pr_1877_review_impl.md`, 오늘할일 보강은 후속 `mydocs/**` 문서 커밋으로 PR head에 포함한다. 따라서 문서
+커밋 push 후 최신 PR head SHA는 위 코드 검증 기준 SHA와 달라진다.
+
+## 변경 요약
+
+`CI / Build & Test`의 긴 직렬 경로 중 Native Skia 검증만 1차로 별도 worker job으로 분리한다.
+
+- `build-default-feature-tests`
+  - 기존 기본 feature 경로를 담당한다.
+  - format check, Build, default-feature tests, WASM target check, Clippy를 실행한다.
+  - 기존 cargo cache key/path를 유지한다.
+  - trusted branch cache save writer를 이 job 하나로 제한한다.
+- `native-skia-tests`
+  - native Skia runtime package 설치와 `cargo test --features native-skia skia --lib`를 담당한다.
+  - cargo cache restore-only로 동작한다.
+  - save step을 두지 않는다.
+- `build-and-test`
+  - job id와 `name: Build & Test`를 유지한다.
+  - 직접 build/test를 수행하지 않고 `preflight`, `Build default-feature tests`, `Native Skia tests` 결과를
+    집계하는 aggregate gate가 된다.
+  - fast-pass PR에서는 worker jobs가 skipped 되어도 preflight 승인 결과를 근거로 success가 된다.
+  - 일반 PR/push에서는 두 worker job이 모두 success여야 success가 된다.
+
+이번 PR은 job 배치를 바꾸는 변경이며 test 명령, cache key/path, golden/sample, renderer/layout 코드는 변경하지
+않는다.
+
+## 변경 범위
+
+코드/CI 변경:
+
+- `.github/workflows/ci.yml`
+  - 기존 `build-and-test` job을 `build-default-feature-tests` worker로 이동
+  - `native-skia-tests` worker 추가
+  - `build-and-test`를 aggregate gate로 재정의
+  - `wasm-build` 조건과 동작은 유지
+
+운영 문서:
+
+- `mydocs/orders/20260704.md`
+- `mydocs/plans/task_m100_1665.md`
+- `mydocs/plans/task_m100_1665_impl.md`
+- `mydocs/working/task_m100_1665_stage1.md`
+
+후속 문서 커밋에서 추가/보강할 운영 기록:
+
+- `mydocs/orders/20260704.md`
+- `mydocs/pr/archives/pr_1877_review.md`
+- `mydocs/pr/archives/pr_1877_review_impl.md`
+
+## 관련 이슈
+
+- #1665 `[CI] Build & Test job 병렬 분리 설계`
+  - 상태: open (문서 작성 시점 참고값)
+  - labels: `enhancement`, `ci`
+  - milestone: `v1.0.0`
+- #1668 `[Tracking/RFC] CI Build & Test 실행 시간 단계별 단축`
+  - 상태: open (문서 작성 시점 참고값)
+  - tracking/RFC 이슈
+
+PR 본문은 `Refs #1665`, `Parent tracking: #1668` 형식이다. Merge만으로 issue auto-close가 발생하지 않는다.
+#1665는 merge 후 `devel` push 관측과 measurement/report 문서 반영이 남으면 open 유지가 자연스럽다. #1668은
+tracking issue이므로 후속 sub-issue 진행 상황에 맞춰 별도 판단한다.
+
+## 로컬 검증
+
+코드 검증 기준 SHA `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5` 기준으로 확인했다.
+
+```bash
+ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"
+actionlint .github/workflows/ci.yml
+git diff --check upstream/devel...HEAD
+git diff --check
+```
+
+결과:
+
+- YAML parse: `yaml ok` 확인. 로컬 Ruby `ffi` gem 확장 경고는 YAML 파싱 실패가 아니었다.
+- `actionlint .github/workflows/ci.yml`: 통과
+- `git diff --check upstream/devel...HEAD`: 통과
+- `git diff --check`: 통과
+- merge base: `upstream/devel`의 `0a741f9e2ac84777c048cb0ff63b302e085a2553`
+
+## GitHub Actions
+
+코드 검증 기준 SHA `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5` 기준 relevant checks:
+
+- CI preflight: success
+- Build default-feature tests: success
+- Native Skia tests: success
+- Build & Test: success
+- WASM Build: skipped
+- Render Diff preflight: success
+- Canvas visual diff: success
+- CodeQL preflight: success
+- Analyze (python): success
+- Analyze (javascript-typescript): success
+- Analyze (rust): success
+- CodeQL: success
+
+CI run:
+
+- <https://github.com/edwardkim/rhwp/actions/runs/28678383547>
+- PR event head SHA: `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5`
+
+핵심 로그 확인:
+
+- preflight: `fast_pass=false reason=no-trailing-review-only-commits`
+- `Build default-feature tests`
+  - cache size: `~1561 MB (1637296893 B)`
+  - cache key: `Linux-cargo-6a1af67968af2b829f31637cb42371573b1fc279c0b7634dc63557a90d4227c2`
+  - Build profile: `release-test`, `event=pull_request`
+  - default-feature tests: `running 2081 tests`
+  - result: `2075 passed; 0 failed; 6 ignored`
+  - PR run에서 `Save cargo registry & build cache` skipped
+- `Native Skia tests`
+  - cache size: `~1561 MB (1637296893 B)`
+  - cache key: `Linux-cargo-6a1af67968af2b829f31637cb42371573b1fc279c0b7634dc63557a90d4227c2`
+  - profile: `release-test`, `event=pull_request`
+  - native Skia tests: `running 48 tests`
+  - result: `48 passed; 0 failed; 0 ignored; 2080 filtered out`
+  - save step 없음
+- aggregate `Build & Test`
+  - `preflight=success`
+  - `fast_pass=false`
+  - `build_default=success`
+  - `native_skia=success`
+
+전체 CI run 로그에서 `Cache reservation failed`, `read only`, `read-only`, `Failed to save`, `Unable to reserve`
+문구는 확인되지 않았다.
+
+## 시각 검증
+
+해당 없음.
+
+이 PR은 GitHub Actions workflow와 운영 문서 변경이며 renderer, layout, paint, wasm render output, samples,
+golden fixture를 변경하지 않는다. 따라서 `visual_sweep_guide.md` 대상이 아니다.
+
+## 검토 중 확인한 사항
+
+### PR 본문 명령 예시 불일치
+
+PR 본문의 `Build default-feature tests` 설명에는 build step이
+`cargo build --profile release-test --no-default-features --features test-utils`로 적혀 있다. 실제 workflow는
+기존 default-feature build 경로인 `cargo build --profile release-test --verbose`를 유지한다.
+
+이 불일치는 workflow 동작 자체의 blocker는 아니지만, PR 설명이 실제 검증 명령과 다르므로 merge 전 PR 본문을
+보정하는 것이 좋다.
+
+## 리뷰 결과
+
+Blocking finding 없음.
+
+Native Skia 검증 분리는 기존 `Build & Test` required check 이름을 aggregate gate로 보존하면서, default-feature
+경로와 native-skia 경로를 병렬 실행하도록 구성됐다. GitHub Actions에서 두 worker job과 aggregate `Build & Test`
+모두 성공했고, default-feature test count와 Native Skia test count도 기존 기대값과 일치한다. PR cache save
+정책도 유지됐다.
+
+단, PR 본문 명령 예시 불일치는 merge 전 보정 권고 사항으로 남긴다.
+
+## merge 전 재확인 조건
+
+merge 전에는 다음을 다시 확인한다.
+
+- 문서 후속 커밋 push 후 최신 PR head SHA
+- latest head 기준 GitHub Actions 또는 후속 기록 fast-pass 결과
+- `mergeable` / `mergeStateStatus`
+- PR diff에 `mydocs/pr/archives/pr_1877_review.md`와 `mydocs/pr/archives/pr_1877_review_impl.md`가 포함됐는지
+- PR 본문 명령 예시 불일치 보정 여부
+- 작업지시자 최종 merge 승인
+
+## issue close 계획
+
+- #1665: PR 본문이 `Refs #1665` 형식이므로 auto-close 대상이 아니다. merge 후에도 `devel` push 관측과
+  measurement/report 문서 정리가 남아 있으면 open 유지한다.
+- #1668: tracking issue이므로 open 유지한다.

--- a/mydocs/pr/archives/pr_1877_review.md
+++ b/mydocs/pr/archives/pr_1877_review.md
@@ -150,6 +150,20 @@ CI run:
 전체 CI run 로그에서 `Cache reservation failed`, `read only`, `read-only`, `Failed to save`, `Unable to reserve`
 문구는 확인되지 않았다.
 
+## 한계
+
+이번 PR은 cache save writer를 `Build default-feature tests` 하나로 제한한다. 변경 전 단일 `Build & Test`
+job에서는 trusted branch cache save 시점에 default-feature 산출물과 Native Skia 산출물이 같은 `target/`에
+함께 포함될 수 있었다. 변경 후에는 Native Skia job의 `target/` 산출물이 별도 runner에서 생성되고 저장되지
+않는다.
+
+이 선택은 같은 cargo cache key에 여러 job이 동시에 save하면서 cache reservation 경합이나 read-only 경고가
+재발하는 것을 피하기 위한 보수적 설계다. 대신 Native Skia job은 exact restore 이후에도 필요한 산출물을 다시
+빌드할 수 있고, runner-minutes 또는 Native Skia job 시간이 기대보다 줄지 않을 수 있다.
+
+따라서 merge 후 `devel` push와 후속 PR run에서 Native Skia compile 시간, cache hit 여부, queue 대기,
+runner-minutes를 관측한 뒤 별도 native-skia cache key 또는 별도 target dir 도입 여부를 판단한다.
+
 ## 시각 검증
 
 해당 없음.

--- a/mydocs/pr/archives/pr_1877_review_impl.md
+++ b/mydocs/pr/archives/pr_1877_review_impl.md
@@ -1,0 +1,171 @@
+# PR #1877 처리 계획 - #1665 Build & Test Native Skia 병렬 분리
+
+## 대상
+
+- PR: #1877
+- 작성자: @postmelee
+- 관련 이슈: #1665, #1668
+- 처리 경로: collaborator self-merge 후보 예외 경로
+- 코드 검증 기준 SHA: `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5`
+- 처리 판단: 문서 후속 커밋 push 후 최신 PR head 기준 CI/fast-pass와 merge state를 재확인하고, 작업지시자
+  승인 후 merge 여부를 결정한다.
+
+## 커밋 구성
+
+원 코드/작업 커밋:
+
+| SHA | 제목 | 비고 |
+|-----|------|------|
+| `bdde0886f39a7bfe6bb78b261c135edfe7bdddc4` | `docs: plan #1665 build test parallel split` | 수행계획서 추가 |
+| `f3597b0caf89ab3196e8eae6ad5b1fa37964f5f4` | `docs: add #1665 implementation plan` | 구현계획서 추가 |
+| `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5` | `ci: split native skia test job` | workflow 구조 변경 및 Stage 1 보고서 |
+
+후속 문서 커밋:
+
+| 항목 | 내용 |
+|------|------|
+| 오늘할일 보강 | `mydocs/orders/20260704.md`의 #1665 진행 상태에 PR review 문서 작성과 merge 승인 대기 반영 |
+| review 문서 | `mydocs/pr/archives/pr_1877_review.md` |
+| 처리 계획 | `mydocs/pr/archives/pr_1877_review_impl.md` |
+| 변경 범위 | `mydocs/**` 문서만 변경 |
+
+후속 문서 커밋은 이 문서를 포함하므로 문서 안에 자기 자신의 최종 SHA를 고정 기록하지 않는다. Push 후
+`gh pr view 1877 --json headRefOid,statusCheckRollup,mergeable,mergeStateStatus`로 최신값을 확인한다.
+
+## Stage 1. PR 메타 정렬
+
+완료.
+
+- labels: `enhancement`, `ci`
+- milestone: `v1.0.0`
+- assignee: @postmelee
+- review request: @edwardkim
+- base: `devel`
+- head: `postmelee:task-1665-build-test-parallel-plan`
+- 문서 작성 시점 참고 상태: draft false, `MERGEABLE`, `CLEAN`
+
+## Stage 2. 변경 내용 검토
+
+완료.
+
+검토한 핵심 변경:
+
+- `.github/workflows/ci.yml`
+  - `Build default-feature tests` worker 추가
+  - `Native Skia tests` worker 추가
+  - 기존 `Build & Test` 이름은 aggregate gate로 유지
+  - aggregate gate가 preflight, default-feature worker, native-skia worker 결과를 확인
+
+보존 확인:
+
+- PR 경로 default-feature test 명령 유지
+- Native Skia test 명령 유지
+- `Build & Test` check 이름 유지
+- cache key/path 유지
+- PR restore-only 정책 유지
+- trusted branch cache save writer는 `Build default-feature tests` 하나로 제한
+- `tests/**`, `tests/golden_svg/**`, sample 변경 없음
+- renderer/layout/paint 변경 없음
+
+검토 중 확인한 보정 권고:
+
+- PR 본문에는 build 명령이 `--no-default-features --features test-utils`로 적혀 있으나, 실제 workflow는 기존
+  default-feature `cargo build --profile release-test --verbose`를 유지한다. Merge 전 PR 본문 보정이 필요하다.
+
+## Stage 3. 로컬 정적 검증
+
+완료.
+
+- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`: 통과
+- `actionlint .github/workflows/ci.yml`: 통과
+- `git diff --check upstream/devel...HEAD`: 통과
+- `git diff --check`: 통과
+
+YAML parse 중 로컬 Ruby `ffi` gem 확장 경고가 출력됐지만 파싱 결과는 `yaml ok`였다.
+
+## Stage 4. GitHub Actions 확인
+
+완료.
+
+코드 검증 기준 SHA `34f714bcab6d9c2e975cce9c8ebf03a6fda77bf5` 기준:
+
+- CI preflight: success
+- Build default-feature tests: success
+- Native Skia tests: success
+- Build & Test: success
+- WASM Build: skipped
+- Render Diff preflight: success
+- Canvas visual diff: success
+- CodeQL preflight: success
+- Analyze (python): success
+- Analyze (javascript-typescript): success
+- Analyze (rust): success
+- CodeQL: success
+
+CI 로그에서 확인한 핵심 결과:
+
+- preflight: `fast_pass=false reason=no-trailing-review-only-commits`
+- `Build default-feature tests`: `running 2081 tests`, `2075 passed; 0 failed; 6 ignored`
+- `Native Skia tests`: `running 48 tests`, `48 passed; 0 failed; 0 ignored`
+- aggregate `Build & Test`: `preflight=success`, `build_default=success`, `native_skia=success`
+- cache restore: 두 worker 모두 동일 cargo cache key restore 성공
+- PR cache save: `Build default-feature tests`의 save step skipped, `Native Skia tests`에는 save step 없음
+- cache reservation/read-only/save failure 경고 없음
+
+## Stage 5. 후속 문서 커밋
+
+진행 계획:
+
+1. `mydocs/orders/20260704.md`의 #1665 행을 PR review 문서 작성 및 merge 승인 대기 상태로 보강
+2. `mydocs/pr/archives/pr_1877_review.md` 작성
+3. `mydocs/pr/archives/pr_1877_review_impl.md` 작성
+4. staging 범위가 위 세 파일로 제한됐는지 확인
+5. 문서 커밋 생성
+6. PR head branch `postmelee:task-1665-build-test-parallel-plan`로 push
+7. PR diff에 review 문서 2건과 오늘할일 보강이 포함됐는지 확인
+
+## Stage 6. 문서 커밋 push 후 확인
+
+문서 커밋 push 후 다음을 확인한다.
+
+- 최신 PR head SHA가 문서 커밋으로 변경됐는지
+- PR diff에 다음 파일이 포함됐는지
+  - `mydocs/pr/archives/pr_1877_review.md`
+  - `mydocs/pr/archives/pr_1877_review_impl.md`
+  - `mydocs/orders/20260704.md`
+- 후속 문서 커밋이 `mydocs/**`만 변경하는 single-parent commit인지
+- 직전 코드 검증 기준 SHA의 relevant checks가 success/skipped 상태인지
+- latest PR head 기준 GitHub Actions 또는 후속 기록 fast-pass 결과가 merge 가능 상태인지
+
+## Stage 7. PR 본문 보정
+
+Merge 전 PR 본문의 `Build default-feature tests` 명령 설명을 실제 workflow와 맞춘다.
+
+보정 대상:
+
+- 현재 설명: `cargo build --profile release-test --no-default-features --features test-utils`
+- 실제 workflow: `cargo build --profile release-test --verbose`
+
+이 보정은 workflow 코드를 바꾸는 것이 아니라 PR 설명의 검증 명령 추적성을 맞추는 작업이다.
+
+## Stage 8. merge 전 대기 조건
+
+문서 커밋 push 후 즉시 merge하지 않는다. 다음 조건을 모두 확인한 뒤 작업지시자 승인으로 넘어간다.
+
+- latest PR head 기준 GitHub Actions 또는 후속 기록 fast-pass 결과가 merge 가능 상태
+- `mergeable` / `mergeStateStatus` 최신값 재확인
+- PR diff에 review 문서와 오늘할일 보강이 포함됨
+- PR 본문 명령 설명이 실제 workflow와 일치함
+- 작업지시자 최종 merge 승인
+
+## Stage 9. merge 후 후속 확인 계획
+
+merge 후에는 다음을 확인한다.
+
+- PR merge commit과 mergedAt
+- `devel` push CI run에서 aggregate `Build & Test`, `Build default-feature tests`, `Native Skia tests` 결과
+- trusted branch cache save writer가 하나뿐인지
+- #1665, #1668 상태
+- #1665는 `Refs` 형식이라 auto-close되지 않는 것이 정상이다. merge 후 measurement/report 정리가 남으면 open
+  유지한다.
+- #1668은 tracking issue이므로 open 유지한다.

--- a/mydocs/pr/archives/pr_1877_review_impl.md
+++ b/mydocs/pr/archives/pr_1877_review_impl.md
@@ -165,6 +165,9 @@ merge 후에는 다음을 확인한다.
 - PR merge commit과 mergedAt
 - `devel` push CI run에서 aggregate `Build & Test`, `Build default-feature tests`, `Native Skia tests` 결과
 - trusted branch cache save writer가 하나뿐인지
+- Native Skia job의 산출물이 별도 runner에서 생성된 뒤 저장되지 않는 한계가 실제 Native Skia compile 시간과
+  runner-minutes에 미치는 영향
+- Native Skia compile 시간이 계속 크면 별도 native-skia cache key 또는 별도 target dir 도입을 후속으로 검토
 - #1665, #1668 상태
 - #1665는 `Refs` 형식이라 auto-close되지 않는 것이 정상이다. merge 후 measurement/report 정리가 남으면 open
   유지한다.

--- a/mydocs/working/task_m100_1665_stage1.md
+++ b/mydocs/working/task_m100_1665_stage1.md
@@ -1,0 +1,155 @@
+# Task M100 #1665 Stage 1 보고서
+
+## 단계 목표
+
+Build & Test의 1차 병렬화 후보로 Native Skia tests를 별도 worker job으로 분리하고, 기존 `Build & Test`
+check 이름은 aggregate gate로 유지하는 workflow 구조를 구현했다.
+
+이번 단계는 `.github/workflows/ci.yml` 구조 변경과 운영 문서 보강이다. measurement / tracking 문서는 PR CI와
+merge 후 `devel` push 관측이 끝난 뒤 별도 문서 PR에서 반영한다.
+
+## 변경 파일
+
+- `.github/workflows/ci.yml`
+- `mydocs/plans/task_m100_1665.md`
+- `mydocs/plans/task_m100_1665_impl.md`
+- `mydocs/working/task_m100_1665_stage1.md`
+- `mydocs/orders/20260704.md`
+
+## workflow 변경 요약
+
+### 기존 구조
+
+기존에는 `build-and-test` job 하나가 `name: Build & Test`로 다음 step을 순차 실행했다.
+
+1. Format check
+2. Build
+3. Run default-feature tests
+4. Check WASM target
+5. Install native Skia runtime packages
+6. Native Skia tests
+7. Clippy
+8. Save cargo registry & build cache
+
+### 변경 후 구조
+
+| job id | name | 역할 |
+|--------|------|------|
+| `preflight` | `CI preflight` | 기존 fast-pass 판정 유지 |
+| `build-default-feature-tests` | `Build default-feature tests` | fmt, Build, default-feature tests, WASM check, Clippy, 단일 cache save writer |
+| `native-skia-tests` | `Native Skia tests` | native package install, native-skia feature lib tests |
+| `build-and-test` | `Build & Test` | worker 결과를 모으는 aggregate gate |
+| `wasm-build` | `WASM Build` | 기존 tag/manual 조건 유지 |
+
+## 구현 세부
+
+### Build default-feature tests
+
+기존 `Build & Test`의 기본 feature 검증 경로를 옮겼다.
+
+- checkout, disk cleanup, Rust toolchain, cargo restore 유지
+- `Format check` 유지
+- `Build` profile 분기 유지
+  - PR: `release-test`
+  - non-PR: `release`
+- `Run default-feature tests` profile 분기 유지
+  - PR / `devel` push: `release-test`
+  - main/tag/manual: `release`
+- `Check WASM target` 유지
+- `Clippy` 유지
+- `Save cargo registry & build cache`는 이 job에만 유지
+
+### Native Skia tests
+
+Native Skia는 feature set이 달라 기본 feature 산출물 재사용성이 낮으므로 별도 job으로 분리했다.
+
+- checkout, disk cleanup, Rust toolchain, cargo restore 수행
+- native Skia runtime package 설치 수행
+- `cargo test --features native-skia skia --lib` profile 분기 유지
+- cache save step 없음
+
+### Build & Test aggregate
+
+기존 `Build & Test` check 이름을 유지하기 위해 `build-and-test` job id와 `name: Build & Test`를 aggregate
+gate로 바꿨다.
+
+동작:
+
+- `preflight` 실패 시 aggregate fail
+- fast-pass PR이면 worker jobs가 skipped 되어도 aggregate success
+- 일반 run이면 `Build default-feature tests`와 `Native Skia tests`가 모두 success일 때만 aggregate success
+- worker failure/skipped/cancelled 상태는 aggregate 로그의 `::error::`로 표시
+
+## cache 정책
+
+| job | restore | save |
+|-----|---------|------|
+| `Build default-feature tests` | 기존 cargo key/path | trusted branch exact miss/fallback일 때만 save |
+| `Native Skia tests` | 기존 cargo key/path | 없음 |
+| `Build & Test` aggregate | 없음 | 없음 |
+
+보존한 것:
+
+- PR restore-only 정책
+- `devel` / `main` push에서만 save 허용
+- cache key/path
+- `Swatinem/rust-cache` 미도입
+
+## 회귀 가드 보존
+
+이번 변경은 workflow job 구조만 바꿨다.
+
+- `tests/**` 변경 없음
+- `tests/golden_svg/**` 변경 없음
+- 통합 테스트 파일 통합 없음
+- 회귀 가드 명명 규칙 변경 없음
+- `cargo test --profile release-test --tests --verbose` 명령 유지
+- `cargo test --profile release-test --features native-skia skia --lib --verbose` 명령 유지
+
+따라서 회귀 가드 1:1 추적성은 명령 구조상 보존된다. 실제 test count는 PR CI에서 확인한다.
+
+## PR CI 확인 항목
+
+- `Build default-feature tests` 성공 여부
+- `Native Skia tests` 성공 여부
+- aggregate `Build & Test` 성공 여부
+- fast-pass가 아닌 PR에서 worker jobs가 실행되는지
+- PR run에서 `Save cargo registry & build cache`가 skipped 되는지
+- Native Skia job에 save step이 없는지
+- cache reservation / read-only / save failure 경고가 없는지
+- `Run default-feature tests` test count 유지
+- `Native Skia tests` 48 tests 유지
+- `CI / Build & Test` required check가 aggregate 결과로 유지되는지
+
+## 예상 효과와 리스크
+
+기대 효과:
+
+- Native Skia package install + test 약 2분대가 default-feature 경로와 겹쳐 wall time 감소 가능
+- Native Skia 실패가 별도 job으로 더 명확히 드러남
+
+리스크:
+
+- checkout/toolchain/cache restore가 Native Skia job에서 한 번 더 발생해 runner-minutes는 늘 수 있음
+- 기존 `Build & Test`가 aggregate gate로 바뀌므로 required check 의미가 달라짐
+- aggregate가 worker failure/skipped 상태를 잘못 전달하면 required check 신뢰성이 떨어질 수 있음
+
+## 로컬 검증
+
+| 항목 | 결과 |
+|------|------|
+| YAML parse | 통과. `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"` |
+| `actionlint .github/workflows/ci.yml` | 통과 |
+| `git diff --check` | 통과 |
+
+비고:
+
+- Ruby 실행 시 local gem 경고 `Ignoring ffi-1.13.1 because its extensions are not built`가 출력됐지만,
+  YAML parse 자체는 `yaml ok`로 통과했다.
+
+## 다음 단계
+
+1. 코드 PR 생성
+2. PR CI 관측
+3. 필요 시 aggregate 조건 보정
+4. Ready for review 전환 판단

--- a/mydocs/working/task_m100_1665_stage1.md
+++ b/mydocs/working/task_m100_1665_stage1.md
@@ -95,6 +95,20 @@ gate로 바꿨다.
 - cache key/path
 - `Swatinem/rust-cache` 미도입
 
+### Native Skia cache 한계
+
+이번 1차 분리는 cache save writer를 `Build default-feature tests` 하나로 제한한다. 변경 전 단일
+`Build & Test` job에서는 trusted branch cache save 시점에 default-feature 산출물과 Native Skia 산출물이 같은
+`target/`에 함께 포함될 수 있었다. 변경 후에는 Native Skia job의 `target/` 산출물이 별도 runner에서 생성되고
+저장되지 않는다.
+
+이 선택은 같은 cache key에 여러 job이 동시에 save하면서 cache reservation 경합이나 read-only 경고가 재발하는
+것을 피하기 위한 보수적 설계다. 대신 Native Skia job은 exact restore 이후에도 필요한 산출물을 다시 빌드할 수
+있으며, runner-minutes 또는 Native Skia job 시간이 기대보다 줄지 않을 수 있다.
+
+merge 후 `devel` push와 후속 PR run에서 Native Skia compile 시간, cache hit 여부, queue 대기,
+runner-minutes를 관측한 뒤 별도 native-skia cache key 또는 별도 target dir 도입 여부를 판단한다.
+
 ## 회귀 가드 보존
 
 이번 변경은 workflow job 구조만 바꿨다.


### PR DESCRIPTION
## 개요

Refs #1665
Parent tracking: #1668

`Build & Test` 안에서 함께 실행되던 default-feature 검증과 Native Skia 검증을 1차로 분리합니다.

이번 PR은 #1665의 전체 병렬화 중 가장 보수적인 1차 실험입니다. 이전 #1667 작업으로 중복 `Run lib tests`를 제거한 상태에서, 남은 긴 단계 중 독립성이 큰 `Native Skia tests`만 별도 job으로 분리해 critical path 감소 여부를 관측합니다.

## 중요 변경점

기존 required check 이름인 `Build & Test`는 유지하지만, 실제 build/test 명령을 직접 수행하는 job이 아니라 두 worker job의 결과를 모으는 aggregate gate가 됩니다.

- `Build default-feature tests`
  - fmt
  - `cargo build --profile release-test --verbose`
  - default-feature tests
  - WASM target check
  - Clippy
  - cargo cache save 단일 writer
- `Native Skia tests`
  - native Skia runtime package 설치
  - native-skia tests
  - cargo cache restore-only
- `Build & Test`
  - 기존 required check 이름 보존
  - `preflight`, `Build default-feature tests`, `Native Skia tests` 결과를 집계
  - fast-pass 경로에서는 worker job이 skipped 되어도 성공 처리
  - 일반 경로에서는 두 worker job이 모두 성공해야 성공

이 변경은 branch protection / required check가 기존 `Build & Test` 이름을 바라보는 상태를 유지하기 위한 설계입니다. PR CI에서 required check 보존 여부를 반드시 확인합니다.

## Cache 정책

- PR run에서는 기존 정책대로 cargo cache save가 skipped 되어야 합니다.
- trusted branch run에서는 `Build default-feature tests`만 cargo cache save writer 역할을 합니다.
- `Native Skia tests`는 restore-only로 두어 동일 workflow 안에서 cache save writer가 늘어나지 않도록 했습니다.
- cache reservation / read-only / save failure 경고가 새로 생기지 않는지 확인합니다.

## 회귀 가드 추적성

테스트 명령 자체는 보존하고 job 배치만 나눕니다.

- default-feature tests: 기존 `Run default-feature tests` 경로 유지
- native-skia tests: 기존 `Native Skia tests` 경로 유지
- golden/integration test 파일 변경 없음
- 기존 PR마다 실행되던 회귀 가드의 1:1 추적성 보존 여부를 PR CI 로그에서 확인

관측 시 최신 기준으로 아래 개수를 다시 기록합니다.

- default-feature test count
- native-skia test count
- integration executable count
- issue executable count

## 측정 기준

각 sub-issue 공통 기준에 맞춰 PR run과 merge 후 `devel` push run을 비교합니다.

- PR checks 완료 시간
- `CI / Build & Test` 완료 시간
- 신규 worker job별 시간
  - `Build default-feature tests`
  - `Native Skia tests`
  - aggregate `Build & Test`
- 주요 step 시간
  - Build
  - Run default-feature tests
  - Native Skia tests
  - WASM target check
  - Clippy
- cache hit/miss/save skipped 여부
- cache 크기
- cache reservation / read-only / save failure 경고 여부
- 실패 시 원인 가시성
- runner-minutes 변화
- branch protection / required check 변경 여부
- 회귀 가드 1:1 추적성 보존 여부

## 정적 검증

로컬에서 다음 검증을 완료했습니다.

- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/ci.yml'); puts 'yaml ok'"`
  - 로컬 Ruby `ffi` 확장 경고는 출력되었지만 YAML parse는 성공했습니다.
- `actionlint .github/workflows/ci.yml`
- `git diff --check`

## PR CI 확인 항목

- `Build default-feature tests` 성공 여부
- `Native Skia tests` 성공 여부
- aggregate `Build & Test` 성공 여부
- 기존 required check 이름 `Build & Test` 보존 여부
- PR run에서 cargo cache save skipped 여부
- `Native Skia tests`에 save post-step 표면이 새로 생기지 않는지
- 전체 PR checks 완료 시간과 worker job별 critical path

