### PR TITLE
Task #2269: PDF 폰트 채번 비결정 원인 규명 + 정규화 비교 도구

### DIFF
--- a/mydocs/tech/pdf_font_numbering_nondeterminism.md
+++ b/mydocs/tech/pdf_font_numbering_nondeterminism.md
@@ -1,0 +1,54 @@
+# PDF 폰트 리소스 채번 비결정 (#2269) — 원인·해법
+
+## 증상
+
+`rhwp export-pdf <문서>` 를 **동일 바이너리로 2회** 실행하면 산출 PDF 가 바이트 diff 를
+낸다(86712: 2.4MB, 75544: 2.57MB diff). **시각 출력·파일 크기·구조는 동일** — 회귀
+diff 게이트(전/후 바이트 대조)만 방해받는다.
+
+## 근본 원인 (업스트림 svg2pdf-0.13)
+
+`svg2pdf-0.13.0/src/util/context.rs:81`:
+
+```rust
+for font in self.fonts.values_mut() {
+    if let Some(font) = font { write_font(pdf, allocator, font)? }
+}
+```
+
+`self.fonts` 는 `HashMap<ID, Option<Font>>`(context.rs:23). `.values_mut()` 반복 순서가
+**프로세스별 랜덤 시드**(Rust 기본 `RandomState`)라 실행마다 다르다. `write_font` 이
+반복 순서대로 객체 ref 를 할당하므로:
+
+- 폰트 **객체 번호**(`/foN → M 0 R` 의 M)가 실행마다 달라진다.
+- `/foN` **리소스 이름**도 다른 폰트에 배정된다(font.reference 가 위 채번 산물이므로).
+- 나아가 객체 **방출 순서**(chunk `offsets` Vec)와 `/Font` 딕셔너리 **항목 순서**도 달라진다.
+
+우리 측 `renderer/pdf.rs:366` 의 `chunk.renumber` 는 결정적(pdf-writer Chunk 는 Vec 저장)
+이나, 입력 chunk 의 객체 순서 자체가 비결정이라 최종 산출이 비결정이 된다.
+
+## 해법
+
+### (권장, 근본) 업스트림 결정화
+`context.rs:81` 을 폰트 ID 정렬 반복으로 바꾸면 결정화된다:
+```rust
+let mut ids: Vec<_> = self.fonts.keys().copied().collect();
+ids.sort();
+for id in ids { if let Some(font) = self.fonts.get_mut(&id).and_then(|f| f.as_mut()) { ... } }
+```
+svg2pdf 상위 기여 또는 `[patch.crates-io]` 벤더 패치가 필요하다(의존성 fork 결정은
+메인테이너 판단 — 본 이슈에서는 미적용).
+
+### (즉시, 자립) 정규화 비교 도구
+`tools/pdf_normalize_compare.py` — 두 PDF 의 (1) 객체 방출 순서(내용 기준 정렬)
+(2) 간접 객체 번호 (3) `/foN` 폰트 이름 (4) `/Font` 딕셔너리 항목 순서를 정준화한 뒤
+바이트 비교한다. 채번 비결정만 제거하므로, **정규형이 동일하면 시각/구조 불변**으로
+판정한다. 회귀 diff 게이트가 이 정규형을 쓰면 된다.
+
+```
+python tools/pdf_normalize_compare.py before.pdf after.pdf   # 0=불변, 1=진짜 회귀
+python tools/pdf_normalize_compare.py --emit x.pdf > x.norm   # 게이트용 정규형 출력
+```
+
+검증: 86712(7폰트·65쪽)·75544 각각 2회 실행 raw diff 2.4~2.57MB → **정규형 바이트 동일**.
+서로 다른 문서는 정규형 상이(회귀 검출) 확인.

--- a/tools/pdf_normalize_compare.py
+++ b/tools/pdf_normalize_compare.py
@@ -1,0 +1,138 @@
+#!/usr/bin/env python
+"""#2269 PDF 결정성 비교 — svg2pdf 폰트 HashMap 비결정을 정규화해 회귀 diff 가능하게.
+
+배경: `export-pdf` 동일 입력 2회 실행이 바이트 diff 를 낸다. 원인은 상위 크레이트
+svg2pdf-0.13 `util/context.rs:81 for font in self.fonts.values_mut()` 의 HashMap
+반복 순서(프로세스별 랜덤 시드)로, 폰트 객체 번호와 `/foN` 리소스 이름이 실행마다
+다른 폰트에 배정된다(시각 출력·파일 크기는 동일).
+
+이 도구는 두 PDF 의 (a) 간접 객체 번호와 (b) `/foN` 폰트 리소스 이름을 **내용 기준
+정준 순서**로 재배치해, 비결정 성분을 제거한 뒤 바이트 비교한다. 정규화 후 동일하면
+"시각/구조 불변, 채번만 비결정" 으로 판정 — 회귀 diff 게이트가 이 정규화 형을 쓰면 된다.
+
+사용:
+    python tools/pdf_normalize_compare.py a.pdf b.pdf
+    python tools/pdf_normalize_compare.py --emit a.pdf > a.norm   # 정규화 형 출력(게이트용)
+종료코드: 0=정규화 동일, 1=정규화 후에도 상이(진짜 회귀), 2=인자 오류.
+"""
+import re
+import sys
+
+OBJ_DEF = re.compile(rb"(\d+) 0 obj")
+OBJ_REF = re.compile(rb"(\d+) 0 R")
+FONT_NAME = re.compile(rb"/fo(\d+)\b")
+
+
+def parse_objects(data: bytes):
+    """{obj_num: body_bytes} — 'N 0 obj' .. 'endobj' 구간."""
+    objs = {}
+    for m in re.finditer(rb"(\d+) 0 obj(.*?)endobj", data, re.S):
+        objs[int(m.group(1))] = m.group(2)
+    return objs
+
+
+def canonical_ref_order(data: bytes):
+    """객체 번호를 '바이트 스트림 최초 등장(정의 or 참조)' 순으로 정준화한 매핑."""
+    order = []
+    seen = set()
+    for m in re.finditer(rb"\b(\d+) 0 (?:obj|R)\b", data):
+        n = int(m.group(1))
+        if n not in seen:
+            seen.add(n)
+            order.append(n)
+    return {old: i + 1 for i, old in enumerate(order)}
+
+
+def canonical_font_names(data: bytes):
+    """/foN 이름을 각 이름이 가리키는 객체의 '정준 번호' 기준으로 재명명.
+
+    /Font << /foN <obj> 0 R ... >> 에서 (이름 -> 대상 객체) 를 모아, 대상 객체의
+    정준 번호로 정렬해 fo0..foK 재배정. 같은 폰트(같은 대상)는 실행 무관 동일 이름."""
+    refmap = canonical_ref_order(data)
+    # /foN <int> 0 R 페어 수집
+    pairs = {}
+    for m in re.finditer(rb"/fo(\d+)\s+(\d+) 0 R", data):
+        name = int(m.group(1))
+        target = int(m.group(2))
+        pairs.setdefault(name, refmap.get(target, 10**9))
+    # 대상 정준번호 -> 새 이름
+    ordered = sorted(pairs.items(), key=lambda kv: kv[1])
+    return {old_name: i for i, (old_name, _) in enumerate(ordered)}
+
+
+def _mask(body: bytes) -> bytes:
+    """정렬 키용 — 참조 번호·폰트 이름을 마스킹해 채번 무관 내용만 남긴다."""
+    b = re.sub(rb"\b\d+ 0 R\b", b"REF", body)
+    b = re.sub(rb"/fo\d+\b", b"/fo", b)
+    return b
+
+
+def normalize(data: bytes) -> bytes:
+    """객체를 내용 기준으로 재정렬 + 채번/폰트이름 정준화한 정규형을 만든다.
+
+    svg2pdf 의 HashMap 비결정은 (1) 객체 방출 순서 (2) 참조 번호 (3) /foN 이름에
+    모두 나타나므로, 객체를 마스킹 내용으로 정렬해 순서를 고정하고, 그 정준 순서로
+    번호·이름을 재배정한다. 동일 시각/구조면 정규형이 바이트 동일해진다."""
+    objs = {}
+    for m in re.finditer(rb"(\d+) 0 obj(.*?)endobj", data, re.S):
+        objs[int(m.group(1))] = m.group(2)
+    # 내용(마스킹) 기준 정렬 → 정준 순서
+    order = sorted(objs.keys(), key=lambda n: (_mask(objs[n]), n))
+    refmap = {old: i + 1 for i, old in enumerate(order)}
+    # 폰트 이름: /foN -> 대상 객체 정준번호 순
+    pairs = {}
+    for m in re.finditer(rb"/fo(\d+)\s+(\d+) 0 R", data):
+        pairs.setdefault(int(m.group(1)), refmap.get(int(m.group(2)), 10**9))
+    namemap = {old: i for i, (old, _) in enumerate(sorted(pairs.items(), key=lambda kv: kv[1]))}
+
+    def sort_font_dict(m) -> bytes:
+        # /Font << /foN X 0 R ... >> 항목을 이름 기준 정렬 (dict 순서 비결정 제거)
+        entries = re.findall(rb"/fo\d+\s+\d+ 0 R", m.group(1))
+        entries.sort()
+        return b"/Font <<" + b" ".join(entries) + b">>"
+
+    def rewrite(body: bytes) -> bytes:
+        b = re.sub(rb"\b(\d+) 0 R\b", lambda m: b"%d 0 R" % refmap.get(int(m.group(1)), 0), body)
+        b = re.sub(rb"/fo(\d+)\b", lambda m: b"/fo%d" % namemap.get(int(m.group(1)), int(m.group(1))), b)
+        # /Font 딕셔너리 항목 정렬
+        b = re.sub(rb"/Font <<(.*?)>>", sort_font_dict, b, flags=re.S)
+        return b
+
+    parts = []
+    for old in order:
+        parts.append(b"%d 0 obj" % refmap[old] + rewrite(objs[old]) + b"endobj\n")
+    return b"".join(parts)
+
+
+def main() -> int:
+    try:
+        sys.stdout.reconfigure(encoding="utf-8")
+        sys.stderr.reconfigure(encoding="utf-8")
+    except Exception:
+        pass
+    args = [a for a in sys.argv[1:] if a != "--emit"]
+    emit = "--emit" in sys.argv
+    if emit:
+        if len(args) != 1:
+            print("사용: pdf_normalize_compare.py --emit a.pdf", file=sys.stderr)
+            return 2
+        sys.stdout.buffer.write(normalize(open(args[0], "rb").read()))
+        return 0
+    if len(args) != 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    a = normalize(open(args[0], "rb").read())
+    b = normalize(open(args[1], "rb").read())
+    if a == b:
+        print(f"정규화 동일 — 채번만 비결정(시각/구조 불변). len={len(a)}")
+        return 0
+    print(f"정규화 후에도 상이 — 진짜 회귀. lenA={len(a)} lenB={len(b)}", file=sys.stderr)
+    for i, (x, y) in enumerate(zip(a, b)):
+        if x != y:
+            print(f"  첫 diff @ {i}\n  A: {a[max(0,i-40):i+40]!r}\n  B: {b[max(0,i-40):i+40]!r}", file=sys.stderr)
+            break
+    return 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 요약

Issue #2269 — `export-pdf` 동일 입력 2회 실행의 바이트 diff(회귀 diff 게이트 방해)의
**정확한 원인을 업스트림 한 줄까지 규명**하고, 즉시 쓸 수 있는 **정규화 비교 도구**를 추가합니다.

## 원인 (업스트림 svg2pdf-0.13)

`svg2pdf-0.13.0/src/util/context.rs:81` `for font in self.fonts.values_mut()` — 폰트를
`HashMap<ID, Option<Font>>` 로 저장하고 `.values_mut()` 로 반복하며 객체 ref 를 방문
순서대로 할당한다. HashMap 이 프로세스별 랜덤 시드라 실행마다 (1) 폰트 객체번호
(2) `/foN` 리소스 이름 (3) 객체 방출순서 (4) `/Font` 딕셔너리 항목순서가 달라진다.
**시각 출력·파일 크기·구조는 동일**. 우리 `renderer/pdf.rs` renumber 는 결정적(pdf-writer
Chunk=Vec)이나 입력 chunk 순서가 비결정.

## 해법

- **근본(권장)**: 업스트림 `context.rs:81` 을 폰트 ID 정렬 반복으로 결정화 → svg2pdf 기여
  또는 `[patch.crates-io]` 벤더 패치. 의존성 fork 결정은 메인테이너 판단이라 본 PR 미포함.
- **즉시·자립(본 PR)**: `tools/pdf_normalize_compare.py` — 두 PDF 의 객체 방출순서(내용
  기준 정렬)·객체번호·`/foN` 이름·`/Font` 딕셔너리 순서를 정준화 후 비교. 채번 비결정만
  제거하므로 정규형 동일 = 시각/구조 불변. 회귀 diff 게이트가 이 정규형을 쓰면 된다.

```
python tools/pdf_normalize_compare.py before.pdf after.pdf   # 0=불변, 1=진짜 회귀
python tools/pdf_normalize_compare.py --emit x.pdf > x.norm   # 게이트용 정규형
```

## 검증 (리뷰어 재현)

리포 내 샘플로 재현 가능:
```
target/release/rhwp export-pdf samples/86712_regulatory_analysis.hwp -o a.pdf
target/release/rhwp export-pdf samples/86712_regulatory_analysis.hwp -o b.pdf
cmp -l a.pdf b.pdf | wc -l            # 2.4M 바이트 diff (비결정)
python tools/pdf_normalize_compare.py a.pdf b.pdf   # 정규형 동일 → exit 0
```
- 86712(7폰트·65쪽): raw diff 2.4MB → 정규형 바이트 동일
- 75544_pii_bunseok.hwpx: raw diff 2.57MB → 정규형 바이트 동일
- 서로 다른 문서: 정규형 상이(회귀 검출) → exit 1

## 변경

- `tools/pdf_normalize_compare.py` (신규, 소스 렌더링 무변경)
- `mydocs/tech/pdf_font_numbering_nondeterminism.md` (원인·해법 기록)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
