### PR TITLE
fix(hwpx): 표 textWrap TIGHT/THROUGH 가 파서 arm 누락으로 SQUARE 로 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1612,6 +1612,11 @@ fn parse_table(
             }
             b"textWrap" => {
                 table.common.text_wrap = match attr_str(&attr).as_str() {
+                    // 표 textWrap 파서만 TIGHT/THROUGH arm 이 빠져 있어, 방출측
+                    // (text_wrap_str)이 내는 이 두 값이 SQUARE 로 유실됐다. 도형/그림/차트
+                    // 파서(같은 파일 2228/2795/5681)는 이미 처리하므로 표만 맞춘다.
+                    "TIGHT" => crate::model::shape::TextWrap::Tight,
+                    "THROUGH" => crate::model::shape::TextWrap::Through,
                     "TOP_AND_BOTTOM" => crate::model::shape::TextWrap::TopAndBottom,
                     "BEHIND_TEXT" => crate::model::shape::TextWrap::BehindText,
                     "IN_FRONT_OF_TEXT" => crate::model::shape::TextWrap::InFrontOfText,
@@ -6657,6 +6662,26 @@ mod tests {
         assert_eq!(table.common.attr, 0x082a_2211);
         assert_eq!(table.attr, 0x01);
         assert_eq!(table.raw_table_record_attr, 0x0400_000e);
+    }
+
+    #[test]
+    fn table_textwrap_tight_and_through_survive_roundtrip() {
+        // 표 textWrap="TIGHT"/"THROUGH" 가 파서 arm 누락으로 SQUARE 로 유실되던 결함.
+        // 방출측 text_wrap_str 은 이 두 값을 내므로 왕복 보존돼야 한다.
+        for (s, expect) in [("TIGHT", TextWrap::Tight), ("THROUGH", TextWrap::Through)] {
+            let xml = format!(
+                r#"<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"><hp:p paraPrIDRef="0" styleIDRef="0"><hp:tbl numberingType="TABLE" textWrap="{s}" pageBreak="CELL" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="1000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0" vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:tr><hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="1000"/></hp:tc></hp:tr></hp:tbl></hp:p></hs:sec>"#
+            );
+            let section = parse_hwpx_section(&xml).unwrap();
+            let table = match &section.paragraphs[0].controls[0] {
+                crate::model::control::Control::Table(t) => t,
+                other => panic!("expected table, got {other:?}"),
+            };
+            assert_eq!(
+                table.common.text_wrap, expect,
+                "textWrap={s} 가 {expect:?} 로 파싱돼야 함(SQUARE 유실 방지)"
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## 요약

hwpx 표 파서의 `textWrap` match 에 **`TIGHT`/`THROUGH` arm 이 빠져** 있어, 이 두 값이 `_ => TextWrap::Square` 로 떨어집니다. 방출측 `text_wrap_str`(serializer/hwpx/picture.rs·shape.rs)은 `TIGHT`/`THROUGH` 를 방출하므로, **빽빽하게(Tight)/투과(Through) 배치의 표가 `.hwpx` 왕복 시 어울림(Square)으로 유실**됩니다.

같은 파일의 **도형/그림/차트 textWrap 파서(section.rs:2228/2795/5681)는 이미 `TIGHT`/`THROUGH` 를 처리**합니다 — 표 파서만 동기화에서 누락된 명백한 오탈입니다.

## 수정

표 textWrap match(section.rs:1614)에 `"TIGHT" => Tight`, `"THROUGH" => Through` arm 추가. **순수 additive**라 기존 동작은 불변입니다(`SQUARE` 는 여전히 `_ => Square`, 나머지 값도 그대로).

## 테스트

`table_textwrap_tight_and_through_survive_roundtrip`: `textWrap="TIGHT"`/`"THROUGH"` 표를 파싱해 각각 `Tight`/`Through` 로 파싱되는지 검증(arm 없으면 `Square` 로 실패). `cargo test --lib` **실행 통과**, `rustfmt` 통과.