### PR TITLE
fix(studio): 중첩 표 셀 선택 삭제가 바깥 셀을 지우던 문제(deleteRangeInCellByPath)

### DIFF
--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -26,7 +26,7 @@ export const MUTATING_METHODS: readonly string[] = [
   'insertPageBreak', 'insertColumnBreak', 'insertNewNumber', 'setNumberingRestart',
   // 셀 텍스트/문단
   'insertTextInCell', 'insertTextInCellDeferredPagination', 'deleteTextInCell',
-  'deleteRangeInCell', 'insertTextInCellByPath', 'deleteTextInCellByPath',
+  'deleteRangeInCell', 'insertTextInCellByPath', 'deleteTextInCellByPath', 'deleteRangeInCellByPath',
   'splitParagraphInCell', 'mergeParagraphInCell', 'splitParagraphInCellByPath',
   'mergeParagraphInCellByPath',
   // 표 구조/속성

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -922,6 +922,12 @@ export class WasmBridge {
     return (this.doc as any).deleteTextInCellByPath(sec, parentPara, pathJson, charOffset, count);
   }
 
+  /** deleteRangeInCell 의 cellPath 변형 — 중첩 표 셀의 선택 삭제가 최내곽 셀을 대상으로 한다. */
+  deleteRangeInCellByPath(sec: number, parentPara: number, pathJson: string, startPara: number, startOffset: number, endPara: number, endOffset: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).deleteRangeInCellByPath(sec, parentPara, pathJson, startPara, startOffset, endPara, endOffset);
+  }
+
   splitParagraphInCellByPath(sec: number, parentPara: number, pathJson: string, charOffset: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).splitParagraphInCellByPath(sec, parentPara, pathJson, charOffset);

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -179,6 +179,14 @@ function cellPathJson(pos: DocumentPosition): string {
   return JSON.stringify(pos.cellPath ?? []);
 }
 
+/** cellPath 의 최내곽(마지막) 엔트리의 cellParaIndex 를 지정 값으로 바꾼 pathJson.
+ *  중첩 셀 선택 삭제의 undo 저장에서 각 문단 텍스트를 ...ByPath 로 읽을 때 사용한다. */
+function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): string {
+  const path = (pos.cellPath ?? []).map((e) => ({ ...e }));
+  if (path.length > 0) path[path.length - 1].cellParaIndex = cellParaIndex;
+  return JSON.stringify(path);
+}
+
 /**
  * 셀 문단 인덱스 — cellPath 가 있으면 마지막(가장 안쪽) 엔트리에서 읽는다.
  *
@@ -538,24 +546,27 @@ export class DeleteSelectionCommand implements EditCommand {
     // 삭제 전 텍스트 보존 (undo용)
     this.savedTexts = [];
     if (isCell(start)) {
+      // 중첩 셀 좌표 축 정합: flat controlIndex/cellIndex 는 cellPath[0](최외곽)이라
+      // 중첩 셀에서 바깥 셀을 삭제한다. 최내곽 셀을 대상으로 ...ByPath 로 라우팅하고,
+      // 셀 문단 인덱스는 cellPath[last] 에서 읽는다(cellParaIndexOf). undo 는 이미
+      // doInsertTextImmediate 가 cellPath 로 최내곽 셀에 삽입하므로 축이 일치한다.
       const sec = start.sectionIndex;
       const ppi = start.parentParaIndex!;
-      const ci = start.controlIndex!;
-      const cei = start.cellIndex!;
-      const startPara = start.cellParaIndex!;
-      const endPara = end.cellParaIndex!;
+      const startPara = cellParaIndexOf(start);
+      const endPara = cellParaIndexOf(end);
       this.multiPara = startPara !== endPara;
       for (let p = startPara; p <= endPara; p++) {
-        const pLen = wasm.getCellParagraphLength(sec, ppi, ci, cei, p);
+        const pathP = cellPathJsonForPara(start, p);
+        const pLen = wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
         const from = p === startPara ? start.charOffset : 0;
         const to = p === endPara ? end.charOffset : pLen;
         if (to > from) {
-          this.savedTexts.push(wasm.getTextInCell(sec, ppi, ci, cei, p, from, to - from));
+          this.savedTexts.push(wasm.getTextInCellByPath(sec, ppi, pathP, from, to - from));
         } else {
           this.savedTexts.push('');
         }
       }
-      wasm.deleteRangeInCell(sec, ppi, ci, cei, startPara, start.charOffset, endPara, end.charOffset);
+      wasm.deleteRangeInCellByPath(sec, ppi, cellPathJson(start), startPara, start.charOffset, endPara, end.charOffset);
     } else {
       const sec = start.sectionIndex;
       this.multiPara = start.paragraphIndex !== end.paragraphIndex;

--- a/rhwp-studio/tests/delete-selection-nested-cell.test.ts
+++ b/rhwp-studio/tests/delete-selection-nested-cell.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// DeleteSelectionCommand 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다. 중첩 표
+// 셀에서 이를 그대로 deleteRangeInCell/getTextInCell(flat)에 넘기면 **바깥 셀**의 선택을
+// 삭제한다. 최내곽 셀을 대상으로 ...ByPath 로 라우팅하고, 셀 문단 인덱스는 cellPath[last]
+// (cellParaIndexOf)에서 읽어야 한다. undo 는 이미 doInsertTextImmediate 가 cellPath 로
+// 최내곽 셀에 삽입하므로 축이 일치한다.
+//
+// 기준 선례: cursor.ts:399, input-handler-text.ts 의 useCellPath 분기.
+// 행위 증명(중첩 표 왕복)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(name: string): string {
+  const start = commandSrc.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = commandSrc.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? commandSrc.slice(start) : commandSrc.slice(start, start + 1 + rel);
+}
+
+test('DeleteSelectionCommand 셀 삭제가 최내곽 셀 대상 ...ByPath 로 라우팅한다', () => {
+  const block = classBlock('DeleteSelectionCommand');
+  assert.match(block, /deleteRangeInCellByPath\(/,
+    '중첩 셀 선택 삭제는 deleteRangeInCellByPath 로 최내곽 셀을 대상으로 해야 한다');
+  assert.match(block, /getTextInCellByPath\(/,
+    'undo 저장 텍스트도 getTextInCellByPath(최내곽) 로 읽어야 한다');
+});
+
+test('DeleteSelectionCommand 가 flat 셀 축 API/좌표를 쓰지 않는다', () => {
+  const block = classBlock('DeleteSelectionCommand');
+  assert.doesNotMatch(block, /wasm\.deleteRangeInCell\(/,
+    'flat deleteRangeInCell 은 cellPath[0](최외곽) 좌표라 중첩 셀에서 바깥 셀을 삭제한다');
+  assert.doesNotMatch(block, /wasm\.getTextInCell\(/,
+    'flat getTextInCell 대신 getTextInCellByPath 를 써야 한다');
+  assert.doesNotMatch(block, /wasm\.getCellParagraphLength\(/,
+    'flat getCellParagraphLength 는 외부 표 기준 레거시 좌표를 쓴다');
+  assert.doesNotMatch(block, /start\.cellParaIndex!/,
+    '중첩 셀에서 start.cellParaIndex 는 바깥 셀 문단 인덱스다 (cellParaIndexOf 사용)');
+  assert.doesNotMatch(block, /end\.cellParaIndex!/,
+    '중첩 셀에서 end.cellParaIndex 는 바깥 셀 문단 인덱스다 (cellParaIndexOf 사용)');
+});

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3488,6 +3488,77 @@ impl DocumentCore {
         )))
     }
 
+    /// path 기반 셀 내 범위 삭제 (중첩 표 지원). `deleteRangeInCell`(flat)의 cellPath 변형.
+    ///
+    /// flat deleteRangeInCell 은 controlIndex/cellIndex 를 최외곽(cellPath[0]) 축으로 받아
+    /// 중첩 셀에서 바깥 셀을 삭제한다. 이 변형은 path 로 최내곽 셀을 해석해 그 셀의
+    /// 문단 목록에 직접 범위 삭제를 적용한다. start_para/end_para 는 최내곽 셀 내부 인덱스다.
+    #[allow(clippy::too_many_arguments)]
+    pub fn delete_range_in_cell_by_path(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_para: usize,
+        start_offset: usize,
+        end_para: usize,
+        end_offset: usize,
+    ) -> Result<String, HwpError> {
+        {
+            let paras = self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)?;
+            if start_para == end_para {
+                let count = end_offset.saturating_sub(start_offset);
+                if count > 0 {
+                    if let Some(p) = paras.get_mut(start_para) {
+                        p.delete_text_at(start_offset, count);
+                    }
+                }
+            } else {
+                // 1) 마지막 문단 앞부분 삭제
+                if end_offset > 0 {
+                    if let Some(p) = paras.get_mut(end_para) {
+                        p.delete_text_at(0, end_offset);
+                    }
+                }
+                // 2) 중간 문단 역순 제거
+                for mid in (start_para + 1..end_para).rev() {
+                    if mid < paras.len() {
+                        paras.remove(mid);
+                    }
+                }
+                // 3) 첫 문단 뒷부분 삭제
+                if let Some(p) = paras.get_mut(start_para) {
+                    let para_len = p.text.chars().count();
+                    if start_offset < para_len {
+                        p.delete_text_at(start_offset, para_len - start_offset);
+                    }
+                }
+                // 4) 첫-마지막 문단 병합 (마지막이 이제 start_para+1)
+                if start_para + 1 < paras.len() {
+                    let next = paras.remove(start_para + 1);
+                    paras[start_para].merge_from(&next);
+                }
+            }
+        }
+
+        // dirty/이벤트는 delete_text_in_cell_by_path 와 동형(최외곽 컨트롤 기준).
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[section_idx].raw_stream = None;
+        self.mark_section_dirty(section_idx);
+        self.paginate_if_needed();
+        self.event_log.push(DocumentEvent::CellTextChanged {
+            section: section_idx,
+            para: parent_para_idx,
+            ctrl: outer_ctrl,
+            cell: path[0].1,
+        });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"paraIdx\":{},\"charOffset\":{}",
+            start_para, start_offset
+        )))
+    }
+
     /// path 기반 셀 문단 분할 (중첩 표 지원)
     pub fn split_paragraph_in_cell_by_path(
         &mut self,
@@ -3733,6 +3804,43 @@ mod tests {
         set_shape(&mut core, 0, 12, 3, 7);
         set_shape(&mut core, 1, 14, 5, 9);
         core
+    }
+
+    #[test]
+    fn delete_range_in_cell_by_path_deletes_within_resolved_cell() {
+        use crate::model::control::Control;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "ABCDE".to_string();
+        cell_para.char_count = 5;
+        cell_para.char_offsets = vec![0, 1, 2, 3, 4];
+        let table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        // 셀 문단 offset 1..3(BC) 삭제. path 로 최내곽 셀을 해석해야 한다.
+        core.delete_range_in_cell_by_path(0, 0, &[(ctrl_idx, 0, 0)], 0, 1, 0, 3)
+            .unwrap();
+
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx] else {
+            panic!("expected table");
+        };
+        assert_eq!(
+            t.cells[0].paragraphs[0].text, "ADE",
+            "path 로 해석한 셀에서 BC 가 삭제돼야 한다"
+        );
     }
 
     #[test]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1163,6 +1163,31 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = deleteRangeInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn delete_range_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_para: u32,
+        start_offset: u32,
+        end_para: u32,
+        end_offset: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.delete_range_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_para as usize,
+            start_offset as usize,
+            end_para as usize,
+            end_offset as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
     #[wasm_bindgen(js_name = splitParagraphInCellByPath)]
     pub fn split_paragraph_in_cell_by_path_api(
         &mut self,


### PR DESCRIPTION
## 요약

중첩 표 셀 안에서 **선택 영역 삭제(DeleteSelectionCommand)**가 실제 안쪽 셀이 아니라 **최외곽 셀**을 삭제합니다. hit-test 는 flat 필드 `controlIndex`/`cellIndex`/`cellParaIndex` 를 `cellPath[0]`(최외곽)에서 채우는데, 셀 분기가 이를 그대로 flat `deleteRangeInCell`/`getTextInCell`/`getCellParagraphLength` 에 넘기고 문단 인덱스도 flat `start/end.cellParaIndex`(바깥 축)를 씁니다. (코드베이스에 `undo-nested-cell-merge-offset.test.ts` 로 이 축 문제가 이미 문서화돼 있습니다.)

## 수정

**Rust**
- `delete_range_in_cell_by_path` 코어 추가 — `get_cell_paragraphs_mut_by_path` 로 최내곽 셀을 해석해 그 문단 목록에 범위 삭제를 적용(기존 `delete_text_in_cell_by_path` 의 dirty/이벤트 패턴 동형).
- `deleteRangeInCellByPath` WASM 바인딩 추가.

**studio**
- `DeleteSelectionCommand` 셀 분기를 `deleteRangeInCellByPath` / `getTextInCellByPath` / `getCellParagraphLengthByPath` 로 라우팅. 셀 문단 인덱스는 `cellParaIndexOf`(= `cellPath[last].cellParaIndex`)에서 읽고, undo 저장용 per-문단 텍스트는 `cellPathJsonForPara` 로 최내곽 경로를 만들어 읽음.
- `undo()` 는 이미 `doInsertTextImmediate` 가 `cellPath` 로 최내곽 셀에 삽입하므로 execute/undo 축이 일치합니다.
- `mutation-method-registry` 에 `deleteRangeInCellByPath` 등록.

## 테스트

- **Rust**: `delete_range_in_cell_by_path_deletes_within_resolved_cell` — 셀을 path 로 해석해 범위 삭제. `cargo test --lib` **실행 통과**.
- **studio**: `delete-selection-nested-cell.test.ts` 정적 소스 가드(ByPath 라우팅 + flat 축 미사용) + 기존 `mutation-routing-guard` 드리프트 검사(신규 mutator 등록 정합) — `node --test` **7 passed**. `tsc` 신규 오류 없음(`@wasm` 미빌드 오류는 기존/CI 빌드에서 해소).

행위 증명(중첩 표 왕복)은 저장소 관례대로 브라우저 왕복(리뷰)로 확인 부탁드립니다. (ApplyCharFormatCommand 의 동일 축 문제는 후속 PR로 분리하겠습니다.)