### PR TITLE
Task #2363: [번호] 새 번호로 시작·미주 모양 다이얼로그를 히스토리에 기록 — undo 불가 수정

### DIFF
--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -277,7 +277,7 @@ export const insertCommands: CommandDef[] = [
     execute(services) {
       const pos = services.getInputHandler()?.getPosition();
       const sectionIdx = pos?.sectionIndex ?? 0;
-      endnoteShapeDialog = new EndnoteShapeDialog(services.wasm, services.eventBus, sectionIdx);
+      endnoteShapeDialog = new EndnoteShapeDialog(services.wasm, services.eventBus, sectionIdx, services);
       endnoteShapeDialog.show();
     },
   },

--- a/rhwp-studio/src/command/commands/page.ts
+++ b/rhwp-studio/src/command/commands/page.ts
@@ -297,7 +297,7 @@ export const pageCommands: CommandDef[] = [
       if (!wasm || !eventBus) return;
       const dlg = new NewNumberDialog(wasm, eventBus, {
         sec: pos.sectionIndex, para: pos.paragraphIndex, offset: pos.charOffset,
-      });
+      }, services);
       dlg.show();
     },
   },

--- a/rhwp-studio/src/ui/endnote-shape-dialog.ts
+++ b/rhwp-studio/src/ui/endnote-shape-dialog.ts
@@ -3,6 +3,7 @@ import type { EventBus } from '@/core/event-bus';
 import type { EndnoteShapeSettings } from '@/core/types';
 import { HWPUNIT_PER_MM } from '@/core/hwp-constants';
 import type { WasmBridge } from '@/core/wasm-bridge';
+import type { CommandServices } from '@/command/types';
 
 type LineTypeChoice = {
   value: string;
@@ -141,6 +142,7 @@ export class EndnoteShapeDialog extends ModalDialog {
     private wasm: WasmBridge,
     private eventBus: EventBus,
     private sectionIdx: number,
+    private services?: CommandServices,
   ) {
     super('미주', 620);
   }
@@ -199,8 +201,19 @@ export class EndnoteShapeDialog extends ModalDialog {
       placement: this.placementSection.checked ? 'sectionEnd' : 'documentEnd',
     };
 
-    this.wasm.applyEndnoteShape(this.sectionIdx, next);
-    this.eventBus.emit('document-changed');
+    // [미주 모양 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    const apply = () => this.wasm.applyEndnoteShape(this.sectionIdx, next);
+    const ih = this.services?.getInputHandler();
+    if (ih) {
+      ih.executeOperation({
+        kind: 'snapshot',
+        operationType: 'endnoteShape',
+        operation: () => { apply(); return ih.getCursorPosition(); },
+      });
+    } else {
+      apply();
+      this.eventBus.emit('document-changed');
+    }
   }
 
   private populate(): void {

--- a/rhwp-studio/src/ui/new-number-dialog.ts
+++ b/rhwp-studio/src/ui/new-number-dialog.ts
@@ -1,5 +1,6 @@
 import { ModalDialog } from './dialog';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 export class NewNumberDialog extends ModalDialog {
   private wasm: any;
@@ -7,7 +8,7 @@ export class NewNumberDialog extends ModalDialog {
   private cursorPos: { sec: number; para: number; offset: number };
   private numInput!: HTMLInputElement;
 
-  constructor(wasm: any, eventBus: EventBus, pos: { sec: number; para: number; offset: number }) {
+  constructor(wasm: any, eventBus: EventBus, pos: { sec: number; para: number; offset: number }, private services?: CommandServices) {
     super('새 번호로 시작', 300);
     this.wasm = wasm;
     this.eventBus = eventBus;
@@ -53,11 +54,22 @@ export class NewNumberDialog extends ModalDialog {
   protected onConfirm(): void | boolean {
     const num = parseInt(this.numInput.value, 10);
     if (isNaN(num) || num < 1 || num > 65535) return false;
+    // [새 번호 이관] snapshot 으로 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+    const apply = () => this.wasm.insertNewNumber(
+      this.cursorPos.sec, this.cursorPos.para, this.cursorPos.offset, num,
+    );
     try {
-      this.wasm.insertNewNumber(
-        this.cursorPos.sec, this.cursorPos.para, this.cursorPos.offset, num,
-      );
-      this.eventBus.emit('document-changed');
+      const ih = this.services?.getInputHandler();
+      if (ih) {
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'insertNewNumber',
+          operation: () => { apply(); return ih.getCursorPosition(); },
+        });
+      } else {
+        apply();
+        this.eventBus.emit('document-changed');
+      }
     } catch (e) {
       console.warn('[NewNumberDialog] 삽입 실패:', e);
     }

--- a/rhwp-studio/tests/undo-number-dialogs.test.ts
+++ b/rhwp-studio/tests/undo-number-dialogs.test.ts
@@ -1,0 +1,33 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #number-dialogs] 새 번호·미주 모양 다이얼로그 히스토리 라우팅 소스 가드.
+//
+// new-number/endnote-shape 다이얼로그는 (wasm,eventBus) 로만 생성돼 편집 라우터에 도달 못 했다
+// → 새 번호 삽입/미주 모양 변경이 미기록(undo 불가). services 주입 + executeOperation snapshot
+// 라우팅 + services 미주입 fallback 을 정적으로 핀한다. 행위 증명은 브라우저 왕복.
+//
+// (numbering-dialog 은 별건 — 문단 적용 ih.applyNumbering 이 이미 라우팅됨; DEF 생성 orphan 은
+//  보이지 않는 잔여라 이 PR 범위 밖.)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, `src/ui/${rel}`), 'utf8');
+
+const DIALOGS: Array<{ file: string; op: string }> = [
+  { file: 'new-number-dialog.ts', op: 'insertNewNumber' },
+  { file: 'endnote-shape-dialog.ts', op: 'endnoteShape' },
+];
+
+for (const { file, op } of DIALOGS) {
+  test(`${file} 는 services 주입 + snapshot 라우팅 + fallback 을 갖춘다`, () => {
+    const s = src(file);
+    assert.match(s, /services\?:\s*CommandServices/, `${file}: 생성자에 services 주입`);
+    assert.match(s, /import type \{ CommandServices \}/, `${file}: CommandServices import`);
+    assert.match(s, /this\.services\?\.getInputHandler\(\)/, `${file}: getInputHandler 로 라우터 도달`);
+    assert.match(s, new RegExp(`operationType:\\s*'${op}'`), `${file}: ${op} snapshot 라우팅`);
+    assert.match(s, /this\.eventBus\.emit\('document-changed'\)/, `${file}: fallback emit 유지`);
+  });
+}


### PR DESCRIPTION
## 요약

**새 번호로 시작·미주 모양** 다이얼로그가 편집 라우터에 도달하지 못해 undo 되지 않던 계급 1 미라우팅을 수정합니다(Track 1 다이얼로그 services 주입, 번호/기타 클러스터).

Fixes #2363

## 변경

- 두 다이얼로그 생성자에 `services?: CommandServices` 주입 → `onConfirm` 뮤테이션(`insertNewNumber`/`applyEndnoteShape`)을 `ih.executeOperation({kind:'snapshot', operationType})` 로 라우팅([#2362 레이아웃 다이얼로그](https://github.com/edwardkim/rhwp/pull/2362)·#2077 동형). `services` 미주입 fallback 유지.
- 호출부 2곳(page.ts, insert.ts)이 `services` 전달.
- 소스 가드 테스트 `undo-number-dialogs`(2) 추가.

## 검증

- `npx tsc --noEmit`, `npm test` 348/348.
- 브라우저 왕복(실제 다이얼로그): 새 번호로 시작 열기 → 값 입력 → 확인 → `undoLen` 0→1(기록) → undo 0. 콘솔 에러 0.

## 범위 외

- **numbering(문단 번호) 다이얼로그**: 문단 적용(`ih.applyNumbering`)이 이미 라우팅됨 — 사용자 가시 효과는 이미 undo 가능(DEF 생성 orphan 만 잔여, 보이지 않음).
- formula 다이얼로그(2-op 원자화) · 스타일 다이얼로그(전문서 reflow 한컴 판정) — 별도.


---

(a′) 이관 로드맵 #2369 의 **Track 1**(다이얼로그 services 주입)에 속합니다.
