### PR TITLE
feat: 메모 렌더링 --show-memos 옵션 (우측 여백 메모 박스 + 연결선)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,6 +141,7 @@ rhwp export-svg sample.hwp -o my_dir/              # 지정 폴더에 출력
 rhwp export-svg sample.hwp -p 0                    # 특정 페이지만 출력 (0부터)
 rhwp export-svg sample.hwp --show-para-marks       # 문단부호(↵/↓) 표시
 rhwp export-svg sample.hwp --show-control-codes    # 조판부호 표시 (문단부호+개체마커)
+rhwp export-svg sample.hwp --show-memos            # 메모 표시 (우측 여백 메모 박스+연결선)
 rhwp export-svg sample.hwp --debug-overlay         # 디버그 오버레이 (문단/표 경계+인덱스)
 rhwp export-svg sample.hwp --font-style            # @font-face local() 참조 삽입
 rhwp export-svg sample.hwp --embed-fonts           # 폰트 서브셋 임베딩 (사용 글자만)

--- a/src/diagnostics/render_geom_diff.rs
+++ b/src/diagnostics/render_geom_diff.rs
@@ -121,6 +121,7 @@ fn node_type_str(t: &RenderNodeType) -> &'static str {
         RenderNodeType::Body { .. } => "Body",
         RenderNodeType::Column(_) => "Column",
         RenderNodeType::FootnoteArea => "FootnoteArea",
+        RenderNodeType::MemoArea => "MemoArea",
         RenderNodeType::TextLine(_) => "TextLine",
         RenderNodeType::TextRun(_) => "TextRun",
         RenderNodeType::Table(_) => "Table",

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -140,6 +140,7 @@ impl DocumentCore {
             show_transparent_borders: false,
             clip_enabled: true,
             debug_overlay: false,
+            show_memos: false,
             respect_vpos_reset: false,
             measured_tables: Vec::new(),
             dirty_sections: vec![true; sec_count],

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -89,6 +89,9 @@ pub struct DocumentCore {
     pub(crate) clip_enabled: bool,
     /// 디버그 오버레이 표시 여부 (문단/표 경계 + pi/ci 라벨)
     pub(crate) debug_overlay: bool,
+    /// 메모 표시 여부 (우측 여백 메모 박스 + 연결선). 한컴 편집기의 "메모 보기"
+    /// 대응 — 한컴 PDF 변환본에는 메모가 출력되지 않으므로 기본값 false (옵트인).
+    pub(crate) show_memos: bool,
     /// LINE_SEG vpos-reset 강제 분리 적용 여부 (페이지네이션 옵션)
     pub(crate) respect_vpos_reset: bool,
     /// 구역별 표 측정 데이터 (페이지네이션 결과 보존)
@@ -266,6 +269,7 @@ impl DocumentCore {
             show_transparent_borders: false,
             clip_enabled: true,
             debug_overlay: false,
+            show_memos: false,
             respect_vpos_reset: false,
             measured_tables: Vec::new(),
             dirty_sections: Vec::new(),

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -3977,6 +3977,11 @@ impl DocumentCore {
         self.layout_engine.set_clip_enabled(self.clip_enabled);
         self.layout_engine
             .set_show_control_codes(self.show_control_codes);
+        self.layout_engine.set_show_memos(self.show_memos);
+        if self.show_memos {
+            self.layout_engine
+                .set_memo_shapes(self.document.doc_info.memo_shapes());
+        }
         self.layout_engine
             .set_hwp3_variant(self.document.is_hwp3_variant);
         self.layout_engine.set_hwp3_origin_flow_spacing_before(

--- a/src/main.rs
+++ b/src/main.rs
@@ -82,6 +82,7 @@ fn print_help() {
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
     println!("      --show-para-marks       문단부호(↵/↓) 표시");
     println!("      --show-control-codes    조판부호 보이기 (문단부호 + 개체 마커 등)");
+    println!("      --show-memos            메모 표시 (우측 여백 메모 박스 + 연결선)");
     println!("      --debug-overlay         디버그 오버레이 (문단/표 경계 + 인덱스 라벨)");
     println!("      --respect-vpos-reset    LINE_SEG vpos=0 리셋을 단/페이지 강제 경계로 처리");
     println!("      --show-grid[=Nmm]       격자 오버레이 (기본: 1mm, 예: --show-grid=3mm)");
@@ -298,6 +299,7 @@ fn export_svg(args: &[String]) {
     let mut target_page: Option<u32> = None;
     let mut show_para_marks = false;
     let mut show_control_codes = false;
+    let mut show_memos = false;
     let mut debug_overlay = false;
     let mut grid_mm: Option<f64> = None;
     let mut grid_origin = GridOriginOption::Fixed((0.0_f64, 0.0_f64));
@@ -338,6 +340,10 @@ fn export_svg(args: &[String]) {
             }
             "--show-control-codes" => {
                 show_control_codes = true;
+                i += 1;
+            }
+            "--show-memos" => {
+                show_memos = true;
                 i += 1;
             }
             "--debug-overlay" => {
@@ -458,6 +464,9 @@ fn export_svg(args: &[String]) {
     }
     if show_control_codes {
         doc.set_show_control_codes(true);
+    }
+    if show_memos {
+        doc.set_show_memos(true);
     }
     if debug_overlay {
         doc.set_debug_overlay(true);

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -313,6 +313,28 @@ impl Field {
         self.extract_wstring_value("HelpState:")
     }
 
+    /// 메모(MEMO) command 에서 작성자 이름을 추출한다.
+    ///
+    /// command 형식: `MEMO/{shapeIdRef}/{number}/{timestamp}/{magic}/{author}/\;;`
+    /// (마지막 `\;;` 는 종결자). 형식이 다르면 None.
+    pub fn memo_author(&self) -> Option<&str> {
+        if self.field_type != FieldType::Memo {
+            return None;
+        }
+        let parts: Vec<&str> = self.command.split('/').collect();
+        if parts.len() < 7 || parts[0] != "MEMO" {
+            return None;
+        }
+        // author 는 6번째 성분부터 마지막 종결자 앞까지 (이름에 '/' 포함 대비)
+        let author_start = self.command.splitn(6, '/').last()?;
+        let author = author_start.rsplit_once('/').map(|(a, _)| a)?;
+        if author.is_empty() {
+            None
+        } else {
+            Some(author)
+        }
+    }
+
     /// 양식 모드에서 편집 가능 여부 (properties bit 0)
     pub fn is_editable_in_form(&self) -> bool {
         self.properties & 1 != 0
@@ -508,6 +530,39 @@ mod tests {
             body.chars().count() - 1,
             "set 길이 = inner 글자수 − 1 (trailing 공백 제외): {cmd}"
         );
+    }
+
+    /// 메모 command 에서 작성자 추출 (실측: aift.hwpx / 첫사랑 원고 형식)
+    #[test]
+    fn memo_author_extracts_from_command() {
+        let field = Field {
+            field_type: FieldType::Memo,
+            command: "MEMO/65535/1/1517431184/31247371/user/\\;;".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(field.memo_author(), Some("user"));
+
+        // 작성자 이름에 공백·한글 포함
+        let field2 = Field {
+            field_type: FieldType::Memo,
+            command: "MEMO/65535/57/3349832816/31233629/이젤 출판사_김민지 PD/\\;;".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(field2.memo_author(), Some("이젤 출판사_김민지 PD"));
+
+        // Memo 타입이 아니거나 형식이 다르면 None
+        let field3 = Field {
+            field_type: FieldType::ClickHere,
+            command: "MEMO/65535/1/1/1/user/\\;;".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(field3.memo_author(), None);
+        let field4 = Field {
+            field_type: FieldType::Memo,
+            command: "not-a-memo-command".to_string(),
+            ..Default::default()
+        };
+        assert_eq!(field4.memo_author(), None);
     }
 
     #[test]

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -553,6 +553,84 @@ impl Document {
     }
 }
 
+/// HWPTAG_MEMO_SHAPE 태그 ID (= HWPTAG_BEGIN(0x10) + 76).
+/// model → parser 역의존을 피하기 위해 값을 복제한다 (parser::tags 와 동기화 테스트 존재).
+pub const MEMO_SHAPE_TAG_ID: u16 = 0x010 + 76;
+
+/// 메모 모양 (HWPTAG_MEMO_SHAPE 레코드 / HWPX `hh:memoPr`)
+///
+/// 메모 렌더링(`--show-memos`)에 사용한다. DocInfo 는 이 레코드를 roundtrip 용
+/// raw 레코드(`extra_records`)로만 보존하므로, 렌더 시점에 [`DocInfo::memo_shapes`]로
+/// 구조화해 읽는다.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MemoShape {
+    /// 메모 박스 폭 (HWPUNIT)
+    pub width: u32,
+    /// 테두리 선 종류 (0=없음, 1=SOLID, …)
+    pub line_type: u8,
+    /// 테두리 선 굵기
+    pub line_width: u8,
+    /// 테두리 색 (ColorRef 0x00BBGGRR)
+    pub line_color: u32,
+    /// 채움 색 (ColorRef 0x00BBGGRR)
+    pub fill_color: u32,
+    /// 활성 메모 색 (ColorRef 0x00BBGGRR)
+    pub active_color: u32,
+    /// 메모 종류 (0=NORMAL)
+    pub memo_type: u32,
+}
+
+impl Default for MemoShape {
+    /// 한컴 기본 메모 모양. memoPr 미등록 문서와 `MemoShapeIDRef=65535`
+    /// (모양 미지정 sentinel) 폴백에 사용한다.
+    fn default() -> Self {
+        Self {
+            width: 15591, // ≈ 55 mm
+            line_type: 1, // SOLID
+            line_width: 3,
+            line_color: 0x00A9A9A9,   // #A9A9A9
+            fill_color: 0x0099FFCB,   // #CBFF99
+            active_color: 0x00DDBCFD, // #FDBCDD
+            memo_type: 0,
+        }
+    }
+}
+
+impl MemoShape {
+    /// HWPTAG_MEMO_SHAPE 레코드 바이트를 파싱한다.
+    ///
+    /// 레이아웃(22B): width u32 | line_type u8 | line_width u8 |
+    /// line_color u32 | fill_color u32 | active_color u32 | memo_type u32
+    pub fn from_record_data(data: &[u8]) -> Option<Self> {
+        if data.len() < 22 {
+            return None;
+        }
+        let u32_at =
+            |i: usize| u32::from_le_bytes([data[i], data[i + 1], data[i + 2], data[i + 3]]);
+        Some(Self {
+            width: u32_at(0),
+            line_type: data[4],
+            line_width: data[5],
+            line_color: u32_at(6),
+            fill_color: u32_at(10),
+            active_color: u32_at(14),
+            memo_type: u32_at(18),
+        })
+    }
+}
+
+impl DocInfo {
+    /// extra_records 에 보존된 HWPTAG_MEMO_SHAPE 레코드를 구조화해 반환한다.
+    /// (HWP5 파서·HWPX 파서 모두 이 레코드를 extra_records 로 보존한다.)
+    pub fn memo_shapes(&self) -> Vec<MemoShape> {
+        self.extra_records
+            .iter()
+            .filter(|r| r.tag_id == MEMO_SHAPE_TAG_ID)
+            .filter_map(|r| MemoShape::from_record_data(&r.data))
+            .collect()
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -562,6 +640,51 @@ mod tests {
         let doc = Document::default();
         assert_eq!(doc.sections.len(), 0);
         assert_eq!(doc.doc_properties.section_count, 0);
+    }
+
+    #[test]
+    fn memo_shape_tag_id_matches_parser_tags() {
+        // model → parser 역의존을 피하려 복제한 상수의 동기화 검증
+        assert_eq!(MEMO_SHAPE_TAG_ID, crate::parser::tags::HWPTAG_MEMO_SHAPE);
+    }
+
+    #[test]
+    fn memo_shapes_parses_memo_shape_record() {
+        // aift.hwpx 의 memoPr: width=15591 lineWidth=3 lineType=SOLID
+        // lineColor=#A9A9A9 fillColor=#CBFF99 activeColor=#FDBCDD
+        let mut data = Vec::new();
+        data.extend_from_slice(&15591u32.to_le_bytes());
+        data.push(1); // line_type SOLID
+        data.push(3); // line_width
+        data.extend_from_slice(&0x00A9A9A9u32.to_le_bytes());
+        data.extend_from_slice(&0x0099FFCBu32.to_le_bytes());
+        data.extend_from_slice(&0x00DDBCFDu32.to_le_bytes());
+        data.extend_from_slice(&0u32.to_le_bytes());
+
+        let doc_info = DocInfo {
+            extra_records: vec![RawRecord {
+                tag_id: MEMO_SHAPE_TAG_ID,
+                level: 1,
+                data,
+            }],
+            ..Default::default()
+        };
+        let shapes = doc_info.memo_shapes();
+        assert_eq!(shapes.len(), 1);
+        assert_eq!(shapes[0], MemoShape::default());
+    }
+
+    #[test]
+    fn memo_shapes_skips_short_record() {
+        let doc_info = DocInfo {
+            extra_records: vec![RawRecord {
+                tag_id: MEMO_SHAPE_TAG_ID,
+                level: 1,
+                data: vec![0u8; 10],
+            }],
+            ..Default::default()
+        };
+        assert!(doc_info.memo_shapes().is_empty());
     }
 
     #[test]

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1315,6 +1315,13 @@ pub struct LayoutEngine {
         std::cell::RefCell<Option<(usize, usize, usize, Option<Vec<(usize, usize, usize)>>)>>,
     /// 조판부호 표시 여부
     show_control_codes: std::cell::Cell<bool>,
+    /// 메모 표시 여부 (우측 여백 메모 박스 + 연결선, --show-memos)
+    show_memos: std::cell::Cell<bool>,
+    /// 문서의 메모 모양 목록 (HWPTAG_MEMO_SHAPE). 비어 있으면 기본 모양.
+    memo_shapes: std::cell::RefCell<Vec<crate::model::document::MemoShape>>,
+    /// 현재 페이지에서 수집된 메모 앵커. build_render_tree 시작 시 비우고,
+    /// 본문 조판 중 수집 → 페이지 마지막에 build_memo_areas 가 소비한다.
+    memo_anchors: std::cell::RefCell<Vec<memo_layout::MemoAnchor>>,
     /// 현재 페이지 용지 너비 (표 HorzRelTo::Paper 위치 계산용)
     current_paper_width: std::cell::Cell<f64>,
     /// 현재 페이지 본문 영역 (표 HorzRelTo::Page / VertRelTo::Page 위치 계산용)
@@ -1352,6 +1359,7 @@ pub struct LayoutEngine {
 }
 
 mod border_rendering;
+mod memo_layout;
 mod paragraph_layout;
 mod picture_footnote;
 mod shape_layout;
@@ -1412,6 +1420,9 @@ impl LayoutEngine {
             endnote_separator_below_hu: std::cell::Cell::new(0),
             active_field: std::cell::RefCell::new(None),
             show_control_codes: std::cell::Cell::new(false),
+            show_memos: std::cell::Cell::new(false),
+            memo_shapes: std::cell::RefCell::new(Vec::new()),
+            memo_anchors: std::cell::RefCell::new(Vec::new()),
             current_paper_width: std::cell::Cell::new(0.0),
             current_body_area: std::cell::Cell::new((0.0, 0.0, 0.0, 0.0)),
             is_hwp3_variant: std::cell::Cell::new(false),
@@ -1832,6 +1843,16 @@ impl LayoutEngine {
         self.show_control_codes.set(enabled);
     }
 
+    /// 메모 표시 여부 설정
+    pub fn set_show_memos(&self, enabled: bool) {
+        self.show_memos.set(enabled);
+    }
+
+    /// 문서의 메모 모양 목록 설정 (DocInfo::memo_shapes 결과)
+    pub fn set_memo_shapes(&self, shapes: Vec<crate::model::document::MemoShape>) {
+        *self.memo_shapes.borrow_mut() = shapes;
+    }
+
     /// 자동 번호 카운터 초기화
     pub fn reset_auto_counter(&self) {
         self.auto_counter.borrow_mut().reset();
@@ -1864,6 +1885,9 @@ impl LayoutEngine {
             layout.page_width,
             layout.page_height,
         );
+
+        // 메모 앵커는 페이지 단위로 수집한다 (본문 조판 중 채워짐).
+        self.memo_anchors.borrow_mut().clear();
 
         // 페이지 배경. hide_fill(쪽 배경 감추기) 시 커스텀 채우기(색/그라데이션/이미지)만
         // 숨기고 흰 종이 바탕 pageBackground 는 유지한다. 통째로 스킵하면 raster 기본 투명
@@ -2058,6 +2082,10 @@ impl LayoutEngine {
             page_border_fill,
         );
         tree.root.children.push(footer_node);
+
+        // 메모 박스 (--show-memos): 본문 조판 중 수집된 앵커를 우측 여백 밖에 배치.
+        // 모든 콘텐츠 위에 그려지도록 마지막에 추가한다.
+        self.build_memo_areas(&mut tree, styles, layout);
 
         tree
     }

--- a/src/renderer/layout/memo_layout.rs
+++ b/src/renderer/layout/memo_layout.rs
@@ -1,0 +1,308 @@
+//! 메모 렌더링 레이아웃 (--show-memos)
+//!
+//! 본문 조판 중 수집된 메모 앵커([`MemoAnchor`])를 페이지 우측 여백 바깥에
+//! 메모 박스로 배치한다. 한컴 편집기의 "메모 보기" 화면 구성을 따른다:
+//! 앵커 밑줄 + 연결선 + 우측 메모 박스(작성자 라벨 + 본문 문단).
+//!
+//! 한컴 PDF 변환본(권위 자료)에는 메모가 출력되지 않으므로 이 경로는
+//! 옵트인 플래그(`--show-memos`)가 켜졌을 때만 동작한다 — 기본 출력 불변.
+
+use super::super::composer::{compose_paragraph, recompose_for_cell_width};
+use super::super::page_layout::{LayoutRect, PageLayoutInfo};
+use super::super::render_tree::*;
+use super::super::style_resolver::ResolvedStyleSet;
+use super::super::{hwpunit_to_px, LineStyle, ShapeStyle};
+use super::text_measurement::resolved_to_text_style;
+use super::LayoutEngine;
+use crate::model::paragraph::Paragraph;
+
+/// 본문 조판 중 수집되는 메모 앵커 정보.
+/// 필드 시작 문자가 놓인 줄의 좌표와 메모 본문(subList) 사본을 담는다.
+pub(crate) struct MemoAnchor {
+    pub section_index: usize,
+    pub para_index: usize,
+    pub control_idx: usize,
+    /// 앵커(필드 시작 문자) x 좌표
+    pub x: f64,
+    /// 앵커 밑줄 끝 x (필드 끝이 같은 줄이면 끝 문자, 아니면 줄 끝)
+    pub end_x: f64,
+    /// 앵커 줄 상단 y
+    pub y: f64,
+    /// 앵커 줄 높이
+    pub line_height: f64,
+    /// 메모 번호 (fieldBegin Number 파라미터)
+    #[allow(dead_code)]
+    pub memo_index: u32,
+    /// 작성자 (MEMO command 6번째 성분)
+    pub author: Option<String>,
+    /// 메모 본문 문단 (fieldBegin subList)
+    pub paragraphs: Vec<Paragraph>,
+}
+
+/// 페이지 우측 끝과 메모 박스 사이 간격 (px)
+const MEMO_GUTTER_GAP: f64 = 12.0;
+/// 메모 박스 내부 패딩 (px)
+const MEMO_BOX_PADDING: f64 = 6.0;
+/// 메모 박스 사이 세로 간격 (px)
+const MEMO_BOX_VGAP: f64 = 8.0;
+/// 앵커 밑줄 두께 (px)
+const ANCHOR_UNDERLINE_H: f64 = 2.0;
+
+impl LayoutEngine {
+    /// 수집된 메모 앵커를 소비해 우측 여백 밖에 메모 박스를 배치한다.
+    /// build_render_tree 마지막(모든 콘텐츠 위)에 호출된다.
+    pub(crate) fn build_memo_areas(
+        &self,
+        tree: &mut PageRenderTree,
+        styles: &ResolvedStyleSet,
+        layout: &PageLayoutInfo,
+    ) {
+        if !self.show_memos.get() {
+            return;
+        }
+        let mut anchors = std::mem::take(&mut *self.memo_anchors.borrow_mut());
+        if anchors.is_empty() {
+            return;
+        }
+
+        // 표 측정 등 사전 패스에서 같은 필드가 중복 수집될 수 있으므로
+        // (section, para, control) 별 마지막 수집(최종 배치 좌표)만 유지한다.
+        {
+            let mut seen = std::collections::HashSet::new();
+            let mut kept: Vec<MemoAnchor> = Vec::with_capacity(anchors.len());
+            for a in anchors.into_iter().rev() {
+                if seen.insert((a.section_index, a.para_index, a.control_idx)) {
+                    kept.push(a);
+                }
+            }
+            kept.reverse();
+            anchors = kept;
+        }
+        // 앵커 세로 순서대로 박스를 쌓는다.
+        anchors.sort_by(|a, b| a.y.total_cmp(&b.y).then(a.x.total_cmp(&b.x)));
+
+        let shape = self
+            .memo_shapes
+            .borrow()
+            .first()
+            .cloned()
+            .unwrap_or_default();
+        let box_w = hwpunit_to_px(shape.width as i32, self.dpi).max(80.0);
+        let inner_w = box_w - 2.0 * MEMO_BOX_PADDING;
+        let box_x = layout.page_width + MEMO_GUTTER_GAP;
+        let border_w = (shape.line_width as f64 * 0.25).max(0.75);
+
+        let mut prev_bottom = f64::NEG_INFINITY;
+        for anchor in &anchors {
+            let memo_node_id = tree.next_id();
+            let mut memo_node = RenderNode::new(
+                memo_node_id,
+                RenderNodeType::MemoArea,
+                BoundingBox::new(box_x, 0.0, box_w, 0.0),
+            );
+
+            // (1) 내용을 y=0 기준으로 조판해 높이를 확정한 뒤 최종 y 로 이동한다.
+            let content_area = LayoutRect {
+                x: box_x + MEMO_BOX_PADDING,
+                y: 0.0,
+                width: inner_w,
+                height: layout.page_height,
+            };
+            let mut content_y = 0.0_f64;
+
+            // 작성자 라벨 (박스 상단, 본문보다 작게)
+            if let Some(author) = &anchor.author {
+                content_y = self.layout_memo_author_label(
+                    tree,
+                    &mut memo_node,
+                    author,
+                    anchor,
+                    styles,
+                    &content_area,
+                );
+            }
+
+            // 메모 본문. subList 의 lineseg 는 한컴 화면 메모 창 폭 기준이라
+            // 박스 폭과 무관하므로 비우고 박스 내부 폭으로 재조판한다.
+            for (p_idx, para) in anchor.paragraphs.iter().enumerate() {
+                let mut p = para.clone();
+                p.line_segs.clear();
+                let mut composed = compose_paragraph(&p);
+                recompose_for_cell_width(&mut composed, &p, inner_w, styles);
+                let line_count = composed.lines.len();
+                content_y = self.layout_composed_paragraph(
+                    tree,
+                    &mut memo_node,
+                    &composed,
+                    styles,
+                    &content_area,
+                    content_y,
+                    0,
+                    line_count,
+                    // 히트테스트 식별용 sentinel (각주의 usize::MAX-2000 스킴과 구분)
+                    anchor.section_index,
+                    usize::MAX - 3000 - p_idx,
+                    None,
+                    false,
+                    false,
+                    0.0,
+                    None,
+                    None,
+                    None,
+                    None,
+                );
+            }
+            let content_h = content_y.max(12.0);
+            let box_h = content_h + 2.0 * MEMO_BOX_PADDING;
+
+            // (2) 박스 y 확정: 앵커 줄 상단에 맞추되 앞 박스와 겹치지 않게 내리고,
+            //     페이지 하단을 넘으면 가능한 범위에서 끌어올린다.
+            let min_y = if prev_bottom.is_finite() {
+                prev_bottom + MEMO_BOX_VGAP
+            } else {
+                0.0
+            };
+            let mut box_y = anchor.y.max(min_y);
+            if box_y + box_h > layout.page_height {
+                box_y = (layout.page_height - box_h).max(min_y).max(0.0);
+            }
+            prev_bottom = box_y + box_h;
+
+            // (3) 조판된 내용을 최종 위치로 이동
+            let dy = box_y + MEMO_BOX_PADDING;
+            for child in &mut memo_node.children {
+                translate_node_y(child, dy);
+            }
+            memo_node.bbox = BoundingBox::new(box_x, box_y, box_w, box_h);
+
+            // (4) 배경 박스 (memoPr fillColor/lineColor) — children 맨 앞에 삽입
+            let bg_style = ShapeStyle {
+                fill_color: Some(shape.fill_color),
+                stroke_color: Some(shape.line_color),
+                stroke_width: border_w,
+                ..ShapeStyle::default()
+            };
+            let bg_id = tree.next_id();
+            let bg_node = RenderNode::new(
+                bg_id,
+                RenderNodeType::Rectangle(RectangleNode::new(2.0, bg_style, None)),
+                BoundingBox::new(box_x, box_y, box_w, box_h),
+            );
+            memo_node.children.insert(0, bg_node);
+
+            // (5) 앵커 밑줄 (본문 텍스트를 가리지 않도록 줄 하단에 fillColor 밴드)
+            let underline_w = (anchor.end_x - anchor.x).max(6.0);
+            let underline_style = ShapeStyle {
+                fill_color: Some(shape.fill_color),
+                ..ShapeStyle::default()
+            };
+            let ul_id = tree.next_id();
+            let underline_node = RenderNode::new(
+                ul_id,
+                RenderNodeType::Rectangle(RectangleNode::new(0.0, underline_style, None)),
+                BoundingBox::new(
+                    anchor.x,
+                    anchor.y + anchor.line_height - ANCHOR_UNDERLINE_H,
+                    underline_w,
+                    ANCHOR_UNDERLINE_H,
+                ),
+            );
+            tree.root.children.push(underline_node);
+
+            // (6) 연결선: 앵커 밑줄 끝 → 박스 좌측 상단
+            let conn_id = tree.next_id();
+            let conn_node = RenderNode::new(
+                conn_id,
+                RenderNodeType::Line(LineNode::new(
+                    anchor.x + underline_w,
+                    anchor.y + anchor.line_height - ANCHOR_UNDERLINE_H / 2.0,
+                    box_x,
+                    box_y + MEMO_BOX_PADDING + 4.0,
+                    LineStyle {
+                        color: shape.line_color,
+                        width: 0.75,
+                        ..LineStyle::default()
+                    },
+                )),
+                BoundingBox::new(
+                    anchor.x + underline_w,
+                    (anchor.y + anchor.line_height).min(box_y),
+                    (box_x - anchor.x - underline_w).abs(),
+                    (box_y - anchor.y).abs().max(1.0),
+                ),
+            );
+            tree.root.children.push(conn_node);
+
+            tree.root.children.push(memo_node);
+        }
+    }
+
+    /// 메모 박스 상단의 작성자 라벨 한 줄을 배치하고 다음 y 를 반환한다.
+    fn layout_memo_author_label(
+        &self,
+        tree: &mut PageRenderTree,
+        memo_node: &mut RenderNode,
+        author: &str,
+        anchor: &MemoAnchor,
+        styles: &ResolvedStyleSet,
+        content_area: &LayoutRect,
+    ) -> f64 {
+        let base_cs_id = anchor
+            .paragraphs
+            .first()
+            .and_then(|p| p.char_shapes.first())
+            .map(|cs| cs.char_shape_id as u32)
+            .unwrap_or(0);
+        let mut style = resolved_to_text_style(styles, base_cs_id, 0);
+        style.font_size = (style.font_size * 0.85).max(8.0);
+        style.bold = true;
+
+        let label_h = style.font_size * 1.5;
+        let baseline = style.font_size * 1.15;
+        let line_id = tree.next_id();
+        let mut line_node = RenderNode::new(
+            line_id,
+            RenderNodeType::TextLine(TextLineNode::new(label_h, baseline)),
+            BoundingBox::new(content_area.x, 0.0, content_area.width, label_h),
+        );
+        let run_id = tree.next_id();
+        let run_node = RenderNode::new(
+            run_id,
+            RenderNodeType::TextRun(TextRunNode {
+                text: author.to_string(),
+                style,
+                char_shape_id: None,
+                para_shape_id: None,
+                section_index: Some(anchor.section_index),
+                para_index: Some(usize::MAX - 3000),
+                char_start: None,
+                cell_context: None,
+                is_para_end: false,
+                is_line_break_end: false,
+                rotation: 0.0,
+                is_vertical: false,
+                char_overlap: None,
+                border_fill_id: 0,
+                baseline,
+                field_marker: FieldMarkerType::None,
+            }),
+            BoundingBox::new(content_area.x, 0.0, content_area.width, label_h),
+        );
+        line_node.children.push(run_node);
+        memo_node.children.push(line_node);
+        label_h + 2.0
+    }
+}
+
+/// 노드와 그 자식들의 y 좌표를 dy 만큼 이동한다 (메모 본문 배치용).
+/// bbox 외에 자체 좌표를 갖는 노드(Line)도 함께 이동한다.
+fn translate_node_y(node: &mut RenderNode, dy: f64) {
+    node.bbox.y += dy;
+    if let RenderNodeType::Line(line) = &mut node.node_type {
+        line.y1 += dy;
+        line.y2 += dy;
+    }
+    for child in &mut node.children {
+        translate_node_y(child, dy);
+    }
+}

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -5193,6 +5193,37 @@ impl LayoutEngine {
 
         for fr in &p.field_ranges {
             if let Some(Control::Field(field)) = p.controls.get(fr.control_idx) {
+                // 메모 앵커 수집 (--show-memos): 필드 시작이 이 줄에 있을 때만.
+                // 박스 배치는 페이지 마지막의 build_memo_areas 가 담당한다.
+                if field.field_type == crate::model::control::FieldType::Memo {
+                    if self.show_memos.get()
+                        && fr.start_char_idx >= line_char_start
+                        && fr.start_char_idx <= line_char_end
+                    {
+                        let anchor_x = find_x_for_char(fr.start_char_idx);
+                        // 앵커 표시 범위: 필드 끝이 같은 줄이면 끝 문자까지, 아니면 줄 끝까지
+                        let end_x = if fr.end_char_idx <= line_char_end {
+                            find_x_for_char(fr.end_char_idx)
+                        } else {
+                            char_x_map.last().map(|&(_, xv)| xv).unwrap_or(anchor_x)
+                        };
+                        self.memo_anchors
+                            .borrow_mut()
+                            .push(super::memo_layout::MemoAnchor {
+                                section_index,
+                                para_index,
+                                control_idx: fr.control_idx,
+                                x: anchor_x,
+                                end_x: end_x.max(anchor_x),
+                                y,
+                                line_height,
+                                memo_index: field.memo_index,
+                                author: field.memo_author().map(str::to_string),
+                                paragraphs: field.memo_paragraphs.clone(),
+                            });
+                    }
+                    continue;
+                }
                 if field.field_type != crate::model::control::FieldType::ClickHere {
                     continue;
                 }

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -160,6 +160,7 @@ impl RenderNode {
             RenderNodeType::Body { .. } => ("Body", String::new()),
             RenderNodeType::Column(c) => ("Column", format!(",\"col\":{}", c)),
             RenderNodeType::FootnoteArea => ("FootnoteArea", String::new()),
+            RenderNodeType::MemoArea => ("MemoArea", String::new()),
             RenderNodeType::TextLine(tl) => (
                 "TextLine",
                 format!(",\"pi\":{}", tl.para_index.unwrap_or(0)),
@@ -263,6 +264,8 @@ pub enum RenderNodeType {
     Column(u16),
     /// 각주 영역
     FootnoteArea,
+    /// 메모 박스 (--show-memos, 페이지 우측 여백 바깥 영역)
+    MemoArea,
     /// 텍스트 줄
     TextLine(TextLineNode),
     /// 텍스트 런 (동일 글자 모양의 텍스트 조각)

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -103,6 +103,10 @@ pub struct SvgRenderer {
     pub font_paths: Vec<std::path::PathBuf>,
     /// 사용된 폰트별 codepoint 수집 (font_family → codepoints)
     font_codepoints: std::collections::HashMap<String, std::collections::HashSet<char>>,
+    /// 메모 박스(--show-memos)가 페이지 우측 밖으로 나가는 폭 (px).
+    /// render_tree 가 MemoArea 노드 범위에서 계산하며, begin_page 가 SVG
+    /// width/viewBox 를 이만큼 넓혀 메모가 잘리지 않게 한다. 페이지 좌표계는 불변.
+    memo_gutter_extra: f64,
 }
 
 /// 디버그 오버레이용 문단 경계 정보
@@ -174,6 +178,7 @@ impl SvgRenderer {
             font_embed_mode: FontEmbedMode::None,
             font_paths: Vec::new(),
             font_codepoints: std::collections::HashMap::new(),
+            memo_gutter_extra: 0.0,
         }
     }
 
@@ -191,6 +196,19 @@ impl SvgRenderer {
 
     /// 렌더 트리를 SVG로 렌더링
     pub fn render_tree(&mut self, tree: &PageRenderTree) {
+        // 메모 박스(--show-memos)가 있으면 SVG 캔버스를 우측으로 확장한다.
+        let page_right = tree.root.bbox.width;
+        let memo_right = tree
+            .root
+            .children
+            .iter()
+            .filter(|c| matches!(c.node_type, RenderNodeType::MemoArea))
+            .map(|c| c.bbox.x + c.bbox.width)
+            .fold(page_right, f64::max);
+        self.memo_gutter_extra = (memo_right - page_right).max(0.0).ceil();
+        if self.memo_gutter_extra > 0.0 {
+            self.memo_gutter_extra += 4.0; // 테두리 선폭 여유
+        }
         self.render_node(&tree.root);
     }
 
@@ -703,11 +721,12 @@ impl SvgRenderer {
                         }
                     }
                 }
-                // 머리말/꼬리말/바탕쪽/각주/텍스트박스/그룹: body 외 영역 제외
+                // 머리말/꼬리말/바탕쪽/각주/메모/텍스트박스/그룹: body 외 영역 제외
                 RenderNodeType::Header
                 | RenderNodeType::Footer
                 | RenderNodeType::MasterPage
                 | RenderNodeType::FootnoteArea
+                | RenderNodeType::MemoArea
                 | RenderNodeType::TextBox
                 | RenderNodeType::Group(_) => {
                     self.overlay_skip_depth += 1;
@@ -743,6 +762,7 @@ impl SvgRenderer {
                 | RenderNodeType::Footer
                 | RenderNodeType::MasterPage
                 | RenderNodeType::FootnoteArea
+                | RenderNodeType::MemoArea
                 | RenderNodeType::TextBox
                 | RenderNodeType::Group(_) => {
                     self.overlay_skip_depth = self.overlay_skip_depth.saturating_sub(1);
@@ -2633,9 +2653,12 @@ impl Renderer for SvgRenderer {
         self.overlay_page_section = -1;
         // xmlns:xlink 필수: SVG 가 <img> 로 로드될 때(예: blob URL 미리보기)
         // 엄격한 XML 파싱으로 인해 xmlns:xlink 미선언 시 <image xlink:href=...> 가 무시됨.
+        // 메모 박스(--show-memos)가 있으면 우측으로만 캔버스를 넓힌다.
+        // viewBox 원점은 그대로라 페이지 좌표계는 변하지 않는다.
+        let canvas_width = width + self.memo_gutter_extra;
         self.output.push_str(&format!(
             "<svg xmlns=\"http://www.w3.org/2000/svg\" xmlns:xlink=\"http://www.w3.org/1999/xlink\" width=\"{}\" height=\"{}\" viewBox=\"0 0 {} {}\">\n",
-            width, height, width, height,
+            canvas_width, height, canvas_width, height,
         ));
         self.defs_insert_pos = self.output.len();
     }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -399,6 +399,19 @@ impl HwpDocument {
         self.invalidate_page_tree_cache();
     }
 
+    /// 메모 표시 여부를 반환한다.
+    #[wasm_bindgen(js_name = getShowMemos)]
+    pub fn get_show_memos(&self) -> bool {
+        self.show_memos
+    }
+
+    /// 메모 표시 여부를 설정한다 (우측 여백 메모 박스 + 연결선).
+    #[wasm_bindgen(js_name = setShowMemos)]
+    pub fn set_show_memos(&mut self, enabled: bool) {
+        self.show_memos = enabled;
+        self.invalidate_page_tree_cache();
+    }
+
     /// 투명선 표시 여부를 반환한다.
     #[wasm_bindgen(js_name = getShowTransparentBorders)]
     pub fn get_show_transparent_borders(&self) -> bool {

--- a/tests/memo_rendering.rs
+++ b/tests/memo_rendering.rs
@@ -1,0 +1,136 @@
+//! 메모 렌더링(--show-memos) 통합 테스트.
+//!
+//! - 기본(플래그 off): 메모가 렌더 트리/SVG에 나타나지 않는다 (기존 출력 불변 —
+//!   한컴 PDF 권위 자료에 메모가 출력되지 않으므로 기본 출력은 메모 없음).
+//! - 플래그 on: 메모 앵커가 있는 페이지에 MemoArea 노드가 생기고, SVG 캔버스가
+//!   우측으로 확장되며, 메모 본문 텍스트가 출력에 포함된다.
+
+use rhwp::wasm_api::HwpDocument;
+
+/// SVG 내 모든 `<text>` 내용을 이어붙인다 (SVG 는 글자 단위 `<text>` 를 방출하므로
+/// 다글자 부분 문자열 검색에는 이 결합 문자열을 쓴다).
+fn svg_text(svg: &str) -> String {
+    let mut out = String::new();
+    let mut rest = svg;
+    while let Some(open) = rest.find("<text") {
+        if let Some(gt) = rest[open..].find('>') {
+            let after = &rest[open + gt + 1..];
+            if let Some(close) = after.find("</text>") {
+                out.push_str(&after[..close]);
+                rest = &after[close + 7..];
+                continue;
+            }
+        }
+        break;
+    }
+    out
+}
+
+/// aift.hwpx: 메모 2건 (같은 페이지, memoPr width=15591 fillColor=#CBFF99).
+/// 플래그를 잠시 켜서 MemoArea 노드가 생기는 페이지(메모 앵커 페이지)를 찾는다.
+fn find_memo_page(doc: &mut HwpDocument) -> Option<u32> {
+    let was_on = doc.get_show_memos();
+    doc.set_show_memos(true);
+    let page = (0..doc.page_count()).find(|&p| {
+        doc.get_page_render_tree(p)
+            .map(|json| json.contains("\"MemoArea\""))
+            .unwrap_or(false)
+    });
+    doc.set_show_memos(was_on);
+    page
+}
+
+#[test]
+fn memo_hidden_by_default() {
+    let bytes = std::fs::read("samples/hwpx/aift.hwpx").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let page = find_memo_page(&mut doc).expect("메모 앵커 페이지");
+
+    let svg = doc.render_page_svg_native(page).expect("렌더");
+    // 기본 출력에는 메모 본문/박스가 없어야 한다 (한컴 PDF 정합).
+    // 앵커 문단 텍스트("공동기관1 : 두아즈")와 메모 본문은 다른 문자열이다.
+    assert!(
+        !memo_body_present(&svg),
+        "플래그 off 인데 메모 본문이 출력됨"
+    );
+
+    let tree_json = doc.get_page_render_tree(page).expect("트리");
+    assert!(
+        !tree_json.contains("MemoArea"),
+        "플래그 off 인데 MemoArea 노드가 생성됨"
+    );
+}
+
+#[test]
+fn memo_rendered_with_show_memos() {
+    let bytes = std::fs::read("samples/hwpx/aift.hwpx").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+    let page = find_memo_page(&mut doc).expect("메모 앵커 페이지");
+
+    // 플래그 off 기준 캔버스 폭
+    let plain_svg = doc.render_page_svg_native(page).expect("렌더 (off)");
+    let plain_width = svg_width(&plain_svg);
+
+    doc.set_show_memos(true);
+    assert!(doc.get_show_memos());
+
+    let svg = doc.render_page_svg_native(page).expect("렌더 (on)");
+
+    // 메모 본문 텍스트가 페이지 SVG에 포함된다.
+    assert!(memo_body_present(&svg), "메모 본문 미출력");
+    // 작성자 라벨 (aift 메모 command 의 author = "user")
+    assert!(svg_text(&svg).contains("user"), "메모 작성자 라벨 미출력");
+    // 캔버스가 우측으로 확장된다 (박스 폭 15591HU ≈ 208px + 거터).
+    let width = svg_width(&svg);
+    assert!(
+        width > plain_width + 100.0,
+        "캔버스 미확장: off={plain_width} on={width}"
+    );
+
+    // 렌더 트리에 MemoArea 노드 2개 (메모 2건).
+    let tree_json = doc.get_page_render_tree(page).expect("트리");
+    let memo_nodes = tree_json.matches("\"MemoArea\"").count();
+    assert_eq!(memo_nodes, 2, "MemoArea 노드 수");
+
+    // 플래그를 다시 끄면 원상 복구된다 (캐시 무효화 확인).
+    doc.set_show_memos(false);
+    let svg_off = doc.render_page_svg_native(page).expect("렌더 (재off)");
+    assert!(
+        !memo_body_present(&svg_off),
+        "플래그 재off 후에도 메모가 남음"
+    );
+    assert!(
+        (svg_width(&svg_off) - plain_width).abs() < 0.01,
+        "재off 폭 복구"
+    );
+}
+
+/// 메모가 없는 페이지는 플래그가 켜져 있어도 캔버스가 확장되지 않는다.
+#[test]
+fn memo_free_page_unchanged_with_flag() {
+    let bytes = std::fs::read("samples/hwpx/aift.hwpx").expect("샘플 읽기");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("파싱");
+
+    let plain = doc.render_page_svg_native(0).expect("렌더 (off)");
+    doc.set_show_memos(true);
+    let with_flag = doc.render_page_svg_native(0).expect("렌더 (on)");
+    assert_eq!(
+        plain, with_flag,
+        "메모 없는 페이지 출력이 플래그에 영향받음"
+    );
+}
+
+/// 메모 본문("기업 소개 및 본 과제 관련 기술력 소개") 포함 여부.
+/// SVG 는 글자 단위 `<text>` 로 방출되고 공백은 요소로 나오지 않으므로
+/// 공백을 제거한 결합 문자열로 비교한다.
+fn memo_body_present(svg: &str) -> bool {
+    svg_text(svg)
+        .replace(' ', "")
+        .contains("기업소개및본과제관련기술력소개")
+}
+
+fn svg_width(svg: &str) -> f64 {
+    let start = svg.find("width=\"").expect("width 속성") + 7;
+    let end = svg[start..].find('"').expect("width 닫힘") + start;
+    svg[start..end].parse().expect("width 숫자")
+}


### PR DESCRIPTION
## 개요

메모(HWP 메모 필드)는 현재 파싱·직렬화(왕복 보존)는 지원되지만(#147, #1092, #1391) **렌더링이 없어** IR에만 존재합니다. 한컴 편집기의 "메모 보기"에 대응하는 옵트인 렌더링을 추가합니다.

```
rhwp export-svg sample.hwpx --show-memos
```

## 동작

- 메모 앵커 줄에 밑줄(memoPr fillColor 밴드) 표시, 연결선으로 페이지 우측 여백 밖 메모 박스와 연결
- 메모 박스: memoPr(width/fillColor/lineColor) 스타일 + 작성자 라벨(MEMO command Author) + 본문 문단, 앵커 세로 순서로 스태킹(겹침 방지, 페이지 하단 클램프)
- 메모가 있는 페이지만 SVG 캔버스를 우측으로 확장 (viewBox 원점 불변 → 페이지 좌표계 불변)

| aift.hwpx (memoPr 있음) | 66건 메모 실문서 (기본 모양 폴백) |
|---|---|
| 메모 2건, 작성자 user | 작성자 라벨 + 본문 재조판 + 스태킹 |

## 설계 결정

1. **옵트인 (기본 off)** — 한글 2022 PDF 권위 자료(`pdf/hwpx/aift-2022.pdf`) 74쪽 전수 확인 결과 **한컴 PDF 변환본에는 메모가 출력되지 않습니다**. 따라서 기본 출력을 바꾸지 않는 `--show-memos` 플래그로만 활성화하여 시각 회귀 게이트를 깨지 않습니다. 플래그 off 시 SVG 출력은 기존과 바이트 동일합니다 (테스트로 보장).
2. **roundtrip 경로 불변** — memoPr(HWPTAG_MEMO_SHAPE)은 기존대로 `extra_records` raw 보존을 유지하고, 렌더 시점에만 `DocInfo::memo_shapes()`로 구조화해 읽습니다. 직렬화 코드는 건드리지 않았습니다.
3. **레이아웃이 렌더 트리 노드를 생성** — 메모 박스를 `RenderNodeType::MemoArea` + 기존 프리미티브(Rectangle/Line/TextLine)로 만들어 SVG 외 렌더러(layer/canvas)도 노드를 자동 상속합니다. SVG 측 변경은 캔버스 확장뿐입니다.
4. **본문 재조판** — 메모 subList의 linesegarray horzsize는 한컴 화면 메모 창 폭 기준이라 박스 폭과 무관 → lineseg를 비우고 `recompose_for_cell_width`로 박스 내부 폭에 재조판합니다.

## 검증

- `cargo test` 전체 통과 (hwpx_roundtrip_baseline 포함, 40 바이너리 실패 0)
- 신규 테스트: `tests/memo_rendering.rs` 3건 (기본 off 불변 / on 시 MemoArea·본문·캔버스 확장 / 메모 없는 페이지 플래그 무영향) + 단위 4건 (MemoShape 파싱, 태그 ID 동기화, memo_author 추출)
- `cargo clippy --all-targets` 클린, 수정 파일만 rustfmt
- 시각 확인: aift.hwpx 메모 페이지, 메모 66건 실문서(memoPr 미등록 → 기본 모양 폴백, `--debug-overlay` 병행) — 한컴 편집기 화면 구성과 유사함 확인

## 후속 계획 (별도 PR 예정)

- rhwp-studio 보기 메뉴 "메모" 토글 (`setShowMemos` WASM export는 이번 PR에 포함됨)
- 에디터 메모 삽입/편집 (../refine 프로젝트의 HWPX 메모 삽입 스펙 참고)

🤖 Generated with [Claude Code](https://claude.com/claude-code)