### PR TITLE
Task #2299: 편집 vpos 재계산의 저장 리셋·문단 여백 보존 — 다단 단-밴드 소멸/쪽수 이탈 수정

### DIFF
--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -638,7 +638,23 @@ impl DocumentCore {
                 new_chars,
             );
 
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
             self.reflow_paragraph(section_idx, para_idx);
+            // [Task #2299] 붙여넣기로 문단 높이가 변했으므로 하류 vpos 를 재연결한다.
+            // 생략하면 후속 문단 first < 커진 end 세임이 저장돼 이후 편집의 리셋
+            // 보존이 이를 단/쪽 경계로 오인한다.
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs,
+                para_idx,
+                None,
+                stored_end_for_reset,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
+            );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
 
@@ -688,6 +704,19 @@ impl DocumentCore {
         for i in para_idx..=last_para_idx {
             self.reflow_paragraph(section_idx, i);
         }
+
+        // [Task #2299] 삽입 문단들의 vpos 를 흐름에 연결한다. 클립보드 클론의
+        // 원본 좌표/placeholder 를 방치하면 이후 편집의 vpos 재계산이 이를 저장
+        // 단/쪽 리셋으로 오인해 영구 고착시킨다 — 신규 구간은 리셋 보존에서 제외.
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs,
+            para_idx,
+            Some(para_idx + 1..last_para_idx + 1),
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
+        );
 
         // 6. 선택적 재구성: 삽입된 문단 composed 추가 + 영향 문단 재구성
         self.recompose_paragraph(section_idx, para_idx);
@@ -1036,6 +1065,8 @@ impl DocumentCore {
         let is_empty_para = para.text.is_empty() && para.controls.is_empty();
 
         let insert_para_idx;
+        // [Task #2299] 분할 삽입이면 우측 절반까지 신규 구간에 포함해야 한다.
+        let mut did_split_for_control = false;
         if is_empty_para && char_offset == 0 {
             self.document.sections[section_idx].paragraphs[para_idx] = clip_para;
             insert_para_idx = para_idx;
@@ -1046,6 +1077,7 @@ impl DocumentCore {
             insert_para_idx = para_idx;
         } else {
             if char_offset > 0 && !para.text.is_empty() {
+                did_split_for_control = true;
                 let new_para =
                     self.document.sections[section_idx].paragraphs[para_idx].split_at(char_offset);
                 self.document.sections[section_idx]
@@ -1121,6 +1153,27 @@ impl DocumentCore {
         self.document.sections[section_idx]
             .paragraphs
             .insert(insert_para_idx + 1, empty_para);
+
+        // [Task #2299] 신규 문단들(컨트롤 host·이웃 빈 문단·분할 우측)의 placeholder
+        // vpos 를 흐름에 연결한다 — 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽
+        // 리셋으로 오인해 영구 고착시킨다. 분할 좌측은 높이가 바뀌어 reflow 한다.
+        let fresh_end = insert_para_idx + 2 + usize::from(did_split_for_control);
+        if did_split_for_control {
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
+            self.reflow_paragraph(section_idx, para_idx);
+        }
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs,
+            para_idx,
+            Some(insert_para_idx..fresh_end),
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
+        );
 
         // 리플로우 + 페이지네이션
         self.recompose_section(section_idx);

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1046,6 +1046,7 @@ impl DocumentCore {
                     &mut section.paragraphs,
                     start,
                     None,
+                    None,
                     &self.styles,
                     self.dpi,
                     self.document.is_hwp3_variant,

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1042,7 +1042,14 @@ impl DocumentCore {
             // 의 vpos 연속성이 깨짐. paginator 의 vpos_h 기반 current_height 조정이
             // 잘못된 값으로 적용되어 페이지가 과다 분할되는 회귀의 원인.
             if let Some(start) = min_reflowed_idx {
-                crate::renderer::composer::recalculate_section_vpos(&mut section.paragraphs, start);
+                crate::renderer::composer::recalculate_section_vpos(
+                    &mut section.paragraphs,
+                    start,
+                    None,
+                    &self.styles,
+                    self.dpi,
+                    self.document.is_hwp3_variant,
+                );
             }
         }
 

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -58,7 +58,22 @@ impl DocumentCore {
                 new_chars,
             );
 
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
             self.reflow_paragraph(section_idx, para_idx);
+            // [Task #2299] 삽입/변경 문단들의 vpos 를 흐름에 연결한다 — placeholder 를
+            // 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해 고착시킨다.
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs,
+                para_idx,
+                None,
+                stored_end_for_reset,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
+            );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
 
@@ -126,6 +141,19 @@ impl DocumentCore {
             for i in para_idx..=last_para_idx {
                 self.reflow_paragraph(section_idx, i);
             }
+            // [Task #2299] 삽입 문단들의 vpos 를 흐름에 연결한다 — 클론/placeholder
+            // 좌표를 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해
+            // 고착시킨다. left_empty 면 host 자체가 클론이라 신규 구간에 포함한다.
+            let fresh_start = if left_empty { para_idx } else { para_idx + 1 };
+            crate::renderer::composer::recalculate_section_vpos(
+                &mut self.document.sections[section_idx].paragraphs,
+                para_idx,
+                Some(fresh_start..last_para_idx + 1),
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
+            );
 
             // 선택적 재구성: 원본 문단 재구성 + 삽입 문단 composed 추가
             self.recompose_paragraph(section_idx, para_idx);
@@ -165,6 +193,17 @@ impl DocumentCore {
         for i in para_idx..=last_para_idx {
             self.reflow_paragraph(section_idx, i);
         }
+        // [Task #2299] 삽입/변경 문단들의 vpos 를 흐름에 연결한다 — placeholder 를
+        // 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해 고착시킨다.
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs,
+            para_idx,
+            Some(para_idx + 1..last_para_idx + 1),
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
+        );
 
         // 선택적 재구성: 원본 문단 재구성 + 삽입 문단 composed 추가
         self.recompose_paragraph(section_idx, para_idx);

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -543,11 +543,16 @@ impl DocumentCore {
             }
         }
         if reflow_text_para_after_floating {
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[parent_para_idx],
+            );
             self.reflow_paragraph(section_idx, parent_para_idx);
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 parent_para_idx,
                 None,
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -547,6 +547,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 parent_para_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
         }
         // 캡션 생성/삭제 시 AutoNumber 재할당. 생성 path 는 문단 placeholder 도 보강한다.

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -660,6 +660,8 @@ impl DocumentCore {
 
         let insert_para_idx;
         let table_control_idx;
+        // [Task #2299] 분할 삽입이면 우측 절반까지 신규 구간에 포함해야 한다.
+        let mut did_split_for_table = false;
         if is_empty_para {
             // 빈 문단이면 UI에서 넘어온 offset과 무관하게 현재 줄을 표 host로 사용한다.
             self.document.sections[section_idx].paragraphs[para_idx] = table_para;
@@ -700,6 +702,7 @@ impl DocumentCore {
         } else {
             // 문단 중간이면 분할 후 삽입
             if char_offset > 0 && !para.text.is_empty() {
+                did_split_for_table = true;
                 let new_para =
                     self.document.sections[section_idx].paragraphs[para_idx].split_at(char_offset);
                 self.document.sections[section_idx]
@@ -725,6 +728,24 @@ impl DocumentCore {
         self.document.sections[section_idx]
             .paragraphs
             .insert(insert_para_idx + 1, make_empty_neighbor_para());
+
+        // [Task #2299] 신규 문단들(표 host·이웃 빈 문단·분할 우측)의 placeholder
+        // vpos 를 흐름에 연결한다 — 방치하면 이후 편집의 vpos 재계산이 이를 저장
+        // 단/쪽 리셋으로 오인해 영구 고착시킨다. 분할 좌측(host)은 높이가 바뀌었을
+        // 수 있어 함께 reflow 한다.
+        let fresh_end = insert_para_idx + 2 + usize::from(did_split_for_table);
+        for i in para_idx..fresh_end.min(self.document.sections[section_idx].paragraphs.len()) {
+            self.reflow_paragraph(section_idx, i);
+        }
+        crate::renderer::composer::recalculate_section_vpos(
+            &mut self.document.sections[section_idx].paragraphs,
+            para_idx,
+            Some(insert_para_idx..fresh_end),
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
+        );
 
         // --- 6. 스타일 갱신 + 리플로우 + 페이지네이션 ---
         // 새 BorderFill 추가 시 styles.border_styles 갱신이 필요하므로 rebuild_section 사용

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -2639,11 +2639,16 @@ impl DocumentCore {
             section.raw_stream = None;
         }
 
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[parent_para_idx],
+        );
         self.reflow_paragraph(section_idx, parent_para_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             parent_para_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -2643,6 +2643,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             parent_para_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -28,16 +28,23 @@ fn recalculate_cell_paragraph_vpos(
     // RowBreak 거대 셀은 후속 문단 vpos를 뒤로 되돌려 다음 조각의 로컬 원점을
     // 표현하기도 한다. 그 경계까지 선형 편집 결과를 연결하되, 경계 이후 저장
     // 좌표는 페이지 분할 신호이므로 이동하지 않는다.
+    // [Task #2299] 합성 seg(TAG_IMPLEMENTATION_PROPERTY, #1811)의 vpos=0 은 배치 전
+    // placeholder 이지 분할 신호가 아니다 — 섹션 recalc 와 동일하게 정지 대상에서
+    // 제외한다 (로드가 합성한 중간-셀 문단에서 가짜 정지 → 꼬리 미갱신 방지).
     let stop_para = paragraphs
         .windows(2)
         .enumerate()
         .skip(start_para)
         .find_map(|(idx, pair)| {
             let previous = pair[0].line_segs.first()?.vertical_pos;
-            let current = pair[1].line_segs.first()?.vertical_pos;
+            let current_seg = pair[1].line_segs.first()?;
+            let current = current_seg.vertical_pos;
+            let is_synthetic = current_seg.tag
+                & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY
+                != 0;
             let reset_para = idx + 1;
             let is_inserted_paragraph = ignore_reset_at == Some(reset_para);
-            (current < previous && !is_inserted_paragraph).then_some(reset_para)
+            (current < previous && !is_inserted_paragraph && !is_synthetic).then_some(reset_para)
         })
         .unwrap_or(paragraphs.len());
 
@@ -483,11 +490,16 @@ impl DocumentCore {
             .and_then(|m| m.get(para_idx))
             .copied()
             .unwrap_or(0);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[para_idx],
+        );
         self.reflow_paragraph(section_idx, para_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -505,11 +517,16 @@ impl DocumentCore {
             if new_col == old_col {
                 break;
             }
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
             self.reflow_paragraph(section_idx, para_idx);
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
                 None,
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -601,11 +618,16 @@ impl DocumentCore {
             .and_then(|m| m.get(para_idx))
             .copied()
             .unwrap_or(0);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[para_idx],
+        );
         self.reflow_paragraph(section_idx, para_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -623,11 +645,16 @@ impl DocumentCore {
             if new_col == old_col {
                 break;
             }
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
             self.reflow_paragraph(section_idx, para_idx);
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
                 None,
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -1270,11 +1297,16 @@ impl DocumentCore {
                 if count > 0 {
                     self.document.sections[section_idx].paragraphs[start_para]
                         .delete_text_at(start_offset, count);
+                    // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+                    let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                        &self.document.sections[section_idx].paragraphs[start_para],
+                    );
                     self.reflow_paragraph(section_idx, start_para);
                     crate::renderer::composer::recalculate_section_vpos(
                         &mut self.document.sections[section_idx].paragraphs,
                         start_para,
                         None,
+                        stored_end_for_reset,
                         &self.styles,
                         self.dpi,
                         self.document.is_hwp3_variant,
@@ -1314,11 +1346,16 @@ impl DocumentCore {
                     self.remove_composed_paragraph(section_idx, start_para + 1);
                     self.document.sections[section_idx].paragraphs[start_para].merge_from(&next);
                 }
+                // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+                let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                    &self.document.sections[section_idx].paragraphs[start_para],
+                );
                 self.reflow_paragraph(section_idx, start_para);
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     start_para,
                     None,
+                    stored_end_for_reset,
                     &self.styles,
                     self.dpi,
                     self.document.is_hwp3_variant,
@@ -1456,7 +1493,8 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
-                Some(new_para_idx),
+                Some(new_para_idx..new_para_idx + 1),
+                None,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -1478,7 +1516,8 @@ impl DocumentCore {
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     para_idx,
-                    Some(new_para_idx),
+                    Some(new_para_idx..new_para_idx + 1),
+                    None,
                     &self.styles,
                     self.dpi,
                     self.document.is_hwp3_variant,
@@ -1507,9 +1546,27 @@ impl DocumentCore {
         if let Some(chain) = square_ole_enter_chain {
             self.document.sections[section_idx].raw_stream = None;
             let new_para_idx = para_idx + 1;
-            let next_vpos = next_line_vpos_after_para_for_enter(
-                &self.document.sections[section_idx].paragraphs[para_idx],
-            );
+            // [Task #2299] 판정 기준을 실제 배치 기준과 일치시킨다: vpos 재계산이
+            // 신규 문단을 anchor end + 문단 여백 gap 에 배치하므로, gap 을 빼고
+            // 판정하면 wrap 영역 바깥(bottom_vpos 이하)에 wrap-줄 폭 문단이 놓인다.
+            let anchor = &self.document.sections[section_idx].paragraphs[para_idx];
+            // 신규 문단은 anchor 서식을 상속하므로(gap = anchor.after + anchor.before)
+            // hwp3 변환은 spacing_before 성분에만 적용한다 — recalc 의 boundary_gap
+            // 과 동일 산식.
+            let enter_gap = {
+                let (after, before) = self
+                    .styles
+                    .para_styles
+                    .get(anchor.para_shape_id as usize)
+                    .map(|style| (style.spacing_after, style.spacing_before))
+                    .unwrap_or((0.0, 0.0));
+                let before = crate::renderer::hwp3_variant_flow_spacing_before(
+                    before,
+                    self.document.is_hwp3_variant,
+                );
+                crate::renderer::px_to_hwpunit(after + before, self.dpi)
+            };
+            let next_vpos = next_line_vpos_after_para_for_enter(anchor).saturating_add(enter_gap);
             let keep_wrap_zone = next_vpos < chain.bottom_vpos;
             let new_para = if keep_wrap_zone {
                 empty_paragraph_after_square_wrap_anchor(
@@ -1530,7 +1587,8 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
-                Some(new_para_idx),
+                Some(new_para_idx..new_para_idx + 1),
+                None,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -1577,12 +1635,17 @@ impl DocumentCore {
             .and_then(|m| m.get(para_idx))
             .copied()
             .unwrap_or(0);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[para_idx],
+        );
         self.reflow_paragraph(section_idx, para_idx);
         self.reflow_paragraph(section_idx, new_para_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
-            Some(new_para_idx),
+            Some(new_para_idx..new_para_idx + 1),
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -1601,12 +1664,17 @@ impl DocumentCore {
             if new_col1 == old_col1 {
                 break;
             }
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[para_idx],
+            );
             self.reflow_paragraph(section_idx, para_idx);
             self.reflow_paragraph(section_idx, new_para_idx);
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
-                Some(new_para_idx),
+                Some(new_para_idx..new_para_idx + 1),
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -1675,13 +1743,18 @@ impl DocumentCore {
 
         // 분할된 두 문단 리플로우
         self.reflow_paragraph(section_idx, para_idx);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[new_para_idx],
+        );
         self.reflow_paragraph(section_idx, new_para_idx);
 
         // 삽입 지점부터 구역 끝까지 vpos 재계산 (페이지 재배치에 필요)
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
-            Some(new_para_idx),
+            Some(new_para_idx..new_para_idx + 1),
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -1744,12 +1817,17 @@ impl DocumentCore {
 
         // 분할된 두 문단 리플로우
         self.reflow_paragraph(section_idx, para_idx);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[new_para_idx],
+        );
         self.reflow_paragraph(section_idx, new_para_idx);
 
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
-            Some(new_para_idx),
+            Some(new_para_idx..new_para_idx + 1),
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -1897,6 +1975,7 @@ impl DocumentCore {
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
                 None,
+                None,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -1922,11 +2001,16 @@ impl DocumentCore {
             .and_then(|m| m.get(prev_idx))
             .copied()
             .unwrap_or(0);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[prev_idx],
+        );
         self.reflow_paragraph(section_idx, prev_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             prev_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -1945,11 +2029,16 @@ impl DocumentCore {
             if new_col == old_col {
                 break;
             }
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+                &self.document.sections[section_idx].paragraphs[prev_idx],
+            );
             self.reflow_paragraph(section_idx, prev_idx);
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
                 None,
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -2012,6 +2101,11 @@ impl DocumentCore {
             .copied()
             .unwrap_or(0);
         self.remove_composed_paragraph(section_idx, para_idx);
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = self.document.sections[section_idx]
+            .paragraphs
+            .get(reflow_idx)
+            .and_then(crate::renderer::composer::paragraph_flow_end);
         if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
             self.reflow_paragraph(section_idx, reflow_idx);
         }
@@ -2019,6 +2113,7 @@ impl DocumentCore {
             &mut self.document.sections[section_idx].paragraphs,
             reflow_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -2038,6 +2133,11 @@ impl DocumentCore {
             if new_col == old_col {
                 break;
             }
+            // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+            let stored_end_for_reset = self.document.sections[section_idx]
+                .paragraphs
+                .get(reflow_idx)
+                .and_then(crate::renderer::composer::paragraph_flow_end);
             if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
                 self.reflow_paragraph(section_idx, reflow_idx);
             }
@@ -2045,6 +2145,7 @@ impl DocumentCore {
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_idx,
                 None,
+                stored_end_for_reset,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,
@@ -2112,7 +2213,8 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             reflow_target,
-            Some(para_idx),
+            Some(para_idx..para_idx + 1),
+            None,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,
@@ -2134,7 +2236,8 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_target,
-                Some(para_idx),
+                Some(para_idx..para_idx + 1),
+                None,
                 &self.styles,
                 self.dpi,
                 self.document.is_hwp3_variant,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -487,6 +487,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -505,6 +509,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -597,6 +605,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -615,6 +627,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -1258,6 +1274,10 @@ impl DocumentCore {
                     crate::renderer::composer::recalculate_section_vpos(
                         &mut self.document.sections[section_idx].paragraphs,
                         start_para,
+                        None,
+                        &self.styles,
+                        self.dpi,
+                        self.document.is_hwp3_variant,
                     );
                 }
                 // 변경 문단만 재구성
@@ -1298,6 +1318,10 @@ impl DocumentCore {
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     start_para,
+                    None,
+                    &self.styles,
+                    self.dpi,
+                    self.document.is_hwp3_variant,
                 );
                 // 병합된 문단 재구성
                 self.recompose_paragraph(section_idx, start_para);
@@ -1432,6 +1456,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
+                Some(new_para_idx),
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.insert_composed_paragraph(section_idx, new_para_idx);
             self.paginate_if_needed();
@@ -1450,6 +1478,10 @@ impl DocumentCore {
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     para_idx,
+                    Some(new_para_idx),
+                    &self.styles,
+                    self.dpi,
+                    self.document.is_hwp3_variant,
                 );
                 self.recompose_paragraph(section_idx, new_para_idx);
                 self.paginate_if_needed();
@@ -1498,6 +1530,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
+                Some(new_para_idx),
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.insert_composed_paragraph(section_idx, new_para_idx);
             self.paginate_if_needed();
@@ -1546,6 +1582,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
+            Some(new_para_idx),
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.insert_composed_paragraph(section_idx, new_para_idx);
@@ -1566,6 +1606,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
+                Some(new_para_idx),
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.recompose_paragraph(section_idx, new_para_idx);
@@ -1637,6 +1681,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
+            Some(new_para_idx),
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
 
         // 전체 구역 재구성 + 재페이지네이션
@@ -1701,6 +1749,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
+            Some(new_para_idx),
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
 
         self.recompose_section(section_idx);
@@ -1844,6 +1896,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.remove_composed_paragraph(section_idx, para_idx);
             self.recompose_paragraph(section_idx, prev_idx);
@@ -1870,6 +1926,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             prev_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.remove_composed_paragraph(section_idx, para_idx);
         self.recompose_paragraph(section_idx, prev_idx);
@@ -1889,6 +1949,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.recompose_paragraph(section_idx, prev_idx);
             self.paginate_if_needed();
@@ -1954,6 +2018,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             reflow_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
             self.recompose_paragraph(section_idx, reflow_idx);
@@ -1976,6 +2044,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_idx,
+                None,
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
                 self.recompose_paragraph(section_idx, reflow_idx);
@@ -2040,6 +2112,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             reflow_target,
+            Some(para_idx),
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.insert_composed_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -2058,6 +2134,10 @@ impl DocumentCore {
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_target,
+                Some(para_idx),
+                &self.styles,
+                self.dpi,
+                self.document.is_hwp3_variant,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -96,11 +96,16 @@ impl DocumentCore {
             )?
         };
 
+        // [Task #2299] 리셋 판별용 — reflow 이전 저장 흐름 end 캡처.
+        let stored_end_for_reset = crate::renderer::composer::paragraph_flow_end(
+            &self.document.sections[section_idx].paragraphs[para_idx],
+        );
         self.reflow_paragraph(section_idx, para_idx);
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
             None,
+            stored_end_for_reset,
             &self.styles,
             self.dpi,
             self.document.is_hwp3_variant,

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -100,6 +100,10 @@ impl DocumentCore {
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
+            None,
+            &self.styles,
+            self.dpi,
+            self.document.is_hwp3_variant,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -813,8 +813,15 @@ impl Paragraph {
             tag,
             ..Default::default()
         }];
+        // [Task #2299] 앞 절반은 원본 첫 LineSeg 의 vertical_pos 를 유지한다 —
+        // 분할해도 문단의 첫 줄 위치는 변하지 않고, 저장 vpos 가 단/쪽 리셋 인코딩인
+        // 문단(예: 다단 col1 첫 문단)을 분할해도 그 신호가 살아남아야 한다.
+        // 새 절반의 vpos=0 은 배치 전 placeholder 로, 호출측 recalc 가
+        // ignore_reset_at 으로 흐름에 연결한다.
+        let orig_vpos = orig_line_seg.as_ref().map(|o| o.vertical_pos).unwrap_or(0);
         self.line_segs = vec![LineSeg {
             text_start: 0,
+            vertical_pos: orig_vpos,
             line_height: lh,
             text_height: th,
             baseline_distance: bd,

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -990,8 +990,14 @@ impl Paragraph {
             ),
             _ => (400, 400, 320, 0, 0, LineSeg::TAG_SINGLE_SEGMENT_LINE),
         };
+        // [Task #2299] split_at 과 동일하게 호스트(self)의 원본 vertical_pos 를
+        // 유지한다 — 병합해도 문단 첫 줄 위치는 변하지 않으며, 0 placeholder 로
+        // 재생성하면 편집발 vpos 재계산이 이를 저장 단/쪽 리셋으로 오인해 병합
+        // 문단을 구역 상단 좌표에 동결시킨다 (밴드 내 range-delete 시 +1 팬텀 쪽).
+        let orig_vpos = orig_line_seg.as_ref().map(|o| o.vertical_pos).unwrap_or(0);
         self.line_segs = vec![LineSeg {
             text_start: 0,
+            vertical_pos: orig_vpos,
             line_height: lh,
             text_height: th,
             baseline_distance: bd,

--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -2346,8 +2346,8 @@ mod line_breaking;
 pub mod lineseg_compare;
 
 pub(crate) use line_breaking::{
-    is_line_end_forbidden, is_line_start_forbidden, recalculate_section_vpos, reflow_line_segs,
-    tokenize_paragraph, BreakToken,
+    is_line_end_forbidden, is_line_start_forbidden, paragraph_flow_end, recalculate_section_vpos,
+    reflow_line_segs, tokenize_paragraph, BreakToken,
 };
 
 #[cfg(test)]

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1274,26 +1274,47 @@ pub(crate) fn reflow_line_segs(
 /// [Task #2299] 저장 vpos 리셋(단/쪽 경계 인코딩) 보존: 편집발 재계산이 구역 전체를
 /// 선형 누적 좌표로 이어붙이면 다단 zone 의 단-상대 리셋(급감)이 소멸해
 /// typeset(#321/#470/#702)·pagination 의 단/쪽 진행 신호가 무력화된다
-/// (shortcut.hwp 앞문단 편집 시 col=[0,1]→[0], 7→9쪽). 직전 문단의 "이동 전(저장)"
-/// end 대비 현재 문단의 저장 first 가 감소하면 경계 인코딩으로 보고 next_vpos 를
-/// 저장 first 로 되돌려 보존한다. 저장 좌표는 밴드 내 정상 흐름에서 단조 증가하므로
-/// 감소 감지에 임계가 필요 없고, 유사-감소(#418 부분표 잔재)도 "보존=원본 유지"라
-/// 동작이 변하지 않는다.
+/// (shortcut.hwp 앞문단 편집 시 col=[0,1]→[0], 7→9쪽). 현재 문단의 저장 first 가
+/// 직전 문단의 "이동 전(저장)" end 보다 감소하면 경계 인코딩으로 보고 delta=0 으로
+/// 보존한다. 저장 좌표는 밴드 내 정상 흐름에서 단조 증가하므로 감소 감지에 임계가
+/// 필요 없다.
 ///
-/// 단, split/insert 가 방금 만든 신규 문단의 vpos=0 은 "아직 배치 전" placeholder 이지
+/// 좌표 갱신은 경계 성격별로 셋으로 나뉜다.
+///
+/// - **리셋 경계**: delta=0 보존.
+/// - **변조 인접 경계**(현재 문단이 편집 대상 `start_para` 이거나 신규
+///   문단(`ignore_reset_range`)이거나, 직전 문단이 그중 하나): 직전 이동 후 end 에
+///   문단 여백 gap(spacing_after + spacing_before, 셀 recalc `boundary_gaps` 동일
+///   산식)을 더해 다시 잇는다. reflow/신규 생성으로 저장 gap 이 소실된 경계라
+///   스타일에서 재유도한다. gap 없는 abutment 는 문단 간격을 압축해 near-top
+///   리셋(#1086/#1921)의 `prev_vpos_end > 60000` 임계를 무너뜨렸다
+///   (SO-SUEOP.hwpx 46→44).
+/// - **미변조 연속 경계**: 직전 문단의 delta 를 그대로 캐리해 저장(또는 로드 합성
+///   #927) 문단 간격을 정확히 보존한다. 스타일 gap 재유도는 저장 gap 과의
+///   오차(px 왕복 절삭 ±1HU, 스타일-저장 불일치)를 밴드 전체에 누적시키고 로드
+///   합성 gap-less 체인과도 어긋나므로 쓰지 않는다. delta==0 이면 순수 no-op.
+///
+/// 리셋 감지는 저장 좌표끼리의 비교여야 한다. 직전 문단이 변조 대상이면 그 end 는
+/// 저장 좌표가 아니므로(성장 편집이 다음 문단을 가짜 리셋으로 동결시키고,
+/// placeholder 는 기준을 붕괴시킨다) reflow 가 보존하는 **first** 로 비교한다.
+/// 미변조 경계는 end 기준을 유지한다(연속 0-first 밴드 감지에 필요).
+///
+/// placeholder 저지선 2종: ① split/insert/paste 가 방금 만든 신규 문단의 vpos=0 은
 /// 경계 인코딩이 아니다 — 보존하면 문단마다 가짜 쪽나눔이 생긴다
-/// (test_page_boundary_with_incremental_spacing_increase 핀). 호출자가 해당 문단
-/// 인덱스를 `ignore_reset_at` 으로 지정하면 그 문단은 보존 없이 흐름에 연결한다
-/// (셀 경로 `recalculate_cell_paragraph_vpos` 의 동명 파라미터와 동일 관례).
+/// (test_page_boundary_with_incremental_spacing_increase 핀). 호출자가 신규 구간을
+/// `ignore_reset_range` 로 지정하면 보존 없이 흐름에 연결한다(셀 경로
+/// `recalculate_cell_paragraph_vpos` 의 ignore_reset_at 과 동일 취지, 다중 삽입을
+/// 위해 범위형). ② lineseg 부재였다가 on-demand reflow(#177/#927)로 합성된
+/// seg(TAG_IMPLEMENTATION_PROPERTY, #1811)도 보존하지 않는다.
 ///
-/// 문단 경계에는 셀 경로와 동일하게 문단 여백(spacing_after + spacing_before)을
-/// gap 으로 더한다. 종전의 gap 없는 abutment 는 저장 vpos 의 문단 간격을 경계마다
-/// 압축해, near-top 리셋(#1086/#1921)의 `prev_vpos_end > 60000` 임계를 무너뜨리고
-/// 쪽 병합을 유발했다 (SO-SUEOP.hwpx 편집 시 46→44).
+/// 줄 전진량은 로드 경로(document.rs 의 vpos 체인)와 동일하게 TAC 호스트
+/// 줄(lh>th)을 th 기준으로 센다 — lh 기준이면 인라인 개체 호스트의 end 가 저장
+/// 후속 first 를 넘어서 가짜 리셋을 만든다.
 pub(crate) fn recalculate_section_vpos(
     paragraphs: &mut [Paragraph],
     start_para: usize,
-    ignore_reset_at: Option<usize>,
+    ignore_reset_range: Option<std::ops::Range<usize>>,
+    start_stored_end: Option<i32>,
     styles: &ResolvedStyleSet,
     dpi: f64,
     is_hwp3_variant: bool,
@@ -1320,17 +1341,33 @@ pub(crate) fn recalculate_section_vpos(
         px_to_hwpunit(spacing_after + spacing_before, dpi)
     };
 
-    // 직전 문단(마지막 비어있지 않은 lineseg 보유 문단) 인덱스와 그 vpos_end.
-    // start_para 이전 문단들은 이 호출에서 이동하지 않으므로 현재 좌표가 곧 저장 좌표다.
-    // [Task #2299] orig_prev_end 는 "이동 전(저장)" end — 리셋(급감) 감지 기준.
-    let mut prev_idx: Option<usize> = paragraphs[..start_para]
-        .iter()
-        .rposition(|p| !p.line_segs.is_empty());
+    // 줄 전진량 — 로드 경로와 동일한 TAC th-관례. saturating: 조작 파일의 극단
+    // spacing/좌표로 i32 가 넘치지 않게 한다 (release wasm 은 overflow-check 가
+    // 없어 무음 랩 → 전 문단 오판으로 이어진다).
+    let seg_advance = |ls: &LineSeg| -> i32 {
+        let height = if ls.line_height > ls.text_height && ls.text_height > 0 {
+            ls.text_height
+        } else {
+            ls.line_height
+        };
+        height.saturating_add(ls.line_spacing)
+    };
     let seg_end = |p: &Paragraph| -> Option<i32> {
         p.line_segs
             .last()
-            .map(|ls| ls.vertical_pos + ls.line_height + ls.line_spacing)
+            .map(|ls| ls.vertical_pos.saturating_add(seg_advance(ls)))
     };
+    let is_ignored = |pi: usize| {
+        ignore_reset_range
+            .as_ref()
+            .is_some_and(|range| range.contains(&pi))
+    };
+
+    // 직전 문단(마지막 비어있지 않은 lineseg 보유 문단) 인덱스.
+    // start_para 이전 문단들은 이 호출에서 이동하지 않으므로 현재 좌표가 곧 저장 좌표다.
+    let mut prev_idx: Option<usize> = paragraphs[..start_para]
+        .iter()
+        .rposition(|p| !p.line_segs.is_empty());
     let mut next_vpos = match prev_idx {
         Some(pp) => seg_end(&paragraphs[pp]).unwrap_or(0),
         // 첫 문단: 기존 vpos 유지
@@ -1340,55 +1377,94 @@ pub(crate) fn recalculate_section_vpos(
             .map(|ls| ls.vertical_pos)
             .unwrap_or(0),
     };
+    // 리셋 감지 기준 — 직전 문단의 "이동 전(저장)" first/end.
+    let mut orig_prev_first: Option<i32> = prev_idx
+        .and_then(|pp| paragraphs[pp].line_segs.first())
+        .map(|ls| ls.vertical_pos);
     let mut orig_prev_end: Option<i32> = prev_idx.and_then(|pp| seg_end(&paragraphs[pp]));
+    // 직전 문단이 이번 편집의 변조 대상이었는가 + 직전 문단에 적용된 delta.
+    let mut prev_modified = false;
+    let mut prev_delta: i32 = 0;
 
     for pi in start_para..paragraphs.len() {
         if paragraphs[pi].line_segs.is_empty() {
             continue;
         }
 
-        // 문단 경계 gap: 직전 lineseg 보유 문단과의 여백 (start 직전 경계 포함).
-        // 직전 문단이 없으면(구역 첫 문단) 경계 자체가 없어 0.
-        let gap = prev_idx
-            .map(|pp| boundary_gap(&paragraphs[pp], &paragraphs[pi]))
-            .unwrap_or(0);
-        let base = next_vpos + gap;
+        let para_modified = pi == start_para || is_ignored(pi);
+        let current_start = paragraphs[pi].line_segs[0].vertical_pos;
+        let is_original_lineseg =
+            paragraphs[pi].line_segs[0].tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0;
 
-        let para = &mut paragraphs[pi];
-        // 현재 문단의 vpos 시작값과의 차이 계산
-        let current_start = para.line_segs[0].vertical_pos;
-        // [Task #2299] 저장 first 가 직전 저장 end 보다 작으면 단/쪽 리셋 경계 —
-        // 누적 좌표로 덮지 않고 저장 좌표를 그대로 유지한다(delta=0).
-        // placeholder 저지선 2종: ① split/insert 직후 신규 문단(ignore_reset_at)
-        // 의 vpos=0, ② lineseg 부재였다가 on-demand reflow(#177/#927)로 합성된
-        // seg(TAG_IMPLEMENTATION_PROPERTY, #1811)의 vpos_start=0 — 둘 다 경계
-        // 인코딩이 아니므로 보존하지 않고 흐름에 연결한다.
-        let is_original_lineseg = para.line_segs[0].tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0;
-        let delta = if is_original_lineseg
-            && ignore_reset_at != Some(pi)
-            && orig_prev_end.is_some_and(|prev_end| current_start < prev_end)
-        {
-            0
+        // 리셋 감지: 신규 문단(placeholder)·합성 seg 는 제외. 기준은 직전 문단의
+        // "저장" 좌표여야 한다 — 직전이 편집 문단(start_para)이면 reflow 로 end 가
+        // 이미 변조됐으므로 호출자가 캡처해 준 reflow 이전 저장 end 를 쓰고(성장
+        // 편집의 가짜 리셋과 저장-겹침 문서의 정당한 리셋을 모두 정확히 판별),
+        // 없으면 reflow 가 보존하는 first 로 보수적으로 비교한다. 신규 문단이
+        // 직전이면 placeholder 라 first(=0) 기준. 미변조 경계는 end 기준을
+        // 유지한다(연속 0-first 밴드 감지에 필요).
+        let prev_stored_bound = if prev_idx == Some(start_para) && !is_ignored(start_para) {
+            start_stored_end.or(orig_prev_first)
+        } else if prev_modified {
+            orig_prev_first
         } else {
-            base - current_start
+            orig_prev_end
         };
-        // 다음 문단의 리셋 감지 기준은 "이동 전(저장)" end 로 기록한다.
-        let orig_end = seg_end(para);
+        let is_reset = is_original_lineseg
+            && !is_ignored(pi)
+            && prev_stored_bound.is_some_and(|bound| current_start < bound);
+
+        let delta = if is_reset {
+            // 단/쪽 리셋 경계 — 저장 좌표 유지.
+            0
+        } else if para_modified || prev_modified {
+            // 변조 인접 경계 — 이동 후 흐름에 스타일 여백 gap 으로 다시 잇는다.
+            let gap = prev_idx
+                .map(|pp| boundary_gap(&paragraphs[pp], &paragraphs[pi]))
+                .unwrap_or(0);
+            next_vpos.saturating_add(gap) - current_start
+        } else {
+            // 미변조 연속 경계 — 직전 delta 캐리로 기존 간격을 정확히 보존.
+            prev_delta
+        };
+
+        // 다음 문단의 리셋 감지 기준은 "이동 전(저장)" first/end 로 기록한다.
+        let orig_first = current_start;
+        let orig_end = seg_end(&paragraphs[pi]);
 
         if delta != 0 {
             // 모든 LineSeg의 vpos를 delta만큼 이동
-            for seg in &mut para.line_segs {
-                seg.vertical_pos += delta;
+            for seg in &mut paragraphs[pi].line_segs {
+                seg.vertical_pos = seg.vertical_pos.saturating_add(delta);
             }
         }
 
         // 다음 문단의 시작 vpos 계산 (이동 후 end = 저장 end + delta)
         if let Some(end) = orig_end {
-            next_vpos = end + delta;
+            next_vpos = end.saturating_add(delta);
         }
+        orig_prev_first = Some(orig_first);
         orig_prev_end = orig_end;
+        prev_modified = para_modified;
+        prev_delta = delta;
         prev_idx = Some(pi);
     }
+}
+
+/// [Task #2299] 문단의 흐름 end (마지막 LineSeg 의 vpos + 전진량, TAC th-관례).
+/// 편집 호출자가 reflow 이전에 캡처해 `recalculate_section_vpos` 의
+/// `start_stored_end` 로 전달하기 위한 헬퍼 — reflow 가 end 를 덮은 뒤에는 저장
+/// 좌표를 복원할 수 없다.
+pub(crate) fn paragraph_flow_end(para: &Paragraph) -> Option<i32> {
+    para.line_segs.last().map(|ls| {
+        let height = if ls.line_height > ls.text_height && ls.text_height > 0 {
+            ls.text_height
+        } else {
+            ls.line_height
+        };
+        ls.vertical_pos
+            .saturating_add(height.saturating_add(ls.line_spacing))
+    })
 }
 
 /// font_size(px)를 LineSeg의 line_height(HWPUNIT)로 변환한다.

--- a/src/renderer/composer/line_breaking.rs
+++ b/src/renderer/composer/line_breaking.rs
@@ -1270,56 +1270,124 @@ pub(crate) fn reflow_line_segs(
 ///
 /// `start_para`부터 구역 끝까지 각 문단의 vpos를 이전 문단의 vpos_end 기준으로 재계산.
 /// 표 등 특수 문단의 line_height는 보존하고 vpos만 갱신한다.
-pub(crate) fn recalculate_section_vpos(paragraphs: &mut [Paragraph], start_para: usize) {
+///
+/// [Task #2299] 저장 vpos 리셋(단/쪽 경계 인코딩) 보존: 편집발 재계산이 구역 전체를
+/// 선형 누적 좌표로 이어붙이면 다단 zone 의 단-상대 리셋(급감)이 소멸해
+/// typeset(#321/#470/#702)·pagination 의 단/쪽 진행 신호가 무력화된다
+/// (shortcut.hwp 앞문단 편집 시 col=[0,1]→[0], 7→9쪽). 직전 문단의 "이동 전(저장)"
+/// end 대비 현재 문단의 저장 first 가 감소하면 경계 인코딩으로 보고 next_vpos 를
+/// 저장 first 로 되돌려 보존한다. 저장 좌표는 밴드 내 정상 흐름에서 단조 증가하므로
+/// 감소 감지에 임계가 필요 없고, 유사-감소(#418 부분표 잔재)도 "보존=원본 유지"라
+/// 동작이 변하지 않는다.
+///
+/// 단, split/insert 가 방금 만든 신규 문단의 vpos=0 은 "아직 배치 전" placeholder 이지
+/// 경계 인코딩이 아니다 — 보존하면 문단마다 가짜 쪽나눔이 생긴다
+/// (test_page_boundary_with_incremental_spacing_increase 핀). 호출자가 해당 문단
+/// 인덱스를 `ignore_reset_at` 으로 지정하면 그 문단은 보존 없이 흐름에 연결한다
+/// (셀 경로 `recalculate_cell_paragraph_vpos` 의 동명 파라미터와 동일 관례).
+///
+/// 문단 경계에는 셀 경로와 동일하게 문단 여백(spacing_after + spacing_before)을
+/// gap 으로 더한다. 종전의 gap 없는 abutment 는 저장 vpos 의 문단 간격을 경계마다
+/// 압축해, near-top 리셋(#1086/#1921)의 `prev_vpos_end > 60000` 임계를 무너뜨리고
+/// 쪽 병합을 유발했다 (SO-SUEOP.hwpx 편집 시 46→44).
+pub(crate) fn recalculate_section_vpos(
+    paragraphs: &mut [Paragraph],
+    start_para: usize,
+    ignore_reset_at: Option<usize>,
+    styles: &ResolvedStyleSet,
+    dpi: f64,
+    is_hwp3_variant: bool,
+) {
     if paragraphs.is_empty() || start_para >= paragraphs.len() {
         return;
     }
 
-    // 시작 문단의 초기 vpos 결정
-    let mut next_vpos = if start_para > 0 {
-        // 이전 문단의 마지막 LineSeg에서 vpos_end 계산
-        let prev = &paragraphs[start_para - 1];
-        if let Some(last_seg) = prev.line_segs.last() {
-            last_seg.vertical_pos + last_seg.line_height + last_seg.line_spacing
-        } else {
-            0
-        }
-    } else {
+    // 문단 경계 gap (HWPUNIT) = 앞 문단 spacing_after + 뒤 문단 spacing_before.
+    // recalculate_cell_paragraph_vpos 의 boundary_gaps 와 동일 산식.
+    let boundary_gap = |prev: &Paragraph, curr: &Paragraph| -> i32 {
+        let spacing_after = styles
+            .para_styles
+            .get(prev.para_shape_id as usize)
+            .map(|style| style.spacing_after)
+            .unwrap_or(0.0);
+        let spacing_before = styles
+            .para_styles
+            .get(curr.para_shape_id as usize)
+            .map(|style| style.spacing_before)
+            .unwrap_or(0.0);
+        let spacing_before =
+            crate::renderer::hwp3_variant_flow_spacing_before(spacing_before, is_hwp3_variant);
+        px_to_hwpunit(spacing_after + spacing_before, dpi)
+    };
+
+    // 직전 문단(마지막 비어있지 않은 lineseg 보유 문단) 인덱스와 그 vpos_end.
+    // start_para 이전 문단들은 이 호출에서 이동하지 않으므로 현재 좌표가 곧 저장 좌표다.
+    // [Task #2299] orig_prev_end 는 "이동 전(저장)" end — 리셋(급감) 감지 기준.
+    let mut prev_idx: Option<usize> = paragraphs[..start_para]
+        .iter()
+        .rposition(|p| !p.line_segs.is_empty());
+    let seg_end = |p: &Paragraph| -> Option<i32> {
+        p.line_segs
+            .last()
+            .map(|ls| ls.vertical_pos + ls.line_height + ls.line_spacing)
+    };
+    let mut next_vpos = match prev_idx {
+        Some(pp) => seg_end(&paragraphs[pp]).unwrap_or(0),
         // 첫 문단: 기존 vpos 유지
-        paragraphs[0]
+        None => paragraphs[start_para]
             .line_segs
             .first()
             .map(|ls| ls.vertical_pos)
-            .unwrap_or(0)
+            .unwrap_or(0),
     };
+    let mut orig_prev_end: Option<i32> = prev_idx.and_then(|pp| seg_end(&paragraphs[pp]));
 
     for pi in start_para..paragraphs.len() {
-        let para = &mut paragraphs[pi];
-        if para.line_segs.is_empty() {
+        if paragraphs[pi].line_segs.is_empty() {
             continue;
         }
 
+        // 문단 경계 gap: 직전 lineseg 보유 문단과의 여백 (start 직전 경계 포함).
+        // 직전 문단이 없으면(구역 첫 문단) 경계 자체가 없어 0.
+        let gap = prev_idx
+            .map(|pp| boundary_gap(&paragraphs[pp], &paragraphs[pi]))
+            .unwrap_or(0);
+        let base = next_vpos + gap;
+
+        let para = &mut paragraphs[pi];
         // 현재 문단의 vpos 시작값과의 차이 계산
         let current_start = para.line_segs[0].vertical_pos;
-        let delta = next_vpos - current_start;
+        // [Task #2299] 저장 first 가 직전 저장 end 보다 작으면 단/쪽 리셋 경계 —
+        // 누적 좌표로 덮지 않고 저장 좌표를 그대로 유지한다(delta=0).
+        // placeholder 저지선 2종: ① split/insert 직후 신규 문단(ignore_reset_at)
+        // 의 vpos=0, ② lineseg 부재였다가 on-demand reflow(#177/#927)로 합성된
+        // seg(TAG_IMPLEMENTATION_PROPERTY, #1811)의 vpos_start=0 — 둘 다 경계
+        // 인코딩이 아니므로 보존하지 않고 흐름에 연결한다.
+        let is_original_lineseg = para.line_segs[0].tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0;
+        let delta = if is_original_lineseg
+            && ignore_reset_at != Some(pi)
+            && orig_prev_end.is_some_and(|prev_end| current_start < prev_end)
+        {
+            0
+        } else {
+            base - current_start
+        };
+        // 다음 문단의 리셋 감지 기준은 "이동 전(저장)" end 로 기록한다.
+        let orig_end = seg_end(para);
 
-        // 변화 없으면 건너뛰기 (성능 최적화)
-        if delta == 0 {
-            if let Some(last_seg) = para.line_segs.last() {
-                next_vpos = last_seg.vertical_pos + last_seg.line_height + last_seg.line_spacing;
+        if delta != 0 {
+            // 모든 LineSeg의 vpos를 delta만큼 이동
+            for seg in &mut para.line_segs {
+                seg.vertical_pos += delta;
             }
-            continue;
         }
 
-        // 모든 LineSeg의 vpos를 delta만큼 이동
-        for seg in &mut para.line_segs {
-            seg.vertical_pos += delta;
+        // 다음 문단의 시작 vpos 계산 (이동 후 end = 저장 end + delta)
+        if let Some(end) = orig_end {
+            next_vpos = end + delta;
         }
-
-        // 다음 문단의 시작 vpos 계산
-        if let Some(last_seg) = para.line_segs.last() {
-            next_vpos = last_seg.vertical_pos + last_seg.line_height + last_seg.line_spacing;
-        }
+        orig_prev_end = orig_end;
+        prev_idx = Some(pi);
     }
 }
 

--- a/tests/issue_2299_edit_vpos_reset_preserve.rs
+++ b/tests/issue_2299_edit_vpos_reset_preserve.rs
@@ -77,6 +77,16 @@ fn editing_reset_paragraph_itself_preserves_layout() {
     // 리셋 문단 자체를 편집해도 reflow 가 첫 LineSeg vpos 를 보존하고
     // 재계산이 그 리셋을 유지해야 한다.
     let mut doc = load_shortcut();
+    // 전제 고정: 픽스처/파서 드리프트로 pi=16 이 리셋 문단이 아니게 되면 이
+    // 테스트는 front-edit 케이스의 중복으로 퇴화한다 — 명시적으로 단언한다.
+    assert_eq!(
+        doc.document().sections[0].paragraphs[16]
+            .line_segs
+            .first()
+            .map(|ls| ls.vertical_pos),
+        Some(0),
+        "전제: pi=16 은 저장 vpos=0 리셋 문단이어야 함 (픽스처 드리프트 감지)"
+    );
     doc.insert_text_native(0, 16, 0, "X")
         .expect("insert at reset para");
     assert_eq!(doc.page_count(), 7, "리셋 문단 자체 편집 후에도 7쪽 유지");
@@ -95,4 +105,154 @@ fn last_paragraph_edit_stays_stable() {
     doc.insert_text_native(0, last, 0, "X")
         .expect("insert at last para");
     assert_eq!(doc.page_count(), 7, "끝 문단 편집은 7쪽 불변");
+}
+
+/// 본문 문단 vpos 의 무겹침 불변식: 각 문단은 직전 문단 흐름 end 이후에서
+/// 시작하거나(연속), 직전 first 이하로 내려간 깨끗한 리셋(단/쪽 경계)이어야 한다.
+/// 가짜-핀 회귀(성장 편집·삽입·붙여넣기 고착)는 prev_first < current < prev_end
+/// 의 "중간 동결"을 만들므로 이 단언이 잡는다.
+fn assert_no_mid_freeze(doc: &HwpDocument, label: &str) {
+    let paras = &doc.document().sections[0].paragraphs;
+    let mut prev: Option<(usize, i32, i32)> = None; // (pi, first, end)
+    for (pi, p) in paras.iter().enumerate() {
+        let Some(first_seg) = p.line_segs.first() else {
+            continue;
+        };
+        let first = first_seg.vertical_pos;
+        let last = p.line_segs.last().unwrap();
+        let advance = if last.line_height > last.text_height && last.text_height > 0 {
+            last.text_height + last.line_spacing
+        } else {
+            last.line_height + last.line_spacing
+        };
+        let end = last.vertical_pos + advance;
+        if let Some((ppi, prev_first, prev_end)) = prev {
+            assert!(
+                first >= prev_end || first <= prev_first,
+                "{label}: pi={pi} first={first} 가 직전 pi={ppi} 구간({prev_first}..{prev_end}) \
+                 안에 동결됨 — 가짜 리셋 핀(#2314 리뷰 확증 회귀)"
+            );
+        }
+        prev = Some((pi, first, end));
+    }
+}
+
+#[test]
+fn growth_edit_pushes_followers_down() {
+    // [리뷰 확증 회귀 1] 문단이 저장 gap 보다 크게 자라는 편집(줄바꿈 유발) 후에도
+    // 다음 문단이 가짜 리셋으로 동결되지 않고 아래로 밀려야 한다.
+    let bytes = std::fs::read("samples/basic/english.hwp").expect("read english.hwp");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse english.hwp");
+    let long = "가나다라마바사아자차카타파하 ".repeat(20);
+    doc.insert_text_native(0, 2, 0, &long).expect("grow para 2");
+
+    let paras = &doc.document().sections[0].paragraphs;
+    let p2_last = paras[2].line_segs.last().unwrap();
+    let p2_end = p2_last.vertical_pos + p2_last.line_height + p2_last.line_spacing;
+    let p3_first = paras[3].line_segs.first().unwrap().vertical_pos;
+    assert!(
+        p3_first >= p2_end,
+        "성장 편집 후 다음 문단이 밀려야 함: p3_first={p3_first} < p2_end={p2_end} (동결 회귀)"
+    );
+    assert_no_mid_freeze(&doc, "growth_edit");
+}
+
+#[test]
+fn insert_empty_paragraph_pushes_displaced_paragraph_down() {
+    // [리뷰 확증 회귀 2] 빈 문단 삽입 시 밀려난 후속 문단(저장 vpos 0)이 신규
+    // placeholder 와 겹치지 않고 아래로 이동해야 한다.
+    let bytes = std::fs::read("samples/basic/english.hwp").expect("read english.hwp");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse english.hwp");
+    let pages_before = doc.page_count();
+    doc.insert_paragraph_native(0, 0)
+        .expect("insert empty at 0");
+
+    let paras = &doc.document().sections[0].paragraphs;
+    let p0_last = paras[0].line_segs.last().unwrap();
+    let p0_end = p0_last.vertical_pos + p0_last.line_height + p0_last.line_spacing;
+    let p1_first = paras[1].line_segs.first().unwrap().vertical_pos;
+    assert!(
+        p1_first >= p0_end,
+        "삽입 후 기존 첫 문단이 밀려야 함: p1_first={p1_first} < p0_end={p0_end} (겹침 회귀)"
+    );
+    // 빈 줄 1개가 정당하게 만들 수 있는 증가는 최대 1쪽 (넘침).
+    let pages_after_insert = doc.page_count();
+    assert!(
+        pages_after_insert <= pages_before + 1,
+        "빈 문단 1개 삽입에 쪽수 {pages_before}→{pages_after_insert} — 팬텀 쪽나눔 회귀"
+    );
+    assert_no_mid_freeze(&doc, "insert_empty_paragraph");
+
+    // 고착류 회귀는 후속 편집마다 팬텀이 증식한다 — 편집 후 쪽수 안정성을 고정.
+    doc.insert_text_native(0, 2, 0, "X").expect("edit below");
+    assert_eq!(
+        doc.page_count(),
+        pages_after_insert,
+        "후속 1자 편집으로 쪽수 변동 — placeholder 고착 회귀"
+    );
+    assert_no_mid_freeze(&doc, "insert_then_edit");
+}
+
+#[test]
+fn paste_then_edit_does_not_entrench_placeholders() {
+    // [리뷰 확증 회귀 3] 다중 문단 붙여넣기가 남긴 신규 문단 좌표가 이후 편집에서
+    // 가짜 리셋으로 고착되지 않아야 한다 (붙여넣기 직후 흐름 재연결 계약).
+    let mut doc = load_shortcut();
+    doc.copy_selection_native(0, 2, 0, 4, 1).expect("copy");
+    doc.paste_internal_native(0, 98, 0).expect("paste");
+    assert_no_mid_freeze(&doc, "after_paste");
+    // 붙여넣기 직후 신규 문단이 흐름 좌표에 연결돼야 한다 — placeholder 0 이
+    // 남으면 "깨끗한 리셋"으로 위장해 무겹침 단언을 통과하면서 이후 편집에서
+    // 가짜 단/쪽 경계로 굳는다 (리뷰 실측: pi=98/99 가 0 에 고착).
+    for pi in [98usize, 99] {
+        let first = doc.document().sections[0].paragraphs[pi]
+            .line_segs
+            .first()
+            .map(|ls| ls.vertical_pos)
+            .unwrap_or(-1);
+        assert!(
+            first > 0,
+            "붙여넣은 pi={pi} 가 placeholder vpos {first} 에 방치됨 — 흐름 재연결 회귀"
+        );
+    }
+    let pages_after_paste = doc.page_count();
+
+    // 고착류 회귀는 이후 편집이 placeholder 를 가짜 리셋으로 굳히며 쪽수를 바꾼다
+    // (리뷰 실측: 수정 전 paste 후 편집에서 팬텀 쪽 고착). 콘텐츠가 실제로 늘어난
+    // 붙여넣기 자체의 쪽수 증가는 정당하므로, "후속 1자 편집의 쪽수 불변"을 계약으로.
+    doc.insert_text_native(0, 0, 0, "X").expect("edit above");
+    assert_no_mid_freeze(&doc, "after_paste_then_edit");
+    assert_eq!(
+        doc.page_count(),
+        pages_after_paste,
+        "붙여넣기 후 1자 편집으로 쪽수 변동 — placeholder 고착 회귀"
+    );
+}
+
+#[test]
+fn edit_above_tac_host_does_not_pin_follower() {
+    // [리뷰 확증 회귀 4] TAC(글자처럼) 개체 호스트 줄은 저장 vpos 체인이 th 기준
+    // 전진(lh>th)이므로, lh 기준 end 로 리셋을 감지하면 호스트 다음 문단이 가짜
+    // 핀된다. 로드 경로와 동일한 th-관례 전진을 고정한다.
+    for sample in [
+        "samples/tac-verify/scenario-a-before.hwp",
+        "samples/test-image.hwp",
+    ] {
+        let Ok(bytes) = std::fs::read(sample) else {
+            continue;
+        };
+        let Ok(mut doc) = HwpDocument::from_bytes(&bytes) else {
+            continue;
+        };
+        let pages_before = doc.page_count();
+        if doc.insert_text_native(0, 0, 0, "X").is_err() {
+            continue;
+        }
+        assert_no_mid_freeze(&doc, sample);
+        assert_eq!(
+            doc.page_count(),
+            pages_before,
+            "{sample}: 1자 삽입으로 쪽수 변동 — TAC 호스트 가짜 리셋 회귀"
+        );
+    }
 }

--- a/tests/issue_2299_edit_vpos_reset_preserve.rs
+++ b/tests/issue_2299_edit_vpos_reset_preserve.rs
@@ -1,0 +1,98 @@
+//! Issue #2299 — 편집발 vpos 재계산이 저장 단/쪽-상대 vpos 리셋(단 경계 인코딩)을
+//! 파괴해 다단 단-밴드가 소멸하던 회귀 핀.
+//!
+//! shortcut.hwp(1단 제목 + 2단 배분 zone 이 카테고리마다 반복, 저장 리셋 76곳 전부
+//! vpos=0)의 앞 문단을 편집하면 `recalculate_section_vpos` 의 선형 누적이 하류 리셋
+//! 전부를 덮어써 typeset(#321/#470/#702)·pagination 의 단/쪽 진행 신호가 소멸 —
+//! 7쪽(한글 2022 정합)이 9쪽으로, 0쪽 Column 이 col=[0]만으로 붕괴하던 결함.
+//! 편집 문단의 높이가 변하지 않는 편집(1자 삽입)에서도 발생한다.
+//!
+//! 수정: 직전 문단의 "이동 전(저장)" end 대비 현재 문단의 저장 first 가 감소하면
+//! 단/쪽 경계 인코딩으로 보고 next_vpos 를 저장 first 로 되돌려 보존.
+//! 근거·임계 불요 사유는 `recalculate_section_vpos` doc comment 참조.
+
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::wasm_api::HwpDocument;
+
+fn load_shortcut() -> HwpDocument {
+    let bytes = std::fs::read("samples/basic/shortcut.hwp").expect("read shortcut.hwp");
+    HwpDocument::from_bytes(&bytes).expect("parse shortcut.hwp")
+}
+
+fn collect_cols(node: &RenderNode, out: &mut Vec<u16>) {
+    if let RenderNodeType::Column(c) = node.node_type {
+        out.push(c);
+    }
+    for child in &node.children {
+        collect_cols(child, out);
+    }
+}
+
+/// 0쪽 렌더트리의 Column 노드 col 인덱스 나열 (문서 순서).
+fn page0_cols(doc: &HwpDocument) -> Vec<u16> {
+    let tree = doc.build_page_render_tree(0).expect("page 0 render tree");
+    let mut cols = Vec::new();
+    collect_cols(&tree.root, &mut cols);
+    cols
+}
+
+#[test]
+fn front_paragraph_edit_preserves_column_bands_and_page_count() {
+    let mut doc = load_shortcut();
+    assert_eq!(doc.page_count(), 7, "원본 쪽수 전제 (한글 2022 = 7쪽)");
+    let cols_before = page0_cols(&doc);
+    assert!(
+        cols_before.contains(&1),
+        "원본 0쪽에 우측 단(col=1) 밴드 존재 전제: {cols_before:?}"
+    );
+
+    doc.insert_text_native(0, 0, 0, "X").expect("insert");
+
+    assert_eq!(
+        doc.page_count(),
+        7,
+        "앞 문단 1자 삽입 후에도 7쪽 유지 — 9쪽이면 저장 vpos 리셋 파괴(#2299) 회귀"
+    );
+    assert_eq!(
+        page0_cols(&doc),
+        cols_before,
+        "편집 후 0쪽 단-밴드 배치 보존 — col=1 소멸이면 #2299 회귀"
+    );
+}
+
+#[test]
+fn delete_edit_preserves_layout() {
+    let mut doc = load_shortcut();
+    doc.delete_text_native(0, 2, 0, 1).expect("delete");
+    assert_eq!(doc.page_count(), 7, "삭제 편집 후에도 7쪽 유지");
+    assert!(
+        page0_cols(&doc).contains(&1),
+        "삭제 편집 후에도 우측 단(col=1) 밴드 보존"
+    );
+}
+
+#[test]
+fn editing_reset_paragraph_itself_preserves_layout() {
+    // pi=16 은 0쪽 2단 zone 의 col1 첫 문단(저장 vpos=0 리셋 문단).
+    // 리셋 문단 자체를 편집해도 reflow 가 첫 LineSeg vpos 를 보존하고
+    // 재계산이 그 리셋을 유지해야 한다.
+    let mut doc = load_shortcut();
+    doc.insert_text_native(0, 16, 0, "X")
+        .expect("insert at reset para");
+    assert_eq!(doc.page_count(), 7, "리셋 문단 자체 편집 후에도 7쪽 유지");
+    assert!(
+        page0_cols(&doc).contains(&1),
+        "리셋 문단 자체 편집 후에도 col=1 밴드 보존"
+    );
+}
+
+#[test]
+fn last_paragraph_edit_stays_stable() {
+    // 마지막 문단은 아래 재계산 대상이 없어 수정 전에도 7쪽이 유지되던 케이스 —
+    // 보존 로직 추가 후에도 불변임을 고정한다.
+    let mut doc = load_shortcut();
+    let last = doc.document().sections[0].paragraphs.len() - 1;
+    doc.insert_text_native(0, last, 0, "X")
+        .expect("insert at last para");
+    assert_eq!(doc.page_count(), 7, "끝 문단 편집은 7쪽 불변");
+}


### PR DESCRIPTION
관련 이슈: #2299

## 문제

다단 문서의 앞쪽 문단을 편집하면 우측 단-밴드가 소멸하고 단일 단으로 합쳐져 쪽수가 이탈한다 (shortcut.hwp 1자 삽입: 7쪽→9쪽, 0쪽 Column `[0,0,0,1,0,0,1]`→`[0,0,0]`). 편집 문단의 높이가 변하지 않아도 발생하며, 손상은 저장 시 lineseg로 직렬화된다. 같은 기전으로 near-top 리셋(#1086/#1921) 문서는 편집 시 쪽 병합이 발생한다 (SO-SUEOP.hwpx 46→45쪽). samples 80건 편집-스윕에서 **8건이 1자 삽입만으로 쪽수가 변동**했다.

## 원인

`recalculate_section_vpos`(`src/renderer/composer/line_breaking.rs`)가 편집 문단부터 구역 끝까지 모든 문단을 "직전 문단 end에 이어붙이는" 선형 abutment로 재계산하며 저장 신호 2종을 파괴한다.

1. **저장 vpos 리셋(단/쪽 경계 인코딩) 소멸** — shortcut.hwp는 카테고리마다 1단 제목 + 2단 배분(Distribute) zone이 반복되고 리셋 76곳이 전부 vpos=0으로 저장돼 있다. 선형화가 이를 누적 좌표로 덮으면(279/280 문단 변조 실측) typeset(#321/#470/#702)과 pagination이 공유하는 단/쪽 진행 신호 `cv < prev_end`가 다시는 참이 되지 않는다. delta==0 최적화는 문단별 비교라 리셋 문단에서는 반드시 delta>0이 된다.
2. **문단 여백 gap 압축** — 저장 vpos의 문단 간 여백(스타일 spacing 인코딩, SO-SUEOP 실측 700HU/경계)을 경계마다 0으로 밀착시켜, near-top 리셋의 `prev_vpos_end > 60000HU` 임계를 밴드 내 누적 압축으로 무너뜨린다.

이슈 본문의 수정 시도가 남긴 +1쪽 잔여의 원인도 규명했다: #2158 방향의 게이트(쪽 스케일 임계 + first==0 제외)가 이 문서의 리셋 형태(전부 first==0, 밴드 스케일 1,200~21,000HU)와 불일치해 부분 보존에 그친 것 (상세: 이슈 조사 코멘트).

## 변경

- `line_breaking.rs` `recalculate_section_vpos` 재설계:
  - **원본(비합성) lineseg 문단**의 저장 first가 직전 문단의 "이동 전(저장)" end보다 감소하면 단/쪽 경계 인코딩으로 보고 `next_vpos`를 저장 first로 되돌려 보존(delta=0). 저장 좌표는 밴드 내에서 단조 증가하므로 감소 감지에 임계가 불필요하고, 유사-감소(#418 부분표 잔재)도 "보존=원본 유지"라 동작 불변.
  - **placeholder 저지선 2종**: ① on-demand reflow(#177/#927) 합성 seg(`TAG_IMPLEMENTATION_PROPERTY`, #1811)의 vpos=0 ② split/insert 직후 신규 문단 — 호출자가 `ignore_reset_at`으로 지정 (셀 경로 `recalculate_cell_paragraph_vpos`의 동명 파라미터 관례).
  - **문단 경계 여백 gap**(prev `spacing_after` + curr `spacing_before`, hwp3 변환 포함)을 셀 recalc의 `boundary_gaps`와 동일 산식으로 반영.
  - 시그니처 +3 인자(styles/dpi/is_hwp3_variant), 호출부 24곳 갱신(text_editing 20 · field_query/picture/table_ops/document 각 1). 이 함수는 편집·필드 경로 전용이므로 **무편집 로딩/렌더링은 구조적으로 무회귀**.
- `paragraph.rs` `split_at`: 앞 절반 lineseg의 `vertical_pos`를 원본 유지. 종전 0 placeholder는 직후 선형화가 덮어 무해했으나 보존 도입 후 가짜 쪽나눔으로 굳는 문제를 기존 핀(`test_page_boundary_with_incremental_spacing_increase`)이 검출해 정정했다. 밴드 시작 문단을 분할해도 리셋이 살아남는 정합 포함.
- 신규 핀 `tests/issue_2299_edit_vpos_reset_preserve.rs` 4건: 앞 문단 삽입(7쪽 + 0쪽 Column 배치 보존), 삭제 편집, col1 리셋 문단 자체 편집, 끝 문단 불변.

## 검증

devel `6ae8930c` 기준, macOS(Apple Silicon) / node 22, WASM 동 SHA 재빌드(nodejs·web 타깃).

- **수정 전(회귀) 실패 증명**: 소스 수정만 stash 원복 후 신규 핀 실행 → **3 FAIL**(front 9쪽·리셋문단 8쪽·delete, 끝문단 불변 핀만 통과) → 복원 후 **4/4**.
- cargo test 전체: **lib 2267/0 + 통합 전 바이너리 0 실패**. 기존 핀 `test_page_boundary_...`가 구현 중간형(placeholder 미차단)의 가짜 쪽나눔을 실제로 잡아 설계를 교정했다.
- `cargo clippy --lib --tests` 0 경고 / rustfmt(수정 파일 한정) 통과.
- WASM 실동작 6시나리오: insert@p0 / delete@p2 / insert@리셋문단 / insert@끝문단 / 편집→저장→재열기 / 다중 편집 — 전부 **7쪽 + col=[0,0,0,1,0,0,1] 보존** (수정 전 9쪽·col 소멸).
- **samples 80건 편집-스윕**(basic 전체 + <2MB 캡, para0 1자 삽입 전후 쪽수): 수정 전 **8건 변동**(shortcut 7→9, 국립국어원 업무계획 35→38, SO-SUEOP.hwpx 46→45, KTX 27→28, biz_plan 6→7 등) → 수정 후 **80/80 안정**. SO-SUEOP.hwpx의 기존 46→45 결함까지 해소(46→46).
- studio text-flow e2e(headless): **5/5**.

## 범위 외

- 밴드 높이가 실제 변하는 편집의 한컴 대비 단 재배분(리밸런싱) 정합 — 본 수정은 "저장 밴드 구조 보존 + 자연 넘침"까지.
- 로딩 경로(#2158 기수정)와 typeset/pagination 산식은 무변경.
- 한글 편집기의 편집 시 단/쪽 유지 동작 실기 대조는 Windows 환경 부재로 미수행 — 리뷰 시 확인 요청.
- 편집-스윕은 80건 캡(대형 문서 제외) — 전수 아님.
