### PR TITLE
fix(chrome): content-script.js 및 dev-tools-inject.js 버전 문자열을 manifest 동적 읽기로 변경

### DIFF
--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -122,10 +122,11 @@
   });
 
   // 확장 존재 알림
+  const EXT_VERSION = chrome.runtime.getManifest().version;
   document.documentElement.setAttribute('data-hwp-extension', 'rhwp');
-  document.documentElement.setAttribute('data-hwp-extension-version', '0.2.8');
+  document.documentElement.setAttribute('data-hwp-extension-version', EXT_VERSION);
   window.dispatchEvent(new CustomEvent('hwp-extension-ready', {
-    detail: { name: 'rhwp', version: '0.2.8', capabilities: ['preview', 'edit', 'print'] }
+    detail: { name: 'rhwp', version: EXT_VERSION, capabilities: ['preview', 'edit', 'print'] }
   }));
 
   // 개발자 도구 주입 (페이지 컨텍스트에 rhwpDev 노출)

--- a/rhwp-chrome/dev-tools-inject.js
+++ b/rhwp-chrome/dev-tools-inject.js
@@ -4,7 +4,7 @@
   'use strict';
   if (window.rhwpDev) return;
 
-  const VERSION = '0.2.8';
+  const VERSION = document.documentElement.getAttribute('data-rhwp-extension-version') || 'unknown';
 
   window.rhwpDev = {
     inspect() {


### PR DESCRIPTION
## 개요

Chrome 확장의 content-script.js와 dev-tools-inject.js에 확장 버전이 '0.2.8'로 하드코딩되어 있어 버전 업데이트 시 별도 갱신이 필요합니다. Firefox는 이미 동적 읽기 방식(rowser.runtime.getManifest().version)을 사용하고 있으므로 Chrome도 동일한 패턴으로 변경합니다.

## 변경

| 파일 | 이전 | 이후 |
|------|------|------|
| content-script.js | '0.2.8' 하드코딩 2곳 | chrome.runtime.getManifest().version |
| dev-tools-inject.js | '0.2.8' 하드코딩 | documentElement의 data-hwp-extension-version 속성에서 읽기 |

## 검증
- node --check: 2개 파일 JS 문법 통과
- Firefox와 동일한 패턴으로 일관성 확보