### PR TITLE
fix(safari): content-script capabilities에 edit/print 추가

### DIFF
--- a/rhwp-safari/src/content-script.js
+++ b/rhwp-safari/src/content-script.js
@@ -37,7 +37,7 @@
   if (shouldAnnounce) {
     document.documentElement.setAttribute('data-hwp-extension', 'rhwp');
     window.dispatchEvent(new CustomEvent('hwp-extension-ready', {
-      detail: { name: 'rhwp', capabilities: ['preview'] }
+      detail: { name: 'rhwp', capabilities: ['preview', 'edit', 'print'] }
     }));
   }
 


### PR DESCRIPTION
## 개요

Safari 확장의 data-hwp-extension CustomEvent detail에서 capabilities를 ['preview']만 포함하고 있어 Chrome/Firefox 확장의 ['preview', 'edit', 'print']와 불일치합니다.

## 원인

hwp-safari/src/content-script.js의 hwp-extension-ready 이벤트 발행 시 capabilities를 ['preview']만 포함하고 있습니다. Safari Web Extension도 동일한 iewer.html을 사용하여 편집(edit) 및 인쇄(print) 기능을 완전히 지원하므로 Chrome/Firefox와 동일한 capabilities를 포함해야 합니다.

## 참고

이 capabilities는 허용 도메인(.go.kr, .or.kr 등)에서만 발행되는 이벤트에 포함되며, 실제 기능에 영향을 주지는 않지만 확장 존재를 감지하는 외부 스크립트가 기대하는 값과의 일관성을 유지하기 위해 수정합니다.

## 변경

| 파일 | 변경 |
|------|------|
| rhwp-safari/src/content-script.js | capabilities에 edit, print 추가 (1라인) |