### PR TITLE
Task #2261: verify_pi_page_vs_hangul PROTECTED_SKIP — 캐럿 차단 보호 문서 분리

### DIFF
--- a/tools/verify_pi_page_vs_hangul.py
+++ b/tools/verify_pi_page_vs_hangul.py
@@ -12,9 +12,12 @@ PI 인덱스가 1:1 정렬된다(다중 구역은 구역별 문단수 누적 오
   PI_MISMATCH: 일부 PI 가 다른 페이지 (페이지수는 같을 수도)
   PAGE_DELTA : 총 페이지수 불일치 (대개 PI_MISMATCH 동반)
   PARA_COUNT : rhwp/한글 문단수 불일치(정렬 불가) — 별도 분류
+  PROTECTED_SKIP : [#2261] 보호/배포용 HWP5 — 한글 정상 개방(PageCount 정상)이나
+                   캐럿이 본문 진입 불가(max_para==0 → hcount==1)인데 rhwp 는 본문
+                   문단 다수. per-PI 대조 불가라 PageCount 만 대조·per-PI 스킵.
   ERR        : 한글 열기/처리 실패
 
-PI_MISMATCH/PAGE_DELTA 1건↑ 종료코드 1.
+PI_MISMATCH/PAGE_DELTA 1건↑ 종료코드 1. PROTECTED_SKIP 은 사각지대 분리라 실패 미계상.
 
 알려진 한계 — 캐럿-개체 분리 (시각 정합인데 PI_MISMATCH 로 나오는 오탐, #1757):
   rhwp 는 "pi 가 처음 등장한 쪽"(표 몸체 시작 쪽), 한글은 SetPos 캐럿 쪽을 보고한다.
@@ -240,7 +243,7 @@ def main() -> int:
 
     hwp = fresh_hwp()
 
-    n_match = n_mism = n_delta = n_para = n_err = n_caret = 0
+    n_match = n_mism = n_delta = n_para = n_err = n_caret = n_protected = 0
     args.out.parent.mkdir(parents=True, exist_ok=True)
     with open(args.out, "w", encoding="utf-8", newline="") as fh:
         w = csv.writer(fh, delimiter="\t")
@@ -274,6 +277,20 @@ def main() -> int:
                     continue
             rcount = sum(sec_counts.values())
             if rcount != hcount:
+                # [#2261] 보호/배포용 HWP5 — 한글이 정상 개방(PageCount 정상)하나
+                # 캐럿이 본문 진입 불가(MoveDocEnd 후 GetPos para=0 → hcount==1)라
+                # per-PI 대조 불가. rhwp 는 본문 문단 다수 파싱. PageCount 만 대조하고
+                # per-PI 는 스킵해 PARA_COUNT(구조적 정렬 불가)와 분리 집계한다.
+                if hcount == 1 and rcount > 1:
+                    n_protected += 1
+                    page_tag = (
+                        "page_match" if rpages == htotal
+                        else f"page_delta={rpages - htotal:+d}"
+                    )
+                    w.writerow([rel, "PROTECTED_SKIP", rpages, htotal, abs(rpages - htotal),
+                                f"rhwp_paras={rcount} hwp_paras=1(caret-blocked) {page_tag}"])
+                    fh.flush()
+                    continue
                 n_para += 1
                 w.writerow([rel, "PARA_COUNT", rpages, htotal, abs(rcount - hcount),
                             f"rhwp_paras={rcount} hwp_paras={hcount}"])
@@ -347,7 +364,7 @@ def main() -> int:
     total = len(files)
     print(f"\n[pi-page-vs-hangul] HEAD={head} 처리={total}")
     print(f"  MATCH={n_match} PI_MISMATCH={n_mism} PI_MISMATCH_CARET={n_caret} "
-          f"PAGE_DELTA={n_delta} PARA_COUNT={n_para} ERR={n_err}")
+          f"PAGE_DELTA={n_delta} PARA_COUNT={n_para} PROTECTED_SKIP={n_protected} ERR={n_err}")
     print(f"  → {args.out}")
     # CARET(오탐 후보)는 실패로 계상하지 않는다 — 시각 대조로 확정 전까지 후보.
     return 1 if (n_mism + n_delta) > 0 else 0


### PR DESCRIPTION
## 요약

Issue #2261 — 캐럿 접근 차단(복사 방지/배포용) HWP5 문서를 `verify_pi_page_vs_hangul.py`
에서 `PROTECTED_SKIP` 으로 분리해, per-PI 오라클 사각지대(10k r13 29건)를
PARA_COUNT(구조적 정렬 불가)와 구분합니다.

## 병인

보호 HWP5 는 한글(pyhwpx COM)이 정상 개방(PageCount 정상)하나 **캐럿이 본문 진입
불가**(`MoveDocEnd` 후 `GetPos()` para=0 → `hcount==1`)라 per-PI SetPos 대조가
불가능. rhwp 는 전체 파싱 정상(본문 문단 다수). 종전엔 `rcount != hcount` 로 뭉뚱그려져
**PARA_COUNT** 로 집계돼 사각지대 성격이 흐려졌다.

## 수정

`rcount != hcount` 분기에서 `hcount == 1 && rcount > 1` 이면 **PROTECTED_SKIP**:
- PageCount(rpages vs htotal) 만 대조 — detail 에 `page_match` / `page_delta=±N` 기록
- per-PI 는 스킵(캐럿 진입 불가라 원천 불가)
- 별도 카운터 집계, **실패 미계상**(사각지대 분리 트랙)
- docstring·요약 출력 갱신

`#2152`(각주·미주 subList pi 열거, `hcount>1`)와는 별개 유형이라 미영향.

## 검증

이슈 명명 샘플 `156736729_(보도자료) 2024년 기준 프랜차이즈…(국가데이터처)`:
```
verdict=PROTECTED_SKIP rhwp_pages=19 hwp_pages=20
detail: rhwp_paras=257 hwp_paras=1(caret-blocked) page_delta=-1
```
- 이슈 실측(캐럿 차단, PageCount 정상, ±1 쪽수차 잔여 3건)과 정합.
- 정상 문서(`3023771_wichokjang.hwpx`)는 `MATCH` 유지 — 오분류 없음.
- 종료코드: PROTECTED_SKIP 은 `n_mism+n_delta` 에 미포함 → 게이트 실패 유발 안 함.

## 변경

- `tools/verify_pi_page_vs_hangul.py` (하니스 전용, 소스 무변경)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
