### PR TITLE
fix(ext): dev-tools-inject.js HML 링크 감지 정규식에 .hml 추가

### DIFF
--- a/mydocs/report/pr-ext-hml-regex.md
+++ b/mydocs/report/pr-ext-hml-regex.md
@@ -29,5 +29,5 @@ const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
 ## 결과
 - **Branch**: `pr/fix-issue-2689-ext-hml-regex`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2690
 - **Closes**: #2689

--- a/mydocs/report/pr-ext-hml-regex.md
+++ b/mydocs/report/pr-ext-hml-regex.md
@@ -1,0 +1,33 @@
+# PR #????: 확장 프로그램 dev-tools-inject.js HML 링크 감지 정규식 보완
+
+## 이슈
+- **Issue**: #2689 — dev-tools-inject.js HML 링크 감지 정규식에 .hml 누락
+
+## 분석
+
+`rhwpDev.inspect()`는 페이지의 `<a>` 링크 중 HWP 문서 링크를 감지하여 `data-hwp="true"` 속성 누락을 검사한다. 감지 정규식에서 `.hml` 확장자가 누락되어 HML 문서 링크를 HWP 문서로 인식하지 못했다.
+
+`content-script.js`는 올바르게 `.hml`을 포함하고 있으나 `dev-tools-inject.js`에만 누락되어 있었다.
+
+## 변경
+
+Chrome 및 Firefox의 `dev-tools-inject.js`에서 정규식 보완:
+
+```javascript
+// before
+const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+// after
+const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
+```
+
+## 검증
+
+- `.hwp` 링크: 기존과 동일하게 감지
+- `.hwpx` 링크: 기존과 동일하게 감지
+- `.hml` 링크: 신규 감지
+- `.hwp?query=1`: 쿼리 파라미터 처리 기존과 동일
+
+## 결과
+- **Branch**: `pr/fix-issue-2689-ext-hml-regex`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2689

--- a/rhwp-chrome/dev-tools-inject.js
+++ b/rhwp-chrome/dev-tools-inject.js
@@ -15,7 +15,7 @@
       for (const a of links) {
         const href = a.href || '';
         const isMarked = a.getAttribute('data-hwp') === 'true';
-        const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+        const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
         if (!isMarked && !isExt) continue;
 

--- a/rhwp-firefox/dev-tools-inject.js
+++ b/rhwp-firefox/dev-tools-inject.js
@@ -16,7 +16,7 @@
       for (const a of links) {
         const href = a.href || '';
         const isMarked = a.getAttribute('data-hwp') === 'true';
-        const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+        const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
         if (!isMarked && !isExt) continue;
 


### PR DESCRIPTION
## 개요

Chrome 및 Firefox 확장 프로그램의 `dev-tools-inject.js`에서 HWP 문서 링크 감지 정규식에 `.hml` 확장자가 누락된 버그를 수정합니다.

## 관련 이슈

- **Closes**: #2689

## 문제 상황

`content-script.js`는 `.hml`을 포함하고 있으나 `dev-tools-inject.js`는 누락:

```javascript
// content-script.js (올바름)
/HWP_EXTENSIONS = /\.(hwp|hwpx|hml)(\?.*)?$/i;

// dev-tools-inject.js (.hml 누락)
const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
```

`rhwpDev.inspect()`가 `.hml` 확장자 링크를 HWP 문서로 감지하지 못해 `data-hwp="true"` 속성 누락 검사를 수행하지 않습니다.

## 수정 내용

| 파일 | 변경 |
|------|------|
| `rhwp-chrome/dev-tools-inject.js` | 정규식에 `hml` 추가 |
| `rhwp-firefox/dev-tools-inject.js` | 정규식에 `hml` 추가 |

## 검증 방법

- `.hwp`/`.hwpx` 링크 감지: 기존과 동일 (회귀 없음)
- `.hml` 링크 감지: 신규 추가 (정규식 일관성 확보)

## 추가 정보

- 2개 파일, 각 1줄 변경
- `content-script.js`는 이미 올바른 패턴 사용 중이므로 추가 수정 불필요
- 처리 결과 문서: `mydocs/report/pr-ext-hml-regex.md`