### PR TITLE
Issue #1946: 암호화 HWPX(ODF encryption-data) 감지 — 오진단 해소 + ENCRYPTED_SKIP 분류

### DIFF
--- a/src/diagnostics/hwpx_roundtrip_batch.rs
+++ b/src/diagnostics/hwpx_roundtrip_batch.rs
@@ -95,6 +95,9 @@ struct RoundtripRow {
     /// [#1914] 매직 바이트 실체가 HWPX(ZIP)가 아닌 확장자 위장 파일 — 검출된
     /// 실체 포맷명. HWPX 구조 게이트의 범위 밖이므로 실패가 아닌 스킵으로 분류.
     format_skip: Option<&'static str>,
+    /// [#1946] ODF 암호화(비밀번호 보호) HWPX — 복호화 미지원. 게이트 범위 밖
+    /// 이므로 실패가 아닌 스킵으로 분류(FORMAT_SKIP 과 동형).
+    encrypted_skip: bool,
     /// #1380 측정 전용 — round1(원본 vs RT) lineseg diff. `--lineseg-report` 시에만 수집.
     lineseg_r1: Vec<LinesegDiff>,
     /// #1380 측정 전용 — round2(RT vs RT²) lineseg diff.
@@ -105,6 +108,8 @@ impl RoundtripRow {
     fn status(&self) -> &'static str {
         if self.format_skip.is_some() {
             "FORMAT_SKIP"
+        } else if self.encrypted_skip {
+            "ENCRYPTED_SKIP"
         } else if !self.parse_ok {
             "PARSE_FAIL"
         } else if !self.serialize_ok {
@@ -126,8 +131,8 @@ impl RoundtripRow {
 
     /// 회귀 검출용 하드 실패 (등급화 대상 분류와 별개).
     fn is_hard_fail(&self) -> bool {
-        if self.format_skip.is_some() {
-            // [#1914] 확장자 위장(실체 비-HWPX)은 게이트 범위 밖 — 실패 아님.
+        if self.format_skip.is_some() || self.encrypted_skip {
+            // [#1914/#1946] 확장자 위장(실체 비-HWPX)·암호화 문서는 게이트 범위 밖 — 실패 아님.
             return false;
         }
         !(self.parse_ok && self.serialize_ok && self.reparse_ok)
@@ -169,6 +174,7 @@ fn roundtrip_one(
         elapsed_ms: 0,
         error: String::new(),
         format_skip: None,
+        encrypted_skip: false,
         lineseg_r1: Vec::new(),
         lineseg_r2: Vec::new(),
     };
@@ -202,6 +208,10 @@ fn roundtrip_one(
     let doc1 = match parse_hwpx(&bytes) {
         Ok(d) => d,
         Err(e) => {
+            // [#1946] 암호화 HWPX 는 게이트 범위 밖 — PARSE_FAIL 대신 ENCRYPTED_SKIP.
+            if e.is_encrypted() {
+                row.encrypted_skip = true;
+            }
             row.error = format!("파싱 실패: {e}");
             return finish(row, started);
         }
@@ -401,6 +411,7 @@ fn print_summary(rows: &[RoundtripRow]) {
     println!("  PKG_FAIL       : {}", count("PKG_FAIL"));
     println!("  ROUND2_DIFF    : {}", count("ROUND2_DIFF"));
     println!("  ROUND2_FAIL    : {}", count("ROUND2_FAIL"));
+    println!("  ENCRYPTED_SKIP : {}", count("ENCRYPTED_SKIP"));
     println!("  PARSE_FAIL     : {}", count("PARSE_FAIL"));
     println!("  SERIALIZE_FAIL : {}", count("SERIALIZE_FAIL"));
     println!("  REPARSE_FAIL   : {}", count("REPARSE_FAIL"));

--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -64,6 +64,16 @@ pub enum HwpxError {
     MissingFile(String),
     /// 데이터 변환 오류
     ConversionError(String),
+    /// [Issue #1946] 비밀번호 암호화 HWPX(ODF encryption-data, AES-256-CBC).
+    /// 복호화 미지원 — 암호문을 UTF-8 로 오독하는 대신 명확히 분류한다.
+    Encrypted(String),
+}
+
+impl HwpxError {
+    /// 암호화 문서 여부 — 배치 게이트의 ENCRYPTED_SKIP 분류에 사용.
+    pub fn is_encrypted(&self) -> bool {
+        matches!(self, HwpxError::Encrypted(_))
+    }
 }
 
 impl std::fmt::Display for HwpxError {
@@ -73,11 +83,38 @@ impl std::fmt::Display for HwpxError {
             HwpxError::XmlError(e) => write!(f, "XML 파싱 오류: {}", e),
             HwpxError::MissingFile(e) => write!(f, "필수 파일 누락: {}", e),
             HwpxError::ConversionError(e) => write!(f, "변환 오류: {}", e),
+            HwpxError::Encrypted(e) => write!(f, "암호화된 문서(복호화 미지원): {}", e),
         }
     }
 }
 
 impl std::error::Error for HwpxError {}
+
+/// [Issue #1946] META-INF/manifest.xml 바이트에서 ODF 암호화 표식을 감지한다.
+/// 암호화면 알고리즘 요약을, 아니면 None 을 반환한다. manifest 자체는 평문이므로
+/// UTF-8 손실 없이 검사 가능하나, 안전을 위해 lossy 로 읽어 부분 손상에도 동작한다.
+fn detect_odf_encryption(manifest_bytes: &[u8]) -> Option<String> {
+    let text = String::from_utf8_lossy(manifest_bytes);
+    if !text.contains("encryption-data") {
+        return None;
+    }
+    let algo = if text.contains("aes256-cbc") {
+        "AES-256-CBC"
+    } else if text.contains("aes128-cbc") {
+        "AES-128-CBC"
+    } else {
+        "미상 알고리즘"
+    };
+    let kdf = if text.contains("pbkdf2") {
+        " + PBKDF2"
+    } else {
+        ""
+    };
+    Some(format!(
+        "ODF encryption-data 감지 ({}{}) — 비밀번호 보호 문서",
+        algo, kdf
+    ))
+}
 
 impl From<zip::result::ZipError> for HwpxError {
     fn from(e: zip::result::ZipError) -> Self {
@@ -141,6 +178,16 @@ fn attach_hwpx_master_page(
 pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
     // 1. ZIP 컨테이너 열기
     let mut reader = reader::HwpxReader::open(data)?;
+
+    // [Issue #1946] 암호화 HWPX 조기 감지. META-INF/manifest.xml 은 암호화 문서에서도
+    // 평문이며, 암호화된 엔트리마다 <odf:encryption-data> 블록을 갖는다. 감지하면
+    // 암호문(Contents/*.xml)을 UTF-8 로 오독하기 전에 명확한 Encrypted 에러로 반환한다
+    // (종전엔 "UTF-8 변환 실패" 오진단). manifest 부재/평문 문서는 종전 경로 유지.
+    if let Ok(manifest) = reader.read_file_bytes("META-INF/manifest.xml") {
+        if let Some(detail) = detect_odf_encryption(&manifest) {
+            return Err(HwpxError::Encrypted(detail));
+        }
+    }
 
     // 1-1. 보조 엔트리 원본 보존 (라운드트립 무손실).
     //   IR 로 모델링되지 않는 엔트리(version.xml/settings.xml/Preview/*)는

--- a/src/parser/hwpx/reader.rs
+++ b/src/parser/hwpx/reader.rs
@@ -106,6 +106,47 @@ mod tests {
         assert!(result.is_err());
     }
 
+    /// [#1946] ODF 암호화 manifest 감지 + 비암호화 manifest 무시.
+    #[test]
+    fn test_detect_odf_encryption() {
+        use crate::parser::hwpx::{detect_odf_encryption, parse_hwpx, HwpxError};
+        use std::io::Write;
+        use zip::write::SimpleFileOptions;
+        use zip::ZipWriter;
+
+        let enc = br#"<odf:manifest><odf:file-entry full-path="Contents/header.xml"><odf:encryption-data><odf:algorithm algorithm-name="http://www.w3.org/2001/04/xmlenc#aes256-cbc"/><odf:key-derivation key-derivation-name="...#pbkdf2"/></odf:encryption-data></odf:file-entry></odf:manifest>"#;
+        let detail = detect_odf_encryption(enc).expect("암호화 감지");
+        assert!(detail.contains("AES-256-CBC"), "{detail}");
+        assert!(detail.contains("PBKDF2"), "{detail}");
+
+        let plain =
+            br#"<odf:manifest><odf:file-entry full-path="Contents/header.xml"/></odf:manifest>"#;
+        assert!(detect_odf_encryption(plain).is_none());
+
+        // parse_hwpx 진입 감지: 암호화 manifest + 암호문 header.xml → Encrypted 에러.
+        let mut out = Cursor::new(Vec::<u8>::new());
+        {
+            let mut zip = ZipWriter::new(&mut out);
+            let opts =
+                SimpleFileOptions::default().compression_method(zip::CompressionMethod::Deflated);
+            zip.start_file("mimetype", opts).unwrap();
+            zip.write_all(b"application/hwp+zip").unwrap();
+            zip.start_file("META-INF/manifest.xml", opts).unwrap();
+            zip.write_all(enc).unwrap();
+            zip.start_file("Contents/header.xml", opts).unwrap();
+            zip.write_all(&[0x93u8, 0xFF, 0x00, 0x11]).unwrap(); // 암호문(비 UTF-8) 모사
+            zip.finish().unwrap();
+        }
+        let bytes = out.into_inner();
+        match parse_hwpx(&bytes) {
+            Err(e @ HwpxError::Encrypted(_)) => {
+                assert!(e.is_encrypted());
+                assert!(e.to_string().contains("암호화된 문서"), "{e}");
+            }
+            other => panic!("expected Encrypted, got {other:?}"),
+        }
+    }
+
     #[test]
     fn test_read_limited_under_cap() {
         let data = vec![0u8; 1000];


### PR DESCRIPTION
## 개요

#1946 — 비밀번호 암호화 HWPX(ODF AES-256-CBC/PBKDF2)를 열면 암호문
`Contents/header.xml` 을 UTF-8 로 디코딩하다 **"UTF-8 변환 실패: invalid utf-8
sequence"** 라는 오해를 부르는 에러로 PARSE_FAIL 했다. 2차 10k 서베이 2건
(#1932 조사에서 원인 규명 — 암호화를 인코딩 손상으로 오진했던 건).

## 수정

- `parse_hwpx` 진입에서 `META-INF/manifest.xml`(암호화 문서에서도 **평문**)의
  `<odf:encryption-data>` 를 감지 → `HwpxError::Encrypted(알고리즘 요약)` 조기 반환.
  암호문을 UTF-8 로 오독하기 전에 명확히 분류. 평문·manifest 부재 문서는 불변.
- `HwpxError::Encrypted` 변형 + `is_encrypted()`, Display `"암호화된 문서(복호화 미지원)"`.
- `hwpx-roundtrip` 배치: 암호화 문서를 FORMAT_SKIP 과 동형인 **ENCRYPTED_SKIP** 로
  분류(하드 실패 제외) + 요약 카운트 추가.

## 검증

| 항목 | 수정 전 | 수정 후 |
|---|---|---|
| info 에러 메시지 | "UTF-8 변환 실패: invalid utf-8" (오진) | **"암호화된 문서(복호화 미지원): ODF encryption-data 감지 (AES-256-CBC + PBKDF2)"** |
| hwpx-roundtrip verdict | PARSE_FAIL (하드 실패) | **ENCRYPTED_SKIP** (게이트 범위 밖) |

- 신규 게이트 `test_detect_odf_encryption`: manifest 감지 + `parse_hwpx` Encrypted 반환.
- lib 2,117 통과. 실파일 2건(156747079 산업활동동향, 1290000-202300073 PRISM 중간보고서)
  info·roundtrip 확인. 전체 스위트는 CI 검증.

참고: 복호화(비밀번호 기반) 자체는 대형 기능 후보로 범위 밖 — 본 PR 은 감지·분류만.

closes #1946

🤖 Generated with [Claude Code](https://claude.com/claude-code)
