### PR TITLE
Task #2377: [누름틀] 넣기/고치기/지우기를 히스토리에 기록 — undo 불가·오프셋 오염 수정

### DIFF
--- a/rhwp-studio/src/command/commands/edit.ts
+++ b/rhwp-studio/src/command/commands/edit.ts
@@ -240,13 +240,23 @@ export const editCommands: CommandDef[] = [
       };
       dialog.onApply = (newProps) => {
         console.log('[field:edit] apply:', newProps);
-        const result = services.wasm.updateClickHereProps(
-          fi.fieldId, newProps.guide, newProps.memo, newProps.name, newProps.editable,
-        );
-        console.log('[field:edit] updateResult:', result);
-        if (result.ok) {
+        try {
+          // [Task #2377] 누름틀 속성 갱신은 안내문 텍스트를 바꿀 수 있다(문자 수 변경) —
+          // snapshot 으로 라우팅(일반 모드 전용 커맨드). 실패 시 throw 로 엔트리 생성을 막는다.
+          ih.executeOperation({
+            kind: 'snapshot',
+            operationType: 'updateFieldProps',
+            operation: (wasm) => {
+              const result = wasm.updateClickHereProps(
+                fi.fieldId, newProps.guide, newProps.memo, newProps.name, newProps.editable,
+              );
+              if (!result.ok) throw new Error('updateClickHereProps not ok');
+              return ih.getCursorPosition();
+            },
+          });
           services.eventBus.emit('document-mutated', 'field-edit');
-          services.eventBus.emit('document-changed', 'field-edit');
+        } catch (err) {
+          console.warn('[field:edit] 누름틀 고치기 실패:', err);
         }
       };
       dialog.onClose = restoreEditorFocus;

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -178,21 +178,22 @@ export const insertCommands: CommandDef[] = [
       fieldInsertDialog = new FieldInsertDialog();
       fieldInsertDialog.onApply = (props) => {
         try {
-          const result = services.wasm.insertClickHereField(
-            pos,
-            props.guide,
-            props.memo,
-            props.name,
-            props.editable,
-          );
-          if (result.ok) {
-            const insertedPos = { ...pos, charOffset: result.charOffset ?? pos.charOffset };
-            ih.moveCursorTo(insertedPos);
-            ih.markCurrentFieldEndOutside();
-            services.wasm.clearActiveField();
-            services.eventBus.emit('document-mutated', 'insert-field');
-            services.eventBus.emit('document-changed');
-          }
+          // [Task #2377] 누름틀 삽입은 안내문 텍스트를 문서에 넣는다(문자 수 변경) —
+          // 미기록 시 undo 불가 + 후속 undo 오프셋 오염. snapshot 으로 라우팅한다(이 커맨드는
+          // 일반 모드 전용이라 게이트 드롭 없음). 실패 시 throw 로 엔트리 생성을 막는다.
+          ih.executeOperation({
+            kind: 'snapshot',
+            operationType: 'insertField',
+            operation: (wasm) => {
+              const result = wasm.insertClickHereField(pos, props.guide, props.memo, props.name, props.editable);
+              if (!result.ok) throw new Error('insertClickHereField not ok');
+              return { ...pos, charOffset: result.charOffset ?? pos.charOffset };
+            },
+          });
+          // 커서는 라우터가 삽입 위치로 이동시킨다 — 필드 끝 밖 마킹·활성 필드 해제는 기존대로.
+          ih.markCurrentFieldEndOutside();
+          services.wasm.clearActiveField();
+          services.eventBus.emit('document-mutated', 'insert-field');
         } catch (err) {
           console.warn('[insert:field] 누름틀 삽입 실패:', err);
         }

--- a/rhwp-studio/src/command/commands/insert.ts
+++ b/rhwp-studio/src/command/commands/insert.ts
@@ -194,6 +194,9 @@ export const insertCommands: CommandDef[] = [
           ih.markCurrentFieldEndOutside();
           services.wasm.clearActiveField();
           services.eventBus.emit('document-mutated', 'insert-field');
+          // 모달 확인 버튼으로 옮겨간 포커스를 편집기로 복원 — 종전엔 moveCursorTo 끝의
+          // focusTextarea 가 담당했으나 라우터 경로엔 없다(field:edit 의 onClose 복원과 동형).
+          ih.focus();
         } catch (err) {
           console.warn('[insert:field] 누름틀 삽입 실패:', err);
         }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -3541,20 +3541,37 @@ export class InputHandler {
     }
 
     try {
-      const result = this.wasm.removeFieldAt(pos);
-      if (result.ok) {
+      // [Task #2377] 누름틀 제거는 필드+안내문 텍스트를 지운다(문자 수 변경) — 일반
+      // 모드에선 snapshot 으로 기록해 undo 가능하게 한다. 양식 모드는 게이트가 snapshot 을
+      // 드롭해 무언 폐기 회귀(#2361 리뷰 계급)가 되므로 기존 직접 경로를 유지한다(비기록 —
+      // 양식 모드 누름틀 제거의 기록은 역연산 설계가 필요해 범위 외).
+      if (this.editMode === 'form') {
+        const result = this.wasm.removeFieldAt(pos);
+        if (!result.ok) return;
         if (restorePos) {
           this.cursor.clearSelection();
           this.cursor.moveTo(restorePos);
           this.cursor.resetPreferredX();
         }
-        this.fieldMarker.hide();
-        this.fieldStartExitKey = null;
-        this.fieldEndExitKey = null;
-        this.wasm.clearActiveField();
         this.afterEdit();
-        this.eventBus.emit('field-info-changed', null);
+      } else {
+        this.cursor.clearSelection();
+        this.executeOperation({
+          kind: 'snapshot',
+          operationType: 'removeField',
+          operation: (wasm) => {
+            const result = wasm.removeFieldAt(pos);
+            if (!result.ok) throw new Error('removeFieldAt not ok');
+            return restorePos ?? pos;
+          },
+        });
+        // 커서 이동·refresh 는 라우터가 수행.
       }
+      this.fieldMarker.hide();
+      this.fieldStartExitKey = null;
+      this.fieldEndExitKey = null;
+      this.wasm.clearActiveField();
+      this.eventBus.emit('field-info-changed', null);
     } catch (err) {
       console.warn('[InputHandler] 누름틀 제거 실패:', err);
     }

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -156,7 +156,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
   // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
-  'src/engine/input-handler.ts': 25,
+  'src/engine/input-handler.ts': 26, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리
   'src/engine/input-handler-connector.ts': 1,
   'src/engine/input-handler-keyboard.ts': 21,
   'src/engine/input-handler-mouse.ts': 3,

--- a/rhwp-studio/tests/undo-field-ops.test.ts
+++ b/rhwp-studio/tests/undo-field-ops.test.ts
@@ -1,0 +1,50 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2377] 누름틀 삽입/고치기/지우기 히스토리 라우팅 소스 가드.
+//
+// 세 op 모두 안내문 텍스트를 넣고/바꾸고/지워 문자 수를 바꾼다 — 미기록 시 undo 불가 +
+// 후속 undo 오프셋 오염. 삽입/고치기는 일반 모드 전용 커맨드라 순수 snapshot, 지우기는
+// 키보드 경계 삭제로 양식 모드에서도 도달하므로(양식 모드 게이트가 snapshot 을 드롭해
+// 무언 폐기 회귀가 됨 — #2361 리뷰 계급) 일반 모드만 snapshot 라우팅하고 양식 모드는
+// 기존 직접 경로를 유지한다. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = (rel: string): string => readFileSync(join(rootDir, rel), 'utf8');
+const insertSrc = src('src/command/commands/insert.ts');
+const editSrc = src('src/command/commands/edit.ts');
+const ihSrc = src('src/engine/input-handler.ts');
+
+function slice(s: string, from: string, to: string): string {
+  const a = s.indexOf(from);
+  assert.notEqual(a, -1, `${from} not found`);
+  const b = s.indexOf(to, a + from.length);
+  return b === -1 ? s.slice(a) : s.slice(a, b);
+}
+
+test('누름틀 삽입(insert:field)은 snapshot 으로 라우팅되고 실패 시 엔트리를 만들지 않는다', () => {
+  const block = slice(insertSrc, "id: 'insert:field'", 'fieldInsertDialog.show()');
+  assert.match(block, /operationType:\s*'insertField'/, 'insertField snapshot 라우팅');
+  assert.match(block, /\bwasm\.insertClickHereField\(/, '뮤테이션은 operation 콜백 안');
+  assert.doesNotMatch(block, /services\.wasm\.insertClickHereField/, '직접 호출 금지');
+  assert.match(block, /if \(!result\.ok\) throw/, '실패 시 throw(no-op 엔트리 방지)');
+});
+
+test('누름틀 고치기(field:edit)는 snapshot 으로 라우팅된다', () => {
+  const block = slice(editSrc, "id: 'field:edit'", "id: 'field:remove'");
+  assert.match(block, /operationType:\s*'updateFieldProps'/, 'updateFieldProps snapshot 라우팅');
+  assert.match(block, /\bwasm\.updateClickHereProps\(/, '뮤테이션은 operation 콜백 안');
+  assert.doesNotMatch(block, /services\.wasm\.updateClickHereProps/, '직접 호출 금지');
+});
+
+test('누름틀 지우기(removeCurrentField)는 일반=snapshot / 양식=직접(비기록) 분기다', () => {
+  const block = slice(ihSrc, 'removeCurrentField(posOverride', 'confirmRemoveCurrentField');
+  // 양식 모드: 게이트가 snapshot 을 드롭하므로 직접 경로 유지(무언 폐기 회귀 방지).
+  assert.match(block, /this\.editMode === 'form'/, '양식 모드 분기 존재');
+  // 일반 모드: snapshot 라우팅.
+  assert.match(block, /operationType:\s*'removeField'/, 'removeField snapshot 라우팅');
+  assert.match(block, /if \(!result\.ok\) throw/, '실패 시 throw(no-op 엔트리 방지)');
+});


### PR DESCRIPTION
## 요약

누름틀 3종 조작(**넣기/고치기/지우기**)이 히스토리를 우회하던 계급 1 미라우팅을 수정합니다 — 셋 다 필드·안내문 텍스트로 문자 수를 바꾸므로 undo 불가에 더해 후속 undo 오프셋 오염·스냅샷 무언 파괴(#2344/#2374 계열)로 이어지던 축입니다. 로드맵 #2369 **Track 2** 잔여분(이로써 Track 2 완결).

Fixes #2377

## 변경

- **넣기(insert:field)·고치기(field:edit)**: 일반 모드 전용 커맨드(양식 모드는 dispatcher 차단)라 순수 `snapshot` 라우팅(`insertField`/`updateFieldProps`). **실패 시 throw 로 no-op 엔트리 방지.** 커서는 라우터가 삽입 위치로 이동(필드 끝 밖 마킹·활성 필드 해제 기존 유지).
- **지우기(removeCurrentField)**: 키보드 경계 Backspace/Delete 경로가 **양식 모드에서도 도달**합니다(누름틀은 양식 모드 편집 대상). 양식 모드에서 snapshot 은 게이트에서 드롭돼 **무언 폐기 회귀**(#2361 리뷰에서 잡아주신 계급)가 되므로 — **일반 모드만 snapshot(`removeField`) 라우팅**, 양식 모드는 기존 직접 경로 유지(비기록, 명시적 범위 외).
- 원장 `input-handler 25→26`(지우기 이관 시 양식/일반 분기 분리) 사유 명시 갱신 + 소스 가드 `undo-field-ops`(3종 라우팅·양식 분기·throw 핀).

## 검증

- `npx tsc --noEmit`, `npm test` 358/358.
- 브라우저 게이트 4종(실제 다이얼로그·dispatcher 경유):
  1. 넣기(`넣기(D)`) → `undoLen`+1 → undo 필드 소멸 → redo 복원.
  2. 지우기(확인 다이얼로그) → 기록 → undo 필드 복원.
  3. 고치기 안내문 `입력하세요`→`이름을 입력` 기록·왕복.
  4. **양식 모드 지우기 무회귀**: 제거 동작(무언 폐기 아님) + 비기록(설계대로).
- 콘솔 에러 0.

## 범위 외

- 양식 모드 누름틀 제거의 **기록**(필드 구조 복원 역연산 설계 필요) — 후속.
- 누름틀 값 채우기(양식 모드 텍스트 입력) — 기존 텍스트 편집 경로.

---

(a′) 이관 로드맵 #2369 의 **Track 2**(form 값·누름틀)에 속합니다 — #2374(PR #2375)와 함께 Track 2 완결.
