### PR TITLE
Task #2327: undo 뮤테이션 라우팅 소스 가드 — 양방향 드리프트 + 표면 원장(런타임 가드 제외)

### DIFF
--- a/rhwp-studio/src/core/wasm-mutation-guard.ts
+++ b/rhwp-studio/src/core/wasm-mutation-guard.ts
@@ -1,0 +1,144 @@
+/**
+ * [Task #2327] 문서 변경 WASM 호출의 히스토리 라우팅 가드 (DEV 전용).
+ *
+ * studio 의 undo 는 executeOperation → CommandHistory 경유가 전제이지만 강제
+ * 장치가 없어 기록이 옵트인이다 — 미기록 뮤테이션은 ① 해당 편집 undo 불가
+ * ② redo 스택 미무효화(옛 after-스냅샷 재적용이 변경을 무언 삭제) ③ 스냅샷
+ * undo 의 전체 문서 복원에 동반 파괴, 3중 위험을 만든다 (#2027/#2037/#2053/
+ * #2077 재발 계급). 이 모듈은 히스토리 실행 창(opDepth) 밖에서 문서 변경
+ * 메서드가 호출되면 DEV 빌드에서 경고한다. 런타임 동작은 바꾸지 않는다.
+ *
+ * `MUTATING_METHODS`/`EXCLUDED_NON_DOCUMENT` 는 단일 권위 목록으로,
+ * tests/mutation-routing-guard.test.ts 가 이 소스를 파싱해 ① 브리지 신규
+ * 메서드의 분류 누락(드리프트)과 ② 소스 내 뮤테이션 호출 원장(BASELINE)을
+ * 검증한다. 브리지에 문서 변경 메서드를 추가하면 두 목록 중 하나에 반드시
+ * 분류해야 한다.
+ */
+
+/** 문서 IR(직렬화 결과)을 바꾸는 WasmBridge 공개 메서드 전수. */
+export const MUTATING_METHODS: readonly string[] = [
+  // 쪽/구역/다단
+  'setPageDef', 'setSectionDef', 'setSectionDefAll', 'setPageBorderFill', 'setColumnDef',
+  // 본문 텍스트/문단
+  'insertText', 'deleteText', 'deleteRange', 'splitParagraph', 'mergeParagraph',
+  'insertPageBreak', 'insertColumnBreak', 'insertNewNumber', 'setNumberingRestart',
+  // 셀 텍스트/문단
+  'insertTextInCell', 'insertTextInCellDeferredPagination', 'deleteTextInCell',
+  'deleteRangeInCell', 'insertTextInCellByPath', 'deleteTextInCellByPath',
+  'splitParagraphInCell', 'mergeParagraphInCell', 'splitParagraphInCellByPath',
+  'mergeParagraphInCellByPath',
+  // 표 구조/속성
+  'createTable', 'createTableEx', 'deleteTableControl', 'insertTableRow',
+  'insertTableColumn', 'deleteTableRow', 'deleteTableColumn', 'mergeTableCells',
+  'splitTableCell', 'splitTableCellInto', 'splitTableCellsInRange', 'resizeTableCells',
+  'moveTableOffset', 'setTableProperties', 'setCellProperties', 'setCellZoneProperties',
+  'pasteTableCellsTransposed', 'transposeTableCellsInPlace', 'pasteTableCellsTransposedAsTable',
+  'evaluateTableFormula',
+  // 그림/도형/수식 개체
+  'insertPicture', 'assignPictureImage', 'setPictureProperties',
+  'setHeaderFooterPictureProperties', 'setCellPicturePropertiesByPath',
+  'setCellShapePropertiesByPath', 'deletePictureControl', 'deleteCellPictureControlByPath',
+  'createShapeControl', 'setShapeProperties', 'deleteShapeControl', 'changeShapeZOrder',
+  'groupShapes', 'ungroupShape', 'moveLineEndpoint', 'updateConnectorsInSection',
+  'insertEquation', 'setEquationProperties', 'setNoteEquationProperties', 'deleteEquationControl',
+  // 각주/미주
+  'insertFootnote', 'insertEndnote', 'deleteFootnote', 'applyEndnoteShape',
+  'insertTextInFootnote', 'deleteTextInFootnote', 'splitParagraphInFootnote',
+  'mergeParagraphInFootnote', 'applyParaFormatInFootnote',
+  // 붙여넣기
+  'pasteInternal', 'pasteInternalInCell', 'pasteInternalInCellByPath', 'pasteControl',
+  'pasteHtml', 'pasteHtmlInCell', 'pasteHtmlInCellByPath',
+  // 글자/문단 모양
+  'applyCharFormat', 'setCharShapeId', 'applyCharFormatInCell', 'setCharShapeIdInCell',
+  'applyParaFormat', 'setParaShapeId', 'applyParaFormatInCell', 'setCellParaShapeId',
+  // 스타일/번호 정의 (DocInfo 변이 포함)
+  'updateStyle', 'updateStyleShapes', 'createStyle', 'deleteStyle', 'applyStyle',
+  'applyCellStyle', 'createNumbering', 'ensureDefaultNumbering', 'ensureDefaultBullet',
+  'findOrCreateFontId', 'findOrCreateFontIdForLang',
+  // 머리말/꼬리말
+  'createHeaderFooter', 'deleteHeaderFooter', 'toggleHideHeaderFooter',
+  'insertTextInHeaderFooter', 'deleteTextInHeaderFooter', 'splitParagraphInHeaderFooter',
+  'mergeParagraphInHeaderFooter', 'applyParaFormatInHf', 'insertFieldInHf', 'applyHfTemplate',
+  // 필드/양식/찾아바꾸기/책갈피
+  'setFieldValue', 'setFieldValueByName', 'removeFieldAt', 'insertClickHereField',
+  'updateClickHereProps', 'setFormValue', 'setFormValueInCell',
+  'replaceText', 'replaceOne', 'replaceAll',
+  'addBookmark', 'deleteBookmark', 'renameBookmark',
+  // lineseg 재계산 (#177 — 저장 lineseg 를 실제로 변경)
+  'reflowLinesegs',
+];
+
+/**
+ * 변이형 동사로 시작하지만 문서 IR 을 바꾸지 않는 메서드 — 드리프트 검사의
+ * 명시 분류. (세션/렌더 상태, 캐럿 탐색, 수명주기)
+ */
+export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
+  'createNewDocument', // 수명주기 — 히스토리는 deactivate 에서 별도 초기화
+  'clearLayerResourceCache', // 렌더 캐시
+  'setShowParagraphMarks', 'setShowControlCodes', 'setShowTransparentBorders', // 표시 토글
+  'setClipEnabled', // 렌더 클립 옵션
+  'setActiveField', 'clearActiveField', // 편집 세션 상태 (직렬화 비대상)
+  'moveVertical', 'moveVerticalByPath', // 캐럿 세로 탐색 (조회)
+  'ensureParagraphStableIds', // 런타임 추적 id 부여
+];
+
+let opDepth = 0;
+let allowDepth = 0;
+const warnedMethods = new Set<string>();
+
+/**
+ * 히스토리 비경유가 계약상 허용된 극소수 경로의 명시 선언.
+ * 현재 유일한 사용처: IME 조합 중간 raw 삽입/삭제 (조합 확정 시
+ * executeOperation(kind:'record') 로 사후 기록되는 2단 계약).
+ */
+export function allowUnrecordedMutation<T>(fn: () => T): T {
+  allowDepth++;
+  try {
+    return fn();
+  } finally {
+    allowDepth--;
+  }
+}
+
+/**
+ * DEV 전용 설치: WasmBridge 인스턴스의 MUTATING_METHODS 를 래핑해 히스토리
+ * 실행 창(CommandHistory.execute/undo/redo/recordWithoutExecute) 밖 호출을
+ * console.warn 으로 알린다. 메서드당 1회만 경고(콘솔 홍수 방지).
+ * 프로토타입 래핑은 installCanvasFontSubstitution 관용구와 동일 결.
+ */
+export function installMutationGuard(
+  bridge: Record<string, unknown>,
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  historyCtor: { prototype: any },
+): void {
+  const proto = historyCtor.prototype as Record<string, unknown>;
+  for (const name of ['execute', 'undo', 'redo', 'recordWithoutExecute']) {
+    const original = proto[name] as ((...args: unknown[]) => unknown) | undefined;
+    if (typeof original !== 'function') continue;
+    proto[name] = function (this: unknown, ...args: unknown[]): unknown {
+      opDepth++;
+      try {
+        return original.apply(this, args);
+      } finally {
+        opDepth--;
+      }
+    };
+  }
+
+  for (const name of MUTATING_METHODS) {
+    const original = bridge[name] as ((...args: unknown[]) => unknown) | undefined;
+    if (typeof original !== 'function') continue;
+    bridge[name] = function (this: unknown, ...args: unknown[]): unknown {
+      if (opDepth === 0 && allowDepth === 0 && !warnedMethods.has(name)) {
+        warnedMethods.add(name);
+        // eslint-disable-next-line no-console
+        console.warn(
+          `[MutationGuard] 미기록 문서 변경: wasm.${name}() 이 히스토리 실행 창 밖에서 ` +
+            `호출됨 — undo 불가·redo 오염·스냅샷 undo 동반 파괴 위험 (#2327). ` +
+            `executeOperation 라우팅 또는 allowUnrecordedMutation 명시 선언 필요.`,
+        );
+      }
+      return original.apply(bridge, args);
+    };
+  }
+}

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1,4 +1,5 @@
 import { WasmBridge } from '@/core/wasm-bridge';
+import { allowUnrecordedMutation } from '@/core/wasm-mutation-guard';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';
 import { CaretRenderer } from './caret-renderer';
@@ -2257,12 +2258,19 @@ export class InputHandler {
 
   /** 위치에 텍스트를 삽입한다 (WASM 직접 호출, IME 조합용) */
   private insertTextAtRaw(pos: DocumentPosition, text: string): void {
-    this.rawTextMutationEffects.add(_text.insertTextAtRaw.call(this, pos, text));
+    // [Task #2327] IME 조합 중간 삽입은 히스토리 비경유가 계약(조합 확정 시
+    // executeOperation(kind:'record')로 사후 기록). 뮤테이션 가드에 명시 선언.
+    allowUnrecordedMutation(() => {
+      this.rawTextMutationEffects.add(_text.insertTextAtRaw.call(this, pos, text));
+    });
   }
 
   /** 위치에서 텍스트를 삭제한다 (WASM 직접 호출, IME 조합용) */
   private deleteTextAt(pos: DocumentPosition, count: number): void {
-    _text.deleteTextAt.call(this, pos, count);
+    // [Task #2327] IME 조합 중간 삭제 — 위와 동일 계약.
+    allowUnrecordedMutation(() => {
+      _text.deleteTextAt.call(this, pos, count);
+    });
     this.rawTextMutationEffects.add(IMMEDIATE_TEXT_MUTATION_EFFECTS);
   }
 

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -31,6 +31,8 @@ import { showToast } from '@/ui/toast';
 import { addRecentDoc, listRecentDocs } from '@/recent/recent-store';
 import { showDropConfirmDialog } from '@/ui/drop-confirm-dialog';
 import { initRhwpDev } from '@/core/rhwp-dev';
+import { installMutationGuard } from '@/core/wasm-mutation-guard';
+import { CommandHistory } from '@/engine/history';
 import { DocumentDirtyState } from '@/core/document-dirty-state';
 import { initThemeSync, setThemeMode, getThemeMode, getEffectiveTheme } from '@/core/theme';
 import { analyzeDocumentFonts } from '@/core/document-font-status';
@@ -77,6 +79,8 @@ if (import.meta.env.DEV) {
   (window as any).__autosaveManager = autosaveManager;
   (window as any).__theme = { getThemeMode, getEffectiveTheme, setThemeMode };
   initRhwpDev(wasm);
+  // [Task #2327] 미기록 문서 변경 감시 — 히스토리 실행 창 밖 뮤테이션 경고.
+  installMutationGuard(wasm as unknown as Record<string, unknown>, CommandHistory);
 }
 let canvasView: CanvasView | null = null;
 let inputHandler: InputHandler | null = null;

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -74,6 +74,20 @@ test('MUTATING_METHODS / EXCLUDED_NON_DOCUMENT 는 서로 겹치지 않는다', 
   assert.deepEqual(dup, [], `양쪽에 중복 분류됨: ${dup.join(', ')}`);
 });
 
+test('MUTATING_METHODS 는 모두 실제 브리지 공개 메서드여야 한다(rename 무통보 skip 방지)', () => {
+  // installMutationGuard 는 `typeof original !== 'function'` 이면 조용히 건너뛴다.
+  // 브리지에서 메서드가 rename/제거되면 목록의 옛 이름은 가드에서 무통보로
+  // 비활성화되므로(가드 사각), 목록 항목이 전부 실재하는지 역방향으로 강제한다.
+  const bridge = new Set(bridgePublicMethods());
+  const missing = MUTATING.filter((m) => !bridge.has(m));
+  assert.deepEqual(
+    missing,
+    [],
+    `MUTATING_METHODS 에 브리지에 없는 이름: ${missing.join(', ')}\n` +
+      `→ 브리지에서 rename/제거된 메서드. 목록을 갱신하라(방치 시 가드 무통보 비활성).`,
+  );
+});
+
 // ── (2) 원장 트립와이어: 뮤테이션 표면 동결 ─────────────────────────────────
 
 /** ui/ + command/ 하위 .ts 파일 나열(테스트 제외). */

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -1,0 +1,162 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync, readdirSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2327] 계급 1(기록 옵트인) 회귀를 저작 시점에 차단하는 소스 가드.
+//
+// 두 정적 검사:
+//  (1) 드리프트 — WasmBridge 의 문서-변경형 공개 메서드는 wasm-mutation-guard.ts 의
+//      MUTATING_METHODS 또는 EXCLUDED_NON_DOCUMENT 중 하나에 반드시 분류돼야 한다.
+//      새 뮤테이터가 목록에 안 잡히면 DEV 가드도 그 호출을 못 잡으므로, 분류 누락을
+//      실패로 만든다.
+//  (2) 원장 트립와이어 — ui/ + command/ 에서 뮤테이터를 직접 호출하는 표면(파일별
+//      호출 수)을 동결한다. 신규 파일·증가는 실패 → 의식적 baseline 갱신 + 리뷰 강제.
+//      (라우팅 경유 여부의 실제 판정은 런타임 DEV MutationGuard 가 담당한다 —
+//      텍스트 카운트는 executeOperation 콜백 내부 호출도 세므로 이관해도 줄지 않는다.
+//      따라서 이 원장은 "라우팅 여부"가 아니라 "뮤테이션 표면 증가"의 트립와이어다.)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(rel: string): string {
+  return readFileSync(join(rootDir, rel), 'utf8');
+}
+
+/** wasm-mutation-guard.ts 의 배열 상수를 단일 권위원으로 파싱한다. */
+function parseStringArray(guardSrc: string, name: string): string[] {
+  // `export const NAME ...= [ ... ];` 선언에 앵커(상단 주석의 이름 언급 회피).
+  const m = guardSrc.match(new RegExp(`export const ${name}\\b[^=]*=\\s*\\[([\\s\\S]*?)\\];`));
+  assert.ok(m, `${name} 상수를 파싱하지 못함`);
+  return [...m![1].matchAll(/'([A-Za-z0-9_]+)'/g)].map((x) => x[1]);
+}
+
+const guardSrc = source('src/core/wasm-mutation-guard.ts');
+const MUTATING = parseStringArray(guardSrc, 'MUTATING_METHODS');
+const EXCLUDED = parseStringArray(guardSrc, 'EXCLUDED_NON_DOCUMENT');
+
+// ── (1) 드리프트: 브리지 공개 메서드 분류 강제 ──────────────────────────────
+
+/** WasmBridge 클래스 본문의 공개 메서드 이름을 추출한다(2칸 들여쓰기 최상위). */
+function bridgePublicMethods(): string[] {
+  const src = source('src/core/wasm-bridge.ts');
+  const names = new Set<string>();
+  const priv = new Set<string>();
+  const re = /^ {2}(public |private |protected )?(async )?([a-zA-Z_]\w*)\s*\(/gm;
+  for (const m of src.matchAll(re)) {
+    const name = m[3];
+    if (['constructor', 'if', 'for', 'while', 'switch', 'catch', 'return'].includes(name)) continue;
+    if (m[1] === 'private ' || m[1] === 'protected ') priv.add(name);
+    else names.add(name);
+  }
+  return [...names].filter((n) => !priv.has(n));
+}
+
+// 문서 변경을 시사하는 동사 접두어.
+const MUTATING_VERB = /^(insert|delete|create|apply|add|remove|move|resize|merge|split|update|toggle|replace|paste|assign|group|ungroup|change|clear|evaluate|equalize|transpose|setPage|setSection|setColumn|setCell|setTable|setPicture|setShape|setEquation|setNote|setChar|setPara|setField|setForm|setNumbering|setHeaderFooter|setActiveField|renameBookmark|reflowLinesegs)/;
+
+test('드리프트: 문서-변경형 브리지 공개 메서드는 모두 분류돼야 한다', () => {
+  const classified = new Set([...MUTATING, ...EXCLUDED]);
+  const unclassified = bridgePublicMethods()
+    .filter((n) => MUTATING_VERB.test(n))
+    .filter((n) => !classified.has(n));
+  assert.deepEqual(
+    unclassified,
+    [],
+    `WasmBridge 신규(?) 뮤테이터가 분류되지 않음: ${unclassified.join(', ')}\n` +
+      `→ wasm-mutation-guard.ts 의 MUTATING_METHODS(기록 강제) 또는 ` +
+      `EXCLUDED_NON_DOCUMENT(문서 비변경 사유)에 추가하라.`,
+  );
+});
+
+test('MUTATING_METHODS / EXCLUDED_NON_DOCUMENT 는 서로 겹치지 않는다', () => {
+  const dup = MUTATING.filter((m) => EXCLUDED.includes(m));
+  assert.deepEqual(dup, [], `양쪽에 중복 분류됨: ${dup.join(', ')}`);
+});
+
+// ── (2) 원장 트립와이어: 뮤테이션 표면 동결 ─────────────────────────────────
+
+/** ui/ + command/ 하위 .ts 파일 나열(테스트 제외). */
+function scanFiles(): string[] {
+  const out: string[] = [];
+  const walk = (rel: string) => {
+    for (const ent of readdirSync(join(rootDir, rel), { withFileTypes: true })) {
+      const child = `${rel}/${ent.name}`;
+      if (ent.isDirectory()) walk(child);
+      else if (ent.name.endsWith('.ts') && !ent.name.endsWith('.test.ts')) out.push(child);
+    }
+  };
+  walk('src/ui');
+  walk('src/command');
+  return out.sort();
+}
+
+function mutatorCallCount(src: string): number {
+  const re = new RegExp(`\\bwasm\\s*\\.\\s*(${MUTATING.join('|')})\\s*\\(`, 'g');
+  return [...src.matchAll(re)].length;
+}
+
+// 뮤테이션 표면 원장 (2026-07-17 동결). 이관/추가 시 이 표를 의식적으로 갱신한다.
+// 값을 낮추는 방향(이관)만 무해하며, 높이거나 신규 키 추가는 리뷰 대상이다.
+const BASELINE: Readonly<Record<string, number>> = {
+  'src/command/commands/edit.ts': 1,
+  'src/command/commands/format.ts': 1,
+  'src/command/commands/insert.ts': 19,
+  'src/command/commands/page.ts': 13,
+  'src/command/commands/table.ts': 33,
+  'src/ui/bookmark-dialog.ts': 3,
+  'src/ui/cell-border-bg-dialog.ts': 5,
+  'src/ui/column-settings-dialog.ts': 1,
+  'src/ui/endnote-shape-dialog.ts': 1,
+  'src/ui/equation-editor-dialog.ts': 2,
+  'src/ui/equation-props-dialog.ts': 2,
+  'src/ui/find-dialog.ts': 4,
+  'src/ui/formula-dialog.ts': 3,
+  'src/ui/new-number-dialog.ts': 1,
+  'src/ui/numbering-dialog.ts': 1,
+  'src/ui/page-border-dialog.ts': 1,
+  'src/ui/page-setup-dialog.ts': 1,
+  'src/ui/picture-props-dialog.ts': 5,
+  'src/ui/section-settings-dialog.ts': 2,
+  'src/ui/style-dialog.ts': 1,
+  'src/ui/style-edit-dialog.ts': 6,
+  'src/ui/table-cell-props-dialog.ts': 2,
+  'src/ui/toolbar.ts': 4,
+};
+
+test('뮤테이션 표면 원장: 신규·증가 사이트는 baseline 갱신을 강제한다', () => {
+  const current: Record<string, number> = {};
+  for (const rel of scanFiles()) {
+    const n = mutatorCallCount(source(rel));
+    if (n > 0) current[rel] = n;
+  }
+
+  const violations: string[] = [];
+  for (const [rel, n] of Object.entries(current)) {
+    const base = BASELINE[rel];
+    if (base === undefined) {
+      violations.push(`  + ${rel}: ${n} (신규 뮤테이션 파일 — executeOperation 라우팅 또는 baseline 등재 필요)`);
+    } else if (n > base) {
+      violations.push(`  ↑ ${rel}: ${base} → ${n} (뮤테이션 사이트 증가 — 라우팅 확인 또는 baseline 갱신)`);
+    }
+  }
+  // 이관으로 값이 줄면 baseline 을 낮추라고 안내(실패는 아님 — 진행을 막지 않음).
+  const stale: string[] = [];
+  for (const [rel, base] of Object.entries(BASELINE)) {
+    const n = current[rel] ?? 0;
+    if (n < base) stale.push(`  ↓ ${rel}: ${base} → ${n} (이관 완료 — baseline 을 ${n}${n === 0 ? ' 로 낮추거나 키 제거' : ''} 로 갱신 권장)`);
+  }
+
+  assert.deepEqual(
+    violations,
+    [],
+    `뮤테이션 표면이 baseline 을 초과했습니다:\n${violations.join('\n')}\n\n` +
+      `새 문서 변경은 InputHandler.executeOperation 라우팅으로 undo 에 기록돼야 합니다(#2327).` +
+      (stale.length ? `\n\n참고(이관 진행 — 실패 아님):\n${stale.join('\n')}` : ''),
+  );
+
+  if (stale.length) {
+    // 진행 상황 가시화 — 실패시키지 않고 로그만.
+    console.log(`[mutation-routing] 이관 진행:\n${stale.join('\n')}`);
+  }
+});


### PR DESCRIPTION
관련 이슈: #2327

## 문제

studio 의 undo 는 `executeOperation` → `CommandHistory` 경유가 전제이지만 강제 장치가 없어 **기록이 옵트인**이다 — `src/ui`+`src/command`+`src/engine/input-handler*` 에 문서 변경 WASM 호출이 흩어져 있고, 미라우팅 뮤테이션은 ① 그 편집 undo 불가 ② redo 스택 미무효화 ③ 스냅샷 undo 의 전체 문서 복원에 동반 파괴, 3중 위험을 만든다(#2027/#2037/#2053/#2077 재발 계급). 기존 방어는 버그당 후행 작성된 소스 가드 5종뿐이라 신규 사이트에 무력하다.

## 변경 (소스 전용 — 런타임 무변경)

**저작 시점 소스 가드로 일원화한다.**

- **`core/mutation-method-registry.ts`**(신규): 문서 IR 을 바꾸는 브리지 공개 메서드를 `MUTATING_METHODS` 로, 변이형 동사지만 비변경인 메서드를 `EXCLUDED_NON_DOCUMENT` 로 단일 권위 목록화.
- **`tests/mutation-routing-guard.test.ts`**(신규):
  - **드리프트(양방향)** — ① 브리지의 문서-변경형 공개 메서드가 두 목록 중 하나에 반드시 분류되도록 강제(신규 뮤테이터 누락 차단), ② 목록 전 항목이 실제 브리지 메서드인지 강제(rename/제거 무통보 skip 차단), ③ `MUTATING_VERB` 가 목록 전 항목을 커버하는지 자기정합(ensure*/findOrCreate* 계열 사각 방지).
  - **원장 트립와이어** — `ui/`+`command/`+`engine/input-handler*` 의 뮤테이션 표면(파일별 호출 수)을 동결. 신규 파일·증가는 실패 → 의식적 baseline 갱신+리뷰 강제. (엔진 층의 드래그/nudge 직접-뮤테이션 최고밀도 영역 포함.)

## 설계 노트 — DEV 런타임 가드를 제외한 이유

초기 설계는 DEV 런타임 opDepth 가드(히스토리 실행 창 밖 뮤테이션 경고)도 포함했으나, **자체 code-review 에서 net-negative 임이 확증**돼 제외했다: `kind:'record'` 계약(개체/표 드래그·키보드 nudge — 뮤테이션을 `recordWithoutExecute` 전에 직접 적용, 재실행 없음)을 구분하지 못해 ① 일상 편집(리사이즈/이동/nudge)마다 `setPictureProperties`/`moveTableOffset` 등에 **가짜 경고** ② `warnedMethods` 가 그 핵심 메서드명을 세션 영구 소진 → 이후 **진짜 미라우팅까지 침묵**. record 사이트를 opt-in 래핑하면 가드가 막으려던 옵트인 취약성이 재도입되고 다중 인스턴스·flush/refresh 완전성 홀도 잔존한다. 오탐 없는 저작 시점 소스 가드가 핵심 가치를 온전히 전달한다.

## 검증

devel `fb82a0f8` 기준.

- 가드 테스트 **5/5**(드리프트 양방향·자기정합·원장 확장). 역방향/자기정합은 가짜 이름 주입 시 FAIL 실증.
- `tsc --noEmit` 0, studio 단위 `node --test` **312/0**, e2e 4종(undo-contracts 24·undo-object-selection 14·unsaved-guard 6·text-flow 5), 부팅 콘솔 에러 0.

## 범위 외

- 미라우팅 사이트의 실제 `executeOperation` 이관 — 후속 연작(원장 baseline 감소가 진행 게이지).
- 의도적 비-undo 판정(스타일 정의·쪽 설정 등 한글 편집기 정합) — 이관 시 개별 질의.
- hwpctl 확장의 raw doc 직접 접근 — 별도 결정.
