### PR TITLE
docs: 영문 README 에 브라우저 확장 스토어 배지 추가

### DIFF
--- a/README_EN.md
+++ b/README_EN.md
@@ -20,6 +20,12 @@
 </p>
 
 <p align="center">
+  <a href="https://chromewebstore.google.com/detail/pgakpjflombjmehnebnbpnalhegaanag"><img src="https://img.shields.io/chrome-web-store/v/pgakpjflombjmehnebnbpnalhegaanag?label=Chrome%20Web%20Store&logo=googlechrome&logoColor=white" alt="Chrome Web Store" /></a>
+  <a href="https://microsoftedge.microsoft.com/addons/detail/rhwp/nfkdfobhmanddlhdbclkpoanbccpigcn"><img src="https://img.shields.io/badge/Edge%20Add--ons-Store-0078D7" alt="Edge Add-ons" /></a>
+  <a href="https://addons.mozilla.org/firefox/addon/rhwp-free-hwp-editor/"><img src="https://img.shields.io/amo/v/rhwp-free-hwp-editor?label=Firefox%20Add-ons&logo=firefoxbrowser&logoColor=white" alt="Firefox Add-ons" /></a>
+</p>
+
+<p align="center">
   <a href="README.md">한국어</a> | <strong>English</strong>
 </p>
 


### PR DESCRIPTION
## 변경 요약

한국어 README(`README.md`)에는 브라우저 확장 스토어 배지 3종이 있는데, 영문 README(`README_EN.md`)에는 통째로 빠져 있습니다. 영어권 사용자는 rhwp 확장이 이미 Chrome / Edge / Firefox 스토어에 출시된 사실을 README 에서 알 수 없습니다.

두 README 는 다른 면에서는 구조가 대칭입니다(제목 42개로 동일). 이 배지 블록만 한쪽에 없어 누락으로 판단했습니다.

| 배지 | README.md | README_EN.md (변경 전) |
|---|---|---|
| Chrome Web Store | 있음 | **없음** |
| Edge Add-ons | 있음 | **없음** |
| Firefox Add-ons | 있음 | **없음** |

한국어 README 와 동일한 배지 블록을 같은 위치(주 배지 줄과 언어 전환 줄 사이)에 추가했습니다. `README_EN.md` 6줄 추가, 삭제 0줄입니다.

## 관련 이슈

없음 (문서 개선).

## 테스트

- [ ] `cargo test` 통과
- [ ] `cargo clippy -- -D warnings` 통과
- [ ] 관련 샘플 파일로 SVG 내보내기 확인
- [ ] 웹(WASM) 렌더링 확인 (해당하는 경우)

`README_EN.md` 한 파일만 변경하여 Rust 빌드에 영향이 없습니다. 다만 로컬 Windows 환경 제약(Smart App Control 이 cargo 빌드 스크립트 실행을 차단)으로 두 명령을 직접 실행하지 못해, 실행하지 않은 검사를 통과했다고 표시하지 않기 위해 비워 둡니다.

실제로 확인한 항목은 다음과 같습니다.

- 추가한 스토어 링크 3개를 **브라우저로 직접 접속해 게시 상태를 확인**했습니다.
  - Chrome Web Store → `rhwp - HWP 문서 뷰어 & 에디터`
  - Microsoft Edge Add-ons → `rhwp - HWP 문서 뷰어 & 에디터`
  - Firefox Add-ons → `rhwp - Free HWP Editor`
- `python3 scripts/check_markdown_links.py` → 통과
- `python3 scripts/check_document_metadata.py` → 통과

## 스크린샷

해당 없음 (배지 마크업 추가).

---

배지 markdown 은 `README.md` 의 것을 그대로 옮겨 shields.io 파라미터와 alt 텍스트가 한국어판과 동일합니다. 영문판에 맞춰 alt 텍스트나 배지 순서를 조정하는 편이 좋다면 알려주세요. 바로 반영하겠습니다.

이 PR 은 #2380 과 독립적인 주제이며, 서로 다른 브랜치에서 작업했습니다.