### PR TITLE
fix(hwpx): 스타일 langID 가 1042 로 고정 방출되어 유실

### DIFF
--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -1281,7 +1281,9 @@ fn write_style<W: Write>(w: &mut Writer<W>, id: u16, st: &Style) -> Result<(), S
             ("paraPrIDRef", &st.para_shape_id.to_string()),
             ("charPrIDRef", &st.char_shape_id.to_string()),
             ("nextStyleIDRef", &st.next_style_id.to_string()),
-            ("langID", "1042"),
+            // 파서가 Style.lang_id 로 읽는 값을 그대로 되돌린다. 종전 "1042"
+            // 하드코딩은 비한국어 langID(예: 1033)를 왕복마다 1042 로 바꿨다.
+            ("langID", &st.lang_id.to_string()),
             ("lockForm", "0"),
         ],
     )
@@ -1325,6 +1327,23 @@ use super::utils::start_tag;
 mod tests {
     use super::*;
     use crate::parser::hwpx::parse_hwpx;
+
+    #[test]
+    fn write_style_emits_ir_lang_id() {
+        // 파서가 읽은 Style.lang_id 가 그대로 방출돼야 한다.
+        // 종전엔 "1042" 하드코딩으로 비한국어 langID 가 왕복마다 뭉개졌다.
+        let st = Style {
+            lang_id: 1033,
+            ..Default::default()
+        };
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_style(&mut w, 0, &st).expect("write_style");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(
+            xml.contains(r#"langID="1033""#),
+            "Style.lang_id 가 방출돼야 함: {xml}"
+        );
+    }
 
     #[test]
     fn write_header_runs_on_empty_document() {


### PR DESCRIPTION
`write_style`(src/serializer/hwpx/header.rs:1284)이 `("langID", "1042")` 를 **하드코딩**합니다. 파서는 이 속성을 `Style.lang_id`(i16, spec 표 47)로 읽습니다(src/parser/hwpx/header.rs:1314).

## 영향
비한국어 `langID`(예: 1033 영어) 스타일이 HWPX 왕복마다 **1042 로 강제 변경**됩니다. `Style.lang_id` 는 모델 주석에 "누락 시 HWP5 STYLE 레코드에서 para_shape_id/char_shape_id 가 2바이트 밀려 한컴이 잘못된 ParaShape 를 적용한다"고 문서화된 **load-bearing** 필드라, 단순 표기 문제가 아닙니다.

`<hh:style>` 은 `write_style` 이 전량 재생성하며 per-style raw 보존이 없습니다(같은 refList 의 numbering paraHead 는 `raw_para_heads` splice 로 가려지지만 style 은 그렇지 않음).

## 수정
```rust
("langID", &st.lang_id.to_string()),
```

## 검증
`write_style_emits_ir_lang_id` 추가: `lang_id=1033` 이 `langID="1033"` 으로 방출됨을 단언 — 수정 전 red(1042), 수정 후 green. `cargo test --lib` 통과.