### PR TITLE
docs: CHANGELOG_EN.md에 Unreleased 섹션 추가

### DIFF
--- a/CHANGELOG_EN.md
+++ b/CHANGELOG_EN.md
@@ -4,6 +4,8 @@ This document records the major changes of the rhwp project.
 
 > 한국어 버전은 [CHANGELOG.md](CHANGELOG.md) 를 참조하세요.
 
+## [Unreleased]
+
 ## [0.7.19] — 2026-07-17
 
 > Patch following v0.7.18 — honoring stored geometry signals (intra-paragraph vpos


### PR DESCRIPTION
## 개요

한국어 CHANGELOG.md에는 [Unreleased] 섹션이 존재하지만 영문 CHANGELOG_EN.md에는 누락되어 있어 일관성을 위해 추가합니다.

## 변경

CHANGELOG_EN.md: [Unreleased] 헤더 추가 (2라인)

## 검증

- CHANGELOG.md 포맷과 일치