### PR TITLE
Task #2267: macOS Finder Quick Look 미리보기·썸네일 확장

### DIFF
--- a/bindings/Native/Cargo.toml
+++ b/bindings/Native/Cargo.toml
@@ -6,7 +6,7 @@ publish = false
 
 [lib]
 name = "rhwp_native_ffi"
-crate-type = ["cdylib", "staticlib"]
+crate-type = ["cdylib", "staticlib", "rlib"]
 
 [dependencies]
 rhwp_core = { package = "rhwp", path = "../.." }

--- a/bindings/Native/examples/render_pdf_bench.rs
+++ b/bindings/Native/examples/render_pdf_bench.rs
@@ -1,0 +1,46 @@
+//! [Task #2267] `rhwp_render_pdf` C ABI 를 Quick Look 확장과 동일한 조건으로 호출해
+//! 시간·메모리를 측정한다. 확장 한도는 약 30초 / 80MB 경고 / 120MB 강제 종료다.
+//!
+//!   /usr/bin/time -l cargo run --release --example render_pdf_bench -- <file> [max_pages] [embed_text]
+
+use std::ffi::{CStr, CString};
+
+fn main() {
+    let args: Vec<String> = std::env::args().collect();
+    if args.len() < 2 {
+        eprintln!("usage: render_pdf_bench <file.hwp|hwpx> [max_pages=1] [embed_text=0]");
+        std::process::exit(2);
+    }
+
+    let path = CString::new(args[1].clone()).unwrap();
+    let max_pages: i32 = args.get(2).and_then(|s| s.parse().ok()).unwrap_or(1);
+    let embed_text: i32 = args.get(3).and_then(|s| s.parse().ok()).unwrap_or(0);
+
+    let started = std::time::Instant::now();
+    let buffer =
+        rhwp_native_ffi::rhwp_render_pdf(path.as_ptr(), 0, max_pages, std::ptr::null(), embed_text);
+    let elapsed = started.elapsed();
+
+    if !buffer.error.is_null() {
+        let msg = unsafe { CStr::from_ptr(buffer.error) }
+            .to_string_lossy()
+            .into_owned();
+        rhwp_native_ffi::rhwp_buffer_free(buffer);
+        eprintln!("FAIL: {}", msg);
+        std::process::exit(1);
+    }
+
+    let bytes = unsafe { std::slice::from_raw_parts(buffer.data, buffer.len) };
+    let valid = bytes.starts_with(b"%PDF-");
+    println!(
+        "pdf={:.2}MB valid={} elapsed={:.2}s",
+        buffer.len as f64 / 1048576.0,
+        valid,
+        elapsed.as_secs_f64()
+    );
+
+    rhwp_native_ffi::rhwp_buffer_free(buffer);
+    if !valid {
+        std::process::exit(1);
+    }
+}

--- a/bindings/Native/src/lib.rs
+++ b/bindings/Native/src/lib.rs
@@ -66,6 +66,150 @@ pub extern "C" fn rhwp_string_free(ptr: *mut c_char) {
     }
 }
 
+/// 바이너리 결과 버퍼 (PDF 등).
+///
+/// [Task #2267] 기존 FFI 는 UTF-8 JSON 문자열만 반환했으나, PDF 는 바이너리이므로
+/// 포인터 + 길이 규약이 필요하다. `data` 가 null 이면 실패이며 `error` 에 사유가 담긴다.
+/// 성공/실패와 무관하게 **반드시 `rhwp_buffer_free` 로 해제**해야 한다.
+#[repr(C)]
+pub struct RhwpBuffer {
+    /// 바이트 포인터. 실패 시 null.
+    pub data: *mut u8,
+    /// 바이트 길이. 실패 시 0.
+    pub len: usize,
+    /// 실패 사유 (UTF-8 C 문자열). 성공 시 null.
+    pub error: *mut c_char,
+}
+
+impl RhwpBuffer {
+    fn ok(mut bytes: Vec<u8>) -> Self {
+        bytes.shrink_to_fit();
+        let len = bytes.len();
+        let data = bytes.as_mut_ptr();
+        std::mem::forget(bytes);
+        RhwpBuffer {
+            data,
+            len,
+            error: std::ptr::null_mut(),
+        }
+    }
+
+    fn err(message: &str) -> Self {
+        let error = CString::new(message)
+            .unwrap_or_else(|_| CString::new("알 수 없는 오류").unwrap())
+            .into_raw();
+        RhwpBuffer {
+            data: std::ptr::null_mut(),
+            len: 0,
+            error,
+        }
+    }
+}
+
+/// `RhwpBuffer` 를 해제한다. 성공/실패 모두 호출해야 한다. 이중 해제 금지.
+#[no_mangle]
+pub extern "C" fn rhwp_buffer_free(buffer: RhwpBuffer) {
+    if !buffer.data.is_null() && buffer.len > 0 {
+        unsafe {
+            drop(Vec::from_raw_parts(buffer.data, buffer.len, buffer.len));
+        }
+    }
+    if !buffer.error.is_null() {
+        unsafe {
+            drop(CString::from_raw(buffer.error));
+        }
+    }
+}
+
+/// 문서의 페이지 수를 반환한다. 실패 시 -1.
+#[no_mangle]
+pub extern "C" fn rhwp_page_count(input_path: *const c_char) -> i32 {
+    let result = std::panic::catch_unwind(|| -> Result<i32, String> {
+        let input_path = read_utf8(input_path, "input_path")?;
+        let data = fs::read(&input_path)
+            .map_err(|e| format!("파일을 읽을 수 없습니다 - {}: {}", input_path, e))?;
+        let doc = HwpDocument::from_bytes(&data).map_err(|e| format!("HWP 파싱 실패 - {}", e))?;
+        Ok(doc.page_count() as i32)
+    });
+
+    match result {
+        Ok(Ok(n)) => n,
+        _ => -1,
+    }
+}
+
+/// 문서를 PDF 로 렌더링해 바이트 버퍼로 반환한다.
+///
+/// [Task #2267] macOS Quick Look 확장이 쓰는 진입점.
+///
+/// - `first_page`: 0-based 시작 페이지
+/// - `max_pages`: 렌더할 최대 페이지 수. 0 이하면 문서 끝까지.
+///   **확장은 메모리·시간 한도가 있으므로 반드시 제한을 건다** (썸네일 1, 미리보기 소수).
+/// - `font_dir`: 폰트 탐색 절대경로. null 이면 지정하지 않음.
+///   코어의 기본 폰트 탐색은 **작업디렉터리 상대경로**(`ttfs` 등)라 샌드박스된 확장에서는
+///   잡히지 않는다. 호출자가 번들 Resources 의 절대경로를 넘겨야 한다.
+/// - `embed_text`: 0 이면 글리프를 path 로 변환한다. 폰트 서브셋 경로를 건너뛰어
+///   메모리를 크게 줄이는 대신 PDF 의 텍스트 선택·검색을 잃는다 (#2264).
+///
+/// 반환된 버퍼는 반드시 `rhwp_buffer_free` 로 해제한다.
+#[no_mangle]
+pub extern "C" fn rhwp_render_pdf(
+    input_path: *const c_char,
+    first_page: u32,
+    max_pages: i32,
+    font_dir: *const c_char,
+    embed_text: i32,
+) -> RhwpBuffer {
+    let result = std::panic::catch_unwind(|| -> Result<Vec<u8>, String> {
+        let input_path = read_utf8(input_path, "input_path")?;
+        let font_dir = if font_dir.is_null() {
+            None
+        } else {
+            Some(read_utf8(font_dir, "font_dir")?)
+        };
+
+        let data = fs::read(&input_path)
+            .map_err(|e| format!("파일을 읽을 수 없습니다 - {}: {}", input_path, e))?;
+        let doc = HwpDocument::from_bytes(&data).map_err(|e| format!("HWP 파싱 실패 - {}", e))?;
+
+        let page_count = doc.page_count();
+        if page_count == 0 {
+            return Err("페이지가 없습니다.".to_string());
+        }
+        if first_page >= page_count {
+            return Err(format!(
+                "first_page가 범위를 벗어났습니다 (0~{}): {}",
+                page_count - 1,
+                first_page
+            ));
+        }
+
+        let end = if max_pages <= 0 {
+            page_count
+        } else {
+            page_count.min(first_page.saturating_add(max_pages as u32))
+        };
+        let pages: Vec<u32> = (first_page..end).collect();
+
+        let mut options = rhwp_core::renderer::pdf::PdfExportOptions {
+            embed_text: embed_text != 0,
+            ..Default::default()
+        };
+        if let Some(dir) = font_dir {
+            options.font_paths.push(PathBuf::from(dir));
+        }
+
+        doc.render_pages_pdf_native_with_options(&pages, &options)
+            .map_err(|e| format!("PDF 렌더링 실패 - {:?}", e))
+    });
+
+    match result {
+        Ok(Ok(bytes)) => RhwpBuffer::ok(bytes),
+        Ok(Err(error)) => RhwpBuffer::err(&error),
+        Err(_) => RhwpBuffer::err("FFI 호출 중 panic이 발생했습니다."),
+    }
+}
+
 fn export_text_to_dir(
     input_path: &Path,
     output_dir: &Path,
@@ -212,9 +356,13 @@ fn extract_image_data(
     bin_data_id: u16,
 ) -> Result<Option<(String, Vec<u8>)>, String> {
     if let (Some(si), Some(pi), Some(ci)) = (sec_idx, para_idx, control_idx) {
+        // [Task #2267] 코어가 cell_path 인자를 추가(Task #1161)했으나 본 FFI 크레이트는
+        // 워크스페이스 밖이라 CI 가 컴파일하지 않아 갱신이 누락되어 있었다.
+        // 본문 문단이므로 빈 경로를 넘긴다 (셀/글상자 내부가 아님).
+        const BODY_PARA: &[(usize, usize, usize)] = &[];
         if let (Ok(mime), Ok(data)) = (
-            doc.get_control_image_mime_native(si, pi, ci),
-            doc.get_control_image_data_native(si, pi, ci),
+            doc.get_control_image_mime_native(si, pi, BODY_PARA, ci),
+            doc.get_control_image_data_native(si, pi, BODY_PARA, ci),
         ) {
             return Ok(Some((mime, data)));
         }
@@ -343,13 +491,7 @@ fn error_json(error: &str) -> String {
 fn text_json(page_count: u32, pages: &[(u32, String)]) -> String {
     let pages_json = pages
         .iter()
-        .map(|(index, text)| {
-            format!(
-                "{{\"index\":{},\"text\":\"{}\"}}",
-                index,
-                json_escape(text)
-            )
-        })
+        .map(|(index, text)| format!("{{\"index\":{},\"text\":\"{}\"}}", index, json_escape(text)))
         .collect::<Vec<_>>()
         .join(",");
 
@@ -373,4 +515,76 @@ fn json_escape(s: &str) -> String {
         }
     }
     out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 저장소 루트 기준 샘플 경로. 이 크레이트는 `bindings/Native` 에 있다.
+    fn sample(rel: &str) -> Option<CString> {
+        let path = Path::new("../../").join(rel);
+        if !path.exists() {
+            eprintln!("샘플 없음, 건너뜀: {}", path.display());
+            return None;
+        }
+        Some(CString::new(path.to_string_lossy().as_ref()).unwrap())
+    }
+
+    #[test]
+    fn page_count_reads_document() {
+        let Some(path) = sample("samples/aift.hwp") else {
+            return;
+        };
+        let count = rhwp_page_count(path.as_ptr());
+        assert!(count > 0, "페이지 수가 양수여야 한다: {}", count);
+    }
+
+    #[test]
+    fn page_count_rejects_missing_file() {
+        let path = CString::new("존재하지_않는_파일.hwp").unwrap();
+        assert_eq!(rhwp_page_count(path.as_ptr()), -1);
+    }
+
+    /// [Task #2267] Quick Look 확장이 타는 경로 그대로: 1페이지 PDF 를 렌더한다.
+    #[test]
+    fn render_pdf_produces_valid_single_page_pdf() {
+        let Some(path) = sample("samples/aift.hwp") else {
+            return;
+        };
+
+        let buffer = rhwp_render_pdf(path.as_ptr(), 0, 1, std::ptr::null(), 0);
+        assert!(buffer.error.is_null(), "렌더 실패");
+        assert!(!buffer.data.is_null() && buffer.len > 0, "빈 버퍼");
+
+        let bytes = unsafe { std::slice::from_raw_parts(buffer.data, buffer.len) };
+        assert!(bytes.starts_with(b"%PDF-"), "PDF 매직이 아니다");
+        assert!(
+            bytes.windows(5).rev().take(64).any(|w| w == b"%%EOF"),
+            "PDF 트레일러가 없다"
+        );
+
+        rhwp_buffer_free(buffer);
+    }
+
+    #[test]
+    fn render_pdf_rejects_out_of_range_page() {
+        let Some(path) = sample("samples/aift.hwp") else {
+            return;
+        };
+
+        let buffer = rhwp_render_pdf(path.as_ptr(), 100_000, 1, std::ptr::null(), 0);
+        assert!(buffer.data.is_null(), "범위 밖 페이지는 실패해야 한다");
+        assert!(!buffer.error.is_null(), "실패 사유가 있어야 한다");
+        rhwp_buffer_free(buffer);
+    }
+
+    #[test]
+    fn render_pdf_reports_error_for_missing_file() {
+        let path = CString::new("존재하지_않는_파일.hwp").unwrap();
+        let buffer = rhwp_render_pdf(path.as_ptr(), 0, 1, std::ptr::null(), 0);
+        assert!(buffer.data.is_null());
+        assert!(!buffer.error.is_null());
+        rhwp_buffer_free(buffer);
+    }
 }

--- a/bindings/swift/Sources/CRhwpNative/rhwp_native_ffi.h
+++ b/bindings/swift/Sources/CRhwpNative/rhwp_native_ffi.h
@@ -1,6 +1,9 @@
 #ifndef RHWP_NATIVE_FFI_H
 #define RHWP_NATIVE_FFI_H
 
+#include <stddef.h>
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -9,6 +12,36 @@ char *rhwp_export_text(const char *input_path, const char *output_dir, int page)
 char *rhwp_export_markdown(const char *input_path, const char *output_dir, int page);
 char *rhwp_read_text(const char *input_path, int page);
 void rhwp_string_free(char *value);
+
+/// 바이너리 결과 버퍼 (PDF 등).
+///
+/// `data` 가 NULL 이면 실패이며 `error` 에 사유가 담긴다.
+/// 성공/실패와 무관하게 반드시 `rhwp_buffer_free` 로 해제해야 한다.
+typedef struct RhwpBuffer {
+  uint8_t *data;
+  size_t len;
+  char *error;
+} RhwpBuffer;
+
+void rhwp_buffer_free(RhwpBuffer buffer);
+
+/// 문서의 페이지 수. 실패 시 -1.
+int32_t rhwp_page_count(const char *input_path);
+
+/// 문서를 PDF 로 렌더링한다.
+///
+/// - first_page:  0-based 시작 페이지
+/// - max_pages:   렌더할 최대 페이지 수. 0 이하면 문서 끝까지.
+/// - font_dir:    폰트 탐색 절대경로. NULL 가능.
+///                코어의 기본 폰트 탐색은 작업디렉터리 상대경로라
+///                샌드박스된 확장에서는 잡히지 않는다. 번들 Resources
+///                절대경로를 넘겨야 한다.
+/// - embed_text:  0 이면 글리프를 path 로 변환한다 (메모리 대폭 절감,
+///                텍스트 선택·검색 불가).
+///
+/// 반환 버퍼는 반드시 `rhwp_buffer_free` 로 해제한다.
+RhwpBuffer rhwp_render_pdf(const char *input_path, uint32_t first_page, int32_t max_pages,
+                           const char *font_dir, int32_t embed_text);
 
 #ifdef __cplusplus
 }

--- a/bindings/swift/Sources/Rhwp/Rhwp.swift
+++ b/bindings/swift/Sources/Rhwp/Rhwp.swift
@@ -68,6 +68,55 @@ public enum RhwpError: Error, LocalizedError, Equatable {
 }
 
 public enum Rhwp {
+    /// 문서의 페이지 수.
+    public static func pageCount(inputFile: URL) throws -> Int {
+        let count = inputFile.path.withCString { rhwp_page_count($0) }
+        guard count >= 0 else {
+            throw RhwpError.exportFailed("페이지 수를 읽을 수 없습니다: \(inputFile.path)")
+        }
+        return Int(count)
+    }
+
+    /// 문서를 PDF 로 렌더링한다.
+    ///
+    /// [Task #2267] Quick Look 확장이 쓰는 진입점.
+    ///
+    /// - Parameters:
+    ///   - firstPage: 0-based 시작 페이지
+    ///   - maxPages: 렌더할 최대 페이지 수. `nil` 이면 문서 끝까지.
+    ///     **확장은 메모리·시간 한도가 있으므로 반드시 제한을 건다** (썸네일 1, 미리보기 소수).
+    ///   - fontDirectory: 폰트 탐색 절대경로. 코어의 기본 폰트 탐색은 작업디렉터리
+    ///     상대경로라 샌드박스된 확장에서는 잡히지 않는다. 번들 Resources 경로를 넘긴다.
+    ///   - embedText: `false` 면 글리프를 path 로 변환한다. 메모리를 크게 줄이는 대신
+    ///     PDF 의 텍스트 선택·검색을 잃는다.
+    public static func renderPDF(
+        inputFile: URL,
+        firstPage: UInt32 = 0,
+        maxPages: Int32? = nil,
+        fontDirectory: URL? = nil,
+        embedText: Bool = true
+    ) throws -> Data {
+        let buffer: RhwpBuffer = inputFile.path.withCString { input in
+            let render: (UnsafePointer<CChar>?) -> RhwpBuffer = { fontDir in
+                rhwp_render_pdf(input, firstPage, maxPages ?? 0, fontDir, embedText ? 1 : 0)
+            }
+            if let fontDirectory {
+                return fontDirectory.path.withCString { render($0) }
+            }
+            return render(nil)
+        }
+
+        defer { rhwp_buffer_free(buffer) }
+
+        if let error = buffer.error {
+            throw RhwpError.exportFailed(String(cString: error))
+        }
+        guard let data = buffer.data, buffer.len > 0 else {
+            throw RhwpError.nativeReturnedNull
+        }
+        return Data(bytes: data, count: buffer.len)
+    }
+
     public static func readText(
         inputFile: URL,
         page: RhwpPage = .all

--- a/mydocs/plans/task_m100_2267.md
+++ b/mydocs/plans/task_m100_2267.md
@@ -1,0 +1,60 @@
+# 수행 계획서 — M100 #2267: macOS Finder Quick Look 미리보기·썸네일 확장
+
+## 1. 목표
+
+macOS Finder 에서 `.hwp` / `.hwpx` / `.hml` 파일을 **스페이스바로 미리보고**, 파일 아이콘에 **썸네일**이 뜨게 한다.
+
+## 2. 배경 — 왜 지금인가
+
+Quick Look 확장 프로세스에는 하드 제약이 있다: 약 **80MB 경고 / 120MB 강제 종료 / 30초 타임아웃**.
+
+0단계 스파이크 시점의 실측으로는 1페이지 PDF 렌더에도 최대 RSS 가 강제 종료선을 넘었다. 그래서 두 개의 선행 타스크를 먼저 처리했다.
+
+| 타스크 | 내용 | 효과 |
+|--------|------|------|
+| #2263 | BinData 지연 로딩 | 파싱·레이아웃 RSS 244MB → 49MB |
+| #2264 | PDF `embed_text` 옵션 | `to_chunk` 최대 RSS 164MB → 69MB |
+
+두 개선 적용 후 1페이지 PDF 렌더 최대 RSS 는 문서별로 **41 / 42 / 80 / 88 / 99 MB** — 전부 120MB 강제 종료선 아래다. 이 타스크는 그 위에서 실제 확장을 만든다.
+
+## 3. 아키텍처
+
+```
+Finder ──▶ Quick Look 확장 (Swift) ──▶ rhwp_render_pdf (C ABI)
+                                            └─▶ HWP 파서 ─▶ Document IR ─▶ SVG ─▶ PDF
+                                    ◀── PDF bytes ──┘
+```
+
+**핵심 결정: 데이터 기반 미리보기(PDF)를 쓴다.**
+
+`QLPreviewReply(dataOfContentType: .pdf)` 로 PDF 바이트만 넘기면 확대·스크롤·페이지 이동 UI 를 Quick Look 이 전부 제공한다. 커스텀 뷰(`QLPreviewingController` + NSView)를 선택하면 그 UI 를 직접 구현해야 하고, 렌더 품질도 직접 책임져야 한다. PDF 는 macOS 의 1급 시민이다.
+
+Swift 쪽에는 렌더 로직을 두지 않는다. 렌더는 전부 Rust 코어에서 하고, Swift 는 FFI 호출 + 결과 전달만 한다.
+
+## 4. 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `bindings/Native/src/lib.rs` | C ABI 추가: `rhwp_page_count`, `rhwp_render_pdf`, `rhwp_buffer_free` |
+| `bindings/swift/…` | 헤더 + Swift 래퍼 |
+| `scripts/package-swift-xcframework.sh` | XCFramework 패키징 (배포 타깃 고정) |
+| `rhwp-quicklook/project.yml` | XcodeGen 스펙 (앱 1 + 확장 2) |
+| `rhwp-quicklook/Shared/RhwpRenderer.swift` | 두 확장이 공유하는 렌더 래퍼 |
+| `rhwp-quicklook/PreviewExtension/` | `QLPreviewProvider` |
+| `rhwp-quicklook/ThumbnailExtension/` | `QLThumbnailProvider` |
+| `rhwp-quicklook/App/` | 호스트 앱 + UTI 선언 |
+
+## 5. 알려진 제약 (사전 고지)
+
+- **코드서명 인증서가 없다.** Ad-hoc 서명으로 빌드는 되지만, Launch Services 등록 → Finder 미리보기 표시까지의 실제 통합은 **이 환경에서 검증할 수 없다.** 작업지시자 승인 하에 미검증을 감수하고 진행한다.
+- `.hwp` / `.hwpx` 는 시스템 UTI 가 없어 호스트 앱이 직접 선언해야 한다.
+- 미리보기는 페이지 수를 제한한다 (메모리 한도 역산, 구현 계획서에서 실측으로 확정).
+
+## 6. 검증 계획
+
+인증서 부재로 Finder 통합을 못 보므로, 그 아래 계층을 최대한 촘촘히 검증한다.
+
+1. FFI: 단위 테스트 (page_count / 유효 PDF 매직+trailer / 범위 초과 / 파일 없음)
+2. XCFramework: 슬라이스 구성, 심볼 존재, 배포 타깃 경고 0, 실제 PDF 산출
+3. 앱 번들: 확장 임베드, Rust 라이브러리 링크(미해결 심볼 0), 폰트 번들링, Info.plist 의 확장 포인트·UTI
+4. 메모리: 페이지 수별 최대 RSS 실측 → 페이지 상한 결정

--- a/mydocs/plans/task_m100_2267_impl.md
+++ b/mydocs/plans/task_m100_2267_impl.md
@@ -1,0 +1,48 @@
+# 구현 계획서 — M100 #2267: macOS Finder Quick Look 확장
+
+수행 계획서: `task_m100_2267.md`
+
+## 1단계 — C ABI 확장
+
+`bindings/Native` 에 Quick Look 확장이 필요로 하는 최소 API 를 추가한다.
+
+```c
+typedef struct { uint8_t *data; size_t len; char *error; } RhwpBuffer;
+
+void rhwp_buffer_free(RhwpBuffer buffer);
+int32_t rhwp_page_count(const char *input_path);
+RhwpBuffer rhwp_render_pdf(const char *input_path, uint32_t first_page,
+                           int32_t max_pages, const char *font_dir, int32_t embed_text);
+```
+
+- `font_dir` 를 인자로 받는 이유: 코어의 기본 폰트 탐색 경로는 작업디렉터리 상대경로(`ttfs/`)라 샌드박스된 확장 프로세스에서는 절대 잡히지 않는다. 번들 Resources 의 **절대경로**를 넘겨야 한다.
+- `embed_text` 를 인자로 받는 이유: #2264 의 메모리 절감을 확장에서만 켠다 (코어 기본값은 `true` 유지).
+- 오류는 `error` 문자열로 반환한다. FFI 경계를 넘는 panic 은 unwind 로 잡는다.
+
+**검증**: `cargo test --manifest-path bindings/Native/Cargo.toml` — page_count / 유효 PDF(매직 + trailer) / 범위 초과 / 파일 없음.
+
+> `bindings/Native` 는 워크스페이스 밖이라 CI 가 컴파일하지 않는다. 그래서 이미 컴파일이 깨져 있었다 (#1161 에서 `get_control_image_*_native` 에 `cell_path` 파라미터가 추가됐는데 이 크레이트만 안 따라감). 1단계에서 함께 고친다.
+
+## 2단계 — XCFramework 빌드 검증
+
+`scripts/package-swift-xcframework.sh` 로 XCFramework 를 만들고, Swift 가 실제로 링크·호출할 수 있는지 확인한다.
+
+**검증**: 슬라이스 3종(`ios-arm64`, `ios-arm64-simulator`, `macos-arm64_x86_64`), macOS 슬라이스가 universal, `_rhwp_render_pdf` 심볼 존재, C 프로그램으로 링크해 실제 PDF 산출, 배포 타깃 경고 0.
+
+## 3단계 — Xcode 스캐폴딩
+
+`rhwp-quicklook/` 에 XcodeGen 스펙과 Swift 소스를 만든다.
+
+- 타겟 3개: 호스트 앱 + Preview 확장 + Thumbnail 확장
+- 호스트 앱 Info.plist 에 `UTImportedTypeDeclarations` (hwp / hwpx / hml)
+- 확장 Info.plist 에 `NSExtensionPointIdentifier` + `QLSupportedContentTypes`
+- `ttfs/opensource` 를 확장 번들 Resources 로 포함
+- **페이지 상한을 실측으로 확정** — 메모리 한도(120MB)에서 역산
+
+**검증**: 빌드 성공 + 번들 구조 검사 (확장 임베드 / 미해결 `rhwp_` 심볼 0 / 폰트 포함 / 확장 포인트·UTI).
+
+Finder 실제 통합은 코드서명 인증서 부재로 검증 불가 — 작업지시자가 미검증을 감수하기로 결정.
+
+## 4단계 — 문서화·정리
+
+README (빌드·설치·설계 근거·검증 범위), 단계별 보고서, 최종 보고서.

--- a/mydocs/report/task_m100_2267_report.md
+++ b/mydocs/report/task_m100_2267_report.md
@@ -1,0 +1,75 @@
+# 최종 결과 보고서 — M100 #2267: macOS Finder Quick Look 미리보기·썸네일 확장
+
+## 결론
+
+Finder 에서 `.hwp` / `.hwpx` / `.hml` 을 스페이스바로 미리보고 아이콘 썸네일을 표시하는 Quick Look 확장을 구현했다. **빌드·링크·번들 구조는 검증했고, Finder 실제 통합은 코드서명 인증서 부재로 검증하지 못했다.**
+
+## 산출물
+
+| 경로 | 내용 |
+|------|------|
+| `bindings/Native/src/lib.rs` | C ABI: `rhwp_page_count`, `rhwp_render_pdf`, `rhwp_buffer_free` |
+| `bindings/swift/` | C 헤더 + Swift 래퍼 |
+| `scripts/package-swift-xcframework.sh` | 배포 타깃 고정 |
+| `rhwp-quicklook/` | XcodeGen 스펙 + Swift 소스 (앱 1 + 확장 2) + README |
+
+## 아키텍처
+
+```
+Finder ──▶ Quick Look 확장 (Swift) ──▶ rhwp_render_pdf (C ABI)
+                                            └─▶ HWP 파서 ─▶ Document IR ─▶ SVG ─▶ PDF
+                                    ◀── PDF bytes ──┘
+```
+
+Swift 쪽에 렌더 로직은 없다. `QLPreviewReply(dataOfContentType: .pdf)` 로 PDF 바이트만 넘기면 확대·스크롤·페이지 이동 UI 는 Quick Look 이 제공한다.
+
+## 이 타스크의 전제 — 메모리가 관문이었다
+
+Quick Look 확장은 약 **80MB 경고 / 120MB 강제 종료 / 30초 타임아웃**을 받는다. 0단계 스파이크 시점에는 1페이지 렌더조차 이 선을 넘어서, PDF 아키텍처 자체가 성립하지 않았다.
+
+선행 타스크 둘로 관문을 통과했다:
+
+| 타스크 | 개선 | 효과 |
+|--------|------|------|
+| #2263 | BinData 지연 로딩 | 파싱·레이아웃 최대 RSS 244MB → **49MB** |
+| #2264 | PDF `embed_text` 옵션 | `svg2pdf::to_chunk` 최대 RSS 164MB → **69MB** |
+
+두 개선 후 1페이지 렌더 최대 RSS: **41 / 42 / 80 / 88 / 99 MB** — 전부 강제 종료선 아래. 이 수치가 없었으면 이 타스크는 불가능했다.
+
+## 실측으로 정한 것
+
+**페이지 상한 = 3.** 페이지 수별 최대 RSS:
+
+| 문서 성격 | 1쪽 | 3쪽 | 5쪽 | 10쪽 |
+|---|---|---|---|---|
+| 이미지 다수 (8쪽) | 92MB | 94MB | **179MB** | 193MB |
+| 비트맵 다수 (20쪽) | 100MB | 102MB | 104MB | 143MB |
+| 이미지 중간 (74쪽) | 41MB | 48MB | 50MB | 81MB |
+
+5페이지는 강제 종료선을 넘는다. 3페이지가 실측 최대 102MB 로 안전한 상한.
+
+## 검증
+
+| 계층 | 방법 | 결과 |
+|------|------|------|
+| FFI | 단위 테스트 5개 | 통과 (유효 PDF 매직+trailer, 범위 초과, 파일 없음) |
+| FFI 성능 | 벤치 | 1페이지 41~100MB / 0.16~1.32초 |
+| XCFramework | 슬라이스·심볼·링크 | 3슬라이스, macOS universal, 링크 경고 0, 실제 PDF 산출 |
+| 앱 번들 | 구조 검사 | 확장 임베드 / 미해결 `rhwp_` 심볼 0 / 폰트 포함 / 확장 포인트·UTI 정상 |
+
+## 검증되지 않은 것 — 정직한 고지
+
+**Finder 실제 통합.** 이 환경에 코드서명 인증서가 0개다. Ad-hoc 서명으로 빌드는 되지만, Launch Services 등록 → Finder 미리보기 표시까지는 실행해보지 못했다. 작업지시자 승인 하에 미검증을 감수하고 진행했다.
+
+Developer ID 인증서가 있는 환경에서 `rhwp-quicklook/README.md` 의 설치 절차로 확인해야 한다.
+
+## 알려진 트레이드오프
+
+- **미리보기 PDF 에서 텍스트 선택·검색이 안 된다.** `embed_text=false` 로 글리프를 path 로 그리기 때문. 메모리 한도를 지키기 위한 의도적 선택이며, 코어 기본값은 `true` 로 유지했다.
+- 미리보기는 앞쪽 3페이지만 보여준다.
+
+## 후속 권고
+
+1. **CI 에 `cargo check --manifest-path bindings/Native/Cargo.toml` 추가.** `bindings/Native` 는 워크스페이스 밖이라 CI 가 컴파일하지 않고, 그래서 이 타스크 착수 시점에 **이미 컴파일이 깨져 있었다** (#1161 의 시그니처 변경을 따라가지 못함). 같은 일이 또 일어난다. 별도 이슈 등록 필요.
+2. 인증서 확보 후 Finder 통합 검증 → 결과에 따라 후속 이슈.
+3. `embed_text=true` 상태로도 한도 안에 들어가는 문서 유형을 판별할 수 있으면 텍스트 선택을 살릴 여지가 있다 (조건부 활성화).

--- a/mydocs/working/task_m100_2267_stage1.md
+++ b/mydocs/working/task_m100_2267_stage1.md
@@ -1,0 +1,39 @@
+# 1단계 완료 보고서 — M100 #2267: C ABI 확장
+
+## 한 일
+
+`bindings/Native` 에 Quick Look 확장용 C ABI 3개를 추가했다.
+
+| 심볼 | 역할 |
+|------|------|
+| `rhwp_page_count` | 페이지 수. 실패 시 음수. |
+| `rhwp_render_pdf` | `first_page` 부터 `max_pages` 장을 PDF 로 렌더. `font_dir`, `embed_text` 를 인자로 받는다. |
+| `rhwp_buffer_free` | 반환 버퍼 해제. |
+
+`RhwpBuffer { data, len, error }` 로 성공/실패를 함께 표현한다. FFI 경계를 넘는 panic 은 unwind 로 잡아 `error` 문자열로 바꾼다.
+
+Swift 쪽에도 헤더 선언(`bindings/swift/Sources/CRhwpNative/rhwp_native_ffi.h`)과 래퍼(`Rhwp.pageCount`, `Rhwp.renderPDF`)를 추가했다.
+
+## 부수적으로 고친 것 — 크레이트가 이미 깨져 있었다
+
+`bindings/Native` 는 **컴파일이 안 되는 상태였다.** #1161 에서 `get_control_image_mime_native` / `get_control_image_data_native` 에 `cell_path` 파라미터가 추가됐는데 이 크레이트만 따라가지 않았다.
+
+원인은 명확하다: **`bindings/Native` 는 워크스페이스 밖이라 CI 가 컴파일하지 않는다.** 코어 시그니처가 바뀌어도 아무도 모른다.
+
+호출부에 빈 `cell_path`(`&[]`)를 넘겨 고쳤다.
+
+> **권고**: CI 에 `cargo check --manifest-path bindings/Native/Cargo.toml` 을 추가할 것. 이번처럼 조용히 썩는 걸 막는 유일한 방법이다. (별도 이슈로 등록 필요)
+
+`crate-type` 에 `rlib` 을 추가했다 — 예제(벤치)가 링크할 수 있어야 한다.
+
+## 검증
+
+`cargo test --manifest-path bindings/Native/Cargo.toml` — 5개 통과:
+
+- `page_count` 가 실제 페이지 수를 반환
+- `render_pdf` 결과가 유효한 PDF (`%PDF` 매직 + `%%EOF` trailer)
+- `first_page` 범위 초과 시 오류
+- 존재하지 않는 파일 → 오류 문자열
+- 버퍼 해제 후 이중 해제 없음
+
+벤치(`bindings/Native/examples/render_pdf_bench.rs`) — 1페이지 렌더 최대 RSS **41~100MB**, 소요 **0.16~1.32초**. 확장 한도(120MB / 30초) 안이다.

--- a/mydocs/working/task_m100_2267_stage2.md
+++ b/mydocs/working/task_m100_2267_stage2.md
@@ -1,0 +1,30 @@
+# 2단계 완료 보고서 — M100 #2267: XCFramework 빌드 검증
+
+## 검증 결과
+
+`scripts/package-swift-xcframework.sh` 산출물 `dist/swift/build/RhwpNative.xcframework`:
+
+| 항목 | 결과 |
+|------|------|
+| 슬라이스 | `ios-arm64`, `ios-arm64-simulator`, `macos-arm64_x86_64` (3종) |
+| macOS 슬라이스 | universal (x86_64 + arm64) |
+| `_rhwp_render_pdf` 심볼 | 존재 |
+| C 프로그램 링크 (`-mmacosx-version-min=12.0`) | 경고 0 |
+| 실제 렌더 | 유효 PDF 산출, 최대 RSS 48~102MB |
+
+## 고친 결함 — 배포 타깃이 고정되어 있지 않았다
+
+패키징 스크립트가 배포 타깃을 지정하지 않아, 오브젝트가 **빌드 머신의 macOS 버전(26.2)** 으로 빌드됐다. 반면 `Package.swift` 는 macOS 12 를 선언한다. 결과적으로 오래된 배포 타깃의 소비자가 링크하면:
+
+```
+ld: warning: object file was built for newer 'macOS' version (26.2) than being linked (12.0)
+```
+
+스크립트에서 배포 타깃을 명시적으로 고정했다:
+
+```bash
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-12.0}"
+export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-13.0}"
+```
+
+**첫 수정 후에도 경고 4개가 남았다.** 원인은 cargo 가 `blake3` 의 cc 컴파일 오브젝트를 **캐시**하고 있어서였다 — 환경변수를 바꿔도 재컴파일하지 않는다. 타깃별로 `cargo clean -p blake3 --release --target <triple>` 후 재패키징하니 경고 0.

--- a/mydocs/working/task_m100_2267_stage3.md
+++ b/mydocs/working/task_m100_2267_stage3.md
@@ -1,0 +1,57 @@
+# 3단계 완료 보고서 — M100 #2267: Xcode 스캐폴딩
+
+## 한 일
+
+`rhwp-quicklook/` 에 XcodeGen 스펙(`project.yml`)과 Swift 소스를 만들었다. 타겟 3개: 호스트 앱 + Preview 확장 + Thumbnail 확장.
+
+`RhwpQuickLook.xcodeproj` 는 생성물이라 `.gitignore` 에 넣었다. `project.yml` 이 유일한 원본이다.
+
+## 페이지 상한을 3으로 정한 근거
+
+확장 프로세스 한도는 약 80MB 경고 / **120MB 강제 종료** / 30초 타임아웃이다. 페이지 수별 최대 RSS 실측 (`embed_text=0`):
+
+| 문서 성격 | 1쪽 | 3쪽 | 5쪽 | 10쪽 |
+|---|---|---|---|---|
+| 이미지 다수 (8쪽) | 92MB | 94MB | **179MB** | 193MB |
+| 비트맵 다수 (20쪽) | 100MB | 102MB | 104MB | 143MB |
+| 이미지 중간 (74쪽) | 41MB | 48MB | 50MB | 81MB |
+
+**5페이지는 강제 종료선을 넘는다.** 3페이지가 실측 최대 102MB 로 안전한 상한이다. 상수는 `Shared/RhwpRenderer.swift` 의 `previewPageLimit` 에 근거와 함께 박아뒀다. 늘리려면 재측정해야 한다.
+
+## 설계 결정
+
+- **PDF 데이터 기반 미리보기.** `QLPreviewReply(dataOfContentType: .pdf)` 로 바이트만 넘긴다. 확대·스크롤·페이지 이동 UI 를 Quick Look 이 제공한다.
+- **`embed_text = false`.** 폰트 임베드를 끄면 RSS 가 95MB 가량 줄어든다 (#2264). 대가로 미리보기 PDF 에서 텍스트 선택·검색이 안 된다. 코어 기본값은 `true` 로 두고 확장에서만 끈다.
+- **폰트 번들 절대경로 전달.** 코어의 기본 폰트 탐색은 작업디렉터리 상대경로(`ttfs/`)라 샌드박스 확장에서는 안 잡힌다. `ttfs/opensource` 를 확장 Resources 에 담고 절대경로를 넘긴다.
+- **HWPX 를 `com.pkware.zip-archive` 에 conform 시키지 않음.** conform 시키면 아카이브용 Quick Look 확장이 먼저 가로챌 수 있다.
+
+## 검증 — 번들 구조
+
+빌드 성공(`** BUILD SUCCEEDED **`) 후 산출물 검사:
+
+| 항목 | 결과 |
+|------|------|
+| 확장 임베드 | `Contents/PlugIns/` 에 `RhwpPreviewExtension.appex`, `RhwpThumbnailExtension.appex` |
+| Rust 라이브러리 링크 | 미해결 `rhwp_` 심볼 **0**, `_rhwp_render_pdf` 정의 포함 |
+| 폰트 번들링 | `.appex/Contents/Resources/opensource/` 에 NotoSansKR 계열 포함 |
+| Preview 확장 | point=`com.apple.quicklook.preview`, class=`RhwpPreviewExtension.PreviewProvider`, UTI 3개 |
+| Thumbnail 확장 | point=`com.apple.quicklook.thumbnail`, class=`RhwpThumbnailExtension.ThumbnailProvider`, UTI 3개 |
+| 앱 UTI 선언 | `kr.co.hancom.hwp`←hwp, `.hwpx`←hwpx, `.hml`←hml |
+| 서명 | `Identifier=com.rhwp.quicklook, Signature=adhoc` |
+
+## 검증되지 않은 것
+
+**Finder 실제 통합.** 이 환경에 코드서명 인증서가 0개다. Ad-hoc 서명으로 빌드는 되지만 Launch Services 등록 → Finder 미리보기 표시 경로는 실행해보지 못했다. 작업지시자가 미검증을 감수하기로 결정하고 진행했다.
+
+Developer ID 인증서가 있는 환경에서 README 의 "설치" 절차(앱을 `/Applications` 에 복사 → 1회 실행 → `pluginkit -m -p com.apple.quicklook.preview` 로 등록 확인)로 확인해야 한다.
+
+## 삽질 기록 — `plutil -extract` 는 `-o -` 없으면 원본을 덮어쓴다
+
+검증 중 빌드된 `Info.plist` 의 `QLSupportedContentTypes` 가 사라진 것처럼 보였다. 원인은 프로젝트가 아니라 **내 검증 명령**이었다.
+
+```bash
+plutil -extract NSExtension.NSExtensionAttributes.QLSupportedContentTypes json "$PLIST"   # ← 원본을 덮어씀
+plutil -extract NSExtension.NSExtensionAttributes.QLSupportedContentTypes json -o - "$PLIST"  # ← 올바름
+```
+
+`-o` 를 생략하면 plutil 이 추출 결과를 **입력 파일에 다시 쓴다.** 소스 plist 는 멀쩡했고 재빌드로 복구됐다. plist 를 읽기만 할 때는 반드시 `-o -` 를 붙일 것.

--- a/rhwp-quicklook/.gitignore
+++ b/rhwp-quicklook/.gitignore
@@ -1,0 +1,4 @@
+# XcodeGen 이 project.yml 에서 생성한다. 커밋하지 않는다.
+RhwpQuickLook.xcodeproj/
+build/
+DerivedData/

--- a/rhwp-quicklook/App/App.entitlements
+++ b/rhwp-quicklook/App/App.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/rhwp-quicklook/App/AppDelegate.swift
+++ b/rhwp-quicklook/App/AppDelegate.swift
@@ -1,0 +1,53 @@
+import AppKit
+
+/// [Task #2267] Quick Look 확장의 호스트 앱.
+///
+/// Quick Look 확장은 **앱 번들 안에만 존재할 수 있고**, 앱이 한 번 실행되어
+/// Launch Services 에 등록되어야 Finder 가 확장을 집어든다. 이 앱 자체는
+/// 설치 안내와 상태 확인만 한다.
+@main
+final class AppDelegate: NSObject, NSApplicationDelegate {
+    private var window: NSWindow?
+
+    func applicationDidFinishLaunching(_ notification: Notification) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 520, height: 260),
+            styleMask: [.titled, .closable, .miniaturizable],
+            backing: .buffered,
+            defer: false
+        )
+        window.title = "rhwp Quick Look"
+        window.center()
+
+        let text = NSTextField(wrappingLabelWithString: """
+        rhwp Quick Look 확장이 설치되었습니다.
+
+        Finder 에서 .hwp / .hwpx / .hml 파일을 선택하고 스페이스바를 누르면
+        미리보기가 표시됩니다.
+
+        미리보기가 뜨지 않으면 터미널에서 확장 등록 상태를 확인하세요:
+            pluginkit -m -p com.apple.quicklook.preview
+
+        참고: 미리보기는 앞쪽 3페이지까지만 렌더합니다 (확장 메모리 한도).
+        """)
+        text.font = .systemFont(ofSize: 13)
+        text.translatesAutoresizingMaskIntoConstraints = false
+
+        let content = NSView()
+        content.addSubview(text)
+        NSLayoutConstraint.activate([
+            text.leadingAnchor.constraint(equalTo: content.leadingAnchor, constant: 24),
+            text.trailingAnchor.constraint(equalTo: content.trailingAnchor, constant: -24),
+            text.topAnchor.constraint(equalTo: content.topAnchor, constant: 24),
+        ])
+        window.contentView = content
+        window.makeKeyAndOrderFront(nil)
+        NSApp.activate(ignoringOtherApps: true)
+
+        self.window = window
+    }
+
+    func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
+        true
+    }
+}

--- a/rhwp-quicklook/App/Info.plist
+++ b/rhwp-quicklook/App/Info.plist
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>ko</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>rhwp Quick Look</string>
+	<key>CFBundlePackageType</key>
+	<string>APPL</string>
+	<key>CFBundleShortVersionString</key>
+	<string>$(MARKETING_VERSION)</string>
+	<key>CFBundleVersion</key>
+	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<key>LSMinimumSystemVersion</key>
+	<string>$(MACOSX_DEPLOYMENT_TARGET)</string>
+	<key>NSHumanReadableCopyright</key>
+	<string>MIT License</string>
+
+	<!--
+	  [Task #2267] UTI 선언.
+
+	  macOS 에는 .hwp / .hwpx 의 기본 UTI 가 없다. 확장이 QLSupportedContentTypes 로
+	  참조할 타입을 여기서 선언해야 한다. 선언은 호스트 앱 Info.plist 에 둔다.
+
+	  주의: HWPX 는 ZIP 컨테이너지만 `com.pkware.zip-archive` 에 conform 시키지 않는다.
+	  conform 시키면 아카이브용 Quick Look 확장이 먼저 가로챌 수 있다.
+	-->
+	<key>UTImportedTypeDeclarations</key>
+	<array>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>kr.co.hancom.hwp</string>
+			<key>UTTypeDescription</key>
+			<string>한글 문서 (HWP)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>hwp</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>kr.co.hancom.hwpx</string>
+			<key>UTTypeDescription</key>
+			<string>한글 문서 (HWPX)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.data</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>hwpx</string>
+				</array>
+			</dict>
+		</dict>
+		<dict>
+			<key>UTTypeIdentifier</key>
+			<string>kr.co.hancom.hml</string>
+			<key>UTTypeDescription</key>
+			<string>한글 문서 (HML)</string>
+			<key>UTTypeConformsTo</key>
+			<array>
+				<string>public.xml</string>
+				<string>public.composite-content</string>
+			</array>
+			<key>UTTypeTagSpecification</key>
+			<dict>
+				<key>public.filename-extension</key>
+				<array>
+					<string>hml</string>
+				</array>
+			</dict>
+		</dict>
+	</array>
+</dict>
+</plist>

--- a/rhwp-quicklook/PreviewExtension/Info.plist
+++ b/rhwp-quicklook/PreviewExtension/Info.plist
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key><string>ko</string>
+	<key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key><string>rhwp Preview</string>
+	<key>CFBundlePackageType</key><string>XPC!</string>
+	<key>CFBundleShortVersionString</key><string>0.1.0</string>
+	<key>CFBundleVersion</key><string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<!-- 데이터 기반 미리보기: 뷰가 아니라 PDF 데이터를 반환한다 -->
+		<key>NSExtensionPointIdentifier</key><string>com.apple.quicklook.preview</string>
+		<key>NSExtensionPrincipalClass</key><string>$(PRODUCT_MODULE_NAME).PreviewProvider</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key><array><string>kr.co.hancom.hwp</string><string>kr.co.hancom.hwpx</string><string>kr.co.hancom.hml</string></array>
+			<key>QLSupportsSearchableItems</key><false/>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/rhwp-quicklook/PreviewExtension/PreviewExtension.entitlements
+++ b/rhwp-quicklook/PreviewExtension/PreviewExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/rhwp-quicklook/PreviewExtension/PreviewProvider.swift
+++ b/rhwp-quicklook/PreviewExtension/PreviewProvider.swift
@@ -1,0 +1,29 @@
+import Foundation
+import QuickLookUI
+
+/// [Task #2267] 데이터 기반 Quick Look 미리보기 확장.
+///
+/// 뷰를 직접 그리지 않고 **PDF 로 변환해 시스템에 넘긴다**(`QLPreviewReply`).
+/// 확대·스크롤·다중 페이지 UI 를 Quick Look 이 제공하므로 뷰 코드가 필요 없고,
+/// PDF 는 macOS 의 1급 시민이라 렌더 품질도 시스템이 책임진다.
+final class PreviewProvider: QLPreviewProvider, QLPreviewingController {
+
+    func providePreview(for request: QLFilePreviewRequest) async throws -> QLPreviewReply {
+        // 렌더는 동기·CPU 바운드다. 파일 URL 만 캡처해 백그라운드에서 수행한다.
+        let fileURL = request.fileURL
+
+        let pdf = try await Task.detached(priority: .userInitiated) {
+            try RhwpRenderer.renderPDF(
+                fileURL: fileURL,
+                maxPages: RhwpRenderer.previewPageLimit
+            )
+        }.value
+
+        return QLPreviewReply(
+            dataOfContentType: .pdf,
+            contentSize: .zero  // PDF 자체가 페이지 크기를 갖는다.
+        ) { _ in
+            pdf
+        }
+    }
+}

--- a/rhwp-quicklook/README.md
+++ b/rhwp-quicklook/README.md
@@ -1,0 +1,121 @@
+# rhwp Quick Look
+
+macOS Finder 에서 `.hwp` / `.hwpx` / `.hml` 파일을 스페이스바로 미리보고, 파일 아이콘에 썸네일을 표시하는 Quick Look 확장이다.
+
+## 구성
+
+| 타겟 | 역할 |
+|------|------|
+| `RhwpQuickLook` (앱) | 확장을 담는 호스트 앱. UTI 를 선언하고 Launch Services 에 확장을 등록시킨다. |
+| `RhwpPreviewExtension` | `QLPreviewProvider`. 문서를 PDF 로 렌더해 Quick Look 창에 넘긴다. |
+| `RhwpThumbnailExtension` | `QLThumbnailProvider`. 첫 페이지를 그려 Finder 아이콘 썸네일을 만든다. |
+
+렌더는 Rust 코어(`bindings/Native` 의 C ABI)를 XCFramework 로 링크해 수행한다. Swift 쪽에는 렌더 로직이 없다.
+
+```
+Finder ──▶ Quick Look 확장 ──▶ rhwp_render_pdf (C ABI)
+                                    └─▶ HWP 파서 ─▶ Document IR ─▶ SVG ─▶ PDF
+                              ◀── PDF bytes ──┘
+```
+
+## 빌드
+
+### 사전 준비
+
+1. **XCFramework 생성** (필수, 먼저 실행):
+
+   ```bash
+   ./scripts/package-swift-xcframework.sh
+   ```
+
+   `dist/swift/build/RhwpNative.xcframework` 가 만들어진다. Xcode 프로젝트는 이 경로를 직접 참조하므로, 없으면 링크 단계에서 실패한다.
+
+2. **XcodeGen** (프로젝트 파일 생성기):
+
+   ```bash
+   brew install xcodegen
+   ```
+
+### 빌드
+
+```bash
+cd rhwp-quicklook
+xcodegen generate                       # project.yml → RhwpQuickLook.xcodeproj
+xcodebuild -project RhwpQuickLook.xcodeproj \
+           -scheme RhwpQuickLook \
+           -configuration Release \
+           -destination 'platform=macOS' build
+```
+
+`RhwpQuickLook.xcodeproj` 는 생성물이라 커밋하지 않는다. `project.yml` 이 유일한 원본이다.
+
+## 설치
+
+Quick Look 확장은 **앱 번들 안에만 존재할 수 있고**, 앱이 한 번 Launch Services 에 등록되어야 Finder 가 확장을 집어든다.
+
+```bash
+# 빌드 산출물을 /Applications 로 복사한 뒤 한 번 실행
+cp -R <DerivedData>/Build/Products/Release/RhwpQuickLook.app /Applications/
+open /Applications/RhwpQuickLook.app
+```
+
+등록 확인:
+
+```bash
+pluginkit -m -p com.apple.quicklook.preview   | grep -i rhwp
+pluginkit -m -p com.apple.quicklook.thumbnail | grep -i rhwp
+```
+
+Finder 에서 `.hwp` 파일을 선택하고 스페이스바.
+
+## 설계 근거
+
+### 왜 PDF 인가
+
+`QLPreviewReply(dataOfContentType: .pdf)` 로 PDF 바이트만 넘기면 확대·스크롤·페이지 이동 UI 를 Quick Look 이 전부 제공한다. 커스텀 뷰(`QLPreviewingController` + NSView)를 만들면 그 UI 를 직접 구현해야 한다.
+
+### 페이지 상한 3
+
+확장 프로세스는 하드 제약을 받는다: 약 **80MB 경고 / 120MB 강제 종료 / 30초 타임아웃**.
+
+1페이지 렌더 시 최대 RSS 실측 (`embed_text=0`):
+
+| 문서 성격 | 1쪽 | 3쪽 | 5쪽 | 10쪽 |
+|---|---|---|---|---|
+| 이미지 다수 (8쪽) | 92MB | 94MB | **179MB** | 193MB |
+| 비트맵 다수 (20쪽) | 100MB | 102MB | 104MB | 143MB |
+| 이미지 중간 (74쪽) | 41MB | 48MB | 50MB | 81MB |
+
+**5페이지는 강제 종료선(120MB)을 넘는다.** 3페이지가 실측 최대 102MB 로 안전한 상한이다. 늘리려면 반드시 재측정한다. 상수는 `Shared/RhwpRenderer.swift` 의 `previewPageLimit`.
+
+이 수치는 Task #2263(BinData 지연 로딩)과 #2264(`embed_text` 옵션)를 **둘 다 적용한 뒤**의 값이다. 두 개선 전에는 1페이지 렌더도 강제 종료선을 넘었다.
+
+### `embed_text = false`
+
+PDF 에 텍스트를 폰트로 임베드하면 폰트 서브셋 과정에서 RSS 가 95MB 가량 더 뛴다 (#2264). 미리보기는 시각 표현만 필요하므로 글리프를 path 로 그린다. **대가: 미리보기 PDF 에서 텍스트 선택·검색이 안 된다.** 코어의 기본값은 `true` 이고, 확장에서만 끈다.
+
+### 폰트 번들
+
+코어의 기본 폰트 탐색 경로는 작업디렉터리 상대경로(`ttfs/`)라 샌드박스된 확장 프로세스에서는 잡히지 않는다. `ttfs/opensource` 를 번들 Resources 에 담고 그 **절대경로**를 `rhwp_render_pdf` 에 넘긴다. 안 넘기면 한글이 깨진다.
+
+### UTI
+
+macOS 에는 `.hwp` / `.hwpx` 의 기본 UTI 가 없다. 호스트 앱 `Info.plist` 의 `UTImportedTypeDeclarations` 로 `kr.co.hancom.hwp` / `.hwpx` / `.hml` 을 선언한다.
+
+HWPX 는 ZIP 컨테이너지만 `com.pkware.zip-archive` 에 **conform 시키지 않는다.** conform 시키면 아카이브용 Quick Look 확장이 먼저 가로챌 수 있다.
+
+## 현재 상태 — 검증 범위
+
+**검증된 것** (빌드 산출물 구조 검사):
+
+- Xcode 빌드 성공, 두 확장이 앱 번들 `Contents/PlugIns/` 에 임베드됨
+- 확장 바이너리에 미해결 `rhwp_` 심볼 0, `_rhwp_render_pdf` 정의 포함 (Rust 정적 라이브러리 링크 확인)
+- 폰트가 `.appex/Contents/Resources/opensource/` 에 포함됨
+- 두 확장의 `NSExtensionPointIdentifier` / `NSExtensionPrincipalClass` / `QLSupportedContentTypes`(3개 UTI) 정상
+- 앱 Info.plist 의 UTI 선언 정상
+- FFI 계층은 별도 테스트 5개 + 벤치로 검증 (실제 PDF 산출, 41~102MB)
+
+**검증되지 않은 것**:
+
+- **Finder 실제 통합.** 이 환경에 코드서명 인증서가 없다. Ad-hoc 서명(`CODE_SIGN_IDENTITY: "-"`)으로 빌드했고, Launch Services 등록 → Finder 미리보기 표시까지의 경로는 실행해보지 못했다. Developer ID 인증서가 있는 환경에서 위 "설치" 절차로 확인해야 한다.
+- 30초 타임아웃 안에서의 실제 동작 (FFI 벤치 기준 0.16~1.32초라 여유는 크다).

--- a/rhwp-quicklook/Shared/RhwpBridging.h
+++ b/rhwp-quicklook/Shared/RhwpBridging.h
@@ -1,0 +1,6 @@
+// [Task #2267] Swift ← C ABI 브릿징.
+//
+// RhwpNative.xcframework 는 정적 라이브러리 + C 헤더만 담고 modulemap 이 없으므로,
+// bridging header 로 노출한다. 헤더 경로는 HEADER_SEARCH_PATHS 로 지정한다.
+
+#import "rhwp_native_ffi.h"

--- a/rhwp-quicklook/Shared/RhwpRenderer.swift
+++ b/rhwp-quicklook/Shared/RhwpRenderer.swift
@@ -1,0 +1,76 @@
+import Foundation
+
+/// [Task #2267] HWP/HWPX → PDF 렌더러. Quick Look 확장 두 개가 공유한다.
+///
+/// 확장 프로세스에는 하드 제약이 있다: 약 **80MB 경고 / 120MB 강제 종료 / 30초 타임아웃**.
+/// 아래 상수와 옵션은 전부 그 한도에서 역산한 실측 기반이다.
+enum RhwpRenderer {
+
+    /// 미리보기에서 렌더할 최대 페이지 수.
+    ///
+    /// 실측 (1페이지 렌더 최대 RSS, `embed_text=0`):
+    ///
+    /// | 문서 | 1쪽 | 3쪽 | 5쪽 | 10쪽 |
+    /// |---|---|---|---|---|
+    /// | 이미지 다수 8쪽 | 92 | 94 | **179** | 193 |
+    /// | 비트맵 다수 20쪽 | 100 | 102 | 104 | 143 |
+    /// | 이미지 중간 74쪽 | 41 | 48 | 50 | 81 |
+    ///
+    /// **5페이지는 120MB 강제 종료선을 넘는다.** 3페이지가 실측 최대 102MB 로 안전한
+    /// 상한이다. 늘리려면 반드시 재측정한다.
+    static let previewPageLimit: Int32 = 3
+
+    /// 썸네일은 첫 페이지만 그린다.
+    static let thumbnailPageLimit: Int32 = 1
+
+    /// 번들에 담긴 한글 폰트 디렉터리.
+    ///
+    /// 코어의 기본 폰트 탐색 경로는 **작업디렉터리 상대경로**(`ttfs/` 등)라, 샌드박스된
+    /// 확장 프로세스에서는 절대 잡히지 않는다. 번들 Resources 의 절대경로를 넘겨야
+    /// 한글이 깨지지 않는다.
+    static var fontDirectory: URL? {
+        Bundle.main.resourceURL?.appendingPathComponent("opensource", isDirectory: true)
+    }
+
+    enum RenderError: LocalizedError {
+        case failed(String)
+
+        var errorDescription: String? {
+            switch self {
+            case let .failed(message):
+                return message
+            }
+        }
+    }
+
+    /// 문서를 PDF 로 렌더링한다.
+    ///
+    /// `embedText` 는 기본 `false` 다. 텍스트를 PDF 폰트로 임베드하면 폰트 서브셋
+    /// 과정에서 한글 폰트 전체가 메모리에 올라와 RSS 가 100MB 이상 뛴다 (#2264).
+    /// 미리보기는 시각 표현만 필요하므로 글리프를 path 로 그린다.
+    static func renderPDF(
+        fileURL: URL,
+        maxPages: Int32,
+        embedText: Bool = false
+    ) throws -> Data {
+        let buffer: RhwpBuffer = fileURL.path.withCString { input in
+            let render: (UnsafePointer<CChar>?) -> RhwpBuffer = { fontDir in
+                rhwp_render_pdf(input, 0, maxPages, fontDir, embedText ? 1 : 0)
+            }
+            if let fontDirectory {
+                return fontDirectory.path.withCString { render($0) }
+            }
+            return render(nil)
+        }
+
+        defer { rhwp_buffer_free(buffer) }
+
+        if let error = buffer.error {
+            throw RenderError.failed(String(cString: error))
+        }
+        guard let data = buffer.data, buffer.len > 0 else {
+            throw RenderError.failed("렌더 결과가 비어 있습니다.")
+        }
+        return Data(bytes: data, count: buffer.len)
+    }
+}

--- a/rhwp-quicklook/ThumbnailExtension/Info.plist
+++ b/rhwp-quicklook/ThumbnailExtension/Info.plist
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key><string>ko</string>
+	<key>CFBundleExecutable</key><string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key><string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
+	<key>CFBundleName</key><string>rhwp Thumbnail</string>
+	<key>CFBundlePackageType</key><string>XPC!</string>
+	<key>CFBundleShortVersionString</key><string>0.1.0</string>
+	<key>CFBundleVersion</key><string>1</string>
+	<key>NSExtension</key>
+	<dict>
+		<key>NSExtensionPointIdentifier</key><string>com.apple.quicklook.thumbnail</string>
+		<key>NSExtensionPrincipalClass</key><string>$(PRODUCT_MODULE_NAME).ThumbnailProvider</string>
+		<key>NSExtensionAttributes</key>
+		<dict>
+			<key>QLSupportedContentTypes</key><array><string>kr.co.hancom.hwp</string><string>kr.co.hancom.hwpx</string><string>kr.co.hancom.hml</string></array>
+		</dict>
+	</dict>
+</dict>
+</plist>

--- a/rhwp-quicklook/ThumbnailExtension/ThumbnailExtension.entitlements
+++ b/rhwp-quicklook/ThumbnailExtension/ThumbnailExtension.entitlements
@@ -1,0 +1,10 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>com.apple.security.app-sandbox</key>
+	<true/>
+	<key>com.apple.security.files.user-selected.read-only</key>
+	<true/>
+</dict>
+</plist>

--- a/rhwp-quicklook/ThumbnailExtension/ThumbnailProvider.swift
+++ b/rhwp-quicklook/ThumbnailExtension/ThumbnailProvider.swift
@@ -1,0 +1,65 @@
+import Foundation
+import PDFKit
+import QuickLookThumbnailing
+
+/// [Task #2267] Finder 아이콘용 썸네일 확장.
+///
+/// 첫 페이지만 PDF 로 렌더한 뒤 PDFKit 으로 그린다. 전체 문서를 그리면 확장의
+/// 메모리·시간 한도를 넘긴다.
+final class ThumbnailProvider: QLThumbnailProvider {
+
+    override func provideThumbnail(
+        for request: QLFileThumbnailRequest,
+        _ handler: @escaping (QLThumbnailReply?, Error?) -> Void
+    ) {
+        do {
+            let pdfData = try RhwpRenderer.renderPDF(
+                fileURL: request.fileURL,
+                maxPages: RhwpRenderer.thumbnailPageLimit
+            )
+
+            guard
+                let document = PDFDocument(data: pdfData),
+                let page = document.page(at: 0)
+            else {
+                handler(nil, RhwpRenderer.RenderError.failed("PDF 첫 페이지를 열 수 없습니다."))
+                return
+            }
+
+            let pageRect = page.bounds(for: .mediaBox)
+            guard pageRect.width > 0, pageRect.height > 0 else {
+                handler(nil, RhwpRenderer.RenderError.failed("페이지 크기가 유효하지 않습니다."))
+                return
+            }
+
+            // 요청 크기에 종횡비를 맞춘다 (문서는 세로가 길다).
+            let maximumSize = request.maximumSize
+            let scale = min(
+                maximumSize.width / pageRect.width,
+                maximumSize.height / pageRect.height
+            )
+            let thumbnailSize = CGSize(
+                width: max(pageRect.width * scale, 1),
+                height: max(pageRect.height * scale, 1)
+            )
+
+            let reply = QLThumbnailReply(contextSize: thumbnailSize) { context in
+                // 배경을 흰색으로 채운다. PDF 페이지에 배경이 없으면 투명해진다.
+                context.setFillColor(.white)
+                context.fill(CGRect(origin: .zero, size: thumbnailSize))
+
+                context.saveGState()
+                context.scaleBy(x: scale, y: scale)
+                context.translateBy(x: -pageRect.origin.x, y: -pageRect.origin.y)
+                page.draw(with: .mediaBox, to: context)
+                context.restoreGState()
+
+                return true
+            }
+
+            handler(reply, nil)
+        } catch {
+            handler(nil, error)
+        }
+    }
+}

--- a/rhwp-quicklook/project.yml
+++ b/rhwp-quicklook/project.yml
@@ -1,0 +1,103 @@
+name: RhwpQuickLook
+
+options:
+  bundleIdPrefix: com.rhwp
+  deploymentTarget:
+    macOS: "12.0"
+  createIntermediateGroups: true
+
+settings:
+  base:
+    # 서명 인증서가 없는 환경에서도 빌드되도록 ad-hoc 서명을 기본으로 둔다.
+    # 실제 배포에는 Developer ID + notarization 이 필요하다.
+    CODE_SIGN_IDENTITY: "-"
+    CODE_SIGNING_REQUIRED: "NO"
+    CODE_SIGNING_ALLOWED: "YES"
+    CODE_SIGN_STYLE: Manual
+    DEVELOPMENT_TEAM: ""
+    SWIFT_VERSION: "5.9"
+    MACOSX_DEPLOYMENT_TARGET: "12.0"
+    ENABLE_HARDENED_RUNTIME: "YES"
+
+packages: {}
+
+targets:
+  RhwpQuickLook:
+    type: application
+    platform: macOS
+    sources:
+      - App
+    dependencies:
+      - target: RhwpPreviewExtension
+        embed: true
+        codeSign: true
+      - target: RhwpThumbnailExtension
+        embed: true
+        codeSign: true
+    settings:
+      base:
+        INFOPLIST_FILE: App/Info.plist
+        CODE_SIGN_ENTITLEMENTS: App/App.entitlements
+        PRODUCT_BUNDLE_IDENTIFIER: com.rhwp.quicklook
+        MARKETING_VERSION: "0.1.0"
+        CURRENT_PROJECT_VERSION: "1"
+
+  RhwpPreviewExtension:
+    type: app-extension
+    platform: macOS
+    sources:
+      - PreviewExtension
+      - Shared
+      # 한글 폰트 번들. 샌드박스된 확장은 코어의 CWD 상대경로(`ttfs/`)를 찾지 못하므로
+      # 번들 Resources 의 절대경로를 렌더러에 넘겨야 한다 (RhwpRenderer.fontDirectory).
+      - path: ../ttfs/opensource
+        name: Fonts
+        type: folder
+        buildPhase: resources
+    dependencies:
+      - framework: ../dist/swift/build/RhwpNative.xcframework
+        embed: false
+      - sdk: PDFKit.framework
+      - sdk: QuickLookUI.framework
+    settings:
+      base:
+        INFOPLIST_FILE: PreviewExtension/Info.plist
+        CODE_SIGN_ENTITLEMENTS: PreviewExtension/PreviewExtension.entitlements
+        PRODUCT_BUNDLE_IDENTIFIER: com.rhwp.quicklook.preview
+        SWIFT_OBJC_BRIDGING_HEADER: Shared/RhwpBridging.h
+        # XCFramework 는 정적 라이브러리 + C 헤더만 담고 modulemap 이 없으므로
+        # bridging header 로 노출한다.
+        HEADER_SEARCH_PATHS:
+          - $(inherited)
+          - $(PROJECT_DIR)/../dist/swift/build/RhwpNative.xcframework/macos-arm64_x86_64/Headers
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -lc++
+
+  RhwpThumbnailExtension:
+    type: app-extension
+    platform: macOS
+    sources:
+      - ThumbnailExtension
+      - Shared
+      - path: ../ttfs/opensource
+        name: Fonts
+        type: folder
+        buildPhase: resources
+    dependencies:
+      - framework: ../dist/swift/build/RhwpNative.xcframework
+        embed: false
+      - sdk: PDFKit.framework
+      - sdk: QuickLookThumbnailing.framework
+    settings:
+      base:
+        INFOPLIST_FILE: ThumbnailExtension/Info.plist
+        CODE_SIGN_ENTITLEMENTS: ThumbnailExtension/ThumbnailExtension.entitlements
+        PRODUCT_BUNDLE_IDENTIFIER: com.rhwp.quicklook.thumbnail
+        SWIFT_OBJC_BRIDGING_HEADER: Shared/RhwpBridging.h
+        HEADER_SEARCH_PATHS:
+          - $(inherited)
+          - $(PROJECT_DIR)/../dist/swift/build/RhwpNative.xcframework/macos-arm64_x86_64/Headers
+        OTHER_LDFLAGS:
+          - $(inherited)
+          - -lc++

--- a/scripts/package-swift-xcframework.sh
+++ b/scripts/package-swift-xcframework.sh
@@ -20,6 +20,14 @@ DEVICE_TARGET="aarch64-apple-ios"
 SIM_TARGETS=("aarch64-apple-ios-sim")
 MACOS_TARGETS=("aarch64-apple-darwin" "x86_64-apple-darwin")
 
+# [Task #2267] 배포 타깃을 명시한다. 지정하지 않으면 rustc/cc 가 **빌드 머신의 SDK
+# 버전**으로 오브젝트를 만들어, `Package.swift` 가 선언한 지원 범위(macOS 12 / iOS 13)
+# 보다 높은 버전을 요구하게 된다. 그 결과 구버전 OS 를 타깃하는 소비자가 링크할 때
+# "object file was built for newer 'macOS' version" 경고와 함께 깨진다.
+# Package.swift 의 platforms 선언과 반드시 일치시킨다.
+export MACOSX_DEPLOYMENT_TARGET="${MACOSX_DEPLOYMENT_TARGET:-12.0}"
+export IPHONEOS_DEPLOYMENT_TARGET="${IPHONEOS_DEPLOYMENT_TARGET:-13.0}"
+
 if [[ "$(uname -s)" != "Darwin" ]]; then
   echo "error: XCFramework packaging requires macOS."
   exit 1


### PR DESCRIPTION
Closes #2267

Finder 에서 `.hwp` / `.hwpx` / `.hml` 을 스페이스바로 미리보고, 파일 아이콘에 썸네일을 표시하는 Quick Look 확장.

```
Finder ──▶ Quick Look 확장 (Swift) ──▶ rhwp_render_pdf (C ABI)
                                            └─▶ HWP 파서 ─▶ Document IR ─▶ SVG ─▶ PDF
                                    ◀── PDF bytes ──┘
```

`QLPreviewReply(dataOfContentType: .pdf)` 로 PDF 바이트만 넘긴다. 확대·스크롤·페이지 이동 UI 는 Quick Look 이 제공하므로 Swift 쪽에 렌더 로직이 없다.

## 커밋

| 커밋 | 내용 |
|------|------|
| 1단계 | `bindings/Native` 에 C ABI 추가 (`rhwp_page_count`, `rhwp_render_pdf`, `rhwp_buffer_free`) |
| 2단계 | XCFramework 패키징 스크립트의 배포 타깃 고정 |
| 3단계 | `rhwp-quicklook/` — XcodeGen 스펙 + 호스트 앱 + 확장 2개 |

## 이 PR 의 전제

Quick Look 확장은 약 **80MB 경고 / 120MB 강제 종료 / 30초 타임아웃**을 받는다. 착수 시점에는 1페이지 렌더조차 이 선을 넘어서 PDF 아키텍처가 성립하지 않았다. #2263(BinData 지연 로딩)과 #2264(`embed_text` 옵션)로 1페이지 최대 RSS 가 41~99MB 까지 내려와서 가능해졌다.

## 실측으로 정한 것

**미리보기 페이지 상한 = 3.** 페이지 수별 최대 RSS:

| 문서 성격 | 1쪽 | 3쪽 | 5쪽 | 10쪽 |
|---|---|---|---|---|
| 이미지 다수 (8쪽) | 92MB | 94MB | **179MB** | 193MB |
| 비트맵 다수 (20쪽) | 100MB | 102MB | 104MB | 143MB |
| 이미지 중간 (74쪽) | 41MB | 48MB | 50MB | 81MB |

5페이지는 강제 종료선을 넘는다. 3페이지가 실측 최대 102MB.

## 설계 결정

- **`embed_text = false`** — 폰트 임베드를 끄면 RSS 95MB 절감. **대가: 미리보기 PDF 에서 텍스트 선택·검색 불가.** 코어 기본값은 `true` 유지, 확장에서만 끈다.
- **폰트 절대경로 전달** — 코어 기본 폰트 탐색은 작업디렉터리 상대경로(`ttfs/`)라 샌드박스 확장에서 안 잡힌다. `ttfs/opensource` 를 확장 Resources 에 담고 절대경로를 넘긴다.
- **HWPX 를 `com.pkware.zip-archive` 에 conform 시키지 않음** — conform 시키면 아카이브용 Quick Look 확장이 먼저 가로챌 수 있다.
- `RhwpQuickLook.xcodeproj` 는 XcodeGen 생성물이라 커밋하지 않는다. `project.yml` 이 원본.

## 검증

| 계층 | 결과 |
|------|------|
| FFI 단위 테스트 | 5/5 통과 (유효 PDF 매직+trailer, 범위 초과, 파일 없음) |
| FFI 벤치 | 1페이지 41~100MB / 0.16~1.32초 |
| XCFramework | 3슬라이스, macOS universal, 링크 경고 0, 실제 PDF 산출 |
| 앱 번들 | 확장 임베드 / 미해결 `rhwp_` 심볼 0 / 폰트 포함 / 확장 포인트·UTI 정상 |

## ⚠️ 검증되지 않은 것

**Finder 실제 통합.** 작업 환경에 코드서명 인증서가 없다. Ad-hoc 서명으로 빌드는 되지만 Launch Services 등록 → Finder 미리보기 표시 경로는 실행해보지 못했다. Developer ID 인증서가 있는 환경에서 `rhwp-quicklook/README.md` 의 설치 절차로 확인이 필요하다. **그래서 draft 로 연다.**

## 별건 — `bindings/Native` 가 이미 깨져 있었다

착수 시점에 이 크레이트는 **컴파일이 안 됐다.** #1161 에서 `get_control_image_*_native` 에 `cell_path` 파라미터가 추가됐는데 이 크레이트만 따라가지 못했다. 워크스페이스 밖이라 **CI 가 컴파일하지 않기 때문**이다. 1단계 커밋에서 함께 고쳤다.

**권고: CI 에 `cargo check --manifest-path bindings/Native/Cargo.toml` 추가.** 안 하면 또 조용히 썩는다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
