### PR TITLE
fix(hwpx): 3D 테두리 선 종류가 hwpx 왕복 시 실선으로 유실

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1975,6 +1975,12 @@ fn parse_border_line_type(attr: &quick_xml::events::attributes::Attribute) -> Bo
         "SLIM_THICK_SLIM" => BorderLineType::ThinThickThinTriple,
         "WAVE" => BorderLineType::Wave,
         "DOUBLE_WAVE" => BorderLineType::DoubleWave,
+        // 방출측 border_line_type_str 은 3D 계열을 이 문자열들로 낸다. 파서가 안 받으면
+        // (_ => Solid) 3D 테두리가 .hwpx 왕복 시 실선으로 유실된다. 변형은 이미 model 에 존재.
+        "THICK3D" => BorderLineType::Thick3D,
+        "THICKREV3D" => BorderLineType::Thick3DReverse,
+        "3D" => BorderLineType::Thin3D,
+        "REV3D" => BorderLineType::Thin3DReverse,
         _ => BorderLineType::Solid,
     }
 }
@@ -2285,6 +2291,30 @@ mod tests {
             for attr in e.attributes().flatten() {
                 if attr.key.as_ref() == b"color" {
                     assert_eq!(parse_color(&attr), 0xFFFFFFFF);
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn parse_border_line_type_accepts_3d_styles() {
+        use crate::model::style::BorderLineType;
+        // 방출측 border_line_type_str 이 내는 3D 계열 문자열이 Solid 로 유실되지 않아야 한다.
+        let cases = [
+            ("THICK3D", BorderLineType::Thick3D),
+            ("THICKREV3D", BorderLineType::Thick3DReverse),
+            ("3D", BorderLineType::Thin3D),
+            ("REV3D", BorderLineType::Thin3DReverse),
+        ];
+        for (value, expected) in cases {
+            let xml = format!(r#"<e type="{value}"/>"#);
+            let mut reader = Reader::from_str(&xml);
+            let mut buf = Vec::new();
+            if let Ok(Event::Empty(ref e)) = reader.read_event_into(&mut buf) {
+                for attr in e.attributes().flatten() {
+                    if attr.key.as_ref() == b"type" {
+                        assert_eq!(parse_border_line_type(&attr), expected, "{value}");
+                    }
                 }
             }
         }


### PR DESCRIPTION
## 요약

`parse_border_line_type`(parser/hwpx/header.rs)이 `DOUBLE_WAVE` 까지만 처리하고 `_ => BorderLineType::Solid` 로 떨어뜨립니다. 방출측 `border_line_type_str`(serializer/hwpx/header.rs:520-523)은 3D 계열을 `"THICK3D"`/`"THICKREV3D"`/`"3D"`/`"REV3D"` 로 내므로, **3D 테두리 선이 `.hwpx` 재로드 시 실선(Solid)으로 유실**됩니다.

변형(`Thick3D`/`Thick3DReverse`/`Thin3D`/`Thin3DReverse`)은 이미 `model/style.rs`에 있고 sibling `parse_border_line_type_code`도 사용합니다 — 문자열 파서 arm만 누락된 것입니다.

## 수정

4개 arm 추가(순수 additive). 테스트: `parse_border_line_type_accepts_3d_styles`. `cargo test --lib` 실행 통과, rustfmt 통과.