### PR TITLE
Task #2279: flow spacing 트림의 복원성 규칙 3종 (기계생성 결재문서 흐름 정합)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -59,6 +59,18 @@ impl DocumentCore {
         let mut document = parsed.document;
         let hml_metadata = parsed.hml_metadata;
 
+        // [#2279 실험 전용] 본문 저장 lineseg 전면 무시 → fresh 재계산.
+        // 기계생성 결재문서의 부분-사다리 불신 실험 계측용 (기본 no-op).
+        // 주의: 92셋 전수 실측(2026-07-18)에서 전면 fresh 는 88→76 광역 회귀 —
+        // 부분 사다리의 정합을 fresh 가 아직 대체하지 못함. 판별-자동화 금지.
+        if std::env::var("RHWP_EXP_BODY_FRESH").is_ok() {
+            for sec in document.sections.iter_mut() {
+                for para in sec.paragraphs.iter_mut() {
+                    para.line_segs.clear();
+                }
+            }
+        }
+
         // [Task #1001] HWP3 변환본의 ParaShape 단위 1/2 추가 보정
         let styles = crate::renderer::style_resolver::resolve_styles_with_variant(
             &document.doc_info,

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -81,9 +81,14 @@ pub struct MetricMatch {
 /// 실무 허용. 정식 DB 엔트리 추가는 별도 이슈.
 fn resolve_metric_alias(name: &str) -> &str {
     match name {
-        "함초롬돋움" | "한컴돋움" => "HCR Dotum",
+        "함초롬돋움" => "HCR Dotum",
+        // [#2279] 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang
+        // (HDOTUM.TTF/HBATANG.TTF name table). HCR(함초롬) 계열과 메트릭이
+        // 다르므로 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em) 별도 연결.
+        "한컴돋움" => "Haansoft Dotum",
         "돋움" => "Dotum",
-        "함초롬바탕" | "한컴바탕" => "HCR Batang",
+        "함초롬바탕" => "HCR Batang",
+        "한컴바탕" => "Haansoft Batang",
         "바탕" => "Batang", // 윈도우 TTF 바탕
         "맑은 고딕" => "Malgun Gothic",
         "나눔고딕" => "NanumGothic",

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1561,10 +1561,15 @@ fn haansoft_latin_override(primary_name: &str, c: char) -> Option<f64> {
 /// 명조(HY견명조 치환) 등 여타 = 반각 (80168 개정안{{7}} p9/p13 '시ㆍ도조례'
 /// 1줄 오라클, 개정안{{1}} P21 마크와 반각 양립 검증). embedded 메트릭
 /// (HY견명조 수록분)이 전각이라 룩업보다 앞서 판정하되, 함초롬(HCR) 계열은
-/// embedded 메트릭을 신뢰한다 (None 반환).
+/// embedded 메트릭을 신뢰한다 (None 반환). [#2279] 한컴바탕/한컴돋움
+/// (Haansoft 실메트릭, ㆍ=1.0em)도 동일하게 embedded 메트릭을 신뢰한다.
 pub(crate) fn area_dot_fallback_width(font_family: &str, font_size: f64) -> Option<f64> {
     let fam = font_family.split(',').next().unwrap_or("").trim();
-    if fam.contains("함초롬") || fam.contains("HCR") {
+    if fam.contains("함초롬")
+        || fam.contains("HCR")
+        || fam.contains("한컴")
+        || fam.contains("Haansoft")
+    {
         return None;
     }
     Some(if fam.contains("한양신명조") {
@@ -2094,6 +2099,58 @@ mod tests {
         assert!(haansoft_latin_override("함초롬바탕 확장", '(').is_none());
         assert!(haansoft_latin_override("HCR Batang Ext", '(').is_none());
         assert!(haansoft_latin_override("바탕", '(').is_none());
+    }
+
+    // ── #2279 한컴돋움/한컴바탕 = Haansoft 실메트릭 ──
+
+    /// 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang (HDOTUM.TTF/HBATANG.TTF
+    /// name table 한국어명). 한글 PDF 실측(36398599 pi35 단일줄 무신축 '*' run:
+    /// 0.583em, 한글 음절 1.0em)과 hmtx 가 일치 — HCR(함초롬) 메트릭('*' 0.498,
+    /// 음절 0.97em)으로 회귀하면 '*' 마스킹 구분선·본문 래핑 줄수가 한글 대비
+    /// ±1 이탈한다 (92 컨트롤셋 36398599/36399105 −1쪽 계열).
+    #[test]
+    fn issue_2279_hancom_dotum_batang_use_haansoft_metrics() {
+        let fs = 20.0; // 15pt
+        let w = |fam: &str, c: char| {
+            measure_char_width_embedded(fam, false, false, c, fs)
+                .unwrap_or_else(|| panic!("측정 실패: {fam} {c:?}"))
+        };
+        // 한컴돋움 = Haansoft Dotum
+        assert!(
+            (w("한컴돋움", '*') - fs * 0.583).abs() < 0.05,
+            "'*' {}",
+            w("한컴돋움", '*')
+        );
+        assert!(
+            (w("한컴돋움", '0') - fs * 0.583).abs() < 0.05,
+            "'0' {}",
+            w("한컴돋움", '0')
+        );
+        assert!(
+            (w("한컴돋움", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴돋움", '가')
+        );
+        // 한컴바탕 = Haansoft Batang (음절 1.0em; ASCII 는 #2156 표와 동일)
+        assert!(
+            (w("한컴바탕", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴바탕", '가')
+        );
+        assert!(
+            (w("한컴바탕", '*') - fs * 0.5).abs() < 0.05,
+            "'*' {}",
+            w("한컴바탕", '*')
+        );
+        // 함초롬돋움은 종전대로 HCR Dotum 메트릭 유지 (한글 대체 여부 미실측)
+        assert!(
+            (w("함초롬돋움", '가') - fs * 0.97).abs() < 0.05,
+            "HCR '가' {}",
+            w("함초롬돋움", '가')
+        );
+        // ㆍ(U+318D): 한컴 계열은 area_dot 폴백 대신 embedded 메트릭(1.0em) 신뢰
+        assert!(area_dot_fallback_width("한컴돋움", fs).is_none());
+        assert!(area_dot_fallback_width("한컴바탕", fs).is_none());
     }
 
     // ── MockTextMeasurer 테스트 ──

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -681,9 +681,14 @@ fn resolve_ttf_font(name: &str) -> Option<&'static str> {
         "Malgun Gothic" => Some("맑은 고딕"),
         "HY그래픽M" => Some("HY그래픽"),
         "SPOQAHANSANS" => Some("SpoqaHanSans"),
-        // 한컴 체인: 한컴바탕→함초롬바탕, 한컴돋움→함초롬돋움
-        "한컴바탕" => Some("함초롬바탕"),
-        "한컴돋움" => Some("함초롬돋움"),
+        // [#2279] 한컴바탕/한컴돋움은 함초롬 계열로 치환하지 않는다.
+        // TTF name table 실측: 한컴바탕 = Haansoft Batang(HBATANG.TTF),
+        // 한컴돋움 = Haansoft Dotum(HDOTUM.TTF) — 함초롬(HCR)과 별개 폰트로
+        // 메트릭이 다르다 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em).
+        // 종전 치환은 한컴돋움 문서의 폭 측정을 HCR Dotum 메트릭으로 보내
+        // 줄수 ±1 오차를 만들었다 (한글 PDF 실측: '*' 0.583em, 음절 1.0em).
+        // 메트릭은 font_metrics_data::resolve_metric_alias 가 Haansoft 엔트리로
+        // 연결하고, SVG 렌더 폴백 체인(svg.rs)은 한컴* 이름을 직접 처리한다.
         // 영어(1) 전용 TTF 치환 (webhwp lang=1)
         "MS Sans Serif" => Some("함초롬돋움"),
         "Tahoma" => Some("함초롬돋움"),

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2105,12 +2105,25 @@ impl FormattedParagraph {
         para: &Paragraph,
         col_count: u16,
         allow_spacing_before_only: bool,
+        ladder_dirty: bool,
     ) -> f64 {
         if col_count > 1 {
             return self.height_for_fit;
         }
+        // [#2279 ①] spacing 트림은 **비합성(authoritative) 저장 lineseg** 문단에만.
+        // 저장 ladder 가 spacing 을 이미 반영하고 vpos-snap 이 좌표를 복원하는
+        // 전제의 트림이므로, 합성(reflow) lineseg 문단은 ladder 가 없어 트림하면
+        // sb·ls 가 흐름에서 그냥 소실된다 (한글 fresh 는 가산 — 기계생성 결재
+        // 문서 −1쪽 계열, DIAG_ADV 실측 문단당 4~33px).
+        // [#2279 ①-2] dirty(합성 혼합) ladder 구간도 동일 — #2243 전방-스냅만
+        // 허용되어 트림분이 복원되지 않으므로 full advance 를 쓴다
+        // (36398700 pi6..9 구간 −60px 폐합, 한글 재저장 anchor 실측).
+        let has_authoritative_seg = para.line_segs.iter().any(|seg| {
+            seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
+        });
         if para.controls.is_empty()
-            && !para.line_segs.is_empty()
+            && has_authoritative_seg
+            && !ladder_dirty
             && (self.spacing_after > 0.5
                 || (allow_spacing_before_only && self.spacing_before > 0.5))
             && self.height_for_fit > 0.0
@@ -2120,6 +2133,35 @@ impl FormattedParagraph {
         }
         self.total_height
     }
+}
+
+/// [#2279 ①-3] spacing 트림의 복원 가능성 전방 판정.
+///
+/// 트림은 다음 authoritative(비합성 lineseg) anchor 에서 vpos-snap 이 좌표를
+/// 복원한다는 전제다. 현 문단과 다음 anchor 사이에 합성/NO_LS 텍스트 문단이
+/// 끼어 있으면 dirty 규칙(#2243 전방-스냅만)으로 복원이 차단되므로 트림하면
+/// 그 spacing 이 흐름에서 소실된다 (36398700 pi6: 다음 anchor pi10 앞에
+/// 합성 pi7~9 → −35.7px 소실 실측). 표 컨트롤 문단은 재앵커(#2243) 지점이라
+/// 복원 가능으로 본다. 탐색은 32문단 한도(초과 시 보수적으로 복원 불가).
+fn spacing_trim_restorable(paragraphs: &[Paragraph], para_idx: usize) -> bool {
+    use crate::model::paragraph::LineSeg;
+    for para in paragraphs.iter().skip(para_idx + 1).take(32) {
+        if !para.controls.is_empty() {
+            return true; // 표/개체 재앵커 지점
+        }
+        match para.line_segs.first() {
+            Some(seg) if seg.tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0 => {
+                return true; // authoritative anchor 도달 — 복원 가능
+            }
+            _ => {
+                if !para.text.is_empty() {
+                    return false; // 합성/NO_LS 텍스트 문단이 먼저 — 복원 불가
+                }
+                // 빈 문단은 계속 탐색
+            }
+        }
+    }
+    false
 }
 
 fn debug_brief_line_text(text: &str, max_chars: usize) -> String {
@@ -10915,7 +10957,12 @@ impl TypesetEngine {
         let spacing_after = para_style.map(|s| s.spacing_after).unwrap_or(0.0);
 
         // [Task #998 실험] spacing_before=0 으로 강제 — 효과 측정용
-        let spacing_before = if para.line_segs.is_empty() && !para.text.is_empty() {
+        // [#2279 실험 전용] RHWP_EXP_BODY_FRESH 시 NO_LS 문단도 sb 를 보존한다
+        // (한글 fresh 는 sb 를 가산 — 생성기 사다리 sb-누락 모사 우회 계측).
+        let spacing_before = if para.line_segs.is_empty()
+            && !para.text.is_empty()
+            && std::env::var("RHWP_EXP_BODY_FRESH").is_err()
+        {
             0.0
         } else {
             raw_spacing_before
@@ -11586,7 +11633,24 @@ impl TypesetEngine {
             //   - 다단 (col_count > 1): height_for_fit (exam_eng 8p 정상 단 채움 복원)
             // 다단에서는 layout 이 vpos 기반으로 항목을 단별로 stacking 하므로
             // typeset 누적 시 trailing_ls 인플레이션이 단을 조기 종료시킴.
-            let advance = fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+            let advance = fmt.flow_advance_height(
+                para,
+                st.col_count,
+                trim_spacing_before_for_flow,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+            );
+            if std::env::var("RHWP_DIAG_ADV").is_ok() {
+                eprintln!(
+                    "DIAG_ADV pi={} adv={:.1} total={:.1} h4f={:.1} sb={:.1} sa={:.1} cur={:.1}",
+                    para_idx,
+                    advance,
+                    fmt.total_height,
+                    fmt.height_for_fit,
+                    fmt.spacing_before,
+                    fmt.spacing_after,
+                    st.current_height,
+                );
+            }
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
             if let Some(v) = body_bottom_vpos {
@@ -11635,8 +11699,12 @@ impl TypesetEngine {
                 st.current_items.push(PageItem::FullParagraph {
                     para_index: para_idx,
                 });
-                let advance =
-                    fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+                let advance = fmt.flow_advance_height(
+                    para,
+                    st.col_count,
+                    trim_spacing_before_for_flow,
+                    st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                );
                 st.current_height += advance;
                 st.flow_underrun += (fmt.total_height - advance).max(0.0);
                 if let Some(v) = body_bottom_vpos {
@@ -11745,7 +11813,12 @@ impl TypesetEngine {
             //   - 다단 (col_count > 1): height_for_fit (exam_eng 8p 정상 단 채움 복원)
             // 다단에서는 layout 이 vpos 기반으로 항목을 단별로 stacking 하므로
             // typeset 누적 시 trailing_ls 인플레이션이 단을 조기 종료시킴.
-            let advance = fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+            let advance = fmt.flow_advance_height(
+                para,
+                st.col_count,
+                trim_spacing_before_for_flow,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+            );
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
             if let Some(v) = body_bottom_vpos {
@@ -13794,7 +13867,12 @@ impl TypesetEngine {
             st.current_items.push(PageItem::FullParagraph {
                 para_index: next_idx,
             });
-            st.current_height += fmt_n.flow_advance_height(next, st.col_count, trim_sb);
+            st.current_height += fmt_n.flow_advance_height(
+                next,
+                st.col_count,
+                trim_sb,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs_all, next_idx),
+            );
             st.prefilled_paras.insert(next_idx);
         }
     }

--- a/tools/task2279/hancom_metric_visual_check.py
+++ b/tools/task2279/hancom_metric_visual_check.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""#2279 한컴돋움/한컴바탕 메트릭 정합 — base vs head 픽셀 대조 (한글 PDF 기준).
+
+지표: tools/task2279/visual_evidence.py 와 동일 (96dpi gray, 임계 이진화 일치율 + IoU).
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import fitz
+import numpy as np
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+FONTS = Path(r"C:\Users\planet\rhwp\ttfs")
+
+
+def render(exe: str, doc: Path, out_pdf: Path):
+    if out_pdf.exists():
+        out_pdf.unlink()
+    r = subprocess.run(
+        [exe, "export-pdf", str(doc), "-o", str(out_pdf), "--font-path", str(FONTS)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=900,
+    )
+    if not out_pdf.exists():
+        raise RuntimeError(f"export-pdf 실패: {r.stderr[:300]}")
+
+
+def page_gray(doc, i):
+    pix = doc[i].get_pixmap(dpi=96, colorspace=fitz.csGRAY)
+    return np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
+
+
+def compare(ref, img):
+    h = min(ref.shape[0], img.shape[0])
+    w = min(ref.shape[1], img.shape[1])
+    a, b = ref[:h, :w].astype(int), img[:h, :w].astype(int)
+    pixel_match = 100.0 * float(((a > 200) == (b > 200)).mean())
+    ink_a = (a <= 200)
+    ink_b = (b <= 200)
+    union = (ink_a | ink_b).sum()
+    iou = 100.0 * float((ink_a & ink_b).sum() / union) if union else 100.0
+    return pixel_match, iou
+
+
+def main():
+    base_exe, head_exe, out_dir = sys.argv[1], sys.argv[2], Path(sys.argv[3])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hwpdocs = Path(r"C:\Users\planet\hwpdocs\samples")
+    poc = Path(r"C:\Users\planet\rhwp\output\poc\task2246")
+    pairs = [
+        (hwpdocs / "문화본부 문화예술과" / "36398599_결재문서본문_「동대문구 찾아가는 전통시장」 ’25년 민간축제 정산 결과 보고.hwpx",
+         poc / "36398599_h.pdf"),
+        (hwpdocs / "문화본부 문화유산활용과" / "36398700_결재문서본문_공유재산 사용허가(임시무상 사용) 검토보고 2.hwpx",
+         poc / "36398700_h.pdf"),
+    ]
+    for doc, ref_pdf in pairs:
+        stem = doc.name.split("_")[0]
+        ref = fitz.open(ref_pdf)
+        print(f"== {stem} (한글 {ref.page_count}쪽)")
+        for tag, exe in (("base", base_exe), ("head", head_exe)):
+            out_pdf = out_dir / f"{stem}_{tag}.pdf"
+            render(exe, doc, out_pdf)
+            got = fitz.open(out_pdf)
+            n = min(ref.page_count, got.page_count)
+            scores = []
+            for i in range(n):
+                pm, iou = compare(page_gray(ref, i), page_gray(got, i))
+                scores.append((pm, iou))
+            avg_pm = sum(s[0] for s in scores) / n
+            avg_iou = sum(s[1] for s in scores) / n
+            per = " ".join(f"p{i}:{s[0]:.1f}/{s[1]:.1f}" for i, s in enumerate(scores))
+            print(f"  {tag}: pages={got.page_count} avg_match={avg_pm:.2f} avg_iou={avg_iou:.2f}  [{per}]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약 (#2279 정밀도 캠페인 — flow spacing 트림의 복원성 규칙)

> **PR #2340 위에 스택**: base 커밋 41d7abf7 = PR #2340(한컴돋움 메트릭)의 squash 커밋. #2340 merge 후 본 PR 은 이 커밋 하나(d6cdddf5)만 남습니다.

`flow_advance_height` 의 spacing(sb/sa) 트림은 "저장 vpos ladder 가 spacing 을 이미 반영하고 vpos-snap 이 좌표를 복원한다"는 전제 위의 최적화다. 이 전제가 깨지는 세 경우에 트림을 차단해 spacing 이 흐름에서 소실되지 않게 한다.

### 규칙 (①-1/2/3)

1. **합성 lineseg 문단 트림 금지**: reflow 합성 lineseg 는 ladder 가 아니므로 트림분(문단당 4~33px, DIAG_ADV 실측)이 그냥 소실된다 — 비합성(authoritative) seg 보유 문단에만 트림.
2. **dirty ladder 구간 트림 금지**: 합성 문단이 섞인(dirty) ladder 는 #2243 규칙상 전방-스냅만 허용되어 복원이 차단된다.
3. **전방 복원성 검사**: 다음 authoritative anchor 도달 전에 합성/NO_LS 텍스트 문단이 끼면 스냅 복원 불가 — 트림 금지 (36398700 pi6 −35.7px 소실 실측 폐합).

부가: `DIAG_ADV`(문단 place advance 구성 진단), `RHWP_EXP_BODY_FRESH`(본문 lineseg 전면-무시 실험 플래그, 기본 no-op — 92셋 전수 실측에서 전면 fresh 는 88→76 회귀임을 코드 주석으로 기록).

### 근거 (한글 재저장본 anchor 실측, 36398700)

한글 재저장본(HWP5)의 저장 vpos ladder = 한글 fresh 좌표. rhwp flow(cur_h)와 지점별 조인:

| 구간 | 한글 step | rhwp step(수정 전) | Δ |
|---|---|---|---|
| pi5→6 | 44.6px | 20.0 | −24.6 (트림 소실) |
| pi6→10 | 169.1 | 108.6 | **−60.5** |
| pi10→13 | 94.0 | 94.0 | 0 (snap 정상 구간) |

수정 후 **36398700 의 p2/p3 분할 경계가 한글 재저장 anchor 와 일치**(p3 시작 = pi20 "□ 검토결과").

### 게이트 (격리 worktree 재검증)

| 게이트 | 결과 |
|---|---|
| 92 컨트롤셋 | 일치 88 / −1×4 (변동 없음, 회귀 0) |
| knife-edge 4 | 86712=65 · 80168=157 · 76076=82 · 80250=17 |
| byeolpyo | 4 · 26 |
| svg_snapshot | 8/8 (골든 불변) |
| 358 recount | **FIXED 39 / REGRESSED 0** / SAME_OK 251 / CHANGED 10 (직전 기준선과 동일 — 게이트 중립) |
| nextest 전체 | 3264/3264 통과 (23 skipped, 격리 worktree) |
| fmt / clippy | 클린 (fmt --check 신규 diff 없음 · clippy --all-targets -D warnings 통과) |
| 시각 (한글 PDF 픽셀) | 36398700: 91.80→**92.60** (p3 match 90.6→92.4, IoU 2.8→9.7) / 36398599 93.63 유지 |

### 남긴 것 (후속, 이슈 #2279 코멘트 참조)

- 92셋 −1×4 잔여: 공통 다음 표적 = TAC 제목표 host 구간 +15~21px (성분②의 원본-경로 미적용).
- 자간(%) 적용 기준(글자폭 vs 폰트크기 비례) 오라클 상충 — 통제 사다리 실측 전용 트랙 (실험 커밋 fb622cab 은 local 브랜치에 보존, 본 PR 미포함).
- 마스킹 문단 저장-분할 실폭-모순 재래핑(36392557 pi34, 한글 3줄 80/68/16 실측)은 자간 트랙과 결합 시 landing.

Closes: 없음 (#2279 umbrella 진행분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
