### PR TITLE
Task #1939: HWP5-origin HWPX render-diff 구조 불일치 수정

### DIFF
--- a/mydocs/orders/20260705.md
+++ b/mydocs/orders/20260705.md
@@ -5,6 +5,7 @@
 | PR | 내용 | 처리 |
 |----|------|------|
 | #1911 | #1655 HWPX 수식 `flowWithText` roundtrip 보존 | 옵션 1 self PR 생성. `render_equation`의 `flowWithText="1"` 하드코딩을 제거하고 `Equation.common.flow_with_text`를 방출하도록 수정. 수식 `flowWithText=0` serialize→parse roundtrip 테스트와 `diff_documents` `ObjectFlowWithText` 게이트 테스트 추가. 로컬 검증(`task1655`, `serializer::hwpx`, fmt, diff-check, `clippy --lib`) 통과. renderer/layout 변경이 아니라 visual sweep 대상 아님. review 문서 `mydocs/pr/archives/pr_1911_review*.md`를 PR head에 포함 후 GitHub Actions 대기 |
+| #1941 | #1939 HWP5-origin HWPX 76076 strict render-diff 구조 불일치 | 옵션 1 self PR 생성. `missing_lineseg_placeholder`가 TAC 표 높이 보정에서 실제 LineSeg처럼 오염되는 경로를 차단하고, 76076 `render-diff --via hwpx` strict PASS를 `tests/issue_1939.rs`로 고정. 로컬 검증(`render-diff`, `export-hwpx --verify-pages`, `issue_1939`, `issue_1891`, `clippy --test issue_1939`, diff-check) 통과. 작업지시자 full integration 검증 `cargo test --profile release-test --tests` 통과. review 문서 `mydocs/pr/archives/pr_1941_review*.md`를 PR head에 포함 후 GitHub Actions 대기 |
 
 
 ## 타스크

--- a/mydocs/pr/archives/pr_1941_review.md
+++ b/mydocs/pr/archives/pr_1941_review.md
@@ -1,0 +1,82 @@
+# PR #1941 Review
+
+## 메타
+
+| 항목 | 값 |
+|------|----|
+| PR | #1941 |
+| 제목 | Task #1939: HWP5-origin HWPX render-diff 구조 불일치 수정 |
+| 작성자 | jangster77 |
+| base | devel |
+| head | task/m100-1939-76076-renderdiff |
+| 관련 이슈 | #1939 |
+| 규모 | 작성 시점 참고값: 3 files, +122/-1 |
+| mergeable | 작성 시점 참고값: MERGEABLE / BLOCKED |
+
+최종 merge 조건은 PR head 최신 커밋 기준 GitHub Actions 통과와 작업지시자 승인이다.
+
+## 변경 범위
+
+- `DocumentCore::reflow_zero_height_paragraphs()`의 TAC 표 높이 보정에서
+  `LineSeg::missing_lineseg_placeholder()` 단일 문단을 제외한다.
+- `tests/issue_1939.rs`를 추가해 76076 HWP5-in-.hwpx 샘플의
+  `roundtrip_geom(..., Via::Hwpx)` strict 구조 안정성을 고정한다.
+- `mydocs/working/task_m100_1939_stage1.md`에 원인 분석과 검증 결과를 기록한다.
+
+## 원인 검토
+
+#1939의 증상은 #1936 이후 페이지 수는 82쪽으로 맞지만, `render-diff --via hwpx` strict 기준에서
+page 38/39 구조가 갈라지는 것이었다.
+
+원본 HWP5-in-.hwpx의 해당 구간에는 TAC RowBreak 표 host 문단이 있고, HWP5 원본 문단에는
+`line_segs`가 없다. HWP5-origin HWPX export는 이 의미를 보존하려고
+`missing_lineseg_placeholder`를 출력한다. 이 marker는 HWPX 재파스 후 reflow gate에서만 쓰이고,
+이후 제거되어 HWP5 원본과 같은 `line_segs.is_empty()` 경로를 타야 한다.
+
+하지만 HWPX 로드 중 TAC 표 높이 보정이 marker의 `line_height`를 표 높이로 바꾸면서
+`clear_missing_lineseg_placeholders()` 제거 조건을 깨뜨렸다. 그 결과 roundtrip 문서만 실제
+LineSeg가 있는 것처럼 처리되어 page 38/39 경계가 밀렸다.
+
+이번 수정은 샘플명, 페이지 번호, 임의 계수가 아니라 `LineSeg` marker의 문서 IR 의미에 근거한다.
+
+## 렌더 영향과 시각 검증 판정
+
+렌더/pagination 영향이 있는 변경이다. 다만 이번 PR의 merge 판단 근거는 기준 PDF와의 사람이 보는
+visual sweep이 아니라, 같은 입력의 HWPX roundtrip 기하 구조가 보존되는지 확인하는 strict
+`render-diff --via hwpx`이다.
+
+실측 결과:
+
+- 수정 전: page 38/39 구조 불일치, 최대 변위 642.53px, `STRUCT_MISMATCH`
+- 수정 후: 페이지 수 A=82 B=82, 구조 불일치 페이지 0, `status: PASS`
+
+따라서 `mydocs/pr/assets/`에 별도 visual PNG asset은 남기지 않는다. 검증 근거는
+`tests/issue_1939.rs`와 stage 문서에 기록된 render-diff 결과다.
+
+## 로컬 검증
+
+- `env CARGO_INCREMENTAL=0 cargo build --bin rhwp`: 통과
+- `target/debug/rhwp render-diff samples/issue1891/76076_regulatory_analysis.hwpx --via hwpx`: PASS
+- `target/debug/rhwp export-hwpx samples/issue1891/76076_regulatory_analysis.hwpx tmp/issue1939/after/76076-roundtrip.hwpx --verify-pages`: 82쪽 통과
+- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1939`: 통과
+- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1891`: 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --test issue_1939 -- -D warnings`: 통과
+- `git diff --check`: 통과
+- 작업지시자 검증: `cargo test --profile release-test --tests` 통과
+
+## 리스크
+
+- TAC 표 host 문단의 LineSeg 높이 보정 경로를 건드리지만, 제외 대상은
+  `missing_lineseg_placeholder` 단일 문단으로 한정된다.
+- HWPX 일반 문서의 누락 LineSeg reflow 및 HWPX RowBreak 합성 보정 경로는 유지된다.
+- #1891 HWP5-origin 샘플군 페이지 수 보존 테스트가 통과했다.
+
+## 결론
+
+merge 후보로 판단한다.
+
+merge 전 조건:
+
+- PR head 최신 커밋 기준 GitHub Actions 통과
+- PR head에 review 문서와 오늘할일 기록 포함
+- 작업지시자 최종 승인

--- a/mydocs/pr/archives/pr_1941_review_impl.md
+++ b/mydocs/pr/archives/pr_1941_review_impl.md
@@ -1,0 +1,55 @@
+# PR #1941 Review Impl
+
+## Stage 1. PR 생성
+
+완료.
+
+- 코드 커밋: `54e3baeda task 1939: HWP5-origin HWPX LineSeg marker 보존`
+- PR: https://github.com/edwardkim/rhwp/pull/1941
+- base: `devel`
+- head: `task/m100-1939-76076-renderdiff`
+
+## Stage 2. 변경 검토
+
+완료.
+
+- HWP5-origin HWPX export marker가 TAC 표 높이 보정에서 실제 LineSeg처럼 변형되는 경로를 확인했다.
+- 보정은 `missing_lineseg_placeholder` 단일 문단에 한정해 TAC 높이 보정에서 제외한다.
+- 특정 샘플명/페이지 번호/임의 계수 분기가 아니라 `LineSeg` marker의 IR 의미에 기반한다.
+
+## Stage 3. 검증
+
+완료.
+
+- `render-diff --via hwpx`: 76076 샘플 PASS
+- `issue_1939`: 통과
+- `issue_1891`: 통과
+- `clippy --test issue_1939`: 통과
+- `git diff --check`: 통과
+- 작업지시자 full integration 검증: `cargo test --profile release-test --tests` 통과
+
+## Stage 4. 옵션 1 문서 반영
+
+진행 중.
+
+- `mydocs/pr/archives/pr_1941_review.md`
+- `mydocs/pr/archives/pr_1941_review_impl.md`
+- `mydocs/orders/20260705.md`
+
+위 문서를 PR head에 추가 커밋으로 포함한다.
+
+## Stage 5. merge 전 조건
+
+- GitHub Actions 최신 head 기준 통과 확인
+- 작업지시자 최종 승인
+
+## Stage 6. merge 후 후속 처리
+
+`mydocs/manual/pr_review_workflow.md` 7장에 따라 순차 처리한다.
+
+- merge SHA 확인
+- #1939 auto-close 여부 확인
+- auto-close 여부와 관계없이 #1939에 검증 코멘트 남김
+- PR #1941 코멘트
+- `devel` sync
+- 로컬/원격 PR head 브랜치 정리

--- a/mydocs/working/task_m100_1939_stage1.md
+++ b/mydocs/working/task_m100_1939_stage1.md
@@ -1,0 +1,67 @@
+# Task m100 #1939 Stage 1
+
+## 목표
+
+`samples/issue1891/76076_regulatory_analysis.hwpx` 는 확장자만 HWPX인 HWP5(OLE/CFB)
+샘플이다. #1936 이후 페이지 수는 82쪽으로 안정화되었지만,
+`render-diff --via hwpx` strict 비교에서 page 38/39 구조 불일치가 남는다.
+
+## 재현
+
+```bash
+target/debug/rhwp render-diff samples/issue1891/76076_regulatory_analysis.hwpx --via hwpx
+```
+
+현재 결과:
+
+- 페이지 수: A=82 B=82
+- 최대 변위: 642.53px (page 39)
+- 구조 불일치 페이지: 2
+- status: `STRUCT_MISMATCH`
+
+## 진행 원칙
+
+- 특정 샘플명, 페이지 번호, 이슈 번호, 임의 계수로 결과를 맞추지 않는다.
+- 보정은 입력 문서에서 읽을 수 있는 `LineSeg`, `ParaShape`, `CharShape`, 표/셀 속성,
+  control 속성, section/page 속성 또는 공개 스펙 필드에 근거한다.
+- 우선 원본 HWP5-in-.hwpx와 export HWPX 재파스 결과의 page 38/39 render tree 차이를 비교해
+  어떤 문서 속성이 왕복 중 바뀌는지 확인한다.
+
+## 분석
+
+- page 38/39 경계에서 원본은 `pi=370..374`와 `pi=375`의 첫 RowBreak 조각이 page 38에
+  남지만, roundtrip HWPX 재파스 결과는 `pi=370` 이후가 page 39로 밀렸다.
+- 해당 구간의 원본 HWP5 문단은 TAC 표 host 문단이면서 `line_segs`가 비어 있다.
+- HWP5-origin HWPX export는 원본 `LineSeg` 부재 의미를 보존하기 위해
+  `LineSeg::missing_lineseg_placeholder()`를 출력한다.
+- HWPX 로드 중 TAC 표 높이 보정이 이 placeholder의 `line_height`를 표 높이로 바꾸면서
+  `clear_missing_lineseg_placeholders()` 제거 조건을 통과하지 못했다.
+- 그 결과 roundtrip 문서만 권위 있는 `LineSeg`를 가진 것으로 처리되어 표 배치 경계가 바뀌었다.
+
+## 수정
+
+- `DocumentCore::reflow_zero_height_paragraphs()`의 TAC 표 높이 보정에서
+  `missing_lineseg_placeholder` 단일 문단은 보정 대상에서 제외했다.
+- 이 marker는 reflow gate 전용이며, 이후 제거되어 HWP5 원본과 같은
+  `line_segs.is_empty()` 경로를 타야 한다.
+
+## 검증
+
+```bash
+env CARGO_INCREMENTAL=0 cargo build --bin rhwp
+target/debug/rhwp render-diff samples/issue1891/76076_regulatory_analysis.hwpx --via hwpx
+target/debug/rhwp export-hwpx samples/issue1891/76076_regulatory_analysis.hwpx tmp/issue1939/after/76076-roundtrip.hwpx --verify-pages
+```
+
+결과:
+
+- `render-diff --via hwpx`: `페이지 수 A=82 B=82`, `구조 불일치 페이지: 0`, `status: PASS`
+- `export-hwpx --verify-pages`: 82쪽 검증 통과
+
+회귀 테스트:
+
+- `tests/issue_1939.rs` 추가
+- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1939`: 통과
+- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1891`: 통과
+- `env CARGO_INCREMENTAL=0 cargo clippy --test issue_1939 -- -D warnings`: 통과
+- `git diff --check`: 통과

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -302,7 +302,12 @@ impl DocumentCore {
                             }
                         }
                     }
-                    if max_tac_h > 0 {
+                    if max_tac_h > 0
+                        && !matches!(
+                            para.line_segs.as_slice(),
+                            [seg] if seg.is_missing_lineseg_placeholder()
+                        )
+                    {
                         // [Task #1068] 이미 표 높이를 담은 LINE_SEG 가 있으면(한컴이
                         // 저장한 실제 linesegarray 보유 — 표 줄 seg 의 vertsize 가 표
                         // 높이) 보정 불필요. 무조건 first_mut() 을 확대하면 표가 두 번째
@@ -312,6 +317,10 @@ impl DocumentCore {
                         // para 567: 제목줄 vertsize=2200 → 63234 오염, 839px overflow).
                         // linesegarray 가 없어 기본 lh=100 단일 seg 만 있는 경우에만
                         // 첫 seg 를 표 높이로 확대한다.
+                        // HWP5-origin HWPX export marker 는 "원본 LineSeg 부재"를 보존하기
+                        // 위한 임시 표식이므로 여기서 표 높이로 오염시키면 안 된다.
+                        // 이 marker 는 reflow gate 후 clear_missing_lineseg_placeholders 에서
+                        // 제거되어 HWP5 원본과 같은 line_segs.is_empty() 경로를 타야 한다.
                         let already_covered =
                             para.line_segs.iter().any(|s| s.line_height >= max_tac_h);
                         if !already_covered {

--- a/tests/issue_1939.rs
+++ b/tests/issue_1939.rs
@@ -1,0 +1,45 @@
+//! Issue #1939 — HWP5-in-.hwpx 76076 strict render-diff 구조 안정성.
+//!
+//! #1936으로 페이지 수는 82쪽으로 맞았지만, `render-diff --via hwpx` strict 기준에서
+//! page 38/39 경계의 TAC RowBreak 표 host 문단들이 다음 쪽으로 밀리며
+//! STRUCT_MISMATCH가 남았다. 원인은 HWP5-origin HWPX export가 넣는
+//! "원본 LineSeg 부재" marker가 HWPX 로드 중 TAC 표 높이 보정에 의해 실제
+//! LineSeg처럼 변형되어 제거되지 않는 것이었다.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::diagnostics::render_geom_diff::{roundtrip_geom, Via};
+
+const SAMPLE: &str = "samples/issue1891/76076_regulatory_analysis.hwpx";
+
+#[test]
+fn issue_1939_hwp5_origin_hwpx_strict_render_diff_is_stable() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join(SAMPLE);
+    let data = fs::read(&path).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"));
+
+    let diff = roundtrip_geom(&data, Via::Hwpx)
+        .unwrap_or_else(|e| panic!("roundtrip_geom({SAMPLE}): {e:?}"));
+
+    assert_eq!(
+        diff.page_count_a, diff.page_count_b,
+        "{SAMPLE} HWPX roundtrip 페이지 수 불일치: A={} B={}",
+        diff.page_count_a, diff.page_count_b
+    );
+    assert_eq!(diff.page_count_a, 82, "{SAMPLE} 공식 PDF 기준 쪽수");
+    assert!(
+        diff.max_disp <= 1.0,
+        "{SAMPLE} HWPX roundtrip 렌더 변위 {:.2}px > 1.0px",
+        diff.max_disp
+    );
+    for pg in &diff.pages {
+        assert!(
+            !pg.structure_mismatch,
+            "{SAMPLE} page {} 구조 불일치 (node {} vs {}) — HWP5-origin LineSeg 부재 marker 오염 회귀",
+            pg.page,
+            pg.node_count_a,
+            pg.node_count_b
+        );
+    }
+}


### PR DESCRIPTION
## 요약

- HWP5-origin HWPX export marker가 TAC 표 높이 보정에서 실제 LineSeg처럼 오염되는 문제를 수정했습니다.
- `samples/issue1891/76076_regulatory_analysis.hwpx`의 `render-diff --via hwpx` strict 구조 불일치를 회귀 테스트로 고정했습니다.
- 옵션 1 흐름에 따라 PR review 문서와 오늘할일 기록을 PR head에 포함했습니다.

## 원인

HWP5 원본에서 LineSeg가 없던 문단은 HWPX export 시 `missing_lineseg_placeholder`로 표시됩니다. 이 marker는 HWPX 재파스 후 reflow gate를 통과한 뒤 제거되어 원본과 같은 `line_segs.is_empty()` 경로를 타야 합니다.

하지만 TAC 표 host 문단의 높이 보정이 marker의 `line_height`를 표 높이로 바꾸면서 marker 제거 조건을 깨뜨렸고, roundtrip 문서만 권위 있는 LineSeg를 가진 것처럼 처리되어 page 38/39 경계 구조가 밀렸습니다.

## 변경

- `DocumentCore::reflow_zero_height_paragraphs()`에서 `missing_lineseg_placeholder` 단일 문단은 TAC 표 높이 보정 대상에서 제외
- `tests/issue_1939.rs` 추가
- `mydocs/working/task_m100_1939_stage1.md` 작성
- `mydocs/pr/archives/pr_1941_review*.md` 작성
- `mydocs/orders/20260705.md` 갱신

## 검증

- `target/debug/rhwp render-diff samples/issue1891/76076_regulatory_analysis.hwpx --via hwpx`
  - 페이지 수 A=82 B=82
  - 구조 불일치 페이지 0
  - `status: PASS`
- `target/debug/rhwp export-hwpx samples/issue1891/76076_regulatory_analysis.hwpx tmp/issue1939/after/76076-roundtrip.hwpx --verify-pages`
  - 82쪽 검증 통과
- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1939`
- `env CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1891`
- `env CARGO_INCREMENTAL=0 cargo clippy --test issue_1939 -- -D warnings`
- `git diff --check`
- 작업지시자 로컬 검증: `cargo test --profile release-test --tests`

Closes #1939
