### PR TITLE
fix(hwpx): 중첩 필드 <hp:parameters> 재조립이 불균형 XML 생성

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4741,7 +4741,6 @@ fn parse_field_parameters(
     raw.push('>');
 
     // 현재 열린 파라미터 요소 태그(닫을 때 사용).
-    let mut open_param: Option<String> = None;
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref ce)) => {
@@ -4758,7 +4757,6 @@ fn parse_field_parameters(
                     raw.push('"');
                 }
                 raw.push('>');
-                open_param = Some(tag);
                 if local == b"stringParam" {
                     for attr in ce.attributes().flatten() {
                         if attr.key.as_ref() == b"name" && attr_str(&attr) == "Command" {
@@ -4820,11 +4818,13 @@ fn parse_field_parameters(
                     raw.push_str("</hp:parameters>");
                     break;
                 }
-                if let Some(tag) = open_param.take() {
-                    raw.push_str("</");
-                    raw.push_str(&tag);
-                    raw.push('>');
-                }
+                // 임의 깊이 중첩(listParam 안의 stringParam 등)에서도 균형 잡힌 XML 을
+                // 재조립하도록, 단일 open_param 추적 대신 End 이벤트 자신의 정규화 이름으로 닫는다.
+                // 종전엔 open_param 이 마지막 Start 로 덮여, 바깥 태그의 닫는 태그가 누락됐다.
+                let qn = String::from_utf8_lossy(eename.as_ref());
+                raw.push_str("</");
+                raw.push_str(&qn);
+                raw.push('>');
                 if local == b"stringParam" {
                     in_command = false;
                 } else if local == b"integerParam" {
@@ -6855,6 +6855,37 @@ mod tests {
 
         assert_eq!(field.command, "MEMO/65535/2/1650281184/31247371/user/\\;;");
         assert_eq!(field.memo_index, 2);
+    }
+
+    #[test]
+    fn parse_field_parameters_reassembles_nested_params_balanced() {
+        // 중첩 파라미터(listParam 안의 stringParam). 종전엔 open_param 이 마지막 Start 로
+        // 덮여 바깥 </hp:listParam> 닫는 태그가 누락돼 raw_parameters_xml 이 불균형이었다.
+        let xml = r#"<hp:parameters xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" cnt="1" name=""><hp:listParam cnt="1" name="L"><hp:stringParam name="A">x</hp:stringParam></hp:listParam></hp:parameters>"#;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut field = Field::default();
+
+        loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"parameters" => {
+                    let start = e.to_owned();
+                    parse_field_parameters(&start, &mut reader, &mut field).unwrap();
+                    break;
+                }
+                Event::Eof => panic!("parameters not found"),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        let raw = field.raw_parameters_xml.expect("raw_parameters_xml");
+        assert!(raw.contains("</hp:stringParam>"), "inner close: {raw}");
+        assert!(
+            raw.contains("</hp:listParam>"),
+            "바깥 </hp:listParam> 누락(중첩 불균형): {raw}"
+        );
+        assert!(raw.ends_with("</hp:parameters>"), "params close: {raw}");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

`parse_field_parameters`는 필드의 `<hp:parameters>` XML을 `raw_parameters_xml`로 verbatim 재조립하는데, 여는 태그를 **단일 `open_param: Option<String>`**로 추적합니다. 중첩(예: `<hp:listParam><hp:stringParam>…</hp:stringParam></hp:listParam>`)에서는 안쪽 `stringParam` Start가 `open_param`을 덮어쓰고, 안쪽 End에서 `take()`된 뒤 **바깥 `listParam` End는 `None`을 만나 `</hp:listParam>`이 누락** → 불균형 XML이 저장됩니다.

## 수정

End 브랜치에서 `open_param` 대신 **End 이벤트 자신의 정규화 이름(`ee.name()`)으로 닫습니다**. 임의 깊이 중첩에서 균형 잡힌 XML을 재조립하며, 비중첩 케이스의 출력은 동일합니다. (이제 불필요해진 `open_param` 추적 제거.)

## 테스트

`parse_field_parameters_reassembles_nested_params_balanced`: 중첩 파라미터를 파싱해 `raw_parameters_xml`이 `</hp:stringParam>`·`</hp:listParam>`을 모두 포함하고 `</hp:parameters>`로 끝나는지 검증. `cargo test --lib --no-run` **컴파일 통과(경고 없음)**, rustfmt 통과. (로컬 PC Smart App Control이 새 테스트 바이너리 실행 차단(os error 4551)해 로컬 실행은 못 했으나, 결정적 검증이며 CI에서 확인됩니다.)