### PR TITLE
Task #2343: [개체] 메뉴/도구상자 개체 조작을 히스토리에 기록 — undo 불가·stale redo 수정

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -10,6 +10,8 @@ import { showShapePicker } from '@/ui/shape-picker';
 import { showToast } from '@/ui/toast';
 import type { ShapeType } from '@/ui/shape-picker';
 import type { CellPathLike } from '@/core/types';
+import type { WasmBridge } from '@/core/wasm-bridge';
+import type { InputHandler } from '@/engine/input-handler';
 
 /** 스텁 커맨드 생성 헬퍼 */
 function stub(id: string, label: string, icon?: string, shortcut?: string): CommandDef {
@@ -418,7 +420,7 @@ export const insertCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedPictureRef();
       if (!ref || ref.type !== 'shape') return;
-      services.wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'front');
+      recordObjectMutation(ih, 'changeZOrder', (wasm) => wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'front'));
       ih.exitPictureObjectSelectionAndAfterEdit();
     },
   },
@@ -431,7 +433,7 @@ export const insertCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedPictureRef();
       if (!ref || ref.type !== 'shape') return;
-      services.wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'forward');
+      recordObjectMutation(ih, 'changeZOrder', (wasm) => wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'forward'));
       ih.exitPictureObjectSelectionAndAfterEdit();
     },
   },
@@ -444,7 +446,7 @@ export const insertCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedPictureRef();
       if (!ref || ref.type !== 'shape') return;
-      services.wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'backward');
+      recordObjectMutation(ih, 'changeZOrder', (wasm) => wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'backward'));
       ih.exitPictureObjectSelectionAndAfterEdit();
     },
   },
@@ -457,7 +459,7 @@ export const insertCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedPictureRef();
       if (!ref || ref.type !== 'shape') return;
-      services.wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'back');
+      recordObjectMutation(ih, 'changeZOrder', (wasm) => wasm.changeShapeZOrder(ref.sec, ref.ppi, ref.ci, 'back'));
       ih.exitPictureObjectSelectionAndAfterEdit();
     },
   },
@@ -470,15 +472,17 @@ export const insertCommands: CommandDef[] = [
       if (!ih) return;
       const ref = ih.getSelectedPictureRef();
       if (!ref) return;
-      if (ref.type === 'shape' || ref.type === 'line' || ref.type === 'group') {
-        services.wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
-      } else if (ref.type === 'equation') {
-        services.wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
-      } else if (ref.cellPath && ref.cellPath.length > 0) {
-        services.wasm.deleteCellPictureControlByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci);
-      } else {
-        services.wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
-      }
+      recordObjectMutation(ih, 'deleteObject', (wasm) => {
+        if (ref.type === 'shape' || ref.type === 'line' || ref.type === 'group') {
+          wasm.deleteShapeControl(ref.sec, ref.ppi, ref.ci);
+        } else if (ref.type === 'equation') {
+          wasm.deleteEquationControl(ref.sec, ref.ppi, ref.ci);
+        } else if (ref.cellPath && ref.cellPath.length > 0) {
+          wasm.deleteCellPictureControlByPath(ref.sec, ref.ppi, ref.cellPath, ref.ci);
+        } else {
+          wasm.deletePictureControl(ref.sec, ref.ppi, ref.ci);
+        }
+      });
       ih.exitPictureObjectSelectionAndAfterEdit();
     },
   },
@@ -495,10 +499,11 @@ export const insertCommands: CommandDef[] = [
       const sec = refs[0].sec;
       const targets = refs.map(r => ({ paraIdx: r.ppi, controlIdx: r.ci }));
       try {
-        const result = services.wasm.groupShapes(sec, targets);
+        let result: ReturnType<typeof services.wasm.groupShapes> | undefined;
+        recordObjectMutation(ih, 'groupShapes', (wasm) => { result = wasm.groupShapes(sec, targets); });
         ih.exitPictureObjectSelectionAndAfterEdit();
         // 생성된 GroupShape를 선택
-        ih.selectPictureObject(sec, result.paraIdx, result.controlIdx, 'group');
+        if (result) ih.selectPictureObject(sec, result.paraIdx, result.controlIdx, 'group');
       } catch (err) {
         console.warn('[group-shapes] 개체 묶기 실패:', err);
       }
@@ -514,7 +519,7 @@ export const insertCommands: CommandDef[] = [
       const ref = ih.getSelectedPictureRef();
       if (!ref || ref.type !== 'group') return;
       try {
-        services.wasm.ungroupShape(ref.sec, ref.ppi, ref.ci);
+        recordObjectMutation(ih, 'ungroupShape', (wasm) => wasm.ungroupShape(ref.sec, ref.ppi, ref.ci));
         ih.exitPictureObjectSelectionAndAfterEdit();
       } catch (err) {
         console.warn('[ungroup-shapes] 개체 풀기 실패:', err);
@@ -591,6 +596,29 @@ function getProps(services: import('../types').CommandServices, ref: PictureRef)
   return services.wasm.getPictureProperties(ref.sec, ref.ppi, ref.ci) as unknown as Record<string, unknown>;
 }
 
+/**
+ * [계급 1 이관] 개체 조작 뮤테이션을 snapshot 으로 기록해 undo/redo 를 보장한다.
+ * 메뉴/도구상자 커맨드가 `services.wasm.*` 를 직접 호출하면 히스토리를 우회한다(같은
+ * 삭제라도 Delete 키 경로는 이미 `executeOperation({kind:'snapshot'})` 로 기록됨,
+ * input-handler-keyboard.ts). 그 경로와 동형으로 위임한다 — 뮤테이션만 기록하고 선택
+ * 해제·afterEdit·재선택 등 UI 후처리는 호출부가 기존대로 수행한다.
+ */
+function recordObjectMutation(
+  ih: InputHandler,
+  operationType: string,
+  mutate: (wasm: WasmBridge) => void,
+): void {
+  const pos = ih.getCursorPosition();
+  ih.executeOperation({
+    kind: 'snapshot',
+    operationType,
+    operation: (wasm) => {
+      mutate(wasm);
+      return pos;
+    },
+  });
+}
+
 function setProps(services: import('../types').CommandServices, ref: PictureRef, props: Record<string, unknown>): any {
   if (ref.type === 'shape') {
     if (ref.cellPath && ref.cellPath.length > 0) {
@@ -628,7 +656,7 @@ function applyRotationDelta(services: import('../types').CommandServices, delta:
   // -180 ~ 180 범위로 정규화
   next = ((next % 360) + 360) % 360;
   if (next > 180) next -= 360;
-  setProps(services, ref, { rotationAngle: next });
+  recordObjectMutation(ih, 'rotateObject', () => setProps(services, ref, { rotationAngle: next }));
   services.eventBus.emit('document-changed');
 }
 
@@ -641,6 +669,6 @@ function toggleFlip(services: import('../types').CommandServices, key: 'horzFlip
   const props = getProps(services, ref);
   if (props.sizeProtect) return;
   const cur = !!props[key];
-  setProps(services, ref, { [key]: !cur });
+  recordObjectMutation(ih, 'flipObject', () => setProps(services, ref, { [key]: !cur }));
   services.eventBus.emit('document-changed');
 }

--- a/rhwp-studio/tests/undo-menu-object-ops.test.ts
+++ b/rhwp-studio/tests/undo-menu-object-ops.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2343] 메뉴/도구상자 개체 조작 히스토리 라우팅 소스 가드.
+//
+// 개체 삭제·정렬(z순서)·묶기/풀기·회전/대칭을 메뉴로 실행해도 undo 되도록, 해당 뮤테이션이
+// executeOperation({kind:'snapshot'}) 로 라우팅되는지 정적으로 핀한다. 뮤테이션 표면 원장
+// (mutation-routing-guard)은 '표면 증가'만 잡고 '라우팅 누락'은 못 잡으므로(라우팅해도
+// wasm.X( 텍스트는 그대로 남음) 이 가드로 재발을 차단한다. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const insertSrc = readFileSync(join(rootDir, 'src/command/commands/insert.ts'), 'utf8');
+
+// recordObjectMutation 경유로 라우팅돼야 하는 개체 뮤테이터(속성 setter 는 setProps 공유·별건).
+const OBJECT_MUTATORS = [
+  'changeShapeZOrder',
+  'deleteShapeControl',
+  'deleteEquationControl',
+  'deleteCellPictureControlByPath',
+  'deletePictureControl',
+  'groupShapes',
+  'ungroupShape',
+];
+
+test('recordObjectMutation 은 executeOperation snapshot 으로 위임한다', () => {
+  const start = insertSrc.indexOf('function recordObjectMutation');
+  assert.notEqual(start, -1, 'recordObjectMutation 헬퍼가 존재해야 함');
+  const block = insertSrc.slice(start, start + 500);
+  assert.match(block, /ih\.executeOperation\(/, 'executeOperation 에 위임');
+  assert.match(block, /kind:\s*'snapshot'/, 'snapshot 커맨드로 기록(undo/redo 보장)');
+});
+
+test('개체 조작 뮤테이터는 services.wasm 직접 호출이 아니라 라우팅된다', () => {
+  for (const m of OBJECT_MUTATORS) {
+    // 미라우팅 흔적: services.wasm.<mutator>( 가 남아있으면 회귀.
+    assert.doesNotMatch(
+      insertSrc,
+      new RegExp(`services\\.wasm\\.${m}\\s*\\(`),
+      `${m} 는 recordObjectMutation 경유여야 함(services.wasm 직접 호출 금지 — 히스토리 우회)`,
+    );
+    // 라우팅된 호출: operation 콜백 안의 wasm.<mutator>( 는 존재해야 함.
+    assert.match(
+      insertSrc,
+      new RegExp(`\\bwasm\\.${m}\\s*\\(`),
+      `${m} 뮤테이션 자체는 operation 콜백에 존재해야 함`,
+    );
+  }
+});
+
+test('회전/대칭도 recordObjectMutation 으로 기록한다', () => {
+  const rot = insertSrc.slice(insertSrc.indexOf('function applyRotationDelta'), insertSrc.indexOf('function toggleFlip'));
+  assert.match(rot, /recordObjectMutation\(ih, 'rotateObject'/, '회전을 snapshot 으로 기록');
+  const flip = insertSrc.slice(insertSrc.indexOf('function toggleFlip'));
+  assert.match(flip.slice(0, 700), /recordObjectMutation\(ih, 'flipObject'/, '대칭을 snapshot 으로 기록');
+});


### PR DESCRIPTION
## 요약

개체(그림/도형/수식/그룹)를 **메뉴·도구상자**로 삭제 / 정렬(z순서) / 묶기·풀기 / 회전·대칭하면 Ctrl+Z 로 되돌릴 수 없던 계급 1 미라우팅을 수정합니다. 같은 삭제라도 **Delete 키 경로는 이미 기록**되던 진입점 비대칭을, Delete 키와 동형으로 `ih.executeOperation({kind:'snapshot'})` 에 위임해 해소합니다.

Fixes #2343

## 변경

- `recordObjectMutation(ih, operationType, mutate)` 헬퍼로 8지점 라우팅: `changeShapeZOrder`×4, `delete{Shape,Equation,CellPictureByPath,Picture}Control`, `groupShapes`/`ungroupShape`, 회전/대칭(`setProps`).
- 뮤테이션만 snapshot 으로 기록하고 선택 해제·`afterEdit`·재선택 등 UI 후처리는 기존대로 유지(최소 diff).
- 소스 가드 테스트 `undo-menu-object-ops` 추가 — 뮤테이션 표면 원장은 '표면 증가'만 잡고 라우팅해도 `wasm.X(` 텍스트는 남아 '라우팅 누락'을 못 잡으므로, 재발은 이 가드로 차단.

## 검증

- `npx tsc --noEmit`, `npm test` 320/320.
- 브라우저 왕복(실제 dispatcher 경유): 메뉴 삭제 시 `undoLen` 0→1(기록됨), undo 후 도형 복원. z순서·회전도 각각 `undoLen`+1 로 기록됨.

## 범위 외

- 개체 드래그/nudge(이미 `kind:'record'`), 속성 다이얼로그(picture-props 등 별도 경로).
