### PR TITLE
test: profile issue 2193 input pagination latency

### DIFF
--- a/mydocs/plans/task_m100_2193.md
+++ b/mydocs/plans/task_m100_2193.md
@@ -1,9 +1,9 @@
 # 수행 계획서 — Task M100 #2193
 
-> 2026-07-19 Stage 3 갱신: `upstream/devel@62bcae43`로 최신화하고 native 20회 기준선과
-> Studio input-to-2-rAF profile을 재실증했다. mutation p50은 약 0.08~0.13ms,
-> full pagination p50은 native 약 1.14초, browser 약 0.92~0.95초였다. production 변경 없이
-> Stage 4 원인·구현 방향 게이트로 진행한다.
+> 2026-07-19 Stage 4 갱신: `upstream/devel@62bcae43` 기준 native/Studio 계측과 #2214
+> continuation correctness pin을 대조했다. 단순 downstream page 재사용은 113쪽의 실제 cut 변경을
+> 놓치므로 기각했다. production 변경 없이 resumable table continuation + 보수적 fallback을 1차,
+> chunk/yield를 2차 후보로 확정하고 전용 실행 이슈 초안을 작성했다.
 
 ## 1. 작업 개요
 

--- a/mydocs/plans/task_m100_2193.md
+++ b/mydocs/plans/task_m100_2193.md
@@ -1,0 +1,192 @@
+# 수행 계획서 — Task M100 #2193
+
+## 1. 작업 개요
+
+- 이슈: [#2193](https://github.com/edwardkim/rhwp/issues/2193)
+- 제목: 115쪽 거대 셀 문서의 단일 입력 지연 및 전체 pagination 비용 추적
+- 유형: 성능 계측 / deferred·full pagination / Studio 입력 파이프라인
+- 마일스톤: M100 / v1.0.0 조판 엔진 체계화
+- 작업 브랜치: `issue-2193-input-pagination-profile`
+- 작업 worktree: `/private/tmp/rhwp-task2193`
+- 기준 브랜치: `upstream/devel@53763944`
+- 작성일: 2026-07-19
+- 권위 재현 픽스처:
+  - `samples/issue1949_giant_cell_nested_tables_perf.hwp`
+  - `samples/issue1949_giant_cell_nested_tables_perf.hwpx`
+- 직접 재사용 자산:
+  - `tests/issue_2214_cache_matrix_probe.rs`
+  - `tests/issue_2214_page_local_repaint.rs`
+  - `rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs`
+  - `mydocs/troubleshootings/deferred_cell_edit_cache_coherence.md`
+
+## 2. 문제 정의와 현재 근거
+
+이슈 최초 단일 관측에서 문단 입력·reflow는 HWP 약 0.162ms, HWPX 약 0.096ms였지만
+명시적 전체 pagination flush는 약 1.168초와 1.185초였다. 이 값은 반복 기준선이 아니며,
+실제 Studio의 입력부터 화면 표시까지 어느 구간이 지배적인지도 아직 같은 실행에서 분리되지
+않았다.
+
+[이슈 #2214](https://github.com/edwardkim/rhwp/issues/2214)와
+[PR #2241](https://github.com/edwardkim/rhwp/pull/2241)은 warm cache 정확성과 cursor exact
+fallback을 해결했다. 줄 내부 stable 입력은 동기 full pagination 0회와 약 28.5~29.2ms p95를
+유지한다. 반면 실제 cell-flow 경계는 정확성을 위해 cursor 조회 전에 full pagination을 1회
+수행하며 약 0.9초가 남는다.
+
+[이슈 #2215](https://github.com/edwardkim/rhwp/issues/2215)와
+[PR #2401](https://github.com/edwardkim/rhwp/pull/2401)의 selection rect 개선은 다른 호출
+경로이므로 이 작업의 단일 입력 기준선이나 pagination 개선으로 합산하지 않는다.
+
+## 3. 목표
+
+1. HWP/HWPX에서 입력·reflow, page-tree/cursor 조회, explicit pagination flush와 후속
+   page-tree 재구축을 같은 프로토콜로 반복 측정한다.
+2. 실행 환경, cold/warm 조건과 반복 횟수를 기록하고 p50/p95 기준선을 만든다.
+3. Studio 실제 입력에서 mutation, pending/flush 판단, page-tree, cursor와 Canvas 표시 구간을
+   한 trace로 분리한다.
+4. 실제 지배 구간과 full pagination 실행 조건, 무효화 범위와 중복 작업을 확정한다.
+5. 계측 결과가 bounded/partial pagination 또는 다른 구현 방향을 지지할 때만 전용 실행 이슈를
+   생성한다.
+6. 이후 구현 전후를 같은 하네스로 비교하고 기존 정확성 핀을 유지한다.
+
+## 4. 범위와 비범위
+
+### 4.1 이번 계측 범위
+
+- HWP/HWPX fresh document 반복 실행
+- cold, pre-warm과 Studio 유사 every-edit warm 통제
+- stable 1글자 입력과 첫 cell-flow 경계 입력 분리
+- mutation/reflow, pre-flush tree·cursor, explicit flush, post-flush tree·cursor 시간 분해
+- Studio input handler의 flush 수·호출 순서·page-tree·Canvas 표시 시점 계측
+- raw 측정값과 p50/p95 요약 JSON 생성
+- 모델 text, `LINE_SEG`, 다음 문단 `vpos`, 115쪽과 저장·재로드 정확성 확인
+
+### 4.2 이번 Stage에서 하지 않는 것
+
+- 계측 전 production paginator 변경
+- 매 입력 global cache clear 또는 full pagination 강제
+- [이슈 #2308](https://github.com/edwardkim/rhwp/issues/2308)의 revision 기반 derived state 재설계
+- [이슈 #2400](https://github.com/edwardkim/rhwp/issues/2400)의 표 테두리 클릭 정확성 수정
+- 한컴 전체 line-break/pagination semantic 재구현
+- OS·폰트·DPR이 다른 머신 사이의 절대 시간 hard gate 또는 PNG golden 추가
+
+## 5. 측정 프로토콜
+
+### 5.1 공통 환경 기록
+
+- 기준 commit과 dirty 상태
+- OS·architecture, Rust/Cargo, Node/npm, Chrome 버전
+- build profile과 `CARGO_TARGET_DIR`
+- 브라우저 viewport, DPR, headless/host 모드
+- fixture 경로·크기·SHA-256
+- warm-up 횟수와 측정 반복 횟수
+
+기본 반복은 빠른 smoke 1회, 기준선 10회로 시작한다. 분산이 크거나 p95가 단일 outlier에
+지배되면 20회 이상으로 늘리되 결과 문서에 이유를 기록한다.
+
+### 5.2 Native 구간
+
+각 case는 fresh document에서 시작한다.
+
+1. 문서와 대상 cell 상태 확인
+2. 선택한 cold/warm 상태 구성
+3. stable 입력 또는 첫 flow 경계 직전까지 준비
+4. 대상 mutation/reflow 시간 측정
+5. pre-flush page-tree와 direct/path cursor 시간·정확성 기록
+6. explicit full pagination 시간 측정
+7. post-flush page-tree와 cursor 시간·정확성 기록
+8. p50/p95/max와 raw sample을 JSON에 보존
+
+ignored diagnostic test는 시간 관찰용이며 timing assertion을 두지 않는다. 정확성은 기존
+non-ignored [이슈 #2214](https://github.com/edwardkim/rhwp/issues/2214) 회귀와 구조 assertion으로
+고정한다.
+
+### 5.3 Studio 구간
+
+기존 E2E trace를 재사용하되 다음 구간이 같은 run에 기록되는지 먼저 감사한다.
+
+- key/input event 시작과 mutation 종료
+- `cellFlowChanged`와 deferred pending 등록
+- flush 시작·종료와 누적 횟수
+- first exact cursor query
+- page invalidation, render 시작·종료와 2 rAF 표시 완료
+- long task와 Canvas crop 안정성
+
+기존 trace에 구간이 없을 때만 최소 instrumentation을 추가한다. 제품 API를 진단용으로 넓히지
+않고 테스트 전용 hook과 재생성 가능한 `output/poc/task2193/` 산출물을 사용한다.
+
+## 6. 단계 계획
+
+### Stage 1. 기존 하네스 재실증과 gap 감사
+
+1. 최신 `upstream/devel`에서 #2214 native ignored probe와 focused E2E smoke를 실행한다.
+2. 현재 출력이 #2193 완료 조건 중 어떤 구간과 환경 정보를 제공하는지 표로 정리한다.
+3. 누락된 phase timing과 반복 통계를 확정한다.
+4. 결과를 `mydocs/working/task_m100_2193_stage1.md`에 기록한다.
+
+### Stage 2. 반복 Native 기준선 하네스
+
+1. `tests/issue_2193_input_pagination_perf.rs` ignored diagnostic을 추가한다.
+2. HWP/HWPX, stable/boundary, cold/warm case를 반복한다.
+3. raw sample과 p50/p95 요약을 `output/poc/task2193/stage2/`에 생성한다.
+4. 정확성 구조 assertion과 기존 #2214 non-ignored test를 함께 실행한다.
+
+### Stage 3. Studio end-to-display 프로파일
+
+1. 기존 #2214 trace의 재사용 가능 구간을 우선 사용한다.
+2. 누락된 page invalidation/render/2 rAF 구간만 테스트 전용 계측으로 보강한다.
+3. HWP/HWPX stable/boundary를 동일 환경에서 반복한다.
+4. mutation, flush, tree/cursor와 Canvas 비용의 p50/p95를 분리한다.
+
+### Stage 4. 원인·구현 방향 게이트
+
+1. full pagination이 실제 지배 항인지 최종 판정한다.
+2. affected page/cell 범위와 continuation cut 변화를 근거로 bounded/partial 가능 범위를 정리한다.
+3. 해결 방향이 확정되면 전용 실행 이슈와 구현 계획서를 제안한다.
+4. 작업지시자 승인 전 production 코드를 변경하지 않는다.
+
+### Stage 5. 승인된 구현·전후 검증
+
+별도 실행 이슈가 승인된 경우에만 진행한다. 동일 하네스로 전후 비교하고 전체 115쪽,
+`LINE_SEG.text_start = [0, 44, 84, 122]`, 다음 문단 `vpos = 17160`, 저장·재로드 결과를
+재검증한다.
+
+## 7. 검증 명령 후보
+
+```bash
+cargo test --profile release-test --test issue_2214_cache_matrix_probe -- --ignored --nocapture
+cargo test --profile release-test --test issue_2214_page_local_repaint
+
+cd rhwp-studio
+npm run e2e:issue-2214 -- --runs=1
+```
+
+Stage 2 이후:
+
+```bash
+cargo test --profile release-test --test issue_2193_input_pagination_perf -- --ignored --nocapture
+```
+
+PR 직전 광역 Rust·Studio·WASM 검증은 focused 결과와 구현 범위를 공유한 뒤 별도 승인을 받아
+수행한다.
+
+## 8. 산출물과 갱신 게이트
+
+- 계획: `mydocs/plans/task_m100_2193.md`
+- 단계 보고: `mydocs/working/task_m100_2193_stage{N}.md`
+- 최종 보고: `mydocs/report/task_m100_2193_report.md`
+- 장기 조사 근거가 필요할 때: `mydocs/tech/investigations/issue-2193/`
+- 재생성 가능한 로컬 증거: `output/poc/task2193/` (Git 제외)
+
+[이슈 #2193 진행 코멘트](https://github.com/edwardkim/rhwp/issues/2193#issuecomment-5014689638)는
+Stage 1 착수, Stage 2/3 기준선 확정, 구현 PR merge, 최종 close 직전에만 갱신한다. 로컬 가설이나
+중간 커밋마다 편집하지 않는다.
+
+## 9. 중단·재승인 조건
+
+- timing을 얻기 위해 production API 또는 공개 WASM 계약 변경이 필요함
+- 기존 #2214 정확성 계약이 latest devel에서 실패함
+- full pagination이 지배 항이 아니거나 다른 이슈의 호출 경로가 직접 원인으로 확인됨
+- bounded/partial paginator가 page continuation semantic 또는 대규모 renderer 재설계를 요구함
+- fixture·폰트·브라우저 환경 차이로 반복 가능한 기준선을 만들 수 없음
+
+위 조건이 발생하면 계측 증거와 대안을 보고하고 구현 범위를 다시 승인받는다.

--- a/mydocs/plans/task_m100_2193.md
+++ b/mydocs/plans/task_m100_2193.md
@@ -1,8 +1,9 @@
 # 수행 계획서 — Task M100 #2193
 
-> 2026-07-19 Stage 2 갱신: latest devel 재실증과 native 20회 반복 기준선에서 mutation
-> p50은 약 0.08~0.13ms, full pagination p50은 약 1.15~1.23초였다. production 변경 없이
-> Stage 3 Studio end-to-display 계측으로 진행한다.
+> 2026-07-19 Stage 3 갱신: `upstream/devel@62bcae43`로 최신화하고 native 20회 기준선과
+> Studio input-to-2-rAF profile을 재실증했다. mutation p50은 약 0.08~0.13ms,
+> full pagination p50은 native 약 1.14초, browser 약 0.92~0.95초였다. production 변경 없이
+> Stage 4 원인·구현 방향 게이트로 진행한다.
 
 ## 1. 작업 개요
 
@@ -12,7 +13,8 @@
 - 마일스톤: M100 / v1.0.0 조판 엔진 체계화
 - 작업 브랜치: `issue-2193-input-pagination-profile`
 - 작업 worktree: `/private/tmp/rhwp-task2193`
-- 기준 브랜치: `upstream/devel@53763944`
+- 최초 기준 브랜치: `upstream/devel@53763944`
+- 최신 재실증 기준: `upstream/devel@62bcae43`
 - 작성일: 2026-07-19
 - 권위 재현 픽스처:
   - `samples/issue1949_giant_cell_nested_tables_perf.hwp`

--- a/mydocs/plans/task_m100_2193.md
+++ b/mydocs/plans/task_m100_2193.md
@@ -1,5 +1,9 @@
 # 수행 계획서 — Task M100 #2193
 
+> 2026-07-19 Stage 2 갱신: latest devel 재실증과 native 20회 반복 기준선에서 mutation
+> p50은 약 0.08~0.13ms, full pagination p50은 약 1.15~1.23초였다. production 변경 없이
+> Stage 3 Studio end-to-display 계측으로 진행한다.
+
 ## 1. 작업 개요
 
 - 이슈: [#2193](https://github.com/edwardkim/rhwp/issues/2193)

--- a/mydocs/working/task_m100_2193_stage1.md
+++ b/mydocs/working/task_m100_2193_stage1.md
@@ -1,0 +1,130 @@
+# Task M100 #2193 Stage 1 작업보고서 — 기존 하네스 재실증과 계측 gap 감사
+
+## 0. 판정 요약
+
+- **Stage 판정**: 완료
+- **기준**: `upstream/devel@53763944`
+- **production 변경**: 없음
+- **정확성 회귀**: native 3/3, browser HWP/HWPX와 raw 8/8 GREEN
+- **기존 native probe**: 30 case 통과, 각 case 단일 관측이라 반복 기준선으로는 부족
+- **기존 browser E2E**: stable/boundary operation과 boundary flush를 분리하지만 mutation,
+  page-tree, render/2 rAF 구간별 통계는 부족
+- **다음 단계**: 반복 native 기준선 하네스를 먼저 추가하고 p50/p95를 확정
+
+## 1. 실행 환경
+
+| 항목 | 값 |
+|------|----|
+| 기준 commit | `537639445332e85b76eb29c76e1dae4d8930369f` |
+| 작업 브랜치 | `issue-2193-input-pagination-profile` |
+| OS / architecture | macOS Darwin 25.5.0 / arm64 |
+| Rust / Cargo | 1.93.1 / 1.93.1 |
+| Node / npm | v24.15.0 / 11.12.1 |
+| Chrome | 150.0.7871.128 |
+| wasm-pack | 0.15.0 |
+| Rust profile | `release-test` |
+| Browser | headless, 1280×900, DPR 1, zoom 1 |
+| Browser 반복 | 형식별 1회 smoke |
+
+| fixture | 크기 | SHA-256 |
+|---------|-----:|---------|
+| `samples/issue1949_giant_cell_nested_tables_perf.hwp` | 303,616 bytes | `ef10261cd29325116028e4f4f3e6be1a72c675eb771bddfd8484e7fe5aa94b4e` |
+| `samples/issue1949_giant_cell_nested_tables_perf.hwpx` | 266,523 bytes | `fc6e5f156de470dfbb14aab392389491720ee7fb1bf6f03fe9a018e93b420c65` |
+
+WASM은 해당 commit에서 새로 빌드했다. `pkg/`와 `output/`은 재생성 가능한 ignored local
+evidence이며 커밋 대상이 아니다.
+
+## 2. 검증 결과
+
+### 2.1 Native 정확성 핀
+
+```text
+cargo test --profile release-test --test issue_2214_page_local_repaint
+```
+
+3/3이 4.88초에 통과했다.
+
+- cold representative tree/cursor exact
+- warm deferred tree/cursor exact
+- cell-flow transition baseline
+
+전체 page count 115, `LINE_SEG.text_start = [0, 44, 84, 122]`, 다음 문단
+`vpos = 17160` 계약이 유지됐다.
+
+### 2.2 기존 native matrix probe
+
+```text
+cargo test --profile release-test --test issue_2214_cache_matrix_probe -- --ignored --nocapture
+```
+
+ignored 1/1이 80.13초에 통과했고 HWP/HWPX 합계 30 case를 생성했다. 출력은
+`output/poc/task2214/stage2/native-matrix.json`이다.
+
+| 형식 | case 수 | full flush 최소 | 중앙 관측값 | 최대 | page count |
+|------|--------:|---------------:|------------:|-----:|-----------:|
+| HWP | 15 | 1,124.317ms | 1,173.222ms | 1,186.453ms | 115 |
+| HWPX | 15 | 1,177.405ms | 1,192.955ms | 1,206.691ms | 115 |
+
+page-tree 생성은 대체로 약 20ms, 첫 cursor query는 약 32~34ms였다. 다만 위 최소·중앙·최대는
+서로 다른 case의 단일 관측을 요약한 값이다. 같은 case 반복의 p50/p95가 아니므로 #2193의
+성능 기준선으로 사용하지 않는다.
+
+### 2.3 Studio 실제 입력 smoke
+
+```text
+npm run e2e:issue-2214 -- --runs=1
+```
+
+새 WASM과 로컬 Vite/Chrome에서 HWP/HWPX focused run 2/2, IME/iOS raw smoke 8/8이
+GREEN이었다. 출력은 `output/poc/task2214/stage4/focused-summary.json`이다.
+
+| 형식 | stable operation p95 | boundary operation | boundary flush | boundary flush 수 |
+|------|---------------------:|-------------------:|---------------:|-----------------:|
+| HWP | 38.7ms | 964.1ms | 909.2ms | 1 |
+| HWPX | 38.1ms | 944.1ms | 892.1ms | 1 |
+
+- stable 49회는 동기 flush 0회, 첫 flow boundary는 1회였다.
+- boundary ordering은 mutation → flush → exact cursor 순서를 유지했다.
+- page count는 두 형식 모두 115였다.
+- IME/iOS raw stable은 flush 0, boundary는 flush 1이었다.
+- 43→44 경계 화면은 10,074 pixel이 바뀌었고 이후 네 checkpoint는 0 pixel 변화로
+  안정적이었다.
+
+이 수치는 최신 환경의 smoke 관찰값이다. 형식별 1회이므로 절대 성능 판정이나 회귀 hard gate로
+사용하지 않는다.
+
+## 3. #2193 완료 조건 대비 gap 감사
+
+| 완료 조건 | 현재 자산 | 판정 | 다음 조치 |
+|-----------|-----------|------|-----------|
+| HWP/HWPX 대표 문서 | native probe와 E2E가 두 형식 사용 | 충족 | 동일 fixture 유지 |
+| cold/warm 통제 | native 30-case가 cold/pre-warm/every-edit 분리 | 부분 충족 | 반복 하네스에서 case를 축소·명시 |
+| input/reflow와 pagination 분리 | native는 explicit flush, E2E는 operation/flush 기록 | 부분 충족 | mutation/reflow 자체 시간을 별도 기록 |
+| 반복 횟수와 p50/p95 | E2E stable 49 operation만 통계 제공 | 미충족 | fresh document case별 10회 raw sample 추가 |
+| page-tree/cursor 비용 | native 단일 elapsed와 exact 결과 존재 | 부분 충족 | pre/post flush 반복 통계 추가 |
+| 실제 Studio input-to-display | operation, flush, cursor, Canvas 안정성 존재 | 부분 충족 | invalidation, render, 2 rAF phase timing 추가 |
+| 정확성 고정 | native 3 tests와 browser structural/pixel gate | 충족 | 기존 non-ignored gate 계속 실행 |
+| 전후 동일 프로토콜 | 아직 구현 전 기준선 없음 | 미충족 | Stage 2/3 JSON schema를 이후에도 고정 |
+| 실행 환경·fixture 식별 | browser summary는 일부, native JSON은 없음 | 부분 충족 | Stage 2 산출물에 commit/tool/fixture metadata 추가 |
+
+## 4. 원인 가설의 현재 강도
+
+이번 재실증에서도 flow boundary operation의 약 94~95%가 full pagination flush였다. 따라서
+115쪽 전역 pagination이 실제 boundary 지연의 지배 항이라는 가설은 강하다. 반면 stable
+operation 약 38ms에는 cursor/page-tree와 browser handler 비용이 섞여 있어 mutation/reflow
+자체 비용으로 해석할 수 없다.
+
+즉 production 최적화를 시작할 근거는 아직 부족하다. 우선 native에서 같은 fresh-document
+case를 반복해 mutation, pre-flush query, flush, post-flush query의 분포를 고정하고, 그 다음
+Studio에서 end-to-display 누락 구간만 계측하는 순서가 적절하다.
+
+## 5. Stage 2 진입 결정
+
+다음 단계는 `tests/issue_2193_input_pagination_perf.rs` ignored diagnostic을 추가하는 것이다.
+
+- HWP/HWPX와 stable/boundary를 분리한다.
+- cold/warm case를 명시하고 기본 10회 측정한다.
+- raw samples와 p50/p95/max를 `output/poc/task2193/stage2/`에 기록한다.
+- timing assertion은 두지 않고 구조 정확성 assertion만 둔다.
+- 기존 `issue_2214_page_local_repaint`를 함께 실행한다.
+- Stage 2 결과를 확인하기 전 production paginator나 공개 WASM API는 변경하지 않는다.

--- a/mydocs/working/task_m100_2193_stage2.md
+++ b/mydocs/working/task_m100_2193_stage2.md
@@ -1,0 +1,109 @@
+# Task M100 #2193 Stage 2 작업보고서 — 반복 Native 입력·pagination 기준선
+
+## 0. 판정 요약
+
+- **Stage 판정**: 완료
+- **production 변경**: 없음
+- **신규 자산**: `tests/issue_2193_input_pagination_perf.rs` ignored diagnostic
+- **측정 범위**: HWP/HWPX × cold/warm × stable/boundary 8 case
+- **최종 반복**: case별 warm-up 1회 + 측정 20회
+- **정확성**: 115쪽, target tree/cursor exact, flow signal, line starts와 후속 문단 vpos 모두 통과
+- **핵심 결과**: mutation p50 약 0.08~0.13ms, full pagination p50 약 1.15~1.23초
+- **다음 단계**: Studio input-to-display에서 flush 외 render/표시 비용을 분리
+
+## 1. 하네스 계약
+
+각 sample은 fresh document에서 시작하고 Studio의 sequential single-key 경로를 재현한다.
+
+1. target 입력 직전까지 1글자씩 준비
+2. warm case만 page-tree와 path-near cursor를 조회
+3. target 1글자 mutation 시간 측정
+4. pre-flush page-tree와 path-near cursor 시간 측정
+5. explicit `flush_deferred_pagination()` 시간 측정
+6. post-flush page-tree와 cursor 시간 측정
+7. 구조 정확성을 확인하고 raw sample과 nearest-rank p50/p95/max 저장
+
+stable case는 28번째 입력이며 `cellFlowChanged=false`를, boundary case는 44번째 입력이며
+`cellFlowChanged=true`를 요구한다. timing assertion은 두지 않는다.
+
+기본 실행은 전체 case이며 다음 환경변수로 반복 측정과 오염 case 재검증을 지원한다.
+
+| 환경변수 | 기본값 | 역할 |
+|----------|--------|------|
+| `RHWP_2193_WARMUPS` | 1 | case별 비기록 warm-up 횟수 |
+| `RHWP_2193_REPEATS` | 10 | case별 기록 반복 횟수 |
+| `RHWP_2193_FORMAT` | 전체 | `hwp` 또는 `hwpx` 선택 |
+| `RHWP_2193_CASE` | 전체 | case 이름 선택 |
+| `RHWP_2193_OUTPUT_NAME` | `native-baseline` | ignored JSON 파일명 stem |
+
+## 2. 검증과 산출물
+
+```text
+cargo fmt --check
+cargo test --profile release-test --test issue_2193_input_pagination_perf --no-run
+RHWP_2193_WARMUPS=1 RHWP_2193_REPEATS=1 cargo test \
+  --profile release-test --test issue_2193_input_pagination_perf -- --ignored --nocapture
+RHWP_2193_WARMUPS=1 RHWP_2193_REPEATS=10 cargo test \
+  --profile release-test --test issue_2193_input_pagination_perf -- --ignored --nocapture
+RHWP_2193_WARMUPS=1 RHWP_2193_REPEATS=20 cargo test \
+  --profile release-test --test issue_2193_input_pagination_perf -- --ignored --nocapture
+```
+
+모든 실행이 통과했다. 10회 p95가 nearest-rank 계산상 단일 최댓값이 되는 한계를 확인해 계획의
+재측정 조건에 따라 최종 기준선을 20회로 늘렸다.
+
+- 전체 run: `output/poc/task2193/stage2/native-baseline.json`
+- 환경 교란 확인 run:
+  `output/poc/task2193/stage2/native-baseline-hwpx-cold-stable-rerun.json`
+
+두 파일은 raw sample, 환경, fixture 크기·SHA-256과 percentile 방식을 포함하는 ignored local
+evidence다.
+
+## 3. 20회 기준선
+
+| 형식 | case | mutation p50/p95 | pre-tree p50 | pre-cursor p50 | flush p50/p95 |
+|------|------|-----------------:|-------------:|---------------:|--------------:|
+| HWP | cold stable | 0.076 / 0.086ms | 32.7ms | 19.7ms | 1,154.6 / 1,229.3ms |
+| HWP | warm stable | 0.122 / 0.152ms | 33.9ms | 20.9ms | 1,196.0 / 1,362.1ms |
+| HWP | cold boundary | 0.086 / 0.119ms | 33.6ms | 20.9ms | 1,201.2 / 1,301.7ms |
+| HWP | warm boundary | 0.126 / 0.148ms | 32.2ms | 20.2ms | 1,191.7 / 1,272.1ms |
+| HWPX | cold stable 재측정 | 0.078 / 0.108ms | 32.4ms | 20.0ms | 1,154.8 / 1,186.8ms |
+| HWPX | warm stable | 0.118 / 0.137ms | 33.3ms | 20.6ms | 1,230.2 / 1,325.2ms |
+| HWPX | cold boundary | 0.086 / 0.094ms | 33.0ms | 20.3ms | 1,217.3 / 1,382.9ms |
+| HWPX | warm boundary | 0.126 / 0.137ms | 32.8ms | 20.3ms | 1,194.1 / 1,262.1ms |
+
+HWPX cold stable은 전체 run 도중 mutation, tree/cursor, load와 flush가 모두 약 2배 이상 느려진
+일시적 구간을 보였다. 바로 뒤 case가 정상 범위로 복귀했고 선택 20회 재측정도 위 표의 정상
+분포를 재현했다. 따라서 전체 run의 해당 원본 값은 삭제하지 않고 환경 교란 근거로 보존하되,
+case 비교에는 선택 재측정 값을 사용한다.
+
+## 4. 해석
+
+### 4.1 실제 지배 구간
+
+정상 run의 full pagination p50은 target mutation p50보다 약 9천~1만5천 배 크다. pre-flush
+page-tree와 cursor를 합쳐도 p50 약 52~55ms로 full pagination의 약 4~5%다. post-flush
+tree/cursor도 같은 수준이었다.
+
+stable과 첫 flow boundary의 mutation 자체에는 의미 있는 비용 차이가 없다. 실제 Studio에서
+boundary만 약 0.9초가 되는 이유는 boundary mutation이 비싸서가 아니라 정확한 cursor를 위해
+동기 full pagination을 실행하기 때문이다.
+
+### 4.2 이 단계에서 확정하지 않는 것
+
+- native release-test의 1.15~1.23초와 browser WASM의 약 0.89~0.91초는 build/runtime가
+  다르므로 절대값을 직접 비교하지 않는다.
+- cold/warm 차이는 full pagination을 제거할 정도의 효과가 없지만 cache 내부 하위 비용의
+  원인까지 확정하지 않는다.
+- 아직 page invalidation, Canvas render와 2 rAF 표시 완료가 phase timing으로 분리되지 않아
+  end-to-display 최종 예산은 확정하지 않는다.
+
+## 5. Stage 3 진입 결정
+
+production paginator 변경 전 마지막 계측 단계로 Studio trace를 보강한다.
+
+- 기존 #2214 ordering/count/Canvas 안정성 assertion을 유지한다.
+- mutation 종료, flush 종료, invalidation, render와 2 rAF 표시 완료를 같은 operation id로 묶는다.
+- HWP/HWPX stable/boundary를 반복하고 raw sample과 p50/p95를 기록한다.
+- browser 계측에서도 full pagination이 지배 항인지 확인한 뒤에만 bounded/partial pagination
+  실행 이슈를 제안한다.

--- a/mydocs/working/task_m100_2193_stage2.md
+++ b/mydocs/working/task_m100_2193_stage2.md
@@ -7,6 +7,7 @@
 - **신규 자산**: `tests/issue_2193_input_pagination_perf.rs` ignored diagnostic
 - **측정 범위**: HWP/HWPX × cold/warm × stable/boundary 8 case
 - **최종 반복**: case별 warm-up 1회 + 측정 20회
+- **최신 재실증**: `upstream/devel@62bcae43`, #2412 typeset 변경 포함
 - **정확성**: 115쪽, target tree/cursor exact, flow signal, line starts와 후속 문단 vpos 모두 통과
 - **핵심 결과**: mutation p50 약 0.08~0.13ms, full pagination p50 약 1.15~1.23초
 - **다음 단계**: Studio input-to-display에서 flush 외 render/표시 비용을 분리
@@ -59,29 +60,29 @@ RHWP_2193_WARMUPS=1 RHWP_2193_REPEATS=20 cargo test \
 두 파일은 raw sample, 환경, fixture 크기·SHA-256과 percentile 방식을 포함하는 ignored local
 evidence다.
 
-## 3. 20회 기준선
+## 3. 최신 devel 20회 기준선
 
 | 형식 | case | mutation p50/p95 | pre-tree p50 | pre-cursor p50 | flush p50/p95 |
 |------|------|-----------------:|-------------:|---------------:|--------------:|
-| HWP | cold stable | 0.076 / 0.086ms | 32.7ms | 19.7ms | 1,154.6 / 1,229.3ms |
-| HWP | warm stable | 0.122 / 0.152ms | 33.9ms | 20.9ms | 1,196.0 / 1,362.1ms |
-| HWP | cold boundary | 0.086 / 0.119ms | 33.6ms | 20.9ms | 1,201.2 / 1,301.7ms |
-| HWP | warm boundary | 0.126 / 0.148ms | 32.2ms | 20.2ms | 1,191.7 / 1,272.1ms |
-| HWPX | cold stable 재측정 | 0.078 / 0.108ms | 32.4ms | 20.0ms | 1,154.8 / 1,186.8ms |
-| HWPX | warm stable | 0.118 / 0.137ms | 33.3ms | 20.6ms | 1,230.2 / 1,325.2ms |
-| HWPX | cold boundary | 0.086 / 0.094ms | 33.0ms | 20.3ms | 1,217.3 / 1,382.9ms |
-| HWPX | warm boundary | 0.126 / 0.137ms | 32.8ms | 20.3ms | 1,194.1 / 1,262.1ms |
+| HWP | cold stable | 0.077 / 0.083ms | 32.9ms | 20.1ms | 1,146.8 / 1,197.1ms |
+| HWP | warm stable | 0.117 / 0.131ms | 32.3ms | 19.9ms | 1,140.4 / 1,193.1ms |
+| HWP | cold boundary | 0.084 / 0.088ms | 32.5ms | 19.8ms | 1,137.9 / 1,175.4ms |
+| HWP | warm boundary | 0.125 / 0.182ms | 32.5ms | 19.7ms | 1,142.5 / 1,154.1ms |
+| HWPX | cold stable | 0.076 / 0.086ms | 32.4ms | 19.9ms | 1,137.8 / 1,190.7ms |
+| HWPX | warm stable | 0.114 / 0.123ms | 32.2ms | 19.9ms | 1,144.1 / 1,173.0ms |
+| HWPX | cold boundary | 0.085 / 0.088ms | 32.7ms | 20.1ms | 1,143.2 / 1,154.1ms |
+| HWPX | warm boundary | 0.124 / 0.140ms | 32.3ms | 19.9ms | 1,139.1 / 1,151.5ms |
 
-HWPX cold stable은 전체 run 도중 mutation, tree/cursor, load와 flush가 모두 약 2배 이상 느려진
-일시적 구간을 보였다. 바로 뒤 case가 정상 범위로 복귀했고 선택 20회 재측정도 위 표의 정상
-분포를 재현했다. 따라서 전체 run의 해당 원본 값은 삭제하지 않고 환경 교란 근거로 보존하되,
-case 비교에는 선택 재측정 값을 사용한다.
+최초 기준 commit의 HWPX cold stable에서 일시적 환경 교란이 한 번 있었지만 선택 재측정과
+최신 devel 전체 20회 재실증에서는 재현되지 않았다. 최신 run은 HWP/HWPX 여덟 case가 모두
+비슷한 분포로 수렴했으며 #2412 typeset 변경도 이 fixture의 정확성이나 지배 구간을 바꾸지
+않았다. 최초 원본과 선택 재측정 JSON은 환경 민감도 근거로 계속 보존한다.
 
 ## 4. 해석
 
 ### 4.1 실제 지배 구간
 
-정상 run의 full pagination p50은 target mutation p50보다 약 9천~1만5천 배 크다. pre-flush
+최신 run의 full pagination p50은 target mutation p50보다 약 9천~1만5천 배 크다. pre-flush
 page-tree와 cursor를 합쳐도 p50 약 52~55ms로 full pagination의 약 4~5%다. post-flush
 tree/cursor도 같은 수준이었다.
 

--- a/mydocs/working/task_m100_2193_stage3.md
+++ b/mydocs/working/task_m100_2193_stage3.md
@@ -1,0 +1,103 @@
+# Task M100 #2193 Stage 3 작업보고서 — Studio input-to-display 프로파일
+
+## 0. 판정 요약
+
+- **Stage 판정**: 완료
+- **기준**: `upstream/devel@62bcae43`
+- **production 변경**: 없음
+- **신규 실행 진입점**: `npm run e2e:issue-2193`
+- **측정 범위**: HWP/HWPX × stable 28번째 입력 / 첫 flow boundary 44번째 입력
+- **기본 기준선**: case별 fresh document 10회
+- **선택 재측정**: HWP stable, HWPX boundary 각 20회
+- **정확성**: 115쪽, model/tree/layout/cursor/caret exact와 flush ordering 전부 통과
+- **핵심 결과**: boundary input-to-2-rAF 약 1.0~1.1초 중 full pagination이 약 0.9~1.0초
+- **다음 단계**: bounded/partial pagination 실행 범위와 안전 조건을 Stage 4에서 결정
+
+## 1. 계측 방식
+
+기존 #2214 E2E의 실제 앱 로드, target 이동, trace wrapper와 구조 assertion을 재사용했다.
+`--profile-2193` 모드는 준비 입력을 마친 뒤 target 한 입력만 trace하므로 각 phase가 하나의
+operation에 속한다.
+
+1. fresh HWP/HWPX를 `open-document-bytes`로 로드
+2. stable은 27자, boundary는 43자를 1글자씩 준비하고 2 rAF 대기
+3. trace 설치 후 target 1글자 입력 시작 clock 기록
+4. mutation, effect, full flush, exact cursor, invalidation/document-changed와 render 기록
+5. 동기 handler 반환과 2 rAF 표시 완료 clock 기록
+6. model, layer tree, page text layout, cursor와 DOM caret exact 검증
+7. raw event와 nearest-rank p50/p95/max를 ignored JSON에 저장
+
+stable은 page-local invalidation 1회, filtered page render 1회, full flush 0회를 요구한다.
+boundary는 mutation → full flush → exact cursor 순서, document-changed 1회, full page render 2회와
+flush 1회를 요구한다.
+
+## 2. 실행 환경과 산출물
+
+| 항목 | 값 |
+|------|----|
+| 기준 commit | `62bcae435370b58373248c284c126c9572098522` + #2193 계측 커밋 |
+| Chrome | 150.0.7871.128, headless |
+| viewport | 1280×900, DPR 1 |
+| Vite | 8.1.4, `127.0.0.1:7714` |
+| WASM | 해당 commit에서 `wasm-pack build --target web` 재빌드 |
+| percentile | nearest-rank `ceil(count × quantile) - 1` |
+
+- 기본 10회: `output/poc/task2193/stage3/studio-profile.json`
+- HWP stable 20회:
+  `output/poc/task2193/stage3/hwp-stable-rerun/studio-profile.json`
+- HWPX boundary 20회:
+  `output/poc/task2193/stage3/hwpx-boundary-rerun/studio-profile.json`
+
+JSON은 환경, fixture SHA-256, raw clocks/events, phase summary와 정확성 snapshot을 포함하는
+ignored local evidence다.
+
+## 3. 결과
+
+표의 값은 p50 / p95다. HWP stable과 HWPX boundary는 선택 20회, 나머지는 기본 10회 결과다.
+
+| 형식 / case | operation | mutation | full flush | cursor | page render 합 | input→2 rAF |
+|-------------|----------:|---------:|-----------:|-------:|---------------:|-------------:|
+| HWP stable | 38.6 / 39.1ms | 0.2 / 0.2ms | 0 / 0ms | 38.0 / 38.5ms | 16.4 / 16.9ms | 73.4 / 75.0ms |
+| HWP boundary | 969.6 / 976.9ms | 0.2 / 0.3ms | 915.4 / 923.0ms | 36.7 / 37.4ms | 53.1 / 54.6ms | 1,013.8 / 1,022.0ms |
+| HWPX stable | 37.6 / 38.2ms | 0.2 / 0.4ms | 0 / 0ms | 37.1 / 37.7ms | 16.1 / 16.7ms | 66.0 / 67.0ms |
+| HWPX boundary | 1,009.0 / 1,023.9ms | 0.2 / 0.3ms | 954.0 / 968.5ms | 37.9 / 38.3ms | 54.3 / 54.9ms | 1,054.9 / 1,071.1ms |
+
+HWP stable 2 rAF는 약 66ms와 74~76ms 두 군으로 관찰됐다. operation/render 시간은 일정하므로
+성능 outlier가 아니라 60Hz frame 경계에 따른 한 frame 차이다. HWPX boundary 20회에서는
+flush와 input-to-display가 함께 움직였고 p95가 단일 최댓값에 지배되지 않았다.
+
+## 4. 지배 구간 판정
+
+### 4.1 stable 입력
+
+mutation은 약 0.2ms지만 exact cursor query가 약 37~38ms, filtered page render가 약 16~17ms다.
+두 작업은 서로 다른 시점에 실행되며 2 rAF frame 대기까지 합쳐 end-to-display는 약 66~75ms다.
+full pagination은 0회이고 pending deferred 상태를 유지한다.
+
+### 4.2 첫 flow boundary
+
+mutation 비용은 stable과 동일하다. full pagination p50은 HWP 915.4ms, HWPX 954.0ms이며
+input-to-display p50의 약 90%를 차지한다. flush 뒤 exact cursor는 약 37~38ms, full page render
+2회의 합은 약 53~54ms다. 따라서 renderer나 mutation 최적화만으로는 약 1초의 boundary latency를
+해결할 수 없다.
+
+### 4.3 호출·표시 계약
+
+- stable: deferred mutation → exact cursor → page-local invalidation → filtered render 1회
+- boundary: deferred mutation → full pagination 1회 → exact cursor → document-changed → full render 2회
+- 두 경로 모두 115쪽, target text length, 4/5 line, cursor offset, overflow false와 DOM caret exact
+- 기존 `npm run e2e:issue-2214 -- --runs=1`도 HWP/HWPX focused와 raw 8건 GREEN
+
+## 5. Stage 4 진입 결정
+
+native와 browser가 모두 full pagination을 확정적인 지배 항으로 가리킨다. 다음 단계에서는
+production 코드를 바로 수정하지 않고 아래 구현 게이트를 정리한다.
+
+1. changed cell의 continuation cut이 영향을 주는 최초·최종 page 범위를 계산할 수 있는가
+2. page 밖의 table continuation, footnote/header/footer와 다음 문단 vpos를 안전하게 보존하는가
+3. bounded pagination 뒤 page count와 downstream page offsets를 증분 갱신할 수 있는가
+4. 불확실한 경우 기존 full pagination으로 안전하게 fallback할 수 있는가
+5. 별도 실행 이슈로 구현·전후 검증 범위를 분리해야 하는가
+
+Stage 4는 위 질문에 코드 근거를 연결하고 실행 이슈 후보를 제안하는 문서 단계다. 사용자 승인
+전 production paginator나 공개 WASM API는 변경하지 않는다.

--- a/mydocs/working/task_m100_2193_stage4.md
+++ b/mydocs/working/task_m100_2193_stage4.md
@@ -1,0 +1,167 @@
+# Task M100 #2193 Stage 4 작업보고서 — pagination 구현 방향 게이트
+
+## 0. 판정 요약
+
+- **Stage 판정**: 완료 — 구현 전용 이슈로 분리할 수 있음
+- **기준**: `upstream/devel@62bcae43`
+- **production 변경**: 없음
+- **기각**: 현재 쪽만 갱신한 뒤 downstream page를 그대로 재사용하는 단순 bounded pagination
+- **채택 후보**: 거대 표 continuation을 재개 가능한 상태로 만들고 영향 범위를 순차 재조판하며,
+  필요하면 UI thread에 양보하는 chunked 실행 경로
+- **안전 원칙**: fragment fingerprint가 완전히 일치하지 않거나 의존성을 증명할 수 없으면 기존
+  full pagination으로 fallback
+- **다음 게이트**: 아래 실행 이슈 초안을 사용자 승인 후 GitHub에 생성하고 구현 범위를 별도 계획
+
+## 1. 코드 경로 판정
+
+| 관찰 | 코드 근거 | 의미 |
+|------|-----------|------|
+| deferred flush는 항상 전체 paginate | `src/wasm_api.rs`의 `flush_deferred_pagination` | page tree를 무효화한 뒤 `self.paginate()`를 동기 호출한다. |
+| dirty section도 조판은 처음부터 시작 | `src/document_core/queries/rendering.rs`의 `paginate_pass`, `src/renderer/typeset.rs`의 `typeset_section_with_variant` | 선택 측정 캐시는 재사용하지만 새 `TypesetState`로 모든 문단을 0번부터 순회한다. |
+| 표 continuation 상태는 loop 지역값 | `src/renderer/typeset.rs`의 `typeset_table_paragraph` | `cursor_row`, `start_cut`, `is_continuation`을 fragment마다 전진시키지만 외부에서 재개할 수 없다. |
+| `TableBreakToken`은 선언만 존재 | `src/renderer/typeset.rs`의 `TableBreakToken` | `start_row`와 cell offset 형태의 의도는 있으나 현재 조판 경로에서 생성·소비되지 않는다. |
+| 수렴 감지는 full typeset 이후 진단 | `src/document_core/queries/rendering.rs`의 `offset != 0` 분기 | 문단 삽입·삭제에만 실행되고, cell edit의 `offset == 0`에는 적용되지 않으며 계산을 줄이지 않는다. |
+| 현재 `PartialTable` match는 cut을 무시 | `src/renderer/pagination.rs`의 `matches_with_offset` | row 범위만 같아도 match하므로 page 재사용의 안전 판정으로 사용할 수 없다. |
+
+`paginate_pass`는 시작 시 render-normalized 파생본도 다시 계산한다. 선택 측정은 변경되지 않은
+문단을 재사용할 수 있지만, dirty table 측정과 section 전체 typeset·후처리는 남는다. 따라서 Stage 3의
+boundary full flush p50 915.4ms(HWP), 954.0ms(HWPX)는 단순 mutation 비용이 아니라 이 동기 경로의
+비용이다.
+
+## 2. 단순 page 수렴 재사용을 기각한 이유
+
+#2214 영구 회귀는 target 표가 115개 `PartialTable` fragment로 모든 쪽에 걸친다는 사실과 fragment
+연속성을 고정한다. 44번째 입력 뒤 flush 전후를 비교하면 다음과 같다.
+
+- page 0의 `end_cut=[37]`, cursor와 cell bounds는 동일하다.
+- page 1도 기존 fragment와 동일하다.
+- page 2부터 page 114까지 113개 continuation cut이 실제로 바뀐다.
+- page count는 양쪽 모두 115지만 각 fragment의 `start_cut == 이전 end_cut` 연속성은 flush 결과로
+  다시 맞춰야 한다.
+
+따라서 visible page가 정확하다는 이유로 pagination을 완료 처리하거나 page 2 이후를 그대로 복사하면
+문서 모델과 downstream fragment가 불일치한다. 일반 문서에서 수렴 최적화가 유효할 수는 있지만,
+이 fixture에는 첫 unchanged page 탐색만으로 줄일 수 있는 affected range가 사실상 없다.
+
+또한 현재 `matches_with_offset`은 `PartialTable`의 `is_continuation`, `start_cut`, `end_cut`,
+`is_block_split`을 비교하지 않는다. 이 match를 그대로 조기 종료 조건으로 승격하는 것은 correctness
+gate가 될 수 없다.
+
+## 3. 대안 비교
+
+| 대안 | 기대 효과 | 위험·한계 | 판정 |
+|------|-----------|-----------|------|
+| unchanged page 이후 기존 결과 복사 | 일반적인 국소 편집은 빠를 수 있음 | 이번 fixture의 113쪽 cut 변경을 놓치며 현 fingerprint도 불충분 | 단독 해법 기각 |
+| affected fragment부터 continuation 재개 | section 앞부분의 정규화·조판 반복을 제거하고 affected page당 필요한 표 split만 계산 | footnote, header/footer, master, page numbering과 후속 flow 상태 보존이 필요 | 1차 구현 후보 |
+| visible page 우선 + 단일 idle full flush | 첫 화면 반응은 빨라짐 | 약 0.9초 작업을 미룰 뿐 main thread freeze는 남음 | 단독 해법 기각 |
+| continuation 재개 + chunk/yield | 즉시 visible state를 유지하면서 긴 propagation을 frame 사이에 분산 | pending 상태·취소·revision 일관성 계약이 필요 | 2차 구현 후보 |
+| worker에서 full pagination | main thread 정지를 제거 | WASM document ownership과 대규모 상태 전달 재설계 필요 | 장기 대안 |
+
+우선 구현은 **동일 section의 단일 table continuation edit**로 좁혀 재개 가능한 split 상태를 만들고,
+동기 전체 완료가 충분히 짧아지는지 측정한다. affected range 자체가 긴 fixture이므로 목표를 달성하지
+못하면 같은 상태 기계를 chunk scheduler에 연결한다. 두 단계 모두 불확실한 구조에서는 기존 full
+pagination을 유지한다.
+
+## 4. 안전한 구현 경계
+
+### 4.1 dirty descriptor
+
+deferred cell mutation이 최소한 다음 정보를 보존해야 한다.
+
+- section, host paragraph, table control, cell과 cell paragraph 식별자
+- 기존 fragment 중 target cell을 포함하는 최초 affected page/column과 table continuation 위치
+- 편집 revision 및 기존 pagination revision
+- row/column/span, section/page/column layout의 구조 변화 여부
+
+이는 pagination 완료 플래그가 아니라 `TableContinuationDirty`와 같은 영향 범위 기술자다.
+
+### 4.2 재개 상태
+
+현재 `typeset_table_paragraph` loop의 `cursor_row`, `start_cut`, `start_cut_is_block`,
+`is_continuation`과 `TypesetState`의 page/column flow 의존값을 명시적인 resume state로 만든다.
+미사용 `TableBreakToken`을 그대로 노출하기보다 실제 fragment cut 표현(`Vec<usize>`)과 column/page
+state를 포함하는 새 내부 타입으로 검증해야 한다.
+
+재계산한 fragment는 아래 전체 fingerprint를 이전 결과와 비교한다.
+
+- para/control, start/end row
+- `is_continuation`, `start_cut`, `end_cut`, `is_block_split`
+- column geometry와 used height
+- page number, active header/footer/master, footnote/endnote 및 후속 flow에 영향을 주는 상태
+
+이 fingerprint와 다음 resume state가 모두 같을 때만 downstream convergence를 인정한다.
+
+### 4.3 보수적 fallback
+
+초기 fast path는 아래 조건에서만 허용하고 하나라도 증명되지 않으면 full pagination한다.
+
+- text-only cell edit이며 row/column/span/control 구조가 변하지 않음
+- section/page/column definition이 변하지 않음
+- target continuation chain에 각주·미주나 pagination 종속 floating object가 없음
+- header/footer/master/new-page-number/page-hide 경계가 영향 범위에 없음
+- fragment 연속성, page count와 global page offset을 완전히 검증할 수 있음
+- 새 edit가 진행 중 작업의 revision과 충돌하지 않음
+
+chunk 실행을 추가한다면 중간 상태를 “pagination complete”로 공개하지 않는다. exact cursor/page-tree
+query는 현재 visible fragment와 pending revision을 구분해야 하며, 저장·인쇄·전체 페이지 질의는 작업을
+완료시키거나 기존 full fallback을 사용해야 한다.
+
+## 5. 전용 실행 이슈 초안
+
+### 제목
+
+`perf: 거대 셀 table continuation pagination을 resumable/chunked 경로로 분리`
+
+### 본문
+
+#### 배경
+
+#2193 계측에서 115쪽 거대 셀 문서의 첫 flow boundary 입력은 mutation p50 약 0.2ms에 비해
+동기 full pagination p50이 HWP 915.4ms, HWPX 954.0ms였고 input-to-2-rAF는 약 1.0~1.1초였다.
+native full flush도 약 1.14초다. #2214 correctness pin에 따르면 page 0 cursor는 flush 전에도 exact지만
+page 2~114의 113개 continuation cut은 flush 후 실제로 재정렬된다.
+
+#### 목표
+
+1. dirty table fragment부터 continuation split을 재개해 section 처음부터의 조판을 피한다.
+2. affected chain이 길 때 작업을 안전하게 chunk하고 UI thread에 양보할 수 있는 상태 계약을 만든다.
+3. unsupported 문서 구조는 기존 full pagination으로 fallback한다.
+4. 기존 #2214 정확성 핀과 #2193 native/browser profile로 전후 효과를 검증한다.
+
+#### 작업 단계
+
+1. render normalization, selective table measurement, table continuation loop와 pagination 후처리에 내부
+   subphase timer를 추가해 full flush 비용을 분해한다.
+2. deferred cell edit에서 section/host/table/cell/revision과 최초 affected fragment를 담는 dirty
+   descriptor를 만든다.
+3. table split cursor와 필요한 page/column flow state를 resume token으로 만들고 affected fragment부터
+   재계산한다.
+4. 완전한 `PartialTable` fingerprint와 downstream 상태가 일치할 때만 수렴·재사용한다.
+5. 동기 목표를 충족하지 못하면 같은 resume state를 frame/idle chunk scheduler에 연결하고 취소·revision
+   교체 규칙을 추가한다.
+6. 각 단계에서 unsupported dependency와 검증 실패는 full pagination으로 fallback한다.
+
+#### 완료 조건
+
+- HWP/HWPX 115쪽 fixture에서 44번째 입력 후 page 0~114 fragment 연속성, 115쪽, model/tree/layout,
+  exact cursor/caret가 full pagination oracle과 동일하다.
+- `PartialTable` fingerprint는 cut, continuation과 block split 상태를 포함한다.
+- 저장·인쇄·전체 페이지 질의가 pending pagination을 완료하거나 안전하게 fallback한다.
+- stable 입력의 flush 0회 계약과 기존 #2214 native/browser 회귀가 유지된다.
+- 같은 #2193 profile로 before/after raw JSON과 p50/p95를 기록한다.
+- 목표 latency는 subphase 계측 후 별도 수치 gate로 확정하며, 단순히 full flush를 idle로 미룬 결과를
+  완료로 간주하지 않는다.
+
+#### 관계
+
+- parent tracking: #2193
+- correctness prerequisite/regression oracle: #2214 / PR #2241
+- selection rect #2215 / PR #2401, revision cache #2308, table border click #2400과는 별도 범위
+
+## 6. 다음 작업
+
+1. 사용자 승인 후 위 초안으로 전용 GitHub 실행 이슈를 생성하고 #2193에 연결한다.
+2. 현재 계측 브랜치를 push하고 계측·Stage 4 기록 PR을 생성한다.
+3. 실행 이슈에서 먼저 subphase 계측을 구현한 뒤 resume state의 최소 범위를 다시 승인받는다.
+
+이번 Stage에서는 production paginator, 공개 WASM API, GitHub issue/comment를 변경하지 않았다.

--- a/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
+++ b/rhwp-studio/e2e/issue-2214-page-local-repaint.test.mjs
@@ -12,6 +12,8 @@
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --diagnose
  *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --diagnose \
  *     --formats=hwp --runs=1
+ *   node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --profile-2193 \
+ *     --runs=10
  */
 
 import assert from 'node:assert/strict';
@@ -33,6 +35,8 @@ const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const REPO_ROOT = path.resolve(__dirname, '../..');
 const OUTPUT_ROOT = process.env.ISSUE2214_OUTPUT_ROOT
   ?? path.join(REPO_ROOT, 'output/poc/task2214/stage4');
+const PROFILE_2193_OUTPUT_ROOT = process.env.ISSUE2193_OUTPUT_ROOT
+  ?? path.join(REPO_ROOT, 'output/poc/task2193/stage3');
 const TARGET = Object.freeze({
   sectionIndex: 0,
   paragraphIndex: 5,
@@ -1397,6 +1401,279 @@ async function runRawBoundarySmoke(page, format, bytes, kind) {
   };
 }
 
+function absoluteEventTiming(trace, event) {
+  const endAt = trace.startedAt + event.atMs;
+  const durationMs = event.durationMs ?? 0;
+  return { startAt: endAt - durationMs, endAt, durationMs };
+}
+
+function issue2193ProfileSample(format, caseConfig, runNumber, trace, clocks, state) {
+  const prefix = `${format} ${caseConfig.name} run ${runNumber}`;
+  const eventsOf = (type) => trace.events.filter((event) => event.type === type);
+  const oneEvent = (type) => {
+    const events = eventsOf(type);
+    assert.equal(events.length, 1, `${prefix}: ${type} count`);
+    return events[0];
+  };
+  const operation = oneEvent('InputHandler.executeOperation');
+  const mutation = oneEvent('wasm.insertTextInCellDeferredPagination');
+  const effect = oneEvent('InputHandler.prepareTextMutationBeforeCursor');
+  const cursor = oneEvent('wasm.getCursorRectByPathNear');
+  const flushes = eventsOf('wasm.flushDeferredPagination');
+  const invalidations = eventsOf('event.document-page-invalidated');
+  const documentChanges = eventsOf('event.document-changed');
+  const refreshes = eventsOf('CanvasView.refreshInvalidatedPageNow');
+  const pageRenders = eventsOf('PageRenderer.renderPage');
+  const filteredRenders = eventsOf('wasm.renderPageToCanvasFiltered');
+
+  assert.equal(mutation.cellFlowChanged, caseConfig.boundary, `${prefix}: flow signal`);
+  assert.equal(effect.cellFlowChanged, caseConfig.boundary, `${prefix}: consumed flow signal`);
+  assert.equal(flushes.length, caseConfig.boundary ? 1 : 0, `${prefix}: full pagination count`);
+  assert.ok(pageRenders.length >= 1, `${prefix}: page render count`);
+
+  const operationTiming = absoluteEventTiming(trace, operation);
+  const mutationTiming = absoluteEventTiming(trace, mutation);
+  const cursorTiming = absoluteEventTiming(trace, cursor);
+  const flushTiming = flushes.length ? absoluteEventTiming(trace, flushes[0]) : null;
+  const pageRenderTimings = pageRenders.map((event) => absoluteEventTiming(trace, event));
+  const filteredRenderTimings = filteredRenders.map((event) => absoluteEventTiming(trace, event));
+  const refreshTimings = refreshes.map((event) => absoluteEventTiming(trace, event));
+  const firstRenderAt = Math.min(...pageRenderTimings.map((timing) => timing.startAt));
+  const lastRenderAt = Math.max(...pageRenderTimings.map((timing) => timing.endAt));
+
+  assert.ok(operationTiming.startAt >= clocks.inputStartedAt, `${prefix}: operation start clock`);
+  assert.ok(mutationTiming.endAt <= cursorTiming.startAt, `${prefix}: mutation before cursor`);
+  if (flushTiming) {
+    assert.ok(mutationTiming.endAt <= flushTiming.startAt, `${prefix}: mutation before flush`);
+    assert.ok(flushTiming.endAt <= cursorTiming.startAt, `${prefix}: flush before cursor`);
+  }
+  assert.ok(clocks.syncCompletedAt <= clocks.displayCompletedAt, `${prefix}: sync before display`);
+  assert.ok(lastRenderAt <= clocks.displayCompletedAt, `${prefix}: render before 2 rAF completion`);
+
+  const eventAtFromInput = (event) => (
+    event ? trace.startedAt + event.atMs - clocks.inputStartedAt : null
+  );
+  const sumDuration = (timings) => timings.reduce((total, timing) => total + timing.durationMs, 0);
+  return {
+    run: runNumber,
+    clocks: {
+      inputStartedAt: clocks.inputStartedAt,
+      syncCompletedAt: clocks.syncCompletedAt,
+      displayCompletedAt: clocks.displayCompletedAt,
+    },
+    timing: {
+      inputToSyncMs: clocks.syncCompletedAt - clocks.inputStartedAt,
+      inputToTwoRafMs: clocks.displayCompletedAt - clocks.inputStartedAt,
+      syncToTwoRafMs: clocks.displayCompletedAt - clocks.syncCompletedAt,
+      operationMs: operationTiming.durationMs,
+      mutationMs: mutationTiming.durationMs,
+      mutationEndFromInputMs: mutationTiming.endAt - clocks.inputStartedAt,
+      flushMs: flushTiming?.durationMs ?? 0,
+      flushEndFromInputMs: flushTiming ? flushTiming.endAt - clocks.inputStartedAt : null,
+      cursorMs: cursorTiming.durationMs,
+      cursorEndFromInputMs: cursorTiming.endAt - clocks.inputStartedAt,
+      invalidationFromInputMs: eventAtFromInput(invalidations[0]),
+      documentChangedFromInputMs: eventAtFromInput(documentChanges[0]),
+      firstRenderFromInputMs: firstRenderAt - clocks.inputStartedAt,
+      lastRenderFromInputMs: lastRenderAt - clocks.inputStartedAt,
+      renderSpanMs: lastRenderAt - firstRenderAt,
+      pageRenderTotalMs: sumDuration(pageRenderTimings),
+      filteredRenderTotalMs: sumDuration(filteredRenderTimings),
+      refreshNowTotalMs: sumDuration(refreshTimings),
+    },
+    counts: {
+      invalidation: invalidations.length,
+      documentChanged: documentChanges.length,
+      refreshNow: refreshes.length,
+      pageRender: pageRenders.length,
+      filteredRender: filteredRenders.length,
+      flush: flushes.length,
+    },
+    accuracy: {
+      length: state.model.length,
+      lineCount: state.model.lineCount,
+      pageCount: state.pagination.pageCount,
+      pending: state.pagination.pending,
+      cursorOffset: state.cursor.position.charOffset,
+      cellOverflowed: state.cursor.rect?.cellOverflowed,
+      layerTextLength: state.layerTree.targetText.length,
+      layoutTextLength: state.pageTextLayout.targetText.length,
+    },
+    events: trace.events,
+  };
+}
+
+async function runIssue2193ProfileCase(page, format, bytes, caseConfig, runNumber) {
+  await restoreTrace(page);
+  const load = await openDocumentThroughApp(page, format, bytes);
+  await moveToTarget(page);
+  const initial = await readFocusedSnapshot(page);
+  const initialText = initial.model.text;
+  assert.equal(initialText.length, TARGET.charOffset, `${format} ${caseConfig.name}: initial text`);
+
+  await typeKeyboardOnes(page, caseConfig.targetInput - 1);
+  await waitTwoRafs(page);
+  await installTrace(page);
+
+  const inputStartedAt = await page.evaluate(() => performance.now());
+  await page.keyboard.type('1');
+  const syncCompletedAt = await page.evaluate(() => performance.now());
+  await waitTwoRafs(page);
+  const displayCompletedAt = await page.evaluate(() => performance.now());
+  const state = await collectState(
+    page,
+    `${caseConfig.name}-run-${runNumber}-after-2raf`,
+    inputStartedAt,
+  );
+  const expectedText = `${initialText}${'1'.repeat(caseConfig.targetInput)}`;
+  assertExactFocusedState(
+    format,
+    `${caseConfig.name}-${runNumber}`,
+    state,
+    expectedText,
+    caseConfig.boundary ? 5 : 4,
+    945.9,
+    !caseConfig.boundary,
+  );
+  const trace = await collectTrace(page);
+  const sample = issue2193ProfileSample(
+    format,
+    caseConfig,
+    runNumber,
+    trace,
+    { inputStartedAt, syncCompletedAt, displayCompletedAt },
+    state,
+  );
+  return { load, sample };
+}
+
+function summarizeIssue2193Profile(samples) {
+  const metrics = [
+    'inputToSyncMs',
+    'inputToTwoRafMs',
+    'syncToTwoRafMs',
+    'operationMs',
+    'mutationMs',
+    'mutationEndFromInputMs',
+    'flushMs',
+    'cursorMs',
+    'cursorEndFromInputMs',
+    'firstRenderFromInputMs',
+    'lastRenderFromInputMs',
+    'renderSpanMs',
+    'pageRenderTotalMs',
+    'filteredRenderTotalMs',
+    'refreshNowTotalMs',
+  ];
+  return Object.fromEntries(metrics.map((metric) => [
+    metric,
+    summarizeDurations(samples.map((sample) => sample.timing[metric])),
+  ]));
+}
+
+async function runIssue2193ProfileMain() {
+  const formats = cliValue('formats', 'hwp,hwpx')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean);
+  const runs = Number(cliValue('runs', '10'));
+  assert.ok(Number.isInteger(runs) && runs > 0, '--runs must be a positive integer');
+  for (const format of formats) assert.ok(SAMPLES[format], `unsupported format: ${format}`);
+  const selectedCaseNames = new Set(cliValue('cases', 'stable-28,boundary-44')
+    .split(',')
+    .map((value) => value.trim().toLowerCase())
+    .filter(Boolean));
+  const caseConfigs = [
+    { name: 'stable-28', targetInput: 28, boundary: false },
+    { name: 'boundary-44', targetInput: 44, boundary: true },
+  ].filter((caseConfig) => selectedCaseNames.has(caseConfig.name));
+  assert.ok(caseConfigs.length > 0, '--cases must select stable-28 and/or boundary-44');
+  const fixtures = Object.fromEntries(formats.map((format) => {
+    const bytes = readFileSync(SAMPLES[format]);
+    return [format, {
+      path: SAMPLES[format],
+      bytes,
+      size: bytes.length,
+      sha256: sha256(bytes),
+    }];
+  }));
+
+  const browser = await launchBrowser();
+  const browserVersion = await browser.version().catch(() => null);
+  const page = await createPage(browser, 1280, 900);
+  page.on('console', (message) => {
+    if (message.type() === 'error' || message.type() === 'warning') {
+      console.log(`  [browser:${message.type()}] ${message.text()}`);
+    }
+  });
+  page.on('pageerror', (error) => console.log(`  [browser:pageerror] ${error.message}`));
+  const startedAt = new Date().toISOString();
+  const cases = [];
+  try {
+    await loadApp(page);
+    for (const format of formats) {
+      for (const caseConfig of caseConfigs) {
+        console.log(`\n[#2193 ${format}/${caseConfig.name}] ${runs} runs`);
+        const samples = [];
+        const loads = [];
+        for (let runNumber = 1; runNumber <= runs; runNumber += 1) {
+          const result = await runIssue2193ProfileCase(
+            page,
+            format,
+            fixtures[format].bytes,
+            caseConfig,
+            runNumber,
+          );
+          samples.push(result.sample);
+          loads.push(result.load);
+          console.log(
+            `  run ${runNumber}: operation=${result.sample.timing.operationMs.toFixed(2)}ms, `
+              + `flush=${result.sample.timing.flushMs.toFixed(2)}ms, `
+              + `2raf=${result.sample.timing.inputToTwoRafMs.toFixed(2)}ms`,
+          );
+        }
+        cases.push({
+          format,
+          case: caseConfig.name,
+          targetInput: caseConfig.targetInput,
+          boundary: caseConfig.boundary,
+          summary: summarizeIssue2193Profile(samples),
+          loads,
+          samples,
+        });
+      }
+    }
+  } finally {
+    await restoreTrace(page).catch(() => {});
+    await closePage(page).catch(() => {});
+    await closeBrowser(browser).catch(() => {});
+  }
+
+  const summary = {
+    issue: 2193,
+    stage: 3,
+    mode: 'studio-input-to-display-profile',
+    percentileMethod: 'nearest-rank: ceil(count * quantile) - 1',
+    startedAt,
+    finishedAt: new Date().toISOString(),
+    environment: {
+      viteUrl: process.env.VITE_URL ?? 'http://localhost:7700',
+      chromePath: process.env.CHROME_PATH ?? process.env.PUPPETEER_EXECUTABLE_PATH ?? null,
+      browserVersion,
+      viewport: { width: 1280, height: 900, deviceScaleFactor: 1 },
+      runs,
+    },
+    fixtures: Object.fromEntries(Object.entries(fixtures).map(([format, value]) => [format, {
+      path: value.path,
+      size: value.size,
+      sha256: value.sha256,
+    }])),
+    cases,
+  };
+  writeJson(path.join(PROFILE_2193_OUTPUT_ROOT, 'studio-profile.json'), summary);
+  console.log(`\nIssue #2193 Studio profile written to ${PROFILE_2193_OUTPUT_ROOT}`);
+}
+
 async function runFocusedMain() {
   const formats = cliValue('formats', 'hwp,hwpx')
     .split(',')
@@ -1541,7 +1818,11 @@ async function runDiagnosticMain() {
   console.log(JSON.stringify(summary.formats, null, 2));
 }
 
-const selectedMain = process.argv.includes('--diagnose') ? runDiagnosticMain : runFocusedMain;
+const selectedMain = process.argv.includes('--profile-2193')
+  ? runIssue2193ProfileMain
+  : process.argv.includes('--diagnose')
+    ? runDiagnosticMain
+    : runFocusedMain;
 selectedMain().catch((error) => {
   console.error(error);
   process.exitCode = 1;

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -16,6 +16,7 @@
     "e2e:drag-autoscroll": "node e2e/drag-selection-autoscroll.test.mjs",
     "e2e:renderer-contract": "node e2e/renderer-contract.test.mjs",
     "e2e:issue-2214": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless",
+    "e2e:issue-2193": "node e2e/issue-2214-page-local-repaint.test.mjs --mode=headless --profile-2193",
     "e2e:canvaskit-font-coverage": "node e2e/canvaskit-font-coverage.test.mjs",
     "e2e:embed": "node e2e/embed-transport.test.mjs --mode=headless",
     "e2e:baseline:headless": "node e2e/renderer-baseline.mjs --mode=headless --manifest=../scripts/renderer_baseline_manifest.json --output=../output/renderer-baseline/studio-headless",

--- a/tests/issue_2193_input_pagination_perf.rs
+++ b/tests/issue_2193_input_pagination_perf.rs
@@ -1,0 +1,456 @@
+//! Issue #2193 Stage 2 repeated native input/pagination baseline.
+//!
+//! 진단 전용 ignored probe다. fresh HWP/HWPX 문서에서 Studio와 같은 sequential single-key
+//! 입력을 준비한 뒤 stable 입력과 첫 cell-flow boundary 입력의 mutation, tree/cursor query,
+//! explicit full-pagination flush를 같은 순서로 반복 측정한다.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::process::Command;
+use std::time::Instant;
+
+use rhwp::document_core::DocumentCore;
+use rhwp::model::control::Control;
+use rhwp::renderer::render_tree::{RenderNode, RenderNodeType};
+use rhwp::wasm_api::HwpDocument;
+use serde_json::{json, Map, Value};
+
+const HWP_SAMPLE: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwp";
+const HWPX_SAMPLE: &str = "samples/issue1949_giant_cell_nested_tables_perf.hwpx";
+
+const SECTION: usize = 0;
+const PARENT_PARAGRAPH: usize = 0;
+const TABLE_CONTROL: usize = 2;
+const CELL: usize = 2;
+const TARGET_PARAGRAPH: usize = 5;
+const INSERT_OFFSET: usize = 130;
+const CELL_PATH: &str = r#"[{"controlIndex":2,"cellIndex":2,"cellParaIndex":5}]"#;
+
+const DEFAULT_WARMUPS: usize = 1;
+const DEFAULT_REPEATS: usize = 10;
+const MAX_REPEATS: usize = 100;
+
+#[derive(Clone, Copy)]
+struct Case {
+    name: &'static str,
+    target_input: usize,
+    warm_before_target: bool,
+}
+
+const CASES: [Case; 4] = [
+    Case {
+        name: "cold_stable_28",
+        target_input: 28,
+        warm_before_target: false,
+    },
+    Case {
+        name: "warm_stable_28",
+        target_input: 28,
+        warm_before_target: true,
+    },
+    Case {
+        name: "cold_boundary_44",
+        target_input: 44,
+        warm_before_target: false,
+    },
+    Case {
+        name: "warm_boundary_44",
+        target_input: 44,
+        warm_before_target: true,
+    },
+];
+
+fn manifest_path(relative: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(relative)
+}
+
+fn load_sample(relative: &str) -> HwpDocument {
+    let bytes = fs::read(manifest_path(relative))
+        .unwrap_or_else(|error| panic!("read {relative}: {error}"));
+    HwpDocument::from_bytes(&bytes).unwrap_or_else(|error| panic!("parse {relative}: {error}"))
+}
+
+fn target_paragraph(core: &DocumentCore) -> &rhwp::model::paragraph::Paragraph {
+    match &core.document().sections[SECTION].paragraphs[PARENT_PARAGRAPH].controls[TABLE_CONTROL] {
+        Control::Table(table) => &table.cells[CELL].paragraphs[TARGET_PARAGRAPH],
+        other => panic!("target control is not a table: {other:?}"),
+    }
+}
+
+fn target_next_vpos(core: &DocumentCore) -> i32 {
+    match &core.document().sections[SECTION].paragraphs[PARENT_PARAGRAPH].controls[TABLE_CONTROL] {
+        Control::Table(table) => {
+            table.cells[CELL].paragraphs[TARGET_PARAGRAPH + 1]
+                .line_segs
+                .first()
+                .expect("next target paragraph line seg")
+                .vertical_pos
+        }
+        other => panic!("target control is not a table: {other:?}"),
+    }
+}
+
+fn line_starts(doc: &HwpDocument) -> Vec<usize> {
+    target_paragraph(doc)
+        .line_segs
+        .iter()
+        .map(|segment| segment.text_start as usize)
+        .collect()
+}
+
+fn insert_one(doc: &mut HwpDocument, inserted: usize) -> Value {
+    let raw = doc
+        .insert_text_in_cell_native_deferred_pagination(
+            SECTION,
+            PARENT_PARAGRAPH,
+            TABLE_CONTROL,
+            CELL,
+            TARGET_PARAGRAPH,
+            INSERT_OFFSET + inserted,
+            "1",
+        )
+        .expect("sequential deferred insert");
+    serde_json::from_str(&raw).expect("cell edit result json")
+}
+
+fn target_tree_end(node: &RenderNode, end: &mut usize) {
+    if let RenderNodeType::TextRun(run) = &node.node_type {
+        if let (Some(start), Some(context)) = (run.char_start, run.cell_context.as_ref()) {
+            let target = context.parent_para_index == PARENT_PARAGRAPH
+                && context.path.len() == 1
+                && context.path.first().is_some_and(|entry| {
+                    entry.control_index == TABLE_CONTROL
+                        && entry.cell_index == CELL
+                        && entry.cell_para_index == TARGET_PARAGRAPH
+                });
+            if target {
+                *end = (*end).max(start + run.text.encode_utf16().count());
+            }
+        }
+    }
+    for child in &node.children {
+        target_tree_end(child, end);
+    }
+}
+
+fn measure_tree(doc: &HwpDocument, expected_end: usize) -> f64 {
+    let started = Instant::now();
+    let tree = doc
+        .build_page_render_tree(0)
+        .expect("build page zero render tree");
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let mut actual_end = 0;
+    target_tree_end(&tree.root, &mut actual_end);
+    assert_eq!(actual_end, expected_end, "target render tree must be exact");
+    elapsed_ms
+}
+
+fn measure_cursor(doc: &HwpDocument, offset: usize) -> f64 {
+    let started = Instant::now();
+    let raw = doc
+        .get_cursor_rect_by_path_near(
+            SECTION as u32,
+            PARENT_PARAGRAPH as u32,
+            CELL_PATH,
+            offset as u32,
+            0,
+        )
+        .expect("path-near cursor rect");
+    let elapsed_ms = started.elapsed().as_secs_f64() * 1000.0;
+    let value: Value = serde_json::from_str(&raw).expect("cursor rect json");
+    assert_eq!(value["pageIndex"], 0, "target cursor page");
+    assert_eq!(value["cellOverflowed"], false, "target cell overflow");
+    elapsed_ms
+}
+
+fn run_sample(format: &str, sample_path: &str, case: Case, run: usize) -> Value {
+    let load_started = Instant::now();
+    let mut doc = load_sample(sample_path);
+    let load_ms = load_started.elapsed().as_secs_f64() * 1000.0;
+    assert_eq!(
+        doc.page_count(),
+        115,
+        "{format}/{} initial pages",
+        case.name
+    );
+    assert_eq!(
+        target_paragraph(&doc).text.encode_utf16().count(),
+        INSERT_OFFSET,
+        "{format}/{} initial target length",
+        case.name
+    );
+    let initial_next_vpos = target_next_vpos(&doc);
+
+    let prepare_started = Instant::now();
+    for inserted in 0..case.target_input - 1 {
+        let result = insert_one(&mut doc, inserted);
+        assert_eq!(result["cellFlowChanged"], false);
+    }
+    let prepare_ms = prepare_started.elapsed().as_secs_f64() * 1000.0;
+
+    let warmup_ms = if case.warm_before_target {
+        let started = Instant::now();
+        let expected_end = INSERT_OFFSET + case.target_input - 1;
+        measure_tree(&doc, expected_end);
+        measure_cursor(&doc, expected_end);
+        started.elapsed().as_secs_f64() * 1000.0
+    } else {
+        0.0
+    };
+
+    let mutation_started = Instant::now();
+    let result = insert_one(&mut doc, case.target_input - 1);
+    let mutation_ms = mutation_started.elapsed().as_secs_f64() * 1000.0;
+    let expected_flow_changed = case.target_input == 44;
+    assert_eq!(
+        result["cellFlowChanged"], expected_flow_changed,
+        "{format}/{} target flow signal",
+        case.name
+    );
+    let expected_end = INSERT_OFFSET + case.target_input;
+    assert_eq!(result["charOffset"], expected_end);
+    assert_eq!(
+        target_paragraph(&doc).text.encode_utf16().count(),
+        expected_end
+    );
+
+    let pre_flush_tree_ms = measure_tree(&doc, expected_end);
+    let pre_flush_cursor_ms = measure_cursor(&doc, expected_end);
+
+    let flush_started = Instant::now();
+    doc.flush_deferred_pagination()
+        .expect("explicit deferred pagination flush");
+    let flush_ms = flush_started.elapsed().as_secs_f64() * 1000.0;
+
+    let post_flush_tree_ms = measure_tree(&doc, expected_end);
+    let post_flush_cursor_ms = measure_cursor(&doc, expected_end);
+    let expected_lines = if expected_flow_changed {
+        vec![0, 44, 84, 122, 129]
+    } else {
+        vec![0, 44, 84, 122]
+    };
+    let expected_next_vpos = initial_next_vpos + if expected_flow_changed { 1920 } else { 0 };
+    assert_eq!(
+        line_starts(&doc),
+        expected_lines,
+        "{format}/{} lines",
+        case.name
+    );
+    assert_eq!(
+        target_next_vpos(&doc),
+        expected_next_vpos,
+        "{format}/{} next paragraph vpos",
+        case.name
+    );
+    assert_eq!(doc.page_count(), 115, "{format}/{} final pages", case.name);
+
+    json!({
+        "run": run,
+        "loadMs": load_ms,
+        "prepareMs": prepare_ms,
+        "warmupMs": warmup_ms,
+        "mutationMs": mutation_ms,
+        "preFlushTreeMs": pre_flush_tree_ms,
+        "preFlushCursorMs": pre_flush_cursor_ms,
+        "flushMs": flush_ms,
+        "postFlushTreeMs": post_flush_tree_ms,
+        "postFlushCursorMs": post_flush_cursor_ms,
+        "accuracy": {
+            "cellFlowChanged": expected_flow_changed,
+            "targetLength": expected_end,
+            "lineStarts": line_starts(&doc),
+            "nextParagraphVpos": target_next_vpos(&doc),
+            "pageCount": doc.page_count(),
+        }
+    })
+}
+
+fn percentile(values: &[f64], quantile: f64) -> f64 {
+    assert!(!values.is_empty());
+    let mut sorted = values.to_vec();
+    sorted.sort_by(f64::total_cmp);
+    let index = ((sorted.len() as f64 * quantile).ceil() as usize)
+        .saturating_sub(1)
+        .min(sorted.len() - 1);
+    sorted[index]
+}
+
+fn summarize(samples: &[Value]) -> Value {
+    let phases = [
+        "loadMs",
+        "prepareMs",
+        "warmupMs",
+        "mutationMs",
+        "preFlushTreeMs",
+        "preFlushCursorMs",
+        "flushMs",
+        "postFlushTreeMs",
+        "postFlushCursorMs",
+    ];
+    let mut summary = Map::new();
+    for phase in phases {
+        let values = samples
+            .iter()
+            .map(|sample| sample[phase].as_f64().expect("timing number"))
+            .collect::<Vec<_>>();
+        summary.insert(
+            phase.to_string(),
+            json!({
+                "count": values.len(),
+                "p50Ms": percentile(&values, 0.50),
+                "p95Ms": percentile(&values, 0.95),
+                "maxMs": percentile(&values, 1.0),
+            }),
+        );
+    }
+    Value::Object(summary)
+}
+
+fn env_count(name: &str, default: usize) -> usize {
+    let value = std::env::var(name)
+        .ok()
+        .map(|raw| {
+            raw.parse::<usize>()
+                .unwrap_or_else(|_| panic!("{name} must be an integer"))
+        })
+        .unwrap_or(default);
+    assert!(
+        (1..=MAX_REPEATS).contains(&value),
+        "{name} must be 1..={MAX_REPEATS}"
+    );
+    value
+}
+
+fn command_output(program: &str, args: &[&str]) -> Option<String> {
+    let output = Command::new(program).args(args).output().ok()?;
+    output
+        .status
+        .success()
+        .then(|| String::from_utf8_lossy(&output.stdout).trim().to_string())
+}
+
+fn sha256(path: &Path) -> Option<String> {
+    if let Some(output) = command_output("shasum", &["-a", "256", path.to_str()?]) {
+        return output.split_whitespace().next().map(str::to_string);
+    }
+    command_output("sha256sum", &[path.to_str()?])?
+        .split_whitespace()
+        .next()
+        .map(str::to_string)
+}
+
+fn fixture_metadata(relative: &str) -> Value {
+    let path = manifest_path(relative);
+    json!({
+        "path": relative,
+        "size": fs::metadata(&path).expect("fixture metadata").len(),
+        "sha256": sha256(&path),
+    })
+}
+
+#[test]
+#[ignore = "performance diagnostic; run explicitly with --ignored --nocapture"]
+fn issue_2193_repeated_input_pagination_baseline() {
+    let warmups = env_count("RHWP_2193_WARMUPS", DEFAULT_WARMUPS);
+    let repeats = env_count("RHWP_2193_REPEATS", DEFAULT_REPEATS);
+    let format_filter = std::env::var("RHWP_2193_FORMAT").ok();
+    let case_filter = std::env::var("RHWP_2193_CASE").ok();
+    let formats = [("hwp", HWP_SAMPLE), ("hwpx", HWPX_SAMPLE)];
+    let mut cases = Vec::new();
+
+    for (format, sample_path) in formats {
+        if format_filter
+            .as_deref()
+            .is_some_and(|filter| filter != format)
+        {
+            continue;
+        }
+        for case in CASES {
+            if case_filter
+                .as_deref()
+                .is_some_and(|filter| filter != case.name)
+            {
+                continue;
+            }
+            eprintln!("#2193 warmup: {format}/{} x{warmups}", case.name);
+            for run in 1..=warmups {
+                let _ = run_sample(format, sample_path, case, run);
+            }
+
+            eprintln!("#2193 measure: {format}/{} x{repeats}", case.name);
+            let samples = (1..=repeats)
+                .map(|run| run_sample(format, sample_path, case, run))
+                .collect::<Vec<_>>();
+            let summary = summarize(&samples);
+            eprintln!(
+                "  mutation p50={:.3}ms p95={:.3}ms; flush p50={:.3}ms p95={:.3}ms",
+                summary["mutationMs"]["p50Ms"]
+                    .as_f64()
+                    .expect("mutation p50"),
+                summary["mutationMs"]["p95Ms"]
+                    .as_f64()
+                    .expect("mutation p95"),
+                summary["flushMs"]["p50Ms"].as_f64().expect("flush p50"),
+                summary["flushMs"]["p95Ms"].as_f64().expect("flush p95"),
+            );
+            cases.push(json!({
+                "format": format,
+                "case": case.name,
+                "targetInput": case.target_input,
+                "warmBeforeTarget": case.warm_before_target,
+                "summary": summary,
+                "samples": samples,
+            }));
+        }
+    }
+    assert!(
+        !cases.is_empty(),
+        "RHWP_2193_FORMAT/RHWP_2193_CASE filters selected no cases"
+    );
+
+    let git_head = command_output("git", &["rev-parse", "HEAD"]);
+    let git_dirty =
+        command_output("git", &["status", "--porcelain"]).map(|status| !status.is_empty());
+    let output = json!({
+        "issue": 2193,
+        "stage": 2,
+        "kind": "native-repeated-baseline",
+        "percentileMethod": "nearest-rank: ceil(count * quantile) - 1",
+        "environment": {
+            "gitHead": git_head,
+            "gitDirty": git_dirty,
+            "os": std::env::consts::OS,
+            "architecture": std::env::consts::ARCH,
+            "rustc": command_output("rustc", &["--version"]),
+            "cargo": command_output("cargo", &["--version"]),
+            "profile": "release-test",
+            "warmups": warmups,
+            "repeats": repeats,
+            "formatFilter": format_filter,
+            "caseFilter": case_filter,
+        },
+        "fixtures": [fixture_metadata(HWP_SAMPLE), fixture_metadata(HWPX_SAMPLE)],
+        "cases": cases,
+    });
+    let output_name =
+        std::env::var("RHWP_2193_OUTPUT_NAME").unwrap_or_else(|_| "native-baseline".to_string());
+    assert!(
+        !output_name.is_empty()
+            && output_name.chars().all(
+                |character| character.is_ascii_alphanumeric() || matches!(character, '-' | '_')
+            ),
+        "RHWP_2193_OUTPUT_NAME must contain only ASCII letters, digits, '-' or '_'"
+    );
+    let output_path = manifest_path(&format!("output/poc/task2193/stage2/{output_name}.json"));
+    fs::create_dir_all(output_path.parent().expect("output parent"))
+        .expect("create output directory");
+    fs::write(
+        &output_path,
+        format!(
+            "{}\n",
+            serde_json::to_string_pretty(&output).expect("serialize output")
+        ),
+    )
+    .expect("write native baseline");
+    eprintln!("#2193 native baseline written: {}", output_path.display());
+}


### PR DESCRIPTION
## 요약

- HWP/HWPX × cold/warm × stable/boundary 반복 Native 성능 하네스를 추가했습니다.
- 실제 Studio 입력에서 mutation, full pagination, cursor, render와 input-to-2-rAF를 분리하는
  `e2e:issue-2193` 진입점을 추가했습니다.
- #2193 Stage 1~4 계획·보고서에 기준선, 병목 판정과 구현 안전성 검토를 기록했습니다.
- production paginator와 공개 WASM API는 변경하지 않았습니다.

## 결론

115쪽 거대 셀 문서의 44번째 flow-boundary 입력에서 mutation은 약 0.1~0.2ms지만 동기 full
pagination이 약 0.9~1.2초로 지배 항입니다. page 2~114의 113개 continuation cut이 실제로 바뀌므로
단순 downstream page 재사용은 correctness를 보장하지 못합니다.

실제 개선은 #2424로 분리했습니다. dirty fragment부터 재개 가능한 table continuation을 우선 검토하고,
affected chain이 길면 chunk/yield를 적용하며 불확실한 구조는 기존 full pagination으로 fallback합니다.

Refs #2193

## 검증

최신 `upstream/devel@3eac4ae0` rebase 후:

- `cargo test --profile release-test --test issue_2214_page_local_repaint`
  - 3 passed
- #2193 HWP warm boundary smoke
  - mutation 0.122ms, full flush 1,258.2ms, correctness 통과
- `node --check e2e/issue-2214-page-local-repaint.test.mjs`
- `npm test`
  - 446 passed
- `npm run build`
- `npm run e2e:manifest-check`
- `npm run e2e:issue-2193 -- --formats=hwp,hwpx --cases=stable-28,boundary-44 --runs=1`
  - HWP stable: flush 0ms, input-to-2-rAF 66.0ms
  - HWP boundary: flush 898.8ms, input-to-2-rAF 996.3ms
  - HWPX stable: flush 0ms, input-to-2-rAF 74.3ms
  - HWPX boundary: flush 914.5ms, input-to-2-rAF 1,012.6ms

성능 하네스는 timing assertion을 두지 않고 raw sample과 p50/p95를 ignored `output/poc/task2193/`에
기록합니다. 정확성은 115쪽, model/tree/layout, continuation cut, cursor/caret assertion으로 고정합니다.

## 후속

- 구현 이슈: #2424
- correctness oracle: #2214 / PR #2241
- fixture origin: #1949
