### PR TITLE
Task #2027: 그림 배치 변경 undo 기록 + tac 해제 시 텍스트 문단 line_segs 재계산

### DIFF
--- a/rhwp-studio/src/command/commands/format.ts
+++ b/rhwp-studio/src/command/commands/format.ts
@@ -472,7 +472,7 @@ export const formatCommands: CommandDef[] = [
           dialog.open(ref.sec, ref.ppi, ref.ci, ref.cellIdx, ref.cellParaIdx, ref.noteRef);
           return;
         }
-        const dialog = new PicturePropsDialog(services.wasm, services.eventBus);
+        const dialog = new PicturePropsDialog(services.wasm, services.eventBus, services);
         dialog.open(ref.sec, ref.ppi, ref.ci, ref.type);
         return;
       }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -322,7 +322,7 @@ export const insertCommands: CommandDef[] = [
         return;
       }
       if (!picturePropsDialog) {
-        picturePropsDialog = new PicturePropsDialog(services.wasm, services.eventBus);
+        picturePropsDialog = new PicturePropsDialog(services.wasm, services.eventBus, services);
       }
       // [Task #825] 머리말/꼬리말 그림은 ref.headerFooter 동반 — dialog 에 전달.
       // [Task #1138] 표 셀 내 도형(shape/line) 은 cellPath 구성하여 dialog 에 전달

--- a/rhwp-studio/src/engine/input-handler-table.ts
+++ b/rhwp-studio/src/engine/input-handler-table.ts
@@ -4,6 +4,7 @@
 import { MoveTableCommand, MovePictureCommand, MoveShapeCommand } from './command';
 import { getObjectProperties, setObjectProperties } from './input-handler-picture';
 import type { CellBbox } from '@/core/types';
+import type { WasmBridge } from '@/core/wasm-bridge';
 import type { BorderEdge } from './table-resize-renderer';
 import { showToast } from '@/ui/toast';
 
@@ -1218,21 +1219,25 @@ export function finishImagePlacement(this: any, e: MouseEvent): void {
   // 개체 설명문 생성 (한컴 기본 패턴)
   const desc = `그림입니다.\r\n원본 그림의 이름: ${imgData.fileName}\r\n원본 그림의 크기: 가로 ${imgData.naturalWidth}pixel, 세로 ${imgData.naturalHeight}pixel`;
 
-  // WASM 호출
+  // WASM 호출 — 스냅샷으로 기록 (Undo 지원, pasteImage 경로와 동일 패턴)
   try {
-    const result = this.wasm.insertPicture(
-      sec, paraIdx, charOffset, cellPathJson, imgData.data,
-      wHwp, hHwp, imgData.naturalWidth, imgData.naturalHeight,
-      imgData.ext, desc,
-      paperOffsetXHu, paperOffsetYHu,
-    );
-    if (result.ok) {
-      this.eventBus.emit('document-changed');
-    } else {
-      const msg = (result as any).error || '삽입 위치 또는 이미지 정보를 확인할 수 없습니다.';
-      console.warn('[InputHandler] 그림 삽입 실패:', result);
+    let insertFailedMsg: string | null = null;
+    this.executeOperation({ kind: 'snapshot', operationType: 'insertPicture', operation: (wasm: WasmBridge) => {
+      const result = wasm.insertPicture(
+        sec, paraIdx, charOffset, cellPathJson, imgData.data,
+        wHwp, hHwp, imgData.naturalWidth, imgData.naturalHeight,
+        imgData.ext, desc,
+        paperOffsetXHu, paperOffsetYHu,
+      );
+      if (!result.ok) {
+        insertFailedMsg = (result as any).error || '삽입 위치 또는 이미지 정보를 확인할 수 없습니다.';
+        console.warn('[InputHandler] 그림 삽입 실패:', result);
+      }
+      return this.cursor.getPosition();
+    }});
+    if (insertFailedMsg) {
       showToast({
-        message: `그림 삽입에 실패했습니다.\n${msg}`,
+        message: `그림 삽입에 실패했습니다.\n${insertFailedMsg}`,
         durationMs: 6000,
       });
     }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -762,60 +762,63 @@ export class InputHandler {
       `그림입니다.\r\n원본 그림의 이름: ${fileName}\r\n원본 그림의 크기: 가로 ${naturalWidth}pixel, 세로 ${naturalHeight}pixel`;
 
     try {
-      const result = this.wasm.insertPicture(
-        sec,
-        paraIdx,
-        hit.charOffset,
-        cellPathJson,
-        data,
-        width,
-        height,
-        naturalWidth,
-        naturalHeight,
-        ext,
-        desc,
-        undefined,
-        undefined,
-      );
-      if (!result.ok) {
-        return {
-          ok: false,
-          error: (result as any).error || '삽입 위치 또는 이미지 정보를 확인할 수 없습니다.',
-        };
-      }
-
-      const logicalOffset = typeof result.logicalOffset === 'number'
-        ? result.logicalOffset
-        : hit.charOffset + 1;
-      const cursorAfter: DocumentPosition = inTextBox
-        ? { ...hit, charOffset: logicalOffset }
-        : {
-            sectionIndex: sec,
-            paragraphIndex: result.paraIdx ?? paraIdx,
-            charOffset: logicalOffset,
-          };
-
-      if (inTextBox && cellPath.length > 0) {
-        this.wasm.setCellPicturePropertiesByPath(
+      // 삽입 + 인라인 전환을 하나의 스냅샷으로 기록 (Undo 지원, pasteImage 경로와 동일 패턴)
+      let insertError: string | null = null;
+      this.executeOperation({ kind: 'snapshot', operationType: 'insertPicture', operation: (wasm: WasmBridge) => {
+        const result = wasm.insertPicture(
           sec,
           paraIdx,
-          cellPath,
-          result.controlIdx,
-          { treatAsChar: true },
+          hit.charOffset,
+          cellPathJson,
+          data,
+          width,
+          height,
+          naturalWidth,
+          naturalHeight,
+          ext,
+          desc,
+          undefined,
+          undefined,
         );
-      } else {
-        this.wasm.setPictureProperties(
-          sec,
-          result.paraIdx ?? paraIdx,
-          result.controlIdx,
-          { treatAsChar: true },
-        );
+        if (!result.ok) {
+          insertError = (result as any).error || '삽입 위치 또는 이미지 정보를 확인할 수 없습니다.';
+          return hit;
+        }
+
+        const logicalOffset = typeof result.logicalOffset === 'number'
+          ? result.logicalOffset
+          : hit.charOffset + 1;
+        const cursorAfter: DocumentPosition = inTextBox
+          ? { ...hit, charOffset: logicalOffset }
+          : {
+              sectionIndex: sec,
+              paragraphIndex: result.paraIdx ?? paraIdx,
+              charOffset: logicalOffset,
+            };
+
+        if (inTextBox && cellPath.length > 0) {
+          wasm.setCellPicturePropertiesByPath(
+            sec,
+            paraIdx,
+            cellPath,
+            result.controlIdx,
+            { treatAsChar: true },
+          );
+        } else {
+          wasm.setPictureProperties(
+            sec,
+            result.paraIdx ?? paraIdx,
+            result.controlIdx,
+            { treatAsChar: true },
+          );
+        }
+        this.cursor.clearSelection();
+        return cursorAfter;
+      }});
+      if (insertError) {
+        return { ok: false, error: insertError };
       }
-      this.cursor.clearSelection();
-      this.cursor.moveTo(cursorAfter);
-      this.cursor.resetPreferredX();
       this.active = true;
-      this.afterEdit();
       this.focusTextarea();
       return { ok: true };
     } catch (err) {

--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -13,6 +13,7 @@
 import type { PictureProperties, ShapeProperties, CellPathLike } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 import { userSettings } from '@/core/user-settings';
 import { enableDialogDrag } from './dialog-drag';
 
@@ -57,6 +58,8 @@ export class PicturePropsDialog {
 
   private wasm: WasmBridge;
   private eventBus: EventBus;
+  /** undo 기록 라우팅용 (없으면 wasm 직접 호출 fallback). */
+  private services: CommandServices | undefined;
 
   // 탭
   private tabs: HTMLButtonElement[] = [];
@@ -217,9 +220,10 @@ export class PicturePropsDialog {
   private shadowDirBtns: HTMLButtonElement[] = [];
   private shadowTransInput!: HTMLInputElement;
 
-  constructor(wasm: WasmBridge, eventBus: EventBus) {
+  constructor(wasm: WasmBridge, eventBus: EventBus, services?: CommandServices) {
     this.wasm = wasm;
     this.eventBus = eventBus;
+    this.services = services;
   }
 
   // ════════════════════════════════════════════════════════
@@ -2217,31 +2221,48 @@ export class PicturePropsDialog {
       // - picture: headerFooter > cellPath > 외부
       //   [Task #1151 v4] 셀 안 inline picture 는 setCellPicturePropertiesByPath
       //   wasm API 호출. 본문 picture (cellPath 없음) 는 기존 setPictureProperties.
-      if (this.objectType === 'shape' || this.objectType === 'line' || this.objectType === 'group') {
-        if (this.cellPath) {
-          this.wasm.setCellShapePropertiesByPath(
+      const applyProps = () => {
+        if (this.objectType === 'shape' || this.objectType === 'line' || this.objectType === 'group') {
+          if (this.cellPath) {
+            this.wasm.setCellShapePropertiesByPath(
+              this.sec, this.para, this.cellPath, this.innerControlIdx, updated,
+            );
+          } else {
+            this.wasm.setShapeProperties(this.sec, this.para, this.ci, updated);
+          }
+        } else if (this.headerFooter) {
+          // [Task #825] 머리말/꼬리말 그림은 별도 API — 5-tuple lookup. 캡션 신규
+          // 생성은 미지원 (set_header_footer_picture_properties_native 가 NotSupported
+          // 에러 반환 — 본 dialog 에서는 일반 속성 변경만 허용).
+          this.wasm.setHeaderFooterPictureProperties(
+            this.sec, this.headerFooter.outerParaIdx, this.headerFooter.outerControlIdx,
+            this.para, this.ci, updated,
+          );
+        } else if (this.cellPath) {
+          // [Task #1151 v4] 셀 안 inline picture — by_path API 호출.
+          this.wasm.setCellPicturePropertiesByPath(
             this.sec, this.para, this.cellPath, this.innerControlIdx, updated,
           );
         } else {
-          this.wasm.setShapeProperties(this.sec, this.para, this.ci, updated);
+          this.wasm.setPictureProperties(this.sec, this.para, this.ci, updated);
         }
-      } else if (this.headerFooter) {
-        // [Task #825] 머리말/꼬리말 그림은 별도 API — 5-tuple lookup. 캡션 신규
-        // 생성은 미지원 (set_header_footer_picture_properties_native 가 NotSupported
-        // 에러 반환 — 본 dialog 에서는 일반 속성 변경만 허용).
-        this.wasm.setHeaderFooterPictureProperties(
-          this.sec, this.headerFooter.outerParaIdx, this.headerFooter.outerControlIdx,
-          this.para, this.ci, updated,
-        );
-      } else if (this.cellPath) {
-        // [Task #1151 v4] 셀 안 inline picture — by_path API 호출.
-        this.wasm.setCellPicturePropertiesByPath(
-          this.sec, this.para, this.cellPath, this.innerControlIdx, updated,
-        );
+      };
+      // 개체 속성 변경도 undo 대상이다 — 편집 라우터를 통과시켜 스냅샷으로
+      // 기록한다 (#1320 계약). services 미주입 환경에서만 직접 적용 fallback.
+      const ih = this.services?.getInputHandler();
+      if (ih) {
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'objectProps',
+          operation: () => {
+            applyProps();
+            return ih.getCursorPosition();
+          },
+        });
       } else {
-        this.wasm.setPictureProperties(this.sec, this.para, this.ci, updated);
+        applyProps();
+        this.eventBus.emit('document-changed');
       }
-      this.eventBus.emit('document-changed');
     }
     this.hide();
   }

--- a/rhwp-studio/tests/picture-props-undo.test.ts
+++ b/rhwp-studio/tests/picture-props-undo.test.ts
@@ -1,0 +1,74 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 그림 속성 다이얼로그와 그림 삽입 경로는 문서를 mutate 하므로 반드시
+// 편집 라우터(executeOperation)를 통과해 undo 스택에 기록되어야 한다.
+// (기존에는 wasm setter 직접 호출 + document-changed emit 만 수행되어,
+// "본문과의 배치" 변경/그림 삽입이 Ctrl+Z 로 복구되지 않았다.)
+
+test('그림 속성 다이얼로그 apply는 스냅샷으로 undo 기록된다', () => {
+  const dialog = source('src/ui/picture-props-dialog.ts');
+
+  const handleOkStart = dialog.indexOf('private handleOk');
+  assert.notEqual(handleOkStart, -1, 'handleOk not found');
+  const handleOk = dialog.slice(handleOkStart, dialog.indexOf('\n  private ', handleOkStart + 1));
+
+  assert.match(
+    handleOk,
+    /executeOperation\(\{\s*kind: 'snapshot',\s*operationType: 'objectProps'/,
+    '개체 속성 적용은 편집 라우터의 snapshot 명령으로 기록되어야 함',
+  );
+});
+
+test('그림 속성 다이얼로그 생성자는 CommandServices를 전달받는다', () => {
+  const insert = source('src/command/commands/insert.ts');
+  const format = source('src/command/commands/format.ts');
+
+  assert.match(
+    insert,
+    /new PicturePropsDialog\(services\.wasm, services\.eventBus, services\)/,
+    'insert:picture-props 진입점에서 services 전달 필요',
+  );
+  assert.match(
+    format,
+    /new PicturePropsDialog\(services\.wasm, services\.eventBus, services\)/,
+    'format:object-properties 진입점에서 services 전달 필요',
+  );
+});
+
+test('배치모드 그림 삽입은 스냅샷으로 undo 기록된다', () => {
+  const table = source('src/engine/input-handler-table.ts');
+
+  const start = table.indexOf('export function finishImagePlacement');
+  assert.notEqual(start, -1, 'finishImagePlacement not found');
+  const block = table.slice(start, table.indexOf('\nexport function ', start + 1));
+
+  assert.match(
+    block,
+    /executeOperation\(\{ kind: 'snapshot', operationType: 'insertPicture'/,
+    '배치모드 그림 삽입은 snapshot 명령으로 기록되어야 함',
+  );
+});
+
+test('드래그드롭 그림 삽입은 스냅샷으로 undo 기록된다', () => {
+  const ih = source('src/engine/input-handler.ts');
+
+  const start = ih.indexOf('insertDroppedImageAtClientPoint(');
+  assert.notEqual(start, -1, 'insertDroppedImageAtClientPoint not found');
+  const block = ih.slice(start, ih.indexOf('\n  private ', start + 1));
+
+  assert.match(
+    block,
+    /executeOperation\(\{ kind: 'snapshot', operationType: 'insertPicture'/,
+    '드래그드롭 그림 삽입은 snapshot 명령으로 기록되어야 함',
+  );
+});

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -474,6 +474,7 @@ impl DocumentCore {
         // 한컴 산출물 Scenario A~D 분석: tac false→true 시 picture 의 control 위치는
         // 불변이고, 4 필드만 갱신 (treat_as_char / h/v_rel_to=Para / h/v_offset=0 /
         // parent line_segs[0]). text/char_offsets/paragraph 수 변화 없음.
+        let mut reflow_text_para_after_floating = false;
         if should_migrate_to_inline || should_migrate_to_floating {
             let section = self.document.sections.get_mut(section_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("구역 인덱스 {} 범위 초과", section_idx))
@@ -518,9 +519,24 @@ impl DocumentCore {
                     }
                     _ => {}
                 }
-            } else {
+            } else if para.text.is_empty() && para.char_offsets.is_empty() {
                 Self::migrate_empty_picture_para_inline_to_floating(para);
+            } else if !para.text.is_empty() && parent_para_idx < body_len {
+                // 텍스트가 있는 문단: false→true 마이그레이션이 line_segs[0] 를
+                // 그림 높이로 키워 놓았으므로, 그림이 inline 흐름에서 빠지는 시점에
+                // 남은 인라인 콘텐츠 기준으로 재계산해야 한다. 그림 삭제 경로
+                // (reflow_paragraph_line_segs_after_control_delete) 와 동일한 원리.
+                // paragraph &mut borrow 가 끝난 뒤 reflow_paragraph 로 수행.
+                // 텍스트 없이 컨트롤 문자만 있는 문단(표 문단 등)은 기존 동작 유지.
+                reflow_text_para_after_floating = true;
             }
+        }
+        if reflow_text_para_after_floating {
+            self.reflow_paragraph(section_idx, parent_para_idx);
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs,
+                parent_para_idx,
+            );
         }
         // 캡션 생성 시 AutoNumber 재할당 + 텍스트 생성 (본문 path 만 — 머리말/꼬리말은 별도).
         if caption_created {

--- a/tests/issue_2027_picture_wrap_toggle_loss.rs
+++ b/tests/issue_2027_picture_wrap_toggle_loss.rs
@@ -1,0 +1,363 @@
+//! Issue #2027: 그림 "본문과의 배치" 반복 변경 시 line_segs 미복원 + undo 미기록 (HOP 보고 버그).
+//!
+//! 시나리오 (studio 그림 속성 다이얼로그가 보내는 diff JSON 을 그대로 모사):
+//! 1. 본문에 그림 삽입 (insert_picture_native 기본 = floating/Square/Paper)
+//! 2. 글자처럼 취급 on  → {"treatAsChar":true}
+//! 3. 글자처럼 취급 off (어울림 복귀) → {"treatAsChar":false}
+//! 4. 자리차지 → {"textWrap":"TopAndBottom"}
+//! 5. 어울림 → {"textWrap":"Square"}
+//! 6. 2~3 한 번 더 왕복
+//!
+//! 각 단계 후: 컨트롤 존재 + render tree ImageNode 존재 + bbox 페이지 교차를 단언한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::model::paragraph::LineSeg;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+
+/// 줄 크기 메트릭 비교 키: (text_start, line_height, text_height, baseline_distance, line_spacing).
+///
+/// vertical_pos / column_start / segment_width / tag 는 비교에서 제외한다 —
+/// 텍스트 편집 표준 경로(reflow_line_segs + recalculate_section_vpos)가 원본 파일
+/// 값 대신 자체 재계산 값을 쓰는 필드들이라, 편집 후 비트 동일성이 보장되지 않는다.
+/// 본 테스트의 관심사는 "그림 높이로 부풀려진 줄 크기가 텍스트 기준으로 복원되는가"다.
+type LineSegKey = (u32, i32, i32, i32, i32);
+
+fn seg_keys(segs: &[LineSeg]) -> Vec<LineSegKey> {
+    segs.iter()
+        .map(|s| {
+            (
+                s.text_start,
+                s.line_height,
+                s.text_height,
+                s.baseline_distance,
+                s.line_spacing,
+            )
+        })
+        .collect()
+}
+
+const SAMPLE: &str = "samples/basic/english.hwp";
+
+/// 1x1 투명 PNG (67 bytes).
+const TINY_PNG: &[u8] = &[
+    0x89, 0x50, 0x4E, 0x47, 0x0D, 0x0A, 0x1A, 0x0A, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x48, 0x44, 0x52,
+    0x00, 0x00, 0x00, 0x01, 0x00, 0x00, 0x00, 0x01, 0x08, 0x06, 0x00, 0x00, 0x00, 0x1F, 0x15, 0xC4,
+    0x89, 0x00, 0x00, 0x00, 0x0D, 0x49, 0x44, 0x41, 0x54, 0x78, 0x9C, 0x62, 0x00, 0x01, 0x00, 0x00,
+    0x05, 0x00, 0x01, 0x0D, 0x0A, 0x2D, 0xB4, 0x00, 0x00, 0x00, 0x00, 0x49, 0x45, 0x4E, 0x44, 0xAE,
+    0x42, 0x60, 0x82,
+];
+
+const PIC_WIDTH_HU: u32 = 9000; // 3.17cm
+const PIC_HEIGHT_HU: u32 = 6000; // 2.12cm
+
+#[derive(Debug, Clone, Copy)]
+struct ImageRender {
+    control_index: usize,
+    x: f64,
+    y: f64,
+    width: f64,
+    height: f64,
+}
+
+fn collect_images(node: &RenderNode, out: &mut Vec<ImageRender>) {
+    if let RenderNodeType::Image(img) = &node.node_type {
+        if let Some(control_index) = img.control_index {
+            out.push(ImageRender {
+                control_index,
+                x: node.bbox.x,
+                y: node.bbox.y,
+                width: node.bbox.width,
+                height: node.bbox.height,
+            });
+        }
+    }
+    for child in &node.children {
+        collect_images(child, out);
+    }
+}
+
+fn load_core() -> DocumentCore {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = std::path::Path::new(repo_root).join(SAMPLE);
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+    DocumentCore::from_bytes(&bytes).unwrap_or_else(|e| panic!("load {SAMPLE}: {e}"))
+}
+
+/// 본문 첫 텍스트 문단에 그림을 삽입하고 (para_idx, control_idx) 반환.
+fn insert_test_picture(core: &mut DocumentCore) -> (usize, usize) {
+    let para_idx = core.document().sections[0]
+        .paragraphs
+        .iter()
+        .position(|p| !p.text.is_empty())
+        .unwrap_or(0);
+    let result = core
+        .insert_picture_native(
+            0,
+            para_idx,
+            0,
+            &[],
+            TINY_PNG,
+            PIC_WIDTH_HU,
+            PIC_HEIGHT_HU,
+            1,
+            1,
+            "png",
+            "repro picture",
+            Some(20000),
+            Some(20000),
+        )
+        .expect("insert_picture_native");
+    let json: serde_json::Value = serde_json::from_str(&result)
+        .unwrap_or_else(|e| panic!("insert 결과 JSON 파싱 실패 `{result}`: {e}"));
+    let ci = json["controlIdx"]
+        .as_u64()
+        .unwrap_or_else(|| panic!("insert 결과에 controlIdx 없음: {result}")) as usize;
+    (para_idx, ci)
+}
+
+fn picture_control(
+    core: &DocumentCore,
+    para_idx: usize,
+    ci: usize,
+) -> Option<&rhwp::model::image::Picture> {
+    match core.document().sections[0].paragraphs[para_idx]
+        .controls
+        .get(ci)
+    {
+        Some(Control::Picture(pic)) => Some(pic.as_ref()),
+        _ => None,
+    }
+}
+
+/// 전체 페이지 render tree 에서 control_index 로 그림 ImageNode 를 찾는다.
+/// 반환: (페이지 번호, 페이지 bbox(w,h), ImageRender)
+fn find_picture_render(
+    core: &mut DocumentCore,
+    ci: usize,
+) -> Option<(u32, (f64, f64), ImageRender)> {
+    let pages = core.page_count();
+    for page in 0..pages {
+        let tree = core
+            .build_page_render_tree(page)
+            .unwrap_or_else(|e| panic!("render tree page {page}: {e}"));
+        let mut images = Vec::new();
+        collect_images(&tree.root, &mut images);
+        if let Some(img) = images.iter().find(|img| img.control_index == ci) {
+            return Some((page, (tree.root.bbox.width, tree.root.bbox.height), *img));
+        }
+    }
+    None
+}
+
+/// 단계별 불변식: 컨트롤 존재 + ImageNode 존재 + bbox 가 페이지 캔버스와 교차.
+fn assert_picture_visible(core: &mut DocumentCore, para_idx: usize, ci: usize, step: &str) {
+    let pic = picture_control(core, para_idx, ci)
+        .unwrap_or_else(|| panic!("[{step}] 그림 컨트롤이 모델에서 사라짐"));
+    let (tac, wrap, vo, ho) = (
+        pic.common.treat_as_char,
+        pic.common.text_wrap,
+        pic.common.vertical_offset,
+        pic.common.horizontal_offset,
+    );
+    let (page, (page_w, page_h), img) = find_picture_render(core, ci).unwrap_or_else(|| {
+        panic!(
+            "[{step}] 그림 ImageNode 가 어느 페이지에도 없음 (tac={tac}, wrap={wrap:?}, v_off={vo}, h_off={ho})"
+        )
+    });
+    let intersects =
+        img.x < page_w && img.x + img.width > 0.0 && img.y < page_h && img.y + img.height > 0.0;
+    assert!(
+        intersects,
+        "[{step}] 그림 bbox 가 페이지 {page} 캔버스({page_w:.0}x{page_h:.0}) 밖: {img:?} (tac={tac}, wrap={wrap:?}, v_off={vo}, h_off={ho})"
+    );
+}
+
+fn set_props(core: &mut DocumentCore, para_idx: usize, ci: usize, json: &str, step: &str) {
+    core.set_picture_properties_native(0, para_idx, ci, json)
+        .unwrap_or_else(|e| panic!("[{step}] set_picture_properties_native({json}): {e}"));
+}
+
+/// 시나리오 재현: 삽입 → 글자처럼 on/off → 자리차지 → 어울림 → 재왕복.
+/// 각 단계에서 그림이 페이지에 보여야 한다.
+#[test]
+fn picture_survives_wrap_and_tac_toggle_sequence() {
+    let mut core = load_core();
+    let (para_idx, ci) = insert_test_picture(&mut core);
+    assert_picture_visible(&mut core, para_idx, ci, "1.삽입(floating/Square/Paper)");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":true}"#,
+        "2.글자처럼 on",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "2.글자처럼 on");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":false}"#,
+        "3.글자처럼 off(어울림)",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "3.글자처럼 off(어울림)");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"textWrap":"TopAndBottom"}"#,
+        "4.자리차지",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "4.자리차지");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"textWrap":"Square"}"#,
+        "5.어울림",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "5.어울림");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":true}"#,
+        "6.글자처럼 on(2회차)",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "6.글자처럼 on(2회차)");
+
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":false}"#,
+        "7.글자처럼 off(2회차)",
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "7.글자처럼 off(2회차)");
+}
+
+/// tac 토글 왕복 후 앵커 문단 line_segs 가 원본으로 복원되는지 (마이그레이션 비가역성 검증).
+#[test]
+fn tac_roundtrip_preserves_anchor_line_segs() {
+    let mut core = load_core();
+    let (para_idx, ci) = insert_test_picture(&mut core);
+
+    let before = seg_keys(&core.document().sections[0].paragraphs[para_idx].line_segs);
+
+    set_props(&mut core, para_idx, ci, r#"{"treatAsChar":true}"#, "tac on");
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":false}"#,
+        "tac off",
+    );
+
+    let after = seg_keys(&core.document().sections[0].paragraphs[para_idx].line_segs);
+    assert_eq!(
+        before, after,
+        "tac on→off 왕복 후 앵커 문단 line_segs 가 원본과 달라짐 (비가역 마이그레이션)"
+    );
+}
+
+/// 대조 실험: core 스냅샷 undo 는 배치 변경을 완전히 복원해야 한다.
+/// (이 테스트가 통과하면 'undo 미복원'은 studio 의 기록 누락이 원인)
+#[test]
+fn snapshot_restore_recovers_picture_placement() {
+    let mut core = load_core();
+    let (para_idx, ci) = insert_test_picture(&mut core);
+
+    let before_common = picture_control(&core, para_idx, ci)
+        .expect("삽입 직후 그림")
+        .common
+        .clone();
+    let before_segs = seg_keys(&core.document().sections[0].paragraphs[para_idx].line_segs);
+
+    let snapshot_id = core.save_snapshot_native();
+
+    set_props(&mut core, para_idx, ci, r#"{"treatAsChar":true}"#, "tac on");
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":false}"#,
+        "tac off",
+    );
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"textWrap":"TopAndBottom"}"#,
+        "자리차지",
+    );
+
+    core.restore_snapshot_native(snapshot_id)
+        .expect("restore_snapshot_native");
+
+    let after_common = &picture_control(&core, para_idx, ci)
+        .unwrap_or_else(|| panic!("스냅샷 복원 후 그림 컨트롤이 사라짐"))
+        .common;
+    assert_eq!(
+        before_common.treat_as_char, after_common.treat_as_char,
+        "스냅샷 복원 후 treat_as_char 불일치"
+    );
+    assert_eq!(
+        before_common.text_wrap, after_common.text_wrap,
+        "스냅샷 복원 후 text_wrap 불일치"
+    );
+    assert_eq!(
+        before_common.vertical_offset, after_common.vertical_offset,
+        "스냅샷 복원 후 vertical_offset 불일치"
+    );
+    assert_eq!(
+        before_common.horizontal_offset, after_common.horizontal_offset,
+        "스냅샷 복원 후 horizontal_offset 불일치"
+    );
+    let after_segs = seg_keys(&core.document().sections[0].paragraphs[para_idx].line_segs);
+    assert_eq!(
+        before_segs, after_segs,
+        "스냅샷 복원 후 앵커 문단 line_segs 불일치"
+    );
+    assert_picture_visible(&mut core, para_idx, ci, "스냅샷 복원 후");
+}
+
+/// floating(어울림) 그림이 HWP 저장 → 재로드에서 보존되는지.
+/// (망가진파일1.hwp 에서 그림 컨트롤이 통째로 사라진 경로 검증)
+#[test]
+fn floating_picture_survives_hwp_save_roundtrip() {
+    let mut core = load_core();
+    let (para_idx, ci) = insert_test_picture(&mut core);
+
+    // 어울림 floating 상태로 만든 뒤 (삽입 기본값이 이미 그 상태지만 tac 왕복도 거침)
+    set_props(&mut core, para_idx, ci, r#"{"treatAsChar":true}"#, "tac on");
+    set_props(
+        &mut core,
+        para_idx,
+        ci,
+        r#"{"treatAsChar":false}"#,
+        "tac off",
+    );
+
+    let saved = core.export_hwp_with_adapter().expect("export_hwp");
+    let reloaded = DocumentCore::from_bytes(&saved).expect("재로드");
+
+    let picture_count: usize = reloaded.document().sections[0]
+        .paragraphs
+        .iter()
+        .map(|p| {
+            p.controls
+                .iter()
+                .filter(|c| matches!(c, Control::Picture(_)))
+                .count()
+        })
+        .sum();
+    assert_eq!(
+        picture_count, 1,
+        "HWP 저장 → 재로드 후 그림 컨트롤이 보존되어야 함 (저장 단계 소실 여부 검증)"
+    );
+}


### PR DESCRIPTION
관련 이슈: #2027

## 문제

HOP(rhwp 기반 앱)에서 보고된 시나리오 — 이미지 삽입 후 개체 속성에서 "본문과의 배치"(어울림/자리차지/글자처럼 취급)를 몇 번 바꾸면 레이아웃이 깨지고, **Ctrl+Z 로 복구되지 않음**. 최신 devel 기준으로 원인을 추적해 결함 2건을 확인했습니다.

1. **그림 배치 변경·삽입이 undo 스택에 기록되지 않음 (studio)**
   - `picture-props-dialog.ts` `handleOk` 가 `wasm.setPictureProperties` 등을 직접 호출하고 `document-changed` 만 emit — `CommandHistory` 에 어떤 EditCommand 도 남지 않아 "본문과의 배치" 변경 전부가 undo 불가.
   - 그림 삽입도 배치모드(`finishImagePlacement`)·드래그드롭(`insertDroppedImageAtClientPoint`) 경로가 미기록 (클립보드 `pasteImage` 만 snapshot 기록).
   - 대조 실험: core 의 `save_snapshot_native`/`restore_snapshot_native` 는 배치 변경을 완전 복원 → 순수 studio 기록 누락 (#1320 편집 라우터 계약 위반).

2. **tac true→false 시 텍스트 문단 line_segs 미복원 (core)**
   - `migrate_picture_floating_to_inline`(#1151 v2) 은 앵커 문단 `line_segs[0]` 을 그림 높이로 덮어쓰는데, 역방향은 `migrate_empty_picture_para_inline_to_floating`(#1459) 이 **빈 문단만** 처리 — 텍스트 문단은 그림 높이가 영구 잔존 (예: lh 1200 → 6000 으로 남음, 저장 파일에도 잔존).

## 변경 내용

**커밋 1 — core** (`src/document_core/commands/object_ops/picture.rs`)

- `set_picture_properties_native` 의 tac true→false 분기: 텍스트가 있는 본문 문단이면 `reflow_paragraph` + `recalculate_section_vpos` 로 line_segs 를 남은 인라인 콘텐츠 기준 재계산 (그림 삭제 경로 `reflow_paragraph_line_segs_after_control_delete` 와 동일 원리).
- 빈 그림 문단(#1459 경로)과 텍스트 없이 컨트롤 문자만 있는 문단(표 문단 등), endnote 가상 문단은 **기존 동작 그대로 유지**.
- 회귀 테스트: `tests/issue_2027_picture_wrap_toggle_loss.rs`
  - `picture_survives_wrap_and_tac_toggle_sequence` — 삽입→글자처럼 on/off→자리차지→어울림→재왕복 각 단계에서 그림 컨트롤 존재 + render tree ImageNode 페이지 내 가시성 단언
  - `tac_roundtrip_preserves_anchor_line_segs` — 토글 왕복 후 줄 크기 메트릭(text_start/line_height/text_height/baseline/line_spacing) 복원 단언 (수정 전 실패: lh 6000 잔존)
  - `snapshot_restore_recovers_picture_placement` — core 스냅샷 undo 건전성 대조 실험
  - `floating_picture_survives_hwp_save_roundtrip` — 어울림 그림 HWP 저장 왕복 보존

**커밋 2 — studio** (`rhwp-studio/`)

- `picture-props-dialog.ts`: 생성자에 `CommandServices` 옵션 주입(기존 두 진입점 `insert:picture-props`/`format:object-properties` 에서 전달), `handleOk` 적용을 `executeOperation({kind:'snapshot', operationType:'objectProps'})` 로 라우팅. services 미주입 환경은 기존 직접 적용 fallback.
- `input-handler-table.ts` `finishImagePlacement`, `input-handler.ts` `insertDroppedImageAtClientPoint`: 삽입(+드롭 경로의 `treatAsChar:true` 후처리 포함)을 `operationType:'insertPicture'` snapshot 으로 기록 — `pasteImage` 기존 패턴 준용.
- 회귀 테스트: `rhwp-studio/tests/picture-props-undo.test.ts` (소스 검사 스타일 4건).

## 검증 (devel 리베이스 후 기준, Windows 11 / Rust 1.93.1)

- `cargo test --release --no-fail-fast` 전체 통과 (실패 0건).
- `rhwp-studio` `npm test` 175건 통과 (신규 4건 포함), `tsc --noEmit` 통과 (pkg 미빌드로 인한 `@wasm/rhwp.js` 해소 오류 2건 제외 — 기존 환경 이슈).
- `cargo clippy --release --tests` 경고 0, rustfmt 적용.
- 수동 검증: `wasm-pack build --target web` 후 rhwp-studio 에서 그림 삽입 → 배치 변경 → Ctrl+Z 로 단계별 복구 및 tac 해제 후 문단 첫 줄 높이 정상 복원 확인.

## 범위 외 (이슈에 언급)

- floating 그림 배치의 페이지 경계 클램프/이월 부재 (좌표가 페이지 밖이면 완전 소실로 표출되는 구조) — 별도 이슈 후보.
- 도형(shape) 경로의 tac 토글 동종 로직 여부.
