### PR TITLE
fix(hwp5): 머리말/꼬리말 LIST_HEADER 페이로드가 파싱되지 않아 list_attr 등이 항상 0 (#2648)

### DIFF
--- a/mydocs/report/task_m100_2648_report.md
+++ b/mydocs/report/task_m100_2648_report.md
@@ -1,0 +1,68 @@
+# task_m100_2648 처리결과 보고서 — 머리말/꼬리말 LIST_HEADER 페이로드 파싱
+
+- **이슈**: [#2648](https://github.com/edwardkim/rhwp/issues/2648)
+- **브랜치**: `task/m100-2648-headerfooter-listheader` (base `devel` @ `3c54abfd`)
+- **범위**: `src/parser/control.rs`
+- **분류**: 결함 수정 (파서 누락)
+
+## 1. 문제
+
+`find_list_header_paragraphs`(파서)가 `HWPTAG_LIST_HEADER` 자식 레코드를 찾아 **그 뒤의
+문단들만** 파싱하고, 레코드 자체의 페이로드(`list_attr`/`text_width`/`text_height`/
+`text_ref`/`num_ref`)는 전혀 읽지 않았다. `parse_header_control`/`parse_footer_control`
+이 이 함수만 호출하므로 `Header`/`Footer` 의 다섯 필드는 항상 `Default`(0)였다.
+
+직렬화(`build_header_footer_list_header`, `serializer/control.rs:2340`)는 이 필드들을
+무조건 사용해 `HWPTAG_LIST_HEADER` 레코드를 재생성하므로, 실제 파일이 담고 있던 값은
+파싱→직렬화 왕복마다 0 으로 뭉개졌다.
+
+같은 파일의 캡션 파서(`:427-431`)는 이미 이 레코드 페이로드를 읽는데, 머리말/꼬리말만
+빠진 비대칭이었다.
+
+## 2. 변경
+
+`find_list_header_paragraphs` 옆에 `find_list_header_layout_and_paragraphs` 를 신설 —
+직렬화 함수(`build_header_footer_list_header`)의 바이트 레이아웃을 역으로 읽어 레이아웃
+필드와 문단을 함께 반환한다:
+```
+u16 para_count | u32 list_attr | u16(예약) | u32 text_width | u32 text_height
+| u8 text_ref | u8 num_ref | u16 ext_flags | [u8;14] 예약
+```
+`parse_header_control`/`parse_footer_control` 양쪽에서 새 함수로 교체하고 다섯 필드를
+채웠다. 기존 `find_list_header_paragraphs` 는 각주/미주/숨은설명 파서가 여전히 쓰므로
+그대로 유지(불필요한 범위 확장 방지).
+
+## 3. 검증
+
+### 신규 테스트
+
+`test_parse_header_control_reads_list_header_layout_fields` — 비영 `list_attr`
+(`0x00020000`), `text_width=5000`, `text_height=3000`, `text_ref=7`, `num_ref=9` 를
+담은 LIST_HEADER 레코드를 파싱해 다섯 값이 그대로 읽힘을 단언.
+
+### red→green 실증
+
+필드 대입 5줄을 제거(`let (_layout, paragraphs) = ...; header.paragraphs = paragraphs;`)
+→ **FAILED**(`assertion left==right failed: list_attr 이 보존돼야 함`). 복원 → **통과**.
+
+```
+FAILED (수정 제거): 0 passed; 1 failed
+GREEN  (수정 복원): parser::control 18 passed; 0 failed
+```
+
+### 회귀
+
+```
+cargo test --lib parser::      →  390 passed / 0 failed
+cargo test --lib serializer::  →  403 passed / 0 failed
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소
+  규약상 작업지시자 별도 승인 사항이라 실행하지 않았다.
+- **parse→serialize→parse 완전 왕복 테스트**는 추가하지 않았다. 새 파서 함수가 직렬화
+  함수(`build_header_footer_list_header`)의 정확한 역함수임을 바이트 단위로 대조
+  확인했고(오프셋·길이 일치), 단위 테스트로 각 필드의 파싱을 직접 검증했다. 완전 왕복
+  테스트는 기존 저장소에 header/footer 전용 parse↔serialize 하네스가 마련돼 있지 않아
+  범위를 넘는다고 판단했다.

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -487,7 +487,13 @@ fn parse_header_control(ctrl_data: &[u8], child_records: &[Record]) -> Control {
         }
     }
 
-    header.paragraphs = find_list_header_paragraphs(child_records);
+    let (layout, paragraphs) = find_list_header_layout_and_paragraphs(child_records);
+    header.list_attr = layout.list_attr;
+    header.text_width = layout.text_width;
+    header.text_height = layout.text_height;
+    header.text_ref = layout.text_ref;
+    header.num_ref = layout.num_ref;
+    header.paragraphs = paragraphs;
 
     Control::Header(Box::new(header))
 }
@@ -511,7 +517,13 @@ fn parse_footer_control(ctrl_data: &[u8], child_records: &[Record]) -> Control {
         }
     }
 
-    footer.paragraphs = find_list_header_paragraphs(child_records);
+    let (layout, paragraphs) = find_list_header_layout_and_paragraphs(child_records);
+    footer.list_attr = layout.list_attr;
+    footer.text_width = layout.text_width;
+    footer.text_height = layout.text_height;
+    footer.text_ref = layout.text_ref;
+    footer.num_ref = layout.num_ref;
+    footer.paragraphs = paragraphs;
 
     Control::Footer(Box::new(footer))
 }
@@ -774,6 +786,55 @@ fn find_list_header_paragraphs(
         idx += 1;
     }
     Vec::new()
+}
+
+/// 머리말/꼬리말 LIST_HEADER 레코드 페이로드.
+///
+/// [#2648] `find_list_header_paragraphs` 는 레코드 뒤의 문단만 파싱하고 레코드
+/// 자체의 페이로드(list_attr/text_width/text_height/text_ref/num_ref)는 읽지
+/// 않았다. 직렬화(`build_header_footer_list_header`, serializer/control.rs)는
+/// 이 값들을 무조건 사용하므로 저장 왕복마다 0 으로 뭉개졌다. 바이트 레이아웃은
+/// 그 직렬화 함수의 역이다:
+/// u16 para_count | u32 list_attr | u16(예약) | u32 text_width | u32 text_height
+/// | u8 text_ref | u8 num_ref | u16 ext_flags | [u8;14] 예약
+struct HeaderFooterListLayoutFields {
+    list_attr: u32,
+    text_width: u32,
+    text_height: u32,
+    text_ref: u8,
+    num_ref: u8,
+}
+
+fn find_list_header_layout_and_paragraphs(
+    child_records: &[Record],
+) -> (
+    HeaderFooterListLayoutFields,
+    Vec<crate::model::paragraph::Paragraph>,
+) {
+    let mut layout = HeaderFooterListLayoutFields {
+        list_attr: 0,
+        text_width: 0,
+        text_height: 0,
+        text_ref: 0,
+        num_ref: 0,
+    };
+    let mut idx = 0;
+    while idx < child_records.len() {
+        if child_records[idx].tag_id == tags::HWPTAG_LIST_HEADER {
+            let mut r = ByteReader::new(&child_records[idx].data);
+            let _para_count = r.read_u16().unwrap_or(0);
+            layout.list_attr = r.read_u32().unwrap_or(0);
+            let _reserved = r.read_u16().unwrap_or(0);
+            layout.text_width = r.read_u32().unwrap_or(0);
+            layout.text_height = r.read_u32().unwrap_or(0);
+            layout.text_ref = r.read_u8().unwrap_or(0);
+            layout.num_ref = r.read_u8().unwrap_or(0);
+            let paragraphs = parse_paragraph_list(&child_records[idx + 1..]);
+            return (layout, paragraphs);
+        }
+        idx += 1;
+    }
+    (layout, Vec::new())
 }
 
 // ============================================================

--- a/src/parser/control/tests.rs
+++ b/src/parser/control/tests.rs
@@ -109,6 +109,43 @@ fn test_parse_header_control() {
     }
 }
 
+/// [#2648] 머리말 LIST_HEADER 레코드 페이로드(list_attr/text_width/text_height/
+/// text_ref/num_ref)가 파싱돼야 한다. 종전엔 레코드 뒤 문단만 읽고 페이로드
+/// 자체는 무시해 이 필드들이 항상 0 이었다.
+#[test]
+fn test_parse_header_control_reads_list_header_layout_fields() {
+    let mut ctrl_data = Vec::new();
+    ctrl_data.extend_from_slice(&0u32.to_le_bytes()); // attr: Both
+
+    let mut list_data = Vec::new();
+    list_data.extend_from_slice(&1u16.to_le_bytes()); // n_paragraphs
+    list_data.extend_from_slice(&0x0002_0000u32.to_le_bytes()); // list_attr (비영)
+    list_data.extend_from_slice(&0u16.to_le_bytes()); // 예약
+    list_data.extend_from_slice(&5000u32.to_le_bytes()); // text_width
+    list_data.extend_from_slice(&3000u32.to_le_bytes()); // text_height
+    list_data.push(7); // text_ref
+    list_data.push(9); // num_ref
+    list_data.extend_from_slice(&0u16.to_le_bytes()); // ext_flags
+    list_data.extend_from_slice(&[0u8; 14]); // 예약
+
+    let child_records = vec![
+        make_record(tags::HWPTAG_LIST_HEADER, 2, list_data),
+        make_record(tags::HWPTAG_PARA_HEADER, 3, make_para_header_data(6)),
+        make_record(tags::HWPTAG_PARA_TEXT, 4, make_para_text_data("머리말")),
+    ];
+
+    let ctrl = parse_header_control(&ctrl_data, &child_records);
+    let Control::Header(header) = ctrl else {
+        panic!("Expected Header control");
+    };
+    assert_eq!(header.list_attr, 0x0002_0000, "list_attr 이 보존돼야 함");
+    assert_eq!(header.text_width, 5000, "text_width 가 보존돼야 함");
+    assert_eq!(header.text_height, 3000, "text_height 가 보존돼야 함");
+    assert_eq!(header.text_ref, 7, "text_ref 가 보존돼야 함");
+    assert_eq!(header.num_ref, 9, "num_ref 가 보존돼야 함");
+    assert_eq!(header.paragraphs.len(), 1);
+}
+
 #[test]
 fn test_parse_footer_control() {
     let mut ctrl_data = Vec::new();


### PR DESCRIPTION
이슈 [#2648](https://github.com/edwardkim/rhwp/issues/2648) 처리.
처리결과 문서: `mydocs/report/task_m100_2648_report.md`

## 문제

`find_list_header_paragraphs` 가 `HWPTAG_LIST_HEADER` 레코드 뒤의 문단만 읽고 레코드 자체의 페이로드(`list_attr`/`text_width`/`text_height`/`text_ref`/`num_ref`)는 전혀 읽지 않았습니다. 직렬화(`build_header_footer_list_header`, serializer/control.rs:2340)는 이 필드들을 무조건 사용하므로 저장 왕복마다 0 으로 뭉개졌습니다. 같은 파일의 캡션 파서(`:427-431`)는 이미 이 페이로드를 읽는데 머리말/꼬리말만 빠진 비대칭이었습니다.

## 수정

`find_list_header_layout_and_paragraphs` 신설 — 직렬화 함수의 바이트 레이아웃을 정확히 역으로 읽어 레이아웃 필드와 문단을 함께 반환:
```
u16 para_count | u32 list_attr | u16(예약) | u32 text_width | u32 text_height | u8 text_ref | u8 num_ref | ...
```
`parse_header_control`/`parse_footer_control` 양쪽에 적용. 각주/미주/숨은설명이 쓰는 기존 `find_list_header_paragraphs` 는 범위를 넘지 않기 위해 그대로 유지했습니다.

## 검증

- **신규 테스트** `test_parse_header_control_reads_list_header_layout_fields` — 비영 값들을 파싱해 보존됨을 단언.
- **red→green 실증**: 필드 대입 제거 시 `FAILED`(assertion 실패), 복원 시 통과.
- **회귀**: `parser::` 390건 / `serializer::` 403건 전부 통과.

### 미실행 (투명 고지)

- PR CI 전체 검증은 저장소 규약상 작업지시자 별도 승인 사항이라 실행하지 않았습니다.
- 완전한 parse→serialize→parse 왕복 테스트는 header/footer 전용 하네스가 없어 범위를 넘는다고 판단, 대신 바이트 레이아웃을 직렬화 함수와 직접 대조하고 단위 테스트로 각 필드를 검증했습니다.