### PR TITLE
Task #2374: [양식] 양식 컨트롤 값 변경을 record+역연산으로 기록 — 스냅샷 undo 무언 파괴 차단

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1526,6 +1526,60 @@ export class ResizeObjectCommand implements EditCommand {
   mergeWith(): null { return null; }
 }
 
+/**
+ * [Task #2374] 양식 값 변경 대상 — 본문 또는 표 셀 내 컨트롤 locator + 전/후 값 JSON.
+ * before/after 는 setFormValue(InCell) 에 그대로 전달되는 JSON 문자열이다.
+ */
+export interface FormValueTarget {
+  sec: number;
+  para: number;
+  ci: number;
+  inCell?: { tablePara: number; tableCi: number; cellIdx: number; cellPara: number };
+  beforeJson: string;
+  afterJson: string;
+}
+
+/**
+ * [Task #2374] 양식 컨트롤 값 변경의 경량 역연산 명령 (kind:'record' 용, #2337 계열).
+ *
+ * 뮤테이션은 클릭 핸들러가 직접 적용하고 이 명령은 기록만 담당한다(재실행 안 함).
+ * 라디오 버튼처럼 다중 쓰기(그룹 해제 + 선택)인 조작은 targets 배열로 묶어 undo/redo 가
+ * 그룹 상태를 원자적으로 왕복하게 한다 — 양식 모드에서는 snapshot 이 게이트에서 드롭되므로
+ * record 가 유일한 기록 경로다.
+ */
+export class SetFormValueCommand implements EditCommand {
+  readonly type = 'setFormValue';
+  readonly timestamp: number;
+
+  constructor(
+    private targets: FormValueTarget[],
+    private pos: DocumentPosition,
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  private apply(wasm: WasmBridge, t: FormValueTarget, json: string): void {
+    if (t.inCell) {
+      wasm.setFormValueInCell(t.sec, t.inCell.tablePara, t.inCell.tableCi, t.inCell.cellIdx, t.inCell.cellPara, t.ci, json);
+    } else {
+      wasm.setFormValue(t.sec, t.para, t.ci, json);
+    }
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    for (const t of this.targets) this.apply(wasm, t, t.afterJson);
+    return this.pos;
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    for (let i = this.targets.length - 1; i >= 0; i--) this.apply(wasm, this.targets[i], this.targets[i].beforeJson);
+    return this.pos;
+  }
+
+  mergeWith(): null { return null; }
+}
+
 // ─── 스냅샷 기반 명령 (복잡한 작업의 Undo/Redo) ─────
 
 /**

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -5,8 +5,8 @@ import { CaretRenderer } from './caret-renderer';
 import { FieldMarkerRenderer } from './field-marker-renderer';
 import { SelectionRenderer } from './selection-renderer';
 import { CommandHistory } from './history';
-import { DeleteSelectionCommand, ApplyCharFormatCommand, ApplyParaFormatCommand, SnapshotCommand, TextMutationEffectAccumulator, IMMEDIATE_TEXT_MUTATION_EFFECTS } from './command';
-import type { OperationDescriptor, ParaFormatTarget, RefreshPolicy, TextMutationEffects, EditCommand, EditContext } from './command';
+import { DeleteSelectionCommand, ApplyCharFormatCommand, ApplyParaFormatCommand, SnapshotCommand, SetFormValueCommand, TextMutationEffectAccumulator, IMMEDIATE_TEXT_MUTATION_EFFECTS } from './command';
+import type { OperationDescriptor, ParaFormatTarget, RefreshPolicy, TextMutationEffects, EditCommand, EditContext, FormValueTarget } from './command';
 import { VirtualScroll } from '@/view/virtual-scroll';
 import { ViewportManager } from '@/view/viewport-manager';
 import type {
@@ -4547,18 +4547,39 @@ export class InputHandler {
     this.applyParaFormat(props as Record<string, unknown>);
   }
 
+  /**
+   * [Task #2374] 이미 적용된 양식 값 변경을 역연산 커맨드로 기록한다(no-op 제외).
+   * 미기록 시 이후 스냅샷 undo 가 값 변경 이전 문서를 복원해 양식 값을 무언 파괴한다
+   * (#2337 계급). 양식 모드에서는 snapshot 이 게이트에서 드롭되므로 record 가 유일한
+   * 기록 경로다. before==after(이미 선택된 라디오 재클릭 등)는 유령 엔트리 방지를 위해
+   * 기록하지 않는다.
+   */
+  private recordFormValueChanges(targets: FormValueTarget[]): void {
+    const changed = targets.filter((t) => t.beforeJson !== t.afterJson);
+    if (changed.length === 0) return;
+    this.executeOperation({
+      kind: 'record',
+      command: new SetFormValueCommand(changed, this.cursor.getPosition()),
+    });
+  }
+
   /** 양식 개체 클릭 처리 */
   handleFormObjectClick(formHit: FormObjectHitResult, pageIdx: number, _zoom: number): void {
     if (!formHit.found || formHit.sec === undefined || formHit.para === undefined || formHit.ci === undefined) return;
 
     const { sec, para, ci, formType } = formHit;
 
+    // 셀 내부 컨트롤 locator (record 대상과 setFormVal 분기가 같은 조건을 공유)
+    const inCellLoc = (formHit.inCell && formHit.tablePara !== undefined && formHit.tableCi !== undefined
+        && formHit.cellIdx !== undefined && formHit.cellPara !== undefined)
+      ? { tablePara: formHit.tablePara, tableCi: formHit.tableCi, cellIdx: formHit.cellIdx, cellPara: formHit.cellPara }
+      : undefined;
+
     // 셀 내부 폼 값 설정 헬퍼
     const setFormVal = (valueJson: string) => {
-      if (formHit.inCell && formHit.tablePara !== undefined && formHit.tableCi !== undefined
-          && formHit.cellIdx !== undefined && formHit.cellPara !== undefined) {
-        this.wasm.setFormValueInCell(sec, formHit.tablePara, formHit.tableCi,
-          formHit.cellIdx, formHit.cellPara, ci, valueJson);
+      if (inCellLoc) {
+        this.wasm.setFormValueInCell(sec, inCellLoc.tablePara, inCellLoc.tableCi,
+          inCellLoc.cellIdx, inCellLoc.cellPara, ci, valueJson);
       } else {
         this.wasm.setFormValue(sec, para, ci, valueJson);
       }
@@ -4567,8 +4588,15 @@ export class InputHandler {
     switch (formType) {
       case 'CheckBox': {
         // 체크박스 토글: value 0↔1
-        const newValue = (formHit.value ?? 0) === 0 ? 1 : 0;
-        setFormVal(JSON.stringify({ value: newValue }));
+        const oldValue = formHit.value ?? 0;
+        const newValue = oldValue === 0 ? 1 : 0;
+        const afterJson = JSON.stringify({ value: newValue });
+        setFormVal(afterJson);
+        this.recordFormValueChanges([{
+          sec, para, ci, inCell: inCellLoc,
+          beforeJson: JSON.stringify({ value: oldValue }),
+          afterJson,
+        }]);
         this.afterEdit();
         break;
       }
@@ -4599,6 +4627,9 @@ export class InputHandler {
     if (!info.ok) return;
 
     const groupName = info.properties?.['GroupName'] ?? '';
+    // [Task #2374] 그룹 해제+선택은 다중 쓰기 — 이전 값을 캡처해 1 엔트리로 원자 기록
+    // (개별 기록 시 undo 가 해제만 복원하는 반쪽 상태를 만든다).
+    const changes: FormValueTarget[] = [];
 
     // 같은 문단 내 다른 라디오 버튼 찾아서 해제
     // (HWP 양식에서 라디오 버튼은 보통 같은 문단에 배치됨)
@@ -4611,11 +4642,22 @@ export class InputHandler {
       const otherGroup = otherInfo.properties?.['GroupName'] ?? '';
       if (otherGroup === groupName && otherInfo.value !== 0) {
         this.wasm.setFormValue(section, para, i, JSON.stringify({ value: 0 }));
+        changes.push({
+          sec: section, para, ci: i,
+          beforeJson: JSON.stringify({ value: otherInfo.value }),
+          afterJson: JSON.stringify({ value: 0 }),
+        });
       }
     }
 
     // 클릭된 라디오 버튼 선택
     this.wasm.setFormValue(sec, para, ci, JSON.stringify({ value: 1 }));
+    changes.push({
+      sec, para, ci,
+      beforeJson: JSON.stringify({ value: info.value ?? 0 }),
+      afterJson: JSON.stringify({ value: 1 }),
+    });
+    this.recordFormValueChanges(changes);
     this.afterEdit();
   }
 
@@ -4681,6 +4723,12 @@ export class InputHandler {
       row.addEventListener('mousedown', (e) => {
         e.preventDefault();
         this.wasm.setFormValue(sec, para, ci, JSON.stringify({ text: item }));
+        // [Task #2374] 콤보 선택 기록(동일 항목 재선택은 no-op 제외).
+        this.recordFormValueChanges([{
+          sec, para, ci,
+          beforeJson: JSON.stringify({ text: currentText }),
+          afterJson: JSON.stringify({ text: item }),
+        }]);
         this.removeFormOverlay();
         this.afterEdit();
       });
@@ -4721,8 +4769,18 @@ export class InputHandler {
     input.style.height = `${rect.height}px`;
     input.style.fontSize = `${rect.height * 0.6}px`;
 
+    // Enter 커밋의 오버레이 제거가 blur 커밋을 재유발해도 이중 적용·이중 기록되지 않게 1회 가드.
+    let committed = false;
     const commit = () => {
+      if (committed) return;
+      committed = true;
       this.wasm.setFormValue(sec, para, ci, JSON.stringify({ text: input.value }));
+      // [Task #2374] 편집 필드 커밋 기록(동일 텍스트는 no-op 제외).
+      this.recordFormValueChanges([{
+        sec, para, ci,
+        beforeJson: JSON.stringify({ text: formHit.text ?? '' }),
+        afterJson: JSON.stringify({ text: input.value }),
+      }]);
       this.removeFormOverlay();
       this.afterEdit();
     };

--- a/rhwp-studio/tests/undo-form-value.test.ts
+++ b/rhwp-studio/tests/undo-form-value.test.ts
@@ -1,0 +1,59 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2374] 양식 컨트롤 값 변경 히스토리 기록 소스 가드.
+//
+// 체크박스/라디오/콤보/편집 필드의 setFormValue(InCell) 직접 쓰기는 미기록이라, 이후
+// 스냅샷 undo 가 값 변경 이전 문서를 복원해 양식 값을 무언 파괴한다(#2337 계급). 양식
+// 모드에서는 snapshot 이 게이트에서 드롭되므로 kind:'record' + 역연산(SetFormValueCommand)
+// 이 유일한 기록 경로다. 4곳 배선 + 원자화(라디오 배치) + no-op 필터를 정적으로 핀한다.
+// 행위 증명은 브라우저 왕복(samples/form-01.hwp, PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const ih = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+const cmd = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** 메서드/블록 소스를 from~to 사이에서 추출. */
+function slice(s: string, from: string, to: string): string {
+  const a = s.indexOf(from);
+  assert.notEqual(a, -1, `${from} not found`);
+  const b = s.indexOf(to, a + from.length);
+  return b === -1 ? s.slice(a) : s.slice(a, b);
+}
+
+test('SetFormValueCommand 는 배치 역연산(execute=after, undo=before 역순)이다', () => {
+  const block = slice(cmd, 'export class SetFormValueCommand', '// ─── 스냅샷 기반 명령');
+  assert.match(block, /implements EditCommand/, 'EditCommand 구현');
+  assert.match(block, /readonly type = 'setFormValue'/, 'type 식별자');
+  // execute 는 afterJson 순방향, undo 는 beforeJson 역순(라디오 그룹 원자 왕복).
+  assert.match(block, /execute\(wasm[\s\S]*?afterJson/, 'execute → after 적용');
+  assert.match(block, /undo\(wasm[\s\S]*?length - 1[\s\S]*?beforeJson/, 'undo → before 역순 적용');
+  assert.match(block, /setFormValueInCell/, '셀 내 컨트롤 locator 지원');
+});
+
+test('recordFormValueChanges 는 kind:record + no-op 필터로 기록한다', () => {
+  const block = slice(ih, 'private recordFormValueChanges', 'handleFormObjectClick');
+  assert.match(block, /beforeJson !== t\.afterJson/, 'no-op(before==after) 제외 — 유령 엔트리 방지');
+  assert.match(block, /kind:\s*'record'/, "record 경로(양식 모드에서 snapshot 은 드롭됨)");
+  assert.match(block, /new SetFormValueCommand\(/, '역연산 커맨드로 기록');
+});
+
+test('양식 값 쓰기 4곳(체크박스/라디오/콤보/편집)이 record 로 배선된다', () => {
+  // 체크박스: handleFormObjectClick CheckBox 분기.
+  const checkbox = slice(ih, "case 'CheckBox': {", 'break;');
+  assert.match(checkbox, /recordFormValueChanges\(/, '체크박스 토글 기록');
+  // 라디오: 그룹 해제+선택을 changes 배열로 모아 1회 기록(원자화).
+  const radio = slice(ih, 'private handleRadioButtonClick', 'formBboxToOverlayRect');
+  assert.match(radio, /const changes: FormValueTarget\[\]/, '라디오 배치 수집');
+  const radioRecords = radio.match(/recordFormValueChanges\(/g) ?? [];
+  assert.equal(radioRecords.length, 1, '라디오는 1회 기록(그룹 원자화)');
+  // 콤보 + 편집 필드.
+  const combo = slice(ih, 'private showComboBoxOverlay', 'private showEditOverlay');
+  assert.match(combo, /recordFormValueChanges\(/, '콤보 선택 기록');
+  const edit = ih.slice(ih.indexOf('private showEditOverlay'));
+  assert.match(edit, /recordFormValueChanges\(/, '편집 필드 커밋 기록');
+  assert.match(edit, /if \(committed\) return/, '이중 커밋(Enter→blur) 가드');
+});


### PR DESCRIPTION
## 요약

양식 컨트롤 값 변경(체크박스·라디오·콤보·편집 필드)이 히스토리를 우회해, undo 불가에 더해 **이후 스냅샷 undo 가 값 변경을 무언 파괴**하던(#2337 계급) 계급 1 미라우팅을 수정합니다. 양식 모드에서는 snapshot 이 게이트에서 드롭되므로, #2337 이 연 **`kind:'record'` + 경량 역연산** 경로로 기록합니다 — 로드맵 #2369 **Track 2** 본체.

Fixes #2374

## 변경

- **`SetFormValueCommand`** (경량 역연산, 배치): `targets {locator(본문/셀), beforeJson, afterJson}` — execute=after 순방향, undo=before 역순. **라디오의 그룹 해제+선택 다중 쓰기를 1 엔트리로 원자화**(개별 기록 시 undo 가 해제만 복원하는 반쪽 상태).
- `recordFormValueChanges` 헬퍼: **before==after 필터**(이미 선택된 라디오 재클릭 등 유령 엔트리 방지 — #2338 FN 교훈) 후 `executeOperation({kind:'record'})`.
- 4곳 배선(이전 값을 뮤테이션 전에 캡처): 체크박스(`formHit.value`) · 라디오(`getFormObjectInfo` 그룹 값) · 콤보(`currentText`) · 편집 필드(`formHit.text`, Enter→blur **이중 커밋 1회 가드**).

## 검증

- `npx tsc --noEmit`, `npm test` 358/358(신규 소스 가드 3 — 역연산 구조·record+no-op 필터·4곳 배선 핀).
- 브라우저(`samples/form-01.hwp`, 실제 `handleFormObjectClick` 경로) **게이트 6종**:
  1. 체크박스 토글 → undoLen+1 → undo/redo 왕복.
  2. **양식 모드에서 record 기록**(snapshot 드롭 모드의 핵심 경로).
  3. 라디오 기록 + 재클릭 **no-op 0 엔트리** + undo.
  4. 편집 필드 `홍길동` 커밋 — Enter+blur 이중 발화에도 **정확히 1 엔트리**, undo 원복.
  5. **손실 게이트**: `page:hide`(스냅샷) → 체크박스 토글 → undo 1회가 **체크박스만 원복하고 hide 보존**(수정 전엔 스냅샷 복원이 양식 값을 무언 파괴) → 2회째 hide 원복.
  6. 콤보 `계절 선택`→`봄` 기록·undo.
- 콘솔 에러 0.

## 범위 외

- 누름틀 삽입(insert:field) — 일반 모드 전용(양식 모드 차단)이라 별도 snapshot 건. active-field 얽힘 포함 Track 2 후속.
- PushButton(웹 비활성), 콤보 항목 없음 시 Edit 폴백(편집 필드 커밋으로 커버).

---

(a′) 이관 로드맵 #2369 의 **Track 2**(form 값·누름틀)에 속합니다.
