### PR TITLE
fix(safari): manifest version 0.2.1 → 0.2.8 동기화

### DIFF
--- a/rhwp-safari/src/manifest.json
+++ b/rhwp-safari/src/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 3,
   "name": "__MSG_extName__",
-  "version": "0.2.1",
+  "version": "0.2.8",
   "description": "__MSG_extDescription__",
   "default_locale": "ko",
   "icons": {


### PR DESCRIPTION
Chrome/Firefox 확장 manifest version은 모두 0.2.8이지만 Safari 확장만 0.2.1로 뒤쳐져 있어 업스트림과 동기화합니다.

**변경:** rhwp-safari/src/manifest.json version 필드 0.2.1 → 0.2.8 (1라인)
**영향:** 없음 (버전 문자열만 변경, 기능/권한/리소스 변경 없음)