### PR TITLE
Issue #1842: CellBreak 표 부재-LINE_SEG 셀 라인높이 em 교정 (과분할 213→159, 한글 162)

### DIFF
--- a/mydocs/report/task_m100_1842_cellbreak_report.md
+++ b/mydocs/report/task_m100_1842_cellbreak_report.md
@@ -1,0 +1,42 @@
+# 최종 결과보고 — #1842 CellBreak 초대형 표 부재-LINE_SEG 셀 라인높이 팽창
+
+브랜치 `fix/1842-cellbreak-synthetic-em` (base: `fix/2063` — issue2063 픽스처 공유). #2063에서 인계된 과분할(+51).
+
+## 1. 근본 원인 (PDF 그라운드트루스 + 계측 확정)
+
+`21914299 화성시 [별표2]`(5,277행×10열 CellBreak) 데이터 셀은 **저장 LINE_SEG 부재**(`line_segs.is_empty()`). composer(composer.rs:527)가 placeholder `line_height=400` 로 합성 → `corrected_line_height(5.33, 폰트 13.33, 160%)` 가 `raw_lh<max_fs` 라 **`max_fs×1.6=21.33px`** 반환 → 행 **25px**.
+
+한글 2022는 동일 셀을 **폰트 em(13.33)+pad = 17px** 로 렌더(line-spacing 160%는 줄 사이 간격이지 단행 박스 높이가 아님).
+
+**측정 대조** (한글 PDF 162p vs rhwp 213p, 동일 page 80, A4 가로):
+| | 행높이 | 쪽당 행수 |
+|---|---|---|
+| 한글 | median **17.07px** | 41 |
+| rhwp(수정 전) | median **25.07px** | 29 |
+
+## 2. 수정
+
+부재-LINE_SEG 셀 라인높이를 **폰트 em(max_fs)** 으로 (hwp3 synthetic 선례 `corrected_line_height_for_variant_synthetic` 확장). **CellBreak 표 한정** — RowBreak 규제영향분석서(76076 등)는 현행 ×1.6 이 공식 PDF 쪽수와 정합(#1891)이라 제외.
+
+- 적용: measure(height_measurer 3사이트) + cut(table_layout cell_units) — `matches!(table.page_break, CellBreak)` 게이트.
+- 판별자: `line_segs.is_empty() && !text.is_empty() && CellBreak`.
+- `src/renderer/height_measurer.rs`, `src/renderer/layout/table_layout.rs`.
+
+## 3. 검증
+
+| 항목 | 결과 |
+|---|---|
+| 21914299 (CellBreak) 페이지 | **213 → 159** (한글 162, −3) |
+| 렌더 행높이 (PDF page 80) | **17.07px, 41행/쪽** (한글 정합) |
+| 76076 (RowBreak) #1891 | **82 불변** (공식 PDF, 회귀 0) |
+| 전체 테스트 | **2922 passed / 0 failed** |
+| 신규 회귀 테스트 | `issue_1842_cellbreak_synthetic_lineheight_em_not_inflated` |
+| clippy | clean |
+
+## 4. 잔여
+
+−3쪽(159 vs 162)은 빈 셀의 저장 cell.height(20px) floor(한글 content 17px) 2차 잔차 — 별건. 본 수정은 지배 기전(부재-LINE_SEG ×1.6 팽창) 해소.
+
+## 5. 판별자 정제 이력 (#1926 방법론)
+
+1차 일반화(모든 synthetic → em)는 **76076(RowBreak) 82→80 회귀**(#1891 반례)로 검출 → **CellBreak 한정**으로 정제. 반례가 판별 기준을 좁힌 사례.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -971,6 +971,13 @@ impl HeightMeasurer {
                                 let cell_ls_type = para_style
                                     .map(|s| s.line_spacing_type)
                                     .unwrap_or(crate::model::style::LineSpacingType::Percent);
+                                // [Issue #1842] 저장 LINE_SEG 부재 셀 문단은 composer 가
+                                // placeholder(line_height=400) 로 합성 → corrected 가
+                                // max_fs*ls% 로 팽창(단행 박스에 줄간격 오적용). 한글은 폰트
+                                // em 으로 렌더 → synthetic 시 em(max_fs). hwp3 synthetic 선례 확장.
+                                let synthetic_line = p.line_segs.is_empty()
+                                    && !p.text.is_empty()
+                                    && matches!(table.page_break, TablePageBreak::CellBreak);
                                 let line_count = comp.lines.len();
                                 let lines_total: f64 = comp
                                     .lines
@@ -989,11 +996,12 @@ impl HeightMeasurer {
                                                     .unwrap_or(0.0)
                                             })
                                             .fold(0.0f64, f64::max);
-                                        let h = crate::renderer::corrected_line_height(
+                                        let h = crate::renderer::corrected_line_height_for_variant_synthetic(
                                             raw_lh,
                                             max_fs,
                                             cell_ls_type,
                                             cell_ls_val,
+                                            synthetic_line,
                                         );
                                         // [Task #874 #4 / #1086] CellBreak/TAC 표는 기존
                                         // trailing geometry 를 보존(aift.hwp pi=123, KTX TOC),
@@ -1241,6 +1249,13 @@ impl HeightMeasurer {
                                 let cell_ls_type = para_style
                                     .map(|s| s.line_spacing_type)
                                     .unwrap_or(crate::model::style::LineSpacingType::Percent);
+                                // [Issue #1842] 저장 LINE_SEG 부재 셀 문단은 composer 가
+                                // placeholder(line_height=400) 로 합성 → corrected 가
+                                // max_fs*ls% 로 팽창(단행 박스에 줄간격 오적용). 한글은 폰트
+                                // em 으로 렌더 → synthetic 시 em(max_fs). hwp3 synthetic 선례 확장.
+                                let synthetic_line = p.line_segs.is_empty()
+                                    && !p.text.is_empty()
+                                    && matches!(table.page_break, TablePageBreak::CellBreak);
                                 let line_count = comp.lines.len();
                                 let lines_total: f64 = comp
                                     .lines
@@ -1259,11 +1274,12 @@ impl HeightMeasurer {
                                                     .unwrap_or(0.0)
                                             })
                                             .fold(0.0f64, f64::max);
-                                        let h = crate::renderer::corrected_line_height(
+                                        let h = crate::renderer::corrected_line_height_for_variant_synthetic(
                                             raw_lh,
                                             max_fs,
                                             cell_ls_type,
                                             cell_ls_val,
+                                            synthetic_line,
                                         );
                                         // [Task #874 #4 / #1086] CellBreak/TAC 표는 기존
                                         // trailing geometry 를 보존(aift.hwp pi=123, KTX TOC),
@@ -1437,6 +1453,10 @@ impl HeightMeasurer {
                             let cell_ls_type = para_style
                                 .map(|s| s.line_spacing_type)
                                 .unwrap_or(crate::model::style::LineSpacingType::Percent);
+                            // [Issue #1842] 부재 LINE_SEG 셀 → em(max_fs), max_fs*ls% 팽창 방지.
+                            let synthetic_line = p.line_segs.is_empty()
+                                && !p.text.is_empty()
+                                && matches!(table.page_break, TablePageBreak::CellBreak);
                             let line_count = comp.lines.len();
                             for (li, line) in comp.lines.iter().enumerate() {
                                 let raw_lh = hwpunit_to_px(line.line_height, self.dpi);
@@ -1451,12 +1471,14 @@ impl HeightMeasurer {
                                             .unwrap_or(0.0)
                                     })
                                     .fold(0.0f64, f64::max);
-                                let h = crate::renderer::corrected_line_height(
-                                    raw_lh,
-                                    max_fs,
-                                    cell_ls_type,
-                                    cell_ls_val,
-                                );
+                                let h =
+                                    crate::renderer::corrected_line_height_for_variant_synthetic(
+                                        raw_lh,
+                                        max_fs,
+                                        cell_ls_type,
+                                        cell_ls_val,
+                                        synthetic_line,
+                                    );
                                 let ls = hwpunit_to_px(line.line_spacing, self.dpi);
                                 // 셀의 마지막 줄(마지막 문단의 마지막 줄)은 ls 제외
                                 let is_cell_last_line = is_last_para && li + 1 == line_count;

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4928,14 +4928,19 @@ impl LayoutEngine {
                                 }
                             })
                             .fold(0.0f64, f64::max);
+                        // [Issue #1842] 부재 LINE_SEG 셀(HWP5 native 포함)은 em(max_fs).
+                        // [Issue #1842] 부재 LINE_SEG 셀의 placeholder(400)→corrected
+                        // max_fs*ls% 팽창(행 25px vs 한글 17px)을 em 으로 교정. **CellBreak 표
+                        // 한정** — RowBreak 규제영향분석서(76076 등)는 현행 ×1.6 이 공식 PDF
+                        // 쪽수와 정합(#1891)이라 제외. (HWPX synthetic 은 4859 가드 분기.)
                         crate::renderer::corrected_line_height_for_variant_synthetic(
                             raw_lh,
                             max_fs,
                             ps.line_spacing_type,
                             ps.line_spacing,
-                            self.is_hwp3_variant.get()
-                                && p.line_segs.is_empty()
-                                && !p.text.is_empty(),
+                            p.line_segs.is_empty()
+                                && !p.text.is_empty()
+                                && matches!(table.page_break, TablePageBreak::CellBreak),
                         )
                     }
                     None => raw_lh,

--- a/tests/issue_1842.rs
+++ b/tests/issue_1842.rs
@@ -79,3 +79,27 @@ fn issue_1842_cell_tac_only_line_keeps_stored_height() {
          (max_fs=0 축소 퇴화 회귀: 종전 ~23px)"
     );
 }
+
+/// [Issue #1842 / #2063 인계] CellBreak 초대형 표의 **저장 LINE_SEG 부재 셀** 라인높이 회귀.
+///
+/// `samples/issue2063_huge_cellbreak_table.hwp` (화성시 [별표2], 5,277행×10열 CellBreak)의
+/// 데이터 셀들은 저장 LINE_SEG 가 없어(`line_segs.is_empty()`) composer 가 placeholder
+/// (line_height=400) 로 합성한다. 종전엔 `corrected_line_height` 가 이를 `max_fs*ls%(160%)`
+/// 로 팽창(행 25px)해 rhwp 213쪽으로 과분할(한글 2022 = 162쪽). 수정: CellBreak 표의
+/// synthetic 셀 라인높이를 폰트 em(max_fs)으로 — 행 17px, 41행/쪽(한글 정합). RowBreak
+/// 규제영향분석서(76076 등)는 현행 유지(#1891 공식 PDF 쪽수 불변).
+#[test]
+fn issue_1842_cellbreak_synthetic_lineheight_em_not_inflated() {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join("samples/issue2063_huge_cellbreak_table.hwp");
+    let data = fs::read(&path).unwrap_or_else(|e| panic!("read: {e}"));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&data).expect("parse");
+    let pages = doc.page_count();
+    // 수정 전 213쪽(synthetic 셀 ×1.6 팽창), 수정 후 159쪽. 한글 2022 = 162쪽.
+    // 하한(150)은 과소, 상한(175)은 synthetic 팽창 재발(→213)을 잡는다.
+    assert!(
+        (150..=175).contains(&pages),
+        "issue1842: CellBreak synthetic 셀 페이지 수 {pages} 가 기대(150..=175, 한글 162) 밖 \
+         — 부재 LINE_SEG 셀 라인높이 팽창(수정 전 213) 회귀 의심",
+    );
+}


### PR DESCRIPTION
## 요약

#1842/#1937 라인높이 드리프트 계열 중 **CellBreak 초대형 표의 부재-LINE_SEG 셀 팽창**을 교정한다. #2063에서 인계된 과분할(`21914299 화성시 [별표2]`: rhwp 213p vs 한글 2022 162p).

> **스택**: 본 PR은 #2065(fix/2063, 성능 O(n²) + issue2063 픽스처)를 base 로 한다. #2065 머지 후 diff 가 #1842 커밋만으로 축소된다.

## 근본 원인 (PDF 그라운드트루스 + 계측 확정)

CellBreak 표(5,277행×10열)의 데이터 셀은 **저장 LINE_SEG 부재**(`line_segs.is_empty()`). composer 가 placeholder `line_height=400` 로 합성 → `corrected_line_height(5.33, 폰트 13.33, 160%)` 가 `raw_lh<max_fs` 라 **`max_fs×1.6=21.33px`** 반환 → 행 **25px**. 한글은 폰트 **em(13.33)+pad = 17px** 렌더(line-spacing 160%는 줄 사이 간격이지 단행 박스 높이 아님).

| (page 80, A4 가로) | 행높이 | 쪽당 행수 |
|---|---|---|
| 한글 2022 | median **17.07px** | 41 |
| rhwp(수정 전) | median **25.07px** | 29 |

## 수정

부재-LINE_SEG 셀 라인높이를 **폰트 em(max_fs)** 으로 (hwp3 synthetic 선례 `corrected_line_height_for_variant_synthetic` 확장). **CellBreak 표 한정** — RowBreak 규제영향분석서(76076 등)는 현행 ×1.6 이 공식 PDF 쪽수와 정합(#1891)이라 제외.

- 판별자: `line_segs.is_empty() && !text.is_empty() && matches!(page_break, CellBreak)`.
- 적용: measure(height_measurer) + cut(cell_units). `src/renderer/height_measurer.rs`, `table_layout.rs`.

## 검증

- **21914299: 213 → 159** (한글 162). 렌더 **17.07px, 41행/쪽**(한글 정합).
- **76076(RowBreak) #1891: 82 불변** (공식 PDF, 회귀 0).
- 전체 테스트 **2922 passed / 0 failed** (roundtrip/snapshot baseline 포함 = 코퍼스 회귀 게이트).
- 신규 회귀 테스트 `issue_1842_cellbreak_synthetic_lineheight_em_not_inflated`. clippy clean.

## 판별자 정제 (#1926 방법론)

1차 일반화(모든 synthetic → em)는 **76076 82→80 회귀**(#1891 반례)로 검출 → **CellBreak 한정**으로 정제.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
Closes #2070 (본 +51 과분할 전용 추적 이슈 — 213→159 해결, 잔여 −3쪽은 저우선 별건).