### PR TITLE
refactor(hwp3): 공통 편집 레이어의 직접 version.major 비교를 layout_profile 질의로 대체

### DIFF
--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -742,8 +742,12 @@ impl DocumentCore {
         let (raw_left_hu, raw_right_hu, raw_indent_hu) = raw_ps
             .map(|r| (r.margin_left, r.margin_right, r.indent))
             .unwrap_or((0, 0, 0));
-        let is_hwp3_native = self.document.header.version.major == 3
-            && !self.document.layout_profile().hwp3_layout();
+        // parser_architecture.md §47: 공통 편집 레이어에서 header.version 직접
+        // 비교를 새로 만들지 않고 layout_profile() 질의로 판정한다.
+        // `version.major==3 && !hwp3_layout()` 은 hwp3_native_layout() 과 동치다:
+        // native HWP3 는 format=Hwp3·hwp3_lineage=false·major=3, 변환본은
+        // format=Hwp5·hwp3_lineage=true·major=5 이므로 4개 출처 모두 결과가 같다.
+        let is_hwp3_native = self.document.layout_profile().hwp3_native_layout();
         let effective_left_hu = if is_hwp3_native {
             raw_left_hu + raw_indent_hu.min(0)
         } else {

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -587,6 +587,37 @@ mod tests {
     }
 
     #[test]
+    fn hwp3_native_layout_matches_legacy_version_and_lineage_expression() {
+        use crate::model::provenance::SourceFormat;
+
+        // formatting.rs 의 종전 판정식 `version.major==3 && !hwp3_layout()` 이
+        // hwp3_native_layout() 과 4개 출처에서 모두 일치함을 고정한다.
+        let build = |format: SourceFormat, hwp3_lineage: bool, major: u8| {
+            let mut doc = Document::default();
+            doc.provenance.format = format;
+            doc.provenance.hwp3_lineage = hwp3_lineage;
+            doc.header.version.major = major;
+            doc
+        };
+
+        let cases = [
+            // (format, hwp3_lineage, major, 기대 native 여부)
+            (SourceFormat::Hwp3, false, 3, true), // native HWP3
+            (SourceFormat::Hwp5, true, 5, false), // HWP3→HWP5 변환본
+            (SourceFormat::Hwp5, false, 5, false), // 일반 HWP5
+            (SourceFormat::Hwpx, false, 5, false), // HWPX
+        ];
+
+        for (format, lineage, major, expected) in cases {
+            let doc = build(format, lineage, major);
+            let legacy = doc.header.version.major == 3 && !doc.layout_profile().hwp3_layout();
+            let refactored = doc.layout_profile().hwp3_native_layout();
+            assert_eq!(legacy, refactored, "{format:?}/{lineage}/{major}");
+            assert_eq!(refactored, expected, "{format:?}/{lineage}/{major}");
+        }
+    }
+
+    #[test]
     fn test_hwp_version() {
         let ver = HwpVersion {
             major: 5,


### PR DESCRIPTION
`get_para_format`(src/document_core/commands/formatting.rs:745)의 dialog 왼쪽 여백 보정에서 공통 편집 레이어인데도 `self.document.header.version.major == 3` 으로 **포맷/버전을 직접 비교**하고 있었습니다. `parser_architecture.md` §47 은 "포맷 이름 직접 비교를 새로 만들지 않는다 — 새 출처 분기는 `layout_profile()` 질의로" 규정합니다.

## 동치 근거
`version.major==3 && !hwp3_layout()` 은 `hwp3_native_layout()` 과 정확히 동치입니다. `layout_profile()`(document.rs:285)은 `hwp3_layout = provenance.hwp3_lineage`, `hwp3_native_layout = (provenance.format == Hwp3)` 로 파생됩니다.

| 출처 | format | hwp3_lineage | major | 종전식 | hwp3_native_layout() |
|---|---|---|---|---|---|
| native HWP3 | Hwp3 | false | 3 | **true** | **true** |
| HWP3→HWP5 변환본 | Hwp5 | true | 5 | false | false |
| 일반 HWP5 | Hwp5 | false | 5 | false | false |
| HWPX | Hwpx | false | 5 | false | false |

- native HWP3 파서: `format=Hwp3`·`major=3` 설정, `hwp3_lineage` 는 기본 false (parser/hwp3/mod.rs).
- 변환본: HWP5 파서가 휴리스틱으로 `hwp3_lineage=true` 만 세팅, format 은 Hwp5 유지·major=5 (parser/mod.rs:291).

## 수정
```rust
let is_hwp3_native = self.document.layout_profile().hwp3_native_layout();
```
`header.version` 직접 읽기를 제거하고, 렌더러(typeset.rs)가 이미 쓰는 계약 질의로 통일합니다. **동작은 4개 출처 모두 불변.**

## 검증
`hwp3_native_layout_matches_legacy_version_and_lineage_expression` 추가: 4개 출처 각각에서 `종전식 == hwp3_native_layout()` 및 기대값을 단언. `cargo test --lib` 통과.