### PR TITLE
fix(vscode): package.json description 및 keywords에 HML 추가

### DIFF
--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -1,7 +1,7 @@
 {
   "name": "rhwp-vscode",
   "displayName": "HWP Viewer",
-  "description": "HWP/HWPX 문서 뷰어 — rhwp 기반",
+  "description": "HWP/HWPX/HML 문서 뷰어 — rhwp 기반",
   "version": "0.7.19",
   "publisher": "edwardkim",
   "license": "MIT",
@@ -17,6 +17,7 @@
   "keywords": [
     "hwp",
     "hwpx",
+    "hml",
     "한글",
     "viewer",
     "document"


### PR DESCRIPTION
## 개요

HML(HWPML 2.9/2.91) 포맷 지원이 v0.7.19에서 추가되었으나 VS Code 확장의 package.json description과 keywords에 HML이 반영되지 않아 Marketplace 검색에서 HML 파일 지원이 노출되지 않는 문제를 수정합니다.

## 변경

rhwp-vscode/package.json (2줄 추가, 1줄 변경)
- description: HWP/HWPX -> HWP/HWPX/HML
- keywords: hml 추가

## 검증

- JSON 문법 유효
- 기존 필드 변경 없음