### PR TITLE
fix(hwpx): kevin G3 필드 왕복 보존 통합

### DIFF
--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -149,5 +149,15 @@ OVR 원커맨드화 + 신규 소실 검출 + 공허 판정 제도화(개체 수 
 - G2: #2444(number_format attr 재인코딩)·#2446(raw_ctrl_data — **계약 4번째
   계층**, 등재 제안 코멘트)·#2447(autoTab 비트, 충돌 합집합 해소·LFS
   locksverify 우회 push)
-- red→green 전건 재현. **G3(#2445/#2450/#2451)·G4(#2452/#2453)는 작업지시자
-  지시로 대기.** 세션 merge 총 42건
+- red→green 전건 재현. 세션 merge 총 42건.
+
+## kevin9327 5차 G3 통합 PR 준비 (#2445/#2450/#2451)
+
+- `TOC` 차례 필드, OWPML `DOC_DATE`/`USER_INFO`/`SUMMERY`, 중첩
+  `hp:parameters` 닫는 태그를 각각 원 PR 커밋 그대로 체리픽했다. 최신 G2 merge가 반영된
+  `upstream/devel` 위 적용 충돌은 없다.
+- focused 3건, `cargo fmt --check`, `git diff --check`,
+  `cargo clippy --all-targets -- -D warnings`,
+  `cargo test --profile release-test --tests`를 통과했다.
+- G3 통합 PR의 최신 head CI를 확인한 뒤 merge한다. G4(#2452/#2453)와 이어지는
+  HWPX 보존 PR #2455-#2463은 G3 완료 후 별도 묶음으로 순차 처리한다.

--- a/mydocs/pr/archives/pr_2445_review.md
+++ b/mydocs/pr/archives/pr_2445_review.md
@@ -1,0 +1,42 @@
+# PR #2445 리뷰 - HWPX 차례 필드 `TOC` 왕복 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| 원 PR | [#2445](https://github.com/edwardkim/rhwp/pull/2445) |
+| 작성자 | `kevin9327` |
+| base | `devel` |
+| 리뷰 경로 | collaborator-mediated 외부 PR, G3 체리픽 통합 |
+| 적용 커밋 | `976ef2672b0b3f45a80c372bfe3b928965013935` |
+| 적용 순서 | G3 1/3, 최신 `upstream/devel` 위 체리픽, 충돌 없음 |
+| 작성 시점 참고값 | 원 PR은 `BEHIND`, 기존 CI 통과. 통합 PR의 최신 head CI를 merge 전 다시 확인한다. |
+
+## 변경 검토
+
+HWPX 직렬화기는 `FieldType::TableOfContents`를 `TOC`로 기록하지만 파서는
+`TABLE_OF_CONTENTS`와 `TABLEOFCONTENTS`만 수용했다. 따라서 rhwp가 저장한 HWPX를 다시
+열 때 차례 필드가 `Unknown`으로 바뀌는 내부 왕복 불일치가 있었다.
+
+`TOC`를 같은 `TableOfContents` 분기에 추가했고, 기존의 두 허용 표기는 유지한다. 변경은
+파서 token 수용 범위만 넓히며 renderer, 페이지네이션, Studio UI에는 영향을 주지 않는다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `parse_field_type_accepts_toc` | PASS |
+| `cargo fmt --check` | PASS |
+| `git diff --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --profile release-test --tests` | PASS |
+
+## 시각 검증 판단
+
+파서의 HWPX enum token 복원만 변경하며 렌더러나 레이아웃을 수정하지 않는다. 별도 visual
+sweep 또는 MCP PDF 검증 대상이 아니다.
+
+## 최종 의견
+
+G3 통합 PR에 원 커밋을 보존해 수용한다. merge 전 통합 PR 최신 head의 GitHub Actions와
+mergeable 상태를 재확인한다.

--- a/mydocs/pr/archives/pr_2450_review.md
+++ b/mydocs/pr/archives/pr_2450_review.md
@@ -1,0 +1,48 @@
+# PR #2450 리뷰 - OWPML 필드 타입 스키마 표기 정합
+
+## 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| 원 PR | [#2450](https://github.com/edwardkim/rhwp/pull/2450) |
+| 작성자 | `kevin9327` |
+| base | `devel` |
+| 리뷰 경로 | collaborator-mediated 외부 PR, G3 체리픽 통합 |
+| 적용 커밋 | `e01647321b5453c77c787f693d64ff1a062815b5` |
+| 적용 순서 | G3 2/3, 최신 `upstream/devel` 위 체리픽, 충돌 없음 |
+| 작성 시점 참고값 | 원 PR은 `BEHIND`, 기존 CI 통과. 통합 PR의 최신 head CI를 merge 전 다시 확인한다. |
+
+## 변경 검토
+
+권위 OWPML schema의 `FieldType` enum은 `SUMMERY`, `USER_INFO`, `DOC_DATE`를 사용한다.
+기존 직렬화기의 `SUMMARY`, `USERINFO`, `DOCDATE`는 이 스키마 표기와 달라 Hancom이 필드
+타입을 인식하지 못할 수 있었다.
+
+저장 표기를 스키마와 맞추고, 파서는 호환성을 위해 기존 표기와 `SUMMERY`를 모두 수용한다.
+스키마의 `SUMMERY` 오탈자도 실제 enum 값이므로 그대로 보존하는 것이 맞다.
+
+## 근거
+
+[`ParaList XML schema.xml`](../../manual/OWPML%20SCHEMA/ParaList%20XML%20schema.xml)의
+`FieldType` enum은 `SUMMERY`, `USER_INFO`, `DOC_DATE`를 명시한다. 리뷰 시 실제 파일의
+2707-2710행을 대조했다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `field_type_str_matches_owpml_schema` | PASS |
+| `cargo fmt --check` | PASS |
+| `git diff --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --profile release-test --tests` | PASS |
+
+## 시각 검증 판단
+
+HWPX parser/serializer 문자열 정합만 변경한다. renderer, 페이지네이션, Studio UI를 바꾸지
+않으므로 별도 visual sweep 또는 MCP PDF 검증 대상이 아니다.
+
+## 최종 의견
+
+G3 통합 PR에 원 커밋을 보존해 수용한다. merge 전 통합 PR 최신 head의 GitHub Actions와
+mergeable 상태를 재확인한다.

--- a/mydocs/pr/archives/pr_2451_review.md
+++ b/mydocs/pr/archives/pr_2451_review.md
@@ -1,0 +1,42 @@
+# PR #2451 리뷰 - 중첩 HWPX field parameters XML 균형 보존
+
+## 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| 원 PR | [#2451](https://github.com/edwardkim/rhwp/pull/2451) |
+| 작성자 | `kevin9327` |
+| base | `devel` |
+| 리뷰 경로 | collaborator-mediated 외부 PR, G3 체리픽 통합 |
+| 적용 커밋 | `47dc2ee9675b91146f97ed6614514ab805be15d4` |
+| 적용 순서 | G3 3/3, 최신 `upstream/devel` 위 체리픽, 충돌 없음 |
+| 작성 시점 참고값 | 원 PR은 `BEHIND`, 기존 CI 통과. 통합 PR의 최신 head CI를 merge 전 다시 확인한다. |
+
+## 변경 검토
+
+`parse_field_parameters`는 무손실 저장을 위해 `hp:parameters` 자식을 원문 형태로 다시
+구성한다. 기존 단일 `open_param` 상태는 중첩 `listParam` 안의 `stringParam`을 만나면
+안쪽 태그로 덮여 바깥 닫는 태그를 잃었다.
+
+End 이벤트가 제공하는 자신의 qualified tag 이름으로 닫도록 바꿔 임의 깊이의 중첩에서도
+균형 잡힌 XML을 구성한다. 비중첩 parameter 출력은 변하지 않는다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `parse_field_parameters_reassembles_nested_params_balanced` | PASS |
+| `cargo fmt --check` | PASS |
+| `git diff --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+| `cargo test --profile release-test --tests` | PASS |
+
+## 시각 검증 판단
+
+중첩 field parameter의 raw XML 저장 경로만 변경한다. renderer와 레이아웃을 수정하지 않으므로
+별도 visual sweep 또는 MCP PDF 검증 대상이 아니다.
+
+## 최종 의견
+
+G3 통합 PR에 원 커밋을 보존해 수용한다. merge 전 통합 PR 최신 head의 GitHub Actions와
+mergeable 상태를 재확인한다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4743,7 +4743,6 @@ fn parse_field_parameters(
     raw.push('>');
 
     // 현재 열린 파라미터 요소 태그(닫을 때 사용).
-    let mut open_param: Option<String> = None;
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref ce)) => {
@@ -4760,7 +4759,6 @@ fn parse_field_parameters(
                     raw.push('"');
                 }
                 raw.push('>');
-                open_param = Some(tag);
                 if local == b"stringParam" {
                     for attr in ce.attributes().flatten() {
                         if attr.key.as_ref() == b"name" && attr_str(&attr) == "Command" {
@@ -4822,11 +4820,13 @@ fn parse_field_parameters(
                     raw.push_str("</hp:parameters>");
                     break;
                 }
-                if let Some(tag) = open_param.take() {
-                    raw.push_str("</");
-                    raw.push_str(&tag);
-                    raw.push('>');
-                }
+                // 임의 깊이 중첩(listParam 안의 stringParam 등)에서도 균형 잡힌 XML 을
+                // 재조립하도록, 단일 open_param 추적 대신 End 이벤트 자신의 정규화 이름으로 닫는다.
+                // 종전엔 open_param 이 마지막 Start 로 덮여, 바깥 태그의 닫는 태그가 누락됐다.
+                let qn = String::from_utf8_lossy(eename.as_ref());
+                raw.push_str("</");
+                raw.push_str(&qn);
+                raw.push('>');
                 if local == b"stringParam" {
                     in_command = false;
                 } else if local == b"integerParam" {
@@ -6857,6 +6857,37 @@ mod tests {
 
         assert_eq!(field.command, "MEMO/65535/2/1650281184/31247371/user/\\;;");
         assert_eq!(field.memo_index, 2);
+    }
+
+    #[test]
+    fn parse_field_parameters_reassembles_nested_params_balanced() {
+        // 중첩 파라미터(listParam 안의 stringParam). 종전엔 open_param 이 마지막 Start 로
+        // 덮여 바깥 </hp:listParam> 닫는 태그가 누락돼 raw_parameters_xml 이 불균형이었다.
+        let xml = r#"<hp:parameters xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" cnt="1" name=""><hp:listParam cnt="1" name="L"><hp:stringParam name="A">x</hp:stringParam></hp:listParam></hp:parameters>"#;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut field = Field::default();
+
+        loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"parameters" => {
+                    let start = e.to_owned();
+                    parse_field_parameters(&start, &mut reader, &mut field).unwrap();
+                    break;
+                }
+                Event::Eof => panic!("parameters not found"),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        let raw = field.raw_parameters_xml.expect("raw_parameters_xml");
+        assert!(raw.contains("</hp:stringParam>"), "inner close: {raw}");
+        assert!(
+            raw.contains("</hp:listParam>"),
+            "바깥 </hp:listParam> 누락(중첩 불균형): {raw}"
+        );
+        assert!(raw.ends_with("</hp:parameters>"), "params close: {raw}");
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4397,7 +4397,9 @@ fn parse_field_type(s: &str) -> FieldType {
         "HYPERLINK" => FieldType::Hyperlink,
         "MEMO" => FieldType::Memo,
         "PRIVATE_INFO" | "PRIVATEINFO" => FieldType::PrivateInfoSecurity,
-        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" => FieldType::TableOfContents,
+        // 직렬화기(serializer/hwpx/field.rs)는 TableOfContents 를 "TOC" 로 방출하므로
+        // 파서도 이를 받아야 hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" | "TOC" => FieldType::TableOfContents,
         _ => FieldType::Unknown,
     }
 }
@@ -7322,5 +7324,16 @@ mod tests {
         let xml = r#"<?xml version="1.0"?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"/>"#;
         let section = parse_hwpx_section(xml).unwrap();
         assert!(section.paragraphs.is_empty());
+    }
+
+    #[test]
+    fn parse_field_type_accepts_toc() {
+        // 직렬화기(hwpx/field.rs)가 방출하는 "TOC" 가 TableOfContents 로 파싱돼야
+        // hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        assert_eq!(parse_field_type("TOC"), FieldType::TableOfContents);
+        assert_eq!(
+            parse_field_type("TABLE_OF_CONTENTS"),
+            FieldType::TableOfContents
+        );
     }
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4392,7 +4392,7 @@ fn parse_field_type(s: &str) -> FieldType {
         "CROSSREF" => FieldType::CrossRef,
         "FORMULA" => FieldType::Formula,
         "CLICK_HERE" | "CLICKHERE" => FieldType::ClickHere,
-        "SUMMARY" => FieldType::Summary,
+        "SUMMARY" | "SUMMERY" => FieldType::Summary,
         "USER_INFO" | "USERINFO" => FieldType::UserInfo,
         "HYPERLINK" => FieldType::Hyperlink,
         "MEMO" => FieldType::Memo,

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -171,15 +171,15 @@ fn field_type_str(t: FieldType) -> &'static str {
     match t {
         Unknown => "UNKNOWN",
         Date => "DATE",
-        DocDate => "DOCDATE",
+        DocDate => "DOC_DATE",
         Path => "PATH",
         Bookmark => "BOOKMARK",
         MailMerge => "MAILMERGE",
         CrossRef => "CROSSREF",
         Formula => "FORMULA",
         ClickHere => "CLICK_HERE",
-        Summary => "SUMMARY",
-        UserInfo => "USERINFO",
+        Summary => "SUMMERY", // OWPML 스키마의 실제 표기(한컴 오탈자). schema.xml:2707
+        UserInfo => "USER_INFO",
         Hyperlink => "HYPERLINK",
         Memo => "MEMO",
         PrivateInfoSecurity => "PRIVATE_INFO",
@@ -253,5 +253,14 @@ mod tests {
         assert_eq!(field_type_str(FieldType::Bookmark), "BOOKMARK");
         assert_eq!(field_type_str(FieldType::Date), "DATE");
         assert_eq!(field_type_str(FieldType::TableOfContents), "TOC");
+    }
+
+    #[test]
+    fn field_type_str_matches_owpml_schema() {
+        // OWPML ParaList schema.xml(2707-2710)의 실제 enum 표기와 일치해야 한컴이 인식한다.
+        // (종전 DOCDATE/USERINFO/SUMMARY 는 스키마에 없어 한컴이 필드 타입을 잃었다.)
+        assert_eq!(field_type_str(FieldType::DocDate), "DOC_DATE");
+        assert_eq!(field_type_str(FieldType::UserInfo), "USER_INFO");
+        assert_eq!(field_type_str(FieldType::Summary), "SUMMERY");
     }
 }


### PR DESCRIPTION
## 요약

kevin9327의 독립 HWPX 왕복 보존 수정 세 건을 최신 `devel` 위에 체리픽 통합합니다.

- [PR #2445](https://github.com/edwardkim/rhwp/pull/2445): `TOC` 차례 필드 파싱 보존
- [PR #2450](https://github.com/edwardkim/rhwp/pull/2450): OWPML `DOC_DATE`/`USER_INFO`/`SUMMERY` 표기 정합
- [PR #2451](https://github.com/edwardkim/rhwp/pull/2451): 중첩 `hp:parameters` raw XML 균형 보존

원 기여 커밋은 rewrite하지 않고 그대로 포함했습니다. 각 원 PR의 검토 기록과 오늘할일은 별도 문서 커밋으로 추가했습니다.

## 검증

- focused 회귀 3건 PASS
  - `parse_field_type_accepts_toc`
  - `field_type_str_matches_owpml_schema`
  - `parse_field_parameters_reassembles_nested_params_balanced`
- `cargo fmt --check` PASS
- `git diff --check` PASS
- `cargo clippy --all-targets -- -D warnings` PASS
- `cargo test --profile release-test --tests` PASS

HWPX parser/serializer token 및 raw XML 보존 변경으로 renderer, layout, Studio UI를 수정하지 않아 별도 visual sweep 대상은 아닙니다.

## 리뷰 기록

- `mydocs/pr/archives/pr_2445_review.md`
- `mydocs/pr/archives/pr_2450_review.md`
- `mydocs/pr/archives/pr_2451_review.md`
- `mydocs/orders/20260719.md`

## 후속

merge 후 원 PR 세 건은 이 통합 PR로 대체되었음을 알리고 close합니다. 다음 묶음은 Studio 중첩 셀 수정인 G4와 후속 HWPX 보존 PR입니다.
