### PR TITLE
10k 서베이 수정: #1981 BinData 빈 확장자 보존 + #1982 DRM/빈파일 감지 분류

### DIFF
--- a/src/diagnostics/hwp5_roundtrip_batch.rs
+++ b/src/diagnostics/hwp5_roundtrip_batch.rs
@@ -230,6 +230,8 @@ fn detected_format_name(fmt: crate::parser::FileFormat) -> Option<&'static str> 
         FileFormat::Hwpx => Some("HWPX(ZIP)"),
         FileFormat::Hwp3 => Some("HWP3"),
         FileFormat::LegacyHwpml => Some("HWPML(구 XML)"),
+        FileFormat::DrmProtected => Some("DRM 보호"),
+        FileFormat::Empty => Some("빈 파일"),
         FileFormat::Hwp | FileFormat::Unknown => None,
     }
 }

--- a/src/diagnostics/hwpx_roundtrip_batch.rs
+++ b/src/diagnostics/hwpx_roundtrip_batch.rs
@@ -148,6 +148,8 @@ fn detected_format_name(fmt: crate::parser::FileFormat) -> Option<&'static str> 
         FileFormat::Hwp => Some("HWP5(OLE/CFB)"),
         FileFormat::Hwp3 => Some("HWP3"),
         FileFormat::LegacyHwpml => Some("HWPML(구 XML)"),
+        FileFormat::DrmProtected => Some("DRM 보호"),
+        FileFormat::Empty => Some("빈 파일"),
         FileFormat::Hwpx | FileFormat::Unknown => None,
     }
 }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -47,6 +47,11 @@ pub enum FileFormat {
     Hwp3,
     /// Legacy raw HWPML XML (미지원 — 감지만, Issue #1053)
     LegacyHwpml,
+    /// DRM/보안 컨테이너로 보호된 문서 (미지원 — 감지만, Issue #1982)
+    /// Fasoo(`\x9b DRMONE`) / SoftCamp SCDSA(`SCDSA00x`) 등. 복호화는 범위 밖.
+    DrmProtected,
+    /// 빈 파일(0 바이트) (Issue #1982)
+    Empty,
     /// 알 수 없는 포맷
     Unknown,
 }
@@ -57,9 +62,28 @@ const UNSUPPORTED_FILE_FORMAT_CODE: &str = "UNSUPPORTED_FILE_FORMAT";
 const SUPPORTED_FORMATS_HINT: &str = "현재 rhwp는 HWP 5.0, HWPX, 일부 HWP 3.0 문서만 지원합니다.";
 const UNSUPPORTED_HWPML_HINT: &str =
     "현재 rhwp는 HWP 5.0, HWPX, 일부 HWP 3.0 문서만 지원합니다. 한컴오피스에서 HWP 5.0 또는 HWPX로 다시 저장한 뒤 열어주세요.";
+const DRM_PROTECTED_CODE: &str = "DRM_PROTECTED";
+const DRM_PROTECTED_HINT: &str =
+    "DRM/보안 컨테이너로 보호된 문서입니다. 한컴오피스 등 DRM 클라이언트에서 보호를 해제한 뒤 저장해 열어주세요.";
+const EMPTY_FILE_CODE: &str = "EMPTY_FILE";
+const EMPTY_FILE_HINT: &str = "빈 파일(0 바이트)입니다.";
+
+// DRM/보안 컨테이너 시그니처 (Issue #1982 — 10k 서베이 검출).
+// Fasoo: `\x9b DRMONE  This Document is encrypted and protected by Fasoo`.
+const FASOO_DRM_SIG: &[u8] = b"\x9b DRMONE";
+// SoftCamp SCDSA(Security Content Document Security Agent): `SCDSA002`/`SCDSA004`.
+const SCDSA_SIG: &[u8] = b"SCDSA";
 
 /// 파일 데이터의 매직 바이트로 포맷을 감지한다.
 pub fn detect_format(data: &[u8]) -> FileFormat {
+    if data.is_empty() {
+        return FileFormat::Empty;
+    }
+    // DRM/보안 컨테이너(미지원 — 감지만, Issue #1982). 정상 매직보다 먼저 판별해
+    // "알 수 없는 파일 형식" 대신 명확한 안내를 준다.
+    if data.starts_with(FASOO_DRM_SIG) || data.starts_with(SCDSA_SIG) {
+        return FileFormat::DrmProtected;
+    }
     if data.len() >= 8 {
         // CFB/OLE 시그니처: D0 CF 11 E0 A1 B1 1A E1
         if data[0] == 0xD0 && data[1] == 0xCF && data[2] == 0x11 && data[3] == 0xE0 {
@@ -929,11 +953,32 @@ pub fn parse_document(data: &[u8]) -> Result<Document, ParseError> {
             format: detect_legacy_hwpml_format_name(data),
             hint: UNSUPPORTED_HWPML_HINT,
         }),
+        FileFormat::DrmProtected => Err(ParseError::UnsupportedFormat {
+            code: DRM_PROTECTED_CODE,
+            format: drm_format_name(data),
+            hint: DRM_PROTECTED_HINT,
+        }),
+        FileFormat::Empty => Err(ParseError::UnsupportedFormat {
+            code: EMPTY_FILE_CODE,
+            format: "빈 파일",
+            hint: EMPTY_FILE_HINT,
+        }),
         FileFormat::Unknown => Err(ParseError::UnsupportedFormat {
             code: UNSUPPORTED_FILE_FORMAT_CODE,
             format: "알 수 없는 파일 형식",
             hint: SUPPORTED_FORMATS_HINT,
         }),
+    }
+}
+
+/// DRM 벤더 시그니처로 사람이 읽을 이름을 고른다 (Issue #1982).
+fn drm_format_name(data: &[u8]) -> &'static str {
+    if data.starts_with(FASOO_DRM_SIG) {
+        "DRM 보호 문서 (Fasoo)"
+    } else if data.starts_with(SCDSA_SIG) {
+        "DRM 보호 문서 (SoftCamp SCDSA)"
+    } else {
+        "DRM 보호 문서"
     }
 }
 
@@ -1317,7 +1362,33 @@ mod tests {
     #[test]
     fn test_detect_format_too_short() {
         assert_eq!(detect_format(&[0x50, 0x4B]), FileFormat::Unknown);
-        assert_eq!(detect_format(&[]), FileFormat::Unknown);
+    }
+
+    #[test]
+    fn issue1982_detect_empty_file() {
+        assert_eq!(detect_format(&[]), FileFormat::Empty);
+        let err = parse_document(&[]).unwrap_err();
+        assert!(
+            matches!(&err, ParseError::UnsupportedFormat { code, .. } if *code == EMPTY_FILE_CODE),
+            "empty file → EMPTY_FILE: {err}"
+        );
+    }
+
+    #[test]
+    fn issue1982_detect_drm_containers() {
+        // Fasoo DRM
+        let fasoo = b"\x9b DRMONE  This Document is encrypted and protected by Fasoo DRM";
+        assert_eq!(detect_format(fasoo), FileFormat::DrmProtected);
+        // SoftCamp SCDSA
+        let scdsa = b"SCDSA002\x00\x00\xd0\x04";
+        assert_eq!(detect_format(scdsa), FileFormat::DrmProtected);
+        let err = parse_document(fasoo).unwrap_err();
+        assert!(
+            matches!(&err, ParseError::UnsupportedFormat { code, .. } if *code == DRM_PROTECTED_CODE),
+            "DRM → DRM_PROTECTED: {err}"
+        );
+        assert_eq!(drm_format_name(fasoo), "DRM 보호 문서 (Fasoo)");
+        assert_eq!(drm_format_name(scdsa), "DRM 보호 문서 (SoftCamp SCDSA)");
     }
 
     #[test]

--- a/src/serializer/hwpx/context.rs
+++ b/src/serializer/hwpx/context.rs
@@ -170,12 +170,12 @@ impl SerializeContext {
         // 순번(i+1) 명명은 링크 항목으로 id 에 구멍이 있는 문서(#1891 73504)에서
         // 이름과 id 가 어긋나 재파스 그림 참조가 엉킨다.
         for bd in doc.bin_data_content.iter() {
-            let ext = if bd.extension.is_empty() {
-                "bin"
-            } else {
-                bd.extension.as_str()
-            };
+            // 빈 확장자는 원본과 동일하게 확장자 없이(`image{id}.`) 재직렬화한다.
+            // 예전엔 `.bin` 기본값을 붙였으나(#1981), 원본이 확장자 없는 BinData
+            // (`BinData/image13.` 등, OLE·미상 임베드)를 담은 경우 라운드트립 확장자
+            // 멀티셋이 `bin` vs `""` 로 어긋나 PKG_FAIL 이 났다. 원본 형태를 보존한다.
             let manifest_id = format!("image{}", bd.id);
+            let ext = bd.extension.as_str();
             let href = format!("BinData/{}.{}", manifest_id, ext);
             let media_type = mime_from_ext(ext);
             ctx.bin_data_map.insert(
@@ -361,6 +361,30 @@ mod tests {
             !ctx.numbering_ids.is_registered(&0),
             "0 은 1-based 축에 없음 (회귀 가드)"
         );
+    }
+
+    #[test]
+    fn issue1981_empty_extension_bindata_keeps_no_ext() {
+        // 빈 확장자 BinData 는 `.bin` 을 붙이지 않고 원본 형태(`image{id}.`)로
+        // 재직렬화해야 한다 — 라운드트립 확장자 멀티셋 보존(#1981).
+        use crate::model::bin_data::BinDataContent;
+        let mut doc = Document::default();
+        doc.bin_data_content.push(BinDataContent {
+            id: 6,
+            data: vec![0, 1, 2],
+            extension: String::new(),
+        });
+        doc.bin_data_content.push(BinDataContent {
+            id: 7,
+            data: vec![3, 4, 5],
+            extension: "bmp".to_string(),
+        });
+        let ctx = SerializeContext::collect_from_document(&doc);
+        let e6 = &ctx.bin_data_map[&6];
+        assert_eq!(e6.href, "BinData/image6.", "빈 확장자는 .bin 금지");
+        assert_eq!(e6.media_type, "application/octet-stream");
+        let e7 = &ctx.bin_data_map[&7];
+        assert_eq!(e7.href, "BinData/image7.bmp");
     }
 
     #[test]


### PR DESCRIPTION
10k 문서 재서베이(seed=20260706)에서 검출된 로드/저장 결함 2건을 수정합니다. 각각 별도 커밋으로 체리픽 가능합니다.

## #1981 — BinData 빈 확장자 재직렬화 시 `.bin` 치환 제거
- 원본이 확장자 없는 BinData(`BinData/image13.` 등 OLE·미상 임베드)를 담은 경우, 직렬화기가 빈 확장자를 `.bin` 기본값으로 치환해 라운드트립 확장자 멀티셋이 `zip=[bin]` vs `ir=[""]` 로 어긋나 **PKG_FAIL**(156758029 조달청 보도자료).
- 빈 확장자는 원본과 동일하게 `image{id}.` 형태로 재직렬화(mime=octet-stream)하여 보존.
- 검증: 해당 파일 `hwpx-roundtrip` PKG_FAIL→PASS, 회귀 테스트 추가, `serializer::hwpx` 280 + `hwpx_roundtrip_baseline` 4/4 통과.

## #1982 — DRM/보안 컨테이너·빈 파일 전용 감지 분류 (#1946 후속)
- Fasoo DRM(`\x9b DRMONE`), SoftCamp SCDSA(`SCDSA00x`), 0바이트 파일을 generic `UNSUPPORTED_FILE_FORMAT` 대신 전용 코드(`DRM_PROTECTED`/`EMPTY_FILE`)로 분류. 복호화는 범위 밖 — 오류 메시지·분류 명확성만 개선.
- `FileFormat`에 `DrmProtected`·`Empty` 추가, `detect_format`에서 정상 매직보다 먼저 판별. 배치 진단 포맷명 매핑 보강.
- 검증: 실파일 E2E로 벤더별 전용 메시지 확인, `parser::` 360 통과, clippy clean.

_출처: output/poc/survey10k_0706 (HEAD a7884b70 기준 서베이). 관련 통계 코멘트: #1920/#1921/#1937._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
