### PR TITLE
fix(hwpx): 그림 무늬(Pattern8x8) 효과가 hwpx 왕복 시 RealPic 로 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2464,6 +2464,9 @@ fn parse_picture(
                                         "REAL_PIC" => ImageEffect::RealPic,
                                         "GRAY_SCALE" => ImageEffect::GrayScale,
                                         "BLACK_WHITE" => ImageEffect::BlackWhite,
+                                        // 방출측 image_effect_str 은 Pattern8x8 을 이 문자열로
+                                        // 낸다. 안 받으면 무늬(패턴) 효과가 왕복 시 RealPic 유실.
+                                        "PATTERN_8_8" => ImageEffect::Pattern8x8,
                                         _ => ImageEffect::RealPic,
                                     };
                                 }


### PR DESCRIPTION
## 요약

`parse_picture` 의 `effect` 파서(parser/hwpx/section.rs)가 `REAL_PIC`/`GRAY_SCALE`/`BLACK_WHITE` 만 처리하고 `_ => ImageEffect::RealPic` 로 떨어뜨립니다. 방출측 `image_effect_str`(serializer/hwpx/picture.rs:514)은 `Pattern8x8` 을 `"PATTERN_8_8"` 로 내므로, **그림 무늬(패턴) 효과가 `.hwpx` 재로드 시 RealPic 로 유실**됩니다.

`ImageEffect::Pattern8x8` 은 이미 `model/image.rs:179`에 존재합니다 — 파서 arm만 누락.

## 수정

`"PATTERN_8_8" => ImageEffect::Pattern8x8` arm 추가(기존 3개 arm과 동형, 순수 additive). `cargo test --lib --no-run` 컴파일 통과, rustfmt 통과. (인라인 picture-effect 파스라 격리 테스트 하네스가 없어 컴파일+구조적 확실성으로 검증 — arm 은 결정적. 행위는 CI 통합 빌드/리뷰에서 확인.)