### PR TITLE
task: kevin9327 그룹D(CI .hml 게이트 + rawSvg 지연 회귀) 통합

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -94,6 +94,7 @@ jobs:
                 && (
                   filename.endsWith('.hwp')
                   || filename.endsWith('.hwpx')
+                  || filename.endsWith('.hml')
                   || filename.endsWith('.pdf')
                   || filename.endsWith('.png')
                 )

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -104,6 +104,7 @@ jobs:
                 && (
                   filename.endsWith('.hwp')
                   || filename.endsWith('.hwpx')
+                  || filename.endsWith('.hml')
                   || filename.endsWith('.pdf')
                   || filename.endsWith('.png')
                 )

--- a/mydocs/report/pr-codeql-hml.md
+++ b/mydocs/report/pr-codeql-hml.md
@@ -1,0 +1,19 @@
+# PR #2644: codeql.yml isReviewReferencePath에 .hml 확장자 추가
+
+## 이슈
+- **Issue**: #2642 — codeql.yml의 리뷰 전용 경로 판정에서 .hml 누락
+
+## 분석
+
+codeql.yml의 preflight 단계에서 isReviewReferencePath() 함수가
+HWP/HWPX 샘플 파일만 리뷰 전용으로 인식한다. HML 샘플 파일이
+추가된 PR은 불필요하게 전체 CodeQL 분석을 트리거한다.
+
+## 변경
+
+`.github/workflows/codeql.yml:97`에 `filename.endsWith('.hml')` 조건 추가
+
+## 결과
+- HML 샘플 파일만 추가된 PR의 CI 효율화
+- 기존 HWP/HWPX/PDF/PNG 경로에 영향 없음
+- Closes #2642

--- a/mydocs/report/pr-rawsvg-delay-fix.md
+++ b/mydocs/report/pr-rawsvg-delay-fix.md
@@ -1,0 +1,39 @@
+# PR #2647: page-renderer 순수 rawSvg 차트 1.5초 지연 회귀 수정
+
+## 이슈
+- **Issue**: #2635 — 순수 RawSvg 차트가 첫 화면에서 1.5초 뒤에 표시됨
+
+## 분석
+
+f32a99856에서 다단계 재렌더(200ms/600ms/1500ms)가 단일 1500ms fallback으로
+변경되었다. 이때 `scheduleReRender()`의 `prefetchLayerImages()`는
+base64 이미지만 디코드 대상으로 찾고, 순수 SVG에는 data URL이 없어
+`tasks.length === 0` → `return false`가 반환된다.
+
+호출부(`scheduleReRender` 라인 873-876):
+```typescript
+this.prefetchLayerImages(pageIdx)
+  .then((decoded) => {
+    if (decoded) finish();  // false면 finish() 호출 안 됨
+  })
+```
+
+순수 SVG 차트는 비동기 디코드가 필요 없으므로 즉시 렌더 가능함에도
+1500ms fallback까지 finish()가 호출되지 않는다.
+
+## 변경
+
+`page-renderer.ts:988`: prefetch할 이미지가 전혀 없으면 `false` 대신 `true` 반환.
+이는 `tasks.length === 0` = "모든 imageCount 항목이 순수 rawSvg(차트/OLE)"
+임을 의미하며, 비동기 디코드가 필요 없으므로 즉시 완료로 간주한다.
+
+## 검증
+
+- 순수 SVG 차트(`samples/chart/원형/쪼개진원형.hwp`): prefetch가 없다 → 즉시 finish()
+- raster 이미지가 있는 페이지: tasks.length > 0 → 기존 decode 완료 후 finish()
+- 이미지/차트가 없는 페이지: imageCount = 0 → scheduleReRender 미진입 (변동 없음)
+- 회귀: 기존 raster 이미지 decode 경로는 tasks.length > 0이므로 동일
+
+## 결과
+- **PR**: https://github.com/edwardkim/rhwp/pull/2647
+- **Closes**: #2635

--- a/mydocs/report/pr-renderdiff-hml.md
+++ b/mydocs/report/pr-renderdiff-hml.md
@@ -1,0 +1,18 @@
+# PR #2653: render-diff.yml isReviewReferencePath에 .hml 확장자 추가
+
+## 이슈
+- **Issue**: #2652 — render-diff.yml 리뷰 전용 경로 판정에서 .hml 누락
+
+## 분석
+
+#2644(codeql.yml), #2646(ci.yml)에서 isReviewReferencePath()에 .hml을
+추가했지만 render-diff.yml은 누락되었다. 3개 워크플로우(ci, codeql, render-diff)가
+동일한 preflight 로직을 공유하므로 모두 일관되어야 한다.
+
+## 변경
+`.github/workflows/render-diff.yml:107`에 `filename.endsWith('.hml')` 조건 추가
+
+## 결과
+- 3개 워크플로우 모두 일관성 확보
+- HML 샘플 파일만 추가된 PR에서 Render Diff 불필요한 실행 방지
+- Closes #2652

--- a/rhwp-studio/src/view/page-renderer.ts
+++ b/rhwp-studio/src/view/page-renderer.ts
@@ -1005,7 +1005,11 @@ export class PageRenderer {
     while ((d = dataUrlRe.exec(json)) !== null) {
       enqueue(`data:${d[1]};base64,${d[2]}`);
     }
-    if (tasks.length === 0) return false;
+    if (tasks.length === 0) {
+      // prefetch할 이미지가 없음 = 모든 imageCount 항목이 순수 rawSvg(차트/OLE).
+      // 이 경우 비동기 디코드가 필요 없으므로 즉시 완료로 간주한다.
+      return true;
+    }
     await Promise.all(tasks);
     return true;
   }


### PR DESCRIPTION
## 통합

kevin9327 님의 CI/렌더 계열을 cherry-pick(-x) 통합.

- #2642: codeql.yml isReviewReferencePath 에 .hml 추가
- #2635: 순수 rawSvg 차트 1.5초 지연 회귀 수정 — prefetch 대상 없으면 즉시 완료 (page-renderer.ts)
- #2652: render-diff.yml isReviewReferencePath 에 .hml 추가

## 중복 흡수 (통합 중 발견)

- **#2539/#2541/#2542/#2545**: GitHub Actions 버전 통일(v4→v5/v7/v8)은 **이미 devel 에 반영**(#2393 아티팩트 보수 + 어제 통합 흡수). cherry-pick 이 빈 커밋이 되어 스킵. #2545 의 workflow 변경분도 동일하며, 잔여 충돌은 어제할일 문서(20260719.md)뿐이라 devel 최신본 유지.
- 4건은 원 PR 에 흡수 결과를 남기고 close.

## 검증

- YAML 유효성 · 마크다운 링크 green
- studio: tsc clean, npm test 456/456
- render-diff/codeql 의 .hml fast-pass 판정 확장은 CI 에서 실동작 검증

## 운영

head CI 성공 + merge 승인 후 원 PR 크레딧·close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)