### PR TITLE
Task #2279: 한컴돋움/한컴바탕 측정 메트릭을 Haansoft Dotum/Batang 실메트릭으로 연결

### DIFF
--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -81,9 +81,14 @@ pub struct MetricMatch {
 /// 실무 허용. 정식 DB 엔트리 추가는 별도 이슈.
 fn resolve_metric_alias(name: &str) -> &str {
     match name {
-        "함초롬돋움" | "한컴돋움" => "HCR Dotum",
+        "함초롬돋움" => "HCR Dotum",
+        // [#2279] 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang
+        // (HDOTUM.TTF/HBATANG.TTF name table). HCR(함초롬) 계열과 메트릭이
+        // 다르므로 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em) 별도 연결.
+        "한컴돋움" => "Haansoft Dotum",
         "돋움" => "Dotum",
-        "함초롬바탕" | "한컴바탕" => "HCR Batang",
+        "함초롬바탕" => "HCR Batang",
+        "한컴바탕" => "Haansoft Batang",
         "바탕" => "Batang", // 윈도우 TTF 바탕
         "맑은 고딕" => "Malgun Gothic",
         "나눔고딕" => "NanumGothic",

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1561,10 +1561,15 @@ fn haansoft_latin_override(primary_name: &str, c: char) -> Option<f64> {
 /// 명조(HY견명조 치환) 등 여타 = 반각 (80168 개정안{{7}} p9/p13 '시ㆍ도조례'
 /// 1줄 오라클, 개정안{{1}} P21 마크와 반각 양립 검증). embedded 메트릭
 /// (HY견명조 수록분)이 전각이라 룩업보다 앞서 판정하되, 함초롬(HCR) 계열은
-/// embedded 메트릭을 신뢰한다 (None 반환).
+/// embedded 메트릭을 신뢰한다 (None 반환). [#2279] 한컴바탕/한컴돋움
+/// (Haansoft 실메트릭, ㆍ=1.0em)도 동일하게 embedded 메트릭을 신뢰한다.
 pub(crate) fn area_dot_fallback_width(font_family: &str, font_size: f64) -> Option<f64> {
     let fam = font_family.split(',').next().unwrap_or("").trim();
-    if fam.contains("함초롬") || fam.contains("HCR") {
+    if fam.contains("함초롬")
+        || fam.contains("HCR")
+        || fam.contains("한컴")
+        || fam.contains("Haansoft")
+    {
         return None;
     }
     Some(if fam.contains("한양신명조") {
@@ -2094,6 +2099,58 @@ mod tests {
         assert!(haansoft_latin_override("함초롬바탕 확장", '(').is_none());
         assert!(haansoft_latin_override("HCR Batang Ext", '(').is_none());
         assert!(haansoft_latin_override("바탕", '(').is_none());
+    }
+
+    // ── #2279 한컴돋움/한컴바탕 = Haansoft 실메트릭 ──
+
+    /// 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang (HDOTUM.TTF/HBATANG.TTF
+    /// name table 한국어명). 한글 PDF 실측(36398599 pi35 단일줄 무신축 '*' run:
+    /// 0.583em, 한글 음절 1.0em)과 hmtx 가 일치 — HCR(함초롬) 메트릭('*' 0.498,
+    /// 음절 0.97em)으로 회귀하면 '*' 마스킹 구분선·본문 래핑 줄수가 한글 대비
+    /// ±1 이탈한다 (92 컨트롤셋 36398599/36399105 −1쪽 계열).
+    #[test]
+    fn issue_2279_hancom_dotum_batang_use_haansoft_metrics() {
+        let fs = 20.0; // 15pt
+        let w = |fam: &str, c: char| {
+            measure_char_width_embedded(fam, false, false, c, fs)
+                .unwrap_or_else(|| panic!("측정 실패: {fam} {c:?}"))
+        };
+        // 한컴돋움 = Haansoft Dotum
+        assert!(
+            (w("한컴돋움", '*') - fs * 0.583).abs() < 0.05,
+            "'*' {}",
+            w("한컴돋움", '*')
+        );
+        assert!(
+            (w("한컴돋움", '0') - fs * 0.583).abs() < 0.05,
+            "'0' {}",
+            w("한컴돋움", '0')
+        );
+        assert!(
+            (w("한컴돋움", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴돋움", '가')
+        );
+        // 한컴바탕 = Haansoft Batang (음절 1.0em; ASCII 는 #2156 표와 동일)
+        assert!(
+            (w("한컴바탕", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴바탕", '가')
+        );
+        assert!(
+            (w("한컴바탕", '*') - fs * 0.5).abs() < 0.05,
+            "'*' {}",
+            w("한컴바탕", '*')
+        );
+        // 함초롬돋움은 종전대로 HCR Dotum 메트릭 유지 (한글 대체 여부 미실측)
+        assert!(
+            (w("함초롬돋움", '가') - fs * 0.97).abs() < 0.05,
+            "HCR '가' {}",
+            w("함초롬돋움", '가')
+        );
+        // ㆍ(U+318D): 한컴 계열은 area_dot 폴백 대신 embedded 메트릭(1.0em) 신뢰
+        assert!(area_dot_fallback_width("한컴돋움", fs).is_none());
+        assert!(area_dot_fallback_width("한컴바탕", fs).is_none());
     }
 
     // ── MockTextMeasurer 테스트 ──

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -681,9 +681,14 @@ fn resolve_ttf_font(name: &str) -> Option<&'static str> {
         "Malgun Gothic" => Some("맑은 고딕"),
         "HY그래픽M" => Some("HY그래픽"),
         "SPOQAHANSANS" => Some("SpoqaHanSans"),
-        // 한컴 체인: 한컴바탕→함초롬바탕, 한컴돋움→함초롬돋움
-        "한컴바탕" => Some("함초롬바탕"),
-        "한컴돋움" => Some("함초롬돋움"),
+        // [#2279] 한컴바탕/한컴돋움은 함초롬 계열로 치환하지 않는다.
+        // TTF name table 실측: 한컴바탕 = Haansoft Batang(HBATANG.TTF),
+        // 한컴돋움 = Haansoft Dotum(HDOTUM.TTF) — 함초롬(HCR)과 별개 폰트로
+        // 메트릭이 다르다 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em).
+        // 종전 치환은 한컴돋움 문서의 폭 측정을 HCR Dotum 메트릭으로 보내
+        // 줄수 ±1 오차를 만들었다 (한글 PDF 실측: '*' 0.583em, 음절 1.0em).
+        // 메트릭은 font_metrics_data::resolve_metric_alias 가 Haansoft 엔트리로
+        // 연결하고, SVG 렌더 폴백 체인(svg.rs)은 한컴* 이름을 직접 처리한다.
         // 영어(1) 전용 TTF 치환 (webhwp lang=1)
         "MS Sans Serif" => Some("함초롬돋움"),
         "Tahoma" => Some("함초롬돋움"),

--- a/tools/task2279/hancom_metric_visual_check.py
+++ b/tools/task2279/hancom_metric_visual_check.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""#2279 한컴돋움/한컴바탕 메트릭 정합 — base vs head 픽셀 대조 (한글 PDF 기준).
+
+지표: tools/task2279/visual_evidence.py 와 동일 (96dpi gray, 임계 이진화 일치율 + IoU).
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import fitz
+import numpy as np
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+FONTS = Path(r"C:\Users\planet\rhwp\ttfs")
+
+
+def render(exe: str, doc: Path, out_pdf: Path):
+    if out_pdf.exists():
+        out_pdf.unlink()
+    r = subprocess.run(
+        [exe, "export-pdf", str(doc), "-o", str(out_pdf), "--font-path", str(FONTS)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=900,
+    )
+    if not out_pdf.exists():
+        raise RuntimeError(f"export-pdf 실패: {r.stderr[:300]}")
+
+
+def page_gray(doc, i):
+    pix = doc[i].get_pixmap(dpi=96, colorspace=fitz.csGRAY)
+    return np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
+
+
+def compare(ref, img):
+    h = min(ref.shape[0], img.shape[0])
+    w = min(ref.shape[1], img.shape[1])
+    a, b = ref[:h, :w].astype(int), img[:h, :w].astype(int)
+    pixel_match = 100.0 * float(((a > 200) == (b > 200)).mean())
+    ink_a = (a <= 200)
+    ink_b = (b <= 200)
+    union = (ink_a | ink_b).sum()
+    iou = 100.0 * float((ink_a & ink_b).sum() / union) if union else 100.0
+    return pixel_match, iou
+
+
+def main():
+    base_exe, head_exe, out_dir = sys.argv[1], sys.argv[2], Path(sys.argv[3])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hwpdocs = Path(r"C:\Users\planet\hwpdocs\samples")
+    poc = Path(r"C:\Users\planet\rhwp\output\poc\task2246")
+    pairs = [
+        (hwpdocs / "문화본부 문화예술과" / "36398599_결재문서본문_「동대문구 찾아가는 전통시장」 ’25년 민간축제 정산 결과 보고.hwpx",
+         poc / "36398599_h.pdf"),
+        (hwpdocs / "문화본부 문화유산활용과" / "36398700_결재문서본문_공유재산 사용허가(임시무상 사용) 검토보고 2.hwpx",
+         poc / "36398700_h.pdf"),
+    ]
+    for doc, ref_pdf in pairs:
+        stem = doc.name.split("_")[0]
+        ref = fitz.open(ref_pdf)
+        print(f"== {stem} (한글 {ref.page_count}쪽)")
+        for tag, exe in (("base", base_exe), ("head", head_exe)):
+            out_pdf = out_dir / f"{stem}_{tag}.pdf"
+            render(exe, doc, out_pdf)
+            got = fitz.open(out_pdf)
+            n = min(ref.page_count, got.page_count)
+            scores = []
+            for i in range(n):
+                pm, iou = compare(page_gray(ref, i), page_gray(got, i))
+                scores.append((pm, iou))
+            avg_pm = sum(s[0] for s in scores) / n
+            avg_iou = sum(s[1] for s in scores) / n
+            per = " ".join(f"p{i}:{s[0]:.1f}/{s[1]:.1f}" for i, s in enumerate(scores))
+            print(f"  {tag}: pages={got.page_count} avg_match={avg_pm:.2f} avg_iou={avg_iou:.2f}  [{per}]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약 (#2279 정밀도 캠페인 — 글자폭 실측 정합 반복분)

`한컴돋움`/`한컴바탕`의 측정 메트릭을 함초롬(HCR) 계열에서 **Haansoft Dotum/Batang 실메트릭**으로 연결한다.

### 근원 (실측 3중 증거)

1. **폰트 정체**: TTF name table(lang=0x412) — `HDOTUM.TTF` 한국어명 = "한컴돋움", `HBATANG.TTF` = "한컴바탕". 함초롬돋움/바탕(`HANDotum/HANBatang` = "HCR Dotum/Batang")과 **별개 폰트**.
2. **한글 PDF 실측** (`output/poc/task2246/36398599_h.pdf`, producer=Hancom PDF 1.3.0.550): Justify **단일줄(무신축) '*' run** dx = 0.583~0.590em, 한글 음절 = 1.0em (장평 96% 문단은 0.96) — Haansoft hmtx('*' 0.583, 음절 1.0)와 정확 일치.
3. **rhwp 종전 경로**: style_resolver 한컴 체인(한컴돋움→함초롬돋움) + metric alias(→HCR Dotum)로 '*' 0.498em/음절 0.97em 측정 → 한글 대비 문단 줄수 ±1 (#2279 2026-07-17 코멘트의 "글자폭 휴리스틱 양방향 줄수오차" 지배 성분, #2246 −1쪽 계열).

### 변경

- `style_resolver.rs`: 한컴바탕/한컴돋움 → 함초롬 치환 제거 (SVG 렌더 폴백 체인은 svg.rs가 한컴* 이름을 직접 처리 — 변경 없음)
- `font_metrics_data.rs` `resolve_metric_alias`: `한컴돋움→Haansoft Dotum`, `한컴바탕→Haansoft Batang` (DB 엔트리 기존재, FONT_6/FONT_7)
- `text_measurement.rs` `area_dot_fallback_width`: 한컴/Haansoft 계열도 embedded 메트릭 신뢰 (ㆍ=1.0em)
- 회귀 방지 단위 테스트 `issue_2279_hancom_dotum_batang_use_haansoft_metrics` 추가 (함초롬돋움은 종전 HCR 유지도 함께 고정)

### 게이트

| 게이트 | 결과 |
|---|---|
| 92 컨트롤셋 (`tools/render_page_gate.py`) | 일치 **86→88** (−1축 6→4: 36398599·36399105 해소, 회귀 0) |
| knife-edge 4문서 | 86712=65 · 80168=157 · 76076=82 · 80250=17 (전부 한글 정답 유지) |
| byeolpyo 양방향 | byeolpyo1=4 · byeolpyo4=26 (유지) |
| 358 recount (`output/poc/task2093/recount_pages.py`, release) | **FIXED 39 / REGRESSED 0** / SAME_OK 251 (직전 기준선 FIXED 37; footer 코호트 36376848·36404953·36358743 등 신규 해소) |
| 시각 (base vs head, 한글 PDF 픽셀·`tools/task2279/hancom_metric_visual_check.py`) | 36398599: 3쪽→**4쪽(=한글)**, 픽셀 90.88→**93.63%** / 36398700: 91.80→92.24% (저하 페이지 없음) |
| 전체 테스트 | cargo nextest 3264/3264 통과 (23 skipped) |
| fmt / clippy | 클린 (cargo fmt --check 신규 diff 없음 · clippy --all-targets -D warnings 통과) |

### 남긴 것 (후속)

- 92셋 잔존 −1×4 (36398700/36392557/36398709/36399374): 원본 기계생성 lineseg 신뢰 vs 한글 fresh 재계산 축 — is-hwpx-source-divergence 위험이 있어 별도 반복분.
- 함초롬돋움 문서를 한글이 Haansoft Dotum ASCII로 대체 렌더하는지 미실측 (#2156은 바탕만 확정) — 본 PR은 함초롬돋움을 종전 HCR 메트릭으로 유지.
- recount CHANGED 10건 중 정답 방향 8건, 방향 판단 불가 2건(20496055 13→14 vs 스냅샷 pdf 8 — r11 스냅샷 오염 의심, 한글 COM PageCount 교차검증은 진행 중인 10k r16 스윕 종료 후).

Closes: 없음 (#2279 umbrella 진행분, open 유지)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
