### PR TITLE
fix(hwp): 수식 속성 편집 시 크기/위치가 .hwp 저장에서 원복(raw_ctrl_data 미클리어)

### DIFF
--- a/src/document_core/commands/object_ops/equation.rs
+++ b/src/document_core/commands/object_ops/equation.rs
@@ -169,6 +169,12 @@ impl DocumentCore {
             crate::renderer::equation::intrinsic_size_hwp(&eq.script, eq.font_size);
         eq.common.width = width;
         eq.common.height = height;
+
+        // raw_ctrl_data 무효화: serialize_equation_control 은 raw_ctrl_data 가 비어있지 않으면
+        // 원본 CTRL_HEADER 바이트를 그대로 방출한다. 편집한 eq.common(크기/위치/treat_as_char)이
+        // .hwp 저장에 반영되도록 원본 passthrough 를 비운다(table_ops 셀 편집 가드, adapt_equation
+        // 의 hwpx→hwp 변환과 동형). EQEDIT 자식 레코드(script/font)는 IR 로 재생성되므로 무관.
+        eq.raw_ctrl_data.clear();
     }
     pub fn get_equation_properties_native(
         &self,
@@ -462,5 +468,29 @@ impl DocumentCore {
             "{{\"ok\":true,\"paraIdx\":{},\"controlIdx\":{}}}",
             para_idx, insert_idx
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Equation;
+
+    /// .hwp 저장 시 serialize_equation_control 은 raw_ctrl_data 가 비어있지 않으면 원본
+    /// CTRL_HEADER 를 그대로 방출한다. 속성 편집 후 raw_ctrl_data 가 비워지지 않으면
+    /// 크기/위치 편집이 저장에서 원복된다.
+    #[test]
+    fn apply_equation_properties_clears_raw_ctrl_data() {
+        let mut eq = Equation {
+            script: "1 over 2".to_string(),
+            font_size: 1000,
+            raw_ctrl_data: vec![0xAB; 16],
+            ..Default::default()
+        };
+        DocumentCore::apply_equation_properties(&mut eq, 96.0, r#"{"width":5000,"height":4000}"#);
+        assert!(
+            eq.raw_ctrl_data.is_empty(),
+            "apply_equation_properties 후 raw_ctrl_data 가 비워져야 편집이 .hwp 저장에 반영된다"
+        );
     }
 }


### PR DESCRIPTION
## 요약

`apply_equation_properties`(src/document_core/commands/object_ops/equation.rs)가 수식의 `eq.common`(크기·위치·treat_as_char)과 `width/height`를 편집하지만 **`eq.raw_ctrl_data`를 비우지 않습니다**. `.hwp` 저장 시 `serialize_equation_control`은 `raw_ctrl_data`가 비어있지 않으면 원본 `CTRL_HEADER` 바이트를 그대로 방출하므로(`if eq.raw_ctrl_data.is_empty() { serialize_common_obj_attr } else { raw_ctrl_data.clone() }`), **편집한 object box(크기/위치)가 저장→재로드 시 원복**됩니다. (EQEDIT 자식의 script/font는 IR로 재생성돼 살아남지만 CTRL_HEADER geometry는 유실.)

이 정확한 패턴을 표 셀 편집 가드(`table_ops.rs`)와 hwpx→hwp 변환(`adapt_equation`, hwpx_to_hwp.rs:1150)은 이미 처리합니다 — 네이티브 편집 경로만 누락됐습니다.

## 수정

`apply_equation_properties` 끝에서 `eq.raw_ctrl_data.clear();` (`serialize_common_obj_attr`가 편집된 `eq.common`에서 CTRL_HEADER를 재생성). `parse_common_obj_attr`가 `common.attr`와 후행 `raw_extra`를 잡아 재방출하므로 무손실입니다.

## 테스트

`apply_equation_properties_clears_raw_ctrl_data`: raw_ctrl_data를 채운 수식에 속성 편집 후 비워짐을 검증. `cargo test --lib --no-run` **컴파일 통과**, rustfmt 통과. (로컬 PC의 Smart App Control이 새 테스트 바이너리 실행을 차단(os error 4551)해 로컬 실행은 못 했으나, clear()는 무조건 실행돼 결정적이며 CI에서 검증됩니다.)