### PR TITLE
fix(undo): 문단 병합 undo 시 split_at이 field_ranges를 새 문단으로 이관하지 않아 누름틀 필드 소실 (#2417)

### DIFF
--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -303,6 +303,7 @@ impl Paragraph {
                 | Control::Endnote(_)
                 | Control::AutoNumber(_)
                 | Control::CharOverlap(_)
+                | Control::Field(_)
         )
     }
 
@@ -896,8 +897,32 @@ impl Paragraph {
         }
         self.range_tags = kept_range_tags;
 
-        // 5-1. field_ranges 분할 (필드 control은 원래 문단에 유지)
-        self.field_ranges.retain(|fr| fr.end_char_idx <= split_pos);
+        // 5-1. field_ranges 분할
+        let mut new_field_ranges: Vec<FieldRange> = Vec::new();
+        let mut kept_field_ranges: Vec<FieldRange> = Vec::new();
+        // 5-1a. controls 분할 시 control_idx 리매핑을 위한 맵 (old → new)
+        let mut moved_control_idx_map: std::collections::HashMap<usize, usize> = std::collections::HashMap::new();
+        for fr in &self.field_ranges {
+            if fr.start_char_idx >= split_pos {
+                // 완전히 새 문단 쪽 → 인덱스 조정 후 이관 (control_idx는 5-2에서 리매핑)
+                new_field_ranges.push(FieldRange {
+                    start_char_idx: fr.start_char_idx - split_pos,
+                    end_char_idx: fr.end_char_idx - split_pos,
+                    control_idx: fr.control_idx,
+                });
+            } else if fr.end_char_idx <= split_pos {
+                // 완전히 원래 문단 쪽
+                kept_field_ranges.push(fr.clone());
+            } else {
+                // 경계에 걸친 필드: 원래 문단에서 종료
+                kept_field_ranges.push(FieldRange {
+                    start_char_idx: fr.start_char_idx,
+                    end_char_idx: split_pos,
+                    control_idx: fr.control_idx,
+                });
+            }
+        }
+        self.field_ranges = kept_field_ranges;
 
         // 5-2. controls 분할
         //
@@ -917,11 +942,18 @@ impl Paragraph {
                 && control_positions.get(ci).copied().unwrap_or(usize::MAX) >= char_offset;
 
             if move_to_new {
+                moved_control_idx_map.insert(ci, new_controls.len());
                 new_controls.push(ctrl);
                 new_ctrl_data_records.push(data);
             } else {
                 kept_controls.push(ctrl);
                 kept_ctrl_data.push(data);
+            }
+        }
+        // field_ranges의 control_idx를 새 문단의 controls 배열에 맞게 리매핑
+        for fr in &mut new_field_ranges {
+            if let Some(&new_idx) = moved_control_idx_map.get(&fr.control_idx) {
+                fr.control_idx = new_idx;
             }
         }
         self.controls = kept_controls;
@@ -942,7 +974,7 @@ impl Paragraph {
         self.control_mask =
             Self::compute_control_mask_for(&self.text, &self.controls, &self.field_ranges);
         let new_control_mask =
-            Self::compute_control_mask_for(&new_text, &new_controls, &Vec::new());
+            Self::compute_control_mask_for(&new_text, &new_controls, &new_field_ranges);
 
         Paragraph {
             text: new_text,
@@ -950,7 +982,7 @@ impl Paragraph {
             char_shapes: new_char_shapes,
             line_segs: new_line_segs,
             range_tags: new_range_tags,
-            field_ranges: Vec::new(), // controls가 이동하지 않으므로 새 문단에는 필드 없음
+            field_ranges: new_field_ranges, // 새 문단으로 이관된 필드 범위
             orphan_field_ends: Vec::new(),
             char_count: new_char_count,
             para_shape_id: self.para_shape_id,


### PR DESCRIPTION
## 개요

Issue #2417: 문단 병합(merge) 후 undo 시 2번째 문단의 누름틀(ClickHere) 필드가 소실된다.

## 원인

문단 병합 undo는 Paragraph::split_at()으로 merge된 문단을 다시 분할한다. 분할 시 세 가지 문제가 있었다:

1. field_ranges가 retain()으로 제거만 되고 새 문단으로 이관되지 않음
2. Paragraph 생성자에서 field_ranges를 Vec::new()로 무조건 초기화
3. Control::Field가 is_split_movable_control에 포함되지 않아 Field 컨트롤이 새 문단으로 이동하지 않음

## 수정 (4개 포인트)

1. **is_split_movable_control에 Control::Field 추가** -- Field 컨트롤이 field_ranges와 함께 새 문단으로 이동
2. **field_ranges 분할 로직** -- split_pos 기준으로 kept/new 분할, 경계 필드는 원래 문단에서 종료
3. **control_idx 리매핑** -- 새 문단 FieldRange의 control_idx를 새 controls 배열에 맞게 변환
4. **control_mask 반영** -- 새 문단 control_mask에 field_ranges 존재 여부 반영

## 변경

1개 파일, +36/-4 라인
- src/model/paragraph.rs

## 검증

- cargo check --lib: 통과
- cargo test --lib -- model::paragraph: 51/51 통과 (test_split_and_merge_roundtrip 포함)
- cargo test --lib -- wasm_api: 238/238 통과 (회귀 없음)
