### PR TITLE
fix(studio): 다중 페이지 표 경계 판정을 현재 페이지 조각으로 제한

### DIFF
--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -6,6 +6,8 @@
 |------|--------|------|------|
 | #2393 | CI 기본 테스트 job 병렬화 — nextest archive + 8샤드 | **PR #2395 merge 완결** — 17→12분(cold). 목표 10분 이내(조정). 캐시 예산 차단 발견 → 스테일 14건 정리(10.48→4.79GB) | local/task2393 |
 | #2215 | 115쪽 거대 셀 드래그 선택 page-tree 범위 제한 | PR 준비 완료 | Stage 4 전체 검증 GREEN, UI 114→115 수동 확인, 클릭 오인은 후속 #2400 분리 |
+| #2400 | 다중 페이지 표 마지막 줄 클릭 캐럿 진입 | Draft PR #2425 최초 클릭 보완 및 재검증 완료 | pointer hit 직접 좌표 사용으로 최초 전체 lookup 제거, Studio 452/build·HWP/HWPX Chrome E2E GREEN, 반복 클릭 각주 비용은 #2428 분리 |
+| #2428 | 거대 표 페이지 본문 클릭의 `hitTestFootnote` 지연 | 이슈 생성 | warm 클릭 p50 258.1ms 중 각주 hit p50 248.2ms, #2193·#2400과 독립 추적 |
 | #2392 | `picture-props-dialog` 적용 파이프라인 책임 분리 | PR #2397 Ready, 최신 `devel` 통합 완료 | fresh WASM·binding·Studio 390/build·Chrome undo E2E PASS, 새 head CI 대기 |
 | #2396 | custom scheme 최상위 문서 legacy rhwp-request 회귀 수정 | 완료 | PR #2398 merge·이슈 자동 종료 확인 · 완료: 12:45 |
 

--- a/mydocs/plans/task_m100_2400.md
+++ b/mydocs/plans/task_m100_2400.md
@@ -12,9 +12,10 @@
   - `rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp`
   - `samples/issue1949_giant_cell_nested_tables_perf.hwpx`
 - 관련: #2215, #717 / PR #725, #919
+- 상태: 구현 승인 및 Stage 2 focused 검증 완료 (2026-07-19)
 
-이 문서는 구현 전 승인 대상이다. 승인 전에는 아래 production source와 회귀 테스트를
-수정하지 않는다.
+이 문서는 구현 전 승인을 거쳤다. Stage 2 구현·focused 검증 결과는
+`mydocs/working/task_m100_2400_stage2.md`에 기록한다.
 
 ## 2. 확정 원인
 

--- a/mydocs/plans/task_m100_2400.md
+++ b/mydocs/plans/task_m100_2400.md
@@ -12,8 +12,8 @@
 - 권위 픽스처:
   - `rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp`
   - `samples/issue1949_giant_cell_nested_tables_perf.hwpx`
-- 관련: #2215, #717 / PR #725, #919
-- 상태: 구현 승인 및 Stage 2 focused 검증 완료 (2026-07-19)
+- 관련: #2215, #717 / PR #725, #919, #2428
+- 상태: 구현 승인 및 Stage 2 최초 클릭 보완·focused 검증 완료 (2026-07-19)
 
 이 문서는 구현 전 승인을 거쳤다. Stage 2 구현·focused 검증 결과는
 `mydocs/working/task_m100_2400_stage2.md`에 기록한다.
@@ -118,6 +118,7 @@ API가 담당하고, helper는 전달받은 한 bbox만 판정한다.
 
 - UI 114쪽 `어 있는 경우` 시작 클릭 후 `tableObjectSelected=false`
 - 커서가 cell paragraph 2499, offset 77에 위치
+- 논리 cursor rect와 화면 caret rect가 같은 글자 앞 좌표를 사용
 - 같은 fragment 실제 하단 클릭은 `tableObjectSelected=true`
 - UI 1→2, 56→57, 114→115 인접 fragment의 텍스트 클릭이 캐럿에 진입
 - #2215의 114→115 drag 선택이 계속 정상
@@ -135,7 +136,9 @@ API가 담당하고, helper는 전달받은 한 bbox만 판정한다.
 | `rhwp-studio/src/core/wasm-bridge.ts` | typed page-scoped wrapper |
 | `rhwp-studio/src/engine/input-handler.ts` | page-aware border helper와 fallback 전달 |
 | `rhwp-studio/src/engine/input-handler-mouse.ts` | 일반 클릭·선택 표·hover page 전달 |
+| `rhwp-studio/src/engine/cursor.ts` | 방금 얻은 pointer hit 좌표를 재조회 없이 캐럿 최종 기하로 유지 |
 | `rhwp-studio/tests/table-border-page-scope.test.ts` | 기하 및 호출 계약 회귀 |
+| `rhwp-studio/tests/cursor-hit-coherence.test.ts` | same-page continuation run 캐럿 회귀 |
 | `mydocs/working/task_m100_2400_stage2.md` | 구현·focused 검증 결과 |
 
 ## 7. 검증 순서
@@ -167,8 +170,12 @@ git diff --check
 ## 9. 완료 조건
 
 - HWP/HWPX UI 114쪽 offset 77 실제 pointer 클릭이 캐럿에 진입한다.
+- 논리 커서와 DOM 캐럿이 UI 114쪽 `어` 앞에서 같은 좌표를 사용한다.
 - 현재 page fragment의 실제 외곽 ±5px 클릭은 표 객체를 선택한다.
 - 다중-page 표의 전·중·후반 fragment에서 다른 page bbox를 사용하지 않는다.
 - 선택된 표의 셀 재진입과 hover/move 판정도 현재 page fragment를 사용한다.
 - legacy `getTableBBox()` 계약과 #717, #919, #2215 회귀가 유지된다.
 - focused source test, Studio test/build 및 실제 pointer 검증이 통과한다.
+
+반복 클릭의 `hitTestFootnote` 비용은 캐럿 정확성과 다른 호출 경로이므로 #2428에서 독립적으로
+추적한다. #2193은 pagination 계측 완료 상태를 유지하며 이 작업을 sub-issue로 다시 열지 않는다.

--- a/mydocs/plans/task_m100_2400.md
+++ b/mydocs/plans/task_m100_2400.md
@@ -6,7 +6,8 @@
 - 제목: 다중 페이지 표 마지막 줄 클릭이 표 경계로 오인되어 캐럿 진입 불가
 - 브랜치: `issue-2400-page-scoped-table-border-hit`
 - worktree: `/private/tmp/rhwp-task2400`
-- 기준: `upstream/devel@62bcae43`
+- 초기 분석 기준: `upstream/devel@62bcae43`
+- PR 전 최종 rebase 기준: `upstream/devel@3eac4ae0`
 - 작성일: 2026-07-19
 - 권위 픽스처:
   - `rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp`

--- a/mydocs/plans/task_m100_2400.md
+++ b/mydocs/plans/task_m100_2400.md
@@ -1,0 +1,172 @@
+# 수행·구현 계획서 — Task M100 #2400
+
+## 1. 작업 개요
+
+- 이슈: [#2400](https://github.com/edwardkim/rhwp/issues/2400)
+- 제목: 다중 페이지 표 마지막 줄 클릭이 표 경계로 오인되어 캐럿 진입 불가
+- 브랜치: `issue-2400-page-scoped-table-border-hit`
+- worktree: `/private/tmp/rhwp-task2400`
+- 기준: `upstream/devel@62bcae43`
+- 작성일: 2026-07-19
+- 권위 픽스처:
+  - `rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp`
+  - `samples/issue1949_giant_cell_nested_tables_perf.hwpx`
+- 관련: #2215, #717 / PR #725, #919
+
+이 문서는 구현 전 승인 대상이다. 승인 전에는 아래 production source와 회귀 테스트를
+수정하지 않는다.
+
+## 2. 확정 원인
+
+최신 devel에서 HWP와 HWPX 모두 실제 pointer 클릭으로 재현했다. UI 114쪽의
+`어 있는 경우` 첫 글자는 내부적으로 다음 위치다.
+
+```text
+pageIndex=113
+section=0, parentPara=0, control=2, cell=2
+cellPara=2499, charOffset=77
+page point=(142.8, 1057.3)
+```
+
+`hitTest()`는 이 현재 page의 셀·문단·offset을 정확히 반환한다. 그 뒤 호출되는
+`isTableBorderClick()`만 page 정보를 버린다.
+
+| 비교 대상 | page | bbox 하단 | 클릭과 거리 | ±5px 판정 |
+| --- | ---: | ---: | ---: | --- |
+| 기존 `getTableBBox()`의 첫 fragment | 0 | 1061.0 | 3.7px | 잘못된 border |
+| 클릭한 page의 실제 fragment | 113 | 1075.9 | 18.6px | text 내부 |
+
+`get_table_bbox_native()`가 page 0부터 순회해 같은 표의 첫 fragment를 즉시 반환하고,
+Studio가 그 bbox와 page 113의 로컬 좌표를 비교하는 것이 직접 원인이다. line break,
+pagination, selection rect, 폰트 metric 문제는 이 클릭 오판에 관여하지 않는다.
+
+## 3. 목표와 비목표
+
+### 목표
+
+1. 표 경계 판정과 선택된 표의 hit 영역 판정이 현재 pointer page의 fragment만 사용하게 한다.
+2. 텍스트/line hit 내부의 클릭은 캐럿 진입으로 유지한다.
+3. 실제 현재 fragment 외곽 ±5px 클릭은 계속 표 객체 선택이 되게 한다.
+4. 기존 page hint 없는 `getTableBBox()` 호출자의 첫-fragment 계약을 보존한다.
+5. HWP/HWPX와 다중-page 표의 전·중·후반 fragment에서 같은 계약을 검증한다.
+
+### 비목표
+
+- 표 조판, page break, line break 또는 폰트 metric 변경
+- #2215 selection rect/page hint 경로 변경
+- 표 이동·리사이즈 UX의 임계값 변경
+- 모든 개체 bbox API의 일괄 재설계
+
+## 4. 확정 설계
+
+### 4.1 native/WASM 호환 API
+
+기존 `get_table_bbox_native()`와 JS `getTableBBox()`는 수정하지 않는다. 현재 page의 표
+fragment를 명시적으로 조회하는 API를 추가한다.
+
+```text
+native: get_table_bbox_at_page_native(sec, parentPara, control, pageIndex)
+WASM:   getTableBBoxAtPage(sec, parentPara, control, pageIndex)
+Studio: WasmBridge.getTableBBoxAtPage(sec, parentPara, control, pageIndex)
+```
+
+- native는 지정한 page tree 한 장만 조회한다.
+- 같은 표 fragment가 그 page에 없거나 page가 범위를 벗어나면 오류를 반환한다.
+- page를 생략해 첫 fragment를 찾는 fallback을 새 API 내부에 두지 않는다. 잘못된 page가
+  다른 page의 bbox로 조용히 대체되면 이번 결함이 재발하기 때문이다.
+- 기존 API는 compare, 렌더 등 page를 모르는 호환 호출자를 위해 유지한다.
+
+### 4.2 Studio 적용 범위
+
+`isTableBorderClick()`의 첫 인자로 `pageIdx`를 추가하고 다음 세 경로를 현재 page API로
+전환한다.
+
+1. 일반 셀 내부 클릭의 표 외곽 우선 판정
+2. 이미 표 객체가 선택된 상태에서 셀 재진입/이동 시작 판정
+3. 선택된 표 내부 hover move cursor 판정
+
+`findTableByOuterClick()`의 `getPageControlLayout(pageIdx)` 우선 경로는 이미 page-scoped이므로
+유지한다. 주변 문단 fallback에서만 같은 `pageIdx`를 `isTableBorderClick()`에 전달한다.
+
+경계 기하 계산은 작은 pure helper로 분리해 ±5px 계약을 단위 테스트한다. page 선택은 WASM
+API가 담당하고, helper는 전달받은 한 bbox만 판정한다.
+
+## 5. 회귀 설계
+
+### Stage 2-A — native RED/GREEN
+
+권위 HWP/HWPX에서 다음을 고정한다.
+
+1. legacy `get_table_bbox_native(0, 0, 2)`는 기존처럼 page 0을 반환한다.
+2. page-scoped API의 page 113 결과는 `pageIndex=113`과 해당 fragment bbox를 반환한다.
+3. UI 114쪽 클릭 y=1057.3은 legacy 하단과 5px 이내지만 page 113 하단과는 5px 밖이다.
+4. 범위 밖 page는 첫 fragment로 fallback하지 않고 오류를 반환한다.
+
+### Stage 2-B — Studio 단위 계약
+
+1. `isTableBorderClick()`이 `pageIdx`와 `getTableBBoxAtPage()`를 사용한다.
+2. 확정 클릭점 `(142.8, 1057.3)`과 page 113 bbox는 border가 아니다.
+3. 실제 page 113 하단 ±5px은 border다.
+4. 좌·우·상·하 경계 및 bbox 바깥 corner는 기존 의미를 유지한다.
+5. 일반 클릭, 선택된 표 재진입, hover의 세 호출 경로가 모두 현재 page를 전달한다.
+
+### Stage 3 — 실제 pointer 검증
+
+로컬 `/private/tmp` probe로 HWP/HWPX를 각각 열고 다음을 확인한다.
+
+- UI 114쪽 `어 있는 경우` 시작 클릭 후 `tableObjectSelected=false`
+- 커서가 cell paragraph 2499, offset 77에 위치
+- 같은 fragment 실제 하단 클릭은 `tableObjectSelected=true`
+- UI 1→2, 56→57, 114→115 인접 fragment의 텍스트 클릭이 캐럿에 진입
+- #2215의 114→115 drag 선택이 계속 정상
+
+일회성 raw probe와 스크린샷은 `/private/tmp`에만 두고 PR에는 포함하지 않는다. 결정적
+계약은 native/Studio source test로 보존한다.
+
+## 6. 예상 변경 파일
+
+| 파일 | 변경 |
+| --- | --- |
+| `src/document_core/commands/table_ops.rs` | 지정 page의 table fragment bbox 조회 native API |
+| `src/wasm_api.rs` | `getTableBBoxAtPage` binding |
+| `src/wasm_api/tests.rs` 또는 신규 focused test | HWP/HWPX page-scoped bbox 회귀 |
+| `rhwp-studio/src/core/wasm-bridge.ts` | typed page-scoped wrapper |
+| `rhwp-studio/src/engine/input-handler.ts` | page-aware border helper와 fallback 전달 |
+| `rhwp-studio/src/engine/input-handler-mouse.ts` | 일반 클릭·선택 표·hover page 전달 |
+| `rhwp-studio/tests/table-border-page-scope.test.ts` | 기하 및 호출 계약 회귀 |
+| `mydocs/working/task_m100_2400_stage2.md` | 구현·focused 검증 결과 |
+
+## 7. 검증 순서
+
+구현 단계의 focused 검증:
+
+```text
+cargo fmt --check
+cargo test --lib test_get_table_bbox -- --nocapture
+npm --prefix rhwp-studio test
+npm --prefix rhwp-studio run build
+git diff --check
+```
+
+로컬 WASM을 다시 빌드한 뒤 위 Stage 3 pointer 시나리오를 HWP/HWPX에서 실행한다. 기존
+#717 셀 빈 영역과 #919 글상자 경계 focused 회귀도 함께 확인한다.
+
+전체 `cargo test --verbose`, `cargo clippy --all-targets -- -D warnings`는 focused 결과를
+공유한 뒤 작업지시자의 별도 승인을 받아 PR 직전에 실행한다.
+
+## 8. 중단·재승인 조건
+
+1. 지정 page tree에 표 fragment가 있는데도 stable `(sec, para, control)`로 찾을 수 없다.
+2. page-scoped bbox만 적용했는데 실제 텍스트 클릭이 계속 표 선택으로 전환된다.
+3. 수정에 pagination, line break, renderer clip 또는 표 조판 semantic 변경이 필요하다.
+4. 현재 page의 실제 외곽 클릭이나 기존 #717/#919 동작이 회귀한다.
+5. 새 API가 page tree를 반복 구축해 눈에 띄는 pointer/hover 지연을 만든다.
+
+## 9. 완료 조건
+
+- HWP/HWPX UI 114쪽 offset 77 실제 pointer 클릭이 캐럿에 진입한다.
+- 현재 page fragment의 실제 외곽 ±5px 클릭은 표 객체를 선택한다.
+- 다중-page 표의 전·중·후반 fragment에서 다른 page bbox를 사용하지 않는다.
+- 선택된 표의 셀 재진입과 hover/move 판정도 현재 page fragment를 사용한다.
+- legacy `getTableBBox()` 계약과 #717, #919, #2215 회귀가 유지된다.
+- focused source test, Studio test/build 및 실제 pointer 검증이 통과한다.

--- a/mydocs/working/task_m100_2400_stage1.md
+++ b/mydocs/working/task_m100_2400_stage1.md
@@ -1,0 +1,111 @@
+# 단계별 완료 보고서 — Task M100 #2400 Stage 1
+
+## 1. 결론
+
+#2400은 최신 `upstream/devel@62bcae43`에서 HWP와 HWPX 모두 재현된다. `hitTest()`는
+UI 114쪽의 텍스트 위치를 정확히 찾지만, 직후 표 경계 판정이 page hint 없는 첫 fragment
+bbox를 사용한다. 첫 fragment 하단과 현재 클릭 y가 우연히 3.7px 차이여서 ±5px 표 외곽으로
+오인되는 것이 직접 원인으로 확정됐다.
+
+수정 범위는 page-scoped table bbox API와 Studio 클릭 판정으로 한정할 수 있다. line break,
+pagination, 폰트 metric 또는 #2215 selection rect를 변경할 필요가 없다.
+
+## 2. 환경
+
+- 날짜: 2026-07-19
+- 브랜치: `issue-2400-page-scoped-table-border-hit`
+- worktree: `/private/tmp/rhwp-task2400`
+- 기준: `upstream/devel@62bcae43`
+- Node.js: v24.15.0
+- wasm-pack: 0.15.0
+- Studio: `http://127.0.0.1:7716`
+- 픽스처:
+  - `rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp`
+  - `samples/issue1949_giant_cell_nested_tables_perf.hwpx`
+
+로컬 `wasm-pack build --target web --out-dir pkg`는 release WASM과 JS binding을 생성한 뒤
+wasm-opt 설치 단계의 sandbox 권한 오류로 exit 1이었지만, 계측에 사용한 `pkg/rhwp_bg.wasm`과
+binding은 현재 소스에서 정상 생성됐다. HWP/HWPX 로드와 API 호출이 모두 성공했다.
+
+## 3. 재현 절차
+
+저장소 headless Chrome 하니스로 실제 앱을 열고 다음을 수행했다.
+
+1. HWP 또는 HWPX 115쪽 샘플을 로드한다.
+2. 셀 문단 2499의 문자열에서 `어 있는 경우` 시작 offset을 API로 찾는다.
+3. page hint 113의 selection rect와 `hitTest`를 이용해 첫 글자 앞의 실제 화면 좌표를 얻는다.
+4. 같은 이벤트에서 legacy table bbox와 현재 page layout의 table fragment를 기록한다.
+5. `page.mouse.click()`으로 실제 mousedown/up을 전달한다.
+6. cursor 위치와 table object selection 상태를 확인한다.
+
+일회성 probe와 스크린샷은 `/private/tmp/issue2400_probe.mjs`,
+`/private/tmp/issue2400_before_fix.png`에 두었으며 저장소 변경에는 포함하지 않는다.
+
+## 4. HWP/HWPX 결과
+
+두 포맷의 결과는 동일했다.
+
+| 항목 | 값 |
+| --- | --- |
+| page 수 | 115 |
+| 대상 page | UI 114 / `pageIndex=113` |
+| 대상 위치 | `cellParaIndex=2499`, `charOffset=77` |
+| 클릭 page 좌표 | `(142.8, 1057.3)` |
+| glyph rect | `(150.8, 1049.3, 16, 16)` |
+| `hitTest` | sec 0 / parent 0 / control 2 / cell 2 / para 2499 / offset 77 |
+| 실제 pointer 결과 | `tableObjectSelected=true` |
+
+### bbox 대조
+
+| 소스 | page | x | y | width | height | bottom | 클릭과 bottom 거리 |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: | ---: |
+| `getTableBBox()` | 0 | 75.6 | 75.6 | 597.2 | 985.4 | 1061.0 | 3.7px |
+| `getPageControlLayout(113)` | 113 | 75.6 | 75.6 | 597.2 | 1000.3 | 1075.9 | 18.6px |
+
+기존 `isTableBorderClick()`의 tolerance는 5px이다. 따라서 page 0 bbox로는 `nearBottom=true`,
+현재 page 113 fragment로는 `nearBottom=false`다. 같은 입력을 실제 pointer로 전달했을 때
+cursor 위치 자체는 offset 77로 계산됐지만 캐럿 표시 전에 table object selection 분기가
+이를 가로챘다.
+
+## 5. 코드 경로
+
+```text
+pointer mousedown
+→ pageIdx=113, pageX/pageY 계산
+→ wasm.hitTest(113, ...): 현재 셀/offset 정상
+→ isTableBorderClick(pageX, pageY, sec, parentPara, control)
+→ wasm.getTableBBox(sec, parentPara, control)
+→ get_table_bbox_native(): page 0부터 순회, 첫 fragment 반환
+→ page 113 좌표와 page 0 bbox 비교
+→ enterTableObjectSelectionDirect()
+```
+
+같은 page 정보 손실은 이미 표 객체가 선택된 상태의 셀 재진입/이동 시작 판정과 hover move
+cursor 판정에도 있다. 일반 클릭 한 곳만 고치면 뒤쪽 fragment의 객체 선택 상태에서 비슷한
+오판이 남으므로 세 경로를 같은 page-scoped 계약으로 묶어야 한다.
+
+## 6. 가설 판정
+
+| 후보 | 판정 | 근거 |
+| --- | --- | --- |
+| `hitTest`가 다른 셀/문단을 반환 | 기각 | page 113, para 2499, offset 77 정확 |
+| #2215 selection rect 오류 | 기각 | rect는 page 113 glyph 위치를 정확히 반환 |
+| 첫 fragment bbox와 page-local 좌표 혼용 | 확정 | 기존 3.7px, 현재 fragment 18.6px |
+| HWP parser 전용 문제 | 기각 | HWPX 결과와 수치까지 동일 |
+| line break/pagination/폰트 metric | 직접 원인 아님 | 경계 판정 전 텍스트 위치가 정확 |
+
+## 7. GitHub 반영
+
+- 이슈 메타데이터: `bug`, assignee `postmelee`, milestone `v1.0.0`
+- 확정 계측 코멘트:
+  [#2400 issuecomment-5014875307](https://github.com/edwardkim/rhwp/issues/2400#issuecomment-5014875307)
+
+## 8. 다음 단계
+
+`mydocs/plans/task_m100_2400.md`의 승인 뒤 다음 순서로 진행한다.
+
+1. legacy API를 보존한 page-scoped native/WASM bbox API와 RED 회귀 추가
+2. Studio bridge와 일반 클릭·선택 표·hover 세 경로에 page 전달
+3. pure border geometry 단위 테스트 GREEN
+4. HWP/HWPX 실제 pointer와 실제 border 클릭 양방향 검증
+5. focused 결과 공유 후 별도 승인으로 PR 전 전체 CI 실행

--- a/mydocs/working/task_m100_2400_stage2.md
+++ b/mydocs/working/task_m100_2400_stage2.md
@@ -86,21 +86,39 @@ UI 114→115 drag를 HWP/HWPX에서 실제 pointer로 다시 수행했다.
 | `issue_717_table_cell_hit_test` | 4 passed |
 | `issue_nested_table_border` | 2 passed |
 | `issue_919_textbox_hit_test` | 5 passed |
-| `npm --prefix rhwp-studio test` | 418 passed |
+| `npm --prefix rhwp-studio test` | 418 passed (최종 rebase 후 449 passed) |
 | `npm --prefix rhwp-studio run build` | 통과 |
 | `git diff --check` | 통과 |
 
 개발용 `wasm-pack build --dev --target web --out-dir pkg`도 통과했다. 실제 포인터 probe와
 스크린샷은 일회성 검증 산출물이므로 `/private/tmp`에만 유지하고 PR에는 포함하지 않는다.
 
-## 6. 남은 단계
+## 6. 전체 CI
 
-수행·구현 계획에 따라 full CI는 focused 결과 공유와 별도 승인 뒤 PR 직전에 실행한다.
+focused 결과 공유와 별도 승인 뒤 PR 전 전체 CI를 실행했다.
 
 ```text
-cargo test --verbose
-cargo clippy --all-targets -- -D warnings
+cargo test --verbose                         통과
+cargo clippy --all-targets -- -D warnings  통과
 ```
 
-full CI 통과 후 변경 요약과 실제 pointer 근거를 #2400에 공유하고 push/PR 생성 승인을
-받는다.
+`cargo test --verbose`는 library 2,288 passed / 0 failed / 7 ignored를 포함해 전체 integration,
+round-trip, visual baseline, doc-test를 완료했다. #1949 전체 115쪽 렌더, #2185 단일 문자 편집,
+#2214 cache coherence, #2215 page-hinted selection 등 장시간 회귀도 모두 통과했다.
+
+다음 단계는 변경 요약과 실제 pointer 근거를 #2400에 공유하고 push/PR 생성 승인을 받는
+것이다.
+
+## 7. 최신 devel rebase 검증
+
+PR 직전 `upstream/devel@3eac4ae0`으로 3개 작업 커밋을 충돌 없이 rebase했다. 유입된 17개
+커밋은 주로 CanvasKit 렌더링 강화와 CFB 헤더 검증이며 page-scoped table hit-test와 의미
+충돌은 없었다.
+
+최종 rebase 후 다음 focused 검증을 다시 통과했다.
+
+- 신규 #2400 HWP/HWPX native 회귀 1 passed
+- Studio 449 passed, production build 통과
+- #2215 selection page range 4 passed
+- #717 table cell hit-test 4 passed
+- #919 textbox hit-test 5 passed

--- a/mydocs/working/task_m100_2400_stage2.md
+++ b/mydocs/working/task_m100_2400_stage2.md
@@ -122,3 +122,66 @@ PR 직전 `upstream/devel@3eac4ae0`으로 3개 작업 커밋을 충돌 없이 re
 - #2215 selection page range 4 passed
 - #717 table cell hit-test 4 passed
 - #919 textbox hit-test 5 passed
+
+## 8. 작업지시자 수동 검증 후 캐럿 기하 보완
+
+작업지시자가 Draft PR #2425 로컬 서버에서 UI 114쪽 `어 있는 경우` 앞을 클릭했을 때
+표 객체 선택은 해소됐지만 클릭 위치에 캐럿이 보이지 않는 잔여 증상을 확인했다. 최신 빌드
+미반영이 아니라 pointer hit 이후 같은 page에서 수행되는 경로 기반 캐럿 재조회가 다른
+continuation run을 선택한 것이 원인이었다.
+
+| 단계 | page | x | y | 결과 |
+| --- | ---: | ---: | ---: | --- |
+| `hitTest.cursorRect` | 113 | 150.8 | 1049.3 | `어` 앞의 정확한 위치 |
+| 기존 `CursorState.updateRect()` 재조회 | 113 | 670.9 | 1023.7 | 같은 page의 이전 줄 끝 |
+| 기존 화면 caret | 113 | 670.9 | 1023.7 | 화면 x 약 924px로 밀림 |
+
+페이지 번호만 비교하던 기존 폴백은 두 결과가 모두 page 113이라 불일치를 감지하지 못했다.
+이를 전역 좌표 허용 오차로 보정하지 않고, 방금 수행한 pointer hit 경로에만
+`moveToHit()`을 도입했다. hit-test가 `cursorRect`를 제공하면 이를 직접 사용하고 좌표가 없는
+호환 경로에서만 기존 경로 재조회를 수행한다. 일반 편집·키보드 이동은 기존 `moveTo()` 재조회를
+유지해 오래된 pointer 좌표를 재사용하지 않는다.
+
+작업지시자의 후속 수동 확인에서 클릭 후 약간의 지연도 관찰됐다. 깨끗한 브라우저 세션에서
+계측한 결과, 최초 pointer 클릭은 `moveToHit()`의 불필요한 선행 `updateRect()`가 legacy
+`getCursorRectByPath()` 전체 탐색을 유발해 약 26.6초를 사용했다. 위 direct-hit 정책으로 이
+탐색을 제거했다. 반복 클릭 중앙값 약 252ms 가운데 약 242ms는 별도 `hitTestFootnote()` 경로로
+확인되어 #2400의 캐럿 기하 수정과 분리해 성능 후속 #2428로 추적한다.
+
+### 최초 클릭 탐색 제거 후 재계측
+
+같은 HWP의 UI 114쪽 offset 77/78을 12회 번갈아 클릭했다.
+
+| 구간 | 호출 수 | 첫 클릭 | p50 | p95 |
+| --- | ---: | ---: | ---: | ---: |
+| 전체 `mousedown` 처리 | 12 | 268.6ms | 258.1ms | 268.6ms |
+| `moveToHit` | 12 | 0ms | 0ms | 0ms |
+| `getCursorRectByPathNear` | 0 | - | - | - |
+| legacy `getCursorRectByPath` | 0 | - | - | - |
+| `hitTestFootnote` | 12 | 248.7ms | 248.2ms | 248.8ms |
+
+최초 클릭 약 26.6초의 cursor lookup은 0회로 제거됐다. 캐럿은 계속
+`pageIndex=113, x=150.8, y=1049.3, height=16`에 진입했다. 남은 warm 지연은 #2428의
+각주 page-local fast-negative/prefilter 범위로 분리했다.
+
+### 보완 검증
+
+- `npm --prefix rhwp-studio test`: 452 passed
+- `npm --prefix rhwp-studio run build`: 통과
+- HWP/HWPX UI 114쪽 offset 77:
+  - `tableObjectSelected=false`
+  - cursor rect `(150.8, 1049.3)`
+  - DOM caret 화면 x 약 404px로 `어` 앞에 표시
+  - 같은 fragment 실제 하단 클릭은 표 객체 선택 유지
+- #2215 UI 114→115 실제 pointer drag HWP/HWPX:
+  - selection 유지, highlight 3개, 복사 문자열 동일
+  - HWP drag p95 5.5ms / rect p95 1.4ms
+  - HWPX drag p95 4.7ms / rect p95 1.3ms
+- HWP/HWPX page 0/1, 55/56, 113/114의 전·중·후반 텍스트 클릭 12건:
+  - 표 객체 오인 0건
+  - 기대 page/cell paragraph/offset 캐럿 일치 12건
+- 후속 성능 이슈: [#2428](https://github.com/edwardkim/rhwp/issues/2428)
+
+일회성 계측 probe와 스크린샷은 `/private/tmp`에만 유지한다. 작업지시자는 같은 7716 서버에서
+UI 114쪽 `어` 앞의 시각 캐럿 진입이 정상화됐음을 확인했다. #2400의 잔여 게이트는 이 보완을
+Draft PR #2425에 반영하고 CI·리뷰를 받는 것이다.

--- a/mydocs/working/task_m100_2400_stage2.md
+++ b/mydocs/working/task_m100_2400_stage2.md
@@ -1,0 +1,106 @@
+# 단계별 완료 보고서 — Task M100 #2400 Stage 2
+
+## 1. 결론
+
+다중 페이지 표의 pointer hit 경로가 현재 page의 표 fragment bbox만 사용하도록 수정했다.
+UI 114쪽 `어 있는 경우` 첫 글자 앞 클릭은 HWP/HWPX 모두 표 객체 선택 없이
+`cellParaIndex=2499`, `charOffset=77`에 캐럿이 진입한다. 같은 page fragment의 실제 하단
+테두리 클릭은 계속 표 객체를 선택하므로 기존 ±5px 외곽 선택 계약도 보존된다.
+
+수정은 table bbox 조회와 Studio hit 판정에 한정된다. pagination, line break, 폰트 metric,
+selection rect semantic은 변경하지 않았다.
+
+## 2. 구현
+
+### native/WASM
+
+- legacy `get_table_bbox_native()` / `getTableBBox()`의 첫 fragment 계약은 유지했다.
+- `get_table_bbox_at_page_native()` / `getTableBBoxAtPage()`를 추가했다.
+- 새 API는 지정 page tree 한 장만 조회하며 다른 page fragment로 fallback하지 않는다.
+- 잘못된 표 참조, 범위 밖 page, 지정 page에 fragment가 없는 경우 오류를 반환한다.
+
+### Studio
+
+- `WasmBridge.getTableBBoxAtPage()` typed wrapper를 추가했다.
+- 일반 셀 클릭, 선택된 표의 셀 재진입·이동 시작, 선택된 표 hover의 세 경로가 pointer
+  `pageIdx`를 전달하도록 변경했다.
+- 표 외부 탐색의 page layout 우선 경로는 유지하고 fallback에도 같은 page를 전달했다.
+- ±5px 외곽 판정을 `isPointNearBoxBorder()` pure helper로 분리했다.
+
+## 3. source 회귀
+
+권위 HWP/HWPX 115쪽 샘플에서 다음 계약을 고정했다.
+
+| 항목 | 결과 |
+| --- | --- |
+| legacy bbox | `pageIndex=0`, 기존 계약 유지 |
+| page-scoped bbox | `pageIndex=113`, 현재 fragment 반환 |
+| 재현점 `(142.8, 1057.3)` | legacy bbox에서는 border, 현재 bbox에서는 text |
+| 범위 밖 `pageIndex=115` | 오류, 첫 fragment fallback 없음 |
+
+Studio 테스트는 확정 좌표와 좌·우·상·하 ±5px 계약, 세 page 전달 경로를 검증한다.
+
+## 4. 실제 pointer 검증
+
+로컬 개발 WASM과 headless Chrome에서 HWP/HWPX를 각각 검증했다.
+
+### #2400 직접 시나리오
+
+| 입력 | HWP | HWPX |
+| --- | --- | --- |
+| UI 114쪽 offset 77 텍스트 클릭 | 표 선택 없음, offset 77 캐럿 | 표 선택 없음, offset 77 캐럿 |
+| page 113 실제 fragment 하단 클릭 | 표 `sec=0, ppi=0, ci=2` 선택 | 동일 |
+
+첫 fragment 하단과 클릭점 거리는 3.7px이지만 현재 fragment 하단과는 18.6px이다.
+수정 후 native 경계 판정은 `false`였고 실제 pointer 결과도 일치했다.
+
+### 인접 fragment 텍스트 클릭
+
+HWP/HWPX 각각 다음 여섯 위치를 실제 pointer로 클릭했다. 12건 모두 표 객체 선택 없이
+요청한 page·문단·offset에 캐럿이 진입했다.
+
+| UI page 경계 | 앞 fragment | 뒤 fragment |
+| --- | --- | --- |
+| 1→2 | page 0 / para 17 / offset 162 | page 1 / para 17 / offset 170 |
+| 56→57 | page 55 / para 1277 / offset 74 | page 56 / para 1277 / offset 82 |
+| 114→115 | page 113 / para 2499 / offset 110 | page 114 / para 2499 / offset 118 |
+
+### #2215 drag 회귀
+
+UI 114→115 drag를 HWP/HWPX에서 실제 pointer로 다시 수행했다.
+
+- 시작: page 113 / para 2499 / offset 40
+- 끝: page 114 / para 2499 / offset 118
+- 두 포맷 모두 selection 유지, highlight 3개, 복사 문자열 동일
+- warm drag handler: HWP p95 5.0ms, HWPX p95 4.9ms
+- selection rect: 두 포맷 p95 약 1.2ms
+
+## 5. focused 검증 결과
+
+| 검증 | 결과 |
+| --- | --- |
+| `cargo fmt --all -- --check` | 통과 |
+| 신규 native #2400 HWP/HWPX 회귀 | 1 passed |
+| legacy `test_get_table_bbox` | 1 passed |
+| `issue_2215_selection_page_range` | 4 passed |
+| `issue_717_table_cell_hit_test` | 4 passed |
+| `issue_nested_table_border` | 2 passed |
+| `issue_919_textbox_hit_test` | 5 passed |
+| `npm --prefix rhwp-studio test` | 418 passed |
+| `npm --prefix rhwp-studio run build` | 통과 |
+| `git diff --check` | 통과 |
+
+개발용 `wasm-pack build --dev --target web --out-dir pkg`도 통과했다. 실제 포인터 probe와
+스크린샷은 일회성 검증 산출물이므로 `/private/tmp`에만 유지하고 PR에는 포함하지 않는다.
+
+## 6. 남은 단계
+
+수행·구현 계획에 따라 full CI는 focused 결과 공유와 별도 승인 뒤 PR 직전에 실행한다.
+
+```text
+cargo test --verbose
+cargo clippy --all-targets -- -D warnings
+```
+
+full CI 통과 후 변경 요약과 실제 pointer 근거를 #2400에 공유하고 push/PR 생성 승인을
+받는다.

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1008,6 +1008,12 @@ export class WasmBridge {
     return JSON.parse(this.doc.getTableBBox(sec, parentPara, controlIdx));
   }
 
+  /** 지정 page 에 배치된 표 fragment 의 페이지 좌표 bbox (#2400). */
+  getTableBBoxAtPage(sec: number, parentPara: number, controlIdx: number, pageIdx: number): { pageIndex: number; x: number; y: number; width: number; height: number } {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse(this.doc.getTableBBoxAtPage(sec, parentPara, controlIdx, pageIdx));
+  }
+
   /** [Task #919] 글상자/도형 컨트롤의 페이지 좌표 바운딩박스 */
   getShapeBBox(sec: number, parentPara: number, controlIdx: number): { pageIndex: number; x: number; y: number; width: number; height: number } {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1,5 +1,5 @@
 import type { DocumentPosition, CursorRect, LineInfo, CellPathEntry, NavContextEntry, CellBbox } from '@/core/types';
-import { WasmBridge } from '@/core/wasm-bridge';
+import type { WasmBridge } from '@/core/wasm-bridge';
 
 type CellSelectionReason = 'manual' | 'protected';
 
@@ -263,6 +263,24 @@ export class CursorState {
     this.position = { ...pos };
     this.atLineEnd = false;
     this.updateRect();
+  }
+
+  /**
+   * 방금 수행한 pointer hit-test 위치로 커서를 이동한다.
+   *
+   * 경로 기반 좌표 조회는 한 페이지에 같은 셀 문단의 여러 continuation run이 있으면
+   * 같은 page의 다른 run을 고를 수 있다. pointer hit-test가 제공한 좌표를 최종 기하로
+   * 직접 사용하고, 좌표가 없는 호환 경로에서만 기존 경로 기반 조회로 보완한다.
+   * 편집·키보드 이동에는 오래된 hit 좌표가 남을 수 있으므로 이 메서드를 사용하지 않는다.
+   */
+  moveToHit(pos: DocumentPosition): void {
+    this.position = { ...pos };
+    this.atLineEnd = false;
+    if (pos.cursorRect) {
+      this.rect = { ...pos.cursorRect };
+    } else {
+      this.updateRect();
+    }
   }
 
   /** preferredX 초기화 (수평 이동/클릭/편집 시) */

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -399,11 +399,11 @@ export function onClick(this: any, e: MouseEvent): void {
                 hit.sectionIndex === ref.sec &&
                 hit.parentParaIndex === ref.ppi &&
                 hit.controlIndex === ref.ci &&
-                !this.isTableBorderClick(px, py, hit.sectionIndex, hit.parentParaIndex, hit.controlIndex)) {
+                !this.isTableBorderClick(pi, px, py, hit.sectionIndex, hit.parentParaIndex, hit.controlIndex)) {
               enterCellHit = hit;
             }
           }
-          const bbox = this.wasm.getTableBBox(ref.sec, ref.ppi, ref.ci);
+          const bbox = this.wasm.getTableBBoxAtPage(ref.sec, ref.ppi, ref.ci, pi);
           if (px >= bbox.x && px <= bbox.x + bbox.width &&
               py >= bbox.y && py <= bbox.y + bbox.height) {
             clickedInsideSelectedTable = true;
@@ -943,7 +943,7 @@ export function onClick(this: any, e: MouseEvent): void {
 
     // 표 경계선 클릭 감지 → 표 객체 선택 (셀 내부에서 외곽 클릭)
     if (hit.parentParaIndex !== undefined && hit.controlIndex !== undefined && !hit.isTextBox) {
-      if (this.isTableBorderClick(pageX, pageY, hit.sectionIndex, hit.parentParaIndex, hit.controlIndex)) {
+      if (this.isTableBorderClick(pageIdx, pageX, pageY, hit.sectionIndex, hit.parentParaIndex, hit.controlIndex)) {
         this.cursor.clearSelection();
         this.cursor.moveTo(hit); // 셀 위치로 이동 (유효한 렌더링 위치)
         this.cursor.enterTableObjectSelectionDirect(hit.sectionIndex, hit.parentParaIndex, hit.controlIndex);
@@ -1714,7 +1714,7 @@ export function onMouseMove(this: any, e: MouseEvent): void {
         const px = (x - pl) / zoom;
         const py = (y - po) / zoom;
         try {
-          const bbox = this.wasm.getTableBBox(ref.sec, ref.ppi, ref.ci);
+          const bbox = this.wasm.getTableBBoxAtPage(ref.sec, ref.ppi, ref.ci, pi);
           if (px >= bbox.x && px <= bbox.x + bbox.width &&
               py >= bbox.y && py <= bbox.y + bbox.height) {
             this.container.style.cursor = 'move';

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -114,7 +114,7 @@ function selectProtectedCell(this: any, hit: any): void {
     this.tableObjectRenderer?.clear();
     this.eventBus.emit('table-object-selection-changed', false);
   }
-  this.cursor.moveTo(hit);
+  this.cursor.moveToHit(hit);
   this.cursor.resetPreferredX();
   if (!this.cursor.enterCellSelectionMode('protected')) return;
   this.active = true;
@@ -211,7 +211,7 @@ function finishCellSelectionDrag(this: any, e: MouseEvent): void {
       this.cursor.exitCellSelectionMode();
       this.cellSelectionRenderer?.clear();
       this.cursor.clearSelection();
-      this.cursor.moveTo(hit);
+      this.cursor.moveToHit(hit);
       this.cursor.resetPreferredX();
       this.cursor.setAnchor();
       this.active = true;
@@ -945,7 +945,7 @@ export function onClick(this: any, e: MouseEvent): void {
     if (hit.parentParaIndex !== undefined && hit.controlIndex !== undefined && !hit.isTextBox) {
       if (this.isTableBorderClick(pageIdx, pageX, pageY, hit.sectionIndex, hit.parentParaIndex, hit.controlIndex)) {
         this.cursor.clearSelection();
-        this.cursor.moveTo(hit); // 셀 위치로 이동 (유효한 렌더링 위치)
+        this.cursor.moveToHit(hit); // 셀 위치로 이동 (유효한 렌더링 위치)
         this.cursor.enterTableObjectSelectionDirect(hit.sectionIndex, hit.parentParaIndex, hit.controlIndex);
         this.active = true;
         this.caret.hide();
@@ -1003,7 +1003,7 @@ export function onClick(this: any, e: MouseEvent): void {
         this.pictureObjectRenderer?.clear();
         this.eventBus.emit('picture-object-selection-changed', false);
         this.cursor.clearSelection();
-        this.cursor.moveTo(hit);
+        this.cursor.moveToHit(hit);
         this.cursor.resetPreferredX();
         this.cursor.setAnchor();
         this.active = true;
@@ -1088,7 +1088,7 @@ export function onClick(this: any, e: MouseEvent): void {
     if (hit.isTextBox) {
       this.exitPictureObjectSelectionIfNeeded();
       this.cursor.clearSelection();
-      this.cursor.moveTo(hit);
+      this.cursor.moveToHit(hit);
       this.cursor.resetPreferredX();
       this.cursor.setAnchor();
       this.active = true;
@@ -1142,7 +1142,7 @@ export function onClick(this: any, e: MouseEvent): void {
             const pos = this.cursor.getPosition();
             if (pos.parentParaIndex === picHit.ppi && pos.controlIndex === picHit.ci) {
               this.cursor.clearSelection();
-              this.cursor.moveTo(hit);
+              this.cursor.moveToHit(hit);
               this.cursor.resetPreferredX();
               this.cursor.setAnchor();
               this.active = true;
@@ -1214,7 +1214,7 @@ export function onClick(this: any, e: MouseEvent): void {
     if (e.shiftKey) {
       // Shift+클릭: 현재 위치에서 클릭 위치까지 선택 확장
       this.cursor.setAnchor(); // anchor가 없으면 현재 커서 위치를 anchor로
-      this.cursor.moveTo(hit);
+      this.cursor.moveToHit(hit);
       this.active = true;
       this.updateCaret();
       this.textarea.focus();
@@ -1223,7 +1223,7 @@ export function onClick(this: any, e: MouseEvent): void {
 
     // 일반 클릭: 커서 배치 + 드래그 시작
     this.cursor.clearSelection();
-    this.cursor.moveTo(hit);
+    this.cursor.moveToHit(hit);
     this.cursor.resetPreferredX();
     this.prepareClickHerePointerEntry?.(pageX);
     this.cursor.setAnchor(); // 드래그 시작점(anchor) 설정

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1449,7 +1449,7 @@ export class InputHandler {
           return;
         }
       }
-      this.cursor.moveTo(hit);
+      this.cursor.moveToHit(hit);
       this.updateCaretDuringDrag();
     }
   }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -38,6 +38,7 @@ import * as _picture from './input-handler-picture';
 import { computeHangingIndentPx } from './hanging-indent';
 import { isPageLocalTextEditCommand, type PageLocalTextEditOptions } from './input-edit-invalidation';
 import type { NavigationKeyInput } from './navigation-keymap';
+import { isPointNearBoxBorder } from './table-border-hit';
 
 const SVG_NS = 'http://www.w3.org/2000/svg';
 const DRAG_SCROLL_EDGE_PX = 48;
@@ -1521,21 +1522,13 @@ export class InputHandler {
 
   /** 클릭 좌표가 표 외곽 경계선 위인지 판별한다 (페이지 좌표 기준) */
   private isTableBorderClick(
+    pageIdx: number,
     pageX: number, pageY: number,
     sec: number, ppi: number, ci: number,
   ): boolean {
     try {
-      const bbox = this.wasm.getTableBBox(sec, ppi, ci);
-      const tolerance = 5; // 페이지 좌표 기준 px
-      const nearLeft = Math.abs(pageX - bbox.x) <= tolerance;
-      const nearRight = Math.abs(pageX - (bbox.x + bbox.width)) <= tolerance;
-      const nearTop = Math.abs(pageY - bbox.y) <= tolerance;
-      const nearBottom = Math.abs(pageY - (bbox.y + bbox.height)) <= tolerance;
-      // 세로 범위 내 좌/우 경계, 가로 범위 내 상/하 경계
-      const inVertRange = pageY >= bbox.y - tolerance && pageY <= bbox.y + bbox.height + tolerance;
-      const inHorzRange = pageX >= bbox.x - tolerance && pageX <= bbox.x + bbox.width + tolerance;
-      return (nearLeft && inVertRange) || (nearRight && inVertRange) ||
-             (nearTop && inHorzRange) || (nearBottom && inHorzRange);
+      const bbox = this.wasm.getTableBBoxAtPage(sec, ppi, ci, pageIdx);
+      return isPointNearBoxBorder(pageX, pageY, bbox);
     } catch {
       return false;
     }
@@ -1598,16 +1591,8 @@ export class InputHandler {
   ): { sec: number; ppi: number; ci: number } | null {
     try {
       const layout = this.wasm.getPageControlLayout(pageIdx);
-      const tolerance = 5;
       const isNearBorder = (x: number, y: number, w: number, h: number): boolean => {
-        const nearLeft = Math.abs(pageX - x) <= tolerance;
-        const nearRight = Math.abs(pageX - (x + w)) <= tolerance;
-        const nearTop = Math.abs(pageY - y) <= tolerance;
-        const nearBottom = Math.abs(pageY - (y + h)) <= tolerance;
-        const inVertRange = pageY >= y - tolerance && pageY <= y + h + tolerance;
-        const inHorzRange = pageX >= x - tolerance && pageX <= x + w + tolerance;
-        return (nearLeft && inVertRange) || (nearRight && inVertRange) ||
-               (nearTop && inHorzRange) || (nearBottom && inHorzRange);
+        return isPointNearBoxBorder(pageX, pageY, { x, y, width: w, height: h });
       };
 
       for (const item of layout.controls) {
@@ -1629,7 +1614,7 @@ export class InputHandler {
       for (const ppi of candidates) {
         if (ppi < 0) continue;
         for (let ci = 0; ci < 10; ci++) {
-          if (this.isTableBorderClick(pageX, pageY, sec, ppi, ci)) {
+          if (this.isTableBorderClick(pageIdx, pageX, pageY, sec, ppi, ci)) {
             return { sec, ppi, ci };
           }
         }

--- a/rhwp-studio/src/engine/table-border-hit.ts
+++ b/rhwp-studio/src/engine/table-border-hit.ts
@@ -1,0 +1,23 @@
+export type BorderHitBox = {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+};
+
+/** 페이지 좌표의 점이 bbox 외곽선 tolerance 안인지 판정한다. */
+export function isPointNearBoxBorder(
+  pageX: number,
+  pageY: number,
+  bbox: BorderHitBox,
+  tolerance = 5,
+): boolean {
+  const nearLeft = Math.abs(pageX - bbox.x) <= tolerance;
+  const nearRight = Math.abs(pageX - (bbox.x + bbox.width)) <= tolerance;
+  const nearTop = Math.abs(pageY - bbox.y) <= tolerance;
+  const nearBottom = Math.abs(pageY - (bbox.y + bbox.height)) <= tolerance;
+  const inVertRange = pageY >= bbox.y - tolerance && pageY <= bbox.y + bbox.height + tolerance;
+  const inHorzRange = pageX >= bbox.x - tolerance && pageX <= bbox.x + bbox.width + tolerance;
+  return (nearLeft && inVertRange) || (nearRight && inVertRange) ||
+         (nearTop && inHorzRange) || (nearBottom && inHorzRange);
+}

--- a/rhwp-studio/tests/cursor-hit-coherence.test.ts
+++ b/rhwp-studio/tests/cursor-hit-coherence.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const cursorSource = readFileSync(new URL('../src/engine/cursor.ts', import.meta.url), 'utf8');
+const mouseSource = readFileSync(
+  new URL('../src/engine/input-handler-mouse.ts', import.meta.url),
+  'utf8',
+);
+const inputSource = readFileSync(
+  new URL('../src/engine/input-handler.ts', import.meta.url),
+  'utf8',
+);
+
+test('일반 편집 이동과 pointer hit 이동의 좌표 정책은 분리한다', () => {
+  assert.match(cursorSource, /moveTo\(pos: DocumentPosition\): void \{[\s\S]*?this\.updateRect\(\);[\s\S]*?\n  \}/);
+  assert.match(
+    cursorSource,
+    /moveToHit\(pos: DocumentPosition\): void \{[\s\S]*?if \(pos\.cursorRect\) \{[\s\S]*?this\.rect = \{ \.\.\.pos\.cursorRect \};[\s\S]*?\} else \{[\s\S]*?this\.updateRect\(\);/,
+  );
+});
+
+test('#2400 pointer hit 좌표가 있으면 선행 경로 재조회를 수행하지 않는다', () => {
+  const moveToHitBody = cursorSource.match(
+    /moveToHit\(pos: DocumentPosition\): void \{([\s\S]*?)\n  \}/,
+  )?.[1];
+
+  assert.ok(moveToHitBody);
+  assert.ok(moveToHitBody.indexOf('if (pos.cursorRect)') < moveToHitBody.indexOf('this.updateRect()'));
+  assert.doesNotMatch(
+    moveToHitBody.slice(0, moveToHitBody.indexOf('if (pos.cursorRect)')),
+    /updateRect/,
+  );
+});
+
+test('일반 클릭·셀 재진입·드래그 pointer 경로가 moveToHit을 사용한다', () => {
+  assert.equal(mouseSource.match(/cursor\.moveTo\(hit\)/g), null);
+  assert.ok((mouseSource.match(/cursor\.moveToHit\(hit\)/g)?.length ?? 0) >= 8);
+  assert.match(inputSource, /const hit = this\.hitTestFromClientPoint[\s\S]*cursor\.moveToHit\(hit\);/);
+});

--- a/rhwp-studio/tests/table-border-page-scope.test.ts
+++ b/rhwp-studio/tests/table-border-page-scope.test.ts
@@ -1,0 +1,51 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { isPointNearBoxBorder } from '../src/engine/table-border-hit.ts';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const input = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+const mouse = readFileSync(join(rootDir, 'src/engine/input-handler-mouse.ts'), 'utf8');
+
+test('#2400 UI 114 텍스트 클릭은 현재 page fragment 경계가 아니다', () => {
+  const point = { x: 142.8, y: 1057.3 };
+  const firstFragment = { x: 75.6, y: 75.6, width: 597.2, height: 985.4 };
+  const currentFragment = { x: 75.6, y: 75.6, width: 597.2, height: 1000.3 };
+
+  assert.equal(isPointNearBoxBorder(point.x, point.y, firstFragment), true,
+    '첫 fragment bbox를 사용하면 재현점이 잘못 경계로 판정되는 전제');
+  assert.equal(isPointNearBoxBorder(point.x, point.y, currentFragment), false,
+    '현재 page fragment에서는 텍스트 내부 클릭이어야 함');
+});
+
+test('현재 fragment의 실제 외곽 ±5px 계약은 유지한다', () => {
+  const bbox = { x: 75.6, y: 75.6, width: 597.2, height: 1000.3 };
+  const midX = bbox.x + bbox.width / 2;
+  const midY = bbox.y + bbox.height / 2;
+
+  assert.equal(isPointNearBoxBorder(bbox.x + 4.9, midY, bbox), true, 'left');
+  assert.equal(isPointNearBoxBorder(bbox.x + bbox.width - 4.9, midY, bbox), true, 'right');
+  assert.equal(isPointNearBoxBorder(midX, bbox.y + 4.9, bbox), true, 'top');
+  assert.equal(isPointNearBoxBorder(midX, bbox.y + bbox.height - 4.9, bbox), true, 'bottom');
+  assert.equal(isPointNearBoxBorder(midX, bbox.y + bbox.height - 5.1, bbox), false,
+    'tolerance 밖의 내부 점');
+  assert.equal(isPointNearBoxBorder(bbox.x - 6, bbox.y - 6, bbox), false,
+    'tolerance 밖의 corner');
+});
+
+test('표 경계와 선택 표 hit 경로가 pointer page를 bbox 조회에 전달한다', () => {
+  assert.match(input, /getTableBBoxAtPage\(sec, ppi, ci, pageIdx\)/,
+    'isTableBorderClick은 현재 page fragment를 조회해야 함');
+  assert.match(input, /isTableBorderClick\(pageIdx, pageX, pageY, sec, ppi, ci\)/,
+    '표 외부 fallback도 현재 page를 전달해야 함');
+
+  assert.match(mouse, /isTableBorderClick\(pi, px, py, hit\.sectionIndex/,
+    '선택된 표의 셀 재진입 판정은 pointer page를 전달해야 함');
+  assert.match(mouse, /isTableBorderClick\(pageIdx, pageX, pageY, hit\.sectionIndex/,
+    '일반 셀 클릭 판정은 pointer page를 전달해야 함');
+  assert.equal(mouse.match(/getTableBBoxAtPage\(ref\.sec, ref\.ppi, ref\.ci, pi\)/g)?.length, 2,
+    '선택된 표의 이동 시작과 hover hit가 모두 현재 page bbox를 사용해야 함');
+});

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -2377,16 +2377,12 @@ impl DocumentCore {
         }
     }
 
-    /// 표 전체의 바운딩박스를 반환한다 (네이티브).
-    pub(crate) fn get_table_bbox_native(
+    fn validate_table_bbox_ref(
         &self,
         section_idx: usize,
         parent_para_idx: usize,
         control_idx: usize,
-    ) -> Result<String, HwpError> {
-        use crate::renderer::render_tree::{RenderNode, RenderNodeType};
-
-        // 해당 문단에 표 컨트롤이 실제로 있는지 사전 확인 (전체 페이지 순회 방지)
+    ) -> Result<(), HwpError> {
         let has_table = self
             .document
             .sections
@@ -2401,6 +2397,17 @@ impl DocumentCore {
                 section_idx, parent_para_idx, control_idx
             )));
         }
+        Ok(())
+    }
+
+    fn find_table_bbox_on_page(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        page_idx: usize,
+    ) -> Result<Option<String>, HwpError> {
+        use crate::renderer::render_tree::{RenderNode, RenderNodeType};
 
         fn find_table_bbox(
             node: &RenderNode,
@@ -2429,16 +2436,33 @@ impl DocumentCore {
             None
         }
 
+        let tree = self.build_page_tree_cached(page_idx as u32)?;
+        Ok(find_table_bbox(
+            &tree.root,
+            section_idx,
+            parent_para_idx,
+            control_idx,
+            page_idx,
+        ))
+    }
+
+    /// 표 전체의 첫 번째 fragment 바운딩박스를 반환한다 (네이티브).
+    ///
+    /// page 를 모르는 기존 호출자의 호환 계약이다. pointer 처럼 현재 page 를 아는 호출자는
+    /// `get_table_bbox_at_page_native` 를 사용해야 한다.
+    pub(crate) fn get_table_bbox_native(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+    ) -> Result<String, HwpError> {
+        self.validate_table_bbox_ref(section_idx, parent_para_idx, control_idx)?;
+
         let total_pages = self.page_count() as usize;
         for page_num in 0..total_pages {
-            let tree = self.build_page_tree_cached(page_num as u32)?;
-            if let Some(result) = find_table_bbox(
-                &tree.root,
-                section_idx,
-                parent_para_idx,
-                control_idx,
-                page_num,
-            ) {
+            if let Some(result) =
+                self.find_table_bbox_on_page(section_idx, parent_para_idx, control_idx, page_num)?
+            {
                 return Ok(result);
             }
         }
@@ -2447,6 +2471,35 @@ impl DocumentCore {
             "표 노드를 찾을 수 없습니다 (sec={}, ppi={}, ci={})",
             section_idx, parent_para_idx, control_idx
         )))
+    }
+
+    /// 지정 page 에 배치된 표 fragment 의 바운딩박스를 반환한다 (네이티브).
+    ///
+    /// 다른 page 의 첫 fragment 로 fallback 하지 않는다. page-local pointer 좌표와 다른
+    /// fragment bbox 를 비교하면 텍스트 클릭이 표 경계로 오인될 수 있기 때문이다 (#2400).
+    pub(crate) fn get_table_bbox_at_page_native(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        control_idx: usize,
+        page_idx: usize,
+    ) -> Result<String, HwpError> {
+        self.validate_table_bbox_ref(section_idx, parent_para_idx, control_idx)?;
+        let total_pages = self.page_count() as usize;
+        if page_idx >= total_pages {
+            return Err(HwpError::RenderError(format!(
+                "페이지 인덱스 {} 범위 초과 (pageCount={})",
+                page_idx, total_pages
+            )));
+        }
+
+        self.find_table_bbox_on_page(section_idx, parent_para_idx, control_idx, page_idx)?
+            .ok_or_else(|| {
+                HwpError::RenderError(format!(
+                    "페이지 {}에서 표 노드를 찾을 수 없습니다 (sec={}, ppi={}, ci={})",
+                    page_idx, section_idx, parent_para_idx, control_idx
+                ))
+            })
     }
 
     /// [Task #919] 글상자/도형 컨트롤의 페이지 좌표 바운딩박스를 반환한다 (네이티브).

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -2690,6 +2690,26 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    /// 지정 page 에 배치된 표 fragment 의 바운딩박스를 반환한다 (#2400).
+    ///
+    /// 반환: JSON `{"pageIndex":<N>,"x":<f>,"y":<f>,"width":<f>,"height":<f>}`
+    #[wasm_bindgen(js_name = getTableBBoxAtPage)]
+    pub fn get_table_bbox_at_page(
+        &self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        control_idx: u32,
+        page_idx: u32,
+    ) -> Result<String, JsValue> {
+        self.get_table_bbox_at_page_native(
+            section_idx as usize,
+            parent_para_idx as usize,
+            control_idx as usize,
+            page_idx as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// [Task #919] 글상자/도형 컨트롤의 페이지 좌표 바운딩박스를 반환한다.
     ///
     /// 반환: JSON `{"pageIndex":<N>,"x":<f>,"y":<f>,"width":<f>,"height":<f>}`

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -19031,6 +19031,56 @@ fn test_get_table_bbox() {
     eprintln!("표 bbox: {}", json);
 }
 
+/// #2400: page-local pointer 좌표는 같은 page 의 표 fragment bbox와 비교해야 한다.
+#[test]
+fn test_get_table_bbox_at_page_for_giant_multi_page_cell() {
+    use std::path::Path;
+
+    for path in [
+        "rhwp-studio/public/samples/issue1949_giant_cell_nested_tables_perf.hwp",
+        "samples/issue1949_giant_cell_nested_tables_perf.hwpx",
+    ] {
+        let data = std::fs::read(Path::new(path)).expect("#2400 권위 샘플 읽기");
+        let doc = HwpDocument::from_bytes(&data).expect("#2400 권위 샘플 파싱");
+        assert_eq!(doc.page_count(), 115, "{path}: page count");
+
+        let legacy: Value = serde_json::from_str(
+            &doc.get_table_bbox_native(0, 0, 2)
+                .expect("legacy 첫 fragment bbox"),
+        )
+        .expect("legacy bbox JSON");
+        let current: Value = serde_json::from_str(
+            &doc.get_table_bbox_at_page_native(0, 0, 2, 113)
+                .expect("page 113 fragment bbox"),
+        )
+        .expect("page-scoped bbox JSON");
+
+        assert_eq!(legacy["pageIndex"].as_u64(), Some(0), "{path}: legacy page");
+        assert_eq!(
+            current["pageIndex"].as_u64(),
+            Some(113),
+            "{path}: current fragment page"
+        );
+
+        let click_y = 1057.3;
+        let legacy_bottom = legacy["y"].as_f64().unwrap() + legacy["height"].as_f64().unwrap();
+        let current_bottom = current["y"].as_f64().unwrap() + current["height"].as_f64().unwrap();
+        assert!(
+            (click_y - legacy_bottom).abs() <= 5.0,
+            "{path}: 재현점은 첫 fragment 하단에 잘못 걸리는 전제"
+        );
+        assert!(
+            (click_y - current_bottom).abs() > 5.0,
+            "{path}: 현재 fragment에서는 실제 경계가 아님"
+        );
+
+        assert!(
+            doc.get_table_bbox_at_page_native(0, 0, 2, 115).is_err(),
+            "{path}: 범위 밖 page가 첫 fragment로 fallback하면 안 됨"
+        );
+    }
+}
+
 /// 표 컨트롤 삭제 테스트 (wasm_api 내부 접근)
 #[test]
 fn test_delete_table_control() {


### PR DESCRIPTION
## 개요

다중 페이지에 걸친 표의 뒤쪽 fragment에서 텍스트를 클릭할 때, 첫 페이지 fragment의 bbox를 사용해 표 경계로 오인하던 문제를 수정합니다.

UI 114쪽 `어 있는 경우` 첫 글자 앞을 클릭하면 표 전체가 선택되어 캐럿을 놓을 수 없었던 #2400 재현을 HWP/HWPX 모두 해결합니다.

## 원인

`hitTest()`는 현재 pointer page와 셀 문단 위치를 정확히 반환했지만, 후속 `isTableBorderClick()`이 page 정보를 전달하지 않았습니다. 기존 `getTableBBox()`는 같은 표의 page 0 첫 fragment를 반환하므로 page 113의 로컬 좌표와 서로 다른 fragment bbox가 비교됐습니다.

확정 재현점의 y는 `1057.3`입니다.

- page 0 첫 fragment 하단 `1061.0`: 3.7px 차이로 기존 ±5px 경계 판정에 포함
- page 113 실제 fragment 하단 `1075.9`: 18.6px 차이로 실제로는 텍스트 내부

## 변경 내용

- 기존 `getTableBBox()`의 첫 fragment 호환 계약 유지
- 지정 page의 표 fragment만 조회하는 native/WASM `getTableBBoxAtPage()` 추가
  - 지정 page에 fragment가 없거나 범위를 벗어나면 오류
  - 다른 page의 첫 fragment로 fallback하지 않음
- Studio의 다음 경로를 pointer page 기준으로 전환
  - 일반 셀 내부의 표 외곽 클릭 판정
  - 선택된 표의 셀 재진입·이동 시작 판정
  - 선택된 표 내부 hover/move 판정
- ±5px 외곽 판정을 pure helper로 분리하고 확정 좌표·호출 경로 회귀 추가

pagination, line break, 폰트 metric, #2215 selection rect semantic은 변경하지 않습니다.

## 실제 포인터 검증

HWP/HWPX 115쪽 권위 샘플에서 각각 확인했습니다.

- UI 114쪽 offset 77 클릭: 표 선택 없음, 정확한 위치에 캐럿 진입
- 같은 page fragment의 실제 하단 클릭: 기존대로 표 객체 선택
- UI 1·2, 56·57, 114·115쪽 인접 fragment 텍스트 클릭 12건: 모두 목표 page/offset에 캐럿 진입
- UI 114→115 drag: 양 포맷 모두 offset 40→118, highlight 3개, 복사 문자열 동일

## 검증

- `cargo test --verbose`
  - 전체 통과
  - library 2,288 passed / 0 failed / 7 ignored 포함
- `cargo clippy --all-targets -- -D warnings`
- 최신 `upstream/devel@3eac4ae0` rebase 후 focused 재검증
  - 신규 #2400 HWP/HWPX native 회귀 1 passed
  - Studio 449 passed
  - Studio production build 통과
  - #2215 4 passed
  - #717 4 passed
  - #919 5 passed

Fixes #2400
