### PR TITLE
chore(safari): 누락된 .gitignore 파일 추가

### DIFF
--- a/rhwp-safari/.gitignore
+++ b/rhwp-safari/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+dist/


### PR DESCRIPTION
## 개요

Safari 확장 디렉토리에 .gitignore가 없어 빌드 산출물(node_modules/, dist/)이 추적될 위험이 있습니다. Chrome 및 Firefox 확장과 동일한 패턴의 .gitignore를 추가합니다.

## 변경

rhwp-safari/.gitignore 생성: node_modules/, dist/ (2라인)

## 검증

- Chrome/Firefox 확장의 .gitignore와 동일한 패턴