### PR TITLE
chore(npm): @rhwp/editor package.json 메타데이터 보강 (README.md, funding)

### DIFF
--- a/npm/editor/package.json
+++ b/npm/editor/package.json
@@ -11,7 +11,8 @@
   "files": [
     "index.js",
     "index.d.ts",
-    "transport.js"
+    "transport.js",
+    "README.md"
   ],
   "keywords": [
     "hwp",
@@ -32,6 +33,7 @@
   "bugs": {
     "url": "https://github.com/edwardkim/rhwp/issues"
   },
+  "funding": "https://github.com/sponsors/edwardkim",
   "license": "MIT",
   "author": "Edward Kim"
 }


### PR DESCRIPTION
## 개요

npm 레지스트리에 게시되는 @rhwp/editor 패키지에 누락된 메타데이터를 추가합니다.

## 변경

1. files 목록에 README.md 추가: npmjs.org 페이지에서 README 표시
2. funding 필드 추가: GitHub Sponsors 링크 노출

## 검증

- cargo check --lib: 통과
- JSON 문법 유효