### PR TITLE
Task #2328: undo 스냅샷 상한 정합 + 예외 안전 스택 이동 — 무통보 축출로 인한 undo 소실 차단

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -14,6 +14,11 @@ export interface EditCommand {
   mergeWith(other: EditCommand): EditCommand | null;
   /** 리소스 해제 (스냅샷 명령의 메모리 반환 등). 스택에서 제거될 때 호출. */
   discard?(wasm: WasmBridge): void;
+  /**
+   * [Task #2328] 이 명령이 현재 점유한 WASM 스냅샷 id 개수(없으면 0).
+   * CommandHistory 가 스냅샷 예산을 WASM 상한과 정합시키는 데 쓴다.
+   */
+  snapshotResourceCount?(): number;
   /** page-local refresh 판정을 위한 가벼운 텍스트 편집 payload. */
   getPageLocalTextEditOptions?(): { insertedText?: string; deleteCount?: number };
   /** 방금 실행한 mutation effect를 한 번만 반환한다. */
@@ -1219,8 +1224,16 @@ export class SnapshotCommand implements EditCommand {
 
     // 최초 실행: before 저장 → 작업 수행 → after 저장
     this.beforeId = wasm.saveSnapshot();
-    if (this.operation) {
-      this.cursorAfter = this.operation(wasm);
+    // [Task #2328] operation 이 throw 하면 커맨드가 히스토리에 등록되지 못해
+    // discard 주체가 사라진다 → before 스냅샷 영구 누수. throw 경로에서 직접 해제.
+    try {
+      if (this.operation) {
+        this.cursorAfter = this.operation(wasm);
+      }
+    } catch (e) {
+      wasm.discardSnapshot(this.beforeId);
+      this.beforeId = null;
+      throw e;
     }
     this.afterId = wasm.saveSnapshot();
 
@@ -1238,6 +1251,11 @@ export class SnapshotCommand implements EditCommand {
   }
 
   mergeWith(): null { return null; }
+
+  /** [Task #2328] 현재 살아있는 before/after 스냅샷 id 개수. */
+  snapshotResourceCount(): number {
+    return (this.beforeId !== null ? 1 : 0) + (this.afterId !== null ? 1 : 0);
+  }
 
   discard(wasm: WasmBridge): void {
     if (this.beforeId !== null) {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1224,18 +1224,19 @@ export class SnapshotCommand implements EditCommand {
 
     // 최초 실행: before 저장 → 작업 수행 → after 저장
     this.beforeId = wasm.saveSnapshot();
-    // [Task #2328] operation 이 throw 하면 커맨드가 히스토리에 등록되지 못해
-    // discard 주체가 사라진다 → before 스냅샷 영구 누수. throw 경로에서 직접 해제.
+    // [Task #2328] operation 또는 after-save 중 어느 것이 throw 하든 커맨드가
+    // 히스토리에 등록되지 못해 discard 주체가 사라진다 → 스냅샷 영구 누수(orphan
+    // → WASM 무통보 축출 재발). after-save(대용량 문서 클론 시 메모리 압박 등)까지
+    // try 범위에 포함해 before/after 를 대칭적으로 해제한다.
     try {
       if (this.operation) {
         this.cursorAfter = this.operation(wasm);
       }
+      this.afterId = wasm.saveSnapshot();
     } catch (e) {
-      wasm.discardSnapshot(this.beforeId);
-      this.beforeId = null;
+      this.discard(wasm); // before/after id 를 null-safe 로 해제
       throw e;
     }
-    this.afterId = wasm.saveSnapshot();
 
     // operation 참조 해제 (클로저에 캡처된 리소스 해제)
     this.operation = null;

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -11,13 +11,23 @@ function discardAll(stack: EditCommand[], wasm: WasmBridge): void {
 }
 
 /**
- * [Task #2328] WASM 스냅샷 저장소 상한(document.rs 의 MAX_SNAPSHOTS)과 정합시킬
- * JS 측 스냅샷 id 예산. JS 가 이 예산을 넘기 전에 undo 스택 front 를 축출해
- * 스냅샷을 discard 하므로, WASM store 는 이 값을 넘지 않고 WASM 자체의 무통보
- * 축출은 결코 발동하지 않는다(축출된 스냅샷 restore 실패로 undo 가 예외·엔트리
- * 유실되던 결함 #2328 의 근원 제거). 값 변경 시 document.rs 와 함께 갱신한다.
+ * [Task #2328] WASM 스냅샷 저장소 상한(document.rs 의 MAX_SNAPSHOTS=100).
+ * 값 변경 시 함께 갱신한다.
  */
-const SNAPSHOT_ID_BUDGET = 100;
+const WASM_MAX_SNAPSHOTS = 100;
+
+/**
+ * [Task #2328] JS 측 살아있는 스냅샷 id 예산. 새 SnapshotCommand 의 최초 execute 는
+ * before/after 2개를 **연속으로** 저장하는데(command.ts), 이 저장은 히스토리의
+ * redo 정리·예산 강제(enforceSnapshotBudget)보다 **먼저** 일어난다. 예산을
+ * MAX 와 같게 두면 그 순간적 +2 가 WASM store 를 MAX 초과로 밀어 WASM 자체의
+ * 무통보 축출이 발동하고, 이때 축출되는 것은 JS 가 아직 참조하는 오래된 undo
+ * 엔트리의 스냅샷이라 이후 그 엔트리 undo 가 restore 실패로 예외가 된다
+ * (인터리브: 예산 채움→undo→새 편집→오래된 undo 시 재현). 따라서 예산에 그
+ * 순간 +2 만큼 여유를 두어, 라이브 총합이 예산 이하면 새 저장 후에도 store 가
+ * MAX 를 넘지 않게 한다 → WASM 축출은 결코 발동하지 않는다.
+ */
+const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;
 
 /** Undo/Redo 히스토리 관리 */
 export class CommandHistory {
@@ -102,10 +112,20 @@ export class CommandHistory {
     const command = this.undoStack[this.undoStack.length - 1];
     if (!command) return null;
 
-    // [Task #2328] op 성공 후에만 스택을 이동한다. command.undo() 가 예외를
-    // 던지면(예: 축출된 스냅샷 restore 실패) 스택을 건드리지 않고 전파해
-    // 엔트리 소실을 막는다 (종전 pop-먼저는 예외 시 엔트리를 유실했다).
-    const cursorAfter = command.undo(wasm);
+    // [Task #2328] op-우선 + 실패시-드롭 하이브리드.
+    // - 성공: 스택을 이동한다(op 전에 pop 하지 않으므로 성공 엔트리 무손실).
+    // - 실패(예: 복구 불가한 스냅샷 restore 오류): 오래동안 스택 top 에 남겨
+    //   두면 Ctrl+Z 마다 같은 엔트리가 재예외 → 세션 undo 락업이 된다. 재시도로
+    //   복구되지 않는 오류이므로, 오염 엔트리를 제거·discard 하고 전파한다
+    //   (스냅샷 복원은 문서 전체 치환이라 다음(더 오래된) 엔트리 undo 가 안전).
+    let cursorAfter: DocumentPosition;
+    try {
+      cursorAfter = command.undo(wasm);
+    } catch (e) {
+      this.undoStack.pop();
+      command.discard?.(wasm);
+      throw e;
+    }
     this.undoStack.pop();
     this.redoStack.push(command);
     return cursorAfter;
@@ -117,8 +137,15 @@ export class CommandHistory {
     const command = this.redoStack[this.redoStack.length - 1];
     if (!command) return null;
 
-    // [Task #2328] undo 와 동일 — execute() 성공 후에만 스택 이동.
-    const cursorAfter = command.execute(wasm);
+    // [Task #2328] undo 와 동일 하이브리드 — 성공 시 이동, 실패 시 오염 엔트리 드롭.
+    let cursorAfter: DocumentPosition;
+    try {
+      cursorAfter = command.execute(wasm);
+    } catch (e) {
+      this.redoStack.pop();
+      command.discard?.(wasm);
+      throw e;
+    }
     this.captureExecutionEffects(command);
     this.redoStack.pop();
     this.undoStack.push(command);

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -11,8 +11,11 @@ function discardAll(stack: EditCommand[], wasm: WasmBridge): void {
 }
 
 /**
- * [Task #2328] WASM 스냅샷 저장소 상한(document.rs 의 MAX_SNAPSHOTS=100).
- * 값 변경 시 함께 갱신한다.
+ * [Task #2328] WASM 스냅샷 저장소 상한 미러 —
+ * src/document_core/commands/document.rs 의 save_snapshot_native 내부
+ * `const MAX_SNAPSHOTS`(함수-로컬). **양방향 결합**: Rust 값을 이 아래로
+ * 낮추면 아래 예산(MAX-2)이 store 를 넘겨 WASM 무통보 축출이 재발한다.
+ * 값 변경 시 반드시 양쪽을 함께 갱신한다(Rust 쪽에도 역참조 주석이 있다).
  */
 const WASM_MAX_SNAPSHOTS = 100;
 
@@ -100,8 +103,13 @@ export class CommandHistory {
       const evicted = this.undoStack.shift();
       evicted?.discard?.(wasm);
     }
-    // [Task #2328] 스냅샷 예산 정합 — WASM 상한 초과 전에 front 축출.
-    this.enforceSnapshotBudget(wasm);
+    // [Task #2328] 스냅샷 예산 정합 — WASM 상한 초과 전에 front 축출. push 이후에
+    // 강제해야 방금 명령의 +2 가 계산에 포함된다. 스냅샷을 점유하는 명령만
+    // 예산을 늘리므로 그 경우에만 강제한다(텍스트 편집은 예산 무영향 →
+    // liveSnapshotIds O(n) 스캔 생략, 편집 hot-path 비용 제거).
+    if ((command.snapshotResourceCount?.() ?? 0) > 0) {
+      this.enforceSnapshotBudget(wasm);
+    }
 
     return cursorAfter;
   }

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -10,12 +10,44 @@ function discardAll(stack: EditCommand[], wasm: WasmBridge): void {
   }
 }
 
+/**
+ * [Task #2328] WASM 스냅샷 저장소 상한(document.rs 의 MAX_SNAPSHOTS)과 정합시킬
+ * JS 측 스냅샷 id 예산. JS 가 이 예산을 넘기 전에 undo 스택 front 를 축출해
+ * 스냅샷을 discard 하므로, WASM store 는 이 값을 넘지 않고 WASM 자체의 무통보
+ * 축출은 결코 발동하지 않는다(축출된 스냅샷 restore 실패로 undo 가 예외·엔트리
+ * 유실되던 결함 #2328 의 근원 제거). 값 변경 시 document.rs 와 함께 갱신한다.
+ */
+const SNAPSHOT_ID_BUDGET = 100;
+
 /** Undo/Redo 히스토리 관리 */
 export class CommandHistory {
   private undoStack: EditCommand[] = [];
   private redoStack: EditCommand[] = [];
   private maxSize = 1000;
   private lastExecutionEffects: TextMutationEffects = NO_TEXT_MUTATION_EFFECTS;
+
+  /** undo/redo 양 스택의 살아있는 스냅샷 id 총합. */
+  private liveSnapshotIds(): number {
+    let n = 0;
+    for (const cmd of this.undoStack) n += cmd.snapshotResourceCount?.() ?? 0;
+    for (const cmd of this.redoStack) n += cmd.snapshotResourceCount?.() ?? 0;
+    return n;
+  }
+
+  /**
+   * [Task #2328] 스냅샷 id 총합이 예산을 넘으면 undo 스택 front(최오래)부터
+   * 연속 축출한다. front 축출은 contiguous 하므로 bounded-history 시멘틱을
+   * 지키며(오래된 것부터 사라짐), 스냅샷 커맨드를 discard 해 WASM id 를 즉시
+   * 반환한다. 텍스트 커맨드가 front 에 있으면 함께 밀려나지만(0 id) 오래된
+   * 순서라 정합적이다. redo 스택은 새 명령 실행 시 항상 비워지므로 여기서만
+   * front 를 다룬다.
+   */
+  private enforceSnapshotBudget(wasm: WasmBridge): void {
+    while (this.liveSnapshotIds() > SNAPSHOT_ID_BUDGET && this.undoStack.length > 1) {
+      const evicted = this.undoStack.shift();
+      evicted?.discard?.(wasm);
+    }
+  }
 
   private captureExecutionEffects(command: EditCommand): void {
     this.lastExecutionEffects =
@@ -58,6 +90,8 @@ export class CommandHistory {
       const evicted = this.undoStack.shift();
       evicted?.discard?.(wasm);
     }
+    // [Task #2328] 스냅샷 예산 정합 — WASM 상한 초과 전에 front 축출.
+    this.enforceSnapshotBudget(wasm);
 
     return cursorAfter;
   }
@@ -65,10 +99,14 @@ export class CommandHistory {
   /** Undo — 성공 시 커서 위치 반환, 스택 비었으면 null */
   undo(wasm: WasmBridge): DocumentPosition | null {
     this.lastExecutionEffects = NO_TEXT_MUTATION_EFFECTS;
-    const command = this.undoStack.pop();
+    const command = this.undoStack[this.undoStack.length - 1];
     if (!command) return null;
 
+    // [Task #2328] op 성공 후에만 스택을 이동한다. command.undo() 가 예외를
+    // 던지면(예: 축출된 스냅샷 restore 실패) 스택을 건드리지 않고 전파해
+    // 엔트리 소실을 막는다 (종전 pop-먼저는 예외 시 엔트리를 유실했다).
     const cursorAfter = command.undo(wasm);
+    this.undoStack.pop();
     this.redoStack.push(command);
     return cursorAfter;
   }
@@ -76,11 +114,13 @@ export class CommandHistory {
   /** Redo — 성공 시 커서 위치 반환, 스택 비었으면 null */
   redo(wasm: WasmBridge): DocumentPosition | null {
     this.lastExecutionEffects = NO_TEXT_MUTATION_EFFECTS;
-    const command = this.redoStack.pop();
+    const command = this.redoStack[this.redoStack.length - 1];
     if (!command) return null;
 
+    // [Task #2328] undo 와 동일 — execute() 성공 후에만 스택 이동.
     const cursorAfter = command.execute(wasm);
     this.captureExecutionEffects(command);
+    this.redoStack.pop();
     this.undoStack.push(command);
     return cursorAfter;
   }

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -18,8 +18,10 @@ const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8')
 function methodBlock(src: string, signature: string): string {
   const start = src.indexOf(signature);
   assert.notEqual(start, -1, `${signature} not found`);
-  // 다음 최상위 메서드( '\n  ' 들여쓰기 + 식별자() ) 또는 클래스 끝까지.
-  const next = src.slice(start + signature.length).search(/\n {2}[a-zA-Z][\w]*\(/);
+  // 다음 최상위 메서드까지( '\n  ' + 선택적 접근자/async/get/set + 식별자() ).
+  // 접근자 접두어를 허용해 modifier 붙은 이웃 메서드로 블록이 새지 않게 한다.
+  const next = src.slice(start + signature.length)
+    .search(/\n {2}(?:public |private |protected |static |async |get |set )*[a-zA-Z][\w]*\s*\(/);
   return next === -1 ? src.slice(start) : src.slice(start, start + signature.length + next);
 }
 
@@ -46,9 +48,13 @@ test('[결함2] undo 는 op-우선 + 실패시-드롭 하이브리드다(pop-먼
   // op 전에 pop 하지 않는다(성공 엔트리 무손실).
   assert.ok(!/const command = this\.undoStack\.pop\(\);[\s\S]*command\.undo/.test(block),
     'pop-먼저(pop 후 undo) 패턴 잔존');
-  // 실패 경로: try/catch 로 오염 엔트리를 pop+discard 후 전파(락업 방지).
-  assert.match(block, /try\s*\{[\s\S]*command\.undo\(wasm\)[\s\S]*\}\s*catch[\s\S]*this\.undoStack\.pop\(\)[\s\S]*discard\?\.\(wasm\)[\s\S]*throw/,
-    'undo 실패 시 오염 엔트리 드롭(pop+discard+throw)이 없으면 세션 undo 락업');
+  // 실패 경로: try/catch 로 오염 엔트리를 pop·discard 후 전파(락업 방지).
+  // pop/discard 순서는 무관(JS 스택 vs WASM id 해제, 독립) — 존재만 강제한다.
+  const catchBody = block.slice(block.search(/\}\s*catch/));
+  assert.match(block, /try\s*\{[\s\S]*command\.undo\(wasm\)[\s\S]*\}\s*catch/, 'command.undo 를 try 로 감싸야 함');
+  assert.match(catchBody, /this\.undoStack\.pop\(\)/, 'catch 에서 오염 엔트리 pop');
+  assert.match(catchBody, /discard\?\.\(wasm\)/, 'catch 에서 스냅샷 discard');
+  assert.match(catchBody, /throw/, 'catch 에서 rethrow');
 });
 
 test('[결함2] redo 도 execute-우선 + 실패시-드롭 하이브리드다', () => {
@@ -58,16 +64,26 @@ test('[결함2] redo 도 execute-우선 + 실패시-드롭 하이브리드다', 
   const idxUndoPush = block.indexOf('this.undoStack.push(command)');
   assert.ok(idxPeek < idxExec && idxExec < idxUndoPush,
     'peek → execute → undo.push 순서여야 함');
-  assert.match(block, /try\s*\{[\s\S]*command\.execute\(wasm\)[\s\S]*\}\s*catch[\s\S]*this\.redoStack\.pop\(\)[\s\S]*discard\?\.\(wasm\)[\s\S]*throw/,
-    'redo 실패 시 오염 엔트리 드롭이 없으면 락업');
+  const catchBody = block.slice(block.search(/\}\s*catch/));
+  assert.match(block, /try\s*\{[\s\S]*command\.execute\(wasm\)[\s\S]*\}\s*catch/, 'command.execute 를 try 로 감싸야 함');
+  assert.match(catchBody, /this\.redoStack\.pop\(\)/, 'catch 에서 오염 엔트리 pop');
+  assert.match(catchBody, /discard\?\.\(wasm\)/, 'catch 에서 discard');
+  assert.match(catchBody, /throw/, 'catch 에서 rethrow');
 });
 
-test('[결함3] SnapshotCommand.execute 는 operation throw 시 before 스냅샷을 해제한다', () => {
+test('[결함3] execute 는 operation·after-save 어느 throw 에도 스냅샷을 누수하지 않는다', () => {
   const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
   assert.match(block, /this\.beforeId = wasm\.saveSnapshot\(\);/, 'before 저장이 있어야 함');
-  // saveSnapshot(before) 이후 operation 을 try/catch 로 감싸 discard + rethrow.
-  assert.match(block, /try\s*\{[\s\S]*this\.operation\(wasm\)[\s\S]*\}\s*catch[\s\S]*discardSnapshot\(this\.beforeId\)[\s\S]*throw/,
-    'operation 을 try/catch 로 감싸 throw 시 beforeId discard 후 rethrow 해야 함');
+  // try 는 operation 과 after-save 를 모두 감싸야 한다 — after-save(대용량 클론
+  // 메모리 압박 등) throw 도 before 누수 → orphan 이므로 대칭 보호 필수.
+  assert.match(block, /try\s*\{[\s\S]*this\.operation\(wasm\)[\s\S]*this\.afterId = wasm\.saveSnapshot\(\)[\s\S]*\}\s*catch[\s\S]*throw/,
+    'operation 과 after-save 를 함께 try 로 감싸야 함(after-save 가 try 밖이면 누수)');
+  // catch 는 before/after 를 해제해야 한다(discard() 는 둘 다 null-safe 처리).
+  assert.match(block, /catch[\s\S]*this\.discard\(wasm\)[\s\S]*throw/,
+    'catch 에서 discard(wasm)로 before/after 대칭 해제 후 rethrow 해야 함');
+  // after-save 가 try 밖(구 구조)이면 실패해야 한다 — catch 다음에 saveSnapshot 금지.
+  assert.ok(!/\}\s*catch[\s\S]*?throw;\s*\}\s*this\.afterId = wasm\.saveSnapshot/.test(block),
+    'after-save 가 catch 밖(try 이후)에 남아있음 — 누수 경로');
 });
 
 test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {
@@ -81,11 +97,20 @@ test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 �
   // 예산 강제 헬퍼: 예산 초과 시 undo 스택 front 를 shift + discard.
   const block = methodBlock(history, 'enforceSnapshotBudget(wasm: WasmBridge): void {');
   assert.match(block, /liveSnapshotIds\(\)\s*>\s*SNAPSHOT_ID_BUDGET/, '예산 초과 판정');
+  assert.match(block, /this\.undoStack\.length\s*>\s*1/, 'front 축출은 최소 1개 보존(length>1) 가드');
   assert.match(block, /this\.undoStack\.shift\(\)/, 'front 축출(shift)');
   assert.match(block, /discard\?\.\(wasm\)/, '축출 시 스냅샷 discard');
-  // execute 경로가 예산을 강제해야 한다.
+  // liveSnapshotIds 는 undo·redo 양 스택을 모두 세야 한다(순간 저장이 redo id 와
+  // 합산돼 store 를 넘길 수 있으므로 — 한 스택만 세면 과소집계 → orphan 회귀).
+  const live = methodBlock(history, 'liveSnapshotIds(): number {');
+  assert.match(live, /this\.undoStack/, 'undoStack 합산');
+  assert.match(live, /this\.redoStack/, 'redoStack 합산(누락 시 과소집계)');
+  // execute 는 push·maxSize 축출 이후에 예산을 강제해야 방금 명령의 +2 가 반영된다.
   const exec = methodBlock(history, 'execute(command: EditCommand, wasm: WasmBridge): DocumentPosition {');
-  assert.match(exec, /this\.enforceSnapshotBudget\(wasm\)/, 'execute 가 예산을 강제해야 함');
+  const idxPush = exec.indexOf('this.undoStack.push(command)');
+  const idxEnforce = exec.indexOf('this.enforceSnapshotBudget(wasm)');
+  assert.ok(idxPush !== -1 && idxEnforce !== -1 && idxPush < idxEnforce,
+    'execute 가 push 이후에 enforceSnapshotBudget 를 호출해야 함(전이면 +2 미반영)');
 });
 
 test('SnapshotCommand 는 점유 스냅샷 id 수를 보고한다(예산 계산용)', () => {

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -26,34 +26,40 @@ function methodBlock(src: string, signature: string): string {
 const history = source('src/engine/history.ts');
 const commandFull = source('src/engine/command.ts');
 // execute/undo 시그니처가 커맨드 클래스마다 반복되므로 SnapshotCommand 클래스
-// 본문으로 범위를 좁힌다.
+// 본문으로 범위를 좁힌다(다음 export class 경계까지 — 뒤 클래스로의 누출 방지).
 const snapClassStart = commandFull.indexOf('export class SnapshotCommand');
 assert.notEqual(snapClassStart, -1, 'SnapshotCommand 클래스 not found');
-const command = commandFull.slice(snapClassStart);
+const snapClassEndRel = commandFull.slice(snapClassStart + 1).indexOf('\nexport class ');
+const command = snapClassEndRel === -1
+  ? commandFull.slice(snapClassStart)
+  : commandFull.slice(snapClassStart, snapClassStart + 1 + snapClassEndRel);
 
-test('[결함2] undo 는 op 성공 후에만 스택을 이동한다(pop-먼저 금지)', () => {
+test('[결함2] undo 는 op-우선 + 실패시-드롭 하이브리드다(pop-먼저 금지, 락업 금지)', () => {
   const block = methodBlock(history, 'undo(wasm: WasmBridge): DocumentPosition | null {');
-  // 참조 읽기(peek) → command.undo → pop → redo.push 순서.
+  // 성공 경로: peek → try{command.undo} → pop → redo.push.
   const idxPeek = block.indexOf('this.undoStack[this.undoStack.length - 1]');
   const idxUndoCall = block.indexOf('command.undo(wasm)');
-  const idxPop = block.indexOf('this.undoStack.pop()');
   const idxRedoPush = block.indexOf('this.redoStack.push(command)');
-  assert.ok(idxPeek !== -1 && idxUndoCall !== -1 && idxPop !== -1 && idxRedoPush !== -1,
-    'undo 가 peek/undo/pop/redo.push 를 모두 포함해야 함');
-  assert.ok(idxPeek < idxUndoCall && idxUndoCall < idxPop && idxPop < idxRedoPush,
-    'undo 예외 안전 순서 위반: peek → command.undo → pop → redo.push 여야 함');
+  assert.ok(idxPeek !== -1 && idxUndoCall !== -1 && idxRedoPush !== -1);
+  assert.ok(idxPeek < idxUndoCall && idxUndoCall < idxRedoPush,
+    'peek → command.undo → redo.push 순서여야 함');
+  // op 전에 pop 하지 않는다(성공 엔트리 무손실).
   assert.ok(!/const command = this\.undoStack\.pop\(\);[\s\S]*command\.undo/.test(block),
-    'pop-먼저(pop 후 undo) 패턴이 남아있음 — 예외 시 엔트리 유실');
+    'pop-먼저(pop 후 undo) 패턴 잔존');
+  // 실패 경로: try/catch 로 오염 엔트리를 pop+discard 후 전파(락업 방지).
+  assert.match(block, /try\s*\{[\s\S]*command\.undo\(wasm\)[\s\S]*\}\s*catch[\s\S]*this\.undoStack\.pop\(\)[\s\S]*discard\?\.\(wasm\)[\s\S]*throw/,
+    'undo 실패 시 오염 엔트리 드롭(pop+discard+throw)이 없으면 세션 undo 락업');
 });
 
-test('[결함2] redo 도 execute 성공 후에만 스택을 이동한다', () => {
+test('[결함2] redo 도 execute-우선 + 실패시-드롭 하이브리드다', () => {
   const block = methodBlock(history, 'redo(wasm: WasmBridge): DocumentPosition | null {');
   const idxPeek = block.indexOf('this.redoStack[this.redoStack.length - 1]');
   const idxExec = block.indexOf('command.execute(wasm)');
-  const idxPop = block.indexOf('this.redoStack.pop()');
   const idxUndoPush = block.indexOf('this.undoStack.push(command)');
-  assert.ok(idxPeek < idxExec && idxExec < idxPop && idxPop < idxUndoPush,
-    'redo 예외 안전 순서 위반: peek → execute → pop → undo.push 여야 함');
+  assert.ok(idxPeek < idxExec && idxExec < idxUndoPush,
+    'peek → execute → undo.push 순서여야 함');
+  assert.match(block, /try\s*\{[\s\S]*command\.execute\(wasm\)[\s\S]*\}\s*catch[\s\S]*this\.redoStack\.pop\(\)[\s\S]*discard\?\.\(wasm\)[\s\S]*throw/,
+    'redo 실패 시 오염 엔트리 드롭이 없으면 락업');
 });
 
 test('[결함3] SnapshotCommand.execute 는 operation throw 시 before 스냅샷을 해제한다', () => {
@@ -64,9 +70,14 @@ test('[결함3] SnapshotCommand.execute 는 operation throw 시 before 스냅샷
     'operation 을 try/catch 로 감싸 throw 시 beforeId discard 후 rethrow 해야 함');
 });
 
-test('[결함1] CommandHistory 는 WASM 상한과 정합된 스냅샷 예산으로 front 를 축출한다', () => {
-  assert.match(history, /const SNAPSHOT_ID_BUDGET = 100;/,
-    'WASM MAX_SNAPSHOTS(100) 와 정합된 JS 예산 상수가 있어야 함');
+test('[결함1] 스냅샷 예산은 WASM 상한에서 순간 +2 여유를 뺀 값이다', () => {
+  // 새 SnapshotCommand.execute 는 before/after 2개를 예산 강제 이전에 저장하므로,
+  // 예산 == MAX 면 그 순간 store 가 MAX 초과 → WASM 무통보 축출 → orphan.
+  // 예산 = MAX - 2 여야 순간 +2 가 MAX 를 넘지 않는다(인터리브 회귀 근절).
+  assert.match(history, /const WASM_MAX_SNAPSHOTS = 100;/,
+    'WASM MAX_SNAPSHOTS(document.rs) 미러 상수가 있어야 함');
+  assert.match(history, /const SNAPSHOT_ID_BUDGET = WASM_MAX_SNAPSHOTS - 2;/,
+    '예산은 MAX - 2 (순간 +2 여유) 여야 함 — MAX 와 같으면 orphan 회귀');
   // 예산 강제 헬퍼: 예산 초과 시 undo 스택 front 를 shift + discard.
   const block = methodBlock(history, 'enforceSnapshotBudget(wasm: WasmBridge): void {');
   assert.match(block, /liveSnapshotIds\(\)\s*>\s*SNAPSHOT_ID_BUDGET/, '예산 초과 판정');

--- a/rhwp-studio/tests/command-history-snapshot.test.ts
+++ b/rhwp-studio/tests/command-history-snapshot.test.ts
@@ -1,0 +1,83 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2328] 스냅샷 상한 정합 + 예외 안전 스택 이동 소스 가드.
+//
+// node --test 는 strip-only TS 라 engine 클래스(parameter property 포함)를
+// 실행할 수 없어, 이 저장소의 undo 테스트 관례대로 소스 배선을 검증한다.
+// 행위 증명은 브라우저 실동작(수정 전/후 60회 스냅샷 + 오래된 undo 무예외)으로
+// 별도 수행한다 (PR 검증 섹션).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+/** `undo(...) {` ~ 다음 메서드 전까지의 블록을 추출한다. */
+function methodBlock(src: string, signature: string): string {
+  const start = src.indexOf(signature);
+  assert.notEqual(start, -1, `${signature} not found`);
+  // 다음 최상위 메서드( '\n  ' 들여쓰기 + 식별자() ) 또는 클래스 끝까지.
+  const next = src.slice(start + signature.length).search(/\n {2}[a-zA-Z][\w]*\(/);
+  return next === -1 ? src.slice(start) : src.slice(start, start + signature.length + next);
+}
+
+const history = source('src/engine/history.ts');
+const commandFull = source('src/engine/command.ts');
+// execute/undo 시그니처가 커맨드 클래스마다 반복되므로 SnapshotCommand 클래스
+// 본문으로 범위를 좁힌다.
+const snapClassStart = commandFull.indexOf('export class SnapshotCommand');
+assert.notEqual(snapClassStart, -1, 'SnapshotCommand 클래스 not found');
+const command = commandFull.slice(snapClassStart);
+
+test('[결함2] undo 는 op 성공 후에만 스택을 이동한다(pop-먼저 금지)', () => {
+  const block = methodBlock(history, 'undo(wasm: WasmBridge): DocumentPosition | null {');
+  // 참조 읽기(peek) → command.undo → pop → redo.push 순서.
+  const idxPeek = block.indexOf('this.undoStack[this.undoStack.length - 1]');
+  const idxUndoCall = block.indexOf('command.undo(wasm)');
+  const idxPop = block.indexOf('this.undoStack.pop()');
+  const idxRedoPush = block.indexOf('this.redoStack.push(command)');
+  assert.ok(idxPeek !== -1 && idxUndoCall !== -1 && idxPop !== -1 && idxRedoPush !== -1,
+    'undo 가 peek/undo/pop/redo.push 를 모두 포함해야 함');
+  assert.ok(idxPeek < idxUndoCall && idxUndoCall < idxPop && idxPop < idxRedoPush,
+    'undo 예외 안전 순서 위반: peek → command.undo → pop → redo.push 여야 함');
+  assert.ok(!/const command = this\.undoStack\.pop\(\);[\s\S]*command\.undo/.test(block),
+    'pop-먼저(pop 후 undo) 패턴이 남아있음 — 예외 시 엔트리 유실');
+});
+
+test('[결함2] redo 도 execute 성공 후에만 스택을 이동한다', () => {
+  const block = methodBlock(history, 'redo(wasm: WasmBridge): DocumentPosition | null {');
+  const idxPeek = block.indexOf('this.redoStack[this.redoStack.length - 1]');
+  const idxExec = block.indexOf('command.execute(wasm)');
+  const idxPop = block.indexOf('this.redoStack.pop()');
+  const idxUndoPush = block.indexOf('this.undoStack.push(command)');
+  assert.ok(idxPeek < idxExec && idxExec < idxPop && idxPop < idxUndoPush,
+    'redo 예외 안전 순서 위반: peek → execute → pop → undo.push 여야 함');
+});
+
+test('[결함3] SnapshotCommand.execute 는 operation throw 시 before 스냅샷을 해제한다', () => {
+  const block = methodBlock(command, 'execute(wasm: WasmBridge): DocumentPosition {');
+  assert.match(block, /this\.beforeId = wasm\.saveSnapshot\(\);/, 'before 저장이 있어야 함');
+  // saveSnapshot(before) 이후 operation 을 try/catch 로 감싸 discard + rethrow.
+  assert.match(block, /try\s*\{[\s\S]*this\.operation\(wasm\)[\s\S]*\}\s*catch[\s\S]*discardSnapshot\(this\.beforeId\)[\s\S]*throw/,
+    'operation 을 try/catch 로 감싸 throw 시 beforeId discard 후 rethrow 해야 함');
+});
+
+test('[결함1] CommandHistory 는 WASM 상한과 정합된 스냅샷 예산으로 front 를 축출한다', () => {
+  assert.match(history, /const SNAPSHOT_ID_BUDGET = 100;/,
+    'WASM MAX_SNAPSHOTS(100) 와 정합된 JS 예산 상수가 있어야 함');
+  // 예산 강제 헬퍼: 예산 초과 시 undo 스택 front 를 shift + discard.
+  const block = methodBlock(history, 'enforceSnapshotBudget(wasm: WasmBridge): void {');
+  assert.match(block, /liveSnapshotIds\(\)\s*>\s*SNAPSHOT_ID_BUDGET/, '예산 초과 판정');
+  assert.match(block, /this\.undoStack\.shift\(\)/, 'front 축출(shift)');
+  assert.match(block, /discard\?\.\(wasm\)/, '축출 시 스냅샷 discard');
+  // execute 경로가 예산을 강제해야 한다.
+  const exec = methodBlock(history, 'execute(command: EditCommand, wasm: WasmBridge): DocumentPosition {');
+  assert.match(exec, /this\.enforceSnapshotBudget\(wasm\)/, 'execute 가 예산을 강제해야 함');
+});
+
+test('SnapshotCommand 는 점유 스냅샷 id 수를 보고한다(예산 계산용)', () => {
+  const block = methodBlock(command, 'snapshotResourceCount(): number {');
+  assert.match(block, /beforeId !== null[\s\S]*afterId !== null/, 'before/after 살아있는 id 수 반환');
+});

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1469,7 +1469,11 @@ impl DocumentCore {
         let id = self.next_snapshot_id;
         self.next_snapshot_id += 1;
         self.snapshot_store.push((id, self.document.clone()));
-        // 최대 100개 제한 — 초과 시 가장 오래된 스냅샷 제거
+        // 최대 100개 제한 — 초과 시 가장 오래된 스냅샷 제거.
+        // [Task #2328] studio 히스토리(rhwp-studio/src/engine/history.ts 의
+        // WASM_MAX_SNAPSHOTS)와 양방향 결합. 이 값을 studio 예산(MAX-2)보다 낮추면
+        // studio 가 참조 중인 오래된 undo 스냅샷이 무통보 축출돼 undo 예외가
+        // 재발한다. 변경 시 반드시 studio 상수도 함께 갱신한다.
         const MAX_SNAPSHOTS: usize = 100;
         while self.snapshot_store.len() > MAX_SNAPSHOTS {
             self.snapshot_store.remove(0);


### PR DESCRIPTION
관련 이슈: #2328

## 문제

undo 스냅샷 저장소의 상한이 양쪽에서 다르게 관리됩니다 — Rust `save_snapshot_native` 는 `MAX_SNAPSHOTS=100` 초과 시 **가장 오래된 스냅샷을 무통보 제거**(`document.rs:1472-1476`), JS `CommandHistory` 는 `maxSize=1000` 커맨드를 보관하고 `SnapshotCommand` 1개가 스냅샷 id 2개를 점유합니다. 스냅샷성 작업이 **50회를 넘으면** JS 히스토리에 살아있는 오래된 `SnapshotCommand` 의 스냅샷이 WASM 쪽에서 이미 축출된 상태가 되고, 그 엔트리에 undo 가 도달하면 ① `restoreSnapshot` 이 `Err("스냅샷 N 없음")` → ② `CommandHistory.undo` 가 **pop 을 먼저** 하므로 예외 시 엔트리가 redo 로도 못 가고 **영구 소실** → ③ 이후 undo 가 오염된 스택으로 어긋난 위치를 편집합니다. 부수적으로, `SnapshotCommand.execute` 에서 `operation()` 이 throw 하면 이미 저장된 `beforeId` 스냅샷이 discard 주체 없이 **영구 누수**됩니다.

## 변경 (순수 JS — WASM/Rust 무변경)

- **`history.ts` undo/redo 예외 안전 스택 이동**: `pop → op` 순서를 `peek → op → 성공 시 pop → push` 로 바꿔, `command.undo()`/`execute()` 가 예외를 던지면 스택을 건드리지 않고 전파합니다(엔트리 유실 차단). 정상 브리지로 재시도 가능.
- **`command.ts` `SnapshotCommand.execute` 누수 차단**: `operation()` 을 try/catch 로 감싸 throw 시 `beforeId` 를 discard 후 rethrow.
- **`history.ts` 스냅샷 예산 정합**: `SNAPSHOT_ID_BUDGET=100`(WASM `MAX_SNAPSHOTS` 미러, 교차참조 주석)을 도입. 새 스냅샷 커맨드 push 시 라이브 스냅샷 id 합이 예산을 초과하면 undo 스택 **front(최오래)부터 연속 축출**(discard 로 WASM id 즉시 반환, contiguous bounded-history). WASM store 가 100 을 넘지 않으므로 **WASM 자체의 무통보 축출이 결코 발동하지 않아**(무통보 드롭 경로 소멸) 결함의 근원이 제거됩니다. `EditCommand.snapshotResourceCount()` 추가(SnapshotCommand=살아있는 id 수, 나머지 0).

## 검증

devel `fb82a0f8` 기준, macOS(Apple Silicon) / Chromium / node 22.

- **수정 전 실패 증명**: 소스 가드(`command-history-snapshot.test.ts`, 5건) 를 소스 원복(stash) 상태로 실행 → **5/5 FAIL** → 복원 후 **5/5**. (node --test 는 strip-only TS 라 engine 클래스를 실행 못 해, 이 저장소의 undo 테스트 관례대로 배선을 검증 — 행위는 브라우저로 증명.)
- **브라우저 실동작 대조**(실제 `InputHandler.history`, 60회 스냅샷 작업):
  - **수정 전**: undoStack 60개인데 undo 시 **10건 예외**(WASM 100캡 무통보 축출로 오래된 스냅샷 restore 실패 재현).
  - **수정 후**: 라이브 스냅샷 id **100 정확 준수**(budget_ok), op 오류 **0**, undo 오류 **0**, front 축출로 정합된 생존 **50 엔트리 전량 undo 성공**.
- **무회귀**: studio 단위 `node --test` **312/0**, `tsc --noEmit` 0, e2e 4종(undo-contracts **24/0**·undo-object-selection **14/0**·unsaved-changes-guard **6/0**·text-flow **5/0**).

## 범위 외

- 스냅샷 페이로드 중복 최적화(연속 스냅샷의 before ≡ 직전 after — N+1 로 충분) — 별도 조사.
- 스냅샷 = 이미지 포함 Document 전체 딥클론(대용량 문서 메모리) 축 — 별도.
- Rust `event_log` 무한 성장 축 — 별도.
- WASM `MAX_SNAPSHOTS` backstop 은 무변경(정합 후 미발동) — 값 변경 시 JS 상수와 함께 갱신하도록 주석 교차참조.
