### PR TITLE
fix(hwpx): 선/연결선 방향 반전(isReverseHV)이 HWPX 왕복 시 유실

### DIFF
--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2707,6 +2707,7 @@ enum ShapeStorageKind {
 struct ObjectElementIds {
     instid: u32,
     round_rate: u8,
+    is_reverse_hv: bool,
 }
 
 /// HWPX 일부 샘플은 `<hp:curSz width="0" height="0">`를 기록하면서 실제 크기는
@@ -2822,6 +2823,9 @@ fn parse_object_element_attrs(
                     _ => crate::model::shape::ObjectNumberingType::None,
                 };
             }
+            // 선/연결선의 방향 뒤집기(isReverseHV). serializer 는 방출하나 파서가
+            // 되읽지 않아 HWPX 원본 선의 방향 반전이 왕복 시 유실됐다.
+            b"isReverseHV" => ids.is_reverse_hv = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -3853,6 +3857,7 @@ fn parse_shape_object(
                 x: x_coords[1],
                 y: y_coords[1],
             },
+            started_right_or_bottom: object_ids.is_reverse_hv,
             ..Default::default()
         }),
         b"connectLine" => ShapeObject::Line(LineShape {
@@ -3875,6 +3880,7 @@ fn parse_shape_object(
                 control_points: connect_control_points,
                 raw_trailing: Vec::new(),
             }),
+            started_right_or_bottom: object_ids.is_reverse_hv,
             ..Default::default()
         }),
         b"arc" => ShapeObject::Arc(ArcShape {
@@ -7264,6 +7270,39 @@ mod tests {
         assert_eq!(
             rect.common.text_flow,
             crate::model::shape::TextFlow::RightOnly
+        );
+    }
+
+    #[test]
+    fn test_parse_line_preserves_is_reverse_hv() {
+        // <hp:line isReverseHV="1"> → LineShape.started_right_or_bottom.
+        // 종전엔 파서가 isReverseHV 를 읽지 않아 방향 반전이 유실됐다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:line id="1" zOrder="0" textWrap="SQUARE" textFlow="BOTH_SIDES" isReverseHV="1">
+        <hp:sz width="1000" height="0" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hp:pt0 x="0" y="0"/>
+        <hp:pt1 x="1000" y="0"/>
+      </hp:line>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Line(line) = shape.as_ref() else {
+            panic!("expected line shape");
+        };
+        assert!(
+            line.started_right_or_bottom,
+            "isReverseHV=\"1\" 이 started_right_or_bottom 로 되읽혀야 함"
         );
     }
 


### PR DESCRIPTION
serializer 는 `<hp:line>`/`<hp:connectLine>` 에 `isReverseHV` 를 방출하지만(src/serializer/hwpx/shape.rs:184, `started_right_or_bottom` 에서), 파서 `parse_object_element_attrs`(src/parser/hwpx/section.rs)는 이 속성을 **읽지 않습니다**. `LineShape` 가 `..Default::default()`(started_right_or_bottom=false)로 생성되어, `isReverseHV` 는 HWP5 바이너리 경로에서만 채워지고 **HWPX 에선 유실**됩니다.

## 영향
`<hp:line isReverseHV="1">` → 파싱(필드 false 유지) → 직렬화 → `isReverseHV="0"`. HWPX 원본 선/연결선의 방향 반전이 왕복마다 사라집니다.

## 수정
`ObjectElementIds` 에 `is_reverse_hv` 필드를 추가하고 `b"isReverseHV"` arm 으로 파싱, `line`/`connectLine` 구성 시 `started_right_or_bottom` 에 연결.

## 검증
`test_parse_line_preserves_is_reverse_hv` 추가: `<hp:line isReverseHV="1">` 파싱이 `started_right_or_bottom==true` 로 되읽힘을 단언 — 수정 전 red(false), 수정 후 green. `cargo test --lib` 통과.

참고: 같은 벤에서 발견된 `<hp:arc>` arc_type, `<hp:curve>` segment_types 는 대칭 드롭(양측 미구현)으로 IR 확장이 필요해 별도 이슈로 둡니다.