### PR TITLE
docs: README/README_EN/CONTRIBUTING 테스트 수 3,300+ → 5,500+ 갱신

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,7 +92,7 @@ HWP 파일이 한컴과 다르게 렌더링되면 알려주세요:
 
 ```bash
 cargo fmt --all -- --check                   # 포맷 정책 준수
-cargo test --profile release-test --tests    # 통합 테스트 포함 전체 (3,300+)
+cargo test --profile release-test --tests    # 통합 테스트 포함 전체 (5,500+)
 cargo clippy -- -D warnings                  # 린트 경고 0건
 ```
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,7 @@ rhwp는 Rust + WebAssembly 기반의 오픈소스 HWP/HWPX 뷰어/에디터입�
 - 페이지네이션 (다단 분할, 표 행 분할), 머리말/꼬리말/바탕쪽/각주
 - SVG/PNG/PDF 내보내기 (CLI) + Canvas/CanvasKit 렌더링 (WASM/Web)
 - 웹 에디터 + hwpctl 호환 API (30 Actions, Field API)
-- 3,300+ Rust 테스트 + studio 단위/e2e/시각 회귀 CI
+- 5,500+ Rust 테스트 + studio 단위/e2e/시각 회귀 CI
 
 > HML은 실제 corpus로 확인된 HWPML 2.9/2.91 구조만 제한 지원합니다. 지원 범위의 수식은
 > 가져와 편집할 수 있고, 보존 불가 요소가 없는 HML 원본은 preflight 검사 후 HML로 다시
@@ -201,7 +201,7 @@ document.getElementById('viewer').innerHTML = doc.renderPageSvg(0);
 ```bash
 cargo build                    # Development build
 cargo build --release          # Release build
-cargo test                     # Run tests (3,300+ tests)
+cargo test                     # Run tests (5,500+ tests)
 ```
 
 ### WASM Build
@@ -329,7 +329,7 @@ scripts/                       # Build & quality tools
 |--|-----------|-----------|
 | **사람의 역할** | AI 출력 수락 | 지시, 검토, 결정 |
 | **계획** | 없음 — "그냥 만들어" | 계획서 작성 → 승인 → 실행 |
-| **품질 관문** | 동작하길 바람 | 3,300+ 테스트 + Clippy + CI + 코드 리뷰 |
+| **품질 관문** | 동작하길 바람 | 5,500+ 테스트 + Clippy + CI + 코드 리뷰 |
 | **디버깅** | AI에게 AI 버그 수정 요청 | 사람이 진단, AI가 구현 |
 | **아키텍처** | 우연히 형성 | 의도적 설계 (CQRS, 의존성 방향) |
 | **문서** | 없음 | 10,000+개 파일의 프로세스 기록 |

--- a/README_EN.md
+++ b/README_EN.md
@@ -71,7 +71,7 @@ Foundation  Typeset   Collab    Complete
 - Pagination (multi-column split, table row split), headers/footers, master pages, footnotes
 - SVG/PNG/PDF export (CLI) + Canvas/CanvasKit rendering (WASM/Web)
 - Web editor + hwpctl-compatible API (30 Actions, Field API)
-- 3,300+ Rust tests + studio unit/e2e/visual-regression CI
+- 5,500+ Rust tests + studio unit/e2e/visual-regression CI
 
 > HML support is limited to HWPML 2.9/2.91 structures verified by the current real-file corpus.
 > Supported equations can be imported and edited; HML-origin documents can be saved back to HML
@@ -206,7 +206,7 @@ New contributors: start with the [onboarding guide](mydocs/eng/manual/onboarding
 ```bash
 cargo build                    # Development build
 cargo build --release          # Release build
-cargo test                     # Run tests (3,300+ tests)
+cargo test                     # Run tests (5,500+ tests)
 ```
 
 ### WASM Build
@@ -335,7 +335,7 @@ This project takes the opposite approach. A human **task director** maintains fu
 |--|-------------|-------------|
 | **Human role** | Accept AI output | Direct, review, decide |
 | **Planning** | None — "just build it" | Written plan → approval → execution |
-| **Quality gate** | Hope it works | 3,300+ tests + Clippy + CI + code review |
+| **Quality gate** | Hope it works | 5,500+ tests + Clippy + CI + code review |
 | **Debugging** | Ask AI to fix AI's bugs | Human diagnoses, AI implements fix |
 | **Architecture** | Emergent (accidental) | Deliberate (CQRS, dependency direction) |
 | **Documentation** | None | 10,000+ files of process records |


### PR DESCRIPTION
## 개요

README.md, README_EN.md, CONTRIBUTING.md에서 아직 3,300+로 표기된 Rust 테스트 수를 현재 CI 기준 5,500+로 갱신합니다.

## 변경 파일 (3개, +7/-7)

- README.md: 3곳 (이정표, Quick Start, AI 개발 표)
- README_EN.md: 3곳 (Milestones, Quick Start, AI development table)
- CONTRIBUTING.md: 1곳 (PR 체크리스트)