### PR TITLE
chore: npm 패키지에 README/LICENSE 포함, keywords/funding 필드 추가

### DIFF
--- a/scripts/prepare-npm.sh
+++ b/scripts/prepare-npm.sh
@@ -22,11 +22,14 @@ cat > "${PKG_DIR}/package.json" << EOF
     "rhwp_bg.wasm",
     "rhwp.js",
     "rhwp.d.ts",
-    "rhwp_bg.wasm.d.ts"
+    "rhwp_bg.wasm.d.ts",
+    "README.md",
+    "LICENSE"
   ],
   "keywords": [
     "hwp",
     "hwpx",
+    "hml",
     "hancom",
     "hangul",
     "한글",
@@ -45,6 +48,7 @@ cat > "${PKG_DIR}/package.json" << EOF
   "bugs": {
     "url": "https://github.com/edwardkim/rhwp/issues"
   },
+  "funding": "https://github.com/sponsors/edwardkim",
   "license": "MIT",
   "author": "Edward Kim",
   "sideEffects": [


### PR DESCRIPTION
## Summary
- npm 패키지 files에 README.md, LICENSE 포함
- keywords에 "hml" 추가
- funding 필드 추가 (github sponsors)

## Test plan
- [ ] npm pack 후 tarball 내용 확인