### PR TITLE
feat(render): add opt-in direct PageLayerTree PDF export

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -517,10 +517,12 @@ jobs:
             echo "profile=release-test event=${GITHUB_EVENT_NAME} ref=${GITHUB_REF}"
             cargo test --profile release-test --features native-skia skia --lib --verbose
             cargo test --profile release-test --features native-skia --test issue_2225_missing_picture_placeholder --verbose
+            cargo test --profile release-test --features native-skia --test render_p37_direct_pdf_export --verbose
           else
             echo "profile=release event=${GITHUB_EVENT_NAME} ref=${GITHUB_REF}"
             cargo test --release --features native-skia skia --lib --verbose
             cargo test --release --features native-skia --test issue_2225_missing_picture_placeholder --verbose
+            cargo test --release --features native-skia --test render_p37_direct_pdf_export --verbose
           fi
 
   frontend-package-gates:

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -250,8 +250,13 @@ jobs:
           targets: wasm32-unknown-unknown
 
       - name: Install PDF raster tools
-        continue-on-error: true
-        run: sudo apt-get update && sudo apt-get install -y poppler-utils
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y --no-install-recommends \
+            fonts-dejavu-core \
+            libfontconfig1-dev \
+            libfreetype6-dev \
+            poppler-utils
 
       - name: Install wasm-pack
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
@@ -275,8 +280,7 @@ jobs:
         run: wasm-pack build --target web --dev
 
       - name: Build native CLI for PDF report
-        continue-on-error: true
-        run: cargo build --bin rhwp
+        run: cargo build --features native-skia --bin rhwp
 
       - name: Save cargo registry & build cache
         if: ${{ github.event_name == 'workflow_dispatch' && (github.ref == 'refs/heads/devel' || github.ref == 'refs/heads/main') && steps.render_diff_cargo_cache_restore.outputs.cache-hit != 'true' }}
@@ -330,6 +334,10 @@ jobs:
           RHWP_RENDER_DIFF_WRITE_IMAGES: ${{ inputs['write-images'] == true && '1' || '0' }}
           RHWP_RENDER_DIFF_PDF: '1'
           RHWP_RENDER_DIFF_PDF_WRITE_IMAGES: '1'
+          RHWP_RENDER_DIFF_DIRECT_PDF: '1'
+          RHWP_RENDER_DIFF_DIRECT_PDF_GATE: '1'
+          RHWP_RENDER_DIFF_DIRECT_PDF_MAX_RATIO: '0.02'
+          RHWP_RENDER_DIFF_DIRECT_PDF_RASTER_DPI: '144'
           RHWP_RENDER_DIFF_RHWP_BIN: ../target/debug/rhwp
         run: npm run e2e:render-diff:ci
 

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -7,11 +7,13 @@ on:
       - 'Cargo.toml'
       - 'Cargo.lock'
       - 'src/paint/**'
+      - 'src/model/**'
       - 'src/renderer/**'
       - 'src/document_core/queries/rendering.rs'
       - 'src/wasm_api.rs'
       - 'src/main.rs'
       - 'assets/fonts/**'
+      - 'ttfs/**'
       - 'scripts/renderer_baseline.py'
       - 'scripts/renderer_baseline_manifest.json'
       - 'scripts/generate_font_glyph_payload_fixture.py'
@@ -61,8 +63,8 @@ jobs:
     name: Render Diff preflight
     runs-on: ubuntu-latest
     permissions:
+      actions: read
       contents: read
-      checks: read
       pull-requests: read
     outputs:
       fast_pass: ${{ steps.detect.outputs.fast_pass || 'false' }}
@@ -76,7 +78,6 @@ jobs:
         uses: actions/github-script@v8
         with:
           script: |
-            const allowedConclusions = new Set(['success', 'skipped', 'neutral']);
             const { owner, repo } = context.repo;
 
             function setResult(fastPass, reason, candidateSha = '') {
@@ -201,31 +202,76 @@ jobs:
                 return;
               }
 
-              const checkRuns = await github.paginate(github.rest.checks.listForRef, {
+              const workflowRuns = await github.paginate(github.rest.actions.listWorkflowRuns, {
                 owner,
                 repo,
-                ref: candidateSha,
+                workflow_id: 'render-diff.yml',
+                event: 'pull_request',
+                status: 'completed',
+                head_sha: candidateSha,
                 per_page: 100,
               });
-              const renderDiffRun = latestRun(checkRuns.filter((run) => (
-                run.name === 'Canvas visual diff'
-                && run.app?.slug === 'github-actions'
+              const renderDiffRun = latestRun(workflowRuns.filter((run) => (
+                run.path === '.github/workflows/render-diff.yml'
+                && run.event === 'pull_request'
+                && run.head_sha === candidateSha
               )));
 
               if (!renderDiffRun) {
-                setResult(false, `missing-canvas-visual-diff:${candidateSha}`, candidateSha);
+                setResult(false, `missing-completed-render-diff-workflow:${candidateSha}`, candidateSha);
                 return;
               }
-              if (renderDiffRun.status !== 'completed') {
-                setResult(false, `canvas-visual-diff-not-completed:${renderDiffRun.status}`, candidateSha);
+              if (renderDiffRun.conclusion !== 'success') {
+                setResult(
+                  false,
+                  `latest-render-diff-workflow-not-success:${renderDiffRun.conclusion}`,
+                  candidateSha,
+                );
                 return;
               }
-              if (!allowedConclusions.has(renderDiffRun.conclusion)) {
-                setResult(false, `canvas-visual-diff-not-green:${renderDiffRun.conclusion}`, candidateSha);
+              const runCreatedAt = Date.parse(renderDiffRun.created_at);
+              const pullCreatedAt = Date.parse(pr.created_at);
+              if (!Number.isFinite(runCreatedAt)
+                || !Number.isFinite(pullCreatedAt)
+                || renderDiffRun.head_branch !== pr.head.ref
+                || renderDiffRun.head_repository?.id !== pr.head.repo?.id
+                || runCreatedAt < pullCreatedAt) {
+                setResult(false, 'render-diff-workflow-pr-identity-mismatch', candidateSha);
                 return;
               }
 
-              setResult(true, `canvas-visual-diff-green:${renderDiffRun.conclusion}`, candidateSha);
+              const jobs = await github.paginate(github.rest.actions.listJobsForWorkflowRun, {
+                owner,
+                repo,
+                run_id: renderDiffRun.id,
+                filter: 'latest',
+                per_page: 100,
+              });
+              const renderDiffJob = latestRun(jobs.filter((job) => (
+                job.name === 'Canvas visual diff'
+              )));
+              if (!renderDiffJob) {
+                setResult(false, `missing-canvas-visual-diff-job:${candidateSha}`, candidateSha);
+                return;
+              }
+              if (renderDiffJob.status !== 'completed' || renderDiffJob.conclusion !== 'success') {
+                setResult(
+                  false,
+                  `canvas-visual-diff-not-success:${renderDiffJob.status}:${renderDiffJob.conclusion}`,
+                  candidateSha,
+                );
+                return;
+              }
+              const expectedIdentityStep = `Render Diff identity PR #${pr.number} base ${pr.base.sha}`;
+              const identityStep = (renderDiffJob.steps || []).find((step) => (
+                step.name === expectedIdentityStep
+              ));
+              if (identityStep?.status !== 'completed' || identityStep.conclusion !== 'success') {
+                setResult(false, 'canvas-visual-diff-identity-mismatch', candidateSha);
+                return;
+              }
+
+              setResult(true, 'canvas-visual-diff-success', candidateSha);
             } catch (error) {
               core.warning(`Render Diff preflight failed; running full Render Diff. ${error.message}`);
               setResult(false, 'preflight-error');
@@ -242,6 +288,10 @@ jobs:
       RHWP_CHROMIUM_BUILD_ID: '1660786'
 
     steps:
+      - name: "Render Diff identity PR #${{ github.event.pull_request.number }} base ${{ github.event.pull_request.base.sha }}"
+        if: ${{ github.event_name == 'pull_request' }}
+        run: printf '%s\n' 'Render Diff identity recorded'
+
       - uses: actions/checkout@v5
 
       - name: Install Rust toolchain

--- a/README.md
+++ b/README.md
@@ -114,16 +114,18 @@ rhwp는 Rust + WebAssembly 기반의 오픈소스 HWP/HWPX 뷰어/에디터입�
 
 ### Output (출력)
 - SVG export (CLI, legacy + layer replay)
-- PNG export (native Skia, `--features native-skia`) / PDF export (`--text-as-paths` 지원, 바이트 재현성)
+- PNG export (native Skia, `--features native-skia`)
+- PDF export: SVG compatibility 기본(`--text-as-paths` 지원, 바이트 재현성), native Skia direct opt-in(`--features native-skia`, `--backend direct`)
 - Canvas rendering (WASM/Web) + CanvasKit direct replay (opt-in)
 - 저장: HWP 편집 저장, HWPX/HML 의미 보존 저장, HWPX → HWP 변환 경로
 - Debug overlay (paragraph/table boundaries + indices + y-coordinates)
 
 ### Multi-Renderer Backends (멀티 렌더러 백엔드)
 - 공통 paint IR: `PageRenderTree` → `PageLayerTree` (Rust `DocumentCore::build_page_layer_tree`, WASM `getPageLayerTree`) — `schemaVersion: 1`, 호환 변경은 additive 원칙
-- 백엔드: legacy/layered SVG, Canvas2D(브라우저 기본), CanvasKit 직접 replay(`?renderer=canvaskit` opt-in + readiness gate), native Skia PNG/PDF(`--features native-skia`)
+- 백엔드: legacy/layered SVG, Canvas2D(브라우저 기본), CanvasKit 직접 replay(`?renderer=canvaskit` opt-in + readiness gate), native Skia PNG/direct PDF(`--features native-skia`)
 - Text IR v2: 폰트 blob 증명 기반 GlyphRun/GlyphOutline 사이드카 — 미증명 케이스는 항상 `TextRun` 폴백 (호환 계약)
-- 시각 회귀 CI: render-diff(Canvas 계열 + report-only PDF diff), 4-backend 공통 replay-plane(배경→글뒤→본문→글앞) 계약
+- direct PDF는 print profile과 CSS px→PDF point `72/96` 변환을 사용합니다. 손실되는 gradient/pattern/shadow/connector/image adjustment는 SVG backend 사용을 안내하며 실패하고, Raw SVG만 `--raster-dpi` 기반 bounded raster fallback을 사용합니다.
+- 시각 회귀 CI: render-diff(Canvas 계열 + browser/compatibility PDF report), selected direct/compatibility PDF 2% hard gate, 4-backend 공통 replay-plane(배경→글뒤→본문→글앞) 계약
 
 ### Web Editor (웹 에디터)
 - Text editing (insert, delete, undo/redo)

--- a/README_EN.md
+++ b/README_EN.md
@@ -112,16 +112,19 @@ Per-cycle changes (including contributor credits) are recorded in [CHANGELOG_EN.
 
 ### Output
 - SVG export (CLI, legacy + layer replay)
-- PNG export (native Skia, `--features native-skia`) / PDF export (`--text-as-paths`, byte-reproducible)
+- PNG export (native Skia, `--features native-skia`)
+- PDF export: SVG compatibility by default (`--text-as-paths`, byte-reproducible), native Skia direct opt-in (`--features native-skia`, `--backend direct`)
 - Canvas rendering (WASM/Web) + CanvasKit direct replay (opt-in)
 - Save: native HWP editing, semantics-preserving HWPX/HML save, HWPX → HWP conversion
 - Debug overlay (paragraph/table boundaries + indices + y-coordinates)
 
 ### Multi-Renderer Backends
 - Shared paint IR: `PageRenderTree` → `PageLayerTree` (Rust `DocumentCore::build_page_layer_tree`, WASM `getPageLayerTree`) — `schemaVersion: 1`, compatible changes stay additive
-- Backends: legacy/layered SVG, Canvas2D (browser default), CanvasKit direct replay (`?renderer=canvaskit` opt-in with a readiness gate), native Skia PNG/PDF (`--features native-skia`)
+- Backends: legacy/layered SVG, Canvas2D (browser default), CanvasKit direct replay (`?renderer=canvaskit` opt-in with a readiness gate), native Skia PNG/direct PDF (`--features native-skia`)
 - Text IR v2: font-blob-proof-gated GlyphRun/GlyphOutline sidecars — unproven cases always fall back to `TextRun` (compatibility contract)
 - Visual regression CI: render-diff (Canvas family + report-only PDF diff), shared replay-plane ordering (background → behindText → flow → inFrontOfText) across all four backends
+- Direct PDF uses the print profile and a CSS-px-to-PDF-point `72/96` transform. Lossy gradient/pattern/shadow/connector/image-adjustment payloads fail with guidance to use the SVG backend; only Raw SVG uses the bounded `--raster-dpi` fallback.
+- Selected direct/compatibility PDF rasters are hard-gated at 2%; the broader browser/compatibility PDF comparison remains report-only.
 
 ### Web Editor
 - Text editing (insert, delete, undo/redo)

--- a/docs/canvaskit-parity-implementation.md
+++ b/docs/canvaskit-parity-implementation.md
@@ -288,6 +288,38 @@ sweeps remain representative. The selected multi-profile sweep also collects
 verified print-profile PDF artifacts, while selected CanvasKit readiness cases
 remain the bounded visual hard gate.
 
+## Direct PDF Export Contract
+
+P37 adds a native-only, opt-in `PageLayerTree` PDF path using the same Skia
+replay-plane, inherited-layer, clip, text-variant, and resource handling as the
+PNG renderer. PDF recording applies one `72/96` transform because layer
+coordinates are CSS pixels and PDF page boxes use points. Direct export uses the
+print profile unless the caller explicitly selects another profile.
+
+The existing SVG-derived PDF APIs and CLI behavior remain the compatibility
+default. Direct export is exposed only with `native-skia` through the additive
+`render_*_pdf_direct_native` methods and `export-pdf --backend direct`; WASM,
+C/Swift, and XCFramework surfaces are unchanged. SVG-only fallback-family,
+equation-family, and text-as-path options are rejected when direct mode is
+selected instead of being silently ignored.
+
+Direct mode preflights every selected page before opening the PDF writer. Native
+Skia approximations that would lose visible semantics, including gradient,
+pattern, shadow, multi-line/arrow, connector, or unbaked
+image-adjustment payloads, return a page/op-specific error directing the caller
+to the SVG backend. Image decode and Raw SVG fallback failures also abort the
+document rather than recording a placeholder. Raw SVG is the explicit raster
+fallback in this phase and uses the requested fallback DPI; supported text,
+paths, simple shapes, clips, equations, images, and form appearances are
+recorded through the PDF canvas.
+
+Render-diff CI keeps browser Canvas versus compatibility PDF report-only. A
+separate selected corpus (`biz_plan.hwp`, `kps-ai.hwp`, and
+`tac-case-001.hwp`) rasterizes direct and compatibility PDF page 1 at the same
+DPI and hard-fails above a 2% differing-pixel ratio or on a page-size/resource
+error. Broader documents and unsupported vector subsets remain report/fallback
+work rather than being declared parity-complete.
+
 ## Non-Goals
 
 - This plan does not switch the public canvas default.

--- a/rhwp-studio/e2e/pdf-render-diff-report.mjs
+++ b/rhwp-studio/e2e/pdf-render-diff-report.mjs
@@ -351,12 +351,21 @@ function comparePngPaths(referencePath, pdfPath, diffPath, channelTolerance) {
   };
 }
 
+function errorMessage(error) {
+  return error?.message || String(error);
+}
+
+function markdownArtifactList(files) {
+  return Object.values(files || {}).map(markdownCell).join('<br>');
+}
+
 function renderMarkdownSummary(config, results) {
-  const errors = results.filter(result => result.error);
-  const warnings = results.filter(result => !result.error && result.exceedsReportThreshold);
-  const directResults = results.filter(result => result.directExpected && !result.error);
+  const errors = results.filter(result => result.reportError);
+  const warnings = results.filter(result => result.reportComparison && result.exceedsReportThreshold);
+  const directResults = results.filter(result => result.directExpected && result.directComparison);
   const directFailures = results.filter(result => (
-    result.directExpected && (result.error || result.directGateFailed)
+    result.directExpected
+    && (result.directError || !result.directComparison || result.directGateFailed)
   ));
   const lines = [
     '# PDF Visual Diff Report',
@@ -369,7 +378,7 @@ function renderMarkdownSummary(config, results) {
     `- channel tolerance: ${config.channelTolerance}`,
     `- command timeout: ${config.commandTimeoutMs}ms`,
     `- report threshold: ${config.maxDiffRatio == null ? 'disabled' : config.maxDiffRatio}`,
-    `- compared pages: ${results.filter(result => !result.error).length}`,
+    `- compared pages: ${results.filter(result => result.reportComparison).length}`,
     `- warning pages: ${warnings.length}`,
     `- error pages: ${errors.length}`,
     `- direct PDF gate: ${config.directPdfGate ? 'enabled' : 'disabled'}`,
@@ -390,7 +399,7 @@ function renderMarkdownSummary(config, results) {
   lines.push('| Status | Fixture | Page | Size | Diff pixels | Diff ratio | Max channel delta | Artifacts |');
   lines.push('| --- | --- | ---: | --- | ---: | ---: | ---: | --- |');
   for (const result of results) {
-    if (result.error) {
+    if (result.reportError || !result.reportComparison) {
       lines.push([
         'error',
         markdownCell(result.fixture),
@@ -399,7 +408,7 @@ function renderMarkdownSummary(config, results) {
         '-',
         '-',
         '-',
-        markdownCell(result.error),
+        markdownCell(result.reportError || 'browser/compatibility comparison was not produced'),
       ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
       continue;
     }
@@ -408,7 +417,6 @@ function renderMarkdownSummary(config, results) {
     const size = result.sameSize
       ? `${result.width}x${result.height}`
       : `${result.referenceWidth}x${result.referenceHeight} vs ${result.pdfWidth}x${result.pdfHeight}`;
-    const artifactText = Object.values(result.artifactFiles || {}).join('<br>');
     lines.push([
       status,
       markdownCell(result.fixture),
@@ -417,7 +425,7 @@ function renderMarkdownSummary(config, results) {
       result.diffPixels,
       result.diffRatio.toFixed(8),
       result.maxChannelDelta,
-      markdownCell(artifactText),
+      markdownArtifactList(result.artifactFiles),
     ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
   }
 
@@ -438,7 +446,7 @@ function renderMarkdownSummary(config, results) {
     lines.push('| Status | Fixture | Page | Size | Diff pixels | Diff ratio | Max channel delta | Artifacts |');
     lines.push('| --- | --- | ---: | --- | ---: | ---: | ---: | --- |');
     for (const result of results.filter(item => item.directExpected)) {
-      if (result.error || !result.directComparison) {
+      if (result.directError || !result.directComparison) {
         lines.push([
           'error',
           markdownCell(result.fixture),
@@ -447,7 +455,7 @@ function renderMarkdownSummary(config, results) {
           '-',
           '-',
           '-',
-          markdownCell(result.error || 'direct comparison was not produced'),
+          markdownCell(result.directError || 'direct comparison was not produced'),
         ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
         continue;
       }
@@ -456,7 +464,6 @@ function renderMarkdownSummary(config, results) {
       const size = comparison.sameSize
         ? `${comparison.width}x${comparison.height}`
         : `${comparison.referenceWidth}x${comparison.referenceHeight} vs ${comparison.pdfWidth}x${comparison.pdfHeight}`;
-      const artifactText = Object.values(result.directArtifactFiles || {}).join('<br>');
       lines.push([
         status,
         markdownCell(result.fixture),
@@ -465,7 +472,7 @@ function renderMarkdownSummary(config, results) {
         comparison.diffPixels,
         comparison.diffRatio.toFixed(8),
         comparison.maxChannelDelta,
-        markdownCell(artifactText),
+        markdownArtifactList(result.directArtifactFiles),
       ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
     }
   }
@@ -475,7 +482,7 @@ function renderMarkdownSummary(config, results) {
     lines.push('## Errors');
     lines.push('');
     for (const error of errors) {
-      lines.push(`- ${markdownCell(error.fixture)} page ${error.pageIndex + 1}: ${markdownCell(error.error)}`);
+      lines.push(`- ${markdownCell(error.fixture)} page ${error.pageIndex + 1} (${markdownCell(error.reportStage || 'unknown stage')}): ${markdownCell(error.reportError)}`);
     }
   }
 
@@ -536,12 +543,19 @@ runTest('PDF export visual diff report', async ({ page }) => {
       let pageCount;
       try {
         ({ pageCount } = await loadHwpFile(page, fixture));
+        if (!Number.isSafeInteger(pageCount) || pageCount <= 0) {
+          throw new Error(`fixture reported invalid page count: ${pageCount}`);
+        }
       } catch (error) {
+        const message = `load-fixture: ${errorMessage(error)}`;
         results.push({
           fixture,
           pageIndex: 0,
           directExpected,
-          error: error.message || String(error),
+          reportStage: 'load-fixture',
+          reportError: message,
+          directStage: directExpected ? 'load-fixture' : null,
+          directError: directExpected ? message : null,
         });
         continue;
       }
@@ -560,37 +574,56 @@ runTest('PDF export visual diff report', async ({ page }) => {
         const directRasterPath = `${directRasterPrefix}.png`;
         const directDiffPath = join(ARTIFACT_DIR, `${baseName}-direct-vs-compat-diff.png`);
 
+        const result = {
+          fixture,
+          pageIndex,
+          directExpected,
+          rhwpMode: rhwp.mode,
+          reportStage: 'cleanup',
+          reportError: null,
+          reportComparison: null,
+          exceedsReportThreshold: false,
+          directStage: directExpected ? 'pending' : null,
+          directError: null,
+          directComparison: null,
+          directGateFailed: false,
+          artifactFiles: {},
+          directArtifactFiles: {},
+        };
+        const reportArtifactEntries = {
+          reference: [referencePath, `e2e/screenshots/render-diff/${baseName}-pdf-reference.png`],
+          pdf: [pdfPath, `e2e/screenshots/render-diff/${baseName}.pdf`],
+          pdfRaster: [pdfRasterPath, `e2e/screenshots/render-diff/${baseName}-pdf-raster.png`],
+          diff: [diffPath, `e2e/screenshots/render-diff/${baseName}-pdf-diff.png`],
+        };
+        const directArtifactEntries = {
+          compatibilityPdf: [pdfPath, `e2e/screenshots/render-diff/${baseName}.pdf`],
+          compatibilityRaster: [pdfRasterPath, `e2e/screenshots/render-diff/${baseName}-pdf-raster.png`],
+          directPdf: [directPdfPath, `e2e/screenshots/render-diff/${baseName}-direct.pdf`],
+          directRaster: [directRasterPath, `e2e/screenshots/render-diff/${baseName}-direct-raster.png`],
+          diff: [directDiffPath, `e2e/screenshots/render-diff/${baseName}-direct-vs-compat-diff.png`],
+        };
+        const existingArtifacts = entries => Object.fromEntries(
+          Object.entries(entries)
+            .filter(([, [localPath]]) => existsSync(localPath))
+            .map(([name, [, reportPath]]) => [name, reportPath]),
+        );
+
+        for (const artifactPath of [
+          referencePath,
+          pdfPath,
+          pdfRasterPath,
+          diffPath,
+          directPdfPath,
+          directRasterPath,
+          directDiffPath,
+        ]) {
+          removeIfExists(artifactPath);
+        }
+
+        let compatibilityReady = false;
         try {
-          for (const artifactPath of [
-            referencePath,
-            pdfPath,
-            pdfRasterPath,
-            diffPath,
-            directPdfPath,
-            directRasterPath,
-            directDiffPath,
-          ]) {
-            removeIfExists(artifactPath);
-          }
-
-          const reference = await page.evaluate((args) => {
-            const doc = window.__wasm?.doc;
-            if (!doc) throw new Error('window.__wasm.doc is not available');
-            if (typeof doc.renderPageToCanvas !== 'function') {
-              throw new Error('renderPageToCanvas is not available');
-            }
-
-            const canvas = document.createElement('canvas');
-            doc.renderPageToCanvas(args.pageIndex, canvas, args.scale);
-            return {
-              width: canvas.width,
-              height: canvas.height,
-              dataUrl: canvas.toDataURL('image/png'),
-            };
-          }, { pageIndex, scale: config.scale });
-
-          writeDataUrl(referencePath, reference.dataUrl);
-
+          result.reportStage = 'compatibility-export';
           runCommand(rhwp.command, [
             ...rhwp.args,
             'export-pdf',
@@ -601,6 +634,7 @@ runTest('PDF export visual diff report', async ({ page }) => {
             String(pageIndex),
           ]);
           assertFreshPdf(pdfPath);
+          result.reportStage = 'compatibility-raster';
           runCommand('pdftoppm', [
             '-r',
             String(config.rasterDpi),
@@ -609,86 +643,102 @@ runTest('PDF export visual diff report', async ({ page }) => {
             pdfPath,
             pdfRasterPrefix,
           ]);
+          compatibilityReady = true;
+        } catch (error) {
+          result.reportError = `${result.reportStage}: ${errorMessage(error)}`;
+        }
 
-          const comparison = comparePngPaths(referencePath, pdfRasterPath, diffPath, config.channelTolerance);
-          let directComparison = null;
-          let directGateFailed = false;
-          let directArtifactFiles = null;
-          if (directExpected) {
-            runCommand(rhwp.command, [
-              ...rhwp.args,
-              'export-pdf',
-              samplePath,
-              '--backend',
-              'direct',
-              '--profile',
-              'print',
-              '--raster-dpi',
-              String(config.directFallbackRasterDpi),
-              '-o',
-              directPdfPath,
-              '-p',
-              String(pageIndex),
-            ]);
-            assertFreshPdf(directPdfPath);
-            runCommand('pdftoppm', [
-              '-r',
-              String(config.rasterDpi),
-              '-singlefile',
-              '-png',
-              directPdfPath,
-              directRasterPrefix,
-            ]);
-            directComparison = comparePngPaths(
+        if (directExpected) {
+          if (!compatibilityReady) {
+            result.directStage = 'compatibility-prerequisite';
+            result.directError = `compatibility-prerequisite: ${result.reportError}`;
+          } else {
+            try {
+              result.directStage = 'direct-export';
+              runCommand(rhwp.command, [
+                ...rhwp.args,
+                'export-pdf',
+                samplePath,
+                '--backend',
+                'direct',
+                '--profile',
+                'print',
+                '--raster-dpi',
+                String(config.directFallbackRasterDpi),
+                '-o',
+                directPdfPath,
+                '-p',
+                String(pageIndex),
+              ]);
+              assertFreshPdf(directPdfPath);
+              result.directStage = 'direct-raster';
+              runCommand('pdftoppm', [
+                '-r',
+                String(config.rasterDpi),
+                '-singlefile',
+                '-png',
+                directPdfPath,
+                directRasterPrefix,
+              ]);
+              result.directStage = 'direct-compare';
+              result.directComparison = comparePngPaths(
+                pdfRasterPath,
+                directRasterPath,
+                directDiffPath,
+                config.channelTolerance,
+              );
+              result.directGateFailed = result.directComparison.majorSizeMismatch
+                || result.directComparison.diffRatio > config.directMaxDiffRatio;
+              result.directStage = 'complete';
+            } catch (error) {
+              result.directError = `${result.directStage}: ${errorMessage(error)}`;
+            }
+          }
+        }
+
+        if (compatibilityReady) {
+          try {
+            result.reportStage = 'browser-capture';
+            const reference = await page.evaluate((args) => {
+              const doc = window.__wasm?.doc;
+              if (!doc) throw new Error('window.__wasm.doc is not available');
+              if (typeof doc.renderPageToCanvas !== 'function') {
+                throw new Error('renderPageToCanvas is not available');
+              }
+
+              const canvas = document.createElement('canvas');
+              doc.renderPageToCanvas(args.pageIndex, canvas, args.scale);
+              return {
+                width: canvas.width,
+                height: canvas.height,
+                dataUrl: canvas.toDataURL('image/png'),
+              };
+            }, { pageIndex, scale: config.scale });
+            writeDataUrl(referencePath, reference.dataUrl);
+            result.reportStage = 'browser-compatibility-compare';
+            result.reportComparison = comparePngPaths(
+              referencePath,
               pdfRasterPath,
-              directRasterPath,
-              directDiffPath,
+              diffPath,
               config.channelTolerance,
             );
-            directGateFailed = directComparison.majorSizeMismatch
-              || directComparison.diffRatio > config.directMaxDiffRatio;
-            directArtifactFiles = {
-              compatibilityPdf: `e2e/screenshots/render-diff/${baseName}.pdf`,
-              compatibilityRaster: `e2e/screenshots/render-diff/${baseName}-pdf-raster.png`,
-              directPdf: `e2e/screenshots/render-diff/${baseName}-direct.pdf`,
-              directRaster: `e2e/screenshots/render-diff/${baseName}-direct-raster.png`,
-              diff: `e2e/screenshots/render-diff/${baseName}-direct-vs-compat-diff.png`,
-            };
+            Object.assign(result, result.reportComparison);
+            result.exceedsReportThreshold = result.reportComparison.majorSizeMismatch
+              || (config.maxDiffRatio != null
+                && result.reportComparison.diffRatio > config.maxDiffRatio);
+            result.reportStage = 'complete';
+          } catch (error) {
+            result.reportError = `${result.reportStage}: ${errorMessage(error)}`;
           }
-          const result = {
-            fixture,
-            pageIndex,
-            directExpected,
-            rhwpMode: rhwp.mode,
-            ...comparison,
-            exceedsReportThreshold: comparison.majorSizeMismatch
-              || (config.maxDiffRatio != null && comparison.diffRatio > config.maxDiffRatio),
-            directComparison,
-            directGateFailed,
-            directArtifactFiles,
-            artifactFiles: {
-              reference: `e2e/screenshots/render-diff/${baseName}-pdf-reference.png`,
-              pdf: `e2e/screenshots/render-diff/${baseName}.pdf`,
-              pdfRaster: `e2e/screenshots/render-diff/${baseName}-pdf-raster.png`,
-              diff: `e2e/screenshots/render-diff/${baseName}-pdf-diff.png`,
-            },
-          };
-
-          if (!config.writeImages) {
-            result.artifactFiles = {
-              pdf: `e2e/screenshots/render-diff/${baseName}.pdf`,
-              diff: `e2e/screenshots/render-diff/${baseName}-pdf-diff.png`,
-            };
-          }
-          results.push(result);
-        } catch (error) {
-          results.push({
-            fixture,
-            pageIndex,
-            directExpected,
-            error: error.message || String(error),
-          });
         }
+
+        result.artifactFiles = existingArtifacts(
+          config.writeImages
+            ? reportArtifactEntries
+            : { pdf: reportArtifactEntries.pdf, diff: reportArtifactEntries.diff },
+        );
+        result.directArtifactFiles = existingArtifacts(directArtifactEntries);
+        results.push(result);
       }
     }
   } finally {
@@ -696,17 +746,22 @@ runTest('PDF export visual diff report', async ({ page }) => {
   }
 
   const warnings = results.filter(result => result.exceedsReportThreshold).length;
-  const errors = results.filter(result => result.error).length;
+  const errors = results.filter(result => result.reportError).length;
+  const directExpectedPages = results.filter(result => result.directExpected).length;
   const directCompared = results.filter(result => result.directExpected && result.directComparison).length;
   const directFailures = results.filter(result => (
-    result.directExpected && (result.error || result.directGateFailed)
+    result.directExpected
+    && (result.directError || !result.directComparison || result.directGateFailed)
   )).length;
   console.log(`PDF visual diff report: ${results.length} page(s), ${warnings} warning(s), ${errors} error(s)`);
-  console.log(`Direct PDF compatibility gate: ${directCompared} compared page(s), ${directFailures} failure(s)`);
+  console.log(`Direct PDF compatibility gate: ${directCompared}/${directExpectedPages} compared page(s), ${directFailures} failure(s)`);
   console.log(`PDF visual diff summary: ${SUMMARY_PATH}`);
-  if (config.directPdfGate && (directCompared === 0 || directFailures > 0)) {
+  if (config.directPdfGate
+    && (directExpectedPages === 0
+      || directCompared !== directExpectedPages
+      || directFailures > 0)) {
     throw new Error(
-      `direct PDF compatibility gate failed: ${directCompared} compared page(s), ${directFailures} failure(s)`,
+      `direct PDF compatibility gate failed: ${directCompared}/${directExpectedPages} compared page(s), ${directFailures} failure(s)`,
     );
   }
 });

--- a/rhwp-studio/e2e/pdf-render-diff-report.mjs
+++ b/rhwp-studio/e2e/pdf-render-diff-report.mjs
@@ -1,9 +1,8 @@
 /**
- * Report-only visual diff between browser Canvas output and SVG-derived PDF
- * export output rasterized back to PNG.
+ * Visual diff for PDF export paths rasterized back to PNG.
  *
- * This is intentionally non-gating. It writes JSON/Markdown summaries and PNG
- * artifacts so PDF export drift can be reviewed before it becomes a hard gate.
+ * Browser Canvas vs SVG-derived PDF remains report-only. A selected corpus can
+ * additionally gate direct PageLayerTree PDF against the SVG compatibility PDF.
  */
 import { createHash } from 'crypto';
 import {
@@ -45,6 +44,12 @@ const MAX_CAPTURE_SIZE_DRIFT_PX = 1;
 const DEFAULT_FIXTURES = [
   'basic/KTX.hwp',
   'biz_plan.hwp',
+  'tac-case-001.hwp',
+];
+
+const DEFAULT_DIRECT_PDF_FIXTURES = [
+  'biz_plan.hwp',
+  'kps-ai.hwp',
   'tac-case-001.hwp',
 ];
 
@@ -148,6 +153,18 @@ function fixturesFromEnv() {
     ? raw.split(',').map(s => s.trim()).filter(Boolean)
     : process.env.RHWP_RENDER_DIFF_ALL === '1' ? ALL_FIXTURES : DEFAULT_FIXTURES;
   return fixtures.map(normalizeFixture);
+}
+
+function directPdfFixturesFromEnv() {
+  const raw = process.env.RHWP_RENDER_DIFF_DIRECT_PDF_FILES;
+  const fixtures = raw
+    ? raw.split(',').map(s => s.trim()).filter(Boolean)
+    : DEFAULT_DIRECT_PDF_FIXTURES;
+  return fixtures.map(normalizeFixture);
+}
+
+function uniqueFixtures(...fixtureLists) {
+  return [...new Set(fixtureLists.flat())];
 }
 
 function safeName(value) {
@@ -337,10 +354,14 @@ function comparePngPaths(referencePath, pdfPath, diffPath, channelTolerance) {
 function renderMarkdownSummary(config, results) {
   const errors = results.filter(result => result.error);
   const warnings = results.filter(result => !result.error && result.exceedsReportThreshold);
+  const directResults = results.filter(result => result.directExpected && !result.error);
+  const directFailures = results.filter(result => (
+    result.directExpected && (result.error || result.directGateFailed)
+  ));
   const lines = [
     '# PDF Visual Diff Report',
     '',
-    `- status: report-only (does not gate CI)`,
+    `- browser/compatibility status: report-only`,
     `- fixtures: ${config.fixtures.map(markdownCell).join(', ')}`,
     `- scale: ${config.scale}`,
     `- raster DPI: ${config.rasterDpi}`,
@@ -351,6 +372,12 @@ function renderMarkdownSummary(config, results) {
     `- compared pages: ${results.filter(result => !result.error).length}`,
     `- warning pages: ${warnings.length}`,
     `- error pages: ${errors.length}`,
+    `- direct PDF gate: ${config.directPdfGate ? 'enabled' : 'disabled'}`,
+    `- direct PDF fixtures: ${config.directPdfFixtures.map(markdownCell).join(', ') || 'none'}`,
+    `- direct PDF fallback raster DPI: ${config.directFallbackRasterDpi}`,
+    `- direct/compatibility max ratio: ${config.directMaxDiffRatio}`,
+    `- direct PDF compared pages: ${directResults.length}`,
+    `- direct PDF failed pages: ${directFailures.length}`,
     '',
   ];
 
@@ -404,6 +431,45 @@ function renderMarkdownSummary(config, results) {
     }
   }
 
+  if (config.directPdfEnabled) {
+    lines.push('');
+    lines.push('## Direct PDF Compatibility Gate');
+    lines.push('');
+    lines.push('| Status | Fixture | Page | Size | Diff pixels | Diff ratio | Max channel delta | Artifacts |');
+    lines.push('| --- | --- | ---: | --- | ---: | ---: | ---: | --- |');
+    for (const result of results.filter(item => item.directExpected)) {
+      if (result.error || !result.directComparison) {
+        lines.push([
+          'error',
+          markdownCell(result.fixture),
+          result.pageIndex + 1,
+          '-',
+          '-',
+          '-',
+          '-',
+          markdownCell(result.error || 'direct comparison was not produced'),
+        ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+        continue;
+      }
+      const comparison = result.directComparison;
+      const status = result.directGateFailed ? 'fail' : 'pass';
+      const size = comparison.sameSize
+        ? `${comparison.width}x${comparison.height}`
+        : `${comparison.referenceWidth}x${comparison.referenceHeight} vs ${comparison.pdfWidth}x${comparison.pdfHeight}`;
+      const artifactText = Object.values(result.directArtifactFiles || {}).join('<br>');
+      lines.push([
+        status,
+        markdownCell(result.fixture),
+        result.pageIndex + 1,
+        size,
+        comparison.diffPixels,
+        comparison.diffRatio.toFixed(8),
+        comparison.maxChannelDelta,
+        markdownCell(artifactText),
+      ].join(' | ').replace(/^/, '| ').replace(/$/, ' |'));
+    }
+  }
+
   if (errors.length > 0) {
     lines.push('');
     lines.push('## Errors');
@@ -428,16 +494,34 @@ function writeReports(config, results) {
   writeFileSync(SUMMARY_PATH, renderMarkdownSummary(config, results));
 }
 
+const requestedFixtures = fixturesFromEnv();
+const directPdfEnabled = process.env.RHWP_RENDER_DIFF_DIRECT_PDF === '1';
+const directPdfFixtures = directPdfEnabled ? directPdfFixturesFromEnv() : [];
 const config = {
-  fixtures: fixturesFromEnv(),
+  fixtures: uniqueFixtures(requestedFixtures, directPdfFixtures),
+  requestedFixtures,
   scale: numberFromEnv('RHWP_RENDER_DIFF_SCALE', 1),
   maxPages: maxPagesFromEnv(),
   channelTolerance: numberFromEnv('RHWP_RENDER_DIFF_PDF_CHANNEL_TOLERANCE', 8),
   maxDiffRatio: optionalNumberFromEnv('RHWP_RENDER_DIFF_PDF_MAX_RATIO'),
   commandTimeoutMs: COMMAND_TIMEOUT_MS,
   writeImages: process.env.RHWP_RENDER_DIFF_PDF_WRITE_IMAGES !== '0',
+  directPdfEnabled,
+  directPdfGate: process.env.RHWP_RENDER_DIFF_DIRECT_PDF_GATE === '1',
+  directPdfFixtures,
+  directFallbackRasterDpi: numberFromEnv('RHWP_RENDER_DIFF_DIRECT_PDF_RASTER_DPI', 144),
+  directMaxDiffRatio: numberFromEnv('RHWP_RENDER_DIFF_DIRECT_PDF_MAX_RATIO', 0.02),
 };
 config.rasterDpi = Math.max(1, Math.round(72 * config.scale));
+if (config.directPdfGate && !config.directPdfEnabled) {
+  throw new Error('RHWP_RENDER_DIFF_DIRECT_PDF_GATE requires RHWP_RENDER_DIFF_DIRECT_PDF=1');
+}
+if (!Number.isFinite(config.directFallbackRasterDpi) || config.directFallbackRasterDpi <= 0) {
+  throw new Error('direct PDF fallback raster DPI must be positive');
+}
+if (!Number.isFinite(config.directMaxDiffRatio) || config.directMaxDiffRatio < 0) {
+  throw new Error('direct PDF max diff ratio must be non-negative');
+}
 
 mkdirSync(ARTIFACT_DIR, { recursive: true });
 
@@ -448,6 +532,7 @@ runTest('PDF export visual diff report', async ({ page }) => {
   try {
     for (const fixture of config.fixtures) {
       setTestCase(`pdf-render-diff ${fixture}`);
+      const directExpected = config.directPdfFixtures.includes(fixture);
       let pageCount;
       try {
         ({ pageCount } = await loadHwpFile(page, fixture));
@@ -455,6 +540,7 @@ runTest('PDF export visual diff report', async ({ page }) => {
         results.push({
           fixture,
           pageIndex: 0,
+          directExpected,
           error: error.message || String(error),
         });
         continue;
@@ -469,9 +555,21 @@ runTest('PDF export visual diff report', async ({ page }) => {
         const pdfRasterPrefix = join(ARTIFACT_DIR, `${baseName}-pdf-raster`);
         const pdfRasterPath = `${pdfRasterPrefix}.png`;
         const diffPath = join(ARTIFACT_DIR, `${baseName}-pdf-diff.png`);
+        const directPdfPath = join(ARTIFACT_DIR, `${baseName}-direct.pdf`);
+        const directRasterPrefix = join(ARTIFACT_DIR, `${baseName}-direct-raster`);
+        const directRasterPath = `${directRasterPrefix}.png`;
+        const directDiffPath = join(ARTIFACT_DIR, `${baseName}-direct-vs-compat-diff.png`);
 
         try {
-          for (const artifactPath of [referencePath, pdfPath, pdfRasterPath, diffPath]) {
+          for (const artifactPath of [
+            referencePath,
+            pdfPath,
+            pdfRasterPath,
+            diffPath,
+            directPdfPath,
+            directRasterPath,
+            directDiffPath,
+          ]) {
             removeIfExists(artifactPath);
           }
 
@@ -513,13 +611,61 @@ runTest('PDF export visual diff report', async ({ page }) => {
           ]);
 
           const comparison = comparePngPaths(referencePath, pdfRasterPath, diffPath, config.channelTolerance);
+          let directComparison = null;
+          let directGateFailed = false;
+          let directArtifactFiles = null;
+          if (directExpected) {
+            runCommand(rhwp.command, [
+              ...rhwp.args,
+              'export-pdf',
+              samplePath,
+              '--backend',
+              'direct',
+              '--profile',
+              'print',
+              '--raster-dpi',
+              String(config.directFallbackRasterDpi),
+              '-o',
+              directPdfPath,
+              '-p',
+              String(pageIndex),
+            ]);
+            assertFreshPdf(directPdfPath);
+            runCommand('pdftoppm', [
+              '-r',
+              String(config.rasterDpi),
+              '-singlefile',
+              '-png',
+              directPdfPath,
+              directRasterPrefix,
+            ]);
+            directComparison = comparePngPaths(
+              pdfRasterPath,
+              directRasterPath,
+              directDiffPath,
+              config.channelTolerance,
+            );
+            directGateFailed = directComparison.majorSizeMismatch
+              || directComparison.diffRatio > config.directMaxDiffRatio;
+            directArtifactFiles = {
+              compatibilityPdf: `e2e/screenshots/render-diff/${baseName}.pdf`,
+              compatibilityRaster: `e2e/screenshots/render-diff/${baseName}-pdf-raster.png`,
+              directPdf: `e2e/screenshots/render-diff/${baseName}-direct.pdf`,
+              directRaster: `e2e/screenshots/render-diff/${baseName}-direct-raster.png`,
+              diff: `e2e/screenshots/render-diff/${baseName}-direct-vs-compat-diff.png`,
+            };
+          }
           const result = {
             fixture,
             pageIndex,
+            directExpected,
             rhwpMode: rhwp.mode,
             ...comparison,
             exceedsReportThreshold: comparison.majorSizeMismatch
               || (config.maxDiffRatio != null && comparison.diffRatio > config.maxDiffRatio),
+            directComparison,
+            directGateFailed,
+            directArtifactFiles,
             artifactFiles: {
               reference: `e2e/screenshots/render-diff/${baseName}-pdf-reference.png`,
               pdf: `e2e/screenshots/render-diff/${baseName}.pdf`,
@@ -539,6 +685,7 @@ runTest('PDF export visual diff report', async ({ page }) => {
           results.push({
             fixture,
             pageIndex,
+            directExpected,
             error: error.message || String(error),
           });
         }
@@ -550,6 +697,16 @@ runTest('PDF export visual diff report', async ({ page }) => {
 
   const warnings = results.filter(result => result.exceedsReportThreshold).length;
   const errors = results.filter(result => result.error).length;
+  const directCompared = results.filter(result => result.directExpected && result.directComparison).length;
+  const directFailures = results.filter(result => (
+    result.directExpected && (result.error || result.directGateFailed)
+  )).length;
   console.log(`PDF visual diff report: ${results.length} page(s), ${warnings} warning(s), ${errors} error(s)`);
+  console.log(`Direct PDF compatibility gate: ${directCompared} compared page(s), ${directFailures} failure(s)`);
   console.log(`PDF visual diff summary: ${SUMMARY_PATH}`);
+  if (config.directPdfGate && (directCompared === 0 || directFailures > 0)) {
+    throw new Error(
+      `direct PDF compatibility gate failed: ${directCompared} compared page(s), ${directFailures} failure(s)`,
+    );
+  }
 });

--- a/rhwp-studio/e2e/renderer-contract.test.mjs
+++ b/rhwp-studio/e2e/renderer-contract.test.mjs
@@ -1435,6 +1435,29 @@ assert.ok(
   'Render Diff preflight must syntax-check and self-test the native parity comparator',
 );
 assert.ok(
+  renderDiffWorkflowSource.includes('actions: read')
+    && renderDiffWorkflowSource.includes('github.rest.actions.listWorkflowRuns')
+    && renderDiffWorkflowSource.includes("workflow_id: 'render-diff.yml'")
+    && renderDiffWorkflowSource.includes('head_sha: candidateSha')
+    && renderDiffWorkflowSource.includes("run.path === '.github/workflows/render-diff.yml'")
+    && renderDiffWorkflowSource.includes("renderDiffRun.conclusion !== 'success'")
+    && renderDiffWorkflowSource.includes('renderDiffRun.head_repository?.id !== pr.head.repo?.id')
+    && renderDiffWorkflowSource.includes('github.rest.actions.listJobsForWorkflowRun')
+    && renderDiffWorkflowSource.includes("job.name === 'Canvas visual diff'")
+    && renderDiffWorkflowSource.includes("renderDiffJob.conclusion !== 'success'")
+    && renderDiffWorkflowSource.includes('`Render Diff identity PR #${pr.number} base ${pr.base.sha}`')
+    && renderDiffWorkflowSource.includes("identityStep.conclusion !== 'success'")
+    && renderDiffWorkflowSource.includes('Render Diff identity PR #${{ github.event.pull_request.number }} base ${{ github.event.pull_request.base.sha }}')
+    && !renderDiffWorkflowSource.includes('github.rest.checks.listForRef')
+    && !renderDiffWorkflowSource.includes('allowedConclusions'),
+  'Render Diff fast-pass must trust only the exact successful workflow and Canvas job',
+);
+assert.ok(
+  renderDiffWorkflowSource.includes("- 'src/model/**'")
+    && renderDiffWorkflowSource.includes("- 'ttfs/**'"),
+  'Render Diff must rerun for model and bundled-font changes',
+);
+assert.ok(
   rendererBaselineDriverSource.includes('--scope')
     && rendererBaselineSource.includes("scope: 'representative'")
     && fullRendererSweepWorkflowSource.includes('corpus:')

--- a/rhwp-studio/e2e/run-render-diff.mjs
+++ b/rhwp-studio/e2e/run-render-diff.mjs
@@ -118,10 +118,14 @@ try {
     await runNpmScript('e2e:render-diff', serverUrl);
   }
   if (process.env.RHWP_RENDER_DIFF_PDF === '1') {
-    try {
+    if (process.env.RHWP_RENDER_DIFF_DIRECT_PDF_GATE === '1') {
       await runNpmScript('e2e:pdf-render-diff', serverUrl);
-    } catch (error) {
-      console.error(`PDF render diff report failed without gating CI: ${error.message || error}`);
+    } else {
+      try {
+        await runNpmScript('e2e:pdf-render-diff', serverUrl);
+      } catch (error) {
+        console.error(`PDF render diff report failed without gating CI: ${error.message || error}`);
+      }
     }
   }
 } finally {

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -724,6 +724,79 @@ impl DocumentCore {
         self.render_pages_pdf_native_with_options(&pages, options)
     }
 
+    /// Direct PageLayerTree PDF export for one page.
+    ///
+    /// This opt-in backend requires `native-skia`. The default print profile
+    /// excludes editor-only overlays from exported documents.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_page_pdf_direct_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError> {
+        self.render_pages_pdf_direct_native(&[page_num])
+    }
+
+    /// Direct PageLayerTree PDF export for an explicit 0-based page selection.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_pages_pdf_direct_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError> {
+        self.render_pages_pdf_direct_native_with_profile_and_options(
+            page_nums,
+            RenderProfile::Print,
+            &crate::renderer::pdf::DirectPdfExportOptions::default(),
+        )
+    }
+
+    /// Direct PageLayerTree PDF export with native Skia recording options.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_pages_pdf_direct_native_with_options(
+        &self,
+        page_nums: &[u32],
+        options: &crate::renderer::pdf::DirectPdfExportOptions,
+    ) -> Result<Vec<u8>, HwpError> {
+        self.render_pages_pdf_direct_native_with_profile_and_options(
+            page_nums,
+            RenderProfile::Print,
+            options,
+        )
+    }
+
+    /// Direct PageLayerTree PDF export with an explicit output profile.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_pages_pdf_direct_native_with_profile_and_options(
+        &self,
+        page_nums: &[u32],
+        profile: RenderProfile,
+        options: &crate::renderer::pdf::DirectPdfExportOptions,
+    ) -> Result<Vec<u8>, HwpError> {
+        if page_nums.is_empty() {
+            return Err(HwpError::RenderError(
+                "PDF export requires at least one page".to_string(),
+            ));
+        }
+
+        let mut layer_trees = Vec::with_capacity(page_nums.len());
+        for &page_num in page_nums {
+            layer_trees.push(self.build_page_layer_tree_with_profile(page_num, profile)?);
+        }
+        crate::renderer::pdf::layer_trees_to_pdf_with_options(&layer_trees, options)
+            .map_err(HwpError::RenderError)
+    }
+
+    /// Direct PageLayerTree PDF export for the full document.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_document_pdf_direct_native(&self) -> Result<Vec<u8>, HwpError> {
+        self.render_document_pdf_direct_native_with_options(
+            &crate::renderer::pdf::DirectPdfExportOptions::default(),
+        )
+    }
+
+    /// Direct PageLayerTree PDF export for the full document with recording options.
+    #[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+    pub fn render_document_pdf_direct_native_with_options(
+        &self,
+        options: &crate::renderer::pdf::DirectPdfExportOptions,
+    ) -> Result<Vec<u8>, HwpError> {
+        let pages: Vec<u32> = (0..self.page_count()).collect();
+        self.render_pages_pdf_direct_native_with_options(&pages, options)
+    }
+
     /// SVG 렌더링 (폰트 임베딩 옵션 포함)
     #[cfg(not(target_arch = "wasm32"))]
     pub fn render_page_svg_with_fonts(

--- a/src/main.rs
+++ b/src/main.rs
@@ -149,13 +149,15 @@ fn print_help() {
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
     println!();
     println!("  export-pdf <파일.hwp|파일.hwpx|파일.hml> [옵션]");
-    println!("      HWP/HWPX/HML 문서를 PDF로 내보내기 (svg2pdf + pdf-writer)");
+    println!("      HWP/HWPX/HML 문서를 PDF로 내보내기 (기본: SVG 호환 backend)");
     println!();
     println!("      -o, --output <파일>      출력 PDF 파일 (기본: output/<입력명>.pdf)");
     println!("      -p, --page <번호>       특정 페이지만 내보내기 (0부터 시작)");
+    println!("      --backend <svg|direct>  PDF backend (기본값: svg)");
     println!(
         "      --profile <프로필>      layer 출력 프로필: screen|print|high-quality|fast-preview"
     );
+    println!("      --raster-dpi <DPI>      direct backend fallback raster DPI (기본값: 144)");
     println!("      --font-path <경로>      폰트 파일 탐색 경로 (여러 번 지정 가능)");
     println!("      --fallback-serif <명>   PDF serif generic fallback family");
     println!("      --fallback-sans <명>    PDF sans-serif generic fallback family");
@@ -1226,8 +1228,12 @@ fn export_pdf(args: &[String]) {
         let file_path = &args[0];
         let mut output_file = String::new();
         let mut target_page: Option<u32> = None;
+        let mut pdf_backend = rhwp::renderer::pdf::PdfBackend::default();
         let mut pdf_options = rhwp::renderer::pdf::PdfExportOptions::default();
+        let mut direct_pdf_options = rhwp::renderer::pdf::DirectPdfExportOptions::default();
         let mut render_profile: Option<rhwp::paint::RenderProfile> = None;
+        let mut compatibility_only_options = Vec::new();
+        let mut direct_raster_dpi_was_set = false;
 
         let mut i = 1;
         while i < args.len() {
@@ -1271,6 +1277,62 @@ fn export_pdf(args: &[String]) {
                         return;
                     }
                 }
+                "--backend" => {
+                    if i + 1 < args.len() {
+                        let Some(backend) = rhwp::renderer::pdf::PdfBackend::parse(&args[i + 1])
+                        else {
+                            eprintln!("오류: --backend 값이 올바르지 않습니다 (svg|direct).");
+                            return;
+                        };
+                        pdf_backend = backend;
+                        i += 2;
+                    } else {
+                        eprintln!("오류: --backend 뒤에 backend 이름이 필요합니다.");
+                        return;
+                    }
+                }
+                arg if arg.starts_with("--backend=") => {
+                    let Some(backend) = rhwp::renderer::pdf::PdfBackend::parse(
+                        arg.trim_start_matches("--backend="),
+                    ) else {
+                        eprintln!("오류: --backend 값이 올바르지 않습니다 (svg|direct).");
+                        return;
+                    };
+                    pdf_backend = backend;
+                    i += 1;
+                }
+                "--raster-dpi" => {
+                    if i + 1 < args.len() {
+                        let Ok(raster_dpi) = args[i + 1].parse::<f32>() else {
+                            eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
+                            return;
+                        };
+                        if !raster_dpi.is_finite() || raster_dpi <= 0.0 {
+                            eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
+                            return;
+                        }
+                        direct_pdf_options.raster_dpi = raster_dpi;
+                        direct_raster_dpi_was_set = true;
+                        i += 2;
+                    } else {
+                        eprintln!("오류: --raster-dpi 뒤에 DPI 값이 필요합니다.");
+                        return;
+                    }
+                }
+                arg if arg.starts_with("--raster-dpi=") => {
+                    let Ok(raster_dpi) = arg.trim_start_matches("--raster-dpi=").parse::<f32>()
+                    else {
+                        eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
+                        return;
+                    };
+                    if !raster_dpi.is_finite() || raster_dpi <= 0.0 {
+                        eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
+                        return;
+                    }
+                    direct_pdf_options.raster_dpi = raster_dpi;
+                    direct_raster_dpi_was_set = true;
+                    i += 1;
+                }
                 "--font-path" => {
                     if i + 1 < args.len() {
                         pdf_options
@@ -1283,6 +1345,7 @@ fn export_pdf(args: &[String]) {
                     }
                 }
                 "--fallback-serif" => {
+                    compatibility_only_options.push("--fallback-serif");
                     if i + 1 < args.len() {
                         pdf_options.fallback_serif = args[i + 1].clone();
                         i += 2;
@@ -1292,11 +1355,13 @@ fn export_pdf(args: &[String]) {
                     }
                 }
                 arg if arg.starts_with("--fallback-serif=") => {
+                    compatibility_only_options.push("--fallback-serif");
                     pdf_options.fallback_serif =
                         arg.trim_start_matches("--fallback-serif=").to_string();
                     i += 1;
                 }
                 "--fallback-sans" | "--fallback-sans-serif" => {
+                    compatibility_only_options.push("--fallback-sans");
                     if i + 1 < args.len() {
                         pdf_options.fallback_sans = args[i + 1].clone();
                         i += 2;
@@ -1308,6 +1373,7 @@ fn export_pdf(args: &[String]) {
                 arg if arg.starts_with("--fallback-sans=")
                     || arg.starts_with("--fallback-sans-serif=") =>
                 {
+                    compatibility_only_options.push("--fallback-sans");
                     pdf_options.fallback_sans = arg
                         .strip_prefix("--fallback-sans=")
                         .or_else(|| arg.strip_prefix("--fallback-sans-serif="))
@@ -1316,6 +1382,7 @@ fn export_pdf(args: &[String]) {
                     i += 1;
                 }
                 "--fallback-mono" | "--fallback-monospace" => {
+                    compatibility_only_options.push("--fallback-mono");
                     if i + 1 < args.len() {
                         pdf_options.fallback_mono = args[i + 1].clone();
                         i += 2;
@@ -1327,6 +1394,7 @@ fn export_pdf(args: &[String]) {
                 arg if arg.starts_with("--fallback-mono=")
                     || arg.starts_with("--fallback-monospace=") =>
                 {
+                    compatibility_only_options.push("--fallback-mono");
                     pdf_options.fallback_mono = arg
                         .strip_prefix("--fallback-mono=")
                         .or_else(|| arg.strip_prefix("--fallback-monospace="))
@@ -1338,10 +1406,12 @@ fn export_pdf(args: &[String]) {
                 // 폰트 서브셋 경로를 건너뛰어 메모리를 크게 줄이는 대신,
                 // PDF 의 텍스트 선택·검색 기능을 잃는다 (시각적 출력은 동일).
                 "--text-as-paths" => {
+                    compatibility_only_options.push("--text-as-paths");
                     pdf_options.embed_text = false;
                     i += 1;
                 }
                 "--equation-font" | "--equation-font-family" => {
+                    compatibility_only_options.push("--equation-font");
                     if i + 1 < args.len() {
                         pdf_options.equation_font = Some(args[i + 1].clone());
                         i += 2;
@@ -1353,6 +1423,7 @@ fn export_pdf(args: &[String]) {
                 arg if arg.starts_with("--equation-font=")
                     || arg.starts_with("--equation-font-family=") =>
                 {
+                    compatibility_only_options.push("--equation-font");
                     pdf_options.equation_font = Some(
                         arg.strip_prefix("--equation-font=")
                             .or_else(|| arg.strip_prefix("--equation-font-family="))
@@ -1367,6 +1438,24 @@ fn export_pdf(args: &[String]) {
                     return;
                 }
             }
+        }
+
+        compatibility_only_options.sort_unstable();
+        compatibility_only_options.dedup();
+        if pdf_backend == rhwp::renderer::pdf::PdfBackend::DirectLayer
+            && !compatibility_only_options.is_empty()
+        {
+            eprintln!(
+                "오류: direct PDF backend는 다음 SVG 호환 옵션을 지원하지 않습니다: {}",
+                compatibility_only_options.join(", ")
+            );
+            return;
+        }
+        if pdf_backend == rhwp::renderer::pdf::PdfBackend::CompatibilitySvg
+            && direct_raster_dpi_was_set
+        {
+            eprintln!("오류: --raster-dpi는 direct PDF backend에서만 사용할 수 있습니다.");
+            return;
         }
 
         // 기본 출력 파일명
@@ -1422,11 +1511,33 @@ fn export_pdf(args: &[String]) {
             None => (0..page_count).collect(),
         };
 
-        let pdf_result = match render_profile {
-            Some(profile) => {
-                doc.render_pages_pdf_native_with_profile_and_options(&pages, profile, &pdf_options)
+        let pdf_result = match pdf_backend {
+            rhwp::renderer::pdf::PdfBackend::CompatibilitySvg => match render_profile {
+                Some(profile) => doc.render_pages_pdf_native_with_profile_and_options(
+                    &pages,
+                    profile,
+                    &pdf_options,
+                ),
+                None => doc.render_pages_pdf_native_with_options(&pages, &pdf_options),
+            },
+            rhwp::renderer::pdf::PdfBackend::DirectLayer => {
+                #[cfg(feature = "native-skia")]
+                {
+                    direct_pdf_options.font_paths = pdf_options.font_paths.clone();
+                    doc.render_pages_pdf_direct_native_with_profile_and_options(
+                        &pages,
+                        render_profile.unwrap_or(rhwp::paint::RenderProfile::Print),
+                        &direct_pdf_options,
+                    )
+                }
+                #[cfg(not(feature = "native-skia"))]
+                {
+                    Err(rhwp::error::HwpError::RenderError(
+                        "direct PDF backend requires a build with the native-skia feature"
+                            .to_string(),
+                    ))
+                }
             }
-            None => doc.render_pages_pdf_native_with_options(&pages, &pdf_options),
         };
         let pdf_bytes = match pdf_result {
             Ok(bytes) => bytes,
@@ -1445,6 +1556,9 @@ fn export_pdf(args: &[String]) {
             pdf_bytes.len() / 1024,
             pages.len()
         );
+        if pdf_backend == rhwp::renderer::pdf::PdfBackend::DirectLayer {
+            println!("PDF backend: direct");
+        }
         println!("PDF 내보내기 완료");
     }
 }
@@ -1453,14 +1567,17 @@ fn print_export_pdf_usage() {
     eprintln!("사용법: rhwp export-pdf <파일.hwp|파일.hwpx|파일.hml> [옵션]");
     eprintln!("  -o, --output <파일>       출력 PDF 파일");
     eprintln!("  -p, --page <번호>        특정 페이지만 내보내기 (0부터 시작)");
+    eprintln!("      --backend <svg|direct> PDF backend (기본값: svg)");
     eprintln!(
         "      --profile <프로필>   layer 출력 프로필 (screen|print|high-quality|fast-preview)"
     );
+    eprintln!("      --raster-dpi <DPI>    direct backend fallback raster DPI (기본값: 144)");
     eprintln!("      --font-path <경로>   폰트 파일 탐색 경로 (여러 번 지정 가능)");
     eprintln!("      --fallback-serif <명>");
     eprintln!("      --fallback-sans <명>");
     eprintln!("      --fallback-mono <명>");
     eprintln!("      --equation-font <명>");
+    eprintln!("  direct backend는 native-skia feature로 빌드한 native CLI가 필요합니다.");
     eprintln!("  참고: <...>는 자리표시자이며, 실제 입력에는 꺾쇠괄호를 쓰지 않습니다.");
     eprintln!("        공백 없는 값: --font-path ./ttfs");
     eprintln!(

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,7 +15,12 @@ fn main() {
         Some("export-render-tree") => export_render_tree(&args[2..]),
         Some("export-structure") => export_structure(&args[2..]),
         Some("export-png") => export_png(&args[2..]),
-        Some("export-pdf") => export_pdf(&args[2..]),
+        Some("export-pdf") => {
+            let exit_code = export_pdf(&args[2..]);
+            if exit_code != 0 {
+                process::exit(exit_code);
+            }
+        }
         Some("export-text") => export_text(&args[2..]),
         Some("export-markdown") => export_markdown(&args[2..]),
         Some("export-hwpx") => export_hwpx(&args[2..]),
@@ -1206,21 +1211,21 @@ fn export_png(args: &[String]) {
     );
 }
 
-fn export_pdf(args: &[String]) {
+fn export_pdf(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: 문서 파일 경로를 지정해주세요.");
         print_export_pdf_usage();
-        return;
+        return 2;
     }
     if args[0] == "--help" || args[0] == "-h" {
         print_export_pdf_usage();
-        return;
+        return 0;
     }
 
     #[cfg(target_arch = "wasm32")]
     {
         eprintln!("오류: PDF 내보내기는 native 빌드에서만 지원됩니다.");
-        return;
+        return 1;
     }
 
     #[cfg(not(target_arch = "wasm32"))]
@@ -1244,7 +1249,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --output 뒤에 파일 경로가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 "--page" | "-p" => {
@@ -1253,13 +1258,13 @@ fn export_pdf(args: &[String]) {
                             Ok(n) => target_page = Some(n),
                             Err(_) => {
                                 eprintln!("오류: 페이지 번호가 올바르지 않습니다.");
-                                return;
+                                return 2;
                             }
                         }
                         i += 2;
                     } else {
                         eprintln!("오류: --page 뒤에 페이지 번호가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 "--profile" => {
@@ -1269,12 +1274,12 @@ fn export_pdf(args: &[String]) {
                             eprintln!(
                                 "오류: --profile 값이 올바르지 않습니다 (screen|print|high-quality|fast-preview)."
                             );
-                            return;
+                            return 2;
                         }
                         i += 2;
                     } else {
                         eprintln!("오류: --profile 뒤에 프로필 이름이 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 "--backend" => {
@@ -1282,13 +1287,13 @@ fn export_pdf(args: &[String]) {
                         let Some(backend) = rhwp::renderer::pdf::PdfBackend::parse(&args[i + 1])
                         else {
                             eprintln!("오류: --backend 값이 올바르지 않습니다 (svg|direct).");
-                            return;
+                            return 2;
                         };
                         pdf_backend = backend;
                         i += 2;
                     } else {
                         eprintln!("오류: --backend 뒤에 backend 이름이 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--backend=") => {
@@ -1296,7 +1301,7 @@ fn export_pdf(args: &[String]) {
                         arg.trim_start_matches("--backend="),
                     ) else {
                         eprintln!("오류: --backend 값이 올바르지 않습니다 (svg|direct).");
-                        return;
+                        return 2;
                     };
                     pdf_backend = backend;
                     i += 1;
@@ -1305,29 +1310,29 @@ fn export_pdf(args: &[String]) {
                     if i + 1 < args.len() {
                         let Ok(raster_dpi) = args[i + 1].parse::<f32>() else {
                             eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
-                            return;
+                            return 2;
                         };
                         if !raster_dpi.is_finite() || raster_dpi <= 0.0 {
                             eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
-                            return;
+                            return 2;
                         }
                         direct_pdf_options.raster_dpi = raster_dpi;
                         direct_raster_dpi_was_set = true;
                         i += 2;
                     } else {
                         eprintln!("오류: --raster-dpi 뒤에 DPI 값이 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--raster-dpi=") => {
                     let Ok(raster_dpi) = arg.trim_start_matches("--raster-dpi=").parse::<f32>()
                     else {
                         eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
-                        return;
+                        return 2;
                     };
                     if !raster_dpi.is_finite() || raster_dpi <= 0.0 {
                         eprintln!("오류: --raster-dpi 값은 양수여야 합니다.");
-                        return;
+                        return 2;
                     }
                     direct_pdf_options.raster_dpi = raster_dpi;
                     direct_raster_dpi_was_set = true;
@@ -1341,7 +1346,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --font-path 뒤에 경로가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 "--fallback-serif" => {
@@ -1351,7 +1356,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --fallback-serif 뒤에 폰트 family가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--fallback-serif=") => {
@@ -1367,7 +1372,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --fallback-sans 뒤에 폰트 family가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--fallback-sans=")
@@ -1388,7 +1393,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --fallback-mono 뒤에 폰트 family가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--fallback-mono=")
@@ -1417,7 +1422,7 @@ fn export_pdf(args: &[String]) {
                         i += 2;
                     } else {
                         eprintln!("오류: --equation-font 뒤에 폰트 family가 필요합니다.");
-                        return;
+                        return 2;
                     }
                 }
                 arg if arg.starts_with("--equation-font=")
@@ -1435,7 +1440,7 @@ fn export_pdf(args: &[String]) {
                 _ => {
                     eprintln!("알 수 없는 옵션: {}", args[i]);
                     print_export_pdf_usage();
-                    return;
+                    return 2;
                 }
             }
         }
@@ -1449,13 +1454,13 @@ fn export_pdf(args: &[String]) {
                 "오류: direct PDF backend는 다음 SVG 호환 옵션을 지원하지 않습니다: {}",
                 compatibility_only_options.join(", ")
             );
-            return;
+            return 2;
         }
         if pdf_backend == rhwp::renderer::pdf::PdfBackend::CompatibilitySvg
             && direct_raster_dpi_was_set
         {
             eprintln!("오류: --raster-dpi는 direct PDF backend에서만 사용할 수 있습니다.");
-            return;
+            return 2;
         }
 
         // 기본 출력 파일명
@@ -1471,7 +1476,7 @@ fn export_pdf(args: &[String]) {
             Ok(d) => d,
             Err(e) => {
                 eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-                return;
+                return 1;
             }
         };
 
@@ -1479,19 +1484,23 @@ fn export_pdf(args: &[String]) {
             Ok(d) => d,
             Err(e) => {
                 eprintln!("오류: 문서 파싱 실패 - {}", e);
-                return;
+                return 1;
             }
         };
 
         let page_count = doc.page_count();
         println!("문서 로드 완료: {} ({}페이지)", file_path, page_count);
+        if page_count == 0 {
+            eprintln!("오류: PDF로 내보낼 페이지가 없습니다.");
+            return 1;
+        }
 
         // 출력 디렉토리 생성
         if let Some(parent) = Path::new(&output_file).parent() {
             if !parent.exists() {
                 if let Err(e) = fs::create_dir_all(parent) {
                     eprintln!("오류: 출력 디렉토리를 만들 수 없습니다 - {}", e);
-                    return;
+                    return 1;
                 }
             }
         }
@@ -1504,7 +1513,7 @@ fn export_pdf(args: &[String]) {
                         "오류: 페이지 번호가 범위를 벗어났습니다 (0~{})",
                         page_count - 1
                     );
-                    return;
+                    return 2;
                 }
                 vec![p]
             }
@@ -1543,12 +1552,12 @@ fn export_pdf(args: &[String]) {
             Ok(bytes) => bytes,
             Err(e) => {
                 eprintln!("오류: PDF 변환 실패 - {}", e);
-                return;
+                return 1;
             }
         };
         if let Err(e) = fs::write(&output_file, &pdf_bytes) {
             eprintln!("오류: PDF 저장 실패 - {}", e);
-            return;
+            return 1;
         }
         println!(
             "  → {} ({}KB, {}페이지)",
@@ -1560,6 +1569,7 @@ fn export_pdf(args: &[String]) {
             println!("PDF backend: direct");
         }
         println!("PDF 내보내기 완료");
+        0
     }
 }
 

--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -1,7 +1,368 @@
-//! PDF 렌더러 (Task #21)
+//! PDF renderers.
 //!
-//! SVG 렌더러의 출력을 svg2pdf + pdf-writer로 PDF를 생성한다.
-//! 단일/다중 페이지 모두 지원. 네이티브 전용 (WASM 미지원).
+//! The compatibility backend converts SVG output with svg2pdf/pdf-writer. The
+//! opt-in direct backend records PageLayerTree replay into a Skia PDF canvas.
+//! Both backends support single and multiple pages and are native-only.
+
+/// Native PDF implementation selected by callers such as `export-pdf`.
+#[cfg(not(target_arch = "wasm32"))]
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub enum PdfBackend {
+    /// Existing PageRenderTree/layered SVG -> svg2pdf compatibility path.
+    #[default]
+    CompatibilitySvg,
+    /// PageLayerTree -> Skia PDF recording path. Requires `native-skia`.
+    DirectLayer,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl PdfBackend {
+    pub fn parse(value: &str) -> Option<Self> {
+        match value.trim().to_ascii_lowercase().as_str() {
+            "svg" | "compat" | "compat-svg" | "compatibility" => Some(Self::CompatibilitySvg),
+            "direct" | "direct-layer" | "layer" | "layer-skia" | "skia" => Some(Self::DirectLayer),
+            _ => None,
+        }
+    }
+
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::CompatibilitySvg => "svg",
+            Self::DirectLayer => "direct",
+        }
+    }
+}
+
+/// Options specific to direct PageLayerTree PDF recording.
+#[cfg(not(target_arch = "wasm32"))]
+#[non_exhaustive]
+#[derive(Debug, Clone, PartialEq)]
+pub struct DirectPdfExportOptions {
+    /// Font directories loaded into the native Skia font manager.
+    pub font_paths: Vec<std::path::PathBuf>,
+    /// Raster resolution for effects that the PDF canvas cannot record as vectors.
+    pub raster_dpi: f32,
+    /// Optional deterministic document metadata. Dates are intentionally omitted.
+    pub title: Option<String>,
+    pub author: Option<String>,
+    pub subject: Option<String>,
+    pub keywords: Option<String>,
+}
+
+#[cfg(not(target_arch = "wasm32"))]
+impl Default for DirectPdfExportOptions {
+    fn default() -> Self {
+        Self {
+            font_paths: Vec::new(),
+            raster_dpi: 144.0,
+            title: None,
+            author: None,
+            subject: None,
+            keywords: None,
+        }
+    }
+}
+
+#[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+fn validate_direct_pdf_tree(
+    tree: &crate::paint::PageLayerTree,
+    page_index: usize,
+) -> Result<(), String> {
+    use crate::model::image::ImageEffect;
+    use crate::paint::{LayerNode, LayerNodeKind, PaintOp};
+    use crate::renderer::render_tree::{BoundingBox, ShapeTransform};
+    use crate::renderer::{ArrowStyle, LineRenderType, PathCommand, ShapeStyle};
+
+    fn is_valid_skia_scalar(value: f64) -> bool {
+        value.is_finite() && value.abs() <= f32::MAX as f64
+    }
+
+    fn validate_bbox(bbox: BoundingBox, page_index: usize, context: &str) -> Result<(), String> {
+        if [bbox.x, bbox.y, bbox.width, bbox.height]
+            .iter()
+            .any(|value| !is_valid_skia_scalar(*value))
+            || bbox.width < 0.0
+            || bbox.height < 0.0
+        {
+            return Err(format!(
+                "direct PDF page {} has invalid {context} bounds",
+                page_index + 1
+            ));
+        }
+        Ok(())
+    }
+
+    fn unsupported(page_index: usize, op: &str, detail: &str) -> String {
+        format!(
+            "direct PDF page {} cannot replay {op} without visual loss: {detail}; use the svg backend",
+            page_index + 1
+        )
+    }
+
+    fn validate_transform(
+        transform: ShapeTransform,
+        page_index: usize,
+        op: &str,
+    ) -> Result<(), String> {
+        if !is_valid_skia_scalar(transform.rotation) {
+            return Err(format!(
+                "direct PDF page {} has invalid {op} rotation",
+                page_index + 1
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_shape_style(
+        style: &ShapeStyle,
+        has_gradient: bool,
+        page_index: usize,
+        op: &str,
+    ) -> Result<(), String> {
+        if has_gradient {
+            return Err(unsupported(page_index, op, "gradient fill"));
+        }
+        if style.pattern.is_some() {
+            return Err(unsupported(page_index, op, "pattern fill"));
+        }
+        if style.shadow.is_some() {
+            return Err(unsupported(page_index, op, "shape shadow"));
+        }
+        if !is_valid_skia_scalar(style.opacity) || !(0.0..=1.0).contains(&style.opacity) {
+            return Err(format!(
+                "direct PDF page {} has invalid {op} opacity: {}",
+                page_index + 1,
+                style.opacity
+            ));
+        }
+        if !is_valid_skia_scalar(style.stroke_width) || style.stroke_width < 0.0 {
+            return Err(format!(
+                "direct PDF page {} has invalid {op} stroke width: {}",
+                page_index + 1,
+                style.stroke_width
+            ));
+        }
+        Ok(())
+    }
+
+    fn validate_node(node: &LayerNode, page_index: usize) -> Result<(), String> {
+        validate_bbox(node.bounds, page_index, "layer")?;
+        match &node.kind {
+            LayerNodeKind::Group { children, .. } => {
+                for child in children {
+                    validate_node(child, page_index)?;
+                }
+            }
+            LayerNodeKind::ClipRect { clip, child, .. } => {
+                validate_bbox(*clip, page_index, "clip")?;
+                validate_node(child, page_index)?;
+            }
+            LayerNodeKind::Leaf { ops } => {
+                for op in ops {
+                    validate_bbox(op.bounds(), page_index, "paint operation")?;
+                    match op {
+                        PaintOp::PageBackground { background, .. } => {
+                            if background.gradient.is_some() {
+                                return Err(unsupported(
+                                    page_index,
+                                    "page background",
+                                    "gradient fill",
+                                ));
+                            }
+                            if !is_valid_skia_scalar(background.border_width)
+                                || background.border_width < 0.0
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid page background border width",
+                                    page_index + 1
+                                ));
+                            }
+                            if let Some(image) = &background.image {
+                                if image.brightness != 0 || image.contrast != 0 {
+                                    return Err(unsupported(
+                                        page_index,
+                                        "page background image",
+                                        "unbaked brightness or contrast",
+                                    ));
+                                }
+                                if image.effect == ImageEffect::Pattern8x8 {
+                                    return Err(unsupported(
+                                        page_index,
+                                        "page background image",
+                                        "Pattern8x8 effect",
+                                    ));
+                                }
+                            }
+                        }
+                        PaintOp::Line { line, .. } => {
+                            validate_transform(line.transform, page_index, "line")?;
+                            if line.style.line_type != LineRenderType::Single
+                                || line.style.start_arrow != ArrowStyle::None
+                                || line.style.end_arrow != ArrowStyle::None
+                                || line.style.shadow.is_some()
+                            {
+                                return Err(unsupported(
+                                    page_index,
+                                    "line",
+                                    "multi-line, arrow, or shadow style",
+                                ));
+                            }
+                            if [line.x1, line.y1, line.x2, line.y2, line.style.width]
+                                .iter()
+                                .any(|value| !is_valid_skia_scalar(*value))
+                                || line.style.width < 0.0
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid line geometry",
+                                    page_index + 1
+                                ));
+                            }
+                        }
+                        PaintOp::Rectangle { rect, .. } => {
+                            validate_transform(rect.transform, page_index, "rectangle")?;
+                            if !is_valid_skia_scalar(rect.corner_radius) || rect.corner_radius < 0.0
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid rectangle corner radius",
+                                    page_index + 1
+                                ));
+                            }
+                            validate_shape_style(
+                                &rect.style,
+                                rect.gradient.is_some(),
+                                page_index,
+                                "rectangle",
+                            )?;
+                        }
+                        PaintOp::Ellipse { ellipse, .. } => {
+                            validate_transform(ellipse.transform, page_index, "ellipse")?;
+                            validate_shape_style(
+                                &ellipse.style,
+                                ellipse.gradient.is_some(),
+                                page_index,
+                                "ellipse",
+                            )?;
+                        }
+                        PaintOp::Path { path, .. } => {
+                            validate_transform(path.transform, page_index, "path")?;
+                            validate_shape_style(
+                                &path.style,
+                                path.gradient.is_some(),
+                                page_index,
+                                "path",
+                            )?;
+                            if path.connector_endpoints.is_some() || path.line_style.is_some() {
+                                return Err(unsupported(
+                                    page_index,
+                                    "path",
+                                    "connector line style",
+                                ));
+                            }
+                            let finite = path.commands.iter().all(|command| match *command {
+                                PathCommand::MoveTo(x, y) | PathCommand::LineTo(x, y) => {
+                                    is_valid_skia_scalar(x) && is_valid_skia_scalar(y)
+                                }
+                                PathCommand::CurveTo(x1, y1, x2, y2, x, y) => {
+                                    [x1, y1, x2, y2, x, y]
+                                        .iter()
+                                        .all(|value| is_valid_skia_scalar(*value))
+                                }
+                                PathCommand::ArcTo(rx, ry, rotation, _, _, x, y) => {
+                                    [rx, ry, rotation, x, y]
+                                        .iter()
+                                        .all(|value| is_valid_skia_scalar(*value))
+                                }
+                                PathCommand::ClosePath => true,
+                            });
+                            if !finite {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid path geometry",
+                                    page_index + 1
+                                ));
+                            }
+                        }
+                        PaintOp::Image {
+                            image, resolved, ..
+                        } => {
+                            validate_transform(image.transform, page_index, "image")?;
+                            let effects_are_baked = resolved
+                                .as_deref()
+                                .is_some_and(|payload| payload.suppress_effects);
+                            if !effects_are_baked && (image.brightness != 0 || image.contrast != 0)
+                            {
+                                return Err(unsupported(
+                                    page_index,
+                                    "image",
+                                    "unbaked brightness or contrast",
+                                ));
+                            }
+                            if !effects_are_baked && image.effect == ImageEffect::Pattern8x8 {
+                                return Err(unsupported(page_index, "image", "Pattern8x8 effect"));
+                            }
+                            if !is_valid_skia_scalar(image.opacity)
+                                || !(0.0..=1.0).contains(&image.opacity)
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid image opacity: {}",
+                                    page_index + 1,
+                                    image.opacity
+                                ));
+                            }
+                        }
+                        PaintOp::TextRun { run, .. } => {
+                            if [
+                                run.baseline,
+                                run.rotation,
+                                run.style.font_size,
+                                run.style.letter_spacing,
+                                run.style.ratio,
+                            ]
+                            .iter()
+                            .any(|value| !is_valid_skia_scalar(*value))
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid text geometry",
+                                    page_index + 1
+                                ));
+                            }
+                        }
+                        PaintOp::FootnoteMarker { marker, .. } => {
+                            if !is_valid_skia_scalar(marker.base_font_size) {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid footnote marker font size",
+                                    page_index + 1
+                                ));
+                            }
+                        }
+                        PaintOp::Equation { equation, .. } => {
+                            if !is_valid_skia_scalar(equation.font_size)
+                                || !is_valid_skia_scalar(equation.layout_box.width)
+                                || !is_valid_skia_scalar(equation.layout_box.height)
+                            {
+                                return Err(format!(
+                                    "direct PDF page {} has invalid equation geometry",
+                                    page_index + 1
+                                ));
+                            }
+                        }
+                        PaintOp::GlyphRun { .. }
+                        | PaintOp::GlyphOutline { .. }
+                        | PaintOp::CharOverlap { .. }
+                        | PaintOp::TextControlMark { .. }
+                        | PaintOp::TabLeader { .. }
+                        | PaintOp::TextDecoration { .. }
+                        | PaintOp::FormObject { .. }
+                        | PaintOp::Placeholder { .. }
+                        | PaintOp::RawSvg { .. } => {}
+                    }
+                }
+            }
+        }
+        Ok(())
+    }
+
+    validate_node(&tree.root, page_index)
+}
 
 /// PDF 내보내기 폰트 설정.
 ///
@@ -419,9 +780,114 @@ pub fn svgs_to_pdf_with_options(
     Ok(pdf.finish())
 }
 
+/// Record PageLayerTree pages directly into a native Skia PDF document.
+#[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+pub fn layer_trees_to_pdf(layer_trees: &[crate::paint::PageLayerTree]) -> Result<Vec<u8>, String> {
+    layer_trees_to_pdf_with_options(layer_trees, &DirectPdfExportOptions::default())
+}
+
+/// Record PageLayerTree pages directly into a native Skia PDF document.
+///
+/// PageLayerTree coordinates are CSS pixels at 96 DPI. PDF page coordinates
+/// are points at 72 DPI, so the page and canvas are scaled by 72/96. Skia keeps
+/// text, paths, and supported effects as vector commands and uses `raster_dpi`
+/// for effects without a native PDF representation.
+#[cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+pub fn layer_trees_to_pdf_with_options(
+    layer_trees: &[crate::paint::PageLayerTree],
+    options: &DirectPdfExportOptions,
+) -> Result<Vec<u8>, String> {
+    const CSS_PX_TO_PDF_POINT: f64 = 72.0 / 96.0;
+    const MAX_PDF_PAGE_DIMENSION_POINTS: f64 = 14_400.0;
+
+    if layer_trees.is_empty() {
+        return Err("direct PDF export requires at least one page".to_string());
+    }
+    if !options.raster_dpi.is_finite() || options.raster_dpi <= 0.0 {
+        return Err(format!(
+            "invalid direct PDF raster dpi: {}",
+            options.raster_dpi
+        ));
+    }
+
+    let page_dimension = |value: f64, label: &str| -> Result<f32, String> {
+        let points = value * CSS_PX_TO_PDF_POINT;
+        if !points.is_finite() || points <= 0.0 {
+            return Err(format!("invalid direct PDF page {label}: {value}"));
+        }
+        if points > MAX_PDF_PAGE_DIMENSION_POINTS {
+            return Err(format!(
+                "direct PDF page {label} exceeds {MAX_PDF_PAGE_DIMENSION_POINTS} points: {points}"
+            ));
+        }
+        Ok(points as f32)
+    };
+
+    let page_sizes = layer_trees
+        .iter()
+        .enumerate()
+        .map(|(page_index, tree)| {
+            validate_direct_pdf_tree(tree, page_index)?;
+            Ok((
+                page_dimension(tree.page_width, "width")?,
+                page_dimension(tree.page_height, "height")?,
+            ))
+        })
+        .collect::<Result<Vec<_>, String>>()?;
+
+    let metadata = skia_safe::pdf::Metadata {
+        title: options.title.clone().unwrap_or_default(),
+        author: options.author.clone().unwrap_or_default(),
+        subject: options.subject.clone().unwrap_or_default(),
+        keywords: options.keywords.clone().unwrap_or_default(),
+        creator: "rhwp".to_string(),
+        producer: "rhwp PageLayerTree direct PDF (Skia)".to_string(),
+        raster_dpi: Some(options.raster_dpi),
+        ..Default::default()
+    };
+    let renderer = crate::renderer::skia::SkiaLayerRenderer::new()
+        .with_font_paths(options.font_paths.as_slice());
+    let mut output = Vec::new();
+
+    {
+        let mut document = skia_safe::pdf::new_document(&mut output, Some(&metadata));
+        for (tree, &(width, height)) in layer_trees.iter().zip(page_sizes.iter()) {
+            let mut page = document.begin_page((width, height), None);
+            let canvas = page.canvas();
+            canvas.clear(skia_safe::Color::WHITE);
+            canvas.scale((CSS_PX_TO_PDF_POINT as f32, CSS_PX_TO_PDF_POINT as f32));
+            renderer
+                .render_page_to_canvas_strict(canvas, tree, options.raster_dpi / 96.0)
+                .map_err(|error| format!("direct PDF page replay failed: {error}"))?;
+            document = page.end_page();
+        }
+        document.close();
+    }
+
+    if !output.starts_with(b"%PDF-") || !output.windows(5).any(|window| window == b"%%EOF") {
+        return Err("Skia direct PDF writer returned an incomplete document".to_string());
+    }
+    Ok(output)
+}
+
 #[cfg(all(test, not(target_arch = "wasm32")))]
 mod tests {
     use super::*;
+
+    #[test]
+    fn pdf_backend_aliases_are_explicit() {
+        assert_eq!(PdfBackend::default(), PdfBackend::CompatibilitySvg);
+        assert_eq!(PdfBackend::parse("svg"), Some(PdfBackend::CompatibilitySvg));
+        assert_eq!(
+            PdfBackend::parse("compat"),
+            Some(PdfBackend::CompatibilitySvg)
+        );
+        assert_eq!(PdfBackend::parse("direct"), Some(PdfBackend::DirectLayer));
+        assert_eq!(PdfBackend::parse("skia"), Some(PdfBackend::DirectLayer));
+        assert_eq!(PdfBackend::parse("unknown"), None);
+        assert_eq!(PdfBackend::CompatibilitySvg.as_str(), "svg");
+        assert_eq!(PdfBackend::DirectLayer.as_str(), "direct");
+    }
 
     #[test]
     fn default_pdf_font_options_are_os_specific_and_non_empty() {
@@ -459,5 +925,185 @@ mod tests {
     fn equation_font_accepts_full_family_chain() {
         let chain = equation_font_chain("'Custom Math', 'Fallback Math', serif");
         assert_eq!(chain, "'Custom Math', 'Fallback Math', serif");
+    }
+
+    #[cfg(feature = "native-skia")]
+    fn direct_pdf_test_tree(
+        width: f64,
+        height: f64,
+        fill_color: crate::model::ColorRef,
+    ) -> crate::paint::PageLayerTree {
+        use crate::paint::{LayerNode, PaintOp, RenderProfile};
+        use crate::renderer::render_tree::{BoundingBox, RectangleNode};
+        use crate::renderer::ShapeStyle;
+
+        let page_bounds = BoundingBox::new(0.0, 0.0, width, height);
+        let rectangle = RectangleNode::new(
+            0.0,
+            ShapeStyle {
+                fill_color: Some(fill_color),
+                ..Default::default()
+            },
+            None,
+        );
+        crate::paint::PageLayerTree::with_profile(
+            width,
+            height,
+            LayerNode::leaf(
+                page_bounds,
+                None,
+                vec![PaintOp::rectangle(
+                    BoundingBox::new(8.0, 8.0, width - 16.0, height - 16.0),
+                    rectangle,
+                )],
+            ),
+            RenderProfile::Print,
+        )
+    }
+
+    #[cfg(feature = "native-skia")]
+    #[test]
+    fn skia_direct_pdf_records_multiple_layer_pages() {
+        let pages = [
+            direct_pdf_test_tree(96.0, 144.0, 0x000000ff),
+            direct_pdf_test_tree(192.0, 96.0, 0x0000ff00),
+        ];
+        let options = DirectPdfExportOptions {
+            title: Some("P37 direct PDF test".to_string()),
+            ..Default::default()
+        };
+
+        let pdf = layer_trees_to_pdf_with_options(&pages, &options).unwrap();
+
+        assert!(pdf.starts_with(b"%PDF-"));
+        assert!(pdf.windows(5).any(|window| window == b"%%EOF"));
+        assert!(pdf
+            .windows(b"P37 direct PDF test".len())
+            .any(|window| window == b"P37 direct PDF test"));
+        assert!(pdf
+            .windows(b"/Count 2".len())
+            .any(|window| window == b"/Count 2"));
+        assert!(pdf
+            .windows(b"/MediaBox [0 0 72 108]".len())
+            .any(|window| window == b"/MediaBox [0 0 72 108]"));
+        assert!(pdf
+            .windows(b"/MediaBox [0 0 144 72]".len())
+            .any(|window| window == b"/MediaBox [0 0 144 72]"));
+        assert!(!pdf
+            .windows(b"/Subtype /Image".len())
+            .any(|window| window == b"/Subtype /Image"));
+    }
+
+    #[cfg(feature = "native-skia")]
+    #[test]
+    fn skia_direct_pdf_rejects_invalid_export_inputs() {
+        assert_eq!(
+            layer_trees_to_pdf(&[]).unwrap_err(),
+            "direct PDF export requires at least one page"
+        );
+
+        let valid = direct_pdf_test_tree(96.0, 96.0, 0x000000ff);
+        for raster_dpi in [0.0, -1.0, f32::NAN, f32::INFINITY] {
+            let options = DirectPdfExportOptions {
+                raster_dpi,
+                ..Default::default()
+            };
+            assert!(
+                layer_trees_to_pdf_with_options(std::slice::from_ref(&valid), &options)
+                    .unwrap_err()
+                    .contains("invalid direct PDF raster dpi")
+            );
+        }
+
+        for invalid in [
+            direct_pdf_test_tree(0.0, 96.0, 0x000000ff),
+            direct_pdf_test_tree(f64::NAN, 96.0, 0x000000ff),
+            direct_pdf_test_tree(20_000.0, 96.0, 0x000000ff),
+        ] {
+            assert!(layer_trees_to_pdf(std::slice::from_ref(&invalid)).is_err());
+        }
+
+        let mut oversized_layer = direct_pdf_test_tree(96.0, 96.0, 0x000000ff);
+        oversized_layer.root.bounds.x = f32::MAX as f64 * 2.0;
+        assert!(layer_trees_to_pdf(&[oversized_layer])
+            .unwrap_err()
+            .contains("invalid layer bounds"));
+    }
+
+    #[cfg(feature = "native-skia")]
+    #[test]
+    fn skia_direct_pdf_rejects_known_lossy_shape_replay() {
+        use crate::paint::{LayerNode, PaintOp, RenderProfile};
+        use crate::renderer::render_tree::{BoundingBox, RectangleNode};
+        use crate::renderer::{GradientFillInfo, ShapeStyle};
+
+        let bbox = BoundingBox::new(0.0, 0.0, 96.0, 96.0);
+        let gradient = GradientFillInfo {
+            gradient_type: 1,
+            angle: 0,
+            center_x: 50,
+            center_y: 50,
+            colors: vec![0x000000ff, 0x00ff0000],
+            positions: vec![0.0, 1.0],
+        };
+        let tree = crate::paint::PageLayerTree::with_profile(
+            96.0,
+            96.0,
+            LayerNode::leaf(
+                bbox,
+                None,
+                vec![PaintOp::rectangle(
+                    bbox,
+                    RectangleNode::new(0.0, ShapeStyle::default(), Some(Box::new(gradient))),
+                )],
+            ),
+            RenderProfile::Print,
+        );
+
+        let error = layer_trees_to_pdf(&[tree]).unwrap_err();
+        assert!(error.contains("gradient fill"), "unexpected error: {error}");
+        assert!(error.contains("use the svg backend"));
+    }
+
+    #[cfg(feature = "native-skia")]
+    #[test]
+    fn skia_direct_pdf_raw_svg_fallback_is_strict_and_uses_requested_dpi() {
+        use crate::paint::{LayerNode, PaintOp, RenderProfile};
+        use crate::renderer::render_tree::{BoundingBox, RawSvgNode};
+
+        let page_bounds = BoundingBox::new(0.0, 0.0, 96.0, 96.0);
+        let svg_bounds = BoundingBox::new(8.0, 8.0, 32.0, 16.0);
+        let tree_with_svg = |svg: &str| {
+            crate::paint::PageLayerTree::with_profile(
+                96.0,
+                96.0,
+                LayerNode::leaf(
+                    page_bounds,
+                    None,
+                    vec![PaintOp::raw_svg(
+                        svg_bounds,
+                        RawSvgNode::new(svg.to_string()),
+                    )],
+                ),
+                RenderProfile::Print,
+            )
+        };
+
+        let invalid = layer_trees_to_pdf(&[tree_with_svg("<path")]).unwrap_err();
+        assert!(invalid.contains("raw SVG raster fallback failed"));
+
+        let options = DirectPdfExportOptions {
+            raster_dpi: 192.0,
+            ..Default::default()
+        };
+        let pdf = layer_trees_to_pdf_with_options(
+            &[tree_with_svg(
+                r##"<rect x="8" y="8" width="32" height="16" fill="#f00"/>"##,
+            )],
+            &options,
+        )
+        .unwrap();
+        assert!(pdf.windows(9).any(|window| window == b"/Width 64"));
+        assert!(pdf.windows(10).any(|window| window == b"/Height 32"));
     }
 }

--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -145,6 +145,30 @@ fn validate_direct_pdf_tree(
         Ok(())
     }
 
+    fn validate_image_payload(data: &[u8], page_index: usize, context: &str) -> Result<(), String> {
+        let format = match crate::renderer::image_resolver::detect_image_mime_type(data) {
+            "image/png" => image::ImageFormat::Png,
+            "image/jpeg" => image::ImageFormat::Jpeg,
+            "image/gif" => image::ImageFormat::Gif,
+            "image/bmp" => image::ImageFormat::Bmp,
+            "image/tiff" => image::ImageFormat::Tiff,
+            format => {
+                return Err(format!(
+                    "direct PDF page {} does not support {context} payload format {format}; use the svg backend",
+                    page_index + 1
+                ));
+            }
+        };
+        image::load_from_memory_with_format(data, format)
+            .map(|_| ())
+            .map_err(|error| {
+                format!(
+                    "direct PDF page {} cannot decode {context} payload: {error}",
+                    page_index + 1
+                )
+            })
+    }
+
     fn validate_node(node: &LayerNode, page_index: usize) -> Result<(), String> {
         validate_bbox(node.bounds, page_index, "layer")?;
         match &node.kind {
@@ -178,6 +202,11 @@ fn validate_direct_pdf_tree(
                                 ));
                             }
                             if let Some(image) = &background.image {
+                                validate_image_payload(
+                                    &image.data,
+                                    page_index,
+                                    "page background image",
+                                )?;
                                 if image.brightness != 0 || image.contrast != 0 {
                                     return Err(unsupported(
                                         page_index,
@@ -285,6 +314,13 @@ fn validate_direct_pdf_tree(
                             image, resolved, ..
                         } => {
                             validate_transform(image.transform, page_index, "image")?;
+                            if let Some(data) = resolved
+                                .as_deref()
+                                .map(|payload| payload.data.as_slice())
+                                .or(image.data.as_deref())
+                            {
+                                validate_image_payload(data, page_index, "image")?;
+                            }
                             let effects_are_baked = resolved
                                 .as_deref()
                                 .is_some_and(|payload| payload.suppress_effects);
@@ -1028,6 +1064,103 @@ mod tests {
         assert!(layer_trees_to_pdf(&[oversized_layer])
             .unwrap_err()
             .contains("invalid layer bounds"));
+    }
+
+    #[cfg(feature = "native-skia")]
+    #[test]
+    fn skia_direct_pdf_rejects_corrupt_and_unvalidated_images() {
+        use crate::paint::{LayerNode, PaintOp, RenderProfile};
+        use crate::renderer::render_tree::{BoundingBox, ImageNode};
+        use image::{ImageFormat, Rgb, RgbImage};
+        use std::io::Cursor;
+
+        let image = RgbImage::from_fn(64, 64, |x, y| {
+            Rgb([
+                (x.wrapping_mul(17) ^ y.wrapping_mul(31)) as u8,
+                (x.wrapping_mul(47).wrapping_add(y.wrapping_mul(13))) as u8,
+                (x.wrapping_mul(7) ^ y.wrapping_mul(53)) as u8,
+            ])
+        });
+        let mut cursor = Cursor::new(Vec::new());
+        image
+            .write_to(&mut cursor, ImageFormat::Png)
+            .expect("encode test PNG");
+        let mut corrupt_png = cursor.into_inner();
+        let idat_type_offset = corrupt_png
+            .windows(4)
+            .position(|window| window == b"IDAT")
+            .expect("encoded PNG must contain IDAT");
+        corrupt_png[idat_type_offset + 4] ^= 0xff;
+        assert!(
+            skia_safe::Image::from_encoded(skia_safe::Data::new_copy(&corrupt_png)).is_some(),
+            "fixture must pass Skia's encoded-header check"
+        );
+        assert!(
+            image::load_from_memory_with_format(&corrupt_png, ImageFormat::Png).is_err(),
+            "fixture must fail strict PNG decoding"
+        );
+
+        let page_bounds = BoundingBox::new(0.0, 0.0, 96.0, 96.0);
+        let tree = crate::paint::PageLayerTree::with_profile(
+            96.0,
+            96.0,
+            LayerNode::leaf(
+                page_bounds,
+                None,
+                vec![PaintOp::image(
+                    BoundingBox::new(8.0, 8.0, 32.0, 32.0),
+                    ImageNode::new(1, Some(corrupt_png)),
+                    None,
+                )],
+            ),
+            RenderProfile::Print,
+        );
+
+        let error = layer_trees_to_pdf(&[tree]).unwrap_err();
+        assert!(
+            error.contains("cannot decode image payload"),
+            "unexpected error: {error}"
+        );
+
+        let malformed_gif = crate::paint::PageLayerTree::with_profile(
+            96.0,
+            96.0,
+            LayerNode::leaf(
+                page_bounds,
+                None,
+                vec![PaintOp::image(
+                    BoundingBox::new(8.0, 8.0, 32.0, 32.0),
+                    ImageNode::new(2, Some(b"GIF89a\x01\x00\x01\x00\x80\x00\x00".to_vec())),
+                    None,
+                )],
+            ),
+            RenderProfile::Print,
+        );
+        let error = layer_trees_to_pdf(&[malformed_gif]).unwrap_err();
+        assert!(
+            error.contains("cannot decode image payload"),
+            "unexpected error: {error}"
+        );
+
+        let unsupported = crate::paint::PageLayerTree::with_profile(
+            96.0,
+            96.0,
+            LayerNode::leaf(
+                page_bounds,
+                None,
+                vec![PaintOp::image(
+                    BoundingBox::new(8.0, 8.0, 32.0, 32.0),
+                    ImageNode::new(3, Some(b"unrecognized image payload".to_vec())),
+                    None,
+                )],
+            ),
+            RenderProfile::Print,
+        );
+        let error = layer_trees_to_pdf(&[unsupported]).unwrap_err();
+        assert!(
+            error.contains("does not support image payload format application/octet-stream"),
+            "unexpected error: {error}"
+        );
     }
 
     #[cfg(feature = "native-skia")]

--- a/src/renderer/skia/image_conv.rs
+++ b/src/renderer/skia/image_conv.rs
@@ -39,12 +39,14 @@ pub fn draw_svg_fragment(
     width: f32,
     height: f32,
     sampling: ImageSampling,
+    raster_scale: f32,
 ) -> bool {
     // [Issue #2292] RawSvg 조각은 페이지 절대 좌표로 방출된다(SVG 백엔드
     // 직접 삽입·web_canvas 와 동일 계약). viewBox 원점에 조각의 페이지
     // 위치(x, y)를 넘겨 bbox 창만 래스터한다 — (0,0) 가정 시 창 밖 콘텐츠
     // 전부 클리핑 + bbox 재배치 이중 오프셋으로 차트가 잘렸다.
-    let Some(png) = rasterize_svg_fragment_to_png(svg_fragment, x, y, width, height) else {
+    let Some(png) = rasterize_svg_fragment_to_png(svg_fragment, x, y, width, height, raster_scale)
+    else {
         return false;
     };
     draw_image_bytes(
@@ -59,8 +61,7 @@ pub fn draw_svg_fragment(
         None,
         ImageEffect::RealPic,
         sampling,
-    );
-    true
+    )
 }
 
 pub fn draw_image_bytes(
@@ -75,7 +76,7 @@ pub fn draw_image_bytes(
     crop: Option<(i32, i32, i32, i32)>,
     effect: ImageEffect,
     sampling: ImageSampling,
-) {
+) -> bool {
     let is_valid_destination_rect = |x: f32, y: f32, width: f32, height: f32| {
         x.is_finite()
             && y.is_finite()
@@ -149,7 +150,7 @@ pub fn draw_image_bytes(
     };
 
     if !is_valid_destination_rect(x, y, width, height) {
-        return;
+        return false;
     }
     let normalized_bytes = if detect_image_mime_type(bytes) == "image/jpeg" {
         grayscale_jpeg_bytes_to_png_bytes(bytes)
@@ -160,7 +161,7 @@ pub fn draw_image_bytes(
 
     let Some(image) = Image::from_encoded(Data::new_copy(encoded_bytes)) else {
         draw_missing_image_placeholder(x, y, width, height);
-        return;
+        return false;
     };
 
     let dst = Rect::from_xywh(x, y, width, height);
@@ -219,7 +220,7 @@ pub fn draw_image_bytes(
 
     if matches!(mode, ImageFillMode::FitToSize | ImageFillMode::None) {
         draw_image_rect(crop_src, dst);
-        return;
+        return true;
     }
 
     let image_width = original_size
@@ -230,7 +231,7 @@ pub fn draw_image_bytes(
         .unwrap_or_else(|| image.height() as f32);
     if !is_valid_image_size(image_width, image_height) {
         draw_missing_image_placeholder(x, y, width, height);
-        return;
+        return false;
     }
 
     canvas.save();
@@ -293,7 +294,7 @@ pub fn draw_image_bytes(
             && draw_tiled_shader(dst, x, y)
         {
             canvas.restore();
-            return;
+            return true;
         }
         if matches!(
             mode,
@@ -306,7 +307,7 @@ pub fn draw_image_bytes(
             };
             if draw_tiled_shader(Rect::from_xywh(x, tile_y, width, image_height), x, tile_y) {
                 canvas.restore();
-                return;
+                return true;
             }
         }
         if matches!(
@@ -320,9 +321,11 @@ pub fn draw_image_bytes(
             };
             if draw_tiled_shader(Rect::from_xywh(tile_x, y, image_width, height), tile_x, y) {
                 canvas.restore();
-                return;
+                return true;
             }
         }
+        canvas.restore();
+        return false;
     } else {
         let (image_x, image_y) =
             resolve_image_placement(mode, x, y, width, height, image_width, image_height);
@@ -333,6 +336,7 @@ pub fn draw_image_bytes(
     }
 
     canvas.restore();
+    true
 }
 
 fn rasterize_svg_fragment_to_png(
@@ -341,6 +345,7 @@ fn rasterize_svg_fragment_to_png(
     src_y: f32,
     width: f32,
     height: f32,
+    raster_scale: f32,
 ) -> Option<Vec<u8>> {
     if svg_fragment.is_empty()
         || svg_fragment.len() > MAX_SVG_FRAGMENT_BYTES
@@ -348,13 +353,17 @@ fn rasterize_svg_fragment_to_png(
         || !src_y.is_finite()
         || !width.is_finite()
         || !height.is_finite()
+        || !raster_scale.is_finite()
         || width <= 0.0
         || height <= 0.0
+        || raster_scale <= 0.0
     {
         return None;
     }
-    let raster_width = width.ceil() as u64;
-    let raster_height = height.ceil() as u64;
+    let output_width = width * raster_scale;
+    let output_height = height * raster_scale;
+    let raster_width = output_width.ceil() as u64;
+    let raster_height = output_height.ceil() as u64;
     if raster_width
         .checked_mul(raster_height)
         .is_none_or(|pixels| pixels > MAX_SVG_RASTER_PIXELS)
@@ -365,7 +374,7 @@ fn rasterize_svg_fragment_to_png(
     // [Issue #2292] 조각은 페이지 절대 좌표 — viewBox 를 조각의 페이지 좌표
     // 창(src_x, src_y 원점)으로 지정해 bbox 영역만 (0,0) 래스터로 사상한다.
     let svg = format!(
-        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{width:.2}\" height=\"{height:.2}\" viewBox=\"{src_x:.2} {src_y:.2} {width:.2} {height:.2}\">{svg_fragment}</svg>"
+        "<svg xmlns=\"http://www.w3.org/2000/svg\" width=\"{output_width:.2}\" height=\"{output_height:.2}\" viewBox=\"{src_x:.2} {src_y:.2} {width:.2} {height:.2}\">{svg_fragment}</svg>"
     );
     let options = svg_parse_options();
     let tree = usvg::Tree::from_str(&svg, &options).ok()?;

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -415,22 +415,7 @@ impl SkiaLayerRenderer {
             canvas.scale((options.scale as f32, options.scale as f32));
         }
 
-        let mut next_text_source_id = 0_u32;
-        for replay_plane in PaintReplayPlane::ORDERED {
-            if !layer_node_has_replay_plane(&tree.root, replay_plane) {
-                continue;
-            }
-            self.render_node(
-                canvas,
-                &tree.root,
-                &tree.output_options,
-                &tree.resources,
-                replay_plane,
-                None,
-                tree.profile.shows_editor_visuals(),
-                &mut next_text_source_id,
-            );
-        }
+        self.render_page_to_canvas_with_options(canvas, tree, options.scale as f32, false)?;
 
         let image = surface.image_snapshot();
         let mut png_options = png_encoder::Options::default();
@@ -453,6 +438,54 @@ impl SkiaLayerRenderer {
         })
     }
 
+    /// Replay a page into an existing Skia canvas.
+    ///
+    /// Raster surfaces and vector recording surfaces must consume the same
+    /// replay-plane, clip, text-variant, and fallback policy. Surface setup
+    /// such as clearing, CSS-pixel scaling, and page finalization remains the
+    /// caller's responsibility.
+    pub(crate) fn render_page_to_canvas_strict(
+        &self,
+        canvas: &Canvas,
+        tree: &PageLayerTree,
+        fallback_raster_scale: f32,
+    ) -> LayerRenderResult<()> {
+        self.render_page_to_canvas_with_options(canvas, tree, fallback_raster_scale, true)
+    }
+
+    fn render_page_to_canvas_with_options(
+        &self,
+        canvas: &Canvas,
+        tree: &PageLayerTree,
+        fallback_raster_scale: f32,
+        strict_resource_failures: bool,
+    ) -> LayerRenderResult<()> {
+        if !fallback_raster_scale.is_finite() || fallback_raster_scale <= 0.0 {
+            return Err(HwpError::RenderError(format!(
+                "invalid Skia fallback raster scale: {fallback_raster_scale}"
+            )));
+        }
+        let mut next_text_source_id = 0_u32;
+        for replay_plane in PaintReplayPlane::ORDERED {
+            if !layer_node_has_replay_plane(&tree.root, replay_plane) {
+                continue;
+            }
+            self.render_node(
+                canvas,
+                &tree.root,
+                &tree.output_options,
+                &tree.resources,
+                replay_plane,
+                None,
+                tree.profile.shows_editor_visuals(),
+                &mut next_text_source_id,
+                fallback_raster_scale,
+                strict_resource_failures,
+            )?;
+        }
+        Ok(())
+    }
+
     fn render_node(
         &self,
         canvas: &Canvas,
@@ -463,7 +496,9 @@ impl SkiaLayerRenderer {
         inherited_layer: Option<RenderLayerInfo>,
         show_editor_placeholders: bool,
         next_text_source_id: &mut u32,
-    ) {
+        fallback_raster_scale: f32,
+        strict_resource_failures: bool,
+    ) -> LayerRenderResult<()> {
         let active_layer = node.layer.or(inherited_layer);
         let clip_enabled = output_options.clip_enabled;
         let apply_dash = |paint: &mut Paint, dash: StrokeDash| {
@@ -574,7 +609,7 @@ impl SkiaLayerRenderer {
                 crop,
                 effect,
                 ImageSampling::linear(),
-            );
+            )
         };
         let text_replay = SkiaTextReplay {
             canvas,
@@ -614,12 +649,14 @@ impl SkiaLayerRenderer {
                         active_layer,
                         show_editor_placeholders,
                         next_text_source_id,
-                    );
+                        fallback_raster_scale,
+                        strict_resource_failures,
+                    )?;
                 }
             }
             LayerNodeKind::ClipRect { clip, child, .. } => {
                 if !clip_enabled {
-                    self.render_node(
+                    return self.render_node(
                         canvas,
                         child,
                         output_options,
@@ -628,8 +665,9 @@ impl SkiaLayerRenderer {
                         active_layer,
                         show_editor_placeholders,
                         next_text_source_id,
+                        fallback_raster_scale,
+                        strict_resource_failures,
                     );
-                    return;
                 }
                 canvas.save();
                 canvas.clip_rect(
@@ -642,7 +680,7 @@ impl SkiaLayerRenderer {
                     None,
                     Some(true),
                 );
-                self.render_node(
+                let result = self.render_node(
                     canvas,
                     child,
                     output_options,
@@ -651,8 +689,11 @@ impl SkiaLayerRenderer {
                     active_layer,
                     show_editor_placeholders,
                     next_text_source_id,
+                    fallback_raster_scale,
+                    strict_resource_failures,
                 );
                 canvas.restore();
+                result?;
             }
             LayerNodeKind::Leaf { ops } => {
                 let mut variant_order = 0usize;
@@ -767,7 +808,7 @@ impl SkiaLayerRenderer {
                                     let alpha = (255.0 * wm_opacity).round() as u32;
                                     canvas.save_layer_alpha(Some(rect), alpha);
                                 }
-                                draw_image(
+                                let rendered = draw_image(
                                     &image.data,
                                     *bbox,
                                     Some(image.fill_mode),
@@ -777,6 +818,11 @@ impl SkiaLayerRenderer {
                                 );
                                 if is_watermark {
                                     canvas.restore();
+                                }
+                                if !rendered && strict_resource_failures {
+                                    return Err(HwpError::RenderError(
+                                        "Skia page background image decode failed".to_string(),
+                                    ));
                                 }
                             }
                             if let Some(color) = background.border_color {
@@ -1024,8 +1070,9 @@ impl SkiaLayerRenderer {
                             image,
                             resolved,
                         } => {
+                            let effective_bbox = image.transform.effective_image_bbox(bbox);
                             if image.transform.has_transform() {
-                                open_shape_transform(image.transform, bbox);
+                                open_shape_transform(image.transform, &effective_bbox);
                             }
                             let data = resolved
                                 .as_deref()
@@ -1043,17 +1090,17 @@ impl SkiaLayerRenderer {
                                 let opacity = image.opacity.clamp(0.0, 1.0);
                                 if opacity < 1.0 {
                                     let rect = Rect::from_xywh(
-                                        bbox.x as f32,
-                                        bbox.y as f32,
-                                        bbox.width as f32,
-                                        bbox.height as f32,
+                                        effective_bbox.x as f32,
+                                        effective_bbox.y as f32,
+                                        effective_bbox.width as f32,
+                                        effective_bbox.height as f32,
                                     );
                                     let alpha = (255.0 * opacity).round() as u32;
                                     canvas.save_layer_alpha(Some(rect), alpha);
                                 }
-                                draw_image(
+                                let rendered = draw_image(
                                     data,
-                                    *bbox,
+                                    effective_bbox,
                                     image.fill_mode,
                                     image.original_size,
                                     image.crop,
@@ -1062,11 +1109,26 @@ impl SkiaLayerRenderer {
                                 if opacity < 1.0 {
                                     canvas.restore();
                                 }
+                                if image.transform.has_transform() {
+                                    canvas.restore();
+                                }
+                                if !rendered && strict_resource_failures {
+                                    return Err(HwpError::RenderError(format!(
+                                        "Skia image decode failed for binData {}",
+                                        image.bin_data_id
+                                    )));
+                                }
                             } else {
-                                draw_placeholder(*bbox, "image");
-                            }
-                            if image.transform.has_transform() {
-                                canvas.restore();
+                                if image.transform.has_transform() {
+                                    canvas.restore();
+                                }
+                                if strict_resource_failures {
+                                    return Err(HwpError::RenderError(format!(
+                                        "Skia image data is missing for binData {}",
+                                        image.bin_data_id
+                                    )));
+                                }
+                                draw_placeholder(effective_bbox, "image");
                             }
                         }
                         PaintOp::Equation { bbox, equation } => {
@@ -1124,7 +1186,13 @@ impl SkiaLayerRenderer {
                                 bbox.width as f32,
                                 bbox.height as f32,
                                 ImageSampling::linear(),
+                                fallback_raster_scale,
                             ) {
+                                if strict_resource_failures {
+                                    return Err(HwpError::RenderError(
+                                        "Skia raw SVG raster fallback failed".to_string(),
+                                    ));
+                                }
                                 draw_placeholder(*bbox, "svg");
                             }
                         }
@@ -1136,6 +1204,7 @@ impl SkiaLayerRenderer {
                 }
             }
         }
+        Ok(())
     }
 }
 
@@ -2366,6 +2435,36 @@ mod tests {
 
         assert_channel(valid, 2, 220, 255);
         assert!(invalid_placeholder[3] > 0);
+    }
+
+    #[test]
+    fn renders_perpendicular_images_with_effective_bounds() {
+        let mut image = ImageNode::new(1, Some(solid_png([0, 0, 255, 255])));
+        image.transform = crate::renderer::render_tree::ShapeTransform {
+            rotation: 90.0,
+            ..Default::default()
+        };
+        let tree = PageLayerTree::new(
+            20.0,
+            20.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                None,
+                vec![PaintOp::image(
+                    BoundingBox::new(5.0, 7.0, 10.0, 4.0),
+                    image,
+                    None,
+                )],
+            ),
+        );
+
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render perpendicular image");
+        let rendered = decode_rgba(&output.bytes);
+
+        assert_channel(*rendered.get_pixel(6, 9), 2, 220, 255);
+        assert_eq!(rendered.get_pixel(10, 5)[3], 0);
     }
 
     #[test]

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -1119,16 +1119,19 @@ impl SkiaLayerRenderer {
                                     )));
                                 }
                             } else {
-                                if image.transform.has_transform() {
-                                    canvas.restore();
-                                }
                                 if strict_resource_failures {
+                                    if image.transform.has_transform() {
+                                        canvas.restore();
+                                    }
                                     return Err(HwpError::RenderError(format!(
                                         "Skia image data is missing for binData {}",
                                         image.bin_data_id
                                     )));
                                 }
                                 draw_placeholder(effective_bbox, "image");
+                                if image.transform.has_transform() {
+                                    canvas.restore();
+                                }
                             }
                         }
                         PaintOp::Equation { bbox, equation } => {
@@ -2464,6 +2467,36 @@ mod tests {
         let rendered = decode_rgba(&output.bytes);
 
         assert_channel(*rendered.get_pixel(6, 9), 2, 220, 255);
+        assert_eq!(rendered.get_pixel(10, 5)[3], 0);
+    }
+
+    #[test]
+    fn missing_perpendicular_image_placeholder_uses_transformed_bounds() {
+        let mut image = ImageNode::new(1, None);
+        image.transform = crate::renderer::render_tree::ShapeTransform {
+            rotation: 90.0,
+            ..Default::default()
+        };
+        let tree = PageLayerTree::new(
+            20.0,
+            20.0,
+            LayerNode::leaf(
+                BoundingBox::new(0.0, 0.0, 20.0, 20.0),
+                None,
+                vec![PaintOp::image(
+                    BoundingBox::new(5.0, 7.0, 10.0, 4.0),
+                    image,
+                    None,
+                )],
+            ),
+        );
+
+        let output = SkiaLayerRenderer::new()
+            .render_raster_with_options(&tree, RasterRenderOptions::default())
+            .expect("render transformed missing image placeholder");
+        let rendered = decode_rgba(&output.bytes);
+
+        assert!(rendered.get_pixel(6, 9)[3] > 0);
         assert_eq!(rendered.get_pixel(10, 5)[3], 0);
     }
 

--- a/tests/render_p37_direct_pdf_export.rs
+++ b/tests/render_p37_direct_pdf_export.rs
@@ -1,0 +1,132 @@
+#![cfg(all(not(target_arch = "wasm32"), feature = "native-skia"))]
+
+use rhwp::error::HwpError;
+use rhwp::renderer::pdf::DirectPdfExportOptions;
+use rhwp::wasm_api::HwpDocument;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/re-03-latin-only-hancom.hwp")
+}
+
+fn sample_doc() -> HwpDocument {
+    let path = sample_path();
+    let bytes =
+        std::fs::read(&path).unwrap_or_else(|error| panic!("read {}: {error}", path.display()));
+    HwpDocument::from_bytes(&bytes).expect("load direct PDF fixture")
+}
+
+fn assert_complete_pdf(bytes: &[u8]) {
+    let end = bytes
+        .iter()
+        .rposition(|byte| !byte.is_ascii_whitespace())
+        .map(|index| index + 1)
+        .unwrap_or(0);
+    assert!(bytes.starts_with(b"%PDF-"), "missing PDF header");
+    assert!(bytes[..end].ends_with(b"%%EOF"), "missing PDF trailer");
+}
+
+fn unique_pdf_path() -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-render-p37-{}-{nonce}.pdf",
+        std::process::id()
+    ))
+}
+
+#[test]
+fn document_core_direct_pdf_exports_page_selection_and_document() {
+    let doc = sample_doc();
+
+    let page = doc
+        .render_page_pdf_direct_native(0)
+        .expect("direct page PDF");
+    let mut options = DirectPdfExportOptions::default();
+    options.raster_dpi = 96.0;
+    options.title = Some("rhwp direct PDF integration".to_string());
+    let selected = doc
+        .render_pages_pdf_direct_native_with_options(&[0], &options)
+        .expect("direct selected-page PDF");
+    let document = doc
+        .render_document_pdf_direct_native()
+        .expect("direct document PDF");
+
+    assert_complete_pdf(&page);
+    assert_complete_pdf(&selected);
+    assert_complete_pdf(&document);
+}
+
+#[test]
+fn document_core_direct_pdf_preserves_selection_errors() {
+    let doc = sample_doc();
+
+    let empty = doc
+        .render_pages_pdf_direct_native(&[])
+        .expect_err("empty page selection must fail");
+    assert!(
+        matches!(empty, HwpError::RenderError(ref message) if message.contains("at least one page")),
+        "unexpected error: {empty:?}"
+    );
+
+    let out_of_range = doc
+        .render_pages_pdf_direct_native(&[0, 99])
+        .expect_err("out-of-range page must fail");
+    assert!(
+        matches!(out_of_range, HwpError::PageOutOfRange(99)),
+        "unexpected error: {out_of_range:?}"
+    );
+}
+
+#[test]
+fn export_pdf_cli_selects_direct_backend_explicitly() {
+    let output_path = unique_pdf_path();
+    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("export-pdf")
+        .arg(sample_path())
+        .args(["--backend", "direct", "--profile", "print"])
+        .args(["--raster-dpi", "96", "--output"])
+        .arg(&output_path)
+        .output()
+        .expect("run direct PDF CLI");
+
+    assert!(
+        output.status.success(),
+        "direct PDF CLI failed\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        String::from_utf8_lossy(&output.stdout).contains("PDF backend: direct"),
+        "CLI did not report direct backend"
+    );
+    let pdf = std::fs::read(&output_path).expect("read direct CLI PDF");
+    let _ = std::fs::remove_file(&output_path);
+    assert_complete_pdf(&pdf);
+}
+
+#[test]
+fn export_pdf_cli_rejects_backend_specific_option_mismatches() {
+    let direct_with_svg_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("export-pdf")
+        .arg(sample_path())
+        .args(["--backend", "direct", "--fallback-serif", "serif"])
+        .output()
+        .expect("run direct PDF CLI with compatibility option");
+    assert!(direct_with_svg_option.status.success());
+    assert!(String::from_utf8_lossy(&direct_with_svg_option.stderr)
+        .contains("SVG 호환 옵션을 지원하지 않습니다"));
+
+    let svg_with_direct_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("export-pdf")
+        .arg(sample_path())
+        .args(["--backend", "svg", "--raster-dpi", "96"])
+        .output()
+        .expect("run compatibility PDF CLI with direct option");
+    assert!(svg_with_direct_option.status.success());
+    assert!(String::from_utf8_lossy(&svg_with_direct_option.stderr)
+        .contains("direct PDF backend에서만"));
+}

--- a/tests/render_p37_direct_pdf_export.rs
+++ b/tests/render_p37_direct_pdf_export.rs
@@ -58,6 +58,9 @@ fn document_core_direct_pdf_exports_page_selection_and_document() {
     assert_complete_pdf(&page);
     assert_complete_pdf(&selected);
     assert_complete_pdf(&document);
+    assert!(selected
+        .windows(b"rhwp direct PDF integration".len())
+        .any(|window| window == b"rhwp direct PDF integration"));
 }
 
 #[test]
@@ -87,7 +90,7 @@ fn export_pdf_cli_selects_direct_backend_explicitly() {
     let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .arg("export-pdf")
         .arg(sample_path())
-        .args(["--backend", "direct", "--profile", "print"])
+        .args(["--backend", "direct"])
         .args(["--raster-dpi", "96", "--output"])
         .arg(&output_path)
         .output()
@@ -106,27 +109,50 @@ fn export_pdf_cli_selects_direct_backend_explicitly() {
     let pdf = std::fs::read(&output_path).expect("read direct CLI PDF");
     let _ = std::fs::remove_file(&output_path);
     assert_complete_pdf(&pdf);
+
+    let explicit_print_path = unique_pdf_path();
+    let explicit_print = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("export-pdf")
+        .arg(sample_path())
+        .args(["--backend", "direct", "--profile", "print"])
+        .args(["--raster-dpi", "96", "--output"])
+        .arg(&explicit_print_path)
+        .output()
+        .expect("run explicit print direct PDF CLI");
+    assert!(explicit_print.status.success());
+    let explicit_print_pdf =
+        std::fs::read(&explicit_print_path).expect("read explicit print direct PDF");
+    let _ = std::fs::remove_file(&explicit_print_path);
+    assert_eq!(pdf, explicit_print_pdf);
 }
 
 #[test]
 fn export_pdf_cli_rejects_backend_specific_option_mismatches() {
+    let direct_output_path = unique_pdf_path();
     let direct_with_svg_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "direct", "--fallback-serif", "serif"])
+        .arg("--output")
+        .arg(&direct_output_path)
         .output()
         .expect("run direct PDF CLI with compatibility option");
-    assert!(direct_with_svg_option.status.success());
+    assert_eq!(direct_with_svg_option.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&direct_with_svg_option.stderr)
         .contains("SVG 호환 옵션을 지원하지 않습니다"));
+    assert!(!direct_output_path.exists());
 
+    let compatibility_output_path = unique_pdf_path();
     let svg_with_direct_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "svg", "--raster-dpi", "96"])
+        .arg("--output")
+        .arg(&compatibility_output_path)
         .output()
         .expect("run compatibility PDF CLI with direct option");
-    assert!(svg_with_direct_option.status.success());
+    assert_eq!(svg_with_direct_option.status.code(), Some(2));
     assert!(String::from_utf8_lossy(&svg_with_direct_option.stderr)
         .contains("direct PDF backend에서만"));
+    assert!(!compatibility_output_path.exists());
 }

--- a/tests/render_p37_pdf_backend_cli.rs
+++ b/tests/render_p37_pdf_backend_cli.rs
@@ -57,7 +57,7 @@ fn direct_backend_reports_missing_native_skia_feature() {
         .output()
         .expect("run direct PDF CLI without native-skia");
 
-    assert!(output.status.success());
+    assert_eq!(output.status.code(), Some(1));
     assert!(String::from_utf8_lossy(&output.stderr)
         .contains("direct PDF backend requires a build with the native-skia feature"));
     assert!(!output_path.exists());

--- a/tests/render_p37_pdf_backend_cli.rs
+++ b/tests/render_p37_pdf_backend_cli.rs
@@ -1,0 +1,64 @@
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::Command;
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/re-03-latin-only-hancom.hwp")
+}
+
+fn unique_pdf_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-render-p37-{label}-{}-{nonce}.pdf",
+        std::process::id()
+    ))
+}
+
+fn run_compatibility_export(output_path: &Path, explicit_backend: bool) -> std::process::Output {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_rhwp"));
+    command.arg("export-pdf").arg(sample_path());
+    if explicit_backend {
+        command.args(["--backend", "svg"]);
+    }
+    command.arg("--output").arg(output_path);
+    command.output().expect("run compatibility PDF CLI")
+}
+
+#[test]
+fn explicit_svg_backend_preserves_default_pdf_bytes_and_stdout() {
+    let output_path = unique_pdf_path("compatibility");
+    let default_output = run_compatibility_export(&output_path, false);
+    assert!(default_output.status.success());
+    let default_pdf = std::fs::read(&output_path).expect("read default PDF");
+
+    let explicit_output = run_compatibility_export(&output_path, true);
+    assert!(explicit_output.status.success());
+    let explicit_pdf = std::fs::read(&output_path).expect("read explicit SVG PDF");
+    let _ = std::fs::remove_file(&output_path);
+
+    assert_eq!(default_output.stdout, explicit_output.stdout);
+    assert_eq!(default_output.stderr, explicit_output.stderr);
+    assert_eq!(default_pdf, explicit_pdf);
+}
+
+#[cfg(not(feature = "native-skia"))]
+#[test]
+fn direct_backend_reports_missing_native_skia_feature() {
+    let output_path = unique_pdf_path("missing-feature");
+    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .arg("export-pdf")
+        .arg(sample_path())
+        .args(["--backend", "direct", "--output"])
+        .arg(&output_path)
+        .output()
+        .expect("run direct PDF CLI without native-skia");
+
+    assert!(output.status.success());
+    assert!(String::from_utf8_lossy(&output.stderr)
+        .contains("direct PDF backend requires a build with the native-skia feature"));
+    assert!(!output_path.exists());
+}


### PR DESCRIPTION
## 무엇을 바꿨나

- 기존 SVG-derived PDF는 기본 compatibility backend로 그대로 유지하고, `native-skia`에서 `PageLayerTree`를 Skia PDF canvas에 직접 기록하는 opt-in backend를 추가했습니다.
- native PNG와 direct PDF가 replay plane, inherited layer, clip, text variant, resource 처리 코드를 공유하도록 Skia replay 진입점을 정리했습니다. layer의 CSS px 좌표는 PDF point로 `72/96` 변환하고, 여러 페이지와 page box, 선택 metadata를 지원합니다.
- `DocumentCore`에 단일 페이지, 명시적 페이지 선택, 전체 문서용 additive direct PDF API를 추가했습니다. CLI는 `export-pdf --backend direct`로만 새 경로를 선택하며 기본 profile은 `print`, Raw SVG fallback 해상도는 `--raster-dpi`로 지정합니다.
- direct mode는 gradient/pattern/shadow shape, multi-line/arrow/connector, 미적용 image adjustment처럼 현재 native replay가 시각적으로 손실하는 op를 기록 전에 거부하고 `--backend svg` 사용을 안내합니다. 이미지 decode나 Raw SVG raster fallback 실패도 placeholder를 기록하지 않고 export를 실패시킵니다.
- 90/270도 이미지가 SVG/Canvas와 같은 effective bbox를 사용하도록 native Skia image replay를 맞췄고, Raw SVG fallback은 요청한 출력 scale/DPI로 rasterize하되 기존 pixel 상한을 유지합니다.
- 기존 compatibility PDF와 direct PDF를 같은 DPI로 rasterize하는 selected corpus hard gate를 추가했습니다. browser Canvas와 compatibility PDF의 넓은 비교는 기존처럼 report-only로 유지합니다.

## 왜 필요한가

P23에서 PDF를 `DocumentCore` API와 CLI로 올렸지만 실제 출력은 계속 SVG를 만든 뒤 `svg2pdf`로 변환하는 compatibility 경로였습니다. 이 상태로는 `PageLayerTree` frontend/backend 경계가 PDF에서도 실제로 replay 가능한지, replay ordering과 clip/resource 실패가 같은 계약으로 처리되는지 검증하기 어려웠습니다.

이번 PR은 기존 PDF 사용자의 기본 동작을 바꾸지 않고 direct backend를 명시적으로 열어, 현재 지원 가능한 vector subset과 raster fallback/error 경계를 먼저 고정합니다. selected fixture는 compatibility PDF를 oracle로 사용해 page size와 raster 결과를 CI에서 바로 비교합니다.

## 이번 PR에서 하지 않는 것

- `export-pdf`의 기본 backend를 direct로 바꾸지 않습니다. 기존 API와 CLI는 계속 SVG compatibility 경로를 사용합니다.
- unsupported op를 자동으로 compatibility backend로 전환하거나 조용히 근사하지 않습니다. 현재 direct subset 밖의 payload는 명시적으로 실패합니다.
- WASM, C/Swift, XCFramework API나 packaging은 변경하지 않습니다.
- exact embedded glyph/searchable text, 모든 gradient/effect/object의 vector parity, 전체 corpus PDF hard gate를 완료한 것으로 보지 않습니다.
- browser 기본 renderer와 public Canvas 경로는 변경하지 않습니다.

## 확인

- `cargo fmt --all -- --check`
- `cargo check --target wasm32-unknown-unknown --lib`
- `cargo test --test render_p23_pdf_export_contract` - 5 passed
- `cargo test --test render_p37_pdf_backend_cli` - 2 passed
- `cargo test --features native-skia skia --lib` - 54 passed
- `cargo test --features native-skia --test issue_2225_missing_picture_placeholder` - 2 passed
- `cargo test --features native-skia --test render_p37_direct_pdf_export` - 4 passed
- `cargo clippy --features native-skia --lib --bin rhwp --test render_p37_direct_pdf_export --test render_p37_pdf_backend_cli -- -D warnings`
- `node --check rhwp-studio/e2e/pdf-render-diff-report.mjs`
- `node --check rhwp-studio/e2e/run-render-diff.mjs`
- local selected direct PDF gate: `biz_plan.hwp` 0.01192232, `kps-ai.hwp` 0.00770577, `tac-case-001.hwp` 0.00387381 (threshold 0.02)
- `git diff --check`

Refs #536
