### PR TITLE
docs: fork 기여자를 위한 upstream 원격 등록 절차 추가

### DIFF
--- a/mydocs/manual/dev_environment_guide.md
+++ b/mydocs/manual/dev_environment_guide.md
@@ -33,6 +33,16 @@ npm --version
 로컬 검증 기준은 최신 `upstream/devel`이다. 일반 변경은 작업 브랜치에서 검증한 뒤 `devel` 대상 PR로
 통합하며 `upstream/devel`에 직접 push하지 않는다.
 
+fork를 clone하면 원격은 fork를 가리키는 `origin` 하나뿐이다. 원본 저장소를 가리키는 `upstream`을
+최초 1회 등록한다.
+
+```bash
+git remote add upstream https://github.com/edwardkim/rhwp.git
+git remote -v
+```
+
+이후 작업 브랜치는 최신 `upstream/devel`에서 만든다.
+
 ```bash
 git fetch upstream
 git switch -c <work-branch> upstream/devel

--- a/mydocs/manual/onboarding_guide.md
+++ b/mydocs/manual/onboarding_guide.md
@@ -28,6 +28,7 @@ rhwp는 Rust로 HWP/HWPX/HWP3 문서를 공통 IR로 변환하고 네이티브�
 ## 로컬 시작
 
 ```bash
+git remote add upstream https://github.com/edwardkim/rhwp.git  # fork를 clone한 경우 최초 1회
 git fetch upstream
 git switch -c <work-branch> upstream/devel
 cargo build


### PR DESCRIPTION
## 변경 요약

rhwp에 처음 기여하면서 실제로 막힌 지점입니다.

`CONTRIBUTING.md`의 Fork & PR 워크플로우대로 fork를 clone한 뒤 `mydocs/manual/onboarding_guide.md`의 "로컬 시작" 절차를 그대로 따라 하면 첫 명령부터 실패합니다.

```console
$ git remote -v
origin  https://github.com/<myid>/rhwp.git (fetch)
origin  https://github.com/<myid>/rhwp.git (push)

$ git fetch upstream
fatal: 'upstream' does not appear to be a git repository
fatal: Could not read from remote repository.
```

fork를 clone하면 원격은 `origin` 하나뿐인데, 온보딩 가이드와 개발 환경 가이드는 모두 `upstream` 원격이 이미 등록돼 있다고 전제합니다. 그러나 등록 방법은 저장소 마크다운 문서 어디에도 없습니다.

```console
$ grep -rn "remote add upstream" --include="*.md" .
(결과 없음)
```

| 파일 | 변경 |
|------|------|
| `mydocs/manual/dev_environment_guide.md` | "저장소와 브랜치" 절에 `git remote add upstream` 과 `git remote -v` 확인 단계 추가 (+10) |
| `mydocs/manual/onboarding_guide.md` | "로컬 시작" 명령 블록에 같은 단계를 주석 한 줄로 추가 (+1) |

문서만 변경했고 코드 변경은 없습니다 (11줄 추가, 0줄 삭제). `onboarding_guide.md`는 "저장소 진입점만 제공하며 세부 명령과 절차를 중복하지 않는다"고 명시하고 있어, 설명 문장 없이 명령 한 줄만 추가했습니다.

## 관련 이슈

없음 (문서 개선). 이슈 등록이 필요하면 알려주세요.

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

**위 항목을 체크하지 못한 이유를 밝힙니다.** `.md` 파일 2개만 변경하여 Rust 빌드 산출물에 영향이 없지만, 로컬 Windows 환경에서 두 명령을 실제로 실행하지는 못했습니다 (Smart App Control 이 cargo 빌드 스크립트 실행을 차단). 실행하지 않은 검사를 통과했다고 표시하지 않기 위해 비워 둡니다.

실제로 확인한 항목은 다음과 같습니다.

- `cargo fmt --all -- --check` → 통과 (rustfmt 는 링커가 필요 없어 실행 가능)
- `python3 scripts/check_markdown_links.py` → 통과
- `python3 scripts/check_document_metadata.py` → 통과
- 문서에 추가한 절차를 실제로 실행해 동작을 확인했습니다.

```console
$ git remote add upstream https://github.com/edwardkim/rhwp.git
$ git fetch upstream
 * [new branch]  devel      -> upstream/devel
 * [new branch]  ios/devel  -> upstream/ios/devel
 * [new branch]  main       -> upstream/main
$ git rev-parse --short upstream/devel
a81f6a34
```

CI 결과를 확인하고 문제가 있으면 바로 대응하겠습니다.

## 스크린샷

해당 없음 (문서 변경).

---

### 메인테이너께 여쭙고 싶은 점

1. `dev_environment_guide.md`에 "원격 이름이나 쓰기 가능한 원격은 clone 방식과 권한에 따라 다를 수 있다"는 안내가 있어, 원격 이름을 의도적으로 일반화하신 것으로도 읽힙니다. 그럼에도 등록 방법 자체가 없으면 신규 기여자가 첫 명령에서 막힌다고 판단해 구체적인 명령을 추가했습니다. canonical 문서(`dev_environment_guide.md`)에만 두고 `onboarding_guide.md` 변경은 되돌리는 편이 낫다면 말씀해 주세요. 바로 수정하겠습니다.

2. 두 문서의 front matter `last_verified` 는 변경하지 않았습니다. 이 필드가 "역할·canonical 관계를 마지막으로 확인한 날짜"로 정의되어 있어, 내용만 수정한 외부 기여자가 갱신해도 되는지 판단이 서지 않았습니다. 갱신이 맞다면 반영하겠습니다.