### PR TITLE
fix(studio): hwpctl 표 셀 텍스트 API 2건 수정 — SetCellText 덮어쓰기 누락 / GetCellText 시그니처 불일치

### DIFF
--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -192,6 +192,16 @@ export class HwpCtrl {
   SetCellText(tableParaIdx: number, row: number, col: number, text: string, colCount: number, controlIdx = 0): boolean {
     try {
       const cellIdx = row * colCount + col;
+      // Set 의미이므로 기존 셀 내용을 지우고 덮어쓴다. delete 없이 offset 0 에 삽입하면
+      // 기존 텍스트 앞에 붙어 누적된다(같은 셀에 두 번 호출 시 "2010" 형태). #2344 계열.
+      const len = this.wasmDoc.getCellParagraphLength(
+        this.cursorSection, tableParaIdx, controlIdx, cellIdx, 0,
+      );
+      if (len > 0) {
+        this.wasmDoc.deleteTextInCell(
+          this.cursorSection, tableParaIdx, controlIdx, cellIdx, 0, 0, len,
+        );
+      }
       const result = this.wasmDoc.insertTextInCell(
         this.cursorSection, tableParaIdx, controlIdx, cellIdx, 0, 0, text,
       );
@@ -207,8 +217,17 @@ export class HwpCtrl {
   GetCellText(tableParaIdx: number, row: number, col: number, colCount: number, controlIdx = 0): string {
     try {
       const cellIdx = row * colCount + col;
-      const path = `s${this.cursorSection}:p${tableParaIdx}:c${controlIdx}:cell${cellIdx}:p0`;
-      const result = this.wasmDoc.getTextInCellByPath(path);
+      // getTextInCellByPath 는 (sec, parentPara, pathJson, charOffset, count) 5 인자 API 이고
+      // pathJson 은 셀 경로 JSON 이다. 단일 "s0:p1:c0:cell2:p0" 문자열 하나만 넘기던 기존
+      // 호출은 어떤 WASM 시그니처와도 맞지 않아 항상 예외로 떨어져 '' 를 반환했다.
+      // SetCellText 와 동일한 인덱스 기반 API 로 맞춘다.
+      const len = this.wasmDoc.getCellParagraphLength(
+        this.cursorSection, tableParaIdx, controlIdx, cellIdx, 0,
+      );
+      if (len <= 0) return '';
+      const result = this.wasmDoc.getTextInCell(
+        this.cursorSection, tableParaIdx, controlIdx, cellIdx, 0, 0, len,
+      );
       return result || '';
     } catch (e) {
       console.error(`[hwpctl] GetCellText(pi=${tableParaIdx}, r=${row}, c=${col}) 실패:`, e);

--- a/rhwp-studio/tests/hwpctl-cell-text.test.ts
+++ b/rhwp-studio/tests/hwpctl-cell-text.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// hwpctl 표 셀 텍스트 API(SetCellText / GetCellText) 소스 가드.
+//
+// 1) SetCellText 는 Set 의미다. delete 없이 offset 0 에 insert 하면 기존 셀 텍스트 앞에
+//    붙어 누적된다(같은 셀 두 번 호출 시 "2010"). #2344/#2367 과 동일한 결함 형태다.
+// 2) GetCellText 는 getTextInCellByPath 를 단일 문자열 path 하나로 호출했는데, 해당 WASM
+//    API 는 (sec, parentPara, pathJson, charOffset, count) 5 인자다. 인자 수가 맞지 않아
+//    항상 예외로 떨어져 '' 를 반환했다.
+//
+// 행위 증명(왕복 read-back)은 브라우저 왕복(PR 검증). 여기서는 호출 형태를 정적으로 핀한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+// CRLF 체크아웃에서도 동일하게 동작하도록 개행을 정규화한다.
+const src = readFileSync(join(rootDir, 'src/hwpctl/index.ts'), 'utf8').replace(/\r\n/g, '\n');
+
+/** 메서드 본문만 잘라낸다(다른 메서드의 호출이 섞이지 않도록). */
+function methodBody(name: string): string {
+  const start = src.indexOf(`  ${name}(`);
+  assert.ok(start >= 0, `${name} 메서드가 존재해야 함`);
+  const rest = src.slice(start + 1);
+  const end = rest.indexOf('\n  }\n');
+  assert.ok(end >= 0, `${name} 본문 경계를 찾아야 함`);
+  return rest.slice(0, end);
+}
+
+test('SetCellText 는 기존 셀 텍스트를 지운 뒤 삽입한다', () => {
+  const body = methodBody('SetCellText');
+
+  assert.match(body, /getCellParagraphLength\s*\(/,
+    '지울 길이를 getCellParagraphLength 로 구해야 함');
+  assert.match(body, /deleteTextInCell\s*\(/,
+    'delete 없이 insert 하면 기존 텍스트 위에 누적된다');
+  assert.match(body, /insertTextInCell\s*\(/, 'insert 호출 유지');
+
+  const deleteAt = body.search(/deleteTextInCell\s*\(/);
+  const insertAt = body.search(/insertTextInCell\s*\(/);
+  assert.ok(deleteAt < insertAt, 'deleteTextInCell 이 insertTextInCell 보다 먼저여야 함');
+});
+
+test('GetCellText 는 인자 수가 맞는 WASM 셀 텍스트 API 를 호출한다', () => {
+  const body = methodBody('GetCellText');
+
+  // 단일 문자열 path 를 만들어 넘기던 형태가 되살아나면 다시 항상 '' 를 반환한다.
+  assert.doesNotMatch(body, /`s\$\{/,
+    '어떤 WASM 시그니처와도 맞지 않는 "s0:p1:c0:cell2:p0" 형태 path 문자열 금지');
+  assert.doesNotMatch(body, /getTextInCellByPath\s*\(\s*path\s*\)/,
+    'getTextInCellByPath 를 단일 인자로 호출 금지 — 실제 시그니처는 5 인자');
+
+  assert.match(body, /getTextInCell\s*\(/, '인덱스 기반 getTextInCell 사용');
+  assert.match(body, /getCellParagraphLength\s*\(/,
+    '읽을 길이를 getCellParagraphLength 로 구해야 함');
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`src/hwpctl/index.ts` 의 표 셀 텍스트 API 쌍에서 서로 다른 결함 2건을 확인했습니다.
대응 이슈는 없고, #2367 작업 중 같은 결함 형태를 찾다가 발견했습니다.

### 1. `SetCellText` — 덮어쓰기 누락 (`:192`)

`Set` 의미인데 기존 셀 내용을 지우지 않고 `charOffset 0` 에 삽입해서 기존 텍스트 **앞에 누적**됩니다.

- 같은 셀에 `"10"` → `"20"` 을 쓰면 결과가 `"2010"`
- 값이 들어있는 서식 표에 바인딩하면 라벨/기존값 위에 겹쳐 기록

`GetCellText` 와 짝이고 이름이 `Set` 이므로 replace 가 의도된 계약이라고 판단했습니다.
`table.ts` 의 셀 숫자 서식 3개 커맨드(#2344)와 동일하게 `getCellParagraphLength` 로 길이를
구해 `deleteTextInCell` 후 `insertTextInCell` 합니다.

**혹시 insert 의미가 의도였다면** 이 수정 대신 메서드명을 바꾸는 쪽이 맞습니다. 판단 부탁드립니다.

### 2. `GetCellText` — WASM 시그니처 불일치 (`:207`)

```ts
const path = `s${this.cursorSection}:p${tableParaIdx}:c${controlIdx}:cell${cellIdx}:p0`;
const result = this.wasmDoc.getTextInCellByPath(path);
```

`getTextInCellByPath` 는 `(section_idx, parent_para_idx, path_json, char_offset, count)` 5 인자입니다
(`src/wasm_api.rs:1183`). 단일 문자열 하나만 넘기므로 인자 수가 맞지 않아 **항상 예외로 떨어져
`''` 를 반환**합니다. 즉 `GetCellText` 는 현재 어떤 입력에도 빈 문자열만 돌려줍니다.

넘기던 `"s0:p1:c0:cell2:p0"` 형식도 저장소의 어떤 path API 와 맞지 않습니다. 저장소 전체에서
이 형식은 이 호출부 한 줄에만 존재하고, 다른 `*ByPath` API 는 모두 `(sec, parentPara, pathJson, …)`
형태입니다. `hwpctl` 의 `wasmDoc` 은 `HwpDocument.createEmpty()` 로 만든 원시 WASM 객체라
(`:375`) 래퍼가 인자를 보정해 주지도 않습니다.

`SetCellText` 와 대칭이 되도록 인덱스 기반 `getTextInCell`(`src/wasm_api.rs:2073`)로 맞췄습니다.

## 관련 이슈

없음 (자체 발견). 별도 이슈 등록이 필요하면 알려주세요.

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 360개 중 358 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, 변경 전 clean `devel` 에서도 동일하게 재현됨을 확인했습니다.

추가한 `tests/hwpctl-cell-text.test.ts` 는 **수정 전 소스에 대해 2/2 실패, 수정 후 2/2 통과**하는
것을 `git stash` 로 원본을 되돌려 실제로 확인했습니다. 즉 회귀를 잡는 가드임을 검증했습니다.

## 확인하지 못한 항목

- **브라우저 왕복 행위 증명(실제 셀 read-back)은 하지 못했습니다.** 특히 2번은 "항상 `''` 반환"
  이라는 판단이 정적 분석(인자 수 불일치 + 해당 형식의 path API 부재)에 근거합니다.
  `hwpctl-test.html` 의 `표 셀 텍스트 입력` / `예산요구서 전체 바인딩` 시나리오로 확인하실 수
  있을 것 같습니다.
- `rhwp-studio` 의 `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다.
  `wasmDoc` 이 `any` 로 선언되어 있어(`:25`) 타입체크가 이 결함을 잡지 못하는 것이
  2번이 지금까지 드러나지 않은 이유로 보입니다.

## 참고

`tests/mutation-routing-guard.test.ts` 의 스캔 대상은 `src/ui` + `src/command` +
`src/engine/input-handler*` 라 `src/hwpctl/` 은 포함되지 않습니다. 그래서 baseline 갱신은
불필요했습니다. 다만 `hwpctl` 도 직접 뮤테이션을 수행하므로 스캔 대상에 넣는 것이 좋을지는
별도 판단이 필요해 보여 이 PR 에서는 건드리지 않았습니다.

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.