### PR TITLE
fix(cli): dump-pages 인자 검증을 형제 명령과 정합 (#2551)

### DIFF
--- a/mydocs/report/task_m100_2551_report.md
+++ b/mydocs/report/task_m100_2551_report.md
@@ -1,0 +1,83 @@
+# task_m100_2551 처리결과 보고서 — dump-pages 인자 검증을 형제 명령과 정합
+
+- **이슈**: [#2551](https://github.com/edwardkim/rhwp/issues/2551)
+- **브랜치**: `task/m100-2551-dump-pages-args` (base `devel` @ `3c54abfd`)
+- **범위**: `src/main.rs` `dump_pages` 인자 파싱 3개 결함
+- **분류**: 결함 수정 (무성 오류 → 명시적 오류)
+
+## 1. 문제
+
+`dump-pages` 만 형제 명령들과 다르게 인자 오류를 조용히 삼켰다. 세 가지 모두 무성이라
+스크립트/CI 에서 잘못된 호출을 감지할 수 없었다.
+
+`src/main.rs:2436-2452` (수정 전)
+
+```rust
+"--page" | "-p" => {
+    if i + 1 < args.len() { target_page = args[i + 1].parse().ok(); i += 2; }
+    else { i += 1; }
+}
+_ => { i += 1; }   // 알 수 없는 옵션, 메시지 없음
+```
+
+| # | 결함 | 종전 동작 |
+|---|---|---|
+| 1 | 파싱 실패를 `.ok()` 로 삼킴 | `-p abc` → `None` → **문서 전체 덤프** |
+| 2 | 범위 검사 없음 | `-p 999` → 빈 출력 → "쪽 없는 문서" 처럼 보임 |
+| 3 | 미지 옵션 무시 | `--respect-vpos-resets`(오타) 조용히 버려짐 |
+
+## 2. 분석 — 새 규약이 아니라 기존 선례로의 정합
+
+형제 명령은 같은 자리를 이미 올바르게 처리한다. 본 수정은 **그 패턴을 그대로 미러링**한 것이며
+새로운 규약을 도입하지 않는다.
+
+| 항목 | 선례 |
+|---|---|
+| 파싱 실패 오류 | `export_svg` `main.rs:337-350`, `export_png` `:995-1008`, `export_text` `:1622-1636` |
+| 범위 검사 | `export_svg` `main.rs:520-527` |
+| 미지 옵션 경고 | `export-svg` / `export-render-tree` |
+
+`-p` 가 0-based 라는 기존 계약(`cli_commands.md:24`)은 유지했고, 범위 메시지도 선례와 동일하게
+`(0~N-1)` 형식으로 맞췄다.
+
+## 3. 변경
+
+`src/main.rs` — `dump_pages` 한 함수만 수정.
+
+1. `-p` 파싱을 `match ... { Ok/Err }` 로 바꾸고 실패 시 `eprintln!` + 조기 반환
+2. `-p` 뒤 인자 누락 시에도 오류 반환
+3. 문서 로드 후 `target_page >= page_count` 범위 검사 추가(`saturating_sub` 로 0쪽 문서 방어)
+4. 미지 옵션 catch-all 에 `알 수 없는 옵션: {}` 경고 추가
+
+## 4. 검증
+
+`cargo build --bin rhwp` 통과 후 **실제 바이너리로 행위 검증**했다(정적 확인이 아님).
+
+| 케이스 | 결과 |
+|---|---|
+| `dump-pages basic-table-01.hwpx -p abc` | `오류: 페이지 번호가 올바르지 않습니다.` + **출력 0줄** (종전: 전체 덤프) |
+| `dump-pages … -p 999` | `오류: 페이지 번호가 범위를 벗어났습니다 (0~0)` (종전: 무성 빈 출력) |
+| `dump-pages … --respect-vpos-resets` | `알 수 없는 옵션: --respect-vpos-resets` (종전: 무성) |
+| `dump-pages … -p 0` (정상) | `문서 로드: … (1페이지)` — **회귀 없음** |
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다.
+- 자동화 통합 테스트(`assert_cmd` 형태)는 추가하지 않았다. 현재 저장소에 CLI 종료코드/표준오류를
+  단언하는 테스트 하네스가 없어, 하네스 도입은 범위를 넘는다고 판단했다. 위 행위 검증 결과로
+  대신했으며, 하네스 추가를 원하시면 별도로 진행하겠다.
+
+## 5. 잔여 — 같은 스윕의 별건 (본 PR 미포함)
+
+범위를 섞지 않기 위해 분리했다. 필요하시면 각각 이슈로 등록하겠다.
+
+1. **대부분의 명령이 치명적 오류 뒤에도 종료 코드 0** — `export-pdf` 만 `process::exit` 사용
+   (`main.rs:17-22`). 매뉴얼 §3 의 종료 코드 계약과 불일치하며, `export-svg`/`export-png` 는
+   쪽 렌더 실패를 경고만 하고 `내보내기 완료: N개` 를 출력한다.
+2. **`export-svg --font-path` 가 파싱만 되고 무시됨** — `--profile` 경로(`main.rs:537-543`)와
+   기본 경로에서 `font_paths` 가 버려진다.
+3. **단일 페이지 출력 파일명 규칙 불일치** — `export-png` 는 선택 쪽 수, `export-svg`/
+   `export-text` 는 문서 쪽 수를 기준으로 삼아 같은 인자에 다른 파일명이 나온다.
+4. **매뉴얼 누락** — `measure-width`, `core-pages`, `export-pdf --backend/--raster-dpi` 가
+   `cli_commands.md` 에 없다(문서가 "39개 전수 등재" 라고 명시).

--- a/src/main.rs
+++ b/src/main.rs
@@ -2435,17 +2435,28 @@ fn dump_pages(args: &[String]) {
         match args[i].as_str() {
             "--page" | "-p" => {
                 if i + 1 < args.len() {
-                    target_page = args[i + 1].parse().ok();
+                    // 형제 명령(export_svg/export_png/export_text)과 동일하게 파싱 실패를
+                    // 오류로 처리한다. 종전 `.parse().ok()` 는 잘못된 인자를 조용히 삼켜
+                    // 한 쪽만 요청했는데 문서 전체를 덤프했다.
+                    match args[i + 1].parse::<u32>() {
+                        Ok(n) => target_page = Some(n),
+                        Err(_) => {
+                            eprintln!("오류: 페이지 번호가 올바르지 않습니다.");
+                            return;
+                        }
+                    }
                     i += 2;
                 } else {
-                    i += 1;
+                    eprintln!("오류: --page 뒤에 페이지 번호가 필요합니다.");
+                    return;
                 }
             }
             "--respect-vpos-reset" => {
                 respect_vpos_reset = true;
                 i += 1;
             }
-            _ => {
+            other => {
+                eprintln!("알 수 없는 옵션: {}", other);
                 i += 1;
             }
         }
@@ -2471,7 +2482,22 @@ fn dump_pages(args: &[String]) {
         doc.set_respect_vpos_reset(true);
     }
 
-    println!("문서 로드: {} ({}페이지)", file_path, doc.page_count());
+    let page_count = doc.page_count();
+
+    // 형제 명령(export_svg)과 동일한 범위 검사. 종전엔 검사가 없어 -p 999 가
+    // 아무것도 매칭하지 않은 빈 출력을 내, 잘못된 인자가 아니라 "쪽이 없는 문서"
+    // 처럼 보였다.
+    if let Some(p) = target_page {
+        if p >= page_count {
+            eprintln!(
+                "오류: 페이지 번호가 범위를 벗어났습니다 (0~{})",
+                page_count.saturating_sub(1)
+            );
+            return;
+        }
+    }
+
+    println!("문서 로드: {} ({}페이지)", file_path, page_count);
     print!("{}", doc.dump_page_items(target_page));
 }
 


### PR DESCRIPTION
이슈 [#2551](https://github.com/edwardkim/rhwp/issues/2551) 처리.
처리결과 문서: `mydocs/report/task_m100_2551_report.md`

## 문제

`dump-pages` **만** 인자 오류를 조용히 삼켰습니다. 세 가지 모두 무성이라 스크립트/CI 가 잘못된 호출을 감지할 수 없습니다.

| # | 결함 | 종전 동작 |
|---|---|---|
| 1 | `.parse().ok()` 로 파싱 실패를 삼킴 | `-p abc` → `None` → **문서 전체 덤프** |
| 2 | 범위 검사 없음 | `-p 999` → 빈 출력 → "쪽 없는 문서" 처럼 보임 |
| 3 | 미지 옵션 무시 | `--respect-vpos-resets`(오타) 조용히 버려짐 |

`dump-pages` 는 페이지네이션 디버깅 명령이라 오타 하나로 **의도와 다른 전체 덤프**가 성공처럼 나오면, 잘못된 산출물을 근거로 분석이 진행됩니다.

## 분석 — 새 규약이 아니라 기존 선례로의 정합

형제 명령이 같은 자리를 **이미 올바르게** 처리합니다. 그 패턴을 그대로 미러링했을 뿐입니다.

- 파싱 실패 오류: `export_svg`(main.rs:337-350), `export_png`(:995-1008), `export_text`(:1622-1636)
- 범위 검사: `export_svg`(main.rs:520-527)
- 미지 옵션 경고: `export-svg` / `export-render-tree`

`-p` 0-based 계약(`cli_commands.md:24`)과 범위 메시지 형식 `(0~N-1)` 도 선례와 동일하게 유지했습니다.

## 검증 — 실제 바이너리 행위 확인

정적 확인이 아니라 `cargo build --bin rhwp` 후 **바이너리를 직접 실행**했습니다.

| 케이스 | 결과 |
|---|---|
| `-p abc` | `오류: 페이지 번호가 올바르지 않습니다.` + **출력 0줄** (종전: 전체 덤프) |
| `-p 999` | `오류: 페이지 번호가 범위를 벗어났습니다 (0~0)` (종전: 무성 빈 출력) |
| `--respect-vpos-resets` | `알 수 없는 옵션: …` (종전: 무성) |
| `-p 0` (정상) | `문서 로드: … (1페이지)` — **회귀 없음** |

### 미실행 (투명 고지)

- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`) 미실행 — 저장소 규약상 작업지시자 별도 승인 사항입니다.
- 자동화 통합 테스트(`assert_cmd` 형태) 미추가 — 현재 저장소에 CLI 종료코드/표준오류를 단언하는 하네스가 없어 도입은 범위를 넘는다고 판단했습니다. 원하시면 별도로 진행하겠습니다.

## 잔여 — 같은 스윕의 별건 (본 PR 미포함, 범위 분리)

필요하시면 각각 이슈로 등록하겠습니다.

1. **대부분의 명령이 치명적 오류 뒤에도 종료 코드 0** — `export-pdf` 만 `process::exit` 사용. 매뉴얼 §3 종료 코드 계약과 불일치.
2. **`export-svg --font-path` 가 파싱만 되고 무시됨** — `--profile` 경로와 기본 경로에서 버려짐.
3. **단일 페이지 출력 파일명 규칙 불일치** — `export-png`(선택 쪽 수) vs `export-svg`/`export-text`(문서 쪽 수).
4. **매뉴얼 누락** — `measure-width`, `core-pages`, `export-pdf --backend/--raster-dpi`.