### PR TITLE
chore(npm): @rhwp/editor package.json에 funding 필드 추가

### DIFF
--- a/npm/editor/package.json
+++ b/npm/editor/package.json
@@ -32,6 +32,7 @@
   "bugs": {
     "url": "https://github.com/edwardkim/rhwp/issues"
   },
+  "funding": "https://github.com/sponsors/edwardkim",
   "license": "MIT",
   "author": "Edward Kim"
 }


### PR DESCRIPTION
## 개요

npm 패키지에 funding 필드를 추가하여 npm 레지스트리 페이지에서 저장소 후원 링크를 노출합니다.

## 변경

npm/editor/package.json: funding: https://github.com/sponsors/edwardkim (1라인 추가)

## 검증

- package.json JSON 문법 유효