### PR TITLE
fix(hwp5): 그림 테두리 속성 워드가 저장 시 0 으로 유실

### DIFF
--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1034,7 +1034,9 @@ fn serialize_picture_data(pic: &Picture) -> Vec<u8> {
     let mut w = ByteWriter::new();
     w.write_color_ref(pic.border_color).unwrap();
     w.write_i32(pic.border_width).unwrap();
-    w.write_u32(0).unwrap(); // border_attr
+    // 테두리 속성 워드(선 종류/끝모양 등, 표 87). 파서는 pic.border_attr.attr 로
+    // 읽지만 종전엔 0 을 고정 방출해 스타일 테두리가 저장 시 유실됐다.
+    w.write_u32(pic.border_attr.attr).unwrap(); // border_attr
 
     for &x in &pic.border_x {
         w.write_i32(x).unwrap();

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -506,6 +506,21 @@ fn issue1452_picture_transparency_updates_hwp_extra_byte() {
     );
 }
 
+#[test]
+fn picture_border_attr_word_serialized_from_ir() {
+    // 그림 테두리 속성 워드(선 종류/끝모양 비트)가 IR 에서 방출돼야 한다.
+    // 레이아웃: border_color(4) + border_width(4) + border_attr(4).
+    // 종전엔 이 워드를 0 으로 고정 방출해 스타일 테두리가 저장 시 유실됐다.
+    let mut pic = Picture::default();
+    pic.border_attr.attr = 0x0000_00A5;
+    let bytes = serialize_picture_data(&pic);
+    assert_eq!(
+        &bytes[8..12],
+        &0x0000_00A5u32.to_le_bytes(),
+        "그림 테두리 속성 워드가 IR(border_attr.attr)에서 방출돼야 함"
+    );
+}
+
 /// [#1808] 셀 field_name 이 raw_list_extra 한컴 계약 레이아웃으로 기록되고
 /// 파서 추출(parse_cell_field_name)과 대칭인지 검증.
 #[test]


### PR DESCRIPTION
`serialize_picture_data`(src/serializer/control.rs:1033)가 그림 테두리의 color·width 는 IR 에서 방출하면서, **테두리 속성 워드**(`border_attr` — 선 종류/끝모양 비트, 한글문서파일구조 표 87)만 `w.write_u32(0)` 으로 **하드코딩**합니다.

## 원인
파서는 이 워드를 `pic.border_attr.attr` 로 읽습니다(src/parser/control/shape.rs:884). HWP5 그림/도형 레코드는 raw_data 패스스루가 없어 IR 재인코딩 경로가 항상 실행되므로(`serialize_control` → `serialize_picture_data`), 스타일이 있는 그림 테두리가 **HWP5 왕복** 및 **HWPX→HWP5 변환**(raw_picture_extra 비어있음)에서 유실됩니다.

## 수정
앞선 color/width 방출과 동형으로:
```rust
w.write_u32(pic.border_attr.attr).unwrap(); // border_attr
```

## 검증
`picture_border_attr_word_serialized_from_ir` 추가: `border_attr.attr=0x0000_00A5` 를 방출한 뒤 바이트 레이아웃(color(4)+width(4)+border_attr(4))의 오프셋 8..12 가 IR 값과 일치함을 단언 — 수정 전 red(0), 수정 후 green. `cargo test --lib` 통과.