### PR TITLE
test: recent-store/recovery-ui에 HML 문서 테스트 케이스 추가

### DIFF
--- a/mydocs/report/pr-recent-store-hml.md
+++ b/mydocs/report/pr-recent-store-hml.md
@@ -1,0 +1,22 @@
+# PR #2632: recent-store HML 문서 테스트 케이스 추가
+
+## 이슈
+- **Issue**: #2631 — recent-store 테스트에 HML 문서 케이스 누락
+
+## 분석
+
+`rhwp-studio/tests/recent-store.test.ts`는 HWP와 HWPX 문서에 대한
+recent store 동작만 검증하고 HML 문서는 전혀 테스트하지 않았다.
+
+HML 포맷 지원이 추가됨에 따라 recent store가 HML 문서를 올바르게
+처리하는지 검증할 필요가 있다.
+
+## 변경
+
+1. **메타-only 기록 테스트에 HML 추가**: `{fileName: '문서.hml', sourceFormat: 'hml'}` 추가
+2. **HML 문서 전용 테스트 추가**: `addRecentDoc` → `listRecentDocs` → 핸들 보존 확인
+3. **최대 8개 상한 테스트 혼합**: HML/HWPX/HWP를 순환하도록 fixture 다양화
+
+## 결과
+- `node --test tests/recent-store.test.ts` → 8/8 pass
+- Closes #2631

--- a/mydocs/report/pr-recovery-ui-hml-test.md
+++ b/mydocs/report/pr-recovery-ui-hml-test.md
@@ -1,0 +1,26 @@
+# PR #2635: recovery-ui HML 문서 테스트 케이스 추가
+
+## 이슈
+- **Issue**: #2634 — recovery-ui 테스트에 HML 문서 케이스 누락
+
+## 분석
+
+recovery-ui.test.ts는 recoveryFileName(), describeDraft()를 HWP/HWPX에
+대해서만 검증하고 HML 문서는 테스트하지 않았다.
+
+recovery-format.ts의 baseNameWithoutKnownExtension()과 describeDraft()에도
+HML 지원이 누락되어 있어, 테스트 추가와 함께 수정이 필요했다.
+
+## 변경
+
+### recovery-format.ts
+1. `baseNameWithoutKnownExtension()`에 `.hml` 확장자 인식 추가
+2. `describeDraft()`에서 HML 출처도 HWP 복구본임을 표시하도록 조건 확장
+
+### recovery-ui.test.ts
+1. `recoveryFileName('sample.hml')` → `'sample 복구본.hwp'` 검증
+2. `describeDraft` HML sourceFormat 전달 시 `HML → HWP 복구본` 표시 검증
+
+## 결과
+- `node --test tests/recovery-ui.test.ts` → 5/5 pass
+- Closes #2634

--- a/rhwp-studio/src/recovery/recovery-format.ts
+++ b/rhwp-studio/src/recovery/recovery-format.ts
@@ -6,7 +6,7 @@ function baseNameWithoutKnownExtension(fileName: string): string {
   if (dot <= 0) return trimmed;
 
   const ext = trimmed.slice(dot).toLowerCase();
-  if (ext === '.hwp' || ext === '.hwpx') {
+  if (ext === '.hwp' || ext === '.hwpx' || ext === '.hml') {
     return trimmed.slice(0, dot);
   }
   return trimmed;
@@ -34,6 +34,6 @@ export function formatDraftSize(byteLength: number): string {
 
 export function describeDraft(draft: AutosaveDraft): string {
   const format = draft.sourceFormat.toUpperCase();
-  const suffix = draft.sourceFormat.toLowerCase() === 'hwpx' ? ' → HWP 복구본' : '';
+  const suffix = ['hwpx', 'hml'].includes(draft.sourceFormat.toLowerCase()) ? ' → HWP 복구본' : '';
   return `${formatDraftSavedAt(draft.savedAt)} · ${formatDraftSize(draft.byteLength)} · ${format}${suffix}`;
 }

--- a/rhwp-studio/tests/recent-store.test.ts
+++ b/rhwp-studio/tests/recent-store.test.ts
@@ -35,13 +35,14 @@ test('핸들 없는 열기는 메타-only 로 기록된다 (드롭/input/URL)', 
   await clearRecentDocs();
   await addRecentDoc({ fileName: '드롭.hwp', sourceFormat: 'hwp' });
   await addRecentDoc({ fileName: '인풋.hwpx', sourceFormat: 'hwpx', handle: null });
+  await addRecentDoc({ fileName: '문서.hml', sourceFormat: 'hml' });
   const docs = await listRecentDocs();
-  assert.equal(docs.length, 2, '핸들 없는 열기도 목록에 남는다');
+  assert.equal(docs.length, 3, '핸들 없는 열기도 목록에 남는다');
   for (const d of docs) {
     assert.equal(d.handle, undefined, '메타-only 항목은 핸들을 갖지 않는다');
     assert.ok(!('bytes' in d), '바이트 스냅샷을 보관하면 안 된다');
   }
-  assert.deepEqual(docs.map((d) => d.fileName).sort(), ['드롭.hwp', '인풋.hwpx']);
+  assert.deepEqual(docs.map((d) => d.fileName).sort(), ['드롭.hwp', '문서.hml', '인풋.hwpx']);
 });
 
 test('같은 파일명은 핸들 유무와 무관하게 파일명 폴백으로 최신화된다 (메타-only)', async () => {
@@ -60,6 +61,16 @@ test('저장 항목은 핸들+메타만 보관하고 바이트를 갖지 않는�
   assert.ok(doc.handle);
   assert.equal(doc.fileName, 'a.hwp');
   assert.ok(!('bytes' in doc), '바이트 스냅샷을 보관하면 안 된다 (#2285 보존 정책)');
+});
+
+test('HML 문서 recent doc 추가 및 조회', async () => {
+  await clearRecentDocs();
+  await addRecentDoc({ fileName: 'report.hml', sourceFormat: 'hml', handle: makeHandle('report') });
+  const docs = await listRecentDocs();
+  assert.equal(docs.length, 1);
+  assert.equal(docs[0].fileName, 'report.hml');
+  assert.equal(docs[0].sourceFormat, 'hml');
+  assert.ok(await docs[0].handle?.isSameEntry?.(docs[0].handle), 'HML 핸들이 보존된다');
 });
 
 test('같은 파일명이라도 isSameEntry=false면 별도 항목으로 공존한다', async () => {
@@ -89,14 +100,16 @@ test('동일 핸들(isSameEntry=true) 재열기는 중복 없이 최신화된다
 test('최대 8개 상한 — 가장 오래된 항목부터 밀려난다', async () => {
   await clearRecentDocs();
   for (let i = 0; i < 10; i++) {
-    await addRecentDoc({ fileName: `f${i}.hwp`, sourceFormat: 'hwp', handle: makeHandle(`f${i}`) });
+    const fmt = i % 3 === 0 ? 'hml' : i % 3 === 1 ? 'hwpx' : 'hwp';
+    const ext = fmt === 'hml' ? 'hml' : fmt === 'hwpx' ? 'hwpx' : 'hwp';
+    await addRecentDoc({ fileName: `f${i}.${ext}`, sourceFormat: fmt, handle: makeHandle(`f${i}`) });
     await new Promise((r) => setTimeout(r, 2));
   }
   const docs = await listRecentDocs();
   assert.equal(docs.length, 8);
-  assert.equal(docs[0].fileName, 'f9.hwp', '최신이 맨 앞');
+  assert.equal(docs[0].fileName, 'f9.hml', '최신이 맨 앞');
   const names = docs.map((d) => d.fileName);
-  assert.ok(!names.includes('f0.hwp') && !names.includes('f1.hwp'), '가장 오래된 2개 제거');
+  assert.ok(!names.includes('f0.hml') && !names.includes('f1.hwpx'), '가장 오래된 2개 제거');
 });
 
 test('removeRecentDoc / clearRecentDocs', async () => {

--- a/rhwp-studio/tests/recovery-ui.test.ts
+++ b/rhwp-studio/tests/recovery-ui.test.ts
@@ -12,6 +12,7 @@ test('recoveryFileName은 원본을 덮어쓰지 않는 복구본 이름을 만�
   assert.equal(recoveryFileName('sample.hwp'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hwpx'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hwpx', 'hwpx'), 'sample 복구본.hwp');
+  assert.equal(recoveryFileName('sample.hml'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('새 문서.hwp'), '새 문서 복구본.hwp');
   assert.equal(recoveryFileName('memo'), 'memo 복구본.hwp');
   assert.equal(recoveryFileName(''), '문서 복구본.hwp');
@@ -38,6 +39,20 @@ test('describeDraft는 저장 시각, 크기, 출처 포맷을 포함한다', ()
   assert.match(text, /HWP/);
   assert.match(text, /2\.0 KB/);
   assert.notEqual(formatDraftSavedAt(savedAt), '저장 시각 알 수 없음');
+});
+
+test('describeDraft는 HML 출처 draft가 HWP 복구본으로 열림을 표시한다', () => {
+  const text = describeDraft({
+    id: 'd3',
+    fileName: '문서.hml',
+    sourceFormat: 'hml',
+    savedAt: 1,
+    byteLength: 2048,
+    data: new Uint8Array([1]),
+  });
+
+  assert.match(text, /HML/);
+  assert.match(text, /HWP 복구본/);
 });
 
 test('describeDraft는 HWPX 출처 draft가 HWP 복구본으로 열림을 표시한다', () => {


### PR DESCRIPTION
## 변경 요약

recent-store와 recovery-ui에 HML 문서 테스트 케이스를 추가하고,
recovery-format.ts의 HML 지원 누락을 수정했다.

---

## 수정 내용

### recent-store.test.ts (Closes #2631)
- 메타-only 기록 테스트에 HML 문서 포함
- HML 문서 전용 테스트 (addRecentDoc → listRecentDocs → 핸들 보존)
- 최대 8개 상한 테스트에 HML/HWPX/HWP 혼합

### recovery-format.ts
- `baseNameWithoutKnownExtension()`에 `.hml` 확장자 인식 추가
- `describeDraft()`에서 HML 출처도 HWP 복구본임을 표시

### recovery-ui.test.ts (Closes #2634)
- `recoveryFileName('sample.hml')` 검증
- `describeDraft` HML sourceFormat 표시 검증

---

## 검증

- `node --test tests/recent-store.test.ts` → **8/8 pass**
- `node --test tests/recovery-ui.test.ts` → **5/5 pass**

Closes #2631
Closes #2634