### PR TITLE
Issue #1920: lineseg 재계산 시 저장 vpos=0 새 쪽 시작 신호 보존 (#1969 후속 커밋 분리)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -276,7 +276,12 @@ impl DocumentCore {
                 .unwrap_or(layout.body_area.width);
 
             let mut body_line_seg_changed = false;
-            for para in &mut section.paragraphs {
+            // [Issue #1920] vpos 재계산(아래) 시 저장 vpos 의 새 쪽 시작 신호를 보존하기
+            // 위해, 이번 패스에서 LINE_SEG 가 합성(reflow)된 문단 — 저장 vpos 신뢰 불가 —
+            // 을 기록한다.
+            let mut reflowed_paras: std::collections::HashSet<usize> =
+                std::collections::HashSet::new();
+            for (pi, para) in section.paragraphs.iter_mut().enumerate() {
                 // 본문 문단 reflow
                 if Self::needs_line_seg_reflow(para, include_empty) {
                     let para_style = styles.para_styles.get(para.para_shape_id as usize);
@@ -285,6 +290,7 @@ impl DocumentCore {
                     let available_width = (col_width - margin_left - margin_right).max(1.0);
                     reflow_line_segs(para, available_width, styles, dpi);
                     body_line_seg_changed = true;
+                    reflowed_paras.insert(pi);
                 }
 
                 // HWPX: TAC 표가 있는 문단의 LINE_SEG lh 보정
@@ -378,7 +384,45 @@ impl DocumentCore {
             // 저장한 HWPX의 vertpos까지 덮어써 page sequence가 어긋난다 (#949 Stage 32).
             if body_line_seg_changed {
                 let mut running_vpos: i32 = 0;
-                for para in section.paragraphs.iter_mut() {
+                // [Issue #1920] 직전까지 본 "원본(비합성) lineseg 보유 문단"의 마지막 저장
+                // vpos. 결재문서류 생성기는 새 쪽 시작 문단(발신명의 틀 host)에 vpos=0 을
+                // 저장하는데, 이 재계산이 연속 좌표로 덮어쓰면 typeset 의 vpos-reset 쪽나눔
+                // (#321, paragraph_saved_vpos_reset_starts_new_page_after)이 무력화되어
+                // 한글이 다음 쪽에 두는 틀이 이전 쪽에 흡수된다(36417450 pi8, 1쪽 vs 2쪽).
+                // 원본 first vpos=0 + 직전 저장 vpos>5000(동일 임계) + 쪽 하단 고정 틀
+                // (vert=쪽·valign=Bottom, 발신명의 서명란·직인 틀) host 문단에서만
+                // running_vpos 를 0 으로 되돌려 리셋 신호를 재계산 좌표계에 보존한다.
+                // 틀 host 한정인 이유: 일반 문단의 mid-doc vpos=0 은 생성기 노이즈일 수
+                // 있어(task1749 pi2/47) 전면 보존 시 무관 문서의 배치가 흔들린다.
+                // wrap 은 불문 — 자리차지(발신명의)와 글뒤로(직인 도장, 36408321 pi12)
+                // 모두 같은 새 쪽 시그니처다.
+                let mut prev_stored_last_vpos: i32 = 0;
+                for (pi, para) in section.paragraphs.iter_mut().enumerate() {
+                    let was_reflowed = reflowed_paras.contains(&pi);
+                    let hosts_bottom_fixed_frame = para.controls.iter().any(|c| {
+                        matches!(c, Control::Table(t)
+                        if !t.common.treat_as_char
+                            && matches!(
+                                t.common.vert_rel_to,
+                                crate::model::shape::VertRelTo::Page
+                            )
+                            && matches!(
+                                t.common.vert_align,
+                                crate::model::shape::VertAlign::Bottom
+                            ))
+                    });
+                    if !was_reflowed
+                        && hosts_bottom_fixed_frame
+                        && prev_stored_last_vpos > 5000
+                        && para.line_segs.first().map(|s| s.vertical_pos) == Some(0)
+                    {
+                        running_vpos = 0;
+                    }
+                    let original_last_vpos = if was_reflowed {
+                        None
+                    } else {
+                        para.line_segs.last().map(|s| s.vertical_pos)
+                    };
                     // 문단의 첫 LINE_SEG vpos를 running_vpos로 갱신
                     if let Some(first_seg) = para.line_segs.first_mut() {
                         first_seg.vertical_pos = running_vpos;
@@ -445,6 +489,9 @@ impl DocumentCore {
                         }
                     }
                     running_vpos = inner_vpos;
+                    if let Some(v) = original_last_vpos {
+                        prev_stored_last_vpos = v;
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 요약

#1969(→ 통합 PR #1971로 merge)의 **후속 커밋 분리 제출**입니다. #1969 close(07-05 17:40Z) 이후 push되어 미반영된 두 번째 메커니즘 수정으로, 원 브랜치의 `99c5183f` 를 최신 devel(c43c22d8) 위에 체리픽·재검증했습니다.

### lineseg 재계산의 저장 vpos=0 새 쪽 신호 보존 (document_core)

결재문서류 HWPX 는 일부 문단(tac 표 host 등)의 linesegarray 가 없어 로드 시 reflow 합성이 일어나는데, 이때 `reflow_zero_height_paragraphs` 가 섹션 전체 vpos 를 재계산하면서 생성기가 저장한 **새 쪽 시작 신호(발신명의/직인 틀 host 의 first vpos=0)** 까지 연속 좌표로 덮어쓴다. 신호가 사라지면 typeset 의 vpos-reset 쪽나눔(#321)이 발동하지 못해, 한글이 다음 쪽에 단독 배치하는 틀이 이전 쪽 하단에 흡수된다(36417450: rhwp 1쪽 vs 한글 2쪽 — 한글 PDF 시각 확인: p1 에 ~400px 여백이 남아도 발신명의 틀은 p2 하단 단독).

재계산 루프에서 "원본(비합성) first vpos=0 + 직전 저장 vpos>5000 + 쪽 기준·하단 정렬(vert=PAGE·valign=BOTTOM) 비-TAC 표 host" 문단을 만나면 running_vpos 를 0 으로 되돌려 리셋 신호를 보존한다. 틀 host 한정 가드로 일반 문단의 노이즈성 mid-doc vpos=0(task1749 pi2/47)은 계속 무시하며, wrap 은 불문(자리차지=발신명의, 글뒤로=직인 도장 모두 커버).

## 검증 (한글 2022 오라클 + 최신 devel 재검증)

- **36417450 및 동일 시그니처(1>2: lineseg 부재 + 마지막 문단 vpos=0 리셋) 8건 전부**: 1쪽 → **2쪽 한글 정합** (오라클 MATCH 전환 7건 + 페이지수 정합 1건)
- **결재문서본문 이탈 표본 60건**: #1969 커밋1 포함 누계 MATCH 0 → **9**, 악화 0
- **회귀 표본 100건**(d=±1 재검 목록): rhwp 측 배치 변화는 결재문서본문 5건의 1→2쪽(전부 한글=2 방향)뿐, 비대상 문서 이동 0
- 최신 devel(c43c22d8) 재검증: 36417450 2쪽·36373162 2쪽 유지, `issue_1749_saved_bounds_page_break` 3/3(가드 한정으로 노이즈 리셋 회귀 차단), lib 2,126 통과. full suite 는 통합 상태에서 통과 확인(CI 위임)

검증 산출물: `output/poc/task1920/` (before/after TSV, 한글 PDF·PNG 시각 증거)

## 관련

- #1920 (진단 코멘트 2건 기록), #1969/#1971 후속, #321/#1380 선례

🤖 Generated with [Claude Code](https://claude.com/claude-code)