### PR TITLE
Task #2279: lazy-확립 사다리의 sb-형 spacing 트림 금지 (92셋 −1축 2→1)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2106,6 +2106,7 @@ impl FormattedParagraph {
         col_count: u16,
         allow_spacing_before_only: bool,
         ladder_dirty: bool,
+        lazy_base: bool,
     ) -> f64 {
         if col_count > 1 {
             return self.height_for_fit;
@@ -2121,11 +2122,28 @@ impl FormattedParagraph {
         let has_authoritative_seg = para.line_segs.iter().any(|seg| {
             seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
         });
+        // [#2279 ①-4] lazy-base(page_base 미확립) 사다리에서는 sb-형 트림의
+        // 복원(스냅)이 성립하지 않는다 — sb-형만 차단, sa-형 트림은 유지
+        // (36398700 pi31/35 −13.5px 미복원 실측 vs issue_1853 캡션 문서의
+        // sa-형 트림은 정상 복원되어 전면 차단 시 +1쪽 과다 반증).
+        let sa_trim = self.spacing_after > 0.5;
+        let sb_trim =
+            allow_spacing_before_only && self.spacing_before > 0.5 && !(lazy_base && !sa_trim);
+        if std::env::var("RHWP_DIAG_LAZYBLK").is_ok()
+            && allow_spacing_before_only
+            && self.spacing_before > 0.5
+            && lazy_base
+            && !sa_trim
+        {
+            eprintln!(
+                "DIAG_LAZYBLK sb={:.1} total={:.1} h4f={:.1}",
+                self.spacing_before, self.total_height, self.height_for_fit
+            );
+        }
         if para.controls.is_empty()
             && has_authoritative_seg
             && !ladder_dirty
-            && (self.spacing_after > 0.5
-                || (allow_spacing_before_only && self.spacing_before > 0.5))
+            && (sa_trim || sb_trim)
             && self.height_for_fit > 0.0
             && self.height_for_fit + 0.5 < self.total_height
         {
@@ -10904,10 +10922,11 @@ impl TypesetEngine {
             y = st.current_height;
         }
         // [#2279 ladder-sb] 후방 스냅량이 이 문단의 spacing_before 와 정확히
-        // 일치(±2px)하면 생성기 ladder 의 sb-누락이다 — 한글 fresh 는 sb 를
-        // 가산하므로(서브픽셀 하니스 실측: 36398709 본문 문단당 −5.0pt 균일
-        // = sb 6.7px) 스냅으로 되감지 않는다. ladder 가 sb 를 포함하는 정상
-        // 문서는 후방 스냅량이 sb 와 일치하지 않아 불변.
+        // 일치(±2px)하고, **저장 ladder 스텝 자체가 sb 를 누락**했으면 생성기
+        // ladder 의 sb-누락이다 — 한글 fresh 는 sb 를 가산하므로(서브픽셀
+        // 하니스 실측: 36398709 문단당 −5.0pt 균일 = sb 6.7px) 스냅으로 되감지
+        // 않는다. 스텝-검사 없이 ±2px 우연 일치만으로 스킵하면 sb-포함 정상
+        // ladder 에서 이중 가산(+1쪽 과다, issue_1853 실측 반증)이 난다.
         if st.is_hwpx_source
             && spacing_before_px > 0.5
             && y < st.current_height
@@ -11675,6 +11694,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_spacing_before_for_flow,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                st.vpos_page_base.is_none() && st.vpos_lazy_base.is_some(),
             );
             if std::env::var("RHWP_DIAG_ADV").is_ok() {
                 eprintln!(
@@ -11741,6 +11761,7 @@ impl TypesetEngine {
                     st.col_count,
                     trim_spacing_before_for_flow,
                     st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                    false,
                 );
                 st.current_height += advance;
                 st.flow_underrun += (fmt.total_height - advance).max(0.0);
@@ -11855,6 +11876,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_spacing_before_for_flow,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                false,
             );
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
@@ -13960,6 +13982,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_sb,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs_all, next_idx),
+                false,
             );
             st.prefilled_paras.insert(next_idx);
         }


### PR DESCRIPTION
## 요약 (#2279 — lazy-base 사다리의 spacing 트림 금지, 92셋 −1축 2→1)

> **PR #2371 위에 스택**. 선행 merge 후 본 PR 은 커밋 하나만 남습니다.

### 근거 — 경계 전환점 이분탐색 + 서브픽셀 하니스 교차 실측

1. **경계 전환점 이분탐색** (하단여백 × 한글 COM PageCount, footer_flip 계승): 36398700 은 body **+20.06px** 에서 4→3쪽 전환 — 한글과의 차이가 규칙이 아니라 **rhwp 흐름 부족 정확히 ~20px** 임을 확정.
2. **서브픽셀 하니스 좌표와 정합**: −5pt 이탈 3곳 합 = −20.2px = ① pi30 백스냅 −6.7px(직전 문단 sb 재흡수) + ② pi31/35 spacing 트림 미복원 −13.5px.
3. **근원**: `vpos_page_base` 미확립(**lazy-base**) 사다리에서는 트림의 복원 전제(vpos-snap)가 성립하지 않는다 — DIAG_SNAP 실측(page_base=None, lazy 좌표계).

### 규칙 (①-4)

본선 place 의 sb-형 spacing 트림 차단 조건에 **(page_base 미확립 && lazy_base 확립)** 을 추가한다. 정상 사다리(page_base 확립)는 종전과 동일.

판별 정밀화 기각 3건(실측): ① page_base-부재 단독 — 패스-의존 오발동으로 issue_1853 캡션 문서 +1 과다 · ② prev-sb 백스냅 비교 — 36392557 +1 · ③ stored-step sb-누락 검사 — 36398709 상실. **(page_base=None && lazy=Some)** 만이 1853 통과와 36398700 4쪽을 동시 성립.

### 반증 기록

- prev-sb 백스냅 규칙(직전 문단 sb 와 비교) 시험 → 36392557 +1 과다 반전으로 **미채택**.
- fit-full(경계 fit 을 total_height 로) 시험 → 92셋 90→86 회귀로 **기각** (#359 트레일링-제외 유지).

### 게이트 (격리 worktree)

| 게이트 | 결과 |
|---|---|
| 92 컨트롤셋 | 일치 **90→91** (−1축 2→1: **36398700 4쪽=한글**, 잔여 36399374 만, 회귀 0) |
| knife-edge 4 / byeolpyo | 전건 유지 |
| 민감 62종 (자간·핀·snapshot·footer·hml) | 전건 통과 (prep 145 · sijang 313 유지) |
| nextest 전체 | **3264/3264** 통과 (23 skipped) |
| 358 recount | **FIXED 39 / REGRESSED 0** / SAME_OK 251 / CHANGED 11 (신규 1건 1342000-201700080 75→76: 스냅샷 pdf=38 절반-오염 의심 패턴 — COM 교차검증 후보로 기록) |
| fmt / clippy | 클린 (fmt --check 신규 diff 없음 · clippy --all-targets -D warnings 통과) |

### 남긴 것

- 잔여 −1×1 (36399374): 전환점 실측 **+0.19px** — 한글 자체가 0.2px 차 박빙인 knife-edge. 경계 문단(pi27, 대형 자리차지 개체 리드인)의 push 규칙 오라클이 필요 (이슈 #2279 로드맵).

Closes: 없음 (#2279 umbrella 진행분)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
