### PR TITLE
fix(studio): DOM flow-image 경로에 그림 색효과(회색조/흑백/밝기/명암) 적용

### DIFF
--- a/rhwp-studio/src/view/flow-image-clip.ts
+++ b/rhwp-studio/src/view/flow-image-clip.ts
@@ -20,6 +20,9 @@ export interface FlowImagePaintOp {
   rotation: number;
   horzFlip: boolean;
   vertFlip: boolean;
+  // 그림 효과(회색조/흑백/밝기/명암)를 DOM <img> 에 적용할 CSS filter. 없으면 null.
+  // web_canvas.rs render_image 의 compose_image_filter 와 동일 산출.
+  filter: string | null;
   // DOM 정적 그림도 원래 PageLayerTree의 clip 계보를 유지해야 한다.
   clip: FlowImageBbox | null;
 }
@@ -39,12 +42,39 @@ type LayerPaintOpLike = {
   mime?: unknown;
   base64?: unknown;
   crop?: unknown;
+  effect?: unknown;
+  brightness?: unknown;
+  contrast?: unknown;
+  bakedWatermark?: unknown;
   transform?: {
     rotation?: unknown;
     horzFlip?: unknown;
     vertFlip?: unknown;
   };
 };
+
+/**
+ * 그림 효과(ImageEffect)+밝기/명암을 DOM <img> 용 CSS filter 문자열로 변환한다.
+ * `src/renderer/web_canvas.rs::compose_image_filter` 와 동일한 산출을 유지해
+ * WASM canvas 경로와 DOM flow-image 경로의 렌더 결과가 일치하도록 한다.
+ * 워터마크로 baked 된 픽셀(bakedWatermark)은 효과가 이미 적용돼 있으므로 제외한다.
+ */
+export function composeImageFilter(op: LayerPaintOpLike): string | null {
+  if (op.bakedWatermark === true) return null;
+  const parts: string[] = [];
+  const effect = typeof op.effect === 'string' ? op.effect : 'realPic';
+  if (effect === 'grayScale' || effect === 'pattern8x8') {
+    parts.push('grayscale(100%)');
+  } else if (effect === 'blackWhite') {
+    parts.push('grayscale(100%)');
+    parts.push('contrast(1000%)');
+  }
+  const brightness = finiteNumber(op.brightness);
+  const contrast = finiteNumber(op.contrast);
+  if (brightness !== 0) parts.push(`brightness(${((100 + brightness) / 100).toFixed(4)})`);
+  if (contrast !== 0) parts.push(`contrast(${((100 + contrast) / 100).toFixed(4)})`);
+  return parts.length > 0 ? parts.join(' ') : null;
+}
 
 export function collectFlowImagePaintOps(
   root: unknown,
@@ -83,6 +113,7 @@ export function collectFlowImagePaintOps(
           rotation: finiteNumber(op.transform?.rotation),
           horzFlip: op.transform?.horzFlip === true,
           vertFlip: op.transform?.vertFlip === true,
+          filter: composeImageFilter(op),
           clip: clip ?? null,
         });
       }

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -453,6 +453,9 @@ export class PageRenderer {
       element.src = `data:${image.mime};base64,${image.base64}`;
       element.style.position = 'absolute';
       element.style.pointerEvents = 'none';
+      // 그림 효과(회색조/흑백/밝기/명암) — WASM canvas 경로(render_image)와 달리
+      // DOM flow-image 경로는 필터가 누락돼 원본 컬러로 렌더되던 문제를 고친다.
+      if (image.filter) element.style.filter = image.filter;
       const applyCrop = () => applyFlowImageCrop(element, image, displayScale);
       element.addEventListener('load', applyCrop, { once: true });
       applyCrop();


### PR DESCRIPTION
## 문제

그림 색효과(회색조/흑백/밝기/명암)가 적용된 이미지가 rhwp-studio 기본(canvas2d)에서
**원본 컬러로 렌더**된다. 예: `pr-149.hwp` 의 "회색조/흑백" 이미지가 컬러로 표시.
rhwp `export-svg` 출력은 (SVG `<filter>` 로) 효과를 정확히 적용한다(chrome 로 래스터 확인).

## 원인 (국소화)

studio canvas2d 는 이미지를 두 경로로 그린다:
- **WASM** `web_canvas.rs render_image` → `compose_image_filter(effect,brightness,contrast)`
  → `ctx.set_filter` 로 **효과 적용**.
- **DOM flow-image 경로**(`usesDomFlowImages`: `getFlowImagePaintOps` → `<img>` 합성) →
  **필터 미적용**.

`pr-149` 는 3개 flow 이미지라 DOM 경로를 타 효과가 누락됐다. 실측: DOM `<img>` 3개 모두
`style.filter = "none"`. layer JSON(`paint/json.rs`)은 이미 `effect`/`brightness`/`contrast`
를 emit 하므로 **TS 수정만으로 충분**(wasm 재빌드 불필요).

## 수정 (TS-only)

- `flow-image-clip.ts`: `FlowImagePaintOp.filter` 추가 + `composeImageFilter()`
  (= `web_canvas.rs::compose_image_filter` 와 동일 CSS — `grayscale(100%)`, 흑백은
  `+contrast(1000%)`, 밝기/명암 linear). `bakedWatermark`(픽셀 baked)는 제외.
- `page-renderer.ts`: DOM flow `<img>` 생성 시 `element.style.filter = image.filter`.

## 검증 (headless Chrome-for-Testing 151, 기본 canvas2d)

- pr-149 DOM `<img>` filter: `none`(원본) / `grayscale(100%)`(회색조) /
  `grayscale(100%) contrast(1000%)`(흑백) 로 정확히 적용(**수정 전 3개 모두 `none`**).
- 자연 렌더 시각 확인: 원본 컬러·회색조·흑백 정상 — chrome 로 래스터한 rhwp SVG 기준과 일치.
- RealPic(비-효과) 그림 `filter:none` 무회귀, `npx tsc --noEmit` 0 errors.

## 비고

- WASM canvas 경로는 이미 효과를 적용하므로 이 PR 은 **DOM flow-image 경로만** 보정한다(중복 없음).
- 조사·근본원인·방법론 정정 로그는 `mydocs/working/task_studio_svg_divergence_20260720.md` (#2522).
