### PR TITLE
fix(hwp): HTML 붙여넣기 서식이 저장 시 사라지던 문제 수정 (raw_data 미무효화)

### DIFF
--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -842,6 +842,13 @@ impl DocumentCore {
             0
         };
         let mut cs = self.document.doc_info.char_shapes[base_id as usize].clone();
+        // 파싱된 문서의 CharShape 는 원본 CHAR_SHAPE 레코드 바이트를 raw_data 로 들고 있고
+        // (parser/doc_info.rs), 직렬화기는 raw_data 가 있으면 필드 대신 그 바이트를 그대로
+        // 쓴다(serializer/doc_info.rs). 아래에서 굵기·색·크기를 바꿔도 raw_data 를 비우지
+        // 않으면 저장 시 원본 서식 바이트가 나가 붙여넣은 서식이 통째로 사라진다.
+        // PartialEq 가 raw_data 를 비교에서 제외하므로 아래 중복 검색도 이를 걸러내지 못한다.
+        // CharShapeMods::apply_to(model/style.rs)가 같은 이유로 첫 줄에서 raw_data 를 비운다.
+        cs.raw_data = None;
 
         // CSS 속성 파싱 및 적용
         let css_lower = css.to_lowercase();
@@ -936,6 +943,9 @@ impl DocumentCore {
             .get(base_id as usize)
             .cloned()
             .unwrap_or_default();
+        // CharShape 쪽과 동일 — 원본 PARA_SHAPE 바이트를 비우지 않으면 정렬·줄간격 변경이
+        // 저장 시 사라진다(ParaShapeMods::apply_to 와 같은 처리).
+        ps.raw_data = None;
 
         let css_lower = css.to_lowercase();
 
@@ -996,5 +1006,55 @@ impl DocumentCore {
             }
         }
         None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::document::Document;
+    use crate::model::style::{CharShape, ParaShape};
+
+    /// 파싱을 거친 문서를 흉내낸다 — CharShape/ParaShape 가 원본 레코드 바이트를
+    /// raw_data 로 들고 있는 상태(parser/doc_info.rs 가 하는 일).
+    fn core_with_parsed_shapes() -> DocumentCore {
+        let mut doc = Document::default();
+        let mut cs = CharShape::default();
+        cs.raw_data = Some(vec![0xAA; 72]);
+        doc.doc_info.char_shapes.push(cs);
+        let mut ps = ParaShape::default();
+        ps.raw_data = Some(vec![0xBB; 54]);
+        doc.doc_info.para_shapes.push(ps);
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core
+    }
+
+    // HTML 붙여넣기가 만드는 CharShape/ParaShape 는 char_shapes[0]/para_shapes[0] 의 clone
+    // 이라 원본 raw_data 를 물고 온다. 직렬화기는 raw_data 가 있으면 필드 대신 그 바이트를
+    // 그대로 쓰므로(serializer/doc_info.rs), 비우지 않으면 붙여넣은 서식이 저장 시 사라진다.
+    // PartialEq 가 raw_data 를 제외하므로 중복 검색도 이를 걸러내지 못한다.
+
+    #[test]
+    fn html_paste_char_shape_drops_stale_raw_data() {
+        let mut core = core_with_parsed_shapes();
+        let id = core.css_to_char_shape_id("font-weight:bold;color:#ff0000", false, false, false);
+        let cs = &core.document.doc_info.char_shapes[id as usize];
+        assert!(cs.bold, "전제: CSS 가 반영돼야 함");
+        assert!(
+            cs.raw_data.is_none(),
+            "raw_data 가 남으면 저장 시 원본 서식 바이트가 나가 붙여넣은 서식이 사라진다"
+        );
+    }
+
+    #[test]
+    fn html_paste_para_shape_drops_stale_raw_data() {
+        let mut core = core_with_parsed_shapes();
+        let id = core.css_to_para_shape_id("text-align:center");
+        let ps = &core.document.doc_info.para_shapes[id as usize];
+        assert!(
+            ps.raw_data.is_none(),
+            "raw_data 가 남으면 정렬·줄간격 변경이 저장 시 사라진다"
+        );
     }
 }


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`css_to_char_shape_id` / `css_to_para_shape_id`(`src/document_core/commands/html_import.rs`)는
`char_shapes[0]` / `para_shapes[0]` 를 clone 해 CSS 를 반영하는데, **clone 이 물고 온 `raw_data`
를 비우지 않습니다.**

파싱된 문서의 `CharShape`/`ParaShape` 는 원본 레코드 바이트를 `raw_data` 로 들고 있고
(`src/parser/doc_info.rs`), 직렬화기는 `raw_data` 가 있으면 **필드 대신 그 바이트를 그대로**
씁니다.

```rust
// src/serializer/doc_info.rs
let data = cs.raw_data.clone().unwrap_or_else(|| serialize_char_shape(cs));
```

즉 굵기·기울임·색·크기·글꼴·밑줄·취소선(그리고 정렬·줄간격)을 아무리 바꿔도, 저장되는 것은
`char_shapes[0]` 의 **원본 바이트**입니다. `serialize_char_shape` 는 아예 호출되지 않습니다.

게다가 `PartialEq for CharShape`(`src/model/style.rs`)가 `raw_data` 를 비교에서 제외하므로,
바로 아래의 중복 검색도 이 stale clone 을 걸러내지 못하고 새 레코드로 push 합니다.
결과적으로 파일에는 새 `CHAR_SHAPE` 레코드가 N 개 생기지만 **전부 0번과 바이트 동일**합니다.

### 사용자 시나리오

```
브라우저/워드에서 굵은 빨간 14pt 제목을 복사 → 붙여넣기 → 편집기에는 정상 표시
→ 저장 → 다시 열기: 붙여넣은 서식이 전부 문서 기본 서식으로 되돌아감
```

`raw_stream_dirty = true` 는 이미 설정되고 있어 DocInfo 스트림이 재생성되는데, 바로 그것이
레코드별 stale 바이트를 드러냅니다.

### 선례

같은 계열의 `CharShapeMods::apply_to`(`style.rs:759`)와 `ParaShapeMods::apply_to`(`:918`)는
**첫 줄에서 `raw_data = None`** 을 합니다. 이 경로만 빠져 있었습니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **전체 스위트는 실행하지 못했습니다.** 아래 참고.
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`, 이 변경 반영 상태)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로가 아니라 직렬화 변경입니다.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 동일 사유입니다.

추가한 테스트 2건은 **정상 실행해 red→green 을 확인했습니다.**

```
html_paste_char_shape_drops_stale_raw_data
html_paste_para_shape_drops_stale_raw_data
```

- 수정 후: **2/2 통과**
- 수정 전 소스로 되돌림: **2/2 실패** (두 단언 모두 패닉)

파싱된 문서를 흉내내 `raw_data` 가 채워진 상태에서 호출하고, 결과 shape 의 `raw_data` 가
비워졌는지 확인합니다.

### 전체 스위트를 못 돌린 이유 (정직하게)

이 변경을 반영한 뒤 전체 `cargo test --lib` 를 **10회 이상 시도했지만 매번 실행 자체가
차단**됐습니다.

```
could not execute process `target\debug\deps\rhwp-*.exe`
애플리케이션 제어 정책에서 이 파일을 차단했습니다. (os error 4551)
```

제 로컬 PC 의 보안 소프트웨어가 새로 빌드된 서명 없는 실행 파일을 차단하는 문제입니다.
바이너리를 다른 경로로 복사해 실행하는 것도 동일하게 막혀(해시 기반) 우회하지 못했습니다.
**저장소나 이 변경의 문제가 아닙니다** — 같은 환경에서 조금 전 다른 브랜치의 전체 스위트는
2285~2286 passed / 0 failed 로 통과했습니다.

변경 자체는 지역 변수에 `raw_data = None` 두 줄이라 다른 테스트에 영향을 줄 표면이 없다고
보지만, **확인하지 못한 것은 확인하지 못한 것**이므로 체크하지 않았습니다. CI 결과로
판단해 주시고, CI 에서 문제가 보이면 바로 대응하겠습니다.

## 같은 계열의 남은 건 (이 PR 범위 밖)

`update_neighbor_borders`(`src/document_core/commands/table_ops.rs`)도 `border_fills` 를
clone → 변경 → push 하면서 `raw_data` 를 비우지 않습니다. 셀 테두리를 바꾸면 **이웃 셀의
공유 변**이 저장 시 옛 바이트로 되돌아갑니다. 같은 커맨드 안의 형제
`create_border_fill_from_json` 은 `bf.raw_data = None` 을 합니다.

기능이 달라(HTML 붙여넣기 vs 표 테두리) 분리했습니다. 이어서 올릴까요?

## 스크린샷

직렬화 변경이라 첨부하지 않았습니다.