### PR TITLE
fix(hwpx): 강조점(symMark)이 파서 no-op 으로 hwpx 재로드 시 유실

### DIFF
--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -573,9 +573,19 @@ fn parse_char_shape(
             b"shadeColor" => cs.shade_color = parse_color(&attr),
             b"useFontSpace" => cs.use_font_space = parse_bool(&attr),
             b"useKerning" => cs.kerning = parse_bool(&attr),
-            // symMark(강조점)은 현재 코퍼스에서 항상 "NONE" 이라 emphasis_dot 기본값
-            // (NONE)과 일치 → 무손실. 비-NONE 값이 발견되면 별도 수집 필요.
-            b"symMark" => {}
+            // symMark(강조점): 방출측 sym_mark_str(cs.emphasis_dot)의 역함수로 파싱한다.
+            // 종전엔 no-op 이라 강조점이 설정된 문서가 hwpx 재로드 시 NONE 으로 유실됐다.
+            b"symMark" => {
+                cs.emphasis_dot = match attr_str(&attr).as_str() {
+                    "DOT_ABOVE" => 1,
+                    "RING_ABOVE" => 2,
+                    "TILDE" => 3,
+                    "CARON" => 4,
+                    "SIDE" => 5,
+                    "COLON" => 6,
+                    _ => 0, // NONE
+                };
+            }
             b"borderFillIDRef" => cs.border_fill_id = parse_u16(&attr),
             _ => {}
         }
@@ -2543,6 +2553,27 @@ mod tests {
         assert_eq!(cs.shadow_color, 0x00C0C0C0);
         assert_eq!(cs.shadow_offset_x, 10);
         assert_eq!(cs.shadow_offset_y, 10);
+    }
+
+    #[test]
+    fn parse_char_pr_captures_sym_mark() {
+        // symMark(강조점)은 종전에 파서가 no-op 으로 무시해 hwpx 재로드 시 NONE 으로 유실됐다
+        // (useKerning[Finding 20]과 동형). 방출측 sym_mark_str 의 역함수로 emphasis_dot 를 보존한다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="1">
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="DOT_ABOVE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(
+            doc_info.char_shapes[0].emphasis_dot, 1,
+            "symMark=DOT_ABOVE 가 emphasis_dot=1 로 파싱돼야 함(NONE 유실 방지)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

hwpx charPr 파서가 `symMark`(강조점)을 `b"symMark" => {}` 로 **완전히 무시**합니다(parser/hwpx/header.rs). 그러나 방출측은 `("symMark", sym_mark_str(cs.emphasis_dot))` 로 강조점을 방출합니다(serializer/hwpx/header.rs:596). 그래서 **강조점이 설정된 문자모양이 `.hwpx` 재로드 시 NONE(0)으로 유실**됩니다. 기존 코드 주석도 "비-NONE 값이 발견되면 별도 수집 필요"로 이 결함을 예고하고 있었습니다.

같은 파일의 `useKerning`(**[Finding 20]**)이 정확히 같은 부류(파서가 속성 무시 → 유실)로 이미 수정된 선례가 있습니다.

## 수정

`sym_mark_str` 의 역함수로 `symMark` 문자열 → `emphasis_dot`(DOT_ABOVE=1, RING_ABOVE=2, TILDE=3, CARON=4, SIDE=5, COLON=6, _ => 0/NONE) 파싱 추가. `"NONE"` 은 기존과 동일하게 0 이라 회귀 없음.

## 테스트

`parse_char_pr_captures_sym_mark`(`symMark="DOT_ABOVE"` → `emphasis_dot=1`). `cargo test --lib` 실행 통과, rustfmt 통과.