### PR TITLE
build(deps): either 1.15.0 → 1.16.0 의존성 업데이트

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,9 +261,9 @@ checksum = "be1e0bca6c3637f992fc1cc7cbc52a78c1ef6db076dbf1059c4323d6a2048376"
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "91622ff5e7162018101f2fea40d6ebf4a78bbe5a49736a2020649edf9693679e"
 
 [[package]]
 name = "embedded-io"


### PR DESCRIPTION
## 요약\ncargo update -p either semver 호환 업데이트.\n\nCloses #2596