### PR TITLE
Task #2234: actions/setup-node@v4 → @v6 (Node.js 20 런타임 deprecation 해소)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -551,7 +551,7 @@ jobs:
         run: wasm-pack build --target web --dev
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
           cache: npm

--- a/.github/workflows/deploy-pages.yml
+++ b/.github/workflows/deploy-pages.yml
@@ -61,7 +61,7 @@ jobs:
 
       # --- rhwp-studio 빌드 ---
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -38,7 +38,7 @@ jobs:
             ${{ runner.os }}-cargo-
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
           cache: npm

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -127,7 +127,7 @@ jobs:
           path: pkg/
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: 20
 

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -283,7 +283,7 @@ jobs:
           key: ${{ runner.os }}-render-diff-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Setup Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '22'
 


### PR DESCRIPTION
## 요약

Issue #2234 — trusted `devel` CI run 의 `actions/setup-node@v4` Node.js 20 runtime
deprecation 경고를 해소합니다. action major 를 저장소가 이미 쓰는 `@v6`(runs.using:
node24)로 통일합니다.

## 변경

`actions/setup-node@v4` → `@v6` (5곳):
- `ci.yml` (frontend package gate)
- `deploy-pages.yml`
- `full-renderer-sweep.yml`
- `npm-publish.yml` (vscode 잡; publish 잡 2곳은 이미 @v6)
- `render-diff.yml`

## 검증

- **런타임**: v6 `action.yml` `runs.using: node24` — Node.js 20 deprecation 해소.
- **캐시 무회귀**: v6 는 `cache` / `cache-dependency-path` 입력을 계속 정의(action.yml
  확인) — npm lockfile 캐시 키·정책 불변. `cache: npm` 사용 잡(ci.yml, full-renderer-sweep.yml)
  입력 그대로 유지.
- **매트릭스 유지**: `node-version`(20/22) 미변경 — Node.js 22 consumer 유지.
- **diff**: 버전 문자열만(구조 변화 없음).
- **actionlint 1.7.12**: 전 워크플로우 통과(무경고).

## 완료 기준 대비

- [x] Node.js runtime deprecation 경고 제거 (v6=node24)
- [x] actionlint 통과
- [x] npm cache 키·정책 무회귀 (입력 불변, v6 지원 확인)
- [x] required check 이름·node-version 매트릭스 불변
- [ ] clean frontend package gate / Studio·Chrome·Firefox·VS Code build/test — CI run 에서 최종 확인(리뷰어)

Related: #2183, #2216

🤖 Generated with [Claude Code](https://claude.com/claude-code)
