### PR TITLE
fix(#2551): dump-pages -p 인자 파싱 무성 오류 제거 (형제 명령 정합)

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -2434,11 +2434,20 @@ fn dump_pages(args: &[String]) {
     while i < args.len() {
         match args[i].as_str() {
             "--page" | "-p" => {
+                // [#2551] 형제 명령(export-svg/png/text)과 동일하게 파싱 실패를
+                // 조용히 삼키지 않는다 — 오타로 문서 전체가 덤프되던 무성 버그.
                 if i + 1 < args.len() {
-                    target_page = args[i + 1].parse().ok();
+                    match args[i + 1].parse::<u32>() {
+                        Ok(n) => target_page = Some(n),
+                        Err(_) => {
+                            eprintln!("오류: 페이지 번호가 올바르지 않습니다: {}", args[i + 1]);
+                            return;
+                        }
+                    }
                     i += 2;
                 } else {
-                    i += 1;
+                    eprintln!("오류: {} 뒤에 페이지 번호가 필요합니다.", args[i]);
+                    return;
                 }
             }
             "--respect-vpos-reset" => {
@@ -2446,7 +2455,8 @@ fn dump_pages(args: &[String]) {
                 i += 1;
             }
             _ => {
-                i += 1;
+                eprintln!("알 수 없는 옵션: {}", args[i]);
+                return;
             }
         }
     }
@@ -2469,6 +2479,19 @@ fn dump_pages(args: &[String]) {
 
     if respect_vpos_reset {
         doc.set_respect_vpos_reset(true);
+    }
+
+    // [#2551] 문서 로드 후 페이지 범위 검사 — 범위 밖 -p 는 빈 출력이 아니라 오류.
+    // page_filter 는 0-기반(global_page==pf), export-svg 와 동일 규약.
+    if let Some(p) = target_page {
+        let total = doc.page_count();
+        if p >= total {
+            eprintln!(
+                "오류: 페이지 번호가 범위를 벗어났습니다 (0~{})",
+                total.saturating_sub(1)
+            );
+            return;
+        }
     }
 
     println!("문서 로드: {} ({}페이지)", file_path, doc.page_count());


### PR DESCRIPTION
## 요약

`dump-pages` 의 `-p` 인자 파싱만 형제 명령과 다르게 오류를 무성으로 삼키던 3가지 결함(#2551)을 형제 패턴 미러링으로 수정.

## 변경 (`src/main.rs` dump_pages)

| 결함 | 종전 | 수정 |
|---|---|---|
| 파싱 실패 삼킴 | `-p abc` → `.ok()`=None → **문서 전체 덤프** | `eprintln! + return` (export-svg 동일) |
| 범위 검사 없음 | `-p 9999` → 빈 출력 | 로드 후 `p >= page_count` 오류 (0-기반, `0~N`) |
| 미지 옵션 무시 | `--respect-vpos-resets`(오타) 조용히 버림 | `알 수 없는 옵션` 출력 + return |

정상 `-p 5` 등은 불변. 새 규약 도입 없이 export-svg/png/text 의 기존 패턴을 그대로 따름.

## 검증

- `-p 3` → 정상 덤프
- `-p xyz` → `오류: 페이지 번호가 올바르지 않습니다: xyz`
- `-p 9999` → `오류: 페이지 번호가 범위를 벗어났습니다 (0~240)`
- `--respect-vpos-resets` → `알 수 없는 옵션`
- fmt/clippy 클린

🤖 Generated with [Claude Code](https://claude.com/claude-code)
