### PR TITLE
fix(hml): 표의 TextWrap 이 HML 되읽기에서 유실

### DIFF
--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -859,8 +859,17 @@ impl<'a> ReadState<'a> {
     }
 
     fn capture_shape_object(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
-        if let Some(rectangle) = self.rectangles.last_mut() {
-            rectangle.text_wrap = parse_text_wrap(attribute(element, b"TextWrap")?.as_deref());
+        let text_wrap = parse_text_wrap(attribute(element, b"TextWrap")?.as_deref());
+        // SHAPEOBJECT 는 표에도 방출되므로(write_shape_object) rectangle 뿐 아니라
+        // 표의 common.text_wrap 도 되읽어야 한다. 종전엔 rectangle 만 처리해 표의
+        // TextWrap(예: TopAndBottom)이 HML 재로드 시 기본값 Square 로 유실됐다.
+        // capture_object_position 과 동일한 표/사각형 판별을 사용한다.
+        if self.nearest_object_is_table() {
+            if let Some(table) = self.tables.last_mut() {
+                table.common.text_wrap = text_wrap;
+            }
+        } else if let Some(rectangle) = self.rectangles.last_mut() {
+            rectangle.text_wrap = text_wrap;
         }
         Ok(())
     }

--- a/tests/hml_serializer.rs
+++ b/tests/hml_serializer.rs
@@ -561,6 +561,38 @@ fn edited_hml_text_is_present_after_export_and_reparse() {
 }
 
 #[test]
+fn table_text_wrap_is_read_back_from_hml() {
+    // 표 SHAPEOBJECT 에 TextWrap 을 주입한 HML 을 파싱하면 표 common.text_wrap 으로
+    // 되읽혀야 한다. 종전엔 reader 의 capture_shape_object 가 표를 처리하지 않아
+    // (rectangle 만) 외부(한컴) HML 의 부동 표 TextWrap 이 기본값 Square 로 유실됐다.
+    let fixture = include_str!("../samples/hml/formatting_table.hml");
+    let injected = fixture.replacen(
+        r#"NumberingType="Table" TextFlow="BothSides" ZOrder="1""#,
+        r#"NumberingType="Table" TextFlow="BothSides" TextWrap="TopAndBottom" ZOrder="1""#,
+        1,
+    );
+    assert_ne!(injected, fixture, "fixture 의 표 SHAPEOBJECT 태그를 찾지 못함");
+
+    let core = DocumentCore::from_bytes(injected.as_bytes()).expect("주입 HML 은 파싱되어야 함");
+    let table = core
+        .document()
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+        .flat_map(|paragraph| paragraph.controls.iter())
+        .find_map(|control| match control {
+            Control::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("표가 있어야 함");
+    assert_eq!(
+        table.common.text_wrap,
+        rhwp::model::shape::TextWrap::TopAndBottom,
+        "표 TextWrap 이 HML 되읽기에서 유실됨"
+    );
+}
+
+#[test]
 fn stale_offsets_after_unequal_direct_text_mutation_block_export() {
     let mut core = DocumentCore::from_bytes(include_bytes!("../samples/hml/formatting_table.hml"))
         .expect("fixture should import");


### PR DESCRIPTION
HML writer 는 표에도 `<SHAPEOBJECT>` 의 `TextWrap` 을 방출합니다(`write_shape_object` 를 표에 대해 `&table.common` 으로 호출, src/serializer/hml/body.rs:412). 그러나 reader 의 `capture_shape_object`(src/parser/hml/reader.rs:861)는 **rectangle 만** 처리하고 표는 무시합니다.

## 영향
`Table.common.text_wrap`(CommonObjAttr, 기본 `Square`)의 reader 소스가 표에는 전혀 없어, 외부(한컴) HML 의 **부동 표**(예: `TextWrap="TopAndBottom"` — 흔한 본문 겹침 회피 설정)를 열면 `Square` 로 유실됩니다. 표 배치/겹침이 원본과 다르게 렌더됩니다. (표의 나머지 common 필드는 `POSITION`→`capture_object_position` 에서 표/사각형을 구분해 채우지만, 그 경로도 `TextWrap` 은 다루지 않습니다.)

## 수정
`capture_object_position` 과 동일한 `nearest_object_is_table()` 판별을 적용해, 표면 `table.common.text_wrap`, 아니면 `rectangle.text_wrap` 를 채웁니다:
```rust
let text_wrap = parse_text_wrap(attribute(element, b"TextWrap")?.as_deref());
if self.nearest_object_is_table() {
    if let Some(table) = self.tables.last_mut() { table.common.text_wrap = text_wrap; }
} else if let Some(rectangle) = self.rectangles.last_mut() {
    rectangle.text_wrap = text_wrap;
}
```
writer 는 이미 대칭이라 reader 한쪽만 보강하면 왕복이 맞습니다.

## 검증
`table_text_wrap_is_read_back_from_hml` 추가: 표 SHAPEOBJECT 에 `TextWrap="TopAndBottom"` 을 주입한 HML 을 파싱해 표의 `common.text_wrap == TopAndBottom` 을 단언 — 수정 전 red(표 rectangle 부재로 Square), 수정 후 green. `cargo test --test hml_serializer` 통과.