### PR TITLE
Task #1929: HWP5 그림 imgDim 왕복 소실 수정 — extra 꼬리 원본 크기 칸 양방향 연결

### DIFF
--- a/mydocs/plans/task_m100_1929.md
+++ b/mydocs/plans/task_m100_1929.md
@@ -1,0 +1,30 @@
+# 수행 계획서 — Task M100 #1929
+
+## 개요
+
+- **이슈**: [#1929 HWP5 저장: raw 미보존 그림의 imgDim (0,0) 소실 — 왕복 그림 크기 손실 (10k 서베이 잔여 2건, #1916 계열)](https://github.com/edwardkim/rhwp/issues/1929)
+- **브랜치**: `pr/devel-1929` (origin/devel 5d5a635e 기반)
+
+## 판별
+
+- HWP5 PICTURE 레코드 extra 꼬리(18바이트 = opacity1+instance4+effect4+**w4+h4**+alpha1)
+  에 원본 이미지 크기 칸이 존재하는데 양방향 모두 IR `img_dim` 과 미연결:
+  1. **파서**: extra 를 raw 보존만 하고 img_dim 으로 읽지 않음 → 재파스 (0,0)
+  2. **직렬화기**: non-raw 경로가 crop 폴백만 기록 (img_dim 무시)
+- HWPX 파스 IR(hp:imgDim 보유, raw_picture_extra 없음) → plain HWP5 저장-재파스
+  에서 imgDim 소실. #1916 과 같은 raw-부재 재구성 결손 계열.
+
+## 수정
+
+- `parser/control/shape.rs`: extra ≥17 바이트면 offset 9..17 을 img_dim 으로 적재
+- `serializer/control.rs`: non-raw 경로에서 img_dim 우선 기록 (0,0 이면 종전
+  crop 폴백 유지)
+
+## 검증
+
+- 인메모리 핀 2건 (`tests/issue_1929.rs`): raw 미보존 img_dim 왕복(2-round 포함)
+  + (0,0) crop 폴백 불변
+- 서베이 잔여 2건 실파일: img_dim 왕복 **3/3 보존** (expected 값 정확 일치)
+- hwp5/hwpx roundtrip baseline + issue_1893 핀 PASS
+- 렌더 비소비 필드(img_dim 은 renderer 미사용)라 코퍼스 렌더 A/B 불필요 —
+  IR 게이트(baseline)로 충분. 풀 스위트는 PR CI 위임.

--- a/mydocs/report/task_m100_1929_report.md
+++ b/mydocs/report/task_m100_1929_report.md
@@ -1,0 +1,43 @@
+# 최종 결과보고서 — Task M100 #1929
+
+## 이슈
+
+[#1929 HWP5 저장: raw 미보존 그림의 imgDim (0,0) 소실 — 왕복 그림 크기 손실 (10k 서베이 잔여 2건, #1916 계열)](https://github.com/edwardkim/rhwp/issues/1929)
+
+## 요약
+
+HWP5 PICTURE 레코드 extra 꼬리의 원본 이미지 크기 칸(18바이트 레이아웃의
+offset 9..17)이 IR `img_dim`(HWPX `hp:imgDim` 대응)과 **양방향 모두 미연결**
+이었다: 파서는 raw 보존만 하고 읽지 않았고, 직렬화기 non-raw 경로는 crop
+폴백만 기록했다. 양측을 연결해 raw 미보존 그림(HWPX 파스 IR·편집기 신설
+그림)의 imgDim 이 HWP5 왕복에서 보존된다.
+
+## 수정
+
+- `parser/control/shape.rs` `parse_picture`: extra ≥17 이면 offset 9..17 →
+  `pic.img_dim` 적재. native HWP5 는 raw 경로 verbatim 재기록이라 2-round 안정.
+- `serializer/control.rs` `serialize_picture_data`: non-raw 경로에서
+  `img_dim != (0,0)` 우선 기록, (0,0) 은 종전 crop 폴백 유지 (동작 불변).
+- 두 호출처(최상위 pic + 그룹 자식 pic) 공통 적용 — 이슈의 본문 직속/표 셀
+  내부/글상자 내부 발현 전부 커버.
+
+## 검증
+
+- 인메모리 핀 2건 (`tests/issue_1929.rs`): (117780,35760) 왕복 + 2-round 보존,
+  (0,0)+crop(4321,1234) 폴백 불변.
+- **서베이 잔여 2건 실파일 (ird_h5_resid)**: 전체 pic 3개 img_dim 왕복
+  **3/3 보존** — 이슈 expected 값 (117780,35760)·(149340,32640) 정확 일치.
+- hwp5/hwpx roundtrip baseline + issue_1893 핀 PASS.
+- img_dim 은 renderer 미사용 필드(HWPX 직렬화·roundtrip 게이트 전용)라 코퍼스
+  렌더 A/B 불필요. 풀 스위트는 PR CI 위임.
+
+## 부수 효과
+
+HWP5→HWPX 변환(export-hwpx)의 `hp:imgDim` 이 0 대신 실값으로 방출 —
+한컴 원본과의 구조 정합 개선.
+
+## 산출물
+
+- 수정: src/parser/control/shape.rs, src/serializer/control.rs
+- 테스트: tests/issue_1929.rs
+- 문서: plans/task_m100_1929.md, 본 보고서

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -943,6 +943,17 @@ fn parse_picture(common: CommonObjAttr, shape_attr: ShapeComponentAttr, data: &[
                     crate::model::image::alpha_byte_to_transparency_percent(alpha);
             }
         }
+        // [#1929] extra 꼬리의 원본 이미지 크기(offset 9..17: w4+h4)를 img_dim 으로
+        // 적재 — HWPX `hp:imgDim` 대응 필드. 종전에는 HWP5 파스가 이를 읽지 않아
+        // HWPX→HWP5 왕복에서 imgDim 이 (0,0) 으로 소실됐다 (직렬화기 non-raw
+        // 경로가 기록해도 재파스가 버림).
+        if pic.raw_picture_extra.len() >= 17 {
+            let e = &pic.raw_picture_extra;
+            pic.img_dim = (
+                u32::from_le_bytes([e[9], e[10], e[11], e[12]]),
+                u32::from_le_bytes([e[13], e[14], e[15], e[16]]),
+            );
+        }
     }
 
     pic

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1071,8 +1071,15 @@ fn serialize_picture_data(pic: &Picture) -> Vec<u8> {
         w.write_u32(pic.instance_id).unwrap();
         w.write_u32(0).unwrap(); // image_effect_extra
                                  // 원본 이미지 크기(HWPUNIT) + 플래그(1): 한컴 호환 추가 9바이트
-        w.write_u32(pic.crop.right as u32).unwrap(); // original width in HWPUNIT
-        w.write_u32(pic.crop.bottom as u32).unwrap(); // original height in HWPUNIT
+                                 // [#1929] IR img_dim(HWPX hp:imgDim 대응)이 있으면 우선 기록 —
+                                 // 종전 crop 폴백만으로는 HWPX→HWP5 왕복에서 imgDim 소실.
+        let (dim_w, dim_h) = if pic.img_dim != (0, 0) {
+            pic.img_dim
+        } else {
+            (pic.crop.right as u32, pic.crop.bottom as u32)
+        };
+        w.write_u32(dim_w).unwrap(); // original width
+        w.write_u32(dim_h).unwrap(); // original height
         w.write_u8(pic.image_attr.transparency_alpha_byte())
             .unwrap();
     }

--- a/tests/issue_1929.rs
+++ b/tests/issue_1929.rs
@@ -1,0 +1,85 @@
+//! Issue #1929 — HWP5 저장: raw 미보존 그림의 imgDim (0,0) 소실.
+//!
+//! HWP5 PICTURE 레코드의 extra 꼬리(18바이트)에는 원본 이미지 크기 칸
+//! (offset 9..17)이 있는데, 종전에는 (1) HWP5 파서가 이를 `img_dim` 으로
+//! 읽지 않았고 (2) 직렬화기 non-raw 경로가 crop 폴백만 기록했다. HWPX 파스
+//! IR(hp:imgDim 보유, raw_picture_extra 없음)을 HWP5 로 저장-재파스하면
+//! imgDim 이 (0,0) 으로 소실됐다 (#1916 과 같은 raw-부재 재구성 결손 계열).
+
+use rhwp::model::control::Control;
+use rhwp::model::document::{Document, Section};
+use rhwp::model::image::Picture;
+use rhwp::model::paragraph::{LineSeg, Paragraph};
+use rhwp::model::style::CharShape;
+use rhwp::parser::parse_document;
+use rhwp::serializer::serialize_document;
+
+fn make_doc_with_pic(img_dim: (u32, u32)) -> Document {
+    let mut pic = Picture::default();
+    pic.image_attr.bin_data_id = 0; // 콘텐츠 없는 placeholder — img_dim 축만 검증
+    pic.img_dim = img_dim;
+    pic.common.width = 8000;
+    pic.common.height = 6000;
+    assert!(pic.raw_picture_extra.is_empty());
+
+    let host = Paragraph {
+        char_count: 1,
+        line_segs: vec![LineSeg {
+            line_height: 1000,
+            line_spacing: 600,
+            ..Default::default()
+        }],
+        controls: vec![Control::Picture(Box::new(pic))],
+        ..Default::default()
+    };
+
+    let mut doc = Document::default();
+    doc.doc_info.char_shapes.push(CharShape::default());
+    let mut section = Section::default();
+    section.paragraphs.push(host);
+    doc.sections.push(section);
+    doc
+}
+
+fn find_pic(doc: &Document) -> &Picture {
+    for para in &doc.sections[0].paragraphs {
+        for ctrl in &para.controls {
+            if let Control::Picture(p) = ctrl {
+                return p;
+            }
+        }
+    }
+    panic!("pic 미발견");
+}
+
+/// raw 미보존 그림의 imgDim 이 plain HWP5 왕복(2-round 포함)에서 보존된다.
+#[test]
+fn issue_1929_img_dim_survives_plain_hwp5_roundtrip() {
+    let doc = make_doc_with_pic((117_780, 35_760));
+    let bytes = serialize_document(&doc).expect("serialize");
+    let doc2 = parse_document(&bytes).expect("reparse");
+    assert_eq!(
+        find_pic(&doc2).img_dim,
+        (117_780, 35_760),
+        "imgDim (0,0) 소실 회귀 (#1929)"
+    );
+
+    // 2-round 안정성: 재파스 IR(raw_picture_extra 채워짐)의 재직렬화도 보존.
+    let bytes2 = serialize_document(&doc2).expect("serialize 2");
+    let doc3 = parse_document(&bytes2).expect("reparse 2");
+    assert_eq!(find_pic(&doc3).img_dim, (117_780, 35_760), "2-round 보존");
+}
+
+/// img_dim 없는(0,0) 그림은 종전 crop 폴백 동작이 유지된다.
+#[test]
+fn issue_1929_zero_img_dim_keeps_crop_fallback() {
+    let mut doc = make_doc_with_pic((0, 0));
+    if let Control::Picture(p) = &mut doc.sections[0].paragraphs[0].controls[0] {
+        p.crop.right = 4321;
+        p.crop.bottom = 1234;
+    }
+    let bytes = serialize_document(&doc).expect("serialize");
+    let doc2 = parse_document(&bytes).expect("reparse");
+    // crop 폴백값이 원본 크기 칸에 기록되고 재파스 img_dim 으로 읽힌다.
+    assert_eq!(find_pic(&doc2).img_dim, (4321, 1234), "crop 폴백 유지");
+}


### PR DESCRIPTION
## 요약

#1929 (raw 미보존 그림의 imgDim (0,0) 왕복 소실, #1916 계열) 수정.

## 근본 원인

HWP5 PICTURE 레코드 extra 꼬리(18바이트 = opacity1+instance4+effect4+**w4+h4**+alpha1)에 원본 이미지 크기 칸이 존재하는데, IR `img_dim`(HWPX `hp:imgDim` 대응, #1389)과 **양방향 모두 미연결**이었습니다:

1. **파서**: extra 를 raw 보존만 하고 img_dim 으로 읽지 않음 → 재파스 (0,0)
2. **직렬화기**: non-raw 경로가 crop 폴백만 기록 (img_dim 무시)

HWPX 파스 IR(hp:imgDim 보유, raw_picture_extra 없음)·편집기 신설 그림의 plain HWP5 저장-재파스에서 imgDim 소실 — #1916(표 CommonObjAttr)과 같은 raw-부재 재구성 결손 계열입니다.

## 수정

- `parser/control/shape.rs`: extra ≥17 바이트면 offset 9..17 → `img_dim` 적재 (native HWP5 는 raw verbatim 재기록이라 2-round 안정)
- `serializer/control.rs`: non-raw 경로에서 `img_dim != (0,0)` 우선 기록, (0,0) 은 종전 crop 폴백 유지 — 최상위/그룹 자식 pic 공통 (이슈의 본문/표 셀/글상자 발현 전부 커버)

## 검증

- 인메모리 핀 2건 (`tests/issue_1929.rs`): (117780,35760) 왕복 + 2-round 보존 / (0,0)+crop 폴백 불변
- **서베이 잔여 2건 실파일**: 전체 pic 3개 img_dim 왕복 **3/3 보존** — 이슈 expected 값 정확 일치
- hwp5/hwpx roundtrip baseline + issue_1893 핀 PASS
- img_dim 은 렌더 미소비 필드(HWPX 직렬화·게이트 전용) — 코퍼스 렌더 A/B 불필요, 풀 스위트는 본 PR CI 위임

## 부수 효과

HWP5→HWPX 변환의 `hp:imgDim` 이 0 대신 실값 방출 — 한컴 원본과의 구조 정합 개선.

Closes #1929

🤖 Generated with [Claude Code](https://claude.com/claude-code)
