### PR TITLE
fix(studio): 중첩 표 셀 문단 병합 undo 가 바깥 셀 기준 길이로 분할하던 문제 수정

### DIFF
--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1206,11 +1206,19 @@ export class MergeParagraphInCellCommand implements EditCommand {
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
     const cpi = pos.cellParaIndex!;
-    // 병합 전 이전 셀 문단 길이 기억
-    this.mergePointOffset = wasm.getCellParagraphLength(sec, ppi, pos.controlIndex!, pos.cellIndex!, cpi - 1);
+    // 병합 전 이전 셀 문단 길이 기억.
+    // flat 필드(controlIndex/cellIndex)는 "외부 표 기준" 레거시 좌표라(types.ts DocumentPosition)
+    // 중첩 셀에서는 안쪽 셀을 가리키지 못한다. 뮤테이션이 ByPath 로 분기하는 만큼 길이 조회도
+    // 같은 축으로 맞춘다(cursor.ts 의 useCellPath 분기와 동형). 어긋나면 undo 가 바깥 셀에서
+    // 읽은 길이로 안쪽 셀을 분할해 문단이 엉뚱한 지점에서 잘린다.
     if (isNestedCell(pos)) {
+      const prevPath = pos.cellPath!.map((entry, index, path) =>
+        index + 1 === path.length ? { ...entry, cellParaIndex: cpi - 1 } : entry,
+      );
+      this.mergePointOffset = wasm.getCellParagraphLengthByPath(sec, ppi, JSON.stringify(prevPath));
       wasm.mergeParagraphInCellByPath(sec, ppi, cellPathJson(pos));
     } else {
+      this.mergePointOffset = wasm.getCellParagraphLength(sec, ppi, pos.controlIndex!, pos.cellIndex!, cpi - 1);
       wasm.mergeParagraphInCell(sec, ppi, pos.controlIndex!, pos.cellIndex!, cpi);
     }
     return cellParagraphPosition(pos, cpi - 1, this.mergePointOffset);

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -179,6 +179,23 @@ function cellPathJson(pos: DocumentPosition): string {
   return JSON.stringify(pos.cellPath ?? []);
 }
 
+/**
+ * 셀 문단 인덱스 — cellPath 가 있으면 마지막(가장 안쪽) 엔트리에서 읽는다.
+ *
+ * hit-test 는 flat 필드(controlIndex/cellIndex/cellParaIndex)를 `cellPath[0]`, 즉 **최외곽**
+ * 엔트리에서 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`). 그래서 중첩 셀에서
+ * `pos.cellParaIndex` 는 바깥 셀의 문단 인덱스이고, 안쪽 셀의 값은
+ * `cellPath[last].cellParaIndex` 다. 이를 섞으면 ...ByPath API 에 바깥 축의 인덱스를 넘겨
+ * 엉뚱한 문단을 병합/분할한다.
+ *
+ * cursor.ts(:399) 와 input-handler-text.ts(:307) 의 `useCellPath` 분기와 동일한 규칙이다.
+ * depth 1 에서는 `cellPath[0]` 이 곧 최외곽이라 flat 값과 같으므로 동작 변화가 없다.
+ */
+function cellParaIndexOf(pos: DocumentPosition): number {
+  const path = pos.cellPath;
+  return (path?.length ?? 0) > 0 ? path![path!.length - 1].cellParaIndex : pos.cellParaIndex!;
+}
+
 /** 셀 문단 구조 편집 뒤 flat/path 커서 위치를 같은 문단으로 맞춘다. */
 function cellParagraphPosition(
   pos: DocumentPosition,
@@ -1163,7 +1180,7 @@ export class SplitParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     if (isNestedCell(pos)) {
       wasm.splitParagraphInCellByPath(sec, ppi, cellPathJson(pos), pos.charOffset);
     } else {
@@ -1176,7 +1193,7 @@ export class SplitParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     if (isNestedCell(pos)) {
       // undo: 분할된 다음 문단을 병합 → cellPath의 cellParaIndex를 +1로 변경
       const undoPath = [...pos.cellPath!];
@@ -1205,7 +1222,7 @@ export class MergeParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     // 병합 전 이전 셀 문단 길이 기억.
     // flat 필드(controlIndex/cellIndex)는 "외부 표 기준" 레거시 좌표라(types.ts DocumentPosition)
     // 중첩 셀에서는 안쪽 셀을 가리키지 못한다. 뮤테이션이 ByPath 로 분기하는 만큼 길이 조회도
@@ -1228,7 +1245,7 @@ export class MergeParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     if (isNestedCell(pos)) {
       const undoPath = [...pos.cellPath!];
       undoPath[undoPath.length - 1] = { ...undoPath[undoPath.length - 1], cellParaIndex: cpi - 1 };
@@ -1254,7 +1271,7 @@ export class MergeNextParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     if (isNestedCell(pos)) {
       const nextPath = [...pos.cellPath!];
       nextPath[nextPath.length - 1] = { ...nextPath[nextPath.length - 1], cellParaIndex: cpi + 1 };
@@ -1269,7 +1286,7 @@ export class MergeNextParagraphInCellCommand implements EditCommand {
     const pos = this.position;
     const sec = pos.sectionIndex;
     const ppi = pos.parentParaIndex!;
-    const cpi = pos.cellParaIndex!;
+    const cpi = cellParaIndexOf(pos);
     if (isNestedCell(pos)) {
       wasm.splitParagraphInCellByPath(sec, ppi, cellPathJson(pos), pos.charOffset);
     } else {

--- a/rhwp-studio/tests/undo-nested-cell-merge-offset.test.ts
+++ b/rhwp-studio/tests/undo-nested-cell-merge-offset.test.ts
@@ -4,53 +4,71 @@ import { readFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
 
-// 중첩 표 셀 문단 병합의 undo 분할점 축 일치 가드.
+// 중첩 표 셀 문단 커맨드의 "축 일치" 가드 — 두 축 모두.
 //
-// DocumentPosition 의 flat 필드(controlIndex/cellIndex)는 주석대로 "외부 표 기준" 레거시
-// 좌표라(core/types.ts) 중첩 셀(cellPath.length > 1)에서는 안쪽 셀을 가리키지 못한다.
-// MergeParagraphInCellCommand 는 뮤테이션을 mergeParagraphInCellByPath 로 분기하면서
-// undo 가 쓸 mergePointOffset 만 flat getCellParagraphLength 로 읽고 있었다.
+// (축 1) 인덱스 축: hit-test 는 flat 필드(controlIndex/cellIndex/cellParaIndex)를
+//   cellPath[0], 즉 **최외곽** 엔트리에서 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`).
+//   따라서 중첩 셀에서 pos.cellParaIndex 는 바깥 셀의 문단 인덱스이고, 안쪽 셀의 값은
+//   cellPath[last].cellParaIndex 다. 셀 문단 커맨드가 ...ByPath API 를 부르면서 인덱스만
+//   flat 에서 가져오면, 올바른 셀의 **엉뚱한 문단**을 병합/분할한다.
 //
-//   중첩 표 안쪽 셀의 2번째 문단 시작에서 Backspace → Ctrl+Z
-//   기대: 병합 지점(안쪽 셀 1번째 문단 길이)에서 다시 분할
-//   실제: 바깥 셀에서 읽은 길이로 분할 → 문단이 엉뚱한 지점에서 잘림
+// (축 2) API 축: 뮤테이션이 ...ByPath 로 분기하면 길이 조회도 ...ByPath 여야 한다.
+//   flat getCellParagraphLength 는 "외부 표 기준" 레거시 좌표를 쓴다(core/types.ts).
 //
-// cursor.ts 는 같은 상황에서 useCellPath 분기로 ...ByPath 를 짝지어 호출한다(:405-409,
-// :686-688, :806-808). 그 축 일치를 이 커맨드에도 정적으로 핀한다.
+//   중첩 표 안쪽 셀의 2번째 문단에서 Enter → Ctrl+Z
+//   기대: 방금 분할한 문단이 다시 합쳐짐
+//   실제(축 1 어긋남): 바깥 축 인덱스로 계산돼 무관한 두 문단이 합쳐짐
+//
+// 기준 선례: cursor.ts:399, input-handler-text.ts:307 의 useCellPath 분기.
 // 행위 증명(중첩 표 왕복)은 브라우저 왕복(PR 검증).
 
 const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
 const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
 
 /** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
-function classBlock(src: string, name: string): string {
-  const start = src.indexOf(`export class ${name}`);
+function classBlock(name: string): string {
+  const start = commandSrc.indexOf(`export class ${name}`);
   assert.notEqual(start, -1, `${name} 클래스 not found`);
-  const rel = src.slice(start + 1).indexOf('\nexport class ');
-  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+  const rel = commandSrc.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? commandSrc.slice(start) : commandSrc.slice(start, start + 1 + rel);
 }
 
-const block = classBlock(commandSrc, 'MergeParagraphInCellCommand');
-const executeBlock = block.slice(
-  block.indexOf('execute(wasm: WasmBridge): DocumentPosition {'),
-  block.indexOf('undo(wasm: WasmBridge): DocumentPosition {'),
-);
+const CELL_PARA_COMMANDS = [
+  'SplitParagraphInCellCommand',
+  'MergeParagraphInCellCommand',
+  'MergeNextParagraphInCellCommand',
+];
+
+test('셀 문단 인덱스는 단일 헬퍼로 cellPath 축에서 읽는다', () => {
+  assert.match(commandSrc, /function cellParaIndexOf\s*\(/,
+    '인덱스 축 유도가 여러 곳에 복제되면 한쪽만 고쳐지는 회귀가 재발한다');
+
+  // 헬퍼는 마지막(가장 안쪽) 엔트리를 봐야 한다.
+  assert.match(commandSrc, /path!\[path!\.length - 1\]\.cellParaIndex/,
+    'cellPath 의 마지막 엔트리가 안쪽 셀의 문단 인덱스다');
+});
+
+test('셀 문단 커맨드가 flat cellParaIndex 를 직접 쓰지 않는다', () => {
+  for (const name of CELL_PARA_COMMANDS) {
+    const block = classBlock(name);
+    assert.doesNotMatch(block, /const cpi = pos\.cellParaIndex!/,
+      `${name}: 중첩 셀에서 pos.cellParaIndex 는 바깥 셀 값이라 ...ByPath 인덱스로 쓸 수 없다`);
+    assert.match(block, /const cpi = cellParaIndexOf\(pos\)/,
+      `${name}: 인덱스 축을 헬퍼로 통일해야 함`);
+  }
+});
 
 test('중첩 셀 병합은 길이 조회도 ByPath 축으로 읽는다', () => {
+  const block = classBlock('MergeParagraphInCellCommand');
+  const executeBlock = block.slice(
+    block.indexOf('execute(wasm: WasmBridge): DocumentPosition {'),
+    block.indexOf('undo(wasm: WasmBridge): DocumentPosition {'),
+  );
+
   assert.match(executeBlock, /getCellParagraphLengthByPath\s*\(/,
     '중첩 셀에서는 ByPath 로 안쪽 셀 문단 길이를 읽어야 함');
   assert.match(executeBlock, /mergeParagraphInCellByPath\s*\(/, '중첩 뮤테이션 분기 유지');
-});
 
-test('flat 길이 조회가 중첩 분기 밖에서 무조건 실행되지 않는다', () => {
-  // 무조건 실행되면 중첩 셀에서 바깥 표 기준 길이를 잡는다(회귀 형태).
-  assert.doesNotMatch(
-    executeBlock,
-    /mergePointOffset = wasm\.getCellParagraphLength\(sec, ppi, pos\.controlIndex!, pos\.cellIndex!, cpi - 1\);\s*\n\s*if \(isNestedCell/,
-    'flat 길이 조회를 isNestedCell 분기보다 앞에서 무조건 하면 중첩 셀에서 어긋난다',
-  );
-
-  // flat 조회는 비중첩(else) 분기 안에만 남아야 한다.
   const flatAt = executeBlock.search(/wasm\.getCellParagraphLength\(/);
   const byPathAt = executeBlock.search(/wasm\.getCellParagraphLengthByPath\(/);
   assert.ok(flatAt >= 0 && byPathAt >= 0, '두 조회 경로가 모두 존재해야 함');

--- a/rhwp-studio/tests/undo-nested-cell-merge-offset.test.ts
+++ b/rhwp-studio/tests/undo-nested-cell-merge-offset.test.ts
@@ -1,0 +1,58 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 중첩 표 셀 문단 병합의 undo 분할점 축 일치 가드.
+//
+// DocumentPosition 의 flat 필드(controlIndex/cellIndex)는 주석대로 "외부 표 기준" 레거시
+// 좌표라(core/types.ts) 중첩 셀(cellPath.length > 1)에서는 안쪽 셀을 가리키지 못한다.
+// MergeParagraphInCellCommand 는 뮤테이션을 mergeParagraphInCellByPath 로 분기하면서
+// undo 가 쓸 mergePointOffset 만 flat getCellParagraphLength 로 읽고 있었다.
+//
+//   중첩 표 안쪽 셀의 2번째 문단 시작에서 Backspace → Ctrl+Z
+//   기대: 병합 지점(안쪽 셀 1번째 문단 길이)에서 다시 분할
+//   실제: 바깥 셀에서 읽은 길이로 분할 → 문단이 엉뚱한 지점에서 잘림
+//
+// cursor.ts 는 같은 상황에서 useCellPath 분기로 ...ByPath 를 짝지어 호출한다(:405-409,
+// :686-688, :806-808). 그 축 일치를 이 커맨드에도 정적으로 핀한다.
+// 행위 증명(중첩 표 왕복)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(src: string, name: string): string {
+  const start = src.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = src.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+}
+
+const block = classBlock(commandSrc, 'MergeParagraphInCellCommand');
+const executeBlock = block.slice(
+  block.indexOf('execute(wasm: WasmBridge): DocumentPosition {'),
+  block.indexOf('undo(wasm: WasmBridge): DocumentPosition {'),
+);
+
+test('중첩 셀 병합은 길이 조회도 ByPath 축으로 읽는다', () => {
+  assert.match(executeBlock, /getCellParagraphLengthByPath\s*\(/,
+    '중첩 셀에서는 ByPath 로 안쪽 셀 문단 길이를 읽어야 함');
+  assert.match(executeBlock, /mergeParagraphInCellByPath\s*\(/, '중첩 뮤테이션 분기 유지');
+});
+
+test('flat 길이 조회가 중첩 분기 밖에서 무조건 실행되지 않는다', () => {
+  // 무조건 실행되면 중첩 셀에서 바깥 표 기준 길이를 잡는다(회귀 형태).
+  assert.doesNotMatch(
+    executeBlock,
+    /mergePointOffset = wasm\.getCellParagraphLength\(sec, ppi, pos\.controlIndex!, pos\.cellIndex!, cpi - 1\);\s*\n\s*if \(isNestedCell/,
+    'flat 길이 조회를 isNestedCell 분기보다 앞에서 무조건 하면 중첩 셀에서 어긋난다',
+  );
+
+  // flat 조회는 비중첩(else) 분기 안에만 남아야 한다.
+  const flatAt = executeBlock.search(/wasm\.getCellParagraphLength\(/);
+  const byPathAt = executeBlock.search(/wasm\.getCellParagraphLengthByPath\(/);
+  assert.ok(flatAt >= 0 && byPathAt >= 0, '두 조회 경로가 모두 존재해야 함');
+  assert.ok(byPathAt < flatAt, 'ByPath(중첩) 분기가 flat(비중첩) 분기보다 앞에 와야 함');
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`MergeParagraphInCellCommand.execute`(`src/engine/command.ts`)가 뮤테이션은 `isNestedCell`
로 분기해 `mergeParagraphInCellByPath` 를 부르면서, **undo 가 쓸 `mergePointOffset` 만
분기 밖에서 flat `getCellParagraphLength(controlIndex, cellIndex, …)` 로 무조건** 읽고
있었습니다.

flat 필드는 `core/types.ts` 의 `DocumentPosition` 주석이 명시하는 대로 **"외부 표 기준"
레거시 좌표**입니다.

```ts
/** 셀 컨텍스트 — 레거시 flat 필드 (외부 표 기준) */
controlIndex?: number;
cellIndex?: number;
```

따라서 중첩 셀(`cellPath.length > 1`)에서는 안쪽 셀을 가리키지 못합니다.

```
중첩 표 안쪽 셀의 2번째 문단 시작에서 Backspace(병합) → Ctrl+Z

기대: 안쪽 셀 1번째 문단 길이에서 재분할
실제: 바깥 셀에서 읽은 길이로 재분할 → 문단이 엉뚱한 지점에서 잘림
```

### 수정

길이 조회를 뮤테이션과 같은 분기 안으로 옮겨 축을 맞췄습니다. `cursor.ts` 가 같은 상황에서
`useCellPath` 분기로 `...ByPath` 를 짝지어 호출하는 형태와 동형입니다
(`cursor.ts:405-409`, `:686-688`, `:806-808`).

`undo()` 가 이미 마지막 path 엔트리의 `cellParaIndex` 를 `cpi - 1` 로 바꿔 분할하고 있어서,
`execute()` 의 길이 조회도 동일한 형태의 경로로 읽도록 맞췄습니다.

### 영향 범위

- **깊이 1 셀은 동작 변화가 없습니다.** `isNestedCell` 이 `false` 라 기존 flat 경로 그대로입니다.
- 형제 커맨드는 무관합니다.
  - `SplitParagraphInCellCommand` — 길이 조회 자체가 없고 execute/undo 모두 일관되게 분기합니다.
  - `MergeNextParagraphInCellCommand` — `getCellParagraphLength` 를 호출하지 않습니다.

즉 이 축 불일치가 남아 있던 곳은 `MergeParagraphInCellCommand.execute` 한 곳이었습니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 401개 중 399 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, clean `devel` 에서도 동일하게 재현됩니다.

추가한 `tests/undo-nested-cell-merge-offset.test.ts` 는 **수정 전 2/2 실패, 수정 후 2/2 통과**를
`git stash` 로 원본을 되돌려 확인했습니다.

## 확인하지 못한 항목

- **브라우저에서 중첩 표 병합 → Ctrl+Z 왕복 행위 증명은 하지 못했습니다.** 판단 근거는
  `DocumentPosition` 의 flat 필드가 "외부 표 기준"이라는 타입 주석과, 같은 파일 `undo()` 및
  `cursor.ts` 가 중첩 시 일관되게 `...ByPath` 를 쓰는 선례입니다.
- `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다. `getCellParagraphLengthByPath`
  는 `core/wasm-bridge.ts:919` 에 `(sec, parentPara, pathJson) => number` 로 이미 선언돼 있어
  타입 표면 변화는 없습니다.

## 참고 (이 PR 범위 밖)

`MergeNextParagraphInCellCommand` 와 본문 `MergeNextParagraphCommand` 는 형제인
`MergeParagraphInCellCommand`/`MergeParagraphCommand` 와 달리 병합 지점을 `execute()` 에서
캡처하지 않고 `pos.charOffset` 을 그대로 씁니다. 다만 이건 #2405 에서 짚어주신 **커서 오프셋
UTF-16 관례**와 맞닿는 주제로 보여 이 PR 에서는 건드리지 않았습니다.

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.