### PR TITLE
Task #2077: 수식 속성 다이얼로그 undo 스냅샷 라우팅 (#2028 수식 판)

### DIFF
--- a/rhwp-studio/src/command/commands/format.ts
+++ b/rhwp-studio/src/command/commands/format.ts
@@ -468,7 +468,7 @@ export const formatCommands: CommandDef[] = [
         const ref = ih.getSelectedPictureRef();
         if (!ref) return;
         if (ref.type === 'equation') {
-          const dialog = new EquationPropertiesDialog(services.wasm, services.eventBus);
+          const dialog = new EquationPropertiesDialog(services.wasm, services.eventBus, services);
           dialog.open(ref.sec, ref.ppi, ref.ci, ref.cellIdx, ref.cellParaIdx, ref.noteRef);
           return;
         }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -316,7 +316,7 @@ export const insertCommands: CommandDef[] = [
       if (!ref) return;
       if (ref.type === 'equation') {
         if (!equationPropsDialog) {
-          equationPropsDialog = new EquationPropertiesDialog(services.wasm, services.eventBus);
+          equationPropsDialog = new EquationPropertiesDialog(services.wasm, services.eventBus, services);
         }
         equationPropsDialog.open(ref.sec, ref.ppi, ref.ci, ref.cellIdx, ref.cellParaIdx, ref.noteRef);
         return;

--- a/rhwp-studio/src/ui/equation-props-dialog.ts
+++ b/rhwp-studio/src/ui/equation-props-dialog.ts
@@ -1,6 +1,7 @@
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { EventBus } from '@/core/event-bus';
 import type { EquationProperties, NoteControlRef } from '@/core/types';
+import type { CommandServices } from '@/command/types';
 import { EquationEditorDialog } from './equation-editor-dialog';
 import { enableDialogDrag } from './dialog-drag';
 
@@ -69,6 +70,7 @@ export class EquationPropertiesDialog {
   constructor(
     private wasm: WasmBridge,
     private eventBus: EventBus,
+    private services?: CommandServices,
   ) {}
 
   open(sec: number, para: number, ci: number, cellIdx?: number, cellParaIdx?: number, noteRef?: NoteControlRef): void {
@@ -338,13 +340,32 @@ export class EquationPropertiesDialog {
     if (fontName && fontName !== this.props.fontName) updated.fontName = fontName;
 
     if (Object.keys(updated).length > 0) {
-      try {
+      const applyProps = () => {
         if (this.noteRef) {
           this.wasm.setNoteEquationProperties(this.noteRef, updated);
         } else {
           this.wasm.setEquationProperties(this.sec, this.para, this.ci, this.cellIdx, this.cellParaIdx, updated);
         }
-        this.eventBus.emit('document-changed');
+      };
+      try {
+        // [Issue #2077] 수식 속성 변경도 undo 대상이다 — 그림 속성 다이얼로그(#1320/#2028)와 동일하게
+        // 편집 라우터(executeOperation)를 통과시켜 스냅샷으로 기록한다. 기존에는 wasm
+        // setter 직접 호출 + document-changed emit 만 수행되어 Ctrl+Z 로 복구되지 않았다.
+        // services 미주입 환경에서만 직접 적용 fallback.
+        const ih = this.services?.getInputHandler();
+        if (ih) {
+          ih.executeOperation({
+            kind: 'snapshot',
+            operationType: 'objectProps',
+            operation: () => {
+              applyProps();
+              return ih.getCursorPosition();
+            },
+          });
+        } else {
+          applyProps();
+          this.eventBus.emit('document-changed');
+        }
       } catch (err) {
         console.warn('[EquationProperties] 수식 속성 설정 실패:', err);
       }

--- a/rhwp-studio/tests/equation-props-undo.test.ts
+++ b/rhwp-studio/tests/equation-props-undo.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 수식 속성 다이얼로그는 문서를 mutate 하므로 그림 속성 다이얼로그(#2028)와 동일하게
+// 편집 라우터(executeOperation)를 통과해 undo 스택에 기록되어야 한다.
+// (기존에는 wasm setEquationProperties 직접 호출 + document-changed emit 만 수행되어,
+// 수식 속성 변경이 Ctrl+Z 로 복구되지 않았다.)
+
+test('수식 속성 다이얼로그 apply는 스냅샷으로 undo 기록된다', () => {
+  const dialog = source('src/ui/equation-props-dialog.ts');
+
+  const handleOkStart = dialog.indexOf('private handleOk');
+  assert.notEqual(handleOkStart, -1, 'handleOk not found');
+  const handleOk = dialog.slice(handleOkStart, dialog.indexOf('\n  private ', handleOkStart + 1));
+
+  assert.match(
+    handleOk,
+    /executeOperation\(\{\s*kind: 'snapshot',\s*operationType: 'objectProps'/,
+    '수식 속성 적용은 편집 라우터의 snapshot 명령으로 기록되어야 함',
+  );
+});
+
+test('수식 속성 다이얼로그 생성자는 CommandServices를 전달받는다', () => {
+  const insert = source('src/command/commands/insert.ts');
+  const format = source('src/command/commands/format.ts');
+
+  assert.match(
+    insert,
+    /new EquationPropertiesDialog\(services\.wasm, services\.eventBus, services\)/,
+    'insert 진입점에서 services 전달 필요',
+  );
+  assert.match(
+    format,
+    /new EquationPropertiesDialog\(services\.wasm, services\.eventBus, services\)/,
+    'format:object-properties 진입점에서 services 전달 필요',
+  );
+});


### PR DESCRIPTION
관련 이슈: #2077

## 문제

수식 속성 다이얼로그의 속성 변경이 undo 스택에 기록되지 않아 Ctrl+Z로 복구되지 않는다(그림 다이얼로그 #2028의 수식 판).

## 원인

`rhwp-studio/src/ui/equation-props-dialog.ts` `handleOk()`가 `wasm.setEquationProperties`를 직접 호출 + `document-changed` emit만 수행하고, 편집 라우터 `executeOperation` 스냅샷 경로를 거치지 않는다. 그림 다이얼로그는 #2028에서 이미 `executeOperation({kind:'snapshot', operationType:'objectProps'})`로 라우팅하도록 수정됨.

## 변경

`picture-props-dialog.ts`(#2028)와 동일 패턴 적용:
- `EquationPropertiesDialog` 생성자에 `services?: CommandServices` 주입.
- `handleOk()`의 속성 적용을 `ih.executeOperation({kind:'snapshot', operationType:'objectProps', operation})` 경유로 라우팅(services 미주입 환경은 직접 적용 fallback 유지).
- `format.ts`·`insert.ts`의 다이얼로그 인스턴스화에 `services` 전달.

추가 테스트: `rhwp-studio/tests/equation-props-undo.test.ts` — `picture-props-undo.test.ts`(#2028)를 미러링. handleOk가 snapshot 명령을 통과하는지 + 두 진입점이 services를 전달하는지 소스 검증.

## 검증

devel `073c8ae7` 기준.

- **수정 전 실패 증명**: 수정 전 `handleOk`는 `setEquationProperties` 직접 호출(no executeOperation)이라 추가 테스트의 `/executeOperation\(\{ kind: 'snapshot', operationType: 'objectProps'/` 매칭 실패. 수정 후 통과.
- `node --test tests/*.test.ts` 전체 183개 통과(신규 2 포함), 회귀 없음.
- `tsc --noEmit`: 변경 3파일 타입 에러 0. (전체 tsc의 `@wasm/rhwp.js` 모듈 부재 2건은 worktree에서 WASM 미빌드한 환경 문제로 변경과 무관.)

## 범위 외

수식 편집기(스크립트 편집) 경로의 undo는 별도.
