### PR TITLE
fix(vscode): .hml 파일 탐색기/에디터 컨텍스트 메뉴 누락 수정 (#2606)

### DIFF
--- a/mydocs/report/PR-2607-vscode-hml-context-menu.md
+++ b/mydocs/report/PR-2607-vscode-hml-context-menu.md
@@ -1,0 +1,16 @@
+# PR #2607: VSCode .hml 파일 컨텍스트 메뉴 누락 수정
+
+## 이슈
+- **Issue**: #2606 — .hml 파일 탐색기/에디터 컨텍스트 메뉴에 rhwp 명령이 표시되지 않음
+
+## 분석
+`rhwp-vscode/package.json`에서 `customEditors.selector`는 `*.hml`을 포함하지만,
+`menus`의 `when` 조건에는 `.hwp`/`.hwpx`만 있고 `.hml`이 누락됨.
+
+## 변경
+모든 `menus[*].when`에 `resourceExtname == .hml` 조건 추가 (총 6곳)
+
+## 결과
+- `.hml` 파일에서도 탐색기/에디터 컨텍스트 메뉴 명령이 올바르게 표시됨
+- **PR**: https://github.com/edwardkim/rhwp/pull/2607
+- **Closes**: #2606

--- a/rhwp-vscode/package.json
+++ b/rhwp-vscode/package.json
@@ -68,34 +68,34 @@
       "explorer/context": [
         {
           "command": "rhwp.exportSvg",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@1"
         },
         {
           "command": "rhwp.debugOverlay",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@2"
         },
         {
           "command": "rhwp.dumpParagraph",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@3"
         }
       ],
       "editor/title/context": [
         {
           "command": "rhwp.exportSvg",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@1"
         },
         {
           "command": "rhwp.debugOverlay",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@2"
         },
         {
           "command": "rhwp.dumpParagraph",
-          "when": "resourceExtname == .hwp || resourceExtname == .hwpx",
+          "when": "resourceExtname == .hwp || resourceExtname == .hwpx || resourceExtname == .hml",
           "group": "rhwp@3"
         }
       ]


### PR DESCRIPTION
## 문제

`rhwp-vscode`의 `customEditors.selector`는 `*.hml`을 포함해 에디터로 열리지만,
탐색기/에디터 타이틀 컨텍스트 메뉴의 `when` 조건에는 `.hwp`/`.hwpx`만 있어
`.hml` 파일에서 "HWP: SVG로 내보내기"/"디버그 오버레이"/"문단 덤프" 명령이
표시되지 않는다.

## 수정

`rhwp-vscode/package.json`의 `menus` 섹션 총 6곳에
`resourceExtname == .hml` 조건을 추가했다.

## 검증

- `customEditors.selector`와 메뉴 `when` 조건이 일치하게 됨
- `.hml` 파일도 `.hwp`/`.hwpx`와 동일한 컨텍스트 메뉴 명령을 사용 가능

Closes #2606