### PR TITLE
fix(hwp): 이웃 셀 테두리 갱신이 저장 시 옛 바이트로 되돌아가던 문제 수정

### DIFF
--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1311,6 +1311,14 @@ impl DocumentCore {
 
             let mut new_bf = self.document.doc_info.border_fills[bf_idx].clone();
             new_bf.borders[dir] = new_border;
+            // 파싱된 문서의 BorderFill 은 원본 BORDER_FILL 레코드 바이트를 raw_data 로
+            // 들고 있고(parser/doc_info.rs), 직렬화기는 raw_data 가 있으면 필드 대신 그
+            // 바이트를 그대로 쓴다(serializer/doc_info.rs). 비우지 않으면 위에서 바꾼
+            // borders[dir] 이 저장 시 사라져 이웃 셀의 공유 변이 옛 테두리로 되돌아간다.
+            // border_fills_equal(helpers.rs)이 raw_data 를 비교에서 제외하므로 아래
+            // 중복 검색도 이를 걸러내지 못한다. 같은 커맨드의 형제
+            // create_border_fill_from_json(html_table_import.rs)은 이미 raw_data 를 비운다.
+            new_bf.raw_data = None;
 
             // 동일한 BorderFill 검색/추가
             let bf_id = {
@@ -2949,5 +2957,119 @@ mod table_attr_save_roundtrip_tests {
             matches!(vrel, VertRelTo::Para),
             "vertRelTo 변경이 HWP5 저장에서 유실됨 (실제: {vrel:?})"
         );
+    }
+}
+
+#[cfg(test)]
+mod neighbor_border_raw_data_tests {
+    //! 이웃 셀 테두리 갱신의 raw_data 유실 회귀 테스트.
+    //!
+    //! update_neighbor_borders 는 이웃 셀의 BorderFill 을 clone 해 한 방향만 바꾸는데,
+    //! 파싱된 문서에서 물려온 raw_data 를 비우지 않으면 직렬화기가 원본 바이트를 그대로
+    //! 써서 방금 바꾼 방향이 저장 시 사라진다. 이웃 셀의 공유 변이 옛 테두리로 되돌아간다.
+    //! 같은 커맨드의 형제 create_border_fill_from_json 은 이미 raw_data 를 비운다.
+
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::document::{Document, Section};
+    use crate::model::paragraph::Paragraph;
+    use crate::model::style::{BorderFill, BorderLine, BorderLineType};
+    use crate::model::table::{Cell, Table};
+
+    /// 2 칸짜리 표 한 줄. 셀 0(target)과 셀 1(neighbor)이 세로 변을 공유한다.
+    fn core_with_two_cell_row() -> DocumentCore {
+        let mut doc = Document::default();
+
+        // border_fills[0] (id=1): target 셀(0)의 fill — 이 테스트에서는 무관.
+        let mut bf_target = BorderFill::default();
+        bf_target.raw_data = Some(vec![0xAA; 39]);
+        doc.doc_info.border_fills.push(bf_target);
+
+        // border_fills[1] (id=2): 이웃 셀(1)의 fill — clone 되어 갱신되는 대상.
+        let mut bf_neighbor = BorderFill::default();
+        bf_neighbor.raw_data = Some(vec![0xBB; 39]);
+        doc.doc_info.border_fills.push(bf_neighbor);
+
+        let mut table = Table::default();
+        table.row_count = 1;
+        table.col_count = 2;
+        table.cells = vec![
+            Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                border_fill_id: 1,
+                ..Default::default()
+            },
+            Cell {
+                row: 0,
+                col: 1,
+                col_span: 1,
+                row_span: 1,
+                border_fill_id: 2,
+                ..Default::default()
+            },
+        ];
+
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Table(Box::new(table)));
+
+        let mut section = Section::default();
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core
+    }
+
+    #[test]
+    fn neighbor_border_update_drops_stale_raw_data() {
+        let mut core = core_with_two_cell_row();
+        let new_border = BorderLine {
+            line_type: BorderLineType::Double,
+            width: 3,
+            color: 0x00FF0000,
+        };
+        // target = 셀 0, 우측 엣지(target_col=0, span=1)를 셀 1 이 공유 → 셀 1 의 좌측(dir=0)
+        // 이 new_borders[1] 로 갱신된다("대상 셀의 우측 엣지 공유 → 이웃 좌측").
+        core.update_neighbor_borders(
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            &[
+                BorderLine::default(),
+                new_border,
+                BorderLine::default(),
+                BorderLine::default(),
+            ],
+        );
+
+        let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Table(t) => t,
+            _ => panic!("표 컨트롤이어야 함"),
+        };
+        let updated_bf_id = table.cells[1].border_fill_id;
+        assert_ne!(
+            updated_bf_id, 2,
+            "테두리가 바뀌었으니 새 BorderFill 이 push 돼야 함"
+        );
+
+        let bf = &core.document.doc_info.border_fills[(updated_bf_id as usize) - 1];
+        assert!(
+            bf.raw_data.is_none(),
+            "raw_data 가 남으면 저장 시 이웃 셀의 공유 변이 옛 테두리로 되돌아간다"
+        );
+        assert_eq!(
+            bf.borders[0].width, 3,
+            "이웃 셀 기준 좌측 테두리가 갱신돼야 함"
+        );
+        assert!(matches!(bf.borders[0].line_type, BorderLineType::Double));
     }
 }


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`update_neighbor_borders`(`src/document_core/commands/table_ops.rs`)는 이웃 셀의
`BorderFill` 을 clone 해 공유 변(edge) 한 방향만 바꾸는데, **clone 이 물고 온 `raw_data`
를 비우지 않습니다.**

파싱된 문서의 `BorderFill` 은 원본 `BORDER_FILL` 레코드 바이트를 `raw_data` 로 들고 있고
(`src/parser/doc_info.rs`), 직렬화기는 `raw_data` 가 있으면 필드 대신 그 바이트를 그대로
씁니다.

```rust
// src/serializer/doc_info.rs
let data = bf.raw_data.clone().unwrap_or_else(|| serialize_border_fill(bf));
```

즉 `borders[dir]` 를 바꿔도 저장되는 것은 **이웃 셀의 원본 바이트**입니다. 게다가
`border_fills_equal`(`src/document_core/helpers.rs`)이 `raw_data` 를 비교에서 제외하므로,
바로 아래 중복 검색도 이 stale clone 을 걸러내지 못하고 새 레코드로 push 합니다.

### 사용자 시나리오

```
표 셀 선택 → 테두리/배경 → 오른쪽 변을 굵은 빨간선으로 변경
→ 화면에는 반영됨 → 저장 → 다시 열기: 대상 셀은 정상, 이웃 셀의 공유 변만 옛 테두리로
  되돌아감
```

`update_neighbor_borders` 는 함수 자체의 존재 이유가 "이웃 셀과의 공유 변 정합"인데
(주석: "한쪽 셀의 테두리만 변경하면 merge_border 우선순위에 의해 변경이 반영되지 않을 수
있으므로, 이웃 셀의 대응 테두리도 함께 갱신한다"), 그 목적이 저장 시 무효화됩니다.

### 선례

같은 커맨드의 형제 `create_border_fill_from_json`(`src/document_core/html_table_import.rs:820`)
은 이미 `bf.raw_data = None` 을 합니다. 이 경로만 빠져 있었습니다. #2416(HTML 붙여넣기
서식 유실)과 같은 결함 클래스입니다.

## 관련 이슈

없음 (자체 발견).

## 테스트

- [ ] `cargo test` 통과 — **로컬에서 실행하지 못했습니다.** 아래 참고.
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로가 아니라 직렬화 변경입니다.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 동일 사유입니다.

추가한 테스트 `neighbor_border_update_drops_stale_raw_data` 는 2칸 표에서 target 셀의
우측 엣지를 갱신하면, 이웃 셀(공유 변)의 `BorderFill` 이 새로 push 되고 그 `raw_data` 가
비워졌는지 + 실제 갱신된 방향(`width`/`line_type`)을 확인합니다.

### 로컬에서 `cargo test` 를 못 돌린 이유 (정직하게)

이 변경을 반영한 뒤 `cargo test --lib neighbor_border_` 를 재시도 20회 이상 시도했지만
**매번 실행 자체가 차단**됐습니다.

```
could not execute process `target\debug\deps\rhwp-*.exe`
애플리케이션 제어 정책에서 이 파일을 차단했습니다. (os error 4551)
```

**#2416 과 동일 증상**이며 제 로컬 PC 의 보안 소프트웨어 문제입니다 — 저장소나 이 변경의
문제가 아닙니다. `cargo test --lib neighbor_border_ --no-run` (빌드만, 실행 안 함)은
정상 성공했고, `cargo build`/`cargo clippy` 도 컴파일 단계라 이 차단과 무관해 정상
통과했습니다. 테스트 로직 자체는 #2416 에서 이미 검증한 것과 동일한 패턴
(`raw_data = None` 전후로 red→green 확인)을 그대로 따랐습니다.

CI 결과로 판단해 주시고, 문제가 보이면 바로 대응하겠습니다.

## 스크린샷

직렬화 변경이라 첨부하지 않았습니다.