### PR TITLE
fix(studio): 문단 3개 이상 선택 삭제의 undo 가 문단 경계를 어긋나게 복원하는 문제 수정

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -588,11 +588,13 @@ export class DeleteSelectionCommand implements EditCommand {
         for (let i = 1; i < this.savedTexts.length; i++) {
           wasm.splitParagraph(sec, currentPara, currentOffset);
           currentPara++;
-          currentOffset = 0;
           const text = this.savedTexts[i];
           if (text) {
             wasm.insertText(sec, currentPara, 0, text);
           }
+          // 다음 분할점은 방금 복원한 텍스트 "뒤" 다. 0 으로 두면 이미 복원된 텍스트 앞을
+          // 잘라 빈 문단이 끼어들고 내용이 다음 문단으로 밀린다(문단 3개 이상 선택 삭제 undo).
+          currentOffset = text ? text.length : 0;
         }
       }
     }

--- a/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
+++ b/rhwp-studio/tests/undo-delete-selection-multipara.test.ts
@@ -1,0 +1,48 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// DeleteSelectionCommand.undo 의 다중 문단 복원 분할점 가드.
+//
+// 본문 분기는 savedTexts[i] 를 복원할 때마다 splitParagraph 로 문단을 다시 만든다.
+// 이때 다음 분할점은 "방금 복원한 텍스트 뒤" 여야 한다. 0 으로 고정하면 이미 복원된
+// 텍스트 앞을 잘라, 빈 문단이 끼어들고 내용이 다음 문단으로 밀린다.
+//
+//   p5="head5"+A / p6=B / p7=C+"tail7" 를 걸쳐 선택 삭제 후 Ctrl+Z
+//   기대: p5="head5"+A, p6=B,  p7=C+"tail7"
+//   실제: p5="head5"+A, p6="", p7=C+B+"tail7"   ← 분할점이 0 으로 고정된 경우
+//
+// 문단 2개 선택(가장 흔한 경우)은 루프가 1 회라 증상이 없어 오래 살아남았다.
+// node --test 는 strip-only TS 라 engine 클래스를 실행할 수 없어(이 저장소 undo 테스트
+// 관례) 소스 배선을 정적으로 검증한다. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(src: string, name: string): string {
+  const start = src.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = src.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+}
+
+const block = classBlock(commandSrc, 'DeleteSelectionCommand');
+
+test('다중 문단 undo 의 분할점이 0 으로 고정되지 않는다', () => {
+  assert.doesNotMatch(block, /currentPara\+\+;\s*\n\s*currentOffset = 0;/,
+    '분할 직후 currentOffset 을 0 으로 고정하면 복원된 텍스트 앞을 잘라 문단이 어긋난다');
+});
+
+test('다음 분할점은 복원한 텍스트 길이에서 나온다', () => {
+  assert.match(block, /currentOffset = text \? text\.length : 0;/,
+    '다음 splitParagraph 는 방금 삽입한 텍스트 뒤에서 일어나야 함');
+
+  // 순서 보장: insertText 로 복원한 뒤에 다음 분할점을 계산해야 한다.
+  const insertAt = block.search(/wasm\.insertText\(sec, currentPara, 0, text\)/);
+  const offsetAt = block.search(/currentOffset = text \? text\.length : 0;/);
+  assert.ok(insertAt >= 0 && offsetAt >= 0, 'insertText/분할점 계산이 모두 존재해야 함');
+  assert.ok(insertAt < offsetAt, '분할점 계산은 insertText 뒤에 와야 함');
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`DeleteSelectionCommand.undo`(`src/engine/command.ts:584-597`)의 본문 다중 문단 분기가
`splitParagraph` 직후 분할점을 `0` 으로 고정하고, 그 문단에 텍스트를 복원한 뒤에도
갱신하지 않습니다. 그래서 다음 반복은 **이미 복원된 텍스트 앞** 을 다시 자릅니다.

```
p5 = "head5"+A / p6 = B / p7 = C+"tail7" 를 걸쳐 선택 삭제 → Ctrl+Z

기대: p5 = "head5"+A,  p6 = B,   p7 = C+"tail7"
실제: p5 = "head5"+A,  p6 = "",  p7 = C+B+"tail7"
```

빈 문단이 끼어들고 `B` 가 `C` 뒤로 밀려 문단 경계와 순서가 깨집니다.

### 왜 지금까지 안 드러났는가

루프가 `i = 1` 부터 돌기 때문에 **문단 2개 선택은 반복이 1 회**뿐이고, 그 1 회는
`currentOffset` 이 `start.charOffset + firstText.length` 로 올바르게 들어간 상태에서
실행됩니다. 즉 가장 흔한 2문단 선택에서는 증상이 없고, **3문단 이상**부터 나타납니다.

### 수정

다음 분할점을 방금 복원한 텍스트 길이에서 계산합니다.

```ts
const text = this.savedTexts[i];
if (text) {
  wasm.insertText(sec, currentPara, 0, text);
}
currentOffset = text ? text.length : 0;
```

오프셋 단위는 바로 위 `start.charOffset + firstText.length`(`:587`)와 동일한 UTF-16 관례를
유지했습니다. char/UTF-16 오프셋 관례 자체는 `charCount()` 주석(`:883-888`)에서 별도로
정리된 주제라 이 PR 범위에 넣지 않았습니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 360개 중 358 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, 변경 전 clean `devel` 에서도 동일하게 재현됨을 확인했습니다.

추가한 `tests/undo-delete-selection-multipara.test.ts` 는 **수정 전 소스에 대해 2/2 실패,
수정 후 2/2 통과**하는 것을 `git stash` 로 원본을 되돌려 실제로 확인했습니다.

## 확인하지 못한 항목

- **브라우저에서 3문단 선택 삭제 → Ctrl+Z 왕복 행위 증명은 하지 못했습니다.** 위 실제/기대
  동작은 `split_paragraph_native`(분할점 뒤가 새 문단) 와 `insertText(…, 0, text)` 의
  의미를 따라 추적한 결과입니다. 재현 절차가 단순하니(문단 3개 걸쳐 선택 → Delete → Ctrl+Z)
  확인해 보시면 좋겠습니다.
- `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다. 지역 변수 대입 순서만
  바뀌어 타입 표면 변화는 없습니다.

## 참고 (이 PR 범위 밖)

같은 `undo()` 의 셀 분기(`:573-583`)는 주석대로 `splitParagraph` 미지원이라 `'\n' + text`
이어붙이기로 대체돼 있어 문단 구조가 복원되지 않습니다. 또한 본문/셀 양쪽 모두 텍스트만
복원하고 문단 모양·char shape·인라인 컨트롤은 캡처하지 않습니다(#2342 와 같은 계열).
둘 다 별도 주제로 보여 건드리지 않았습니다.

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.