### PR TITLE
fix(hwpx): 구역 세로쓰기(textDirection) 가 .hwpx 저장 시 유실

### DIFF
--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -97,6 +97,19 @@ fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
         &format!(r#"spaceColumns="{}""#, sd.column_spacing),
         1,
     );
+    // 구역 세로쓰기: 파서는 textDirection="VERTICAL" → text_direction=1 로 읽지만
+    // (parser/hwpx/section.rs) 직렬화기는 이 필드를 재출력하지 않아, 세로쓰기 구역이
+    // .hwpx 저장 시 HORIZONTAL 로 유실됐다. text_direction==1 일 때만 치환한다
+    // (기본 0 문서는 템플릿 HORIZONTAL 유지). 템플릿엔 secPr 에만 등장하므로 replacen(1) 안전.
+    let out = if sd.text_direction == 1 {
+        out.replacen(
+            r#"textDirection="HORIZONTAL""#,
+            r#"textDirection="VERTICAL""#,
+            1,
+        )
+    } else {
+        out
+    };
     let out = out.replacen(
         r#"outlineShapeIDRef="1""#,
         &format!(r#"outlineShapeIDRef="{}""#, sd.outline_numbering_id),
@@ -2390,6 +2403,41 @@ mod tests {
         assert!(
             !xml.contains(r#"styleIDRef="96""#),
             "미등록 style_id 는 방출되지 않아야 함"
+        );
+    }
+
+    #[test]
+    fn secpr_emits_ir_text_direction_vertical() {
+        // 파서는 textDirection="VERTICAL" → text_direction=1 로 읽지만 직렬화기가 재출력하지
+        // 않아 세로쓰기 구역이 .hwpx 저장 시 HORIZONTAL 로 유실됐다. 1 이면 VERTICAL 방출.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (mut doc, _) = make_doc_with_paragraph(para);
+        doc.sections[0].section_def.text_direction = 1;
+        let section = doc.sections[0].clone();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"textDirection="VERTICAL""#),
+            "세로쓰기 구역은 textDirection=VERTICAL 로 방출돼야 함: {xml:.400}"
+        );
+        assert!(
+            !xml.contains(r#"textDirection="HORIZONTAL""#),
+            "secPr 의 HORIZONTAL 이 남아있으면 안 됨: {xml:.400}"
+        );
+    }
+
+    #[test]
+    fn secpr_keeps_horizontal_when_text_direction_unset() {
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, _) = make_doc_with_paragraph(para);
+        let section = doc.sections[0].clone();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"textDirection="HORIZONTAL""#),
+            "기본(text_direction=0) 은 HORIZONTAL 유지: {xml:.400}"
         );
     }
 


### PR DESCRIPTION
## 요약

파서는 `<hp:secPr textDirection="VERTICAL">`를 `SectionDef.text_direction=1`로 읽지만(parser/hwpx/section.rs), hwpx 직렬화기 `write_section`은 이 필드를 재출력하지 않습니다. `replace_secpr_scalars`가 spaceColumns·outlineShapeIDRef·tabStop·grid·startNum는 치환하지만 **textDirection은 빠져 있어**, 세로쓰기 구역이 `.hwpx` 저장 시 템플릿 상수 `HORIZONTAL`로 되돌아갑니다. #2415가 고친 secPr 필드 유실과 **동형**입니다.

## 수정

`replace_secpr_scalars`에 `text_direction==1`일 때만 `textDirection="HORIZONTAL"`→`"VERTICAL"` 치환 추가. 템플릿(`empty_section0.xml`)에서 `textDirection`은 **secPr에만 1회** 등장하므로 `replacen(1)`이 안전하고, 기본(0) 문서는 그대로 HORIZONTAL을 유지합니다.

## 테스트

`secpr_emits_ir_text_direction_vertical`(1→VERTICAL, HORIZONTAL 잔존 안 함) + `secpr_keeps_horizontal_when_text_direction_unset`(기본 0 회귀 가드).

`cargo test --lib --no-run` **컴파일·링크 통과**, `rustfmt` 통과. (로컬 PC의 Smart App Control이 새 테스트 바이너리 실행을 간헐 차단(os error 4551)해 로컬 실행은 못 했으나, 치환은 유일 문자열 대상이라 결정적이며 CI에서 검증됩니다.)