### PR TITLE
docs: PR 2170 머지 후속 기록

### DIFF
--- a/mydocs/orders/20260710.md
+++ b/mydocs/orders/20260710.md
@@ -13,9 +13,9 @@
 
 | 항목 | 내용 | 상태 |
 |------|------|------|
-| #2156 / PR #2163 | 함초롬 계열 라틴 폭 대체를 최신 `devel` 위 통합 브랜치에서 재검토. 메인터너가 Haansoft Batang 적용 범위를 검증된 `함초롬바탕`/`HCR Batang` 정확한 별칭으로 제한하고, Dotum/확장 별칭 negative 회귀와 HCR Batang alias 회귀를 추가했다. 기준 PDF와 width-ladder visual sweep을 review asset으로 보존한다. | 옵션 1 archive 문서·PDF·대표 PNG 포함. 깨끗한 `target` 전체 Rust/Studio/WASM 사전 검증 통과. 통합 PR #2170 생성, 최신 CI 대기. |
-| #2158 / PR #2165 | HWPX 저장 vpos 리셋 보존 변경을 #2163/#2168과 누적 체리픽했다. sample16 HWPX/HWP5 64쪽 pin은 통과했으며, HWP2020 MCP PDF 64쪽과 대표 visual sweep PNG를 보존한다. page 3/62/63/64의 기존 font/layout fidelity 차이는 serializer 보정과 분리해 잔여로 기록한다. | 옵션 1 archive 문서·PDF·대표 PNG 포함. 깨끗한 `target` 전체 Rust/Studio/WASM 사전 검증 통과. 통합 PR #2170 생성, 최신 CI 대기. |
-| #2148 / PR #2168 | 80168의 em 줄높이·NO_LS 중첩 표·래핑 폭 상쇄 분석과 Windows Hancom COM 진단 도구를 누적 체리픽했다. production renderer는 변경하지 않으며, Python 문법/CLI 검증을 완료했다. | 옵션 1 archive 문서 포함. 깨끗한 `target` 전체 Rust/Studio/WASM 사전 검증 통과. 통합 PR #2170 생성, 최신 CI 대기. |
+| #2156 / PR #2163 | 함초롬 계열 라틴 폭 대체를 최신 `devel` 위 통합 브랜치에서 재검토. 메인터너가 Haansoft Batang 적용 범위를 검증된 `함초롬바탕`/`HCR Batang` 정확한 별칭으로 제한하고, Dotum/확장 별칭 negative 회귀와 HCR Batang alias 회귀를 추가했다. 기준 PDF와 width-ladder visual sweep을 review asset으로 보존한다. | 통합 PR #2170 merge (`c95d8fd`), 최신 CI/CodeQL/Render Diff 성공. #2156 auto-close 확인. |
+| #2158 / PR #2165 | HWPX 저장 vpos 리셋 보존 변경을 #2163/#2168과 누적 체리픽했다. sample16 HWPX/HWP5 64쪽 pin은 통과했으며, HWP2020 MCP PDF 64쪽과 대표 visual sweep PNG를 보존한다. page 3/62/63/64의 기존 font/layout fidelity 차이는 serializer 보정과 분리해 잔여로 기록한다. | 통합 PR #2170 merge (`c95d8fd`), 최신 CI/CodeQL/Render Diff 성공. #2158 auto-close 확인. |
+| #2148 / PR #2168 | 80168의 em 줄높이·NO_LS 중첩 표·래핑 폭 상쇄 분석과 Windows Hancom COM 진단 도구를 누적 체리픽했다. production renderer는 변경하지 않으며, Python 문법/CLI 검증을 완료했다. | 통합 PR #2170 merge (`c95d8fd`), 최신 CI/CodeQL/Render Diff 성공. #2148은 래핑 폭 축 후속을 위해 open 유지. |
 
 ## Task #2164 Chrome 확장 표 셀 Enter 문단 겹침
 

--- a/mydocs/pr/archives/pr_2163_review.md
+++ b/mydocs/pr/archives/pr_2163_review.md
@@ -82,3 +82,11 @@ Haansoft Batang 대체는 검증된 `함초롬바탕`/`HCR Batang` 정확한 별
 ## 옵션 1 기록
 
 이 문서, 기준 PDF, 대표 review PNG와 오늘할일 `mydocs/orders/20260710.md`를 통합 PR에 함께 포함한다.
+
+## Merge 결과
+
+- 통합 PR [#2170](https://github.com/edwardkim/rhwp/pull/2170)은 2026-07-10에 merge commit
+  `c95d8fd743ae4cfcbcbb0e26444ebef4e42b84ba`로 `devel`에 반영됐다.
+- 최신 head CI, CodeQL, Render Diff는 모두 성공했다. 갱신 전 head `19abd763b`의 CI/CodeQL/Render Diff는
+  force-cancel 후 `completed/cancelled`를 확인했다.
+- #2156은 PR body의 closing keyword로 auto-close된 것을 확인했다.

--- a/mydocs/pr/archives/pr_2163_review_impl.md
+++ b/mydocs/pr/archives/pr_2163_review_impl.md
@@ -24,7 +24,7 @@
 
 1. 통합 branch diff와 기준 PDF visual sweep을 재검토했다.
 2. 깨끗한 `target` 전체 검증을 통과했다.
-3. 통합 PR #2170을 생성했고, 최신 GitHub Actions를 확인한다.
+3. 통합 PR #2170은 `c95d8fd`로 merge됐고, 최신 GitHub Actions 성공 및 #2156 auto-close를 확인했다.
 
 ## 작업지시자 확인 사항
 

--- a/mydocs/pr/archives/pr_2165_review.md
+++ b/mydocs/pr/archives/pr_2165_review.md
@@ -94,3 +94,11 @@ PR 전후 온새미로 SVG와 render tree는 바이트 단위로 같았고, 44-4
 ## 옵션 1 기록
 
 이 문서, 기준 PDF, 대표 review PNG와 오늘할일 `mydocs/orders/20260710.md`를 통합 PR에 함께 포함한다.
+
+## Merge 결과
+
+- 통합 PR [#2170](https://github.com/edwardkim/rhwp/pull/2170)은 2026-07-10에 merge commit
+  `c95d8fd743ae4cfcbcbb0e26444ebef4e42b84ba`로 `devel`에 반영됐다.
+- 최신 head CI, CodeQL, Render Diff는 모두 성공했다. 갱신 전 head `19abd763b`의 CI/CodeQL/Render Diff는
+  force-cancel 후 `completed/cancelled`를 확인했다.
+- #2158은 PR body의 closing keyword로 auto-close된 것을 확인했다.

--- a/mydocs/pr/archives/pr_2165_review_impl.md
+++ b/mydocs/pr/archives/pr_2165_review_impl.md
@@ -19,8 +19,8 @@
 ## Stage 3 - 통합 PR 준비
 
 1. 깨끗한 `target` 전체 검증을 통과했다.
-2. 통합 PR #2170을 생성했고, 통합 PR CI를 확인한다.
-3. merge 후 원 PR을 close하고 review 문서와 PDF asset은 archive에 유지한다.
+2. 통합 PR #2170은 `c95d8fd`로 merge됐고, 통합 PR CI 성공 및 #2158 auto-close를 확인했다.
+3. supersede 된 원 PR을 close하고 review 문서와 PDF asset은 archive에 유지한다.
 
 ## 작업지시자 확인 사항
 

--- a/mydocs/pr/archives/pr_2168_review.md
+++ b/mydocs/pr/archives/pr_2168_review.md
@@ -49,3 +49,11 @@
 
 이 문서와 오늘할일 `mydocs/orders/20260710.md`를 통합 PR에 함께 포함한다. 시각 출력 경로를
 바꾸지 않는 분석/도구 PR이므로 별도 review PNG는 만들지 않는다.
+
+## Merge 결과
+
+- 통합 PR [#2170](https://github.com/edwardkim/rhwp/pull/2170)은 2026-07-10에 merge commit
+  `c95d8fd743ae4cfcbcbb0e26444ebef4e42b84ba`로 `devel`에 반영됐다.
+- 최신 head CI, CodeQL, Render Diff는 모두 성공했다. 갱신 전 head `19abd763b`의 CI/CodeQL/Render Diff는
+  force-cancel 후 `completed/cancelled`를 확인했다.
+- #2148은 래핑 폭 축이 남아 있으므로 auto-close하지 않고 open으로 유지한다.

--- a/mydocs/pr/archives/pr_2168_review_impl.md
+++ b/mydocs/pr/archives/pr_2168_review_impl.md
@@ -19,8 +19,8 @@
 ## Stage 3 - 통합 PR 준비
 
 1. 깨끗한 `target` 전체 검증을 통과했다.
-2. 통합 PR #2170을 생성했고, 통합 PR CI를 확인한다.
-3. merge 후 원 PR close 및 review 문서 archive 보존을 처리한다.
+2. 통합 PR #2170은 `c95d8fd`로 merge됐고, 통합 PR CI 성공을 확인했다.
+3. supersede 된 원 PR을 close하고 review 문서 archive 보존을 처리한다. #2148은 open으로 유지한다.
 
 ## 작업지시자 확인 사항
 


### PR DESCRIPTION
## 범위

- PR #2170 merge commit `c95d8fd743ae4cfcbcbb0e26444ebef4e42b84ba`
- 최신 CI/CodeQL/Render Diff 성공, 이전 head CI force-cancel 결과
- #2156/#2158 auto-close와 #2148 open 유지 상태
- archive review 문서 및 2026-07-10 오늘할일 확정 기록

## Fast-pass 근거

- 변경 파일은 `mydocs/**` 7개뿐이며 코드, 기준 샘플, workflow는 변경하지 않는다.
- `git diff --check` 통과.
- PR #2170의 전체 로컬 검증과 최신 CI는 이미 성공했다.

Refs #2170
