### PR TITLE
fix(hwpx2hwp): BinData 재정렬 시 표/도형 캡션 그림 bin_data_id 미remap

### DIFF
--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -390,6 +390,9 @@ fn collect_bin_order_from_control(
             for cell in &table.cells {
                 collect_bin_order_from_paragraphs(&cell.paragraphs, bin_count, order, seen);
             }
+            if let Some(caption) = &table.caption {
+                collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
+            }
         }
         Control::Header(header) => {
             collect_bin_order_from_paragraphs(&header.paragraphs, bin_count, order, seen);
@@ -437,6 +440,9 @@ fn collect_bin_order_from_shape(
         if let Some(text_box) = &drawing.text_box {
             collect_bin_order_from_paragraphs(&text_box.paragraphs, bin_count, order, seen);
         }
+        if let Some(caption) = &drawing.caption {
+            collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
+        }
     }
 }
 
@@ -471,6 +477,9 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
             for cell in &mut table.cells {
                 remap_bin_refs_in_paragraphs(&mut cell.paragraphs, remap);
             }
+            if let Some(caption) = &mut table.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         Control::Header(header) => remap_bin_refs_in_paragraphs(&mut header.paragraphs, remap),
         Control::Footer(footer) => remap_bin_refs_in_paragraphs(&mut footer.paragraphs, remap),
@@ -504,6 +513,9 @@ fn remap_bin_refs_in_shape(shape: &mut ShapeObject, remap: &[u16]) {
         remap_bin_ref_in_fill(&mut drawing.fill, remap);
         if let Some(text_box) = &mut drawing.text_box {
             remap_bin_refs_in_paragraphs(&mut text_box.paragraphs, remap);
+        }
+        if let Some(caption) = &mut drawing.caption {
+            remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
         }
     }
 }
@@ -2740,5 +2752,41 @@ mod tests {
         );
         assert_eq!(para.char_shapes[1].start_pos, 9);
         assert_eq!(para.char_shapes[2].start_pos, 16);
+    }
+
+    /// [bin remap 회귀] HWPX→HWP 변환의 BinData 재정렬 시 표 캡션 문단 안의 그림
+    /// bin_data_id 가 remap 되지 않아 캡션 그림이 엉뚱한 이미지로 해석되던 결함.
+    #[test]
+    fn table_caption_picture_bin_ref_is_remapped() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+        use crate::model::table::Table;
+
+        let mut pic = Picture::default();
+        pic.image_attr.bin_data_id = 1;
+        let mut cap_para = Paragraph::default();
+        cap_para.controls.push(Control::Picture(Box::new(pic)));
+        let mut table = Table::default();
+        table.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut ctrl = Control::Table(Box::new(table));
+
+        // remap: bin id 1 → 2
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::Table(table) = &ctrl else {
+            panic!("expected table");
+        };
+        let caption = table.caption.as_ref().unwrap();
+        let Control::Picture(pic) = &caption.paragraphs[0].controls[0] else {
+            panic!("expected caption picture");
+        };
+        assert_eq!(
+            pic.image_attr.bin_data_id, 2,
+            "표 캡션 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
     }
 }


### PR DESCRIPTION
## 요약

HWPX→HWP 변환의 `materialize_hwp5_bin_data_order`는 `bin_data_list`를 재정렬하고 모든 이미지 참조를 remap합니다. 그런데 `collect_bin_order_from_*` / `remap_bin_refs_in_*`가 표 `cells`와 도형 `text_box` 문단만 재귀하고 **캡션 문단(`table.caption` / `drawing.caption`)은 방문하지 않습니다**. 그 결과 캡션에 삽입된 그림의 `image_attr.bin_data_id`가 재정렬 전 값으로 남아, 캡션 그림이 **엉뚱한 이미지(또는 OLE Storage)로 해석**됩니다.

`collect_bin_order_from_control`이 캡션 id를 순서에 넣지 않아 remap 인덱스도 어긋나고, `remap_bin_refs_in_control`/`_shape`가 캡션 Picture의 id를 재작성하지 않는 두 가지가 겹칩니다.

## 수정

4개 함수(collect/remap × control/shape)에 캡션 문단 재귀를 추가했습니다 — 기존 `cells`/`text_box` 처리와 완전히 동형입니다.

## 테스트

`table_caption_picture_bin_ref_is_remapped`: 캡션에 `bin_data_id=1` 그림을 둔 표에 `remap_bin_refs_in_control(remap=[_,2,1])`을 호출해 캡션 그림 id가 `2`로 remap되는지 검증(캡션 미방문 시 `1`로 남아 실패). `cargo test --lib --no-run` 컴파일 통과, 대상 테스트 GREEN, rustfmt 통과.