### PR TITLE
Task #2366: [표] 계산식 다이얼로그를 히스토리에 기록 — 2-뮤테이션 원자화로 undo 불가·오프셋 오염 수정

### DIFF
--- a/rhwp-studio/src/command/commands/table.ts
+++ b/rhwp-studio/src/command/commands/table.ts
@@ -111,7 +111,7 @@ function openFormulaDialog(services: Parameters<CommandDef['execute']>[0]): void
     ppi: pos.parentParaIndex,
     ci: pos.controlIndex,
     cellIndex: pos.cellIndex,
-  });
+  }, services);
   dialog.show();
 }
 

--- a/rhwp-studio/src/ui/formula-dialog.ts
+++ b/rhwp-studio/src/ui/formula-dialog.ts
@@ -11,6 +11,7 @@
 import { ModalDialog } from './dialog';
 import { makeOption } from './dom-utils';
 import type { EventBus } from '@/core/event-bus';
+import type { CommandServices } from '@/command/types';
 
 interface FormulaContext {
   sec: number;
@@ -69,7 +70,7 @@ export class FormulaDialog extends ModalDialog {
   private commaCheck!: HTMLInputElement;
   private errorMsg!: HTMLDivElement;
 
-  constructor(wasm: any, eventBus: EventBus, ctx: FormulaContext) {
+  constructor(wasm: any, eventBus: EventBus, ctx: FormulaContext, private services?: CommandServices) {
     super('계산식', 420);
     this.wasm = wasm;
     this.eventBus = eventBus;
@@ -205,32 +206,49 @@ export class FormulaDialog extends ModalDialog {
         return false;
       }
 
-      // 검증 통과 → 실제 적용 (write_result=true)
-      this.wasm.evaluateTableFormula(
-        this.ctx.sec, this.ctx.ppi, this.ctx.ci,
-        row, col, formula, true,
-      );
-
-      // 형식 + 쉼표 처리
+      // 형식 + 쉼표 문자열은 dry-run 결과만으로 산출 가능 → 뮤테이션 전에 계산.
       let displayValue = validated.result;
       const fmt = this.formatSelect.value;
       if (fmt === 'integer') displayValue = Math.round(displayValue);
       else if (fmt === 'decimal1') displayValue = Number(displayValue.toFixed(1));
       else if (fmt === 'decimal2') displayValue = Number(displayValue.toFixed(2));
 
+      let formatted: string | null = null;
       if (this.commaCheck.checked && typeof displayValue === 'number') {
         const parts = displayValue.toString().split('.');
         parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
-        const formatted = parts.join('.');
-        try {
-          this.wasm.insertTextInCell(
-            this.ctx.sec, this.ctx.ppi, this.ctx.ci,
-            this.ctx.cellIndex, 0, 0, formatted,
-          );
-        } catch { /* 쉼표 포맷 기록 실패 시 기본값 유지 */ }
+        formatted = parts.join('.');
       }
 
-      this.eventBus.emit('document-changed');
+      // 검증 통과 → 실제 적용 (write_result=true) + 쉼표 기록.
+      // [계산식 이관] 두 뮤테이션(commit + insertTextInCell)이 미기록이면 undo 불가에 더해
+      // 셀 문자 수 변화로 후속 undo 오프셋이 오염된다(#2344 계열) → 하나의 snapshot 으로
+      // 원자화해 라우팅(#2077 동형). services 미주입 시 직접 적용 fallback.
+      const commit = () => {
+        this.wasm.evaluateTableFormula(
+          this.ctx.sec, this.ctx.ppi, this.ctx.ci,
+          row, col, formula, true,
+        );
+        if (formatted !== null) {
+          try {
+            this.wasm.insertTextInCell(
+              this.ctx.sec, this.ctx.ppi, this.ctx.ci,
+              this.ctx.cellIndex, 0, 0, formatted,
+            );
+          } catch { /* 쉼표 포맷 기록 실패 시 기본값 유지 */ }
+        }
+      };
+      const ih = this.services?.getInputHandler();
+      if (ih) {
+        ih.executeOperation({
+          kind: 'snapshot',
+          operationType: 'tableFormula',
+          operation: () => { commit(); return ih.getCursorPosition(); },
+        });
+      } else {
+        commit();
+        this.eventBus.emit('document-changed');
+      }
       return true; // 성공 → 대화상자 닫기
     } catch (e: any) {
       this.showError('계산식 실행 실패: ' + (e.message || e));

--- a/rhwp-studio/tests/undo-formula-dialog.test.ts
+++ b/rhwp-studio/tests/undo-formula-dialog.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #formula-dialog] 계산식 다이얼로그 히스토리 라우팅 소스 가드.
+//
+// formula-dialog 는 (wasm,eventBus,ctx) 로만 생성돼 편집 라우터에 도달 못 했고, commit
+// (evaluateTableFormula write=true) + 쉼표 insertTextInCell 두 뮤테이션이 미기록이라 undo
+// 불가 + 셀 문자 수 변화로 후속 undo 오프셋 오염(#2344 계열). services 주입 + 두 뮤테이션의
+// 단일 snapshot 원자화 + dry-run(검증)은 스냅샷 밖 유지를 정적으로 핀한다. 행위 증명은
+// 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/ui/formula-dialog.ts'), 'utf8');
+
+test('formula-dialog 는 services 주입 + tableFormula snapshot 라우팅 + fallback 을 갖춘다', () => {
+  assert.match(src, /services\?:\s*CommandServices/, '생성자에 services 주입');
+  assert.match(src, /import type \{ CommandServices \}/, 'CommandServices import');
+  assert.match(src, /this\.services\?\.getInputHandler\(\)/, 'getInputHandler 로 라우터 도달');
+  assert.match(src, /operationType:\s*'tableFormula'/, 'tableFormula snapshot 라우팅');
+  assert.match(src, /this\.eventBus\.emit\('document-changed'\)/, 'fallback emit 유지');
+});
+
+test('commit + 쉼표 insert 는 하나의 commit 클로저로 원자화되고 dry-run 은 밖에 있다', () => {
+  // 원자화: 두 뮤테이션이 같은 commit 클로저 안에 있어야 함(사이에 스냅샷 경계 금지).
+  const commitStart = src.indexOf('const commit = () => {');
+  assert.notEqual(commitStart, -1, 'commit 클로저 존재');
+  const commitEnd = src.indexOf('};', src.indexOf('catch { /* 쉼표', commitStart));
+  const commitBody = src.slice(commitStart, commitEnd);
+  assert.match(commitBody, /evaluateTableFormula\([\s\S]*?true,?\s*\)/, 'commit(write=true)은 클로저 안');
+  assert.match(commitBody, /insertTextInCell\(/, '쉼표 insert 도 같은 클로저 안(원자화)');
+  // dry-run(write=false) 검증은 클로저/스냅샷 밖(실패 시 no-op 스냅샷 방지).
+  const dryRunIdx = src.indexOf('formula, false,');
+  assert.ok(dryRunIdx !== -1 && dryRunIdx < commitStart, 'dry-run 검증은 commit 클로저보다 앞(밖)');
+});


### PR DESCRIPTION
## 요약

**계산식 다이얼로그**가 편집 라우터에 도달하지 못해 commit+쉼표 기록 두 뮤테이션이 미기록되던 계급 1 미라우팅을 수정합니다(Track 1 다이얼로그 services 주입, 마지막 클러스터). 셀 문자 수를 바꾸는 기록이라 후속 undo 오프셋 오염 위험(#2344 계열)까지 닫습니다.

Fixes #2366

## 변경

- 생성자에 `services?: CommandServices` 주입 → 호출부(table.ts `openFormulaDialog`)가 전달(#2077·[#2362](https://github.com/edwardkim/rhwp/pull/2362)·[#2364](https://github.com/edwardkim/rhwp/pull/2364) 동형).
- **commit(`evaluateTableFormula` write=true) + 쉼표 `insertTextInCell` 를 하나의 `tableFormula` snapshot 으로 원자화.** 쉼표 문자열은 dry-run 결과만으로 산출 → 뮤테이션 전에 계산. dry-run 검증은 스냅샷 밖 유지(실패 시 no-op 스냅샷 방지 — #2347 블록계산과 동일 설계).
- `services` 미주입 fallback(직접 적용+emit) 유지. 소스 가드 테스트 `undo-formula-dialog`(2) 추가 — 원자화(두 뮤테이션이 같은 commit 클로저)와 dry-run 위치까지 핀.

## 검증

- `npx tsc --noEmit`, `npm test` 348/348.
- 브라우저 왕복(실제 다이얼로그): 셀 `1234`/`5678` → `=SUM(above)` 확인 → `undoLen` **정확히 +1**(두 뮤테이션 = 1 엔트리, 원자성 게이트) → undo **한 번**에 셀 원상 복원. 콘솔 에러 0.

## 범위 외

- 검증 중 발견한 **사전존재 표시 결함**: 쉼표 경로가 선행 삭제 없이 offset 0 에 insert 해 `6,9126912` 로 겹침 → #2367 분리(본 PR 은 동일 호출·순서 보존 — 라우팅만).


---

(a′) 이관 로드맵 #2369 의 **Track 1**(다이얼로그 services 주입)에 속합니다.
