### PR TITLE
chore(deps): dependabot에 github-actions, npm/editor, rhwp-vscode 누락 ecosystem 추가

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -59,3 +59,24 @@ updates:
     schedule:
       interval: "weekly"
     open-pull-requests-limit: 10
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/npm/editor"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10
+
+  - package-ecosystem: "npm"
+    directory: "/rhwp-vscode"
+    target-branch: "devel"
+    schedule:
+      interval: "weekly"
+    open-pull-requests-limit: 10


### PR DESCRIPTION
## 개요

Dependabot 설정에 3가지 누락된 ecosystem을 추가합니다.

## 변경

- **github-actions**: actions/checkout, upload-artifact 등 GitHub Actions 액션을 Dependabot이 자동 추적
- **npm/editor**: @rhwp/editor npm 패키지 의존성(dependencies) 관리
- **rhwp-vscode**: VS Code 확장의 devDependencies 관리

## 영향

- PR이 자동 생성되는 ecosystem이 확장되어 보안 패치 누락 방지
- 1개 파일, +21 라인