### PR TITLE
refactor(safari): background.js에서 미사용 MAX_FILE_SIZE 상수 제거

### DIFF
--- a/rhwp-safari/src/background.js
+++ b/rhwp-safari/src/background.js
@@ -14,7 +14,6 @@ const PRIVATE_IP_PATTERNS = [
 ];
 const HWP_SIGNATURE = [0xD0, 0xCF, 0x11, 0xE0];
 const HWPX_SIGNATURE = [0x50, 0x4B, 0x03, 0x04];
-const MAX_FILE_SIZE = 20 * 1024 * 1024; // 20MB
 
 function isPrivateHost(hostname) {
   return PRIVATE_IP_PATTERNS.some(re => re.test(hostname));


### PR DESCRIPTION
## 개요

rhwp-safari/src/background.js에 const MAX_FILE_SIZE = 20 * 1024 * 1024로 20MB 상수가 정의되어 있으나, 실제 파일 크기 검사는 browser.storage.local의 maxFileSize 설정값(settings.maxFileSize)을 사용하므로 해당 상수는 사용되지 않습니다.

## 변경

1개 파일, 1라인 삭제
- rhwp-safari/src/background.js: MAX_FILE_SIZE 상수 제거

## 검증

- 상수 참조가 코드 내에 없음을 grep으로 확인