### PR TITLE
chore(ci): GitHub Actions 버전을 최신으로 통일

### DIFF
--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload full renderer sweep artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-renderer-sweep-artifacts
           path: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: wasm-pack build --target web --release
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-pkg
           path: pkg/
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-pkg
           path: pkg/
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-pkg
           path: pkg/

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine version tag
         id: version
@@ -127,7 +127,7 @@ jobs:
           "ARCHIVE_NAME=$archiveName" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -416,7 +416,7 @@ jobs:
 
       - name: Upload render diff artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: render-diff-artifacts
           path: |


### PR DESCRIPTION
## 개요

4개 CI 워크플로우에서 GitHub Actions의 구버전 액션을 최신 버전으로 업데이트합니다.

## 변경

| workflow | 액션 | 이전 | 이후 |
|----------|------|------|------|
| full-renderer-sweep | upload-artifact | v4 | v7 |
| npm-publish | upload-artifact / download-artifact | v4 | v7 / v8 |
| release-binary | checkout / upload-artifact / download-artifact | v4 | v5 / v7 / v8 |
| render-diff | upload-artifact | v4 | v7 |

## 검증

- GitHub Actions에서 빌드 시 deprecation 경고 제거
- 8개 파일, +8/-8 라인 (모두 버전 문자열만 변경)
- 기존 CI 동작 변경 없음