### PR TITLE
Task #2244: KBU=1 글자 단위 줄바꿈의 행두 금칙 retraction — 마침표 고립 방지

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -1905,6 +1905,30 @@ fn split_composed_line_by_width(
                     // 줄끝 초과 공백 1개 hang — 줄바꿈 없이 현재 줄에 계상.
                     hung = true;
                 } else if over {
+                    // [#2244] 행두 금칙: 새 줄이 금칙 문자(마침표 등)로 시작하지
+                    // 않도록 직전 글자를 함께 다음 줄로 이월한다 — 한컴 2024 저장
+                    // 오라클 정합 ("적용한 | 다.111…", LINE_SEG [...,128]).
+                    // 직전 글자가 같은 run 안에 있고(스타일 경계 아님) 공백이
+                    // 아니며 줄에 2자 이상 남을 때만 1자 retraction.
+                    let carried: Option<(char, f64)> = if is_line_start_forbidden(ch)
+                        && chars_in_line > 1
+                        && current_run_text
+                            .chars()
+                            .last()
+                            .is_some_and(|p| p != ' ' && !is_line_start_forbidden(p))
+                    {
+                        current_run_text.pop().map(|prev| {
+                            let prev_str: String = std::iter::once(prev).collect();
+                            let prev_w = crate::renderer::layout::estimate_text_width_unrounded(
+                                &prev_str, &ts,
+                            );
+                            current_width -= prev_w;
+                            chars_in_line -= 1;
+                            (prev, prev_w)
+                        })
+                    } else {
+                        None
+                    };
                     flush_run(
                         &mut current_runs,
                         &mut current_run_text,
@@ -1919,6 +1943,11 @@ fn split_composed_line_by_width(
                     );
                     space_w = 0.0;
                     hung = false;
+                    if let Some((pch, pw)) = carried {
+                        current_run_text.push(pch);
+                        current_width += pw;
+                        chars_in_line += 1;
+                    }
                 }
                 current_run_text.push(ch);
                 current_width += ch_width;

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1107,3 +1107,53 @@ fn test_expand_hancom_relationship_line_pua_to_box_drawing() {
         "한컴 관계도 PUA 선문자는 공개 폰트 환경에서 두부가 아닌 box drawing 문자로 표시되어야 함"
     );
 }
+
+/// [#2244] KBU=1(글자 단위) 줄바꿈에서 행두 금칙 문자 retraction —
+/// 새 줄이 마침표로 시작하지 않도록 직전 글자를 함께 이월한다.
+/// 한컴 2024 저장 오라클: "…하여 적용한 | 다.111…" (LINE_SEG [...,128] —
+/// '다'(128) 앞에서 분리, '.'(129) 고립 금지).
+#[test]
+fn test_kbu1_line_start_forbidden_retraction() {
+    let styles = make_styles_with_font_size(16.0);
+    let line = ComposedLine {
+        runs: vec![ComposedTextRun {
+            text: "적용한다.111111".to_string(),
+            char_style_id: 0,
+            lang_index: 0,
+            char_overlap: None,
+            footnote_marker: None,
+            display_text: None,
+        }],
+        line_height: 400,
+        baseline_distance: 320,
+        segment_width: 0,
+        column_start: 0,
+        line_spacing: 0,
+        has_line_break: false,
+        char_start: 0,
+    };
+    // 한글 4자(64px)는 들어가고 '.'에서 초과하는 폭 → 수정 전엔 둘째 줄이
+    // "."로 시작 ("적용한다 | .111111"), 수정 후엔 '다' 동반 이월.
+    let frags = split_composed_line_by_width(&line, 68.0, 68.0, &styles, true, 0.0);
+    assert!(
+        frags.len() >= 2,
+        "두 줄 이상으로 분할되어야 함: {:?}",
+        frags.len()
+    );
+    let line2_text: String = frags[1].runs.iter().map(|r| r.text.as_str()).collect();
+    assert!(
+        !line2_text.starts_with('.'),
+        "새 줄이 행두 금칙 '.'로 시작하면 안 됨 (한컴: 직전 글자 동반 이월): {:?}",
+        line2_text
+    );
+    assert!(
+        line2_text.starts_with("다."),
+        "한컴 오라클 정합: 둘째 줄은 '다.'로 시작해야 함: {:?}",
+        line2_text
+    );
+    // char_start 정합: 둘째 줄 시작 = '다' 위치(3)
+    assert_eq!(
+        frags[1].char_start, 3,
+        "retraction 후 char_start 는 '다' 위치"
+    );
+}


### PR DESCRIPTION
## 요약

#2244 — `korean_break_unit=1`(글자 단위) 문단의 편집 reflow 가 행두 금칙 문자(마침표 등)를 새 줄 첫 글자로 고립시키는 결함 수정. devel 단독 기반, composer 한정 (대기 중인 레이아웃 PR 들과 무충돌).

## 결함과 수정

- 이슈 오라클(한컴 2024 저장 `LINE_SEG [...,128]`): 줄 압력에서 `적용한 | 다.111…` — 직전 한글 음절까지 함께 다음 줄로 이월
- rhwp KBU=1 char_break 경로는 초과 문자 앞에서 무조건 분리 → `적용한다 | .111…`
- `split_composed_line_by_width` 의 char_break 분기에 **행두 금칙 retraction** 추가: 초과 문자가 `is_line_start_forbidden` 이고, 직전 글자가 같은 run 의 비공백·비금칙 문자이며, 줄에 2자 이상 남을 때 직전 글자 1자를 함께 이월. `char_start` 는 이월분만큼 당겨 LINE_SEG 정합 유지

## 검증

- 단위 테스트 동봉: 수정 전 형상(`….111` 시작) 재현 구성에서 둘째 줄 `다.` 시작 + `char_start=3` 단언
- KBU 경로 인접 핀 유지: #2070 시장구조조사 312 / #2097 밴드 필 5종 / #2291 잔여관례 / byeolpyo1=4·byeolpyo4=26 / (통합 브랜치에서) 연결맵 385
- `cargo nextest run` (devel + 본 패치): **3,254 passed / 0 failed**
- 열린 PR 5건 통합 브랜치(`survey/all-prs-20260717`) 위에서도 3,263 passed / 0 failed
- fmt(LF)/clippy 클린

Closes #2244

🤖 Generated with [Claude Code](https://claude.com/claude-code)
