### PR TITLE
fix(hwp5): 각주/미주 닫는 장식 문자 0 이 ")" 로 오염

### DIFF
--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -786,12 +786,11 @@ fn serialize_footnote(fn_: &Footnote, level: u16, records: &mut Vec<Record>) {
     let mut w = ByteWriter::new();
     w.write_u32(fn_.number as u32).unwrap();
     w.write_u16(fn_.before_decoration_letter).unwrap();
-    let after = if fn_.after_decoration_letter == 0 {
-        0x0029 // ')' default
-    } else {
-        fn_.after_decoration_letter
-    };
-    w.write_u16(after).unwrap();
+    // after_decoration_letter 를 IR 값 그대로 방출한다. 종전엔 0 을 ')'(0x0029)로
+    // 치환해, 닫는 장식이 없는(0) HWP5 각주가 저장 시 ')' 로 오염됐다. 생성 경로
+    // (insert_footnote_native, HWPX 파서)는 항상 0x0029/실제값을 명시 설정하므로
+    // 이 치환은 불필요하고, before_decoration_letter 방출과도 비대칭이었다.
+    w.write_u16(fn_.after_decoration_letter).unwrap();
     w.write_u32(fn_.number_shape).unwrap();
     w.write_u32(fn_.instance_id).unwrap();
     records.push(make_ctrl_record(tags::CTRL_FOOTNOTE, level, w.as_bytes()));
@@ -809,12 +808,8 @@ fn serialize_endnote(en: &Endnote, level: u16, records: &mut Vec<Record>) {
     let mut w = ByteWriter::new();
     w.write_u32(en.number as u32).unwrap();
     w.write_u16(en.before_decoration_letter).unwrap();
-    let after = if en.after_decoration_letter == 0 {
-        0x0029
-    } else {
-        en.after_decoration_letter
-    };
-    w.write_u16(after).unwrap();
+    // after_decoration_letter 를 IR 값 그대로 방출(footnote 와 동일 근거).
+    w.write_u16(en.after_decoration_letter).unwrap();
     w.write_u32(en.number_shape).unwrap();
     w.write_u32(en.instance_id).unwrap();
     records.push(make_ctrl_record(tags::CTRL_ENDNOTE, level, w.as_bytes()));

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -348,6 +348,60 @@ fn test_roundtrip_footnote() {
     }
 }
 
+#[test]
+fn footnote_after_decoration_zero_is_not_forced_to_paren() {
+    use crate::model::footnote::Footnote;
+    // 닫는 장식이 없는(after_decoration_letter=0) 각주는 저장 후에도 0 이어야 한다.
+    // 종전엔 serializer 가 0 을 ')'(0x0029)로 치환해 오염됐다.
+    let fn_ = Footnote {
+        number: 1,
+        before_decoration_letter: 0,
+        after_decoration_letter: 0,
+        paragraphs: vec![Paragraph {
+            char_count: 3,
+            text: "주".to_string(),
+            char_offsets: vec![0],
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let para = Paragraph {
+        char_count: 2,
+        text: "".to_string(),
+        char_offsets: vec![],
+        controls: vec![Control::Footnote(Box::new(fn_))],
+        ..Default::default()
+    };
+    let section = Section {
+        paragraphs: vec![para],
+        raw_stream: None,
+        ..Default::default()
+    };
+
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+    let Some(Control::Footnote(fn_)) = parsed.paragraphs[0]
+        .controls
+        .iter()
+        .find(|c| matches!(c, Control::Footnote(_)))
+    else {
+        panic!("Expected Footnote control");
+    };
+    assert_eq!(
+        fn_.after_decoration_letter, 0,
+        "닫는 장식 없음(0)이 ')'(0x0029)로 오염되면 안 됨"
+    );
+}
+
 /// Header 라운드트립
 #[test]
 fn test_roundtrip_header() {


### PR DESCRIPTION
`serialize_footnote`/`serialize_endnote`(src/serializer/control.rs)가 `after_decoration_letter == 0` 을 `)`(0x0029)로 **치환**해 방출합니다. 파서는 이 워드를 raw 로 읽으므로(src/parser/control.rs:533/558), **닫는 장식이 없는(0)** HWP5 각주/미주가 저장 시 `)` 가 붙는 오염이 발생합니다.

## 왜 안전한 수정인가
- `before_decoration_letter` 는 raw 로 방출돼 **비대칭**(치환은 after 에만 있는 워크어라운드)입니다.
- 생성 경로가 이 치환에 **의존하지 않습니다**:
  - 편집기 `insert_footnote_native`(src/document_core/commands/object_ops/note.rs:469)는 항상 `after_decoration_letter: 0x0029` 를 명시 설정.
  - HWPX 파서(src/parser/hwpx/section.rs:4483/4530)도 항상 `0x0029` 또는 실제 `suffixChar` 를 설정.
- 따라서 치환이 실제로 발동하는 유일한 경우는 **원본 HWP5 가 0 을 가진** 경우이며, 그때 0→`)` 로 오염됩니다. IR 값을 그대로 방출하면 이 경우가 정확히 왕복됩니다(편집기/변환 경로는 이미 0x0029 라 무변화).

## 검증
`footnote_after_decoration_zero_is_not_forced_to_paren` 추가: `after_decoration_letter=0` 각주를 `serialize_section`→`parse_body_text_section` 왕복 후 0 보존을 단언 — 수정 전 red(0x0029), 수정 후 green. 기존 `test_roundtrip_footnote`(after=0x0029) 등 회귀 9건 통과.