### PR TITLE
Issue #2017: HWPX 재직렬화 시 curSz=0 sentinel 복원 (IR-invisible 충실도)

### DIFF
--- a/mydocs/report/task_m100_2017_report.md
+++ b/mydocs/report/task_m100_2017_report.md
@@ -1,0 +1,27 @@
+# 최종 결과보고 — #2017 curSz=0 sentinel HWPX 재직렬화 충실도 복원
+
+브랜치 `fix/2017-cursz-fidelity` (base: devel).
+
+## 1. 배경
+#2017(IR-invisible HWPX 저장 페이지붕괴, #1589 잔여). 구조 IR diff=0인데 한글 재열림 시 페이지수 변동.
+
+## 2. 근본원인 (XML orig↔rt 직접 대조, 오라클 불요)
+`materialize_shape_current_size_from_original`(`src/parser/hwpx/section.rs`)가 HWPX **파싱** 시 `curSz.w/h==0 && orgSz>0`이면 curSz를 orgSz로 치환(HWP5 저장·렌더가 실크기 필요). 이 치환이 IR을 오염 → **HWPX 재직렬화가 원본 `curSz=0` 대신 materialize값 기록** → 한글이 도형 geometry를 다르게 읽음.
+
+계측(21965845 응시원서): 원본 `curSz 0×0`(×12)·`44752×0`(×2)이 rt에서 `2794×2792`·`44752×100`으로 변형.
+
+## 3. 수정 (충실도 복원, materialize 유지)
+`ShapeComponentAttr`에 `current_width_was_zero`/`current_height_was_zero` 플래그 추가. 파싱 materialize 시 dimension별로 기록. **HWPX 직렬화(picture.rs·shape.rs의 write_cur_sz 2곳)만** 플래그가 서면 `0` 출력해 원본 sentinel 복원. **HWP5 저장(control.rs 독립 materialize)·rhwp 렌더는 materialize된 실크기 그대로 사용**(무영향).
+
+변경: `src/model/shape.rs`(+필드), `src/parser/hwpx/section.rs`(플래그 set), `src/serializer/hwpx/picture.rs`·`shape.rs`(플래그 반영).
+
+## 4. 검증
+| 항목 | 결과 |
+|---|---|
+| curSz 충실도 | orig↔rt **완전 일치** (`0×0`×12, `44752×0`×2 복원) |
+| 구조 roundtrip | **[PASS] diff=0 r2=0** |
+| rhwp 렌더 | orig=rt=**3** (불변) |
+| 전체 테스트 | **2945 / 0** (#1389 그림 curSz·roundtrip baseline 포함) |
+
+## 5. 판정
+HWPX roundtrip이 curSz=0 sentinel을 정확히 보존 → #1589-계열 IR-invisible 직렬화 드롭 1종 해소. 한글 페이지 delta 확증은 원본 collapse repro(코퍼스 ID 재배정으로 드리프트) + 한글 COM 오라클 필요(별도). 충실도 개선은 roundtrip이 입력을 보존해야 한다는 원칙상 그 자체로 정당.

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -208,6 +208,12 @@ pub struct ShapeComponentAttr {
     pub current_width: u32,
     /// 현재 높이
     pub current_height: u32,
+    /// [#2017] HWPX 원본이 `curSz width="0"`을 기록했고 파싱 시 orgSz로 materialize된 경우 true.
+    /// materialize는 렌더/HWP5 저장이 실크기를 필요로 하기 때문에 유지하되, HWPX 재직렬화는
+    /// 이 플래그로 원본 `0` sentinel을 복원해 roundtrip 충실도를 보존한다.
+    pub current_width_was_zero: bool,
+    /// [#2017] HWPX 원본이 `curSz height="0"`을 기록했고 파싱 시 orgSz로 materialize된 경우 true.
+    pub current_height_was_zero: bool,
     /// 뒤집기 속성 원본 값 (bit 0: 수평, bit 1: 수직, 상위 비트 보존)
     pub flip: u32,
     /// 수평 뒤집기
@@ -250,6 +256,8 @@ impl Default for ShapeComponentAttr {
             original_height: 0,
             current_width: 0,
             current_height: 0,
+            current_width_was_zero: false,
+            current_height_was_zero: false,
             flip: 0,
             horz_flip: false,
             vert_flip: false,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2705,12 +2705,15 @@ fn materialize_shape_current_size_from_original(
 ) {
     if shape_attr.current_width == 0 && shape_attr.original_width > 0 {
         shape_attr.current_width = shape_attr.original_width;
+        // [#2017] HWPX 재직렬화 시 원본 curSz=0 을 복원하기 위해 materialize 여부를 기록.
+        shape_attr.current_width_was_zero = true;
         if common.width == 0 {
             common.width = shape_attr.original_width;
         }
     }
     if shape_attr.current_height == 0 && shape_attr.original_height > 0 {
         shape_attr.current_height = shape_attr.original_height;
+        shape_attr.current_height_was_zero = true;
         if common.height == 0 {
             common.height = shape_attr.original_height;
         }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -129,12 +129,17 @@ fn write_org_sz<W: Write>(
 fn write_cur_sz<W: Write>(w: &mut Writer<W>, p: &Picture) -> Result<(), SerializeError> {
     // [#1389] 현재 크기는 shape_attr.current_width/height (IR 보존). 0 이면 common(sz)
     // 폴백 — 원본도 그 경우 sz=curSz. 종전 common 직출이라 current≠sz 인 pic 변형.
-    let cw = if p.shape_attr.current_width > 0 {
+    // [#2017] 파싱 시 orgSz로 materialize된 dimension 은 원본 `0` sentinel 로 복원.
+    let cw = if p.shape_attr.current_width_was_zero {
+        0
+    } else if p.shape_attr.current_width > 0 {
         p.shape_attr.current_width
     } else {
         p.common.width
     };
-    let ch = if p.shape_attr.current_height > 0 {
+    let ch = if p.shape_attr.current_height_was_zero {
+        0
+    } else if p.shape_attr.current_height > 0 {
         p.shape_attr.current_height
     } else {
         p.common.height

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -536,8 +536,19 @@ fn write_cur_sz<W: Write>(
     w: &mut Writer<W>,
     sa: &ShapeComponentAttr,
 ) -> Result<(), SerializeError> {
-    let width = sa.current_width.to_string();
-    let height = sa.current_height.to_string();
+    // [#2017] 파싱 시 orgSz로 materialize된 dimension 은 원본 `0` sentinel 로 복원.
+    let width = if sa.current_width_was_zero {
+        0
+    } else {
+        sa.current_width
+    }
+    .to_string();
+    let height = if sa.current_height_was_zero {
+        0
+    } else {
+        sa.current_height
+    }
+    .to_string();
     empty_tag(w, "hp:curSz", &[("width", &width), ("height", &height)])
 }
 


### PR DESCRIPTION
## 요약

#2017(IR-invisible HWPX 저장 페이지붕괴, #1589 잔여)의 직렬화 드롭 1종을 해소한다. HWPX roundtrip 이 원본 `curSz=0` sentinel 을 보존하지 못하던 충실도 손실을 복원한다.

## 근본원인 (XML orig↔rt 직접 대조 — 오라클 불요)

`materialize_shape_current_size_from_original`(`src/parser/hwpx/section.rs`)이 HWPX **파싱** 시 `curSz.w/h==0 && orgSz>0`이면 curSz 를 orgSz 로 치환한다(HWP5 저장에서 curSz0→effective0 회피 + 렌더가 실크기 필요). 이 치환이 **파싱 시점에 IR 을 오염** → HWPX 재직렬화가 원본 `curSz=0` 대신 materialize 값을 기록 → 한글이 도형 geometry 를 다르게 읽어 페이지수가 변동한다.

계측(21965845 응시원서): 원본 `curSz 0×0`(×12)·`44752×0`(×2)이 rt 에서 `2794×2792`·`44752×100`으로 변형됨.

## 수정

`ShapeComponentAttr` 에 `current_width_was_zero`/`current_height_was_zero` 플래그 추가. 파싱 materialize 시 dimension 별로 기록하고, **HWPX 직렬화(`picture.rs`·`shape.rs` 의 `write_cur_sz` 2곳)만** 플래그가 서면 `0` 을 출력해 원본 sentinel 을 복원한다. **HWP5 저장(`control.rs` 독립 materialize)·rhwp 렌더는 materialize 된 실크기를 그대로 사용**(무영향).

## 검증

| 항목 | 결과 |
|---|---|
| curSz 충실도 | orig↔rt **완전 일치**(`0×0`×12, `44752×0`×2 복원) |
| 구조 roundtrip | **[PASS] diff=0 r2=0** |
| rhwp 렌더 | orig=rt=**3** (불변) |
| 전체 테스트 | **2945 / 0** (#1389 그림 curSz·roundtrip baseline 포함) |

한글 페이지 delta 확증은 원본 collapse repro(코퍼스 ID 재배정으로 드리프트) + 한글 COM 오라클이 필요(별도). 충실도 개선은 roundtrip 이 입력을 보존해야 한다는 원칙상 그 자체로 정당하다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
