### PR TITLE
Task #2344: [표] 셀 숫자 서식을 히스토리에 기록 — undo 오프셋 오염·텍스트 손상 수정

### DIFF
--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -937,9 +937,18 @@ export const tableCommands: CommandDef[] = [
           result = sign + formatted + decPart;
         }
         if (result === text) return;
-        services.wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
-        services.wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
-        services.eventBus.emit('document-changed');
+        // [#2344] delete+insert 를 하나의 snapshot 으로 원자화해 라우팅 — 미기록 시 셀 문자
+        // 수가 바뀌어 후속 undo 오프셋이 오염되고 텍스트가 손상된다("1234567"→쉼표→Ctrl+Z="67").
+        // 라우터가 refresh 하므로 수동 document-changed emit 은 제거.
+        safeTableOp(() => ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'cellNumberFormat',
+          operation: (wasm) => {
+            wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
+            wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
+            return pos;
+          },
+        }), '셀 숫자 서식');
       } catch (err) {
         console.warn('[table:thousand-sep] 구분 쉼표 변환 실패:', err);
       }
@@ -970,9 +979,18 @@ export const tableCommands: CommandDef[] = [
         const fmtInt = hasCommas ? intPart.replace(/\B(?=(\d{3})+(?!\d))/g, ',') : intPart;
         const result = sign + fmtInt + '.' + newDecimals;
         if (result === text) return;
-        services.wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
-        services.wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
-        services.eventBus.emit('document-changed');
+        // [#2344] delete+insert 를 하나의 snapshot 으로 원자화해 라우팅 — 미기록 시 셀 문자
+        // 수가 바뀌어 후속 undo 오프셋이 오염되고 텍스트가 손상된다("1234567"→쉼표→Ctrl+Z="67").
+        // 라우터가 refresh 하므로 수동 document-changed emit 은 제거.
+        safeTableOp(() => ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'cellNumberFormat',
+          operation: (wasm) => {
+            wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
+            wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
+            return pos;
+          },
+        }), '셀 숫자 서식');
       } catch (err) {
         console.warn('[table:decimal-add] 자릿점 넣기 실패:', err);
       }
@@ -1003,9 +1021,18 @@ export const tableCommands: CommandDef[] = [
         const newDecimals = decimals.slice(0, -1);
         const result = newDecimals ? sign + fmtInt + '.' + newDecimals : sign + fmtInt;
         if (result === text) return;
-        services.wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
-        services.wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
-        services.eventBus.emit('document-changed');
+        // [#2344] delete+insert 를 하나의 snapshot 으로 원자화해 라우팅 — 미기록 시 셀 문자
+        // 수가 바뀌어 후속 undo 오프셋이 오염되고 텍스트가 손상된다("1234567"→쉼표→Ctrl+Z="67").
+        // 라우터가 refresh 하므로 수동 document-changed emit 은 제거.
+        safeTableOp(() => ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'cellNumberFormat',
+          operation: (wasm) => {
+            wasm.deleteTextInCell(sec, ppi, ci, cei, cpi, 0, len);
+            wasm.insertTextInCell(sec, ppi, ci, cei, cpi, 0, result);
+            return pos;
+          },
+        }), '셀 숫자 서식');
       } catch (err) {
         console.warn('[table:decimal-remove] 자릿점 빼기 실패:', err);
       }

--- a/rhwp-studio/tests/undo-cell-number-format.test.ts
+++ b/rhwp-studio/tests/undo-cell-number-format.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2344] 셀 숫자 서식(천단위 쉼표·자릿점) 히스토리 라우팅 소스 가드.
+//
+// 세 서식 op(thousand-sep / decimal-add / decimal-remove)가 deleteTextInCell+insertTextInCell
+// 을 직접 호출하면 미기록되어, 미기록으로 바뀐 셀 문자 수가 후속 undo 의 오프셋을 오염시켜
+// 텍스트가 손상된다("1234567"→쉼표→Ctrl+Z="67"). delete+insert 를 하나의 snapshot 으로
+// 원자화해 라우팅했는지 정적으로 핀한다. 행위 증명(손상 회귀 게이트)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const tableSrc = readFileSync(join(rootDir, 'src/command/commands/table.ts'), 'utf8');
+
+test('셀 숫자 서식은 deleteTextInCell/insertTextInCell 를 직접 호출하지 않고 라우팅한다', () => {
+  // 미라우팅 흔적: services.wasm.<X>InCell( 직접 호출이 남아있으면 손상 재발.
+  assert.doesNotMatch(tableSrc, /services\.wasm\.deleteTextInCell\s*\(/,
+    'deleteTextInCell 직접 호출 금지 — executeOperation snapshot 경유여야 함');
+  assert.doesNotMatch(tableSrc, /services\.wasm\.insertTextInCell\s*\(/,
+    'insertTextInCell 직접 호출 금지 — executeOperation snapshot 경유여야 함');
+});
+
+test('세 서식 op 는 delete+insert 를 하나의 cellNumberFormat snapshot 으로 원자화한다', () => {
+  // 3개 커맨드(thousand-sep/decimal-add/decimal-remove) 각각 라우팅.
+  const routed = tableSrc.match(/operationType:\s*'cellNumberFormat'/g) ?? [];
+  assert.equal(routed.length, 3, `3개 서식 op 가 모두 라우팅돼야 함(현재 ${routed.length})`);
+  // 뮤테이션 자체는 operation 콜백 안의 wasm.<X>InCell( 로 존재.
+  assert.match(tableSrc, /\bwasm\.deleteTextInCell\s*\(/, 'delete 는 operation 콜백에 존재');
+  assert.match(tableSrc, /\bwasm\.insertTextInCell\s*\(/, 'insert 는 operation 콜백에 존재');
+  // 세 커맨드 id 존재(회귀 시 커맨드 자체가 사라지는 것 방지).
+  for (const id of ['table:thousand-sep', 'table:decimal-add', 'table:decimal-remove']) {
+    assert.match(tableSrc, new RegExp(`id:\\s*'${id}'`), `${id} 커맨드 존재`);
+  }
+});


### PR DESCRIPTION
## 요약

표 셀의 **`1,000 단위 구분 쉼표` · `자릿점 넣기` · `자릿점 빼기`** 가 히스토리를 우회해, 미기록으로 셀 문자 수가 바뀌면 후속 Ctrl+Z 의 오프셋이 오염돼 **텍스트가 손상**되던 계급 1 미라우팅을 수정합니다(단순 undo 불가를 넘는 데이터 손상).

Fixes #2344

## 손상 메커니즘

1. 셀에 `1234567` 입력(기록됨).
2. 쉼표 적용 → `1,234,567`(9자)로 바뀜 — **미기록**.
3. Ctrl+Z → 이전 입력 undo 가 stale 오프셋으로 앞 7자를 지워 **`67` 잔류**.

## 변경

- 세 서식 op 의 `deleteTextInCell`+`insertTextInCell` 을 **하나의 `cellNumberFormat` snapshot 으로 원자화**해 `safeTableOp(() => ih.executeOperation({kind:'snapshot'}))` 로 라우팅합니다. 같은 파일의 줄/칸 추가(`applyTableInsertRowColumn`, table.ts:138)와 동형 패턴.
- 서식 계산(길이/텍스트 읽기·result 산출)은 읽기이므로 `operation` 밖에 유지. 라우터가 refresh 하므로 수동 `document-changed` emit 제거.
- 소스 가드 테스트 `undo-cell-number-format` 추가.

## 검증

- `npx tsc --noEmit`, `npm test` 319/319.
- **브라우저 손상 게이트**(실제 dispatcher 경유): 셀에 `1234567`(기록) 입력 후 쉼표 적용 시 `undoLen` +1(기록됨) → `1,234,567`, Ctrl+Z 후 **`1234567` 정확 복원(손상 `67` 없음)**, redo 재적용. 콘솔 에러 0.

## 범위 외

- 블록 계산(합계/평균/곱, `evaluateTableFormula` commit)·계산식 다이얼로그(FormulaDialog)의 미라우팅 — 동일 계급이나 별도 후속.
