### PR TITLE
Task #1914: roundtrip 게이트 확장자 위장 파일 FORMAT_SKIP 분류 — 매직 바이트 스니핑

### DIFF
--- a/mydocs/plans/task_m100_1914.md
+++ b/mydocs/plans/task_m100_1914.md
@@ -1,0 +1,37 @@
+# 수행 계획서 — Task M100 #1914
+
+## 개요
+
+- **이슈**: [#1914 파일 열기: 확장자-실체 불일치 시 매직 바이트 스니핑 부재 — .hwpx 명명 HWP5 49/4580건 로드 실패 (한글은 열림)](https://github.com/edwardkim/rhwp/issues/1914)
+- **브랜치**: `pr/devel-1914` (origin/devel 054be69c 기반)
+
+## 조사 계획
+
+1. 이슈 재현: 서베이 실패 파일(156XXXXXX 계열)로 `rhwp info` 등 로드 경로 검증
+2. 확장자 신뢰 경로 전수 식별 (`detect_format` 호출 여부)
+3. 최소 수정 + 서베이 53건 전수 재검
+
+## 판별 결과 (이슈 전제 정정)
+
+- **제품 로드 경로는 이미 매직 바이트 스니핑**: `parse_document`/`detect_format`
+  (내용 기반), `DocumentCore::from_bytes`, `HwpDocument::from_bytes`(= `rhwp
+  info`) 모두 확장자 무관. 서베이 49건 전수를 `rhwp info` 로 재검 → **49/49
+  정상 로드** (버전 5.1.0.1). 이슈 재현 블록의 "rhwp info → EOCD 오류"는
+  현 devel 에서 재현되지 않음.
+- **실제 오분류 표면 = roundtrip 게이트 CLI 2종** (확장자 신뢰):
+  - `hwpx-roundtrip`: `parse_hwpx` 직행 → 위장 HWP5 가 PARSE_FAIL("ZIP EOCD")
+    — 서베이 오류 문자열과 정확히 일치 (#1891 의 'EOCD 단서'의 실체이기도 함).
+  - `hwp5-roundtrip` 단일 모드: 포맷 필터 부재 → HWP3 실체가 어댑터 미경유
+    plain serialize 로 돌아 오도성 IR_DIFF 표기 (#1892 도구 축 후속).
+
+## 수정 방향
+
+두 게이트에 `detect_format` 스니핑 → 실체가 게이트 대상 포맷이 아니면
+**FORMAT_SKIP**(하드 실패 아님, exit 0) + 실체·올바른 게이트 안내.
+Unknown(빈 파일/DRM 래퍼)은 종전대로 파싱 실패 유지(정당한 거부).
+
+## 산출물
+
+- 수정: `src/diagnostics/hwpx_roundtrip_batch.rs`, `src/diagnostics/hwp5_roundtrip_batch.rs`
+- 테스트: `tests/issue_1914.rs` (제품 스니핑 핀 + 게이트 FORMAT_SKIP 핀)
+- 보고서: `mydocs/report/task_m100_1914_report.md`

--- a/mydocs/plans/task_m100_1914_impl.md
+++ b/mydocs/plans/task_m100_1914_impl.md
@@ -1,0 +1,22 @@
+# 구현 계획서 — Task M100 #1914
+
+## 단계
+
+1. **판별 확정** — 서베이 53건(EOCD 실패 .hwpx) 매직 바이트 분류 + 제품 로드
+   경로(`rhwp info`) 전수 재검 → 제품 경로 정상(49/49), 오분류 표면 = 게이트
+   CLI 2종으로 확정.
+2. **게이트 스니핑** — `hwpx_roundtrip_batch`/`hwp5_roundtrip_batch` 의
+   `roundtrip_one` 진입부에 `detect_format` 판별:
+   - `RoundtripRow.format_skip: Option<&'static str>` 신설 (실체 포맷명)
+   - `status()` 최우선 분기 `FORMAT_SKIP`, `is_hard_fail()` 제외 (exit 0)
+   - error 컬럼에 실체 + 올바른 게이트 안내
+   - `Unknown`(빈 파일/DRM)은 종전 흐름 유지 (파싱 실패 = 정당한 거부)
+3. **핀 + 전수 검증** — `tests/issue_1914.rs` (제품 스니핑 3포맷 핀 +
+   CARGO_BIN_EXE 게이트 FORMAT_SKIP 핀), 서베이 53건 전수 재검, 전체 스위트.
+
+## 비수정 범위
+
+- 제품 로드 경로(`parse_document`/`DocumentCore`/`HwpDocument`) — 이미 내용
+  기반. 수정 불필요 (핀만 추가).
+- `render-diff` — parse_document 경유로 이미 정상.
+- 배치 수집 필터(확장자 글롭) — 수집은 확장자, 판별·분류는 실체로 이원화.

--- a/mydocs/report/task_m100_1914_report.md
+++ b/mydocs/report/task_m100_1914_report.md
@@ -1,0 +1,53 @@
+# 최종 결과보고서 — Task M100 #1914
+
+## 이슈
+
+[#1914 파일 열기: 확장자-실체 불일치 시 매직 바이트 스니핑 부재 — .hwpx 명명 HWP5 49/4580건 로드 실패 (한글은 열림)](https://github.com/edwardkim/rhwp/issues/1914)
+
+## 요약
+
+이슈 전제를 정정한다: **제품 열기 경로는 이미 매직 바이트 스니핑으로 동작**하며
+서베이 49건 전수가 `rhwp info`(= `HwpDocument::from_bytes`)로 정상 로드된다
+(49/49, 버전 5.1.0.1). 서베이의 LOAD_FAIL("ZIP EOCD")은 **확장자를 신뢰하던
+roundtrip 게이트 CLI 경로**의 오분류였고, 두 게이트에 실체 판별(FORMAT_SKIP)을
+추가해 해소했다. #1891 의 'EOCD 단서'와 #1892 의 도구 축 후속(어댑터 미경유
+HWP3 오도성 IR_DIFF)이 같은 뿌리로 함께 해소된다.
+
+## 판별
+
+| 경로 | 판별 방식 | 위장 파일 동작 (수정 전) |
+|---|---|---|
+| `parse_document` / `detect_format` | 내용(매직 바이트) | 정상 파싱 ✓ |
+| `DocumentCore::from_bytes` / `HwpDocument::from_bytes` (`rhwp info` 등) | 내용 | 정상 파싱 ✓ (49/49 실측) |
+| `render-diff` (20k/서베이 렌더 경로) | 내용 | 정상 ✓ (#1891 에서 확인) |
+| **`hwpx-roundtrip`** | 확장자(parse_hwpx 직행) | **PARSE_FAIL "ZIP EOCD"** ← 서베이 오류 문자열 |
+| **`hwp5-roundtrip` 단일 모드** | 필터 없음 | HWP3 실체 → **오도성 IR_DIFF** (#1892 도구 축) |
+
+## 수정
+
+두 게이트의 `roundtrip_one` 진입부에 `detect_format` 스니핑:
+
+- 실체가 게이트 대상이 아니면 **`FORMAT_SKIP`** 상태 (하드 실패 아님, exit 0)
+  + 실체 포맷명 + 올바른 게이트 안내를 error 컬럼에 기록.
+  - hwpx 게이트: `확장자 위장: 실체 HWP5(OLE/CFB) — HWP5 는 hwp5-roundtrip 사용`
+  - hwp5 게이트: HWP3 → `HWP3 저장 검증은 convert/export 경로 사용` (plain
+    serialize 는 어댑터 미경유라 SectionPageDef 소실 등 도구-전용 diff 오표기)
+- `Unknown`(빈 파일 2건·DRM 래퍼 2건)은 종전대로 파싱 실패 유지 — 정당한 거부.
+
+## 검증
+
+- 서베이 EOCD 실패 .hwpx **53건 전수 재검**: OLE 실체 49건 → **FORMAT_SKIP 49/49
+  (exit 0)**, 잔여 4건(빈 파일 2·DRM 래퍼 2) = 비-OLE 로 종전 거부 유지 —
+  이슈의 분해(49+2+2)와 정확히 일치.
+- 제품 로드: 동일 49건 `rhwp info` **49/49 정상** (내용 스니핑 기존 동작 핀).
+- HWP3 `.hwp` → hwp5-roundtrip: 오도성 IR_DIFF=1 → **FORMAT_SKIP** 전환.
+- 동일 바이트를 `.hwp` 로 hwp5-roundtrip: **PASS** (진짜 HWP5 게이트 정상 진행).
+- `tests/issue_1914.rs` 2건: 제품 스니핑 핀(3포맷) + 게이트 FORMAT_SKIP 핀
+  (CARGO_BIN_EXE 로 실제 CLI 구동).
+- cargo test 전 스위트 (195 바이너리): **PASS**
+
+## 산출물
+
+- 수정: `src/diagnostics/hwpx_roundtrip_batch.rs`, `src/diagnostics/hwp5_roundtrip_batch.rs`
+- 테스트: `tests/issue_1914.rs`
+- 문서: plans/task_m100_1914.md, 본 보고서

--- a/src/diagnostics/hwp5_roundtrip_batch.rs
+++ b/src/diagnostics/hwp5_roundtrip_batch.rs
@@ -170,11 +170,18 @@ struct RoundtripRow {
     round2_error: String,
     elapsed_ms: u128,
     error: String,
+    /// [#1914] 매직 바이트 실체가 HWP5(OLE/CFB)가 아닌 확장자 위장 파일 —
+    /// 검출된 실체 포맷명. plain serialize 게이트의 범위 밖이므로 스킵으로 분류.
+    /// (HWP3 는 어댑터(`export_hwp_with_adapter`) 경유가 제품 경로 — 여기서
+    /// 돌리면 SectionPageDef 소실 등 도구-경로 전용 IR_DIFF 가 오표기된다, #1892.)
+    format_skip: Option<&'static str>,
 }
 
 impl RoundtripRow {
     fn status(&self) -> &'static str {
-        if !self.parse_ok {
+        if self.format_skip.is_some() {
+            "FORMAT_SKIP"
+        } else if !self.parse_ok {
             "PARSE_FAIL"
         } else if !self.serialize_ok {
             "SERIALIZE_FAIL"
@@ -204,11 +211,26 @@ impl RoundtripRow {
 
     /// 회귀 검출용 하드 실패 (등급화 대상 분류와 별개).
     fn is_hard_fail(&self) -> bool {
+        if self.format_skip.is_some() {
+            // [#1914] 확장자 위장(실체 비-HWP5)은 게이트 범위 밖 — 실패 아님.
+            return false;
+        }
         !(self.parse_ok && self.serialize_ok && self.reparse_ok)
             || self.bindata_lost > 0
             || self.cfb_struct_ok == Some(false)
             || self.page_mismatch()
             || !self.round2_error.is_empty()
+    }
+}
+
+/// [#1914] 매직 바이트 실체 포맷명 (FORMAT_SKIP 사유 표기용).
+fn detected_format_name(fmt: crate::parser::FileFormat) -> Option<&'static str> {
+    use crate::parser::FileFormat;
+    match fmt {
+        FileFormat::Hwpx => Some("HWPX(ZIP)"),
+        FileFormat::Hwp3 => Some("HWP3"),
+        FileFormat::LegacyHwpml => Some("HWPML(구 XML)"),
+        FileFormat::Hwp | FileFormat::Unknown => None,
     }
 }
 
@@ -232,6 +254,7 @@ fn roundtrip_one(path: &Path, rel_path: &str, rt_path: &Path) -> RoundtripRow {
         round2_error: String::new(),
         elapsed_ms: 0,
         error: String::new(),
+        format_skip: None,
     };
 
     let finish = |mut row: RoundtripRow, started: Instant| -> RoundtripRow {
@@ -246,6 +269,19 @@ fn roundtrip_one(path: &Path, rel_path: &str, rt_path: &Path) -> RoundtripRow {
             return finish(row, started);
         }
     };
+
+    // [#1914] 확장자 아닌 매직 바이트로 실체 판별. HWP3/HWPX 실체는 plain
+    // serialize 게이트의 범위 밖 — HWP3 를 여기서 돌리면 어댑터 미경유
+    // SectionPageDef 소실 등 도구-경로 전용 IR_DIFF 가 오표기된다(#1892).
+    // Unknown(빈 파일/DRM 래퍼 등)은 종전대로 파싱 실패가 정당하므로 진행한다.
+    if let Some(actual) = detected_format_name(crate::parser::detect_format(&bytes)) {
+        row.format_skip = Some(actual);
+        row.error = format!(
+            "확장자 위장/포맷 불일치: 실체 {actual} — HWP5 게이트 범위 밖 \
+             (HWPX 는 hwpx-roundtrip, HWP3 저장 검증은 convert/export 경로 사용)"
+        );
+        return finish(row, started);
+    }
 
     let doc1 = match parse_document(&bytes) {
         Ok(d) => d,
@@ -604,6 +640,7 @@ mod tests {
             round2_error: String::new(),
             elapsed_ms: 0,
             error: String::new(),
+            format_skip: None,
         }
     }
 

--- a/src/diagnostics/hwpx_roundtrip_batch.rs
+++ b/src/diagnostics/hwpx_roundtrip_batch.rs
@@ -92,6 +92,9 @@ struct RoundtripRow {
     round2_error: String,
     elapsed_ms: u128,
     error: String,
+    /// [#1914] 매직 바이트 실체가 HWPX(ZIP)가 아닌 확장자 위장 파일 — 검출된
+    /// 실체 포맷명. HWPX 구조 게이트의 범위 밖이므로 실패가 아닌 스킵으로 분류.
+    format_skip: Option<&'static str>,
     /// #1380 측정 전용 — round1(원본 vs RT) lineseg diff. `--lineseg-report` 시에만 수집.
     lineseg_r1: Vec<LinesegDiff>,
     /// #1380 측정 전용 — round2(RT vs RT²) lineseg diff.
@@ -100,7 +103,9 @@ struct RoundtripRow {
 
 impl RoundtripRow {
     fn status(&self) -> &'static str {
-        if !self.parse_ok {
+        if self.format_skip.is_some() {
+            "FORMAT_SKIP"
+        } else if !self.parse_ok {
             "PARSE_FAIL"
         } else if !self.serialize_ok {
             "SERIALIZE_FAIL"
@@ -121,9 +126,24 @@ impl RoundtripRow {
 
     /// 회귀 검출용 하드 실패 (등급화 대상 분류와 별개).
     fn is_hard_fail(&self) -> bool {
+        if self.format_skip.is_some() {
+            // [#1914] 확장자 위장(실체 비-HWPX)은 게이트 범위 밖 — 실패 아님.
+            return false;
+        }
         !(self.parse_ok && self.serialize_ok && self.reparse_ok)
             || self.pkg_ok == Some(false)
             || !self.round2_error.is_empty()
+    }
+}
+
+/// [#1914] 매직 바이트 실체 포맷명 (FORMAT_SKIP 사유 표기용).
+fn detected_format_name(fmt: crate::parser::FileFormat) -> Option<&'static str> {
+    use crate::parser::FileFormat;
+    match fmt {
+        FileFormat::Hwp => Some("HWP5(OLE/CFB)"),
+        FileFormat::Hwp3 => Some("HWP3"),
+        FileFormat::LegacyHwpml => Some("HWPML(구 XML)"),
+        FileFormat::Hwpx | FileFormat::Unknown => None,
     }
 }
 
@@ -148,6 +168,7 @@ fn roundtrip_one(
         round2_error: String::new(),
         elapsed_ms: 0,
         error: String::new(),
+        format_skip: None,
         lineseg_r1: Vec::new(),
         lineseg_r2: Vec::new(),
     };
@@ -164,6 +185,19 @@ fn roundtrip_one(
             return finish(row, started);
         }
     };
+
+    // [#1914] 확장자 아닌 매직 바이트로 실체 판별 — .hwpx 로 유통되는 HWP5(OLE)
+    // 실체 파일(정부 보도자료 계열 다수)은 HWPX 구조 게이트의 범위 밖이다.
+    // 종전 PARSE_FAIL("ZIP EOCD") 오분류를 FORMAT_SKIP 으로 정정하고 실체와
+    // 올바른 게이트를 안내한다. Unknown(빈 파일/DRM 래퍼 등)은 종전대로
+    // 파싱 실패가 정당하므로 그대로 진행한다.
+    if let Some(actual) = detected_format_name(crate::parser::detect_format(&bytes)) {
+        row.format_skip = Some(actual);
+        row.error = format!(
+            "확장자 위장: 실체 {actual} — HWPX 게이트 범위 밖 (HWP5 는 hwp5-roundtrip 사용)"
+        );
+        return finish(row, started);
+    }
 
     let doc1 = match parse_hwpx(&bytes) {
         Ok(d) => d,

--- a/tests/issue_1914.rs
+++ b/tests/issue_1914.rs
@@ -1,0 +1,99 @@
+//! Issue #1914 — 확장자-실체 불일치 파일의 매직 바이트 스니핑.
+//!
+//! 정부 배포 채널에서 HWP5(OLE/CFB) 실체 파일이 `.hwpx` 확장자로 다수 유통된다
+//! (10k 서베이: .hwpx 4,580건 중 49건). 제품 로드 경로(`parse_document`/
+//! `DocumentCore::from_bytes`)는 내용 기반 감지로 이미 열리며(한글 정합),
+//! 확장자를 신뢰하던 roundtrip 게이트 CLI 는 PARSE_FAIL("ZIP EOCD") 오분류
+//! 대신 FORMAT_SKIP(실체·올바른 게이트 안내)으로 분류한다.
+
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+use rhwp::parser::{detect_format, parse_document, FileFormat};
+
+fn sample_bytes(rel: &str) -> Vec<u8> {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    fs::read(Path::new(repo_root).join(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"))
+}
+
+/// 제품 로드 경로 핀: 세 포맷 모두 파일명/확장자와 무관하게 내용으로 감지·파싱된다.
+#[test]
+fn issue_1914_parse_document_sniffs_content_for_all_formats() {
+    let cases = [
+        ("samples/hwpers_test4_complex_table.hwp", FileFormat::Hwp),
+        (
+            "samples/issue1892_hwp3_drawing_group_roundtrip.hwp",
+            FileFormat::Hwp3,
+        ),
+        (
+            "samples/issue1893_clickhere_field_roundtrip.hwpx",
+            FileFormat::Hwpx,
+        ),
+    ];
+    for (rel, expected) in cases {
+        let bytes = sample_bytes(rel);
+        assert_eq!(
+            detect_format(&bytes),
+            expected,
+            "{rel}: 매직 바이트 감지 포맷 불일치"
+        );
+        // parse_document 는 바이트만 받는다 — 확장자 개입 여지 자체가 없음을 핀.
+        parse_document(&bytes).unwrap_or_else(|e| panic!("{rel}: 내용 기반 파싱 실패: {e}"));
+    }
+}
+
+/// roundtrip 게이트 CLI 핀: 확장자 위장 파일은 실패가 아닌 FORMAT_SKIP + exit 0.
+#[test]
+fn issue_1914_roundtrip_gates_classify_masqueraded_files_as_format_skip() {
+    let repo_root = Path::new(env!("CARGO_MANIFEST_DIR"));
+    let tmp = std::env::temp_dir().join("issue_1914_gate_probe");
+    fs::create_dir_all(&tmp).expect("temp dir");
+
+    // HWP5(OLE) 실체 → .hwpx 확장자 (10k 서베이 49건 클래스)
+    let masq_hwpx = tmp.join("ole_as.hwpx");
+    fs::copy(
+        repo_root.join("samples/hwpers_test4_complex_table.hwp"),
+        &masq_hwpx,
+    )
+    .expect("copy masq hwpx");
+    // HWP3 실체 → .hwp 확장자 (hwp5 게이트 범위 밖 — #1892 도구 축)
+    let hwp3_as_hwp = repo_root.join("samples/issue1892_hwp3_drawing_group_roundtrip.hwp");
+
+    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let out_dir = tmp.join("out");
+
+    let run = |args: &[&str]| -> (String, bool) {
+        let output = Command::new(exe).args(args).output().expect("run rhwp");
+        let text = format!(
+            "{}{}",
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+        (text, output.status.success())
+    };
+
+    let (text, ok) = run(&[
+        "hwpx-roundtrip",
+        masq_hwpx.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(
+        text.contains("FORMAT_SKIP") && text.contains("HWP5"),
+        "hwpx-roundtrip 위장 HWP5: FORMAT_SKIP+실체 안내여야 함 (종전 PARSE_FAIL EOCD): {text}"
+    );
+    assert!(ok, "FORMAT_SKIP 은 하드 실패가 아님 (exit 0): {text}");
+
+    let (text, ok) = run(&[
+        "hwp5-roundtrip",
+        hwp3_as_hwp.to_str().unwrap(),
+        "-o",
+        out_dir.to_str().unwrap(),
+    ]);
+    assert!(
+        text.contains("FORMAT_SKIP") && text.contains("HWP3"),
+        "hwp5-roundtrip HWP3 실체: FORMAT_SKIP+실체 안내여야 함 (종전 오도성 IR_DIFF, #1892): {text}"
+    );
+    assert!(ok, "FORMAT_SKIP 은 하드 실패가 아님 (exit 0): {text}");
+}


### PR DESCRIPTION
## 요약

#1914 (.hwpx 명명 HWP5 49/4,580건 로드 실패) — 판별 + roundtrip 게이트 FORMAT_SKIP 분류.

**이슈 전제 정정**: 제품 열기 경로(`parse_document`/`DocumentCore::from_bytes`/`HwpDocument::from_bytes` = `rhwp info`)는 **이미 매직 바이트 스니핑으로 동작**하며, 서베이 49건 전수를 재검한 결과 **49/49 정상 로드**됩니다(한글 정합). 서베이의 LOAD_FAIL("ZIP EOCD")은 확장자를 신뢰하던 **roundtrip 게이트 CLI 경로**의 오분류였습니다:

| 게이트 | 종전 동작 | 문제 |
|---|---|---|
| `hwpx-roundtrip` | `parse_hwpx` 직행 → 위장 HWP5 가 PARSE_FAIL("ZIP 오류: EOCD") | 하드 실패 오표기 — #1891 'EOCD 단서'의 실체 |
| `hwp5-roundtrip` (단일) | 포맷 필터 부재 → HWP3 실체가 plain serialize 로 진행 | 어댑터 미경유 SectionPageDef 소실 등 **오도성 IR_DIFF** (#1892 도구 축 후속) |

## 수정

두 게이트의 `roundtrip_one` 진입부에 `detect_format` 스니핑:

- 실체가 게이트 대상 포맷이 아니면 **`FORMAT_SKIP`**(하드 실패 아님, exit 0) + 실체 포맷명 + 올바른 게이트 안내.
- `Unknown`(빈 파일·DRM 래퍼)은 종전대로 파싱 실패 유지 — 정당한 거부.

## 검증

- 서베이 EOCD 실패 .hwpx **53건 전수 재검**: OLE 실체 49건 → **FORMAT_SKIP 49/49 (exit 0)**, 잔여 4건(빈 파일 2·DRM 래퍼 2) 종전 거부 유지 — 이슈의 분해(49+2+2)와 정확히 일치
- 제품 로드: 동일 49건 `rhwp info` **49/49 정상** (기존 스니핑 동작을 `tests/issue_1914.rs` 로 핀)
- HWP3 `.hwp` → hwp5-roundtrip: 오도성 IR_DIFF=1 → **FORMAT_SKIP** 전환 / 동일 바이트 진짜 HWP5 는 **PASS** 유지
- 핀 2건: 제품 스니핑(3포맷) + 게이트 FORMAT_SKIP(CARGO_BIN_EXE 실 CLI 구동)
- `cargo test` 전 스위트(195 바이너리) PASS

Closes #1914

🤖 Generated with [Claude Code](https://claude.com/claude-code)
