### PR TITLE
fix(field): 누름틀 command 의 wstring/set 길이를 UTF-16 WCHAR 수로 계산 (§4.5)

### DIFF
--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -329,16 +329,19 @@ impl Field {
     /// - 필드 이름(Name)은 command 에 넣지 않는다 — CTRL_DATA 레코드(0x57) 전담.
     ///   (이전엔 Name 키를 넣어 한컴이 Direction 범위를 잘못 잘라 안내문 바인딩 실패.)
     pub fn build_clickhere_command(guide: &str, memo: &str) -> String {
-        let guide_len = guide.chars().count();
-        let memo_len = memo.chars().count();
+        // §4.5: wstring {n} 은 UTF-16 code unit(WCHAR) 수다. chars().count()(스칼라 수)는
+        // BMP 밖 문자(이모지·CJK 확장한자 등)를 문자당 1개 적게 세어, 한컴이 안내문/메모
+        // 범위를 잘못 해석한다.
+        let guide_len = guide.encode_utf16().count();
+        let memo_len = memo.encode_utf16().count();
 
         // HelpState 값 뒤 공백 2개 (한컴 정답지 동형).
         let inner = format!(
             "Direction:wstring:{}:{} HelpState:wstring:{}:{}  ",
             guide_len, guide, memo_len, memo
         );
-        // set 길이는 마지막 trailing 공백 1개를 제외한 inner 글자수.
-        let set_len = inner.chars().count() - 1;
+        // set 길이도 WCHAR 수 기준. 마지막 trailing 공백 1개 제외(-1) — 공백은 BMP 라 유지.
+        let set_len = inner.encode_utf16().count() - 1;
         format!("Clickhere:set:{}:{}", set_len, inner)
     }
 
@@ -507,6 +510,27 @@ mod tests {
             set_len,
             body.chars().count() - 1,
             "set 길이 = inner 글자수 − 1 (trailing 공백 제외): {cmd}"
+        );
+    }
+
+    /// §4.5: wstring {n}·set {N} 은 UTF-16 code unit(WCHAR) 수여야 한다.
+    /// BMP 밖 문자(U+20000)는 2 WCHAR 이므로 chars().count() 로는 1개 적게 세어진다.
+    #[test]
+    fn clickhere_wstring_len_counts_utf16_wchars() {
+        // guide "a𠀀b": a(1) + U+20000(2 WCHAR) + b(1) = 4 WCHAR (chars().count()=3)
+        let cmd = Field::build_clickhere_command("a\u{20000}b", "");
+        assert!(
+            cmd.contains("Direction:wstring:4:a\u{20000}b "),
+            "guide {{n}} 은 UTF-16 code unit 수(4)여야 한다(chars().count()=3 이면 RED): {cmd}"
+        );
+        // set 길이도 WCHAR 기준 (inner 의 UTF-16 수 − 1).
+        let body = cmd.strip_prefix("Clickhere:set:").unwrap();
+        let (set_str, inner) = body.split_once(':').unwrap();
+        let set_len: usize = set_str.parse().unwrap();
+        assert_eq!(
+            set_len,
+            inner.encode_utf16().count() - 1,
+            "set {{N}} 은 WCHAR 수: {cmd}"
         );
     }
 


### PR DESCRIPTION
## 변경 요약

`Field::build_clickhere_command`(src/model/control.rs)가 누름틀(ClickHere) command의 `wstring:{n}` 안내문/메모 길이와 `set:{N}` 길이를 **`String::chars().count()`(유니코드 스칼라 수)**로 계산합니다. 그러나 저장 기술 가이드 §4.5는 이 길이들이 **UTF-16 code unit(WCHAR) 수**라고 규정합니다.

command 문자열은 CTRL_HEADER에 **UTF-16LE**로 방출되므로, BMP 밖 문자(이모지, CJK 확장한자 등 — 1 스칼라 = **2 WCHAR**)가 안내문/메모에 포함되면 길이 필드가 문자당 1씩 작아집니다. 그러면 한컴이 안내문(Direction)/메모(HelpState) 범위를 잘못 잘라 안내문 바인딩이 어긋납니다.

## 수정

세 곳의 `.chars().count()` → `.encode_utf16().count()`:

```rust
let guide_len = guide.encode_utf16().count();      // L332
let memo_len  = memo.encode_utf16().count();       // L333
...
let set_len   = inner.encode_utf16().count() - 1;  // L341 (trailing 공백은 BMP → -1 유지)
```

`-1` 보정은 마지막 trailing 공백(BMP, 1 WCHAR)을 제외하는 것이라 영향 없습니다.

## 회귀 안전

BMP-only 입력은 `chars().count() == encode_utf16().count()`이므로 값이 동일합니다. 기존 한컴 정답지 테스트(`task1434_clickhere_command_hancom_format`, "여기에 입력"/"제목 입력")는 그대로 통과합니다.

## 테스트

`clickhere_wstring_len_counts_utf16_wchars` 추가: `build_clickhere_command("a𠀀b", "")`(U+20000, 2 WCHAR)가 `Direction:wstring:4:...`를 내는지, `set:{N}`이 `inner.encode_utf16().count()-1`인지 검증.

로컬(`cargo test --lib clickhere`): 수정 상태 **3 passed**(신규 + task1434 2건). 세 spot을 `.chars().count()`로 되돌리면 신규 테스트가 **FAILED**(wstring:3), 복원 시 **GREEN** — RED→GREEN 양방향 확인. `rustfmt` 통과.
