### PR TITLE
fix(hwpx): 세로쓰기 셀(textDirection)이 HWPX 왕복 시 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2094,14 +2094,24 @@ fn parse_table_cell(
                         }
                     }
                     b"subList" => {
-                        // subList: vertAlign 속성 파싱
+                        // subList: vertAlign + textDirection 속성 파싱
                         for attr in ce.attributes().flatten() {
-                            if attr.key.as_ref() == b"vertAlign" {
-                                cell.vertical_align = match attr_str(&attr).as_str() {
-                                    "CENTER" => VerticalAlign::Center,
-                                    "BOTTOM" => VerticalAlign::Bottom,
-                                    _ => VerticalAlign::Top,
-                                };
+                            match attr.key.as_ref() {
+                                b"vertAlign" => {
+                                    cell.vertical_align = match attr_str(&attr).as_str() {
+                                        "CENTER" => VerticalAlign::Center,
+                                        "BOTTOM" => VerticalAlign::Bottom,
+                                        _ => VerticalAlign::Top,
+                                    };
+                                }
+                                // 세로쓰기 셀(textDirection). serializer 는 셀 <hp:subList>
+                                // 에 방출하지만 종전엔 vertAlign 만 읽어 세로쓰기가 왕복 시
+                                // 유실됐다(cellPr 경로는 serializer 가 방출하지 않음).
+                                b"textDirection" => {
+                                    cell.text_direction =
+                                        if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+                                }
+                                _ => {}
                             }
                         }
                     }

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -545,6 +545,54 @@ mod tests {
         t
     }
 
+    #[test]
+    fn cell_text_direction_survives_hwpx_roundtrip() {
+        use crate::model::control::Control;
+        // 세로쓰기 셀(text_direction=1)이 HWPX 왕복에서 보존돼야 한다. serializer 는
+        // 셀 <hp:subList> 에 textDirection 을 방출하지만, 종전엔 파서가 subList 에서
+        // vertAlign 만 읽어 세로쓰기가 유실됐다. (유효한 DocInfo 를 위해 표 샘플 사용.)
+        let find_first_table = |doc: &Document| -> usize {
+            doc.sections
+                .iter()
+                .flat_map(|s| &s.paragraphs)
+                .flat_map(|p| &p.controls)
+                .filter(|c| matches!(c, Control::Table(_)))
+                .count()
+        };
+
+        let bytes0 = std::fs::read("samples/hwpx/basic-table-01.hwpx").expect("샘플 읽기");
+        let mut doc = crate::parser::hwpx::parse_hwpx(&bytes0).expect("샘플 파싱");
+        assert!(find_first_table(&doc) >= 1, "샘플에 표가 있어야 함");
+
+        // 첫 표의 첫 셀을 세로쓰기로 설정
+        for section in &mut doc.sections {
+            for para in &mut section.paragraphs {
+                for control in &mut para.controls {
+                    if let Control::Table(table) = control {
+                        table.cells[0].text_direction = 1;
+                    }
+                }
+            }
+        }
+
+        let bytes = crate::serializer::hwpx::serialize_hwpx(&doc).expect("직렬화");
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("재파싱");
+        let table2 = doc2
+            .sections
+            .iter()
+            .flat_map(|s| &s.paragraphs)
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표");
+        assert_eq!(
+            table2.cells[0].text_direction, 1,
+            "세로쓰기 셀 방향(textDirection)이 HWPX 왕복에서 보존돼야 함"
+        );
+    }
+
     fn serialize(table: &Table) -> String {
         let doc = Document::default();
         let mut ctx = SerializeContext::collect_from_document(&doc);


### PR DESCRIPTION
serializer 는 셀의 `<hp:subList>` 에 `textDirection`(VERTICAL/HORIZONTAL)을 방출하지만(src/serializer/hwpx/table.rs:280), 파서의 `subList` 처리는 `vertAlign` 만 읽습니다(src/parser/hwpx/section.rs:2096). 파서가 `textDirection` 을 읽는 곳은 `tcPr`/`cellPr` 인데 serializer 는 셀을 `subList` 로 방출하므로, rhwp→rhwp 왕복에서 **세로쓰기 셀이 항상 HORIZONTAL**(`text_direction=0`)로 되돌아갑니다.

## 영향
`Cell.text_direction`(src/model/table.rs:124, 0=가로/1=세로)이 유실 → 세로쓰기 셀의 레이아웃/렌더가 저장 후 달라집니다. raw passthrough 로 가려지지 않습니다(HWPX 파싱 시 raw_list_extra 비어있음).

## 수정
`subList` 처리를 `match` 로 바꿔 `textDirection` arm 추가(`cellPr` 경로와 동일 로직):
```rust
b"textDirection" => { cell.text_direction = if attr_str(&attr) == "VERTICAL" { 1 } else { 0 }; }
```

## 검증
`cell_text_direction_survives_hwpx_roundtrip` 추가: 표 샘플(basic-table-01.hwpx)의 첫 셀을 세로쓰기로 설정 후 `serialize_hwpx`→`parse_hwpx` 왕복에서 `text_direction==1` 보존을 단언 — 수정 전 red(0), 수정 후 green. `cargo test --lib` 통과.