### PR TITLE
fix(serializer): 템플릿 생성 문서의 PrvText placeholder 보정 — 빈 미리보기 수정 (#2387)

### DIFF
--- a/src/serializer/cfb_writer.rs
+++ b/src/serializer/cfb_writer.rs
@@ -56,17 +56,75 @@ pub fn serialize_hwp(doc: &Document) -> Result<Vec<u8>, SerializeError> {
     // 4. 압축 여부 결정
     let compressed = doc.header.compressed;
 
-    // 5. CFB 컨테이너 조립
+    // 5. 미리보기 텍스트 보정
+    //
+    // preview 는 파싱 원본에서 그대로 실려 온다 (원본 보존 우선). 그러나 내장
+    // 템플릿에서 만든 새 문서는 템플릿의 placeholder 미리보기("\r\n")를 물고
+    // 나가 탐색기·한컴 미리보기에 빈 문서로 보인다. 원본 미리보기가 없거나
+    // placeholder 일 때만 본문에서 새로 만든다 — 실문서의 원본 미리보기는 건드리지 않는다.
+    let preview = supplement_preview(doc);
+
+    // 6. CFB 컨테이너 조립
     write_hwp_cfb(
         &header_bytes,
         &doc_info_bytes,
         &section_bytes_list,
         &doc.doc_info.bin_data_list,
         &doc.bin_data_content,
-        &doc.preview,
+        &preview,
         &doc.extra_streams,
         compressed,
     )
+}
+
+/// PrvText 가 비었거나 placeholder 면 본문 텍스트로 채운다.
+///
+/// 원본 미리보기가 실재하면 그대로 둔다 (라운드트립 보존).
+fn supplement_preview(doc: &Document) -> Option<Preview> {
+    let has_real_text = doc
+        .preview
+        .as_ref()
+        .and_then(|p| p.text.as_ref())
+        .map(|t| !t.trim().is_empty())
+        .unwrap_or(false);
+
+    if has_real_text {
+        return doc.preview.clone();
+    }
+
+    let text = build_preview_text(doc);
+    if text.trim().is_empty() {
+        return doc.preview.clone();
+    }
+
+    Some(Preview {
+        image: doc.preview.as_ref().and_then(|p| p.image.clone()),
+        text: Some(text),
+    })
+}
+
+/// 본문 문단에서 미리보기 텍스트를 만든다.
+///
+/// 한컴은 앞부분 일부만 담는다 (shortcut.hwp 실측 2044B ≈ 1022자).
+/// 표/글상자 안 텍스트는 제외하고 본문 문단만 이어 붙인다.
+fn build_preview_text(doc: &Document) -> String {
+    const MAX_CHARS: usize = 1000;
+
+    let mut out = String::new();
+    for section in &doc.sections {
+        for para in &section.paragraphs {
+            let line = para.text.trim_end_matches('\u{0}');
+            if line.is_empty() {
+                continue;
+            }
+            out.push_str(line);
+            out.push_str("\r\n");
+            if out.chars().count() >= MAX_CHARS {
+                return out.chars().take(MAX_CHARS).collect();
+            }
+        }
+    }
+    out
 }
 
 /// raw deflate 압축 (wbits=-15)

--- a/tests/issue_2387_prvtext_supplement.rs
+++ b/tests/issue_2387_prvtext_supplement.rs
@@ -1,0 +1,61 @@
+//! 템플릿 생성 문서의 PrvText 보정 회귀 테스트 (#2387).
+//!
+//! `serialize_hwp` 은 `doc.preview` 를 파싱 원본 그대로 실어 낸다(원본 보존 우선).
+//! 내장 템플릿(blank2010)으로 만든 새 문서는 템플릿 placeholder 미리보기("\r\n")를
+//! 그대로 물고 나가, 내용을 채워도 탐색기·한컴 미리보기에 빈 문서로 보인다.
+//!
+//! 수정: 원본 PrvText 가 없거나 공백/placeholder 일 때만 본문에서 새로 만든다.
+//! 실문서의 원본 미리보기는 건드리지 않아 라운드트립 보존을 깨지 않는다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::serializer::cfb_writer::serialize_hwp;
+
+fn preview_text(core: &DocumentCore) -> String {
+    core.document()
+        .preview
+        .as_ref()
+        .and_then(|p| p.text.as_ref())
+        .cloned()
+        .unwrap_or_default()
+}
+
+/// 템플릿으로 만든 문서를 직렬화하면 PrvText 가 본문을 담아야 한다.
+///
+/// 보정 전에는 placeholder "\r\n"(2B)만 남아 미리보기가 빈 문서로 보였다.
+#[test]
+fn generated_document_preview_carries_body_text() {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank 템플릿");
+    core.insert_text_native(0, 0, 0, "2026년 상반기 사업 보고서")
+        .expect("제목");
+
+    let bytes = serialize_hwp(core.document()).expect("직렬화");
+    let reparsed = DocumentCore::from_bytes(&bytes).expect("재파싱");
+
+    let prv = preview_text(&reparsed);
+    assert!(
+        prv.contains("2026년 상반기 사업 보고서"),
+        "PrvText 가 본문 제목을 담아야 한다 — 실측: {prv:?}"
+    );
+}
+
+/// 이미 실재하는 PrvText 는 재직렬화해도 보존된다(원본 보존, 중복 생성 안 함).
+#[test]
+fn existing_preview_is_preserved_on_reserialize() {
+    let mut core = DocumentCore::new_empty();
+    core.create_blank_document_native().expect("blank 템플릿");
+    core.insert_text_native(0, 0, 0, "제목 텍스트").expect("제목");
+
+    // 1차 직렬화 → PrvText 가 본문으로 보정됨
+    let bytes1 = serialize_hwp(core.document()).expect("직렬화1");
+    let doc1 = DocumentCore::from_bytes(&bytes1).expect("재파싱1");
+    let prv1 = preview_text(&doc1);
+    assert!(prv1.contains("제목 텍스트"), "1차 보정 실패: {prv1:?}");
+
+    // 2차 직렬화 → 실재하는 PrvText 를 건드리지 않고 그대로 유지
+    let bytes2 = serialize_hwp(doc1.document()).expect("직렬화2");
+    let doc2 = DocumentCore::from_bytes(&bytes2).expect("재파싱2");
+    let prv2 = preview_text(&doc2);
+
+    assert_eq!(prv1, prv2, "실재 PrvText 는 재직렬화 시 보존되어야 한다");
+}

--- a/tests/issue_2387_prvtext_supplement.rs
+++ b/tests/issue_2387_prvtext_supplement.rs
@@ -44,7 +44,8 @@ fn generated_document_preview_carries_body_text() {
 fn existing_preview_is_preserved_on_reserialize() {
     let mut core = DocumentCore::new_empty();
     core.create_blank_document_native().expect("blank 템플릿");
-    core.insert_text_native(0, 0, 0, "제목 텍스트").expect("제목");
+    core.insert_text_native(0, 0, 0, "제목 텍스트")
+        .expect("제목");
 
     // 1차 직렬화 → PrvText 가 본문으로 보정됨
     let bytes1 = serialize_hwp(core.document()).expect("직렬화1");


### PR DESCRIPTION
## 개요
내장 템플릿(`create_blank_document_native`, blank2010)으로 만든 문서를 직렬화하면 PrvText 스트림이 템플릿 placeholder(`"\r\n"`, 2B)로 남아, 제목·본문을 채워도 탐색기·한컴 미리보기에 빈 문서로 보이는 버그를 수정한다.

Closes #2387

## 원인
`serialize_hwp` 은 `doc.preview` 를 파싱 원본 그대로 실어 낸다("원본 보존 우선"). 템플릿에서 시작한 새 문서는 템플릿의 placeholder 미리보기를 그대로 물고 나간다.

## 수정
`supplement_preview()`: 원본 PrvText 가 없거나 공백/placeholder 일 때만 본문 문단에서 미리보기 텍스트를 새로 만든다. 원본 미리보기가 실재하면 건드리지 않아 라운드트립 보존을 깨지 않는다. 한컴 실측(shortcut.hwp 2044B ≈ 1022자)에 맞춰 앞부분 ~1000자로 자른다.

## 검증
회귀 테스트 `tests/issue_2387_prvtext_supplement.rs` 추가 (2 케이스):
- 템플릿 생성 문서의 PrvText 가 본문 제목을 담는다 (수정 전 `"\r\n"` placeholder)
- 실재하는 PrvText 는 재직렬화해도 보존된다 (원본 보존, 중복 생성 안 함)

수정 전 최신 main(`8d3bfa4b`) 실측: 본문에 제목이 있어도 PrvText = `"\r\n"`. 수정 후 본문 텍스트 반영. `cargo build` 정상.

> 참고: PrvImage(썸네일)는 여전히 템플릿 빈 페이지 이미지 — 렌더러 경유가 필요해 이 PR 범위 밖입니다.