### PR TITLE
fix(ext): Chrome/Firefox 컨텍스트 메뉴 targetUrlPatterns에 .hml 추가 (#2608)

### DIFF
--- a/mydocs/report/PR-2609-ext-hml-context-menus.md
+++ b/mydocs/report/PR-2609-ext-hml-context-menus.md
@@ -1,0 +1,16 @@
+# PR #2609: Chrome/Firefox 컨텍스트 메뉴 .hml 누락 수정
+
+## 이슈
+- **Issue**: #2608 — 확장 컨텍스트 메뉴의 `targetUrlPatterns`에 `.hml` 누락
+
+## 변경
+`rhwp-chrome/sw/context-menus.js` + `rhwp-firefox/sw/context-menus.js`:
+```js
+// 추가
+'*://*/*.hml',
+'*://*/*.hml?*'
+```
+
+## 결과
+- `.hml` 파일 링크도 "rhwp로 열기" 메뉴 사용 가능
+- Closes #2608

--- a/rhwp-chrome/sw/context-menus.js
+++ b/rhwp-chrome/sw/context-menus.js
@@ -20,7 +20,9 @@ export function setupContextMenus() {
         '*://*/*.hwp',
         '*://*/*.hwp?*',
         '*://*/*.hwpx',
-        '*://*/*.hwpx?*'
+        '*://*/*.hwpx?*',
+        '*://*/*.hml',
+        '*://*/*.hml?*'
       ]
     });
   });

--- a/rhwp-firefox/sw/context-menus.js
+++ b/rhwp-firefox/sw/context-menus.js
@@ -21,7 +21,9 @@ export function setupContextMenus() {
           '*://*/*.hwp',
           '*://*/*.hwp?*',
           '*://*/*.hwpx',
-          '*://*/*.hwpx?*'
+          '*://*/*.hwpx?*',
+          '*://*/*.hml',
+          '*://*/*.hml?*'
         ]
       });
     } catch (err) {


### PR DESCRIPTION
## 문제

Chrome/Firefox 확장의 컨텍스트 메뉴가 `.hwp`/`.hwpx` 링크만 감지하고
`.hml` 링크는 감지하지 못한다. content-script.js는 이미 `.hml`을 지원하지만
컨텍스트 메뉴의 `targetUrlPatterns`에 누락되어 있다.

## 수정

두 파일의 `targetUrlPatterns`에 `*://*/*.hml`와 `*://*/*.hml?*`를 추가했다.

## 검증

- content-script.js의 `HWP_EXTENSIONS` 패턴과 일치하게 됨
- `.hml` 파일 링크에서도 "rhwp로 열기" 우클릭 메뉴 사용 가능

Closes #2608