### PR TITLE
Task #2269: pdf_normalize_compare 파일 부재 시 exit 2 (PR #2272 후속)

### DIFF
--- a/tools/pdf_normalize_compare.py
+++ b/tools/pdf_normalize_compare.py
@@ -104,6 +104,16 @@ def normalize(data: bytes) -> bytes:
     return b"".join(parts)
 
 
+def _read(path: str) -> bytes:
+    """입력 파일 읽기 — 부재/접근불가 시 traceback 없이 인자 오류(exit 2)로 종료."""
+    try:
+        with open(path, "rb") as f:
+            return f.read()
+    except OSError as e:
+        print(f"입력 파일을 열 수 없음: {path} ({e.strerror})", file=sys.stderr)
+        raise SystemExit(2)
+
+
 def main() -> int:
     try:
         sys.stdout.reconfigure(encoding="utf-8")
@@ -116,13 +126,13 @@ def main() -> int:
         if len(args) != 1:
             print("사용: pdf_normalize_compare.py --emit a.pdf", file=sys.stderr)
             return 2
-        sys.stdout.buffer.write(normalize(open(args[0], "rb").read()))
+        sys.stdout.buffer.write(normalize(_read(args[0])))
         return 0
     if len(args) != 2:
         print(__doc__, file=sys.stderr)
         return 2
-    a = normalize(open(args[0], "rb").read())
-    b = normalize(open(args[1], "rb").read())
+    a = normalize(_read(args[0]))
+    b = normalize(_read(args[1]))
     if a == b:
         print(f"정규화 동일 — 채번만 비결정(시각/구조 불변). len={len(a)}")
         return 0


### PR DESCRIPTION
## 요약

PR #2272 머지 코멘트의 **비차단 개선 요청 1건** 반영 — `tools/pdf_normalize_compare.py`가
입력 파일 부재 시 traceback + exit 1 로 종료되어 docstring 계약(2=인자 오류)과 어긋나고,
게이트에서 경로 오타가 "진짜 회귀"로 위장되는 문제를 수정합니다.

## 변경

- `open()` 직접 호출을 `_read()` 헬퍼로 교체: `OSError`(부재·디렉터리·권한 포함)를 잡아
  `입력 파일을 열 수 없음: <경로> (<사유>)` 메시지 + **exit 2** 로 종료.
- 비교 모드·`--emit` 모드 양쪽 적용. 정규화 로직은 무변경.

> FileNotFoundError 만이 아니라 OSError 로 잡은 이유: 디렉터리 지정·권한 오류도 동일하게
> traceback + exit 1 로 위장되는 인자 오류 계열이므로 함께 계약에 편입했습니다.

## 검증 (전 경로)

| 케이스 | 기대 | 결과 |
|---|---|---|
| 파일 부재 (비교 모드) | 메시지 + exit 2 | ✅ |
| 파일 부재 (`--emit`) | 메시지 + exit 2 | ✅ |
| 동일 입력 2회 | exit 0 | ✅ |
| 상이 입력 | exit 1 + 첫 diff 위치 | ✅ |
| 인자 부족 | exit 2 | ✅ |

🤖 Generated with [Claude Code](https://claude.com/claude-code)
