### PR TITLE
fix(hwp): 양식(Form) 값 입력이 저장 시 통째로 사라지던 문제 수정 (raw_stream 미무효화)

### DIFF
--- a/src/document_core/queries/form_query.rs
+++ b/src/document_core/queries/form_query.rs
@@ -111,6 +111,14 @@ impl DocumentCore {
         match control {
             Some(Control::Form(f)) => {
                 apply_form_value(f, value_json);
+                // 원본 스트림 무효화 — serialize_section 은 raw_stream 이 있으면 원본
+                // 바이트를 그대로 반환하므로(serializer/body_text.rs), 비우지 않으면
+                // 방금 넣은 양식 값이 저장 시 통째로 사라진다. 화면은 recompose 로
+                // 갱신되니 사용자는 저장이 됐다고 믿게 된다. 누름틀 쪽
+                // set_field_value_*(field_query.rs)와 동일한 불변식이다.
+                if let Some(s) = self.document.sections.get_mut(sec) {
+                    s.raw_stream = None;
+                }
                 self.recompose_section(sec);
                 Ok(r#"{"ok":true}"#.to_string())
             }
@@ -162,6 +170,11 @@ impl DocumentCore {
         match form {
             Some(f) => {
                 apply_form_value(f, value_json);
+                // set_form_value_native 와 동일 — 셀 안 양식 값도 섹션 raw_stream 을
+                // 비워야 저장 시 반영된다.
+                if let Some(s) = self.document.sections.get_mut(sec) {
+                    s.raw_stream = None;
+                }
                 self.recompose_section(sec);
                 Ok(r#"{"ok":true}"#.to_string())
             }
@@ -403,4 +416,119 @@ fn parse_insert_string_args(args: &str) -> Option<(String, usize)> {
     let idx = idx_str.parse().unwrap_or(0);
 
     Some((text, idx))
+}
+
+#[cfg(test)]
+mod tests {
+    //! 양식 값 설정의 raw_stream 무효화 회귀 테스트.
+    //!
+    //! serialize_section(serializer/body_text.rs)은 raw_stream 이 Some 이면 IR 을 무시하고
+    //! 원본 바이트를 그대로 반환한다. HWP5 파서는 모든 섹션에 raw_stream 을 채우므로
+    //! (parser/mod.rs), 양식 값 설정이 raw_stream 을 비우지 않으면 — 양식 채우기만 하고
+    //! 저장하는 표준 워크플로에서 — 입력한 값 전부가 저장 시 조용히 사라진다.
+    //! 누름틀 쪽 set_field_value_*(field_query.rs)는 같은 불변식을 이미 지킨다.
+
+    use crate::document_core::DocumentCore;
+    use crate::model::control::{Control, FormObject};
+    use crate::model::document::{Document, Section};
+    use crate::model::paragraph::Paragraph;
+    use crate::model::table::{Cell, Table};
+    use crate::serializer::body_text::serialize_section;
+
+    const SENTINEL: u8 = 0xAB;
+
+    fn core_from(doc: Document) -> DocumentCore {
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        core
+    }
+
+    /// 파싱된 문서를 흉내낸다 — 섹션이 원본 스트림 바이트를 물고 있는 상태.
+    fn section_with_raw_stream(paragraphs: Vec<Paragraph>) -> Section {
+        Section {
+            paragraphs,
+            raw_stream: Some(vec![SENTINEL; 64]),
+            ..Default::default()
+        }
+    }
+
+    fn body_form_doc() -> Document {
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Form(Box::default()));
+        let mut doc = Document::default();
+        doc.sections.push(section_with_raw_stream(vec![para]));
+        doc
+    }
+
+    fn cell_form_doc() -> Document {
+        let mut cell_para = Paragraph::default();
+        cell_para.controls.push(Control::Form(Box::default()));
+        let mut table = Table::default();
+        table.row_count = 1;
+        table.col_count = 1;
+        table.cells = vec![Cell {
+            row: 0,
+            col: 0,
+            col_span: 1,
+            row_span: 1,
+            paragraphs: vec![cell_para],
+            ..Default::default()
+        }];
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Table(Box::new(table)));
+        let mut doc = Document::default();
+        doc.sections.push(section_with_raw_stream(vec![para]));
+        doc
+    }
+
+    #[test]
+    fn set_form_value_invalidates_section_raw_stream() {
+        let mut core = core_from(body_form_doc());
+        let r = core
+            .set_form_value_native(0, 0, 0, r#"{"value":1,"text":"동의함"}"#)
+            .expect("호출이 성공해야 함");
+        assert!(r.contains(r#""ok":true"#), "전제: 양식 값 설정 성공 ({r})");
+
+        // 값은 IR 에 반영됐고,
+        match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Form(f) => {
+                assert_eq!(f.value, 1);
+                assert_eq!(f.text, "동의함");
+            }
+            _ => panic!("양식 컨트롤이어야 함"),
+        }
+        // 원본 스트림은 무효화돼야 한다 — 남아 있으면 저장이 원본 바이트를 그대로 써서
+        // 방금 넣은 값이 파일에서 사라진다.
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "raw_stream 이 남으면 양식 값이 저장 시 통째로 사라진다"
+        );
+        // 저장 경로 결과로도 확인: 원본 sentinel 바이트가 더 이상 그대로 나가지 않는다.
+        let out = serialize_section(&core.document.sections[0]);
+        assert_ne!(
+            out,
+            vec![SENTINEL; 64],
+            "serialize_section 이 여전히 원본 바이트를 반환하면 값 유실"
+        );
+    }
+
+    #[test]
+    fn set_form_value_in_cell_invalidates_section_raw_stream() {
+        let mut core = core_from(cell_form_doc());
+        let r = core
+            .set_form_value_in_cell_native(0, 0, 0, 0, 0, 0, r#"{"value":1}"#)
+            .expect("호출이 성공해야 함");
+        assert!(
+            r.contains(r#""ok":true"#),
+            "전제: 셀 양식 값 설정 성공 ({r})"
+        );
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "셀 안 양식 값도 섹션 raw_stream 을 비워야 저장에 반영된다"
+        );
+    }
 }


### PR DESCRIPTION
> PR base 브랜치가 `devel` 인지 확인했습니다.
> 작업 브랜치는 `upstream/devel` 기준으로 생성했습니다.

## 변경 요약

`set_form_value_native` / `set_form_value_in_cell_native`(`src/document_core/queries/form_query.rs`)는
`Control::Form` 의 값을 IR 에 반영하고 `recompose_section` 만 합니다 — **파일 전체에
`raw_stream` 참조가 한 건도 없습니다.**

그런데 사슬의 나머지 두 고리는 이렇습니다.

- HWP5 파서는 **모든 섹션에 원본 스트림을 채웁니다** (`src/parser/mod.rs:465`, `:521`).
- `serialize_section` 은 `raw_stream` 이 `Some` 이면 **IR 을 무시하고 원본 바이트를 그대로
  반환합니다** (`src/serializer/body_text.rs:28` — "원본 스트림이 있으면 그대로 반환").

### 사용자 시나리오 — 양식 채우기의 표준 워크플로 그 자체

```
양식 .hwp(신청서·동의서 등)를 연다
→ 양식 모드에서 체크박스 체크, 라디오 선택, 입력 필드 작성
  (전부 setFormValue / setFormValueInCell 계열만 호출됨)
→ 화면에는 전부 표시됨 → 저장 → 다시 열기: 입력한 값이 전부 사라짐
```

같은 섹션에 **텍스트 편집을 하나라도 섞지 않는 한** — 즉 "양식만 채워서 저장"하는 가장
흔한 사용 방식 그대로 — 아무것도 저장되지 않습니다. 화면은 recompose 로 갱신되므로
사용자는 저장된 줄 알게 되는 **무증상 데이터 손실**입니다.

### 선례 — 누름틀은 이미 지키는 불변식

`set_field_value_*`(`src/document_core/queries/field_query.rs`)는 같은 불변식을 **6곳**에서
지킵니다. `:355-358` 에는 주석까지 있습니다:

```rust
// raw_stream 무효화
if let Some(sec) = self.document.sections.get_mut(section_index) {
    sec.raw_stream = None;
}
```

`:519` 의 주석은 더 명시적입니다 — "raw_stream 무효화: 직렬화 시 수정된 모델을 사용하도록
강제". 양식 쪽만 빠져 있었습니다.

### 수정

두 함수의 **성공 분기**에서 섹션 `raw_stream` 을 비웁니다. 실패 분기(양식 아님/못 찾음)는
문서를 건드리지 않았으므로 바이트 보존을 위해 그대로 둡니다.

## 관련 이슈

없음 (자체 발견). #2411(셀 안 Edit 필드가 IR 에조차 안 써지던 문제)의 후속 성격입니다 —
그 수정으로 값이 IR 에는 반영되게 됐지만, 이 결함 때문에 저장 단계에서 다시 사라지고
있었습니다. 이 PR 로 입력→IR→저장 사슬이 완결됩니다.

## 테스트

- [x] `cargo test` 통과 — **2317 passed, 0 failed, 7 ignored** (`cargo test --lib`)
- [x] `cargo clippy -- -D warnings` 통과 — 경고 0건 (`--lib --all-targets`)
- [ ] 관련 샘플 파일로 SVG 내보내기 확인 — **미실행**. 렌더링 경로가 아니라 저장 경로 변경입니다.
- [ ] 웹(WASM) 렌더링 확인 — **미실행**. 동일 사유입니다.

추가한 `form_query::tests` 2건은 파싱된 문서를 흉내내(`raw_stream = Some(sentinel)`)
값 설정 후 세 가지를 단언합니다.

1. 값이 IR 에 반영됨 (`f.value` / `f.text`)
2. `raw_stream` 이 비워짐
3. `serialize_section` 이 더 이상 sentinel 원본 바이트를 반환하지 않음 — 저장 경로 결과 직접 확인

**수정 전 소스로 되돌려 2/2 실패**(정확히 해당 단언에서 패닉, 메시지: "raw_stream 이 남으면
양식 값이 저장 시 통째로 사라진다"), **수정 후 2/2 통과**를 확인했습니다.

## 확인하지 못한 항목

- **실제 양식 .hwp 를 브라우저에서 열어 저장→재열기 왕복은 하지 못했습니다.** 다만 손실
  사슬의 세 고리(파서가 raw_stream 채움 → 양식 설정이 안 비움 → 직렬화기가 원본 반환)를
  각각 코드에서 확인했고, 세 번째 고리는 테스트에서 `serialize_section` 호출로 직접
  검증했습니다.

## 스크린샷

저장 경로 변경이라 첨부하지 않았습니다.