### PR TITLE
Issue #2015: HWPX 부동 RowBreak 표 vert_offset 이중계상 수정 (91.2px 오버플로우 소거)

### DIFF
--- a/mydocs/plans/task_m100_2015.md
+++ b/mydocs/plans/task_m100_2015.md
@@ -1,0 +1,65 @@
+# 수행계획서 — #2015 HWPX saved-bounds RowBreak 표 잔존 드리프트 (#1811 후속)
+
+- 이슈: #2015
+- 마일스톤: v1.0.0 (M100)
+- 브랜치: `fix/2015-saved-bounds-rowbreak-overflow` (base: `origin/devel`)
+- 관련: #1811(PR #1887), #1749(PR #1752)
+- 대상 샘플: `samples/task1749/saved_bounds_cumulative_page_break.hwpx`
+- 정답지: `samples/task1749/saved_bounds_cumulative_page_break-2024.pdf` (한글 2024)
+
+## 문제 요약
+
+PR #1887이 RowBreak/saved-bounds 조판을 보정했으나 visual sweep p4/p5 잉크 정합이 낮게 남았다
+(`ink_match` p4≈9.6% / p5≈5.1%). 재분석 결과 #1811 seam의 **미해소 잔존분 2종**으로 특정.
+
+### 핵심 모순 (typeset 추정 vs 실측, ≈215px)
+
+| 항목 | 값 |
+|---|---|
+| body 바닥(절대) | 1026.5px (y=96.0 + h=930.5) |
+| typeset `used` | 806.0px → "들어감" 판정 |
+| 실측 render tree 바닥(pi=52 표) | 1117.7px |
+| 초과 | 91.2px (`LAYOUT_OVERFLOW: para=52 PartialTable`) |
+
+### 발원지 ① 부동(tac=false) RowBreak 표 pi=52 — 포맷 공통
+
+- 표 `size=48214×8555`(저장 114px) vs 셀[5] 내용 `h=21111`(281px), 별표 문단 6개.
+- typeset fit·`used`는 저장 바운드 기준, layout은 내용 파생 높이로 그려 프래그먼트가 바닥 초과.
+- `ir-diff` pi=52 **차이 0건** → 레이아웃 row-cut·높이 회계 결함(파싱 아님).
+- 소스 경계: `src/renderer/typeset.rs`(fit·`used`) ↔ `src/renderer/layout/table_layout.rs`(PartialTable 높이/`end_cut`).
+
+### 발원지 ② 인라인(tac=true) 표 pi=50 — HWPX 전용
+
+- `ir-diff` pi=50 **line_segs A=0(HWPX)/B=1(HWP)** → HWPX 표 컨테이너 lineSeg 미저장 → `lh=28769` 합성.
+- 합성 셀 내부 별표 줄 피치: 문단 내 1818HU(24.24px)/문단 사이 +500HU(≈30.9px) 교대 → 한컴 균일 렌더와 불일치.
+- 소스 경계: `src/renderer/composer.rs` / `src/renderer/layout/table_layout.rs` HWPX 합성 lineSeg 높이·줄 피치.
+
+## 목표 / 완료 기준
+
+1. pi=52 부동 RowBreak 표 프래그먼트가 body 바닥(1026.5px)을 넘지 않도록 typeset `used` 회계와
+   layout row-cut 높이를 정합 → `LAYOUT_OVERFLOW` 소거.
+2. pi=50 HWPX 인라인 표 합성 lineSeg 내부 줄 피치를 한컴 균일 렌더에 정합.
+3. `tests/issue_1749_*`, `issue_1035_alignment`, `issue_1139_inline_picture_duplicate` 등 기존 회귀 유지.
+4. visual sweep p4/p5 잉크 정합 개선(수치는 착수 후 계측 기준선 대비).
+
+## 범위 밖
+
+- HWP3 경로(별도 파서 규칙), 각주/미주(#1875 계열 오염 회피), #2004 image-stack.
+- 특정 샘플명·페이지·임의 계수 하드코딩 분기(리뷰 규칙 위반) 금지 — 문서 속성 기반만.
+
+## 접근 원칙
+
+- 소스 무수정 분석은 완료. 구현은 별도 구현계획서(3~6단계) 승인 후 착수.
+- 발원지 ①(오버플로우, 포맷 공통)을 우선 — 회귀 위험이 명확하고 자체 진단(`LAYOUT_OVERFLOW`)으로 검증 가능.
+- 발원지 ②(HWPX 합성 줄 피치)는 ① 안정화 후, ir-diff/ render-tree y좌표로 한컴 정합 확인하며 진행.
+
+## 검증 수단
+
+- `rhwp export-svg … | grep OVERFLOW`, `dump-pages -p 3`, `dump -s0 -p50/-p52`, `ir-diff … -s0 -p50/-p52`
+- `export-render-tree -p 3` y좌표 before/after diff
+- `cargo test --profile release-test --tests`, `cargo clippy --all-targets -- -D warnings`
+- visual sweep(래스터 도구 있는 환경): p4/p5 `ink_match`
+
+## 다음 단계
+
+본 수행계획서 승인 → 구현계획서(`task_m100_2015_impl.md`, 3~6단계) 작성 → 승인 → 단계별 착수.

--- a/mydocs/plans/task_m100_2015_impl.md
+++ b/mydocs/plans/task_m100_2015_impl.md
@@ -1,0 +1,57 @@
+# 구현계획서 — #2015 HWPX saved-bounds RowBreak 표 잔존 드리프트
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow` (base `origin/devel`)
+- 수행계획서: `mydocs/plans/task_m100_2015.md`
+- 원칙: 소스 무수정 분석 완료. 각 단계는 **자체 진단(`LAYOUT_OVERFLOW`)+회귀 테스트**로 검증. 하드코딩 분기 금지.
+
+## 대상 코드 (규모 주의)
+
+| 파일 | 줄수 | 역할 |
+|---|---:|---|
+| `src/renderer/typeset.rs` | 15910 | fit·`used`(current_height) 회계, saved-bounds fit 판정 |
+| `src/renderer/layout/table_layout.rs` | 7558 | PartialTable 프래그먼트 실측 높이/`end_cut` |
+| `src/renderer/composer.rs` | 1883 | HWPX 합성 lineSeg 생성 |
+
+## 단계 (5단계)
+
+### Stage 1 — 기준선 하네스 + 코드 국소화 (소스 무수정)
+- 목표: 재현을 고정하고 오차 발생 함수를 **정확히** 특정.
+- 산출: `tests/issue_2015_saved_bounds_rowbreak.rs` — p3(4쪽) 렌더 시 `LAYOUT_OVERFLOW(para=52)` 부재를 기대하는 실패 테스트(현재 red) + `used` vs 실측 바닥 계측.
+- typeset의 pi=52 부동 표 높이 회계 지점과 layout의 프래그먼트 실측 높이 지점을 코드 인용으로 문서화(`working/task_m100_2015_stage1.md`).
+- 커밋: 테스트 + stage1 문서.
+
+### Stage 2 — 발원지 ① 부동 RowBreak 표 오버플로우 소거 (포맷 공통)
+- typeset `used` 회계가 부동(tac=false) RowBreak PartialTable 프래그먼트의 **실측 row-cut 높이**를 반영하도록 정합.
+- body 바닥(1026.5px) 초과 금지. `end_cut` 이 페이지 잔여공간에 맞게 산출되는지 확인.
+- 검증: `para=52` OVERFLOW 소거, `issue_1749_*`/`issue_1035`/`issue_1139` 회귀 유지, clippy.
+- 커밋: 소스 + stage2 문서.
+
+### Stage 3 — 발원지 ② HWPX 인라인 표 합성 lineSeg 줄 피치 (HWPX 전용)
+- pi=50 합성 lineSeg 내부 별표 줄 피치(문단 내 1818HU / 문단 사이 +500HU 교대)를 한컴 균일 렌더에 정합.
+- HWP 경로(B=1 저장 lineSeg)는 불변, HWPX 합성 경로만 보정.
+- 검증: `export-render-tree -p 3` y좌표가 PDF 균일 피치에 근접, ir-diff 회귀 없음.
+- 커밋: 소스 + stage3 문서.
+
+### Stage 4 — 회귀·시각 검증
+- `cargo test --profile release-test --tests` 전량, `cargo clippy --all-targets -- -D warnings`.
+- p2 부수 `pi=26 overflow=1.6px` 동반 해소 여부 확인(같은 계열이면 포함, 아니면 별도 기록).
+- 시각: 래스터 도구 가용 환경에서 p4/p5 `ink_match` 기준선 대비 개선 계측(불가 시 render-tree y좌표 정합으로 대체 판정).
+- 커밋: stage4 문서.
+
+### Stage 5 — 최종 보고 + 오늘할일
+- `mydocs/report/task_m100_2015_report.md` 작성(before/after 수치, 회귀 결과, 잔여 리스크).
+- 오늘할일(`orders/`)은 불가침 메모리 룰에 따라 수정하지 않음(참조만).
+- merge 전 `git status` 클린 확인.
+
+## 완료 기준
+
+1. `para=52 PartialTable` `LAYOUT_OVERFLOW` 소거(body 바닥 미초과).
+2. HWPX 인라인 표 줄 피치 한컴 정합.
+3. 기존 회귀 전량 유지, clippy 무경고.
+4. p4/p5 잉크 정합(또는 render-tree y 정합) 개선.
+
+## 리스크
+
+- 16k줄 엔진의 saved-bounds fit 로직은 다수 샘플이 얽힘 → 각 단계마다 광범위 회귀 필수.
+- ①/② 상호작용: ① 높이 정합이 ②의 후속 문단 vpos 기준점을 바꿀 수 있음 → Stage 3에서 재계측.
+- 완전 정합이 어려우면 오버플로우 소거(①)까지 확정하고 ②는 후속 이슈로 분리 가능(보고서에 명시).

--- a/mydocs/report/task_m100_2015_report.md
+++ b/mydocs/report/task_m100_2015_report.md
@@ -1,0 +1,82 @@
+# 최종 결과보고서 — #2015 HWPX saved-bounds RowBreak 표 잔존 드리프트
+
+- 이슈: #2015 (#1811/#1887 후속, 마일스톤 v1.0.0)
+- 브랜치: `fix/2015-saved-bounds-rowbreak-overflow` (base `origin/devel`)
+- 대상 샘플: `samples/task1749/saved_bounds_cumulative_page_break.hwpx`
+- 정답지: `samples/task1749/saved_bounds_cumulative_page_break-2024.pdf` (한글 2024)
+
+## 1. 배경
+
+PR #1887(task 1811)가 RowBreak/saved-bounds 조판을 보정했으나 visual sweep p4/p5 잉크 정합이
+낮게 남았다(`ink_match` p4≈9.6% / p5≈5.1%). 재분석 결과 #1811 seam 의 **미해소 잔존분 2종**으로
+특정됐다.
+
+## 2. 원인 (2 발원지)
+
+### 발원지 ① 부동(tac=false) RowBreak 표 91.2px 오버플로우 — 포맷 공통, **수정 완료**
+
+- `pre_emit_visible_rowbreak_host_text`(#1811)가 host 텍스트를 pre-emit 하며 `current_height`
+  를 `para_start → para_start+host_h(≈146px)` 로 전진.
+- 이후 typeset 예산과 layout 배치가 각각 `vert_offset`(=144.3px, para_start 기준)을 **재차감/재적용**
+  → host_h 만큼 이중계상 → 표 앵커가 body 바닥(1026.5px) 아래로 밀려 91.2px 초과.
+- `RHWP_TABLE_DRIFT`: `page_avail = 930.5 − 806.0 − 144.3 = −19.8 → 0.0` (강제 1유닛 오버플로우).
+
+### 발원지 ② 인라인(tac=true) 표 valign 무력화 — HWPX 전용, **findings 인계**
+
+- HWPX 합성 셀 `total_content_height` 과대계산(362.8 vs HWP 293.3, 69.5px) → valign=Center 의
+  `mechanical_offset` 이 0 으로 클램프 → 별표가 셀 상단 37px 위.
+- 별표 줄 피치는 rhwp/PDF 동일(버그 아님). 오버플로우·페이지수·본문흐름 무관한 미관 수준.
+- 상세: `mydocs/working/task_m100_2015_stage4.md`.
+
+## 3. 수정 (발원지 ①)
+
+`pre_emitted_host_heights: HashMap<usize,f64>` 를 TypesetState → PaginationResult → LayoutEngine
+로 전파. host pre-emit 된 문단에 한해 `vert_offset` 을 `(vert_off − host_h).max(0)` 로 감액하여
+typeset 예산(`typeset.rs`)과 layout 배치(`table_partial.rs`)를 정합. host pre-emit 아니면 `host_h=0`
+→ 종전과 동일(비대상 문서 회귀 0).
+
+변경 파일: `typeset.rs`, `pagination.rs`, `pagination/engine.rs`, `layout.rs`,
+`layout/table_partial.rs`, `document_core/queries/rendering.rs`.
+
+## 4. 결과
+
+| 지표 | 수정 전 | 수정 후 |
+|---|---|---|
+| `LAYOUT_OVERFLOW` para=52 | 91.2px | **2.1px** (엔진 tolerance 수준) |
+| 표 top (render tree, p4) | y=1056.4 | **y=912.1** (host 텍스트 직후) |
+| HWPX end_cut | `[1]` | **`[3]`** (= HWP 저장 LINE_SEG 참조·한컴 PDF) |
+| 페이지 수 | 5 | 5 |
+| 시각 오라클 p5 ink_match | 11.62% | 13.12% |
+
+- 잔여 2.1px 는 마지막 유닛이 경계에 걸치는 행높이 측정 드리프트(엔진
+  `ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE=2.0px` 수준)로 컷 오류 아님. HWPX end_cut=[3] 이 HWP·PDF 와 일치.
+- p4 총 ink 는 발원지 ②(상단 인라인 표)가 지배해 집계 변화가 작다. 하단 pi=52 는 오버레이로
+  rhwp/PDF 정렬 확인.
+
+## 5. 검증
+
+- 전체 테스트: **2923 passed / 0 failed** (210 바이너리, release-test, --no-fail-fast).
+- `cargo clippy --all-targets -- -D warnings`: 통과(무경고).
+- `issue_1811_hwpx_pi52_rowbreak_cut_matches_hwp_reference`: HWPX 기대값 `[1]→[3]` 교정
+  (종전 `[1]` 은 이중계상 버그값. 주석에 #2015 근거 명시).
+- 신규 `tests/issue_2015_saved_bounds_rowbreak.rs`: Body 서브트리 content ≤ body 바닥 불변식(≤5px 게이트).
+- 형제 샘플 `saved_bounds_cumulative_vpos`(HWPX/HWP): 2쪽·overflow 0 유지.
+
+## 6. 부수 산출
+
+- `scripts/visual_oracle_native.py`: Windows/래스터라이저 부재 환경용 자립형 시각 오라클
+  (rhwp export-png(native-skia) + PyMuPDF + PIL/numpy). before/after 픽셀 검증 게이트.
+
+## 7. 잔여·후속
+
+- 발원지 ②(HWPX 인라인 표 합성 content-height 과대계산)는 수정 locus 가 전 HWPX 표 행높이·
+  오버플로우에 영향(광범위 회귀 표면)하고 이득이 미관 수준이라 **별도 스코프 타스크 권장**.
+  findings(`task_m100_2015_stage4.md`)로 인계.
+- 최종 한컴 편집기 시각 판정은 오라클 보유(Windows+한컴) 환경에서 확정 권장.
+
+## 8. 단계별 문서
+
+- Stage1: `working/task_m100_2015_stage1.md` (기준선 하네스 + 국소화)
+- Stage2: `working/task_m100_2015_stage2.md` (근본원인 확정), `..._stage2_oracle.md` (오라클 구축)
+- Stage3: `working/task_m100_2015_stage3.md` (발원지 ① 수정)
+- Stage4: `working/task_m100_2015_stage4.md` (발원지 ② findings)

--- a/mydocs/working/task_m100_2015_stage1.md
+++ b/mydocs/working/task_m100_2015_stage1.md
@@ -1,0 +1,52 @@
+# #2015 Stage 1 완료보고서 — 기준선 하네스 + 코드 국소화
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow` (base `origin/devel`)
+- 범위: 소스(렌더러) **무수정**. 회귀 테스트 하네스 추가 + 오차 발생 지점 코드 국소화.
+
+## 1. 재현 고정 (base=origin/devel)
+
+```
+LAYOUT_OVERFLOW: page=3, sec=0, col=0, para=52, type=PartialTable, first=false,
+                 y=1117.7, bottom=1026.5, overflow=91.2px
+dump-pages -p 3:  단 0 (items=7, used=806.0px)
+```
+
+- 부수 관찰: p2 `pi=26 overflow=1.6px`(sub-2px, 같은 계열 가능성). Stage 4에서 동반 여부 확인.
+
+## 2. 기준선 하네스
+
+`tests/issue_2015_saved_bounds_rowbreak.rs` 추가. `get_page_render_tree(3)`(public) JSON을 파싱해
+**Body 서브트리 content 노드(Table/Cell/TextLine/TextRun/Line/Shape/Picture)의 최대 바닥 ≤ Body 바닥**
+불변식을 검사. 매직넘버·텍스트매칭 없이 geometry 로만 판정.
+
+| 테스트 | 역할 | 현재 |
+|---|---|---|
+| `issue_2015_stage1_documents_current_overflow` | 기준선 계측(항상 통과) | body_bottom=1026.5, worst=1118.2(Table), **overflow=91.7px** |
+| `issue_2015_page4_rowbreak_table_stays_in_body` | 정답 불변식 | `#[ignore]`(red). Stage 2에서 ignore 제거 |
+
+- `#[ignore]`로 CI green 유지. `--include-ignored` 실행 시 정답 테스트가 91.7px 초과로 fail(기준선 red 확인).
+- Body/Column 컨테이너 노드는 clamp(바닥=1026.5)되므로 content 타입만 대상.
+
+## 3. 코드 국소화
+
+### 발원지 ① 부동 RowBreak 표 (pi=52) — 포맷 공통, Stage 2 대상
+
+- 표 속성(`dump -s0 -p52`): `treat_as_char=false`, `wrap=자리차지`, `vert=문단(10823=38.2mm)`,
+  `size=48214×8555`(저장 114px) vs 셀[5] 내용 `h=21111`(281px, 별표 문단 6개).
+- `ir-diff -s0 -p52` **차이 0건** → 파싱/포맷 아님, 순수 레이아웃 회계.
+- typeset(`src/renderer/typeset.rs`): 자리차지 float 표는 `apply_visible_float_exclusions`(≈1664)
+  기반 예약으로 처리되어 선형 `current_height`(=`used`, 806.0px)에 **저장바운드 기준**만 반영.
+- layout(`src/renderer/layout/table_layout.rs`): PartialTable 프래그먼트를 **내용 파생 높이**(row-cut)
+  로 그려 앵커+offset 위치에서 1117.7px까지 내려가 body 바닥 초과.
+- 결론: **typeset 예약 높이(저장바운드)와 layout 실측 row-cut 높이의 불일치**가 91.2px 오차.
+
+### 발원지 ② HWPX 인라인 표 (pi=50) — HWPX 전용, Stage 3 대상
+
+- `ir-diff -s0 -p50` **line_segs A=0(HWPX)/B=1(HWP)** → HWPX 표 컨테이너 lineSeg 미저장 → 합성 `lh=28769`.
+- 합성 셀 내부 별표 줄 피치: 문단 내 1818HU(24.24px)/문단 사이 +500HU(≈30.9px) 교대 → 한컴 균일 렌더와 불일치.
+- 대상: `src/renderer/composer.rs` / `table_layout.rs` HWPX 합성 lineSeg 높이·줄 피치.
+
+## 4. 다음 단계
+
+Stage 2: 발원지 ① — typeset 자리차지 float 예약 높이를 layout row-cut 실측과 정합하여
+`para=52` 오버플로우 소거. 완료 후 정답 테스트 `#[ignore]` 제거. 광범위 회귀(1749/1035/1139) 필수.

--- a/mydocs/working/task_m100_2015_stage2.md
+++ b/mydocs/working/task_m100_2015_stage2.md
@@ -1,0 +1,62 @@
+# #2015 Stage 2 findings — 부동 RowBreak 표 91.2px 오버플로우 근본원인 확정
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow`
+- 범위: 소스 **무수정**. 오차 산식을 진단 트레이스로 확정 + 수정 후보/검증 판단.
+
+## 1. 진단 수치 (RHWP_TABLE_DRIFT=1, pi=52)
+
+```
+첫 fragment: cursor_row=0 cont=false cur_h=806.0 table_avail=930.5
+             host_before=0.0 vert_off=144.3 page_avail=0.0 avail_for_rows=0.0
+연속:        cursor_row=2 cont=true  cur_h=0.0  page_avail=930.5 start_cut=[1]
+```
+
+`page_avail = table_avail − cur_h − vert_off = 930.5 − 806.0 − 144.3 = −19.8 → max(0)=0.0`
+
+RHWP_CUT_DBG: row=2 를 `avail=0.0` 로 컷 → "진행보장 1유닛 강제소비" → 앵커(cur_h+vert_off=950.3px,
+body 바닥 930.5 아래)에서 fragment 가 아래로 그려져 절대 1117.7px, body 바닥 1026.5px **초과 91.2px**.
+
+## 2. 근본원인 — vert_offset 이중계상 (host pre-emit 상호작용)
+
+`typeset.rs::pre_emit_visible_rowbreak_host_text`(#1811, ~12203):
+```
+let host_h = host_fmt.line_advances_sum(0..host_lines);  // ≈146px (4줄)
+st.current_items.push(PartialParagraph{...});
+st.current_height += host_h;                             // cur_h 를 para_start → para_start+host_h 로 전진
+```
+
+메인 분기(~13206 `vert_offset_overhead`, ~13264 `page_avail`):
+```
+page_avail = table_avail − st.current_height − vert_offset_overhead
+           = table_avail − (para_start+host_h) − vert_off
+```
+
+- `vert_off`(144.3px)는 **para_start 기준** 표 오프셋.
+- host 텍스트 pre-emit 가 이미 cur_h 를 para_start → para_start+host_h(≈146px)로 전진.
+- 표의 참 위치 = para_start + vert_off. 현재 cur_h(=para_start+host_h) 기준 오프셋 = **vert_off − host_h ≈ 144.3 − 146 ≈ 0**.
+- 그런데 산식은 full `vert_off` 를 다시 빼서 host_h 만큼 **이중차감** → page_avail 이 0 으로 붕괴, 앵커가 host_h 만큼 아래로 밀림.
+- host_h ≈ vert_off (둘 다 para_start~표 사이 동일 구간)라 오차가 정확히 이 크기.
+
+즉 **host 를 pre-emit 한 뒤에는 vert_offset_overhead 를 `max(0, vert_off − host_h)` 로 줄여야** 한다.
+`ir-diff` 차이 0(포맷 공통)과도 정합 — 파싱이 아니라 typeset↔layout 배치 산식 문제.
+
+## 3. 수정 후보
+
+1. (typeset 예산) `vert_offset_overhead` 를 host pre-emit 시 `host_h` 만큼 감액
+   (`st.pre_emitted_host_paras.contains(&para_idx)` 가드).
+2. (layout 배치) 표 y 를 `cur_h + host_before + vert_off` 대신 pre-emit 케이스에서 동일 감액 —
+   typeset 컷과 layout 배치가 **정의상 일치**해야 하므로 두 경로 동시 정합 필수(안 하면 fit 은 통과하나 그림은 여전히 초과).
+
+## 4. 검증 한계 (판단 필요)
+
+- 이 수정은 #1811 pre-emit + saved-bounds 코퍼스와 얽혀, 표 y 와 컷 경계가 함께 이동한다.
+- 본 환경엔 시각 오라클 래스터 도구(`rsvg-convert`/`pdftoppm`) 부재 → visual sweep 픽셀 검증 불가.
+- 프로젝트 방법론상 **시각 판정이 최종 게이트**이고 saved-bounds 다수 샘플 회귀가 필수.
+- 따라서 엔진 편집은 (A) `cargo test` 전량 + 신규 #2015 불변식 + 전 샘플 `LAYOUT_OVERFLOW` 스캔으로
+  1차 검증 후, 시각 판정은 오라클 보유 환경(메인테이너)에서 확정하는 절차를 권장.
+
+## 5. 다음 단계 (Stage 3 예정)
+
+`vert_offset_overhead` 감액 + layout 배치 정합 구현 → #2015 불변식 통과(`#[ignore]` 해제) →
+`cargo test --profile release-test --tests` 전량 + 전 샘플 overflow 스캔 회귀 → 시각 판정.
+발원지 ②(HWPX 인라인 표 합성 줄 피치)는 ① 안정화 후 별도 단계.

--- a/mydocs/working/task_m100_2015_stage2_oracle.md
+++ b/mydocs/working/task_m100_2015_stage2_oracle.md
@@ -1,0 +1,47 @@
+# #2015 시각 오라클 구축 (Windows/래스터라이저 부재 환경)
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow`
+- 목적: 이 환경에 `rsvg-convert`/`pdftoppm` 부재 → visual sweep 불가 문제 해소.
+  Stage 3 엔진 수정의 **픽셀 검증(before/after)** 을 가능케 한다.
+
+## 구성 (자립형, 시스템 바이너리 불필요)
+
+`scripts/visual_oracle_native.py`
+
+| 축 | 수단 | 비고 |
+|---|---|---|
+| rhwp 래스터 | `rhwp export-png`(native-skia) | 네이티브 렌더(프로덕션 경로). `--features native-skia` 빌드 필요 |
+| PDF 래스터 | PyMuPDF(fitz) | poppler 불필요, 이미 설치됨 |
+| 비교/오버레이 | PIL + numpy | task1274_visual_sweep.py 시맨틱 정합 |
+
+- 96 DPI 기준: A4 → 794×1122~1123px (rhwp/PDF 정합, ±1px 패딩).
+- 산출: `rhwp_png/ pdf_png/ overlay/ review/ metrics.json`.
+- overlay 색: 빨강=rhwp-only 잉크, 파랑=PDF-only, 주황=양쪽 위치차, 회색=일치.
+- proxy = 잉크영역 존재 시 `ink_match`, 없으면 `pixel_match`.
+
+## 실행
+
+```bash
+python scripts/visual_oracle_native.py \
+  --hwp samples/task1749/saved_bounds_cumulative_page_break.hwpx \
+  --pdf samples/task1749/saved_bounds_cumulative_page_break-2024.pdf \
+  --pages 4,5 --dpi 96 --out output/poc/i2015/oracle_baseline
+```
+
+## 기준선 (base=origin/devel, 수정 전)
+
+| page | pixel_match | ink_match | proxy | ink_union | diff |
+|---|---|---|---|---|---|
+| p4 | 90.69% | **13.87%** | 13.87% | 96343px | 82985px |
+| p5 | 90.38% | **11.62%** | 11.62% | 97020px | 85746px |
+
+- PR #1887 보고값(9.64%/5.10%)과 계열 동일. 절대값 차이는 렌더 경로 차이
+  (native-skia PNG vs rsvg SVG→PNG, PyMuPDF vs pdftoppm, ink cutoff)이며,
+  **before/after 내부 비교용 지표로 일관**되면 충분하다.
+- overlay(`review_004.png`) 시각 확인: 상단 정합→하단 발산의 누적 세로 드리프트가
+  PR 커밋 review 이미지와 동일하게 재현됨(부동 표 앵커 이중계상 결과).
+
+## 용도
+
+Stage 3 에서 `vert_offset` 이중계상 수정 후 동일 명령 재실행 → `ink_match` 상승·overlay
+드리프트 감소를 픽셀로 확인. 최종 한컴 편집기 시각 판정의 대체가 아니라 1차 자동 게이트.

--- a/mydocs/working/task_m100_2015_stage3.md
+++ b/mydocs/working/task_m100_2015_stage3.md
@@ -1,0 +1,57 @@
+# #2015 Stage 3 완료보고서 — 부동 RowBreak 표 vert_offset 이중계상 수정
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow`
+- 범위: 발원지 ①(부동 tac=false RowBreak 표 91.2px 오버플로우) 수정. 발원지 ②(HWPX 인라인 표
+  합성 줄 피치)는 후속.
+
+## 수정 내용
+
+pre-emit 된 host 텍스트가 `current_height` 를 `para_start → para_start+host_h` 로 전진시킨 뒤,
+typeset 예산과 layout 배치가 각각 `vert_offset`(para_start 기준)을 **재차감/재적용**해 host_h 만큼
+이중계상되던 것을 보정. 표의 참 오프셋은 current_height 기준 `vert_off − host_h`.
+
+### 데이터 흐름 (host_h 전파)
+- `TypesetState.pre_emitted_host_heights: HashMap<usize,f64>` 추가, `pre_emit_visible_rowbreak_host_text`
+  에서 host_h 기록.
+- `PaginationResult.pre_emitted_host_heights` 로 전달 → `LayoutEngine.set_pre_emitted_host_heights`.
+
+### 보정 지점 (typeset ↔ layout 정합)
+- `typeset.rs` `vert_offset_overhead`: `(vert_off − host_h).max(0)` — page_avail 정정.
+- `table_partial.rs` `layout_partial_table` 첫 fragment: `(vert_off − host_h).max(0)` — 표 y 정정.
+- host pre-emit 아니면 `host_h=0` → `(vert_off−0)` 종전과 동일 → **비대상 문서 회귀 0**.
+
+### 파일
+`typeset.rs`, `pagination.rs`, `pagination/engine.rs`, `layout.rs`,
+`layout/table_partial.rs`, `document_core/queries/rendering.rs`.
+
+## 결과 (base=origin/devel 대비)
+
+| 지표 | 수정 전 | 수정 후 |
+|---|---|---|
+| `LAYOUT_OVERFLOW` para=52 | **91.2px** | **2.1px** (엔진 tolerance 수준) |
+| 표 top (render tree, p4) | y=1056.4 (host 끝+vert_off) | **y=912.1** (host 끝 직후) |
+| HWPX end_cut | `[1]` | **`[3]`** (= HWP 참조·PDF) |
+| 페이지 수 | 5 | 5 (유지) |
+| 시각 오라클 p5 ink_match | 11.62% | **13.12%** |
+| 시각 오라클 p4 ink_match | 13.87% | 13.83%* |
+
+*p4 총 ink 는 상단 인라인 표 pi=50(발원지 ②, 미수정)의 드리프트가 지배 → 하단 pi=52 개선이
+집계에 덜 반영. overlay(`oracle_fixed/review_004.png`)에서 하단 "< 사회기여 봉사활동 아이디어 >"
+박스가 rhwp/PDF 정렬됨을 시각 확인(수정 전 완전 분리·오버플로우).
+
+## 잔여 2.1px 판단
+HWPX end_cut=[3] 이 HWP 저장 LINE_SEG 참조([3]) 및 한컴 PDF 와 동일한 컷. 잔여 2.1px 는 마지막
+유닛이 경계에 걸치는 행높이 측정 드리프트(엔진 `ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE=2.0px`
+수준)로, 컷 오류가 아니다.
+
+## 회귀 검증
+- 전체 테스트: **2923 passed / 0 failed** (210 바이너리, release-test, --no-fail-fast).
+- `issue_1749_saved_bounds_page_break`: `issue_1811_hwpx_pi52_rowbreak_cut_matches_hwp_reference`
+  의 HWPX 기대값을 `[1]→[3]` 으로 교정(종전 `[1]` 은 이중계상 버그값. 주석에 #2015 근거 명시).
+- `issue_1035_alignment`, `issue_1139_inline_picture_duplicate` 등 유지.
+- 형제 샘플 `saved_bounds_cumulative_vpos`(HWPX/HWP): 2쪽·overflow 0 유지.
+- 신규 `issue_2015_page4_rowbreak_table_stays_in_body`: 통과(≤5px 게이트, 91px 회귀 방지).
+- `cargo clippy --all-targets -- -D warnings`: 통과(무경고).
+
+## 다음
+Stage 4: 발원지 ②(HWPX 인라인 표 pi=50 합성 lineSeg 줄 피치) — p4 상단 드리프트. 별도 조사 후 진행.

--- a/mydocs/working/task_m100_2015_stage4.md
+++ b/mydocs/working/task_m100_2015_stage4.md
@@ -1,0 +1,64 @@
+# #2015 Stage 4 findings — HWPX 인라인 표 pi=50 별표 셀 valign 무력화 (발원지 ②)
+
+- 이슈: #2015 / 브랜치: `fix/2015-saved-bounds-rowbreak-overflow`
+- 범위: 소스 무수정. 발원지 ②(p4 상단 인라인 표 pi=50 세로 드리프트) 근본원인 확정 + 수정 판단.
+
+## 1. 재특성화 — 피치가 아니라 셀 내용 세로정렬
+
+시각 오라클(PDF=PyMuPDF) 좌표 대조:
+
+- 별표 줄 **피치는 rhwp/PDF 동일**(24.3/30.9px 교대) → 피치 버그 아님.
+- 별표 **블록 크기 동일**(span ≈ 269px).
+- 차이는 **박스 내부 "제목→별표 시작" 간격**:
+  - rhwp(HWPX): 제목 359.3 → 별표 382.6 (간격 23.3px)
+  - rhwp(HWP): 제목 359.9 → 별표 413.6 (간격 53.7px)
+  - 한컴 PDF: 제목 360 → 별표 420.5 (간격 60px)
+- 박스 위 본문·제목·표 bbox(355.2, h=383.6)는 HWPX/HWP **동일**하고 ~1px 정합.
+
+즉 **같은 박스 안에서 별표(row 2 셀[5]) 내용이 HWPX 에서만 37px 위로 붙는다.**
+
+## 2. 근본원인 — HWPX 합성 셀 내용높이 과대계산 → valign=Center 무력화
+
+`table_layout.rs` 셀 세로정렬(2688~):
+```
+VerticalAlign::Center => mechanical_offset = (inner_height − total_content_height).max(0)/2
+```
+
+`RHWP_VALIGN_DBG` 계측 (pi=50 별표 셀[5], valign=Center):
+
+| | inner_height | total_content_height | mech_off |
+|---|---|---|---|
+| HWPX | 354.3 | **362.8** | **0.0** (내용>셀 → 클램프) |
+| HWP  | 353.2 | **293.3** | **29.9** (센터링) |
+
+- 셀 inner_height 는 동일(≈354). **total_content_height 만 HWPX 가 69.5px 과대**(362.8 vs 293.3).
+- 렌더 별표 span 은 둘 다 269px 인데 **계산 content-height 만 다르다** → HWPX 합성
+  lineSeg/문단 높이 과대계산.
+- 과대계산분이 셀 높이를 초과 → `mech_off` 가 0 으로 클램프 → 별표가 셀 상단에 붙어 37px 위.
+- IR(`dump`)은 HWPX/HWP 동일(컨테이너 lh=28769, 셀 999/1998/26771). 유일 차이는 lineSeg
+  tag synthetic 비트(0x80000000)와 ls(720 vs 1200). → **렌더 경로의 HWPX 합성 content-height 문제.**
+
+## 3. 영향·심각도
+
+- **오버플로우/페이지수/본문 흐름 영향 없음**: 박스 아래 본문은 재정렬되어 정합(“(사회기여)”
+  rhwp 765.7 vs PDF 768, 2.3px). 순수 **박스 내부 별표 위치 37px** 국소 시각 오차.
+- 발원지 ①(오버플로우, 실제 조판 결함)과 성격이 다르다 — ②는 미관 수준.
+
+## 4. 수정 판단 — 후속 스코프 권장
+
+- 수정 locus: HWPX 합성 lineSeg/문단 content-height 계산(composer 계열). 이 값은 **센터링뿐
+  아니라 행높이·오버플로우 검출에도 쓰여** 모든 HWPX 표 다중줄 셀에 영향 → **광범위 회귀 표면**.
+- 이득은 미관(별표 박스 센터링), 위험은 전 HWPX 표 조판. 리스크-이득 비대칭.
+- 프로젝트 방법론상 레이아웃 변경은 시각 판정 최종 게이트 + 다수 HWPX 샘플 회귀 필수.
+- 따라서 **발원지 ②는 별도 스코프 타스크로 분리** 권장: HWPX 합성 content-height 를 HWP 저장
+  경로와 정합(362.8→~293)시키되, HWPX 코퍼스 전수 시각/구조 회귀로 검증.
+- 본 이슈 #2015 는 발원지 ①(오버플로우) 확정 수정으로 마무리하고, ②는 findings 로 인계.
+
+## 5. 재현
+
+```bash
+# 별표 셀 valign 클램프 계측(디버그 필요 시 table_layout.rs Center 분기에 일시 print)
+# 좌표 대조:
+python scripts/visual_oracle_native.py --hwp <hwpx> --pdf <pdf> --pages 4 --out output/poc/oracle
+# rhwp render tree(HWPX vs HWP) 별표 첫 줄 y: 382.6 vs 413.6 (한컴 420.5)
+```

--- a/scripts/visual_oracle_native.py
+++ b/scripts/visual_oracle_native.py
@@ -1,0 +1,229 @@
+#!/usr/bin/env python3
+"""자립형 visual oracle — 시스템 래스터라이저(rsvg-convert/pdftoppm) 없이 동작.
+
+rhwp 쪽:  `rhwp export-png`(native-skia) 네이티브 래스터
+PDF 쪽:   PyMuPDF(fitz) 로 직접 래스터 (poppler 불필요)
+비교:     PIL + numpy 로 pixel/ink match + overlay (task1274_visual_sweep.py 시맨틱 정합)
+
+Windows/Git-Bash 환경(패키지 매니저 없음)에서 시각 판정을 가능케 한다.
+scripts/task1274_visual_sweep.py 의 대체가 아니라, 오라클 도구 부재 환경용 경량 경로.
+
+사용:
+  python scripts/visual_oracle_native.py \
+      --hwp samples/task1749/saved_bounds_cumulative_page_break.hwpx \
+      --pdf samples/task1749/saved_bounds_cumulative_page_break-2024.pdf \
+      --pages 4,5 --dpi 96 --out output/poc/oracle
+
+출력(--out):
+  rhwp_png/page_00N.png, pdf_png/page_00N.png, overlay/overlay_00N.png,
+  review/review_00N.png, metrics.json
+페이지 번호는 사용자가 PDF 뷰어에서 보는 1-based.
+"""
+import argparse
+import json
+import os
+import subprocess
+import sys
+
+import fitz  # PyMuPDF
+import numpy as np
+from PIL import Image, ImageDraw, ImageFont
+
+PIXEL_DIFF_THRESHOLD = 32  # task1274 기본과 동일
+INK_WHITE_CUTOFF = 245     # 이 값 이상(모든 채널)이면 배경(잉크 아님)
+
+
+def rhwp_bin():
+    for p in ("target/release/rhwp.exe", "target/release/rhwp",
+              "target/debug/rhwp.exe", "target/debug/rhwp"):
+        if os.path.exists(p):
+            return os.path.abspath(p)
+    sys.exit("rhwp 바이너리를 찾을 수 없습니다 (cargo build --release --features native-skia)")
+
+
+def parse_pages(spec):
+    out = []
+    for part in spec.split(","):
+        part = part.strip()
+        if not part:
+            continue
+        if "-" in part:
+            a, b = part.split("-")
+            out.extend(range(int(a), int(b) + 1))
+        else:
+            out.append(int(part))
+    return sorted(set(out))
+
+
+def export_rhwp_png(binary, hwp, page0, dpi, out_path, font_paths):
+    """rhwp export-png 으로 단일 페이지 PNG 생성. page0 은 0-based."""
+    tmp_dir = os.path.join(os.path.dirname(out_path), "_rhwp_tmp")
+    os.makedirs(tmp_dir, exist_ok=True)
+    cmd = [binary, "export-png", hwp, "-p", str(page0), "-o", tmp_dir, "--dpi", str(dpi)]
+    for fp in font_paths or []:
+        cmd += ["--font-path", fp]
+    res = subprocess.run(cmd, capture_output=True, text=True,
+                         encoding="utf-8", errors="replace")
+    if res.returncode != 0:
+        sys.exit(f"export-png 실패(p{page0}):\n{res.stderr}")
+    # rhwp 는 page_00N.png 또는 <stem>_00N.png 형태로 낼 수 있음 — 가장 최근 png 채택
+    cand = [os.path.join(tmp_dir, f) for f in os.listdir(tmp_dir) if f.lower().endswith(".png")]
+    if not cand:
+        sys.exit(f"export-png 산출 PNG 없음(p{page0}) in {tmp_dir}\n{res.stdout}")
+    # 파일명에 (page0+1) 또는 page0 이 들어간 것을 우선
+    want = [c for c in cand if f"{page0 + 1:03d}" in os.path.basename(c)
+            or f"{page0 + 1}" in os.path.basename(c)]
+    src = (want or cand)[0]
+    Image.open(src).convert("RGB").save(out_path)
+    for c in cand:
+        try:
+            os.remove(c)
+        except OSError:
+            pass
+    return out_path
+
+
+def render_pdf_png(pdf_doc, page_idx0, dpi, out_path):
+    """PyMuPDF 로 PDF 페이지(0-based) 를 dpi 로 래스터."""
+    page = pdf_doc[page_idx0]
+    zoom = dpi / 72.0
+    pix = page.get_pixmap(matrix=fitz.Matrix(zoom, zoom), alpha=False)
+    img = Image.frombytes("RGB", (pix.width, pix.height), pix.samples)
+    img.save(out_path)
+    return out_path
+
+
+def to_common_canvas(img_a, img_b):
+    """두 이미지를 좌상단 정렬로 공통 캔버스(흰 배경)에 패딩."""
+    w = max(img_a.width, img_b.width)
+    h = max(img_a.height, img_b.height)
+    ca = Image.new("RGB", (w, h), (255, 255, 255))
+    cb = Image.new("RGB", (w, h), (255, 255, 255))
+    ca.paste(img_a, (0, 0))
+    cb.paste(img_b, (0, 0))
+    return ca, cb
+
+
+def compute_metrics(rhwp_img, pdf_img):
+    a = np.asarray(rhwp_img, dtype=np.int16)   # rhwp
+    b = np.asarray(pdf_img, dtype=np.int16)    # pdf
+    diff = np.abs(a - b).max(axis=2)           # per-pixel 최대 채널차
+    total = diff.size
+    diff_mask = diff > PIXEL_DIFF_THRESHOLD
+    pixel_match = 100.0 * (1.0 - diff_mask.sum() / total)
+
+    a_ink = (a.max(axis=2) < INK_WHITE_CUTOFF)  # rhwp 잉크
+    b_ink = (b.max(axis=2) < INK_WHITE_CUTOFF)  # pdf 잉크
+    ink_union = a_ink | b_ink
+    ink_union_n = int(ink_union.sum())
+    ink_diff = np.logical_and(ink_union, diff_mask)
+    if ink_union_n > 0:
+        ink_match = 100.0 * (1.0 - ink_diff.sum() / ink_union_n)
+        proxy = ink_match
+    else:
+        ink_match = 100.0
+        proxy = pixel_match
+
+    return {
+        "pixel_match_percent": round(float(pixel_match), 4),
+        "ink_match_percent": round(float(ink_match), 4),
+        "visual_accuracy_proxy_percent": round(float(proxy), 4),
+        "ink_union_pixels": ink_union_n,
+        "diff_pixels": int(diff_mask.sum()),
+    }, (a_ink, b_ink, diff_mask)
+
+
+def build_overlay(rhwp_img, pdf_img, masks):
+    a_ink, b_ink, diff_mask = masks
+    h, w = diff_mask.shape
+    out = np.full((h, w, 3), 235, dtype=np.uint8)  # 옅은 회색 배경
+    both_ink = a_ink & b_ink
+    only_a = a_ink & ~b_ink            # rhwp 만: 빨강
+    only_b = b_ink & ~a_ink            # pdf 만: 파랑
+    both_diff = both_ink & diff_mask   # 양쪽 잉크 위치차: 주황
+    both_same = both_ink & ~diff_mask  # 일치: 진회색
+    out[only_a] = (220, 40, 40)
+    out[only_b] = (40, 80, 220)
+    out[both_diff] = (240, 150, 30)
+    out[both_same] = (90, 90, 90)
+    return Image.fromarray(out, "RGB")
+
+
+def build_review(rhwp_img, pdf_img, overlay_img, caption):
+    pad = 12
+    w = rhwp_img.width + pdf_img.width + overlay_img.width + pad * 4
+    h = max(rhwp_img.height, pdf_img.height, overlay_img.height) + 60
+    canvas = Image.new("RGB", (w, h), (255, 255, 255))
+    x = pad
+    for img, label in ((rhwp_img, "rhwp"), (pdf_img, "pdf(oracle)"), (overlay_img, "overlay")):
+        canvas.paste(img, (x, 30))
+        d = ImageDraw.Draw(canvas)
+        d.text((x, 8), label, fill=(0, 0, 0))
+        x += img.width + pad
+    d = ImageDraw.Draw(canvas)
+    d.text((pad, h - 24), caption, fill=(0, 0, 0))
+    return canvas
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--hwp", required=True)
+    ap.add_argument("--pdf", required=True)
+    ap.add_argument("--pages", required=True, help="1-based, 예: 4,5 또는 3-6")
+    ap.add_argument("--dpi", type=float, default=96.0)
+    ap.add_argument("--out", default="output/poc/oracle")
+    ap.add_argument("--font-path", action="append", default=[])
+    args = ap.parse_args()
+
+    binary = rhwp_bin()
+    pages = parse_pages(args.pages)
+    for sub in ("rhwp_png", "pdf_png", "overlay", "review"):
+        os.makedirs(os.path.join(args.out, sub), exist_ok=True)
+
+    pdf_doc = fitz.open(args.pdf)
+    n_pdf = pdf_doc.page_count
+    results = []
+    for p in pages:  # 1-based
+        if p < 1 or p > n_pdf:
+            print(f"[skip] page {p} (PDF pages=1..{n_pdf})")
+            continue
+        page0 = p - 1
+        rhwp_png = os.path.join(args.out, "rhwp_png", f"page_{p:03d}.png")
+        pdf_png = os.path.join(args.out, "pdf_png", f"page_{p:03d}.png")
+        export_rhwp_png(binary, args.hwp, page0, args.dpi, rhwp_png, args.font_path)
+        render_pdf_png(pdf_doc, page0, args.dpi, pdf_png)
+
+        ra = Image.open(rhwp_png).convert("RGB")
+        pb = Image.open(pdf_png).convert("RGB")
+        ca, cb = to_common_canvas(ra, pb)
+        metrics, masks = compute_metrics(ca, cb)
+        overlay = build_overlay(ca, cb, masks)
+        overlay_png = os.path.join(args.out, "overlay", f"overlay_{p:03d}.png")
+        overlay.save(overlay_png)
+
+        cap = (f"page {p}  pixel_match={metrics['pixel_match_percent']:.2f}%  "
+               f"ink_match={metrics['ink_match_percent']:.2f}%  "
+               f"proxy={metrics['visual_accuracy_proxy_percent']:.2f}%")
+        review = build_review(ca, cb, overlay, cap)
+        review_png = os.path.join(args.out, "review", f"review_{p:03d}.png")
+        review.save(review_png)
+
+        row = {"page": p, "rhwp_png": rhwp_png, "pdf_png": pdf_png,
+               "overlay_png": overlay_png, "review_png": review_png, **metrics}
+        results.append(row)
+        print(f"[page {p}] {cap}")
+
+    # 임시 폴더 정리
+    tmp = os.path.join(args.out, "rhwp_png", "_rhwp_tmp")
+    if os.path.isdir(tmp):
+        try:
+            os.rmdir(tmp)
+        except OSError:
+            pass
+    with open(os.path.join(args.out, "metrics.json"), "w", encoding="utf-8") as f:
+        json.dump(results, f, ensure_ascii=False, indent=2)
+    print(f"metrics: {os.path.join(args.out, 'metrics.json')}")
+
+
+if __name__ == "__main__":
+    main()

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2289,6 +2289,7 @@ impl DocumentCore {
                 wrap_around_paras: Vec::new(),
                 hidden_empty_paras: std::collections::HashSet::new(),
                 pre_emitted_host_paras: std::collections::HashSet::new(),
+                pre_emitted_host_heights: std::collections::HashMap::new(),
                 endnotes: Vec::new(),
                 endnote_paragraphs: Vec::new(),
                 endnote_para_sources: Vec::new(),
@@ -3680,6 +3681,9 @@ impl DocumentCore {
             // [Task #1755] pre-emit 된 host 문단 → fragment 쪽 host 렌더 억제.
             self.layout_engine
                 .set_pre_emitted_host_paras(&pr.pre_emitted_host_paras);
+            // [#2015] pre-emit host 높이 → layout vert_offset 이중계상 보정.
+            self.layout_engine
+                .set_pre_emitted_host_heights(&pr.pre_emitted_host_heights);
             self.layout_engine
                 .set_endnote_para_sources(paragraphs.len(), &pr.endnote_para_sources);
             // 섹션 미주 모양의 정규화 여백 전달 → HeightCursor min-gap 및 renderer overflow 판정.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -939,6 +939,8 @@ pub struct LayoutEngine {
     /// [Task #1755] 지연 이월 표의 host 텍스트 줄이 typeset 에서 이월 전 쪽에
     /// PartialParagraph 로 pre-emit 된 문단 집합 — 마지막 fragment 뒤 host 렌더 억제.
     pre_emitted_host_paras: std::cell::RefCell<std::collections::HashSet<usize>>,
+    /// [#2015] pre-emit 한 host 텍스트 높이(px) — vert_offset 이중계상 보정용.
+    pre_emitted_host_heights: std::cell::RefCell<std::collections::HashMap<usize, f64>>,
     /// 렌더용 가상 미주 문단 시작 인덱스
     endnote_para_base: std::cell::Cell<usize>,
     /// 가상 미주 문단별 원본 위치
@@ -1037,6 +1039,7 @@ impl LayoutEngine {
             last_item_endnote_equation_tail_line_box: std::cell::Cell::new(false),
             hidden_empty_paras: std::cell::RefCell::new(std::collections::HashSet::new()),
             pre_emitted_host_paras: std::cell::RefCell::new(std::collections::HashSet::new()),
+            pre_emitted_host_heights: std::cell::RefCell::new(std::collections::HashMap::new()),
             endnote_para_base: std::cell::Cell::new(usize::MAX),
             endnote_para_sources: std::cell::RefCell::new(Vec::new()),
             endnote_between_notes_hu: std::cell::Cell::new(0),
@@ -1241,6 +1244,11 @@ impl LayoutEngine {
     /// [Task #1755] 이월 전 쪽에 host 텍스트가 pre-emit 된 문단 집합 설정
     pub fn set_pre_emitted_host_paras(&self, paras: &std::collections::HashSet<usize>) {
         *self.pre_emitted_host_paras.borrow_mut() = paras.clone();
+    }
+
+    /// [#2015] pre-emit 된 host 텍스트 높이 맵 설정 (vert_offset 이중계상 보정용)
+    pub fn set_pre_emitted_host_heights(&self, heights: &std::collections::HashMap<usize, f64>) {
+        *self.pre_emitted_host_heights.borrow_mut() = heights.clone();
     }
 
     /// 렌더용 가상 미주 문단과 원본 Endnote 내부 문단의 매핑을 설정한다.

--- a/src/renderer/layout/table_partial.rs
+++ b/src/renderer/layout/table_partial.rs
@@ -139,7 +139,20 @@ impl LayoutEngine {
             )
             && vert_off_signed > 0
         {
-            y_start + hwpunit_to_px(vert_off_signed, self.dpi)
+            // [#2015] host 텍스트가 pre-emit 된 경우, 진입 y_start 는 이미
+            // para_start+host_h(host 텍스트 끝) 흐름 위치다. vert_offset 은 para_start 기준
+            // 오프셋이므로 그대로 더하면 host_h 만큼 이중계상되어 표가 아래로 밀린다
+            // (부동 RowBreak 표 91.2px 오버플로우). 표의 참 상단 = para_start+vert_off =
+            // y_start+(vert_off−host_h). typeset 예산도 동일 감액을 적용한다.
+            // host pre-emit 이 아니면 host_h=0 → 종전과 동일(회귀 없음).
+            let host_h = self
+                .pre_emitted_host_heights
+                .borrow()
+                .get(&para_index)
+                .copied()
+                .unwrap_or(0.0);
+            let eff_off = (hwpunit_to_px(vert_off_signed, self.dpi) - host_h).max(0.0);
+            y_start + eff_off
         } else {
             y_start
         };

--- a/src/renderer/pagination.rs
+++ b/src/renderer/pagination.rs
@@ -109,6 +109,8 @@ pub struct PaginationResult {
     /// PartialParagraph 로 pre-emit 된 문단 집합 — layout 의 마지막 fragment 뒤
     /// host 렌더(`render_deferred_rowbreak_host_text_after`) 이중 렌더 억제용.
     pub pre_emitted_host_paras: std::collections::HashSet<usize>,
+    /// [#2015] pre-emit 한 host 텍스트 높이(px). layout 이 vert_offset 이중계상을 보정할 때 사용.
+    pub pre_emitted_host_heights: std::collections::HashMap<usize, f64>,
     /// 섹션별 미주 목록 (문서 끝 또는 섹션 끝에 렌더)
     pub endnotes: Vec<EndnoteRef>,
     /// [Task #836] 미주 paragraphs (endnote_para_base + idx 로 lookup)

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -1024,6 +1024,7 @@ impl Paginator {
             wrap_around_paras: all_wrap_around_paras,
             hidden_empty_paras,
             pre_emitted_host_paras: std::collections::HashSet::new(),
+            pre_emitted_host_heights: std::collections::HashMap::new(),
             endnotes: Vec::new(),
             endnote_paragraphs: Vec::new(),
             endnote_para_sources: Vec::new(),

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -331,6 +331,10 @@ struct TypesetState {
     /// [Task #1755] 이월 전 쪽에 host 텍스트 줄을 PartialParagraph 로 pre-emit 한 문단 —
     /// layout 의 마지막 fragment 뒤 host 렌더 억제 신호(PaginationResult 로 전달).
     pre_emitted_host_paras: std::collections::HashSet<usize>,
+    /// [#2015] pre-emit 한 host 텍스트의 실제 높이(px). vert_offset(para_start 기준)를
+    /// current_height(=para_start+host_h) 기준으로 환산할 때 감액분으로 쓴다. typeset 예산과
+    /// layout(table_partial.rs) 배치가 동일 감액을 적용해 정합한다.
+    pre_emitted_host_heights: std::collections::HashMap<usize, f64>,
     /// [Task #359] 다음 pi 가 vpos-reset 가드를 발동할 예정 → 현재 pi 의 fit 안전마진 비활성화.
     /// 단독 항목 페이지 발생 차단용.
     skip_safety_margin_once: bool,
@@ -1419,6 +1423,7 @@ impl TypesetState {
             deferred_table_controls: Vec::new(),
             prefilled_paras: std::collections::HashSet::new(),
             pre_emitted_host_paras: std::collections::HashSet::new(),
+            pre_emitted_host_heights: std::collections::HashMap::new(),
             skip_safety_margin_once: false,
             skip_footnote_margin_once: false,
             tail_overflow_tolerance_once: 0.0,
@@ -3806,6 +3811,7 @@ impl TypesetEngine {
             wrap_around_paras: Vec::new(),
             hidden_empty_paras: st.hidden_empty_paras,
             pre_emitted_host_paras: st.pre_emitted_host_paras,
+            pre_emitted_host_heights: st.pre_emitted_host_heights,
             endnotes: st.endnotes,
             endnote_paragraphs: st.endnote_paragraphs,
             endnote_para_sources: st.endnote_para_sources,
@@ -12244,6 +12250,8 @@ impl TypesetEngine {
         });
         st.current_height += host_h;
         st.pre_emitted_host_paras.insert(para_idx);
+        // [#2015] vert_offset 이중계상 보정용 host 높이 기록.
+        st.pre_emitted_host_heights.insert(para_idx, host_h);
         true
     }
 
@@ -13213,7 +13221,19 @@ impl TypesetEngine {
                 // HwpUnit=u32 이므로 음수 (u32 wrap) 는 i32 로 캐스트 후 확인.
                 let v_off_i32 = table.common.vertical_offset as i32;
                 if is_para_topbottom && v_off_i32 > 0 {
-                    hwpunit_to_px(v_off_i32, self.dpi)
+                    let raw = hwpunit_to_px(v_off_i32, self.dpi);
+                    // [#2015] host 텍스트가 pre-emit(pre_emit_visible_rowbreak_host_text)
+                    // 되어 current_height 를 para_start → para_start+host_h 로 전진시킨 경우,
+                    // vert_off(para_start 기준 표 오프셋)를 그대로 빼면 host_h 만큼 이중계상되어
+                    // 앵커가 body 바닥 아래로 밀린다(91.2px 오버플로우). 표의 참 오프셋은
+                    // current_height 기준 (vert_off − host_h) 이므로 pre-emit host_h 만큼 감액.
+                    // layout(table_partial.rs) 도 동일 감액을 적용해 typeset 컷과 정합한다.
+                    let host_h = st
+                        .pre_emitted_host_heights
+                        .get(&para_idx)
+                        .copied()
+                        .unwrap_or(0.0);
+                    (raw - host_h).max(0.0)
                 } else {
                     0.0
                 }

--- a/tests/issue_1749_saved_bounds_page_break.rs
+++ b/tests/issue_1749_saved_bounds_page_break.rs
@@ -72,9 +72,14 @@ fn issue_1811_hwpx_pi52_rowbreak_cut_matches_hwp_reference() {
     );
     let pi52_line = page4_lines[table_idx];
 
+    // [#2015] 종전 이 테스트는 HWPX end_cut=[1] 을 기대했으나, 그것은 vert_offset 이중계상
+    // (pre-emit 된 host_h 위에 vert_off 를 재차감 → page_avail=0)으로 남는 공간이 0 이라
+    // 오판된 값이었다. 이중계상을 보정하면 실제 잔여 공간(≈124px)에 3 유닛이 들어가
+    // HWPX end_cut=[3] 이 HWP 저장 LINE_SEG 참조([3] 아래) 및 한컴 PDF 와 일치한다.
     assert!(
-        pi52_line.contains("end_cut=[1]"),
-        "HWPX mixed host 텍스트를 p4 에 먼저 배치하면 첫 fragment 는 남은 공간에 맞춰 1개 유닛만 남겨야 한다\n{pi52_line}"
+        pi52_line.contains("end_cut=[3]"),
+        "HWPX mixed host 텍스트를 p4 에 먼저 배치한 뒤, vert_offset 이중계상 보정으로 첫 fragment 는 \
+         HWP 참조와 동일하게 3 유닛을 담아야 한다(#2015)\n{pi52_line}"
     );
 
     let hwp_doc = load_sample(HWP_SAMPLE);

--- a/tests/issue_2015_saved_bounds_rowbreak.rs
+++ b/tests/issue_2015_saved_bounds_rowbreak.rs
@@ -1,0 +1,127 @@
+//! Issue #2015: HWPX saved-bounds RowBreak 표 잔존 드리프트 (#1811 후속).
+//!
+//! samples/task1749/saved_bounds_cumulative_page_break.hwpx 4쪽(0-based 3)에서:
+//! - 부동(tac=false) RowBreak 표 pi=52 프래그먼트가 body 영역 바닥을 91.2px 초과
+//!   (LAYOUT_OVERFLOW: para=52, type=PartialTable, overflow=91.2px).
+//!   typeset 의 used 회계(저장바운드 806.0px)와 layout 실측 바닥(1117.7px)이 어긋난다.
+//!
+//! 불변식(정답): Body 서브트리의 어떤 content 노드도 Body 영역 바닥을 넘지 않는다.
+//! (꼬리말/머리말은 Body 밖 형제 노드이므로 대상 아님. Column/Body 자신은 clamp 되므로 제외.)
+//!
+//! Stage 1 에서는 red 기준선이므로 #[ignore]. Stage 2(오버플로우 소거) 에서 ignore 제거.
+
+use std::fs;
+use std::path::Path;
+
+use serde_json::Value;
+
+const HWPX_SAMPLE: &str = "samples/task1749/saved_bounds_cumulative_page_break.hwpx";
+
+fn load_doc() -> rhwp::wasm_api::HwpDocument {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(HWPX_SAMPLE);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", HWPX_SAMPLE, e));
+    rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {}: {}", HWPX_SAMPLE, e))
+}
+
+/// content 노드로 취급하는 타입 (Body 영역 안에 그려지는 실제 잉크 요소).
+/// Column/Body 는 컨테이너(영역 자체이므로 바닥 == body_bottom)이라 제외.
+fn is_content_type(t: &str) -> bool {
+    matches!(
+        t,
+        "Table" | "Cell" | "TextLine" | "TextRun" | "Line" | "Shape" | "Picture"
+    )
+}
+
+fn find_node<'a>(node: &'a Value, target: &str) -> Option<&'a Value> {
+    if node.get("type").and_then(Value::as_str) == Some(target) {
+        return Some(node);
+    }
+    if let Some(children) = node.get("children").and_then(Value::as_array) {
+        for c in children {
+            if let Some(found) = find_node(c, target) {
+                return Some(found);
+            }
+        }
+    }
+    None
+}
+
+fn bbox_bottom(node: &Value) -> Option<f64> {
+    let b = node.get("bbox")?;
+    Some(b.get("y")?.as_f64()? + b.get("h")?.as_f64().unwrap_or(0.0))
+}
+
+/// (worst content bottom, its type) within the subtree.
+fn max_content_bottom(node: &Value) -> Option<(f64, String)> {
+    let mut worst: Option<(f64, String)> = None;
+    fn walk(node: &Value, worst: &mut Option<(f64, String)>) {
+        if let Some(t) = node.get("type").and_then(Value::as_str) {
+            if is_content_type(t) {
+                if let Some(bot) = bbox_bottom(node) {
+                    if worst.as_ref().map(|(b, _)| bot > *b).unwrap_or(true) {
+                        *worst = Some((bot, t.to_string()));
+                    }
+                }
+            }
+        }
+        if let Some(children) = node.get("children").and_then(Value::as_array) {
+            for c in children {
+                walk(c, worst);
+            }
+        }
+    }
+    walk(node, &mut worst);
+    worst
+}
+
+fn page3_body_and_worst() -> (f64, f64, String) {
+    let doc = load_doc();
+    let json = doc
+        .get_page_render_tree(3)
+        .unwrap_or_else(|e| panic!("render tree page 3: {:?}", e));
+    let root: Value = serde_json::from_str(&json).expect("render tree json");
+    let body = find_node(&root, "Body").expect("Body node exists");
+    let body_bottom = bbox_bottom(body).expect("Body bbox bottom");
+    let (worst_bottom, worst_type) = max_content_bottom(body).expect("body has content nodes");
+    (body_bottom, worst_bottom, worst_type)
+}
+
+/// Stage 1 기준선: 현재는 91.2px 초과가 존재함을 명시적으로 기록(문서화 목적).
+/// Stage 2 에서 오버플로우가 소거되면 이 값이 0 에 수렴하며, 아래 정답 테스트가 통과한다.
+#[test]
+fn issue_2015_stage1_documents_current_overflow() {
+    let (body_bottom, worst_bottom, worst_type) = page3_body_and_worst();
+    let overflow = (worst_bottom - body_bottom).max(0.0);
+    // Stage 1: 기준선 관찰만. 초과가 있든 없든 통과시켜 CI 를 막지 않는다.
+    // Stage 2 이후엔 overflow ≈ 0 이어야 한다.
+    eprintln!(
+        "[#2015 baseline] body_bottom={:.1} worst={:.1}({}) overflow={:.1}px",
+        body_bottom, worst_bottom, worst_type, overflow
+    );
+    assert!(overflow >= 0.0, "sanity: overflow 계산이 음수일 수 없다");
+}
+
+/// 정답: 부동 RowBreak 표 pi=52 프래그먼트가 body 바닥을 (사실상) 넘지 않는다.
+///
+/// 수정 전 91.2px 오버플로우 → vert_offset 이중계상 보정 후 잔여 ~2.6px.
+/// 잔여분은 엔진의 `ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE(2.0px)` 수준 행높이 측정
+/// 드리프트로, HWPX end_cut=[3] 이 HWP 저장 LINE_SEG 참조([3]) 및 한컴 PDF 와 동일한
+/// 컷이다(= 마지막 유닛이 경계에 걸치는 정상 상황). 91px 회귀만 확실히 잡도록 5px 게이트.
+#[test]
+fn issue_2015_page4_rowbreak_table_stays_in_body() {
+    let doc = load_doc();
+    assert_eq!(doc.page_count(), 5, "보정 후에도 전체 5쪽 유지");
+
+    let (body_bottom, worst_bottom, worst_type) = page3_body_and_worst();
+    let overflow = (worst_bottom - body_bottom).max(0.0);
+    assert!(
+        overflow <= 5.0,
+        "Body 서브트리 content 가 body 바닥을 크게 초과하면 안 된다(91px 회귀 방지): \
+         body_bottom={:.1}px, worst={:.1}px({}), overflow={:.1}px",
+        body_bottom,
+        worst_bottom,
+        worst_type,
+        overflow
+    );
+}


### PR DESCRIPTION
## 요약

#1811(PR #1887) 후속으로 남은 `saved_bounds_cumulative_page_break.hwpx` 잔존 드리프트 중
**발원지 ①(부동 tac=false RowBreak 표 91.2px 오버플로우)** 를 수정합니다.

Closes #2015 (발원지 ②는 findings 로 인계 — 아래 참조)

## 원인

`pre_emit_visible_rowbreak_host_text`(#1811)가 host 텍스트를 pre-emit 하며 `current_height` 를
`para_start → para_start+host_h(≈146px)` 로 전진시킨 뒤, typeset 예산과 layout 배치가 각각
`vert_offset`(=144.3px, para_start 기준)을 **재차감/재적용** → host_h 만큼 이중계상 → 표 앵커가
body 바닥(1026.5px) 아래로 밀려 91.2px 초과.

`RHWP_TABLE_DRIFT`: `page_avail = 930.5 − 806.0 − 144.3 = −19.8 → 0.0`.

## 수정

`pre_emitted_host_heights: HashMap<usize,f64>` 를 TypesetState → PaginationResult → LayoutEngine
전파. host pre-emit 된 문단에 한해 `vert_offset` 을 `(vert_off − host_h).max(0)` 로 감액하여
typeset 예산(`typeset.rs`)과 layout 배치(`table_partial.rs`)를 정합. host pre-emit 아니면
`host_h=0` → 종전 동일(비대상 문서 회귀 0).

## 결과

| 지표 | 전 | 후 |
|---|---|---|
| `LAYOUT_OVERFLOW` para=52 | 91.2px | **2.1px** |
| 표 top (render tree, p4) | 1056.4 | **912.1** (host 직후) |
| HWPX end_cut | `[1]` | **`[3]`** (= HWP 저장 LINE_SEG 참조·한컴 PDF) |
| 페이지 수 | 5 | 5 |

잔여 2.1px 는 마지막 유닛 경계 걸침(엔진 `ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE=2.0px` 수준)
으로 컷 오류 아님. `issue_1811` 테스트의 HWPX 기대값을 `[1]→[3]` 으로 교정했습니다(종전 `[1]` 은
이중계상 버그값, 주석에 근거 명시).

## 검증

- 전체 테스트: **2923 passed / 0 failed** (release-test, --no-fail-fast).
- `cargo clippy --all-targets -- -D warnings`: 통과.
- 신규 `tests/issue_2015_saved_bounds_rowbreak.rs`: Body 서브트리 content ≤ body 바닥 불변식.
- 형제 샘플 `saved_bounds_cumulative_vpos`: 2쪽·overflow 0 유지.

## 발원지 ② (본 PR 범위 밖, findings 인계)

HWPX 인라인(tac=true) 표 pi=50 의 별표 셀 valign=Center 무력화(합성 `total_content_height`
과대계산 362.8 vs HWP 293.3 → 센터링 클램프 → 별표 37px 위). 오버플로우·페이지수·본문흐름 무관한
미관 수준이며, 수정 locus(HWPX content-height 합성)가 전 HWPX 표에 영향(광범위 회귀 표면)이라
별도 스코프 타스크를 권장합니다. 상세: `mydocs/working/task_m100_2015_stage4.md`.

## 부수 산출

`scripts/visual_oracle_native.py`: 시스템 래스터라이저(rsvg-convert/pdftoppm) 없이 동작하는
자립형 시각 오라클(rhwp export-png(native-skia) + PyMuPDF + PIL/numpy). before/after 픽셀 검증용.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
