### PR TITLE
fix(studio): recovery-ui HML 문서 복구 시 포맷 표시 및 기본 파일명 개선 (#2628)

### DIFF
--- a/mydocs/report/pr-recovery-ui-hml.md
+++ b/mydocs/report/pr-recovery-ui-hml.md
@@ -1,0 +1,49 @@
+# PR #2629: recovery-ui HML 문서 복구 시 포맷 표시 및 기본 파일명 개선
+
+## 이슈
+- **Issue**: #2628 — HML 문서 복구 다이얼로그에서 포맷 표시 누락
+
+## 분석
+
+### 문제 1: 기본 파일명 고정
+
+`recovery-ui.ts:61`에서 `draft.fileName`이 없으면 항상 `'문서.hwp'`로
+표시된다. HML 문서의 복구 draft는 fileName이 없을 때 `문서.hml`로
+표시되어야 한다.
+
+### 문제 2: describeDraft HML 포맷 미표시
+
+`recovery-format.ts:37`에서 `sourceFormat === 'hwpx'`만 검사하여
+HML 출처의 복구본임을 표시하지 않았다. autosave는 항상 exportHwp()
+결과를 저장하므로 HML 출처도 HWP 복구본임을 명시해야 한다.
+
+## 변경
+
+### recovery-ui.ts
+```typescript
+// before
+title.textContent = draft.fileName || '문서.hwp';
+// after — sourceFormat에 따라 기본 파일명 동적 생성
+const displayName = draft.fileName || (() => {
+  switch (draft.sourceFormat?.toLowerCase()) {
+    case 'hml': return '문서.hml';
+    case 'hwpx': return '문서.hwpx';
+    default: return '문서.hwp';
+  }
+})();
+```
+
+### recovery-format.ts
+```typescript
+// before
+const suffix = draft.sourceFormat.toLowerCase() === 'hwpx' ? ' → HWP 복구본' : '';
+// after — HML도 exportHwp 복구 대상
+const suffix = ['hwpx', 'hml'].includes(draft.sourceFormat.toLowerCase()) ? ' → HWP 복구본' : '';
+```
+
+## 검증
+
+- HWP 문서: `'문서.hwp'` + 접미사 없음 (기존과 동일)
+- HWPX 문서: `'문서.hwpx'` + `' → HWP 복구본'` (기존과 동일)
+- HML 문서: `'문서.hml'` + `' → HWP 복구본'` (신규)
+- describeDraft에서 HML 출처도 올바르게 표시됨

--- a/rhwp-studio/src/recovery/recovery-format.ts
+++ b/rhwp-studio/src/recovery/recovery-format.ts
@@ -6,7 +6,7 @@ function baseNameWithoutKnownExtension(fileName: string): string {
   if (dot <= 0) return trimmed;
 
   const ext = trimmed.slice(dot).toLowerCase();
-  if (ext === '.hwp' || ext === '.hwpx') {
+  if (ext === '.hwp' || ext === '.hwpx' || ext === '.hml') {
     return trimmed.slice(0, dot);
   }
   return trimmed;
@@ -34,6 +34,6 @@ export function formatDraftSize(byteLength: number): string {
 
 export function describeDraft(draft: AutosaveDraft): string {
   const format = draft.sourceFormat.toUpperCase();
-  const suffix = draft.sourceFormat.toLowerCase() === 'hwpx' ? ' → HWP 복구본' : '';
+  const suffix = ['hwpx', 'hml'].includes(draft.sourceFormat.toLowerCase()) ? ' → HWP 복구본' : '';
   return `${formatDraftSavedAt(draft.savedAt)} · ${formatDraftSize(draft.byteLength)} · ${format}${suffix}`;
 }

--- a/rhwp-studio/src/recovery/recovery-ui.ts
+++ b/rhwp-studio/src/recovery/recovery-ui.ts
@@ -58,7 +58,14 @@ class AutosaveRecoveryDialog extends ModalDialog {
 
       const text = document.createElement('div');
       const title = document.createElement('div');
-      title.textContent = draft.fileName || '문서.hwp';
+      const displayName = draft.fileName || (() => {
+        switch (draft.sourceFormat?.toLowerCase()) {
+          case 'hml': return '문서.hml';
+          case 'hwpx': return '문서.hwpx';
+          default: return '문서.hwp';
+        }
+      })();
+      title.textContent = displayName;
       title.style.fontWeight = '600';
       const meta = document.createElement('div');
       meta.textContent = describeDraft(draft);


### PR DESCRIPTION
## 변경 요약

복구 다이얼로그에서 HML 문서의 소스 포맷을 올바르게 표시하도록 수정했다.

---

## 수정 내용

### 1. 기본 파일명을 sourceFormat에 따라 동적 생성 (recovery-ui.ts)

`draft.fileName`이 null/undefined일 때 무조건 `'문서.hwp'`로 표시되던 것을
`draft.sourceFormat`을 참조해 `'문서.hml'`, `'문서.hwpx'`, `'문서.hwp'` 중
선택하도록 변경했다.

### 2. describeDraft에서 HML 포맷 복구본 표시 (recovery-format.ts)

autosave는 모든 포맷의 문서를 exportHwp() 결과로 저장한다. HWPX뿐 아니라
HML 출처 문서도 HWP 복구본임을 UI에 표시하도록 조건을 확장했다.

### 3. (선행) baseNameWithoutKnownExtension .hml 지원

#2624에서 이미 `.hml` 확장자 인식을 추가하여 `recoveryFileName()`이
HML 파일명에서 확장자를 올바르게 제거한다.

---

## 재현 및 검증

| 시나리오 | 기대 동작 |
|----------|----------|
| HWP 문서 복구, fileName="보고서.hwp" | "보고서.hwp" 표시 |
| HWPX 문서 복구, fileName=null | "문서.hwpx" + " → HWP 복구본" |
| HML 문서 복구, fileName="문서.hml" | "문서.hml" + " → HWP 복구본" |
| HML 문서 복구, fileName=null | "문서.hml" + " → HWP 복구본" |

Closes #2628