### PR TITLE
fix(studio): recovery-format.ts baseNameWithoutKnownExtension()에 .hml 추가 (#2623)

### DIFF
--- a/mydocs/report/PR-2624-recovery-format-hml.md
+++ b/mydocs/report/PR-2624-recovery-format-hml.md
@@ -1,0 +1,11 @@
+# PR #2624: recovery-format.ts baseNameWithoutKnownExtension()에 .hml 추가
+
+## 이슈
+- **Issue**: #2623 — baseNameWithoutKnownExtension()이 .hml 확장자 미인식
+
+## 변경
+`rhwp-studio/src/recovery/recovery-format.ts:9`: `.hml` 조건 추가
+
+## 결과
+- HML 문서 복구 파일명에서 확장자가 올바르게 제거됨
+- Closes #2623


### PR DESCRIPTION
## 요약\nrecovery-format.ts의 baseNameWithoutKnownExtension()이 .hml 확장자를 인식하지 못하던 문제 수정.\n\nCloses #2623