### PR TITLE
Task #1916+#1917: 표 CTRL_HEADER 빈 데이터 방출 + BinData 64MB 상한 — HWP5/HWPX 저장 데이터 소실 2건 (배치)

### DIFF
--- a/mydocs/plans/task_m100_1916.md
+++ b/mydocs/plans/task_m100_1916.md
@@ -1,0 +1,38 @@
+# 수행 계획서 — Task M100 #1916
+
+## 개요
+
+- **이슈**: [#1916 HWP5 저장: 표(tbl) flowWithText 플래그 소실 (10k 서베이 12건, #1655의 HWP5·표 축)](https://github.com/edwardkim/rhwp/issues/1916)
+- **브랜치**: `pr/devel-1916` (origin/devel bf5228df — 리팩토링 라운드 1 이후)
+
+## 조사 계획
+
+1. 서베이 12건 재현 (`ird_h5/out/inventory.tsv` flowWithText 행)
+2. 소실 지점 특정 (parse ↔ serialize 어느 쪽인지, 경로별)
+3. 최소 수정 + 핀
+
+## 판별 결과 (이슈 전제 보정)
+
+- **서베이 12건은 전부 ZIP(HWPX) 실체의 .hwp 파일** (역방향 확장자 위장,
+  매직 바이트 전수 확인). 이슈의 "원본 v5.1.0.0"은 HWPX 파서가 합성한 IR
+  버전 필드의 판독. 게이트 유입 축은 #1914 의 FORMAT_SKIP 으로 별도 해소.
+- **제품 변환 경로는 정상**: `export_hwp_with_adapter`(어댑터 Stage 2 가
+  표 raw_ctrl_data 합성) 왕복에서 flowWithText=true 보존 실측
+  (hwp5-anchor-trace, properties bit 13 유지).
+- **실결함 = plain serialize 의 표 CTRL_HEADER 빈 데이터 방출**:
+  `serialize_table` 이 `raw_ctrl_data` 부재 시 CTRL_HEADER 데이터를 빈 값으로
+  써서 재파스 CommonObjAttr **전체**(treat_as_char/wrap/flowWithText/크기)가
+  기본값으로 붕괴. flowWithText 는 그 한 단면이다. raw_ctrl_data 없는 IR
+  (편집기 신설 표의 HWP5-native 저장 등)이 실경로.
+
+## 수정 방향
+
+`serialize_table`: raw_ctrl_data 부재 시 IR `common` 을 `serialize_common_obj_attr`
+로 합성 (다른 GSO 컨트롤과 동일 계약; attr=0 → pack_common_attr_bits 가
+flow_with_text bit 13 포함). HWP5 파스본(raw 보존)·어댑터 경로(합성 raw)는 불변.
+
+## 산출물
+
+- 수정: `src/serializer/control.rs`
+- 테스트: `tests/issue_1916.rs` (raw 없는 표의 plain 왕복 CommonObjAttr 보존 핀)
+- 보고서: `mydocs/report/task_m100_1916_report.md`

--- a/mydocs/plans/task_m100_1916_impl.md
+++ b/mydocs/plans/task_m100_1916_impl.md
@@ -1,0 +1,20 @@
+# 구현 계획서 — Task M100 #1916
+
+## 단계
+
+1. **판별** — 서베이 12건 매직 바이트 전수(12/12 ZIP 실체) + 어댑터 경로
+   flowWithText 보존 실측 + plain 경로 소실 지점 특정
+   (`serialize_table` CTRL_HEADER 빈 데이터 폴백).
+2. **수정** — `serialize_table`: raw_ctrl_data 부재 시
+   `serialize_common_obj_attr(&table.common)` 합성 방출.
+   - attr=0 → `pack_common_attr_bits` (flow_with_text bit 13, tac bit 0,
+     wrap bits 21-23 등 포함)
+   - raw 보존 경로(HWP5 파스본)·어댑터 경로(Stage 2 합성 raw)는 분기 불변
+3. **핀 + 게이트** — `tests/issue_1916.rs`: raw 없는 표 IR 의 plain 왕복에서
+   flowWithText/treat_as_char/wrap/크기 보존. 전체 스위트
+   (hwp5_roundtrip_baseline 포함).
+
+## 비수정 범위
+
+- 게이트 유입 분류(.hwp 명명 HWPX): #1914 FORMAT_SKIP (PR #1922)
+- HWPX 직렬화의 표 flowWithText: #1637 에서 기수정 (`hwpx/table.rs`)

--- a/mydocs/plans/task_m100_1917.md
+++ b/mydocs/plans/task_m100_1917.md
@@ -1,0 +1,26 @@
+# 수행 계획서 — Task M100 #1917
+
+## 개요
+
+- **이슈**: [#1917 HWPX BinData 64MB 엔트리 상한 — 대형 이미지 로드 거부 + 왕복 시 pic 컨트롤 소실 (10k 서베이 4건)](https://github.com/edwardkim/rhwp/issues/1917)
+- **브랜치**: `pr/devel-1916` (#1916 과 배치 처리 — 작업지시자 지시)
+
+## 판별
+
+- `parser/hwpx/reader.rs` `MAX_BINDATA_SIZE = 64MB` (zip-bomb 방어)가 실문서를
+  거부: 정부 보도자료 비압축 BMP 103.7MB (한글 정상 열람). 로드 거부 →
+  그림 소실, 재직렬화 시 bin_data_map 미등록 → pic 컨트롤 드롭 (왕복 손실).
+- 서베이 hwpx IR_DIFF 4건 전부 이 클래스 (bmp 2, tif 1, jpg 1).
+
+## 수정
+
+상한 64MB → **512MB** (이슈 제안 채택). 무제한 read_to_end 차단이라는
+zip-bomb 방어 목적은 유지. 512MB 초과 실문서는 서베이에 부재 — 초과 시
+pass-through 보존은 필요 시 후속.
+
+## 검증
+
+- 인메모리 핀 (`tests/issue_1917.rs`): 70MB BinData(종전 상한 초과) HWPX 왕복
+  보존 + pic 컨트롤 유지
+- 서베이 4건 전수 재검: **IR_DIFF → PASS 4/4** (diff 0, r2 0)
+- 타깃 게이트: hwpx/hwp5_roundtrip_baseline PASS (풀 스위트는 PR CI)

--- a/mydocs/report/task_m100_1916_report.md
+++ b/mydocs/report/task_m100_1916_report.md
@@ -1,0 +1,52 @@
+# 최종 결과보고서 — Task M100 #1916
+
+## 이슈
+
+[#1916 HWP5 저장: 표(tbl) flowWithText 플래그 소실 (10k 서베이 12건, #1655의 HWP5·표 축)](https://github.com/edwardkim/rhwp/issues/1916)
+
+## 요약
+
+flowWithText 는 빙산의 일각이었다. `serialize_table` 이 `raw_ctrl_data` 부재 시
+CTRL_HEADER 데이터를 **빈 값**으로 방출해, 재파스 시 표의 **CommonObjAttr
+전체**(treat_as_char/text_wrap/flowWithText/크기/여백)가 기본값으로 붕괴했다.
+부재 시 IR `common` 을 합성 방출하도록 수정 (다른 GSO 컨트롤과 동일 계약).
+
+## 판별 (이슈 전제 보정)
+
+- 서베이 12건은 **전부 ZIP(HWPX) 실체의 .hwp 파일**(역방향 확장자 위장 —
+  매직 바이트 전수 확인). "원본 v5.1.0.0"은 HWPX 파서가 합성하는 IR 버전
+  필드의 판독이다. 이들이 `hwp5-roundtrip`(어댑터 미경유 plain serialize)에
+  들어가 표 attr 가 붕괴한 것 — 게이트 유입 분류는 #1914(FORMAT_SKIP,
+  PR #1922)로 별도 해소됐다.
+- **제품 변환 경로는 정상**: `export_hwp_with_adapter` 는 어댑터 Stage 2 가
+  표 raw_ctrl_data 를 합성하므로 flowWithText=true 가 보존된다
+  (hwp5-anchor-trace 실측, properties bit 13 유지).
+- **남는 실경로** = raw_ctrl_data 없는 IR 의 plain HWP5 저장: 편집기에서
+  신설한 표를 가진 HWP5-native 문서의 저장(`export_hwp_native`) 등. 이 경로가
+  표의 모든 공통속성을 잃고 있었다.
+
+## 수정
+
+`src/serializer/control.rs` `serialize_table`:
+
+```
+raw_ctrl_data 있음 → 그대로 (HWP5 파스본·어댑터 경로 — 불변)
+raw_ctrl_data 없음 → serialize_common_obj_attr(&table.common) 합성
+```
+
+attr=0 인 IR 은 `pack_common_attr_bits` 경유로 flow_with_text(bit 13)·
+treat_as_char(bit 0)·wrap(bit 21-23) 등이 인코딩된다.
+
+## 검증
+
+- `tests/issue_1916.rs`: raw_ctrl_data 없는 표(flowWithText/tac/TopAndBottom/
+  크기)의 plain HWP5 왕복 보존 핀 — 수정 전 전항목 붕괴, 수정 후 PASS.
+- 타깃 게이트: issue_1916 + hwpx/hwp5_roundtrip_baseline PASS (풀 스위트는
+  PR CI `Build default-feature tests` 가 담당 — 로컬 이중 실행 생략, 작업지시자
+  지시에 따른 배치 검증 체계)
+
+## 산출물
+
+- 수정: src/serializer/control.rs
+- 테스트: tests/issue_1916.rs
+- 문서: plans/task_m100_1916.md, plans/task_m100_1916_impl.md, 본 보고서

--- a/mydocs/report/task_m100_1917_report.md
+++ b/mydocs/report/task_m100_1917_report.md
@@ -1,0 +1,32 @@
+# 최종 결과보고서 — Task M100 #1917
+
+## 이슈
+
+[#1917 HWPX BinData 64MB 엔트리 상한 — 대형 이미지 로드 거부 + 왕복 시 pic 컨트롤 소실 (10k 서베이 4건)](https://github.com/edwardkim/rhwp/issues/1917)
+
+## 요약
+
+`MAX_BINDATA_SIZE`(zip-bomb 방어)의 64MB 가 실문서를 거부했다 — 정부 보도자료
+계열의 비압축 BMP/TIF 대형 이미지(최대 103.7MB, 한글 정상 열람). 로드 거부는
+그림 소실에 그치지 않고 재직렬화에서 pic 컨트롤 드롭(왕복 데이터 손실,
+IR_DIFF 하드 실패)으로 증폭됐다. 상한을 512MB 로 상향 (무제한 팽창 차단이라는
+방어 목적 유지).
+
+## 검증
+
+- 인메모리 핀 (`tests/issue_1917.rs`): 압축 해제 70MB BinData(종전 상한 초과)의
+  HWPX 왕복 보존 + pic 컨트롤 유지 — 수정 전 로드 거부/pic 드롭, 수정 후 PASS.
+- **서베이 4건 전수 재검: IR_DIFF → PASS 4/4** (diff 0, r2 0 — bmp 2, tif 1, jpg 1).
+- 타깃 게이트: hwpx/hwp5_roundtrip_baseline PASS. 풀 스위트는 PR CI 담당.
+
+## 남는 축 (후속 판단)
+
+512MB 초과 실문서는 서베이 10k 에 부재. 그 너머의 견고성(상한 초과 시에도
+pic 컨트롤·binaryItemIDRef 보존 + 원본 ZIP 엔트리 pass-through)은 실수요
+확인 시 별도 타스크로.
+
+## 산출물
+
+- 수정: src/parser/hwpx/reader.rs (MAX_BINDATA_SIZE 64→512MB)
+- 테스트: tests/issue_1917.rs
+- 문서: plans/task_m100_1917.md, 본 보고서 (#1916 과 배치 PR)

--- a/src/parser/hwpx/reader.rs
+++ b/src/parser/hwpx/reader.rs
@@ -23,7 +23,13 @@ use super::HwpxError;
 pub const MAX_XML_SIZE: usize = 32 * 1024 * 1024; // 32 MB
 
 /// BinData(이미지·폰트 등) 엔트리당 압축 해제 상한.
-pub const MAX_BINDATA_SIZE: usize = 64 * 1024 * 1024; // 64 MB
+///
+/// [#1917] 종전 64MB 는 실문서를 거부했다 — 정부 보도자료 계열에 비압축
+/// BMP/TIF 대형 이미지가 실재한다 (10k 서베이: 최대 103.7MB BMP, 한글은
+/// 정상 열람). 로드 거부는 그림 소실 + 재직렬화에서 pic 컨트롤 드롭(왕복
+/// 데이터 손실)으로 이어지므로 512MB 로 상향한다. zip-bomb 방어(무제한
+/// read_to_end 차단)라는 목적은 유지된다.
+pub const MAX_BINDATA_SIZE: usize = 512 * 1024 * 1024; // 512 MB
 
 /// `reader`에서 최대 `max` 바이트까지 읽는다. 초과 시 `InvalidData` 에러.
 ///

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -471,15 +471,21 @@ fn serialize_column_def(cd: &ColumnDef, level: u16, records: &mut Vec<Record>) {
 fn serialize_table(table: &Table, level: u16, records: &mut Vec<Record>) {
     // CTRL_HEADER: raw_ctrl_data는 CommonObjAttr 전체 (attr 포함)
     // Task 271에서 파싱 변경: ctrl_data 전체 = CommonObjAttr
-    records.push(make_ctrl_record(
-        tags::CTRL_TABLE,
-        level,
-        if !table.raw_ctrl_data.is_empty() {
-            &table.raw_ctrl_data
-        } else {
-            &[]
-        },
-    ));
+    //
+    // [#1916] raw_ctrl_data 부재 시(HWPX 파스 IR·편집기 신설 표 등) 종전에는
+    // 빈 데이터를 방출해 재파스 CommonObjAttr 전체(treat_as_char/wrap/
+    // flowWithText 등)가 기본값으로 붕괴했다. 다른 GSO 컨트롤과 동일하게
+    // IR 의 common 으로 합성한다 (attr=0 이면 pack_common_attr_bits 경유 —
+    // flow_with_text bit 13 포함). HWP5 파스본(raw 보존)·어댑터 경로(Stage 2
+    // 합성)는 raw_ctrl_data 가 채워져 있어 동작 불변.
+    let composed_common;
+    let ctrl_data: &[u8] = if !table.raw_ctrl_data.is_empty() {
+        &table.raw_ctrl_data
+    } else {
+        composed_common = serialize_common_obj_attr(&table.common);
+        &composed_common
+    };
+    records.push(make_ctrl_record(tags::CTRL_TABLE, level, ctrl_data));
 
     // 캡션 (TABLE 이전, level+1)
     if let Some(ref caption) = table.caption {

--- a/tests/issue_1916.rs
+++ b/tests/issue_1916.rs
@@ -1,0 +1,98 @@
+//! Issue #1916 — HWP5 저장 시 표(tbl) CommonObjAttr 소실 (flowWithText 축).
+//!
+//! `serialize_table` 은 `raw_ctrl_data`(HWP5 파스 원본 바이트)가 없으면 CTRL_HEADER
+//! 데이터를 **빈 값**으로 방출했고, 재파스 시 표의 CommonObjAttr 전체
+//! (treat_as_char/wrap/flowWithText 등)가 기본값으로 붕괴했다. 10k 서베이의
+//! 12건은 .hwp 명명 HWPX(역방향 확장자 위장)가 어댑터 미경유 plain serialize 로
+//! 들어간 케이스(게이트 분류는 #1914 의 FORMAT_SKIP 으로 별도 해소)지만,
+//! **raw_ctrl_data 없는 IR**(편집기 신설 표 등)의 plain 저장이 같은 붕괴를 겪는
+//! 실경로다. 수정: 부재 시 IR `common` 으로 합성 (다른 GSO 컨트롤과 동일).
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::shape::TextWrap;
+use rhwp::model::style::CharShape;
+use rhwp::model::table::{Cell, Table};
+use rhwp::parser::parse_document;
+use rhwp::serializer::serialize_document;
+
+fn make_doc_with_flow_table() -> Document {
+    let mut table = Table {
+        row_count: 1,
+        col_count: 1,
+        cells: vec![Cell {
+            col: 0,
+            row: 0,
+            col_span: 1,
+            row_span: 1,
+            width: 8000,
+            height: 2000,
+            paragraphs: vec![Paragraph::default()],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    // raw_ctrl_data 는 비워 둔다 — plain serialize 의 합성 경로를 검증.
+    assert!(table.raw_ctrl_data.is_empty());
+    table.common.treat_as_char = true;
+    table.common.flow_with_text = true;
+    table.common.text_wrap = TextWrap::TopAndBottom;
+    table.common.width = 8000;
+    table.common.height = 2000;
+
+    let host = Paragraph {
+        text: String::new(),
+        char_count: 1,
+        line_segs: vec![LineSeg {
+            line_height: 1000,
+            line_spacing: 600,
+            ..Default::default()
+        }],
+        controls: vec![Control::Table(Box::new(table))],
+        ..Default::default()
+    };
+
+    let mut doc = Document::default();
+    doc.doc_info.char_shapes.push(CharShape::default());
+    let mut section = Section::default();
+    section.paragraphs.push(host);
+    doc.sections.push(section);
+    doc
+}
+
+fn find_table(doc: &Document) -> &Table {
+    for para in &doc.sections[0].paragraphs {
+        for ctrl in &para.controls {
+            if let Control::Table(t) = ctrl {
+                return t;
+            }
+        }
+    }
+    panic!("표 컨트롤 미발견");
+}
+
+/// raw_ctrl_data 없는 표의 plain HWP5 저장 왕복에서 CommonObjAttr 이 보존된다.
+#[test]
+fn issue_1916_table_common_attr_survives_plain_hwp5_roundtrip() {
+    let doc = make_doc_with_flow_table();
+    let bytes = serialize_document(&doc).expect("serialize");
+    let doc2 = parse_document(&bytes).expect("reparse");
+    let t = find_table(&doc2);
+
+    assert!(
+        t.common.flow_with_text,
+        "flowWithText true → false 소실 (#1916 — CTRL_HEADER 빈 데이터 방출 회귀)"
+    );
+    assert!(
+        t.common.treat_as_char,
+        "treat_as_char 소실 (CommonObjAttr 전체 붕괴 회귀)"
+    );
+    assert_eq!(
+        t.common.text_wrap,
+        TextWrap::TopAndBottom,
+        "text_wrap 소실 (CommonObjAttr 전체 붕괴 회귀)"
+    );
+    assert_eq!(t.common.width, 8000, "표 폭 소실");
+    assert_eq!(t.common.height, 2000, "표 높이 소실");
+}

--- a/tests/issue_1917.rs
+++ b/tests/issue_1917.rs
@@ -1,0 +1,73 @@
+//! Issue #1917 — HWPX BinData 64MB 엔트리 상한이 실문서를 거부.
+//!
+//! 정부 보도자료 계열에 비압축 BMP/TIF 대형 이미지가 실재한다 (10k 서베이:
+//! 압축 7.5MB/원본 103.7MB BMP — 한글은 정상 열람). 종전 64MB 상한은 로드
+//! 거부(그림 소실) + 재직렬화 pic 컨트롤 드롭(왕복 데이터 손실)으로 이어졌다.
+//! 상한을 512MB 로 상향 (zip-bomb 무제한 팽창 차단 목적은 유지).
+
+use rhwp::model::bin_data::BinDataContent;
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::image::Picture;
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::CharShape;
+use rhwp::parser::hwpx::parse_hwpx;
+use rhwp::serializer::hwpx::serialize_hwpx;
+
+/// 압축 해제 크기 70MB(종전 상한 64MB 초과) BinData 가 HWPX 왕복에서 보존된다.
+#[test]
+fn issue_1917_large_bindata_survives_hwpx_roundtrip() {
+    const BIG: usize = 70 * 1024 * 1024; // 70MB > 종전 64MB 상한
+
+    let mut pic = Picture::default();
+    pic.image_attr.bin_data_id = 1;
+    pic.common.width = 8000;
+    pic.common.height = 6000;
+    pic.shape_attr.original_width = 8000;
+    pic.shape_attr.original_height = 6000;
+    pic.shape_attr.current_width = 8000;
+    pic.shape_attr.current_height = 6000;
+
+    let host = Paragraph {
+        char_count: 1,
+        line_segs: vec![LineSeg {
+            line_height: 1000,
+            line_spacing: 600,
+            ..Default::default()
+        }],
+        controls: vec![Control::Picture(Box::new(pic))],
+        ..Default::default()
+    };
+
+    let mut doc = Document::default();
+    doc.doc_info.char_shapes.push(CharShape::default());
+    let mut section = Section::default();
+    section.paragraphs.push(host);
+    doc.sections.push(section);
+    doc.bin_data_content.push(BinDataContent {
+        id: 1,
+        data: vec![0u8; BIG], // ZIP 으로는 소형 압축 — 압축 해제 상한 검증에 적합
+        extension: "bmp".to_string(),
+    });
+
+    let bytes = serialize_hwpx(&doc).expect("serialize");
+    let doc2 = parse_hwpx(&bytes).expect("parse (종전: 64MB 상한으로 BinData 로드 거부)");
+
+    let content = doc2
+        .bin_data_content
+        .iter()
+        .find(|b| b.data.len() == BIG)
+        .expect("70MB BinData 가 로드되어야 함 (상한 512MB)");
+    assert_eq!(content.data.len(), BIG);
+
+    // pic 컨트롤 보존 (종전: 콘텐츠 미등록 → 재직렬화에서 pic 드롭)
+    let out2 = serialize_hwpx(&doc2).expect("re-serialize");
+    let doc3 = parse_hwpx(&out2).expect("re-parse");
+    let pic_count = doc3.sections[0]
+        .paragraphs
+        .iter()
+        .flat_map(|p| p.controls.iter())
+        .filter(|c| matches!(c, Control::Picture(_)))
+        .count();
+    assert_eq!(pic_count, 1, "대형 BinData 참조 pic 컨트롤 왕복 보존");
+}


### PR DESCRIPTION
## 요약

#1916 + #1917 배치 PR (작업지시자 지시 — 커밋은 이슈별 분리, 검증·CI 는 1회).

### 커밋 1 — #1916: HWP5 저장 표 CTRL_HEADER 빈 데이터 방출 (CommonObjAttr 전체 붕괴)

flowWithText 는 빙산의 일각: `serialize_table` 이 `raw_ctrl_data` 부재 시 CTRL_HEADER 데이터를 **빈 값**으로 방출해, 재파스 표의 **CommonObjAttr 전체**(treat_as_char/text_wrap/flowWithText/크기)가 기본값으로 붕괴했습니다.

- **판별**: 서베이 12건은 매직 바이트 전수 확인 결과 **전부 .hwp 명명 HWPX(역방향 확장자 위장)** — 게이트 유입 분류는 #1914(PR #1922 FORMAT_SKIP)로 별도 해소. 제품 변환 경로(`export_hwp_with_adapter`)는 어댑터 Stage 2 의 raw_ctrl_data 합성으로 **정상 보존**(hwp5-anchor-trace 실측, bit 13 유지). **남는 실경로 = raw 없는 IR 의 plain 저장** (편집기 신설 표를 가진 HWP5-native 문서의 저장).
- **수정**: 부재 시 `serialize_common_obj_attr(&table.common)` 합성 방출 (다른 GSO 컨트롤과 동일 계약; attr=0 → `pack_common_attr_bits` 가 flow bit 13 포함). raw 보존·어댑터 경로 불변.
- **핀**: `tests/issue_1916.rs` — raw 없는 표(flowWithText/tac/wrap/크기)의 plain 왕복 보존.

### 커밋 2 — #1917: HWPX BinData 상한 64MB → 512MB

정부 보도자료 계열의 비압축 BMP/TIF 대형 이미지(최대 103.7MB, 한글 정상 열람)를 zip-bomb 방어 상한이 거부 — 그림 소실 + 재직렬화 pic 컨트롤 드롭(왕복 데이터 손실). 512MB 상향(무제한 팽창 차단 목적 유지).

- **검증**: 서베이 hwpx IR_DIFF **4건 전수 PASS 전환** (diff 0, r2 0). 인메모리 70MB 왕복 핀 `tests/issue_1917.rs`.
- 512MB 초과 실문서는 10k 에 부재 — 그 너머의 pass-through 보존은 실수요 확인 시 후속 (보고서 기록).

## 게이트

- 타깃: issue_1916 + issue_1917 + hwpx/hwp5_roundtrip_baseline PASS
- 풀 스위트: 본 PR CI (`Build default-feature tests`) 가 담당

Closes #1916
Closes #1917

🤖 Generated with [Claude Code](https://claude.com/claude-code)
