### PR TITLE
fix(studio): 계산식 쉼표 옵션이 원시 결과 위에 겹쳐 기록되는 문제 수정 (#2367)

### DIFF
--- a/rhwp-studio/src/ui/formula-dialog.ts
+++ b/rhwp-studio/src/ui/formula-dialog.ts
@@ -231,6 +231,20 @@ export class FormulaDialog extends ModalDialog {
         );
         if (formatted !== null) {
           try {
+            // [#2367] 위 evaluateTableFormula(write_result=true) 가 이미 원시 결과를 셀에
+            // 기록했다. 지우지 않고 offset 0 에 삽입하면 두 값이 겹쳐 남는다
+            // ("6,912" + "6912" → "6,9126912"). #2344 계열과 동형으로 delete 후 insert 한다.
+            // 같은 commit() 안이라 두 뮤테이션은 하나의 snapshot 으로 원자화된다.
+            const len = this.wasm.getCellParagraphLength(
+              this.ctx.sec, this.ctx.ppi, this.ctx.ci,
+              this.ctx.cellIndex, 0,
+            );
+            if (len > 0) {
+              this.wasm.deleteTextInCell(
+                this.ctx.sec, this.ctx.ppi, this.ctx.ci,
+                this.ctx.cellIndex, 0, 0, len,
+              );
+            }
             this.wasm.insertTextInCell(
               this.ctx.sec, this.ctx.ppi, this.ctx.ci,
               this.ctx.cellIndex, 0, 0, formatted,

--- a/rhwp-studio/tests/formula-comma-format.test.ts
+++ b/rhwp-studio/tests/formula-comma-format.test.ts
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2367] 계산식 쉼표 옵션 겹침 회귀 소스 가드.
+//
+// evaluateTableFormula(write_result=true) 가 원시 결과를 셀에 먼저 기록하므로, 쉼표 포맷
+// 문자열을 지우지 않고 offset 0 에 삽입하면 두 값이 겹쳐 남는다("6,912" + "6912" →
+// "6,9126912"). #2344 계열과 동형으로 delete 후 insert 해야 한다. 행위 증명(셀 텍스트
+// 회귀 게이트)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const dialogSrc = readFileSync(join(rootDir, 'src/ui/formula-dialog.ts'), 'utf8');
+
+test('쉼표 포맷은 기존 셀 텍스트를 지운 뒤 삽입한다', () => {
+  assert.match(dialogSrc, /\bthis\.wasm\.deleteTextInCell\s*\(/,
+    'delete 없이 insert 하면 원시 결과 위에 겹쳐 기록된다');
+  assert.match(dialogSrc, /\bthis\.wasm\.getCellParagraphLength\s*\(/,
+    '지울 길이는 getCellParagraphLength 로 산출해야 함');
+
+  // 순서 보장: delete 가 insert 보다 앞서야 겹침이 발생하지 않는다.
+  const deleteAt = dialogSrc.search(/\bthis\.wasm\.deleteTextInCell\s*\(/);
+  const insertAt = dialogSrc.search(/\bthis\.wasm\.insertTextInCell\s*\(/);
+  assert.ok(deleteAt >= 0 && insertAt >= 0, 'delete/insert 호출이 모두 존재해야 함');
+  assert.ok(deleteAt < insertAt, 'deleteTextInCell 이 insertTextInCell 보다 먼저 호출돼야 함');
+});
+
+test('쉼표 기록은 commit() snapshot 안에서 원자화된다', () => {
+  // 라우팅이 사라지면 셀 문자 수 변화가 미기록되어 후속 undo 오프셋이 오염된다(#2344).
+  assert.match(dialogSrc, /operationType:\s*'tableFormula'/,
+    'tableFormula snapshot 라우팅 유지');
+
+  // delete/insert 는 commit 클로저 안에 있어야 한다 — executeOperation 호출보다 앞선 위치.
+  const commitAt = dialogSrc.search(/const commit\s*=\s*\(\)\s*=>/);
+  const execAt = dialogSrc.search(/executeOperation\s*\(/);
+  const deleteAt = dialogSrc.search(/\bthis\.wasm\.deleteTextInCell\s*\(/);
+  assert.ok(commitAt >= 0 && execAt >= 0, 'commit 클로저와 executeOperation 이 존재해야 함');
+  assert.ok(deleteAt > commitAt && deleteAt < execAt,
+    'delete 는 commit() 클로저 안에 있어야 함');
+});

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -144,7 +144,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/equation-editor-dialog.ts': 2,
   'src/ui/equation-props-dialog.ts': 2,
   'src/ui/find-dialog.ts': 4,
-  'src/ui/formula-dialog.ts': 3,
+  'src/ui/formula-dialog.ts': 4, // +1: [#2367] 쉼표 포맷이 원시 결과 위에 겹치지 않도록 deleteTextInCell 추가(commit() snapshot 내부 — 라우팅 유지)
   'src/ui/new-number-dialog.ts': 1,
   'src/ui/numbering-dialog.ts': 1,
   'src/ui/page-border-dialog.ts': 1,


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel`(426b13b2) 기준으로 생성했습니다.

## 변경 요약

`=SUM(above)` 를 1234 / 5678 셀에 적용하고 **쉼표 옵션**을 켜면 결과가 겹쳐 기록됩니다.

- 기대: `6,912`
- 실제: `6,9126912`

원인은 `formula-dialog.ts` 의 `commit()` 안에서

1. `evaluateTableFormula(..., write_result=true)` 가 **원시 결과 `6912` 를 셀에 먼저 기록**하고
2. 이어서 `insertTextInCell(..., cellIndex, 0, 0, formatted)` 가 기존 텍스트를 지우지 않고
   offset 0 에 `6,912` 를 삽입하기 때문입니다.

#2344 에서 확인된 "delete 누락" 패턴과 동형입니다.

**수정**: `getCellParagraphLength` 로 현재 셀 문단 길이를 구해 `deleteTextInCell` 한 뒤
`insertTextInCell` 합니다. `table.ts` 의 셀 숫자 서식 3개 커맨드
(`table:thousand-sep` / `table:decimal-add` / `table:decimal-remove`)가 #2344 에서 채택한
방식과 동일한 형태로 맞췄습니다.

두 뮤테이션 모두 **기존 `commit()` 클로저 안**에 있으므로 `tableFormula` snapshot 으로
원자화됩니다. 즉 라우팅이 유지되어, 셀 문자 수 변화가 미기록되는 undo 오프셋 오염
(#2327 / #2344 계열)은 발생하지 않습니다.

추가한 테스트:

- `rhwp-studio/tests/formula-comma-format.test.ts` — `deleteTextInCell` 이 `insertTextInCell`
  보다 **앞서** 호출되는지, 그리고 delete 가 `commit()` 클로저 안(= `executeOperation` 라우팅
  경로)에 있는지 정적으로 핀합니다. `undo-cell-number-format.test.ts` 와 동형의 소스 가드입니다.
- `rhwp-studio/tests/mutation-routing-guard.test.ts` — `src/ui/formula-dialog.ts` baseline
  `3 → 4`. 증가분은 라우팅된 delete 호출 1건이며 사유를 주석으로 남겼습니다.

## 관련 이슈

closes #2367

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(rhwp-studio TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링·레이아웃 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 "확인하지 못한 항목" 참고.

대신 실행한 검증:

```
cd rhwp-studio && npm test
→ 360개 중 358 통과
```

실패 2건은 이 변경과 무관한 **사전 실패**이며, 변경 전 clean `devel` 에서도 동일하게
재현됨을 stash 후 재실행으로 확인했습니다.

- `tests/canvaskit-resource-key.test.ts`
- `tests/cell-flow-boundary.test.ts`

`tests/mutation-routing-guard.test.ts` 는 baseline 갱신 전에 이 변경을 정확히 잡아냈고
(`src/ui/formula-dialog.ts: 3 → 4`), 갱신 후 통과합니다.

## 확인하지 못한 항목

- **브라우저 왕복 행위 증명은 하지 못했습니다.** `undo-cell-number-format.test.ts` 의 주석에서
  이 계열 회귀의 행위 증명은 PR 검증 단계의 브라우저 왕복으로 한다고 이해했는데, 제가 절차를
  잘못 파악했다면 알려주시면 보완하겠습니다.
- `rhwp-studio` 의 `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다.
  다만 `FormulaDialog` 의 `wasm` 은 `any` 로 선언되어 있어 타입체크로 얻을 신호가 없다고 보고,
  호출 시그니처는 `core/wasm-bridge.ts` 의 선언과 직접 대조했습니다.
  - `getCellParagraphLength(sec, parentPara, controlIdx, cellIdx, cellParaIdx)`
  - `deleteTextInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset, count)`

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.