### PR TITLE
fix(hwp5): Solid/Image 채우기 alpha 가 직렬화 시 0 으로 유실

### DIFF
--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -360,9 +360,12 @@ fn serialize_fill(w: &mut ByteWriter, fill: &crate::model::style::Fill) {
                 w.write_color_ref(solid.pattern_color).unwrap();
                 w.write_i32(solid.pattern_type).unwrap();
             }
-            // 추가 채우기 속성: size(u32) + alpha(u8)
-            w.write_u32(1).unwrap();
-            w.write_u8(0).unwrap(); // alpha
+            // 추가 채우기 속성: size(u32) = 0, 이어서 미확인 바이트로 alpha(u8).
+            // hwplib 및 parse_fill(additional_size 만큼 skip 후 종류별 1바이트를
+            // alpha 로 읽음)과 정합. 종전엔 size=1·0x00 을 내보내 skip 이 alpha
+            // 자리를 먹고 alpha 가 항상 0 으로 되읽혔다.
+            w.write_u32(0).unwrap();
+            w.write_u8(fill.alpha).unwrap();
         }
         FillType::Gradient => {
             if let Some(ref grad) = fill.gradient {
@@ -394,8 +397,11 @@ fn serialize_fill(w: &mut ByteWriter, fill: &crate::model::style::Fill) {
                 w.write_u8(img.effect).unwrap();
                 w.write_u16(img.bin_data_id).unwrap();
             }
-            // 추가 채우기 속성: size(u32)
+            // 추가 채우기 속성: size(u32) = 0, 이어서 미확인 바이트로 alpha(u8).
+            // parse_fill 의 image(0x02) 경로가 종류별 1바이트를 alpha 로 읽으므로
+            // 이 바이트가 없으면 EOF 로 alpha 가 0 이 됐다.
             w.write_u32(0).unwrap();
+            w.write_u8(fill.alpha).unwrap();
         }
         FillType::None => {
             // 추가 채우기 속성: size(u32) = 0

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -372,6 +372,55 @@ fn test_serialize_border_fill_solid() {
 }
 
 #[test]
+fn test_serialize_border_fill_preserves_solid_and_image_alpha() {
+    // 채우기는 BorderFill 헤더(attr 2 + 4테두리×6 + 대각선 6) 뒤 오프셋 32 부터.
+    const FILL_OFFSET: usize = 32;
+
+    // Solid: alpha=180 이 왕복해야 한다(종전엔 additional_size=1+0x00 로 항상 0).
+    let mut bf = BorderFill {
+        raw_data: None,
+        attr: 0,
+        borders: [BorderLine::default(); 4],
+        diagonal: DiagonalLine::default(),
+        center_line: CenterLine::None,
+        fill: Fill {
+            fill_type: FillType::Solid,
+            solid: Some(SolidFill {
+                background_color: 0x00FFFFFF,
+                pattern_color: 0,
+                pattern_type: -1,
+            }),
+            gradient: None,
+            image: None,
+            alpha: 180,
+        },
+    };
+    let data = serialize_border_fill(&bf);
+    let mut r = crate::parser::byte_reader::ByteReader::new(&data[FILL_OFFSET..]);
+    let parsed = crate::parser::doc_info::parse_fill(&mut r);
+    assert_eq!(parsed.alpha, 180, "Solid 채우기 alpha 가 왕복에서 유실됨");
+
+    // Image: alpha=200 이 왕복해야 한다(종전엔 alpha 바이트를 아예 안 냈다).
+    bf.fill = Fill {
+        fill_type: FillType::Image,
+        solid: None,
+        gradient: None,
+        image: Some(crate::model::style::ImageFill {
+            fill_mode: crate::model::style::ImageFillMode::TileAll,
+            brightness: 0,
+            contrast: 0,
+            effect: 0,
+            bin_data_id: 1,
+        }),
+        alpha: 200,
+    };
+    let data = serialize_border_fill(&bf);
+    let mut r = crate::parser::byte_reader::ByteReader::new(&data[FILL_OFFSET..]);
+    let parsed = crate::parser::doc_info::parse_fill(&mut r);
+    assert_eq!(parsed.alpha, 200, "Image 채우기 alpha 가 왕복에서 유실됨");
+}
+
+#[test]
 fn test_serialize_border_fill_cross_centerline_uses_hwp5_center_bits() {
     let bf = BorderFill {
         raw_data: None,


### PR DESCRIPTION
`serialize_fill`(src/serializer/doc_info.rs)은 **Gradient** 채우기에만 alpha 바이트를 올바로 썼습니다. **Solid/Image** 채우기는 alpha 가 유실됩니다.

## 원인
- **Solid**: `additional_size=1` + 하드코딩 `0x00` 을 방출 → `parse_fill`이 `skip(additional_size)`로 그 `0x00` 을 소비하고, 뒤이은 alpha 바이트 읽기는 EOF → **alpha 가 항상 0 으로 되읽힘**.
- **Image**: alpha 바이트를 아예 내보내지 않음 → 종류별(0x02) alpha 읽기가 EOF → 역시 0.
- **Gradient**(`w.write_u8(fill.alpha)`)만 정상이라 비대칭이 드러납니다.

`parse_fill`은 `additional_size` 만큼 skip 후 채우기 종류별 1바이트를 alpha 로 읽습니다(hwplib `ForFillInfo` 동형). 실제 한컴 solid 채우기는 `additional_size=0` 뒤에 alpha 바이트가 오는 형태입니다.

## 수정
Solid/Image 모두 `additional_size=0` 뒤 `fill.alpha` 를 방출하도록 정정(바이트 정합, 파서·hwplib 와 일치). HWPX→HWP 변환 경로 및 IR 편집 BorderFill(`raw_data=None`)에서 채우기 투명도가 이제 보존됩니다. HWPX 파서는 `winBrush@alpha`(solid)를 `raw_data=None` 인 BorderFill 에 채우므로(header.rs) 반투명 음영이 저장 시 불투명으로 바뀌던 문제가 사라집니다.

## 검증
`test_serialize_border_fill_preserves_solid_and_image_alpha` 추가: Solid alpha=180, Image alpha=200 을 직렬화 후 `parse_fill` 로 되읽어 보존을 단언 — 수정 전 red(0), 수정 후 green. `cargo test --lib` 통과.