### PR TITLE
docs(editor): README에 exportHml·getHmlSaveState API 문서 추가

### DIFF
--- a/mydocs/report/pr-editor-readme-hml.md
+++ b/mydocs/report/pr-editor-readme-hml.md
@@ -1,0 +1,20 @@
+# PR #????: @rhwp/editor README에 exportHml·getHmlSaveState 문서 추가
+
+## 이슈
+- **Issue**: #2691 — README에 exportHml·getHmlSaveState API 문서 누락
+
+## 분석
+
+`npm/editor/index.js`에는 `exportHml()`과 `getHmlSaveState()`가 구현되어 있지만 `npm/editor/README.md`의 API 문서에는 누락되어 있었다. SDK 사용자가 해당 API의 존재를 인지할 수 없었다.
+
+## 변경
+
+`README.md`의 API 섹션에 `exportHwpVerify()` 다음에 두 메서드 추가:
+
+1. `exportHml()` — HML(XML) 내보내기 예제 코드 포함
+2. `getHmlSaveState()` — HML 저장 가능 여부 반환
+
+## 결과
+- **Branch**: `pr/fix-issue-2691-editor-readme-hml`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2691

--- a/mydocs/report/pr-editor-readme-hml.md
+++ b/mydocs/report/pr-editor-readme-hml.md
@@ -16,5 +16,5 @@
 
 ## 결과
 - **Branch**: `pr/fix-issue-2691-editor-readme-hml`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2692
 - **Closes**: #2691

--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -193,6 +193,31 @@ if (!verify.recovered || verify.pageCountBefore !== verify.pageCountAfter) {
 }
 ```
 
+### editor.exportHml()
+
+현재 편집 중인 문서를 HML(XML) 바이너리로 내보냅니다.
+
+```javascript
+const bytes = await editor.exportHml();
+const blob = new Blob([bytes], { type: 'application/xml' });
+
+const url = URL.createObjectURL(blob);
+const a = document.createElement('a');
+a.href = url;
+a.download = 'document.hml';
+a.click();
+URL.revokeObjectURL(url);
+```
+
+### editor.getHmlSaveState()
+
+현재 문서의 HML 저장 가능 여부와 blocker를 반환합니다.
+
+```javascript
+const state = await editor.getHmlSaveState();
+// { ok: true } 또는 { ok: false, blocker: '...' }
+```
+
 ### editor.destroy()
 
 에디터를 제거합니다.


### PR DESCRIPTION
## 개요

`npm/editor/README.md`에 누락된 `exportHml()` 및 `getHmlSaveState()` API 문서를 추가합니다.

## 관련 이슈

- **Closes**: #2691

## 누락된 API

`index.js`에는 구현되어 있으나 README에 문서화되지 않았습니다:

- `exportHml()` — 현재 문서를 HML(XML) 바이너리로 내보내기 (사용 예제 포함)
- `getHmlSaveState()` — 현재 문서의 HML 저장 가능 여부와 blocker 반환

## 수정 내용

`exportHwpVerify()` 섹션 다음에 두 API를 알파벳 순서로 추가했습니다. 기존 `exportHwp()`와 `exportHwpx()`의 문서 패턴과 동일한 형식을 사용합니다.

## 검증 방법

- README.md 마크다운 형식 검증 (코드 블록, 목차 일관성)
- 문서에 추가된 API가 `index.js`의 실제 시그니처와 일치

## 추가 정보

- 1개 파일, 25줄 추가
- 처리 결과 문서: `mydocs/report/pr-editor-readme-hml.md`