### PR TITLE
build(deps): smallvec 1.15.1 → 1.15.2 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1162,9 +1162,9 @@ dependencies = [
 
 [[package]]
 name = "smallvec"
-version = "1.15.1"
+version = "1.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
+checksum = "8ed6a63f02c8539c91a8685a86f4099661ba3da017932f6ebbea6de3f0fa7c90"
 
 [[package]]
 name = "snafu"


### PR DESCRIPTION
## 요약\ncargo update -p smallvec semver 호환 업데이트.\n\nCloses #2588