### PR TITLE
chore(#2510 후속): preflight identity 아티팩트 누적 보존 + EVIDENCE 라벨 정정

### DIFF
--- a/tools/task2430/EVIDENCE.md
+++ b/tools/task2430/EVIDENCE.md
@@ -18,7 +18,8 @@
 왕복 조회로 실제 해소 결과를 검증한다. **실존 HFT 는 FontType=2 가 유지**되고,
 미설치 face 는 fallback 으로 FontType 이 변질된다(아래 negative-control).
 
-측정 환경 로그 (`tools/task2430/measured/preflight_report.tsv` 커밋본):
+아래는 측정 환경에서 5종을 per-face 실행했을 때의 preflight **콘솔 stdout**
+로그다(파일 형식이 아니라 실행 시 표준출력):
 
 ```
 한양신명조: readback=('한양신명조', FontType=2) OK
@@ -27,6 +28,18 @@
 한양견고딕: readback=('한양견고딕', FontType=2) OK
 휴먼명조:   readback=('휴먼명조',   FontType=2) OK
 ```
+
+> **커밋 아티팩트 상태(정정)**: 위 5행 블록은 *콘솔 로그*이며 커밋된
+> `tools/task2430/measured/preflight_report.tsv` 파일 내용 자체가 아니다.
+> 최초 커밋 시점의 `preflight_report.tsv` 는 per-face 프로세스 분할 실행에서
+> **매 실행이 파일을 덮어써 마지막 face(휴먼명조) 1행만** 잔존했다. 따라서
+> **저장소에 identity 아티팩트로 독립 보존된 것은 휴먼명조 1종**이고, 한양
+> 4종의 FontType=2 readback 은 현재 이 문서 산문으로만 남아 있다. 이 갭을
+> 없애기 위해 `hy_ascii_ladder.py` preflight 를 requested_face 기준 **누적
+> 병합**으로 개선했으므로(#2510 리뷰 후속 커밋), 저자가 동일 COM 환경에서
+> 5종 per-face 를 재실행하면 5행 `preflight_report.tsv` 가 커밋 아티팩트로
+> 보존된다. `--verify` 재현성(아래 §4)은 커밋 TSV↔배열 일치만 보증하며 HFT
+> vs fallback identity 는 이 preflight 아티팩트로만 입증되는 점에 유의한다.
 
 PDF 단 이중 확인: 각 face 프로브 PDF 의 임베드 폰트가 한양 4종=**Type3**(HFT
 렌더 경로), 휴먼명조=**Type0 `INPILL+휴먼명조`**(cp949 복원) — 시스템 TTF

--- a/tools/task2430/hy_ascii_ladder.py
+++ b/tools/task2430/hy_ascii_ladder.py
@@ -22,7 +22,8 @@ preflight: 측정 전 각 요청 face 가 실제 HFT 로 선택 가능한지 Cha
 하나라도 실패하면 TSV 를 만들지 않고 non-zero 로 중단한다 — 존재하지 않는
 이름을 지정하는 것이 곧 negative-control 이다. 측정 후에는 PDF 임베드 폰트
 테이블에서 시스템 폰트 fallback(Haansoft*)이 섞이지 않았는지 재확인한다.
-결과는 out-dir/preflight_report.tsv 에 남는다.
+결과는 out-dir/preflight_report.tsv 에 requested_face 기준으로 누적 병합된다
+(per-face 프로세스 분할 실행에서도 5종 identity 행이 모두 보존된다).
 
 Windows + 한컴(pyhwpx) 전제. 경로는 리포지토리 루트 기준(절대 경로 하드코딩 없음).
 """
@@ -103,11 +104,35 @@ def preflight(hwp, fonts, report_path):
             failures.append(face)
         print(f"  [preflight] {face}: readback=({rb_name!r}, FontType={rb_type}) "
               f"{'OK' if ok else '** HFT 미확인 **'}")
-    with open(report_path, "w", encoding="utf-8") as fh:
-        fh.write("requested_face\treadback_face\treadback_fonttype\tverdict\n")
-        for r in rows:
-            fh.write("\t".join(str(x) for x in r) + "\n")
+    _merge_preflight_report(report_path, rows)
     return failures
+
+
+HEADER = "requested_face\treadback_face\treadback_fonttype\tverdict\n"
+
+
+def _merge_preflight_report(report_path, rows):
+    """preflight_report.tsv 를 requested_face 기준으로 누적 병합한다.
+
+    per-face 프로세스 분할 실행(권장 경로)에서 매 실행이 파일을 덮어쓰면 마지막
+    face 만 남아 5종 identity 증거가 소실된다. 기존 행을 읽어 이번 실행 결과로
+    같은 face 를 갱신하고, 나머지는 보존한 뒤 requested_face 순으로 재기록한다.
+    """
+    merged = {}
+    if os.path.exists(report_path):
+        with open(report_path, encoding="utf-8") as fh:
+            for i, line in enumerate(fh):
+                if i == 0 and line.startswith("requested_face"):
+                    continue
+                cols = line.rstrip("\n").split("\t")
+                if len(cols) == 4:
+                    merged[cols[0]] = tuple(cols)
+    for r in rows:
+        merged[r[0]] = tuple(str(x) for x in r)
+    with open(report_path, "w", encoding="utf-8") as fh:
+        fh.write(HEADER)
+        for face in sorted(merged):
+            fh.write("\t".join(merged[face]) + "\n")
 
 
 def check_pdf_fonts(pdf_path, face):


### PR DESCRIPTION
## 배경

merged [#2510](https://github.com/edwardkim/rhwp/pull/2510) (merge commit `215a1743`) 의 실측 검증 자산 후속 보정이다. `tools/task2430/` 도구·문서만 변경하며 소스/golden/기존 샘플 변경은 없다.

리뷰 재검토 중, 커밋된 `tools/task2430/measured/preflight_report.tsv` 가 per-face 프로세스 분할 실행에서 **매 실행이 파일을 덮어써 마지막 face(휴먼명조) 1행만** 잔존한 것을 확인했다. 이로 인해:

- `EVIDENCE.md` §2 는 5종 readback 블록을 이 파일 "커밋본" 으로 라벨링했으나 실제 파일 내용과 어긋난다.
- 저장소에 HFT identity 아티팩트로 독립 보존된 것은 **휴먼명조 1종** 뿐이고, 한양 4종의 FontType=2 readback 은 EVIDENCE 산문으로만 남아 있다.
- `gen_metrics.py --verify` 는 커밋 TSV↔배열 일치만 보증하며 HFT vs 시스템 fallback identity 는 preflight 아티팩트로만 입증되므로, 한양 4종의 in-repo identity 증거가 빈다.

## 변경

- `hy_ascii_ladder.py` preflight: `preflight_report.tsv` 를 `requested_face` 기준 **누적 병합**(`_merge_preflight_report`). per-face 분할 실행에서도 5종 identity 행이 모두 보존된다(기존 행 읽어 같은 face 갱신, 나머지 보존, face 순 재기록).
- `EVIDENCE.md` §2: 5종 블록이 커밋 파일이 아니라 per-face **콘솔 stdout** 임을 정정하고, 최초 커밋본이 휴먼명조 1행만 잔존했음·`--verify` 의 identity-무관 한계를 명시.

## 검증

- `python -c ast.parse` 구문 확인, `_merge_preflight_report` per-face 3회 누적 + 재실행 dedup 단위 검증(헤더 포함 4행 유지).
- 실측 데이터(ladder TSV·배열) 변경 없음. `tools/**` 전용이라 fast-pass 대상.

## 남은 후속 (본 PR 범위 밖)

한양 4종의 5행 `preflight_report.tsv` 실측 재보존은 동일 Windows+한컴 COM 환경 per-face 재실행이 필요하며, 원저자(@planet6897)에게 [#2510 코멘트](https://github.com/edwardkim/rhwp/pull/2510)로 비차단 후속 요청한다. 본 PR 의 harness 개선이 그 재실행 시 5행 보존을 보장한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)