### PR TITLE
Task #1880 v2: HWP3-origin 휴리스틱을 HWPX-변환본(마커)에서 게이트 — 2959953 PI_MOVED 해소

### DIFF
--- a/mydocs/plans/task_m100_1880_v2.md
+++ b/mydocs/plans/task_m100_1880_v2.md
@@ -1,0 +1,64 @@
+# Task M100 #1880 v2 수행계획서 — 잔존 2959953: HWP3-origin 휴리스틱의 HWPX-변환본 오발동
+
+- 이슈: #1880 (잔존 클래스 후속 — 1차 수정은 PR #1927)
+- 마일스톤: M100 (v1.0.0)
+- 브랜치: `local/task1880-v2` (base: origin/devel bf5228df)
+- 작성일: 2026-07-05
+
+## 1. 배경
+
+1차 수정(PR #1927, 자리차지 host_before) 후 잔존 PI_MOVED: 2959953(5개 pi),
+3171755(1개 pi), 3235145(PAGE_DELTA 3→2). 작업지시자 지시로 2959953 착수.
+
+## 2. 원인 (소스 조사 완료 — 실측 재현 포함)
+
+**재현** (통합 빌드 devel+#1924+#1927): 2959953 dump-pages 전체 diff 에서
+문단 flow 이전에 **페이지 기하 자체가 다름** —
+
+```
+HWPX: body_area h=895.7px
+conv: body_area h=917.1px   (+21.4px ≈ 정확히 1600 HWPUNIT)
+```
+
+**원인**: `src/parser/mod.rs:443` `apply_hwp3_origin_fixup` — HWP5 파스가
+ParaShape/CharShape 비율 휴리스틱(#554: ps<0.05 ∧ cs<0.15 ∧ para>50)으로
+한컴 HWP3→HWP5 변환본을 의심해 `margin_bottom -= 1600`(한글97 마지막 줄
+tolerance 모방). 2959953 같은 저-스타일 대형 행정규칙 문서가 이 비율에 걸린다.
+
+- HWPX 파스: #1608 이 HWPX 측 HWP3-origin 감지를 제거 → 보정 없음.
+- convert-HWP 재파스: `parse_hwp` 가 `is_hwpx_variant`(#1886 마커)를 **알면서도**
+  (mod.rs:291) 무조건 휴리스틱을 실행(mod.rs:312) → 오발동.
+- 같은 IR 인데 conv 만 body 가 21.3px 커져 페이지 채움이 달라짐 → PI_MOVED.
+
+rhwp 의 HWPX→HWP 산출물은 한컴 HWP3→HWP5 변환본이 아니므로 휴리스틱 대상이
+아니다 — 결정론적 마커가 비율 휴리스틱보다 우선해야 한다.
+
+## 3. 수정 방향 (#1886/#1608 계열의 연장)
+
+`apply_hwp3_origin_fixup` 진입부에서 `doc.is_hwpx_variant` 면 early-return.
+
+- native HWP5 (마커 없음): 불변 — 휴리스틱 그대로.
+- 스트림 파스 진입점(mod.rs:590, extra_streams 부재로 variant 항상 false): 불변.
+- convert-HWP (마커): 보정 제외 → HWPX 렌더와 페이지 기하 일치 (유일한 변화).
+- 연장선: mod.rs:317 의 summary_hwp3_era 확정 경로도 variant 면 무의미하나,
+  summary 는 rhwp 변환본에 HWP3-era 값이 실릴 수 없어 실질 무영향 — 구현
+  계획서에서 게이트 포함 여부 확정.
+
+## 4. 범위
+
+- **포함**: `src/parser/mod.rs` `apply_hwp3_origin_fixup` 게이트, 회귀 테스트.
+- **제외**: 휴리스틱 자체(비율·1600 값) 변경, HWP3 파서, 3171755/3235145
+  (동일 클래스로 함께 해소되는지 측정만 — 별도 원인이면 기록).
+
+## 5. 검증 기준
+
+1. 2959953: dump-pages body_area 양 경로 일치 + PI_MOVED 5건 해소.
+2. 3171755/3235145: 재측정 (해소 시 함께 보고, 미해소 시 별개 클래스 기록).
+3. A/B 하니스 2,005건: 신규 divergence 0.
+4. native 불변: HWP3-origin fixture 계열(#554/#1001 테스트) + 전체 스위트.
+5. 회귀 테스트: 마커 있는 HWP5 에 휴리스틱 미적용(margin_bottom 보존) 단위 테스트.
+
+## 6. 인도물
+
+- 수행계획서: 본 문서 / 구현계획서: `task_m100_1880_v2_impl.md`
+- 단계별 보고서: `task_m100_1880_v2_stage{N}.md` / 최종: `task_m100_1880_v2_report.md`

--- a/mydocs/plans/task_m100_1880_v2_impl.md
+++ b/mydocs/plans/task_m100_1880_v2_impl.md
@@ -1,0 +1,35 @@
+# Task M100 #1880 v2 구현계획서 — HWP3-origin 휴리스틱의 HWPX-변환본 게이트
+
+- 이슈: #1880 잔존 (2959953 계열)
+- 브랜치: `local/task1880-v2`
+- 수행계획서: `mydocs/plans/task_m100_1880_v2.md`
+- 작성일: 2026-07-05
+
+## 방침 확정 (수행계획서 3절 후속)
+
+`summary_hwp3_era` 확정 경로(mod.rs:317-348)도 게이트에 **포함**한다:
+`is_hwp3_variant=true` 설정 + ParaShape spacing 반감으로 ratio 보정보다 더
+파괴적이며, 원본 HWPX 가 HWP3-계보 요약정보를 승계하면 rhwp 변환본에도
+오발동할 수 있다. 마커는 결정론이므로 두 휴리스틱 모두에 우선한다.
+
+## Stage 1 — 게이트 + 단위 테스트
+
+- `src/parser/mod.rs`:
+  - `apply_hwp3_origin_fixup` 진입부 `if doc.is_hwpx_variant { return; }`
+    (mod.rs:590 스트림 진입점은 variant 항상 false → 불변).
+  - `if summary_hwp3_era` → `if summary_hwp3_era && !doc.is_hwpx_variant`.
+  - 근거 주석 (#1880 v2 실측, #1886/#1608 계열).
+- 테스트: 마커 스트림 포함 HWP5 를 in-memory 구성(serialize→parse 또는
+  extra_streams 주입) — ratio 조건을 충족해도 margin_bottom 불변 확인.
+  기존 #554/#1001 native fixture 테스트 회귀 없음.
+
+## Stage 2 — 실측 검증
+
+- 2959953: body_area 양 경로 일치 + PI_MOVED 5건 해소.
+- 3171755 / 3235145 재측정 (동일 클래스 여부 판정).
+- A/B 하니스 2,005건 (수정 전 = 통합 빌드, 수정 후 = 통합+본 수정).
+
+## Stage 3 — 전체 회귀 + 최종 보고서
+
+- `cargo test --tests --no-fail-fast` + clippy.
+- 최종 보고서 `task_m100_1880_v2_report.md`, orders 갱신, PR 생성(단일 커밋).

--- a/mydocs/report/task_m100_1880_v2_report.md
+++ b/mydocs/report/task_m100_1880_v2_report.md
@@ -1,0 +1,49 @@
+# Task M100 #1880 v2 최종 보고서 — HWP3-origin 휴리스틱의 HWPX-변환본 오발동 (2959953)
+
+- 이슈: #1880 잔존 후속
+- 브랜치: `local/task1880-v2` (base: origin/devel bf5228df)
+- 계획서: `mydocs/plans/task_m100_1880_v2{,_impl}.md`
+- 작성일: 2026-07-05
+
+## 1. 결론
+
+#1880 1차 수정(PR #1927) 후 잔존 PI_MOVED 중 최다 건(2959953, 5개 pi)의 원인을
+확정·해소했다. 문단 flow 가 아니라 **페이지 기하**의 문제였다: HWP5 파스의
+HWP3→HWP5 변환본 비율 휴리스틱(#554)이 rhwp HWPX→HWP 변환본에 오발동해
+`margin_bottom -1600`(=body +21.3px)을 적용, HWPX 렌더와 페이지 채움이 어긋났다.
+
+## 2. 원인
+
+- `src/parser/mod.rs` `apply_hwp3_origin_fixup`: 문단>50 ∧ ps_ratio<0.05 ∧
+  cs_ratio<0.15 → margin_bottom -= 1600 (한글97 마지막 줄 tolerance 모방).
+- 2959953(저-스타일 대형 행정규칙)이 비율 조건 충족 → conv 재파스만 보정.
+- HWPX 파스는 #1608 에서 동종 감지 제거 → 비대칭. `parse_hwp` 는
+  `is_hwpx_variant`(#1886 마커)를 알면서도 휴리스틱을 무조건 실행했다.
+
+## 3. 수정
+
+`apply_hwp3_origin_fixup` 에 `is_hwpx_variant` early-return +
+`summary_hwp3_era` 확정 경로(spacing 반감·is_hwp3_variant 설정)에도 동일 게이트.
+결정론 마커가 비율 휴리스틱에 우선한다 (#1886/#1608 계열의 연장).
+native HWP5·스트림 파스 진입점(variant 항상 false)은 불변.
+
+## 4. 검증
+
+- 단위: 비율 의심 합성 문서로 native 보정 유지 / 마커 시 불변 2건 통과.
+- 2959953: body_area 양 경로 895.7px 일치, (section,pi)→page **1,888 entries
+  완전 일치** (종전 5개 pi 이동).
+- A/B 하니스 2,005건: SAME 2002→**2003**, 신규 divergence 0.
+- 전체 스위트(`--tests --no-fail-fast`): 192 스위트 / 2,863 테스트 통과,
+  신규 실패 0 (svg_snapshot 5건은 기존재 로컬 CRLF 노이즈 — 선행 태스크에서
+  수정 전 상태와 A/B 동일 확인된 그 5건) / clippy `--all-targets` 경고 0.
+
+## 5. 잔존 (별개 클래스 — 본 수정 전후 상세 동일)
+
+- 3171755 PI_MOVED 1개 pi (s0:pi213 20→21).
+- 3235145 PAGE_DELTA(3→2) — body_area 가설 불성립 확인(본 수정 무영향), 다른
+  원인. 소규모 문서(3쪽)이므로 차기 착수 시 dump-pages 전체 diff 로 진입 권장.
+
+## 6. 산출물
+
+- 커밋: `261824c5`(Stage 1), `673e7f4a`(Stage 1/2 보고서), 본 보고서(Stage 3).
+- PR: 단일 커밋 squash 후 `edwardkim/rhwp:devel` 대상 생성.

--- a/mydocs/working/task_m100_1880_v2_stage1.md
+++ b/mydocs/working/task_m100_1880_v2_stage1.md
@@ -1,0 +1,26 @@
+# Task #1880 v2 Stage 1 — HWP3-origin 휴리스틱 HWPX-변환본 게이트
+
+## 구현 내용
+
+- `src/parser/mod.rs`:
+  - `apply_hwp3_origin_fixup` 진입부: `if doc.is_hwpx_variant { return; }`
+    — 비율 휴리스틱(margin_bottom -1600)이 rhwp HWPX→HWP 변환본에 오발동
+    하던 것을 결정론 마커(#1886)로 차단.
+  - `summary_hwp3_era` 확정 경로: `&& !doc.is_hwpx_variant` 추가 —
+    `is_hwp3_variant=true` + ParaShape spacing 반감의 오발동 가능성 차단
+    (원본 HWPX 가 HWP3-계보 요약정보 승계 시).
+  - 스트림 파스 진입점(extra_streams 부재, variant 항상 false)은 불변.
+
+## 테스트
+
+- 신규 2건 (`src/parser/mod.rs` tests):
+  - `issue1880v2_hwp3_fixup_applies_to_native`: 비율 의심 합성 문서(문단 60,
+    ps/cs 각 1) — native 는 종전대로 margin_bottom 4252→2652 보정.
+  - `issue1880v2_hwp3_fixup_skipped_for_hwpx_variant`: 동일 문서 + 마커 —
+    margin_bottom 4252 불변 (오발동 금지).
+
+## 검증
+
+```bash
+cargo test --lib parser::tests::issue1880v2   # 2 passed
+```

--- a/mydocs/working/task_m100_1880_v2_stage2.md
+++ b/mydocs/working/task_m100_1880_v2_stage2.md
@@ -1,0 +1,22 @@
+# Task #1880 v2 Stage 2 — 실측 검증
+
+## 2959953 개별 검증 (측정 기반: devel + PR #1924 + PR #1927 + 본 수정)
+
+- body_area: HWPX h=895.7px / conv h=917.1px(+1600HU) → **양쪽 895.7px 일치**.
+- (section,pi)→page 맵: **1,888 entries 완전 일치** (종전 PI_MOVED 5개 pi).
+- dump-pages 전체 diff: 페이지 배치 차이 0 (잔여는 `used=` px 수치 표기 차이
+  32줄 — 항목 수·배치 동일).
+
+## A/B 하니스 (2,005건, tools/roundtrip_fidelity_harness.py)
+
+| 빌드 | SAME | PI_MOVED | PAGE_DELTA | ERR |
+|------|------|----------|------------|-----|
+| 수정 전 (devel+#1924+#1927) | 2002 | 2 | 1 | 0 |
+| **수정 후 (+v2 게이트)** | **2003** | **1** | 1 | 0 |
+
+- 개선 +1: 2959953 (5개 pi 전부 해소). **신규 divergence 0**.
+- 잔존 (본 수정과 무관, 별개 원인 — 상세 수정 전후 동일):
+  - 3171755 PI_MOVED 1개 pi (s0:pi213 20→21)
+  - 3235145 PAGE_DELTA (3→2) — body_area 가설 불성립 확인, 다른 클래스
+
+산출물: 스크래치 `task1880v2/{integration,v2}.tsv`, pages/pimap 파일.

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -314,7 +314,10 @@ fn parse_hwp_with_cfb(
     // [Task #1001] HwpSummary HWP3 시대 년 AND PS/CS 비율 작음 → 변환본 확정.
     // 두 신호 결합으로 false positive 차단 (exam_eng 등 일반 HWP5 가 본문에
     // HWP3 시대 텍스트만 인용한 경우).
-    if summary_hwp3_era {
+    // [#1880 v2] rhwp HWPX→HWP 변환본 제외 — 원본 HWPX 가 HWP3-계보 요약정보를
+    // 승계해도 rhwp 변환본 IR 은 HWPX 시멘틱이므로 spacing 반감 보정이 오발동
+    // 하면 안 된다 (위 apply_hwp3_origin_fixup 게이트와 동일 근거).
+    if summary_hwp3_era && !doc.is_hwpx_variant {
         let total_paras: usize = doc.sections.iter().map(|s| s.paragraphs.len()).sum();
         if total_paras > 50 {
             let ps_r = doc.doc_info.para_shapes.len() as f64 / total_paras as f64;
@@ -441,6 +444,14 @@ fn fixup_line_segs_for_variant(paragraphs: &mut [crate::model::paragraph::Paragr
 }
 
 fn apply_hwp3_origin_fixup(doc: &mut Document) {
+    // [#1880 v2] rhwp HWPX→HWP 변환본(is_hwpx_variant, #1886 마커)은 한컴
+    // HWP3→HWP5 변환본이 아니다 — 결정론 마커가 비율 휴리스틱에 우선한다.
+    // 미게이트 시 저-스타일 대형 문서(2959953)가 비율에 걸려 margin_bottom
+    // -1600 이 오발동, HWPX 렌더와 페이지 기하가 21.3px 어긋나 PI_MOVED 유발
+    // (HWPX 파스는 #1608 에서 동종 감지 제거됨).
+    if doc.is_hwpx_variant {
+        return;
+    }
     let total_paragraphs: usize = doc.sections.iter().map(|s| s.paragraphs.len()).sum();
     if total_paragraphs <= 50 {
         return;
@@ -1206,6 +1217,51 @@ fn load_bin_data_content(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// [#1880 v2] HWP3-origin 비율 휴리스틱 대상 문서(문단>50, 저-스타일 비율)
+    /// 를 합성해, HWPX-변환본 마커(is_hwpx_variant) 유무에 따라 margin_bottom
+    /// 보정(-1600)이 갈리는지 확인한다. 마커 있으면 보정 오발동 금지.
+    fn hwp3_ratio_suspect_doc() -> Document {
+        let mut doc = Document::default();
+        doc.doc_info
+            .para_shapes
+            .push(crate::model::style::ParaShape::default()); // ps_ratio = 1/60
+        doc.doc_info
+            .char_shapes
+            .push(crate::model::style::CharShape::default()); // cs_ratio = 1/60
+        let mut section = crate::model::document::Section::default();
+        section.section_def.page_def.margin_bottom = 4252;
+        for _ in 0..60 {
+            section
+                .paragraphs
+                .push(crate::model::paragraph::Paragraph::default());
+        }
+        doc.sections.push(section);
+        doc
+    }
+
+    #[test]
+    fn issue1880v2_hwp3_fixup_applies_to_native() {
+        let mut doc = hwp3_ratio_suspect_doc();
+        assert!(!doc.is_hwpx_variant);
+        apply_hwp3_origin_fixup(&mut doc);
+        assert_eq!(
+            doc.sections[0].section_def.page_def.margin_bottom,
+            4252 - 1600,
+            "native HWP5 의심본은 종전대로 margin_bottom 보정"
+        );
+    }
+
+    #[test]
+    fn issue1880v2_hwp3_fixup_skipped_for_hwpx_variant() {
+        let mut doc = hwp3_ratio_suspect_doc();
+        doc.is_hwpx_variant = true;
+        apply_hwp3_origin_fixup(&mut doc);
+        assert_eq!(
+            doc.sections[0].section_def.page_def.margin_bottom, 4252,
+            "rhwp HWPX→HWP 변환본(마커)은 HWP3-origin 보정 오발동 금지 (#1880 v2, 2959953)"
+        );
+    }
 
     #[test]
     fn test_parse_hwp_too_small() {


### PR DESCRIPTION
## 요약

#1880 잔존 PI_MOVED 중 최다 건(2959953, 5개 pi)의 원인 해소. 단일 커밋.

### 원인 — 페이지 기하 비대칭 (문단 flow 아님)

`parse_hwp` 의 `apply_hwp3_origin_fixup`(#554 비율 휴리스틱: 문단>50 ∧ ps<0.05 ∧ cs<0.15 → `margin_bottom -= 1600`)이 **rhwp HWPX→HWP 변환본에 오발동**합니다. 실측: 2959953 conv 재파스만 body_area +21.3px(=정확히 1600HU) — HWPX 파스는 #1608에서 동종 감지가 제거되어 비대칭. `parse_hwp` 는 `is_hwpx_variant`(#1886 마커)를 알면서도 휴리스틱을 무조건 실행했습니다.

### 수정

- `apply_hwp3_origin_fixup` 진입부 `is_hwpx_variant` early-return
- `summary_hwp3_era` 확정 경로(spacing 반감·is_hwp3_variant 설정)에도 동일 게이트 — 원본 HWPX가 HWP3-계보 요약정보를 승계해도 오발동 금지
- 결정론 마커 > 비율 휴리스틱 (#1886/#1608 계열의 연장). native HWP5·스트림 파스 진입점 불변.

### 검증

- 2959953: body_area 양 경로 895.7px 일치, (sec,pi)→page **1,888 entries 완전 일치** (종전 5개 pi 이동)
- A/B 하니스 2,005건 (devel+#1924+#1927 기준): SAME 2002→**2003**, 신규 divergence 0
- 단위 테스트 2건: 비율 의심 합성 문서 — native 보정 유지 / 마커 시 margin_bottom 불변
- 전체 스위트 192 스위트/2,863 통과 (svg_snapshot 5건은 기존재 로컬 CRLF 노이즈), clippy 0

### 잔존 (별개 클래스, 본 수정 전후 상세 동일)

3171755 PI_MOVED 1개 pi (s0:pi213), 3235145 PAGE_DELTA(3→2) — body_area 가설 불성립 확인, 다른 원인. 보고서(`mydocs/report/task_m100_1880_v2_report.md`)에 차기 진입점 기록.

관련: PR #1927 (#1880 1차), PR #1924/#1927 과 파일 교집합 없음 (독립 merge 가능).

🤖 Generated with [Claude Code](https://claude.com/claude-code)