### PR TITLE
fix(studio): 표 셀 안 Edit 양식 필드 값이 저장되지 않던 문제 수정

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -4580,17 +4580,30 @@ export class InputHandler {
     });
   }
 
+  /**
+   * 셀 내부 컨트롤 locator (뮤테이션 분기와 record 대상이 같은 조건을 공유).
+   *
+   * 셀 안 양식 개체는 hit 결과의 para 가 "표를 담은 최상위 문단" 이고 ci 는 "셀 문단 안의
+   * 컨트롤 인덱스" 다(form_query.rs get_form_object_at_native). 따라서 flat
+   * setFormValue(sec, para, ci) 로 쓰면 표 컨트롤 슬롯을 가리켜 항상 실패한다
+   * (set_form_value_native 의 `not a form object`). 셀 안이면 반드시 이 locator 로
+   * setFormValueInCell 을 쓰고, 기록에도 inCell 을 실어야 undo 가 같은 슬롯을 되돌린다.
+   */
+  private formInCellLoc(formHit: FormObjectHitResult):
+    { tablePara: number; tableCi: number; cellIdx: number; cellPara: number } | undefined {
+    return (formHit.inCell && formHit.tablePara !== undefined && formHit.tableCi !== undefined
+        && formHit.cellIdx !== undefined && formHit.cellPara !== undefined)
+      ? { tablePara: formHit.tablePara, tableCi: formHit.tableCi, cellIdx: formHit.cellIdx, cellPara: formHit.cellPara }
+      : undefined;
+  }
+
   /** 양식 개체 클릭 처리 */
   handleFormObjectClick(formHit: FormObjectHitResult, pageIdx: number, _zoom: number): void {
     if (!formHit.found || formHit.sec === undefined || formHit.para === undefined || formHit.ci === undefined) return;
 
     const { sec, para, ci, formType } = formHit;
 
-    // 셀 내부 컨트롤 locator (record 대상과 setFormVal 분기가 같은 조건을 공유)
-    const inCellLoc = (formHit.inCell && formHit.tablePara !== undefined && formHit.tableCi !== undefined
-        && formHit.cellIdx !== undefined && formHit.cellPara !== undefined)
-      ? { tablePara: formHit.tablePara, tableCi: formHit.tableCi, cellIdx: formHit.cellIdx, cellPara: formHit.cellPara }
-      : undefined;
+    const inCellLoc = this.formInCellLoc(formHit);
 
     // 셀 내부 폼 값 설정 헬퍼
     const setFormVal = (valueJson: string) => {
@@ -4791,12 +4804,22 @@ export class InputHandler {
     const commit = () => {
       if (committed) return;
       committed = true;
-      this.wasm.setFormValue(sec, para, ci, JSON.stringify({ text: input.value }));
+      // 셀 안 Edit 필드는 flat setFormValue 로 쓰면 표 컨트롤 슬롯을 가리켜 조용히 실패한다
+      // (CheckBox 분기와 동일 조건 — formInCellLoc 참고). 기록에도 inCell 을 실어야 undo 가
+      // 같은 슬롯을 되돌린다(SetFormValueCommand.apply 가 inCell 로 분기).
+      const inCellLoc = this.formInCellLoc(formHit);
+      const afterJson = JSON.stringify({ text: input.value });
+      if (inCellLoc) {
+        this.wasm.setFormValueInCell(sec, inCellLoc.tablePara, inCellLoc.tableCi,
+          inCellLoc.cellIdx, inCellLoc.cellPara, ci, afterJson);
+      } else {
+        this.wasm.setFormValue(sec, para, ci, afterJson);
+      }
       // [Task #2374] 편집 필드 커밋 기록(동일 텍스트는 no-op 제외).
       this.recordFormValueChanges([{
-        sec, para, ci,
+        sec, para, ci, inCell: inCellLoc,
         beforeJson: JSON.stringify({ text: formHit.text ?? '' }),
-        afterJson: JSON.stringify({ text: input.value }),
+        afterJson,
       }]);
       this.removeFormOverlay();
       this.afterEdit();

--- a/rhwp-studio/tests/form-edit-in-cell.test.ts
+++ b/rhwp-studio/tests/form-edit-in-cell.test.ts
@@ -1,0 +1,60 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2374 후속] 셀 내부 양식 개체 쓰기 경로의 locator 일치 가드.
+//
+// 셀 안 양식 개체는 hit 결과의 para 가 "표를 담은 최상위 문단", ci 가 "셀 문단 안의 컨트롤
+// 인덱스"다(form_query.rs get_form_object_at_native). 따라서 flat setFormValue(sec, para, ci)
+// 는 표 컨트롤 슬롯을 가리켜 set_form_value_native 의 `not a form object` 로 조용히 실패한다.
+//
+//   양식 모드에서 표 셀 안 Edit 필드 클릭 → 입력 → Enter
+//   기대: 값이 저장되고 Ctrl+Z 로 되돌아감
+//   실제: 값이 저장되지 않고(반환값 미확인), inCell 없는 기록만 남아 유령 undo 엔트리 발생
+//
+// CheckBox 분기는 setFormValueInCell + record 의 inCell 을 모두 갖추고 있었고 Edit 커밋만
+// 누락돼 있었다. 두 경로가 같은 locator 를 쓰는지 정적으로 핀한다.
+// 행위 증명(셀 안 Edit 왕복)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+
+/** 메서드 시작부터 다음 최상위 메서드 전까지 본문을 자른다. */
+function methodBlock(name: string): string {
+  const start = src.indexOf(`  private ${name}(`) >= 0
+    ? src.indexOf(`  private ${name}(`)
+    : src.indexOf(`  ${name}(`);
+  assert.notEqual(start, -1, `${name} 메서드 not found`);
+  const rest = src.slice(start + 1);
+  const end = rest.search(/\n {2}(private |public )?[a-zA-Z_]\w*\s*\(/);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+test('셀 내부 locator 계산이 단일 헬퍼로 공유된다', () => {
+  assert.match(src, /private formInCellLoc\s*\(/,
+    'locator 조건이 여러 곳에 복제되면 한쪽만 고쳐지는 회귀가 재발한다');
+
+  // 인라인 복제본이 남아 있으면 헬퍼가 무력화된다.
+  const inlineCopies = src.match(/formHit\.inCell && formHit\.tablePara !== undefined/g) ?? [];
+  assert.equal(inlineCopies.length, 1,
+    `locator 조건은 헬퍼 안에만 있어야 함(현재 ${inlineCopies.length}곳)`);
+});
+
+test('Edit 오버레이 커밋이 셀 내부 경로로 분기한다', () => {
+  const block = methodBlock('showEditOverlay');
+
+  assert.match(block, /formInCellLoc\s*\(/, 'Edit 커밋도 셀 내부 locator 를 계산해야 함');
+  assert.match(block, /setFormValueInCell\s*\(/,
+    '셀 안에서는 setFormValueInCell 로 써야 표 컨트롤 슬롯을 피한다');
+  assert.match(block, /inCell: inCellLoc/,
+    '기록에 inCell 을 실어야 undo 가 같은 슬롯을 되돌린다');
+});
+
+test('CheckBox 분기의 셀 내부 처리가 유지된다', () => {
+  // 선례가 사라지면 Edit 쪽 수정의 근거도 사라진다.
+  const block = methodBlock('handleFormObjectClick');
+  assert.match(block, /setFormValueInCell\s*\(/, 'CheckBox 셀 내부 쓰기 유지');
+  assert.match(block, /inCell: inCellLoc/, 'CheckBox 기록의 inCell 유지');
+});

--- a/rhwp-studio/tests/mutation-routing-guard.test.ts
+++ b/rhwp-studio/tests/mutation-routing-guard.test.ts
@@ -156,7 +156,7 @@ const BASELINE: Readonly<Record<string, number>> = {
   'src/ui/table-cell-props-dialog.ts': 2,
   'src/ui/toolbar.ts': 4,
   // engine/input-handler* — 드래그/nudge 등 직접-뮤테이션 최고밀도 영역.
-  'src/engine/input-handler.ts': 26, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리
+  'src/engine/input-handler.ts': 27, // +1: 누름틀 제거 이관 시 removeFieldAt 이 양식모드(직접 유지)/일반모드(snapshot) 두 분기로 분리 / +1: Edit 오버레이 커밋이 셀 내부는 setFormValueInCell 로 분기(CheckBox 와 동일 조건 — 기존 flat 호출은 표 컨트롤 슬롯을 가리켜 실패)
   'src/engine/input-handler-connector.ts': 1,
   'src/engine/input-handler-keyboard.ts': 21,
   'src/engine/input-handler-mouse.ts': 3,


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

셀 안 양식 개체는 hit 결과의 `para` 가 **표를 담은 최상위 문단**, `ci` 가 **셀 문단 안의
컨트롤 인덱스**입니다(`form_query.rs` `get_form_object_at_native` 의 `ret_para = tpi`).

```rust
// sec/para는 최상위 문단 인덱스로 반환
// cell_location이 있으면 table_para_index를 para로 사용
let (ret_para, ret_ci) = if let Some((tpi, _tci, _ci_idx, _cp_idx)) = form.cell_location {
    (tpi, form.control_index)
```

따라서 flat `setFormValue(sec, para, ci)` 로 쓰면 `sections[sec].paragraphs[tpi].controls[ci]`
를 보게 되는데, 그 슬롯은 `Control::Table` 이라 `set_form_value_native` 가 매치에서 떨어져
`{"ok":false,"error":"not a form object"}` 를 돌려줍니다.

`showEditOverlay` 의 `commit()` 이 이 flat 경로를 그대로 쓰고 **반환값도 확인하지 않습니다.**

```
양식 모드에서 표 셀 안 Edit 필드 클릭 → 입력 → Enter

기대: 값이 저장되고 Ctrl+Z 로 복원
실제: 값이 저장되지 않음. 게다가 recordFormValueChanges 는 before ≠ after 라
      inCell 없는 SetFormValueCommand 를 기록해, Ctrl+Z 가 같은 잘못된 슬롯에
      쓰는 유령 undo 엔트리가 쌓임
```

`showEditOverlay` 는 `getFormObjectInfo` 를 호출하지 않아 조기 반환이 없습니다. 즉 오버레이는
정상적으로 뜨고 입력도 받으므로, 사용자 입장에서는 **아무 오류 없이 값만 사라집니다.**

### 수정

`handleFormObjectClick` 의 **CheckBox 분기는 이미 `setFormValueInCell` 과 record 의 `inCell`
을 모두 갖추고 있었습니다**(`inCellLoc` + `setFormVal` 헬퍼). Edit 커밋만 누락돼 있었으므로
같은 조건으로 맞췄습니다.

locator 계산이 두 곳에 복제되면 한쪽만 고쳐지는 회귀가 재발하므로 `formInCellLoc` 헬퍼로
추출해 두 경로가 공유하게 했습니다. `SetFormValueCommand.apply` 가 `t.inCell` 로 분기하므로
(`command.ts`) 기록에도 `inCell` 을 실어야 undo 가 같은 슬롯을 되돌립니다.

셀 밖 Edit 필드는 `formInCellLoc` 이 `undefined` 라 기존 flat 경로 그대로이며 동작 변화가 없습니다.

## 관련 이슈

없음 (자체 발견). #2374 후속 성격입니다.

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 402개 중 400 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, clean `devel` 에서도 동일하게 재현됩니다.

추가한 `tests/form-edit-in-cell.test.ts` 는 **수정 전 3건 중 2 실패, 수정 후 3/3 통과**를
`git stash` 로 원본을 되돌려 확인했습니다.

`tests/mutation-routing-guard.test.ts` 가 이 변경을 정확히 잡아내서(`input-handler.ts: 26 → 27`)
사유와 함께 baseline 을 갱신했습니다. 증가분은 셀 분기로 추가된 `setFormValueInCell` 1건입니다.

## 확인하지 못한 항목

- **브라우저에서 셀 안 Edit 필드 왕복 행위 증명은 하지 못했습니다.** 판단은 Rust 측 슬롯
  해석(`get_form_object_at_native` 의 `ret_para = tpi` → `set_form_value_native` 의
  `Control::Form` 매치 실패) 추적과, CheckBox 분기가 같은 조건에서 `...InCell` 을 쓴다는
  선례에 근거합니다.
- `node_modules` 미설치 상태라 `tsc` 타입체크는 실행하지 못했습니다. `setFormValueInCell` 은
  CheckBox 분기에서 동일 인자 형태로 이미 호출 중이라 타입 표면 변화는 없습니다.

## 참고 (이 PR 범위 밖)

`showComboBoxOverlay`(`:4742`)와 `handleRadioButtonClick`(`:4622` 호출 지점)도 같은 계열입니다.
다만 두 경로는 `getFormObjectInfo(sec, para, ci)` 로 먼저 조회한 뒤 `!info.ok` 에서 조기
반환하는데, **`getFormObjectInfo` 의 셀 내부 변형이 Rust 에 없습니다**(`wasm-bridge.ts` 에도
`getFormObjectInfo` / `getFormValue` 만 존재). 즉 TS 만으로는 고칠 수 없어 제외했습니다.
필요하시면 별도 이슈로 정리하겠습니다.

기존 e2e(`e2e/form-control.test.mjs`)의 셀 내부 케이스도 CheckBox(TC-4/TC-5)만 있고
Edit/ComboBox/Radio 는 없습니다.

## 스크린샷

렌더링 변경이 아니라 첨부하지 않았습니다.