### PR TITLE
refactor: #2403 Stage 1 — SourceProvenance/LayoutCompatibilityProfile 도입 (behavior 불변)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -254,6 +254,11 @@ rhwp-studio/        ← 웹 에디터 (TypeScript + Vite)
 - `cargo clippy -- -D warnings` 경고 0건 (CI에서 강제)
 - `unwrap()` 최소화
 - 모든 문서는 한국어로 작성
+- **소스 포맷 분기**: HWP3/HWPX 등 원본 포맷에 따른 레이아웃 분기가 필요하면
+  boolean 전달이나 포맷 이름 비교 대신 `Document::layout_profile()` 질의를
+  사용합니다 (`mydocs/tech/parser_architecture.md` 의 "소스 출처와 레이아웃
+  호환 정책" 참조). 새 판별이 필요하면 profile 질의를 추가하는 방식으로
+  엽니다.
 
 ## 문서 작성 규칙
 

--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -29,3 +29,9 @@
 
 10k +8 회수, 92셋 92/92 보존. #2373 은 revert 기각·존치 추적(잔여 21건).
 devel run 에서 #2393 rust-cache 저장 재개 확인(v0-rust 2키 적재).
+
+## #2403 착수 (메인테이너 할당, 작업지시자 지시)
+
+Stage 1 Provenance/Profile — assignee 지정, local/task2403 분기, 수행계획서
+(plans/task_m100_2403.md) 작성. 현황 실측: 소스분기 참조 176곳(typeset 57 밀집).
+수행계획서 승인 대기.

--- a/mydocs/plans/task_m100_2403.md
+++ b/mydocs/plans/task_m100_2403.md
@@ -1,0 +1,63 @@
+# 수행계획서 — #2403 Stage 1: SourceProvenance / LayoutCompatibilityProfile
+
+- 이슈: #2403 (assignee: edwardkim) / 브랜치: local/task2403 / 마일스톤: M100
+- 기준 문서: `plans/refactoring_plan_2026.md` v2 **Phase P** (#1582 합의 승계)
+- 원칙: **observable behavior 불변** (bit-identical 기대), shim 유지, 소유권만 분리
+
+## 현황 (2026-07-19 실측)
+
+- `is_hwp3_variant`/`is_hwpx_source`/`is_hwp3_origin` 참조 **176곳** (src, 테스트 포함)
+- 밀집: typeset.rs 57 / text_editing.rs 29 / table_layout.rs 11 / style_resolver.rs 9 /
+  layout.rs 9 / parser 8 / rendering.rs 8 …
+- 필드 원점: `model/document.rs:55 is_hwp3_variant`, TypesetState·pagination 계열 파생
+- 착수 관문 중 verdict 재실측은 완료(최대 CC 118, #1582 종결 실측)
+
+## 단계 (각 단계 = 승인 게이트, PR 은 작은 단위 회전)
+
+### 0단계 — 착수 관문 이행 (Phase P 규정)
+
+advisory 3종 스냅샷 생성·커밋: ①public Rust API 표면(`cargo public-api` 또는
+rustdoc JSON 요약) ②WASM JSON 계약(대표 질의 출력) ③CLI output(대표 명령 ×
+대표 샘플). 이후 각 단계 게이트에서 무변동 대조.
+
+### 1단계 — 타입 도입 + 파싱 시점 확정 배선
+
+- `SourceProvenance` (model): 포맷 축(Hwp5/Hwp3/Hwpx/Hml)·재저장/생성기 서명
+  자리(초기엔 포맷 축만 실사용, 서명 필드는 #2373 판별자 트랙이 채움)
+- `LayoutCompatibilityProfile`: provenance 에서 파생되는 질의 표면 —
+  기존 boolean 의미를 1:1 매핑하는 메서드로 시작 (`hwp3_layout()`,
+  `hwpx_stored_layout()` 등, 시멘틱 개명 없이 기계 대응)
+- Document 에 provenance 보유, 기존 `is_hwp3_variant` 필드는 **shim 존치**
+  (파생 동기화) — 직렬화·라운드트립 영향 0 확인
+- 게이트: 전체 스위트 + advisory 3종 무변동 + fmt/clippy
+
+### 2단계 — 밀집 1파 이관 (renderer 코어)
+
+- typeset.rs(57)·table_layout.rs(11)·layout.rs(9) 의 직접 참조를 profile 질의로
+  기계 치환 — 로직 변경 0, 치환만. §1 금지 목록(분기 밀집 구간 해체 보류)은
+  이 단계로 해제되나 **해체는 하지 않음** (치환만, 해체는 후속 별도)
+- 게이트: bit-identical — 전체 스위트 + 대표 샘플 SVG/PDF 바이트 동일 스윕
+  (svg_snapshot 계열 + byeolpyo/민감 핀) + advisory 무변동
+
+### 3단계 — 잔여 이관 + 신규 규약
+
+- style_resolver·pagination·rendering·commands 계열 잔여 치환
+- 신규 소스분기는 profile 경유 규약: CONTRIBUTING 1절 + tech 문서
+  (`parser_architecture.md` 연계) 명문화
+- 계량: 직접 참조 176 → 목표 **필드 원점·shim·파서 확정 지점만 잔존**
+  (renderer/layout/commands 0), metrics 대시보드에 계열 참조 수 추가
+
+### 4단계 — 최종 보고
+
+before/after 계량, #2373 판별자 트랙(서명 필드 실사용)과의 이음새 명시,
+#2403 close 는 작업지시자 승인.
+
+## 위험과 완화
+
+- 학습된 위험(마스터 플랜 §1): 치환과 해체 혼합 금지 — 이 계획은 전 단계 치환만
+- text_editing.rs 29곳은 편집 커맨드 영역 — 렌더 게이트 외에 undo/원장
+  테스트(스튜디오 아님, Rust 측) 무변동 확인 포함
+- shim 이중 상태 위험: provenance 를 단일 진실로, boolean 은 read-only 파생
+  (쓰기 지점 파서 한정) — 쓰기 참조부터 이관
+
+— 0단계부터 승인 시 착수합니다.

--- a/mydocs/tech/investigations/issue-2403/README.md
+++ b/mydocs/tech/investigations/issue-2403/README.md
@@ -28,3 +28,13 @@ last_verified: 2026-07-19
   `model/provenance.rs` 신설(SourceFormat/SourceProvenance/
   LayoutCompatibilityProfile + 질의 2), `Document::layout_profile`,
   `pub mod provenance`. CLI output·render-tree 해시는 **무변동**.
+
+## 2단계 재고정 (2026-07-19)
+
+- 의도 delta (검토 완료): profile 질의 2 추가(hwp3_native_layout/
+  hwp5_origin_hwpx), LayoutEngine setter 교체(set_hwp3_variant+set_hwpx_source
+  → set_layout_profile). CLI output·render-tree 해시 **무변동**, 연결맵 414쪽
+  유지, 전체 스위트 284 바이너리 0 실패.
+- 계량: 소스분기 직접 참조 renderer 코어(typeset/layout/table·paragraph·shape
+  _layout) 77→8 (잔존 = 값 전달 자유 함수 파라미터 2쌍 + 이력 주석 4).
+  src 전체 176→105.

--- a/mydocs/tech/investigations/issue-2403/README.md
+++ b/mydocs/tech/investigations/issue-2403/README.md
@@ -19,3 +19,12 @@ last_verified: 2026-07-19
 | WASM/render-tree JSON 계약 | `advisory/render_tree_sha256.txt` | export-render-tree p0 구조 해시 3건 |
 
 재현성: 동일 커밋에서 2회 생성 `diff -r` 바이트 동일 검증 완료 (2026-07-19).
+
+## 1단계 재고정 (2026-07-19)
+
+- api_surface 정규화에서 **줄번호 제외**로 스크립트 보정 (무관 필드 추가로 전
+  항목이 밀리는 노이즈 — 1단계 실측) 후 baseline 재고정.
+- 1단계 의도 delta (검토 완료, 추가 7건뿐 — 이동/제거 0):
+  `model/provenance.rs` 신설(SourceFormat/SourceProvenance/
+  LayoutCompatibilityProfile + 질의 2), `Document::layout_profile`,
+  `pub mod provenance`. CLI output·render-tree 해시는 **무변동**.

--- a/mydocs/tech/investigations/issue-2403/README.md
+++ b/mydocs/tech/investigations/issue-2403/README.md
@@ -38,3 +38,15 @@ last_verified: 2026-07-19
 - 계량: 소스분기 직접 참조 renderer 코어(typeset/layout/table·paragraph·shape
   _layout) 77→8 (잔존 = 값 전달 자유 함수 파라미터 2쌍 + 이력 주석 4).
   src 전체 176→105.
+
+## 3단계 (2026-07-19)
+
+- document_core 필드 읽기 40곳 → profile/provenance 질의 (가변 차용 겹침 31곳
+  호이스팅, 루프 내 1곳 루프 밖 이동) + 자유 함수 3곳. **document_core 필드
+  읽기 0 달성.**
+- 규약 명문화: parser_architecture.md "소스 출처와 레이아웃 호환 정책" 절 +
+  CONTRIBUTING 코드 스타일 항목.
+- 게이트: 전체 스위트 0 실패, clippy 0, CLI·render-tree 무변동, **API 표면
+  delta 0**, 연결맵 414 유지.
+- 최종 계량: 소스분기 계열 참조 **176 → 87** — 잔존 전부 원점(파서 확정
+  지점 18)·모델 shim 선언·테스트 초기화·값 전달 파라미터·주석.

--- a/mydocs/tech/investigations/issue-2403/README.md
+++ b/mydocs/tech/investigations/issue-2403/README.md
@@ -1,0 +1,21 @@
+---
+kind: investigation
+status: active
+canonical: mydocs/tech/investigations/issue-2403/README.md
+last_verified: 2026-07-19
+---
+
+# #2403 Stage 1 — Provenance/Profile advisory baseline
+
+- 기준 commit: 생성 시점 devel merge 상태 (커밋 메시지 참조) / 빌드:
+  `cargo build --profile release-test`
+- 생성·대조: `./scripts/advisory_snapshot.sh <dir>` → 단계 게이트마다 재생성 후
+  `diff -r` (advisory — 무변동 기대, Phase P 규정 `plans/refactoring_plan_2026.md` §3·§7)
+
+| 자산 | 파일 | 내용 |
+|------|------|------|
+| public Rust API 표면 | `advisory/api_surface.txt` (3,034줄) | src pub 선언 정규화 시그니처 목록 (grep 기반 결정적 추출) |
+| CLI output 계약 | `advisory/cli_output.txt` | info·dump-pages × HWP5/HWP3/HWPX 대표 3샘플 |
+| WASM/render-tree JSON 계약 | `advisory/render_tree_sha256.txt` | export-render-tree p0 구조 해시 3건 |
+
+재현성: 동일 커밋에서 2회 생성 `diff -r` 바이트 동일 검증 완료 (2026-07-19).

--- a/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
+++ b/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
@@ -1,0 +1,3034 @@
+src/diagnostics/bench.rs:48:pub fn run(args: &[String])
+src/diagnostics/core_pages_probe.rs:29:pub fn run(args: &[String])
+src/diagnostics/hwp5_anchor_trace.rs:25:pub fn run(args: &[String])
+src/diagnostics/hwp5_borderfill_diagonal_probe.rs:82:pub fn run(args: &[String])
+src/diagnostics/hwp5_cell_header_probe.rs:138:pub fn run(args: &[String])
+src/diagnostics/hwp5_contract_analyze.rs:66:pub fn run(args: &[String])
+src/diagnostics/hwp5_contract_probe.rs:78:pub fn run(args: &[String])
+src/diagnostics/hwp5_ctrl_data_trace.rs:22:pub fn run(args: &[String])
+src/diagnostics/hwp5_first_para_control_probe.rs:91:pub fn run(args: &[String])
+src/diagnostics/hwp5_inventory.rs:186:pub fn build_inventory(path: &Path, section_filter: Option<u32>) -> Result<Hwp5Inventory, String>
+src/diagnostics/hwp5_inventory.rs:43:pub struct Hwp5InventoryItem
+src/diagnostics/hwp5_inventory.rs:72:pub struct Hwp5Inventory
+src/diagnostics/hwp5_inventory.rs:83:pub fn run(args: &[String])
+src/diagnostics/hwp5_inventory_diff.rs:190:pub fn run(args: &[String])
+src/diagnostics/hwp5_mel_personnel_probe.rs:84:pub fn run(args: &[String])
+src/diagnostics/hwp5_roundtrip_batch.rs:369:pub fn baseline_check(bytes: &[u8]) -> Result<(), String>
+src/diagnostics/hwp5_roundtrip_batch.rs:525:pub fn run(args: &[String])
+src/diagnostics/hwp5_table_probe.rs:90:pub fn run(args: &[String])
+src/diagnostics/hwpx_roundtrip_batch.rs:437:pub fn run(args: &[String])
+src/diagnostics/mod.rs:10:pub mod hwp5_ctrl_data_trace
+src/diagnostics/mod.rs:11:pub mod hwp5_first_para_control_probe
+src/diagnostics/mod.rs:12:pub mod hwp5_inventory
+src/diagnostics/mod.rs:13:pub mod hwp5_inventory_diff
+src/diagnostics/mod.rs:14:pub mod hwp5_mel_personnel_probe
+src/diagnostics/mod.rs:15:pub mod hwp5_roundtrip_batch
+src/diagnostics/mod.rs:16:pub mod hwp5_table_probe
+src/diagnostics/mod.rs:17:pub mod hwpx_roundtrip_batch
+src/diagnostics/mod.rs:18:pub mod render_geom_diff
+src/diagnostics/mod.rs:19:pub mod text_width_probe
+src/diagnostics/mod.rs:3:pub mod bench
+src/diagnostics/mod.rs:4:pub mod core_pages_probe
+src/diagnostics/mod.rs:5:pub mod hwp5_anchor_trace
+src/diagnostics/mod.rs:6:pub mod hwp5_borderfill_diagonal_probe
+src/diagnostics/mod.rs:7:pub mod hwp5_cell_header_probe
+src/diagnostics/mod.rs:8:pub mod hwp5_contract_analyze
+src/diagnostics/mod.rs:9:pub mod hwp5_contract_probe
+src/diagnostics/render_geom_diff.rs:100: pub fn page_count_mismatch(&self) -> bool
+src/diagnostics/render_geom_diff.rs:105: pub fn any_structure_mismatch(&self) -> bool
+src/diagnostics/render_geom_diff.rs:20:pub enum Via
+src/diagnostics/render_geom_diff.rs:29:pub struct NodeDelta
+src/diagnostics/render_geom_diff.rs:383:pub fn diff_page(page: u32, root_a: &RenderNode, root_b: &RenderNode) -> PageGeomDiff
+src/diagnostics/render_geom_diff.rs:42: pub fn disp(&self) -> f64
+src/diagnostics/render_geom_diff.rs:437:pub fn diff_render_geometry(a: &DocumentCore, b: &DocumentCore) -> Result<DocGeomDiff, HwpError>
+src/diagnostics/render_geom_diff.rs:461:pub fn roundtrip_geom(data: &[u8], via: Via) -> Result<DocGeomDiff, HwpError>
+src/diagnostics/render_geom_diff.rs:53:pub struct TypeDelta
+src/diagnostics/render_geom_diff.rs:61: pub fn net(&self) -> i64
+src/diagnostics/render_geom_diff.rs:68:pub struct PageGeomDiff
+src/diagnostics/render_geom_diff.rs:90:pub struct DocGeomDiff
+src/diagnostics/render_geom_diff.rs:929:pub fn run(args: &[String])
+src/diagnostics/text_width_probe.rs:16:pub fn run(args: &[String])
+src/document_core/builders/exam_paper.rs:33:pub fn build_exam_paper(ingest: &IngestDocument) -> Document
+src/document_core/builders/mod.rs:17:pub mod exam_paper
+src/document_core/commands/clipboard.rs:1004: pub fn paste_control_native(
+src/document_core/commands/clipboard.rs:1195: pub fn export_selection_html_native(
+src/document_core/commands/clipboard.rs:1235: pub fn export_selection_in_cell_html_native(
+src/document_core/commands/clipboard.rs:1289: pub fn export_control_html_native(
+src/document_core/commands/clipboard.rs:1644: pub fn get_control_image_data_native(
+src/document_core/commands/clipboard.rs:1686: pub fn get_control_image_mime_native(
+src/document_core/commands/clipboard.rs:1728: pub fn get_bin_data_image_data_native(&self, bin_data_id: u16) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/clipboard.rs:1745: pub fn get_bin_data_image_mime_native(&self, bin_data_id: u16) -> Result<String, HwpError>
+src/document_core/commands/clipboard.rs:276: pub fn has_internal_clipboard_native(&self) -> bool
+src/document_core/commands/clipboard.rs:281: pub fn get_clipboard_text_native(&self) -> String
+src/document_core/commands/clipboard.rs:289: pub fn clear_clipboard_native(&mut self)
+src/document_core/commands/clipboard.rs:310: pub fn copy_selection_native(
+src/document_core/commands/clipboard.rs:398: pub fn copy_selection_in_cell_native(
+src/document_core/commands/clipboard.rs:488: pub fn copy_control_native(
+src/document_core/commands/clipboard.rs:589: pub fn paste_internal_native(
+src/document_core/commands/clipboard.rs:791: pub fn paste_internal_in_cell_native(
+src/document_core/commands/clipboard.rs:875: pub fn paste_internal_in_cell_by_path_native(
+src/document_core/commands/clipboard.rs:981: pub fn clipboard_has_control_native(&self) -> bool
+src/document_core/commands/document.rs:1087: pub fn create_blank_document_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs:1124: pub fn export_hwp_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs:1135: pub fn export_hwp_with_adapter(&mut self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs:1157: pub fn serialize_hwp_with_verify(&mut self) -> Result<HwpExportVerification, HwpError>
+src/document_core/commands/document.rs:1174: pub fn export_hwpx_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs:1196: pub fn export_hml_native(&self) -> Result<Vec<u8>, crate::serializer::hml::HmlExportError>
+src/document_core/commands/document.rs:1206: pub fn hml_export_preflight(&self) -> Result<(), crate::serializer::hml::HmlExportError>
+src/document_core/commands/document.rs:1429: pub fn convert_to_editable_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs:1435: pub fn document(&self) -> &Document
+src/document_core/commands/document.rs:1441: pub fn document_mut(&mut self) -> &mut Document
+src/document_core/commands/document.rs:1446: pub fn set_document(&mut self, doc: Document)
+src/document_core/commands/document.rs:1460: pub fn begin_batch_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs:1468: pub fn end_batch_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs:1480: pub fn save_snapshot_native(&mut self) -> u32
+src/document_core/commands/document.rs:1498: pub fn restore_snapshot_native(&mut self, id: u32) -> Result<String, HwpError>
+src/document_core/commands/document.rs:1526: pub fn discard_snapshot_native(&mut self, id: u32)
+src/document_core/commands/document.rs:1530: pub fn measure_width_diagnostic_native(
+src/document_core/commands/document.rs:25:pub struct HwpExportVerification
+src/document_core/commands/document.rs:47: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
+src/document_core/commands/document.rs:55: pub fn from_bytes(data: &[u8]) -> Result<DocumentCore, HwpError>
+src/document_core/commands/document.rs:995: pub fn reflow_linesegs_on_demand(&mut self) -> usize
+src/document_core/commands/footnote_ops.rs:128: pub fn delete_footnote_native(
+src/document_core/commands/footnote_ops.rs:328: pub fn get_para_properties_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:347: pub fn apply_para_format_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:418: pub fn get_footnote_info_native(
+src/document_core/commands/footnote_ops.rs:475: pub fn insert_text_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:509: pub fn delete_text_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:545: pub fn split_paragraph_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:623: pub fn merge_paragraph_in_footnote_native(
+src/document_core/commands/footnote_ops.rs:75: pub fn get_footnote_at_cursor_native(
+src/document_core/commands/formatting.rs:1038: pub fn set_char_shape_id_native(
+src/document_core/commands/formatting.rs:1099: pub fn apply_char_format_in_cell_native(
+src/document_core/commands/formatting.rs:1189: pub fn set_char_shape_id_in_cell_native(
+src/document_core/commands/formatting.rs:1239: pub fn apply_para_format_native(
+src/document_core/commands/formatting.rs:1336: pub fn set_para_shape_id_native(
+src/document_core/commands/formatting.rs:1392: pub fn apply_para_format_in_cell_native(
+src/document_core/commands/formatting.rs:1510: pub fn set_cell_para_shape_id_native(
+src/document_core/commands/formatting.rs:1715: pub fn apply_style_native(
+src/document_core/commands/formatting.rs:1809: pub fn apply_cell_style_native(
+src/document_core/commands/formatting.rs:184: pub fn get_cell_para_properties_at_native(
+src/document_core/commands/formatting.rs:1942: pub fn set_numbering_restart_native(
+src/document_core/commands/formatting.rs:1980: pub fn set_page_hide_native(
+src/document_core/commands/formatting.rs:2054: pub fn get_page_hide_native(
+src/document_core/commands/formatting.rs:49: pub fn get_char_properties_at_native(
+src/document_core/commands/formatting.rs:68: pub fn get_cell_char_properties_at_native(
+src/document_core/commands/formatting.rs:859: pub fn find_or_create_font_id_native(&mut self, name: &str) -> i32
+src/document_core/commands/formatting.rs:905: pub fn find_or_create_font_id_for_lang(&mut self, lang: usize, name: &str) -> i32
+src/document_core/commands/formatting.rs:90: pub fn get_para_properties_at_native(
+src/document_core/commands/formatting.rs:966: pub fn apply_char_format_native(
+src/document_core/commands/header_footer_ops.rs:115: pub fn create_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:257: pub fn insert_text_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:300: pub fn delete_text_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:346: pub fn split_paragraph_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:418: pub fn merge_paragraph_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:483: pub fn get_header_footer_para_info_native(
+src/document_core/commands/header_footer_ops.rs:525: pub fn delete_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:570: pub fn get_header_footer_list_native(
+src/document_core/commands/header_footer_ops.rs:621: pub fn navigate_header_footer_by_page_native(
+src/document_core/commands/header_footer_ops.rs:701: pub fn toggle_hide_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:72: pub fn get_header_footer_native(
+src/document_core/commands/header_footer_ops.rs:730: pub fn is_header_footer_hidden(&self, page_num: u32, is_header: bool) -> bool
+src/document_core/commands/header_footer_ops.rs:780: pub fn get_para_properties_in_hf_native(
+src/document_core/commands/header_footer_ops.rs:796: pub fn apply_para_format_in_hf_native(
+src/document_core/commands/header_footer_ops.rs:867: pub fn insert_field_in_hf_native(
+src/document_core/commands/header_footer_ops.rs:920: pub fn apply_hf_template_native(
+src/document_core/commands/html_import.rs:12: pub fn paste_html_native(
+src/document_core/commands/html_import.rs:316: pub fn paste_html_in_cell_native(
+src/document_core/commands/html_import.rs:385: pub fn paste_html_in_cell_by_path_native(
+src/document_core/commands/object_ops/common.rs:272: pub fn move_line_endpoint_native(
+src/document_core/commands/object_ops/common.rs:342: pub fn insert_new_number_native(
+src/document_core/commands/object_ops/connector.rs:14: pub fn update_connector_subject_ids(
+src/document_core/commands/object_ops/connector.rs:213: pub fn update_connectors_in_section(&mut self, section_idx: usize)
+src/document_core/commands/object_ops/connector.rs:41: pub fn recalculate_connector_routing(
+src/document_core/commands/object_ops/equation.rs:173: pub fn get_equation_properties_native(
+src/document_core/commands/object_ops/equation.rs:192: pub fn set_equation_properties_native(
+src/document_core/commands/object_ops/equation.rs:231: pub fn render_equation_preview_native(
+src/document_core/commands/object_ops/equation.rs:258: pub fn delete_equation_control_native(
+src/document_core/commands/object_ops/equation.rs:362: pub fn insert_equation_native(
+src/document_core/commands/object_ops/note.rs:106: pub fn set_note_equation_properties_native(
+src/document_core/commands/object_ops/note.rs:281: pub fn insert_footnote_native(
+src/document_core/commands/object_ops/note.rs:594: pub fn insert_endnote_native(
+src/document_core/commands/object_ops/note.rs:87: pub fn get_note_equation_properties_native(
+src/document_core/commands/object_ops/picture.rs:113: pub fn get_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs:1166: pub fn delete_picture_control_native(
+src/document_core/commands/object_ops/picture.rs:1323: pub fn assign_picture_image_native(
+src/document_core/commands/object_ops/picture.rs:1412: pub fn insert_picture_native(
+src/document_core/commands/object_ops/picture.rs:278: pub fn get_header_footer_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs:454: pub fn set_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs:609: pub fn set_header_footer_picture_properties_native(
+src/document_core/commands/object_ops/shape.rs:1093: pub fn create_shape_control_native(
+src/document_core/commands/object_ops/shape.rs:1566: pub fn change_shape_z_order_native(
+src/document_core/commands/object_ops/shape.rs:1873: pub fn group_shapes_native(
+src/document_core/commands/object_ops/shape.rs:2145: pub fn ungroup_shape_native(
+src/document_core/commands/object_ops/shape.rs:2456: pub fn get_endnote_shape_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/commands/object_ops/shape.rs:2517: pub fn apply_endnote_shape_native(
+src/document_core/commands/object_ops/shape.rs:259: pub fn get_shape_properties_native(
+src/document_core/commands/object_ops/shape.rs:383: pub fn set_shape_properties_native(
+src/document_core/commands/object_ops/shape.rs:991: pub fn delete_shape_control_native(
+src/document_core/commands/object_ops/table.rs:1278: pub fn get_cell_picture_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs:1302: pub fn get_cell_shape_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs:1336: pub fn set_cell_picture_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs:1407: pub fn delete_cell_picture_control_by_path_native(
+src/document_core/commands/object_ops/table.rs:1503: pub fn set_cell_shape_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs:364: pub fn create_table_native(
+src/document_core/commands/object_ops/table.rs:771: pub fn create_table_ex_native(
+src/document_core/commands/table_ops.rs:105: pub fn delete_table_row_native(
+src/document_core/commands/table_ops.rs:136: pub fn delete_table_column_native(
+src/document_core/commands/table_ops.rs:1599: pub fn set_table_column_widths_native(
+src/document_core/commands/table_ops.rs:1654: pub fn fit_table_to_page_native(
+src/document_core/commands/table_ops.rs:167: pub fn merge_table_cells_native(
+src/document_core/commands/table_ops.rs:199: pub fn split_table_cell_native(
+src/document_core/commands/table_ops.rs:230: pub fn split_table_cell_into_native(
+src/document_core/commands/table_ops.rs:2539: pub fn delete_table_control_native(
+src/document_core/commands/table_ops.rs:265: pub fn split_table_cells_in_range_native(
+src/document_core/commands/table_ops.rs:2677: pub fn evaluate_table_formula(
+src/document_core/commands/table_ops.rs:309: pub fn copy_table_cells_transposed_native(
+src/document_core/commands/table_ops.rs:336: pub fn paste_table_cells_transposed_native(
+src/document_core/commands/table_ops.rs:388: pub fn transpose_table_cells_in_place_native(
+src/document_core/commands/table_ops.rs:41: pub fn insert_table_row_native(
+src/document_core/commands/table_ops.rs:432: pub fn paste_table_cells_transposed_as_new_table_native(
+src/document_core/commands/table_ops.rs:479: pub fn has_table_transpose_clipboard_native(&self) -> bool
+src/document_core/commands/table_ops.rs:73: pub fn insert_table_column_native(
+src/document_core/commands/text_editing.rs:1542: pub fn split_paragraph_native(
+src/document_core/commands/text_editing.rs:1792: pub fn insert_page_break_native(
+src/document_core/commands/text_editing.rs:1874: pub fn insert_column_break_native(
+src/document_core/commands/text_editing.rs:1950: pub fn set_column_def_native(
+src/document_core/commands/text_editing.rs:2021: pub fn merge_paragraph_native(
+src/document_core/commands/text_editing.rs:2153: pub fn delete_paragraph_native(
+src/document_core/commands/text_editing.rs:2265: pub fn insert_paragraph_native(
+src/document_core/commands/text_editing.rs:2367: pub fn split_paragraph_in_cell_native(
+src/document_core/commands/text_editing.rs:2466: pub fn merge_paragraph_in_cell_native(
+src/document_core/commands/text_editing.rs:2587: pub fn get_paragraph_count_native(&self, section_idx: usize) -> Result<usize, HwpError>
+src/document_core/commands/text_editing.rs:2599: pub fn get_paragraph_length_native(
+src/document_core/commands/text_editing.rs:2623: pub fn get_textbox_control_index_native(&self, section_idx: usize, para_idx: usize) -> i32
+src/document_core/commands/text_editing.rs:2651: pub fn find_next_editable_control_native(
+src/document_core/commands/text_editing.rs:2816: pub fn find_nearest_control_backward_native(
+src/document_core/commands/text_editing.rs:2909: pub fn find_nearest_control_forward_native(
+src/document_core/commands/text_editing.rs:2999: pub fn get_text_range_native(
+src/document_core/commands/text_editing.rs:3034: pub fn get_cell_paragraph_count_native(
+src/document_core/commands/text_editing.rs:3089: pub fn get_cell_paragraph_length_native(
+src/document_core/commands/text_editing.rs:3115: pub fn get_text_in_cell_native(
+src/document_core/commands/text_editing.rs:3369: pub fn insert_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs:3442: pub fn delete_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs:3472: pub fn split_paragraph_in_cell_by_path(
+src/document_core/commands/text_editing.rs:3557: pub fn merge_paragraph_in_cell_by_path(
+src/document_core/commands/text_editing.rs:3646: pub fn get_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs:439: pub fn insert_text_native(
+src/document_core/commands/text_editing.rs:594: pub fn delete_text_native(
+src/document_core/commands/text_editing.rs:753: pub fn insert_text_in_cell_native(
+src/document_core/commands/text_editing.rs:777: pub fn insert_text_in_cell_native_deferred_pagination(
+src/document_core/commands/text_editing.rs:951: pub fn delete_text_in_cell_native(
+src/document_core/converters/common_obj_attr_writer.rs:28:pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8>
+src/document_core/converters/diagnostics.rs:15:pub struct IrFieldDiff
+src/document_core/converters/diagnostics.rs:186:pub fn diff_hwpx_vs_hwp(hwpx: &Document, hwp: &Document) -> DiffSummary
+src/document_core/converters/diagnostics.rs:28:pub struct DiffSummary
+src/document_core/converters/diagnostics.rs:33: pub fn new() -> Self
+src/document_core/converters/diagnostics.rs:37: pub fn push(&mut self, item: IrFieldDiff)
+src/document_core/converters/diagnostics.rs:42: pub fn counts_by_area(&self) -> Vec<(&'static str, usize)>
+src/document_core/converters/diagnostics.rs:52: pub fn human_report(&self) -> String
+src/document_core/converters/diagnostics.rs:81:pub fn diff_hwpx_vs_serializer_assumptions(hwpx: &Document) -> DiffSummary
+src/document_core/converters/hwpx_to_hwp.rs:109: pub fn new() -> Self
+src/document_core/converters/hwpx_to_hwp.rs:113: pub fn no_op(mut self, reason: impl Into<String>) -> Self
+src/document_core/converters/hwpx_to_hwp.rs:119: pub fn changed_anything(&self) -> bool
+src/document_core/converters/hwpx_to_hwp.rs:1588:pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin"
+src/document_core/converters/hwpx_to_hwp.rs:1593:pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> AdapterReport
+src/document_core/converters/hwpx_to_hwp.rs:177:pub fn convert_hwpx_to_hwp_ir(doc: &mut Document) -> AdapterReport
+src/document_core/converters/hwpx_to_hwp.rs:37:pub struct AdapterReport
+src/document_core/converters/mod.rs:10:pub mod hwpx_to_hwp
+src/document_core/converters/mod.rs:8:pub mod common_obj_attr_writer
+src/document_core/converters/mod.rs:9:pub mod diagnostics
+src/document_core/mod.rs:11:pub mod converters
+src/document_core/mod.rs:13:pub mod queries
+src/document_core/mod.rs:14:pub mod table_calc
+src/document_core/mod.rs:155:pub struct ActiveFieldInfo
+src/document_core/mod.rs:15:pub mod validation
+src/document_core/mod.rs:169: pub fn page_count(&self) -> u32
+src/document_core/mod.rs:178: pub fn get_document_info(&self) -> String
+src/document_core/mod.rs:234: pub fn serialize_event_log(&self) -> String
+src/document_core/mod.rs:239: pub fn set_dpi(&mut self, dpi: f64)
+src/document_core/mod.rs:251: pub fn new_empty() -> Self
+src/document_core/mod.rs:293: pub fn hml_metadata(&self) -> Option<&crate::parser::HmlImportMetadata>
+src/document_core/mod.rs:302: pub fn validation_report(&self) -> &validation::ValidationReport
+src/document_core/mod.rs:32:pub const DEFAULT_FALLBACK_FONT: &str = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+src/document_core/mod.rs:51:pub struct DocumentCore
+src/document_core/mod.rs:9:pub mod builders
+src/document_core/queries/bookmark_query.rs:103: pub fn delete_bookmark_native(
+src/document_core/queries/bookmark_query.rs:142: pub fn rename_bookmark_native(
+src/document_core/queries/bookmark_query.rs:21: pub fn get_bookmarks_native(&self) -> Result<String, HwpError>
+src/document_core/queries/bookmark_query.rs:43: pub fn add_bookmark_native(
+src/document_core/queries/cursor_rect.rs:1360: pub fn hit_test_native(&self, page_num: u32, x: f64, y: f64) -> Result<String, HwpError>
+src/document_core/queries/cursor_rect.rs:2566: pub fn get_cursor_rect_in_cell_native(
+src/document_core/queries/cursor_rect.rs:256: pub fn get_cursor_rect_native(
+src/document_core/queries/cursor_rect.rs:3706: pub fn get_cursor_rect_in_header_footer_native(
+src/document_core/queries/cursor_rect.rs:3866: pub fn hit_test_header_footer_native(
+src/document_core/queries/cursor_rect.rs:3983: pub fn hit_test_in_header_footer_native(
+src/document_core/queries/cursor_rect.rs:4172: pub fn hit_test_footnote_native(
+src/document_core/queries/cursor_rect.rs:4220: pub fn hit_test_in_footnote_native(
+src/document_core/queries/cursor_rect.rs:4447: pub fn get_selection_rects_in_footnote_native(
+src/document_core/queries/cursor_rect.rs:4746: pub fn get_note_edit_info_native(
+src/document_core/queries/cursor_rect.rs:4792: pub fn get_cursor_rect_in_note_native(
+src/document_core/queries/cursor_rect.rs:4864: pub fn get_cursor_rect_in_footnote_native(
+src/document_core/queries/cursor_rect.rs:5039: pub fn hit_test_body_footnote_marker_native(
+src/document_core/queries/cursor_rect.rs:5125: pub fn get_page_footnote_info_native(
+src/document_core/queries/doc_tree_nav.rs:18:pub struct OverflowLink
+src/document_core/queries/doc_tree_nav.rs:33:pub struct NavContextEntry
+src/document_core/queries/doc_tree_nav.rs:48:pub enum NavResult
+src/document_core/queries/field_query.rs:130: pub fn insert_click_here_field_at_in_cell(
+src/document_core/queries/field_query.rs:14:pub struct FieldLocation
+src/document_core/queries/field_query.rs:192: pub fn insert_click_here_field_at_by_path(
+src/document_core/queries/field_query.rs:23:pub enum NestedEntry
+src/document_core/queries/field_query.rs:242: pub fn get_field_list_json(&self) -> String
+src/document_core/queries/field_query.rs:271: pub fn get_field_value_by_id(&self, field_id: u32) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs:285: pub fn get_field_value_by_name(&self, name: &str) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs:302: pub fn set_field_value_by_id(
+src/document_core/queries/field_query.rs:331: pub fn set_field_value_by_name(&mut self, name: &str, value: &str) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs:39:pub struct FieldInfo
+src/document_core/queries/field_query.rs:50: pub fn collect_all_fields(&self) -> Vec<FieldInfo>
+src/document_core/queries/field_query.rs:649: pub fn remove_field_at(
+src/document_core/queries/field_query.rs:667: pub fn remove_field_at_in_cell(
+src/document_core/queries/field_query.rs:66: pub fn insert_click_here_field_at(
+src/document_core/queries/field_query.rs:727: pub fn set_active_field(
+src/document_core/queries/field_query.rs:752: pub fn set_active_field_in_cell(
+src/document_core/queries/field_query.rs:790: pub fn clear_active_field(&mut self)
+src/document_core/queries/field_query.rs:801: pub fn get_field_info_at(
+src/document_core/queries/field_query.rs:820: pub fn get_field_info_at_in_cell(
+src/document_core/queries/field_query.rs:858: pub fn get_field_info_at_by_path(
+src/document_core/queries/field_query.rs:872: pub fn set_active_field_by_path(
+src/document_core/queries/form_query.rs:128: pub fn set_form_value_in_cell_native(
+src/document_core/queries/form_query.rs:15: pub fn get_form_object_at_native(
+src/document_core/queries/form_query.rs:174: pub fn get_form_object_info_native(
+src/document_core/queries/form_query.rs:64: pub fn get_form_value_native(
+src/document_core/queries/form_query.rs:97: pub fn set_form_value_native(
+src/document_core/queries/mod.rs:7:pub mod rendering
+src/document_core/queries/mod.rs:9:pub mod structure
+src/document_core/queries/rendering.rs:1085:pub struct PngExportOptions
+src/document_core/queries/rendering.rs:1102:pub enum VlmTarget
+src/document_core/queries/rendering.rs:1120: pub fn constraints(&self) -> (i32, u64)
+src/document_core/queries/rendering.rs:1133: pub fn from_str(s: &str) -> Option<Self>
+src/document_core/queries/rendering.rs:1145: pub fn all_names() -> &'static str
+src/document_core/queries/rendering.rs:1151: pub fn get_page_layer_tree_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1155: pub fn get_page_layer_tree_with_profile_native(
+src/document_core/queries/rendering.rs:1212: pub fn get_page_overlay_images_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1475: pub fn get_page_info_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1559: pub fn get_section_def_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1692: pub fn set_section_def_native(
+src/document_core/queries/rendering.rs:1703: pub fn set_section_def_all_native(&mut self, json: &str) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1713: pub fn get_page_border_fill_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1803: pub fn set_page_border_fill_native(
+src/document_core/queries/rendering.rs:1922: pub fn get_page_def_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:1954: pub fn set_page_def_native(
+src/document_core/queries/rendering.rs:2046: pub fn get_page_text_layout_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:2151: pub fn get_page_control_layout_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:3769: pub fn dump_page_items(&self, page_filter: Option<u32>) -> String
+src/document_core/queries/rendering.rs:445: pub fn build_page_render_tree(&self, page_num: u32) -> Result<PageRenderTree, HwpError>
+src/document_core/queries/rendering.rs:452: pub fn build_page_layer_tree(&self, page_num: u32) -> Result<PageLayerTree, HwpError>
+src/document_core/queries/rendering.rs:456: pub fn build_page_layer_tree_with_profile(
+src/document_core/queries/rendering.rs:4640: pub fn extract_page_text_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:4704: pub fn extract_page_markdown_with_images_native(
+src/document_core/queries/rendering.rs:4931: pub fn extract_page_markdown_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:601: pub fn get_bin_data(&self, index: usize) -> Option<Vec<u8>>
+src/document_core/queries/rendering.rs:608: pub fn render_page_svg_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:618: pub fn render_page_svg_legacy_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:629: pub fn render_page_svg_layer_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:633: pub fn render_page_svg_layer_with_profile_native(
+src/document_core/queries/rendering.rs:650: pub fn render_page_pdf_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:660: pub fn render_pages_pdf_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:669: pub fn render_pages_pdf_native_with_options(
+src/document_core/queries/rendering.rs:690: pub fn render_pages_pdf_native_with_profile_and_options(
+src/document_core/queries/rendering.rs:712: pub fn render_document_pdf_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:719: pub fn render_document_pdf_native_with_options(
+src/document_core/queries/rendering.rs:732: pub fn render_page_pdf_direct_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:738: pub fn render_pages_pdf_direct_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:748: pub fn render_pages_pdf_direct_native_with_options(
+src/document_core/queries/rendering.rs:762: pub fn render_pages_pdf_direct_native_with_profile_and_options(
+src/document_core/queries/rendering.rs:784: pub fn render_document_pdf_direct_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:792: pub fn render_document_pdf_direct_native_with_options(
+src/document_core/queries/rendering.rs:802: pub fn render_page_svg_with_fonts(
+src/document_core/queries/rendering.rs:834: pub fn render_page_html_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs:845: pub fn render_page_canvas_native(&self, page_num: u32) -> Result<u32, HwpError>
+src/document_core/queries/rendering.rs:852: pub fn render_page_canvas_legacy_native(&self, page_num: u32) -> Result<u32, HwpError>
+src/document_core/queries/rendering.rs:860: pub fn get_canvaskit_replay_plan_native(
+src/document_core/queries/rendering.rs:868: pub fn get_canvaskit_replay_plan_with_profile_native(
+src/document_core/queries/rendering.rs:893: pub fn render_page_png_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs:904: pub fn render_page_png_native_with_fonts(
+src/document_core/queries/rendering.rs:921: pub fn render_page_png_native_with_export_options(
+src/document_core/queries/rendering.rs:934: pub fn render_page_png_native_with_profile_and_export_options(
+src/document_core/queries/search_query.rs:149: pub fn search_text_native(
+src/document_core/queries/search_query.rs:205: pub fn search_all_text_native(
+src/document_core/queries/search_query.rs:250: pub fn replace_text_native(
+src/document_core/queries/search_query.rs:273: pub fn replace_one_native(
+src/document_core/queries/search_query.rs:302: pub fn replace_all_native(
+src/document_core/queries/search_query.rs:387: pub fn get_position_of_page_native(&self, global_page: usize) -> Result<String, HwpError>
+src/document_core/queries/search_query.rs:441: pub fn get_page_of_position_native(
+src/document_core/queries/structure.rs:184:pub fn build_structure(doc: &Document, mode: StructureMode) -> StructureDoc
+src/document_core/queries/structure.rs:18:pub enum StructureMode
+src/document_core/queries/structure.rs:271: pub fn get_structure_native(&self, mode: &str) -> Result<String, HwpError>
+src/document_core/queries/structure.rs:28: pub fn parse(s: &str) -> Option<Self>
+src/document_core/queries/structure.rs:40:pub struct StructureNode
+src/document_core/queries/structure.rs:61:pub struct StructureDoc
+src/document_core/table_calc/evaluator.rs:11:pub struct TableContext
+src/document_core/table_calc/evaluator.rs:27:pub fn evaluate_formula(
+src/document_core/table_calc/evaluator.rs:8:pub type CellValueFn<'a> = &'a dyn Fn(usize, usize) -> Option<f64>
+src/document_core/table_calc/mod.rs:17:pub use evaluator::{evaluate_formula, TableContext}
+src/document_core/table_calc/mod.rs:18:pub use parser::FormulaNode
+src/document_core/table_calc/parser.rs:35:pub enum BinOpKind
+src/document_core/table_calc/parser.rs:43:pub fn parse_formula(input: &str) -> Option<FormulaNode>
+src/document_core/table_calc/parser.rs:7:pub enum FormulaNode
+src/document_core/table_calc/tokenizer.rs:26:pub enum DirectionKind
+src/document_core/table_calc/tokenizer.rs:35:pub fn tokenize(input: &str) -> Vec<Token>
+src/document_core/table_calc/tokenizer.rs:4:pub enum Token
+src/document_core/validation.rs:101: pub fn summary(&self) -> HashMap<String, usize>
+src/document_core/validation.rs:21:pub struct CellPath
+src/document_core/validation.rs:34:pub enum WarningKind
+src/document_core/validation.rs:63:pub struct ValidationWarning
+src/document_core/validation.rs:79:pub struct ValidationReport
+src/document_core/validation.rs:84: pub fn new() -> Self
+src/document_core/validation.rs:88: pub fn is_empty(&self) -> bool
+src/document_core/validation.rs:92: pub fn len(&self) -> usize
+src/document_core/validation.rs:96: pub fn push(&mut self, w: ValidationWarning)
+src/emf/converter/device_context.rs:105: pub fn current(&self) -> &DeviceContext
+src/emf/converter/device_context.rs:108: pub fn current_mut(&mut self) -> &mut DeviceContext
+src/emf/converter/device_context.rs:112: pub fn depth(&self) -> usize
+src/emf/converter/device_context.rs:119:pub struct ObjectTable
+src/emf/converter/device_context.rs:125: pub fn new() -> Self
+src/emf/converter/device_context.rs:129: pub fn insert(&mut self, handle: u32, obj: GraphicsObject)
+src/emf/converter/device_context.rs:12:pub enum GraphicsObject
+src/emf/converter/device_context.rs:133: pub fn get(&self, handle: u32) -> Option<&GraphicsObject>
+src/emf/converter/device_context.rs:136: pub fn remove(&mut self, handle: u32) -> Option<GraphicsObject>
+src/emf/converter/device_context.rs:140: pub fn len(&self) -> usize
+src/emf/converter/device_context.rs:144: pub fn is_empty(&self) -> bool
+src/emf/converter/device_context.rs:20:pub struct DeviceContext
+src/emf/converter/device_context.rs:62:pub struct DcStack
+src/emf/converter/device_context.rs:69: pub fn new() -> Self
+src/emf/converter/device_context.rs:73: pub fn save(&mut self)
+src/emf/converter/device_context.rs:82: pub fn restore(&mut self, relative: i32) -> bool
+src/emf/converter/mod.rs:10:pub use svg::{colorref_to_rgb, escape_xml, SvgBuilder}
+src/emf/converter/mod.rs:4:pub mod device_context
+src/emf/converter/mod.rs:5:pub mod player
+src/emf/converter/mod.rs:6:pub mod svg
+src/emf/converter/mod.rs:8:pub use device_context::{DcStack, DeviceContext, GraphicsObject, ObjectTable}
+src/emf/converter/mod.rs:9:pub use player::Player
+src/emf/converter/player.rs:16:pub struct Player
+src/emf/converter/player.rs:30: pub fn new(render_rect: (f32, f32, f32, f32)) -> Self
+src/emf/converter/player.rs:411:pub struct StrokeSpec
+src/emf/converter/player.rs:43: pub fn play(&mut self, records: &[Record]) -> Result<(), Error>
+src/emf/converter/svg.rs:13: pub fn new() -> Self
+src/emf/converter/svg.rs:17: pub fn push(&mut self, node: &str)
+src/emf/converter/svg.rs:22: pub fn open_group_matrix(&mut self, m: [f32
+src/emf/converter/svg.rs:30: pub fn close_group(&mut self)
+src/emf/converter/svg.rs:35: pub fn into_string(self) -> String
+src/emf/converter/svg.rs:40: pub fn as_str(&self) -> &str
+src/emf/converter/svg.rs:47:pub fn colorref_to_rgb(c: u32) -> String
+src/emf/converter/svg.rs:56:pub fn escape_xml(s: &str) -> String
+src/emf/converter/svg.rs:7:pub struct SvgBuilder
+src/emf/mod.rs:21:pub mod converter
+src/emf/mod.rs:22:pub mod parser
+src/emf/mod.rs:27:pub use parser::records::Record
+src/emf/mod.rs:28:pub use parser::Header
+src/emf/mod.rs:32:pub enum Error
+src/emf/mod.rs:73:pub fn parse_emf(bytes: &[u8]) -> Result<Vec<Record>, Error>
+src/emf/mod.rs:83:pub fn convert_to_svg(bytes: &[u8], render_rect: (f32, f32, f32, f32)) -> Result<String, Error>
+src/emf/parser/constants/mod.rs:4:pub mod record_type
+src/emf/parser/constants/mod.rs:6:pub use record_type::RecordType
+src/emf/parser/constants/record_type.rs:97: pub fn from_u32(v: u32) -> Option<Self>
+src/emf/parser/constants/record_type.rs:9:pub enum RecordType
+src/emf/parser/mod.rs:231:pub struct RecordHeader
+src/emf/parser/mod.rs:237:pub struct Cursor<'a>
+src/emf/parser/mod.rs:244: pub fn new(buf: &'a [u8]) -> Self
+src/emf/parser/mod.rs:248: pub fn position(&self) -> usize
+src/emf/parser/mod.rs:252: pub fn remaining(&self) -> usize
+src/emf/parser/mod.rs:256: pub fn is_empty(&self) -> bool
+src/emf/parser/mod.rs:260: pub fn take(&mut self, n: usize) -> Result<&'a [u8], Error>
+src/emf/parser/mod.rs:272: pub fn peek(&self, n: usize) -> Result<&'a [u8], Error>
+src/emf/parser/mod.rs:282: pub fn u32(&mut self) -> Result<u32, Error>
+src/emf/parser/mod.rs:286: pub fn i32(&mut self) -> Result<i32, Error>
+src/emf/parser/mod.rs:289: pub fn u16(&mut self) -> Result<u16, Error>
+src/emf/parser/mod.rs:296: pub fn full_buf(&self) -> &'a [u8]
+src/emf/parser/mod.rs:300: pub fn peek_record_header(&self) -> Result<RecordHeader, Error>
+src/emf/parser/mod.rs:3:pub mod constants
+src/emf/parser/mod.rs:4:pub mod objects
+src/emf/parser/mod.rs:57:pub fn parse(bytes: &[u8]) -> Result<Vec<Record>, Error>
+src/emf/parser/mod.rs:5:pub mod records
+src/emf/parser/mod.rs:7:pub use objects::header::Header
+src/emf/parser/objects/header.rs:12:pub const SIGNATURE: u32 = 0x464D4520
+src/emf/parser/objects/header.rs:15:pub struct Header
+src/emf/parser/objects/header.rs:37:pub struct HeaderExt1
+src/emf/parser/objects/header.rs:44:pub struct HeaderExt2
+src/emf/parser/objects/header.rs:53: pub fn read(cursor: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logbrush.rs:14: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logbrush.rs:7:pub struct LogBrush
+src/emf/parser/objects/logfont.rs:26: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logfont.rs:7:pub struct LogFontW
+src/emf/parser/objects/logpen.rs:15: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logpen.rs:7:pub struct LogPen
+src/emf/parser/objects/mod.rs:10:pub use header::Header
+src/emf/parser/objects/mod.rs:11:pub use logbrush::LogBrush
+src/emf/parser/objects/mod.rs:12:pub use logfont::LogFontW
+src/emf/parser/objects/mod.rs:13:pub use logpen::LogPen
+src/emf/parser/objects/mod.rs:14:pub use rectl::{PointL, RectL, SizeL}
+src/emf/parser/objects/mod.rs:15:pub use xform::XForm
+src/emf/parser/objects/mod.rs:3:pub mod header
+src/emf/parser/objects/mod.rs:4:pub mod logbrush
+src/emf/parser/objects/mod.rs:5:pub mod logfont
+src/emf/parser/objects/mod.rs:6:pub mod logpen
+src/emf/parser/objects/mod.rs:7:pub mod rectl
+src/emf/parser/objects/mod.rs:8:pub mod xform
+src/emf/parser/objects/rectl.rs:16: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs:25: pub const fn width(&self) -> i32
+src/emf/parser/objects/rectl.rs:29: pub const fn height(&self) -> i32
+src/emf/parser/objects/rectl.rs:36:pub struct PointL
+src/emf/parser/objects/rectl.rs:42: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs:52:pub struct SizeL
+src/emf/parser/objects/rectl.rs:58: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs:8:pub struct RectL
+src/emf/parser/objects/xform.rs:19: pub const fn identity() -> Self
+src/emf/parser/objects/xform.rs:30: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/xform.rs:7:pub struct XForm
+src/emf/parser/records/bitmap.rs:28:pub struct StretchDIBits
+src/emf/parser/records/bitmap.rs:43:pub fn parse(payload: &[u8]) -> Result<StretchDIBits, Error>
+src/emf/parser/records/drawing.rs:13:pub fn parse_rect(c: &mut Cursor<'_>) -> Result<RectL, Error>
+src/emf/parser/records/drawing.rs:18:pub fn parse_round_rect(c: &mut Cursor<'_>) -> Result<(RectL, i32, i32), Error>
+src/emf/parser/records/drawing.rs:26:pub fn parse_arc_like(c: &mut Cursor<'_>) -> Result<(RectL, PointL, PointL), Error>
+src/emf/parser/records/drawing.rs:34:pub fn parse_points16(c: &mut Cursor<'_>) -> Result<(RectL, Vec<(i16, i16)>), Error>
+src/emf/parser/records/drawing.rs:9:pub fn parse_point(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/header.rs:7:pub fn parse(cursor: &mut Cursor<'_>) -> Result<Header, Error>
+src/emf/parser/records/mod.rs:12:pub use bitmap::StretchDIBits
+src/emf/parser/records/mod.rs:13:pub use text::ExtTextOut
+src/emf/parser/records/mod.rs:17:pub enum Record
+src/emf/parser/records/mod.rs:3:pub mod bitmap
+src/emf/parser/records/mod.rs:4:pub mod drawing
+src/emf/parser/records/mod.rs:5:pub mod header
+src/emf/parser/records/mod.rs:6:pub mod object
+src/emf/parser/records/mod.rs:7:pub mod path
+src/emf/parser/records/mod.rs:8:pub mod state
+src/emf/parser/records/mod.rs:9:pub mod text
+src/emf/parser/records/object.rs:10:pub fn parse_create_pen(c: &mut Cursor<'_>) -> Result<(u32, LogPen), Error>
+src/emf/parser/records/object.rs:17:pub fn parse_create_brush_indirect(c: &mut Cursor<'_>) -> Result<(u32, LogBrush), Error>
+src/emf/parser/records/object.rs:26:pub fn parse_ext_create_font_indirect_w(
+src/emf/parser/records/object.rs:41:pub fn parse_select_object(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/object.rs:46:pub fn parse_delete_object(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/path.rs:6:pub fn parse_path_bounds(c: &mut Cursor<'_>) -> Result<RectL, Error>
+src/emf/parser/records/state.rs:13:pub fn parse_set_world_transform(c: &mut Cursor<'_>) -> Result<XForm, Error>
+src/emf/parser/records/state.rs:18:pub fn parse_modify_world_transform(c: &mut Cursor<'_>) -> Result<(XForm, u32), Error>
+src/emf/parser/records/state.rs:24:pub fn parse_set_window_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
+src/emf/parser/records/state.rs:27:pub fn parse_set_window_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/state.rs:30:pub fn parse_set_viewport_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
+src/emf/parser/records/state.rs:33:pub fn parse_set_viewport_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/state.rs:37:pub fn parse_u32_single(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/state.rs:9:pub fn parse_restore_dc(c: &mut Cursor<'_>) -> Result<i32, Error>
+src/emf/parser/records/text.rs:23:pub struct ExtTextOut
+src/emf/parser/records/text.rs:36:pub fn parse(payload: &[u8]) -> Result<ExtTextOut, Error>
+src/error.rs:7:pub enum HwpError
+src/lib.rs:10:pub mod error
+src/lib.rs:11:pub mod model
+src/lib.rs:12:pub mod ole_chart
+src/lib.rs:13:pub mod ooxml_chart
+src/lib.rs:14:pub mod paint
+src/lib.rs:15:pub mod parser
+src/lib.rs:16:pub mod renderer
+src/lib.rs:17:pub mod serializer
+src/lib.rs:18:pub mod wasm_api
+src/lib.rs:19:pub mod wmf
+src/lib.rs:21:pub use document_core::DocumentCore
+src/lib.rs:22:pub use error::HwpError
+src/lib.rs:23:pub use model::event::DocumentEvent
+src/lib.rs:24:pub use parser::{parse_document, DocumentParser}
+src/lib.rs:25:pub use serializer::{serialize_document, DocumentSerializer}
+src/lib.rs:29:pub fn init_panic_hook()
+src/lib.rs:35:pub fn version() -> String
+src/lib.rs:7:pub mod diagnostics
+src/lib.rs:8:pub mod document_core
+src/lib.rs:9:pub mod emf
+src/model/bin_data.rs:113: pub fn load(&self) -> Vec<u8>
+src/model/bin_data.rs:122: pub fn len(&self) -> usize
+src/model/bin_data.rs:135: pub fn is_empty(&self) -> bool
+src/model/bin_data.rs:28:pub enum BinDataType
+src/model/bin_data.rs:40:pub enum BinDataCompression
+src/model/bin_data.rs:52:pub enum BinDataStatus
+src/model/bin_data.rs:5:pub struct BinData
+src/model/bin_data.rs:66:pub struct BinDataContent
+src/model/bin_data.rs:80:pub trait BinDataResolver:
+src/model/bin_data.rs:96:pub enum BinDataBytes
+src/model/control.rs:111:pub enum AutoNumberType
+src/model/control.rs:123:pub struct NewNumber
+src/model/control.rs:132:pub struct PageNumberPos
+src/model/control.rs:149:pub struct Bookmark
+src/model/control.rs:156:pub struct Hyperlink
+src/model/control.rs:165:pub struct Ruby
+src/model/control.rs:16:pub enum Control
+src/model/control.rs:185:pub struct CharOverlap
+src/model/control.rs:200:pub struct PageHide
+src/model/control.rs:217:pub struct HiddenComment
+src/model/control.rs:224:pub struct Field
+src/model/control.rs:255: pub fn guide_text(&self) -> Option<&str>
+src/model/control.rs:265: pub fn field_name(&self) -> Option<&str>
+src/model/control.rs:284: pub fn extract_wstring_value(&self, key: &str) -> Option<&str>
+src/model/control.rs:309: pub fn memo_text(&self) -> Option<&str>
+src/model/control.rs:317: pub fn is_editable_in_form(&self) -> bool
+src/model/control.rs:331: pub fn build_clickhere_command(guide: &str, memo: &str) -> String
+src/model/control.rs:346: pub fn field_type_str(&self) -> &'static str
+src/model/control.rs:369:pub enum FieldType
+src/model/control.rs:390:pub enum FormType
+src/model/control.rs:406:pub struct FormObject
+src/model/control.rs:433:pub struct UnknownControl
+src/model/control.rs:65:pub struct Equation
+src/model/control.rs:90:pub struct AutoNumber
+src/model/document.rs:114:pub struct HwpVersion
+src/model/document.rs:123:pub struct DocProperties
+src/model/document.rs:150:pub struct DocInfo
+src/model/document.rs:16:pub const HWP5_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp5-origin"
+src/model/document.rs:195:pub struct Section
+src/model/document.rs:207:pub struct SectionDef
+src/model/document.rs:20:pub struct RawRecord
+src/model/document.rs:268: pub fn hwpx_aux_entry(&self, path: &str) -> Option<&[u8]>
+src/model/document.rs:31:pub struct Document
+src/model/document.rs:383: pub fn convert_to_editable(&mut self) -> bool
+src/model/document.rs:410: pub fn find_or_create_char_shape(
+src/model/document.rs:440: pub fn find_or_create_para_shape(
+src/model/document.rs:468: pub fn find_or_create_tab_def(&mut self, new_td: super::style::TabDef) -> u16
+src/model/document.rs:494: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
+src/model/document.rs:66:pub struct Preview
+src/model/document.rs:75:pub struct PreviewImage
+src/model/document.rs:84:pub enum PreviewImageFormat
+src/model/document.rs:97:pub struct FileHeader
+src/model/event.rs:134: pub fn to_json(&self) -> String
+src/model/event.rs:310:pub fn serialize_event_log(events: &[DocumentEvent]) -> String
+src/model/event.rs:8:pub enum DocumentEvent
+src/model/footnote.rs:113: pub fn encode_attr(&self) -> u32
+src/model/footnote.rs:140: pub fn number_format_from_attr_code(code: u32) -> NumberFormat
+src/model/footnote.rs:166: pub fn number_format_attr_code(format: NumberFormat) -> u32
+src/model/footnote.rs:16:pub struct Footnote
+src/model/footnote.rs:191: pub fn number_format_from_name(value: &str, fallback: NumberFormat) -> NumberFormat
+src/model/footnote.rs:219: pub fn separator_above_margin_hu(&self) -> HwpUnit16
+src/model/footnote.rs:229: pub fn separator_below_margin_hu(&self) -> HwpUnit16
+src/model/footnote.rs:234: pub fn between_notes_margin_hu(&self) -> u16
+src/model/footnote.rs:241:pub enum NumberFormat
+src/model/footnote.rs:266:pub enum FootnoteNumbering
+src/model/footnote.rs:278:pub enum FootnotePlacement
+src/model/footnote.rs:35:pub struct Endnote
+src/model/footnote.rs:54:pub struct FootnoteShape
+src/model/footnote.rs:96: pub fn apply_attr_fields_from_raw(&mut self)
+src/model/header_footer.rs:30:pub struct Footer
+src/model/header_footer.rs:53:pub enum HeaderFooterApply
+src/model/header_footer.rs:68:pub struct MasterPage
+src/model/header_footer.rs:7:pub struct Header
+src/model/image.rs:104:pub struct EffectPoint
+src/model/image.rs:111:pub struct EffectColor
+src/model/image.rs:121:pub struct EffectRgb
+src/model/image.rs:128: pub fn clamped_transparency(&self) -> u8
+src/model/image.rs:132: pub fn transparency_alpha_byte(&self) -> u8
+src/model/image.rs:136: pub fn opacity(&self) -> f64
+src/model/image.rs:148: pub fn is_watermark(&self) -> bool
+src/model/image.rs:153: pub fn watermark_preset(&self) -> Option<&'static str>
+src/model/image.rs:163:pub fn transparency_percent_to_alpha_byte(transparency: u8) -> u8
+src/model/image.rs:168:pub fn alpha_byte_to_transparency_percent(alpha: u8) -> u8
+src/model/image.rs:174:pub enum ImageEffect
+src/model/image.rs:184:pub struct ImageData
+src/model/image.rs:193:pub enum ImageFormat
+src/model/image.rs:54:pub struct CropInfo
+src/model/image.rs:63:pub struct ImageAttr
+src/model/image.rs:83:pub struct PictureEffects
+src/model/image.rs:89:pub struct PictureShadow
+src/model/image.rs:9:pub struct Picture
+src/model/mod.rs:10:pub mod footnote
+src/model/mod.rs:11:pub mod header_footer
+src/model/mod.rs:12:pub mod image
+src/model/mod.rs:13:pub mod page
+src/model/mod.rs:14:pub mod paragraph
+src/model/mod.rs:15:pub mod path
+src/model/mod.rs:16:pub mod shape
+src/model/mod.rs:17:pub mod style
+src/model/mod.rs:18:pub mod table
+src/model/mod.rs:21:pub type HwpUnit = u32
+src/model/mod.rs:24:pub type SHwpUnit = i32
+src/model/mod.rs:27:pub type HwpUnit16 = i16
+src/model/mod.rs:30:pub type ColorRef = u32
+src/model/mod.rs:34:pub struct Point
+src/model/mod.rs:41:pub struct Rect
+src/model/mod.rs:49: pub fn width(&self) -> i32
+src/model/mod.rs:53: pub fn height(&self) -> i32
+src/model/mod.rs:60:pub struct Padding
+src/model/mod.rs:6:pub mod bin_data
+src/model/mod.rs:7:pub mod control
+src/model/mod.rs:8:pub mod document
+src/model/mod.rs:9:pub mod event
+src/model/page.rs:101:pub enum PageBorderBasis
+src/model/page.rs:111:pub enum PageBorderUiBasis
+src/model/page.rs:121:pub struct ColumnDef
+src/model/page.rs:151:pub enum ColumnType
+src/model/page.rs:162:pub enum ColumnDirection
+src/model/page.rs:170:pub struct PageAreas
+src/model/page.rs:195: pub fn from_page_def(page_def: &PageDef) -> Self
+src/model/page.rs:204: pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self
+src/model/page.rs:40: pub fn a4_default() -> Self
+src/model/page.rs:58:pub enum BindingMethod
+src/model/page.rs:70:pub struct PageBorderFill
+src/model/page.rs:7:pub struct PageDef
+src/model/paragraph.rs:1063: pub fn char_shape_id_at(&self, char_offset: usize) -> Option<u32>
+src/model/paragraph.rs:1108: pub fn control_text_positions(&self) -> Vec<usize>
+src/model/paragraph.rs:112:pub enum ColumnBreakType
+src/model/paragraph.rs:1221: pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize
+src/model/paragraph.rs:1233: pub fn apply_char_shape_range(
+src/model/paragraph.rs:127:pub struct CharShapeRef
+src/model/paragraph.rs:1364: pub fn set_single_char_shape(&mut self, char_shape_id: u32)
+src/model/paragraph.rs:1373: pub fn replace_style_char_shape_preserving_overrides(
+src/model/paragraph.rs:1397: pub fn apply_char_shape_to_entire_text(&mut self, char_shape_id: u32)
+src/model/paragraph.rs:139:pub struct LineSeg
+src/model/paragraph.rs:173: pub const TAG_FIRST_LINE_OF_PAGE: u32 = 1 << 0
+src/model/paragraph.rs:174: pub const TAG_FIRST_LINE_OF_COLUMN: u32 = 1 << 1
+src/model/paragraph.rs:175: pub const TAG_EMPTY_SEGMENT: u32 = 1 << 16
+src/model/paragraph.rs:176: pub const TAG_FIRST_SEGMENT: u32 = 1 << 17
+src/model/paragraph.rs:177: pub const TAG_LAST_SEGMENT: u32 = 1 << 18
+src/model/paragraph.rs:178: pub const TAG_AUTO_HYPHENATION: u32 = 1 << 19
+src/model/paragraph.rs:179: pub const TAG_INDENTATION: u32 = 1 << 20
+src/model/paragraph.rs:180: pub const TAG_PARAGRAPH_HEAD: u32 = 1 << 21
+src/model/paragraph.rs:181: pub const TAG_IMPLEMENTATION_PROPERTY: u32 = 1 << 31
+src/model/paragraph.rs:184: pub const TAG_SINGLE_SEGMENT_LINE: u32 = Self::TAG_FIRST_SEGMENT | Self::TAG_LAST_SEGMENT
+src/model/paragraph.rs:186: pub const TAG_MISSING_LINESEG_PLACEHOLDER: u32 =
+src/model/paragraph.rs:190: pub fn missing_lineseg_placeholder() -> Self
+src/model/paragraph.rs:198: pub fn is_missing_lineseg_placeholder(&self) -> bool
+src/model/paragraph.rs:208: pub fn is_first_line_of_page(&self) -> bool
+src/model/paragraph.rs:222: pub fn is_in_wrap_zone(&self, col_w_hu: i32) -> bool
+src/model/paragraph.rs:227: pub fn is_first_line_of_column(&self) -> bool
+src/model/paragraph.rs:232: pub fn is_empty_segment(&self) -> bool
+src/model/paragraph.rs:237: pub fn is_first_segment(&self) -> bool
+src/model/paragraph.rs:242: pub fn is_last_segment(&self) -> bool
+src/model/paragraph.rs:247: pub fn has_indentation(&self) -> bool
+src/model/paragraph.rs:252: pub fn has_paragraph_head(&self) -> bool
+src/model/paragraph.rs:259:pub struct RangeTag
+src/model/paragraph.rs:270:pub struct FieldRange
+src/model/paragraph.rs:284:pub struct OrphanFieldEnd
+src/model/paragraph.rs:411: pub fn new_empty() -> Self
+src/model/paragraph.rs:433: pub fn new_empty_like(template: &Paragraph) -> Self
+src/model/paragraph.rs:466: pub fn insert_text_at(&mut self, char_offset: usize, new_text: &str)
+src/model/paragraph.rs:609: pub fn delete_text_at(&mut self, char_offset: usize, count: usize) -> usize
+src/model/paragraph.rs:62:pub enum NumberingRestart
+src/model/paragraph.rs:714: pub fn split_at(&mut self, char_offset: usize) -> Paragraph
+src/model/paragraph.rs:71:pub enum CtrlChar
+src/model/paragraph.rs:7:pub struct Paragraph
+src/model/paragraph.rs:929: pub fn merge_from(&mut self, other: &Paragraph) -> usize
+src/model/path.rs:24:pub type DocumentPath = Vec<PathSegment>
+src/model/path.rs:27:pub fn path_from_flat(parent_para_idx: usize, control_idx: usize) -> DocumentPath
+src/model/path.rs:8:pub enum PathSegment
+src/model/shape.rs:109:pub enum VertRelTo
+src/model/shape.rs:118:pub enum VertAlign
+src/model/shape.rs:129:pub enum HorzRelTo
+src/model/shape.rs:139:pub enum HorzAlign
+src/model/shape.rs:13: pub const FLAGS: std::ops::Range<usize> = 0..4
+src/model/shape.rs:14: pub const V_OFFSET: std::ops::Range<usize> = 4..8
+src/model/shape.rs:150:pub enum SizeCriterion
+src/model/shape.rs:15: pub const H_OFFSET: std::ops::Range<usize> = 8..12
+src/model/shape.rs:166:pub enum TextWrap
+src/model/shape.rs:16: pub const WIDTH: std::ops::Range<usize> = 12..16
+src/model/shape.rs:17: pub const HEIGHT: std::ops::Range<usize> = 16..20
+src/model/shape.rs:180:pub enum TextFlow
+src/model/shape.rs:18: pub const Z_ORDER: std::ops::Range<usize> = 20..24
+src/model/shape.rs:190:pub struct ShapeComponentAttr
+src/model/shape.rs:19: pub const MARGIN_LEFT: std::ops::Range<usize> = 24..26
+src/model/shape.rs:20: pub const MARGIN_RIGHT: std::ops::Range<usize> = 26..28
+src/model/shape.rs:21: pub const MARGIN_TOP: std::ops::Range<usize> = 28..30
+src/model/shape.rs:22: pub const MARGIN_BOTTOM: std::ops::Range<usize> = 30..32
+src/model/shape.rs:23: pub const INSTANCE_ID: std::ops::Range<usize> = 32..36
+src/model/shape.rs:24: pub const PREVENT_PAGE_BREAK: std::ops::Range<usize> = 36..40
+src/model/shape.rs:25: pub const MIN_LEN: usize = INSTANCE_ID.end
+src/model/shape.rs:26: pub const MIN_LEN_WITH_PREVENT_PAGE_BREAK: usize = PREVENT_PAGE_BREAK.end
+src/model/shape.rs:280:pub struct DrawingObjAttr
+src/model/shape.rs:307:pub struct TextBox
+src/model/shape.rs:31:pub struct CommonObjAttr
+src/model/shape.rs:335:pub enum ShapeObject
+src/model/shape.rs:360: pub fn common(&self) -> &CommonObjAttr
+src/model/shape.rs:376: pub fn common_mut(&mut self) -> &mut CommonObjAttr
+src/model/shape.rs:392: pub fn drawing(&self) -> Option<&DrawingObjAttr>
+src/model/shape.rs:407: pub fn drawing_mut(&mut self) -> Option<&mut DrawingObjAttr>
+src/model/shape.rs:422: pub fn z_order(&self) -> i32
+src/model/shape.rs:427: pub fn shape_attr(&self) -> &ShapeComponentAttr
+src/model/shape.rs:443: pub fn shape_name(&self) -> &'static str
+src/model/shape.rs:461:pub struct LineShape
+src/model/shape.rs:479:pub enum LinkLineType
+src/model/shape.rs:493: pub fn from_u32(v: u32) -> Self
+src/model/shape.rs:509: pub fn is_stroke(&self) -> bool
+src/model/shape.rs:517: pub fn is_arc(&self) -> bool
+src/model/shape.rs:524:pub struct ConnectorControlPoint
+src/model/shape.rs:532:pub struct ConnectorData
+src/model/shape.rs:551:pub struct RectangleShape
+src/model/shape.rs:566:pub struct EllipseShape
+src/model/shape.rs:591:pub struct ArcShape
+src/model/shape.rs:608:pub struct PolygonShape
+src/model/shape.rs:621:pub struct CurveShape
+src/model/shape.rs:634:pub struct GroupShape
+src/model/shape.rs:647:pub struct Caption
+src/model/shape.rs:666:pub enum CaptionDirection
+src/model/shape.rs:676:pub enum CaptionVertAlign
+src/model/shape.rs:689:pub enum ChartType
+src/model/shape.rs:702:pub enum LegendPosition
+src/model/shape.rs:717:pub struct Legend
+src/model/shape.rs:724:pub struct Axis
+src/model/shape.rs:733:pub struct DataSeries
+src/model/shape.rs:746:pub struct ChartShape
+src/model/shape.rs:775:pub enum OlePreviewFormat
+src/model/shape.rs:784:pub struct OlePreview
+src/model/shape.rs:791:pub enum OleDrawingAspect
+src/model/shape.rs:801:pub struct OleShape
+src/model/shape.rs:99:pub enum ObjectNumberingType
+src/model/style.rs:100:pub struct CharShape
+src/model/style.rs:12:pub const BORDER_WIDTHS: [(f64, &str)
+src/model/style.rs:204:pub enum UnderlineType
+src/model/style.rs:213:pub enum HeadType
+src/model/style.rs:227:pub struct ParaShape
+src/model/style.rs:302:pub struct Numbering
+src/model/style.rs:323:pub struct NumberingHead
+src/model/style.rs:32:pub fn border_width_index(mm: f64) -> u8
+src/model/style.rs:338:pub struct Bullet
+src/model/style.rs:361:pub enum Alignment
+src/model/style.rs:373:pub enum LineSpacingType
+src/model/style.rs:383:pub struct TabDef
+src/model/style.rs:398:pub struct TabItem
+src/model/style.rs:427:pub struct Style
+src/model/style.rs:43:pub fn border_width_mm_str(index: u8) -> &'static str
+src/model/style.rs:451:pub struct BorderFill
+src/model/style.rs:468:pub enum CenterLine
+src/model/style.rs:481: pub fn from_hwp_attr(attr: u16) -> Self
+src/model/style.rs:494: pub fn from_hwpx(value: &str) -> Self
+src/model/style.rs:503: pub fn hwp_attr_bits(self) -> u16
+src/model/style.rs:512: pub fn hwp_binary_attr_bits(self) -> u16
+src/model/style.rs:521: pub fn as_hwpx(self) -> &'static str
+src/model/style.rs:52:pub struct Font
+src/model/style.rs:533:pub struct BorderLine
+src/model/style.rs:545:pub enum BorderLineType
+src/model/style.rs:587:pub struct DiagonalLine
+src/model/style.rs:598:pub struct Fill
+src/model/style.rs:613:pub enum FillType
+src/model/style.rs:623:pub struct SolidFill
+src/model/style.rs:634:pub struct GradientFill
+src/model/style.rs:655:pub struct ImageFill
+src/model/style.rs:670:pub enum ImageFillMode
+src/model/style.rs:693:pub struct ShapeBorderLine
+src/model/style.rs:706:pub struct CharShapeMods
+src/model/style.rs:756: pub fn apply_to(&self, base: &CharShape) -> CharShape
+src/model/style.rs:85:pub struct SubstFont
+src/model/style.rs:878:pub struct ParaShapeMods
+src/model/style.rs:915: pub fn apply_to(&self, base: &ParaShape) -> ParaShape
+src/model/table.rs:102:pub struct Cell
+src/model/table.rs:1056: pub fn delete_row(&mut self, row_idx: u16) -> Result<(), String>
+src/model/table.rs:10:pub const CELL_FLAG_EDITABLE_IN_FORM: u16 = 0x0008
+src/model/table.rs:1126: pub fn delete_column(&mut self, col_idx: u16) -> Result<(), String>
+src/model/table.rs:1202: pub fn merge_cells(
+src/model/table.rs:1355: pub fn split_cell(&mut self, target_row: u16, target_col: u16) -> Result<(), String>
+src/model/table.rs:143:pub struct TableTransposeData
+src/model/table.rs:1458: pub fn split_cell_into(
+src/model/table.rs:14:pub struct Table
+src/model/table.rs:162:pub enum VerticalAlign
+src/model/table.rs:1633: pub fn split_cells_in_range(
+src/model/table.rs:170: pub fn set_apply_inner_margin(&mut self, value: bool)
+src/model/table.rs:182: pub fn use_cell_padding_axis(
+src/model/table.rs:209: pub fn table_padding_unspecified(table_padding: &crate::model::Padding) -> bool
+src/model/table.rs:216: pub fn effective_padding(
+src/model/table.rs:238: pub fn cell_protect(&self) -> bool
+src/model/table.rs:242: pub fn set_cell_protect(&mut self, value: bool)
+src/model/table.rs:246: pub fn set_header(&mut self, value: bool)
+src/model/table.rs:251: pub fn editable_in_form(&self) -> bool
+src/model/table.rs:255: pub fn set_editable_in_form(&mut self, value: bool)
+src/model/table.rs:268: pub fn new_empty(
+src/model/table.rs:292: pub fn new_from_template(
+src/model/table.rs:352: pub fn leading_header_rows(&self) -> Vec<usize>
+src/model/table.rs:381: pub fn inferred_local_resize_rows(&self) -> Vec<u16>
+src/model/table.rs:473: pub fn rebuild_grid(&mut self)
+src/model/table.rs:490: pub fn cell_index_at(&self, row: u16, col: u16) -> Option<usize>
+src/model/table.rs:496: pub fn cell_at(&self, row: u16, col: u16) -> Option<&Cell>
+src/model/table.rs:503: pub fn cell_at_mut(&mut self, row: u16, col: u16) -> Option<&mut Cell>
+src/model/table.rs:545: pub fn copy_transpose_range(
+src/model/table.rs:579: pub fn paste_transposed_cells(
+src/model/table.rs:630: pub fn transpose_unmerged_table_in_place(&mut self) -> Result<Vec<(usize, usize)>, String>
+src/model/table.rs:715: pub fn update_ctrl_dimensions(&mut self)
+src/model/table.rs:75:pub enum TablePageBreak
+src/model/table.rs:771: pub fn get_column_widths(&self) -> Vec<HwpUnit>
+src/model/table.rs:798: pub fn set_column_widths(&mut self, widths: &[HwpUnit]) -> Result<(), String>
+src/model/table.rs:7:pub const CELL_FLAG_HAS_MARGIN: u16 = 0x0001
+src/model/table.rs:821: pub fn get_row_heights(&self) -> Vec<HwpUnit>
+src/model/table.rs:834: pub fn get_raw_row_heights(&self) -> Vec<HwpUnit>
+src/model/table.rs:857: pub fn insert_row(&mut self, row_idx: u16, below: bool) -> Result<(), String>
+src/model/table.rs:87:pub struct TableZone
+src/model/table.rs:8:pub const CELL_FLAG_PROTECT: u16 = 0x0002
+src/model/table.rs:960: pub fn insert_column(&mut self, col_idx: u16, right: bool) -> Result<(), String>
+src/model/table.rs:9:pub const CELL_FLAG_HEADER: u16 = 0x0004
+src/ole_chart/ir.rs:13:pub struct OleChartIrPayload<'a>
+src/ole_chart/ir.rs:20: pub fn new(chart: &'a OleChart) -> Self
+src/ole_chart/ir.rs:29:pub fn ole_chart_ir_json(chart: &OleChart) -> Result<String, serde_json::Error>
+src/ole_chart/ir.rs:33:pub fn ole_chart_ir_base64(chart: &OleChart) -> Result<String, serde_json::Error>
+src/ole_chart/ir.rs:8:pub const OLE_CHART_IR_SCHEMA: &str = "rhwp.oleChartIr"
+src/ole_chart/ir.rs:9:pub const OLE_CHART_IR_VERSION: u32 = 1
+src/ole_chart/mod.rs:11:pub use ir::{
+src/ole_chart/mod.rs:15:pub use parser::{
+src/ole_chart/mod.rs:19:pub use svg_renderer::{
+src/ole_chart/mod.rs:7:pub mod ir
+src/ole_chart/mod.rs:8:pub mod parser
+src/ole_chart/mod.rs:9:pub mod svg_renderer
+src/ole_chart/parser.rs:102:pub fn parse_ole_chart_contents(bytes: &[u8]) -> Result<OleChart, OleChartParseError>
+src/ole_chart/parser.rs:15:pub struct OleChart
+src/ole_chart/parser.rs:194:pub fn probe_ole_chart_contents(bytes: &[u8]) -> Result<OleChartContentsProbe, OleChartParseError>
+src/ole_chart/parser.rs:25:pub enum OleChartType
+src/ole_chart/parser.rs:37:pub struct OleChartSeries
+src/ole_chart/parser.rs:44:pub struct OleChartContentsProbe
+src/ole_chart/parser.rs:59:pub enum OleChartParseError
+src/ole_chart/parser.rs:72: pub fn code(&self) -> &'static str
+src/ole_chart/parser.rs:80: pub fn stable_message(&self) -> String
+src/ole_chart/svg_renderer.rs:29:pub fn render_ole_chart_standalone_svg(chart: &OleChart, width: u32, height: u32) -> String
+src/ole_chart/svg_renderer.rs:39:pub fn render_ole_chart_svg_body(chart: &OleChart, width: f64, height: f64) -> String
+src/ole_chart/svg_renderer.rs:6:pub fn render_ole_chart_svg_fragment(
+src/ooxml_chart/mod.rs:105:pub enum BarGrouping
+src/ooxml_chart/mod.rs:119:pub enum ScatterStyle
+src/ooxml_chart/mod.rs:133: pub fn flags(&self) -> (bool, bool, bool)
+src/ooxml_chart/mod.rs:145:pub enum OoxmlChartType
+src/ooxml_chart/mod.rs:163: pub fn label(&self) -> &'static str
+src/ooxml_chart/mod.rs:178:pub struct OoxmlSeries
+src/ooxml_chart/mod.rs:200: pub fn parse(xml: &[u8]) -> Option<Self>
+src/ooxml_chart/mod.rs:206: pub fn render_svg(&self, x: f64, y: f64, w: f64, h: f64) -> String
+src/ooxml_chart/mod.rs:211: pub fn is_combo(&self) -> bool
+src/ooxml_chart/mod.rs:24:pub mod parser
+src/ooxml_chart/mod.rs:25:pub mod renderer
+src/ooxml_chart/mod.rs:29:pub struct OoxmlChart
+src/ooxml_chart/mod.rs:76:pub enum SeriesMarker
+src/ooxml_chart/mod.rs:94:pub enum LegendPos
+src/ooxml_chart/parser.rs:58:pub fn parse_chart_xml(xml: &[u8]) -> Option<OoxmlChart>
+src/ooxml_chart/renderer.rs:91:pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> String
+src/paint/builder.rs:11:pub struct LayerBuilder
+src/paint/builder.rs:17: pub fn new(profile: RenderProfile) -> Self
+src/paint/builder.rs:24: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
+src/paint/builder.rs:29: pub fn build(&mut self, tree: &PageRenderTree) -> PageLayerTree
+src/paint/builder.rs:33: pub fn build_with_embedded_fonts(
+src/paint/font.rs:106: pub fn as_str(self) -> &'static str
+src/paint/font.rs:10:pub struct FontDigest
+src/paint/font.rs:118:pub struct LocalizedName
+src/paint/font.rs:124:pub struct FontBlobResource
+src/paint/font.rs:133:pub struct FontFaceResource
+src/paint/font.rs:148:pub struct FontResourceTable
+src/paint/font.rs:154: pub fn is_empty(&self) -> bool
+src/paint/font.rs:160:pub struct VariationAxisValue
+src/paint/font.rs:166:pub struct OpenTypeFeatureSetting
+src/paint/font.rs:16:pub struct BinaryResourceRef
+src/paint/font.rs:173:pub struct ScriptTag(pub String)
+src/paint/font.rs:176:pub struct LanguageTag(pub String)
+src/paint/font.rs:179:pub struct ShapingEngineId(pub String)
+src/paint/font.rs:182:pub struct FontFallbackPolicyId(pub String)
+src/paint/font.rs:185:pub enum TextDirection
+src/paint/font.rs:192: pub fn as_str(self) -> &'static str
+src/paint/font.rs:202:pub enum WritingMode
+src/paint/font.rs:209: pub fn as_str(self) -> &'static str
+src/paint/font.rs:219:pub struct FontInstanceKey
+src/paint/font.rs:228:pub struct ShapeKey
+src/paint/font.rs:22:pub enum BinaryResourceKind
+src/paint/font.rs:240:pub enum GlyphRunReplayEligibility
+src/paint/font.rs:248: pub fn as_str(self) -> &'static str
+src/paint/font.rs:28: pub fn as_str(self) -> &'static str
+src/paint/font.rs:37:pub struct FontExternalRef
+src/paint/font.rs:3:pub struct FontBlobKey(pub String)
+src/paint/font.rs:42:pub enum FontResourceSource
+src/paint/font.rs:51: pub fn as_str(self) -> &'static str
+src/paint/font.rs:64:pub enum FontPortability
+src/paint/font.rs:7:pub struct FontFaceKey(pub String)
+src/paint/font.rs:81: pub fn kind(&self) -> FontPortabilityKind
+src/paint/font.rs:91: pub fn is_self_contained_replayable(&self) -> bool
+src/paint/font.rs:97:pub enum FontPortabilityKind
+src/paint/font_glyph.rs:105:pub fn decode_font_bitmap_glyph_payload(
+src/paint/font_glyph.rs:197:pub struct FontSvgGlyphDecodeOptions
+src/paint/font_glyph.rs:205: pub fn new(source_range_utf8: TextSourceRange, glyph_range: GlyphRange) -> Self
+src/paint/font_glyph.rs:216:pub enum FontSvgGlyphDecodeError
+src/paint/font_glyph.rs:233: pub fn as_str(self) -> &'static str
+src/paint/font_glyph.rs:252:pub fn decode_font_svg_glyph_payload(
+src/paint/font_glyph.rs:359:pub struct EmbeddedFontFace<'a>
+src/paint/font_glyph.rs:368:pub fn resolve_embedded_font_face_index(
+src/paint/font_glyph.rs:414:pub struct FontGlyphLoweringReport
+src/paint/font_glyph.rs:41:pub struct FontBitmapGlyphDecodeOptions
+src/paint/font_glyph.rs:421:pub fn lower_font_native_glyph_sidecars(
+src/paint/font_glyph.rs:54: pub fn new(
+src/paint/font_glyph.rs:75:pub enum FontBitmapGlyphDecodeError
+src/paint/font_glyph.rs:89: pub fn as_str(self) -> &'static str
+src/paint/json.rs:67: pub fn to_json(&self) -> String
+src/paint/layer_tree.rs:115:pub struct TextSourceTable
+src/paint/layer_tree.rs:11:pub struct PageLayerTree
+src/paint/layer_tree.rs:120: pub fn from_layer_node(root: &LayerNode) -> Self
+src/paint/layer_tree.rs:126: pub fn is_empty(&self) -> bool
+src/paint/layer_tree.rs:223:pub struct LayerOutputOptions
+src/paint/layer_tree.rs:22: pub fn new(page_width: f64, page_height: f64, root: LayerNode) -> Self
+src/paint/layer_tree.rs:244:pub enum CacheHint
+src/paint/layer_tree.rs:253:pub enum ClipKind
+src/paint/layer_tree.rs:261:pub struct LayerNode
+src/paint/layer_tree.rs:269: pub fn group(
+src/paint/layer_tree.rs:288: pub fn clip_rect(
+src/paint/layer_tree.rs:307: pub fn leaf(bounds: BoundingBox, source_node_id: Option<NodeId>, ops: Vec<PaintOp>) -> Self
+src/paint/layer_tree.rs:316: pub fn with_layer(mut self, layer: Option<RenderLayerInfo>) -> Self
+src/paint/layer_tree.rs:323:pub enum LayerNodeKind
+src/paint/layer_tree.rs:340:pub enum GroupKind
+src/paint/layer_tree.rs:35: pub fn with_profile(
+src/paint/layer_tree.rs:53: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
+src/paint/layer_tree.rs:58: pub fn with_text_sources(mut self, text_sources: TextSourceTable) -> Self
+src/paint/layer_tree.rs:65:pub struct TextSourceId(pub u32)
+src/paint/layer_tree.rs:68:pub struct TextSourceRange
+src/paint/layer_tree.rs:74: pub fn new(start: u32, end: u32) -> Self
+src/paint/layer_tree.rs:80:pub struct TextSourceSpan
+src/paint/layer_tree.rs:88:pub struct TextSourceEntry
+src/paint/layer_tree.rs:98:pub enum TextSourceAnnotation
+src/paint/mod.rs:10:pub mod paint_op
+src/paint/mod.rs:11:pub mod profile
+src/paint/mod.rs:12:pub mod replay_order
+src/paint/mod.rs:13:pub mod resources
+src/paint/mod.rs:14:pub mod schema
+src/paint/mod.rs:15:pub mod text_shape
+src/paint/mod.rs:16:pub mod text_v2
+src/paint/mod.rs:17:pub mod text_variants
+src/paint/mod.rs:19:pub use builder::LayerBuilder
+src/paint/mod.rs:20:pub use font::{
+src/paint/mod.rs:27:pub use font_glyph::{
+src/paint/mod.rs:33:pub use layer_tree::{
+src/paint/mod.rs:38:pub use paint_op::{
+src/paint/mod.rs:52:pub use profile::RenderProfile
+src/paint/mod.rs:53:pub use replay_order::{
+src/paint/mod.rs:57:pub use resources::{
+src/paint/mod.rs:5:pub mod builder
+src/paint/mod.rs:61:pub use schema::{
+src/paint/mod.rs:66:pub use text_shape::{
+src/paint/mod.rs:6:pub mod font
+src/paint/mod.rs:70:pub use text_v2::{
+src/paint/mod.rs:74:pub use text_variants::{validate_text_variant_scope, TextVariantScopeError}
+src/paint/mod.rs:7:pub mod font_glyph
+src/paint/mod.rs:9:pub mod layer_tree
+src/paint/paint_op.rs:1008:pub struct ColorLayersPayload
+src/paint/paint_op.rs:1019: pub fn has_colrv0_resolved_layer_contract(&self) -> bool
+src/paint/paint_op.rs:1048: pub fn has_colrv1_stage1_graph_contract(&self) -> bool
+src/paint/paint_op.rs:1052: pub fn has_colrv1_supported_graph_contract(&self) -> bool
+src/paint/paint_op.rs:1068:pub enum BitmapGlyphScalingPolicy
+src/paint/paint_op.rs:1075: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1085:pub enum BitmapGlyphFiltering
+src/paint/paint_op.rs:1091: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1100:pub struct BitmapGlyphPayload
+src/paint/paint_op.rs:1112: pub fn has_strict_visual_contract(&self) -> bool
+src/paint/paint_op.rs:1128:pub struct SvgGlyphPayload
+src/paint/paint_op.rs:1143: pub fn has_static_sanitized_contract(&self) -> bool
+src/paint/paint_op.rs:1188:pub struct LayerGlyphOutlinePath
+src/paint/paint_op.rs:1197:pub enum GlyphOutlineFillRule
+src/paint/paint_op.rs:1203: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1212:pub struct GlyphOutlineStrokeStyle
+src/paint/paint_op.rs:1222: pub fn is_strict_subset(&self) -> bool
+src/paint/paint_op.rs:1237:pub enum GlyphOutlineStrokeJoin
+src/paint/paint_op.rs:1244: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1254:pub enum GlyphOutlineStrokeCap
+src/paint/paint_op.rs:1261: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1271:pub enum GlyphOutlinePaintOrder
+src/paint/paint_op.rs:1279: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1294:pub struct PaintVariantMeta
+src/paint/paint_op.rs:1308: pub fn text_run_default(equivalence_group: impl Into<String>) -> Self
+src/paint/paint_op.rs:1325:pub enum TextVariantKind
+src/paint/paint_op.rs:1332: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1342:pub enum TextVariantQuality
+src/paint/paint_op.rs:134: pub fn page_background(bbox: BoundingBox, background: PageBackgroundNode) -> Self
+src/paint/paint_op.rs:1351: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1363:pub struct LayerPoint
+src/paint/paint_op.rs:1369:pub struct LayerVector
+src/paint/paint_op.rs:1375:pub struct LayerAffineTransform
+src/paint/paint_op.rs:1385:pub struct TextRunPlacement
+src/paint/paint_op.rs:1391:pub enum GlyphRunOrientation
+src/paint/paint_op.rs:1399: pub fn from_text_run(run: &TextRunNode) -> Self
+src/paint/paint_op.rs:1409: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:141: pub fn text_run(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs:1420:pub struct GlyphTransform
+src/paint/paint_op.rs:1430:pub struct GlyphRange
+src/paint/paint_op.rs:1436: pub fn new(start: u32, end: u32) -> Self
+src/paint/paint_op.rs:1440: pub fn is_non_empty(self) -> bool
+src/paint/paint_op.rs:1446:pub enum GlyphClusterFlag
+src/paint/paint_op.rs:1452: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:1461:pub struct GlyphCluster
+src/paint/paint_op.rs:1470:pub struct GlyphRunDiagnostics
+src/paint/paint_op.rs:1484:pub struct PaintTextStyle
+src/paint/paint_op.rs:148: pub fn glyph_run(bbox: BoundingBox, run: LayerGlyphRunPaint) -> Self
+src/paint/paint_op.rs:14:pub enum TextDecorationKind
+src/paint/paint_op.rs:1545: pub fn is_fill_only_glyph_replay(&self) -> bool
+src/paint/paint_op.rs:155: pub fn glyph_outline(bbox: BoundingBox, outline: LayerGlyphOutlinePaint) -> Self
+src/paint/paint_op.rs:162: pub fn char_overlap(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs:169: pub fn text_control_mark(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs:176: pub fn tab_leader(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs:183: pub fn text_decoration(bbox: BoundingBox, run: TextRunNode, kind: TextDecorationKind) -> Self
+src/paint/paint_op.rs:191: pub fn footnote_marker(bbox: BoundingBox, marker: FootnoteMarkerNode) -> Self
+src/paint/paint_op.rs:198: pub fn line(bbox: BoundingBox, line: LineNode) -> Self
+src/paint/paint_op.rs:205: pub fn rectangle(bbox: BoundingBox, rect: RectangleNode) -> Self
+src/paint/paint_op.rs:212: pub fn ellipse(bbox: BoundingBox, ellipse: EllipseNode) -> Self
+src/paint/paint_op.rs:219: pub fn path(bbox: BoundingBox, path: PathNode) -> Self
+src/paint/paint_op.rs:21: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:226: pub fn image(
+src/paint/paint_op.rs:238: pub fn equation(bbox: BoundingBox, equation: EquationNode) -> Self
+src/paint/paint_op.rs:245: pub fn form_object(bbox: BoundingBox, form: FormObjectNode) -> Self
+src/paint/paint_op.rs:252: pub fn placeholder(bbox: BoundingBox, placeholder: PlaceholderNode) -> Self
+src/paint/paint_op.rs:259: pub fn raw_svg(bbox: BoundingBox, raw: RawSvgNode) -> Self
+src/paint/paint_op.rs:266: pub fn bounds(&self) -> BoundingBox
+src/paint/paint_op.rs:291:pub struct LayerGlyphRunPaint
+src/paint/paint_op.rs:315:pub struct LayerGlyphOutlinePaint
+src/paint/paint_op.rs:31:pub enum ResolvedImageKind
+src/paint/paint_op.rs:330:pub enum GlyphOutlinePayloadKind
+src/paint/paint_op.rs:339: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:351: pub fn has_exclusive_payload_family(&self) -> bool
+src/paint/paint_op.rs:37:pub struct ResolvedImagePayload
+src/paint/paint_op.rs:380: pub fn payload_resource_key(&self) -> Option<String>
+src/paint/paint_op.rs:384: pub fn payload_resource_key_with_resources(
+src/paint/paint_op.rs:409: pub fn has_payload_resource_key(&self) -> bool
+src/paint/paint_op.rs:49:pub enum PaintOp
+src/paint/paint_op.rs:617:pub enum ColorGlyphFormat
+src/paint/paint_op.rs:624: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:634:pub struct FontColorGlyphRef
+src/paint/paint_op.rs:642:pub struct PaletteRef
+src/paint/paint_op.rs:649:pub struct ResolvedColor
+src/paint/paint_op.rs:655:pub struct ColorLayerNode
+src/paint/paint_op.rs:671:pub enum ColorPaintGraphNodeKind
+src/paint/paint_op.rs:681: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs:692: pub fn is_colrv1_stage1_supported(self) -> bool
+src/paint/paint_op.rs:705:pub struct ColorPaintSolidPathNode
+src/paint/paint_op.rs:714:pub struct ColorGradientStop
+src/paint/paint_op.rs:720:pub struct ColorLinearGradient
+src/paint/paint_op.rs:729:pub struct ColorRadialGradient
+src/paint/paint_op.rs:737:pub struct ColorSweepGradient
+src/paint/paint_op.rs:746:pub struct ColorPaintLinearGradientPathNode
+src/paint/paint_op.rs:755:pub struct ColorPaintRadialGradientPathNode
+src/paint/paint_op.rs:764:pub struct ColorPaintSweepGradientPathNode
+src/paint/paint_op.rs:773:pub struct ColorPaintTransformNode
+src/paint/paint_op.rs:779:pub struct ColorPaintGraphNode
+src/paint/paint_op.rs:793:pub struct ColorPaintGraphPayload
+src/paint/paint_op.rs:868: pub fn has_colrv1_stage1_contract(&self) -> bool
+src/paint/paint_op.rs:872: pub fn has_colrv1_supported_graph_contract(&self) -> bool
+src/paint/profile.rs:12: pub fn parse(value: &str) -> Option<Self>
+src/paint/profile.rs:22: pub fn shows_editor_visuals(self) -> bool
+src/paint/profile.rs:3:pub enum RenderProfile
+src/paint/replay_order.rs:11:pub enum PaintReplayPlane
+src/paint/replay_order.rs:19: pub const ORDERED: [Self
+src/paint/replay_order.rs:26: pub fn as_str(self) -> &'static str
+src/paint/replay_order.rs:36:pub fn paint_op_replay_plane(op: &PaintOp) -> PaintReplayPlane
+src/paint/replay_order.rs:40:pub fn paint_op_replay_plane_with_layer(
+src/paint/replay_order.rs:62:pub fn render_layer_replay_plane(layer: Option<RenderLayerInfo>) -> PaintReplayPlane
+src/paint/resources.rs:114: pub fn svg_fragment(&self, id: SvgResourceId) -> Option<&str>
+src/paint/resources.rs:118: pub fn svg_count(&self) -> usize
+src/paint/resources.rs:122: pub fn svg_hash(&self, id: SvgResourceId) -> Option<u64>
+src/paint/resources.rs:126: pub fn svg_fingerprint(&self, id: SvgResourceId) -> Option<[u8
+src/paint/resources.rs:12:pub struct FontBlobResourceId(pub usize)
+src/paint/resources.rs:130: pub fn svg_resource_key(&self, id: SvgResourceId) -> Option<&str>
+src/paint/resources.rs:134: pub fn svg_resources(&self) -> impl Iterator<Item = (SvgResourceId, &str)> + '_
+src/paint/resources.rs:141: pub fn intern_font_blob_bytes(&mut self, bytes: &[u8]) -> FontBlobResourceId
+src/paint/resources.rs:14:pub const RESOURCE_KEY_ALGORITHM: &str = "blake3"
+src/paint/resources.rs:165: pub fn font_blob_bytes(&self, id: FontBlobResourceId) -> Option<&[u8]>
+src/paint/resources.rs:169: pub fn font_blob_count(&self) -> usize
+src/paint/resources.rs:173: pub fn font_blob_hash(&self, id: FontBlobResourceId) -> Option<u64>
+src/paint/resources.rs:177: pub fn font_blob_fingerprint(&self, id: FontBlobResourceId) -> Option<[u8
+src/paint/resources.rs:181: pub fn font_blob_resources(&self) -> impl Iterator<Item = (FontBlobResourceId, &[u8])> + '_
+src/paint/resources.rs:188: pub fn font_blob_bytes_for_ref(&self, data_ref: &BinaryResourceRef) -> Option<&[u8]>
+src/paint/resources.rs:197: pub fn font_resources(&self) -> &FontResourceTable
+src/paint/resources.rs:201: pub fn font_resources_mut(&mut self) -> &mut FontResourceTable
+src/paint/resources.rs:21:pub struct ResourceArena
+src/paint/resources.rs:225:pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String
+src/paint/resources.rs:229:pub fn image_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs:233:pub fn svg_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs:237:pub fn font_blob_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs:41: pub fn intern_image_bytes(&mut self, bytes: &[u8]) -> ImageResourceId
+src/paint/resources.rs:64: pub fn image_bytes(&self, id: ImageResourceId) -> Option<&[u8]>
+src/paint/resources.rs:68: pub fn image_count(&self) -> usize
+src/paint/resources.rs:6:pub struct ImageResourceId(pub usize)
+src/paint/resources.rs:72: pub fn image_hash(&self, id: ImageResourceId) -> Option<u64>
+src/paint/resources.rs:76: pub fn image_fingerprint(&self, id: ImageResourceId) -> Option<[u8
+src/paint/resources.rs:80: pub fn image_resource_key(&self, id: ImageResourceId) -> Option<&str>
+src/paint/resources.rs:84: pub fn image_resources(&self) -> impl Iterator<Item = (ImageResourceId, &[u8])> + '_
+src/paint/resources.rs:91: pub fn intern_svg_fragment(&mut self, svg: &str) -> SvgResourceId
+src/paint/resources.rs:9:pub struct SvgResourceId(pub usize)
+src/paint/schema.rs:16:pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema
+src/paint/schema.rs:25:pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version
+src/paint/schema.rs:26:pub const PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION: u32 = LAYER_TREE_SCHEMA.schema_minor_version
+src/paint/schema.rs:27:pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version
+src/paint/schema.rs:28:pub const PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION: u32 =
+src/paint/schema.rs:30:pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit
+src/paint/schema.rs:31:pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system
+src/paint/schema.rs:3:pub struct LayerTreeSchema
+src/paint/text_shape.rs:104: pub fn public_glyph_run_count(&self) -> usize
+src/paint/text_shape.rs:112:pub struct TextShapeLowerer<'a>
+src/paint/text_shape.rs:117: pub fn new(resolver: &'a dyn FontResolver) -> Self
+src/paint/text_shape.rs:11:pub struct FontRequest
+src/paint/text_shape.rs:121: pub fn diagnostics_only(resolver: &'a dyn FontResolver) -> Self
+src/paint/text_shape.rs:125: pub fn analyze_root(&self, root: &LayerNode) -> TextShapeReport
+src/paint/text_shape.rs:131: pub fn lower_root(&self, root: &mut LayerNode) -> TextShapeReport
+src/paint/text_shape.rs:28:pub struct ResolvedFontFace
+src/paint/text_shape.rs:33:pub struct ResolvedGlyphRun
+src/paint/text_shape.rs:42:pub trait FontResolver
+src/paint/text_shape.rs:56:pub struct NoopFontResolver
+src/paint/text_shape.rs:67:pub enum GlyphRunQuality
+src/paint/text_shape.rs:76: pub fn as_str(self) -> &'static str
+src/paint/text_shape.rs:88:pub struct TextShapeDiagnostic
+src/paint/text_shape.rs:99:pub struct TextShapeReport
+src/paint/text_v2.rs:105:pub struct TextV2SlotDiagnostic
+src/paint/text_v2.rs:118:pub struct TextV2LineBreakRisk
+src/paint/text_v2.rs:127:pub struct TextV2Diagnostics
+src/paint/text_v2.rs:137: pub fn from_layer_tree(tree: &PageLayerTree) -> Self
+src/paint/text_v2.rs:141: pub fn from_layer_tree_with_profile(
+src/paint/text_v2.rs:213: pub fn has_errors(&self) -> bool
+src/paint/text_v2.rs:219: pub fn to_json(&self) -> String
+src/paint/text_v2.rs:225: pub fn write_json(&self, buf: &mut String)
+src/paint/text_v2.rs:24:pub enum TextV2CompatibilityProfile
+src/paint/text_v2.rs:31: pub fn as_str(self) -> &'static str
+src/paint/text_v2.rs:42:pub enum TextV2ValidationSeverity
+src/paint/text_v2.rs:60:pub enum TextV2LineBreakRiskLevel
+src/paint/text_v2.rs:78:pub struct TextV2ValidationIssue
+src/paint/text_v2.rs:90:pub struct TextV2VariantDiagnostic
+src/paint/text_variants.rs:149:pub fn validate_text_variant_scope(tree: &PageLayerTree) -> Result<(), TextVariantScopeError>
+src/paint/text_variants.rs:15:pub enum TextVariantScopeError
+src/parser/bin_data.rs:10:pub enum BinDataError
+src/parser/bin_data.rs:26:pub struct BinDataContent
+src/parser/bin_data.rs:36:pub fn extract_all_bin_data(cfb_reader: &mut CfbReader) -> Vec<BinDataContent>
+src/parser/bin_data.rs:56:pub fn bin_data_storage_name(bin_id: u16, extension: &str) -> String
+src/parser/bin_data.rs:61:pub fn read_bin_data_by_name(
+src/parser/body_text.rs:128:pub fn parse_paragraph(records: &[Record]) -> Result<Paragraph, BodyTextError>
+src/parser/body_text.rs:35:pub enum BodyTextError
+src/parser/body_text.rs:491:pub fn parse_paragraph_list(records: &[Record]) -> Vec<Paragraph>
+src/parser/body_text.rs:54:pub fn parse_body_text_section(data: &[u8]) -> Result<Section, BodyTextError>
+src/parser/byte_reader.rs:102: pub fn read_hwp_string(&mut self) -> io::Result<String>
+src/parser/byte_reader.rs:10:pub struct ByteReader<'a>
+src/parser/byte_reader.rs:116: pub fn read_utf16_string(&mut self, char_count: usize) -> io::Result<String>
+src/parser/byte_reader.rs:129: pub fn read_color_ref(&mut self) -> io::Result<u32>
+src/parser/byte_reader.rs:134: pub fn read_remaining(&mut self) -> io::Result<Vec<u8>>
+src/parser/byte_reader.rs:17: pub fn new(data: &'a [u8]) -> Self
+src/parser/byte_reader.rs:25: pub fn position(&self) -> usize
+src/parser/byte_reader.rs:30: pub fn remaining(&self) -> usize
+src/parser/byte_reader.rs:35: pub fn is_empty(&self) -> bool
+src/parser/byte_reader.rs:40: pub fn read_u8(&mut self) -> io::Result<u8>
+src/parser/byte_reader.rs:45: pub fn read_u16(&mut self) -> io::Result<u16>
+src/parser/byte_reader.rs:50: pub fn read_u32(&mut self) -> io::Result<u32>
+src/parser/byte_reader.rs:55: pub fn read_i8(&mut self) -> io::Result<i8>
+src/parser/byte_reader.rs:60: pub fn read_i16(&mut self) -> io::Result<i16>
+src/parser/byte_reader.rs:65: pub fn read_i32(&mut self) -> io::Result<i32>
+src/parser/byte_reader.rs:70: pub fn read_i64(&mut self) -> io::Result<i64>
+src/parser/byte_reader.rs:75: pub fn read_bytes(&mut self, len: usize) -> io::Result<Vec<u8>>
+src/parser/byte_reader.rs:82: pub fn set_position(&mut self, pos: usize)
+src/parser/byte_reader.rs:87: pub fn skip(&mut self, n: usize) -> io::Result<()>
+src/parser/cfb_reader.rs:100: pub fn read_body_text_section(
+src/parser/cfb_reader.rs:13:pub struct CfbReader
+src/parser/cfb_reader.rs:140: pub fn read_bin_data(&mut self, storage_name: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:146: pub fn section_count(&self) -> u32
+src/parser/cfb_reader.rs:167: pub fn list_bin_data(&self) -> Vec<String>
+src/parser/cfb_reader.rs:182: pub fn list_streams(&self) -> Vec<String>
+src/parser/cfb_reader.rs:193: pub fn list_all_entries(&self) -> Vec<(String, u64, bool)>
+src/parser/cfb_reader.rs:19:pub enum CfbError
+src/parser/cfb_reader.rs:208: pub fn read_preview_image(&mut self) -> Option<Vec<u8>>
+src/parser/cfb_reader.rs:220: pub fn read_preview_text(&mut self) -> Option<String>
+src/parser/cfb_reader.rs:265: pub fn detect_hwp3_variant(&mut self) -> bool
+src/parser/cfb_reader.rs:291:pub struct LenientCfbReader
+src/parser/cfb_reader.rs:310: pub fn open(data: &[u8]) -> Result<Self, CfbError>
+src/parser/cfb_reader.rs:45: pub fn open(data: &[u8]) -> Result<Self, CfbError>
+src/parser/cfb_reader.rs:541: pub fn read_stream(&self, path: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:54: pub fn has_stream(&self, path: &str) -> bool
+src/parser/cfb_reader.rs:562: pub fn has_stream(&self, path: &str) -> bool
+src/parser/cfb_reader.rs:566: pub fn read_doc_info(&self, compressed: bool) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:575: pub fn read_body_text_section(
+src/parser/cfb_reader.rs:589: pub fn list_entries(&self) -> &[(String, u32, u64, u8)]
+src/parser/cfb_reader.rs:594: pub fn read_file_header(&self) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:599: pub fn read_body_text_section_full(
+src/parser/cfb_reader.rs:59: pub fn read_stream_raw(&mut self, path: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:623: pub fn section_count(&self) -> u32
+src/parser/cfb_reader.rs:640:pub fn decompress_stream(data: &[u8]) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:78: pub fn read_file_header(&mut self) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs:83: pub fn read_doc_info(&mut self, compressed: bool) -> Result<Vec<u8>, CfbError>
+src/parser/control.rs:33:pub fn parse_control(ctrl_id: u32, ctrl_data: &[u8], child_records: &[Record]) -> Control
+src/parser/crypto.rs:19:pub enum CryptoError
+src/parser/crypto.rs:327:pub fn decrypt_viewtext_section(
+src/parser/doc_info.rs:24:pub enum DocInfoError
+src/parser/doc_info.rs:60:pub fn parse_doc_info(data: &[u8]) -> Result<(DocInfo, DocProperties), DocInfoError>
+src/parser/header.rs:103:pub enum HeaderError
+src/parser/header.rs:130:pub fn parse_file_header(data: &[u8]) -> Result<FileHeader, HeaderError>
+src/parser/header.rs:14:pub const HWP_SIGNATURE: &[u8] = b"HWP Document File"
+src/parser/header.rs:17:pub const FILE_HEADER_SIZE: usize = 256
+src/parser/header.rs:21:pub struct HwpVersion
+src/parser/header.rs:30: pub fn is_supported(&self) -> bool
+src/parser/header.rs:47:pub struct FileHeaderFlags
+src/parser/header.rs:76: pub fn from_u32(flags: u32) -> Self
+src/parser/header.rs:96:pub struct FileHeader
+src/parser/hml/encoding.rs:10:pub struct DecodedHml
+src/parser/hml/encoding.rs:15:pub fn decode(bytes: &[u8], max_bytes: usize) -> Result<DecodedHml, HmlError>
+src/parser/hml/encoding.rs:4:pub enum HmlEncoding
+src/parser/hml/envelope.rs:8:pub struct PreservedFragment
+src/parser/hml/error.rs:2:pub enum HmlError
+src/parser/hml/mod.rs:10:pub use encoding::HmlEncoding
+src/parser/hml/mod.rs:11:pub use envelope::PreservedFragment
+src/parser/hml/mod.rs:12:pub use error::HmlError
+src/parser/hml/mod.rs:13:pub use reader::HmlLimits
+src/parser/hml/mod.rs:14:pub use warnings::{HmlWarning, HmlWarningCode}
+src/parser/hml/mod.rs:18:pub fn detect_hml_signature(bytes: &[u8]) -> bool
+src/parser/hml/mod.rs:23:pub struct HmlMetadata
+src/parser/hml/mod.rs:2:pub mod encoding
+src/parser/hml/mod.rs:31:pub struct HmlParseResult
+src/parser/hml/mod.rs:38:pub fn parse_hml(bytes: &[u8]) -> Result<HmlParseResult, HmlError>
+src/parser/hml/mod.rs:42:pub fn parse_hml_with_limits(bytes: &[u8], limits: &HmlLimits) -> Result<HmlParseResult, HmlError>
+src/parser/hml/mod.rs:4:pub mod error
+src/parser/hml/reader.rs:39:pub struct HmlLimits
+src/parser/hml/warnings.rs:13:pub struct HmlWarning
+src/parser/hml/warnings.rs:2:pub enum HmlWarningCode
+src/parser/hwp3/drawing.rs:111: pub fn has_gradient(&self) -> bool
+src/parser/hwp3/drawing.rs:115: pub fn has_rotation(&self) -> bool
+src/parser/hwp3/drawing.rs:119: pub fn has_bitmap_pattern(&self) -> bool
+src/parser/hwp3/drawing.rs:11:pub struct Hwp3DrawingObjectFrameHeader
+src/parser/hwp3/drawing.rs:125:pub struct Hwp3DrawingObjectRotationAttr
+src/parser/hwp3/drawing.rs:132: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:149:pub struct Hwp3DrawingObjectGradientAttr
+src/parser/hwp3/drawing.rs:160: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:174:pub struct Hwp3DrawingObjectBitmapPatternAttr
+src/parser/hwp3/drawing.rs:182: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:19: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:206:pub struct Hwp3DrawingObjectCommonHeader
+src/parser/hwp3/drawing.rs:221: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:282:pub enum Hwp3DrawingObject
+src/parser/hwp3/drawing.rs:299:pub struct Hwp3DrawingLine
+src/parser/hwp3/drawing.rs:306: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:316:pub struct Hwp3DrawingArc
+src/parser/hwp3/drawing.rs:323: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:333:pub struct Hwp3DrawingPolygon
+src/parser/hwp3/drawing.rs:341: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:363:pub struct Hwp3DrawingTextBox
+src/parser/hwp3/drawing.rs:370: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:386:pub struct Hwp3DrawingCurve
+src/parser/hwp3/drawing.rs:394: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:40:pub struct Hwp3DrawingObjectHypertextInfo
+src/parser/hwp3/drawing.rs:416:pub struct Hwp3DrawingModifiedEllipse
+src/parser/hwp3/drawing.rs:423: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:438:pub struct Hwp3DrawingExtendedPolygon
+src/parser/hwp3/drawing.rs:447: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:474: pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:50: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs:572:pub fn parse_drawing_object_tree(
+src/parser/hwp3/drawing.rs:79:pub struct Hwp3DrawingObjectBasicAttr
+src/parser/hwp3/drawing.rs:93: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/encoding.rs:14:pub fn decode_hwp3_string(bytes: &[u8]) -> String
+src/parser/hwp3/johab.rs:8:pub fn decode_johab(ch: u16) -> char
+src/parser/hwp3/johab_map.rs:6:pub const JOHAB_SYMBOLS: &[(u16, char)] = &[
+src/parser/hwp3/mod.rs:10:pub mod drawing
+src/parser/hwp3/mod.rs:11:pub mod encoding
+src/parser/hwp3/mod.rs:12:pub mod johab
+src/parser/hwp3/mod.rs:13:pub mod johab_map
+src/parser/hwp3/mod.rs:14:pub mod ole
+src/parser/hwp3/mod.rs:15:pub mod paragraph
+src/parser/hwp3/mod.rs:16:pub mod records
+src/parser/hwp3/mod.rs:17:pub mod special_char
+src/parser/hwp3/mod.rs:23:pub enum Hwp3Error
+src/parser/hwp3/mod.rs:2852:pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error>
+src/parser/hwp3/ole.rs:11:pub enum Hwp3OleError
+src/parser/hwp3/ole.rs:127: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/ole.rs:26:pub struct Hwp3OleInfo
+src/parser/hwp3/ole.rs:32: pub fn read<R: Read>(mut reader: R, total_length: u32) -> Result<Self, Hwp3OleError>
+src/parser/hwp3/ole.rs:61:pub struct Hwp3OleStreamInfo
+src/parser/hwp3/ole.rs:80: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/ole.rs:98:pub struct Hwp3ChartConnectionInfo
+src/parser/hwp3/paragraph.rs:11:pub struct Hwp3LineInfo
+src/parser/hwp3/paragraph.rs:22: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/paragraph.rs:44:pub struct Hwp3ParaInfo
+src/parser/hwp3/paragraph.rs:57: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:12:pub struct Hwp3DocInfo
+src/parser/hwp3/records.rs:148:pub struct Hwp3DocSummary
+src/parser/hwp3/records.rs:158: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:193:pub struct Hwp3CharShape
+src/parser/hwp3/records.rs:206: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:237: pub fn is_italic(&self) -> bool
+src/parser/hwp3/records.rs:240: pub fn is_bold(&self) -> bool
+src/parser/hwp3/records.rs:243: pub fn is_underline(&self) -> bool
+src/parser/hwp3/records.rs:246: pub fn is_outline(&self) -> bool
+src/parser/hwp3/records.rs:249: pub fn is_shadow(&self) -> bool
+src/parser/hwp3/records.rs:252: pub fn is_superscript(&self) -> bool
+src/parser/hwp3/records.rs:255: pub fn is_subscript(&self) -> bool
+src/parser/hwp3/records.rs:258: pub fn is_font_blank(&self) -> bool
+src/parser/hwp3/records.rs:264:pub struct Hwp3TabDef
+src/parser/hwp3/records.rs:271: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:287:pub struct Hwp3ColumnDef
+src/parser/hwp3/records.rs:295: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:311:pub struct Hwp3ParaShape
+src/parser/hwp3/records.rs:350: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:388: pub fn alignment(&self) -> u8
+src/parser/hwp3/records.rs:392: pub fn has_border(&self) -> bool
+src/parser/hwp3/records.rs:396: pub fn border_connection(&self) -> bool
+src/parser/hwp3/records.rs:402:pub struct Hwp3Style
+src/parser/hwp3/records.rs:409: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:426:pub struct Hwp3InfoBlock
+src/parser/hwp3/records.rs:433: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:443:pub struct Hwp3AdditionalInfoBlock
+src/parser/hwp3/records.rs:450: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs:54: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/special_char.rs:10:pub enum Hwp3SpecialCharError
+src/parser/hwp3/special_char.rs:133: pub fn parse(code: u16, length: u32, data: Vec<u8>) -> Result<Self, Hwp3SpecialCharError>
+src/parser/hwp3/special_char.rs:24:pub enum Hwp3SpecialChar
+src/parser/hwpx/content.rs:13:pub struct PackageItem
+src/parser/hwpx/content.rs:27:pub struct PackageInfo
+src/parser/hwpx/content.rs:45:pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError>
+src/parser/hwpx/header.rs:71:pub fn parse_hwpx_hwpml_version(xml: &str) -> Option<String>
+src/parser/hwpx/header.rs:95:pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxError>
+src/parser/hwpx/mod.rs:116:pub enum HwpxError
+src/parser/hwpx/mod.rs:132: pub fn is_encrypted(&self) -> bool
+src/parser/hwpx/mod.rs:13:pub mod content
+src/parser/hwpx/mod.rs:15:pub mod header
+src/parser/hwpx/mod.rs:16:pub mod reader
+src/parser/hwpx/mod.rs:17:pub mod section
+src/parser/hwpx/mod.rs:18:pub mod utils
+src/parser/hwpx/mod.rs:236:pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError>
+src/parser/hwpx/reader.rs:102: pub fn read_file_bytes(&mut self, path: &str) -> Result<Vec<u8>, HwpxError>
+src/parser/hwpx/reader.rs:112: pub fn file_names(&self) -> Vec<String>
+src/parser/hwpx/reader.rs:27:pub const MAX_XML_SIZE: usize = 256 * 1024 * 1024
+src/parser/hwpx/reader.rs:36:pub const MAX_BINDATA_SIZE: usize = 512 * 1024 * 1024
+src/parser/hwpx/reader.rs:59:pub struct HwpxReader
+src/parser/hwpx/reader.rs:65: pub fn open(data: &[u8]) -> Result<Self, HwpxError>
+src/parser/hwpx/reader.rs:79: pub fn read_file(&mut self, path: &str) -> Result<String, HwpxError>
+src/parser/hwpx/section.rs:116:pub fn parse_hwpx_master_page(xml: &str) -> Result<MasterPage, HwpxError>
+src/parser/hwpx/section.rs:44:pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError>
+src/parser/hwpx/section.rs:77:pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError>
+src/parser/hwpx/utils.rs:116:pub fn parse_bool(attr: &quick_xml::events::attributes::Attribute) -> bool
+src/parser/hwpx/utils.rs:126:pub fn parse_hatch_style(value: &str) -> Option<i32>
+src/parser/hwpx/utils.rs:12:pub fn local_name(name: &[u8]) -> &[u8]
+src/parser/hwpx/utils.rs:139:pub fn parse_gradient_type(value: &str) -> i16
+src/parser/hwpx/utils.rs:150:pub fn skip_element(reader: &mut Reader<&[u8]>, _end_tag: &[u8]) -> Result<(), HwpxError>
+src/parser/hwpx/utils.rs:29:pub fn attr_str(attr: &quick_xml::events::attributes::Attribute) -> String
+src/parser/hwpx/utils.rs:38:pub fn attr_eq(attr: &quick_xml::events::attributes::Attribute, val: &str) -> bool
+src/parser/hwpx/utils.rs:42:pub fn parse_u8(attr: &quick_xml::events::attributes::Attribute) -> u8
+src/parser/hwpx/utils.rs:46:pub fn parse_i8(attr: &quick_xml::events::attributes::Attribute) -> i8
+src/parser/hwpx/utils.rs:50:pub fn parse_u16(attr: &quick_xml::events::attributes::Attribute) -> u16
+src/parser/hwpx/utils.rs:54:pub fn parse_i16(attr: &quick_xml::events::attributes::Attribute) -> i16
+src/parser/hwpx/utils.rs:58:pub fn parse_u32(attr: &quick_xml::events::attributes::Attribute) -> u32
+src/parser/hwpx/utils.rs:62:pub fn parse_i32(attr: &quick_xml::events::attributes::Attribute) -> i32
+src/parser/hwpx/utils.rs:71:pub fn parse_i32_wrapping(attr: &quick_xml::events::attributes::Attribute) -> i32
+src/parser/hwpx/utils.rs:83:pub fn parse_color(attr: &quick_xml::events::attributes::Attribute) -> u32
+src/parser/hwpx/utils.rs:89:pub fn parse_color_str(s: &str) -> u32
+src/parser/ingest/mod.rs:12:pub mod schema
+src/parser/ingest/mod.rs:14:pub use schema::*
+src/parser/ingest/mod.rs:19:pub fn parse_ingest_bytes(bytes: &[u8]) -> Result<IngestDocument, HwpError>
+src/parser/ingest/mod.rs:25:pub fn parse_ingest_str(s: &str) -> Result<IngestDocument, HwpError>
+src/parser/ingest/schema.rs:109:pub enum StemBlock
+src/parser/ingest/schema.rs:134:pub struct Choice
+src/parser/ingest/schema.rs:143:pub struct Media
+src/parser/ingest/schema.rs:162:pub enum Placement
+src/parser/ingest/schema.rs:54:pub struct PageSize
+src/parser/ingest/schema.rs:61:pub struct Passage
+src/parser/ingest/schema.rs:71:pub struct Question
+src/parser/ingest/schema.rs:9:pub struct IngestDocument
+src/parser/mod.rs:1043:pub fn parse_document(data: &[u8]) -> Result<Document, ParseError>
+src/parser/mod.rs:1080:pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult>
+src/parser/mod.rs:108:pub enum ParseError
+src/parser/mod.rs:1178:pub struct ThumbnailResult
+src/parser/mod.rs:175:pub fn parse_hwp(data: &[u8]) -> Result<Document, ParseError>
+src/parser/mod.rs:18:pub mod bin_data
+src/parser/mod.rs:19:pub mod body_text
+src/parser/mod.rs:20:pub mod byte_reader
+src/parser/mod.rs:21:pub mod cfb_reader
+src/parser/mod.rs:22:pub mod control
+src/parser/mod.rs:23:pub mod crypto
+src/parser/mod.rs:24:pub mod doc_info
+src/parser/mod.rs:25:pub mod header
+src/parser/mod.rs:26:pub mod hml
+src/parser/mod.rs:27:pub mod hwp3
+src/parser/mod.rs:28:pub mod hwpx
+src/parser/mod.rs:29:pub mod ingest
+src/parser/mod.rs:30:pub mod ole_container
+src/parser/mod.rs:31:pub mod record
+src/parser/mod.rs:32:pub mod tags
+src/parser/mod.rs:42:pub enum FileFormat
+src/parser/mod.rs:76:pub fn detect_format(data: &[u8]) -> FileFormat
+src/parser/mod.rs:937:pub trait DocumentParser
+src/parser/mod.rs:942:pub struct HwpParser
+src/parser/mod.rs:951:pub struct HwpxParser
+src/parser/mod.rs:960:pub struct Hwp3Parser
+src/parser/mod.rs:969:pub struct HmlParser
+src/parser/mod.rs:980:pub struct HmlImportMetadata
+src/parser/mod.rs:991:pub struct ParsedDocument
+src/parser/mod.rs:997:pub fn parse_document_with_metadata(data: &[u8]) -> Result<ParsedDocument, ParseError>
+src/parser/ole_container.rs:11:pub enum NativeImageKind
+src/parser/ole_container.rs:162:pub fn is_hmapsi_ole_container(cfb_bytes: &[u8]) -> bool
+src/parser/ole_container.rs:171:pub fn detect_native_image(data: &[u8]) -> Option<(NativeImageKind, Vec<u8>)>
+src/parser/ole_container.rs:19: pub fn mime(&self) -> &'static str
+src/parser/ole_container.rs:31:pub struct OleContainer
+src/parser/ole_container.rs:44: pub fn has_ooxml_chart(&self) -> bool
+src/parser/ole_container.rs:49: pub fn has_preview(&self) -> bool
+src/parser/ole_container.rs:58:pub fn parse_ole_container(cfb_bytes: &[u8]) -> Option<OleContainer>
+src/parser/record.rs:101:pub enum RecordError
+src/parser/record.rs:16:pub struct Record
+src/parser/record.rs:29: pub fn tag_name(&self) -> &'static str
+src/parser/record.rs:34: pub fn read_all(data: &[u8]) -> Result<Vec<Record>, RecordError>
+src/parser/tags.rs:100:pub const HWPTAG_FORM_OBJECT: u16 = HWPTAG_BEGIN + 75
+src/parser/tags.rs:102:pub const HWPTAG_MEMO_SHAPE: u16 = HWPTAG_BEGIN + 76
+src/parser/tags.rs:104:pub const HWPTAG_MEMO_LIST: u16 = HWPTAG_BEGIN + 77
+src/parser/tags.rs:106:pub const HWPTAG_FORBIDDEN_CHAR: u16 = HWPTAG_BEGIN + 78
+src/parser/tags.rs:108:pub const HWPTAG_CHART_DATA: u16 = HWPTAG_BEGIN + 79
+src/parser/tags.rs:115:pub const CHAR_SECTION_COLUMN_DEF: u16 = 0x0002
+src/parser/tags.rs:117:pub const CHAR_FIELD_BEGIN: u16 = 0x0003
+src/parser/tags.rs:119:pub const CHAR_FIELD_END: u16 = 0x0004
+src/parser/tags.rs:121:pub const CHAR_INLINE_NON_TEXT: u16 = 0x0008
+src/parser/tags.rs:123:pub const CHAR_EXTENDED_CTRL: u16 = 0x000B
+src/parser/tags.rs:125:pub const CHAR_LINE_BREAK: u16 = 0x000A
+src/parser/tags.rs:127:pub const CHAR_PARA_BREAK: u16 = 0x000D
+src/parser/tags.rs:129:pub const CHAR_HYPHEN: u16 = 0x0018
+src/parser/tags.rs:131:pub const CHAR_NBSPACE: u16 = 0x001E
+src/parser/tags.rs:133:pub const CHAR_FIXED_WIDTH_SPACE: u16 = 0x0019
+src/parser/tags.rs:135:pub const CHAR_FIXED_WIDTH_SPACE_31: u16 = 0x001F
+src/parser/tags.rs:13:pub const HWPTAG_DOCUMENT_PROPERTIES: u16 = HWPTAG_BEGIN
+src/parser/tags.rs:142:pub const CTRL_SECTION_DEF: u32 = ctrl_id(b"secd")
+src/parser/tags.rs:144:pub const CTRL_COLUMN_DEF: u32 = ctrl_id(b"cold")
+src/parser/tags.rs:146:pub const CTRL_TABLE: u32 = ctrl_id(b"tbl ")
+src/parser/tags.rs:148:pub const CTRL_EQUATION: u32 = ctrl_id(b"eqed")
+src/parser/tags.rs:150:pub const CTRL_GEN_SHAPE: u32 = ctrl_id(b"gso ")
+src/parser/tags.rs:152:pub const SHAPE_PICTURE_ID: u32 = ctrl_id(b"$pic")
+src/parser/tags.rs:154:pub const SHAPE_OLE_ID: u32 = ctrl_id(b"$ole")
+src/parser/tags.rs:156:pub const SHAPE_RECT_ID: u32 = ctrl_id(b"$rec")
+src/parser/tags.rs:158:pub const SHAPE_LINE_ID: u32 = ctrl_id(b"$lin")
+src/parser/tags.rs:15:pub const HWPTAG_ID_MAPPINGS: u16 = HWPTAG_BEGIN + 1
+src/parser/tags.rs:160:pub const SHAPE_ELLIPSE_ID: u32 = ctrl_id(b"$ell")
+src/parser/tags.rs:162:pub const SHAPE_POLYGON_ID: u32 = ctrl_id(b"$pol")
+src/parser/tags.rs:164:pub const SHAPE_ARC_ID: u32 = ctrl_id(b"$arc")
+src/parser/tags.rs:166:pub const SHAPE_CURVE_ID: u32 = ctrl_id(b"$cur")
+src/parser/tags.rs:168:pub const SHAPE_CONNECTOR_ID: u32 = ctrl_id(b"$col")
+src/parser/tags.rs:170:pub const SHAPE_CONTAINER_ID: u32 = ctrl_id(b"$con")
+src/parser/tags.rs:172:pub const CTRL_HEADER: u32 = ctrl_id(b"head")
+src/parser/tags.rs:174:pub const CTRL_FOOTER: u32 = ctrl_id(b"foot")
+src/parser/tags.rs:176:pub const CTRL_FOOTNOTE: u32 = ctrl_id(b"fn ")
+src/parser/tags.rs:178:pub const CTRL_ENDNOTE: u32 = ctrl_id(b"en ")
+src/parser/tags.rs:17:pub const HWPTAG_BIN_DATA: u16 = HWPTAG_BEGIN + 2
+src/parser/tags.rs:180:pub const CTRL_AUTO_NUMBER: u32 = ctrl_id(b"atno")
+src/parser/tags.rs:182:pub const CTRL_NEW_NUMBER: u32 = ctrl_id(b"nwno")
+src/parser/tags.rs:184:pub const CTRL_PAGE_NUM_POS: u32 = ctrl_id(b"pgnp")
+src/parser/tags.rs:186:pub const CTRL_PAGE_HIDE: u32 = ctrl_id(b"pghd")
+src/parser/tags.rs:188:pub const CTRL_INDEX_MARK: u32 = ctrl_id(b"idxm")
+src/parser/tags.rs:190:pub const CTRL_BOOKMARK: u32 = ctrl_id(b"bokm")
+src/parser/tags.rs:192:pub const CTRL_TCPS: u32 = ctrl_id(b"tcps")
+src/parser/tags.rs:194:pub const CTRL_FORM: u32 = ctrl_id(b"form")
+src/parser/tags.rs:196:pub const CTRL_CHAR_OVERLAP: u32 = ctrl_id(b"tdut")
+src/parser/tags.rs:198:pub const CTRL_HIDDEN_COMMENT: u32 = ctrl_id(b"tcmt")
+src/parser/tags.rs:19:pub const HWPTAG_FACE_NAME: u16 = HWPTAG_BEGIN + 3
+src/parser/tags.rs:205:pub const FIELD_CLICKHERE: u32 = ctrl_id(b"%clk")
+src/parser/tags.rs:207:pub const FIELD_HYPERLINK: u32 = ctrl_id(b"%hlk")
+src/parser/tags.rs:209:pub const FIELD_BOOKMARK: u32 = ctrl_id(b"%bmk")
+src/parser/tags.rs:211:pub const FIELD_DATE: u32 = ctrl_id(b"%dte")
+src/parser/tags.rs:213:pub const FIELD_DOCDATE: u32 = ctrl_id(b"%ddt")
+src/parser/tags.rs:215:pub const FIELD_PATH: u32 = ctrl_id(b"%pat")
+src/parser/tags.rs:217:pub const FIELD_MAILMERGE: u32 = ctrl_id(b"%mmg")
+src/parser/tags.rs:219:pub const FIELD_CROSSREF: u32 = ctrl_id(b"%xrf")
+src/parser/tags.rs:21:pub const HWPTAG_BORDER_FILL: u16 = HWPTAG_BEGIN + 4
+src/parser/tags.rs:221:pub const FIELD_FORMULA: u32 = ctrl_id(b"%fmu")
+src/parser/tags.rs:223:pub const FIELD_SUMMARY: u32 = ctrl_id(b"%smr")
+src/parser/tags.rs:225:pub const FIELD_USERINFO: u32 = ctrl_id(b"%usr")
+src/parser/tags.rs:227:pub const FIELD_MEMO: u32 = ctrl_id(b"%%me")
+src/parser/tags.rs:229:pub const FIELD_PRIVATE_INFO: u32 = ctrl_id(b"%cpr")
+src/parser/tags.rs:231:pub const FIELD_TOC: u32 = ctrl_id(b"%toc")
+src/parser/tags.rs:233:pub const FIELD_UNKNOWN: u32 = ctrl_id(b"%unk")
+src/parser/tags.rs:236:pub const fn is_field_ctrl_id(id: u32) -> bool
+src/parser/tags.rs:23:pub const HWPTAG_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 5
+src/parser/tags.rs:250:pub fn tag_name(tag_id: u16) -> &'static str
+src/parser/tags.rs:25:pub const HWPTAG_TAB_DEF: u16 = HWPTAG_BEGIN + 6
+src/parser/tags.rs:27:pub const HWPTAG_NUMBERING: u16 = HWPTAG_BEGIN + 7
+src/parser/tags.rs:29:pub const HWPTAG_BULLET: u16 = HWPTAG_BEGIN + 8
+src/parser/tags.rs:302:pub fn ctrl_name(ctrl_id: u32) -> &'static str
+src/parser/tags.rs:31:pub const HWPTAG_PARA_SHAPE: u16 = HWPTAG_BEGIN + 9
+src/parser/tags.rs:33:pub const HWPTAG_STYLE: u16 = HWPTAG_BEGIN + 10
+src/parser/tags.rs:35:pub const HWPTAG_DOC_DATA: u16 = HWPTAG_BEGIN + 11
+src/parser/tags.rs:37:pub const HWPTAG_DISTRIBUTE_DOC_DATA: u16 = HWPTAG_BEGIN + 12
+src/parser/tags.rs:40:pub const HWPTAG_COMPATIBLE_DOCUMENT: u16 = HWPTAG_BEGIN + 14
+src/parser/tags.rs:42:pub const HWPTAG_LAYOUT_COMPATIBILITY: u16 = HWPTAG_BEGIN + 15
+src/parser/tags.rs:44:pub const HWPTAG_TRACKCHANGE: u16 = HWPTAG_BEGIN + 16
+src/parser/tags.rs:51:pub const HWPTAG_PARA_HEADER: u16 = HWPTAG_BEGIN + 50
+src/parser/tags.rs:53:pub const HWPTAG_PARA_TEXT: u16 = HWPTAG_BEGIN + 51
+src/parser/tags.rs:55:pub const HWPTAG_PARA_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 52
+src/parser/tags.rs:57:pub const HWPTAG_PARA_LINE_SEG: u16 = HWPTAG_BEGIN + 53
+src/parser/tags.rs:59:pub const HWPTAG_PARA_RANGE_TAG: u16 = HWPTAG_BEGIN + 54
+src/parser/tags.rs:61:pub const HWPTAG_CTRL_HEADER: u16 = HWPTAG_BEGIN + 55
+src/parser/tags.rs:63:pub const HWPTAG_LIST_HEADER: u16 = HWPTAG_BEGIN + 56
+src/parser/tags.rs:65:pub const HWPTAG_PAGE_DEF: u16 = HWPTAG_BEGIN + 57
+src/parser/tags.rs:67:pub const HWPTAG_FOOTNOTE_SHAPE: u16 = HWPTAG_BEGIN + 58
+src/parser/tags.rs:69:pub const HWPTAG_PAGE_BORDER_FILL: u16 = HWPTAG_BEGIN + 59
+src/parser/tags.rs:6:pub const HWPTAG_BEGIN: u16 = 0x010
+src/parser/tags.rs:71:pub const HWPTAG_SHAPE_COMPONENT: u16 = HWPTAG_BEGIN + 60
+src/parser/tags.rs:73:pub const HWPTAG_TABLE: u16 = HWPTAG_BEGIN + 61
+src/parser/tags.rs:75:pub const HWPTAG_SHAPE_COMPONENT_LINE: u16 = HWPTAG_BEGIN + 62
+src/parser/tags.rs:77:pub const HWPTAG_SHAPE_COMPONENT_RECTANGLE: u16 = HWPTAG_BEGIN + 63
+src/parser/tags.rs:79:pub const HWPTAG_SHAPE_COMPONENT_ELLIPSE: u16 = HWPTAG_BEGIN + 64
+src/parser/tags.rs:81:pub const HWPTAG_SHAPE_COMPONENT_ARC: u16 = HWPTAG_BEGIN + 65
+src/parser/tags.rs:83:pub const HWPTAG_SHAPE_COMPONENT_POLYGON: u16 = HWPTAG_BEGIN + 66
+src/parser/tags.rs:85:pub const HWPTAG_SHAPE_COMPONENT_CURVE: u16 = HWPTAG_BEGIN + 67
+src/parser/tags.rs:87:pub const HWPTAG_SHAPE_COMPONENT_OLE: u16 = HWPTAG_BEGIN + 68
+src/parser/tags.rs:89:pub const HWPTAG_SHAPE_COMPONENT_PICTURE: u16 = HWPTAG_BEGIN + 69
+src/parser/tags.rs:91:pub const HWPTAG_SHAPE_COMPONENT_CONTAINER: u16 = HWPTAG_BEGIN + 70
+src/parser/tags.rs:93:pub const HWPTAG_CTRL_DATA: u16 = HWPTAG_BEGIN + 71
+src/parser/tags.rs:95:pub const HWPTAG_EQEDIT: u16 = HWPTAG_BEGIN + 72
+src/parser/tags.rs:98:pub const HWPTAG_SHAPE_COMPONENT_TEXTART: u16 = HWPTAG_BEGIN + 74
+src/renderer/canvas.rs:16:pub struct CanvasRenderer
+src/renderer/canvas.rs:27:pub enum CanvasCommand
+src/renderer/canvas.rs:64: pub fn new() -> Self
+src/renderer/canvas.rs:73: pub fn commands(&self) -> &[CanvasCommand]
+src/renderer/canvas.rs:78: pub fn command_count(&self) -> usize
+src/renderer/canvas.rs:83: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/canvas.rs:88: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
+src/renderer/canvaskit_policy.rs:112:pub enum CanvasKitReplayFeature
+src/renderer/canvaskit_policy.rs:129:pub enum CanvasKitReplayStatus
+src/renderer/canvaskit_policy.rs:139:pub enum CanvasKitReplayReason
+src/renderer/canvaskit_policy.rs:150:pub struct CanvasKitTextVariantReport
+src/renderer/canvaskit_policy.rs:163:pub struct CanvasKitRejectedTextVariant
+src/renderer/canvaskit_policy.rs:169:pub fn analyze_canvaskit_replay_plan(
+src/renderer/canvaskit_policy.rs:27:pub enum CanvasKitReplayMode
+src/renderer/canvaskit_policy.rs:33: pub fn from_str(value: &str) -> Option<Self>
+src/renderer/canvaskit_policy.rs:41: pub fn as_str(self) -> &'static str
+src/renderer/canvaskit_policy.rs:74:pub struct CanvasKitReplayPlan
+src/renderer/canvaskit_policy.rs:85:pub struct CanvasKitReplaySummary
+src/renderer/canvaskit_policy.rs:97:pub struct CanvasKitReplayItem
+src/renderer/composer.rs:108:pub fn compose_section(section: &Section) -> Vec<ComposedParagraph>
+src/renderer/composer.rs:1263:pub fn estimate_composed_line_width(line: &ComposedLine, styles: &ResolvedStyleSet) -> f64
+src/renderer/composer.rs:1419:pub fn recompose_for_body_width(
+src/renderer/composer.rs:1437:pub fn recompose_stored_single_line_if_overflowing(
+src/renderer/composer.rs:1476:pub fn stored_lines_overflow(
+src/renderer/composer.rs:1530:pub fn recompose_stored_lines_if_overflowing_body(
+src/renderer/composer.rs:1544:pub fn recompose_for_cell_width(
+src/renderer/composer.rs:16:pub struct CharOverlapInfo
+src/renderer/composer.rs:2230:pub fn effective_text_for_metrics(run: &ComposedTextRun) -> &str
+src/renderer/composer.rs:2288:pub fn decode_pua_overlap_number(chars: &[char]) -> Option<String>
+src/renderer/composer.rs:2308:pub fn char_overlap_advance_units(chars: &[char]) -> usize
+src/renderer/composer.rs:2364:pub fn expand_pua_display_text(text: &str) -> String
+src/renderer/composer.rs:2386:pub fn expand_pua_render_text(text: &str) -> String
+src/renderer/composer.rs:2393:pub fn pua_to_display_text(ch: char) -> Option<String>
+src/renderer/composer.rs:2490:pub mod lineseg_compare
+src/renderer/composer.rs:25:pub struct ComposedTextRun
+src/renderer/composer.rs:263:pub fn compose_paragraph(para: &Paragraph) -> ComposedParagraph
+src/renderer/composer.rs:44:pub struct ComposedLine
+src/renderer/composer.rs:65:pub enum InlineControlType
+src/renderer/composer.rs:76:pub struct InlineControl
+src/renderer/composer.rs:87:pub struct ComposedParagraph
+src/renderer/composer/lineseg_compare.rs:10:pub struct LineSegFieldDiff
+src/renderer/composer/lineseg_compare.rs:133:pub struct AvgFieldDeltas
+src/renderer/composer/lineseg_compare.rs:145:pub fn compare_line_segs(
+src/renderer/composer/lineseg_compare.rs:180:pub fn format_report(reports: &[SectionLineSegReport]) -> String
+src/renderer/composer/lineseg_compare.rs:23: pub fn text_start_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs:28: pub fn all_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs:40:pub struct ParagraphLineSegDiff
+src/renderer/composer/lineseg_compare.rs:50: pub fn line_breaks_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs:55: pub fn all_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs:62:pub struct SectionLineSegReport
+src/renderer/composer/lineseg_compare.rs:73: pub fn line_count_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs:80: pub fn line_break_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs:87: pub fn all_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs:95: pub fn avg_field_deltas(&self) -> AvgFieldDeltas
+src/renderer/equation/ast.rs:153:pub enum PileAlign
+src/renderer/equation/ast.rs:161: pub fn simplify(self) -> Self
+src/renderer/equation/ast.rs:18:pub enum SpaceKind
+src/renderer/equation/ast.rs:26:pub enum EqNode
+src/renderer/equation/ast.rs:9:pub enum MatrixStyle
+src/renderer/equation/canvas_render.rs:12:pub fn render_equation_canvas(
+src/renderer/equation/layout.rs:10:pub struct LayoutBox
+src/renderer/equation/layout.rs:122:pub struct EqLayout
+src/renderer/equation/layout.rs:197: pub fn new(font_size: f64) -> Self
+src/renderer/equation/layout.rs:202: pub fn layout(&self, node: &EqNode) -> LayoutBox
+src/renderer/equation/layout.rs:27:pub enum LayoutKind
+src/renderer/equation/mod.rs:10:pub mod parser
+src/renderer/equation/mod.rs:11:pub mod svg_render
+src/renderer/equation/mod.rs:12:pub mod symbols
+src/renderer/equation/mod.rs:13:pub mod tokenizer
+src/renderer/equation/mod.rs:16:pub fn intrinsic_size_hwp(script: &str, font_size: u32) -> (u32, u32)
+src/renderer/equation/mod.rs:6:pub mod ast
+src/renderer/equation/mod.rs:8:pub mod canvas_render
+src/renderer/equation/mod.rs:9:pub mod layout
+src/renderer/equation/parser.rs:13:pub struct EqParser
+src/renderer/equation/parser.rs:1628:pub fn parse(script: &str) -> EqNode
+src/renderer/equation/parser.rs:19: pub fn new(tokens: Vec<Token>) -> Self
+src/renderer/equation/parser.rs:92: pub fn parse(&mut self) -> EqNode
+src/renderer/equation/svg_render.rs:13:pub const DEFAULT_EQUATION_FONT_FAMILY_ATTR: &str =
+src/renderer/equation/svg_render.rs:21:pub fn render_equation_svg(layout: &LayoutBox, color: &str, base_font_size: f64) -> String
+src/renderer/equation/svg_render.rs:676:pub fn eq_color_to_svg(color: u32) -> String
+src/renderer/equation/symbols.rs:457:pub static DECORATIONS: LazyLock<HashMap<&'static str, DecoKind>> = LazyLock::new(||
+src/renderer/equation/symbols.rs:488:pub static FONT_STYLES: LazyLock<HashMap<&'static str, FontStyleKind>> = LazyLock::new(||
+src/renderer/equation/symbols.rs:509:pub fn is_structure_command(cmd: &str) -> bool
+src/renderer/equation/symbols.rs:567:pub fn is_big_operator(cmd: &str) -> bool
+src/renderer/equation/symbols.rs:572:pub fn is_function(cmd: &str) -> bool
+src/renderer/equation/symbols.rs:581:pub fn lookup_symbol(cmd: &str) -> Option<&'static str>
+src/renderer/equation/symbols.rs:612:pub fn lookup_function(cmd: &str) -> Option<&'static str>
+src/renderer/equation/symbols.rs:625:pub fn lookup_equation_pua(ch: char) -> Option<&'static str>
+src/renderer/equation/symbols.rs:631:pub enum DecoKind
+src/renderer/equation/symbols.rs:651:pub enum FontStyleKind
+src/renderer/equation/tokenizer.rs:27:pub struct Token
+src/renderer/equation/tokenizer.rs:326: pub fn next_token(&mut self) -> Token
+src/renderer/equation/tokenizer.rs:37: pub fn new(ty: TokenType, value: impl Into<String>, pos: usize) -> Self
+src/renderer/equation/tokenizer.rs:46: pub fn eof(pos: usize) -> Self
+src/renderer/equation/tokenizer.rs:485: pub fn tokenize(mut self) -> Vec<Token>
+src/renderer/equation/tokenizer.rs:57:pub struct Tokenizer
+src/renderer/equation/tokenizer.rs:586:pub fn tokenize(script: &str) -> Vec<Token>
+src/renderer/equation/tokenizer.rs:65: pub fn new(script: &str) -> Self
+src/renderer/equation/tokenizer.rs:7:pub enum TokenType
+src/renderer/font_metrics_data.rs:151:pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch>
+src/renderer/font_metrics_data.rs:18:pub struct FontMetric
+src/renderer/font_metrics_data.rs:28:pub struct LatinRange
+src/renderer/font_metrics_data.rs:35: pub fn get_width(&self, ch: char) -> Option<u16>
+src/renderer/font_metrics_data.rs:41068:pub static FONT_METRICS: [FontMetric
+src/renderer/font_metrics_data.rs:63:pub struct MetricMatch
+src/renderer/font_metrics_data.rs:7:pub struct HangulMetric
+src/renderer/height_measurer.rs:145:pub struct MeasuredParagraph
+src/renderer/height_measurer.rs:169: pub fn line_advance(&self, line_idx: usize) -> f64
+src/renderer/height_measurer.rs:174: pub fn line_advances_sum(&self, range: std::ops::Range<usize>) -> f64
+src/renderer/height_measurer.rs:184:pub struct MeasuredTable
+src/renderer/height_measurer.rs:20:pub fn is_tac_table_inline(
+src/renderer/height_measurer.rs:218:pub fn fit_measured_table_to_declared_height(
+src/renderer/height_measurer.rs:2196: pub fn measure_section_incremental(
+src/renderer/height_measurer.rs:2257: pub fn measure_section_selective(
+src/renderer/height_measurer.rs:2392: pub fn remaining_content_for_row(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs:2468: pub fn max_padding_for_row(&self, row: usize) -> f64
+src/renderer/height_measurer.rs:2477: pub fn effective_row_height(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs:2486: pub fn is_row_splittable(&self, row: usize) -> bool
+src/renderer/height_measurer.rs:2503: pub fn min_first_line_height_for_row(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs:2536: pub fn find_break_row(
+src/renderer/height_measurer.rs:2561: pub fn range_height(&self, start_row: usize, end_row: usize) -> f64
+src/renderer/height_measurer.rs:2576: pub fn row_block_for(&self, row: usize) -> (usize, usize, f64)
+src/renderer/height_measurer.rs:2593: pub fn snap_to_block_boundary(&self, end_row: usize) -> usize
+src/renderer/height_measurer.rs:2625: pub fn allows_row_break_split(&self) -> bool
+src/renderer/height_measurer.rs:2635:pub const BLOCK_UNIT_MAX_ROWS: usize = 3
+src/renderer/height_measurer.rs:2710: pub fn get_paragraph_height(&self, para_index: usize) -> Option<f64>
+src/renderer/height_measurer.rs:2715: pub fn get_table_height(&self, para_index: usize, control_index: usize) -> Option<f64>
+src/renderer/height_measurer.rs:2723: pub fn get_measured_table(
+src/renderer/height_measurer.rs:2734: pub fn get_measured_paragraph(&self, para_index: usize) -> Option<&MeasuredParagraph>
+src/renderer/height_measurer.rs:2739: pub fn paragraph_has_table(&self, para_index: usize) -> bool
+src/renderer/height_measurer.rs:273:pub struct MeasuredCell
+src/renderer/height_measurer.rs:2748: pub fn shift_for_insert(&mut self, insert_at: usize)
+src/renderer/height_measurer.rs:2778: pub fn shift_for_remove(&mut self, remove_at: usize)
+src/renderer/height_measurer.rs:2802: pub fn estimate_footnote_area_height(
+src/renderer/height_measurer.rs:2854: pub fn estimate_single_footnote_height(&self, footnote: &Footnote) -> f64
+src/renderer/height_measurer.rs:300:pub struct MeasuredSection
+src/renderer/height_measurer.rs:308:pub struct HeightMeasurer
+src/renderer/height_measurer.rs:315: pub fn new(dpi: f64) -> Self
+src/renderer/height_measurer.rs:323: pub fn with_hwp3_variant(mut self, enabled: bool) -> Self
+src/renderer/height_measurer.rs:329: pub fn with_hwp3_origin_flow_spacing_before(mut self, enabled: bool) -> Self
+src/renderer/height_measurer.rs:334: pub fn with_default_dpi() -> Self
+src/renderer/height_measurer.rs:442: pub fn measure_section(
+src/renderer/height_measurer.rs:58:pub fn is_tac_table_inline_in_para(table: &Table, seg_width: i32, para: &Paragraph) -> bool
+src/renderer/height_measurer.rs:846: pub fn cell_controls_height(
+src/renderer/html.rs:17:pub struct HtmlRenderer
+src/renderer/html.rs:31: pub fn new() -> Self
+src/renderer/html.rs:42: pub fn output(&self) -> &str
+src/renderer/html.rs:47: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/layer_renderer.rs:104: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs:115:pub enum VariantSelectedReason
+src/renderer/layer_renderer.rs:123: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs:134:pub enum VariantRejectReason
+src/renderer/layer_renderer.rs:171: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs:17:pub type LayerRenderResult<T> = Result<T, HwpError>
+src/renderer/layer_renderer.rs:20:pub trait LayerRenderer
+src/renderer/layer_renderer.rs:213:pub struct TextVariantSelectionOptions
+src/renderer/layer_renderer.rs:235: pub fn canvaskit() -> Self
+src/renderer/layer_renderer.rs:249: pub fn canvaskit_strict_outline() -> Self
+src/renderer/layer_renderer.rs:258:pub struct TextVariantSelectionReport
+src/renderer/layer_renderer.rs:25:pub struct RasterRenderOptions
+src/renderer/layer_renderer.rs:269:pub struct TextVariantRejectReport
+src/renderer/layer_renderer.rs:275:pub fn analyze_text_variant_selection(
+src/renderer/layer_renderer.rs:52:pub enum RasterColorSpace
+src/renderer/layer_renderer.rs:57:pub enum RasterOutputFormat
+src/renderer/layer_renderer.rs:62:pub struct RasterRenderOutput
+src/renderer/layer_renderer.rs:72:pub trait LayerRasterRenderer
+src/renderer/layer_renderer.rs:96:pub enum VariantSelectionBackend
+src/renderer/layout.rs:1007:pub struct LayoutOverflow
+src/renderer/layout.rs:1243:pub struct LayoutEngine
+src/renderer/layout.rs:1379:pub use paragraph_layout::map_pua_bullet_char
+src/renderer/layout.rs:1391: pub fn new(dpi: f64) -> Self
+src/renderer/layout.rs:1434: pub fn clear_layout_caches(&self)
+src/renderer/layout.rs:1440: pub fn with_default_dpi() -> Self
+src/renderer/layout.rs:1445: pub fn take_overflows(&self) -> Vec<LayoutOverflow>
+src/renderer/layout.rs:1613: pub fn set_hidden_empty_paras(&self, paras: &std::collections::HashSet<usize>)
+src/renderer/layout.rs:1618: pub fn set_pre_emitted_host_paras(&self, paras: &std::collections::HashSet<usize>)
+src/renderer/layout.rs:1623: pub fn set_pre_emitted_host_heights(&self, heights: &std::collections::HashMap<usize, f64>)
+src/renderer/layout.rs:1628: pub fn set_endnote_para_sources(&self, base: usize, sources: &[EndnoteParaSource])
+src/renderer/layout.rs:1657: pub fn set_endnote_between_notes_hu(&self, between_notes_hu: i32)
+src/renderer/layout.rs:1662: pub fn set_endnote_shape_margins_hu(
+src/renderer/layout.rs:1734: pub fn reset_numbering_state(&self)
+src/renderer/layout.rs:1738: pub fn set_hwp3_variant(&self, enabled: bool)
+src/renderer/layout.rs:1743: pub fn set_hwp3_origin_flow_spacing_before(&self, enabled: bool)
+src/renderer/layout.rs:1748: pub fn set_hwpx_source(&self, enabled: bool)
+src/renderer/layout.rs:1753: pub fn set_hwpx_page_preview(&self, data: Option<&[u8]>)
+src/renderer/layout.rs:1791: pub fn advance_numbering(&self, numbering_id: u16, level: u8)
+src/renderer/layout.rs:1798: pub fn set_clip_enabled(&self, enabled: bool)
+src/renderer/layout.rs:1803: pub fn set_show_transparent_borders(&self, enabled: bool)
+src/renderer/layout.rs:1808: pub fn set_hidden_header_footer(&self, hidden: &std::collections::HashSet<(u32, bool)>)
+src/renderer/layout.rs:1813: pub fn set_total_pages(&self, total: u32)
+src/renderer/layout.rs:1819: pub fn set_current_page_is_section_first(&self, is_first: bool)
+src/renderer/layout.rs:1824: pub fn set_file_name(&self, name: &str)
+src/renderer/layout.rs:1829: pub fn set_active_field(
+src/renderer/layout.rs:1837: pub fn set_show_control_codes(&self, enabled: bool)
+src/renderer/layout.rs:1842: pub fn reset_auto_counter(&self)
+src/renderer/layout.rs:1851: pub fn build_render_tree(
+src/renderer/layout.rs:513:pub struct CellPathEntry
+src/renderer/layout.rs:526:pub struct CellContext
+src/renderer/layout.rs:557: pub fn outermost_control(&self) -> usize
+src/renderer/layout.rs:561: pub fn outermost_cell(&self) -> usize
+src/renderer/layout.rs:565: pub fn outermost_cell_para(&self) -> usize
+src/renderer/layout.rs:569: pub fn innermost(&self) -> &CellPathEntry
+src/renderer/layout.rs:573: pub fn text_direction(&self) -> u8
+src/renderer/layout.rs:580: pub fn last_image_indices(&self) -> (Option<usize>, Option<usize>, Option<usize>)
+src/renderer/layout/paragraph_layout.rs:6581:pub fn map_pua_bullet_char(ch: char) -> char
+src/renderer/layout/text_measurement.rs:1045:pub struct WasmTextMeasurer
+src/renderer/layout/text_measurement.rs:15:pub trait TextMeasurer
+src/renderer/layout/text_measurement.rs:1925:pub fn split_into_clusters(text: &str) -> Vec<(usize, String)>
+src/renderer/layout/text_measurement.rs:2030: pub struct MockTextMeasurer
+src/renderer/layout/text_measurement.rs:203:pub fn extract_tab_leaders(text: &str, positions: &[f64], style: &TextStyle) -> Vec<TabLeaderInfo>
+src/renderer/layout/text_measurement.rs:209:pub fn extract_tab_leaders_with_extended(
+src/renderer/layout/text_measurement.rs:451:pub struct EmbeddedTextMeasurer
+src/renderer/layout/utils.rs:84:pub fn resolve_numbering_id(
+src/renderer/mod.rs:1062:pub struct AutoNumberCounter
+src/renderer/mod.rs:1079: pub fn new() -> Self
+src/renderer/mod.rs:1084: pub fn increment(&mut self, number_type: AutoNumberType) -> u16
+src/renderer/mod.rs:1114: pub fn current(&self, number_type: AutoNumberType) -> u16
+src/renderer/mod.rs:1126: pub fn reset(&mut self)
+src/renderer/mod.rs:1133:pub enum NumberFormat
+src/renderer/mod.rs:1157: pub fn from_hwp_format(format: u8) -> Self
+src/renderer/mod.rs:115:pub struct TextStyle
+src/renderer/mod.rs:1174:pub fn format_number(number: u16, format: NumberFormat) -> String
+src/renderer/mod.rs:11:pub mod canvas
+src/renderer/mod.rs:12:pub mod canvaskit_policy
+src/renderer/mod.rs:13:pub mod composer
+src/renderer/mod.rs:14:pub mod equation
+src/renderer/mod.rs:16:pub mod float_placement
+src/renderer/mod.rs:17:pub mod font_metrics_data
+src/renderer/mod.rs:19:pub mod height_cursor
+src/renderer/mod.rs:208: pub fn is_visually_bold(&self) -> bool
+src/renderer/mod.rs:20:pub mod height_measurer
+src/renderer/mod.rs:215: pub fn is_medium_weight(&self) -> bool
+src/renderer/mod.rs:21:pub mod html
+src/renderer/mod.rs:220: pub fn css_font_weight(&self) -> Option<&'static str>
+src/renderer/mod.rs:22:pub mod image_resolver
+src/renderer/mod.rs:23:pub mod layer_renderer
+src/renderer/mod.rs:24:pub mod layout
+src/renderer/mod.rs:25:pub mod page_layout
+src/renderer/mod.rs:26:pub mod page_number
+src/renderer/mod.rs:278:pub struct PatternFillInfo
+src/renderer/mod.rs:27:pub mod pagination
+src/renderer/mod.rs:289:pub struct ShapeStyle
+src/renderer/mod.rs:29:pub mod pdf
+src/renderer/mod.rs:308:pub struct ShadowStyle
+src/renderer/mod.rs:30:pub mod pua_oldhangul
+src/renderer/mod.rs:31:pub mod render_tree
+src/renderer/mod.rs:32:pub mod scheduler
+src/renderer/mod.rs:337:pub struct GradientFillInfo
+src/renderer/mod.rs:34:pub mod skia
+src/renderer/mod.rs:354:pub struct LineStyle
+src/renderer/mod.rs:36:pub mod style_resolver
+src/renderer/mod.rs:377:pub enum StrokeDash
+src/renderer/mod.rs:37:pub mod svg
+src/renderer/mod.rs:388:pub enum LineRenderType
+src/renderer/mod.rs:38:pub mod svg_fragment
+src/renderer/mod.rs:39:pub mod svg_layer
+src/renderer/mod.rs:403:pub enum ArrowStyle
+src/renderer/mod.rs:40:pub mod typeset
+src/renderer/mod.rs:426:pub enum PathCommand
+src/renderer/mod.rs:42:pub mod web_canvas
+src/renderer/mod.rs:440:pub fn svg_arc_to_beziers(
+src/renderer/mod.rs:48:pub enum RenderBackend
+src/renderer/mod.rs:559:pub trait Renderer
+src/renderer/mod.rs:580:pub const DEFAULT_DPI: f64 = 96.0
+src/renderer/mod.rs:581:pub const HWPUNIT_PER_INCH: f64 = 7200.0
+src/renderer/mod.rs:587:pub fn corrected_line_height(
+src/renderer/mod.rs:59: pub fn from_str(s: &str) -> Option<Self>
+src/renderer/mod.rs:610:pub fn corrected_line_metrics(
+src/renderer/mod.rs:71:pub struct TabStop
+src/renderer/mod.rs:787:pub fn corrected_line_metrics_for_source(
+src/renderer/mod.rs:825:pub fn corrected_line_height_for_variant_synthetic(
+src/renderer/mod.rs:82:pub struct TabLeaderInfo
+src/renderer/mod.rs:917:pub fn hwpunit_to_px(hwpunit: i32, dpi: f64) -> f64
+src/renderer/mod.rs:923:pub fn px_to_hwpunit(px: f64, dpi: f64) -> i32
+src/renderer/mod.rs:974:pub fn generic_fallback(font_family: &str) -> &'static str
+src/renderer/page_layout.rs:115: pub fn from_page_def_default(page_def: &PageDef, column_def: &ColumnDef) -> Self
+src/renderer/page_layout.rs:123: pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32)
+src/renderer/page_layout.rs:154: pub fn available_body_height(&self) -> f64
+src/renderer/page_layout.rs:159: pub fn column_width_hu(&self) -> i32
+src/renderer/page_layout.rs:169: pub fn update_footnote_area(&mut self, footnote_height: f64)
+src/renderer/page_layout.rs:37:pub struct LayoutRect
+src/renderer/page_layout.rs:45: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
+src/renderer/page_layout.rs:58: pub fn from_page_def(page_def: &PageDef, column_def: &ColumnDef, dpi: f64) -> Self
+src/renderer/page_layout.rs:63: pub fn from_page_def_for_page(
+src/renderer/page_layout.rs:9:pub struct PageLayoutInfo
+src/renderer/page_number.rs:29: pub fn new(new_page_numbers: &'a [(usize, u16)], initial: u32) -> Self
+src/renderer/page_number.rs:42: pub fn assign(&mut self, page: &PageContent) -> u32
+src/renderer/page_number.rs:59: pub fn next_counter(&self) -> u32
+src/renderer/page_number.rs:65: pub fn should_hide_page_number(&self) -> bool
+src/renderer/pagination.rs:101:pub struct PaginationResult
+src/renderer/pagination.rs:131:pub struct PageContent
+src/renderer/pagination.rs:160:pub struct MasterPageRef
+src/renderer/pagination.rs:169:pub struct HeaderFooterRef
+src/renderer/pagination.rs:180:pub enum FootnoteSource
+src/renderer/pagination.rs:205:pub struct FootnoteRef
+src/renderer/pagination.rs:214:pub struct ColumnContent
+src/renderer/pagination.rs:21:pub fn estimate_footnote_note_height(footnote: &Footnote, dpi: f64) -> f64
+src/renderer/pagination.rs:248:pub struct WrapAroundPara
+src/renderer/pagination.rs:263:pub struct WrapAnchorRef
+src/renderer/pagination.rs:279:pub enum PageItem
+src/renderer/pagination.rs:354:pub fn find_inline_control_target_page(
+src/renderer/pagination.rs:39:pub fn footnote_separator_overhead_px(shape: &FootnoteShape, dpi: f64) -> f64
+src/renderer/pagination.rs:410: pub fn para_index(&self) -> usize
+src/renderer/pagination.rs:422: pub fn with_offset(&self, offset: i32) -> Self
+src/renderer/pagination.rs:45:pub fn footnote_between_notes_margin_px(shape: &FootnoteShape, dpi: f64) -> f64
+src/renderer/pagination.rs:51:pub struct EndnoteRef
+src/renderer/pagination.rs:554: pub fn find_convergence(&self, old: &PaginationResult, offset: i32) -> Option<usize>
+src/renderer/pagination.rs:584: pub fn copy_converged_pages(
+src/renderer/pagination.rs:68:pub struct DeferredEndnote
+src/renderer/pagination.rs:719:pub struct PaginationOpts
+src/renderer/pagination.rs:734:pub struct Paginator
+src/renderer/pagination.rs:740: pub fn new(dpi: f64) -> Self
+src/renderer/pagination.rs:745: pub fn with_default_dpi() -> Self
+src/renderer/pagination.rs:74:pub enum EndnoteDeferral<'a>
+src/renderer/pagination.rs:777: pub fn paginate(
+src/renderer/pagination.rs:88:pub struct EndnoteParaSource
+src/renderer/pagination/engine.rs:158: pub fn paginate_with_measured(
+src/renderer/pagination/engine.rs:178: pub fn paginate_with_measured_opts(
+src/renderer/pagination/state.rs:108: pub fn flush_column_always(&mut self)
+src/renderer/pagination/state.rs:128: pub fn advance_column_or_new_page(&mut self)
+src/renderer/pagination/state.rs:172: pub fn reinsert_carry_with_height(&mut self, carry_height: f64)
+src/renderer/pagination/state.rs:180: pub fn force_new_page(&mut self)
+src/renderer/pagination/state.rs:186: pub fn ensure_page(&mut self)
+src/renderer/pagination/state.rs:193: pub fn available_height(&self) -> f64
+src/renderer/pagination/state.rs:204: pub fn base_available_height(&self) -> f64
+src/renderer/pagination/state.rs:209: pub fn add_footnote_height(&mut self, height: f64)
+src/renderer/pagination/state.rs:220: pub fn projected_footnote_height(&self, note_content_height: f64, note_count: usize) -> f64
+src/renderer/pagination/state.rs:50: pub fn new(
+src/renderer/pagination/state.rs:85: pub fn flush_column(&mut self)
+src/renderer/pdf.rs:10:pub enum PdfBackend
+src/renderer/pdf.rs:20: pub fn parse(value: &str) -> Option<Self>
+src/renderer/pdf.rs:28: pub fn as_str(self) -> &'static str
+src/renderer/pdf.rs:409:pub struct PdfExportOptions
+src/renderer/pdf.rs:40:pub struct DirectPdfExportOptions
+src/renderer/pdf.rs:678:pub fn svg_to_pdf(svg_content: &str) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs:684:pub fn svg_to_pdf_with_options(
+src/renderer/pdf.rs:693:pub fn svgs_to_pdf(svg_pages: &[String]) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs:699:pub fn svgs_to_pdf_with_options(
+src/renderer/pdf.rs:821:pub fn layer_trees_to_pdf(layer_trees: &[crate::paint::PageLayerTree]) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs:832:pub fn layer_trees_to_pdf_with_options(
+src/renderer/pua_oldhangul.rs:5719:pub fn map_pua_old_hangul(ch: char) -> Option<&'static [char]>
+src/renderer/pua_oldhangul.rs:5728:pub fn is_pua_old_hangul(ch: char) -> bool
+src/renderer/render_tree.rs:1016: pub fn new(
+src/renderer/render_tree.rs:1040:pub struct ImageNode
+src/renderer/render_tree.rs:107: pub fn new(id: NodeId, node_type: RenderNodeType, bbox: BoundingBox) -> Self
+src/renderer/render_tree.rs:1114:pub struct HeaderFooterImageRef
+src/renderer/render_tree.rs:1125:pub enum HeaderFooterKind
+src/renderer/render_tree.rs:1134: pub fn is_watermark(&self) -> bool
+src/renderer/render_tree.rs:1138: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
+src/renderer/render_tree.rs:1142: pub fn new(bin_data_id: u16, data: Option<Vec<u8>>) -> Self
+src/renderer/render_tree.rs:1171:pub struct GroupNode
+src/renderer/render_tree.rs:1182:pub struct NoteControlRef
+src/renderer/render_tree.rs:1199:pub struct EquationNode
+src/renderer/render_tree.rs:120: pub fn with_layer(mut self, layer: RenderLayerInfo) -> Self
+src/renderer/render_tree.rs:1229:pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>)
+src/renderer/render_tree.rs:1233:pub struct PageRenderTree
+src/renderer/render_tree.rs:1246: pub fn new(page_index: u32, width: f64, height: f64) -> Self
+src/renderer/render_tree.rs:126: pub fn set_layer(&mut self, layer: RenderLayerInfo)
+src/renderer/render_tree.rs:1284: pub fn set_inline_shape_position(
+src/renderer/render_tree.rs:1301: pub fn get_inline_shape_position(
+src/renderer/render_tree.rs:1316: pub fn inline_shape_positions(&self) -> &std::collections::HashMap<InlineShapeKey, (f64, f64)>
+src/renderer/render_tree.rs:131: pub fn invalidate(&mut self)
+src/renderer/render_tree.rs:1321: pub fn next_id(&mut self) -> NodeId
+src/renderer/render_tree.rs:1328: pub fn needs_render(&self) -> bool
+src/renderer/render_tree.rs:1333: pub fn mark_all_clean(&mut self)
+src/renderer/render_tree.rs:1354: pub fn clip_overlapping_same_bin_images(&mut self)
+src/renderer/render_tree.rs:136: pub fn mark_clean(&mut self)
+src/renderer/render_tree.rs:141: pub fn mark_clean_recursive(&mut self)
+src/renderer/render_tree.rs:149: pub fn has_dirty_nodes(&self) -> bool
+src/renderer/render_tree.rs:157: pub fn to_json(&self) -> String
+src/renderer/render_tree.rs:16:pub const REAL_PICTURE_WATERMARK_PAGE_OPACITY: f64 = 0.26
+src/renderer/render_tree.rs:17:pub const REAL_PICTURE_WATERMARK_FILL_OPACITY: f64 = 0.15
+src/renderer/render_tree.rs:18:pub const REAL_PICTURE_WATERMARK_OPACITY: f64 = REAL_PICTURE_WATERMARK_PAGE_OPACITY
+src/renderer/render_tree.rs:19:pub const REAL_PICTURE_WATERMARK_SATURATION: f64 = 0.91646104
+src/renderer/render_tree.rs:20:pub const REAL_PICTURE_WATERMARK_CONTRAST: f64 = 0.93125103
+src/renderer/render_tree.rs:21:pub const REAL_PICTURE_WATERMARK_BRIGHTNESS: f64 = 1.80
+src/renderer/render_tree.rs:22:pub const REAL_PICTURE_WATERMARK_CORRECTION_MATRIX: [[f64
+src/renderer/render_tree.rs:258:pub enum RenderNodeType
+src/renderer/render_tree.rs:27:pub const REAL_PICTURE_WATERMARK_CORRECTION_BIAS: [f64
+src/renderer/render_tree.rs:29:pub const REAL_PICTURE_WATERMARK_CHROMA_GAIN: f64 = 3.0
+src/renderer/render_tree.rs:30:pub const REAL_PICTURE_WATERMARK_WHITE_BLEND: f64 = 0.0
+src/renderer/render_tree.rs:314:pub struct ObjectControlRef
+src/renderer/render_tree.rs:31:pub const REAL_PICTURE_WATERMARK_FILL_CHROMA_GAIN: f64 = 0.42
+src/renderer/render_tree.rs:322: pub fn ole(section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs:32:pub const REAL_PICTURE_WATERMARK_FILL_WHITE_BLEND: f64 = 0.16
+src/renderer/render_tree.rs:332: pub fn picture(section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs:33:pub const LEGACY_IMAGE_WATERMARK_OPACITY: f64 = 0.17
+src/renderer/render_tree.rs:351:pub struct RawSvgNode
+src/renderer/render_tree.rs:359: pub fn new(svg: String) -> Self
+src/renderer/render_tree.rs:35:pub fn is_real_picture_watermark_tone_preset(
+src/renderer/render_tree.rs:366: pub fn ole(svg: String, section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs:387:pub struct PlaceholderNode
+src/renderer/render_tree.rs:409:pub enum PlaceholderKind
+src/renderer/render_tree.rs:418: pub fn new(fill_color: u32, stroke_color: u32, label: String) -> Self
+src/renderer/render_tree.rs:437: pub fn missing_picture(
+src/renderer/render_tree.rs:44:pub type NodeId = u32
+src/renderer/render_tree.rs:457: pub fn ole(
+src/renderer/render_tree.rs:489:pub struct FootnoteMarkerNode
+src/renderer/render_tree.rs:509:pub struct FormObjectNode
+src/renderer/render_tree.rs:539:pub struct BoundingBox
+src/renderer/render_tree.rs:54:pub struct RenderLayerInfo
+src/renderer/render_tree.rs:551: pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self
+src/renderer/render_tree.rs:561: pub fn intersects(&self, other: &BoundingBox) -> bool
+src/renderer/render_tree.rs:569: pub fn contains(&self, other: &BoundingBox) -> bool
+src/renderer/render_tree.rs:577: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
+src/renderer/render_tree.rs:590:pub struct PageNode
+src/renderer/render_tree.rs:603:pub struct PageBackgroundNode
+src/renderer/render_tree.rs:618:pub struct PageBackgroundImage
+src/renderer/render_tree.rs:638: pub fn is_watermark(&self) -> bool
+src/renderer/render_tree.rs:642: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
+src/renderer/render_tree.rs:649:pub struct TextLineNode
+src/renderer/render_tree.rs:666: pub fn new(line_height: f64, baseline: f64) -> Self
+src/renderer/render_tree.rs:678: pub fn with_para(
+src/renderer/render_tree.rs:695: pub fn with_para_vpos(
+src/renderer/render_tree.rs:70: pub fn new(text_wrap: Option<TextWrap>, z_order: i32, stable_index: u32) -> Self
+src/renderer/render_tree.rs:716:pub struct TextRunNode
+src/renderer/render_tree.rs:753:pub enum FieldMarkerType
+src/renderer/render_tree.rs:768:pub struct TableNode
+src/renderer/render_tree.rs:785:pub struct TableCellNode
+src/renderer/render_tree.rs:806:pub struct ShapeTransform
+src/renderer/render_tree.rs:80: pub fn for_master_page(mut self) -> Self
+src/renderer/render_tree.rs:817: pub fn has_transform(&self) -> bool
+src/renderer/render_tree.rs:829: pub fn effective_image_bbox(&self, bbox: &BoundingBox) -> BoundingBox
+src/renderer/render_tree.rs:845:pub struct LineNode
+src/renderer/render_tree.rs:874: pub fn new(x1: f64, y1: f64, x2: f64, y2: f64, style: LineStyle) -> Self
+src/renderer/render_tree.rs:88:pub struct RenderNode
+src/renderer/render_tree.rs:894:pub struct RectangleNode
+src/renderer/render_tree.rs:921: pub fn new(
+src/renderer/render_tree.rs:943:pub struct EllipseNode
+src/renderer/render_tree.rs:968: pub fn new(style: ShapeStyle, gradient: Option<Box<GradientFillInfo>>) -> Self
+src/renderer/render_tree.rs:985:pub struct PathNode
+src/renderer/scheduler.rs:106:pub trait RenderObserver
+src/renderer/scheduler.rs:11:pub enum RenderPriority
+src/renderer/scheduler.rs:121:pub trait RenderWorker
+src/renderer/scheduler.rs:134:pub enum RenderError
+src/renderer/scheduler.rs:147:pub struct RenderScheduler
+src/renderer/scheduler.rs:165: pub fn new(total_pages: u32) -> Self
+src/renderer/scheduler.rs:178: pub fn set_page_heights(&mut self, heights: &[f64])
+src/renderer/scheduler.rs:188: pub fn update_viewport(&mut self, viewport: Viewport)
+src/renderer/scheduler.rs:194: pub fn update_zoom(&mut self, zoom: f64)
+src/renderer/scheduler.rs:202: pub fn invalidate_page(&mut self, page_index: u32)
+src/renderer/scheduler.rs:216: pub fn visible_pages(&self) -> Vec<u32>
+src/renderer/scheduler.rs:22:pub enum TaskStatus
+src/renderer/scheduler.rs:245: pub fn next_task(&mut self) -> Option<&RenderTask>
+src/renderer/scheduler.rs:254: pub fn complete_task(&mut self, task_id: u32)
+src/renderer/scheduler.rs:261: pub fn cleanup_tasks(&mut self)
+src/renderer/scheduler.rs:267: pub fn pending_count(&self) -> usize
+src/renderer/scheduler.rs:35:pub struct RenderTask
+src/renderer/scheduler.rs:47: pub fn new(id: u32, page_index: u32, priority: RenderPriority) -> Self
+src/renderer/scheduler.rs:59:pub struct Viewport
+src/renderer/scheduler.rs:73: pub fn new(width: f64, height: f64) -> Self
+src/renderer/scheduler.rs:84: pub fn as_bbox(&self) -> BoundingBox
+src/renderer/scheduler.rs:91:pub enum RenderEvent
+src/renderer/skia/equation_conv.rs:17:pub fn render_equation(
+src/renderer/skia/image_conv.rs:16:pub struct ImageSampling
+src/renderer/skia/image_conv.rs:22: pub fn linear() -> Self
+src/renderer/skia/image_conv.rs:34:pub fn draw_svg_fragment(
+src/renderer/skia/image_conv.rs:67:pub fn draw_image_bytes(
+src/renderer/skia/mod.rs:11:pub use renderer::SkiaLayerRenderer
+src/renderer/skia/renderer.rs:110:pub fn native_skia_glyph_run_replay_proof(
+src/renderer/skia/renderer.rs:278:pub struct SkiaLayerRenderer
+src/renderer/skia/renderer.rs:291: pub fn new() -> Self
+src/renderer/skia/renderer.rs:313: pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self
+src/renderer/skia/renderer.rs:345: pub fn render_raster_with_options(
+src/renderer/skia/renderer.rs:34:pub enum NativeGlyphRunReplayProofReason
+src/renderer/skia/renderer.rs:62: pub fn as_str(self) -> &'static str
+src/renderer/skia/renderer.rs:93:pub struct NativeGlyphRunReplayProof
+src/renderer/style_resolver.rs:120: pub fn font_family_for_lang(&self, lang_index: usize) -> &str
+src/renderer/style_resolver.rs:131: pub fn letter_spacing_for_lang(&self, lang_index: usize) -> f64
+src/renderer/style_resolver.rs:140: pub fn ratio_for_lang(&self, lang_index: usize) -> f64
+src/renderer/style_resolver.rs:151:pub struct ResolvedParaStyle
+src/renderer/style_resolver.rs:16:pub const LANG_COUNT: usize = 7
+src/renderer/style_resolver.rs:20:pub struct ResolvedCharStyle
+src/renderer/style_resolver.rs:233:pub struct ResolvedBorderStyle
+src/renderer/style_resolver.rs:254:pub struct ResolvedImageFill
+src/renderer/style_resolver.rs:284:pub struct ResolvedStyleSet
+src/renderer/style_resolver.rs:301:pub fn resolve_styles(doc_info: &DocInfo, dpi: f64) -> ResolvedStyleSet
+src/renderer/style_resolver.rs:308:pub fn resolve_styles_with_variant(
+src/renderer/style_resolver.rs:402:pub fn detect_lang_category(ch: char) -> usize
+src/renderer/style_resolver.rs:470:pub fn primary_font_name(font_family: &str) -> &str
+src/renderer/svg.rs:157: pub fn new() -> Self
+src/renderer/svg.rs:184: pub fn output(&self) -> &str
+src/renderer/svg.rs:189: pub fn font_codepoints(
+src/renderer/svg.rs:196: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/svg.rs:3554:pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::PathBuf]) -> String
+src/renderer/svg.rs:52:pub enum FontEmbedMode
+src/renderer/svg.rs:65:pub struct SvgRenderer
+src/renderer/svg_layer.rs:13:pub struct SvgLayerRenderer
+src/renderer/svg_layer.rs:19: pub fn new() -> Self
+src/renderer/svg_layer.rs:26: pub fn output(&self) -> &str
+src/renderer/svg_layer.rs:30: pub fn inner_mut(&mut self) -> &mut SvgRenderer
+src/renderer/typeset.rs:2336: pub fn new(dpi: f64) -> Self
+src/renderer/typeset.rs:2344: pub fn with_default_dpi() -> Self
+src/renderer/typeset.rs:2494: pub fn typeset_section(
+src/renderer/typeset.rs:3022: pub fn typeset_section_with_variant(
+src/renderer/typeset.rs:361:pub struct TypesetEngine
+src/renderer/web_canvas.rs:275:pub enum LayerFilter
+src/renderer/web_canvas.rs:309:pub struct WebCanvasRenderer
+src/renderer/web_canvas.rs:336: pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsValue>
+src/renderer/web_canvas.rs:357: pub fn set_scale(&mut self, scale: f64)
+src/renderer/web_canvas.rs:362: pub fn set_layer_filter(&mut self, filter: LayerFilter)
+src/renderer/web_canvas.rs:412: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/web_canvas.rs:417: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
+src/serializer/body_text.rs:201:pub fn serialize_paragraph_list(
+src/serializer/body_text.rs:26:pub fn serialize_section(section: &Section) -> Vec<u8>
+src/serializer/body_text.rs:442:pub fn test_serialize_para_text(para: &Paragraph) -> Vec<u8>
+src/serializer/byte_writer.rs:10:pub struct ByteWriter
+src/serializer/byte_writer.rs:16: pub fn new() -> Self
+src/serializer/byte_writer.rs:21: pub fn position(&self) -> usize
+src/serializer/byte_writer.rs:26: pub fn write_u8(&mut self, v: u8) -> io::Result<()>
+src/serializer/byte_writer.rs:31: pub fn write_u16(&mut self, v: u16) -> io::Result<()>
+src/serializer/byte_writer.rs:36: pub fn write_u32(&mut self, v: u32) -> io::Result<()>
+src/serializer/byte_writer.rs:41: pub fn write_i8(&mut self, v: i8) -> io::Result<()>
+src/serializer/byte_writer.rs:46: pub fn write_i16(&mut self, v: i16) -> io::Result<()>
+src/serializer/byte_writer.rs:51: pub fn write_i32(&mut self, v: i32) -> io::Result<()>
+src/serializer/byte_writer.rs:56: pub fn write_f64(&mut self, v: f64) -> io::Result<()>
+src/serializer/byte_writer.rs:61: pub fn write_bytes(&mut self, data: &[u8]) -> io::Result<()>
+src/serializer/byte_writer.rs:70: pub fn write_hwp_string(&mut self, s: &str) -> io::Result<()>
+src/serializer/byte_writer.rs:80: pub fn write_color_ref(&mut self, color: u32) -> io::Result<()>
+src/serializer/byte_writer.rs:85: pub fn write_zeros(&mut self, count: usize) -> io::Result<()>
+src/serializer/byte_writer.rs:91: pub fn into_bytes(self) -> Vec<u8>
+src/serializer/byte_writer.rs:96: pub fn as_bytes(&self) -> &[u8]
+src/serializer/cfb_writer.rs:24:pub fn serialize_hwp(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/control.rs:31:pub fn serialize_control(
+src/serializer/doc_info.rs:135:pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8>
+src/serializer/doc_info.rs:155:pub fn serialize_id_mappings(doc_info: &DocInfo) -> Vec<u8>
+src/serializer/doc_info.rs:201:pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8>
+src/serializer/doc_info.rs:22:pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8>
+src/serializer/doc_info.rs:231:pub fn serialize_face_name(font: &Font) -> Vec<u8>
+src/serializer/doc_info.rs:308:pub fn serialize_border_fill(bf: &BorderFill) -> Vec<u8>
+src/serializer/doc_info.rs:407:pub fn serialize_char_shape(cs: &CharShape) -> Vec<u8>
+src/serializer/doc_info.rs:528:pub fn serialize_tab_def(td: &TabDef) -> Vec<u8>
+src/serializer/doc_info.rs:603:pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8>
+src/serializer/doc_info.rs:665:pub fn serialize_style(style: &Style) -> Vec<u8>
+src/serializer/doc_info.rs:781:pub fn surgical_insert_record(
+src/serializer/doc_info.rs:841:pub fn surgical_insert_font_all_langs(raw_stream: &mut Vec<u8>, data: &[u8]) -> Result<(), String>
+src/serializer/doc_info.rs:934:pub fn surgical_remove_records(raw_stream: &mut Vec<u8>, tag_id: u16) -> usize
+src/serializer/doc_info.rs:958:pub fn surgical_update_caret(
+src/serializer/header.rs:16:pub fn serialize_file_header(header: &FileHeader) -> Vec<u8>
+src/serializer/hml/error.rs:11:pub enum HmlExportError
+src/serializer/hml/error.rs:28: pub fn blockers(&self) -> &[HmlSaveBlocker]
+src/serializer/hml/error.rs:4:pub struct HmlSaveBlocker
+src/serializer/hml/mod.rs:12:pub use error::{HmlExportError, HmlSaveBlocker}
+src/serializer/hml/mod.rs:18:pub fn serialize_hml(
+src/serializer/hwpx/canonical_defaults.rs:103:pub const PAGE_BORDER_HEADER_INSIDE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:104:pub const PAGE_BORDER_FOOTER_INSIDE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:109:pub const BEGIN_NUM_PAGE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:110:pub const BEGIN_NUM_FOOTNOTE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:111:pub const BEGIN_NUM_ENDNOTE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:112:pub const BEGIN_NUM_PIC: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:113:pub const BEGIN_NUM_TBL: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:114:pub const BEGIN_NUM_EQUATION: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:119:pub const FONT_IS_EMBEDDED: bool = false
+src/serializer/hwpx/canonical_defaults.rs:120:pub const FONT_TYPE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:125:pub const LS_PERCENT: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:126:pub const LS_FIXED: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:127:pub const LS_BETWEEN_LINES: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:128:pub const LS_AT_LEAST: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:133:pub const AH_JUSTIFY: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:134:pub const AH_LEFT: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:135:pub const AH_RIGHT: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:136:pub const AH_CENTER: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:137:pub const AH_DISTRIBUTE: u32 = 4
+src/serializer/hwpx/canonical_defaults.rs:138:pub const AH_DISTRIBUTE_SPACE: u32 = 5
+src/serializer/hwpx/canonical_defaults.rs:143:pub const AV_BASELINE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:144:pub const AV_TOP: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:145:pub const AV_CENTER: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:146:pub const AV_BOTTOM: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:151:pub const FLT_HANGUL: usize = 0
+src/serializer/hwpx/canonical_defaults.rs:152:pub const FLT_LATIN: usize = 1
+src/serializer/hwpx/canonical_defaults.rs:153:pub const FLT_HANJA: usize = 2
+src/serializer/hwpx/canonical_defaults.rs:154:pub const FLT_JAPANESE: usize = 3
+src/serializer/hwpx/canonical_defaults.rs:155:pub const FLT_OTHER: usize = 4
+src/serializer/hwpx/canonical_defaults.rs:156:pub const FLT_SYMBOL: usize = 5
+src/serializer/hwpx/canonical_defaults.rs:157:pub const FLT_USER: usize = 6
+src/serializer/hwpx/canonical_defaults.rs:160:pub const FONTFACE_LANG_NAMES: [&str
+src/serializer/hwpx/canonical_defaults.rs:167:pub const VRT_PAPER: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:168:pub const VRT_PAGE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:169:pub const VRT_PARA: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:174:pub const HRT_PAPER: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:175:pub const HRT_PAGE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:176:pub const HRT_COLUMN: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:177:pub const HRT_PARA: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:17:pub const CHARSHAPE_HEIGHT: u32 = 1000
+src/serializer/hwpx/canonical_defaults.rs:182:pub const ASOTWT_SQUARE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:183:pub const ASOTWT_TOP_AND_BOTTOM: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:184:pub const ASOTWT_BEHIND_TEXT: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:185:pub const ASOTWT_IN_FRONT_OF_TEXT: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:18:pub const CHARSHAPE_TEXT_COLOR: u32 = 0x000000
+src/serializer/hwpx/canonical_defaults.rs:190:pub const TPBT_NONE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:191:pub const TPBT_TABLE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:192:pub const TPBT_CELL: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:197:pub const SMT_NONE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:198:pub const SMT_DOT_ABOVE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:199:pub const SMT_RING_ABOVE: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs:19:pub const CHARSHAPE_SHADE_COLOR: u32 = 0xFFFFFF
+src/serializer/hwpx/canonical_defaults.rs:200:pub const SMT_TILDE: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs:205:pub const ST_PARA: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:206:pub const ST_CHAR: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:20:pub const CHARSHAPE_USE_FONT_SPACE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:21:pub const CHARSHAPE_USE_KERNING: bool = false
+src/serializer/hwpx/canonical_defaults.rs:22:pub const CHARSHAPE_SYM_MARK: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:28:pub const PARASHAPE_SNAP_TO_GRID: bool = true
+src/serializer/hwpx/canonical_defaults.rs:29:pub const PARASHAPE_FONT_LINE_HEIGHT: bool = false
+src/serializer/hwpx/canonical_defaults.rs:30:pub const PARASHAPE_SUPPRESS_LINE_NUMBERS: bool = false
+src/serializer/hwpx/canonical_defaults.rs:31:pub const PARASHAPE_CHECKED: bool = false
+src/serializer/hwpx/canonical_defaults.rs:32:pub const PARASHAPE_CONDENSE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:33:pub const PARASHAPE_TAB_PR_ID_REF: u16 = 0
+src/serializer/hwpx/canonical_defaults.rs:38:pub const BORDERFILL_THREE_D: bool = false
+src/serializer/hwpx/canonical_defaults.rs:39:pub const BORDERFILL_SHADOW: bool = false
+src/serializer/hwpx/canonical_defaults.rs:40:pub const BORDERFILL_BREAK_CELL_SEPARATE_LINE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:41:pub const BORDERFILL_CENTER_LINE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:46:pub const BREAKSETTING_WIDOW_ORPHAN: bool = false
+src/serializer/hwpx/canonical_defaults.rs:47:pub const BREAKSETTING_KEEP_WITH_NEXT: bool = false
+src/serializer/hwpx/canonical_defaults.rs:48:pub const BREAKSETTING_KEEP_LINES: bool = false
+src/serializer/hwpx/canonical_defaults.rs:49:pub const BREAKSETTING_PAGE_BREAK_BEFORE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:50:pub const BREAKSETTING_BREAK_NON_LATIN_WORD: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:51:pub const BREAKSETTING_LINE_WRAP: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:56:pub const VISIBILITY_HIDE_FIRST_HEADER: bool = false
+src/serializer/hwpx/canonical_defaults.rs:57:pub const VISIBILITY_HIDE_FIRST_FOOTER: bool = false
+src/serializer/hwpx/canonical_defaults.rs:58:pub const VISIBILITY_HIDE_FIRST_MASTER_PAGE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:59:pub const VISIBILITY_HIDE_FIRST_PAGE_NUM: bool = false
+src/serializer/hwpx/canonical_defaults.rs:60:pub const VISIBILITY_HIDE_FIRST_EMPTY_LINE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:61:pub const VISIBILITY_SHOW_LINE_NUMBER: bool = false
+src/serializer/hwpx/canonical_defaults.rs:67:pub const CELLSPAN_COL_SPAN: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:68:pub const CELLSPAN_ROW_SPAN: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs:74:pub const RUN_CHAR_PR_ID_REF_UNSET: u32 = u32::MAX
+src/serializer/hwpx/canonical_defaults.rs:79:pub const TABLE_REPEAT_HEADER: bool = false
+src/serializer/hwpx/canonical_defaults.rs:80:pub const TABLE_NO_ADJUST: bool = false
+src/serializer/hwpx/canonical_defaults.rs:85:pub const PICTURE_REVERSE: bool = false
+src/serializer/hwpx/canonical_defaults.rs:90:pub const SZ_WIDTH_REL_TO: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:91:pub const SZ_HEIGHT_REL_TO: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs:92:pub const SZ_PROTECT: bool = false
+src/serializer/hwpx/canonical_defaults.rs:98:pub const NUMBERING_START: i32 = 1
+src/serializer/hwpx/content.rs:15:pub struct BinDataEntry
+src/serializer/hwpx/content.rs:37:pub fn write_content_hpf(
+src/serializer/hwpx/context.rs:116: pub fn collect_from_document(doc: &Document) -> Self
+src/serializer/hwpx/context.rs:224: pub fn bin_data_entries(&self) -> Vec<BinDataEntry>
+src/serializer/hwpx/context.rs:231: pub fn resolve_bin_id(&self, bin_data_id: u16) -> Option<&str>
+src/serializer/hwpx/context.rs:238: pub fn assert_all_refs_resolved(&self) -> Result<(), SerializeError>
+src/serializer/hwpx/context.rs:26:pub struct IdPool<T: Copy + Eq + std::hash::Hash>
+src/serializer/hwpx/context.rs:276: pub fn next_para_id(&mut self) -> u32
+src/serializer/hwpx/context.rs:289: pub fn effective_style_id(&self, raw: u8) -> u8
+src/serializer/hwpx/context.rs:32: pub fn new() -> Self
+src/serializer/hwpx/context.rs:40: pub fn register(&mut self, id: T)
+src/serializer/hwpx/context.rs:45: pub fn reference(&mut self, id: T)
+src/serializer/hwpx/context.rs:49: pub fn is_registered(&self, id: &T) -> bool
+src/serializer/hwpx/context.rs:54: pub fn unresolved(&self) -> Vec<T>
+src/serializer/hwpx/context.rs:61: pub fn registered_count(&self) -> usize
+src/serializer/hwpx/context.rs:68:pub struct BinDataEntry
+src/serializer/hwpx/context.rs:84:pub struct SerializeContext
+src/serializer/hwpx/field.rs:105:pub fn write_hyperlink_begin<W: Write>(
+src/serializer/hwpx/field.rs:132:pub fn write_footnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:140:pub fn write_footnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:145:pub fn write_endnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:153:pub fn write_endnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:25:pub fn write_bookmark<W: Write>(w: &mut Writer<W>, bm: &Bookmark) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:37:pub fn field_begin_open_tag(field: &Field) -> String
+src/serializer/hwpx/field.rs:60:pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:76:pub fn write_field_end<W: Write>(w: &mut Writer<W>, field_id: u32) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs:83:pub fn write_field_end_full<W: Write>(
+src/serializer/hwpx/fixtures.rs:12:pub const EMPTY_HEADER_XML: &str = include_str!("templates/empty_header.xml")
+src/serializer/hwpx/fixtures.rs:13:pub const EMPTY_SECTION0_XML: &str = include_str!("templates/empty_section0.xml")
+src/serializer/hwpx/fixtures.rs:14:pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
+src/serializer/hwpx/form.rs:81:pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), SerializeError>
+src/serializer/hwpx/header.rs:32:pub fn write_header(doc: &Document, ctx: &SerializeContext) -> Result<Vec<u8>, SerializeError>
+src/serializer/hwpx/master_page.rs:54:pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeContext) -> String
+src/serializer/hwpx/master_page.rs:91:pub fn render_master_page_refs(ids: &[String]) -> String
+src/serializer/hwpx/mod.rs:11:pub mod canonical_defaults
+src/serializer/hwpx/mod.rs:12:pub mod content
+src/serializer/hwpx/mod.rs:13:pub mod context
+src/serializer/hwpx/mod.rs:14:pub mod field
+src/serializer/hwpx/mod.rs:15:pub mod fixtures
+src/serializer/hwpx/mod.rs:16:pub mod form
+src/serializer/hwpx/mod.rs:17:pub mod header
+src/serializer/hwpx/mod.rs:18:pub mod master_page
+src/serializer/hwpx/mod.rs:19:pub mod package_check
+src/serializer/hwpx/mod.rs:20:pub mod picture
+src/serializer/hwpx/mod.rs:21:pub mod roundtrip
+src/serializer/hwpx/mod.rs:22:pub mod section
+src/serializer/hwpx/mod.rs:23:pub mod shape
+src/serializer/hwpx/mod.rs:24:pub mod static_assets
+src/serializer/hwpx/mod.rs:25:pub mod table
+src/serializer/hwpx/mod.rs:26:pub mod utils
+src/serializer/hwpx/mod.rs:27:pub mod writer
+src/serializer/hwpx/mod.rs:44:pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/hwpx/package_check.rs:41:pub struct PackageCheckReport
+src/serializer/hwpx/package_check.rs:46: pub fn is_ok(&self) -> bool
+src/serializer/hwpx/package_check.rs:50: pub fn summary(&self) -> String
+src/serializer/hwpx/package_check.rs:62:pub fn check_package(hwpx_bytes: &[u8], doc: &Document) -> PackageCheckReport
+src/serializer/hwpx/picture.rs:47:pub fn write_picture<W: Write>(
+src/serializer/hwpx/roundtrip.rs:492:pub fn roundtrip_ir_diff(hwpx_bytes: &[u8]) -> Result<IrDiff, SerializeError>
+src/serializer/hwpx/roundtrip.rs:505:pub fn diff_documents(a: &Document, b: &Document) -> IrDiff
+src/serializer/hwpx/roundtrip.rs:56:pub struct IrDiff
+src/serializer/hwpx/roundtrip.rs:61: pub fn is_empty(&self) -> bool
+src/serializer/hwpx/roundtrip.rs:65: pub fn push(&mut self, d: IrDifference)
+src/serializer/hwpx/roundtrip.rs:70: pub fn allowed(&self, _allow: IrDiffAllow) -> bool
+src/serializer/hwpx/roundtrip.rs:765:pub struct LinesegDiff
+src/serializer/hwpx/roundtrip.rs:774:pub enum LinesegDiffKind
+src/serializer/hwpx/roundtrip.rs:77:pub struct IrDiffAllow
+src/serializer/hwpx/roundtrip.rs:813:pub fn diff_linesegs(a: &Document, b: &Document) -> Vec<LinesegDiff>
+src/serializer/hwpx/roundtrip.rs:83:pub enum IrDifference
+src/serializer/hwpx/section.rs:189:pub fn write_section(
+src/serializer/hwpx/shape.rs:144:pub fn write_line<W: Write>(
+src/serializer/hwpx/shape.rs:275:pub fn write_container_open<W: Write>(
+src/serializer/hwpx/shape.rs:315:pub fn write_container_close<W: Write>(
+src/serializer/hwpx/shape.rs:40:pub fn write_rect<W: Write>(
+src/serializer/hwpx/shape.rs:413:pub fn write_draw_text<W: Write>(
+src/serializer/hwpx/static_assets.rs:10:pub const META_INF_CONTAINER_XML: &str = concat!(
+src/serializer/hwpx/static_assets.rs:23:pub const META_INF_CONTAINER_RDF: &str = concat!(
+src/serializer/hwpx/static_assets.rs:45:pub const META_INF_MANIFEST_XML: &str = concat!(
+src/serializer/hwpx/static_assets.rs:51:pub const SETTINGS_XML: &str = include_str!("templates/settings.xml")
+src/serializer/hwpx/static_assets.rs:54:pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
+src/serializer/hwpx/static_assets.rs:57:pub const PRV_TEXT: &[u8] = b"\r\n"
+src/serializer/hwpx/static_assets.rs:60:pub const PRV_IMAGE_PNG: &[u8] = &[
+src/serializer/hwpx/static_assets.rs:7:pub const VERSION_XML: &str = include_str!("templates/version.xml")
+src/serializer/hwpx/table.rs:42:pub fn write_table<W: Write>(
+src/serializer/hwpx/utils.rs:11:pub fn write_xml_decl<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs:22:pub fn start_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs:29:pub fn start_tag_attrs<W: Write>(
+src/serializer/hwpx/utils.rs:44:pub fn end_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs:51:pub fn empty_tag<W: Write>(
+src/serializer/hwpx/utils.rs:66:pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs:73:pub fn xml_escape(s: &str) -> String
+src/serializer/hwpx/writer.rs:18:pub struct HwpxZipWriter
+src/serializer/hwpx/writer.rs:24: pub fn new() -> Self
+src/serializer/hwpx/writer.rs:36: pub fn write_stored(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
+src/serializer/hwpx/writer.rs:50: pub fn write_deflated(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
+src/serializer/hwpx/writer.rs:64: pub fn finish(mut self) -> Result<Vec<u8>, SerializeError>
+src/serializer/mini_cfb.rs:71:pub fn build_cfb(named_streams: &[(&str, &[u8])]) -> Result<Vec<u8>, String>
+src/serializer/mod.rs:10:pub mod doc_info
+src/serializer/mod.rs:11:pub mod header
+src/serializer/mod.rs:12:pub mod hml
+src/serializer/mod.rs:13:pub mod hwpx
+src/serializer/mod.rs:14:pub mod mini_cfb
+src/serializer/mod.rs:15:pub mod record_writer
+src/serializer/mod.rs:17:pub use cfb_writer::serialize_hwp
+src/serializer/mod.rs:18:pub use hml::serialize_hml
+src/serializer/mod.rs:19:pub use hwpx::serialize_hwpx
+src/serializer/mod.rs:23:pub enum SerializeError
+src/serializer/mod.rs:57:pub trait DocumentSerializer
+src/serializer/mod.rs:62:pub struct HwpSerializer
+src/serializer/mod.rs:6:pub mod body_text
+src/serializer/mod.rs:71:pub struct HwpxSerializer
+src/serializer/mod.rs:7:pub mod byte_writer
+src/serializer/mod.rs:80:pub fn serialize_document(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/mod.rs:8:pub mod cfb_writer
+src/serializer/mod.rs:9:pub mod control
+src/serializer/record_writer.rs:16:pub fn write_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8>
+src/serializer/record_writer.rs:36:pub fn write_record_from(record: &Record) -> Vec<u8>
+src/serializer/record_writer.rs:41:pub fn write_records(records: &[Record]) -> Vec<u8>
+src/wasm_api.rs:1006: pub fn insert_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:1024: pub fn delete_text_in_cell(
+src/wasm_api.rs:1051: pub fn delete_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:1069: pub fn split_paragraph_in_cell(
+src/wasm_api.rs:1093: pub fn merge_paragraph_in_cell(
+src/wasm_api.rs:1114: pub fn insert_text_in_cell_by_path_api(
+src/wasm_api.rs:1134: pub fn delete_text_in_cell_by_path_api(
+src/wasm_api.rs:1154: pub fn split_paragraph_in_cell_by_path_api(
+src/wasm_api.rs:1172: pub fn merge_paragraph_in_cell_by_path_api(
+src/wasm_api.rs:1184: pub fn get_text_in_cell_by_path_api(
+src/wasm_api.rs:1209: pub fn get_header_footer(
+src/wasm_api.rs:1223: pub fn create_header_footer(
+src/wasm_api.rs:1237: pub fn insert_text_in_header_footer(
+src/wasm_api.rs:1261: pub fn delete_text_in_header_footer(
+src/wasm_api.rs:1285: pub fn split_paragraph_in_header_footer(
+src/wasm_api.rs:1307: pub fn merge_paragraph_in_header_footer(
+src/wasm_api.rs:1327: pub fn get_header_footer_para_info(
+src/wasm_api.rs:1347: pub fn insert_table_row(
+src/wasm_api.rs:1369: pub fn insert_table_column(
+src/wasm_api.rs:1391: pub fn delete_table_row(
+src/wasm_api.rs:1411: pub fn delete_table_column(
+src/wasm_api.rs:1431: pub fn merge_table_cells(
+src/wasm_api.rs:1458: pub fn merge_table_cells_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:1476: pub fn split_table_cell(
+src/wasm_api.rs:1498: pub fn split_table_cell_into(
+src/wasm_api.rs:1529: pub fn split_table_cell_into_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:1549: pub fn split_table_cells_in_range(
+src/wasm_api.rs:1582: pub fn split_table_cells_in_range_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:1603: pub fn copy_table_cells_transposed(
+src/wasm_api.rs:1629: pub fn paste_table_cells_transposed(
+src/wasm_api.rs:1651: pub fn transpose_table_cells_in_place(
+src/wasm_api.rs:1669: pub fn paste_table_cells_transposed_as_table(
+src/wasm_api.rs:1685: pub fn has_table_transpose_clipboard(&self) -> bool
+src/wasm_api.rs:1694: pub fn split_paragraph(
+src/wasm_api.rs:1710: pub fn insert_page_break(
+src/wasm_api.rs:1726: pub fn insert_column_break(
+src/wasm_api.rs:1742: pub fn insert_new_number(
+src/wasm_api.rs:1765: pub fn set_column_def(
+src/wasm_api.rs:177:pub struct HwpDocument
+src/wasm_api.rs:1788: pub fn merge_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:1794: pub fn delete_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:1800: pub fn insert_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:1809: pub fn get_section_count(&self) -> u32
+src/wasm_api.rs:1815: pub fn get_paragraph_count(&self, section_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs:1823: pub fn get_paragraph_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs:1832: pub fn get_textbox_control_index(&self, section_idx: u32, para_idx: u32) -> i32
+src/wasm_api.rs:1839: pub fn find_next_editable_control(
+src/wasm_api.rs:1856: pub fn find_nearest_control_backward(
+src/wasm_api.rs:1871: pub fn find_nearest_control_forward(
+src/wasm_api.rs:1886: pub fn get_control_text_positions(&self, section_idx: u32, para_idx: u32) -> String
+src/wasm_api.rs:1907: pub fn navigate_next_editable_wasm(
+src/wasm_api.rs:1953: pub fn get_text_range(
+src/wasm_api.rs:1971: pub fn get_cell_paragraph_count(
+src/wasm_api.rs:198: pub fn from_bytes(data: &[u8]) -> Result<HwpDocument, HwpError>
+src/wasm_api.rs:1990: pub fn get_cell_paragraph_length(
+src/wasm_api.rs:2011: pub fn get_cell_paragraph_count_by_path(
+src/wasm_api.rs:202: pub fn find_initial_column_def(paragraphs: &[Paragraph]) -> ColumnDef
+src/wasm_api.rs:2030: pub fn get_cell_paragraph_length_by_path(
+src/wasm_api.rs:2045: pub fn get_cell_text_direction(
+src/wasm_api.rs:206: pub fn find_column_def_for_paragraph(paragraphs: &[Paragraph], para_idx: usize) -> ColumnDef
+src/wasm_api.rs:2074: pub fn get_text_in_cell(
+src/wasm_api.rs:2101: pub fn get_text_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:2123: pub fn get_cursor_rect(
+src/wasm_api.rs:2143: pub fn get_cursor_rect_on_line(
+src/wasm_api.rs:2178: pub fn hit_test(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs:2187: pub fn get_cursor_rect_in_header_footer(
+src/wasm_api.rs:2211: pub fn hit_test_header_footer(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs:2221: pub fn hit_test_in_header_footer(
+src/wasm_api.rs:2234: pub fn get_para_properties_in_hf(
+src/wasm_api.rs:2247: pub fn apply_para_format_in_hf(
+src/wasm_api.rs:2267: pub fn insert_field_in_hf(
+src/wasm_api.rs:2289: pub fn apply_hf_template(
+src/wasm_api.rs:2302: pub fn delete_header_footer(
+src/wasm_api.rs:2314: pub fn get_header_footer_list(
+src/wasm_api.rs:2333: pub fn navigate_header_footer_by_page(
+src/wasm_api.rs:2347: pub fn toggle_hide_header_footer(
+src/wasm_api.rs:2360: pub fn get_cursor_rect_in_cell(
+src/wasm_api.rs:2386: pub fn get_line_info(
+src/wasm_api.rs:2404: pub fn get_line_info_in_cell(
+src/wasm_api.rs:2428: pub fn get_caret_position(&self) -> Result<String, JsValue>
+src/wasm_api.rs:2436: pub fn get_table_dimensions(
+src/wasm_api.rs:2454: pub fn get_cell_info(
+src/wasm_api.rs:2474: pub fn get_cell_properties(
+src/wasm_api.rs:2494: pub fn get_cell_own_properties(
+src/wasm_api.rs:2514: pub fn set_cell_properties(
+src/wasm_api.rs:2536: pub fn set_cell_zone_properties(
+src/wasm_api.rs:2565: pub fn resize_table_cells(
+src/wasm_api.rs:2586: pub fn move_table_offset(
+src/wasm_api.rs:2608: pub fn get_table_properties(
+src/wasm_api.rs:2626: pub fn set_table_properties(
+src/wasm_api.rs:2646: pub fn get_table_cell_bboxes(
+src/wasm_api.rs:2666: pub fn get_table_bbox(
+src/wasm_api.rs:2685: pub fn get_shape_bbox(
+src/wasm_api.rs:2703: pub fn delete_table_control(
+src/wasm_api.rs:2721: pub fn create_table(
+src/wasm_api.rs:2744: pub fn create_table_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:2812: pub fn insert_picture(
+src/wasm_api.rs:2865: pub fn insert_picture_ex(
+src/wasm_api.rs:2920: pub fn assign_picture_image(
+src/wasm_api.rs:2954: pub fn get_external_image_references(&self) -> String
+src/wasm_api.rs:2967: pub fn get_external_image_basenames(&self) -> String
+src/wasm_api.rs:2991: pub fn inject_external_image(
+src/wasm_api.rs:3050: pub fn inject_external_image_by_key(
+src/wasm_api.rs:3072: pub fn get_picture_properties(
+src/wasm_api.rs:3090: pub fn get_header_footer_picture_properties(
+src/wasm_api.rs:3112: pub fn set_picture_properties(
+src/wasm_api.rs:3130: pub fn set_header_footer_picture_properties(
+src/wasm_api.rs:3154: pub fn delete_picture_control(
+src/wasm_api.rs:3170: pub fn delete_cell_picture_control_by_path(
+src/wasm_api.rs:3188: pub fn get_cell_shape_properties_by_path(
+src/wasm_api.rs:3206: pub fn get_cell_picture_properties_by_path(
+src/wasm_api.rs:3224: pub fn set_cell_shape_properties_by_path(
+src/wasm_api.rs:3244: pub fn set_cell_picture_properties_by_path(
+src/wasm_api.rs:3268: pub fn delete_equation_control(
+src/wasm_api.rs:3286: pub fn get_equation_properties(
+src/wasm_api.rs:3318: pub fn set_equation_properties(
+src/wasm_api.rs:3350: pub fn get_note_equation_properties(
+src/wasm_api.rs:3372: pub fn set_note_equation_properties(
+src/wasm_api.rs:3399: pub fn set_note_equation_properties_ex(
+src/wasm_api.rs:3421: pub fn render_equation_preview(
+src/wasm_api.rs:343: pub fn new(data: &[u8]) -> Result<HwpDocument, JsValue>
+src/wasm_api.rs:3463: pub fn create_shape_control(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:3529: pub fn get_shape_properties(
+src/wasm_api.rs:3547: pub fn set_shape_properties(
+src/wasm_api.rs:355: pub fn create_empty() -> HwpDocument
+src/wasm_api.rs:3567: pub fn delete_shape_control(
+src/wasm_api.rs:3584: pub fn change_shape_z_order(
+src/wasm_api.rs:3604: pub fn group_shapes(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:3640: pub fn ungroup_shape(
+src/wasm_api.rs:3656: pub fn move_line_endpoint(
+src/wasm_api.rs:3674: pub fn move_line_endpoint_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:3690: pub fn update_connectors_in_section_wasm(&mut self, section_idx: u32)
+src/wasm_api.rs:3696: pub fn insert_footnote(
+src/wasm_api.rs:3712: pub fn insert_endnote(
+src/wasm_api.rs:3728: pub fn get_endnote_shape(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:372: pub fn create_blank_document(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs:3735: pub fn apply_endnote_shape(
+src/wasm_api.rs:3746: pub fn insert_equation(
+src/wasm_api.rs:3768: pub fn get_footnote_info(
+src/wasm_api.rs:3786: pub fn get_footnote_at_cursor(
+src/wasm_api.rs:378: pub fn set_show_paragraph_marks(&mut self, enabled: bool)
+src/wasm_api.rs:3804: pub fn delete_footnote(
+src/wasm_api.rs:3820: pub fn insert_text_in_footnote(
+src/wasm_api.rs:3842: pub fn delete_text_in_footnote(
+src/wasm_api.rs:385: pub fn get_show_paragraph_marks(&self) -> bool
+src/wasm_api.rs:3864: pub fn split_paragraph_in_footnote(
+src/wasm_api.rs:3884: pub fn merge_paragraph_in_footnote(
+src/wasm_api.rs:3902: pub fn hit_test_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs:3909: pub fn hit_test_in_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs:3916: pub fn get_page_footnote_info(
+src/wasm_api.rs:391: pub fn get_show_control_codes(&self) -> bool
+src/wasm_api.rs:3927: pub fn get_cursor_rect_in_footnote(
+src/wasm_api.rs:3945: pub fn get_note_edit_info(
+src/wasm_api.rs:3961: pub fn get_cursor_rect_in_note(
+src/wasm_api.rs:397: pub fn set_show_control_codes(&mut self, enabled: bool)
+src/wasm_api.rs:3981: pub fn get_para_properties_in_footnote(
+src/wasm_api.rs:3999: pub fn apply_para_format_in_footnote(
+src/wasm_api.rs:4019: pub fn hit_test_body_footnote_marker(
+src/wasm_api.rs:4037: pub fn move_vertical(
+src/wasm_api.rs:404: pub fn get_show_transparent_borders(&self) -> bool
+src/wasm_api.rs:4076: pub fn move_vertical_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:4107: pub fn get_field_list(&self) -> String
+src/wasm_api.rs:410: pub fn set_show_transparent_borders(&mut self, enabled: bool)
+src/wasm_api.rs:4115: pub fn get_field_value(&self, field_id: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4123: pub fn get_field_value_by_name_api(&self, name: &str) -> Result<String, JsValue>
+src/wasm_api.rs:4131: pub fn set_field_value(&mut self, field_id: u32, value: &str) -> Result<String, JsValue>
+src/wasm_api.rs:4140: pub fn set_field_value_by_name_api(
+src/wasm_api.rs:4151: pub fn insert_click_here_field_api(
+src/wasm_api.rs:416: pub fn set_clip_enabled(&mut self, enabled: bool)
+src/wasm_api.rs:4178: pub fn insert_click_here_field_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:4194: pub fn insert_click_here_field_in_cell_api(
+src/wasm_api.rs:4229: pub fn insert_click_here_field_in_cell_ex(
+src/wasm_api.rs:422: pub fn set_debug_overlay(&mut self, enabled: bool)
+src/wasm_api.rs:4252: pub fn insert_click_here_field_by_path_api(
+src/wasm_api.rs:4282: pub fn insert_click_here_field_by_path_ex(
+src/wasm_api.rs:428: pub fn set_respect_vpos_reset(&mut self, enabled: bool)
+src/wasm_api.rs:4310: pub fn get_form_object_at(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs:4320: pub fn get_form_value(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4331: pub fn set_form_value(
+src/wasm_api.rs:4353: pub fn set_form_value_in_cell(
+src/wasm_api.rs:4381: pub fn set_form_value_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:4401: pub fn get_form_object_info(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4411: pub fn search_text(
+src/wasm_api.rs:442: pub fn page_count(&self) -> u32
+src/wasm_api.rs:4434: pub fn search_all_text(
+src/wasm_api.rs:4447: pub fn replace_text(
+src/wasm_api.rs:4468: pub fn replace_one(
+src/wasm_api.rs:4481: pub fn replace_all(
+src/wasm_api.rs:448: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4494: pub fn get_position_of_page(&self, global_page: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4502: pub fn get_page_of_position(&self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4512: pub fn get_field_info_at_api(
+src/wasm_api.rs:4527: pub fn get_field_info_at_in_cell_api(
+src/wasm_api.rs:454: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:4553: pub fn get_field_info_at_in_cell_ex(&self, options_json: &str) -> String
+src/wasm_api.rs:4568: pub fn remove_field_at_api(
+src/wasm_api.rs:4589: pub fn remove_field_at_in_cell_api(
+src/wasm_api.rs:460: pub fn render_page_canvas(&self, page_num: u32) -> Result<u32, JsValue>
+src/wasm_api.rs:4621: pub fn remove_field_at_in_cell_ex(&mut self, options_json: &str) -> String
+src/wasm_api.rs:4642: pub fn set_active_field_api(
+src/wasm_api.rs:4658: pub fn set_active_field_in_cell_api(
+src/wasm_api.rs:466: pub fn render_page_canvas_legacy(&self, page_num: u32) -> Result<u32, JsValue>
+src/wasm_api.rs:4684: pub fn set_active_field_in_cell_ex(&mut self, options_json: &str) -> bool
+src/wasm_api.rs:4699: pub fn get_field_info_at_by_path_api(
+src/wasm_api.rs:4719: pub fn set_active_field_by_path_api(
+src/wasm_api.rs:4739: pub fn clear_active_field_api(&mut self)
+src/wasm_api.rs:4749: pub fn get_click_here_props(&self, field_id: u32) -> String
+src/wasm_api.rs:477: pub fn render_page_to_canvas(
+src/wasm_api.rs:4812: pub fn update_click_here_props(
+src/wasm_api.rs:4946: pub fn get_cursor_rect_by_path(
+src/wasm_api.rs:4966: pub fn get_cursor_rect_by_path_near(
+src/wasm_api.rs:4988: pub fn get_cell_info_by_path(
+src/wasm_api.rs:5002: pub fn get_table_dimensions_by_path(
+src/wasm_api.rs:5020: pub fn get_table_cell_bboxes_by_path(
+src/wasm_api.rs:5038: pub fn move_vertical_by_path(
+src/wasm_api.rs:5064: pub fn get_selection_rects(
+src/wasm_api.rs:5087: pub fn get_selection_rects_in_cell(
+src/wasm_api.rs:5118: pub fn get_selection_rects_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:5137: pub fn get_selection_rects_in_footnote(
+src/wasm_api.rs:5161: pub fn delete_range(
+src/wasm_api.rs:5184: pub fn delete_range_in_cell(
+src/wasm_api.rs:519: pub fn render_page_to_canvas_filtered(
+src/wasm_api.rs:5215: pub fn delete_range_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:5245: pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs:5251: pub fn export_hwpx(&self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs:5257: pub fn export_hml(&self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs:5277: pub fn export_hwp_verify(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs:5287: pub fn get_source_format(&self) -> String
+src/wasm_api.rs:5294: pub fn get_hml_open_metadata(&self) -> String
+src/wasm_api.rs:5323: pub fn get_hml_save_state(&self) -> String
+src/wasm_api.rs:533: pub fn render_page_to_canvas_filtered_with_profile(
+src/wasm_api.rs:5356: pub fn get_validation_warnings(&self) -> String
+src/wasm_api.rs:5411: pub fn reflow_linesegs(&mut self) -> usize
+src/wasm_api.rs:5419: pub fn convert_to_editable(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs:5425: pub fn begin_batch(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs:5431: pub fn end_batch(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs:5437: pub fn get_event_log(&self) -> String
+src/wasm_api.rs:5445: pub fn save_snapshot(&mut self) -> u32
+src/wasm_api.rs:5451: pub fn restore_snapshot(&mut self, id: u32) -> Result<String, JsValue>
+src/wasm_api.rs:5457: pub fn discard_snapshot(&mut self, id: u32)
+src/wasm_api.rs:5465: pub fn get_char_properties_at(
+src/wasm_api.rs:5477: pub fn get_cell_char_properties_at(
+src/wasm_api.rs:5501: pub fn get_para_properties_at(
+src/wasm_api.rs:5512: pub fn get_cell_para_properties_at(
+src/wasm_api.rs:5534: pub fn get_style_list(&self) -> String
+src/wasm_api.rs:5556: pub fn get_style_detail(&self, style_id: u32) -> String
+src/wasm_api.rs:5619: pub fn update_style(&mut self, style_id: u32, json: &str) -> bool
+src/wasm_api.rs:5645: pub fn update_style_shapes(
+src/wasm_api.rs:5791: pub fn create_style(&mut self, json: &str) -> i32
+src/wasm_api.rs:5844: pub fn delete_style(&mut self, style_id: u32) -> bool
+src/wasm_api.rs:585: pub fn render_page_to_canvas_legacy(
+src/wasm_api.rs:5892: pub fn get_numbering_list(&self) -> String
+src/wasm_api.rs:5916: pub fn get_bullet_list(&self) -> String
+src/wasm_api.rs:5936: pub fn ensure_default_numbering(&mut self) -> u16
+src/wasm_api.rs:5993: pub fn create_numbering(&mut self, json: &str) -> u16
+src/wasm_api.rs:6053: pub fn ensure_default_bullet(&mut self, bullet_char_str: &str) -> u16
+src/wasm_api.rs:6078: pub fn get_style_at(&self, sec_idx: u32, para_idx: u32) -> String
+src/wasm_api.rs:6106: pub fn get_cell_style_at(
+src/wasm_api.rs:6142: pub fn apply_style(
+src/wasm_api.rs:614: pub fn get_page_render_tree(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6155: pub fn apply_cell_style(
+src/wasm_api.rs:6181: pub fn evaluate_table_formula(
+src/wasm_api.rs:6209: pub fn evaluate_table_formula_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6229: pub fn find_or_create_font_id(&mut self, name: &str) -> i32
+src/wasm_api.rs:6235: pub fn wasm_find_or_create_font_id_for_lang(&mut self, lang: u32, name: &str) -> i32
+src/wasm_api.rs:623: pub fn get_page_layer_tree(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6242: pub fn apply_char_format(
+src/wasm_api.rs:6256: pub fn set_char_shape_id(
+src/wasm_api.rs:6270: pub fn apply_char_format_in_cell(
+src/wasm_api.rs:629: pub fn get_page_layer_tree_with_profile(
+src/wasm_api.rs:6300: pub fn apply_char_format_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6318: pub fn set_char_shape_id_in_cell(
+src/wasm_api.rs:6347: pub fn set_char_shape_id_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6364: pub fn set_page_hide(
+src/wasm_api.rs:6393: pub fn set_page_hide_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6410: pub fn get_page_hide(&self, sec: u32, para: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6418: pub fn set_numbering_restart(
+src/wasm_api.rs:6430: pub fn apply_para_format(
+src/wasm_api.rs:6442: pub fn set_para_shape_id(
+src/wasm_api.rs:6454: pub fn apply_para_format_in_cell(
+src/wasm_api.rs:646: pub fn get_canvaskit_replay_plan(&self, page_num: u32, mode: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6476: pub fn set_cell_para_shape_id(
+src/wasm_api.rs:6502: pub fn has_internal_clipboard(&self) -> bool
+src/wasm_api.rs:6508: pub fn get_clipboard_text(&self) -> String
+src/wasm_api.rs:6514: pub fn clear_clipboard(&mut self)
+src/wasm_api.rs:6522: pub fn copy_selection(
+src/wasm_api.rs:652: pub fn get_canvaskit_replay_plan_with_profile(
+src/wasm_api.rs:6542: pub fn copy_selection_in_cell(
+src/wasm_api.rs:6571: pub fn copy_selection_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6591: pub fn copy_control(
+src/wasm_api.rs:6610: pub fn clipboard_has_control(&self) -> bool
+src/wasm_api.rs:6618: pub fn paste_control(
+src/wasm_api.rs:6636: pub fn paste_internal(
+src/wasm_api.rs:6654: pub fn paste_internal_in_cell(
+src/wasm_api.rs:666: pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6678: pub fn paste_internal_in_cell_by_path(
+src/wasm_api.rs:6697: pub fn export_selection_html(
+src/wasm_api.rs:6717: pub fn export_selection_in_cell_html(
+src/wasm_api.rs:673: pub fn get_page_info(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6746: pub fn export_selection_in_cell_html_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6763: pub fn export_control_html(
+src/wasm_api.rs:6782: pub fn get_control_image_data(
+src/wasm_api.rs:679: pub fn get_page_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6801: pub fn get_control_image_mime(
+src/wasm_api.rs:6820: pub fn paste_html(
+src/wasm_api.rs:6838: pub fn paste_html_in_cell(
+src/wasm_api.rs:6865: pub fn paste_html_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:686: pub fn set_page_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:6881: pub fn paste_html_in_cell_by_path(
+src/wasm_api.rs:6902: pub fn measure_width_diagnostic(
+src/wasm_api.rs:6916:pub struct HwpViewer
+src/wasm_api.rs:6927: pub fn new(document: HwpDocument) -> Self
+src/wasm_api.rs:6938: pub fn update_viewport(&mut self, scroll_x: f64, scroll_y: f64, width: f64, height: f64)
+src/wasm_api.rs:693: pub fn get_section_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6951: pub fn set_zoom(&mut self, zoom: f64)
+src/wasm_api.rs:6958: pub fn visible_pages(&self) -> Vec<u32>
+src/wasm_api.rs:6964: pub fn pending_task_count(&self) -> u32
+src/wasm_api.rs:6970: pub fn page_count(&self) -> u32
+src/wasm_api.rs:6976: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6982: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:6999: pub fn get_bookmarks(&self) -> Result<String, JsValue>
+src/wasm_api.rs:7007: pub fn get_structure(&self, mode: &str) -> Result<String, JsValue>
+src/wasm_api.rs:700: pub fn set_section_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:7013: pub fn add_bookmark(
+src/wasm_api.rs:7027: pub fn delete_bookmark(
+src/wasm_api.rs:7040: pub fn rename_bookmark(
+src/wasm_api.rs:7060:pub fn extract_thumbnail(data: &[u8]) -> JsValue
+src/wasm_api.rs:707: pub fn set_section_def_all(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs:713: pub fn get_page_border_fill(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:720: pub fn set_page_border_fill(
+src/wasm_api.rs:731: pub fn get_column_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs:752: pub fn get_document_info(&self) -> String
+src/wasm_api.rs:760: pub fn get_page_text_layout(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:767: pub fn get_page_control_layout(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs:774: pub fn set_dpi(&mut self, dpi: f64)
+src/wasm_api.rs:780: pub fn set_file_name(&mut self, name: &str)
+src/wasm_api.rs:789: pub fn get_dpi(&self) -> f64
+src/wasm_api.rs:795: pub fn set_fallback_font(&mut self, path: &str)
+src/wasm_api.rs:801: pub fn get_fallback_font(&self) -> String
+src/wasm_api.rs:810: pub fn insert_text(
+src/wasm_api.rs:833: pub fn insert_text_logical(
+src/wasm_api.rs:862: pub fn get_logical_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs:876: pub fn logical_to_text_offset(
+src/wasm_api.rs:897: pub fn text_to_logical_offset(
+src/wasm_api.rs:920: pub fn delete_text(
+src/wasm_api.rs:940: pub fn insert_text_in_cell(
+src/wasm_api.rs:968: pub fn insert_text_in_cell_deferred_pagination(
+src/wasm_api.rs:992: pub fn flush_deferred_pagination(&mut self) -> Result<String, JsValue>
+src/wasm_api/event.rs:6:pub use crate::model::event::*
+src/wmf/converter/bitmap.rs:15: pub fn as_slice(&self) -> &[u8]
+src/wmf/converter/bitmap.rs:19: pub fn to_vec(self) -> Vec<u8>
+src/wmf/converter/bitmap.rs:4:pub struct Bitmap(Vec<u8>)
+src/wmf/converter/graphics_object.rs:104: pub fn pen(mut self, pen: Pen) -> Self
+src/wmf/converter/graphics_object.rs:109: pub fn region(mut self, region: Region) -> Self
+src/wmf/converter/graphics_object.rs:14:pub struct GraphicsObjects(Vec<GraphicsObject>, GraphicsObject)
+src/wmf/converter/graphics_object.rs:17: pub fn new(v: usize) -> Self
+src/wmf/converter/graphics_object.rs:21: pub fn delete(&mut self, i: usize)
+src/wmf/converter/graphics_object.rs:25: pub fn get(&self, i: usize) -> &GraphicsObject
+src/wmf/converter/graphics_object.rs:29: pub fn push(&mut self, g: GraphicsObject)
+src/wmf/converter/graphics_object.rs:40:pub struct SelectedGraphicsObject
+src/wmf/converter/graphics_object.rs:4:pub enum GraphicsObject
+src/wmf/converter/graphics_object.rs:89: pub fn brush(mut self, brush: Brush) -> Self
+src/wmf/converter/graphics_object.rs:94: pub fn font(mut self, font: Font) -> Self
+src/wmf/converter/graphics_object.rs:99: pub fn palette(mut self, palette: Palette) -> Self
+src/wmf/converter/mod.rs:11:pub use self::svg::*
+src/wmf/converter/mod.rs:14:pub enum ConvertError
+src/wmf/converter/mod.rs:35:pub struct WMFConverter<B, P>
+src/wmf/converter/mod.rs:41: pub fn new(buffer: B, player: P) -> Self
+src/wmf/converter/mod.rs:56: pub fn run(self) -> Result<Vec<u8>, ConvertError>
+src/wmf/converter/mod.rs:6:pub use self::{bitmap::Bitmap, player::*}
+src/wmf/converter/player.rs:17:pub trait Player: Sized
+src/wmf/converter/player.rs:4:pub enum PlayError
+src/wmf/converter/svg/device_context.rs:106: pub fn map_mode(mut self, map_mode: MapMode) -> Self
+src/wmf/converter/svg/device_context.rs:111: pub fn poly_fill_mode(mut self, poly_fill_mode: PolyFillMode) -> Self
+src/wmf/converter/svg/device_context.rs:116: pub fn text_align_horizontal(mut self, text_align_horizontal: TextAlignmentMode) -> Self
+src/wmf/converter/svg/device_context.rs:121: pub fn text_align_vertical(mut self, text_align_vertical: VerticalTextAlignmentMode) -> Self
+src/wmf/converter/svg/device_context.rs:126: pub fn text_align_update_cp(mut self, text_align_update_cp: bool) -> Self
+src/wmf/converter/svg/device_context.rs:131: pub fn text_bk_color(mut self, text_bk_color: ColorRef) -> Self
+src/wmf/converter/svg/device_context.rs:136: pub fn text_color(mut self, text_color: ColorRef) -> Self
+src/wmf/converter/svg/device_context.rs:141: pub fn window_ext(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs:146: pub fn window_origin(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs:151: pub fn window_scale(mut self, x: f32, y: f32) -> Self
+src/wmf/converter/svg/device_context.rs:158: pub fn as_css_text_align(&self) -> String
+src/wmf/converter/svg/device_context.rs:166: pub fn as_css_text_align_vertical(&self) -> String
+src/wmf/converter/svg/device_context.rs:176: pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS
+src/wmf/converter/svg/device_context.rs:183: pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS
+src/wmf/converter/svg/device_context.rs:192: pub fn poly_fill_rule(&self) -> String
+src/wmf/converter/svg/device_context.rs:200: pub fn text_color_as_css_color(&self) -> String
+src/wmf/converter/svg/device_context.rs:206:pub struct Window
+src/wmf/converter/svg/device_context.rs:236: pub fn new() -> Self
+src/wmf/converter/svg/device_context.rs:240: pub fn ext(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs:253: pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self
+src/wmf/converter/svg/device_context.rs:259: pub fn scale(mut self, scale_x: f32, scale_y: f32) -> Self
+src/wmf/converter/svg/device_context.rs:265: pub fn as_view_box(&self) -> (i16, i16, i16, i16)
+src/wmf/converter/svg/device_context.rs:48: pub fn bk_mode(mut self, bk_mode: MixMode) -> Self
+src/wmf/converter/svg/device_context.rs:4:pub struct DeviceContext
+src/wmf/converter/svg/device_context.rs:53: pub fn create_object_table(mut self, length: u16) -> Self
+src/wmf/converter/svg/device_context.rs:58: pub fn clipping_region(mut self, clipping_region: Rect) -> Self
+src/wmf/converter/svg/device_context.rs:73: pub fn drawing_position(mut self, drawing_position: PointS) -> Self
+src/wmf/converter/svg/device_context.rs:78: pub fn draw_mode(mut self, draw_mode: BinaryRasterOperation) -> Self
+src/wmf/converter/svg/device_context.rs:83: pub fn extend_window(self, p: &PointS) -> Self
+src/wmf/converter/svg/mod.rs:21:pub struct SVGPlayer
+src/wmf/converter/svg/mod.rs:31: pub fn new() -> Self
+src/wmf/converter/svg/node.rs:101: pub fn close(mut self) -> Self
+src/wmf/converter/svg/node.rs:107: pub fn elliptical_arc_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs:113: pub fn line_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs:119: pub fn move_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs:132:pub struct Parameters(String)
+src/wmf/converter/svg/node.rs:18: pub fn new(name: impl ToString) -> Self
+src/wmf/converter/svg/node.rs:26: pub fn new_text(value: impl ToString) -> Self
+src/wmf/converter/svg/node.rs:34: pub fn add(mut self, node: Node) -> Self
+src/wmf/converter/svg/node.rs:42: pub fn set(mut self, name: impl ToString, value: impl ToString) -> Self
+src/wmf/converter/svg/node.rs:4:pub struct Node
+src/wmf/converter/svg/node.rs:91:pub struct Data
+src/wmf/converter/svg/node.rs:96: pub fn new() -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs:14:pub struct TernaryRasterOperator
+src/wmf/converter/svg/ternary_raster_operator.rs:30: pub fn new(operation: TernaryRasterOperation, x: i16, y: i16, height: i16, width: i16) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs:42: pub fn brush(mut self, brush: Brush) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs:47: pub fn source_bitmap16(mut self, source: Bitmap16) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs:52: pub fn source_bitmap(mut self, source: DeviceIndependentBitmap) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs:57: pub fn run(
+src/wmf/converter/svg/ternary_raster_operator.rs:7:pub enum TernaryRasterOperationError
+src/wmf/converter/svg/util.rs:11:pub fn url_string(link: &str) -> String
+src/wmf/converter/svg/util.rs:15:pub fn as_point_string(point: &PointS) -> String
+src/wmf/converter/svg/util.rs:20: pub fn as_data_url(&self) -> String
+src/wmf/converter/svg/util.rs:210:pub struct Stroke
+src/wmf/converter/svg/util.rs:336: pub fn color(&self) -> String
+src/wmf/converter/svg/util.rs:340: pub fn dash_array(&self) -> String
+src/wmf/converter/svg/util.rs:344: pub fn line_cap(&self) -> String
+src/wmf/converter/svg/util.rs:348: pub fn line_join(&self) -> String
+src/wmf/converter/svg/util.rs:34: pub fn as_filter(&self) -> Node
+src/wmf/converter/svg/util.rs:352: pub fn opacity(&self) -> String
+src/wmf/converter/svg/util.rs:356: pub fn width(&self) -> i16
+src/wmf/converter/svg/util.rs:360: pub fn set_props(&self, elem: Node) -> Node
+src/wmf/converter/svg/util.rs:375: pub fn set_props(&self, mut elem: Node, point: &PointS) -> (Node, Vec<String>)
+src/wmf/converter/svg/util.rs:7:pub fn css_color_from_color_ref(c: &ColorRef) -> String
+src/wmf/converter/svg/util.rs:84:pub enum Fill
+src/wmf/mod.rs:37:pub mod converter
+src/wmf/mod.rs:38:pub mod parser
+src/wmf/mod.rs:41: pub use std::{
+src/wmf/mod.rs:50:pub use embedded_io::Read
+src/wmf/parser/constants/enums/binary_raster_operation.rs:7:pub enum BinaryRasterOperation
+src/wmf/parser/constants/enums/bit_count.rs:5:pub enum BitCount
+src/wmf/parser/constants/enums/brush_style.rs:6:pub enum BrushStyle
+src/wmf/parser/constants/enums/character_set.rs:7:pub enum CharacterSet
+src/wmf/parser/constants/enums/color_usage.rs:5:pub enum ColorUsage
+src/wmf/parser/constants/enums/compression.rs:5:pub enum Compression
+src/wmf/parser/constants/enums/family_font.rs:6:pub enum FamilyFont
+src/wmf/parser/constants/enums/flood_fill.rs:5:pub enum FloodFill
+src/wmf/parser/constants/enums/font_quality.rs:5:pub enum FontQuality
+src/wmf/parser/constants/enums/gamut_mapping_intent.rs:6:pub enum GamutMappingIntent
+src/wmf/parser/constants/enums/hatch_style.rs:4:pub enum HatchStyle
+src/wmf/parser/constants/enums/layout.rs:7:pub enum Layout
+src/wmf/parser/constants/enums/logical_color_space.rs:10:pub enum LogicalColorSpace
+src/wmf/parser/constants/enums/map_mode.rs:17:pub enum MapMode
+src/wmf/parser/constants/enums/metafile_escapes.rs:8:pub enum MetafileEscapes
+src/wmf/parser/constants/enums/metafile_type.rs:4:pub enum MetafileType
+src/wmf/parser/constants/enums/metafile_version.rs:5:pub enum MetafileVersion
+src/wmf/parser/constants/enums/mix_mode.rs:5:pub enum MixMode
+src/wmf/parser/constants/enums/mod.rs:35:pub use self::{
+src/wmf/parser/constants/enums/out_precision.rs:7:pub enum OutPrecision
+src/wmf/parser/constants/enums/palette_entry_flag.rs:4:pub enum PaletteEntryFlag
+src/wmf/parser/constants/enums/pen_style.rs:49: pub fn end_cap() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pen_style.rs:58: pub fn line_join() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pen_style.rs:67: pub fn style() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pen_style.rs:7:pub enum PenStyle
+src/wmf/parser/constants/enums/pitch_font.rs:9:pub enum PitchFont
+src/wmf/parser/constants/enums/poly_fill_mode.rs:5:pub enum PolyFillMode
+src/wmf/parser/constants/enums/post_script_cap.rs:5:pub enum PostScriptCap
+src/wmf/parser/constants/enums/post_script_clipping.rs:5:pub enum PostScriptClipping
+src/wmf/parser/constants/enums/post_script_feature_setting.rs:7:pub enum PostScriptFeatureSetting
+src/wmf/parser/constants/enums/post_script_join.rs:5:pub enum PostScriptJoin
+src/wmf/parser/constants/enums/record_type.rs:5:pub enum RecordType
+src/wmf/parser/constants/enums/stretch_mode.rs:6:pub enum StretchMode
+src/wmf/parser/constants/enums/ternary_raster_operation.rs:532: pub fn use_selected_brush(&self) -> bool
+src/wmf/parser/constants/enums/ternary_raster_operation.rs:537: pub fn use_source(&self) -> bool
+src/wmf/parser/constants/enums/ternary_raster_operation.rs:8:pub enum TernaryRasterOperation
+src/wmf/parser/constants/flags/clip_precision.rs:6:pub enum ClipPrecision
+src/wmf/parser/constants/flags/ext_text_out_options.rs:5:pub enum ExtTextOutOptions
+src/wmf/parser/constants/flags/mod.rs:9:pub use self::{
+src/wmf/parser/constants/flags/text_alignment_mode.rs:10:pub enum TextAlignmentMode
+src/wmf/parser/constants/flags/vertical_text_alignment_mode.rs:11:pub enum VerticalTextAlignmentMode
+src/wmf/parser/constants/mod.rs:30: pub fn parse<R: $crate::wmf::Read>(
+src/wmf/parser/constants/mod.rs:6:pub use self::{enums::*, flags::*}
+src/wmf/parser/mod.rs:28:pub struct ReadError
+src/wmf/parser/mod.rs:33: pub fn new(err: impl core::fmt::Display) -> Self
+src/wmf/parser/mod.rs:40:pub fn read<R: crate::wmf::Read, const N: usize>(
+src/wmf/parser/mod.rs:54:pub fn read_variable<R: crate::wmf::Read>(
+src/wmf/parser/mod.rs:5:pub use self::{constants::*, objects::*, records::*}
+src/wmf/parser/mod.rs:77: pub fn [<read_ $t _from_le_bytes>]<R: $crate::wmf::Read>(
+src/wmf/parser/mod.rs:9:pub enum ParseError
+src/wmf/parser/objects/graphics/brush.rs:29: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/brush.rs:5:pub enum Brush
+src/wmf/parser/objects/graphics/font.rs:110: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/font.rs:5:pub struct Font
+src/wmf/parser/objects/graphics/mod.rs:10:pub use self::{brush::*, font::*, palette::*, pen::*, region::*}
+src/wmf/parser/objects/graphics/palette.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/palette.rs:5:pub struct Palette
+src/wmf/parser/objects/graphics/pen.rs:22: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/pen.rs:3:pub struct Pen
+src/wmf/parser/objects/graphics/pen.rs:43:pub struct PenStyleSubsection
+src/wmf/parser/objects/graphics/pen.rs:56: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/pen.rs:85: pub fn line_join(v: u16) -> crate::wmf::parser::PenStyle
+src/wmf/parser/objects/graphics/pen.rs:97: pub fn style(v: u16) -> crate::wmf::parser::PenStyle
+src/wmf/parser/objects/graphics/region.rs:39: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/region.rs:6:pub struct Region
+src/wmf/parser/objects/mod.rs:6:pub use self::{graphics::*, structure::*}
+src/wmf/parser/objects/structure/bitmap16.rs:125: pub fn calc_length(&self) -> usize
+src/wmf/parser/objects/structure/bitmap16.rs:56: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap16.rs:73: pub fn parse_without_bits<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap16.rs:8:pub struct Bitmap16
+src/wmf/parser/objects/structure/bitmap_info_header/core.rs:10:pub struct BitmapInfoHeaderCore
+src/wmf/parser/objects/structure/bitmap_info_header/info.rs:6:pub struct BitmapInfoHeaderInfo
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:123: pub fn color_used(&self) -> u32
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:157: pub fn height(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:166: pub fn width(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:17: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:56: pub fn header_size(&self) -> u32
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:65: pub fn bit_count(&self) -> crate::wmf::parser::BitCount
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:6:pub use self::{core::*, info::*, v4::*, v5::*}
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:74: pub fn size(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:9:pub enum BitmapInfoHeader
+src/wmf/parser/objects/structure/bitmap_info_header/v4.rs:6:pub struct BitmapInfoHeaderV4
+src/wmf/parser/objects/structure/bitmap_info_header/v5.rs:171: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap_info_header/v5.rs:7:pub struct BitmapInfoHeaderV5
+src/wmf/parser/objects/structure/ciexyz.rs:21: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/ciexyz.rs:3:pub struct CIEXYZ
+src/wmf/parser/objects/structure/ciexyz_triple.rs:22: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/ciexyz_triple.rs:4:pub struct CIEXYZTriple
+src/wmf/parser/objects/structure/color_ref.rs:23: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/color_ref.rs:3:pub struct ColorRef
+src/wmf/parser/objects/structure/color_ref.rs:61: pub fn black() -> Self
+src/wmf/parser/objects/structure/color_ref.rs:70: pub fn white() -> Self
+src/wmf/parser/objects/structure/device_independent_bitmap.rs:245:pub struct BitmapBuffer
+src/wmf/parser/objects/structure/device_independent_bitmap.rs:63:pub enum Colors
+src/wmf/parser/objects/structure/device_independent_bitmap.rs:6:pub struct DeviceIndependentBitmap
+src/wmf/parser/objects/structure/device_independent_bitmap.rs:71: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_brush.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_brush.rs:5:pub enum LogBrush
+src/wmf/parser/objects/structure/log_color_space.rs:59: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_color_space.rs:7:pub struct LogColorSpace
+src/wmf/parser/objects/structure/log_color_space_w.rs:59: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_color_space_w.rs:7:pub struct LogColorSpaceW
+src/wmf/parser/objects/structure/mod.rs:25:pub use self::{
+src/wmf/parser/objects/structure/palette_entry.rs:26: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/palette_entry.rs:4:pub struct PaletteEntry
+src/wmf/parser/objects/structure/pitch_and_family.rs:20: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/pitch_and_family.rs:5:pub struct PitchAndFamily
+src/wmf/parser/objects/structure/point_l.rs:18: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/point_l.rs:3:pub struct PointL
+src/wmf/parser/objects/structure/point_s.rs:18: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/point_s.rs:3:pub struct PointS
+src/wmf/parser/objects/structure/poly_polygon.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/poly_polygon.rs:5:pub struct PolyPolygon
+src/wmf/parser/objects/structure/rect.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rect.rs:3:pub struct Rect
+src/wmf/parser/objects/structure/rect.rs:46: pub fn overlap(&self, other: &Rect) -> Option<Rect>
+src/wmf/parser/objects/structure/rect_l.rs:27: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rect_l.rs:6:pub struct RectL
+src/wmf/parser/objects/structure/rgb_quad.rs:26: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rgb_quad.rs:6:pub struct RGBQuad
+src/wmf/parser/objects/structure/rgb_triple.rs:22: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rgb_triple.rs:4:pub struct RGBTriple
+src/wmf/parser/objects/structure/scan.rs:102: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/scan.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/scan.rs:6:pub struct Scan
+src/wmf/parser/objects/structure/scan.rs:85:pub struct ScanLine
+src/wmf/parser/objects/structure/size_l.rs:18: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/size_l.rs:3:pub struct SizeL
+src/wmf/parser/records/bitmap/bit_blt.rs:110: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/bit_blt.rs:19:pub enum META_BITBLT
+src/wmf/parser/records/bitmap/dib_bit_blt.rs:114: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/dib_bit_blt.rs:23:pub enum META_DIBBITBLT
+src/wmf/parser/records/bitmap/dib_stretch_blt.rs:131: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/dib_stretch_blt.rs:29:pub enum META_DIBSTRETCHBLT
+src/wmf/parser/records/bitmap/mod.rs:11:pub use self::{
+src/wmf/parser/records/bitmap/set_dib_to_dev.rs:60: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/set_dib_to_dev.rs:6:pub struct META_SETDIBTODEV
+src/wmf/parser/records/bitmap/stretch_blt.rs:128: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/stretch_blt.rs:25:pub enum META_STRETCHBLT
+src/wmf/parser/records/bitmap/stretch_dib.rs:71: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/stretch_dib.rs:8:pub struct META_STRETCHDIB
+src/wmf/parser/records/control/eof.rs:26: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/control/eof.rs:5:pub struct META_EOF
+src/wmf/parser/records/control/header.rs:6:pub struct META_HEADER
+src/wmf/parser/records/control/mod.rs:11:pub enum MetafileHeader
+src/wmf/parser/records/control/mod.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/control/mod.rs:8:pub use self::{eof::*, header::*, placeable::*}
+src/wmf/parser/records/control/placeable.rs:11:pub struct META_PLACEABLE
+src/wmf/parser/records/drawing/arc.rs:3:pub struct META_ARC
+src/wmf/parser/records/drawing/arc.rs:56: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/chord.rs:59: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/chord.rs:6:pub struct META_CHORD
+src/wmf/parser/records/drawing/ellipse.rs:43: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ellipse.rs:6:pub struct META_ELLIPSE
+src/wmf/parser/records/drawing/ext_flood_fill.rs:38: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ext_flood_fill.rs:4:pub struct META_EXTFLOODFILL
+src/wmf/parser/records/drawing/ext_text_out.rs:168: pub fn into_utf8(
+src/wmf/parser/records/drawing/ext_text_out.rs:64: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ext_text_out.rs:7:pub struct META_EXTTEXTOUT
+src/wmf/parser/records/drawing/fill_region.rs:30: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/fill_region.rs:3:pub struct META_FILLREGION
+src/wmf/parser/records/drawing/flood_fill.rs:34: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/flood_fill.rs:4:pub struct META_FLOODFILL
+src/wmf/parser/records/drawing/frame_region.rs:37: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/frame_region.rs:4:pub struct META_FRAMEREGION
+src/wmf/parser/records/drawing/invert_region.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/invert_region.rs:4:pub struct META_INVERTREGION
+src/wmf/parser/records/drawing/line_to.rs:32: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/line_to.rs:5:pub struct META_LINETO
+src/wmf/parser/records/drawing/mod.rs:25:pub use self::{
+src/wmf/parser/records/drawing/paint_region.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/paint_region.rs:4:pub struct META_PAINTREGION
+src/wmf/parser/records/drawing/pat_blt.rs:44: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/pat_blt.rs:5:pub struct META_PATBLT
+src/wmf/parser/records/drawing/pie.rs:58: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/pie.rs:5:pub struct META_PIE
+src/wmf/parser/records/drawing/poly_line.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/poly_line.rs:6:pub struct META_POLYLINE
+src/wmf/parser/records/drawing/poly_polygon.rs:30: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/poly_polygon.rs:6:pub struct META_POLYPOLYGON
+src/wmf/parser/records/drawing/polygon.rs:36: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/polygon.rs:8:pub struct META_POLYGON
+src/wmf/parser/records/drawing/rectangle.rs:42: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/rectangle.rs:5:pub struct META_RECTANGLE
+src/wmf/parser/records/drawing/round_rect.rs:48: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/round_rect.rs:5:pub struct META_ROUNDRECT
+src/wmf/parser/records/drawing/set_pixel.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/set_pixel.rs:4:pub struct META_SETPIXEL
+src/wmf/parser/records/drawing/text_out.rs:47: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/text_out.rs:7:pub struct META_TEXTOUT
+src/wmf/parser/records/drawing/text_out.rs:90: pub fn into_utf8(
+src/wmf/parser/records/escape/mod.rs:54:pub enum META_ESCAPE
+src/wmf/parser/records/escape/mod.rs:843: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/mod.rs:102: pub fn remaining(&self) -> bool
+src/wmf/parser/records/mod.rs:106: pub fn remaining_bytes(&self) -> usize
+src/wmf/parser/records/mod.rs:10:pub use self::{bitmap::*, control::*, drawing::*, escape::*, object::*, state::*}
+src/wmf/parser/records/mod.rs:42:pub struct RecordSize(u32, usize)
+src/wmf/parser/records/mod.rs:50: pub fn parse<R: crate::wmf::Read>(buf: &mut R) -> Result<Self, crate::wmf::parser::ParseError>
+src/wmf/parser/records/mod.rs:86: pub fn byte_count(&self) -> usize
+src/wmf/parser/records/mod.rs:90: pub fn word_size(&self) -> usize
+src/wmf/parser/records/mod.rs:94: pub fn consume(&mut self, consumed_bytes: usize)
+src/wmf/parser/records/mod.rs:98: pub fn consumed_bytes(&self) -> usize
+src/wmf/parser/records/object/create_brush_indirect.rs:30: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_brush_indirect.rs:4:pub struct META_CREATEBRUSHINDIRECT
+src/wmf/parser/records/object/create_brush_indirect.rs:52: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/create_font_indirect.rs:26: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_font_indirect.rs:3:pub struct META_CREATEFONTINDIRECT
+src/wmf/parser/records/object/create_palette.rs:27: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_palette.rs:3:pub struct META_CREATEPALETTE
+src/wmf/parser/records/object/create_pattern_brush.rs:55: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_pattern_brush.rs:85: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/create_pattern_brush.rs:9:pub struct META_CREATEPATTERNBRUSH
+src/wmf/parser/records/object/create_pen_indirect.rs:26: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_pen_indirect.rs:3:pub struct META_CREATEPENINDIRECT
+src/wmf/parser/records/object/create_region.rs:27: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_region.rs:3:pub struct META_CREATEREGION
+src/wmf/parser/records/object/delete_object.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/delete_object.rs:7:pub struct META_DELETEOBJECT
+src/wmf/parser/records/object/dib_create_pattern_brush.rs:43: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/dib_create_pattern_brush.rs:4:pub struct META_DIBCREATEPATTERNBRUSH
+src/wmf/parser/records/object/dib_create_pattern_brush.rs:80: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/mod.rs:16:pub use self::{
+src/wmf/parser/records/object/select_clip_region.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_clip_region.rs:4:pub struct META_SELECTCLIPREGION
+src/wmf/parser/records/object/select_object.rs:10:pub struct META_SELECTOBJECT
+src/wmf/parser/records/object/select_object.rs:34: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_palette.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_palette.rs:4:pub struct META_SELECTPALETTE
+src/wmf/parser/records/state/animate_palette.rs:13:pub struct META_ANIMATEPALETTE
+src/wmf/parser/records/state/animate_palette.rs:37: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/exclude_clip_rect.rs:39: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/exclude_clip_rect.rs:5:pub struct META_EXCLUDECLIPRECT
+src/wmf/parser/records/state/intersect_clip_rect.rs:39: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/intersect_clip_rect.rs:5:pub struct META_INTERSECTCLIPRECT
+src/wmf/parser/records/state/mod.rs:36:pub use self::{
+src/wmf/parser/records/state/move_to.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/move_to.rs:4:pub struct META_MOVETO
+src/wmf/parser/records/state/offset_clip_rgn.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_clip_rgn.rs:4:pub struct META_OFFSETCLIPRGN
+src/wmf/parser/records/state/offset_viewport_org.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_viewport_org.rs:4:pub struct META_OFFSETVIEWPORTORG
+src/wmf/parser/records/state/offset_window_org.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_window_org.rs:4:pub struct META_OFFSETWINDOWORG
+src/wmf/parser/records/state/realize_palette.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/realize_palette.rs:4:pub struct META_REALIZEPALETTE
+src/wmf/parser/records/state/resize_palette.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/resize_palette.rs:4:pub struct META_RESIZEPALETTE
+src/wmf/parser/records/state/restore_dc.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/restore_dc.rs:4:pub struct META_RESTOREDC
+src/wmf/parser/records/state/save_dc.rs:25: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/save_dc.rs:4:pub struct META_SAVEDC
+src/wmf/parser/records/state/scale_viewport_ext.rs:40: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/scale_viewport_ext.rs:5:pub struct META_SCALEVIEWPORTEXT
+src/wmf/parser/records/state/scale_window_ext.rs:40: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/scale_window_ext.rs:5:pub struct META_SCALEWINDOWEXT
+src/wmf/parser/records/state/set_bk_color.rs:29: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_bk_color.rs:5:pub struct META_SETBKCOLOR
+src/wmf/parser/records/state/set_bk_mode.rs:34: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_bk_mode.rs:6:pub struct META_SETBKMODE
+src/wmf/parser/records/state/set_layout.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_layout.rs:6:pub struct META_SETLAYOUT
+src/wmf/parser/records/state/set_map_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_map_mode.rs:8:pub struct META_SETMAPMODE
+src/wmf/parser/records/state/set_mapper_flags.rs:30: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_mapper_flags.rs:4:pub struct META_SETMAPPERFLAGS
+src/wmf/parser/records/state/set_pal_entries.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_pal_entries.rs:4:pub struct META_SETPALENTRIES
+src/wmf/parser/records/state/set_polyfill_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_polyfill_mode.rs:4:pub struct META_SETPOLYFILLMODE
+src/wmf/parser/records/state/set_relabs.rs:24: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_relabs.rs:3:pub struct META_SETRELABS
+src/wmf/parser/records/state/set_rop2.rs:35: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_rop2.rs:6:pub struct META_SETROP2
+src/wmf/parser/records/state/set_stretch_blt_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_stretch_blt_mode.rs:4:pub struct META_SETSTRETCHBLTMODE
+src/wmf/parser/records/state/set_text_align.rs:34: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_align.rs:4:pub struct META_SETTEXTALIGN
+src/wmf/parser/records/state/set_text_char_extra.rs:33: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_char_extra.rs:6:pub struct META_SETTEXTCHAREXTRA
+src/wmf/parser/records/state/set_text_color.rs:28: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_color.rs:4:pub struct META_SETTEXTCOLOR
+src/wmf/parser/records/state/set_text_justification.rs:34: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_justification.rs:4:pub struct META_SETTEXTJUSTIFICATION
+src/wmf/parser/records/state/set_viewport_ext.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_viewport_ext.rs:4:pub struct META_SETVIEWPORTEXT
+src/wmf/parser/records/state/set_viewport_org.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_viewport_org.rs:4:pub struct META_SETVIEWPORTORG
+src/wmf/parser/records/state/set_window_ext.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_window_ext.rs:4:pub struct META_SETWINDOWEXT
+src/wmf/parser/records/state/set_window_org.rs:31: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_window_org.rs:4:pub struct META_SETWINDOWORG

--- a/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
+++ b/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
@@ -1,3034 +1,3041 @@
-src/diagnostics/bench.rs:48:pub fn run(args: &[String])
-src/diagnostics/core_pages_probe.rs:29:pub fn run(args: &[String])
-src/diagnostics/hwp5_anchor_trace.rs:25:pub fn run(args: &[String])
-src/diagnostics/hwp5_borderfill_diagonal_probe.rs:82:pub fn run(args: &[String])
-src/diagnostics/hwp5_cell_header_probe.rs:138:pub fn run(args: &[String])
-src/diagnostics/hwp5_contract_analyze.rs:66:pub fn run(args: &[String])
-src/diagnostics/hwp5_contract_probe.rs:78:pub fn run(args: &[String])
-src/diagnostics/hwp5_ctrl_data_trace.rs:22:pub fn run(args: &[String])
-src/diagnostics/hwp5_first_para_control_probe.rs:91:pub fn run(args: &[String])
-src/diagnostics/hwp5_inventory.rs:186:pub fn build_inventory(path: &Path, section_filter: Option<u32>) -> Result<Hwp5Inventory, String>
-src/diagnostics/hwp5_inventory.rs:43:pub struct Hwp5InventoryItem
-src/diagnostics/hwp5_inventory.rs:72:pub struct Hwp5Inventory
-src/diagnostics/hwp5_inventory.rs:83:pub fn run(args: &[String])
-src/diagnostics/hwp5_inventory_diff.rs:190:pub fn run(args: &[String])
-src/diagnostics/hwp5_mel_personnel_probe.rs:84:pub fn run(args: &[String])
-src/diagnostics/hwp5_roundtrip_batch.rs:369:pub fn baseline_check(bytes: &[u8]) -> Result<(), String>
-src/diagnostics/hwp5_roundtrip_batch.rs:525:pub fn run(args: &[String])
-src/diagnostics/hwp5_table_probe.rs:90:pub fn run(args: &[String])
-src/diagnostics/hwpx_roundtrip_batch.rs:437:pub fn run(args: &[String])
-src/diagnostics/mod.rs:10:pub mod hwp5_ctrl_data_trace
-src/diagnostics/mod.rs:11:pub mod hwp5_first_para_control_probe
-src/diagnostics/mod.rs:12:pub mod hwp5_inventory
-src/diagnostics/mod.rs:13:pub mod hwp5_inventory_diff
-src/diagnostics/mod.rs:14:pub mod hwp5_mel_personnel_probe
-src/diagnostics/mod.rs:15:pub mod hwp5_roundtrip_batch
-src/diagnostics/mod.rs:16:pub mod hwp5_table_probe
-src/diagnostics/mod.rs:17:pub mod hwpx_roundtrip_batch
-src/diagnostics/mod.rs:18:pub mod render_geom_diff
-src/diagnostics/mod.rs:19:pub mod text_width_probe
-src/diagnostics/mod.rs:3:pub mod bench
-src/diagnostics/mod.rs:4:pub mod core_pages_probe
-src/diagnostics/mod.rs:5:pub mod hwp5_anchor_trace
-src/diagnostics/mod.rs:6:pub mod hwp5_borderfill_diagonal_probe
-src/diagnostics/mod.rs:7:pub mod hwp5_cell_header_probe
-src/diagnostics/mod.rs:8:pub mod hwp5_contract_analyze
-src/diagnostics/mod.rs:9:pub mod hwp5_contract_probe
-src/diagnostics/render_geom_diff.rs:100: pub fn page_count_mismatch(&self) -> bool
-src/diagnostics/render_geom_diff.rs:105: pub fn any_structure_mismatch(&self) -> bool
-src/diagnostics/render_geom_diff.rs:20:pub enum Via
-src/diagnostics/render_geom_diff.rs:29:pub struct NodeDelta
-src/diagnostics/render_geom_diff.rs:383:pub fn diff_page(page: u32, root_a: &RenderNode, root_b: &RenderNode) -> PageGeomDiff
-src/diagnostics/render_geom_diff.rs:42: pub fn disp(&self) -> f64
-src/diagnostics/render_geom_diff.rs:437:pub fn diff_render_geometry(a: &DocumentCore, b: &DocumentCore) -> Result<DocGeomDiff, HwpError>
-src/diagnostics/render_geom_diff.rs:461:pub fn roundtrip_geom(data: &[u8], via: Via) -> Result<DocGeomDiff, HwpError>
-src/diagnostics/render_geom_diff.rs:53:pub struct TypeDelta
-src/diagnostics/render_geom_diff.rs:61: pub fn net(&self) -> i64
-src/diagnostics/render_geom_diff.rs:68:pub struct PageGeomDiff
-src/diagnostics/render_geom_diff.rs:90:pub struct DocGeomDiff
-src/diagnostics/render_geom_diff.rs:929:pub fn run(args: &[String])
-src/diagnostics/text_width_probe.rs:16:pub fn run(args: &[String])
-src/document_core/builders/exam_paper.rs:33:pub fn build_exam_paper(ingest: &IngestDocument) -> Document
-src/document_core/builders/mod.rs:17:pub mod exam_paper
-src/document_core/commands/clipboard.rs:1004: pub fn paste_control_native(
-src/document_core/commands/clipboard.rs:1195: pub fn export_selection_html_native(
-src/document_core/commands/clipboard.rs:1235: pub fn export_selection_in_cell_html_native(
-src/document_core/commands/clipboard.rs:1289: pub fn export_control_html_native(
-src/document_core/commands/clipboard.rs:1644: pub fn get_control_image_data_native(
-src/document_core/commands/clipboard.rs:1686: pub fn get_control_image_mime_native(
-src/document_core/commands/clipboard.rs:1728: pub fn get_bin_data_image_data_native(&self, bin_data_id: u16) -> Result<Vec<u8>, HwpError>
-src/document_core/commands/clipboard.rs:1745: pub fn get_bin_data_image_mime_native(&self, bin_data_id: u16) -> Result<String, HwpError>
-src/document_core/commands/clipboard.rs:276: pub fn has_internal_clipboard_native(&self) -> bool
-src/document_core/commands/clipboard.rs:281: pub fn get_clipboard_text_native(&self) -> String
-src/document_core/commands/clipboard.rs:289: pub fn clear_clipboard_native(&mut self)
-src/document_core/commands/clipboard.rs:310: pub fn copy_selection_native(
-src/document_core/commands/clipboard.rs:398: pub fn copy_selection_in_cell_native(
-src/document_core/commands/clipboard.rs:488: pub fn copy_control_native(
-src/document_core/commands/clipboard.rs:589: pub fn paste_internal_native(
-src/document_core/commands/clipboard.rs:791: pub fn paste_internal_in_cell_native(
-src/document_core/commands/clipboard.rs:875: pub fn paste_internal_in_cell_by_path_native(
-src/document_core/commands/clipboard.rs:981: pub fn clipboard_has_control_native(&self) -> bool
-src/document_core/commands/document.rs:1087: pub fn create_blank_document_native(&mut self) -> Result<String, HwpError>
-src/document_core/commands/document.rs:1124: pub fn export_hwp_native(&self) -> Result<Vec<u8>, HwpError>
-src/document_core/commands/document.rs:1135: pub fn export_hwp_with_adapter(&mut self) -> Result<Vec<u8>, HwpError>
-src/document_core/commands/document.rs:1157: pub fn serialize_hwp_with_verify(&mut self) -> Result<HwpExportVerification, HwpError>
-src/document_core/commands/document.rs:1174: pub fn export_hwpx_native(&self) -> Result<Vec<u8>, HwpError>
-src/document_core/commands/document.rs:1196: pub fn export_hml_native(&self) -> Result<Vec<u8>, crate::serializer::hml::HmlExportError>
-src/document_core/commands/document.rs:1206: pub fn hml_export_preflight(&self) -> Result<(), crate::serializer::hml::HmlExportError>
-src/document_core/commands/document.rs:1429: pub fn convert_to_editable_native(&mut self) -> Result<String, HwpError>
-src/document_core/commands/document.rs:1435: pub fn document(&self) -> &Document
-src/document_core/commands/document.rs:1441: pub fn document_mut(&mut self) -> &mut Document
-src/document_core/commands/document.rs:1446: pub fn set_document(&mut self, doc: Document)
-src/document_core/commands/document.rs:1460: pub fn begin_batch_native(&mut self) -> Result<String, HwpError>
-src/document_core/commands/document.rs:1468: pub fn end_batch_native(&mut self) -> Result<String, HwpError>
-src/document_core/commands/document.rs:1480: pub fn save_snapshot_native(&mut self) -> u32
-src/document_core/commands/document.rs:1498: pub fn restore_snapshot_native(&mut self, id: u32) -> Result<String, HwpError>
-src/document_core/commands/document.rs:1526: pub fn discard_snapshot_native(&mut self, id: u32)
-src/document_core/commands/document.rs:1530: pub fn measure_width_diagnostic_native(
-src/document_core/commands/document.rs:25:pub struct HwpExportVerification
-src/document_core/commands/document.rs:47: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
-src/document_core/commands/document.rs:55: pub fn from_bytes(data: &[u8]) -> Result<DocumentCore, HwpError>
-src/document_core/commands/document.rs:995: pub fn reflow_linesegs_on_demand(&mut self) -> usize
-src/document_core/commands/footnote_ops.rs:128: pub fn delete_footnote_native(
-src/document_core/commands/footnote_ops.rs:328: pub fn get_para_properties_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:347: pub fn apply_para_format_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:418: pub fn get_footnote_info_native(
-src/document_core/commands/footnote_ops.rs:475: pub fn insert_text_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:509: pub fn delete_text_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:545: pub fn split_paragraph_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:623: pub fn merge_paragraph_in_footnote_native(
-src/document_core/commands/footnote_ops.rs:75: pub fn get_footnote_at_cursor_native(
-src/document_core/commands/formatting.rs:1038: pub fn set_char_shape_id_native(
-src/document_core/commands/formatting.rs:1099: pub fn apply_char_format_in_cell_native(
-src/document_core/commands/formatting.rs:1189: pub fn set_char_shape_id_in_cell_native(
-src/document_core/commands/formatting.rs:1239: pub fn apply_para_format_native(
-src/document_core/commands/formatting.rs:1336: pub fn set_para_shape_id_native(
-src/document_core/commands/formatting.rs:1392: pub fn apply_para_format_in_cell_native(
-src/document_core/commands/formatting.rs:1510: pub fn set_cell_para_shape_id_native(
-src/document_core/commands/formatting.rs:1715: pub fn apply_style_native(
-src/document_core/commands/formatting.rs:1809: pub fn apply_cell_style_native(
-src/document_core/commands/formatting.rs:184: pub fn get_cell_para_properties_at_native(
-src/document_core/commands/formatting.rs:1942: pub fn set_numbering_restart_native(
-src/document_core/commands/formatting.rs:1980: pub fn set_page_hide_native(
-src/document_core/commands/formatting.rs:2054: pub fn get_page_hide_native(
-src/document_core/commands/formatting.rs:49: pub fn get_char_properties_at_native(
-src/document_core/commands/formatting.rs:68: pub fn get_cell_char_properties_at_native(
-src/document_core/commands/formatting.rs:859: pub fn find_or_create_font_id_native(&mut self, name: &str) -> i32
-src/document_core/commands/formatting.rs:905: pub fn find_or_create_font_id_for_lang(&mut self, lang: usize, name: &str) -> i32
-src/document_core/commands/formatting.rs:90: pub fn get_para_properties_at_native(
-src/document_core/commands/formatting.rs:966: pub fn apply_char_format_native(
-src/document_core/commands/header_footer_ops.rs:115: pub fn create_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:257: pub fn insert_text_in_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:300: pub fn delete_text_in_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:346: pub fn split_paragraph_in_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:418: pub fn merge_paragraph_in_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:483: pub fn get_header_footer_para_info_native(
-src/document_core/commands/header_footer_ops.rs:525: pub fn delete_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:570: pub fn get_header_footer_list_native(
-src/document_core/commands/header_footer_ops.rs:621: pub fn navigate_header_footer_by_page_native(
-src/document_core/commands/header_footer_ops.rs:701: pub fn toggle_hide_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:72: pub fn get_header_footer_native(
-src/document_core/commands/header_footer_ops.rs:730: pub fn is_header_footer_hidden(&self, page_num: u32, is_header: bool) -> bool
-src/document_core/commands/header_footer_ops.rs:780: pub fn get_para_properties_in_hf_native(
-src/document_core/commands/header_footer_ops.rs:796: pub fn apply_para_format_in_hf_native(
-src/document_core/commands/header_footer_ops.rs:867: pub fn insert_field_in_hf_native(
-src/document_core/commands/header_footer_ops.rs:920: pub fn apply_hf_template_native(
-src/document_core/commands/html_import.rs:12: pub fn paste_html_native(
-src/document_core/commands/html_import.rs:316: pub fn paste_html_in_cell_native(
-src/document_core/commands/html_import.rs:385: pub fn paste_html_in_cell_by_path_native(
-src/document_core/commands/object_ops/common.rs:272: pub fn move_line_endpoint_native(
-src/document_core/commands/object_ops/common.rs:342: pub fn insert_new_number_native(
-src/document_core/commands/object_ops/connector.rs:14: pub fn update_connector_subject_ids(
-src/document_core/commands/object_ops/connector.rs:213: pub fn update_connectors_in_section(&mut self, section_idx: usize)
-src/document_core/commands/object_ops/connector.rs:41: pub fn recalculate_connector_routing(
-src/document_core/commands/object_ops/equation.rs:173: pub fn get_equation_properties_native(
-src/document_core/commands/object_ops/equation.rs:192: pub fn set_equation_properties_native(
-src/document_core/commands/object_ops/equation.rs:231: pub fn render_equation_preview_native(
-src/document_core/commands/object_ops/equation.rs:258: pub fn delete_equation_control_native(
-src/document_core/commands/object_ops/equation.rs:362: pub fn insert_equation_native(
-src/document_core/commands/object_ops/note.rs:106: pub fn set_note_equation_properties_native(
-src/document_core/commands/object_ops/note.rs:281: pub fn insert_footnote_native(
-src/document_core/commands/object_ops/note.rs:594: pub fn insert_endnote_native(
-src/document_core/commands/object_ops/note.rs:87: pub fn get_note_equation_properties_native(
-src/document_core/commands/object_ops/picture.rs:113: pub fn get_picture_properties_native(
-src/document_core/commands/object_ops/picture.rs:1166: pub fn delete_picture_control_native(
-src/document_core/commands/object_ops/picture.rs:1323: pub fn assign_picture_image_native(
-src/document_core/commands/object_ops/picture.rs:1412: pub fn insert_picture_native(
-src/document_core/commands/object_ops/picture.rs:278: pub fn get_header_footer_picture_properties_native(
-src/document_core/commands/object_ops/picture.rs:454: pub fn set_picture_properties_native(
-src/document_core/commands/object_ops/picture.rs:609: pub fn set_header_footer_picture_properties_native(
-src/document_core/commands/object_ops/shape.rs:1093: pub fn create_shape_control_native(
-src/document_core/commands/object_ops/shape.rs:1566: pub fn change_shape_z_order_native(
-src/document_core/commands/object_ops/shape.rs:1873: pub fn group_shapes_native(
-src/document_core/commands/object_ops/shape.rs:2145: pub fn ungroup_shape_native(
-src/document_core/commands/object_ops/shape.rs:2456: pub fn get_endnote_shape_native(&self, section_idx: usize) -> Result<String, HwpError>
-src/document_core/commands/object_ops/shape.rs:2517: pub fn apply_endnote_shape_native(
-src/document_core/commands/object_ops/shape.rs:259: pub fn get_shape_properties_native(
-src/document_core/commands/object_ops/shape.rs:383: pub fn set_shape_properties_native(
-src/document_core/commands/object_ops/shape.rs:991: pub fn delete_shape_control_native(
-src/document_core/commands/object_ops/table.rs:1278: pub fn get_cell_picture_properties_by_path_native(
-src/document_core/commands/object_ops/table.rs:1302: pub fn get_cell_shape_properties_by_path_native(
-src/document_core/commands/object_ops/table.rs:1336: pub fn set_cell_picture_properties_by_path_native(
-src/document_core/commands/object_ops/table.rs:1407: pub fn delete_cell_picture_control_by_path_native(
-src/document_core/commands/object_ops/table.rs:1503: pub fn set_cell_shape_properties_by_path_native(
-src/document_core/commands/object_ops/table.rs:364: pub fn create_table_native(
-src/document_core/commands/object_ops/table.rs:771: pub fn create_table_ex_native(
-src/document_core/commands/table_ops.rs:105: pub fn delete_table_row_native(
-src/document_core/commands/table_ops.rs:136: pub fn delete_table_column_native(
-src/document_core/commands/table_ops.rs:1599: pub fn set_table_column_widths_native(
-src/document_core/commands/table_ops.rs:1654: pub fn fit_table_to_page_native(
-src/document_core/commands/table_ops.rs:167: pub fn merge_table_cells_native(
-src/document_core/commands/table_ops.rs:199: pub fn split_table_cell_native(
-src/document_core/commands/table_ops.rs:230: pub fn split_table_cell_into_native(
-src/document_core/commands/table_ops.rs:2539: pub fn delete_table_control_native(
-src/document_core/commands/table_ops.rs:265: pub fn split_table_cells_in_range_native(
-src/document_core/commands/table_ops.rs:2677: pub fn evaluate_table_formula(
-src/document_core/commands/table_ops.rs:309: pub fn copy_table_cells_transposed_native(
-src/document_core/commands/table_ops.rs:336: pub fn paste_table_cells_transposed_native(
-src/document_core/commands/table_ops.rs:388: pub fn transpose_table_cells_in_place_native(
-src/document_core/commands/table_ops.rs:41: pub fn insert_table_row_native(
-src/document_core/commands/table_ops.rs:432: pub fn paste_table_cells_transposed_as_new_table_native(
-src/document_core/commands/table_ops.rs:479: pub fn has_table_transpose_clipboard_native(&self) -> bool
-src/document_core/commands/table_ops.rs:73: pub fn insert_table_column_native(
-src/document_core/commands/text_editing.rs:1542: pub fn split_paragraph_native(
-src/document_core/commands/text_editing.rs:1792: pub fn insert_page_break_native(
-src/document_core/commands/text_editing.rs:1874: pub fn insert_column_break_native(
-src/document_core/commands/text_editing.rs:1950: pub fn set_column_def_native(
-src/document_core/commands/text_editing.rs:2021: pub fn merge_paragraph_native(
-src/document_core/commands/text_editing.rs:2153: pub fn delete_paragraph_native(
-src/document_core/commands/text_editing.rs:2265: pub fn insert_paragraph_native(
-src/document_core/commands/text_editing.rs:2367: pub fn split_paragraph_in_cell_native(
-src/document_core/commands/text_editing.rs:2466: pub fn merge_paragraph_in_cell_native(
-src/document_core/commands/text_editing.rs:2587: pub fn get_paragraph_count_native(&self, section_idx: usize) -> Result<usize, HwpError>
-src/document_core/commands/text_editing.rs:2599: pub fn get_paragraph_length_native(
-src/document_core/commands/text_editing.rs:2623: pub fn get_textbox_control_index_native(&self, section_idx: usize, para_idx: usize) -> i32
-src/document_core/commands/text_editing.rs:2651: pub fn find_next_editable_control_native(
-src/document_core/commands/text_editing.rs:2816: pub fn find_nearest_control_backward_native(
-src/document_core/commands/text_editing.rs:2909: pub fn find_nearest_control_forward_native(
-src/document_core/commands/text_editing.rs:2999: pub fn get_text_range_native(
-src/document_core/commands/text_editing.rs:3034: pub fn get_cell_paragraph_count_native(
-src/document_core/commands/text_editing.rs:3089: pub fn get_cell_paragraph_length_native(
-src/document_core/commands/text_editing.rs:3115: pub fn get_text_in_cell_native(
-src/document_core/commands/text_editing.rs:3369: pub fn insert_text_in_cell_by_path(
-src/document_core/commands/text_editing.rs:3442: pub fn delete_text_in_cell_by_path(
-src/document_core/commands/text_editing.rs:3472: pub fn split_paragraph_in_cell_by_path(
-src/document_core/commands/text_editing.rs:3557: pub fn merge_paragraph_in_cell_by_path(
-src/document_core/commands/text_editing.rs:3646: pub fn get_text_in_cell_by_path(
-src/document_core/commands/text_editing.rs:439: pub fn insert_text_native(
-src/document_core/commands/text_editing.rs:594: pub fn delete_text_native(
-src/document_core/commands/text_editing.rs:753: pub fn insert_text_in_cell_native(
-src/document_core/commands/text_editing.rs:777: pub fn insert_text_in_cell_native_deferred_pagination(
-src/document_core/commands/text_editing.rs:951: pub fn delete_text_in_cell_native(
-src/document_core/converters/common_obj_attr_writer.rs:28:pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8>
-src/document_core/converters/diagnostics.rs:15:pub struct IrFieldDiff
-src/document_core/converters/diagnostics.rs:186:pub fn diff_hwpx_vs_hwp(hwpx: &Document, hwp: &Document) -> DiffSummary
-src/document_core/converters/diagnostics.rs:28:pub struct DiffSummary
-src/document_core/converters/diagnostics.rs:33: pub fn new() -> Self
-src/document_core/converters/diagnostics.rs:37: pub fn push(&mut self, item: IrFieldDiff)
-src/document_core/converters/diagnostics.rs:42: pub fn counts_by_area(&self) -> Vec<(&'static str, usize)>
-src/document_core/converters/diagnostics.rs:52: pub fn human_report(&self) -> String
-src/document_core/converters/diagnostics.rs:81:pub fn diff_hwpx_vs_serializer_assumptions(hwpx: &Document) -> DiffSummary
-src/document_core/converters/hwpx_to_hwp.rs:109: pub fn new() -> Self
-src/document_core/converters/hwpx_to_hwp.rs:113: pub fn no_op(mut self, reason: impl Into<String>) -> Self
-src/document_core/converters/hwpx_to_hwp.rs:119: pub fn changed_anything(&self) -> bool
-src/document_core/converters/hwpx_to_hwp.rs:1588:pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin"
-src/document_core/converters/hwpx_to_hwp.rs:1593:pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> AdapterReport
-src/document_core/converters/hwpx_to_hwp.rs:177:pub fn convert_hwpx_to_hwp_ir(doc: &mut Document) -> AdapterReport
-src/document_core/converters/hwpx_to_hwp.rs:37:pub struct AdapterReport
-src/document_core/converters/mod.rs:10:pub mod hwpx_to_hwp
-src/document_core/converters/mod.rs:8:pub mod common_obj_attr_writer
-src/document_core/converters/mod.rs:9:pub mod diagnostics
-src/document_core/mod.rs:11:pub mod converters
-src/document_core/mod.rs:13:pub mod queries
-src/document_core/mod.rs:14:pub mod table_calc
-src/document_core/mod.rs:155:pub struct ActiveFieldInfo
-src/document_core/mod.rs:15:pub mod validation
-src/document_core/mod.rs:169: pub fn page_count(&self) -> u32
-src/document_core/mod.rs:178: pub fn get_document_info(&self) -> String
-src/document_core/mod.rs:234: pub fn serialize_event_log(&self) -> String
-src/document_core/mod.rs:239: pub fn set_dpi(&mut self, dpi: f64)
-src/document_core/mod.rs:251: pub fn new_empty() -> Self
-src/document_core/mod.rs:293: pub fn hml_metadata(&self) -> Option<&crate::parser::HmlImportMetadata>
-src/document_core/mod.rs:302: pub fn validation_report(&self) -> &validation::ValidationReport
-src/document_core/mod.rs:32:pub const DEFAULT_FALLBACK_FONT: &str = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
-src/document_core/mod.rs:51:pub struct DocumentCore
-src/document_core/mod.rs:9:pub mod builders
-src/document_core/queries/bookmark_query.rs:103: pub fn delete_bookmark_native(
-src/document_core/queries/bookmark_query.rs:142: pub fn rename_bookmark_native(
-src/document_core/queries/bookmark_query.rs:21: pub fn get_bookmarks_native(&self) -> Result<String, HwpError>
-src/document_core/queries/bookmark_query.rs:43: pub fn add_bookmark_native(
-src/document_core/queries/cursor_rect.rs:1360: pub fn hit_test_native(&self, page_num: u32, x: f64, y: f64) -> Result<String, HwpError>
-src/document_core/queries/cursor_rect.rs:2566: pub fn get_cursor_rect_in_cell_native(
-src/document_core/queries/cursor_rect.rs:256: pub fn get_cursor_rect_native(
-src/document_core/queries/cursor_rect.rs:3706: pub fn get_cursor_rect_in_header_footer_native(
-src/document_core/queries/cursor_rect.rs:3866: pub fn hit_test_header_footer_native(
-src/document_core/queries/cursor_rect.rs:3983: pub fn hit_test_in_header_footer_native(
-src/document_core/queries/cursor_rect.rs:4172: pub fn hit_test_footnote_native(
-src/document_core/queries/cursor_rect.rs:4220: pub fn hit_test_in_footnote_native(
-src/document_core/queries/cursor_rect.rs:4447: pub fn get_selection_rects_in_footnote_native(
-src/document_core/queries/cursor_rect.rs:4746: pub fn get_note_edit_info_native(
-src/document_core/queries/cursor_rect.rs:4792: pub fn get_cursor_rect_in_note_native(
-src/document_core/queries/cursor_rect.rs:4864: pub fn get_cursor_rect_in_footnote_native(
-src/document_core/queries/cursor_rect.rs:5039: pub fn hit_test_body_footnote_marker_native(
-src/document_core/queries/cursor_rect.rs:5125: pub fn get_page_footnote_info_native(
-src/document_core/queries/doc_tree_nav.rs:18:pub struct OverflowLink
-src/document_core/queries/doc_tree_nav.rs:33:pub struct NavContextEntry
-src/document_core/queries/doc_tree_nav.rs:48:pub enum NavResult
-src/document_core/queries/field_query.rs:130: pub fn insert_click_here_field_at_in_cell(
-src/document_core/queries/field_query.rs:14:pub struct FieldLocation
-src/document_core/queries/field_query.rs:192: pub fn insert_click_here_field_at_by_path(
-src/document_core/queries/field_query.rs:23:pub enum NestedEntry
-src/document_core/queries/field_query.rs:242: pub fn get_field_list_json(&self) -> String
-src/document_core/queries/field_query.rs:271: pub fn get_field_value_by_id(&self, field_id: u32) -> Result<String, HwpError>
-src/document_core/queries/field_query.rs:285: pub fn get_field_value_by_name(&self, name: &str) -> Result<String, HwpError>
-src/document_core/queries/field_query.rs:302: pub fn set_field_value_by_id(
-src/document_core/queries/field_query.rs:331: pub fn set_field_value_by_name(&mut self, name: &str, value: &str) -> Result<String, HwpError>
-src/document_core/queries/field_query.rs:39:pub struct FieldInfo
-src/document_core/queries/field_query.rs:50: pub fn collect_all_fields(&self) -> Vec<FieldInfo>
-src/document_core/queries/field_query.rs:649: pub fn remove_field_at(
-src/document_core/queries/field_query.rs:667: pub fn remove_field_at_in_cell(
-src/document_core/queries/field_query.rs:66: pub fn insert_click_here_field_at(
-src/document_core/queries/field_query.rs:727: pub fn set_active_field(
-src/document_core/queries/field_query.rs:752: pub fn set_active_field_in_cell(
-src/document_core/queries/field_query.rs:790: pub fn clear_active_field(&mut self)
-src/document_core/queries/field_query.rs:801: pub fn get_field_info_at(
-src/document_core/queries/field_query.rs:820: pub fn get_field_info_at_in_cell(
-src/document_core/queries/field_query.rs:858: pub fn get_field_info_at_by_path(
-src/document_core/queries/field_query.rs:872: pub fn set_active_field_by_path(
-src/document_core/queries/form_query.rs:128: pub fn set_form_value_in_cell_native(
-src/document_core/queries/form_query.rs:15: pub fn get_form_object_at_native(
-src/document_core/queries/form_query.rs:174: pub fn get_form_object_info_native(
-src/document_core/queries/form_query.rs:64: pub fn get_form_value_native(
-src/document_core/queries/form_query.rs:97: pub fn set_form_value_native(
-src/document_core/queries/mod.rs:7:pub mod rendering
-src/document_core/queries/mod.rs:9:pub mod structure
-src/document_core/queries/rendering.rs:1085:pub struct PngExportOptions
-src/document_core/queries/rendering.rs:1102:pub enum VlmTarget
-src/document_core/queries/rendering.rs:1120: pub fn constraints(&self) -> (i32, u64)
-src/document_core/queries/rendering.rs:1133: pub fn from_str(s: &str) -> Option<Self>
-src/document_core/queries/rendering.rs:1145: pub fn all_names() -> &'static str
-src/document_core/queries/rendering.rs:1151: pub fn get_page_layer_tree_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1155: pub fn get_page_layer_tree_with_profile_native(
-src/document_core/queries/rendering.rs:1212: pub fn get_page_overlay_images_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1475: pub fn get_page_info_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1559: pub fn get_section_def_native(&self, section_idx: usize) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1692: pub fn set_section_def_native(
-src/document_core/queries/rendering.rs:1703: pub fn set_section_def_all_native(&mut self, json: &str) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1713: pub fn get_page_border_fill_native(&self, section_idx: usize) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1803: pub fn set_page_border_fill_native(
-src/document_core/queries/rendering.rs:1922: pub fn get_page_def_native(&self, section_idx: usize) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:1954: pub fn set_page_def_native(
-src/document_core/queries/rendering.rs:2046: pub fn get_page_text_layout_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:2151: pub fn get_page_control_layout_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:3769: pub fn dump_page_items(&self, page_filter: Option<u32>) -> String
-src/document_core/queries/rendering.rs:445: pub fn build_page_render_tree(&self, page_num: u32) -> Result<PageRenderTree, HwpError>
-src/document_core/queries/rendering.rs:452: pub fn build_page_layer_tree(&self, page_num: u32) -> Result<PageLayerTree, HwpError>
-src/document_core/queries/rendering.rs:456: pub fn build_page_layer_tree_with_profile(
-src/document_core/queries/rendering.rs:4640: pub fn extract_page_text_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:4704: pub fn extract_page_markdown_with_images_native(
-src/document_core/queries/rendering.rs:4931: pub fn extract_page_markdown_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:601: pub fn get_bin_data(&self, index: usize) -> Option<Vec<u8>>
-src/document_core/queries/rendering.rs:608: pub fn render_page_svg_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:618: pub fn render_page_svg_legacy_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:629: pub fn render_page_svg_layer_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:633: pub fn render_page_svg_layer_with_profile_native(
-src/document_core/queries/rendering.rs:650: pub fn render_page_pdf_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:660: pub fn render_pages_pdf_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:669: pub fn render_pages_pdf_native_with_options(
-src/document_core/queries/rendering.rs:690: pub fn render_pages_pdf_native_with_profile_and_options(
-src/document_core/queries/rendering.rs:712: pub fn render_document_pdf_native(&self) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:719: pub fn render_document_pdf_native_with_options(
-src/document_core/queries/rendering.rs:732: pub fn render_page_pdf_direct_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:738: pub fn render_pages_pdf_direct_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:748: pub fn render_pages_pdf_direct_native_with_options(
-src/document_core/queries/rendering.rs:762: pub fn render_pages_pdf_direct_native_with_profile_and_options(
-src/document_core/queries/rendering.rs:784: pub fn render_document_pdf_direct_native(&self) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:792: pub fn render_document_pdf_direct_native_with_options(
-src/document_core/queries/rendering.rs:802: pub fn render_page_svg_with_fonts(
-src/document_core/queries/rendering.rs:834: pub fn render_page_html_native(&self, page_num: u32) -> Result<String, HwpError>
-src/document_core/queries/rendering.rs:845: pub fn render_page_canvas_native(&self, page_num: u32) -> Result<u32, HwpError>
-src/document_core/queries/rendering.rs:852: pub fn render_page_canvas_legacy_native(&self, page_num: u32) -> Result<u32, HwpError>
-src/document_core/queries/rendering.rs:860: pub fn get_canvaskit_replay_plan_native(
-src/document_core/queries/rendering.rs:868: pub fn get_canvaskit_replay_plan_with_profile_native(
-src/document_core/queries/rendering.rs:893: pub fn render_page_png_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
-src/document_core/queries/rendering.rs:904: pub fn render_page_png_native_with_fonts(
-src/document_core/queries/rendering.rs:921: pub fn render_page_png_native_with_export_options(
-src/document_core/queries/rendering.rs:934: pub fn render_page_png_native_with_profile_and_export_options(
-src/document_core/queries/search_query.rs:149: pub fn search_text_native(
-src/document_core/queries/search_query.rs:205: pub fn search_all_text_native(
-src/document_core/queries/search_query.rs:250: pub fn replace_text_native(
-src/document_core/queries/search_query.rs:273: pub fn replace_one_native(
-src/document_core/queries/search_query.rs:302: pub fn replace_all_native(
-src/document_core/queries/search_query.rs:387: pub fn get_position_of_page_native(&self, global_page: usize) -> Result<String, HwpError>
-src/document_core/queries/search_query.rs:441: pub fn get_page_of_position_native(
-src/document_core/queries/structure.rs:184:pub fn build_structure(doc: &Document, mode: StructureMode) -> StructureDoc
-src/document_core/queries/structure.rs:18:pub enum StructureMode
-src/document_core/queries/structure.rs:271: pub fn get_structure_native(&self, mode: &str) -> Result<String, HwpError>
-src/document_core/queries/structure.rs:28: pub fn parse(s: &str) -> Option<Self>
-src/document_core/queries/structure.rs:40:pub struct StructureNode
-src/document_core/queries/structure.rs:61:pub struct StructureDoc
-src/document_core/table_calc/evaluator.rs:11:pub struct TableContext
-src/document_core/table_calc/evaluator.rs:27:pub fn evaluate_formula(
-src/document_core/table_calc/evaluator.rs:8:pub type CellValueFn<'a> = &'a dyn Fn(usize, usize) -> Option<f64>
-src/document_core/table_calc/mod.rs:17:pub use evaluator::{evaluate_formula, TableContext}
-src/document_core/table_calc/mod.rs:18:pub use parser::FormulaNode
-src/document_core/table_calc/parser.rs:35:pub enum BinOpKind
-src/document_core/table_calc/parser.rs:43:pub fn parse_formula(input: &str) -> Option<FormulaNode>
-src/document_core/table_calc/parser.rs:7:pub enum FormulaNode
-src/document_core/table_calc/tokenizer.rs:26:pub enum DirectionKind
-src/document_core/table_calc/tokenizer.rs:35:pub fn tokenize(input: &str) -> Vec<Token>
-src/document_core/table_calc/tokenizer.rs:4:pub enum Token
-src/document_core/validation.rs:101: pub fn summary(&self) -> HashMap<String, usize>
-src/document_core/validation.rs:21:pub struct CellPath
-src/document_core/validation.rs:34:pub enum WarningKind
-src/document_core/validation.rs:63:pub struct ValidationWarning
-src/document_core/validation.rs:79:pub struct ValidationReport
-src/document_core/validation.rs:84: pub fn new() -> Self
-src/document_core/validation.rs:88: pub fn is_empty(&self) -> bool
-src/document_core/validation.rs:92: pub fn len(&self) -> usize
-src/document_core/validation.rs:96: pub fn push(&mut self, w: ValidationWarning)
-src/emf/converter/device_context.rs:105: pub fn current(&self) -> &DeviceContext
-src/emf/converter/device_context.rs:108: pub fn current_mut(&mut self) -> &mut DeviceContext
-src/emf/converter/device_context.rs:112: pub fn depth(&self) -> usize
-src/emf/converter/device_context.rs:119:pub struct ObjectTable
-src/emf/converter/device_context.rs:125: pub fn new() -> Self
-src/emf/converter/device_context.rs:129: pub fn insert(&mut self, handle: u32, obj: GraphicsObject)
-src/emf/converter/device_context.rs:12:pub enum GraphicsObject
-src/emf/converter/device_context.rs:133: pub fn get(&self, handle: u32) -> Option<&GraphicsObject>
-src/emf/converter/device_context.rs:136: pub fn remove(&mut self, handle: u32) -> Option<GraphicsObject>
-src/emf/converter/device_context.rs:140: pub fn len(&self) -> usize
-src/emf/converter/device_context.rs:144: pub fn is_empty(&self) -> bool
-src/emf/converter/device_context.rs:20:pub struct DeviceContext
-src/emf/converter/device_context.rs:62:pub struct DcStack
-src/emf/converter/device_context.rs:69: pub fn new() -> Self
-src/emf/converter/device_context.rs:73: pub fn save(&mut self)
-src/emf/converter/device_context.rs:82: pub fn restore(&mut self, relative: i32) -> bool
-src/emf/converter/mod.rs:10:pub use svg::{colorref_to_rgb, escape_xml, SvgBuilder}
-src/emf/converter/mod.rs:4:pub mod device_context
-src/emf/converter/mod.rs:5:pub mod player
-src/emf/converter/mod.rs:6:pub mod svg
-src/emf/converter/mod.rs:8:pub use device_context::{DcStack, DeviceContext, GraphicsObject, ObjectTable}
-src/emf/converter/mod.rs:9:pub use player::Player
-src/emf/converter/player.rs:16:pub struct Player
-src/emf/converter/player.rs:30: pub fn new(render_rect: (f32, f32, f32, f32)) -> Self
-src/emf/converter/player.rs:411:pub struct StrokeSpec
-src/emf/converter/player.rs:43: pub fn play(&mut self, records: &[Record]) -> Result<(), Error>
-src/emf/converter/svg.rs:13: pub fn new() -> Self
-src/emf/converter/svg.rs:17: pub fn push(&mut self, node: &str)
-src/emf/converter/svg.rs:22: pub fn open_group_matrix(&mut self, m: [f32
-src/emf/converter/svg.rs:30: pub fn close_group(&mut self)
-src/emf/converter/svg.rs:35: pub fn into_string(self) -> String
-src/emf/converter/svg.rs:40: pub fn as_str(&self) -> &str
-src/emf/converter/svg.rs:47:pub fn colorref_to_rgb(c: u32) -> String
-src/emf/converter/svg.rs:56:pub fn escape_xml(s: &str) -> String
-src/emf/converter/svg.rs:7:pub struct SvgBuilder
-src/emf/mod.rs:21:pub mod converter
-src/emf/mod.rs:22:pub mod parser
-src/emf/mod.rs:27:pub use parser::records::Record
-src/emf/mod.rs:28:pub use parser::Header
-src/emf/mod.rs:32:pub enum Error
-src/emf/mod.rs:73:pub fn parse_emf(bytes: &[u8]) -> Result<Vec<Record>, Error>
-src/emf/mod.rs:83:pub fn convert_to_svg(bytes: &[u8], render_rect: (f32, f32, f32, f32)) -> Result<String, Error>
-src/emf/parser/constants/mod.rs:4:pub mod record_type
-src/emf/parser/constants/mod.rs:6:pub use record_type::RecordType
-src/emf/parser/constants/record_type.rs:97: pub fn from_u32(v: u32) -> Option<Self>
-src/emf/parser/constants/record_type.rs:9:pub enum RecordType
-src/emf/parser/mod.rs:231:pub struct RecordHeader
-src/emf/parser/mod.rs:237:pub struct Cursor<'a>
-src/emf/parser/mod.rs:244: pub fn new(buf: &'a [u8]) -> Self
-src/emf/parser/mod.rs:248: pub fn position(&self) -> usize
-src/emf/parser/mod.rs:252: pub fn remaining(&self) -> usize
-src/emf/parser/mod.rs:256: pub fn is_empty(&self) -> bool
-src/emf/parser/mod.rs:260: pub fn take(&mut self, n: usize) -> Result<&'a [u8], Error>
-src/emf/parser/mod.rs:272: pub fn peek(&self, n: usize) -> Result<&'a [u8], Error>
-src/emf/parser/mod.rs:282: pub fn u32(&mut self) -> Result<u32, Error>
-src/emf/parser/mod.rs:286: pub fn i32(&mut self) -> Result<i32, Error>
-src/emf/parser/mod.rs:289: pub fn u16(&mut self) -> Result<u16, Error>
-src/emf/parser/mod.rs:296: pub fn full_buf(&self) -> &'a [u8]
-src/emf/parser/mod.rs:300: pub fn peek_record_header(&self) -> Result<RecordHeader, Error>
-src/emf/parser/mod.rs:3:pub mod constants
-src/emf/parser/mod.rs:4:pub mod objects
-src/emf/parser/mod.rs:57:pub fn parse(bytes: &[u8]) -> Result<Vec<Record>, Error>
-src/emf/parser/mod.rs:5:pub mod records
-src/emf/parser/mod.rs:7:pub use objects::header::Header
-src/emf/parser/objects/header.rs:12:pub const SIGNATURE: u32 = 0x464D4520
-src/emf/parser/objects/header.rs:15:pub struct Header
-src/emf/parser/objects/header.rs:37:pub struct HeaderExt1
-src/emf/parser/objects/header.rs:44:pub struct HeaderExt2
-src/emf/parser/objects/header.rs:53: pub fn read(cursor: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/logbrush.rs:14: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/logbrush.rs:7:pub struct LogBrush
-src/emf/parser/objects/logfont.rs:26: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/logfont.rs:7:pub struct LogFontW
-src/emf/parser/objects/logpen.rs:15: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/logpen.rs:7:pub struct LogPen
-src/emf/parser/objects/mod.rs:10:pub use header::Header
-src/emf/parser/objects/mod.rs:11:pub use logbrush::LogBrush
-src/emf/parser/objects/mod.rs:12:pub use logfont::LogFontW
-src/emf/parser/objects/mod.rs:13:pub use logpen::LogPen
-src/emf/parser/objects/mod.rs:14:pub use rectl::{PointL, RectL, SizeL}
-src/emf/parser/objects/mod.rs:15:pub use xform::XForm
-src/emf/parser/objects/mod.rs:3:pub mod header
-src/emf/parser/objects/mod.rs:4:pub mod logbrush
-src/emf/parser/objects/mod.rs:5:pub mod logfont
-src/emf/parser/objects/mod.rs:6:pub mod logpen
-src/emf/parser/objects/mod.rs:7:pub mod rectl
-src/emf/parser/objects/mod.rs:8:pub mod xform
-src/emf/parser/objects/rectl.rs:16: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/rectl.rs:25: pub const fn width(&self) -> i32
-src/emf/parser/objects/rectl.rs:29: pub const fn height(&self) -> i32
-src/emf/parser/objects/rectl.rs:36:pub struct PointL
-src/emf/parser/objects/rectl.rs:42: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/rectl.rs:52:pub struct SizeL
-src/emf/parser/objects/rectl.rs:58: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/rectl.rs:8:pub struct RectL
-src/emf/parser/objects/xform.rs:19: pub const fn identity() -> Self
-src/emf/parser/objects/xform.rs:30: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
-src/emf/parser/objects/xform.rs:7:pub struct XForm
-src/emf/parser/records/bitmap.rs:28:pub struct StretchDIBits
-src/emf/parser/records/bitmap.rs:43:pub fn parse(payload: &[u8]) -> Result<StretchDIBits, Error>
-src/emf/parser/records/drawing.rs:13:pub fn parse_rect(c: &mut Cursor<'_>) -> Result<RectL, Error>
-src/emf/parser/records/drawing.rs:18:pub fn parse_round_rect(c: &mut Cursor<'_>) -> Result<(RectL, i32, i32), Error>
-src/emf/parser/records/drawing.rs:26:pub fn parse_arc_like(c: &mut Cursor<'_>) -> Result<(RectL, PointL, PointL), Error>
-src/emf/parser/records/drawing.rs:34:pub fn parse_points16(c: &mut Cursor<'_>) -> Result<(RectL, Vec<(i16, i16)>), Error>
-src/emf/parser/records/drawing.rs:9:pub fn parse_point(c: &mut Cursor<'_>) -> Result<PointL, Error>
-src/emf/parser/records/header.rs:7:pub fn parse(cursor: &mut Cursor<'_>) -> Result<Header, Error>
-src/emf/parser/records/mod.rs:12:pub use bitmap::StretchDIBits
-src/emf/parser/records/mod.rs:13:pub use text::ExtTextOut
-src/emf/parser/records/mod.rs:17:pub enum Record
-src/emf/parser/records/mod.rs:3:pub mod bitmap
-src/emf/parser/records/mod.rs:4:pub mod drawing
-src/emf/parser/records/mod.rs:5:pub mod header
-src/emf/parser/records/mod.rs:6:pub mod object
-src/emf/parser/records/mod.rs:7:pub mod path
-src/emf/parser/records/mod.rs:8:pub mod state
-src/emf/parser/records/mod.rs:9:pub mod text
-src/emf/parser/records/object.rs:10:pub fn parse_create_pen(c: &mut Cursor<'_>) -> Result<(u32, LogPen), Error>
-src/emf/parser/records/object.rs:17:pub fn parse_create_brush_indirect(c: &mut Cursor<'_>) -> Result<(u32, LogBrush), Error>
-src/emf/parser/records/object.rs:26:pub fn parse_ext_create_font_indirect_w(
-src/emf/parser/records/object.rs:41:pub fn parse_select_object(c: &mut Cursor<'_>) -> Result<u32, Error>
-src/emf/parser/records/object.rs:46:pub fn parse_delete_object(c: &mut Cursor<'_>) -> Result<u32, Error>
-src/emf/parser/records/path.rs:6:pub fn parse_path_bounds(c: &mut Cursor<'_>) -> Result<RectL, Error>
-src/emf/parser/records/state.rs:13:pub fn parse_set_world_transform(c: &mut Cursor<'_>) -> Result<XForm, Error>
-src/emf/parser/records/state.rs:18:pub fn parse_modify_world_transform(c: &mut Cursor<'_>) -> Result<(XForm, u32), Error>
-src/emf/parser/records/state.rs:24:pub fn parse_set_window_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
-src/emf/parser/records/state.rs:27:pub fn parse_set_window_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
-src/emf/parser/records/state.rs:30:pub fn parse_set_viewport_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
-src/emf/parser/records/state.rs:33:pub fn parse_set_viewport_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
-src/emf/parser/records/state.rs:37:pub fn parse_u32_single(c: &mut Cursor<'_>) -> Result<u32, Error>
-src/emf/parser/records/state.rs:9:pub fn parse_restore_dc(c: &mut Cursor<'_>) -> Result<i32, Error>
-src/emf/parser/records/text.rs:23:pub struct ExtTextOut
-src/emf/parser/records/text.rs:36:pub fn parse(payload: &[u8]) -> Result<ExtTextOut, Error>
-src/error.rs:7:pub enum HwpError
-src/lib.rs:10:pub mod error
-src/lib.rs:11:pub mod model
-src/lib.rs:12:pub mod ole_chart
-src/lib.rs:13:pub mod ooxml_chart
-src/lib.rs:14:pub mod paint
-src/lib.rs:15:pub mod parser
-src/lib.rs:16:pub mod renderer
-src/lib.rs:17:pub mod serializer
-src/lib.rs:18:pub mod wasm_api
-src/lib.rs:19:pub mod wmf
-src/lib.rs:21:pub use document_core::DocumentCore
-src/lib.rs:22:pub use error::HwpError
-src/lib.rs:23:pub use model::event::DocumentEvent
-src/lib.rs:24:pub use parser::{parse_document, DocumentParser}
-src/lib.rs:25:pub use serializer::{serialize_document, DocumentSerializer}
-src/lib.rs:29:pub fn init_panic_hook()
-src/lib.rs:35:pub fn version() -> String
-src/lib.rs:7:pub mod diagnostics
-src/lib.rs:8:pub mod document_core
-src/lib.rs:9:pub mod emf
-src/model/bin_data.rs:113: pub fn load(&self) -> Vec<u8>
-src/model/bin_data.rs:122: pub fn len(&self) -> usize
-src/model/bin_data.rs:135: pub fn is_empty(&self) -> bool
-src/model/bin_data.rs:28:pub enum BinDataType
-src/model/bin_data.rs:40:pub enum BinDataCompression
-src/model/bin_data.rs:52:pub enum BinDataStatus
-src/model/bin_data.rs:5:pub struct BinData
-src/model/bin_data.rs:66:pub struct BinDataContent
-src/model/bin_data.rs:80:pub trait BinDataResolver:
-src/model/bin_data.rs:96:pub enum BinDataBytes
-src/model/control.rs:111:pub enum AutoNumberType
-src/model/control.rs:123:pub struct NewNumber
-src/model/control.rs:132:pub struct PageNumberPos
-src/model/control.rs:149:pub struct Bookmark
-src/model/control.rs:156:pub struct Hyperlink
-src/model/control.rs:165:pub struct Ruby
-src/model/control.rs:16:pub enum Control
-src/model/control.rs:185:pub struct CharOverlap
-src/model/control.rs:200:pub struct PageHide
-src/model/control.rs:217:pub struct HiddenComment
-src/model/control.rs:224:pub struct Field
-src/model/control.rs:255: pub fn guide_text(&self) -> Option<&str>
-src/model/control.rs:265: pub fn field_name(&self) -> Option<&str>
-src/model/control.rs:284: pub fn extract_wstring_value(&self, key: &str) -> Option<&str>
-src/model/control.rs:309: pub fn memo_text(&self) -> Option<&str>
-src/model/control.rs:317: pub fn is_editable_in_form(&self) -> bool
-src/model/control.rs:331: pub fn build_clickhere_command(guide: &str, memo: &str) -> String
-src/model/control.rs:346: pub fn field_type_str(&self) -> &'static str
-src/model/control.rs:369:pub enum FieldType
-src/model/control.rs:390:pub enum FormType
-src/model/control.rs:406:pub struct FormObject
-src/model/control.rs:433:pub struct UnknownControl
-src/model/control.rs:65:pub struct Equation
-src/model/control.rs:90:pub struct AutoNumber
-src/model/document.rs:114:pub struct HwpVersion
-src/model/document.rs:123:pub struct DocProperties
-src/model/document.rs:150:pub struct DocInfo
-src/model/document.rs:16:pub const HWP5_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp5-origin"
-src/model/document.rs:195:pub struct Section
-src/model/document.rs:207:pub struct SectionDef
-src/model/document.rs:20:pub struct RawRecord
-src/model/document.rs:268: pub fn hwpx_aux_entry(&self, path: &str) -> Option<&[u8]>
-src/model/document.rs:31:pub struct Document
-src/model/document.rs:383: pub fn convert_to_editable(&mut self) -> bool
-src/model/document.rs:410: pub fn find_or_create_char_shape(
-src/model/document.rs:440: pub fn find_or_create_para_shape(
-src/model/document.rs:468: pub fn find_or_create_tab_def(&mut self, new_td: super::style::TabDef) -> u16
-src/model/document.rs:494: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
-src/model/document.rs:66:pub struct Preview
-src/model/document.rs:75:pub struct PreviewImage
-src/model/document.rs:84:pub enum PreviewImageFormat
-src/model/document.rs:97:pub struct FileHeader
-src/model/event.rs:134: pub fn to_json(&self) -> String
-src/model/event.rs:310:pub fn serialize_event_log(events: &[DocumentEvent]) -> String
-src/model/event.rs:8:pub enum DocumentEvent
-src/model/footnote.rs:113: pub fn encode_attr(&self) -> u32
-src/model/footnote.rs:140: pub fn number_format_from_attr_code(code: u32) -> NumberFormat
-src/model/footnote.rs:166: pub fn number_format_attr_code(format: NumberFormat) -> u32
-src/model/footnote.rs:16:pub struct Footnote
-src/model/footnote.rs:191: pub fn number_format_from_name(value: &str, fallback: NumberFormat) -> NumberFormat
-src/model/footnote.rs:219: pub fn separator_above_margin_hu(&self) -> HwpUnit16
-src/model/footnote.rs:229: pub fn separator_below_margin_hu(&self) -> HwpUnit16
-src/model/footnote.rs:234: pub fn between_notes_margin_hu(&self) -> u16
-src/model/footnote.rs:241:pub enum NumberFormat
-src/model/footnote.rs:266:pub enum FootnoteNumbering
-src/model/footnote.rs:278:pub enum FootnotePlacement
-src/model/footnote.rs:35:pub struct Endnote
-src/model/footnote.rs:54:pub struct FootnoteShape
-src/model/footnote.rs:96: pub fn apply_attr_fields_from_raw(&mut self)
-src/model/header_footer.rs:30:pub struct Footer
-src/model/header_footer.rs:53:pub enum HeaderFooterApply
-src/model/header_footer.rs:68:pub struct MasterPage
-src/model/header_footer.rs:7:pub struct Header
-src/model/image.rs:104:pub struct EffectPoint
-src/model/image.rs:111:pub struct EffectColor
-src/model/image.rs:121:pub struct EffectRgb
-src/model/image.rs:128: pub fn clamped_transparency(&self) -> u8
-src/model/image.rs:132: pub fn transparency_alpha_byte(&self) -> u8
-src/model/image.rs:136: pub fn opacity(&self) -> f64
-src/model/image.rs:148: pub fn is_watermark(&self) -> bool
-src/model/image.rs:153: pub fn watermark_preset(&self) -> Option<&'static str>
-src/model/image.rs:163:pub fn transparency_percent_to_alpha_byte(transparency: u8) -> u8
-src/model/image.rs:168:pub fn alpha_byte_to_transparency_percent(alpha: u8) -> u8
-src/model/image.rs:174:pub enum ImageEffect
-src/model/image.rs:184:pub struct ImageData
-src/model/image.rs:193:pub enum ImageFormat
-src/model/image.rs:54:pub struct CropInfo
-src/model/image.rs:63:pub struct ImageAttr
-src/model/image.rs:83:pub struct PictureEffects
-src/model/image.rs:89:pub struct PictureShadow
-src/model/image.rs:9:pub struct Picture
-src/model/mod.rs:10:pub mod footnote
-src/model/mod.rs:11:pub mod header_footer
-src/model/mod.rs:12:pub mod image
-src/model/mod.rs:13:pub mod page
-src/model/mod.rs:14:pub mod paragraph
-src/model/mod.rs:15:pub mod path
-src/model/mod.rs:16:pub mod shape
-src/model/mod.rs:17:pub mod style
-src/model/mod.rs:18:pub mod table
-src/model/mod.rs:21:pub type HwpUnit = u32
-src/model/mod.rs:24:pub type SHwpUnit = i32
-src/model/mod.rs:27:pub type HwpUnit16 = i16
-src/model/mod.rs:30:pub type ColorRef = u32
-src/model/mod.rs:34:pub struct Point
-src/model/mod.rs:41:pub struct Rect
-src/model/mod.rs:49: pub fn width(&self) -> i32
-src/model/mod.rs:53: pub fn height(&self) -> i32
-src/model/mod.rs:60:pub struct Padding
-src/model/mod.rs:6:pub mod bin_data
-src/model/mod.rs:7:pub mod control
-src/model/mod.rs:8:pub mod document
-src/model/mod.rs:9:pub mod event
-src/model/page.rs:101:pub enum PageBorderBasis
-src/model/page.rs:111:pub enum PageBorderUiBasis
-src/model/page.rs:121:pub struct ColumnDef
-src/model/page.rs:151:pub enum ColumnType
-src/model/page.rs:162:pub enum ColumnDirection
-src/model/page.rs:170:pub struct PageAreas
-src/model/page.rs:195: pub fn from_page_def(page_def: &PageDef) -> Self
-src/model/page.rs:204: pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self
-src/model/page.rs:40: pub fn a4_default() -> Self
-src/model/page.rs:58:pub enum BindingMethod
-src/model/page.rs:70:pub struct PageBorderFill
-src/model/page.rs:7:pub struct PageDef
-src/model/paragraph.rs:1063: pub fn char_shape_id_at(&self, char_offset: usize) -> Option<u32>
-src/model/paragraph.rs:1108: pub fn control_text_positions(&self) -> Vec<usize>
-src/model/paragraph.rs:112:pub enum ColumnBreakType
-src/model/paragraph.rs:1221: pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize
-src/model/paragraph.rs:1233: pub fn apply_char_shape_range(
-src/model/paragraph.rs:127:pub struct CharShapeRef
-src/model/paragraph.rs:1364: pub fn set_single_char_shape(&mut self, char_shape_id: u32)
-src/model/paragraph.rs:1373: pub fn replace_style_char_shape_preserving_overrides(
-src/model/paragraph.rs:1397: pub fn apply_char_shape_to_entire_text(&mut self, char_shape_id: u32)
-src/model/paragraph.rs:139:pub struct LineSeg
-src/model/paragraph.rs:173: pub const TAG_FIRST_LINE_OF_PAGE: u32 = 1 << 0
-src/model/paragraph.rs:174: pub const TAG_FIRST_LINE_OF_COLUMN: u32 = 1 << 1
-src/model/paragraph.rs:175: pub const TAG_EMPTY_SEGMENT: u32 = 1 << 16
-src/model/paragraph.rs:176: pub const TAG_FIRST_SEGMENT: u32 = 1 << 17
-src/model/paragraph.rs:177: pub const TAG_LAST_SEGMENT: u32 = 1 << 18
-src/model/paragraph.rs:178: pub const TAG_AUTO_HYPHENATION: u32 = 1 << 19
-src/model/paragraph.rs:179: pub const TAG_INDENTATION: u32 = 1 << 20
-src/model/paragraph.rs:180: pub const TAG_PARAGRAPH_HEAD: u32 = 1 << 21
-src/model/paragraph.rs:181: pub const TAG_IMPLEMENTATION_PROPERTY: u32 = 1 << 31
-src/model/paragraph.rs:184: pub const TAG_SINGLE_SEGMENT_LINE: u32 = Self::TAG_FIRST_SEGMENT | Self::TAG_LAST_SEGMENT
-src/model/paragraph.rs:186: pub const TAG_MISSING_LINESEG_PLACEHOLDER: u32 =
-src/model/paragraph.rs:190: pub fn missing_lineseg_placeholder() -> Self
-src/model/paragraph.rs:198: pub fn is_missing_lineseg_placeholder(&self) -> bool
-src/model/paragraph.rs:208: pub fn is_first_line_of_page(&self) -> bool
-src/model/paragraph.rs:222: pub fn is_in_wrap_zone(&self, col_w_hu: i32) -> bool
-src/model/paragraph.rs:227: pub fn is_first_line_of_column(&self) -> bool
-src/model/paragraph.rs:232: pub fn is_empty_segment(&self) -> bool
-src/model/paragraph.rs:237: pub fn is_first_segment(&self) -> bool
-src/model/paragraph.rs:242: pub fn is_last_segment(&self) -> bool
-src/model/paragraph.rs:247: pub fn has_indentation(&self) -> bool
-src/model/paragraph.rs:252: pub fn has_paragraph_head(&self) -> bool
-src/model/paragraph.rs:259:pub struct RangeTag
-src/model/paragraph.rs:270:pub struct FieldRange
-src/model/paragraph.rs:284:pub struct OrphanFieldEnd
-src/model/paragraph.rs:411: pub fn new_empty() -> Self
-src/model/paragraph.rs:433: pub fn new_empty_like(template: &Paragraph) -> Self
-src/model/paragraph.rs:466: pub fn insert_text_at(&mut self, char_offset: usize, new_text: &str)
-src/model/paragraph.rs:609: pub fn delete_text_at(&mut self, char_offset: usize, count: usize) -> usize
-src/model/paragraph.rs:62:pub enum NumberingRestart
-src/model/paragraph.rs:714: pub fn split_at(&mut self, char_offset: usize) -> Paragraph
-src/model/paragraph.rs:71:pub enum CtrlChar
-src/model/paragraph.rs:7:pub struct Paragraph
-src/model/paragraph.rs:929: pub fn merge_from(&mut self, other: &Paragraph) -> usize
-src/model/path.rs:24:pub type DocumentPath = Vec<PathSegment>
-src/model/path.rs:27:pub fn path_from_flat(parent_para_idx: usize, control_idx: usize) -> DocumentPath
-src/model/path.rs:8:pub enum PathSegment
-src/model/shape.rs:109:pub enum VertRelTo
-src/model/shape.rs:118:pub enum VertAlign
-src/model/shape.rs:129:pub enum HorzRelTo
-src/model/shape.rs:139:pub enum HorzAlign
-src/model/shape.rs:13: pub const FLAGS: std::ops::Range<usize> = 0..4
-src/model/shape.rs:14: pub const V_OFFSET: std::ops::Range<usize> = 4..8
-src/model/shape.rs:150:pub enum SizeCriterion
-src/model/shape.rs:15: pub const H_OFFSET: std::ops::Range<usize> = 8..12
-src/model/shape.rs:166:pub enum TextWrap
-src/model/shape.rs:16: pub const WIDTH: std::ops::Range<usize> = 12..16
-src/model/shape.rs:17: pub const HEIGHT: std::ops::Range<usize> = 16..20
-src/model/shape.rs:180:pub enum TextFlow
-src/model/shape.rs:18: pub const Z_ORDER: std::ops::Range<usize> = 20..24
-src/model/shape.rs:190:pub struct ShapeComponentAttr
-src/model/shape.rs:19: pub const MARGIN_LEFT: std::ops::Range<usize> = 24..26
-src/model/shape.rs:20: pub const MARGIN_RIGHT: std::ops::Range<usize> = 26..28
-src/model/shape.rs:21: pub const MARGIN_TOP: std::ops::Range<usize> = 28..30
-src/model/shape.rs:22: pub const MARGIN_BOTTOM: std::ops::Range<usize> = 30..32
-src/model/shape.rs:23: pub const INSTANCE_ID: std::ops::Range<usize> = 32..36
-src/model/shape.rs:24: pub const PREVENT_PAGE_BREAK: std::ops::Range<usize> = 36..40
-src/model/shape.rs:25: pub const MIN_LEN: usize = INSTANCE_ID.end
-src/model/shape.rs:26: pub const MIN_LEN_WITH_PREVENT_PAGE_BREAK: usize = PREVENT_PAGE_BREAK.end
-src/model/shape.rs:280:pub struct DrawingObjAttr
-src/model/shape.rs:307:pub struct TextBox
-src/model/shape.rs:31:pub struct CommonObjAttr
-src/model/shape.rs:335:pub enum ShapeObject
-src/model/shape.rs:360: pub fn common(&self) -> &CommonObjAttr
-src/model/shape.rs:376: pub fn common_mut(&mut self) -> &mut CommonObjAttr
-src/model/shape.rs:392: pub fn drawing(&self) -> Option<&DrawingObjAttr>
-src/model/shape.rs:407: pub fn drawing_mut(&mut self) -> Option<&mut DrawingObjAttr>
-src/model/shape.rs:422: pub fn z_order(&self) -> i32
-src/model/shape.rs:427: pub fn shape_attr(&self) -> &ShapeComponentAttr
-src/model/shape.rs:443: pub fn shape_name(&self) -> &'static str
-src/model/shape.rs:461:pub struct LineShape
-src/model/shape.rs:479:pub enum LinkLineType
-src/model/shape.rs:493: pub fn from_u32(v: u32) -> Self
-src/model/shape.rs:509: pub fn is_stroke(&self) -> bool
-src/model/shape.rs:517: pub fn is_arc(&self) -> bool
-src/model/shape.rs:524:pub struct ConnectorControlPoint
-src/model/shape.rs:532:pub struct ConnectorData
-src/model/shape.rs:551:pub struct RectangleShape
-src/model/shape.rs:566:pub struct EllipseShape
-src/model/shape.rs:591:pub struct ArcShape
-src/model/shape.rs:608:pub struct PolygonShape
-src/model/shape.rs:621:pub struct CurveShape
-src/model/shape.rs:634:pub struct GroupShape
-src/model/shape.rs:647:pub struct Caption
-src/model/shape.rs:666:pub enum CaptionDirection
-src/model/shape.rs:676:pub enum CaptionVertAlign
-src/model/shape.rs:689:pub enum ChartType
-src/model/shape.rs:702:pub enum LegendPosition
-src/model/shape.rs:717:pub struct Legend
-src/model/shape.rs:724:pub struct Axis
-src/model/shape.rs:733:pub struct DataSeries
-src/model/shape.rs:746:pub struct ChartShape
-src/model/shape.rs:775:pub enum OlePreviewFormat
-src/model/shape.rs:784:pub struct OlePreview
-src/model/shape.rs:791:pub enum OleDrawingAspect
-src/model/shape.rs:801:pub struct OleShape
-src/model/shape.rs:99:pub enum ObjectNumberingType
-src/model/style.rs:100:pub struct CharShape
-src/model/style.rs:12:pub const BORDER_WIDTHS: [(f64, &str)
-src/model/style.rs:204:pub enum UnderlineType
-src/model/style.rs:213:pub enum HeadType
-src/model/style.rs:227:pub struct ParaShape
-src/model/style.rs:302:pub struct Numbering
-src/model/style.rs:323:pub struct NumberingHead
-src/model/style.rs:32:pub fn border_width_index(mm: f64) -> u8
-src/model/style.rs:338:pub struct Bullet
-src/model/style.rs:361:pub enum Alignment
-src/model/style.rs:373:pub enum LineSpacingType
-src/model/style.rs:383:pub struct TabDef
-src/model/style.rs:398:pub struct TabItem
-src/model/style.rs:427:pub struct Style
-src/model/style.rs:43:pub fn border_width_mm_str(index: u8) -> &'static str
-src/model/style.rs:451:pub struct BorderFill
-src/model/style.rs:468:pub enum CenterLine
-src/model/style.rs:481: pub fn from_hwp_attr(attr: u16) -> Self
-src/model/style.rs:494: pub fn from_hwpx(value: &str) -> Self
-src/model/style.rs:503: pub fn hwp_attr_bits(self) -> u16
-src/model/style.rs:512: pub fn hwp_binary_attr_bits(self) -> u16
-src/model/style.rs:521: pub fn as_hwpx(self) -> &'static str
-src/model/style.rs:52:pub struct Font
-src/model/style.rs:533:pub struct BorderLine
-src/model/style.rs:545:pub enum BorderLineType
-src/model/style.rs:587:pub struct DiagonalLine
-src/model/style.rs:598:pub struct Fill
-src/model/style.rs:613:pub enum FillType
-src/model/style.rs:623:pub struct SolidFill
-src/model/style.rs:634:pub struct GradientFill
-src/model/style.rs:655:pub struct ImageFill
-src/model/style.rs:670:pub enum ImageFillMode
-src/model/style.rs:693:pub struct ShapeBorderLine
-src/model/style.rs:706:pub struct CharShapeMods
-src/model/style.rs:756: pub fn apply_to(&self, base: &CharShape) -> CharShape
-src/model/style.rs:85:pub struct SubstFont
-src/model/style.rs:878:pub struct ParaShapeMods
-src/model/style.rs:915: pub fn apply_to(&self, base: &ParaShape) -> ParaShape
-src/model/table.rs:102:pub struct Cell
-src/model/table.rs:1056: pub fn delete_row(&mut self, row_idx: u16) -> Result<(), String>
-src/model/table.rs:10:pub const CELL_FLAG_EDITABLE_IN_FORM: u16 = 0x0008
-src/model/table.rs:1126: pub fn delete_column(&mut self, col_idx: u16) -> Result<(), String>
-src/model/table.rs:1202: pub fn merge_cells(
-src/model/table.rs:1355: pub fn split_cell(&mut self, target_row: u16, target_col: u16) -> Result<(), String>
-src/model/table.rs:143:pub struct TableTransposeData
-src/model/table.rs:1458: pub fn split_cell_into(
-src/model/table.rs:14:pub struct Table
-src/model/table.rs:162:pub enum VerticalAlign
-src/model/table.rs:1633: pub fn split_cells_in_range(
-src/model/table.rs:170: pub fn set_apply_inner_margin(&mut self, value: bool)
-src/model/table.rs:182: pub fn use_cell_padding_axis(
-src/model/table.rs:209: pub fn table_padding_unspecified(table_padding: &crate::model::Padding) -> bool
-src/model/table.rs:216: pub fn effective_padding(
-src/model/table.rs:238: pub fn cell_protect(&self) -> bool
-src/model/table.rs:242: pub fn set_cell_protect(&mut self, value: bool)
-src/model/table.rs:246: pub fn set_header(&mut self, value: bool)
-src/model/table.rs:251: pub fn editable_in_form(&self) -> bool
-src/model/table.rs:255: pub fn set_editable_in_form(&mut self, value: bool)
-src/model/table.rs:268: pub fn new_empty(
-src/model/table.rs:292: pub fn new_from_template(
-src/model/table.rs:352: pub fn leading_header_rows(&self) -> Vec<usize>
-src/model/table.rs:381: pub fn inferred_local_resize_rows(&self) -> Vec<u16>
-src/model/table.rs:473: pub fn rebuild_grid(&mut self)
-src/model/table.rs:490: pub fn cell_index_at(&self, row: u16, col: u16) -> Option<usize>
-src/model/table.rs:496: pub fn cell_at(&self, row: u16, col: u16) -> Option<&Cell>
-src/model/table.rs:503: pub fn cell_at_mut(&mut self, row: u16, col: u16) -> Option<&mut Cell>
-src/model/table.rs:545: pub fn copy_transpose_range(
-src/model/table.rs:579: pub fn paste_transposed_cells(
-src/model/table.rs:630: pub fn transpose_unmerged_table_in_place(&mut self) -> Result<Vec<(usize, usize)>, String>
-src/model/table.rs:715: pub fn update_ctrl_dimensions(&mut self)
-src/model/table.rs:75:pub enum TablePageBreak
-src/model/table.rs:771: pub fn get_column_widths(&self) -> Vec<HwpUnit>
-src/model/table.rs:798: pub fn set_column_widths(&mut self, widths: &[HwpUnit]) -> Result<(), String>
-src/model/table.rs:7:pub const CELL_FLAG_HAS_MARGIN: u16 = 0x0001
-src/model/table.rs:821: pub fn get_row_heights(&self) -> Vec<HwpUnit>
-src/model/table.rs:834: pub fn get_raw_row_heights(&self) -> Vec<HwpUnit>
-src/model/table.rs:857: pub fn insert_row(&mut self, row_idx: u16, below: bool) -> Result<(), String>
-src/model/table.rs:87:pub struct TableZone
-src/model/table.rs:8:pub const CELL_FLAG_PROTECT: u16 = 0x0002
-src/model/table.rs:960: pub fn insert_column(&mut self, col_idx: u16, right: bool) -> Result<(), String>
-src/model/table.rs:9:pub const CELL_FLAG_HEADER: u16 = 0x0004
-src/ole_chart/ir.rs:13:pub struct OleChartIrPayload<'a>
-src/ole_chart/ir.rs:20: pub fn new(chart: &'a OleChart) -> Self
-src/ole_chart/ir.rs:29:pub fn ole_chart_ir_json(chart: &OleChart) -> Result<String, serde_json::Error>
-src/ole_chart/ir.rs:33:pub fn ole_chart_ir_base64(chart: &OleChart) -> Result<String, serde_json::Error>
-src/ole_chart/ir.rs:8:pub const OLE_CHART_IR_SCHEMA: &str = "rhwp.oleChartIr"
-src/ole_chart/ir.rs:9:pub const OLE_CHART_IR_VERSION: u32 = 1
-src/ole_chart/mod.rs:11:pub use ir::{
-src/ole_chart/mod.rs:15:pub use parser::{
-src/ole_chart/mod.rs:19:pub use svg_renderer::{
-src/ole_chart/mod.rs:7:pub mod ir
-src/ole_chart/mod.rs:8:pub mod parser
-src/ole_chart/mod.rs:9:pub mod svg_renderer
-src/ole_chart/parser.rs:102:pub fn parse_ole_chart_contents(bytes: &[u8]) -> Result<OleChart, OleChartParseError>
-src/ole_chart/parser.rs:15:pub struct OleChart
-src/ole_chart/parser.rs:194:pub fn probe_ole_chart_contents(bytes: &[u8]) -> Result<OleChartContentsProbe, OleChartParseError>
-src/ole_chart/parser.rs:25:pub enum OleChartType
-src/ole_chart/parser.rs:37:pub struct OleChartSeries
-src/ole_chart/parser.rs:44:pub struct OleChartContentsProbe
-src/ole_chart/parser.rs:59:pub enum OleChartParseError
-src/ole_chart/parser.rs:72: pub fn code(&self) -> &'static str
-src/ole_chart/parser.rs:80: pub fn stable_message(&self) -> String
-src/ole_chart/svg_renderer.rs:29:pub fn render_ole_chart_standalone_svg(chart: &OleChart, width: u32, height: u32) -> String
-src/ole_chart/svg_renderer.rs:39:pub fn render_ole_chart_svg_body(chart: &OleChart, width: f64, height: f64) -> String
-src/ole_chart/svg_renderer.rs:6:pub fn render_ole_chart_svg_fragment(
-src/ooxml_chart/mod.rs:105:pub enum BarGrouping
-src/ooxml_chart/mod.rs:119:pub enum ScatterStyle
-src/ooxml_chart/mod.rs:133: pub fn flags(&self) -> (bool, bool, bool)
-src/ooxml_chart/mod.rs:145:pub enum OoxmlChartType
-src/ooxml_chart/mod.rs:163: pub fn label(&self) -> &'static str
-src/ooxml_chart/mod.rs:178:pub struct OoxmlSeries
-src/ooxml_chart/mod.rs:200: pub fn parse(xml: &[u8]) -> Option<Self>
-src/ooxml_chart/mod.rs:206: pub fn render_svg(&self, x: f64, y: f64, w: f64, h: f64) -> String
-src/ooxml_chart/mod.rs:211: pub fn is_combo(&self) -> bool
-src/ooxml_chart/mod.rs:24:pub mod parser
-src/ooxml_chart/mod.rs:25:pub mod renderer
-src/ooxml_chart/mod.rs:29:pub struct OoxmlChart
-src/ooxml_chart/mod.rs:76:pub enum SeriesMarker
-src/ooxml_chart/mod.rs:94:pub enum LegendPos
-src/ooxml_chart/parser.rs:58:pub fn parse_chart_xml(xml: &[u8]) -> Option<OoxmlChart>
-src/ooxml_chart/renderer.rs:91:pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> String
-src/paint/builder.rs:11:pub struct LayerBuilder
-src/paint/builder.rs:17: pub fn new(profile: RenderProfile) -> Self
-src/paint/builder.rs:24: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
-src/paint/builder.rs:29: pub fn build(&mut self, tree: &PageRenderTree) -> PageLayerTree
-src/paint/builder.rs:33: pub fn build_with_embedded_fonts(
-src/paint/font.rs:106: pub fn as_str(self) -> &'static str
-src/paint/font.rs:10:pub struct FontDigest
-src/paint/font.rs:118:pub struct LocalizedName
-src/paint/font.rs:124:pub struct FontBlobResource
-src/paint/font.rs:133:pub struct FontFaceResource
-src/paint/font.rs:148:pub struct FontResourceTable
-src/paint/font.rs:154: pub fn is_empty(&self) -> bool
-src/paint/font.rs:160:pub struct VariationAxisValue
-src/paint/font.rs:166:pub struct OpenTypeFeatureSetting
-src/paint/font.rs:16:pub struct BinaryResourceRef
-src/paint/font.rs:173:pub struct ScriptTag(pub String)
-src/paint/font.rs:176:pub struct LanguageTag(pub String)
-src/paint/font.rs:179:pub struct ShapingEngineId(pub String)
-src/paint/font.rs:182:pub struct FontFallbackPolicyId(pub String)
-src/paint/font.rs:185:pub enum TextDirection
-src/paint/font.rs:192: pub fn as_str(self) -> &'static str
-src/paint/font.rs:202:pub enum WritingMode
-src/paint/font.rs:209: pub fn as_str(self) -> &'static str
-src/paint/font.rs:219:pub struct FontInstanceKey
-src/paint/font.rs:228:pub struct ShapeKey
-src/paint/font.rs:22:pub enum BinaryResourceKind
-src/paint/font.rs:240:pub enum GlyphRunReplayEligibility
-src/paint/font.rs:248: pub fn as_str(self) -> &'static str
-src/paint/font.rs:28: pub fn as_str(self) -> &'static str
-src/paint/font.rs:37:pub struct FontExternalRef
-src/paint/font.rs:3:pub struct FontBlobKey(pub String)
-src/paint/font.rs:42:pub enum FontResourceSource
-src/paint/font.rs:51: pub fn as_str(self) -> &'static str
-src/paint/font.rs:64:pub enum FontPortability
-src/paint/font.rs:7:pub struct FontFaceKey(pub String)
-src/paint/font.rs:81: pub fn kind(&self) -> FontPortabilityKind
-src/paint/font.rs:91: pub fn is_self_contained_replayable(&self) -> bool
-src/paint/font.rs:97:pub enum FontPortabilityKind
-src/paint/font_glyph.rs:105:pub fn decode_font_bitmap_glyph_payload(
-src/paint/font_glyph.rs:197:pub struct FontSvgGlyphDecodeOptions
-src/paint/font_glyph.rs:205: pub fn new(source_range_utf8: TextSourceRange, glyph_range: GlyphRange) -> Self
-src/paint/font_glyph.rs:216:pub enum FontSvgGlyphDecodeError
-src/paint/font_glyph.rs:233: pub fn as_str(self) -> &'static str
-src/paint/font_glyph.rs:252:pub fn decode_font_svg_glyph_payload(
-src/paint/font_glyph.rs:359:pub struct EmbeddedFontFace<'a>
-src/paint/font_glyph.rs:368:pub fn resolve_embedded_font_face_index(
-src/paint/font_glyph.rs:414:pub struct FontGlyphLoweringReport
-src/paint/font_glyph.rs:41:pub struct FontBitmapGlyphDecodeOptions
-src/paint/font_glyph.rs:421:pub fn lower_font_native_glyph_sidecars(
-src/paint/font_glyph.rs:54: pub fn new(
-src/paint/font_glyph.rs:75:pub enum FontBitmapGlyphDecodeError
-src/paint/font_glyph.rs:89: pub fn as_str(self) -> &'static str
-src/paint/json.rs:67: pub fn to_json(&self) -> String
-src/paint/layer_tree.rs:115:pub struct TextSourceTable
-src/paint/layer_tree.rs:11:pub struct PageLayerTree
-src/paint/layer_tree.rs:120: pub fn from_layer_node(root: &LayerNode) -> Self
-src/paint/layer_tree.rs:126: pub fn is_empty(&self) -> bool
-src/paint/layer_tree.rs:223:pub struct LayerOutputOptions
-src/paint/layer_tree.rs:22: pub fn new(page_width: f64, page_height: f64, root: LayerNode) -> Self
-src/paint/layer_tree.rs:244:pub enum CacheHint
-src/paint/layer_tree.rs:253:pub enum ClipKind
-src/paint/layer_tree.rs:261:pub struct LayerNode
-src/paint/layer_tree.rs:269: pub fn group(
-src/paint/layer_tree.rs:288: pub fn clip_rect(
-src/paint/layer_tree.rs:307: pub fn leaf(bounds: BoundingBox, source_node_id: Option<NodeId>, ops: Vec<PaintOp>) -> Self
-src/paint/layer_tree.rs:316: pub fn with_layer(mut self, layer: Option<RenderLayerInfo>) -> Self
-src/paint/layer_tree.rs:323:pub enum LayerNodeKind
-src/paint/layer_tree.rs:340:pub enum GroupKind
-src/paint/layer_tree.rs:35: pub fn with_profile(
-src/paint/layer_tree.rs:53: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
-src/paint/layer_tree.rs:58: pub fn with_text_sources(mut self, text_sources: TextSourceTable) -> Self
-src/paint/layer_tree.rs:65:pub struct TextSourceId(pub u32)
-src/paint/layer_tree.rs:68:pub struct TextSourceRange
-src/paint/layer_tree.rs:74: pub fn new(start: u32, end: u32) -> Self
-src/paint/layer_tree.rs:80:pub struct TextSourceSpan
-src/paint/layer_tree.rs:88:pub struct TextSourceEntry
-src/paint/layer_tree.rs:98:pub enum TextSourceAnnotation
-src/paint/mod.rs:10:pub mod paint_op
-src/paint/mod.rs:11:pub mod profile
-src/paint/mod.rs:12:pub mod replay_order
-src/paint/mod.rs:13:pub mod resources
-src/paint/mod.rs:14:pub mod schema
-src/paint/mod.rs:15:pub mod text_shape
-src/paint/mod.rs:16:pub mod text_v2
-src/paint/mod.rs:17:pub mod text_variants
-src/paint/mod.rs:19:pub use builder::LayerBuilder
-src/paint/mod.rs:20:pub use font::{
-src/paint/mod.rs:27:pub use font_glyph::{
-src/paint/mod.rs:33:pub use layer_tree::{
-src/paint/mod.rs:38:pub use paint_op::{
-src/paint/mod.rs:52:pub use profile::RenderProfile
-src/paint/mod.rs:53:pub use replay_order::{
-src/paint/mod.rs:57:pub use resources::{
-src/paint/mod.rs:5:pub mod builder
-src/paint/mod.rs:61:pub use schema::{
-src/paint/mod.rs:66:pub use text_shape::{
-src/paint/mod.rs:6:pub mod font
-src/paint/mod.rs:70:pub use text_v2::{
-src/paint/mod.rs:74:pub use text_variants::{validate_text_variant_scope, TextVariantScopeError}
-src/paint/mod.rs:7:pub mod font_glyph
-src/paint/mod.rs:9:pub mod layer_tree
-src/paint/paint_op.rs:1008:pub struct ColorLayersPayload
-src/paint/paint_op.rs:1019: pub fn has_colrv0_resolved_layer_contract(&self) -> bool
-src/paint/paint_op.rs:1048: pub fn has_colrv1_stage1_graph_contract(&self) -> bool
-src/paint/paint_op.rs:1052: pub fn has_colrv1_supported_graph_contract(&self) -> bool
-src/paint/paint_op.rs:1068:pub enum BitmapGlyphScalingPolicy
-src/paint/paint_op.rs:1075: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1085:pub enum BitmapGlyphFiltering
-src/paint/paint_op.rs:1091: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1100:pub struct BitmapGlyphPayload
-src/paint/paint_op.rs:1112: pub fn has_strict_visual_contract(&self) -> bool
-src/paint/paint_op.rs:1128:pub struct SvgGlyphPayload
-src/paint/paint_op.rs:1143: pub fn has_static_sanitized_contract(&self) -> bool
-src/paint/paint_op.rs:1188:pub struct LayerGlyphOutlinePath
-src/paint/paint_op.rs:1197:pub enum GlyphOutlineFillRule
-src/paint/paint_op.rs:1203: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1212:pub struct GlyphOutlineStrokeStyle
-src/paint/paint_op.rs:1222: pub fn is_strict_subset(&self) -> bool
-src/paint/paint_op.rs:1237:pub enum GlyphOutlineStrokeJoin
-src/paint/paint_op.rs:1244: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1254:pub enum GlyphOutlineStrokeCap
-src/paint/paint_op.rs:1261: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1271:pub enum GlyphOutlinePaintOrder
-src/paint/paint_op.rs:1279: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1294:pub struct PaintVariantMeta
-src/paint/paint_op.rs:1308: pub fn text_run_default(equivalence_group: impl Into<String>) -> Self
-src/paint/paint_op.rs:1325:pub enum TextVariantKind
-src/paint/paint_op.rs:1332: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1342:pub enum TextVariantQuality
-src/paint/paint_op.rs:134: pub fn page_background(bbox: BoundingBox, background: PageBackgroundNode) -> Self
-src/paint/paint_op.rs:1351: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1363:pub struct LayerPoint
-src/paint/paint_op.rs:1369:pub struct LayerVector
-src/paint/paint_op.rs:1375:pub struct LayerAffineTransform
-src/paint/paint_op.rs:1385:pub struct TextRunPlacement
-src/paint/paint_op.rs:1391:pub enum GlyphRunOrientation
-src/paint/paint_op.rs:1399: pub fn from_text_run(run: &TextRunNode) -> Self
-src/paint/paint_op.rs:1409: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:141: pub fn text_run(bbox: BoundingBox, run: TextRunNode) -> Self
-src/paint/paint_op.rs:1420:pub struct GlyphTransform
-src/paint/paint_op.rs:1430:pub struct GlyphRange
-src/paint/paint_op.rs:1436: pub fn new(start: u32, end: u32) -> Self
-src/paint/paint_op.rs:1440: pub fn is_non_empty(self) -> bool
-src/paint/paint_op.rs:1446:pub enum GlyphClusterFlag
-src/paint/paint_op.rs:1452: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:1461:pub struct GlyphCluster
-src/paint/paint_op.rs:1470:pub struct GlyphRunDiagnostics
-src/paint/paint_op.rs:1484:pub struct PaintTextStyle
-src/paint/paint_op.rs:148: pub fn glyph_run(bbox: BoundingBox, run: LayerGlyphRunPaint) -> Self
-src/paint/paint_op.rs:14:pub enum TextDecorationKind
-src/paint/paint_op.rs:1545: pub fn is_fill_only_glyph_replay(&self) -> bool
-src/paint/paint_op.rs:155: pub fn glyph_outline(bbox: BoundingBox, outline: LayerGlyphOutlinePaint) -> Self
-src/paint/paint_op.rs:162: pub fn char_overlap(bbox: BoundingBox, run: TextRunNode) -> Self
-src/paint/paint_op.rs:169: pub fn text_control_mark(bbox: BoundingBox, run: TextRunNode) -> Self
-src/paint/paint_op.rs:176: pub fn tab_leader(bbox: BoundingBox, run: TextRunNode) -> Self
-src/paint/paint_op.rs:183: pub fn text_decoration(bbox: BoundingBox, run: TextRunNode, kind: TextDecorationKind) -> Self
-src/paint/paint_op.rs:191: pub fn footnote_marker(bbox: BoundingBox, marker: FootnoteMarkerNode) -> Self
-src/paint/paint_op.rs:198: pub fn line(bbox: BoundingBox, line: LineNode) -> Self
-src/paint/paint_op.rs:205: pub fn rectangle(bbox: BoundingBox, rect: RectangleNode) -> Self
-src/paint/paint_op.rs:212: pub fn ellipse(bbox: BoundingBox, ellipse: EllipseNode) -> Self
-src/paint/paint_op.rs:219: pub fn path(bbox: BoundingBox, path: PathNode) -> Self
-src/paint/paint_op.rs:21: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:226: pub fn image(
-src/paint/paint_op.rs:238: pub fn equation(bbox: BoundingBox, equation: EquationNode) -> Self
-src/paint/paint_op.rs:245: pub fn form_object(bbox: BoundingBox, form: FormObjectNode) -> Self
-src/paint/paint_op.rs:252: pub fn placeholder(bbox: BoundingBox, placeholder: PlaceholderNode) -> Self
-src/paint/paint_op.rs:259: pub fn raw_svg(bbox: BoundingBox, raw: RawSvgNode) -> Self
-src/paint/paint_op.rs:266: pub fn bounds(&self) -> BoundingBox
-src/paint/paint_op.rs:291:pub struct LayerGlyphRunPaint
-src/paint/paint_op.rs:315:pub struct LayerGlyphOutlinePaint
-src/paint/paint_op.rs:31:pub enum ResolvedImageKind
-src/paint/paint_op.rs:330:pub enum GlyphOutlinePayloadKind
-src/paint/paint_op.rs:339: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:351: pub fn has_exclusive_payload_family(&self) -> bool
-src/paint/paint_op.rs:37:pub struct ResolvedImagePayload
-src/paint/paint_op.rs:380: pub fn payload_resource_key(&self) -> Option<String>
-src/paint/paint_op.rs:384: pub fn payload_resource_key_with_resources(
-src/paint/paint_op.rs:409: pub fn has_payload_resource_key(&self) -> bool
-src/paint/paint_op.rs:49:pub enum PaintOp
-src/paint/paint_op.rs:617:pub enum ColorGlyphFormat
-src/paint/paint_op.rs:624: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:634:pub struct FontColorGlyphRef
-src/paint/paint_op.rs:642:pub struct PaletteRef
-src/paint/paint_op.rs:649:pub struct ResolvedColor
-src/paint/paint_op.rs:655:pub struct ColorLayerNode
-src/paint/paint_op.rs:671:pub enum ColorPaintGraphNodeKind
-src/paint/paint_op.rs:681: pub fn as_str(self) -> &'static str
-src/paint/paint_op.rs:692: pub fn is_colrv1_stage1_supported(self) -> bool
-src/paint/paint_op.rs:705:pub struct ColorPaintSolidPathNode
-src/paint/paint_op.rs:714:pub struct ColorGradientStop
-src/paint/paint_op.rs:720:pub struct ColorLinearGradient
-src/paint/paint_op.rs:729:pub struct ColorRadialGradient
-src/paint/paint_op.rs:737:pub struct ColorSweepGradient
-src/paint/paint_op.rs:746:pub struct ColorPaintLinearGradientPathNode
-src/paint/paint_op.rs:755:pub struct ColorPaintRadialGradientPathNode
-src/paint/paint_op.rs:764:pub struct ColorPaintSweepGradientPathNode
-src/paint/paint_op.rs:773:pub struct ColorPaintTransformNode
-src/paint/paint_op.rs:779:pub struct ColorPaintGraphNode
-src/paint/paint_op.rs:793:pub struct ColorPaintGraphPayload
-src/paint/paint_op.rs:868: pub fn has_colrv1_stage1_contract(&self) -> bool
-src/paint/paint_op.rs:872: pub fn has_colrv1_supported_graph_contract(&self) -> bool
-src/paint/profile.rs:12: pub fn parse(value: &str) -> Option<Self>
-src/paint/profile.rs:22: pub fn shows_editor_visuals(self) -> bool
-src/paint/profile.rs:3:pub enum RenderProfile
-src/paint/replay_order.rs:11:pub enum PaintReplayPlane
-src/paint/replay_order.rs:19: pub const ORDERED: [Self
-src/paint/replay_order.rs:26: pub fn as_str(self) -> &'static str
-src/paint/replay_order.rs:36:pub fn paint_op_replay_plane(op: &PaintOp) -> PaintReplayPlane
-src/paint/replay_order.rs:40:pub fn paint_op_replay_plane_with_layer(
-src/paint/replay_order.rs:62:pub fn render_layer_replay_plane(layer: Option<RenderLayerInfo>) -> PaintReplayPlane
-src/paint/resources.rs:114: pub fn svg_fragment(&self, id: SvgResourceId) -> Option<&str>
-src/paint/resources.rs:118: pub fn svg_count(&self) -> usize
-src/paint/resources.rs:122: pub fn svg_hash(&self, id: SvgResourceId) -> Option<u64>
-src/paint/resources.rs:126: pub fn svg_fingerprint(&self, id: SvgResourceId) -> Option<[u8
-src/paint/resources.rs:12:pub struct FontBlobResourceId(pub usize)
-src/paint/resources.rs:130: pub fn svg_resource_key(&self, id: SvgResourceId) -> Option<&str>
-src/paint/resources.rs:134: pub fn svg_resources(&self) -> impl Iterator<Item = (SvgResourceId, &str)> + '_
-src/paint/resources.rs:141: pub fn intern_font_blob_bytes(&mut self, bytes: &[u8]) -> FontBlobResourceId
-src/paint/resources.rs:14:pub const RESOURCE_KEY_ALGORITHM: &str = "blake3"
-src/paint/resources.rs:165: pub fn font_blob_bytes(&self, id: FontBlobResourceId) -> Option<&[u8]>
-src/paint/resources.rs:169: pub fn font_blob_count(&self) -> usize
-src/paint/resources.rs:173: pub fn font_blob_hash(&self, id: FontBlobResourceId) -> Option<u64>
-src/paint/resources.rs:177: pub fn font_blob_fingerprint(&self, id: FontBlobResourceId) -> Option<[u8
-src/paint/resources.rs:181: pub fn font_blob_resources(&self) -> impl Iterator<Item = (FontBlobResourceId, &[u8])> + '_
-src/paint/resources.rs:188: pub fn font_blob_bytes_for_ref(&self, data_ref: &BinaryResourceRef) -> Option<&[u8]>
-src/paint/resources.rs:197: pub fn font_resources(&self) -> &FontResourceTable
-src/paint/resources.rs:201: pub fn font_resources_mut(&mut self) -> &mut FontResourceTable
-src/paint/resources.rs:21:pub struct ResourceArena
-src/paint/resources.rs:225:pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String
-src/paint/resources.rs:229:pub fn image_resource_key(byte_len: usize, digest: &str) -> String
-src/paint/resources.rs:233:pub fn svg_resource_key(byte_len: usize, digest: &str) -> String
-src/paint/resources.rs:237:pub fn font_blob_resource_key(byte_len: usize, digest: &str) -> String
-src/paint/resources.rs:41: pub fn intern_image_bytes(&mut self, bytes: &[u8]) -> ImageResourceId
-src/paint/resources.rs:64: pub fn image_bytes(&self, id: ImageResourceId) -> Option<&[u8]>
-src/paint/resources.rs:68: pub fn image_count(&self) -> usize
-src/paint/resources.rs:6:pub struct ImageResourceId(pub usize)
-src/paint/resources.rs:72: pub fn image_hash(&self, id: ImageResourceId) -> Option<u64>
-src/paint/resources.rs:76: pub fn image_fingerprint(&self, id: ImageResourceId) -> Option<[u8
-src/paint/resources.rs:80: pub fn image_resource_key(&self, id: ImageResourceId) -> Option<&str>
-src/paint/resources.rs:84: pub fn image_resources(&self) -> impl Iterator<Item = (ImageResourceId, &[u8])> + '_
-src/paint/resources.rs:91: pub fn intern_svg_fragment(&mut self, svg: &str) -> SvgResourceId
-src/paint/resources.rs:9:pub struct SvgResourceId(pub usize)
-src/paint/schema.rs:16:pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema
-src/paint/schema.rs:25:pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version
-src/paint/schema.rs:26:pub const PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION: u32 = LAYER_TREE_SCHEMA.schema_minor_version
-src/paint/schema.rs:27:pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version
-src/paint/schema.rs:28:pub const PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION: u32 =
-src/paint/schema.rs:30:pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit
-src/paint/schema.rs:31:pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system
-src/paint/schema.rs:3:pub struct LayerTreeSchema
-src/paint/text_shape.rs:104: pub fn public_glyph_run_count(&self) -> usize
-src/paint/text_shape.rs:112:pub struct TextShapeLowerer<'a>
-src/paint/text_shape.rs:117: pub fn new(resolver: &'a dyn FontResolver) -> Self
-src/paint/text_shape.rs:11:pub struct FontRequest
-src/paint/text_shape.rs:121: pub fn diagnostics_only(resolver: &'a dyn FontResolver) -> Self
-src/paint/text_shape.rs:125: pub fn analyze_root(&self, root: &LayerNode) -> TextShapeReport
-src/paint/text_shape.rs:131: pub fn lower_root(&self, root: &mut LayerNode) -> TextShapeReport
-src/paint/text_shape.rs:28:pub struct ResolvedFontFace
-src/paint/text_shape.rs:33:pub struct ResolvedGlyphRun
-src/paint/text_shape.rs:42:pub trait FontResolver
-src/paint/text_shape.rs:56:pub struct NoopFontResolver
-src/paint/text_shape.rs:67:pub enum GlyphRunQuality
-src/paint/text_shape.rs:76: pub fn as_str(self) -> &'static str
-src/paint/text_shape.rs:88:pub struct TextShapeDiagnostic
-src/paint/text_shape.rs:99:pub struct TextShapeReport
-src/paint/text_v2.rs:105:pub struct TextV2SlotDiagnostic
-src/paint/text_v2.rs:118:pub struct TextV2LineBreakRisk
-src/paint/text_v2.rs:127:pub struct TextV2Diagnostics
-src/paint/text_v2.rs:137: pub fn from_layer_tree(tree: &PageLayerTree) -> Self
-src/paint/text_v2.rs:141: pub fn from_layer_tree_with_profile(
-src/paint/text_v2.rs:213: pub fn has_errors(&self) -> bool
-src/paint/text_v2.rs:219: pub fn to_json(&self) -> String
-src/paint/text_v2.rs:225: pub fn write_json(&self, buf: &mut String)
-src/paint/text_v2.rs:24:pub enum TextV2CompatibilityProfile
-src/paint/text_v2.rs:31: pub fn as_str(self) -> &'static str
-src/paint/text_v2.rs:42:pub enum TextV2ValidationSeverity
-src/paint/text_v2.rs:60:pub enum TextV2LineBreakRiskLevel
-src/paint/text_v2.rs:78:pub struct TextV2ValidationIssue
-src/paint/text_v2.rs:90:pub struct TextV2VariantDiagnostic
-src/paint/text_variants.rs:149:pub fn validate_text_variant_scope(tree: &PageLayerTree) -> Result<(), TextVariantScopeError>
-src/paint/text_variants.rs:15:pub enum TextVariantScopeError
-src/parser/bin_data.rs:10:pub enum BinDataError
-src/parser/bin_data.rs:26:pub struct BinDataContent
-src/parser/bin_data.rs:36:pub fn extract_all_bin_data(cfb_reader: &mut CfbReader) -> Vec<BinDataContent>
-src/parser/bin_data.rs:56:pub fn bin_data_storage_name(bin_id: u16, extension: &str) -> String
-src/parser/bin_data.rs:61:pub fn read_bin_data_by_name(
-src/parser/body_text.rs:128:pub fn parse_paragraph(records: &[Record]) -> Result<Paragraph, BodyTextError>
-src/parser/body_text.rs:35:pub enum BodyTextError
-src/parser/body_text.rs:491:pub fn parse_paragraph_list(records: &[Record]) -> Vec<Paragraph>
-src/parser/body_text.rs:54:pub fn parse_body_text_section(data: &[u8]) -> Result<Section, BodyTextError>
-src/parser/byte_reader.rs:102: pub fn read_hwp_string(&mut self) -> io::Result<String>
-src/parser/byte_reader.rs:10:pub struct ByteReader<'a>
-src/parser/byte_reader.rs:116: pub fn read_utf16_string(&mut self, char_count: usize) -> io::Result<String>
-src/parser/byte_reader.rs:129: pub fn read_color_ref(&mut self) -> io::Result<u32>
-src/parser/byte_reader.rs:134: pub fn read_remaining(&mut self) -> io::Result<Vec<u8>>
-src/parser/byte_reader.rs:17: pub fn new(data: &'a [u8]) -> Self
-src/parser/byte_reader.rs:25: pub fn position(&self) -> usize
-src/parser/byte_reader.rs:30: pub fn remaining(&self) -> usize
-src/parser/byte_reader.rs:35: pub fn is_empty(&self) -> bool
-src/parser/byte_reader.rs:40: pub fn read_u8(&mut self) -> io::Result<u8>
-src/parser/byte_reader.rs:45: pub fn read_u16(&mut self) -> io::Result<u16>
-src/parser/byte_reader.rs:50: pub fn read_u32(&mut self) -> io::Result<u32>
-src/parser/byte_reader.rs:55: pub fn read_i8(&mut self) -> io::Result<i8>
-src/parser/byte_reader.rs:60: pub fn read_i16(&mut self) -> io::Result<i16>
-src/parser/byte_reader.rs:65: pub fn read_i32(&mut self) -> io::Result<i32>
-src/parser/byte_reader.rs:70: pub fn read_i64(&mut self) -> io::Result<i64>
-src/parser/byte_reader.rs:75: pub fn read_bytes(&mut self, len: usize) -> io::Result<Vec<u8>>
-src/parser/byte_reader.rs:82: pub fn set_position(&mut self, pos: usize)
-src/parser/byte_reader.rs:87: pub fn skip(&mut self, n: usize) -> io::Result<()>
-src/parser/cfb_reader.rs:100: pub fn read_body_text_section(
-src/parser/cfb_reader.rs:13:pub struct CfbReader
-src/parser/cfb_reader.rs:140: pub fn read_bin_data(&mut self, storage_name: &str) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:146: pub fn section_count(&self) -> u32
-src/parser/cfb_reader.rs:167: pub fn list_bin_data(&self) -> Vec<String>
-src/parser/cfb_reader.rs:182: pub fn list_streams(&self) -> Vec<String>
-src/parser/cfb_reader.rs:193: pub fn list_all_entries(&self) -> Vec<(String, u64, bool)>
-src/parser/cfb_reader.rs:19:pub enum CfbError
-src/parser/cfb_reader.rs:208: pub fn read_preview_image(&mut self) -> Option<Vec<u8>>
-src/parser/cfb_reader.rs:220: pub fn read_preview_text(&mut self) -> Option<String>
-src/parser/cfb_reader.rs:265: pub fn detect_hwp3_variant(&mut self) -> bool
-src/parser/cfb_reader.rs:291:pub struct LenientCfbReader
-src/parser/cfb_reader.rs:310: pub fn open(data: &[u8]) -> Result<Self, CfbError>
-src/parser/cfb_reader.rs:45: pub fn open(data: &[u8]) -> Result<Self, CfbError>
-src/parser/cfb_reader.rs:541: pub fn read_stream(&self, path: &str) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:54: pub fn has_stream(&self, path: &str) -> bool
-src/parser/cfb_reader.rs:562: pub fn has_stream(&self, path: &str) -> bool
-src/parser/cfb_reader.rs:566: pub fn read_doc_info(&self, compressed: bool) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:575: pub fn read_body_text_section(
-src/parser/cfb_reader.rs:589: pub fn list_entries(&self) -> &[(String, u32, u64, u8)]
-src/parser/cfb_reader.rs:594: pub fn read_file_header(&self) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:599: pub fn read_body_text_section_full(
-src/parser/cfb_reader.rs:59: pub fn read_stream_raw(&mut self, path: &str) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:623: pub fn section_count(&self) -> u32
-src/parser/cfb_reader.rs:640:pub fn decompress_stream(data: &[u8]) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:78: pub fn read_file_header(&mut self) -> Result<Vec<u8>, CfbError>
-src/parser/cfb_reader.rs:83: pub fn read_doc_info(&mut self, compressed: bool) -> Result<Vec<u8>, CfbError>
-src/parser/control.rs:33:pub fn parse_control(ctrl_id: u32, ctrl_data: &[u8], child_records: &[Record]) -> Control
-src/parser/crypto.rs:19:pub enum CryptoError
-src/parser/crypto.rs:327:pub fn decrypt_viewtext_section(
-src/parser/doc_info.rs:24:pub enum DocInfoError
-src/parser/doc_info.rs:60:pub fn parse_doc_info(data: &[u8]) -> Result<(DocInfo, DocProperties), DocInfoError>
-src/parser/header.rs:103:pub enum HeaderError
-src/parser/header.rs:130:pub fn parse_file_header(data: &[u8]) -> Result<FileHeader, HeaderError>
-src/parser/header.rs:14:pub const HWP_SIGNATURE: &[u8] = b"HWP Document File"
-src/parser/header.rs:17:pub const FILE_HEADER_SIZE: usize = 256
-src/parser/header.rs:21:pub struct HwpVersion
-src/parser/header.rs:30: pub fn is_supported(&self) -> bool
-src/parser/header.rs:47:pub struct FileHeaderFlags
-src/parser/header.rs:76: pub fn from_u32(flags: u32) -> Self
-src/parser/header.rs:96:pub struct FileHeader
-src/parser/hml/encoding.rs:10:pub struct DecodedHml
-src/parser/hml/encoding.rs:15:pub fn decode(bytes: &[u8], max_bytes: usize) -> Result<DecodedHml, HmlError>
-src/parser/hml/encoding.rs:4:pub enum HmlEncoding
-src/parser/hml/envelope.rs:8:pub struct PreservedFragment
-src/parser/hml/error.rs:2:pub enum HmlError
-src/parser/hml/mod.rs:10:pub use encoding::HmlEncoding
-src/parser/hml/mod.rs:11:pub use envelope::PreservedFragment
-src/parser/hml/mod.rs:12:pub use error::HmlError
-src/parser/hml/mod.rs:13:pub use reader::HmlLimits
-src/parser/hml/mod.rs:14:pub use warnings::{HmlWarning, HmlWarningCode}
-src/parser/hml/mod.rs:18:pub fn detect_hml_signature(bytes: &[u8]) -> bool
-src/parser/hml/mod.rs:23:pub struct HmlMetadata
-src/parser/hml/mod.rs:2:pub mod encoding
-src/parser/hml/mod.rs:31:pub struct HmlParseResult
-src/parser/hml/mod.rs:38:pub fn parse_hml(bytes: &[u8]) -> Result<HmlParseResult, HmlError>
-src/parser/hml/mod.rs:42:pub fn parse_hml_with_limits(bytes: &[u8], limits: &HmlLimits) -> Result<HmlParseResult, HmlError>
-src/parser/hml/mod.rs:4:pub mod error
-src/parser/hml/reader.rs:39:pub struct HmlLimits
-src/parser/hml/warnings.rs:13:pub struct HmlWarning
-src/parser/hml/warnings.rs:2:pub enum HmlWarningCode
-src/parser/hwp3/drawing.rs:111: pub fn has_gradient(&self) -> bool
-src/parser/hwp3/drawing.rs:115: pub fn has_rotation(&self) -> bool
-src/parser/hwp3/drawing.rs:119: pub fn has_bitmap_pattern(&self) -> bool
-src/parser/hwp3/drawing.rs:11:pub struct Hwp3DrawingObjectFrameHeader
-src/parser/hwp3/drawing.rs:125:pub struct Hwp3DrawingObjectRotationAttr
-src/parser/hwp3/drawing.rs:132: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:149:pub struct Hwp3DrawingObjectGradientAttr
-src/parser/hwp3/drawing.rs:160: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:174:pub struct Hwp3DrawingObjectBitmapPatternAttr
-src/parser/hwp3/drawing.rs:182: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:19: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:206:pub struct Hwp3DrawingObjectCommonHeader
-src/parser/hwp3/drawing.rs:221: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:282:pub enum Hwp3DrawingObject
-src/parser/hwp3/drawing.rs:299:pub struct Hwp3DrawingLine
-src/parser/hwp3/drawing.rs:306: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:316:pub struct Hwp3DrawingArc
-src/parser/hwp3/drawing.rs:323: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:333:pub struct Hwp3DrawingPolygon
-src/parser/hwp3/drawing.rs:341: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:363:pub struct Hwp3DrawingTextBox
-src/parser/hwp3/drawing.rs:370: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:386:pub struct Hwp3DrawingCurve
-src/parser/hwp3/drawing.rs:394: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:40:pub struct Hwp3DrawingObjectHypertextInfo
-src/parser/hwp3/drawing.rs:416:pub struct Hwp3DrawingModifiedEllipse
-src/parser/hwp3/drawing.rs:423: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:438:pub struct Hwp3DrawingExtendedPolygon
-src/parser/hwp3/drawing.rs:447: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:474: pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:50: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/drawing.rs:572:pub fn parse_drawing_object_tree(
-src/parser/hwp3/drawing.rs:79:pub struct Hwp3DrawingObjectBasicAttr
-src/parser/hwp3/drawing.rs:93: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/encoding.rs:14:pub fn decode_hwp3_string(bytes: &[u8]) -> String
-src/parser/hwp3/johab.rs:8:pub fn decode_johab(ch: u16) -> char
-src/parser/hwp3/johab_map.rs:6:pub const JOHAB_SYMBOLS: &[(u16, char)] = &[
-src/parser/hwp3/mod.rs:10:pub mod drawing
-src/parser/hwp3/mod.rs:11:pub mod encoding
-src/parser/hwp3/mod.rs:12:pub mod johab
-src/parser/hwp3/mod.rs:13:pub mod johab_map
-src/parser/hwp3/mod.rs:14:pub mod ole
-src/parser/hwp3/mod.rs:15:pub mod paragraph
-src/parser/hwp3/mod.rs:16:pub mod records
-src/parser/hwp3/mod.rs:17:pub mod special_char
-src/parser/hwp3/mod.rs:23:pub enum Hwp3Error
-src/parser/hwp3/mod.rs:2852:pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error>
-src/parser/hwp3/ole.rs:11:pub enum Hwp3OleError
-src/parser/hwp3/ole.rs:127: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/ole.rs:26:pub struct Hwp3OleInfo
-src/parser/hwp3/ole.rs:32: pub fn read<R: Read>(mut reader: R, total_length: u32) -> Result<Self, Hwp3OleError>
-src/parser/hwp3/ole.rs:61:pub struct Hwp3OleStreamInfo
-src/parser/hwp3/ole.rs:80: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/ole.rs:98:pub struct Hwp3ChartConnectionInfo
-src/parser/hwp3/paragraph.rs:11:pub struct Hwp3LineInfo
-src/parser/hwp3/paragraph.rs:22: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/paragraph.rs:44:pub struct Hwp3ParaInfo
-src/parser/hwp3/paragraph.rs:57: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:12:pub struct Hwp3DocInfo
-src/parser/hwp3/records.rs:148:pub struct Hwp3DocSummary
-src/parser/hwp3/records.rs:158: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:193:pub struct Hwp3CharShape
-src/parser/hwp3/records.rs:206: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:237: pub fn is_italic(&self) -> bool
-src/parser/hwp3/records.rs:240: pub fn is_bold(&self) -> bool
-src/parser/hwp3/records.rs:243: pub fn is_underline(&self) -> bool
-src/parser/hwp3/records.rs:246: pub fn is_outline(&self) -> bool
-src/parser/hwp3/records.rs:249: pub fn is_shadow(&self) -> bool
-src/parser/hwp3/records.rs:252: pub fn is_superscript(&self) -> bool
-src/parser/hwp3/records.rs:255: pub fn is_subscript(&self) -> bool
-src/parser/hwp3/records.rs:258: pub fn is_font_blank(&self) -> bool
-src/parser/hwp3/records.rs:264:pub struct Hwp3TabDef
-src/parser/hwp3/records.rs:271: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:287:pub struct Hwp3ColumnDef
-src/parser/hwp3/records.rs:295: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:311:pub struct Hwp3ParaShape
-src/parser/hwp3/records.rs:350: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:388: pub fn alignment(&self) -> u8
-src/parser/hwp3/records.rs:392: pub fn has_border(&self) -> bool
-src/parser/hwp3/records.rs:396: pub fn border_connection(&self) -> bool
-src/parser/hwp3/records.rs:402:pub struct Hwp3Style
-src/parser/hwp3/records.rs:409: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:426:pub struct Hwp3InfoBlock
-src/parser/hwp3/records.rs:433: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:443:pub struct Hwp3AdditionalInfoBlock
-src/parser/hwp3/records.rs:450: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/records.rs:54: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
-src/parser/hwp3/special_char.rs:10:pub enum Hwp3SpecialCharError
-src/parser/hwp3/special_char.rs:133: pub fn parse(code: u16, length: u32, data: Vec<u8>) -> Result<Self, Hwp3SpecialCharError>
-src/parser/hwp3/special_char.rs:24:pub enum Hwp3SpecialChar
-src/parser/hwpx/content.rs:13:pub struct PackageItem
-src/parser/hwpx/content.rs:27:pub struct PackageInfo
-src/parser/hwpx/content.rs:45:pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError>
-src/parser/hwpx/header.rs:71:pub fn parse_hwpx_hwpml_version(xml: &str) -> Option<String>
-src/parser/hwpx/header.rs:95:pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxError>
-src/parser/hwpx/mod.rs:116:pub enum HwpxError
-src/parser/hwpx/mod.rs:132: pub fn is_encrypted(&self) -> bool
-src/parser/hwpx/mod.rs:13:pub mod content
-src/parser/hwpx/mod.rs:15:pub mod header
-src/parser/hwpx/mod.rs:16:pub mod reader
-src/parser/hwpx/mod.rs:17:pub mod section
-src/parser/hwpx/mod.rs:18:pub mod utils
-src/parser/hwpx/mod.rs:236:pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError>
-src/parser/hwpx/reader.rs:102: pub fn read_file_bytes(&mut self, path: &str) -> Result<Vec<u8>, HwpxError>
-src/parser/hwpx/reader.rs:112: pub fn file_names(&self) -> Vec<String>
-src/parser/hwpx/reader.rs:27:pub const MAX_XML_SIZE: usize = 256 * 1024 * 1024
-src/parser/hwpx/reader.rs:36:pub const MAX_BINDATA_SIZE: usize = 512 * 1024 * 1024
-src/parser/hwpx/reader.rs:59:pub struct HwpxReader
-src/parser/hwpx/reader.rs:65: pub fn open(data: &[u8]) -> Result<Self, HwpxError>
-src/parser/hwpx/reader.rs:79: pub fn read_file(&mut self, path: &str) -> Result<String, HwpxError>
-src/parser/hwpx/section.rs:116:pub fn parse_hwpx_master_page(xml: &str) -> Result<MasterPage, HwpxError>
-src/parser/hwpx/section.rs:44:pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError>
-src/parser/hwpx/section.rs:77:pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError>
-src/parser/hwpx/utils.rs:116:pub fn parse_bool(attr: &quick_xml::events::attributes::Attribute) -> bool
-src/parser/hwpx/utils.rs:126:pub fn parse_hatch_style(value: &str) -> Option<i32>
-src/parser/hwpx/utils.rs:12:pub fn local_name(name: &[u8]) -> &[u8]
-src/parser/hwpx/utils.rs:139:pub fn parse_gradient_type(value: &str) -> i16
-src/parser/hwpx/utils.rs:150:pub fn skip_element(reader: &mut Reader<&[u8]>, _end_tag: &[u8]) -> Result<(), HwpxError>
-src/parser/hwpx/utils.rs:29:pub fn attr_str(attr: &quick_xml::events::attributes::Attribute) -> String
-src/parser/hwpx/utils.rs:38:pub fn attr_eq(attr: &quick_xml::events::attributes::Attribute, val: &str) -> bool
-src/parser/hwpx/utils.rs:42:pub fn parse_u8(attr: &quick_xml::events::attributes::Attribute) -> u8
-src/parser/hwpx/utils.rs:46:pub fn parse_i8(attr: &quick_xml::events::attributes::Attribute) -> i8
-src/parser/hwpx/utils.rs:50:pub fn parse_u16(attr: &quick_xml::events::attributes::Attribute) -> u16
-src/parser/hwpx/utils.rs:54:pub fn parse_i16(attr: &quick_xml::events::attributes::Attribute) -> i16
-src/parser/hwpx/utils.rs:58:pub fn parse_u32(attr: &quick_xml::events::attributes::Attribute) -> u32
-src/parser/hwpx/utils.rs:62:pub fn parse_i32(attr: &quick_xml::events::attributes::Attribute) -> i32
-src/parser/hwpx/utils.rs:71:pub fn parse_i32_wrapping(attr: &quick_xml::events::attributes::Attribute) -> i32
-src/parser/hwpx/utils.rs:83:pub fn parse_color(attr: &quick_xml::events::attributes::Attribute) -> u32
-src/parser/hwpx/utils.rs:89:pub fn parse_color_str(s: &str) -> u32
-src/parser/ingest/mod.rs:12:pub mod schema
-src/parser/ingest/mod.rs:14:pub use schema::*
-src/parser/ingest/mod.rs:19:pub fn parse_ingest_bytes(bytes: &[u8]) -> Result<IngestDocument, HwpError>
-src/parser/ingest/mod.rs:25:pub fn parse_ingest_str(s: &str) -> Result<IngestDocument, HwpError>
-src/parser/ingest/schema.rs:109:pub enum StemBlock
-src/parser/ingest/schema.rs:134:pub struct Choice
-src/parser/ingest/schema.rs:143:pub struct Media
-src/parser/ingest/schema.rs:162:pub enum Placement
-src/parser/ingest/schema.rs:54:pub struct PageSize
-src/parser/ingest/schema.rs:61:pub struct Passage
-src/parser/ingest/schema.rs:71:pub struct Question
-src/parser/ingest/schema.rs:9:pub struct IngestDocument
-src/parser/mod.rs:1043:pub fn parse_document(data: &[u8]) -> Result<Document, ParseError>
-src/parser/mod.rs:1080:pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult>
-src/parser/mod.rs:108:pub enum ParseError
-src/parser/mod.rs:1178:pub struct ThumbnailResult
-src/parser/mod.rs:175:pub fn parse_hwp(data: &[u8]) -> Result<Document, ParseError>
-src/parser/mod.rs:18:pub mod bin_data
-src/parser/mod.rs:19:pub mod body_text
-src/parser/mod.rs:20:pub mod byte_reader
-src/parser/mod.rs:21:pub mod cfb_reader
-src/parser/mod.rs:22:pub mod control
-src/parser/mod.rs:23:pub mod crypto
-src/parser/mod.rs:24:pub mod doc_info
-src/parser/mod.rs:25:pub mod header
-src/parser/mod.rs:26:pub mod hml
-src/parser/mod.rs:27:pub mod hwp3
-src/parser/mod.rs:28:pub mod hwpx
-src/parser/mod.rs:29:pub mod ingest
-src/parser/mod.rs:30:pub mod ole_container
-src/parser/mod.rs:31:pub mod record
-src/parser/mod.rs:32:pub mod tags
-src/parser/mod.rs:42:pub enum FileFormat
-src/parser/mod.rs:76:pub fn detect_format(data: &[u8]) -> FileFormat
-src/parser/mod.rs:937:pub trait DocumentParser
-src/parser/mod.rs:942:pub struct HwpParser
-src/parser/mod.rs:951:pub struct HwpxParser
-src/parser/mod.rs:960:pub struct Hwp3Parser
-src/parser/mod.rs:969:pub struct HmlParser
-src/parser/mod.rs:980:pub struct HmlImportMetadata
-src/parser/mod.rs:991:pub struct ParsedDocument
-src/parser/mod.rs:997:pub fn parse_document_with_metadata(data: &[u8]) -> Result<ParsedDocument, ParseError>
-src/parser/ole_container.rs:11:pub enum NativeImageKind
-src/parser/ole_container.rs:162:pub fn is_hmapsi_ole_container(cfb_bytes: &[u8]) -> bool
-src/parser/ole_container.rs:171:pub fn detect_native_image(data: &[u8]) -> Option<(NativeImageKind, Vec<u8>)>
-src/parser/ole_container.rs:19: pub fn mime(&self) -> &'static str
-src/parser/ole_container.rs:31:pub struct OleContainer
-src/parser/ole_container.rs:44: pub fn has_ooxml_chart(&self) -> bool
-src/parser/ole_container.rs:49: pub fn has_preview(&self) -> bool
-src/parser/ole_container.rs:58:pub fn parse_ole_container(cfb_bytes: &[u8]) -> Option<OleContainer>
-src/parser/record.rs:101:pub enum RecordError
-src/parser/record.rs:16:pub struct Record
-src/parser/record.rs:29: pub fn tag_name(&self) -> &'static str
-src/parser/record.rs:34: pub fn read_all(data: &[u8]) -> Result<Vec<Record>, RecordError>
-src/parser/tags.rs:100:pub const HWPTAG_FORM_OBJECT: u16 = HWPTAG_BEGIN + 75
-src/parser/tags.rs:102:pub const HWPTAG_MEMO_SHAPE: u16 = HWPTAG_BEGIN + 76
-src/parser/tags.rs:104:pub const HWPTAG_MEMO_LIST: u16 = HWPTAG_BEGIN + 77
-src/parser/tags.rs:106:pub const HWPTAG_FORBIDDEN_CHAR: u16 = HWPTAG_BEGIN + 78
-src/parser/tags.rs:108:pub const HWPTAG_CHART_DATA: u16 = HWPTAG_BEGIN + 79
-src/parser/tags.rs:115:pub const CHAR_SECTION_COLUMN_DEF: u16 = 0x0002
-src/parser/tags.rs:117:pub const CHAR_FIELD_BEGIN: u16 = 0x0003
-src/parser/tags.rs:119:pub const CHAR_FIELD_END: u16 = 0x0004
-src/parser/tags.rs:121:pub const CHAR_INLINE_NON_TEXT: u16 = 0x0008
-src/parser/tags.rs:123:pub const CHAR_EXTENDED_CTRL: u16 = 0x000B
-src/parser/tags.rs:125:pub const CHAR_LINE_BREAK: u16 = 0x000A
-src/parser/tags.rs:127:pub const CHAR_PARA_BREAK: u16 = 0x000D
-src/parser/tags.rs:129:pub const CHAR_HYPHEN: u16 = 0x0018
-src/parser/tags.rs:131:pub const CHAR_NBSPACE: u16 = 0x001E
-src/parser/tags.rs:133:pub const CHAR_FIXED_WIDTH_SPACE: u16 = 0x0019
-src/parser/tags.rs:135:pub const CHAR_FIXED_WIDTH_SPACE_31: u16 = 0x001F
-src/parser/tags.rs:13:pub const HWPTAG_DOCUMENT_PROPERTIES: u16 = HWPTAG_BEGIN
-src/parser/tags.rs:142:pub const CTRL_SECTION_DEF: u32 = ctrl_id(b"secd")
-src/parser/tags.rs:144:pub const CTRL_COLUMN_DEF: u32 = ctrl_id(b"cold")
-src/parser/tags.rs:146:pub const CTRL_TABLE: u32 = ctrl_id(b"tbl ")
-src/parser/tags.rs:148:pub const CTRL_EQUATION: u32 = ctrl_id(b"eqed")
-src/parser/tags.rs:150:pub const CTRL_GEN_SHAPE: u32 = ctrl_id(b"gso ")
-src/parser/tags.rs:152:pub const SHAPE_PICTURE_ID: u32 = ctrl_id(b"$pic")
-src/parser/tags.rs:154:pub const SHAPE_OLE_ID: u32 = ctrl_id(b"$ole")
-src/parser/tags.rs:156:pub const SHAPE_RECT_ID: u32 = ctrl_id(b"$rec")
-src/parser/tags.rs:158:pub const SHAPE_LINE_ID: u32 = ctrl_id(b"$lin")
-src/parser/tags.rs:15:pub const HWPTAG_ID_MAPPINGS: u16 = HWPTAG_BEGIN + 1
-src/parser/tags.rs:160:pub const SHAPE_ELLIPSE_ID: u32 = ctrl_id(b"$ell")
-src/parser/tags.rs:162:pub const SHAPE_POLYGON_ID: u32 = ctrl_id(b"$pol")
-src/parser/tags.rs:164:pub const SHAPE_ARC_ID: u32 = ctrl_id(b"$arc")
-src/parser/tags.rs:166:pub const SHAPE_CURVE_ID: u32 = ctrl_id(b"$cur")
-src/parser/tags.rs:168:pub const SHAPE_CONNECTOR_ID: u32 = ctrl_id(b"$col")
-src/parser/tags.rs:170:pub const SHAPE_CONTAINER_ID: u32 = ctrl_id(b"$con")
-src/parser/tags.rs:172:pub const CTRL_HEADER: u32 = ctrl_id(b"head")
-src/parser/tags.rs:174:pub const CTRL_FOOTER: u32 = ctrl_id(b"foot")
-src/parser/tags.rs:176:pub const CTRL_FOOTNOTE: u32 = ctrl_id(b"fn ")
-src/parser/tags.rs:178:pub const CTRL_ENDNOTE: u32 = ctrl_id(b"en ")
-src/parser/tags.rs:17:pub const HWPTAG_BIN_DATA: u16 = HWPTAG_BEGIN + 2
-src/parser/tags.rs:180:pub const CTRL_AUTO_NUMBER: u32 = ctrl_id(b"atno")
-src/parser/tags.rs:182:pub const CTRL_NEW_NUMBER: u32 = ctrl_id(b"nwno")
-src/parser/tags.rs:184:pub const CTRL_PAGE_NUM_POS: u32 = ctrl_id(b"pgnp")
-src/parser/tags.rs:186:pub const CTRL_PAGE_HIDE: u32 = ctrl_id(b"pghd")
-src/parser/tags.rs:188:pub const CTRL_INDEX_MARK: u32 = ctrl_id(b"idxm")
-src/parser/tags.rs:190:pub const CTRL_BOOKMARK: u32 = ctrl_id(b"bokm")
-src/parser/tags.rs:192:pub const CTRL_TCPS: u32 = ctrl_id(b"tcps")
-src/parser/tags.rs:194:pub const CTRL_FORM: u32 = ctrl_id(b"form")
-src/parser/tags.rs:196:pub const CTRL_CHAR_OVERLAP: u32 = ctrl_id(b"tdut")
-src/parser/tags.rs:198:pub const CTRL_HIDDEN_COMMENT: u32 = ctrl_id(b"tcmt")
-src/parser/tags.rs:19:pub const HWPTAG_FACE_NAME: u16 = HWPTAG_BEGIN + 3
-src/parser/tags.rs:205:pub const FIELD_CLICKHERE: u32 = ctrl_id(b"%clk")
-src/parser/tags.rs:207:pub const FIELD_HYPERLINK: u32 = ctrl_id(b"%hlk")
-src/parser/tags.rs:209:pub const FIELD_BOOKMARK: u32 = ctrl_id(b"%bmk")
-src/parser/tags.rs:211:pub const FIELD_DATE: u32 = ctrl_id(b"%dte")
-src/parser/tags.rs:213:pub const FIELD_DOCDATE: u32 = ctrl_id(b"%ddt")
-src/parser/tags.rs:215:pub const FIELD_PATH: u32 = ctrl_id(b"%pat")
-src/parser/tags.rs:217:pub const FIELD_MAILMERGE: u32 = ctrl_id(b"%mmg")
-src/parser/tags.rs:219:pub const FIELD_CROSSREF: u32 = ctrl_id(b"%xrf")
-src/parser/tags.rs:21:pub const HWPTAG_BORDER_FILL: u16 = HWPTAG_BEGIN + 4
-src/parser/tags.rs:221:pub const FIELD_FORMULA: u32 = ctrl_id(b"%fmu")
-src/parser/tags.rs:223:pub const FIELD_SUMMARY: u32 = ctrl_id(b"%smr")
-src/parser/tags.rs:225:pub const FIELD_USERINFO: u32 = ctrl_id(b"%usr")
-src/parser/tags.rs:227:pub const FIELD_MEMO: u32 = ctrl_id(b"%%me")
-src/parser/tags.rs:229:pub const FIELD_PRIVATE_INFO: u32 = ctrl_id(b"%cpr")
-src/parser/tags.rs:231:pub const FIELD_TOC: u32 = ctrl_id(b"%toc")
-src/parser/tags.rs:233:pub const FIELD_UNKNOWN: u32 = ctrl_id(b"%unk")
-src/parser/tags.rs:236:pub const fn is_field_ctrl_id(id: u32) -> bool
-src/parser/tags.rs:23:pub const HWPTAG_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 5
-src/parser/tags.rs:250:pub fn tag_name(tag_id: u16) -> &'static str
-src/parser/tags.rs:25:pub const HWPTAG_TAB_DEF: u16 = HWPTAG_BEGIN + 6
-src/parser/tags.rs:27:pub const HWPTAG_NUMBERING: u16 = HWPTAG_BEGIN + 7
-src/parser/tags.rs:29:pub const HWPTAG_BULLET: u16 = HWPTAG_BEGIN + 8
-src/parser/tags.rs:302:pub fn ctrl_name(ctrl_id: u32) -> &'static str
-src/parser/tags.rs:31:pub const HWPTAG_PARA_SHAPE: u16 = HWPTAG_BEGIN + 9
-src/parser/tags.rs:33:pub const HWPTAG_STYLE: u16 = HWPTAG_BEGIN + 10
-src/parser/tags.rs:35:pub const HWPTAG_DOC_DATA: u16 = HWPTAG_BEGIN + 11
-src/parser/tags.rs:37:pub const HWPTAG_DISTRIBUTE_DOC_DATA: u16 = HWPTAG_BEGIN + 12
-src/parser/tags.rs:40:pub const HWPTAG_COMPATIBLE_DOCUMENT: u16 = HWPTAG_BEGIN + 14
-src/parser/tags.rs:42:pub const HWPTAG_LAYOUT_COMPATIBILITY: u16 = HWPTAG_BEGIN + 15
-src/parser/tags.rs:44:pub const HWPTAG_TRACKCHANGE: u16 = HWPTAG_BEGIN + 16
-src/parser/tags.rs:51:pub const HWPTAG_PARA_HEADER: u16 = HWPTAG_BEGIN + 50
-src/parser/tags.rs:53:pub const HWPTAG_PARA_TEXT: u16 = HWPTAG_BEGIN + 51
-src/parser/tags.rs:55:pub const HWPTAG_PARA_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 52
-src/parser/tags.rs:57:pub const HWPTAG_PARA_LINE_SEG: u16 = HWPTAG_BEGIN + 53
-src/parser/tags.rs:59:pub const HWPTAG_PARA_RANGE_TAG: u16 = HWPTAG_BEGIN + 54
-src/parser/tags.rs:61:pub const HWPTAG_CTRL_HEADER: u16 = HWPTAG_BEGIN + 55
-src/parser/tags.rs:63:pub const HWPTAG_LIST_HEADER: u16 = HWPTAG_BEGIN + 56
-src/parser/tags.rs:65:pub const HWPTAG_PAGE_DEF: u16 = HWPTAG_BEGIN + 57
-src/parser/tags.rs:67:pub const HWPTAG_FOOTNOTE_SHAPE: u16 = HWPTAG_BEGIN + 58
-src/parser/tags.rs:69:pub const HWPTAG_PAGE_BORDER_FILL: u16 = HWPTAG_BEGIN + 59
-src/parser/tags.rs:6:pub const HWPTAG_BEGIN: u16 = 0x010
-src/parser/tags.rs:71:pub const HWPTAG_SHAPE_COMPONENT: u16 = HWPTAG_BEGIN + 60
-src/parser/tags.rs:73:pub const HWPTAG_TABLE: u16 = HWPTAG_BEGIN + 61
-src/parser/tags.rs:75:pub const HWPTAG_SHAPE_COMPONENT_LINE: u16 = HWPTAG_BEGIN + 62
-src/parser/tags.rs:77:pub const HWPTAG_SHAPE_COMPONENT_RECTANGLE: u16 = HWPTAG_BEGIN + 63
-src/parser/tags.rs:79:pub const HWPTAG_SHAPE_COMPONENT_ELLIPSE: u16 = HWPTAG_BEGIN + 64
-src/parser/tags.rs:81:pub const HWPTAG_SHAPE_COMPONENT_ARC: u16 = HWPTAG_BEGIN + 65
-src/parser/tags.rs:83:pub const HWPTAG_SHAPE_COMPONENT_POLYGON: u16 = HWPTAG_BEGIN + 66
-src/parser/tags.rs:85:pub const HWPTAG_SHAPE_COMPONENT_CURVE: u16 = HWPTAG_BEGIN + 67
-src/parser/tags.rs:87:pub const HWPTAG_SHAPE_COMPONENT_OLE: u16 = HWPTAG_BEGIN + 68
-src/parser/tags.rs:89:pub const HWPTAG_SHAPE_COMPONENT_PICTURE: u16 = HWPTAG_BEGIN + 69
-src/parser/tags.rs:91:pub const HWPTAG_SHAPE_COMPONENT_CONTAINER: u16 = HWPTAG_BEGIN + 70
-src/parser/tags.rs:93:pub const HWPTAG_CTRL_DATA: u16 = HWPTAG_BEGIN + 71
-src/parser/tags.rs:95:pub const HWPTAG_EQEDIT: u16 = HWPTAG_BEGIN + 72
-src/parser/tags.rs:98:pub const HWPTAG_SHAPE_COMPONENT_TEXTART: u16 = HWPTAG_BEGIN + 74
-src/renderer/canvas.rs:16:pub struct CanvasRenderer
-src/renderer/canvas.rs:27:pub enum CanvasCommand
-src/renderer/canvas.rs:64: pub fn new() -> Self
-src/renderer/canvas.rs:73: pub fn commands(&self) -> &[CanvasCommand]
-src/renderer/canvas.rs:78: pub fn command_count(&self) -> usize
-src/renderer/canvas.rs:83: pub fn render_tree(&mut self, tree: &PageRenderTree)
-src/renderer/canvas.rs:88: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
-src/renderer/canvaskit_policy.rs:112:pub enum CanvasKitReplayFeature
-src/renderer/canvaskit_policy.rs:129:pub enum CanvasKitReplayStatus
-src/renderer/canvaskit_policy.rs:139:pub enum CanvasKitReplayReason
-src/renderer/canvaskit_policy.rs:150:pub struct CanvasKitTextVariantReport
-src/renderer/canvaskit_policy.rs:163:pub struct CanvasKitRejectedTextVariant
-src/renderer/canvaskit_policy.rs:169:pub fn analyze_canvaskit_replay_plan(
-src/renderer/canvaskit_policy.rs:27:pub enum CanvasKitReplayMode
-src/renderer/canvaskit_policy.rs:33: pub fn from_str(value: &str) -> Option<Self>
-src/renderer/canvaskit_policy.rs:41: pub fn as_str(self) -> &'static str
-src/renderer/canvaskit_policy.rs:74:pub struct CanvasKitReplayPlan
-src/renderer/canvaskit_policy.rs:85:pub struct CanvasKitReplaySummary
-src/renderer/canvaskit_policy.rs:97:pub struct CanvasKitReplayItem
-src/renderer/composer.rs:108:pub fn compose_section(section: &Section) -> Vec<ComposedParagraph>
-src/renderer/composer.rs:1263:pub fn estimate_composed_line_width(line: &ComposedLine, styles: &ResolvedStyleSet) -> f64
-src/renderer/composer.rs:1419:pub fn recompose_for_body_width(
-src/renderer/composer.rs:1437:pub fn recompose_stored_single_line_if_overflowing(
-src/renderer/composer.rs:1476:pub fn stored_lines_overflow(
-src/renderer/composer.rs:1530:pub fn recompose_stored_lines_if_overflowing_body(
-src/renderer/composer.rs:1544:pub fn recompose_for_cell_width(
-src/renderer/composer.rs:16:pub struct CharOverlapInfo
-src/renderer/composer.rs:2230:pub fn effective_text_for_metrics(run: &ComposedTextRun) -> &str
-src/renderer/composer.rs:2288:pub fn decode_pua_overlap_number(chars: &[char]) -> Option<String>
-src/renderer/composer.rs:2308:pub fn char_overlap_advance_units(chars: &[char]) -> usize
-src/renderer/composer.rs:2364:pub fn expand_pua_display_text(text: &str) -> String
-src/renderer/composer.rs:2386:pub fn expand_pua_render_text(text: &str) -> String
-src/renderer/composer.rs:2393:pub fn pua_to_display_text(ch: char) -> Option<String>
-src/renderer/composer.rs:2490:pub mod lineseg_compare
-src/renderer/composer.rs:25:pub struct ComposedTextRun
-src/renderer/composer.rs:263:pub fn compose_paragraph(para: &Paragraph) -> ComposedParagraph
-src/renderer/composer.rs:44:pub struct ComposedLine
-src/renderer/composer.rs:65:pub enum InlineControlType
-src/renderer/composer.rs:76:pub struct InlineControl
-src/renderer/composer.rs:87:pub struct ComposedParagraph
-src/renderer/composer/lineseg_compare.rs:10:pub struct LineSegFieldDiff
-src/renderer/composer/lineseg_compare.rs:133:pub struct AvgFieldDeltas
-src/renderer/composer/lineseg_compare.rs:145:pub fn compare_line_segs(
-src/renderer/composer/lineseg_compare.rs:180:pub fn format_report(reports: &[SectionLineSegReport]) -> String
-src/renderer/composer/lineseg_compare.rs:23: pub fn text_start_match(&self) -> bool
-src/renderer/composer/lineseg_compare.rs:28: pub fn all_match(&self) -> bool
-src/renderer/composer/lineseg_compare.rs:40:pub struct ParagraphLineSegDiff
-src/renderer/composer/lineseg_compare.rs:50: pub fn line_breaks_match(&self) -> bool
-src/renderer/composer/lineseg_compare.rs:55: pub fn all_match(&self) -> bool
-src/renderer/composer/lineseg_compare.rs:62:pub struct SectionLineSegReport
-src/renderer/composer/lineseg_compare.rs:73: pub fn line_count_match_rate(&self) -> f64
-src/renderer/composer/lineseg_compare.rs:80: pub fn line_break_match_rate(&self) -> f64
-src/renderer/composer/lineseg_compare.rs:87: pub fn all_match_rate(&self) -> f64
-src/renderer/composer/lineseg_compare.rs:95: pub fn avg_field_deltas(&self) -> AvgFieldDeltas
-src/renderer/equation/ast.rs:153:pub enum PileAlign
-src/renderer/equation/ast.rs:161: pub fn simplify(self) -> Self
-src/renderer/equation/ast.rs:18:pub enum SpaceKind
-src/renderer/equation/ast.rs:26:pub enum EqNode
-src/renderer/equation/ast.rs:9:pub enum MatrixStyle
-src/renderer/equation/canvas_render.rs:12:pub fn render_equation_canvas(
-src/renderer/equation/layout.rs:10:pub struct LayoutBox
-src/renderer/equation/layout.rs:122:pub struct EqLayout
-src/renderer/equation/layout.rs:197: pub fn new(font_size: f64) -> Self
-src/renderer/equation/layout.rs:202: pub fn layout(&self, node: &EqNode) -> LayoutBox
-src/renderer/equation/layout.rs:27:pub enum LayoutKind
-src/renderer/equation/mod.rs:10:pub mod parser
-src/renderer/equation/mod.rs:11:pub mod svg_render
-src/renderer/equation/mod.rs:12:pub mod symbols
-src/renderer/equation/mod.rs:13:pub mod tokenizer
-src/renderer/equation/mod.rs:16:pub fn intrinsic_size_hwp(script: &str, font_size: u32) -> (u32, u32)
-src/renderer/equation/mod.rs:6:pub mod ast
-src/renderer/equation/mod.rs:8:pub mod canvas_render
-src/renderer/equation/mod.rs:9:pub mod layout
-src/renderer/equation/parser.rs:13:pub struct EqParser
-src/renderer/equation/parser.rs:1628:pub fn parse(script: &str) -> EqNode
-src/renderer/equation/parser.rs:19: pub fn new(tokens: Vec<Token>) -> Self
-src/renderer/equation/parser.rs:92: pub fn parse(&mut self) -> EqNode
-src/renderer/equation/svg_render.rs:13:pub const DEFAULT_EQUATION_FONT_FAMILY_ATTR: &str =
-src/renderer/equation/svg_render.rs:21:pub fn render_equation_svg(layout: &LayoutBox, color: &str, base_font_size: f64) -> String
-src/renderer/equation/svg_render.rs:676:pub fn eq_color_to_svg(color: u32) -> String
-src/renderer/equation/symbols.rs:457:pub static DECORATIONS: LazyLock<HashMap<&'static str, DecoKind>> = LazyLock::new(||
-src/renderer/equation/symbols.rs:488:pub static FONT_STYLES: LazyLock<HashMap<&'static str, FontStyleKind>> = LazyLock::new(||
-src/renderer/equation/symbols.rs:509:pub fn is_structure_command(cmd: &str) -> bool
-src/renderer/equation/symbols.rs:567:pub fn is_big_operator(cmd: &str) -> bool
-src/renderer/equation/symbols.rs:572:pub fn is_function(cmd: &str) -> bool
-src/renderer/equation/symbols.rs:581:pub fn lookup_symbol(cmd: &str) -> Option<&'static str>
-src/renderer/equation/symbols.rs:612:pub fn lookup_function(cmd: &str) -> Option<&'static str>
-src/renderer/equation/symbols.rs:625:pub fn lookup_equation_pua(ch: char) -> Option<&'static str>
-src/renderer/equation/symbols.rs:631:pub enum DecoKind
-src/renderer/equation/symbols.rs:651:pub enum FontStyleKind
-src/renderer/equation/tokenizer.rs:27:pub struct Token
-src/renderer/equation/tokenizer.rs:326: pub fn next_token(&mut self) -> Token
-src/renderer/equation/tokenizer.rs:37: pub fn new(ty: TokenType, value: impl Into<String>, pos: usize) -> Self
-src/renderer/equation/tokenizer.rs:46: pub fn eof(pos: usize) -> Self
-src/renderer/equation/tokenizer.rs:485: pub fn tokenize(mut self) -> Vec<Token>
-src/renderer/equation/tokenizer.rs:57:pub struct Tokenizer
-src/renderer/equation/tokenizer.rs:586:pub fn tokenize(script: &str) -> Vec<Token>
-src/renderer/equation/tokenizer.rs:65: pub fn new(script: &str) -> Self
-src/renderer/equation/tokenizer.rs:7:pub enum TokenType
-src/renderer/font_metrics_data.rs:151:pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch>
-src/renderer/font_metrics_data.rs:18:pub struct FontMetric
-src/renderer/font_metrics_data.rs:28:pub struct LatinRange
-src/renderer/font_metrics_data.rs:35: pub fn get_width(&self, ch: char) -> Option<u16>
-src/renderer/font_metrics_data.rs:41068:pub static FONT_METRICS: [FontMetric
-src/renderer/font_metrics_data.rs:63:pub struct MetricMatch
-src/renderer/font_metrics_data.rs:7:pub struct HangulMetric
-src/renderer/height_measurer.rs:145:pub struct MeasuredParagraph
-src/renderer/height_measurer.rs:169: pub fn line_advance(&self, line_idx: usize) -> f64
-src/renderer/height_measurer.rs:174: pub fn line_advances_sum(&self, range: std::ops::Range<usize>) -> f64
-src/renderer/height_measurer.rs:184:pub struct MeasuredTable
-src/renderer/height_measurer.rs:20:pub fn is_tac_table_inline(
-src/renderer/height_measurer.rs:218:pub fn fit_measured_table_to_declared_height(
-src/renderer/height_measurer.rs:2196: pub fn measure_section_incremental(
-src/renderer/height_measurer.rs:2257: pub fn measure_section_selective(
-src/renderer/height_measurer.rs:2392: pub fn remaining_content_for_row(&self, row: usize, content_offset: f64) -> f64
-src/renderer/height_measurer.rs:2468: pub fn max_padding_for_row(&self, row: usize) -> f64
-src/renderer/height_measurer.rs:2477: pub fn effective_row_height(&self, row: usize, content_offset: f64) -> f64
-src/renderer/height_measurer.rs:2486: pub fn is_row_splittable(&self, row: usize) -> bool
-src/renderer/height_measurer.rs:2503: pub fn min_first_line_height_for_row(&self, row: usize, content_offset: f64) -> f64
-src/renderer/height_measurer.rs:2536: pub fn find_break_row(
-src/renderer/height_measurer.rs:2561: pub fn range_height(&self, start_row: usize, end_row: usize) -> f64
-src/renderer/height_measurer.rs:2576: pub fn row_block_for(&self, row: usize) -> (usize, usize, f64)
-src/renderer/height_measurer.rs:2593: pub fn snap_to_block_boundary(&self, end_row: usize) -> usize
-src/renderer/height_measurer.rs:2625: pub fn allows_row_break_split(&self) -> bool
-src/renderer/height_measurer.rs:2635:pub const BLOCK_UNIT_MAX_ROWS: usize = 3
-src/renderer/height_measurer.rs:2710: pub fn get_paragraph_height(&self, para_index: usize) -> Option<f64>
-src/renderer/height_measurer.rs:2715: pub fn get_table_height(&self, para_index: usize, control_index: usize) -> Option<f64>
-src/renderer/height_measurer.rs:2723: pub fn get_measured_table(
-src/renderer/height_measurer.rs:2734: pub fn get_measured_paragraph(&self, para_index: usize) -> Option<&MeasuredParagraph>
-src/renderer/height_measurer.rs:2739: pub fn paragraph_has_table(&self, para_index: usize) -> bool
-src/renderer/height_measurer.rs:273:pub struct MeasuredCell
-src/renderer/height_measurer.rs:2748: pub fn shift_for_insert(&mut self, insert_at: usize)
-src/renderer/height_measurer.rs:2778: pub fn shift_for_remove(&mut self, remove_at: usize)
-src/renderer/height_measurer.rs:2802: pub fn estimate_footnote_area_height(
-src/renderer/height_measurer.rs:2854: pub fn estimate_single_footnote_height(&self, footnote: &Footnote) -> f64
-src/renderer/height_measurer.rs:300:pub struct MeasuredSection
-src/renderer/height_measurer.rs:308:pub struct HeightMeasurer
-src/renderer/height_measurer.rs:315: pub fn new(dpi: f64) -> Self
-src/renderer/height_measurer.rs:323: pub fn with_hwp3_variant(mut self, enabled: bool) -> Self
-src/renderer/height_measurer.rs:329: pub fn with_hwp3_origin_flow_spacing_before(mut self, enabled: bool) -> Self
-src/renderer/height_measurer.rs:334: pub fn with_default_dpi() -> Self
-src/renderer/height_measurer.rs:442: pub fn measure_section(
-src/renderer/height_measurer.rs:58:pub fn is_tac_table_inline_in_para(table: &Table, seg_width: i32, para: &Paragraph) -> bool
-src/renderer/height_measurer.rs:846: pub fn cell_controls_height(
-src/renderer/html.rs:17:pub struct HtmlRenderer
-src/renderer/html.rs:31: pub fn new() -> Self
-src/renderer/html.rs:42: pub fn output(&self) -> &str
-src/renderer/html.rs:47: pub fn render_tree(&mut self, tree: &PageRenderTree)
-src/renderer/layer_renderer.rs:104: pub fn as_str(self) -> &'static str
-src/renderer/layer_renderer.rs:115:pub enum VariantSelectedReason
-src/renderer/layer_renderer.rs:123: pub fn as_str(self) -> &'static str
-src/renderer/layer_renderer.rs:134:pub enum VariantRejectReason
-src/renderer/layer_renderer.rs:171: pub fn as_str(self) -> &'static str
-src/renderer/layer_renderer.rs:17:pub type LayerRenderResult<T> = Result<T, HwpError>
-src/renderer/layer_renderer.rs:20:pub trait LayerRenderer
-src/renderer/layer_renderer.rs:213:pub struct TextVariantSelectionOptions
-src/renderer/layer_renderer.rs:235: pub fn canvaskit() -> Self
-src/renderer/layer_renderer.rs:249: pub fn canvaskit_strict_outline() -> Self
-src/renderer/layer_renderer.rs:258:pub struct TextVariantSelectionReport
-src/renderer/layer_renderer.rs:25:pub struct RasterRenderOptions
-src/renderer/layer_renderer.rs:269:pub struct TextVariantRejectReport
-src/renderer/layer_renderer.rs:275:pub fn analyze_text_variant_selection(
-src/renderer/layer_renderer.rs:52:pub enum RasterColorSpace
-src/renderer/layer_renderer.rs:57:pub enum RasterOutputFormat
-src/renderer/layer_renderer.rs:62:pub struct RasterRenderOutput
-src/renderer/layer_renderer.rs:72:pub trait LayerRasterRenderer
-src/renderer/layer_renderer.rs:96:pub enum VariantSelectionBackend
-src/renderer/layout.rs:1007:pub struct LayoutOverflow
-src/renderer/layout.rs:1243:pub struct LayoutEngine
-src/renderer/layout.rs:1379:pub use paragraph_layout::map_pua_bullet_char
-src/renderer/layout.rs:1391: pub fn new(dpi: f64) -> Self
-src/renderer/layout.rs:1434: pub fn clear_layout_caches(&self)
-src/renderer/layout.rs:1440: pub fn with_default_dpi() -> Self
-src/renderer/layout.rs:1445: pub fn take_overflows(&self) -> Vec<LayoutOverflow>
-src/renderer/layout.rs:1613: pub fn set_hidden_empty_paras(&self, paras: &std::collections::HashSet<usize>)
-src/renderer/layout.rs:1618: pub fn set_pre_emitted_host_paras(&self, paras: &std::collections::HashSet<usize>)
-src/renderer/layout.rs:1623: pub fn set_pre_emitted_host_heights(&self, heights: &std::collections::HashMap<usize, f64>)
-src/renderer/layout.rs:1628: pub fn set_endnote_para_sources(&self, base: usize, sources: &[EndnoteParaSource])
-src/renderer/layout.rs:1657: pub fn set_endnote_between_notes_hu(&self, between_notes_hu: i32)
-src/renderer/layout.rs:1662: pub fn set_endnote_shape_margins_hu(
-src/renderer/layout.rs:1734: pub fn reset_numbering_state(&self)
-src/renderer/layout.rs:1738: pub fn set_hwp3_variant(&self, enabled: bool)
-src/renderer/layout.rs:1743: pub fn set_hwp3_origin_flow_spacing_before(&self, enabled: bool)
-src/renderer/layout.rs:1748: pub fn set_hwpx_source(&self, enabled: bool)
-src/renderer/layout.rs:1753: pub fn set_hwpx_page_preview(&self, data: Option<&[u8]>)
-src/renderer/layout.rs:1791: pub fn advance_numbering(&self, numbering_id: u16, level: u8)
-src/renderer/layout.rs:1798: pub fn set_clip_enabled(&self, enabled: bool)
-src/renderer/layout.rs:1803: pub fn set_show_transparent_borders(&self, enabled: bool)
-src/renderer/layout.rs:1808: pub fn set_hidden_header_footer(&self, hidden: &std::collections::HashSet<(u32, bool)>)
-src/renderer/layout.rs:1813: pub fn set_total_pages(&self, total: u32)
-src/renderer/layout.rs:1819: pub fn set_current_page_is_section_first(&self, is_first: bool)
-src/renderer/layout.rs:1824: pub fn set_file_name(&self, name: &str)
-src/renderer/layout.rs:1829: pub fn set_active_field(
-src/renderer/layout.rs:1837: pub fn set_show_control_codes(&self, enabled: bool)
-src/renderer/layout.rs:1842: pub fn reset_auto_counter(&self)
-src/renderer/layout.rs:1851: pub fn build_render_tree(
-src/renderer/layout.rs:513:pub struct CellPathEntry
-src/renderer/layout.rs:526:pub struct CellContext
-src/renderer/layout.rs:557: pub fn outermost_control(&self) -> usize
-src/renderer/layout.rs:561: pub fn outermost_cell(&self) -> usize
-src/renderer/layout.rs:565: pub fn outermost_cell_para(&self) -> usize
-src/renderer/layout.rs:569: pub fn innermost(&self) -> &CellPathEntry
-src/renderer/layout.rs:573: pub fn text_direction(&self) -> u8
-src/renderer/layout.rs:580: pub fn last_image_indices(&self) -> (Option<usize>, Option<usize>, Option<usize>)
-src/renderer/layout/paragraph_layout.rs:6581:pub fn map_pua_bullet_char(ch: char) -> char
-src/renderer/layout/text_measurement.rs:1045:pub struct WasmTextMeasurer
-src/renderer/layout/text_measurement.rs:15:pub trait TextMeasurer
-src/renderer/layout/text_measurement.rs:1925:pub fn split_into_clusters(text: &str) -> Vec<(usize, String)>
-src/renderer/layout/text_measurement.rs:2030: pub struct MockTextMeasurer
-src/renderer/layout/text_measurement.rs:203:pub fn extract_tab_leaders(text: &str, positions: &[f64], style: &TextStyle) -> Vec<TabLeaderInfo>
-src/renderer/layout/text_measurement.rs:209:pub fn extract_tab_leaders_with_extended(
-src/renderer/layout/text_measurement.rs:451:pub struct EmbeddedTextMeasurer
-src/renderer/layout/utils.rs:84:pub fn resolve_numbering_id(
-src/renderer/mod.rs:1062:pub struct AutoNumberCounter
-src/renderer/mod.rs:1079: pub fn new() -> Self
-src/renderer/mod.rs:1084: pub fn increment(&mut self, number_type: AutoNumberType) -> u16
-src/renderer/mod.rs:1114: pub fn current(&self, number_type: AutoNumberType) -> u16
-src/renderer/mod.rs:1126: pub fn reset(&mut self)
-src/renderer/mod.rs:1133:pub enum NumberFormat
-src/renderer/mod.rs:1157: pub fn from_hwp_format(format: u8) -> Self
-src/renderer/mod.rs:115:pub struct TextStyle
-src/renderer/mod.rs:1174:pub fn format_number(number: u16, format: NumberFormat) -> String
-src/renderer/mod.rs:11:pub mod canvas
-src/renderer/mod.rs:12:pub mod canvaskit_policy
-src/renderer/mod.rs:13:pub mod composer
-src/renderer/mod.rs:14:pub mod equation
-src/renderer/mod.rs:16:pub mod float_placement
-src/renderer/mod.rs:17:pub mod font_metrics_data
-src/renderer/mod.rs:19:pub mod height_cursor
-src/renderer/mod.rs:208: pub fn is_visually_bold(&self) -> bool
-src/renderer/mod.rs:20:pub mod height_measurer
-src/renderer/mod.rs:215: pub fn is_medium_weight(&self) -> bool
-src/renderer/mod.rs:21:pub mod html
-src/renderer/mod.rs:220: pub fn css_font_weight(&self) -> Option<&'static str>
-src/renderer/mod.rs:22:pub mod image_resolver
-src/renderer/mod.rs:23:pub mod layer_renderer
-src/renderer/mod.rs:24:pub mod layout
-src/renderer/mod.rs:25:pub mod page_layout
-src/renderer/mod.rs:26:pub mod page_number
-src/renderer/mod.rs:278:pub struct PatternFillInfo
-src/renderer/mod.rs:27:pub mod pagination
-src/renderer/mod.rs:289:pub struct ShapeStyle
-src/renderer/mod.rs:29:pub mod pdf
-src/renderer/mod.rs:308:pub struct ShadowStyle
-src/renderer/mod.rs:30:pub mod pua_oldhangul
-src/renderer/mod.rs:31:pub mod render_tree
-src/renderer/mod.rs:32:pub mod scheduler
-src/renderer/mod.rs:337:pub struct GradientFillInfo
-src/renderer/mod.rs:34:pub mod skia
-src/renderer/mod.rs:354:pub struct LineStyle
-src/renderer/mod.rs:36:pub mod style_resolver
-src/renderer/mod.rs:377:pub enum StrokeDash
-src/renderer/mod.rs:37:pub mod svg
-src/renderer/mod.rs:388:pub enum LineRenderType
-src/renderer/mod.rs:38:pub mod svg_fragment
-src/renderer/mod.rs:39:pub mod svg_layer
-src/renderer/mod.rs:403:pub enum ArrowStyle
-src/renderer/mod.rs:40:pub mod typeset
-src/renderer/mod.rs:426:pub enum PathCommand
-src/renderer/mod.rs:42:pub mod web_canvas
-src/renderer/mod.rs:440:pub fn svg_arc_to_beziers(
-src/renderer/mod.rs:48:pub enum RenderBackend
-src/renderer/mod.rs:559:pub trait Renderer
-src/renderer/mod.rs:580:pub const DEFAULT_DPI: f64 = 96.0
-src/renderer/mod.rs:581:pub const HWPUNIT_PER_INCH: f64 = 7200.0
-src/renderer/mod.rs:587:pub fn corrected_line_height(
-src/renderer/mod.rs:59: pub fn from_str(s: &str) -> Option<Self>
-src/renderer/mod.rs:610:pub fn corrected_line_metrics(
-src/renderer/mod.rs:71:pub struct TabStop
-src/renderer/mod.rs:787:pub fn corrected_line_metrics_for_source(
-src/renderer/mod.rs:825:pub fn corrected_line_height_for_variant_synthetic(
-src/renderer/mod.rs:82:pub struct TabLeaderInfo
-src/renderer/mod.rs:917:pub fn hwpunit_to_px(hwpunit: i32, dpi: f64) -> f64
-src/renderer/mod.rs:923:pub fn px_to_hwpunit(px: f64, dpi: f64) -> i32
-src/renderer/mod.rs:974:pub fn generic_fallback(font_family: &str) -> &'static str
-src/renderer/page_layout.rs:115: pub fn from_page_def_default(page_def: &PageDef, column_def: &ColumnDef) -> Self
-src/renderer/page_layout.rs:123: pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32)
-src/renderer/page_layout.rs:154: pub fn available_body_height(&self) -> f64
-src/renderer/page_layout.rs:159: pub fn column_width_hu(&self) -> i32
-src/renderer/page_layout.rs:169: pub fn update_footnote_area(&mut self, footnote_height: f64)
-src/renderer/page_layout.rs:37:pub struct LayoutRect
-src/renderer/page_layout.rs:45: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
-src/renderer/page_layout.rs:58: pub fn from_page_def(page_def: &PageDef, column_def: &ColumnDef, dpi: f64) -> Self
-src/renderer/page_layout.rs:63: pub fn from_page_def_for_page(
-src/renderer/page_layout.rs:9:pub struct PageLayoutInfo
-src/renderer/page_number.rs:29: pub fn new(new_page_numbers: &'a [(usize, u16)], initial: u32) -> Self
-src/renderer/page_number.rs:42: pub fn assign(&mut self, page: &PageContent) -> u32
-src/renderer/page_number.rs:59: pub fn next_counter(&self) -> u32
-src/renderer/page_number.rs:65: pub fn should_hide_page_number(&self) -> bool
-src/renderer/pagination.rs:101:pub struct PaginationResult
-src/renderer/pagination.rs:131:pub struct PageContent
-src/renderer/pagination.rs:160:pub struct MasterPageRef
-src/renderer/pagination.rs:169:pub struct HeaderFooterRef
-src/renderer/pagination.rs:180:pub enum FootnoteSource
-src/renderer/pagination.rs:205:pub struct FootnoteRef
-src/renderer/pagination.rs:214:pub struct ColumnContent
-src/renderer/pagination.rs:21:pub fn estimate_footnote_note_height(footnote: &Footnote, dpi: f64) -> f64
-src/renderer/pagination.rs:248:pub struct WrapAroundPara
-src/renderer/pagination.rs:263:pub struct WrapAnchorRef
-src/renderer/pagination.rs:279:pub enum PageItem
-src/renderer/pagination.rs:354:pub fn find_inline_control_target_page(
-src/renderer/pagination.rs:39:pub fn footnote_separator_overhead_px(shape: &FootnoteShape, dpi: f64) -> f64
-src/renderer/pagination.rs:410: pub fn para_index(&self) -> usize
-src/renderer/pagination.rs:422: pub fn with_offset(&self, offset: i32) -> Self
-src/renderer/pagination.rs:45:pub fn footnote_between_notes_margin_px(shape: &FootnoteShape, dpi: f64) -> f64
-src/renderer/pagination.rs:51:pub struct EndnoteRef
-src/renderer/pagination.rs:554: pub fn find_convergence(&self, old: &PaginationResult, offset: i32) -> Option<usize>
-src/renderer/pagination.rs:584: pub fn copy_converged_pages(
-src/renderer/pagination.rs:68:pub struct DeferredEndnote
-src/renderer/pagination.rs:719:pub struct PaginationOpts
-src/renderer/pagination.rs:734:pub struct Paginator
-src/renderer/pagination.rs:740: pub fn new(dpi: f64) -> Self
-src/renderer/pagination.rs:745: pub fn with_default_dpi() -> Self
-src/renderer/pagination.rs:74:pub enum EndnoteDeferral<'a>
-src/renderer/pagination.rs:777: pub fn paginate(
-src/renderer/pagination.rs:88:pub struct EndnoteParaSource
-src/renderer/pagination/engine.rs:158: pub fn paginate_with_measured(
-src/renderer/pagination/engine.rs:178: pub fn paginate_with_measured_opts(
-src/renderer/pagination/state.rs:108: pub fn flush_column_always(&mut self)
-src/renderer/pagination/state.rs:128: pub fn advance_column_or_new_page(&mut self)
-src/renderer/pagination/state.rs:172: pub fn reinsert_carry_with_height(&mut self, carry_height: f64)
-src/renderer/pagination/state.rs:180: pub fn force_new_page(&mut self)
-src/renderer/pagination/state.rs:186: pub fn ensure_page(&mut self)
-src/renderer/pagination/state.rs:193: pub fn available_height(&self) -> f64
-src/renderer/pagination/state.rs:204: pub fn base_available_height(&self) -> f64
-src/renderer/pagination/state.rs:209: pub fn add_footnote_height(&mut self, height: f64)
-src/renderer/pagination/state.rs:220: pub fn projected_footnote_height(&self, note_content_height: f64, note_count: usize) -> f64
-src/renderer/pagination/state.rs:50: pub fn new(
-src/renderer/pagination/state.rs:85: pub fn flush_column(&mut self)
-src/renderer/pdf.rs:10:pub enum PdfBackend
-src/renderer/pdf.rs:20: pub fn parse(value: &str) -> Option<Self>
-src/renderer/pdf.rs:28: pub fn as_str(self) -> &'static str
-src/renderer/pdf.rs:409:pub struct PdfExportOptions
-src/renderer/pdf.rs:40:pub struct DirectPdfExportOptions
-src/renderer/pdf.rs:678:pub fn svg_to_pdf(svg_content: &str) -> Result<Vec<u8>, String>
-src/renderer/pdf.rs:684:pub fn svg_to_pdf_with_options(
-src/renderer/pdf.rs:693:pub fn svgs_to_pdf(svg_pages: &[String]) -> Result<Vec<u8>, String>
-src/renderer/pdf.rs:699:pub fn svgs_to_pdf_with_options(
-src/renderer/pdf.rs:821:pub fn layer_trees_to_pdf(layer_trees: &[crate::paint::PageLayerTree]) -> Result<Vec<u8>, String>
-src/renderer/pdf.rs:832:pub fn layer_trees_to_pdf_with_options(
-src/renderer/pua_oldhangul.rs:5719:pub fn map_pua_old_hangul(ch: char) -> Option<&'static [char]>
-src/renderer/pua_oldhangul.rs:5728:pub fn is_pua_old_hangul(ch: char) -> bool
-src/renderer/render_tree.rs:1016: pub fn new(
-src/renderer/render_tree.rs:1040:pub struct ImageNode
-src/renderer/render_tree.rs:107: pub fn new(id: NodeId, node_type: RenderNodeType, bbox: BoundingBox) -> Self
-src/renderer/render_tree.rs:1114:pub struct HeaderFooterImageRef
-src/renderer/render_tree.rs:1125:pub enum HeaderFooterKind
-src/renderer/render_tree.rs:1134: pub fn is_watermark(&self) -> bool
-src/renderer/render_tree.rs:1138: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
-src/renderer/render_tree.rs:1142: pub fn new(bin_data_id: u16, data: Option<Vec<u8>>) -> Self
-src/renderer/render_tree.rs:1171:pub struct GroupNode
-src/renderer/render_tree.rs:1182:pub struct NoteControlRef
-src/renderer/render_tree.rs:1199:pub struct EquationNode
-src/renderer/render_tree.rs:120: pub fn with_layer(mut self, layer: RenderLayerInfo) -> Self
-src/renderer/render_tree.rs:1229:pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>)
-src/renderer/render_tree.rs:1233:pub struct PageRenderTree
-src/renderer/render_tree.rs:1246: pub fn new(page_index: u32, width: f64, height: f64) -> Self
-src/renderer/render_tree.rs:126: pub fn set_layer(&mut self, layer: RenderLayerInfo)
-src/renderer/render_tree.rs:1284: pub fn set_inline_shape_position(
-src/renderer/render_tree.rs:1301: pub fn get_inline_shape_position(
-src/renderer/render_tree.rs:1316: pub fn inline_shape_positions(&self) -> &std::collections::HashMap<InlineShapeKey, (f64, f64)>
-src/renderer/render_tree.rs:131: pub fn invalidate(&mut self)
-src/renderer/render_tree.rs:1321: pub fn next_id(&mut self) -> NodeId
-src/renderer/render_tree.rs:1328: pub fn needs_render(&self) -> bool
-src/renderer/render_tree.rs:1333: pub fn mark_all_clean(&mut self)
-src/renderer/render_tree.rs:1354: pub fn clip_overlapping_same_bin_images(&mut self)
-src/renderer/render_tree.rs:136: pub fn mark_clean(&mut self)
-src/renderer/render_tree.rs:141: pub fn mark_clean_recursive(&mut self)
-src/renderer/render_tree.rs:149: pub fn has_dirty_nodes(&self) -> bool
-src/renderer/render_tree.rs:157: pub fn to_json(&self) -> String
-src/renderer/render_tree.rs:16:pub const REAL_PICTURE_WATERMARK_PAGE_OPACITY: f64 = 0.26
-src/renderer/render_tree.rs:17:pub const REAL_PICTURE_WATERMARK_FILL_OPACITY: f64 = 0.15
-src/renderer/render_tree.rs:18:pub const REAL_PICTURE_WATERMARK_OPACITY: f64 = REAL_PICTURE_WATERMARK_PAGE_OPACITY
-src/renderer/render_tree.rs:19:pub const REAL_PICTURE_WATERMARK_SATURATION: f64 = 0.91646104
-src/renderer/render_tree.rs:20:pub const REAL_PICTURE_WATERMARK_CONTRAST: f64 = 0.93125103
-src/renderer/render_tree.rs:21:pub const REAL_PICTURE_WATERMARK_BRIGHTNESS: f64 = 1.80
-src/renderer/render_tree.rs:22:pub const REAL_PICTURE_WATERMARK_CORRECTION_MATRIX: [[f64
-src/renderer/render_tree.rs:258:pub enum RenderNodeType
-src/renderer/render_tree.rs:27:pub const REAL_PICTURE_WATERMARK_CORRECTION_BIAS: [f64
-src/renderer/render_tree.rs:29:pub const REAL_PICTURE_WATERMARK_CHROMA_GAIN: f64 = 3.0
-src/renderer/render_tree.rs:30:pub const REAL_PICTURE_WATERMARK_WHITE_BLEND: f64 = 0.0
-src/renderer/render_tree.rs:314:pub struct ObjectControlRef
-src/renderer/render_tree.rs:31:pub const REAL_PICTURE_WATERMARK_FILL_CHROMA_GAIN: f64 = 0.42
-src/renderer/render_tree.rs:322: pub fn ole(section_index: usize, para_index: usize, control_index: usize) -> Self
-src/renderer/render_tree.rs:32:pub const REAL_PICTURE_WATERMARK_FILL_WHITE_BLEND: f64 = 0.16
-src/renderer/render_tree.rs:332: pub fn picture(section_index: usize, para_index: usize, control_index: usize) -> Self
-src/renderer/render_tree.rs:33:pub const LEGACY_IMAGE_WATERMARK_OPACITY: f64 = 0.17
-src/renderer/render_tree.rs:351:pub struct RawSvgNode
-src/renderer/render_tree.rs:359: pub fn new(svg: String) -> Self
-src/renderer/render_tree.rs:35:pub fn is_real_picture_watermark_tone_preset(
-src/renderer/render_tree.rs:366: pub fn ole(svg: String, section_index: usize, para_index: usize, control_index: usize) -> Self
-src/renderer/render_tree.rs:387:pub struct PlaceholderNode
-src/renderer/render_tree.rs:409:pub enum PlaceholderKind
-src/renderer/render_tree.rs:418: pub fn new(fill_color: u32, stroke_color: u32, label: String) -> Self
-src/renderer/render_tree.rs:437: pub fn missing_picture(
-src/renderer/render_tree.rs:44:pub type NodeId = u32
-src/renderer/render_tree.rs:457: pub fn ole(
-src/renderer/render_tree.rs:489:pub struct FootnoteMarkerNode
-src/renderer/render_tree.rs:509:pub struct FormObjectNode
-src/renderer/render_tree.rs:539:pub struct BoundingBox
-src/renderer/render_tree.rs:54:pub struct RenderLayerInfo
-src/renderer/render_tree.rs:551: pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self
-src/renderer/render_tree.rs:561: pub fn intersects(&self, other: &BoundingBox) -> bool
-src/renderer/render_tree.rs:569: pub fn contains(&self, other: &BoundingBox) -> bool
-src/renderer/render_tree.rs:577: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
-src/renderer/render_tree.rs:590:pub struct PageNode
-src/renderer/render_tree.rs:603:pub struct PageBackgroundNode
-src/renderer/render_tree.rs:618:pub struct PageBackgroundImage
-src/renderer/render_tree.rs:638: pub fn is_watermark(&self) -> bool
-src/renderer/render_tree.rs:642: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
-src/renderer/render_tree.rs:649:pub struct TextLineNode
-src/renderer/render_tree.rs:666: pub fn new(line_height: f64, baseline: f64) -> Self
-src/renderer/render_tree.rs:678: pub fn with_para(
-src/renderer/render_tree.rs:695: pub fn with_para_vpos(
-src/renderer/render_tree.rs:70: pub fn new(text_wrap: Option<TextWrap>, z_order: i32, stable_index: u32) -> Self
-src/renderer/render_tree.rs:716:pub struct TextRunNode
-src/renderer/render_tree.rs:753:pub enum FieldMarkerType
-src/renderer/render_tree.rs:768:pub struct TableNode
-src/renderer/render_tree.rs:785:pub struct TableCellNode
-src/renderer/render_tree.rs:806:pub struct ShapeTransform
-src/renderer/render_tree.rs:80: pub fn for_master_page(mut self) -> Self
-src/renderer/render_tree.rs:817: pub fn has_transform(&self) -> bool
-src/renderer/render_tree.rs:829: pub fn effective_image_bbox(&self, bbox: &BoundingBox) -> BoundingBox
-src/renderer/render_tree.rs:845:pub struct LineNode
-src/renderer/render_tree.rs:874: pub fn new(x1: f64, y1: f64, x2: f64, y2: f64, style: LineStyle) -> Self
-src/renderer/render_tree.rs:88:pub struct RenderNode
-src/renderer/render_tree.rs:894:pub struct RectangleNode
-src/renderer/render_tree.rs:921: pub fn new(
-src/renderer/render_tree.rs:943:pub struct EllipseNode
-src/renderer/render_tree.rs:968: pub fn new(style: ShapeStyle, gradient: Option<Box<GradientFillInfo>>) -> Self
-src/renderer/render_tree.rs:985:pub struct PathNode
-src/renderer/scheduler.rs:106:pub trait RenderObserver
-src/renderer/scheduler.rs:11:pub enum RenderPriority
-src/renderer/scheduler.rs:121:pub trait RenderWorker
-src/renderer/scheduler.rs:134:pub enum RenderError
-src/renderer/scheduler.rs:147:pub struct RenderScheduler
-src/renderer/scheduler.rs:165: pub fn new(total_pages: u32) -> Self
-src/renderer/scheduler.rs:178: pub fn set_page_heights(&mut self, heights: &[f64])
-src/renderer/scheduler.rs:188: pub fn update_viewport(&mut self, viewport: Viewport)
-src/renderer/scheduler.rs:194: pub fn update_zoom(&mut self, zoom: f64)
-src/renderer/scheduler.rs:202: pub fn invalidate_page(&mut self, page_index: u32)
-src/renderer/scheduler.rs:216: pub fn visible_pages(&self) -> Vec<u32>
-src/renderer/scheduler.rs:22:pub enum TaskStatus
-src/renderer/scheduler.rs:245: pub fn next_task(&mut self) -> Option<&RenderTask>
-src/renderer/scheduler.rs:254: pub fn complete_task(&mut self, task_id: u32)
-src/renderer/scheduler.rs:261: pub fn cleanup_tasks(&mut self)
-src/renderer/scheduler.rs:267: pub fn pending_count(&self) -> usize
-src/renderer/scheduler.rs:35:pub struct RenderTask
-src/renderer/scheduler.rs:47: pub fn new(id: u32, page_index: u32, priority: RenderPriority) -> Self
-src/renderer/scheduler.rs:59:pub struct Viewport
-src/renderer/scheduler.rs:73: pub fn new(width: f64, height: f64) -> Self
-src/renderer/scheduler.rs:84: pub fn as_bbox(&self) -> BoundingBox
-src/renderer/scheduler.rs:91:pub enum RenderEvent
-src/renderer/skia/equation_conv.rs:17:pub fn render_equation(
-src/renderer/skia/image_conv.rs:16:pub struct ImageSampling
-src/renderer/skia/image_conv.rs:22: pub fn linear() -> Self
-src/renderer/skia/image_conv.rs:34:pub fn draw_svg_fragment(
-src/renderer/skia/image_conv.rs:67:pub fn draw_image_bytes(
-src/renderer/skia/mod.rs:11:pub use renderer::SkiaLayerRenderer
-src/renderer/skia/renderer.rs:110:pub fn native_skia_glyph_run_replay_proof(
-src/renderer/skia/renderer.rs:278:pub struct SkiaLayerRenderer
-src/renderer/skia/renderer.rs:291: pub fn new() -> Self
-src/renderer/skia/renderer.rs:313: pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self
-src/renderer/skia/renderer.rs:345: pub fn render_raster_with_options(
-src/renderer/skia/renderer.rs:34:pub enum NativeGlyphRunReplayProofReason
-src/renderer/skia/renderer.rs:62: pub fn as_str(self) -> &'static str
-src/renderer/skia/renderer.rs:93:pub struct NativeGlyphRunReplayProof
-src/renderer/style_resolver.rs:120: pub fn font_family_for_lang(&self, lang_index: usize) -> &str
-src/renderer/style_resolver.rs:131: pub fn letter_spacing_for_lang(&self, lang_index: usize) -> f64
-src/renderer/style_resolver.rs:140: pub fn ratio_for_lang(&self, lang_index: usize) -> f64
-src/renderer/style_resolver.rs:151:pub struct ResolvedParaStyle
-src/renderer/style_resolver.rs:16:pub const LANG_COUNT: usize = 7
-src/renderer/style_resolver.rs:20:pub struct ResolvedCharStyle
-src/renderer/style_resolver.rs:233:pub struct ResolvedBorderStyle
-src/renderer/style_resolver.rs:254:pub struct ResolvedImageFill
-src/renderer/style_resolver.rs:284:pub struct ResolvedStyleSet
-src/renderer/style_resolver.rs:301:pub fn resolve_styles(doc_info: &DocInfo, dpi: f64) -> ResolvedStyleSet
-src/renderer/style_resolver.rs:308:pub fn resolve_styles_with_variant(
-src/renderer/style_resolver.rs:402:pub fn detect_lang_category(ch: char) -> usize
-src/renderer/style_resolver.rs:470:pub fn primary_font_name(font_family: &str) -> &str
-src/renderer/svg.rs:157: pub fn new() -> Self
-src/renderer/svg.rs:184: pub fn output(&self) -> &str
-src/renderer/svg.rs:189: pub fn font_codepoints(
-src/renderer/svg.rs:196: pub fn render_tree(&mut self, tree: &PageRenderTree)
-src/renderer/svg.rs:3554:pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::PathBuf]) -> String
-src/renderer/svg.rs:52:pub enum FontEmbedMode
-src/renderer/svg.rs:65:pub struct SvgRenderer
-src/renderer/svg_layer.rs:13:pub struct SvgLayerRenderer
-src/renderer/svg_layer.rs:19: pub fn new() -> Self
-src/renderer/svg_layer.rs:26: pub fn output(&self) -> &str
-src/renderer/svg_layer.rs:30: pub fn inner_mut(&mut self) -> &mut SvgRenderer
-src/renderer/typeset.rs:2336: pub fn new(dpi: f64) -> Self
-src/renderer/typeset.rs:2344: pub fn with_default_dpi() -> Self
-src/renderer/typeset.rs:2494: pub fn typeset_section(
-src/renderer/typeset.rs:3022: pub fn typeset_section_with_variant(
-src/renderer/typeset.rs:361:pub struct TypesetEngine
-src/renderer/web_canvas.rs:275:pub enum LayerFilter
-src/renderer/web_canvas.rs:309:pub struct WebCanvasRenderer
-src/renderer/web_canvas.rs:336: pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsValue>
-src/renderer/web_canvas.rs:357: pub fn set_scale(&mut self, scale: f64)
-src/renderer/web_canvas.rs:362: pub fn set_layer_filter(&mut self, filter: LayerFilter)
-src/renderer/web_canvas.rs:412: pub fn render_tree(&mut self, tree: &PageRenderTree)
-src/renderer/web_canvas.rs:417: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
-src/serializer/body_text.rs:201:pub fn serialize_paragraph_list(
-src/serializer/body_text.rs:26:pub fn serialize_section(section: &Section) -> Vec<u8>
-src/serializer/body_text.rs:442:pub fn test_serialize_para_text(para: &Paragraph) -> Vec<u8>
-src/serializer/byte_writer.rs:10:pub struct ByteWriter
-src/serializer/byte_writer.rs:16: pub fn new() -> Self
-src/serializer/byte_writer.rs:21: pub fn position(&self) -> usize
-src/serializer/byte_writer.rs:26: pub fn write_u8(&mut self, v: u8) -> io::Result<()>
-src/serializer/byte_writer.rs:31: pub fn write_u16(&mut self, v: u16) -> io::Result<()>
-src/serializer/byte_writer.rs:36: pub fn write_u32(&mut self, v: u32) -> io::Result<()>
-src/serializer/byte_writer.rs:41: pub fn write_i8(&mut self, v: i8) -> io::Result<()>
-src/serializer/byte_writer.rs:46: pub fn write_i16(&mut self, v: i16) -> io::Result<()>
-src/serializer/byte_writer.rs:51: pub fn write_i32(&mut self, v: i32) -> io::Result<()>
-src/serializer/byte_writer.rs:56: pub fn write_f64(&mut self, v: f64) -> io::Result<()>
-src/serializer/byte_writer.rs:61: pub fn write_bytes(&mut self, data: &[u8]) -> io::Result<()>
-src/serializer/byte_writer.rs:70: pub fn write_hwp_string(&mut self, s: &str) -> io::Result<()>
-src/serializer/byte_writer.rs:80: pub fn write_color_ref(&mut self, color: u32) -> io::Result<()>
-src/serializer/byte_writer.rs:85: pub fn write_zeros(&mut self, count: usize) -> io::Result<()>
-src/serializer/byte_writer.rs:91: pub fn into_bytes(self) -> Vec<u8>
-src/serializer/byte_writer.rs:96: pub fn as_bytes(&self) -> &[u8]
-src/serializer/cfb_writer.rs:24:pub fn serialize_hwp(doc: &Document) -> Result<Vec<u8>, SerializeError>
-src/serializer/control.rs:31:pub fn serialize_control(
-src/serializer/doc_info.rs:135:pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8>
-src/serializer/doc_info.rs:155:pub fn serialize_id_mappings(doc_info: &DocInfo) -> Vec<u8>
-src/serializer/doc_info.rs:201:pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8>
-src/serializer/doc_info.rs:22:pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8>
-src/serializer/doc_info.rs:231:pub fn serialize_face_name(font: &Font) -> Vec<u8>
-src/serializer/doc_info.rs:308:pub fn serialize_border_fill(bf: &BorderFill) -> Vec<u8>
-src/serializer/doc_info.rs:407:pub fn serialize_char_shape(cs: &CharShape) -> Vec<u8>
-src/serializer/doc_info.rs:528:pub fn serialize_tab_def(td: &TabDef) -> Vec<u8>
-src/serializer/doc_info.rs:603:pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8>
-src/serializer/doc_info.rs:665:pub fn serialize_style(style: &Style) -> Vec<u8>
-src/serializer/doc_info.rs:781:pub fn surgical_insert_record(
-src/serializer/doc_info.rs:841:pub fn surgical_insert_font_all_langs(raw_stream: &mut Vec<u8>, data: &[u8]) -> Result<(), String>
-src/serializer/doc_info.rs:934:pub fn surgical_remove_records(raw_stream: &mut Vec<u8>, tag_id: u16) -> usize
-src/serializer/doc_info.rs:958:pub fn surgical_update_caret(
-src/serializer/header.rs:16:pub fn serialize_file_header(header: &FileHeader) -> Vec<u8>
-src/serializer/hml/error.rs:11:pub enum HmlExportError
-src/serializer/hml/error.rs:28: pub fn blockers(&self) -> &[HmlSaveBlocker]
-src/serializer/hml/error.rs:4:pub struct HmlSaveBlocker
-src/serializer/hml/mod.rs:12:pub use error::{HmlExportError, HmlSaveBlocker}
-src/serializer/hml/mod.rs:18:pub fn serialize_hml(
-src/serializer/hwpx/canonical_defaults.rs:103:pub const PAGE_BORDER_HEADER_INSIDE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:104:pub const PAGE_BORDER_FOOTER_INSIDE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:109:pub const BEGIN_NUM_PAGE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:110:pub const BEGIN_NUM_FOOTNOTE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:111:pub const BEGIN_NUM_ENDNOTE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:112:pub const BEGIN_NUM_PIC: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:113:pub const BEGIN_NUM_TBL: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:114:pub const BEGIN_NUM_EQUATION: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:119:pub const FONT_IS_EMBEDDED: bool = false
-src/serializer/hwpx/canonical_defaults.rs:120:pub const FONT_TYPE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:125:pub const LS_PERCENT: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:126:pub const LS_FIXED: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:127:pub const LS_BETWEEN_LINES: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:128:pub const LS_AT_LEAST: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:133:pub const AH_JUSTIFY: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:134:pub const AH_LEFT: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:135:pub const AH_RIGHT: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:136:pub const AH_CENTER: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:137:pub const AH_DISTRIBUTE: u32 = 4
-src/serializer/hwpx/canonical_defaults.rs:138:pub const AH_DISTRIBUTE_SPACE: u32 = 5
-src/serializer/hwpx/canonical_defaults.rs:143:pub const AV_BASELINE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:144:pub const AV_TOP: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:145:pub const AV_CENTER: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:146:pub const AV_BOTTOM: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:151:pub const FLT_HANGUL: usize = 0
-src/serializer/hwpx/canonical_defaults.rs:152:pub const FLT_LATIN: usize = 1
-src/serializer/hwpx/canonical_defaults.rs:153:pub const FLT_HANJA: usize = 2
-src/serializer/hwpx/canonical_defaults.rs:154:pub const FLT_JAPANESE: usize = 3
-src/serializer/hwpx/canonical_defaults.rs:155:pub const FLT_OTHER: usize = 4
-src/serializer/hwpx/canonical_defaults.rs:156:pub const FLT_SYMBOL: usize = 5
-src/serializer/hwpx/canonical_defaults.rs:157:pub const FLT_USER: usize = 6
-src/serializer/hwpx/canonical_defaults.rs:160:pub const FONTFACE_LANG_NAMES: [&str
-src/serializer/hwpx/canonical_defaults.rs:167:pub const VRT_PAPER: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:168:pub const VRT_PAGE: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:169:pub const VRT_PARA: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:174:pub const HRT_PAPER: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:175:pub const HRT_PAGE: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:176:pub const HRT_COLUMN: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:177:pub const HRT_PARA: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:17:pub const CHARSHAPE_HEIGHT: u32 = 1000
-src/serializer/hwpx/canonical_defaults.rs:182:pub const ASOTWT_SQUARE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:183:pub const ASOTWT_TOP_AND_BOTTOM: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:184:pub const ASOTWT_BEHIND_TEXT: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:185:pub const ASOTWT_IN_FRONT_OF_TEXT: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:18:pub const CHARSHAPE_TEXT_COLOR: u32 = 0x000000
-src/serializer/hwpx/canonical_defaults.rs:190:pub const TPBT_NONE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:191:pub const TPBT_TABLE: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:192:pub const TPBT_CELL: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:197:pub const SMT_NONE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:198:pub const SMT_DOT_ABOVE: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:199:pub const SMT_RING_ABOVE: u32 = 2
-src/serializer/hwpx/canonical_defaults.rs:19:pub const CHARSHAPE_SHADE_COLOR: u32 = 0xFFFFFF
-src/serializer/hwpx/canonical_defaults.rs:200:pub const SMT_TILDE: u32 = 3
-src/serializer/hwpx/canonical_defaults.rs:205:pub const ST_PARA: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:206:pub const ST_CHAR: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:20:pub const CHARSHAPE_USE_FONT_SPACE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:21:pub const CHARSHAPE_USE_KERNING: bool = false
-src/serializer/hwpx/canonical_defaults.rs:22:pub const CHARSHAPE_SYM_MARK: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:28:pub const PARASHAPE_SNAP_TO_GRID: bool = true
-src/serializer/hwpx/canonical_defaults.rs:29:pub const PARASHAPE_FONT_LINE_HEIGHT: bool = false
-src/serializer/hwpx/canonical_defaults.rs:30:pub const PARASHAPE_SUPPRESS_LINE_NUMBERS: bool = false
-src/serializer/hwpx/canonical_defaults.rs:31:pub const PARASHAPE_CHECKED: bool = false
-src/serializer/hwpx/canonical_defaults.rs:32:pub const PARASHAPE_CONDENSE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:33:pub const PARASHAPE_TAB_PR_ID_REF: u16 = 0
-src/serializer/hwpx/canonical_defaults.rs:38:pub const BORDERFILL_THREE_D: bool = false
-src/serializer/hwpx/canonical_defaults.rs:39:pub const BORDERFILL_SHADOW: bool = false
-src/serializer/hwpx/canonical_defaults.rs:40:pub const BORDERFILL_BREAK_CELL_SEPARATE_LINE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:41:pub const BORDERFILL_CENTER_LINE: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:46:pub const BREAKSETTING_WIDOW_ORPHAN: bool = false
-src/serializer/hwpx/canonical_defaults.rs:47:pub const BREAKSETTING_KEEP_WITH_NEXT: bool = false
-src/serializer/hwpx/canonical_defaults.rs:48:pub const BREAKSETTING_KEEP_LINES: bool = false
-src/serializer/hwpx/canonical_defaults.rs:49:pub const BREAKSETTING_PAGE_BREAK_BEFORE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:50:pub const BREAKSETTING_BREAK_NON_LATIN_WORD: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:51:pub const BREAKSETTING_LINE_WRAP: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:56:pub const VISIBILITY_HIDE_FIRST_HEADER: bool = false
-src/serializer/hwpx/canonical_defaults.rs:57:pub const VISIBILITY_HIDE_FIRST_FOOTER: bool = false
-src/serializer/hwpx/canonical_defaults.rs:58:pub const VISIBILITY_HIDE_FIRST_MASTER_PAGE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:59:pub const VISIBILITY_HIDE_FIRST_PAGE_NUM: bool = false
-src/serializer/hwpx/canonical_defaults.rs:60:pub const VISIBILITY_HIDE_FIRST_EMPTY_LINE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:61:pub const VISIBILITY_SHOW_LINE_NUMBER: bool = false
-src/serializer/hwpx/canonical_defaults.rs:67:pub const CELLSPAN_COL_SPAN: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:68:pub const CELLSPAN_ROW_SPAN: u32 = 1
-src/serializer/hwpx/canonical_defaults.rs:74:pub const RUN_CHAR_PR_ID_REF_UNSET: u32 = u32::MAX
-src/serializer/hwpx/canonical_defaults.rs:79:pub const TABLE_REPEAT_HEADER: bool = false
-src/serializer/hwpx/canonical_defaults.rs:80:pub const TABLE_NO_ADJUST: bool = false
-src/serializer/hwpx/canonical_defaults.rs:85:pub const PICTURE_REVERSE: bool = false
-src/serializer/hwpx/canonical_defaults.rs:90:pub const SZ_WIDTH_REL_TO: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:91:pub const SZ_HEIGHT_REL_TO: u32 = 0
-src/serializer/hwpx/canonical_defaults.rs:92:pub const SZ_PROTECT: bool = false
-src/serializer/hwpx/canonical_defaults.rs:98:pub const NUMBERING_START: i32 = 1
-src/serializer/hwpx/content.rs:15:pub struct BinDataEntry
-src/serializer/hwpx/content.rs:37:pub fn write_content_hpf(
-src/serializer/hwpx/context.rs:116: pub fn collect_from_document(doc: &Document) -> Self
-src/serializer/hwpx/context.rs:224: pub fn bin_data_entries(&self) -> Vec<BinDataEntry>
-src/serializer/hwpx/context.rs:231: pub fn resolve_bin_id(&self, bin_data_id: u16) -> Option<&str>
-src/serializer/hwpx/context.rs:238: pub fn assert_all_refs_resolved(&self) -> Result<(), SerializeError>
-src/serializer/hwpx/context.rs:26:pub struct IdPool<T: Copy + Eq + std::hash::Hash>
-src/serializer/hwpx/context.rs:276: pub fn next_para_id(&mut self) -> u32
-src/serializer/hwpx/context.rs:289: pub fn effective_style_id(&self, raw: u8) -> u8
-src/serializer/hwpx/context.rs:32: pub fn new() -> Self
-src/serializer/hwpx/context.rs:40: pub fn register(&mut self, id: T)
-src/serializer/hwpx/context.rs:45: pub fn reference(&mut self, id: T)
-src/serializer/hwpx/context.rs:49: pub fn is_registered(&self, id: &T) -> bool
-src/serializer/hwpx/context.rs:54: pub fn unresolved(&self) -> Vec<T>
-src/serializer/hwpx/context.rs:61: pub fn registered_count(&self) -> usize
-src/serializer/hwpx/context.rs:68:pub struct BinDataEntry
-src/serializer/hwpx/context.rs:84:pub struct SerializeContext
-src/serializer/hwpx/field.rs:105:pub fn write_hyperlink_begin<W: Write>(
-src/serializer/hwpx/field.rs:132:pub fn write_footnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:140:pub fn write_footnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:145:pub fn write_endnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:153:pub fn write_endnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:25:pub fn write_bookmark<W: Write>(w: &mut Writer<W>, bm: &Bookmark) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:37:pub fn field_begin_open_tag(field: &Field) -> String
-src/serializer/hwpx/field.rs:60:pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:76:pub fn write_field_end<W: Write>(w: &mut Writer<W>, field_id: u32) -> Result<(), SerializeError>
-src/serializer/hwpx/field.rs:83:pub fn write_field_end_full<W: Write>(
-src/serializer/hwpx/fixtures.rs:12:pub const EMPTY_HEADER_XML: &str = include_str!("templates/empty_header.xml")
-src/serializer/hwpx/fixtures.rs:13:pub const EMPTY_SECTION0_XML: &str = include_str!("templates/empty_section0.xml")
-src/serializer/hwpx/fixtures.rs:14:pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
-src/serializer/hwpx/form.rs:81:pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), SerializeError>
-src/serializer/hwpx/header.rs:32:pub fn write_header(doc: &Document, ctx: &SerializeContext) -> Result<Vec<u8>, SerializeError>
-src/serializer/hwpx/master_page.rs:54:pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeContext) -> String
-src/serializer/hwpx/master_page.rs:91:pub fn render_master_page_refs(ids: &[String]) -> String
-src/serializer/hwpx/mod.rs:11:pub mod canonical_defaults
-src/serializer/hwpx/mod.rs:12:pub mod content
-src/serializer/hwpx/mod.rs:13:pub mod context
-src/serializer/hwpx/mod.rs:14:pub mod field
-src/serializer/hwpx/mod.rs:15:pub mod fixtures
-src/serializer/hwpx/mod.rs:16:pub mod form
-src/serializer/hwpx/mod.rs:17:pub mod header
-src/serializer/hwpx/mod.rs:18:pub mod master_page
-src/serializer/hwpx/mod.rs:19:pub mod package_check
-src/serializer/hwpx/mod.rs:20:pub mod picture
-src/serializer/hwpx/mod.rs:21:pub mod roundtrip
-src/serializer/hwpx/mod.rs:22:pub mod section
-src/serializer/hwpx/mod.rs:23:pub mod shape
-src/serializer/hwpx/mod.rs:24:pub mod static_assets
-src/serializer/hwpx/mod.rs:25:pub mod table
-src/serializer/hwpx/mod.rs:26:pub mod utils
-src/serializer/hwpx/mod.rs:27:pub mod writer
-src/serializer/hwpx/mod.rs:44:pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError>
-src/serializer/hwpx/package_check.rs:41:pub struct PackageCheckReport
-src/serializer/hwpx/package_check.rs:46: pub fn is_ok(&self) -> bool
-src/serializer/hwpx/package_check.rs:50: pub fn summary(&self) -> String
-src/serializer/hwpx/package_check.rs:62:pub fn check_package(hwpx_bytes: &[u8], doc: &Document) -> PackageCheckReport
-src/serializer/hwpx/picture.rs:47:pub fn write_picture<W: Write>(
-src/serializer/hwpx/roundtrip.rs:492:pub fn roundtrip_ir_diff(hwpx_bytes: &[u8]) -> Result<IrDiff, SerializeError>
-src/serializer/hwpx/roundtrip.rs:505:pub fn diff_documents(a: &Document, b: &Document) -> IrDiff
-src/serializer/hwpx/roundtrip.rs:56:pub struct IrDiff
-src/serializer/hwpx/roundtrip.rs:61: pub fn is_empty(&self) -> bool
-src/serializer/hwpx/roundtrip.rs:65: pub fn push(&mut self, d: IrDifference)
-src/serializer/hwpx/roundtrip.rs:70: pub fn allowed(&self, _allow: IrDiffAllow) -> bool
-src/serializer/hwpx/roundtrip.rs:765:pub struct LinesegDiff
-src/serializer/hwpx/roundtrip.rs:774:pub enum LinesegDiffKind
-src/serializer/hwpx/roundtrip.rs:77:pub struct IrDiffAllow
-src/serializer/hwpx/roundtrip.rs:813:pub fn diff_linesegs(a: &Document, b: &Document) -> Vec<LinesegDiff>
-src/serializer/hwpx/roundtrip.rs:83:pub enum IrDifference
-src/serializer/hwpx/section.rs:189:pub fn write_section(
-src/serializer/hwpx/shape.rs:144:pub fn write_line<W: Write>(
-src/serializer/hwpx/shape.rs:275:pub fn write_container_open<W: Write>(
-src/serializer/hwpx/shape.rs:315:pub fn write_container_close<W: Write>(
-src/serializer/hwpx/shape.rs:40:pub fn write_rect<W: Write>(
-src/serializer/hwpx/shape.rs:413:pub fn write_draw_text<W: Write>(
-src/serializer/hwpx/static_assets.rs:10:pub const META_INF_CONTAINER_XML: &str = concat!(
-src/serializer/hwpx/static_assets.rs:23:pub const META_INF_CONTAINER_RDF: &str = concat!(
-src/serializer/hwpx/static_assets.rs:45:pub const META_INF_MANIFEST_XML: &str = concat!(
-src/serializer/hwpx/static_assets.rs:51:pub const SETTINGS_XML: &str = include_str!("templates/settings.xml")
-src/serializer/hwpx/static_assets.rs:54:pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
-src/serializer/hwpx/static_assets.rs:57:pub const PRV_TEXT: &[u8] = b"\r\n"
-src/serializer/hwpx/static_assets.rs:60:pub const PRV_IMAGE_PNG: &[u8] = &[
-src/serializer/hwpx/static_assets.rs:7:pub const VERSION_XML: &str = include_str!("templates/version.xml")
-src/serializer/hwpx/table.rs:42:pub fn write_table<W: Write>(
-src/serializer/hwpx/utils.rs:11:pub fn write_xml_decl<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
-src/serializer/hwpx/utils.rs:22:pub fn start_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
-src/serializer/hwpx/utils.rs:29:pub fn start_tag_attrs<W: Write>(
-src/serializer/hwpx/utils.rs:44:pub fn end_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
-src/serializer/hwpx/utils.rs:51:pub fn empty_tag<W: Write>(
-src/serializer/hwpx/utils.rs:66:pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeError>
-src/serializer/hwpx/utils.rs:73:pub fn xml_escape(s: &str) -> String
-src/serializer/hwpx/writer.rs:18:pub struct HwpxZipWriter
-src/serializer/hwpx/writer.rs:24: pub fn new() -> Self
-src/serializer/hwpx/writer.rs:36: pub fn write_stored(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
-src/serializer/hwpx/writer.rs:50: pub fn write_deflated(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
-src/serializer/hwpx/writer.rs:64: pub fn finish(mut self) -> Result<Vec<u8>, SerializeError>
-src/serializer/mini_cfb.rs:71:pub fn build_cfb(named_streams: &[(&str, &[u8])]) -> Result<Vec<u8>, String>
-src/serializer/mod.rs:10:pub mod doc_info
-src/serializer/mod.rs:11:pub mod header
-src/serializer/mod.rs:12:pub mod hml
-src/serializer/mod.rs:13:pub mod hwpx
-src/serializer/mod.rs:14:pub mod mini_cfb
-src/serializer/mod.rs:15:pub mod record_writer
-src/serializer/mod.rs:17:pub use cfb_writer::serialize_hwp
-src/serializer/mod.rs:18:pub use hml::serialize_hml
-src/serializer/mod.rs:19:pub use hwpx::serialize_hwpx
-src/serializer/mod.rs:23:pub enum SerializeError
-src/serializer/mod.rs:57:pub trait DocumentSerializer
-src/serializer/mod.rs:62:pub struct HwpSerializer
-src/serializer/mod.rs:6:pub mod body_text
-src/serializer/mod.rs:71:pub struct HwpxSerializer
-src/serializer/mod.rs:7:pub mod byte_writer
-src/serializer/mod.rs:80:pub fn serialize_document(doc: &Document) -> Result<Vec<u8>, SerializeError>
-src/serializer/mod.rs:8:pub mod cfb_writer
-src/serializer/mod.rs:9:pub mod control
-src/serializer/record_writer.rs:16:pub fn write_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8>
-src/serializer/record_writer.rs:36:pub fn write_record_from(record: &Record) -> Vec<u8>
-src/serializer/record_writer.rs:41:pub fn write_records(records: &[Record]) -> Vec<u8>
-src/wasm_api.rs:1006: pub fn insert_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:1024: pub fn delete_text_in_cell(
-src/wasm_api.rs:1051: pub fn delete_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:1069: pub fn split_paragraph_in_cell(
-src/wasm_api.rs:1093: pub fn merge_paragraph_in_cell(
-src/wasm_api.rs:1114: pub fn insert_text_in_cell_by_path_api(
-src/wasm_api.rs:1134: pub fn delete_text_in_cell_by_path_api(
-src/wasm_api.rs:1154: pub fn split_paragraph_in_cell_by_path_api(
-src/wasm_api.rs:1172: pub fn merge_paragraph_in_cell_by_path_api(
-src/wasm_api.rs:1184: pub fn get_text_in_cell_by_path_api(
-src/wasm_api.rs:1209: pub fn get_header_footer(
-src/wasm_api.rs:1223: pub fn create_header_footer(
-src/wasm_api.rs:1237: pub fn insert_text_in_header_footer(
-src/wasm_api.rs:1261: pub fn delete_text_in_header_footer(
-src/wasm_api.rs:1285: pub fn split_paragraph_in_header_footer(
-src/wasm_api.rs:1307: pub fn merge_paragraph_in_header_footer(
-src/wasm_api.rs:1327: pub fn get_header_footer_para_info(
-src/wasm_api.rs:1347: pub fn insert_table_row(
-src/wasm_api.rs:1369: pub fn insert_table_column(
-src/wasm_api.rs:1391: pub fn delete_table_row(
-src/wasm_api.rs:1411: pub fn delete_table_column(
-src/wasm_api.rs:1431: pub fn merge_table_cells(
-src/wasm_api.rs:1458: pub fn merge_table_cells_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:1476: pub fn split_table_cell(
-src/wasm_api.rs:1498: pub fn split_table_cell_into(
-src/wasm_api.rs:1529: pub fn split_table_cell_into_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:1549: pub fn split_table_cells_in_range(
-src/wasm_api.rs:1582: pub fn split_table_cells_in_range_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:1603: pub fn copy_table_cells_transposed(
-src/wasm_api.rs:1629: pub fn paste_table_cells_transposed(
-src/wasm_api.rs:1651: pub fn transpose_table_cells_in_place(
-src/wasm_api.rs:1669: pub fn paste_table_cells_transposed_as_table(
-src/wasm_api.rs:1685: pub fn has_table_transpose_clipboard(&self) -> bool
-src/wasm_api.rs:1694: pub fn split_paragraph(
-src/wasm_api.rs:1710: pub fn insert_page_break(
-src/wasm_api.rs:1726: pub fn insert_column_break(
-src/wasm_api.rs:1742: pub fn insert_new_number(
-src/wasm_api.rs:1765: pub fn set_column_def(
-src/wasm_api.rs:177:pub struct HwpDocument
-src/wasm_api.rs:1788: pub fn merge_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:1794: pub fn delete_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:1800: pub fn insert_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:1809: pub fn get_section_count(&self) -> u32
-src/wasm_api.rs:1815: pub fn get_paragraph_count(&self, section_idx: u32) -> Result<u32, JsValue>
-src/wasm_api.rs:1823: pub fn get_paragraph_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
-src/wasm_api.rs:1832: pub fn get_textbox_control_index(&self, section_idx: u32, para_idx: u32) -> i32
-src/wasm_api.rs:1839: pub fn find_next_editable_control(
-src/wasm_api.rs:1856: pub fn find_nearest_control_backward(
-src/wasm_api.rs:1871: pub fn find_nearest_control_forward(
-src/wasm_api.rs:1886: pub fn get_control_text_positions(&self, section_idx: u32, para_idx: u32) -> String
-src/wasm_api.rs:1907: pub fn navigate_next_editable_wasm(
-src/wasm_api.rs:1953: pub fn get_text_range(
-src/wasm_api.rs:1971: pub fn get_cell_paragraph_count(
-src/wasm_api.rs:198: pub fn from_bytes(data: &[u8]) -> Result<HwpDocument, HwpError>
-src/wasm_api.rs:1990: pub fn get_cell_paragraph_length(
-src/wasm_api.rs:2011: pub fn get_cell_paragraph_count_by_path(
-src/wasm_api.rs:202: pub fn find_initial_column_def(paragraphs: &[Paragraph]) -> ColumnDef
-src/wasm_api.rs:2030: pub fn get_cell_paragraph_length_by_path(
-src/wasm_api.rs:2045: pub fn get_cell_text_direction(
-src/wasm_api.rs:206: pub fn find_column_def_for_paragraph(paragraphs: &[Paragraph], para_idx: usize) -> ColumnDef
-src/wasm_api.rs:2074: pub fn get_text_in_cell(
-src/wasm_api.rs:2101: pub fn get_text_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:2123: pub fn get_cursor_rect(
-src/wasm_api.rs:2143: pub fn get_cursor_rect_on_line(
-src/wasm_api.rs:2178: pub fn hit_test(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
-src/wasm_api.rs:2187: pub fn get_cursor_rect_in_header_footer(
-src/wasm_api.rs:2211: pub fn hit_test_header_footer(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
-src/wasm_api.rs:2221: pub fn hit_test_in_header_footer(
-src/wasm_api.rs:2234: pub fn get_para_properties_in_hf(
-src/wasm_api.rs:2247: pub fn apply_para_format_in_hf(
-src/wasm_api.rs:2267: pub fn insert_field_in_hf(
-src/wasm_api.rs:2289: pub fn apply_hf_template(
-src/wasm_api.rs:2302: pub fn delete_header_footer(
-src/wasm_api.rs:2314: pub fn get_header_footer_list(
-src/wasm_api.rs:2333: pub fn navigate_header_footer_by_page(
-src/wasm_api.rs:2347: pub fn toggle_hide_header_footer(
-src/wasm_api.rs:2360: pub fn get_cursor_rect_in_cell(
-src/wasm_api.rs:2386: pub fn get_line_info(
-src/wasm_api.rs:2404: pub fn get_line_info_in_cell(
-src/wasm_api.rs:2428: pub fn get_caret_position(&self) -> Result<String, JsValue>
-src/wasm_api.rs:2436: pub fn get_table_dimensions(
-src/wasm_api.rs:2454: pub fn get_cell_info(
-src/wasm_api.rs:2474: pub fn get_cell_properties(
-src/wasm_api.rs:2494: pub fn get_cell_own_properties(
-src/wasm_api.rs:2514: pub fn set_cell_properties(
-src/wasm_api.rs:2536: pub fn set_cell_zone_properties(
-src/wasm_api.rs:2565: pub fn resize_table_cells(
-src/wasm_api.rs:2586: pub fn move_table_offset(
-src/wasm_api.rs:2608: pub fn get_table_properties(
-src/wasm_api.rs:2626: pub fn set_table_properties(
-src/wasm_api.rs:2646: pub fn get_table_cell_bboxes(
-src/wasm_api.rs:2666: pub fn get_table_bbox(
-src/wasm_api.rs:2685: pub fn get_shape_bbox(
-src/wasm_api.rs:2703: pub fn delete_table_control(
-src/wasm_api.rs:2721: pub fn create_table(
-src/wasm_api.rs:2744: pub fn create_table_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:2812: pub fn insert_picture(
-src/wasm_api.rs:2865: pub fn insert_picture_ex(
-src/wasm_api.rs:2920: pub fn assign_picture_image(
-src/wasm_api.rs:2954: pub fn get_external_image_references(&self) -> String
-src/wasm_api.rs:2967: pub fn get_external_image_basenames(&self) -> String
-src/wasm_api.rs:2991: pub fn inject_external_image(
-src/wasm_api.rs:3050: pub fn inject_external_image_by_key(
-src/wasm_api.rs:3072: pub fn get_picture_properties(
-src/wasm_api.rs:3090: pub fn get_header_footer_picture_properties(
-src/wasm_api.rs:3112: pub fn set_picture_properties(
-src/wasm_api.rs:3130: pub fn set_header_footer_picture_properties(
-src/wasm_api.rs:3154: pub fn delete_picture_control(
-src/wasm_api.rs:3170: pub fn delete_cell_picture_control_by_path(
-src/wasm_api.rs:3188: pub fn get_cell_shape_properties_by_path(
-src/wasm_api.rs:3206: pub fn get_cell_picture_properties_by_path(
-src/wasm_api.rs:3224: pub fn set_cell_shape_properties_by_path(
-src/wasm_api.rs:3244: pub fn set_cell_picture_properties_by_path(
-src/wasm_api.rs:3268: pub fn delete_equation_control(
-src/wasm_api.rs:3286: pub fn get_equation_properties(
-src/wasm_api.rs:3318: pub fn set_equation_properties(
-src/wasm_api.rs:3350: pub fn get_note_equation_properties(
-src/wasm_api.rs:3372: pub fn set_note_equation_properties(
-src/wasm_api.rs:3399: pub fn set_note_equation_properties_ex(
-src/wasm_api.rs:3421: pub fn render_equation_preview(
-src/wasm_api.rs:343: pub fn new(data: &[u8]) -> Result<HwpDocument, JsValue>
-src/wasm_api.rs:3463: pub fn create_shape_control(&mut self, json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:3529: pub fn get_shape_properties(
-src/wasm_api.rs:3547: pub fn set_shape_properties(
-src/wasm_api.rs:355: pub fn create_empty() -> HwpDocument
-src/wasm_api.rs:3567: pub fn delete_shape_control(
-src/wasm_api.rs:3584: pub fn change_shape_z_order(
-src/wasm_api.rs:3604: pub fn group_shapes(&mut self, json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:3640: pub fn ungroup_shape(
-src/wasm_api.rs:3656: pub fn move_line_endpoint(
-src/wasm_api.rs:3674: pub fn move_line_endpoint_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:3690: pub fn update_connectors_in_section_wasm(&mut self, section_idx: u32)
-src/wasm_api.rs:3696: pub fn insert_footnote(
-src/wasm_api.rs:3712: pub fn insert_endnote(
-src/wasm_api.rs:3728: pub fn get_endnote_shape(&self, section_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:372: pub fn create_blank_document(&mut self) -> Result<String, JsValue>
-src/wasm_api.rs:3735: pub fn apply_endnote_shape(
-src/wasm_api.rs:3746: pub fn insert_equation(
-src/wasm_api.rs:3768: pub fn get_footnote_info(
-src/wasm_api.rs:3786: pub fn get_footnote_at_cursor(
-src/wasm_api.rs:378: pub fn set_show_paragraph_marks(&mut self, enabled: bool)
-src/wasm_api.rs:3804: pub fn delete_footnote(
-src/wasm_api.rs:3820: pub fn insert_text_in_footnote(
-src/wasm_api.rs:3842: pub fn delete_text_in_footnote(
-src/wasm_api.rs:385: pub fn get_show_paragraph_marks(&self) -> bool
-src/wasm_api.rs:3864: pub fn split_paragraph_in_footnote(
-src/wasm_api.rs:3884: pub fn merge_paragraph_in_footnote(
-src/wasm_api.rs:3902: pub fn hit_test_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
-src/wasm_api.rs:3909: pub fn hit_test_in_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
-src/wasm_api.rs:3916: pub fn get_page_footnote_info(
-src/wasm_api.rs:391: pub fn get_show_control_codes(&self) -> bool
-src/wasm_api.rs:3927: pub fn get_cursor_rect_in_footnote(
-src/wasm_api.rs:3945: pub fn get_note_edit_info(
-src/wasm_api.rs:3961: pub fn get_cursor_rect_in_note(
-src/wasm_api.rs:397: pub fn set_show_control_codes(&mut self, enabled: bool)
-src/wasm_api.rs:3981: pub fn get_para_properties_in_footnote(
-src/wasm_api.rs:3999: pub fn apply_para_format_in_footnote(
-src/wasm_api.rs:4019: pub fn hit_test_body_footnote_marker(
-src/wasm_api.rs:4037: pub fn move_vertical(
-src/wasm_api.rs:404: pub fn get_show_transparent_borders(&self) -> bool
-src/wasm_api.rs:4076: pub fn move_vertical_ex(&self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:4107: pub fn get_field_list(&self) -> String
-src/wasm_api.rs:410: pub fn set_show_transparent_borders(&mut self, enabled: bool)
-src/wasm_api.rs:4115: pub fn get_field_value(&self, field_id: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4123: pub fn get_field_value_by_name_api(&self, name: &str) -> Result<String, JsValue>
-src/wasm_api.rs:4131: pub fn set_field_value(&mut self, field_id: u32, value: &str) -> Result<String, JsValue>
-src/wasm_api.rs:4140: pub fn set_field_value_by_name_api(
-src/wasm_api.rs:4151: pub fn insert_click_here_field_api(
-src/wasm_api.rs:416: pub fn set_clip_enabled(&mut self, enabled: bool)
-src/wasm_api.rs:4178: pub fn insert_click_here_field_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:4194: pub fn insert_click_here_field_in_cell_api(
-src/wasm_api.rs:4229: pub fn insert_click_here_field_in_cell_ex(
-src/wasm_api.rs:422: pub fn set_debug_overlay(&mut self, enabled: bool)
-src/wasm_api.rs:4252: pub fn insert_click_here_field_by_path_api(
-src/wasm_api.rs:4282: pub fn insert_click_here_field_by_path_ex(
-src/wasm_api.rs:428: pub fn set_respect_vpos_reset(&mut self, enabled: bool)
-src/wasm_api.rs:4310: pub fn get_form_object_at(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
-src/wasm_api.rs:4320: pub fn get_form_value(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4331: pub fn set_form_value(
-src/wasm_api.rs:4353: pub fn set_form_value_in_cell(
-src/wasm_api.rs:4381: pub fn set_form_value_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:4401: pub fn get_form_object_info(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4411: pub fn search_text(
-src/wasm_api.rs:442: pub fn page_count(&self) -> u32
-src/wasm_api.rs:4434: pub fn search_all_text(
-src/wasm_api.rs:4447: pub fn replace_text(
-src/wasm_api.rs:4468: pub fn replace_one(
-src/wasm_api.rs:4481: pub fn replace_all(
-src/wasm_api.rs:448: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4494: pub fn get_position_of_page(&self, global_page: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4502: pub fn get_page_of_position(&self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4512: pub fn get_field_info_at_api(
-src/wasm_api.rs:4527: pub fn get_field_info_at_in_cell_api(
-src/wasm_api.rs:454: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:4553: pub fn get_field_info_at_in_cell_ex(&self, options_json: &str) -> String
-src/wasm_api.rs:4568: pub fn remove_field_at_api(
-src/wasm_api.rs:4589: pub fn remove_field_at_in_cell_api(
-src/wasm_api.rs:460: pub fn render_page_canvas(&self, page_num: u32) -> Result<u32, JsValue>
-src/wasm_api.rs:4621: pub fn remove_field_at_in_cell_ex(&mut self, options_json: &str) -> String
-src/wasm_api.rs:4642: pub fn set_active_field_api(
-src/wasm_api.rs:4658: pub fn set_active_field_in_cell_api(
-src/wasm_api.rs:466: pub fn render_page_canvas_legacy(&self, page_num: u32) -> Result<u32, JsValue>
-src/wasm_api.rs:4684: pub fn set_active_field_in_cell_ex(&mut self, options_json: &str) -> bool
-src/wasm_api.rs:4699: pub fn get_field_info_at_by_path_api(
-src/wasm_api.rs:4719: pub fn set_active_field_by_path_api(
-src/wasm_api.rs:4739: pub fn clear_active_field_api(&mut self)
-src/wasm_api.rs:4749: pub fn get_click_here_props(&self, field_id: u32) -> String
-src/wasm_api.rs:477: pub fn render_page_to_canvas(
-src/wasm_api.rs:4812: pub fn update_click_here_props(
-src/wasm_api.rs:4946: pub fn get_cursor_rect_by_path(
-src/wasm_api.rs:4966: pub fn get_cursor_rect_by_path_near(
-src/wasm_api.rs:4988: pub fn get_cell_info_by_path(
-src/wasm_api.rs:5002: pub fn get_table_dimensions_by_path(
-src/wasm_api.rs:5020: pub fn get_table_cell_bboxes_by_path(
-src/wasm_api.rs:5038: pub fn move_vertical_by_path(
-src/wasm_api.rs:5064: pub fn get_selection_rects(
-src/wasm_api.rs:5087: pub fn get_selection_rects_in_cell(
-src/wasm_api.rs:5118: pub fn get_selection_rects_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:5137: pub fn get_selection_rects_in_footnote(
-src/wasm_api.rs:5161: pub fn delete_range(
-src/wasm_api.rs:5184: pub fn delete_range_in_cell(
-src/wasm_api.rs:519: pub fn render_page_to_canvas_filtered(
-src/wasm_api.rs:5215: pub fn delete_range_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:5245: pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue>
-src/wasm_api.rs:5251: pub fn export_hwpx(&self) -> Result<Vec<u8>, JsValue>
-src/wasm_api.rs:5257: pub fn export_hml(&self) -> Result<Vec<u8>, JsValue>
-src/wasm_api.rs:5277: pub fn export_hwp_verify(&mut self) -> Result<String, JsValue>
-src/wasm_api.rs:5287: pub fn get_source_format(&self) -> String
-src/wasm_api.rs:5294: pub fn get_hml_open_metadata(&self) -> String
-src/wasm_api.rs:5323: pub fn get_hml_save_state(&self) -> String
-src/wasm_api.rs:533: pub fn render_page_to_canvas_filtered_with_profile(
-src/wasm_api.rs:5356: pub fn get_validation_warnings(&self) -> String
-src/wasm_api.rs:5411: pub fn reflow_linesegs(&mut self) -> usize
-src/wasm_api.rs:5419: pub fn convert_to_editable(&mut self) -> Result<String, JsValue>
-src/wasm_api.rs:5425: pub fn begin_batch(&mut self) -> Result<String, JsValue>
-src/wasm_api.rs:5431: pub fn end_batch(&mut self) -> Result<String, JsValue>
-src/wasm_api.rs:5437: pub fn get_event_log(&self) -> String
-src/wasm_api.rs:5445: pub fn save_snapshot(&mut self) -> u32
-src/wasm_api.rs:5451: pub fn restore_snapshot(&mut self, id: u32) -> Result<String, JsValue>
-src/wasm_api.rs:5457: pub fn discard_snapshot(&mut self, id: u32)
-src/wasm_api.rs:5465: pub fn get_char_properties_at(
-src/wasm_api.rs:5477: pub fn get_cell_char_properties_at(
-src/wasm_api.rs:5501: pub fn get_para_properties_at(
-src/wasm_api.rs:5512: pub fn get_cell_para_properties_at(
-src/wasm_api.rs:5534: pub fn get_style_list(&self) -> String
-src/wasm_api.rs:5556: pub fn get_style_detail(&self, style_id: u32) -> String
-src/wasm_api.rs:5619: pub fn update_style(&mut self, style_id: u32, json: &str) -> bool
-src/wasm_api.rs:5645: pub fn update_style_shapes(
-src/wasm_api.rs:5791: pub fn create_style(&mut self, json: &str) -> i32
-src/wasm_api.rs:5844: pub fn delete_style(&mut self, style_id: u32) -> bool
-src/wasm_api.rs:585: pub fn render_page_to_canvas_legacy(
-src/wasm_api.rs:5892: pub fn get_numbering_list(&self) -> String
-src/wasm_api.rs:5916: pub fn get_bullet_list(&self) -> String
-src/wasm_api.rs:5936: pub fn ensure_default_numbering(&mut self) -> u16
-src/wasm_api.rs:5993: pub fn create_numbering(&mut self, json: &str) -> u16
-src/wasm_api.rs:6053: pub fn ensure_default_bullet(&mut self, bullet_char_str: &str) -> u16
-src/wasm_api.rs:6078: pub fn get_style_at(&self, sec_idx: u32, para_idx: u32) -> String
-src/wasm_api.rs:6106: pub fn get_cell_style_at(
-src/wasm_api.rs:6142: pub fn apply_style(
-src/wasm_api.rs:614: pub fn get_page_render_tree(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6155: pub fn apply_cell_style(
-src/wasm_api.rs:6181: pub fn evaluate_table_formula(
-src/wasm_api.rs:6209: pub fn evaluate_table_formula_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6229: pub fn find_or_create_font_id(&mut self, name: &str) -> i32
-src/wasm_api.rs:6235: pub fn wasm_find_or_create_font_id_for_lang(&mut self, lang: u32, name: &str) -> i32
-src/wasm_api.rs:623: pub fn get_page_layer_tree(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6242: pub fn apply_char_format(
-src/wasm_api.rs:6256: pub fn set_char_shape_id(
-src/wasm_api.rs:6270: pub fn apply_char_format_in_cell(
-src/wasm_api.rs:629: pub fn get_page_layer_tree_with_profile(
-src/wasm_api.rs:6300: pub fn apply_char_format_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6318: pub fn set_char_shape_id_in_cell(
-src/wasm_api.rs:6347: pub fn set_char_shape_id_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6364: pub fn set_page_hide(
-src/wasm_api.rs:6393: pub fn set_page_hide_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6410: pub fn get_page_hide(&self, sec: u32, para: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6418: pub fn set_numbering_restart(
-src/wasm_api.rs:6430: pub fn apply_para_format(
-src/wasm_api.rs:6442: pub fn set_para_shape_id(
-src/wasm_api.rs:6454: pub fn apply_para_format_in_cell(
-src/wasm_api.rs:646: pub fn get_canvaskit_replay_plan(&self, page_num: u32, mode: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6476: pub fn set_cell_para_shape_id(
-src/wasm_api.rs:6502: pub fn has_internal_clipboard(&self) -> bool
-src/wasm_api.rs:6508: pub fn get_clipboard_text(&self) -> String
-src/wasm_api.rs:6514: pub fn clear_clipboard(&mut self)
-src/wasm_api.rs:6522: pub fn copy_selection(
-src/wasm_api.rs:652: pub fn get_canvaskit_replay_plan_with_profile(
-src/wasm_api.rs:6542: pub fn copy_selection_in_cell(
-src/wasm_api.rs:6571: pub fn copy_selection_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6591: pub fn copy_control(
-src/wasm_api.rs:6610: pub fn clipboard_has_control(&self) -> bool
-src/wasm_api.rs:6618: pub fn paste_control(
-src/wasm_api.rs:6636: pub fn paste_internal(
-src/wasm_api.rs:6654: pub fn paste_internal_in_cell(
-src/wasm_api.rs:666: pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6678: pub fn paste_internal_in_cell_by_path(
-src/wasm_api.rs:6697: pub fn export_selection_html(
-src/wasm_api.rs:6717: pub fn export_selection_in_cell_html(
-src/wasm_api.rs:673: pub fn get_page_info(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6746: pub fn export_selection_in_cell_html_ex(&self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6763: pub fn export_control_html(
-src/wasm_api.rs:6782: pub fn get_control_image_data(
-src/wasm_api.rs:679: pub fn get_page_def(&self, section_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6801: pub fn get_control_image_mime(
-src/wasm_api.rs:6820: pub fn paste_html(
-src/wasm_api.rs:6838: pub fn paste_html_in_cell(
-src/wasm_api.rs:6865: pub fn paste_html_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:686: pub fn set_page_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:6881: pub fn paste_html_in_cell_by_path(
-src/wasm_api.rs:6902: pub fn measure_width_diagnostic(
-src/wasm_api.rs:6916:pub struct HwpViewer
-src/wasm_api.rs:6927: pub fn new(document: HwpDocument) -> Self
-src/wasm_api.rs:6938: pub fn update_viewport(&mut self, scroll_x: f64, scroll_y: f64, width: f64, height: f64)
-src/wasm_api.rs:693: pub fn get_section_def(&self, section_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6951: pub fn set_zoom(&mut self, zoom: f64)
-src/wasm_api.rs:6958: pub fn visible_pages(&self) -> Vec<u32>
-src/wasm_api.rs:6964: pub fn pending_task_count(&self) -> u32
-src/wasm_api.rs:6970: pub fn page_count(&self) -> u32
-src/wasm_api.rs:6976: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6982: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:6999: pub fn get_bookmarks(&self) -> Result<String, JsValue>
-src/wasm_api.rs:7007: pub fn get_structure(&self, mode: &str) -> Result<String, JsValue>
-src/wasm_api.rs:700: pub fn set_section_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:7013: pub fn add_bookmark(
-src/wasm_api.rs:7027: pub fn delete_bookmark(
-src/wasm_api.rs:7040: pub fn rename_bookmark(
-src/wasm_api.rs:7060:pub fn extract_thumbnail(data: &[u8]) -> JsValue
-src/wasm_api.rs:707: pub fn set_section_def_all(&mut self, json: &str) -> Result<String, JsValue>
-src/wasm_api.rs:713: pub fn get_page_border_fill(&self, section_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:720: pub fn set_page_border_fill(
-src/wasm_api.rs:731: pub fn get_column_def(&self, section_idx: u32) -> Result<String, JsValue>
-src/wasm_api.rs:752: pub fn get_document_info(&self) -> String
-src/wasm_api.rs:760: pub fn get_page_text_layout(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:767: pub fn get_page_control_layout(&self, page_num: u32) -> Result<String, JsValue>
-src/wasm_api.rs:774: pub fn set_dpi(&mut self, dpi: f64)
-src/wasm_api.rs:780: pub fn set_file_name(&mut self, name: &str)
-src/wasm_api.rs:789: pub fn get_dpi(&self) -> f64
-src/wasm_api.rs:795: pub fn set_fallback_font(&mut self, path: &str)
-src/wasm_api.rs:801: pub fn get_fallback_font(&self) -> String
-src/wasm_api.rs:810: pub fn insert_text(
-src/wasm_api.rs:833: pub fn insert_text_logical(
-src/wasm_api.rs:862: pub fn get_logical_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
-src/wasm_api.rs:876: pub fn logical_to_text_offset(
-src/wasm_api.rs:897: pub fn text_to_logical_offset(
-src/wasm_api.rs:920: pub fn delete_text(
-src/wasm_api.rs:940: pub fn insert_text_in_cell(
-src/wasm_api.rs:968: pub fn insert_text_in_cell_deferred_pagination(
-src/wasm_api.rs:992: pub fn flush_deferred_pagination(&mut self) -> Result<String, JsValue>
-src/wasm_api/event.rs:6:pub use crate::model::event::*
-src/wmf/converter/bitmap.rs:15: pub fn as_slice(&self) -> &[u8]
-src/wmf/converter/bitmap.rs:19: pub fn to_vec(self) -> Vec<u8>
-src/wmf/converter/bitmap.rs:4:pub struct Bitmap(Vec<u8>)
-src/wmf/converter/graphics_object.rs:104: pub fn pen(mut self, pen: Pen) -> Self
-src/wmf/converter/graphics_object.rs:109: pub fn region(mut self, region: Region) -> Self
-src/wmf/converter/graphics_object.rs:14:pub struct GraphicsObjects(Vec<GraphicsObject>, GraphicsObject)
-src/wmf/converter/graphics_object.rs:17: pub fn new(v: usize) -> Self
-src/wmf/converter/graphics_object.rs:21: pub fn delete(&mut self, i: usize)
-src/wmf/converter/graphics_object.rs:25: pub fn get(&self, i: usize) -> &GraphicsObject
-src/wmf/converter/graphics_object.rs:29: pub fn push(&mut self, g: GraphicsObject)
-src/wmf/converter/graphics_object.rs:40:pub struct SelectedGraphicsObject
-src/wmf/converter/graphics_object.rs:4:pub enum GraphicsObject
-src/wmf/converter/graphics_object.rs:89: pub fn brush(mut self, brush: Brush) -> Self
-src/wmf/converter/graphics_object.rs:94: pub fn font(mut self, font: Font) -> Self
-src/wmf/converter/graphics_object.rs:99: pub fn palette(mut self, palette: Palette) -> Self
-src/wmf/converter/mod.rs:11:pub use self::svg::*
-src/wmf/converter/mod.rs:14:pub enum ConvertError
-src/wmf/converter/mod.rs:35:pub struct WMFConverter<B, P>
-src/wmf/converter/mod.rs:41: pub fn new(buffer: B, player: P) -> Self
-src/wmf/converter/mod.rs:56: pub fn run(self) -> Result<Vec<u8>, ConvertError>
-src/wmf/converter/mod.rs:6:pub use self::{bitmap::Bitmap, player::*}
-src/wmf/converter/player.rs:17:pub trait Player: Sized
-src/wmf/converter/player.rs:4:pub enum PlayError
-src/wmf/converter/svg/device_context.rs:106: pub fn map_mode(mut self, map_mode: MapMode) -> Self
-src/wmf/converter/svg/device_context.rs:111: pub fn poly_fill_mode(mut self, poly_fill_mode: PolyFillMode) -> Self
-src/wmf/converter/svg/device_context.rs:116: pub fn text_align_horizontal(mut self, text_align_horizontal: TextAlignmentMode) -> Self
-src/wmf/converter/svg/device_context.rs:121: pub fn text_align_vertical(mut self, text_align_vertical: VerticalTextAlignmentMode) -> Self
-src/wmf/converter/svg/device_context.rs:126: pub fn text_align_update_cp(mut self, text_align_update_cp: bool) -> Self
-src/wmf/converter/svg/device_context.rs:131: pub fn text_bk_color(mut self, text_bk_color: ColorRef) -> Self
-src/wmf/converter/svg/device_context.rs:136: pub fn text_color(mut self, text_color: ColorRef) -> Self
-src/wmf/converter/svg/device_context.rs:141: pub fn window_ext(mut self, x: i16, y: i16) -> Self
-src/wmf/converter/svg/device_context.rs:146: pub fn window_origin(mut self, x: i16, y: i16) -> Self
-src/wmf/converter/svg/device_context.rs:151: pub fn window_scale(mut self, x: f32, y: f32) -> Self
-src/wmf/converter/svg/device_context.rs:158: pub fn as_css_text_align(&self) -> String
-src/wmf/converter/svg/device_context.rs:166: pub fn as_css_text_align_vertical(&self) -> String
-src/wmf/converter/svg/device_context.rs:176: pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS
-src/wmf/converter/svg/device_context.rs:183: pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS
-src/wmf/converter/svg/device_context.rs:192: pub fn poly_fill_rule(&self) -> String
-src/wmf/converter/svg/device_context.rs:200: pub fn text_color_as_css_color(&self) -> String
-src/wmf/converter/svg/device_context.rs:206:pub struct Window
-src/wmf/converter/svg/device_context.rs:236: pub fn new() -> Self
-src/wmf/converter/svg/device_context.rs:240: pub fn ext(mut self, x: i16, y: i16) -> Self
-src/wmf/converter/svg/device_context.rs:253: pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self
-src/wmf/converter/svg/device_context.rs:259: pub fn scale(mut self, scale_x: f32, scale_y: f32) -> Self
-src/wmf/converter/svg/device_context.rs:265: pub fn as_view_box(&self) -> (i16, i16, i16, i16)
-src/wmf/converter/svg/device_context.rs:48: pub fn bk_mode(mut self, bk_mode: MixMode) -> Self
-src/wmf/converter/svg/device_context.rs:4:pub struct DeviceContext
-src/wmf/converter/svg/device_context.rs:53: pub fn create_object_table(mut self, length: u16) -> Self
-src/wmf/converter/svg/device_context.rs:58: pub fn clipping_region(mut self, clipping_region: Rect) -> Self
-src/wmf/converter/svg/device_context.rs:73: pub fn drawing_position(mut self, drawing_position: PointS) -> Self
-src/wmf/converter/svg/device_context.rs:78: pub fn draw_mode(mut self, draw_mode: BinaryRasterOperation) -> Self
-src/wmf/converter/svg/device_context.rs:83: pub fn extend_window(self, p: &PointS) -> Self
-src/wmf/converter/svg/mod.rs:21:pub struct SVGPlayer
-src/wmf/converter/svg/mod.rs:31: pub fn new() -> Self
-src/wmf/converter/svg/node.rs:101: pub fn close(mut self) -> Self
-src/wmf/converter/svg/node.rs:107: pub fn elliptical_arc_to(mut self, param: impl Into<Parameters>) -> Self
-src/wmf/converter/svg/node.rs:113: pub fn line_to(mut self, param: impl Into<Parameters>) -> Self
-src/wmf/converter/svg/node.rs:119: pub fn move_to(mut self, param: impl Into<Parameters>) -> Self
-src/wmf/converter/svg/node.rs:132:pub struct Parameters(String)
-src/wmf/converter/svg/node.rs:18: pub fn new(name: impl ToString) -> Self
-src/wmf/converter/svg/node.rs:26: pub fn new_text(value: impl ToString) -> Self
-src/wmf/converter/svg/node.rs:34: pub fn add(mut self, node: Node) -> Self
-src/wmf/converter/svg/node.rs:42: pub fn set(mut self, name: impl ToString, value: impl ToString) -> Self
-src/wmf/converter/svg/node.rs:4:pub struct Node
-src/wmf/converter/svg/node.rs:91:pub struct Data
-src/wmf/converter/svg/node.rs:96: pub fn new() -> Self
-src/wmf/converter/svg/ternary_raster_operator.rs:14:pub struct TernaryRasterOperator
-src/wmf/converter/svg/ternary_raster_operator.rs:30: pub fn new(operation: TernaryRasterOperation, x: i16, y: i16, height: i16, width: i16) -> Self
-src/wmf/converter/svg/ternary_raster_operator.rs:42: pub fn brush(mut self, brush: Brush) -> Self
-src/wmf/converter/svg/ternary_raster_operator.rs:47: pub fn source_bitmap16(mut self, source: Bitmap16) -> Self
-src/wmf/converter/svg/ternary_raster_operator.rs:52: pub fn source_bitmap(mut self, source: DeviceIndependentBitmap) -> Self
-src/wmf/converter/svg/ternary_raster_operator.rs:57: pub fn run(
-src/wmf/converter/svg/ternary_raster_operator.rs:7:pub enum TernaryRasterOperationError
-src/wmf/converter/svg/util.rs:11:pub fn url_string(link: &str) -> String
-src/wmf/converter/svg/util.rs:15:pub fn as_point_string(point: &PointS) -> String
-src/wmf/converter/svg/util.rs:20: pub fn as_data_url(&self) -> String
-src/wmf/converter/svg/util.rs:210:pub struct Stroke
-src/wmf/converter/svg/util.rs:336: pub fn color(&self) -> String
-src/wmf/converter/svg/util.rs:340: pub fn dash_array(&self) -> String
-src/wmf/converter/svg/util.rs:344: pub fn line_cap(&self) -> String
-src/wmf/converter/svg/util.rs:348: pub fn line_join(&self) -> String
-src/wmf/converter/svg/util.rs:34: pub fn as_filter(&self) -> Node
-src/wmf/converter/svg/util.rs:352: pub fn opacity(&self) -> String
-src/wmf/converter/svg/util.rs:356: pub fn width(&self) -> i16
-src/wmf/converter/svg/util.rs:360: pub fn set_props(&self, elem: Node) -> Node
-src/wmf/converter/svg/util.rs:375: pub fn set_props(&self, mut elem: Node, point: &PointS) -> (Node, Vec<String>)
-src/wmf/converter/svg/util.rs:7:pub fn css_color_from_color_ref(c: &ColorRef) -> String
-src/wmf/converter/svg/util.rs:84:pub enum Fill
-src/wmf/mod.rs:37:pub mod converter
-src/wmf/mod.rs:38:pub mod parser
-src/wmf/mod.rs:41: pub use std::{
-src/wmf/mod.rs:50:pub use embedded_io::Read
-src/wmf/parser/constants/enums/binary_raster_operation.rs:7:pub enum BinaryRasterOperation
-src/wmf/parser/constants/enums/bit_count.rs:5:pub enum BitCount
-src/wmf/parser/constants/enums/brush_style.rs:6:pub enum BrushStyle
-src/wmf/parser/constants/enums/character_set.rs:7:pub enum CharacterSet
-src/wmf/parser/constants/enums/color_usage.rs:5:pub enum ColorUsage
-src/wmf/parser/constants/enums/compression.rs:5:pub enum Compression
-src/wmf/parser/constants/enums/family_font.rs:6:pub enum FamilyFont
-src/wmf/parser/constants/enums/flood_fill.rs:5:pub enum FloodFill
-src/wmf/parser/constants/enums/font_quality.rs:5:pub enum FontQuality
-src/wmf/parser/constants/enums/gamut_mapping_intent.rs:6:pub enum GamutMappingIntent
-src/wmf/parser/constants/enums/hatch_style.rs:4:pub enum HatchStyle
-src/wmf/parser/constants/enums/layout.rs:7:pub enum Layout
-src/wmf/parser/constants/enums/logical_color_space.rs:10:pub enum LogicalColorSpace
-src/wmf/parser/constants/enums/map_mode.rs:17:pub enum MapMode
-src/wmf/parser/constants/enums/metafile_escapes.rs:8:pub enum MetafileEscapes
-src/wmf/parser/constants/enums/metafile_type.rs:4:pub enum MetafileType
-src/wmf/parser/constants/enums/metafile_version.rs:5:pub enum MetafileVersion
-src/wmf/parser/constants/enums/mix_mode.rs:5:pub enum MixMode
-src/wmf/parser/constants/enums/mod.rs:35:pub use self::{
-src/wmf/parser/constants/enums/out_precision.rs:7:pub enum OutPrecision
-src/wmf/parser/constants/enums/palette_entry_flag.rs:4:pub enum PaletteEntryFlag
-src/wmf/parser/constants/enums/pen_style.rs:49: pub fn end_cap() -> BTreeSet<Self>
-src/wmf/parser/constants/enums/pen_style.rs:58: pub fn line_join() -> BTreeSet<Self>
-src/wmf/parser/constants/enums/pen_style.rs:67: pub fn style() -> BTreeSet<Self>
-src/wmf/parser/constants/enums/pen_style.rs:7:pub enum PenStyle
-src/wmf/parser/constants/enums/pitch_font.rs:9:pub enum PitchFont
-src/wmf/parser/constants/enums/poly_fill_mode.rs:5:pub enum PolyFillMode
-src/wmf/parser/constants/enums/post_script_cap.rs:5:pub enum PostScriptCap
-src/wmf/parser/constants/enums/post_script_clipping.rs:5:pub enum PostScriptClipping
-src/wmf/parser/constants/enums/post_script_feature_setting.rs:7:pub enum PostScriptFeatureSetting
-src/wmf/parser/constants/enums/post_script_join.rs:5:pub enum PostScriptJoin
-src/wmf/parser/constants/enums/record_type.rs:5:pub enum RecordType
-src/wmf/parser/constants/enums/stretch_mode.rs:6:pub enum StretchMode
-src/wmf/parser/constants/enums/ternary_raster_operation.rs:532: pub fn use_selected_brush(&self) -> bool
-src/wmf/parser/constants/enums/ternary_raster_operation.rs:537: pub fn use_source(&self) -> bool
-src/wmf/parser/constants/enums/ternary_raster_operation.rs:8:pub enum TernaryRasterOperation
-src/wmf/parser/constants/flags/clip_precision.rs:6:pub enum ClipPrecision
-src/wmf/parser/constants/flags/ext_text_out_options.rs:5:pub enum ExtTextOutOptions
-src/wmf/parser/constants/flags/mod.rs:9:pub use self::{
-src/wmf/parser/constants/flags/text_alignment_mode.rs:10:pub enum TextAlignmentMode
-src/wmf/parser/constants/flags/vertical_text_alignment_mode.rs:11:pub enum VerticalTextAlignmentMode
-src/wmf/parser/constants/mod.rs:30: pub fn parse<R: $crate::wmf::Read>(
-src/wmf/parser/constants/mod.rs:6:pub use self::{enums::*, flags::*}
-src/wmf/parser/mod.rs:28:pub struct ReadError
-src/wmf/parser/mod.rs:33: pub fn new(err: impl core::fmt::Display) -> Self
-src/wmf/parser/mod.rs:40:pub fn read<R: crate::wmf::Read, const N: usize>(
-src/wmf/parser/mod.rs:54:pub fn read_variable<R: crate::wmf::Read>(
-src/wmf/parser/mod.rs:5:pub use self::{constants::*, objects::*, records::*}
-src/wmf/parser/mod.rs:77: pub fn [<read_ $t _from_le_bytes>]<R: $crate::wmf::Read>(
-src/wmf/parser/mod.rs:9:pub enum ParseError
-src/wmf/parser/objects/graphics/brush.rs:29: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/brush.rs:5:pub enum Brush
-src/wmf/parser/objects/graphics/font.rs:110: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/font.rs:5:pub struct Font
-src/wmf/parser/objects/graphics/mod.rs:10:pub use self::{brush::*, font::*, palette::*, pen::*, region::*}
-src/wmf/parser/objects/graphics/palette.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/palette.rs:5:pub struct Palette
-src/wmf/parser/objects/graphics/pen.rs:22: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/pen.rs:3:pub struct Pen
-src/wmf/parser/objects/graphics/pen.rs:43:pub struct PenStyleSubsection
-src/wmf/parser/objects/graphics/pen.rs:56: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/pen.rs:85: pub fn line_join(v: u16) -> crate::wmf::parser::PenStyle
-src/wmf/parser/objects/graphics/pen.rs:97: pub fn style(v: u16) -> crate::wmf::parser::PenStyle
-src/wmf/parser/objects/graphics/region.rs:39: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/graphics/region.rs:6:pub struct Region
-src/wmf/parser/objects/mod.rs:6:pub use self::{graphics::*, structure::*}
-src/wmf/parser/objects/structure/bitmap16.rs:125: pub fn calc_length(&self) -> usize
-src/wmf/parser/objects/structure/bitmap16.rs:56: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/bitmap16.rs:73: pub fn parse_without_bits<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/bitmap16.rs:8:pub struct Bitmap16
-src/wmf/parser/objects/structure/bitmap_info_header/core.rs:10:pub struct BitmapInfoHeaderCore
-src/wmf/parser/objects/structure/bitmap_info_header/info.rs:6:pub struct BitmapInfoHeaderInfo
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:123: pub fn color_used(&self) -> u32
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:157: pub fn height(&self) -> usize
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:166: pub fn width(&self) -> usize
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:17: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:56: pub fn header_size(&self) -> u32
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:65: pub fn bit_count(&self) -> crate::wmf::parser::BitCount
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:6:pub use self::{core::*, info::*, v4::*, v5::*}
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:74: pub fn size(&self) -> usize
-src/wmf/parser/objects/structure/bitmap_info_header/mod.rs:9:pub enum BitmapInfoHeader
-src/wmf/parser/objects/structure/bitmap_info_header/v4.rs:6:pub struct BitmapInfoHeaderV4
-src/wmf/parser/objects/structure/bitmap_info_header/v5.rs:171: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/bitmap_info_header/v5.rs:7:pub struct BitmapInfoHeaderV5
-src/wmf/parser/objects/structure/ciexyz.rs:21: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/ciexyz.rs:3:pub struct CIEXYZ
-src/wmf/parser/objects/structure/ciexyz_triple.rs:22: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/ciexyz_triple.rs:4:pub struct CIEXYZTriple
-src/wmf/parser/objects/structure/color_ref.rs:23: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/color_ref.rs:3:pub struct ColorRef
-src/wmf/parser/objects/structure/color_ref.rs:61: pub fn black() -> Self
-src/wmf/parser/objects/structure/color_ref.rs:70: pub fn white() -> Self
-src/wmf/parser/objects/structure/device_independent_bitmap.rs:245:pub struct BitmapBuffer
-src/wmf/parser/objects/structure/device_independent_bitmap.rs:63:pub enum Colors
-src/wmf/parser/objects/structure/device_independent_bitmap.rs:6:pub struct DeviceIndependentBitmap
-src/wmf/parser/objects/structure/device_independent_bitmap.rs:71: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/log_brush.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/log_brush.rs:5:pub enum LogBrush
-src/wmf/parser/objects/structure/log_color_space.rs:59: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/log_color_space.rs:7:pub struct LogColorSpace
-src/wmf/parser/objects/structure/log_color_space_w.rs:59: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/log_color_space_w.rs:7:pub struct LogColorSpaceW
-src/wmf/parser/objects/structure/mod.rs:25:pub use self::{
-src/wmf/parser/objects/structure/palette_entry.rs:26: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/palette_entry.rs:4:pub struct PaletteEntry
-src/wmf/parser/objects/structure/pitch_and_family.rs:20: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/pitch_and_family.rs:5:pub struct PitchAndFamily
-src/wmf/parser/objects/structure/point_l.rs:18: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/point_l.rs:3:pub struct PointL
-src/wmf/parser/objects/structure/point_s.rs:18: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/point_s.rs:3:pub struct PointS
-src/wmf/parser/objects/structure/poly_polygon.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/poly_polygon.rs:5:pub struct PolyPolygon
-src/wmf/parser/objects/structure/rect.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/rect.rs:3:pub struct Rect
-src/wmf/parser/objects/structure/rect.rs:46: pub fn overlap(&self, other: &Rect) -> Option<Rect>
-src/wmf/parser/objects/structure/rect_l.rs:27: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/rect_l.rs:6:pub struct RectL
-src/wmf/parser/objects/structure/rgb_quad.rs:26: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/rgb_quad.rs:6:pub struct RGBQuad
-src/wmf/parser/objects/structure/rgb_triple.rs:22: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/rgb_triple.rs:4:pub struct RGBTriple
-src/wmf/parser/objects/structure/scan.rs:102: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/scan.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/scan.rs:6:pub struct Scan
-src/wmf/parser/objects/structure/scan.rs:85:pub struct ScanLine
-src/wmf/parser/objects/structure/size_l.rs:18: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/objects/structure/size_l.rs:3:pub struct SizeL
-src/wmf/parser/records/bitmap/bit_blt.rs:110: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/bit_blt.rs:19:pub enum META_BITBLT
-src/wmf/parser/records/bitmap/dib_bit_blt.rs:114: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/dib_bit_blt.rs:23:pub enum META_DIBBITBLT
-src/wmf/parser/records/bitmap/dib_stretch_blt.rs:131: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/dib_stretch_blt.rs:29:pub enum META_DIBSTRETCHBLT
-src/wmf/parser/records/bitmap/mod.rs:11:pub use self::{
-src/wmf/parser/records/bitmap/set_dib_to_dev.rs:60: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/set_dib_to_dev.rs:6:pub struct META_SETDIBTODEV
-src/wmf/parser/records/bitmap/stretch_blt.rs:128: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/stretch_blt.rs:25:pub enum META_STRETCHBLT
-src/wmf/parser/records/bitmap/stretch_dib.rs:71: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/bitmap/stretch_dib.rs:8:pub struct META_STRETCHDIB
-src/wmf/parser/records/control/eof.rs:26: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/control/eof.rs:5:pub struct META_EOF
-src/wmf/parser/records/control/header.rs:6:pub struct META_HEADER
-src/wmf/parser/records/control/mod.rs:11:pub enum MetafileHeader
-src/wmf/parser/records/control/mod.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/control/mod.rs:8:pub use self::{eof::*, header::*, placeable::*}
-src/wmf/parser/records/control/placeable.rs:11:pub struct META_PLACEABLE
-src/wmf/parser/records/drawing/arc.rs:3:pub struct META_ARC
-src/wmf/parser/records/drawing/arc.rs:56: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/chord.rs:59: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/chord.rs:6:pub struct META_CHORD
-src/wmf/parser/records/drawing/ellipse.rs:43: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/ellipse.rs:6:pub struct META_ELLIPSE
-src/wmf/parser/records/drawing/ext_flood_fill.rs:38: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/ext_flood_fill.rs:4:pub struct META_EXTFLOODFILL
-src/wmf/parser/records/drawing/ext_text_out.rs:168: pub fn into_utf8(
-src/wmf/parser/records/drawing/ext_text_out.rs:64: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/ext_text_out.rs:7:pub struct META_EXTTEXTOUT
-src/wmf/parser/records/drawing/fill_region.rs:30: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/fill_region.rs:3:pub struct META_FILLREGION
-src/wmf/parser/records/drawing/flood_fill.rs:34: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/flood_fill.rs:4:pub struct META_FLOODFILL
-src/wmf/parser/records/drawing/frame_region.rs:37: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/frame_region.rs:4:pub struct META_FRAMEREGION
-src/wmf/parser/records/drawing/invert_region.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/invert_region.rs:4:pub struct META_INVERTREGION
-src/wmf/parser/records/drawing/line_to.rs:32: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/line_to.rs:5:pub struct META_LINETO
-src/wmf/parser/records/drawing/mod.rs:25:pub use self::{
-src/wmf/parser/records/drawing/paint_region.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/paint_region.rs:4:pub struct META_PAINTREGION
-src/wmf/parser/records/drawing/pat_blt.rs:44: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/pat_blt.rs:5:pub struct META_PATBLT
-src/wmf/parser/records/drawing/pie.rs:58: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/pie.rs:5:pub struct META_PIE
-src/wmf/parser/records/drawing/poly_line.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/poly_line.rs:6:pub struct META_POLYLINE
-src/wmf/parser/records/drawing/poly_polygon.rs:30: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/poly_polygon.rs:6:pub struct META_POLYPOLYGON
-src/wmf/parser/records/drawing/polygon.rs:36: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/polygon.rs:8:pub struct META_POLYGON
-src/wmf/parser/records/drawing/rectangle.rs:42: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/rectangle.rs:5:pub struct META_RECTANGLE
-src/wmf/parser/records/drawing/round_rect.rs:48: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/round_rect.rs:5:pub struct META_ROUNDRECT
-src/wmf/parser/records/drawing/set_pixel.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/set_pixel.rs:4:pub struct META_SETPIXEL
-src/wmf/parser/records/drawing/text_out.rs:47: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/drawing/text_out.rs:7:pub struct META_TEXTOUT
-src/wmf/parser/records/drawing/text_out.rs:90: pub fn into_utf8(
-src/wmf/parser/records/escape/mod.rs:54:pub enum META_ESCAPE
-src/wmf/parser/records/escape/mod.rs:843: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/mod.rs:102: pub fn remaining(&self) -> bool
-src/wmf/parser/records/mod.rs:106: pub fn remaining_bytes(&self) -> usize
-src/wmf/parser/records/mod.rs:10:pub use self::{bitmap::*, control::*, drawing::*, escape::*, object::*, state::*}
-src/wmf/parser/records/mod.rs:42:pub struct RecordSize(u32, usize)
-src/wmf/parser/records/mod.rs:50: pub fn parse<R: crate::wmf::Read>(buf: &mut R) -> Result<Self, crate::wmf::parser::ParseError>
-src/wmf/parser/records/mod.rs:86: pub fn byte_count(&self) -> usize
-src/wmf/parser/records/mod.rs:90: pub fn word_size(&self) -> usize
-src/wmf/parser/records/mod.rs:94: pub fn consume(&mut self, consumed_bytes: usize)
-src/wmf/parser/records/mod.rs:98: pub fn consumed_bytes(&self) -> usize
-src/wmf/parser/records/object/create_brush_indirect.rs:30: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_brush_indirect.rs:4:pub struct META_CREATEBRUSHINDIRECT
-src/wmf/parser/records/object/create_brush_indirect.rs:52: pub fn create_brush(&self) -> crate::wmf::parser::Brush
-src/wmf/parser/records/object/create_font_indirect.rs:26: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_font_indirect.rs:3:pub struct META_CREATEFONTINDIRECT
-src/wmf/parser/records/object/create_palette.rs:27: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_palette.rs:3:pub struct META_CREATEPALETTE
-src/wmf/parser/records/object/create_pattern_brush.rs:55: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_pattern_brush.rs:85: pub fn create_brush(&self) -> crate::wmf::parser::Brush
-src/wmf/parser/records/object/create_pattern_brush.rs:9:pub struct META_CREATEPATTERNBRUSH
-src/wmf/parser/records/object/create_pen_indirect.rs:26: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_pen_indirect.rs:3:pub struct META_CREATEPENINDIRECT
-src/wmf/parser/records/object/create_region.rs:27: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/create_region.rs:3:pub struct META_CREATEREGION
-src/wmf/parser/records/object/delete_object.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/delete_object.rs:7:pub struct META_DELETEOBJECT
-src/wmf/parser/records/object/dib_create_pattern_brush.rs:43: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/dib_create_pattern_brush.rs:4:pub struct META_DIBCREATEPATTERNBRUSH
-src/wmf/parser/records/object/dib_create_pattern_brush.rs:80: pub fn create_brush(&self) -> crate::wmf::parser::Brush
-src/wmf/parser/records/object/mod.rs:16:pub use self::{
-src/wmf/parser/records/object/select_clip_region.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/select_clip_region.rs:4:pub struct META_SELECTCLIPREGION
-src/wmf/parser/records/object/select_object.rs:10:pub struct META_SELECTOBJECT
-src/wmf/parser/records/object/select_object.rs:34: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/select_palette.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/object/select_palette.rs:4:pub struct META_SELECTPALETTE
-src/wmf/parser/records/state/animate_palette.rs:13:pub struct META_ANIMATEPALETTE
-src/wmf/parser/records/state/animate_palette.rs:37: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/exclude_clip_rect.rs:39: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/exclude_clip_rect.rs:5:pub struct META_EXCLUDECLIPRECT
-src/wmf/parser/records/state/intersect_clip_rect.rs:39: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/intersect_clip_rect.rs:5:pub struct META_INTERSECTCLIPRECT
-src/wmf/parser/records/state/mod.rs:36:pub use self::{
-src/wmf/parser/records/state/move_to.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/move_to.rs:4:pub struct META_MOVETO
-src/wmf/parser/records/state/offset_clip_rgn.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/offset_clip_rgn.rs:4:pub struct META_OFFSETCLIPRGN
-src/wmf/parser/records/state/offset_viewport_org.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/offset_viewport_org.rs:4:pub struct META_OFFSETVIEWPORTORG
-src/wmf/parser/records/state/offset_window_org.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/offset_window_org.rs:4:pub struct META_OFFSETWINDOWORG
-src/wmf/parser/records/state/realize_palette.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/realize_palette.rs:4:pub struct META_REALIZEPALETTE
-src/wmf/parser/records/state/resize_palette.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/resize_palette.rs:4:pub struct META_RESIZEPALETTE
-src/wmf/parser/records/state/restore_dc.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/restore_dc.rs:4:pub struct META_RESTOREDC
-src/wmf/parser/records/state/save_dc.rs:25: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/save_dc.rs:4:pub struct META_SAVEDC
-src/wmf/parser/records/state/scale_viewport_ext.rs:40: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/scale_viewport_ext.rs:5:pub struct META_SCALEVIEWPORTEXT
-src/wmf/parser/records/state/scale_window_ext.rs:40: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/scale_window_ext.rs:5:pub struct META_SCALEWINDOWEXT
-src/wmf/parser/records/state/set_bk_color.rs:29: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_bk_color.rs:5:pub struct META_SETBKCOLOR
-src/wmf/parser/records/state/set_bk_mode.rs:34: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_bk_mode.rs:6:pub struct META_SETBKMODE
-src/wmf/parser/records/state/set_layout.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_layout.rs:6:pub struct META_SETLAYOUT
-src/wmf/parser/records/state/set_map_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_map_mode.rs:8:pub struct META_SETMAPMODE
-src/wmf/parser/records/state/set_mapper_flags.rs:30: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_mapper_flags.rs:4:pub struct META_SETMAPPERFLAGS
-src/wmf/parser/records/state/set_pal_entries.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_pal_entries.rs:4:pub struct META_SETPALENTRIES
-src/wmf/parser/records/state/set_polyfill_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_polyfill_mode.rs:4:pub struct META_SETPOLYFILLMODE
-src/wmf/parser/records/state/set_relabs.rs:24: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_relabs.rs:3:pub struct META_SETRELABS
-src/wmf/parser/records/state/set_rop2.rs:35: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_rop2.rs:6:pub struct META_SETROP2
-src/wmf/parser/records/state/set_stretch_blt_mode.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_stretch_blt_mode.rs:4:pub struct META_SETSTRETCHBLTMODE
-src/wmf/parser/records/state/set_text_align.rs:34: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_text_align.rs:4:pub struct META_SETTEXTALIGN
-src/wmf/parser/records/state/set_text_char_extra.rs:33: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_text_char_extra.rs:6:pub struct META_SETTEXTCHAREXTRA
-src/wmf/parser/records/state/set_text_color.rs:28: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_text_color.rs:4:pub struct META_SETTEXTCOLOR
-src/wmf/parser/records/state/set_text_justification.rs:34: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_text_justification.rs:4:pub struct META_SETTEXTJUSTIFICATION
-src/wmf/parser/records/state/set_viewport_ext.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_viewport_ext.rs:4:pub struct META_SETVIEWPORTEXT
-src/wmf/parser/records/state/set_viewport_org.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_viewport_org.rs:4:pub struct META_SETVIEWPORTORG
-src/wmf/parser/records/state/set_window_ext.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_window_ext.rs:4:pub struct META_SETWINDOWEXT
-src/wmf/parser/records/state/set_window_org.rs:31: pub fn parse<R: crate::wmf::Read>(
-src/wmf/parser/records/state/set_window_org.rs:4:pub struct META_SETWINDOWORG
+src/diagnostics/bench.rs: pub fn run(args: &[String])
+src/diagnostics/core_pages_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_anchor_trace.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_borderfill_diagonal_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_cell_header_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_contract_analyze.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_contract_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_ctrl_data_trace.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_first_para_control_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_inventory.rs: pub fn build_inventory(path: &Path, section_filter: Option<u32>) -> Result<Hwp5Inventory, String>
+src/diagnostics/hwp5_inventory.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_inventory.rs: pub struct Hwp5Inventory
+src/diagnostics/hwp5_inventory.rs: pub struct Hwp5InventoryItem
+src/diagnostics/hwp5_inventory_diff.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_mel_personnel_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_roundtrip_batch.rs: pub fn baseline_check(bytes: &[u8]) -> Result<(), String>
+src/diagnostics/hwp5_roundtrip_batch.rs: pub fn run(args: &[String])
+src/diagnostics/hwp5_table_probe.rs: pub fn run(args: &[String])
+src/diagnostics/hwpx_roundtrip_batch.rs: pub fn run(args: &[String])
+src/diagnostics/mod.rs: pub mod bench
+src/diagnostics/mod.rs: pub mod core_pages_probe
+src/diagnostics/mod.rs: pub mod hwp5_anchor_trace
+src/diagnostics/mod.rs: pub mod hwp5_borderfill_diagonal_probe
+src/diagnostics/mod.rs: pub mod hwp5_cell_header_probe
+src/diagnostics/mod.rs: pub mod hwp5_contract_analyze
+src/diagnostics/mod.rs: pub mod hwp5_contract_probe
+src/diagnostics/mod.rs: pub mod hwp5_ctrl_data_trace
+src/diagnostics/mod.rs: pub mod hwp5_first_para_control_probe
+src/diagnostics/mod.rs: pub mod hwp5_inventory
+src/diagnostics/mod.rs: pub mod hwp5_inventory_diff
+src/diagnostics/mod.rs: pub mod hwp5_mel_personnel_probe
+src/diagnostics/mod.rs: pub mod hwp5_roundtrip_batch
+src/diagnostics/mod.rs: pub mod hwp5_table_probe
+src/diagnostics/mod.rs: pub mod hwpx_roundtrip_batch
+src/diagnostics/mod.rs: pub mod render_geom_diff
+src/diagnostics/mod.rs: pub mod text_width_probe
+src/diagnostics/render_geom_diff.rs: pub enum Via
+src/diagnostics/render_geom_diff.rs: pub fn any_structure_mismatch(&self) -> bool
+src/diagnostics/render_geom_diff.rs: pub fn diff_page(page: u32, root_a: &RenderNode, root_b: &RenderNode) -> PageGeomDiff
+src/diagnostics/render_geom_diff.rs: pub fn diff_render_geometry(a: &DocumentCore, b: &DocumentCore) -> Result<DocGeomDiff, HwpError>
+src/diagnostics/render_geom_diff.rs: pub fn disp(&self) -> f64
+src/diagnostics/render_geom_diff.rs: pub fn net(&self) -> i64
+src/diagnostics/render_geom_diff.rs: pub fn page_count_mismatch(&self) -> bool
+src/diagnostics/render_geom_diff.rs: pub fn roundtrip_geom(data: &[u8], via: Via) -> Result<DocGeomDiff, HwpError>
+src/diagnostics/render_geom_diff.rs: pub fn run(args: &[String])
+src/diagnostics/render_geom_diff.rs: pub struct DocGeomDiff
+src/diagnostics/render_geom_diff.rs: pub struct NodeDelta
+src/diagnostics/render_geom_diff.rs: pub struct PageGeomDiff
+src/diagnostics/render_geom_diff.rs: pub struct TypeDelta
+src/diagnostics/text_width_probe.rs: pub fn run(args: &[String])
+src/document_core/builders/exam_paper.rs: pub fn build_exam_paper(ingest: &IngestDocument) -> Document
+src/document_core/builders/mod.rs: pub mod exam_paper
+src/document_core/commands/clipboard.rs: pub fn clear_clipboard_native(&mut self)
+src/document_core/commands/clipboard.rs: pub fn clipboard_has_control_native(&self) -> bool
+src/document_core/commands/clipboard.rs: pub fn copy_control_native(
+src/document_core/commands/clipboard.rs: pub fn copy_selection_in_cell_native(
+src/document_core/commands/clipboard.rs: pub fn copy_selection_native(
+src/document_core/commands/clipboard.rs: pub fn export_control_html_native(
+src/document_core/commands/clipboard.rs: pub fn export_selection_html_native(
+src/document_core/commands/clipboard.rs: pub fn export_selection_in_cell_html_native(
+src/document_core/commands/clipboard.rs: pub fn get_bin_data_image_data_native(&self, bin_data_id: u16) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/clipboard.rs: pub fn get_bin_data_image_mime_native(&self, bin_data_id: u16) -> Result<String, HwpError>
+src/document_core/commands/clipboard.rs: pub fn get_clipboard_text_native(&self) -> String
+src/document_core/commands/clipboard.rs: pub fn get_control_image_data_native(
+src/document_core/commands/clipboard.rs: pub fn get_control_image_mime_native(
+src/document_core/commands/clipboard.rs: pub fn has_internal_clipboard_native(&self) -> bool
+src/document_core/commands/clipboard.rs: pub fn paste_control_native(
+src/document_core/commands/clipboard.rs: pub fn paste_internal_in_cell_by_path_native(
+src/document_core/commands/clipboard.rs: pub fn paste_internal_in_cell_native(
+src/document_core/commands/clipboard.rs: pub fn paste_internal_native(
+src/document_core/commands/document.rs: pub fn begin_batch_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs: pub fn convert_to_editable_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs: pub fn create_blank_document_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs: pub fn discard_snapshot_native(&mut self, id: u32)
+src/document_core/commands/document.rs: pub fn document(&self) -> &Document
+src/document_core/commands/document.rs: pub fn document_mut(&mut self) -> &mut Document
+src/document_core/commands/document.rs: pub fn end_batch_native(&mut self) -> Result<String, HwpError>
+src/document_core/commands/document.rs: pub fn export_hml_native(&self) -> Result<Vec<u8>, crate::serializer::hml::HmlExportError>
+src/document_core/commands/document.rs: pub fn export_hwp_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs: pub fn export_hwp_with_adapter(&mut self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs: pub fn export_hwpx_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/commands/document.rs: pub fn from_bytes(data: &[u8]) -> Result<DocumentCore, HwpError>
+src/document_core/commands/document.rs: pub fn hml_export_preflight(&self) -> Result<(), crate::serializer::hml::HmlExportError>
+src/document_core/commands/document.rs: pub fn measure_width_diagnostic_native(
+src/document_core/commands/document.rs: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
+src/document_core/commands/document.rs: pub fn reflow_linesegs_on_demand(&mut self) -> usize
+src/document_core/commands/document.rs: pub fn restore_snapshot_native(&mut self, id: u32) -> Result<String, HwpError>
+src/document_core/commands/document.rs: pub fn save_snapshot_native(&mut self) -> u32
+src/document_core/commands/document.rs: pub fn serialize_hwp_with_verify(&mut self) -> Result<HwpExportVerification, HwpError>
+src/document_core/commands/document.rs: pub fn set_document(&mut self, doc: Document)
+src/document_core/commands/document.rs: pub struct HwpExportVerification
+src/document_core/commands/footnote_ops.rs: pub fn apply_para_format_in_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn delete_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn delete_text_in_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn get_footnote_at_cursor_native(
+src/document_core/commands/footnote_ops.rs: pub fn get_footnote_info_native(
+src/document_core/commands/footnote_ops.rs: pub fn get_para_properties_in_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn insert_text_in_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn merge_paragraph_in_footnote_native(
+src/document_core/commands/footnote_ops.rs: pub fn split_paragraph_in_footnote_native(
+src/document_core/commands/formatting.rs: pub fn apply_cell_style_native(
+src/document_core/commands/formatting.rs: pub fn apply_char_format_in_cell_native(
+src/document_core/commands/formatting.rs: pub fn apply_char_format_native(
+src/document_core/commands/formatting.rs: pub fn apply_para_format_in_cell_native(
+src/document_core/commands/formatting.rs: pub fn apply_para_format_native(
+src/document_core/commands/formatting.rs: pub fn apply_style_native(
+src/document_core/commands/formatting.rs: pub fn find_or_create_font_id_for_lang(&mut self, lang: usize, name: &str) -> i32
+src/document_core/commands/formatting.rs: pub fn find_or_create_font_id_native(&mut self, name: &str) -> i32
+src/document_core/commands/formatting.rs: pub fn get_cell_char_properties_at_native(
+src/document_core/commands/formatting.rs: pub fn get_cell_para_properties_at_native(
+src/document_core/commands/formatting.rs: pub fn get_char_properties_at_native(
+src/document_core/commands/formatting.rs: pub fn get_page_hide_native(
+src/document_core/commands/formatting.rs: pub fn get_para_properties_at_native(
+src/document_core/commands/formatting.rs: pub fn set_cell_para_shape_id_native(
+src/document_core/commands/formatting.rs: pub fn set_char_shape_id_in_cell_native(
+src/document_core/commands/formatting.rs: pub fn set_char_shape_id_native(
+src/document_core/commands/formatting.rs: pub fn set_numbering_restart_native(
+src/document_core/commands/formatting.rs: pub fn set_page_hide_native(
+src/document_core/commands/formatting.rs: pub fn set_para_shape_id_native(
+src/document_core/commands/header_footer_ops.rs: pub fn apply_hf_template_native(
+src/document_core/commands/header_footer_ops.rs: pub fn apply_para_format_in_hf_native(
+src/document_core/commands/header_footer_ops.rs: pub fn create_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn delete_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn delete_text_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn get_header_footer_list_native(
+src/document_core/commands/header_footer_ops.rs: pub fn get_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn get_header_footer_para_info_native(
+src/document_core/commands/header_footer_ops.rs: pub fn get_para_properties_in_hf_native(
+src/document_core/commands/header_footer_ops.rs: pub fn insert_field_in_hf_native(
+src/document_core/commands/header_footer_ops.rs: pub fn insert_text_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn is_header_footer_hidden(&self, page_num: u32, is_header: bool) -> bool
+src/document_core/commands/header_footer_ops.rs: pub fn merge_paragraph_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn navigate_header_footer_by_page_native(
+src/document_core/commands/header_footer_ops.rs: pub fn split_paragraph_in_header_footer_native(
+src/document_core/commands/header_footer_ops.rs: pub fn toggle_hide_header_footer_native(
+src/document_core/commands/html_import.rs: pub fn paste_html_in_cell_by_path_native(
+src/document_core/commands/html_import.rs: pub fn paste_html_in_cell_native(
+src/document_core/commands/html_import.rs: pub fn paste_html_native(
+src/document_core/commands/object_ops/common.rs: pub fn insert_new_number_native(
+src/document_core/commands/object_ops/common.rs: pub fn move_line_endpoint_native(
+src/document_core/commands/object_ops/connector.rs: pub fn recalculate_connector_routing(
+src/document_core/commands/object_ops/connector.rs: pub fn update_connector_subject_ids(
+src/document_core/commands/object_ops/connector.rs: pub fn update_connectors_in_section(&mut self, section_idx: usize)
+src/document_core/commands/object_ops/equation.rs: pub fn delete_equation_control_native(
+src/document_core/commands/object_ops/equation.rs: pub fn get_equation_properties_native(
+src/document_core/commands/object_ops/equation.rs: pub fn insert_equation_native(
+src/document_core/commands/object_ops/equation.rs: pub fn render_equation_preview_native(
+src/document_core/commands/object_ops/equation.rs: pub fn set_equation_properties_native(
+src/document_core/commands/object_ops/note.rs: pub fn get_note_equation_properties_native(
+src/document_core/commands/object_ops/note.rs: pub fn insert_endnote_native(
+src/document_core/commands/object_ops/note.rs: pub fn insert_footnote_native(
+src/document_core/commands/object_ops/note.rs: pub fn set_note_equation_properties_native(
+src/document_core/commands/object_ops/picture.rs: pub fn assign_picture_image_native(
+src/document_core/commands/object_ops/picture.rs: pub fn delete_picture_control_native(
+src/document_core/commands/object_ops/picture.rs: pub fn get_header_footer_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs: pub fn get_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs: pub fn insert_picture_native(
+src/document_core/commands/object_ops/picture.rs: pub fn set_header_footer_picture_properties_native(
+src/document_core/commands/object_ops/picture.rs: pub fn set_picture_properties_native(
+src/document_core/commands/object_ops/shape.rs: pub fn apply_endnote_shape_native(
+src/document_core/commands/object_ops/shape.rs: pub fn change_shape_z_order_native(
+src/document_core/commands/object_ops/shape.rs: pub fn create_shape_control_native(
+src/document_core/commands/object_ops/shape.rs: pub fn delete_shape_control_native(
+src/document_core/commands/object_ops/shape.rs: pub fn get_endnote_shape_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/commands/object_ops/shape.rs: pub fn get_shape_properties_native(
+src/document_core/commands/object_ops/shape.rs: pub fn group_shapes_native(
+src/document_core/commands/object_ops/shape.rs: pub fn set_shape_properties_native(
+src/document_core/commands/object_ops/shape.rs: pub fn ungroup_shape_native(
+src/document_core/commands/object_ops/table.rs: pub fn create_table_ex_native(
+src/document_core/commands/object_ops/table.rs: pub fn create_table_native(
+src/document_core/commands/object_ops/table.rs: pub fn delete_cell_picture_control_by_path_native(
+src/document_core/commands/object_ops/table.rs: pub fn get_cell_picture_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs: pub fn get_cell_shape_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs: pub fn set_cell_picture_properties_by_path_native(
+src/document_core/commands/object_ops/table.rs: pub fn set_cell_shape_properties_by_path_native(
+src/document_core/commands/table_ops.rs: pub fn copy_table_cells_transposed_native(
+src/document_core/commands/table_ops.rs: pub fn delete_table_column_native(
+src/document_core/commands/table_ops.rs: pub fn delete_table_control_native(
+src/document_core/commands/table_ops.rs: pub fn delete_table_row_native(
+src/document_core/commands/table_ops.rs: pub fn evaluate_table_formula(
+src/document_core/commands/table_ops.rs: pub fn fit_table_to_page_native(
+src/document_core/commands/table_ops.rs: pub fn has_table_transpose_clipboard_native(&self) -> bool
+src/document_core/commands/table_ops.rs: pub fn insert_table_column_native(
+src/document_core/commands/table_ops.rs: pub fn insert_table_row_native(
+src/document_core/commands/table_ops.rs: pub fn merge_table_cells_native(
+src/document_core/commands/table_ops.rs: pub fn paste_table_cells_transposed_as_new_table_native(
+src/document_core/commands/table_ops.rs: pub fn paste_table_cells_transposed_native(
+src/document_core/commands/table_ops.rs: pub fn set_table_column_widths_native(
+src/document_core/commands/table_ops.rs: pub fn split_table_cell_into_native(
+src/document_core/commands/table_ops.rs: pub fn split_table_cell_native(
+src/document_core/commands/table_ops.rs: pub fn split_table_cells_in_range_native(
+src/document_core/commands/table_ops.rs: pub fn transpose_table_cells_in_place_native(
+src/document_core/commands/text_editing.rs: pub fn delete_paragraph_native(
+src/document_core/commands/text_editing.rs: pub fn delete_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs: pub fn delete_text_in_cell_native(
+src/document_core/commands/text_editing.rs: pub fn delete_text_native(
+src/document_core/commands/text_editing.rs: pub fn find_nearest_control_backward_native(
+src/document_core/commands/text_editing.rs: pub fn find_nearest_control_forward_native(
+src/document_core/commands/text_editing.rs: pub fn find_next_editable_control_native(
+src/document_core/commands/text_editing.rs: pub fn get_cell_paragraph_count_native(
+src/document_core/commands/text_editing.rs: pub fn get_cell_paragraph_length_native(
+src/document_core/commands/text_editing.rs: pub fn get_paragraph_count_native(&self, section_idx: usize) -> Result<usize, HwpError>
+src/document_core/commands/text_editing.rs: pub fn get_paragraph_length_native(
+src/document_core/commands/text_editing.rs: pub fn get_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs: pub fn get_text_in_cell_native(
+src/document_core/commands/text_editing.rs: pub fn get_text_range_native(
+src/document_core/commands/text_editing.rs: pub fn get_textbox_control_index_native(&self, section_idx: usize, para_idx: usize) -> i32
+src/document_core/commands/text_editing.rs: pub fn insert_column_break_native(
+src/document_core/commands/text_editing.rs: pub fn insert_page_break_native(
+src/document_core/commands/text_editing.rs: pub fn insert_paragraph_native(
+src/document_core/commands/text_editing.rs: pub fn insert_text_in_cell_by_path(
+src/document_core/commands/text_editing.rs: pub fn insert_text_in_cell_native(
+src/document_core/commands/text_editing.rs: pub fn insert_text_in_cell_native_deferred_pagination(
+src/document_core/commands/text_editing.rs: pub fn insert_text_native(
+src/document_core/commands/text_editing.rs: pub fn merge_paragraph_in_cell_by_path(
+src/document_core/commands/text_editing.rs: pub fn merge_paragraph_in_cell_native(
+src/document_core/commands/text_editing.rs: pub fn merge_paragraph_native(
+src/document_core/commands/text_editing.rs: pub fn set_column_def_native(
+src/document_core/commands/text_editing.rs: pub fn split_paragraph_in_cell_by_path(
+src/document_core/commands/text_editing.rs: pub fn split_paragraph_in_cell_native(
+src/document_core/commands/text_editing.rs: pub fn split_paragraph_native(
+src/document_core/converters/common_obj_attr_writer.rs: pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8>
+src/document_core/converters/diagnostics.rs: pub fn counts_by_area(&self) -> Vec<(&'static str, usize)>
+src/document_core/converters/diagnostics.rs: pub fn diff_hwpx_vs_hwp(hwpx: &Document, hwp: &Document) -> DiffSummary
+src/document_core/converters/diagnostics.rs: pub fn diff_hwpx_vs_serializer_assumptions(hwpx: &Document) -> DiffSummary
+src/document_core/converters/diagnostics.rs: pub fn human_report(&self) -> String
+src/document_core/converters/diagnostics.rs: pub fn new() -> Self
+src/document_core/converters/diagnostics.rs: pub fn push(&mut self, item: IrFieldDiff)
+src/document_core/converters/diagnostics.rs: pub struct DiffSummary
+src/document_core/converters/diagnostics.rs: pub struct IrFieldDiff
+src/document_core/converters/hwpx_to_hwp.rs: pub const HWPX_ORIGIN_STREAM_PATH: &str = "/RhwpHwpxOrigin"
+src/document_core/converters/hwpx_to_hwp.rs: pub fn changed_anything(&self) -> bool
+src/document_core/converters/hwpx_to_hwp.rs: pub fn convert_hwpx_to_hwp_ir(doc: &mut Document) -> AdapterReport
+src/document_core/converters/hwpx_to_hwp.rs: pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> AdapterReport
+src/document_core/converters/hwpx_to_hwp.rs: pub fn new() -> Self
+src/document_core/converters/hwpx_to_hwp.rs: pub fn no_op(mut self, reason: impl Into<String>) -> Self
+src/document_core/converters/hwpx_to_hwp.rs: pub struct AdapterReport
+src/document_core/converters/mod.rs: pub mod common_obj_attr_writer
+src/document_core/converters/mod.rs: pub mod diagnostics
+src/document_core/converters/mod.rs: pub mod hwpx_to_hwp
+src/document_core/mod.rs: pub const DEFAULT_FALLBACK_FONT: &str = "/usr/share/fonts/truetype/nanum/NanumGothic.ttf"
+src/document_core/mod.rs: pub fn get_document_info(&self) -> String
+src/document_core/mod.rs: pub fn hml_metadata(&self) -> Option<&crate::parser::HmlImportMetadata>
+src/document_core/mod.rs: pub fn new_empty() -> Self
+src/document_core/mod.rs: pub fn page_count(&self) -> u32
+src/document_core/mod.rs: pub fn serialize_event_log(&self) -> String
+src/document_core/mod.rs: pub fn set_dpi(&mut self, dpi: f64)
+src/document_core/mod.rs: pub fn validation_report(&self) -> &validation::ValidationReport
+src/document_core/mod.rs: pub mod builders
+src/document_core/mod.rs: pub mod converters
+src/document_core/mod.rs: pub mod queries
+src/document_core/mod.rs: pub mod table_calc
+src/document_core/mod.rs: pub mod validation
+src/document_core/mod.rs: pub struct ActiveFieldInfo
+src/document_core/mod.rs: pub struct DocumentCore
+src/document_core/queries/bookmark_query.rs: pub fn add_bookmark_native(
+src/document_core/queries/bookmark_query.rs: pub fn delete_bookmark_native(
+src/document_core/queries/bookmark_query.rs: pub fn get_bookmarks_native(&self) -> Result<String, HwpError>
+src/document_core/queries/bookmark_query.rs: pub fn rename_bookmark_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_cursor_rect_in_cell_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_cursor_rect_in_footnote_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_cursor_rect_in_header_footer_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_cursor_rect_in_note_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_cursor_rect_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_note_edit_info_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_page_footnote_info_native(
+src/document_core/queries/cursor_rect.rs: pub fn get_selection_rects_in_footnote_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_body_footnote_marker_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_footnote_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_header_footer_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_in_footnote_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_in_header_footer_native(
+src/document_core/queries/cursor_rect.rs: pub fn hit_test_native(&self, page_num: u32, x: f64, y: f64) -> Result<String, HwpError>
+src/document_core/queries/doc_tree_nav.rs: pub enum NavResult
+src/document_core/queries/doc_tree_nav.rs: pub struct NavContextEntry
+src/document_core/queries/doc_tree_nav.rs: pub struct OverflowLink
+src/document_core/queries/field_query.rs: pub enum NestedEntry
+src/document_core/queries/field_query.rs: pub fn clear_active_field(&mut self)
+src/document_core/queries/field_query.rs: pub fn collect_all_fields(&self) -> Vec<FieldInfo>
+src/document_core/queries/field_query.rs: pub fn get_field_info_at(
+src/document_core/queries/field_query.rs: pub fn get_field_info_at_by_path(
+src/document_core/queries/field_query.rs: pub fn get_field_info_at_in_cell(
+src/document_core/queries/field_query.rs: pub fn get_field_list_json(&self) -> String
+src/document_core/queries/field_query.rs: pub fn get_field_value_by_id(&self, field_id: u32) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs: pub fn get_field_value_by_name(&self, name: &str) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs: pub fn insert_click_here_field_at(
+src/document_core/queries/field_query.rs: pub fn insert_click_here_field_at_by_path(
+src/document_core/queries/field_query.rs: pub fn insert_click_here_field_at_in_cell(
+src/document_core/queries/field_query.rs: pub fn remove_field_at(
+src/document_core/queries/field_query.rs: pub fn remove_field_at_in_cell(
+src/document_core/queries/field_query.rs: pub fn set_active_field(
+src/document_core/queries/field_query.rs: pub fn set_active_field_by_path(
+src/document_core/queries/field_query.rs: pub fn set_active_field_in_cell(
+src/document_core/queries/field_query.rs: pub fn set_field_value_by_id(
+src/document_core/queries/field_query.rs: pub fn set_field_value_by_name(&mut self, name: &str, value: &str) -> Result<String, HwpError>
+src/document_core/queries/field_query.rs: pub struct FieldInfo
+src/document_core/queries/field_query.rs: pub struct FieldLocation
+src/document_core/queries/form_query.rs: pub fn get_form_object_at_native(
+src/document_core/queries/form_query.rs: pub fn get_form_object_info_native(
+src/document_core/queries/form_query.rs: pub fn get_form_value_native(
+src/document_core/queries/form_query.rs: pub fn set_form_value_in_cell_native(
+src/document_core/queries/form_query.rs: pub fn set_form_value_native(
+src/document_core/queries/mod.rs: pub mod rendering
+src/document_core/queries/mod.rs: pub mod structure
+src/document_core/queries/rendering.rs: pub enum VlmTarget
+src/document_core/queries/rendering.rs: pub fn all_names() -> &'static str
+src/document_core/queries/rendering.rs: pub fn build_page_layer_tree(&self, page_num: u32) -> Result<PageLayerTree, HwpError>
+src/document_core/queries/rendering.rs: pub fn build_page_layer_tree_with_profile(
+src/document_core/queries/rendering.rs: pub fn build_page_render_tree(&self, page_num: u32) -> Result<PageRenderTree, HwpError>
+src/document_core/queries/rendering.rs: pub fn constraints(&self) -> (i32, u64)
+src/document_core/queries/rendering.rs: pub fn dump_page_items(&self, page_filter: Option<u32>) -> String
+src/document_core/queries/rendering.rs: pub fn extract_page_markdown_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn extract_page_markdown_with_images_native(
+src/document_core/queries/rendering.rs: pub fn extract_page_text_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn from_str(s: &str) -> Option<Self>
+src/document_core/queries/rendering.rs: pub fn get_bin_data(&self, index: usize) -> Option<Vec<u8>>
+src/document_core/queries/rendering.rs: pub fn get_canvaskit_replay_plan_native(
+src/document_core/queries/rendering.rs: pub fn get_canvaskit_replay_plan_with_profile_native(
+src/document_core/queries/rendering.rs: pub fn get_page_border_fill_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_control_layout_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_def_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_info_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_layer_tree_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_layer_tree_with_profile_native(
+src/document_core/queries/rendering.rs: pub fn get_page_overlay_images_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_page_text_layout_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn get_section_def_native(&self, section_idx: usize) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_document_pdf_direct_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_document_pdf_direct_native_with_options(
+src/document_core/queries/rendering.rs: pub fn render_document_pdf_native(&self) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_document_pdf_native_with_options(
+src/document_core/queries/rendering.rs: pub fn render_page_canvas_legacy_native(&self, page_num: u32) -> Result<u32, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_canvas_native(&self, page_num: u32) -> Result<u32, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_html_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_pdf_direct_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_pdf_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_png_native(&self, page_num: u32) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_png_native_with_export_options(
+src/document_core/queries/rendering.rs: pub fn render_page_png_native_with_fonts(
+src/document_core/queries/rendering.rs: pub fn render_page_png_native_with_profile_and_export_options(
+src/document_core/queries/rendering.rs: pub fn render_page_svg_layer_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_svg_layer_with_profile_native(
+src/document_core/queries/rendering.rs: pub fn render_page_svg_legacy_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_svg_native(&self, page_num: u32) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_page_svg_with_fonts(
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_direct_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_direct_native_with_options(
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_direct_native_with_profile_and_options(
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_native(&self, page_nums: &[u32]) -> Result<Vec<u8>, HwpError>
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_native_with_options(
+src/document_core/queries/rendering.rs: pub fn render_pages_pdf_native_with_profile_and_options(
+src/document_core/queries/rendering.rs: pub fn set_page_border_fill_native(
+src/document_core/queries/rendering.rs: pub fn set_page_def_native(
+src/document_core/queries/rendering.rs: pub fn set_section_def_all_native(&mut self, json: &str) -> Result<String, HwpError>
+src/document_core/queries/rendering.rs: pub fn set_section_def_native(
+src/document_core/queries/rendering.rs: pub struct PngExportOptions
+src/document_core/queries/search_query.rs: pub fn get_page_of_position_native(
+src/document_core/queries/search_query.rs: pub fn get_position_of_page_native(&self, global_page: usize) -> Result<String, HwpError>
+src/document_core/queries/search_query.rs: pub fn replace_all_native(
+src/document_core/queries/search_query.rs: pub fn replace_one_native(
+src/document_core/queries/search_query.rs: pub fn replace_text_native(
+src/document_core/queries/search_query.rs: pub fn search_all_text_native(
+src/document_core/queries/search_query.rs: pub fn search_text_native(
+src/document_core/queries/structure.rs: pub enum StructureMode
+src/document_core/queries/structure.rs: pub fn build_structure(doc: &Document, mode: StructureMode) -> StructureDoc
+src/document_core/queries/structure.rs: pub fn get_structure_native(&self, mode: &str) -> Result<String, HwpError>
+src/document_core/queries/structure.rs: pub fn parse(s: &str) -> Option<Self>
+src/document_core/queries/structure.rs: pub struct StructureDoc
+src/document_core/queries/structure.rs: pub struct StructureNode
+src/document_core/table_calc/evaluator.rs: pub fn evaluate_formula(
+src/document_core/table_calc/evaluator.rs: pub struct TableContext
+src/document_core/table_calc/evaluator.rs: pub type CellValueFn<'a> = &'a dyn Fn(usize, usize) -> Option<f64>
+src/document_core/table_calc/mod.rs: pub use evaluator::{evaluate_formula, TableContext}
+src/document_core/table_calc/mod.rs: pub use parser::FormulaNode
+src/document_core/table_calc/parser.rs: pub enum BinOpKind
+src/document_core/table_calc/parser.rs: pub enum FormulaNode
+src/document_core/table_calc/parser.rs: pub fn parse_formula(input: &str) -> Option<FormulaNode>
+src/document_core/table_calc/tokenizer.rs: pub enum DirectionKind
+src/document_core/table_calc/tokenizer.rs: pub enum Token
+src/document_core/table_calc/tokenizer.rs: pub fn tokenize(input: &str) -> Vec<Token>
+src/document_core/validation.rs: pub enum WarningKind
+src/document_core/validation.rs: pub fn is_empty(&self) -> bool
+src/document_core/validation.rs: pub fn len(&self) -> usize
+src/document_core/validation.rs: pub fn new() -> Self
+src/document_core/validation.rs: pub fn push(&mut self, w: ValidationWarning)
+src/document_core/validation.rs: pub fn summary(&self) -> HashMap<String, usize>
+src/document_core/validation.rs: pub struct CellPath
+src/document_core/validation.rs: pub struct ValidationReport
+src/document_core/validation.rs: pub struct ValidationWarning
+src/emf/converter/device_context.rs: pub enum GraphicsObject
+src/emf/converter/device_context.rs: pub fn current(&self) -> &DeviceContext
+src/emf/converter/device_context.rs: pub fn current_mut(&mut self) -> &mut DeviceContext
+src/emf/converter/device_context.rs: pub fn depth(&self) -> usize
+src/emf/converter/device_context.rs: pub fn get(&self, handle: u32) -> Option<&GraphicsObject>
+src/emf/converter/device_context.rs: pub fn insert(&mut self, handle: u32, obj: GraphicsObject)
+src/emf/converter/device_context.rs: pub fn is_empty(&self) -> bool
+src/emf/converter/device_context.rs: pub fn len(&self) -> usize
+src/emf/converter/device_context.rs: pub fn new() -> Self
+src/emf/converter/device_context.rs: pub fn new() -> Self
+src/emf/converter/device_context.rs: pub fn remove(&mut self, handle: u32) -> Option<GraphicsObject>
+src/emf/converter/device_context.rs: pub fn restore(&mut self, relative: i32) -> bool
+src/emf/converter/device_context.rs: pub fn save(&mut self)
+src/emf/converter/device_context.rs: pub struct DcStack
+src/emf/converter/device_context.rs: pub struct DeviceContext
+src/emf/converter/device_context.rs: pub struct ObjectTable
+src/emf/converter/mod.rs: pub mod device_context
+src/emf/converter/mod.rs: pub mod player
+src/emf/converter/mod.rs: pub mod svg
+src/emf/converter/mod.rs: pub use device_context::{DcStack, DeviceContext, GraphicsObject, ObjectTable}
+src/emf/converter/mod.rs: pub use player::Player
+src/emf/converter/mod.rs: pub use svg::{colorref_to_rgb, escape_xml, SvgBuilder}
+src/emf/converter/player.rs: pub fn new(render_rect: (f32, f32, f32, f32)) -> Self
+src/emf/converter/player.rs: pub fn play(&mut self, records: &[Record]) -> Result<(), Error>
+src/emf/converter/player.rs: pub struct Player
+src/emf/converter/player.rs: pub struct StrokeSpec
+src/emf/converter/svg.rs: pub fn as_str(&self) -> &str
+src/emf/converter/svg.rs: pub fn close_group(&mut self)
+src/emf/converter/svg.rs: pub fn colorref_to_rgb(c: u32) -> String
+src/emf/converter/svg.rs: pub fn escape_xml(s: &str) -> String
+src/emf/converter/svg.rs: pub fn into_string(self) -> String
+src/emf/converter/svg.rs: pub fn new() -> Self
+src/emf/converter/svg.rs: pub fn open_group_matrix(&mut self, m: [f32
+src/emf/converter/svg.rs: pub fn push(&mut self, node: &str)
+src/emf/converter/svg.rs: pub struct SvgBuilder
+src/emf/mod.rs: pub enum Error
+src/emf/mod.rs: pub fn convert_to_svg(bytes: &[u8], render_rect: (f32, f32, f32, f32)) -> Result<String, Error>
+src/emf/mod.rs: pub fn parse_emf(bytes: &[u8]) -> Result<Vec<Record>, Error>
+src/emf/mod.rs: pub mod converter
+src/emf/mod.rs: pub mod parser
+src/emf/mod.rs: pub use parser::Header
+src/emf/mod.rs: pub use parser::records::Record
+src/emf/parser/constants/mod.rs: pub mod record_type
+src/emf/parser/constants/mod.rs: pub use record_type::RecordType
+src/emf/parser/constants/record_type.rs: pub enum RecordType
+src/emf/parser/constants/record_type.rs: pub fn from_u32(v: u32) -> Option<Self>
+src/emf/parser/mod.rs: pub fn full_buf(&self) -> &'a [u8]
+src/emf/parser/mod.rs: pub fn i32(&mut self) -> Result<i32, Error>
+src/emf/parser/mod.rs: pub fn is_empty(&self) -> bool
+src/emf/parser/mod.rs: pub fn new(buf: &'a [u8]) -> Self
+src/emf/parser/mod.rs: pub fn parse(bytes: &[u8]) -> Result<Vec<Record>, Error>
+src/emf/parser/mod.rs: pub fn peek(&self, n: usize) -> Result<&'a [u8], Error>
+src/emf/parser/mod.rs: pub fn peek_record_header(&self) -> Result<RecordHeader, Error>
+src/emf/parser/mod.rs: pub fn position(&self) -> usize
+src/emf/parser/mod.rs: pub fn remaining(&self) -> usize
+src/emf/parser/mod.rs: pub fn take(&mut self, n: usize) -> Result<&'a [u8], Error>
+src/emf/parser/mod.rs: pub fn u16(&mut self) -> Result<u16, Error>
+src/emf/parser/mod.rs: pub fn u32(&mut self) -> Result<u32, Error>
+src/emf/parser/mod.rs: pub mod constants
+src/emf/parser/mod.rs: pub mod objects
+src/emf/parser/mod.rs: pub mod records
+src/emf/parser/mod.rs: pub struct Cursor<'a>
+src/emf/parser/mod.rs: pub struct RecordHeader
+src/emf/parser/mod.rs: pub use objects::header::Header
+src/emf/parser/objects/header.rs: pub const SIGNATURE: u32 = 0x464D4520
+src/emf/parser/objects/header.rs: pub fn read(cursor: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/header.rs: pub struct Header
+src/emf/parser/objects/header.rs: pub struct HeaderExt1
+src/emf/parser/objects/header.rs: pub struct HeaderExt2
+src/emf/parser/objects/logbrush.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logbrush.rs: pub struct LogBrush
+src/emf/parser/objects/logfont.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logfont.rs: pub struct LogFontW
+src/emf/parser/objects/logpen.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/logpen.rs: pub struct LogPen
+src/emf/parser/objects/mod.rs: pub mod header
+src/emf/parser/objects/mod.rs: pub mod logbrush
+src/emf/parser/objects/mod.rs: pub mod logfont
+src/emf/parser/objects/mod.rs: pub mod logpen
+src/emf/parser/objects/mod.rs: pub mod rectl
+src/emf/parser/objects/mod.rs: pub mod xform
+src/emf/parser/objects/mod.rs: pub use header::Header
+src/emf/parser/objects/mod.rs: pub use logbrush::LogBrush
+src/emf/parser/objects/mod.rs: pub use logfont::LogFontW
+src/emf/parser/objects/mod.rs: pub use logpen::LogPen
+src/emf/parser/objects/mod.rs: pub use rectl::{PointL, RectL, SizeL}
+src/emf/parser/objects/mod.rs: pub use xform::XForm
+src/emf/parser/objects/rectl.rs: pub const fn height(&self) -> i32
+src/emf/parser/objects/rectl.rs: pub const fn width(&self) -> i32
+src/emf/parser/objects/rectl.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/rectl.rs: pub struct PointL
+src/emf/parser/objects/rectl.rs: pub struct RectL
+src/emf/parser/objects/rectl.rs: pub struct SizeL
+src/emf/parser/objects/xform.rs: pub const fn identity() -> Self
+src/emf/parser/objects/xform.rs: pub fn read(c: &mut Cursor<'_>) -> Result<Self, Error>
+src/emf/parser/objects/xform.rs: pub struct XForm
+src/emf/parser/records/bitmap.rs: pub fn parse(payload: &[u8]) -> Result<StretchDIBits, Error>
+src/emf/parser/records/bitmap.rs: pub struct StretchDIBits
+src/emf/parser/records/drawing.rs: pub fn parse_arc_like(c: &mut Cursor<'_>) -> Result<(RectL, PointL, PointL), Error>
+src/emf/parser/records/drawing.rs: pub fn parse_point(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/drawing.rs: pub fn parse_points16(c: &mut Cursor<'_>) -> Result<(RectL, Vec<(i16, i16)>), Error>
+src/emf/parser/records/drawing.rs: pub fn parse_rect(c: &mut Cursor<'_>) -> Result<RectL, Error>
+src/emf/parser/records/drawing.rs: pub fn parse_round_rect(c: &mut Cursor<'_>) -> Result<(RectL, i32, i32), Error>
+src/emf/parser/records/header.rs: pub fn parse(cursor: &mut Cursor<'_>) -> Result<Header, Error>
+src/emf/parser/records/mod.rs: pub enum Record
+src/emf/parser/records/mod.rs: pub mod bitmap
+src/emf/parser/records/mod.rs: pub mod drawing
+src/emf/parser/records/mod.rs: pub mod header
+src/emf/parser/records/mod.rs: pub mod object
+src/emf/parser/records/mod.rs: pub mod path
+src/emf/parser/records/mod.rs: pub mod state
+src/emf/parser/records/mod.rs: pub mod text
+src/emf/parser/records/mod.rs: pub use bitmap::StretchDIBits
+src/emf/parser/records/mod.rs: pub use text::ExtTextOut
+src/emf/parser/records/object.rs: pub fn parse_create_brush_indirect(c: &mut Cursor<'_>) -> Result<(u32, LogBrush), Error>
+src/emf/parser/records/object.rs: pub fn parse_create_pen(c: &mut Cursor<'_>) -> Result<(u32, LogPen), Error>
+src/emf/parser/records/object.rs: pub fn parse_delete_object(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/object.rs: pub fn parse_ext_create_font_indirect_w(
+src/emf/parser/records/object.rs: pub fn parse_select_object(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/path.rs: pub fn parse_path_bounds(c: &mut Cursor<'_>) -> Result<RectL, Error>
+src/emf/parser/records/state.rs: pub fn parse_modify_world_transform(c: &mut Cursor<'_>) -> Result<(XForm, u32), Error>
+src/emf/parser/records/state.rs: pub fn parse_restore_dc(c: &mut Cursor<'_>) -> Result<i32, Error>
+src/emf/parser/records/state.rs: pub fn parse_set_viewport_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
+src/emf/parser/records/state.rs: pub fn parse_set_viewport_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/state.rs: pub fn parse_set_window_ext_ex(c: &mut Cursor<'_>) -> Result<SizeL, Error>
+src/emf/parser/records/state.rs: pub fn parse_set_window_org_ex(c: &mut Cursor<'_>) -> Result<PointL, Error>
+src/emf/parser/records/state.rs: pub fn parse_set_world_transform(c: &mut Cursor<'_>) -> Result<XForm, Error>
+src/emf/parser/records/state.rs: pub fn parse_u32_single(c: &mut Cursor<'_>) -> Result<u32, Error>
+src/emf/parser/records/text.rs: pub fn parse(payload: &[u8]) -> Result<ExtTextOut, Error>
+src/emf/parser/records/text.rs: pub struct ExtTextOut
+src/error.rs: pub enum HwpError
+src/lib.rs: pub fn init_panic_hook()
+src/lib.rs: pub fn version() -> String
+src/lib.rs: pub mod diagnostics
+src/lib.rs: pub mod document_core
+src/lib.rs: pub mod emf
+src/lib.rs: pub mod error
+src/lib.rs: pub mod model
+src/lib.rs: pub mod ole_chart
+src/lib.rs: pub mod ooxml_chart
+src/lib.rs: pub mod paint
+src/lib.rs: pub mod parser
+src/lib.rs: pub mod renderer
+src/lib.rs: pub mod serializer
+src/lib.rs: pub mod wasm_api
+src/lib.rs: pub mod wmf
+src/lib.rs: pub use document_core::DocumentCore
+src/lib.rs: pub use error::HwpError
+src/lib.rs: pub use model::event::DocumentEvent
+src/lib.rs: pub use parser::{parse_document, DocumentParser}
+src/lib.rs: pub use serializer::{serialize_document, DocumentSerializer}
+src/model/bin_data.rs: pub enum BinDataBytes
+src/model/bin_data.rs: pub enum BinDataCompression
+src/model/bin_data.rs: pub enum BinDataStatus
+src/model/bin_data.rs: pub enum BinDataType
+src/model/bin_data.rs: pub fn is_empty(&self) -> bool
+src/model/bin_data.rs: pub fn len(&self) -> usize
+src/model/bin_data.rs: pub fn load(&self) -> Vec<u8>
+src/model/bin_data.rs: pub struct BinData
+src/model/bin_data.rs: pub struct BinDataContent
+src/model/bin_data.rs: pub trait BinDataResolver:
+src/model/control.rs: pub enum AutoNumberType
+src/model/control.rs: pub enum Control
+src/model/control.rs: pub enum FieldType
+src/model/control.rs: pub enum FormType
+src/model/control.rs: pub fn build_clickhere_command(guide: &str, memo: &str) -> String
+src/model/control.rs: pub fn extract_wstring_value(&self, key: &str) -> Option<&str>
+src/model/control.rs: pub fn field_name(&self) -> Option<&str>
+src/model/control.rs: pub fn field_type_str(&self) -> &'static str
+src/model/control.rs: pub fn guide_text(&self) -> Option<&str>
+src/model/control.rs: pub fn is_editable_in_form(&self) -> bool
+src/model/control.rs: pub fn memo_text(&self) -> Option<&str>
+src/model/control.rs: pub struct AutoNumber
+src/model/control.rs: pub struct Bookmark
+src/model/control.rs: pub struct CharOverlap
+src/model/control.rs: pub struct Equation
+src/model/control.rs: pub struct Field
+src/model/control.rs: pub struct FormObject
+src/model/control.rs: pub struct HiddenComment
+src/model/control.rs: pub struct Hyperlink
+src/model/control.rs: pub struct NewNumber
+src/model/control.rs: pub struct PageHide
+src/model/control.rs: pub struct PageNumberPos
+src/model/control.rs: pub struct Ruby
+src/model/control.rs: pub struct UnknownControl
+src/model/document.rs: pub const HWP5_ORIGIN_HWPX_MARKER_PATH: &str = "META-INF/rhwp-hwp5-origin"
+src/model/document.rs: pub enum PreviewImageFormat
+src/model/document.rs: pub fn convert_to_editable(&mut self) -> bool
+src/model/document.rs: pub fn find_or_create_char_shape(
+src/model/document.rs: pub fn find_or_create_para_shape(
+src/model/document.rs: pub fn find_or_create_tab_def(&mut self, new_td: super::style::TabDef) -> u16
+src/model/document.rs: pub fn hwpx_aux_entry(&self, path: &str) -> Option<&[u8]>
+src/model/document.rs: pub fn layout_profile(&self) -> crate::model::provenance::LayoutCompatibilityProfile
+src/model/document.rs: pub fn populate_external_images_from_dir(&mut self, base_dir: &std::path::Path) -> usize
+src/model/document.rs: pub struct DocInfo
+src/model/document.rs: pub struct DocProperties
+src/model/document.rs: pub struct Document
+src/model/document.rs: pub struct FileHeader
+src/model/document.rs: pub struct HwpVersion
+src/model/document.rs: pub struct Preview
+src/model/document.rs: pub struct PreviewImage
+src/model/document.rs: pub struct RawRecord
+src/model/document.rs: pub struct Section
+src/model/document.rs: pub struct SectionDef
+src/model/event.rs: pub enum DocumentEvent
+src/model/event.rs: pub fn serialize_event_log(events: &[DocumentEvent]) -> String
+src/model/event.rs: pub fn to_json(&self) -> String
+src/model/footnote.rs: pub enum FootnoteNumbering
+src/model/footnote.rs: pub enum FootnotePlacement
+src/model/footnote.rs: pub enum NumberFormat
+src/model/footnote.rs: pub fn apply_attr_fields_from_raw(&mut self)
+src/model/footnote.rs: pub fn between_notes_margin_hu(&self) -> u16
+src/model/footnote.rs: pub fn encode_attr(&self) -> u32
+src/model/footnote.rs: pub fn number_format_attr_code(format: NumberFormat) -> u32
+src/model/footnote.rs: pub fn number_format_from_attr_code(code: u32) -> NumberFormat
+src/model/footnote.rs: pub fn number_format_from_name(value: &str, fallback: NumberFormat) -> NumberFormat
+src/model/footnote.rs: pub fn separator_above_margin_hu(&self) -> HwpUnit16
+src/model/footnote.rs: pub fn separator_below_margin_hu(&self) -> HwpUnit16
+src/model/footnote.rs: pub struct Endnote
+src/model/footnote.rs: pub struct Footnote
+src/model/footnote.rs: pub struct FootnoteShape
+src/model/header_footer.rs: pub enum HeaderFooterApply
+src/model/header_footer.rs: pub struct Footer
+src/model/header_footer.rs: pub struct Header
+src/model/header_footer.rs: pub struct MasterPage
+src/model/image.rs: pub enum ImageEffect
+src/model/image.rs: pub enum ImageFormat
+src/model/image.rs: pub fn alpha_byte_to_transparency_percent(alpha: u8) -> u8
+src/model/image.rs: pub fn clamped_transparency(&self) -> u8
+src/model/image.rs: pub fn is_watermark(&self) -> bool
+src/model/image.rs: pub fn opacity(&self) -> f64
+src/model/image.rs: pub fn transparency_alpha_byte(&self) -> u8
+src/model/image.rs: pub fn transparency_percent_to_alpha_byte(transparency: u8) -> u8
+src/model/image.rs: pub fn watermark_preset(&self) -> Option<&'static str>
+src/model/image.rs: pub struct CropInfo
+src/model/image.rs: pub struct EffectColor
+src/model/image.rs: pub struct EffectPoint
+src/model/image.rs: pub struct EffectRgb
+src/model/image.rs: pub struct ImageAttr
+src/model/image.rs: pub struct ImageData
+src/model/image.rs: pub struct Picture
+src/model/image.rs: pub struct PictureEffects
+src/model/image.rs: pub struct PictureShadow
+src/model/mod.rs: pub fn height(&self) -> i32
+src/model/mod.rs: pub fn width(&self) -> i32
+src/model/mod.rs: pub mod bin_data
+src/model/mod.rs: pub mod control
+src/model/mod.rs: pub mod document
+src/model/mod.rs: pub mod event
+src/model/mod.rs: pub mod footnote
+src/model/mod.rs: pub mod header_footer
+src/model/mod.rs: pub mod image
+src/model/mod.rs: pub mod page
+src/model/mod.rs: pub mod paragraph
+src/model/mod.rs: pub mod path
+src/model/mod.rs: pub mod provenance
+src/model/mod.rs: pub mod shape
+src/model/mod.rs: pub mod style
+src/model/mod.rs: pub mod table
+src/model/mod.rs: pub struct Padding
+src/model/mod.rs: pub struct Point
+src/model/mod.rs: pub struct Rect
+src/model/mod.rs: pub type ColorRef = u32
+src/model/mod.rs: pub type HwpUnit = u32
+src/model/mod.rs: pub type HwpUnit16 = i16
+src/model/mod.rs: pub type SHwpUnit = i32
+src/model/page.rs: pub enum BindingMethod
+src/model/page.rs: pub enum ColumnDirection
+src/model/page.rs: pub enum ColumnType
+src/model/page.rs: pub enum PageBorderBasis
+src/model/page.rs: pub enum PageBorderUiBasis
+src/model/page.rs: pub fn a4_default() -> Self
+src/model/page.rs: pub fn from_page_def(page_def: &PageDef) -> Self
+src/model/page.rs: pub fn from_page_def_for_page(page_def: &PageDef, page_number: u32) -> Self
+src/model/page.rs: pub struct ColumnDef
+src/model/page.rs: pub struct PageAreas
+src/model/page.rs: pub struct PageBorderFill
+src/model/page.rs: pub struct PageDef
+src/model/paragraph.rs: pub const TAG_AUTO_HYPHENATION: u32 = 1 << 19
+src/model/paragraph.rs: pub const TAG_EMPTY_SEGMENT: u32 = 1 << 16
+src/model/paragraph.rs: pub const TAG_FIRST_LINE_OF_COLUMN: u32 = 1 << 1
+src/model/paragraph.rs: pub const TAG_FIRST_LINE_OF_PAGE: u32 = 1 << 0
+src/model/paragraph.rs: pub const TAG_FIRST_SEGMENT: u32 = 1 << 17
+src/model/paragraph.rs: pub const TAG_IMPLEMENTATION_PROPERTY: u32 = 1 << 31
+src/model/paragraph.rs: pub const TAG_INDENTATION: u32 = 1 << 20
+src/model/paragraph.rs: pub const TAG_LAST_SEGMENT: u32 = 1 << 18
+src/model/paragraph.rs: pub const TAG_MISSING_LINESEG_PLACEHOLDER: u32 =
+src/model/paragraph.rs: pub const TAG_PARAGRAPH_HEAD: u32 = 1 << 21
+src/model/paragraph.rs: pub const TAG_SINGLE_SEGMENT_LINE: u32 = Self::TAG_FIRST_SEGMENT | Self::TAG_LAST_SEGMENT
+src/model/paragraph.rs: pub enum ColumnBreakType
+src/model/paragraph.rs: pub enum CtrlChar
+src/model/paragraph.rs: pub enum NumberingRestart
+src/model/paragraph.rs: pub fn apply_char_shape_range(
+src/model/paragraph.rs: pub fn apply_char_shape_to_entire_text(&mut self, char_shape_id: u32)
+src/model/paragraph.rs: pub fn char_shape_id_at(&self, char_offset: usize) -> Option<u32>
+src/model/paragraph.rs: pub fn control_text_positions(&self) -> Vec<usize>
+src/model/paragraph.rs: pub fn delete_text_at(&mut self, char_offset: usize, count: usize) -> usize
+src/model/paragraph.rs: pub fn has_indentation(&self) -> bool
+src/model/paragraph.rs: pub fn has_paragraph_head(&self) -> bool
+src/model/paragraph.rs: pub fn insert_text_at(&mut self, char_offset: usize, new_text: &str)
+src/model/paragraph.rs: pub fn is_empty_segment(&self) -> bool
+src/model/paragraph.rs: pub fn is_first_line_of_column(&self) -> bool
+src/model/paragraph.rs: pub fn is_first_line_of_page(&self) -> bool
+src/model/paragraph.rs: pub fn is_first_segment(&self) -> bool
+src/model/paragraph.rs: pub fn is_in_wrap_zone(&self, col_w_hu: i32) -> bool
+src/model/paragraph.rs: pub fn is_last_segment(&self) -> bool
+src/model/paragraph.rs: pub fn is_missing_lineseg_placeholder(&self) -> bool
+src/model/paragraph.rs: pub fn merge_from(&mut self, other: &Paragraph) -> usize
+src/model/paragraph.rs: pub fn missing_lineseg_placeholder() -> Self
+src/model/paragraph.rs: pub fn new_empty() -> Self
+src/model/paragraph.rs: pub fn new_empty_like(template: &Paragraph) -> Self
+src/model/paragraph.rs: pub fn replace_style_char_shape_preserving_overrides(
+src/model/paragraph.rs: pub fn set_single_char_shape(&mut self, char_shape_id: u32)
+src/model/paragraph.rs: pub fn split_at(&mut self, char_offset: usize) -> Paragraph
+src/model/paragraph.rs: pub fn utf16_pos_to_char_idx(&self, utf16_pos: u32) -> usize
+src/model/paragraph.rs: pub struct CharShapeRef
+src/model/paragraph.rs: pub struct FieldRange
+src/model/paragraph.rs: pub struct LineSeg
+src/model/paragraph.rs: pub struct OrphanFieldEnd
+src/model/paragraph.rs: pub struct Paragraph
+src/model/paragraph.rs: pub struct RangeTag
+src/model/path.rs: pub enum PathSegment
+src/model/path.rs: pub fn path_from_flat(parent_para_idx: usize, control_idx: usize) -> DocumentPath
+src/model/path.rs: pub type DocumentPath = Vec<PathSegment>
+src/model/provenance.rs: pub enum SourceFormat
+src/model/provenance.rs: pub fn hwp3_layout(&self) -> bool
+src/model/provenance.rs: pub fn hwpx_stored_layout(&self) -> bool
+src/model/provenance.rs: pub struct LayoutCompatibilityProfile
+src/model/provenance.rs: pub struct SourceProvenance
+src/model/shape.rs: pub const FLAGS: std::ops::Range<usize> = 0..4
+src/model/shape.rs: pub const HEIGHT: std::ops::Range<usize> = 16..20
+src/model/shape.rs: pub const H_OFFSET: std::ops::Range<usize> = 8..12
+src/model/shape.rs: pub const INSTANCE_ID: std::ops::Range<usize> = 32..36
+src/model/shape.rs: pub const MARGIN_BOTTOM: std::ops::Range<usize> = 30..32
+src/model/shape.rs: pub const MARGIN_LEFT: std::ops::Range<usize> = 24..26
+src/model/shape.rs: pub const MARGIN_RIGHT: std::ops::Range<usize> = 26..28
+src/model/shape.rs: pub const MARGIN_TOP: std::ops::Range<usize> = 28..30
+src/model/shape.rs: pub const MIN_LEN: usize = INSTANCE_ID.end
+src/model/shape.rs: pub const MIN_LEN_WITH_PREVENT_PAGE_BREAK: usize = PREVENT_PAGE_BREAK.end
+src/model/shape.rs: pub const PREVENT_PAGE_BREAK: std::ops::Range<usize> = 36..40
+src/model/shape.rs: pub const V_OFFSET: std::ops::Range<usize> = 4..8
+src/model/shape.rs: pub const WIDTH: std::ops::Range<usize> = 12..16
+src/model/shape.rs: pub const Z_ORDER: std::ops::Range<usize> = 20..24
+src/model/shape.rs: pub enum CaptionDirection
+src/model/shape.rs: pub enum CaptionVertAlign
+src/model/shape.rs: pub enum ChartType
+src/model/shape.rs: pub enum HorzAlign
+src/model/shape.rs: pub enum HorzRelTo
+src/model/shape.rs: pub enum LegendPosition
+src/model/shape.rs: pub enum LinkLineType
+src/model/shape.rs: pub enum ObjectNumberingType
+src/model/shape.rs: pub enum OleDrawingAspect
+src/model/shape.rs: pub enum OlePreviewFormat
+src/model/shape.rs: pub enum ShapeObject
+src/model/shape.rs: pub enum SizeCriterion
+src/model/shape.rs: pub enum TextFlow
+src/model/shape.rs: pub enum TextWrap
+src/model/shape.rs: pub enum VertAlign
+src/model/shape.rs: pub enum VertRelTo
+src/model/shape.rs: pub fn common(&self) -> &CommonObjAttr
+src/model/shape.rs: pub fn common_mut(&mut self) -> &mut CommonObjAttr
+src/model/shape.rs: pub fn drawing(&self) -> Option<&DrawingObjAttr>
+src/model/shape.rs: pub fn drawing_mut(&mut self) -> Option<&mut DrawingObjAttr>
+src/model/shape.rs: pub fn from_u32(v: u32) -> Self
+src/model/shape.rs: pub fn is_arc(&self) -> bool
+src/model/shape.rs: pub fn is_stroke(&self) -> bool
+src/model/shape.rs: pub fn shape_attr(&self) -> &ShapeComponentAttr
+src/model/shape.rs: pub fn shape_name(&self) -> &'static str
+src/model/shape.rs: pub fn z_order(&self) -> i32
+src/model/shape.rs: pub struct ArcShape
+src/model/shape.rs: pub struct Axis
+src/model/shape.rs: pub struct Caption
+src/model/shape.rs: pub struct ChartShape
+src/model/shape.rs: pub struct CommonObjAttr
+src/model/shape.rs: pub struct ConnectorControlPoint
+src/model/shape.rs: pub struct ConnectorData
+src/model/shape.rs: pub struct CurveShape
+src/model/shape.rs: pub struct DataSeries
+src/model/shape.rs: pub struct DrawingObjAttr
+src/model/shape.rs: pub struct EllipseShape
+src/model/shape.rs: pub struct GroupShape
+src/model/shape.rs: pub struct Legend
+src/model/shape.rs: pub struct LineShape
+src/model/shape.rs: pub struct OlePreview
+src/model/shape.rs: pub struct OleShape
+src/model/shape.rs: pub struct PolygonShape
+src/model/shape.rs: pub struct RectangleShape
+src/model/shape.rs: pub struct ShapeComponentAttr
+src/model/shape.rs: pub struct TextBox
+src/model/style.rs: pub const BORDER_WIDTHS: [(f64, &str)
+src/model/style.rs: pub enum Alignment
+src/model/style.rs: pub enum BorderLineType
+src/model/style.rs: pub enum CenterLine
+src/model/style.rs: pub enum FillType
+src/model/style.rs: pub enum HeadType
+src/model/style.rs: pub enum ImageFillMode
+src/model/style.rs: pub enum LineSpacingType
+src/model/style.rs: pub enum UnderlineType
+src/model/style.rs: pub fn apply_to(&self, base: &CharShape) -> CharShape
+src/model/style.rs: pub fn apply_to(&self, base: &ParaShape) -> ParaShape
+src/model/style.rs: pub fn as_hwpx(self) -> &'static str
+src/model/style.rs: pub fn border_width_index(mm: f64) -> u8
+src/model/style.rs: pub fn border_width_mm_str(index: u8) -> &'static str
+src/model/style.rs: pub fn from_hwp_attr(attr: u16) -> Self
+src/model/style.rs: pub fn from_hwpx(value: &str) -> Self
+src/model/style.rs: pub fn hwp_attr_bits(self) -> u16
+src/model/style.rs: pub fn hwp_binary_attr_bits(self) -> u16
+src/model/style.rs: pub struct BorderFill
+src/model/style.rs: pub struct BorderLine
+src/model/style.rs: pub struct Bullet
+src/model/style.rs: pub struct CharShape
+src/model/style.rs: pub struct CharShapeMods
+src/model/style.rs: pub struct DiagonalLine
+src/model/style.rs: pub struct Fill
+src/model/style.rs: pub struct Font
+src/model/style.rs: pub struct GradientFill
+src/model/style.rs: pub struct ImageFill
+src/model/style.rs: pub struct Numbering
+src/model/style.rs: pub struct NumberingHead
+src/model/style.rs: pub struct ParaShape
+src/model/style.rs: pub struct ParaShapeMods
+src/model/style.rs: pub struct ShapeBorderLine
+src/model/style.rs: pub struct SolidFill
+src/model/style.rs: pub struct Style
+src/model/style.rs: pub struct SubstFont
+src/model/style.rs: pub struct TabDef
+src/model/style.rs: pub struct TabItem
+src/model/table.rs: pub const CELL_FLAG_EDITABLE_IN_FORM: u16 = 0x0008
+src/model/table.rs: pub const CELL_FLAG_HAS_MARGIN: u16 = 0x0001
+src/model/table.rs: pub const CELL_FLAG_HEADER: u16 = 0x0004
+src/model/table.rs: pub const CELL_FLAG_PROTECT: u16 = 0x0002
+src/model/table.rs: pub enum TablePageBreak
+src/model/table.rs: pub enum VerticalAlign
+src/model/table.rs: pub fn cell_at(&self, row: u16, col: u16) -> Option<&Cell>
+src/model/table.rs: pub fn cell_at_mut(&mut self, row: u16, col: u16) -> Option<&mut Cell>
+src/model/table.rs: pub fn cell_index_at(&self, row: u16, col: u16) -> Option<usize>
+src/model/table.rs: pub fn cell_protect(&self) -> bool
+src/model/table.rs: pub fn copy_transpose_range(
+src/model/table.rs: pub fn delete_column(&mut self, col_idx: u16) -> Result<(), String>
+src/model/table.rs: pub fn delete_row(&mut self, row_idx: u16) -> Result<(), String>
+src/model/table.rs: pub fn editable_in_form(&self) -> bool
+src/model/table.rs: pub fn effective_padding(
+src/model/table.rs: pub fn get_column_widths(&self) -> Vec<HwpUnit>
+src/model/table.rs: pub fn get_raw_row_heights(&self) -> Vec<HwpUnit>
+src/model/table.rs: pub fn get_row_heights(&self) -> Vec<HwpUnit>
+src/model/table.rs: pub fn inferred_local_resize_rows(&self) -> Vec<u16>
+src/model/table.rs: pub fn insert_column(&mut self, col_idx: u16, right: bool) -> Result<(), String>
+src/model/table.rs: pub fn insert_row(&mut self, row_idx: u16, below: bool) -> Result<(), String>
+src/model/table.rs: pub fn leading_header_rows(&self) -> Vec<usize>
+src/model/table.rs: pub fn merge_cells(
+src/model/table.rs: pub fn new_empty(
+src/model/table.rs: pub fn new_from_template(
+src/model/table.rs: pub fn paste_transposed_cells(
+src/model/table.rs: pub fn rebuild_grid(&mut self)
+src/model/table.rs: pub fn set_apply_inner_margin(&mut self, value: bool)
+src/model/table.rs: pub fn set_cell_protect(&mut self, value: bool)
+src/model/table.rs: pub fn set_column_widths(&mut self, widths: &[HwpUnit]) -> Result<(), String>
+src/model/table.rs: pub fn set_editable_in_form(&mut self, value: bool)
+src/model/table.rs: pub fn set_header(&mut self, value: bool)
+src/model/table.rs: pub fn split_cell(&mut self, target_row: u16, target_col: u16) -> Result<(), String>
+src/model/table.rs: pub fn split_cell_into(
+src/model/table.rs: pub fn split_cells_in_range(
+src/model/table.rs: pub fn table_padding_unspecified(table_padding: &crate::model::Padding) -> bool
+src/model/table.rs: pub fn transpose_unmerged_table_in_place(&mut self) -> Result<Vec<(usize, usize)>, String>
+src/model/table.rs: pub fn update_ctrl_dimensions(&mut self)
+src/model/table.rs: pub fn use_cell_padding_axis(
+src/model/table.rs: pub struct Cell
+src/model/table.rs: pub struct Table
+src/model/table.rs: pub struct TableTransposeData
+src/model/table.rs: pub struct TableZone
+src/ole_chart/ir.rs: pub const OLE_CHART_IR_SCHEMA: &str = "rhwp.oleChartIr"
+src/ole_chart/ir.rs: pub const OLE_CHART_IR_VERSION: u32 = 1
+src/ole_chart/ir.rs: pub fn new(chart: &'a OleChart) -> Self
+src/ole_chart/ir.rs: pub fn ole_chart_ir_base64(chart: &OleChart) -> Result<String, serde_json::Error>
+src/ole_chart/ir.rs: pub fn ole_chart_ir_json(chart: &OleChart) -> Result<String, serde_json::Error>
+src/ole_chart/ir.rs: pub struct OleChartIrPayload<'a>
+src/ole_chart/mod.rs: pub mod ir
+src/ole_chart/mod.rs: pub mod parser
+src/ole_chart/mod.rs: pub mod svg_renderer
+src/ole_chart/mod.rs: pub use ir::{
+src/ole_chart/mod.rs: pub use parser::{
+src/ole_chart/mod.rs: pub use svg_renderer::{
+src/ole_chart/parser.rs: pub enum OleChartParseError
+src/ole_chart/parser.rs: pub enum OleChartType
+src/ole_chart/parser.rs: pub fn code(&self) -> &'static str
+src/ole_chart/parser.rs: pub fn parse_ole_chart_contents(bytes: &[u8]) -> Result<OleChart, OleChartParseError>
+src/ole_chart/parser.rs: pub fn probe_ole_chart_contents(bytes: &[u8]) -> Result<OleChartContentsProbe, OleChartParseError>
+src/ole_chart/parser.rs: pub fn stable_message(&self) -> String
+src/ole_chart/parser.rs: pub struct OleChart
+src/ole_chart/parser.rs: pub struct OleChartContentsProbe
+src/ole_chart/parser.rs: pub struct OleChartSeries
+src/ole_chart/svg_renderer.rs: pub fn render_ole_chart_standalone_svg(chart: &OleChart, width: u32, height: u32) -> String
+src/ole_chart/svg_renderer.rs: pub fn render_ole_chart_svg_body(chart: &OleChart, width: f64, height: f64) -> String
+src/ole_chart/svg_renderer.rs: pub fn render_ole_chart_svg_fragment(
+src/ooxml_chart/mod.rs: pub enum BarGrouping
+src/ooxml_chart/mod.rs: pub enum LegendPos
+src/ooxml_chart/mod.rs: pub enum OoxmlChartType
+src/ooxml_chart/mod.rs: pub enum ScatterStyle
+src/ooxml_chart/mod.rs: pub enum SeriesMarker
+src/ooxml_chart/mod.rs: pub fn flags(&self) -> (bool, bool, bool)
+src/ooxml_chart/mod.rs: pub fn is_combo(&self) -> bool
+src/ooxml_chart/mod.rs: pub fn label(&self) -> &'static str
+src/ooxml_chart/mod.rs: pub fn parse(xml: &[u8]) -> Option<Self>
+src/ooxml_chart/mod.rs: pub fn render_svg(&self, x: f64, y: f64, w: f64, h: f64) -> String
+src/ooxml_chart/mod.rs: pub mod parser
+src/ooxml_chart/mod.rs: pub mod renderer
+src/ooxml_chart/mod.rs: pub struct OoxmlChart
+src/ooxml_chart/mod.rs: pub struct OoxmlSeries
+src/ooxml_chart/parser.rs: pub fn parse_chart_xml(xml: &[u8]) -> Option<OoxmlChart>
+src/ooxml_chart/renderer.rs: pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> String
+src/paint/builder.rs: pub fn build(&mut self, tree: &PageRenderTree) -> PageLayerTree
+src/paint/builder.rs: pub fn build_with_embedded_fonts(
+src/paint/builder.rs: pub fn new(profile: RenderProfile) -> Self
+src/paint/builder.rs: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
+src/paint/builder.rs: pub struct LayerBuilder
+src/paint/font.rs: pub enum BinaryResourceKind
+src/paint/font.rs: pub enum FontPortability
+src/paint/font.rs: pub enum FontPortabilityKind
+src/paint/font.rs: pub enum FontResourceSource
+src/paint/font.rs: pub enum GlyphRunReplayEligibility
+src/paint/font.rs: pub enum TextDirection
+src/paint/font.rs: pub enum WritingMode
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn as_str(self) -> &'static str
+src/paint/font.rs: pub fn is_empty(&self) -> bool
+src/paint/font.rs: pub fn is_self_contained_replayable(&self) -> bool
+src/paint/font.rs: pub fn kind(&self) -> FontPortabilityKind
+src/paint/font.rs: pub struct BinaryResourceRef
+src/paint/font.rs: pub struct FontBlobKey(pub String)
+src/paint/font.rs: pub struct FontBlobResource
+src/paint/font.rs: pub struct FontDigest
+src/paint/font.rs: pub struct FontExternalRef
+src/paint/font.rs: pub struct FontFaceKey(pub String)
+src/paint/font.rs: pub struct FontFaceResource
+src/paint/font.rs: pub struct FontFallbackPolicyId(pub String)
+src/paint/font.rs: pub struct FontInstanceKey
+src/paint/font.rs: pub struct FontResourceTable
+src/paint/font.rs: pub struct LanguageTag(pub String)
+src/paint/font.rs: pub struct LocalizedName
+src/paint/font.rs: pub struct OpenTypeFeatureSetting
+src/paint/font.rs: pub struct ScriptTag(pub String)
+src/paint/font.rs: pub struct ShapeKey
+src/paint/font.rs: pub struct ShapingEngineId(pub String)
+src/paint/font.rs: pub struct VariationAxisValue
+src/paint/font_glyph.rs: pub enum FontBitmapGlyphDecodeError
+src/paint/font_glyph.rs: pub enum FontSvgGlyphDecodeError
+src/paint/font_glyph.rs: pub fn as_str(self) -> &'static str
+src/paint/font_glyph.rs: pub fn as_str(self) -> &'static str
+src/paint/font_glyph.rs: pub fn decode_font_bitmap_glyph_payload(
+src/paint/font_glyph.rs: pub fn decode_font_svg_glyph_payload(
+src/paint/font_glyph.rs: pub fn lower_font_native_glyph_sidecars(
+src/paint/font_glyph.rs: pub fn new(
+src/paint/font_glyph.rs: pub fn new(source_range_utf8: TextSourceRange, glyph_range: GlyphRange) -> Self
+src/paint/font_glyph.rs: pub fn resolve_embedded_font_face_index(
+src/paint/font_glyph.rs: pub struct EmbeddedFontFace<'a>
+src/paint/font_glyph.rs: pub struct FontBitmapGlyphDecodeOptions
+src/paint/font_glyph.rs: pub struct FontGlyphLoweringReport
+src/paint/font_glyph.rs: pub struct FontSvgGlyphDecodeOptions
+src/paint/json.rs: pub fn to_json(&self) -> String
+src/paint/layer_tree.rs: pub enum CacheHint
+src/paint/layer_tree.rs: pub enum ClipKind
+src/paint/layer_tree.rs: pub enum GroupKind
+src/paint/layer_tree.rs: pub enum LayerNodeKind
+src/paint/layer_tree.rs: pub enum TextSourceAnnotation
+src/paint/layer_tree.rs: pub fn clip_rect(
+src/paint/layer_tree.rs: pub fn from_layer_node(root: &LayerNode) -> Self
+src/paint/layer_tree.rs: pub fn group(
+src/paint/layer_tree.rs: pub fn is_empty(&self) -> bool
+src/paint/layer_tree.rs: pub fn leaf(bounds: BoundingBox, source_node_id: Option<NodeId>, ops: Vec<PaintOp>) -> Self
+src/paint/layer_tree.rs: pub fn new(page_width: f64, page_height: f64, root: LayerNode) -> Self
+src/paint/layer_tree.rs: pub fn new(start: u32, end: u32) -> Self
+src/paint/layer_tree.rs: pub fn with_layer(mut self, layer: Option<RenderLayerInfo>) -> Self
+src/paint/layer_tree.rs: pub fn with_output_options(mut self, output_options: LayerOutputOptions) -> Self
+src/paint/layer_tree.rs: pub fn with_profile(
+src/paint/layer_tree.rs: pub fn with_text_sources(mut self, text_sources: TextSourceTable) -> Self
+src/paint/layer_tree.rs: pub struct LayerNode
+src/paint/layer_tree.rs: pub struct LayerOutputOptions
+src/paint/layer_tree.rs: pub struct PageLayerTree
+src/paint/layer_tree.rs: pub struct TextSourceEntry
+src/paint/layer_tree.rs: pub struct TextSourceId(pub u32)
+src/paint/layer_tree.rs: pub struct TextSourceRange
+src/paint/layer_tree.rs: pub struct TextSourceSpan
+src/paint/layer_tree.rs: pub struct TextSourceTable
+src/paint/mod.rs: pub mod builder
+src/paint/mod.rs: pub mod font
+src/paint/mod.rs: pub mod font_glyph
+src/paint/mod.rs: pub mod layer_tree
+src/paint/mod.rs: pub mod paint_op
+src/paint/mod.rs: pub mod profile
+src/paint/mod.rs: pub mod replay_order
+src/paint/mod.rs: pub mod resources
+src/paint/mod.rs: pub mod schema
+src/paint/mod.rs: pub mod text_shape
+src/paint/mod.rs: pub mod text_v2
+src/paint/mod.rs: pub mod text_variants
+src/paint/mod.rs: pub use builder::LayerBuilder
+src/paint/mod.rs: pub use font::{
+src/paint/mod.rs: pub use font_glyph::{
+src/paint/mod.rs: pub use layer_tree::{
+src/paint/mod.rs: pub use paint_op::{
+src/paint/mod.rs: pub use profile::RenderProfile
+src/paint/mod.rs: pub use replay_order::{
+src/paint/mod.rs: pub use resources::{
+src/paint/mod.rs: pub use schema::{
+src/paint/mod.rs: pub use text_shape::{
+src/paint/mod.rs: pub use text_v2::{
+src/paint/mod.rs: pub use text_variants::{validate_text_variant_scope, TextVariantScopeError}
+src/paint/paint_op.rs: pub enum BitmapGlyphFiltering
+src/paint/paint_op.rs: pub enum BitmapGlyphScalingPolicy
+src/paint/paint_op.rs: pub enum ColorGlyphFormat
+src/paint/paint_op.rs: pub enum ColorPaintGraphNodeKind
+src/paint/paint_op.rs: pub enum GlyphClusterFlag
+src/paint/paint_op.rs: pub enum GlyphOutlineFillRule
+src/paint/paint_op.rs: pub enum GlyphOutlinePaintOrder
+src/paint/paint_op.rs: pub enum GlyphOutlinePayloadKind
+src/paint/paint_op.rs: pub enum GlyphOutlineStrokeCap
+src/paint/paint_op.rs: pub enum GlyphOutlineStrokeJoin
+src/paint/paint_op.rs: pub enum GlyphRunOrientation
+src/paint/paint_op.rs: pub enum PaintOp
+src/paint/paint_op.rs: pub enum ResolvedImageKind
+src/paint/paint_op.rs: pub enum TextDecorationKind
+src/paint/paint_op.rs: pub enum TextVariantKind
+src/paint/paint_op.rs: pub enum TextVariantQuality
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn as_str(self) -> &'static str
+src/paint/paint_op.rs: pub fn bounds(&self) -> BoundingBox
+src/paint/paint_op.rs: pub fn char_overlap(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs: pub fn ellipse(bbox: BoundingBox, ellipse: EllipseNode) -> Self
+src/paint/paint_op.rs: pub fn equation(bbox: BoundingBox, equation: EquationNode) -> Self
+src/paint/paint_op.rs: pub fn footnote_marker(bbox: BoundingBox, marker: FootnoteMarkerNode) -> Self
+src/paint/paint_op.rs: pub fn form_object(bbox: BoundingBox, form: FormObjectNode) -> Self
+src/paint/paint_op.rs: pub fn from_text_run(run: &TextRunNode) -> Self
+src/paint/paint_op.rs: pub fn glyph_outline(bbox: BoundingBox, outline: LayerGlyphOutlinePaint) -> Self
+src/paint/paint_op.rs: pub fn glyph_run(bbox: BoundingBox, run: LayerGlyphRunPaint) -> Self
+src/paint/paint_op.rs: pub fn has_colrv0_resolved_layer_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_colrv1_stage1_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_colrv1_stage1_graph_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_colrv1_supported_graph_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_colrv1_supported_graph_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_exclusive_payload_family(&self) -> bool
+src/paint/paint_op.rs: pub fn has_payload_resource_key(&self) -> bool
+src/paint/paint_op.rs: pub fn has_static_sanitized_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn has_strict_visual_contract(&self) -> bool
+src/paint/paint_op.rs: pub fn image(
+src/paint/paint_op.rs: pub fn is_colrv1_stage1_supported(self) -> bool
+src/paint/paint_op.rs: pub fn is_fill_only_glyph_replay(&self) -> bool
+src/paint/paint_op.rs: pub fn is_non_empty(self) -> bool
+src/paint/paint_op.rs: pub fn is_strict_subset(&self) -> bool
+src/paint/paint_op.rs: pub fn line(bbox: BoundingBox, line: LineNode) -> Self
+src/paint/paint_op.rs: pub fn new(start: u32, end: u32) -> Self
+src/paint/paint_op.rs: pub fn page_background(bbox: BoundingBox, background: PageBackgroundNode) -> Self
+src/paint/paint_op.rs: pub fn path(bbox: BoundingBox, path: PathNode) -> Self
+src/paint/paint_op.rs: pub fn payload_resource_key(&self) -> Option<String>
+src/paint/paint_op.rs: pub fn payload_resource_key_with_resources(
+src/paint/paint_op.rs: pub fn placeholder(bbox: BoundingBox, placeholder: PlaceholderNode) -> Self
+src/paint/paint_op.rs: pub fn raw_svg(bbox: BoundingBox, raw: RawSvgNode) -> Self
+src/paint/paint_op.rs: pub fn rectangle(bbox: BoundingBox, rect: RectangleNode) -> Self
+src/paint/paint_op.rs: pub fn tab_leader(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs: pub fn text_control_mark(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs: pub fn text_decoration(bbox: BoundingBox, run: TextRunNode, kind: TextDecorationKind) -> Self
+src/paint/paint_op.rs: pub fn text_run(bbox: BoundingBox, run: TextRunNode) -> Self
+src/paint/paint_op.rs: pub fn text_run_default(equivalence_group: impl Into<String>) -> Self
+src/paint/paint_op.rs: pub struct BitmapGlyphPayload
+src/paint/paint_op.rs: pub struct ColorGradientStop
+src/paint/paint_op.rs: pub struct ColorLayerNode
+src/paint/paint_op.rs: pub struct ColorLayersPayload
+src/paint/paint_op.rs: pub struct ColorLinearGradient
+src/paint/paint_op.rs: pub struct ColorPaintGraphNode
+src/paint/paint_op.rs: pub struct ColorPaintGraphPayload
+src/paint/paint_op.rs: pub struct ColorPaintLinearGradientPathNode
+src/paint/paint_op.rs: pub struct ColorPaintRadialGradientPathNode
+src/paint/paint_op.rs: pub struct ColorPaintSolidPathNode
+src/paint/paint_op.rs: pub struct ColorPaintSweepGradientPathNode
+src/paint/paint_op.rs: pub struct ColorPaintTransformNode
+src/paint/paint_op.rs: pub struct ColorRadialGradient
+src/paint/paint_op.rs: pub struct ColorSweepGradient
+src/paint/paint_op.rs: pub struct FontColorGlyphRef
+src/paint/paint_op.rs: pub struct GlyphCluster
+src/paint/paint_op.rs: pub struct GlyphOutlineStrokeStyle
+src/paint/paint_op.rs: pub struct GlyphRange
+src/paint/paint_op.rs: pub struct GlyphRunDiagnostics
+src/paint/paint_op.rs: pub struct GlyphTransform
+src/paint/paint_op.rs: pub struct LayerAffineTransform
+src/paint/paint_op.rs: pub struct LayerGlyphOutlinePaint
+src/paint/paint_op.rs: pub struct LayerGlyphOutlinePath
+src/paint/paint_op.rs: pub struct LayerGlyphRunPaint
+src/paint/paint_op.rs: pub struct LayerPoint
+src/paint/paint_op.rs: pub struct LayerVector
+src/paint/paint_op.rs: pub struct PaintTextStyle
+src/paint/paint_op.rs: pub struct PaintVariantMeta
+src/paint/paint_op.rs: pub struct PaletteRef
+src/paint/paint_op.rs: pub struct ResolvedColor
+src/paint/paint_op.rs: pub struct ResolvedImagePayload
+src/paint/paint_op.rs: pub struct SvgGlyphPayload
+src/paint/paint_op.rs: pub struct TextRunPlacement
+src/paint/profile.rs: pub enum RenderProfile
+src/paint/profile.rs: pub fn parse(value: &str) -> Option<Self>
+src/paint/profile.rs: pub fn shows_editor_visuals(self) -> bool
+src/paint/replay_order.rs: pub const ORDERED: [Self
+src/paint/replay_order.rs: pub enum PaintReplayPlane
+src/paint/replay_order.rs: pub fn as_str(self) -> &'static str
+src/paint/replay_order.rs: pub fn paint_op_replay_plane(op: &PaintOp) -> PaintReplayPlane
+src/paint/replay_order.rs: pub fn paint_op_replay_plane_with_layer(
+src/paint/replay_order.rs: pub fn render_layer_replay_plane(layer: Option<RenderLayerInfo>) -> PaintReplayPlane
+src/paint/resources.rs: pub const RESOURCE_KEY_ALGORITHM: &str = "blake3"
+src/paint/resources.rs: pub fn font_blob_bytes(&self, id: FontBlobResourceId) -> Option<&[u8]>
+src/paint/resources.rs: pub fn font_blob_bytes_for_ref(&self, data_ref: &BinaryResourceRef) -> Option<&[u8]>
+src/paint/resources.rs: pub fn font_blob_count(&self) -> usize
+src/paint/resources.rs: pub fn font_blob_fingerprint(&self, id: FontBlobResourceId) -> Option<[u8
+src/paint/resources.rs: pub fn font_blob_hash(&self, id: FontBlobResourceId) -> Option<u64>
+src/paint/resources.rs: pub fn font_blob_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs: pub fn font_blob_resources(&self) -> impl Iterator<Item = (FontBlobResourceId, &[u8])> + '_
+src/paint/resources.rs: pub fn font_resources(&self) -> &FontResourceTable
+src/paint/resources.rs: pub fn font_resources_mut(&mut self) -> &mut FontResourceTable
+src/paint/resources.rs: pub fn image_bytes(&self, id: ImageResourceId) -> Option<&[u8]>
+src/paint/resources.rs: pub fn image_count(&self) -> usize
+src/paint/resources.rs: pub fn image_fingerprint(&self, id: ImageResourceId) -> Option<[u8
+src/paint/resources.rs: pub fn image_hash(&self, id: ImageResourceId) -> Option<u64>
+src/paint/resources.rs: pub fn image_resource_key(&self, id: ImageResourceId) -> Option<&str>
+src/paint/resources.rs: pub fn image_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs: pub fn image_resources(&self) -> impl Iterator<Item = (ImageResourceId, &[u8])> + '_
+src/paint/resources.rs: pub fn intern_font_blob_bytes(&mut self, bytes: &[u8]) -> FontBlobResourceId
+src/paint/resources.rs: pub fn intern_image_bytes(&mut self, bytes: &[u8]) -> ImageResourceId
+src/paint/resources.rs: pub fn intern_svg_fragment(&mut self, svg: &str) -> SvgResourceId
+src/paint/resources.rs: pub fn resource_digest_hex(bytes: impl AsRef<[u8]>) -> String
+src/paint/resources.rs: pub fn svg_count(&self) -> usize
+src/paint/resources.rs: pub fn svg_fingerprint(&self, id: SvgResourceId) -> Option<[u8
+src/paint/resources.rs: pub fn svg_fragment(&self, id: SvgResourceId) -> Option<&str>
+src/paint/resources.rs: pub fn svg_hash(&self, id: SvgResourceId) -> Option<u64>
+src/paint/resources.rs: pub fn svg_resource_key(&self, id: SvgResourceId) -> Option<&str>
+src/paint/resources.rs: pub fn svg_resource_key(byte_len: usize, digest: &str) -> String
+src/paint/resources.rs: pub fn svg_resources(&self) -> impl Iterator<Item = (SvgResourceId, &str)> + '_
+src/paint/resources.rs: pub struct FontBlobResourceId(pub usize)
+src/paint/resources.rs: pub struct ImageResourceId(pub usize)
+src/paint/resources.rs: pub struct ResourceArena
+src/paint/resources.rs: pub struct SvgResourceId(pub usize)
+src/paint/schema.rs: pub const LAYER_TREE_SCHEMA: LayerTreeSchema = LayerTreeSchema
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_COORDINATE_SYSTEM: &str = LAYER_TREE_SCHEMA.coordinate_system
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_RESOURCE_TABLE_MINOR_VERSION: u32 =
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_RESOURCE_TABLE_VERSION: u32 = LAYER_TREE_SCHEMA.resource_table_version
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_SCHEMA_MINOR_VERSION: u32 = LAYER_TREE_SCHEMA.schema_minor_version
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_SCHEMA_VERSION: u32 = LAYER_TREE_SCHEMA.schema_version
+src/paint/schema.rs: pub const PAGE_LAYER_TREE_UNIT: &str = LAYER_TREE_SCHEMA.unit
+src/paint/schema.rs: pub struct LayerTreeSchema
+src/paint/text_shape.rs: pub enum GlyphRunQuality
+src/paint/text_shape.rs: pub fn analyze_root(&self, root: &LayerNode) -> TextShapeReport
+src/paint/text_shape.rs: pub fn as_str(self) -> &'static str
+src/paint/text_shape.rs: pub fn diagnostics_only(resolver: &'a dyn FontResolver) -> Self
+src/paint/text_shape.rs: pub fn lower_root(&self, root: &mut LayerNode) -> TextShapeReport
+src/paint/text_shape.rs: pub fn new(resolver: &'a dyn FontResolver) -> Self
+src/paint/text_shape.rs: pub fn public_glyph_run_count(&self) -> usize
+src/paint/text_shape.rs: pub struct FontRequest
+src/paint/text_shape.rs: pub struct NoopFontResolver
+src/paint/text_shape.rs: pub struct ResolvedFontFace
+src/paint/text_shape.rs: pub struct ResolvedGlyphRun
+src/paint/text_shape.rs: pub struct TextShapeDiagnostic
+src/paint/text_shape.rs: pub struct TextShapeLowerer<'a>
+src/paint/text_shape.rs: pub struct TextShapeReport
+src/paint/text_shape.rs: pub trait FontResolver
+src/paint/text_v2.rs: pub enum TextV2CompatibilityProfile
+src/paint/text_v2.rs: pub enum TextV2LineBreakRiskLevel
+src/paint/text_v2.rs: pub enum TextV2ValidationSeverity
+src/paint/text_v2.rs: pub fn as_str(self) -> &'static str
+src/paint/text_v2.rs: pub fn from_layer_tree(tree: &PageLayerTree) -> Self
+src/paint/text_v2.rs: pub fn from_layer_tree_with_profile(
+src/paint/text_v2.rs: pub fn has_errors(&self) -> bool
+src/paint/text_v2.rs: pub fn to_json(&self) -> String
+src/paint/text_v2.rs: pub fn write_json(&self, buf: &mut String)
+src/paint/text_v2.rs: pub struct TextV2Diagnostics
+src/paint/text_v2.rs: pub struct TextV2LineBreakRisk
+src/paint/text_v2.rs: pub struct TextV2SlotDiagnostic
+src/paint/text_v2.rs: pub struct TextV2ValidationIssue
+src/paint/text_v2.rs: pub struct TextV2VariantDiagnostic
+src/paint/text_variants.rs: pub enum TextVariantScopeError
+src/paint/text_variants.rs: pub fn validate_text_variant_scope(tree: &PageLayerTree) -> Result<(), TextVariantScopeError>
+src/parser/bin_data.rs: pub enum BinDataError
+src/parser/bin_data.rs: pub fn bin_data_storage_name(bin_id: u16, extension: &str) -> String
+src/parser/bin_data.rs: pub fn extract_all_bin_data(cfb_reader: &mut CfbReader) -> Vec<BinDataContent>
+src/parser/bin_data.rs: pub fn read_bin_data_by_name(
+src/parser/bin_data.rs: pub struct BinDataContent
+src/parser/body_text.rs: pub enum BodyTextError
+src/parser/body_text.rs: pub fn parse_body_text_section(data: &[u8]) -> Result<Section, BodyTextError>
+src/parser/body_text.rs: pub fn parse_paragraph(records: &[Record]) -> Result<Paragraph, BodyTextError>
+src/parser/body_text.rs: pub fn parse_paragraph_list(records: &[Record]) -> Vec<Paragraph>
+src/parser/byte_reader.rs: pub fn is_empty(&self) -> bool
+src/parser/byte_reader.rs: pub fn new(data: &'a [u8]) -> Self
+src/parser/byte_reader.rs: pub fn position(&self) -> usize
+src/parser/byte_reader.rs: pub fn read_bytes(&mut self, len: usize) -> io::Result<Vec<u8>>
+src/parser/byte_reader.rs: pub fn read_color_ref(&mut self) -> io::Result<u32>
+src/parser/byte_reader.rs: pub fn read_hwp_string(&mut self) -> io::Result<String>
+src/parser/byte_reader.rs: pub fn read_i16(&mut self) -> io::Result<i16>
+src/parser/byte_reader.rs: pub fn read_i32(&mut self) -> io::Result<i32>
+src/parser/byte_reader.rs: pub fn read_i64(&mut self) -> io::Result<i64>
+src/parser/byte_reader.rs: pub fn read_i8(&mut self) -> io::Result<i8>
+src/parser/byte_reader.rs: pub fn read_remaining(&mut self) -> io::Result<Vec<u8>>
+src/parser/byte_reader.rs: pub fn read_u16(&mut self) -> io::Result<u16>
+src/parser/byte_reader.rs: pub fn read_u32(&mut self) -> io::Result<u32>
+src/parser/byte_reader.rs: pub fn read_u8(&mut self) -> io::Result<u8>
+src/parser/byte_reader.rs: pub fn read_utf16_string(&mut self, char_count: usize) -> io::Result<String>
+src/parser/byte_reader.rs: pub fn remaining(&self) -> usize
+src/parser/byte_reader.rs: pub fn set_position(&mut self, pos: usize)
+src/parser/byte_reader.rs: pub fn skip(&mut self, n: usize) -> io::Result<()>
+src/parser/byte_reader.rs: pub struct ByteReader<'a>
+src/parser/cfb_reader.rs: pub enum CfbError
+src/parser/cfb_reader.rs: pub fn decompress_stream(data: &[u8]) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn detect_hwp3_variant(&mut self) -> bool
+src/parser/cfb_reader.rs: pub fn has_stream(&self, path: &str) -> bool
+src/parser/cfb_reader.rs: pub fn has_stream(&self, path: &str) -> bool
+src/parser/cfb_reader.rs: pub fn list_all_entries(&self) -> Vec<(String, u64, bool)>
+src/parser/cfb_reader.rs: pub fn list_bin_data(&self) -> Vec<String>
+src/parser/cfb_reader.rs: pub fn list_entries(&self) -> &[(String, u32, u64, u8)]
+src/parser/cfb_reader.rs: pub fn list_streams(&self) -> Vec<String>
+src/parser/cfb_reader.rs: pub fn open(data: &[u8]) -> Result<Self, CfbError>
+src/parser/cfb_reader.rs: pub fn open(data: &[u8]) -> Result<Self, CfbError>
+src/parser/cfb_reader.rs: pub fn read_bin_data(&mut self, storage_name: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_body_text_section(
+src/parser/cfb_reader.rs: pub fn read_body_text_section(
+src/parser/cfb_reader.rs: pub fn read_body_text_section_full(
+src/parser/cfb_reader.rs: pub fn read_doc_info(&mut self, compressed: bool) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_doc_info(&self, compressed: bool) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_file_header(&mut self) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_file_header(&self) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_preview_image(&mut self) -> Option<Vec<u8>>
+src/parser/cfb_reader.rs: pub fn read_preview_text(&mut self) -> Option<String>
+src/parser/cfb_reader.rs: pub fn read_stream(&self, path: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn read_stream_raw(&mut self, path: &str) -> Result<Vec<u8>, CfbError>
+src/parser/cfb_reader.rs: pub fn section_count(&self) -> u32
+src/parser/cfb_reader.rs: pub fn section_count(&self) -> u32
+src/parser/cfb_reader.rs: pub struct CfbReader
+src/parser/cfb_reader.rs: pub struct LenientCfbReader
+src/parser/control.rs: pub fn parse_control(ctrl_id: u32, ctrl_data: &[u8], child_records: &[Record]) -> Control
+src/parser/crypto.rs: pub enum CryptoError
+src/parser/crypto.rs: pub fn decrypt_viewtext_section(
+src/parser/doc_info.rs: pub enum DocInfoError
+src/parser/doc_info.rs: pub fn parse_doc_info(data: &[u8]) -> Result<(DocInfo, DocProperties), DocInfoError>
+src/parser/header.rs: pub const FILE_HEADER_SIZE: usize = 256
+src/parser/header.rs: pub const HWP_SIGNATURE: &[u8] = b"HWP Document File"
+src/parser/header.rs: pub enum HeaderError
+src/parser/header.rs: pub fn from_u32(flags: u32) -> Self
+src/parser/header.rs: pub fn is_supported(&self) -> bool
+src/parser/header.rs: pub fn parse_file_header(data: &[u8]) -> Result<FileHeader, HeaderError>
+src/parser/header.rs: pub struct FileHeader
+src/parser/header.rs: pub struct FileHeaderFlags
+src/parser/header.rs: pub struct HwpVersion
+src/parser/hml/encoding.rs: pub enum HmlEncoding
+src/parser/hml/encoding.rs: pub fn decode(bytes: &[u8], max_bytes: usize) -> Result<DecodedHml, HmlError>
+src/parser/hml/encoding.rs: pub struct DecodedHml
+src/parser/hml/envelope.rs: pub struct PreservedFragment
+src/parser/hml/error.rs: pub enum HmlError
+src/parser/hml/mod.rs: pub fn detect_hml_signature(bytes: &[u8]) -> bool
+src/parser/hml/mod.rs: pub fn parse_hml(bytes: &[u8]) -> Result<HmlParseResult, HmlError>
+src/parser/hml/mod.rs: pub fn parse_hml_with_limits(bytes: &[u8], limits: &HmlLimits) -> Result<HmlParseResult, HmlError>
+src/parser/hml/mod.rs: pub mod encoding
+src/parser/hml/mod.rs: pub mod error
+src/parser/hml/mod.rs: pub struct HmlMetadata
+src/parser/hml/mod.rs: pub struct HmlParseResult
+src/parser/hml/mod.rs: pub use encoding::HmlEncoding
+src/parser/hml/mod.rs: pub use envelope::PreservedFragment
+src/parser/hml/mod.rs: pub use error::HmlError
+src/parser/hml/mod.rs: pub use reader::HmlLimits
+src/parser/hml/mod.rs: pub use warnings::{HmlWarning, HmlWarningCode}
+src/parser/hml/reader.rs: pub struct HmlLimits
+src/parser/hml/warnings.rs: pub enum HmlWarningCode
+src/parser/hml/warnings.rs: pub struct HmlWarning
+src/parser/hwp3/drawing.rs: pub enum Hwp3DrawingObject
+src/parser/hwp3/drawing.rs: pub fn has_bitmap_pattern(&self) -> bool
+src/parser/hwp3/drawing.rs: pub fn has_gradient(&self) -> bool
+src/parser/hwp3/drawing.rs: pub fn has_rotation(&self) -> bool
+src/parser/hwp3/drawing.rs: pub fn parse_drawing_object_tree(
+src/parser/hwp3/drawing.rs: pub fn read<R: Read + Seek>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingArc
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingCurve
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingExtendedPolygon
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingLine
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingModifiedEllipse
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectBasicAttr
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectBitmapPatternAttr
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectCommonHeader
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectFrameHeader
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectGradientAttr
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectHypertextInfo
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingObjectRotationAttr
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingPolygon
+src/parser/hwp3/drawing.rs: pub struct Hwp3DrawingTextBox
+src/parser/hwp3/encoding.rs: pub fn decode_hwp3_string(bytes: &[u8]) -> String
+src/parser/hwp3/johab.rs: pub fn decode_johab(ch: u16) -> char
+src/parser/hwp3/johab_map.rs: pub const JOHAB_SYMBOLS: &[(u16, char)] = &[
+src/parser/hwp3/mod.rs: pub enum Hwp3Error
+src/parser/hwp3/mod.rs: pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error>
+src/parser/hwp3/mod.rs: pub mod drawing
+src/parser/hwp3/mod.rs: pub mod encoding
+src/parser/hwp3/mod.rs: pub mod johab
+src/parser/hwp3/mod.rs: pub mod johab_map
+src/parser/hwp3/mod.rs: pub mod ole
+src/parser/hwp3/mod.rs: pub mod paragraph
+src/parser/hwp3/mod.rs: pub mod records
+src/parser/hwp3/mod.rs: pub mod special_char
+src/parser/hwp3/ole.rs: pub enum Hwp3OleError
+src/parser/hwp3/ole.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/ole.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/ole.rs: pub fn read<R: Read>(mut reader: R, total_length: u32) -> Result<Self, Hwp3OleError>
+src/parser/hwp3/ole.rs: pub struct Hwp3ChartConnectionInfo
+src/parser/hwp3/ole.rs: pub struct Hwp3OleInfo
+src/parser/hwp3/ole.rs: pub struct Hwp3OleStreamInfo
+src/parser/hwp3/paragraph.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/paragraph.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/paragraph.rs: pub struct Hwp3LineInfo
+src/parser/hwp3/paragraph.rs: pub struct Hwp3ParaInfo
+src/parser/hwp3/records.rs: pub fn alignment(&self) -> u8
+src/parser/hwp3/records.rs: pub fn border_connection(&self) -> bool
+src/parser/hwp3/records.rs: pub fn has_border(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_bold(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_font_blank(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_italic(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_outline(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_shadow(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_subscript(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_superscript(&self) -> bool
+src/parser/hwp3/records.rs: pub fn is_underline(&self) -> bool
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub fn read<R: Read>(mut reader: R) -> Result<Self, io::Error>
+src/parser/hwp3/records.rs: pub struct Hwp3AdditionalInfoBlock
+src/parser/hwp3/records.rs: pub struct Hwp3CharShape
+src/parser/hwp3/records.rs: pub struct Hwp3ColumnDef
+src/parser/hwp3/records.rs: pub struct Hwp3DocInfo
+src/parser/hwp3/records.rs: pub struct Hwp3DocSummary
+src/parser/hwp3/records.rs: pub struct Hwp3InfoBlock
+src/parser/hwp3/records.rs: pub struct Hwp3ParaShape
+src/parser/hwp3/records.rs: pub struct Hwp3Style
+src/parser/hwp3/records.rs: pub struct Hwp3TabDef
+src/parser/hwp3/special_char.rs: pub enum Hwp3SpecialChar
+src/parser/hwp3/special_char.rs: pub enum Hwp3SpecialCharError
+src/parser/hwp3/special_char.rs: pub fn parse(code: u16, length: u32, data: Vec<u8>) -> Result<Self, Hwp3SpecialCharError>
+src/parser/hwpx/content.rs: pub fn parse_content_hpf(xml: &str) -> Result<PackageInfo, HwpxError>
+src/parser/hwpx/content.rs: pub struct PackageInfo
+src/parser/hwpx/content.rs: pub struct PackageItem
+src/parser/hwpx/header.rs: pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxError>
+src/parser/hwpx/header.rs: pub fn parse_hwpx_hwpml_version(xml: &str) -> Option<String>
+src/parser/hwpx/mod.rs: pub enum HwpxError
+src/parser/hwpx/mod.rs: pub fn is_encrypted(&self) -> bool
+src/parser/hwpx/mod.rs: pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError>
+src/parser/hwpx/mod.rs: pub mod content
+src/parser/hwpx/mod.rs: pub mod header
+src/parser/hwpx/mod.rs: pub mod reader
+src/parser/hwpx/mod.rs: pub mod section
+src/parser/hwpx/mod.rs: pub mod utils
+src/parser/hwpx/reader.rs: pub const MAX_BINDATA_SIZE: usize = 512 * 1024 * 1024
+src/parser/hwpx/reader.rs: pub const MAX_XML_SIZE: usize = 256 * 1024 * 1024
+src/parser/hwpx/reader.rs: pub fn file_names(&self) -> Vec<String>
+src/parser/hwpx/reader.rs: pub fn open(data: &[u8]) -> Result<Self, HwpxError>
+src/parser/hwpx/reader.rs: pub fn read_file(&mut self, path: &str) -> Result<String, HwpxError>
+src/parser/hwpx/reader.rs: pub fn read_file_bytes(&mut self, path: &str) -> Result<Vec<u8>, HwpxError>
+src/parser/hwpx/reader.rs: pub struct HwpxReader
+src/parser/hwpx/section.rs: pub fn collect_hwpx_section_master_page_refs(xml: &str) -> Result<Vec<String>, HwpxError>
+src/parser/hwpx/section.rs: pub fn parse_hwpx_master_page(xml: &str) -> Result<MasterPage, HwpxError>
+src/parser/hwpx/section.rs: pub fn parse_hwpx_section(xml: &str) -> Result<Section, HwpxError>
+src/parser/hwpx/utils.rs: pub fn attr_eq(attr: &quick_xml::events::attributes::Attribute, val: &str) -> bool
+src/parser/hwpx/utils.rs: pub fn attr_str(attr: &quick_xml::events::attributes::Attribute) -> String
+src/parser/hwpx/utils.rs: pub fn local_name(name: &[u8]) -> &[u8]
+src/parser/hwpx/utils.rs: pub fn parse_bool(attr: &quick_xml::events::attributes::Attribute) -> bool
+src/parser/hwpx/utils.rs: pub fn parse_color(attr: &quick_xml::events::attributes::Attribute) -> u32
+src/parser/hwpx/utils.rs: pub fn parse_color_str(s: &str) -> u32
+src/parser/hwpx/utils.rs: pub fn parse_gradient_type(value: &str) -> i16
+src/parser/hwpx/utils.rs: pub fn parse_hatch_style(value: &str) -> Option<i32>
+src/parser/hwpx/utils.rs: pub fn parse_i16(attr: &quick_xml::events::attributes::Attribute) -> i16
+src/parser/hwpx/utils.rs: pub fn parse_i32(attr: &quick_xml::events::attributes::Attribute) -> i32
+src/parser/hwpx/utils.rs: pub fn parse_i32_wrapping(attr: &quick_xml::events::attributes::Attribute) -> i32
+src/parser/hwpx/utils.rs: pub fn parse_i8(attr: &quick_xml::events::attributes::Attribute) -> i8
+src/parser/hwpx/utils.rs: pub fn parse_u16(attr: &quick_xml::events::attributes::Attribute) -> u16
+src/parser/hwpx/utils.rs: pub fn parse_u32(attr: &quick_xml::events::attributes::Attribute) -> u32
+src/parser/hwpx/utils.rs: pub fn parse_u8(attr: &quick_xml::events::attributes::Attribute) -> u8
+src/parser/hwpx/utils.rs: pub fn skip_element(reader: &mut Reader<&[u8]>, _end_tag: &[u8]) -> Result<(), HwpxError>
+src/parser/ingest/mod.rs: pub fn parse_ingest_bytes(bytes: &[u8]) -> Result<IngestDocument, HwpError>
+src/parser/ingest/mod.rs: pub fn parse_ingest_str(s: &str) -> Result<IngestDocument, HwpError>
+src/parser/ingest/mod.rs: pub mod schema
+src/parser/ingest/mod.rs: pub use schema::*
+src/parser/ingest/schema.rs: pub enum Placement
+src/parser/ingest/schema.rs: pub enum StemBlock
+src/parser/ingest/schema.rs: pub struct Choice
+src/parser/ingest/schema.rs: pub struct IngestDocument
+src/parser/ingest/schema.rs: pub struct Media
+src/parser/ingest/schema.rs: pub struct PageSize
+src/parser/ingest/schema.rs: pub struct Passage
+src/parser/ingest/schema.rs: pub struct Question
+src/parser/mod.rs: pub enum FileFormat
+src/parser/mod.rs: pub enum ParseError
+src/parser/mod.rs: pub fn detect_format(data: &[u8]) -> FileFormat
+src/parser/mod.rs: pub fn extract_thumbnail_only(data: &[u8]) -> Option<ThumbnailResult>
+src/parser/mod.rs: pub fn parse_document(data: &[u8]) -> Result<Document, ParseError>
+src/parser/mod.rs: pub fn parse_document_with_metadata(data: &[u8]) -> Result<ParsedDocument, ParseError>
+src/parser/mod.rs: pub fn parse_hwp(data: &[u8]) -> Result<Document, ParseError>
+src/parser/mod.rs: pub mod bin_data
+src/parser/mod.rs: pub mod body_text
+src/parser/mod.rs: pub mod byte_reader
+src/parser/mod.rs: pub mod cfb_reader
+src/parser/mod.rs: pub mod control
+src/parser/mod.rs: pub mod crypto
+src/parser/mod.rs: pub mod doc_info
+src/parser/mod.rs: pub mod header
+src/parser/mod.rs: pub mod hml
+src/parser/mod.rs: pub mod hwp3
+src/parser/mod.rs: pub mod hwpx
+src/parser/mod.rs: pub mod ingest
+src/parser/mod.rs: pub mod ole_container
+src/parser/mod.rs: pub mod record
+src/parser/mod.rs: pub mod tags
+src/parser/mod.rs: pub struct HmlImportMetadata
+src/parser/mod.rs: pub struct HmlParser
+src/parser/mod.rs: pub struct Hwp3Parser
+src/parser/mod.rs: pub struct HwpParser
+src/parser/mod.rs: pub struct HwpxParser
+src/parser/mod.rs: pub struct ParsedDocument
+src/parser/mod.rs: pub struct ThumbnailResult
+src/parser/mod.rs: pub trait DocumentParser
+src/parser/ole_container.rs: pub enum NativeImageKind
+src/parser/ole_container.rs: pub fn detect_native_image(data: &[u8]) -> Option<(NativeImageKind, Vec<u8>)>
+src/parser/ole_container.rs: pub fn has_ooxml_chart(&self) -> bool
+src/parser/ole_container.rs: pub fn has_preview(&self) -> bool
+src/parser/ole_container.rs: pub fn is_hmapsi_ole_container(cfb_bytes: &[u8]) -> bool
+src/parser/ole_container.rs: pub fn mime(&self) -> &'static str
+src/parser/ole_container.rs: pub fn parse_ole_container(cfb_bytes: &[u8]) -> Option<OleContainer>
+src/parser/ole_container.rs: pub struct OleContainer
+src/parser/record.rs: pub enum RecordError
+src/parser/record.rs: pub fn read_all(data: &[u8]) -> Result<Vec<Record>, RecordError>
+src/parser/record.rs: pub fn tag_name(&self) -> &'static str
+src/parser/record.rs: pub struct Record
+src/parser/tags.rs: pub const CHAR_EXTENDED_CTRL: u16 = 0x000B
+src/parser/tags.rs: pub const CHAR_FIELD_BEGIN: u16 = 0x0003
+src/parser/tags.rs: pub const CHAR_FIELD_END: u16 = 0x0004
+src/parser/tags.rs: pub const CHAR_FIXED_WIDTH_SPACE: u16 = 0x0019
+src/parser/tags.rs: pub const CHAR_FIXED_WIDTH_SPACE_31: u16 = 0x001F
+src/parser/tags.rs: pub const CHAR_HYPHEN: u16 = 0x0018
+src/parser/tags.rs: pub const CHAR_INLINE_NON_TEXT: u16 = 0x0008
+src/parser/tags.rs: pub const CHAR_LINE_BREAK: u16 = 0x000A
+src/parser/tags.rs: pub const CHAR_NBSPACE: u16 = 0x001E
+src/parser/tags.rs: pub const CHAR_PARA_BREAK: u16 = 0x000D
+src/parser/tags.rs: pub const CHAR_SECTION_COLUMN_DEF: u16 = 0x0002
+src/parser/tags.rs: pub const CTRL_AUTO_NUMBER: u32 = ctrl_id(b"atno")
+src/parser/tags.rs: pub const CTRL_BOOKMARK: u32 = ctrl_id(b"bokm")
+src/parser/tags.rs: pub const CTRL_CHAR_OVERLAP: u32 = ctrl_id(b"tdut")
+src/parser/tags.rs: pub const CTRL_COLUMN_DEF: u32 = ctrl_id(b"cold")
+src/parser/tags.rs: pub const CTRL_ENDNOTE: u32 = ctrl_id(b"en ")
+src/parser/tags.rs: pub const CTRL_EQUATION: u32 = ctrl_id(b"eqed")
+src/parser/tags.rs: pub const CTRL_FOOTER: u32 = ctrl_id(b"foot")
+src/parser/tags.rs: pub const CTRL_FOOTNOTE: u32 = ctrl_id(b"fn ")
+src/parser/tags.rs: pub const CTRL_FORM: u32 = ctrl_id(b"form")
+src/parser/tags.rs: pub const CTRL_GEN_SHAPE: u32 = ctrl_id(b"gso ")
+src/parser/tags.rs: pub const CTRL_HEADER: u32 = ctrl_id(b"head")
+src/parser/tags.rs: pub const CTRL_HIDDEN_COMMENT: u32 = ctrl_id(b"tcmt")
+src/parser/tags.rs: pub const CTRL_INDEX_MARK: u32 = ctrl_id(b"idxm")
+src/parser/tags.rs: pub const CTRL_NEW_NUMBER: u32 = ctrl_id(b"nwno")
+src/parser/tags.rs: pub const CTRL_PAGE_HIDE: u32 = ctrl_id(b"pghd")
+src/parser/tags.rs: pub const CTRL_PAGE_NUM_POS: u32 = ctrl_id(b"pgnp")
+src/parser/tags.rs: pub const CTRL_SECTION_DEF: u32 = ctrl_id(b"secd")
+src/parser/tags.rs: pub const CTRL_TABLE: u32 = ctrl_id(b"tbl ")
+src/parser/tags.rs: pub const CTRL_TCPS: u32 = ctrl_id(b"tcps")
+src/parser/tags.rs: pub const FIELD_BOOKMARK: u32 = ctrl_id(b"%bmk")
+src/parser/tags.rs: pub const FIELD_CLICKHERE: u32 = ctrl_id(b"%clk")
+src/parser/tags.rs: pub const FIELD_CROSSREF: u32 = ctrl_id(b"%xrf")
+src/parser/tags.rs: pub const FIELD_DATE: u32 = ctrl_id(b"%dte")
+src/parser/tags.rs: pub const FIELD_DOCDATE: u32 = ctrl_id(b"%ddt")
+src/parser/tags.rs: pub const FIELD_FORMULA: u32 = ctrl_id(b"%fmu")
+src/parser/tags.rs: pub const FIELD_HYPERLINK: u32 = ctrl_id(b"%hlk")
+src/parser/tags.rs: pub const FIELD_MAILMERGE: u32 = ctrl_id(b"%mmg")
+src/parser/tags.rs: pub const FIELD_MEMO: u32 = ctrl_id(b"%%me")
+src/parser/tags.rs: pub const FIELD_PATH: u32 = ctrl_id(b"%pat")
+src/parser/tags.rs: pub const FIELD_PRIVATE_INFO: u32 = ctrl_id(b"%cpr")
+src/parser/tags.rs: pub const FIELD_SUMMARY: u32 = ctrl_id(b"%smr")
+src/parser/tags.rs: pub const FIELD_TOC: u32 = ctrl_id(b"%toc")
+src/parser/tags.rs: pub const FIELD_UNKNOWN: u32 = ctrl_id(b"%unk")
+src/parser/tags.rs: pub const FIELD_USERINFO: u32 = ctrl_id(b"%usr")
+src/parser/tags.rs: pub const HWPTAG_BEGIN: u16 = 0x010
+src/parser/tags.rs: pub const HWPTAG_BIN_DATA: u16 = HWPTAG_BEGIN + 2
+src/parser/tags.rs: pub const HWPTAG_BORDER_FILL: u16 = HWPTAG_BEGIN + 4
+src/parser/tags.rs: pub const HWPTAG_BULLET: u16 = HWPTAG_BEGIN + 8
+src/parser/tags.rs: pub const HWPTAG_CHART_DATA: u16 = HWPTAG_BEGIN + 79
+src/parser/tags.rs: pub const HWPTAG_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 5
+src/parser/tags.rs: pub const HWPTAG_COMPATIBLE_DOCUMENT: u16 = HWPTAG_BEGIN + 14
+src/parser/tags.rs: pub const HWPTAG_CTRL_DATA: u16 = HWPTAG_BEGIN + 71
+src/parser/tags.rs: pub const HWPTAG_CTRL_HEADER: u16 = HWPTAG_BEGIN + 55
+src/parser/tags.rs: pub const HWPTAG_DISTRIBUTE_DOC_DATA: u16 = HWPTAG_BEGIN + 12
+src/parser/tags.rs: pub const HWPTAG_DOCUMENT_PROPERTIES: u16 = HWPTAG_BEGIN
+src/parser/tags.rs: pub const HWPTAG_DOC_DATA: u16 = HWPTAG_BEGIN + 11
+src/parser/tags.rs: pub const HWPTAG_EQEDIT: u16 = HWPTAG_BEGIN + 72
+src/parser/tags.rs: pub const HWPTAG_FACE_NAME: u16 = HWPTAG_BEGIN + 3
+src/parser/tags.rs: pub const HWPTAG_FOOTNOTE_SHAPE: u16 = HWPTAG_BEGIN + 58
+src/parser/tags.rs: pub const HWPTAG_FORBIDDEN_CHAR: u16 = HWPTAG_BEGIN + 78
+src/parser/tags.rs: pub const HWPTAG_FORM_OBJECT: u16 = HWPTAG_BEGIN + 75
+src/parser/tags.rs: pub const HWPTAG_ID_MAPPINGS: u16 = HWPTAG_BEGIN + 1
+src/parser/tags.rs: pub const HWPTAG_LAYOUT_COMPATIBILITY: u16 = HWPTAG_BEGIN + 15
+src/parser/tags.rs: pub const HWPTAG_LIST_HEADER: u16 = HWPTAG_BEGIN + 56
+src/parser/tags.rs: pub const HWPTAG_MEMO_LIST: u16 = HWPTAG_BEGIN + 77
+src/parser/tags.rs: pub const HWPTAG_MEMO_SHAPE: u16 = HWPTAG_BEGIN + 76
+src/parser/tags.rs: pub const HWPTAG_NUMBERING: u16 = HWPTAG_BEGIN + 7
+src/parser/tags.rs: pub const HWPTAG_PAGE_BORDER_FILL: u16 = HWPTAG_BEGIN + 59
+src/parser/tags.rs: pub const HWPTAG_PAGE_DEF: u16 = HWPTAG_BEGIN + 57
+src/parser/tags.rs: pub const HWPTAG_PARA_CHAR_SHAPE: u16 = HWPTAG_BEGIN + 52
+src/parser/tags.rs: pub const HWPTAG_PARA_HEADER: u16 = HWPTAG_BEGIN + 50
+src/parser/tags.rs: pub const HWPTAG_PARA_LINE_SEG: u16 = HWPTAG_BEGIN + 53
+src/parser/tags.rs: pub const HWPTAG_PARA_RANGE_TAG: u16 = HWPTAG_BEGIN + 54
+src/parser/tags.rs: pub const HWPTAG_PARA_SHAPE: u16 = HWPTAG_BEGIN + 9
+src/parser/tags.rs: pub const HWPTAG_PARA_TEXT: u16 = HWPTAG_BEGIN + 51
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT: u16 = HWPTAG_BEGIN + 60
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_ARC: u16 = HWPTAG_BEGIN + 65
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_CONTAINER: u16 = HWPTAG_BEGIN + 70
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_CURVE: u16 = HWPTAG_BEGIN + 67
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_ELLIPSE: u16 = HWPTAG_BEGIN + 64
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_LINE: u16 = HWPTAG_BEGIN + 62
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_OLE: u16 = HWPTAG_BEGIN + 68
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_PICTURE: u16 = HWPTAG_BEGIN + 69
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_POLYGON: u16 = HWPTAG_BEGIN + 66
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_RECTANGLE: u16 = HWPTAG_BEGIN + 63
+src/parser/tags.rs: pub const HWPTAG_SHAPE_COMPONENT_TEXTART: u16 = HWPTAG_BEGIN + 74
+src/parser/tags.rs: pub const HWPTAG_STYLE: u16 = HWPTAG_BEGIN + 10
+src/parser/tags.rs: pub const HWPTAG_TABLE: u16 = HWPTAG_BEGIN + 61
+src/parser/tags.rs: pub const HWPTAG_TAB_DEF: u16 = HWPTAG_BEGIN + 6
+src/parser/tags.rs: pub const HWPTAG_TRACKCHANGE: u16 = HWPTAG_BEGIN + 16
+src/parser/tags.rs: pub const SHAPE_ARC_ID: u32 = ctrl_id(b"$arc")
+src/parser/tags.rs: pub const SHAPE_CONNECTOR_ID: u32 = ctrl_id(b"$col")
+src/parser/tags.rs: pub const SHAPE_CONTAINER_ID: u32 = ctrl_id(b"$con")
+src/parser/tags.rs: pub const SHAPE_CURVE_ID: u32 = ctrl_id(b"$cur")
+src/parser/tags.rs: pub const SHAPE_ELLIPSE_ID: u32 = ctrl_id(b"$ell")
+src/parser/tags.rs: pub const SHAPE_LINE_ID: u32 = ctrl_id(b"$lin")
+src/parser/tags.rs: pub const SHAPE_OLE_ID: u32 = ctrl_id(b"$ole")
+src/parser/tags.rs: pub const SHAPE_PICTURE_ID: u32 = ctrl_id(b"$pic")
+src/parser/tags.rs: pub const SHAPE_POLYGON_ID: u32 = ctrl_id(b"$pol")
+src/parser/tags.rs: pub const SHAPE_RECT_ID: u32 = ctrl_id(b"$rec")
+src/parser/tags.rs: pub const fn is_field_ctrl_id(id: u32) -> bool
+src/parser/tags.rs: pub fn ctrl_name(ctrl_id: u32) -> &'static str
+src/parser/tags.rs: pub fn tag_name(tag_id: u16) -> &'static str
+src/renderer/canvas.rs: pub enum CanvasCommand
+src/renderer/canvas.rs: pub fn command_count(&self) -> usize
+src/renderer/canvas.rs: pub fn commands(&self) -> &[CanvasCommand]
+src/renderer/canvas.rs: pub fn new() -> Self
+src/renderer/canvas.rs: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
+src/renderer/canvas.rs: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/canvas.rs: pub struct CanvasRenderer
+src/renderer/canvaskit_policy.rs: pub enum CanvasKitReplayFeature
+src/renderer/canvaskit_policy.rs: pub enum CanvasKitReplayMode
+src/renderer/canvaskit_policy.rs: pub enum CanvasKitReplayReason
+src/renderer/canvaskit_policy.rs: pub enum CanvasKitReplayStatus
+src/renderer/canvaskit_policy.rs: pub fn analyze_canvaskit_replay_plan(
+src/renderer/canvaskit_policy.rs: pub fn as_str(self) -> &'static str
+src/renderer/canvaskit_policy.rs: pub fn from_str(value: &str) -> Option<Self>
+src/renderer/canvaskit_policy.rs: pub struct CanvasKitRejectedTextVariant
+src/renderer/canvaskit_policy.rs: pub struct CanvasKitReplayItem
+src/renderer/canvaskit_policy.rs: pub struct CanvasKitReplayPlan
+src/renderer/canvaskit_policy.rs: pub struct CanvasKitReplaySummary
+src/renderer/canvaskit_policy.rs: pub struct CanvasKitTextVariantReport
+src/renderer/composer.rs: pub enum InlineControlType
+src/renderer/composer.rs: pub fn char_overlap_advance_units(chars: &[char]) -> usize
+src/renderer/composer.rs: pub fn compose_paragraph(para: &Paragraph) -> ComposedParagraph
+src/renderer/composer.rs: pub fn compose_section(section: &Section) -> Vec<ComposedParagraph>
+src/renderer/composer.rs: pub fn decode_pua_overlap_number(chars: &[char]) -> Option<String>
+src/renderer/composer.rs: pub fn effective_text_for_metrics(run: &ComposedTextRun) -> &str
+src/renderer/composer.rs: pub fn estimate_composed_line_width(line: &ComposedLine, styles: &ResolvedStyleSet) -> f64
+src/renderer/composer.rs: pub fn expand_pua_display_text(text: &str) -> String
+src/renderer/composer.rs: pub fn expand_pua_render_text(text: &str) -> String
+src/renderer/composer.rs: pub fn pua_to_display_text(ch: char) -> Option<String>
+src/renderer/composer.rs: pub fn recompose_for_body_width(
+src/renderer/composer.rs: pub fn recompose_for_cell_width(
+src/renderer/composer.rs: pub fn recompose_stored_lines_if_overflowing_body(
+src/renderer/composer.rs: pub fn recompose_stored_single_line_if_overflowing(
+src/renderer/composer.rs: pub fn stored_lines_overflow(
+src/renderer/composer.rs: pub mod lineseg_compare
+src/renderer/composer.rs: pub struct CharOverlapInfo
+src/renderer/composer.rs: pub struct ComposedLine
+src/renderer/composer.rs: pub struct ComposedParagraph
+src/renderer/composer.rs: pub struct ComposedTextRun
+src/renderer/composer.rs: pub struct InlineControl
+src/renderer/composer/lineseg_compare.rs: pub fn all_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs: pub fn all_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs: pub fn all_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs: pub fn avg_field_deltas(&self) -> AvgFieldDeltas
+src/renderer/composer/lineseg_compare.rs: pub fn compare_line_segs(
+src/renderer/composer/lineseg_compare.rs: pub fn format_report(reports: &[SectionLineSegReport]) -> String
+src/renderer/composer/lineseg_compare.rs: pub fn line_break_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs: pub fn line_breaks_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs: pub fn line_count_match_rate(&self) -> f64
+src/renderer/composer/lineseg_compare.rs: pub fn text_start_match(&self) -> bool
+src/renderer/composer/lineseg_compare.rs: pub struct AvgFieldDeltas
+src/renderer/composer/lineseg_compare.rs: pub struct LineSegFieldDiff
+src/renderer/composer/lineseg_compare.rs: pub struct ParagraphLineSegDiff
+src/renderer/composer/lineseg_compare.rs: pub struct SectionLineSegReport
+src/renderer/equation/ast.rs: pub enum EqNode
+src/renderer/equation/ast.rs: pub enum MatrixStyle
+src/renderer/equation/ast.rs: pub enum PileAlign
+src/renderer/equation/ast.rs: pub enum SpaceKind
+src/renderer/equation/ast.rs: pub fn simplify(self) -> Self
+src/renderer/equation/canvas_render.rs: pub fn render_equation_canvas(
+src/renderer/equation/layout.rs: pub enum LayoutKind
+src/renderer/equation/layout.rs: pub fn layout(&self, node: &EqNode) -> LayoutBox
+src/renderer/equation/layout.rs: pub fn new(font_size: f64) -> Self
+src/renderer/equation/layout.rs: pub struct EqLayout
+src/renderer/equation/layout.rs: pub struct LayoutBox
+src/renderer/equation/mod.rs: pub fn intrinsic_size_hwp(script: &str, font_size: u32) -> (u32, u32)
+src/renderer/equation/mod.rs: pub mod ast
+src/renderer/equation/mod.rs: pub mod canvas_render
+src/renderer/equation/mod.rs: pub mod layout
+src/renderer/equation/mod.rs: pub mod parser
+src/renderer/equation/mod.rs: pub mod svg_render
+src/renderer/equation/mod.rs: pub mod symbols
+src/renderer/equation/mod.rs: pub mod tokenizer
+src/renderer/equation/parser.rs: pub fn new(tokens: Vec<Token>) -> Self
+src/renderer/equation/parser.rs: pub fn parse(&mut self) -> EqNode
+src/renderer/equation/parser.rs: pub fn parse(script: &str) -> EqNode
+src/renderer/equation/parser.rs: pub struct EqParser
+src/renderer/equation/svg_render.rs: pub const DEFAULT_EQUATION_FONT_FAMILY_ATTR: &str =
+src/renderer/equation/svg_render.rs: pub fn eq_color_to_svg(color: u32) -> String
+src/renderer/equation/svg_render.rs: pub fn render_equation_svg(layout: &LayoutBox, color: &str, base_font_size: f64) -> String
+src/renderer/equation/symbols.rs: pub enum DecoKind
+src/renderer/equation/symbols.rs: pub enum FontStyleKind
+src/renderer/equation/symbols.rs: pub fn is_big_operator(cmd: &str) -> bool
+src/renderer/equation/symbols.rs: pub fn is_function(cmd: &str) -> bool
+src/renderer/equation/symbols.rs: pub fn is_structure_command(cmd: &str) -> bool
+src/renderer/equation/symbols.rs: pub fn lookup_equation_pua(ch: char) -> Option<&'static str>
+src/renderer/equation/symbols.rs: pub fn lookup_function(cmd: &str) -> Option<&'static str>
+src/renderer/equation/symbols.rs: pub fn lookup_symbol(cmd: &str) -> Option<&'static str>
+src/renderer/equation/symbols.rs: pub static DECORATIONS: LazyLock<HashMap<&'static str, DecoKind>> = LazyLock::new(||
+src/renderer/equation/symbols.rs: pub static FONT_STYLES: LazyLock<HashMap<&'static str, FontStyleKind>> = LazyLock::new(||
+src/renderer/equation/tokenizer.rs: pub enum TokenType
+src/renderer/equation/tokenizer.rs: pub fn eof(pos: usize) -> Self
+src/renderer/equation/tokenizer.rs: pub fn new(script: &str) -> Self
+src/renderer/equation/tokenizer.rs: pub fn new(ty: TokenType, value: impl Into<String>, pos: usize) -> Self
+src/renderer/equation/tokenizer.rs: pub fn next_token(&mut self) -> Token
+src/renderer/equation/tokenizer.rs: pub fn tokenize(mut self) -> Vec<Token>
+src/renderer/equation/tokenizer.rs: pub fn tokenize(script: &str) -> Vec<Token>
+src/renderer/equation/tokenizer.rs: pub struct Token
+src/renderer/equation/tokenizer.rs: pub struct Tokenizer
+src/renderer/font_metrics_data.rs: pub fn find_metric(name: &str, bold: bool, italic: bool) -> Option<MetricMatch>
+src/renderer/font_metrics_data.rs: pub fn get_width(&self, ch: char) -> Option<u16>
+src/renderer/font_metrics_data.rs: pub static FONT_METRICS: [FontMetric
+src/renderer/font_metrics_data.rs: pub struct FontMetric
+src/renderer/font_metrics_data.rs: pub struct HangulMetric
+src/renderer/font_metrics_data.rs: pub struct LatinRange
+src/renderer/font_metrics_data.rs: pub struct MetricMatch
+src/renderer/height_measurer.rs: pub const BLOCK_UNIT_MAX_ROWS: usize = 3
+src/renderer/height_measurer.rs: pub fn allows_row_break_split(&self) -> bool
+src/renderer/height_measurer.rs: pub fn cell_controls_height(
+src/renderer/height_measurer.rs: pub fn effective_row_height(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs: pub fn estimate_footnote_area_height(
+src/renderer/height_measurer.rs: pub fn estimate_single_footnote_height(&self, footnote: &Footnote) -> f64
+src/renderer/height_measurer.rs: pub fn find_break_row(
+src/renderer/height_measurer.rs: pub fn fit_measured_table_to_declared_height(
+src/renderer/height_measurer.rs: pub fn get_measured_paragraph(&self, para_index: usize) -> Option<&MeasuredParagraph>
+src/renderer/height_measurer.rs: pub fn get_measured_table(
+src/renderer/height_measurer.rs: pub fn get_paragraph_height(&self, para_index: usize) -> Option<f64>
+src/renderer/height_measurer.rs: pub fn get_table_height(&self, para_index: usize, control_index: usize) -> Option<f64>
+src/renderer/height_measurer.rs: pub fn is_row_splittable(&self, row: usize) -> bool
+src/renderer/height_measurer.rs: pub fn is_tac_table_inline(
+src/renderer/height_measurer.rs: pub fn is_tac_table_inline_in_para(table: &Table, seg_width: i32, para: &Paragraph) -> bool
+src/renderer/height_measurer.rs: pub fn line_advance(&self, line_idx: usize) -> f64
+src/renderer/height_measurer.rs: pub fn line_advances_sum(&self, range: std::ops::Range<usize>) -> f64
+src/renderer/height_measurer.rs: pub fn max_padding_for_row(&self, row: usize) -> f64
+src/renderer/height_measurer.rs: pub fn measure_section(
+src/renderer/height_measurer.rs: pub fn measure_section_incremental(
+src/renderer/height_measurer.rs: pub fn measure_section_selective(
+src/renderer/height_measurer.rs: pub fn min_first_line_height_for_row(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs: pub fn new(dpi: f64) -> Self
+src/renderer/height_measurer.rs: pub fn paragraph_has_table(&self, para_index: usize) -> bool
+src/renderer/height_measurer.rs: pub fn range_height(&self, start_row: usize, end_row: usize) -> f64
+src/renderer/height_measurer.rs: pub fn remaining_content_for_row(&self, row: usize, content_offset: f64) -> f64
+src/renderer/height_measurer.rs: pub fn row_block_for(&self, row: usize) -> (usize, usize, f64)
+src/renderer/height_measurer.rs: pub fn shift_for_insert(&mut self, insert_at: usize)
+src/renderer/height_measurer.rs: pub fn shift_for_remove(&mut self, remove_at: usize)
+src/renderer/height_measurer.rs: pub fn snap_to_block_boundary(&self, end_row: usize) -> usize
+src/renderer/height_measurer.rs: pub fn with_default_dpi() -> Self
+src/renderer/height_measurer.rs: pub fn with_hwp3_origin_flow_spacing_before(mut self, enabled: bool) -> Self
+src/renderer/height_measurer.rs: pub fn with_hwp3_variant(mut self, enabled: bool) -> Self
+src/renderer/height_measurer.rs: pub struct HeightMeasurer
+src/renderer/height_measurer.rs: pub struct MeasuredCell
+src/renderer/height_measurer.rs: pub struct MeasuredParagraph
+src/renderer/height_measurer.rs: pub struct MeasuredSection
+src/renderer/height_measurer.rs: pub struct MeasuredTable
+src/renderer/html.rs: pub fn new() -> Self
+src/renderer/html.rs: pub fn output(&self) -> &str
+src/renderer/html.rs: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/html.rs: pub struct HtmlRenderer
+src/renderer/layer_renderer.rs: pub enum RasterColorSpace
+src/renderer/layer_renderer.rs: pub enum RasterOutputFormat
+src/renderer/layer_renderer.rs: pub enum VariantRejectReason
+src/renderer/layer_renderer.rs: pub enum VariantSelectedReason
+src/renderer/layer_renderer.rs: pub enum VariantSelectionBackend
+src/renderer/layer_renderer.rs: pub fn analyze_text_variant_selection(
+src/renderer/layer_renderer.rs: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs: pub fn as_str(self) -> &'static str
+src/renderer/layer_renderer.rs: pub fn canvaskit() -> Self
+src/renderer/layer_renderer.rs: pub fn canvaskit_strict_outline() -> Self
+src/renderer/layer_renderer.rs: pub struct RasterRenderOptions
+src/renderer/layer_renderer.rs: pub struct RasterRenderOutput
+src/renderer/layer_renderer.rs: pub struct TextVariantRejectReport
+src/renderer/layer_renderer.rs: pub struct TextVariantSelectionOptions
+src/renderer/layer_renderer.rs: pub struct TextVariantSelectionReport
+src/renderer/layer_renderer.rs: pub trait LayerRasterRenderer
+src/renderer/layer_renderer.rs: pub trait LayerRenderer
+src/renderer/layer_renderer.rs: pub type LayerRenderResult<T> = Result<T, HwpError>
+src/renderer/layout.rs: pub fn advance_numbering(&self, numbering_id: u16, level: u8)
+src/renderer/layout.rs: pub fn build_render_tree(
+src/renderer/layout.rs: pub fn clear_layout_caches(&self)
+src/renderer/layout.rs: pub fn innermost(&self) -> &CellPathEntry
+src/renderer/layout.rs: pub fn last_image_indices(&self) -> (Option<usize>, Option<usize>, Option<usize>)
+src/renderer/layout.rs: pub fn new(dpi: f64) -> Self
+src/renderer/layout.rs: pub fn outermost_cell(&self) -> usize
+src/renderer/layout.rs: pub fn outermost_cell_para(&self) -> usize
+src/renderer/layout.rs: pub fn outermost_control(&self) -> usize
+src/renderer/layout.rs: pub fn reset_auto_counter(&self)
+src/renderer/layout.rs: pub fn reset_numbering_state(&self)
+src/renderer/layout.rs: pub fn set_active_field(
+src/renderer/layout.rs: pub fn set_clip_enabled(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_current_page_is_section_first(&self, is_first: bool)
+src/renderer/layout.rs: pub fn set_endnote_between_notes_hu(&self, between_notes_hu: i32)
+src/renderer/layout.rs: pub fn set_endnote_para_sources(&self, base: usize, sources: &[EndnoteParaSource])
+src/renderer/layout.rs: pub fn set_endnote_shape_margins_hu(
+src/renderer/layout.rs: pub fn set_file_name(&self, name: &str)
+src/renderer/layout.rs: pub fn set_hidden_empty_paras(&self, paras: &std::collections::HashSet<usize>)
+src/renderer/layout.rs: pub fn set_hidden_header_footer(&self, hidden: &std::collections::HashSet<(u32, bool)>)
+src/renderer/layout.rs: pub fn set_hwp3_origin_flow_spacing_before(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_hwp3_variant(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_hwpx_page_preview(&self, data: Option<&[u8]>)
+src/renderer/layout.rs: pub fn set_hwpx_source(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_pre_emitted_host_heights(&self, heights: &std::collections::HashMap<usize, f64>)
+src/renderer/layout.rs: pub fn set_pre_emitted_host_paras(&self, paras: &std::collections::HashSet<usize>)
+src/renderer/layout.rs: pub fn set_show_control_codes(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_show_transparent_borders(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_total_pages(&self, total: u32)
+src/renderer/layout.rs: pub fn take_overflows(&self) -> Vec<LayoutOverflow>
+src/renderer/layout.rs: pub fn text_direction(&self) -> u8
+src/renderer/layout.rs: pub fn with_default_dpi() -> Self
+src/renderer/layout.rs: pub struct CellContext
+src/renderer/layout.rs: pub struct CellPathEntry
+src/renderer/layout.rs: pub struct LayoutEngine
+src/renderer/layout.rs: pub struct LayoutOverflow
+src/renderer/layout.rs: pub use paragraph_layout::map_pua_bullet_char
+src/renderer/layout/paragraph_layout.rs: pub fn map_pua_bullet_char(ch: char) -> char
+src/renderer/layout/text_measurement.rs: pub fn extract_tab_leaders(text: &str, positions: &[f64], style: &TextStyle) -> Vec<TabLeaderInfo>
+src/renderer/layout/text_measurement.rs: pub fn extract_tab_leaders_with_extended(
+src/renderer/layout/text_measurement.rs: pub fn split_into_clusters(text: &str) -> Vec<(usize, String)>
+src/renderer/layout/text_measurement.rs: pub struct EmbeddedTextMeasurer
+src/renderer/layout/text_measurement.rs: pub struct MockTextMeasurer
+src/renderer/layout/text_measurement.rs: pub struct WasmTextMeasurer
+src/renderer/layout/text_measurement.rs: pub trait TextMeasurer
+src/renderer/layout/utils.rs: pub fn resolve_numbering_id(
+src/renderer/mod.rs: pub const DEFAULT_DPI: f64 = 96.0
+src/renderer/mod.rs: pub const HWPUNIT_PER_INCH: f64 = 7200.0
+src/renderer/mod.rs: pub enum ArrowStyle
+src/renderer/mod.rs: pub enum LineRenderType
+src/renderer/mod.rs: pub enum NumberFormat
+src/renderer/mod.rs: pub enum PathCommand
+src/renderer/mod.rs: pub enum RenderBackend
+src/renderer/mod.rs: pub enum StrokeDash
+src/renderer/mod.rs: pub fn corrected_line_height(
+src/renderer/mod.rs: pub fn corrected_line_height_for_variant_synthetic(
+src/renderer/mod.rs: pub fn corrected_line_metrics(
+src/renderer/mod.rs: pub fn corrected_line_metrics_for_source(
+src/renderer/mod.rs: pub fn css_font_weight(&self) -> Option<&'static str>
+src/renderer/mod.rs: pub fn current(&self, number_type: AutoNumberType) -> u16
+src/renderer/mod.rs: pub fn format_number(number: u16, format: NumberFormat) -> String
+src/renderer/mod.rs: pub fn from_hwp_format(format: u8) -> Self
+src/renderer/mod.rs: pub fn from_str(s: &str) -> Option<Self>
+src/renderer/mod.rs: pub fn generic_fallback(font_family: &str) -> &'static str
+src/renderer/mod.rs: pub fn hwpunit_to_px(hwpunit: i32, dpi: f64) -> f64
+src/renderer/mod.rs: pub fn increment(&mut self, number_type: AutoNumberType) -> u16
+src/renderer/mod.rs: pub fn is_medium_weight(&self) -> bool
+src/renderer/mod.rs: pub fn is_visually_bold(&self) -> bool
+src/renderer/mod.rs: pub fn new() -> Self
+src/renderer/mod.rs: pub fn px_to_hwpunit(px: f64, dpi: f64) -> i32
+src/renderer/mod.rs: pub fn reset(&mut self)
+src/renderer/mod.rs: pub fn svg_arc_to_beziers(
+src/renderer/mod.rs: pub mod canvas
+src/renderer/mod.rs: pub mod canvaskit_policy
+src/renderer/mod.rs: pub mod composer
+src/renderer/mod.rs: pub mod equation
+src/renderer/mod.rs: pub mod float_placement
+src/renderer/mod.rs: pub mod font_metrics_data
+src/renderer/mod.rs: pub mod height_cursor
+src/renderer/mod.rs: pub mod height_measurer
+src/renderer/mod.rs: pub mod html
+src/renderer/mod.rs: pub mod image_resolver
+src/renderer/mod.rs: pub mod layer_renderer
+src/renderer/mod.rs: pub mod layout
+src/renderer/mod.rs: pub mod page_layout
+src/renderer/mod.rs: pub mod page_number
+src/renderer/mod.rs: pub mod pagination
+src/renderer/mod.rs: pub mod pdf
+src/renderer/mod.rs: pub mod pua_oldhangul
+src/renderer/mod.rs: pub mod render_tree
+src/renderer/mod.rs: pub mod scheduler
+src/renderer/mod.rs: pub mod skia
+src/renderer/mod.rs: pub mod style_resolver
+src/renderer/mod.rs: pub mod svg
+src/renderer/mod.rs: pub mod svg_fragment
+src/renderer/mod.rs: pub mod svg_layer
+src/renderer/mod.rs: pub mod typeset
+src/renderer/mod.rs: pub mod web_canvas
+src/renderer/mod.rs: pub struct AutoNumberCounter
+src/renderer/mod.rs: pub struct GradientFillInfo
+src/renderer/mod.rs: pub struct LineStyle
+src/renderer/mod.rs: pub struct PatternFillInfo
+src/renderer/mod.rs: pub struct ShadowStyle
+src/renderer/mod.rs: pub struct ShapeStyle
+src/renderer/mod.rs: pub struct TabLeaderInfo
+src/renderer/mod.rs: pub struct TabStop
+src/renderer/mod.rs: pub struct TextStyle
+src/renderer/mod.rs: pub trait Renderer
+src/renderer/page_layout.rs: pub fn apply_page_number_margins(&mut self, page_def: &PageDef, page_number: u32)
+src/renderer/page_layout.rs: pub fn available_body_height(&self) -> f64
+src/renderer/page_layout.rs: pub fn column_width_hu(&self) -> i32
+src/renderer/page_layout.rs: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
+src/renderer/page_layout.rs: pub fn from_page_def(page_def: &PageDef, column_def: &ColumnDef, dpi: f64) -> Self
+src/renderer/page_layout.rs: pub fn from_page_def_default(page_def: &PageDef, column_def: &ColumnDef) -> Self
+src/renderer/page_layout.rs: pub fn from_page_def_for_page(
+src/renderer/page_layout.rs: pub fn update_footnote_area(&mut self, footnote_height: f64)
+src/renderer/page_layout.rs: pub struct LayoutRect
+src/renderer/page_layout.rs: pub struct PageLayoutInfo
+src/renderer/page_number.rs: pub fn assign(&mut self, page: &PageContent) -> u32
+src/renderer/page_number.rs: pub fn new(new_page_numbers: &'a [(usize, u16)], initial: u32) -> Self
+src/renderer/page_number.rs: pub fn next_counter(&self) -> u32
+src/renderer/page_number.rs: pub fn should_hide_page_number(&self) -> bool
+src/renderer/pagination.rs: pub enum EndnoteDeferral<'a>
+src/renderer/pagination.rs: pub enum FootnoteSource
+src/renderer/pagination.rs: pub enum PageItem
+src/renderer/pagination.rs: pub fn copy_converged_pages(
+src/renderer/pagination.rs: pub fn estimate_footnote_note_height(footnote: &Footnote, dpi: f64) -> f64
+src/renderer/pagination.rs: pub fn find_convergence(&self, old: &PaginationResult, offset: i32) -> Option<usize>
+src/renderer/pagination.rs: pub fn find_inline_control_target_page(
+src/renderer/pagination.rs: pub fn footnote_between_notes_margin_px(shape: &FootnoteShape, dpi: f64) -> f64
+src/renderer/pagination.rs: pub fn footnote_separator_overhead_px(shape: &FootnoteShape, dpi: f64) -> f64
+src/renderer/pagination.rs: pub fn new(dpi: f64) -> Self
+src/renderer/pagination.rs: pub fn paginate(
+src/renderer/pagination.rs: pub fn para_index(&self) -> usize
+src/renderer/pagination.rs: pub fn with_default_dpi() -> Self
+src/renderer/pagination.rs: pub fn with_offset(&self, offset: i32) -> Self
+src/renderer/pagination.rs: pub struct ColumnContent
+src/renderer/pagination.rs: pub struct DeferredEndnote
+src/renderer/pagination.rs: pub struct EndnoteParaSource
+src/renderer/pagination.rs: pub struct EndnoteRef
+src/renderer/pagination.rs: pub struct FootnoteRef
+src/renderer/pagination.rs: pub struct HeaderFooterRef
+src/renderer/pagination.rs: pub struct MasterPageRef
+src/renderer/pagination.rs: pub struct PageContent
+src/renderer/pagination.rs: pub struct PaginationOpts
+src/renderer/pagination.rs: pub struct PaginationResult
+src/renderer/pagination.rs: pub struct Paginator
+src/renderer/pagination.rs: pub struct WrapAnchorRef
+src/renderer/pagination.rs: pub struct WrapAroundPara
+src/renderer/pagination/engine.rs: pub fn paginate_with_measured(
+src/renderer/pagination/engine.rs: pub fn paginate_with_measured_opts(
+src/renderer/pagination/state.rs: pub fn add_footnote_height(&mut self, height: f64)
+src/renderer/pagination/state.rs: pub fn advance_column_or_new_page(&mut self)
+src/renderer/pagination/state.rs: pub fn available_height(&self) -> f64
+src/renderer/pagination/state.rs: pub fn base_available_height(&self) -> f64
+src/renderer/pagination/state.rs: pub fn ensure_page(&mut self)
+src/renderer/pagination/state.rs: pub fn flush_column(&mut self)
+src/renderer/pagination/state.rs: pub fn flush_column_always(&mut self)
+src/renderer/pagination/state.rs: pub fn force_new_page(&mut self)
+src/renderer/pagination/state.rs: pub fn new(
+src/renderer/pagination/state.rs: pub fn projected_footnote_height(&self, note_content_height: f64, note_count: usize) -> f64
+src/renderer/pagination/state.rs: pub fn reinsert_carry_with_height(&mut self, carry_height: f64)
+src/renderer/pdf.rs: pub enum PdfBackend
+src/renderer/pdf.rs: pub fn as_str(self) -> &'static str
+src/renderer/pdf.rs: pub fn layer_trees_to_pdf(layer_trees: &[crate::paint::PageLayerTree]) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs: pub fn layer_trees_to_pdf_with_options(
+src/renderer/pdf.rs: pub fn parse(value: &str) -> Option<Self>
+src/renderer/pdf.rs: pub fn svg_to_pdf(svg_content: &str) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs: pub fn svg_to_pdf_with_options(
+src/renderer/pdf.rs: pub fn svgs_to_pdf(svg_pages: &[String]) -> Result<Vec<u8>, String>
+src/renderer/pdf.rs: pub fn svgs_to_pdf_with_options(
+src/renderer/pdf.rs: pub struct DirectPdfExportOptions
+src/renderer/pdf.rs: pub struct PdfExportOptions
+src/renderer/pua_oldhangul.rs: pub fn is_pua_old_hangul(ch: char) -> bool
+src/renderer/pua_oldhangul.rs: pub fn map_pua_old_hangul(ch: char) -> Option<&'static [char]>
+src/renderer/render_tree.rs: pub const LEGACY_IMAGE_WATERMARK_OPACITY: f64 = 0.17
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_BRIGHTNESS: f64 = 1.80
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_CHROMA_GAIN: f64 = 3.0
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_CONTRAST: f64 = 0.93125103
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_CORRECTION_BIAS: [f64
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_CORRECTION_MATRIX: [[f64
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_FILL_CHROMA_GAIN: f64 = 0.42
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_FILL_OPACITY: f64 = 0.15
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_FILL_WHITE_BLEND: f64 = 0.16
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_OPACITY: f64 = REAL_PICTURE_WATERMARK_PAGE_OPACITY
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_PAGE_OPACITY: f64 = 0.26
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_SATURATION: f64 = 0.91646104
+src/renderer/render_tree.rs: pub const REAL_PICTURE_WATERMARK_WHITE_BLEND: f64 = 0.0
+src/renderer/render_tree.rs: pub enum FieldMarkerType
+src/renderer/render_tree.rs: pub enum HeaderFooterKind
+src/renderer/render_tree.rs: pub enum PlaceholderKind
+src/renderer/render_tree.rs: pub enum RenderNodeType
+src/renderer/render_tree.rs: pub fn clip_overlapping_same_bin_images(&mut self)
+src/renderer/render_tree.rs: pub fn contains(&self, other: &BoundingBox) -> bool
+src/renderer/render_tree.rs: pub fn effective_image_bbox(&self, bbox: &BoundingBox) -> BoundingBox
+src/renderer/render_tree.rs: pub fn for_master_page(mut self) -> Self
+src/renderer/render_tree.rs: pub fn from_hwpunit_rect(rect: &Rect, dpi: f64) -> Self
+src/renderer/render_tree.rs: pub fn get_inline_shape_position(
+src/renderer/render_tree.rs: pub fn has_dirty_nodes(&self) -> bool
+src/renderer/render_tree.rs: pub fn has_transform(&self) -> bool
+src/renderer/render_tree.rs: pub fn inline_shape_positions(&self) -> &std::collections::HashMap<InlineShapeKey, (f64, f64)>
+src/renderer/render_tree.rs: pub fn intersects(&self, other: &BoundingBox) -> bool
+src/renderer/render_tree.rs: pub fn invalidate(&mut self)
+src/renderer/render_tree.rs: pub fn is_real_picture_watermark_tone_preset(
+src/renderer/render_tree.rs: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
+src/renderer/render_tree.rs: pub fn is_real_picture_watermark_tone_preset(&self) -> bool
+src/renderer/render_tree.rs: pub fn is_watermark(&self) -> bool
+src/renderer/render_tree.rs: pub fn is_watermark(&self) -> bool
+src/renderer/render_tree.rs: pub fn mark_all_clean(&mut self)
+src/renderer/render_tree.rs: pub fn mark_clean(&mut self)
+src/renderer/render_tree.rs: pub fn mark_clean_recursive(&mut self)
+src/renderer/render_tree.rs: pub fn missing_picture(
+src/renderer/render_tree.rs: pub fn needs_render(&self) -> bool
+src/renderer/render_tree.rs: pub fn new(
+src/renderer/render_tree.rs: pub fn new(
+src/renderer/render_tree.rs: pub fn new(bin_data_id: u16, data: Option<Vec<u8>>) -> Self
+src/renderer/render_tree.rs: pub fn new(fill_color: u32, stroke_color: u32, label: String) -> Self
+src/renderer/render_tree.rs: pub fn new(id: NodeId, node_type: RenderNodeType, bbox: BoundingBox) -> Self
+src/renderer/render_tree.rs: pub fn new(line_height: f64, baseline: f64) -> Self
+src/renderer/render_tree.rs: pub fn new(page_index: u32, width: f64, height: f64) -> Self
+src/renderer/render_tree.rs: pub fn new(style: ShapeStyle, gradient: Option<Box<GradientFillInfo>>) -> Self
+src/renderer/render_tree.rs: pub fn new(svg: String) -> Self
+src/renderer/render_tree.rs: pub fn new(text_wrap: Option<TextWrap>, z_order: i32, stable_index: u32) -> Self
+src/renderer/render_tree.rs: pub fn new(x1: f64, y1: f64, x2: f64, y2: f64, style: LineStyle) -> Self
+src/renderer/render_tree.rs: pub fn new(x: f64, y: f64, width: f64, height: f64) -> Self
+src/renderer/render_tree.rs: pub fn next_id(&mut self) -> NodeId
+src/renderer/render_tree.rs: pub fn ole(
+src/renderer/render_tree.rs: pub fn ole(section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs: pub fn ole(svg: String, section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs: pub fn picture(section_index: usize, para_index: usize, control_index: usize) -> Self
+src/renderer/render_tree.rs: pub fn set_inline_shape_position(
+src/renderer/render_tree.rs: pub fn set_layer(&mut self, layer: RenderLayerInfo)
+src/renderer/render_tree.rs: pub fn to_json(&self) -> String
+src/renderer/render_tree.rs: pub fn with_layer(mut self, layer: RenderLayerInfo) -> Self
+src/renderer/render_tree.rs: pub fn with_para(
+src/renderer/render_tree.rs: pub fn with_para_vpos(
+src/renderer/render_tree.rs: pub struct BoundingBox
+src/renderer/render_tree.rs: pub struct EllipseNode
+src/renderer/render_tree.rs: pub struct EquationNode
+src/renderer/render_tree.rs: pub struct FootnoteMarkerNode
+src/renderer/render_tree.rs: pub struct FormObjectNode
+src/renderer/render_tree.rs: pub struct GroupNode
+src/renderer/render_tree.rs: pub struct HeaderFooterImageRef
+src/renderer/render_tree.rs: pub struct ImageNode
+src/renderer/render_tree.rs: pub struct LineNode
+src/renderer/render_tree.rs: pub struct NoteControlRef
+src/renderer/render_tree.rs: pub struct ObjectControlRef
+src/renderer/render_tree.rs: pub struct PageBackgroundImage
+src/renderer/render_tree.rs: pub struct PageBackgroundNode
+src/renderer/render_tree.rs: pub struct PageNode
+src/renderer/render_tree.rs: pub struct PageRenderTree
+src/renderer/render_tree.rs: pub struct PathNode
+src/renderer/render_tree.rs: pub struct PlaceholderNode
+src/renderer/render_tree.rs: pub struct RawSvgNode
+src/renderer/render_tree.rs: pub struct RectangleNode
+src/renderer/render_tree.rs: pub struct RenderLayerInfo
+src/renderer/render_tree.rs: pub struct RenderNode
+src/renderer/render_tree.rs: pub struct ShapeTransform
+src/renderer/render_tree.rs: pub struct TableCellNode
+src/renderer/render_tree.rs: pub struct TableNode
+src/renderer/render_tree.rs: pub struct TextLineNode
+src/renderer/render_tree.rs: pub struct TextRunNode
+src/renderer/render_tree.rs: pub type InlineShapeKey = (usize, usize, usize, Vec<(usize, usize, usize)>)
+src/renderer/render_tree.rs: pub type NodeId = u32
+src/renderer/scheduler.rs: pub enum RenderError
+src/renderer/scheduler.rs: pub enum RenderEvent
+src/renderer/scheduler.rs: pub enum RenderPriority
+src/renderer/scheduler.rs: pub enum TaskStatus
+src/renderer/scheduler.rs: pub fn as_bbox(&self) -> BoundingBox
+src/renderer/scheduler.rs: pub fn cleanup_tasks(&mut self)
+src/renderer/scheduler.rs: pub fn complete_task(&mut self, task_id: u32)
+src/renderer/scheduler.rs: pub fn invalidate_page(&mut self, page_index: u32)
+src/renderer/scheduler.rs: pub fn new(id: u32, page_index: u32, priority: RenderPriority) -> Self
+src/renderer/scheduler.rs: pub fn new(total_pages: u32) -> Self
+src/renderer/scheduler.rs: pub fn new(width: f64, height: f64) -> Self
+src/renderer/scheduler.rs: pub fn next_task(&mut self) -> Option<&RenderTask>
+src/renderer/scheduler.rs: pub fn pending_count(&self) -> usize
+src/renderer/scheduler.rs: pub fn set_page_heights(&mut self, heights: &[f64])
+src/renderer/scheduler.rs: pub fn update_viewport(&mut self, viewport: Viewport)
+src/renderer/scheduler.rs: pub fn update_zoom(&mut self, zoom: f64)
+src/renderer/scheduler.rs: pub fn visible_pages(&self) -> Vec<u32>
+src/renderer/scheduler.rs: pub struct RenderScheduler
+src/renderer/scheduler.rs: pub struct RenderTask
+src/renderer/scheduler.rs: pub struct Viewport
+src/renderer/scheduler.rs: pub trait RenderObserver
+src/renderer/scheduler.rs: pub trait RenderWorker
+src/renderer/skia/equation_conv.rs: pub fn render_equation(
+src/renderer/skia/image_conv.rs: pub fn draw_image_bytes(
+src/renderer/skia/image_conv.rs: pub fn draw_svg_fragment(
+src/renderer/skia/image_conv.rs: pub fn linear() -> Self
+src/renderer/skia/image_conv.rs: pub struct ImageSampling
+src/renderer/skia/mod.rs: pub use renderer::SkiaLayerRenderer
+src/renderer/skia/renderer.rs: pub enum NativeGlyphRunReplayProofReason
+src/renderer/skia/renderer.rs: pub fn as_str(self) -> &'static str
+src/renderer/skia/renderer.rs: pub fn native_skia_glyph_run_replay_proof(
+src/renderer/skia/renderer.rs: pub fn new() -> Self
+src/renderer/skia/renderer.rs: pub fn render_raster_with_options(
+src/renderer/skia/renderer.rs: pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self
+src/renderer/skia/renderer.rs: pub struct NativeGlyphRunReplayProof
+src/renderer/skia/renderer.rs: pub struct SkiaLayerRenderer
+src/renderer/style_resolver.rs: pub const LANG_COUNT: usize = 7
+src/renderer/style_resolver.rs: pub fn detect_lang_category(ch: char) -> usize
+src/renderer/style_resolver.rs: pub fn font_family_for_lang(&self, lang_index: usize) -> &str
+src/renderer/style_resolver.rs: pub fn letter_spacing_for_lang(&self, lang_index: usize) -> f64
+src/renderer/style_resolver.rs: pub fn primary_font_name(font_family: &str) -> &str
+src/renderer/style_resolver.rs: pub fn ratio_for_lang(&self, lang_index: usize) -> f64
+src/renderer/style_resolver.rs: pub fn resolve_styles(doc_info: &DocInfo, dpi: f64) -> ResolvedStyleSet
+src/renderer/style_resolver.rs: pub fn resolve_styles_with_variant(
+src/renderer/style_resolver.rs: pub struct ResolvedBorderStyle
+src/renderer/style_resolver.rs: pub struct ResolvedCharStyle
+src/renderer/style_resolver.rs: pub struct ResolvedImageFill
+src/renderer/style_resolver.rs: pub struct ResolvedParaStyle
+src/renderer/style_resolver.rs: pub struct ResolvedStyleSet
+src/renderer/svg.rs: pub enum FontEmbedMode
+src/renderer/svg.rs: pub fn font_codepoints(
+src/renderer/svg.rs: pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::PathBuf]) -> String
+src/renderer/svg.rs: pub fn new() -> Self
+src/renderer/svg.rs: pub fn output(&self) -> &str
+src/renderer/svg.rs: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/svg.rs: pub struct SvgRenderer
+src/renderer/svg_layer.rs: pub fn inner_mut(&mut self) -> &mut SvgRenderer
+src/renderer/svg_layer.rs: pub fn new() -> Self
+src/renderer/svg_layer.rs: pub fn output(&self) -> &str
+src/renderer/svg_layer.rs: pub struct SvgLayerRenderer
+src/renderer/typeset.rs: pub fn new(dpi: f64) -> Self
+src/renderer/typeset.rs: pub fn typeset_section(
+src/renderer/typeset.rs: pub fn typeset_section_with_variant(
+src/renderer/typeset.rs: pub fn with_default_dpi() -> Self
+src/renderer/typeset.rs: pub struct TypesetEngine
+src/renderer/web_canvas.rs: pub enum LayerFilter
+src/renderer/web_canvas.rs: pub fn new(canvas: &HtmlCanvasElement) -> Result<Self, JsValue>
+src/renderer/web_canvas.rs: pub fn render_layer_tree(&mut self, tree: &PageLayerTree)
+src/renderer/web_canvas.rs: pub fn render_tree(&mut self, tree: &PageRenderTree)
+src/renderer/web_canvas.rs: pub fn set_layer_filter(&mut self, filter: LayerFilter)
+src/renderer/web_canvas.rs: pub fn set_scale(&mut self, scale: f64)
+src/renderer/web_canvas.rs: pub struct WebCanvasRenderer
+src/serializer/body_text.rs: pub fn serialize_paragraph_list(
+src/serializer/body_text.rs: pub fn serialize_section(section: &Section) -> Vec<u8>
+src/serializer/body_text.rs: pub fn test_serialize_para_text(para: &Paragraph) -> Vec<u8>
+src/serializer/byte_writer.rs: pub fn as_bytes(&self) -> &[u8]
+src/serializer/byte_writer.rs: pub fn into_bytes(self) -> Vec<u8>
+src/serializer/byte_writer.rs: pub fn new() -> Self
+src/serializer/byte_writer.rs: pub fn position(&self) -> usize
+src/serializer/byte_writer.rs: pub fn write_bytes(&mut self, data: &[u8]) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_color_ref(&mut self, color: u32) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_f64(&mut self, v: f64) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_hwp_string(&mut self, s: &str) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_i16(&mut self, v: i16) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_i32(&mut self, v: i32) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_i8(&mut self, v: i8) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_u16(&mut self, v: u16) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_u32(&mut self, v: u32) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_u8(&mut self, v: u8) -> io::Result<()>
+src/serializer/byte_writer.rs: pub fn write_zeros(&mut self, count: usize) -> io::Result<()>
+src/serializer/byte_writer.rs: pub struct ByteWriter
+src/serializer/cfb_writer.rs: pub fn serialize_hwp(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/control.rs: pub fn serialize_control(
+src/serializer/doc_info.rs: pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_border_fill(bf: &BorderFill) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_char_shape(cs: &CharShape) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_doc_info(doc_info: &DocInfo, doc_props: &DocProperties) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_document_properties(props: &DocProperties) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_face_name(font: &Font) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_id_mappings(doc_info: &DocInfo) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_style(style: &Style) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn serialize_tab_def(td: &TabDef) -> Vec<u8>
+src/serializer/doc_info.rs: pub fn surgical_insert_font_all_langs(raw_stream: &mut Vec<u8>, data: &[u8]) -> Result<(), String>
+src/serializer/doc_info.rs: pub fn surgical_insert_record(
+src/serializer/doc_info.rs: pub fn surgical_remove_records(raw_stream: &mut Vec<u8>, tag_id: u16) -> usize
+src/serializer/doc_info.rs: pub fn surgical_update_caret(
+src/serializer/header.rs: pub fn serialize_file_header(header: &FileHeader) -> Vec<u8>
+src/serializer/hml/error.rs: pub enum HmlExportError
+src/serializer/hml/error.rs: pub fn blockers(&self) -> &[HmlSaveBlocker]
+src/serializer/hml/error.rs: pub struct HmlSaveBlocker
+src/serializer/hml/mod.rs: pub fn serialize_hml(
+src/serializer/hml/mod.rs: pub use error::{HmlExportError, HmlSaveBlocker}
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_CENTER: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_DISTRIBUTE: u32 = 4
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_DISTRIBUTE_SPACE: u32 = 5
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_JUSTIFY: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_LEFT: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const AH_RIGHT: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const ASOTWT_BEHIND_TEXT: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const ASOTWT_IN_FRONT_OF_TEXT: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const ASOTWT_SQUARE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const ASOTWT_TOP_AND_BOTTOM: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const AV_BASELINE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const AV_BOTTOM: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const AV_CENTER: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const AV_TOP: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_ENDNOTE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_EQUATION: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_FOOTNOTE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_PAGE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_PIC: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BEGIN_NUM_TBL: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BORDERFILL_BREAK_CELL_SEPARATE_LINE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BORDERFILL_CENTER_LINE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BORDERFILL_SHADOW: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BORDERFILL_THREE_D: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_BREAK_NON_LATIN_WORD: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_KEEP_LINES: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_KEEP_WITH_NEXT: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_LINE_WRAP: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_PAGE_BREAK_BEFORE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const BREAKSETTING_WIDOW_ORPHAN: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const CELLSPAN_COL_SPAN: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const CELLSPAN_ROW_SPAN: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_HEIGHT: u32 = 1000
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_SHADE_COLOR: u32 = 0xFFFFFF
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_SYM_MARK: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_TEXT_COLOR: u32 = 0x000000
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_USE_FONT_SPACE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const CHARSHAPE_USE_KERNING: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_HANGUL: usize = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_HANJA: usize = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_JAPANESE: usize = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_LATIN: usize = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_OTHER: usize = 4
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_SYMBOL: usize = 5
+src/serializer/hwpx/canonical_defaults.rs: pub const FLT_USER: usize = 6
+src/serializer/hwpx/canonical_defaults.rs: pub const FONTFACE_LANG_NAMES: [&str
+src/serializer/hwpx/canonical_defaults.rs: pub const FONT_IS_EMBEDDED: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const FONT_TYPE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const HRT_COLUMN: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const HRT_PAGE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const HRT_PAPER: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const HRT_PARA: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const LS_AT_LEAST: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const LS_BETWEEN_LINES: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const LS_FIXED: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const LS_PERCENT: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const NUMBERING_START: i32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const PAGE_BORDER_FOOTER_INSIDE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const PAGE_BORDER_HEADER_INSIDE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_CHECKED: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_CONDENSE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_FONT_LINE_HEIGHT: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_SNAP_TO_GRID: bool = true
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_SUPPRESS_LINE_NUMBERS: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const PARASHAPE_TAB_PR_ID_REF: u16 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const PICTURE_REVERSE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const RUN_CHAR_PR_ID_REF_UNSET: u32 = u32::MAX
+src/serializer/hwpx/canonical_defaults.rs: pub const SMT_DOT_ABOVE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const SMT_NONE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const SMT_RING_ABOVE: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const SMT_TILDE: u32 = 3
+src/serializer/hwpx/canonical_defaults.rs: pub const ST_CHAR: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const ST_PARA: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const SZ_HEIGHT_REL_TO: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const SZ_PROTECT: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const SZ_WIDTH_REL_TO: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const TABLE_NO_ADJUST: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const TABLE_REPEAT_HEADER: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const TPBT_CELL: u32 = 2
+src/serializer/hwpx/canonical_defaults.rs: pub const TPBT_NONE: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const TPBT_TABLE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_HIDE_FIRST_EMPTY_LINE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_HIDE_FIRST_FOOTER: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_HIDE_FIRST_HEADER: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_HIDE_FIRST_MASTER_PAGE: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_HIDE_FIRST_PAGE_NUM: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VISIBILITY_SHOW_LINE_NUMBER: bool = false
+src/serializer/hwpx/canonical_defaults.rs: pub const VRT_PAGE: u32 = 1
+src/serializer/hwpx/canonical_defaults.rs: pub const VRT_PAPER: u32 = 0
+src/serializer/hwpx/canonical_defaults.rs: pub const VRT_PARA: u32 = 2
+src/serializer/hwpx/content.rs: pub fn write_content_hpf(
+src/serializer/hwpx/content.rs: pub struct BinDataEntry
+src/serializer/hwpx/context.rs: pub fn assert_all_refs_resolved(&self) -> Result<(), SerializeError>
+src/serializer/hwpx/context.rs: pub fn bin_data_entries(&self) -> Vec<BinDataEntry>
+src/serializer/hwpx/context.rs: pub fn collect_from_document(doc: &Document) -> Self
+src/serializer/hwpx/context.rs: pub fn effective_style_id(&self, raw: u8) -> u8
+src/serializer/hwpx/context.rs: pub fn is_registered(&self, id: &T) -> bool
+src/serializer/hwpx/context.rs: pub fn new() -> Self
+src/serializer/hwpx/context.rs: pub fn next_para_id(&mut self) -> u32
+src/serializer/hwpx/context.rs: pub fn reference(&mut self, id: T)
+src/serializer/hwpx/context.rs: pub fn register(&mut self, id: T)
+src/serializer/hwpx/context.rs: pub fn registered_count(&self) -> usize
+src/serializer/hwpx/context.rs: pub fn resolve_bin_id(&self, bin_data_id: u16) -> Option<&str>
+src/serializer/hwpx/context.rs: pub fn unresolved(&self) -> Vec<T>
+src/serializer/hwpx/context.rs: pub struct BinDataEntry
+src/serializer/hwpx/context.rs: pub struct IdPool<T: Copy + Eq + std::hash::Hash>
+src/serializer/hwpx/context.rs: pub struct SerializeContext
+src/serializer/hwpx/field.rs: pub fn field_begin_open_tag(field: &Field) -> String
+src/serializer/hwpx/field.rs: pub fn write_bookmark<W: Write>(w: &mut Writer<W>, bm: &Bookmark) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_endnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_endnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_field_end<W: Write>(w: &mut Writer<W>, field_id: u32) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_field_end_full<W: Write>(
+src/serializer/hwpx/field.rs: pub fn write_footnote_close<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_footnote_open<W: Write>(w: &mut Writer<W>, number: u16) -> Result<(), SerializeError>
+src/serializer/hwpx/field.rs: pub fn write_hyperlink_begin<W: Write>(
+src/serializer/hwpx/fixtures.rs: pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
+src/serializer/hwpx/fixtures.rs: pub const EMPTY_HEADER_XML: &str = include_str!("templates/empty_header.xml")
+src/serializer/hwpx/fixtures.rs: pub const EMPTY_SECTION0_XML: &str = include_str!("templates/empty_section0.xml")
+src/serializer/hwpx/form.rs: pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), SerializeError>
+src/serializer/hwpx/header.rs: pub fn write_header(doc: &Document, ctx: &SerializeContext) -> Result<Vec<u8>, SerializeError>
+src/serializer/hwpx/master_page.rs: pub fn render_master_page_refs(ids: &[String]) -> String
+src/serializer/hwpx/master_page.rs: pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeContext) -> String
+src/serializer/hwpx/mod.rs: pub fn serialize_hwpx(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/hwpx/mod.rs: pub mod canonical_defaults
+src/serializer/hwpx/mod.rs: pub mod content
+src/serializer/hwpx/mod.rs: pub mod context
+src/serializer/hwpx/mod.rs: pub mod field
+src/serializer/hwpx/mod.rs: pub mod fixtures
+src/serializer/hwpx/mod.rs: pub mod form
+src/serializer/hwpx/mod.rs: pub mod header
+src/serializer/hwpx/mod.rs: pub mod master_page
+src/serializer/hwpx/mod.rs: pub mod package_check
+src/serializer/hwpx/mod.rs: pub mod picture
+src/serializer/hwpx/mod.rs: pub mod roundtrip
+src/serializer/hwpx/mod.rs: pub mod section
+src/serializer/hwpx/mod.rs: pub mod shape
+src/serializer/hwpx/mod.rs: pub mod static_assets
+src/serializer/hwpx/mod.rs: pub mod table
+src/serializer/hwpx/mod.rs: pub mod utils
+src/serializer/hwpx/mod.rs: pub mod writer
+src/serializer/hwpx/package_check.rs: pub fn check_package(hwpx_bytes: &[u8], doc: &Document) -> PackageCheckReport
+src/serializer/hwpx/package_check.rs: pub fn is_ok(&self) -> bool
+src/serializer/hwpx/package_check.rs: pub fn summary(&self) -> String
+src/serializer/hwpx/package_check.rs: pub struct PackageCheckReport
+src/serializer/hwpx/picture.rs: pub fn write_picture<W: Write>(
+src/serializer/hwpx/roundtrip.rs: pub enum IrDifference
+src/serializer/hwpx/roundtrip.rs: pub enum LinesegDiffKind
+src/serializer/hwpx/roundtrip.rs: pub fn allowed(&self, _allow: IrDiffAllow) -> bool
+src/serializer/hwpx/roundtrip.rs: pub fn diff_documents(a: &Document, b: &Document) -> IrDiff
+src/serializer/hwpx/roundtrip.rs: pub fn diff_linesegs(a: &Document, b: &Document) -> Vec<LinesegDiff>
+src/serializer/hwpx/roundtrip.rs: pub fn is_empty(&self) -> bool
+src/serializer/hwpx/roundtrip.rs: pub fn push(&mut self, d: IrDifference)
+src/serializer/hwpx/roundtrip.rs: pub fn roundtrip_ir_diff(hwpx_bytes: &[u8]) -> Result<IrDiff, SerializeError>
+src/serializer/hwpx/roundtrip.rs: pub struct IrDiff
+src/serializer/hwpx/roundtrip.rs: pub struct IrDiffAllow
+src/serializer/hwpx/roundtrip.rs: pub struct LinesegDiff
+src/serializer/hwpx/section.rs: pub fn write_section(
+src/serializer/hwpx/shape.rs: pub fn write_container_close<W: Write>(
+src/serializer/hwpx/shape.rs: pub fn write_container_open<W: Write>(
+src/serializer/hwpx/shape.rs: pub fn write_draw_text<W: Write>(
+src/serializer/hwpx/shape.rs: pub fn write_line<W: Write>(
+src/serializer/hwpx/shape.rs: pub fn write_rect<W: Write>(
+src/serializer/hwpx/static_assets.rs: pub const EMPTY_CONTENT_HPF: &str = include_str!("templates/empty_content.hpf")
+src/serializer/hwpx/static_assets.rs: pub const META_INF_CONTAINER_RDF: &str = concat!(
+src/serializer/hwpx/static_assets.rs: pub const META_INF_CONTAINER_XML: &str = concat!(
+src/serializer/hwpx/static_assets.rs: pub const META_INF_MANIFEST_XML: &str = concat!(
+src/serializer/hwpx/static_assets.rs: pub const PRV_IMAGE_PNG: &[u8] = &[
+src/serializer/hwpx/static_assets.rs: pub const PRV_TEXT: &[u8] = b"\r\n"
+src/serializer/hwpx/static_assets.rs: pub const SETTINGS_XML: &str = include_str!("templates/settings.xml")
+src/serializer/hwpx/static_assets.rs: pub const VERSION_XML: &str = include_str!("templates/version.xml")
+src/serializer/hwpx/table.rs: pub fn write_table<W: Write>(
+src/serializer/hwpx/utils.rs: pub fn empty_tag<W: Write>(
+src/serializer/hwpx/utils.rs: pub fn end_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs: pub fn start_tag<W: Write>(w: &mut Writer<W>, name: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs: pub fn start_tag_attrs<W: Write>(
+src/serializer/hwpx/utils.rs: pub fn text<W: Write>(w: &mut Writer<W>, content: &str) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs: pub fn write_xml_decl<W: Write>(w: &mut Writer<W>) -> Result<(), SerializeError>
+src/serializer/hwpx/utils.rs: pub fn xml_escape(s: &str) -> String
+src/serializer/hwpx/writer.rs: pub fn finish(mut self) -> Result<Vec<u8>, SerializeError>
+src/serializer/hwpx/writer.rs: pub fn new() -> Self
+src/serializer/hwpx/writer.rs: pub fn write_deflated(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
+src/serializer/hwpx/writer.rs: pub fn write_stored(&mut self, name: &str, data: &[u8]) -> Result<(), SerializeError>
+src/serializer/hwpx/writer.rs: pub struct HwpxZipWriter
+src/serializer/mini_cfb.rs: pub fn build_cfb(named_streams: &[(&str, &[u8])]) -> Result<Vec<u8>, String>
+src/serializer/mod.rs: pub enum SerializeError
+src/serializer/mod.rs: pub fn serialize_document(doc: &Document) -> Result<Vec<u8>, SerializeError>
+src/serializer/mod.rs: pub mod body_text
+src/serializer/mod.rs: pub mod byte_writer
+src/serializer/mod.rs: pub mod cfb_writer
+src/serializer/mod.rs: pub mod control
+src/serializer/mod.rs: pub mod doc_info
+src/serializer/mod.rs: pub mod header
+src/serializer/mod.rs: pub mod hml
+src/serializer/mod.rs: pub mod hwpx
+src/serializer/mod.rs: pub mod mini_cfb
+src/serializer/mod.rs: pub mod record_writer
+src/serializer/mod.rs: pub struct HwpSerializer
+src/serializer/mod.rs: pub struct HwpxSerializer
+src/serializer/mod.rs: pub trait DocumentSerializer
+src/serializer/mod.rs: pub use cfb_writer::serialize_hwp
+src/serializer/mod.rs: pub use hml::serialize_hml
+src/serializer/mod.rs: pub use hwpx::serialize_hwpx
+src/serializer/record_writer.rs: pub fn write_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8>
+src/serializer/record_writer.rs: pub fn write_record_from(record: &Record) -> Vec<u8>
+src/serializer/record_writer.rs: pub fn write_records(records: &[Record]) -> Vec<u8>
+src/wasm_api.rs: pub fn add_bookmark(
+src/wasm_api.rs: pub fn apply_cell_style(
+src/wasm_api.rs: pub fn apply_char_format(
+src/wasm_api.rs: pub fn apply_char_format_in_cell(
+src/wasm_api.rs: pub fn apply_char_format_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn apply_endnote_shape(
+src/wasm_api.rs: pub fn apply_hf_template(
+src/wasm_api.rs: pub fn apply_para_format(
+src/wasm_api.rs: pub fn apply_para_format_in_cell(
+src/wasm_api.rs: pub fn apply_para_format_in_footnote(
+src/wasm_api.rs: pub fn apply_para_format_in_hf(
+src/wasm_api.rs: pub fn apply_style(
+src/wasm_api.rs: pub fn assign_picture_image(
+src/wasm_api.rs: pub fn begin_batch(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn change_shape_z_order(
+src/wasm_api.rs: pub fn clear_active_field_api(&mut self)
+src/wasm_api.rs: pub fn clear_clipboard(&mut self)
+src/wasm_api.rs: pub fn clipboard_has_control(&self) -> bool
+src/wasm_api.rs: pub fn convert_to_editable(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn copy_control(
+src/wasm_api.rs: pub fn copy_selection(
+src/wasm_api.rs: pub fn copy_selection_in_cell(
+src/wasm_api.rs: pub fn copy_selection_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn copy_table_cells_transposed(
+src/wasm_api.rs: pub fn create_blank_document(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn create_empty() -> HwpDocument
+src/wasm_api.rs: pub fn create_header_footer(
+src/wasm_api.rs: pub fn create_numbering(&mut self, json: &str) -> u16
+src/wasm_api.rs: pub fn create_shape_control(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn create_style(&mut self, json: &str) -> i32
+src/wasm_api.rs: pub fn create_table(
+src/wasm_api.rs: pub fn create_table_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn delete_bookmark(
+src/wasm_api.rs: pub fn delete_cell_picture_control_by_path(
+src/wasm_api.rs: pub fn delete_equation_control(
+src/wasm_api.rs: pub fn delete_footnote(
+src/wasm_api.rs: pub fn delete_header_footer(
+src/wasm_api.rs: pub fn delete_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn delete_picture_control(
+src/wasm_api.rs: pub fn delete_range(
+src/wasm_api.rs: pub fn delete_range_in_cell(
+src/wasm_api.rs: pub fn delete_range_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn delete_shape_control(
+src/wasm_api.rs: pub fn delete_style(&mut self, style_id: u32) -> bool
+src/wasm_api.rs: pub fn delete_table_column(
+src/wasm_api.rs: pub fn delete_table_control(
+src/wasm_api.rs: pub fn delete_table_row(
+src/wasm_api.rs: pub fn delete_text(
+src/wasm_api.rs: pub fn delete_text_in_cell(
+src/wasm_api.rs: pub fn delete_text_in_cell_by_path_api(
+src/wasm_api.rs: pub fn delete_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn delete_text_in_footnote(
+src/wasm_api.rs: pub fn delete_text_in_header_footer(
+src/wasm_api.rs: pub fn discard_snapshot(&mut self, id: u32)
+src/wasm_api.rs: pub fn end_batch(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn ensure_default_bullet(&mut self, bullet_char_str: &str) -> u16
+src/wasm_api.rs: pub fn ensure_default_numbering(&mut self) -> u16
+src/wasm_api.rs: pub fn evaluate_table_formula(
+src/wasm_api.rs: pub fn evaluate_table_formula_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn export_control_html(
+src/wasm_api.rs: pub fn export_hml(&self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs: pub fn export_hwp(&mut self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs: pub fn export_hwp_verify(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn export_hwpx(&self) -> Result<Vec<u8>, JsValue>
+src/wasm_api.rs: pub fn export_selection_html(
+src/wasm_api.rs: pub fn export_selection_in_cell_html(
+src/wasm_api.rs: pub fn export_selection_in_cell_html_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn extract_thumbnail(data: &[u8]) -> JsValue
+src/wasm_api.rs: pub fn find_column_def_for_paragraph(paragraphs: &[Paragraph], para_idx: usize) -> ColumnDef
+src/wasm_api.rs: pub fn find_initial_column_def(paragraphs: &[Paragraph]) -> ColumnDef
+src/wasm_api.rs: pub fn find_nearest_control_backward(
+src/wasm_api.rs: pub fn find_nearest_control_forward(
+src/wasm_api.rs: pub fn find_next_editable_control(
+src/wasm_api.rs: pub fn find_or_create_font_id(&mut self, name: &str) -> i32
+src/wasm_api.rs: pub fn flush_deferred_pagination(&mut self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn from_bytes(data: &[u8]) -> Result<HwpDocument, HwpError>
+src/wasm_api.rs: pub fn get_bookmarks(&self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_bullet_list(&self) -> String
+src/wasm_api.rs: pub fn get_canvaskit_replay_plan(&self, page_num: u32, mode: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_canvaskit_replay_plan_with_profile(
+src/wasm_api.rs: pub fn get_caret_position(&self) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_cell_char_properties_at(
+src/wasm_api.rs: pub fn get_cell_info(
+src/wasm_api.rs: pub fn get_cell_info_by_path(
+src/wasm_api.rs: pub fn get_cell_own_properties(
+src/wasm_api.rs: pub fn get_cell_para_properties_at(
+src/wasm_api.rs: pub fn get_cell_paragraph_count(
+src/wasm_api.rs: pub fn get_cell_paragraph_count_by_path(
+src/wasm_api.rs: pub fn get_cell_paragraph_length(
+src/wasm_api.rs: pub fn get_cell_paragraph_length_by_path(
+src/wasm_api.rs: pub fn get_cell_picture_properties_by_path(
+src/wasm_api.rs: pub fn get_cell_properties(
+src/wasm_api.rs: pub fn get_cell_shape_properties_by_path(
+src/wasm_api.rs: pub fn get_cell_style_at(
+src/wasm_api.rs: pub fn get_cell_text_direction(
+src/wasm_api.rs: pub fn get_char_properties_at(
+src/wasm_api.rs: pub fn get_click_here_props(&self, field_id: u32) -> String
+src/wasm_api.rs: pub fn get_clipboard_text(&self) -> String
+src/wasm_api.rs: pub fn get_column_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_control_image_data(
+src/wasm_api.rs: pub fn get_control_image_mime(
+src/wasm_api.rs: pub fn get_control_text_positions(&self, section_idx: u32, para_idx: u32) -> String
+src/wasm_api.rs: pub fn get_cursor_rect(
+src/wasm_api.rs: pub fn get_cursor_rect_by_path(
+src/wasm_api.rs: pub fn get_cursor_rect_by_path_near(
+src/wasm_api.rs: pub fn get_cursor_rect_in_cell(
+src/wasm_api.rs: pub fn get_cursor_rect_in_footnote(
+src/wasm_api.rs: pub fn get_cursor_rect_in_header_footer(
+src/wasm_api.rs: pub fn get_cursor_rect_in_note(
+src/wasm_api.rs: pub fn get_cursor_rect_on_line(
+src/wasm_api.rs: pub fn get_document_info(&self) -> String
+src/wasm_api.rs: pub fn get_dpi(&self) -> f64
+src/wasm_api.rs: pub fn get_endnote_shape(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_equation_properties(
+src/wasm_api.rs: pub fn get_event_log(&self) -> String
+src/wasm_api.rs: pub fn get_external_image_basenames(&self) -> String
+src/wasm_api.rs: pub fn get_external_image_references(&self) -> String
+src/wasm_api.rs: pub fn get_fallback_font(&self) -> String
+src/wasm_api.rs: pub fn get_field_info_at_api(
+src/wasm_api.rs: pub fn get_field_info_at_by_path_api(
+src/wasm_api.rs: pub fn get_field_info_at_in_cell_api(
+src/wasm_api.rs: pub fn get_field_info_at_in_cell_ex(&self, options_json: &str) -> String
+src/wasm_api.rs: pub fn get_field_list(&self) -> String
+src/wasm_api.rs: pub fn get_field_value(&self, field_id: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_field_value_by_name_api(&self, name: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_footnote_at_cursor(
+src/wasm_api.rs: pub fn get_footnote_info(
+src/wasm_api.rs: pub fn get_form_object_at(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_form_object_info(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_form_value(&self, sec: u32, para: u32, ci: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_header_footer(
+src/wasm_api.rs: pub fn get_header_footer_list(
+src/wasm_api.rs: pub fn get_header_footer_para_info(
+src/wasm_api.rs: pub fn get_header_footer_picture_properties(
+src/wasm_api.rs: pub fn get_hml_open_metadata(&self) -> String
+src/wasm_api.rs: pub fn get_hml_save_state(&self) -> String
+src/wasm_api.rs: pub fn get_line_info(
+src/wasm_api.rs: pub fn get_line_info_in_cell(
+src/wasm_api.rs: pub fn get_logical_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs: pub fn get_note_edit_info(
+src/wasm_api.rs: pub fn get_note_equation_properties(
+src/wasm_api.rs: pub fn get_numbering_list(&self) -> String
+src/wasm_api.rs: pub fn get_page_border_fill(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_control_layout(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_footnote_info(
+src/wasm_api.rs: pub fn get_page_hide(&self, sec: u32, para: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_info(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_layer_tree(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_layer_tree_with_profile(
+src/wasm_api.rs: pub fn get_page_of_position(&self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_overlay_images(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_render_tree(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_page_text_layout(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_para_properties_at(
+src/wasm_api.rs: pub fn get_para_properties_in_footnote(
+src/wasm_api.rs: pub fn get_para_properties_in_hf(
+src/wasm_api.rs: pub fn get_paragraph_count(&self, section_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs: pub fn get_paragraph_length(&self, section_idx: u32, para_idx: u32) -> Result<u32, JsValue>
+src/wasm_api.rs: pub fn get_picture_properties(
+src/wasm_api.rs: pub fn get_position_of_page(&self, global_page: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_section_count(&self) -> u32
+src/wasm_api.rs: pub fn get_section_def(&self, section_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_selection_rects(
+src/wasm_api.rs: pub fn get_selection_rects_in_cell(
+src/wasm_api.rs: pub fn get_selection_rects_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_selection_rects_in_footnote(
+src/wasm_api.rs: pub fn get_shape_bbox(
+src/wasm_api.rs: pub fn get_shape_properties(
+src/wasm_api.rs: pub fn get_show_control_codes(&self) -> bool
+src/wasm_api.rs: pub fn get_show_paragraph_marks(&self) -> bool
+src/wasm_api.rs: pub fn get_show_transparent_borders(&self) -> bool
+src/wasm_api.rs: pub fn get_source_format(&self) -> String
+src/wasm_api.rs: pub fn get_structure(&self, mode: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_style_at(&self, sec_idx: u32, para_idx: u32) -> String
+src/wasm_api.rs: pub fn get_style_detail(&self, style_id: u32) -> String
+src/wasm_api.rs: pub fn get_style_list(&self) -> String
+src/wasm_api.rs: pub fn get_table_bbox(
+src/wasm_api.rs: pub fn get_table_cell_bboxes(
+src/wasm_api.rs: pub fn get_table_cell_bboxes_by_path(
+src/wasm_api.rs: pub fn get_table_dimensions(
+src/wasm_api.rs: pub fn get_table_dimensions_by_path(
+src/wasm_api.rs: pub fn get_table_properties(
+src/wasm_api.rs: pub fn get_text_in_cell(
+src/wasm_api.rs: pub fn get_text_in_cell_by_path_api(
+src/wasm_api.rs: pub fn get_text_in_cell_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn get_text_range(
+src/wasm_api.rs: pub fn get_textbox_control_index(&self, section_idx: u32, para_idx: u32) -> i32
+src/wasm_api.rs: pub fn get_validation_warnings(&self) -> String
+src/wasm_api.rs: pub fn group_shapes(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn has_internal_clipboard(&self) -> bool
+src/wasm_api.rs: pub fn has_table_transpose_clipboard(&self) -> bool
+src/wasm_api.rs: pub fn hit_test(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn hit_test_body_footnote_marker(
+src/wasm_api.rs: pub fn hit_test_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn hit_test_header_footer(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn hit_test_in_footnote(&self, page_num: u32, x: f64, y: f64) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn hit_test_in_header_footer(
+src/wasm_api.rs: pub fn inject_external_image(
+src/wasm_api.rs: pub fn inject_external_image_by_key(
+src/wasm_api.rs: pub fn insert_click_here_field_api(
+src/wasm_api.rs: pub fn insert_click_here_field_by_path_api(
+src/wasm_api.rs: pub fn insert_click_here_field_by_path_ex(
+src/wasm_api.rs: pub fn insert_click_here_field_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn insert_click_here_field_in_cell_api(
+src/wasm_api.rs: pub fn insert_click_here_field_in_cell_ex(
+src/wasm_api.rs: pub fn insert_column_break(
+src/wasm_api.rs: pub fn insert_endnote(
+src/wasm_api.rs: pub fn insert_equation(
+src/wasm_api.rs: pub fn insert_field_in_hf(
+src/wasm_api.rs: pub fn insert_footnote(
+src/wasm_api.rs: pub fn insert_new_number(
+src/wasm_api.rs: pub fn insert_page_break(
+src/wasm_api.rs: pub fn insert_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn insert_picture(
+src/wasm_api.rs: pub fn insert_picture_ex(
+src/wasm_api.rs: pub fn insert_table_column(
+src/wasm_api.rs: pub fn insert_table_row(
+src/wasm_api.rs: pub fn insert_text(
+src/wasm_api.rs: pub fn insert_text_in_cell(
+src/wasm_api.rs: pub fn insert_text_in_cell_by_path_api(
+src/wasm_api.rs: pub fn insert_text_in_cell_deferred_pagination(
+src/wasm_api.rs: pub fn insert_text_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn insert_text_in_footnote(
+src/wasm_api.rs: pub fn insert_text_in_header_footer(
+src/wasm_api.rs: pub fn insert_text_logical(
+src/wasm_api.rs: pub fn logical_to_text_offset(
+src/wasm_api.rs: pub fn measure_width_diagnostic(
+src/wasm_api.rs: pub fn merge_paragraph(&mut self, section_idx: u32, para_idx: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn merge_paragraph_in_cell(
+src/wasm_api.rs: pub fn merge_paragraph_in_cell_by_path_api(
+src/wasm_api.rs: pub fn merge_paragraph_in_footnote(
+src/wasm_api.rs: pub fn merge_paragraph_in_header_footer(
+src/wasm_api.rs: pub fn merge_table_cells(
+src/wasm_api.rs: pub fn merge_table_cells_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn move_line_endpoint(
+src/wasm_api.rs: pub fn move_line_endpoint_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn move_table_offset(
+src/wasm_api.rs: pub fn move_vertical(
+src/wasm_api.rs: pub fn move_vertical_by_path(
+src/wasm_api.rs: pub fn move_vertical_ex(&self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn navigate_header_footer_by_page(
+src/wasm_api.rs: pub fn navigate_next_editable_wasm(
+src/wasm_api.rs: pub fn new(data: &[u8]) -> Result<HwpDocument, JsValue>
+src/wasm_api.rs: pub fn new(document: HwpDocument) -> Self
+src/wasm_api.rs: pub fn page_count(&self) -> u32
+src/wasm_api.rs: pub fn page_count(&self) -> u32
+src/wasm_api.rs: pub fn paste_control(
+src/wasm_api.rs: pub fn paste_html(
+src/wasm_api.rs: pub fn paste_html_in_cell(
+src/wasm_api.rs: pub fn paste_html_in_cell_by_path(
+src/wasm_api.rs: pub fn paste_html_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn paste_internal(
+src/wasm_api.rs: pub fn paste_internal_in_cell(
+src/wasm_api.rs: pub fn paste_internal_in_cell_by_path(
+src/wasm_api.rs: pub fn paste_table_cells_transposed(
+src/wasm_api.rs: pub fn paste_table_cells_transposed_as_table(
+src/wasm_api.rs: pub fn pending_task_count(&self) -> u32
+src/wasm_api.rs: pub fn reflow_linesegs(&mut self) -> usize
+src/wasm_api.rs: pub fn remove_field_at_api(
+src/wasm_api.rs: pub fn remove_field_at_in_cell_api(
+src/wasm_api.rs: pub fn remove_field_at_in_cell_ex(&mut self, options_json: &str) -> String
+src/wasm_api.rs: pub fn rename_bookmark(
+src/wasm_api.rs: pub fn render_equation_preview(
+src/wasm_api.rs: pub fn render_page_canvas(&self, page_num: u32) -> Result<u32, JsValue>
+src/wasm_api.rs: pub fn render_page_canvas_legacy(&self, page_num: u32) -> Result<u32, JsValue>
+src/wasm_api.rs: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn render_page_html(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn render_page_svg(&self, page_num: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn render_page_to_canvas(
+src/wasm_api.rs: pub fn render_page_to_canvas_filtered(
+src/wasm_api.rs: pub fn render_page_to_canvas_filtered_with_profile(
+src/wasm_api.rs: pub fn render_page_to_canvas_legacy(
+src/wasm_api.rs: pub fn replace_all(
+src/wasm_api.rs: pub fn replace_one(
+src/wasm_api.rs: pub fn replace_text(
+src/wasm_api.rs: pub fn resize_table_cells(
+src/wasm_api.rs: pub fn restore_snapshot(&mut self, id: u32) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn save_snapshot(&mut self) -> u32
+src/wasm_api.rs: pub fn search_all_text(
+src/wasm_api.rs: pub fn search_text(
+src/wasm_api.rs: pub fn set_active_field_api(
+src/wasm_api.rs: pub fn set_active_field_by_path_api(
+src/wasm_api.rs: pub fn set_active_field_in_cell_api(
+src/wasm_api.rs: pub fn set_active_field_in_cell_ex(&mut self, options_json: &str) -> bool
+src/wasm_api.rs: pub fn set_cell_para_shape_id(
+src/wasm_api.rs: pub fn set_cell_picture_properties_by_path(
+src/wasm_api.rs: pub fn set_cell_properties(
+src/wasm_api.rs: pub fn set_cell_shape_properties_by_path(
+src/wasm_api.rs: pub fn set_cell_zone_properties(
+src/wasm_api.rs: pub fn set_char_shape_id(
+src/wasm_api.rs: pub fn set_char_shape_id_in_cell(
+src/wasm_api.rs: pub fn set_char_shape_id_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_clip_enabled(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_column_def(
+src/wasm_api.rs: pub fn set_debug_overlay(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_dpi(&mut self, dpi: f64)
+src/wasm_api.rs: pub fn set_equation_properties(
+src/wasm_api.rs: pub fn set_fallback_font(&mut self, path: &str)
+src/wasm_api.rs: pub fn set_field_value(&mut self, field_id: u32, value: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_field_value_by_name_api(
+src/wasm_api.rs: pub fn set_file_name(&mut self, name: &str)
+src/wasm_api.rs: pub fn set_form_value(
+src/wasm_api.rs: pub fn set_form_value_in_cell(
+src/wasm_api.rs: pub fn set_form_value_in_cell_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_header_footer_picture_properties(
+src/wasm_api.rs: pub fn set_note_equation_properties(
+src/wasm_api.rs: pub fn set_note_equation_properties_ex(
+src/wasm_api.rs: pub fn set_numbering_restart(
+src/wasm_api.rs: pub fn set_page_border_fill(
+src/wasm_api.rs: pub fn set_page_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_page_hide(
+src/wasm_api.rs: pub fn set_page_hide_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_para_shape_id(
+src/wasm_api.rs: pub fn set_picture_properties(
+src/wasm_api.rs: pub fn set_respect_vpos_reset(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_section_def(&mut self, section_idx: u32, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_section_def_all(&mut self, json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn set_shape_properties(
+src/wasm_api.rs: pub fn set_show_control_codes(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_show_paragraph_marks(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_show_transparent_borders(&mut self, enabled: bool)
+src/wasm_api.rs: pub fn set_table_properties(
+src/wasm_api.rs: pub fn set_zoom(&mut self, zoom: f64)
+src/wasm_api.rs: pub fn split_paragraph(
+src/wasm_api.rs: pub fn split_paragraph_in_cell(
+src/wasm_api.rs: pub fn split_paragraph_in_cell_by_path_api(
+src/wasm_api.rs: pub fn split_paragraph_in_footnote(
+src/wasm_api.rs: pub fn split_paragraph_in_header_footer(
+src/wasm_api.rs: pub fn split_table_cell(
+src/wasm_api.rs: pub fn split_table_cell_into(
+src/wasm_api.rs: pub fn split_table_cell_into_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn split_table_cells_in_range(
+src/wasm_api.rs: pub fn split_table_cells_in_range_ex(&mut self, options_json: &str) -> Result<String, JsValue>
+src/wasm_api.rs: pub fn text_to_logical_offset(
+src/wasm_api.rs: pub fn toggle_hide_header_footer(
+src/wasm_api.rs: pub fn transpose_table_cells_in_place(
+src/wasm_api.rs: pub fn ungroup_shape(
+src/wasm_api.rs: pub fn update_click_here_props(
+src/wasm_api.rs: pub fn update_connectors_in_section_wasm(&mut self, section_idx: u32)
+src/wasm_api.rs: pub fn update_style(&mut self, style_id: u32, json: &str) -> bool
+src/wasm_api.rs: pub fn update_style_shapes(
+src/wasm_api.rs: pub fn update_viewport(&mut self, scroll_x: f64, scroll_y: f64, width: f64, height: f64)
+src/wasm_api.rs: pub fn visible_pages(&self) -> Vec<u32>
+src/wasm_api.rs: pub fn wasm_find_or_create_font_id_for_lang(&mut self, lang: u32, name: &str) -> i32
+src/wasm_api.rs: pub struct HwpDocument
+src/wasm_api.rs: pub struct HwpViewer
+src/wasm_api/event.rs: pub use crate::model::event::*
+src/wmf/converter/bitmap.rs: pub fn as_slice(&self) -> &[u8]
+src/wmf/converter/bitmap.rs: pub fn to_vec(self) -> Vec<u8>
+src/wmf/converter/bitmap.rs: pub struct Bitmap(Vec<u8>)
+src/wmf/converter/graphics_object.rs: pub enum GraphicsObject
+src/wmf/converter/graphics_object.rs: pub fn brush(mut self, brush: Brush) -> Self
+src/wmf/converter/graphics_object.rs: pub fn delete(&mut self, i: usize)
+src/wmf/converter/graphics_object.rs: pub fn font(mut self, font: Font) -> Self
+src/wmf/converter/graphics_object.rs: pub fn get(&self, i: usize) -> &GraphicsObject
+src/wmf/converter/graphics_object.rs: pub fn new(v: usize) -> Self
+src/wmf/converter/graphics_object.rs: pub fn palette(mut self, palette: Palette) -> Self
+src/wmf/converter/graphics_object.rs: pub fn pen(mut self, pen: Pen) -> Self
+src/wmf/converter/graphics_object.rs: pub fn push(&mut self, g: GraphicsObject)
+src/wmf/converter/graphics_object.rs: pub fn region(mut self, region: Region) -> Self
+src/wmf/converter/graphics_object.rs: pub struct GraphicsObjects(Vec<GraphicsObject>, GraphicsObject)
+src/wmf/converter/graphics_object.rs: pub struct SelectedGraphicsObject
+src/wmf/converter/mod.rs: pub enum ConvertError
+src/wmf/converter/mod.rs: pub fn new(buffer: B, player: P) -> Self
+src/wmf/converter/mod.rs: pub fn run(self) -> Result<Vec<u8>, ConvertError>
+src/wmf/converter/mod.rs: pub struct WMFConverter<B, P>
+src/wmf/converter/mod.rs: pub use self::svg::*
+src/wmf/converter/mod.rs: pub use self::{bitmap::Bitmap, player::*}
+src/wmf/converter/player.rs: pub enum PlayError
+src/wmf/converter/player.rs: pub trait Player: Sized
+src/wmf/converter/svg/device_context.rs: pub fn as_css_text_align(&self) -> String
+src/wmf/converter/svg/device_context.rs: pub fn as_css_text_align_vertical(&self) -> String
+src/wmf/converter/svg/device_context.rs: pub fn as_view_box(&self) -> (i16, i16, i16, i16)
+src/wmf/converter/svg/device_context.rs: pub fn bk_mode(mut self, bk_mode: MixMode) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn clipping_region(mut self, clipping_region: Rect) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn create_object_table(mut self, length: u16) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn draw_mode(mut self, draw_mode: BinaryRasterOperation) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn drawing_position(mut self, drawing_position: PointS) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn ext(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn extend_window(self, p: &PointS) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn map_mode(mut self, map_mode: MapMode) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn new() -> Self
+src/wmf/converter/svg/device_context.rs: pub fn origin(mut self, origin_x: i16, origin_y: i16) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn point_s_to_absolute_point(&self, point: &PointS) -> PointS
+src/wmf/converter/svg/device_context.rs: pub fn point_s_to_relative_point(&self, point: &PointS) -> PointS
+src/wmf/converter/svg/device_context.rs: pub fn poly_fill_mode(mut self, poly_fill_mode: PolyFillMode) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn poly_fill_rule(&self) -> String
+src/wmf/converter/svg/device_context.rs: pub fn scale(mut self, scale_x: f32, scale_y: f32) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_align_horizontal(mut self, text_align_horizontal: TextAlignmentMode) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_align_update_cp(mut self, text_align_update_cp: bool) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_align_vertical(mut self, text_align_vertical: VerticalTextAlignmentMode) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_bk_color(mut self, text_bk_color: ColorRef) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_color(mut self, text_color: ColorRef) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn text_color_as_css_color(&self) -> String
+src/wmf/converter/svg/device_context.rs: pub fn window_ext(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn window_origin(mut self, x: i16, y: i16) -> Self
+src/wmf/converter/svg/device_context.rs: pub fn window_scale(mut self, x: f32, y: f32) -> Self
+src/wmf/converter/svg/device_context.rs: pub struct DeviceContext
+src/wmf/converter/svg/device_context.rs: pub struct Window
+src/wmf/converter/svg/mod.rs: pub fn new() -> Self
+src/wmf/converter/svg/mod.rs: pub struct SVGPlayer
+src/wmf/converter/svg/node.rs: pub fn add(mut self, node: Node) -> Self
+src/wmf/converter/svg/node.rs: pub fn close(mut self) -> Self
+src/wmf/converter/svg/node.rs: pub fn elliptical_arc_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs: pub fn line_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs: pub fn move_to(mut self, param: impl Into<Parameters>) -> Self
+src/wmf/converter/svg/node.rs: pub fn new() -> Self
+src/wmf/converter/svg/node.rs: pub fn new(name: impl ToString) -> Self
+src/wmf/converter/svg/node.rs: pub fn new_text(value: impl ToString) -> Self
+src/wmf/converter/svg/node.rs: pub fn set(mut self, name: impl ToString, value: impl ToString) -> Self
+src/wmf/converter/svg/node.rs: pub struct Data
+src/wmf/converter/svg/node.rs: pub struct Node
+src/wmf/converter/svg/node.rs: pub struct Parameters(String)
+src/wmf/converter/svg/ternary_raster_operator.rs: pub enum TernaryRasterOperationError
+src/wmf/converter/svg/ternary_raster_operator.rs: pub fn brush(mut self, brush: Brush) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs: pub fn new(operation: TernaryRasterOperation, x: i16, y: i16, height: i16, width: i16) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs: pub fn run(
+src/wmf/converter/svg/ternary_raster_operator.rs: pub fn source_bitmap(mut self, source: DeviceIndependentBitmap) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs: pub fn source_bitmap16(mut self, source: Bitmap16) -> Self
+src/wmf/converter/svg/ternary_raster_operator.rs: pub struct TernaryRasterOperator
+src/wmf/converter/svg/util.rs: pub enum Fill
+src/wmf/converter/svg/util.rs: pub fn as_data_url(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn as_filter(&self) -> Node
+src/wmf/converter/svg/util.rs: pub fn as_point_string(point: &PointS) -> String
+src/wmf/converter/svg/util.rs: pub fn color(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn css_color_from_color_ref(c: &ColorRef) -> String
+src/wmf/converter/svg/util.rs: pub fn dash_array(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn line_cap(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn line_join(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn opacity(&self) -> String
+src/wmf/converter/svg/util.rs: pub fn set_props(&self, elem: Node) -> Node
+src/wmf/converter/svg/util.rs: pub fn set_props(&self, mut elem: Node, point: &PointS) -> (Node, Vec<String>)
+src/wmf/converter/svg/util.rs: pub fn url_string(link: &str) -> String
+src/wmf/converter/svg/util.rs: pub fn width(&self) -> i16
+src/wmf/converter/svg/util.rs: pub struct Stroke
+src/wmf/mod.rs: pub mod converter
+src/wmf/mod.rs: pub mod parser
+src/wmf/mod.rs: pub use embedded_io::Read
+src/wmf/mod.rs: pub use std::{
+src/wmf/parser/constants/enums/binary_raster_operation.rs: pub enum BinaryRasterOperation
+src/wmf/parser/constants/enums/bit_count.rs: pub enum BitCount
+src/wmf/parser/constants/enums/brush_style.rs: pub enum BrushStyle
+src/wmf/parser/constants/enums/character_set.rs: pub enum CharacterSet
+src/wmf/parser/constants/enums/color_usage.rs: pub enum ColorUsage
+src/wmf/parser/constants/enums/compression.rs: pub enum Compression
+src/wmf/parser/constants/enums/family_font.rs: pub enum FamilyFont
+src/wmf/parser/constants/enums/flood_fill.rs: pub enum FloodFill
+src/wmf/parser/constants/enums/font_quality.rs: pub enum FontQuality
+src/wmf/parser/constants/enums/gamut_mapping_intent.rs: pub enum GamutMappingIntent
+src/wmf/parser/constants/enums/hatch_style.rs: pub enum HatchStyle
+src/wmf/parser/constants/enums/layout.rs: pub enum Layout
+src/wmf/parser/constants/enums/logical_color_space.rs: pub enum LogicalColorSpace
+src/wmf/parser/constants/enums/map_mode.rs: pub enum MapMode
+src/wmf/parser/constants/enums/metafile_escapes.rs: pub enum MetafileEscapes
+src/wmf/parser/constants/enums/metafile_type.rs: pub enum MetafileType
+src/wmf/parser/constants/enums/metafile_version.rs: pub enum MetafileVersion
+src/wmf/parser/constants/enums/mix_mode.rs: pub enum MixMode
+src/wmf/parser/constants/enums/mod.rs: pub use self::{
+src/wmf/parser/constants/enums/out_precision.rs: pub enum OutPrecision
+src/wmf/parser/constants/enums/palette_entry_flag.rs: pub enum PaletteEntryFlag
+src/wmf/parser/constants/enums/pen_style.rs: pub enum PenStyle
+src/wmf/parser/constants/enums/pen_style.rs: pub fn end_cap() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pen_style.rs: pub fn line_join() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pen_style.rs: pub fn style() -> BTreeSet<Self>
+src/wmf/parser/constants/enums/pitch_font.rs: pub enum PitchFont
+src/wmf/parser/constants/enums/poly_fill_mode.rs: pub enum PolyFillMode
+src/wmf/parser/constants/enums/post_script_cap.rs: pub enum PostScriptCap
+src/wmf/parser/constants/enums/post_script_clipping.rs: pub enum PostScriptClipping
+src/wmf/parser/constants/enums/post_script_feature_setting.rs: pub enum PostScriptFeatureSetting
+src/wmf/parser/constants/enums/post_script_join.rs: pub enum PostScriptJoin
+src/wmf/parser/constants/enums/record_type.rs: pub enum RecordType
+src/wmf/parser/constants/enums/stretch_mode.rs: pub enum StretchMode
+src/wmf/parser/constants/enums/ternary_raster_operation.rs: pub enum TernaryRasterOperation
+src/wmf/parser/constants/enums/ternary_raster_operation.rs: pub fn use_selected_brush(&self) -> bool
+src/wmf/parser/constants/enums/ternary_raster_operation.rs: pub fn use_source(&self) -> bool
+src/wmf/parser/constants/flags/clip_precision.rs: pub enum ClipPrecision
+src/wmf/parser/constants/flags/ext_text_out_options.rs: pub enum ExtTextOutOptions
+src/wmf/parser/constants/flags/mod.rs: pub use self::{
+src/wmf/parser/constants/flags/text_alignment_mode.rs: pub enum TextAlignmentMode
+src/wmf/parser/constants/flags/vertical_text_alignment_mode.rs: pub enum VerticalTextAlignmentMode
+src/wmf/parser/constants/mod.rs: pub fn parse<R: $crate::wmf::Read>(
+src/wmf/parser/constants/mod.rs: pub use self::{enums::*, flags::*}
+src/wmf/parser/mod.rs: pub enum ParseError
+src/wmf/parser/mod.rs: pub fn [<read_ $t _from_le_bytes>]<R: $crate::wmf::Read>(
+src/wmf/parser/mod.rs: pub fn new(err: impl core::fmt::Display) -> Self
+src/wmf/parser/mod.rs: pub fn read<R: crate::wmf::Read, const N: usize>(
+src/wmf/parser/mod.rs: pub fn read_variable<R: crate::wmf::Read>(
+src/wmf/parser/mod.rs: pub struct ReadError
+src/wmf/parser/mod.rs: pub use self::{constants::*, objects::*, records::*}
+src/wmf/parser/objects/graphics/brush.rs: pub enum Brush
+src/wmf/parser/objects/graphics/brush.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/font.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/font.rs: pub struct Font
+src/wmf/parser/objects/graphics/mod.rs: pub use self::{brush::*, font::*, palette::*, pen::*, region::*}
+src/wmf/parser/objects/graphics/palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/palette.rs: pub struct Palette
+src/wmf/parser/objects/graphics/pen.rs: pub fn line_join(v: u16) -> crate::wmf::parser::PenStyle
+src/wmf/parser/objects/graphics/pen.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/pen.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/pen.rs: pub fn style(v: u16) -> crate::wmf::parser::PenStyle
+src/wmf/parser/objects/graphics/pen.rs: pub struct Pen
+src/wmf/parser/objects/graphics/pen.rs: pub struct PenStyleSubsection
+src/wmf/parser/objects/graphics/region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/graphics/region.rs: pub struct Region
+src/wmf/parser/objects/mod.rs: pub use self::{graphics::*, structure::*}
+src/wmf/parser/objects/structure/bitmap16.rs: pub fn calc_length(&self) -> usize
+src/wmf/parser/objects/structure/bitmap16.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap16.rs: pub fn parse_without_bits<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap16.rs: pub struct Bitmap16
+src/wmf/parser/objects/structure/bitmap_info_header/core.rs: pub struct BitmapInfoHeaderCore
+src/wmf/parser/objects/structure/bitmap_info_header/info.rs: pub struct BitmapInfoHeaderInfo
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub enum BitmapInfoHeader
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn bit_count(&self) -> crate::wmf::parser::BitCount
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn color_used(&self) -> u32
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn header_size(&self) -> u32
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn height(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn size(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub fn width(&self) -> usize
+src/wmf/parser/objects/structure/bitmap_info_header/mod.rs: pub use self::{core::*, info::*, v4::*, v5::*}
+src/wmf/parser/objects/structure/bitmap_info_header/v4.rs: pub struct BitmapInfoHeaderV4
+src/wmf/parser/objects/structure/bitmap_info_header/v5.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/bitmap_info_header/v5.rs: pub struct BitmapInfoHeaderV5
+src/wmf/parser/objects/structure/ciexyz.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/ciexyz.rs: pub struct CIEXYZ
+src/wmf/parser/objects/structure/ciexyz_triple.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/ciexyz_triple.rs: pub struct CIEXYZTriple
+src/wmf/parser/objects/structure/color_ref.rs: pub fn black() -> Self
+src/wmf/parser/objects/structure/color_ref.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/color_ref.rs: pub fn white() -> Self
+src/wmf/parser/objects/structure/color_ref.rs: pub struct ColorRef
+src/wmf/parser/objects/structure/device_independent_bitmap.rs: pub enum Colors
+src/wmf/parser/objects/structure/device_independent_bitmap.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/device_independent_bitmap.rs: pub struct BitmapBuffer
+src/wmf/parser/objects/structure/device_independent_bitmap.rs: pub struct DeviceIndependentBitmap
+src/wmf/parser/objects/structure/log_brush.rs: pub enum LogBrush
+src/wmf/parser/objects/structure/log_brush.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_color_space.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_color_space.rs: pub struct LogColorSpace
+src/wmf/parser/objects/structure/log_color_space_w.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/log_color_space_w.rs: pub struct LogColorSpaceW
+src/wmf/parser/objects/structure/mod.rs: pub use self::{
+src/wmf/parser/objects/structure/palette_entry.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/palette_entry.rs: pub struct PaletteEntry
+src/wmf/parser/objects/structure/pitch_and_family.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/pitch_and_family.rs: pub struct PitchAndFamily
+src/wmf/parser/objects/structure/point_l.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/point_l.rs: pub struct PointL
+src/wmf/parser/objects/structure/point_s.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/point_s.rs: pub struct PointS
+src/wmf/parser/objects/structure/poly_polygon.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/poly_polygon.rs: pub struct PolyPolygon
+src/wmf/parser/objects/structure/rect.rs: pub fn overlap(&self, other: &Rect) -> Option<Rect>
+src/wmf/parser/objects/structure/rect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rect.rs: pub struct Rect
+src/wmf/parser/objects/structure/rect_l.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rect_l.rs: pub struct RectL
+src/wmf/parser/objects/structure/rgb_quad.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rgb_quad.rs: pub struct RGBQuad
+src/wmf/parser/objects/structure/rgb_triple.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/rgb_triple.rs: pub struct RGBTriple
+src/wmf/parser/objects/structure/scan.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/scan.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/scan.rs: pub struct Scan
+src/wmf/parser/objects/structure/scan.rs: pub struct ScanLine
+src/wmf/parser/objects/structure/size_l.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/objects/structure/size_l.rs: pub struct SizeL
+src/wmf/parser/records/bitmap/bit_blt.rs: pub enum META_BITBLT
+src/wmf/parser/records/bitmap/bit_blt.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/dib_bit_blt.rs: pub enum META_DIBBITBLT
+src/wmf/parser/records/bitmap/dib_bit_blt.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/dib_stretch_blt.rs: pub enum META_DIBSTRETCHBLT
+src/wmf/parser/records/bitmap/dib_stretch_blt.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/mod.rs: pub use self::{
+src/wmf/parser/records/bitmap/set_dib_to_dev.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/set_dib_to_dev.rs: pub struct META_SETDIBTODEV
+src/wmf/parser/records/bitmap/stretch_blt.rs: pub enum META_STRETCHBLT
+src/wmf/parser/records/bitmap/stretch_blt.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/stretch_dib.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/bitmap/stretch_dib.rs: pub struct META_STRETCHDIB
+src/wmf/parser/records/control/eof.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/control/eof.rs: pub struct META_EOF
+src/wmf/parser/records/control/header.rs: pub struct META_HEADER
+src/wmf/parser/records/control/mod.rs: pub enum MetafileHeader
+src/wmf/parser/records/control/mod.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/control/mod.rs: pub use self::{eof::*, header::*, placeable::*}
+src/wmf/parser/records/control/placeable.rs: pub struct META_PLACEABLE
+src/wmf/parser/records/drawing/arc.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/arc.rs: pub struct META_ARC
+src/wmf/parser/records/drawing/chord.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/chord.rs: pub struct META_CHORD
+src/wmf/parser/records/drawing/ellipse.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ellipse.rs: pub struct META_ELLIPSE
+src/wmf/parser/records/drawing/ext_flood_fill.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ext_flood_fill.rs: pub struct META_EXTFLOODFILL
+src/wmf/parser/records/drawing/ext_text_out.rs: pub fn into_utf8(
+src/wmf/parser/records/drawing/ext_text_out.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/ext_text_out.rs: pub struct META_EXTTEXTOUT
+src/wmf/parser/records/drawing/fill_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/fill_region.rs: pub struct META_FILLREGION
+src/wmf/parser/records/drawing/flood_fill.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/flood_fill.rs: pub struct META_FLOODFILL
+src/wmf/parser/records/drawing/frame_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/frame_region.rs: pub struct META_FRAMEREGION
+src/wmf/parser/records/drawing/invert_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/invert_region.rs: pub struct META_INVERTREGION
+src/wmf/parser/records/drawing/line_to.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/line_to.rs: pub struct META_LINETO
+src/wmf/parser/records/drawing/mod.rs: pub use self::{
+src/wmf/parser/records/drawing/paint_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/paint_region.rs: pub struct META_PAINTREGION
+src/wmf/parser/records/drawing/pat_blt.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/pat_blt.rs: pub struct META_PATBLT
+src/wmf/parser/records/drawing/pie.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/pie.rs: pub struct META_PIE
+src/wmf/parser/records/drawing/poly_line.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/poly_line.rs: pub struct META_POLYLINE
+src/wmf/parser/records/drawing/poly_polygon.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/poly_polygon.rs: pub struct META_POLYPOLYGON
+src/wmf/parser/records/drawing/polygon.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/polygon.rs: pub struct META_POLYGON
+src/wmf/parser/records/drawing/rectangle.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/rectangle.rs: pub struct META_RECTANGLE
+src/wmf/parser/records/drawing/round_rect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/round_rect.rs: pub struct META_ROUNDRECT
+src/wmf/parser/records/drawing/set_pixel.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/set_pixel.rs: pub struct META_SETPIXEL
+src/wmf/parser/records/drawing/text_out.rs: pub fn into_utf8(
+src/wmf/parser/records/drawing/text_out.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/drawing/text_out.rs: pub struct META_TEXTOUT
+src/wmf/parser/records/escape/mod.rs: pub enum META_ESCAPE
+src/wmf/parser/records/escape/mod.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/mod.rs: pub fn byte_count(&self) -> usize
+src/wmf/parser/records/mod.rs: pub fn consume(&mut self, consumed_bytes: usize)
+src/wmf/parser/records/mod.rs: pub fn consumed_bytes(&self) -> usize
+src/wmf/parser/records/mod.rs: pub fn parse<R: crate::wmf::Read>(buf: &mut R) -> Result<Self, crate::wmf::parser::ParseError>
+src/wmf/parser/records/mod.rs: pub fn remaining(&self) -> bool
+src/wmf/parser/records/mod.rs: pub fn remaining_bytes(&self) -> usize
+src/wmf/parser/records/mod.rs: pub fn word_size(&self) -> usize
+src/wmf/parser/records/mod.rs: pub struct RecordSize(u32, usize)
+src/wmf/parser/records/mod.rs: pub use self::{bitmap::*, control::*, drawing::*, escape::*, object::*, state::*}
+src/wmf/parser/records/object/create_brush_indirect.rs: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/create_brush_indirect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_brush_indirect.rs: pub struct META_CREATEBRUSHINDIRECT
+src/wmf/parser/records/object/create_font_indirect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_font_indirect.rs: pub struct META_CREATEFONTINDIRECT
+src/wmf/parser/records/object/create_palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_palette.rs: pub struct META_CREATEPALETTE
+src/wmf/parser/records/object/create_pattern_brush.rs: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/create_pattern_brush.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_pattern_brush.rs: pub struct META_CREATEPATTERNBRUSH
+src/wmf/parser/records/object/create_pen_indirect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_pen_indirect.rs: pub struct META_CREATEPENINDIRECT
+src/wmf/parser/records/object/create_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/create_region.rs: pub struct META_CREATEREGION
+src/wmf/parser/records/object/delete_object.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/delete_object.rs: pub struct META_DELETEOBJECT
+src/wmf/parser/records/object/dib_create_pattern_brush.rs: pub fn create_brush(&self) -> crate::wmf::parser::Brush
+src/wmf/parser/records/object/dib_create_pattern_brush.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/dib_create_pattern_brush.rs: pub struct META_DIBCREATEPATTERNBRUSH
+src/wmf/parser/records/object/mod.rs: pub use self::{
+src/wmf/parser/records/object/select_clip_region.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_clip_region.rs: pub struct META_SELECTCLIPREGION
+src/wmf/parser/records/object/select_object.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_object.rs: pub struct META_SELECTOBJECT
+src/wmf/parser/records/object/select_palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/object/select_palette.rs: pub struct META_SELECTPALETTE
+src/wmf/parser/records/state/animate_palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/animate_palette.rs: pub struct META_ANIMATEPALETTE
+src/wmf/parser/records/state/exclude_clip_rect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/exclude_clip_rect.rs: pub struct META_EXCLUDECLIPRECT
+src/wmf/parser/records/state/intersect_clip_rect.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/intersect_clip_rect.rs: pub struct META_INTERSECTCLIPRECT
+src/wmf/parser/records/state/mod.rs: pub use self::{
+src/wmf/parser/records/state/move_to.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/move_to.rs: pub struct META_MOVETO
+src/wmf/parser/records/state/offset_clip_rgn.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_clip_rgn.rs: pub struct META_OFFSETCLIPRGN
+src/wmf/parser/records/state/offset_viewport_org.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_viewport_org.rs: pub struct META_OFFSETVIEWPORTORG
+src/wmf/parser/records/state/offset_window_org.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/offset_window_org.rs: pub struct META_OFFSETWINDOWORG
+src/wmf/parser/records/state/realize_palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/realize_palette.rs: pub struct META_REALIZEPALETTE
+src/wmf/parser/records/state/resize_palette.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/resize_palette.rs: pub struct META_RESIZEPALETTE
+src/wmf/parser/records/state/restore_dc.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/restore_dc.rs: pub struct META_RESTOREDC
+src/wmf/parser/records/state/save_dc.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/save_dc.rs: pub struct META_SAVEDC
+src/wmf/parser/records/state/scale_viewport_ext.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/scale_viewport_ext.rs: pub struct META_SCALEVIEWPORTEXT
+src/wmf/parser/records/state/scale_window_ext.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/scale_window_ext.rs: pub struct META_SCALEWINDOWEXT
+src/wmf/parser/records/state/set_bk_color.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_bk_color.rs: pub struct META_SETBKCOLOR
+src/wmf/parser/records/state/set_bk_mode.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_bk_mode.rs: pub struct META_SETBKMODE
+src/wmf/parser/records/state/set_layout.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_layout.rs: pub struct META_SETLAYOUT
+src/wmf/parser/records/state/set_map_mode.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_map_mode.rs: pub struct META_SETMAPMODE
+src/wmf/parser/records/state/set_mapper_flags.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_mapper_flags.rs: pub struct META_SETMAPPERFLAGS
+src/wmf/parser/records/state/set_pal_entries.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_pal_entries.rs: pub struct META_SETPALENTRIES
+src/wmf/parser/records/state/set_polyfill_mode.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_polyfill_mode.rs: pub struct META_SETPOLYFILLMODE
+src/wmf/parser/records/state/set_relabs.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_relabs.rs: pub struct META_SETRELABS
+src/wmf/parser/records/state/set_rop2.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_rop2.rs: pub struct META_SETROP2
+src/wmf/parser/records/state/set_stretch_blt_mode.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_stretch_blt_mode.rs: pub struct META_SETSTRETCHBLTMODE
+src/wmf/parser/records/state/set_text_align.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_align.rs: pub struct META_SETTEXTALIGN
+src/wmf/parser/records/state/set_text_char_extra.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_char_extra.rs: pub struct META_SETTEXTCHAREXTRA
+src/wmf/parser/records/state/set_text_color.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_color.rs: pub struct META_SETTEXTCOLOR
+src/wmf/parser/records/state/set_text_justification.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_text_justification.rs: pub struct META_SETTEXTJUSTIFICATION
+src/wmf/parser/records/state/set_viewport_ext.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_viewport_ext.rs: pub struct META_SETVIEWPORTEXT
+src/wmf/parser/records/state/set_viewport_org.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_viewport_org.rs: pub struct META_SETVIEWPORTORG
+src/wmf/parser/records/state/set_window_ext.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_window_ext.rs: pub struct META_SETWINDOWEXT
+src/wmf/parser/records/state/set_window_org.rs: pub fn parse<R: crate::wmf::Read>(
+src/wmf/parser/records/state/set_window_org.rs: pub struct META_SETWINDOWORG

--- a/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
+++ b/mydocs/tech/investigations/issue-2403/advisory/api_surface.txt
@@ -715,6 +715,8 @@ src/model/path.rs: pub fn path_from_flat(parent_para_idx: usize, control_idx: us
 src/model/path.rs: pub type DocumentPath = Vec<PathSegment>
 src/model/provenance.rs: pub enum SourceFormat
 src/model/provenance.rs: pub fn hwp3_layout(&self) -> bool
+src/model/provenance.rs: pub fn hwp3_native_layout(&self) -> bool
+src/model/provenance.rs: pub fn hwp5_origin_hwpx(&self) -> bool
 src/model/provenance.rs: pub fn hwpx_stored_layout(&self) -> bool
 src/model/provenance.rs: pub struct LayoutCompatibilityProfile
 src/model/provenance.rs: pub struct SourceProvenance
@@ -1744,9 +1746,8 @@ src/renderer/layout.rs: pub fn set_file_name(&self, name: &str)
 src/renderer/layout.rs: pub fn set_hidden_empty_paras(&self, paras: &std::collections::HashSet<usize>)
 src/renderer/layout.rs: pub fn set_hidden_header_footer(&self, hidden: &std::collections::HashSet<(u32, bool)>)
 src/renderer/layout.rs: pub fn set_hwp3_origin_flow_spacing_before(&self, enabled: bool)
-src/renderer/layout.rs: pub fn set_hwp3_variant(&self, enabled: bool)
 src/renderer/layout.rs: pub fn set_hwpx_page_preview(&self, data: Option<&[u8]>)
-src/renderer/layout.rs: pub fn set_hwpx_source(&self, enabled: bool)
+src/renderer/layout.rs: pub fn set_layout_profile(
 src/renderer/layout.rs: pub fn set_pre_emitted_host_heights(&self, heights: &std::collections::HashMap<usize, f64>)
 src/renderer/layout.rs: pub fn set_pre_emitted_host_paras(&self, paras: &std::collections::HashSet<usize>)
 src/renderer/layout.rs: pub fn set_show_control_codes(&self, enabled: bool)

--- a/mydocs/tech/investigations/issue-2403/advisory/cli_output.txt
+++ b/mydocs/tech/investigations/issue-2403/advisory/cli_output.txt
@@ -1,0 +1,195 @@
+===== biz_plan.hwp : info =====
+파일: samples/biz_plan.hwp
+크기: 33792 bytes
+버전: 5.1.0.1
+압축: 예
+암호화: 아니오
+배포용: 아니오
+구역 수: 1
+페이지 수: 6
+구역0 용지: 59528×84188 HWPUNIT, 방향=세로 (여백: 좌5102 우5102 상5668 하4252)
+  머리말여백=4252 꼬리말여백=4252 제본여백=0
+폰트(한글): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M, [7]나눔명조
+폰트(영어): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M, [7]나눔명조
+폰트(한자): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M
+폰트(일어): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M
+폰트(기타): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M
+폰트(기호): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M
+폰트(사용자): [0]굴림, [1]맑은 고딕, [2]한컴바탕, [3]함초롬돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY헤드라인M
+스타일: 바탕글, 새 스타일, 본문, 개요 1, 개요 2, 개요 3, 개요 4, 개요 5, 개요 6, 개요 7, 쪽 번호, 머리말, 각주, 미주, 메모, xl1488, xl1485, xl1492, xl1487, xl66, xl65, xl70, xl71, xl73, xl68, 표본문
+총 문단 수: 93
+ParaShape: 47 (PS/문단 = 0.505)
+CharShape: 29 (CS/문단 = 0.312)
+Origin 추정: 한컴 한글 직접 작성 추정
+표1 [구역0:문단2]: 2행×1열, 셀 2개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표2 [구역0:문단70]: 5행×6열, 셀 30개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표3 [구역0:문단79]: 4행×2열, 셀 8개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표4 [구역0:문단83]: 3행×4열, 셀 12개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표5 [구역0:문단85]: 6행×2열, 셀 12개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표6 [구역0:문단87]: 6행×2열, 셀 12개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표7 [구역0:문단89]: 5행×2열, 셀 10개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+표8 [구역0:문단92]: 5행×2열, 셀 10개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+===== biz_plan.hwp : dump-pages =====
+문서 로드: samples/biz_plan.hwp (6페이지)
+
+=== 페이지 1 (global_idx=0, section=0, page_num=1) ===
+  body_area: x=68.0 y=132.3 w=657.7 h=876.9
+  단 0 (items=28, used=727.0px, hwp_used≈860.9px, diff=-133.9px)
+    FullParagraph  pi=0  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=0  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=1  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=1600  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    Table          pi=2 ci=0  2x1  653.7x141.9px  wrap=TopAndBottom tac=true  vpos=3200  ls=1[ts=0 lh=10925 th=10925 bl=9286 gap=1800 cs=0 sw=49324]
+    FullParagraph  pi=3  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=15925  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=4  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=17525  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=5  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=19125  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=6  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=20725  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=7  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=22325  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=8  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=23925  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=9  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=25525  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=10  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=27125  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=11  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=28725  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=12  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=30325  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=13  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=31925  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=14  h=38.4 (sb=0.0 lines=38.4 lh=24.0 ls=14.4 sa=0.0)  vpos=33525  ls=1[ts=0 lh=1800 th=1800 bl=1530 gap=1080 cs=0 sw=49324]  "20XX. 1."
+    FullParagraph  pi=15  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=36405  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=16  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=38005  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=17  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=39605  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=18  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=41205  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=19  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=42805  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=20  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=44405  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=21  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=46005  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=22  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=47605  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=23  h=40.5 (sb=0.0 lines=40.5 lh=25.3 ls=15.2 sa=0.0)  vpos=49205  ls=1[ts=0 lh=1900 th=1900 bl=1615 gap=1140 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=24  h=40.5 (sb=0.0 lines=40.5 lh=25.3 ls=15.2 sa=0.0)  vpos=52245  ls=1[ts=0 lh=1900 th=1900 bl=1615 gap=1140 cs=0 sw=49324]  "주식회사 OOO소O트"
+    FullParagraph  pi=25  h=40.5 (sb=0.0 lines=40.5 lh=25.3 ls=15.2 sa=0.0)  vpos=55285  ls=1[ts=0 lh=1900 th=1900 bl=1615 gap=1140 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=26  h=40.5 (sb=0.0 lines=40.5 lh=25.3 ls=15.2 sa=0.0)  vpos=58325  ls=1[ts=0 lh=1900 th=1900 bl=1615 gap=1140 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=27  h=42.7 (sb=0.0 lines=42.7 lh=26.7 ls=16.0 sa=0.0)  vpos=61365  ls=1[ts=0 lh=2000 th=2000 bl=1700 gap=1200 cs=0 sw=49324]  "(빈)"
+
+=== 페이지 2 (global_idx=1, section=0, page_num=2) ===
+  body_area: x=68.0 y=132.3 w=657.7 h=876.9
+  단 0 (items=19, used=632.5px, hwp_used≈865.9px, diff=-233.3px)
+    FullParagraph  pi=28  h=42.7 (sb=0.0 lines=42.7 lh=26.7 ls=16.0 sa=0.0)  vpos=0  ls=1[ts=0 lh=2000 th=2000 bl=1700 gap=1200 cs=0 sw=49324]  "- 목    차 -"
+    FullParagraph  pi=29  h=29.9 (sb=0.0 lines=29.9 lh=18.7 ls=11.2 sa=0.0)  vpos=3200  ls=1[ts=0 lh=1400 th=1400 bl=1190 gap=840 cs=0 sw=49324]  "(빈)"
+    FullParagraph  pi=30  h=46.7 (sb=0.0 lines=46.7 lh=18.7 ls=28.0 sa=0.0)  vpos=5440  ls=1[ts=0 lh=1400 th=1400 bl=1190 gap=2100 cs=0 sw=49324]  "사 업 명···································"
+===== hwp3-sample.hwp : info =====
+파일: samples/hwp3-sample.hwp
+크기: 88880 bytes
+버전: 3.0.0.0
+압축: 아니오
+암호화: 아니오
+배포용: 아니오
+구역 수: 1
+페이지 수: 16
+구역0 용지: 59528×84188 HWPUNIT, 방향=세로 (여백: 좌8504 우8504 상5668 하4252)
+  머리말여백=4252 꼬리말여백=4252 제본여백=0
+폰트(한글): [0]HY신명조, [1]HY중고딕, [2]HY견고딕, [3]타이프, [4]휴먼옛체
+폰트(영어): [0]HY신명조, [1]HY중고딕, [2]HY견고딕, [3]궁서, [4]타이프
+폰트(한자): [0]HY신명조, [1]HY중고딕, [2]신명 중명조
+폰트(일어): [0]HY신명조, [1]HY중고딕, [2]신명 태명조
+폰트(기타): [0]HY신명조
+폰트(기호): [0]HY신명조, [1]HY중고딕, [2]#태명조
+폰트(사용자): [0]명조
+스타일: 바탕글, 본문(신명조10), 본문(중고딕10), 작은제목(중고딕15), 중간제목(옛체20), 큰제목(견고딕20), 큰제목(견고딕30), 머리말(신명조9), 머리말(중고딕9), 각주내용(신명조9), 쪽번호
+총 문단 수: 195
+ParaShape: 119 (PS/문단 = 0.610)
+CharShape: 747 (CS/문단 = 3.831)
+Origin 추정: 한컴 한글 직접 작성 추정
+BinData:
+  [0] Embedding (ID: 1, ext: jpg, loaded: 1808 bytes)
+  [1] Embedding (ID: 2, ext: gif, loaded: 9149 bytes)
+  [2] Embedding (ID: 3, ext: gif, loaded: 9602 bytes)
+  [3] Embedding (ID: 4, ext: gif, loaded: 4228 bytes)
+  [4] Embedding (ID: 5, ext: gif, loaded: 10079 bytes)
+그림1 [구역0:문단41]: bin_data_id=2, size=40020×35580
+그림2 [구역0:문단76]: bin_data_id=3, size=38940×36300
+그림3 [구역0:문단78]: bin_data_id=4, size=23340×19920
+표1 [구역0:문단80]: 5행×6열, 셀 22개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+표2 [구역0:문단85]: 1행×4열, 셀 4개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+표3 [구역0:문단87]: 1행×4열, 셀 4개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+표4 [구역0:문단89]: 1행×4열, 셀 4개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+표5 [구역0:문단91]: 1행×4열, 셀 4개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+그림4 [구역0:문단97]: bin_data_id=5, size=41460×39540
+표6 [구역0:문단194]: 17행×2열, 셀 34개, 쪽나눔=나누지 않음 (attr=0x00000000), 제목반복=false
+===== hwp3-sample.hwp : dump-pages =====
+문서 로드: samples/hwp3-sample.hwp (16페이지)
+
+=== 페이지 1 (global_idx=0, section=0, page_num=1) ===
+  body_area: x=113.4 y=132.3 w=566.9 h=876.9
+  단 0 (items=28, used=857.6px, hwp_used≈878.9px, diff=-21.3px)
+    FullParagraph  pi=0  h=38.4 (sb=0.0 lines=38.4 lh=24.0 ls=14.4 sa=0.0)  vpos=0  ls=1[ts=0 lh=1800 th=1800 bl=1530 gap=1080 cs=0 sw=42520]  "￼Creating Linux Virtual Servers"
+    FullParagraph  pi=1  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=2880  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=2  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=4480  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=3  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=6080  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "Wensong Zhang, Shiyao Jin, Quanyuan Wu"
+    FullParagraph  pi=4  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=7680  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "National Laboratory for Parallel & Distr"
+    FullParagraph  pi=5  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=9280  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "Changsha, Hunan 410073, China"
+    FullParagraph  pi=6  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=10880  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "wensong@iinchina.net"
+    FullParagraph  pi=7  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=12480  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "http://proxy.iinchina.net/~wensong"
+    FullParagraph  pi=8  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=14080  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=9  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=15680  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=10  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=17280  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=11  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=18880  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=12  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=20480  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=13  h=29.9 (sb=0.0 lines=29.9 lh=18.7 ls=11.2 sa=0.0)  vpos=22080  ls=1[ts=0 lh=1400 th=1400 bl=1190 gap=840 cs=0 sw=42520]  "개  요"
+    FullParagraph  pi=14  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=24320  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=15  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=25920  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=16  h=106.7 (sb=0.0 lines=106.7 lh=66.7 ls=40.0 sa=0.0)  vpos=27520..33920  ls=5[first ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520; last ts=227 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "  빠른 넷트웍에 연결된 서버(server)들의 클러스터(cluster)"
+    FullParagraph  pi=17  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=35520  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=18  h=192.0 (sb=0.0 lines=192.0 lh=120.0 ls=72.0 sa=0.0)  vpos=37120..49920  ls=9[first ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520; last ts=442 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "  이 글은 어떻게 리눅스 가상 서버들을 만드는지 설명하고 있다. 가상 "
+    FullParagraph  pi=19  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=51520  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=20  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=53120  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=21  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=54720  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=22  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=56320  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=23  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=57920  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=24  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=59520  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=25  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=61120  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=26  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=62720  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "번역 : 리눅스코리아(주) 개발팀 이선중"
+    FullParagraph  pi=27  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=64320  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+
+=== 페이지 2 (global_idx=1, section=0, page_num=2) ===
+  body_area: x=113.4 y=132.3 w=566.9 h=876.9
+  단 0 (items=13, used=763.7px, hwp_used≈763.7px, diff=+0.0px)
+    FullParagraph  pi=28  h=38.4 (sb=0.0 lines=38.4 lh=24.0 ls=14.4 sa=0.0)  vpos=0  ls=1[ts=0 lh=1800 th=1800 bl=1530 gap=1080 cs=0 sw=42520]  "1. 소개"
+    FullParagraph  pi=29  h=21.3 (sb=0.0 lines=21.3 lh=13.3 ls=8.0 sa=0.0)  vpos=2880  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "(빈)"
+    FullParagraph  pi=30  h=213.3 (sb=0.0 lines=213.3 lh=133.3 ls=80.0 sa=0.0)  vpos=4480..18880  ls=10[first ts=0 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520; last ts=464 lh=1000 th=1000 bl=850 gap=600 cs=0 sw=42520]  "인터넷의 폭발적 성장과 인터넷이 우리 생활에서 차지하는 중요도가 커짐에 "
+===== issue_2148_degenerate_cell_vpos.hwpx : info =====
+파일: samples/issue_2148_degenerate_cell_vpos.hwpx
+크기: 7067222 bytes
+버전: 5.1.0.0
+압축: 아니오
+암호화: 아니오
+배포용: 아니오
+구역 수: 1
+페이지 수: 1
+구역0 용지: 59528×84188 HWPUNIT, 방향=세로 (여백: 좌5102 우5102 상3600 하3600)
+  머리말여백=3600 꼬리말여백=3600 제본여백=0
+폰트(한글): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY견고딕, [7]HY견명조, [8]HY신명조, [9]HY중고딕, [10]HY헤드라인M
+폰트(영어): [0]굴림체, [1]궁서, [2]맑은 고딕, [3]바탕체, [4]한컴돋움, [5]함초롬바탕, [6]휴먼명조, [7]HY견고딕, [8]HY견명조, [9]HY신명조, [10]HY중고딕, [11]HY헤드라인M, [12]Times New Roman
+폰트(한자): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY견고딕, [7]HY견명조, [8]HY신명조, [9]HY중고딕, [10]HY헤드라인M
+폰트(일어): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY견고딕, [7]HY견명조, [8]HY신명조, [9]HY중고딕, [10]HY헤드라인M
+폰트(기타): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]한컴바탕, [5]함초롬바탕, [6]휴먼명조, [7]HY견고딕, [8]HY견명조, [9]HY신명조, [10]HY중고딕, [11]HY헤드라인M
+폰트(기호): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY견고딕, [7]HY견명조, [8]HY신명조, [9]HY중고딕, [10]HY헤드라인M
+폰트(사용자): [0]굴림체, [1]맑은 고딕, [2]바탕체, [3]한컴돋움, [4]함초롬바탕, [5]휴먼명조, [6]HY견고딕, [7]HY견명조, [8]HY중고딕, [9]HY헤드라인M
+스타일: 바탕글, 본문(신명조10), 본문(중고딕10), 작은제목(중고딕15), 중간제목(옛체20), 큰제목(견고딕20), 큰제목(견고딕30), 머리말(신명조9), 머리말(중고딕9), 각주내용(신명조9), 본문(신견고 28), 본문(신태고14), 본문(신견명20), 신명 중고딕13, xl65
+총 문단 수: 2
+ParaShape: 55 (PS/문단 = 27.500)
+CharShape: 134 (CS/문단 = 67.000)
+Origin 추정: 판정 불가 (문단 수 ≤ 50, 비율 왜곡 회피)
+BinData:
+  [0] Embedding (ID: 1, ext: png, loaded: 18776 bytes)
+  [1] Embedding (ID: 2, ext: jpg, loaded: 78917 bytes)
+  [2] Embedding (ID: 3, ext: bmp, loaded: 198351 bytes)
+  [3] Embedding (ID: 4, ext: bmp, loaded: 443382 bytes)
+  [4] Embedding (ID: 5, ext: bmp, loaded: 170256 bytes)
+  [5] Embedding (ID: 6, ext: jpg, loaded: 1068628 bytes)
+  [6] Embedding (ID: 7, ext: jpg, loaded: 1127407 bytes)
+  [7] Embedding (ID: 8, ext: jpg, loaded: 1499442 bytes)
+  [8] Embedding (ID: 9, ext: jpg, loaded: 1350209 bytes)
+  [9] Embedding (ID: 10, ext: jpg, loaded: 1112857 bytes)
+표1 [구역0:문단1]: 3행×3열, 셀 6개, 쪽나눔=나눔(행 단위) (attr=0x04000006), 제목반복=true
+===== issue_2148_degenerate_cell_vpos.hwpx : dump-pages =====
+문서 로드: samples/issue_2148_degenerate_cell_vpos.hwpx (1페이지)
+
+=== 페이지 1 (global_idx=0, section=0, page_num=1) ===
+  body_area: x=68.0 y=96.0 w=657.7 h=930.5
+  단 0 (items=2, used=378.4px)
+    FullParagraph  pi=0  h=17.3 (sb=0.0 lines=17.3 lh=13.3 ls=4.0 sa=0.0)  vpos=0  ls=1[ts=0 lh=1000 th=1000 bl=850 gap=300 cs=0 sw=49324]  "(빈)"
+    Table          pi=1 ci=0  3x3  644.4x348.0px  wrap=TopAndBottom tac=true  vpos=1300  ls=1[ts=0 lh=26098 th=26098 bl=22183 gap=360 cs=0 sw=49324]

--- a/mydocs/tech/investigations/issue-2403/advisory/render_tree_sha256.txt
+++ b/mydocs/tech/investigations/issue-2403/advisory/render_tree_sha256.txt
@@ -1,0 +1,3 @@
+cca04bb33efd387a63fc7b76d50415ce4298eb4a539c02896ecc58480352af7a  rt_biz_plan.hwp.d/render_tree_001.json
+2b323e99a1c9ae8ed9da4a279b83d8971bf62e87b73680ffd68b78b1f8decd28  rt_hwp3-sample.hwp.d/render_tree_001.json
+65da8893f959300f29624922645e30b69a7dfc918fbc16fce2ca54d77fefc514  rt_issue_2148_degenerate_cell_vpos.hwpx.d/render_tree_001.json

--- a/mydocs/tech/parser_architecture.md
+++ b/mydocs/tech/parser_architecture.md
@@ -34,3 +34,19 @@ HWP3 바이너리 해석과 HWP3 전용 보정은 `src/parser/hwp3/` 안에서 �
 
 공통 영역에 추가 정보가 필요하면 HWP3 여부를 직접 전달하지 않고, 다른 포맷에도 적용 가능한 IR 속성으로
 정의한다. 이 규칙은 포맷별 예외가 렌더링과 편집 계층으로 확산되는 것을 막는다.
+
+## 소스 출처와 레이아웃 호환 정책 (#2403)
+
+소스 포맷·변환 계보 판단은 파싱 시점에 `Document.provenance`
+(`src/model/provenance.rs` 의 `SourceProvenance`)로 한 번 확정된다 — 쓰기
+지점은 파서로 한정한다. 렌더러·레이아웃·편집 계층은 boolean 필드를 직접
+읽지 않고 `Document::layout_profile()` 이 돌려주는
+`LayoutCompatibilityProfile` 질의(`hwp3_layout`/`hwp3_native_layout`/
+`hwpx_stored_layout`/`hwp5_origin_hwpx`)를 사용한다.
+
+- **신규 소스분기는 profile 질의 추가로만 연다** — 흩어진 boolean 전달이나
+  포맷 이름 직접 비교를 새로 만들지 않는다.
+- 문서군 판별 신호(생성기·재저장 서명 등)가 확정되면 `SourceProvenance` 의
+  서명 필드와 profile 질의로 수용한다 (#2373 잔여 판별자 트랙).
+- 기존 `is_hwp3_variant`/`is_hwpx_variant` 필드는 shim 이며 파서의 같은 쓰기
+  지점에서 provenance 와 동기된다 — 신규 코드에서 읽지 않는다.

--- a/scripts/advisory_snapshot.sh
+++ b/scripts/advisory_snapshot.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# [#2403 Phase P] advisory 3종 스냅샷 생성 — public API 표면 / WASM JSON 계약 / CLI output.
+# 사용법: ./scripts/advisory_snapshot.sh <출력 dir>
+# 재현 조건: 같은 커밋 + release-test 빌드된 target/release-test/rhwp 존재.
+# 대조: 리팩토링 각 단계 게이트에서 재생성 후 `diff -r` — advisory (무변동 기대).
+set -euo pipefail
+OUT="${1:?출력 디렉터리 필요}"
+BIN=target/release-test/rhwp
+[[ -x "$BIN" ]] || { echo "error: $BIN 없음 — cargo build --profile release-test 선행" >&2; exit 1; }
+mkdir -p "$OUT"
+
+# 1) public Rust API 표면 — pub 선언 시그니처의 결정적 목록 (파일 경로 + 정규화 시그니처)
+#    도구 무의존(grep 기반) — 같은 방법으로 재생성해 비교하는 전제의 advisory 스냅샷.
+grep -rn --include="*.rs" -E "^[[:space:]]*pub (fn|struct|enum|trait|type|const|static|mod|use) " src \
+  | sed -E 's/[[:space:]]+/ /g; s/ \{.*$//; s/;.*$//' \
+  | sort > "$OUT/api_surface.txt"
+
+# 2) WASM JSON 계약 — wasm_api 가 노출하는 JSON 반환 계약의 대표 표본.
+#    네이티브에서 같은 document_core 질의를 쓰는 CLI 명령으로 고정한다.
+# 3) CLI output — 대표 명령 × 대표 샘플 (HWP5/HWPX/HWP3 각 1 이상)
+SAMPLES=(samples/biz_plan.hwp samples/hwp3-sample.hwp samples/issue_2148_degenerate_cell_vpos.hwpx)
+: > "$OUT/cli_output.txt"
+for s in "${SAMPLES[@]}"; do
+  base=$(basename "$s")
+  {
+    echo "===== $base : info ====="
+    "$BIN" info "$s" 2>&1
+    echo "===== $base : dump-pages ====="
+    "$BIN" dump-pages "$s" 2>&1 | head -40
+  } >> "$OUT/cli_output.txt"
+  # export-render-tree 는 -o 를 디렉터리로 취급해 render_tree_NNN.json 을 만든다
+  rtdir="$OUT/rt_${base}.d"
+  "$BIN" export-render-tree "$s" -p 0 -o "$rtdir" >/dev/null 2>&1 || \
+    echo "render-tree 실패: $base" >> "$OUT/cli_output.txt"
+done
+# render tree JSON 은 크므로 sha256 만 표에 남기고 원본은 삭제 (계약 = 구조 해시)
+: > "$OUT/render_tree_sha256.txt"
+for d in "$OUT"/rt_*.d; do
+  [[ -d "$d" ]] || continue
+  for f in "$d"/*.json; do
+    [[ -f "$f" ]] || continue
+    echo "$(sha256sum "$f" | cut -d' ' -f1)  $(basename "$d")/$(basename "$f")" >> "$OUT/render_tree_sha256.txt"
+  done
+  rm -rf "$d"
+done
+
+echo "advisory snapshot → $OUT"
+wc -l "$OUT"/api_surface.txt "$OUT"/cli_output.txt "$OUT"/render_tree_sha256.txt

--- a/scripts/advisory_snapshot.sh
+++ b/scripts/advisory_snapshot.sh
@@ -11,8 +11,9 @@ mkdir -p "$OUT"
 
 # 1) public Rust API 표면 — pub 선언 시그니처의 결정적 목록 (파일 경로 + 정규화 시그니처)
 #    도구 무의존(grep 기반) — 같은 방법으로 재생성해 비교하는 전제의 advisory 스냅샷.
+#    줄번호는 제외한다 — 무관한 필드 추가로 전 항목이 밀리는 diff 노이즈 방지 (1단계 실측).
 grep -rn --include="*.rs" -E "^[[:space:]]*pub (fn|struct|enum|trait|type|const|static|mod|use) " src \
-  | sed -E 's/[[:space:]]+/ /g; s/ \{.*$//; s/;.*$//' \
+  | sed -E 's/^([^:]+):[0-9]+:/\1: /; s/[[:space:]]+/ /g; s/ \{.*$//; s/;.*$//' \
   | sort > "$OUT/api_surface.txt"
 
 # 2) WASM JSON 계약 — wasm_api 가 노출하는 JSON 반환 계약의 대표 표본.

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -646,6 +646,7 @@ impl DocumentCore {
             // [Task #2299] 붙여넣기로 문단 높이가 변했으므로 하류 vpos 를 재연결한다.
             // 생략하면 후속 문단 first < 커진 end 세임이 저장돼 이후 편집의 리셋
             // 보존이 이를 단/쪽 경계로 오인한다.
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -653,7 +654,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -708,6 +709,7 @@ impl DocumentCore {
         // [Task #2299] 삽입 문단들의 vpos 를 흐름에 연결한다. 클립보드 클론의
         // 원본 좌표/placeholder 를 방치하면 이후 편집의 vpos 재계산이 이를 저장
         // 단/쪽 리셋으로 오인해 영구 고착시킨다 — 신규 구간은 리셋 보존에서 제외.
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -715,7 +717,7 @@ impl DocumentCore {
             None,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         // 6. 선택적 재구성: 삽입된 문단 composed 추가 + 영향 문단 재구성
@@ -1165,6 +1167,7 @@ impl DocumentCore {
             );
             self.reflow_paragraph(section_idx, para_idx);
         }
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -1172,7 +1175,7 @@ impl DocumentCore {
             None,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         // 리플로우 + 페이지네이션

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -75,7 +75,7 @@ impl DocumentCore {
         let styles = crate::renderer::style_resolver::resolve_styles_with_variant(
             &document.doc_info,
             DEFAULT_DPI,
-            document.is_hwp3_variant,
+            document.layout_profile().hwp3_layout(),
         );
 
         let hwp5_origin_hwpx = matches!(source_format, crate::parser::FileFormat::Hwpx)
@@ -106,7 +106,7 @@ impl DocumentCore {
         // 문단은 typeset 의 em 폴백(#2070 축3)이 담당하고(80168 pi=424 오라클),
         // 본문 텍스트 문단 합성은 흐름 소비 팽창으로 sijang 밀도 핀 -5쪽(#2070v2).
         // HWP3 변환본은 #998 게이트(sample16-hwp5=64) 정합상 종전 유지.
-        let include_cell_empty = !document.is_hwp3_variant;
+        let include_cell_empty = !document.layout_profile().hwp3_layout();
         Self::reflow_zero_height_paragraphs(
             &mut document,
             &styles,
@@ -1001,6 +1001,7 @@ impl DocumentCore {
         let styles = resolve_styles(&self.document.doc_info, self.dpi);
         let dpi = self.dpi;
         let mut reflowed = 0usize;
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
 
         for section in &mut self.document.sections {
             let page_def = &section.section_def.page_def;
@@ -1061,7 +1062,7 @@ impl DocumentCore {
                     None,
                     &self.styles,
                     self.dpi,
-                    self.document.is_hwp3_variant,
+                    doc_hwp3_layout,
                 );
             }
         }

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -742,8 +742,8 @@ impl DocumentCore {
         let (raw_left_hu, raw_right_hu, raw_indent_hu) = raw_ps
             .map(|r| (r.margin_left, r.margin_right, r.indent))
             .unwrap_or((0, 0, 0));
-        let is_hwp3_native =
-            self.document.header.version.major == 3 && !self.document.is_hwp3_variant;
+        let is_hwp3_native = self.document.header.version.major == 3
+            && !self.document.layout_profile().hwp3_layout();
         let effective_left_hu = if is_hwp3_native {
             raw_left_hu + raw_indent_hu.min(0)
         } else {

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -65,6 +65,7 @@ impl DocumentCore {
             self.reflow_paragraph(section_idx, para_idx);
             // [Task #2299] 삽입/변경 문단들의 vpos 를 흐름에 연결한다 — placeholder 를
             // 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해 고착시킨다.
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -72,7 +73,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -145,6 +146,7 @@ impl DocumentCore {
             // 좌표를 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해
             // 고착시킨다. left_empty 면 host 자체가 클론이라 신규 구간에 포함한다.
             let fresh_start = if left_empty { para_idx } else { para_idx + 1 };
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -152,7 +154,7 @@ impl DocumentCore {
                 None,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
 
             // 선택적 재구성: 원본 문단 재구성 + 삽입 문단 composed 추가
@@ -195,6 +197,7 @@ impl DocumentCore {
         }
         // [Task #2299] 삽입/변경 문단들의 vpos 를 흐름에 연결한다 — placeholder 를
         // 방치하면 이후 편집의 vpos 재계산이 저장 단/쪽 리셋으로 오인해 고착시킨다.
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -202,7 +205,7 @@ impl DocumentCore {
             None,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         // 선택적 재구성: 원본 문단 재구성 + 삽입 문단 composed 추가

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -548,6 +548,7 @@ impl DocumentCore {
                 &self.document.sections[section_idx].paragraphs[parent_para_idx],
             );
             self.reflow_paragraph(section_idx, parent_para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 parent_para_idx,
@@ -555,7 +556,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
         }
         // 캡션 생성/삭제 시 AutoNumber 재할당. 생성 path 는 문단 placeholder 도 보강한다.

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -737,6 +737,7 @@ impl DocumentCore {
         for i in para_idx..fresh_end.min(self.document.sections[section_idx].paragraphs.len()) {
             self.reflow_paragraph(section_idx, i);
         }
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -744,7 +745,7 @@ impl DocumentCore {
             None,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         // --- 6. 스타일 갱신 + 리플로우 + 페이지네이션 ---

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -2644,6 +2644,7 @@ impl DocumentCore {
             &self.document.sections[section_idx].paragraphs[parent_para_idx],
         );
         self.reflow_paragraph(section_idx, parent_para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             parent_para_idx,
@@ -2651,7 +2652,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -506,6 +506,7 @@ impl DocumentCore {
             &self.document.sections[section_idx].paragraphs[para_idx],
         );
         self.reflow_paragraph(section_idx, para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -513,7 +514,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -533,6 +534,7 @@ impl DocumentCore {
                 &self.document.sections[section_idx].paragraphs[para_idx],
             );
             self.reflow_paragraph(section_idx, para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -540,7 +542,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -634,6 +636,7 @@ impl DocumentCore {
             &self.document.sections[section_idx].paragraphs[para_idx],
         );
         self.reflow_paragraph(section_idx, para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -641,7 +644,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -661,6 +664,7 @@ impl DocumentCore {
                 &self.document.sections[section_idx].paragraphs[para_idx],
             );
             self.reflow_paragraph(section_idx, para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -668,7 +672,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -1264,7 +1268,7 @@ impl DocumentCore {
     ) {
         let styles = &self.styles;
         let dpi = self.dpi;
-        let is_hwp3_variant = self.document.is_hwp3_variant;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
         let Some(control) = self.document.sections[section_idx].paragraphs[parent_para_idx]
             .controls
             .get_mut(control_idx)
@@ -1394,6 +1398,7 @@ impl DocumentCore {
                         &self.document.sections[section_idx].paragraphs[start_para],
                     );
                     self.reflow_paragraph(section_idx, start_para);
+                    let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
                     crate::renderer::composer::recalculate_section_vpos(
                         &mut self.document.sections[section_idx].paragraphs,
                         start_para,
@@ -1401,7 +1406,7 @@ impl DocumentCore {
                         stored_end_for_reset,
                         &self.styles,
                         self.dpi,
-                        self.document.is_hwp3_variant,
+                        doc_hwp3_layout,
                     );
                 }
                 // 변경 문단만 재구성
@@ -1443,6 +1448,7 @@ impl DocumentCore {
                     &self.document.sections[section_idx].paragraphs[start_para],
                 );
                 self.reflow_paragraph(section_idx, start_para);
+                let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     start_para,
@@ -1450,7 +1456,7 @@ impl DocumentCore {
                     stored_end_for_reset,
                     &self.styles,
                     self.dpi,
-                    self.document.is_hwp3_variant,
+                    doc_hwp3_layout,
                 );
                 // 병합된 문단 재구성
                 self.recompose_paragraph(section_idx, start_para);
@@ -1582,6 +1588,7 @@ impl DocumentCore {
                 .copied()
                 .unwrap_or(0);
             self.reflow_paragraph(section_idx, new_para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -1589,7 +1596,7 @@ impl DocumentCore {
                 None,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.insert_composed_paragraph(section_idx, new_para_idx);
             self.paginate_if_needed();
@@ -1605,6 +1612,7 @@ impl DocumentCore {
                     break;
                 }
                 self.reflow_paragraph(section_idx, new_para_idx);
+                let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
                 crate::renderer::composer::recalculate_section_vpos(
                     &mut self.document.sections[section_idx].paragraphs,
                     para_idx,
@@ -1612,7 +1620,7 @@ impl DocumentCore {
                     None,
                     &self.styles,
                     self.dpi,
-                    self.document.is_hwp3_variant,
+                    doc_hwp3_layout,
                 );
                 self.recompose_paragraph(section_idx, new_para_idx);
                 self.paginate_if_needed();
@@ -1654,7 +1662,7 @@ impl DocumentCore {
                     .unwrap_or((0.0, 0.0));
                 let before = crate::renderer::hwp3_variant_flow_spacing_before(
                     before,
-                    self.document.is_hwp3_variant,
+                    self.document.layout_profile().hwp3_layout(),
                 );
                 crate::renderer::px_to_hwpunit(after + before, self.dpi)
             };
@@ -1676,6 +1684,7 @@ impl DocumentCore {
             if !keep_wrap_zone {
                 self.reflow_paragraph(section_idx, new_para_idx);
             }
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -1683,7 +1692,7 @@ impl DocumentCore {
                 None,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.insert_composed_paragraph(section_idx, new_para_idx);
             self.paginate_if_needed();
@@ -1733,6 +1742,7 @@ impl DocumentCore {
         );
         self.reflow_paragraph(section_idx, para_idx);
         self.reflow_paragraph(section_idx, new_para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -1740,7 +1750,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.insert_composed_paragraph(section_idx, new_para_idx);
@@ -1762,6 +1772,7 @@ impl DocumentCore {
             );
             self.reflow_paragraph(section_idx, para_idx);
             self.reflow_paragraph(section_idx, new_para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 para_idx,
@@ -1769,7 +1780,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.recompose_paragraph(section_idx, new_para_idx);
@@ -1842,6 +1853,7 @@ impl DocumentCore {
         self.reflow_paragraph(section_idx, new_para_idx);
 
         // 삽입 지점부터 구역 끝까지 vpos 재계산 (페이지 재배치에 필요)
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
@@ -1849,7 +1861,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         // 전체 구역 재구성 + 재페이지네이션
@@ -1915,6 +1927,7 @@ impl DocumentCore {
         );
         self.reflow_paragraph(section_idx, new_para_idx);
 
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             new_para_idx,
@@ -1922,7 +1935,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
 
         self.recompose_section(section_idx);
@@ -2063,6 +2076,7 @@ impl DocumentCore {
             self.document.sections[section_idx].paragraphs[prev_idx].merge_from(&current_para);
 
         if preserve_square_ole_wrap_line {
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
@@ -2070,7 +2084,7 @@ impl DocumentCore {
                 None,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.remove_composed_paragraph(section_idx, para_idx);
             self.recompose_paragraph(section_idx, prev_idx);
@@ -2098,6 +2112,7 @@ impl DocumentCore {
             &self.document.sections[section_idx].paragraphs[prev_idx],
         );
         self.reflow_paragraph(section_idx, prev_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             prev_idx,
@@ -2105,7 +2120,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.remove_composed_paragraph(section_idx, para_idx);
         self.recompose_paragraph(section_idx, prev_idx);
@@ -2126,6 +2141,7 @@ impl DocumentCore {
                 &self.document.sections[section_idx].paragraphs[prev_idx],
             );
             self.reflow_paragraph(section_idx, prev_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 prev_idx,
@@ -2133,7 +2149,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, prev_idx);
             self.paginate_if_needed();
@@ -2201,6 +2217,7 @@ impl DocumentCore {
         if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
             self.reflow_paragraph(section_idx, reflow_idx);
         }
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             reflow_idx,
@@ -2208,7 +2225,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
             self.recompose_paragraph(section_idx, reflow_idx);
@@ -2233,6 +2250,7 @@ impl DocumentCore {
             if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
                 self.reflow_paragraph(section_idx, reflow_idx);
             }
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_idx,
@@ -2240,7 +2258,7 @@ impl DocumentCore {
                 stored_end_for_reset,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             if reflow_idx < self.document.sections[section_idx].paragraphs.len() {
                 self.recompose_paragraph(section_idx, reflow_idx);
@@ -2316,6 +2334,7 @@ impl DocumentCore {
             .copied()
             .unwrap_or(0);
         self.reflow_paragraph(section_idx, para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             reflow_target,
@@ -2323,7 +2342,7 @@ impl DocumentCore {
             None,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.insert_composed_paragraph(section_idx, para_idx);
         self.paginate_if_needed();
@@ -2339,6 +2358,7 @@ impl DocumentCore {
                 break;
             }
             self.reflow_paragraph(section_idx, para_idx);
+            let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
             crate::renderer::composer::recalculate_section_vpos(
                 &mut self.document.sections[section_idx].paragraphs,
                 reflow_target,
@@ -2346,7 +2366,7 @@ impl DocumentCore {
                 None,
                 &self.styles,
                 self.dpi,
-                self.document.is_hwp3_variant,
+                doc_hwp3_layout,
             );
             self.recompose_paragraph(section_idx, para_idx);
             self.paginate_if_needed();
@@ -3481,7 +3501,7 @@ impl DocumentCore {
         let cell_para_idx = last.2;
         let styles = &self.styles;
         let dpi = self.dpi;
-        let is_hwp3_variant = self.document.is_hwp3_variant;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
 
         // 셀에 접근하여 문단 분할
         let section = self
@@ -3569,7 +3589,7 @@ impl DocumentCore {
         }
         let styles = &self.styles;
         let dpi = self.dpi;
-        let is_hwp3_variant = self.document.is_hwp3_variant;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
 
         let section = self
             .document

--- a/src/document_core/mod.rs
+++ b/src/document_core/mod.rs
@@ -224,7 +224,7 @@ impl DocumentCore {
             self.document.sections.len(),
             self.page_count(),
             self.document.header.encrypted,
-            self.document.is_hwp3_variant,
+            self.document.layout_profile().hwp3_layout(),
             escaped_fallback,
             fonts_json.join(","),
         )
@@ -242,7 +242,7 @@ impl DocumentCore {
         self.styles = resolve_styles_with_variant(
             &self.document.doc_info,
             dpi,
-            self.document.is_hwp3_variant,
+            self.document.layout_profile().hwp3_layout(),
         );
         self.paginate();
     }

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -101,6 +101,7 @@ impl DocumentCore {
             &self.document.sections[section_idx].paragraphs[para_idx],
         );
         self.reflow_paragraph(section_idx, para_idx);
+        let doc_hwp3_layout = self.document.layout_profile().hwp3_layout();
         crate::renderer::composer::recalculate_section_vpos(
             &mut self.document.sections[section_idx].paragraphs,
             para_idx,
@@ -108,7 +109,7 @@ impl DocumentCore {
             stored_end_for_reset,
             &self.styles,
             self.dpi,
-            self.document.is_hwp3_variant,
+            doc_hwp3_layout,
         );
         self.recompose_paragraph(section_idx, para_idx);
         self.paginate_if_needed();

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -169,7 +169,7 @@ fn uses_hwp3_origin_flow_spacing_before(document: &Document) -> bool {
     // HWP3-origin HWP5 변환본은 parser 단계에서 ParaShape spacing 계열을 절반으로
     // 정규화하므로, 본문 흐름 계산에서는 원래 spacing_before를 복원한다.
     // 원본 HWP3는 HWP3 parser가 만든 spacing 값을 기준으로 삼아 여기서 재확대하지 않는다.
-    document.is_hwp3_variant
+    document.layout_profile().hwp3_layout()
 }
 
 fn should_insert_hwp3_title_filler_page(
@@ -2959,8 +2959,8 @@ impl DocumentCore {
                 measurer.measure_section(para_src, composed, &self.styles, Some(col_w_pre))
             };
 
-            let hwp3_origin_page_tolerance =
-                self.document.is_hwp3_variant || uses_hwp3_origin_page_tolerance(&self.document);
+            let hwp3_origin_page_tolerance = self.document.layout_profile().hwp3_layout()
+                || uses_hwp3_origin_page_tolerance(&self.document);
             let column_def = Self::find_initial_column_def(para_src);
             // TypesetEngine을 main pagination으로 사용. RHWP_USE_PAGINATOR=1 로 fallback 가능.
             let use_paginator = std::env::var("RHWP_USE_PAGINATOR")
@@ -2977,7 +2977,7 @@ impl DocumentCore {
                     crate::renderer::pagination::PaginationOpts {
                         hide_empty_line: section.section_def.hide_empty_line,
                         respect_vpos_reset: self.respect_vpos_reset,
-                        is_hwp3_variant: self.document.is_hwp3_variant,
+                        is_hwp3_variant: self.document.layout_profile().hwp3_layout(),
                         footnote_shape: Some(section.section_def.footnote_shape.clone()),
                     },
                 )

--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -2775,20 +2775,11 @@ impl DocumentCore {
         self.compute_render_normalized();
         let paginator = Paginator::new(self.dpi);
         let hwp3_origin_flow_spacing_before = uses_hwp3_origin_flow_spacing_before(&self.document);
-        let is_hwp5_origin_hwpx = self
-            .document
-            .hwpx_aux_entry(crate::model::document::HWP5_ORIGIN_HWPX_MARKER_PATH)
-            .is_some();
-        // [Issue #1770] rhwp HWPX→HWP 변환본(is_hwpx_variant, 마커 감지)은 IR 이
-        // HWPX 시멘틱 그대로이므로 pagination 분기도 HWPX 로 해석한다 (roundtrip
-        // 자기정합). native HWP5 는 마커가 없어 불변.
-        // 반대로 rhwp HWP5→HWPX 산출물은 HWPX ZIP 이지만 HWP5 원본의 lineSeg 부재와
-        // pagination 시멘틱을 유지해야 하므로 HWPX 전용 분기에서 제외한다.
-        let is_hwpx_source = (matches!(self.source_format, crate::parser::FileFormat::Hwpx)
-            && !is_hwp5_origin_hwpx)
-            || self.document.is_hwpx_variant;
+        // [#2403] 소스분기 파생 일원화 — HWPX 시멘틱/HWP5→HWPX 마커/HWP3 변환본
+        // 판단은 Document::layout_profile 이 단일 소유 (Issue #1770 규칙 승계).
+        let profile = self.document.layout_profile();
         let measurer = HeightMeasurer::new(self.dpi)
-            .with_hwp3_variant(self.document.is_hwp3_variant)
+            .with_hwp3_variant(profile.hwp3_layout())
             .with_hwp3_origin_flow_spacing_before(hwp3_origin_flow_spacing_before);
 
         if self.document.sections.is_empty() {
@@ -3062,15 +3053,12 @@ impl DocumentCore {
                     idx,
                     &measured.tables,
                     section.section_def.hide_empty_line,
-                    self.document.is_hwp3_variant,
+                    profile,
                     hwp3_origin_flow_spacing_before,
                     hwp3_origin_page_tolerance,
                     Some(&section.section_def.footnote_shape),
                     Some(&section.section_def.endnote_shape),
                     force_breaks.get(idx).unwrap_or(&empty_breaks),
-                    matches!(self.source_format, crate::parser::FileFormat::Hwp3),
-                    is_hwpx_source,
-                    is_hwp5_origin_hwpx,
                     endnote_deferral,
                 )
             };
@@ -4337,19 +4325,13 @@ impl DocumentCore {
         self.layout_engine.set_clip_enabled(self.clip_enabled);
         self.layout_engine
             .set_show_control_codes(self.show_control_codes);
+        // [#2403] 소스분기 파생 일원화 — paginate_pass 와 동일하게 layout_profile
+        // 단일 소유 (Issue #1770 규칙 승계). set_layout_profile 의 결합 부수효과
+        // (variant → flow spacing_before)는 다음 줄이 종전 순서대로 덮어쓴다.
         self.layout_engine
-            .set_hwp3_variant(self.document.is_hwp3_variant);
+            .set_layout_profile(self.document.layout_profile());
         self.layout_engine.set_hwp3_origin_flow_spacing_before(
             uses_hwp3_origin_flow_spacing_before(&self.document),
-        );
-        let is_hwp5_origin_hwpx = self
-            .document
-            .hwpx_aux_entry(crate::model::document::HWP5_ORIGIN_HWPX_MARKER_PATH)
-            .is_some();
-        // [Issue #1770] HWPX→HWP 변환본도 HWPX 시멘틱 (paginate_pass 와 동일 규칙).
-        self.layout_engine.set_hwpx_source(
-            (matches!(self.source_format, crate::parser::FileFormat::Hwpx) && !is_hwp5_origin_hwpx)
-                || self.document.is_hwpx_variant,
         );
         self.layout_engine.set_hwpx_page_preview(
             self.document

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -287,8 +287,10 @@ impl Document {
         let hwp5_origin_hwpx = self.hwpx_aux_entry(HWP5_ORIGIN_HWPX_MARKER_PATH).is_some();
         crate::model::provenance::LayoutCompatibilityProfile::new(
             self.provenance.hwp3_lineage,
+            self.provenance.format == SourceFormat::Hwp3,
             (self.provenance.format == SourceFormat::Hwpx && !hwp5_origin_hwpx)
                 || self.provenance.hwpx_lineage,
+            hwp5_origin_hwpx,
         )
     }
 

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -59,6 +59,10 @@ pub struct Document {
     /// tolerance 2.0 vs 64.0px 등)를 HWPX 로 해석해야 같은 IR 이 같은 쪽수가 된다
     /// (roundtrip 자기정합). native HWP5 는 마커가 없어 불변.
     pub is_hwpx_variant: bool,
+    /// [#2403 Stage 1] 문서 출처 서명 — 파서가 확정하는 단일 진실.
+    /// `is_hwp3_variant`/`is_hwpx_variant` 는 shim 으로 존치하며 파서의 같은
+    /// 쓰기 지점에서 동기된다. 레이아웃 분기는 [`Self::layout_profile`] 경유.
+    pub provenance: crate::model::provenance::SourceProvenance,
 }
 
 /// 미리보기 데이터 (PrvImage, PrvText 스트림)
@@ -270,6 +274,22 @@ impl Document {
             .iter()
             .find(|(p, _)| p == path)
             .map(|(_, d)| d.as_slice())
+    }
+
+    /// [#2403 Stage 1] 레이아웃 호환 정책 질의 표면.
+    ///
+    /// 기존 분기의 1:1 파생 — `hwp3_layout` = `is_hwp3_variant`,
+    /// `hwpx_stored_layout` = (HWPX 컨테이너 && rhwp HWP5→HWPX 산출물 마커
+    /// 없음) || rhwp HWPX→HWP 변환본. HWP5→HWPX 마커는 세션 중 부착될 수
+    /// 있어 저장 값이 아닌 현재 문서 상태에서 파생한다.
+    pub fn layout_profile(&self) -> crate::model::provenance::LayoutCompatibilityProfile {
+        use crate::model::provenance::SourceFormat;
+        let hwp5_origin_hwpx = self.hwpx_aux_entry(HWP5_ORIGIN_HWPX_MARKER_PATH).is_some();
+        crate::model::provenance::LayoutCompatibilityProfile::new(
+            self.provenance.hwp3_lineage,
+            (self.provenance.format == SourceFormat::Hwpx && !hwp5_origin_hwpx)
+                || self.provenance.hwpx_lineage,
+        )
     }
 
     /// 외부 이미지 binDataId가 이미 로드되었는지 확인한다.

--- a/src/model/mod.rs
+++ b/src/model/mod.rs
@@ -13,6 +13,7 @@ pub mod image;
 pub mod page;
 pub mod paragraph;
 pub mod path;
+pub mod provenance;
 pub mod shape;
 pub mod style;
 pub mod table;

--- a/src/model/provenance.rs
+++ b/src/model/provenance.rs
@@ -46,21 +46,36 @@ pub struct SourceProvenance {
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
 pub struct LayoutCompatibilityProfile {
     hwp3_layout: bool,
+    hwp3_native_layout: bool,
     hwpx_stored_layout: bool,
+    hwp5_origin_hwpx: bool,
 }
 
 impl LayoutCompatibilityProfile {
-    pub(crate) fn new(hwp3_layout: bool, hwpx_stored_layout: bool) -> Self {
+    pub(crate) fn new(
+        hwp3_layout: bool,
+        hwp3_native_layout: bool,
+        hwpx_stored_layout: bool,
+        hwp5_origin_hwpx: bool,
+    ) -> Self {
         Self {
             hwp3_layout,
+            hwp3_native_layout,
             hwpx_stored_layout,
+            hwp5_origin_hwpx,
         }
     }
 
     /// HWP3 계보 레이아웃 보정(ParaShape 단위 정규화 등) 적용 여부 —
-    /// 기존 `is_hwp3_variant` 분기 동치.
+    /// 기존 `is_hwp3_variant` 분기 동치 (HWP3→HWP5 변환본 휴리스틱).
     pub fn hwp3_layout(&self) -> bool {
         self.hwp3_layout
+    }
+
+    /// 원본이 HWP3 파일인지 — 변환본 휴리스틱과 분리된 HWP3 저장 LINE_SEG
+    /// 계약 분기. 기존 `is_hwp3_source` 동치.
+    pub fn hwp3_native_layout(&self) -> bool {
+        self.hwp3_native_layout
     }
 
     /// 저장 lineseg 를 HWPX 시멘틱으로 해석할지 여부(RowBreak 분할 tolerance
@@ -68,5 +83,11 @@ impl LayoutCompatibilityProfile {
     /// HWP5→HWPX 산출물이 아니거나, rhwp HWPX→HWP 변환본인 경우.
     pub fn hwpx_stored_layout(&self) -> bool {
         self.hwpx_stored_layout
+    }
+
+    /// rhwp 가 HWP5 원본에서 내보낸 HWPX 인지 — HWPX 컨테이너라도 HWP5 원본의
+    /// 저장 행 높이·pagination marker 를 보존한다. 기존 `is_hwp5_origin_hwpx` 동치.
+    pub fn hwp5_origin_hwpx(&self) -> bool {
+        self.hwp5_origin_hwpx
     }
 }

--- a/src/model/provenance.rs
+++ b/src/model/provenance.rs
@@ -1,0 +1,72 @@
+//! [#2403 Stage 1] 문서 출처(provenance)와 레이아웃 호환 정책 표면.
+//!
+//! 소스 포맷·변환 계보 판단은 파싱 시점에 한 번 확정되는 값이다. 이 모듈은
+//! 그 판단의 소유권을 typed 값으로 모은다 — 렌더러/레이아웃은 흩어진 boolean
+//! 필드 대신 [`LayoutCompatibilityProfile`] 질의를 사용한다 (Stage 1 은 기존
+//! 분기의 1:1 기계 대응만, 시멘틱 변경 없음).
+
+/// 파싱된 문서의 원본 컨테이너 포맷.
+///
+/// `parser::FileFormat` 의 감지 전용 항목(DRM/Empty/Unknown)은 파싱된
+/// `Document` 에 도달하지 않으므로 여기 없다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum SourceFormat {
+    /// HWP 5.x 바이너리 (CFB)
+    #[default]
+    Hwp5,
+    /// HWPX (OWPML ZIP)
+    Hwpx,
+    /// HWP 3.x 바이너리
+    Hwp3,
+    /// Standalone HWPML
+    Hml,
+}
+
+/// 문서 출처 서명 — 파서가 확정하며 이후 read-only.
+///
+/// 기존 `Document.is_hwp3_variant`/`is_hwpx_variant` 는 Stage 1 동안 shim 으로
+/// 존치하고 같은 쓰기 지점에서 이 값과 동기된다 (쓰기 지점은 파서 한정).
+/// 생성기/재저장 서명 필드는 #2373 판별자 트랙이 채운다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct SourceProvenance {
+    /// 원본 컨테이너 포맷.
+    pub format: SourceFormat,
+    /// 한컴 HWP3→HWP5 변환본 (휴리스틱 식별, Task #1001) — `is_hwp3_variant` 동치.
+    pub hwp3_lineage: bool,
+    /// rhwp HWPX→HWP 변환본 (`/RhwpHwpxOrigin` 마커, Issue #1770) —
+    /// `is_hwpx_variant` 동치.
+    pub hwpx_lineage: bool,
+}
+
+/// 레이아웃 호환 정책 질의 표면.
+///
+/// Stage 1 은 기존 boolean 분기의 1:1 대응이다 — 질의 이름은 "무엇을 켜는가"
+/// 를 말하고, 값 계산은 [`crate::model::document::Document::layout_profile`] 이
+/// 기존 파생식을 그대로 따른다.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub struct LayoutCompatibilityProfile {
+    hwp3_layout: bool,
+    hwpx_stored_layout: bool,
+}
+
+impl LayoutCompatibilityProfile {
+    pub(crate) fn new(hwp3_layout: bool, hwpx_stored_layout: bool) -> Self {
+        Self {
+            hwp3_layout,
+            hwpx_stored_layout,
+        }
+    }
+
+    /// HWP3 계보 레이아웃 보정(ParaShape 단위 정규화 등) 적용 여부 —
+    /// 기존 `is_hwp3_variant` 분기 동치.
+    pub fn hwp3_layout(&self) -> bool {
+        self.hwp3_layout
+    }
+
+    /// 저장 lineseg 를 HWPX 시멘틱으로 해석할지 여부(RowBreak 분할 tolerance
+    /// 등) — 기존 `is_hwpx_source` 분기 동치: HWPX 컨테이너이면서 rhwp
+    /// HWP5→HWPX 산출물이 아니거나, rhwp HWPX→HWP 변환본인 경우.
+    pub fn hwpx_stored_layout(&self) -> bool {
+        self.hwpx_stored_layout
+    }
+}

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -19,6 +19,11 @@ pub(crate) fn into_document(mut source: HmlSource) -> Result<Document, HmlError>
             },
             ..Default::default()
         },
+        provenance: crate::model::provenance::SourceProvenance {
+            format: crate::model::provenance::SourceFormat::Hml,
+            hwp3_lineage: false,
+            hwpx_lineage: false,
+        },
         ..Default::default()
     };
     document.doc_info.hwpml_version = Some(source.version.clone());

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2860,6 +2860,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
 
     // 기본 Document 껍데기를 생성한다.
     let mut doc = Document::default();
+    doc.provenance.format = crate::model::provenance::SourceFormat::Hwp3;
     // version.major=3: assign_auto_numbers()가 HWP3 문단 카운팅 방식을 사용하도록 표시.
     // 직렬화(serialize_file_header)는 raw_data가 Some이면 개별 필드 대신 raw_data를 사용.
     // → raw_data에 HWP5 헤더를 설정하면 저장 시 올바른 HWP5 CFB 파일이 생성된다.

--- a/src/parser/hwpx/mod.rs
+++ b/src/parser/hwpx/mod.rs
@@ -464,6 +464,11 @@ pub fn parse_hwpx(data: &[u8]) -> Result<Document, HwpxError> {
         hwpx_aux_entries,
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: crate::model::provenance::SourceProvenance {
+            format: crate::model::provenance::SourceFormat::Hwpx,
+            hwp3_lineage: false,
+            hwpx_lineage: false,
+        },
     };
 
     // [Task #873] BinData Link 타입 의 외부 file path 영역 영역 Picture.external_path 영역

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -262,6 +262,11 @@ fn parse_hwp_with_cfb(
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant,
+        provenance: crate::model::provenance::SourceProvenance {
+            format: crate::model::provenance::SourceFormat::Hwp5,
+            hwp3_lineage: false,
+            hwpx_lineage: is_hwpx_variant,
+        },
     };
 
     // 자동 번호 할당 (문서 전체에서 순차적으로)
@@ -283,6 +288,7 @@ fn parse_hwp_with_cfb(
             let cs_r = doc.doc_info.char_shapes.len() as f64 / total_paras as f64;
             if ps_r < 0.20 && cs_r < 0.20 {
                 doc.is_hwp3_variant = true;
+                doc.provenance.hwp3_lineage = true;
                 // [Task #1001 Stage 11] line_segs.vertical_pos /2 보정 revert —
                 // 실제 raw vpos 비교 결과 HWP5 변환본 vpos 는 HWP3 의 2배가 아닌
                 // ~1.15배 (15% 만 차이). /2 fix 시 HWP5 가 HWP3 보다 더 compact 되어
@@ -551,6 +557,11 @@ fn parse_hwp_with_lenient(
         is_hwpx_variant: false,
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
+        provenance: crate::model::provenance::SourceProvenance {
+            format: crate::model::provenance::SourceFormat::Hwp5,
+            hwp3_lineage: false,
+            hwpx_lineage: false,
+        },
     };
 
     assign_auto_numbers(&mut doc);

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1321,12 +1321,11 @@ pub struct LayoutEngine {
     /// (x, y, width, height). 미설정 시 (0, 0, 0, 0) — 호출부에서 col_area로 폴백.
     current_body_area: std::cell::Cell<(f64, f64, f64, f64)>,
     /// HWP3-origin HWP5 변환본 여부.
-    is_hwp3_variant: std::cell::Cell<bool>,
+    /// [#2403] 소스분기 질의 표면 — set_layout_profile 로 배선 (종전 hwp3_variant/
+    /// hwpx_source Cell 2개 통합).
+    profile: std::cell::Cell<crate::model::provenance::LayoutCompatibilityProfile>,
     /// HWP3 원본 및 HWP3-origin HWP5 변환본의 본문 흐름 spacing_before 보정 여부.
     use_hwp3_origin_flow_spacing_before: std::cell::Cell<bool>,
-    /// [Task #1147 v2] HWPX 원본 여부 — 빈 앵커 TopAndBottom 비-TAC 표 직후 갭을
-    /// typeset (host_line_spacing=0) 과 동일하게 0 으로 억제하기 위한 트리거.
-    is_hwpx_source: std::cell::Cell<bool>,
     /// [Task #1728 v2] RowBreak 셀-내 continuation 조각의 첫 가시 문단에서만 set.
     /// 이 문단은 셀-상단(is_column_top)이고 셀-상대 인덱스>0 이지만, 한컴은 앞 간격
     /// (spacing_before)을 유지하므로 column-top 트림을 우회해 전량 적용한다.
@@ -1417,10 +1416,9 @@ impl LayoutEngine {
             show_control_codes: std::cell::Cell::new(false),
             current_paper_width: std::cell::Cell::new(0.0),
             current_body_area: std::cell::Cell::new((0.0, 0.0, 0.0, 0.0)),
-            is_hwp3_variant: std::cell::Cell::new(false),
+            profile: std::cell::Cell::new(Default::default()),
             use_hwp3_origin_flow_spacing_before: std::cell::Cell::new(false),
             keep_continuation_column_top_spacing_before: std::cell::Cell::new(false),
-            is_hwpx_source: std::cell::Cell::new(false),
             hwpx_page_preview: std::cell::RefCell::new(None),
             cell_units_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
             table_nested_text_flag_cache: std::cell::RefCell::new(std::collections::HashMap::new()),
@@ -1735,18 +1733,21 @@ impl LayoutEngine {
         self.numbering_state.borrow_mut().reset();
     }
 
-    pub fn set_hwp3_variant(&self, enabled: bool) {
-        self.is_hwp3_variant.set(enabled);
-        self.use_hwp3_origin_flow_spacing_before.set(enabled);
+    /// [#2403] 소스분기 프로파일 배선 — 종전 set_hwp3_variant + set_hwpx_source
+    /// 통합. set_hwp3_variant 의 결합 부수효과(hwp3 변환본 → flow spacing_before
+    /// 보정 동시 활성)를 그대로 승계한다; 별도 값이 필요한 호출자는 이어서
+    /// set_hwp3_origin_flow_spacing_before 로 덮어쓴다 (rendering 경로 종전 순서).
+    pub fn set_layout_profile(
+        &self,
+        profile: crate::model::provenance::LayoutCompatibilityProfile,
+    ) {
+        self.profile.set(profile);
+        self.use_hwp3_origin_flow_spacing_before
+            .set(profile.hwp3_layout());
     }
 
     pub fn set_hwp3_origin_flow_spacing_before(&self, enabled: bool) {
         self.use_hwp3_origin_flow_spacing_before.set(enabled);
-    }
-
-    /// [Task #1147 v2] HWPX 원본 소스 표시.
-    pub fn set_hwpx_source(&self, enabled: bool) {
-        self.is_hwpx_source.set(enabled);
     }
 
     /// HWPX page preview 이미지를 렌더 fallback용으로 설정한다.
@@ -4389,7 +4390,7 @@ impl LayoutEngine {
             col_content.endnote_flow && col_content.start_height < -0.5,
             col_content.endnote_flow,
         );
-        hcursor.suppress_hwpx_stale_forward = self.is_hwpx_source.get();
+        hcursor.suppress_hwpx_stale_forward = self.profile.get().hwpx_stored_layout();
         // [Task #1246] 미주 흐름 컬럼에만 between-notes 마진(HU)을 주입 → HeightCursor 가 새 미주
         // 제목 forward 흐름의 min-gap 보정에 사용. 본문 컬럼은 0 (무영향).
         if col_content.endnote_flow {
@@ -6328,7 +6329,7 @@ impl LayoutEngine {
                     iy
                 } else if is_current_visible_para_float {
                     let v_off = hwpunit_to_px(signed_hwpunit(t.common.vertical_offset), self.dpi);
-                    if self.is_hwpx_source.get() && v_off <= 0.0 {
+                    if self.profile.get().hwpx_stored_layout() && v_off <= 0.0 {
                         let flow_at_para_start = (table_y_before - para_y_for_table).abs() < 0.5;
                         table_y_before
                             + if flow_at_para_start {
@@ -6510,7 +6511,7 @@ impl LayoutEngine {
                 y_offset = if is_current_visible_para_float {
                     if signed_hwpunit(t.common.vertical_offset) > 0 {
                         table_y_before
-                    } else if self.is_hwpx_source.get() {
+                    } else if self.profile.get().hwpx_stored_layout() {
                         let following_non_positive =
                             has_following_non_positive_visible_float(para, control_index);
                         let inter_float_gap = if following_non_positive {

--- a/src/renderer/layout/paragraph_layout.rs
+++ b/src/renderer/layout/paragraph_layout.rs
@@ -2891,11 +2891,11 @@ impl LayoutEngine {
                 .map(|seg| hwpunit_to_px(seg.text_height, self.dpi))
                 .unwrap_or(0.0);
             let use_stored_text_height = para.map(|p| p.controls.is_empty()).unwrap_or(false)
-                && (self.is_hwpx_source.get() || cell_ctx.is_none());
+                && (self.profile.get().hwpx_stored_layout() || cell_ctx.is_none());
             let source_metrics_reflow_eligible = para
                 .map(|p| crate::renderer::controls_mark_section_start(&p.controls))
                 .unwrap_or(false)
-                && self.is_hwpx_source.get();
+                && self.profile.get().hwpx_stored_layout();
             let source_metrics_reflowed = crate::renderer::source_line_metrics_need_reflow(
                 raw_lh,
                 raw_text_height,
@@ -3212,7 +3212,11 @@ impl LayoutEngine {
             // available_width 의 effective indent 를 불변 유지: 변환본은 scale 을 절반으로.
             // (종전: IR(half)×2.0=full → 현재: IR(full)×1.0=full)
             let equation_indent_scale = (if cell_ctx.is_some() { 1.0 } else { 2.0 })
-                * if self.is_hwp3_variant.get() { 0.5 } else { 1.0 };
+                * if self.profile.get().hwp3_layout() {
+                    0.5
+                } else {
+                    1.0
+                };
             let equation_first_effective_margin_left =
                 crate::renderer::equation_tac_flow::paragraph_effective_margin_left_with_indent_scale(
                     margin_left,
@@ -3742,7 +3746,11 @@ impl LayoutEngine {
                     is_last_line_of_para,
                     defer_empty_line_control_marker,
                     equation_tac_extra_rows,
-                    hwp3_indent_scale: if self.is_hwp3_variant.get() { 0.5 } else { 1.0 },
+                    hwp3_indent_scale: if self.profile.get().hwp3_layout() {
+                        0.5
+                    } else {
+                        1.0
+                    },
                     section_index,
                     para_index,
                 },

--- a/src/renderer/layout/shape_layout.rs
+++ b/src/renderer/layout/shape_layout.rs
@@ -444,7 +444,7 @@ impl LayoutEngine {
         bbox: BoundingBox,
         cfb_data: &[u8],
     ) -> bool {
-        if !self.is_hwpx_source.get()
+        if !self.profile.get().hwpx_stored_layout()
             || !crate::parser::ole_container::is_hmapsi_ole_container(cfb_data)
         {
             return false;

--- a/src/renderer/layout/table_layout.rs
+++ b/src/renderer/layout/table_layout.rs
@@ -1895,7 +1895,9 @@ impl LayoutEngine {
                 self.calc_para_lines_height(
                     &comp.lines,
                     p,
-                    self.is_hwp3_variant.get() && p.line_segs.is_empty() && !p.text.is_empty(),
+                    self.profile.get().hwp3_layout()
+                        && p.line_segs.is_empty()
+                        && !p.text.is_empty(),
                     !p.line_segs.is_empty(),
                     pidx,
                     cell_para_count,
@@ -1927,7 +1929,7 @@ impl LayoutEngine {
                 self.calc_para_lines_height(
                     &comp.lines,
                     para,
-                    self.is_hwp3_variant.get()
+                    self.profile.get().hwp3_layout()
                         && para.line_segs.is_empty()
                         && !para.text.is_empty(),
                     !para.line_segs.is_empty(),
@@ -4277,7 +4279,7 @@ impl LayoutEngine {
         styles: &ResolvedStyleSet,
     ) -> f64 {
         let measurer = super::super::height_measurer::HeightMeasurer::new(self.dpi)
-            .with_hwp3_variant(self.is_hwp3_variant.get());
+            .with_hwp3_variant(self.profile.get().hwp3_layout());
         measurer.cell_controls_height(&cell.paragraphs, styles, 0, 0.0)
     }
 
@@ -4852,7 +4854,7 @@ impl LayoutEngine {
                                 max_fs,
                                 ps.line_spacing_type,
                                 ps.line_spacing,
-                                self.is_hwp3_variant.get()
+                                self.profile.get().hwp3_layout()
                                     && para.line_segs.is_empty()
                                     && !para.text.is_empty(),
                             )
@@ -5209,7 +5211,7 @@ impl LayoutEngine {
             let raw_spacing_before = para_style.map(|s| s.spacing_before).unwrap_or(0.0);
             let spacing_before = if pi > 0 {
                 raw_spacing_before
-            } else if self.is_hwpx_source.get()
+            } else if self.profile.get().hwpx_stored_layout()
                 && is_block_rowbreak
                 && para_uses_synthetic_line_segs
             {
@@ -5308,7 +5310,10 @@ impl LayoutEngine {
                 // [Task #1811] HWPX RowBreak 셀의 synthetic lineSeg 는 저장 근거가 아니라
                 // reflow 산물이다. row cut 측정에서 다시 corrected_line_height 를 적용하면
                 // HWP 기준보다 줄 유닛이 커져 p4→p5 split 이 한 유닛 빨라진다.
-                if self.is_hwpx_source.get() && is_block_rowbreak && para_uses_synthetic_line_segs {
+                if self.profile.get().hwpx_stored_layout()
+                    && is_block_rowbreak
+                    && para_uses_synthetic_line_segs
+                {
                     return raw_lh;
                 }
                 // [#2112] 실제 저장 LINE_SEG 를 보유한 셀 문단은 저장 줄높이를 신뢰한다.
@@ -5825,9 +5830,10 @@ impl LayoutEngine {
                             let target_top = normalized_vpos_px(seg.vertical_pos);
                             if target_top > unit_cum {
                                 let delta = target_top - unit_cum;
-                                let suppress_hwpx_mixed_nested_gap = self.is_hwpx_source.get()
-                                    && prev_para_has_mixed_nested_table
-                                    && delta <= 24.0;
+                                let suppress_hwpx_mixed_nested_gap =
+                                    self.profile.get().hwpx_stored_layout()
+                                        && prev_para_has_mixed_nested_table
+                                        && delta <= 24.0;
                                 if !suppress_hwpx_mixed_nested_gap {
                                     para_h += delta;
                                     vpos_gap_before = true;
@@ -5904,10 +5910,11 @@ impl LayoutEngine {
                                 let target_top = normalized_vpos_px(seg.vertical_pos);
                                 if target_top > unit_cum {
                                     let delta = target_top - unit_cum;
-                                    let suppress_hwpx_mixed_nested_gap = self.is_hwpx_source.get()
-                                        && li == 0
-                                        && prev_para_has_mixed_nested_table
-                                        && delta <= 24.0;
+                                    let suppress_hwpx_mixed_nested_gap =
+                                        self.profile.get().hwpx_stored_layout()
+                                            && li == 0
+                                            && prev_para_has_mixed_nested_table
+                                            && delta <= 24.0;
                                     if !suppress_hwpx_mixed_nested_gap {
                                         lh += delta;
                                         vpos_gap_before = true;
@@ -6283,7 +6290,8 @@ impl LayoutEngine {
             crate::model::table::TablePageBreak::RowBreak
         ) && (table.col_count <= 2 || table.row_count > 5)
             && !row_has_top_and_bottom_flow;
-        let allow_midpage_reset_absorb = self.is_hwpx_source.get() || row_has_top_and_bottom_flow;
+        let allow_midpage_reset_absorb =
+            self.profile.get().hwpx_stored_layout() || row_has_top_and_bottom_flow;
         let rewind_internal_hard_break_orphan = Self::row_has_prior_rowspan_cover(table, row);
         for (i, cell) in row_cells.iter().enumerate() {
             let units = self.cell_units(cell, table, styles);
@@ -6486,7 +6494,8 @@ impl LayoutEngine {
             crate::model::table::TablePageBreak::RowBreak
         ) && (table.col_count <= 2 || table.row_count > 5)
             && !block_has_top_and_bottom_flow;
-        let allow_midpage_reset_absorb = self.is_hwpx_source.get() || block_has_top_and_bottom_flow;
+        let allow_midpage_reset_absorb =
+            self.profile.get().hwpx_stored_layout() || block_has_top_and_bottom_flow;
         for (i, cell) in cells.iter().enumerate() {
             let units = self.cell_units(cell, table, styles);
             let start = start_cut.get(i).copied().unwrap_or(0).min(units.len());
@@ -8282,7 +8291,9 @@ mod row_cut_tests {
         // HWPX 저장 LINE_SEG vpos 리셋이어도 페이지 절반 이상이 남은 중간 리셋이면
         // 로컬 좌표 재시작으로 보고 같은 쪽에 이어 담는다.
         let eng = LayoutEngine::new(96.0);
-        eng.set_hwpx_source(true);
+        eng.set_layout_profile(crate::model::provenance::LayoutCompatibilityProfile::new(
+            false, false, true, false,
+        ));
         let styles = ResolvedStyleSet::default();
         let t = rowbreak_table(vec![cell(
             0,
@@ -8303,7 +8314,9 @@ mod row_cut_tests {
         // 같은 HWPX 저장 리셋이라도 이미 페이지 하단 근처까지 채운 경우에는
         // 한컴 저장 쪽 경계로 보존한다.
         let eng = LayoutEngine::new(96.0);
-        eng.set_hwpx_source(true);
+        eng.set_layout_profile(crate::model::provenance::LayoutCompatibilityProfile::new(
+            false, false, true, false,
+        ));
         let styles = ResolvedStyleSet::default();
         let t = rowbreak_table(vec![cell(
             0,

--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -360,11 +360,9 @@ struct HostSpacing {
 /// 단일 패스 조판 엔진
 pub struct TypesetEngine {
     dpi: f64,
-    /// 현재 조판 중인 입력이 HWPX 원본인지 여부.
-    is_hwpx_source: std::cell::Cell<bool>,
-    /// [Task #1472] HWP3-origin 변환본 여부 — format_paragraph 의 미주 TAC 수식
-    /// indent_scale 보정(effective indent 불변)에 사용. typeset 진입 시 set.
-    is_hwp3_variant: std::cell::Cell<bool>,
+    /// [#2403] 현재 조판 입력의 레이아웃 호환 프로파일 — typeset 진입 시 set.
+    /// (HWPX 저장 시멘틱·HWP3 변환본 판단 등 소스분기의 단일 질의 표면.)
+    profile: std::cell::Cell<crate::model::provenance::LayoutCompatibilityProfile>,
 }
 
 /// 조판 중 현재 페이지/단 상태
@@ -474,17 +472,13 @@ struct TypesetState {
     /// 페이지가 수 px over-fill 되어 tail 이 밀리는 케이스(국제고속선기준 pi=718/995/1789/2128).
     /// 한글은 tail 을 본문 하단(여백 침범 무시)에 배치하므로 tail 에 한해 소량 초과를 허용한다.
     tail_overflow_tolerance_once: f64,
-    /// [Task #1007] HWP3-origin HWP5 변환본 여부 — widow 방지 등 variant-specific
-    /// behavior 분기에 사용.
-    is_hwp3_variant: bool,
-    /// 원본 HWP3 파일 여부 — HWP5 변환본 휴리스틱과 분리해 HWP3 저장 LINE_SEG 계약에 사용.
-    is_hwp3_source: bool,
-    /// [Task #1147] HWPX 원본 여부 — HWPX 의 LINE_SEG 시멘틱은 빈 앵커 TopAndBottom 표에서
-    /// host_line_spacing 을 표 다음 갭으로 더하지 않음. HWP5/HWP3 와 분리.
-    is_hwpx_source: bool,
-    /// rhwp가 HWP5 원본에서 내보낸 HWPX 여부. HWPX 컨테이너라도 HWP5 원본의
-    /// 저장 행 높이와 pagination marker를 보존해야 한다.
-    is_hwp5_origin_hwpx: bool,
+    /// [#2403] 소스분기 질의 표면 — 단일 소유, typeset 진입 시 set. 종전 4필드의
+    /// 시멘틱 승계: hwp3_layout()=HWP3→HWP5 변환본(widow 방지 등 variant 분기,
+    /// Task #1007) / hwp3_native_layout()=원본 HWP3 (저장 LINE_SEG 계약) /
+    /// hwpx_stored_layout()=HWPX 원본 (빈 앵커 TAC 표 host_line_spacing 미가산,
+    /// Task #1147) / hwp5_origin_hwpx()=rhwp HWP5→HWPX 산출물 (HWP5 저장 행높이·
+    /// pagination marker 보존).
+    profile: crate::model::provenance::LayoutCompatibilityProfile,
     /// 문서 전체에 실제 저장 LineSeg가 있는지 여부. HWP5-origin CFB라도 LineSeg가 전부
     /// 비어 있으면 저장 vpos 기반 흐름이 아니라 재조판 흐름으로 취급한다.
     has_stored_line_segs: bool,
@@ -1775,10 +1769,7 @@ impl TypesetState {
             skip_safety_margin_once: false,
             skip_footnote_margin_once: false,
             tail_overflow_tolerance_once: 0.0,
-            is_hwp3_variant: false,
-            is_hwp3_source: false,
-            is_hwpx_source: false,
-            is_hwp5_origin_hwpx: false,
+            profile: Default::default(),
             has_stored_line_segs: false,
             hide_empty_line: false,
             hidden_empty_lines: 0,
@@ -2036,7 +2027,7 @@ impl TypesetState {
             return;
         }
 
-        let use_overlap_probe = self.is_hwpx_source && probe_height > 0.0;
+        let use_overlap_probe = self.profile.hwpx_stored_layout() && probe_height > 0.0;
         self.visible_float_exclusions
             .retain(|zone| self.current_height < zone.bottom - 0.5);
 
@@ -2336,8 +2327,7 @@ impl TypesetEngine {
     pub fn new(dpi: f64) -> Self {
         Self {
             dpi,
-            is_hwpx_source: std::cell::Cell::new(false),
-            is_hwp3_variant: std::cell::Cell::new(false),
+            profile: std::cell::Cell::new(Default::default()),
         }
     }
 
@@ -2512,15 +2502,12 @@ impl TypesetEngine {
             section_index,
             measured_tables,
             hide_empty_line,
-            false,
+            Default::default(),
             false,
             false,
             None,
             None,
             force_break_before,
-            false,
-            false,
-            false,
             EndnoteDeferral::None,
         )
     }
@@ -3029,19 +3016,17 @@ impl TypesetEngine {
         section_index: usize,
         measured_tables: &[MeasuredTable],
         hide_empty_line: bool,
-        is_hwp3_variant: bool,
+        profile: crate::model::provenance::LayoutCompatibilityProfile,
         skip_spacing_before_prededuct: bool,
         hwp3_origin_page_tolerance: bool,
         footnote_shape: Option<&FootnoteShape>,
         endnote_shape: Option<&FootnoteShape>,
         force_break_before: &std::collections::HashSet<usize>,
-        is_hwp3_source: bool,
-        is_hwpx_source: bool,
-        is_hwp5_origin_hwpx: bool,
         endnote_deferral: EndnoteDeferral<'_>,
     ) -> PaginationResult {
         let layout = PageLayoutInfo::from_page_def(page_def, column_def, self.dpi);
-        self.is_hwpx_source.set(is_hwpx_source);
+        // [#2403] 소스분기 프로파일 — 엔진(Cell)과 state 에 한 번에 배선.
+        self.profile.set(profile);
         let col_count = column_def.column_count.max(1);
         let default_footnote_shape = FootnoteShape::default();
         let footnote_shape = footnote_shape.unwrap_or(&default_footnote_shape);
@@ -3050,7 +3035,7 @@ impl TypesetEngine {
             footnote_between_notes_margin_px(footnote_shape, self.dpi);
         let footnote_safety_margin = hwpunit_to_px(3000, self.dpi);
         // [Task #1007] variant cross-paragraph vpos reset THRESHOLD 계산용 body height (HU)
-        let body_height_hu_for_variant: i32 = if is_hwp3_variant {
+        let body_height_hu_for_variant: i32 = if profile.hwp3_layout() {
             page_def.height.saturating_sub(
                 page_def
                     .margin_top
@@ -3074,12 +3059,7 @@ impl TypesetEngine {
             column_def.column_type,
         );
         st.hide_empty_line = hide_empty_line;
-        st.is_hwp3_variant = is_hwp3_variant;
-        st.is_hwp3_source = is_hwp3_source;
-        // [Task #1472] format_paragraph 의 미주 수식 indent_scale 보정용.
-        self.is_hwp3_variant.set(is_hwp3_variant);
-        st.is_hwpx_source = is_hwpx_source;
-        st.is_hwp5_origin_hwpx = is_hwp5_origin_hwpx;
+        st.profile = profile;
         st.has_stored_line_segs = paragraphs
             .iter()
             .any(|p| p.line_segs.iter().any(|ls| !is_synthetic_line_seg(ls)));
@@ -3240,7 +3220,7 @@ impl TypesetEngine {
             // sample16-2022 pi=87 (빈 문단, text_len=0) skip ✓
             // sample16-2022 pi=118 (content, sb=284) skip ✓
             // sample16-2022 pi=316 (content, sb=0) skip ✓
-            let variant_vpos_reset_break = is_hwp3_variant
+            let variant_vpos_reset_break = profile.hwp3_layout()
                 && self.judge_hwp3_variant_vpos_reset_break(
                     para,
                     paragraphs,
@@ -3405,7 +3385,7 @@ impl TypesetEngine {
                                 && para_has_visible_text(next_para)
                                 && next_sb_hu >= 500
                         });
-                    let hwp3_content_vpos_zero_reset = is_hwp3_variant
+                    let hwp3_content_vpos_zero_reset = profile.hwp3_layout()
                         && st.col_count == 1
                         && cv == 0
                         && prev_vpos_end > body_height_hu_for_variant * 70 / 100
@@ -3467,7 +3447,7 @@ impl TypesetEngine {
                         para,
                         next_para,
                         st.col_count,
-                        st.is_hwp3_variant,
+                        st.profile.hwp3_layout(),
                     )
                 }
             } else {
@@ -3494,7 +3474,7 @@ impl TypesetEngine {
                             mid,
                             after,
                             st.col_count,
-                            st.is_hwp3_variant,
+                            st.profile.hwp3_layout(),
                         )
                 };
             if tail_before_break_through_empty {
@@ -3538,7 +3518,7 @@ impl TypesetEngine {
                                 prev,
                                 next_para,
                                 st.col_count,
-                                st.is_hwp3_variant,
+                                st.profile.hwp3_layout(),
                             );
                         let high_tail_heading_then_reset = para_has_visible_text(next_para)
                             && next_para.controls.is_empty()
@@ -3556,7 +3536,7 @@ impl TypesetEngine {
                                         next_para,
                                         after,
                                         st.col_count,
-                                        st.is_hwp3_variant,
+                                        st.profile.hwp3_layout(),
                                     )
                             });
 
@@ -3979,7 +3959,7 @@ impl TypesetEngine {
                     // p4 +16.6px 팬텀 → sliver 쪽 +2). lh 가 개체를 못 담는 일반
                     // 케이스는 종전대로 무효화. HWPX(기계생성 결재문서 계열) 한정 —
                     // HWP5 native 는 종전 핀 보존 (issue_1418 2026_oss_rst 6쪽).
-                    let host_line_covers_object = st.is_hwpx_source
+                    let host_line_covers_object = st.profile.hwpx_stored_layout()
                         && matches!(last, Some(PageItem::Table { .. }))
                         && para.line_segs.first().is_some_and(|s| {
                             s.tag & crate::model::paragraph::LineSeg::TAG_IMPLEMENTATION_PROPERTY
@@ -10915,7 +10895,7 @@ impl TypesetEngine {
             allow_vpos_rewind: false,
             allow_start_height_backtrack: false,
             suppress_large_forward_jump: false,
-            suppress_hwpx_stale_forward: st.is_hwpx_source,
+            suppress_hwpx_stale_forward: st.profile.hwpx_stored_layout(),
             endnote_between_notes_hu: 0,
             prev_item_content_bottom_y: None,
             last_compacted_endnote_title_gap: false,
@@ -10932,7 +10912,7 @@ impl TypesetEngine {
         // 하니스 실측: 36398709 문단당 −5.0pt 균일 = sb 6.7px) 스냅으로 되감지
         // 않는다. 스텝-검사 없이 ±2px 우연 일치만으로 스킵하면 sb-포함 정상
         // ladder 에서 이중 가산(+1쪽 과다, issue_1853 실측 반증)이 난다.
-        if st.is_hwpx_source
+        if st.profile.hwpx_stored_layout()
             && spacing_before_px > 0.5
             && y < st.current_height
             && (st.current_height - y - spacing_before_px).abs() < 2.0
@@ -11080,7 +11060,12 @@ impl TypesetEngine {
                 })
             };
             // [Task #1472] 변환본은 미주 수식 effective indent 불변 위해 scale 절반(2.0→1.0).
-            let eq_indent_scale = 2.0 * if self.is_hwp3_variant.get() { 0.5 } else { 1.0 };
+            let eq_indent_scale = 2.0
+                * if self.profile.get().hwp3_layout() {
+                    0.5
+                } else {
+                    1.0
+                };
             let equation_line_available_width_px = |visual_line_idx: usize| {
                 column_width_px.map(|cw| {
                     let margin_l = para_style.map(|s| s.margin_left).unwrap_or(0.0);
@@ -11264,7 +11249,7 @@ impl TypesetEngine {
                     para,
                     styles,
                     para_style,
-                    self.is_hwp3_variant.get(),
+                    self.profile.get().hwp3_layout(),
                 ) {
                     pairs.push(metric);
                 }
@@ -11296,7 +11281,7 @@ impl TypesetEngine {
             para,
             styles,
             para_style,
-            self.is_hwp3_variant.get(),
+            self.profile.get().hwp3_layout(),
         ) {
             (vec![lh], vec![ls])
         } else {
@@ -11321,7 +11306,7 @@ impl TypesetEngine {
                 para,
                 styles,
                 para_style,
-                self.is_hwp3_variant.get(),
+                self.profile.get().hwp3_layout(),
             )
             .unwrap_or((hwpunit_to_px(400, self.dpi), 0.0));
             line_heights = vec![lh];
@@ -11432,7 +11417,7 @@ impl TypesetEngine {
         } else {
             layout_drift_safety_px
         };
-        let exclusion_probe_height = if st.is_hwpx_source {
+        let exclusion_probe_height = if st.profile.hwpx_stored_layout() {
             fmt.line_heights
                 .first()
                 .zip(fmt.line_spacings.first())
@@ -11595,7 +11580,7 @@ impl TypesetEngine {
             fmt.line_heights.len(),
             st.layout.body_area.height,
             self.dpi,
-            st.is_hwp3_source,
+            st.profile.hwp3_native_layout(),
         )
         .or_else(|| {
             sample16_missing_lineseg_tail_break_line(
@@ -11621,7 +11606,7 @@ impl TypesetEngine {
         // HWP3-origin 변환본은 spacing_before 누적을 보존해야 dump-pages 요약과
         // 실제 한컴 줄 흐름이 유지된다(#1116).
         let trim_spacing_before_for_flow =
-            !st.is_hwp3_variant && !para_near_rowbreak_table(paragraphs, para_idx);
+            !st.profile.hwp3_layout() && !para_near_rowbreak_table(paragraphs, para_idx);
 
         let current_page_vpos_base = st.vpos_page_base.or_else(|| {
             st.current_items
@@ -11804,7 +11789,7 @@ impl TypesetEngine {
                     prior_para,
                     next_para,
                     st.col_count,
-                    st.is_hwp3_variant,
+                    st.profile.hwp3_layout(),
                 ) {
                     forced = true;
                     break;
@@ -11938,7 +11923,7 @@ impl TypesetEngine {
         // 첫 줄이 이전 쪽 말미에 남는다 (3024019 pi22: ls[0] vpos=700, 한글도
         // 문단 전체를 새 쪽 배치). 전체 배치가 이미 실패한 분할 직전에만 적용해
         // 일반 흐름(#418/#321 보수 기준)은 건드리지 않는다.
-        let current_page_has_stale_hwpx_line_metrics = st.is_hwpx_source
+        let current_page_has_stale_hwpx_line_metrics = st.profile.hwpx_stored_layout()
             && st
                 .current_items
                 .iter()
@@ -12224,7 +12209,7 @@ impl TypesetEngine {
         // oracle p13→p12). 의미 필드 + 소스 게이트로 교체: native 는 비트⇔열거형
         // 전단사(shape.rs:394)로 불변, 순수 HWPX 는 종전에도 미진입으로 불변,
         // convert-HWP 만 HWPX 렌더 경로로 정합된다(#1886 origin 전달의 연장).
-        let table_wrap_take_place = !self.is_hwpx_source.get()
+        let table_wrap_take_place = !self.profile.get().hwpx_stored_layout()
             && matches!(
                 table.common.text_wrap,
                 crate::model::shape::TextWrap::TopAndBottom
@@ -13239,7 +13224,7 @@ impl TypesetEngine {
             // 일치). 이때 cap 을 fmt.total 로 올리고 ladder 를 dirty 로 표시해
             // 후속 스냅이 성장분을 압축 anchor 로 되감지 못하게 한다. 스텝이
             // fmt.total 과 일치(±1px)하는 정상 생성기 ladder 는 불변.
-            let stored_step_px = if st.is_hwpx_source && para.text.is_empty() {
+            let stored_step_px = if st.profile.hwpx_stored_layout() && para.text.is_empty() {
                 para.line_segs
                     .first()
                     .filter(|s| {
@@ -13693,7 +13678,7 @@ impl TypesetEngine {
         // 후속 문단 스냅이 드리프트 역산 lazy base(-796HU 등)로 고착되던 결함.
         // 저장 lineseg 가 개체 높이를 온전히 포함하는 호스트(기계생성 결재문서
         // lh = 표 + outMargin)로 한정한다.
-        if st.is_hwpx_source
+        if st.profile.hwpx_stored_layout()
             && st.col_count == 1
             && st.current_items.is_empty()
             && pre_height <= 0.5
@@ -13740,7 +13725,7 @@ impl TypesetEngine {
             let outer_top_px = hwpunit_to_px(table.outer_margin_top as i32, self.dpi);
             let table_top = if signed_vertical_offset > 0 {
                 para_start_height + outer_top_px + v_off_px
-            } else if st.is_hwpx_source {
+            } else if st.profile.hwpx_stored_layout() {
                 // HWPX visible float 는 같은 문단 안의 앞선 float 뒤에 이어 쌓인다.
                 // B/C처럼 둘 다 non-positive offset 이면 문단 시작점이 아니라 현재 흐름
                 // 높이를 기준으로 reserve 해야 layout 의 세로 stacking 과 page break 가 맞는다.
@@ -13767,7 +13752,7 @@ impl TypesetEngine {
             } else {
                 let following_non_positive =
                     has_following_non_positive_visible_float(para, ctrl_idx);
-                let inter_float_gap = if st.is_hwpx_source && following_non_positive {
+                let inter_float_gap = if st.profile.hwpx_stored_layout() && following_non_positive {
                     para_line_spacing_px(para, self.dpi)
                 } else {
                     0.0
@@ -13776,7 +13761,7 @@ impl TypesetEngine {
             }
         } else if tac_wrap_split {
             st.current_height += table_total_height;
-        } else if let Some(host_line_px) = if st.is_hwpx_source && is_last_placed {
+        } else if let Some(host_line_px) = if st.profile.hwpx_stored_layout() && is_last_placed {
             // [#2279 10k] host 빈 줄박스는 **문단당 1개** — 다중 표 문단에서
             // 표마다 가산하면 중간 표 배치의 fit 이 과대해져 후속 표가 조기
             // 개행된다 (156767148 보도자료 pi7: 표2개 문단, 한글 1쪽 vs +1쪽,
@@ -14042,7 +14027,7 @@ impl TypesetEngine {
         // [Task #1811] HWPX 의 누적좌표 RowBreak 문서는 host 줄 pre-emit 자체를
         // 저장 vpos 가드보다 먼저 수행한다. 쪽 내부 vpos 를 가진 HWP/HWP3/일반 HWPX
         // 경로는 기존처럼 같은 쪽 저장 flow 확인 뒤에만 pre-emit 한다.
-        let pre_emit_before_vpos_check = st.is_hwpx_source && host_vpos > body_h_hu;
+        let pre_emit_before_vpos_check = st.profile.hwpx_stored_layout() && host_vpos > body_h_hu;
         if pre_emit_before_vpos_check
             && !self.pre_emit_visible_rowbreak_host_text(st, para_idx, para, composed_all, styles)
         {
@@ -14083,7 +14068,7 @@ impl TypesetEngine {
                 break;
             }
             let trim_sb =
-                !st.is_hwp3_variant && !para_near_rowbreak_table(paragraphs_all, next_idx);
+                !st.profile.hwp3_layout() && !para_near_rowbreak_table(paragraphs_all, next_idx);
             st.current_items.push(PageItem::FullParagraph {
                 para_index: next_idx,
             });
@@ -14888,7 +14873,7 @@ impl TypesetEngine {
         let declared_object_total = raw_table_ctrl_height_px(table, self.dpi)
             .unwrap_or_else(|| hwpunit_to_px(table.common.height as i32, self.dpi).max(0.0))
             + host_spacing_total;
-        let declared_empty_para_float_total = if !st.is_hwpx_source
+        let declared_empty_para_float_total = if !st.profile.hwpx_stored_layout()
             && !table.common.treat_as_char
             && is_para_topbottom_float(&table.common)
             && !para_has_visible_text(para)
@@ -15558,8 +15543,7 @@ impl TypesetEngine {
         // [Task #993] advance_row_cut 호출용 LayoutEngine — 컷 측정은 dpi 와
         // 셀 패딩/중첩 표 높이 계산에만 의존하므로 ad hoc 인스턴스로 충분하다.
         let layout_engine = crate::renderer::layout::LayoutEngine::new(self.dpi);
-        layout_engine.set_hwp3_variant(st.is_hwp3_variant);
-        layout_engine.set_hwpx_source(st.is_hwpx_source);
+        layout_engine.set_layout_profile(st.profile);
         // [Task #993] rowspan(row_span>1) 셀이 걸친 행 — 컷 모델(advance_row_cut)은
         // row_span==1 셀만 다루므로 rowspan 셀 높이를 측정하지 못한다. 구현계획서
         // §4대로 rowspan 행은 MeasuredTable 행 높이를 권위로 쓴다(렌더러도 동일).
@@ -15868,7 +15852,7 @@ impl TypesetEngine {
                 seg.vertical_pos
                     > crate::renderer::px_to_hwpunit(st.layout.body_area.height, self.dpi)
             });
-        if st.is_hwpx_source
+        if st.profile.hwpx_stored_layout()
             && host_vpos_is_cumulative
             && !table.common.treat_as_char
             && is_para_topbottom_float(&table.common)
@@ -16076,23 +16060,23 @@ impl TypesetEngine {
             const HWPX_LANDSCAPE_ROWBREAK_SHORT_ROW_TOLERANCE_PX: f64 = 320.0;
             const HWPX_LANDSCAPE_ROWBREAK_SHORT_ROW_MAX_HEIGHT_PX: f64 = 320.0;
             let landscape_rowbreak_bleed = st.layout.body_area.height < 700.0;
-            let landscape_whole_row_tolerance = if st.is_hwpx_source {
+            let landscape_whole_row_tolerance = if st.profile.hwpx_stored_layout() {
                 HWPX_LANDSCAPE_ROWBREAK_WHOLE_ROW_TOLERANCE_PX
             } else {
                 LANDSCAPE_ROWBREAK_WHOLE_ROW_TOLERANCE_PX
             };
-            let landscape_short_row_tolerance = if st.is_hwpx_source {
+            let landscape_short_row_tolerance = if st.profile.hwpx_stored_layout() {
                 HWPX_LANDSCAPE_ROWBREAK_SHORT_ROW_TOLERANCE_PX
             } else {
                 LANDSCAPE_ROWBREAK_SHORT_ROW_TOLERANCE_PX
             };
-            let landscape_short_row_max_height = if st.is_hwpx_source {
+            let landscape_short_row_max_height = if st.profile.hwpx_stored_layout() {
                 HWPX_LANDSCAPE_ROWBREAK_SHORT_ROW_MAX_HEIGHT_PX
             } else {
                 LANDSCAPE_ROWBREAK_SHORT_ROW_MAX_HEIGHT_PX
             };
             let rowbreak_split_row_overflow_tolerance =
-                if st.is_hwpx_source || !st.has_stored_line_segs {
+                if st.profile.hwpx_stored_layout() || !st.has_stored_line_segs {
                     HWPX_ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE_PX
                 } else {
                     ROWBREAK_SPLIT_ROW_OVERFLOW_TOLERANCE_PX
@@ -17515,15 +17499,12 @@ mod tests {
             0,
             &[],
             false,
-            false,
+            Default::default(),
             false,
             false,
             Some(&shape),
             None,
             &std::collections::HashSet::new(),
-            false,
-            false,
-            false,
             EndnoteDeferral::None,
         );
 

--- a/src/serializer/cfb_writer/tests.rs
+++ b/src/serializer/cfb_writer/tests.rs
@@ -70,6 +70,7 @@ fn test_serialize_hwp_cfb_streams() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     let bytes = serialize_hwp(&doc).unwrap();
@@ -114,6 +115,7 @@ fn test_serialize_hwp_compressed() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     let bytes = serialize_hwp(&doc).unwrap();
@@ -215,6 +217,7 @@ fn test_full_roundtrip_uncompressed() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     // Document → HWP bytes
@@ -294,6 +297,7 @@ fn test_full_roundtrip_compressed() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     // Document → HWP bytes (compressed)
@@ -1686,6 +1690,7 @@ fn test_ole_storage_size_prefix_restored() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     let bytes = serialize_hwp(&doc).unwrap();
@@ -1772,6 +1777,7 @@ fn test_compressed_ole_storage_payload_is_deflated() {
         hwpx_aux_entries: Vec::new(),
         is_hwp3_variant: false,
         is_hwpx_variant: false,
+        provenance: Default::default(),
     };
 
     let bytes = serialize_hwp(&doc).unwrap();

--- a/tests/issue_2403_provenance_stage1.rs
+++ b/tests/issue_2403_provenance_stage1.rs
@@ -1,0 +1,94 @@
+//! [#2403 Stage 1] SourceProvenance / LayoutCompatibilityProfile 등가성 가드.
+//!
+//! 파서가 확정한 provenance 가 shim(legacy boolean)과 동기이고, layout_profile()
+//! 질의가 기존 파생식과 정확히 같은 값을 내는지 포맷별 실샘플로 고정한다.
+//! 이 가드가 있어야 2단계(치환 이관)가 behavior 불변임을 등가로 환원할 수 있다.
+
+use rhwp::model::document::{Document, HWP5_ORIGIN_HWPX_MARKER_PATH};
+use rhwp::model::provenance::SourceFormat;
+use rhwp::parser::parse_document;
+
+fn load(path: &str) -> Document {
+    let data = std::fs::read(path).unwrap_or_else(|e| panic!("{path}: {e}"));
+    parse_document(&data).unwrap_or_else(|e| panic!("{path}: {e:?}"))
+}
+
+/// 기존 파생식 (document_core::queries::rendering::paginate_pass 의 원본 식).
+fn legacy_hwpx_stored_layout(doc: &Document, container_is_hwpx: bool) -> bool {
+    let hwp5_origin = doc.hwpx_aux_entry(HWP5_ORIGIN_HWPX_MARKER_PATH).is_some();
+    (container_is_hwpx && !hwp5_origin) || doc.is_hwpx_variant
+}
+
+#[test]
+fn hwp5_native_provenance() {
+    let doc = load("samples/biz_plan.hwp");
+    assert_eq!(doc.provenance.format, SourceFormat::Hwp5);
+    assert_eq!(doc.provenance.hwp3_lineage, doc.is_hwp3_variant);
+    assert_eq!(doc.provenance.hwpx_lineage, doc.is_hwpx_variant);
+    assert!(!doc.is_hwp3_variant && !doc.is_hwpx_variant);
+    let p = doc.layout_profile();
+    assert!(!p.hwp3_layout());
+    assert_eq!(
+        p.hwpx_stored_layout(),
+        legacy_hwpx_stored_layout(&doc, false)
+    );
+}
+
+#[test]
+fn hwpx_native_provenance() {
+    let doc = load("samples/issue_2148_degenerate_cell_vpos.hwpx");
+    assert_eq!(doc.provenance.format, SourceFormat::Hwpx);
+    let p = doc.layout_profile();
+    assert_eq!(
+        p.hwpx_stored_layout(),
+        legacy_hwpx_stored_layout(&doc, true)
+    );
+    assert!(p.hwpx_stored_layout(), "native HWPX 는 HWPX 저장 시멘틱");
+}
+
+#[test]
+fn hwp3_native_provenance() {
+    let doc = load("samples/hwp3-sample.hwp");
+    assert_eq!(doc.provenance.format, SourceFormat::Hwp3);
+    assert_eq!(doc.provenance.hwp3_lineage, doc.is_hwp3_variant);
+    let p = doc.layout_profile();
+    assert_eq!(p.hwp3_layout(), doc.is_hwp3_variant);
+    assert!(!p.hwpx_stored_layout());
+}
+
+#[test]
+fn hml_provenance() {
+    let doc = load("samples/hml/aligns.hml");
+    assert_eq!(doc.provenance.format, SourceFormat::Hml);
+    let p = doc.layout_profile();
+    assert!(!p.hwp3_layout() && !p.hwpx_stored_layout());
+}
+
+#[test]
+fn hwp3_to_hwp5_variant_lineage_sync() {
+    // HWP3→HWP5 변환본 휴리스틱이 발동하는 샘플 — shim 과 provenance 동기 검증.
+    let doc = load("samples/hwp3-sample-hwp5.hwp");
+    assert_eq!(doc.provenance.format, SourceFormat::Hwp5);
+    assert_eq!(
+        doc.provenance.hwp3_lineage, doc.is_hwp3_variant,
+        "hwp3_lineage 는 is_hwp3_variant 쓰기 지점에서 동기되어야 한다"
+    );
+    assert_eq!(doc.layout_profile().hwp3_layout(), doc.is_hwp3_variant);
+}
+
+#[test]
+fn hwp5_origin_hwpx_marker_excludes_hwpx_layout() {
+    // 마커가 부착된 HWPX 는 HWP5 시멘틱 유지 — 파생식 등가를 합성 케이스로 고정.
+    let mut doc = load("samples/issue_2148_degenerate_cell_vpos.hwpx");
+    assert!(doc.layout_profile().hwpx_stored_layout());
+    doc.hwpx_aux_entries
+        .push((HWP5_ORIGIN_HWPX_MARKER_PATH.to_string(), Vec::new()));
+    assert!(
+        !doc.layout_profile().hwpx_stored_layout(),
+        "HWP5→HWPX 산출물 마커는 HWPX 전용 분기에서 제외 (세션 중 부착 반영)"
+    );
+    assert_eq!(
+        doc.layout_profile().hwpx_stored_layout(),
+        legacy_hwpx_stored_layout(&doc, true)
+    );
+}


### PR DESCRIPTION
## 요약

소스 포맷·변환 계보 판단의 소유권을 typed 값으로 통합합니다 — 마스터 플랜 v2 **Phase P**, #1582 umbrella 이관분. **observable behavior 불변** (bit-identical 게이트 전 단계 통과). Closes #2403

## 단계 구성 (커밋 4개 = 승인 게이트 4회)

1. **0단계** — advisory 3종 스냅샷 (`scripts/advisory_snapshot.sh`: API 표면/CLI output/render-tree 해시, 재현성 2회 생성 diff 0)
2. **1단계** — `model/provenance.rs` 신설: `SourceFormat`·`SourceProvenance`(파서 확정, 서명 필드는 #2373 트랙 몫)·`LayoutCompatibilityProfile`(기존 분기 1:1 질의 4종) + `Document::layout_profile()` + 파서 5지점 동기 배선 + **등가성 가드 6케이스** (tests/issue_2403_provenance_stage1.rs)
3. **2단계** — renderer 통합: TypesetState 4필드·엔진 Cell 4개 → profile 1개, rendering.rs 파생 쌍둥이 2곳(Issue #1770 규칙 중복) 일원화, `set_hwp3_variant`+`set_hwpx_source` → `set_layout_profile`(결합 부수효과 명시 승계)
4. **3단계** — document_core 필드 읽기 40곳 이관(가변 차용 겹침 31곳 호이스팅) + **규약 명문화** (parser_architecture.md 정책 절 + CONTRIBUTING)

## 게이트 (전 단계)

- 전체 스위트(release-test, 284 바이너리) 0 실패 / clippy --all-targets -D warnings 0 / fmt
- **bit-identical**: CLI output·render-tree 해시 무변동, 연결맵 414쪽 유지
- API 표면: 1·2단계 의도 추가분만(스냅샷 대조 기록), 3단계 delta 0

## 계량

| 지표 | before | after |
|------|--------|-------|
| 소스분기 계열 참조 (src) | 176 | **87** |
| renderer 코어 필드 읽기 | 77 | **0** |
| document_core 필드 읽기 | 40 | **0** |

잔존 87 = 파서 확정 지점(원점) 18·모델 shim 선언·테스트 초기화·값 전달 파라미터·주석 — 계획 범주 내.

## 하지 않는 것

- 분기 밀집 구간 해체 (마스터 플랜 §1 — 치환만, 해체는 후속)
- shim 필드 제거 (API 호환 — 후속 단계)
- behavior 를 바꾸는 판별자 추가 (#2373 잔여 트랙의 몫)

작업지시자 단계별 승인 4회 완료 (수행계획서 mydocs/plans/task_m100_2403.md).

🤖 Generated with [Claude Code](https://claude.com/claude-code)