### PR TITLE
build(deps): Dependabot patch update 통합

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -37,7 +37,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -69,7 +69,7 @@ dependencies = [
  "regex",
  "rustc-hash",
  "shlex",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -121,7 +121,7 @@ checksum = "f9abbd1bc6865053c427f7198e6af43bfdedc55ab791faed4fbd361d789575ff"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -785,7 +785,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1031,9 +1031,9 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a8e94ea7f378bd32cbbd37198a4a91436180c5bb472411e48b5ec2e2124ae9e"
+checksum = "4148590afebada386688f18773da617792bf2ef03ffc1e4cbd2b1d45b023e0ba"
 dependencies = [
  "serde_core",
  "serde_derive",
@@ -1041,22 +1041,22 @@ dependencies = [
 
 [[package]]
 name = "serde_core"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41d385c7d4ca58e59fc732af25c3983b67ac852c1a25000afe1175de458b67ad"
+checksum = "67dca2c9c51e58a4791a4b1ed58308b39c64224d349a935ab5039aa360942a48"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.228"
+version = "1.0.229"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
+checksum = "e7a5d71263a5a7d47b41f6b3f06ba276f10cc18b0931f1799f710578e2309348"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 3.0.1",
 ]
 
 [[package]]
@@ -1184,7 +1184,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1214,7 +1214,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1273,6 +1273,17 @@ name = "syn"
 version = "2.0.114"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "unicode-ident",
+]
+
+[[package]]
+name = "syn"
+version = "3.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5edbec4ed188954a10c12c038215f8ce7606b2d5c973cd8dc43e8795065c5f2f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1602,7 +1613,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
  "wasm-bindgen-shared",
 ]
 
@@ -1645,7 +1656,7 @@ checksum = "fccaddcb2cd722baa7453b4c3d2cb2a3071597bb91f7a4373e8775bdb151778c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]
@@ -1756,7 +1767,7 @@ checksum = "1ae7f38b72ec2a254e2b87ef277cf2cd4fb97cbebf944faa6f33354da0867930"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn",
+ "syn 2.0.114",
 ]
 
 [[package]]

--- a/mydocs/orders/20260720.md
+++ b/mydocs/orders/20260720.md
@@ -18,3 +18,14 @@
 - collaborator 보정: Chrome DevTools version DOM attribute contract, Safari HML signature gate 및 build failure propagation, Rust 테스트 수 `3,400+` 정정. 중복 CI/npm/Dependabot PR은 상위 통합 변경으로만 반영했다.
 - CI 보정: 최초 통합 PR CI에서 [#2480](https://github.com/edwardkim/rhwp/pull/2480)의 FieldRange 분할 보정이 ClickHere 복사/붙여넣기 3건을 회귀시킨 것을 확인했다. `Field`를 보이는 문자 offset 계산에서는 제외하고, 새 문단으로 이관되는 `FieldRange`가 참조할 때만 control을 옮기도록 보정했다. focused ClickHere 13건과 undo·offset 회귀는 통과했다.
 - 다음 단계: 이 보정을 포함한 최신 head CI 전체 성공 뒤 merge 판단 및 원 PR 후속 처리를 진행한다.
+
+## Dependabot 의존성 patch update 통합 PR 준비
+
+- 수용 대상: [#2514](https://github.com/edwardkim/rhwp/pull/2514), [#2515](https://github.com/edwardkim/rhwp/pull/2515), [#2516](https://github.com/edwardkim/rhwp/pull/2516), [#2517](https://github.com/edwardkim/rhwp/pull/2517).
+- 원 PR마다 `jangster77` reviewer를 지정하고, PR 본문·코멘트·변경 범위·검증·권고를
+  [PR 검토 기록](../pr/archives/)에 분리해 보존했다. 검토 시점 원 PR 코멘트는 없었다.
+- Dependabot 원 커밋을 저자 보존 체리픽했다. Studio·Chrome·Firefox의 Vite는 8.1.5로 통일했고,
+  `serde`, `serde_core`, `serde_derive`는 1.0.229로 올렸다. derive 경로의 `syn 3.0.1` 추가도 확인했다.
+- `npm ci`와 production build 3건, Studio `npm test`, production `npm audit --omit=dev`,
+  `cargo test --profile release-test --tests`, Clippy, diff check를 모두 통과했다.
+- 다음 단계: 최신 통합 PR head CI 성공 후 merge하고, 원 Dependabot PR에 통합 결과를 남긴 뒤 close한다.

--- a/mydocs/pr/archives/pr_2514_review.md
+++ b/mydocs/pr/archives/pr_2514_review.md
@@ -1,0 +1,32 @@
+# PR #2514 검토 기록
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#2514](https://github.com/edwardkim/rhwp/pull/2514) |
+| 작성자 / base | dependabot[bot] / `devel` |
+| 검토자 | @jangster77 (검토 전 지정) |
+| 규모 / 검토 스냅샷 | 2026-07-20 GitHub 조회: +16/-16, 2 files, `mergeStateStatus=BEHIND` (동적 참고값) |
+| 범위 | `rhwp-studio` Vite 8.1.4 → 8.1.5 및 lockfile 갱신 |
+| 판단 | Dependabot 누적 통합 PR에 수용 |
+
+## 변경 범위와 통합
+
+- PR 본문은 Vite 8.1.5 patch release의 bundled-dev, client, optimizer, SSR 보완을 안내한다. 검토 시점 PR 코멘트는 없었다.
+- 원 커밋 `7b5f58f13`을 최신 `upstream/devel` 위에 충돌 없이 적용했고, 통합 브랜치 적용 커밋은 `73bc884de`다.
+- manifest와 lockfile이 같은 Vite 8.1.5를 가리키며, Studio 외 경로의 의존성 선언은 이 PR에서 바꾸지 않는다.
+
+## 렌더 영향 판정
+
+- 개발 서버·번들 도구 patch update이며 renderer·layout 산출 계약을 직접 변경하지 않는다. visual sweep 대상이 아니다.
+
+## 검증
+
+- `rhwp-studio`: `npm ci`, `npm test`, `npm run build` 통과.
+- production 의존성 기준 `npm audit --omit=dev`는 취약점 0건이다.
+- 전체 통합 브랜치에서 `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`,
+  `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD`를 통과했다.
+
+## 리스크와 권고
+
+- production build의 CanvasKit `fs`/`path` externalization 및 bundle-size 경고는 변경 전부터 있던 build 경고로, 빌드를 실패시키지 않는다.
+- **권고**: 누적 통합 PR에 수용. 최신 통합 PR head의 CI가 성공한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_2515_review.md
+++ b/mydocs/pr/archives/pr_2515_review.md
@@ -1,0 +1,32 @@
+# PR #2515 검토 기록
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#2515](https://github.com/edwardkim/rhwp/pull/2515) |
+| 작성자 / base | dependabot[bot] / `devel` |
+| 검토자 | @jangster77 (검토 전 지정) |
+| 규모 / 검토 스냅샷 | 2026-07-20 GitHub 조회: +27/-16, 1 file, `mergeStateStatus=BEHIND` (동적 참고값) |
+| 범위 | `serde` 1.0.228 → 1.0.229 lockfile 갱신 |
+| 판단 | Dependabot 누적 통합 PR에 수용 |
+
+## 변경 범위와 통합
+
+- PR 본문은 serde 1.0.229의 syn 3 대응을 안내한다. 검토 시점 PR 코멘트는 없었다.
+- 원 커밋 `660c56aec`을 최신 `upstream/devel` 위에 충돌 없이 적용했고, 통합 브랜치 적용 커밋은 `cd4f1969f`다.
+- `serde`, `serde_core`, `serde_derive`가 1.0.229로 갱신되고, derive 경로에만 `syn 3.0.1`이 추가된다. 기존 proc-macro 소비자는 `syn 2.0.114`를 계속 사용한다.
+
+## 렌더 영향 판정
+
+- Rust 직렬화 라이브러리의 lockfile patch update이며 renderer·layout 정책을 직접 변경하지 않는다. visual sweep 대상이 아니다.
+
+## 검증
+
+- `cargo tree -i serde@1.0.229`로 `rhwp`와 `wasm-bindgen-test`의 새 serde 해소를 확인했다.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과.
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings` 통과.
+- `git diff --check upstream/devel...HEAD` 통과.
+
+## 리스크와 권고
+
+- derive macro의 `syn` major가 분리되어 추가되므로 전체 Rust compile/test를 검증 근거로 사용한다.
+- **권고**: 누적 통합 PR에 수용. 최신 통합 PR head의 CI가 성공한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_2516_review.md
+++ b/mydocs/pr/archives/pr_2516_review.md
@@ -1,0 +1,31 @@
+# PR #2516 검토 기록
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#2516](https://github.com/edwardkim/rhwp/pull/2516) |
+| 작성자 / base | dependabot[bot] / `devel` |
+| 검토자 | @jangster77 (검토 전 지정) |
+| 규모 / 검토 스냅샷 | 2026-07-20 GitHub 조회: +14/-14, 2 files, `mergeStateStatus=BEHIND` (동적 참고값) |
+| 범위 | `rhwp-chrome` Vite 8.1.4 → 8.1.5 및 lockfile 갱신 |
+| 판단 | Dependabot 누적 통합 PR에 수용 |
+
+## 변경 범위와 통합
+
+- PR 본문은 Vite 8.1.5 patch release를 안내한다. 검토 시점 PR 코멘트는 없었다.
+- 원 커밋 `2f6717579`을 최신 `upstream/devel` 위에 충돌 없이 적용했고, 통합 브랜치 적용 커밋은 `15dfc276a`다.
+- manifest와 lockfile이 같은 Vite 8.1.5 및 Rolldown 1.1.5 해소를 가리킨다.
+
+## 렌더 영향 판정
+
+- Chrome 확장 production bundle의 build tool patch update이며 viewer renderer·layout 계약을 직접 변경하지 않는다. visual sweep 대상이 아니다.
+
+## 검증
+
+- `rhwp-chrome`: `npm ci`, `npm run build` 통과. manifest, content script, WASM, 폰트 복사까지 build script가 완료됐다.
+- 전체 통합 브랜치에서 `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`,
+  `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD`를 통과했다.
+
+## 리스크와 권고
+
+- production build의 기존 HTML script·asset resolution·bundle-size 경고는 새 실패가 아니며 build가 성공했다.
+- **권고**: 누적 통합 PR에 수용. 최신 통합 PR head의 CI가 성공한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_2517_review.md
+++ b/mydocs/pr/archives/pr_2517_review.md
@@ -1,0 +1,31 @@
+# PR #2517 검토 기록
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#2517](https://github.com/edwardkim/rhwp/pull/2517) |
+| 작성자 / base | dependabot[bot] / `devel` |
+| 검토자 | @jangster77 (검토 전 지정) |
+| 규모 / 검토 스냅샷 | 2026-07-20 GitHub 조회: +14/-14, 2 files, `mergeStateStatus=BEHIND` (동적 참고값) |
+| 범위 | `rhwp-firefox` Vite 8.1.4 → 8.1.5 및 lockfile 갱신 |
+| 판단 | Dependabot 누적 통합 PR에 수용 |
+
+## 변경 범위와 통합
+
+- PR 본문은 Vite 8.1.5 patch release를 안내한다. 검토 시점 PR 코멘트는 없었다.
+- 원 커밋 `afe0412d1`을 최신 `upstream/devel` 위에 충돌 없이 적용했고, 통합 브랜치 적용 커밋은 `b76f42a83`다.
+- manifest와 lockfile이 같은 Vite 8.1.5 및 Rolldown 1.1.5 해소를 가리킨다.
+
+## 렌더 영향 판정
+
+- Firefox 확장 production bundle의 build tool patch update이며 viewer renderer·layout 계약을 직접 변경하지 않는다. visual sweep 대상이 아니다.
+
+## 검증
+
+- `rhwp-firefox`: `npm ci`, `npm run build` 통과. manifest, content script, WASM, 폰트 복사까지 build script가 완료됐다.
+- 전체 통합 브랜치에서 `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`,
+  `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`, `git diff --check upstream/devel...HEAD`를 통과했다.
+
+## 리스크와 권고
+
+- production build의 기존 HTML script·asset resolution·bundle-size 경고는 새 실패가 아니며 build가 성공했다.
+- **권고**: 누적 통합 PR에 수용. 최신 통합 PR head의 CI가 성공한 뒤 merge한다.

--- a/mydocs/pr/archives/pr_2526_review.md
+++ b/mydocs/pr/archives/pr_2526_review.md
@@ -1,0 +1,35 @@
+# PR #2526 검토 - Dependabot 의존성 patch update 통합
+
+| 항목 | 내용 |
+|---|---|
+| PR | [#2526](https://github.com/edwardkim/rhwp/pull/2526) |
+| 작성자 / base | jangster77 / `devel` |
+| 대상 | Dependabot 원 PR [#2514](https://github.com/edwardkim/rhwp/pull/2514), [#2515](https://github.com/edwardkim/rhwp/pull/2515), [#2516](https://github.com/edwardkim/rhwp/pull/2516), [#2517](https://github.com/edwardkim/rhwp/pull/2517) |
+| 검토자 | @jangster77 |
+| 판단 | 최신 통합 PR head CI 성공을 조건으로 수용 |
+
+## 통합 범위
+
+- Studio, Chrome, Firefox의 Vite를 8.1.4에서 8.1.5로 통일하고 각 package lockfile을 함께 갱신한다.
+- `serde`, `serde_core`, `serde_derive`를 1.0.229로 갱신한다. derive macro 경로에는 `syn 3.0.1`이 추가되며 기존 소비자는 `syn 2.0.114`를 유지한다.
+- 원 PR별 검토 기록은 [PR #2514 검토 기록](pr_2514_review.md), [PR #2515 검토 기록](pr_2515_review.md), [PR #2516 검토 기록](pr_2516_review.md), [PR #2517 검토 기록](pr_2517_review.md)에 보관한다.
+- Dependabot 원 커밋은 rewrite하지 않고 저자 보존 체리픽했다. 새 maintainer 소스 보정은 없다.
+
+## 검증
+
+- `rhwp-studio`, `rhwp-chrome`, `rhwp-firefox`에서 각각 `npm ci`, `npm run build`를 통과했다.
+- Studio `npm test`를 통과했고, `npm audit --omit=dev`는 production 취약점 0건이다.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests` 통과.
+- `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings` 통과.
+- `git diff --check upstream/devel...HEAD` 통과.
+
+## 렌더 영향 판정
+
+- package manifest·lockfile의 patch update만 포함한다. renderer, layout, PDF/SVG 출력 계약은 바뀌지 않아 visual sweep 대상이 아니다.
+- Chrome과 Firefox extension build는 manifest, content script, WASM, 폰트 복사까지 완료되는 것을 확인했다.
+
+## Merge 전 조건과 후속
+
+- [#2526](https://github.com/edwardkim/rhwp/pull/2526) 최신 head의 필수 GitHub Actions가 성공해야 한다.
+- 작업지시자의 merge 승인 뒤에만 merge한다.
+- merge 뒤 `upstream/devel`을 동기화하고, 각 원 Dependabot PR에 통합 PR 링크와 개별 검토 기록을 남긴 뒤 close한다. merge SHA와 close 결과는 GitHub 원천 기록으로 확인한다.

--- a/mydocs/working/task_m100_2514_2517_stage1.md
+++ b/mydocs/working/task_m100_2514_2517_stage1.md
@@ -1,0 +1,29 @@
+# 작업 2514-2517 단계 1 - Dependabot 의존성 patch update 통합
+
+## 범위
+
+- Dependabot이 `devel` 대상으로 제출한 열린 PR 4건을 최신 `upstream/devel` 위에서 누적 검토한다.
+- [#2514](https://github.com/edwardkim/rhwp/pull/2514)는 `rhwp-studio`의 Vite를 8.1.4에서 8.1.5로 올린다.
+- [#2515](https://github.com/edwardkim/rhwp/pull/2515)는 `serde`를 1.0.228에서 1.0.229로 올린다.
+- [#2516](https://github.com/edwardkim/rhwp/pull/2516), [#2517](https://github.com/edwardkim/rhwp/pull/2517)은 각각 Chrome, Firefox 확장의 Vite를 8.1.5로 올린다.
+
+## 적용
+
+- 각 원 PR에 `jangster77` reviewer를 먼저 지정했다.
+- Dependabot 원 커밋을 rewrite하지 않고 `git cherry-pick`으로 저자를 보존했다.
+- 적용 커밋은 `73bc884de`(Studio Vite), `15dfc276a`(Chrome Vite), `b76f42a83`(Firefox Vite),
+  `cd4f1969f`(serde)다.
+
+## 검증
+
+- `git diff --check upstream/devel...HEAD`를 통과했다.
+- 세 npm workspace에서 `npm ci`와 `npm run build`를 통과했다.
+- `rhwp-studio`에서 `npm test`를 통과했고, production 의존성 기준 `npm audit --omit=dev`는 취약점 0건이다.
+- `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`와
+  `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`를 통과했다.
+
+## 경계와 다음 단계
+
+- package manifest·lockfile만 변경하므로 renderer, layout, 문서 출력 경로의 시각 검증 대상이 아니다.
+- 새 maintainer 소스 보정은 추가하지 않는다.
+- 원격 push, 통합 PR 생성, 원 PR close와 감사 코멘트는 작업지시자 승인 뒤에 수행한다.

--- a/rhwp-chrome/package-lock.json
+++ b/rhwp-chrome/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -1085,7 +1085,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1198,16 +1198,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/rhwp-chrome/package.json
+++ b/rhwp-chrome/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   }
 }

--- a/rhwp-firefox/package-lock.json
+++ b/rhwp-firefox/package-lock.json
@@ -10,7 +10,7 @@
       "license": "MIT",
       "devDependencies": {
         "typescript": "^7.0.2",
-        "vite": "^8.1.4"
+        "vite": "^8.1.5"
       }
     },
     "node_modules/@emnapi/core": {
@@ -1026,9 +1026,9 @@
       }
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -1065,9 +1065,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -1085,7 +1085,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -1198,16 +1198,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/rhwp-firefox/package.json
+++ b/rhwp-firefox/package.json
@@ -12,6 +12,6 @@
   },
   "devDependencies": {
     "typescript": "^7.0.2",
-    "vite": "^8.1.4"
+    "vite": "^8.1.5"
   }
 }

--- a/rhwp-studio/package-lock.json
+++ b/rhwp-studio/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "rhwp-studio",
-  "version": "0.7.18",
+  "version": "0.7.19",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "rhwp-studio",
-      "version": "0.7.18",
+      "version": "0.7.19",
       "license": "MIT",
       "dependencies": {
         "@noble/hashes": "^2.2.0",
@@ -18,7 +18,7 @@
         "@types/chrome": "^0.2.2",
         "puppeteer-core": "^25.3.0",
         "typescript": "^7.0.2",
-        "vite": "^8.1.4",
+        "vite": "^8.1.5",
         "vite-plugin-pwa": "^1.3.0",
         "workbox-window": "^7.4.1"
       }
@@ -5124,9 +5124,9 @@
       "dev": true
     },
     "node_modules/nanoid": {
-      "version": "3.3.15",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
-      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "version": "3.3.16",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.16.tgz",
+      "integrity": "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q==",
       "dev": true,
       "funding": [
         {
@@ -5314,9 +5314,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.16",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
-      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "version": "8.5.20",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.20.tgz",
+      "integrity": "sha512-lW616l85ucIQL+FocMmL7pQFPqBmwejrCMg+iPxyImlrANNJG9NHq/RkyCZopDhd8C3LA03PHRJDjkbGu8vvug==",
       "dev": true,
       "funding": [
         {
@@ -5334,7 +5334,7 @@
       ],
       "license": "MIT",
       "dependencies": {
-        "nanoid": "^3.3.12",
+        "nanoid": "^3.3.16",
         "picocolors": "^1.1.1",
         "source-map-js": "^1.2.1"
       },
@@ -6387,16 +6387,16 @@
       }
     },
     "node_modules/vite": {
-      "version": "8.1.4",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.4.tgz",
-      "integrity": "sha512-bTT9PsdWO+MQMNG9ZXIP/qM9wGh37DFxTV/sPq9cFpHr3w4jkgef032PkAL9jAqhk3Nz8NQw3O8n6/xFkqO4QQ==",
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.1.5.tgz",
+      "integrity": "sha512-7ULLwsCdYx/nRyrpiEwvqb5TFHrMVZyBt+rg/OAXT7rgj/z+DtTDyKFeLAdDkubDVDKD8jOsndmy7m55XcfUsw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "lightningcss": "^1.32.0",
         "picomatch": "^4.0.5",
-        "postcss": "^8.5.16",
-        "rolldown": "~1.1.4",
+        "postcss": "^8.5.17",
+        "rolldown": "~1.1.5",
         "tinyglobby": "^0.2.17"
       },
       "bin": {

--- a/rhwp-studio/package.json
+++ b/rhwp-studio/package.json
@@ -29,7 +29,7 @@
     "@types/chrome": "^0.2.2",
     "puppeteer-core": "^25.3.0",
     "typescript": "^7.0.2",
-    "vite": "^8.1.4",
+    "vite": "^8.1.5",
     "vite-plugin-pwa": "^1.3.0",
     "workbox-window": "^7.4.1"
   },


### PR DESCRIPTION
## 범위

- [PR #2514](https://github.com/edwardkim/rhwp/pull/2514): Studio Vite 8.1.4 -> 8.1.5
- [PR #2515](https://github.com/edwardkim/rhwp/pull/2515): serde 1.0.228 -> 1.0.229
- [PR #2516](https://github.com/edwardkim/rhwp/pull/2516): Chrome Vite 8.1.4 -> 8.1.5
- [PR #2517](https://github.com/edwardkim/rhwp/pull/2517): Firefox Vite 8.1.4 -> 8.1.5

각 Dependabot 원 커밋을 저자 보존 체리픽했고, 개별 검토 기록과 오늘할일을 포함했습니다.

## 검증

- Studio/Chrome/Firefox: `npm ci`, `npm run build`
- Studio: `npm test`, `npm audit --omit=dev` (0 vulnerabilities)
- Rust: `CARGO_INCREMENTAL=0 cargo test --profile release-test --tests`
- Rust: `CARGO_INCREMENTAL=0 cargo clippy --all-targets -- -D warnings`
- `git diff --check upstream/devel...HEAD`

renderer/layout 변경은 없어 visual sweep 대상이 아닙니다.
