### PR TITLE
fix(studio): InsertTextCommand.undo 가 astral 문자에서 인접 문자까지 삭제하는 문제 수정

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -286,7 +286,9 @@ export class InsertTextCommand implements EditCommand {
 
   undo(wasm: WasmBridge): DocumentPosition {
     this.lastMutationEffects = NO_TEXT_MUTATION_EFFECTS;
-    doDeleteText(wasm, this.position, this.text.length);
+    // [#2337-review] 삭제 count 는 char(Unicode scalar) 단위다. UTF-16 length 를 넘기면
+    // astral 문자에서 실제보다 많이 지워 인접 문자를 잃는다 → HF/FN 과 동일하게 charCount.
+    doDeleteText(wasm, this.position, charCount(this.text));
     return { ...this.position };
   }
 

--- a/rhwp-studio/tests/undo-delete-char-count.test.ts
+++ b/rhwp-studio/tests/undo-delete-char-count.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2337-review 후속] 삭제 count 의 char 단위 가드 — 본문/셀 경로.
+//
+// WASM 삭제 count 는 Rust `Paragraph::delete_text_at` 의 char(Unicode scalar) 단위다
+// (src/model/paragraph.rs). JS `String.length`(UTF-16 code unit)를 넘기면 astral 문자
+// (😀 등)에서 실제보다 많이 삭제해 undo 가 인접 문자를 잃는다.
+//
+// #2337 리뷰에서 HF/FN 경로에는 charCount() 가 적용됐지만 본문/셀의
+// InsertTextCommand.undo 에는 누락돼 있었다. 되돌아가지 않도록 정면으로 핀한다.
+// 행위 증명(😀 입력 → Ctrl+Z 왕복)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(src: string, name: string): string {
+  const start = src.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = src.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+}
+
+/** 클래스 본문에서 undo() 블록만 분리. */
+function undoBlock(block: string): string {
+  const uIdx = block.indexOf('undo(wasm: WasmBridge): DocumentPosition {');
+  assert.notEqual(uIdx, -1, 'undo 시그니처 not found');
+  return block.slice(uIdx);
+}
+
+test('InsertTextCommand.undo 는 삭제 count 를 charCount 로 계산한다', () => {
+  const undo = undoBlock(classBlock(commandSrc, 'InsertTextCommand'));
+
+  assert.match(undo, /doDeleteText\([^)]*charCount\(this\.text\)/,
+    'astral 문자 over-delete 방지 — charCount 로 코드포인트 수를 넘겨야 함');
+  assert.doesNotMatch(undo, /doDeleteText\([^)]*this\.text\.length/,
+    'UTF-16 length 를 삭제 count 로 넘기면 😀 입력 후 undo 가 인접 문자까지 지운다');
+});
+
+test('command.ts 의 삭제 count 에 UTF-16 length 를 넘기는 호출이 없다', () => {
+  // 커서 오프셋(charOffset + text.length)은 studio 의 UTF-16 관례를 유지하므로 제외하고,
+  // 삭제 count 인자만 본다.
+  const deleteCalls = /(doDeleteText|deleteTextInHeaderFooter|deleteTextInFootnote|deleteTextInCell)\(([^;]{0,400}?)\)/g;
+  const offenders: string[] = [];
+  for (const m of commandSrc.matchAll(deleteCalls)) {
+    const args = m[2];
+    // 마지막 인자(count)가 `.length` 로 끝나면 UTF-16 단위다.
+    if (/\.length\s*$/.test(args.trim())) offenders.push(m[0]);
+  }
+  assert.deepEqual(offenders, [],
+    `삭제 count 는 charCount() 로 계산해야 함:\n${offenders.join('\n')}`);
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`InsertTextCommand.undo`(`src/engine/command.ts:287`)가 삭제 count 로 JS `String.length`
(UTF-16 code unit)를 넘기고 있었습니다. WASM 삭제 count 는 Rust `Paragraph::delete_text_at`
의 char(Unicode scalar) 단위(`src/model/paragraph.rs`)라서 astral 문자에서 어긋납니다.

```
문단이 "ab", 오프셋 0 에서 "😀" 입력 → "😀ab"
Ctrl+Z 기대: "ab"
Ctrl+Z 실제: "b"      ← 😀 가 length 2 로 계산돼 'a' 까지 삭제
```

astral 문자 1개당 인접 문자 1개가 조용히 사라집니다.

이 결함 자체는 #2337 리뷰에서 이미 식별되어 `charCount()` 헬퍼가 추가됐고
(`command.ts:889`, 주석에 근거가 기록돼 있습니다), HF/FN 4곳에 적용됐습니다
(`:916`, `:942`, `:1047`, `:1072`). 다만 **본문·셀 경로인 `InsertTextCommand.undo` 에는
누락**돼 있었습니다. 같은 헬퍼를 적용해 맞췄습니다.

### 건드리지 않은 것

- **커서 오프셋**(`:274`, `:306`의 `charOffset + this.text.length`)은 그대로 뒀습니다.
  `charCount()` 주석이 "커서 오프셋은 studio 의 UTF-16 관례를 유지"라고 명시하고 있어,
  이 PR 은 삭제 count 만 char 단위로 맞추는 범위로 한정했습니다.
- `DeleteTextCommand`(`:344`)는 호출자가 char 단위 `count` 를 주므로 영향 없습니다.
- `InsertLineBreakCommand`(`:417`) / `InsertTabCommand`(`:439`)는 count 가 1 이라 무관합니다.

즉 본문/셀 경로에서 이 결함이 남아 있던 곳은 `:289` 한 곳이었습니다.

## 관련 이슈

없음 (자체 발견). #2337 리뷰 후속 성격입니다.

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 360개 중 358 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, 변경 전 clean `devel` 에서도 동일하게 재현됨을 확인했습니다.

추가한 `tests/undo-delete-char-count.test.ts` 는 **수정 전 소스에 대해 2/2 실패, 수정 후 2/2 통과**
하는 것을 `git stash` 로 원본을 되돌려 실제로 확인했습니다.

두 번째 케이스는 `command.ts` 전역에서 삭제 count 인자에 `.length` 를 넘기는 호출이 없음을
확인하는 그물이라, 앞으로 다른 경로에 같은 결함이 추가되는 것도 막습니다.

## 확인하지 못한 항목

- **브라우저에서 😀 입력 → Ctrl+Z 왕복 행위 증명은 하지 못했습니다.** 판단 근거는
  `charCount()` 주석에 기록된 동일 결함 정의와, `delete_text_at` 이 `text.chars()` 기준으로
  clamp 한다는 점입니다. 이 저장소의 undo 테스트 관례(`command-history-hffn.test.ts:9-12`)상
  행위 증명은 브라우저 왕복으로 알고 있어 그에 맞췄습니다.
- `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다. 이 변경은 기존 헬퍼
  `charCount(s: string): number` 를 같은 파일 안에서 호출하는 것이라 타입 표면 변화가 없습니다.

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.