### PR TITLE
build(deps): pin-project-lite 0.2.16 → 0.2.17 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -736,9 +736,9 @@ checksum = "5be167a7af36ee22fe3115051bc51f6e6c7054c9348e28deb4f49bd6f705a315"
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.16"
+version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b3cff922bd51709b605d9ead9aa71031d81447142d828eb4a6eba76fe619f9b"
+checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pkg-config"


### PR DESCRIPTION
## 요약\ncargo update -p pin-project-lite semver 호환 업데이트.\n\nCloses #2592