### PR TITLE
feat(vscode): HML 파일(.hml)을 HWP Viewer로 열도록 filenamePattern 추가

### DIFF
--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -41,6 +41,9 @@
           },
           {
             "filenamePattern": "*.hwpx"
+          },
+          {
+            "filenamePattern": "*.hml"
           }
         ],
         "priority": "default"


### PR DESCRIPTION
## 개요

rhwp-studio와 CLI는 이미 HML(HWPML 2.9/2.91) 포맷을 지원하지만, VS Code 확장의 customEditor selector에 *.hml이 누락되어 HML 파일을 더블클릭해도 HWP Viewer가 열리지 않습니다.

## 변경

rhwp-vscode/package.json contributes.customEditors.selector에 *.hml 패턴 추가 (3라인)

## 검증

- JSON 문법 검증: 유효
- 기존 *.hwp, *.hwpx 동작 영향 없음