### PR TITLE
fix(parser): lenient CFB 파서가 손상된 헤더 값에 패닉하지 않도록 검증 추가

### DIFF
--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -316,9 +316,28 @@ impl LenientCfbReader {
             return Err(CfbError::OpenError("CFB 매직 넘버 불일치".into()));
         }
 
+        // 섹터 크기 지수는 파일에서 온 값(0~65535)이라 검증 없이 shift 하면 안 된다.
+        // - power >= 64(wasm32 에서는 >= 32): `1usize << power` 가 shift overflow.
+        //   debug 는 패닉, release 는 마스킹돼 엉뚱한 sector_size 가 된다.
+        // - power 가 0·1 이면 sector_size 가 1·2 라 아래 DIFAT 순회의
+        //   `sector_size / 4 - 1` 이 언더플로한다(debug 패닉, release 는 usize::MAX 로
+        //   감싸져 곧바로 슬라이스 범위 초과 패닉).
+        // CFB 사양상 섹터 크기는 512B(9) 또는 4096B(12)이므로 그 범위를 벗어나면
+        // 해석을 포기하고 Err 를 돌려준다. 패닉은 WASM 모듈 전체를 죽여 편집 중인
+        // 다른 문서까지 잃게 하므로, 열기 실패로 처리하는 편이 언제나 낫다.
         let sector_size_power = u16::from_le_bytes([data[30], data[31]]) as usize;
+        if !(9..=12).contains(&sector_size_power) {
+            return Err(CfbError::OpenError(format!(
+                "CFB 섹터 크기 지수가 사양 범위를 벗어남: {sector_size_power}"
+            )));
+        }
         let sector_size = 1usize << sector_size_power;
         let mini_sector_size_power = u16::from_le_bytes([data[32], data[33]]) as usize;
+        if mini_sector_size_power >= usize::BITS as usize {
+            return Err(CfbError::OpenError(format!(
+                "CFB 미니 섹터 크기 지수가 사양 범위를 벗어남: {mini_sector_size_power}"
+            )));
+        }
         let _mini_sector_size = 1usize << mini_sector_size_power;
 
         let fat_sectors_count =
@@ -402,7 +421,12 @@ impl LenientCfbReader {
         let n_entries = dir_data.len() / entry_size;
         for i in 0..n_entries {
             let eoff = i * entry_size;
-            let name_len = u16::from_le_bytes([dir_data[eoff + 64], dir_data[eoff + 65]]) as usize;
+            // name_len 도 파일에서 온 값(0~65535)이다. 이름 필드는 엔트리 선두 64바이트이므로
+            // 그보다 큰 값은 손상으로 보고 잘라낸다. 잘라내지 않으면 아래 슬라이스가
+            // dir_data(= n_entries * 128 바이트) 범위를 넘어 패닉한다 — 슬라이스 경계 검사는
+            // release 에서도 켜져 있어 배포 WASM 에서도 그대로 터진다.
+            let name_len =
+                (u16::from_le_bytes([dir_data[eoff + 64], dir_data[eoff + 65]]) as usize).min(64);
             let name = if name_len > 2 {
                 let name_bytes = &dir_data[eoff..eoff + name_len - 2]; // UTF-16LE, exclude null
                 String::from_utf16_lossy(
@@ -660,6 +684,72 @@ pub fn decompress_stream(data: &[u8]) -> Result<Vec<u8>, CfbError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // ── LenientCfbReader 헤더 필드 검증 ──────────────────────────────────
+    //
+    // LenientCfbReader 는 엄격 파서가 실패한 뒤에만 쓰인다(parser/mod.rs). 즉 입력 모집단이
+    // "이미 손상이 확인된 파일"이라, 헤더 필드에 쓰레기 값이 들어있을 확률이 가장 높은
+    // 자리다. 그런데 파일에서 온 값을 검증 없이 shift/슬라이스에 쓰고 있었다.
+    // WASM 에서 패닉은 모듈 전체를 트랩시켜 편집 중이던 다른 문서까지 잃게 하므로,
+    // 해석 불가한 헤더는 패닉이 아니라 Err 로 돌려줘야 한다.
+
+    /// 최소 CFB 헤더(512B). 섹터 크기 512B, DIFAT/디렉터리 없음.
+    fn minimal_header() -> Vec<u8> {
+        let mut d = vec![0u8; 512];
+        d[0..8].copy_from_slice(&[0xD0, 0xCF, 0x11, 0xE0, 0xA1, 0xB1, 0x1A, 0xE1]);
+        d[30..32].copy_from_slice(&9u16.to_le_bytes()); // sector size = 1 << 9
+        d[32..34].copy_from_slice(&6u16.to_le_bytes()); // mini sector size = 1 << 6
+        d[68..72].copy_from_slice(&0xFFFF_FFFEu32.to_le_bytes()); // first DIFAT = EOC
+        d
+    }
+
+    #[test]
+    fn lenient_open_rejects_out_of_range_sector_size_power() {
+        // power >= 64 는 `1usize << power` 가 shift overflow(debug 패닉 / release 마스킹).
+        let mut d = minimal_header();
+        d[30..32].copy_from_slice(&64u16.to_le_bytes());
+        assert!(LenientCfbReader::open(&d).is_err(), "shift overflow 대신 Err 이어야 함");
+
+        // power 0·1 은 sector_size 가 1·2 라 DIFAT 순회의 `sector_size / 4 - 1` 이 언더플로.
+        for bad in [0u16, 1u16] {
+            let mut d = minimal_header();
+            d[30..32].copy_from_slice(&bad.to_le_bytes());
+            d[68..72].copy_from_slice(&0u32.to_le_bytes()); // DIFAT 체인 진입
+            d[72..76].copy_from_slice(&1u32.to_le_bytes());
+            assert!(
+                LenientCfbReader::open(&d).is_err(),
+                "sector_size_power={bad} 에서 언더플로 대신 Err 이어야 함"
+            );
+        }
+    }
+
+    #[test]
+    fn lenient_open_rejects_out_of_range_mini_sector_size_power() {
+        let mut d = minimal_header();
+        d[32..34].copy_from_slice(&64u16.to_le_bytes());
+        assert!(LenientCfbReader::open(&d).is_err(), "shift overflow 대신 Err 이어야 함");
+    }
+
+    #[test]
+    fn lenient_open_survives_oversized_directory_entry_name_len() {
+        // 디렉터리 섹터까지 도달하는 최소 컨테이너.
+        // 레이아웃: [0]=헤더 512B, [512]=FAT 섹터, [1024]=디렉터리 섹터
+        let mut d = minimal_header();
+        d[44..48].copy_from_slice(&1u32.to_le_bytes()); // FAT 섹터 1개
+        d[48..52].copy_from_slice(&1u32.to_le_bytes()); // 디렉터리 시작 = 섹터 1
+        d[76..80].copy_from_slice(&0u32.to_le_bytes()); // DIFAT[0] = FAT 은 섹터 0
+        d.resize(512 * 3, 0);
+
+        // FAT(섹터 0): 엔트리 1 = END_OF_CHAIN → 디렉터리 체인은 한 섹터로 끝난다.
+        d[512 + 4..512 + 8].copy_from_slice(&0xFFFF_FFFEu32.to_le_bytes());
+
+        // 디렉터리(섹터 1)의 첫 엔트리 name_len 을 최대값으로 손상시킨다.
+        // 잘라내지 않으면 dir_data(512B) 범위를 한참 넘겨 슬라이스해 패닉한다.
+        d[1024 + 64..1024 + 66].copy_from_slice(&0xFFFFu16.to_le_bytes());
+
+        let r = LenientCfbReader::open(&d);
+        assert!(r.is_ok(), "손상된 name_len 에서 패닉 없이 열려야 함");
+    }
 
     #[test]
     fn test_decompress_empty() {

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -708,7 +708,10 @@ mod tests {
         // power >= 64 는 `1usize << power` 가 shift overflow(debug 패닉 / release 마스킹).
         let mut d = minimal_header();
         d[30..32].copy_from_slice(&64u16.to_le_bytes());
-        assert!(LenientCfbReader::open(&d).is_err(), "shift overflow 대신 Err 이어야 함");
+        assert!(
+            LenientCfbReader::open(&d).is_err(),
+            "shift overflow 대신 Err 이어야 함"
+        );
 
         // power 0·1 은 sector_size 가 1·2 라 DIFAT 순회의 `sector_size / 4 - 1` 이 언더플로.
         for bad in [0u16, 1u16] {
@@ -727,7 +730,10 @@ mod tests {
     fn lenient_open_rejects_out_of_range_mini_sector_size_power() {
         let mut d = minimal_header();
         d[32..34].copy_from_slice(&64u16.to_le_bytes());
-        assert!(LenientCfbReader::open(&d).is_err(), "shift overflow 대신 Err 이어야 함");
+        assert!(
+            LenientCfbReader::open(&d).is_err(),
+            "shift overflow 대신 Err 이어야 함"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`LenientCfbReader::open`(`src/parser/cfb_reader.rs`)이 파일에서 읽은 헤더 값을 **검증 없이**
shift·슬라이스에 사용해, 손상된 파일을 열 때 패닉합니다.

이 함수는 **엄격 파서가 실패한 뒤에만** 호출됩니다(`src/parser/mod.rs`의 폴백 경로). 즉 입력
모집단이 "이미 손상이 확인된 파일"이라, 헤더에 쓰레기 값이 들어있을 확률이 가장 높은 자리에
검증이 없는 상태였습니다.

WASM 에서 패닉은 모듈 전체를 트랩시킵니다. `console_error_panic_hook` 이 로그를 남겨도 인스턴스는
죽고, `wasm-bridge.ts` 의 `try/catch` 로도 복구되지 않습니다. **편집 중이던 다른 문서까지 함께
잃습니다.** 그래서 해석 불가한 헤더는 패닉이 아니라 `Err` 로 돌려주는 것이 언제나 낫습니다.

### 1. `sector_size_power` — `data[30..32]`, 0~65535

```rust
let sector_size = 1usize << sector_size_power;
```

- `power >= 64`(wasm32 는 `>= 32`) → **shift overflow**. debug 패닉 / release 마스킹.
- `power` 가 0·1 이면 `sector_size` 가 1·2 라, DIFAT 순회의 `sector_size / 4 - 1` 이 **언더플로**.
  debug 패닉 / release 는 `usize::MAX` 로 감싸져 곧바로 슬라이스 범위 초과 패닉.

CFB 사양상 섹터 크기는 512B(9) 또는 4096B(12)이므로 그 범위를 벗어나면 `Err` 로 돌려줍니다.

### 2. `mini_sector_size_power` — `data[32..34]`

같은 shift overflow. 범위 검사를 추가했습니다.

### 3. `name_len` — 디렉터리 엔트리 `data[eoff+64..66]`, 0~65535

```rust
let name = if name_len > 2 {
    let name_bytes = &dir_data[eoff..eoff + name_len - 2];
```

`> 2` 만 검사하고 **상한이 없습니다.** `dir_data.len() == n_entries * 128` 이고 `eoff == i * 128`
이므로, `name_len > 130` 이면 범위를 넘겨 슬라이스합니다. 이름 필드는 엔트리 선두 64바이트이므로
64 로 잘라냅니다.

**세 건 중 유일하게 릴리스 빌드를 죽이는 경로입니다** — 슬라이스 경계 검사는 `overflow-checks`
와 무관하게 항상 켜져 있어, 배포되는 WASM 에서도 그대로 터집니다.

### 재현 경로

다운로드 중단·저장 실패 등으로 잘린 `.hwp` 를 연다 → 엄격 파서가 거부 → **설계대로** lenient 로
폴백 → 손상된 헤더 값에서 패닉 → 편집기 탭 사망.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [x] `cargo test` 통과 — **2286 passed, 0 failed, 7 ignored** (`cargo test --lib`)
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로 변경이 아닙니다.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 렌더링 변경이 아니며, 이 변경의 효과는
      "손상 파일에서 패닉하지 않는 것"이라 Rust 테스트로 직접 증명했습니다.

추가한 테스트 3건은 **정적 소스 검사가 아니라 실제 바이트 픽스처로 패닉을 재현**합니다.

```
lenient_open_rejects_out_of_range_sector_size_power
lenient_open_rejects_out_of_range_mini_sector_size_power
lenient_open_survives_oversized_directory_entry_name_len
```

수정 전 소스로 되돌려 실행하면 **3/3 실패**하며, 패닉이 그대로 관측됩니다.

```
panicked at src\parser\cfb_reader.rs:329: attempt to shift left with overflow
panicked at src\parser\cfb_reader.rs:331: attempt to shift left with overflow
panicked at src\parser\cfb_reader.rs:420: (슬라이스 범위 초과)
```

수정 후 3/3 통과입니다.

## 이 PR 에서 다루지 않은 것

같은 파일의 `read_chain_static`(`:469`)과 `read_mini_stream`(`:490`)은 체인 순회에서
`END_OF_CHAIN`/`FREE_SECT` 만 걸러내고 `DIFSECT`(`0xFFFFFFFC`)·`FATSECT`(`0xFFFFFFFD`)는
일반 섹터 번호로 통과시킵니다. **wasm32 에서는** `sid as usize * sector_size` 가 오버플로하고,
`off + sector_size > data.len()` 가드 자체도 같은 조건에서 오버플로해 불건전해집니다.

host(64비트)에서는 곱셈이 오버플로하지 않고 가드가 정상 동작하므로 **로컬 `cargo test` 로
증명할 수 없어** 이 PR 범위에서 제외했습니다. 별도로 다루는 게 좋을지 판단 부탁드립니다.

## 스크린샷

파서 변경이라 첨부하지 않았습니다.