### PR TITLE
Issue #1933: 미등록 styleIDRef 를 기본 스타일(0)로 강등 — HWPX 저장 하드 실패 해소

### DIFF
--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -278,6 +278,21 @@ impl SerializeContext {
         self.para_id_counter += 1;
         id
     }
+
+    /// [Issue #1933] 스타일 목록 밖 styleIDRef 를 기본 스타일(0)로 강등한다.
+    ///
+    /// 일부 생성기 산출물(보도자료 계열)은 header 스타일 목록에 없는 style_id 를
+    /// 문단이 참조한다(파일 자기모순). 종전에는 `assert_all_refs_resolved` 가
+    /// 하드 실패해 "열리는데 저장 불가" 상태가 됐다. 한글은 이런 문서를 기본
+    /// 스타일로 폴백해 열고 저장하므로, 미등록 참조는 0(항상 등록됨)으로 강등한다.
+    /// 등록된 참조는 그대로 반환한다.
+    pub fn effective_style_id(&self, raw: u8) -> u8 {
+        if self.style_ids.is_registered(&(raw as u16)) {
+            raw
+        } else {
+            0
+        }
+    }
 }
 
 fn mime_from_ext(ext: &str) -> &'static str {

--- a/src/serializer/hwpx/master_page.rs
+++ b/src/serializer/hwpx/master_page.rs
@@ -57,7 +57,9 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
     for p in &mp.paragraphs {
         let (runs, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
         vert_cursor = advance;
-        body.push_str(&render_hp_p_open(p, ctx.next_para_id()));
+        let pid = ctx.next_para_id();
+        let sid = ctx.effective_style_id(p.style_id);
+        body.push_str(&render_hp_p_open(p, pid, sid));
         body.push_str(&runs);
         body.push_str(&linesegs);
         body.push_str("</hp:p>");

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -163,7 +163,11 @@ pub fn write_section(
 
     if let Some(p) = first_para {
         // 첫 문단 `<hp:p>` 태그를 IR 기반 속성으로 교체
-        let new_p_tag = render_hp_p_open(p, ctx.next_para_id());
+        // (#1933) 본문 경로는 종전에 style_id 를 reference 하지 않았다 — emit 만
+        // 강등해 미등록 ID 방출을 막고, 참조 집합/assert 동작은 종전 유지한다.
+        let pid = ctx.next_para_id();
+        let sid = ctx.effective_style_id(p.style_id);
+        let new_p_tag = render_hp_p_open(p, pid, sid);
         out = out.replacen(TEMPLATE_FIRST_P_TAG, &new_p_tag, 1);
 
         // 섹션 첫 run(secPr/colPr 전용)의 charPrIDRef 를 첫 텍스트 run id 와 일치시킨다.
@@ -185,7 +189,9 @@ pub fn write_section(
         for p in section.paragraphs.iter().skip(1) {
             let (runs, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
             vert_cursor = advance;
-            extra.push_str(&render_hp_p_open(p, ctx.next_para_id()));
+            let pid = ctx.next_para_id();
+            let sid = ctx.effective_style_id(p.style_id);
+            extra.push_str(&render_hp_p_open(p, pid, sid));
             extra.push_str(&runs);
             extra.push_str(&linesegs);
             extra.push_str("</hp:p>");
@@ -200,7 +206,11 @@ pub fn write_section(
 ///
 /// `id` 는 문단 순서 기반(0, 1, 2, ...)로 할당한다. 한컴 샘플은 랜덤 해시도 쓰지만
 /// 파서는 id 를 무시하므로 순차값으로 충분.
-pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32) -> String {
+///
+/// `style_id_ref` 는 호출자가 `ctx.effective_style_id(p.style_id)` 로 강등한 값
+/// (미등록 스타일 → 0, #1933). 전 문단 경로가 이 함수를 거치므로 여기가 단일
+/// 방출 지점이다.
+pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32, style_id_ref: u8) -> String {
     let page_break = if matches!(p.column_type, ColumnBreakType::Page) {
         1
     } else {
@@ -213,7 +223,7 @@ pub(crate) fn render_hp_p_open(p: &Paragraph, id: u32) -> String {
     };
     format!(
         r#"<hp:p id="{}" paraPrIDRef="{}" styleIDRef="{}" pageBreak="{}" columnBreak="{}" merged="0">"#,
-        id, p.para_shape_id, p.style_id, page_break, column_break,
+        id, p.para_shape_id, style_id_ref, page_break, column_break,
     )
 }
 
@@ -1046,11 +1056,13 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                     let mut vert_cursor: u32 = 0;
                     for para in &f.memo_paragraphs {
                         ctx.para_shape_ids.reference(para.para_shape_id);
-                        ctx.style_ids.reference(para.style_id as u16);
+                        let sid = ctx.effective_style_id(para.style_id);
+                        ctx.style_ids.reference(sid as u16);
                         let (runs, linesegs, advance) =
                             render_paragraph_parts(para, vert_cursor, ctx);
                         vert_cursor = advance;
-                        out.push_str(&render_hp_p_open(para, ctx.next_para_id()));
+                        let pid = ctx.next_para_id();
+                        out.push_str(&render_hp_p_open(para, pid, sid));
                         out.push_str(&runs);
                         out.push_str(&linesegs);
                         out.push_str("</hp:p>");
@@ -1295,7 +1307,9 @@ fn render_header_footer(
     for p in h.paragraphs.iter() {
         let (runs, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
         vert_cursor = advance;
-        out.push_str(&render_hp_p_open(p, ctx.next_para_id()));
+        let pid = ctx.next_para_id();
+        let sid = ctx.effective_style_id(p.style_id);
+        out.push_str(&render_hp_p_open(p, pid, sid));
         out.push_str(&runs);
         out.push_str(&linesegs);
         out.push_str("</hp:p>");
@@ -1693,7 +1707,9 @@ fn render_note_sublist(
     for p in paragraphs.iter() {
         let (runs, linesegs, advance) = render_paragraph_parts(p, vert_cursor, ctx);
         vert_cursor = advance;
-        out.push_str(&render_hp_p_open(p, ctx.next_para_id()));
+        let pid = ctx.next_para_id();
+        let sid = ctx.effective_style_id(p.style_id);
+        out.push_str(&render_hp_p_open(p, pid, sid));
         out.push_str(&runs);
         out.push_str(&linesegs);
         out.push_str("</hp:p>");
@@ -2075,7 +2091,9 @@ mod tests {
         para.para_shape_id = 7;
         para.style_id = 3;
         para.text = "hi".to_string();
-        let (doc, section) = make_doc_with_paragraph(para);
+        let (mut doc, section) = make_doc_with_paragraph(para);
+        // style_id=3 이 등록되도록 스타일 4개 확보 (미등록 강등 #1933 회피).
+        doc.doc_info.styles = vec![crate::model::style::Style::default(); 4];
         let mut ctx = SerializeContext::collect_from_document(&doc);
         let bytes = write_section(&section, &doc, 0, &mut ctx).unwrap();
         let xml = std::str::from_utf8(&bytes).unwrap();
@@ -2087,6 +2105,31 @@ mod tests {
         assert!(
             xml.contains(r#"styleIDRef="3""#),
             "<hp:p> must reflect style_id=3"
+        );
+    }
+
+    /// [Issue #1933] 스타일 목록 밖 styleIDRef 는 기본(0)으로 강등되어 직렬화가
+    /// 하드 실패하지 않는다 (한글 정합 — 열리는데 저장 불가 해소).
+    #[test]
+    fn out_of_range_style_id_downgraded_to_default() {
+        let mut para = Paragraph::default();
+        para.style_id = 96; // 스타일 목록(4개, idx 0..3) 밖
+        para.text = "hi".to_string();
+        let (mut doc, section) = make_doc_with_paragraph(para);
+        doc.doc_info.styles = vec![crate::model::style::Style::default(); 4];
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let bytes = write_section(&section, &doc, 0, &mut ctx).unwrap();
+        // 참조 정합 단언 — 강등 없으면 styleIDRef:[96] 미등록으로 하드 실패한다.
+        ctx.assert_all_refs_resolved()
+            .expect("#1933: 미등록 styleIDRef 강등으로 참조 정합해야 함");
+        let xml = std::str::from_utf8(&bytes).unwrap();
+        assert!(
+            xml.contains(r#"styleIDRef="0""#),
+            "미등록 style_id=96 은 0 으로 강등되어야 함"
+        );
+        assert!(
+            !xml.contains(r#"styleIDRef="96""#),
+            "미등록 style_id 는 방출되지 않아야 함"
         );
     }
 

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -370,11 +370,13 @@ pub fn write_draw_text<W: Write>(
     let mut vert_cursor: u32 = 0;
     for para in tb.paragraphs.iter() {
         ctx.para_shape_ids.reference(para.para_shape_id);
-        ctx.style_ids.reference(para.style_id as u16);
+        let sid = ctx.effective_style_id(para.style_id);
+        ctx.style_ids.reference(sid as u16);
 
         let (runs, linesegs, advance) = render_paragraph_parts(para, vert_cursor, ctx);
         vert_cursor = advance;
-        let mut p_xml = render_hp_p_open(para, ctx.next_para_id());
+        let pid = ctx.next_para_id();
+        let mut p_xml = render_hp_p_open(para, pid, sid);
         p_xml.push_str(&runs);
         p_xml.push_str(&linesegs);
         p_xml.push_str("</hp:p>");

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -311,11 +311,13 @@ fn write_sub_list_paragraphs<W: Write>(
     let mut vert_cursor: u32 = 0;
     for para in paragraphs {
         ctx.para_shape_ids.reference(para.para_shape_id);
-        ctx.style_ids.reference(para.style_id as u16);
+        let sid = ctx.effective_style_id(para.style_id);
+        ctx.style_ids.reference(sid as u16);
 
         let (runs, linesegs, advance) = render_paragraph_parts(para, vert_cursor, ctx);
         vert_cursor = advance;
-        let mut p_xml = render_hp_p_open(para, ctx.next_para_id());
+        let pid = ctx.next_para_id();
+        let mut p_xml = render_hp_p_open(para, pid, sid);
         p_xml.push_str(&runs);
         p_xml.push_str(&linesegs);
         p_xml.push_str("</hp:p>");


### PR DESCRIPTION
## 개요

#1933 — 문단이 header 스타일 목록 밖 styleIDRef 를 참조하는 자기모순 문서(보도자료 생성기 계열)가 **파싱은 되는데 HWPX 저장이 하드 실패**(열리는데 저장 불가)하던 것을 해소. 2차 10k 서베이 1건(156711930 농림부 보도자료, styleIDRef 91~96).

## 근본 원인

\ssert_all_refs_resolved\ 가 \eferenced - registered\ 의 미등록 styleIDRef 를 하드 실패시킨다. 한글은 이런 문서를 기본 스타일로 폴백해 열고 저장하는데, rhwp 는 저장을 거부했다.

## 수정

\SerializeContext::effective_style_id(raw)\ — 미등록 style_id 를 0(항상 등록되는 기본 스타일)으로 강등. 전 문단 방출 경로(본문/셀/글상자/머리꼬리말/각미주/바탕쪽/메모)의 단일 방출 지점 \ender_hp_p_open\ 이 강등값을 방출하고, 종전에 style_id 를 참조하던 경로(셀/글상자/메모)는 참조 집합에도 강등값을 기록해 정합 유지. **본문 경로는 종전에 style 을 참조하지 않았으므로 emit 만 강등**(참조/assert 동작 불변).

## 검증

- 신규 게이트 \out_of_range_style_id_downgraded_to_default\(style 96 → styleIDRef=0), 기존 \hp_p_attrs\(등록 스타일 3 보존) 유지.
- lib 2,119 통과, 실파일 156711930 hwpx-roundtrip **SERIALIZE_FAIL → PASS**. 전체 스위트는 CI 검증.

closes #1933

🤖 Generated with [Claude Code](https://claude.com/claude-code)