### PR TITLE
Issue #2145: 개요번호 ^n/^N 레벨 경로 자동코드 구현 — 리터럴 '^N' 출력 수정

### DIFF
--- a/mydocs/plans/task_m100_2145.md
+++ b/mydocs/plans/task_m100_2145.md
@@ -1,0 +1,44 @@
+# 수행계획서 — Task M100 #2145: 개요번호 `^n`/`^N` 레벨 경로 자동코드 구현
+
+- 이슈: #2145 / 브랜치: `fix/2145-outline-levelpath` / 작성일: 2026-07-10
+- 배경: 개요번호 형식 문자열이 `^N`인 실문서(비공개, 로컬 `1.hwp`)에서 개요번호가
+  숫자 대신 **리터럴 `^N`** 으로 렌더됨. 한글 oracle(COM HPrint 1-up PDF)은
+  `1.` / `1.1.` / `2.` / `3.` 을 표시. `expand_numbering_format`
+  (`src/renderer/layout/utils.rs`)이 `^1`~`^7`만 치환하고 OWPML ParaHeadType
+  스펙의 자동 코드 `^n`(레벨 경로), `^N`(레벨 경로+후행 마침표)이 미구현.
+
+## 범위
+
+- 수정: `expand_numbering_format` — `^n`/`^N` 분기 추가 (현재 수준 파라미터 신설)
+- 호출부: `apply_paragraph_numbering`(`src/renderer/layout/paragraph_layout.rs`) 1곳
+- 비범위: HWP3/HWPX 파서, 시리얼라이저(형식 문자열은 raw 보존이 정답), wasm_api의
+  별도 numbering 경로(있다면 조사 후 동일 결함 여부만 기록)
+
+## 확장 의미 (스펙 + oracle 검증 완료)
+
+- `^n` → 수준 1~현재 수준 카운터를 각 수준의 `number_format`으로 포맷해 `.` 연결 (예: `1.1.1`)
+- `^N` → `^n` + 후행 `.` (예: `1.1.1.`) — 재현 문서 사용 코드
+- level 0 문단: `^N` → `1.`, level 1: `^N` → `1.1.` (oracle 페이지 2 확인)
+
+## 단계 (3단계)
+
+### 1단계 — 구현
+- `expand_numbering_format`에 `current_level`(0-based) 파라미터 추가,
+  `^n`/`^N` 치환 분기 구현. 호출부 갱신.
+
+### 2단계 — 회귀 테스트
+- `src/renderer/layout/tests.rs`에 단위 테스트 추가:
+  `^N` level 0 → `1.`, level 1 → `1.1.`, `^n` 무마침표, 기존 `^1.` 회귀 불변,
+  start_number/카운터 조합.
+
+### 3단계 — 검증 + 보고
+- 로컬 `1.hwp` export-png 페이지 2~4를 oracle PDF와 시각 대조 (`1.`~`3.`, `1.1.`~`1.4.`)
+- `cargo test` + `cargo clippy` 게이트
+- 10k 대량 회귀는 비접촉 영역(치환 함수 한정)이므로 생략, 대신 `samples/` 개요번호
+  사용 샘플 유무 확인 후 있으면 전후 SVG diff
+- 최종 보고서 `mydocs/report/task_m100_2145_report.md`
+
+## 게이트
+
+`cargo build` / `cargo test` / `cargo clippy` + 시각 oracle 대조(비공개 문서 로컬).
+재현 문서는 비공개라 저장소 미포함 — 회귀는 단위 테스트로 고정.

--- a/mydocs/plans/task_m100_2145_impl.md
+++ b/mydocs/plans/task_m100_2145_impl.md
@@ -1,0 +1,32 @@
+# 구현계획서 — Task M100 #2145: 개요번호 `^n`/`^N` 레벨 경로 자동코드
+
+- 수행계획서: `task_m100_2145.md` / 브랜치: `fix/2145-outline-levelpath`
+
+## 1단계 — `expand_numbering_format` 확장 (utils.rs)
+
+- 시그니처에 `current_level: usize`(0-based, 호출부의 `level_idx`) 추가.
+- 수준 1개 번호 포맷 로직(카운터+시작번호 → `format_number`)을 지역 클로저
+  `format_level(idx)`로 추출 (기존 `^digit` 분기와 신규 분기가 공유).
+- `^` 다음 문자 분기 확장:
+  - ASCII 숫자(`1`~`7`): 기존 동작 유지 (`format_level(digit-1)`)
+  - `n`: `format_level(0)`~`format_level(current_level)`을 `.`로 join
+  - `N`: `^n` 결과 + 후행 `.`
+  - 그 외: 기존대로 리터럴 통과
+- 호출부 1곳(`paragraph_layout.rs` `apply_paragraph_numbering`)에 `level_idx` 전달.
+
+## 2단계 — 회귀 테스트 (renderer/layout/tests.rs)
+
+- 기존 `expand_numbering_format` 호출 2건에 파라미터 추가 (동작 불변 확인).
+- 신규 테스트 `test_expand_numbering_format_level_path`:
+  - `^N`, level 0, counters=[1,..] → `"1."`
+  - `^N`, level 1, counters=[1,1,..] → `"1.1."`
+  - `^n`, level 1 → `"1.1"` (후행 마침표 없음)
+  - `^N`, level 1, 수준별 number_format 혼합(L2=HangulGaNaDa) → `"1.가."`
+  - 상위 수준 카운터 0(start 폴백) 케이스
+
+## 3단계 — 게이트 + 시각 검증 + 보고
+
+- `cargo build --release --features native-skia` / `cargo test` / `cargo clippy`
+- 로컬 `1.hwp` `export-png -p 1..3` ↔ oracle PDF 대조:
+  `1. 개 요`, `1.1.`~`1.4.`, `2. 점검 결과`, `3. 상세 점검 결과`
+- 최종 보고서 `mydocs/report/task_m100_2145_report.md` + 이슈 클로즈(승인 후)

--- a/mydocs/report/task_m100_2145_report.md
+++ b/mydocs/report/task_m100_2145_report.md
@@ -1,0 +1,53 @@
+# 최종 보고서 — Task M100 #2145: 개요번호 `^n`/`^N` 레벨 경로 자동코드 구현
+
+- 이슈: #2145 / 브랜치: `fix/2145-outline-levelpath` / 작성일: 2026-07-10
+- 계획서: `mydocs/plans/task_m100_2145.md`, `task_m100_2145_impl.md`
+
+## 증상 → 원인
+
+비공개 실문서(로컬 `1.hwp`, 웹 취약점 점검 보고서 5쪽)의 개요 문단이 rhwp 렌더에서
+번호 대신 **리터럴 `^N`** 으로 출력. 한글 COM oracle(HPrint 1-up PDF, 5쪽 일치)은
+`1.` / `1.1.`~`1.4.` / `2.` / `3.` 표시.
+
+원인: `expand_numbering_format`(`src/renderer/layout/utils.rs`)이 `^1`~`^7`만
+치환하고, OWPML ParaHeadType 스펙의 자동 코드 `^n`(레벨 경로, `1.1.1`)과
+`^N`(레벨 경로+후행 마침표, `1.1.1.`)이 미구현 — 미치환 문자는 리터럴 통과.
+
+## 수정
+
+- `expand_numbering_format`에 `current_level`(0-based) 파라미터 추가,
+  수준별 번호 포맷을 `format_level` 클로저로 추출, `^n`/`^N` 분기 구현
+  (수준 1~현재 수준을 각 수준의 `number_format`으로 포맷해 `.` 연결,
+  `^N`은 후행 `.` 부가). 호출부 `apply_paragraph_numbering` 1곳 갱신.
+- 변경 파일: `utils.rs` +52/−22줄 내외, `paragraph_layout.rs` 호출부,
+  `tests.rs` 단위 테스트.
+
+## 검증 자산
+
+**대외비 정책에 따라 fixture/PDF/통합 테스트는 저장소 미포함** — 회귀는 단위
+테스트로 고정하고, 검증 자산은 로컬 보관한다.
+
+| 자산 | 위치 (로컬, gitignore) |
+|------|------|
+| 재현 fixture (합성 HWPX, 개요 4문단 level 0→1→1→0, 전 수준 `^N`) | `output/poc/issue_1hwp_outline/local_assets/issue2145_outline_levelpath.hwpx` |
+| 권위 PDF (한글 2022 COM HPrint 1-up) | `output/poc/issue_1hwp_outline/local_assets/issue2145_outline_levelpath-2022.pdf` |
+| 통합 테스트 원본 (fixture 의존, 미커밋) | `output/poc/issue_1hwp_outline/local_assets/issue_2145_outline_levelpath.rs` |
+| 단위 테스트 (**커밋됨**, 회귀 가드) | `src/renderer/layout/tests.rs` `test_expand_numbering_format_level_path{,_mixed_format}` |
+
+fixture는 `issue1549_empty_host_float_clamp.hwpx` 구조에서 본문·numbering만 교체한
+합성본으로, **한글이 직접 열어 재조판한 출력**을 권위 PDF로 확보 —
+한글도 `1. / 1.1. / 1.2. / 2.`를 표시하여 rhwp 수정 후 렌더와 일치.
+(비공개 원문서 및 시각 대조 산출물도 로컬 `output/poc/issue_1hwp_outline/`.)
+
+## 게이트
+
+- `cargo test --release` 전체: 실패 0
+- `cargo clippy --release`: warning/error 0
+- `hwpx_roundtrip_baseline` / `visual_roundtrip_baseline`: 통과
+- 코퍼스 영향: 추적 샘플 8건이 `^n`/`^N` numbering 정의를 보유하나 **본문에서
+  Outline 문단을 사용하는 샘플은 0건** (diag 전수 확인) — 기존 샘플 시각 변화 없음.
+
+## 판정
+
+한글 oracle과 픽셀 수준 대조 완료(비공개 문서 페이지 2~4 + 합성 fixture),
+번호·카운터 전진(`2.`, `3.`)·하위 수준 경로(`1.1.`~`1.4.`) 모두 일치. 수정 완료.

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -5993,8 +5993,13 @@ impl LayoutEngine {
                     return None;
                 }
 
-                let text =
-                    expand_numbering_format(format_str, &counters, numbering, &start_numbers);
+                let text = expand_numbering_format(
+                    format_str,
+                    &counters,
+                    numbering,
+                    &start_numbers,
+                    level_idx,
+                );
                 if text.is_empty() {
                     return None;
                 }

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -1075,12 +1075,22 @@ fn test_expand_numbering_format_digit() {
         raw_para_heads: None,
     };
     let counters = [3, 2, 1, 0, 0, 0, 0];
-    let result =
-        expand_numbering_format("^1.", &counters, &numbering, &numbering.level_start_numbers);
+    let result = expand_numbering_format(
+        "^1.",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        0,
+    );
     assert_eq!(result, "3.");
 
-    let result =
-        expand_numbering_format("^2.", &counters, &numbering, &numbering.level_start_numbers);
+    let result = expand_numbering_format(
+        "^2.",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
     assert_eq!(result, "2.");
 
     let result = expand_numbering_format(
@@ -1088,6 +1098,7 @@ fn test_expand_numbering_format_digit() {
         &counters,
         &numbering,
         &numbering.level_start_numbers,
+        2,
     );
     assert_eq!(result, "(1)");
 }
@@ -1113,9 +1124,142 @@ fn test_expand_numbering_format_hangul() {
         raw_para_heads: None,
     };
     let counters = [1, 3, 0, 0, 0, 0, 0];
-    let result =
-        expand_numbering_format("^2.", &counters, &numbering, &numbering.level_start_numbers);
+    let result = expand_numbering_format(
+        "^2.",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
     assert_eq!(result, "다.");
+}
+
+#[test]
+fn test_expand_numbering_format_level_path() {
+    // ^n/^N: 레벨 경로 자동코드 (#2145). 재현 문서는 전 수준 "^N".
+    let numbering = Numbering {
+        raw_data: None,
+        heads: [NumberingHead {
+            number_format: 0,
+            ..Default::default()
+        }; 7],
+        level_formats: [
+            "^N".to_string(),
+            "^N".to_string(),
+            "^N".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ],
+        start_number: 0,
+        level_start_numbers: [1, 1, 1, 1, 1, 1, 1],
+        raw_para_heads: None,
+    };
+
+    // level 0: "1.", 카운터 전진 후 "2."
+    let counters = [1, 0, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        0,
+    );
+    assert_eq!(result, "1.");
+    let counters = [2, 0, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        0,
+    );
+    assert_eq!(result, "2.");
+
+    // level 1: "1.1." → "1.4."
+    let counters = [1, 1, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "1.1.");
+    let counters = [1, 4, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "1.4.");
+
+    // ^n: 후행 마침표 없음
+    let counters = [2, 3, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^n",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "2.3");
+
+    // 접두·접미 문자 보존
+    let result = expand_numbering_format(
+        "[^n]",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "[2.3]");
+
+    // 상위 수준 카운터 0이면 시작번호로 폴백
+    let counters = [0, 2, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "1.2.");
+}
+
+#[test]
+fn test_expand_numbering_format_level_path_mixed_format() {
+    // 수준별 number_format 혼합: L1=Digit, L2=HangulGaNaDa → "1.가."
+    let mut heads = [NumberingHead::default(); 7];
+    heads[1].number_format = 8; // HangulGaNaDa
+    let numbering = Numbering {
+        raw_data: None,
+        heads,
+        level_formats: [
+            "^N".to_string(),
+            "^N".to_string(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+            String::new(),
+        ],
+        start_number: 0,
+        level_start_numbers: [1, 1, 1, 1, 1, 1, 1],
+        raw_para_heads: None,
+    };
+    let counters = [1, 1, 0, 0, 0, 0, 0];
+    let result = expand_numbering_format(
+        "^N",
+        &counters,
+        &numbering,
+        &numbering.level_start_numbers,
+        1,
+    );
+    assert_eq!(result, "1.가.");
 }
 
 #[test]

--- a/src/renderer/layout/utils.rs
+++ b/src/renderer/layout/utils.rs
@@ -93,37 +93,61 @@ pub fn resolve_numbering_id(
     }
 }
 
-/// 번호 형식 문자열의 `^N` 제어코드를 실제 번호로 치환
+/// 번호 형식 문자열의 `^` 제어코드를 실제 번호로 치환.
+///
+/// - `^1`~`^7`: 해당 수준의 번호
+/// - `^n`: 수준 1~현재 수준의 레벨 경로 (예: `1.1.1`)
+/// - `^N`: 레벨 경로 + 후행 마침표 (예: `1.1.1.`)
+///
+/// `current_level`은 0-based 수준 인덱스(`para_level`).
 pub(crate) fn expand_numbering_format(
     format_str: &str,
     counters: &[u32; 7],
     numbering: &Numbering,
     start_numbers: &[u32; 7],
+    current_level: usize,
 ) -> String {
+    let format_level = |idx: usize| -> String {
+        let counter_val = counters[idx];
+        let start = start_numbers[idx];
+        let num = if counter_val > 0 {
+            (start - 1) + counter_val
+        } else {
+            start
+        };
+        let fmt_code = numbering.heads[idx].number_format;
+        let num_fmt = numbering_format_to_number_format(fmt_code);
+        format_number(num as u16, num_fmt)
+    };
+
     let mut result = String::new();
     let mut chars = format_str.chars().peekable();
 
     while let Some(ch) = chars.next() {
         if ch == '^' {
-            if let Some(&digit) = chars.peek() {
-                if digit.is_ascii_digit() {
+            match chars.peek() {
+                Some(&digit) if digit.is_ascii_digit() => {
                     chars.next();
                     let level_ref = (digit as u8 - b'0') as usize;
                     if level_ref >= 1 && level_ref <= 7 {
-                        let idx = level_ref - 1;
-                        let counter_val = counters[idx];
-                        let start = start_numbers[idx];
-                        let num = if counter_val > 0 {
-                            (start - 1) + counter_val
-                        } else {
-                            start
-                        };
-                        let fmt_code = numbering.heads[idx].number_format;
-                        let num_fmt = numbering_format_to_number_format(fmt_code);
-                        result.push_str(&format_number(num as u16, num_fmt));
+                        result.push_str(&format_level(level_ref - 1));
                     }
                     continue;
                 }
+                Some(&code @ ('n' | 'N')) => {
+                    chars.next();
+                    for idx in 0..=current_level.min(6) {
+                        if idx > 0 {
+                            result.push('.');
+                        }
+                        result.push_str(&format_level(idx));
+                    }
+                    if code == 'N' {
+                        result.push('.');
+                    }
+                    continue;
+                }
+                _ => {}
             }
         }
         result.push(ch);


### PR DESCRIPTION
## 요약

개요번호(head_type=Outline) 형식 문자열이 `^N`인 문서에서 번호 대신 리터럴 `^N`이 렌더되던 결함 수정. closes #2145

## 원인 → 수정

`expand_numbering_format`(`src/renderer/layout/utils.rs`)이 `^1`~`^7`만 치환 — OWPML ParaHeadType 자동 코드 미구현:

- `^n` — 레벨 경로 (예: `1.1.1`)
- `^N` — 레벨 경로 + 후행 마침표 (예: `1.1.1.`)

`current_level` 파라미터를 추가하고 수준 1~현재 수준 카운터를 각 수준의 `number_format`으로 포맷해 `.`로 연결하는 분기 구현. 호출부는 `apply_paragraph_numbering` 1곳.

## oracle 대조 (한글 2022 COM HPrint 1-up PDF)

| 문단 | 한글 oracle | rhwp 수정 전 | rhwp 수정 후 |
|---|---|---|---|
| 개요 level 0 ×3 | `1.` `2.` `3.` | `^N` | `1.` `2.` `3.` |
| 개요 level 1 ×4 | `1.1.`~`1.4.` | `^N` | `1.1.`~`1.4.` |

재현 문서·합성 fixture·권위 PDF는 **대외비로 저장소 미포함** (로컬 보관, 시각 대조 완료). 합성 fixture(개요 4문단 level 0→1→1→0, 전 수준 `^N`)를 한글이 직접 열어 `1. / 1.1. / 1.2. / 2.` 표시 — 수정 후 rhwp와 일치 확인.

## 회귀 가드

- 단위 테스트 2건: `test_expand_numbering_format_level_path` (level 0 `1.`, level 1 `1.1.`, `^n` 무마침표, 접두·접미 보존, 상위 카운터 0 폴백), `test_expand_numbering_format_level_path_mixed_format` (`1.가.`)

## 게이트

- `cargo test --release` 전체 green / `cargo clippy --release` 0
- `hwpx_roundtrip_baseline` / `visual_roundtrip_baseline` 통과
- 코퍼스 영향: 추적 샘플 중 `^n/^N` numbering 정의 보유 8건 전수 diag — 본문 Outline 문단 사용 0건, 기존 시각 변화 없음

🤖 Generated with [Claude Code](https://claude.com/claude-code)