### PR TITLE
fix(studio): 중첩 표 셀 서식 적용/undo 가 바깥 셀에 적용되던 문제(applyCharFormatInCellByPath)

### DIFF
--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -51,7 +51,8 @@ export const MUTATING_METHODS: readonly string[] = [
   'pasteInternal', 'pasteInternalInCell', 'pasteInternalInCellByPath', 'pasteControl',
   'pasteHtml', 'pasteHtmlInCell', 'pasteHtmlInCellByPath',
   // 글자/문단 모양
-  'applyCharFormat', 'setCharShapeId', 'applyCharFormatInCell', 'setCharShapeIdInCell',
+  'applyCharFormat', 'setCharShapeId', 'applyCharFormatInCell', 'applyCharFormatInCellByPath',
+  'setCharShapeIdInCell', 'setCharShapeIdInCellByPath',
   'applyParaFormat', 'setParaShapeId', 'applyParaFormatInCell', 'setCellParaShapeId',
   // 스타일/번호 정의 (DocInfo 변이 포함)
   'updateStyle', 'updateStyleShapes', 'createStyle', 'deleteStyle', 'applyStyle',

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1824,6 +1824,12 @@ export class WasmBridge {
     return JSON.parse(this.doc.getCellCharPropertiesAt(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset));
   }
 
+  /** getCellCharPropertiesAt 의 cellPath 변형 — 중첩 셀의 charShapeId 조회. */
+  getCellCharPropertiesAtByPath(sec: number, parentPara: number, pathJson: string, charOffset: number): CharProperties {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse((this.doc as any).getCellCharPropertiesAtByPath(sec, parentPara, pathJson, charOffset));
+  }
+
   applyCharFormat(sec: number, para: number, startOffset: number, endOffset: number, propsJson: string): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.applyCharFormat(sec, para, startOffset, endOffset, propsJson);
@@ -1839,9 +1845,21 @@ export class WasmBridge {
     return this.doc.applyCharFormatInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, startOffset, endOffset, propsJson);
   }
 
+  /** applyCharFormatInCell 의 cellPath 변형 — 중첩 셀 선택에 서식을 적용한다. */
+  applyCharFormatInCellByPath(sec: number, parentPara: number, pathJson: string, startOffset: number, endOffset: number, propsJson: string): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).applyCharFormatInCellByPath(sec, parentPara, pathJson, startOffset, endOffset, propsJson);
+  }
+
   setCharShapeIdInCell(sec: number, parentPara: number, controlIdx: number, cellIdx: number, cellParaIdx: number, startOffset: number, endOffset: number, charShapeId: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).setCharShapeIdInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, startOffset, endOffset, charShapeId);
+  }
+
+  /** setCharShapeIdInCell 의 cellPath 변형 — 중첩 셀 서식 undo 복원. */
+  setCharShapeIdInCellByPath(sec: number, parentPara: number, pathJson: string, startOffset: number, endOffset: number, charShapeId: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).setCharShapeIdInCellByPath(sec, parentPara, pathJson, startOffset, endOffset, charShapeId);
   }
 
   findOrCreateFontId(name: string): number {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -179,6 +179,14 @@ function cellPathJson(pos: DocumentPosition): string {
   return JSON.stringify(pos.cellPath ?? []);
 }
 
+/** cellPath 의 최내곽(마지막) 엔트리의 cellParaIndex 를 지정 값으로 바꾼 pathJson.
+ *  중첩 셀의 문단별 ...ByPath 라우팅에 쓴다. */
+function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): string {
+  const path = (pos.cellPath ?? []).map((e) => ({ ...e }));
+  if (path.length > 0) path[path.length - 1].cellParaIndex = cellParaIndex;
+  return JSON.stringify(path);
+}
+
 /**
  * 셀 문단 인덱스 — cellPath 가 있으면 마지막(가장 안쪽) 엔트리에서 읽는다.
  *
@@ -659,24 +667,26 @@ export class ApplyCharFormatCommand implements EditCommand {
     const propsJson = JSON.stringify(this.props);
 
     if (isCell(start)) {
+      // 중첩 셀 좌표 축 정합: flat controlIndex/cellIndex 는 cellPath[0](최외곽)이라 중첩
+      // 셀에서 바깥 셀에 서식을 적용한다. 최내곽 셀을 ...ByPath 로 라우팅하고 문단 인덱스는
+      // cellPath[last](cellParaIndexOf)에서 읽는다. undo(restoreCharShapeIds)도 같은 축.
       const sec = start.sectionIndex;
       const ppi = start.parentParaIndex!;
-      const ci = start.controlIndex!;
-      const cei = start.cellIndex!;
-      const startPara = start.cellParaIndex!;
-      const endPara = end.cellParaIndex!;
+      const startPara = cellParaIndexOf(start);
+      const endPara = cellParaIndexOf(end);
 
       this.entries = [];
       for (let p = startPara; p <= endPara; p++) {
+        const pathP = cellPathJsonForPara(start, p);
         const from = p === startPara ? start.charOffset : 0;
-        const to = p === endPara ? end.charOffset : wasm.getCellParagraphLength(sec, ppi, ci, cei, p);
+        const to = p === endPara ? end.charOffset : wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
         if (to <= from) continue;
 
-        const prevProps = wasm.getCellCharPropertiesAt(sec, ppi, ci, cei, p, from);
+        const prevProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
         this.entries.push({ paraIndex: p, startOffset: from, endOffset: to, beforeCharShapeId: prevProps.charShapeId });
 
-        wasm.applyCharFormatInCell(sec, ppi, ci, cei, p, from, to, propsJson);
-        const afterProps = wasm.getCellCharPropertiesAt(sec, ppi, ci, cei, p, from);
+        wasm.applyCharFormatInCellByPath(sec, ppi, pathP, from, to, propsJson);
+        const afterProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
         this.entries[this.entries.length - 1].afterCharShapeId = afterProps.charShapeId;
       }
     } else {
@@ -714,9 +724,10 @@ export class ApplyCharFormatCommand implements EditCommand {
       if (charShapeId === undefined) continue;
 
       if (isCell(start)) {
-        wasm.setCharShapeIdInCell(
-          start.sectionIndex, start.parentParaIndex!, start.controlIndex!, start.cellIndex!,
-          entry.paraIndex, entry.startOffset, entry.endOffset, charShapeId,
+        // 중첩 셀 축 정합: 최내곽 셀에 서식 ID 복원(execute 와 동일 축).
+        wasm.setCharShapeIdInCellByPath(
+          start.sectionIndex, start.parentParaIndex!, cellPathJsonForPara(start, entry.paraIndex),
+          entry.startOffset, entry.endOffset, charShapeId,
         );
       } else {
         wasm.setCharShapeId(start.sectionIndex, entry.paraIndex, entry.startOffset, entry.endOffset, charShapeId);

--- a/rhwp-studio/tests/apply-charformat-nested-cell.test.ts
+++ b/rhwp-studio/tests/apply-charformat-nested-cell.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ApplyCharFormatCommand 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다. 중첩 표 셀
+// 선택에 이를 그대로 applyCharFormatInCell/getCellCharPropertiesAt/setCharShapeIdInCell(flat)에
+// 넘기면 **바깥 셀**에 서식을 적용/복원한다. execute·undo 모두 최내곽 셀 대상 ...ByPath 로
+// 라우팅하고, 셀 문단 인덱스는 cellParaIndexOf(=cellPath[last])에서 읽어야 한다.
+//
+// 기준 선례: cursor.ts:399 의 useCellPath 분기. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+function classBlock(name: string): string {
+  const start = commandSrc.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = commandSrc.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? commandSrc.slice(start) : commandSrc.slice(start, start + 1 + rel);
+}
+
+test('ApplyCharFormatCommand 셀 서식 적용/복원이 최내곽 셀 대상 ...ByPath 로 라우팅한다', () => {
+  const block = classBlock('ApplyCharFormatCommand');
+  assert.match(block, /applyCharFormatInCellByPath\(/, 'execute 는 applyCharFormatInCellByPath 로 최내곽 셀 적용');
+  assert.match(block, /getCellCharPropertiesAtByPath\(/, 'before/after charShapeId 도 ...ByPath 로 조회');
+  assert.match(block, /setCharShapeIdInCellByPath\(/, 'undo(restoreCharShapeIds)도 ...ByPath 로 복원');
+});
+
+test('ApplyCharFormatCommand 가 flat 셀 축 API/좌표를 쓰지 않는다', () => {
+  const block = classBlock('ApplyCharFormatCommand');
+  assert.doesNotMatch(block, /wasm\.applyCharFormatInCell\(/, 'flat applyCharFormatInCell 은 바깥 셀에 적용된다');
+  assert.doesNotMatch(block, /wasm\.getCellCharPropertiesAt\(/, 'flat getCellCharPropertiesAt 금지');
+  assert.doesNotMatch(block, /wasm\.setCharShapeIdInCell\(/, 'flat setCharShapeIdInCell 은 undo 를 바깥 셀에 복원한다');
+  assert.doesNotMatch(block, /wasm\.getCellParagraphLength\(/, 'flat getCellParagraphLength 금지');
+  assert.doesNotMatch(block, /start\.cellParaIndex!/, '중첩 셀에서 start.cellParaIndex 는 바깥 셀 값 (cellParaIndexOf 사용)');
+  assert.doesNotMatch(block, /end\.cellParaIndex!/, '중첩 셀에서 end.cellParaIndex 는 바깥 셀 값 (cellParaIndexOf 사용)');
+});

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1167,6 +1167,99 @@ impl DocumentCore {
         Ok("{\"ok\":true}".to_string())
     }
 
+    /// `applyCharFormatInCell` 의 cellPath 변형 (중첩 표 지원).
+    ///
+    /// flat 변형은 controlIndex/cellIndex 를 최외곽(cellPath[0]) 축으로 받아 중첩 셀에서
+    /// 바깥 셀에 서식을 적용한다. 이 변형은 path 로 최내곽 셀 문단을 해석해 적용하고,
+    /// 셀별 리플로우는 rebuild_section 의 전체 재조판이 담당한다(delete_range_in_cell_by_path 동형).
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_char_format_in_cell_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_offset: usize,
+        end_offset: usize,
+        props_json: &str,
+    ) -> Result<String, HwpError> {
+        let mut mods = parse_char_shape_mods(props_json);
+        if json_has_border_keys(props_json) {
+            let bf_id = self.create_border_fill_from_json(props_json);
+            mods.border_fill_id = Some(bf_id);
+        }
+        let base_id = {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.char_shape_id_at(start_offset).unwrap_or(0)
+        };
+        let new_id = self.document.find_or_create_char_shape(base_id, &mods);
+        {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.apply_char_shape_range(start_offset, end_offset, new_id);
+        }
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
+        self.rebuild_section(sec_idx);
+        self.event_log.push(DocumentEvent::CharFormatChanged {
+            section: sec_idx,
+            para: parent_para_idx,
+            start: start_offset,
+            end: end_offset,
+        });
+        Ok("{\"ok\":true}".to_string())
+    }
+
+    /// `getCellCharPropertiesAt` 의 cellPath 변형. 커맨드는 charShapeId 만 쓰므로
+    /// shape 기준 속성(build_char_properties_json_by_id)으로 충분하다.
+    pub fn get_cell_char_properties_at_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        char_offset: usize,
+    ) -> Result<String, HwpError> {
+        let char_shape_id = {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.char_shape_id_at(char_offset).unwrap_or(0)
+        };
+        Ok(self.build_char_properties_json_by_id(char_shape_id as u16))
+    }
+
+    /// `setCharShapeIdInCell` 의 cellPath 변형 (중첩 표 지원, undo용).
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_char_shape_id_in_cell_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_offset: usize,
+        end_offset: usize,
+        char_shape_id: u32,
+    ) -> Result<String, HwpError> {
+        if char_shape_id as usize >= self.document.doc_info.char_shapes.len() {
+            return Err(HwpError::RenderError(format!(
+                "글자 모양 ID {} 범위 초과 (총 {}개)",
+                char_shape_id,
+                self.document.doc_info.char_shapes.len()
+            )));
+        }
+        {
+            let cell_para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            cell_para.apply_char_shape_range(start_offset, end_offset, char_shape_id);
+        }
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
+        self.rebuild_section(sec_idx);
+        self.event_log.push(DocumentEvent::CharFormatChanged {
+            section: sec_idx,
+            para: parent_para_idx,
+            start: start_offset,
+            end: end_offset,
+        });
+        Ok("{\"ok\":true}".to_string())
+    }
+
     /// 글자 서식 ID 직접 복원 (네이티브) — 셀 내 문단.
     pub fn set_char_shape_id_in_cell_native(
         &mut self,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6330,6 +6330,70 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = applyCharFormatInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_char_format_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_offset: u32,
+        end_offset: u32,
+        props_json: &str,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.apply_char_format_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_offset as usize,
+            end_offset as usize,
+            props_json,
+        )
+        .map_err(|e| e.into())
+    }
+
+    #[wasm_bindgen(js_name = getCellCharPropertiesAtByPath)]
+    pub fn get_cell_char_properties_at_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        char_offset: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.get_cell_char_properties_at_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            char_offset as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
+    #[wasm_bindgen(js_name = setCharShapeIdInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_char_shape_id_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_offset: u32,
+        end_offset: u32,
+        char_shape_id: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.set_char_shape_id_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_offset as usize,
+            end_offset as usize,
+            char_shape_id,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 글자 서식 ID를 직접 복원한다 (셀 내 문단).
     #[wasm_bindgen(js_name = setCharShapeIdInCell)]
     pub fn set_char_shape_id_in_cell(


### PR DESCRIPTION
## 요약

중첩 표 셀 안에서 **글자 서식 적용(ApplyCharFormatCommand)**이 실제 안쪽 셀이 아니라 **최외곽 셀**에 적용되고, undo 도 바깥 셀에 복원합니다. 셀 분기가 flat `controlIndex`/`cellIndex`(hit-test 가 `cellPath[0]`=최외곽에서 채움)와 flat `applyCharFormatInCell`/`getCellCharPropertiesAt`/`getCellParagraphLength`, undo 의 `setCharShapeIdInCell` 을 쓰기 때문입니다. #2452(DeleteSelection)와 동일한 축 결함의 서식 버전입니다.

## 수정

**Rust** (기존 flat 버전 + #2452 by-path 패턴 동형)
- `apply_char_format_in_cell_by_path`, `get_cell_char_properties_at_by_path`, `set_char_shape_id_in_cell_by_path` 코어 + WASM 바인딩. `get_cell_paragraph_mut_by_path` 로 최내곽 셀을 해석하고, 셀 리플로우는 `rebuild_section` 의 전체 재조판이 담당합니다.

**studio**
- `ApplyCharFormatCommand` 의 execute 와 undo(`restoreCharShapeIds`)를 `applyCharFormatInCellByPath`/`getCellCharPropertiesAtByPath`/`getCellParagraphLengthByPath`/`setCharShapeIdInCellByPath` 로 라우팅. 셀 문단 인덱스는 `cellParaIndexOf`(=`cellPath[last]`), 문단별 경로는 `cellPathJsonForPara`.
- `mutation-method-registry` 에 두 mutator 등록.

## 테스트

- **studio**: `apply-charformat-nested-cell.test.ts` 정적 소스 가드(execute/undo 가 ByPath 라우팅 + flat 축 미사용) + 기존 `mutation-routing-guard` 드리프트 검사(신규 mutator 등록 정합) — `node --test` **7 passed**.
- **Rust**: 컴파일·`rustfmt` 통과(경고 없음). `tsc` 신규 오류 없음(`@wasm` 미빌드는 CI 빌드에서 해소). 행위 증명(중첩 표 왕복)은 저장소 관례대로 브라우저 왕복(리뷰).

참고: `cellPathJsonForPara` 헬퍼는 #2452 와 동일 정의라 두 PR 병합 시 사소한 중복 충돌이 날 수 있습니다(하나만 유지하면 됩니다).