### PR TITLE
Task #2311: tac 대형 그림 문단 통밀림 수정 — intra-para 리셋 존중 + 유령 높이 계상 제거

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -12514,6 +12514,40 @@ impl TypesetEngine {
             false
         };
 
+        // [#2311] 단일 TAC 표가 후행 줄(ctrl 1:1 lineseg, vpos==0 저장 리셋)에 있고
+        // 선행 줄이 전부 TAC 그림/도형이면, 표는 아래 #1152 intra-para reset 가드가
+        // 자체적으로 새 쪽 이동한다. 이때 pre-flush 를 문단 전체 높이로 판정하면
+        // 잔여 공간에 들어가는 선행 전면 그림까지 통째로 밀려 한글 대비 +1쪽씩
+        // 벌어진다 (10k r15 156744475: 붙임 포스터+차기 붙임 헤더 표 문단 ×2 →
+        // rhwp 5쪽 vs 한글 3쪽, 저장 ls[0] vpos=5435 는 같은 쪽 배치를 명시).
+        // 리셋 이전 줄들의 높이만 fit 기준으로 삼는다.
+        let pre_reset_height_for_fit = if has_tac
+            && tac_count == 1
+            && first_line_tac_height.is_none()
+            && para.text.is_empty()
+            && para.line_segs.len() == para.controls.len()
+        {
+            para.controls
+                .iter()
+                .position(|c| {
+                    matches!(c, Control::Table(t) if self.is_effective_tac_table(para, t, &fmt))
+                })
+                .filter(|&ti| {
+                    ti > 0
+                        && ti <= fmt.line_heights.len()
+                        && para.line_segs.get(ti).map(|s| s.vertical_pos) == Some(0)
+                        && para.controls[..ti].iter().all(|c| match c {
+                            Control::Picture(p) => p.common.treat_as_char,
+                            Control::Shape(s) => s.common().treat_as_char,
+                            _ => false,
+                        })
+                })
+                .map(|ti| (0..ti).map(|li| fmt.line_advance(li)).sum::<f64>())
+        } else {
+            None
+        };
+        let height_for_fit = pre_reset_height_for_fit.unwrap_or(height_for_fit);
+
         // 넘치면 flush (단일 TAC 표만)
         if st.current_height + height_for_fit > st.available_height()
             && !st.current_items.is_empty()
@@ -13103,8 +13137,7 @@ impl TypesetEngine {
         // 새 페이지 상단부터" 라고 명시한 신호. fit 검사는 표 크기가 잔여 영역에
         // 들어가면 통과시키지만 명시 신호를 존중하려면 fit 이전에 advance.
         // 케이스: 2022년 국립국어원 업무계획.hwp pi=586 ci=1 (별첨 박스).
-        if !st.current_items.is_empty()
-            && ctrl_idx > 0
+        let intra_para_reset = ctrl_idx > 0
             && para.text.is_empty()
             && para.line_segs.len() == para.controls.len()
             && para
@@ -13112,8 +13145,8 @@ impl TypesetEngine {
                 .get(ctrl_idx)
                 .map(|s| s.vertical_pos)
                 .unwrap_or(-1)
-                == 0
-        {
+                == 0;
+        if intra_para_reset && !st.current_items.is_empty() {
             st.advance_column_or_new_page();
         }
 
@@ -13155,6 +13188,14 @@ impl TypesetEngine {
             // 분리된 문서에서, 표 자체는 남은 영역에 들어가는데도 spacing 때문에
             // 표가 다음 페이지로 밀린다(2025 donations HWPX pi=25).
             fmt.line_heights[0]
+        } else if intra_para_reset && ctrl_idx < fmt.line_heights.len() {
+            // [#2311] intra-para reset(저장 vpos==0)으로 새 쪽에 온 표는 자신의
+            // 줄(ctrl 1:1 lineseg)부터만 계상한다. 문단 전체 height_for_fit 을
+            // 쓰면 이전 쪽에 남은 선행 줄(전면 tac 그림 등)의 높이가 새 쪽에
+            // 유령 계상되어 후속 문단을 한 쪽 더 밀어낸다 (156744475 4쪽→3쪽).
+            (ctrl_idx..fmt.line_heights.len())
+                .map(|li| fmt.line_advance(li))
+                .sum::<f64>()
         } else if fmt.total_height > 0.0 {
             // 단일 TAC: 호스트 문단의 height_for_fit 사용
             fmt.height_for_fit

--- a/tests/issue_2311_attachment_poster_intra_para_reset.rs
+++ b/tests/issue_2311_attachment_poster_intra_para_reset.rs
@@ -1,0 +1,63 @@
+//! Issue #2311 — 붙임 전면 포스터 문단(tac 그림 + 후행 tac 헤더 표) 통밀림 회귀.
+//!
+//! `samples/task2311/156744475_nano_plan_poster.hwpx` (과기정통부 보도자료)
+//! pi=21: ls[0](vpos=5435, lh=63156) = 전면 포스터 tac 그림,
+//! ls[1](vpos=0) = 붙임2 헤더 tac 표 — 한글 저장 lineseg 는 "그림은 현재
+//! 쪽(붙임1 헤더 아래), 표는 새 쪽"의 intra-para 분할을 명시한다.
+//!
+//! 회귀 시그니처 (수정 전, 10k r15 픽셀 58.91% / PAGE_DELTA +2):
+//! - typeset_table_paragraph pre-flush 가 문단 전체 높이로 fit 판정
+//!   → 포스터까지 새 쪽으로 통밀림 (붙임 헤더만 남은 유령 쪽 생성)
+//! - 표 advance 후 새 쪽에 문단 전체 높이가 유령 계상
+//!   → 후속 그래프 문단들이 또 한 쪽 밀림
+//! - 결과: rhwp 5쪽 vs 한글 3쪽
+//!
+//! 고정: 총 3쪽 + 포스터 그림이 p2(0-based 1), 붙임2 내용이 p3 에 존재.
+
+use std::fs;
+use std::path::Path;
+
+use rhwp::document_core::DocumentCore;
+
+fn core() -> DocumentCore {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join("samples/task2311/156744475_nano_plan_poster.hwpx");
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    DocumentCore::from_bytes(&bytes).expect("parse 156744475_nano_plan_poster.hwpx")
+}
+
+#[test]
+fn issue_2311_poster_doc_paginates_to_three_pages() {
+    let core = core();
+    assert_eq!(
+        core.page_count(),
+        3,
+        "한글 오라클 3쪽 정합 (수정 전 5쪽: 붙임 포스터/그래프 통밀림)"
+    );
+}
+
+#[test]
+fn issue_2311_poster_shape_stays_with_attachment_header() {
+    let core = core();
+    let dump = core.dump_page_items(None);
+    // 페이지 블록별로 분해
+    let mut pages: Vec<&str> = Vec::new();
+    let mut starts: Vec<usize> = dump.match_indices("=== 페이지").map(|(i, _)| i).collect();
+    starts.push(dump.len());
+    for w in starts.windows(2) {
+        pages.push(&dump[w[0]..w[1]]);
+    }
+    assert_eq!(pages.len(), 3, "페이지 블록 3개");
+    // p2: 붙임1 헤더 표(pi=19) + 포스터 그림(pi=21 ci=0)이 같은 쪽
+    assert!(
+        pages[1].contains("pi=19") && pages[1].contains("pi=21 ci=0"),
+        "p2 에 붙임1 헤더(pi=19)와 포스터 그림(pi=21 ci=0)이 함께 있어야 함:\n{}",
+        pages[1]
+    );
+    // p3: 붙임2 헤더 표(pi=21 ci=1)가 새 쪽에서 시작 (저장 lineseg vpos==0 존중)
+    assert!(
+        pages[2].contains("pi=21 ci=1"),
+        "p3 이 붙임2 헤더 표(pi=21 ci=1)로 시작해야 함:\n{}",
+        pages[2]
+    );
+}


### PR DESCRIPTION
## 요약

10k r15 서베이(#2311)에서 확증된 **붙임 포스터 문단 통밀림** 수정 — 전면 tac 그림 + 후행 tac 헤더 표로 구성된 문단에서 한글 저장 lineseg 의 intra-para 분할(그림=현재쪽, 표=새쪽 vpos==0)을 무시하고 문단 전체를 다음 쪽으로 밀어내던 2결함을 정정한다.

## 결함 기전 (156744475 실측)

pi=21: `ls[0](vpos=5435, lh=63156)` = 전면 포스터 tac 그림, `ls[1](ts=8, vpos=0)` = 붙임2 헤더 tac 표.

1. **pre-flush 전체높이 판정**: `typeset_table_paragraph` 의 단일 TAC 표 pre-flush 가 표가 line0 이 아니면 문단 전체 높이(≈888px)로 fit 판정 → 잔여 865px 에 들어가는 포스터 줄(850px)까지 새 쪽으로 통밀림. 붙임 헤더만 남은 유령 쪽 생성.
2. **유령 높이 계상**: 표가 #1152 intra-para 리셋 가드로 새 쪽 이동한 뒤 문단 전체 `height_for_fit` 을 새 쪽에 계상 → 이전 쪽에 남은 포스터 높이가 유령 계상되어 후속 그래프 문단들이 또 한 쪽 밀림.

결과: rhwp 5쪽 vs 한글 3쪽 (+2), 픽셀 대조 p2(백지)↔p2(포스터) 붕괴 58.91%.

## 수정

- pre-flush: 후행 단일 TAC 표가 저장 리셋(ctrl 1:1 lineseg, vpos==0)으로 새 쪽 시작을 명시하고 선행 줄이 전부 tac 그림/도형이면, **리셋 이전 줄들의 높이만** fit 기준으로 판정 (`pre_reset_height_for_fit`).
- `typeset_tac_table`: intra-para 리셋으로 새 쪽에 온 표는 **자신의 줄부터만** 계상.

## 검증

- 156744475: **5쪽 → 3쪽** (한글 PageCount 정합), 포스터 쪽 픽셀 일치율 **58.9% → 95.4%** (한글 PDF 대조, p1 86.6/p2 95.4/p3 95.8)
- 페이지네이션 게이트: byeolpyo1=4쪽 / byeolpyo4=26쪽 현행 유지
- `cargo nextest run` (upstream/devel + 본 패치): **3,230 passed / 0 failed**
- 통합 브랜치(제출 PR #2284/#2286/#2290 적용) 위에서도 3,226 passed / 0 failed
- `cargo fmt --check`(LF 기준) / `cargo clippy --all-targets` 클린

## 재현

```
rhwp dump-pages samples/task2311/156744475_nano_plan_poster.hwpx   # 3쪽
cargo test --test issue_2311_attachment_poster_intra_para_reset
```

리뷰어 재현용 샘플(`samples/task2311/`)과 회귀 테스트 포함.

Closes #2311

🤖 Generated with [Claude Code](https://claude.com/claude-code)
