### PR TITLE
build(deps): serde_json 1.0.150 → 1.0.151 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1061,9 +1061,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.150"
+version = "1.0.151"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8014e44b4736ed0538adeecded0fce2a272f22dc9578a7eb6b2d9993c74cfb9"
+checksum = "c841b55ecdae098c80dcae9cf767f6f8a0c2cdb3416bbef72181df4d0fe73f14"
 dependencies = [
  "itoa",
  "memchr",


### PR DESCRIPTION
## 요약
`cargo update -p serde_json` 으로 semver 호환 범위 내에서 업데이트:
- serde_json 1.0.150 → 1.0.151

Closes #2565