### PR TITLE
chore(npm): @rhwp/editor package.json에 engines.node 및 README.md 파일 목록 추가

### DIFF
--- a/npm/editor/package.json
+++ b/npm/editor/package.json
@@ -11,7 +11,8 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "transport.js"
+    "transport.js",
+    "README.md"
   ],
   "keywords": [
     "hwp",
@@ -33,5 +34,8 @@
     "url": "https://github.com/edwardkim/rhwp/issues"
   },
   "license": "MIT",
-  "author": "Edward Kim"
+  "author": "Edward Kim",
+  "engines": {
+    "node": ">=18.0.0"
+  }
 }


### PR DESCRIPTION
## 개요

@rhwp/editor npm 패키지에 누락된 메타데이터를 추가합니다.

## 변경

- engines.node >= 18.0.0 추가: node:test(Node.js 내장 테스트 러너) 사용으로 18+ 필요
- files 목록에 README.md 추가: npmjs.org 페이지에서 README 표시

## 검증

- JSON 문법 유효 (node -c package.json)
- npm test: 18/18 통과