### PR TITLE
Task #2053: 표/셀 속성·셀 테두리/배경 다이얼로그를 편집 라우터 snapshot 으로 기록

### DIFF
--- a/rhwp-studio/src/command/commands/format.ts
+++ b/rhwp-studio/src/command/commands/format.ts
@@ -482,7 +482,7 @@ export const formatCommands: CommandDef[] = [
         const pos = ih.getCursorPosition();
         if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
         const tableCtx = { sec: pos.sectionIndex, ppi: pos.parentParaIndex, ci: pos.controlIndex };
-        const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, pos.cellIndex, 'table');
+        const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, pos.cellIndex, 'table', services);
         dialog.show();
       }
     },

--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -279,7 +279,7 @@ export const tableCommands: CommandDef[] = [
         const ref = ih.getSelectedTableRef();
         if (!ref) return;
         const tableCtx = { sec: ref.sec, ppi: ref.ppi, ci: ref.ci };
-        const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, 0, 'table');
+        const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, 0, 'table', services);
         dialog.show();
         return;
       }
@@ -287,7 +287,7 @@ export const tableCommands: CommandDef[] = [
       const pos = ih.getCursorPosition();
       if (pos.parentParaIndex === undefined || pos.controlIndex === undefined || pos.cellIndex === undefined) return;
       const tableCtx = { sec: pos.sectionIndex, ppi: pos.parentParaIndex, ci: pos.controlIndex };
-      const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, pos.cellIndex, 'cell');
+      const dialog = new TableCellPropsDialog(services.wasm, services.eventBus, tableCtx, pos.cellIndex, 'cell', services);
       dialog.show();
     },
   },
@@ -309,6 +309,7 @@ export const tableCommands: CommandDef[] = [
         pos.cellIndex,
         'each',
         selectionRange,
+        services,
       );
       dialog.show();
     },
@@ -331,6 +332,7 @@ export const tableCommands: CommandDef[] = [
         pos.cellIndex,
         'asOne',
         ih.getSelectedCellRange(),
+        services,
       );
       dialog.show();
     },

--- a/rhwp-studio/src/ui/cell-border-bg-dialog.ts
+++ b/rhwp-studio/src/ui/cell-border-bg-dialog.ts
@@ -2,6 +2,7 @@ import { ModalDialog } from './dialog';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { CellBbox, CellProperties } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 const HWPUNIT_PER_MM = 7200 / 25.4;
 
@@ -83,6 +84,8 @@ export class CellBorderBgDialog extends ModalDialog {
   private cellIdx: number;
   private applyMode: 'each' | 'asOne';
   private selectionRange: CellRange | null;
+  /** undo 기록 라우팅용 (없으면 wasm 직접 호출 fallback). */
+  private services: CommandServices | undefined;
 
   // 탭 UI
   private tabs: HTMLButtonElement[] = [];
@@ -134,6 +137,7 @@ export class CellBorderBgDialog extends ModalDialog {
     cellIdx: number,
     applyMode: 'each' | 'asOne' = 'each',
     selectionRange: CellRange | null = null,
+    services?: CommandServices,
   ) {
     super('셀 테두리/배경', 460);
     this.wasm = wasm;
@@ -142,6 +146,7 @@ export class CellBorderBgDialog extends ModalDialog {
     this.cellIdx = cellIdx;
     this.applyMode = applyMode;
     this.selectionRange = selectionRange;
+    this.services = services;
   }
 
   show(): void {
@@ -1013,38 +1018,56 @@ export class CellBorderBgDialog extends ModalDialog {
         ? this.diagScopeRadios
         : this.borderScopeRadios;
     const scope = scopeRadios?.find(r => r.checked)?.value ?? 'selected';
-    if (this.applyMode === 'asOne') {
-      const range = scope === 'all'
-        ? (() => {
-          const dims = this.wasm.getTableDimensions(sec, ppi, ci);
-          return {
-            startRow: 0,
-            startCol: 0,
-            endRow: Math.max(0, dims.rowCount - 1),
-            endCol: Math.max(0, dims.colCount - 1),
-          };
-        })()
-        : this.selectionRange;
-      if (range) {
-        this.wasm.setCellZoneProperties(sec, ppi, ci, range, newProps as Partial<CellProperties>);
+    const applyProps = () => {
+      if (this.applyMode === 'asOne') {
+        const range = scope === 'all'
+          ? (() => {
+            const dims = this.wasm.getTableDimensions(sec, ppi, ci);
+            return {
+              startRow: 0,
+              startCol: 0,
+              endRow: Math.max(0, dims.rowCount - 1),
+              endCol: Math.max(0, dims.colCount - 1),
+            };
+          })()
+          : this.selectionRange;
+        if (range) {
+          this.wasm.setCellZoneProperties(sec, ppi, ci, range, newProps as Partial<CellProperties>);
+        } else {
+          this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
+        }
+      } else if (scope === 'all') {
+        const dims = this.wasm.getTableDimensions(sec, ppi, ci);
+        for (let i = 0; i < dims.cellCount; i++) {
+          this.wasm.setCellProperties(sec, ppi, ci, i, newProps as Partial<CellProperties>);
+        }
+      } else if (this.selectionRange) {
+        const cellIndices = this.selectedCellIndicesForRange(this.selectionRange);
+        const targetIndices = cellIndices.length > 0 ? cellIndices : [this.cellIdx];
+        for (const cellIdx of targetIndices) {
+          this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
+        }
       } else {
         this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
       }
-    } else if (scope === 'all') {
-      const dims = this.wasm.getTableDimensions(sec, ppi, ci);
-      for (let i = 0; i < dims.cellCount; i++) {
-        this.wasm.setCellProperties(sec, ppi, ci, i, newProps as Partial<CellProperties>);
-      }
-    } else if (this.selectionRange) {
-      const cellIndices = this.selectedCellIndicesForRange(this.selectionRange);
-      const targetIndices = cellIndices.length > 0 ? cellIndices : [this.cellIdx];
-      for (const cellIdx of targetIndices) {
-        this.wasm.setCellProperties(sec, ppi, ci, cellIdx, newProps as Partial<CellProperties>);
-      }
+    };
+    // 셀 테두리/배경 일괄 적용도 undo 대상이다 — 편집 라우터를 통과시켜
+    // 스냅샷 하나로 기록한다 (#1320 계약, picture-props-dialog(#2027)와 동일
+    // 패턴). services 미주입 환경에서만 직접 적용 fallback.
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'objectProps',
+        operation: () => {
+          applyProps();
+          return ih.getCursorPosition();
+        },
+      });
     } else {
-      this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newProps as Partial<CellProperties>);
+      applyProps();
+      this.eventBus.emit('document-changed');
     }
-    this.eventBus.emit('document-changed');
   }
 
   // ─── DOM 헬퍼 ────────────────────────────────

--- a/rhwp-studio/src/ui/table-cell-props-dialog.ts
+++ b/rhwp-studio/src/ui/table-cell-props-dialog.ts
@@ -3,6 +3,7 @@ import { appendSvgMarkup } from './dom-utils';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { CellProperties, TableProperties } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 const HWPUNIT_PER_MM = 7200 / 25.4;
 
@@ -126,6 +127,8 @@ export class TableCellPropsDialog extends ModalDialog {
   // 현재 속성값 캐시
   private cellProps!: CellProperties;
   private tableProps!: TableProperties;
+  /** undo 기록 라우팅용 (없으면 wasm 직접 호출 fallback). */
+  private services: CommandServices | undefined;
 
   constructor(
     wasm: WasmBridge,
@@ -133,6 +136,7 @@ export class TableCellPropsDialog extends ModalDialog {
     tableCtx: { sec: number; ppi: number; ci: number },
     cellIdx: number,
     mode: 'table' | 'cell' = 'cell',
+    services?: CommandServices,
   ) {
     super('표/셀 속성', 480);
     this.wasm = wasm;
@@ -140,6 +144,7 @@ export class TableCellPropsDialog extends ModalDialog {
     this.tableCtx = tableCtx;
     this.cellIdx = cellIdx;
     this.mode = mode;
+    this.services = services;
   }
 
   show(): void {
@@ -1374,8 +1379,6 @@ export class TableCellPropsDialog extends ModalDialog {
       }
     }
 
-    this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newCellProps as Partial<CellProperties>);
-
     // 표 속성 수정
     const pbValue = parseInt(this.tablePageBreakSelect.value, 10);
     const newTableProps: Record<string, unknown> = {
@@ -1434,9 +1437,27 @@ export class TableCellPropsDialog extends ModalDialog {
       }
     }
 
-    this.wasm.setTableProperties(sec, ppi, ci, newTableProps as Partial<TableProperties>);
-
-    this.eventBus.emit('document-changed');
+    const applyProps = () => {
+      this.wasm.setCellProperties(sec, ppi, ci, this.cellIdx, newCellProps as Partial<CellProperties>);
+      this.wasm.setTableProperties(sec, ppi, ci, newTableProps as Partial<TableProperties>);
+    };
+    // 표/셀 속성 변경도 undo 대상이다 — 편집 라우터를 통과시켜 스냅샷으로
+    // 기록한다 (#1320 계약, picture-props-dialog(#2027)와 동일 패턴).
+    // services 미주입 환경에서만 직접 적용 fallback.
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'objectProps',
+        operation: () => {
+          applyProps();
+          return ih.getCursorPosition();
+        },
+      });
+    } else {
+      applyProps();
+      this.eventBus.emit('document-changed');
+    }
   }
 
   // ─── "모두(A)" 일괄 여백 스피너 ─────────────────────

--- a/rhwp-studio/tests/table-props-undo.test.ts
+++ b/rhwp-studio/tests/table-props-undo.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 표/셀 속성·셀 테두리/배경 다이얼로그는 수십 개 속성을 한 번에 덮어쓰는
+// 문서 mutation 이므로 반드시 편집 라우터(executeOperation)를 통과해 undo
+// 스택에 기록되어야 한다 (#1320 계약, picture-props-dialog #2027 과 동일).
+
+test('표/셀 속성 다이얼로그 onConfirm은 스냅샷으로 undo 기록된다', () => {
+  const dialog = source('src/ui/table-cell-props-dialog.ts');
+  const start = dialog.indexOf('protected onConfirm');
+  assert.notEqual(start, -1, 'onConfirm not found');
+  const block = dialog.slice(start, dialog.indexOf('\n  private ', start + 1));
+
+  assert.match(
+    block,
+    /executeOperation\(\{\s*kind: 'snapshot',\s*operationType: 'objectProps'/,
+    '표/셀 속성 적용은 snapshot 명령으로 기록되어야 함',
+  );
+});
+
+test('셀 테두리/배경 다이얼로그 onConfirm은 스냅샷으로 undo 기록된다', () => {
+  const dialog = source('src/ui/cell-border-bg-dialog.ts');
+  const start = dialog.indexOf('protected onConfirm');
+  assert.notEqual(start, -1, 'onConfirm not found');
+  const block = dialog.slice(start, dialog.indexOf('\n  private ', start + 1));
+
+  assert.match(
+    block,
+    /executeOperation\(\{\s*kind: 'snapshot',\s*operationType: 'objectProps'/,
+    '셀 테두리/배경 적용은 snapshot 명령으로 기록되어야 함',
+  );
+});
+
+test('두 다이얼로그 진입점 모두 CommandServices를 전달한다', () => {
+  const table = source('src/command/commands/table.ts');
+  const format = source('src/command/commands/format.ts');
+
+  assert.match(
+    table,
+    /new TableCellPropsDialog\(services\.wasm, services\.eventBus, tableCtx, 0, 'table', services\)/,
+    'table:cell-props(표 선택) 진입점에서 services 전달 필요',
+  );
+  assert.match(
+    table,
+    /new TableCellPropsDialog\(services\.wasm, services\.eventBus, tableCtx, pos\.cellIndex, 'cell', services\)/,
+    'table:cell-props(셀 커서) 진입점에서 services 전달 필요',
+  );
+  assert.match(
+    format,
+    /new TableCellPropsDialog\(services\.wasm, services\.eventBus, tableCtx, pos\.cellIndex, 'table', services\)/,
+    'format:object-properties 진입점에서 services 전달 필요',
+  );
+  const borderDialogCalls = table.match(/new CellBorderBgDialog\([\s\S]*?\);/g) ?? [];
+  assert.equal(borderDialogCalls.length, 2, 'CellBorderBgDialog 진입점 2곳');
+  for (const call of borderDialogCalls) {
+    assert.match(call, /services,\s*\);$/, '셀 테두리/배경 진입점에서 services 전달 필요');
+  }
+});


### PR DESCRIPTION
관련 이슈: #2053

## 문제
표/셀 속성·셀 테두리/배경 다이얼로그의 변경이 undo 스택에 기록되지 않아 Ctrl+Z 복구가 불가능하다(#1320 계약 위반). 수십 개 속성을 한 번에 덮어쓰므로 수동 복원도 사실상 불가능하다.

## 원인
`table-cell-props-dialog.ts`와 `cell-border-bg-dialog.ts`의 onConfirm이 wasm setter(`setCellProperties`/`setTableProperties`/`setCellZoneProperties`)를 직접 호출하고 `document-changed`만 emit한다 — `CommandHistory` 기록 경로(executeOperation)를 거치지 않는다. #2027이 그림 속성 다이얼로그를 고친 것과 동일 클래스의 잔여 결함이다.

## 변경
- 두 onConfirm을 `executeOperation({kind:'snapshot', operationType:'objectProps'})`로 라우팅한다 (picture-props-dialog #2027과 동일 패턴).
- 두 다이얼로그 생성자에 `CommandServices` 옵션을 주입하고, 진입점 5곳(table:cell-props ×2, table:border-each/one, format:object-properties)에서 전달한다. services 미주입 환경은 직접 적용 fallback.
- 소스 검사 회귀 테스트 3건 (`tests/table-props-undo.test.ts`).

## 검증
- rhwp-studio `npm test` 178건 통과(신규 3건 포함), `tsc --noEmit` 통과 (devel add14126 기준).

## 범위 외
수식 속성 다이얼로그(equation-props-dialog.ts)의 동종 미기록은 별도 후속.
