### PR TITLE
task 1655: HWPX 수식 flowWithText 보존

### DIFF
--- a/mydocs/orders/20260705.md
+++ b/mydocs/orders/20260705.md
@@ -1,0 +1,8 @@
+# 오늘 할일 - 2026년 7월 5일
+
+## PR 처리
+
+| PR | 내용 | 처리 |
+|----|------|------|
+| #1911 | #1655 HWPX 수식 `flowWithText` roundtrip 보존 | 옵션 1 self PR 생성. `render_equation`의 `flowWithText="1"` 하드코딩을 제거하고 `Equation.common.flow_with_text`를 방출하도록 수정. 수식 `flowWithText=0` serialize→parse roundtrip 테스트와 `diff_documents` `ObjectFlowWithText` 게이트 테스트 추가. 로컬 검증(`task1655`, `serializer::hwpx`, fmt, diff-check, `clippy --lib`) 통과. renderer/layout 변경이 아니라 visual sweep 대상 아님. review 문서 `mydocs/pr/archives/pr_1911_review*.md`를 PR head에 포함 후 GitHub Actions 대기 |
+

--- a/mydocs/plans/task_m100_1655.md
+++ b/mydocs/plans/task_m100_1655.md
@@ -1,0 +1,40 @@
+# Task M100 #1655 계획서
+
+## 이슈
+
+- GitHub: https://github.com/edwardkim/rhwp/issues/1655
+- 제목: HWPX 수식 flowWithText roundtrip 보존
+- 작성일: 2026-07-05
+
+## 배경
+
+PR #1642에서 표 `hp:pos@flowWithText` 하드코딩은 정정되었지만, 수식(`hp:equation`) 직렬화 경로에는
+아직 `flowWithText="1"` 고정 방출이 남아 있다. HWPX parser는 수식의 `hp:pos@flowWithText`를
+`Equation.common.flow_with_text`로 적재할 수 있으므로, 원본이 `flowWithText="0"`인 경우
+roundtrip 후 값이 `1`로 바뀔 수 있다.
+
+## 목표
+
+1. 수식 직렬화에서 `Equation.common.flow_with_text`를 `hp:pos@flowWithText`로 방출한다.
+2. 수식 `flowWithText=0` roundtrip 회귀 테스트를 추가한다.
+3. `diff_documents`의 수식 비교에도 `ObjectFlowWithText` 게이트를 추가한다.
+4. 관련 focused test와 formatting/clippy 검증으로 회귀를 확인한다.
+
+## 범위
+
+- 대상 파일
+  - `src/serializer/hwpx/section.rs`
+  - `src/serializer/hwpx/mod.rs`
+  - `src/serializer/hwpx/roundtrip.rs`
+- 렌더러, layout, parser 구조 변경은 범위 밖이다.
+- visual sweep은 렌더링 변경이 아니라 HWPX serializer/roundtrip 보존 변경이므로 기본 대상이 아니다.
+
+## 검증 계획
+
+- `cargo fmt --check`
+- `env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx`
+- 필요 시 더 좁은 테스트:
+  - `env CARGO_INCREMENTAL=0 cargo test --lib task1655`
+  - `env CARGO_INCREMENTAL=0 cargo test --lib equation_control_roundtrip_preserves_script`
+- `env CARGO_INCREMENTAL=0 cargo clippy --lib -- -D warnings`
+

--- a/mydocs/pr/archives/pr_1911_review.md
+++ b/mydocs/pr/archives/pr_1911_review.md
@@ -1,0 +1,74 @@
+# PR #1911 Review — task 1655: HWPX 수식 flowWithText 보존
+
+## 메타
+
+| 항목 | 내용 |
+|---|---|
+| PR | https://github.com/edwardkim/rhwp/pull/1911 |
+| 작성자 | `jangster77` |
+| base | `devel` |
+| head | `task_m100_1655_equation_flowwithtext` |
+| 관련 이슈 | https://github.com/edwardkim/rhwp/issues/1655 |
+| 문서 작성 시점 코드 변경 규모 | 5 files, +170/-1 |
+| 문서 작성 시점 참고 SHA | `10556bb2a03c8bdfd2032a479d5dba5fbb4002a0` |
+
+`draft`, `mergeable`, CI 상태는 merge 전 최신 PR head 기준으로 다시 확인한다.
+
+## 관련 이슈 요약
+
+#1655는 HWPX 수식(`hp:equation`)의 `hp:pos@flowWithText`가 roundtrip에서 보존되지 않는 문제를
+다룬다. parser는 이미 `flowWithText`를 `Equation.common.flow_with_text`로 읽을 수 있지만,
+serializer는 수식 경로에서 `flowWithText="1"`을 고정 방출하고 있었다.
+
+## 변경 범위
+
+- `src/serializer/hwpx/section.rs`
+  - `render_equation`에서 `flowWithText="1"` 하드코딩을 제거했다.
+  - 입력 문서에서 읽거나 IR에 설정된 `Equation.common.flow_with_text` 값을 방출한다.
+- `src/serializer/hwpx/mod.rs`
+  - 수식 `flow_with_text=false`가 XML에서 `flowWithText="0"`으로 방출되고 재파싱 뒤에도 보존되는
+    roundtrip 테스트를 추가했다.
+- `src/serializer/hwpx/roundtrip.rs`
+  - `Control::Equation` 비교에서도 기존 `ObjectFlowWithText` 게이트를 재사용한다.
+  - 수식 `flowWithText` 차이가 IR diff에서 검출되는지 테스트를 추가했다.
+- 문서
+  - `mydocs/plans/task_m100_1655.md`
+  - `mydocs/working/task_m100_1655_stage1.md`
+
+## 렌더 영향 및 visual sweep 판정
+
+이 PR은 HWPX serializer/roundtrip 보존 게이트 변경이다. renderer/layout/typeset/paint 경로는 수정하지
+않고, 페이지 수 또는 기준 PDF 대비 시각 정합을 주장하지 않는다.
+
+따라서 visual sweep 대상이 아니다. 검증은 XML 방출값, 재파싱 IR, `diff_documents` 게이트를 중심으로
+수행했다.
+
+## 로컬 검증
+
+```bash
+env CARGO_INCREMENTAL=0 cargo test --lib task1655 -- --nocapture
+cargo fmt --check
+env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx -- --nocapture
+git diff --check
+env CARGO_INCREMENTAL=0 cargo clippy --lib -- -D warnings
+```
+
+결과:
+
+- `task1655` focused test 2개 통과
+- `serializer::hwpx` 범위 275개 통과
+- fmt check 통과
+- diff check 통과
+- `clippy --lib -D warnings` 통과
+
+## 리스크와 범위 밖
+
+- 수식 렌더링 품질이나 수식 파서 문법을 바꾸는 PR이 아니다.
+- HWP5 binary 수식 저장 경로는 변경하지 않는다.
+- `allowOverlap`, `affectLSpacing` 같은 다른 수식 `hp:pos` 속성의 보존은 별도 이슈 범위다.
+
+## 최종 권고
+
+PR head 최신 커밋 기준 GitHub Actions가 통과하면 merge 후보로 판단한다.
+옵션 1 self PR 경로이므로 review 문서와 오늘할일을 PR head에 포함한다.
+

--- a/mydocs/pr/archives/pr_1911_review_impl.md
+++ b/mydocs/pr/archives/pr_1911_review_impl.md
@@ -1,0 +1,40 @@
+# PR #1911 Review Impl — task 1655: HWPX 수식 flowWithText 보존
+
+## Stage 1. 사전 확인
+
+완료.
+
+- #1655는 `OPEN` 상태였고, 같은 범위를 처리하는 열린 PR은 없었다.
+- `Equation.common`은 `CommonObjAttr`를 보유하므로 `flow_with_text`를 표현할 수 있다.
+- HWPX parser는 수식의 `hp:pos@flowWithText`를 `CommonObjAttr.flow_with_text`로 읽는다.
+- serializer의 `render_equation`에는 `flowWithText="1"` 하드코딩이 남아 있었다.
+- roundtrip diff gate는 표의 `flowWithText`만 비교하고 수식 arm에는 누락되어 있었다.
+
+## Stage 2. 구현
+
+완료.
+
+- `render_equation`이 `Equation.common.flow_with_text`를 `flowWithText` 값으로 방출하도록 수정했다.
+- 수식 roundtrip 테스트 `task1655_equation_flow_with_text_roundtrips`를 추가했다.
+- `diff_documents`의 `Control::Equation` arm에 `diff_flow_with_text` 호출을 추가했다.
+- gate 테스트 `task1655_equation_flow_with_text_in_gate`를 추가했다.
+
+## Stage 3. 검증
+
+완료.
+
+- `env CARGO_INCREMENTAL=0 cargo test --lib task1655 -- --nocapture`: 통과, 2 passed
+- `cargo fmt --check`: 통과
+- `env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx -- --nocapture`: 통과, 275 passed
+- `git diff --check`: 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --lib -- -D warnings`: 통과
+
+## Stage 4. merge 전 확인
+
+대기.
+
+- PR head 최신 커밋 기준 GitHub Actions 통과 확인
+- 작업지시자 merge 승인 확인
+- merge 후 #1655 auto-close 여부 확인 및 후속 코멘트 수행
+- merge 후 브랜치 정리
+

--- a/mydocs/working/task_m100_1655_stage1.md
+++ b/mydocs/working/task_m100_1655_stage1.md
@@ -1,0 +1,46 @@
+# Task M100 #1655 Stage 1
+
+## 목적
+
+HWPX 수식(`hp:equation`)의 `hp:pos@flowWithText`가 roundtrip에서 원본 IR 값대로 보존되는지 확인하고,
+하드코딩된 직렬화 경로를 정정한다.
+
+## 사전 확인
+
+- GitHub 이슈 #1655는 `OPEN` 상태였다.
+- 동일 범위를 처리하는 열린 PR은 없었다.
+- parser는 `hp:pos@flowWithText`를 `CommonObjAttr.flow_with_text`로 읽을 수 있다.
+- 모델은 `Equation.common`에 `CommonObjAttr`를 보유한다.
+- serializer는 `render_equation`에서 `flowWithText="1"`을 고정 방출하고 있었다.
+- roundtrip diff gate는 표의 `flowWithText`만 비교하고, 수식 arm에서는 누락되어 있었다.
+
+## 구현 방침
+
+- 수식 serializer는 입력 문서에서 읽은 `Equation.common.flow_with_text`를 그대로 방출한다.
+- diff gate는 기존 `ObjectFlowWithText` 차이 타입을 재사용하되 path만 `eq`로 남긴다.
+- 테스트는 수동 생성 IR에서 `flow_with_text=false` 수식을 만들고, serialize 후 XML 및 reparse 결과가
+  모두 `false`인지 확인한다.
+
+## 구현 결과
+
+- `src/serializer/hwpx/section.rs`
+  - `render_equation`의 `flowWithText="1"` 고정값을 제거하고 `Equation.common.flow_with_text`를 방출한다.
+- `src/serializer/hwpx/mod.rs`
+  - `task1655_equation_flow_with_text_roundtrips` 테스트를 추가했다.
+  - `flow_with_text=false` 수식이 XML에서 `flowWithText="0"`으로 방출되고 재파싱 뒤에도 `false`로 유지되는지 확인한다.
+- `src/serializer/hwpx/roundtrip.rs`
+  - `Control::Equation` 비교에서도 `diff_flow_with_text`를 호출한다.
+  - `task1655_equation_flow_with_text_in_gate` 테스트로 수식 차이가 `ObjectFlowWithText`로 검출되는지 확인한다.
+
+## 검증
+
+- `env CARGO_INCREMENTAL=0 cargo test --lib task1655 -- --nocapture`: 통과, 2 passed
+- `cargo fmt --check`: 통과
+- `env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx -- --nocapture`: 통과, 275 passed
+- `git diff --check`: 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --lib -- -D warnings`: 통과
+
+## 메모
+
+- 변경은 HWPX serializer/roundtrip 게이트에 한정된다.
+- renderer/layout/paint 변경이 아니므로 visual sweep 대상은 아니다.

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -610,6 +610,60 @@ mod tests {
     }
 
     #[test]
+    fn task1655_equation_flow_with_text_roundtrips() {
+        use crate::model::control::{Control, Equation};
+        use crate::model::shape::CommonObjAttr;
+
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "A".to_string();
+        para.char_offsets = vec![0];
+        para.char_count = 9;
+        para.controls.push(Control::Equation(Box::new(Equation {
+            common: CommonObjAttr {
+                width: 1600,
+                height: 900,
+                treat_as_char: true,
+                flow_with_text: false,
+                ..Default::default()
+            },
+            script: "a+b".to_string(),
+            font_size: 1000,
+            ..Default::default()
+        })));
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize equation");
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
+        assert!(
+            xml.contains(r#"flowWithText="0""#),
+            "수식 flowWithText=false 는 0으로 방출되어야 한다: {}",
+            xml
+        );
+        drop(sec0);
+
+        let parsed = parse_hwpx(&bytes).expect("parse back");
+        let parsed_eq = parsed.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|ctrl| match ctrl {
+                Control::Equation(eq) => Some(eq),
+                _ => None,
+            })
+            .expect("equation control");
+        assert!(
+            !parsed_eq.common.flow_with_text,
+            "수식 flowWithText=false 는 재파싱 뒤에도 보존되어야 한다"
+        );
+    }
+
+    #[test]
     fn equation_control_between_text_runs_roundtrips_position() {
         use crate::model::control::{Control, Equation};
         use crate::model::page::ColumnDef;

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1168,6 +1168,15 @@ fn diff_paragraph_char_shapes(
                         detail,
                     });
                 }
+                // [#1655] 수식 flowWithText 보존 게이트.
+                if let Some(detail) = diff_flow_with_text(&ea.common, &eb.common) {
+                    diff.push(IrDifference::ObjectFlowWithText {
+                        section,
+                        paragraph,
+                        path: format!("{path}/ctrl[{ci}]eq"),
+                        detail,
+                    });
+                }
             }
             (Control::Shape(sa), Control::Shape(sb)) => {
                 let p = format!("{path}/ctrl[{ci}]shape");
@@ -2174,6 +2183,25 @@ mod tests {
                 .iter()
                 .any(|d| matches!(d, IrDifference::ObjectFlowWithText { .. })),
             "표 flowWithText 차이는 게이트에서 검출되어야 한다: {:?}",
+            diff.differences
+        );
+    }
+
+    #[test]
+    fn task1655_equation_flow_with_text_in_gate() {
+        // 수식 flowWithText 차이도 diff_documents(게이트)에서 ObjectFlowWithText 로 검출.
+        let mut ea = crate::model::control::Equation::default();
+        ea.common.flow_with_text = false;
+        let mut eb = crate::model::control::Equation::default();
+        eb.common.flow_with_text = true;
+        let a = doc_with_control(crate::model::control::Control::Equation(Box::new(ea)));
+        let b = doc_with_control(crate::model::control::Control::Equation(Box::new(eb)));
+        let diff = diff_documents(&a, &b);
+        assert!(
+            diff.differences
+                .iter()
+                .any(|d| matches!(d, IrDifference::ObjectFlowWithText { .. })),
+            "수식 flowWithText 차이는 게이트에서 검출되어야 한다: {:?}",
             diff.differences
         );
     }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1723,6 +1723,7 @@ fn render_equation(eq: &Equation) -> String {
     let width = c.width.to_string();
     let height = c.height.to_string();
     let treat = if c.treat_as_char { "1" } else { "0" };
+    let flow_with_text = if c.flow_with_text { "1" } else { "0" };
     let vert_offset = c.vertical_offset.to_string();
     let horz_offset = c.horizontal_offset.to_string();
     let margin_left = c.margin.left.to_string();
@@ -1744,7 +1745,7 @@ fn render_equation(eq: &Equation) -> String {
     let hold = if c.prevent_page_break != 0 { "1" } else { "0" };
 
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         vert_rel_to_hwpx(c.vert_rel_to),
         horz_rel_to_hwpx(c.horz_rel_to),


### PR DESCRIPTION
## 요약

- HWPX 수식 serializer의 `flowWithText="1"` 하드코딩을 제거하고 `Equation.common.flow_with_text`를 방출합니다.
- 수식 `flowWithText=0` roundtrip 회귀 테스트를 추가했습니다.
- `diff_documents`의 수식 비교에도 `ObjectFlowWithText` 게이트를 추가했습니다.
- 옵션 1 self PR 경로로 review 문서와 오늘할일을 PR head에 포함했습니다.

## 검증

- `env CARGO_INCREMENTAL=0 cargo test --lib task1655 -- --nocapture`
- `cargo fmt --check`
- `env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx -- --nocapture`
- `git diff --check`
- `env CARGO_INCREMENTAL=0 cargo clippy --lib -- -D warnings`

## Review 문서

- `mydocs/pr/archives/pr_1911_review.md`
- `mydocs/pr/archives/pr_1911_review_impl.md`
- `mydocs/orders/20260705.md`

Closes #1655
