### PR TITLE
Task #1898: tac 인라인 그림 문단 렌더 줄 전진 +11.7px 수정 — vpos 기준점 초기화 예외

### DIFF
--- a/mydocs/plans/task_m100_1898.md
+++ b/mydocs/plans/task_m100_1898.md
@@ -1,0 +1,36 @@
+# 수행 계획서 — Task M100 #1898
+
+## 개요
+
+- **이슈**: [#1898 tac 인라인 그림 문단 렌더 줄 전진 +11.7px(gap 이중 가산) — 36388711 아웃라이어 기전 (#1858 분리)](https://github.com/edwardkim/rhwp/issues/1898)
+- **브랜치**: `pr/devel-1898` (origin/devel 054be69c 기반)
+- **범위**: 기전 1 (렌더-레이아웃 자기 불일치)만. 기전 2 (p8/p9 누적 적재
+  드리프트, #1759/#1763 계열)는 이슈에 측정 기록만 유지.
+
+## 조사 계획
+
+1. 재현: `export-svg -p 8` 글리프 y 실측 → +44.8px/줄 (layout 33.1, 한컴 32.9)
+2. 계측 훅 정비: `RHWP_DEBUG_PARA_TAC`(pi 하드코딩 → 콤마 목록),
+   `RHWP_DEBUG_TAC_CURSOR` 로 항목별 y 추적
+3. 과대 전진 주입 지점 특정 → 최소 수정
+4. 회귀 게이트: 스위트 + big_hwp/big_hwpx A/B
+
+## 판별 결과
+
+- 문단 내부 줄 전진은 정상 (TAC_ADV: lh=14.7 ls=11.7 label_extra=0).
+- +11.7 은 **항목 사이**에서 주입: tac 그림의 `PageItem::Shape`(dy=0)가
+  `layout_column_item` 뒤 vpos 기준점(page/lazy base)을 무조건 초기화 →
+  다음 문단의 `HeightCursor::vpos_adjust` 가 lazy_base 재산출에서 trailing-ls
+  bridge(#1022 v2)를 다시 적용 → 그림 문단마다 렌더 y +줄간격 1회분.
+- 반례 (1차 수정의 회귀): sample16 pi=71 은 **텍스트 없는 tac-전용 문단**
+  (LINE_SEG lh=9764 = 개체 높이 130px 박스) — 이 경우 lh 가 개체 높이를
+  포함하므로 기준점 초기화가 맞다 (issue_1116 한컴 핀 2건이 검출).
+- 판별 기준 = **호스트 문단의 실제 텍스트 보유 여부**: 텍스트 줄에 통합된
+  tac 개체(36388711 불릿)만 초기화 면제, tac-전용 문단(sample16 박스)은 종전 유지.
+
+## 산출물
+
+- 수정: `src/renderer/layout.rs` (초기화 예외), `src/renderer/layout/paragraph_layout.rs`
+  (RHWP_DEBUG_PARA_TAC pi 목록화 — 계측 개선)
+- 테스트: `tests/issue_1898.rs` (p9 TextLine 간격 33.1px 핀)
+- 보고서: `mydocs/report/task_m100_1898_report.md`

--- a/mydocs/plans/task_m100_1898_impl.md
+++ b/mydocs/plans/task_m100_1898_impl.md
@@ -1,0 +1,42 @@
+# 구현 계획서 — Task M100 #1898 (기전 1)
+
+## 근본 원인
+
+`layout.rs` 의 항목 후처리(#409/#1027 계열)가 `PageItem::Shape` 전부에 대해
+vpos 기준점(page/lazy base)을 초기화한다. 근거는 "표/Shape 의 LINE_SEG lh 는
+개체 높이를 포함해 순차 y 와 drift" — 이는 **tac-전용 문단**(빈 텍스트,
+lh=개체 높이)에는 맞지만, **텍스트 줄에 통합된 tac 개체**(불릿 그림)에는
+성립하지 않는다(호스트 LINE_SEG 는 텍스트 줄 높이, Shape 항목 dy=0).
+
+초기화되면 다음 문단의 `HeightCursor::vpos_adjust` 가 base 부재 → lazy_base
+재산출 경로 진입 → 직전 문단과 vpos 가 불연속(spacing_before 500HU 갭)이므로
+trailing-ls bridge(+880HU=11.7px) 적용 → 불릿 문단마다 렌더 y 과대 전진.
+문서 전반에 불릿이 많아 페이지 내 누적 밀림(참고자료 리스트 +44.8px/줄)이 커진다.
+
+## 수정
+
+`layout.rs` 초기화 조건에 예외 추가:
+
+```
+is_inline_tac_object = PageItem::Shape 이고
+  호스트 문단이 실제 텍스트 보유(para_has_visible_text)
+  ∧ 해당 컨트롤(Picture/Shape/Equation)의 treat_as_char=true
+→ 기준점 초기화 생략
+```
+
+- 기존 예외(Para-float 표)와 같은 구조로 병렬 배치.
+- tac-전용 문단(sample16 pi=71 RFP 박스)은 텍스트 부재로 예외 미적용 —
+  issue_1116 한컴 핀 2건 보존 (1차 blanket 면제안이 이 핀에서 −8.5px 회귀,
+  텍스트 보유 조건으로 정제).
+
+## 계측 개선 (동반)
+
+`RHWP_DEBUG_PARA_TAC` 의 대상 pi 가 651/652 하드코딩이던 것을 콤마 목록
+환경변수 값으로 일반화 (빈 값/`all` = 전체).
+
+## 검증 계획
+
+- 36388711 p9: TextLine 간격 44.8 → 33.1px (한컴 32.9) + 핀 테스트
+- issue_1116 (sample16 한컴 핀) 13/13
+- cargo test 전 스위트
+- big_hwp/big_hwpx 2,500×2 A/B (origin/devel 054be69c 베이스 exe)

--- a/mydocs/report/task_m100_1898_report.md
+++ b/mydocs/report/task_m100_1898_report.md
@@ -1,0 +1,62 @@
+# 최종 결과보고서 — Task M100 #1898 (기전 1)
+
+## 이슈
+
+[#1898 tac 인라인 그림 문단 렌더 줄 전진 +11.7px(gap 이중 가산) — 36388711 아웃라이어 기전 (#1858 분리)](https://github.com/edwardkim/rhwp/issues/1898)
+
+## 요약
+
+36388711 p9 불릿(tac 인라인 그림) 문단의 렌더 줄 전진이 layout 대비 +11.7px
+(= 줄간격 1회분) 과대하던 렌더-레이아웃 자기 불일치를 수정했다. 원인은 이슈가
+추정한 "렌더러의 그림 라인 전진량 gap 이중 가산"이 아니라, **tac 그림의
+`PageItem::Shape` 항목이 vpos 기준점을 초기화 → 다음 문단 `vpos_adjust` 의
+lazy_base 재산출이 trailing-ls bridge 를 재적용**하는 항목-간 주입이었다.
+수정 후 p9 리스트 간격 44.8 → 33.1px (layout 33.1 / 한컴 오라클 32.9 정합).
+
+## 진단 경로
+
+1. `TAC_ADV` 트레이스 (`RHWP_DEBUG_PARA_TAC` — 이번에 pi 하드코딩을 콤마 목록
+   env 로 일반화): 문단 내부 줄 전진은 정상 (lh=14.7 ls=11.7 label_extra=0).
+2. `TAC_CURSOR` 트레이스 (`RHWP_DEBUG_TAC_CURSOR`): FullPara pi=95 dy=33.1 정상,
+   **Shape pi=95 ci=0 dy=0.0 인데 다음 항목 y_in 이 +11.7** — 주입은 항목 사이.
+3. `layout.rs` 항목 후처리: `PageItem::Shape` 전부에 대해 vpos 기준점
+   (page/lazy base) 초기화 (#409/#1027 — "표/Shape 의 LINE_SEG lh 는 개체 높이를
+   포함해 drift" 근거). 초기화 후 다음 문단의 `HeightCursor::vpos_adjust` 가
+   base 재산출 경로에서 vpos 불연속(spacing_before 500HU 갭) + trailing-ls
+   bridge(#1022 v2) → +880HU(11.7px).
+
+## 수정과 판별 기준
+
+`layout.rs` 초기화 조건에 예외: **실제 텍스트 줄에 통합된 tac 개체**
+(호스트 문단 `para_has_visible_text` ∧ 컨트롤 treat_as_char)의 Shape 항목은
+기준점을 초기화하지 않는다 — 호스트 LINE_SEG 는 텍스트 줄 높이이고 Shape
+항목은 dy=0 이라 drift 근거가 성립하지 않는다.
+
+**반례가 판별 기준을 정제했다**: 1차 blanket 면제(모든 tac Shape)는
+sample16 pi=71 — **텍스트 없는 tac-전용 문단**(LINE_SEG lh=9764 = 34.4mm 박스
+높이) — 에서 한컴 핀 2건(issue_1116)을 −8.5px 로 깨뜨렸다. tac-전용 문단은
+lh 가 개체 높이를 포함하므로 종전 초기화가 맞다. 최종 기준 = 텍스트 보유 여부.
+
+## 검증
+
+- 36388711 p9: 불릿 리스트 TextLine 간격 **44.8 → 33.1px** (layout 33.1,
+  한컴 2022 오라클 32.9 — `output/poc/task1858_oracle/36388711_hancom2022.pdf`)
+- 핀: `tests/issue_1898.rs` (p9 pi=95/96/97 간격 33.1±1.5px)
+- issue_1116 (sample16 한컴 핀) 13/13 — tac-전용 문단 경로 불변 확인
+- cargo test 전 스위트 (195 바이너리) PASS
+- big_hwp 2,500 A/B (origin/devel 054be69c 베이스): **완전 동일** (PASS 2495/OVER 5)
+- big_hwpx 2,500 A/B: **완전 동일** (PASS 2483/STRUCT 9/OVER 8, 파일별 diff 0)
+  — 자기 라운드트립은 본 수정에 대칭이므로 예상 결과이며, 시각 정답 검증은
+  한컴 오라클(36388711)·한컴 핀(issue_1116)이 담당.
+
+## 범위 외 (이슈 기전 2)
+
+p8/p9 누적 적재 드리프트(저장 lineseg 분할점 vs rhwp 적재 +158.3px)는
+#1759/#1763 계열 per-line 적재 축 — 이슈에 측정 기록 유지, 본 수정과 무관.
+
+## 산출물
+
+- 수정: `src/renderer/layout.rs` (tac 인라인 개체 기준점 초기화 예외),
+  `src/renderer/layout/paragraph_layout.rs` (RHWP_DEBUG_PARA_TAC pi 목록화)
+- 테스트: `tests/issue_1898.rs`
+- 문서: plans/task_m100_1898.md, plans/task_m100_1898_impl.md, 본 보고서

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -4566,7 +4566,38 @@ impl LayoutEngine {
             } else {
                 false
             };
-            if was_tac || (is_table_or_shape && !is_para_float_table) {
+            // 예외 2 (#1898): 실제 텍스트 줄에 통합된 글자처럼(tac) 인라인 개체의
+            // Shape 항목은 흐름에 독립 높이를 만들지 않는다(호스트 LINE_SEG 는 텍스트
+            // 줄 높이, 본 항목 dy=0). 기준점을 초기화하면 다음 문단 vpos_adjust 가
+            // lazy_base 재산출에서 trailing-ls bridge 를 다시 적용해, 불릿 그림 문단
+            // 마다 렌더 y 가 줄간격 1회분씩 과대 전진한다 (36388711 p9: layout
+            // 33.1px vs 렌더 44.8px, 한컴 32.9px). 단, 텍스트 없는 tac-전용 문단
+            // (LINE_SEG lh = 개체 높이, sample16 pi=71 RFP 박스)은 종전대로 초기화 —
+            // 그 lh 는 개체 높이를 포함해 vpos 누적과 순차 y 의 drift 근거가 맞다.
+            let is_inline_tac_object = if let PageItem::Shape {
+                para_index,
+                control_index,
+            } = item
+            {
+                paragraphs
+                    .get(*para_index)
+                    .map(|p| {
+                        para_has_visible_text(p)
+                            && p.controls
+                                .get(*control_index)
+                                .map(|c| match c {
+                                    Control::Picture(pic) => pic.common.treat_as_char,
+                                    Control::Shape(shape) => shape.common().treat_as_char,
+                                    Control::Equation(eq) => eq.common.treat_as_char,
+                                    _ => false,
+                                })
+                                .unwrap_or(false)
+                    })
+                    .unwrap_or(false)
+            } else {
+                false
+            };
+            if was_tac || (is_table_or_shape && !is_para_float_table && !is_inline_tac_object) {
                 hcursor.vpos_page_base = None;
                 hcursor.vpos_lazy_base = None;
             }

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -5055,9 +5055,12 @@ impl LayoutEngine {
             let skip_advance_empty_line = skip_advance_empty_wrap
                 || skip_advance_empty_tac_picture
                 || skip_advance_empty_tac_lead;
-            if std::env::var("RHWP_DEBUG_PARA_TAC").is_ok()
-                && (para_index == 651 || para_index == 652)
-            {
+            // RHWP_DEBUG_PARA_TAC="95,96,97" — 대상 pi 를 콤마 목록으로 지정 (빈 값/all=전체).
+            if std::env::var("RHWP_DEBUG_PARA_TAC").is_ok_and(|v| {
+                v.is_empty()
+                    || v == "all"
+                    || v.split(',').any(|t| t.trim().parse() == Ok(para_index))
+            }) {
                 eprintln!(
                     "  TAC_ADV pi={} line_idx={} y={:.1} raw_lh={:.1} lh={:.1} ls={:.1} label_extra={:.1} whitespace={} cur_pic={:?} prev_pic={:?} skip_wrap={} skip_pic={} skip={}",
                     para_index,

--- a/tests/issue_1898.rs
+++ b/tests/issue_1898.rs
@@ -1,0 +1,62 @@
+//! Issue #1898 기전 1 — tac(글자처럼) 인라인 그림 문단의 렌더 줄 전진 과대.
+//!
+//! 36388711 p9 의 불릿(▷) 리스트는 각 문단이 2.5mm tac 그림을 갖는다. 종전에는
+//! tac 그림의 Shape 페이지 항목이 vpos 기준점(page/lazy base)을 초기화해, 다음
+//! 문단의 vpos_adjust 가 lazy_base 재산출에서 trailing-ls bridge 를 다시 적용
+//! → 그림 문단마다 렌더 y 가 줄간격 1회분(+11.7px) 과대 전진했다
+//! (layout 33.1px/줄 vs 렌더 44.8px/줄; 한컴 오라클 32.9px — layout 이 정답).
+//! tac 개체는 호스트 LINE_SEG 에 통합되어 흐름에 독립 높이를 만들지 않으므로
+//! 기준점을 초기화하지 않는다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+const SAMPLE: &str =
+    "samples/hwpx/opengov/36388711_사회보장제도 신설 협의요청서(청년오피스)_260624.hwpx";
+
+/// p9 (0-based 8) 의 pi=95/96/97 참고자료 리스트: TextLine 간 y 간격이 layout
+/// (lh+ls+sb = 33.1px)과 일치해야 한다. 종전 44.8px (= +ls 이중 가산).
+#[test]
+fn issue_1898_tac_picture_line_advance_matches_layout() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let data = fs::read(Path::new(repo_root).join(SAMPLE)).unwrap_or_else(|e| panic!("read: {e}"));
+    let core = DocumentCore::from_bytes(&data).expect("load");
+    let tree = core.build_page_render_tree(8).expect("render p9");
+
+    // pi=95..=97 의 TextLine y 수집 (본문 컬럼)
+    fn collect(node: &RenderNode, out: &mut Vec<(usize, f64)>) {
+        if let RenderNodeType::TextLine(ref tl) = node.node_type {
+            if let Some(pi) = tl.para_index {
+                if (95..=97).contains(&pi) {
+                    out.push((pi, node.bbox.y));
+                }
+            }
+        }
+        for child in &node.children {
+            collect(child, out);
+        }
+    }
+    let mut ys = Vec::new();
+    collect(&tree.root, &mut ys);
+    ys.sort_by(|a, b| a.0.cmp(&b.0).then(a.1.partial_cmp(&b.1).unwrap()));
+
+    let y95 = ys.iter().find(|(pi, _)| *pi == 95).map(|(_, y)| *y);
+    let y96 = ys.iter().find(|(pi, _)| *pi == 96).map(|(_, y)| *y);
+    let y97 = ys.iter().find(|(pi, _)| *pi == 97).map(|(_, y)| *y);
+    let (Some(y95), Some(y96), Some(y97)) = (y95, y96, y97) else {
+        panic!("pi=95/96/97 TextLine 미발견: {ys:?}");
+    };
+
+    // layout 정답 = lh(1100)+ls(880)+sb(500) = 2480 HU = 33.07px (한컴 32.9px).
+    // 종전 결함 값 = 44.8px. 허용 오차 ±1.5px.
+    for (label, delta) in [("95→96", y96 - y95), ("96→97", y97 - y96)] {
+        assert!(
+            (delta - 33.1).abs() <= 1.5,
+            "{label} TextLine 간격 {delta:.1}px ≠ 33.1px (tac 그림 vpos 기준점 초기화 → \
+             trailing-ls bridge 이중 가산 회귀: 종전 44.8px)"
+        );
+    }
+}


### PR DESCRIPTION
## 요약

#1898 기전 1 — tac(글자처럼) 인라인 그림 문단의 렌더 줄 전진 +11.7px(줄간격 1회분) 렌더-레이아웃 자기 불일치 수정. 36388711 p9 불릿 리스트가 layout 33.1px/줄인데 렌더만 44.8px/줄로 밀리던 문제 (한컴 오라클 32.9px — layout 이 정답).

## 근본 원인 — 이슈 추정과 다른 항목-간 주입

렌더러의 그림 라인 전진량 gap 이중 가산이 아니라(문단 내부 줄 전진은 정상 — `TAC_ADV` 트레이스로 확인), **tac 그림의 `PageItem::Shape`(렌더 dy=0)가 vpos 기준점(page/lazy base)을 무조건 초기화**(#409/#1027 후처리)하는 것이 원인입니다. 초기화되면 다음 문단의 `HeightCursor::vpos_adjust` 가 base 재산출 경로에 진입하고, 직전 문단과 vpos 가 불연속(spacing_before 갭)이라 **trailing-ls bridge(#1022 v2)를 재적용 → +880HU(11.7px)**. `TAC_CURSOR` 트레이스에서 Shape 항목 y_out(684.7)과 다음 항목 y_in(696.5)의 간극으로 특정했습니다.

## 수정 — 판별 기준: 호스트 문단의 텍스트 보유

- **면제**: 실제 텍스트 줄에 통합된 tac 개체(호스트 `para_has_visible_text` ∧ Picture/Shape/Equation `treat_as_char`)의 Shape 항목 — 호스트 LINE_SEG 는 텍스트 줄 높이이고 항목 dy=0 이라 "lh 가 개체 높이를 포함해 drift" 근거가 성립하지 않음.
- **유지**: 텍스트 없는 tac-전용 문단(sample16 pi=71 RFP 박스, LINE_SEG lh=개체 높이 34.4mm) — 종전 초기화가 맞음. 1차 blanket 면제안은 issue_1116 한컴 핀 2건을 −8.5px 로 깨뜨렸고, 이 반례가 판별 기준을 정제했습니다.

동반 계측 개선: `RHWP_DEBUG_PARA_TAC` 대상 pi 하드코딩(651/652)을 콤마 목록 env 값으로 일반화.

## 검증

- 36388711 p9: 불릿 리스트 간격 **44.8 → 33.1px** (layout 33.1 / 한컴 2022 오라클 32.9)
- 핀 신설: `tests/issue_1898.rs` (p9 TextLine 간격 33.1±1.5px)
- issue_1116 (sample16 한컴 핀) **13/13** — tac-전용 문단 경로 불변
- `cargo test` 전 스위트(195 바이너리) PASS
- big_hwp/big_hwpx 2,500×2 A/B (origin/devel 054be69c 베이스 exe): **완전 동일** — 자기 라운드트립은 본 수정에 대칭이라 예상 결과이며, 시각 정답 검증은 한컴 오라클·핀이 담당

## 범위 외

이슈 기전 2 (p8/p9 누적 적재 드리프트, 저장 lineseg 분할점 대비 +158.3px — #1759/#1763 계열 per-line 축)는 이슈에 측정 기록이 유지되어 있습니다. 기전 1 해소 후 이슈 처리(클로즈/재정의)는 판단 부탁드립니다.

Refs #1898

🤖 Generated with [Claude Code](https://claude.com/claude-code)
