### PR TITLE
fix(hwpx): secPr 의 grid/startNum/tabStop 이 IR 값 대신 템플릿 상수로 저장되던 문제 수정

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -97,9 +97,45 @@ fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
         &format!(r#"spaceColumns="{}""#, sd.column_spacing),
         1,
     );
-    out.replacen(
+    let out = out.replacen(
         r#"outlineShapeIDRef="1""#,
         &format!(r#"outlineShapeIDRef="{}""#, sd.outline_numbering_id),
+        1,
+    );
+
+    // 기본 탭 폭. HWPX 파서는 secPr 의 tabStop 속성을 default_tab_spacing 으로 읽는다
+    // (parser/hwpx/section.rs). 치환하지 않으면 열었던 값과 무관하게 늘 템플릿 상수
+    // 8000 으로 저장돼, 탭 정렬이 원본과 어긋난다.
+    //
+    // 다만 SectionDef 는 derive(Default) 라 파싱을 거치지 않은 문서(신규 작성 등)에서는
+    // 0 이다. 0 을 그대로 내보내면 탭 폭이 0 이 되어 지금보다 나빠지므로, 값이 있을 때만
+    // 치환하고 없으면 템플릿 기본값을 유지한다.
+    let out = if sd.default_tab_spacing != 0 {
+        out.replacen(
+            r#"tabStop="8000""#,
+            &format!(r#"tabStop="{}""#, sd.default_tab_spacing),
+            1,
+        )
+    } else {
+        out
+    };
+
+    // 구역 그리드와 시작 번호. 템플릿 상수가 모두 0 이고 SectionDef 기본값도 0 이라
+    // 기본 문서의 출력은 그대로이며, 파싱된 문서에서만 실제 값이 살아난다.
+    let out = out.replacen(
+        r#"<hp:grid lineGrid="0" charGrid="0" wonggojiFormat="0"/>"#,
+        &format!(
+            r#"<hp:grid lineGrid="{}" charGrid="{}" wonggojiFormat="0"/>"#,
+            sd.line_grid, sd.char_grid
+        ),
+        1,
+    );
+    out.replacen(
+        r#"<hp:startNum pageStartsOn="BOTH" page="0" pic="0" tbl="0" equation="0"/>"#,
+        &format!(
+            r#"<hp:startNum pageStartsOn="BOTH" page="{}" pic="{}" tbl="{}" equation="{}"/>"#,
+            sd.page_num, sd.picture_num, sd.table_num, sd.equation_num
+        ),
         1,
     )
 }
@@ -2355,6 +2391,54 @@ mod tests {
             !xml.contains(r#"styleIDRef="96""#),
             "미등록 style_id 는 방출되지 않아야 함"
         );
+    }
+
+    #[test]
+    fn secpr_emits_ir_tab_stop_grid_and_start_num() {
+        // 템플릿 secPr 의 grid / startNum / tabStop 은 [#1987] 의 spaceColumns·
+        // outlineShapeIDRef 치환에서 빠져 있어, IR 값과 무관하게 늘 템플릿 상수로
+        // 나갔다. 열었다 저장하면 구역 그리드·시작 번호·기본 탭 폭이 사라진다.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, _) = make_doc_with_paragraph(para);
+        {
+            let sd = &mut doc.sections[0].section_def;
+            sd.default_tab_spacing = 4000;
+            sd.line_grid = 1200;
+            sd.char_grid = 900;
+            sd.page_num = 47;
+            sd.picture_num = 3;
+            sd.table_num = 5;
+            sd.equation_num = 7;
+        }
+        let section = doc.sections[0].clone();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(xml.contains(r#"tabStop="4000""#), "기본 탭 폭이 IR 값이어야 함: {xml:.600}");
+        assert!(
+            xml.contains(r#"<hp:grid lineGrid="1200" charGrid="900" wonggojiFormat="0"/>"#),
+            "구역 그리드가 IR 값이어야 함: {xml:.600}"
+        );
+        assert!(
+            xml.contains(
+                r#"<hp:startNum pageStartsOn="BOTH" page="47" pic="3" tbl="5" equation="7"/>"#
+            ),
+            "시작 번호가 IR 값이어야 함: {xml:.600}"
+        );
+    }
+
+    #[test]
+    fn secpr_keeps_template_tab_stop_when_ir_unset() {
+        // SectionDef 는 derive(Default) 라 파싱을 거치지 않은 문서에서 0 이다.
+        // 0 을 그대로 내보내면 탭 폭이 0 이 되어 지금보다 나빠지므로 템플릿 기본값을 유지한다.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, section) = make_doc_with_paragraph(para);
+        assert_eq!(section.section_def.default_tab_spacing, 0, "전제: 기본값은 0");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(xml.contains(r#"tabStop="8000""#), "IR 미설정 시 템플릿 상수 유지: {xml:.600}");
     }
 
     #[test]

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2415,7 +2415,10 @@ mod tests {
         let mut ctx = SerializeContext::collect_from_document(&doc);
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
 
-        assert!(xml.contains(r#"tabStop="4000""#), "기본 탭 폭이 IR 값이어야 함: {xml:.600}");
+        assert!(
+            xml.contains(r#"tabStop="4000""#),
+            "기본 탭 폭이 IR 값이어야 함: {xml:.600}"
+        );
         assert!(
             xml.contains(r#"<hp:grid lineGrid="1200" charGrid="900" wonggojiFormat="0"/>"#),
             "구역 그리드가 IR 값이어야 함: {xml:.600}"
@@ -2435,10 +2438,16 @@ mod tests {
         let mut para = Paragraph::default();
         para.text = "x".to_string();
         let (doc, section) = make_doc_with_paragraph(para);
-        assert_eq!(section.section_def.default_tab_spacing, 0, "전제: 기본값은 0");
+        assert_eq!(
+            section.section_def.default_tab_spacing, 0,
+            "전제: 기본값은 0"
+        );
         let mut ctx = SerializeContext::collect_from_document(&doc);
         let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
-        assert!(xml.contains(r#"tabStop="8000""#), "IR 미설정 시 템플릿 상수 유지: {xml:.600}");
+        assert!(
+            xml.contains(r#"tabStop="8000""#),
+            "IR 미설정 시 템플릿 상수 유지: {xml:.600}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

HWPX writer 는 고정 템플릿(`templates/empty_section0.xml`)에 `replacen` 을 적용하는 구조라,
치환 목록에 없는 `secPr` 하위 요소는 **IR 내용과 무관하게 템플릿 상수 그대로** 나갑니다.

`[#1987]` 이 `spaceColumns` · `outlineShapeIDRef` 를 IR 치환 대상으로 만들었는데
(`replace_secpr_scalars`), 아래 셋은 빠져 있었습니다.

| 템플릿 상수 | IR 필드 |
| --- | --- |
| `<hp:grid lineGrid="0" charGrid="0" …/>` | `SectionDef.line_grid` / `char_grid` |
| `<hp:startNum … page="0" pic="0" tbl="0" equation="0"/>` | `page_num` / `picture_num` / `table_num` / `equation_num` |
| `tabStop="8000"` | `default_tab_spacing` |

`tabStop` 이 `default_tab_spacing` 이라는 근거는 파서 쪽입니다 — `src/parser/hwpx/section.rs` 의
`b"tabStop" => { sec_def.default_tab_spacing = parse_u32(&attr); }`.

### 사용자 영향

HWPX 를 **열었다 저장하기만 해도** 다음이 사라집니다.

- 47쪽부터 시작하던 구역의 시작 페이지 번호가 1 로 돌아갑니다(그림/표/수식 번호도 동일).
  이어지는 장(章) 문서에서 모든 쪽 번호가 어긋납니다.
- 원고지·그리드 정렬 문서의 구역 그리드가 꺼집니다.
- 기본 탭 폭이 늘 8000 으로 덮어써져, 탭 정렬과 목차 점선이 원본과 어긋납니다.

HWP(바이너리) writer 는 셋 다 보존합니다(`src/serializer/control.rs`). **포맷 한계가 아니라
HWPX 쪽 누락**입니다.

### tabStop 만 조건부로 치환한 이유

`SectionDef` 는 `derive(Default)` 라 파싱을 거치지 않은 문서(신규 작성 등)에서
`default_tab_spacing` 이 0 입니다. 0 을 그대로 내보내면 탭 폭이 0 이 되어 **지금보다 나빠집니다.**
그래서 값이 있을 때만 치환하고, 없으면 템플릿 기본값 8000 을 유지합니다.

`grid` / `startNum` 은 템플릿 상수와 IR 기본값이 **모두 0** 이라 무조건 치환해도 기본 문서의
출력이 동일합니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [x] `cargo test` 통과 — **2285 passed, 0 failed, 7 ignored** (`cargo test --lib`)
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로가 아니라 직렬화 변경입니다.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 동일 사유이며, 효과는 "저장된 XML 에 IR 값이 실리는 것"
      이라 Rust 테스트로 직접 증명했습니다.

추가한 테스트 2건:

```
secpr_emits_ir_tab_stop_grid_and_start_num   — IR 값이 실제 XML 에 나가는지
secpr_keeps_template_tab_stop_when_ir_unset  — 미설정 시 템플릿 기본값 유지(위 설계 근거)
```

수정 전 소스로 되돌리면 전자가 **실패**합니다. 기존 `secpr_emits_tab_stop_val_and_unit` 은
**수정 없이 그대로 통과**합니다 — 조건부 치환 설계가 기존 계약을 깨지 않는다는 증거입니다.

## 함께 발견했지만 이 PR 에 넣지 않은 것

같은 감사에서 HWPX writer 의 누락 두 건을 더 확인했습니다. 성격이 달라 분리했습니다.

1. **각주/미주 번호 형식** — `replace_footnote_shape` 가 `noteLine` / `noteSpacing` 만 치환해서
   `autoNumFormat`(①②③ 등) · `numbering`(쪽마다 새 번호) · `placement`(미주 위치)가 템플릿
   상수로 나갑니다. 특히 `placement` 는 미주 블록의 물리적 위치를 바꿉니다.
2. **`Control::HiddenComment`(숨은 설명)** — `render_control_slot` 에 arm 이 없어 통째로
   사라집니다. HWP writer 는 `serialize_hidden_comment` 로 처리합니다.

원하시면 이어서 올리겠습니다. 1번은 이 PR 과 같은 치환 방식이고, 2번은 컨트롤 슬롯 추가라
범위가 조금 더 큽니다.

## 스크린샷

직렬화 변경이라 첨부하지 않았습니다.