### PR TITLE
fix(queries): 중첩 표 내부 run 을 바깥 셀로 오인하는 path[0]-only 매칭

### DIFF
--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -2630,7 +2630,12 @@ impl DocumentCore {
         ) -> Option<CursorHit> {
             if let RenderNodeType::TextRun(ref text_run) = node.node_type {
                 let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+                    // path 길이 일치를 계약으로 명시한다.
                     ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                         && ctx.path[0].cell_para_index == cp_idx
@@ -2720,7 +2725,12 @@ impl DocumentCore {
         ) -> Option<(f64, f64, f64)> {
             if let RenderNodeType::TextRun(ref text_run) = node.node_type {
                 let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+                    // path 길이 일치를 계약으로 명시한다.
                     ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                         && ctx.path[0].cell_para_index == cp_idx
@@ -2847,7 +2857,11 @@ impl DocumentCore {
             let mut result: Option<usize> = None;
             if let RenderNodeType::TextRun(ref tr) = node.node_type {
                 if let Some(ref ctx) = tr.cell_context {
+                    // 위와 동일 근거의 path.len()==1 가드. 이 함수는 max 를 취하므로
+                    // 중첩 표 내부 run 이 섞이면 바깥 셀이 실제로 그려지지 않은
+                    // 페이지에서도 "그려졌다"고 보고해 캐럿 클램프가 어긋난다.
                     if ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                     {


### PR DESCRIPTION
`cursor_rect.rs` 의 세 매처가 `cell_context` 를 **`path[0]` 만으로** 비교하고 path 길이를 확인하지 않습니다. 중첩 표 **내부** 셀의 TextRun 은 `path = [바깥, 안쪽]` 이고 그 `path[0]` 이 **중첩 표를 품은 바깥 셀과 정확히 같으므로**, 내부 run 이 바깥 셀의 run 으로 매칭됩니다.

## 계약 위반 근거
같은 파일의 `cell_context_matches` 헬퍼(:3022)가 `ctx.path.len() == path.len()` 를 **계약으로 명시**합니다. 설계 모호성이 아니라 그 계약을 지키지 않은 지점들입니다.

## 영향
- **`find_cursor_in_cell`(:2634) / `find_cell_run`(:2724)** — 깊이 우선 first-match-wins 라, 바깥 셀에 자체 텍스트 run 이 없으면(예: 셀 첫 문단이 중첩 표뿐) **내부 run 이 이겨** 캐럿이 중첩 표 안에 그려집니다. 모델 위치는 바깥 셀인데 렌더 위치가 다릅니다. 게다가 `hit_test_native`(:3620)는 전체 cellPath 를 내므로 **두 질의가 서로 어긋납니다**(hit-test 는 "바깥 셀", cursor-rect 는 내부 셀). 이후 Up/Down 은 이 rect 에서 재유도되어 엉뚱한 열로 이동합니다.
- **`last_rendered_para_in_container`(:2850)** — `max` 를 취하므로 내부 run 이 섞이면 바깥 셀이 실제로 그려지지 않은 페이지에서도 "그려졌다"고 보고합니다. 이 값은 `wasm_api.rs:1967` 로 편집기에 노출돼 캐럿 클램프에 쓰이므로 End/Ctrl-End 가 어긋납니다.

## 수정
세 곳에 `ctx.path.len() == 1` 가드 추가.

## 검증 (투명 고지)
`document_core::queries` **45건 회귀 통과**(무회귀 확인). 다만 **행위 수준 red→green 테스트는 넣지 못했습니다** — 이 매처들은 메서드 내부 중첩 함수라 직접 호출할 수 없고, 재현하려면 `CellContext` 가 달린 중첩 표 render-tree 하네스가 필요한데 이 모듈의 테스트는 순수 헬퍼(clamp/resolve_x_on_line)만 다루고 있어 하네스가 없습니다. 근거는 ① 같은 파일 `cell_context_matches` 의 명시적 계약, ② 내부 run 의 `path.len() >= 2` 라는 구조적 확실성, ③ 45건 무회귀입니다. 하네스를 추가해 행위 테스트까지 넣기를 원하시면 말씀해 주세요.