### PR TITLE
task: kevin9327 그룹A(HWP 코어 견고성·왕복 보존) 12건 통합

### DIFF
--- a/mydocs/report/task_m100_2553_report.md
+++ b/mydocs/report/task_m100_2553_report.md
@@ -1,0 +1,78 @@
+# task_m100_2553 처리결과 보고서 — 높이 측정 경로를 조판/렌더와 정합
+
+- **이슈**: [#2553](https://github.com/edwardkim/rhwp/issues/2553)
+- **브랜치**: `task/m100-2553-height-measurer-body-recompose` (base `devel` @ `3c54abfd`)
+- **범위**: `src/renderer/height_measurer.rs` 의 recompose 분기 20줄
+- **분류**: 결함 수정 (페이지 분할 입력 오차)
+
+## 1. 문제
+
+`HeightMeasurer` 가 **본문** 문단을 측정하면서 형제 두 경로와 다르게 동작했다. 측정 결과는
+페이지네이션 입력이므로, 측정과 실제 조판이 서로 다른 줄 수·높이를 갖게 된다.
+
+### (a) cell recompose 오용
+
+`height_measurer.rs:527` 이 `recompose_for_cell_width` 를 호출한다. 형제는 모두 body 래퍼다:
+
+- `typeset.rs:11162` — 주석: `[#2279] 본문 NO_LS 는 글자모양 재분할 포함 래퍼 사용 —
+  paragraph_layout(렌더)와 동일 (측정/렌더 줄수·pitch 정합)`
+- `paragraph_layout.rs:1907`
+
+body 는 cell 의 strict superset 이다(`composer.rs`):
+
+```rust
+pub fn recompose_for_body_width(...) {
+    restyle_fallback_runs_by_char_shapes(composed, para);   // 측정 경로가 빠뜨린 부분
+    recompose_for_cell_width(composed, para, column_inner_width_px, styles);
+}
+```
+
+`restyle_fallback_runs_by_char_shapes` 는 `compose_lines` NO_LS 폴백이 만든 단일
+`default_style_id` run 을 실제 글자모양으로 재분할하는 유일한 지점이다. 빠지면 혼합 글자모양
+문단(15pt 도입부 + 14pt 본문 등)을 전부 도입부 크기로 측정해 폭이 과대해지고, 줄별 `max_fs`
+가 일괄 15pt 라 `Percent` 줄간격 기준까지 부풀어 누적 높이 오차가 생긴다.
+
+### (b) 도달 불가 분기
+
+`height_measurer.rs:521` 이 `para.line_segs.is_empty()` 를 **match guard** 에 올려, 저장
+line_segs 가 있는 문단은 곧장 `_ => None` 으로 떨어졌다. 형제는 같은 술어를 arm 본문에 두고
+`else if` 로 stale 재래핑을 잇는다(`typeset.rs:11158-11182`,
+`paragraph_layout.rs:1913-1930`). `recompose_stored_lines_if_overflowing_body` 의 호출부는
+그 두 곳뿐이었고 측정 경로에는 대응물이 없었다 — 즉 기능이 구조적으로 도달 불가였다.
+
+마스킹 문단에서 조판/렌더는 stale 분할을 버리고 재래핑하는데 측정은 저장 분할을 유지하므로
+`line_heights` 의 줄 수 자체가 달라져 `PartialParagraph` 시작/끝 줄 인덱스가 어긋난다.
+
+## 2. 변경
+
+두 결함이 같은 블록에서 각각 갈라진 것이라, `typeset.rs:11153-11185` 구조를 통째로 이식했다.
+
+1. guard 의 `para.line_segs.is_empty()` 를 arm 본문으로 이동
+2. NO_LS 경로를 `recompose_for_body_width` 로 교체
+3. `else if masked_stored_lines_stale(...)` → `recompose_stored_lines_if_overflowing_body`
+   분기 추가
+
+## 3. 검증
+
+페이지 분할 입력을 바꾸는 변경이라 회귀를 넓게 확인했다.
+
+| 스위트 | 결과 |
+|---|---|
+| `cargo test --lib renderer` | **862 passed / 0 failed** |
+| `cargo test --lib document_core` | **254 passed / 0 failed** |
+| `cargo test --lib` (전체) | **2377 passed / 0 failed / 7 ignored** |
+
+측정 경로를 조판 경로와 동일하게 만드는 변경이므로, 두 경로가 이미 일치하던 문서에서는 동작이
+바뀌지 않는다(전체 무회귀가 이를 뒷받침한다). 어긋나 있던 문단에서만 측정이 조판을 따라간다.
+
+### 미실행 항목 (투명 고지)
+
+- **전용 red→green 단위 테스트 미추가**. 이 결함은 "측정과 조판이 서로 다른 값을 낸다" 는
+  경로 간 불일치라, 단언하려면 `measure_section` 결과와 조판 결과를 같은 문단에 대해 비교하는
+  하네스가 필요하다. 현재 `height_measurer` 에는 그런 교차 비교 하네스가 없다. 대신 근거는
+  ① 형제 두 경로의 코드와 `[#2279]` 주석이 "측정/렌더 정합" 을 이 래퍼의 목적으로 명시,
+  ② body 가 cell 의 strict superset 이라는 정의, ③ 전체 2377건 무회귀다.
+  하네스를 세워 교차 비교 테스트까지 넣기를 원하시면 별도로 진행하겠다.
+- **PR CI 전체 검증**(`cargo clippy -- -D warnings`, visual sweep): 저장소 규약상 작업지시자
+  별도 승인 사항이라 실행하지 않았다. 렌더 출력 경로를 바꾸는 변경이므로 visual sweep 판단이
+  필요하면 지시 바란다.

--- a/mydocs/report/task_m100_2555_report.md
+++ b/mydocs/report/task_m100_2555_report.md
@@ -1,0 +1,66 @@
+# task_m100_2555 처리결과 보고서 — 이웃 셀 BorderFill push 시 DocInfo 패스스루 무효화
+
+- **이슈**: [#2555](https://github.com/edwardkim/rhwp/issues/2555)
+- **브랜치**: `task/m100-2555-neighbor-border-docinfo-dirty` (base `devel` @ `3c54abfd`)
+- **범위**: `src/document_core/commands/table_ops.rs` `update_neighbor_borders` 1줄 + 테스트
+- **분류**: 결함 수정 (저장 시 dangling border_fill_id)
+
+## 1. 문제
+
+`update_neighbor_borders` 가 새 `BorderFill` 을 DocInfo 에 push 하면서 **DocInfo 패스스루를
+무효화하지 않았다**. 이 함수는 섹션 스트림만 지우는데(`:971`), 섹션과 DocInfo 는 서로 다른
+패스스루 계층이다.
+
+직렬화 근거(`src/serializer/doc_info.rs:23-33`): `!raw_stream_dirty` 이고 `raw_stream` 이
+`Some` 이면 **DocInfo 스트림 전체를 원본 그대로 반환**한다. 따라서 push 된 `BORDER_FILL`
+레코드는 기록되지 않고 `ID_MAPPINGS` 도 여전히 N 개인데, 본문에는 `border_fill_id = N+1` 이
+쓰인다(`:1347`) → 재열기 시 **범위 밖 id**.
+
+## 2. 분석 — 규약이 아니라 누락
+
+형제 호출부는 모두 무효화한다. 즉 이 코드가 규약을 벗어난 것이다.
+
+| 호출부 | 무효화 |
+|---|---|
+| `object_ops/table.rs:451` | `raw_stream = None` |
+| `html_table_import.rs:769-770` | `raw_stream_dirty = true` |
+| `html_import.rs:923, 988` | `raw_stream_dirty = true` |
+| **`table_ops.rs:1337`** | **없음 ← 결함** |
+
+도달 가능성: `create_border_fill_from_json` 은 dedup 히트에서 dirty 를 세우지 않고 조기
+반환한다(`html_table_import.rs:761-765`). 실제 .hwp 는 BORDER_FILL 을 10개 이상 갖고 있어
+dedup 히트가 흔하므로, "대상 셀은 dedup 히트(무효화 없음) + 이웃 셀은 새 조합(push)" 조합이
+자연스럽게 발생한다.
+
+## 3. 변경
+
+`table_ops.rs` push 직후 `self.document.doc_info.raw_stream_dirty = true;` 1줄 추가.
+
+## 4. 검증
+
+### red→green 실증
+
+`neighbor_border_push_marks_doc_info_dirty` 추가 — 파싱된 문서 상태(`raw_stream = Some(..)`,
+`raw_stream_dirty = false`)를 재현하고 새 조합을 만든 뒤, BorderFill 이 push 되었고
+`raw_stream_dirty` 가 섰는지 단언한다.
+
+- 수정 제거 시 → **FAILED** (`DocInfo 패스스루가 무효화되지 않으면 …` 로 panic)
+- 복원 시 → **2 passed**
+
+> 검증 과정 기록: 처음에 `perl` 로 수정을 제거해 RED 를 확인하려 했으나 저장소가 CRLF 라
+> `$` 앵커가 매칭되지 않아 **수정이 제거되지 않은 채 통과**했다. 이를 오탐 신호로 보고
+> 프로덕션 코드의 `raw_stream_dirty = true` 발생 개수를 세어 원인을 특정한 뒤, 편집기로
+> 정확히 제거해 RED 를 재확인했다.
+
+### 회귀
+
+`cargo test --lib document_core` → **255 passed / 0 failed**.
+
+### 미실행 항목 (투명 고지)
+
+- **저장→재파싱 왕복 테스트 미추가.** 이슈 본문에 적었던 "export → from_bytes → 이웃 셀 id 가
+  범위 내로 해소" 까지 확인하려면 유효한 CFB 왕복 픽스처가 필요하다. 본 PR 은 결함의 직접
+  원인인 무효화 누락을 단언하는 데 그쳤다(그 지점이 red→green 으로 갈리는 유일한 지점이다).
+  왕복 하네스까지 원하시면 별도로 진행하겠다.
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다.

--- a/mydocs/report/task_m100_2557_report.md
+++ b/mydocs/report/task_m100_2557_report.md
@@ -1,0 +1,61 @@
+# task_m100_2557 처리결과 보고서 — 스타일/번호 JSON 이스케이프 정합
+
+- **이슈**: [#2557](https://github.com/edwardkim/rhwp/issues/2557)
+- **브랜치**: `task/m100-2557-style-json-escape` (base `devel` @ `3c54abfd`)
+- **범위**: `src/wasm_api.rs` JSON 방출 5곳
+- **분류**: 결함 수정 (깨진 JSON → 편집기 예외)
+
+## 1. 문제
+
+스타일·번호 정의 JSON 방출부가 **큰따옴표만** 이스케이프했다. 역슬래시·개행·탭이 든 이름이면
+문법적으로 깨진 JSON 이 나오고, TS 측은 가드 없이 `JSON.parse` 하므로 **예외**가 난다.
+
+같은 파일에 올바른 헬퍼(`json_escape`, `helpers.rs:825` — `\ " \n \r \t` 처리)가 있고
+`wasm_api.rs:4866-4868` 이 이미 쓰고 있었다. 아래 5곳만 누락이었다.
+
+| 위치 | 함수 |
+|---|---|
+| `wasm_api.rs:5610`, `:5611` | `getStyleList` (local_name, english_name) |
+| `wasm_api.rs:5979` | `getNumberingList` (level_formats) |
+| `wasm_api.rs:6180`, `:6216` | `getStyleAt` + 셀 내 변형 |
+
+## 2. 영향
+
+HWP 스타일 이름에 역슬래시·개행은 적법하며 템플릿 문서에서 드물지 않다.
+
+- `JSON.parse` 가 **throw** 한다(값 이상이 아니라 예외).
+- 호출부에 try/catch 가 없다 — `ui/style-dialog.ts:137`, `ui/toolbar.ts:548`,
+  `engine/input-handler.ts:4397`.
+- `getStyleAt` 은 **커서 이동마다** 호출된다(`input-handler.ts:2060`, `:4386`, `:4524`)
+  → 해당 문서에서 **키 입력마다 예외**가 나고 스타일 드롭다운·툴바가 채워지지 않는다.
+
+## 3. 변경
+
+5곳을 `json_escape(...)` 로 교체. 새 헬퍼를 만들지 않고 기존 것을 재사용했다.
+
+**범위 밖으로 남긴 것**: `wasm_api.rs:4646`, `:4675`, `:4699`, `:5434` 는 역슬래시까지 2단계로
+처리해(개행만 미처리) 위험도가 낮고 오류 메시지/키 경로다. 기존 테스트 기대값에 영향을 줄 수
+있어 건드리지 않았다.
+
+## 4. 검증
+
+### red→green 실증
+
+`style_json_survives_backslash_and_control_chars` 추가 — 스타일 이름에
+`a\b`(역슬래시) + 개행 + 탭 + 큰따옴표를 넣고 `get_style_list()` / `get_style_at()` 결과가
+`serde_json` 으로 파싱되는지, 그리고 왕복 후 원래 이름이 복원되는지 단언한다.
+
+- `:5610` 을 나이브 이스케이프로 되돌리면 → **FAILED**
+- 복원하면 → **passed**
+
+### 회귀
+
+`cargo test --lib wasm_api` 통과.
+
+### 미실행 항목 (투명 고지)
+
+- **TS 측 행위 검증 미실행** — 실제 편집기에서 키 입력마다 예외가 사라지는지는 브라우저
+  왕복이 필요하다. 본 PR 은 근본 원인(Rust 방출부)을 고치고 Rust 단에서 JSON 유효성을
+  단언하는 데 그쳤다.
+- **PR CI 전체 검증**(`cargo clippy -- -D warnings` 등): 저장소 규약상 작업지시자 별도 승인
+  사항이라 실행하지 않았다.

--- a/mydocs/report/task_m100_2563_report.md
+++ b/mydocs/report/task_m100_2563_report.md
@@ -1,0 +1,68 @@
+# task_m100_2563 처리결과 보고서 — 도형 이미지 채우기 왕복 정합
+
+- **이슈**: [#2563](https://github.com/edwardkim/rhwp/issues/2563)
+- **브랜치**: `task/m100-shape-imgbrush` (base `devel` @ `3c54abfd`)
+- **범위**: `src/parser/hwpx/section.rs` `parse_shape_fill_brush`
+- **분류**: 결함 수정 (이미지 도형이 빈 도형으로 왕복)
+
+## 1. 문제
+
+도형(`<hp:rect>` 등)의 `<hc:imgBrush>` 파서가 헤더(borderFill) 파서보다 얕았다.
+**같은 파일·같은 IR** 인데 한쪽만 온전한 비대칭이다.
+
+### 결함 1 — `<hc:img>` 자식 미처리로 그림 참조 유실
+
+`b"imgBrush"` arm 이 `mode` 만 읽고 `<hc:img>` 자식 arm 이 없어
+`binaryItemIDRef`·`bright`·`contrast`·`effect` 가 전부 버려졌다.
+
+직렬화(`serializer/hwpx/shape.rs:837-877`)는 이 값들을 방출할 능력이 있지만
+`img.bin_data_id` 가 항상 0 이라 `resolve_bin_id` 가 `None` 을 반환해
+`<hc:imgBrush mode="…"/>` 만 나갔다. → **이미지로 채운 도형이 왕복 후 빈 도형**.
+
+serializer 주석(`shape.rs:846-848`)이 이 결함을 이미 지목하고 있었다
+("body shape 의 fill 파서가 bin_data_id 미캡처").
+
+### 결함 2 — 채우기 모드 12종 중 8종이 TILE 로 붕괴
+
+도형 파서는 4종만 매핑하고 나머지는 `_ => TileAll`. 헤더 파서
+(`header.rs:1490-1503`)는 `TOTAL`, `TILE_HORZ_*`, `TILE_VERT_*`, `CENTER_*`,
+`TOP_LEFT_ALIGN` 까지 전부 매핑한다. → `mode="TOTAL"`(늘여서 채우기)이 `TILE` 로.
+
+## 2. 분석 — 같은 코드베이스의 선례를 그대로 이식
+
+새 규약을 만들지 않았다. 헤더 파서가 이미 정답을 갖고 있어 그 매핑과 `b"img"` arm
+처리를 도형 파서에 맞췄다. `b"color"` arm 이 "부모 뒤에 오는 자식" 처리 패턴을
+이미 보여주고 있어 구조도 동일하다.
+
+IR 근거: `Fill.image: Option<ImageFill>` → `ImageFill { bin_data_id, brightness,
+contrast, effect, fill_mode }`(`model/style.rs:655-666`). 네 필드 모두 존재하며
+헤더 경로에서는 정상 채워진다 — **도형 경로만의 결함**임이 증명된다.
+
+## 3. 변경
+
+`parse_shape_fill_brush` 한 함수:
+1. `mode` 매핑을 헤더와 동일한 12종으로 확장
+2. `b"img" | b"image"` arm 추가(헤더의 동명 arm 과 동형)
+
+## 4. 검증
+
+### red→green 실증
+
+`test_shape_img_brush_preserves_image_ref_and_mode` 추가 —
+`<hc:imgBrush mode="TOTAL"><hc:img binaryItemIDRef="image3" bright="10"
+contrast="-5" effect="GRAY_SCALE"/>` 를 파싱해 5개 필드를 단언.
+
+- `b"img"` arm 을 비활성화하면 → **FAILED** (`bin_data_id` left: 0, right: 3)
+- 복원하면 → **passed**
+
+### 회귀
+
+`cargo test --lib parser::hwpx` 통과.
+
+### 미실행 항목 (투명 고지)
+
+- **왕복 직렬화 단언 미포함** — 파싱이 IR 을 채우면 직렬화는 기존 코드가 그대로
+  방출하므로(그 경로는 이미 구현돼 있고 주석이 파서만 지목했다), red→green 이
+  갈리는 지점인 파싱을 단언하는 데 그쳤다. 직렬화 왕복까지 원하시면 추가하겠다.
+- **시각 검증 미실행** — 이미지 채우기 렌더 결과 비교는 visual sweep 이 필요하다.
+  저장소 규약상 작업지시자 승인 사항이라 실행하지 않았다.

--- a/mydocs/report/task_m100_2632_report.md
+++ b/mydocs/report/task_m100_2632_report.md
@@ -1,0 +1,82 @@
+# task_m100_2632 처리결과 보고서 — HeightMeasurer 본문 재래핑 래퍼 정합
+
+- **이슈**: [#2632](https://github.com/edwardkim/rhwp/issues/2632)
+- **브랜치**: `task/m100-2632-height-measurer-body-recompose` (base `devel` @ `3c54abfd`)
+- **범위**: `src/renderer/height_measurer.rs` 한 지점
+- **분류**: 결함 수정 (측정↔렌더 불일치)
+
+## 1. 문제
+
+`HeightMeasurer::measure_paragraph` 의 본문(column) NO_LS 재래핑 분기가 형제 두 경로
+(`typeset.rs::format_paragraph`, `paragraph_layout.rs::layout_partial_paragraph`)와 **다른
+래퍼 함수**를 썼다.
+
+| 파일 | 함수 | 사용 래퍼(수정 전) |
+|---|---|---|
+| `height_measurer.rs:527` | `measure_paragraph` | `recompose_for_cell_width` |
+| `typeset.rs:11162` | `format_paragraph` | `recompose_for_body_width` |
+| `paragraph_layout.rs:1911` | `layout_partial_paragraph` | `recompose_for_body_width` |
+
+`recompose_for_body_width`(`composer.rs:1419-1427`)는 `recompose_for_cell_width` 의
+superset이다:
+```rust
+pub fn recompose_for_body_width(...) {
+    restyle_fallback_runs_by_char_shapes(composed, para);   // ← measurement 만 빠짐
+    recompose_for_cell_width(composed, para, column_inner_width_px, styles);
+}
+```
+측정 경로만 `restyle_fallback_runs_by_char_shapes` 를 건너뛰어, `compose_lines` NO_LS
+fallback 이 만든 단일 스타일 run 을 실제 글자모양별로 재분할하지 않았다.
+
+## 2. 영향
+
+`PARA_LINE_SEG` 가 없고 글자모양이 섞인 본문 문단(예: 15pt 도입부 + 14pt 본문)에서
+typeset/render 는 CharShapeRef 로 run 을 쪼개 정확히 측정하는데 `HeightMeasurer` 는 모든
+run 을 단일 스타일로 측정 → 폭/줄수/줄간격 오차가 페이지네이션 입력(`document_core/queries/
+rendering.rs:3065` `measure_section`)에 누적되어 실제 렌더 결과와 다른 쪽에서 분할됐다.
+
+## 3. 변경
+
+`src/renderer/height_measurer.rs:527` — `recompose_for_cell_width` → `recompose_for_body_width`
+(한 단어). 주변 주석을 실제 코드·형제 경로와 일치하도록 갱신.
+
+## 4. 검증
+
+### 신규 테스트 (기전 증명)
+
+`src/renderer/composer/tests.rs::body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not`
+
+`compose_lines` fallback(단일 run, char_style_id=0)을 만든 뒤 두 래퍼에 각각 통과시켜:
+- `recompose_for_cell_width` → run 이 `[0]` 그대로(재분할 없음)
+- `recompose_for_body_width` → run 이 `[0, 1]` 로 분할(두 글자모양이 드러남)
+
+임을 단언한다. `height_measurer.rs` 의 수정이 기대는 정확한 메커니즘(body 래퍼가 cell
+래퍼의 superset)을 직접 증명하는 white-box 테스트다.
+
+```
+test renderer::composer::tests::body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not ... ok
+```
+
+### 회귀
+
+```
+cargo test --lib renderer::  →  861 passed / 0 failed / 4 ignored
+```
+
+### 미실행 항목 (투명 고지)
+
+- **`measure_paragraph` 를 통한 end-to-end 회귀**: `HeightMeasurer::measure_paragraph` 가
+  `fn` (비공개)이고 `ResolvedStyleSet` 을 실제 폰트 폭 테이블까지 채워 구성해야 픽셀 단위
+  높이 차이를 직접 단언할 수 있어, 이번 검증에서는 그 대신 근본 메커니즘(composer 레벨)을
+  직접 테스트했다. 호출부 자체는 한 단어 교체이고 형제 두 경로가 이미 같은 패턴으로 검증돼
+  있어(각각 자체 테스트 보유, 861건에 포함), 추가 위험은 낮다고 판단했다.
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다.
+
+## 5. 잔여 (같은 스윕의 별건, 범위 분리)
+
+이슈 본문에 기록. 별도 이슈로 등록해 순차 처리 예정:
+- `height_measurer.rs:521` match guard 로 인해 `masked_stored_lines_stale` 재래핑 분기가
+  구조적으로 도달 불가.
+- `table_ops.rs:1337` `update_neighbor_borders` DocInfo passthrough 무효화 누락.
+- `formatting.rs:944-965` `find_or_create_font_id_for_lang` raw/IR 글꼴 불일치.

--- a/mydocs/report/task_m100_2638_report.md
+++ b/mydocs/report/task_m100_2638_report.md
@@ -1,0 +1,63 @@
+# task_m100_2638 처리결과 보고서 — update_neighbor_borders DocInfo passthrough 무효화
+
+- **이슈**: [#2638](https://github.com/edwardkim/rhwp/issues/2638)
+- **브랜치**: `task/m100-2638-neighbor-border-invalidate` (base `devel` @ `3c54abfd`)
+- **범위**: `src/document_core/commands/table_ops.rs` 한 지점
+- **분류**: 결함 수정 (dangling border_fill_id 방지)
+
+## 1. 문제
+
+`set_cell_properties` 가 이웃 셀 테두리를 갱신하는 `update_neighbor_borders`(`table_ops.rs:1337`)
+가 새 `BorderFill` 을 DocInfo 에 push 하면서 **DocInfo passthrough 를 무효화하지 않았다**.
+섹션 스트림만 지웠고(`:971`), 섹션과 DocInfo 는 서로 다른 passthrough 레이어다.
+
+`src/serializer/doc_info.rs:24-33` — `!raw_stream_dirty && raw_stream.is_some()` 이면 DocInfo
+스트림 전체를 **원본 그대로** 반환하므로, 방금 push 한 `BORDER_FILL` 레코드는 저장에서 통째로
+사라지고 `ID_MAPPINGS` 도 예전 개수를 유지한다.
+
+형제 호출부 4곳(`html_table_import.rs:769-770,904-905`, `object_ops/table.rs:450-451,885-886`)은
+모두 push 직후 무효화하므로, 이 지점만의 누락이었다.
+
+## 2. 재현 시나리오
+
+`create_border_fill_from_json` 이 dedup 히트 시 무효화 없이 조기 반환하는 경로가 있어(범위 밖):
+1. DocInfo 에 이미 일치하는 테두리 스타일이 있는 문서를 연다
+2. 셀 A 에 그 스타일 적용 → dedup 히트(무효화 없음)
+3. 이웃 셀 B 의 결합 테두리(A 의 새 변 + B 의 나머지 3변)는 새 조합이라 `update_neighbor_borders`
+   가 push → `table.cells[B].border_fill_id = N+1` 이 본문에 기록됨
+4. 저장 → DocInfo 는 N 개만 있음 → 재로드 시 이웃 셀이 **범위 밖 border_fill_id** 를 가짐
+
+## 3. 변경
+
+`table_ops.rs:1337` push 직후 `self.document.doc_info.raw_stream_dirty = true;` 추가.
+
+## 4. 검증
+
+### 신규 테스트
+
+`neighbor_border_raw_data_tests::neighbor_border_push_invalidates_doc_info_passthrough` — 파싱된
+문서를 흉내(`raw_stream = Some(...)`, `raw_stream_dirty = false`)내고 `update_neighbor_borders`
+호출 후 `raw_stream_dirty == true` 를 단언.
+
+### red→green 실증
+
+수정 라인(`raw_stream_dirty = true;`)을 제거 → **FAILED**(panic at assert). 복원 → **2건 통과**.
+
+```
+FAILED (fix 제거 시): 0 passed; 1 failed
+GREEN (fix 복원 후):  2 passed; 0 failed
+```
+
+### 회귀
+
+```
+cargo test --lib document_core::commands::table_ops  →  5 passed / 0 failed
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다.
+- `create_border_fill_from_json` 의 dedup-hit 무효화 보강(이슈 본문의 "보강" 항목)은 **본 PR
+  범위에 포함하지 않았다** — 이슈에서 지목한 핵심 누락(`table_ops.rs:1337`)만 최소 수정했다.
+  필요시 별도 이슈로 처리한다.

--- a/mydocs/report/task_m100_2648_report.md
+++ b/mydocs/report/task_m100_2648_report.md
@@ -1,0 +1,68 @@
+# task_m100_2648 처리결과 보고서 — 머리말/꼬리말 LIST_HEADER 페이로드 파싱
+
+- **이슈**: [#2648](https://github.com/edwardkim/rhwp/issues/2648)
+- **브랜치**: `task/m100-2648-headerfooter-listheader` (base `devel` @ `3c54abfd`)
+- **범위**: `src/parser/control.rs`
+- **분류**: 결함 수정 (파서 누락)
+
+## 1. 문제
+
+`find_list_header_paragraphs`(파서)가 `HWPTAG_LIST_HEADER` 자식 레코드를 찾아 **그 뒤의
+문단들만** 파싱하고, 레코드 자체의 페이로드(`list_attr`/`text_width`/`text_height`/
+`text_ref`/`num_ref`)는 전혀 읽지 않았다. `parse_header_control`/`parse_footer_control`
+이 이 함수만 호출하므로 `Header`/`Footer` 의 다섯 필드는 항상 `Default`(0)였다.
+
+직렬화(`build_header_footer_list_header`, `serializer/control.rs:2340`)는 이 필드들을
+무조건 사용해 `HWPTAG_LIST_HEADER` 레코드를 재생성하므로, 실제 파일이 담고 있던 값은
+파싱→직렬화 왕복마다 0 으로 뭉개졌다.
+
+같은 파일의 캡션 파서(`:427-431`)는 이미 이 레코드 페이로드를 읽는데, 머리말/꼬리말만
+빠진 비대칭이었다.
+
+## 2. 변경
+
+`find_list_header_paragraphs` 옆에 `find_list_header_layout_and_paragraphs` 를 신설 —
+직렬화 함수(`build_header_footer_list_header`)의 바이트 레이아웃을 역으로 읽어 레이아웃
+필드와 문단을 함께 반환한다:
+```
+u16 para_count | u32 list_attr | u16(예약) | u32 text_width | u32 text_height
+| u8 text_ref | u8 num_ref | u16 ext_flags | [u8;14] 예약
+```
+`parse_header_control`/`parse_footer_control` 양쪽에서 새 함수로 교체하고 다섯 필드를
+채웠다. 기존 `find_list_header_paragraphs` 는 각주/미주/숨은설명 파서가 여전히 쓰므로
+그대로 유지(불필요한 범위 확장 방지).
+
+## 3. 검증
+
+### 신규 테스트
+
+`test_parse_header_control_reads_list_header_layout_fields` — 비영 `list_attr`
+(`0x00020000`), `text_width=5000`, `text_height=3000`, `text_ref=7`, `num_ref=9` 를
+담은 LIST_HEADER 레코드를 파싱해 다섯 값이 그대로 읽힘을 단언.
+
+### red→green 실증
+
+필드 대입 5줄을 제거(`let (_layout, paragraphs) = ...; header.paragraphs = paragraphs;`)
+→ **FAILED**(`assertion left==right failed: list_attr 이 보존돼야 함`). 복원 → **통과**.
+
+```
+FAILED (수정 제거): 0 passed; 1 failed
+GREEN  (수정 복원): parser::control 18 passed; 0 failed
+```
+
+### 회귀
+
+```
+cargo test --lib parser::      →  390 passed / 0 failed
+cargo test --lib serializer::  →  403 passed / 0 failed
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소
+  규약상 작업지시자 별도 승인 사항이라 실행하지 않았다.
+- **parse→serialize→parse 완전 왕복 테스트**는 추가하지 않았다. 새 파서 함수가 직렬화
+  함수(`build_header_footer_list_header`)의 정확한 역함수임을 바이트 단위로 대조
+  확인했고(오프셋·길이 일치), 단위 테스트로 각 필드의 파싱을 직접 검증했다. 완전 왕복
+  테스트는 기존 저장소에 header/footer 전용 parse↔serialize 하네스가 마련돼 있지 않아
+  범위를 넘는다고 판단했다.

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -1335,6 +1335,13 @@ impl DocumentCore {
                     Some(id) => id,
                     None => {
                         self.document.doc_info.border_fills.push(new_bf);
+                        // [#2555] DocInfo 패스스루 무효화. 이 함수는 섹션 스트림만
+                        // 지우는데 섹션과 DocInfo 는 별개 계층이라, 이게 없으면
+                        // serialize_doc_info 가 원본 스트림을 그대로 반환해
+                        // (serializer/doc_info.rs:23-33) 새 BORDER_FILL 이 저장되지 않고
+                        // 본문의 border_fill_id 만 범위를 벗어난다. 형제 호출부
+                        // (object_ops/table.rs:451, html_table_import.rs:769)는 모두 무효화한다.
+                        self.document.doc_info.raw_stream_dirty = true;
                         self.document.doc_info.border_fills.len() as u16
                     }
                 }
@@ -3124,5 +3131,53 @@ mod neighbor_border_raw_data_tests {
             "이웃 셀 기준 좌측 테두리가 갱신돼야 함"
         );
         assert!(matches!(bf.borders[0].line_type, BorderLineType::Double));
+    }
+
+    /// [#2555] 새 BorderFill push 시 DocInfo 패스스루를 무효화해야 한다.
+    ///
+    /// 이 함수는 섹션 스트림만 지우는데 섹션과 DocInfo 는 별개 계층이다.
+    /// 무효화가 없으면 serialize_doc_info 가 원본 스트림을 그대로 반환해
+    /// (serializer/doc_info.rs:23-33) 새 BORDER_FILL 이 저장되지 않고, 본문의
+    /// border_fill_id 만 범위를 벗어나 dangling 이 된다.
+    #[test]
+    fn neighbor_border_push_marks_doc_info_dirty() {
+        let mut core = core_with_two_cell_row();
+        // 파싱된 문서 상태 재현: 원본 DocInfo 스트림이 있고 아직 깨끗하다.
+        core.document.doc_info.raw_stream = Some(vec![0xCC; 64]);
+        core.document.doc_info.raw_stream_dirty = false;
+        let before_len = core.document.doc_info.border_fills.len();
+
+        let new_border = BorderLine {
+            line_type: BorderLineType::Double,
+            width: 3,
+            color: 0x00FF0000,
+        };
+        core.update_neighbor_borders(
+            0,
+            0,
+            0,
+            0,
+            0,
+            0,
+            1,
+            1,
+            &[
+                BorderLine::default(),
+                new_border,
+                BorderLine::default(),
+                BorderLine::default(),
+            ],
+        );
+
+        assert_eq!(
+            core.document.doc_info.border_fills.len(),
+            before_len + 1,
+            "새 조합이므로 BorderFill 이 push 돼야 함(전제 확인)"
+        );
+        assert!(
+            core.document.doc_info.raw_stream_dirty,
+            "DocInfo 패스스루가 무효화되지 않으면 push 한 BORDER_FILL 이 저장되지 않아 \
+             본문의 border_fill_id 가 dangling 이 된다"
+        );
     }
 }

--- a/src/document_core/queries/cursor_rect.rs
+++ b/src/document_core/queries/cursor_rect.rs
@@ -2630,7 +2630,12 @@ impl DocumentCore {
         ) -> Option<CursorHit> {
             if let RenderNodeType::TextRun(ref text_run) = node.node_type {
                 let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+                    // path 길이 일치를 계약으로 명시한다.
                     ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                         && ctx.path[0].cell_para_index == cp_idx
@@ -2720,7 +2725,12 @@ impl DocumentCore {
         ) -> Option<(f64, f64, f64)> {
             if let RenderNodeType::TextRun(ref text_run) = node.node_type {
                 let matches_cell = text_run.cell_context.as_ref().map_or(false, |ctx| {
+                    // path.len()==1 가드가 없으면 중첩 표 *내부* 셀의 run 도
+                    // 매칭된다: 내부 run 의 path[0] 은 그 중첩 표를 품은 바깥 셀과
+                    // 정확히 같기 때문이다. 같은 파일의 cell_context_matches 가
+                    // path 길이 일치를 계약으로 명시한다.
                     ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                         && ctx.path[0].cell_para_index == cp_idx
@@ -2847,7 +2857,11 @@ impl DocumentCore {
             let mut result: Option<usize> = None;
             if let RenderNodeType::TextRun(ref tr) = node.node_type {
                 if let Some(ref ctx) = tr.cell_context {
+                    // 위와 동일 근거의 path.len()==1 가드. 이 함수는 max 를 취하므로
+                    // 중첩 표 내부 run 이 섞이면 바깥 셀이 실제로 그려지지 않은
+                    // 페이지에서도 "그려졌다"고 보고해 캐럿 클램프가 어긋난다.
                     if ctx.parent_para_index == parent_para
+                        && ctx.path.len() == 1
                         && ctx.path[0].control_index == ctrl_idx
                         && ctx.path[0].cell_index == c_idx
                     {

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -487,7 +487,13 @@ fn parse_header_control(ctrl_data: &[u8], child_records: &[Record]) -> Control {
         }
     }
 
-    header.paragraphs = find_list_header_paragraphs(child_records);
+    let (layout, paragraphs) = find_list_header_layout_and_paragraphs(child_records);
+    header.list_attr = layout.list_attr;
+    header.text_width = layout.text_width;
+    header.text_height = layout.text_height;
+    header.text_ref = layout.text_ref;
+    header.num_ref = layout.num_ref;
+    header.paragraphs = paragraphs;
 
     Control::Header(Box::new(header))
 }
@@ -511,7 +517,13 @@ fn parse_footer_control(ctrl_data: &[u8], child_records: &[Record]) -> Control {
         }
     }
 
-    footer.paragraphs = find_list_header_paragraphs(child_records);
+    let (layout, paragraphs) = find_list_header_layout_and_paragraphs(child_records);
+    footer.list_attr = layout.list_attr;
+    footer.text_width = layout.text_width;
+    footer.text_height = layout.text_height;
+    footer.text_ref = layout.text_ref;
+    footer.num_ref = layout.num_ref;
+    footer.paragraphs = paragraphs;
 
     Control::Footer(Box::new(footer))
 }
@@ -774,6 +786,55 @@ fn find_list_header_paragraphs(
         idx += 1;
     }
     Vec::new()
+}
+
+/// 머리말/꼬리말 LIST_HEADER 레코드 페이로드.
+///
+/// [#2648] `find_list_header_paragraphs` 는 레코드 뒤의 문단만 파싱하고 레코드
+/// 자체의 페이로드(list_attr/text_width/text_height/text_ref/num_ref)는 읽지
+/// 않았다. 직렬화(`build_header_footer_list_header`, serializer/control.rs)는
+/// 이 값들을 무조건 사용하므로 저장 왕복마다 0 으로 뭉개졌다. 바이트 레이아웃은
+/// 그 직렬화 함수의 역이다:
+/// u16 para_count | u32 list_attr | u16(예약) | u32 text_width | u32 text_height
+/// | u8 text_ref | u8 num_ref | u16 ext_flags | [u8;14] 예약
+struct HeaderFooterListLayoutFields {
+    list_attr: u32,
+    text_width: u32,
+    text_height: u32,
+    text_ref: u8,
+    num_ref: u8,
+}
+
+fn find_list_header_layout_and_paragraphs(
+    child_records: &[Record],
+) -> (
+    HeaderFooterListLayoutFields,
+    Vec<crate::model::paragraph::Paragraph>,
+) {
+    let mut layout = HeaderFooterListLayoutFields {
+        list_attr: 0,
+        text_width: 0,
+        text_height: 0,
+        text_ref: 0,
+        num_ref: 0,
+    };
+    let mut idx = 0;
+    while idx < child_records.len() {
+        if child_records[idx].tag_id == tags::HWPTAG_LIST_HEADER {
+            let mut r = ByteReader::new(&child_records[idx].data);
+            let _para_count = r.read_u16().unwrap_or(0);
+            layout.list_attr = r.read_u32().unwrap_or(0);
+            let _reserved = r.read_u16().unwrap_or(0);
+            layout.text_width = r.read_u32().unwrap_or(0);
+            layout.text_height = r.read_u32().unwrap_or(0);
+            layout.text_ref = r.read_u8().unwrap_or(0);
+            layout.num_ref = r.read_u8().unwrap_or(0);
+            let paragraphs = parse_paragraph_list(&child_records[idx + 1..]);
+            return (layout, paragraphs);
+        }
+        idx += 1;
+    }
+    (layout, Vec::new())
 }
 
 // ============================================================

--- a/src/parser/control/tests.rs
+++ b/src/parser/control/tests.rs
@@ -109,6 +109,43 @@ fn test_parse_header_control() {
     }
 }
 
+/// [#2648] 머리말 LIST_HEADER 레코드 페이로드(list_attr/text_width/text_height/
+/// text_ref/num_ref)가 파싱돼야 한다. 종전엔 레코드 뒤 문단만 읽고 페이로드
+/// 자체는 무시해 이 필드들이 항상 0 이었다.
+#[test]
+fn test_parse_header_control_reads_list_header_layout_fields() {
+    let mut ctrl_data = Vec::new();
+    ctrl_data.extend_from_slice(&0u32.to_le_bytes()); // attr: Both
+
+    let mut list_data = Vec::new();
+    list_data.extend_from_slice(&1u16.to_le_bytes()); // n_paragraphs
+    list_data.extend_from_slice(&0x0002_0000u32.to_le_bytes()); // list_attr (비영)
+    list_data.extend_from_slice(&0u16.to_le_bytes()); // 예약
+    list_data.extend_from_slice(&5000u32.to_le_bytes()); // text_width
+    list_data.extend_from_slice(&3000u32.to_le_bytes()); // text_height
+    list_data.push(7); // text_ref
+    list_data.push(9); // num_ref
+    list_data.extend_from_slice(&0u16.to_le_bytes()); // ext_flags
+    list_data.extend_from_slice(&[0u8; 14]); // 예약
+
+    let child_records = vec![
+        make_record(tags::HWPTAG_LIST_HEADER, 2, list_data),
+        make_record(tags::HWPTAG_PARA_HEADER, 3, make_para_header_data(6)),
+        make_record(tags::HWPTAG_PARA_TEXT, 4, make_para_text_data("머리말")),
+    ];
+
+    let ctrl = parse_header_control(&ctrl_data, &child_records);
+    let Control::Header(header) = ctrl else {
+        panic!("Expected Header control");
+    };
+    assert_eq!(header.list_attr, 0x0002_0000, "list_attr 이 보존돼야 함");
+    assert_eq!(header.text_width, 5000, "text_width 가 보존돼야 함");
+    assert_eq!(header.text_height, 3000, "text_height 가 보존돼야 함");
+    assert_eq!(header.text_ref, 7, "text_ref 가 보존돼야 함");
+    assert_eq!(header.num_ref, 9, "num_ref 가 보존돼야 함");
+    assert_eq!(header.paragraphs.len(), 1);
+}
+
 #[test]
 fn test_parse_footer_control() {
     let mut ctrl_data = Vec::new();

--- a/src/parser/crypto.rs
+++ b/src/parser/crypto.rs
@@ -399,12 +399,17 @@ fn read_first_record(data: &[u8]) -> Result<Record, String> {
     }
 
     let pos = cursor.position() as usize;
-    if pos + size as usize > data.len() {
+    // record.rs 와 동일 근거: wasm32(usize 32비트)에서 `pos + size` 랩어라운드로
+    // 경계 검사가 무력화되는 것을 checked_add 로 막는다.
+    if pos
+        .checked_add(size as usize)
+        .map_or(true, |end| end > data.len())
+    {
         return Err(format!(
             "레코드 데이터 부족: tag={}, 필요={}, 가용={}",
             tag_id,
             size,
-            data.len() - pos
+            data.len().saturating_sub(pos)
         ));
     }
 

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -909,6 +909,34 @@ mod tests {
         );
     }
 
+    #[test]
+    fn face_name_roundtrips_subst_font_as_alt_name() {
+        use crate::model::style::SubstFont;
+        // HWPX 파서는 대체 글꼴을 subst_font 로 채우고 alt_name 은 None 으로 둔다.
+        // HWP5 FACE_NAME 은 alt_name 한 곳에만 담으므로, 직렬화가 두 출처를 합치지
+        // 않으면 HWPX→HWP5 저장에서 대체 글꼴이 통째로 사라진다.
+        let font = crate::model::style::Font {
+            name: "굴림".to_string(),
+            alt_name: None,
+            subst_font: Some(SubstFont {
+                face: "맑은 고딕".to_string(),
+                font_type: 1,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+
+        let bytes = crate::serializer::doc_info::serialize_face_name(&font);
+        assert_eq!(bytes[0] & 0x80, 0x80, "대체 글꼴 있으면 attr bit7 이 서야 함");
+
+        let parsed = parse_face_name(&bytes).expect("FACE_NAME 재파싱");
+        assert_eq!(
+            parsed.alt_name.as_deref(),
+            Some("맑은 고딕"),
+            "subst_font 의 대체 글꼴이 HWP5 왕복에서 보존돼야 함"
+        );
+    }
+
     // 레코드 바이트 생성 헬퍼
     fn make_record(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8> {
         let size = data.len() as u32;

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -927,7 +927,11 @@ mod tests {
         };
 
         let bytes = crate::serializer::doc_info::serialize_face_name(&font);
-        assert_eq!(bytes[0] & 0x80, 0x80, "대체 글꼴 있으면 attr bit7 이 서야 함");
+        assert_eq!(
+            bytes[0] & 0x80,
+            0x80,
+            "대체 글꼴 있으면 attr bit7 이 서야 함"
+        );
 
         let parsed = parse_face_name(&bytes).expect("FACE_NAME 재파싱");
         assert_eq!(

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5756,7 +5756,8 @@ fn parse_hp_chart_element(
         }
     }
 
-    parse_common_shape_children(reader, &mut common, b"chart")?;
+    let mut extent: Option<(i32, i32)> = None;
+    parse_common_shape_children(reader, &mut common, b"chart", &mut extent)?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -5769,8 +5770,10 @@ fn parse_hp_chart_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.bin_data_id = 60000u32 + chart_num as u32;
-    ole.extent_x = 7200;
-    ole.extent_y = 7200;
+    // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
+    let (ext_x, ext_y) = extent.unwrap_or((7200, 7200));
+    ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
+    ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
@@ -5784,15 +5787,28 @@ fn parse_hp_ole_element(
 ) -> Result<Option<Control>, HwpxError> {
     use crate::model::shape::OleShape;
 
+    use crate::model::shape::OleDrawingAspect;
+
     let mut common = CommonObjAttr::default();
     common.hwp5_gen_shape_attr_bit26 = true;
     let mut bin_id: u32 = 0;
     let mut numbering_type_picture = false;
+    let mut draw_aspect = OleDrawingAspect::default();
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
             b"numberingType" => {
                 numbering_type_picture = attr_str(&attr).eq_ignore_ascii_case("PICTURE");
+            }
+            // 표시 방식(아이콘/썸네일/인쇄용/내용). serializer 는 방출하나 종전엔
+            // 파서가 읽지 않아 ICON 등이 왕복 시 CONTENT 로 바뀌었다.
+            b"drawAspect" => {
+                draw_aspect = match attr_str(&attr).as_str() {
+                    "ICON" => OleDrawingAspect::Icon,
+                    "THUMBNAIL" => OleDrawingAspect::Thumbnail,
+                    "DOCPRINT" => OleDrawingAspect::DocPrint,
+                    _ => OleDrawingAspect::Content,
+                };
             }
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
@@ -5824,7 +5840,8 @@ fn parse_hp_ole_element(
         }
     }
 
-    parse_common_shape_children(reader, &mut common, b"ole")?;
+    let mut extent: Option<(i32, i32)> = None;
+    parse_common_shape_children(reader, &mut common, b"ole", &mut extent)?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -5833,8 +5850,11 @@ fn parse_hp_ole_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.bin_data_id = bin_id;
-    ole.extent_x = 7200;
-    ole.extent_y = 7200;
+    ole.drawing_aspect = draw_aspect;
+    // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
+    let (ext_x, ext_y) = extent.unwrap_or((7200, 7200));
+    ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
+    ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
@@ -5877,6 +5897,9 @@ fn parse_common_shape_children(
     reader: &mut Reader<&[u8]>,
     common: &mut CommonObjAttr,
     end_tag: &[u8],
+    // OLE 전용 `<hc:extent>`(원본 개체 크기) 수집용. 호출자(ole/chart)만 사용한다.
+    // 종전엔 이 자식을 무시하고 호출자가 7200 을 하드코딩해 개체 크기가 유실됐다.
+    extent_out: &mut Option<(i32, i32)>,
 ) -> Result<(), HwpxError> {
     let mut buf = Vec::new();
     loop {
@@ -5885,6 +5908,18 @@ fn parse_common_shape_children(
                 let cname = ce.name();
                 let local = local_name(cname.as_ref());
                 match local {
+                    b"extent" => {
+                        let mut x = 0i32;
+                        let mut y = 0i32;
+                        for attr in ce.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"x" => x = parse_i32(&attr),
+                                b"y" => y = parse_i32(&attr),
+                                _ => {}
+                            }
+                        }
+                        *extent_out = Some((x, y));
+                    }
                     b"sz" => {
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
@@ -7431,6 +7466,43 @@ mod tests {
         assert!(
             line.started_right_or_bottom,
             "isReverseHV=\"1\" 이 started_right_or_bottom 로 되읽혀야 함"
+        );
+    }
+
+    #[test]
+    fn test_parse_ole_preserves_extent_and_draw_aspect() {
+        // <hc:extent> 원본 개체 크기와 drawAspect(표시 방식)가 IR 로 되읽혀야 한다.
+        // 종전엔 extent 를 7200 으로 하드코딩하고 drawAspect 를 읽지 않아,
+        // 모든 OLE 이 7200x7200 / CONTENT 로 왕복에서 뭉개졌다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" drawAspect="ICON" binaryItemIDRef="ole1">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hc:extent x="12345" y="6789"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape");
+        };
+        assert_eq!(ole.extent_x, 12345, "hc:extent x 가 보존돼야 함");
+        assert_eq!(ole.extent_y, 6789, "hc:extent y 가 보존돼야 함");
+        assert_eq!(
+            ole.drawing_aspect,
+            crate::model::shape::OleDrawingAspect::Icon,
+            "drawAspect=ICON 이 보존돼야 함"
         );
     }
 

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -3456,13 +3456,23 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         let mut img = ImageFill::default();
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
+                                // [#2563] 헤더(borderFill) 파서와 동일한 12종 매핑.
+                                // 종전엔 4종만 받아 TOTAL 등 8종이 TILE 로 붕괴했다.
                                 b"mode" => {
                                     img.fill_mode = match attr_str(&attr).as_str() {
                                         "TILE" | "TILE_ALL" => ImageFillMode::TileAll,
+                                        "TILE_HORZ_TOP" => ImageFillMode::TileHorzTop,
+                                        "TILE_HORZ_BOTTOM" => ImageFillMode::TileHorzBottom,
+                                        "TILE_VERT_LEFT" => ImageFillMode::TileVertLeft,
+                                        "TILE_VERT_RIGHT" => ImageFillMode::TileVertRight,
+                                        "CENTER" => ImageFillMode::Center,
+                                        "CENTER_TOP" => ImageFillMode::CenterTop,
+                                        "CENTER_BOTTOM" => ImageFillMode::CenterBottom,
                                         "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                             ImageFillMode::FitToSize
                                         }
-                                        "CENTER" => ImageFillMode::Center,
+                                        "TOTAL" => ImageFillMode::Total,
+                                        "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                         _ => ImageFillMode::TileAll,
                                     };
                                 }
@@ -3470,6 +3480,35 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                             }
                         }
                         fill.image = Some(img);
+                    }
+                    // [#2563] <hc:imgBrush> 의 <hc:img> 자식. 종전엔 이 arm 이 없어
+                    // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌고,
+                    // bin_data_id 가 0 이라 직렬화가 <hc:img> 를 아예 못 내
+                    // 이미지로 채운 도형이 왕복 후 빈 도형이 됐다.
+                    // 헤더(borderFill) 파서 header.rs 의 b"img" arm 과 동형.
+                    b"img" | b"image" => {
+                        if let Some(ref mut img_fill) = fill.image {
+                            for attr in ce.attributes().flatten() {
+                                match attr.key.as_ref() {
+                                    b"binaryItemIDRef" => {
+                                        let val = attr_str(&attr);
+                                        let num: String =
+                                            val.chars().filter(|c| c.is_ascii_digit()).collect();
+                                        img_fill.bin_data_id = num.parse().unwrap_or(0);
+                                    }
+                                    b"bright" => img_fill.brightness = parse_i8(&attr),
+                                    b"contrast" => img_fill.contrast = parse_i8(&attr),
+                                    b"effect" => {
+                                        img_fill.effect = match attr_str(&attr).as_str() {
+                                            "GRAY_SCALE" => 1,
+                                            "BLACK_WHITE" => 2,
+                                            _ => 0, // REAL_PIC
+                                        };
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -7503,6 +7542,57 @@ mod tests {
             ole.drawing_aspect,
             crate::model::shape::OleDrawingAspect::Icon,
             "drawAspect=ICON 이 보존돼야 함"
+        );
+    }
+
+    #[test]
+    fn test_shape_img_brush_preserves_image_ref_and_mode() {
+        // [#2563] 도형 <hc:imgBrush> 의 <hc:img> 자식과 12종 mode 매핑.
+        // 종전엔 mode 4종만 받아 TOTAL 이 TILE 로 붕괴했고, <hc:img> arm 이 없어
+        // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌다. bin_data_id 가
+        // 0 이면 직렬화가 <hc:img> 를 못 내므로 이미지 도형이 빈 도형이 된다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:rect id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hc:fillBrush>
+          <hc:imgBrush mode="TOTAL">
+            <hc:img binaryItemIDRef="image3" bright="10" contrast="-5" effect="GRAY_SCALE"/>
+          </hc:imgBrush>
+        </hc:fillBrush>
+      </hp:rect>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Rectangle(rect) = shape.as_ref() else {
+            panic!("expected rectangle shape");
+        };
+        let img = rect
+            .drawing
+            .fill
+            .image
+            .as_ref()
+            .expect("imgBrush 는 ImageFill 을 남겨야 함");
+
+        assert_eq!(img.bin_data_id, 3, "binaryItemIDRef 가 보존돼야 함");
+        assert_eq!(img.brightness, 10, "bright 가 보존돼야 함");
+        assert_eq!(img.contrast, -5, "contrast 가 보존돼야 함");
+        assert_eq!(img.effect, 1, "effect=GRAY_SCALE 가 보존돼야 함");
+        assert_eq!(
+            img.fill_mode,
+            crate::model::style::ImageFillMode::Total,
+            "mode=TOTAL 이 TILE 로 붕괴하면 안 됨"
         );
     }
 

--- a/src/parser/record.rs
+++ b/src/parser/record.rs
@@ -58,11 +58,18 @@ impl Record {
 
             // 데이터 읽기
             let pos = cursor.position() as usize;
-            if pos + size as usize > data.len() {
+            // size 는 파일에서 온 확장 32비트 레코드 크기다. `pos + size` 를 그대로
+            // 더하면 usize 가 32비트인 wasm32(이 크레이트의 배포 타깃) 에서 랩어라운드가
+            // 일어나 경계 검사가 무력화되고, 뒤이어 vec![0u8; size] 가 4GB 할당을
+            // 시도한다. checked_add 로 오버플로 자체를 실패로 처리한다.
+            if pos
+                .checked_add(size as usize)
+                .map_or(true, |end| end > data.len())
+            {
                 return Err(RecordError::UnexpectedEof {
                     tag_id,
                     expected: size as usize,
-                    available: data.len() - pos,
+                    available: data.len().saturating_sub(pos),
                 });
             }
 
@@ -129,6 +136,18 @@ impl std::error::Error for RecordError {}
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn extended_size_overflow_is_rejected() {
+        // 헤더의 크기 필드가 0xFFF 면 다음 4바이트가 확장 크기다. 그 값이
+        // 0xFFFFFFFF 여도 경계 검사가 통과해선 안 된다(wasm32 에서 pos+size
+        // 랩어라운드로 무력화되던 경로). 할당 시도 없이 Err 로 끝나야 한다.
+        let data = [0x00u8, 0x00, 0xF0, 0xFF, 0xFF, 0xFF, 0xFF, 0xFF];
+        assert!(
+            Record::read_all(&data).is_err(),
+            "확장 크기 오버플로 입력은 Err 여야 함"
+        );
+    }
 
     /// 기본 레코드 생성 헬퍼
     fn make_record_bytes(tag_id: u16, level: u16, data: &[u8]) -> Vec<u8> {

--- a/src/renderer/composer/tests.rs
+++ b/src/renderer/composer/tests.rs
@@ -1,6 +1,63 @@
 use super::*;
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
 
+/// [#2632] `recompose_for_body_width` 는 `recompose_for_cell_width` 의 superset
+/// (`restyle_fallback_runs_by_char_shapes` 를 추가로 적용)이다. line_segs 가
+/// 없는(NO_LS) 본문 문단에서 글자모양이 섞여 있으면, compose_lines fallback 이
+/// 만든 단일 run 을 body 래퍼만 char shape 별로 재분할한다.
+/// HeightMeasurer(측정)가 cell 래퍼를 쓰던 종전엔 이 재분할이 빠져
+/// typeset/render 와 다른 값으로 측정됐다 — 그 근본 메커니즘을 여기서 고정한다.
+#[test]
+fn body_recompose_splits_fallback_run_by_char_shapes_but_cell_recompose_does_not() {
+    let para = Paragraph {
+        text: "abcdefghij".to_string(),
+        char_offsets: (0..10).collect(),
+        char_count: 11,
+        char_shapes: vec![
+            CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            },
+            CharShapeRef {
+                start_pos: 5,
+                char_shape_id: 1,
+            },
+        ],
+        // line_segs 가 비어 있어 compose_lines 의 CHARS_PER_LINE fallback 경로를 탄다.
+        ..Default::default()
+    };
+    let styles = crate::renderer::style_resolver::ResolvedStyleSet::default();
+    // 문단 폭 안에 다 들어가도록 충분히 넓게 잡아 줄바꿈 자체는 문제되지 않게 한다.
+    let inner_width_px = 2000.0;
+
+    let mut cell_variant = compose_paragraph(&para);
+    recompose_for_cell_width(&mut cell_variant, &para, inner_width_px, &styles);
+    let cell_run_ids: Vec<u32> = cell_variant.lines[0]
+        .runs
+        .iter()
+        .map(|r| r.char_style_id)
+        .collect();
+
+    let mut body_variant = compose_paragraph(&para);
+    recompose_for_body_width(&mut body_variant, &para, inner_width_px, &styles);
+    let body_run_ids: Vec<u32> = body_variant.lines[0]
+        .runs
+        .iter()
+        .map(|r| r.char_style_id)
+        .collect();
+
+    assert_eq!(
+        cell_run_ids,
+        vec![0],
+        "cell 래퍼는 재분할하지 않아 fallback 단일 run(스타일 0)이 그대로 남아야 함"
+    );
+    assert_eq!(
+        body_run_ids,
+        vec![0, 1],
+        "body 래퍼는 restyle_fallback_runs_by_char_shapes 로 재분할해 두 글자모양이 드러나야 함"
+    );
+}
+
 /// 단일 줄, 단일 스타일 문단
 #[test]
 fn test_compose_single_line_single_style() {

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -515,8 +515,12 @@ impl HeightMeasurer {
         );
         let spacing_after = para_style.map(|s| s.spacing_after).unwrap_or(0.0);
 
-        // [Task #1042 Stage 6c] line_segs.empty paragraph 의 compose_lines fallback
-        // 결과를 단 너비 기반으로 recompose — paragraph_layout (Stage 6b) 와 동일.
+        // [Task #1042 Stage 6c][#2632] line_segs.empty paragraph 의 compose_lines
+        // fallback 결과를 단 너비 기반으로 recompose — typeset(format_paragraph)·
+        // render(layout_partial_paragraph) 와 동일한 본문 래퍼(recompose_for_body_width)
+        // 사용. 종전엔 셀 전용 recompose_for_cell_width 를 써 restyle_fallback_runs_
+        // by_char_shapes(글자모양별 run 재분할)를 건너뛰어, 글자모양이 섞인 본문
+        // NO_LS 문단의 측정 폭/줄수가 typeset/render 와 어긋났다.
         let recomposed: Option<ComposedParagraph> = match (composed, column_width_px) {
             // [#2553] line_segs.is_empty() 를 match guard 에 두면 저장 line_segs 가 있는
             // 문단이 곧장 `_ => None` 으로 떨어져 아래 stale 재래핑 분기에 도달할 수 없다.

--- a/src/renderer/height_measurer.rs
+++ b/src/renderer/height_measurer.rs
@@ -518,13 +518,33 @@ impl HeightMeasurer {
         // [Task #1042 Stage 6c] line_segs.empty paragraph 의 compose_lines fallback
         // 결과를 단 너비 기반으로 recompose — paragraph_layout (Stage 6b) 와 동일.
         let recomposed: Option<ComposedParagraph> = match (composed, column_width_px) {
-            (Some(c), Some(cw)) if para.line_segs.is_empty() && cw > 0.0 => {
+            // [#2553] line_segs.is_empty() 를 match guard 에 두면 저장 line_segs 가 있는
+            // 문단이 곧장 `_ => None` 으로 떨어져 아래 stale 재래핑 분기에 도달할 수 없다.
+            // typeset.rs / paragraph_layout.rs 와 동일하게 술어를 arm 본문으로 내린다.
+            (Some(c), Some(cw)) if cw > 0.0 => {
                 let margin_l = para_style.map(|s| s.margin_left).unwrap_or(0.0);
                 let margin_r = para_style.map(|s| s.margin_right).unwrap_or(0.0);
                 let inner = (cw - margin_l - margin_r).max(0.0);
-                if inner > 0.0 {
+                if inner > 0.0 && para.line_segs.is_empty() {
                     let mut cloned = c.clone();
-                    crate::renderer::composer::recompose_for_cell_width(
+                    // [#2279] 본문 NO_LS 는 글자모양 재분할 포함 래퍼 사용 —
+                    // typeset/paragraph_layout(렌더)와 동일 (측정/렌더 줄수·pitch 정합).
+                    // cell 래퍼는 restyle_fallback_runs_by_char_shapes 를 빠뜨려
+                    // 혼합 글자모양 문단의 측정 폭이 렌더와 어긋났다.
+                    crate::renderer::composer::recompose_for_body_width(
+                        &mut cloned,
+                        para,
+                        inner,
+                        styles,
+                    );
+                    Some(cloned)
+                } else if inner > 0.0
+                    && crate::renderer::composer::masked_stored_lines_stale(c, para, inner, styles)
+                {
+                    // [#2279] 마스킹 저장분할 stale(실폭-과잉/줄수-과소) 본문 문단
+                    // fresh 재래핑 — typeset/paragraph_layout(렌더)와 동일.
+                    let mut cloned = c.clone();
+                    crate::renderer::composer::recompose_stored_lines_if_overflowing_body(
                         &mut cloned,
                         para,
                         inner,

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -231,9 +231,20 @@ pub fn serialize_bin_data(bin_data: &BinData) -> Vec<u8> {
 pub fn serialize_face_name(font: &Font) -> Vec<u8> {
     let mut w = ByteWriter::new();
 
+    // 대체 글꼴 이름: HWP5 는 alt_name 한 곳에만 담는다. HWPX 파서는 같은 값을
+    // subst_font(<hh:substFont face=...>)로 채우고 alt_name 은 None 으로 두므로,
+    // 여기서 두 출처를 합쳐야 HWPX→HWP5 저장에서 대체 글꼴이 살아남는다.
+    // (종전엔 alt_name 만 봐서 HWPX 출처 대체 글꼴이 통째로 유실됐다.)
+    let alt_name = font.alt_name.as_deref().or_else(|| {
+        font.subst_font
+            .as_ref()
+            .map(|s| s.face.as_str())
+            .filter(|face| !face.is_empty())
+    });
+
     // attr 바이트 재구성
     let mut attr = font.alt_type & 0x03;
-    if font.alt_name.is_some() {
+    if alt_name.is_some() {
         attr |= 0x80;
     }
     if font.type_info.is_some() {
@@ -246,7 +257,7 @@ pub fn serialize_face_name(font: &Font) -> Vec<u8> {
 
     w.write_hwp_string(&font.name).unwrap();
 
-    if let Some(ref alt_name) = font.alt_name {
+    if let Some(alt_name) = alt_name {
         w.write_u8(font.alt_type & 0x03).unwrap();
         w.write_hwp_string(alt_name).unwrap();
     }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -277,11 +277,34 @@ fn replace_footnote_shape(xml: &str, sd: &SectionDef) -> String {
     // `type="CONTINUOUS" newNum="1"` 로 동일해, 미치환 시 페이지/구역마다
     // 새로 매기거나 시작 번호가 1이 아닌 문서가 저장 때 연속·1로 되돌아간다.
     // fn/en 템플릿 문자열이 같으므로 위치 기반 2회 치환을 쓴다.
-    replace_first_two(
+    let out = replace_first_two(
         &out,
         r#"<hp:numbering type="CONTINUOUS" newNum="1"/>"#,
         &render_note_numbering(&sd.footnote_shape),
         &render_note_numbering(&sd.endnote_shape),
+    );
+
+    // beneathText(본문 아래 바로 이어 출력). placement 의 `place` 열거형은 각주/
+    // 미주 의미를 conflate 해 무손실 역매핑이 어렵지만, beneathText 는 같은 요소의
+    // 독립 bool 이라 역매핑이 명확하다. 파서는 이 값을
+    // FootnoteShape.print_inline_after_text(HWP 바이너리 attr bit13)로 읽는데
+    // 템플릿이 "0" 으로 고정돼 저장 때마다 꺼졌다.
+    // 각주/미주 앵커의 place 값이 서로 달라 replacen(1) 충돌이 없다.
+    out.replacen(
+        r#"<hp:placement place="EACH_COLUMN" beneathText="0"/>"#,
+        &format!(
+            r#"<hp:placement place="EACH_COLUMN" beneathText="{}"/>"#,
+            u8::from(sd.footnote_shape.print_inline_after_text)
+        ),
+        1,
+    )
+    .replacen(
+        r#"<hp:placement place="END_OF_DOCUMENT" beneathText="0"/>"#,
+        &format!(
+            r#"<hp:placement place="END_OF_DOCUMENT" beneathText="{}"/>"#,
+            u8::from(sd.endnote_shape.print_inline_after_text)
+        ),
+        1,
     )
 }
 
@@ -2401,6 +2424,32 @@ mod tests {
         let mut doc = Document::default();
         doc.sections.push(section.clone());
         (doc, section)
+    }
+
+    #[test]
+    fn footnote_endnote_beneath_text_reflects_ir() {
+        // beneathText(본문 아래 바로 이어 출력)가 IR 에서 방출돼야 한다.
+        // 종전엔 템플릿 "0" 고정이라 저장할 때마다 이 설정이 꺼졌다.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, mut section) = make_doc_with_paragraph(para);
+        section.section_def.footnote_shape.print_inline_after_text = true;
+        section.section_def.endnote_shape.print_inline_after_text = true;
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:placement place="EACH_COLUMN" beneathText="1"/>"#),
+            "각주 beneathText 가 IR 값이어야 함"
+        );
+        assert!(
+            xml.contains(r#"<hp:placement place="END_OF_DOCUMENT" beneathText="1"/>"#),
+            "미주 beneathText 가 IR 값이어야 함"
+        );
+        assert!(
+            !xml.contains(r#"beneathText="0""#),
+            "템플릿 기본 beneathText=0 잔존 금지"
+        );
     }
 
     #[test]

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -6174,11 +6174,7 @@ impl HwpDocument {
             .get(style_id)
             .map(|s| s.local_name.as_str())
             .unwrap_or("");
-        format!(
-            "{{\"id\":{},\"name\":\"{}\"}}",
-            style_id,
-            json_escape(name)
-        )
+        format!("{{\"id\":{},\"name\":\"{}\"}}", style_id, json_escape(name))
     }
 
     /// 셀 내부 문단의 스타일을 조회한다.
@@ -6210,11 +6206,7 @@ impl HwpDocument {
             .get(style_id)
             .map(|s| s.local_name.as_str())
             .unwrap_or("");
-        format!(
-            "{{\"id\":{},\"name\":\"{}\"}}",
-            style_id,
-            json_escape(name)
-        )
+        format!("{{\"id\":{},\"name\":\"{}\"}}", style_id, json_escape(name))
     }
 
     /// 스타일을 적용한다 (본문 문단).

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -5607,8 +5607,8 @@ impl HwpDocument {
             items.push(format!(
                 "{{\"id\":{},\"name\":\"{}\",\"englishName\":\"{}\",\"type\":{},\"nextStyleId\":{},\"paraShapeId\":{},\"charShapeId\":{}}}",
                 i,
-                s.local_name.replace('"', "\\\""),
-                s.english_name.replace('"', "\\\""),
+                json_escape(&s.local_name),
+                json_escape(&s.english_name),
                 s.style_type,
                 s.next_style_id,
                 s.para_shape_id,
@@ -5976,7 +5976,7 @@ impl HwpDocument {
             let formats: Vec<String> = n
                 .level_formats
                 .iter()
-                .map(|f| format!("\"{}\"", f.replace('"', "\\\"")))
+                .map(|f| format!("\"{}\"", json_escape(f)))
                 .collect();
             items.push(format!(
                 "{{\"id\":{},\"levelFormats\":[{}],\"startNumber\":{}}}",
@@ -6177,7 +6177,7 @@ impl HwpDocument {
         format!(
             "{{\"id\":{},\"name\":\"{}\"}}",
             style_id,
-            name.replace('"', "\\\"")
+            json_escape(name)
         )
     }
 
@@ -6213,7 +6213,7 @@ impl HwpDocument {
         format!(
             "{{\"id\":{},\"name\":\"{}\"}}",
             style_id,
-            name.replace('"', "\\\"")
+            json_escape(name)
         )
     }
 

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -24934,3 +24934,34 @@ fn delete_style_invalidates_docinfo_and_sections() {
         "문단 style_id 재배정이 반영되도록 섹션 raw_stream 이 무효화돼야 한다"
     );
 }
+
+/// [#2557] 스타일 이름에 역슬래시/개행/탭이 있어도 방출 JSON 이 파싱 가능해야 한다.
+///
+/// 종전엔 큰따옴표만 이스케이프해 깨진 JSON 이 나왔고, TS 측은 가드 없이
+/// JSON.parse 하므로(wasm-bridge.ts:1957, :2025) 예외가 났다. getStyleAt 은 커서
+/// 이동마다 호출되어 해당 문서에서 키 입력마다 편집기가 멈춘다.
+#[test]
+fn style_json_survives_backslash_and_control_chars() {
+    let mut doc = HwpDocument::create_empty();
+    {
+        let styles = &mut doc.core.document.doc_info.styles;
+        if styles.is_empty() {
+            styles.push(crate::model::style::Style::default());
+        }
+        styles[0].local_name = "a\\b\nc\td\"e".to_string();
+        styles[0].english_name = "x\\y\nz".to_string();
+    }
+
+    let list = doc.get_style_list();
+    let parsed: Value = serde_json::from_str(&list)
+        .expect("스타일 이름에 역슬래시/개행이 있어도 유효한 JSON 이어야 함");
+    assert_eq!(
+        parsed[0]["name"].as_str().unwrap(),
+        "a\\b\nc\td\"e",
+        "이스케이프 왕복 후 원래 이름이 복원돼야 함"
+    );
+
+    let at = doc.get_style_at(0, 0);
+    serde_json::from_str::<Value>(&at)
+        .expect("getStyleAt 도 유효한 JSON 이어야 함(커서 이동마다 호출됨)");
+}


### PR DESCRIPTION
## 통합 목적

kevin9327 님의 HWP/HWPX/HWP5 코어 계열 기여 12건을 최신 `devel` 위에 누적 검토·통합합니다. 각 원 PR의 기능 커밋을 `cherry-pick -x`로 이식해 provenance(원 커밋 SHA)를 보존했습니다.

## 반영 범위 (원 PR)

- **파서 견고성**: #2537(확장 레코드 pos+size 오버플로 경계 검사 무력화, wasm32)
- **왕복 보존(HWPX/HWP5)**: #2534(OLE hc:extent·drawAspect), #2538(substFont→alt_name), #2544(각주/미주 beneathText), #2564(도형 imgBrush 그림 참조·mode), #2649(머리말/꼬리말 LIST_HEADER 페이로드 파싱)
- **편집·저장 정합**: #2547(중첩 표 path[0]-only 오매칭), #2556(이웃 셀 BorderFill push 시 DocInfo passthrough 무효화), #2558(스타일/번호 JSON json_escape 정합)
- **측정·렌더 정합**: #2554(높이 측정 경로), #2636(HeightMeasurer 본문 NO_LS 재래핑 래퍼)

## 중복 흡수 (통합 중 발견)

- **#2636 ⊂ #2554**: #2636 의 실코드(recompose_for_cell_width→_body_width 교체)는 #2554 가 이미 더 넓은 분기로 포함. #2636 은 테스트·문서만 추가로 흡수.
- **#2643 = #2556**: 동일 버그(이웃 셀 BorderFill push 시 raw_stream_dirty 미설정)의 동일 실코드 수정(이슈만 #2555 vs #2638 상이). #2556 채택, #2643 흡수.
- 두 흡수 건은 원 PR 에 결과를 남기고 close 예정.

## 검증

- `cargo test --profile release-test --tests --no-fail-fast` — 전건 통과
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt --all -- --check` 클린
- `hwp5_roundtrip_baseline` 3/3 · `hwpx_roundtrip_baseline` 4/4 무회귀
- 충돌 4건(2538/2564/2636/2643) 수동 해소 — 전부 테스트 인접 추가 또는 실코드 중복 흡수, 로직 병합 없음

## 운영

- 최신 head CI 성공 + 작업지시자 merge 승인 후, merge SHA 를 근거로 각 원 PR 에 통합 결과·크레딧·close 를 남긴다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)