### PR TITLE
fix(hwp5): 묶음 빈칸(U+00A0) 문단의 control_mask 비트 30 누락

### DIFF
--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -349,6 +349,11 @@ fn compute_control_mask(para: &Paragraph) -> u32 {
     if para.text.contains('\n') {
         mask |= 1u32 << 0x000A;
     }
+    // 묶음 빈칸 (0x001E, NBSP): serialize_para_text 가 U+00A0 마다 코드 0x1E 를 방출하므로
+    // (#1793) control_mask 비트 30 도 세워 PARA_HEADER 를 PARA_TEXT 와 일치시킨다.
+    if para.text.contains('\u{00A0}') {
+        mask |= 1u32 << 0x001E;
+    }
     // FIXED_WIDTH_SPACE (0x001F): HWPX에서 들어온 일부 문맥은 U+2007을
     // literal code point가 아니라 HWP5 fixed blank control로 저장해야 한다.
     if should_serialize_figure_space_as_hwp_fixed_blank(para) {
@@ -1174,6 +1179,23 @@ mod tests {
         let bytes = test_serialize_para_text(&para);
 
         assert_eq!(&bytes[2..4], &0x001E_u16.to_le_bytes());
+    }
+
+    /// [NBSP mask] U+00A0 은 PARA_TEXT 에 코드 0x1E 로 방출되므로 PARA_HEADER control_mask
+    /// 비트 30 도 서야 한다(안 서면 한컴에서 헤더/텍스트 불일치).
+    #[test]
+    fn test_nbsp_sets_control_mask_bit_30() {
+        let para = Paragraph {
+            char_count: 4,
+            text: "가\u{00A0}나".to_string(),
+            char_offsets: vec![0, 1, 2],
+            ..Default::default()
+        };
+        assert_ne!(
+            compute_control_mask(&para) & (1u32 << 0x001E),
+            0,
+            "U+00A0 포함 시 control_mask 비트 30 이 서야 PARA_TEXT(0x1E)와 일치한다"
+        );
     }
 
     /// 컨트롤 문자 코드 매핑 테스트


### PR DESCRIPTION
## 요약

`serialize_para_text`는 U+00A0(묶음 빈칸)마다 PARA_TEXT에 제어코드 `0x1E`를 방출하지만(#1793), `compute_control_mask`(src/serializer/body_text.rs)에는 `0x1E` 분기가 없어 **PARA_HEADER.control_mask 비트 30이 서지 않습니다**. 결과적으로 헤더의 control_mask가 실제 PARA_TEXT와 불일치해, U+00A0을 포함한 문단을 한컴이 잘못 해석할 수 있습니다.

이웃한 고정폭 빈칸(U+2007→`0x1F`→비트31)은 이미 마스크에 반영됩니다 — NBSP(비트30)만 누락됐습니다.

## 수정

`compute_control_mask`에 U+00A0 존재 시 비트 30을 세우는 한 줄 추가(고정폭 빈칸 분기와 동형).

## 테스트

`test_nbsp_sets_control_mask_bit_30` 추가(`"가\u{00A0}나"` → 비트30 확인). `cargo test --lib nbsp` → **3 passed**(신규 + 기존 `test_nbsp_serializes_as_code_30`). 마스크 한 줄을 제거하면 신규 테스트가 결정적으로 실패합니다.