### PR TITLE
fix(ext): 다운로드 인터셉터 HWP_EXTENSION_RE에 .hml 추가 (#2610)

### DIFF
--- a/mydocs/report/PR-2611-download-interceptor-hml.md
+++ b/mydocs/report/PR-2611-download-interceptor-hml.md
@@ -1,0 +1,17 @@
+# PR #2611: 다운로드 인터셉터 HWP_EXTENSION_RE에 .hml 추가
+
+## 이슈
+- **Issue**: #2610 — 다운로드 인터셉터가 .hml 파일을 감지하지 못함
+
+## 변경
+`rhwp-shared/sw/download-interceptor-common.js`:
+```js
+// before
+export const HWP_EXTENSION_RE = /\.(hwp|hwpx)(\?|$)/i;
+// after
+export const HWP_EXTENSION_RE = /\.(hwp|hwpx|hml)(\?|$)/i;
+```
+
+## 결과
+- 크롬/파이어폭스 다운로드 인터셉터가 .hml 파일도 감지
+- Closes #2610

--- a/rhwp-shared/sw/download-interceptor-common.js
+++ b/rhwp-shared/sw/download-interceptor-common.js
@@ -12,8 +12,8 @@
 // - #198: Chrome 마지막 저장 위치 보존 + DEXT5 블랙리스트 + MIME 힌트
 // - #207: 동일 판정 로직을 Firefox 측에도 적용
 
-/** filename 또는 URL 에서 .hwp/.hwpx 확장자를 감지 (쿼리 문자열 허용). */
-export const HWP_EXTENSION_RE = /\.(hwp|hwpx)(\?|$)/i;
+/** filename 또는 URL 에서 .hwp/.hwpx/.hml 확장자를 감지 (쿼리 문자열 허용). */
+export const HWP_EXTENSION_RE = /\.(hwp|hwpx|hml)(\?|$)/i;
 
 /** 한컴 HWP/HWPX MIME 타입 힌트 (소문자 비교). */
 export const HWP_MIME_HINTS = ['haansoft', 'x-hwp', 'hwp+zip'];


### PR DESCRIPTION
## 문제

`download-interceptor-common.js`의 `HWP_EXTENSION_RE`가 `.hwp`/`.hwpx`만
매치하여 `.hml` 파일 다운로드를 감지하지 못한다. content-script.js는 이미
`.hml`을 지원하므로 불일치가 발생한다.

## 수정

정규식에 `hml`을 추가했다:
```js
/\.(hwp|hwpx|hml)(\?|$)/i
```

## 검증

- 크롬/파이어폭스 symlink로 연결되어 있어 하나의 파일 수정으로 양쪽 적용
- content-script.js의 `HWP_EXTENSIONS` 패턴과 일치

Closes #2610