### PR TITLE
fix(ext): 브라우저 확장의 파일 확장자 패턴에 .hml 추가

### DIFF
--- a/rhwp-chrome/content-script.js
+++ b/rhwp-chrome/content-script.js
@@ -4,8 +4,8 @@
 (() => {
   'use strict';
 
-  const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
-  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const HWP_EXTENSIONS = /\.(hwp|hwpx|hml)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx|hml)$/i;
   const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';

--- a/rhwp-firefox/content-script.js
+++ b/rhwp-firefox/content-script.js
@@ -4,8 +4,8 @@
 (() => {
   'use strict';
 
-  const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
-  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const HWP_EXTENSIONS = /\.(hwp|hwpx|hml)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx|hml)$/i;
   const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';

--- a/rhwp-safari/src/content-script.js
+++ b/rhwp-safari/src/content-script.js
@@ -5,8 +5,8 @@
 (() => {
   'use strict';
 
-  const HWP_EXTENSIONS = /\.(hwp|hwpx)(\?.*)?$/i;
-  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx)$/i;
+  const HWP_EXTENSIONS = /\.(hwp|hwpx|hml)(\?.*)?$/i;
+  const DOCUMENT_PATH_EXTENSIONS = /\.(hwp|hwpx|hml)$/i;
   const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
   const BADGE_CLASS = 'rhwp-badge';
   const HOVER_CLASS = 'rhwp-hover-card';
@@ -296,7 +296,7 @@
         card.appendChild(createDiv('rhwp-hover-desc', truncate(description, 500)));
       }
     } else {
-      const ext = filename.match(/\.(hwp|hwpx)$/i)?.[1]?.toUpperCase() || 'HWP';
+      const ext = filename.match(/\.(hwp|hwpx|hml)$/i)?.[1]?.toUpperCase() || 'HWP';
       card.appendChild(createDiv('rhwp-hover-title', truncate(filename, 200)));
       card.appendChild(createDiv('rhwp-hover-meta', `${ext} \uBB38\uC11C`));
     }

--- a/rhwp-shared/sw/document-url-resolver.js
+++ b/rhwp-shared/sw/document-url-resolver.js
@@ -3,7 +3,7 @@
 // "링크 URL"과 "실제 파일 바이트 URL"이 다른 서비스(provider)를
 // 호출부에서 직접 분기하지 않도록 이 모듈에서 정규화한다.
 
-const DOCUMENT_EXTENSION_RE = /\.(hwp|hwpx)$/i;
+const DOCUMENT_EXTENSION_RE = /\.(hwp|hwpx|hml)$/i;
 const GITHUB_NON_DOCUMENT_MARKERS = new Set(['edit', 'commits', 'blame', 'tree']);
 
 function classification(status, reason, resolvedUrl) {


### PR DESCRIPTION
## 개요

HML(HWPML 2.9/2.91) 형식 지원이 v0.7.19에서 추가되었으나 브라우저 확장의 파일 확장자 감지 정규식에 .hml이 누락되어 있습니다. 웹페이지에서 .hml 파일 링크를 클릭해도 rhwp 확장이 인식하지 못하고 배지/호버 카드가 표시되지 않습니다.

## 변경 (4개 파일, +8/-8)

| 파일 | 변경 내용 |
|------|----------|
| rhwp-chrome/content-script.js | HWP_EXTENSIONS, DOCUMENT_PATH_EXTENSIONS |
| rhwp-firefox/content-script.js | HWP_EXTENSIONS, DOCUMENT_PATH_EXTENSIONS |
| rhwp-safari/src/content-script.js | HWP_EXTENSIONS, DOCUMENT_PATH_EXTENSIONS, 확장자 추출 |
| rhwp-shared/sw/document-url-resolver.js | DOCUMENT_EXTENSION_RE |

## 검증
- node --check: 4개 파일 모두 JS 문법 통과
- 기존 .hwp/.hwpx 동작에 영향 없음 (정규식만 확장)