### PR TITLE
fix(hwp5): whitelist strike shapes instead of trusting strikeout bits

### DIFF
--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -503,6 +503,16 @@ pub(crate) fn parse_fill(r: &mut ByteReader) -> Fill {
     fill
 }
 
+/// 취소선 모양 id(bit 26-29)가 표 27 선 종류 13종에 해당하는지 판정한다.
+///
+/// 한컴은 취소선이 없는 문자에도 취소선 비트(bit 18-20)에 1을 넣으므로 비트만으로는
+/// 판정할 수 없고, 취소선이 없으면 모양 id에 선 종류가 아닌 placeholder(15 등)가
+/// 들어온다. HWPX의 `shape="3D"`와 같은 역할이다 (`hwpx::header::is_real_strike_shape`).
+/// 알 수 없는 값은 fail-closed로 no-strike 처리한다.
+fn is_real_strike_shape_id(shape: u8) -> bool {
+    shape <= 12
+}
+
 fn parse_char_shape(data: &[u8]) -> Result<CharShape, DocInfoError> {
     let mut r = ByteReader::new(data);
 
@@ -584,19 +594,15 @@ fn parse_char_shape(data: &[u8]) -> Result<CharShape, DocInfoError> {
     // HWP 스펙 표 37: bit 15 = 위첨자, bit 16 = 아래첨자 (개별 플래그)
     let superscript = (attr & (1 << 15)) != 0;
     let subscript = (attr & (1 << 16)) != 0;
-    // 취소선 종류 (bit 18-20)
-    // 0 = 없음 (이론상)
-    // 1 = 없음 (실제로 많은 문서에서 기본값으로 사용됨)
-    // 2 이상 = 취소선 있음
-    let strikethrough_bits = (attr >> 18) & 0x07;
-    let strikethrough = strikethrough_bits > 1;
-
     // 밑줄 모양 (bit 4-7, 표 27 선 종류)
     let underline_shape = ((attr >> 4) & 0x0F) as u8;
     // 강조점 종류 (bit 21-24)
     let emphasis_dot = ((attr >> 21) & 0x0F) as u8;
     // 취소선 모양 (bit 26-29, 표 27 선 종류)
     let strike_shape = ((attr >> 26) & 0x0F) as u8;
+    // 취소선 여부 (bit 18-20). 비트만으로는 판정할 수 없어 모양 id를 함께 본다
+    // (is_real_strike_shape_id 참고).
+    let strikethrough = (attr >> 18) & 0x07 != 0 && is_real_strike_shape_id(strike_shape);
     // 커닝 여부 (bit 30)
     let kerning = (attr & (1 << 30)) != 0;
     // 글꼴에 어울리는 빈칸 사용 여부 (bit 25)
@@ -1072,6 +1078,55 @@ mod tests {
         let cs = parse_char_shape(&make_data((1 << 30) | (1 << 25))).unwrap();
         assert!(cs.kerning);
         assert!(cs.use_font_space);
+    }
+
+    #[test]
+    fn test_parse_char_shape_strikethrough() {
+        fn make_data(strike_bits: u32, strike_shape: u32) -> Vec<u8> {
+            let attr = (strike_bits << 18) | (strike_shape << 26);
+            let mut data = Vec::new();
+            for _ in 0..7 {
+                data.extend_from_slice(&0u16.to_le_bytes());
+            }
+            for _ in 0..7 {
+                data.push(100);
+            }
+            for _ in 0..7 {
+                data.push(0i8 as u8);
+            }
+            for _ in 0..7 {
+                data.push(100);
+            }
+            for _ in 0..7 {
+                data.push(0i8 as u8);
+            }
+            data.extend_from_slice(&1000i32.to_le_bytes());
+            data.extend_from_slice(&attr.to_le_bytes());
+            data.push(0); // shadow_offset_x
+            data.push(0); // shadow_offset_y
+            data.extend_from_slice(&0u32.to_le_bytes()); // text_color
+            data.extend_from_slice(&0u32.to_le_bytes()); // underline_color
+            data.extend_from_slice(&0x00FFFFFFu32.to_le_bytes()); // shade_color
+            data.extend_from_slice(&0x00B2B2B2u32.to_le_bytes()); // shadow_color
+            data
+        }
+
+        // 취소선 없는 평범한 본문
+        assert!(!parse_char_shape(&make_data(0, 0)).unwrap().strikethrough);
+
+        // 한컴이 취소선 없는 문자에 넣는 기본값: 비트는 1, 모양은 placeholder
+        assert!(!parse_char_shape(&make_data(1, 15)).unwrap().strikethrough);
+        assert!(!parse_char_shape(&make_data(1, 13)).unwrap().strikethrough);
+
+        // 실제 취소선 — 비트가 1이어도 모양이 선 종류면 취소선이다
+        let cs = parse_char_shape(&make_data(1, 0)).unwrap();
+        assert!(cs.strikethrough);
+        assert_eq!(cs.strike_shape, 0);
+        assert!(parse_char_shape(&make_data(1, 12)).unwrap().strikethrough);
+        assert!(parse_char_shape(&make_data(3, 1)).unwrap().strikethrough);
+
+        // 비트가 0이면 모양과 무관하게 취소선이 아니다
+        assert!(!parse_char_shape(&make_data(0, 1)).unwrap().strikethrough);
     }
 
     #[test]

--- a/tests/hwp5_strikeout_shape_parity.rs
+++ b/tests/hwp5_strikeout_shape_parity.rs
@@ -1,0 +1,66 @@
+//! HWP5 취소선 판정 회귀 가드 — HWPX 경로와의 자기정합.
+//!
+//! 한컴은 취소선이 없는 문자에도 CharShape `attr` 의 취소선 비트(bit 18-20)에 1 을
+//! 기본값으로 넣는다. 그래서 비트만으로는 취소선 유무를 판정할 수 없고, 실제
+//! 판별자는 취소선 모양(bit 26-29, 표 27 선 종류)이다. 취소선이 없으면 모양에
+//! 선 종류가 아닌 placeholder(15 등)가 들어온다 — HWPX 의 `shape="3D"` 와 같다.
+//!
+//! HWPX 경로는 PR #154 에서 이미 모양 화이트리스트(`is_real_strike_shape`)로
+//! 전환했으나 HWP5 경로는 `strikethrough_bits > 1` 로 남아 있었다. 그 결과
+//! 같은 문서를 HWP5 로 열면 취소선이 사라지고 HWPX 로 열면 그려졌다.
+//!
+//! fixture: `samples/issue1949_giant_cell_nested_tables_perf.{hwp,hwpx}` — 같은
+//! 문서의 두 포맷 쌍. 취소선 CharShape 4개(모양 SOLID 2, DOUBLE_SLIM 2)를 가진다.
+//! 수정 전: HWP5 파스 결과 취소선 0개 / HWPX 파스 결과 4개.
+
+use rhwp::wasm_api::HwpDocument;
+use std::fs;
+use std::path::Path;
+
+const HWP: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+const HWPX: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwpx";
+
+/// (char_shape 인덱스, 취소선 모양) 목록.
+fn strikeout_shapes(path: &str) -> Vec<(usize, u8)> {
+    let p = Path::new(env!("CARGO_MANIFEST_DIR")).join(path);
+    let bytes = fs::read(&p).unwrap_or_else(|e| panic!("read {path}: {e}"));
+    let doc = HwpDocument::from_bytes(&bytes).unwrap_or_else(|e| panic!("parse {path}: {e:?}"));
+    doc.document()
+        .doc_info
+        .char_shapes
+        .iter()
+        .enumerate()
+        .filter(|(_, cs)| cs.strikethrough)
+        .map(|(index, cs)| (index, cs.strike_shape))
+        .collect()
+}
+
+/// 같은 문서의 HWP5 와 HWPX 파스가 같은 취소선 집합을 낸다.
+#[test]
+fn hwp5_strikeout_matches_hwpx_counterpart() {
+    let hwpx = strikeout_shapes(HWPX);
+    assert!(
+        !hwpx.is_empty(),
+        "전제 불성립: {HWPX} 에 취소선 CharShape 가 없다"
+    );
+
+    let hwp = strikeout_shapes(HWP);
+    assert_eq!(
+        hwp, hwpx,
+        "HWP5 취소선 판정이 HWPX 와 갈렸다. 취소선 비트(bit 18-20)만으로 판정하면 \
+         한컴이 기본값으로 넣는 1 을 걸러내려다 실제 취소선(비트=1 + 유효한 모양)까지 \
+         버린다. 모양(bit 26-29)이 표 27 선 종류인지 함께 확인해야 한다."
+    );
+}
+
+/// 취소선으로 인정한 모양은 모두 표 27 선 종류(0..=12)다 — placeholder 는 제외된다.
+#[test]
+fn strikeout_shapes_are_real_line_types() {
+    for (index, shape) in strikeout_shapes(HWP) {
+        assert!(
+            shape <= 12,
+            "char_shape[{index}] 의 취소선 모양 {shape} 은 표 27 선 종류가 아니다 \
+             (placeholder 를 취소선으로 오인식 — 본문 전체에 취소선이 그어진다)"
+        );
+    }
+}


### PR DESCRIPTION
## 요약

- `parse_char_shape` 의 취소선 판정을 **취소선 비트 + 모양 화이트리스트**로 바꿉니다. 한컴이 취소선 없는 문자에도 비트(bit 18-20)를 `1` 로 채우므로 비트만으로는 판정할 수 없습니다.
- 모양(bit 26-29)이 표 27 선 종류(`0..=12`)일 때만 취소선으로 인정하고, placeholder(`15` 등)와 미지 값은 fail-closed 로 no-strike 처리합니다. HWPX 의 `is_real_strike_shape` (PR #154) 와 같은 원리입니다.
- 저장소 샘플 쌍으로 HWP5 ↔ HWPX 자기정합 회귀 가드를 추가했습니다.
- `parse_char_shape` 유닛 테스트를 추가했습니다 (평범한 본문 / placeholder 15·13 / 실제 취소선 0·12 / bits=3 / bits=0).

## 문제

기존 주석대로 한컴은 취소선이 없는 문자에도 취소선 비트에 `1` 을 넣습니다. 이를 걸러내려고 `strikethrough_bits > 1` 을 요구했는데, **실제 취소선도 비트가 `1`** 이라 함께 버려졌습니다. 진짜와 placeholder 를 가르는 것은 비트가 아니라 취소선 모양입니다 — HWPX 의 `shape="3D"` 가 하던 역할을 HWP5 에서는 모양 `15` 가 합니다.

그 결과 **같은 문서를 HWP5 로 열면 취소선이 사라지고 HWPX 로 열면 그려집니다.**

## 재현

저장소에 이미 들어 있는 샘플 쌍을 씁니다. 같은 문서의 두 포맷이고, 별도 파일이 필요 없습니다.

- [`samples/issue1949_giant_cell_nested_tables_perf.hwp`](https://github.com/edwardkim/rhwp/blob/devel/samples/issue1949_giant_cell_nested_tables_perf.hwp)
- [`samples/issue1949_giant_cell_nested_tables_perf.hwpx`](https://github.com/edwardkim/rhwp/blob/devel/samples/issue1949_giant_cell_nested_tables_perf.hwpx)

각각 파싱해 `doc_info.char_shapes` 중 `strikethrough == true` 인 항목을 `(인덱스, 모양)` 으로 나열하면 이렇게 갈립니다. 두 파일 모두 `char_shapes` 는 65개로 같습니다.

```
.hwp   → []                                     ← 취소선 0개
.hwpx  → [(17, 7), (33, 0), (36, 0), (49, 7)]   ← 취소선 4개 (SOLID 2, DOUBLE_SLIM 2)
```

본 PR 의 회귀 테스트가 바로 이 비교입니다. 수정 전 코드에서는 실패합니다.

```
cargo test --profile release-test --test hwp5_strikeout_shape_parity
```

렌더 결과로도 확인됩니다. 이 샘플은 115쪽이고, 위 취소선이 **실제로 본문에 그려지는 곳은 111쪽 한 곳**입니다 (`843℃` 뒤 문자).

```
rhwp export-pdf samples/issue1949_giant_cell_nested_tables_perf.hwp  -o hwp.pdf
rhwp export-pdf samples/issue1949_giant_cell_nested_tables_perf.hwpx -o hwpx.pdf
```

두 PDF 의 111쪽을 래스터로 비교하면 **수정 전에는 취소선 획 영역만큼 다르고, 수정 후에는 픽셀 단위로 동일**해집니다. 나머지 114개 쪽은 수정 전후로 변화가 없습니다.

## 검증

- `cargo test --profile release-test --tests` — **3,160 passed, 0 failed**
- `cargo clippy --all-targets -- -D warnings` — 경고 0
- `cargo fmt --all -- --check` 통과
- 신규 회귀 테스트가 수정 전 상태에서 실패하는 것을 확인했습니다.

## 참고 — 사내 문서 집계

공개할 수 없는 자료라 참고로만 적습니다. 한국어 실무 HWP5 문서 189건을 같은 방식으로 조사한 결과입니다.

| 판정 | 취소선 run | 해당 문서 |
|---|---|---|
| `bits > 1` (수정 전) | 0 | 0 |
| `bits != 0` (모양 미확인) | 376 | 7 |
| `bits != 0 && shape <= 12` (본 PR) | 76 | 4 |

수정 전에는 189건 전체에서 취소선이 하나도 인식되지 않았습니다. 반대로 모양을 확인하지 않고 `bits != 0` 만 쓰면 3개 문서에서 300 runs 가 오탐되며, 그중 한 문서는 178 runs — 본문 전체에 취소선이 그어집니다. 이는 #154 가 HWPX 에서 막은 현상과 같습니다. 해당 문서들은 기밀이라 첨부하지 못했고, 재현은 위의 저장소 샘플만으로 충분합니다.

## 범위

- HWP5 파서만 변경했습니다. HWPX 경로는 #154 로 이미 화이트리스트입니다.
- 페이지 분할에 영향이 없습니다 (샘플 115쪽, 수정 전후 동일).