### PR TITLE
build(deps): log 0.4.29 → 0.4.33 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -605,9 +605,9 @@ checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "0ceec5bc11778974d1bcb055b18002eba7f4b3518b6a0081b3af5f21666da9ad"
 
 [[package]]
 name = "memchr"


### PR DESCRIPTION
## 요약\ncargo update -p log semver 호환 업데이트.\n\nCloses #2578