### PR TITLE
Task #1955/#1956: wrap 밴드 오매칭·쪽나누기 무시 + 글뒤로 표 후행 문단 귀속 수정

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -3030,7 +3030,22 @@ impl DocumentCore {
                             .unwrap_or(0.0);
                         let body_w = page.layout.body_area.width;
                         let is_wrap_zone = sw_px > 0.0 && sw_px < body_w * 0.9;
-                        let disp = if is_wrap_zone {
+                        // [#1955] 글뒤로/글앞으로 anchor 표는 플로우를 소비하지 않으므로
+                        // 후행 문단은 폭과 무관하게 **앵커 페이지** 귀속 (한글: stored
+                        // LINE_SEG vpos 가 앵커 쪽 위치를 가리킴).
+                        let anchor_behind = paragraphs
+                            .get(wp.table_para_index)
+                            .map(|p| {
+                                p.controls.iter().any(|c| {
+                                    matches!(c, Control::Table(t)
+                                        if !t.common.treat_as_char
+                                            && matches!(t.common.text_wrap,
+                                                crate::model::shape::TextWrap::BehindText
+                                                    | crate::model::shape::TextWrap::InFrontOfText))
+                                })
+                            })
+                            .unwrap_or(false);
+                        let disp = if is_wrap_zone || anchor_behind {
                             item_first_page.get(&wp.table_para_index)
                         } else {
                             item_disp_page.get(&wp.table_para_index)

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -469,6 +469,14 @@ impl Paginator {
                 }
             }
 
+            // [#1956] 명시적 쪽나누기 문단부터는 wrap 밴드 무효 — 새 쪽에는 anchor
+            // 개체가 없으므로 후속 문단을 옆에 흡수하면 안 된다 (typeset.rs 동형).
+            if (force_page_break || para_style_break) && wrap_around_cs >= 0 {
+                wrap_around_cs = -1;
+                wrap_around_sw = -1;
+                wrap_around_any_seg = false;
+            }
+
             if (force_page_break || para_style_break || variant_vpos_reset_break)
                 && !st.current_items.is_empty()
             {
@@ -827,14 +835,23 @@ impl Paginator {
                 if is_wrap_around {
                     // 어울림 배치: 표의 LINE_SEG (cs, sw) 쌍과 동일한 후속 문단은
                     // 표 옆에 배치되므로 높이를 소비하지 않음
-                    wrap_around_cs = para.line_segs.first().map(|s| s.column_start).unwrap_or(0);
-                    wrap_around_sw = para
+                    let anchor_cs = para.line_segs.first().map(|s| s.column_start).unwrap_or(0);
+                    let anchor_sw = para
                         .line_segs
                         .first()
                         .map(|s| s.segment_width as i32)
                         .unwrap_or(0);
-                    wrap_around_table_para = para_idx;
-                    wrap_around_any_seg = false;
+                    // [#1956] 밴드 폭이 단 폭과 사실상 같으면(표가 본문 폭 이상 =
+                    // 옆 공간 없음) 후속 전체 폭 문단들이 전부 오매칭되므로 arming
+                    // 하지 않는다. sw=0 케이스는 기존 sw0_match 경로가 담당.
+                    let col_w_hu = st.layout.column_width_hu();
+                    let band_full_width = anchor_sw > 0 && (anchor_sw - col_w_hu).abs() < 3000;
+                    if !band_full_width {
+                        wrap_around_cs = anchor_cs;
+                        wrap_around_sw = anchor_sw;
+                        wrap_around_table_para = para_idx;
+                        wrap_around_any_seg = false;
+                    }
                 }
             }
             // 비-TAC Picture Square wrap (어울림 그림): TABLE wrap과 동일 메커니즘.
@@ -865,7 +882,11 @@ impl Paginator {
                     .first()
                     .map(|s| s.segment_width as i32)
                     .unwrap_or(0);
-                if anchor_cs > 0 || anchor_sw > 0 {
+                // [#1956] 표와 동일한 전체 폭 밴드 가드 — 옆 공간이 없는 그림은
+                // 후속 문단을 옆으로 흘릴 수 없다.
+                let col_w_hu = st.layout.column_width_hu();
+                let band_full_width = anchor_sw > 0 && (anchor_sw - col_w_hu).abs() < 3000;
+                if (anchor_cs > 0 || anchor_sw > 0) && !band_full_width {
                     wrap_around_cs = anchor_cs;
                     wrap_around_sw = anchor_sw;
                     wrap_around_table_para = para_idx;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -12373,9 +12373,10 @@ impl TypesetEngine {
                 None => (f64::NAN, 0, 0.0),
             };
             eprintln!(
-                "TABLE_DRIFT: pi={} sec={} eff_h={:.1} host_sp={:.1} table_total={:.1} mt_sum={:.1} mt_rows={} cs={:.1} cur_h={:.1} tac={} rows={}",
+                "TABLE_DRIFT: pi={} sec={} eff_h={:.1} host_sp={:.1} table_total={:.1} mt_sum={:.1} mt_rows={} cs={:.1} cur_h={:.1} tac={} rows={} avail={:.1} base={:.1} fn={:.1} zone={:.1}",
                 para_idx, st.section_index, ft.effective_height, host_spacing_total, table_total,
                 mt_sum, mt_rows, mt_cs, st.current_height, table.common.treat_as_char, table.row_count,
+                available, st.base_available_height(), total_footnote, st.current_zone_y_offset,
             );
         }
         // [Task #1027 Stage E1] treat_as_char 인라인 표 advance 정합.

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2432,6 +2432,16 @@ impl TypesetEngine {
                 }
             }
 
+            // [#1956] 명시적 쪽나누기 문단부터는 wrap 밴드 무효 — 새 쪽에는 anchor
+            // 개체가 없으므로 후속 문단을 옆에 흡수하면 안 된다. current_items 가 비어
+            // 있어 force_new_page 를 생략하는 경우에도 사용자 의도(새 쪽)는 동일하므로
+            // 밴드는 해제한다. (법령안 신구조문대비표: 쪽나누기 표제가 흡수되어 pi 6쪽 이탈)
+            if (force_page_break || para_style_break) && st.wrap_around_cs >= 0 {
+                st.wrap_around_cs = -1;
+                st.wrap_around_sw = -1;
+                st.wrap_around_any_seg = false;
+            }
+
             if (force_page_break || para_style_break || variant_vpos_reset_break)
                 && !st.current_items.is_empty()
             {
@@ -3287,17 +3297,29 @@ impl TypesetEngine {
                         {
                             st.wrap_around_cs = strip_cs;
                             st.wrap_around_sw = strip_sw;
+                            st.wrap_around_table_para = para_idx;
+                            st.wrap_around_any_seg = false;
                         } else {
-                            st.wrap_around_cs =
+                            let anchor_cs =
                                 para.line_segs.first().map(|s| s.column_start).unwrap_or(0);
-                            st.wrap_around_sw = para
+                            let anchor_sw = para
                                 .line_segs
                                 .first()
                                 .map(|s| s.segment_width as i32)
                                 .unwrap_or(0);
+                            // [#1956] anchor LINE_SEG 가 단 전체 폭이면(표가 본문 폭
+                            // 이상 = 옆 공간 없음) 후속 전체 폭 문단들이 전부 오매칭
+                            // 되므로 arming 하지 않는다. sw=0 은 기존 sw0_match 담당.
+                            let col_w_hu = st.layout.column_width_hu();
+                            let band_full_width =
+                                anchor_sw > 0 && (anchor_sw - col_w_hu).abs() < 3000;
+                            if !band_full_width {
+                                st.wrap_around_cs = anchor_cs;
+                                st.wrap_around_sw = anchor_sw;
+                                st.wrap_around_table_para = para_idx;
+                                st.wrap_around_any_seg = false;
+                            }
                         }
-                        st.wrap_around_table_para = para_idx;
-                        st.wrap_around_any_seg = false;
                     }
                 }
             }
@@ -3339,7 +3361,10 @@ impl TypesetEngine {
                         .first()
                         .map(|s| s.segment_width as i32)
                         .unwrap_or(0);
-                    if anchor_cs > 0 || anchor_sw > 0 {
+                    // [#1956] 전체 폭 밴드 가드 — 옆 공간이 없으면 arming 하지 않는다.
+                    let col_w_hu = st.layout.column_width_hu();
+                    let band_full_width = anchor_sw > 0 && (anchor_sw - col_w_hu).abs() < 3000;
+                    if (anchor_cs > 0 || anchor_sw > 0) && !band_full_width {
                         st.wrap_around_cs = anchor_cs;
                         st.wrap_around_sw = anchor_sw;
                         st.wrap_around_table_para = para_idx;

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2548,6 +2548,22 @@ impl TypesetEngine {
                     let para_sb_hu_for_reset = para_style
                         .map(|s| (s.spacing_before * 7200.0 / 96.0) as i32)
                         .unwrap_or(0);
+                    // [#1921 d=-1] 네이티브 HWP5/HWPX 의 비영 near-top reset:
+                    // 한글은 새 쪽 첫 줄의 stored vpos 를 0 이 아니라 해당 문단의
+                    // spacing_before 로 기록하기도 한다 (조문별/규제영향분석서 클래스,
+                    // 예: 86034 pi24 vpos=500 = sb 6.7px). cv==0 전용 트리거가 이를
+                    // 놓쳐 한 쪽을 과적한다. cv≈sb(±150HU) + 쪽 하단(prev_vpos_end
+                    // > 60_000) + 텍스트 전용 문단으로 한정해 partial-table 잔재
+                    // (#418)·표 host(#1086 주석) 케이스와 구분한다.
+                    let native_near_top_reset = !hwp3_origin_page_tolerance
+                        && cv > 0
+                        && cv <= 2000
+                        && para_sb_hu_for_reset > 0
+                        && (cv - para_sb_hu_for_reset).abs() <= 150
+                        && !shape_only_para
+                        && !has_table_control
+                        && para_has_visible_text(para)
+                        && prev_vpos_end > 60_000;
                     let next_heading_after_top_content_reset =
                         paragraphs.get(para_idx + 1).is_some_and(|next_para| {
                             let next_sb_hu = styles
@@ -2584,6 +2600,7 @@ impl TypesetEngine {
                     } else {
                         (cv == 0 && pv > 5000 && !hwp3_content_vpos_zero_reset)
                             || near_page_top_reset
+                            || native_near_top_reset
                     };
                     if trigger {
                         // [Task #724] wrap_around active 시 강제 종료 — anchor cs=0

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -385,6 +385,15 @@ struct TypesetState {
     /// 비-TAC Picture/Shape Square wrap: any_seg_matches만으로 후속 문단 판정 허용.
     /// 그림의 lineseg는 첫 seg cs=0일 수 있어 전체 seg 중 하나라도 일치하면 흡수.
     wrap_around_any_seg: bool,
+    /// [#1955] 글뒤로/글앞으로(BehindText/InFrontOfText) 비-TAC 표 anchor 문단.
+    /// 이 wrap 은 본문 플로우를 소비하지 않으므로(한글: 후속 문단이 anchor 쪽에
+    /// 남음), 직후의 빈 후행 문단들을 anchor 첫 fragment 단에 소급 흡수한다.
+    /// 비어있지 않은 문단/새 표/쪽나누기를 만나면 해제.
+    behind_float_table_para: Option<usize>,
+    /// [#1955] 글뒤로 표 후행 빈 문단의 보류 흡수 목록. 표 fragment 는 지연 flush
+    /// 되므로 흡수 시점에는 anchor 첫 fragment 단을 찾을 수 없다 — 페이지 확정 후
+    /// (최종 flush 뒤) 첫 fragment 단에 일괄 부착한다.
+    behind_pending_absorbs: Vec<crate::renderer::pagination::WrapAroundPara>,
     /// [Task #362] 현재 단에서 표 옆에 배치되는 wrap-around paragraphs.
     /// flush_column 에서 ColumnContent 로 전달.
     current_column_wrap_around_paras: Vec<crate::renderer::pagination::WrapAroundPara>,
@@ -1432,6 +1441,8 @@ impl TypesetState {
             wrap_around_sw: -1,
             wrap_around_table_para: 0,
             wrap_around_any_seg: false,
+            behind_float_table_para: None,
+            behind_pending_absorbs: Vec::new(),
             current_column_wrap_around_paras: Vec::new(),
             current_column_wrap_anchors: std::collections::HashMap::new(),
             current_zone_column_type: column_type,
@@ -2441,6 +2452,10 @@ impl TypesetEngine {
                 st.wrap_around_sw = -1;
                 st.wrap_around_any_seg = false;
             }
+            // [#1955] 명시적 쪽나누기부터는 글뒤로 표 후행 흡수도 해제 (사용자 의도 새 쪽).
+            if force_page_break || para_style_break {
+                st.behind_float_table_para = None;
+            }
 
             if (force_page_break || para_style_break || variant_vpos_reset_break)
                 && !st.current_items.is_empty()
@@ -2917,6 +2932,36 @@ impl TypesetEngine {
                 }
             }
 
+            // [#1955] 글뒤로/글앞으로 표 직후의 빈 후행 문단 흡수.
+            // 이 wrap 은 본문 플로우를 소비하지 않아야 하나(한글 시멘틱) 현재
+            // 페이지네이션은 fragment 로 플로우를 소비하므로, 최소한 빈 후행 문단은
+            // anchor 첫 fragment 단에 소급 기록하여 pi-page 정합을 복원한다.
+            // (조례 [별표] 서식: 표 끝 쪽으로 밀리던 후행 빈 문단 — pi 9쪽 이탈)
+            if let Some(anchor_pi) = st.behind_float_table_para {
+                if !has_table {
+                    let is_empty_para = para
+                        .text
+                        .chars()
+                        .all(|ch| ch.is_whitespace() || ch == '\r' || ch == '\n')
+                        && para.controls.is_empty();
+                    if is_empty_para {
+                        // 표 fragment 가 지연 flush 라 지금은 anchor 단을 특정할 수
+                        // 없다 — 보류 목록에 넣고 페이지 확정 후 일괄 부착.
+                        st.behind_pending_absorbs.push(
+                            crate::renderer::pagination::WrapAroundPara {
+                                para_index: para_idx,
+                                table_para_index: anchor_pi,
+                                has_text: false,
+                            },
+                        );
+                        continue;
+                    }
+                    st.behind_float_table_para = None;
+                } else {
+                    st.behind_float_table_para = None;
+                }
+            }
+
             // [Task #362] 어울림(Square wrap) 표 옆 paragraph 흡수.
             // Paginator engine.rs:288-320 동일 시멘틱.
             // 직전에 처리한 Square wrap 표의 (cs, sw) 와 동일한 LINE_SEG 를 가진
@@ -3332,6 +3377,17 @@ impl TypesetEngine {
                     measured_tables,
                     Some(para_idx),
                 );
+                // [#1955] 글뒤로/글앞으로 비-TAC 표 anchor: 후행 빈 문단 흡수 arming.
+                let has_behind_float_table = para.controls.iter().any(|c| {
+                    matches!(c, Control::Table(t)
+                        if !t.common.treat_as_char
+                            && matches!(t.common.text_wrap,
+                                crate::model::shape::TextWrap::BehindText
+                                    | crate::model::shape::TextWrap::InFrontOfText))
+                });
+                if has_behind_float_table {
+                    st.behind_float_table_para = Some(para_idx);
+                }
             }
             // 비-TAC Picture/Shape Square wrap: engine.rs:380-397 동일 시멘틱.
             // 그림의 첫 lineseg cs가 0일 수 있어 any_seg_matches 허용 플래그 활성화.
@@ -3647,6 +3703,42 @@ impl TypesetEngine {
             st.flush_column_always();
         }
         st.ensure_page();
+
+        // [#1955] 글뒤로 표 후행 빈 문단 보류 흡수 부착 — 페이지 확정 후
+        // anchor 표의 첫 fragment 가 있는 단에 소급 기록 (한글: 글뒤로 표는
+        // 플로우를 소비하지 않으므로 후행 문단이 anchor 쪽에 남음).
+        for wrap_para in std::mem::take(&mut st.behind_pending_absorbs) {
+            let anchor = wrap_para.table_para_index;
+            let is_first_fragment = |it: &PageItem| match it {
+                PageItem::Table { para_index, .. } => *para_index == anchor,
+                PageItem::PartialTable {
+                    para_index,
+                    is_continuation,
+                    ..
+                } => *para_index == anchor && !*is_continuation,
+                _ => false,
+            };
+            let mut attached = false;
+            'outer: for page in st.pages.iter_mut() {
+                for col in page.column_contents.iter_mut() {
+                    if col.items.iter().any(is_first_fragment) {
+                        col.wrap_around_paras.push(wrap_para.clone());
+                        attached = true;
+                        break 'outer;
+                    }
+                }
+            }
+            if !attached {
+                // anchor 미발견(예: 표가 배치 제외) — 마지막 단에 부착해 문단 누락 방지
+                if let Some(col) = st
+                    .pages
+                    .last_mut()
+                    .and_then(|p| p.column_contents.last_mut())
+                {
+                    col.wrap_around_paras.push(wrap_para);
+                }
+            }
+        }
 
         // 페이지 번호 + 머리말/꼬리말 할당
         Self::finalize_pages(

--- a/tools/verify_pi_page_vs_hangul.py
+++ b/tools/verify_pi_page_vs_hangul.py
@@ -163,6 +163,7 @@ def main() -> int:
     g = ap.add_mutually_exclusive_group(required=True)
     g.add_argument("--batch", type=Path, help="원본 폴더(재귀)")
     g.add_argument("--files", nargs="+", type=Path)
+    g.add_argument("--list", type=Path, help="파일 목록 텍스트(줄당 절대경로) — 표본 재현용")
     ap.add_argument("--sample", type=int, default=0)
     ap.add_argument("--seed", type=int, default=42)
     ap.add_argument("-o", "--out", type=Path, required=True)
@@ -181,6 +182,10 @@ def main() -> int:
     if args.batch:
         files = [p for p in sorted(args.batch.rglob("*"))
                  if p.suffix.lower() in (".hwpx", ".hwp")]
+    elif args.list:
+        # utf-8-sig: PowerShell Out-File 등이 넣는 BOM 이 첫 경로를 오염시키는 것 방지
+        files = [Path(l.strip()) for l in args.list.read_text(encoding="utf-8-sig").splitlines()
+                 if l.strip()]
     else:
         files = list(args.files)
     if args.sample and len(files) > args.sample:


### PR DESCRIPTION
## 요약

20k 서베이(seed=20260705)에서 발견한 pi-page 이탈 2개 축 수정 + 서베이 도구 개선.

### Task #1956 — WrapAroundPara 쪽나누기 무시 + 전체 폭 밴드 오매칭 (closes #1956)

- 명시적 쪽나누기(orce_page_break/para_style_break) 문단부터 wrap 밴드 해제 — 쪽나누기 표제가 표 옆에 흡수되던 결함 차단
- anchor LINE_SEG 가 단 전체 폭이면(표가 본문 폭 이상 = 옆 공간 없음) wrap 밴드 arming 억제 — 후속 전체 폭 문단 전부 오매칭 차단
- typeset.rs(활성 엔진) + pagination/engine.rs(동형) 동시 적용

### Task #1955 — 글뒤로/글앞으로 다중 쪽 표의 후행 빈 문단 귀속 (closes #1955)

- 글뒤로/글앞으로 표는 플로우 비소비(한글 시멘틱) — 후행 빈 문단을 anchor 첫 fragment 단에 소급 흡수 (fragment 지연 flush 고려, 페이지 확정 후 일괄 부착)
- 표시 귀속 휴리스틱([#1705]): anchor 가 글뒤로/글앞으로면 앵커 페이지 귀속

### tools — verify_pi_page_vs_hangul --list 옵션 + BOM 내성

## 한글 2022 오라클 검증

| 파일 | 전 | 후 |
|------|----|----|
| 61181 전자서명법 시행령 (법령안) | PI_MISMATCH 9건 (6쪽 이탈) | **MATCH** |
| 32310 국세청 직제 시행규칙 | PI_MISMATCH 7건 (5쪽 이탈) | **MATCH** |
| 15392329 구로구 위임사무 조례 별표 | PI_MISMATCH (9쪽 이탈) | **MATCH** |

영향 클래스 재계측(법령안·조문별·규제영향분석·직제 483건): MATCH 전환 6건 + n_mismatch 감소 2건, 악화 1건(32787 — 종전 wrap 오흡수가 우연히 한글 쪽번호와 일치해 가려졌던 pi126~132 가 기존 off-by-one 드리프트에 노출된 것, 총 쪽수 29vs28 불변. off-by-one 캘리브레이션 트랙 #1921 에서 후속). 나머지는 #1921 캘리브레이션 축으로 본 수정 범위 밖.

## 테스트

- wrap 유닛 12 / issue_1116 한컴 핀 13 / lib 전체 2,116 통과
- full suite 는 CI 위임

🤖 Generated with [Claude Code](https://claude.com/claude-code)
