### PR TITLE
fix(hwp5): 문단 번호 형식(number_format)이 .hwp 저장 시 유실

### DIFF
--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -544,7 +544,12 @@ fn serialize_numbering(numbering: &Numbering) -> Vec<u8> {
     // 수준별(1~7) 문단 머리 정보 + 번호 형식 문자열
     for level in 0..7 {
         let head = &numbering.heads[level];
-        w.write_u32(head.attr).unwrap();
+        // number_format(문단 번호 형식)을 attr 비트 5~8 로 재인코딩한다. 파서는 number_format
+        // 을 (attr>>5)&0xF 로만 복원하므로(parser/doc_info.rs), IR 로 생성된 번호(WASM
+        // create_numbering)처럼 attr=0 이고 number_format 만 세팅된 경우 이를 반영하지 않으면
+        // 저장·재로드 시 모든 수준이 DIGIT(0)로 유실된다. serialize_para_shape 의 attr1 재인코딩과 동형.
+        let attr = (head.attr & !(0x0f << 5)) | ((head.number_format as u32 & 0x0f) << 5);
+        w.write_u32(attr).unwrap();
         w.write_i16(head.width_adjust).unwrap();
         w.write_i16(head.text_distance).unwrap();
         w.write_u32(head.char_shape_id).unwrap();

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -608,6 +608,32 @@ fn test_serialize_numbering_roundtrip() {
     assert_eq!(len, 3);
 }
 
+/// IR 로 생성된 번호(WASM create_numbering)는 attr=0 이고 number_format 만 세팅된다.
+/// serialize_numbering 이 number_format 을 attr 비트 5~8 로 재인코딩하지 않으면 저장·재로드
+/// 시 파서가 number_format=(0>>5)&0xF=0(DIGIT)로 복원해 모든 수준의 번호 형식이 유실된다.
+#[test]
+fn numbering_serializes_number_format_into_attr_bits() {
+    let mut numbering = Numbering::default();
+    numbering.heads[0] = NumberingHead {
+        attr: 0,
+        width_adjust: 0,
+        text_distance: 0,
+        char_shape_id: 0,
+        number_format: 8, // 예: HANGUL_MIXED
+    };
+    numbering.level_formats[0] = "^1.".to_string();
+    numbering.level_start_numbers = [1; 7];
+
+    let data = serialize_numbering(&numbering);
+    let mut r = crate::parser::byte_reader::ByteReader::new(&data);
+    let attr = r.read_u32().unwrap();
+    assert_eq!(
+        (attr >> 5) & 0x0F,
+        8,
+        "number_format 가 attr 비트 5~8 로 방출돼야 재로드 시 형식이 보존된다"
+    );
+}
+
 /// [#1793] BULLET 레코드 직렬화 레이아웃 — 문단 머리 정보는 char_shape_id 포함
 /// 12바이트. char_shape_id 4바이트 누락 시 재파싱에서 bullet_char 오프셋이
 /// 어긋나 글머리표 문자가 NUL 로 손상된다 (HWPX→HWP 저장 후 렌더 손상).


### PR DESCRIPTION
## 요약

`serialize_numbering`(src/serializer/doc_info.rs)이 `head.attr`을 그대로 쓰고 **`NumberingHead.number_format`을 attr 비트 5~8로 재인코딩하지 않습니다**. 파서는 number_format을 `(attr>>5)&0xF`로만 복원하는데(parser/doc_info.rs), IR로 생성된 번호는 이 불변을 깹니다: WASM `create_numbering`/`ensure_default_numbering`은 `NumberingHead { number_format: code, ..Default::default() }`로 만들어 **attr=0**을 남깁니다.

결과: 문단 번호/글머리표 대화상자에서 `가`/`①`/`(1)` 같은 **비-digit 프리셋**을 골라 저장(applyNumbering→applyParaFormat이 raw_stream_dirty를 세워 IR 직렬화 경로 진입)하면, 재로드 시 파서가 `number_format=(0>>5)&0xF=0`(DIGIT)로 복원해 **모든 수준이 `1. 2. 3.`로 유실**됩니다.

`serialize_para_shape`는 자신의 모델 필드를 attr1로 재인코딩하는데(doc_info.rs:605-636) `serialize_numbering`만 누락돼 있었습니다.

## 수정

```rust
let attr = (head.attr & !(0x0f << 5)) | ((head.number_format as u32 & 0x0f) << 5);
w.write_u32(attr).unwrap();
```
(HWPX 파서 header.rs:1858의 인코딩과 동일)

## 회귀 안전 / 테스트

attr과 number_format이 일관된 기존 문서는 재인코딩 값이 동일해 변화 없음 — 기존 `test_serialize_numbering_roundtrip`(attr=0x60/number_format=3) 통과. 신규 `numbering_serializes_number_format_into_attr_bits`(attr=0/number_format=8 → 방출 attr의 비트5~8이 8) 추가. `cargo test --lib numbering` **19 passed**, `--no-run` 컴파일·rustfmt 통과. (수정 없으면 attr=0 방출로 비트=0이 되어 결정적으로 실패.)