### PR TITLE
fix(hwp3): 쪽 시작 번호/각주 시작 번호가 IR 매핑 누락으로 유실

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -2883,6 +2883,13 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     // 1. 문서 정보 파싱 (128 바이트)
     let doc_info = Hwp3DocInfo::read(&mut cursor)?;
 
+    // 쪽 시작 번호 / 각주 시작 번호를 공용 IR(DocProperties)로 매핑한다.
+    // 소비처(assign_auto_numbers, fixup_hwp3_notes)는 이미 이 필드를 읽지만
+    // 종전엔 HWP3 파서가 doc_properties 를 전혀 채우지 않아 항상 0(→1)로 시작했다.
+    // HWP5(doc_info.rs)·HWPX(hwpx/header.rs)는 이미 매핑하는 필드다.
+    doc.doc_properties.page_start_num = doc_info.start_page_number;
+    doc.doc_properties.footnote_start_num = doc_info.footnote_start_number;
+
     // 2. 문서 요약 파싱 (1008 바이트)
     let doc_summary = Hwp3DocSummary::read(&mut cursor)?;
 
@@ -3971,6 +3978,28 @@ mod tests {
         let cs = convert_char_shape(&hwp3_cs);
 
         assert_eq!(cs.text_color, 0x00FF0000);
+    }
+
+    #[test]
+    fn hwp3_maps_page_and_footnote_start_numbers() {
+        // HWP3 doc_info 의 쪽 시작 번호 / 각주 시작 번호가 DocProperties 로 매핑돼야
+        // 한다. 종전엔 HWP3 파서가 doc_properties 를 전혀 채우지 않아 0 이었다.
+        // 정상 문서는 두 값이 1 이므로 0(미매핑) → 1(매핑) 로 red→green.
+        let path = "samples/hwp3-sample.hwp";
+        if !std::path::Path::new(path).exists() {
+            return;
+        }
+        let mut data = Vec::new();
+        File::open(path).unwrap().read_to_end(&mut data).unwrap();
+        let doc = parse_hwp3(&data).expect("hwp3-sample parse failed");
+        assert_eq!(
+            doc.doc_properties.page_start_num, 1,
+            "쪽 시작 번호가 doc_info 에서 매핑돼야 함(미매핑 시 0)"
+        );
+        assert_eq!(
+            doc.doc_properties.footnote_start_num, 1,
+            "각주 시작 번호가 doc_info 에서 매핑돼야 함(미매핑 시 0)"
+        );
     }
 
     #[test]


### PR DESCRIPTION
HWP3 파서(`parse_hwp3`, src/parser/hwp3/mod.rs)가 `doc.doc_properties` 를 **전혀 채우지 않습니다**. `Hwp3DocInfo` 가 읽은 `start_page_number`(records.rs:83)와 `footnote_start_number`(records.rs:84)가 버려지고, `DocProperties` 는 항상 `Default`(0)로 남습니다.

## 영향 (소비처는 이미 배선됨)
- `assign_auto_numbers`(src/parser/mod.rs:698-699)가 PAGE/FOOTNOTE 자동번호 카운터를 이 필드에서 시드합니다.
- `fixup_hwp3_notes`(src/parser/hwp3/mod.rs:3266)가 `doc.doc_properties.footnote_start_num.max(1)` 를 사용합니다.

둘 다 HWP3 파서가 **쓰지 않은** 값을 읽으므로 0 → `max(1)` 로 클램프됩니다. 결과적으로 v3 `.hwp` 의 "쪽 시작 번호 = N", "각주 시작 번호 = N" 설정이 **항상 1 부터** 렌더됩니다. HWP5(doc_info.rs:163-164)·HWPX(hwpx/header.rs:372-373)는 이미 매핑하는 필드로, HWP3 만 누락이었습니다.

## 수정
`doc_info` 파싱 직후 2줄 매핑(파서 내부, parser_architecture 준수):
```rust
doc.doc_properties.page_start_num = doc_info.start_page_number;
doc.doc_properties.footnote_start_num = doc_info.footnote_start_number;
```

## 검증
`hwp3_maps_page_and_footnote_start_numbers` 추가: HWP3 샘플 파싱 후 두 필드가 파일의 실제 값(1)로 매핑됨을 단언 — 수정 전 red(미매핑 0), 수정 후 green. `cargo test --lib` 통과.