### PR TITLE
Task #2054: 배치 버튼 미선택 시 개체의 원래 textWrap 보존

### DIFF
--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -2571,7 +2571,12 @@ export class PicturePropsDialog {
 
   private getSelectedWrap(): string {
     const idx = this.wrapBtns.findIndex(b => b.classList.contains('active'));
-    return idx >= 0 ? this.wrapValues[idx] : 'Square';
+    if (idx >= 0) return this.wrapValues[idx];
+    // 활성 버튼 없음 = 현재 배치가 UI 버튼에 매핑되지 않는 값('Through' 등,
+    // populateFromProps 의 indexOf = -1). 여기서 'Square' 로 대체하면 사용자가
+    // 아무것도 바꾸지 않고 확인만 눌러도 diff 가 생겨 배치가 조용히 변경·
+    // 저장되므로, 개체의 원래 배치 값을 그대로 보존한다.
+    return this.props?.textWrap ?? 'Square';
   }
 
   /** 캡션 direction + vertAlign → 3×3 그리드 인덱스 */

--- a/rhwp-studio/tests/wrap-through-preserve.test.ts
+++ b/rhwp-studio/tests/wrap-through-preserve.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 개체 속성 다이얼로그의 wrapValues 에는 core TextWrap 의 'Through'(빈 공간
+// 채움)가 없어, Through 배치 개체의 속성창을 열면 배치 버튼이 전부 비활성이
+// 된다. 이때 getSelectedWrap() 이 기본값 'Square' 를 반환하면 사용자가 아무
+// 것도 바꾸지 않고 확인만 눌러도 textWrap diff 가 전송되어 배치가 조용히
+// 변경·저장된다. 활성 버튼이 없으면 개체의 원래 배치 값을 보존해야 한다.
+
+test('배치 버튼 미선택 시 getSelectedWrap은 원래 textWrap을 보존한다', () => {
+  const dialog = source('src/ui/picture-props-dialog.ts');
+  const start = dialog.indexOf('private getSelectedWrap');
+  assert.notEqual(start, -1, 'getSelectedWrap not found');
+  const block = dialog.slice(start, dialog.indexOf('\n  private ', start + 1));
+
+  assert.match(
+    block,
+    /return this\.props\?\.textWrap \?\? 'Square';/,
+    '활성 버튼이 없으면 props.textWrap 을 반환해 의도치 않은 배치 변경을 막아야 함',
+  );
+  assert.doesNotMatch(
+    block,
+    /idx >= 0 \? this\.wrapValues\[idx\] : 'Square'/,
+    "무조건 'Square' 폴백은 Through 배치를 조용히 덮어쓴다",
+  );
+});


### PR DESCRIPTION
관련 이슈: #2054

## 문제
Through(빈 공간 채움) 배치 개체의 속성창에서 아무것도 바꾸지 않고 확인만 눌러도 배치가 어울림(Square)으로 조용히 바뀌고, 저장 시 원본 배치가 파손된다.

## 원인
다이얼로그 `wrapValues`(picture-props-dialog.ts:98)에 core `TextWrap::Through`("Through")가 없어, populateFromProps의 indexOf가 -1이 되어 활성 배치 버튼이 세워지지 않는다. 이 상태에서 `getSelectedWrap()`이 기본값 'Square'를 반환해 `'Square' !== 'Through'` diff가 전송된다. rhwp-studio 전체에 'Through' 문자열이 0건이라 TS 계층 보상 경로도 없다.

## 변경
활성 배치 버튼이 없으면 `getSelectedWrap()`이 기본값 'Square' 대신 개체의 원래 `props.textWrap`을 반환하도록 한다 — 무변경 확인이 무해해진다. 소스 검사 회귀 테스트 1건 (`tests/wrap-through-preserve.test.ts`).

## 검증
- rhwp-studio `npm test` 176건 통과(신규 1건 포함), `tsc --noEmit` 통과 (devel add14126 기준).

## 범위 외
UI에서 Through를 표시/선택할 수 없는 문제(버튼 라벨 "빈 공간 채움"이 'Tight'로 매핑)는 한컴 정답 매핑(oracle) 대조가 필요해 별도 후속으로 분리한다.
