### PR TITLE
Task #2334: #2329 DEV 런타임 뮤테이션 가드 제거 — kind:'record' 오탐 net-negative, 소스 가드로 일원화

### DIFF
--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -1,18 +1,20 @@
 /**
- * [Task #2327] 문서 변경 WASM 호출의 히스토리 라우팅 가드 (DEV 전용).
+ * [Task #2327] 문서 변경 WasmBridge 메서드의 단일 권위 목록(레지스트리).
  *
  * studio 의 undo 는 executeOperation → CommandHistory 경유가 전제이지만 강제
  * 장치가 없어 기록이 옵트인이다 — 미기록 뮤테이션은 ① 해당 편집 undo 불가
- * ② redo 스택 미무효화(옛 after-스냅샷 재적용이 변경을 무언 삭제) ③ 스냅샷
- * undo 의 전체 문서 복원에 동반 파괴, 3중 위험을 만든다 (#2027/#2037/#2053/
- * #2077 재발 계급). 이 모듈은 히스토리 실행 창(opDepth) 밖에서 문서 변경
- * 메서드가 호출되면 DEV 빌드에서 경고한다. 런타임 동작은 바꾸지 않는다.
+ * ② redo 스택 미무효화 ③ 스냅샷 undo 의 전체 문서 복원에 동반 파괴, 3중
+ * 위험을 만든다 (#2027/#2037/#2053/#2077 재발 계급).
  *
- * `MUTATING_METHODS`/`EXCLUDED_NON_DOCUMENT` 는 단일 권위 목록으로,
- * tests/mutation-routing-guard.test.ts 가 이 소스를 파싱해 ① 브리지 신규
- * 메서드의 분류 누락(드리프트)과 ② 소스 내 뮤테이션 호출 원장(BASELINE)을
- * 검증한다. 브리지에 문서 변경 메서드를 추가하면 두 목록 중 하나에 반드시
- * 분류해야 한다.
+ * 이 레지스트리는 tests/mutation-routing-guard.test.ts 가 파싱해 저작 시점에
+ * ① 브리지 신규/rename 뮤테이터의 분류 누락(양방향 드리프트)과 ② 뮤테이션
+ * 표면 원장(BASELINE)의 증가를 차단한다. 브리지에 문서 변경 메서드를 추가하면
+ * 두 목록 중 하나에 반드시 분류해야 한다.
+ *
+ * (초기 설계의 DEV 런타임 opDepth 가드는 kind:'record' 계약(드래그/이동/표
+ * nudge — 뮤테이션을 record 전에 직접 적용)을 구분하지 못해 일상 편집마다
+ * 오탐하고 warnedMethods 소진으로 진짜 미라우팅까지 침묵시켜, 저작 시점 소스
+ * 가드만 남겼다. 자세한 근거: PR #2329 리뷰 스레드.)
  */
 
 /** 문서 IR(직렬화 결과)을 바꾸는 WasmBridge 공개 메서드 전수. */
@@ -82,63 +84,3 @@ export const EXCLUDED_NON_DOCUMENT: readonly string[] = [
   'ensureParagraphStableIds', // 런타임 추적 id 부여
 ];
 
-let opDepth = 0;
-let allowDepth = 0;
-const warnedMethods = new Set<string>();
-
-/**
- * 히스토리 비경유가 계약상 허용된 극소수 경로의 명시 선언.
- * 현재 유일한 사용처: IME 조합 중간 raw 삽입/삭제 (조합 확정 시
- * executeOperation(kind:'record') 로 사후 기록되는 2단 계약).
- */
-export function allowUnrecordedMutation<T>(fn: () => T): T {
-  allowDepth++;
-  try {
-    return fn();
-  } finally {
-    allowDepth--;
-  }
-}
-
-/**
- * DEV 전용 설치: WasmBridge 인스턴스의 MUTATING_METHODS 를 래핑해 히스토리
- * 실행 창(CommandHistory.execute/undo/redo/recordWithoutExecute) 밖 호출을
- * console.warn 으로 알린다. 메서드당 1회만 경고(콘솔 홍수 방지).
- * 프로토타입 래핑은 installCanvasFontSubstitution 관용구와 동일 결.
- */
-export function installMutationGuard(
-  bridge: Record<string, unknown>,
-  // eslint-disable-next-line @typescript-eslint/no-explicit-any
-  historyCtor: { prototype: any },
-): void {
-  const proto = historyCtor.prototype as Record<string, unknown>;
-  for (const name of ['execute', 'undo', 'redo', 'recordWithoutExecute']) {
-    const original = proto[name] as ((...args: unknown[]) => unknown) | undefined;
-    if (typeof original !== 'function') continue;
-    proto[name] = function (this: unknown, ...args: unknown[]): unknown {
-      opDepth++;
-      try {
-        return original.apply(this, args);
-      } finally {
-        opDepth--;
-      }
-    };
-  }
-
-  for (const name of MUTATING_METHODS) {
-    const original = bridge[name] as ((...args: unknown[]) => unknown) | undefined;
-    if (typeof original !== 'function') continue;
-    bridge[name] = function (this: unknown, ...args: unknown[]): unknown {
-      if (opDepth === 0 && allowDepth === 0 && !warnedMethods.has(name)) {
-        warnedMethods.add(name);
-        // eslint-disable-next-line no-console
-        console.warn(
-          `[MutationGuard] 미기록 문서 변경: wasm.${name}() 이 히스토리 실행 창 밖에서 ` +
-            `호출됨 — undo 불가·redo 오염·스냅샷 undo 동반 파괴 위험 (#2327). ` +
-            `executeOperation 라우팅 또는 allowUnrecordedMutation 명시 선언 필요.`,
-        );
-      }
-      return original.apply(bridge, args);
-    };
-  }
-}

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1,5 +1,4 @@
 import { WasmBridge } from '@/core/wasm-bridge';
-import { allowUnrecordedMutation } from '@/core/wasm-mutation-guard';
 import { EventBus } from '@/core/event-bus';
 import { CursorState } from './cursor';
 import { CaretRenderer } from './caret-renderer';
@@ -2258,19 +2257,12 @@ export class InputHandler {
 
   /** 위치에 텍스트를 삽입한다 (WASM 직접 호출, IME 조합용) */
   private insertTextAtRaw(pos: DocumentPosition, text: string): void {
-    // [Task #2327] IME 조합 중간 삽입은 히스토리 비경유가 계약(조합 확정 시
-    // executeOperation(kind:'record')로 사후 기록). 뮤테이션 가드에 명시 선언.
-    allowUnrecordedMutation(() => {
-      this.rawTextMutationEffects.add(_text.insertTextAtRaw.call(this, pos, text));
-    });
+    this.rawTextMutationEffects.add(_text.insertTextAtRaw.call(this, pos, text));
   }
 
   /** 위치에서 텍스트를 삭제한다 (WASM 직접 호출, IME 조합용) */
   private deleteTextAt(pos: DocumentPosition, count: number): void {
-    // [Task #2327] IME 조합 중간 삭제 — 위와 동일 계약.
-    allowUnrecordedMutation(() => {
-      _text.deleteTextAt.call(this, pos, count);
-    });
+    _text.deleteTextAt.call(this, pos, count);
     this.rawTextMutationEffects.add(IMMEDIATE_TEXT_MUTATION_EFFECTS);
   }
 

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -31,8 +31,6 @@ import { showToast } from '@/ui/toast';
 import { addRecentDoc, listRecentDocs } from '@/recent/recent-store';
 import { showDropConfirmDialog } from '@/ui/drop-confirm-dialog';
 import { initRhwpDev } from '@/core/rhwp-dev';
-import { installMutationGuard } from '@/core/wasm-mutation-guard';
-import { CommandHistory } from '@/engine/history';
 import { DocumentDirtyState } from '@/core/document-dirty-state';
 import { initThemeSync, setThemeMode, getThemeMode, getEffectiveTheme } from '@/core/theme';
 import { analyzeDocumentFonts } from '@/core/document-font-status';
@@ -79,8 +77,6 @@ if (import.meta.env.DEV) {
   (window as any).__autosaveManager = autosaveManager;
   (window as any).__theme = { getThemeMode, getEffectiveTheme, setThemeMode };
   initRhwpDev(wasm);
-  // [Task #2327] 미기록 문서 변경 감시 — 히스토리 실행 창 밖 뮤테이션 경고.
-  installMutationGuard(wasm as unknown as Record<string, unknown>, CommandHistory);
 }
 let canvasView: CanvasView | null = null;
 let inputHandler: InputHandler | null = null;

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -7,15 +7,15 @@ import { fileURLToPath } from 'node:url';
 // [Task #2327] 계급 1(기록 옵트인) 회귀를 저작 시점에 차단하는 소스 가드.
 //
 // 두 정적 검사:
-//  (1) 드리프트 — WasmBridge 의 문서-변경형 공개 메서드는 wasm-mutation-guard.ts 의
-//      MUTATING_METHODS 또는 EXCLUDED_NON_DOCUMENT 중 하나에 반드시 분류돼야 한다.
-//      새 뮤테이터가 목록에 안 잡히면 DEV 가드도 그 호출을 못 잡으므로, 분류 누락을
-//      실패로 만든다.
-//  (2) 원장 트립와이어 — ui/ + command/ 에서 뮤테이터를 직접 호출하는 표면(파일별
-//      호출 수)을 동결한다. 신규 파일·증가는 실패 → 의식적 baseline 갱신 + 리뷰 강제.
-//      (라우팅 경유 여부의 실제 판정은 런타임 DEV MutationGuard 가 담당한다 —
-//      텍스트 카운트는 executeOperation 콜백 내부 호출도 세므로 이관해도 줄지 않는다.
-//      따라서 이 원장은 "라우팅 여부"가 아니라 "뮤테이션 표면 증가"의 트립와이어다.)
+//  (1) 드리프트(양방향) — mutation-method-registry.ts 의 MUTATING_METHODS /
+//      EXCLUDED_NON_DOCUMENT 가 브리지의 문서-변경형 공개 메서드를 전수 분류하고
+//      (신규 뮤테이터 누락 차단), 역으로 목록 전 항목이 실제 브리지 메서드인지도
+//      강제한다(rename/제거 무통보 차단).
+//  (2) 원장 트립와이어 — ui/ + command/ + engine/input-handler* 에서 뮤테이터를
+//      직접 호출하는 표면(파일별 호출 수)을 동결한다. 신규 파일·증가는 실패 →
+//      의식적 baseline 갱신 + 리뷰 강제. (텍스트 카운트는 executeOperation 콜백
+//      내부 호출도 세므로 "라우팅 여부"가 아니라 "뮤테이션 표면 증가"의
+//      트립와이어다.)
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 
@@ -23,7 +23,7 @@ function source(rel: string): string {
   return readFileSync(join(rootDir, rel), 'utf8');
 }
 
-/** wasm-mutation-guard.ts 의 배열 상수를 단일 권위원으로 파싱한다. */
+/** mutation-method-registry.ts 의 배열 상수를 단일 권위원으로 파싱한다. */
 function parseStringArray(guardSrc: string, name: string): string[] {
   // `export const NAME ...= [ ... ];` 선언에 앵커(상단 주석의 이름 언급 회피).
   const m = guardSrc.match(new RegExp(`export const ${name}\\b[^=]*=\\s*\\[([\\s\\S]*?)\\];`));
@@ -31,7 +31,7 @@ function parseStringArray(guardSrc: string, name: string): string[] {
   return [...m![1].matchAll(/'([A-Za-z0-9_]+)'/g)].map((x) => x[1]);
 }
 
-const guardSrc = source('src/core/wasm-mutation-guard.ts');
+const guardSrc = source('src/core/mutation-method-registry.ts');
 const MUTATING = parseStringArray(guardSrc, 'MUTATING_METHODS');
 const EXCLUDED = parseStringArray(guardSrc, 'EXCLUDED_NON_DOCUMENT');
 
@@ -52,8 +52,18 @@ function bridgePublicMethods(): string[] {
   return [...names].filter((n) => !priv.has(n));
 }
 
-// 문서 변경을 시사하는 동사 접두어.
-const MUTATING_VERB = /^(insert|delete|create|apply|add|remove|move|resize|merge|split|update|toggle|replace|paste|assign|group|ungroup|change|clear|evaluate|equalize|transpose|setPage|setSection|setColumn|setCell|setTable|setPicture|setShape|setEquation|setNote|setChar|setPara|setField|setForm|setNumbering|setHeaderFooter|setActiveField|renameBookmark|reflowLinesegs)/;
+// 문서 변경을 시사하는 동사 접두어. MUTATING_METHODS 의 모든 이름을 커버해야
+// 하며(아래 자기정합 단언이 강제), 그래야 새 브리지 뮤테이터가 drift 에 걸린다.
+// find* 는 쿼리(findNextEditableControl 등)가 많아 findOrCreate 로 좁힌다.
+const MUTATING_VERB = /^(insert|delete|create|apply|add|remove|move|resize|merge|split|update|toggle|replace|paste|assign|group|ungroup|change|clear|evaluate|transpose|ensure|findOrCreate|reflow|setPage|setSection|setColumn|setCell|setTable|setPicture|setShape|setEquation|setNote|setChar|setPara|setField|setForm|setNumbering|setHeaderFooter|setActiveField|renameBookmark)/;
+
+test('MUTATING_VERB 는 MUTATING_METHODS 전 항목을 커버한다(drift 사각 방지)', () => {
+  // 목록에 있으나 동사 패턴에 안 걸리는 이름이 있으면, 그 계열의 신규 브리지
+  // 뮤테이터가 drift 에서 누락된다(ensure*/find* 계열 사각이 실제였음).
+  const uncovered = MUTATING.filter((m) => !MUTATING_VERB.test(m));
+  assert.deepEqual(uncovered, [],
+    `MUTATING_METHODS 에 MUTATING_VERB 가 못 잡는 이름: ${uncovered.join(', ')} → 동사 추가 필요`);
+});
 
 test('드리프트: 문서-변경형 브리지 공개 메서드는 모두 분류돼야 한다', () => {
   const classified = new Set([...MUTATING, ...EXCLUDED]);
@@ -64,7 +74,7 @@ test('드리프트: 문서-변경형 브리지 공개 메서드는 모두 분류
     unclassified,
     [],
     `WasmBridge 신규(?) 뮤테이터가 분류되지 않음: ${unclassified.join(', ')}\n` +
-      `→ wasm-mutation-guard.ts 의 MUTATING_METHODS(기록 강제) 또는 ` +
+      `→ mutation-method-registry.ts 의 MUTATING_METHODS(기록 대상) 또는 ` +
       `EXCLUDED_NON_DOCUMENT(문서 비변경 사유)에 추가하라.`,
   );
 });
@@ -74,10 +84,9 @@ test('MUTATING_METHODS / EXCLUDED_NON_DOCUMENT 는 서로 겹치지 않는다', 
   assert.deepEqual(dup, [], `양쪽에 중복 분류됨: ${dup.join(', ')}`);
 });
 
-test('MUTATING_METHODS 는 모두 실제 브리지 공개 메서드여야 한다(rename 무통보 skip 방지)', () => {
-  // installMutationGuard 는 `typeof original !== 'function'` 이면 조용히 건너뛴다.
-  // 브리지에서 메서드가 rename/제거되면 목록의 옛 이름은 가드에서 무통보로
-  // 비활성화되므로(가드 사각), 목록 항목이 전부 실재하는지 역방향으로 강제한다.
+test('MUTATING_METHODS 는 모두 실제 브리지 공개 메서드여야 한다(rename skip 방지)', () => {
+  // 브리지에서 메서드가 rename/제거되면 목록의 옛 이름이 드리프트·원장 검사에서
+  // 무의미해지므로(권위 목록 사각), 목록 항목이 전부 실재하는지 역방향으로 강제한다.
   const bridge = new Set(bridgePublicMethods());
   const missing = MUTATING.filter((m) => !bridge.has(m));
   assert.deepEqual(
@@ -90,7 +99,11 @@ test('MUTATING_METHODS 는 모두 실제 브리지 공개 메서드여야 한다
 
 // ── (2) 원장 트립와이어: 뮤테이션 표면 동결 ─────────────────────────────────
 
-/** ui/ + command/ 하위 .ts 파일 나열(테스트 제외). */
+/**
+ * 뮤테이션 표면 스캔 대상: ui/ + command/ + engine/input-handler*.ts.
+ * input-handler* 는 드래그/키보드 nudge 등 최고밀도 직접-뮤테이션 영역이므로
+ * 반드시 포함한다(누락 시 엔진 층의 신규 미라우팅이 원장에 안 걸림).
+ */
 function scanFiles(): string[] {
   const out: string[] = [];
   const walk = (rel: string) => {
@@ -102,6 +115,12 @@ function scanFiles(): string[] {
   };
   walk('src/ui');
   walk('src/command');
+  for (const ent of readdirSync(join(rootDir, 'src/engine'), { withFileTypes: true })) {
+    if (ent.isFile() && ent.name.startsWith('input-handler') && ent.name.endsWith('.ts')
+      && !ent.name.endsWith('.test.ts')) {
+      out.push(`src/engine/${ent.name}`);
+    }
+  }
   return out.sort();
 }
 
@@ -136,6 +155,14 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/style-edit-dialog.ts': 6,
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
+  // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
+  'src/engine/input-handler.ts': 25,
+  'src/engine/input-handler-connector.ts': 1,
+  'src/engine/input-handler-keyboard.ts': 21,
+  'src/engine/input-handler-mouse.ts': 3,
+  'src/engine/input-handler-picture.ts': 11,
+  'src/engine/input-handler-table.ts': 7,
+  'src/engine/input-handler-text.ts': 14,
 };
 
 test('뮤테이션 표면 원장: 신규·증가 사이트는 baseline 갱신을 강제한다', () => {


### PR DESCRIPTION
관련 이슈: #2334 (PR #2329 / #2327 후속)

## 경위

[PR #2329](https://github.com/edwardkim/rhwp/pull/2329)를 머지해 주셔서 감사합니다 — 코멘트에서 `allowUnrecordedMutation` IME 계약과 런타임 가드를 좋게 봐 주셨는데, **머지 직후 진행한 자체 code-review(재실행)에서 그 DEV 런타임 가드가 net-negative 임을 확증**했습니다. 제거 커밋 `1d51e89e` 를 준비했으나 **머지 레이스**로 반영되지 못했습니다(머지 시점 head=`e26690ba`, 제거 커밋은 그 직후 push). 이 PR 로 후속 제거합니다.

## 문제 — 런타임 가드가 kind:'record' 계약을 구분하지 못함

`installMutationGuard` 는 히스토리 실행 창(`CommandHistory.execute/undo/redo/recordWithoutExecute`, opDepth) 밖에서 `MUTATING_METHODS` 호출이 일어나면 경고합니다. 그러나 studio 의 **`kind:'record'` 편집 계약**은 뮤테이션을 `recordWithoutExecute`(재실행 안 함) **이전에 `opDepth==0` 에서 직접 적용**합니다 — 개체/표 드래그·키보드 nudge 8곳+:

- `input-handler-picture.ts` 리사이즈/이동 드래그·Shift+화살표 (`setPictureProperties`/`setShapeProperties`)
- `input-handler-table.ts` 표 이동 nudge/드래그 (`moveTableOffset`)
- 이동 후 side-effect (`updateConnectorsInSection`) 등

따라서 **① 일상 리사이즈/이동/nudge 마다 가짜 '미기록 문서 변경' 경고**(undo/redo 는 정상인데도) ② `warnedMethods`(메서드당 1회 dedup)가 그 **고빈도 핵심 메서드명을 세션 영구 소진** → 이후 그 메서드의 **진짜 미라우팅(#2327 이 잡으려는 바로 그 버그)까지 침묵**. 가드가 자기 목적을 훼손합니다.

`kind:'record'` 사이트 8곳+ 를 `allowUnrecordedMutation` 으로 개별 래핑하면 가드가 막으려던 **옵트인 취약성이 재도입**되고, 다중 WasmBridge 인스턴스(diff/compare)·flush/refresh 완전성 홀도 잔존합니다. 그래서 래핑이 아니라 **런타임 가드 제거 + 소스 가드 일원화**가 옳다고 판단했습니다.

## 변경 (소스 전용, devel 기준)

- 런타임 가드 제거: `installMutationGuard`/`allowUnrecordedMutation`/opDepth 삭제, `main.ts` install·`input-handler` IME 래핑 되돌림.
- `wasm-mutation-guard.ts` → **`mutation-method-registry.ts`**(권위 목록만).
- **소스 가드 강화**: 원장 스캔에 `engine/input-handler*`(드래그/nudge 최고밀도 직접-뮤테이션 영역 — 종전 누락) 추가; `MUTATING_VERB` 에 `ensure`/`findOrCreate`/`reflow` 추가 + 목록 전 항목 커버 자기정합 단언 + dead `equalize` 제거.

이로써 오탐 없는 저작 시점 소스 가드(양방향 드리프트 + 표면 원장)만 남고, #2329 가 세운 "기록 옵트인 구조 결함을 저작 시점에 차단" 목표는 온전히 유지됩니다.

## 검증

devel `7ccfc5a0` 기준.

- 가드 테스트 **5/5**(드리프트 양방향·자기정합·원장 확장). 역방향/자기정합은 가짜 이름 주입 시 FAIL 실증.
- `tsc --noEmit` 0, studio 단위 `node --test` **312/0**, e2e(undo-contracts 24·text-flow 5), 부팅 콘솔 에러 0(오탐 경고 소멸).

## 범위 외

- 미라우팅 ~45곳 이관 연작(원장 감소 게이지) — #2327 후속으로 유지.
