### PR TITLE
fix(render): harden CanvasKit script replay

### DIFF
--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -321,6 +321,7 @@ const renderLineBody = extractMethodBody(canvaskitSource, 'renderLine');
 const renderFormObjectBody = extractMethodBody(canvaskitSource, 'renderFormObject');
 const renderPlaceholderBody = extractMethodBody(canvaskitSource, 'renderPlaceholder');
 const renderTextRunBody = extractMethodBody(canvaskitSource, 'renderTextRun');
+const renderShapedScriptTextBody = extractMethodBody(canvaskitSource, 'renderShapedScriptText');
 const renderGlyphOutlineBody = extractMethodBody(canvaskitSource, 'renderGlyphOutline');
 const renderColorPaintGraphNodeBody = extractMethodBody(canvaskitSource, 'renderColorPaintGraphNode');
 const recordTextRunCoverageGapsBody = extractMethodBody(canvaskitSource, 'recordTextRunCoverageGaps');
@@ -340,7 +341,12 @@ try {
   await vite.close();
 }
 
-function runExecutableTextReplay(op, { glyphIds, drawGlyphsError } = {}) {
+function runExecutableTextReplay(op, {
+  glyphIds,
+  drawGlyphsError,
+  drawParagraphError,
+  shapedTextAvailable = true,
+} = {}) {
   const events = [];
   const unsupportedOps = new Set();
   const replayText = op.displayText ?? op.text;
@@ -361,6 +367,34 @@ function runExecutableTextReplay(op, { glyphIds, drawGlyphsError } = {}) {
       events.push({ type: 'font.delete' });
     }
   }
+
+  class FakeParagraphStyle {
+    constructor(style) {
+      this.style = style;
+      events.push({ type: 'paragraphStyle.create', style });
+    }
+  }
+
+  const paragraph = {
+    layout(width) {
+      events.push({ type: 'paragraph.layout', width });
+    },
+    delete() {
+      events.push({ type: 'paragraph.delete' });
+    },
+  };
+  const paragraphBuilder = {
+    addText(text) {
+      events.push({ type: 'paragraphBuilder.addText', text });
+    },
+    build() {
+      events.push({ type: 'paragraphBuilder.build' });
+      return paragraph;
+    },
+    delete() {
+      events.push({ type: 'paragraphBuilder.delete' });
+    },
+  };
 
   const paint = {
     setAntiAlias(value) {
@@ -393,11 +427,24 @@ function runExecutableTextReplay(op, { glyphIds, drawGlyphsError } = {}) {
     drawText(text, x, y) {
       events.push({ type: 'canvas.drawText', text, x, y });
     },
+    drawParagraph(_paragraph, x, y) {
+      events.push({ type: 'canvas.drawParagraph', x, y });
+      if (drawParagraphError) throw drawParagraphError;
+    },
     restore() {
       events.push({ type: 'canvas.restore' });
     },
   };
-  const renderer = new CanvasKitLayerRendererRuntime({ Font: FakeFont }, 'default', {}, {});
+  const renderer = new CanvasKitLayerRendererRuntime({
+    Font: FakeFont,
+    ParagraphStyle: FakeParagraphStyle,
+    ParagraphBuilder: {
+      Make(style, fontManager) {
+        events.push({ type: 'paragraphBuilder.make', style, fontManager });
+        return paragraphBuilder;
+      },
+    },
+  }, 'default', {}, {}, shapedTextAvailable ? {} : null, 'Noto Sans KR');
   renderer.unsupportedOps = unsupportedOps;
   renderer.recordTextRunCoverageGaps = () => {
     events.push({ type: 'coverage.record' });
@@ -406,6 +453,7 @@ function runExecutableTextReplay(op, { glyphIds, drawGlyphsError } = {}) {
     events.push({ type: 'paint.create' });
     return paint;
   };
+  renderer.color = (color) => color;
 
   let error = null;
   try {
@@ -470,13 +518,18 @@ requireSnippet(
 );
 requireSnippet(
   renderTextRunBody,
-  /const replayText = op\.displayText \?\? op\.text;[\s\S]*?const replayPositions = op\.displayText !== undefined \? op\.displayPositions : op\.positions;[\s\S]*?const codePoints = Array\.from\(replayText\);[\s\S]*?const hasSimpleScriptText[\s\S]*?code >= 0x20 && code <= 0x7e[\s\S]*?needsPreservedAdvances && hasSimpleScriptText && hasLayoutPositions[\s\S]*?font\.getGlyphIDs\(replayText, codePoints\.length\)[\s\S]*?glyphIds\.every\(\(glyphId\) => glyphId !== 0\)[\s\S]*?glyphPositions\[index \* 2\] = replayPositions!\[index\];[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
+  /const replayText = op\.displayText \?\? op\.text;[\s\S]*?const replayPositions = op\.displayText !== undefined \? op\.displayPositions : op\.positions;[\s\S]*?const codePoints = Array\.from\(replayText\);[\s\S]*?const hasSimpleScriptText[\s\S]*?code >= 0x20 && code <= 0x7e[\s\S]*?needsPreservedAdvances && !hasSimpleScriptText[\s\S]*?this\.renderShapedScriptText\([\s\S]*?needsPreservedAdvances && hasLayoutPositions[\s\S]*?font\.getGlyphIDs\(replayText, codePoints\.length\)[\s\S]*?glyphIds\.every\(\(glyphId\) => glyphId !== 0\)[\s\S]*?glyphPositions\[index \* 2\] = replayPositions!\[index\];[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
   'textRun replay should preserve serialized layout advances when glyph size changes',
 );
 requireSnippet(
+  renderShapedScriptTextBody,
+  /new this\.canvasKit\.ParagraphStyle[\s\S]*?this\.canvasKit\.ParagraphBuilder\.Make[\s\S]*?builder\.addText\(text\)[\s\S]*?paragraph\.layout\(CanvasKitLayerRenderer\.MAX_SHAPED_TEXT_WIDTH\)[\s\S]*?canvas\.drawParagraph\(paragraph, originX, originY - fontSize \+ baselineShift\)[\s\S]*?paragraph\.delete\?\.\(\)[\s\S]*?builder\.delete\?\.\(\)/,
+  'non-ASCII script replay should use CanvasKit paragraph shaping and release native objects',
+);
+requireSnippet(
   renderTextRunBody,
-  /textRun:glyphMapping[\s\S]*?textRun:scriptTextRequiresShaping[\s\S]*?textRun:layoutPositions/,
-  'textRun replay should expose malformed positioned-text fallbacks',
+  /textRun:scriptTextRequiresShaping[\s\S]*?textRun:glyphMapping[\s\S]*?textRun:layoutPositions/,
+  'textRun replay should expose unavailable shaping and malformed positioned-text fallbacks',
 );
 requireSnippet(
   renderTextRunBody,
@@ -543,22 +596,22 @@ assert.deepEqual(
 const projectedTextReplay = runExecutableTextReplay({
   type: 'textRun',
   bbox: { x: 0, y: 20, width: 30, height: 20 },
-  text: '\uF012B',
-  displayText: 'AB',
+  text: '\u{F012B}',
+  displayText: '(인)',
   baseline: 15,
   positions: [0, 5],
-  displayPositions: [0, 11, 22],
+  displayPositions: [0, 11, 22, 33],
   style: { fontSize: 20, superscript: true },
 });
 assert.deepEqual(
-  projectedTextReplay.events.find((event) => event.type === 'font.getGlyphIDs'),
-  { type: 'font.getGlyphIDs', text: 'AB', count: 2 },
-  'CanvasKit replay should use displayText when the IR declares a visual projection',
+  projectedTextReplay.events.find((event) => event.type === 'paragraphBuilder.addText'),
+  { type: 'paragraphBuilder.addText', text: '(인)' },
+  'CanvasKit replay should shape the actual PUA display projection',
 );
-assert.deepEqual(
-  projectedTextReplay.events.find((event) => event.type === 'canvas.drawGlyphs')?.positions,
-  [0, -6, 11, -6],
-  'displayText replay should use matching displayPositions',
+assert.equal(
+  projectedTextReplay.events.some((event) => event.type === 'canvas.drawGlyphs'),
+  false,
+  'a non-ASCII PUA display projection should not enter direct glyph replay',
 );
 
 const shapedTextReplay = runExecutableTextReplay({
@@ -569,11 +622,31 @@ const shapedTextReplay = runExecutableTextReplay({
   positions: [0, 8, 8],
   style: { fontSize: 20, superscript: true },
 });
-assert.equal(shapedTextReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'), true);
 assert.equal(
   shapedTextReplay.events.some((event) => event.type === 'font.getGlyphIDs'),
   false,
   'text requiring shaping should not enter nominal glyph replay',
+);
+assert.equal(
+  shapedTextReplay.events.some((event) => event.type === 'canvas.drawParagraph'),
+  true,
+  'text requiring shaping should use CanvasKit paragraph replay',
+);
+assert.equal(shapedTextReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'), false);
+
+const unavailableShapingReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: 'e\u0301',
+  baseline: 15,
+  positions: [0, 8, 8],
+  style: { fontSize: 20, superscript: true },
+}, { shapedTextAvailable: false });
+assert.equal(unavailableShapingReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'), true);
+assert.equal(
+  unavailableShapingReplay.events.some((event) => event.type === 'canvas.drawText'),
+  false,
+  'text requiring shaping must not silently fall back to CanvasKit drawText',
 );
 
 const missingGlyphReplay = runExecutableTextReplay({
@@ -605,6 +678,23 @@ for (const cleanupEvent of ['canvas.restore', 'font.delete', 'paint.delete']) {
     cleanupReplay.events.some((event) => event.type === cleanupEvent),
     true,
     `${cleanupEvent} should run after drawGlyphs throws`,
+  );
+}
+
+const shapedCleanupReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: 'e\u0301',
+  baseline: 15,
+  positions: [0, 8, 8],
+  style: { fontSize: 20, superscript: true },
+}, { drawParagraphError: new Error('paragraph draw failed') });
+assert.equal(shapedCleanupReplay.error?.message, 'paragraph draw failed');
+for (const cleanupEvent of ['canvas.restore', 'paragraph.delete', 'paragraphBuilder.delete', 'paint.delete']) {
+  assert.equal(
+    shapedCleanupReplay.events.some((event) => event.type === cleanupEvent),
+    true,
+    `${cleanupEvent} should run after drawParagraph throws`,
   );
 }
 for (const expectedTextRunGap of [

--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -2,6 +2,7 @@ import assert from 'node:assert/strict';
 import fs from 'node:fs';
 import path from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { createServer } from 'vite';
 
 const studioRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '..');
 const repoRoot = path.resolve(studioRoot, '..');
@@ -324,6 +325,97 @@ const renderGlyphOutlineBody = extractMethodBody(canvaskitSource, 'renderGlyphOu
 const renderColorPaintGraphNodeBody = extractMethodBody(canvaskitSource, 'renderColorPaintGraphNode');
 const recordTextRunCoverageGapsBody = extractMethodBody(canvaskitSource, 'recordTextRunCoverageGaps');
 
+const vite = await createServer({
+  root: studioRoot,
+  server: { middlewareMode: true },
+  appType: 'custom',
+  logLevel: 'silent',
+});
+let CanvasKitLayerRendererRuntime;
+try {
+  ({ CanvasKitLayerRenderer: CanvasKitLayerRendererRuntime } = await vite.ssrLoadModule(
+    '/src/view/canvaskit-renderer.ts',
+  ));
+} finally {
+  await vite.close();
+}
+
+function runExecutableTextReplay(op, { glyphIds, drawGlyphsError } = {}) {
+  const events = [];
+  const unsupportedOps = new Set();
+  const replayText = op.displayText ?? op.text;
+  const resolvedGlyphIds = glyphIds
+    ?? Array.from({ length: Array.from(replayText).length }, (_, index) => index + 1);
+
+  class FakeFont {
+    constructor(_typeface, size) {
+      events.push({ type: 'font.create', size });
+    }
+
+    getGlyphIDs(text, count) {
+      events.push({ type: 'font.getGlyphIDs', text, count });
+      return Uint16Array.from(resolvedGlyphIds);
+    }
+
+    delete() {
+      events.push({ type: 'font.delete' });
+    }
+  }
+
+  const paint = {
+    setAntiAlias(value) {
+      events.push({ type: 'paint.antiAlias', value });
+    },
+    delete() {
+      events.push({ type: 'paint.delete' });
+    },
+  };
+  const canvas = {
+    save() {
+      events.push({ type: 'canvas.save' });
+    },
+    concat(matrix) {
+      events.push({ type: 'canvas.concat', matrix: Array.from(matrix) });
+    },
+    rotate(rotation, x, y) {
+      events.push({ type: 'canvas.rotate', rotation, x, y });
+    },
+    drawGlyphs(ids, positions, x, y) {
+      events.push({
+        type: 'canvas.drawGlyphs',
+        glyphIds: Array.from(ids),
+        positions: Array.from(positions),
+        x,
+        y,
+      });
+      if (drawGlyphsError) throw drawGlyphsError;
+    },
+    drawText(text, x, y) {
+      events.push({ type: 'canvas.drawText', text, x, y });
+    },
+    restore() {
+      events.push({ type: 'canvas.restore' });
+    },
+  };
+  const renderer = new CanvasKitLayerRendererRuntime({ Font: FakeFont }, 'default', {}, {});
+  renderer.unsupportedOps = unsupportedOps;
+  renderer.recordTextRunCoverageGaps = () => {
+    events.push({ type: 'coverage.record' });
+  };
+  renderer.makeFillPaint = () => {
+    events.push({ type: 'paint.create' });
+    return paint;
+  };
+
+  let error = null;
+  try {
+    renderer.renderTextRun(canvas, op);
+  } catch (caught) {
+    error = caught;
+  }
+  return { error, events, unsupportedOps };
+}
+
 requireSnippet(
   renderRectangleBody,
   /this\.drawStyledShape\(canvas, op\.bbox, op\.style,[\s\S]*?drawRRect[\s\S]*?drawRect/,
@@ -378,14 +470,143 @@ requireSnippet(
 );
 requireSnippet(
   renderTextRunBody,
-  /const codePoints = Array\.from\(op\.text\);[\s\S]*?const needsPreservedAdvances = style\.superscript \|\| style\.subscript;[\s\S]*?op\.positions\?\.length === codePoints\.length \+ 1[\s\S]*?needsPreservedAdvances && hasLayoutPositions[\s\S]*?font\.getGlyphIDs\(op\.text, codePoints\.length\)[\s\S]*?glyphPositions\[index \* 2\] = op\.positions!\[index\];[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
+  /const replayText = op\.displayText \?\? op\.text;[\s\S]*?const replayPositions = op\.displayText !== undefined \? op\.displayPositions : op\.positions;[\s\S]*?const codePoints = Array\.from\(replayText\);[\s\S]*?const hasSimpleScriptText[\s\S]*?code >= 0x20 && code <= 0x7e[\s\S]*?needsPreservedAdvances && hasSimpleScriptText && hasLayoutPositions[\s\S]*?font\.getGlyphIDs\(replayText, codePoints\.length\)[\s\S]*?glyphIds\.every\(\(glyphId\) => glyphId !== 0\)[\s\S]*?glyphPositions\[index \* 2\] = replayPositions!\[index\];[\s\S]*?canvas\.drawGlyphs\(glyphIds, glyphPositions, originX, originY, font, paint\)/,
   'textRun replay should preserve serialized layout advances when glyph size changes',
 );
 requireSnippet(
   renderTextRunBody,
-  /textRun:glyphMapping[\s\S]*?textRun:layoutPositions/,
+  /textRun:glyphMapping[\s\S]*?textRun:scriptTextRequiresShaping[\s\S]*?textRun:layoutPositions/,
   'textRun replay should expose malformed positioned-text fallbacks',
 );
+requireSnippet(
+  renderTextRunBody,
+  /try \{[\s\S]*?canvas\.save\(\);[\s\S]*?\} finally \{[\s\S]*?if \(canvasSaved\) canvas\.restore\(\);[\s\S]*?font\?\.delete\?\.\(\);[\s\S]*?paint\.delete\?\.\(\);/,
+  'textRun replay should restore CanvasKit state and delete native objects after failures',
+);
+
+const placedSuperscriptReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 10, y: 100, width: 30, height: 20 },
+  text: 'AB',
+  baseline: 15,
+  rotation: 90,
+  placement: {
+    runToPage: { a: 0, b: 1, c: -1, d: 0, e: 50, f: 60 },
+    baselineY: 0,
+  },
+  positions: [0, 12, 24],
+  style: { fontSize: 20, superscript: true },
+});
+assert.equal(placedSuperscriptReplay.error, null);
+assert.deepEqual(
+  placedSuperscriptReplay.events.find((event) => event.type === 'canvas.concat')?.matrix,
+  [0, -1, 50, 1, 0, 60, 0, 0, 1],
+  'placement transform should use the serialized affine coefficient order',
+);
+assert.equal(
+  placedSuperscriptReplay.events.some((event) => event.type === 'canvas.rotate'),
+  false,
+  'placement transform should suppress the legacy rotation fallback',
+);
+assert.deepEqual(
+  placedSuperscriptReplay.events.find((event) => event.type === 'canvas.drawGlyphs'),
+  {
+    type: 'canvas.drawGlyphs',
+    glyphIds: [1, 2],
+    positions: [0, -6, 12, -6],
+    x: 0,
+    y: 0,
+  },
+  'superscript replay should keep producer advances and apply a run-local baseline shift',
+);
+
+const rotatedSubscriptReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 7, y: 100, width: 30, height: 20 },
+  text: 'AB',
+  baseline: 15,
+  rotation: 90,
+  positions: [0, 9, 18],
+  style: { fontSize: 20, subscript: true },
+});
+assert.deepEqual(
+  rotatedSubscriptReplay.events.find((event) => event.type === 'canvas.rotate'),
+  { type: 'canvas.rotate', rotation: 90, x: 7, y: 115 },
+  'legacy placement fallback should add the run-local baseline exactly once',
+);
+assert.deepEqual(
+  rotatedSubscriptReplay.events.find((event) => event.type === 'canvas.drawGlyphs')?.positions,
+  [0, 3, 9, 3],
+  'subscript replay should apply its baseline shift in rotated run-local space',
+);
+
+const projectedTextReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: '\uF012B',
+  displayText: 'AB',
+  baseline: 15,
+  positions: [0, 5],
+  displayPositions: [0, 11, 22],
+  style: { fontSize: 20, superscript: true },
+});
+assert.deepEqual(
+  projectedTextReplay.events.find((event) => event.type === 'font.getGlyphIDs'),
+  { type: 'font.getGlyphIDs', text: 'AB', count: 2 },
+  'CanvasKit replay should use displayText when the IR declares a visual projection',
+);
+assert.deepEqual(
+  projectedTextReplay.events.find((event) => event.type === 'canvas.drawGlyphs')?.positions,
+  [0, -6, 11, -6],
+  'displayText replay should use matching displayPositions',
+);
+
+const shapedTextReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: 'e\u0301',
+  baseline: 15,
+  positions: [0, 8, 8],
+  style: { fontSize: 20, superscript: true },
+});
+assert.equal(shapedTextReplay.unsupportedOps.has('textRun:scriptTextRequiresShaping'), true);
+assert.equal(
+  shapedTextReplay.events.some((event) => event.type === 'font.getGlyphIDs'),
+  false,
+  'text requiring shaping should not enter nominal glyph replay',
+);
+
+const missingGlyphReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: 'AB',
+  baseline: 15,
+  positions: [0, 8, 16],
+  style: { fontSize: 20, superscript: true },
+}, { glyphIds: [1, 0] });
+assert.equal(missingGlyphReplay.unsupportedOps.has('textRun:glyphMapping'), true);
+assert.equal(
+  missingGlyphReplay.events.some((event) => event.type === 'canvas.drawGlyphs'),
+  false,
+  'glyph ID zero should reject positioned glyph replay',
+);
+
+const cleanupReplay = runExecutableTextReplay({
+  type: 'textRun',
+  bbox: { x: 0, y: 20, width: 30, height: 20 },
+  text: 'AB',
+  baseline: 15,
+  positions: [0, 8, 16],
+  style: { fontSize: 20, superscript: true },
+}, { drawGlyphsError: new Error('draw failed') });
+assert.equal(cleanupReplay.error?.message, 'draw failed');
+for (const cleanupEvent of ['canvas.restore', 'font.delete', 'paint.delete']) {
+  assert.equal(
+    cleanupReplay.events.some((event) => event.type === cleanupEvent),
+    true,
+    `${cleanupEvent} should run after drawGlyphs throws`,
+  );
+}
 for (const expectedTextRunGap of [
   'textRun:verticalText',
   'textRun:textDecoration',

--- a/rhwp-studio/src/core/types.ts
+++ b/rhwp-studio/src/core/types.ts
@@ -1012,6 +1012,7 @@ export interface LayerTextRunOp {
   type: 'textRun';
   bbox: LayerBounds;
   text: string;
+  displayText?: string;
   /** Run-local baseline offset from bbox.y when placement is absent. */
   baseline?: number;
   rotation?: number;
@@ -1019,6 +1020,7 @@ export interface LayerTextRunOp {
   style?: LayerTextStyle;
   placement?: { runToPage?: LayerAffineTransform; baselineY?: number };
   positions?: number[];
+  displayPositions?: number[];
 }
 
 export interface LayerFootnoteMarkerOp {

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -4,6 +4,7 @@ import type {
   CanvasKit,
   Color,
   Font,
+  FontMgr,
   Image as SkImage,
   Paint,
   Path,
@@ -78,6 +79,8 @@ export interface CanvasKitRenderDiagnostics {
 export class CanvasKitLayerRenderer {
   // Prevent pathological tiled fills from monopolizing the render loop.
   private static readonly MAX_IMAGE_TILE_DRAWS = 4096;
+  // 단일 text run은 줄바꿈 없이 문서가 지정한 위치에 재생한다.
+  private static readonly MAX_SHAPED_TEXT_WIDTH = 1_000_000;
 
   private readonly imageCache = new Map<string, SkImage>();
   private readonly unsupportedOps = new Set<string>();
@@ -90,6 +93,8 @@ export class CanvasKitLayerRenderer {
     private readonly renderMode: CanvasKitRenderMode,
     private readonly surfaceRequest: CanvasKitSurfaceRequest,
     private readonly defaultTypeface: Typeface | null,
+    private readonly defaultFontManager: FontMgr | null = null,
+    private readonly defaultFontFamily: string | null = null,
   ) {}
 
   static async create(
@@ -110,17 +115,30 @@ export class CanvasKitLayerRenderer {
     // "글자가 안 나오는" 현상이 나타날 수 있다. 이는 P16 foundation 의 알려진
     // non-goal 이며, 동일 컨트리뷰터의 후속 폰트 단계에서 다룬다 (Refs #536).
     let defaultTypeface: Typeface | null = null;
+    let defaultFontManager: FontMgr | null = null;
+    let defaultFontFamily: string | null = null;
     try {
       const response = await fetch('fonts/NotoSansKR-Regular.woff2');
       if (response.ok) {
         const bytes = await response.arrayBuffer();
         defaultTypeface = canvasKit.Typeface.MakeFreeTypeFaceFromData(bytes)
           ?? canvasKit.Typeface.MakeTypefaceFromData(bytes);
+        defaultFontManager = canvasKit.FontMgr.FromData(bytes);
+        if (defaultFontManager && defaultFontManager.countFamilies() > 0) {
+          defaultFontFamily = defaultFontManager.getFamilyName(0);
+        }
       }
     } catch (error) {
       console.warn('[CanvasKitLayerRenderer] 기본 CJK 폰트 로딩 실패:', error);
     }
-    return new CanvasKitLayerRenderer(canvasKit, renderMode, resolvedSurfaceRequest, defaultTypeface);
+    return new CanvasKitLayerRenderer(
+      canvasKit,
+      renderMode,
+      resolvedSurfaceRequest,
+      defaultTypeface,
+      defaultFontManager,
+      defaultFontFamily,
+    );
   }
 
   renderPage(tree: PageLayerTree, targetCanvas: HTMLCanvasElement, scale: number, pageInfo?: PageInfo): void {
@@ -207,6 +225,7 @@ export class CanvasKitLayerRenderer {
     }
     this.imageCache.clear();
     this.defaultTypeface?.delete();
+    this.defaultFontManager?.delete();
   }
 
   private makeSurface(targetCanvas: HTMLCanvasElement): SkSurface {
@@ -883,11 +902,10 @@ export class CanvasKitLayerRenderer {
       // 글리프를 만들 수 없어 조용히 skip 하고 진단(unsupportedOps)에만 남긴다.
       // Canvas2D 로 덮지 않는 것이 P16 본질이다. fontFamily 별 typeface 매핑과
       // 폴백 체인은 동일 컨트리뷰터의 후속 폰트 단계에서 보강한다 (Refs #536).
-      if (!this.defaultTypeface && /[^\u0000-\u00ff]/.test(replayText)) {
+      if (!this.defaultTypeface && !this.defaultFontManager && /[^\u0000-\u00ff]/.test(replayText)) {
         this.unsupportedOps.add('textRunFont');
         return;
       }
-      font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
       canvas.save();
       canvasSaved = true;
       if (placementMatrix) {
@@ -896,31 +914,41 @@ export class CanvasKitLayerRenderer {
         canvas.rotate(rotation, originX, originY);
       }
 
-      if (needsPreservedAdvances && hasSimpleScriptText && hasLayoutPositions) {
-        const glyphIds = font.getGlyphIDs(replayText, codePoints.length);
-        const hasGlyphMapping = glyphIds.length === codePoints.length
-          && glyphIds.every((glyphId) => glyphId !== 0);
-        if (hasGlyphMapping) {
-          const glyphPositions = new Float32Array(codePoints.length * 2);
-          for (let index = 0; index < codePoints.length; index += 1) {
-            glyphPositions[index * 2] = replayPositions![index];
-            glyphPositions[index * 2 + 1] = baselineShift;
-          }
-          canvas.drawGlyphs(glyphIds, glyphPositions, originX, originY, font, paint);
-        } else {
-          this.unsupportedOps.add('textRun:glyphMapping');
-          canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
-        }
-      } else if (needsPreservedAdvances) {
-        if (!hasSimpleScriptText) {
+      if (needsPreservedAdvances && !hasSimpleScriptText) {
+        if (!this.renderShapedScriptText(
+          canvas,
+          replayText,
+          style.color ?? '#000000',
+          fontSize,
+          originX,
+          originY,
+          baselineShift,
+        )) {
           this.unsupportedOps.add('textRun:scriptTextRequiresShaping');
         }
-        if (!hasLayoutPositions) {
-          this.unsupportedOps.add('textRun:layoutPositions');
-        }
-        canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
       } else {
-        canvas.drawText(replayText, originX, originY, paint, font);
+        font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
+        if (needsPreservedAdvances && hasLayoutPositions) {
+          const glyphIds = font.getGlyphIDs(replayText, codePoints.length);
+          const hasGlyphMapping = glyphIds.length === codePoints.length
+            && glyphIds.every((glyphId) => glyphId !== 0);
+          if (hasGlyphMapping) {
+            const glyphPositions = new Float32Array(codePoints.length * 2);
+            for (let index = 0; index < codePoints.length; index += 1) {
+              glyphPositions[index * 2] = replayPositions![index];
+              glyphPositions[index * 2 + 1] = baselineShift;
+            }
+            canvas.drawGlyphs(glyphIds, glyphPositions, originX, originY, font, paint);
+          } else {
+            this.unsupportedOps.add('textRun:glyphMapping');
+            canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
+          }
+        } else if (needsPreservedAdvances) {
+          this.unsupportedOps.add('textRun:layoutPositions');
+          canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
+        } else {
+          canvas.drawText(replayText, originX, originY, paint, font);
+        }
       }
     } finally {
       try {
@@ -929,6 +957,41 @@ export class CanvasKitLayerRenderer {
         font?.delete?.();
         paint.delete?.();
       }
+    }
+  }
+
+  private renderShapedScriptText(
+    canvas: SkCanvas,
+    text: string,
+    color: string,
+    fontSize: number,
+    originX: number,
+    originY: number,
+    baselineShift: number,
+  ): boolean {
+    if (!this.defaultFontManager) return false;
+    const textStyle = {
+      color: this.color(color),
+      fontSize,
+      ...(this.defaultFontFamily ? { fontFamilies: [this.defaultFontFamily] } : {}),
+    };
+    const paragraphStyle = new this.canvasKit.ParagraphStyle({
+      maxLines: 1,
+      textStyle,
+    });
+    const builder = this.canvasKit.ParagraphBuilder.Make(paragraphStyle, this.defaultFontManager);
+    try {
+      builder.addText(text);
+      const paragraph = builder.build();
+      try {
+        paragraph.layout(CanvasKitLayerRenderer.MAX_SHAPED_TEXT_WIDTH);
+        canvas.drawParagraph(paragraph, originX, originY - fontSize + baselineShift);
+        return true;
+      } finally {
+        paragraph.delete?.();
+      }
+    } finally {
+      builder.delete?.();
     }
   }
 

--- a/rhwp-studio/src/view/canvaskit-renderer.ts
+++ b/rhwp-studio/src/view/canvaskit-renderer.ts
@@ -3,6 +3,7 @@ import type {
   Canvas,
   CanvasKit,
   Color,
+  Font,
   Image as SkImage,
   Paint,
   Path,
@@ -844,11 +845,12 @@ export class CanvasKitLayerRenderer {
   }
 
   private renderTextRun(canvas: SkCanvas, op: LayerTextRunOp): void {
-    if (!op.text) return;
+    const replayText = op.displayText ?? op.text;
+    const replayPositions = op.displayText !== undefined ? op.displayPositions : op.positions;
+    if (!replayText) return;
     const style = op.style ?? {};
     this.recordTextRunCoverageGaps(op);
     const paint = this.makeFillPaint(style.color ?? '#000000');
-    paint.setAntiAlias?.(true);
     const baseFontSize = style.fontSize ?? Math.max(1, op.bbox.height || 12);
     let fontSize = baseFontSize;
     let baselineShift = 0;
@@ -859,55 +861,75 @@ export class CanvasKitLayerRenderer {
       fontSize = baseFontSize * 0.7;
       baselineShift += baseFontSize * 0.15;
     }
-    // P16 한계: 기본 typeface 가 없으면 (로딩 실패) 비-Latin (CJK 등) 텍스트는
-    // 글리프를 만들 수 없어 조용히 skip 하고 진단(unsupportedOps)에만 남긴다.
-    // Canvas2D 로 덮지 않는 것이 P16 본질이다. fontFamily 별 typeface 매핑과
-    // 폴백 체인은 동일 컨트리뷰터의 후속 폰트 단계에서 보강한다 (Refs #536).
-    if (!this.defaultTypeface && /[^\u0000-\u00ff]/.test(op.text)) {
-      this.unsupportedOps.add('textRunFont');
-      paint.delete();
-      return;
-    }
-    const font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
     const placementMatrix = this.affineToCanvasKitMatrix(op.placement?.runToPage);
     const originX = placementMatrix ? 0 : op.bbox.x;
     const originY = placementMatrix
       ? (op.placement?.baselineY ?? 0)
       : op.bbox.y + (op.baseline ?? baseFontSize);
     const rotation = op.rotation ?? 0;
-    canvas.save();
-    if (placementMatrix) {
-      canvas.concat(placementMatrix);
-    } else if (rotation !== 0) {
-      canvas.rotate(rotation, originX, originY);
-    }
-
-    const codePoints = Array.from(op.text);
+    const codePoints = Array.from(replayText);
     const needsPreservedAdvances = style.superscript || style.subscript;
-    const hasLayoutPositions = op.positions?.length === codePoints.length + 1
-      && op.positions.every(Number.isFinite);
-    if (needsPreservedAdvances && hasLayoutPositions) {
-      const glyphIds = font.getGlyphIDs(op.text, codePoints.length);
-      if (glyphIds.length === codePoints.length) {
-        const glyphPositions = new Float32Array(codePoints.length * 2);
-        for (let index = 0; index < codePoints.length; index += 1) {
-          glyphPositions[index * 2] = op.positions![index];
-          glyphPositions[index * 2 + 1] = baselineShift;
-        }
-        canvas.drawGlyphs(glyphIds, glyphPositions, originX, originY, font, paint);
-      } else {
-        this.unsupportedOps.add('textRun:glyphMapping');
-        canvas.drawText(op.text, originX, originY + baselineShift, paint, font);
+    const hasSimpleScriptText = codePoints.every((codePoint) => {
+      const code = codePoint.charCodeAt(0);
+      return codePoint.length === 1 && code >= 0x20 && code <= 0x7e;
+    });
+    const hasLayoutPositions = replayPositions?.length === codePoints.length + 1
+      && replayPositions.every(Number.isFinite);
+    let font: Font | null = null;
+    let canvasSaved = false;
+    try {
+      paint.setAntiAlias?.(true);
+      // P16 한계: 기본 typeface 가 없으면 (로딩 실패) 비-Latin (CJK 등) 텍스트는
+      // 글리프를 만들 수 없어 조용히 skip 하고 진단(unsupportedOps)에만 남긴다.
+      // Canvas2D 로 덮지 않는 것이 P16 본질이다. fontFamily 별 typeface 매핑과
+      // 폴백 체인은 동일 컨트리뷰터의 후속 폰트 단계에서 보강한다 (Refs #536).
+      if (!this.defaultTypeface && /[^\u0000-\u00ff]/.test(replayText)) {
+        this.unsupportedOps.add('textRunFont');
+        return;
       }
-    } else if (needsPreservedAdvances) {
-      this.unsupportedOps.add('textRun:layoutPositions');
-      canvas.drawText(op.text, originX, originY + baselineShift, paint, font);
-    } else {
-      canvas.drawText(op.text, originX, originY, paint, font);
+      font = new this.canvasKit.Font(this.defaultTypeface, fontSize);
+      canvas.save();
+      canvasSaved = true;
+      if (placementMatrix) {
+        canvas.concat(placementMatrix);
+      } else if (rotation !== 0) {
+        canvas.rotate(rotation, originX, originY);
+      }
+
+      if (needsPreservedAdvances && hasSimpleScriptText && hasLayoutPositions) {
+        const glyphIds = font.getGlyphIDs(replayText, codePoints.length);
+        const hasGlyphMapping = glyphIds.length === codePoints.length
+          && glyphIds.every((glyphId) => glyphId !== 0);
+        if (hasGlyphMapping) {
+          const glyphPositions = new Float32Array(codePoints.length * 2);
+          for (let index = 0; index < codePoints.length; index += 1) {
+            glyphPositions[index * 2] = replayPositions![index];
+            glyphPositions[index * 2 + 1] = baselineShift;
+          }
+          canvas.drawGlyphs(glyphIds, glyphPositions, originX, originY, font, paint);
+        } else {
+          this.unsupportedOps.add('textRun:glyphMapping');
+          canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
+        }
+      } else if (needsPreservedAdvances) {
+        if (!hasSimpleScriptText) {
+          this.unsupportedOps.add('textRun:scriptTextRequiresShaping');
+        }
+        if (!hasLayoutPositions) {
+          this.unsupportedOps.add('textRun:layoutPositions');
+        }
+        canvas.drawText(replayText, originX, originY + baselineShift, paint, font);
+      } else {
+        canvas.drawText(replayText, originX, originY, paint, font);
+      }
+    } finally {
+      try {
+        if (canvasSaved) canvas.restore();
+      } finally {
+        font?.delete?.();
+        paint.delete?.();
+      }
     }
-    canvas.restore();
-    font.delete?.();
-    paint.delete?.();
   }
 
   private renderFormObject(canvas: SkCanvas, op: LayerFormObjectOp): void {

--- a/src/renderer/canvaskit_policy.rs
+++ b/src/renderer/canvaskit_policy.rs
@@ -9,6 +9,7 @@ use crate::paint::{
     PaintOp, PaintReplayPlane, ResolvedImageKind, ResolvedImagePayload, TextDecorationKind,
     TextVariantKind,
 };
+use crate::renderer::composer::expand_pua_display_text;
 use crate::renderer::layer_renderer::{
     analyze_text_variant_selection, TextVariantSelectionOptions, VariantSelectedReason,
     VariantSelectionBackend,
@@ -652,6 +653,15 @@ fn text_run_transition_detail(run: &TextRunNode) -> Option<&'static str> {
     if (run.style.ratio - 1.0).abs() > f64::EPSILON {
         return Some("ratioTextEffect");
     }
+    if run.style.superscript || run.style.subscript {
+        let display_text = expand_pua_display_text(&run.text);
+        if !display_text
+            .bytes()
+            .all(|byte| (0x20..=0x7e).contains(&byte))
+        {
+            return Some("scriptTextRequiresShaping");
+        }
+    }
     None
 }
 
@@ -1205,6 +1215,30 @@ mod tests {
             assert_eq!(plan.summary.direct_required_items, 1);
             assert_eq!(plan.items[0].status, CanvasKitReplayStatus::DirectRequired);
             assert_eq!(plan.items[0].detail.as_deref(), Some("charOverlap"));
+        }
+    }
+
+    #[test]
+    fn shaped_script_text_stays_policy_visible() {
+        for text in ["가", "e\u{0301}", "\u{F012B}"] {
+            let mut superscript = text_run(text);
+            superscript.style.superscript = true;
+            let tree = tree_with_ops(vec![PaintOp::text_run(bbox(), superscript)]);
+
+            for mode in [CanvasKitReplayMode::Default, CanvasKitReplayMode::Compat] {
+                let plan = analyze_canvaskit_replay_plan(&tree, mode);
+                assert_eq!(plan.summary.direct_required_items, 1, "text={text:?}");
+                assert_eq!(
+                    plan.items[0].status,
+                    CanvasKitReplayStatus::DirectRequired,
+                    "text={text:?}"
+                );
+                assert_eq!(
+                    plan.items[0].detail.as_deref(),
+                    Some("scriptTextRequiresShaping"),
+                    "text={text:?}"
+                );
+            }
         }
     }
 


### PR DESCRIPTION
## 무엇을 바꿨나

- 위첨자/아래첨자 direct glyph replay를 projection 이후 printable ASCII로 제한합니다.
- shaping이 필요한 한글, 결합문자, 복합 script, PUA projection은 `scriptTextRequiresShaping`으로 남깁니다.
- `displayText`와 `displayPositions`를 CanvasKit replay 입력에 반영합니다.
- glyph ID `0`을 유효한 mapping으로 처리하지 않고 `textRun:glyphMapping` 진단으로 전환합니다.
- text replay 중 예외가 발생해도 Canvas state와 `Font`/`Paint`가 정리되도록 보강합니다.
- Vite SSR로 실제 `CanvasKitLayerRenderer`를 실행하는 계약 테스트를 추가합니다.

## 왜 필요한가

#2188에서 위첨자/아래첨자의 위치와 advance를 CanvasKit direct path에 맞췄습니다. 다만 CanvasKit `Font.getGlyphIDs()`는 shaping 결과가 아니라 code point별 nominal glyph를 반환하고, missing glyph도 길이가 같은 ID `0` 배열로 반환할 수 있습니다.

그래서 문자열 길이만 확인하면 결합문자, 옛한글, Arabic/Indic 계열, emoji, PUA가 direct-ready로 잘못 분류될 수 있습니다. 이번 후속 PR은 안전하게 검증된 단순 문자열만 direct로 유지하고, 나머지는 기존 진단 경계를 보존합니다.

## 호환성

- printable ASCII 위첨자/아래첨자는 계속 direct replay합니다.
- shaping 또는 projection 처리가 불완전한 문자열은 조용히 direct로 승격하지 않습니다.
- public canvas 기본 renderer와 `GlyphRun`/`GlyphOutline` 선택 정책은 변경하지 않습니다.

## 확인

- `cargo fmt --all -- --check`
- `cargo test renderer::canvaskit_policy::tests --lib` (19 passed)
- `npm test` (185 passed)
- `npm run e2e:renderer-contract`
- `npm run build`
- `git diff --check upstream/devel..HEAD`

Follow-up to #2188.
Refs #536
