### PR TITLE
task: kevin9327 그룹B(studio 편집 — IME·그리드 뷰) 통합

### DIFF
--- a/mydocs/report/task_m100_2548_report.md
+++ b/mydocs/report/task_m100_2548_report.md
@@ -1,0 +1,100 @@
+# task_m100_2548 처리결과 보고서 — IME 조합 삭제 count 의 char 단위 정합
+
+- **이슈**: [#2548](https://github.com/edwardkim/rhwp/issues/2548)
+- **브랜치**: `task/m100-2548-char-offset-scalar` (base `devel` @ `3c54abfd`)
+- **범위**: `rhwp-studio/src/engine/input-handler-text.ts` IME 조합 경로의 삭제 count 단위
+- **분류**: 결함 수정 (astral 문자 인접 문자 손실)
+
+## 1. 문제
+
+[#2337-review] 에서 확립된 계약 — **WASM 삭제/조회 count 는 Rust `Paragraph::delete_text_at`
+의 char(Unicode scalar) 단위**이며, JS `String.length`(UTF-16 code unit)를 넘기면 astral
+문자(😀 등)에서 실제보다 많이 지운다. 당시 `InsertTextCommand.undo` 와 HF/FN 경로에는
+`charCount()` 가 적용됐으나 **IME 조합 경로는 누락**돼 있었다.
+
+```ts
+this.compositionLength = text.length;               // :487  UTF-16 code unit
+...
+this.deleteTextAt(anchor, this.compositionLength);  // :481  scalar count 로 전달
+```
+
+`deleteTextAt(pos, count)`(:685)은 `count` 를 그대로
+`wasm.deleteText / deleteTextInCell / deleteTextInCellByPath / deleteTextInHeaderFooter /
+deleteTextInFootnote` 로 넘긴다. iOS 조합 폴백의 `_iosLength`(:553→:546) 도 동일하다.
+
+### 영향
+
+1. IME 조합 중 후보에 astral 문자가 포함(일본어·중국어 IME 의 이모지 후보 등)
+2. 조합 업데이트 N 이 `😀`(UTF-16 2) 삽입 후 `compositionLength = 2` 기록
+3. 조합 업데이트 N+1 이 anchor 에서 **scalar 2개** 삭제 → `😀` + **뒤따르는 실제 문자 1개** 제거
+4. 조합 종료 시 `getTextAt(anchor, finalLength)` 도 이웃 문자를 포함해 읽어 undo 레코드가 부정확
+
+## 2. 분석 — 오탐 배제
+
+최초 이슈 등록 시 `InsertTextCommand.execute()` 의 `charOffset + this.text.length` 도 함께
+지적했으나 **검증 결과 오탐이라 철회**했다(이슈 본문에 정정 고지 기재).
+
+근거: 해당 값은 *커서 오프셋* 이며, 저장소가 UTF-16 관례로 **의도적으로 고정**해 두었다.
+
+- `src/engine/command.ts:922` `charCount` 주석: "커서 오프셋은 studio 의 UTF-16 관례를
+  유지하므로 여기서만 char 단위를 쓴다."
+- `tests/undo-delete-char-count.test.ts`: "커서 오프셋(`charOffset + text.length`)은
+  studio 의 UTF-16 관례를 유지하므로 제외하고, …"
+
+즉 `execute()`(커서 오프셋, UTF-16)와 `undo()`(삭제 count, scalar)는 **서로 다른 양**이며
+모순이 아니다. 본 수정은 **삭제/조회 count 에만** 적용하고 커서 오프셋은 손대지 않았다.
+
+## 3. 변경
+
+`rhwp-studio/src/engine/input-handler-text.ts`
+
+| 위치 | 변경 | 성격 |
+|---|---|---|
+| 파일 상단 | `charCount()` 헬퍼 추가(`command.ts` 와 동일 정의, 계약 주석 포함) | 신규 |
+| `:488` | `this.compositionLength = charCount(text)` | 삭제 count |
+| `:553` | `this._iosLength = charCount(text)` | 삭제 count |
+
+**불변으로 둔 지점**(커서 오프셋, UTF-16 관례 유지): `:497` `anchor.charOffset + text.length`,
+`:615`/`:634` HF/FN `charOffset + text.length`.
+
+## 4. 검증
+
+### 신규 테스트
+
+`rhwp-studio/tests/ime-composition-char-count.test.ts` (3건) — 선례
+`tests/undo-delete-char-count.test.ts` 와 동일한 **정적 소스 가드** 방식.
+
+1. `compositionLength` 가 `charCount(text)` 로 계산되고 `.length` 가 아님
+2. `_iosLength` 동일
+3. 삭제 count 로 쓰이는 두 변수에 UTF-16 `.length` 대입이 남아있지 않음(정규식 스캔)
+
+### red→green 실증
+
+수정을 되돌려(`compositionLength = text.length`) 실행 → **3건 중 2건 실패**.
+복원 후 → **3건 전부 통과**. 가드가 실제로 회귀를 잡는다.
+
+### 회귀
+
+```
+node --test tests/*.test.ts  →  pass 436 / fail 1
+```
+
+유일한 실패 `tests/cell-flow-boundary.test.ts` 는 **사전 실패**다. 변경을 `git stash` 로
+제거한 깨끗한 `devel` 에서 같은 테스트를 단독 실행해 `pass 0 / fail 1` 로 동일하게 실패함을
+확인했다 — 본 변경과 무관.
+
+### 미실행 항목 (투명 고지)
+
+- **행위 증명(브라우저 왕복)**: 이모지 후보 조합 → 인접 문자 보존 확인은 실행하지 않았다.
+  선례 `undo-delete-char-count.test.ts` 도 동일 방침("행위 증명은 브라우저 왕복(PR 검증)")을
+  주석에 명시하고 있어 그에 따랐다.
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약상
+  작업지시자 별도 승인 사항이라 실행하지 않았다. Rust 코드는 변경하지 않았다.
+
+## 5. 잔여 / 후속
+
+같은 이슈 본문에 기록한 **각주 커서 경계**(`cursor.ts:1738,1752`)와
+**단어 경계 탐색**(`cursor.ts:1775,1790`)은 본 변경에 포함하지 않았다. 이들은 *커서 오프셋*
+계열이라 위 UTF-16 관례와의 관계를 먼저 확정해야 하며(머리말/꼬리말 쌍둥이는 WASM 이 준
+`info.charCount` 를 쓰는 반면 각주판은 JS `.length` 로 계산하는 비대칭이 있다), 별도 판단이
+필요하다. 범위를 섞지 않기 위해 분리했다.

--- a/mydocs/report/task_m100_2560_report.md
+++ b/mydocs/report/task_m100_2560_report.md
@@ -1,0 +1,78 @@
+# task_m100_2560 처리결과 보고서 — 그리드 보기 "현재 쪽" 판정 정합
+
+- **이슈**: [#2560](https://github.com/edwardkim/rhwp/issues/2560)
+- **브랜치**: `task/m100-2560-grid-current-page` (base `devel` @ `3c54abfd`)
+- **범위**: `rhwp-studio` view/engine 3파일 + 신규 테스트
+- **분류**: 결함 수정 (PageUp 무동작, 쪽 표시기 오표시)
+
+## 1. 문제
+
+`getPageAtY` 가 그리드 보기에서 **행의 마지막 쪽**을 반환한다. `layoutGrid` 가 한 행의 모든
+쪽에 같은 `rowTop` 을 넣으므로, 뒤에서부터 스캔하는 이 함수는 언제나 그 행의 최대 인덱스를
+돌려준다.
+
+이 의미 자체는 의도된 것이다 — `getPageAtPoint`(`virtual-scroll.ts:149`)가 반환값을
+**`rowLastIdx`** 로 명명하고 X 로 좁히기 위한 스캔 끝점으로 쓴다. 문제는 **"현재 쪽" 이 필요한
+소비처가 이 Y 전용 진입점을 직접 쓴 것**이다.
+
+### 결함 1 — PageUp 무동작
+
+`input-handler-keyboard.ts:1203-1209` 는 `currentPage ± 1` 로 목표를 정한다. 3열에서 현재 행이
+(3,4,5)면 `currentPage = 5`, PageUp 목표는 4 — **같은 행**이라 `getPageOffset` 이 동일해
+`setScrollTop` 이 제자리다. 아무리 눌러도 행을 벗어나지 못한다.
+
+PageDown 은 `5+1 = 6` 이 실제로 다음 행이라 우연히 동작한다. **이 비대칭이 근본 원인을 가리킨다.**
+
+### 결함 2 — 쪽 표시기 오표시
+
+`canvas-view.ts:301` → `current-page-changed` → 상태바. 3열이면 첫 행에서 "3 / N" 으로 표시되고
+1·2쪽은 현재 쪽으로 표시될 수 없다.
+
+## 2. 분석 — 영향 없는 소비처 구분
+
+| 소비처 | 판정 |
+|---|---|
+| `canvas-view.ts:512` `focusPage` | **영향 없음** — offset/height 만 쓰는데 한 행은 offset 이 같다 |
+| `getPageAtPoint` | **영향 없음** — `rowLastIdx` 를 스캔 끝점으로 쓰는 현재 의미가 맞다 |
+| `view/coordinate-system.ts:18` | 현재 `src/` 내 소비처 없음 — 잠재 위험만 |
+
+`getPageAtY` 의 의미를 바꾸면 `getPageAtPoint` 가 깨지므로, **의미는 유지하고 별도 진입점을
+추가**하는 방향을 택했다.
+
+## 3. 변경
+
+| 파일 | 변경 |
+|---|---|
+| `view/virtual-scroll.ts` | `getRowFirstPageAtY()` 추가(단일 컬럼에선 `getPageAtY` 와 동치), `pagesPerRow` 게터 추가, `getPageAtY` 에 의미 문서화 |
+| `view/canvas-view.ts:301` | 쪽 표시기를 `getRowFirstPageAtY` 로 |
+| `engine/input-handler-keyboard.ts` | PageUp/PageDown 을 행 첫 쪽 기준 **±열수** 로 |
+
+`±1` → `±pagesPerRow` 가 핵심이다. 단일 컬럼에서는 `pagesPerRow = 1` 이라 **종전 동작과 동일**하다.
+
+## 4. 검증
+
+### 신규 테스트 — 이 클래스의 첫 테스트
+
+`tests/virtual-scroll-grid-page.test.ts` (4건). `VirtualScroll` 은 타입만 import 하는 순수
+모듈이라 **DOM/브라우저 없이** `node --test` 로 검증된다. 종전엔 `tests/virtual-scroll*` 파일이
+**존재하지 않아 이 클래스 전체가 미테스트**였다.
+
+1. `getPageAtY` 가 행의 마지막 쪽을 준다(의도된 의미 고정)
+2. `getRowFirstPageAtY` 가 행의 첫 쪽을 준다 — 상태바가 1쪽을 표시 가능
+3. PageUp 목표의 offset 이 현재와 **달라야** 한다 — 종전 ±1 이 무동작이던 지점
+4. 단일 컬럼에서 두 진입점이 동치(회귀 없음)
+
+전제 조건(`isGridMode()`, `pagesPerRow > 1`)을 테스트 안에서 단언해, 레이아웃이 바뀌어
+그리드가 아니게 되면 조용히 통과하지 않고 실패한다.
+
+### 회귀
+
+`node --test tests/*.test.ts` — 신규 4건 포함 전부 통과, 기존 실패는 `cell-flow-boundary.test.ts`
+하나로 이는 깨끗한 devel 에서도 실패하는 **사전 실패**다(이전 작업에서 stash 로 확인함).
+
+### 미실행 항목 (투명 고지)
+
+- **실제 키 입력 행위 검증 미실행** — PageUp 키다운→스크롤 이동까지는 jsdom/브라우저가 필요하다.
+  본 PR 은 그 결정 요인인 좌표/스텝 계산을 순수 단위 테스트로 고정하는 데 그쳤다.
+- 같은 스윕에서 나온 별건(`page:col-right` 가 `page:col-left` 와 바이트 동일, 머리말/꼬리말
+  숨김 명령이 undo 라우팅 우회)은 **범위를 섞지 않기 위해 제외**했다. 필요하면 별도 이슈로 등록하겠다.

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -1200,10 +1200,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const vpSize = this.viewportManager.getViewportSize();
       const scrollY = this.viewportManager.getScrollY();
       const vpCenter = scrollY + vpSize.height / 2;
-      const currentPage = this.virtualScroll.getPageAtY(vpCenter);
+      // [#2560] 그리드 모드에서는 한 행의 쪽들이 같은 offset 을 갖는다. 행의
+      // 마지막 쪽에서 ±1 하면 같은 행에 머물러 스크롤이 움직이지 않으므로
+      // (PageUp 이 무동작), 행의 첫 쪽 기준으로 행 단위(±열수)로 이동한다.
+      // 단일 컬럼에서는 pagesPerRow=1 이라 종전 동작과 동일하다.
+      const currentPage = this.virtualScroll.getRowFirstPageAtY(vpCenter);
+      const step = this.virtualScroll.pagesPerRow;
       const targetPage = e.key === 'PageUp'
-        ? Math.max(0, currentPage - 1)
-        : Math.min(this.virtualScroll.pageCount - 1, currentPage + 1);
+        ? Math.max(0, currentPage - step)
+        : Math.min(this.virtualScroll.pageCount - 1, currentPage + step);
       if (targetPage !== currentPage) {
         const targetOffset = this.virtualScroll.getPageOffset(targetPage);
         this.viewportManager.setScrollTop(targetOffset - this.virtualScroll.gap);

--- a/rhwp-studio/src/engine/input-handler-text.ts
+++ b/rhwp-studio/src/engine/input-handler-text.ts
@@ -26,6 +26,19 @@ import {
   type NavigationKeyInput,
 } from './navigation-keymap';
 
+/**
+ * [#2548] WASM 삭제/조회 count 는 Rust `Paragraph::delete_text_at` 의 char(Unicode
+ * scalar) 단위다. JS `String.length`(UTF-16 code unit)를 넘기면 astral 문자(😀 등)에서
+ * 실제보다 많이 지워 인접 문자를 잃는다 — [#2337-review] 가 undo/HF/FN 경로에 적용한
+ * 계약을 IME 조합 경로에도 맞춘다.
+ *
+ * 주의: *커서 오프셋* 은 studio 의 UTF-16 관례를 유지한다(command.ts `charCount` 주석,
+ * tests/undo-delete-char-count.test.ts 참조). 여기서는 삭제/조회 count 에만 쓴다.
+ */
+function charCount(s: string): number {
+  return [...s].length;
+}
+
 const FOOTNOTE_DELETE_TITLE = '각주 삭제';
 const FOOTNOTE_DELETE_MESSAGE = '각주를 삭제하시겠습니까?';
 
@@ -471,7 +484,8 @@ export function onInput(this: any, e?: InputEvent): void {
     // 현재 조합 텍스트 삽입
     if (text) {
       this.insertTextAtRaw(anchor, text);
-      this.compositionLength = text.length;
+      // 다음 조합 업데이트에서 deleteTextAt 의 삭제 count 로 쓰이므로 scalar 단위.
+      this.compositionLength = charCount(text);
       this._lastCompositionText = text; // 더블 자음 분리 방지용
     } else {
       this.compositionLength = 0;
@@ -536,7 +550,7 @@ export function onInput(this: any, e?: InputEvent): void {
     // 현재 div 전체 텍스트를 문서에 삽입 (빈 값이면 삭제만)
     if (text) {
       this.insertTextAtRaw(this._iosAnchor, text);
-      this._iosLength = text.length;
+      this._iosLength = charCount(text);
     } else {
       this._iosLength = 0;
     }

--- a/rhwp-studio/src/view/canvas-view.ts
+++ b/rhwp-studio/src/view/canvas-view.ts
@@ -298,7 +298,9 @@ export class CanvasView {
     // 현재 페이지 번호 갱신
     if (visiblePages.length > 0) {
       const vpCenter = scrollY + vpHeight / 2;
-      const currentPage = this.virtualScroll.getPageAtY(vpCenter);
+      // [#2560] 그리드 모드에서 getPageAtY 는 행의 마지막 쪽을 준다. 상태바가
+      // 3열이면 첫 행에서 "3 / N" 으로 표시되고 1·2쪽은 현재 쪽이 될 수 없었다.
+      const currentPage = this.virtualScroll.getRowFirstPageAtY(vpCenter);
       this.eventBus.emit(
         'current-page-changed',
         currentPage,

--- a/rhwp-studio/src/view/virtual-scroll.ts
+++ b/rhwp-studio/src/view/virtual-scroll.ts
@@ -130,6 +130,15 @@ export class VirtualScroll {
   }
 
   /** 특정 문서 Y 좌표가 속하는 페이지 인덱스를 반환한다 */
+  /**
+   * Y 가 속한 행의 **마지막** 쪽 인덱스.
+   *
+   * 그리드 모드에서 한 행의 모든 쪽은 같은 offset 을 가지므로(layoutGrid),
+   * 뒤에서부터 스캔하는 이 함수는 그 행의 최대 인덱스를 돌려준다.
+   * `getPageAtPoint` 가 X 로 좁히기 위한 스캔 끝점으로 쓴다.
+   *
+   * "현재 쪽" 이 필요하면 [`getRowFirstPageAtY`] 를 쓸 것 — [#2560].
+   */
   getPageAtY(docY: number): number {
     for (let i = this.pageOffsets.length - 1; i >= 0; i--) {
       if (docY >= this.pageOffsets[i]) {
@@ -137,6 +146,25 @@ export class VirtualScroll {
       }
     }
     return 0;
+  }
+
+  /**
+   * Y 가 속한 행의 **첫** 쪽 인덱스 — 사람이 말하는 "현재 쪽".
+   *
+   * 단일 컬럼 모드에서는 `getPageAtY` 와 동치다.
+   */
+  getRowFirstPageAtY(docY: number): number {
+    const rowLastIdx = this.getPageAtY(docY);
+    if (!this.gridMode) return rowLastIdx;
+    const rowOffset = this.pageOffsets[rowLastIdx];
+    let rowFirst = rowLastIdx;
+    while (rowFirst > 0 && this.pageOffsets[rowFirst - 1] === rowOffset) rowFirst--;
+    return rowFirst;
+  }
+
+  /** 한 행에 놓이는 쪽 수. 단일 컬럼 모드는 1. */
+  get pagesPerRow(): number {
+    return this.gridMode ? this.columns : 1;
   }
 
   /**

--- a/rhwp-studio/tests/ime-composition-char-count.test.ts
+++ b/rhwp-studio/tests/ime-composition-char-count.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#2548] IME 조합 경로의 삭제 count char 단위 가드.
+//
+// WASM 삭제/조회 count 는 Rust `Paragraph::delete_text_at` 의 char(Unicode scalar)
+// 단위다(src/model/paragraph.rs). JS `String.length`(UTF-16 code unit)를 넘기면
+// astral 문자(😀 등)에서 실제보다 많이 지워 인접 문자를 잃는다.
+//
+// [#2337-review] 는 undo/HF/FN 경로에 charCount() 를 적용했으나 IME 조합 경로
+// (compositionLength / _iosLength)는 누락돼 있었다. 되돌아가지 않도록 핀한다.
+//
+// 주의: *커서 오프셋* (`anchor.charOffset + text.length`)은 studio 의 UTF-16 관례를
+// 유지하므로 이 가드의 대상이 아니다 — tests/undo-delete-char-count.test.ts 와 동일 방침.
+// 행위 증명(이모지 후보 조합 → 인접 문자 보존)은 브라우저 왕복(PR 검증).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler-text.ts'), 'utf8');
+
+test('IME 조합 길이는 charCount(scalar)로 계산한다', () => {
+  assert.match(src, /this\.compositionLength = charCount\(text\)/,
+    'compositionLength 는 deleteTextAt 의 삭제 count 로 쓰이므로 scalar 여야 함');
+  assert.doesNotMatch(src, /this\.compositionLength = text\.length/,
+    'UTF-16 length 를 삭제 count 로 쓰면 조합 중 astral 문자에서 뒤 문자를 잡아먹는다');
+});
+
+test('iOS 조합 폴백 길이도 charCount(scalar)로 계산한다', () => {
+  assert.match(src, /this\._iosLength = charCount\(text\)/,
+    '_iosLength 도 deleteTextAt 의 삭제 count 로 쓰이므로 scalar 여야 함');
+  assert.doesNotMatch(src, /this\._iosLength = text\.length/,
+    'iOS 폴백도 동일한 over-delete 결함을 갖는다');
+});
+
+test('삭제 count 로 전달되는 길이 변수에 UTF-16 length 가 남아있지 않다', () => {
+  // deleteTextAt(pos, count) 는 count 를 그대로 wasm.deleteText* 에 넘긴다.
+  // 그 count 의 출처인 두 변수만 검사한다(커서 오프셋은 대상 아님).
+  const offenders = [...src.matchAll(/this\.(compositionLength|_iosLength) = ([^;]+);/g)]
+    .filter((m) => /\.length\b/.test(m[2]) && !/charCount\(/.test(m[2]));
+  assert.deepEqual(offenders.map((m) => m[0]), [],
+    '삭제 count 변수에 UTF-16 length 대입이 남아있음');
+});

--- a/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
+++ b/rhwp-studio/tests/virtual-scroll-grid-page.test.ts
@@ -1,0 +1,85 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { VirtualScroll } from '../src/view/virtual-scroll.ts';
+
+// [#2560] 그리드 모드에서 "현재 쪽" 판정 가드.
+//
+// layoutGrid 는 한 행의 모든 쪽에 같은 offset(rowTop)을 넣는다. 뒤에서부터
+// 스캔하는 getPageAtY 는 그래서 행의 *마지막* 쪽을 돌려준다 — getPageAtPoint 가
+// X 로 좁히기 위한 스캔 끝점으로 쓰는 의도된 의미다.
+//
+// 문제는 "현재 쪽" 이 필요한 소비처가 그걸 직접 쓴 것이었다:
+//   - 상태바(canvas-view.ts) → 3열이면 첫 행에서 "3 / N" 으로 표시
+//   - PageUp(input-handler-keyboard.ts) → 행의 마지막 쪽에서 -1 하면 같은 행에
+//     머물러 offset 이 동일 → 스크롤이 전혀 움직이지 않음(PageUp 무동작)
+//
+// getRowFirstPageAtY 와 pagesPerRow 로 두 소비처를 고쳤고, 이 테스트가 그 계약을
+// 고정한다. VirtualScroll 은 타입만 import 하는 순수 모듈이라 DOM 없이 검증된다.
+
+/** width×height 페이지 n개. */
+function pages(n: number, width = 800, height = 1000) {
+  return Array.from({ length: n }, () => ({ width, height })) as never;
+}
+
+/** 3열 그리드가 되도록 충분히 넓은 뷰포트. zoom 0.4 < 0.5 임계값. */
+const ZOOM = 0.4;
+const VIEWPORT = 2000;
+
+test('그리드 모드에서 getPageAtY 는 행의 마지막 쪽을 준다(의도된 의미)', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(6), ZOOM, VIEWPORT);
+  assert.ok(vs.isGridMode(), '전제: 그리드 모드여야 함');
+  assert.ok(vs.pagesPerRow > 1, `전제: 다중 열이어야 함 (실제 ${vs.pagesPerRow})`);
+
+  const firstRowY = vs.getPageOffset(0);
+  assert.equal(
+    vs.getPageAtY(firstRowY),
+    vs.pagesPerRow - 1,
+    'getPageAtPoint 의 스캔 끝점으로 쓰이므로 행의 마지막 쪽이어야 함',
+  );
+});
+
+test('getRowFirstPageAtY 는 행의 첫 쪽을 준다 — 상태바가 1쪽을 표시할 수 있어야 함', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(6), ZOOM, VIEWPORT);
+
+  const firstRowY = vs.getPageOffset(0);
+  assert.equal(
+    vs.getRowFirstPageAtY(firstRowY),
+    0,
+    '첫 행의 현재 쪽은 0 이어야 한다(종전엔 행의 마지막 쪽이라 1쪽을 표시할 수 없었다)',
+  );
+});
+
+test('PageUp 이 이전 행으로 실제로 이동한다 — 행 단위 스텝', () => {
+  const vs = new VirtualScroll(10);
+  vs.setPageDimensions(pages(9), ZOOM, VIEWPORT);
+  const step = vs.pagesPerRow;
+
+  // 둘째 행 위에 커서가 있다고 가정.
+  const secondRowY = vs.getPageOffset(step);
+  const current = vs.getRowFirstPageAtY(secondRowY);
+  assert.equal(current, step, '둘째 행의 첫 쪽이어야 함');
+
+  const target = Math.max(0, current - step);
+  assert.notEqual(
+    vs.getPageOffset(target),
+    vs.getPageOffset(current),
+    'PageUp 목표는 offset 이 달라야 스크롤이 움직인다 — 종전 ±1 은 같은 행이라 무동작이었다',
+  );
+});
+
+test('단일 컬럼 모드에서는 종전 동작과 동일하다', () => {
+  const vs = new VirtualScroll(10);
+  // viewportWidth=0 → 그리드 모드 아님
+  vs.setPageDimensions(pages(4), 1.0, 0);
+  assert.ok(!vs.isGridMode(), '전제: 단일 컬럼');
+  assert.equal(vs.pagesPerRow, 1, '단일 컬럼은 행당 1쪽');
+
+  const y = vs.getPageOffset(2);
+  assert.equal(
+    vs.getRowFirstPageAtY(y),
+    vs.getPageAtY(y),
+    '단일 컬럼에서는 두 진입점이 동치여야 한다(회귀 없음)',
+  );
+});


### PR DESCRIPTION
## 통합

kevin9327 님의 studio 편집 계열 2건을 cherry-pick(-x) 통합.

- #2549: IME 조합 삭제 count 를 char(scalar) 단위로 정정 (#2548) — input-handler-text.ts
- #2562: 그리드 보기 PageUp 무동작·쪽 표시기 오표시 (#2560) — virtual-scroll/canvas-view/keyboard

## 검증

- `npx tsc --noEmit` clean, `npm test` 463/463
- **red→green 재실증**: #2549 소스 원복 시 3건 FAIL, #2562 원복 시 4건 FAIL → 복원 7/7
- 충돌 0

## 운영

head CI 성공 + merge 승인 후 원 PR 크레딧·close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)