### PR TITLE
fix(hwp5): 파일 유래 개수로 인한 무제한 할당·무한 루프 방지 (TAB_DEF, 연결선 제어점)

### DIFF
--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -976,9 +976,17 @@ fn parse_line_shape_data(data: &[u8], line: &mut LineShape, is_connector: bool) 
         let start_subject_index = r.read_u32().unwrap_or(0);
         let end_subject_id = r.read_u32().unwrap_or(0);
         let end_subject_index = r.read_u32().unwrap_or(0);
-        let count = r.read_u32().unwrap_or(0) as usize;
+        // countCP 는 파일에서 온 u32 다. 남은 바이트로 실제 담을 수 있는 개수
+        // (제어점당 4+4+2=10바이트)로 상한을 둔다. 종전엔 상한이 없어
+        // (a) Vec::with_capacity 가 최대 ~51GB 예약을 시도해 RawVec 오버플로
+        // panic/abort, (b) read_*().unwrap_or(0) 가 EOF 를 삼켜 루프가 count
+        // 만큼(최대 40억회) 0 을 채우며 도는 문제가 있었다.
+        let count = (r.read_u32().unwrap_or(0) as usize).min(r.remaining() / 10);
         let mut control_points = Vec::with_capacity(count);
         for _ in 0..count {
+            if r.remaining() < 10 {
+                break;
+            }
             let x = r.read_i32().unwrap_or(0);
             let y = r.read_i32().unwrap_or(0);
             let point_type = r.read_u16().unwrap_or(0);
@@ -1095,6 +1103,33 @@ fn parse_curve_shape_data(data: &[u8], curve: &mut CurveShape) {
 #[cfg(test)]
 mod task195_tests {
     use super::*;
+
+    #[test]
+    fn connector_control_point_count_is_bounded_by_remaining() {
+        // 악의적 countCP(0xFFFFFFFF)가 (a) ~51GB Vec 예약으로 abort 하거나
+        // (b) EOF 를 삼킨 채 40억회 루프를 도는 일이 없어야 한다.
+        // 페이로드: link_type(4)+ssid(4)+ssidx(4)+esid(4)+esidx(4)=20, 그 뒤 countCP.
+        let mut data = Vec::new();
+        data.extend_from_slice(&0i32.to_le_bytes()); // start.x
+        data.extend_from_slice(&0i32.to_le_bytes()); // start.y
+        data.extend_from_slice(&0i32.to_le_bytes()); // end.x
+        data.extend_from_slice(&0i32.to_le_bytes()); // end.y
+        data.extend_from_slice(&0u32.to_le_bytes()); // link_type
+        data.extend_from_slice(&0u32.to_le_bytes()); // start_subject_id
+        data.extend_from_slice(&0u32.to_le_bytes()); // start_subject_index
+        data.extend_from_slice(&0u32.to_le_bytes()); // end_subject_id
+        data.extend_from_slice(&0u32.to_le_bytes()); // end_subject_index
+        data.extend_from_slice(&0xFFFF_FFFFu32.to_le_bytes()); // countCP (악성)
+
+        let mut line = LineShape::default();
+        parse_line_shape_data(&data, &mut line, true);
+        let connector = line.connector.expect("connector 파싱");
+        assert!(
+            connector.control_points.is_empty(),
+            "남은 바이트가 없으므로 제어점은 비어야 함: {}",
+            connector.control_points.len()
+        );
+    }
 
     #[test]
     fn test_parse_ole_shape_minimal() {

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -649,7 +649,11 @@ fn parse_char_shape(data: &[u8]) -> Result<CharShape, DocInfoError> {
 fn parse_tab_def(data: &[u8]) -> Result<TabDef, DocInfoError> {
     let mut r = ByteReader::new(data);
     let attr = r.read_u32().unwrap_or(0);
-    let tab_count = r.read_u32().unwrap_or(0) as usize;
+    // tab_count 는 파일에서 온 u32 다. 남은 바이트로 실제 담을 수 있는 개수
+    // (탭당 4+1+1+2=8바이트)로 상한을 둔다. 종전엔 상한이 없어 아래 루프의
+    // remaining()<8 가드가 돌기도 전에 Vec::with_capacity 가 최대 ~34GB 예약을
+    // 시도해 OOM abort 로 이어졌다. 정상 파일에선 값이 그대로라 동작 불변.
+    let tab_count = (r.read_u32().unwrap_or(0) as usize).min(r.remaining() / 8);
 
     let mut tabs = Vec::with_capacity(tab_count);
     for _ in 0..tab_count {
@@ -891,6 +895,19 @@ fn parse_style(data: &[u8]) -> Result<Style, DocInfoError> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn parse_tab_def_bounds_hostile_tab_count() {
+        // 악의적 tab_count(0xFFFFFFFF)가 Vec::with_capacity 로 ~34GB 예약을
+        // 시도해 OOM abort 되면 안 된다. 남은 바이트 기준으로 상한이 걸려
+        // 빈 탭 목록으로 정상 반환해야 한다.
+        let data = [0u8, 0, 0, 0, 0xFF, 0xFF, 0xFF, 0xFF];
+        let tab_def = parse_tab_def(&data).expect("악성 입력도 graceful 하게 처리");
+        assert!(
+            tab_def.tabs.is_empty(),
+            "남은 바이트가 없으므로 탭은 비어야 함"
+        );
+    }
 
     // 레코드 바이트 생성 헬퍼
     fn make_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
HWP3 파서는 #877 이후 `check_record_count` 가드를 갖췄지만, **HWP5 바이너리 경로에는 동등한 가드가 없습니다** — 파일에서 읽은 `u32` 개수를 그대로 `Vec::with_capacity` 에 넘깁니다. rhwp 는 WASM/브라우저에서 **신뢰할 수 없는 문서**를 파싱하므로 abort/행(hang)은 실제 결함입니다.

## 1) `parse_tab_def` (src/parser/doc_info.rs) — HIGH
`tab_count = 0xFFFFFFFF` 이면 루프의 `remaining() < 8` 가드가 **돌기도 전에** `Vec::with_capacity` 가 약 **34GB** 예약을 시도해 OOM abort 합니다. `HWPTAG_TAB_DEF` 디스패치에서 바로 도달하며, 재현 입력은 **12바이트 남짓의 DocInfo 스트림**입니다.

## 2) 연결선 제어점 (src/parser/control/shape.rs) — HIGH
`countCP = 0xFFFFFFFF` 일 때 두 결함이 겹칩니다:
- `Vec::with_capacity(count)` 가 약 **51GB**(2^32 × 12B) 예약 → RawVec 오버플로 panic/abort
- 루프가 **EOF 로 종료되지 않음** — `read_i32().unwrap_or(0)` 이 `UnexpectedEof` 를 삼켜 0 을 반환하므로, 버퍼가 끝나도 `count` 만큼(최대 **40억회**) 0 제어점을 채우며 돕니다

## 수정
남은 바이트로 실제 담을 수 있는 개수를 상한으로 둡니다(스트라이드: 탭 8B, 제어점 10B) + 연결선 루프에 EOF 가드 추가.
```rust
let tab_count = (r.read_u32().unwrap_or(0) as usize).min(r.remaining() / 8);
let count = (r.read_u32().unwrap_or(0) as usize).min(r.remaining() / 10);
```
**정상 파일에서는 개수가 남은 바이트 이하라 값이 그대로여서 동작 불변**입니다(무회귀). 이미 같은 패턴이 `doc_info.rs` 그라데이션 `.min(64)` 와 `hwp3/drawing.rs` 의 `check_record_count` 에 있습니다.

## 검증
악성 입력(0xFFFFFFFF)이 graceful 하게 처리됨을 단언하는 테스트 2개 추가 — 수정 전 abort/행, 수정 후 green. `parser::doc_info` 16건 / `parser::control` 18건 회귀 통과.