### PR TITLE
docs: PR #1961 리뷰 후속 기록

### DIFF
--- a/mydocs/orders/20260706.md
+++ b/mydocs/orders/20260706.md
@@ -1,0 +1,7 @@
+# 오늘 할일 - 2026년 7월 6일
+
+## PR 처리
+
+| PR | 내용 | 처리 |
+|----|------|------|
+| #1961 | #1943 HWPX `write_line` 직렬화 결손 보정 | **머지**. `LineShape.connector` 기반 `hp:connectLine` 방출, `hp:startPt`/`hp:endPt`, `hp:controlPoints`, component block, `lineShape`, `fillBrush`, `shadow`, `groupLevel`, `instid` 보존으로 `connectLine` 변질과 그룹 자식 line 좌표/스타일 소실을 보정. 최신 head `6c846710e1365c5ba597ef14692676f951cd80f5` 기준 GitHub Actions 통과, 로컬 검증(`serializer::hwpx::shape`, full `cargo test --profile release-test --tests`, `clippy --all-targets`, `fmt`, `diff-check`) 통과. merge commit `bb2df91c63de36606a0bd642cb56fcfe137a031c`. review 문서는 옵션 2 docs-only PR로 archive 반영. #1943은 merge 직후 open 상태라 docs-only PR merge 후 후속 코멘트와 close 처리 필요 |

--- a/mydocs/pr/archives/pr_1961_review.md
+++ b/mydocs/pr/archives/pr_1961_review.md
@@ -1,0 +1,109 @@
+# PR #1961 리뷰 - write_line 직렬화 결손 보정
+
+## 메타
+
+| 항목 | 내용 |
+|---|---|
+| PR | https://github.com/edwardkim/rhwp/pull/1961 |
+| 제목 | Issue #1943: write_line 완전 재작성 — connectLine 변질 + 컴포넌트 블록/좌표 소실 수정 (최대 625px) |
+| 작성자 | planet6897 |
+| base | `devel` |
+| head | `fix/1943-line-serialize` |
+| 검토 시점 head SHA | `6c846710e1365c5ba597ef14692676f951cd80f5` |
+| merge commit | `bb2df91c63de36606a0bd642cb56fcfe137a031c` |
+| mergedAt | `2026-07-05T15:13:42Z` |
+| 규모 | 1 file, +172 / -35 |
+| mergeable | merge 전 최종 확인: `MERGEABLE` / `CLEAN` |
+| CI | 검토 시점 head 기준 GitHub Actions 통과 |
+| closingIssuesReferences | 비어 있음. PR 본문에는 `closes #1943`가 있었지만 merge 직후 #1943은 open 상태라 후속 docs-only PR merge 후 수동 close/comment 필요 |
+
+## 변경 범위
+
+- `src/serializer/hwpx/shape.rs`
+  - `LineShape.connector.is_some()`이면 `<hp:connectLine>`으로 방출하고, 아니면 기존 `<hp:line>`으로 방출한다.
+  - `LinkLineType`을 OWPML `ConnectLineType.type` enum 문자열로 직렬화한다.
+  - `hp:startPt`/`hp:endPt` 자식 요소와 connector의 `subjectIDRef`/`subjectIdx`, `hp:controlPoints`/`hp:point`를 보존한다.
+  - `offset/orgSz/curSz/flip/rotationInfo/renderingInfo`, `lineShape`, `fillBrush`, `shadow`, `groupLevel`, `instid`를 `write_rect`와 같은 구조로 방출한다.
+  - 기존 line 좌표 게이트를 `startX/startY/endX/endY` attr 확인에서 `hp:startPt`/`hp:endPt` 자식 확인으로 갱신하고, connectLine 태그/type/controlPoints 게이트를 추가했다.
+
+## 계약 확인
+
+- parser는 HWPX line 좌표를 `startPt`/`endPt` 자식 요소에서 읽고, `connectLine`은 `LineShape { connector: Some(...) }`로 materialize한다.
+- OWPML schema의 `ConnectLineType`도 `startPt`, `endPt`, optional `controlPoints`, `type` enum을 요구한다.
+- 따라서 PR의 serializer 변경 방향은 parser/schema 계약과 일치한다.
+- 특정 샘플명이나 페이지 번호로 결과를 맞추는 하드코딩은 보이지 않는다. 보정 근거는 문서 구조 필드(`LineShape.connector`, `ShapeComponentAttr`, `DrawingObjAttr.inst_id`, line geometry/style children)다.
+
+## 실파일/시각 검증
+
+이 PR은 HWPX 저장/라운드트립 후 도형 XML 손실을 다루므로 render/visual 영향이 있다. 다만 PR/이슈 본문에 적힌 대표 파일은 작성자 로컬 `hwpdocs` 코퍼스 경로로만 제시되어 있고, 현재 검토 환경에서 아래 파일명 계열은 찾지 못했다.
+
+- `2654625`
+- `3180687`
+- `1079960`
+- `21264499`
+- `156715276`
+
+따라서 이번 리뷰에서 한컴 기준 PDF visual sweep은 수행하지 않았다. 대신 serializer/parser/schema 계약, 신규 단위 게이트, 전체 테스트와 GitHub CI 통과를 merge 판단 근거로 삼는다.
+
+PR 본문 기준 작성자 실파일 검증 요약:
+
+- `2654625`: connectLine `6 -> 6`, render displacement `625.7px -> 0.00px`
+- `3180687`: 그룹 내 line `OVER 452.9px -> PASS`
+
+## 로컬 검증
+
+검토 시작 시 cargo cache 비대화 영향을 줄이기 위해 `/Users/tsjang/rhwp/target` 하위 항목을 삭제했다. 이후 아래 명령을 순차 실행했다.
+
+```bash
+gh pr edit 1961 --repo edwardkim/rhwp --add-reviewer jangster77
+git fetch upstream devel pull/1961/head:local/pr1961
+git switch -C review/pr1961 local/pr1961
+git merge upstream/devel --no-commit --no-ff
+git diff --check upstream/devel...HEAD
+cargo fmt --check
+env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx::shape
+env CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
+env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
+```
+
+결과:
+
+- reviewer assign: `jangster77`
+- `git merge upstream/devel --no-commit --no-ff`: `Already up to date`, 충돌 없음
+- `git diff --check upstream/devel...HEAD`: 통과
+- `cargo fmt --check`: 통과
+- `cargo test --lib serializer::hwpx::shape`: 18 passed
+- `cargo test --profile release-test --tests`: 통과
+  - lib tests: 2126 passed, 6 ignored
+  - `tests/svg_snapshot.rs`: 8 passed
+  - command exit 0
+- `cargo clippy --all-targets -- -D warnings`: 통과
+
+## GitHub CI
+
+검토 시점 `6c846710e1365c5ba597ef14692676f951cd80f5` 기준:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Native Skia tests: success
+- Build default-feature tests: success
+- Build & Test: success
+- CodeQL rust/javascript-typescript/python: success
+- WASM Build: skipped
+
+## 검토 결과
+
+merge 완료로 정리한다.
+
+근거:
+
+- 변경 범위가 `write_line` serializer로 좁다.
+- parser가 읽는 자식 요소 경로와 OWPML schema에 맞게 출력 경로를 보정했다.
+- `connectLine` 변질, component block/style/coordinate 소실, `groupLevel`/`instid` 대체 문제를 직접 겨냥한다.
+- 신규 단위 게이트와 전체 integration/clippy/GitHub CI가 통과했다.
+
+후속:
+
+- 원 PR merge commit: `bb2df91c63de36606a0bd642cb56fcfe137a031c`
+- 옵션 2에 따라 review 문서와 오늘할일은 문서-only PR로 반영한다.
+- `closingIssuesReferences`가 비어 있고 merge 직후 #1943이 open 상태였으므로, 문서-only PR merge 후 후속 코멘트와 close 처리를 수행한다.

--- a/mydocs/pr/archives/pr_1961_review_impl.md
+++ b/mydocs/pr/archives/pr_1961_review_impl.md
@@ -1,0 +1,129 @@
+# PR #1961 리뷰 구현 로그
+
+## Stage 1. 메타 확인
+
+완료.
+
+- PR: https://github.com/edwardkim/rhwp/pull/1961
+- 제목: `Issue #1943: write_line 완전 재작성 — connectLine 변질 + 컴포넌트 블록/좌표 소실 수정 (최대 625px)`
+- 작성자: `planet6897`
+- base: `devel`
+- head: `fix/1943-line-serialize`
+- 검토 시점 head SHA: `6c846710e1365c5ba597ef14692676f951cd80f5`
+- merge commit: `bb2df91c63de36606a0bd642cb56fcfe137a031c`
+- mergedAt: `2026-07-05T15:13:42Z`
+- 상태: merged, draft 아님, merge 전 `MERGEABLE` / `CLEAN`
+- 변경 규모: 1 file, +172 / -35
+- reviewer assign: `jangster77`
+- `closingIssuesReferences`: 비어 있음. 본문 `closes #1943`가 있었지만 merge 직후 #1943은 open 상태로 남음.
+
+## Stage 2. 로컬 fetch 및 merge 확인
+
+완료.
+
+```bash
+git fetch upstream devel pull/1961/head:local/pr1961
+git switch -C review/pr1961 local/pr1961
+git merge upstream/devel --no-commit --no-ff
+```
+
+결과:
+
+- `review/pr1961`에서 검토했다.
+- `upstream/devel` 기준 `Already up to date`.
+- 충돌 없음.
+
+## Stage 3. 변경 내용 검토
+
+완료.
+
+확인한 변경 범위:
+
+- `src/serializer/hwpx/shape.rs`
+
+중점 확인:
+
+- connector 보유 `LineShape`는 `<hp:connectLine>`으로 직렬화한다.
+- `LinkLineType`은 OWPML `ConnectLineType.type` enum 문자열로 방출한다.
+- 좌표는 parser가 실제로 읽는 `hp:startPt`/`hp:endPt` 자식 요소로 방출한다.
+- connector의 `subjectIDRef`/`subjectIdx`, `controlPoints`/`point`를 보존한다.
+- `ShapeComponentAttr` 기반 component block, line style, fill, shadow, `groupLevel`, `instid`를 보존한다.
+- OWPML schema `ConnectLineType`과 parser `parse_shape_object` 경로를 함께 확인했다.
+- 샘플명/페이지 번호/임의 계수 기반 하드코딩은 보이지 않는다.
+
+## Stage 4. 실파일/시각 검증 범위 확인
+
+완료.
+
+대표 파일 검색:
+
+```bash
+rg --files /Users/tsjang/rhwp /Users/tsjang/hwpdocs /Users/tsjang/Cloud/Devel/hwpdocs 2>/dev/null | rg '2654625|3180687|1079960|21264499|156715276'
+find /Users/tsjang/rhwp /Users/tsjang/Downloads /Users/tsjang/Documents /Users/tsjang/Cloud/Devel \
+  -path '*/target' -prune -o -path '*/node_modules' -prune -o -path '*/.git' -prune -o \
+  \( -iname '*2654625*' -o -iname '*3180687*' -o -iname '*1079960*' -o -iname '*21264499*' -o -iname '*156715276*' \) -print
+find output -path '*/target' -prune -o \
+  \( -iname '*2654625*' -o -iname '*3180687*' -o -iname '*1079960*' -o -iname '*21264499*' -o -iname '*156715276*' \) -print
+```
+
+결과:
+
+- 현재 검토 환경에서 PR 본문/이슈 본문 대표 실파일을 찾지 못했다.
+- 기준 PDF도 PR에 첨부되어 있지 않아 visual sweep은 수행하지 않았다.
+- 작성자 PR 본문에 실파일 `render-diff --via hwpx` 결과가 기록되어 있으므로, 리뷰어 로컬은 serializer/parser/schema 계약과 테스트 게이트 중심으로 검증했다.
+
+## Stage 5. 로컬 검증
+
+완료.
+
+검토 시작 시 `/Users/tsjang/rhwp/target` 하위 항목을 삭제했다. 이후 명령은 순차 실행했다.
+
+```bash
+git diff --check upstream/devel...HEAD
+cargo fmt --check
+env CARGO_INCREMENTAL=0 cargo test --lib serializer::hwpx::shape
+env CARGO_INCREMENTAL=0 cargo test --profile release-test --tests
+env CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings
+```
+
+결과:
+
+- `git diff --check upstream/devel...HEAD`: 통과
+- `cargo fmt --check`: 통과
+- `cargo test --lib serializer::hwpx::shape`: 18 passed
+- `cargo test --profile release-test --tests`: 통과
+  - lib tests: 2126 passed, 6 ignored
+  - `tests/svg_snapshot.rs`: 8 passed
+  - command exit 0
+- `cargo clippy --all-targets -- -D warnings`: 통과
+
+## Stage 6. GitHub CI 확인
+
+완료.
+
+최신 head `6c846710e1365c5ba597ef14692676f951cd80f5` 기준:
+
+- CI preflight: success
+- CodeQL preflight: success
+- Native Skia tests: success
+- Build default-feature tests: success
+- Build & Test: success
+- CodeQL: success
+- WASM Build: skipped
+
+## Stage 7. 결론
+
+merge 완료로 정리한다.
+
+근거:
+
+- 변경 범위가 HWPX line serializer로 제한되어 있다.
+- parser/schema 계약에 맞는 구조 보존 수정이다.
+- 신규 게이트가 PR 핵심 결손을 직접 확인한다.
+- 로컬 전체 테스트와 clippy, GitHub CI가 통과했다.
+
+옵션 2 후속 필요:
+
+- 원 PR merge commit: `bb2df91c63de36606a0bd642cb56fcfe137a031c`
+- review 문서와 오늘할일은 문서-only PR로 처리한다.
+- merge 직후 #1943은 open 상태이므로 문서-only PR merge 후 후속 코멘트와 close 처리를 수행한다.


### PR DESCRIPTION
## 개요

PR #1961 merge 후 옵션 2 절차에 따라 review 문서와 오늘할일만 별도 문서-only PR로 반영합니다.

## 변경 범위

- `mydocs/pr/archives/pr_1961_review.md`
- `mydocs/pr/archives/pr_1961_review_impl.md`
- `mydocs/orders/20260706.md`

## 원 PR

- PR: https://github.com/edwardkim/rhwp/pull/1961
- merge commit: `bb2df91c63de36606a0bd642cb56fcfe137a031c`
- 관련 이슈: https://github.com/edwardkim/rhwp/issues/1943

## 검증

- 문서-only 변경
- `git diff --check -- mydocs/pr/archives/pr_1961_review.md mydocs/pr/archives/pr_1961_review_impl.md mydocs/orders/20260706.md` 통과

## 후속

이 PR merge 후 #1943 상태를 확인하고, auto-close가 동작하지 않은 경우 후속 코멘트와 close 처리를 수행합니다.
