### PR TITLE
fix(hwpx): 표 저장 시 allowOverlap 이 IR 대신 "0" 하드코딩돼 개체 겹침 허용 유실

### DIFF
--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -148,7 +148,11 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
             // treatAsChar 표의 1→0 케이스에서 0→1 드롭으로 표 partial-split 임계를 흔들어
             // 페이지네이션이 달라졌다(IR-invisible). #1594 holdAnchorAndSO 와 동형.
             ("flowWithText", bool01(c.flow_with_text)),
-            ("allowOverlap", "0"),
+            // allowOverlap 는 IR(allow_overlap)을 보존한다. 이웃 flowWithText(#1637)·
+            // holdAnchorAndSO(#1594)는 이미 IR 보존으로 고쳐졌는데 그 사이 allowOverlap 만
+            // "0" 하드코딩으로 남아, "개체 겹침 허용"이 켜진 플로팅 표가 저장 시 1→0 으로
+            // 드롭됐다(IR-invisible). shape.rs·picture.rs 의 write_pos 와 동형으로 방출.
+            ("allowOverlap", bool01(c.allow_overlap)),
             ("holdAnchorAndSO", hold),
             ("vertRelTo", vert_rel_to_str(c.vert_rel_to)),
             ("horzRelTo", horz_rel_to_str(c.horz_rel_to)),
@@ -579,6 +583,34 @@ mod tests {
         let xml = serialize(&t);
         assert!(
             xml.contains(r#"holdAnchorAndSO="0""#),
+            "기본 0: {}",
+            &xml[..xml.len().min(300)]
+        );
+    }
+
+    // ---------- allowOverlap 보존 ----------
+
+    #[test]
+    fn allow_overlap_preserved() {
+        // allowOverlap 는 IR(common.allow_overlap)을 보존해야 한다. 종전 "0" 하드코딩은
+        // 개체 겹침 허용이 켜진 플로팅 표에서 1→0 드롭으로 저장 시 설정을 유실시켰다. RED.
+        let mut t = empty_table(1, 1);
+        t.common.allow_overlap = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"allowOverlap="1""#),
+            "allowOverlap 가 IR 값(1)으로 방출돼야 한다(종전 0 하드코딩): {}",
+            &xml[..xml.len().min(500)]
+        );
+    }
+
+    #[test]
+    fn allow_overlap_zero_when_unset() {
+        // allow_overlap=false 이면 allowOverlap="0" (기존 동작 보존).
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"allowOverlap="0""#),
             "기본 0: {}",
             &xml[..xml.len().min(300)]
         );


### PR DESCRIPTION
## 변경 요약

HWPX 표 직렬화 `write_pos`(src/serializer/hwpx/table.rs)에서 `<hp:pos allowOverlap>`가 IR 값 대신 `"0"` 상수로 하드코딩되어 있어, **"개체 겹침 허용"이 켜진 플로팅 표가 `.hwpx` 저장 시 꺼진 상태로 유실**됩니다.

이 함수의 **바로 이웃한 두 pos 불리언은 이미 IR 보존으로 고쳐졌습니다** — `flowWithText`(#1637, `common.flow_with_text`), `holdAnchorAndSO`(#1594, `common.prevent_page_break`). 그 사이의 `allowOverlap`만 상수로 남아 누락됐습니다.

```rust
("flowWithText", bool01(c.flow_with_text)),   // #1637: IR 보존
("allowOverlap", "0"),                        // ← 상수 하드코딩 (이 PR가 수정)
("holdAnchorAndSO", hold),                    // #1594: IR 보존
```

`allow_overlap`는 파싱은 정상입니다(`src/parser/hwpx/section.rs:1692` `b"allowOverlap" => table.common.allow_overlap = parse_bool(...)`) — IR로는 올바르게 왕복하므로 **ir-diff로는 안 잡히는 IR-invisible 결함**이고, 방출 XML에서만 값이 어긋납니다. 같은 `write_pos` 계열인 **도형(`shape.rs:1006`)·그림(`picture.rs:412`)은 이미 `bool01(c.allow_overlap)`을 방출**합니다 — 표 경로만 누락된 상태였습니다.

## 수정

`table.rs`의 해당 줄을 이웃 두 필드와 동형으로:

```rust
("allowOverlap", bool01(c.allow_overlap)),
```

## 영향

플로팅 표에 "개체 겹침 허용"을 설정한 문서를 열어 `.hwpx`로 저장하면 그 설정이 유지됩니다. 종전에는 저장 시 항상 꺼져(겹침 금지) 자동 레이아웃/겹침 배치가 달라질 수 있었습니다(이웃 #1594/#1637이 고친 것과 동일한 부류의 영향).

## 테스트

`src/serializer/hwpx/table.rs`에 `#1594` 테스트와 동형으로 2건 추가:
- `allow_overlap_preserved` — `common.allow_overlap = true` → XML에 `allowOverlap="1"`
- `allow_overlap_zero_when_unset` — 기본값 → `allowOverlap="0"` (기존 동작 보존)

로컬 검증(`cargo test --lib allow_overlap`): **2 passed**. 수정을 되돌리면 `allow_overlap_preserved`가 **FAILED**(RED→GREEN 확인). `rustfmt` 재포맷 없음(CRLF 로컬 노이즈 제외).
