### PR TITLE
refactor(recovery): recoveryFileName 데드코드 제거

### DIFF
--- a/mydocs/report/pr-recovery-deadcode.md
+++ b/mydocs/report/pr-recovery-deadcode.md
@@ -1,0 +1,51 @@
+# PR #????: recoveryFileName 데드코드 제거
+
+## 이슈
+- **Issue**: #2687 — recoveryFileName 데드코드 제거
+
+## 분석
+
+`rhwp-studio/src/recovery/recovery-format.ts`의 `recoveryFileName()`에 불필요한 조건 분기가 존재한다.
+
+### 문제
+
+```typescript
+export function recoveryFileName(fileName: string, sourceFormat = 'hwp'): string {
+  const base = baseNameWithoutKnownExtension(fileName);
+  if (sourceFormat.toLowerCase() === 'hwpx') return `${base} 복구본.hwp`;
+  return `${base} 복구본.hwp`;  // hwpx 분기와 동일
+}
+```
+
+두 분기가 완전히 동일한 값을 반환한다 (`복구본.hwp`). 주석에서도 "autosave draft는 exportHwp() 결과"라고 명시하고 있어, sourceFormat과 무관하게 항상 .hwp 확장자를 사용하는 것이 의도된 동작이다.
+
+### 영향
+
+- 호출처에서 `sourceFormat`을 넘기지만 실제로 사용되지 않음
+- 불필요한 조건문으로 인한 코드 복잡도 증가
+
+## 변경
+
+1. `sourceFormat` 파라미터 제거
+2. 단일 `return`으로 통일
+3. 호출처(`main.ts:restoreAutosaveDraft`)에서 두 번째 인자 제거
+4. 테스트(`recovery-ui.test.ts`)에서 불필요한 두 번째 인자 제거
+
+```typescript
+// after
+export function recoveryFileName(fileName: string): string {
+  const base = baseNameWithoutKnownExtension(fileName);
+  return `${base} 복구본.hwp`;
+}
+```
+
+## 검증
+
+- `node --test tests/recovery-ui.test.ts` — 전과 동일하게 5/5 통과
+- `recoveryFileName` 시그니처 변경에 따른 타입 오류 없음 (기존 호출처 모두 수정 완료)
+- 함수 동작이 변경되지 않으므로 회귀 없음
+
+## 결과
+- **Branch**: `pr/fix-issue-2687-recovery-deadcode`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2687

--- a/mydocs/report/pr-recovery-deadcode.md
+++ b/mydocs/report/pr-recovery-deadcode.md
@@ -47,5 +47,5 @@ export function recoveryFileName(fileName: string): string {
 
 ## 결과
 - **Branch**: `pr/fix-issue-2687-recovery-deadcode`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2688
 - **Closes**: #2687

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -1082,7 +1082,7 @@ async function offerAutosaveRecoveryIfIdle(): Promise<void> {
 }
 
 async function restoreAutosaveDraft(draft: AutosaveDraft): Promise<void> {
-  const fileName = recoveryFileName(draft.fileName, draft.sourceFormat);
+  const fileName = recoveryFileName(draft.fileName);
   await loadBytes(new Uint8Array(draft.data), fileName, null, performance.now(), { skipRecent: true });
   await deleteAutosaveDraft(draft.id);
   documentState.markDirty('autosave-recovered');

--- a/rhwp-studio/src/recovery/recovery-format.ts
+++ b/rhwp-studio/src/recovery/recovery-format.ts
@@ -12,10 +12,9 @@ function baseNameWithoutKnownExtension(fileName: string): string {
   return trimmed;
 }
 
-export function recoveryFileName(fileName: string, sourceFormat = 'hwp'): string {
+export function recoveryFileName(fileName: string): string {
   const base = baseNameWithoutKnownExtension(fileName);
-  // autosave draft는 exportHwp() 결과이므로 HWPX 출처도 복구본은 HWP로 연다.
-  if (sourceFormat.toLowerCase() === 'hwpx') return `${base} 복구본.hwp`;
+  // autosave draft는 exportHwp() 결과이므로 모든 출처의 복구본은 HWP로 생성한다.
   return `${base} 복구본.hwp`;
 }
 

--- a/rhwp-studio/tests/recovery-ui.test.ts
+++ b/rhwp-studio/tests/recovery-ui.test.ts
@@ -11,7 +11,7 @@ import {
 test('recoveryFileName은 원본을 덮어쓰지 않는 복구본 이름을 만든다', () => {
   assert.equal(recoveryFileName('sample.hwp'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hwpx'), 'sample 복구본.hwp');
-  assert.equal(recoveryFileName('sample.hwpx', 'hwpx'), 'sample 복구본.hwp');
+  assert.equal(recoveryFileName('sample.hwpx'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hml'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('새 문서.hwp'), '새 문서 복구본.hwp');
   assert.equal(recoveryFileName('memo'), 'memo 복구본.hwp');


### PR DESCRIPTION
## 개요

`recoveryFileName()` 함수에서 `sourceFormat` 조건 분기가 양쪽 모두 동일한 값을 반환하는 데드코드를 제거합니다.

## 관련 이슈

- **Closes**: #2687

## 문제 상황

`rhwp-studio/src/recovery/recovery-format.ts`의 `recoveryFileName()`:

```typescript
// before
export function recoveryFileName(fileName: string, sourceFormat = 'hwp'): string {
  const base = baseNameWithoutKnownExtension(fileName);
  if (sourceFormat.toLowerCase() === 'hwpx') return `${base} 복구본.hwp`;
  return `${base} 복구본.hwp`;  // ← 동일!
}
```

두 분기가 완전히 동일하여 조건문이 실제 분기 효과를 전혀 가지지 않습니다.

## 수정 내용

| 파일 | 변경 |
|------|------|
| `recovery-format.ts` | `sourceFormat` 파라미터 제거, 단일 return으로 통일 |
| `main.ts` | `recoveryFileName(draft.fileName, draft.sourceFormat)` → `recoveryFileName(draft.fileName)` |
| `recovery-ui.test.ts` | `recoveryFileName('sample.hwpx', 'hwpx')` → `recoveryFileName('sample.hwpx')` |

## 검증 방법

- `node --test tests/recovery-ui.test.ts` — 5/5 통과 (기존과 동일)
- 함수 반환값 변경 없음 (항상 `복구본.hwp`)

## 추가 정보

- 3개 파일 수정, 4줄 추가 / 5줄 삭제
- 처리 결과 문서: `mydocs/report/pr-recovery-deadcode.md`