### PR TITLE
Issue #1945: PartialParagraph start_line 슬라이스 범위 밖 패닉 방어 (실문서 크래시)

### DIFF
--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -1648,9 +1648,17 @@ impl LayoutEngine {
 
         // 문단 전체에서 모든 라인의 runs가 비어있는지 확인
         // (텍스트 없이 TAC 이미지만 있는 문단)
-        let all_runs_empty = composed.lines[start_line..end]
-            .iter()
-            .all(|l| l.runs.is_empty());
+        //
+        // [Issue #1945] `start_line` 은 PartialTable/Partial 이월 경로에서 인자로
+        // 전달되며 `end`(= end_line.min(lines.len())) 와 독립 계산이라, 이월 루프가
+        // 조판 라인 수를 넘겨 `start_line > end`(또는 > lines.len())가 되면 직접
+        // 슬라이스가 패닉했다(실문서 크래시). 아래 렌더 루프(`for line_idx in
+        // start_line..end`)는 빈 범위를 안전히 처리하므로, 여기서도 `get()` 으로
+        // 방어해 범위 밖이면 "가시 run 없음"(vacuously true)으로 본다.
+        let all_runs_empty = composed
+            .lines
+            .get(start_line..end)
+            .map_or(true, |slice| slice.iter().all(|l| l.runs.is_empty()));
 
         // 개요 번호/글머리표 마커 폭 사전 계산 (첫 줄 가용폭 차감용)
         let numbering_width = if start_line == 0 {

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -169,6 +169,76 @@ fn test_build_page_with_paragraph() {
     assert!(!body.children.is_empty());
 }
 
+/// [Issue #1945] PartialParagraph 의 start_line 이 조판 라인 수를 넘어도
+/// 패닉하지 않아야 한다 (실문서 크래시 — paragraph_layout.rs 슬라이스 범위 밖).
+/// 수정 전에는 `composed.lines[start_line..end]` 직접 인덱싱이
+/// "range start index N out of range" 로 패닉했다.
+#[test]
+fn partial_paragraph_start_line_beyond_lines_does_not_panic() {
+    let engine = LayoutEngine::with_default_dpi();
+    let layout = PageLayoutInfo::from_page_def_default(&a4_page_def(), &ColumnDef::default());
+
+    // 조판 라인 1개짜리 문단.
+    let paragraphs = vec![Paragraph {
+        text: "한 줄".to_string(),
+        line_segs: vec![LineSeg {
+            line_height: 400,
+            baseline_distance: 320,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }];
+    let composed: Vec<_> = paragraphs.iter().map(|p| compose_paragraph(p)).collect();
+    let styles = ResolvedStyleSet::default();
+
+    let page_content = PageContent {
+        page_index: 0,
+        page_number: 0,
+        section_index: 0,
+        layout,
+        column_contents: vec![ColumnContent {
+            column_index: 0,
+            start_height: 0.0,
+            endnote_flow: false,
+            // start_line(5) > 조판 라인 수(1) — 이월 오버슛 재현.
+            items: vec![PageItem::PartialParagraph {
+                para_index: 0,
+                start_line: 5,
+                end_line: 6,
+            }],
+            zone_layout: None,
+            zone_y_offset: 0.0,
+            wrap_around_paras: Vec::new(),
+            used_height: 0.0,
+            wrap_anchors: std::collections::HashMap::new(),
+        }],
+        active_header: None,
+        active_footer: None,
+        page_number_pos: None,
+        page_hide: None,
+        footnotes: Vec::new(),
+        active_master_page: None,
+        extra_master_pages: Vec::new(),
+    };
+
+    // 패닉 없이 반환하면 성공 (범위 밖 조각은 빈 렌더).
+    let _tree = engine.build_render_tree(
+        &page_content,
+        &paragraphs,
+        &paragraphs,
+        &paragraphs,
+        &composed,
+        &styles,
+        &FootnoteShape::default(),
+        &[],
+        None,
+        &[],
+        None,
+        0,
+        &[],
+    );
+}
+
 #[test]
 fn test_layout_with_composed_styles() {
     use crate::renderer::style_resolver::ResolvedCharStyle;


### PR DESCRIPTION
## 개요

#1945 — 이월(PartialTable/Partial) 경로에서 `start_line` 이 조판 라인 수를 넘으면
`paragraph_layout.rs` 의 `composed.lines[start_line..end]` 직접 인덱싱이
`range start index N out of range` 로 **패닉(실문서 크래시)**. 75838 규제영향분석서
export-svg 에서 발생 보고됨.

## 근본 원인

`start_line`(이월 인자)과 `end = end_line.min(lines.len())` 는 독립 계산이라
`start_line <= end` 불변식이 없다. 이월 루프가 라인 수를 넘겨 진행하면 슬라이스가
범위 밖.

## 수정

직접 슬라이스를 `lines.get(start_line..end).map_or(true, |s| s.iter().all(...))` 로
방어. 범위 밖이면 "가시 run 없음"(vacuously true). 아래 렌더 루프
`for line_idx in start_line..end` 는 빈 범위를 이미 안전 처리하므로 **유효 범위
동작은 완전 동일**.

## 검증

- 신규 게이트 `partial_paragraph_start_line_beyond_lines_does_not_panic`
  (start_line=5 > lines=1): **수정 전 정확히 동일 패닉 재현**
  (`range start index 5 out of range for slice of length 1`), 수정 후 통과 —
  가드 유효성 직접 검증.
- lib 2,117 통과, 실파일 75838 export-svg 28쪽 정상 렌더. 전체 스위트는 CI 검증.

참고: 현재 devel 에선 상위 페이지네이션 변경으로 이 특정 파일이 우연히
트리거하지 않으나, 불변식 없는 직접 슬라이스는 잠재 패닉 클래스로 남아 방어함.
근본 원인(이월 루프 start_line 오버슛)은 별도 조사 대상.

closes #1945

🤖 Generated with [Claude Code](https://claude.com/claude-code)
