### PR TITLE
chore(ci): full-renderer-sweep의 actions/cache v4 -> v5

### DIFF
--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry


### PR DESCRIPTION
## 개요

full-renderer-sweep.yml의 actions/cache가 v4로 남아 있어 다른 workflow와 통일합니다.

| workflow | cache 버전 |
|----------|-----------|
| ci.yml | v5 |
| deploy-pages.yml | v5 |
| npm-publish.yml | v5 |
| release-binary.yml | v5 |
| full-renderer-sweep.yml | v4 -> v5 (수정) |

## 변경
1개 파일, +1/-1 라인 (버전 문자열만 변경)