### PR TITLE
fix(#2524): export-svg 가 문서 임베디드(BinData) 폰트를 data-URI 로 임베딩

### DIFF
--- a/src/document_core/queries/rendering.rs
+++ b/src/document_core/queries/rendering.rs
@@ -860,6 +860,43 @@ impl DocumentCore {
         self.render_pages_pdf_direct_native_with_options(&pages, options)
     }
 
+    /// [#2524] 문서 임베디드(BinData) 폰트를 face명 → 원본 bytes 로 수집한다.
+    ///
+    /// SVG `@font-face` 직접 임베딩용. 미설치 임베디드 폰트(bitmap 등)가
+    /// `local()` 폴백으로 chrome 두부가 되던 문제 해소. 동일 face 명이 여러
+    /// 언어 슬롯에 있으면 첫 항목만 담는다.
+    #[cfg(not(target_arch = "wasm32"))]
+    fn collect_embedded_font_bytes_by_name(&self) -> std::collections::HashMap<String, Vec<u8>> {
+        let mut ids = Vec::new();
+        let mut name_id: Vec<(String, u16)> = Vec::new();
+        for fonts in &self.document.doc_info.font_faces {
+            for font in fonts {
+                if font.is_embedded {
+                    if let Some(id) = font.resolved_bin_data_id {
+                        ids.push(id);
+                        name_id.push((font.name.clone(), id));
+                    }
+                }
+            }
+        }
+        if ids.is_empty() {
+            return std::collections::HashMap::new();
+        }
+        let bytes_by_id = load_bounded_embedded_font_bytes(
+            &self.document.bin_data_content,
+            &ids,
+            MAX_EMBEDDED_FONT_BYTES,
+            MAX_EMBEDDED_FONT_BYTES_PER_PAGE,
+        );
+        let mut map = std::collections::HashMap::new();
+        for (name, id) in name_id {
+            if let Some(bytes) = bytes_by_id.get(&id) {
+                map.entry(name).or_insert_with(|| bytes.clone());
+            }
+        }
+        map
+    }
+
     /// SVG 렌더링 (폰트 임베딩 옵션 포함)
     #[cfg(not(target_arch = "wasm32"))]
     pub fn render_page_svg_with_fonts(
@@ -881,7 +918,11 @@ impl DocumentCore {
         // 폰트 임베딩 후처리
         let mut svg = renderer.output().to_string();
         if font_embed_mode != crate::renderer::svg::FontEmbedMode::None {
-            let style_css = crate::renderer::svg::generate_font_style(&renderer, font_paths);
+            // [#2524] 문서 임베디드(BinData) 폰트를 face명 → bytes 로 수집해
+            // @font-face 직접 임베딩에 쓴다(미설치 임베디드 폰트 chrome 두부 해소).
+            let embedded_fonts = self.collect_embedded_font_bytes_by_name();
+            let style_css =
+                crate::renderer::svg::generate_font_style(&renderer, font_paths, &embedded_fonts);
             if !style_css.is_empty() {
                 // <svg ...> 직후에 <style> 삽입
                 if let Some(pos) = svg.find('>') {

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -3549,9 +3549,49 @@ fn find_font_file(
     None
 }
 
+/// [#2524] 문서 임베디드(BinData) 폰트를 @font-face 로 직접 임베딩한다.
+///
+/// 미설치 임베디드 폰트(bitmap 등)는 `find_font_file`(디스크) 조회에 실패해
+/// `local()` 폴백이 되고, blink(chrome) 는 해결 못해 글리프가 두부(□)로 렌더된다
+/// (#2524). 서브셋터(typst)는 bitmap glyph 테이블(EBDT/EBLC)을 보존하지 못하므로
+/// 임베디드 폰트는 서브셋하지 않고 원본 전체를 data-URI 로 임베딩한다.
+fn embedded_font_face_css(
+    font_name: &str,
+    embedded_fonts: &std::collections::HashMap<String, Vec<u8>>,
+) -> Option<String> {
+    let bytes = embedded_fonts.get(font_name)?;
+    if bytes.is_empty() {
+        return None;
+    }
+    let (mime, format) = font_data_uri_format(bytes);
+    let b64 = base64::engine::general_purpose::STANDARD.encode(bytes);
+    Some(format!(
+        "@font-face {{ font-family: \"{}\"; src: url(\"data:{};base64,{}\") format(\"{}\"); }}\n",
+        font_name, mime, b64, format,
+    ))
+}
+
+/// 폰트 매직 바이트(sfnt version)로 data-URI mime 과 CSS `format()` 을 판별한다.
+fn font_data_uri_format(bytes: &[u8]) -> (&'static str, &'static str) {
+    match bytes.get(0..4) {
+        Some(b"OTTO") => ("font/otf", "opentype"),
+        Some(b"wOFF") => ("font/woff", "woff"),
+        Some(b"wOF2") => ("font/woff2", "woff2"),
+        // 0x00010000 (TrueType) · "true" · "ttcf"(TTC) 등은 truetype 으로 취급
+        _ => ("font/ttf", "truetype"),
+    }
+}
+
 /// SvgRenderer의 수집된 폰트 정보를 기반으로 @font-face CSS를 생성한다.
+///
+/// `embedded_fonts` (face명 → 원본 폰트 bytes) 에 있는 폰트는 임베드 모드와
+/// 무관하게 data-URI 로 전체 임베딩한다(#2524, 미설치 임베디드 폰트 대응).
 #[cfg(not(target_arch = "wasm32"))]
-pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::PathBuf]) -> String {
+pub fn generate_font_style(
+    renderer: &SvgRenderer,
+    font_paths: &[std::path::PathBuf],
+    embedded_fonts: &std::collections::HashMap<String, Vec<u8>>,
+) -> String {
     let codepoints = renderer.font_codepoints();
     if codepoints.is_empty() {
         return String::new();
@@ -3562,6 +3602,10 @@ pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::Path
     match renderer.font_embed_mode {
         FontEmbedMode::Style => {
             for font_name in codepoints.keys() {
+                if let Some(line) = embedded_font_face_css(font_name, embedded_fonts) {
+                    css.push_str(&line);
+                    continue;
+                }
                 let aliases = font_local_aliases(font_name);
                 let src = if aliases.is_empty() {
                     format!("local(\"{}\")", font_name)
@@ -3580,6 +3624,10 @@ pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::Path
         }
         FontEmbedMode::Subset => {
             for (font_name, chars) in codepoints.iter() {
+                if let Some(line) = embedded_font_face_css(font_name, embedded_fonts) {
+                    css.push_str(&line);
+                    continue;
+                }
                 if let Some(font_path) = find_font_file(font_name, font_paths) {
                     if let Ok(font_data) = std::fs::read(&font_path) {
                         // codepoint → glyph ID 변환 (ttf-parser cmap 사용)
@@ -3639,6 +3687,10 @@ pub fn generate_font_style(renderer: &SvgRenderer, font_paths: &[std::path::Path
         }
         FontEmbedMode::Full => {
             for font_name in codepoints.keys() {
+                if let Some(line) = embedded_font_face_css(font_name, embedded_fonts) {
+                    css.push_str(&line);
+                    continue;
+                }
                 if let Some(font_path) = find_font_file(font_name, font_paths) {
                     if let Ok(font_data) = std::fs::read(&font_path) {
                         let b64 = base64::engine::general_purpose::STANDARD.encode(&font_data);

--- a/tests/issue_2524_embedded_font_svg.rs
+++ b/tests/issue_2524_embedded_font_svg.rs
@@ -1,0 +1,56 @@
+//! [#2524] 문서 임베디드(BinData) 폰트를 export-svg 폰트 임베딩에서 실제로
+//! data-URI 로 방출하는지 회귀 가드.
+//!
+//! 종전: SVG 폰트 임베더(`generate_font_style`)가 `find_font_file`(디스크)만
+//! 조회 → 미설치 임베디드 폰트는 `src: local(...)` 폴백 → blink(chrome) 가
+//! 해결 못해 글리프 두부(□). 샘플 `render-p35-font-native-bitmap.hwpx` 는
+//! 폰트 "RHWP Bitmap SVG Glyph Smoke" 를 BinData 에 임베딩(isEmbedded="1").
+//!
+//! 수정 후: 문서 임베디드 폰트를 face명→bytes 로 수집해 임베드 모드에서
+//! `src: url("data:font/...;base64,...")` 로 원본 전체 임베딩한다.
+
+use rhwp::document_core::DocumentCore;
+use rhwp::renderer::svg::FontEmbedMode;
+
+const SAMPLE: &str = "samples/render-p35-font-native-bitmap.hwpx";
+const EMBEDDED_FACE: &str = "RHWP Bitmap SVG Glyph Smoke";
+
+fn render_with_embed(mode: FontEmbedMode) -> String {
+    let path = std::path::Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE);
+    let bytes = std::fs::read(&path).expect("read sample");
+    let core = DocumentCore::from_bytes(&bytes).expect("parse");
+    core.render_page_svg_with_fonts(0, mode, &[])
+        .expect("render svg with fonts")
+}
+
+#[test]
+fn embedded_font_is_emitted_as_data_uri_not_local() {
+    let svg = render_with_embed(FontEmbedMode::Subset);
+    // 임베디드 face 의 @font-face 가 존재해야 한다.
+    assert!(
+        svg.contains(EMBEDDED_FACE),
+        "SVG 에 임베디드 폰트 face 참조가 있어야 함"
+    );
+    // 원본 바이트가 data-URI 로 임베딩되어야 한다.
+    assert!(
+        svg.contains("src: url(\"data:font/"),
+        "임베디드 폰트가 data-URI 로 임베딩되어야 함 (local() 폴백 아님). SVG:\n{}",
+        &svg[..svg.len().min(1200)]
+    );
+    // 임베디드 face 에 대한 local()-only @font-face 가 남아 있으면 안 된다.
+    let local_only = format!("font-family: \"{EMBEDDED_FACE}\"; src: local(");
+    assert!(
+        !svg.contains(&local_only),
+        "임베디드 폰트가 local() 폴백으로 남으면 안 됨 (#2524)"
+    );
+}
+
+#[test]
+fn embedded_font_embedded_in_style_mode_too() {
+    // --font-style(local 참조 전용) 모드라도 미설치 임베디드 폰트는 embed 해야 한다.
+    let svg = render_with_embed(FontEmbedMode::Style);
+    assert!(
+        svg.contains("src: url(\"data:font/"),
+        "Style 모드에서도 임베디드 폰트는 data-URI 로 embed 되어야 함 (#2524)"
+    );
+}


### PR DESCRIPTION
## 요약

export-svg 폰트 임베딩이 **문서 임베디드(BinData) 폰트를 실제로 방출하지 않고 `local()` 로 폴백**해, 미설치 임베디드 폰트(특히 native bitmap 폰트)가 chrome/blink 에서 글리프 두부(□)로 렌더되던 #2524 를 수정한다.

## 근인

샘플 `samples/render-p35-font-native-bitmap.hwpx` 는 폰트 "RHWP Bitmap SVG Glyph Smoke" 를 BinData 에 임베딩한다(`isEmbedded="1" binaryItemIDRef=…`). 그러나 `--embed-fonts` 출력의 @font-face 는:
```
@font-face { font-family: "RHWP Bitmap SVG Glyph Smoke"; src: local("RHWP Bitmap SVG Glyph Smoke"); }
```
즉 **데이터 미임베딩·local() 폴백**. `generate_font_style`(`src/renderer/svg.rs`) 이 `find_font_file`(디스크)만 조회했기 때문 — 임베디드 폰트는 디스크에 없어 실패 → local(). 미설치 폰트라 blink 가 해결 못해 두부. 파서는 임베디드 폰트를 이미 해석해 둔다(`resolve_embedded_font_references`, `Document.bin_data_content`, 폰트 `resolved_bin_data_id`).

## 수정

- `render_page_svg_with_fonts` 가 문서 임베디드 폰트를 face명→원본 bytes 로 수집(`collect_embedded_font_bytes_by_name`, 기존 `load_bounded_embedded_font_bytes` 재사용, 32MB/폰트·64MB/페이지 상한)해 `generate_font_style` 에 전달.
- `generate_font_style` 은 임베드 모드(Style/Subset/Full)에서 해당 폰트가 임베디드면 `find_font_file`·서브셋 대신 **원본 전체를 data-URI 로 임베딩**한다(`embedded_font_face_css`). 서브셋터(typst)는 bitmap glyph 테이블(EBDT/EBLC)을 보존 못하므로 임베디드 폰트는 서브셋하지 않는다. sfnt 매직으로 `truetype`/`opentype`/`woff` format 판별.

수정 후: `@font-face { … src: url("data:font/ttf;base64,…") format("truetype"); }` — chrome 이 글리프를 렌더.

## 스코프

**렌더 전용**(font-face CSS)이라 레이아웃·페이지네이션 불변. 기본(embed 없음) 출력은 관례대로 미변경 — 자립형 SVG 는 `--embed-fonts`/`--font-style`/`--embed-fonts=full` opt-in. None 모드·golden(svg_snapshot 은 embed OFF) 무영향.

## 게이트

- **92 결재문서 통제셋**: 92/92 = 100% (레이아웃 불변 확인)
- **10k 모집단 페이지수**: N/A — 레이아웃 코드 미변경(font-face CSS만), 페이지수 변화 구조상 0
- **nextest**: 3449/3449 통과 (exit 0)

## 테스트

`tests/issue_2524_embedded_font_svg.rs` — 임베디드 폰트가 Subset·Style 모드에서 `data:font` data-URI 로 방출되고 `local()` 폴백이 남지 않음을 고정. 샘플 `samples/render-p35-font-native-bitmap.hwpx` 저장소 기존 포함.

## 재현

`rhwp export-svg samples/render-p35-font-native-bitmap.hwpx --embed-fonts` → @font-face 가 `data:font/ttf` (수정 전 `local()`).
