### PR TITLE
Task #2148: 문서 생성기 마커 추출 도구 (선언신뢰 판별 신호 조사)

### DIFF
--- a/tools/hwp_generator_probe.py
+++ b/tools/hwp_generator_probe.py
@@ -1,0 +1,77 @@
+#!/usr/bin/env python
+"""#2148 문서 생성기 마커 추출 — NO_LS 라벨 셀 선언-신뢰 vs 성장 판별 신호 후보.
+
+HWP5 는 `\\x05HwpSummaryInformation`(OLE property set)의 last-author(PID 8)와
+설명 문자열에, HWPX 는 `Contents/content.hpf` 의 `lastsaveby` 메타에 생성기 흔적이
+남는다. 특정 생성기(opendoc=온나라 전자결재, 법제처 정부입법지원센터 법령안편집기,
+한국법령정보원)는 선언-신뢰형 NO_LS 셀을, 국가법령정보센터·수동 편집(사람이름/User)
+은 성장형을 만든다(#2148 코멘트 대조표 참조).
+
+사용:
+    python tools/hwp_generator_probe.py <file.hwp|file.hwpx> [...]
+요구: olefile (HWP5), 표준 zipfile (HWPX).
+"""
+import re
+import sys
+import zipfile
+from pathlib import Path
+
+sys.stdout.reconfigure(encoding="utf-8", errors="replace")
+
+# 알려진 선언-신뢰형 생성기 시그니처(부분 문자열)
+DECLARED_TRUST_MARKERS = ("opendoc", "법령안편집기", "정부입법지원센터", "한국법령정보원")
+GROWTH_MARKERS = ("국가법령정보센터",)
+
+
+def hwpx_lastsaveby(path: str) -> str:
+    try:
+        with zipfile.ZipFile(path) as z:
+            data = z.read("Contents/content.hpf").decode("utf-8", "replace")
+        m = re.search(r'lastsaveby"\s+content="text">([^<]*)', data)
+        return m.group(1) if m else ""
+    except Exception:  # noqa: BLE001
+        return ""
+
+
+def hwp5_generator(path: str) -> str:
+    try:
+        import olefile
+    except ImportError:
+        return "(olefile 미설치)"
+    try:
+        ole = olefile.OleFileIO(path)
+        raw = ole.openstream("\x05HwpSummaryInformation").read()
+        ole.close()
+        txt = raw.decode("utf-16-le", errors="replace")
+        # 생성기 설명 문자열 우선, 없으면 last-author 근사 추출
+        for mk in DECLARED_TRUST_MARKERS + GROWTH_MARKERS:
+            if mk in txt:
+                return mk
+        strs = [s.strip() for s in re.findall(r"[가-힣A-Za-z0-9_.\- ]{3,}", txt) if s.strip()]
+        return strs[0] if strs else ""
+    except Exception as e:  # noqa: BLE001
+        return f"(ERR {e})"
+
+
+def classify(marker: str) -> str:
+    ml = marker.lower()
+    if any(m.lower() in ml for m in DECLARED_TRUST_MARKERS):
+        return "선언신뢰?"
+    if any(m in marker for m in GROWTH_MARKERS):
+        return "성장?"
+    return "미상(수동/plain)"
+
+
+def main() -> int:
+    if len(sys.argv) < 2:
+        print(__doc__, file=sys.stderr)
+        return 2
+    for f in sys.argv[1:]:
+        ext = Path(f).suffix.lower()
+        marker = hwpx_lastsaveby(f) if ext == ".hwpx" else hwp5_generator(f)
+        print(f"  [{classify(marker):14}] marker={marker!r:40}  {Path(f).name[:44]}")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## 요약

Issue #2148(비사선 NO_LS 라벨 셀 선언-신뢰 조건) **조사 산출물** — 슬랙 스칼라·국소 형상이
못 가른 선언신뢰 vs 성장을 **문서 생성기 마커**로 대부분 분리 가능함을 확인하고, 그 마커를
추출하는 도구를 추가합니다. **소스 렌더링 무변경**(조사 도구만), 구현은 별도 승인.

## 배경

#2148: 동일 국소 형상(NO_LS+1줄+선언여유)에서 한글 진실이 **문서에 따라 반대**(정책연구/
결재=선언유지 vs 규제영향분석서=성장). #2098 은 53px 경험 스칼라로 부분 대응했으나 판별
신호 미규명.

## 발견 (이슈 코멘트 대조표)

HWP5 `\x05HwpSummaryInformation` last-author + HWPX `lastsaveby` 파싱:

| 정답 | 생성기 마커 |
|---|---|
| 선언신뢰 | opendoc(온나라 결재) / 법제처 정부입법지원센터 법령안편집기 / 한국법령정보원 |
| 성장 | 법제처 국가법령정보센터 / 수동(사람이름·User·Administrator) |

특정 생성기가 강한 **부분 판별자**(FIXED 결재·별지 회수). 반례 1건(1730000 정책연구 plain
USER)은 콘텐츠 신호(제안 1) 필요.

## 도구

`tools/hwp_generator_probe.py` — HWP5/HWPX 생성기 마커 추출 + 선언신뢰/성장 후보 분류.
```
python tools/hwp_generator_probe.py <file.hwp|.hwpx> [...]
```
검증: 36404953(opendoc)·19378753(법령안편집기)=선언신뢰?, 18092931(국가법령정보센터)=성장?.

## 다음 (구현 경로, 별도 승인)

생성기 화이트리스트 게이트로 NO_LS 선언-신뢰 클램프를 {opendoc,법령안편집기,한국법령정보원}
문서에 한해 활성 → 국가법령정보센터/수동(규제·보도·issue_1891) 보호. 선결: 생성기 파싱
파서 배관 + 359 recount·92셋·issue_1891 무회귀 전 게이트. 광역 파급이라 별도 승인 필요.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
