### PR TITLE
fix(embed): loadFile 기본 suppressDialogs를 true로 변경 — 교착 timeout 해소 (#2513)

### DIFF
--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -102,7 +102,7 @@ await editor.loadFile(buffer, 'sample.hwpx', { suppressDialogs: true });
 | 옵션 | 기본값 | 설명 |
 |------|--------|------|
 | `skipUnsavedGuard` | `false` | 미저장 변경 확인 없이 문서 교체 |
-| `suppressDialogs` | `false` | 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기 |
+| `suppressDialogs` | `true` | 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기 |
 
 > **임베드 환경에서는 `suppressDialogs: true`를 권장합니다.** 스튜디오는 문서 로드 후
 > 안내창(HWPX 비표준 lineseg 검증, 로컬 글꼴 감지)의 사용자 선택을 기다린 뒤에

--- a/npm/editor/index.js
+++ b/npm/editor/index.js
@@ -121,6 +121,7 @@ export class RhwpEditor {
    * @param options.suppressDialogs - 로드 후 안내창(HWPX 검증, 로컬 글꼴 감지) 없이 열기.
    *   임베드 환경에서 안내창의 사용자 선택을 기다리느라 loadFile 응답이 지연/교착되는
    *   것을 방지한다. 검증 경고는 '그대로 열기'로 처리되고, 글꼴은 웹 대체 글꼴로 표시된다.
+   *   기본값 true. 명시적으로 false를 주면 안내창을 표시한다.
    * @returns { pageCount: number }
    *
    * @example
@@ -136,7 +137,7 @@ export class RhwpEditor {
       data,
       fileName,
       skipUnsavedGuard: options.skipUnsavedGuard === true,
-      suppressDialogs: options.suppressDialogs === true,
+      suppressDialogs: options.suppressDialogs !== false,
     });
   }
 


### PR DESCRIPTION
## 문제

`@rhwp/editor`를 cross-origin iframe으로 생성 후 `loadFile()` 호출 시 기본값이
`suppressDialogs: false`여서 iframe 내부 안내창 응답을 기다리다 RPC timeout이 발생한다
(#2513).

## 원인

`npm/editor/index.js:139`에서 `suppressDialogs: options.suppressDialogs === true`로
되어 있어, 옵션 생략 시 `undefined !== true` → `false`로 평가된다. 그 결과
`initializeDocument()`의 `promptLocalFontsIfNeeded()`가 await되어 iframe 내부
대화상자가 RPC 완료 경로에 포함된다.

## 수정

```js
// before
suppressDialogs: options.suppressDialogs === true,   // 옵션 생략 시 false
// after  
suppressDialogs: options.suppressDialogs !== false,   // 옵션 생략 시 true
```

- `loadFile(data, name)` → `true` (안내창 건너뜀 → timeout 해소)
- `loadFile(data, name, { suppressDialogs: false })` → `false` (안내창 표시, opt-in)
- `loadFile(data, name, { suppressDialogs: true })` → `true`

**top-level Studio는 이 경로를 거치지 않으므로 영향 없음.**

Closes #2513