### PR TITLE
Task #2279: TAC-자리차지 모순 표의 host 줄박스 가산 (92셋 -1축 4→3)

### DIFF
--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -59,6 +59,18 @@ impl DocumentCore {
         let mut document = parsed.document;
         let hml_metadata = parsed.hml_metadata;
 
+        // [#2279 실험 전용] 본문 저장 lineseg 전면 무시 → fresh 재계산.
+        // 기계생성 결재문서의 부분-사다리 불신 실험 계측용 (기본 no-op).
+        // 주의: 92셋 전수 실측(2026-07-18)에서 전면 fresh 는 88→76 광역 회귀 —
+        // 부분 사다리의 정합을 fresh 가 아직 대체하지 못함. 판별-자동화 금지.
+        if std::env::var("RHWP_EXP_BODY_FRESH").is_ok() {
+            for sec in document.sections.iter_mut() {
+                for para in sec.paragraphs.iter_mut() {
+                    para.line_segs.clear();
+                }
+            }
+        }
+
         // [Task #1001] HWP3 변환본의 ParaShape 단위 1/2 추가 보정
         let styles = crate::renderer::style_resolver::resolve_styles_with_variant(
             &document.doc_info,

--- a/src/renderer/font_metrics_data.rs
+++ b/src/renderer/font_metrics_data.rs
@@ -81,9 +81,14 @@ pub struct MetricMatch {
 /// 실무 허용. 정식 DB 엔트리 추가는 별도 이슈.
 fn resolve_metric_alias(name: &str) -> &str {
     match name {
-        "함초롬돋움" | "한컴돋움" => "HCR Dotum",
+        "함초롬돋움" => "HCR Dotum",
+        // [#2279] 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang
+        // (HDOTUM.TTF/HBATANG.TTF name table). HCR(함초롬) 계열과 메트릭이
+        // 다르므로 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em) 별도 연결.
+        "한컴돋움" => "Haansoft Dotum",
         "돋움" => "Dotum",
-        "함초롬바탕" | "한컴바탕" => "HCR Batang",
+        "함초롬바탕" => "HCR Batang",
+        "한컴바탕" => "Haansoft Batang",
         "바탕" => "Batang", // 윈도우 TTF 바탕
         "맑은 고딕" => "Malgun Gothic",
         "나눔고딕" => "NanumGothic",

--- a/src/renderer/layout/text_measurement.rs
+++ b/src/renderer/layout/text_measurement.rs
@@ -1561,10 +1561,15 @@ fn haansoft_latin_override(primary_name: &str, c: char) -> Option<f64> {
 /// 명조(HY견명조 치환) 등 여타 = 반각 (80168 개정안{{7}} p9/p13 '시ㆍ도조례'
 /// 1줄 오라클, 개정안{{1}} P21 마크와 반각 양립 검증). embedded 메트릭
 /// (HY견명조 수록분)이 전각이라 룩업보다 앞서 판정하되, 함초롬(HCR) 계열은
-/// embedded 메트릭을 신뢰한다 (None 반환).
+/// embedded 메트릭을 신뢰한다 (None 반환). [#2279] 한컴바탕/한컴돋움
+/// (Haansoft 실메트릭, ㆍ=1.0em)도 동일하게 embedded 메트릭을 신뢰한다.
 pub(crate) fn area_dot_fallback_width(font_family: &str, font_size: f64) -> Option<f64> {
     let fam = font_family.split(',').next().unwrap_or("").trim();
-    if fam.contains("함초롬") || fam.contains("HCR") {
+    if fam.contains("함초롬")
+        || fam.contains("HCR")
+        || fam.contains("한컴")
+        || fam.contains("Haansoft")
+    {
         return None;
     }
     Some(if fam.contains("한양신명조") {
@@ -2094,6 +2099,58 @@ mod tests {
         assert!(haansoft_latin_override("함초롬바탕 확장", '(').is_none());
         assert!(haansoft_latin_override("HCR Batang Ext", '(').is_none());
         assert!(haansoft_latin_override("바탕", '(').is_none());
+    }
+
+    // ── #2279 한컴돋움/한컴바탕 = Haansoft 실메트릭 ──
+
+    /// 한컴돋움/한컴바탕의 실체는 Haansoft Dotum/Batang (HDOTUM.TTF/HBATANG.TTF
+    /// name table 한국어명). 한글 PDF 실측(36398599 pi35 단일줄 무신축 '*' run:
+    /// 0.583em, 한글 음절 1.0em)과 hmtx 가 일치 — HCR(함초롬) 메트릭('*' 0.498,
+    /// 음절 0.97em)으로 회귀하면 '*' 마스킹 구분선·본문 래핑 줄수가 한글 대비
+    /// ±1 이탈한다 (92 컨트롤셋 36398599/36399105 −1쪽 계열).
+    #[test]
+    fn issue_2279_hancom_dotum_batang_use_haansoft_metrics() {
+        let fs = 20.0; // 15pt
+        let w = |fam: &str, c: char| {
+            measure_char_width_embedded(fam, false, false, c, fs)
+                .unwrap_or_else(|| panic!("측정 실패: {fam} {c:?}"))
+        };
+        // 한컴돋움 = Haansoft Dotum
+        assert!(
+            (w("한컴돋움", '*') - fs * 0.583).abs() < 0.05,
+            "'*' {}",
+            w("한컴돋움", '*')
+        );
+        assert!(
+            (w("한컴돋움", '0') - fs * 0.583).abs() < 0.05,
+            "'0' {}",
+            w("한컴돋움", '0')
+        );
+        assert!(
+            (w("한컴돋움", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴돋움", '가')
+        );
+        // 한컴바탕 = Haansoft Batang (음절 1.0em; ASCII 는 #2156 표와 동일)
+        assert!(
+            (w("한컴바탕", '가') - fs * 1.0).abs() < 0.05,
+            "'가' {}",
+            w("한컴바탕", '가')
+        );
+        assert!(
+            (w("한컴바탕", '*') - fs * 0.5).abs() < 0.05,
+            "'*' {}",
+            w("한컴바탕", '*')
+        );
+        // 함초롬돋움은 종전대로 HCR Dotum 메트릭 유지 (한글 대체 여부 미실측)
+        assert!(
+            (w("함초롬돋움", '가') - fs * 0.97).abs() < 0.05,
+            "HCR '가' {}",
+            w("함초롬돋움", '가')
+        );
+        // ㆍ(U+318D): 한컴 계열은 area_dot 폴백 대신 embedded 메트릭(1.0em) 신뢰
+        assert!(area_dot_fallback_width("한컴돋움", fs).is_none());
+        assert!(area_dot_fallback_width("한컴바탕", fs).is_none());
     }
 
     // ── MockTextMeasurer 테스트 ──

--- a/src/renderer/style_resolver.rs
+++ b/src/renderer/style_resolver.rs
@@ -681,9 +681,14 @@ fn resolve_ttf_font(name: &str) -> Option<&'static str> {
         "Malgun Gothic" => Some("맑은 고딕"),
         "HY그래픽M" => Some("HY그래픽"),
         "SPOQAHANSANS" => Some("SpoqaHanSans"),
-        // 한컴 체인: 한컴바탕→함초롬바탕, 한컴돋움→함초롬돋움
-        "한컴바탕" => Some("함초롬바탕"),
-        "한컴돋움" => Some("함초롬돋움"),
+        // [#2279] 한컴바탕/한컴돋움은 함초롬 계열로 치환하지 않는다.
+        // TTF name table 실측: 한컴바탕 = Haansoft Batang(HBATANG.TTF),
+        // 한컴돋움 = Haansoft Dotum(HDOTUM.TTF) — 함초롬(HCR)과 별개 폰트로
+        // 메트릭이 다르다 ('*' 0.583 vs 0.498em, 한글 음절 1.0 vs 0.97em).
+        // 종전 치환은 한컴돋움 문서의 폭 측정을 HCR Dotum 메트릭으로 보내
+        // 줄수 ±1 오차를 만들었다 (한글 PDF 실측: '*' 0.583em, 음절 1.0em).
+        // 메트릭은 font_metrics_data::resolve_metric_alias 가 Haansoft 엔트리로
+        // 연결하고, SVG 렌더 폴백 체인(svg.rs)은 한컴* 이름을 직접 처리한다.
         // 영어(1) 전용 TTF 치환 (webhwp lang=1)
         "MS Sans Serif" => Some("함초롬돋움"),
         "Tahoma" => Some("함초롬돋움"),

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2105,12 +2105,25 @@ impl FormattedParagraph {
         para: &Paragraph,
         col_count: u16,
         allow_spacing_before_only: bool,
+        ladder_dirty: bool,
     ) -> f64 {
         if col_count > 1 {
             return self.height_for_fit;
         }
+        // [#2279 ①] spacing 트림은 **비합성(authoritative) 저장 lineseg** 문단에만.
+        // 저장 ladder 가 spacing 을 이미 반영하고 vpos-snap 이 좌표를 복원하는
+        // 전제의 트림이므로, 합성(reflow) lineseg 문단은 ladder 가 없어 트림하면
+        // sb·ls 가 흐름에서 그냥 소실된다 (한글 fresh 는 가산 — 기계생성 결재
+        // 문서 −1쪽 계열, DIAG_ADV 실측 문단당 4~33px).
+        // [#2279 ①-2] dirty(합성 혼합) ladder 구간도 동일 — #2243 전방-스냅만
+        // 허용되어 트림분이 복원되지 않으므로 full advance 를 쓴다
+        // (36398700 pi6..9 구간 −60px 폐합, 한글 재저장 anchor 실측).
+        let has_authoritative_seg = para.line_segs.iter().any(|seg| {
+            seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
+        });
         if para.controls.is_empty()
-            && !para.line_segs.is_empty()
+            && has_authoritative_seg
+            && !ladder_dirty
             && (self.spacing_after > 0.5
                 || (allow_spacing_before_only && self.spacing_before > 0.5))
             && self.height_for_fit > 0.0
@@ -2120,6 +2133,35 @@ impl FormattedParagraph {
         }
         self.total_height
     }
+}
+
+/// [#2279 ①-3] spacing 트림의 복원 가능성 전방 판정.
+///
+/// 트림은 다음 authoritative(비합성 lineseg) anchor 에서 vpos-snap 이 좌표를
+/// 복원한다는 전제다. 현 문단과 다음 anchor 사이에 합성/NO_LS 텍스트 문단이
+/// 끼어 있으면 dirty 규칙(#2243 전방-스냅만)으로 복원이 차단되므로 트림하면
+/// 그 spacing 이 흐름에서 소실된다 (36398700 pi6: 다음 anchor pi10 앞에
+/// 합성 pi7~9 → −35.7px 소실 실측). 표 컨트롤 문단은 재앵커(#2243) 지점이라
+/// 복원 가능으로 본다. 탐색은 32문단 한도(초과 시 보수적으로 복원 불가).
+fn spacing_trim_restorable(paragraphs: &[Paragraph], para_idx: usize) -> bool {
+    use crate::model::paragraph::LineSeg;
+    for para in paragraphs.iter().skip(para_idx + 1).take(32) {
+        if !para.controls.is_empty() {
+            return true; // 표/개체 재앵커 지점
+        }
+        match para.line_segs.first() {
+            Some(seg) if seg.tag & LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0 => {
+                return true; // authoritative anchor 도달 — 복원 가능
+            }
+            _ => {
+                if !para.text.is_empty() {
+                    return false; // 합성/NO_LS 텍스트 문단이 먼저 — 복원 불가
+                }
+                // 빈 문단은 계속 탐색
+            }
+        }
+    }
+    false
 }
 
 fn debug_brief_line_text(text: &str, max_chars: usize) -> String {
@@ -10915,7 +10957,12 @@ impl TypesetEngine {
         let spacing_after = para_style.map(|s| s.spacing_after).unwrap_or(0.0);
 
         // [Task #998 실험] spacing_before=0 으로 강제 — 효과 측정용
-        let spacing_before = if para.line_segs.is_empty() && !para.text.is_empty() {
+        // [#2279 실험 전용] RHWP_EXP_BODY_FRESH 시 NO_LS 문단도 sb 를 보존한다
+        // (한글 fresh 는 sb 를 가산 — 생성기 사다리 sb-누락 모사 우회 계측).
+        let spacing_before = if para.line_segs.is_empty()
+            && !para.text.is_empty()
+            && std::env::var("RHWP_EXP_BODY_FRESH").is_err()
+        {
             0.0
         } else {
             raw_spacing_before
@@ -11586,7 +11633,24 @@ impl TypesetEngine {
             //   - 다단 (col_count > 1): height_for_fit (exam_eng 8p 정상 단 채움 복원)
             // 다단에서는 layout 이 vpos 기반으로 항목을 단별로 stacking 하므로
             // typeset 누적 시 trailing_ls 인플레이션이 단을 조기 종료시킴.
-            let advance = fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+            let advance = fmt.flow_advance_height(
+                para,
+                st.col_count,
+                trim_spacing_before_for_flow,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+            );
+            if std::env::var("RHWP_DIAG_ADV").is_ok() {
+                eprintln!(
+                    "DIAG_ADV pi={} adv={:.1} total={:.1} h4f={:.1} sb={:.1} sa={:.1} cur={:.1}",
+                    para_idx,
+                    advance,
+                    fmt.total_height,
+                    fmt.height_for_fit,
+                    fmt.spacing_before,
+                    fmt.spacing_after,
+                    st.current_height,
+                );
+            }
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
             if let Some(v) = body_bottom_vpos {
@@ -11635,8 +11699,12 @@ impl TypesetEngine {
                 st.current_items.push(PageItem::FullParagraph {
                     para_index: para_idx,
                 });
-                let advance =
-                    fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+                let advance = fmt.flow_advance_height(
+                    para,
+                    st.col_count,
+                    trim_spacing_before_for_flow,
+                    st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                );
                 st.current_height += advance;
                 st.flow_underrun += (fmt.total_height - advance).max(0.0);
                 if let Some(v) = body_bottom_vpos {
@@ -11745,7 +11813,12 @@ impl TypesetEngine {
             //   - 다단 (col_count > 1): height_for_fit (exam_eng 8p 정상 단 채움 복원)
             // 다단에서는 layout 이 vpos 기반으로 항목을 단별로 stacking 하므로
             // typeset 누적 시 trailing_ls 인플레이션이 단을 조기 종료시킴.
-            let advance = fmt.flow_advance_height(para, st.col_count, trim_spacing_before_for_flow);
+            let advance = fmt.flow_advance_height(
+                para,
+                st.col_count,
+                trim_spacing_before_for_flow,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+            );
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
             if let Some(v) = body_bottom_vpos {
@@ -13794,7 +13867,12 @@ impl TypesetEngine {
             st.current_items.push(PageItem::FullParagraph {
                 para_index: next_idx,
             });
-            st.current_height += fmt_n.flow_advance_height(next, st.col_count, trim_sb);
+            st.current_height += fmt_n.flow_advance_height(
+                next,
+                st.col_count,
+                trim_sb,
+                st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs_all, next_idx),
+            );
             st.prefilled_paras.insert(next_idx);
         }
     }

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -12905,6 +12905,7 @@ impl TypesetEngine {
                             tac_count,
                             is_first_placed,
                             is_last_placed,
+                            styles,
                         );
                     } else if self.try_typeset_empty_para_float_table(
                         st,
@@ -13261,6 +13262,7 @@ impl TypesetEngine {
         tac_count: usize,
         is_first_placed: bool,
         is_last_placed: bool,
+        styles: &ResolvedStyleSet,
     ) {
         // [Task #1152] 호스트 문단의 intra-paragraph vpos-reset 가드.
         // empty-text host paragraph 가 N controls + N line_segs 1:1 매핑이고,
@@ -13409,7 +13411,41 @@ impl TypesetEngine {
             table_height,
             is_first_placed,
             is_last_placed,
+            styles,
         );
+    }
+
+    /// [#2279 TAC host] 모순 조합(treat_as_char=true + wrap=자리차지) 표의
+    /// host 빈 줄박스 높이 (한글 fresh 가 표 위에 별도 배치하는 성분).
+    ///
+    /// 정상 문서의 TAC 표는 줄박스에 포함되어 별도 가산이 없다 — 본 판정은
+    /// 기계생성 결재문서 특유의 모순 조합 + 빈 host 문단에만 발동한다.
+    /// 반환 = host 첫 글자모양의 폰트 크기(px) — 한글 PDF 괘선 실측
+    /// (36392557 pi27: 진입 22px ≈ om_top 1.9 + 15pt 줄박스 20px)과 정합.
+    fn tac_topbottom_conflict_host_line_px(
+        &self,
+        para: &Paragraph,
+        table: &crate::model::table::Table,
+        styles: &ResolvedStyleSet,
+    ) -> Option<f64> {
+        if !table.common.treat_as_char
+            || !matches!(
+                table.common.text_wrap,
+                crate::model::shape::TextWrap::TopAndBottom
+            )
+            || para_has_non_whitespace_text(para)
+        {
+            return None;
+        }
+        let cs_id = para
+            .char_shape_id_at(0)
+            .or_else(|| para.char_shapes.first().map(|cs| cs.char_shape_id))?
+            as usize;
+        let font_size = styles.char_styles.get(cs_id)?.font_size;
+        if font_size <= 0.0 {
+            return None;
+        }
+        Some(font_size)
     }
 
     /// 표를 pre-text/table/post-text와 함께 배치한다 (Paginator place_table_fits 동일).
@@ -13426,6 +13462,7 @@ impl TypesetEngine {
         table_total_height: f64,
         is_first_placed: bool,
         is_last_placed: bool,
+        styles: &ResolvedStyleSet,
     ) {
         let vertical_offset = Self::get_table_vertical_offset(table);
         let is_visible_para_float =
@@ -13575,6 +13612,20 @@ impl TypesetEngine {
             }
         } else if tac_wrap_split {
             st.current_height += table_total_height;
+        } else if let Some(host_line_px) = if st.is_hwpx_source {
+            self.tac_topbottom_conflict_host_line_px(para, table, styles)
+        } else {
+            None
+        } {
+            // [#2279 TAC host] 기계생성 결재문서의 모순 조합(treat_as_char=true +
+            // wrap=자리차지) 장제목/결재표: 한글 fresh 는 host 빈 줄박스(호스트
+            // CS 크기)를 표 **위에** 별도 배치한다 — 36392557 pi27 한글 PDF
+            // 괘선 실측: 표 top = 흐름 + om_top(1.9px) + host 줄박스(20px=15pt).
+            // rhwp 는 lh-포함형(host lh = 표+om)으로만 소비해 표당 ~20px 과소
+            // (92셋 −1쪽 계열의 "TAC host +15~21px" 성분). 가산 후에는 생성기
+            // 압축 anchor 로의 후방 스냅이 성장분을 되돌리지 못하게 dirty 처리.
+            st.current_height += host_line_px + pre_height + table_total_height;
+            st.vpos_ladder_dirty = true;
         } else {
             // [#2097 프로브 기록] 빈 host 자리차지 float(v_off>0)의 흐름 전진에
             // v_off + outer_bottom 을 더하는 기하 정합(82802 pi75: 저장 322.6 =
@@ -14778,6 +14829,7 @@ impl TypesetEngine {
                         0.0,
                         is_first_placed,
                         is_last_placed,
+                        styles,
                     );
                     return;
                 }
@@ -14932,6 +14984,7 @@ impl TypesetEngine {
                     block_height,
                     is_first_placed,
                     is_last_placed,
+                    styles,
                 );
                 // 배타 모델: 블록은 flow 를 소비하지 않는다(하단 절대배치) — 소비 롤백
                 // 후 하단 배타 영역으로 예약. 저장-flow 소비 누계는 후속 틀 vpos 보정용.
@@ -15189,6 +15242,7 @@ impl TypesetEngine {
                 },
                 is_first_placed,
                 is_last_placed,
+                styles,
             );
             return;
         }
@@ -15217,6 +15271,7 @@ impl TypesetEngine {
                 table_total,
                 is_first_placed,
                 is_last_placed,
+                styles,
             );
             return;
         }
@@ -15273,6 +15328,7 @@ impl TypesetEngine {
                 table_total,
                 is_first_placed,
                 is_last_placed,
+                styles,
             );
             return;
         }
@@ -15307,6 +15363,7 @@ impl TypesetEngine {
                 table_total,
                 is_first_placed,
                 is_last_placed,
+                styles,
             );
             return;
         }

--- a/tests/issue_2006_1790387_prep_pagination_pin.rs
+++ b/tests/issue_2006_1790387_prep_pagination_pin.rs
@@ -26,9 +26,10 @@ fn page_count_of(rel: &str) -> u32 {
 fn prep_1790387_page_count_pin() {
     let pages = page_count_of("samples/issue2006/1790387_prep_final_report.hwpx");
     assert_eq!(
-        pages, 141,
-        "issue2006 1790387 핀 141쪽 (한글 2022 정답지 146쪽, 잔여 -5=줄-채움 누적 축). \
-         실측 {}p — 130p 부근이면 tac 이미지 스택 미분할(#2006) 회귀, 141p 초과 개선 시 \
+        pages, 144,
+        "issue2006 1790387 핀 144쪽 (한글 2022 정답지 146쪽, 잔여 -2). \
+         141→144 는 #2279 TAC-자리차지 host 줄박스 가산 landing. 실측 {}p — \
+         130p 부근이면 tac 이미지 스택 미분할(#2006) 회귀, 144p 초과 개선 시 \
          핀과 정답지(146)를 갱신할 것.",
         pages
     );

--- a/tools/task2279/hancom_metric_visual_check.py
+++ b/tools/task2279/hancom_metric_visual_check.py
@@ -1,0 +1,77 @@
+# -*- coding: utf-8 -*-
+"""#2279 한컴돋움/한컴바탕 메트릭 정합 — base vs head 픽셀 대조 (한글 PDF 기준).
+
+지표: tools/task2279/visual_evidence.py 와 동일 (96dpi gray, 임계 이진화 일치율 + IoU).
+"""
+import subprocess
+import sys
+from pathlib import Path
+
+import fitz
+import numpy as np
+
+sys.stdout.reconfigure(encoding="utf-8")
+
+FONTS = Path(r"C:\Users\planet\rhwp\ttfs")
+
+
+def render(exe: str, doc: Path, out_pdf: Path):
+    if out_pdf.exists():
+        out_pdf.unlink()
+    r = subprocess.run(
+        [exe, "export-pdf", str(doc), "-o", str(out_pdf), "--font-path", str(FONTS)],
+        capture_output=True, text=True, encoding="utf-8", errors="replace", timeout=900,
+    )
+    if not out_pdf.exists():
+        raise RuntimeError(f"export-pdf 실패: {r.stderr[:300]}")
+
+
+def page_gray(doc, i):
+    pix = doc[i].get_pixmap(dpi=96, colorspace=fitz.csGRAY)
+    return np.frombuffer(pix.samples, dtype=np.uint8).reshape(pix.height, pix.width)
+
+
+def compare(ref, img):
+    h = min(ref.shape[0], img.shape[0])
+    w = min(ref.shape[1], img.shape[1])
+    a, b = ref[:h, :w].astype(int), img[:h, :w].astype(int)
+    pixel_match = 100.0 * float(((a > 200) == (b > 200)).mean())
+    ink_a = (a <= 200)
+    ink_b = (b <= 200)
+    union = (ink_a | ink_b).sum()
+    iou = 100.0 * float((ink_a & ink_b).sum() / union) if union else 100.0
+    return pixel_match, iou
+
+
+def main():
+    base_exe, head_exe, out_dir = sys.argv[1], sys.argv[2], Path(sys.argv[3])
+    out_dir.mkdir(parents=True, exist_ok=True)
+    hwpdocs = Path(r"C:\Users\planet\hwpdocs\samples")
+    poc = Path(r"C:\Users\planet\rhwp\output\poc\task2246")
+    pairs = [
+        (hwpdocs / "문화본부 문화예술과" / "36398599_결재문서본문_「동대문구 찾아가는 전통시장」 ’25년 민간축제 정산 결과 보고.hwpx",
+         poc / "36398599_h.pdf"),
+        (hwpdocs / "문화본부 문화유산활용과" / "36398700_결재문서본문_공유재산 사용허가(임시무상 사용) 검토보고 2.hwpx",
+         poc / "36398700_h.pdf"),
+    ]
+    for doc, ref_pdf in pairs:
+        stem = doc.name.split("_")[0]
+        ref = fitz.open(ref_pdf)
+        print(f"== {stem} (한글 {ref.page_count}쪽)")
+        for tag, exe in (("base", base_exe), ("head", head_exe)):
+            out_pdf = out_dir / f"{stem}_{tag}.pdf"
+            render(exe, doc, out_pdf)
+            got = fitz.open(out_pdf)
+            n = min(ref.page_count, got.page_count)
+            scores = []
+            for i in range(n):
+                pm, iou = compare(page_gray(ref, i), page_gray(got, i))
+                scores.append((pm, iou))
+            avg_pm = sum(s[0] for s in scores) / n
+            avg_iou = sum(s[1] for s in scores) / n
+            per = " ".join(f"p{i}:{s[0]:.1f}/{s[1]:.1f}" for i, s in enumerate(scores))
+            print(f"  {tag}: pages={got.page_count} avg_match={avg_pm:.2f} avg_iou={avg_iou:.2f}  [{per}]")
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## 요약 (#2279 — TAC-자리차지 모순 표의 host 줄박스 가산)

> **PR #2351 위에 스택** (base = #2340 + #2351 커밋). 선행 PR merge 후 본 PR 은 커밋 하나만 남습니다.

기계생성 결재문서(HWPX)의 모순 조합 **treat_as_char=true + wrap=자리차지** 장제목/결재표에서, 한글 fresh 는 host 빈 줄박스(호스트 글자모양 크기)를 표 위에 별도 배치한다. rhwp 는 lh-포함형(host lh = 표+outer margin)으로만 소비해 표당 ~15~21px 과소했다 — 92셋 −1쪽 계열의 "TAC host" 성분.

### 근거 (한글 warm PDF 괘선 실측, 36392557 pi27)

- 한글 표 top 괘선 y = 흐름 + om_top(1.9px) + **host 줄박스 20px(=15pt)** — 텍스트 bbox 가 아닌 벡터 괘선 좌표로 확정.
- rhwp(종전): 표 진입 시 host 줄박스 없음 → 표 top −22px, 문서 끝 −1쪽.
- 가산 후 vpos_ladder_dirty 전방-전용 전환 — 생성기 압축 anchor 로의 후방 스냅이 성장분을 재흡수(pi28 −5.6px 실측)하는 것을 차단.

### 스코프 가드

- **HWPX 한정** (`is_hwpx_source`): HWP5 한글-저장 문서(국립국어원·kps_ai·sijang 등)는 같은 조합에서도 한글이 별도 줄박스를 두지 않음 — nextest 6건 실측 반증으로 확정.
- 빈 host(공백뿐) + host CS font_size 기반. 정상 TAC(줄박스 포함형) 경로 불변.

### 게이트 (격리 worktree)

| 게이트 | 결과 |
|---|---|
| 92 컨트롤셋 | 일치 **88→89** (−1축 4→3: 36392557 6쪽=한글, 회귀 0) |
| knife-edge 4 | 86712=65 · 80168=157 · 76076=82 · 80250=17 |
| byeolpyo | 4 · 26 |
| footer 오라클 | 4/4 |
| svg_snapshot | 8/8 (골든 불변) |
| prep_1790387 핀 | 141→**144** (한글 2022 정답 146 방향 +3 — 핀 주석의 갱신 지침 이행) |
| nextest 전체 | **3264/3264** 통과 (23 skipped) |
| 358 recount | **FIXED 39 / REGRESSED 0** / SAME_OK 251 / CHANGED 10 (선행 PR 기준선과 동일 — recount 중립) |
| fmt / clippy | 클린 (fmt --check 신규 diff 없음 · clippy --all-targets -D warnings 통과) |
| 시각 (한글 warm PDF 픽셀) | 36392557: 5→**6쪽(=한글)**, 평균 93.14→**93.71** |

### 남긴 것 (후속 — 이슈 #2279 기록)

- 잔여 −1×3 (36398700/36398709/36399374): 표 문단의 **TAC 높이 보정 cap** 이 host 가산을 재흡수하는 메커니즘 확인. cap 에 host 성분을 포함하는 실험은 36398700 4쪽·36398709 6쪽 **정답 도달**을 보이나 36392557/36399374 를 +1~2쪽 과다로 뒤집음 — host 줄박스의 표별 유무 판별 신호(저장 ls>0·lh-covers 후보는 부분 반증)가 미확정. 표별 한글 괘선 오라클 스윕 후 landing.

Closes: 없음 (#2279 umbrella 진행분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
