### PR TITLE
test(#2523 후속): composeImageFilter 효과별 CSS filter 문자열 pin

### DIFF
--- a/rhwp-studio/tests/flow-image-clip.test.ts
+++ b/rhwp-studio/tests/flow-image-clip.test.ts
@@ -3,6 +3,7 @@ import assert from 'node:assert/strict';
 
 import {
   collectFlowImagePaintOps,
+  composeImageFilter,
   visibleFlowImageBbox,
 } from '../src/view/flow-image-clip.ts';
 
@@ -47,4 +48,41 @@ test('flow image collector leaves unclipped images unchanged', () => {
   assert.equal(images.length, 1);
   assert.equal(images[0].clip, null);
   assert.deepEqual(visibleFlowImageBbox(images[0]), { x: 3, y: 4, width: 5, height: 6 });
+});
+
+// composeImageFilter 효과별 CSS filter 문자열 pin (PR #2523 검토 후속 권고).
+// web_canvas.rs::compose_image_filter 와 동일 산출 계약 — 문자열이 바뀌면
+// WASM canvas 경로와 DOM flow-image 경로의 그림 효과가 갈라진다.
+
+test('composeImageFilter pins effect-only outputs', () => {
+  assert.equal(composeImageFilter({}), null);
+  assert.equal(composeImageFilter({ effect: 'realPic' }), null);
+  assert.equal(composeImageFilter({ effect: 'grayScale' }), 'grayscale(100%)');
+  assert.equal(composeImageFilter({ effect: 'pattern8x8' }), 'grayscale(100%)');
+  assert.equal(
+    composeImageFilter({ effect: 'blackWhite' }),
+    'grayscale(100%) contrast(1000%)',
+  );
+});
+
+test('composeImageFilter pins brightness/contrast scaling', () => {
+  assert.equal(composeImageFilter({ brightness: 20 }), 'brightness(1.2000)');
+  assert.equal(composeImageFilter({ brightness: -20 }), 'brightness(0.8000)');
+  assert.equal(composeImageFilter({ contrast: -30 }), 'contrast(0.7000)');
+  assert.equal(composeImageFilter({ contrast: 50 }), 'contrast(1.5000)');
+  assert.equal(
+    composeImageFilter({ effect: 'grayScale', brightness: 10, contrast: -10 }),
+    'grayscale(100%) brightness(1.1000) contrast(0.9000)',
+  );
+});
+
+test('composeImageFilter ignores baked watermark and non-finite inputs', () => {
+  // baked 픽셀은 효과가 이미 적용돼 있으므로 filter 를 걸지 않는다.
+  assert.equal(
+    composeImageFilter({ effect: 'blackWhite', brightness: 40, bakedWatermark: true }),
+    null,
+  );
+  // 비유한/비문자 입력은 기본값(효과 없음, 0)으로 정규화.
+  assert.equal(composeImageFilter({ brightness: Number.NaN, contrast: Infinity }), null);
+  assert.equal(composeImageFilter({ effect: 123 }), null);
 });


### PR DESCRIPTION
## 대상

PR #2523 검토([pr_2523_review.md](https://github.com/edwardkim/rhwp/blob/devel/mydocs/pr/archives/pr_2523_review.md))의 후속 권고 대응:

> 현행 `flow-image-clip.test.ts`는 clip 계보만 검사하고 새 `composeImageFilter()`의 효과별 기대 문자열은 직접 pin하지 않는다. … 회색조·흑백·brightness/contrast·baked watermark 회귀 단위 테스트를 후속 보강하는 것을 권고한다.

## 내용

`rhwp-studio/tests/flow-image-clip.test.ts` 에 `composeImageFilter()` 효과별 CSS filter 문자열 pin 3케이스(단정 13건) 추가:

- 효과 단독: `realPic`/기본=null, `grayScale`·`pattern8x8`=`grayscale(100%)`, `blackWhite`=`grayscale(100%) contrast(1000%)`
- 밝기/명암 스케일: ±값의 `brightness(1.2000)`/`contrast(0.7000)` 등 소수 4자리 고정 + `grayScale`+밝기+명암 조합 순서
- 경계: `bakedWatermark`(효과 기적용 픽셀)=null, 비유한(NaN/Infinity)·비문자 effect 입력 정규화

pin 문자열은 `web_canvas.rs::compose_image_filter` 구현(`{:.4}` 포맷)과 대조해 동일 산출 계약을 가드한다 — 문자열이 갈라지면 WASM canvas 경로와 DOM flow-image 경로의 그림 효과가 달라진다.

## 검증

- `node --test tests/flow-image-clip.test.ts` 5/5 GREEN (기존 2 + 신규 3)
- Rust 쪽 `compose_image_filter` 소스 대조로 기대 문자열 동일성 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)
