### PR TITLE
fix(field): 누름틀 필드 제거 시 raw_stream 미무효화로 저장에서 필드가 되살아남

### DIFF
--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -660,6 +660,12 @@ impl DocumentCore {
             .and_then(|s| s.paragraphs.get_mut(para_idx))
             .ok_or_else(|| HwpError::InvalidField("문단 위치 초과".into()))?;
         remove_field_in_para(para, char_offset)?;
+        // 필드 제거는 섹션 본문을 바꾸므로 raw_stream 을 무효화해야 저장에 반영된다
+        // (삽입 짝 insert_click_here_field_at 과 동형). 누락 시 recompose 로 화면만
+        // 갱신되고 저장은 원본 바이트를 재방출해 지운 필드가 되살아난다.
+        if let Some(section) = self.document.sections.get_mut(section_idx) {
+            section.raw_stream = None;
+        }
         self.recompose_section(section_idx);
         Ok(r#"{"ok":true}"#.to_string())
     }
@@ -716,6 +722,11 @@ impl DocumentCore {
             }
         };
         remove_field_in_para(para, char_offset)?;
+        // 셀/글상자 내 필드 제거도 섹션 본문 스트림을 바꾸므로 raw_stream 무효화 필요
+        // (삽입 짝 insert_click_here_field_at_in_cell 과 동형).
+        if let Some(section) = self.document.sections.get_mut(section_idx) {
+            section.raw_stream = None;
+        }
         self.recompose_section(section_idx);
         Ok(r#"{"ok":true}"#.to_string())
     }
@@ -1477,6 +1488,91 @@ mod tests {
             memo_paragraphs: Vec::new(),
             raw_parameters_xml: None,
         })
+    }
+
+    fn para_with_click_here_field() -> Paragraph {
+        // 스트림: [ColumnDef 8B] A B C [FIELD_BEGIN] X Y [FIELD_END], 필드는 [3,5]
+        Paragraph {
+            text: "ABCXY".into(),
+            controls: vec![
+                Control::ColumnDef(Default::default()),
+                make_field_control(100),
+            ],
+            field_ranges: vec![FieldRange {
+                start_char_idx: 3,
+                end_char_idx: 5,
+                control_idx: 1,
+            }],
+            char_count: 21,
+            char_offsets: vec![8, 9, 10, 19, 20],
+            ..Default::default()
+        }
+    }
+
+    #[test]
+    fn remove_field_at_invalidates_raw_stream() {
+        // 본문 필드 제거는 섹션 본문을 바꾸므로 raw_stream 이 무효화돼야 저장에 반영된다.
+        // 무효화 라인을 제거하면 이 테스트가 실패한다(RED): 저장이 원본 바이트를 재방출해
+        // 지운 필드가 되살아난다.
+        let mut core = DocumentCore::new_empty();
+        core.document.sections.push(Section {
+            paragraphs: vec![para_with_click_here_field()],
+            raw_stream: Some(vec![0xAB; 64]),
+            ..Default::default()
+        });
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+
+        core.remove_field_at(0, 0, 4).unwrap();
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "remove_field_at 후 raw_stream 이 무효화돼야 한다"
+        );
+        let bytes = crate::serializer::body_text::serialize_section(&core.document.sections[0]);
+        assert_ne!(
+            bytes,
+            vec![0xAB; 64],
+            "serialize_section 이 여전히 원본 바이트를 반환"
+        );
+        // 필드 컨트롤이 실제로 제거돼 ColumnDef 만 남는다
+        assert_eq!(core.document.sections[0].paragraphs[0].controls.len(), 1);
+    }
+
+    #[test]
+    fn remove_field_at_in_cell_invalidates_raw_stream() {
+        // 표 셀 내 필드 제거도 섹션 본문 스트림을 바꾸므로 raw_stream 무효화가 필요하다.
+        let table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![para_with_click_here_field()],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        let parent_para = Paragraph {
+            controls: vec![Control::Table(Box::new(table))],
+            ..Default::default()
+        };
+        let mut core = DocumentCore::new_empty();
+        core.document.sections.push(Section {
+            paragraphs: vec![parent_para],
+            raw_stream: Some(vec![0xAB; 64]),
+            ..Default::default()
+        });
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+
+        core.remove_field_at_in_cell(0, 0, 0, 0, 0, 4, false)
+            .unwrap();
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "remove_field_at_in_cell 후 raw_stream 이 무효화돼야 한다"
+        );
+        let bytes = crate::serializer::body_text::serialize_section(&core.document.sections[0]);
+        assert_ne!(bytes, vec![0xAB; 64]);
     }
 
     #[test]


### PR DESCRIPTION
## 변경 요약

누름틀(ClickHere) 필드를 **제거**하는 `remove_field_at`(본문)·`remove_field_at_in_cell`(표 셀/글상자)가 필드를 IR에서 지운 뒤 `recompose_section`만 호출하고 **섹션 `raw_stream`을 무효화하지 않습니다**. 저장 경로 `serialize_section`은 `raw_stream`이 `Some`이면 파서가 넣어둔 원본 바이트를 그대로 재방출하므로, **화면에서는 필드가 사라지지만 저장→재로드하면 지운 필드가 되살아납니다**(직렬화 passthrough 계약).

`recompose_section`은 조판 캐시만 갱신할 뿐 `raw_stream`을 건드리지 않으므로, 이 결함은 **화면 확인으로는 잡히지 않고 저장 라운드트립에서만** 드러납니다.

## 이건 오탈이 명확합니다 (삽입 짝은 이미 무효화)

같은 파일의 **삽입** 함수들은 모두 제거 후와 동일한 지점에서 `raw_stream`을 무효화합니다:

| 함수 | raw_stream 무효화 |
| --- | --- |
| `insert_click_here_field_at` | :83 ✅ |
| `insert_click_here_field_at_in_cell` | :174 ✅ |
| `insert_click_here_field_at_by_path` | :224 ✅ |
| `set_field_text_at` | :521 ✅ |
| **`remove_field_at`** | ❌ (이 PR) |
| **`remove_field_at_in_cell`** | ❌ (이 PR) |

즉 삽입은 저장에 반영되는데 제거만 유실되는 비대칭입니다. 두 함수 모두 WASM 표면에서 도달 가능합니다(`removeFieldAt`, `removeFieldAtInCell`).

## 수정

각 함수에서 `remove_field_in_para(...)?` 직후, 해당 섹션의 `raw_stream = None` (삽입 짝과 동형):

```rust
remove_field_in_para(para, char_offset)?;
if let Some(section) = self.document.sections.get_mut(section_idx) {
    section.raw_stream = None;
}
self.recompose_section(section_idx);
```

## 테스트

`field_query.rs` 테스트 모듈에 sentinel 라운드트립 2건 추가:
- `remove_field_at_invalidates_raw_stream` — 본문
- `remove_field_at_in_cell_invalidates_raw_stream` — 표 셀

각 테스트: 섹션에 `raw_stream = Some(vec![0xAB; 64])` sentinel을 심고 필드를 제거한 뒤 ① `raw_stream.is_none()` ② `serialize_section(...)`이 sentinel을 반환하지 않음을 검증.

로컬 검증(`cargo test --lib remove_field_at`): **3 passed**. 무효화 라인을 제거하면 두 테스트가 실패하도록 설계했습니다(RED→GREEN). *로컬 참고:* 이 PC의 Smart App Control이 새로 빌드된 테스트 바이너리를 간헐 차단(os error 4551)해 RED 방향 바이너리 실행은 이번엔 반복 차단됐습니다 — GREEN 실행은 통과했고, 어서션이 `raw_stream.is_none()`을 직접 검사하므로 무효화가 없으면 결정적으로 실패합니다. 업스트림 CI(Linux)에서 양방향 모두 재현됩니다.
