### PR TITLE
fix(ci): codeql.yml isReviewReferencePath에 .hml 확장자 추가 (#2642)

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -94,6 +94,7 @@ jobs:
                 && (
                   filename.endsWith('.hwp')
                   || filename.endsWith('.hwpx')
+                  || filename.endsWith('.hml')
                   || filename.endsWith('.pdf')
                   || filename.endsWith('.png')
                 )

--- a/mydocs/report/pr-codeql-hml.md
+++ b/mydocs/report/pr-codeql-hml.md
@@ -1,0 +1,19 @@
+# PR #2644: codeql.yml isReviewReferencePath에 .hml 확장자 추가
+
+## 이슈
+- **Issue**: #2642 — codeql.yml의 리뷰 전용 경로 판정에서 .hml 누락
+
+## 분석
+
+codeql.yml의 preflight 단계에서 isReviewReferencePath() 함수가
+HWP/HWPX 샘플 파일만 리뷰 전용으로 인식한다. HML 샘플 파일이
+추가된 PR은 불필요하게 전체 CodeQL 분석을 트리거한다.
+
+## 변경
+
+`.github/workflows/codeql.yml:97`에 `filename.endsWith('.hml')` 조건 추가
+
+## 결과
+- HML 샘플 파일만 추가된 PR의 CI 효율화
+- 기존 HWP/HWPX/PDF/PNG 경로에 영향 없음
+- Closes #2642


### PR DESCRIPTION
## 변경 요약

`.github/workflows/codeql.yml`의 `isReviewReferencePath()` 함수가
HML 샘플 파일(`.hml`)을 리뷰 전용 경로로 인식하지 못하는 문제를 수정했다.

---

## 배경

codeql.yml의 preflight 단계는 변경된 파일이 리뷰 전용 경로(샘플, 문서 등)로만
구성된 PR을 감지해 불필요한 CodeQL 분석을 건너뛴다.

이때 HWP와 HWPX 샘플 파일은 포함되어 있었지만 HML은 누락되어 있어,
HML 샘플만 추가된 PR이 전체 CodeQL 분석을 불필요하게 트리거했다.

## 수정

```yaml
# before
filename.endsWith('.hwpx')
|| filename.endsWith('.pdf')

# after
filename.endsWith('.hwpx')
|| filename.endsWith('.hml')
|| filename.endsWith('.pdf')
```

## 검증

- 기존 HWP/HWPX/PDF/PNG 경로는 그대로 유지 (영향 없음)
- HML 샘플 파일만 추가된 PR에서 preflight fast_pass=true로 판정됨

Closes #2642