### PR TITLE
fix(hwpx): 필드 타입 문자열을 OWPML 스키마 표기로 정렬(DOC_DATE/USER_INFO/SUMMERY)

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4392,7 +4392,7 @@ fn parse_field_type(s: &str) -> FieldType {
         "CROSSREF" => FieldType::CrossRef,
         "FORMULA" => FieldType::Formula,
         "CLICK_HERE" | "CLICKHERE" => FieldType::ClickHere,
-        "SUMMARY" => FieldType::Summary,
+        "SUMMARY" | "SUMMERY" => FieldType::Summary,
         "USER_INFO" | "USERINFO" => FieldType::UserInfo,
         "HYPERLINK" => FieldType::Hyperlink,
         "MEMO" => FieldType::Memo,

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -171,15 +171,15 @@ fn field_type_str(t: FieldType) -> &'static str {
     match t {
         Unknown => "UNKNOWN",
         Date => "DATE",
-        DocDate => "DOCDATE",
+        DocDate => "DOC_DATE",
         Path => "PATH",
         Bookmark => "BOOKMARK",
         MailMerge => "MAILMERGE",
         CrossRef => "CROSSREF",
         Formula => "FORMULA",
         ClickHere => "CLICK_HERE",
-        Summary => "SUMMARY",
-        UserInfo => "USERINFO",
+        Summary => "SUMMERY", // OWPML 스키마의 실제 표기(한컴 오탈자). schema.xml:2707
+        UserInfo => "USER_INFO",
         Hyperlink => "HYPERLINK",
         Memo => "MEMO",
         PrivateInfoSecurity => "PRIVATE_INFO",
@@ -253,5 +253,14 @@ mod tests {
         assert_eq!(field_type_str(FieldType::Bookmark), "BOOKMARK");
         assert_eq!(field_type_str(FieldType::Date), "DATE");
         assert_eq!(field_type_str(FieldType::TableOfContents), "TOC");
+    }
+
+    #[test]
+    fn field_type_str_matches_owpml_schema() {
+        // OWPML ParaList schema.xml(2707-2710)의 실제 enum 표기와 일치해야 한컴이 인식한다.
+        // (종전 DOCDATE/USERINFO/SUMMARY 는 스키마에 없어 한컴이 필드 타입을 잃었다.)
+        assert_eq!(field_type_str(FieldType::DocDate), "DOC_DATE");
+        assert_eq!(field_type_str(FieldType::UserInfo), "USER_INFO");
+        assert_eq!(field_type_str(FieldType::Summary), "SUMMERY");
     }
 }


### PR DESCRIPTION
## 요약

HWPX `field_type_str`가 `DocDate`/`UserInfo`/`Summary`를 각각 `"DOCDATE"`/`"USERINFO"`/`"SUMMARY"`로 방출하지만, 권위 OWPML ParaList 스키마(리포지토리 내 `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2707-2710`)의 enum은 **`DOC_DATE`/`USER_INFO`/`SUMMERY`**(한컴의 실제 오탈자 포함)입니다. 스키마에 없는 표기라 한컴이 이 필드 타입들을 인식하지 못합니다.

## 수정

- 직렬화기 `field_type_str`: 세 값을 스키마 표기(`DOC_DATE`/`USER_INFO`/`SUMMERY`)로 정렬.
- 파서 `parse_field_type`: Summary arm에 `"SUMMERY"` 추가. (DocDate/UserInfo는 이미 `DOC_DATE|DOCDATE`, `USER_INFO|USERINFO`를 모두 수용하므로 rhwp 자기 왕복 안 깨짐; 구 표기도 leniency로 유지.)

리포지토리 내 스키마로 검증되는 변경입니다(한컴 실물 불필요). 기존 `field_type_str_covers_main_variants`(Hyperlink/Bookmark/Date/TOC)는 영향 없음.

## 테스트

`field_type_str_matches_owpml_schema`. `cargo test --lib` **컴파일·GREEN**, rustfmt 통과.