### PR TITLE
fix(studio): 표 리사이즈 hover marker 가 표시되지 않던 문제 수정 (pageHint 미기록)

### DIFF
--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -695,6 +695,10 @@ export function onClick(this: any, e: MouseEvent): void {
             const contentX = e.clientX - contentRect.left;
             const contentY = e.clientY - contentRect.top;
             const pageIdx = this.virtualScroll.getPageAtPoint(contentX, contentY);
+            // hover 경로(handleMouseMove)의 캐시 일치 판정이 pageHint 를 비교하므로 여기서
+            // 채워준다. 비워두면 `undefined !== pageIdx` 가 항상 참이라 hover 가 매번
+            // early return 해 표 리사이즈 marker 가 한 번도 표시되지 않는다.
+            this.cachedTableRef.pageHint = pageIdx;
             const pageOffset = this.virtualScroll.getPageOffset(pageIdx);
             const pageDisplayWidth = this.virtualScroll.getPageWidth(pageIdx);
             const pageLeft = this.virtualScroll.getPageLeftResolved(pageIdx, scrollContent.clientWidth);

--- a/rhwp-studio/tests/table-hover-pagehint.test.ts
+++ b/rhwp-studio/tests/table-hover-pagehint.test.ts
@@ -1,0 +1,38 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 표 리사이즈 hover marker 의 캐시 일치 판정 가드.
+//
+// handleMouseMove 는 `cachedTableRef.pageHint !== pageIdx` 로 캐시 유효성을 판정한다.
+// 그런데 cachedTableRef 에 값을 넣는 유일한 지점(mousedown, 셀 선택 모드)이 pageHint 를
+// 채우지 않으면 `undefined !== pageIdx` 가 항상 참이라 hover 가 매번 early return 하고,
+// 그 아래 marker 갱신 코드는 도달하지 못한다(리사이즈 marker 가 절대 표시되지 않음).
+//
+// 행위 증명(표 경계 hover → marker 표시)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler-mouse.ts'), 'utf8');
+
+test('pageHint 를 비교만 하고 채우지 않는 상태가 아니어야 한다', () => {
+  const reads = src.match(/cachedTableRef\.pageHint\s*!==/g) ?? [];
+  assert.ok(reads.length > 0, 'hover 캐시 판정이 pageHint 를 비교하고 있어야 함(전제 확인)');
+
+  // 비교하는 이상 어딘가에서 반드시 값이 채워져야 한다.
+  const writes = src.match(/cachedTableRef\.pageHint\s*=[^=]/g) ?? [];
+  assert.ok(writes.length > 0,
+    'pageHint 를 비교만 하고 대입하지 않으면 hover marker 가 영구히 표시되지 않는다');
+});
+
+test('pageHint 는 hover 판정과 같은 pageIdx 로 채운다', () => {
+  assert.match(src, /this\.cachedTableRef\.pageHint = pageIdx;/,
+    '캐시를 만든 페이지 번호를 그대로 기록해야 hover 판정과 축이 맞는다');
+
+  // pageIdx 산출보다 뒤에서 대입해야 한다(선언 전 사용 방지).
+  const pageIdxAt = src.search(/const pageIdx = this\.virtualScroll\.getPageAtPoint\(/);
+  const assignAt = src.search(/this\.cachedTableRef\.pageHint = pageIdx;/);
+  assert.ok(pageIdxAt >= 0 && assignAt >= 0, 'pageIdx 산출과 대입이 모두 존재해야 함');
+  assert.ok(pageIdxAt < assignAt, 'pageHint 대입은 pageIdx 산출 뒤여야 함');
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`handleMouseMove` 의 표 캐시 일치 판정이 `cachedTableRef.pageHint` 를 비교합니다
(`input-handler-mouse.ts:1801`).

```ts
if (!this.cachedTableRef ||
    this.cachedTableRef.sec !== tableRef.sec ||
    this.cachedTableRef.ppi !== tableRef.ppi ||
    this.cachedTableRef.ci !== tableRef.ci ||
    this.cachedTableRef.pageHint !== pageIdx) {   // ← 항상 참
  this.tableResizeRenderer.clear();
  …
  return;                                          // ← 항상 여기서 끝
}
```

그런데 `cachedTableRef` 에 **값을 넣는 유일한 지점**(`:689`)이 `pageHint` 를 채우지 않습니다.

```ts
this.cachedTableRef = { sec: ctx.sec, ppi: ctx.ppi, ci: ctx.ci };
```

나머지 대입은 전부 `null` 입니다(`:1785`, `input-handler-table.ts:1069`, `input-handler.ts:712`).
따라서 `pageHint` 는 항상 `undefined` 이고 `undefined !== pageIdx` 가 항상 참이라,
`:1810` 이후의 marker 갱신 코드가 **한 번도 실행되지 않습니다**. 표 경계에 hover 해도
리사이즈 marker 가 표시되지 않습니다.

`pageHint` 는 `input-handler.ts:307` 과 `input-handler-mouse.ts:164` 두 곳에 타입으로
선언돼 있고 비교에도 쓰이므로, 값이 채워지는 것이 원래 의도라고 판단했습니다.

### 수정

`pageIdx` 산출(`:697`) 직후 캐시에 기록합니다. `cachedTableRef` 대입(`:689`)이 `pageIdx`
산출보다 앞에 있어서 대입 시점에는 값을 알 수 없는 구조였습니다.

### 대안 (판단 부탁드립니다)

의도가 **"페이지 조건 자체가 불필요"** 였다면, `pageHint` 를 채우는 대신 `:1801` 의 비교와
두 곳의 타입 선언을 제거하는 쪽이 맞습니다. `cachedCellBboxes` 는 `getTableCellBboxes` 를
`pageHint` 없이 호출해(`:688`) 전 페이지 bbox 를 담고 있고, hover 판정은 `pageBboxes` 로
다시 페이지 필터링하므로 그쪽도 성립합니다.

지금 PR 은 **선언된 필드를 살리는 방향**을 택했습니다. 제거 쪽을 원하시면 그렇게 바꾸겠습니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 360개 중 358 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, clean `devel` 에서도 동일하게 재현됩니다.

추가한 `tests/table-hover-pagehint.test.ts` 는 **수정 전 2/2 실패, 수정 후 2/2 통과**를
`git stash` 로 원본을 되돌려 확인했습니다. "비교만 하고 대입하지 않는 상태" 자체를 핀하므로
대안(비교 제거)을 택하시면 이 테스트도 함께 조정해야 합니다.

## 확인하지 못한 항목

- **브라우저에서 표 경계 hover → marker 표시 행위 증명은 하지 못했습니다.** 판단은
  `cachedTableRef` 대입 지점 전수 확인(비-null 대입이 `:689` 하나뿐)에 근거합니다.
- `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다. `pageHint` 가 이미
  optional 로 선언돼 있어(`input-handler.ts:307`) 타입 표면 변화는 없습니다.

## 스크린샷

marker 표시 여부라 변경 전후 비교가 유의미하지만, 브라우저 검증을 못 해 첨부하지 못했습니다.