### PR TITLE
fix(ci): render-diff.yml isReviewReferencePath에 .hml 확장자 추가 (#2652)

### DIFF
--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -104,6 +104,7 @@ jobs:
                 && (
                   filename.endsWith('.hwp')
                   || filename.endsWith('.hwpx')
+                  || filename.endsWith('.hml')
                   || filename.endsWith('.pdf')
                   || filename.endsWith('.png')
                 )

--- a/mydocs/report/pr-renderdiff-hml.md
+++ b/mydocs/report/pr-renderdiff-hml.md
@@ -1,0 +1,18 @@
+# PR #2653: render-diff.yml isReviewReferencePath에 .hml 확장자 추가
+
+## 이슈
+- **Issue**: #2652 — render-diff.yml 리뷰 전용 경로 판정에서 .hml 누락
+
+## 분석
+
+#2644(codeql.yml), #2646(ci.yml)에서 isReviewReferencePath()에 .hml을
+추가했지만 render-diff.yml은 누락되었다. 3개 워크플로우(ci, codeql, render-diff)가
+동일한 preflight 로직을 공유하므로 모두 일관되어야 한다.
+
+## 변경
+`.github/workflows/render-diff.yml:107`에 `filename.endsWith('.hml')` 조건 추가
+
+## 결과
+- 3개 워크플로우 모두 일관성 확보
+- HML 샘플 파일만 추가된 PR에서 Render Diff 불필요한 실행 방지
+- Closes #2652


### PR DESCRIPTION
## 변경 요약

`render-diff.yml`의 `isReviewReferencePath()` 함수에 `.hml` 확장자를 추가했다.

---

## 배경

#2644(codeql.yml)와 #2646(ci.yml)에서 isReviewReferencePath()에 .hml을
추가했지만, 동일한 preflight 로직을 가진 render-diff.yml은 누락되었다.

## 수정

```yaml
# before
filename.endsWith('.hwpx') || filename.endsWith('.pdf')
# after
filename.endsWith('.hwpx') || filename.endsWith('.hml') || filename.endsWith('.pdf')
```

## 검증

- 3개 워크플로우(ci.yml, codeql.yml, render-diff.yml) 모두 일관성 확보
- HML 샘플 파일만 추가된 PR에서 Render Diff 불필요한 실행 방지

Closes #2652