### PR TITLE
chore(ci): render-diff workflow upload-artifact v4→v7

### DIFF
--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -416,7 +416,7 @@ jobs:
 
       - name: Upload render diff artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: render-diff-artifacts
           path: |


### PR DESCRIPTION
## 변경

render-diff.yml의 actions/upload-artifact를 v4에서 v7로 업그레이드합니다.

#2488에서 다른 workflow 파일 3개는 모두 업데이트했으나 render-diff.yml이 누락되어 있었습니다.

## 검증
- 1개 파일, +1/-1 라인 (버전 문자열만 변경)