### PR TITLE
fix(hwp5): HWPX 대체 글꼴(substFont)이 HWP5 저장 시 유실

### DIFF
--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -892,6 +892,34 @@ fn parse_style(data: &[u8]) -> Result<Style, DocInfoError> {
 mod tests {
     use super::*;
 
+    #[test]
+    fn face_name_roundtrips_subst_font_as_alt_name() {
+        use crate::model::style::SubstFont;
+        // HWPX 파서는 대체 글꼴을 subst_font 로 채우고 alt_name 은 None 으로 둔다.
+        // HWP5 FACE_NAME 은 alt_name 한 곳에만 담으므로, 직렬화가 두 출처를 합치지
+        // 않으면 HWPX→HWP5 저장에서 대체 글꼴이 통째로 사라진다.
+        let font = crate::model::style::Font {
+            name: "굴림".to_string(),
+            alt_name: None,
+            subst_font: Some(SubstFont {
+                face: "맑은 고딕".to_string(),
+                font_type: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let bytes = crate::serializer::doc_info::serialize_face_name(&font);
+        assert_eq!(bytes[0] & 0x80, 0x80, "대체 글꼴 있으면 attr bit7 이 서야 함");
+
+        let parsed = parse_face_name(&bytes).expect("FACE_NAME 재파싱");
+        assert_eq!(
+            parsed.alt_name.as_deref(),
+            Some("맑은 고딕"),
+            "subst_font 의 대체 글꼴이 HWP5 왕복에서 보존돼야 함"
+        );
+    }
+
     // 레코드 바이트 생성 헬퍼
     fn make_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8> {
         let size = data.len() as u32;

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -231,9 +231,20 @@ pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8> {
 pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     let mut w = ByteWriter::new();
 
+    // 대체 글꼴 이름: HWP5 는 alt_name 한 곳에만 담는다. HWPX 파서는 같은 값을
+    // subst_font(<hh:substFont face=...>)로 채우고 alt_name 은 None 으로 두므로,
+    // 여기서 두 출처를 합쳐야 HWPX→HWP5 저장에서 대체 글꼴이 살아남는다.
+    // (종전엔 alt_name 만 봐서 HWPX 출처 대체 글꼴이 통째로 유실됐다.)
+    let alt_name = font.alt_name.as_deref().or_else(|| {
+        font.subst_font
+            .as_ref()
+            .map(|s| s.face.as_str())
+            .filter(|face| !face.is_empty())
+    });
+
     // attr 바이트 재구성
     let mut attr = font.alt_type & 0x03;
-    if font.alt_name.is_some() {
+    if alt_name.is_some() {
         attr |= 0x80;
     }
     if font.type_info.is_some() {
@@ -246,7 +257,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
 
     w.write_hwp_string(&font.name).unwrap();
 
-    if let Some(ref alt_name) = font.alt_name {
+    if let Some(alt_name) = alt_name {
         w.write_u8(font.alt_type & 0x03).unwrap();
         w.write_hwp_string(alt_name).unwrap();
     }


### PR DESCRIPTION
`serialize_face_name`(src/serializer/doc_info.rs:231)이 대체 글꼴 유무를 **`font.alt_name` 으로만** 판단해, attr bit7(`0x80`)과 alt-name 기록 블록을 모두 건너뜁니다.

## 왜 유실되나
HWPX 파서는 `<hh:substFont face="맑은 고딕" .../>` 를 **`Font.subst_font`** 로 채우고(src/parser/hwpx/header.rs:421,451), 같은 `Font` 리터럴이 `..Default::default()` 를 쓰므로 **`alt_name` 은 항상 `None`** 입니다. 따라서 HWPX 출처 문서를 HWP5 로 저장하면 FACE_NAME 레코드에 attr bit7 이 꺼진 채 alt-name 필드가 아예 빠져 **대체 글꼴이 통째로 사라집니다**. (`grep subst_font src/serializer/doc_info.rs` → 0건)

이 값이 의미 있다는 근거: HWPX 직렬화는 왕복시키고(`write_subst_font`, serializer/hwpx/header.rs:272), 렌더러도 소비합니다(document_core/queries/rendering.rs:559,606). **HWP5 분기만의 누락**입니다.

## 수정
같은 함수의 `default_name` 폴백 패턴과 동형으로, 유효 대체 글꼴 이름을 먼저 해석해 attr 비트와 기록 블록에 함께 사용합니다:
```rust
let alt_name = font.alt_name.as_deref().or_else(|| {
    font.subst_font.as_ref().map(|s| s.face.as_str()).filter(|f| !f.is_empty())
});
```
`alt_type` 바이트는 스펙 모호성이 있어 **종전 동작을 유지**했습니다(범위 밖).

## 검증
`face_name_roundtrips_subst_font_as_alt_name` 추가: `subst_font` 만 가진 Font 를 `serialize_face_name`→`parse_face_name` 왕복 후 `alt_name == Some("맑은 고딕")` 과 attr bit7 을 단언 — 수정 전 red(None/bit 미설정), 수정 후 green. `parser::doc_info` 16건 통과.