### PR TITLE
Issue #1920: 쪽 하단 고정 틀(발신명의/직인) 저장 flow 이중 계산 + vpos=0 새 쪽 신호 보존 (결재문서 군집 MATCH 0→9)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -12516,9 +12516,13 @@ impl TypesetEngine {
                     self.dpi,
                 );
                 let prospective_excl = st.current_bottom_fixed_exclusion.max(block_height + v_off);
-                // available 은 이미 현재 배타 영역을 차감한 값 — 이 블록 편입 후의
-                // 가용 높이로 보정해 "본문 텍스트 끝이 배타 영역을 침범하는가"를 판정.
-                let avail_after = available + st.current_bottom_fixed_exclusion - prospective_excl;
+                // available(12359)은 배타 영역 미차감 값(base - 각주 - zone)이다. 이 블록
+                // 편입 후의 배타 영역(prospective_excl)을 차감해 "본문 텍스트 끝이 배타
+                // 영역을 침범하는가"를 판정한다. [Issue #1920] 종전 `available +
+                // current_excl - prospective_excl` 은 available 이 이미 차감됐다는 잘못된
+                // 가정으로, 같은 쪽 두 번째 틀에서 기존 배타분만큼 과관용해져 한글이
+                // 다음 쪽으로 넘기는 틀을 현재 쪽에 흡수했다(36373162 pi16, 2쪽→1쪽).
+                let avail_after = available - prospective_excl;
                 if sync_h <= avail_after {
                     // 현재 쪽 하단에 배치 — 본문 흐름은 vpos 동기 위치까지만 전진.
                     st.current_height = sync_h;
@@ -12546,6 +12550,23 @@ impl TypesetEngine {
                 st.bottom_fixed_consumed_flow += consumed;
                 st.current_bottom_fixed_exclusion =
                     st.current_bottom_fixed_exclusion.max(block_height + v_off);
+                // [Issue #1920] 후속 일반 문단의 vpos 캘리브레이션(vpos_snap_current_height)은
+                // 저장 flow 좌표를 그대로 따라간다. 한글 저장 vpos 는 하단 고정 틀의 높이도
+                // 문서순 누적하므로, 스냅이 틀 높이만큼 전진한 좌표로 이동한 뒤 배타 영역
+                // 차감(available)과 이중 계산되어 문단이 다음 쪽으로 밀린다(결재문서본문
+                // 36373162 pi15: 694→935px 스냅 + 247px 배타 → 한글 p1 이 p2 로, d=+1).
+                // 롤백한 소비분만큼 활성 vpos base 를 전진시켜 후속 문단의 저장→flow 변환을
+                // 본문 흐름 좌표계에 정렬한다(후속 틀의 target_y 보정과 동일 원리).
+                if consumed > 0.0 {
+                    let consumed_hu = (consumed / self.dpi * 7200.0).round() as i32;
+                    if consumed_hu > 0 {
+                        if let Some(base) = st.vpos_page_base {
+                            st.vpos_page_base = Some(base + consumed_hu);
+                        } else if let Some(base) = st.vpos_lazy_base {
+                            st.vpos_lazy_base = Some(base + consumed_hu);
+                        }
+                    }
+                }
                 return;
             }
         }


### PR DESCRIPTION
## 요약

#1920(결재문서본문 PI_MISMATCH 군집) / #1921 잔여 트랙의 규명된 서브 메커니즘 2건 수정. 두 커밋 모두 **쪽 하단 고정 틀(vert=쪽·valign=Bottom — 발신명의 서명란·직인 틀)** 축.

### 커밋 1 — 하단 고정 틀 저장 flow 이중 계산 (typeset.rs)

한글 저장 vpos 는 하단 고정 틀의 높이도 문서순 누적한다(#1658 v3 확인 사항). 그런데:

1. **후속 일반 문단의 vpos 캘리브레이션 이중 계산** — `vpos_snap_current_height` 가 후속 문단을 저장 좌표(틀 높이 포함)로 전진 스냅한 뒤, available 의 하단 배타 영역 차감과 겹쳐 문단이 한 쪽 일찍 넘어간다(36373162 pi15: 흐름 694px 를 935px 로 스냅 + 배타 247px → 한글 p1 이 p2, d=+1). #1611 이 후속 *틀*의 target_y 는 `bottom_fixed_consumed_flow` 로 보정했지만 후속 *일반 문단*의 스냅은 미보정이었다. 배타 롤백 시 롤백 소비분만큼 활성 vpos base 를 전진시켜 동일 원리로 정렬.
2. **같은 쪽 두 번째 틀의 page-fit 과관용** — `avail_after = available + current_excl - prospective_excl` 은 available 이 배타 영역을 이미 차감했다는 가정인데 이 call site 의 available 은 미차감 값이라, 두 번째 틀에서 기존 배타분만큼 과관용해진다. 한글이 다음 쪽으로 넘기는 pi16 틀을 현재 쪽에 흡수해 2쪽→1쪽이 됐다. `available - prospective_excl` 로 정정(첫 틀은 current_excl=0 이라 동작 불변).

### 커밋 2 — lineseg 재계산의 저장 vpos=0 새 쪽 신호 보존 (document_core)

결재문서류 HWPX 는 일부 문단(tac 표 host 등)의 linesegarray 가 없어 로드 시 reflow 합성이 일어나고, `reflow_zero_height_paragraphs` 가 섹션 전체 vpos 를 재계산하면서 생성기가 저장한 **새 쪽 시작 신호(발신명의/직인 틀 host 의 first vpos=0)** 까지 연속 좌표로 덮어썼다. 신호가 사라지면 typeset 의 vpos-reset 쪽나눔(#321)이 발동하지 못해, 한글이 다음 쪽에 단독 배치하는 틀이 이전 쪽 하단에 흡수된다(36417450: rhwp 1쪽 vs 한글 2쪽 — 한글 PDF 시각 확인: p1 에 ~400px 여백이 남아도 발신명의 틀은 p2 하단 단독).

재계산 루프에서 "원본(비합성) first vpos=0 + 직전 저장 vpos>5000 + 쪽 기준·하단 정렬 비-TAC 표 host" 문단을 만나면 running_vpos 를 0 으로 되돌려 리셋을 보존한다. 틀 host 한정 가드로 일반 문단의 노이즈성 mid-doc vpos=0(task1749 pi2/47)은 계속 무시 — 해당 회귀 테스트(issue_1749_saved_bounds_page_break) 3/3 통과.

## 검증 (한글 2022 오라클)

- **36373162**: PI_MISMATCH → **MATCH** (2쪽, pi15=p1, pi16=p2)
- **36417450 및 동일 시그니처(1>2, lineseg 부재+vpos=0 리셋) 8건 전부**: 1쪽 → **2쪽 한글 정합**
- **결재문서본문 이탈 표본 60건** (20k 서베이 260건 중 seed 20260706): MATCH 0 → **9**, 악화 0
- **회귀 표본 100건** (d=+1 40 + d=-1 60 재검 목록): rhwp 측 배치 변화는 결재문서본문 5건의 1→2쪽(전부 한글=2 방향)뿐, **비대상 문서 이동 0**
- 관악 36389312(#1658 근거, 틀 2개 겹침): 1쪽 유지
- full suite(release-test 전체) + lib 2,126 통과, clippy 경고 0

(참고: 장시간 오라클 런에서 한글 COM 인스턴스 열화로 판정 잡음(com_error·가짜 PARA_COUNT)이 관찰되어, 회귀 판정은 rhwp 측 페이지 수 교차 대조로 확정. 검증 산출물 output/poc/task1920/)

## 관련

- #1920, #1921, #1611/#1624/#1658 선례의 미봉합 지점 2건
- 잔여: 결재문서본문 군집의 별도 메커니즘(empty-caret 오탐, 다방향 드리프트)은 #1920 에서 계속 추적

🤖 Generated with [Claude Code](https://claude.com/claude-code)