### PR TITLE
Task #2279: TAC-모순 host 줄박스 가산을 문단 마지막 표로 이연 (10k +8 회수)

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13776,7 +13776,12 @@ impl TypesetEngine {
             }
         } else if tac_wrap_split {
             st.current_height += table_total_height;
-        } else if let Some(host_line_px) = if st.is_hwpx_source {
+        } else if let Some(host_line_px) = if st.is_hwpx_source && is_last_placed {
+            // [#2279 10k] host 빈 줄박스는 **문단당 1개** — 다중 표 문단에서
+            // 표마다 가산하면 중간 표 배치의 fit 이 과대해져 후속 표가 조기
+            // 개행된다 (156767148 보도자료 pi7: 표2개 문단, 한글 1쪽 vs +1쪽,
+            // 10k 회귀 +29건 군집의 지배 형상). 마지막 표 배치 시점으로 이연
+            // — 단일 표 문단(36392557 pi27 장제목)은 종전과 동일.
             self.tac_topbottom_conflict_host_line_px(para, table, styles)
         } else {
             None


### PR DESCRIPTION
## 요약

TAC-모순 표의 host 줄박스 가산(#2352 CS-근사)을 **문단의 마지막 표 배치 시점으로 이연**한다. 10k 모집단 이분탐색에서 #2352가 +29건 회귀의 최대 원인으로 특정됐고, 그 지배 형상(다중 표 문단의 표별 중복 가산)을 수정해 **8건을 회수**한다.

## 배경 (10k 이분탐색, #2279 코멘트 참조)

r15 한글 COM 오라클 대조 10k 게이트에서 스택-이전 REGRESSED 53건을 12회 릴리즈 프로브로 분해한 원장: **#2352 +29(최대)**, #2309 +10, #2354 +4, #2365 +2, #2319/#2322 각 +1, 기준선 잔차 6.

## 결함 형상 (156767148 보도자료 최소 재현: 한글 1쪽 vs rhwp 2쪽)

host 빈 줄박스는 문단당 1개인데, 가산이 표 배치마다 발화해:

- 다중 표 문단에서 중간 표 배치의 fit이 과대 → 후속 표 조기 개행 (pi7: 표 2개, 둘째 표가 2쪽으로)
- 단일 표 문단은 TAC cap이 가산을 fmt.total로 되감아 무해하나, 배치 중 페이지 넘김 시 cap이 스킵돼 잔존

## 수정

가산 발화를 `is_last_placed`(문단 마지막 표)로 한정 — 중간 fit은 가산 없이 판정, 말미 가산은 종전대로 cap/dirty 처리. 단일 표 문단(36392557 장제목 계열)은 완전 불변.

## 게이트

- 10k 53셋: 53→45 (8건 회수, 회귀 0; 목록 세션 로그 보존)
- 92셋 92/92 유지, byeolpyo 4/26, 민감 핀(prep 145·sijang 313·issue_1733=242·issue_2148) 유지
- 358 recount 일치 290 기준선 동일, nextest 3265/3265, fmt+clippy 클린

## 잔여 (별도 트랙)

#2352 계열 잔여 21건(단일-표/경계 케이스)은 두 문서군(한글이 host 줄박스를 실제 가산하는 36392557 계열 vs 무가산 보도자료 계열)의 판별자가 필요 — 한글 COM 재저장 실측으로 후속.

## 스택

`pr/task2279-split-entry-advance`(#2391) 위에 스택됨 (#2376 → #2382 → #2383 → #2391 → 본 PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
