### PR TITLE
Task #2347: [명령] 다단 설정·문단 감추기·표 블록계산을 히스토리에 기록 — undo 불가 수정

### DIFF
--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -417,22 +417,23 @@ export const pageCommands: CommandDef[] = [
       if (!ih) return;
       const pos = ih.getPosition();
       try {
-        // 현재 문단의 감추기 상태 조회
-        const result = JSON.parse((services.wasm as any).doc.getPageHide(pos.sectionIndex, pos.paragraphIndex));
-        if (result.exists) {
-          // 이미 감추기 있음 → 토글 (제거)
-          (services.wasm as any).doc.setPageHide(
-            pos.sectionIndex, pos.paragraphIndex,
-            false, false, false, false, false, false,
-          );
-        } else {
-          // 감추기 없음 → 쪽 번호 감추기 기본 적용
-          (services.wasm as any).doc.setPageHide(
-            pos.sectionIndex, pos.paragraphIndex,
-            false, false, false, false, false, true,
-          );
-        }
-        services.eventBus.emit('document-changed');
+        // 현재 문단의 감추기 상태 조회(읽기) 후 토글값 결정.
+        const cur = JSON.parse((services.wasm as any).doc.getPageHide(pos.sectionIndex, pos.paragraphIndex));
+        // exists → 제거(false), 없음 → 쪽 번호 감추기 적용(true). 나머지 5플래그는 양쪽 모두 false.
+        const applyPageNumHide = !cur.exists;
+        // [page-hide 이관] 문단 감추기 변경을 snapshot 으로 라우팅(기존 emit-only → undo 불가였음).
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'pageHide',
+          operation: (wasm) => {
+            (wasm as any).doc.setPageHide(
+              pos.sectionIndex, pos.paragraphIndex,
+              false, false, false, false, false, applyPageNumHide,
+            );
+            return pos;
+          },
+          meta: { actionId: 'page:hide', domain: 'page', refresh: 'full', dirtyScope: 'document' },
+        });
       } catch (err) {
         console.warn('[page:hide] 감추기 실패:', err);
       }
@@ -483,9 +484,16 @@ export const pageCommands: CommandDef[] = [
       if (!ih) return;
       const pos = ih.getPosition();
       try {
-        // 일반 다단(0), 같은 너비(1), 간격 8mm=2268HU
-        services.wasm.setColumnDef(pos.sectionIndex, def.cols, 0, 1, 2268);
-        services.eventBus.emit('document-changed');
+        // 일반 다단(0), 같은 너비(1), 간격 8mm=2268HU. snapshot 으로 라우팅해 undo 가능.
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'setColumnDef',
+          operation: (wasm) => {
+            wasm.setColumnDef(pos.sectionIndex, def.cols, 0, 1, 2268);
+            return pos;
+          },
+          meta: { actionId: def.id, domain: 'page', refresh: 'full', dirtyScope: 'document' },
+        });
       } catch (err) {
         console.warn(`[${def.id}] 다단 설정 실패:`, err);
       }
@@ -498,9 +506,17 @@ export const pageCommands: CommandDef[] = [
     execute(services) {
       const ih = services.getInputHandler();
       if (!ih) return;
+      const pos = ih.getPosition();
       try {
-        services.wasm.setColumnDef(ih.getPosition().sectionIndex, 2, 0, 0, 2268);
-        services.eventBus.emit('document-changed');
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'setColumnDef',
+          operation: (wasm) => {
+            wasm.setColumnDef(pos.sectionIndex, 2, 0, 0, 2268);
+            return pos;
+          },
+          meta: { actionId: 'page:col-left', domain: 'page', refresh: 'full', dirtyScope: 'document' },
+        });
       } catch (err) { console.warn('[page:col-left]', err); }
     },
   },
@@ -511,9 +527,17 @@ export const pageCommands: CommandDef[] = [
     execute(services) {
       const ih = services.getInputHandler();
       if (!ih) return;
+      const pos = ih.getPosition();
       try {
-        services.wasm.setColumnDef(ih.getPosition().sectionIndex, 2, 0, 0, 2268);
-        services.eventBus.emit('document-changed');
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'setColumnDef',
+          operation: (wasm) => {
+            wasm.setColumnDef(pos.sectionIndex, 2, 0, 0, 2268);
+            return pos;
+          },
+          meta: { actionId: 'page:col-right', domain: 'page', refresh: 'full', dirtyScope: 'document' },
+        });
       } catch (err) { console.warn('[page:col-right]', err); }
     },
   },

--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -79,14 +79,21 @@ function blockCalcCommand(id: string, label: string, func: string, shortcut: str
         const row = cellInfo.row;
         const col = cellInfo.col;
         const formula = `=${func}(above)`;
-        const result = services.wasm.evaluateTableFormula(
-          pos.sectionIndex, pos.parentParaIndex, pos.controlIndex,
-          row, col, formula, true,
-        );
-        const parsed = JSON.parse(result);
-        if (parsed.ok) {
-          services.eventBus.emit('document-changed');
-        }
+        // [블록계산 이관] write=true 는 결과를 셀에 써서 문자 수를 바꾼다 — 미기록 시 후속
+        // undo 오프셋 오염(#2344 셀 숫자 서식과 동일 계열). dry-run(write=false)으로 ok 를
+        // 확인한 뒤 commit 을 snapshot 으로 라우팅한다(라우터가 refresh → 수동 emit 제거).
+        const check = JSON.parse(services.wasm.evaluateTableFormula(
+          pos.sectionIndex, pos.parentParaIndex, pos.controlIndex, row, col, formula, false,
+        ));
+        if (!check.ok) return;
+        safeTableOp(() => ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'tableBlockCalc',
+          operation: (wasm) => {
+            wasm.evaluateTableFormula(pos.sectionIndex, pos.parentParaIndex!, pos.controlIndex!, row, col, formula, true);
+            return pos;
+          },
+        }), '블록 계산');
       } catch (err) {
         console.warn(`[${id}] 블록 계산 실패:`, err);
       }

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -136,7 +136,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/command/commands/format.ts': 1,
   'src/command/commands/insert.ts': 19,
   'src/command/commands/page.ts': 13,
-  'src/command/commands/table.ts': 33,
+  'src/command/commands/table.ts': 34, // +1: 블록계산 이관 시 evaluateTableFormula dry-run(write=false, 검증) 추가
   'src/ui/bookmark-dialog.ts': 3,
   'src/ui/cell-border-bg-dialog.ts': 5,
   'src/ui/column-settings-dialog.ts': 1,

--- a/rhwp-studio/tests/undo-page-blockcalc.test.ts
+++ b/rhwp-studio/tests/undo-page-blockcalc.test.ts
@@ -1,0 +1,46 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #page-blockcalc] 명령 계층(page.ts·table.ts 블록계산) 히스토리 라우팅 소스 가드.
+//
+// 다단 설정·문단 감추기·표 블록계산(합계/평균/곱)이 wasm 뮤테이터를 직접 호출하면 미기록되어
+// undo 불가(블록계산은 셀 문자 수까지 바꿔 오프셋 오염). executeOperation snapshot 라우팅을 핀한다.
+// 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+const pageSrc = src('src/command/commands/page.ts');
+const tableSrc = src('src/command/commands/table.ts');
+
+/** 함수/블록 소스를 시그니처~다음 최상위 함수 전까지 추출. */
+function slice(s: string, from: string, to: string): string {
+  const a = s.indexOf(from);
+  assert.notEqual(a, -1, `${from} not found`);
+  const b = s.indexOf(to, a + from.length);
+  return b === -1 ? s.slice(a) : s.slice(a, b);
+}
+
+test('표 블록계산은 evaluateTableFormula commit 을 snapshot 으로 라우팅한다', () => {
+  const block = slice(tableSrc, 'function blockCalcCommand', 'function openFormulaDialog');
+  assert.match(block, /operationType:\s*'tableBlockCalc'/, 'tableBlockCalc snapshot 라우팅');
+  assert.match(block, /\bwasm\.evaluateTableFormula\([^)]*true\s*\)/, 'commit(write=true)은 operation 콜백 안');
+  // 기존 직접 commit + emit 패턴 제거(회귀 방지).
+  assert.doesNotMatch(block, /services\.eventBus\.emit\('document-changed'\)/,
+    '직접 emit 제거 — 라우터가 refresh');
+});
+
+test('page.ts 다단 설정·문단 감추기는 snapshot 으로 라우팅한다', () => {
+  // 미라우팅 흔적: services.wasm.setColumnDef( 직접 호출 금지.
+  assert.doesNotMatch(pageSrc, /services\.wasm\.setColumnDef\s*\(/,
+    'setColumnDef 직접 호출 금지 — executeOperation 경유');
+  // setPageHide 직접 호출(operation 밖) 금지: services.wasm 경유 setPageHide 는 없어야.
+  assert.doesNotMatch(pageSrc, /services\.wasm\s+as\s+any\)\.doc\.setPageHide/,
+    'setPageHide 는 operation 콜백(wasm 파라미터) 경유');
+  // 라우팅 마커: 다단 3종 + 감추기.
+  const colRouted = pageSrc.match(/operationType:\s*'setColumnDef'/g) ?? [];
+  assert.equal(colRouted.length, 3, `다단 설정 3종 라우팅(현재 ${colRouted.length})`);
+  assert.match(pageSrc, /operationType:\s*'pageHide'/, '문단 감추기 라우팅');
+});


### PR DESCRIPTION
## 요약

명령 팔레트/메뉴의 **다단 설정**·**문단 감추기**·**표 블록 계산**이 히스토리를 우회해 undo 되지 않던 계급 1 미라우팅을 수정합니다. 블록 계산은 셀 문자 수까지 바꿔 후속 undo 오프셋을 오염시킵니다(#2344 계열).

Fixes #2347

## 변경

- `page.ts` 다단(`setColumnDef` ×3 커맨드)·감추기(`setPageHide`): 같은 파일의 `page:break` 패턴(`executeOperation({kind:'snapshot', meta:{domain:'page',refresh:'full',dirtyScope:'document'}})`)으로 라우팅.
- `table.ts` 블록 계산: dry-run(`write=false`)으로 ok 확인 후 commit(`write=true`)을 snapshot 으로 라우팅(실패 시 no-op 스냅샷 방지). 뮤테이션 표면 원장 baseline `table.ts 33→34`(dry-run 검증 호출) 반영.
- 소스 가드 테스트 `undo-page-blockcalc` 추가.

## 검증

- `npx tsc --noEmit`, `npm test` 319/319.
- 브라우저 왕복(실제 dispatcher): 블록합계 10+20 → 셀 `30` + `undoLen` 0→1(기록) → undo `""`; `page:col-2`·`page:hide` 각각 `undoLen`+1 후 undo 균형. 콘솔 에러 0.

## 범위 외

- 머리말/꼬리말 구조 조작(page.ts:57/77/139/260/317) — HF 서브모드·#2337 HF undo machinery와 얽힘.
- 구역/쪽/다단 **다이얼로그** — InputHandler 미도달로 services 주입 필요(별도 사이클).
