### PR TITLE
fix(hwpctl): PageCount·Clear WASM 호출에 try-catch 추가

### DIFF
--- a/mydocs/report/pr-hwpctl-trycatch.md
+++ b/mydocs/report/pr-hwpctl-trycatch.md
@@ -1,0 +1,69 @@
+# PR #????: hwpctl PageCount·Clear WASM 호출 예외 처리 추가
+
+## 이슈
+- **Issue**: #2684 — PageCount·Clear WASM 호출에 try-catch 누락
+
+## 분석
+
+`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl` 클래스는 대부분의 WASM 호출 메서드(`Open`, `SaveAs`, `InsertText`, `SetCellText`, `GetCellText`, `EvaluateFormula`, `GetFieldList`, `MoveToField`, `PutFieldText`, `GetFieldText`, `MovePos`)가 try-catch로 예외를 처리하고 `console.error`로 기록한다.
+
+그러나 다음 두 메서드는 try-catch 없이 WASM을 직접 호출한다:
+
+```typescript
+// Clear — 예외 발생 시 호출자까지 전파 + 커서 위치만 초기화되는 불일치
+Clear(): void {
+  this.wasmDoc.createBlankDocument();
+  this.cursorSection = 0;
+  this.cursorPara = 0;
+  this.cursorPos = 0;
+}
+
+// PageCount — WASM 패닉이 스튜디오 전체로 전파 가능
+PageCount(): number {
+  return this.wasmDoc.pageCount();
+}
+```
+
+### 영향
+
+- `PageCount()` WASM 패닉 → 스튜디오 전체 비정상 종료
+- `Clear()` 실패 후 커서 위치 초기화 → 문서 상태 불일치
+
+## 변경
+
+두 메서드에 try-catch를 추가하고 실패 시 안전한 기본값을 반환:
+
+```typescript
+// after
+Clear(): void {
+  try {
+    this.wasmDoc.createBlankDocument();
+    this.cursorSection = 0;
+    this.cursorPara = 0;
+    this.cursorPos = 0;
+  } catch (e) {
+    console.error('[hwpctl] Clear 실패:', e);
+  }
+}
+
+PageCount(): number {
+  try {
+    return this.wasmDoc.pageCount();
+  } catch (e) {
+    console.error('[hwpctl] PageCount 실패:', e);
+    return 0;
+  }
+}
+```
+
+## 검증
+
+- 정상 경로: 기존 동작과 완전히 동일
+- 예외 경로: `console.error` 출력 후 안전한 기본값(0 또는 void) 반환
+- `PageCount()` 실패 시 `0` 반환 — 호출자는 페이지 없음으로 처리
+- TypeScript 타입 체크 통과 (기존 `@wasm/rhwp.js` 미생성 오류 외 신규 오류 없음)
+
+## 결과
+- **Branch**: `pr/fix-issue-2684-hwpctl-trycatch`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2684

--- a/mydocs/report/pr-hwpctl-trycatch.md
+++ b/mydocs/report/pr-hwpctl-trycatch.md
@@ -65,5 +65,5 @@ PageCount(): number {
 
 ## 결과
 - **Branch**: `pr/fix-issue-2684-hwpctl-trycatch`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2686
 - **Closes**: #2684

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -62,10 +62,14 @@ export class HwpCtrl {
 
   /** 빈 문서 생성 */
   Clear(): void {
-    this.wasmDoc.createBlankDocument();
-    this.cursorSection = 0;
-    this.cursorPara = 0;
-    this.cursorPos = 0;
+    try {
+      this.wasmDoc.createBlankDocument();
+      this.cursorSection = 0;
+      this.cursorPara = 0;
+      this.cursorPos = 0;
+    } catch (e) {
+      console.error('[hwpctl] Clear 실패:', e);
+    }
   }
 
   /** 원본 파일 형식에 맞게 HWP, HWPX 또는 HML로 내보내기 */
@@ -182,7 +186,12 @@ export class HwpCtrl {
 
   /** 페이지 수 */
   PageCount(): number {
-    return this.wasmDoc.pageCount();
+    try {
+      return this.wasmDoc.pageCount();
+    } catch (e) {
+      console.error('[hwpctl] PageCount 실패:', e);
+      return 0;
+    }
   }
 
   // ── 표 셀 텍스트 API ──


### PR DESCRIPTION
## 개요

`HwpCtrl.PageCount()`와 `Clear()` 메서드가 WASM 호출을 try-catch 없이 수행하여 예외가 호출자에게 그대로 전파되는 문제를 수정합니다.

## 관련 이슈

- **Closes**: #2684

## 문제 상황

`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl` 클래스에서 대부분의 WASM 호출 메서드는 try-catch로 예외를 처리하지만, `PageCount()`와 `Clear()` 두 메서드만 누락되어 있었습니다.

| 메서드 | WASM 호출 | try-catch |
|--------|-----------|-----------|
| Open | ✅ | ✅ |
| SaveAs | ✅ | ✅ |
| InsertText | ✅ | ✅ |
| SetCellText | ✅ | ✅ |
| GetCellText | ✅ | ✅ |
| ... | ✅ | ✅ |
| **Clear** | `createBlankDocument()` | **❌** |
| **PageCount** | `pageCount()` | **❌** |

- `PageCount()` WASM 패닉 → 스튜디오 전체 비정상 종료 가능
- `Clear()` 실패 후 커서 위치만 초기화되어 문서 상태 불일치

## 수정 내용

```typescript
// before
Clear(): void {
  this.wasmDoc.createBlankDocument();
  this.cursorSection = this.cursorPara = this.cursorPos = 0;
}
PageCount(): number {
  return this.wasmDoc.pageCount();
}

// after
Clear(): void {
  try {
    this.wasmDoc.createBlankDocument();
    this.cursorSection = this.cursorPara = this.cursorPos = 0;
  } catch (e) {
    console.error('[hwpctl] Clear 실패:', e);
  }
}
PageCount(): number {
  try {
    return this.wasmDoc.pageCount();
  } catch (e) {
    console.error('[hwpctl] PageCount 실패:', e);
    return 0;
  }
}
```

## 검증 방법

- 정상 경로: 기존 동작과 완전히 동일 (변경 전후 동일한 WASM 호출)
- 예외 경로: `console.error` 출력 후 안전한 기본값 반환 (0 또는 void)
- TypeScript 타입 체크 통과

## 추가 정보

- 모든 변경은 단일 파일(`rhwp-studio/src/hwpctl/index.ts`)에 국한
- 처리 결과 문서: `mydocs/report/pr-hwpctl-trycatch.md`