### PR TITLE
fix(hwpx): 탭 리더 이중실선(DOUBLE_SLIM)이 hwpx 왕복 시 NONE 으로 유실

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1612,10 +1612,12 @@ fn parse_tab_item(ce: &quick_xml::events::BytesStart) -> TabItem {
                     "DASH_DOT_DOT" => 5, // 이점쇄선
                     "LONG_DASH" => 6,    // 긴파선
                     "CIRCLE" => 7,       // 원형점선
-                    "DOUBLE_LINE" => 8,  // 이중실선
-                    "THIN_THICK" => 9,   // 얇고 굵은 이중선
-                    "THICK_THIN" => 10,  // 굵고 얇은 이중선
-                    "TRIM" => 11,        // 얇고 굵고 얇은 삼중선
+                    // 방출측 tab_leader_str 은 fill_type 8 을 "DOUBLE_SLIM" 으로 낸다
+                    // (border 명명과 동일). 안 받으면 이중실선 탭 리더가 왕복 시 NONE(0)으로 유실.
+                    "DOUBLE_LINE" | "DOUBLE_SLIM" => 8, // 이중실선
+                    "THIN_THICK" => 9,                  // 얇고 굵은 이중선
+                    "THICK_THIN" => 10,                 // 굵고 얇은 이중선
+                    "TRIM" => 11,                       // 얇고 굵고 얇은 삼중선
                     _ => 0,
                 };
             }
@@ -2287,6 +2289,21 @@ mod tests {
                     assert_eq!(parse_color(&attr), 0xFFFFFFFF);
                 }
             }
+        }
+    }
+
+    #[test]
+    fn parse_tab_item_leader_double_slim_maps_to_8() {
+        // 방출측 tab_leader_str 이 fill_type 8 을 "DOUBLE_SLIM" 으로 내므로 파서도 8 로
+        // 받아야 이중실선 탭 리더가 왕복 보존된다(종전엔 _ => 0/NONE 유실).
+        let xml = r#"<hh:tabItem pos="1000" type="LEFT" leader="DOUBLE_SLIM"/>"#;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        match reader.read_event_into(&mut buf) {
+            Ok(Event::Empty(ref e)) => {
+                assert_eq!(parse_tab_item(e).fill_type, 8, "DOUBLE_SLIM → fill_type 8");
+            }
+            other => panic!("tabItem not parsed: {other:?}"),
         }
     }
 


### PR DESCRIPTION
## 요약

`parse_tab_item` 의 `leader` 파서(parser/hwpx/header.rs)가 fill_type `8`(이중실선)을 `"DOUBLE_LINE"` 에서만 받습니다. 그러나 방출측 `tab_leader_str`(serializer/hwpx/header.rs:839)은 `8` 을 **`"DOUBLE_SLIM"`** 으로 냅니다(borderFill 의 Double 명명과 동일). 그래서 **이중실선 탭 리더가 `.hwpx` 재로드 시 `_ => 0`(NONE)으로 유실**됩니다.

## 수정

`"DOUBLE_LINE" | "DOUBLE_SLIM" => 8` (순수 additive, 기존 `DOUBLE_LINE` 유지). 테스트: `parse_tab_item_leader_double_slim_maps_to_8`. `cargo test --lib` 실행 통과, rustfmt 통과.