### PR TITLE
fix(studio): 중첩 표 셀 삭제·서식 경로를 최내곽 셀로 보정

### DIFF
--- a/mydocs/orders/20260719.md
+++ b/mydocs/orders/20260719.md
@@ -161,3 +161,16 @@ OVR 원커맨드화 + 신규 소실 검출 + 공허 판정 제도화(개체 수 
   `cargo test --profile release-test --tests`를 통과했다.
 - G3 통합 PR의 최신 head CI를 확인한 뒤 merge한다. G4(#2452/#2453)와 이어지는
   HWPX 보존 PR #2455-#2463은 G3 완료 후 별도 묶음으로 순차 처리한다.
+
+## kevin9327 5차 G3 merge 및 G4 통합 PR 준비
+
+- G3 통합 PR [#2466](https://github.com/edwardkim/rhwp/pull/2466) merge 완료. 원 PR
+  [#2445](https://github.com/edwardkim/rhwp/pull/2445),
+  [#2450](https://github.com/edwardkim/rhwp/pull/2450),
+  [#2451](https://github.com/edwardkim/rhwp/pull/2451)은 통합 PR 링크 코멘트 후 종료.
+- G4는 [#2452](https://github.com/edwardkim/rhwp/pull/2452) 삭제 경로와
+  [#2453](https://github.com/edwardkim/rhwp/pull/2453) 서식 apply/undo 경로를
+  `upstream/devel`에 순서대로 체리픽했다. 실제 2단 중첩 표 회귀를 추가해 안쪽 셀만
+  변경·복원되고 바깥 셀이 보존됨을 확인했다.
+- focused Rust 2건, Studio source guard 9건, TypeScript, fresh WASM, production build,
+  fmt, diff check, clippy가 모두 GREEN. G4 통합 PR 생성 후 최신 CI를 확인한다.

--- a/mydocs/pr/archives/pr_2452_review.md
+++ b/mydocs/pr/archives/pr_2452_review.md
@@ -1,0 +1,52 @@
+# PR #2452 리뷰 - 중첩 표 셀 선택 삭제의 최내곽 경로 적용
+
+## 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| 원 PR | [#2452](https://github.com/edwardkim/rhwp/pull/2452) |
+| 작성자 | `kevin9327` |
+| base | `devel` |
+| 리뷰 경로 | collaborator-mediated 외부 PR, G4 체리픽 통합 |
+| 적용 커밋 | `7a3342ad708746eab5be5734c7952d9320f96ce5` |
+| 적용 순서 | G4 1/2, G3 merge 뒤 최신 `upstream/devel` 위 체리픽, 충돌 없음 |
+| 작성 시점 참고값 | 원 PR CI 통과. 통합 PR의 최신 head CI와 mergeable 상태를 merge 전 다시 확인한다. |
+
+## 변경 검토
+
+중첩 표를 hit-test하면 flat `controlIndex`/`cellIndex`는 `cellPath[0]`의 바깥 셀을 가리킨다.
+기존 `DeleteSelectionCommand`는 그 flat 좌표로 삭제 범위와 undo 텍스트를 처리해, 실제 선택한
+최내곽 셀 대신 바깥 셀을 지울 수 있었다.
+
+PR은 삭제, 삭제 전 텍스트 수집, 문단 길이 확인을 `cellPath[last]` 기반 ByPath API로 통일한다.
+Rust의 `delete_range_in_cell_by_path`와 WASM export를 추가하고 mutation registry에도 등록해
+문서 변경 추적 규약을 지킨다.
+
+통합 검토에서 실제 2단 중첩 표 구조를 구성해 안쪽 `INNER`의 중간 두 글자만 삭제했을 때 `IER`가
+되고, 같은 외곽 셀의 `OUTER`가 그대로 남는 회귀 테스트를 추가했다. 원 PR의 정적 source guard만으로
+대상 축이 실제로 분리되는지 보장하기 어려운 공백을 메인터너 보강으로 메웠다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `delete_range_in_nested_cell_by_path_preserves_outer_cell` | PASS |
+| nested-cell Studio source guard + mutation routing 9건 | PASS |
+| `npx tsc --noEmit` | PASS |
+| `wasm-pack build --target web --out-dir pkg` | PASS |
+| `npm run build` | PASS |
+| `cargo fmt --check` | PASS |
+| `git diff --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+
+## 시각 검증 판단
+
+변경 범위는 이미 조판된 페이지의 renderer/layout 출력이 아니라 중첩 표 셀 편집 명령의 대상
+해석과 WASM bridge다. 실제 문서 구조 회귀와 Studio production build로 명령 경로를 검증했으며,
+PDF visual sweep 또는 MCP 기준 PDF의 비교 대상은 아니다. 원 PR 본문에 적힌 실제 브라우저 왕복은
+merge 뒤에도 대표 중첩 표 문서로 수동 확인한다.
+
+## 최종 의견
+
+G4 통합 PR에 원 커밋을 보존해 수용한다. #2453의 같은 경로 보정 및 undo 회귀와 함께 merge하며,
+merge 전 통합 PR 최신 head의 GitHub Actions와 mergeable 상태를 재확인한다.

--- a/mydocs/pr/archives/pr_2453_review.md
+++ b/mydocs/pr/archives/pr_2453_review.md
@@ -1,0 +1,51 @@
+# PR #2453 리뷰 - 중첩 표 셀 서식 적용과 undo의 최내곽 경로 적용
+
+## 메타데이터
+
+| 항목 | 값 |
+|---|---|
+| 원 PR | [#2453](https://github.com/edwardkim/rhwp/pull/2453) |
+| 작성자 | `kevin9327` |
+| base | `devel` |
+| 리뷰 경로 | collaborator-mediated 외부 PR, G4 체리픽 통합 |
+| 적용 커밋 | `3a428b3841eb5825e8618e02bd89ee9270e8e9d3` |
+| 적용 순서 | G4 2/2, #2452 뒤 최신 `upstream/devel` 위 체리픽, comment-only 충돌을 통합 헬퍼 설명으로 해소 |
+| 작성 시점 참고값 | 원 PR CI 통과. 통합 PR의 최신 head CI와 mergeable 상태를 merge 전 다시 확인한다. |
+
+## 변경 검토
+
+`ApplyCharFormatCommand`도 flat 셀 좌표를 사용해 실제 안쪽 선택 대신 바깥 셀에 서식을 적용하고
+undo할 위험이 있었다. PR은 apply, 현재 char shape 조회, 문단 길이, undo 복원을 모두 ByPath API로
+전환하고 WASM bridge 및 mutation registry를 함께 갱신한다.
+
+공통 `cellPathJsonForPara` 헬퍼는 #2452와 중복될 수 있다는 작성자 메모가 있었으나, 체리픽 순서에서
+하나의 구현만 유지되어 기능 중복이나 실행 충돌은 없다.
+
+통합 검토에서는 2단 중첩 표의 안쪽 `INNER` 전체에 bold를 적용한 뒤, undo가 쓰는
+`set_char_shape_id_in_cell_by_path`로 기본 shape ID를 복원했다. 적용 전후 모두 외곽 `OUTER`의
+shape ID가 바뀌지 않음을 확인해 execute와 undo 양쪽의 대상 축을 검증했다.
+
+## 검증
+
+| 게이트 | 결과 |
+|---|---|
+| `apply_char_format_in_nested_cell_by_path_preserves_outer_cell` | PASS |
+| nested-cell Studio source guard + mutation routing 9건 | PASS |
+| `npx tsc --noEmit` | PASS |
+| `wasm-pack build --target web --out-dir pkg` | PASS |
+| `npm run build` | PASS |
+| `cargo fmt --check` | PASS |
+| `git diff --check` | PASS |
+| `cargo clippy --all-targets -- -D warnings` | PASS |
+
+## 시각 검증 판단
+
+서식이 화면에 나타나는 결과 자체는 사용자-visible이지만, 이 PR은 char shape의 renderer/layout
+해석을 바꾸지 않고 편집 명령이 어느 중첩 셀에 변경을 기록하는지만 교정한다. 실제 중첩 구조에서
+apply/undo 대상을 검증했고 Studio production build도 통과했다. 따라서 PDF visual sweep 또는 MCP
+기준 PDF 비교 대상은 아니며, 원 PR 본문의 브라우저 왕복은 merge 뒤 대표 문서로 수동 확인한다.
+
+## 최종 의견
+
+G4 통합 PR에 원 커밋을 보존해 수용한다. #2452의 삭제 경로 보정과 함께 merge하며, merge 전 통합 PR
+최신 head의 GitHub Actions와 mergeable 상태를 재확인한다.

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -26,7 +26,7 @@ export const MUTATING_METHODS: readonly string[] = [
   'insertPageBreak', 'insertColumnBreak', 'insertNewNumber', 'setNumberingRestart',
   // 셀 텍스트/문단
   'insertTextInCell', 'insertTextInCellDeferredPagination', 'deleteTextInCell',
-  'deleteRangeInCell', 'insertTextInCellByPath', 'deleteTextInCellByPath',
+  'deleteRangeInCell', 'insertTextInCellByPath', 'deleteTextInCellByPath', 'deleteRangeInCellByPath',
   'splitParagraphInCell', 'mergeParagraphInCell', 'splitParagraphInCellByPath',
   'mergeParagraphInCellByPath',
   // 표 구조/속성

--- a/rhwp-studio/src/core/mutation-method-registry.ts
+++ b/rhwp-studio/src/core/mutation-method-registry.ts
@@ -51,7 +51,8 @@ export const MUTATING_METHODS: readonly string[] = [
   'pasteInternal', 'pasteInternalInCell', 'pasteInternalInCellByPath', 'pasteControl',
   'pasteHtml', 'pasteHtmlInCell', 'pasteHtmlInCellByPath',
   // 글자/문단 모양
-  'applyCharFormat', 'setCharShapeId', 'applyCharFormatInCell', 'setCharShapeIdInCell',
+  'applyCharFormat', 'setCharShapeId', 'applyCharFormatInCell', 'applyCharFormatInCellByPath',
+  'setCharShapeIdInCell', 'setCharShapeIdInCellByPath',
   'applyParaFormat', 'setParaShapeId', 'applyParaFormatInCell', 'setCellParaShapeId',
   // 스타일/번호 정의 (DocInfo 변이 포함)
   'updateStyle', 'updateStyleShapes', 'createStyle', 'deleteStyle', 'applyStyle',

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -922,6 +922,12 @@ export class WasmBridge {
     return (this.doc as any).deleteTextInCellByPath(sec, parentPara, pathJson, charOffset, count);
   }
 
+  /** deleteRangeInCell 의 cellPath 변형 — 중첩 표 셀의 선택 삭제가 최내곽 셀을 대상으로 한다. */
+  deleteRangeInCellByPath(sec: number, parentPara: number, pathJson: string, startPara: number, startOffset: number, endPara: number, endOffset: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).deleteRangeInCellByPath(sec, parentPara, pathJson, startPara, startOffset, endPara, endOffset);
+  }
+
   splitParagraphInCellByPath(sec: number, parentPara: number, pathJson: string, charOffset: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).splitParagraphInCellByPath(sec, parentPara, pathJson, charOffset);

--- a/rhwp-studio/src/core/wasm-bridge.ts
+++ b/rhwp-studio/src/core/wasm-bridge.ts
@@ -1836,6 +1836,12 @@ export class WasmBridge {
     return JSON.parse(this.doc.getCellCharPropertiesAt(sec, parentPara, controlIdx, cellIdx, cellParaIdx, charOffset));
   }
 
+  /** getCellCharPropertiesAt 의 cellPath 변형 — 중첩 셀의 charShapeId 조회. */
+  getCellCharPropertiesAtByPath(sec: number, parentPara: number, pathJson: string, charOffset: number): CharProperties {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return JSON.parse((this.doc as any).getCellCharPropertiesAtByPath(sec, parentPara, pathJson, charOffset));
+  }
+
   applyCharFormat(sec: number, para: number, startOffset: number, endOffset: number, propsJson: string): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return this.doc.applyCharFormat(sec, para, startOffset, endOffset, propsJson);
@@ -1851,9 +1857,21 @@ export class WasmBridge {
     return this.doc.applyCharFormatInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, startOffset, endOffset, propsJson);
   }
 
+  /** applyCharFormatInCell 의 cellPath 변형 — 중첩 셀 선택에 서식을 적용한다. */
+  applyCharFormatInCellByPath(sec: number, parentPara: number, pathJson: string, startOffset: number, endOffset: number, propsJson: string): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).applyCharFormatInCellByPath(sec, parentPara, pathJson, startOffset, endOffset, propsJson);
+  }
+
   setCharShapeIdInCell(sec: number, parentPara: number, controlIdx: number, cellIdx: number, cellParaIdx: number, startOffset: number, endOffset: number, charShapeId: number): string {
     if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
     return (this.doc as any).setCharShapeIdInCell(sec, parentPara, controlIdx, cellIdx, cellParaIdx, startOffset, endOffset, charShapeId);
+  }
+
+  /** setCharShapeIdInCell 의 cellPath 변형 — 중첩 셀 서식 undo 복원. */
+  setCharShapeIdInCellByPath(sec: number, parentPara: number, pathJson: string, startOffset: number, endOffset: number, charShapeId: number): string {
+    if (!this.doc) throw new Error('문서가 로드되지 않았습니다');
+    return (this.doc as any).setCharShapeIdInCellByPath(sec, parentPara, pathJson, startOffset, endOffset, charShapeId);
   }
 
   findOrCreateFontId(name: string): number {

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -180,7 +180,7 @@ function cellPathJson(pos: DocumentPosition): string {
 }
 
 /** cellPath 의 최내곽(마지막) 엔트리의 cellParaIndex 를 지정 값으로 바꾼 pathJson.
- *  중첩 셀 선택 삭제의 undo 저장에서 각 문단 텍스트를 ...ByPath 로 읽을 때 사용한다. */
+ *  중첩 셀의 문단별 ByPath 호출(삭제 undo 저장과 문자 서식 적용/undo)에 쓴다. */
 function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): string {
   const path = (pos.cellPath ?? []).map((e) => ({ ...e }));
   if (path.length > 0) path[path.length - 1].cellParaIndex = cellParaIndex;
@@ -670,24 +670,26 @@ export class ApplyCharFormatCommand implements EditCommand {
     const propsJson = JSON.stringify(this.props);
 
     if (isCell(start)) {
+      // 중첩 셀 좌표 축 정합: flat controlIndex/cellIndex 는 cellPath[0](최외곽)이라 중첩
+      // 셀에서 바깥 셀에 서식을 적용한다. 최내곽 셀을 ...ByPath 로 라우팅하고 문단 인덱스는
+      // cellPath[last](cellParaIndexOf)에서 읽는다. undo(restoreCharShapeIds)도 같은 축.
       const sec = start.sectionIndex;
       const ppi = start.parentParaIndex!;
-      const ci = start.controlIndex!;
-      const cei = start.cellIndex!;
-      const startPara = start.cellParaIndex!;
-      const endPara = end.cellParaIndex!;
+      const startPara = cellParaIndexOf(start);
+      const endPara = cellParaIndexOf(end);
 
       this.entries = [];
       for (let p = startPara; p <= endPara; p++) {
+        const pathP = cellPathJsonForPara(start, p);
         const from = p === startPara ? start.charOffset : 0;
-        const to = p === endPara ? end.charOffset : wasm.getCellParagraphLength(sec, ppi, ci, cei, p);
+        const to = p === endPara ? end.charOffset : wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
         if (to <= from) continue;
 
-        const prevProps = wasm.getCellCharPropertiesAt(sec, ppi, ci, cei, p, from);
+        const prevProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
         this.entries.push({ paraIndex: p, startOffset: from, endOffset: to, beforeCharShapeId: prevProps.charShapeId });
 
-        wasm.applyCharFormatInCell(sec, ppi, ci, cei, p, from, to, propsJson);
-        const afterProps = wasm.getCellCharPropertiesAt(sec, ppi, ci, cei, p, from);
+        wasm.applyCharFormatInCellByPath(sec, ppi, pathP, from, to, propsJson);
+        const afterProps = wasm.getCellCharPropertiesAtByPath(sec, ppi, pathP, from);
         this.entries[this.entries.length - 1].afterCharShapeId = afterProps.charShapeId;
       }
     } else {
@@ -725,9 +727,10 @@ export class ApplyCharFormatCommand implements EditCommand {
       if (charShapeId === undefined) continue;
 
       if (isCell(start)) {
-        wasm.setCharShapeIdInCell(
-          start.sectionIndex, start.parentParaIndex!, start.controlIndex!, start.cellIndex!,
-          entry.paraIndex, entry.startOffset, entry.endOffset, charShapeId,
+        // 중첩 셀 축 정합: 최내곽 셀에 서식 ID 복원(execute 와 동일 축).
+        wasm.setCharShapeIdInCellByPath(
+          start.sectionIndex, start.parentParaIndex!, cellPathJsonForPara(start, entry.paraIndex),
+          entry.startOffset, entry.endOffset, charShapeId,
         );
       } else {
         wasm.setCharShapeId(start.sectionIndex, entry.paraIndex, entry.startOffset, entry.endOffset, charShapeId);

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -179,6 +179,14 @@ function cellPathJson(pos: DocumentPosition): string {
   return JSON.stringify(pos.cellPath ?? []);
 }
 
+/** cellPath 의 최내곽(마지막) 엔트리의 cellParaIndex 를 지정 값으로 바꾼 pathJson.
+ *  중첩 셀 선택 삭제의 undo 저장에서 각 문단 텍스트를 ...ByPath 로 읽을 때 사용한다. */
+function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): string {
+  const path = (pos.cellPath ?? []).map((e) => ({ ...e }));
+  if (path.length > 0) path[path.length - 1].cellParaIndex = cellParaIndex;
+  return JSON.stringify(path);
+}
+
 /**
  * 셀 문단 인덱스 — cellPath 가 있으면 마지막(가장 안쪽) 엔트리에서 읽는다.
  *
@@ -538,24 +546,27 @@ export class DeleteSelectionCommand implements EditCommand {
     // 삭제 전 텍스트 보존 (undo용)
     this.savedTexts = [];
     if (isCell(start)) {
+      // 중첩 셀 좌표 축 정합: flat controlIndex/cellIndex 는 cellPath[0](최외곽)이라
+      // 중첩 셀에서 바깥 셀을 삭제한다. 최내곽 셀을 대상으로 ...ByPath 로 라우팅하고,
+      // 셀 문단 인덱스는 cellPath[last] 에서 읽는다(cellParaIndexOf). undo 는 이미
+      // doInsertTextImmediate 가 cellPath 로 최내곽 셀에 삽입하므로 축이 일치한다.
       const sec = start.sectionIndex;
       const ppi = start.parentParaIndex!;
-      const ci = start.controlIndex!;
-      const cei = start.cellIndex!;
-      const startPara = start.cellParaIndex!;
-      const endPara = end.cellParaIndex!;
+      const startPara = cellParaIndexOf(start);
+      const endPara = cellParaIndexOf(end);
       this.multiPara = startPara !== endPara;
       for (let p = startPara; p <= endPara; p++) {
-        const pLen = wasm.getCellParagraphLength(sec, ppi, ci, cei, p);
+        const pathP = cellPathJsonForPara(start, p);
+        const pLen = wasm.getCellParagraphLengthByPath(sec, ppi, pathP);
         const from = p === startPara ? start.charOffset : 0;
         const to = p === endPara ? end.charOffset : pLen;
         if (to > from) {
-          this.savedTexts.push(wasm.getTextInCell(sec, ppi, ci, cei, p, from, to - from));
+          this.savedTexts.push(wasm.getTextInCellByPath(sec, ppi, pathP, from, to - from));
         } else {
           this.savedTexts.push('');
         }
       }
-      wasm.deleteRangeInCell(sec, ppi, ci, cei, startPara, start.charOffset, endPara, end.charOffset);
+      wasm.deleteRangeInCellByPath(sec, ppi, cellPathJson(start), startPara, start.charOffset, endPara, end.charOffset);
     } else {
       const sec = start.sectionIndex;
       this.multiPara = start.paragraphIndex !== end.paragraphIndex;

--- a/rhwp-studio/tests/apply-charformat-nested-cell.test.ts
+++ b/rhwp-studio/tests/apply-charformat-nested-cell.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ApplyCharFormatCommand 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다. 중첩 표 셀
+// 선택에 이를 그대로 applyCharFormatInCell/getCellCharPropertiesAt/setCharShapeIdInCell(flat)에
+// 넘기면 **바깥 셀**에 서식을 적용/복원한다. execute·undo 모두 최내곽 셀 대상 ...ByPath 로
+// 라우팅하고, 셀 문단 인덱스는 cellParaIndexOf(=cellPath[last])에서 읽어야 한다.
+//
+// 기준 선례: cursor.ts:399 의 useCellPath 분기. 행위 증명은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+function classBlock(name: string): string {
+  const start = commandSrc.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = commandSrc.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? commandSrc.slice(start) : commandSrc.slice(start, start + 1 + rel);
+}
+
+test('ApplyCharFormatCommand 셀 서식 적용/복원이 최내곽 셀 대상 ...ByPath 로 라우팅한다', () => {
+  const block = classBlock('ApplyCharFormatCommand');
+  assert.match(block, /applyCharFormatInCellByPath\(/, 'execute 는 applyCharFormatInCellByPath 로 최내곽 셀 적용');
+  assert.match(block, /getCellCharPropertiesAtByPath\(/, 'before/after charShapeId 도 ...ByPath 로 조회');
+  assert.match(block, /setCharShapeIdInCellByPath\(/, 'undo(restoreCharShapeIds)도 ...ByPath 로 복원');
+});
+
+test('ApplyCharFormatCommand 가 flat 셀 축 API/좌표를 쓰지 않는다', () => {
+  const block = classBlock('ApplyCharFormatCommand');
+  assert.doesNotMatch(block, /wasm\.applyCharFormatInCell\(/, 'flat applyCharFormatInCell 은 바깥 셀에 적용된다');
+  assert.doesNotMatch(block, /wasm\.getCellCharPropertiesAt\(/, 'flat getCellCharPropertiesAt 금지');
+  assert.doesNotMatch(block, /wasm\.setCharShapeIdInCell\(/, 'flat setCharShapeIdInCell 은 undo 를 바깥 셀에 복원한다');
+  assert.doesNotMatch(block, /wasm\.getCellParagraphLength\(/, 'flat getCellParagraphLength 금지');
+  assert.doesNotMatch(block, /start\.cellParaIndex!/, '중첩 셀에서 start.cellParaIndex 는 바깥 셀 값 (cellParaIndexOf 사용)');
+  assert.doesNotMatch(block, /end\.cellParaIndex!/, '중첩 셀에서 end.cellParaIndex 는 바깥 셀 값 (cellParaIndexOf 사용)');
+});

--- a/rhwp-studio/tests/delete-selection-nested-cell.test.ts
+++ b/rhwp-studio/tests/delete-selection-nested-cell.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// DeleteSelectionCommand 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다. 중첩 표
+// 셀에서 이를 그대로 deleteRangeInCell/getTextInCell(flat)에 넘기면 **바깥 셀**의 선택을
+// 삭제한다. 최내곽 셀을 대상으로 ...ByPath 로 라우팅하고, 셀 문단 인덱스는 cellPath[last]
+// (cellParaIndexOf)에서 읽어야 한다. undo 는 이미 doInsertTextImmediate 가 cellPath 로
+// 최내곽 셀에 삽입하므로 축이 일치한다.
+//
+// 기준 선례: cursor.ts:399, input-handler-text.ts 의 useCellPath 분기.
+// 행위 증명(중첩 표 왕복)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+/** `export class NAME ...` 부터 다음 `export class` 전까지 클래스 본문을 추출. */
+function classBlock(name: string): string {
+  const start = commandSrc.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = commandSrc.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? commandSrc.slice(start) : commandSrc.slice(start, start + 1 + rel);
+}
+
+test('DeleteSelectionCommand 셀 삭제가 최내곽 셀 대상 ...ByPath 로 라우팅한다', () => {
+  const block = classBlock('DeleteSelectionCommand');
+  assert.match(block, /deleteRangeInCellByPath\(/,
+    '중첩 셀 선택 삭제는 deleteRangeInCellByPath 로 최내곽 셀을 대상으로 해야 한다');
+  assert.match(block, /getTextInCellByPath\(/,
+    'undo 저장 텍스트도 getTextInCellByPath(최내곽) 로 읽어야 한다');
+});
+
+test('DeleteSelectionCommand 가 flat 셀 축 API/좌표를 쓰지 않는다', () => {
+  const block = classBlock('DeleteSelectionCommand');
+  assert.doesNotMatch(block, /wasm\.deleteRangeInCell\(/,
+    'flat deleteRangeInCell 은 cellPath[0](최외곽) 좌표라 중첩 셀에서 바깥 셀을 삭제한다');
+  assert.doesNotMatch(block, /wasm\.getTextInCell\(/,
+    'flat getTextInCell 대신 getTextInCellByPath 를 써야 한다');
+  assert.doesNotMatch(block, /wasm\.getCellParagraphLength\(/,
+    'flat getCellParagraphLength 는 외부 표 기준 레거시 좌표를 쓴다');
+  assert.doesNotMatch(block, /start\.cellParaIndex!/,
+    '중첩 셀에서 start.cellParaIndex 는 바깥 셀 문단 인덱스다 (cellParaIndexOf 사용)');
+  assert.doesNotMatch(block, /end\.cellParaIndex!/,
+    '중첩 셀에서 end.cellParaIndex 는 바깥 셀 문단 인덱스다 (cellParaIndexOf 사용)');
+});

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -2139,8 +2139,11 @@ impl DocumentCore {
 
 #[cfg(test)]
 mod tests {
-    use super::char_shape_mods_affect_text_flow;
+    use super::{char_shape_mods_affect_text_flow, DocumentCore};
+    use crate::model::control::Control;
+    use crate::model::paragraph::{CharShapeRef, Paragraph};
     use crate::model::style::CharShapeMods;
+    use crate::model::table::{Cell, Table};
 
     #[test]
     fn char_ratio_and_spacing_changes_require_text_reflow() {
@@ -2164,6 +2167,109 @@ mod tests {
             ..Default::default()
         };
         assert!(!char_shape_mods_affect_text_flow(&mods));
+    }
+
+    #[test]
+    fn apply_char_format_in_nested_cell_by_path_preserves_outer_cell() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        if core.document.doc_info.char_shapes.is_empty() {
+            // 실제 문서는 기본 글자 모양을 보유한다. 새 서식이 0번을 재사용하지 않게 맞춘다.
+            core.document.doc_info.char_shapes.push(Default::default());
+        }
+
+        let inner_para = Paragraph {
+            text: "INNER".to_string(),
+            char_count: 5,
+            char_offsets: vec![0, 1, 2, 3, 4],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            ..Default::default()
+        };
+        let nested_table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut outer_para = Paragraph {
+            text: "OUTER".to_string(),
+            char_count: 5,
+            char_offsets: vec![0, 1, 2, 3, 4],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            ..Default::default()
+        };
+        outer_para
+            .controls
+            .push(Control::Table(Box::new(nested_table)));
+        let nested_ctrl_idx = outer_para.controls.len() - 1;
+        let outer_table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![outer_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+        let outer_ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+        let path = [(outer_ctrl_idx, 0, 0), (nested_ctrl_idx, 0, 0)];
+
+        // 안쪽 셀에만 굵게 적용한다. 바깥 셀의 글자 모양 ID는 그대로여야 한다.
+        core.apply_char_format_in_cell_by_path(0, 0, &path, 0, 5, r#"{"bold":true}"#)
+            .unwrap();
+
+        let inner_shape_id = {
+            let Control::Table(outer) =
+                &core.document.sections[0].paragraphs[0].controls[outer_ctrl_idx]
+            else {
+                panic!("expected outer table");
+            };
+            assert_eq!(
+                outer.cells[0].paragraphs[0].char_shape_id_at(0),
+                Some(0),
+                "바깥 셀에는 서식이 적용되면 안 된다"
+            );
+            let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[nested_ctrl_idx]
+            else {
+                panic!("expected nested table");
+            };
+            let inner_shape_id = inner.cells[0].paragraphs[0].char_shape_id_at(0);
+            assert_ne!(
+                inner_shape_id,
+                Some(0),
+                "안쪽 셀에는 새 글자 서식이 적용돼야 한다"
+            );
+            inner_shape_id
+        };
+
+        // undo가 쓰는 ByPath 복원도 안쪽 셀만 기본 글자 모양으로 되돌려야 한다.
+        core.set_char_shape_id_in_cell_by_path(0, 0, &path, 0, 5, 0)
+            .unwrap();
+
+        let Control::Table(outer) =
+            &core.document.sections[0].paragraphs[0].controls[outer_ctrl_idx]
+        else {
+            panic!("expected outer table");
+        };
+        assert_eq!(outer.cells[0].paragraphs[0].char_shape_id_at(0), Some(0));
+        let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[nested_ctrl_idx] else {
+            panic!("expected nested table");
+        };
+        assert_eq!(inner.cells[0].paragraphs[0].char_shape_id_at(0), Some(0));
+        assert_ne!(
+            inner_shape_id,
+            Some(0),
+            "복원 전에는 안쪽 셀만 새 ID여야 한다"
+        );
     }
 }
 

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1167,6 +1167,99 @@ impl DocumentCore {
         Ok("{\"ok\":true}".to_string())
     }
 
+    /// `applyCharFormatInCell` 의 cellPath 변형 (중첩 표 지원).
+    ///
+    /// flat 변형은 controlIndex/cellIndex 를 최외곽(cellPath[0]) 축으로 받아 중첩 셀에서
+    /// 바깥 셀에 서식을 적용한다. 이 변형은 path 로 최내곽 셀 문단을 해석해 적용하고,
+    /// 셀별 리플로우는 rebuild_section 의 전체 재조판이 담당한다(delete_range_in_cell_by_path 동형).
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_char_format_in_cell_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_offset: usize,
+        end_offset: usize,
+        props_json: &str,
+    ) -> Result<String, HwpError> {
+        let mut mods = parse_char_shape_mods(props_json);
+        if json_has_border_keys(props_json) {
+            let bf_id = self.create_border_fill_from_json(props_json);
+            mods.border_fill_id = Some(bf_id);
+        }
+        let base_id = {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.char_shape_id_at(start_offset).unwrap_or(0)
+        };
+        let new_id = self.document.find_or_create_char_shape(base_id, &mods);
+        {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.apply_char_shape_range(start_offset, end_offset, new_id);
+        }
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
+        self.rebuild_section(sec_idx);
+        self.event_log.push(DocumentEvent::CharFormatChanged {
+            section: sec_idx,
+            para: parent_para_idx,
+            start: start_offset,
+            end: end_offset,
+        });
+        Ok("{\"ok\":true}".to_string())
+    }
+
+    /// `getCellCharPropertiesAt` 의 cellPath 변형. 커맨드는 charShapeId 만 쓰므로
+    /// shape 기준 속성(build_char_properties_json_by_id)으로 충분하다.
+    pub fn get_cell_char_properties_at_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        char_offset: usize,
+    ) -> Result<String, HwpError> {
+        let char_shape_id = {
+            let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            para.char_shape_id_at(char_offset).unwrap_or(0)
+        };
+        Ok(self.build_char_properties_json_by_id(char_shape_id as u16))
+    }
+
+    /// `setCharShapeIdInCell` 의 cellPath 변형 (중첩 표 지원, undo용).
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_char_shape_id_in_cell_by_path(
+        &mut self,
+        sec_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_offset: usize,
+        end_offset: usize,
+        char_shape_id: u32,
+    ) -> Result<String, HwpError> {
+        if char_shape_id as usize >= self.document.doc_info.char_shapes.len() {
+            return Err(HwpError::RenderError(format!(
+                "글자 모양 ID {} 범위 초과 (총 {}개)",
+                char_shape_id,
+                self.document.doc_info.char_shapes.len()
+            )));
+        }
+        {
+            let cell_para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
+            cell_para.apply_char_shape_range(start_offset, end_offset, char_shape_id);
+        }
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[sec_idx].raw_stream = None;
+        self.rebuild_section(sec_idx);
+        self.event_log.push(DocumentEvent::CharFormatChanged {
+            section: sec_idx,
+            para: parent_para_idx,
+            start: start_offset,
+            end: end_offset,
+        });
+        Ok("{\"ok\":true}".to_string())
+    }
+
     /// 글자 서식 ID 직접 복원 (네이티브) — 셀 내 문단.
     pub fn set_char_shape_id_in_cell_native(
         &mut self,

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3844,6 +3844,63 @@ mod tests {
     }
 
     #[test]
+    fn delete_range_in_nested_cell_by_path_preserves_outer_cell() {
+        use crate::model::control::Control;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut inner_para = Paragraph::default();
+        inner_para.text = "INNER".to_string();
+        inner_para.char_count = 5;
+        inner_para.char_offsets = vec![0, 1, 2, 3, 4];
+        let nested_table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut outer_para = Paragraph::default();
+        outer_para.text = "OUTER".to_string();
+        outer_para.char_count = 5;
+        outer_para.char_offsets = vec![0, 1, 2, 3, 4];
+        outer_para
+            .controls
+            .push(Control::Table(Box::new(nested_table)));
+        let nested_ctrl_idx = outer_para.controls.len() - 1;
+        let outer_table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![outer_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+        let outer_ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+        let path = [(outer_ctrl_idx, 0, 0), (nested_ctrl_idx, 0, 0)];
+
+        // INNER의 1..3(NN)만 지우고, 같은 컨테이너의 바깥 셀 OUTER는 보존해야 한다.
+        core.delete_range_in_cell_by_path(0, 0, &path, 0, 1, 0, 3)
+            .unwrap();
+
+        let Control::Table(outer) =
+            &core.document.sections[0].paragraphs[0].controls[outer_ctrl_idx]
+        else {
+            panic!("expected outer table");
+        };
+        assert_eq!(outer.cells[0].paragraphs[0].text, "OUTER");
+        let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[nested_ctrl_idx] else {
+            panic!("expected nested table");
+        };
+        assert_eq!(inner.cells[0].paragraphs[0].text, "IER");
+    }
+
+    #[test]
     fn insert_paragraph_inherits_shape_from_previous_paragraph() {
         let mut core = core_with_two_shaped_paragraphs();
 

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -3488,6 +3488,77 @@ impl DocumentCore {
         )))
     }
 
+    /// path 기반 셀 내 범위 삭제 (중첩 표 지원). `deleteRangeInCell`(flat)의 cellPath 변형.
+    ///
+    /// flat deleteRangeInCell 은 controlIndex/cellIndex 를 최외곽(cellPath[0]) 축으로 받아
+    /// 중첩 셀에서 바깥 셀을 삭제한다. 이 변형은 path 로 최내곽 셀을 해석해 그 셀의
+    /// 문단 목록에 직접 범위 삭제를 적용한다. start_para/end_para 는 최내곽 셀 내부 인덱스다.
+    #[allow(clippy::too_many_arguments)]
+    pub fn delete_range_in_cell_by_path(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_para: usize,
+        start_offset: usize,
+        end_para: usize,
+        end_offset: usize,
+    ) -> Result<String, HwpError> {
+        {
+            let paras = self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)?;
+            if start_para == end_para {
+                let count = end_offset.saturating_sub(start_offset);
+                if count > 0 {
+                    if let Some(p) = paras.get_mut(start_para) {
+                        p.delete_text_at(start_offset, count);
+                    }
+                }
+            } else {
+                // 1) 마지막 문단 앞부분 삭제
+                if end_offset > 0 {
+                    if let Some(p) = paras.get_mut(end_para) {
+                        p.delete_text_at(0, end_offset);
+                    }
+                }
+                // 2) 중간 문단 역순 제거
+                for mid in (start_para + 1..end_para).rev() {
+                    if mid < paras.len() {
+                        paras.remove(mid);
+                    }
+                }
+                // 3) 첫 문단 뒷부분 삭제
+                if let Some(p) = paras.get_mut(start_para) {
+                    let para_len = p.text.chars().count();
+                    if start_offset < para_len {
+                        p.delete_text_at(start_offset, para_len - start_offset);
+                    }
+                }
+                // 4) 첫-마지막 문단 병합 (마지막이 이제 start_para+1)
+                if start_para + 1 < paras.len() {
+                    let next = paras.remove(start_para + 1);
+                    paras[start_para].merge_from(&next);
+                }
+            }
+        }
+
+        // dirty/이벤트는 delete_text_in_cell_by_path 와 동형(최외곽 컨트롤 기준).
+        let outer_ctrl = path[0].0;
+        self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
+        self.document.sections[section_idx].raw_stream = None;
+        self.mark_section_dirty(section_idx);
+        self.paginate_if_needed();
+        self.event_log.push(DocumentEvent::CellTextChanged {
+            section: section_idx,
+            para: parent_para_idx,
+            ctrl: outer_ctrl,
+            cell: path[0].1,
+        });
+        Ok(super::super::helpers::json_ok_with(&format!(
+            "\"paraIdx\":{},\"charOffset\":{}",
+            start_para, start_offset
+        )))
+    }
+
     /// path 기반 셀 문단 분할 (중첩 표 지원)
     pub fn split_paragraph_in_cell_by_path(
         &mut self,
@@ -3733,6 +3804,43 @@ mod tests {
         set_shape(&mut core, 0, 12, 3, 7);
         set_shape(&mut core, 1, 14, 5, 9);
         core
+    }
+
+    #[test]
+    fn delete_range_in_cell_by_path_deletes_within_resolved_cell() {
+        use crate::model::control::Control;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let mut cell_para = Paragraph::default();
+        cell_para.text = "ABCDE".to_string();
+        cell_para.char_count = 5;
+        cell_para.char_offsets = vec![0, 1, 2, 3, 4];
+        let table = Table {
+            cells: vec![Cell {
+                paragraphs: vec![cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        core.document.sections[0].paragraphs[0]
+            .controls
+            .push(Control::Table(Box::new(table)));
+        let ctrl_idx = core.document.sections[0].paragraphs[0].controls.len() - 1;
+
+        // 셀 문단 offset 1..3(BC) 삭제. path 로 최내곽 셀을 해석해야 한다.
+        core.delete_range_in_cell_by_path(0, 0, &[(ctrl_idx, 0, 0)], 0, 1, 0, 3)
+            .unwrap();
+
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[ctrl_idx] else {
+            panic!("expected table");
+        };
+        assert_eq!(
+            t.cells[0].paragraphs[0].text, "ADE",
+            "path 로 해석한 셀에서 BC 가 삭제돼야 한다"
+        );
     }
 
     #[test]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -1163,6 +1163,31 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = deleteRangeInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn delete_range_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_para: u32,
+        start_offset: u32,
+        end_para: u32,
+        end_offset: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.delete_range_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_para as usize,
+            start_offset as usize,
+            end_para as usize,
+            end_offset as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
     #[wasm_bindgen(js_name = splitParagraphInCellByPath)]
     pub fn split_paragraph_in_cell_by_path_api(
         &mut self,

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6386,6 +6386,70 @@ impl HwpDocument {
         .map_err(|e| e.into())
     }
 
+    #[wasm_bindgen(js_name = applyCharFormatInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn apply_char_format_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_offset: u32,
+        end_offset: u32,
+        props_json: &str,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.apply_char_format_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_offset as usize,
+            end_offset as usize,
+            props_json,
+        )
+        .map_err(|e| e.into())
+    }
+
+    #[wasm_bindgen(js_name = getCellCharPropertiesAtByPath)]
+    pub fn get_cell_char_properties_at_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        char_offset: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.get_cell_char_properties_at_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            char_offset as usize,
+        )
+        .map_err(|e| e.into())
+    }
+
+    #[wasm_bindgen(js_name = setCharShapeIdInCellByPath)]
+    #[allow(clippy::too_many_arguments)]
+    pub fn set_char_shape_id_in_cell_by_path_api(
+        &mut self,
+        section_idx: u32,
+        parent_para_idx: u32,
+        path_json: &str,
+        start_offset: u32,
+        end_offset: u32,
+        char_shape_id: u32,
+    ) -> Result<String, JsValue> {
+        let path = DocumentCore::parse_cell_path(path_json)?;
+        self.set_char_shape_id_in_cell_by_path(
+            section_idx as usize,
+            parent_para_idx as usize,
+            &path,
+            start_offset as usize,
+            end_offset as usize,
+            char_shape_id,
+        )
+        .map_err(|e| e.into())
+    }
+
     /// 글자 서식 ID를 직접 복원한다 (셀 내 문단).
     #[wasm_bindgen(js_name = setCharShapeIdInCell)]
     pub fn set_char_shape_id_in_cell(


### PR DESCRIPTION
## 요약

- [#2452](https://github.com/edwardkim/rhwp/pull/2452)의 선택 삭제를 `cellPath[last]` 기반 ByPath API로 전환합니다.
- [#2453](https://github.com/edwardkim/rhwp/pull/2453)의 글자 서식 적용과 undo 복원을 같은 최내곽 경로로 전환합니다.
- 메인터너 회귀 테스트를 보강해 2단 중첩 표에서 안쪽 셀만 변경되고 바깥 셀이 보존됨을 검증합니다.
- 원 PR별 검토 기록과 오늘할일을 포함합니다.

## 검증

- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`
- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
- `cargo fmt --check`
- `git diff --check`
- `npx tsc --noEmit`
- `node --test tests/delete-selection-nested-cell.test.ts tests/apply-charformat-nested-cell.test.ts tests/mutation-routing-guard.test.ts`
- `wasm-pack build --target web --out-dir pkg`
- `npm run build`

## 원 PR

- [#2452](https://github.com/edwardkim/rhwp/pull/2452)
- [#2453](https://github.com/edwardkim/rhwp/pull/2453)

merge 후 원 PR에는 이 통합 PR 링크와 수용 결론을 남기고 종료합니다.
