### PR TITLE
fix(undo): 문단 병합 undo 시 split_at이 field_ranges를 새 문단으로 이관하지 않아 누름틀 필드 소실 (#2417)

### DIFF
--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -896,8 +896,32 @@ impl Paragraph {
         }
         self.range_tags = kept_range_tags;
 
-        // 5-1. field_ranges 분할 (필드 control은 원래 문단에 유지)
-        self.field_ranges.retain(|fr| fr.end_char_idx <= split_pos);
+        // 5-1. field_ranges 분할
+        let mut new_field_ranges: Vec<FieldRange> = Vec::new();
+        let mut kept_field_ranges: Vec<FieldRange> = Vec::new();
+        // 5-1a. controls 분할 시 control_idx 리매핑을 위한 맵 (old → new)
+        let mut moved_control_idx_map: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+        for fr in &self.field_ranges {
+            if fr.start_char_idx >= split_pos {
+                // 완전히 새 문단 쪽 → 인덱스 조정 후 이관 (control_idx는 5-2에서 리매핑)
+                new_field_ranges.push(FieldRange {
+                    start_char_idx: fr.start_char_idx - split_pos,
+                    end_char_idx: fr.end_char_idx - split_pos,
+                    control_idx: fr.control_idx,
+                });
+            } else if fr.end_char_idx <= split_pos {
+                // 완전히 원래 문단 쪽
+                kept_field_ranges.push(fr.clone());
+            } else {
+                // 경계에 걸친 필드: 원래 문단에서 종료
+                kept_field_ranges.push(FieldRange {
+                    start_char_idx: fr.start_char_idx,
+                    end_char_idx: split_pos,
+                    control_idx: fr.control_idx,
+                });
+            }
+        }
+        self.field_ranges = kept_field_ranges;
 
         // 5-2. controls 분할
         //
@@ -917,11 +941,18 @@ impl Paragraph {
                 && control_positions.get(ci).copied().unwrap_or(usize::MAX) >= char_offset;
 
             if move_to_new {
+                moved_control_idx_map.insert(ci, new_controls.len());
                 new_controls.push(ctrl);
                 new_ctrl_data_records.push(data);
             } else {
                 kept_controls.push(ctrl);
                 kept_ctrl_data.push(data);
+            }
+        }
+        // field_ranges의 control_idx를 새 문단의 controls 배열에 맞게 리매핑
+        for fr in &mut new_field_ranges {
+            if let Some(&new_idx) = moved_control_idx_map.get(&fr.control_idx) {
+                fr.control_idx = new_idx;
             }
         }
         self.controls = kept_controls;
@@ -942,7 +973,7 @@ impl Paragraph {
         self.control_mask =
             Self::compute_control_mask_for(&self.text, &self.controls, &self.field_ranges);
         let new_control_mask =
-            Self::compute_control_mask_for(&new_text, &new_controls, &Vec::new());
+            Self::compute_control_mask_for(&new_text, &new_controls, &new_field_ranges);
 
         Paragraph {
             text: new_text,
@@ -950,7 +981,7 @@ impl Paragraph {
             char_shapes: new_char_shapes,
             line_segs: new_line_segs,
             range_tags: new_range_tags,
-            field_ranges: Vec::new(), // controls가 이동하지 않으므로 새 문단에는 필드 없음
+            field_ranges: new_field_ranges, // 새 문단으로 이관된 필드 범위
             orphan_field_ends: Vec::new(),
             char_count: new_char_count,
             para_shape_id: self.para_shape_id,


### PR DESCRIPTION
## 개요

Issue #2417: 문단 병합(merge) 후 undo 시 2번째 문단의 누름틀(ClickHere) 필드가 소실된다.

## 원인

문단 병합 undo는 Paragraph::split_at()으로 merge된 문단을 다시 분할한다. 분할 시:
1. ield_ranges가 .retain(|fr| fr.end_char_idx <= split_pos)로 제거만 되고 새 문단으로 이관되지 않음
2. 새 Paragraph 생성자에서 ield_ranges: Vec::new()로 무조건 빈 벡터 초기화
3. 새 문단의 control_mask에도 field_ranges가 반영되지 않아 HWP 저장 시 비트 누락

## 수정

- **분할 로직**: split_pos 기준으로 kept(원래 문단 유지) / new(새 문단 이관) 분할
- **경계 필드**: split_pos에 걸친 field_range는 원래 문단에서 종료(truncate)
- **control_idx 리매핑**: 새 문단으로 이관된 field_range의 control_idx를 새 controls 배열 인덱스에 맞게 변환
- **control_mask**: 새 문단의 control_mask에 field_ranges 존재 여부 반영

## 변경

1개 파일, +35/-4 라인
- src/model/paragraph.rs: split_at()의 field_ranges 처리 전면 개선

## 영향

- 문단 병합 undo 시 field_ranges가 정상 복원됨
- 새 문단의 control_mask가 올바르게 계산됨
- 경계 필드는 원래 문단에서 정상 종료