### PR TITLE
Task #2337: [undo] 머리말/꼬리말·각주 편집 히스토리 기록 — 본문 스냅샷 undo의 무언 데이터 손실 차단

### DIFF
--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1498,7 +1498,7 @@ export class WasmBridge {
     return JSON.parse((this.doc as any).insertTextInFootnote(sec, para, controlIdx, fnParaIdx, charOffset, text));
   }
 
-  deleteTextInFootnote(sec: number, para: number, controlIdx: number, fnParaIdx: number, charOffset: number, count: number): { ok: boolean; charOffset: number } {
+  deleteTextInFootnote(sec: number, para: number, controlIdx: number, fnParaIdx: number, charOffset: number, count: number): { ok: boolean; charOffset: number; deletedText: string } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return JSON.parse((this.doc as any).deleteTextInFootnote(sec, para, controlIdx, fnParaIdx, charOffset, count));
   }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -880,6 +880,16 @@ function hfFnStubPosition(sectionIdx: number): DocumentPosition {
   return { sectionIndex: sectionIdx, paragraphIndex: 0, charOffset: 0 };
 }
 
+/**
+ * [Task #2337-review] WASM 삭제 count 는 Rust `Paragraph::delete_text_at` 의 char(Unicode
+ * scalar) 단위다. JS `String.length`(UTF-16 code unit)를 넘기면 astral 문자(😀 등)에서
+ * 실제보다 많이 삭제해 undo/redo 가 인접 문자를 잃는다 → 코드포인트 수로 계산한다.
+ * (커서 오프셋은 studio 의 UTF-16 관례를 유지하므로 여기서만 char 단위를 쓴다.)
+ */
+function charCount(s: string): number {
+  return [...s].length;
+}
+
 // ── 머리말/꼬리말 ──────────────────────────────────────────
 
 export class InsertTextInHeaderFooterCommand implements EditCommand {
@@ -903,7 +913,7 @@ export class InsertTextInHeaderFooterCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.text.length);
+    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, charCount(this.text));
     this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset);
     return hfFnStubPosition(this.target.sectionIdx);
   }
@@ -929,7 +939,7 @@ export class DeleteTextInHeaderFooterCommand implements EditCommand {
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.deletedText.length);
+    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, charCount(this.deletedText));
     this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset);
     return hfFnStubPosition(this.target.sectionIdx);
   }
@@ -1034,7 +1044,7 @@ export class InsertTextInFootnoteCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.text.length);
+    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, charCount(this.text));
     this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset);
     return hfFnStubPosition(this.target.sectionIdx);
   }
@@ -1059,7 +1069,7 @@ export class DeleteTextInFootnoteCommand implements EditCommand {
   }
 
   execute(wasm: WasmBridge): DocumentPosition {
-    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.deletedText.length);
+    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, charCount(this.deletedText));
     this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset);
     return hfFnStubPosition(this.target.sectionIdx);
   }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -23,7 +23,38 @@ export interface EditCommand {
   getPageLocalTextEditOptions?(): { insertedText?: string; deleteCount?: number };
   /** 방금 실행한 mutation effect를 한 번만 반환한다. */
   consumeTextMutationEffects?(): TextMutationEffects;
+  /**
+   * [Task #2337] 이 커맨드의 마지막 execute/undo 후 복원할 머리말/꼬리말·각주 편집
+   * 컨텍스트. 본문 커맨드는 미구현(→ 반환 없음 = 본문 모드). InputHandler 가 undo/redo
+   * 시 이 값을 읽어 HF/FN 모드 재진입 + 커서 위치를 복원하고 본문 moveTo 를 건너뛴다.
+   */
+  editContext?(): EditContext | null;
 }
+
+/**
+ * [Task #2337] 머리말/꼬리말·각주 편집 커맨드가 undo/redo 후 복원할 편집 컨텍스트.
+ * 본문 DocumentPosition 과 별개인 HF/FN 커서 모드를 서술한다(cursor.ts 의
+ * enterHeaderFooterMode/enterFootnoteMode + set{Hf,Fn}CursorPosition 인자에 대응).
+ */
+export type EditContext =
+  | {
+      readonly mode: 'headerFooter';
+      readonly sectionIdx: number;
+      readonly isHeader: boolean;
+      readonly applyTo: number;
+      readonly paraIdx: number;
+      readonly charOffset: number;
+    }
+  | {
+      readonly mode: 'footnote';
+      readonly sectionIdx: number;
+      readonly paraIdx: number;
+      readonly controlIdx: number;
+      readonly footnoteIndex: number;
+      readonly pageNum: number;
+      readonly innerParaIdx: number;
+      readonly charOffset: number;
+    };
 
 /** cell text mutation의 deferred/flow 경계와 immediate pagination 완료를 함께 전달한다. */
 export interface TextMutationEffects {
@@ -801,6 +832,308 @@ export class MergeNextParagraphCommand implements EditCommand {
     return { ...this.position };
   }
 
+  mergeWith(): null { return null; }
+}
+
+// ─── [Task #2337] 머리말/꼬리말·각주 편집 커맨드 ───────────────────────────
+//
+// HF/FN 편집은 본문과 별개 WASM 경로(insert/delete/merge/split × HeaderFooter/Footnote)
+// 를 쓰고 커서도 별도 모드다. 본문 텍스트/문단 커맨드(역연산 경량)를 미러링해 히스토리에
+// 기록함으로써, 본문 스냅샷 undo 가 미기록 HF/FN 편집을 무언 파괴하던 데이터 손실을 막는다.
+// 최초 적용은 InputHandler 가 인라인 뮤테이션 후 kind:'record' 로 기록하므로 execute()
+// 는 redo 시에만 호출된다. undo()/execute() 는 lastContext 를 각각 실행 전/후 좌표로
+// 갱신하며, InputHandler 가 editContext() 로 읽어 HF/FN 커서 모드를 복원한다(커맨드는 순수).
+
+export interface HeaderFooterEditTarget {
+  readonly sectionIdx: number;
+  readonly isHeader: boolean;
+  readonly applyTo: number;
+}
+
+export interface FootnoteEditTarget {
+  readonly sectionIdx: number;
+  /** 각주 컨트롤을 담은 본문 문단 인덱스 */
+  readonly paraIdx: number;
+  readonly controlIdx: number;
+  /** 모드 재진입용 (enterFootnoteMode 인자) */
+  readonly footnoteIndex: number;
+  readonly pageNum: number;
+}
+
+function hfEditContext(t: HeaderFooterEditTarget, paraIdx: number, charOffset: number): EditContext {
+  return { mode: 'headerFooter', sectionIdx: t.sectionIdx, isHeader: t.isHeader, applyTo: t.applyTo, paraIdx, charOffset };
+}
+
+function fnEditContext(t: FootnoteEditTarget, innerParaIdx: number, charOffset: number): EditContext {
+  return {
+    mode: 'footnote', sectionIdx: t.sectionIdx, paraIdx: t.paraIdx, controlIdx: t.controlIdx,
+    footnoteIndex: t.footnoteIndex, pageNum: t.pageNum, innerParaIdx, charOffset,
+  };
+}
+
+/**
+ * HF/FN 커맨드의 execute/undo 반환 위치는 형식상 값이다 — InputHandler 는 editContext()
+ * 로 커서를 복원하며 이 본문 위치로 moveTo 하지 않는다(단, 반환은 non-null 이어야
+ * history.undo/redo 가 성공으로 간주한다).
+ */
+function hfFnStubPosition(sectionIdx: number): DocumentPosition {
+  return { sectionIndex: sectionIdx, paragraphIndex: 0, charOffset: 0 };
+}
+
+// ── 머리말/꼬리말 ──────────────────────────────────────────
+
+export class InsertTextInHeaderFooterCommand implements EditCommand {
+  readonly type = 'insertTextInHeaderFooter';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: HeaderFooterEditTarget,
+    private paraIdx: number,
+    private charOffset: number,
+    private text: string,
+  ) {
+    this.lastContext = hfEditContext(target, paraIdx, charOffset + text.length);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.insertTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.text);
+    this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset + this.text.length);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.text.length);
+    this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class DeleteTextInHeaderFooterCommand implements EditCommand {
+  readonly type = 'deleteTextInHeaderFooter';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: HeaderFooterEditTarget,
+    private paraIdx: number,
+    private charOffset: number,
+    private deletedText: string,
+    /** undo(재삽입) 후 커서 오프셋 — 삭제 방향에 따라 호출부가 정한다(Backspace: charOffset+len, Delete: charOffset). */
+    private cursorBeforeOffset: number,
+  ) {
+    this.lastContext = hfEditContext(target, paraIdx, charOffset);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.deleteTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.deletedText.length);
+    this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.insertTextInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset, this.deletedText);
+    this.lastContext = hfEditContext(this.target, this.paraIdx, this.cursorBeforeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class SplitParagraphInHeaderFooterCommand implements EditCommand {
+  readonly type = 'splitParagraphInHeaderFooter';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: HeaderFooterEditTarget,
+    private paraIdx: number,
+    private charOffset: number,
+    /** 분할로 생긴 다음 문단 인덱스(인라인 결과의 hfParaIndex). */
+    private newParaIdx: number,
+  ) {
+    this.lastContext = hfEditContext(target, newParaIdx, 0);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.splitParagraphInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx, this.charOffset);
+    this.lastContext = hfEditContext(this.target, this.newParaIdx, 0);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.mergeParagraphInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.newParaIdx);
+    this.lastContext = hfEditContext(this.target, this.paraIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class MergeParagraphInHeaderFooterCommand implements EditCommand {
+  readonly type = 'mergeParagraphInHeaderFooter';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: HeaderFooterEditTarget,
+    /** 병합되는 문단 M (M 을 M-1 로 합침). */
+    private paraIdx: number,
+    /** 병합 후 이전 문단 인덱스(인라인 결과 hfParaIndex, = paraIdx-1). */
+    private prevParaIdx: number,
+    /** 병합 지점 오프셋(이전 문단의 원래 길이, 인라인 결과 charOffset). undo 분할점 + 병합 후 커서. */
+    private mergeOffset: number,
+    /** 병합 전 커서(undo 복원용) — Backspace: (paraIdx,0), Delete: (prevParaIdx,mergeOffset). */
+    private beforeParaIdx: number,
+    private beforeOffset: number,
+  ) {
+    this.lastContext = hfEditContext(target, prevParaIdx, mergeOffset);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.mergeParagraphInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.paraIdx);
+    this.lastContext = hfEditContext(this.target, this.prevParaIdx, this.mergeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.splitParagraphInHeaderFooter(this.target.sectionIdx, this.target.isHeader, this.target.applyTo, this.prevParaIdx, this.mergeOffset);
+    this.lastContext = hfEditContext(this.target, this.beforeParaIdx, this.beforeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+// ── 각주/미주 ──────────────────────────────────────────────
+
+export class InsertTextInFootnoteCommand implements EditCommand {
+  readonly type = 'insertTextInFootnote';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: FootnoteEditTarget,
+    private innerParaIdx: number,
+    private charOffset: number,
+    private text: string,
+  ) {
+    this.lastContext = fnEditContext(target, innerParaIdx, charOffset + text.length);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.insertTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.text);
+    this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset + this.text.length);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.text.length);
+    this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class DeleteTextInFootnoteCommand implements EditCommand {
+  readonly type = 'deleteTextInFootnote';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: FootnoteEditTarget,
+    private innerParaIdx: number,
+    private charOffset: number,
+    private deletedText: string,
+    private cursorBeforeOffset: number,
+  ) {
+    this.lastContext = fnEditContext(target, innerParaIdx, charOffset);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.deleteTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.deletedText.length);
+    this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.insertTextInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset, this.deletedText);
+    this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.cursorBeforeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class SplitParagraphInFootnoteCommand implements EditCommand {
+  readonly type = 'splitParagraphInFootnote';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: FootnoteEditTarget,
+    private innerParaIdx: number,
+    private charOffset: number,
+    private newInnerParaIdx: number,
+  ) {
+    this.lastContext = fnEditContext(target, newInnerParaIdx, 0);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.splitParagraphInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx, this.charOffset);
+    this.lastContext = fnEditContext(this.target, this.newInnerParaIdx, 0);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.mergeParagraphInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.newInnerParaIdx);
+    this.lastContext = fnEditContext(this.target, this.innerParaIdx, this.charOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
+  mergeWith(): null { return null; }
+}
+
+export class MergeParagraphInFootnoteCommand implements EditCommand {
+  readonly type = 'mergeParagraphInFootnote';
+  readonly timestamp = Date.now();
+  private lastContext: EditContext;
+
+  constructor(
+    private target: FootnoteEditTarget,
+    private innerParaIdx: number,
+    private prevInnerParaIdx: number,
+    private mergeOffset: number,
+    /** 병합 전 커서(undo 복원) — Backspace: (innerParaIdx,0), Delete: (prevInnerParaIdx,mergeOffset). */
+    private beforeInnerParaIdx: number,
+    private beforeOffset: number,
+  ) {
+    this.lastContext = fnEditContext(target, prevInnerParaIdx, mergeOffset);
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.mergeParagraphInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.innerParaIdx);
+    this.lastContext = fnEditContext(this.target, this.prevInnerParaIdx, this.mergeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.splitParagraphInFootnote(this.target.sectionIdx, this.target.paraIdx, this.target.controlIdx, this.prevInnerParaIdx, this.mergeOffset);
+    this.lastContext = fnEditContext(this.target, this.beforeInnerParaIdx, this.beforeOffset);
+    return hfFnStubPosition(this.target.sectionIdx);
+  }
+
+  editContext(): EditContext { return this.lastContext; }
   mergeWith(): null { return null; }
 }
 

--- a/rhwp-studio/src/engine/history.ts
+++ b/rhwp-studio/src/engine/history.ts
@@ -192,6 +192,15 @@ export class CommandHistory {
   canUndo(): boolean { return this.undoStack.length > 0; }
   canRedo(): boolean { return this.redoStack.length > 0; }
 
+  /**
+   * [Task #2337] 직전 undo/redo 로 방금 이동한 커맨드를 조회한다.
+   * undo() 후 방금 되돌린 커맨드는 redoStack top(peekRedoTop), redo() 후 방금 다시
+   * 실행한 커맨드는 undoStack top(peekUndoTop). InputHandler 가 HF/FN 편집 커맨드의
+   * editContext() 를 읽어 커서 모드를 복원하는 데 쓴다(본문 커맨드면 null-컨텍스트).
+   */
+  peekUndoTop(): EditCommand | null { return this.undoStack[this.undoStack.length - 1] ?? null; }
+  peekRedoTop(): EditCommand | null { return this.redoStack[this.redoStack.length - 1] ?? null; }
+
   /** 히스토리 초기화 (문서 로드 시). wasm이 있으면 스냅샷 리소스도 해제. */
   clear(wasm?: WasmBridge): void {
     if (wasm) {

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1,7 +1,7 @@
 /** input-handler keyboard methods — extracted from InputHandler class */
 /* eslint-disable @typescript-eslint/no-explicit-any */
 
-import { InsertTextCommand, InsertLineBreakCommand, InsertTabCommand, SplitParagraphCommand, SplitParagraphInCellCommand } from './command';
+import { InsertTextCommand, InsertLineBreakCommand, InsertTabCommand, SplitParagraphCommand, SplitParagraphInCellCommand, InsertTextInHeaderFooterCommand, SplitParagraphInHeaderFooterCommand, SplitParagraphInFootnoteCommand, DeleteTextInFootnoteCommand, MergeParagraphInFootnoteCommand } from './command';
 import { matchShortcut, defaultShortcuts } from '@/command/shortcut-map';
 import * as _connector from './input-handler-connector';
 import {
@@ -539,11 +539,12 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       e.preventDefault();
       const isHeader = this.cursor.headerFooterMode === 'header';
       try {
-        this.wasm.insertTextInHeaderFooter(
-          this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-          this.cursor.hfParaIdx, this.cursor.hfCharOffset, '\n',
-        );
-        this.cursor.setHfCursorPosition(this.cursor.hfParaIdx, this.cursor.hfCharOffset + 1);
+        const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo };
+        const paraIdx = this.cursor.hfParaIdx;
+        const charOffset = this.cursor.hfCharOffset;
+        this.wasm.insertTextInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx, charOffset, '\n');
+        this.executeOperation({ kind: 'record', command: new InsertTextInHeaderFooterCommand(target, paraIdx, charOffset, '\n') });
+        this.cursor.setHfCursorPosition(paraIdx, charOffset + 1);
         this.afterEdit();
       } catch { /* ignore */ }
       return;
@@ -554,10 +555,11 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       e.preventDefault();
       const isHeader = this.cursor.headerFooterMode === 'header';
       try {
-        const result = JSON.parse(this.wasm.splitParagraphInHeaderFooter(
-          this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-          this.cursor.hfParaIdx, this.cursor.hfCharOffset,
-        ));
+        const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo };
+        const paraIdx = this.cursor.hfParaIdx;
+        const charOffset = this.cursor.hfCharOffset;
+        const result = JSON.parse(this.wasm.splitParagraphInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx, charOffset));
+        this.executeOperation({ kind: 'record', command: new SplitParagraphInHeaderFooterCommand(target, paraIdx, charOffset, result.hfParaIndex) });
         this.cursor.setHfCursorPosition(result.hfParaIndex, 0);
         this.afterEdit();
       } catch { /* ignore */ }
@@ -605,10 +607,11 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     if (e.key === 'Enter') {
       e.preventDefault();
       try {
-        const result = this.wasm.splitParagraphInFootnote(
-          this.cursor.fnSectionIdx, this.cursor.fnParaIdx, this.cursor.fnControlIdx,
-          this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset,
-        );
+        const target = { sectionIdx: this.cursor.fnSectionIdx, paraIdx: this.cursor.fnParaIdx, controlIdx: this.cursor.fnControlIdx, footnoteIndex: this.cursor.fnFootnoteIndex, pageNum: this.cursor.fnPageNum };
+        const innerParaIdx = this.cursor.fnInnerParaIdx;
+        const charOffset = this.cursor.fnCharOffset;
+        const result = this.wasm.splitParagraphInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx, charOffset);
+        this.executeOperation({ kind: 'record', command: new SplitParagraphInFootnoteCommand(target, innerParaIdx, charOffset, result.fnParaIndex) });
         this.cursor.setFnCursorPosition(result.fnParaIndex, 0);
         this.afterEdit();
       } catch { /* ignore */ }
@@ -618,34 +621,32 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
     // Backspace / Delete
     if (e.key === 'Backspace' || e.key === 'Delete') {
       e.preventDefault();
+      const target = { sectionIdx: this.cursor.fnSectionIdx, paraIdx: this.cursor.fnParaIdx, controlIdx: this.cursor.fnControlIdx, footnoteIndex: this.cursor.fnFootnoteIndex, pageNum: this.cursor.fnPageNum };
+      const innerParaIdx = this.cursor.fnInnerParaIdx;
+      const fnOff = this.cursor.fnCharOffset;
       if (e.key === 'Backspace') {
-        if (this.cursor.fnCharOffset > 0) {
+        if (fnOff > 0) {
           try {
-            this.wasm.deleteTextInFootnote(
-              this.cursor.fnSectionIdx, this.cursor.fnParaIdx, this.cursor.fnControlIdx,
-              this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset - 1, 1,
-            );
-            this.cursor.setFnCursorPosition(this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset - 1);
+            // [Task #2337] 삭제 텍스트를 반환에서 확보해 역연산 기록. Backspace → undo 후 커서 fnOff.
+            const res = this.wasm.deleteTextInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx, fnOff - 1, 1);
+            this.executeOperation({ kind: 'record', command: new DeleteTextInFootnoteCommand(target, innerParaIdx, fnOff - 1, res.deletedText ?? '', fnOff) });
+            this.cursor.setFnCursorPosition(innerParaIdx, fnOff - 1);
             this.afterEdit();
           } catch { /* ignore */ }
-        } else if (this.cursor.fnInnerParaIdx > 0) {
-          // 문단 시작에서 Backspace → 이전 문단과 병합
+        } else if (innerParaIdx > 0) {
+          // 문단 시작에서 Backspace → 이전 문단과 병합. 병합 전 커서 (innerParaIdx, 0).
           try {
-            const result = this.wasm.mergeParagraphInFootnote(
-              this.cursor.fnSectionIdx, this.cursor.fnParaIdx, this.cursor.fnControlIdx,
-              this.cursor.fnInnerParaIdx,
-            );
+            const result = this.wasm.mergeParagraphInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx);
+            this.executeOperation({ kind: 'record', command: new MergeParagraphInFootnoteCommand(target, innerParaIdx, result.fnParaIndex, result.charOffset, innerParaIdx, 0) });
             this.cursor.setFnCursorPosition(result.fnParaIndex, result.charOffset);
             this.afterEdit();
           } catch { /* ignore */ }
         }
       } else {
-        // Delete
+        // Delete(forward): 커서는 fnOff 유지 → undo 후에도 fnOff.
         try {
-          this.wasm.deleteTextInFootnote(
-            this.cursor.fnSectionIdx, this.cursor.fnParaIdx, this.cursor.fnControlIdx,
-            this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset, 1,
-          );
+          const res = this.wasm.deleteTextInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx, fnOff, 1);
+          this.executeOperation({ kind: 'record', command: new DeleteTextInFootnoteCommand(target, innerParaIdx, fnOff, res.deletedText ?? '', fnOff) });
           this.afterEdit();
         } catch { /* ignore */ }
       }

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -646,7 +646,11 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
         // Delete(forward): 커서는 fnOff 유지 → undo 후에도 fnOff.
         try {
           const res = this.wasm.deleteTextInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx, fnOff, 1);
-          this.executeOperation({ kind: 'record', command: new DeleteTextInFootnoteCommand(target, innerParaIdx, fnOff, res.deletedText ?? '', fnOff) });
+          // 문단 끝(삭제 대상 없음)에서는 clamp 로 실삭제 0 → 유령 undo 엔트리를 만들지
+          // 않도록 실제로 삭제됐을 때만 기록한다(HF Delete 의 charCount 가드와 동형).
+          if (res.deletedText) {
+            this.executeOperation({ kind: 'record', command: new DeleteTextInFootnoteCommand(target, innerParaIdx, fnOff, res.deletedText, fnOff) });
+          }
           this.afterEdit();
         } catch { /* ignore */ }
       }

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -8,6 +8,10 @@ import {
   MergeNextParagraphCommand,
   MergeParagraphInCellCommand,
   MergeNextParagraphInCellCommand,
+  InsertTextInHeaderFooterCommand,
+  DeleteTextInHeaderFooterCommand,
+  MergeParagraphInHeaderFooterCommand,
+  InsertTextInFootnoteCommand,
   insertTextWithMutationEffects,
   NO_TEXT_MUTATION_EFFECTS,
 } from './command';
@@ -200,19 +204,20 @@ export function handleBackspace(this: any, pos: DocumentPosition, inCell: boolea
   if (this.cursor.isInHeaderFooter()) {
     const isHeader = this.cursor.headerFooterMode === 'header';
     const hfOff = this.cursor.hfCharOffset;
+    const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo };
+    const paraIdx = this.cursor.hfParaIdx;
     if (hfOff > 0) {
-      this.wasm.deleteTextInHeaderFooter(
-        this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-        this.cursor.hfParaIdx, hfOff - 1, 1,
-      );
-      this.cursor.setHfCursorPosition(this.cursor.hfParaIdx, hfOff - 1);
+      // [Task #2337] 삭제 텍스트를 WASM 반환에서 확보해 역연산(재삽입) 기록. Backspace 이므로
+      // undo 후 커서는 hfOff(삭제 전 위치)로 복귀.
+      const res = JSON.parse(this.wasm.deleteTextInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx, hfOff - 1, 1));
+      this.executeOperation({ kind: 'record', command: new DeleteTextInHeaderFooterCommand(target, paraIdx, hfOff - 1, res.deletedText ?? '', hfOff) });
+      this.cursor.setHfCursorPosition(paraIdx, hfOff - 1);
       this.afterEdit();
-    } else if (this.cursor.hfParaIdx > 0) {
+    } else if (paraIdx > 0) {
       // 문단 시작에서 Backspace → 이전 문단과 병합
-      const result = JSON.parse(this.wasm.mergeParagraphInHeaderFooter(
-        this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-        this.cursor.hfParaIdx,
-      ));
+      const result = JSON.parse(this.wasm.mergeParagraphInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx));
+      // Backspace 병합: 병합 전 커서는 (paraIdx, 0).
+      this.executeOperation({ kind: 'record', command: new MergeParagraphInHeaderFooterCommand(target, paraIdx, result.hfParaIndex, result.charOffset, paraIdx, 0) });
       this.cursor.setHfCursorPosition(result.hfParaIndex, result.charOffset);
       this.afterEdit();
     }
@@ -261,24 +266,20 @@ export function handleDelete(this: any, pos: DocumentPosition, inCell: boolean):
   // 머리말/꼬리말 편집 모드
   if (this.cursor.isInHeaderFooter()) {
     const isHeader = this.cursor.headerFooterMode === 'header';
+    const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo };
     try {
-      const info = JSON.parse(this.wasm.getHeaderFooterParaInfo(
-        this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-        this.cursor.hfParaIdx,
-      ));
+      const paraIdx = this.cursor.hfParaIdx;
+      const info = JSON.parse(this.wasm.getHeaderFooterParaInfo(target.sectionIdx, isHeader, target.applyTo, paraIdx));
       const hfOff = this.cursor.hfCharOffset;
       if (hfOff < info.charCount) {
-        this.wasm.deleteTextInHeaderFooter(
-          this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-          this.cursor.hfParaIdx, hfOff, 1,
-        );
+        // Delete(forward): 커서는 hfOff 유지 → undo 후에도 hfOff.
+        const res = JSON.parse(this.wasm.deleteTextInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx, hfOff, 1));
+        this.executeOperation({ kind: 'record', command: new DeleteTextInHeaderFooterCommand(target, paraIdx, hfOff, res.deletedText ?? '', hfOff) });
         this.afterEdit();
-      } else if (this.cursor.hfParaIdx + 1 < info.paraCount) {
-        // 문단 끝에서 Delete → 다음 문단과 병합 (다음 문단을 merge)
-        const result = JSON.parse(this.wasm.mergeParagraphInHeaderFooter(
-          this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-          this.cursor.hfParaIdx + 1,
-        ));
+      } else if (paraIdx + 1 < info.paraCount) {
+        // 문단 끝에서 Delete → 다음 문단(paraIdx+1)을 현재 문단으로 병합. 병합 전 커서는 (paraIdx, 끝).
+        const result = JSON.parse(this.wasm.mergeParagraphInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx + 1));
+        this.executeOperation({ kind: 'record', command: new MergeParagraphInHeaderFooterCommand(target, paraIdx + 1, result.hfParaIndex, result.charOffset, result.hfParaIndex, result.charOffset) });
         this.cursor.setHfCursorPosition(result.hfParaIndex, result.charOffset);
         this.afterEdit();
       }
@@ -392,12 +393,32 @@ export function onCompositionEnd(this: any): void {
 
   // 조합 중 WASM 직접 호출로 이미 문서에 삽입된 텍스트를
   // Command로 기록하여 Undo 가능하게 한다.
-  // 머리말/꼬리말·각주 모드에서는 Undo 기록 생략 (별도 Undo 시스템 없음)
-  if (anchor && finalLength > 0 && !this.cursor.isInHeaderFooter() && !this.cursor.isInFootnote()) {
-    const insertedText = this.getTextAt(anchor, finalLength);
-    if (insertedText) {
-      // execute() 없이 히스토리에만 기록 (텍스트는 이미 문서에 있음)
-      this.executeOperation({ kind: 'record', command: new InsertTextCommand(anchor, insertedText) });
+  // [Task #2337] 머리말/꼬리말·각주 모드도 이제 기록한다(본문 스냅샷 undo 의 무언 파괴 차단).
+  if (anchor && finalLength > 0) {
+    if (this.cursor.isInHeaderFooter()) {
+      // HF 는 신뢰할 텍스트 read 가 없어 getTextAt(본문 리더)을 쓸 수 없으므로 조합 텍스트
+      // (_lastCompositionText)를 그대로 기록한다. anchor.charOffset = 조합 시작 오프셋,
+      // hfParaIdx 는 조합 중 불변.
+      const composed = this._lastCompositionText || '';
+      if (composed) {
+        const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader: this.cursor.headerFooterMode === 'header', applyTo: this.cursor.hfApplyTo };
+        this.executeOperation({ kind: 'record', command: new InsertTextInHeaderFooterCommand(target, this.cursor.hfParaIdx, anchor.charOffset, composed) });
+      }
+    } else if (this.cursor.isInFootnote()) {
+      const composed = this._lastCompositionText || '';
+      if (composed) {
+        const target = {
+          sectionIdx: this.cursor.fnSectionIdx, paraIdx: this.cursor.fnParaIdx, controlIdx: this.cursor.fnControlIdx,
+          footnoteIndex: this.cursor.fnFootnoteIndex, pageNum: this.cursor.fnPageNum,
+        };
+        this.executeOperation({ kind: 'record', command: new InsertTextInFootnoteCommand(target, this.cursor.fnInnerParaIdx, anchor.charOffset, composed) });
+      }
+    } else {
+      const insertedText = this.getTextAt(anchor, finalLength);
+      if (insertedText) {
+        // execute() 없이 히스토리에만 기록 (텍스트는 이미 문서에 있음)
+        this.executeOperation({ kind: 'record', command: new InsertTextCommand(anchor, insertedText) });
+      }
     }
   }
 
@@ -571,11 +592,13 @@ export function onInput(this: any, e?: InputEvent): void {
   if (this.cursor.isInHeaderFooter()) {
     const isHeader = this.cursor.headerFooterMode === 'header';
     try {
-      this.wasm.insertTextInHeaderFooter(
-        this.cursor.hfSectionIdx, isHeader, this.cursor.hfApplyTo,
-        this.cursor.hfParaIdx, this.cursor.hfCharOffset, text,
-      );
-      this.cursor.setHfCursorPosition(this.cursor.hfParaIdx, this.cursor.hfCharOffset + text.length);
+      const target = { sectionIdx: this.cursor.hfSectionIdx, isHeader, applyTo: this.cursor.hfApplyTo };
+      const paraIdx = this.cursor.hfParaIdx;
+      const charOffset = this.cursor.hfCharOffset;
+      this.wasm.insertTextInHeaderFooter(target.sectionIdx, isHeader, target.applyTo, paraIdx, charOffset, text);
+      // [Task #2337] 히스토리 기록 → 본문 스냅샷 undo 가 이 편집을 무언 파괴하지 않게 한다.
+      this.executeOperation({ kind: 'record', command: new InsertTextInHeaderFooterCommand(target, paraIdx, charOffset, text) });
+      this.cursor.setHfCursorPosition(paraIdx, charOffset + text.length);
       this.afterEdit();
     } catch (err) {
       console.error('[HF-input] insertTextInHeaderFooter 실패:', err);
@@ -586,11 +609,15 @@ export function onInput(this: any, e?: InputEvent): void {
   // 각주 편집 모드
   if (this.cursor.isInFootnote()) {
     try {
-      this.wasm.insertTextInFootnote(
-        this.cursor.fnSectionIdx, this.cursor.fnParaIdx, this.cursor.fnControlIdx,
-        this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset, text,
-      );
-      this.cursor.setFnCursorPosition(this.cursor.fnInnerParaIdx, this.cursor.fnCharOffset + text.length);
+      const target = {
+        sectionIdx: this.cursor.fnSectionIdx, paraIdx: this.cursor.fnParaIdx, controlIdx: this.cursor.fnControlIdx,
+        footnoteIndex: this.cursor.fnFootnoteIndex, pageNum: this.cursor.fnPageNum,
+      };
+      const innerParaIdx = this.cursor.fnInnerParaIdx;
+      const charOffset = this.cursor.fnCharOffset;
+      this.wasm.insertTextInFootnote(target.sectionIdx, target.paraIdx, target.controlIdx, innerParaIdx, charOffset, text);
+      this.executeOperation({ kind: 'record', command: new InsertTextInFootnoteCommand(target, innerParaIdx, charOffset, text) });
+      this.cursor.setFnCursorPosition(innerParaIdx, charOffset + text.length);
       this.afterEdit();
     } catch (err) {
       console.error('[FN-input] insertTextInFootnote 실패:', err);

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2177,8 +2177,9 @@ export class InputHandler {
           this.cursor.switchHeaderFooterTarget(ctx.isHeader, ctx.sectionIdx, ctx.applyTo);
         } else {
           this.cursor.enterHeaderFooterMode(ctx.isHeader, ctx.sectionIdx, ctx.applyTo);
-          this.eventBus.emit('headerFooterModeChanged', ctx.isHeader ? 'header' : 'footer');
         }
+        // 진입/전환 양쪽 모두 mode-change 를 알려 툴바/오버레이가 stale 하지 않게 한다.
+        this.eventBus.emit('headerFooterModeChanged', ctx.isHeader ? 'header' : 'footer');
       }
       this.cursor.setHfCursorPosition(ctx.paraIdx, ctx.charOffset);
       return;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3357,6 +3357,12 @@ export class InputHandler {
 
   private isOperationAllowedInEditMode(desc: OperationDescriptor): boolean {
     if (this.editMode !== 'form') return true;
+    // [Task #2337-review] kind:'record' 는 이미 적용된 뮤테이션을 히스토리에 기록만 한다.
+    // form mode 에서 이를 드롭하면 그 뮤테이션이 undo 불가한 미기록 편집으로 남아(더블클릭
+    // 진입한 HF/FN 입력·Enter 분할 등) 이 커밋이 막으려는 무언 손실 경로가 그대로 유지된다.
+    // 뮤테이션 적용 여부는 호출부의 form-mode 게이트(IME 조합·본문 입력 경로)가 이미 결정하므로,
+    // 이미 적용된 편집은 항상 기록한다.
+    if (desc.kind === 'record') return true;
     if (desc.kind === 'snapshot') return false;
 
     const command = desc.command as any;

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -6,7 +6,7 @@ import { FieldMarkerRenderer } from './field-marker-renderer';
 import { SelectionRenderer } from './selection-renderer';
 import { CommandHistory } from './history';
 import { DeleteSelectionCommand, ApplyCharFormatCommand, ApplyParaFormatCommand, SnapshotCommand, TextMutationEffectAccumulator, IMMEDIATE_TEXT_MUTATION_EFFECTS } from './command';
-import type { OperationDescriptor, ParaFormatTarget, RefreshPolicy, TextMutationEffects } from './command';
+import type { OperationDescriptor, ParaFormatTarget, RefreshPolicy, TextMutationEffects, EditCommand, EditContext } from './command';
 import { VirtualScroll } from '@/view/virtual-scroll';
 import { ViewportManager } from '@/view/viewport-manager';
 import type {
@@ -2129,7 +2129,8 @@ export class InputHandler {
       this.prepareTextMutationBeforeCursor(IMMEDIATE_TEXT_MUTATION_EFFECTS);
       this.clearTableResizeRuntimeCache();
       this.exitObjectSelectionAfterHistoryJump();
-      this.cursor.moveTo(newPos);
+      // [Task #2337] 방금 되돌린 커맨드가 HF/FN 편집이면 그 커서 모드로 복원(본문 moveTo 대신).
+      this.restoreEditContextAfterHistory(this.history.peekRedoTop(), newPos);
       this.afterEdit();
     }
   }
@@ -2143,9 +2144,74 @@ export class InputHandler {
       );
       this.clearTableResizeRuntimeCache();
       this.exitObjectSelectionAfterHistoryJump();
-      this.cursor.moveTo(newPos);
+      // [Task #2337] 방금 다시 실행한 커맨드가 HF/FN 편집이면 그 커서 모드로 복원.
+      this.restoreEditContextAfterHistory(this.history.peekUndoTop(), newPos);
       this.afterEdit(!boundaryHandled);
     }
+  }
+
+  /**
+   * [Task #2337] undo/redo 후 편집 컨텍스트(본문 vs HF/FN) 복원.
+   *
+   * 본문 커맨드(editContext 없음)는 기존대로 HF/FN 모드를 빠져나오고 본문 커서를
+   * 이동한다. HF/FN 편집 커맨드는 해당 모드로 (재)진입해 커서 오프셋을 복원하며,
+   * 이때 본문 moveTo 는 건너뛴다(HF/FN 커서는 별도 상태라 본문 위치 이동이 부적합).
+   * 모드 전환 시 mode-change 이벤트를 emit 해 툴바/오버레이가 따라오게 한다.
+   * enterHeaderFooterMode/enterFootnoteMode 는 _savedBodyPosition 을 덮어쓰므로 이미
+   * 같은 모드일 때는 재진입하지 않고 switch/set 만 한다.
+   */
+  private restoreEditContextAfterHistory(cmd: EditCommand | null, bodyPos: DocumentPosition): void {
+    const ctx: EditContext | null = cmd?.editContext?.() ?? null;
+
+    if (ctx?.mode === 'headerFooter') {
+      if (this.cursor.isInFootnote()) {
+        this.cursor.exitFootnoteMode();
+        this.eventBus.emit('footnoteModeChanged', false);
+      }
+      const sameTarget = this.cursor.isInHeaderFooter()
+        && this.cursor.hfSectionIdx === ctx.sectionIdx
+        && (this.cursor.headerFooterMode === 'header') === ctx.isHeader
+        && this.cursor.hfApplyTo === ctx.applyTo;
+      if (!sameTarget) {
+        if (this.cursor.isInHeaderFooter()) {
+          this.cursor.switchHeaderFooterTarget(ctx.isHeader, ctx.sectionIdx, ctx.applyTo);
+        } else {
+          this.cursor.enterHeaderFooterMode(ctx.isHeader, ctx.sectionIdx, ctx.applyTo);
+          this.eventBus.emit('headerFooterModeChanged', ctx.isHeader ? 'header' : 'footer');
+        }
+      }
+      this.cursor.setHfCursorPosition(ctx.paraIdx, ctx.charOffset);
+      return;
+    }
+
+    if (ctx?.mode === 'footnote') {
+      if (this.cursor.isInHeaderFooter()) {
+        this.cursor.exitHeaderFooterMode();
+        this.eventBus.emit('headerFooterModeChanged', 'none');
+      }
+      const sameTarget = this.cursor.isInFootnote()
+        && this.cursor.fnSectionIdx === ctx.sectionIdx
+        && this.cursor.fnParaIdx === ctx.paraIdx
+        && this.cursor.fnControlIdx === ctx.controlIdx;
+      if (!sameTarget) {
+        if (this.cursor.isInFootnote()) this.cursor.exitFootnoteMode();
+        this.cursor.enterFootnoteMode(ctx.sectionIdx, ctx.paraIdx, ctx.controlIdx, ctx.footnoteIndex, ctx.pageNum);
+        this.eventBus.emit('footnoteModeChanged', true);
+      }
+      this.cursor.setFnCursorPosition(ctx.innerParaIdx, ctx.charOffset);
+      return;
+    }
+
+    // 본문 커맨드 — HF/FN 모드였으면 빠져나오고 본문 커서 이동.
+    if (this.cursor.isInHeaderFooter()) {
+      this.cursor.exitHeaderFooterMode();
+      this.eventBus.emit('headerFooterModeChanged', 'none');
+    }
+    if (this.cursor.isInFootnote()) {
+      this.cursor.exitFootnoteMode();
+      this.eventBus.emit('footnoteModeChanged', false);
+    }
+    this.cursor.moveTo(bodyPos);
   }
 
   /**

--- a/rhwp-studio/tests/command-history-hffn.test.ts
+++ b/rhwp-studio/tests/command-history-hffn.test.ts
@@ -98,6 +98,10 @@ test('HF/FN 삭제 사이트는 WASM 반환의 deletedText 를 역연산 재삽�
   assert.match(keyboardSrc, /deletedText \?\? ''/, 'FN 삭제가 deletedText 를 커맨드에 전달해야 함');
   assert.match(textSrc, /new DeleteTextInHeaderFooterCommand\(/, 'HF 삭제 record');
   assert.match(keyboardSrc, /new DeleteTextInFootnoteCommand\(/, 'FN 삭제 record');
+  // FN forward-Delete 는 문단 끝에서 clamp 로 실삭제 0 → 유령 undo 엔트리를 막기 위해
+  // 실삭제(res.deletedText 비어있지 않음)일 때만 기록해야 한다.
+  assert.match(keyboardSrc, /if \(res\.deletedText\)\s*\{[\s\S]*?new DeleteTextInFootnoteCommand\(/,
+    'FN Delete 기록은 실삭제 시에만(유령 엔트리 방지) — if (res.deletedText) 가드 필요');
 });
 
 test('HF/FN 편집 사이트가 kind:record 로 히스토리에 기록한다', () => {

--- a/rhwp-studio/tests/command-history-hffn.test.ts
+++ b/rhwp-studio/tests/command-history-hffn.test.ts
@@ -155,3 +155,34 @@ test('history 는 peekUndoTop/peekRedoTop 으로 방금 이동한 커맨드를 �
   assert.match(historySrc, /peekUndoTop\(\): EditCommand \| null \{ return this\.undoStack\[this\.undoStack\.length - 1\] \?\? null; \}/);
   assert.match(historySrc, /peekRedoTop\(\): EditCommand \| null \{ return this\.redoStack\[this\.redoStack\.length - 1\] \?\? null; \}/);
 });
+
+// ── (6) [리뷰 반영] Unicode 단위 · form mode 기록 ────────────────────────────
+
+test('HF/FN 삭제 count 는 char(코드포인트) 단위여야 한다 — astral 문자 over-delete 방지', () => {
+  // Rust delete_text_at 은 char 단위인데 JS String.length(UTF-16)를 넘기면 '😀' 같은
+  // astral 문자 undo/redo 때 인접 문자를 잃는다(P1). charCount([...s].length)로 계산해야 한다.
+  assert.match(commandSrc, /function charCount\(s: string\): number \{\s*return \[\.\.\.s\]\.length;/,
+    'charCount(코드포인트 수) 헬퍼 필요');
+  // HF/FN 삭제 WASM 호출의 count 인자가 .length 가 아니라 charCount 여야 한다.
+  for (const cls of ['DeleteTextInHeaderFooterCommand', 'DeleteTextInFootnoteCommand',
+    'InsertTextInHeaderFooterCommand', 'InsertTextInFootnoteCommand']) {
+    const block = classBlock(commandSrc, cls);
+    assert.doesNotMatch(block, /deleteTextIn(HeaderFooter|Footnote)\([^)]*\.(text|deletedText)\.length\)/,
+      `${cls}: 삭제 count 에 .length(UTF-16) 사용 금지 — charCount 사용`);
+  }
+});
+
+test('form mode 에서 kind:record 는 항상 허용된다 — 이미 적용된 편집의 무언 손실 방지', () => {
+  // form mode 에서 HF/FN record 를 드롭하면 뮤테이션이 undo 불가한 미기록 편집으로 남는다(P1).
+  const block = inputHandlerSrc.slice(
+    inputHandlerSrc.indexOf('private isOperationAllowedInEditMode'),
+    inputHandlerSrc.indexOf('private isOperationAllowedInEditMode') + 900,
+  );
+  assert.match(block, /if \(desc\.kind === 'record'\) return true;/,
+    "isOperationAllowedInEditMode 는 kind:'record' 를 항상 허용해야 함");
+  // record 허용이 form 게이트(editMode!=='form' → true) 이후에 와야 실효가 있다.
+  const idxForm = block.indexOf("this.editMode !== 'form'");
+  const idxRecord = block.indexOf("desc.kind === 'record'");
+  assert.ok(idxForm !== -1 && idxRecord !== -1 && idxForm < idxRecord,
+    'record 허용은 editMode form 체크 뒤에 위치');
+});

--- a/rhwp-studio/tests/command-history-hffn.test.ts
+++ b/rhwp-studio/tests/command-history-hffn.test.ts
@@ -1,0 +1,153 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2337] 머리말/꼬리말·각주 편집 히스토리 기록 소스 가드.
+//
+// 미기록이던 HF/FN 편집을 executeOperation 경유로 기록해 본문 스냅샷 undo 의 무언
+// 데이터 손실을 막는다. node --test 는 strip-only TS 라 engine 클래스를 실행할 수
+// 없어(이 저장소 undo 테스트 관례), 소스 배선을 정적으로 검증한다. 행위 증명(브라우저
+// 데이터손실 재현→차단, undo/redo 왕복)은 PR 검증 섹션에서 별도로 수행한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const source = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+
+const commandSrc = source('src/engine/command.ts');
+const textSrc = source('src/engine/input-handler-text.ts');
+const keyboardSrc = source('src/engine/input-handler-keyboard.ts');
+const inputHandlerSrc = source('src/engine/input-handler.ts');
+const historySrc = source('src/engine/history.ts');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(src: string, name: string): string {
+  const start = src.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = src.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+}
+
+/** 클래스 본문에서 execute()/undo() 각 메서드 블록을 분리. */
+function executeUndo(block: string): { execute: string; undo: string } {
+  const eIdx = block.indexOf('execute(wasm: WasmBridge): DocumentPosition {');
+  const uIdx = block.indexOf('undo(wasm: WasmBridge): DocumentPosition {');
+  assert.ok(eIdx !== -1 && uIdx !== -1, 'execute/undo 시그니처 not found');
+  // execute 가 undo 보다 앞에 오므로 undo 시작으로 execute 를 자른다.
+  return {
+    execute: block.slice(eIdx, uIdx),
+    undo: block.slice(uIdx),
+  };
+}
+
+// ── (1) 역연산 쌍: execute 와 undo 가 서로 반대 WASM 을 호출해야 한다 ──────────
+// 쌍이 어긋나면(예: undo 가 execute 와 같은 방향) undo 가 문서를 되돌리지 못하고
+// 오히려 오염시킨다. 이 저장소에서 가장 치명적인 회귀이므로 정면으로 핀한다.
+
+const INVERSE_PAIRS: Array<{ cls: string; fwd: string; inv: string }> = [
+  { cls: 'InsertTextInHeaderFooterCommand', fwd: 'insertTextInHeaderFooter', inv: 'deleteTextInHeaderFooter' },
+  { cls: 'DeleteTextInHeaderFooterCommand', fwd: 'deleteTextInHeaderFooter', inv: 'insertTextInHeaderFooter' },
+  { cls: 'SplitParagraphInHeaderFooterCommand', fwd: 'splitParagraphInHeaderFooter', inv: 'mergeParagraphInHeaderFooter' },
+  { cls: 'MergeParagraphInHeaderFooterCommand', fwd: 'mergeParagraphInHeaderFooter', inv: 'splitParagraphInHeaderFooter' },
+  { cls: 'InsertTextInFootnoteCommand', fwd: 'insertTextInFootnote', inv: 'deleteTextInFootnote' },
+  { cls: 'DeleteTextInFootnoteCommand', fwd: 'deleteTextInFootnote', inv: 'insertTextInFootnote' },
+  { cls: 'SplitParagraphInFootnoteCommand', fwd: 'splitParagraphInFootnote', inv: 'mergeParagraphInFootnote' },
+  { cls: 'MergeParagraphInFootnoteCommand', fwd: 'mergeParagraphInFootnote', inv: 'splitParagraphInFootnote' },
+];
+
+for (const { cls, fwd, inv } of INVERSE_PAIRS) {
+  test(`${cls}: execute=${fwd} / undo=${inv} (역연산 쌍 정합)`, () => {
+    const { execute, undo } = executeUndo(classBlock(commandSrc, cls));
+    assert.match(execute, new RegExp(`wasm\\.${fwd}\\(`), `execute 는 ${fwd} 를 호출해야 함`);
+    assert.doesNotMatch(execute, new RegExp(`wasm\\.${inv}\\(`), `execute 에 역연산 ${inv} 가 섞이면 안 됨`);
+    assert.match(undo, new RegExp(`wasm\\.${inv}\\(`), `undo 는 ${inv} 를 호출해야 함`);
+    assert.doesNotMatch(undo, new RegExp(`wasm\\.${fwd}\\(`), `undo 에 정연산 ${fwd} 가 섞이면 안 됨`);
+  });
+}
+
+test('모든 HF/FN 커맨드는 editContext() 로 커서 컨텍스트를 노출한다', () => {
+  for (const { cls } of INVERSE_PAIRS) {
+    const block = classBlock(commandSrc, cls);
+    assert.match(block, /editContext\(\): EditContext \{ return this\.lastContext; \}/,
+      `${cls} 는 editContext() 를 구현해야 한다(InputHandler 의 커서 모드 복원용)`);
+  }
+});
+
+// ── (2) IME 게이트: compositionEnd 가 HF/FN 을 기록해야 한다 ──────────────────
+
+test('onCompositionEnd 게이트가 HF/FN 을 기록에서 제외하지 않는다(데이터 손실 회귀 차단)', () => {
+  // 회귀 전 코드: `if (anchor && finalLength > 0 && !isInHeaderFooter() && !isInFootnote())`
+  // 로 HF/FN 을 배제해 IME 조합이 미기록 → 무언 파괴. 그 배제 패턴이 되살아나면 실패.
+  assert.doesNotMatch(
+    textSrc,
+    /finalLength > 0 && !this\.cursor\.isInHeaderFooter\(\) && !this\.cursor\.isInFootnote\(\)/,
+    'compositionEnd 게이트가 HF/FN 을 다시 배제함 → IME 편집 미기록(데이터 손실)',
+  );
+  // HF/FN 조합 결과를 실제로 record 한다.
+  assert.match(textSrc, /new InsertTextInHeaderFooterCommand\(target,[^)]*composed\)/,
+    'compositionEnd 에서 HF 조합 텍스트를 기록해야 함');
+  assert.match(textSrc, /new InsertTextInFootnoteCommand\(target,[^)]*composed\)/,
+    'compositionEnd 에서 FN 조합 텍스트를 기록해야 함');
+});
+
+// ── (3) 라우팅: HF/FN 편집 사이트가 executeOperation record 로 기록한다 ────────
+
+test('HF/FN 삭제 사이트는 WASM 반환의 deletedText 를 역연산 재삽입용으로 확보한다', () => {
+  // 삭제된 텍스트 없이는 undo 재삽입이 불가능하므로 반드시 확보해야 한다.
+  assert.match(textSrc, /deletedText \?\? ''/, 'HF 삭제가 deletedText 를 커맨드에 전달해야 함');
+  assert.match(keyboardSrc, /deletedText \?\? ''/, 'FN 삭제가 deletedText 를 커맨드에 전달해야 함');
+  assert.match(textSrc, /new DeleteTextInHeaderFooterCommand\(/, 'HF 삭제 record');
+  assert.match(keyboardSrc, /new DeleteTextInFootnoteCommand\(/, 'FN 삭제 record');
+});
+
+test('HF/FN 편집 사이트가 kind:record 로 히스토리에 기록한다', () => {
+  // 최소 개수 가드 — 이관 사이트가 조용히 사라지면(=미기록 복귀) 실패.
+  const hfCmds = (textSrc.match(/new (Insert|Delete|Merge)\w*InHeaderFooterCommand\(/g) ?? []).length
+    + (keyboardSrc.match(/new (Insert|Split|Merge|Delete)\w*InHeaderFooterCommand\(/g) ?? []).length;
+  const fnCmds = (textSrc.match(/new (Insert|Delete|Merge)\w*InFootnoteCommand\(/g) ?? []).length
+    + (keyboardSrc.match(/new (Insert|Split|Merge|Delete)\w*InFootnoteCommand\(/g) ?? []).length;
+  assert.ok(hfCmds >= 5, `HF 편집 커맨드 사이트가 부족: ${hfCmds} (<5) — 라우팅 누락?`);
+  assert.ok(fnCmds >= 4, `FN 편집 커맨드 사이트가 부족: ${fnCmds} (<4) — 라우팅 누락?`);
+});
+
+// ── (4) undo/redo 커서 복원: 본문 moveTo 를 HF/FN 에서 건너뛴다 ────────────────
+
+test('handleUndo/handleRedo 는 restoreEditContextAfterHistory 로 위임한다(HF/FN 커서 복원)', () => {
+  // 회귀 전: handleUndo/Redo 가 곧장 cursor.moveTo(newPos) 만 호출 → HF/FN 커서 깨짐.
+  const undoBlock = inputHandlerSrc.slice(
+    inputHandlerSrc.indexOf('private handleUndo()'),
+    inputHandlerSrc.indexOf('private handleRedo()'),
+  );
+  const redoBlock = inputHandlerSrc.slice(
+    inputHandlerSrc.indexOf('private handleRedo()'),
+    inputHandlerSrc.indexOf('private restoreEditContextAfterHistory'),
+  );
+  assert.match(undoBlock, /restoreEditContextAfterHistory\(this\.history\.peekRedoTop\(\)/,
+    'handleUndo 는 방금 되돌린 커맨드(redoStack top)로 컨텍스트 복원해야 함');
+  assert.match(redoBlock, /restoreEditContextAfterHistory\(this\.history\.peekUndoTop\(\)/,
+    'handleRedo 는 방금 다시 실행한 커맨드(undoStack top)로 복원해야 함');
+  assert.doesNotMatch(undoBlock, /this\.cursor\.moveTo\(newPos\)/, 'handleUndo 의 직접 moveTo 는 제거돼야 함');
+  assert.doesNotMatch(redoBlock, /this\.cursor\.moveTo\(newPos\)/, 'handleRedo 의 직접 moveTo 는 제거돼야 함');
+});
+
+test('restoreEditContextAfterHistory 는 HF/FN 모드로 복원하고 본문 커맨드는 moveTo 한다', () => {
+  const block = inputHandlerSrc.slice(inputHandlerSrc.indexOf('private restoreEditContextAfterHistory'));
+  const method = block.slice(0, block.search(/\n {2}(?:public |private |protected )?[a-zA-Z][\w]*\s*\(/) + 1 || block.length);
+  // HF/FN 컨텍스트면 모드 진입 + 오프셋 복원.
+  assert.match(block, /ctx\?\.mode === 'headerFooter'/, 'HF 컨텍스트 분기');
+  assert.match(block, /ctx\?\.mode === 'footnote'/, 'FN 컨텍스트 분기');
+  assert.match(block, /enterHeaderFooterMode\(/, 'HF 모드 진입');
+  assert.match(block, /enterFootnoteMode\(/, 'FN 모드 진입');
+  assert.match(block, /setHfCursorPosition\(/, 'HF 커서 오프셋 복원');
+  assert.match(block, /setFnCursorPosition\(/, 'FN 커서 오프셋 복원');
+  // 본문 커맨드(컨텍스트 없음)면 HF/FN 을 빠져나오고 본문 moveTo.
+  assert.match(block, /this\.cursor\.moveTo\(bodyPos\)/, '본문 커맨드는 bodyPos 로 moveTo');
+  void method;
+});
+
+// ── (5) history 접근자: undo/redo 직후 커맨드 조회 ────────────────────────────
+
+test('history 는 peekUndoTop/peekRedoTop 으로 방금 이동한 커맨드를 노출한다', () => {
+  assert.match(historySrc, /peekUndoTop\(\): EditCommand \| null \{ return this\.undoStack\[this\.undoStack\.length - 1\] \?\? null; \}/);
+  assert.match(historySrc, /peekRedoTop\(\): EditCommand \| null \{ return this\.redoStack\[this\.redoStack\.length - 1\] \?\? null; \}/);
+});

--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -517,6 +517,9 @@ impl DocumentCore {
     ) -> Result<String, HwpError> {
         let fn_para =
             self.get_footnote_paragraph_mut(section_idx, para_idx, control_idx, fn_para_idx)?;
+        // [Task #2337] undo 재삽입용 삭제 텍스트 확보 (HF 와 동일 방식 — char 슬라이스로
+        // delete_text_at 클램핑과 동일 범위). 역연산 삭제 커맨드가 사용한다.
+        let deleted_text: String = fn_para.text.chars().skip(char_offset).take(count).collect();
         fn_para.delete_text_at(char_offset, count);
 
         self.reflow_footnote_paragraph(section_idx, para_idx, control_idx, fn_para_idx);
@@ -532,8 +535,9 @@ impl DocumentCore {
             count,
         });
         Ok(super::super::helpers::json_ok_with(&format!(
-            "\"charOffset\":{}",
-            char_offset
+            "\"charOffset\":{},\"deletedText\":\"{}\"",
+            char_offset,
+            super::super::helpers::json_escape(&deleted_text)
         )))
     }
 

--- a/src/document_core/commands/header_footer_ops.rs
+++ b/src/document_core/commands/header_footer_ops.rs
@@ -315,6 +315,10 @@ impl DocumentCore {
         }
 
         let hf_para = self.get_hf_paragraph_mut(section_idx, is_header, apply_to, hf_para_idx)?;
+        // [Task #2337] undo 재삽입용으로 삭제될 텍스트를 먼저 확보한다. char 단위 슬라이스는
+        // delete_text_at 의 클램핑(text_len - char_offset)과 동일 범위이며, Rust char 경계로
+        // 잘라 studio(UTF-16) 측 조인 모호성을 피한다. 역연산 삭제 커맨드가 재삽입에 쓴다.
+        let deleted_text: String = hf_para.text.chars().skip(char_offset).take(count).collect();
         hf_para.delete_text_at(char_offset, count);
 
         // 리플로우
@@ -332,8 +336,9 @@ impl DocumentCore {
             count,
         });
         Ok(super::super::helpers::json_ok_with(&format!(
-            "\"charOffset\":{}",
-            char_offset
+            "\"charOffset\":{},\"deletedText\":\"{}\"",
+            char_offset,
+            super::super::helpers::json_escape(&deleted_text)
         )))
     }
 


### PR DESCRIPTION
## 문제

머리말/꼬리말(HF)·각주/미주(FN) 편집이 undo 히스토리에 **전혀 기록되지 않아**:

- **(A) 무언 데이터 손실 — 복구 불가:** HF/FN 편집 후 본문에서 스냅샷 기반 작업(표/개체/구조 편집)을 undo하면, 그 스냅샷이 HF/FN 편집 **이전** 문서를 담고 있어 복원 시 HF/FN 편집이 경고 없이 사라진다. redo도 after-스냅샷이 편집 이전이라 복구 불가.
- **(B) HF/FN 자체 undo 부재:** HF/FN 모드에서 Ctrl+Z가 그 편집을 되돌리지 못한다(스택에 없음).

closes #2337. #2327(소스 가드가 저작 시점에 차단하는 그 "기록 옵트인" 계급)의 최중량 표본.

## 원인

HF/FN 편집 경로(8개 WASM 뮤테이터 `insert/delete/merge/split × HeaderFooter/Footnote`, ~16 호출처)가 전부 **WASM 직접 호출 + `executeOperation` 우회**였고, IME 기록 게이트(`input-handler-text.ts` onCompositionEnd)가 `!isInHeaderFooter() && !isInFootnote()`로 HF/FN을 **명시적으로 제외**했다. 스냅샷은 문서 전체 딥클론이고 HF/FN 내용을 포함하므로 스냅샷 undo가 그 사이 발생한 미기록 HF/FN 편집을 파괴한다.

## 변경

본문 텍스트/문단 커맨드(역연산 경량, 스냅샷 비용 0)를 미러링해 HF/FN 편집을 히스토리에 기록한다.

- **역연산 커맨드 8종** (`engine/command.ts`): `Insert/Delete/Split/MergeParagraph × InHeaderFooter/InFootnote`. execute=정연산 WASM, undo=역연산(Delete는 보존 텍스트 재삽입, Merge는 분할). **순수**(wasm만 접근)하며 `editContext()`로 복원할 HF/FN 커서 컨텍스트를 노출한다(`EditContext` 타입 신설).
- **라우팅** (`engine/input-handler-text.ts`, `engine/input-handler-keyboard.ts`): 인라인 뮤테이션 직후 `executeOperation({ kind: 'record', … })`로 기록(본문 IME 패턴 미러링 — 뮤테이션은 이미 적용됨, 재실행 없음). IME 조합은 `onCompositionEnd`에서 조합 텍스트를 기록. 게이트의 HF/FN 배제 제거.
- **커서 복원** (`engine/input-handler.ts`): `restoreEditContextAfterHistory(cmd, bodyPos)` — undo/redo 후 커맨드가 HF/FN `editContext()`를 가지면 그 모드로 (재)진입 + 오프셋 복원하고 **본문 `moveTo`를 건너뛴다**(HF/FN 커서는 별도 상태). 본문 커맨드면 HF/FN 모드를 빠져나오고 `moveTo`. `handleUndo`는 `history.peekRedoTop()`(방금 되돌린 커맨드), `handleRedo`는 `peekUndoTop()`을 쓴다. `enterHeaderFooterMode`/`enterFootnoteMode`가 `_savedBodyPosition`을 덮어쓰므로 이미 같은 모드면 재진입하지 않는다.
- **history 접근자** (`engine/history.ts`): `peekUndoTop`/`peekRedoTop`.
- **Rust** (`document_core/commands/header_footer_ops.rs`, `footnote_ops.rs`): HF/FN 삭제 네이티브가 삭제된 텍스트(`deletedText`)를 반환하도록 최소 변경 — undo 재삽입에 필요(HF는 신뢰할 텍스트 read 경로가 없었음). char 슬라이스로 `delete_text_at`의 클램핑과 동일 범위를 잘라 studio(UTF-16) 측 조인 모호성을 피한다.
- **소스 가드** (`tests/command-history-hffn.test.ts`): 8쌍 역연산 정합, IME 게이트 HF/FN 미배제, deletedText 확보, 라우팅 최소 개수, handleUndo/Redo의 컨텍스트 위임을 핀.

## 검증

- `tsc` 0, 단위/가드 **317 pass**(신규 15), WASM 바인딩 테스트, Rust `header_footer` 16 + `footnote` 12 pass.
- **브라우저 실측**(window.__inputHandler 실동작):
  - HF: 머리말 "K" 뒤 "M" 입력 → `undoStack` 기록(`insertTextInHeaderFooter`, editContext `{header, para0, off2}`) → undo "KM"→"K"(커서 off 1·**HF 모드 유지**) → redo "KM"(off 2). **0 콘솔 에러**.
  - FN: 각주에 "X" 입력 → 기록(`insertTextInFootnote`) → undo 시 placeholder 복귀(off 2·**FN 모드 유지**) → redo "X"(off 3). **0 에러**.
  - HF/FN 커맨드 `snapshotResourceCount = 0` → 스냅샷 예산 무영향·orphan 불가(본문 텍스트 커맨드와 동일하게 SnapshotCommand와 안전 공존).

## 범위 외

- 계급 2 일반화(`history-jumped` 이벤트)·계급 3 진입점 단일화는 별도 이슈.
- iOS 전용 조합-없는 폴백 입력 경로(`_isIOS`)는 미변경 — 본문 입력과 동일하게 이 커맨드 경유를 쓰지 않는다(별도 후속). 데스크톱/안드로이드의 표준 compositionEnd IME + 직접 입력은 완전 기록된다.
- 미라우팅 나머지 파일군(page/table/다이얼로그) 이관은 별도 연작(#2327 원장 baseline 감소가 게이지).

Refs #2327
