### PR TITLE
chore(ci): workflow 액션 버전 v4 -> v5/v7/v8 일괄 업데이트

### DIFF
--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -35,7 +35,7 @@ jobs:
         uses: ./.github/actions/install-wasm-pack
 
       - name: Cache cargo registry & build
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: |
             ~/.cargo/registry
@@ -111,7 +111,7 @@ jobs:
 
       - name: Upload full renderer sweep artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: full-renderer-sweep-artifacts
           path: |

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -45,7 +45,7 @@ jobs:
         run: wasm-pack build --target web --release
 
       - name: Upload WASM artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wasm-pkg
           path: pkg/
@@ -60,7 +60,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-pkg
           path: pkg/
@@ -121,7 +121,7 @@ jobs:
       - uses: actions/checkout@v5
 
       - name: Download WASM artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: wasm-pkg
           path: pkg/

--- a/.github/workflows/release-binary.yml
+++ b/.github/workflows/release-binary.yml
@@ -52,7 +52,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v5
 
       - name: Determine version tag
         id: version
@@ -127,7 +127,7 @@ jobs:
           "ARCHIVE_NAME=$archiveName" | Out-File -FilePath $env:GITHUB_ENV -Append
 
       - name: Upload artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.ARCHIVE_NAME }}
           path: ${{ env.ARCHIVE_NAME }}
@@ -151,7 +151,7 @@ jobs:
           fi
 
       - name: Download all artifacts
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: dist/
           merge-multiple: true

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -416,7 +416,7 @@ jobs:
 
       - name: Upload render diff artifacts
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: render-diff-artifacts
           path: |


### PR DESCRIPTION
## 개요

4개 workflow 파일에 남아있던 GitHub Actions 구버전을 최신 버전으로 일괄 업데이트합니다.

## 변경

| workflow | 액션 | 이전 | 이후 |
|----------|------|------|------|
| full-renderer-sweep | cache | v4 | v5 |
| full-renderer-sweep | upload-artifact | v4 | v7 |
| npm-publish | download-artifact | v4 | v8 |
| npm-publish | upload-artifact | v4 | v7 |
| release-binary | checkout | v4 | v5 |
| release-binary | download-artifact | v4 | v8 |
| release-binary | upload-artifact | v4 | v7 |
| render-diff | upload-artifact | v4 | v7 |

## 이전 PR과의 관계

PR #2490, #2498, #2499에서 일부 동일한 파일을 수정했으나 미병합 상태입니다.
이 PR은 모든 workflow의 구버전 액션을 일괄 처리하여 누락을 방지합니다.

## 검증
- 4개 파일, +9/-9 라인 (모두 버전 문자열만 변경)
- ci.yml, codeql.yml과 일관된 버전