### PR TITLE
fix(studio): 표 구조 편집 후 옛 bbox 캐시로 엉뚱한 행이 리사이즈되던 문제 수정

### DIFF
--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -2365,6 +2365,12 @@ export class InputHandler {
     }
     this.lastCellKey = null; // 편집 후 셀 bbox 캐시 무효화
     this.protectedCellHitCache = null;
+    // 표 구조 편집(줄/칸 삽입·삭제, 셀 합치기·나누기)은 cachedCellBboxes 의 기하와 cellIdx
+    // 번호를 모두 바꾸지만, cachedTableRef 는 {sec, ppi, ci} 라 표 "정체성"만 담아 신선도
+    // 검사를 그대로 통과한다. 지우지 않으면 hover marker 가 옛 경계에 그려지고
+    // resolveTableResizeHit → startResizeDrag 가 옛 번호의 cellIdx 로 엉뚱한 행을 리사이즈한다.
+    // undo/redo 경로가 이미 같은 이유로 이 루틴을 부른다.
+    this.clearTableResizeRuntimeCache();
     this.eventBus.emit('document-mutated', 'input-handler-edit');
     this.eventBus.emit('document-changed');
     this.updateCaret();

--- a/rhwp-studio/tests/table-bbox-cache-invalidation.test.ts
+++ b/rhwp-studio/tests/table-bbox-cache-invalidation.test.ts
@@ -1,0 +1,57 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 표 리사이즈 런타임 캐시(cachedCellBboxes / cachedTableRef) 무효화 가드.
+//
+// cachedTableRef 는 {sec, ppi, ci} — 표의 "정체성"만 담는다. 줄 지우기 같은 구조 편집은
+// 이 셋을 바꾸지 않으므로 handleResizeHover 의 신선도 검사(sec/ppi/ci/pageHint)를 그대로
+// 통과한다. 반면 cachedCellBboxes 의 기하와 cellIdx 번호는 바뀐다.
+//
+//   10줄 표에 커서 → 셀 선택 모드에서 클릭(캐시 채워짐) → 줄 지우기 ×2 → Esc
+//   → 지금의 5/6행 경계를 드래그
+//   기대: 현재 5/6행이 리사이즈됨
+//   실제: 옛 경계에 marker 가 뜨고, 옛 번호의 cellIdx 로 다른 두 행이 리사이즈됨
+//
+// resolveTableResizeHit(input-handler-mouse.ts)는 캐시를 아무 검증 없이 그대로 반환하고,
+// finishResizeDrag 는 state.bboxes 의 cellIdx 로 resizeTableCells 를 부른다.
+// undo/redo 경로는 이미 같은 이유로 clearTableResizeRuntimeCache 를 호출한다.
+// 행위 증명(표 구조 편집 후 리사이즈)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+
+/** 메서드 본문을 다음 최상위 멤버 직전까지 잘라낸다. */
+function methodBody(name: string): string {
+  const start = src.indexOf(`  private ${name}(`);
+  assert.notEqual(start, -1, `${name} 메서드 not found`);
+  const rest = src.slice(start + 1);
+  const end = rest.search(/\n {2}(private |public )?[a-zA-Z_]\w*\s*\(/);
+  return end === -1 ? rest : rest.slice(0, end);
+}
+
+test('편집 후 처리에서 표 리사이즈 런타임 캐시를 무효화한다', () => {
+  const body = methodBody('afterEdit');
+
+  assert.match(body, /clearTableResizeRuntimeCache\s*\(/,
+    'afterEdit 가 캐시를 지우지 않으면 구조 편집 뒤 옛 bbox 로 엉뚱한 행이 리사이즈된다');
+
+  // lastCellKey 만 지우고 끝내던 형태로 되돌아가면 안 된다.
+  assert.match(body, /this\.lastCellKey = null/, 'lastCellKey 무효화 유지');
+  assert.match(body, /this\.protectedCellHitCache = null/, 'protectedCellHitCache 무효화 유지');
+});
+
+test('무효화 루틴이 두 캐시 필드를 모두 비운다', () => {
+  const body = methodBody('clearTableResizeRuntimeCache');
+  assert.match(body, /this\.cachedTableRef = null/, 'cachedTableRef 를 비워야 함');
+  assert.match(body, /this\.cachedCellBboxes = null/, 'cachedCellBboxes 를 비워야 함');
+});
+
+test('undo/redo 도 같은 루틴을 계속 사용한다', () => {
+  // 구조 편집만 고치고 undo/redo 경로가 빠지면 반쪽짜리가 된다(회귀 그물).
+  const calls = src.match(/this\.clearTableResizeRuntimeCache\(\)/g) ?? [];
+  assert.ok(calls.length >= 3,
+    `문서 로드·undo/redo·편집 후 처리에서 모두 호출돼야 함(현재 ${calls.length}곳)`);
+});


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`afterEdit`(`src/engine/input-handler.ts`)은 `lastCellKey` 를 **"편집 후 셀 bbox 캐시 무효화"**
주석과 함께 지우지만, 정작 표 리사이즈 런타임 캐시(`cachedCellBboxes` / `cachedTableRef`)는
건드리지 않습니다.

```ts
this.lastCellKey = null; // 편집 후 셀 bbox 캐시 무효화
this.protectedCellHitCache = null;
```

`cachedTableRef` 는 `{sec, ppi, ci}` — 표의 **정체성**만 담습니다. 줄/칸 삽입·삭제, 셀
합치기·나누기는 이 셋을 바꾸지 않으므로 `handleResizeHover` 의 신선도 검사
(`sec`/`ppi`/`ci`/`pageHint`)를 그대로 통과합니다. 반면 `cachedCellBboxes` 의 기하와
`cellIdx` 번호는 바뀝니다.

```
10줄 표에서 셀 선택 모드로 클릭(캐시 채워짐) → 표 > 줄 지우기 ×2 → Esc
→ 지금의 5/6행 경계를 드래그

기대: 현재 5/6행이 리사이즈됨
실제: 옛 경계에 marker 가 뜨고(짧아진 표 아래 빈 공간에서도 잡힘),
      옛 번호의 cellIdx 로 다른 두 행이 리사이즈됨
```

중간에 교정될 기회가 없습니다.

- `resolveTableResizeHit` 은 캐시를 **아무 검증 없이** 반환합니다 — `hitTest` 도, `pageHint`
  비교도, 신선도 토큰도 없습니다.
- `startResizeDrag` 는 그 배열을 `resizeDragState.bboxes` 에 그대로 저장하고,
  `finishResizeDrag` 는 재조회 없이 `state.bboxes` 의 `cellIdx` 로 `resizeTableCells` 를 부릅니다.

### 수정

문서 로드(`:625`, `:628`)와 undo/redo(`:2130`, `:2145`)는 **이미 같은 이유로**
`clearTableResizeRuntimeCache()` 를 호출합니다. 구조 편집 경로만 빠져 있었으므로 동일하게
맞췄습니다.

기존 루틴을 재사용해 `tableLocalResizeSegments` 와 marker 까지 함께 정리되므로, 필드를
개별로 나열하는 것보다 누락 위험이 없습니다.

### 왜 이제껏 안 드러났는가

캐시를 채우는 유일한 지점(`input-handler-mouse.ts`)이 **셀 선택 모드** 가드 안에 있어서,
캐시가 살아있는 상태로 구조 편집을 하는 경로가 좁습니다. 또 포인터가 표 밖으로 나가면
hover 경로가 캐시를 비웁니다. 다만 Esc 나 일반 키 입력으로 셀 선택 모드를 빠져나가는 것만으로는
캐시가 지워지지 않아, 그 조합에서 재현됩니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **미실행**. Rust 코드 변경이 없습니다(TypeScript 단독 변경).
- [ ] `cargo clippy -- -D warnings` 통과 — **미실행**. 동일 사유입니다.
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미확인**. 아래 참고.

실행한 검증:

```
cd rhwp-studio && npm test
→ 402개 중 400 통과
```

실패 2건(`tests/canvaskit-resource-key.test.ts`, `tests/cell-flow-boundary.test.ts`)은 이 변경과
무관한 사전 실패이며, clean `devel` 에서도 동일하게 재현됩니다.

추가한 `tests/table-bbox-cache-invalidation.test.ts` 는 **수정 전 3건 중 1 실패, 수정 후 3/3
통과**를 `git stash` 로 원본을 되돌려 확인했습니다.

## 확인하지 못한 항목

- **브라우저 재현은 하지 못했습니다.** 판단 근거는 `cachedCellBboxes` 의 대입 지점 전수 확인
  (채우는 곳 1군데, 비우는 곳 3군데), `clearTableResizeRuntimeCache` 호출부 전수 확인
  (문서 로드 2 + undo/redo 2), 그리고 `afterEdit` / `document-changed` 구독자가 이 두 필드를
  건드리지 않는다는 점입니다.
- 성능 영향: `afterEdit` 은 전체 재렌더 경로이고, 텍스트 입력은 `afterPageLocalEdit` 를 타므로
  타이핑마다 캐시가 지워지지는 않습니다. 다만 구조 편집 직후 첫 hover 는 bbox 를 다시
  조회하게 됩니다(대형 표에서 한 번의 비용). 이 트레이드오프가 과하다고 보시면
  구조 편집 커맨드에서만 선별 호출하는 쪽으로 좁히겠습니다.

## 스크린샷

marker 위치 차이라 변경 전후 비교가 유의미하지만, 브라우저 검증을 못 해 첨부하지 못했습니다.