### PR TITLE
fix(security): url-validator.js hasHwpExtension()에 .hml 확장자 추가 (#2619)

### DIFF
--- a/mydocs/report/PR-2620-url-validator-hml.md
+++ b/mydocs/report/PR-2620-url-validator-hml.md
@@ -1,0 +1,13 @@
+# PR #2620: url-validator.js hasHwpExtension()에 .hml 추가
+
+## 이슈
+- **Issue**: #2619 — hasHwpExtension()이 .hml을 누락하여 HML URL이 차단됨
+
+## 변경
+`rhwp-shared/security/url-validator.js`:
+- `hasHwpExtension()`에 `.hml` 확장자 검사 추가
+- 관련 주석 갱신
+
+## 결과
+- `.hml` 파일 URL이 확장 URL 검증을 통과
+- Closes #2619

--- a/rhwp-shared/security/url-validator.js
+++ b/rhwp-shared/security/url-validator.js
@@ -41,13 +41,13 @@ function isPrivateHost(hostname) {
 }
 
 /**
- * URL의 pathname에서 HWP 확장자를 확인한다.
+ * URL의 pathname에서 HWP/HWPX/HML 확장자를 확인한다.
  * @param {URL} parsed
  * @returns {boolean}
  */
 function hasHwpExtension(parsed) {
   const pathname = parsed.pathname.toLowerCase();
-  return pathname.endsWith('.hwp') || pathname.endsWith('.hwpx');
+  return pathname.endsWith('.hwp') || pathname.endsWith('.hwpx') || pathname.endsWith('.hml');
 }
 
 /**
@@ -76,7 +76,7 @@ function isDownloadEndpoint(parsed) {
 
 /**
  * open-hwp 용 URL 검증 (3단계).
- * ① pathname에 .hwp/.hwpx → 즉시 허용
+ * ① pathname에 .hwp/.hwpx/.hml → 즉시 허용
  * ② 허용 도메인 + 다운로드 패턴 → 허용 (viewer에서 재검증)
  * ③ 그 외 → 차단
  *


### PR DESCRIPTION
## 요약\nurl-validator.js의 hasHwpExtension()이 .hwp/.hwpx만 검사하여 .hml URL이 validateOpenHwpUrl()에서 차단됨. .hml 추가로 Safari background.js와 일치.\n\nCloses #2619