### PR TITLE
fix(hwpx): 차례(TableOfContents) 필드가 "TOC" 미파싱으로 왕복 시 Unknown 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4397,7 +4397,9 @@ fn parse_field_type(s: &str) -> FieldType {
         "HYPERLINK" => FieldType::Hyperlink,
         "MEMO" => FieldType::Memo,
         "PRIVATE_INFO" | "PRIVATEINFO" => FieldType::PrivateInfoSecurity,
-        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" => FieldType::TableOfContents,
+        // 직렬화기(serializer/hwpx/field.rs)는 TableOfContents 를 "TOC" 로 방출하므로
+        // 파서도 이를 받아야 hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" | "TOC" => FieldType::TableOfContents,
         _ => FieldType::Unknown,
     }
 }
@@ -7322,5 +7324,16 @@ mod tests {
         let xml = r#"<?xml version="1.0"?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"/>"#;
         let section = parse_hwpx_section(xml).unwrap();
         assert!(section.paragraphs.is_empty());
+    }
+
+    #[test]
+    fn parse_field_type_accepts_toc() {
+        // 직렬화기(hwpx/field.rs)가 방출하는 "TOC" 가 TableOfContents 로 파싱돼야
+        // hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        assert_eq!(parse_field_type("TOC"), FieldType::TableOfContents);
+        assert_eq!(
+            parse_field_type("TABLE_OF_CONTENTS"),
+            FieldType::TableOfContents
+        );
     }
 }


### PR DESCRIPTION
## 요약

HWPX 직렬화기는 `FieldType::TableOfContents`를 `type="TOC"`로 방출하지만(serializer/hwpx/field.rs:186, `write_field_begin`/`field_begin_open_tag` 공용), 파서 `parse_field_type`은 `"TABLE_OF_CONTENTS"`/`"TABLEOFCONTENTS"`만 받고 `"TOC"`는 `_ => FieldType::Unknown`으로 떨어뜨립니다. 그래서 rhwp가 저장한 `.hwpx`를 다시 열면 **차례 필드가 Unknown**이 되어 왕복 보존이 깨집니다(순수 코드로 증명되는 self-inconsistency).

## 수정

`parse_field_type`의 TableOfContents arm에 `"TOC"` 추가.

## 테스트

`parse_field_type_accepts_toc`: `parse_field_type("TOC") == TableOfContents`(및 기존 문자열 유지). `cargo test --lib` 컴파일·GREEN·rustfmt 통과. (arm이 없으면 "TOC"→Unknown으로 결정적 실패.)