### PR TITLE
render: widen CanvasKit text replay coverage

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -318,6 +318,7 @@ const renderEllipseBody = extractMethodBody(canvaskitSource, 'renderEllipse');
 const renderPathBody = extractMethodBody(canvaskitSource, 'renderPath');
 const renderLineBody = extractMethodBody(canvaskitSource, 'renderLine');
 const renderFormObjectBody = extractMethodBody(canvaskitSource, 'renderFormObject');
+const renderPlaceholderBody = extractMethodBody(canvaskitSource, 'renderPlaceholder');
 const renderTextRunBody = extractMethodBody(canvaskitSource, 'renderTextRun');
 const renderGlyphOutlineBody = extractMethodBody(canvaskitSource, 'renderGlyphOutline');
 const renderColorPaintGraphNodeBody = extractMethodBody(canvaskitSource, 'renderColorPaintGraphNode');
@@ -348,20 +349,42 @@ requireSnippet(
   /op\.formType === 'checkbox' \|\| op\.formType === 'radio'[\s\S]*?canvas\.drawLine[\s\S]*?const label = op\.caption \|\| op\.text[\s\S]*?this\.renderTextRun/,
   'form object replay should keep checkbox/radio mark and caption text branches explicit',
 );
+for (const [label, body, baselinePattern] of [
+  ['footnote marker', extractSwitchCaseClusterBody(renderOpBody, 'footnoteMarker'), /baseline: op\.fontSize \?\? 7/],
+  ['form object', renderFormObjectBody, /baseline: Math\.max\(10, op\.bbox\.height \* 0\.68\)/],
+  ['placeholder', renderPlaceholderBody, /baseline: Math\.max\(10, op\.bbox\.height \* 0\.65\)/],
+]) {
+  requireSnippet(body, baselinePattern, `${label} replay should declare its run-local baseline`);
+  assert.doesNotMatch(
+    body,
+    /baseline:\s*op\.bbox\.y/,
+    `${label} replay should pass a run-local baseline to renderTextRun`,
+  );
+}
 requireSnippet(
   renderTextRunBody,
-  /this\.recordTextRunCoverageGaps\(op\);[\s\S]*?canvas\.drawText\(op\.text, x, y, paint, font\)/,
-  'textRun replay should record unsupported effect diagnostics before drawing the compatibility text',
+  /this\.recordTextRunCoverageGaps\(op\);[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
+  'textRun replay should record unsupported effect diagnostics before drawing positioned glyphs',
 );
 requireSnippet(
   renderTextRunBody,
-  /const rotation = op\.rotation \?\? 0;[\s\S]*?if \(rotation !== 0\) \{[\s\S]*?canvas\.rotate\(rotation, x, y\);[\s\S]*?\}/,
-  'textRun replay should keep rotation on the direct CanvasKit path',
+  /const placementMatrix = this\.affineToCanvasKitMatrix\(op\.placement\?\.runToPage\);[\s\S]*?op\.bbox\.y \+ \(op\.baseline \?\? baseFontSize\)[\s\S]*?canvas\.concat\(placementMatrix\);[\s\S]*?canvas\.rotate\(rotation, originX, originY\);/,
+  'textRun replay should use canonical run placement with a page-space fallback',
 );
 requireSnippet(
   renderTextRunBody,
-  /let fontSize = baseFontSize;[\s\S]*?let y = op\.baseline \?\? op\.bbox\.y \+ baseFontSize;[\s\S]*?style\.superscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?y -= baseFontSize \* 0\.3;[\s\S]*?style\.subscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?y \+= baseFontSize \* 0\.15;/,
-  'textRun replay should keep superscript/subscript on the direct CanvasKit path',
+  /let fontSize = baseFontSize;[\s\S]*?let baselineShift = 0;[\s\S]*?style\.superscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?baselineShift -= baseFontSize \* 0\.3;[\s\S]*?style\.subscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?baselineShift \+= baseFontSize \* 0\.15;/,
+  'textRun replay should apply superscript/subscript offsets in run-local space',
+);
+requireSnippet(
+  renderTextRunBody,
+  /const codePoints = Array\.from\(op\.text\);[\s\S]*?const needsPreservedAdvances = style\.superscript \|\| style\.subscript;[\s\S]*?op\.positions\?\.length === codePoints\.length \+ 1[\s\S]*?needsPreservedAdvances && hasLayoutPositions[\s\S]*?font\.getGlyphIDs\(op\.text, codePoints\.length\)[\s\S]*?glyphPositions\[index \* 2\] = op\.positions!\[index\];[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
+  'textRun replay should preserve serialized layout advances when glyph size changes',
+);
+requireSnippet(
+  renderTextRunBody,
+  /textRun:glyphMapping[\s\S]*?textRun:layoutPositions/,
+  'textRun replay should expose malformed positioned-text fallbacks',
 );
 for (const expectedTextRunGap of [
   'textRun:verticalText',

--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -358,6 +358,11 @@ requireSnippet(
   /const rotation = op\.rotation \?\? 0;[\s\S]*?if \(rotation !== 0\) \{[\s\S]*?canvas\.rotate\(rotation, x, y\);[\s\S]*?\}/,
   'textRun replay should keep rotation on the direct CanvasKit path',
 );
+requireSnippet(
+  renderTextRunBody,
+  /let fontSize = baseFontSize;[\s\S]*?let y = op\.baseline \?\? op\.bbox\.y \+ baseFontSize;[\s\S]*?style\.superscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?y -= baseFontSize \* 0\.3;[\s\S]*?style\.subscript[\s\S]*?fontSize = baseFontSize \* 0\.7;[\s\S]*?y \+= baseFontSize \* 0\.15;/,
+  'textRun replay should keep superscript/subscript on the direct CanvasKit path',
+);
 for (const expectedTextRunGap of [
   'textRun:verticalText',
   'textRun:textDecoration',
@@ -366,8 +371,6 @@ for (const expectedTextRunGap of [
   'textRun:shadowTextEffect',
   'textRun:embossTextEffect',
   'textRun:engraveTextEffect',
-  'textRun:superscriptTextEffect',
-  'textRun:subscriptTextEffect',
   'textRun:shadeTextEffect',
   'textRun:ratioTextEffect',
 ]) {

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -1008,10 +1008,12 @@ export interface LayerTextRunOp {
   type: 'textRun';
   bbox: LayerBounds;
   text: string;
+  /** Run-local baseline offset from bbox.y when placement is absent. */
   baseline?: number;
   rotation?: number;
   isVertical?: boolean;
   style?: LayerTextStyle;
+  placement?: { runToPage?: LayerAffineTransform; baselineY?: number };
   positions?: number[];
 }
 

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -313,7 +313,7 @@ export class CanvasKitLayerRenderer {
           type: 'textRun',
           bbox: op.bbox,
           text: op.text,
-          baseline: op.bbox.y + (op.fontSize ?? 7),
+          baseline: op.fontSize ?? 7,
           style: { fontFamily: op.fontFamily, fontSize: op.fontSize, color: op.color },
         });
         return;
@@ -851,13 +851,13 @@ export class CanvasKitLayerRenderer {
     paint.setAntiAlias?.(true);
     const baseFontSize = style.fontSize ?? Math.max(1, op.bbox.height || 12);
     let fontSize = baseFontSize;
-    let y = op.baseline ?? op.bbox.y + baseFontSize;
+    let baselineShift = 0;
     if (style.superscript) {
       fontSize = baseFontSize * 0.7;
-      y -= baseFontSize * 0.3;
+      baselineShift -= baseFontSize * 0.3;
     } else if (style.subscript) {
       fontSize = baseFontSize * 0.7;
-      y += baseFontSize * 0.15;
+      baselineShift += baseFontSize * 0.15;
     }
     // P16 한계: 기본 typeface 가 없으면 (로딩 실패) 비-Latin (CJK 등) 텍스트는
     // 글리프를 만들 수 없어 조용히 skip 하고 진단(unsupportedOps)에만 남긴다.
@@ -869,13 +869,42 @@ export class CanvasKitLayerRenderer {
       return;
     }
     const font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
-    const x = op.bbox.x;
+    const placementMatrix = this.affineToCanvasKitMatrix(op.placement?.runToPage);
+    const originX = placementMatrix ? 0 : op.bbox.x;
+    const originY = placementMatrix
+      ? (op.placement?.baselineY ?? 0)
+      : op.bbox.y + (op.baseline ?? baseFontSize);
     const rotation = op.rotation ?? 0;
     canvas.save();
-    if (rotation !== 0) {
-      canvas.rotate(rotation, x, y);
+    if (placementMatrix) {
+      canvas.concat(placementMatrix);
+    } else if (rotation !== 0) {
+      canvas.rotate(rotation, originX, originY);
     }
-    canvas.drawText(op.text, x, y, paint, font);
+
+    const codePoints = Array.from(op.text);
+    const needsPreservedAdvances = style.superscript || style.subscript;
+    const hasLayoutPositions = op.positions?.length === codePoints.length + 1
+      && op.positions.every(Number.isFinite);
+    if (needsPreservedAdvances && hasLayoutPositions) {
+      const glyphIds = font.getGlyphIDs(op.text, codePoints.length);
+      if (glyphIds.length === codePoints.length) {
+        const glyphPositions = new Float32Array(codePoints.length * 2);
+        for (let index = 0; index < codePoints.length; index += 1) {
+          glyphPositions[index * 2] = op.positions![index];
+          glyphPositions[index * 2 + 1] = baselineShift;
+        }
+        canvas.drawGlyphs(glyphIds, glyphPositions, originX, originY, font, paint);
+      } else {
+        this.unsupportedOps.add('textRun:glyphMapping');
+        canvas.drawText(op.text, originX, originY + baselineShift, paint, font);
+      }
+    } else if (needsPreservedAdvances) {
+      this.unsupportedOps.add('textRun:layoutPositions');
+      canvas.drawText(op.text, originX, originY + baselineShift, paint, font);
+    } else {
+      canvas.drawText(op.text, originX, originY, paint, font);
+    }
     canvas.restore();
     font.delete?.();
     paint.delete?.();
@@ -902,7 +931,7 @@ export class CanvasKitLayerRenderer {
         type: 'textRun',
         bbox: { ...op.bbox, x: op.bbox.x + 4, width: Math.max(0, op.bbox.width - 8) },
         text: label,
-        baseline: op.bbox.y + Math.max(10, op.bbox.height * 0.68),
+        baseline: Math.max(10, op.bbox.height * 0.68),
         style: { fontSize: Math.max(9, Math.min(14, op.bbox.height * 0.55)), color: op.foreColor ?? '#111111' },
       });
     }
@@ -919,7 +948,7 @@ export class CanvasKitLayerRenderer {
         type: 'textRun',
         bbox: { ...op.bbox, x: op.bbox.x + 4 },
         text: op.label,
-        baseline: op.bbox.y + Math.max(10, op.bbox.height * 0.65),
+        baseline: Math.max(10, op.bbox.height * 0.65),
         style: { fontSize: Math.max(9, Math.min(14, op.bbox.height * 0.45)), color: '#555555' },
       });
     }

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -826,12 +826,6 @@ export class CanvasKitLayerRenderer {
     if (style.engrave) {
       this.unsupportedOps.add('textRun:engraveTextEffect');
     }
-    if (style.superscript) {
-      this.unsupportedOps.add('textRun:superscriptTextEffect');
-    }
-    if (style.subscript) {
-      this.unsupportedOps.add('textRun:subscriptTextEffect');
-    }
     if (style.shadeColor && style.shadeColor.toLowerCase() !== '#ffffff') {
       this.unsupportedOps.add('textRun:shadeTextEffect');
     }
@@ -855,7 +849,16 @@ export class CanvasKitLayerRenderer {
     this.recordTextRunCoverageGaps(op);
     const paint = this.makeFillPaint(style.color ?? '#000000');
     paint.setAntiAlias?.(true);
-    const fontSize = style.fontSize ?? Math.max(1, op.bbox.height || 12);
+    const baseFontSize = style.fontSize ?? Math.max(1, op.bbox.height || 12);
+    let fontSize = baseFontSize;
+    let y = op.baseline ?? op.bbox.y + baseFontSize;
+    if (style.superscript) {
+      fontSize = baseFontSize * 0.7;
+      y -= baseFontSize * 0.3;
+    } else if (style.subscript) {
+      fontSize = baseFontSize * 0.7;
+      y += baseFontSize * 0.15;
+    }
     // P16 한계: 기본 typeface 가 없으면 (로딩 실패) 비-Latin (CJK 등) 텍스트는
     // 글리프를 만들 수 없어 조용히 skip 하고 진단(unsupportedOps)에만 남긴다.
     // Canvas2D 로 덮지 않는 것이 P16 본질이다. fontFamily 별 typeface 매핑과
@@ -867,7 +870,6 @@ export class CanvasKitLayerRenderer {
     }
     const font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
     const x = op.bbox.x;
-    const y = op.baseline ?? op.bbox.y + fontSize;
     const rotation = op.rotation ?? 0;
     canvas.save();
     if (rotation !== 0) {

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -646,12 +646,6 @@ fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
     if run.style.engrave {
         return Some("engraveTextEffect");
     }
-    if run.style.superscript {
-        return Some("superscriptTextEffect");
-    }
-    if run.style.subscript {
-        return Some("subscriptTextEffect");
-    }
     if run.style.shade_color != 0x00FF_FFFF {
         return Some("shadeTextEffect");
     }
@@ -1177,34 +1171,22 @@ mod tests {
         ]);
 
         let default_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Default);
-        assert_eq!(default_plan.summary.direct_items, 2);
-        assert_eq!(default_plan.summary.direct_required_items, 3);
+        assert_eq!(default_plan.summary.direct_items, 4);
+        assert_eq!(default_plan.summary.direct_required_items, 1);
         assert_eq!(
             default_plan.items[2].detail.as_deref(),
             Some("verticalText")
         );
-        assert_eq!(
-            default_plan.items[3].detail.as_deref(),
-            Some("superscriptTextEffect")
-        );
-        assert_eq!(
-            default_plan.items[4].detail.as_deref(),
-            Some("subscriptTextEffect")
-        );
+        assert_eq!(default_plan.items[3].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(default_plan.items[4].status, CanvasKitReplayStatus::Direct);
 
         let compat_plan = analyze_canvaskit_replay_plan(&tree, CanvasKitReplayMode::Compat);
-        assert_eq!(compat_plan.summary.direct_items, 2);
-        assert_eq!(compat_plan.summary.direct_required_items, 3);
+        assert_eq!(compat_plan.summary.direct_items, 4);
+        assert_eq!(compat_plan.summary.direct_required_items, 1);
         assert_eq!(compat_plan.summary.compat_overlay_items, 0);
         assert_eq!(compat_plan.items[2].detail.as_deref(), Some("verticalText"));
-        assert_eq!(
-            compat_plan.items[3].detail.as_deref(),
-            Some("superscriptTextEffect")
-        );
-        assert_eq!(
-            compat_plan.items[4].detail.as_deref(),
-            Some("subscriptTextEffect")
-        );
+        assert_eq!(compat_plan.items[3].status, CanvasKitReplayStatus::Direct);
+        assert_eq!(compat_plan.items[4].status, CanvasKitReplayStatus::Direct);
     }
 
     #[test]

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -784,6 +784,7 @@ mod tests {
     use crate::model::control::FormType;
     use crate::model::style::ImageFillMode;
     use crate::paint::{GroupKind, LayerNode, ResolvedImageKind, ResolvedImagePayload};
+    use crate::renderer::composer::CharOverlapInfo;
     use crate::renderer::equation::layout::{LayoutBox, LayoutKind};
     use crate::renderer::render_tree::{
         BoundingBox, EquationNode, FootnoteMarkerNode, FormObjectNode, ImageNode,
@@ -1187,6 +1188,24 @@ mod tests {
         assert_eq!(compat_plan.items[2].detail.as_deref(), Some("verticalText"));
         assert_eq!(compat_plan.items[3].status, CanvasKitReplayStatus::Direct);
         assert_eq!(compat_plan.items[4].status, CanvasKitReplayStatus::Direct);
+    }
+
+    #[test]
+    fn superscript_with_char_overlap_stays_policy_visible() {
+        let mut superscript = text_run("AB");
+        superscript.style.superscript = true;
+        superscript.char_overlap = Some(CharOverlapInfo {
+            border_type: 0,
+            inner_char_size: 100,
+        });
+        let tree = tree_with_ops(vec![PaintOp::text_run(bbox(), superscript)]);
+
+        for mode in [CanvasKitReplayMode::Default, CanvasKitReplayMode::Compat] {
+            let plan = analyze_canvaskit_replay_plan(&tree, mode);
+            assert_eq!(plan.summary.direct_required_items, 1);
+            assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
+            assert_eq!(plan.items[0].detail.as_deref(), Some("charOverlap"));
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 무엇을 바꿨나

- CanvasKit `TextRun`에서 위첨자/아래첨자를 더 이상 unsupported effect로 분류하지 않고 direct replay 합니다.
- 기존 SVG/WebCanvas와 같은 비율로 글꼴 크기와 baseline을 조정합니다.
- `placement.runToPage`와 직렬화된 `positions`를 사용해서 회전된 run의 위치와 원래 layout advance를 유지합니다.
- 위치 배열이나 glyph mapping이 불완전한 경우에는 `textRun:layoutPositions`, `textRun:glyphMapping` 진단을 남깁니다.
- `charOverlap`과 첨자가 같이 있는 경우는 계속 fallback-required로 남도록 정책 테스트를 추가했습니다.

## 왜 필요한가

P32에서 object fragment의 의도적인 replay gap을 진단으로 고정했고, 이번 단계에서는 이미 다른 renderer에서 검증된 위첨자/아래첨자 동작을 CanvasKit direct path로 옮깁니다.

단순히 70% 크기의 문자열을 한 번에 그리면 여러 글자의 advance까지 같이 줄어듭니다. 또 `baseline`은 page 절대 좌표가 아니라 run 내부 좌표라서 그대로 사용하면 페이지 아래쪽이나 회전된 text run에서 위치가 틀어집니다. 이번 PR은 glyph 크기만 줄이고 layout이 계산한 위치는 그대로 유지하도록 이 둘을 함께 처리합니다.

## 이번 PR에서 하지 않는 것

- public canvas 기본 renderer는 바꾸지 않습니다.
- CanvasKit에 layout/measurement 권한을 주지 않습니다.
- `charOverlap`, vertical text, decoration, outline/shadow 같은 나머지 text gap은 계속 진단 또는 fallback 대상으로 유지합니다.
- `GlyphRun`/`GlyphOutline` 선택 정책은 변경하지 않습니다.

## 확인

- `cargo fmt --all -- --check`
- `cargo test renderer::canvaskit_policy::tests --lib` (18 passed)
- `node --check e2e/renderer-contract.test.mjs`
- `npm run e2e:renderer-contract`
- `wasm-pack build --target web --dev`
- `npm run build`
- `git diff --check upstream/devel`

Refs #536
