### PR TITLE
10k 서베이 저장 충실도 수정: #1986 breakLatinWord 보존 + #1987 secPr 스칼라 보존

### DIFF
--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -252,6 +252,11 @@ pub struct ParaShape {
     pub head_type: HeadType,
     /// 문단 수준 (0~6 → 1~7수준, attr1 bit 25~27)
     pub para_level: u8,
+    /// [#1984] HWPX breakSetting@breakLatinWord 원문 보존
+    /// (BREAK_WORD/KEEP_WORD/HYPHENATION). 파서 미수집 시 None → 직렬화 기본값
+    /// KEEP_WORD. 값이 3가지라 attr1 비트 인코딩 대신 원문 보존으로 무손실 방출.
+    /// 꼬리말·표셀 등 재계산 경로에서 줄나눔이 달라져 레이아웃이 갈리는 것을 막는다.
+    pub break_latin_word: Option<String>,
 }
 
 /// ParaShape 비교: raw_data 필드 제외 (라운드트립용 원본 바이트는 논리적 동일성과 무관)
@@ -275,6 +280,7 @@ impl PartialEq for ParaShape {
             && self.line_spacing_v2 == other.line_spacing_v2
             && self.head_type == other.head_type
             && self.para_level == other.para_level
+            && self.break_latin_word == other.break_latin_word
     }
 }
 

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -753,6 +753,9 @@ fn parse_para_shape(data: &[u8]) -> Result<ParaShape, DocInfoError> {
         line_spacing_v2,
         head_type,
         para_level,
+        // HWP5 는 breakLatinWord 를 attr1 비트로 갖지만 HWPX 원문 보존 필드는 미사용
+        // (None → 직렬화 KEEP_WORD 기본, 기존 동작 유지). (#1984)
+        break_latin_word: None,
     })
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -978,6 +978,12 @@ fn parse_para_shape_child(
         b"breakSetting" => {
             for attr in ce.attributes().flatten() {
                 match attr.key.as_ref() {
+                    b"breakLatinWord" => {
+                        // [#1984] 값 3종(BREAK_WORD/KEEP_WORD/HYPHENATION) — 원문 보존.
+                        // 미보존 시 직렬화가 KEEP_WORD 로 고정해 꼬리말·표셀 재계산
+                        // 줄나눔이 바뀌고 레이아웃(페이지 수)이 갈린다.
+                        ps.break_latin_word = Some(attr_str(&attr));
+                    }
                     b"breakNonLatinWord" => {
                         // HWP5 ParaShape attr1 bit 7: non-Latin line-break unit.
                         //

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -238,6 +238,7 @@ fn test_serialize_para_shape_roundtrip() {
         line_spacing_v2: 0,
         head_type: crate::model::style::HeadType::None,
         para_level: 0,
+        break_latin_word: None,
     };
 
     let data = serialize_para_shape(&ps);
@@ -540,6 +541,7 @@ fn test_serialize_doc_info_roundtrip() {
         line_spacing_v2: 0,
         head_type: crate::model::style::HeadType::None,
         para_level: 0,
+        break_latin_word: None,
     });
     doc_info.styles.push(Style {
         raw_data: None,

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -996,6 +996,8 @@ fn write_para_pr<W: Write>(
     } else {
         "BREAK_WORD"
     };
+    // [#1984] breakLatinWord 는 IR 원문 보존값(없으면 KEEP_WORD 기본).
+    let break_latin = ps.break_latin_word.as_deref().unwrap_or("KEEP_WORD");
     let widow_orphan = ((ps.attr2 >> 5) & 1).to_string();
     let keep_with_next = ((ps.attr2 >> 6) & 1).to_string();
     let keep_lines = ((ps.attr2 >> 7) & 1).to_string();
@@ -1021,7 +1023,7 @@ fn write_para_pr<W: Write>(
         w,
         "hh:breakSetting",
         &[
-            ("breakLatinWord", "KEEP_WORD"),
+            ("breakLatinWord", break_latin),
             ("breakNonLatinWord", break_non_latin),
             ("widowOrphan", &widow_orphan),
             ("keepWithNext", &keep_with_next),

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -89,6 +89,21 @@ fn replace_visibility(xml: &str, sd: &SectionDef) -> String {
     xml.replacen(TEMPLATE_VISIBILITY, &render_visibility(sd), 1)
 }
 
+/// [#1987] 템플릿 secPr 의 하드코딩 스칼라(spaceColumns, outlineShapeIDRef)를 IR 값으로 치환.
+/// 각 속성은 템플릿 secPr 여는 태그에 정확히 1회 등장하므로 replacen(1)로 안전하다.
+fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
+    let out = xml.replacen(
+        r#"spaceColumns="1134""#,
+        &format!(r#"spaceColumns="{}""#, sd.column_spacing),
+        1,
+    );
+    out.replacen(
+        r#"outlineShapeIDRef="1""#,
+        &format!(r#"outlineShapeIDRef="{}""#, sd.outline_numbering_id),
+        1,
+    )
+}
+
 /// 레퍼런스 기준 줄 레이아웃 파라미터.
 const VERT_STEP: u32 = 1600; // vertsize(1000) + spacing(600)
 /// 탭 기본 폭 (한컴이 열면서 재계산하지만 초기값으로 필요).
@@ -125,6 +140,12 @@ pub fn write_section(
     out = replace_page_border_fill(&out, &section.section_def);
     // [#1637] secPr visibility — 템플릿 고정값을 IR 값으로 치환(hideFirstEmptyLine 등 보존).
     out = replace_visibility(&out, &section.section_def);
+
+    // [#1987] secPr 스칼라 필드 — 템플릿 하드코딩(spaceColumns="1134", outlineShapeIDRef="1")을
+    // IR 값으로 치환한다. 미치환 시 원본이 spaceColumns=1130·outlineShapeIDRef=0 등이어도
+    // 1134/1 로 방출돼 단 간격·개요번호 문단모양 참조가 어긋난다. ir-diff 는 secPr 스칼라를
+    // 비교하지 않아 못 잡던 저장 충실도 결함.
+    out = replace_secpr_scalars(&out, &section.section_def);
 
     // 바탕쪽(masterPage) — secPr 의 masterPageCnt 치환 + secPr 내부 끝에 idRef 참조 삽입.
     // 누락 시 라운드트립에서 바탕쪽 전체(그 안의 그림/표/문단 노드 포함)가 소실된다.
@@ -2220,6 +2241,8 @@ mod tests {
         // [Finding 14] 원본 secPr 의 tabStopVal="4000" tabStopUnit="HWPUNIT" (한컴
         // 기본 탭 폭 상수) 이 직렬화에서 누락되지 않아야 한다. 순서는
         // tabStop → tabStopVal → tabStopUnit → outlineShapeIDRef.
+        // [#1987] outlineShapeIDRef 는 이제 IR 값 치환 대상 — 기본 SectionDef 는
+        // outline_numbering_id=0 이므로 "0" 이 방출된다.
         let mut para = Paragraph::default();
         para.text = "x".to_string();
         let (doc, section) = make_doc_with_paragraph(para);
@@ -2227,10 +2250,37 @@ mod tests {
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
         assert!(
             xml.contains(
-                r#"tabStop="8000" tabStopVal="4000" tabStopUnit="HWPUNIT" outlineShapeIDRef="1""#
+                r#"tabStop="8000" tabStopVal="4000" tabStopUnit="HWPUNIT" outlineShapeIDRef="0""#
             ),
             "secPr 에 tabStopVal/tabStopUnit 이 정확 순서로 있어야 함: {}",
             &xml[..600.min(xml.len())]
+        );
+    }
+
+    #[test]
+    fn issue1987_secpr_scalars_reflect_ir() {
+        // [#1987] secPr 의 spaceColumns/outlineShapeIDRef 가 템플릿 하드코딩(1134/1)이
+        // 아니라 IR 값으로 방출돼야 한다. 미치환 시 멀티구역 문서 후반부 렌더 붕괴.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, mut section) = make_doc_with_paragraph(para);
+        section.section_def.column_spacing = 1130;
+        section.section_def.outline_numbering_id = 0;
+        doc.sections = vec![section.clone()];
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"spaceColumns="1130""#),
+            "spaceColumns=1130 방출: {}",
+            &xml[..400]
+        );
+        assert!(
+            xml.contains(r#"outlineShapeIDRef="0""#),
+            "outlineShapeIDRef=0 방출"
+        );
+        assert!(
+            !xml.contains(r#"spaceColumns="1134""#),
+            "템플릿 1134 잔존 금지"
         );
     }
 


### PR DESCRIPTION
10k 재서베이(seed=20260707)에서 발견한 HWPX 저장 충실도 결함 2건을 수정합니다. 각각 별도 커밋으로 체리픽 가능.

## #1986 — ParaShape `breakLatinWord` 원문 보존
파서가 `breakSetting@breakLatinWord`를 IR로 수집하지 않고 직렬화가 `KEEP_WORD`로 하드코딩(header.rs TODO)해, 원본의 `HYPHENATION`/`BREAK_WORD`가 라운드트립에서 전멸했습니다(`1543000 농업환경`: HYPHENATION 89 → 0).
- 영어 단어 줄나눔 방식이라 꼬리말·각주·표셀 등 **재계산 경로에서 줄바꿈·높이**가 달라집니다.
- 값이 3종이라 attr1 비트 인코딩 대신 **ParaShape 원문 보존 필드**(`break_latin_word: Option<String>`)로 무손실 방출. HWP5 경로는 `None`(기존 `KEEP_WORD` 기본, 무회귀).
- 검증: 라운드트립 후 `breakLatinWord` 분포가 원본과 완전 일치.

## #1987 — secPr `spaceColumns`/`outlineShapeIDRef` 원본 값 보존
템플릿 하드코딩(`spaceColumns="1134"`, `outlineShapeIDRef="1"`)을 IR 값으로 치환. 미치환 시 원본 1130/0 등이 1134/1로 방출돼 단 간격·개요번호 문단모양 참조가 어긋났습니다. `ir-diff`가 secPr 스칼라를 비교하지 않아 미검출. 회귀 테스트 추가.

## 검증
- `hwpx_roundtrip_baseline` 게이트 4/4 PASS (skeleton 무회귀).
- render-diff 재검: 이전 PASS 12건 전부 PASS 유지 (렌더 무회귀).
- 신규 단위 테스트 통과 (`issue1987_secpr_scalars_reflect_ir`, `secpr_emits_tab_stop_val_and_unit`).

_출처: output/poc/survey10k_0707. 관련: #1988(tabItem 드롭, 별도), #1984(각주/표 재계산 캐스케이드, 별도·미해결)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
