### PR TITLE
fix(parser): 확장 레코드 크기의 pos+size 오버플로가 경계 검사를 무력화 (wasm32)

### DIFF
--- a/src/parser/crypto.rs
+++ b/src/parser/crypto.rs
@@ -399,12 +399,17 @@ fn read_first_record(data: &[u8]) -> Result<Record, String> {
     }
 
     let pos = cursor.position() as usize;
-    if pos + size as usize > data.len() {
+    // record.rs 와 동일 근거: wasm32(usize 32비트)에서 `pos + size` 랩어라운드로
+    // 경계 검사가 무력화되는 것을 checked_add 로 막는다.
+    if pos
+        .checked_add(size as usize)
+        .map_or(true, |end| end > data.len())
+    {
         return Err(format!(
             "레코드 데이터 부족: tag={}, 필요={}, 가용={}",
             tag_id,
             size,
-            data.len() - pos
+            data.len().saturating_sub(pos)
         ));
     }
 

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -58,11 +58,18 @@ impl Record {
 
             // 데이터 읽기
             let pos = cursor.position() as usize;
-            if pos + size as usize > data.len() {
+            // size 는 파일에서 온 확장 32비트 레코드 크기다. `pos + size` 를 그대로
+            // 더하면 usize 가 32비트인 wasm32(이 크레이트의 배포 타깃) 에서 랩어라운드가
+            // 일어나 경계 검사가 무력화되고, 뒤이어 vec![0u8; size] 가 4GB 할당을
+            // 시도한다. checked_add 로 오버플로 자체를 실패로 처리한다.
+            if pos
+                .checked_add(size as usize)
+                .map_or(true, |end| end > data.len())
+            {
                 return Err(RecordError::UnexpectedEof {
                     tag_id,
                     expected: size as usize,
-                    available: data.len() - pos,
+                    available: data.len().saturating_sub(pos),
                 });
             }
 
@@ -129,6 +136,18 @@ impl std::error::Error for RecordError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extended_size_overflow_is_rejected() {
+        // 헤더의 크기 필드가 0xFFF 면 다음 4바이트가 확장 크기다. 그 값이
+        // 0xFFFFFFFF 여도 경계 검사가 통과해선 안 된다(wasm32 에서 pos+size
+        // 랩어라운드로 무력화되던 경로). 할당 시도 없이 Err 로 끝나야 한다.
+        let data = [0x00u8, 0x00, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+        assert!(
+            Record::read_all(&data).is_err(),
+            "확장 크기 오버플로 입력은 Err 여야 함"
+        );
+    }
 
     /// 기본 레코드 생성 헬퍼
     fn make_record_bytes(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8> {


### PR DESCRIPTION
레코드 헤더의 크기 필드가 `0xFFF` 이면 다음 4바이트가 **확장 크기**이며, 이 값은 파일에서 옵니다. 경계 검사가

```rust
if pos + size as usize > data.len() { ... }
```

로 되어 있어, **`usize` 가 32비트인 wasm32** — 이 크레이트의 실제 배포 타깃(`crate-type = ["cdylib"]`, `cfg(target_arch = "wasm32")` 의존성 존재) — 에서 **랩어라운드**가 발생합니다. `size = 0xFFFFFFFF`, `pos = 8` 이면 합이 `7` 로 감싸져 검사를 통과하고, 뒤이어 `vec![0u8; 0xFFFFFFFF]` 가 브라우저 힙에서 **4GB 할당**을 시도해 panic 합니다. 재현 입력은 **8바이트**입니다.

64비트 호스트에서는 합이 감싸지 않아 지금까지 드러나지 않았습니다.

## 수정
`src/parser/record.rs` 와 `src/parser/crypto.rs`(동일 로직이 중복돼 있음) 양쪽에 `checked_add` 가드를 적용하고, 오류 메시지의 `data.len() - pos` 도 `saturating_sub` 로 바꿨습니다. **64비트에서는 동작 불변**입니다.

## 검증
`extended_size_overflow_is_rejected` 추가: 확장 크기 오버플로 입력이 할당 시도 없이 `Err` 로 끝남을 단언. `parser::record` 8건 통과.

**투명한 고지**: 이 테스트는 durable 회귀 가드입니다. 오버플로 자체는 32비트 `usize`(wasm32)에서만 발현하므로 x86_64 로컬 실행에서는 수정 전에도 통과합니다 — 즉 이 PR 의 red→green 은 타깃 의존적입니다. 필요하시면 `wasm-bindgen-test` 로 wasm32 커버리지를 추가하겠습니다.