### PR TITLE
fix(renderer): HeightMeasurer 본문 NO_LS 재래핑을 typeset/render 와 동일 래퍼로 정합 (#2632)

### DIFF
--- a/mydocs/report/task_m100_2632_report.md
+++ b/mydocs/report/task_m100_2632_report.md
@@ -1,0 +1,82 @@
+# task_m100_2632 처리결과 보고서 — HeightMeasurer 본문 재래핑 래퍼 정합
+
+- **이슈**: [#2632](https://github.com/edwardkim/rhwp/issues/2632)
+- **브랜치**: `task/m100-2632-height-measurer-body-recompose` (base `devel` @ `3c54abfd`)
+- **범위**: `src/renderer/height_measurer.rs` 한 지점
+- **분류**: 결함 수정 (측정↔렌더 불일치)
+
+## 1. 문제
+
+`HeightMeasurer::measure_paragraph` 의 본문(column) NO_LS 재래핑 분기가 형제 두 경로
+(`typeset.rs::format_paragraph`, `paragraph_layout.rs::layout_partial_paragraph`)와 **다른
+래퍼 함수**를 썼다.
+
+| 파일 | 함수 | 사용 래퍼(수정 전) |
+|---|---|---|
+| `height_measurer.rs:527` | `measure_paragraph` | `recompose_for_cell_width` |
+| `typeset.rs:11162` | `format_paragraph` | `recompose_for_body_width` |
+| `paragraph_layout.rs:1911` | `layout_partial_paragraph` | `recompose_for_body_width` |
+
+`recompose_for_body_width`(`composer.rs:1419-1427`)는 `recompose_for_cell_width` 의
+superset이다:
+```rust
+pub fn recompose_for_body_width(...) {
+    restyle_fallback_runs_by_char_shapes(composed, para);   // ← measurement 만 빠짐
+    recompose_for_cell_width(composed, para, column_inner_width_px, styles);
+}
+```
+측정 경로만 `restyle_fallback_runs_by_char_shapes` 를 건너뛰어, `compose_lines` NO_LS
+fallback 이 만든 단일 스타일 run 을 실제 글자모양별로 재분할하지 않았다.
+
+## 2. 영향
+
+`PARA_LINE_SEG` 가 없고 글자모양이 섞인 본문 문단(예: 15pt 도입부 + 14pt 본문)에서
+typeset/render 는 CharShapeRef 로 run 을 쪼개 정확히 측정하는데 `HeightMeasurer` 는 모든
+run 을 단일 스타일로 측정 → 폭/줄수/줄간격 오차가 페이지네이션 입력(`document_core/queries/
+rendering.rs:3065` `measure_section`)에 누적되어 실제 렌더 결과와 다른 쪽에서 분할됐다.
+
+## 3. 변경
+
+`src/renderer/height_measurer.rs:527` — `recompose_for_cell_width` → `recompose_for_body_width`
+(한 단어). 주변 주석을 실제 코드·형제 경로와 일치하도록 갱신.
+
+## 4. 검증
+
+### 신규 테스트 (기전 증명)
+
+`src/renderer/composer/tests.rs::body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not`
+
+`compose_lines` fallback(단일 run, char_style_id=0)을 만든 뒤 두 래퍼에 각각 통과시켜:
+- `recompose_for_cell_width` → run 이 `[0]` 그대로(재분할 없음)
+- `recompose_for_body_width` → run 이 `[0, 1]` 로 분할(두 글자모양이 드러남)
+
+임을 단언한다. `height_measurer.rs` 의 수정이 기대는 정확한 메커니즘(body 래퍼가 cell
+래퍼의 superset)을 직접 증명하는 white-box 테스트다.
+
+```
+test renderer::composer::tests::body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not ... ok
+```
+
+### 회귀
+
+```
+cargo test --lib renderer::  →  861 passed / 0 failed / 4 ignored
+```
+
+### 미실행 항목 (투명 고지)
+
+- **`measure_paragraph` 를 통한 end-to-end 회귀**: `HeightMeasurer::measure_paragraph` 가
+  `fn` (비공개)이고 `ResolvedStyleSet` 을 실제 폰트 폭 테이블까지 채워 구성해야 픽셀 단위
+  높이 차이를 직접 단언할 수 있어, 이번 검증에서는 그 대신 근본 메커니즘(composer 레벨)을
+  직접 테스트했다. 호출부 자체는 한 단어 교체이고 형제 두 경로가 이미 같은 패턴으로 검증돼
+  있어(각각 자체 테스트 보유, 861건에 포함), 추가 위험은 낮다고 판단했다.
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다.
+
+## 5. 잔여 (같은 스윕의 별건, 범위 분리)
+
+이슈 본문에 기록. 별도 이슈로 등록해 순차 처리 예정:
+- `height_measurer.rs:521` match guard 로 인해 `masked_stored_lines_stale` 재래핑 분기가
+  구조적으로 도달 불가.
+- `table_ops.rs:1337` `update_neighbor_borders` DocInfo passthrough 무효화 누락.
+- `formatting.rs:944-965` `find_or_create_font_id_for_lang` raw/IR 글꼴 불일치.

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1,6 +1,63 @@
 use super::*;
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
 
+/// [#2632] `recompose_for_body_width` 는 `recompose_for_cell_width` 의 superset
+/// (`restyle_fallback_runs_by_char_shapes` 를 추가로 적용)이다. line_segs 가
+/// 없는(NO_LS) 본문 문단에서 글자모양이 섞여 있으면, compose_lines fallback 이
+/// 만든 단일 run 을 body 래퍼만 char shape 별로 재분할한다.
+/// HeightMeasurer(측정)가 cell 래퍼를 쓰던 종전엔 이 재분할이 빠져
+/// typeset/render 와 다른 값으로 측정됐다 — 그 근본 메커니즘을 여기서 고정한다.
+#[test]
+fn body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not() {
+    let para = Paragraph {
+        text: "abcdefghij".to_string(),
+        char_offsets: (0..10).collect(),
+        char_count: 11,
+        char_shapes: vec![
+            CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            },
+            CharShapeRef {
+                start_pos: 5,
+                char_shape_id: 1,
+            },
+        ],
+        // line_segs 가 비어 있어 compose_lines 의 CHARS_PER_LINE fallback 경로를 탄다.
+        ..Default::default()
+    };
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    // 문단 폭 안에 다 들어가도록 충분히 넓게 잡아 줄바꿈 자체는 문제되지 않게 한다.
+    let inner_width_px = 2000.0;
+
+    let mut cell_variant = compose_paragraph(&para);
+    recompose_for_cell_width(&mut cell_variant, &para, inner_width_px, &styles);
+    let cell_run_ids: Vec<u32> = cell_variant.lines[0]
+        .runs
+        .iter()
+        .map(|r| r.char_style_id)
+        .collect();
+
+    let mut body_variant = compose_paragraph(&para);
+    recompose_for_body_width(&mut body_variant, &para, inner_width_px, &styles);
+    let body_run_ids: Vec<u32> = body_variant.lines[0]
+        .runs
+        .iter()
+        .map(|r| r.char_style_id)
+        .collect();
+
+    assert_eq!(
+        cell_run_ids,
+        vec![0],
+        "cell 래퍼는 재분할하지 않아 fallback 단일 run(스타일 0)이 그대로 남아야 함"
+    );
+    assert_eq!(
+        body_run_ids,
+        vec![0, 1],
+        "body 래퍼는 restyle_fallback_runs_by_char_shapes 로 재분할해 두 글자모양이 드러나야 함"
+    );
+}
+
 /// 단일 줄, 단일 스타일 문단
 #[test]
 fn test_compose_single_line_single_style() {

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -515,8 +515,12 @@ impl HeightMeasurer {
         );
         let spacing_after = para_style.map(|s| s.spacing_after).unwrap_or(0.0);
 
-        // [Task #1042 Stage 6c] line_segs.empty paragraph 의 compose_lines fallback
-        // 결과를 단 너비 기반으로 recompose — paragraph_layout (Stage 6b) 와 동일.
+        // [Task #1042 Stage 6c][#2632] line_segs.empty paragraph 의 compose_lines
+        // fallback 결과를 단 너비 기반으로 recompose — typeset(format_paragraph)·
+        // render(layout_partial_paragraph) 와 동일한 본문 래퍼(recompose_for_body_width)
+        // 사용. 종전엔 셀 전용 recompose_for_cell_width 를 써 restyle_fallback_runs_
+        // by_char_shapes(글자모양별 run 재분할)를 건너뛰어, 글자모양이 섞인 본문
+        // NO_LS 문단의 측정 폭/줄수가 typeset/render 와 어긋났다.
         let recomposed: Option<ComposedParagraph> = match (composed, column_width_px) {
             (Some(c), Some(cw)) if para.line_segs.is_empty() && cw > 0.0 => {
                 let margin_l = para_style.map(|s| s.margin_left).unwrap_or(0.0);
@@ -524,7 +528,7 @@ impl HeightMeasurer {
                 let inner = (cw - margin_l - margin_r).max(0.0);
                 if inner > 0.0 {
                     let mut cloned = c.clone();
-                    crate::renderer::composer::recompose_for_cell_width(
+                    crate::renderer::composer::recompose_for_body_width(
                         &mut cloned,
                         para,
                         inner,


### PR DESCRIPTION
이슈 [#2632](https://github.com/edwardkim/rhwp/issues/2632) 처리.
처리결과 문서: `mydocs/report/task_m100_2632_report.md`

## 문제

`height_measurer.rs` 의 본문 재래핑 분기가 형제 두 경로와 다른 래퍼를 씁니다.

| 파일 | 함수 | 사용 래퍼(수정 전) |
|---|---|---|
| `height_measurer.rs:527` | `measure_paragraph` | `recompose_for_cell_width` |
| `typeset.rs:11162` | `format_paragraph` | `recompose_for_body_width` |
| `paragraph_layout.rs:1911` | `layout_partial_paragraph` | `recompose_for_body_width` |

`recompose_for_body_width`(composer.rs:1419)의 문서 주석이 명확히 구분합니다: "typeset·render 의 본문 NO_LS 문단 전용. **셀 경로는 recompose_for_cell_width 를 그대로 사용한다.**" `height_measurer.rs:519` 위 주석은 "paragraph_layout 과 동일" 이라 적혀 있지만 실제로는 그 형제가 쓰지 않는 함수를 호출하고 있었습니다 — 주석과 코드가 어긋난 상태.

`recompose_for_body_width` 는 `recompose_for_cell_width` 의 **superset**입니다(`restyle_fallback_runs_by_char_shapes` 추가 적용) — `compose_lines` NO_LS fallback 의 단일 스타일 run 을 실제 글자모양별로 재분할하는 유일한 단계입니다.

## 영향

글자모양이 섞인 본문 NO_LS 문단(예: 15pt 도입부 + 14pt 본문)에서 typeset/render 는 CharShapeRef 로 run 을 쪼개 정확히 측정하는데 `HeightMeasurer` 는 모든 run 을 단일 스타일로 측정 → 폭/줄수/줄간격 오차가 `measure_section`(document_core/queries/rendering.rs:3065) 을 통해 **페이지네이션 입력**에 누적됩니다. 실제 렌더 결과와 다른 쪽에서 분할됩니다.

## 수정

한 단어 교체 + 주석 정합.

## 검증

- **기전 증명(composer 레벨 white-box)**: `body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not` 추가 — `compose_lines` fallback(단일 run)을 두 래퍼에 각각 통과시켜 `recompose_for_cell_width` 는 재분할 없음(`[0]`), `recompose_for_body_width` 는 재분할됨(`[0,1]`)을 단언. 수정이 기대는 정확한 메커니즘을 직접 증명합니다.
- **회귀**: `cargo test --lib renderer::` → **861 passed / 0 failed**.

### 미실행 (투명 고지)

- `measure_paragraph` 를 통한 end-to-end 픽셀 단위 검증은 `ResolvedStyleSet` 실폭 테이블 구성이 필요해 이번엔 근본 메커니즘(composer 레벨)을 대신 테스트했습니다. 호출부는 한 단어 교체이고 형제 두 경로가 이미 같은 패턴으로 검증돼 있어(861건에 포함) 추가 위험은 낮다고 판단했습니다.
- PR CI 전체 검증(`cargo test --verbose`, `cargo clippy -- -D warnings`)은 저장소 규약상 작업지시자 별도 승인 사항이라 실행하지 않았습니다.

## 잔여 (범위 분리, 이슈 본문에 기록)

`height_measurer.rs:521` match guard 로 인한 `masked_stored_lines_stale` 분기 도달 불가, `table_ops.rs:1337` DocInfo 무효화 누락, `formatting.rs` 글꼴 raw/IR 불일치 — 별도 이슈로 순차 처리 예정.