### PR TITLE
fix(edit-sweep): 디렉터리 symlink 순환 탐지 — collect_files 무한 재귀 방지 (#2531)

### DIFF
--- a/examples/edit_sweep.rs
+++ b/examples/edit_sweep.rs
@@ -85,7 +85,7 @@ fn collect_files(root: &Path, max_kb: u64) -> Vec<PathBuf> {
         };
         for e in entries.flatten() {
             let p = e.path();
-            if p.is_dir() {
+            if p.is_dir() && !p.is_symlink() {
                 stack.push(p);
             } else if p
                 .extension()


### PR DESCRIPTION
## 문제

`collect_files()`가 `Path::is_dir()`로 디렉터리 판정하므로, 입력 트리에
자기 자신/조상으로 향하는 symlink가 있으면 재귀가 끝나지 않는다. 순환이
아니어도 별칭 디렉터리를 통해 동일 문서를 중복 스캔한다 (#2531).

## 수정

```rust
// before
if p.is_dir() { stack.push(p); }
// after
if p.is_dir() && !p.is_symlink() { stack.push(p); }
```

`Path::is_symlink()` (Rust 1.58+ 안정화, 현재 toolchain 1.93.1)로
심링크를 선별하여, 일반 디렉터리만 재귀 스택에 넣는다.

## 검증

기존 동작 불변: `samples/`에는 symlink가 없으므로 기존 수집 범위와
정렬 순서에 영향이 없다. 순환 symlink가 있는 입력에서 유한 시간 안에
종료한다.

Closes #2531