### PR TITLE
fix(embed): loadFile에 suppressDialogs 옵션 — 로드 후 안내창 대기로 인한 임베더 교착 방지 (#2389)

### DIFF
--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -84,14 +84,30 @@ const editor = await createEditor(document.getElementById('editor'));
 | `requestTimeoutMs` | method별 기본값 | 모든 method 제한 시간 override(ms). 일반 10초, load/export 60초 |
 | `handshakeTimeoutMs` | `1000` | v1 협상 후 legacy 전환까지의 제한 시간(ms) |
 
-### editor.loadFile(data, fileName?)
+### editor.loadFile(data, fileName?, options?)
 
 HWP 파일을 로드합니다.
 
 ```javascript
 const result = await editor.loadFile(buffer, 'sample.hwp');
 // result = { pageCount: 5 }
+
+// 임베드 환경 권장: 로드 후 안내창 없이 열기
+await editor.loadFile(buffer, 'sample.hwpx', { suppressDialogs: true });
 ```
+
+**options:**
+
+| 옵션 | 기본값 | 설명 |
+|------|--------|------|
+| `skipUnsavedGuard` | `false` | 미저장 변경 확인 없이 문서 교체 |
+| `suppressDialogs` | `false` | 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기 |
+
+> **임베드 환경에서는 `suppressDialogs: true`를 권장합니다.** 스튜디오는 문서 로드 후
+> 안내창(HWPX 비표준 lineseg 검증, 로컬 글꼴 감지)의 사용자 선택을 기다린 뒤에
+> `loadFile` 응답을 보냅니다. iframe이 가려져 있거나 사용자가 안내창을 인지하지 못하면
+> 응답이 오지 않아 타임아웃처럼 보일 수 있습니다. `suppressDialogs: true`면 검증 경고는
+> '그대로 열기'로 처리하고 글꼴은 웹 대체 글꼴로 표시하여 즉시 응답합니다.
 
 ### editor.pageCount()
 

--- a/npm/editor/index.d.ts
+++ b/npm/editor/index.d.ts
@@ -85,10 +85,21 @@ export interface RendererDiagnosticsV1 {
   page: { index: number; canvaskit: CanvasKitRendererDiagnostics | null };
 }
 
+export interface LoadFileOptions {
+  /** 미저장 변경 확인 없이 문서 교체 */
+  skipUnsavedGuard?: boolean;
+  /**
+   * 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기.
+   * 임베드 환경에서 안내창의 사용자 선택을 기다리느라 loadFile 응답이
+   * 지연/교착되는 것을 방지한다.
+   */
+  suppressDialogs?: boolean;
+}
+
 export declare class RhwpEditor {
   private constructor();
   /** HWP 파일을 로드합니다 */
-  loadFile(data: ArrayBuffer | Uint8Array, fileName?: string): Promise<LoadResult>;
+  loadFile(data: ArrayBuffer | Uint8Array, fileName?: string, options?: LoadFileOptions): Promise<LoadResult>;
   /** 현재 문서의 페이지 수를 반환합니다 */
   pageCount(): Promise<number>;
   /** 특정 페이지를 SVG 문자열로 렌더링합니다 */

--- a/npm/editor/index.js
+++ b/npm/editor/index.js
@@ -108,6 +108,11 @@ export class RhwpEditor {
    *
    * @param data - HWP 파일의 ArrayBuffer 또는 Uint8Array
    * @param fileName - 파일 이름 (선택)
+   * @param options - 로드 옵션 (선택)
+   * @param options.skipUnsavedGuard - 미저장 변경 확인 없이 문서 교체
+   * @param options.suppressDialogs - 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기.
+   *   임베드 환경에서 안내창의 사용자 선택을 기다리느라 loadFile 응답이 지연/교착되는
+   *   것을 방지한다. 검증 경고는 '그대로 열기'로 처리되고, 글꼴은 웹 대체 글꼴로 표시된다.
    * @returns { pageCount: number }
    *
    * @example
@@ -118,8 +123,13 @@ export class RhwpEditor {
    * console.log(`${result.pageCount}페이지`);
    * ```
    */
-  async loadFile(data, fileName = 'document.hwp') {
-    return this._request('loadFile', { data, fileName });
+  async loadFile(data, fileName = 'document.hwp', options = {}) {
+    return this._request('loadFile', {
+      data,
+      fileName,
+      skipUnsavedGuard: options.skipUnsavedGuard === true,
+      suppressDialogs: options.suppressDialogs === true,
+    });
   }
 
   /**

--- a/rhwp-studio/src/embed/rpc-router.ts
+++ b/rhwp-studio/src/embed/rpc-router.ts
@@ -6,6 +6,7 @@ export interface EmbedRpcHandlers {
     data: Uint8Array,
     fileName: string,
     skipUnsavedGuard: boolean,
+    suppressDialogs: boolean,
   ): Promise<{ pageCount: number }>;
   pageCount(): Promise<number>;
   getRendererDiagnostics(page: number): Promise<EmbedRendererDiagnosticsV1>;
@@ -52,6 +53,7 @@ export async function routeEmbedRequest(
         asBytes(params.data, allowLegacyArray),
         typeof params.fileName === 'string' ? params.fileName : 'document.hwp',
         params.skipUnsavedGuard === true,
+        params.suppressDialogs === true,
       );
     case 'pageCount': return handlers.pageCount();
     case 'getRendererDiagnostics': {

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -766,7 +766,11 @@ function applySavedTextMarkSettings(): void {
   syncClipMenu(clipEnabled);
 }
 
-async function initializeDocument(docInfo: DocumentInfo, displayName: string): Promise<void> {
+async function initializeDocument(
+  docInfo: DocumentInfo,
+  displayName: string,
+  options: { suppressDialogs?: boolean } = {},
+): Promise<void> {
   const msg = sbMessage();
   let normalizedDuringLoad = false;
   try {
@@ -804,8 +808,12 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
         const report = wasm.getValidationWarnings();
         console.log(`[validation] ${report.count} warnings`, report.summary);
         if (report.count > 0) {
-          const choice = await showValidationModalIfNeeded(report);
-          console.log(`[validation] user choice: ${choice}`);
+          // embed 등 비대화형 로드에서는 모달 없이 '그대로 열기'로 진행한다 —
+          // 모달 await가 loadFile 응답을 막아 임베더가 교착되는 것을 방지 (suppressDialogs).
+          const choice = options.suppressDialogs
+            ? 'as-is'
+            : await showValidationModalIfNeeded(report);
+          console.log(`[validation] user choice: ${choice}${options.suppressDialogs ? ' (dialogs suppressed)' : ''}`);
           if (choice === 'auto-fix') {
             const n = wasm.reflowLinesegs();
             console.log(`[validation] reflowed ${n} paragraphs`);
@@ -825,7 +833,9 @@ async function initializeDocument(docInfo: DocumentInfo, displayName: string): P
       console.warn('[validation] 감지/보정 실패 (치명적이지 않음):', e);
     }
 
-    await promptLocalFontsIfNeeded(docInfo, displayName);
+    if (!options.suppressDialogs) {
+      await promptLocalFontsIfNeeded(docInfo, displayName);
+    }
 
     // 로컬 글꼴 감지 결과가 뷰를 갱신한 뒤에 캐럿을 연결해야 입력 포커스가 재설정과 경합하지 않는다.
     console.log('[initDoc] 8. inputHandler activateWithCaretPosition');
@@ -914,7 +924,7 @@ async function loadBytes(
   fileName: string,
   fileHandle: typeof wasm.currentFileHandle,
   startTime = performance.now(),
-  options: { dataReadProgressShown?: boolean; skipRecent?: boolean } = {},
+  options: { dataReadProgressShown?: boolean; skipRecent?: boolean; suppressDialogs?: boolean } = {},
 ): Promise<void> {
   if (!options.dataReadProgressShown) {
     await updateLoadProgress(0, '문서 데이터 준비 중...');
@@ -944,7 +954,9 @@ async function loadBytes(
   );
   await updateLoadProgress(50, '문서 초기화 중...');
   const elapsed = performance.now() - startTime;
-  await initializeDocument(docInfo, `${fileName} — ${docInfo.pageCount}페이지 (${elapsed.toFixed(1)}ms)`);
+  await initializeDocument(docInfo, `${fileName} — ${docInfo.pageCount}페이지 (${elapsed.toFixed(1)}ms)`, {
+    suppressDialogs: options.suppressDialogs,
+  });
 }
 
 /** 파일 메뉴 "최근 문서" 서브패널을 최신 목록으로 다시 렌더한다(메뉴 open 시 호출). */
@@ -1253,12 +1265,12 @@ installEmbedRuntime({
       await initPromise;
       return true;
     },
-    async loadFile(data, fileName, skipUnsavedGuard) {
+    async loadFile(data, fileName, skipUnsavedGuard, suppressDialogs) {
       await initPromise;
       if (!await canReplaceCurrentDocument(skipUnsavedGuard)) {
         throw new Error('문서 열기가 취소되었습니다.');
       }
-      await loadBytes(data, fileName, null);
+      await loadBytes(data, fileName, null, undefined, { suppressDialogs });
       return { pageCount: wasm.pageCount };
     },
     async pageCount() {

--- a/rhwp-studio/tests/embed-protocol.test.ts
+++ b/rhwp-studio/tests/embed-protocol.test.ts
@@ -604,3 +604,34 @@ test('embed runtime은 거부되거나 정리된 모든 transferred port의 소�
   assert.equal(bound.closed, true);
   assert.equal(bound.onmessage, null);
 });
+
+test('embed router는 suppressDialogs 파라미터를 핸들러로 전달한다 (기본 false)', async () => {
+  const calls: Array<{ skipUnsavedGuard: boolean; suppressDialogs: boolean }> = [];
+  const handlers: EmbedRpcHandlers = {
+    ready: async () => true,
+    loadFile: async (_data, _fileName, skipUnsavedGuard, suppressDialogs) => {
+      calls.push({ skipUnsavedGuard, suppressDialogs });
+      return { pageCount: 1 };
+    },
+    pageCount: async () => 1,
+    getRendererDiagnostics: async () => { throw new Error('unused'); },
+    getPageSvg: async () => '<svg/>',
+    exportHwp: async () => new Uint8Array(),
+    exportHwpx: async () => new Uint8Array(),
+    exportHml: async () => new Uint8Array(),
+    getHmlSaveState: async () => ({ sourceFormat: 'hml', hmlSavable: true, blockers: [] }),
+    exportHwpVerify: async () => ({}),
+  };
+
+  await routeEmbedRequest('loadFile', { data: new Uint8Array([1]) }, handlers);
+  await routeEmbedRequest(
+    'loadFile',
+    { data: new Uint8Array([1]), skipUnsavedGuard: true, suppressDialogs: true },
+    handlers,
+  );
+
+  assert.deepEqual(calls, [
+    { skipUnsavedGuard: false, suppressDialogs: false },
+    { skipUnsavedGuard: true, suppressDialogs: true },
+  ]);
+});


### PR DESCRIPTION
## 변경 요약

embed `loadFile` 응답이 로드 후 안내창(HWPX lineseg 검증 모달 #177, 로컬 글꼴 감지 안내창)의 **사용자 선택을 기다린 뒤에야 전송**되어, 안내창이 뜨면 임베더가 타임아웃/무한 대기에 빠지는 문제를 수정합니다. iframe 위에 로딩 오버레이를 씌우는 흔한 임베드 패턴에서는 안내창이 보이지도 않아 완전한 교착이 됩니다 (재현 로그는 이슈 참고).

opt-in `params.suppressDialogs`(기본 `false`)를 추가했습니다:

- **rpc-router**: `EmbedRpcHandlers.loadFile`에 `suppressDialogs` 파라미터 추가, `params.suppressDialogs === true` 전달
- **main.ts**: `loadBytes`/`initializeDocument`에 옵션 관통 — `true`면 검증 모달 없이 '그대로 열기(as-is)', 로컬 글꼴 안내는 건너뛰고 웹 대체 글꼴로 표시 → 로드 완료 즉시 응답
- **@rhwp/editor**: `loadFile(data, fileName, options?: { skipUnsavedGuard?, suppressDialogs? })` 노출 + README에 임베드 환경 권장 안내
- 기본값 `false`라 기존 대화형(직접 사용) 동작은 변경 없습니다. 기존 `skipUnsavedGuard` param과 같은 결의 opt-in입니다.

## 관련 이슈

closes #2389

## 테스트

- [x] `rhwp-studio` `npm test` 통과 (embed-protocol 라우터 param 전달 테스트 추가 — 기본 false/명시 true 검증)
- [x] `rhwp-studio` `tsc` 통과
- [x] `npm/editor` `node --test tests/*.mjs` 통과
- [x] 웹(WASM) 임베드 흐름 headless 재현으로 확인 — suppressDialogs 시 안내창 없이 즉시 로드 응답 (스크린샷 참고)
- [ ] `cargo test` — Rust 변경 없음 (TS/JS만)

## 스크린샷

수정 전(안내창이 loadFile 응답을 막는 상태 — 임베더는 이 화면을 볼 수 없어 교착):

이슈 #2389 재현 로그 참조. 문서는 로드 완료되었지만 "로컬 글꼴 감지" 안내창이 응답을 보류시킵니다.
