### PR TITLE
Task #2279: 분할 진입 첫 줄 full advance 요구 — spacing-누락 ladder 문서군 (92셋 100%)

### DIFF
--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -4099,7 +4099,7 @@ impl LayoutEngine {
             // 지오메트리를 신뢰한다: 정렬 기준 콘텐츠 높이를 저장 extent 로
             // 바꾸고, 문단 배치도 저장 vpos 스냅을 강제한다 (한컴 실측:
             // 가사 top = 셀 top + pad + 센터 오프셋(저장 extent 기준) + vpos).
-            let stored_flow_extent = if !has_nested_table
+            let (stored_flow_extent, stored_flow_line_sum) = if !has_nested_table
                 && !cell.paragraphs.is_empty()
                 && cell.paragraphs.iter().all(|p| !p.line_segs.is_empty())
             {
@@ -4107,10 +4107,15 @@ impl LayoutEngine {
                     .iter()
                     .flat_map(|p| p.line_segs.iter())
                     .filter(|s| s.vertical_pos >= 0 && s.line_height > 0)
-                    .map(|s| hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi))
-                    .fold(0.0f64, f64::max)
+                    .map(|s| {
+                        (
+                            hwpunit_to_px(s.vertical_pos + s.line_height, self.dpi),
+                            hwpunit_to_px(s.line_height, self.dpi),
+                        )
+                    })
+                    .fold((0.0f64, 0.0f64), |(ext, sum), (e, h)| (ext.max(e), sum + h))
             } else {
-                0.0
+                (0.0, 0.0)
             };
             // Square/중첩 표 등 비-flow 개체의 시각 bottom 은 저장 LINE_SEG 흐름에
             // 포함되지 않으므로(#1486 p19 Square 그림), 그런 개체가 저장 extent 를
@@ -4119,10 +4124,17 @@ impl LayoutEngine {
             let non_flow_object_extent = self
                 .calc_nested_controls_bottom_height(&cell.paragraphs, styles)
                 .max(self.calc_cell_wrap_objects_bottom_height(&cell.paragraphs));
+            // [#2148 #2279] 저장 vpos 흐름이 물리적으로 줄들을 담지 못하는 퇴화
+            // 형상(다문단 전부 vpos=0 등, 36399374 pi=79 병합 셀: extent 35px vs
+            // 줄높이 합 260px)은 신뢰 대상이 아니다 — 전 문단이 셀 상단 한 y 에
+            // 겹쳐 그려진다(한글은 fresh 재적층). 음수 line_spacing 누적 보정용
+            // 정상 vpos 스냅(조직도형·악보 셀)은 extent ≈ 줄높이 합이므로 0.5
+            // 비율 가드에 걸리지 않는다.
             let trust_stored_cell_flow = (depth > 0 || table.common.treat_as_char)
                 && stored_flow_extent > 0.0
                 && stored_flow_extent + 0.5 < total_content_height
-                && non_flow_object_extent <= stored_flow_extent + 0.5;
+                && non_flow_object_extent <= stored_flow_extent + 0.5
+                && stored_flow_extent + 0.5 >= 0.5 * stored_flow_line_sum;
             let total_content_height = if trust_stored_cell_flow {
                 stored_flow_extent
             } else {

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13175,7 +13175,6 @@ impl TypesetEngine {
             && !para.line_segs.is_empty()
             && st.pages.len() == page_count_before
         {
-            let height_added = st.current_height - height_before;
             // tac_seg_total 계산: 각 TAC 표의 max(seg.lh, 실측높이) + ls/2
             let mut tac_seg_total = 0.0;
             let mut tac_idx = 0;
@@ -13214,8 +13213,95 @@ impl TypesetEngine {
             } else {
                 fmt.total_height
             };
-            if height_added > cap {
-                st.current_height = height_before + cap;
+            // [#2279 누적Δ] 저장 ladder 가 host paraPr spacing 을 누락한 기계생성
+            // 결재문서(HWPX, 빈 host TAC 표): 저장 스텝(다음 문단 vpos−현 vpos)이
+            // fmt.total_height(sb+lh+ls+sa)보다 짧으면 생성기가 sa/sb 를 좌표에
+            // 반영하지 않은 것이다 — 한글 fresh 는 전량 순수 가산(36399374 재저장
+            // 오라클: pi4 +500(sa)+300(sb), pi5 +300(sb), fmt.total 과 HU 단위
+            // 일치). 이때 cap 을 fmt.total 로 올리고 ladder 를 dirty 로 표시해
+            // 후속 스냅이 성장분을 압축 anchor 로 되감지 못하게 한다. 스텝이
+            // fmt.total 과 일치(±1px)하는 정상 생성기 ladder 는 불변.
+            let stored_step_px = if st.is_hwpx_source && para.text.is_empty() {
+                para.line_segs
+                    .first()
+                    .filter(|s| {
+                        s.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
+                    })
+                    .zip(next_para.and_then(|np| np.line_segs.first()).filter(|s| {
+                        s.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
+                    }))
+                    .map(|(cur, next)| {
+                        hwpunit_to_px(
+                            (next.vertical_pos as i64 - cur.vertical_pos as i64) as i32,
+                            self.dpi,
+                        )
+                    })
+                    .filter(|&s| s > 0.0)
+            } else {
+                None
+            };
+            // 저장 스텝이 fmt.total(sb+lh+ls+sa)보다 짧고 그 부족분이 host
+            // paraPr spacing(sb+sa)과 정확히 일치하면, 생성기가 sb/sa 를 좌표에
+            // 반영하지 않은 ladder 다 — 한글 fresh 는 전량 순수 가산한다
+            // (36399374 재저장 오라클: pi4 부족분 6.7px=sa, pi5 4.0px=sb, HU
+            // 단위 일치). cap 을 fmt.total 로 올리고 ladder 를 dirty 로 표시해
+            // 후속 스냅이 성장분을 압축 anchor 로 되감지 못하게 한다.
+            // 부족분이 sb/sa 서명과 다른 ladder(#2352 host 줄박스 계열,
+            // 36392557 pi27 부족분 13.3px)는 대상이 아니다 — 그 경로의 별도
+            // 가산과 이중 성장(+1쪽 회귀 실측)한다.
+            let ladder_omits_spacing = stored_step_px
+                .filter(|&step| step + 1.0 < fmt.total_height && cap + 1.0 < fmt.total_height)
+                .map(|step| {
+                    let shortfall = fmt.total_height - step;
+                    let sig = fmt.spacing_before + fmt.spacing_after;
+                    sig > 0.5 && (shortfall - sig).abs() < 2.0
+                })
+                .unwrap_or(false);
+            if ladder_omits_spacing {
+                if std::env::var("RHWP_DIAG_LADSP").is_ok() {
+                    eprintln!(
+                        "DIAG_LADSP pi={} OMIT step={:.1} cap={:.1} fmt_total={:.1} sb={:.1} sa={:.1}",
+                        para_idx,
+                        stored_step_px.unwrap_or(0.0),
+                        cap,
+                        fmt.total_height,
+                        fmt.spacing_before,
+                        fmt.spacing_after
+                    );
+                }
+                st.vpos_ladder_dirty = true;
+            }
+            // 성장 전에 저장 anchor 로 전방 사전-스냅 — 직전 표들이 cap
+            // (lh+ls/2)으로 ladder 보다 짧게 전진한 잔차(36399374 pi3 −3.1px)를
+            // 표→표 연쇄(스냅 부재 구간)에서 회수한다. 전방·소폭 한정.
+            let snapped_base = if ladder_omits_spacing {
+                para.line_segs
+                    .first()
+                    .zip(st.vpos_page_base)
+                    .map(|(seg0, base)| {
+                        let implied = st.vpos_col_anchor
+                            + hwpunit_to_px(
+                                (seg0.vertical_pos as i64 - base as i64) as i32,
+                                self.dpi,
+                            );
+                        let delta = implied - height_before;
+                        if delta > 0.0 && delta < 24.0 {
+                            implied
+                        } else {
+                            height_before
+                        }
+                    })
+                    .unwrap_or(height_before)
+            } else {
+                height_before
+            };
+            let cap = if ladder_omits_spacing {
+                fmt.total_height
+            } else {
+                cap
+            };
+            if st.current_height - snapped_base > cap {
+                st.current_height = snapped_base + cap;
             }
         }
     }

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -2106,6 +2106,7 @@ impl FormattedParagraph {
         col_count: u16,
         allow_spacing_before_only: bool,
         ladder_dirty: bool,
+        lazy_base: bool,
     ) -> f64 {
         if col_count > 1 {
             return self.height_for_fit;
@@ -2121,11 +2122,28 @@ impl FormattedParagraph {
         let has_authoritative_seg = para.line_segs.iter().any(|seg| {
             seg.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY == 0
         });
+        // [#2279 ①-4] lazy-base(page_base 미확립) 사다리에서는 sb-형 트림의
+        // 복원(스냅)이 성립하지 않는다 — sb-형만 차단, sa-형 트림은 유지
+        // (36398700 pi31/35 −13.5px 미복원 실측 vs issue_1853 캡션 문서의
+        // sa-형 트림은 정상 복원되어 전면 차단 시 +1쪽 과다 반증).
+        let sa_trim = self.spacing_after > 0.5;
+        let sb_trim =
+            allow_spacing_before_only && self.spacing_before > 0.5 && !(lazy_base && !sa_trim);
+        if std::env::var("RHWP_DIAG_LAZYBLK").is_ok()
+            && allow_spacing_before_only
+            && self.spacing_before > 0.5
+            && lazy_base
+            && !sa_trim
+        {
+            eprintln!(
+                "DIAG_LAZYBLK sb={:.1} total={:.1} h4f={:.1}",
+                self.spacing_before, self.total_height, self.height_for_fit
+            );
+        }
         if para.controls.is_empty()
             && has_authoritative_seg
             && !ladder_dirty
-            && (self.spacing_after > 0.5
-                || (allow_spacing_before_only && self.spacing_before > 0.5))
+            && (sa_trim || sb_trim)
             && self.height_for_fit > 0.0
             && self.height_for_fit + 0.5 < self.total_height
         {
@@ -10904,10 +10922,11 @@ impl TypesetEngine {
             y = st.current_height;
         }
         // [#2279 ladder-sb] 후방 스냅량이 이 문단의 spacing_before 와 정확히
-        // 일치(±2px)하면 생성기 ladder 의 sb-누락이다 — 한글 fresh 는 sb 를
-        // 가산하므로(서브픽셀 하니스 실측: 36398709 본문 문단당 −5.0pt 균일
-        // = sb 6.7px) 스냅으로 되감지 않는다. ladder 가 sb 를 포함하는 정상
-        // 문서는 후방 스냅량이 sb 와 일치하지 않아 불변.
+        // 일치(±2px)하고, **저장 ladder 스텝 자체가 sb 를 누락**했으면 생성기
+        // ladder 의 sb-누락이다 — 한글 fresh 는 sb 를 가산하므로(서브픽셀
+        // 하니스 실측: 36398709 문단당 −5.0pt 균일 = sb 6.7px) 스냅으로 되감지
+        // 않는다. 스텝-검사 없이 ±2px 우연 일치만으로 스킵하면 sb-포함 정상
+        // ladder 에서 이중 가산(+1쪽 과다, issue_1853 실측 반증)이 난다.
         if st.is_hwpx_source
             && spacing_before_px > 0.5
             && y < st.current_height
@@ -11675,6 +11694,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_spacing_before_for_flow,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                st.vpos_page_base.is_none() && st.vpos_lazy_base.is_some(),
             );
             if std::env::var("RHWP_DIAG_ADV").is_ok() {
                 eprintln!(
@@ -11741,6 +11761,7 @@ impl TypesetEngine {
                     st.col_count,
                     trim_spacing_before_for_flow,
                     st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                    false,
                 );
                 st.current_height += advance;
                 st.flow_underrun += (fmt.total_height - advance).max(0.0);
@@ -11855,6 +11876,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_spacing_before_for_flow,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs, para_idx),
+                false,
             );
             st.current_height += advance;
             st.flow_underrun += (fmt.total_height - advance).max(0.0);
@@ -13960,6 +13982,7 @@ impl TypesetEngine {
                 st.col_count,
                 trim_sb,
                 st.vpos_ladder_dirty || !spacing_trim_restorable(paragraphs_all, next_idx),
+                false,
             );
             st.prefilled_paras.insert(next_idx);
         }

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -409,6 +409,10 @@ struct TypesetState {
     /// 렌더러(layout)와 한글은 이 성분을 가산하므로, footer(발신명의) fit 판정의
     /// 렌더-정합 좌표 복원용. 단 advance 시 0.
     flow_underrun: f64,
+    /// [#2279 pi78] 이 문서에서 저장 ladder 의 host spacing 누락 서명(OMIT)이
+    /// 검출됐는가 — 기계생성 압축 ladder 문서군 판별(문서 단위, 리셋 없음).
+    /// 분할 진입 첫 줄 full-advance 요구는 이 문서군에만 적용한다.
+    stored_ladder_spacing_omitted: bool,
     /// 현재 단 인덱스
     current_column: u16,
     /// 단 수
@@ -1747,6 +1751,7 @@ impl TypesetState {
             current_endnote_flow: false,
             prev_body_bottom_vpos: None,
             flow_underrun: 0.0,
+            stored_ladder_spacing_omitted: false,
             current_column: 0,
             col_count,
             layout,
@@ -11890,7 +11895,20 @@ impl TypesetEngine {
         let base_available = (st.base_available_height() - layout_drift_safety_px).max(0.0);
 
         // 남은 공간이 없거나 첫 줄도 못 넣으면 먼저 다음 단/페이지로
-        let first_line_h = fmt.line_heights[0];
+        // [#2279 pi78] 다중 줄 문단의 분할 진입 첫 줄은 full advance(lh+ls)를
+        // 요구한다 — 한글 COM 하단여백 18단 사다리 실측(36399374 pi78):
+        // 슬랙 < lh+ls(22.5pt)면 첫 줄을 넣지 않고 통째 이월, [lh+ls, h4f)
+        // 구간 1+1 분할, ≥ h4f 전체 수용 — 곡선 전체가 이 규칙과 일치.
+        // 트레일링 ls 트림(#359 h4f)은 문단 마지막 줄에만 해당하므로 단일 줄
+        // 문단은 종전 lh-만 유지.
+        let first_line_h = if line_count > 1 && st.stored_ladder_spacing_omitted {
+            // 적용 대상은 spacing-누락 서명이 검출된 기계생성 문서군뿐이다 —
+            // 전역/HWPX-전체 적용은 각각 2572521 별지6(HWP5, 한글 6쪽 +1)과
+            // 1733 국제고속선기준(한글-저장 HWPX, 242쪽 +2) 회귀 실측.
+            fmt.line_advance(0)
+        } else {
+            fmt.line_heights[0]
+        };
         let remaining = (available - st.current_height).max(0.0);
         // [Task #1086] 단일 단에서도 HWP가 paragraph 내부 page reset 을
         // LINE_SEG(vpos=0) 로 인코딩하는 케이스가 있다(k-water-rfp pi=66).
@@ -13258,6 +13276,7 @@ impl TypesetEngine {
                 })
                 .unwrap_or(false);
             if ladder_omits_spacing {
+                st.stored_ladder_spacing_omitted = true;
                 if std::env::var("RHWP_DIAG_LADSP").is_ok() {
                     eprintln!(
                         "DIAG_LADSP pi={} OMIT step={:.1} cap={:.1} fmt_total={:.1} sb={:.1} sa={:.1}",

--- a/tests/issue_2148_degenerate_cell_vpos.rs
+++ b/tests/issue_2148_degenerate_cell_vpos.rs
@@ -1,0 +1,113 @@
+//! Issue #2148/#2279: 셀 저장 lineSeg vpos 퇴화(다문단 전부 vpos=0) 신뢰 가드.
+//!
+//! 36399374 결재문서 pi=79 병합 셀(15문단, 전부 stored vpos=0·1줄)은 저장
+//! extent(≈35px)가 줄높이 합(≈260px)을 물리적으로 담지 못한다. 종전에는
+//! `trust_stored_cell_flow` 가 이 퇴화 흐름을 신뢰해 전 문단을 셀 상단 한
+//! y 에 겹쳐 그렸다(한글 PDF 실측: 14.4pt 피치 순차 적층). extent 가 줄높이
+//! 합의 절반에도 못 미치면 저장 흐름을 불신하고 누적 적층으로 폴백한다.
+
+use rhwp::wasm_api::HwpDocument;
+
+const SAMPLE: &str = "samples/issue_2148_degenerate_cell_vpos.hwpx";
+
+/// SVG 의 글자 단위 <text> 요소들을 (y, 문자) 로 수집한다.
+fn collect_text_chars(svg: &str) -> Vec<(f64, String)> {
+    let mut out = Vec::new();
+    let mut rest = svg;
+    while let Some(i) = rest.find("<text") {
+        rest = &rest[i..];
+        let Some(open_end) = rest.find('>') else {
+            break;
+        };
+        let attrs = &rest[..open_end];
+        let Some(close) = rest.find("</text>") else {
+            break;
+        };
+        let content = &rest[open_end + 1..close];
+        // y 는 `transform="translate(x,y)"` 또는 ` y="..."` 로 표현된다.
+        let y_val = attrs
+            .find("translate(")
+            .and_then(|ts| {
+                let tv = &attrs[ts + 10..];
+                let comma = tv.find(',')?;
+                let end = tv[comma + 1..]
+                    .find(|c: char| c == ')' || c == ' ')
+                    .map(|i| comma + 1 + i)?;
+                tv[comma + 1..end].parse::<f64>().ok()
+            })
+            .or_else(|| {
+                let ys = attrs.find(" y=\"")?;
+                let yv = &attrs[ys + 4..];
+                let ye = yv.find('"')?;
+                yv[..ye].parse::<f64>().ok()
+            });
+        if let Some(y) = y_val {
+            out.push((y, content.to_string()));
+        }
+        rest = &rest[close + 7..];
+    }
+    out
+}
+
+/// `needle` 문자열이 등장하는 줄(y 반올림 그룹)의 y 를 찾는다.
+fn line_y_containing(chars: &[(f64, String)], needle: &str) -> f64 {
+    use std::collections::BTreeMap;
+    let mut lines: BTreeMap<i64, Vec<(f64, &str)>> = BTreeMap::new();
+    for (y, c) in chars {
+        lines
+            .entry((*y * 2.0).round() as i64)
+            .or_default()
+            .push((*y, c));
+    }
+    for group in lines.values() {
+        let joined: String = group.iter().map(|(_, c)| *c).collect();
+        let compact: String = joined.chars().filter(|c| !c.is_whitespace()).collect();
+        let needle_compact: String = needle.chars().filter(|c| !c.is_whitespace()).collect();
+        if compact.contains(&needle_compact) {
+            return group[0].0;
+        }
+    }
+    panic!("no rendered line contains: {needle}");
+}
+
+#[test]
+fn issue_2148_degenerate_cell_paragraphs_stack_sequentially() {
+    let bytes = std::fs::read(SAMPLE).expect("read sample");
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse sample");
+    let svg = doc.render_page_svg_native(0).expect("render page 1");
+    let chars = collect_text_chars(&svg);
+    assert!(
+        chars.len() > 100,
+        "too few text chars: {} (svg len={}, head={})",
+        chars.len(),
+        svg.len(),
+        &svg[..svg.len().min(400)]
+    );
+
+    // 문서 순서상 뒤 문단일수록 아래에 그려져야 한다. 퇴화 vpos 신뢰 시
+    // 전부 같은 y(셀 상단)로 붕괴한다.
+    let y_15 = line_y_containing(&chars, "1.5 (안전우선)");
+    let y_23 = line_y_containing(&chars, "2.3 (차선침범)");
+    let y_242 = line_y_containing(&chars, "2.4.2 교차로 진입");
+    let y_last = line_y_containing(&chars, "비추어 차가 접근");
+
+    assert!(
+        y_23 > y_15 + 10.0,
+        "2.3 은 1.5 보다 아래여야 함: y_23={y_23:.1} y_15={y_15:.1}"
+    );
+    assert!(
+        y_242 > y_23 + 10.0,
+        "2.4.2 는 2.3 보다 아래여야 함: y_242={y_242:.1} y_23={y_23:.1}"
+    );
+    assert!(
+        y_last > y_242 + 10.0,
+        "마지막 줄은 2.4.2 보다 아래여야 함: y_last={y_last:.1} y_242={y_242:.1}"
+    );
+
+    // 16줄 총 스팬은 200px 이상 (한글 실측 ≈ 288px 스팬).
+    assert!(
+        y_last - y_15 > 200.0,
+        "셀 줄 스팬 과소: {:.1}px",
+        y_last - y_15
+    );
+}

--- a/tools/task2279/pi78_split_ladder.py
+++ b/tools/task2279/pi78_split_ladder.py
@@ -1,0 +1,112 @@
+# -*- coding: utf-8 -*-
+"""#2279 pi78 분할 정책 판별 사다리 — 하단여백 변형 × 한글 COM PDF.
+
+가설 (a) 말미 fit에 trailing ls 요구: 슬랙 +0.19pt(여백 -15HU~)부터 첫 줄 삽입.
+가설 (b) 2줄 문단 orphan 회피: 통째(45pt)가 들어갈 때까지 이월 유지.
+각 변형을 한글로 열어 PDF 저장 후, pi77('모든 재난현장') 페이지에
+pi78 line1('긴급한 출동일수록')/line2('컨트롤 필요')가 삽입됐는지와
+pi77 baseline·페이지수를 기록한다.
+"""
+import re, sys, time, zipfile, subprocess
+from pathlib import Path
+sys.stdout.reconfigure(encoding="utf-8")
+
+import argparse
+_ap = argparse.ArgumentParser()
+_ap.add_argument("--src", required=True, help="대상 HWPX (기본 실험: 36399374)")
+_ap.add_argument("--out", default="output/poc/pi78_ladder")
+_a = _ap.parse_args()
+SRC = _a.src
+TMP = Path(_a.out)
+TMP.mkdir(parents=True, exist_ok=True)
+BOTTOMS = [3600, 3585, 3570, 3550, 3520, 3480, 3440, 3400, 3300, 3200,
+           3000, 2800, 2600, 2400, 2200, 2000, 1800, 1600]
+
+MARGIN_RE = re.compile(r'(<hp:margin[^>]*bottom=")(\d+)(")')
+
+def build_variant(bottom):
+    out = TMP / f"v{bottom}.hwpx"
+    if out.exists():
+        return out
+    with zipfile.ZipFile(SRC) as zin:
+        infos = zin.infolist()
+        data = {i.filename: zin.read(i.filename) for i in infos}
+    xml = data["Contents/section0.xml"].decode("utf-8")
+    m = MARGIN_RE.search(xml)
+    xml = xml[: m.start(2)] + str(bottom) + xml[m.end(2):]
+    with zipfile.ZipFile(out, "w") as zo:
+        for zi in infos:
+            payload = xml.encode("utf-8") if zi.filename == "Contents/section0.xml" else data[zi.filename]
+            zo.writestr(zi, payload, zi.compress_type)
+    return out
+
+WORKER = r"""
+# -*- coding: utf-8 -*-
+import sys
+from pyhwpx import Hwp
+src, pdf = sys.argv[1], sys.argv[2]
+hwp = Hwp(visible=False)
+try:
+    hwp.open(src)
+    hwp.save_as(pdf, format="PDF")
+finally:
+    try: hwp.quit()
+    except Exception: pass
+"""
+(TMP / "worker.py").write_text(WORKER, encoding="utf-8")
+
+def make_pdf(doc, pdf):
+    for attempt in range(2):
+        try:
+            r = subprocess.run([sys.executable, str(TMP / "worker.py"), str(doc), str(pdf)],
+                               capture_output=True, timeout=180)
+            if Path(pdf).exists():
+                return True
+        except subprocess.TimeoutExpired:
+            pass
+        subprocess.run(["taskkill", "/IM", "Hwp.exe", "/F"], capture_output=True)
+        time.sleep(5)
+    return False
+
+def analyze(pdf, bottom):
+    import fitz
+    d = fitz.open(str(pdf))
+    body_bottom = 841.89 - bottom / 100.0
+    for pno in range(d.page_count):
+        lines = []
+        for blk in d[pno].get_text("rawdict")["blocks"]:
+            if blk["type"] != 0:
+                continue
+            for line in blk["lines"]:
+                chars = [c for span in line["spans"] for c in span["chars"]]
+                t = "".join(c["c"] for c in chars)
+                if t.strip():
+                    lines.append((chars[0]["origin"][1], t))
+        lines.sort()
+        joined = [t for _, t in lines]
+        if any("모든 재난현장" in t for t in joined):
+            bl77 = next(y for y, t in lines if "모든 재난현장" in t)
+            l1 = any("긴급한 출동일수록" in t for t in joined)
+            l2 = any("컨트롤 필요" in t for t in joined)
+            # 같은 페이지 & pi77 아래쪽인지 확인
+            if l1:
+                yl1 = next(y for y, t in lines if "긴급한 출동일수록" in t)
+                l1 = yl1 > bl77
+            if l2:
+                yl2 = next(y for y, t in lines if "컨트롤 필요" in t)
+                l2 = yl2 > bl77
+            return dict(page=pno + 1, pages=d.page_count, bl77=round(bl77, 2),
+                        slack=round(body_bottom - bl77, 2), l1=l1, l2=l2)
+    return dict(page=None, pages=d.page_count)
+
+print("bottom\tpages\tp(pi77)\tbl77\tslack_pt\tline1\tline2", flush=True)
+for b in BOTTOMS:
+    doc = build_variant(b)
+    pdf = TMP / f"v{b}.pdf"
+    if not pdf.exists():
+        ok = make_pdf(doc, pdf)
+        if not ok:
+            print(f"{b}\tERR", flush=True)
+            continue
+    r = analyze(pdf, b)
+    print(f"{b}\t{r.get('pages')}\t{r.get('page')}\t{r.get('bl77')}\t{r.get('slack')}\t{r.get('l1')}\t{r.get('l2')}", flush=True)


### PR DESCRIPTION
## 요약

다중 줄 문단의 페이지 말미 분할 진입 시 **첫 줄에 full advance(lh+ls)를 요구**한다. 한글 COM 통제 사다리로 분할 정책을 실측 판별한 결과이며, 이 수정으로 **92 컨트롤셋 92/92 (100%) 완전 소거**를 달성한다. (#2279 마지막 잔여 −1, 36399374 pi78)

## 실측 판별 (한글 COM 하단여백 18단 사다리)

경합 가설: (a) 한글은 신규 진입 줄에 trailing line-gap까지 요구 vs (b) 2줄 문단 orphan 회피(분할 금지). `tools/task2279/pi78_split_ladder.py` — 하단여백 3600→1600HU 변형 × 한글 PDF에서 pi78 첫/둘째 줄 삽입 여부 검출:

| bottom(HU) | 실슬랙(pt) | line1 | line2 | 쪽수 |
|---|---|---|---|---|
| 3600(원본), 3585 | 22.31, 22.47 | ✗ | ✗ | 8 |
| 3570~3480 | 22.62~23.51 | **○ (1+1 분할)** | ✗ | 7 |
| 3400~ (상류 유입 후 슬랙 ≥45) | — | ○ | ○ | 7 |

- 임계 = **lh+ls(22.5pt) ±0.15pt**에서 첫 줄 삽입 → (a) 확정
- 3570~3480 구간의 1+1 분할로 orphan 가설 (b) **기각**
- 전체 곡선(거절 → 1+1 → 통째 수용 at h4f)이 "신규 진입 줄은 자기 trailing ls 포함 full advance 요구 + 문단 마지막 줄만 트림(#359 h4f)"과 일치

## 수정

분할 진입의 통째-이월 판정(`remaining < first_line_h`)에서 다중 줄 문단의 첫 줄 요구를 `line_heights[0]`(lh) → `line_advance(0)`(lh+ls)로 교체. 단일 줄 문단(=자신이 마지막 줄)은 #359 트림 의미론대로 종전 유지. 분할 루프·h4f 전체-fit 판정은 불변 — 기존 규칙과의 조합만으로 실측 곡선 전체가 재현된다.

**적용 대상은 저장 ladder 의 host spacing 누락 서명(OMIT, #2383)이 검출된 기계생성 문서군으로 한정** (`TypesetState::stored_ladder_spacing_omitted`, 문서 단위). 대안 게이트는 모두 실측 기각:
- 전역 적용 → 2572521 별지6(HWP5, 한글 6쪽) +1쪽 — 358 recount 실측
- HWPX 전체 적용 → 1733 국제고속선기준(한글-저장 HWPX, 242쪽 핀) +2쪽 — nextest 실측
- 각주 reserve 게이트 → 1733 +1쪽 잔존으로 불충분

## 게이트

- **92 컨트롤셋: 92/92 일치 (100%), 회귀 0** — 캠페인 완전 소거 (86→92)
- 36399374: 7→8쪽(한글 일치), 7쪽=pi78 통째~, 8쪽=pi99 단독 — 한글 PDF 경계 동일
- 358 recount: 일치 290(SAME_OK 251+FIXED 39) — 기준선 완전 동일, 모집단 회귀 없음
- byeolpyo 4·26, 민감 핀(prep 145, sijang 313, svg_snapshot), issue_1733=242 유지
- cargo nextest 전체 3265 passed / 0 failed, fmt --check + clippy -D warnings 클린

## 스택

`pr/task2279-ladder-spacing`(#2383) 위에 스택됨 (#2376 → #2382 → #2383 → 본 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
