### PR TITLE
Issue #1984: HWPX 각주/미주 모양(noteLine·noteSpacing) 원본 값 보존 — 각주 페이지 표 분할 캐스케이드 해소

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -89,6 +89,82 @@ fn replace_visibility(xml: &str, sd: &SectionDef) -> String {
     xml.replacen(TEMPLATE_VISIBILITY, &render_visibility(sd), 1)
 }
 
+/// [#1984] noteLine `type` u8 → HWPX 문자열 (parser noteLine type 역매핑).
+fn note_line_type_str(t: u8) -> &'static str {
+    match t {
+        0 => "NONE",
+        2 => "DASH",
+        3 => "DOT",
+        4 => "DASH_DOT",
+        5 => "DASH_DOT_DOT",
+        6 => "LONG_DASH",
+        7 => "CIRCLE",
+        8 => "DOUBLE_SLIM",
+        9 => "SLIM_THICK",
+        10 => "THICK_SLIM",
+        11 => "SLIM_THICK_SLIM",
+        _ => "SOLID",
+    }
+}
+
+/// [#1984] separator_color(0xBBGGRR LE) → "#RRGGBB" (parser noteLine color 역매핑).
+fn note_color_hex(c: u32) -> String {
+    let r = c & 0xFF;
+    let g = (c >> 8) & 0xFF;
+    let b = (c >> 16) & 0xFF;
+    format!("#{r:02X}{g:02X}{b:02X}")
+}
+
+/// [#1984] FootnoteShape → `<hp:noteLine .../>` + `<hp:noteSpacing .../>` 두 요소.
+fn render_note_line_spacing(shape: &crate::model::footnote::FootnoteShape) -> (String, String) {
+    let note_line = format!(
+        r#"<hp:noteLine length="{}" type="{}" width="{} mm" color="{}"/>"#,
+        shape.separator_length,
+        note_line_type_str(shape.separator_line_type),
+        line_width_mm(shape.separator_line_width),
+        note_color_hex(shape.separator_color),
+    );
+    let note_spacing = format!(
+        r#"<hp:noteSpacing betweenNotes="{}" belowLine="{}" aboveLine="{}"/>"#,
+        shape.between_notes_margin_hu(),
+        shape.separator_below_margin_hu(),
+        shape.separator_above_margin_hu(),
+    );
+    (note_line, note_spacing)
+}
+
+/// [#1984] 템플릿 footNotePr/endNotePr 의 하드코딩 noteLine·noteSpacing 을 IR 값으로 치환.
+/// 미치환 시 각주 구분선 위/아래 여백·주석간격이 항상 기본값(aboveLine=850 등)으로 방출돼
+/// 각주 zone 높이가 달라지고, 각주 있는 페이지의 본문 가용높이가 어긋나 표 분할·페이지 수가
+/// 갈린다(1543000: 각주 overhead 32.83→19.39px → p141 표 1행/3행 → 192/190쪽). 파서는
+/// 값을 FootnoteShape 로 수집하나 직렬화가 템플릿 상수만 방출하던 결함.
+fn replace_footnote_shape(xml: &str, sd: &SectionDef) -> String {
+    // 템플릿: 첫 noteLine(length="-1")·noteSpacing(betweenNotes="283") = 각주,
+    // 둘째(length="14692344"·betweenNotes="0") = 미주.
+    let (fn_line, fn_spacing) = render_note_line_spacing(&sd.footnote_shape);
+    let (en_line, en_spacing) = render_note_line_spacing(&sd.endnote_shape);
+    xml.replacen(
+        r##"<hp:noteLine length="-1" type="SOLID" width="0.12 mm" color="#000000"/>"##,
+        &fn_line,
+        1,
+    )
+    .replacen(
+        r#"<hp:noteSpacing betweenNotes="283" belowLine="567" aboveLine="850"/>"#,
+        &fn_spacing,
+        1,
+    )
+    .replacen(
+        r##"<hp:noteLine length="14692344" type="SOLID" width="0.12 mm" color="#000000"/>"##,
+        &en_line,
+        1,
+    )
+    .replacen(
+        r#"<hp:noteSpacing betweenNotes="0" belowLine="567" aboveLine="850"/>"#,
+        &en_spacing,
+        1,
+    )
+}
+
 /// 레퍼런스 기준 줄 레이아웃 파라미터.
 const VERT_STEP: u32 = 1600; // vertsize(1000) + spacing(600)
 /// 탭 기본 폭 (한컴이 열면서 재계산하지만 초기값으로 필요).
@@ -125,6 +201,10 @@ pub fn write_section(
     out = replace_page_border_fill(&out, &section.section_def);
     // [#1637] secPr visibility — 템플릿 고정값을 IR 값으로 치환(hideFirstEmptyLine 등 보존).
     out = replace_visibility(&out, &section.section_def);
+
+    // [#1984] 각주/미주 모양(구분선 여백·주석간격)을 IR 값으로 치환 — 미치환 시 각주 zone
+    // 높이가 기본값으로 고정돼 각주 있는 페이지의 표 분할·페이지 수가 갈린다.
+    out = replace_footnote_shape(&out, &section.section_def);
 
     // 바탕쪽(masterPage) — secPr 의 masterPageCnt 치환 + secPr 내부 끝에 idRef 참조 삽입.
     // 누락 시 라운드트립에서 바탕쪽 전체(그 안의 그림/표/문단 노드 포함)가 소실된다.
@@ -2165,6 +2245,47 @@ mod tests {
         let mut doc = Document::default();
         doc.sections.push(section.clone());
         (doc, section)
+    }
+
+    #[test]
+    fn issue1984_footnote_shape_reflects_ir() {
+        // [#1984] footNotePr 의 noteLine/noteSpacing 이 템플릿 기본값(aboveLine=850,
+        // betweenNotes=283 등)이 아니라 IR FootnoteShape 값으로 방출돼야 한다. 미치환 시
+        // 각주 zone 높이가 달라져 각주 있는 페이지의 표 분할·페이지 수가 갈린다.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, mut section) = make_doc_with_paragraph(para);
+        let fs = &mut section.section_def.footnote_shape;
+        fs.separator_margin_top = 1417; // aboveLine
+        fs.note_spacing = 850; // belowLine
+        fs.raw_unknown = 566; // betweenNotes
+        fs.separator_line_width = 9; // 0.7 mm
+        fs.separator_length = -2;
+        fs.separator_line_type = 1; // SOLID
+        fs.separator_color = 0x99_99_99; // #999999
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(
+                r#"<hp:noteSpacing betweenNotes="566" belowLine="850" aboveLine="1417"/>"#
+            ),
+            "각주 noteSpacing 이 IR 값이어야 함: {}",
+            &xml[..xml
+                .find("footNote")
+                .map(|i| i + 300)
+                .unwrap_or(600)
+                .min(xml.len())]
+        );
+        assert!(
+            xml.contains(
+                r##"<hp:noteLine length="-2" type="SOLID" width="0.7 mm" color="#999999"/>"##
+            ),
+            "각주 noteLine 이 IR 값이어야 함"
+        );
+        assert!(
+            !xml.contains(r#"betweenNotes="283""#),
+            "템플릿 기본 betweenNotes=283 잔존 금지"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약
10k 재서베이(seed=20260707)의 PAGE_MISMATCH 근본 원인. HWPX 직렬화가 각주/미주 모양(`<hp:noteLine>`·`<hp:noteSpacing>`)을 **템플릿 상수로만 방출**해, 파서가 `FootnoteShape`로 수집한 원본 값(구분선 위/아래 여백·주석 간격·구분선 굵기/길이/색)이 라운드트립에서 전부 기본값으로 손실됩니다.

## 왜 렌더가 갈리나
각주 zone 높이 = separator overhead(`aboveLine + line_width + belowLine`) + between-notes margin × 각주수 + 내용. 이 값이 기본값으로 고정되면 **각주 있는 페이지의 본문 가용 높이**가 달라집니다.

`1543000-202500005 농업환경(중간보고)`:
```
원본 noteSpacing: aboveLine=1417 belowLine=850  betweenNotes=566, noteLine width=0.7mm
저장 후(기본값):  aboveLine= 850 belowLine=567  betweenNotes=283, width=0.12mm
→ 각주 separator overhead 32.83px → 19.39px
→ p141 표 가용공간이 커져 31행 표가 1행/3행으로 다르게 분할
→ 페이지 나눔 캐스케이드 → 192 → 190쪽, 최대 변위 1034px
```
본문 문단은 저장 LINE_SEG를 써서 무영향이나, **꼬리말·각주·표 셀은 재계산 경로**라 이 손실이 레이아웃으로 발현됩니다. (코드 계측 `available` 성분: `total_footnote 103.47 vs 78.71` 로 확정.)

## 수정
`write_section`에서 템플릿 `noteLine`/`noteSpacing`(각주+미주)을 IR `footnote_shape`/`endnote_shape` 값으로 치환(`replace_footnote_shape`).

## 검증
- `1543000` render-diff: **192↔190·1034px → 192=192·0px**. (잔여 STRUCT는 사전 존재하던 p0 `nodes=31/32` disp=0 — #1984 무관.)
- `hwpx_roundtrip_baseline` 4/4 PASS, 각주 보유 문서 render-diff **10/10 무회귀**.
- 회귀 테스트 `issue1984_footnote_shape_reflects_ir` 추가.

_출처: output/poc/survey10k_0707. 조사 중 발견한 별개 저장 결함: #1986/#1987(→ PR #1989), #1988(tabItem)._

🤖 Generated with [Claude Code](https://claude.com/claude-code)
