### PR TITLE
fix(hwp): 표 셀 서식 적용이 페이지 폭으로 리플로우해 텍스트가 셀 밖으로 흘러넘치던 문제 수정

### DIFF
--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1139,39 +1139,21 @@ impl DocumentCore {
         }
 
         // 텍스트 폭/높이에 영향을 주는 글자 모양 변경 시 셀 내 LineSeg 재계산.
+        //
+        // [자체 발견] 예전에는 여기서 페이지 본문 단(column) 폭을 셀 리플로우에 그대로
+        // 썼다 — 셀 폭은 보통 그 1/3~1/5 라 텍스트가 한 줄로 뭉쳐졌다 붙었다 하며 셀
+        // 경계를 넘어 그려졌다. 같은 파일의 undo 형제 set_char_shape_id_in_cell_native
+        // (:1219)는 이미 reflow_cell_paragraph 로 셀/글상자/캡션 폭을 올바르게 계산해서,
+        // 서식 적용(do)과 undo 사이에 눈에 보이는 비대칭이 있었다. 그 헬퍼로 통일한다.
         if char_shape_mods_affect_text_flow(&mods) {
-            let dpi = self.dpi;
-            let styles = resolve_styles(&self.document.doc_info, dpi);
-            let section = &self.document.sections[sec_idx];
-            let page_def = &section.section_def.page_def;
-            let column_def = DocumentCore::find_initial_column_def(&section.paragraphs);
-            let layout = PageLayoutInfo::from_page_def(page_def, &column_def, dpi);
-            let col_width = layout
-                .column_areas
-                .first()
-                .map(|a| a.width)
-                .unwrap_or(layout.body_area.width);
-            let cell_para = self.get_cell_paragraph_mut(
+            self.reflow_cell_paragraph(
                 sec_idx,
                 parent_para_idx,
                 control_idx,
                 cell_idx,
                 cell_para_idx,
-            )?;
-            let para_shape_id = cell_para.para_shape_id;
-            let para_style = styles.para_styles.get(para_shape_id as usize);
-            let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
-            let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
-            let available_width = (col_width - margin_left - margin_right).max(1.0);
-            cell_para.line_segs.clear();
-            reflow_line_segs(cell_para, available_width, &styles, dpi);
-
-            // 표 dirty 마킹 — 셀 높이 재계산 필요
-            if let Control::Table(ref mut t) =
-                self.document.sections[sec_idx].paragraphs[parent_para_idx].controls[control_idx]
-            {
-                t.dirty = true;
-            }
+            );
+            self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
         }
 
         self.document.sections[sec_idx].raw_stream = None;
@@ -1460,42 +1442,23 @@ impl DocumentCore {
             cell_para.para_shape_id = new_id;
         }
 
-        // 줄간격 변경 시 셀 내 문단 LineSeg 재계산
+        // 줄간격 변경 시 셀 내 문단 LineSeg 재계산.
+        //
+        // [자체 발견] apply_char_format_in_cell_native 와 동일한 결함 — 페이지 본문 단 폭을
+        // 셀 리플로우에 썼다. undo 형제 set_cell_para_shape_id_native(:1538)는 이미
+        // reflow_cell_paragraph 를 쓴다. 그 헬퍼로 통일해 폭 계산과 dirty 마킹을 함께 맞춘다.
         if mods.line_spacing.is_some() || mods.line_spacing_type.is_some() {
-            let dpi = self.dpi;
-            let styles = resolve_styles(&self.document.doc_info, dpi);
-            let section = &self.document.sections[sec_idx];
-            let page_def = &section.section_def.page_def;
-            let column_def = DocumentCore::find_initial_column_def(&section.paragraphs);
-            let layout = PageLayoutInfo::from_page_def(page_def, &column_def, dpi);
-            let col_width = layout
-                .column_areas
-                .first()
-                .map(|a| a.width)
-                .unwrap_or(layout.body_area.width);
-            let para_style = styles.para_styles.get(new_id as usize);
-            let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
-            let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
-            let available_width = (col_width - margin_left - margin_right).max(1.0);
-            let cell_para = self.get_cell_paragraph_mut(
+            self.reflow_cell_paragraph(
                 sec_idx,
                 parent_para_idx,
                 control_idx,
                 cell_idx,
                 cell_para_idx,
-            )?;
-            reflow_line_segs(cell_para, available_width, &styles, dpi);
+            );
         }
 
         // 표 dirty 마킹 — measure_section_incremental이 셀 높이를 재계산하도록
-        {
-            use crate::model::control::Control;
-            if let Control::Table(ref mut t) =
-                self.document.sections[sec_idx].paragraphs[parent_para_idx].controls[control_idx]
-            {
-                t.dirty = true;
-            }
-        }
+        self.mark_cell_control_dirty(sec_idx, parent_para_idx, control_idx);
 
         self.document.sections[sec_idx].raw_stream = None;
         self.rebuild_section(sec_idx);
@@ -2108,5 +2071,127 @@ mod tests {
             ..Default::default()
         };
         assert!(!char_shape_mods_affect_text_flow(&mods));
+    }
+}
+
+#[cfg(test)]
+mod cell_reflow_width_tests {
+    //! 셀 서식 적용의 리플로우 폭 회귀 테스트.
+    //!
+    //! apply_char_format_in_cell_native / apply_para_format_in_cell_native 는 예전에
+    //! 페이지 본문 단(column) 폭으로 셀 문단을 리플로우했다 — 셀 폭은 보통 그보다 훨씬
+    //! 좁아 텍스트가 한 줄로 뭉쳐졌다 셀 경계를 넘어 그려졌다. 같은 파일의 undo 형제
+    //! set_char_shape_id_in_cell_native/set_cell_para_shape_id_native 는 이미
+    //! reflow_cell_paragraph(셀/글상자 폭 기준)를 썼다 — do/undo 사이의 눈에 보이는 비대칭.
+    //!
+    //! 페이지 본문 폭(수만 HWPUNIT)과 셀 폭(200 HWPUNIT)을 극단적으로 벌려, 어떤 폰트
+    //! 폭 추정치를 쓰든 "페이지 폭 사용" 과 "셀 폭 사용" 이 줄 수로 갈리게 한다.
+
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::document::{Document, Section, SectionDef};
+    use crate::model::page::PageDef;
+    use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+    use crate::model::table::{Cell, Table};
+
+    fn core_with_narrow_cell(text: &str) -> DocumentCore {
+        let mut doc = Document::default();
+
+        let mut cell_para = Paragraph {
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_count: text.chars().count() as u32,
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        cell_para.has_para_text = true;
+
+        let mut table = Table::default();
+        table.row_count = 1;
+        table.col_count = 1;
+        table.cells = vec![Cell {
+            row: 0,
+            col: 0,
+            col_span: 1,
+            row_span: 1,
+            width: 200, // 셀 폭 — 페이지 본문 폭(수만 HWPUNIT)의 1% 미만
+            paragraphs: vec![cell_para],
+            ..Default::default()
+        }];
+
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Table(Box::new(table)));
+
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        core
+    }
+
+    #[test]
+    fn char_format_reflow_uses_cell_width_not_page_column_width() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell(&text);
+
+        core.apply_char_format_in_cell_native(0, 0, 0, 0, 0, 0, 40, r#"{"fontSize":2000}"#)
+            .expect("서식 적용이 성공해야 함");
+
+        let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Table(t) => t,
+            _ => panic!("표 컨트롤이어야 함"),
+        };
+        let line_count = table.cells[0].paragraphs[0].line_segs.len();
+        assert!(
+            line_count > 1,
+            "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함              (실제 {line_count}줄 — 페이지 본문 폭을 쓰면 1줄로 뭉친다)"
+        );
+    }
+
+    #[test]
+    fn para_format_reflow_uses_cell_width_not_page_column_width() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell(&text);
+
+        core.apply_para_format_in_cell_native(0, 0, 0, 0, 0, r#"{"lineSpacing":150}"#)
+            .expect("서식 적용이 성공해야 함");
+
+        let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Table(t) => t,
+            _ => panic!("표 컨트롤이어야 함"),
+        };
+        let line_count = table.cells[0].paragraphs[0].line_segs.len();
+        assert!(
+            line_count > 1,
+            "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함              (실제 {line_count}줄 — 페이지 본문 폭을 쓰면 1줄로 뭉친다)"
+        );
     }
 }


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`apply_char_format_in_cell_native` / `apply_para_format_in_cell_native`
(`src/document_core/commands/formatting.rs`)는 텍스트 흐름에 영향을 주는 서식(굵기 폭
변화·자간·장평·줄간격)을 셀 문단에 적용한 뒤, **셀 폭이 아니라 페이지 본문 단(column) 폭**
으로 `LineSeg` 를 재계산하고 있었습니다.

```rust
let layout = PageLayoutInfo::from_page_def(page_def, &column_def, dpi);
let col_width = layout.column_areas.first().map(|a| a.width)...
```

셀 폭은 보통 본문 폭의 1/3~1/5 라, 한 줄에 다 들어가는 것처럼 재배치된 뒤 실제로는 셀
경계를 넘어 그려집니다.

### do/undo 비대칭

같은 파일의 undo 형제 — `set_char_shape_id_in_cell_native`(`:1219`),
`set_cell_para_shape_id_native`(`:1538`) — 는 이미 셀/글상자/캡션 폭을 올바르게 계산하는
`reflow_cell_paragraph` 헬퍼를 씁니다. 즉 **서식을 적용하면 깨지고, Ctrl+Z 하면 undo
형제가 올바른 폭을 써서 정상으로 돌아옵니다.**

```
3단 표의 좁은 셀(전체 폭의 1/4)에 3줄로 감싸진 문장이 있는 상태에서 굵게 적용

기대: 계속 3줄 안팎으로 셀 안에서 감싸짐
실제: 페이지 폭 기준으로 재계산돼 1줄로 뭉치고, 텍스트가 셀 경계를 넘어 그려짐
      Ctrl+Z 하면 정상으로 돌아옴
```

### 수정

두 함수 모두 `col_width` 계산 블록을 `reflow_cell_paragraph` 호출로 교체했습니다. 표
dirty 마킹도 형제와 동일하게 `mark_cell_control_dirty` 로 통일했습니다.

## 관련 이슈

없음 (자체 발견). undo/병합/분할 메타데이터 복원 계열(#2342/#2417/#2418)과는 무관한
별개 축입니다 — 이쪽은 서식 적용 시 리플로우 **폭 계산**의 문제입니다.

## 테스트

- [x] `cargo test` 통과 — **2317 passed, 0 failed, 7 ignored** (`cargo test --lib`)
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 아래 참고.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 동일 사유.

추가한 `cell_reflow_width_tests` 모듈은 페이지 본문 폭(수만 HWPUNIT)과 셀 폭
(200 HWPUNIT)을 극단적으로 벌려, 40자 ASCII 문자열이 셀 폭 기준이면 여러 줄로, 페이지
폭 기준이면 1줄로 뭉치는 것으로 회귀를 판별합니다. **수정 전 소스로 되돌려 2/2 실패**
(둘 다 "실제 1줄" 로 패닉), **수정 후 2/2 통과**를 직접 확인했습니다.

## 확인하지 못한 항목

- **브라우저 렌더링 확인은 하지 못했습니다.** 판단 근거는 수치 비교(줄 수)로 대체했습니다 —
  페이지 본문 폭은 수만 HWPUNIT, 셀 폭은 200 HWPUNIT 이라 어떤 폰트 폭 추정치를 쓰든
  40자가 줄 수로 갈릴 만큼 차이가 큽니다.
- 이번엔 `cargo test` 실행이 정상적으로 됐습니다(이전 PR 들에서 겪은 로컬 실행 차단 없이).
  다만 fmt 지적을 이번엔 CI 전에 직접 잡아 반영했습니다(`rustfmt --edition 2021` 로 함수
  호출 인자 줄바꿈 정리).

## 스크린샷

렌더링 변경은 맞지만 브라우저 확인을 못 해 첨부하지 못했습니다.