### PR TITLE
refactor(safari): content-script.js 미사용 escapeHtml 함수 제거

### DIFF
--- a/rhwp-safari/src/content-script.js
+++ b/rhwp-safari/src/content-script.js
@@ -43,12 +43,6 @@
 
   // ─── 유틸리티 ───
 
-  function escapeHtml(str) {
-    const div = document.createElement('div');
-    div.textContent = str;
-    return div.innerHTML;
-  }
-
   function extractFilename(anchor) {
     // URL에서 파일명 추출
     try {


### PR DESCRIPTION
## 개요

Safari content-script.js에 정의된 escapeHtml 함수가 한 번도 호출되지 않아 제거합니다. Chrome/Firefox 확장은 createEl(textContent) 방식으로 안전하게 HTML을 생성하고 있어 이 함수 없이도 동일한 보안 수준을 유지합니다.

## 변경

rhwp-safari/src/content-script.js: escapeHtml 함수 삭제 (6라인)

## 검증
- node --check: JS 문법 검증 통과
- grep으로 escapeHtml 호출부 없음 확인