### PR TITLE
fix(#2525): 비마스킹 단일-lineseg 과밀 본문 재래핑 — SVG 글리프 겹침 해소

### DIFF
--- a/src/renderer/composer.rs
+++ b/src/renderer/composer.rs
@@ -1490,6 +1490,20 @@ pub fn stored_lines_overflow(
     if composed.lines.len() != para.line_segs.len() {
         return false;
     }
+    // [#2525] 비마스킹 대형 과밀: 저장 lineseg 이 장평 반영 실폭
+    // (estimate_composed_line_width 는 ts.ratio 를 자체 반영) 기준으로도 내폭을
+    // 크게(≥1.8×) 초과하면, 정당한 장평/자간 압축 범위(최소 advance 클램프 0.5×
+    // → 최대 ~2× 과밀)를 벗어난 부실 단일-저장 lineseg 다 (hwpx-02 p5: 135자
+    // 1줄 ≈4.5× 과밀 → 숫자 char_px*ratio*0.5 클램프로 0.5em 겹침). 마스킹(*)
+    // 게이트와 무관하게 fresh 재래핑한다. 정당한 장평 압축 문서는 ratio 반영
+    // 실폭이 내폭 이내라 오발동하지 않는다.
+    if composed
+        .lines
+        .iter()
+        .any(|l| estimate_composed_line_width(l, styles) > inner_width_px * 1.8)
+    {
+        return true;
+    }
     // 마스킹 판별: 공백 제외 글자의 절반 이상이 '*'
     let (mut stars, mut others) = (0usize, 0usize);
     for c in para.text.chars() {

--- a/tests/issue_2525_single_lineseg_rewrap.rs
+++ b/tests/issue_2525_single_lineseg_rewrap.rs
@@ -1,0 +1,50 @@
+//! [#2525] 비마스킹 단일-lineseg 과밀 문서(기계생성 HWPX)의 본문 줄을
+//! rhwp 가 한 줄에 욱여넣어 음수 자간으로 압축 → SVG 글리프 겹침(숫자
+//! advance 0.5× 클램프)이 발생하던 회귀 가드.
+//!
+//! 정본(한컴 COM PDF, 2026-07-21): `samples/hwpx/hwpx-02.hwpx` p0 숫자
+//! "2024" advance = 0.590em, 첫 본문 줄 ≈ 30자로 재래핑. 수정 전 rhwp 는
+//! 110자를 한 줄에 넣고 숫자 advance 0.297em(char_px*ratio*0.5 최소 클램프)
+//! 으로 압축 → 겹침. 근인: `stored_lines_overflow`(composer.rs)의 오버플로우
+//! 재래핑이 마스킹(`*`) 문서에만 발동 → 비마스킹 과밀 제외. 수정: 장평 반영
+//! 실폭이 내폭 ≥1.8× 인 저장 lineseg 도 fresh 재래핑.
+
+use std::path::Path;
+
+fn render_page_svg(rel: &str, page: u32) -> String {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = std::fs::read(&path).expect("read sample");
+    let mut doc = rhwp::wasm_api::HwpDocument::from_bytes(&bytes).expect("parse");
+    doc.render_page_svg(page).expect("render svg")
+}
+
+/// 같은 baseline(y) 을 공유하는 <text> 글리프 최대 개수.
+/// 과밀(한 줄에 전 문단) 이면 매우 큼(수정 전 110), 재래핑되면 작음(≈30).
+fn max_glyphs_on_one_baseline(svg: &str) -> usize {
+    use std::collections::HashMap;
+    let mut by_y: HashMap<String, usize> = HashMap::new();
+    let mut rest = svg;
+    while let Some(p) = rest.find("<text x=\"") {
+        rest = &rest[p + 8..];
+        if let Some(yp) = rest.find(" y=\"") {
+            let after = &rest[yp + 4..];
+            if let Some(end) = after.find('"') {
+                let y = after[..end].to_string();
+                *by_y.entry(y).or_insert(0) += 1;
+            }
+        }
+    }
+    by_y.values().copied().max().unwrap_or(0)
+}
+
+#[test]
+fn hwpx02_single_lineseg_paragraph_is_rewrapped_not_crammed() {
+    let svg = render_page_svg("samples/hwpx/hwpx-02.hwpx", 0);
+    let max_line = max_glyphs_on_one_baseline(&svg);
+    // 한컴 정본 첫 줄 ≈ 30자. 수정 전 crammed = 110. 60 미만이면 재래핑됨.
+    assert!(
+        max_line < 60,
+        "본문 단일-lineseg 문단이 재래핑되지 않고 한 줄에 과밀 배치됨: \
+         한 baseline 최대 {max_line}자 (한컴 정본 ≈30, 수정 전 110). #2525"
+    );
+}


### PR DESCRIPTION
## 요약

비마스킹 **단일-lineseg 과밀** 기계생성 HWPX 본문 문단을 rhwp 가 한 줄에 욱여넣어 음수 자간으로 압축 → SVG 글리프 겹침(숫자 advance 0.5× 클램프)이 발생하던 #2525 를 수정한다.

## 근인 (한컴 COM 정본 대조)

`samples/hwpx/hwpx-02.hwpx` p0 숫자 "2024" advance 실측:

| | 숫자 advance | 첫 본문 줄 글자수 |
|---|---|---|
| **한컴(정본)** | **0.590em** | **30자** (재래핑) |
| **rhwp (수정 전)** | **0.297em** | **110자** (한 줄) |

p5 문단은 lineseg 1개인데 텍스트 135자(기계생성 저장). rhwp 가 이 저장 lineseg 를 존중해 135자를 한 줄에 배치하고 컬럼 폭에 맞추려 큰 음수 자간을 적용 → 숫자는 `char_px*ratio*0.5` 최소 클램프에 걸려 0.297em, 글리프 실폭 > advance box → 겹침. 오버플로우 재래핑 게이트 `stored_lines_overflow`(composer.rs)가 마스킹(`*`≥8) 문서에만 발동해 비마스킹 과밀은 제외돼 있었다.

## 수정

`stored_lines_overflow` 에 비마스킹 분기 추가: 저장 lineseg 의 **장평 반영 실폭**(`estimate_composed_line_width` 은 ts.ratio 자체 반영)이 내폭 **≥1.8×** 면 부실 저장으로 보고 fresh 재래핑한다. 정당한 장평/자간 압축 문서(ratio 반영 실폭 ≤ 내폭)는 오발동하지 않는다. body recompose 호출부(typeset.rs:11200, paragraph_layout.rs:1866)는 기존 그대로.

수정 후 hwpx-02 p0: 첫 줄 **31자**(한컴 30), 숫자 advance **0.595em**(한컴 0.590) — 겹침 해소.

## 3중 게이트

- **92 결재문서 통제셋**: 92/92 = **100%** (변화 없음)
- **10k 모집단 페이지수**: 개선 0 / 회귀 0 / **순변화 +0** (9948문서, 측정실패 0) — 고임계(1.8×)라 prism 표본엔 트리거 문서 없음, 모집단 무회귀
- **nextest**: 3425/3425 통과 (23 skip, EXIT 0)

## 디스클로저 (페이지수 tradeoff)

hwpx-02 자체 페이지수는 6→7 (한컴 정본 5). 이 문서는 빈 p4·표/차트 과다분할 등 **본 수정과 무관한 기존 페이지네이션 부정확**을 별도로 갖고 있어(수정 전 6도 이미 5와 불일치) 재래핑으로 +1 노출됐다. #2525 는 렌더(글자 advance/겹침) 이슈이며 렌더 정확성을 우선했다. 모집단·92셋 무영향.

## 테스트

`tests/issue_2525_single_lineseg_rewrap.rs` — hwpx-02 p0 한 baseline 최대 글자수 < 60 (재래핑 확인). 샘플 `samples/hwpx/hwpx-02.hwpx` 는 저장소 기존 포함.

## 재현

`RHWP_DIAG_REWRAP=1 rhwp export-svg samples/hwpx/hwpx-02.hwpx`; 한컴 대조 `output/poc/task2525/hancom_advance.py`.
