### PR TITLE
fix(renderer): 높이 측정 경로를 조판/렌더와 정합 (#2553)

### DIFF
--- a/mydocs/report/task_m100_2553_report.md
+++ b/mydocs/report/task_m100_2553_report.md
@@ -1,0 +1,78 @@
+# task_m100_2553 처리결과 보고서 — 높이 측정 경로를 조판/렌더와 정합
+
+- **이슈**: [#2553](https://github.com/edwardkim/rhwp/issues/2553)
+- **브랜치**: `task/m100-2553-height-measurer-body-recompose` (base `devel` @ `3c54abfd`)
+- **범위**: `src/renderer/height_measurer.rs` 의 recompose 분기 20줄
+- **분류**: 결함 수정 (페이지 분할 입력 오차)
+
+## 1. 문제
+
+`HeightMeasurer` 가 **본문** 문단을 측정하면서 형제 두 경로와 다르게 동작했다. 측정 결과는
+페이지네이션 입력이므로, 측정과 실제 조판이 서로 다른 줄 수·높이를 갖게 된다.
+
+### (a) cell recompose 오용
+
+`height_measurer.rs:527` 이 `recompose_for_cell_width` 를 호출한다. 형제는 모두 body 래퍼다:
+
+- `typeset.rs:11162` — 주석: `[#2279] 본문 NO_LS 는 글자모양 재분할 포함 래퍼 사용 —
+  paragraph_layout(렌더)와 동일 (측정/렌더 줄수·pitch 정합)`
+- `paragraph_layout.rs:1907`
+
+body 는 cell 의 strict superset 이다(`composer.rs`):
+
+```rust
+pub fn recompose_for_body_width(...) {
+    restyle_fallback_runs_by_char_shapes(composed, para);   // 측정 경로가 빠뜨린 부분
+    recompose_for_cell_width(composed, para, column_inner_width_px, styles);
+}
+```
+
+`restyle_fallback_runs_by_char_shapes` 는 `compose_lines` NO_LS 폴백이 만든 단일
+`default_style_id` run 을 실제 글자모양으로 재분할하는 유일한 지점이다. 빠지면 혼합 글자모양
+문단(15pt 도입부 + 14pt 본문 등)을 전부 도입부 크기로 측정해 폭이 과대해지고, 줄별 `max_fs`
+가 일괄 15pt 라 `Percent` 줄간격 기준까지 부풀어 누적 높이 오차가 생긴다.
+
+### (b) 도달 불가 분기
+
+`height_measurer.rs:521` 이 `para.line_segs.is_empty()` 를 **match guard** 에 올려, 저장
+line_segs 가 있는 문단은 곧장 `_ => None` 으로 떨어졌다. 형제는 같은 술어를 arm 본문에 두고
+`else if` 로 stale 재래핑을 잇는다(`typeset.rs:11158-11182`,
+`paragraph_layout.rs:1913-1930`). `recompose_stored_lines_if_overflowing_body` 의 호출부는
+그 두 곳뿐이었고 측정 경로에는 대응물이 없었다 — 즉 기능이 구조적으로 도달 불가였다.
+
+마스킹 문단에서 조판/렌더는 stale 분할을 버리고 재래핑하는데 측정은 저장 분할을 유지하므로
+`line_heights` 의 줄 수 자체가 달라져 `PartialParagraph` 시작/끝 줄 인덱스가 어긋난다.
+
+## 2. 변경
+
+두 결함이 같은 블록에서 각각 갈라진 것이라, `typeset.rs:11153-11185` 구조를 통째로 이식했다.
+
+1. guard 의 `para.line_segs.is_empty()` 를 arm 본문으로 이동
+2. NO_LS 경로를 `recompose_for_body_width` 로 교체
+3. `else if masked_stored_lines_stale(...)` → `recompose_stored_lines_if_overflowing_body`
+   분기 추가
+
+## 3. 검증
+
+페이지 분할 입력을 바꾸는 변경이라 회귀를 넓게 확인했다.
+
+| 스위트 | 결과 |
+|---|---|
+| `cargo test --lib renderer` | **862 passed / 0 failed** |
+| `cargo test --lib document_core` | **254 passed / 0 failed** |
+| `cargo test --lib` (전체) | **2377 passed / 0 failed / 7 ignored** |
+
+측정 경로를 조판 경로와 동일하게 만드는 변경이므로, 두 경로가 이미 일치하던 문서에서는 동작이
+바뀌지 않는다(전체 무회귀가 이를 뒷받침한다). 어긋나 있던 문단에서만 측정이 조판을 따라간다.
+
+### 미실행 항목 (투명 고지)
+
+- **전용 red→green 단위 테스트 미추가**. 이 결함은 "측정과 조판이 서로 다른 값을 낸다" 는
+  경로 간 불일치라, 단언하려면 `measure_section` 결과와 조판 결과를 같은 문단에 대해 비교하는
+  하네스가 필요하다. 현재 `height_measurer` 에는 그런 교차 비교 하네스가 없다. 대신 근거는
+  ① 형제 두 경로의 코드와 `[#2279]` 주석이 "측정/렌더 정합" 을 이 래퍼의 목적으로 명시,
+  ② body 가 cell 의 strict superset 이라는 정의, ③ 전체 2377건 무회귀다.
+  하네스를 세워 교차 비교 테스트까지 넣기를 원하시면 별도로 진행하겠다.
+- **PR CI 전체 검증**(`cargo clippy -- -D warnings`, visual sweep): 저장소 규약상 작업지시자
+  별도 승인 사항이라 실행하지 않았다. 렌더 출력 경로를 바꾸는 변경이므로 visual sweep 판단이
+  필요하면 지시 바란다.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -518,13 +518,33 @@ impl HeightMeasurer {
         // [Task #1042 Stage 6c] line_segs.empty paragraph 의 compose_lines fallback
         // 결과를 단 너비 기반으로 recompose — paragraph_layout (Stage 6b) 와 동일.
         let recomposed: Option<ComposedParagraph> = match (composed, column_width_px) {
-            (Some(c), Some(cw)) if para.line_segs.is_empty() && cw > 0.0 => {
+            // [#2553] line_segs.is_empty() 를 match guard 에 두면 저장 line_segs 가 있는
+            // 문단이 곧장 `_ => None` 으로 떨어져 아래 stale 재래핑 분기에 도달할 수 없다.
+            // typeset.rs / paragraph_layout.rs 와 동일하게 술어를 arm 본문으로 내린다.
+            (Some(c), Some(cw)) if cw > 0.0 => {
                 let margin_l = para_style.map(|s| s.margin_left).unwrap_or(0.0);
                 let margin_r = para_style.map(|s| s.margin_right).unwrap_or(0.0);
                 let inner = (cw - margin_l - margin_r).max(0.0);
-                if inner > 0.0 {
+                if inner > 0.0 && para.line_segs.is_empty() {
                     let mut cloned = c.clone();
-                    crate::renderer::composer::recompose_for_cell_width(
+                    // [#2279] 본문 NO_LS 는 글자모양 재분할 포함 래퍼 사용 —
+                    // typeset/paragraph_layout(렌더)와 동일 (측정/렌더 줄수·pitch 정합).
+                    // cell 래퍼는 restyle_fallback_runs_by_char_shapes 를 빠뜨려
+                    // 혼합 글자모양 문단의 측정 폭이 렌더와 어긋났다.
+                    crate::renderer::composer::recompose_for_body_width(
+                        &mut cloned,
+                        para,
+                        inner,
+                        styles,
+                    );
+                    Some(cloned)
+                } else if inner > 0.0
+                    && crate::renderer::composer::masked_stored_lines_stale(c, para, inner, styles)
+                {
+                    // [#2279] 마스킹 저장분할 stale(실폭-과잉/줄수-과소) 본문 문단
+                    // fresh 재래핑 — typeset/paragraph_layout(렌더)와 동일.
+                    let mut cloned = c.clone();
+                    crate::renderer::composer::recompose_stored_lines_if_overflowing_body(
                         &mut cloned,
                         para,
                         inner,


### PR DESCRIPTION
이슈 [#2553](https://github.com/edwardkim/rhwp/issues/2553) 처리.
처리결과 문서: `mydocs/report/task_m100_2553_report.md`

`HeightMeasurer` 가 **본문** 문단을 측정하면서 형제 두 경로와 다르게 동작합니다. 측정 결과는 **페이지네이션 입력**(`rendering.rs:3065` → `paginate_with_measured`)이라, 측정과 실제 조판이 서로 다른 줄 수·높이를 갖습니다.

## (a) cell recompose 오용

`height_measurer.rs:527` 이 `recompose_for_cell_width` 를 호출합니다. 형제는 모두 body 래퍼입니다:

- `typeset.rs:11162` — 주석: *`[#2279] 본문 NO_LS 는 글자모양 재분할 포함 래퍼 사용 — paragraph_layout(렌더)와 동일 (측정/렌더 줄수·pitch 정합)`*
- `paragraph_layout.rs:1907`

body 는 cell 의 **strict superset** 입니다:
```rust
pub fn recompose_for_body_width(...) {
    restyle_fallback_runs_by_char_shapes(composed, para);   // ← 측정 경로가 빠뜨린 부분
    recompose_for_cell_width(composed, para, column_inner_width_px, styles);
}
```

`restyle_fallback_runs_by_char_shapes` 는 `compose_lines` NO_LS 폴백의 단일 `default_style_id` run 을 실제 글자모양으로 재분할하는 **유일한 지점**입니다. 빠지면 혼합 글자모양 문단(15pt 도입부 + 14pt 본문)을 전부 도입부 크기로 측정 → 폭 과대 → 줄 수가 달라지고, 줄별 `max_fs` 가 일괄 15pt 라 `Percent` 줄간격 기준까지 부풀어 누적 높이 오차가 납니다.

`typeset` 주석이 이 래퍼의 목적을 **"측정/렌더 정합"** 이라고 명시하는데, 정작 **측정 경로가 안 쓰고 있었습니다**.

## (b) 도달 불가 분기

`height_measurer.rs:521` 이 `para.line_segs.is_empty()` 를 **match guard** 에 올려, 저장 line_segs 가 **있는** 문단은 곧장 `_ => None` 으로 떨어집니다. 그래서 형제들이 가진 `masked_stored_lines_stale` → `recompose_stored_lines_if_overflowing_body` 분기에 **구조적으로 도달할 수 없습니다**(그 함수의 호출부는 typeset·paragraph_layout 두 곳뿐). 형제는 같은 술어를 arm 본문에 두고 `else if` 를 답니다.

마스킹 문단에서 조판/렌더는 stale 분할을 버리고 재래핑하는데 측정은 저장 분할을 유지 → `line_heights` 의 **줄 수 자체가 달라져** `PartialParagraph` 시작/끝 줄 인덱스가 어긋납니다.

## 수정

두 결함이 같은 블록에서 갈라진 것이라 `typeset.rs:11153-11185` 구조를 **통째로 이식**했습니다(guard → arm 본문 이동, body 래퍼로 교체, stale 분기 추가).

## 검증

페이지 분할 입력을 바꾸므로 회귀를 넓게 확인했습니다.

| 스위트 | 결과 |
|---|---|
| `cargo test --lib renderer` | **862 passed / 0 failed** |
| `cargo test --lib document_core` | **254 passed / 0 failed** |
| `cargo test --lib` 전체 | **2377 passed / 0 failed** |

측정을 조판에 맞추는 변경이므로 두 경로가 이미 일치하던 문서는 **동작 불변**입니다(전체 무회귀가 뒷받침). 어긋나 있던 문단에서만 측정이 조판을 따라갑니다.

### 미실행 (투명 고지)

- **전용 red→green 단위 테스트 미추가** — 이 결함은 "측정과 조판이 서로 다른 값을 낸다" 는 **경로 간 불일치**라, 단언하려면 `measure_section` 결과와 조판 결과를 같은 문단에 대해 비교하는 하네스가 필요한데 현재 없습니다. 근거는 ① 형제 코드와 `[#2279]` 주석이 이 래퍼의 목적을 "측정/렌더 정합" 으로 명시, ② body 가 cell 의 strict superset 이라는 정의, ③ 전체 2377건 무회귀입니다. 교차 비교 하네스를 세우기를 원하시면 별도로 진행하겠습니다.
- **visual sweep / clippy 전체** 미실행 — 저장소 규약상 작업지시자 별도 승인 사항입니다. 렌더 경로를 바꾸는 변경이라 visual sweep 판단이 필요하면 지시 바랍니다.