### PR TITLE
fix(ooxml-chart): dPt explosion 비승격 + splitType 해석 게이트 (PR #2500 리뷰 후속)

### DIFF
--- a/src/ooxml_chart/mod.rs
+++ b/src/ooxml_chart/mod.rs
@@ -93,6 +93,10 @@ pub struct OoxmlChart {
 pub struct OfPieInfo {
     /// `c:ofPieType val` — pie=원형대원형(보조 원), bar=원형대가로막대형(누적 막대)
     pub of_pie_type: OfPieType,
+    /// `c:splitType val` — splitPos 해석 방식. 현재 count 해석은 pos(및 미지정
+    /// auto: 종전 코퍼스 정책 보존)만 적용하고, val/percent/cust 는 splitPos 를
+    /// 무시해 기본 정책(마지막 2개)으로 안전 폴백한다. (PR #2500 후속)
+    pub split_type: OfPieSplitType,
     /// `c:splitPos val` — 보조 플롯으로 보낼 마지막 카테고리 수. 코퍼스 부재 →
     /// None → 기본 2. (스키마상 double — f64 파싱, 사용 시 반올림·클램프)
     pub split_pos: Option<f64>,
@@ -106,11 +110,28 @@ impl Default for OfPieInfo {
     fn default() -> Self {
         Self {
             of_pie_type: OfPieType::Pie,
+            split_type: OfPieSplitType::Auto,
             split_pos: None,
             second_pie_size: 75.0,
             has_ser_lines: false,
         }
     }
+}
+
+/// `c:splitType` — ofPie 보조 플롯 항목 선택 방식 (PR #2500 후속)
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Default)]
+pub enum OfPieSplitType {
+    /// 미지정(스키마 기본 auto) — 앱 재량. splitPos 가 오면 종전 count 정책 유지.
+    #[default]
+    Auto,
+    /// splitPos = 마지막 N개 카테고리 수 (현재 구현 대상)
+    Pos,
+    /// splitPos = 값 임계 — 미구현, splitPos 무시 폴백
+    Val,
+    /// splitPos = 백분율 임계 — 미구현, splitPos 무시 폴백
+    Percent,
+    /// custPlt 점별 지정 — 미구현, splitPos 무시 폴백
+    Cust,
 }
 
 /// ofPie 보조 플롯 종류 (C2b #2278)

--- a/src/ooxml_chart/parser.rs
+++ b/src/ooxml_chart/parser.rs
@@ -10,8 +10,8 @@
 //! - 파싱 완료 시 시리즈의 axis_ids를 primary/secondary 집합과 비교해 axis_group 지정
 
 use super::{
-    BarGrouping, LegendPos, OfPieInfo, OfPieType, OoxmlChart, OoxmlChartType, OoxmlSeries,
-    ScatterStyle, SeriesMarker, View3D,
+    BarGrouping, LegendPos, OfPieInfo, OfPieSplitType, OfPieType, OoxmlChart, OoxmlChartType,
+    OoxmlSeries, ScatterStyle, SeriesMarker, View3D,
 };
 use quick_xml::events::Event;
 use quick_xml::Reader;
@@ -34,6 +34,9 @@ struct ParseState {
     in_solid_fill: bool, // a:solidFill
     in_ln: bool,         // a:ln (stroke)
     in_num_cache: bool,  // c:numCache — formatCode 파싱
+    // c:dPt(점별 속성) 블록 내부 — 점별 explosion 을 계열로 승격하지 않기 위한
+    // 문맥 게이트 (PR #2500 후속)
+    in_d_pt: bool,
     bar_dir: Option<BarDir>,
     // 현재 파싱 중인 plot 블록 (barChart/lineChart/pieChart) 안에 있는지
     cur_plot_type: Option<OoxmlChartType>,
@@ -346,6 +349,19 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
                 }
             }
         }
+        b"splitType" => {
+            // pos 외 형태(val/percent/cust)는 splitPos 해석이 달라 count 적용을
+            // 막는다 — 렌더에서 기본 정책 폴백. (PR #2500 후속)
+            if let (Some(of), Some(val)) = (chart.of_pie.as_mut(), attr_val(e, "val")) {
+                of.split_type = match val.as_str() {
+                    "pos" => OfPieSplitType::Pos,
+                    "val" => OfPieSplitType::Val,
+                    "percent" => OfPieSplitType::Percent,
+                    "cust" => OfPieSplitType::Cust,
+                    _ => OfPieSplitType::Auto,
+                };
+            }
+        }
         b"splitPos" => {
             if let (Some(of), Some(v)) = (chart.of_pie.as_mut(), attr_f64(e)) {
                 of.split_pos = Some(v);
@@ -422,10 +438,16 @@ fn handle_start(e: &quick_xml::events::BytesStart, chart: &mut OoxmlChart, st: &
         }
         b"explosion" => {
             // 계열 레벨 쪼개진원형 (%) — 렌더는 2D 원형 경로만 반영. (C2b #2278)
+            // c:dPt 내부의 점별 explosion 은 계열 전체로 승격하지 않고 무시한다
+            // (점별 렌더 미지원 — PR #2500 후속).
+            if st.in_d_pt {
+                return;
+            }
             if let (Some(ser), Some(v)) = (st.cur_series.as_mut(), attr_f64(e)) {
                 ser.explosion = Some(v);
             }
         }
+        b"dPt" => st.in_d_pt = true,
         b"ser" => {
             let mut ser = OoxmlSeries::default();
             if let Some(t) = st.cur_plot_type {
@@ -578,6 +600,7 @@ fn handle_end(name: &[u8], chart: &mut OoxmlChart, st: &mut ParseState) {
         b"tx" => st.in_tx = false,
         b"cat" => st.in_cat = false,
         b"val" => st.in_val = false,
+        b"dPt" => st.in_d_pt = false,
         b"xVal" => st.in_x_val = false,
         b"yVal" => st.in_y_val = false,
         b"title" => st.in_chart_title = false,
@@ -1058,6 +1081,45 @@ mod tests {
             parse_chart_xml(xml2).expect("parse OK").series[0].explosion,
             None
         );
+    }
+
+    // --- PR #2500 후속: dPt 점별 explosion 비승격 + splitType 해석 ---
+
+    #[test]
+    fn test_dpt_explosion_not_promoted_to_series() {
+        // c:dPt 내부 점별 explosion — 점별 렌더 미지원 동안 계열 승격 금지
+        let xml = br#"<?xml version="1.0"?><c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:plotArea><c:pieChart><c:ser><c:dPt><c:idx val="1"/><c:explosion val="25"/></c:dPt><c:val><c:numCache><c:pt idx="0"><c:v>4</c:v></c:pt><c:pt idx="1"><c:v>3</c:v></c:pt></c:numCache></c:val></c:ser></c:pieChart></c:plotArea></c:chart></c:chartSpace>"#;
+        assert_eq!(
+            parse_chart_xml(xml).expect("parse OK").series[0].explosion,
+            None,
+            "dPt explosion 이 계열 전체로 승격되면 안 됨"
+        );
+        // 계열 레벨 explosion 은 dPt 공존 시에도 유지
+        let xml2 = br#"<?xml version="1.0"?><c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:plotArea><c:pieChart><c:ser><c:explosion val="10"/><c:dPt><c:idx val="1"/><c:explosion val="25"/></c:dPt><c:val><c:numCache><c:pt idx="0"><c:v>4</c:v></c:pt></c:numCache></c:val></c:ser></c:pieChart></c:plotArea></c:chart></c:chartSpace>"#;
+        assert_eq!(
+            parse_chart_xml(xml2).expect("parse OK").series[0].explosion,
+            Some(10.0),
+            "계열 레벨 explosion 은 유지"
+        );
+    }
+
+    #[test]
+    fn test_ofpie_split_type_parsed() {
+        let make = |ty: &str| {
+            let xml = format!(
+                r#"<?xml version="1.0"?><c:chartSpace xmlns:c="x" xmlns:a="y"><c:chart><c:plotArea><c:ofPieChart><c:ofPieType val="pie"/><c:splitType val="{ty}"/><c:splitPos val="3"/><c:ser><c:val><c:numCache><c:pt idx="0"><c:v>4</c:v></c:pt></c:numCache></c:val></c:ser></c:ofPieChart></c:plotArea></c:chart></c:chartSpace>"#
+            );
+            parse_chart_xml(xml.as_bytes())
+                .expect("parse OK")
+                .of_pie
+                .expect("of_pie")
+        };
+        assert_eq!(make("pos").split_type, OfPieSplitType::Pos);
+        assert_eq!(make("val").split_type, OfPieSplitType::Val);
+        assert_eq!(make("percent").split_type, OfPieSplitType::Percent);
+        assert_eq!(make("cust").split_type, OfPieSplitType::Cust);
+        // splitPos 값 자체는 형태와 무관하게 IR 에 보존 (해석은 렌더에서 게이트)
+        assert_eq!(make("val").split_pos, Some(3.0));
     }
 
     #[test]

--- a/src/ooxml_chart/renderer.rs
+++ b/src/ooxml_chart/renderer.rs
@@ -1189,8 +1189,16 @@ fn render_of_pie(
     if total <= 0.0 {
         return;
     }
+    // splitPos 의 count 해석은 splitType=pos(및 미지정 auto — 종전 코퍼스 정책
+    // 보존)에만 유효. val/percent/cust 는 값·백분율·점별 임계라 count 로 읽으면
+    // 오분할 — splitPos 를 무시하고 기본 2로 폴백한다. (PR #2500 후속)
+    let split_pos_as_count = matches!(
+        of.split_type,
+        super::OfPieSplitType::Auto | super::OfPieSplitType::Pos
+    );
     let k = of
         .split_pos
+        .filter(|_| split_pos_as_count)
         .map(|v| (v.round() as usize).clamp(1, n - 1))
         .unwrap_or(2)
         .min(n - 1);
@@ -3686,6 +3694,9 @@ mod tests {
     fn test_bar3d_clustered_faces_both_orientations() {
         // 3D 묶은: 막대(2cat×3ser=6)마다 top/side 면 1쌍 (정답지: 윗면 밝게 +
         // 우측면 어둡게 사선 압출). 2D는 면 없음.
+        // [지원 범위 — PR #2500 리뷰 P2] 이 시어 투영은 rAngAx=1(직각 축)
+        // 코퍼스 한정 근사다. rAngAx=0(회전 투영)·rotX/rotY 임의 조합은
+        // 동일 시어로 폴백하며 정답지 검증이 없다 — 별도 후속 트랙.
         for chart_type in [OoxmlChartType::Column, OoxmlChartType::Bar] {
             let chart = bars3d_chart(chart_type, BarGrouping::Clustered);
             let svg = render_chart_svg(&chart, 0.0, 0.0, 400.0, 300.0);
@@ -4424,6 +4435,45 @@ mod tests {
         );
         assert_eq!(svg.matches("hwp-ofpie-main").count(), 2, "주 원 2");
         assert_eq!(svg.matches("hwp-ofpie-second").count(), 3, "보조 3");
+    }
+
+    #[test]
+    fn test_ofpie_non_pos_split_type_falls_back_to_default() {
+        // PR #2500 후속: val/percent/cust 의 splitPos 는 count 가 아니므로
+        // 무시하고 기본 k=2 로 폴백 — 주 원 3(= 4−2+1) + 보조 2.
+        for ty in [
+            super::super::OfPieSplitType::Val,
+            super::super::OfPieSplitType::Percent,
+            super::super::OfPieSplitType::Cust,
+        ] {
+            let svg = render_chart_svg(
+                &ofpie_chart(OfPieInfo {
+                    split_type: ty,
+                    split_pos: Some(3.0),
+                    ..Default::default()
+                }),
+                0.0,
+                0.0,
+                400.0,
+                300.0,
+            );
+            assert_eq!(svg.matches("hwp-ofpie-main").count(), 3, "{ty:?}: 주 원 3");
+            assert_eq!(svg.matches("hwp-ofpie-second").count(), 2, "{ty:?}: 보조 2");
+        }
+        // splitType=pos 는 종전대로 count 적용
+        let svg = render_chart_svg(
+            &ofpie_chart(OfPieInfo {
+                split_type: super::super::OfPieSplitType::Pos,
+                split_pos: Some(3.0),
+                ..Default::default()
+            }),
+            0.0,
+            0.0,
+            400.0,
+            300.0,
+        );
+        assert_eq!(svg.matches("hwp-ofpie-main").count(), 2, "pos: 주 원 2");
+        assert_eq!(svg.matches("hwp-ofpie-second").count(), 3, "pos: 보조 3");
     }
 
     #[test]


### PR DESCRIPTION
## 대상

PR #2500 검토([pr_2500_review.md](https://github.com/edwardkim/rhwp/blob/devel/mydocs/pr/archives/pr_2500_review.md))의 "후속 보완 요청" 대응.

## P1-1 — `c:dPt/c:explosion` 계열 승격 차단

- 파서에 `c:dPt` 문맥 게이트(`in_d_pt`)를 추가해 점별 explosion 이 계열 전체로 승격되던 것을 차단. 점별 explosion 렌더는 미지원이므로 권고의 안전 옵션대로 **무시**한다.
- 회귀 fixture: `<c:dPt><c:idx/><c:explosion/></c:dPt>` → 계열 explosion `None`, 계열 레벨 explosion 과 dPt 공존 시 계열 값 유지.

## P1-2 — `c:splitType` 해석 게이트

- `OfPieSplitType`(Auto/Pos/Val/Percent/Cust)을 IR 로 파싱. splitPos 의 "마지막 N개" count 해석은 **pos 및 미지정(auto)** 에만 적용 — auto 를 포함한 것은 기존 코퍼스·`test_ofpie_split_pos_respected` 계약(형태 미지정+splitPos) 보존 목적.
- **val/percent/cust 는 splitPos 를 무시하고 기본 정책(마지막 2개)으로 안전 폴백** — 값·백분율·점별 임계를 count 로 오독하던 P1 해소.
- fixture: splitType 4형태 파싱 + 렌더 폴백(주 원 3/보조 2)·pos 적용(주 원 2/보조 3) 검증.

## P2 — 3D 지원 범위 명시

- 3D 막대 시어 투영이 **rAngAx=1 코퍼스 한정 근사**이며 rAngAx=0·임의 rotX/rotY 조합은 동일 시어 폴백(정답지 미검증, 별도 후속)임을 대표 테스트 주석에 명시. (원 PR 본문은 작성자 소유라 테스트 주석으로 기록.)

## 검증

- `cargo test --lib ooxml_chart` 137/137 GREEN (신규 3 테스트 포함)
- `cargo clippy --lib -- -D warnings` 통과, rustfmt 적용

🤖 Generated with [Claude Code](https://claude.com/claude-code)
