### PR TITLE
fix(hwpx): 바탕쪽 pageFront(표지 전용) 속성이 왕복 시 유실

### DIFF
--- a/src/model/header_footer.rs
+++ b/src/model/header_footer.rs
@@ -79,6 +79,9 @@ pub struct MasterPage {
     pub replace_base: bool,
     /// 확장 플래그 raw 값 (LIST_HEADER byte 18-19)
     pub ext_flags: u16,
+    /// HWPX `masterPage@pageFront` — 첫 쪽(표지) 전용 바탕쪽 여부.
+    /// HWP5에서 읽은 바탕쪽은 해당 XML 속성이 없으므로 기본 false.
+    pub page_front: bool,
     /// 문단 리스트
     pub paragraphs: Vec<Paragraph>,
     /// 텍스트 영역 폭 (HWPUNIT)

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -723,6 +723,7 @@ fn parse_master_pages_from_raw(raw_records: &[RawRecord]) -> Vec<MasterPage> {
             overlap,
             replace_base: false,
             ext_flags,
+            page_front: false, // HWP5 바이너리 바탕쪽엔 pageFront 개념 없음
             paragraphs,
             text_width,
             text_height,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -218,6 +218,9 @@ fn parse_master_page_start(e: &quick_xml::events::BytesStart, master_page: &mut 
                 master_page.overlap = duplicate;
             }
             b"pageNumber" => master_page.hwpx_page_number = Some(parse_u16(&attr)),
+            // 표지(첫 쪽) 전용 바탕쪽. serializer 는 방출하나 종전엔 미독 →
+            // pageFront="1" 바탕쪽이 왕복 시 "0" 으로 적용 범위가 바뀌었다.
+            b"pageFront" => master_page.page_front = attr_str(&attr) != "0",
             _ => {}
         }
     }

--- a/src/serializer/hwpx/master_page.rs
+++ b/src/serializer/hwpx/master_page.rs
@@ -68,7 +68,7 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
     format!(
         concat!(
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>"#,
-            r#"<masterPage {xmlns} id="{id}" type="{ty}" pageNumber="{pn}" pageDuplicate="{pd}" pageFront="0">"#,
+            r#"<masterPage {xmlns} id="{id}" type="{ty}" pageNumber="{pn}" pageDuplicate="{pd}" pageFront="{pf}">"#,
             r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" hasTextRef="{tr}" hasNumRef="{nr}">"#,
             "{body}",
             r#"</hp:subList></masterPage>"#,
@@ -78,6 +78,7 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
         ty = master_page_type_str(mp),
         pn = mp.hwpx_page_number.unwrap_or(0),
         pd = page_duplicate_str(mp),
+        pf = mp.page_front as u8,
         tw = mp.text_width,
         th = mp.text_height,
         tr = mp.text_ref,
@@ -92,4 +93,28 @@ pub fn render_master_page_refs(ids: &[String]) -> String {
     ids.iter()
         .map(|id| format!(r#"<hp:masterPage idRef="{id}"/>"#))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::document::Document;
+
+    #[test]
+    fn master_page_page_front_round_trips() {
+        // pageFront(표지 전용 바탕쪽)이 render→parse 왕복에서 보존돼야 한다.
+        // 종전엔 serializer 가 pageFront="0" 고정, 파서 미독으로 유실됐다.
+        let mp = MasterPage {
+            page_front: true,
+            ..Default::default()
+        };
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = render_master_page_xml(&mp, "0", &mut ctx);
+        assert!(xml.contains(r#"pageFront="1""#), "pageFront=1 방출: {xml}");
+
+        let parsed =
+            crate::parser::hwpx::section::parse_hwpx_master_page(&xml).expect("master page parse");
+        assert!(parsed.page_front, "pageFront 이 왕복에서 보존돼야 함");
+    }
 }


### PR DESCRIPTION
`masterPage` 직렬화(src/serializer/hwpx/master_page.rs:71)가 `pageFront="0"` 을 **하드코딩**하고, 파서 `parse_master_page_start`(src/parser/hwpx/section.rs:191)는 `pageFront` 를 **읽지 않습니다**. `MasterPage` 에 해당 IR 필드도 없었습니다.

## 영향
`pageFront="1"`(첫 쪽/표지 전용 바탕쪽)으로 저작된 바탕쪽이 HWPX 왕복 시 `"0"` 으로 바뀌어, **바탕쪽이 적용되는 쪽 범위가 달라집니다**. (섹션 XML/masterpage{N}.xml 은 raw 패스스루가 아니라 IR 에서 재생성되므로 실제 유실됩니다.)

## 수정
- `MasterPage` 에 `page_front: bool` 필드 추가(HWP5 바이너리 경로는 `false`).
- 파서에 `b"pageFront"` arm 추가.
- 직렬화가 `mp.page_front` 를 방출하도록 정정.

## 검증
`master_page_page_front_round_trips` 추가: `page_front=true` 를 `render_master_page_xml`→`parse_hwpx_master_page` 왕복 후 보존됨을 단언 — 수정 전 red("0" 고정+미독), 수정 후 green. `cargo test --lib` 통과.

참고: 같은 벤의 autoNumFormat/placement 는 IR 열거형 conflate/토큰맵 이슈로 별도 처리합니다.