### PR TITLE
Task #2279: TAC-모순 host 가산을 sb+sa 정확 모델로 교체 — CS-근사 종결

### DIFF
--- a/src/renderer/typeset.rs
+++ b/src/renderer/typeset.rs
@@ -13982,32 +13982,46 @@ impl TypesetEngine {
             }
         } else if tac_wrap_split {
             st.current_height += table_total_height;
-        } else if let Some(host_line_px) = if st.profile.hwpx_stored_layout()
+        } else if let Some(host_spacing_px) = if st.profile.hwpx_stored_layout()
             && is_last_placed
             && total_lines <= pre_table_end_line + 1
+            && fmt.spacing_before + fmt.spacing_after > 0.5
+            && self
+                .tac_topbottom_conflict_host_line_px(para, table, styles)
+                .is_some()
         {
-            // [#2279 10k] host 빈 줄박스는 **문단당 1개** — 다중 표 문단에서
+            // [#2279 10k] host spacing 가산은 **문단당 1회** — 다중 표 문단에서
             // 표마다 가산하면 중간 표 배치의 fit 이 과대해져 후속 표가 조기
             // 개행된다 (156767148 보도자료 pi7: 표2개 문단, 한글 1쪽 vs +1쪽,
-            // 10k 회귀 +29건 군집의 지배 형상). 마지막 표 배치 시점으로 이연
-            // — 단일 표 문단(36392557 pi27 장제목)은 종전과 동일.
+            // 10k 회귀 +29건 군집의 지배 형상). 마지막 표 배치 시점으로 이연.
             // [#2279 sec0] host 문단에 표 줄 외 추가 줄박스(트레일러 빈 줄)가
-            // 이미 있으면 host 줄박스가 그 줄로 실체화된 것 — 별도 가산하면
-            // 이중 계상으로 분할 유발(36392557 sec0 표지: 표 892.5 + 트레일러
-            // 25.6 = 918.1 로 한글 1쪽인데 +16 가산 시 934.1 > 930.5 분할).
-            self.tac_topbottom_conflict_host_line_px(para, table, styles)
+            // 이미 있으면 그 줄의 fmt 가 spacing 을 계상하므로 제외(36392557
+            // sec0 표지: 표 892.5 + 트레일러 25.6 = 918.1 로 한글 1쪽).
+            Some(fmt.spacing_before + fmt.spacing_after)
         } else {
             None
         } {
-            // [#2279 TAC host] 기계생성 결재문서의 모순 조합(treat_as_char=true +
-            // wrap=자리차지) 장제목/결재표: 한글 fresh 는 host 빈 줄박스(호스트
-            // CS 크기)를 표 **위에** 별도 배치한다 — 36392557 pi27 한글 PDF
-            // 괘선 실측: 표 top = 흐름 + om_top(1.9px) + host 줄박스(20px=15pt).
-            // rhwp 는 lh-포함형(host lh = 표+om)으로만 소비해 표당 ~20px 과소
-            // (92셋 −1쪽 계열의 "TAC host +15~21px" 성분). 가산 후에는 생성기
-            // 압축 anchor 로의 후방 스냅이 성장분을 되돌리지 못하게 dirty 처리.
-            st.current_height += host_line_px + pre_height + table_total_height;
+            // [#2279 sb+α 종결] 기계생성 문서의 TAC-모순(treat_as_char=true +
+            // wrap=자리차지) host 표: 한글 fresh 는 host CS 크기의 "빈 줄박스"가
+            // 아니라 host paraPr 의 **sb+sa 를 순수 가산**한다(α=0) — 재저장
+            // ladder 실측: 36399374 pi4→5 = bare + (pi4.sa 500 + pi5.sb 300)
+            // 정확, pi3(sb/sa=0)→4 = bare, 계열X 보도자료 156745609 host 4개
+            // 전부 bare. 종전 font_size 근사(#2352 CS-근사)는 2557 pi27
+            // (sb 1000)에서 우연히 ±2px 로 맞았던 것. 가산 후에는 생성기 압축
+            // anchor 로의 후방 스냅이 성장분을 되돌리지 못하게 dirty 처리.
+            st.current_height += host_spacing_px + pre_height + table_total_height;
             st.vpos_ladder_dirty = true;
+            // [#2279 sb+α 진단] host spacing 가산 내역. 동작 불변.
+            if std::env::var("RHWP_DIAG_TAC").is_ok() {
+                eprintln!(
+                    "DIAG_HOSTBOX pi={} add={:.1} host_sb={:.1} host_sa={:.1} stored_gap_hu={}",
+                    para_idx,
+                    host_spacing_px,
+                    fmt.spacing_before,
+                    fmt.spacing_after,
+                    para.line_segs.first().map(|s| s.line_spacing).unwrap_or(-1),
+                );
+            }
         } else {
             // [#2097 프로브 기록] 빈 host 자리차지 float(v_off>0)의 흐름 전진에
             // v_off + outer_bottom 을 더하는 기하 정합(82802 pi75: 저장 322.6 =

--- a/tests/issue_2006_1790387_prep_pagination_pin.rs
+++ b/tests/issue_2006_1790387_prep_pagination_pin.rs
@@ -26,11 +26,13 @@ fn page_count_of(rel: &str) -> u32 {
 fn prep_1790387_page_count_pin() {
     let pages = page_count_of("samples/issue2006/1790387_prep_final_report.hwpx");
     assert_eq!(
-        pages, 145,
-        "issue2006 1790387 핀 145쪽 (한글 2022 정답지 146쪽, 잔여 -1). \
-         141→144 는 #2279 TAC host 가산, 144→145 는 자간 글자폭-비례 landing. \
-         실측 {}p — 130p 부근이면 tac 이미지 스택 미분할(#2006) 회귀, \
-         145p 초과 개선 시 핀과 정답지(146)를 갱신할 것.",
+        pages, 144,
+        "issue2006 1790387 핀 144쪽 (한글 2022 정답지 146쪽, 잔여 -2). \
+         141→144 는 #2279 TAC host 가산, 144→145 는 자간 글자폭-비례 landing, \
+         145→144 는 host 가산의 sb+sa 정확 모델 전환(#2279 sb+α 종결) — sb=0 \
+         host 의 font_size 근사 box 가 별건 결손(#1921 텍스트 채움 계열)을 우연 \
+         보정하던 몫이 걷힘. 실측 {}p — 130p 부근이면 tac 이미지 스택 \
+         미분할(#2006) 회귀, 144p 초과 개선 시 핀과 정답지(146)를 갱신할 것.",
         pages
     );
 }


### PR DESCRIPTION
## 요약 (#2279 sb+α 트랙 종결 — #2412 직속 후속)

#2412 머지 직전 준비된 2번째 커밋의 독립 PR 입니다(머지 타이밍과 엇갈려 분리
제출). 한글 COM 재저장 오라클로 코멘트 5013003334 의 sb+α 분해를 완결하고,
TAC-모순 host 의 font_size box 근사(#2352 CS-근사)를 **host paraPr sb+sa 의
정확 가산(α=0)** 으로 교체합니다.

### 실측 근거 (재저장 = 한글 fresh ladder, 신규 COM 수집 3건 + 36399374)

- **36399374**: pi4→5 스텝 = bare + **(pi4.sa 500 + pi5.sb 300)** 정확 일치,
  pi3(sb/sa=0)→4 = bare, pi5→6 = bare + pi6.sb 300. 한글의 host 가산 =
  경계 spacing 순수 가산이며 "host CS 빈 줄박스"는 실재하지 않음.
- **계열X 보도자료 156745609**: host 표 4개 전부 bare(4600+0, 1847+452,
  12171+600, 4096+560) — sb=0 → 가산 0. 종전 box(+~20px×4)는 로고 문단을
  **빈 p2 로 밀어내는 유령 페이지**를 만들고 있었음(한글 PDF 1쪽 확인,
  `output/poc/task2279_advance/156745609_warm.pdf`).
- 2557 pi27 은 sb 1000(13.3px) vs box 20px 이 괘선 오차 안에서 겹쳐 근사가
  #2352 이래 생존해 온 것.

### 반증 기록

sb>0 조건으로 box 를 **억제만** 하는 중간안은 36399374 8→7 −1 반증(sb=0
host 라도 sa 성분은 필요) — 가산량 자체를 sb+sa 로 교체하는 것이 정답.

### 게이트

| 게이트 | 결과 |
|---|---|
| 92 컨트롤셋 | **92/92 (100%) 유지** |
| 10k 모집단 (devel #2412-머지-전 대비 누적) | **FIXED 20 / REGRESSED 0** / BOTH_DIFF 5(오라클 방향 개선 4, 2344111 245쪽 잔차 1) · 정합률 95.41%→**95.51%** |
| nextest (no-fail-fast) | **3281/3281** |
| COM 재수집 오라클 | 156745609=1, 156695381=2, 156761098=5 전부 일치 |
| fmt / clippy -D warnings | clean |

1790387 핀은 145→144 정직 갱신(정답 146): sb=0 host 의 근사 box 가 별건
결손(#1921 텍스트 채움 계열)을 우연 보정하던 몫이 걷힌 것. 상세 계보는
#2279 코멘트 5015461766, #2412 코멘트 5015460189.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
