### PR TITLE
fix(hwp3): 위첨자/아래첨자 글자속성이 IR 매핑 누락으로 유실

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -278,6 +278,10 @@ pub(crate) fn convert_char_shape(
     };
     cs.outline_type = if hwp3_cs.is_outline() { 1 } else { 0 };
     cs.shadow_type = if hwp3_cs.is_shadow() { 1 } else { 0 };
+    // 위첨자(attr 0x20)/아래첨자(attr 0x40). 접근자는 있었으나 매핑이 빠져
+    // 렌더러(글자 축소·baseline 이동)가 소비하는 IR 필드가 항상 false 였다.
+    cs.superscript = hwp3_cs.is_superscript();
+    cs.subscript = hwp3_cs.is_subscript();
     cs
 }
 
@@ -3971,6 +3975,26 @@ mod tests {
         let cs = convert_char_shape(&hwp3_cs);
 
         assert_eq!(cs.text_color, 0x00FF0000);
+    }
+
+    #[test]
+    fn convert_char_shape_maps_superscript_and_subscript() {
+        // attr 0x20=위첨자, 0x40=아래첨자. 종전엔 매핑이 빠져 항상 false.
+        let sup = crate::parser::hwp3::records::Hwp3CharShape {
+            attr: 0x20,
+            ..Default::default()
+        };
+        let cs = convert_char_shape(&sup);
+        assert!(cs.superscript);
+        assert!(!cs.subscript);
+
+        let sub = crate::parser::hwp3::records::Hwp3CharShape {
+            attr: 0x40,
+            ..Default::default()
+        };
+        let cs = convert_char_shape(&sub);
+        assert!(cs.subscript);
+        assert!(!cs.superscript);
     }
 
     #[test]


### PR DESCRIPTION
HWP 3.0 파서의 `convert_char_shape`(src/parser/hwp3/mod.rs:251)가 italic/bold/underline/outline/shadow 는 `attr` 에서 매핑하면서 **위첨자(attr `0x20`)/아래첨자(attr `0x40`)** 만 빠뜨립니다.

## 원인
- 접근자 `is_superscript()`/`is_subscript()` 는 `records.rs:252,255` 에 정의돼 있으나 **호출부가 한 곳도 없습니다**(코드베이스 grep 결과 dead).
- 결과적으로 공용 IR `CharShape.superscript`/`subscript`(src/model/style.rs:146-147)가 v3 문서에서 항상 `false`.

## 영향
렌더러가 이 두 bool 을 소비해 글자를 축소하고 baseline 을 올리거나 내립니다 — svg.rs:2689, html.rs:299, web_canvas.rs:2141 (style_resolver.rs:386-387, text_measurement.rs:1453-1454 경유). 따라서 v3 `.hwp` 의 위/아래첨자 텍스트(각주·참조 표식, 서수, H₂O·수식 지수 등)가 **원래 크기로 baseline 에** 렌더돼 크기·세로위치가 모두 틀립니다. HWPX 파서는 같은 필드를 header.rs:781-782 에서 채웁니다(비대칭).

## 수정
`records.rs` 의 기존 접근자를 그대로 사용해 두 필드를 매핑(파서 내부 additive, 렌더러/document_core 무변경 — parser_architecture 준수):
```rust
cs.superscript = hwp3_cs.is_superscript();
cs.subscript = hwp3_cs.is_subscript();
```

## 검증
`convert_char_shape_maps_superscript_and_subscript` 추가: attr 0x20→superscript, 0x40→subscript 단언 — 수정 전 red(false), 수정 후 green. `cargo test --lib` 통과.