### PR TITLE
Issue #1898: tac 그림 문단 뒤 lazy vpos 재역산의 trailing_ls 이중 가산 수정

### DIFF
--- a/src/renderer/height_cursor.rs
+++ b/src/renderer/height_cursor.rs
@@ -230,7 +230,32 @@ impl HeightCursor {
                 .text
                 .chars()
                 .any(|c| c > '\u{001F}' && c != '\u{FFFC}');
-            let vpos_continuous = matches!(curr_first_vpos, Some(v) if v <= prev_vpos_end);
+            // [Issue #1898] 직전 문단이 "실텍스트 + 인라인(tac) 그림 호스트" 이면, 저장
+            // vpos gap 이 현재 문단 spacing_before 이하일 때 연속으로 본다. 이 gap 은 sb
+            // 인코딩이며 sb 는 vpos_corrected_end_y 가 별도로 사전 차감하므로 이미 계상된
+            // 정상 전진이다. tac 그림 PageItem 이 vpos base 를 리셋한 직후 이 gap 을
+            // 불연속으로 오판해 +trailing_ls bridge 를 더하면 그림 문단 뒤 줄 전진이
+            // gap 1회분(+11.7px) 과대해진다 (36388711 p9 참고자료: 렌더 44.8px vs
+            // layout/한컴 33.1px — 기전 1). 시그니처를 tac 그림 텍스트 호스트 직후로
+            // 한정해 일반 lazy 재역산의 bridge 는 종전 유지 (rowbreak-problem-pages
+            // 쪽나눔 무회귀). HWP3-origin 변환본(sb 사전 차감 생략 경로)도 종전 유지.
+            let prev_is_tac_picture_text_host = prev_has_text
+                && prev_para
+                    .controls
+                    .iter()
+                    .any(|c| matches!(c, Control::Picture(p) if p.common.treat_as_char));
+            let curr_sb_hu = if self.skip_spacing_before_prededuct || !prev_is_tac_picture_text_host
+            {
+                0
+            } else {
+                paragraphs
+                    .get(item_para)
+                    .and_then(|p| styles.para_styles.get(p.para_shape_id as usize))
+                    .map(|ps| ((ps.spacing_before * 7200.0 / self.dpi).round() as i32).max(0))
+                    .unwrap_or(0)
+            };
+            let vpos_continuous =
+                matches!(curr_first_vpos, Some(v) if v <= prev_vpos_end + curr_sb_hu);
             let trailing_ls_hu = if vpos_continuous && prev_has_text {
                 0
             } else {

--- a/tests/issue_1898_tac_image_line_advance.rs
+++ b/tests/issue_1898_tac_image_line_advance.rs
@@ -46,10 +46,11 @@ fn first_text_line_y(node: &RenderNode, pi: usize) -> Option<f64> {
 #[test]
 fn tac_image_paragraph_render_advance_matches_layout() {
     let tree = page_tree(8); // p9 (0-based)
+
     // (그림 문단 pi, 다음 문단 pi). 기대 전진 = lh(14.67) + ls(11.73) + sb(6.67) = 33.1px.
     for (img_pi, next_pi) in [(87usize, 88usize), (95, 96), (96, 97)] {
-        let y_img = first_text_line_y(&tree.root, img_pi)
-            .unwrap_or_else(|| panic!("pi={img_pi} TextLine"));
+        let y_img =
+            first_text_line_y(&tree.root, img_pi).unwrap_or_else(|| panic!("pi={img_pi} TextLine"));
         let y_next = first_text_line_y(&tree.root, next_pi)
             .unwrap_or_else(|| panic!("pi={next_pi} TextLine"));
         let advance = y_next - y_img;

--- a/tests/issue_1898_tac_image_line_advance.rs
+++ b/tests/issue_1898_tac_image_line_advance.rs
@@ -1,0 +1,70 @@
+//! Issue #1898 기전 1: tac(글자처럼) 인라인 그림 문단의 렌더 줄 전진 과대 회귀 가드.
+//!
+//! tac 그림의 PageItem::Shape 처리가 vpos base 를 리셋한 뒤, 다음 문단의 lazy_base
+//! 재역산에서 spacing_before 가 저장 vpos 에 인코딩된 gap(=sb)을 불연속으로 오판해
+//! +trailing_ls bridge 를 이중 가산 — 그림 문단 뒤 줄 전진이 44.8px 로 layout(33.1px)
+//! ·한컴 오라클(32.9px) 대비 line gap 1회분(+11.7px) 과대해졌다.
+//!
+//! fixture: `samples/hwpx/opengov/36388711_...hwpx` p9 — 2.5mm tac 불릿 그림 문단
+//! (pi=87/95/96/97, ps line=180%). 오라클: 한글 2022 PDF (mutool stext) 라인 pitch
+//! 24.7pt(32.9px) 균일 — 그림 유무와 무관.
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use std::fs;
+use std::path::Path;
+
+const SAMPLE: &str =
+    "samples/hwpx/opengov/36388711_사회보장제도 신설 협의요청서(청년오피스)_260624.hwpx";
+
+fn page_tree(page: u32) -> rhwp::renderer::render_tree::PageRenderTree {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = fs::read(&p).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+    let doc =
+        rhwp::wasm_api::HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse: {e:?}"));
+    doc.build_page_render_tree(page)
+        .unwrap_or_else(|e| panic!("render p{}: {e}", page + 1))
+}
+
+/// pi 의 첫 TextLine y (본문 단 직속 — 셀 내부 pi 충돌 방지를 위해 Table 하위는 제외).
+fn first_text_line_y(node: &RenderNode, pi: usize) -> Option<f64> {
+    if matches!(node.node_type, RenderNodeType::Table(_)) {
+        return None;
+    }
+    if let RenderNodeType::TextLine(tl) = &node.node_type {
+        if tl.para_index == Some(pi) {
+            return Some(node.bbox.y);
+        }
+    }
+    node.children
+        .iter()
+        .filter_map(|c| first_text_line_y(c, pi))
+        .fold(None, |acc, y| Some(acc.map_or(y, |a: f64| a.min(y))))
+}
+
+/// tac 그림 문단(pi=87/95/96) 다음 줄까지의 렌더 전진이 layout 전진(33.1px)과 일치.
+/// 수정 전에는 세 곳 모두 44.8px(+line gap 1회분)로 확실히 구분된다.
+#[test]
+fn tac_image_paragraph_render_advance_matches_layout() {
+    let tree = page_tree(8); // p9 (0-based)
+    // (그림 문단 pi, 다음 문단 pi). 기대 전진 = lh(14.67) + ls(11.73) + sb(6.67) = 33.1px.
+    for (img_pi, next_pi) in [(87usize, 88usize), (95, 96), (96, 97)] {
+        let y_img = first_text_line_y(&tree.root, img_pi)
+            .unwrap_or_else(|| panic!("pi={img_pi} TextLine"));
+        let y_next = first_text_line_y(&tree.root, next_pi)
+            .unwrap_or_else(|| panic!("pi={next_pi} TextLine"));
+        let advance = y_next - y_img;
+        assert!(
+            (advance - 33.1).abs() <= 3.0,
+            "#1898: tac 그림 문단 pi={img_pi} → pi={next_pi} 렌더 전진 {advance:.1}px \
+             (기대 33.1±3) — trailing_ls bridge 이중 가산(+11.7px) 회귀",
+        );
+    }
+    // 대조군: 그림 없는 pi=93(빈) → pi=94 는 수정 전에도 정상(26.4px, sb=0).
+    let y93 = first_text_line_y(&tree.root, 93).expect("pi=93");
+    let y94 = first_text_line_y(&tree.root, 94).expect("pi=94");
+    assert!(
+        ((y94 - y93) - 26.4).abs() <= 3.0,
+        "#1898 대조군: pi=93→94 전진 {:.1}px (기대 26.4±3)",
+        y94 - y93,
+    );
+}


### PR DESCRIPTION
## 개요

#1898 기전 1 — tac(글자처럼) 인라인 그림 문단 뒤 렌더 줄 전진이 layout·한컴 대비
**line gap 1회분(+11.7px) 과대**해지는 렌더-레이아웃 자기 불일치 수정.

## 근본 원인

1. tac 그림의 `PageItem::Shape` 처리 후 렌더러가 vpos base 를 리셋 (layout.rs
   표/Shape 공통 무효화 경로).
2. 다음 문단에서 `HeightCursor::vpos_adjust` 가 lazy_base 를 재역산할 때,
   현재 문단 **spacing_before 가 저장 vpos 에 인코딩된 gap(=sb, 500HU)** 을
   `vpos_continuous`(gap==0 요건) 실패로 불연속 오판 → **+trailing_ls(880HU)
   bridge 를 base 에 이중 가산**.
3. 결과: 그림 문단 뒤 줄 전진 44.8px = layout(33.1px) + gap 1회분. 검산:
   `end_y = col_y + (53802−10420)/75 − 6.67 = 696.46` = 관측값 재현.

sb 는 `vpos_corrected_end_y` 가 별도 사전 차감하므로 gap=sb 는 이미 계상된
정상 전진이다.

## 수정

`height_cursor.rs`: **직전 문단이 실텍스트 + tac 그림 호스트인 경우에 한해**
gap ≤ 현재 문단 spacing_before 를 연속으로 판정해 bridge 를 생략.

- 시그니처를 한정하지 않은 1차 접근(모든 lazy 재역산에 sb 허용)은
  `issue_rowbreak_chart_overlap` 쪽나눔 2건을 회귀시켜 **반증** → tac 그림
  텍스트 호스트 직후로 좁혀 무회귀 확인 (일반 재역산의 bridge 종전 유지).
- HWP3-origin 변환본(parser 가 vpos 에서 sb 기분리, 사전 차감 생략 경로)은
  종전 판정 유지.

## 검증 (PR #1894 적용 상태)

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| 36388711 p9 그림 문단 뒤 전진 (pi=87/95/96) | 44.8px | **33.1px** (layout 33.1 · 한컴 32.9) |
| 36388711 쪽수 | 9 | 9 (불변) |
| opengov 코퍼스 21건 쪽수 | — | 20건 한컴 오라클 정합, 1건(36385445)은 #1733 계열 기왕증 |

- 신규 게이트 `tests/issue_1898_tac_image_line_advance.rs` — 세 전이 33.1±3px
  (수정 전 44.8px 로 확실히 구분) + 무그림 대조군.
- `issue_rowbreak_chart_overlap` 20/20, `issue_1858` 게이트 통과.
- 전체 스위트 **2,851 통과** (잔여 5건 = svg_snapshot CRLF 로컬 노이즈,
  줄바꿈 정규화 시 내용 diff 0 확인).

## 재현

```bash
rhwp export-render-tree "samples/hwpx/opengov/36388711_...hwpx" -p 8
# TextLine pi=95→96→97 y 간격: 수정 전 44.8px, 수정 후 33.1px
rhwp dump-pages "samples/hwpx/opengov/36388711_...hwpx" -p 8   # layout 은 양쪽 33.1px
mutool draw -F stext -o o.xml <한글2022 오라클 PDF> 9          # 한컴 32.9px 균일
```

기전 2(누적 적재 드리프트, p8/p9 경계 5줄 상이)는 #1759 계열로 이슈에 측정만
기록 — 본 PR 범위 밖.

closes #1898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
