### PR TITLE
Task #2269: svg2pdf 결정화 벤더 패치 — export-pdf 바이트 재현성 확보

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1231,8 +1231,7 @@ dependencies = [
 [[package]]
 name = "svg2pdf"
 version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e50dc062439cc1a396181059c80932a6e6bd731b130e674c597c0c8874b6df22"
+source = "git+https://github.com/planet6897/svg2pdf?branch=determinism-0.13#2caeb0a038f9128b79833d803b94c2667565c4da"
 dependencies = [
  "fontdb",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -161,3 +161,10 @@ strip = "debuginfo"
 inherits = "release"
 lto = false
 codegen-units = 16
+
+# #2269 PDF 채번 비결정 근본 정정 — svg2pdf 0.13 의 HashMap 반복(폰트 객체 방출·
+# 리소스 딕셔너리 순서)을 결정화한 벤더 패치. 업스트림(typst/svg2pdf)이 2026-07
+# 아카이브되어 기여 불가, 포크 브랜치로 대체 (Cargo.lock 이 정확한 rev 를 고정).
+# krilla-svg 마이그레이션 시 이 패치는 제거한다.
+[patch.crates-io]
+svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism-0.13" }

--- a/mydocs/tech/pdf_font_numbering_nondeterminism.md
+++ b/mydocs/tech/pdf_font_numbering_nondeterminism.md
@@ -52,3 +52,43 @@ python tools/pdf_normalize_compare.py --emit x.pdf > x.norm   # 게이트용 정
 
 검증: 86712(7폰트·65쪽)·75544 각각 2회 실행 raw diff 2.4~2.57MB → **정규형 바이트 동일**.
 서로 다른 문서는 정규형 상이(회귀 검출) 확인.
+
+## 근본 정정 채택 (2026-07-15, #2269 (a)안 승인)
+
+업스트림 기여 시도 결과 **typst/svg2pdf 는 2026-07-10 아카이브**되어 PR 개설이 불가
+("This project is not maintained anymore", 공식 대체: krilla/krilla-svg). master 에도
+해당 비결정 코드는 미수정으로 남아 있어, 작업지시자 승인 하에 **벤더 패치**를 채택했다.
+
+### 패치 브랜치
+
+**planet6897/svg2pdf `determinism-0.13`** (커밋 2caeb0a, v0.13.0 태그 기반 2지점 수정):
+
+| 지점 | 수정 | 결정화 대상 |
+|---|---|---|
+| `util/context.rs` `write_global_objects` | 폰트를 `Font.reference` 정렬 후 반복 | `write_font` 내부 부가 객체 4개/폰트(CID·descriptor·cmap·data)의 채번 + 방출순서 |
+| `util/resources.rs` `finish()` | 딕셔너리 항목을 reference 정렬 후 방출 | `/Font` 등 리소스 딕셔너리 항목순서 |
+
+규명 보완: `Font.reference` 와 `/foN` 이름은 문서 순회 순서(`fill_fonts`/glyph 순회)라
+**원래 결정적**이다. 비결정의 실체는 (1) write 시점 부가 객체 채번·방출순서
+(2) 리소스 딕셔너리 항목순서 2지점이며, 따라서 위 표의 reference 정렬(폰트 ID 정렬이
+아니라)이 자연스러운 정준 순서다.
+
+### rhwp 적용
+
+`Cargo.toml` 에 `[patch.crates-io]` 로 포크 브랜치를 지정 (Cargo.lock 이 정확한 rev 고정):
+
+```toml
+[patch.crates-io]
+svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism-0.13" }
+```
+
+### 검증 (upstream/devel 640d04f7 + 패치)
+
+- 86712(7폰트·65쪽)·75544: 각 2회 실행 **바이트 동일** (기존 raw diff 2.4~2.57MB → 0)
+- 같은 소스 무패치↔패치 출력: `pdf_normalize_compare.py` **정규형 동일** (순서/채번만 변경, 시각·구조 불변)
+- 별도 컴파일 2회의 산출물도 바이트 동일 (빌드 재현성)
+
+### 유지보수 노트
+
+- `pdf_normalize_compare.py` 게이트는 이중 안전망으로 유지한다.
+- **krilla-svg 마이그레이션 시 이 패치는 제거**한다 (svg2pdf 계열 EOL — 장기 축은 별도 이슈).


### PR DESCRIPTION
## 요약

Issue #2269 근본 정정 — `export-pdf` 동일 입력 2회 실행의 바이트 비결정(svg2pdf-0.13
폰트 HashMap 반복)을 **벤더 패치**로 결정화합니다. (a)안 작업지시자 승인에 따른 제출.

업스트림 typst/svg2pdf 는 2026-07-10 아카이브되어 PR 개설 불가 ("This project is not
maintained anymore", 공식 대체: krilla/krilla-svg) — 상세는 #2269 코멘트 참조.

## 변경

- `Cargo.toml`: `[patch.crates-io]` — [planet6897/svg2pdf `determinism-0.13`](https://github.com/planet6897/svg2pdf/tree/determinism-0.13)
  (v0.13.0 태그 + 2지점 최소 수정, 커밋 [2caeb0a](https://github.com/planet6897/svg2pdf/commit/2caeb0a))
- `Cargo.lock`: 정확한 rev 고정 (`#2caeb0a…`)
- `mydocs/tech/pdf_font_numbering_nondeterminism.md`: 채택 기록 + 유지보수 노트 (krilla-svg 마이그레이션 시 패치 제거)

**rhwp 소스(.rs) 무변경** — 의존성 패치와 문서만.

### 패치 내용 (svg2pdf 측 2지점)

| 지점 | 수정 | 결정화 대상 |
|---|---|---|
| `util/context.rs` `write_global_objects` | 폰트를 `Font.reference` 정렬 후 반복 | `write_font` 부가 객체 4개/폰트의 채번 + 방출순서 |
| `util/resources.rs` `finish()` | 딕셔너리 항목 reference 정렬 후 방출 | `/Font` 등 리소스 딕셔너리 항목순서 |

`Font.reference`/`/foN` 이름은 문서 순회 순서라 원래 결정적 — reference 정렬이 자연스러운 정준 순서입니다.

## 검증 (upstream/devel 640d04f7 기준)

- 86712(7폰트·65쪽)·75544_pii_bunseok: 각 2회 실행 **바이트 동일** (기존 raw diff 2.4~2.57MB → 0)
- 같은 소스 무패치↔패치: `tools/pdf_normalize_compare.py` **정규형 동일** — 순서/채번만 변경, 시각·구조 불변
- 별도 컴파일 2회 산출물도 바이트 동일 (빌드 재현성)
- `cargo nextest run` 전체 게이트: **3159/3159 passed** (22 skipped)

## 재현 (리뷰어)

```
cargo build
target/debug/rhwp export-pdf samples/86712_regulatory_analysis.hwp -o a.pdf
target/debug/rhwp export-pdf samples/86712_regulatory_analysis.hwp -o b.pdf
cmp a.pdf b.pdf && echo IDENTICAL
```

Refs #2269 (close 여부는 작업지시자 판단 — 장기 krilla-svg 축 분리 여부에 따름)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
