### PR TITLE
fix(hwpx): 나눔(Split) 정렬이 hwpx 왕복 시 양쪽정렬로 유실

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1944,7 +1944,9 @@ fn parse_alignment(attr: &quick_xml::events::attributes::Attribute) -> Alignment
         "RIGHT" => Alignment::Right,
         "CENTER" => Alignment::Center,
         "DISTRIBUTE" => Alignment::Distribute,
-        "DISTRIBUTE_SPACE" => Alignment::Justify,
+        // 방출측 alignment_str 은 Split(나눔, HWP5 정렬 bit 5) 을 "DISTRIBUTE_SPACE" 로 낸다.
+        // 종전엔 이를 Justify 로 되읽어 나눔 정렬이 hwpx 왕복 시 양쪽정렬로 유실됐다.
+        "DISTRIBUTE_SPACE" => Alignment::Split,
         _ => Alignment::Justify,
     }
 }
@@ -2295,7 +2297,8 @@ mod tests {
         let cases = [
             ("CENTER", Alignment::Center),
             ("DISTRIBUTE", Alignment::Distribute),
-            ("DISTRIBUTE_SPACE", Alignment::Justify),
+            // 방출측이 Split 을 "DISTRIBUTE_SPACE" 로 내므로 되읽기도 Split 이어야 왕복 보존.
+            ("DISTRIBUTE_SPACE", Alignment::Split),
         ];
 
         for (value, expected) in cases {


### PR DESCRIPTION
## 요약

hwpx `parse_alignment` 이 `"DISTRIBUTE_SPACE"` 를 `Alignment::Justify` 로 되읽습니다(parser/hwpx/header.rs:1947). 그러나 방출측 `alignment_str` 은 **`Split`(나눔)을 `"DISTRIBUTE_SPACE"`** 로 냅니다(serializer/hwpx/header.rs:1208). 그래서 **나눔 정렬 문단이 `.hwpx` 저장→재로드 시 양쪽정렬(Justify)로 유실**됩니다.

HWP5 정렬 비트도 `Split=5`, `Distribute=4` 로 명확히 구분되고(parser·serializer `doc_info.rs` 모두 일치), 직렬화기 문자열도 Split→DISTRIBUTE_SPACE 이므로 — **이 파서 arm 하나만 어긋난 자체 불일치**입니다(스펙 모호성 없음).

## 수정

`"DISTRIBUTE_SPACE" => Alignment::Split` (was `Justify`). 종전(버그) 동작을 단언하던 기존 `test_parse_alignment` 케이스도 `Split` 으로 갱신했습니다 — 수정이 없으면 이 테스트가 실패(RED)합니다.

## 테스트

`test_parse_alignment` (`DISTRIBUTE_SPACE` → `Split`). `cargo test --lib` **실행 통과**, `rustfmt` 통과.