### PR TITLE
fix(hwp): 인라인 컨트롤(각주/미주/수식/새번호) 삽입 시 char_shapes 미시프트로 글자모양 오염

### DIFF
--- a/src/document_core/commands/object_ops/common.rs
+++ b/src/document_core/commands/object_ops/common.rs
@@ -387,13 +387,7 @@ impl crate::document_core::DocumentCore {
             .insert(insert_idx, Control::NewNumber(new_number));
         paragraph.ctrl_data_records.insert(insert_idx, None);
 
-        if !paragraph.char_offsets.is_empty() {
-            let text_len = paragraph.text.chars().count();
-            let safe_offset = char_offset.min(text_len);
-            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
-                *co += 8;
-            }
-        }
+        paragraph.shift_for_inline_control_insert(char_offset);
         paragraph.char_count += 8;
         paragraph.control_mask |= 1u32 << 0x0012;
         paragraph.has_para_text = true;

--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -421,13 +421,7 @@ impl DocumentCore {
             .insert(insert_idx, Control::Equation(Box::new(equation)));
         paragraph.ctrl_data_records.insert(insert_idx, None);
 
-        if !paragraph.char_offsets.is_empty() {
-            let text_len = paragraph.text.chars().count();
-            let safe_offset = char_offset.min(text_len);
-            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
-                *co += 8;
-            }
-        }
+        paragraph.shift_for_inline_control_insert(char_offset);
         paragraph.char_count += 8;
         paragraph.control_mask |= 1u32 << 11;
         paragraph.has_para_text = true;

--- a/src/document_core/commands/object_ops/note.rs
+++ b/src/document_core/commands/object_ops/note.rs
@@ -496,13 +496,7 @@ impl DocumentCore {
         // char_offsets[i]는 텍스트 i번째 문자의 UTF-16 오프셋 (컨트롤은 갭으로 표현)
         // 주의: char_offset은 텍스트 기준 인덱스이지만, char_offsets 배열 길이는 text.chars().count()
         // text에 포함되지 않는 제어 문자(cc - text_len 차이)가 있을 수 있으므로 범위 확인
-        if !paragraph.char_offsets.is_empty() {
-            let text_len = paragraph.text.chars().count();
-            let safe_offset = char_offset.min(text_len);
-            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
-                *co += 8;
-            }
-        }
+        paragraph.shift_for_inline_control_insert(char_offset);
         paragraph.char_count += 8;
         paragraph.control_mask |= 1u32 << 0x0011; // 각주/미주 비트
         paragraph.has_para_text = true;
@@ -724,13 +718,7 @@ impl DocumentCore {
             .insert(insert_idx, Control::Endnote(Box::new(endnote)));
         paragraph.ctrl_data_records.insert(insert_idx, None);
 
-        if !paragraph.char_offsets.is_empty() {
-            let text_len = paragraph.text.chars().count();
-            let safe_offset = char_offset.min(text_len);
-            for co in paragraph.char_offsets[safe_offset..].iter_mut() {
-                *co += 8;
-            }
-        }
+        paragraph.shift_for_inline_control_insert(char_offset);
         paragraph.char_count += 8;
         paragraph.control_mask |= 1u32 << 0x0011;
         paragraph.has_para_text = true;
@@ -850,6 +838,39 @@ mod char_shape_inherit_tests {
             inner.char_shapes.first().map(|cs| cs.char_shape_id),
             Some(37),
             "미주 내부 문단이 커서 offset 글자모양(37)이 아닌 값을 상속"
+        );
+    }
+
+    /// [index-axis 회귀] 인라인 각주 삽입이 char_offsets 는 +8 시프트하면서
+    /// char_shapes.start_pos 는 시프트하지 않아 글자모양 run 경계가 텍스트와 어긋나던 결함.
+    /// text="abcd", char_offsets=[0,1,2,3], run [{0→id5},{2→id6}]. offset 1 에 각주 삽입 후
+    /// 원래 'b'(char idx 1)는 여전히 id 5 여야 한다(결함 시 run1(id6)이 덮어 6 반환).
+    #[test]
+    fn insert_footnote_shifts_char_shapes_with_char_offsets() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "abcd").unwrap();
+        {
+            let para = &mut core.document.sections[0].paragraphs[0];
+            para.text = "abcd".to_string();
+            para.char_offsets = vec![0, 1, 2, 3];
+            para.char_shapes = vec![
+                CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 5,
+                },
+                CharShapeRef {
+                    start_pos: 2,
+                    char_shape_id: 6,
+                },
+            ];
+        }
+        core.insert_footnote_native(0, 0, 1).unwrap();
+        let para = &core.document.sections[0].paragraphs[0];
+        assert_eq!(
+            para.char_shape_id_at(1),
+            Some(5),
+            "각주 삽입 후 원래 'b'(char idx 1) 글자모양이 오염됨 — char_shapes.start_pos 미시프트"
         );
     }
 }

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -457,6 +457,52 @@ impl Paragraph {
     }
 
     /// char_offset 위치에 텍스트를 삽입한다.
+    /// 인라인 컨트롤(각주/미주/수식/새 번호 등, 8 code unit)을 char_offset 위치에 삽입할 때
+    /// 문단 메타데이터를 일괄 시프트한다.
+    ///
+    /// `char_offsets[safe_offset..]` 를 +8 하고, 삽입 지점(UTF-16) 이후의
+    /// `char_shapes.start_pos` 와 `range_tags.start/end` 도 +8 시프트한다. 종전에는
+    /// 각 삽입 경로가 char_offsets 만 밀고 char_shapes/range_tags 를 그대로 둬서, 삽입
+    /// 지점 이후 글자모양 run 경계가 텍스트와 어긋났다(글자모양 오염). `insert_text_at`
+    /// 의 시프트 규약과 동형이다.
+    pub(crate) fn shift_for_inline_control_insert(&mut self, char_offset: usize) {
+        if self.char_offsets.is_empty() {
+            return;
+        }
+        let text_len = self.text.chars().count();
+        let safe_offset = char_offset.min(text_len);
+        // 컨트롤이 삽입되는 UTF-16 위치 — char_offsets 시프트 전에 계산한다.
+        let insert_pos: u32 = if safe_offset < self.char_offsets.len() {
+            self.char_offsets[safe_offset]
+        } else {
+            let last_idx = self.char_offsets.len() - 1;
+            let last_w = self
+                .text
+                .chars()
+                .nth(last_idx)
+                .map(|c| if (c as u32) > 0xFFFF { 2 } else { 1 })
+                .unwrap_or(1);
+            self.char_offsets[last_idx] + last_w
+        };
+        for co in self.char_offsets[safe_offset..].iter_mut() {
+            *co += 8;
+        }
+        // 문단 시작(pos 0)에 고정된 첫 스타일은 유지(insert_text_at 과 동일).
+        for cs in &mut self.char_shapes {
+            if cs.start_pos > insert_pos || (cs.start_pos == insert_pos && cs.start_pos > 0) {
+                cs.start_pos += 8;
+            }
+        }
+        for rt in &mut self.range_tags {
+            if rt.start >= insert_pos {
+                rt.start += 8;
+            }
+            if rt.end >= insert_pos {
+                rt.end += 8;
+            }
+        }
+    }
+
     ///
     /// char_offset은 Rust 문자(char) 인덱스이다 (바이트 인덱스가 아님).
     /// 삽입 후 char_offsets, char_shapes, line_segs, char_count가 자동 갱신된다.


### PR DESCRIPTION
## 요약

`insert_footnote_native` / `insert_endnote_native`(note.rs) · `insert_equation_native`(equation.rs) · `insert_new_number_native`(common.rs) — 인라인 컨트롤 삽입 4경로가 `char_offsets[safe_offset..]`를 `+8`(컨트롤 8 code unit) 시프트하면서 **`char_shapes[i].start_pos`와 `range_tags`는 그대로 둡니다**. 두 축 모두 같은 UTF-16 code-unit 위치라, 삽입 지점 이후의 **글자모양 run 경계가 텍스트와 어긋나** 굵게/색/글꼴 등이 엉뚱한 글자에 적용됩니다.

정본 `Paragraph::insert_text_at`은 이미 char_shapes/range_tags를 함께 시프트합니다 — 이 command 경로들만 누락했습니다.

## 수정

`insert_text_at`의 시프트 규약과 동형인 공유 헬퍼 **`Paragraph::shift_for_inline_control_insert(char_offset)`**를 추가하고, 4경로의 중복 `char_offsets` 시프트 블록을 이 한 줄 호출로 대체했습니다. 헬퍼는 char_offsets를 밀기 전 UTF-16 삽입 위치를 잡아, char_offsets·char_shapes.start_pos·range_tags를 일관되게 `+8` 시프트합니다(문단 시작 pos 0 고정 스타일은 유지).

## 테스트

`insert_footnote_shifts_char_shapes_with_char_offsets`: text="abcd", runs `[{0→id5},{2→id6}]`, offset 1에 각주 삽입 후 원래 `b`가 여전히 id 5인지 검증. **로컬 RED→GREEN 확인**(헬퍼의 char_shapes 시프트를 끄면 id 6 반환하며 FAILED, 켜면 GREEN). `cargo test --lib --no-run` 컴파일 통과, rustfmt 통과.