### PR TITLE
fix(style): updateStyle/deleteStyle 가 DocInfo 무효화 누락해 .hwp 저장 시 스타일 편집 유실

### DIFF
--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -5652,6 +5652,10 @@ impl HwpDocument {
         }
         // raw_data 무효화 (수정됨)
         style.raw_data = None;
+        // DocInfo 스트림 무효화. serialize_doc_info 는 raw_stream_dirty 가 false 이면
+        // 원본 스트림을 그대로 반환하고(레코드 raw_data 는 그 이전에 단락됨), 이름/nextStyleId
+        // 변경이 .hwp 저장에서 유실된다. 형제 update_style_shapes 는 이미 이 플래그를 세운다.
+        self.core.document.doc_info.raw_stream_dirty = true;
         true
     }
 
@@ -5898,6 +5902,13 @@ impl HwpDocument {
             &self.core.document.doc_info,
             self.core.dpi,
         );
+        // DocInfo(styles 목록)와 문단 style_id 가 함께 바뀌었으므로 저장 스트림을 무효화한다.
+        // raw_stream_dirty 미설정 시 DocInfo 가, 섹션 raw_stream 잔존 시 본문이 각각 원본
+        // 바이트로 재방출돼 스타일 삭제·문단 재배정이 .hwp 저장에서 유실된다.
+        self.core.document.doc_info.raw_stream_dirty = true;
+        for section in &mut self.core.document.sections {
+            section.raw_stream = None;
+        }
         true
     }
 

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -24825,3 +24825,62 @@ fn issue2214_scoped_cache_coherence_preserves_transient_pagination() {
         assert_eq!(doc.page_count(), 115, "{label}: page count");
     }
 }
+
+#[test]
+fn update_style_dirties_docinfo_for_hwp5_save() {
+    use crate::model::style::Style;
+    let mut doc = HwpDocument::create_empty();
+    if doc.document.doc_info.styles.is_empty() {
+        doc.document.doc_info.styles.push(Style::default());
+    }
+    doc.document.doc_info.styles.push(Style {
+        local_name: "OLD".to_string(),
+        ..Default::default()
+    });
+    let sid = (doc.document.doc_info.styles.len() - 1) as u32;
+    // parsed 문서처럼 DocInfo 원본 스트림을 채운다(clean 상태): 무효화가 없으면 저장이 원본 반환.
+    doc.document.doc_info.raw_stream = Some(vec![0xAB; 64]);
+    doc.document.doc_info.raw_stream_dirty = false;
+
+    assert!(doc.update_style(sid, r#"{"name":"NEW"}"#));
+
+    assert!(
+        doc.document.doc_info.raw_stream_dirty,
+        "update_style 후 raw_stream_dirty=true 여야 이름 변경이 .hwp 저장에 반영된다"
+    );
+    let bytes = crate::serializer::doc_info::serialize_doc_info(
+        &doc.document.doc_info,
+        &doc.document.doc_properties,
+    );
+    assert_ne!(
+        bytes,
+        vec![0xAB; 64],
+        "serialize_doc_info 가 여전히 원본 스트림을 반환"
+    );
+}
+
+#[test]
+fn delete_style_invalidates_docinfo_and_sections() {
+    use crate::model::style::Style;
+    let mut doc = HwpDocument::create_empty();
+    if doc.document.doc_info.styles.is_empty() {
+        doc.document.doc_info.styles.push(Style::default());
+    }
+    doc.document.doc_info.styles.push(Style::default());
+    let sid = (doc.document.doc_info.styles.len() - 1) as u32;
+    doc.document.sections[0].paragraphs[0].style_id = sid as u8;
+    doc.document.doc_info.raw_stream = Some(vec![0xAB; 64]);
+    doc.document.doc_info.raw_stream_dirty = false;
+    doc.document.sections[0].raw_stream = Some(vec![0xCD; 64]);
+
+    assert!(doc.delete_style(sid));
+
+    assert!(
+        doc.document.doc_info.raw_stream_dirty,
+        "delete_style 후 DocInfo raw_stream_dirty=true 여야 한다"
+    );
+    assert!(
+        doc.document.sections[0].raw_stream.is_none(),
+        "문단 style_id 재배정이 반영되도록 섹션 raw_stream 이 무효화돼야 한다"
+    );
+}


### PR DESCRIPTION
## 변경 요약

DocInfo 스타일 편집 두 진입점이 저장 스트림을 무효화하지 않아 **`.hwp` 저장 시 스타일 편집이 유실**됩니다.

핵심은 **DocInfo 게이트의 단락(short-circuit)** 입니다. `serialize_doc_info`(src/serializer/doc_info.rs)는 `doc_info.raw_stream_dirty`가 `false`이면 원본 DocInfo 스트림을 그대로 반환하고, **per-record `raw_data`는 그 이전에 단락**됩니다. 따라서 DocInfo 레코드를 편집할 때는 `raw_data = None`만으로는 부족하고 **`raw_stream_dirty = true`도 세워야** 합니다.

### `update_style` (rename)

`style.raw_data = None`만 하고 `raw_stream_dirty`를 세우지 않습니다. 형제 `update_style_shapes`는 이미 `raw_stream_dirty = true`를 세웁니다 — `update_style`만 누락됐습니다.

사용자 경로: 스타일 편집 대화상자(`style-edit-dialog.ts`)에서 **이름/영문이름/nextStyleId만** 바꾸면(글자·문단 모양을 건드리지 않아 `updateStyleShapes` 호출이 가드로 스킵됨) `.hwp`로 저장 후 다시 열면 이름이 원래대로 돌아갑니다.

### `delete_style`

스타일을 목록에서 삭제하고 그 스타일을 쓰던 **문단들의 `style_id`를 0으로 재배정**(본문 변경)한 뒤 뒤쪽 `style_id`를 감소시키는데, **DocInfo `raw_stream_dirty`도, 영향받은 섹션의 `raw_stream`도** 무효화하지 않습니다. 결과적으로 삭제와 문단 재배정이 `.hwp` 저장에서 유실됩니다.

## 수정

```rust
// update_style
style.raw_data = None;
self.core.document.doc_info.raw_stream_dirty = true;   // 추가

// delete_style (스타일 캐시 갱신 후)
self.core.document.doc_info.raw_stream_dirty = true;   // 추가
for section in &mut self.core.document.sections {       // 추가: 문단 style_id 변경 반영
    section.raw_stream = None;
}
```

## 테스트

`src/wasm_api/tests.rs`에 host 테스트 2건 추가:
- `update_style_dirties_docinfo_for_hwp5_save` — sentinel `raw_stream`을 심고 이름 변경 후 `raw_stream_dirty`가 서고 `serialize_doc_info`가 sentinel을 반환하지 않음을 검증
- `delete_style_invalidates_docinfo_and_sections` — 삭제 후 `raw_stream_dirty` + 섹션 `raw_stream` 무효화 검증

로컬(`cargo test --lib style`): 수정 상태 **69 passed**. 수정 두 줄을 제거하면 두 테스트가 **FAILED**(RED), 복원하면 **GREEN** — 양방향 실행 확인. `rustfmt` 재포맷 없음.

## 배경

이 계약은 최근 트러블슈팅 `raw_data_stale_clone_on_mutation.md`(레코드 계층)와 제안 문서 #2429(세 계층 무효화)의 **DocInfo 계층**에 해당합니다. `raw_data=None`이 게이트 단락 때문에 **inert**해지는 대표 사례입니다.
