### PR TITLE
chore: .mailmap에 v0.7.19 기여자 cskwork, lpaiu-cs 매핑 추가

### DIFF
--- a/.mailmap
+++ b/.mailmap
@@ -57,3 +57,11 @@ edwardkim <tangokorea@gmail.com> edward.kim <edward.kim@minervasoft.co.kr>
 # ── oleg-sung: 오타 표기(Sungyrovsky) + 이메일 2종 통합 ──
 Oleg Sungurovsky <safasgasc.asfg@gmail.com> Oleg Sungyrovsky <andreisungurovsky@yandex.ru>
 Oleg Sungurovsky <safasgasc.asfg@gmail.com> Oleg Sungurovsky <andreisungurovsky@yandex.ru>
+
+# ── v0.7.19 신규 기여자 (CHANGELOG 기준) ──
+# @cskwork — HML open/semantics-preserving save (#2219), MessageChannel embed (#2187)
+cskwork <76669236+cskwork@users.noreply.github.com> cskwork <csk917work@gmail.com>
+cskwork <76669236+cskwork@users.noreply.github.com> donga-csk <76669236+cskwork@users.noreply.github.com>
+# @lpaiu-cs (Juneyoung Kim) — undo/redo migration 연작
+lpaiu-cs <99919585+lpaiu-cs@users.noreply.github.com> lpaiu-cs <lpaiu.cs@gmail.com>
+lpaiu-cs <99919585+lpaiu-cs@users.noreply.github.com> 김준영 (Juneyoung, Kim) <lpaiu.cs@gmail.com>


### PR DESCRIPTION
## 개요

v0.7.19 릴리즈에서 기여한 cskwork(@cskwork)와 lpaiu-cs(@lpaiu-cs)가 서로 다른 이메일로 커밋을 남겨 git-shortlog 통계에서 분리되어 표시됩니다. .mailmap에 이들을 통합하는 매핑을 추가합니다.

## 변경

| 기여자 | 통합 전 | 통합 후 |
|--------|---------|---------|
| cskwork | csk917work@gmail.com / donga-csk noreply | cskwork noreply |
| lpaiu-cs | lpaiu.cs@gmail.com / '김준영' | lpaiu-cs noreply |

## 검증
- git-shortlog 통계 정확도 향상 (중복 카운트 방지)