### PR TITLE
fix(hwpx): 쪽 번호 홀수/짝수 시작(pageStartsOn)이 왕복 시 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1237,6 +1237,15 @@ fn parse_start_num(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) 
             b"pic" => sec_def.picture_num = parse_u16(&attr),
             b"tbl" => sec_def.table_num = parse_u16(&attr),
             b"equation" => sec_def.equation_num = parse_u16(&attr),
+            // 쪽 번호 시작 종류(0=이어서/1=홀수/2=짝수, flags bit20-21). 종전엔
+            // 미독이라 HWPX 왕복 시 홀/짝 시작이 유실됐다(serializer 는 BOTH 고정).
+            b"pageStartsOn" => {
+                sec_def.page_num_type = match attr_str(&attr).as_str() {
+                    "ODD" => 1,
+                    "EVEN" => 2,
+                    _ => 0,
+                };
+            }
             _ => {}
         }
     }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -146,11 +146,25 @@ fn replace_secpr_scalars(xml: &str, sd: &SectionDef) -> String {
     out.replacen(
         r#"<hp:startNum pageStartsOn="BOTH" page="0" pic="0" tbl="0" equation="0"/>"#,
         &format!(
-            r#"<hp:startNum pageStartsOn="BOTH" page="{}" pic="{}" tbl="{}" equation="{}"/>"#,
-            sd.page_num, sd.picture_num, sd.table_num, sd.equation_num
+            r#"<hp:startNum pageStartsOn="{}" page="{}" pic="{}" tbl="{}" equation="{}"/>"#,
+            page_starts_on_str(sd.page_num_type),
+            sd.page_num,
+            sd.picture_num,
+            sd.table_num,
+            sd.equation_num
         ),
         1,
     )
+}
+
+/// 쪽 번호 시작 종류(SectionDef.page_num_type, 0/1/2) → HWPX `pageStartsOn` 토큰.
+/// 파서 `parse_start_num` 의 역매핑. 0(이어서)=BOTH, 1(홀수)=ODD, 2(짝수)=EVEN.
+fn page_starts_on_str(page_num_type: u8) -> &'static str {
+    match page_num_type {
+        1 => "ODD",
+        2 => "EVEN",
+        _ => "BOTH",
+    }
 }
 
 /// [#1984] noteLine `type` u8 → HWPX 문자열 (parser noteLine type 역매핑).
@@ -3708,6 +3722,25 @@ mod tests {
         assert_eq!(
             coldef_count, 2,
             "본문 첫 문단의 ColumnDef 2개가 roundtrip 후 모두 보존돼야 한다 (템플릿1 + 인라인1): {coldef_count}"
+        );
+    }
+
+    #[test]
+    fn page_starts_on_odd_survives_hwpx_roundtrip() {
+        // pageStartsOn(홀수 시작)이 HWPX 왕복에서 보존돼야 한다. 종전엔 파서 미독 +
+        // serializer 의 pageStartsOn="BOTH" 고정으로 page_num_type 이 0 으로 유실됐다.
+        let mut section = Section::default();
+        section.section_def.page_num_type = 1; // 홀수 시작
+        section.section_def.page_num = 1;
+        section.paragraphs.push(Paragraph::default());
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let bytes = crate::serializer::hwpx::serialize_hwpx(&doc).expect("serialize");
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("parse");
+        assert_eq!(
+            doc2.sections[0].section_def.page_num_type, 1,
+            "홀수 쪽 시작(pageStartsOn=ODD)이 왕복에서 보존돼야 함"
         );
     }
 


### PR DESCRIPTION
`<hp:startNum>` 의 `pageStartsOn`(쪽 번호 시작을 홀수/짝수 쪽에 맞춤)이 HWPX 왕복에서 유실됩니다.

## 원인 (양방향 갭)
- **파서**: `parse_start_num`(src/parser/hwpx/section.rs:1233)이 `page`/`pic`/`tbl`/`equation` 만 읽고 `pageStartsOn` 을 무시합니다.
- **직렬화**: secPr 의 `<hp:startNum>` 을 `pageStartsOn="BOTH"` 로 **하드코딩** 방출합니다.

결과적으로 `SectionDef.page_num_type`(0=이어서/1=홀수/2=짝수, HWP5 flags bit20-21)이 HWPX 왕복 시 항상 0 으로 유실됩니다. 이 값은 렌더링에서 소비됩니다(`document_core/queries/rendering.rs:1753` — `flags |= (page_num_type & 0x03) << 20`). 장(章)을 홀수 쪽에서 시작하는 문서 등이 영향받습니다.

## 수정
- 파서: `pageStartsOn` arm 추가 — `ODD`→1, `EVEN`→2, 그 외→0.
- 직렬화: `page_starts_on_str(page_num_type)` 로 방출(파서의 역매핑, 0→BOTH/1→ODD/2→EVEN).

> 안전성: 종전 동작은 *항상* `BOTH` 이므로 IR 값 방출은 회귀 없이 홀/짝 시작만 복원합니다.

## 검증
`page_starts_on_odd_survives_hwpx_roundtrip` 추가: `page_num_type=1`(홀수)을 `serialize_hwpx`→`parse_hwpx` 왕복 후 보존됨을 단언 — 수정 전 red(0), 수정 후 green. `cargo test --lib` 통과.