### PR TITLE
Task #1860: 분할 co-anchored 빈-host float 예산 이중차감 교정 + 노드-자식 포섭 불변

### DIFF
--- a/mydocs/plans/task_m100_1860.md
+++ b/mydocs/plans/task_m100_1860.md
@@ -1,0 +1,93 @@
+# 수행 계획서 — Task #1860
+
+**이슈**: #1860 분할(RowBreak) 행의 valign=Center 라벨 세로 위치 −23~+42pt 어긋남
+**브랜치**: `local/task1860` (통합 베이스 `local/prstack-0703` 에서 분기)
+**마일스톤**: M100
+**작성일**: 2026-07-03
+
+---
+
+## 1. 배경 / 증상
+
+78842 데이터기반행정 이유서(유사입법례 표, PR #1855 fixture
+`samples/issue1853_caption_precedes_body_split.hwpx`)의 3×2 RowBreak 표에서,
+`valign=Center` 라벨 셀의 세로 위치가 한글 2024 편집기와 크게 어긋난다.
+
+| 라벨 (valign=Center) | rhwp | 한글 2024 | Δ |
+|---------------------|------|-----------|---|
+| 공공데이터법 (row1, p44 분할) | y=422.0pt | y=445.0pt | **−23.0pt (rhwp 위)** |
+| 전자정부법 (row2, p45) | y=386.6pt | y=344.2pt | **+42.4pt (rhwp 아래)** |
+
+두 라벨이 반대 방향으로 어긋난다.
+
+## 2. 재현 및 실측 (본 세션 확인)
+
+- fixture 는 PR #1855 merge 커밋 `772dc2c7` 에서 추출 (현 통합 베이스에 미포함).
+  임시 위치 재현: `export-pdf` → `tools/compare_line_baselines.py --page 44/45`.
+- **표 구조** (`rhwp dump -p 371`): pi=371 ci=1, 3×2 RowBreak.
+  - row0 = 헤더("관련 법령"/"내용"), h=2131
+  - row1 = 라벨 "공공데이터법"(valign=Center, 1줄) + 내용셀(23문단, h=71062HU≈947px) → **p44/p45 분할**
+  - row2 = 라벨 "전자정부법"(valign=Center, 1줄) + 내용셀(10문단, h=36564)
+- **p44 실측**: median −1.85pt(대부분 정합), 라벨 공공데이터법에서만 −24.6pt 스텝.
+- **p45 실측**: 전 줄 균일 +40.8pt(min +40.79 / max +44.81).
+
+### 핵심 관측 — 단일 근본원인
+
+p44 두 PDF 의 **본문 내용 줄은 동일 y** 에 있다(예: "7. 제17조…" rhwp 428.0 / 한글 428.2).
+라벨만 −23pt 다르다. 분할 지점(마지막 가시 줄)은:
+
+- **rhwp p44**: 내용 line 17 (y≈696.8) 에서 컷 → row1 fragment 짧음
+- **한글 p44**: line 20 (③④문단, y≈747.4) 까지 채우고 컷 → fragment 3줄 더 김
+- 두 엔진 모두 body 하단(y=1020.5)까지 **120~180px 여유를 남기고** 컷 →
+  **페이지 용량 한계가 아니라 intra-row 분할 예산이 과소**.
+
+⇒ **valign=Center 자체는 정상**(각 엔진이 자기 fragment 중앙에 라벨 배치).
+근본은 **rhwp 가 row1 분할을 한글보다 ~55px(~3줄) 일찍 컷**하는 것. 이 하나가
+두 증상을 모두 설명한다:
+
+1. p44: fragment 짧음 → valign=Center 라벨 중앙이 위로 → **−23pt**
+2. p45: 밀려난 3줄이 p45 최상단에 얹힘 → 이하 전부 아래로 → **+40.8pt 균일**
+
+## 3. 원인 위치 (코드)
+
+- 분할 컷 결정: `src/renderer/pagination/engine.rs::split_table_rows`
+  (약 2318~2720). intra-row 컷은 `split_end_limit = avail_content`
+  (= `avail_for_rows − max_padding_for_row`) 로 fragment 내용 예산을 정하고,
+  이를 내용셀 줄 수(end_cut 유닛)로 환산.
+- `avail_for_rows = page_avail − header_overhead − sb_extra`,
+  `page_avail = table_available_height − current_height − caption_extra − host_extra − v_extra`.
+- 본 표 ci=1 은 `v_offset=4327HU(≈204px)`, 상단 캡션표 ci=0, host 텍스트가 있어
+  예산 차감 항이 여럿 — **과소 예산의 정확한 항(v_offset 중복차감 / caption·host_extra /
+  max_padding / split_end_limit→줄 환산 반올림)은 Stage1 계측으로 특정**.
+
+## 4. 수행 목표
+
+- rhwp RowBreak intra-row 분할 컷을 한글 기준(fragment 를 ~3줄 더 채움)으로 정합.
+- 결과적으로 p44 라벨 −23pt·p45 균일 +40.8pt 동시 해소(단일 축 교정).
+- valign=Center 로직(table_partial.rs)은 **불변** — 증상이 아니라 fragment 예산이 원인.
+
+## 5. 리스크
+
+- **razor-thin 계열**: 분할 예산 상수/항을 건드리면 다른 RowBreak 표의 쪽나눔이
+  ±1줄 이동할 수 있음 → big_hwpx/big_hwp 코퍼스 회귀 게이트 필수.
+- #1809(RowBreak top pad·컷 이월)·#1841(자리차지 표 om 재개)·#1836 과 같은
+  분할/예산 계열과 상호작용 → 통합 베이스에서 검증.
+- 권위 기준: 한글 2024 PDF(fixture 동봉 `pdf/issue1853_..._-2024.pdf`) +
+  저장 vpos 산술. 직전 렌더값으로 핀 재설정 금지.
+
+## 6. 단계 개요 (구현계획서에서 3~6단계로 상세화)
+
+1. **계측·특정**: split_end_limit / avail_for_rows / 각 차감항을 임시 계측하여
+   rhwp 55px 과소의 정확한 항을 확정(한글 20줄 vs rhwp 17줄).
+2. **교정 설계**: 특정된 항만 최소 수정(전면 상수 변경 지양). fixture 컷을
+   line 17→20 으로 이동시키는 조건 도출.
+3. **구현 + fixture 검증**: p44 라벨 Δ→~0, p45 균일오프셋→~0 확인.
+4. **회귀 게이트**: big_hwpx/big_hwp render-diff, 분할표 계열 테스트,
+   #1809/#1841/#1836 불변 확인. 보상 핀 있으면 권위 기준으로 정정.
+5. **최종 보고서 + 오늘할일 갱신**.
+
+---
+
+**승인 요청**: 위 진단(단일 근본원인 = intra-row 분할 예산 과소)과 단계 개요로
+진행해도 될지 확인 부탁드립니다. 승인 후 구현계획서(`task_m100_1860_impl.md`)를
+작성하겠습니다.

--- a/mydocs/plans/task_m100_1860_impl.md
+++ b/mydocs/plans/task_m100_1860_impl.md
@@ -1,0 +1,72 @@
+# 구현 계획서 — Task #1860
+
+**이슈**: #1860 분할(RowBreak) 행 valign=Center 라벨 세로 위치 어긋남
+**브랜치**: `local/task1860` (통합 베이스 `local/prstack-0703`, #1841 워킹트리 유지)
+**수행계획서**: `task_m100_1860.md` (승인·자동승인)
+
+---
+
+## 근본원인 요약 (수행계획서 확정분)
+
+- 증상: p44 라벨 −24.6pt / p45 균일 +40.8pt (반대방향).
+- 진단: **valign 정상**. rhwp 가 row1(공공데이터법 947px 내용셀) RowBreak 분할을
+  한글보다 **~55px(~3줄) 일찍 컷**(rhwp line17 / 한글 line20). 두 엔진 모두 body
+  하단까지 120~180px 여유 → 페이지 용량 아님, **intra-row 분할 예산 과소**.
+- 컷 결정 경로: `pagination/engine.rs::split_table_rows`. PartialTable 은
+  `end_cut=[]` 로 push 되고 실제 유닛 컷은 **layout 시 `content_offset`(높이 예산)**
+  에서 파생. 컷 위치를 정하는 유일 변수 = `split_end_limit`
+  (= `avail_for_rows − max_padding_for_row(r) − cs`).
+- `avail_for_rows = page_avail − header_overhead − sb_extra`,
+  `page_avail = table_available_height − current_height − caption_extra − host_extra − v_extra`.
+  본 표 ci=1: `v_offset=4327HU≈204px`, 상단 캡션표 ci=0, host 텍스트 존재.
+
+## 단계 (5)
+
+### Stage 1 — 계측·과소 항 특정
+- `split_table_rows` 에 env-gated(`RHWP_SPLIT_DBG`) eprintln 임시 추가:
+  para_idx/ctrl_idx, table_available_height, current_height,
+  caption_extra/host_extra/v_extra, header_overhead/sb_extra, avail_for_rows,
+  range_height, max_padding_for_row(1), cs, **split_end_limit**, 그리고 layout
+  이 이 예산으로 실제 컷한 줄 수.
+- 한글 20줄(≈629px 내용) vs rhwp 17줄(≈574px)의 55px 차이가 어느 항에서
+  발생하는지 확정: (a) v_extra 중복차감, (b) caption/host_extra 과다,
+  (c) max_padding 과다, (d) split_end_limit→줄 환산 반올림/여유(MIN_SPLIT/…),
+  (e) layout 컷과 pagination 예산 불일치.
+- **산출물**: `mydocs/tech/task_m100_1860_split_budget.md` (계측표 + 특정 결론).
+  이 결과로 Stage 2 수정 범위 확정. (본 단계는 계측 only, 로직 불변.)
+
+### Stage 2 — 교정 설계
+- 특정된 과소 항만 최소 수정하는 패치 설계. 전면 상수 변경 지양.
+- fixture 컷을 line17→line20 으로 이동시키되, 다른 RowBreak 표 컷을 흔들지 않는
+  조건(가드) 도출. 필요 시 layout 컷과 pagination 예산의 산식 일치화.
+- `table_partial.rs` valign 로직은 **불변** 원칙 유지.
+
+### Stage 3 — 구현 + fixture 검증
+- Stage 2 패치 적용. `RHWP_SPLIT_DBG` 계측 제거.
+- fixture export-pdf → compare_line_baselines p44/p45:
+  - 목표: p44 라벨 Δ −24.6→~0, p45 균일 +40.8→~0(±2pt 이내).
+  - 성공 판정: 공공데이터법·전자정부법 라벨이 한글 y(445.0 / 344.2)에 수렴.
+
+### Stage 4 — 회귀 게이트
+- `cargo test` 전체 + 분할표 계열 테스트(issue_1809/1748/993/1025/474 등) 통과.
+- big_hwpx/big_hwp render-diff 코퍼스: 통합 베이스 대비 회귀 0, 개선 확인.
+  (기준선: rd_big_*_1841 또는 현 통합 재빌드.)
+- #1809/#1841/#1836 불변 확인. 보상 좌표 핀 발생 시 **권위(한글 PDF/저장 vpos)**
+  로만 정정.
+
+### Stage 5 — 보고서
+- `mydocs/report/task_m100_1860_report.md` 최종 보고서.
+- 오늘할일(orders)은 불가침 규칙(`no-touch-mydocs-orders`)으로 미수정.
+- 단계별 커밋: 각 stage 소스+`_stage{N}` 보고서 동반 커밋.
+
+## 검증 기준 (권위)
+
+- 1차: 한글 2024 PDF `pdf/issue1853_caption_precedes_body_split-2024.pdf`
+  (fixture 동봉, merge 커밋 772dc2c7).
+- 보조: 저장 vpos 산술. 직전 렌더값 기반 핀 재설정 금지.
+
+## 리스크·롤백
+
+- 분할 예산은 razor-thin → 코퍼스 게이트 미통과 시 즉시 롤백/조건 정밀화.
+- 단일 표 fixture 개선이 코퍼스 회귀를 유발하면 fixture 특성(v_offset+캡션+host
+  동시 존재) 한정 가드로 좁힘.

--- a/mydocs/report/task_m100_1860_report.md
+++ b/mydocs/report/task_m100_1860_report.md
@@ -1,0 +1,157 @@
+# 최종 결과 보고서 — Task #1860
+
+**이슈**: #1860 분할(RowBreak) 행 valign=Center 라벨 세로 위치 −23~+42pt 어긋남
+**브랜치**: `local/task1860` (통합 베이스 `local/prstack-0703` + #1841 워킹트리)
+**마일스톤**: M100
+**작성일**: 2026-07-03
+
+---
+
+## 1. 요약
+
+78842 유사입법례 표(3×2 RowBreak, PR #1855 fixture)에서 `valign=Center` 라벨
+공공데이터법(−23pt)·전자정부법(+42pt)이 한글 2024 대비 반대방향으로 어긋나던 문제를,
+**분할 예산의 para_start 소실(current_height 이중차감)** 로 규명하고 교정했다.
+
+**valign 로직은 결함이 아니었다** — 라벨은 각 fragment 중앙에 정상 배치되며, fragment
+높이가 잘못(짧게) 계산된 것이 근본. 원인은 #1855 지연 co-anchored 경로가 out-of-flow
+float 의 참 para_start 를 current_height(선행 tac 캡션 포함)로 덮어써, 분할 예산이
+캡션 높이만큼 이중차감되어 RowBreak 컷이 소스 hard_break 보다 3줄 조기 발동한 것.
+
+| 지표 | 수정 전 | 수정 후 | 한글 |
+|------|--------|--------|------|
+| pi=371 page_avail | 795.2px | **860.8px** | (참값 860.8) |
+| RowBreak end_cut | 34 | **36** | ~37 |
+| p44 라벨 공공데이터법 Δ | −24.6pt | **−7.8pt** | 0 |
+| p45 균일 오프셋 | +40.8pt | **+7.2pt** | 0 |
+
+잔여 −7.8/+7.2pt = **1줄 razor**(end_cut 36 vs 소스 hard_break 37, 내용셀 avail
+828.6 vs 필요 828.8, 0.2px). = 내용셀 per-line 미세 과대 누적(#1759/#1760/#1763 계열,
+별개 축) — 본 예산 교정 범위 밖으로 잔존.
+
+## 2. 근본원인
+
+`typeset_block_table`(typeset.rs)의 첫 fragment 분할 예산:
+`page_avail = table_available − current_height − caption − host − vert_offset_overhead`.
+
+빈 host out-of-flow para float(TopAndBottom+vert=Para+v_off>0)은 `para_start + v_off`
+에 앵커되므로(#986/#1088/#157) 예산 기준은 **para_start** 여야 한다. current_height
+기준이면 같은 문단 선행 in-flow inline(tac 캡션)이 이미 흐름을 para_start 위로 밀어놓은
+만큼 이중차감된다.
+
+pi=371 ci=1 은 **#1855 지연 co-anchored 경로**(is_deferred_coanchored_rowbreak_table)
+로 배치되는데, 지연 핸들러(typeset.rs ~10637)가 `para_start_height = st.current_height`
+(=65.5, 선행 캡션 참고|유사입법례 포함)로 **참 para_start(0)를 소실**. → page_avail
+795.2(참값 860.8). 내용셀 avail 763 → 소스 hard_break(unit37, 한컴 저장 분할점) 3줄
+앞(unit34)에서 용량컷 → fragment 3줄 짧음:
+- p44: 짧은 fragment 중앙 → 라벨 −23pt
+- p45: 밀려난 3줄 → 이하 균일 +40.8pt
+
+상세 계측: `mydocs/tech/task_m100_1860_split_budget.md`.
+
+## 3. 수정 내용
+
+`src/renderer/typeset.rs` — **예산 전용 참 para_start** 분리:
+1. `DeferredTableControl` 에 `para_start_height: f64` 필드 추가(원 배치 시점 참값).
+2. `typeset_block_table` 에 예산 전용 `budget_para_start_height` 파라미터 추가.
+   **렌더 위치용 `para_start_height` 는 종전대로 유지**(지연 경로 = 라이브
+   current_height).
+3. 두 호출부: 비지연 → para_start_height, 지연 → deferred.para_start_height.
+4. page_avail: 빈 host out-of-flow float(`is_empty_host_column_float`)만
+   `current_height` 대신 `budget_para_start_height.min(current_height)` 기준으로
+   차감. 선행 inline 없으면 두 값 동일 → 종전 불변(#874 pi=584/242).
+
+**함정 노트(중요) ①**: 지연 핸들러의 `para_start_height` 자체를 참값으로 바꾸면 그 값이
+**렌더 위치**에도 쓰여, 지연 배치 대형 visible-host 표(admrul_1065 pi=0)가 무한
+재배치 루프(render-diff 20분+ 미완)에 빠진다. 반드시 **예산 전용**으로만 분리해야 함.
+
+**함정 노트(중요) ② — current_height 클램프 필수**: 지연 배치가 **페이지/컬럼 경계를
+넘은 뒤** 실행되면 저장된 para_start(원 페이지 흐름 좌표)가 새 페이지에서 무효가 된다.
+CI 회귀(issue_1686, samples/pr-1674 35→36쪽)로 발견: pi=27 빈 host 에 형제 float 표
+2개(ci=0 v_off=0, ci=1 v_off>0) — ci=1 지연 배치가 새 페이지(cur_h=0)에서 stale
+para_start 583.8 을 차감해 예산 −584px → 조기 분할 → +1쪽. 참 para_start 는 현재
+흐름 높이를 초과할 수 없으므로 `min(current_height)` 상한. 클램프 후 pr-1674 hwp/hwpx
+35쪽(오라클 정합) 복원 + fixture −7.8/+7.2pt 유지 + issue_1686 4/4.
+
+`src/renderer/layout/table_partial.rs` — **노드-자식 포섭 불변** (pi=28 회귀 해소):
+5. 예산 교정이 co-anchored 표(pi=28, rowbreak-problem-pages)의 분할점을 이동시켜,
+   분할 조각의 셀 내 as-char 텍스트박스 rect 가 유닛 기반 셀 높이보다 ~15px 아래로
+   그려져 표 노드 bbox 가 자식을 clip(page17). 렌더 완료 후 표 노드 bbox 높이를 모든
+   자손의 최하단까지 확장(확장만, 축소 없음)해 자식 포섭 불변을 보장.
+   - 시도했다 폐기: split-높이 계산(row_cut_content_height) 확장 — 표 노드 높이는
+     유닛 합을 이미 포함(clip 원인은 shape **렌더 배치**), 높이 계산 수정은 무효.
+
+**table_partial.rs valign 로직은 불변** (증상 아님).
+
+## 4. 검증
+
+### 단위/통합 테스트
+- 예산 교정판 `cargo test --release` 전 195 바이너리 **4878 통과 / 0 실패**.
+- 예산+포섭 최종판 `cargo test`(debug) 전 스위트 **통과**(doc-test 까지 exit 0),
+  `issue_rowbreak_chart_overlap` **20/20**(pi=28 회귀 해소), visual_roundtrip_baseline
+  포함 모두 ok.
+- 핵심: svg_snapshot(골든 8), issue_1753_deferred_table_fill_ahead(지연 경로),
+  issue_874(예산 불변 케이스), issue_1748/1156/1488(RowBreak 분할),
+  issue_1073/1133(nested split/valign), issue_1772(om sync) 모두 통과.
+
+### fixture (권위: 한글 2024 PDF)
+- p44 라벨 공공데이터법 −24.6→−7.8pt, p45 +40.8→+7.2pt.
+- pi=117(캡션이 別문단, para_start==current_height) budget 850.1 불변,
+  이전 broad 시도의 51.2px 오버플로 없음(회귀 방지 확인).
+
+### 코퍼스 render-diff (roundtrip 안정성, baseline A/B 클린 비교)
+- **big_hwpx** (2500 doc): 수정 전/후 summary 동일(PASS 2480 / OVER 9 /
+  STRUCT 11 / PAGE_MISMATCH 0 / max_disp 690.33). timing 제외 per-doc diff =
+  **3 doc만 page 수 ±1 변동**(admrul_0326 7→6, seoul_0022 6→5, admrul_0650 134→135)
+  — 전부 PASS·max_disp 0(roundtrip 안정). STRUCT/OVER/PAGE_MISMATCH 회귀 0.
+- **big_hwp** (native, 2500 doc): 최종판 A/B — summary baseline 과 **동일**
+  (PASS 2494 / OVER 4 / STRUCT 2 / PAGE_MISMATCH 0 / max_disp 465.00). timing 제외
+  per-doc diff = **3 doc page ±1**(admrul_0360 9→10, admrul_0527 2→3,
+  admrul_0549 13→14) 전부 PASS·max_disp 0. STRUCT/OVER/PAGE_MISMATCH 회귀 0.
+  admrul_1065 무한루프 해소 확인. 대형표(admrul_1234, baseline ~19분) 저속은
+  선존 성능 이슈로 무관.
+
+> 주: render-diff 는 원본 IR render vs roundtrip render 의 내부 정합(회귀)만 본다.
+> 본 수정은 두 render 를 대칭 변경하므로 roundtrip 지표는 불변이며(=회귀 없음),
+> 3 doc page 수 변동은 예산 교정으로 분할점이 이동한 정상 효과다.
+
+### 성능 함정(무한루프 회피 검증)
+- native 코퍼스 스캔 중 admrul_1065(baseline 12쪽/32s)·admrul_1234(baseline
+  77쪽/**1132s≈19분**)가 초기 fix(지연 렌더 para_start 변경본)에서 무한 재배치
+  루프 발생. **예산 전용 분리 후 admrul_1065 정상**(12쪽 PASS, baseline 동일),
+  admrul_1234 는 else 분기라 불변(baseline 동일 저속). 초대형 표 저속은 선존 성능
+  이슈로 본 타스크 무관.
+
+## 4-b. 회귀 발견 및 해소 — pi=28 텍스트박스 클리핑
+
+`cargo test`(debug) 에서 `rowbreak_page17_split_table_covers_visible_textbox_shape`
+(samples/rowbreak-problem-pages.hwpx, pi=28 ci=0) **1건 실패**.
+
+- pi=28 = pi=371 과 **동일 구조 클래스**(빈 host, 지연 co-anchored, tac ci=1 +
+  float ci=0). 내 예산 교정이 pi=28 예산도 165.2→295.1(+130px)로 키움.
+- 결과: page17 float 조각이 짧아져 셀 내 고정높이 텍스트박스(하단 760.8pt)를
+  조각 하단(749.4pt)이 ~11px 클리핑. baseline(작은 예산)은 우연히 클리핑 회피 →
+  테스트 통과했었음.
+- **권위 대조(pdf/rowbreak-problem-pages-2024.pdf) page17**: 내 fix 본문 텍스트는
+  한글과 정합(max bottom 796.2 vs 799.0, median −3.24pt) — **분할점 자체는 한글
+  충실**. 클리핑은 분할 셀이 내부 고정 shape 를 못 감싸는 별개 엣지.
+
+**해소**: 예산 교정은 pi=28 에도 원칙상 옳다(float 은 para_start+v_off 앵커). 클리핑은
+분할 조각의 셀 노드 bbox 가 자식 shape rect 를 못 감싸던 **선존 렌더 불변 결함**이
+예산 교정으로 표면화된 것 → **노드-자식 포섭 불변**(위 §3.5)으로 해소. 재빌드 후
+`issue_rowbreak_chart_overlap` **20/20 통과**(형제 회귀 0).
+
+## 5. 잔여/후속
+
+- **잔여 1줄 razor(−7.8/+7.2pt)**: 내용셀 per-line 측정 미세 과대 누적으로 end_cut 이
+  소스 hard_break(37) 직전(36)에서 용량컷. #1759/#1760/#1763 계열 별개 축.
+  후속: advance_row_cut 이 임박 hard_break(한컴 저장 분할점)을 소량 tolerance 내에서
+  스냅하도록 하는 게이트 검토(공유 함수라 별도 신중 검증 필요) — 본 타스크 범위 외.
+
+## 6. 파일
+
+- `src/renderer/typeset.rs` (예산 교정)
+- `src/renderer/layout/table_partial.rs` (노드-자식 포섭 불변)
+- `mydocs/plans/task_m100_1860.md`, `_impl.md`
+- `mydocs/tech/task_m100_1860_split_budget.md`
+- `mydocs/report/task_m100_1860_report.md`

--- a/mydocs/tech/task_m100_1860_split_budget.md
+++ b/mydocs/tech/task_m100_1860_split_budget.md
@@ -1,0 +1,93 @@
+# Task #1860 — 분할 예산 계측·근본원인 (Stage 1)
+
+**대상**: #1860 RowBreak valign=Center 라벨 세로 위치 −23/+42pt
+**fixture**: `samples/issue1853_caption_precedes_body_split.hwpx` (PR #1855 merge 772dc2c7)
+**권위**: `pdf/issue1853_caption_precedes_body_split-2024.pdf` (한글 2024)
+
+## 계측 도구
+
+- `RHWP_TABLE_DRIFT=1 rhwp export-pdf …` → `TABLE_SPLIT_AVAIL` (typeset 예산 항, pi 포함)
+- `RHWP_CUT_DBG=1 …` → `CUT_DBG`(advance_row_cut 유닛/avail — pi 미포함, avail 로 대조)
+- `tools/compare_line_baselines.py rhwp.pdf hangul.pdf --page N`
+- `pdf_lines.py`(임시): PDF 줄별 (y,x,text)
+
+## 실측 (pi=371 ci=1, 3×2 RowBreak, p44 첫 fragment)
+
+`TABLE_SPLIT_AVAIL: pi=371 cursor_row=0 cont=false cur_h=65.5 table_avail=918.5`
+`caption=0.0 host_before=0.0 vert_off=57.7 page_avail=795.2 avail_for_rows=795.2`
+
+`CUT_DBG row=1 cell=1 avail=763.0 units=[42 × h=22.4 … unit37=hb …]`
+→ 용량컷 j=34 (34×22.4=761.6 ≈ avail 763) → **end_cut=34**.
+소스 hard_break(한컴 저장 분할점) = unit 37 (≈829px).
+
+- rhwp p44 라벨 공공데이터법 y=422.0pt / 한글 445.0pt (Δ −23.0)
+- 본문 내용 줄은 rhwp/한글 **동일 y**(예 "7.제17조" 428.0/428.2) → 라벨만 어긋남
+- rhwp 마지막 내용줄 y≈697pt, 한글 ≈747pt, body 하단 765.4pt
+  → rhwp 는 하단에 ~68pt(≈91px) 여백을 남기고 컷(용량 미달 아님, **예산이 짧음**)
+
+## 근본원인
+
+`page_avail = table_available − current_height − caption_extra − host_before − vert_offset_overhead`
+(typeset.rs `typeset_block_table`, ~12334). 빈 host out-of-flow para float 은
+`para_start + v_off` 에 앵커되므로(#986/#1088/#157), 분할 예산은 **para_start** 기준이
+맞다. current_height 기준이면 같은 문단의 선행 in-flow inline(tac 캡션)이 이미 흐름을
+para_start 위로 밀어놓은 만큼 이중차감된다.
+
+- 본 표 pi=371: 같은 문단 ci=0 = inline tac 캡션(참고|유사입법례, 65.5px)이 흐름을
+  0→65.5px 전진(current_height=65.5). float ci=1 은 para_start(0)+v_off(57.7)=57.7px
+  에 배치(렌더 측정 header 63.7px body-rel = v_off+outer 로 확인).
+- 그런데 pi=371 ci=1 은 **#1855 지연 co-anchored 경로**(is_deferred_coanchored_
+  rowbreak_table)로 배치되고, 지연 핸들러(typeset.rs ~10637)가
+  `para_start_height = st.current_height`(=65.5) 로 **참 para_start(0)를 덮어씀**.
+  → page_avail = 918.5 − 65.5 − 57.7 = **795.2**(참값 918.5 − 0 − 57.7 = 860.8).
+  ~65px 과소.
+- 내용셀 avail 763 → 용량컷이 소스 hard_break(unit37, 한컴 저장 분할점) 3줄 앞
+  (unit34)에서 발동 → end_cut=34.
+
+이 단일 예산 과소가 두 증상을 모두 설명:
+1. p44 fragment 3줄 짧음 → valign=Center 라벨(정상 로직)이 짧은 fragment 중앙 → −23pt
+2. 밀려난 3줄이 p45 최상단 → 이하 균일 +40.8pt
+
+**valign 로직(table_partial.rs)은 정상 — 원인은 지연 경로의 para_start 소실로 인한
+분할 예산 과소(current_height 이중차감).**
+
+## 교정 (구현 — 예산 전용 참 para_start)
+
+**중요 함정**: 처음엔 지연 핸들러의 `para_start_height` 자체를 참값으로 바꿨으나,
+이 값은 **렌더 위치**(place_table_with_text)에도 쓰여, 지연 배치되는 대형 visible-host
+표(admrul_1065 pi=0 giant table)의 배치가 어긋나 **무한 재배치 루프**를 유발했다
+(render-diff 20분+ 미완). 따라서 렌더 위치는 불변으로 두고 **예산 계산에만** 참
+para_start 를 쓰도록 분리한다.
+
+1. `DeferredTableControl` 에 `para_start_height` 필드 추가 — 원 배치 시점의 참
+   para_start 보존(typeset.rs 154, push).
+2. `typeset_block_table` 에 **예산 전용** `budget_para_start_height: f64` 파라미터 추가.
+   렌더용 `para_start_height` 는 종전대로(지연 경로 = 라이브 current_height) 유지.
+3. 두 호출부: 비지연 → `para_start_height`(그 자체가 참 para_start),
+   지연 → `deferred.para_start_height`(원 배치 시점 참값).
+4. page_avail: 빈 host out-of-flow float(`is_empty_host_column_float`) 만
+   `current_height` 대신 `budget_para_start_height` 기준으로 차감. 선행 inline 없으면
+   두 값이 같아 종전과 동일(#874 pi=584/242 불변). visible-host 표(admrul_1065/1234
+   pi=0/33/35)는 `is_empty_host_column_float=false` → else 분기(불변) → 루프 없음.
+
+## 결과 (계측·권위 대조)
+
+| | 수정 전 | 수정 후 | 한글 |
+|---|---|---|---|
+| pi=371 page_avail | 795.2 | **860.8** | (참값 860.8) |
+| end_cut | 34 | **36** | ~37 |
+| p44 라벨 공공데이터법 Δ | −24.6pt | **−7.8pt** | 0 |
+| p45 균일 오프셋 | +40.8pt | **+7.2pt** | 0 |
+| pi=117 (empty-host, 캡션 別문단) page_avail | 850.1 | 850.1(불변) | — |
+
+- **잔여 −7.8/+7.2pt = 1줄 razor**: end_cut 36 vs 37(소스 hard_break). 내용셀
+  avail 828.6 vs 필요 828.8(0.2px). advance_row_cut 이 hard_break 도달 직전 용량컷.
+  = 내용셀 per-line 측정 미세 과대 누적(#1759/#1760/#1763 계열, 별개 축). 본 예산
+  교정 범위 밖.
+
+## 회귀 관점
+
+- 영향면: 빈 host + out-of-flow para float(TopAndBottom+vert=Para+v_off>0) **且
+  같은 문단 선행 in-flow inline 존재** 표만. 그 외(#874 등 선행 inline 없음)는 불변.
+  검증: pi=117(캡션이 別문단)=budget 불변, 오버플로 미발생.
+- 게이트: cargo test, big_hwpx/big_hwp render-diff, #874/#1022/#1046/#1855.

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -1689,6 +1689,29 @@ impl LayoutEngine {
             ));
         }
 
+        // [Task #1860] 노드-자식 포섭 불변: 분할 표 조각의 셀 내 절대위치 shape
+        // (as-char 텍스트박스/그림 등)가 유닛 기반 셀 높이를 초과해 그려지면 표 노드
+        // bbox 가 자식을 clip 한다(page17 pi=28 텍스트박스 하단 잘림). 렌더 완료 후 모든
+        // 자손의 최하단을 구해 표 노드 높이를 그만큼 확장한다(확장만, 축소 없음).
+        {
+            fn descendant_bottom(node: &RenderNode) -> f64 {
+                let mut b = node.bbox.y + node.bbox.height;
+                for c in &node.children {
+                    b = b.max(descendant_bottom(c));
+                }
+                b
+            }
+            let content_bottom = table_node
+                .children
+                .iter()
+                .map(descendant_bottom)
+                .fold(table_node.bbox.y + table_node.bbox.height, f64::max);
+            let grown = content_bottom - table_node.bbox.y;
+            if grown > table_node.bbox.height {
+                table_node.bbox.height = grown;
+            }
+        }
+
         col_node.children.push(table_node);
 
         // ── 캡션 렌더링 ──

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -156,6 +156,11 @@ struct DeferredTableControl {
     control_index: usize,
     is_first_placed: bool,
     is_last_placed: bool,
+    /// [Task #1860] 이 float 이 속한 문단의 **참 시작 흐름 높이**(선행 형제 control 이
+    /// current_height 를 전진시키기 전). 지연 배치 시점의 current_height 는 이미 선행
+    /// inline(캡션)을 반영해 out-of-flow float 예산을 과소평가하므로, 분할 예산 기준용
+    /// para_start 를 원 배치 시점 값으로 보존한다.
+    para_start_height: f64,
 }
 
 /// 호스트 문단의 spacing (표 전/후)
@@ -10837,6 +10842,11 @@ impl TypesetEngine {
                 mt,
                 styles,
                 para_start_height,
+                // [Task #1860] 예산 전용 참 para_start(원 배치 시점). 지연 배치의
+                // current_height 는 선행 캡션을 이미 반영하므로 out-of-flow float
+                // 예산이 이중차감된다. 렌더 위치(para_start_height)는 불변 유지하고
+                // 예산 계산에만 이 값을 쓴다.
+                deferred.para_start_height,
                 deferred.is_first_placed,
                 deferred.is_last_placed,
                 paragraphs,
@@ -11171,6 +11181,8 @@ impl TypesetEngine {
                             mt,
                             styles,
                             para_start_height,
+                            // [Task #1860] 비지연 경로: para_start_height 가 곧 참 para_start.
+                            para_start_height,
                             is_first_placed,
                             is_last_placed,
                             paragraphs_all,
@@ -11204,6 +11216,8 @@ impl TypesetEngine {
                                                 == Some(next_ctrl_idx),
                                             is_last_placed: last_placed_table
                                                 == Some(next_ctrl_idx),
+                                            // [Task #1860] 원 배치 시점의 참 para_start.
+                                            para_start_height,
                                         }
                                     })
                                 })
@@ -11956,6 +11970,11 @@ impl TypesetEngine {
         mt: Option<&MeasuredTable>,
         styles: &ResolvedStyleSet,
         para_start_height: f64,
+        // [Task #1860] 예산 전용 참 para_start(문단의 참 시작 흐름 높이). 대부분
+        // para_start_height 와 같으나, 지연 co-anchored 배치에선 para_start_height 가
+        // 라이브 current_height(선행 캡션 반영)라 out-of-flow float 예산이 이중차감된다.
+        // 렌더 위치는 para_start_height, 빈-host float 예산만 이 값을 쓴다.
+        budget_para_start_height: f64,
         is_first_placed: bool,
         is_last_placed: bool,
         // [Task #1753] 지연 이월 직전 후속 문단 prefill 용 전체 슬라이스.
@@ -12601,8 +12620,39 @@ impl TypesetEngine {
                     0.0
                 }
             };
+            // [Task #1860] 빈 host out-of-flow para float(비-TAC, TopAndBottom,
+            // vert=Para, v_off>0, host 텍스트 없음)는 para_start + v_off 에 배치되는
+            // 개체다(#986/#1088/#157). 같은 문단의 선행 in-flow inline(예: tac 캡션 표,
+            // #1855 유사입법례 표의 "참고|유사입법례" 캡션)이 current_height 를 전진시켜도,
+            // float 은 para_start 기준에 놓여 세로로 겹치므로 아래로 쓰는 실가용은
+            // para_start 기준이다. page_avail 이 current_height 를 빼면 선행 inline 만큼
+            // 이중차감 → 분할 예산이 짧아져 RowBreak 컷이 소스 hard_break 보다 조기 발동
+            // (공공데이터법 라벨 −23pt / p45 +40.8pt). 이 클래스만 current_height 대신
+            // para_start_height 기준으로 예산을 잡는다.
+            let is_empty_host_column_float = !is_continuation
+                && !table.common.treat_as_char
+                && vert_offset_overhead > 0.0
+                && !para_has_non_whitespace_text(para);
             let page_avail = if is_continuation {
                 table_available
+            } else if is_empty_host_column_float {
+                // out-of-flow float 은 para_start + v_off 에 배치된다(#986/#1088/#157).
+                // 같은 문단의 선행 in-flow inline(예: tac 캡션 표)이 current_height 를
+                // para_start 위로 밀어도, float 은 para_start+v_off 부터 시작해 그 아래를
+                // 전부 쓴다 → 예산 기준은 current_height 가 아니라 참 para_start 다. 선행
+                // inline 이 없으면 budget_para_start==current_height 라 종전과 동일(#874 불변).
+                //
+                // 클램프: 지연(deferred) 배치가 페이지/컬럼 경계를 넘은 뒤 실행되면
+                // 저장된 para_start(원 페이지 흐름 좌표)가 새 페이지의 current_height 보다
+                // 커져 무효가 된다(pr-1674 pi=27 ci=1: 새 페이지 cur_h=0 에서 stale
+                // para_start 583.8 차감 → 예산 −584px → 조기 분할 +1쪽). 참 para_start 는
+                // 현재 흐름 높이를 초과할 수 없으므로 current_height 로 상한한다.
+                (table_available
+                    - budget_para_start_height.min(st.current_height)
+                    - caption_extra
+                    - host_before_overhead
+                    - vert_offset_overhead)
+                    .max(0.0)
             } else {
                 (table_available
                     - st.current_height


### PR DESCRIPTION
## 요약

#1860 수정. 분할(RowBreak) 표에서 `valign=Center` 라벨 셀의 세로 위치가 한글 2024 대비
−23~+42pt 어긋나던 문제(78842 데이터기반행정 이유서 pi=371 유사입법례 표,
PR #1855 리뷰에서 표면화)를 해소한다.

## 근본 원인 — valign 버그가 아님

두 PDF의 본문 내용 줄은 동일 y에 있고(예: "7. 제17조…" rhwp 428.0 / 한글 428.2),
라벨만 어긋난다. valign=Center 로직은 각 fragment 중앙에 정상 배치 중이며,
**fragment 높이(분할 예산)가 잘못**이었다.

- pi=371 ci=1(3×2 RowBreak float)은 #1855의 **지연 co-anchored 경로**로 배치되는데,
  지연 핸들러가 `para_start_height = st.current_height`(선행 inline tac 캡션 65.5px
  포함)로 **참 para_start(0)를 소실**.
- 빈 host out-of-flow float은 `para_start + v_off`에 앵커되므로(#986/#1088/#157)
  분할 예산 기준은 para_start여야 하는데, current_height(캡션 반영)와 v_off를
  **둘 다** 차감해 ~58px 이중차감 → `page_avail` 795.2(참값 860.8).
- 결과: RowBreak 컷이 소스 hard_break(unit 37)보다 3줄 앞(unit 34)에서 용량컷
  → p44 fragment 3줄 짧음(라벨 −23pt) + 밀린 3줄이 p45 최상단(이하 +40.8pt 균일).
  단일 결함이 반대방향 두 증상을 모두 설명.

## 수정

**`src/renderer/typeset.rs`** — 예산 전용 참 para_start 분리:
- `DeferredTableControl.para_start_height` 필드 추가(원 배치 시점 참값 보존).
- `typeset_block_table`에 **예산 전용** `budget_para_start_height` 파라미터 추가.
  렌더 위치용 `para_start_height`는 종전 유지 — 지연 렌더 위치를 바꾸면 대형
  visible-host 지연 표(admrul_1065)가 **무한 재배치 루프**에 빠짐(계측으로 확인).
- `is_empty_host_column_float`(빈 host + TopAndBottom + vert=Para + v_off>0)만
  page_avail 기준을 current_height → budget_para_start_height. 선행 inline이 없으면
  두 값이 같아 종전 동일(#874 pi=584/242 불변).

**`src/renderer/layout/table_partial.rs`** — 노드-자식 포섭 불변:
- 예산 교정이 같은 클래스 표(rowbreak-problem-pages pi=28)의 분할점을 이동시켜,
  분할 조각 셀 내 as-char 텍스트박스 rect가 유닛 기반 셀 높이보다 아래로 그려지는
  **선존 clip 결함**이 표면화됨. 렌더 완료 후 표 노드 bbox를 모든 자손 최하단까지
  확장(확장만, 축소 없음)해 해소.

## 결과 (권위: pdf/issue1853_caption_precedes_body_split-2024.pdf)

| 지표 | 수정 전 | 수정 후 |
|------|--------|--------|
| p44 라벨 공공데이터법 Δ | −24.6pt | **−7.8pt** |
| p45 균일 오프셋 | +40.8pt | **+7.2pt** |
| RowBreak end_cut | 34 | 36 (소스 hard_break 37) |

잔여 −7.8/+7.2pt = 1줄 razor(내용셀 per-line 측정 미세 과대 누적, #1759/#1760/#1763
계열) — 별개 축으로 본 PR 범위 외.

## 검증

- `cargo test` 전 스위트 통과. `issue_rowbreak_chart_overlap` 20/20(pi=28 회귀 해소
  포함), svg 골든 8/8, issue_874/1753/1748/1156/1488/1073/1133/1772 통과.
- **big_hwpx render-diff (2,500)**: roundtrip 지표 불변(PASS 2480/OVER 9/STRUCT 11/
  PAGE 0). per-doc 변화 = page ±1 3건(전부 PASS, max_disp 0).
- **big_hwp render-diff (2,500)**: 동일 불변(PASS 2494/OVER 4/STRUCT 2/PAGE 0).
  per-doc 변화 = page ±1 3건(전부 PASS). admrul_1065 무한루프 없음.

상세: `mydocs/tech/task_m100_1860_split_budget.md`(계측),
`mydocs/report/task_m100_1860_report.md`(최종 보고서).

Closes #1860

🤖 Generated with [Claude Code](https://claude.com/claude-code)
