### PR TITLE
docs: PR #2518 검토 기록과 npm 검증 절차

### DIFF
--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -505,8 +505,40 @@ Cargo 계열 검증은 순차 실행한다. `cargo test`, `cargo clippy`, `cargo
 | Rust parser/model/CLI | focused test, `cargo test --profile release-test --tests`, `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings` |
 | renderer/layout/typeset/WASM | Rust 검증, `wasm-pack build --target web --out-dir pkg`, 2.6·3.5절 시각 검증 |
 | `rhwp-studio/**` frontend만 변경 | `npx tsc --noEmit`, `npm test`, 실제 브라우저 동작 확인 |
+| `npm/editor/**` 공개 SDK·transport·타입 변경 | 4.3.1절 package unit/contract/type/pack/iframe smoke 확인 |
 | CI workflow 변경 | workflow 구문·변경 조건 확인과 최신 GitHub Actions 결과 확인 |
 | 기존 golden/baseline/fixture 변경 | 관련 focused test, snapshot 결정성 재확인, 최신 PR head CI |
+
+#### 4.3.1 `@rhwp/editor` npm package 로컬 검증
+
+`npm/editor/**`의 public API, transport, `index.d.ts`, README 또는 package manifest를 바꾸는 PR은 Studio
+테스트만으로 끝내지 않는다. publish하지 않고 아래 순서로 package 자체와 소비자 경계를 확인한다.
+
+```bash
+# 1. SDK unit/contract: public option 기본값, transport, timeout, destroy를 확인한다.
+npm --prefix npm/editor test
+
+# 2. CI와 같은 public embed/WASM contract를 확인한다.
+node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs
+
+# 3. 공개 선언 파일의 TypeScript 구문을 확인한다.
+cd rhwp-studio && npx tsc --noEmit --skipLibCheck ../npm/editor/index.d.ts
+
+# 4. publish 없이 tarball에 JS, declaration, transport, README가 포함되는지 확인한다.
+npm --prefix npm/editor pack --dry-run --json
+```
+
+iframe RPC 완료 시점이나 기본 옵션처럼 실제 Studio와의 결합이 바뀌면, fresh WASM build와 로컬 Vite를 준비한
+뒤 실제 embed E2E도 추가한다. 이미 실행 중인 Vite가 있으면 그 URL을 사용하고 새 서버를 중복으로 열지 않는다.
+
+```bash
+wasm-pack build --target web --out-dir pkg
+VITE_URL=http://127.0.0.1:7700 npm --prefix rhwp-studio run e2e:embed
+```
+
+특정 기본값 변경은 E2E에 해당 옵션을 명시해 우회하지 말고, 옵션을 생략한 별도 smoke로도 확인한다. 이 경우
+`createEditor()`로 iframe을 만든 뒤 `loadFile()` Promise가 대화상자 클릭 없이 제한 시간 안에 완료되는지와
+문서 페이지 수를 기록한다. 이 절의 명령, package 파일 목록, 실제 iframe 결과는 review 문서에 함께 남긴다.
 
 공용 API, 여러 crate, renderer와 frontend를 함께 바꾸는 대형 변경이나 작업지시자가 전체 검증을 승인한 경우에는
 다음 전체 게이트를 순차 실행한다.

--- a/mydocs/orders/20260721.md
+++ b/mydocs/orders/20260721.md
@@ -1,5 +1,19 @@
 # 오늘 할일 - 2026년 7월 21일
 
+## PR #2518 embed loadFile 대화상자 교착 수정 처리 완료
+
+- [PR #2518](https://github.com/edwardkim/rhwp/pull/2518)은 `@rhwp/editor.loadFile()`의 생략 기본값을
+  비대화형으로 바꿔 iframe 안내창 입력 대기로 인한 timeout을 막았다. 명시적 `suppressDialogs: false`와
+  raw protocol·Studio 직접 열기 기본값은 유지된다.
+- 원 PR 최신 head의 CI, CodeQL, Render Diff, Native Skia, frontend package gates 및 default-feature shard
+  성공을 확인한 뒤 merge commit [`a621ac1`](https://github.com/edwardkim/rhwp/commit/a621ac19c95a5bc2f79086408b17c9a6ae94f442)로
+  `devel`에 반영됐다.
+- npm package는 unit/contract 19건, public embed/WASM contract 3건, TypeScript declaration, publish tarball
+  파일 목록, 기본 renderer 실제 iframe smoke까지 확인했다. 상세 절차는
+  [PR 검토 워크플로](../manual/pr_review_workflow.md)에 보강했다.
+- 관련 [#2513](https://github.com/edwardkim/rhwp/issues/2513)은 `Closes` 자동 close가 적용되지 않아, 이 docs-only
+  후속 PR merge 후 수동 close와 처리 완료 코멘트를 남긴다.
+
 ## PR #2510 한양·휴먼 ASCII 메트릭 교정 검토 및 후속 기록
 
 - [PR #2510](https://github.com/edwardkim/rhwp/pull/2510)은 한양·휴먼 face가 HY 계열로 오귀속되던 문제를

--- a/mydocs/pr/archives/pr_2518_review.md
+++ b/mydocs/pr/archives/pr_2518_review.md
@@ -1,0 +1,51 @@
+# PR #2518 검토 기록
+
+| 항목 | 내용 |
+|---|---|
+| 원 PR | [#2518](https://github.com/edwardkim/rhwp/pull/2518) |
+| 관련 이슈 | [#2513](https://github.com/edwardkim/rhwp/issues/2513) |
+| 작성자 / base | [@cskwork](https://github.com/cskwork) / `devel` |
+| 검토 범위 | `@rhwp/editor.loadFile()`의 대화상자 기본값, transport 계약, npm package surface |
+| 원 PR 규모 | +494/-21, 12 files |
+| 원 PR merge | 2026-07-21, [`a621ac1`](https://github.com/edwardkim/rhwp/commit/a621ac19c95a5bc2f79086408b17c9a6ae94f442) |
+| 최종 판단 | 수용 및 merge 완료. [#2513](https://github.com/edwardkim/rhwp/issues/2513)은 auto-close되지 않아 후속 상태 확인 대상 |
+
+## 변경과 판단
+
+이 PR은 `@rhwp/editor`의 `loadFile(data, fileName)`에서 `suppressDialogs`를 생략하면 `true`를 보내도록
+변경했다. iframe 내부의 HWPX 검증 또는 로컬 글꼴 안내창이 사용자 입력을 기다려 embed caller의 Promise가
+timeout되는 문제를 SDK 경계에서 막는다.
+
+명시적 `{ suppressDialogs: false }`는 대화형 흐름을 유지하고, 명시적 `true`도 기존 비대화형 동작을 유지한다.
+raw embed protocol과 Studio 직접 열기의 생략 기본값은 바꾸지 않아 SDK 외 caller의 계약도 보존한다. README와
+`index.d.ts`는 새 기본값과 대화형 opt-out을 같은 의미로 설명한다.
+
+`renderer: 'auto'`를 명시한 기존 embed E2E 변경은 이 이슈의 직접 수정 범위는 아니다. 따라서 reviewer는
+별도 headless smoke에서 renderer 옵션을 생략한 `createEditor()`와 zero-option `loadFile()`도 확인했다.
+`canvas2d` 요청 상태에서 7페이지 문서가 제한 시간 안에 완료되어, 기본 renderer 경로가 테스트에서 빠지지
+않았음을 확인했다.
+
+## 검증
+
+- `npm --prefix npm/editor test`: 19/19 통과. 생략, 명시 `false`, 명시 `true`의 `suppressDialogs` 전달 계약을
+  포함한다.
+- `node --test scripts/frontend-wasm-bindings.test.mjs scripts/frontend-editor-embed.test.mjs`: 3/3 통과.
+  public MessageChannel v1, binary transport, legacy fallback, WASM binding 선언을 확인했다.
+- `cd rhwp-studio && npx tsc --noEmit --skipLibCheck ../npm/editor/index.d.ts`: 통과.
+- `npm --prefix npm/editor pack --dry-run --json`: `index.js`, `index.d.ts`, `transport.js`, README,
+  `package.json`의 5개 publish 파일을 확인했다.
+- 실제 headless iframe smoke: renderer 옵션을 생략한 `createEditor()`에서 `loadFile()`이 사용자 대화상자
+  클릭 없이 완료됐고 `pageCount: 7`, requested/backend 모두 `canvas2d`였다.
+- 원 PR 최종 head [`d63d0e2`](https://github.com/edwardkim/rhwp/commit/d63d0e2147b194b01a3f70b1a04b42137491a275)의
+  CI, CodeQL, Render Diff, Native Skia, frontend package gates와 default-feature shard가 모두 성공했다.
+
+## 시각 검증 판정
+
+SDK request option과 package 문서·테스트만 변경하며 renderer, layout, typeset, PDF/SVG 출력 경로는 바꾸지
+않는다. 따라서 visual sweep과 별도 image asset은 필요하지 않다.
+
+## 후속 상태
+
+원 PR은 merge됐다. `devel`이 default branch가 아니므로 PR 본문의 `Closes #2513`가 자동 close를 수행하지
+않았고, 이 docs-only 후속 PR 반영 뒤 [#2513](https://github.com/edwardkim/rhwp/issues/2513)의 해결 상태를
+수동으로 정리한다.


### PR DESCRIPTION
## 변경

- merge된 [PR #2518](https://github.com/edwardkim/rhwp/pull/2518)의 archive 검토 기록과 오늘할일을 보존합니다.
- `npm/editor/**` 공개 SDK·transport·타입 변경 시 필요한 package unit/contract/type/pack/실제 iframe smoke 절차를 PR 검토 매뉴얼에 추가합니다.

## 검증

- `git diff --check`
- 문서 경로·상대 링크·변경 범위 확인
- 원 코드 PR #2518의 최종 CI, CodeQL, Render Diff, Native Skia, frontend package gates 및 default-feature shard 성공 확인

## 후속

- 이 문서 PR merge 후 [#2513](https://github.com/edwardkim/rhwp/issues/2513)의 자동 close 누락을 수동으로 정리하고 원 PR에 처리 완료 코멘트를 남깁니다.
