### PR TITLE
Task #2361: [레이아웃] 편집 용지·구역·다단·쪽 테두리 다이얼로그를 히스토리에 기록 — undo 불가 수정

### DIFF
--- a/rhwp-studio/src/command/commands/file.ts
+++ b/rhwp-studio/src/command/commands/file.ts
@@ -457,7 +457,7 @@ export const fileCommands: CommandDef[] = [
     shortcutLabel: 'F7',
     canExecute: (ctx) => ctx.hasDocument,
     execute(services) {
-      const dialog = new PageSetupDialog(services.wasm, services.eventBus, 0);
+      const dialog = new PageSetupDialog(services.wasm, services.eventBus, 0, services);
       dialog.show();
     },
   },

--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -177,7 +177,7 @@ export const pageCommands: CommandDef[] = [
       const ih = services.getInputHandler();
       const cursor = ih ? (ih as any).cursor : null;
       const sectionIdx = cursor?.getPosition()?.sectionIndex ?? 0;
-      const dialog = new PageSetupDialog(services.wasm, services.eventBus, sectionIdx);
+      const dialog = new PageSetupDialog(services.wasm, services.eventBus, sectionIdx, services);
       dialog.show();
     },
   },
@@ -189,7 +189,7 @@ export const pageCommands: CommandDef[] = [
       const ih = services.getInputHandler();
       const cursor = ih ? (ih as any).cursor : null;
       const sectionIdx = cursor?.getPosition()?.sectionIndex ?? 0;
-      const dialog = new PageBorderDialog(services.wasm, services.eventBus, sectionIdx);
+      const dialog = new PageBorderDialog(services.wasm, services.eventBus, sectionIdx, services);
       dialog.show();
     },
   },
@@ -550,7 +550,7 @@ export const pageCommands: CommandDef[] = [
       const ih = services.getInputHandler();
       if (!ih) return;
       const pos = ih.getPosition();
-      const dlg = new ColumnSettingsDialog(services.wasm, services.eventBus, pos.sectionIndex);
+      const dlg = new ColumnSettingsDialog(services.wasm, services.eventBus, pos.sectionIndex, services);
       dlg.show();
     },
   },
@@ -564,7 +564,7 @@ export const pageCommands: CommandDef[] = [
       if (!ih) return;
       const cursor = (ih as any).cursor;
       const sectionIdx = cursor?.getPosition()?.sectionIndex ?? 0;
-      const dialog = new SectionSettingsDialog(services.wasm, services.eventBus, sectionIdx);
+      const dialog = new SectionSettingsDialog(services.wasm, services.eventBus, sectionIdx, services);
       dialog.show();
     },
   },

--- a/rhwp-studio/src/command/dispatcher.ts
+++ b/rhwp-studio/src/command/dispatcher.ts
@@ -8,6 +8,10 @@ const FORM_MODE_BLOCKED_IDS = new Set([
   'edit:delete',
   'field:edit',
   'field:remove',
+  // [#2361 리뷰] 편집 용지의 파일 메뉴/F7 변형. page:setup 은 'page:' prefix 로 차단되는데
+  // 이 변형만 열려 있었다 — 양식 모드에선 snapshot 이 드롭되므로(입력-핸들러 게이트) 다이얼로그가
+  // 열리면 확인이 무언 폐기된다. 두 진입점을 동일하게 차단해 정합.
+  'file:page-setup',
 ]);
 
 const FORM_MODE_BLOCKED_PREFIXES = [

--- a/rhwp-studio/src/ui/column-settings-dialog.ts
+++ b/rhwp-studio/src/ui/column-settings-dialog.ts
@@ -1,6 +1,7 @@
 import { ModalDialog } from './dialog';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 const HWPUNIT_PER_MM = 7200 / 25.4;
 
@@ -24,7 +25,7 @@ export class ColumnSettingsDialog extends ModalDialog {
   private sameWidthCheck!: HTMLInputElement;
   private spacingInput!: HTMLInputElement;
 
-  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number) {
+  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number, private services?: CommandServices) {
     super('다단 설정', 360);
     this.wasm = wasm;
     this.eventBus = eventBus;
@@ -109,9 +110,20 @@ export class ColumnSettingsDialog extends ModalDialog {
     const type = Math.max(0, Math.min(2, parseInt(this.typeSelect.value, 10) || 0));
     const sameWidth = this.sameWidthCheck.checked ? 1 : 0;
     const spacingHu = Math.max(0, Math.min(32767, mmToHwpunit(parseFloat(this.spacingInput.value) || 0)));
+    // [다단 설정 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    const apply = () => this.wasm.setColumnDef(this.sectionIdx, count, type, sameWidth, spacingHu);
     try {
-      this.wasm.setColumnDef(this.sectionIdx, count, type, sameWidth, spacingHu);
-      this.eventBus.emit('document-changed');
+      const ih = this.services?.getInputHandler();
+      if (ih) {
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'columnSettings',
+          operation: () => { apply(); return ih.getCursorPosition(); },
+        });
+      } else {
+        apply();
+        this.eventBus.emit('document-changed');
+      }
     } catch (err) {
       console.warn('[ColumnSettingsDialog] 다단 설정 실패:', err);
     }

--- a/rhwp-studio/src/ui/page-border-dialog.ts
+++ b/rhwp-studio/src/ui/page-border-dialog.ts
@@ -1,5 +1,6 @@
 import { ModalDialog } from './dialog';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 import type { PageBorderFillSettings, BorderLineProps } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
 
@@ -59,6 +60,7 @@ export class PageBorderDialog extends ModalDialog {
     private wasm: WasmBridge,
     private eventBus: EventBus,
     private sectionIdx: number,
+    private services?: CommandServices,
   ) {
     super('쪽 테두리/배경', 560);
   }
@@ -133,8 +135,19 @@ export class PageBorderDialog extends ModalDialog {
       applyPage: applyPage === 'exceptFirst' ? 'exceptFirst' : 'all',
     };
 
-    this.wasm.setPageBorderFill(this.sectionIdx, next);
-    this.eventBus.emit('document-changed');
+    // [쪽 테두리/배경 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    const apply = () => this.wasm.setPageBorderFill(this.sectionIdx, next);
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'pageBorder',
+        operation: () => { apply(); return ih.getCursorPosition(); },
+      });
+    } else {
+      apply();
+      this.eventBus.emit('document-changed');
+    }
   }
 
   private buildBorderTab(): HTMLElement {

--- a/rhwp-studio/src/ui/page-setup-dialog.ts
+++ b/rhwp-studio/src/ui/page-setup-dialog.ts
@@ -3,6 +3,7 @@ import { appendSvgMarkup } from './dom-utils';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { PageDef } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 const HWPUNIT_PER_MM = 7200 / 25.4; // ≈283.46
 const PAPER_PRESET_TOLERANCE_HU = 3;
@@ -68,7 +69,7 @@ export class PageSetupDialog extends ModalDialog {
   private marginInputs!: Record<string, HTMLInputElement>;
   private scopeSelect!: HTMLSelectElement;
 
-  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number) {
+  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number, private services?: CommandServices) {
     super('편집 용지', 440);
     this.wasm = wasm;
     this.eventBus = eventBus;
@@ -226,8 +227,17 @@ export class PageSetupDialog extends ModalDialog {
       binding: parseInt(this.bindingRadios.find(r => r.checked)?.value ?? '0'),
     };
 
-    const result = this.wasm.setPageDef(this.sectionIdx, newDef);
-    if (result.ok) {
+    // [편집 용지 이관] 쪽 정의 변경을 snapshot 으로 라우팅해 undo 가능(#2077 수식 속성 동형).
+    // services 미주입 환경(구 호출부)에서만 직접 적용 fallback.
+    const apply = () => this.wasm.setPageDef(this.sectionIdx, newDef);
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'pageSetup',
+        operation: () => { apply(); return ih.getCursorPosition(); },
+      });
+    } else if (apply().ok) {
       this.eventBus.emit('document-changed');
     }
   }

--- a/rhwp-studio/src/ui/section-settings-dialog.ts
+++ b/rhwp-studio/src/ui/section-settings-dialog.ts
@@ -2,6 +2,7 @@ import { ModalDialog } from './dialog';
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { SectionDef } from '@/core/types';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 const HWPUNIT_PER_PT = 100; // 1pt = 100 HWPUNIT (HWP 내부 단위)
 
@@ -41,7 +42,7 @@ export class SectionSettingsDialog extends ModalDialog {
   private defaultTabSpacingInput!: HTMLInputElement;
   private applyScopeSelect!: HTMLSelectElement;
 
-  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number) {
+  constructor(wasm: WasmBridge, eventBus: EventBus, sectionIdx: number, private services?: CommandServices) {
     super('구역 설정', 400);
     this.wasm = wasm;
     this.eventBus = eventBus;
@@ -153,14 +154,19 @@ export class SectionSettingsDialog extends ModalDialog {
     };
 
     const scope = this.applyScopeSelect.value;
-    let result: { ok: boolean };
-    if (scope === 'all') {
-      result = this.wasm.setSectionDefAll(newDef);
-    } else {
-      // 'current' 또는 'selection' (선택 문자열은 현재 구역과 동일하게 처리)
-      result = this.wasm.setSectionDef(this.sectionIdx, newDef);
-    }
-    if (result.ok) {
+    // 'current'/'selection' 은 현재 구역과 동일 처리. all=전 구역(전문서 효과).
+    const apply = () => scope === 'all'
+      ? this.wasm.setSectionDefAll(newDef)
+      : this.wasm.setSectionDef(this.sectionIdx, newDef);
+    // [구역 설정 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'sectionSettings',
+        operation: () => { apply(); return ih.getCursorPosition(); },
+      });
+    } else if (apply().ok) {
       this.eventBus.emit('document-changed');
     }
   }

--- a/rhwp-studio/tests/undo-layout-dialogs.test.ts
+++ b/rhwp-studio/tests/undo-layout-dialogs.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #layout-dialogs] 쪽/구역 레이아웃 다이얼로그 히스토리 라우팅 소스 가드.
+//
+// page-setup/section/column/page-border 다이얼로그는 (wasm,eventBus) 로만 생성돼 InputHandler
+// (편집 라우터)에 도달 못 했다 → 편집 용지/구역/다단/쪽테두리 변경이 미기록(undo 불가).
+// services 를 생성자에 주입하고 onConfirm 을 executeOperation snapshot 으로 라우팅했는지,
+// services 미주입 fallback(직접 적용)을 유지했는지 정적으로 핀한다. 행위 증명은 브라우저 왕복.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, `src/ui/${rel}`), 'utf8');
+
+const DIALOGS: Array<{ file: string; op: string }> = [
+  { file: 'page-setup-dialog.ts', op: 'pageSetup' },
+  { file: 'section-settings-dialog.ts', op: 'sectionSettings' },
+  { file: 'column-settings-dialog.ts', op: 'columnSettings' },
+  { file: 'page-border-dialog.ts', op: 'pageBorder' },
+];
+
+for (const { file, op } of DIALOGS) {
+  test(`${file} 는 services 주입 + snapshot 라우팅 + fallback 을 갖춘다`, () => {
+    const s = src(file);
+    // services 를 생성자에 주입(라우터 도달 경로 확보).
+    assert.match(s, /services\?:\s*CommandServices/, `${file}: 생성자에 services 주입`);
+    assert.match(s, /import type \{ CommandServices \}/, `${file}: CommandServices import`);
+    // onConfirm 이 라우터 경유로 snapshot 기록.
+    assert.match(s, /this\.services\?\.getInputHandler\(\)/, `${file}: getInputHandler 로 라우터 도달`);
+    assert.match(s, new RegExp(`operationType:\\s*'${op}'`), `${file}: ${op} snapshot 라우팅`);
+    // services 미주입 환경 호환 fallback(직접 적용 + emit) 유지.
+    assert.match(s, /this\.eventBus\.emit\('document-changed'\)/, `${file}: fallback emit 유지`);
+  });
+}

--- a/rhwp-studio/tests/undo-layout-dialogs.test.ts
+++ b/rhwp-studio/tests/undo-layout-dialogs.test.ts
@@ -21,6 +21,18 @@ const DIALOGS: Array<{ file: string; op: string }> = [
   { file: 'page-border-dialog.ts', op: 'pageBorder' },
 ];
 
+test('양식 모드에서 file:page-setup 은 차단된다(#2361 리뷰 — snapshot 드롭 무언 폐기 방지)', () => {
+  // page:setup 은 'page:' prefix 로 차단되지만 파일 메뉴/F7 변형(file:page-setup)은 목록에
+  // 없어 양식 모드에서 다이얼로그가 열렸고, 라우팅된 snapshot 이 입력-핸들러 게이트에서
+  // 드롭돼 확인이 무언 폐기됐다. 두 진입점의 차단 정합을 핀한다.
+  const dispatcher = readFileSync(join(rootDir, 'src/command/dispatcher.ts'), 'utf8');
+  const blockedIds = dispatcher.slice(
+    dispatcher.indexOf('FORM_MODE_BLOCKED_IDS'),
+    dispatcher.indexOf('FORM_MODE_BLOCKED_PREFIXES'),
+  );
+  assert.match(blockedIds, /'file:page-setup'/, 'file:page-setup 이 FORM_MODE_BLOCKED_IDS 에 있어야 함');
+});
+
 for (const { file, op } of DIALOGS) {
   test(`${file} 는 services 주입 + snapshot 라우팅 + fallback 을 갖춘다`, () => {
     const s = src(file);


### PR DESCRIPTION
## 요약

**편집 용지·구역 설정·다단 설정·쪽 테두리/배경** 다이얼로그가 편집 라우터에 도달하지 못해 undo 되지 않던 계급 1 미라우팅을 수정합니다(Track 1 다이얼로그 services 주입, 레이아웃 클러스터).

Fixes #2361

## 변경

- 네 다이얼로그 생성자에 `services?: CommandServices` 주입 → `onConfirm` 뮤테이션을 `ih.executeOperation({kind:'snapshot', operationType})` 로 라우팅. 이미 라우팅된 #2077(수식 속성)·책갈피 다이얼로그와 동형.
- 라우팅 경로는 수동 `document-changed` emit 제거. **`services` 미주입(구 호출부) 환경은 직접 적용+emit fallback 유지** — 최소·비파괴 변경.
- 호출부 5곳(page.ts×4, file.ts×1)이 `services` 전달.
- 소스 가드 테스트 `undo-layout-dialogs`(4) 추가.

## 검증

- `npx tsc --noEmit`, `npm test` 350/350.
- 브라우저 왕복(실제 다이얼로그 구동): 다단 설정 열기 → count=2 → 확인 → `undoLen` 0→1(기록) → undo 0. **services 주입이 런타임에 라우터에 도달함을 end-to-end 확인**. 콘솔 에러 0.

## 범위 외 (동일 패턴, 별도 PR)

- 번호/기타 다이얼로그(numbering/new-number/endnote-shape) · formula 다이얼로그(2-op 원자화) · 스타일 다이얼로그(전문서 reflow undo 한컴 판정 얽힘).


---

(a′) 이관 로드맵 #2369 의 **Track 1**(다이얼로그 services 주입)에 속합니다.
