### PR TITLE
fix(hwpctl): Open()이 커서 위치를 초기화하지 않음 — Clear()와 일관성

### DIFF
--- a/mydocs/report/pr-hwpctl-open-cursor.md
+++ b/mydocs/report/pr-hwpctl-open-cursor.md
@@ -1,0 +1,13 @@
+# PR #????: hwpctl Open() 커서 위치 초기화
+
+## 이슈
+- **Issue**: #2693 — Open()이 커서 위치를 초기화하지 않음
+
+## 분석
+`Clear()`는 `createBlankDocument()` 후 커서를 (0,0,0)으로 초기화하지만, `Open()`은 `wasmDoc` 교체만 하고 cursor 필드를 초기화하지 않아 이전 문서의 커서 위치가 잔류하는 불일치가 있었다.
+
+## 변경
+`Open()` 성공 경로에 `cursorSection = cursorPara = cursorPos = 0` 추가 (Clear와 동일).
+
+## 결과
+- **Branch**: `pr/fix-issue-2693-hwpctl-open-cursor`

--- a/mydocs/report/pr-hwpctl-open-cursor.md
+++ b/mydocs/report/pr-hwpctl-open-cursor.md
@@ -11,3 +11,5 @@
 
 ## 결과
 - **Branch**: `pr/fix-issue-2693-hwpctl-open-cursor`
+- **PR**: https://github.com/edwardkim/rhwp/pull/2694
+- **Closes**: #2693

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -51,6 +51,9 @@ export class HwpCtrl {
     try {
       const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
       this.wasmDoc = new (this.wasmDoc.constructor)(bytes);
+      this.cursorSection = 0;
+      this.cursorPara = 0;
+      this.cursorPos = 0;
       callback?.(true);
       return true;
     } catch (e) {


### PR DESCRIPTION
## 개요

`HwpCtrl.Open()`이 문서를 새로 열 때 커서 위치를 초기화하지 않아 Clear()와 불일치하는 문제를 수정합니다.

## 관련 이슈

- **Closes**: #2693

## 문제 상황

Clear()는 createBlankDocument() 후 `cursorSection = cursorPara = cursorPos = 0`으로 초기화하지만, Open()은 wasmDoc 교체만 수행하고 cursor 필드를 초기화하지 않습니다.

## 수정 내용

Open() 성공 시 Clear()와 동일하게 세 cursor 필드를 0으로 초기화합니다. 실패 시에는 cursor를 변경하지 않습니다.

## 추가 정보

- 단일 파일, 3줄 추가
- 처리 결과 문서: `mydocs/report/pr-hwpctl-open-cursor.md`