### PR TITLE
build(deps): once_cell 1.21.3 → 1.21.4 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -691,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.21.3"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "oorandom"


### PR DESCRIPTION
## 요약\ncargo update -p once_cell semver 호환 업데이트.\n\nCloses #2582