### PR TITLE
tools: HWPX→HWP roundtrip 페이지네이션 fidelity 하니스 추가

### DIFF
--- a/mydocs/manual/roundtrip_fidelity_harness.md
+++ b/mydocs/manual/roundtrip_fidelity_harness.md
@@ -1,0 +1,63 @@
+# HWPX→HWP roundtrip 페이지네이션 fidelity 하니스
+
+`tools/roundtrip_fidelity_harness.py` + `tools/roundtrip_fidelity_diff.py`.
+
+## 무엇을 측정하나
+
+기존 `hwpx-roundtrip` / `cargo test --test hwpx_roundtrip_baseline` 은 **HWPX→HWPX**
+직렬화의 IR 뼈대·패키지 구조 보존을 검사한다. 본 하니스는 이와 **상보적**으로
+**HWPX→HWP 변환 후 페이지네이션이 원본 HWPX 와 일치하는지**를 측정한다.
+
+각 HWPX 를 `rhwp convert` 로 HWP 로 변환한 뒤, orig-HWPX 와 변환-HWP 의 `dump-pages`
+`(section, pi) → 첫 등장 페이지` 매핑을 대조한다. 불일치는 HWPX↔HWP5 파서/typeset
+경로의 divergence 를 의미한다(예: 빈-앵커 host_line_spacing 소스-의존 억제 계열).
+
+`.hwpx` 옆에 native `.hwp` 가 함께 있으면 실제갭 vs phantom갭 두 인코딩을 같은
+하니스에서 비교할 수 있다(예: `samples/rowbreak-problem-pages.{hwp,hwpx}`).
+
+## 판정
+
+| verdict | 의미 |
+|---|---|
+| SAME | orig-HWPX 와 변환-HWP 의 페이지 수·(sec,pi)→page 완전 일치 |
+| PI_MOVED | 페이지 수 동일하나 일부 (sec,pi) 가 다른 페이지 |
+| PAGE_DELTA | 총 페이지 수가 다름 |
+| ERR | convert/dump 실패 |
+
+종료 코드: `PI_MOVED + PAGE_DELTA > 0` 이면 1.
+
+## 사용
+
+전제: `cargo build --release` (`target/release/rhwp[.exe]` 사용).
+
+```bash
+# 폴더 전수(재귀)
+python tools/roundtrip_fidelity_harness.py --corpus samples/hwpx --workdir /tmp/wd -o out.tsv
+
+# 파일 목록(재현용 코퍼스; 줄당 HWPX 경로, # 주석 허용)
+python tools/roundtrip_fidelity_harness.py --file-list corpus.txt --workdir /tmp/wd -o out.tsv
+
+# 개별 파일
+python tools/roundtrip_fidelity_harness.py --files a.hwpx b.hwpx --workdir /tmp/wd -o out.tsv
+```
+
+산출 TSV 컬럼: `sample / verdict / hwpx_pages / hwp_pages / n_moved / detail`.
+
+## 두 바이너리 비교 (회귀/개선 정량화)
+
+기준 바이너리와 후보 수정 바이너리로 **동일 코퍼스**를 각각 측정한 뒤 전이를 분류한다:
+
+```bash
+# 기준 바이너리로 측정
+python tools/roundtrip_fidelity_harness.py --file-list corpus.txt --workdir /tmp/base -o base.tsv
+# (수정 후 재빌드) 후보 바이너리로 측정
+python tools/roundtrip_fidelity_harness.py --file-list corpus.txt --workdir /tmp/new  -o new.tsv
+# 전이 분류
+python tools/roundtrip_fidelity_diff.py --base base.tsv --new new.tsv -o diff.tsv
+```
+
+`diff.tsv` 분류: `IMPROVED`(회귀 해소) / `REGRESSED`(신규 회귀) / `STILL_MOVED` /
+`STILL_SAME`. `roundtrip_fidelity_diff.py` 는 `REGRESSED` 가 있으면 종료 코드 1.
+
+> 주의: 본 하니스는 **HWPX↔변환HWP 자기정합**(proxy)을 측정하며, 한컴 편집기/PDF 대비
+> 시각 정합(oracle)이 아니다. 시각 판정은 `pdf/`·한컴 편집기 정답지를 사용한다.

--- a/tools/roundtrip_fidelity_diff.py
+++ b/tools/roundtrip_fidelity_diff.py
@@ -1,0 +1,82 @@
+# -*- coding: utf-8 -*-
+"""두 roundtrip fidelity TSV(기준 vs 후보 바이너리)를 대조해 verdict 전이를 분류.
+
+roundtrip_fidelity_harness.py 를 서로 다른 두 바이너리(예: 기준 devel vs 후보 수정본)로
+동일 코퍼스에 실행한 두 TSV 를 sample 기준으로 join 하여, 각 문서의 verdict 전이를
+분류한다. 후보 수정이 roundtrip fidelity 를 개선/회귀시키는지 정량화하는 데 쓴다.
+
+분류(--base=기준, --new=후보):
+  IMPROVED    base=PI_MOVED/PAGE_DELTA → new=SAME  (회귀 해소)
+  REGRESSED   base=SAME → new=PI_MOVED/PAGE_DELTA  (신규 회귀)
+  STILL_MOVED 양쪽 모두 non-SAME (수정 무관 divergence)
+  STILL_SAME  양쪽 모두 SAME
+  ERR_*       한쪽/양쪽 ERR
+
+사용: python tools/roundtrip_fidelity_diff.py --base base.tsv --new candidate.tsv -o diff.tsv
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+from pathlib import Path
+
+
+def load(p: Path) -> dict[str, dict]:
+    rows = {}
+    with open(p, encoding="utf-8", newline="") as fh:
+        for r in csv.DictReader(fh, delimiter="\t"):
+            rows[r["sample"]] = r
+    return rows
+
+
+NONSAME = {"PI_MOVED", "PAGE_DELTA"}
+
+
+def classify(dv: str, nv: str) -> str:
+    if dv == "ERR" or nv == "ERR":
+        return "ERR_BOTH" if dv == nv else ("ERR_BASE" if dv == "ERR" else "ERR_NEW")
+    if dv in NONSAME and nv == "SAME":
+        return "IMPROVED"
+    if dv == "SAME" and nv in NONSAME:
+        return "REGRESSED"
+    if dv in NONSAME and nv in NONSAME:
+        return "STILL_MOVED"
+    return "STILL_SAME"
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--base", "--devel", dest="base", type=Path, required=True,
+                    help="기준 바이너리 TSV")
+    ap.add_argument("--new", type=Path, required=True, help="후보 바이너리 TSV")
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    args = ap.parse_args()
+
+    d, n = load(args.base), load(args.new)
+    keys = sorted(set(d) | set(n))
+    counts: dict[str, int] = {}
+    with open(args.out, "w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["sample", "class", "base_verdict", "new_verdict",
+                    "base_pages", "new_pages", "base_detail", "new_detail"])
+        for k in keys:
+            dr, nr = d.get(k), n.get(k)
+            dv = dr["verdict"] if dr else "MISSING"
+            nv = nr["verdict"] if nr else "MISSING"
+            cls = classify(dv, nv) if dv != "MISSING" and nv != "MISSING" else "MISSING"
+            counts[cls] = counts.get(cls, 0) + 1
+            w.writerow([k, cls, dv, nv,
+                        (dr or {}).get("hwp_pages", ""), (nr or {}).get("hwp_pages", ""),
+                        (dr or {}).get("detail", ""), (nr or {}).get("detail", "")])
+    total = sum(counts.values())
+    print(f"[fidelity-diff] samples={total}")
+    for cls in ["IMPROVED", "REGRESSED", "STILL_MOVED", "STILL_SAME",
+                "ERR_BASE", "ERR_NEW", "ERR_BOTH", "MISSING"]:
+        if counts.get(cls):
+            print(f"  {cls:12s} {counts[cls]}")
+    print(f"  → {args.out}")
+    return 1 if counts.get("REGRESSED") else 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/roundtrip_fidelity_harness.py
+++ b/tools/roundtrip_fidelity_harness.py
@@ -1,0 +1,152 @@
+# -*- coding: utf-8 -*-
+"""HWPX→HWP roundtrip 페이지네이션 fidelity 하니스.
+
+`hwpx-roundtrip`/`hwpx_roundtrip_baseline` 이 검사하는 것은 HWPX→HWPX 의 IR 뼈대
+보존이다. 본 하니스는 이와 상보적으로 **HWPX→HWP 변환 후 페이지네이션이 원본 HWPX 와
+일치하는지**를 측정한다: 임의 HWPX 를 `rhwp convert` 로 HWP 로 변환하고, orig-HWPX 와
+변환-HWP 의 `dump-pages` `(section,pi)→page` 를 대조한다. 불일치(PI_MOVED/PAGE_DELTA)는
+HWPX↔HWP5 파서/typeset 경로 divergence 를 의미한다(예: 빈-앵커 host_line_spacing
+소스-의존 억제 #1836 계열).
+
+동시에 **native HWP** 파일이 함께 있으면 native 렌더 정합(별도 축)을 확인할 수 있다
+(예: rowbreak-problem-pages 의 .hwp/.hwpx 두 인코딩 대조).
+
+용도:
+  1. 후보 수정 바이너리마다 코퍼스에 대해 fidelity 를 측정해 HWPX↔변환HWP divergence
+     회귀를 정량화(두 바이너리 산출 TSV 를 roundtrip_fidelity_diff.py 로 전이 분류).
+  2. native .hwp 와 .hwpx 가 모두 있는 문서에서 실제갭 vs phantom갭을 한 하니스에서 비교.
+
+사용:
+    python tools/roundtrip_fidelity_harness.py --corpus <HWPX폴더> --workdir <작업폴더> -o out.tsv
+    python tools/roundtrip_fidelity_harness.py --files a.hwpx b.hwpx --workdir wd -o out.tsv
+
+산출 TSV: sample / verdict(SAME|PI_MOVED|PAGE_DELTA|ERR) / hwpx_pages / hwp_pages / n_moved / detail
+종료코드: PI_MOVED+PAGE_DELTA > 0 이면 1.
+"""
+from __future__ import annotations
+
+import argparse
+import csv
+import re
+import subprocess
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+RHWP = ROOT / "target" / "release" / ("rhwp.exe" if sys.platform == "win32" else "rhwp")
+PAGE_HDR = re.compile(r"=== 페이지 (\d+) \(global_idx=\d+, section=(\d+), page_num=")
+PI_RE = re.compile(r"\bpi=(\d+)")
+
+
+def dump_pi_pages(path: Path):
+    """dump-pages → ({(section,pi): first_page}, total_pages) 또는 (None, err)."""
+    try:
+        out = subprocess.run(
+            [str(RHWP), "dump-pages", str(path)],
+            capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=180,
+        )
+    except Exception as e:  # noqa: BLE001
+        return None, f"exc:{e}"
+    if out.returncode != 0:
+        return None, "rc"
+    cur_page, cur_sec = 0, 0
+    pages = set()
+    first: dict[tuple[int, int], int] = {}
+    for ln in out.stdout.splitlines():
+        m = PAGE_HDR.search(ln)
+        if m:
+            cur_page = int(m.group(1))
+            cur_sec = int(m.group(2))
+            pages.add(cur_page)
+            continue
+        for q in PI_RE.finditer(ln):
+            key = (cur_sec, int(q.group(1)))
+            if key not in first:
+                first[key] = cur_page
+    if not pages:
+        return None, "nopages"
+    return (first, len(pages)), None
+
+
+def compare(hwpx: Path, hwp: Path):
+    a, ea = dump_pi_pages(hwpx)
+    if ea:
+        return "ERR", "", "", 0, f"hwpx:{ea}"
+    b, eb = dump_pi_pages(hwp)
+    if eb:
+        return "ERR", str(a[1]), "", 0, f"hwp:{eb}"
+    (fa, pa), (fb, pb) = a, b
+    moved = []
+    for key in sorted(set(fa) | set(fb)):
+        if fa.get(key) != fb.get(key):
+            moved.append((key, fa.get(key), fb.get(key)))
+    if not moved and pa == pb:
+        return "SAME", str(pa), str(pb), 0, ""
+    verdict = "PAGE_DELTA" if pa != pb else "PI_MOVED"
+    detail = " ; ".join(f"s{s}:pi{p} {oa}->{ob}" for (s, p), oa, ob in moved[:30])
+    return verdict, str(pa), str(pb), len(moved), detail
+
+
+def main() -> int:
+    ap = argparse.ArgumentParser()
+    g = ap.add_mutually_exclusive_group(required=True)
+    g.add_argument("--corpus", type=Path, help="HWPX 폴더(재귀)")
+    g.add_argument("--files", nargs="+", type=Path)
+    g.add_argument("--file-list", type=Path, help="줄당 HWPX 경로 목록 파일(재현용 코퍼스)")
+    ap.add_argument("--workdir", type=Path, required=True, help="변환 HWP 임시 폴더")
+    ap.add_argument("-o", "--out", type=Path, required=True)
+    ap.add_argument("--limit", type=int, default=0)
+    args = ap.parse_args()
+
+    if not RHWP.exists():
+        print(f"오류: rhwp 바이너리 없음 {RHWP}", file=sys.stderr)
+        return 2
+    if args.corpus:
+        files = sorted(p for p in args.corpus.rglob("*.hwpx"))
+    elif args.file_list:
+        files = [
+            Path(ln.strip())
+            for ln in args.file_list.read_text(encoding="utf-8").splitlines()
+            if ln.strip() and not ln.lstrip().startswith("#")
+        ]
+    else:
+        files = list(args.files)
+    if args.limit and len(files) > args.limit:
+        files = files[: args.limit]
+    args.workdir.mkdir(parents=True, exist_ok=True)
+    args.out.parent.mkdir(parents=True, exist_ok=True)
+
+    n_same = n_moved = n_delta = n_err = 0
+    with open(args.out, "w", encoding="utf-8", newline="") as fh:
+        w = csv.writer(fh, delimiter="\t")
+        w.writerow(["sample", "verdict", "hwpx_pages", "hwp_pages", "n_moved", "detail"])
+        for i, hwpx in enumerate(files):
+            gen = args.workdir / (hwpx.stem + ".gen.hwp")
+            conv = subprocess.run(
+                [str(RHWP), "convert", str(hwpx), str(gen)],
+                capture_output=True, text=True, encoding="utf-8", errors="replace",
+            )
+            if conv.returncode != 0 or not gen.exists():
+                n_err += 1
+                w.writerow([hwpx.name, "ERR", "", "", 0, "convert_fail"])
+                fh.flush()
+                continue
+            verdict, pa, pb, nm, detail = compare(hwpx, gen)
+            w.writerow([hwpx.name, verdict, pa, pb, nm, detail])
+            fh.flush()
+            if verdict == "SAME":
+                n_same += 1
+            elif verdict == "PI_MOVED":
+                n_moved += 1
+            elif verdict == "PAGE_DELTA":
+                n_delta += 1
+            else:
+                n_err += 1
+    print(f"[roundtrip-fidelity] 처리={len(files)}")
+    print(f"  SAME={n_same} PI_MOVED={n_moved} PAGE_DELTA={n_delta} ERR={n_err}")
+    print(f"  → {args.out}")
+    return 1 if (n_moved + n_delta) > 0 else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 개요

`hwpx-roundtrip`(HWPX→HWPX IR 뼈대·패키지 보존)과 **상보적**으로, **HWPX→HWP 변환 후
페이지네이션이 원본 HWPX 와 일치하는지** 측정하는 하니스와 두-바이너리 전이 분류 도구를
추가합니다. 코드 변경 없음(파이썬 도구 + 매뉴얼).

## 무엇을 측정하나

각 HWPX 를 `rhwp convert` 로 HWP 로 변환한 뒤 orig-HWPX 와 변환-HWP 의 `dump-pages`
`(section, pi) → 첫 등장 페이지` 를 대조합니다. 불일치는 HWPX↔HWP5 파서/typeset 경로
divergence 를 의미합니다(예: 빈-앵커 host_line_spacing 소스-의존 억제 계열).

- `SAME` / `PI_MOVED`(페이지 수 동일, pi 이동) / `PAGE_DELTA`(총 페이지 수 상이) / `ERR`
- native `.hwp` 가 함께 있으면 실제갭 vs phantom갭 두 인코딩을 같은 하니스에서 비교
  (예: `samples/rowbreak-problem-pages.{hwp,hwpx}`)

## 구성

- `tools/roundtrip_fidelity_harness.py` — 측정. `--corpus`/`--files`/`--file-list` 입력,
  TSV 산출, `PI_MOVED+PAGE_DELTA>0 → exit 1`.
- `tools/roundtrip_fidelity_diff.py` — 기준 vs 후보 바이너리 두 TSV 전이 분류
  (`IMPROVED`/`REGRESSED`/`STILL_MOVED`/`STILL_SAME`, `REGRESSED>0 → exit 1`).
- `mydocs/manual/roundtrip_fidelity_harness.md` — 사용 가이드.

## 검증

- `python -m py_compile` 통과, `--help` 정상.
- `samples/hwpx` 실행: SAME 정상 산출, diff self-compare STILL_SAME.

## 비고

self-consistency proxy 측정이며 한컴 편집기/PDF 대비 시각 정합(oracle)이 아닙니다
(가이드 명시). 코드 변경이 없어 blast-radius 없음.

🤖 Generated with [Claude Code](https://claude.com/claude-code)