### PR TITLE
task 1951: 표 셀 장문 입력 캐럿 및 IME 경계 보정

### DIFF
--- a/mydocs/plans/task_m100_1951.md
+++ b/mydocs/plans/task_m100_1951.md
@@ -1,0 +1,48 @@
+# Task #1951 수행 계획서
+
+## 1. 작업 개요
+
+- 이슈: [#1951](https://github.com/edwardkim/rhwp/issues/1951)
+- 제목: 표 셀 장문 입력 시 IME 조합 오버레이가 셀/페이지 밖으로 이동하고 초과 텍스트가 가려짐
+- 작업 브랜치: `codex/task_m100_1951`
+- 기준 브랜치: `upstream/devel`
+- 재현 원본: `samples/복학원서.hwp`
+
+## 2. 재현과 범위
+
+첫 표의 `Name of College` 값 셀에 장문을 입력하면 고정 높이 셀의 마지막 가시 줄 아래로
+캐럿 좌표가 내려간다. Canvas의 셀 텍스트는 `TableCell` clip을 받지만, 편집 캐럿과 한글
+IME 조합창은 `scroll-content`에 별도 DOM으로 배치되어 같은 clip을 받지 않는다.
+
+이번 작업은 저장된 표의 행 높이, 자동 행 확장, 페이지네이션 정책을 변경하지 않는다. 현재
+고정 셀 정책을 유지하면서 가시 셀 범위 밖에 캐럿 또는 IME 조합창이 그려지지 않도록 한다.
+
+## 3. 수행 단계
+
+### Stage 1. 좌표 계약과 회귀 테스트
+
+1. 실제 샘플에서 장문 입력 뒤 셀 bbox와 캐럿 rect를 비교한다.
+2. 셀 경로 기반과 단일 셀 기반 cursor API 모두에 대해 캐럿 상단과 하단이 셀 bbox 안에
+   들어와야 한다는 실패 회귀 테스트를 추가한다.
+3. DOM 조합창도 같은 가시 bbox를 이용하도록 TypeScript 계약을 정한다.
+
+### Stage 2. 최소 범위 구현
+
+1. Rust cursor query가 일치하는 `TableCell` bbox를 찾아 캐럿 좌표를 가시 범위로 제한한다.
+2. cursor JSON에 선택적인 `cellBounds`를 추가해 Studio가 IME 조합창의 폭과 높이까지 제한할
+   수 있도록 한다.
+3. 일반 본문, 글상자, 머리말/꼬리말, 각주 cursor JSON은 기존 계약을 유지한다.
+
+### Stage 3. WASM과 브라우저 검증
+
+1. focused Rust 회귀 테스트와 Studio TypeScript 테스트를 실행한다.
+2. `wasm-pack build --target web --out-dir pkg` 뒤 기존 `localhost:7700`에서 원본을 열어
+   장문 입력, 캐럿, 조판부호, 셀 경계 표시를 확인한다.
+3. 실제 한글 IME 조합창은 Windows Chrome 환경에서 후속 수동 검증 대상으로 남긴다.
+
+## 4. 완료 조건
+
+- 장문 입력 뒤 normal caret의 rect가 활성 셀 bbox를 벗어나지 않는다.
+- IME 조합 DOM의 위치와 크기도 셀 bbox 안에 들어간다.
+- 중첩 표 path cursor와 단일 표 cell cursor 모두 같은 정책을 따른다.
+- 고정 셀의 clip 및 기존 표 크기/페이지 수가 변하지 않는다.

--- a/mydocs/plans/task_m100_1951_impl.md
+++ b/mydocs/plans/task_m100_1951_impl.md
@@ -1,0 +1,34 @@
+# Task #1951 구현 계획서
+
+## 1. 좌표 계약
+
+`CursorRect`는 기존 `pageIndex`, `x`, `y`, `height`를 유지한다. 표 셀 내부에서 반환할 때만
+선택적 `cellBounds: { x, y, w, h }`를 함께 포함한다.
+
+- `x`는 셀 좌우 경계 안에 제한한다.
+- `y`는 caret 높이를 포함해 셀 상하 경계 안에 제한한다.
+- 실제 TextRun의 좌표와 셀 bbox는 모두 같은 render tree에서 얻는다.
+- 텍스트 모델, char offset, LINE_SEG, 저장 셀 높이는 바꾸지 않는다.
+
+## 2. 수정 범위
+
+- `src/document_core/queries/cursor_rect.rs`
+  - 단일 셀과 cell path cursor query에서 현재 TextRun이 속한 `TableCell` bbox를 함께 추적한다.
+  - 계산된 caret rect를 해당 bbox에 맞춰 제한하고 `cellBounds`를 직렬화한다.
+- `rhwp-studio/src/core/types.ts`
+  - `CursorRect.cellBounds` 선택 타입을 추가한다.
+- `rhwp-studio/src/engine/caret-renderer.ts`
+  - 일반 caret과 IME 조합창의 DOM left/top/width/height를 `cellBounds`에 맞춰 제한한다.
+- `tests/issue_1951_table_cell_cursor_clip.rs`
+  - `복학원서.hwp`에 장문 입력 후 단일/path cursor rect가 대상 셀 bbox 안에 있는지 검증한다.
+- `rhwp-studio/tests/`
+  - renderer 소스 계약 테스트로 cell bounds가 IME 조합창의 위치와 크기에 적용되는지 검증한다.
+
+## 3. 회귀 위험과 방어
+
+- 셀 bbox를 매 입력마다 별도 조회하지 않는다. cursor query가 이미 빌드한 page render tree의
+  `TableCell` 조상 bbox를 재사용한다.
+- 고정 셀 밖의 숨은 텍스트는 보존한다. 이번 수정은 UI cursor와 조합창의 가시 위치만 정한다.
+- `cellBounds`가 없는 본문/글상자/각주/머리말 경로는 기존 DOM 배치를 그대로 유지한다.
+- 최소 가시 폭이나 높이보다 작은 셀도 DOM 요소가 셀 밖으로 나가지 않도록 width/height를
+  셀 크기에 맞춰 제한한다.

--- a/mydocs/report/task_m100_1951_report.md
+++ b/mydocs/report/task_m100_1951_report.md
@@ -1,0 +1,77 @@
+# Task M100 #1951 결과보고서
+
+- 이슈: [#1951](https://github.com/edwardkim/rhwp/issues/1951)
+- 브랜치: `codex/task_m100_1951`
+- 기준 브랜치: `upstream/devel`
+- 재현 원본: `samples/복학원서.hwp`
+- 작성일: 2026-07-10
+
+## 1. 문제와 원인
+
+첫 표의 `Name of College` 값 셀에 장문을 빠르게 입력하면, page-local 지연 페이지네이션이
+기존 셀 높이의 render tree를 유지한 채 새 줄을 compose했다. 그 결과 raw cursor y가 셀 bbox
+아래로 내려갔고, Canvas clip을 공유하지 않는 DOM caret 및 IME 조합창도 셀 밖으로 배치될 수 있었다.
+
+또한 one-depth `cellPath`를 전달하는 IME 삽입은 일반 셀 삽입과 달리 셀 폭 리플로우 및 셀 문단
+vpos 재계산을 건너뛰고 있었다.
+
+## 2. 수정
+
+1. 단일 셀 및 cell path cursor query가 일치하는 `TableCell` bbox를 `cellBounds`로 반환한다.
+2. raw TextRun 좌표가 셀 bbox를 넘으면 반환 caret 좌표와 높이를 가시 bbox 안으로 제한하고
+   `cellOverflowed=true`를 표시한다.
+3. Studio는 일반 caret과 IME 조합창의 DOM 위치·폭·높이를 `cellBounds`로 한 번 더 제한한다.
+4. 지연 입력 뒤 `cellOverflowed`를 확인하면 해당 입력에만 즉시 페이지네이션을 flush하여 표 행의
+   실제 내용 높이를 다시 계산한다.
+5. one-depth `cellPath` 삽입은 일반 셀 삽입 경로를 재사용해 셀 reflow와 vpos 재계산을 보장한다.
+
+문서 모델의 text/offset/LINE_SEG와 저장 표 크기는 바꾸지 않았다. 정상적인 짧은 셀 입력은 기존
+page-local 갱신 경로를 그대로 사용한다.
+
+## 3. 회귀 테스트
+
+- `tests/issue_1951_table_cell_cursor_clip.rs`
+  - 지연 삽입 뒤 direct/path cursor가 모두 셀 bbox 안에 머무르고 overflow 상태를 전달하는지 검증
+  - one-depth path 삽입이 즉시 reflow되어 overflow 없이 셀 bbox 안에 머무는지 검증
+- `rhwp-studio/tests/caret-cell-bounds.test.ts`
+  - IME 조합 DOM의 cell bounds 제한과 overflow 시 즉시 flush 계약을 검증
+- `src/document_core/queries/cursor_rect.rs` 단위 테스트
+  - 셀 높이보다 큰 caret도 bbox 안으로 축소되는지 검증
+
+## 4. 수행 검증
+
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1951_table_cell_cursor_clip -- --nocapture`: 2 passed
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --lib document_core::queries::cursor_rect::tests::cell_cursor_bounds_clamp_coordinates_and_height -- --nocapture`: 1 passed
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_717_table_cell_hit_test -- --nocapture`: 4 passed
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_2164_cell_enter_overlap -- --nocapture`: 3 passed
+- `rhwp-studio`: `npm test` 185 passed, `npx tsc --noEmit` 통과
+- `wasm-pack build --target web --out-dir pkg`: 통과
+- `cargo fmt --check`, `git diff --check`: 통과
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`: 통과
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`: 통과
+- `localhost:7700` 실제 검증: `복학원서.hwp` 값 셀에 `가` 160자를 입력한 뒤 첫 행이 확장되고
+  caret이 셀 안에 유지됨. 브라우저 error/warn log 없음.
+
+## 5. PR 전 남은 검증
+
+- 실제 Windows Chrome 한글 IME 조합 상태에서 검은 조합창이 셀 경계 안에 유지되는지 수동 확인
+
+## 6. PR 본문 초안
+
+```markdown
+## Summary
+
+- 표 셀 장문 입력에서 cursor query가 셀 bbox를 반환하고, caret 및 IME 조합창을 그 범위 안으로 제한했습니다.
+- 지연 입력이 셀 높이를 초과한 경우에만 즉시 페이지네이션을 수행해 표 행을 확장합니다.
+- one-depth `cellPath` IME 삽입도 일반 셀 삽입 경로를 사용하도록 통일했습니다.
+
+## Tests
+
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
+- `rhwp-studio`: `npm test`, `npx tsc --noEmit`
+- `wasm-pack build --target web --out-dir pkg`
+- `samples/복학원서.hwp` 브라우저 장문 입력 검증
+
+Closes #1951
+```

--- a/mydocs/working/task_m100_1951_stage1.md
+++ b/mydocs/working/task_m100_1951_stage1.md
@@ -1,0 +1,28 @@
+# Task M100 #1951 Stage 1 작업 기록
+
+- 이슈: #1951
+- 브랜치: `codex/task_m100_1951`
+- 재현 원본: `samples/복학원서.hwp`
+- 작성일: 2026-07-10
+
+## 시작 기준
+
+브라우저에서 첫 표의 `Name of College` 값 셀에 장문을 입력해 셀 하단을 넘어가는 캐럿을
+재현했다. JavaScript 예외는 없었고, Canvas 텍스트 clip과 별도 DOM 편집 오버레이의 좌표 기준이
+서로 다른 것이 확인됐다.
+
+## Stage 1 결과
+
+`tests/issue_1951_table_cell_cursor_clip.rs`에서 첫 표의 `Name of College` 값 셀에 `가` 160자를
+삽입했다.
+
+- 일반 즉시 삽입은 전체 페이지네이션으로 행 높이가 재계산되어 셀 bbox 안에 남았다.
+- Studio가 사용하는 지연 삽입은 기존 셀 bbox `y=145.3, h=60.1`을 유지한 상태에서 raw caret이
+  `y=348.1, h=14.7`까지 내려가 기존 행 밖으로 나갔다.
+- 따라서 원인은 저장 표 높이나 Canvas clip 자체가 아니라, page-local 갱신 중의 stale table layout과
+  그 좌표를 그대로 쓰는 편집 오버레이다.
+- one-depth `cellPath` IME 삽입은 일반 셀 삽입과 달리 셀 폭 리플로우와 vpos 재계산을 거치지
+  않는 별도 경로도 확인됐다.
+
+Stage 2에서는 cursor JSON에 셀 bbox/overflow 상태를 제공하고, overflow 순간에만 지연
+페이지네이션을 즉시 flush하는 방식으로 진행한다.

--- a/mydocs/working/task_m100_1951_stage2.md
+++ b/mydocs/working/task_m100_1951_stage2.md
@@ -1,0 +1,34 @@
+# Task M100 #1951 Stage 2 완료보고서
+
+- 이슈: #1951
+- 브랜치: `codex/task_m100_1951`
+- 재현 원본: `samples/복학원서.hwp`
+- 작성일: 2026-07-10
+
+## 1. 수정
+
+- `cursor_rect.rs`
+  - 단일 셀과 cell path cursor query가 일치하는 `TableCell` bbox를 `cellBounds`로 반환한다.
+  - raw TextRun 좌표가 bbox 밖이면 caret 좌표를 가시 범위 안으로 제한하고
+    `cellOverflowed=true`를 함께 반환한다.
+- `text_editing.rs`
+  - one-depth `cellPath` 삽입은 일반 셀 삽입 경로를 재사용한다. 따라서 IME가 path를 전달해도
+    셀 폭 리플로우, vpos 재계산, 페이지네이션을 빠뜨리지 않는다.
+- Studio
+  - DOM caret과 IME 조합창의 위치/폭/높이를 `cellBounds` 안으로 제한한다.
+  - 지연 입력 뒤 `cellOverflowed`가 감지되면 그 순간에만 전체 페이지네이션을 flush해 표 행을
+    최신 내용 높이로 다시 계산한다.
+
+## 2. 검증
+
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --test issue_1951_table_cell_cursor_clip -- --nocapture`: 2 passed
+- `node --test tests/caret-cell-bounds.test.ts`: 2 passed
+- `npx tsc --noEmit`: 통과
+- `wasm-pack build --target web --out-dir pkg`: 통과
+- `localhost:7700` 실제 브라우저에서 장문 160자 입력: 첫 행이 확장되고 caret이 행 내부에 유지됨
+- 브라우저 error/warn log: 없음
+
+## 3. 남은 수동 검증
+
+자동 입력은 OS 한글 IME 조합 이벤트를 만들지 않는다. Windows Chrome에서 실제 한글 조합 중 검은
+조합창의 위치와 폭이 셀 안에 유지되는지 확인해야 한다.

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -183,6 +183,10 @@ export interface CursorRect {
   x: number;
   y: number;
   height: number;
+  /** 표 셀 내부 커서일 때만 제공되는 가시 셀 bbox */
+  cellBounds?: { x: number; y: number; w: number; h: number };
+  /** 원래 TextRun 좌표가 셀 bbox를 벗어나 보정됐는지 여부 */
+  cellOverflowed?: boolean;
 }
 
 /** WASM hitTest() 반환 타입 */

--- a/rhwp-studio/src/engine/caret-renderer.ts
+++ b/rhwp-studio/src/engine/caret-renderer.ts
@@ -60,7 +60,8 @@ export class CaretRenderer {
   /** 줌/스크롤 변경 시 위치를 갱신한다 */
   updatePosition(zoom: number): void {
     if (!this.currentRect) return;
-    const { pageIndex, x, y, height } = this.currentRect;
+    const { pageIndex } = this.currentRect;
+    const { x, y, height } = this.clampCaretRect(this.currentRect, zoom);
     const pageOffset = this.virtualScroll.getPageOffset(pageIndex);
     const pageLeft = this.calcPageLeft(pageIndex);
 
@@ -106,21 +107,22 @@ export class CaretRenderer {
     // 일반 캐럿 숨기기
     this.caretEl.style.display = 'none';
 
-    const { pageIndex, x, y, height } = startRect;
+    const { pageIndex } = startRect;
+    const box = this.clampCompositionBox(startRect, charWidth);
     const pageOffset = this.virtualScroll.getPageOffset(pageIndex);
     const pageLeft = this.calcPageLeft(pageIndex);
 
     // 블랙박스 위치/크기
-    const w = Math.max(charWidth, height * 0.6) * zoom;
-    const h = height * zoom;
-    const left = pageLeft + x * zoom;
-    const top = pageOffset + y * zoom;
+    const w = box.w * zoom;
+    const h = box.h * zoom;
+    const left = pageLeft + box.x * zoom;
+    const top = pageOffset + box.y * zoom;
 
     this.compEl.style.left = `${left}px`;
     this.compEl.style.top = `${top}px`;
     this.compEl.style.width = `${w}px`;
     this.compEl.style.height = `${h}px`;
-    this.compEl.style.fontSize = `${height * 0.85 * zoom}px`;
+    this.compEl.style.fontSize = `${box.h * 0.85 * zoom}px`;
     this.compEl.style.fontFamily = fontFamily || 'sans-serif';
     this.compEl.style.lineHeight = `${h}px`;
     this.compEl.textContent = text;
@@ -135,6 +137,43 @@ export class CaretRenderer {
     if (!this.isCompMode) return;
     this.isCompMode = false;
     this.compEl.style.display = 'none';
+  }
+
+  /** 셀 bbox가 있는 캐럿은 DOM 선 폭까지 셀 안에 남도록 보정한다. */
+  private clampCaretRect(rect: CursorRect, zoom: number): { x: number; y: number; height: number } {
+    const bounds = rect.cellBounds;
+    if (!bounds) return rect;
+
+    const caretWidth = 2 / Math.max(zoom, 0.01);
+    const height = Math.min(rect.height, Math.max(0, bounds.h));
+    const maxX = Math.max(bounds.x, bounds.x + bounds.w - caretWidth);
+    const maxY = Math.max(bounds.y, bounds.y + bounds.h - height);
+    return {
+      x: Math.min(Math.max(rect.x, bounds.x), maxX),
+      y: Math.min(Math.max(rect.y, bounds.y), maxY),
+      height,
+    };
+  }
+
+  /** IME 조합창은 Canvas clip을 받지 않으므로 셀 가시 bbox로 별도 제한한다. */
+  private clampCompositionBox(
+    rect: CursorRect,
+    charWidth: number,
+  ): { x: number; y: number; w: number; h: number } {
+    let x = rect.x;
+    let y = rect.y;
+    let w = Math.max(charWidth, rect.height * 0.6);
+    let h = rect.height;
+    const bounds = rect.cellBounds;
+    if (!bounds) return { x, y, w, h };
+
+    w = Math.min(w, Math.max(0, bounds.w));
+    h = Math.min(h, Math.max(0, bounds.h));
+    const maxX = Math.max(bounds.x, bounds.x + bounds.w - w);
+    const maxY = Math.max(bounds.y, bounds.y + bounds.h - h);
+    x = Math.min(Math.max(x, bounds.x), maxX);
+    y = Math.min(Math.max(y, bounds.y), maxY);
+    return { x, y, w, h };
   }
 
   /** 페이지의 화면 X 좌표를 계산한다 (그리드/단일 열 공통) */

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2248,6 +2248,8 @@ export class InputHandler {
 
   /** 셀 내부 단일 텍스트 편집 후 처리: 현재 페이지 canvas만 갱신한다. */
   private afterPageLocalEdit(): void {
+    if (this.flushDeferredPaginationForCellOverflow()) return;
+
     // 텍스트 입력은 셀 폭을 바꾸지 않으므로 눈금자 셀 bbox 캐시를 무효화하지 않는다.
     this.protectedCellHitCache = null;
     this.eventBus.emit('document-mutated', 'input-handler-edit');
@@ -2259,6 +2261,27 @@ export class InputHandler {
     }
     this.scheduleDeferredPaginationFlush();
     this.updateCaret();
+  }
+
+  /** 셀 안 새 줄이 기존 가시 높이를 넘으면 즉시 전체 표 레이아웃을 다시 계산한다. */
+  private flushDeferredPaginationForCellOverflow(): boolean {
+    if (!this.cursor.getRect()?.cellOverflowed) return false;
+
+    this.cancelDeferredPaginationFlush();
+    try {
+      this.wasm.flushDeferredPagination();
+      this.deferredPaginationPending = false;
+      this.lastCellKey = null;
+      this.protectedCellHitCache = null;
+      this.eventBus.emit('document-mutated', 'input-handler-cell-overflow');
+      this.eventBus.emit('document-changed', 'cell-overflow-pagination');
+      this.cursor.moveTo(this.cursor.getPosition());
+      this.updateCaret();
+      return true;
+    } catch (err) {
+      console.warn('[InputHandler] 셀 overflow 페이지네이션 flush 실패:', err);
+      return false;
+    }
   }
 
   private scheduleDeferredPaginationFlush(): void {

--- a/rhwp-studio/tests/caret-cell-bounds.test.ts
+++ b/rhwp-studio/tests/caret-cell-bounds.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const caretRenderer = readFileSync(new URL('../src/engine/caret-renderer.ts', import.meta.url), 'utf8');
+const inputHandler = readFileSync(new URL('../src/engine/input-handler.ts', import.meta.url), 'utf8');
+
+test('표 셀 IME 조합창은 Canvas clip과 별도로 cellBounds 안에 제한한다', () => {
+  assert.match(caretRenderer, /private clampCompositionBox\(/);
+  assert.match(caretRenderer, /const bounds = rect\.cellBounds;/);
+  assert.match(caretRenderer, /w = Math\.min\(w, Math\.max\(0, bounds\.w\)\);/);
+  assert.match(caretRenderer, /x = Math\.min\(Math\.max\(x, bounds\.x\), maxX\);/);
+  assert.match(caretRenderer, /y = Math\.min\(Math\.max\(y, bounds\.y\), maxY\);/);
+});
+
+test('지연 셀 입력이 가시 높이를 넘으면 즉시 전체 페이지네이션을 수행한다', () => {
+  assert.match(inputHandler, /if \(this\.flushDeferredPaginationForCellOverflow\(\)\) return;/);
+  assert.match(inputHandler, /private flushDeferredPaginationForCellOverflow\(\): boolean/);
+  assert.match(inputHandler, /if \(!this\.cursor\.getRect\(\)\?\.cellOverflowed\) return false;/);
+  assert.match(inputHandler, /this\.wasm\.flushDeferredPagination\(\);/);
+  assert.match(inputHandler, /this\.cursor\.moveTo\(this\.cursor\.getPosition\(\)\);/);
+});

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3085,6 +3085,21 @@ impl DocumentCore {
         char_offset: usize,
         text: &str,
     ) -> Result<String, HwpError> {
+        // 깊이 1 표는 일반 셀 삽입 경로가 셀 폭 리플로우와 vpos 재계산을 이미 담당한다.
+        // IME가 cellPath를 항상 전달하더라도 같은 편집 계약을 사용해야 한다.
+        if path.len() == 1 {
+            let (control_idx, cell_idx, cell_para_idx) = path[0];
+            return self.insert_text_in_cell_native(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                char_offset,
+                text,
+            );
+        }
+
         let new_chars_count = text.chars().count();
         let active_field = self.active_field.clone();
         let cell_para = self.get_cell_paragraph_mut_by_path(section_idx, parent_para_idx, path)?;

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -24,6 +24,57 @@ fn effective_char_count(text_run: &TextRunNode) -> usize {
     text_run.text.chars().count()
 }
 
+/// 표 셀 안 편집 캐럿과 IME 조합창이 공유하는 가시 경계다.
+///
+/// TextRun의 실제 좌표가 고정 높이 셀 밖으로 이어져도 문서 모델의 offset은 보존한다.
+/// 대신 편집 UI가 사용할 좌표만 이 bbox 안으로 제한한다.
+#[derive(Clone, Copy)]
+struct CellCursorBounds {
+    x: f64,
+    y: f64,
+    w: f64,
+    h: f64,
+}
+
+fn clamp_cursor_to_cell_bounds(
+    x: f64,
+    y: f64,
+    height: f64,
+    bounds: CellCursorBounds,
+) -> (f64, f64, f64, bool) {
+    let right = bounds.x + bounds.w.max(0.0);
+    let bottom = bounds.y + bounds.h.max(0.0);
+    let clamped_height = height.min(bounds.h.max(0.0));
+    let max_y = (bottom - clamped_height).max(bounds.y);
+    let clamped_x = x.clamp(bounds.x, right);
+    let clamped_y = y.clamp(bounds.y, max_y);
+    let overflowed = (x - clamped_x).abs() > 0.01
+        || (y - clamped_y).abs() > 0.01
+        || (height - clamped_height).abs() > 0.01;
+    (clamped_x, clamped_y, clamped_height, overflowed)
+}
+
+fn format_cursor_rect_json(
+    page_index: u32,
+    x: f64,
+    y: f64,
+    height: f64,
+    cell_bounds: Option<CellCursorBounds>,
+) -> String {
+    if let Some(bounds) = cell_bounds {
+        let (x, y, height, overflowed) = clamp_cursor_to_cell_bounds(x, y, height, bounds);
+        format!(
+            "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1},\"cellBounds\":{{\"x\":{:.1},\"y\":{:.1},\"w\":{:.1},\"h\":{:.1}}},\"cellOverflowed\":{}}}",
+            page_index, x, y, height, bounds.x, bounds.y, bounds.w, bounds.h, overflowed
+        )
+    } else {
+        format!(
+            "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
+            page_index, x, y, height
+        )
+    }
+}
+
 fn note_number_format_from_hwp_code(code: u8) -> crate::renderer::NumberFormat {
     match code {
         0 => crate::renderer::NumberFormat::Digit,
@@ -2536,6 +2587,38 @@ impl DocumentCore {
             height: f64,
         }
 
+        fn find_table_cell_bounds(
+            node: &RenderNode,
+            parent_para: usize,
+            ctrl_idx: usize,
+            c_idx: usize,
+        ) -> Option<CellCursorBounds> {
+            if let RenderNodeType::Table(ref table) = node.node_type {
+                let matches_table =
+                    table.para_index == Some(parent_para) && table.control_index == Some(ctrl_idx);
+                if matches_table {
+                    for child in &node.children {
+                        if let RenderNodeType::TableCell(ref cell) = child.node_type {
+                            if cell.model_cell_index == Some(c_idx as u32) {
+                                return Some(CellCursorBounds {
+                                    x: child.bbox.x,
+                                    y: child.bbox.y,
+                                    w: child.bbox.width,
+                                    h: child.bbox.height,
+                                });
+                            }
+                        }
+                    }
+                }
+            }
+            for child in &node.children {
+                if let Some(bounds) = find_table_cell_bounds(child, parent_para, ctrl_idx, c_idx) {
+                    return Some(bounds);
+                }
+            }
+            None
+        }
+
         fn find_cursor_in_cell(
             node: &RenderNode,
             parent_para: usize,
@@ -2601,6 +2684,8 @@ impl DocumentCore {
 
         for &page_num in &pages {
             let tree = self.build_page_tree(page_num)?;
+            let cell_bounds =
+                find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
             if let Some(hit) = find_cursor_in_cell(
                 &tree.root,
                 parent_para_idx,
@@ -2610,9 +2695,12 @@ impl DocumentCore {
                 char_offset,
                 page_num,
             ) {
-                return Ok(format!(
-                    "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
-                    hit.page_index, hit.x, hit.y, hit.height
+                return Ok(format_cursor_rect_json(
+                    hit.page_index,
+                    hit.x,
+                    hit.y,
+                    hit.height,
+                    cell_bounds,
                 ));
             }
         }
@@ -2620,6 +2708,8 @@ impl DocumentCore {
         // 빈 셀 fallback: 해당 셀의 아무 TextRun을 찾아 위치 반환
         let first_page = pages[0];
         let tree = self.build_page_tree(first_page)?;
+        let first_page_cell_bounds =
+            find_table_cell_bounds(&tree.root, parent_para_idx, control_idx, cell_idx);
 
         fn find_cell_run(
             node: &RenderNode,
@@ -2654,9 +2744,12 @@ impl DocumentCore {
             cell_idx,
             cell_para_idx,
         ) {
-            return Ok(format!(
-                "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
-                first_page, x, y, h
+            return Ok(format_cursor_rect_json(
+                first_page,
+                x,
+                y,
+                h,
+                first_page_cell_bounds,
             ));
         }
 
@@ -2711,12 +2804,17 @@ impl DocumentCore {
             let pad_left = cell_pos.2;
             let pad_top = cell_pos.3;
             let caret_h = (ch - pad_top - cell_pos.4).max(10.0); // 패딩 제외한 높이
-            return Ok(format!(
-                "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
+            return Ok(format_cursor_rect_json(
                 first_page,
                 cx + pad_left,
                 cy + pad_top,
-                caret_h
+                caret_h,
+                Some(CellCursorBounds {
+                    x: cx,
+                    y: cy,
+                    w: _cw,
+                    h: ch,
+                }),
             ));
         }
 
@@ -2946,10 +3044,12 @@ impl DocumentCore {
             page: u32,
             current_table_ctx: Option<CellContext>,
             current_cell_ctx: Option<CellContext>,
-        ) -> Option<(u32, f64, f64, f64)> {
+            current_cell_bounds: Option<CellCursorBounds>,
+        ) -> Option<(u32, f64, f64, f64, Option<CellCursorBounds>)> {
             let table_ctx =
                 table_ctx_from_node(node, current_table_ctx.as_ref(), current_cell_ctx.as_ref());
             let mut child_cell_ctx = current_cell_ctx.clone();
+            let mut child_cell_bounds = current_cell_bounds;
             if let RenderNodeType::TableCell(ref tc) = node.node_type {
                 if let Some(cell_idx) = tc.model_cell_index {
                     child_cell_ctx = cell_ctx_for_table_cell(
@@ -2958,6 +3058,12 @@ impl DocumentCore {
                         0,
                         tc.text_direction,
                     );
+                    child_cell_bounds = Some(CellCursorBounds {
+                        x: node.bbox.x,
+                        y: node.bbox.y,
+                        w: node.bbox.width,
+                        h: node.bbox.height,
+                    });
                 }
             }
             if let RenderNodeType::TextRun(ref tr) = node.node_type {
@@ -2982,7 +3088,13 @@ impl DocumentCore {
                         } else {
                             0.0
                         };
-                        return Some((page, node.bbox.x + xr, node.bbox.y, node.bbox.height));
+                        return Some((
+                            page,
+                            node.bbox.x + xr,
+                            node.bbox.y,
+                            node.bbox.height,
+                            child_cell_bounds,
+                        ));
                     }
                 }
             }
@@ -2997,6 +3109,7 @@ impl DocumentCore {
                     page,
                     table_ctx.clone(),
                     child_cell_ctx.clone(),
+                    child_cell_bounds,
                 ) {
                     return Some(hit);
                 }
@@ -3006,7 +3119,7 @@ impl DocumentCore {
 
         for &page_num in &pages {
             let tree = self.build_page_tree_cached(page_num)?;
-            if let Some((pi, x, y, h)) = find_cursor_by_path(
+            if let Some((pi, x, y, h, cell_bounds)) = find_cursor_by_path(
                 self,
                 &tree.root,
                 section_idx,
@@ -3016,11 +3129,9 @@ impl DocumentCore {
                 page_num,
                 None,
                 None,
+                None,
             ) {
-                return Ok(format!(
-                    "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
-                    pi, x, y, h
-                ));
+                return Ok(format_cursor_rect_json(pi, x, y, h, cell_bounds));
             }
         }
 
@@ -3036,13 +3147,15 @@ impl DocumentCore {
                 page: u32,
                 current_table_ctx: Option<CellContext>,
                 current_cell_ctx: Option<CellContext>,
-            ) -> Option<(u32, f64, f64, f64)> {
+                current_cell_bounds: Option<CellCursorBounds>,
+            ) -> Option<(u32, f64, f64, f64, Option<CellCursorBounds>)> {
                 let table_ctx = table_ctx_from_node(
                     node,
                     current_table_ctx.as_ref(),
                     current_cell_ctx.as_ref(),
                 );
                 let mut child_cell_ctx = current_cell_ctx.clone();
+                let mut child_cell_bounds = current_cell_bounds;
                 if let RenderNodeType::TableCell(ref tc) = node.node_type {
                     if let Some(cell_idx) = tc.model_cell_index {
                         child_cell_ctx = cell_ctx_for_table_cell(
@@ -3051,6 +3164,12 @@ impl DocumentCore {
                             0,
                             tc.text_direction,
                         );
+                        child_cell_bounds = Some(CellCursorBounds {
+                            x: node.bbox.x,
+                            y: node.bbox.y,
+                            w: node.bbox.width,
+                            h: node.bbox.height,
+                        });
                     }
                 }
                 if let RenderNodeType::TextRun(ref tr) = node.node_type {
@@ -3060,7 +3179,13 @@ impl DocumentCore {
                         core.repair_unwrapped_wrapper_cell_context(section_idx, ctx);
                     }
                     if cell_context_matches(&cell_context, parent_para, path) {
-                        return Some((page, node.bbox.x, node.bbox.y, node.bbox.height));
+                        return Some((
+                            page,
+                            node.bbox.x,
+                            node.bbox.y,
+                            node.bbox.height,
+                            child_cell_bounds,
+                        ));
                     }
                 }
                 for child in &node.children {
@@ -3073,13 +3198,14 @@ impl DocumentCore {
                         page,
                         table_ctx.clone(),
                         child_cell_ctx.clone(),
+                        child_cell_bounds,
                     ) {
                         return Some(hit);
                     }
                 }
                 None
             }
-            if let Some((pi, x, y, h)) = find_any_run(
+            if let Some((pi, x, y, h, cell_bounds)) = find_any_run(
                 self,
                 &tree.root,
                 section_idx,
@@ -3088,11 +3214,9 @@ impl DocumentCore {
                 page_num,
                 None,
                 None,
+                None,
             ) {
-                return Ok(format!(
-                    "{{\"pageIndex\":{},\"x\":{:.1},\"y\":{:.1},\"height\":{:.1}}}",
-                    pi, x, y, h
-                ));
+                return Ok(format_cursor_rect_json(pi, x, y, h, cell_bounds));
             }
         }
 
@@ -5049,7 +5173,19 @@ impl DocumentCore {
 
 #[cfg(test)]
 mod tests {
-    use super::{resolve_x_on_line, LineRunView};
+    use super::{clamp_cursor_to_cell_bounds, resolve_x_on_line, CellCursorBounds, LineRunView};
+
+    #[test]
+    fn cell_cursor_bounds_clamp_coordinates_and_height() {
+        let bounds = CellCursorBounds {
+            x: 10.0,
+            y: 20.0,
+            w: 30.0,
+            h: 8.0,
+        };
+        let (x, y, height, overflowed) = clamp_cursor_to_cell_bounds(50.0, 40.0, 14.0, bounds);
+        assert_eq!((x, y, height, overflowed), (40.0, 20.0, 8.0, true));
+    }
 
     // 줄 단위 x 해석(`resolve_x_on_line`)의 회귀 테스트.
     //

--- a/tests/issue_1951_table_cell_cursor_clip.rs
+++ b/tests/issue_1951_table_cell_cursor_clip.rs
@@ -1,0 +1,183 @@
+//! Issue #1951: 고정 높이 표 셀의 장문 입력 뒤 캐럿이 셀 가시 범위를 벗어나는 회귀.
+//!
+//! `복학원서.hwp` 첫 표의 대학명 입력 칸은 고정 높이 셀이다. 장문을 입력해도
+//! 편집 캐럿과 IME 조합 기준 좌표는 해당 셀 bbox 안에 남아야 한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::wasm_api::HwpDocument;
+use serde_json::{json, Value};
+
+const SAMPLE: &str = "samples/복학원서.hwp";
+
+fn sample_bytes() -> Vec<u8> {
+    std::fs::read(SAMPLE).unwrap_or_else(|e| panic!("read {SAMPLE}: {e}"))
+}
+
+fn find_college_value_cell(core: &DocumentCore) -> (usize, usize, usize) {
+    for (parent_para_idx, para) in core.document().sections[0].paragraphs.iter().enumerate() {
+        for (control_idx, control) in para.controls.iter().enumerate() {
+            let Control::Table(table) = control else {
+                continue;
+            };
+            let Some(label) = table.cells.iter().find(|cell| {
+                cell.paragraphs
+                    .iter()
+                    .any(|paragraph| paragraph.text.contains("Name of College"))
+            }) else {
+                continue;
+            };
+            let value_col = label.col + label.col_span;
+            let value_idx = table
+                .cells
+                .iter()
+                .position(|cell| cell.row == label.row && cell.col == value_col)
+                .expect("대학명 값 입력 셀");
+            return (parent_para_idx, control_idx, value_idx);
+        }
+    }
+    panic!("Name of College 표 셀을 찾지 못함");
+}
+
+fn parse_json(label: &str, value: &str) -> Value {
+    serde_json::from_str(value).unwrap_or_else(|e| panic!("parse {label}: {e}; json={value}"))
+}
+
+fn assert_rect_inside_cell(rect: &Value, cell: &Value, label: &str) {
+    assert_eq!(
+        rect["pageIndex"], cell["pageIndex"],
+        "{label}: page mismatch"
+    );
+    let x = rect["x"].as_f64().expect("cursor x");
+    let y = rect["y"].as_f64().expect("cursor y");
+    let h = rect["height"].as_f64().expect("cursor height");
+    let left = cell["x"].as_f64().expect("cell x");
+    let top = cell["y"].as_f64().expect("cell y");
+    let right = left + cell["w"].as_f64().expect("cell w");
+    let bottom = top + cell["h"].as_f64().expect("cell h");
+    const EPSILON: f64 = 0.11;
+
+    assert!(
+        x >= left - EPSILON && x <= right + EPSILON,
+        "{label}: caret x must stay inside cell: rect={rect}, cell={cell}"
+    );
+    assert!(
+        y >= top - EPSILON && y + h <= bottom + EPSILON,
+        "{label}: caret y/height must stay inside cell: rect={rect}, cell={cell}"
+    );
+}
+
+#[test]
+fn long_text_cursor_stays_in_fixed_cell_for_direct_and_path_queries() {
+    let bytes = sample_bytes();
+    let core = DocumentCore::from_bytes(&bytes).expect("parse sample for target lookup");
+    let (parent_para, control, cell) = find_college_value_cell(&core);
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse sample for edit");
+    let text = "가".repeat(160);
+
+    doc.insert_text_in_cell_deferred_pagination(
+        0,
+        parent_para as u32,
+        control as u32,
+        cell as u32,
+        0,
+        0,
+        &text,
+    )
+    .expect("insert long text in college cell with deferred pagination");
+
+    let bboxes = parse_json(
+        "table cell bboxes",
+        &doc.get_table_cell_bboxes(0, parent_para as u32, control as u32, Some(0))
+            .expect("get table cell bboxes"),
+    );
+    let target_bbox = bboxes
+        .as_array()
+        .expect("cell bboxes array")
+        .iter()
+        .find(|bbox| bbox["cellIdx"].as_u64() == Some(cell as u64))
+        .expect("target cell bbox");
+
+    let direct = parse_json(
+        "direct cell cursor",
+        &doc.get_cursor_rect_in_cell(
+            0,
+            parent_para as u32,
+            control as u32,
+            cell as u32,
+            0,
+            text.chars().count() as u32,
+        )
+        .expect("get direct cell cursor"),
+    );
+    assert_rect_inside_cell(&direct, target_bbox, "direct cell cursor");
+    assert_eq!(
+        direct["cellOverflowed"].as_bool(),
+        Some(true),
+        "지연 페이지네이션 중에는 overflow 상태를 Studio에 알려야 함: {direct}"
+    );
+    assert_eq!(
+        direct["cellBounds"]["x"], target_bbox["x"],
+        "direct cell cursor는 활성 셀 bbox를 함께 반환해야 함"
+    );
+
+    let path = json!([{
+        "controlIndex": control,
+        "cellIndex": cell,
+        "cellParaIndex": 0,
+    }])
+    .to_string();
+    let by_path = parse_json(
+        "path cell cursor",
+        &doc.get_cursor_rect_by_path(0, parent_para as u32, &path, text.chars().count() as u32)
+            .expect("get path cell cursor"),
+    );
+    assert_rect_inside_cell(&by_path, target_bbox, "path cell cursor");
+    assert_eq!(
+        by_path["cellOverflowed"].as_bool(),
+        Some(true),
+        "path cursor도 지연 레이아웃 overflow를 알려야 함: {by_path}"
+    );
+}
+
+#[test]
+fn one_depth_path_insert_reflows_the_same_as_direct_cell_insert() {
+    let bytes = sample_bytes();
+    let core = DocumentCore::from_bytes(&bytes).expect("parse sample for target lookup");
+    let (parent_para, control, cell) = find_college_value_cell(&core);
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse sample for edit");
+    let text = "가".repeat(160);
+    let path = json!([{
+        "controlIndex": control,
+        "cellIndex": cell,
+        "cellParaIndex": 0,
+    }])
+    .to_string();
+
+    doc.insert_text_in_cell_by_path(0, parent_para, &[(control, cell, 0)], 0, &text)
+        .expect("insert long text through one-depth path");
+
+    let bboxes = parse_json(
+        "table cell bboxes",
+        &doc.get_table_cell_bboxes(0, parent_para as u32, control as u32, Some(0))
+            .expect("get table cell bboxes"),
+    );
+    let target_bbox = bboxes
+        .as_array()
+        .expect("cell bboxes array")
+        .iter()
+        .find(|bbox| bbox["cellIdx"].as_u64() == Some(cell as u64))
+        .expect("target cell bbox");
+    let rect = parse_json(
+        "path cursor after path insert",
+        &doc.get_cursor_rect_by_path(0, parent_para as u32, &path, text.chars().count() as u32)
+            .expect("get path cursor"),
+    );
+
+    assert_rect_inside_cell(&rect, target_bbox, "path cursor after path insert");
+    assert_eq!(
+        rect["cellOverflowed"].as_bool(),
+        Some(false),
+        "즉시 재페이지네이션을 거친 one-depth path 삽입은 overflow가 남지 않아야 함: {rect}"
+    );
+}


### PR DESCRIPTION
## Summary

- 표 셀 장문 입력에서 cursor query가 셀 bbox를 반환하고, caret 및 IME 조합창을 그 범위 안으로 제한했습니다.
- 지연 입력이 셀 높이를 초과한 경우에만 즉시 페이지네이션을 수행해 표 행을 확장합니다.
- one-depth `cellPath` IME 삽입도 일반 셀 삽입 경로를 사용하도록 통일했습니다.

## Tests

- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`
- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
- `rhwp-studio`: `npm test`, `npx tsc --noEmit`
- `wasm-pack build --target web --out-dir pkg`
- `samples/복학원서.hwp` 브라우저 장문 입력 검증

Closes #1951
