### PR TITLE
fix(hwpctl): SaveAs 성공 시 dirty 상태를 정리할 onSave 콜백 추가

### DIFF
--- a/mydocs/report/pr-hwpctl-saveas-markclean.md
+++ b/mydocs/report/pr-hwpctl-saveas-markclean.md
@@ -96,5 +96,5 @@ const ctrl = await createHwpCtrl({
 
 ## 결과
 - **Branch**: `pr/fix-issue-2661-hwpctl-markclean`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2683
 - **Closes**: #2661

--- a/mydocs/report/pr-hwpctl-saveas-markclean.md
+++ b/mydocs/report/pr-hwpctl-saveas-markclean.md
@@ -1,0 +1,100 @@
+# PR #????: hwpctl SaveAs 성공 시 dirty 상태 정리 — onSave 콜백 추가
+
+## 이슈
+- **Issue**: #2661 — rhwp-studio: hwpctl SaveAs()가 dirty 상태를 정리하지 않음
+
+## 분석
+
+`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl.SaveAs()`는 blob 다운로드 방식 내보내기를 수행한 후 `documentState.markClean()`을 호출하지 않는다. 이로 인해 SaveAs 성공 후에도 편집 창의 dirty 상태와 자동 백업 draft가 정리되지 않는다.
+
+### 문제의 원인
+
+`HwpCtrl`은 `wasmDoc`만 주입받는 독립 객체로 설계되어 있다. 내부 저장 경로(`file.ts`)는 `services.documentState.markClean('save-as')`를 호출하지만, HwpCtrl은 `documentState`나 `eventBus`에 접근할 방법이 없다.
+
+이슈 본문에서 언급된 대로, 생성자 시그니처를 변경하거나 콜백을 주입하는 방식이 필요하다.
+
+### 해결 방안
+
+세 가지 접근법을 고려했다:
+
+1. **`documentState` 직접 주입**: HwpCtrl이 `DocumentDirtyState`를 직접 알게 하는 방법. 그러나 HwpCtrl의 독립성과 테스트 용이성이 손상됨.
+2. **커스텀 이벤트 발생**: SaveAs 성공 시 DOM 커스텀 이벤트를 발생시키는 방법. 그러나 전역 이벤트는 디버깅이 어렵고 타입 안전성이 낮음.
+3. **✅ 선택적 콜백 주입 (채택)**: 생성자에 선택적 `onSave: SaveCallback` 파라미터를 추가. HwpCtrl의 독립성을 유지하면서 호출자가 후처리를 원하는 대로 구성 가능.
+
+### 선택한 방식의 장점
+
+- **하위 호환성**: `onSave`는 선택적(optional) 파라미터로, 기존 `new HwpCtrl(wasmDoc)` 호출은 전혀 영향 없음
+- **단일 책임**: HwpCtrl은 저장 자체만 담당하고, dirty 상태 관리는 호출자에게 위임
+- **테스트 용이성**: 콜백 모킹이 간단함
+
+## 변경
+
+```typescript
+// before
+export class HwpCtrl {
+  wasmDoc: any;
+  constructor(wasmDoc: any) {
+    this.wasmDoc = wasmDoc;
+  }
+  SaveAs(filename: string): boolean {
+    // ... blob 생성 및 다운로드 ...
+    return true;
+  }
+}
+
+// after
+export type SaveCallback = () => void;
+
+export class HwpCtrl {
+  wasmDoc: any;
+  private onSave: SaveCallback | undefined;
+
+  constructor(wasmDoc: any, onSave?: SaveCallback) {
+    this.wasmDoc = wasmDoc;
+    this.onSave = onSave;  // 선택적 콜백 저장
+  }
+
+  SaveAs(filename: string): boolean {
+    // ... blob 생성 및 다운로드 ...
+    this.onSave?.();  // 저장 성공 시 콜백 호출
+    return true;
+  }
+}
+```
+
+`createHwpCtrl` 팩토리 함수도 확장:
+
+```typescript
+export async function createHwpCtrl(options: {
+  wasmUrl?: string;
+  wasmModule?: any;
+  onSave?: SaveCallback;  // 신규
+}): Promise<HwpCtrl> {
+  // ...
+  return new HwpCtrl(wasmDoc, options.onSave);
+}
+```
+
+## 사용 예
+
+호출자(embed runtime 등)에서 `onSave`로 `documentState.markClean()`을 연결:
+
+```typescript
+const ctrl = await createHwpCtrl({
+  wasmUrl: '/pkg/rhwp_bg.wasm',
+  onSave: () => documentState.markClean('hwpctl-save-as'),
+});
+```
+
+## 검증
+
+- `onSave` 미지정 시 기존 동작 완전히 동일 (`this.onSave`가 `undefined`이므로 `?.()`는 무시)
+- 기존 `new HwpCtrl(wasmDoc)` 생성자 호출 전혀 영향 없음
+- TypeScript 타입 체크 통과 (기존 오류만 존재)
+- 콜백 등록 시 SaveAs 성공 후 정확히 한 번 호출됨
+- SaveAs 예외 발생 시 콜백 호출되지 않음 (catch 블록보다 위에 위치)
+
+## 결과
+- **Branch**: `pr/fix-issue-2661-hwpctl-markclean`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2661

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -20,6 +20,8 @@ import './actions/page';
 export { ParameterSet } from './parameter-set';
 export { Action } from './action';
 
+export type SaveCallback = () => void;
+
 export class HwpCtrl {
   /** rhwp WASM 문서 객체 */
   private wasmDoc: any;
@@ -29,9 +31,12 @@ export class HwpCtrl {
   private cursorPos = 0;
   /** 이벤트 리스너 */
   private listeners: Map<number, Function[]> = new Map();
+  /** 저장 성공 시 dirty 상태 정리 등 후처리 콜백 */
+  private onSave: SaveCallback | undefined;
 
-  constructor(wasmDoc: any) {
+  constructor(wasmDoc: any, onSave?: SaveCallback) {
     this.wasmDoc = wasmDoc;
+    this.onSave = onSave;
   }
 
   /** 내부: WASM 문서 객체 접근 */
@@ -109,6 +114,7 @@ export class HwpCtrl {
       a.download = filename;
       a.click();
       URL.revokeObjectURL(url);
+      this.onSave?.();
       return true;
     } catch (e) {
       console.error('[hwpctl] SaveAs 실패:', e);
@@ -387,6 +393,7 @@ export class HwpCtrl {
 export async function createHwpCtrl(options: {
   wasmUrl?: string;
   wasmModule?: any;
+  onSave?: SaveCallback;
 }): Promise<HwpCtrl> {
   let wasmDoc: any;
 
@@ -400,5 +407,5 @@ export async function createHwpCtrl(options: {
     wasmDoc = HwpDocument.createEmpty();
   }
 
-  return new HwpCtrl(wasmDoc);
+  return new HwpCtrl(wasmDoc, options.onSave);
 }


### PR DESCRIPTION
## 개요

`HwpCtrl.SaveAs()`가 blob 다운로드 성공 후 `markClean()`을 호출하지 않아 dirty 상태와 자동 백업 draft가 정리되지 않는 문제를 수정합니다.

## 관련 이슈

- **Closes**: #2661
- **상위 맥락**: #2660 (호스트 저장 완료 통지 API) 범위에서 제외된 후속 과제

## 문제 상황

`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl.SaveAs()`는 내보내기 성공 후 `documentState.markClean()`을 호출하지 않습니다. 내부 저장 경로(`file.ts`)는 `services.documentState.markClean('save-as')`를 호출하는 것과 일관성이 맞지 않습니다.

`HwpCtrl`은 `wasmDoc`만 주입받는 독립 객체로 설계되어 있어 `documentState`나 `eventBus`에 직접 접근할 수 없습니다.

## 수정 내용

`HwpCtrl` 생성자에 선택적 `onSave: SaveCallback` 파라미터를 추가하고, `SaveAs()` 성공 시 이를 호출합니다. `createHwpCtrl()` 팩토리 함수의 `options`에도 `onSave`를 전달할 수 있게 확장했습니다.

### 변경 사항

| 항목 | 설명 |
|------|------|
| `SaveCallback` 타입 내보내기 | `() => void` 시그니처의 콜백 타입 |
| `HwpCtrl` 생성자 | 두 번째 선택적 파라미터 `onSave` 추가 |
| `SaveAs()` | 성공 경로 끝에 `this.onSave?.()` 호출 추가 |
| `createHwpCtrl()` | `options.onSave`를 받아 생성자에 전달 |

### 코드 비교

```typescript
// before
const ctrl = new HwpCtrl(wasmDoc);
ctrl.SaveAs('doc.hwp');  // markClean() 미호출

// after
const ctrl = new HwpCtrl(wasmDoc, () => documentState.markClean('hwpctl-save-as'));
ctrl.SaveAs('doc.hwp');  // 성공 시 markClean() 호출
```

## 검증 방법

- `onSave`를 지정하지 않으면 기존 동작과 100% 동일 (`undefined?.()`는 무시)
- `SaveAs()` 예외 발생 시 콜백 미호출 (try-catch 구조 유지)
- TypeScript 타입 체크 통과 (기존 `@wasm/rhwp.js` 미생성 오류 외 신규 오류 없음)

## 추가 정보

- 모든 변경은 단일 파일(`rhwp-studio/src/hwpctl/index.ts`)에 국한
- `HwpCtrl`의 공개 API는 완전히 하위 호환 유지
- 처리 결과 문서: `mydocs/report/pr-hwpctl-saveas-markclean.md`