### PR TITLE
Issue #2151: HWP3 그림 pgy=0 페이지 시작 후 거짓 쪽 경계 — prev_last_pgy 리셋

### DIFF
--- a/mydocs/plans/task_m100_2151.md
+++ b/mydocs/plans/task_m100_2151.md
@@ -1,0 +1,32 @@
+# 수행계획서 — Task M100 #2151: HWP3 pgy 기준 오유지 — 그림 pgy=0 페이지 시작 후 거짓 쪽 경계
+
+- 이슈: #2151 / 브랜치: `fix/2151-hwp3-pagination` / 작성일: 2026-07-10
+- 배경: samples/ 전수 pi-page 스윕(#2154)에서 HWP3 원본 계열만 +1쪽 이탈
+  (변환본 MATCH). 최소 재현 hwp3-sample14.hwp (rhwp 12쪽 vs 한글 11쪽).
+
+## 원인 (RHWP3_PGY_DEBUG 임시 계측으로 확정)
+
+`src/parser/hwp3/mod.rs`의 페이지 경계 승격 체인:
+
+1. pi16(그림 호스트)은 저장 line_info.pgy=0 — `first_pgy(0) < prev_last_pgy(15441)`
+   로 쪽 경계 승격 (정당: 한글도 2쪽 시작)
+2. `prev_last_pgy` 갱신이 `last_pgy > 0` 조건부라 pi16(pgy=0)이 **이전 페이지
+   기준값 15441을 유지**
+3. pi17의 정상 새-페이지 pgy(3521 = HWP5 변환본 vpos 14084/4와 정확 일치)가
+   15441보다 작아 **거짓 쪽 경계 재승격** → 그림만 있는 유령 페이지 생성
+
+## 수정
+
+- `prev_last_pgy` 갱신 조건을 `last_pgy > 0 || is_page_break`로 확장 — 새 페이지를
+  시작한 문단은 pgy=0이어도 기준을 리셋 (1줄 수정 + 주석)
+- HWP3 전용 로직으로 `src/parser/hwp3/` 내부만 수정 (CLAUDE.md 규칙 준수)
+
+## 단계
+
+1. 수정 + HWP3 원본 쪽수 확인 (sample14 12→11, sample11 152→151, 나머지 불변)
+2. 회귀: cargo test 전체 + HWP3 원본 10종 per-pi 오라클 재검(전/후 n_mm 비교)
+3. 회귀 테스트 추가(파서 단위) + 보고서 + PR
+
+## 게이트
+
+cargo test / clippy / HWP3 오라클 재검 (MATCH 확대·무회귀 확인)

--- a/mydocs/report/task_m100_2151_report.md
+++ b/mydocs/report/task_m100_2151_report.md
@@ -1,0 +1,51 @@
+# 최종 보고서 — Task M100 #2151: HWP3 그림 pgy=0 페이지 시작 후 거짓 쪽 경계 수정
+
+- 이슈: #2151 / 브랜치: `fix/2151-hwp3-pagination` / 작성일: 2026-07-10
+- 계획서: `mydocs/plans/task_m100_2151.md`
+
+## 원인 (계측 확정)
+
+HWP3 저장 `line_info.pgy`(한글97 계산 줄 Y, 감소 = 새 페이지 신호) 처리에서:
+
+1. 그림 호스트 문단은 pgy=0으로 저장 — `first_pgy(0) < prev_last_pgy(15441)`로
+   쪽 경계 승격 (정당)
+2. `prev_last_pgy` 갱신이 `last_pgy > 0` 조건부라 그림 문단(pgy=0)이 **이전
+   페이지 기준값을 유지**
+3. 다음 문단의 정상 새-페이지 pgy(sample14 pi17=3521, HWP5 변환본 vpos 14084/4와
+   정확 일치)가 잔존 기준(15441)보다 작아 **거짓 쪽 경계 재승격** → 그림만 있는
+   유령 페이지 (rhwp 12쪽 vs 한글 11쪽)
+
+## 수정 (1줄 + 주석, `src/parser/hwp3/mod.rs`)
+
+`prev_last_pgy` 갱신 조건 `last_pgy > 0` → `last_pgy > 0 || is_page_break`.
+새 페이지를 시작한 문단은 pgy=0이어도 기준을 리셋한다. HWP3 전용 로직으로
+`src/parser/hwp3/` 밖 무접촉 (CLAUDE.md 규칙 준수).
+
+## 검증
+
+### 한글 2022 COM per-pi 오라클 (HWP3 원본 10종 전수 재검)
+
+| 파일 | 수정 전 (#2154 스윕) | 수정 후 |
+|---|---|---|
+| hwp3-sample14 | PAGE_DELTA 12vs11, n_mm 239 | **MATCH 11=11** |
+| hwp3-sample11 | PAGE_DELTA 152vs151, n_mm 3523 | **MATCH 151=151** |
+| hwp3-sample10 | PI_MISMATCH 92 (763=763) | PI_MISMATCH 92 — 잔존 서브축(p39부터 산발), 이슈에 기록 |
+| hwp3-sample16 | CARET 1 | CARET 1 (오탐 후보, 불변) |
+| sample/4/5/13/19/pagedef-1915 | MATCH | MATCH (무회귀) |
+
+- 산출: `output/poc/task_pipage_sweep/hwp3_retest.tsv`
+
+### 게이트
+
+- `cargo test --release` 전체: 실패 0 (변경 후 전량 재실행)
+- `cargo clippy --release`: 0
+- 신규 핀 테스트: `tests/issue_2151_hwp3_ghost_page.rs`
+  (sample14=11쪽, sample11=151쪽 — repo 추적 실문서 fixture, 한글 오라클 +
+  HWP5/HWPX 변환본 3자 정합 권위)
+
+## 잔존 (이슈 유지 사유)
+
+- hwp3-sample10.hwp n_mm 92 (쪽수 동일, p39부터 산발 밀림) — pgy 기준 축이 아닌
+  별도 서브시그니처. caret 혼입 다수로 시각 대조 필요.
+- hwp3-sample16-hwp5.hwpx −1쪽 / sample5-hwp5 계열 16mm — **HWP5/HWPX 변환본**
+  전용 축(HWP3 파서 무관), #2151 본문 표 참조.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2644,7 +2644,12 @@ pub(crate) fn parse_paragraph_list(
         }
 
         let last_pgy = line_infos.last().map(|l| l.pgy).unwrap_or(0);
-        if last_pgy > 0 {
+        // pgy=0 줄(그림 호스트 등)은 기준 미갱신이 원칙이나, 이 문단이 새 페이지를
+        // 시작했다면(is_page_break) 이전 페이지의 pgy 기준을 유지하면 안 된다 —
+        // 유지 시 다음 문단의 정상 pgy(새 페이지 좌표)가 이전 페이지 기준보다 작아
+        // 거짓 페이지 경계가 재승격된다 (#2151: hwp3-sample14 pi16 그림 pgy=0 →
+        // pi17 pgy=3521 < 15441 오판, 그림만 있는 유령 페이지 생성).
+        if last_pgy > 0 || is_page_break {
             prev_last_pgy = last_pgy;
         }
         let is_top_level_body = body_height_hu > 0 && column_width_hu >= 30000;

--- a/tests/issue_2151_hwp3_ghost_page.rs
+++ b/tests/issue_2151_hwp3_ghost_page.rs
@@ -1,0 +1,45 @@
+//! Issue #2151 — HWP3 그림 pgy=0 페이지 시작 후 거짓 쪽 경계(유령 페이지) 핀.
+//!
+//! HWP3 저장 line_info.pgy 는 한글97 계산 줄 Y 좌표로, 감소 시 새 페이지 신호다.
+//! 그림 호스트 문단은 pgy=0 으로 저장되는데, 이 문단이 새 페이지를 시작한 경우
+//! `prev_last_pgy`(직전 유효 pgy 기준)를 리셋하지 않으면 다음 문단의 정상
+//! 새-페이지 pgy(예: sample14 pi17 pgy=3521 — HWP5 변환본 vpos 14084/4 와 일치)가
+//! 이전 페이지 기준(15441)보다 작아 거짓 쪽 경계로 재승격 → 그림만 있는
+//! 유령 페이지가 생긴다.
+//!
+//! 권위: 한글 2022 COM per-pi 오라클 (samples/ 전수 스윕 #2154, hwp3-sample14
+//! 한글 11쪽 / hwp3-sample11 한글 151쪽 — 동일 문서 HWP5/HWPX 변환본도 각각
+//! 11쪽·151쪽 MATCH).
+
+use std::fs;
+use std::path::Path;
+
+fn page_count_of(rel: &str) -> u32 {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    let doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes)
+        .unwrap_or_else(|e| panic!("parse {}: {:?}", rel, e));
+    doc.page_count()
+}
+
+#[test]
+fn hwp3_sample14_no_ghost_image_page() {
+    let pages = page_count_of("samples/hwp3-sample14.hwp");
+    assert_eq!(
+        pages, 11,
+        "hwp3-sample14 기대 11쪽 (한글 2022 오라클 + HWP5 변환본 정합). 실측 {}p — \
+         12p면 그림 pgy=0 페이지 시작 후 prev_last_pgy 미리셋으로 거짓 쪽 경계(#2151) 회귀.",
+        pages
+    );
+}
+
+#[test]
+fn hwp3_sample11_page_count_matches_hangul() {
+    let pages = page_count_of("samples/hwp3-sample11.hwp");
+    assert_eq!(
+        pages, 151,
+        "hwp3-sample11 기대 151쪽 (한글 2022 오라클 + HWP5/HWPX 변환본 정합). 실측 {}p (#2151).",
+        pages
+    );
+}


### PR DESCRIPTION
## 요약

samples/ 전수 pi-page 스윕(#2154)에서 발견된 HWP3 원본 계열 +1쪽 이탈(#2151)의 1차 수정. HWP3 원본 2건(sample14, sample11)이 한글 2022 오라클과 완전 MATCH로 회복. Refs #2151

## 원인 (RHWP3_PGY_DEBUG 임시 계측으로 확정)

HWP3 저장 `line_info.pgy`(한글97 계산 줄 Y, 감소 = 새 페이지 신호) 처리 체인:

1. 그림 호스트 문단은 **pgy=0으로 저장** — `first_pgy(0) < prev_last_pgy(15441)`로 쪽 경계 승격 (정당: 한글도 이 그림에서 2쪽 시작)
2. `prev_last_pgy` 갱신이 `last_pgy > 0` 조건부라 그림 문단(pgy=0)이 이전 페이지 기준값을 유지
3. 다음 문단의 정상 새-페이지 pgy(sample14 pi17=3521 — **HWP5 변환본 vpos 14084/4와 정확 일치**)가 잔존 기준(15441)보다 작아 **거짓 쪽 경계 재승격** → 그림만 있는 유령 페이지

## 수정

`src/parser/hwp3/mod.rs` 1줄: `prev_last_pgy` 갱신 조건 `last_pgy > 0` → `last_pgy > 0 || is_page_break`. 새 페이지를 시작한 문단은 pgy=0이어도 기준 리셋. HWP3 전용 로직으로 `src/parser/hwp3/` 밖 무접촉.

## 오라클 검증 (한글 2022 COM per-pi, HWP3 원본 10종 전수)

| 파일 | 수정 전 | 수정 후 |
|---|---|---|
| hwp3-sample14 | PAGE_DELTA 12vs11, n_mm 239 | **MATCH 11=11** |
| hwp3-sample11 | PAGE_DELTA 152vs151, n_mm 3523 | **MATCH 151=151** |
| hwp3-sample10 | PI_MISMATCH 92 (763=763) | 불변 (잔존 서브축, 이슈 유지) |
| 나머지 7종 | MATCH/CARET1 | 동일 (무회귀) |

## 회귀 가드

- `tests/issue_2151_hwp3_ghost_page.rs` — repo 추적 실문서 2종 쪽수 핀 (한글 오라클 + HWP5/HWPX 변환본 3자 정합 권위)
- `cargo test --release` 전체 green / `cargo clippy --release` 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)