### PR TITLE
Task #2349: [책갈피] 책갈피 추가/삭제/이름변경을 히스토리에 기록 — undo 불가 수정

### DIFF
--- a/rhwp-studio/src/ui/bookmark-dialog.ts
+++ b/rhwp-studio/src/ui/bookmark-dialog.ts
@@ -279,16 +279,25 @@ export class BookmarkDialog {
     if (!ih) return;
     const pos = ih.getCursorPosition();
 
-    const result = this.services.wasm.addBookmark(
-      pos.sectionIndex, pos.paragraphIndex, pos.charOffset, name,
-    );
+    // [책갈피 이관] 추가를 snapshot 으로 라우팅해 undo 가능(기존 emit-only → 되돌릴 수 없었음).
+    let ok = false;
+    let errMsg: string | undefined;
+    ih.executeOperation({
+      kind: 'snapshot',
+      operationType: 'addBookmark',
+      operation: (wasm) => {
+        const r = wasm.addBookmark(pos.sectionIndex, pos.paragraphIndex, pos.charOffset, name);
+        ok = r.ok;
+        errMsg = r.error;
+        return pos;
+      },
+    });
 
-    if (result.ok) {
-      this.services.eventBus.emit('document-changed');
+    if (ok) {
       this.hide();
     } else {
       this.statusLabel.style.color = '#c00';
-      this.statusLabel.textContent = result.error ?? '책갈피 추가 실패';
+      this.statusLabel.textContent = errMsg ?? '책갈피 추가 실패';
     }
   }
 
@@ -318,9 +327,19 @@ export class BookmarkDialog {
 
     if (!confirm(`선택한 책갈피 '${bm.name}'를 지울까요?`)) return;
 
-    const result = this.services.wasm.deleteBookmark(bm.sec, bm.para, bm.ctrlIdx);
-    if (result.ok) {
-      this.services.eventBus.emit('document-changed');
+    const ih = this.services.getInputHandler();
+    if (!ih) return;
+    // [책갈피 이관] 삭제를 snapshot 으로 라우팅.
+    let ok = false;
+    ih.executeOperation({
+      kind: 'snapshot',
+      operationType: 'deleteBookmark',
+      operation: (wasm) => {
+        ok = wasm.deleteBookmark(bm.sec, bm.para, bm.ctrlIdx).ok;
+        return ih.getCursorPosition();
+      },
+    });
+    if (ok) {
       this.refreshList();
       this.statusLabel.textContent = '';
     }
@@ -332,13 +351,26 @@ export class BookmarkDialog {
     const newName = prompt('새 책갈피 이름:', bm.name);
     if (!newName || newName.trim() === '' || newName === bm.name) return;
 
-    const result = this.services.wasm.renameBookmark(bm.sec, bm.para, bm.ctrlIdx, newName.trim());
-    if (result.ok) {
-      this.services.eventBus.emit('document-changed');
+    const ih = this.services.getInputHandler();
+    if (!ih) return;
+    // [책갈피 이관] 이름 변경을 snapshot 으로 라우팅.
+    let ok = false;
+    let errMsg: string | undefined;
+    ih.executeOperation({
+      kind: 'snapshot',
+      operationType: 'renameBookmark',
+      operation: (wasm) => {
+        const r = wasm.renameBookmark(bm.sec, bm.para, bm.ctrlIdx, newName.trim());
+        ok = r.ok;
+        errMsg = r.error;
+        return ih.getCursorPosition();
+      },
+    });
+    if (ok) {
       this.refreshList();
     } else {
       this.statusLabel.style.color = '#c00';
-      this.statusLabel.textContent = result.error ?? '이름 변경 실패';
+      this.statusLabel.textContent = errMsg ?? '이름 변경 실패';
     }
   }
 }

--- a/rhwp-studio/tests/undo-bookmark.test.ts
+++ b/rhwp-studio/tests/undo-bookmark.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #bookmark] 책갈피 추가/삭제/이름변경 히스토리 라우팅 소스 가드.
+//
+// 책갈피 관리(추가/삭제/이름변경)가 wasm 뮤테이터를 직접 호출하면 미기록되어 undo 불가.
+// this.services.getInputHandler() 로 라우터에 도달하므로 executeOperation snapshot 으로
+// 라우팅했는지 정적으로 핀한다. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/ui/bookmark-dialog.ts'), 'utf8');
+
+const OPS = ['addBookmark', 'deleteBookmark', 'renameBookmark'];
+
+test('책갈피 관리 op 는 wasm 직접 호출이 아니라 snapshot 으로 라우팅한다', () => {
+  for (const op of OPS) {
+    // 미라우팅 흔적: this.services.wasm.<op>( 직접 호출 금지.
+    assert.doesNotMatch(src, new RegExp(`this\\.services\\.wasm\\.${op}\\s*\\(`),
+      `${op} 는 executeOperation 경유여야 함(this.services.wasm 직접 호출 금지)`);
+    // 라우팅 마커 + operation 콜백 안의 실제 뮤테이션.
+    assert.match(src, new RegExp(`operationType:\\s*'${op}'`), `${op} snapshot 라우팅`);
+    assert.match(src, new RegExp(`\\bwasm\\.${op}\\s*\\(`), `${op} 뮤테이션은 operation 콜백에 존재`);
+  }
+});


### PR DESCRIPTION
## 요약

책갈피 관리 다이얼로그의 **추가/삭제/이름 변경**이 히스토리를 우회해 undo 되지 않던 계급 1 미라우팅을 수정합니다.

Fixes #2349

## 변경

- `bookmark-dialog.ts` `doAdd`/`doDelete`/`doRename`: `this.services.wasm.*Bookmark` 직접 호출 → `ih.executeOperation({kind:'snapshot', operationType})` 로 라우팅(이미 라우팅된 #2077 수식 속성 다이얼로그와 동형 — 이 다이얼로그는 `services` 를 보유해 라우터에 도달 가능).
- 라우터가 refresh → 수동 `document-changed` emit 제거. `result.ok`/`error` 는 operation 밖 지역 변수로 캡처해 상태 라벨 흐름 유지.
- 소스 가드 테스트 `undo-bookmark` 추가.

## 검증

- `npx tsc --noEmit`, `npm test` 318/318.
- 브라우저 왕복(doAdd 와 동일 라우팅): 추가 → `getBookmarks()` 1건 + `undoLen` 0→1 → undo 0건 → redo 1건. 콘솔 에러 0.

## 범위 외 (별도 후속 — 각각 얽힘)

- 각주/미주/수식 삽입(insert.ts): 삽입 후 노트 편집 **서브모드**/모달 진입 → undo 시 서브모드 복원(#2337식) 필요.
- 누름틀·form 값: **form 모드 게이팅**(`isOperationAllowedInEditMode` 가 form 모드에서 snapshot 차단) → record+역연산 처리 필요.
