### PR TITLE
fix(studio): 그리드 보기에서 PageUp 무동작·쪽 표시기 오표시 (#2560)

### DIFF
--- a/mydocs/report/task_m100_2560_report.md
+++ b/mydocs/report/task_m100_2560_report.md
@@ -1,0 +1,78 @@
+# task_m100_2560 처리결과 보고서 — 그리드 보기 "현재 쪽" 판정 정합
+
+- **이슈**: [#2560](https://github.com/edwardkim/rhwp/issues/2560)
+- **브랜치**: `task/m100-2560-grid-current-page` (base `devel` @ `3c54abfd`)
+- **범위**: `rhwp-studio` view/engine 3파일 + 신규 테스트
+- **분류**: 결함 수정 (PageUp 무동작, 쪽 표시기 오표시)
+
+## 1. 문제
+
+`getPageAtY` 가 그리드 보기에서 **행의 마지막 쪽**을 반환한다. `layoutGrid` 가 한 행의 모든
+쪽에 같은 `rowTop` 을 넣으므로, 뒤에서부터 스캔하는 이 함수는 언제나 그 행의 최대 인덱스를
+돌려준다.
+
+이 의미 자체는 의도된 것이다 — `getPageAtPoint`(`virtual-scroll.ts:149`)가 반환값을
+**`rowLastIdx`** 로 명명하고 X 로 좁히기 위한 스캔 끝점으로 쓴다. 문제는 **"현재 쪽" 이 필요한
+소비처가 이 Y 전용 진입점을 직접 쓴 것**이다.
+
+### 결함 1 — PageUp 무동작
+
+`input-handler-keyboard.ts:1203-1209` 는 `currentPage ± 1` 로 목표를 정한다. 3열에서 현재 행이
+(3,4,5)면 `currentPage = 5`, PageUp 목표는 4 — **같은 행**이라 `getPageOffset` 이 동일해
+`setScrollTop` 이 제자리다. 아무리 눌러도 행을 벗어나지 못한다.
+
+PageDown 은 `5+1 = 6` 이 실제로 다음 행이라 우연히 동작한다. **이 비대칭이 근본 원인을 가리킨다.**
+
+### 결함 2 — 쪽 표시기 오표시
+
+`canvas-view.ts:301` → `current-page-changed` → 상태바. 3열이면 첫 행에서 "3 / N" 으로 표시되고
+1·2쪽은 현재 쪽으로 표시될 수 없다.
+
+## 2. 분석 — 영향 없는 소비처 구분
+
+| 소비처 | 판정 |
+|---|---|
+| `canvas-view.ts:512` `focusPage` | **영향 없음** — offset/height 만 쓰는데 한 행은 offset 이 같다 |
+| `getPageAtPoint` | **영향 없음** — `rowLastIdx` 를 스캔 끝점으로 쓰는 현재 의미가 맞다 |
+| `view/coordinate-system.ts:18` | 현재 `src/` 내 소비처 없음 — 잠재 위험만 |
+
+`getPageAtY` 의 의미를 바꾸면 `getPageAtPoint` 가 깨지므로, **의미는 유지하고 별도 진입점을
+추가**하는 방향을 택했다.
+
+## 3. 변경
+
+| 파일 | 변경 |
+|---|---|
+| `view/virtual-scroll.ts` | `getRowFirstPageAtY()` 추가(단일 컬럼에선 `getPageAtY` 와 동치), `pagesPerRow` 게터 추가, `getPageAtY` 에 의미 문서화 |
+| `view/canvas-view.ts:301` | 쪽 표시기를 `getRowFirstPageAtY` 로 |
+| `engine/input-handler-keyboard.ts` | PageUp/PageDown 을 행 첫 쪽 기준 **±열수** 로 |
+
+`±1` → `±pagesPerRow` 가 핵심이다. 단일 컬럼에서는 `pagesPerRow = 1` 이라 **종전 동작과 동일**하다.
+
+## 4. 검증
+
+### 신규 테스트 — 이 클래스의 첫 테스트
+
+`tests/virtual-scroll-grid-page.test.ts` (4건). `VirtualScroll` 은 타입만 import 하는 순수
+모듈이라 **DOM/브라우저 없이** `node --test` 로 검증된다. 종전엔 `tests/virtual-scroll*` 파일이
+**존재하지 않아 이 클래스 전체가 미테스트**였다.
+
+1. `getPageAtY` 가 행의 마지막 쪽을 준다(의도된 의미 고정)
+2. `getRowFirstPageAtY` 가 행의 첫 쪽을 준다 — 상태바가 1쪽을 표시 가능
+3. PageUp 목표의 offset 이 현재와 **달라야** 한다 — 종전 ±1 이 무동작이던 지점
+4. 단일 컬럼에서 두 진입점이 동치(회귀 없음)
+
+전제 조건(`isGridMode()`, `pagesPerRow > 1`)을 테스트 안에서 단언해, 레이아웃이 바뀌어
+그리드가 아니게 되면 조용히 통과하지 않고 실패한다.
+
+### 회귀
+
+`node --test tests/*.test.ts` — 신규 4건 포함 전부 통과, 기존 실패는 `cell-flow-boundary.test.ts`
+하나로 이는 깨끗한 devel 에서도 실패하는 **사전 실패**다(이전 작업에서 stash 로 확인함).
+
+### 미실행 항목 (투명 고지)
+
+- **실제 키 입력 행위 검증 미실행** — PageUp 키다운→스크롤 이동까지는 jsdom/브라우저가 필요하다.
+  본 PR 은 그 결정 요인인 좌표/스텝 계산을 순수 단위 테스트로 고정하는 데 그쳤다.
+- 같은 스윕에서 나온 별건(`page:col-right` 가 `page:col-left` 와 바이트 동일, 머리말/꼬리말
+  숨김 명령이 undo 라우팅 우회)은 **범위를 섞지 않기 위해 제외**했다. 필요하면 별도 이슈로 등록하겠다.

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1200,10 +1200,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const vpSize = this.viewportManager.getViewportSize();
       const scrollY = this.viewportManager.getScrollY();
       const vpCenter = scrollY + vpSize.height / 2;
-      const currentPage = this.virtualScroll.getPageAtY(vpCenter);
+      // [#2560] 그리드 모드에서는 한 행의 쪽들이 같은 offset 을 갖는다. 행의
+      // 마지막 쪽에서 ±1 하면 같은 행에 머물러 스크롤이 움직이지 않으므로
+      // (PageUp 이 무동작), 행의 첫 쪽 기준으로 행 단위(±열수)로 이동한다.
+      // 단일 컬럼에서는 pagesPerRow=1 이라 종전 동작과 동일하다.
+      const currentPage = this.virtualScroll.getRowFirstPageAtY(vpCenter);
+      const step = this.virtualScroll.pagesPerRow;
       const targetPage = e.key === 'PageUp'
-        ? Math.max(0, currentPage - 1)
-        : Math.min(this.virtualScroll.pageCount - 1, currentPage + 1);
+        ? Math.max(0, currentPage - step)
+        : Math.min(this.virtualScroll.pageCount - 1, currentPage + step);
       if (targetPage !== currentPage) {
         const targetOffset = this.virtualScroll.getPageOffset(targetPage);
         this.viewportManager.setScrollTop(targetOffset - this.virtualScroll.gap);

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -298,7 +298,9 @@ export class CanvasView {
     // 현재 페이지 번호 갱신
     if (visiblePages.length > 0) {
       const vpCenter = scrollY + vpHeight / 2;
-      const currentPage = this.virtualScroll.getPageAtY(vpCenter);
+      // [#2560] 그리드 모드에서 getPageAtY 는 행의 마지막 쪽을 준다. 상태바가
+      // 3열이면 첫 행에서 "3 / N" 으로 표시되고 1·2쪽은 현재 쪽이 될 수 없었다.
+      const currentPage = this.virtualScroll.getRowFirstPageAtY(vpCenter);
       this.eventBus.emit(
         'current-page-changed',
         currentPage,

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -130,6 +130,15 @@ export class VirtualScroll {
   }
 
   /** 특정 문서 Y 좌표가 속하는 페이지 인덱스를 반환한다 */
+  /**
+   * Y 가 속한 행의 **마지막** 쪽 인덱스.
+   *
+   * 그리드 모드에서 한 행의 모든 쪽은 같은 offset 을 가지므로(layoutGrid),
+   * 뒤에서부터 스캔하는 이 함수는 그 행의 최대 인덱스를 돌려준다.
+   * `getPageAtPoint` 가 X 로 좁히기 위한 스캔 끝점으로 쓴다.
+   *
+   * "현재 쪽" 이 필요하면 [`getRowFirstPageAtY`] 를 쓸 것 — [#2560].
+   */
   getPageAtY(docY: number): number {
     for (let i = this.pageOffsets.length - 1; i >= 0; i--) {
       if (docY >= this.pageOffsets[i]) {
@@ -137,6 +146,25 @@ export class VirtualScroll {
       }
     }
     return 0;
+  }
+
+  /**
+   * Y 가 속한 행의 **첫** 쪽 인덱스 — 사람이 말하는 "현재 쪽".
+   *
+   * 단일 컬럼 모드에서는 `getPageAtY` 와 동치다.
+   */
+  getRowFirstPageAtY(docY: number): number {
+    const rowLastIdx = this.getPageAtY(docY);
+    if (!this.gridMode) return rowLastIdx;
+    const rowOffset = this.pageOffsets[rowLastIdx];
+    let rowFirst = rowLastIdx;
+    while (rowFirst > 0 && this.pageOffsets[rowFirst - 1] === rowOffset) rowFirst--;
+    return rowFirst;
+  }
+
+  /** 한 행에 놓이는 쪽 수. 단일 컬럼 모드는 1. */
+  get pagesPerRow(): number {
+    return this.gridMode ? this.columns : 1;
   }
 
   /**

--- a/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { VirtualScroll } from '../src/view/virtual-scroll.ts';
+
+// [#2560] 그리드 모드에서 "현재 쪽" 판정 가드.
+//
+// layoutGrid 는 한 행의 모든 쪽에 같은 offset(rowTop)을 넣는다. 뒤에서부터
+// 스캔하는 getPageAtY 는 그래서 행의 *마지막* 쪽을 돌려준다 — getPageAtPoint 가
+// X 로 좁히기 위한 스캔 끝점으로 쓰는 의도된 의미다.
+//
+// 문제는 "현재 쪽" 이 필요한 소비처가 그걸 직접 쓴 것이었다:
+//   - 상태바(canvas-view.ts) → 3열이면 첫 행에서 "3 / N" 으로 표시
+//   - PageUp(input-handler-keyboard.ts) → 행의 마지막 쪽에서 -1 하면 같은 행에
+//     머물러 offset 이 동일 → 스크롤이 전혀 움직이지 않음(PageUp 무동작)
+//
+// getRowFirstPageAtY 와 pagesPerRow 로 두 소비처를 고쳤고, 이 테스트가 그 계약을
+// 고정한다. VirtualScroll 은 타입만 import 하는 순수 모듈이라 DOM 없이 검증된다.
+
+/** width×height 페이지 n개. */
+function pages(n: number, width = 800, height = 1000) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
+}
+
+/** 3열 그리드가 되도록 충분히 넓은 뷰포트. zoom 0.4 < 0.5 임계값. */
+const ZOOM = 0.4;
+const VIEWPORT = 2000;
+
+test('그리드 모드에서 getPageAtY 는 행의 마지막 쪽을 준다(의도된 의미)', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(6), ZOOM, VIEWPORT);
+  assert.ok(vs.isGridMode(), '전제: 그리드 모드여야 함');
+  assert.ok(vs.pagesPerRow > 1, `전제: 다중 열이어야 함 (실제 ${vs.pagesPerRow})`);
+
+  const firstRowY = vs.getPageOffset(0);
+  assert.equal(
+    vs.getPageAtY(firstRowY),
+    vs.pagesPerRow - 1,
+    'getPageAtPoint 의 스캔 끝점으로 쓰이므로 행의 마지막 쪽이어야 함',
+  );
+});
+
+test('getRowFirstPageAtY 는 행의 첫 쪽을 준다 — 상태바가 1쪽을 표시할 수 있어야 함', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(6), ZOOM, VIEWPORT);
+
+  const firstRowY = vs.getPageOffset(0);
+  assert.equal(
+    vs.getRowFirstPageAtY(firstRowY),
+    0,
+    '첫 행의 현재 쪽은 0 이어야 한다(종전엔 행의 마지막 쪽이라 1쪽을 표시할 수 없었다)',
+  );
+});
+
+test('PageUp 이 이전 행으로 실제로 이동한다 — 행 단위 스텝', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(9), ZOOM, VIEWPORT);
+  const step = vs.pagesPerRow;
+
+  // 둘째 행 위에 커서가 있다고 가정.
+  const secondRowY = vs.getPageOffset(step);
+  const current = vs.getRowFirstPageAtY(secondRowY);
+  assert.equal(current, step, '둘째 행의 첫 쪽이어야 함');
+
+  const target = Math.max(0, current - step);
+  assert.notEqual(
+    vs.getPageOffset(target),
+    vs.getPageOffset(current),
+    'PageUp 목표는 offset 이 달라야 스크롤이 움직인다 — 종전 ±1 은 같은 행이라 무동작이었다',
+  );
+});
+
+test('단일 컬럼 모드에서는 종전 동작과 동일하다', () => {
+  const vs = new VirtualScroll(10);
+  // viewportWidth=0 → 그리드 모드 아님
+  vs.setPageDimensions(pages(4), 1.0, 0);
+  assert.ok(!vs.isGridMode(), '전제: 단일 컬럼');
+  assert.equal(vs.pagesPerRow, 1, '단일 컬럼은 행당 1쪽');
+
+  const y = vs.getPageOffset(2);
+  assert.equal(
+    vs.getRowFirstPageAtY(y),
+    vs.getPageAtY(y),
+    '단일 컬럼에서는 두 진입점이 동치여야 한다(회귀 없음)',
+  );
+});


### PR DESCRIPTION
이슈 [#2560](https://github.com/edwardkim/rhwp/issues/2560) 처리.
처리결과 문서: `mydocs/report/task_m100_2560_report.md`

## 문제

`getPageAtY` 가 그리드 보기에서 **행의 마지막 쪽**을 반환합니다 — `layoutGrid` 가 한 행의 모든 쪽에 같은 `rowTop` 을 넣기 때문입니다.

**이 의미 자체는 의도된 것**입니다: `getPageAtPoint`(`virtual-scroll.ts:149`)가 반환값을 **`rowLastIdx`** 라 명명하고 X 로 좁히기 위한 스캔 끝점으로 씁니다. 문제는 **"현재 쪽" 이 필요한 소비처가 이 Y 전용 진입점을 직접 쓴 것**입니다.

### 결함 1 — PageUp 이 아무 동작도 안 함

3열에서 현재 행이 (3,4,5)면 `currentPage = 5`, PageUp 목표는 4 — **같은 행**이라 `getPageOffset` 이 동일해 `setScrollTop` 이 제자리입니다. 아무리 눌러도 행을 벗어나지 못합니다.

PageDown 은 `5+1 = 6` 이 실제로 다음 행이라 **우연히** 동작합니다. 이 비대칭이 근본 원인을 가리킵니다.

### 결함 2 — 쪽 표시기

3열이면 첫 행에서 "3 / N" 으로 표시되어 **1·2쪽은 현재 쪽이 될 수 없습니다**.

## 영향 없는 소비처 (구분 확인)

| 소비처 | 판정 |
|---|---|
| `canvas-view.ts:512` `focusPage` | 영향 없음 — offset/height 만 쓰는데 한 행은 offset 이 동일 |
| `getPageAtPoint` | 영향 없음 — `rowLastIdx` 스캔 끝점 의미가 맞음 |

## 수정

`getPageAtY` 의미를 바꾸면 `getPageAtPoint` 가 깨지므로 **의미는 유지**하고 별도 진입점을 추가했습니다.

- `getRowFirstPageAtY()` — 행의 첫 쪽(단일 컬럼에선 `getPageAtY` 와 동치)
- `pagesPerRow` 게터
- PageUp/PageDown 을 **±1 → ±열수** 로 (행 단위 이동). 단일 컬럼은 `pagesPerRow=1` 이라 **종전 동작 그대로**

## 검증 — 이 클래스의 첫 테스트

`tests/virtual-scroll-grid-page.test.ts` **4건 신규**. `VirtualScroll` 은 타입만 import 하는 순수 모듈이라 **DOM/브라우저 없이** `node --test` 로 검증됩니다. 종전엔 `tests/virtual-scroll*` 파일이 **존재하지 않아 이 클래스 전체가 미테스트**였습니다.

1. `getPageAtY` 가 행의 마지막 쪽 (의도된 의미 고정)
2. `getRowFirstPageAtY` 가 행의 첫 쪽 — 상태바가 1쪽 표시 가능
3. **PageUp 목표의 offset 이 현재와 달라야 함** — 종전 ±1 이 무동작이던 바로 그 지점
4. 단일 컬럼에서 두 진입점 동치 (회귀 없음)

전제 조건(`isGridMode()`, `pagesPerRow > 1`)을 테스트 안에서 단언해, 레이아웃이 바뀌어 그리드가 아니게 되면 **조용히 통과하지 않고 실패**합니다.

**회귀**: `node --test tests/*.test.ts` → **437 pass / 1 fail**. 유일한 실패 `cell-flow-boundary.test.ts` 는 깨끗한 devel 에서도 실패하는 **사전 실패**입니다(이전 작업에서 `git stash` 로 확인).

### 미실행 (투명 고지)

- **실제 키 입력 행위 검증 미실행** — PageUp 키다운→스크롤 이동까지는 jsdom/브라우저가 필요합니다. 본 PR 은 그 결정 요인인 좌표/스텝 계산을 순수 단위 테스트로 고정하는 데 그쳤습니다.
- 같은 스윕의 별건(`page:col-right` 가 `page:col-left` 와 **바이트 동일**, 머리말/꼬리말 숨김 명령이 undo 라우팅 우회)은 범위를 섞지 않기 위해 제외했습니다 — 별도 이슈로 등록할까요?