### PR TITLE
fix(hwpx): charPr outline 8값·shadow DROP 열거 절단 수정 (#2695)

### DIFF
--- a/mydocs/report/task_m100_2695_report.md
+++ b/mydocs/report/task_m100_2695_report.md
@@ -1,0 +1,203 @@
+# task_m100_2695 처리결과 보고서 — HWPX charPr outline/shadow 열거값 절단 수정
+
+- **이슈**: [#2695](https://github.com/edwardkim/rhwp/issues/2695)
+- **브랜치**: `task/m100-2695-hwpx-charpr-outline-shadow` (base `devel` @ `2cd4d78b`)
+- **범위**: `src/parser/hwpx/header.rs`, `src/serializer/hwpx/header.rs`
+- **분류**: 결함 수정 (열거값 매핑 누락 — 파싱·직렬화 양측)
+
+## 1. 문제
+
+`<hh:charPr>` 자식 두 개가 **파싱측과 직렬화측 양쪽에서 동시에** 열거값을 잘라먹었다.
+
+| 요소 | 스펙 값 수 | 파서가 구분한 수 | 직렬화가 방출 가능한 수 |
+|---|---|---|---|
+| `<hh:outline type>` | 8 | 4 | 4 |
+| `<hh:shadow type>` | 3 | 2 | 2 |
+
+- **outline**: 파서 `_ => 0`(`parser/hwpx/header.rs:751-764`), 직렬화 `_ => "NONE"`
+  (`outline_type_str`, `serializer/hwpx/header.rs:759-767`). 값 4~7
+  (`DASH_DOT`/`DASH_DOT_DOT`/`LONG_DASH`/`CIRCLE`)이 `NONE` 으로 떨어져 **외곽선이 다른 선으로
+  열화되는 게 아니라 아예 소멸**했다.
+- **shadow**: 파서가 `"DROP" | "CONTINUOUS" => 1` 로 두 종류를 한 슬롯에 합치고
+  (`parser/hwpx/header.rs:765-782`), 직렬화는 `if shadow_type == 0 {"NONE"} else {"CONTINUOUS"}`
+  (`serializer/hwpx/header.rs:649-665`)라 **`"DROP"` 문자열이 코드 어디에도 없었다** — 방출 불가능.
+
+두 필드 모두 IR 은 이미 충분한 값 범위를 담고 있었다. `CharShape.outline_type`(`model/style.rs:124`)은
+HWP5 `attr` bits 8-10 **3비트**를 그대로 받고(`parser/doc_info.rs:592`의 `(attr >> 8) & 0x07`,
+재패킹 `serializer/doc_info.rs:470-472`), `CharShape.shadow_type`(`model/style.rs:126`)은
+bits 11-12 **2비트**를 받는다(`parser/doc_info.rs:593`의 `(attr >> 11) & 0x03`, 재패킹 `:473-475`).
+즉 손실 지점은 오직 HWPX 매핑 테이블이었다.
+
+## 2. 분석
+
+### 2.1 누락임을 보이는 자기모순
+
+**같은 파서 파일**이 40여 줄 위에서 밑줄(`header.rs:695-710`)·취소선(`:727-742`)에 대해 선 종류
+13종(0~12) 전체를 이미 매핑한다. 직렬화측 `line_shape_str`(`serializer/hwpx/header.rs:742-757`)도
+0~12 를 전부 되돌린다. 즉 `DASH_DOT`/`DASH_DOT_DOT`/`LONG_DASH`/`CIRCLE` 네 문자열은 저장소가
+**이미 알고 이미 처리하던 값**이고, outline 매핑에서만 빠져 있었다. 한 파일 안에서 같은 선 종류
+계열을 한쪽은 13개, 다른 쪽은 4개로 다루는 것은 설계가 아니라 불일치다.
+
+같은 파일의 기존 테스트 `tab_leader_str_emits_double_and_triple_line_types` 가 이미 동일 유형
+(`fill_type 9/10/11` 이 `"NONE"` 으로 유실)을 결함으로 인정하고 고친 전례다.
+
+### 2.2 손실 경로 4종
+
+| # | 입력 | 경로 | 산출 | 피해 |
+|---|---|---|---|---|
+| L1 | HWPX `outline type="DASH_DOT"` | 파싱 → IR `0` → 직렬화 | `type="NONE"` | 외곽선 소멸 (파싱측 유실) |
+| L2 | HWP5 attr bits 8-10 = `0b101` | `doc_info` → IR `5` → HWPX 직렬화 | `type="NONE"` | 외곽선 소멸 (직렬화측 유실) |
+| L3 | HWPX `shadow type="DROP" offsetX/Y` | 파싱 → IR `1` → 직렬화 | `type="CONTINUOUS"` + 오프셋 잔존 | 종류 변조, 오프셋이 해석 주체를 잃음 |
+| L4 | HWP5 attr bits 11-12 = `0b10` | `doc_info` → IR `2` → HWPX `CONTINUOUS` → **재파싱** → IR `1` → `doc_info` | bits = `0b01` | **바이너리 손상** (HWPX 경유만으로 2→1) |
+
+L1 은 직렬화만, L2 는 파서만 고쳐서는 해결되지 않는다. 양측을 함께 고쳐야 하는 근거다.
+
+### 2.3 마스킹 없음 확인
+
+원문 보존(raw splice) 경로가 이 결함을 가리는지 확인했고 **해당 없음**으로 판정했다.
+
+- `hwpx_head_tail` splice(파서 `:218-224` → 직렬화 `:92-103`)는 `</hh:refList>` **이후** 꼬리
+  구간만 보존한다. `charPr` 은 `refList` **안**이라 범위 밖이다.
+- `write_char_pr`(`serializer/hwpx/header.rs:574`)에 원문 재사용 단축 경로가 없다.
+- `raw_para_heads` 보존(`:885-891`)은 numbering 의 `paraHead` 전용이다.
+
+### 2.4 하위 호환 확인 (범위 확대의 안전성)
+
+`outline_type`/`shadow_type` 의 **모든 소비 지점이 `!= 0` / `> 0` 불리언 판정 또는 단순 복사**임을
+전수 확인했다. `outline_type <= 3` 이나 `shadow_type <= 1` 을 전제하는 코드는 없다.
+
+`canvaskit_policy.rs:1834,1837` · `html.rs:352` · `web_canvas.rs:2189,2893,2901` · `svg.rs:2823` ·
+`skia/text_replay.rs:531,539` · `paint/text_v2.rs:758-759` — 전부 비영 판정.
+`paint/paint_op.rs:1551-1552` 는 `== 0` 빈 스타일 판정. `style_resolver.rs:379-380`,
+`layout/text_measurement.rs:1446-1447` 은 단순 복사. `parser/hwp3/mod.rs:279-280` 은 HWP3 불리언을
+`0`/`1` 로만 쓰므로 영향 없다.
+
+## 3. 변경
+
+매핑 테이블 4곳만 수정했다(파일 2개).
+
+1. **파서 outline**(`parser/hwpx/header.rs`) — `DASH_DOT=4`, `DASH_DOT_DOT=5`, `LONG_DASH=6`,
+   `CIRCLE=7` 4개 arm 추가. 문자열은 같은 파일 `underline_shape` 테이블이 쓰는 이름 그대로다
+   (outline 은 `NONE` 이 0번을 차지하므로 선 종류 인덱스보다 1 크다).
+2. **직렬화 `outline_type_str`** — (1)의 정확한 역함수로 `4..=7` 확장.
+3. **파서 shadow** — `"DROP" | "CONTINUOUS" => 1` 을 `"DROP" => 1, "CONTINUOUS" => 2` 로 분리.
+4. **직렬화 shadow** — `write_char_pr` 인라인 `if`/`else` 를 신설 `shadow_type_str(t)` 3분기
+   `match` 로 교체. 인접한 `outline_type_str`/`line_shape_str` 과 동일한 헬퍼 형태를 따랐다.
+
+주석은 저장소 관례대로 한국어 `[#2695]` 접두어로 달고, 각 값이 HWP5 어느 비트에 대응하는지를 남겼다.
+
+## 4. 검증
+
+### 신규 테스트 (`serializer/hwpx/header.rs` 기존 `#[cfg(test)]` 모듈)
+
+파싱과 직렬화를 한 테스트에서 함께 고정하는 왕복 형태다(헬퍼 `parse_single_char_pr` /
+`write_single_char_pr` 신설).
+
+- `char_pr_outline_type_roundtrips_all_eight_values` — 8값 전부에 대해 `type=X` → IR 기대값 →
+  재직렬화 `type=X` 를 단언.
+- `char_pr_shadow_drop_survives_roundtrip_with_offsets` — `DROP` + `offsetX=10`/`offsetY=-7` →
+  IR `1` → 재직렬화 `type="DROP"` 및 오프셋 보존.
+- `char_pr_shadow_continuous_is_ir_two_not_one` — `CONTINUOUS` → IR `2` → 재직렬화
+  `type="CONTINUOUS"` (L4 바이너리 손상 경로 고정).
+
+### red→green 실증 (수정 4곳을 각각 되돌려 4회 수행)
+
+각 수정을 **하나씩만** 되돌려 테스트가 실제로 실패하는지 확인하고 복원했다. 아래는 실제 캡처
+출력이다.
+
+**RED 1 — 파서 outline arm 4~7 제거**
+
+```
+test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (3412) panicked at src\serializer\hwpx\header.rs:1984:13:
+assertion `left == right` failed: outline type=DASH_DOT 은 IR 4 로 파싱돼야 함
+  left: 0
+ right: 4
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 2 — 직렬화 `outline_type_str` arm 4~7 제거** (IR 은 4를 들고 있는데 `NONE` 이 방출되는
+소멸 현상이 출력에 그대로 찍힌다)
+
+```
+test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (33564) panicked at src\serializer\hwpx\header.rs:1986:13:
+outline_type=4 은 type="DASH_DOT" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="NONE" color="#000000" offsetX="0" offsetY="0"/></hh:charPr>
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 3 — 파서 shadow 를 `"DROP" | "CONTINUOUS" => 1` 로 되돌림** (L4 의 값 붕괴 2→1 이 그대로 재현)
+
+```
+test serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one' (9720) panicked at src\serializer\hwpx\header.rs:2026:9:
+assertion `left == right` failed: CONTINUOUS 는 IR 2(연속)
+  left: 1
+ right: 2
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 4 — 직렬화 shadow 를 `if`/`else` 로 되돌림** (L3 의 "종류는 변조되고 오프셋만 남는" 증상이
+출력에 그대로 찍힌다: `type="CONTINUOUS" ... offsetX="10" offsetY="-7"`)
+
+```
+test serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets' (33392) panicked at src\serializer\hwpx\header.rs:2011:9:
+shadow_type=1 은 type="DROP" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="CONTINUOUS" color="#C0C0C0" offsetX="10" offsetY="-7"/></hh:charPr>
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**GREEN — 4곳 모두 복원**
+
+```
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+### 회귀
+
+```
+cargo test --lib hwpx    →  474 passed / 0 failed / 0 ignored
+cargo test --lib header  →  130 passed / 0 failed / 1 ignored
+cargo test --lib (전체)  → 2448 passed / 0 failed / 7 ignored
+```
+
+값 범위를 넓히는 변경이라 렌더러까지 영향이 갈 수 있어 전체 lib 테스트도 돌렸고, 실패는 없다.
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
+  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라 실행하지 않았다.
+- **실제 한/글 시각 검증**: 외곽선 4종·비연속 그림자를 지정한 실문서를 한/글에서 열어 확인하는
+  절차는 수행하지 않았다. 검증은 파싱·직렬화 왕복의 값 보존 수준에서 이뤄졌다. 다만 §2.4 에서
+  모든 렌더러 소비 지점이 비영 판정만 한다는 점을 확인했으므로, 이 변경이 렌더링 동작을 바꾸는
+  경로는 없다(렌더러는 종전에도 지금도 "외곽선 있음/없음"만 구분한다). 즉 이번 수정의 효과는
+  **저장 파일의 값 보존**에 한정되며, 종류별 렌더링 차등화는 별개 과제다.
+- **HWP5 왕복 통합 테스트**(L4 경로를 `.hwp` 바이트 수준에서 끝까지 검증)는 추가하지 않았다.
+  `serializer/doc_info.rs:473-475` 가 `shadow_type` 을 `& 0x03` 으로 그대로 재패킹함을 코드로
+  확인했고, 붕괴 지점이 HWPX 매핑임을 `char_pr_shadow_continuous_is_ir_two_not_one` 으로 직접
+  고정했다. 포맷 간 완전 왕복 하네스는 이 범위를 넘는다고 판단했다.
+
+## 5. 잔여 (범위 밖)
+
+조사 중 같은 두 파일에서 확인했으나 이번 범위에 넣지 않은 항목. 이슈 #2695 §7 에 상세를 남겼다.
+
+- **`breakSetting@lineWrap`** 이 `"BREAK"` 상수 하드코딩. 파서는 이 속성을 읽지도 않는다. IR
+  귀속처는 `ParaShape.attr2` bits 0-1 (`ParaShapeMods::single_line`, `model/style.rs:974-976`).
+  파서·직렬화·IR 세 곳을 함께 이어야 하는 별개 작업.
+- **`<hh:autoSpacing>`** 이 `"0"/"0"` 하드코딩. **이것은 단순 매핑 문제가 아니라 `attr2` bit 5 의
+  규약 충돌 때문에 의도적으로 보류했다.** `model/style.rs:977-982` 계열은 bit 4 =
+  `auto_space_kr_en`, bit 5 = `auto_space_kr_num` 으로 쓰고, HWPX 파서(`header.rs:1023-1028`)·
+  직렬화(`serializer/hwpx/header.rs:1048`)·렌더러(`style_resolver.rs:883`) 계열은 bit 5 =
+  `widowOrphan` 으로 쓴다. 한쪽을 설정하면 다른 쪽이 오염되는 실버그이며, **어느 비트 규약을
+  정본으로 삼을지에 대한 설계 결정이 선행**돼야 해서 이번 수정에 포함하지 않았다.
+- **`charPr@shadeColor` 의 `0 → "none"` 특례**(`serializer/hwpx/header.rs:581-585`) — 검정
+  음영(`#000000`)과 음영 없음이 구분되지 않아 검정 음영이 소멸한다. 센티넬 값 설계 사안이라 분리.
+- **`paraPr@suppressLineNumbers` / `@checked`** — 대응 IR 필드가 아예 없어 모델 확장이 선행돼야 한다.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -752,11 +752,18 @@ fn parse_char_shape(
                             for attr in ce.attributes().flatten() {
                                 if attr.key.as_ref() == b"type" {
                                     let val = attr_str(&attr);
+                                    // [#2695] 외곽선 8종 (표 27 선 종류 앞 7개 + NONE).
+                                    // HWP5 attr bits 8-10 (3비트) 과 1:1 대응하므로
+                                    // 4~7 을 버리면 외곽선이 NONE 으로 소멸한다.
                                     cs.outline_type = match val.as_str() {
                                         "NONE" => 0,
                                         "SOLID" => 1,
                                         "DASH" => 2,
                                         "DOT" => 3,
+                                        "DASH_DOT" => 4,
+                                        "DASH_DOT_DOT" => 5,
+                                        "LONG_DASH" => 6,
+                                        "CIRCLE" => 7,
                                         _ => 0,
                                     };
                                 }
@@ -767,9 +774,13 @@ fn parse_char_shape(
                                 match attr.key.as_ref() {
                                     b"type" => {
                                         let val = attr_str(&attr);
+                                        // [#2695] HWP5 attr bits 11-12: 1=비연속(DROP,
+                                        // offsetX/Y 사용), 2=연속(CONTINUOUS). 둘을 1 로
+                                        // 합치면 HWP5 왕복에서 2 가 1 로 손상된다.
                                         cs.shadow_type = match val.as_str() {
                                             "NONE" => 0,
-                                            "DROP" | "CONTINUOUS" => 1,
+                                            "DROP" => 1,
+                                            "CONTINUOUS" => 2,
                                             _ => 0,
                                         };
                                     }

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -650,14 +650,7 @@ fn write_char_pr<W: Write>(
         w,
         "hh:shadow",
         &[
-            (
-                "type",
-                if cs.shadow_type == 0 {
-                    "NONE"
-                } else {
-                    "CONTINUOUS"
-                },
-            ),
+            ("type", shadow_type_str(cs.shadow_type)),
             ("color", &color_hex(cs.shadow_color)),
             ("offsetX", &cs.shadow_offset_x.to_string()),
             ("offsetY", &cs.shadow_offset_y.to_string()),
@@ -756,13 +749,29 @@ fn line_shape_str(s: u8) -> &'static str {
     }
 }
 
+// [#2695] 외곽선 8종. IR outline_type 은 HWP5 attr bits 8-10(3비트)을 그대로 담으므로
+// 0~7 전부를 방출해야 한다. 4~7 을 NONE 으로 떨구면 외곽선이 소멸한다.
 fn outline_type_str(t: u8) -> &'static str {
     match t {
         0 => "NONE",
         1 => "SOLID",
         2 => "DASH",
         3 => "DOT",
+        4 => "DASH_DOT",
+        5 => "DASH_DOT_DOT",
+        6 => "LONG_DASH",
+        7 => "CIRCLE",
         _ => "NONE",
+    }
+}
+
+// [#2695] 그림자 3종. IR shadow_type 은 HWP5 attr bits 11-12(2비트).
+// 1=비연속(DROP), 2=연속(CONTINUOUS).
+fn shadow_type_str(t: u8) -> &'static str {
+    match t {
+        0 => "NONE",
+        1 => "DROP",
+        _ => "CONTINUOUS",
     }
 }
 
@@ -1926,6 +1935,100 @@ mod tests {
         assert!(
             xml.contains(r#"<hh:shadow type="NONE""#),
             "shadow NONE 항상 출력: {xml}"
+        );
+    }
+
+    /// [#2695] charPr 자식 하나를 담은 최소 hh:head 를 파싱해 CharShape 를 얻는다.
+    fn parse_single_char_pr(child: &str) -> CharShape {
+        let xml = format!(
+            r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="1">
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+        {child}
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##
+        );
+        let (doc_info, _) =
+            crate::parser::hwpx::header::parse_hwpx_header(&xml).expect("parse hh:head");
+        doc_info.char_shapes[0].clone()
+    }
+
+    /// [#2695] CharShape 를 charPr 로 직렬화한 XML 문자열.
+    fn write_single_char_pr(cs: &CharShape) -> String {
+        let mut writer = Writer::new(Vec::new());
+        write_char_pr(&mut writer, 0, cs).expect("write charPr");
+        String::from_utf8(writer.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn char_pr_outline_type_roundtrips_all_eight_values() {
+        // [#2695] 외곽선은 HWP5 attr bits 8-10(3비트) = 8종이다. 종전엔 파서가
+        // NONE/SOLID/DASH/DOT 4종만 알고 나머지를 `_ => 0` 으로, 직렬화가
+        // `_ => "NONE"` 으로 떨궈 4~7 지정 시 외곽선이 통째로 사라졌다.
+        for (name, expected) in [
+            ("NONE", 0u8),
+            ("SOLID", 1),
+            ("DASH", 2),
+            ("DOT", 3),
+            ("DASH_DOT", 4),
+            ("DASH_DOT_DOT", 5),
+            ("LONG_DASH", 6),
+            ("CIRCLE", 7),
+        ] {
+            let cs = parse_single_char_pr(&format!(r#"<hh:outline type="{name}"/>"#));
+            assert_eq!(
+                cs.outline_type, expected,
+                "outline type={name} 은 IR {expected} 로 파싱돼야 함"
+            );
+
+            let xml = write_single_char_pr(&cs);
+            assert!(
+                xml.contains(&format!(r#"<hh:outline type="{name}"/>"#)),
+                "outline_type={expected} 은 type=\"{name}\" 으로 방출돼야 함: {xml}"
+            );
+        }
+    }
+
+    #[test]
+    fn char_pr_shadow_drop_survives_roundtrip_with_offsets() {
+        // [#2695] 비연속(DROP)은 offsetX/offsetY 로 본체와 떨어뜨려 그리는 종류다.
+        // 종전엔 파서가 DROP|CONTINUOUS 를 모두 1 로 합치고 직렬화가 0 이외를
+        // 무조건 CONTINUOUS 로 써서 DROP 이 방출 불가능했고, 보존된 오프셋도
+        // 해석 주체를 잃었다.
+        let cs = parse_single_char_pr(
+            r##"<hh:shadow type="DROP" color="#C0C0C0" offsetX="10" offsetY="-7"/>"##,
+        );
+        assert_eq!(cs.shadow_type, 1, "DROP 은 IR 1(비연속)");
+        assert_eq!(cs.shadow_offset_x, 10);
+        assert_eq!(cs.shadow_offset_y, -7);
+
+        let xml = write_single_char_pr(&cs);
+        assert!(
+            xml.contains(r#"<hh:shadow type="DROP""#),
+            "shadow_type=1 은 type=\"DROP\" 으로 방출돼야 함: {xml}"
+        );
+        assert!(
+            xml.contains(r#"offsetX="10" offsetY="-7""#),
+            "오프셋도 함께 보존돼야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn char_pr_shadow_continuous_is_ir_two_not_one() {
+        // [#2695] 연속은 HWP5 attr bits 11-12 = 2 다. 종전 파서는 1 로 읽어
+        // HWPX 를 경유한 .hwp 재저장 시 비트값이 2→1 로 손상됐다.
+        let cs = parse_single_char_pr(r##"<hh:shadow type="CONTINUOUS" color="#808080"/>"##);
+        assert_eq!(cs.shadow_type, 2, "CONTINUOUS 는 IR 2(연속)");
+
+        let xml = write_single_char_pr(&cs);
+        assert!(
+            xml.contains(r#"<hh:shadow type="CONTINUOUS""#),
+            "shadow_type=2 는 type=\"CONTINUOUS\" 로 방출돼야 함: {xml}"
         );
     }
 


### PR DESCRIPTION
## 개요

- **이슈**: #2695
- **범위**: `src/parser/hwpx/header.rs`, `src/serializer/hwpx/header.rs` (+ 처리결과 보고서)
- **분류**: 결함 수정 (열거값 매핑 누락 — 파싱·직렬화 양측)

`<hh:charPr>` 자식 두 개가 **파싱측과 직렬화측 양쪽에서 동시에** 열거값을 잘라먹었다. 매핑 테이블
4곳만 스펙 전체 값으로 확장한다.

| 요소 | 스펙 값 수 | 수정 전 파서 | 수정 전 직렬화 | 수정 후 |
|---|---|---|---|---|
| `<hh:outline type>` | 8 | 4 | 4 | 8 |
| `<hh:shadow type>` | 3 | 2 | 2 | 3 |

## 왜 결함인가

두 IR 필드는 **이미 충분한 값 범위를 담고 있었다.** 손실 지점은 오직 HWPX 매핑 테이블이다.

- `CharShape.outline_type`(`model/style.rs:124`) ← HWP5 `attr` bits 8-10 **3비트**
  (`parser/doc_info.rs:592` 의 `(attr >> 8) & 0x07`, 재패킹 `serializer/doc_info.rs:470-472`).
  OWPML 외곽선 열거도 정확히 8원소라 3비트와 1:1 대응한다.
- `CharShape.shadow_type`(`model/style.rs:126`) ← bits 11-12 **2비트**
  (`parser/doc_info.rs:593` 의 `(attr >> 11) & 0x03`, 재패킹 `:473-475`).
  `0=없음, 1=비연속(DROP), 2=연속(CONTINUOUS)`.

**같은 파서 파일**이 40여 줄 위에서 밑줄(`header.rs:695-710`)·취소선(`:727-742`)에 대해 선 종류
13종(0~12)을 이미 전부 매핑한다. `DASH_DOT`/`DASH_DOT_DOT`/`LONG_DASH`/`CIRCLE` 은 저장소가 이미
알고 이미 처리하던 문자열이고, outline 매핑에서만 빠져 있었다. 한 파일 안에서 같은 선 종류 계열을
한쪽은 13개, 다른 쪽은 4개로 다루는 것은 설계가 아니라 불일치다. (같은 파일의 기존 테스트
`tab_leader_str_emits_double_and_triple_line_types` 가 `fill_type 9/10/11` 에 대해 동일 유형을 이미
결함으로 인정하고 고친 전례다.)

## 손실 경로

| # | 입력 | 경로 | 산출 | 피해 |
|---|---|---|---|---|
| L1 | HWPX `outline type="DASH_DOT"` | 파싱 → IR `0` → 직렬화 | `type="NONE"` | 외곽선 소멸 (파싱측 유실) |
| L2 | HWP5 attr bits 8-10 = `0b101` | `doc_info` → IR `5` → HWPX 직렬화 | `type="NONE"` | 외곽선 소멸 (직렬화측 유실) |
| L3 | HWPX `shadow type="DROP" offsetX/Y` | 파싱 → IR `1` → 직렬화 | `type="CONTINUOUS"` + 오프셋 잔존 | 종류 변조, 오프셋이 해석 주체를 잃음 |
| L4 | HWP5 attr bits 11-12 = `0b10` | `doc_info` → IR `2` → HWPX `CONTINUOUS` → **재파싱** → IR `1` → `doc_info` | bits = `0b01` | **바이너리 손상** (HWPX 경유만으로 2→1) |

outline 값 4~7 은 모두 `NONE` 으로 귀결되므로 **열화가 아니라 소멸**이다. L1 은 직렬화만, L2 는
파서만 고쳐서는 해결되지 않아 양측을 함께 고쳤다.

원문 보존 splice 가 이를 가리지 않음도 확인했다 — `hwpx_head_tail`(파서 `:218-224` → 직렬화
`:92-103`)은 `</hh:refList>` **이후** 꼬리만 보존하는데 `charPr` 은 `refList` **안**이고,
`write_char_pr` 에는 원문 재사용 단축 경로가 없다.

## 변경

1. **파서 outline** — `DASH_DOT=4`, `DASH_DOT_DOT=5`, `LONG_DASH=6`, `CIRCLE=7` 추가. 문자열은 같은
   파일 `underline_shape` 테이블이 쓰는 이름 그대로다(outline 은 `NONE` 이 0번이라 선 종류
   인덱스보다 1 크다).
2. **직렬화 `outline_type_str`** — (1)의 정확한 역함수로 `4..=7` 확장.
3. **파서 shadow** — `"DROP" | "CONTINUOUS" => 1` → `"DROP" => 1, "CONTINUOUS" => 2`.
4. **직렬화 shadow** — `write_char_pr` 인라인 `if`/`else` 를 신설 `shadow_type_str(t)` 3분기 `match`
   로 교체(인접 `outline_type_str`/`line_shape_str` 과 동일한 헬퍼 형태).

리팩터링이나 범위 확대는 없다. 주석은 저장소 관례대로 `[#2695]` 접두어 한국어로 달고 각 값이 HWP5
어느 비트에 대응하는지 남겼다.

### 범위 확대의 안전성

`outline_type`/`shadow_type` 의 **모든 소비 지점이 `!= 0` / `> 0` 판정 또는 단순 복사**임을 전수
확인했다. `outline_type <= 3` 이나 `shadow_type <= 1` 을 전제하는 코드는 없다.
`canvaskit_policy.rs:1834,1837` · `html.rs:352` · `web_canvas.rs:2189,2893,2901` · `svg.rs:2823` ·
`skia/text_replay.rs:531,539` · `paint/text_v2.rs:758-759` 는 비영 판정,
`paint/paint_op.rs:1551-1552` 는 `== 0` 빈 스타일 판정, `style_resolver.rs:379-380` ·
`layout/text_measurement.rs:1446-1447` 은 단순 복사, `parser/hwp3/mod.rs:279-280` 은 불리언을
`0`/`1` 로만 쓴다.

## 검증

### 신규 테스트 3건 (`serializer/hwpx/header.rs` 기존 테스트 모듈)

파싱과 직렬화를 한 테스트에서 함께 고정하는 왕복 형태다.

- `char_pr_outline_type_roundtrips_all_eight_values` — 8값 전부 `type=X` → IR 기대값 → 재직렬화 `type=X`
- `char_pr_shadow_drop_survives_roundtrip_with_offsets` — `DROP` + 오프셋 → IR `1` → `type="DROP"`
- `char_pr_shadow_continuous_is_ir_two_not_one` — `CONTINUOUS` → IR `2` (L4 경로 고정)

### red→green 실증 (수정 4곳을 각각 되돌려 4회)

수정을 **하나씩만** 되돌려 테스트가 실제로 실패함을 확인하고 복원했다. 아래는 실제 캡처 출력이다.

**RED 1 — 파서 outline arm 4~7 제거**

```
test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED

thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (3412) panicked at src\serializer\hwpx\header.rs:1984:13:
assertion `left == right` failed: outline type=DASH_DOT 은 IR 4 로 파싱돼야 함
  left: 0
 right: 4

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
```

**RED 2 — 직렬화 `outline_type_str` arm 4~7 제거** (IR 이 4 인데 `NONE` 이 방출되는 소멸 현상이
출력에 그대로 찍힌다)

```
test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED

thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (33564) panicked at src\serializer\hwpx\header.rs:1986:13:
outline_type=4 은 type="DASH_DOT" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="NONE" color="#000000" offsetX="0" offsetY="0"/></hh:charPr>

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
```

**RED 3 — 파서 shadow 를 `"DROP" | "CONTINUOUS" => 1` 로 되돌림** (L4 의 값 붕괴 2→1 재현)

```
test serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one ... FAILED

thread 'serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one' (9720) panicked at src\serializer\hwpx\header.rs:2026:9:
assertion `left == right` failed: CONTINUOUS 는 IR 2(연속)
  left: 1
 right: 2

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
```

**RED 4 — 직렬화 shadow 를 `if`/`else` 로 되돌림** (L3 의 "종류는 변조되고 오프셋만 남는" 증상이
출력에 그대로 찍힌다)

```
test serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets ... FAILED

thread 'serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets' (33392) panicked at src\serializer\hwpx\header.rs:2011:9:
shadow_type=1 은 type="DROP" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="CONTINUOUS" color="#C0C0C0" offsetX="10" offsetY="-7"/></hh:charPr>

test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
```

**GREEN — 4곳 모두 복원**

```
test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2445 filtered out
```

### 회귀

```
cargo test --lib hwpx    →  474 passed / 0 failed / 0 ignored
cargo test --lib header  →  130 passed / 0 failed / 1 ignored
cargo test --lib (전체)  → 2448 passed / 0 failed / 7 ignored
```

값 범위를 넓히는 변경이라 렌더러까지 영향이 갈 수 있어 전체 lib 테스트도 돌렸고 실패는 없다.

### 미실행 항목 (투명 고지)

- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라 실행하지 않았다.
- **실제 한/글 시각 검증**은 수행하지 않았다. 다만 모든 렌더러 소비 지점이 비영 판정만 하므로
  (위 "범위 확대의 안전성") 이 변경이 렌더링 동작을 바꾸는 경로는 없다. 효과는 **저장 파일의 값
  보존**에 한정되며, 종류별 렌더링 차등화는 별개 과제다.
- **HWP5 바이트 수준 완전 왕복 테스트**는 추가하지 않았다. `serializer/doc_info.rs:473-475` 가
  `& 0x03` 으로 그대로 재패킹함을 코드로 확인했고, 붕괴 지점이 HWPX 매핑임을
  `char_pr_shadow_continuous_is_ir_two_not_one` 으로 직접 고정했다.

## 잔여 (이번 PR 범위 밖)

이슈 #2695 §7 에 상세를 남겼다. 특히 **`<hh:autoSpacing>` 하드코딩은 단순 매핑 문제가 아니라
`attr2` bit 5 의 규약 충돌** 때문에 의도적으로 보류했다 — `model/style.rs:977-982` 계열은 bit 5 를
`auto_space_kr_num` 으로, HWPX 파서(`header.rs:1023-1028`)·직렬화(`:1048`)·렌더러
(`style_resolver.rs:883`) 계열은 `widowOrphan` 으로 쓴다. 한쪽을 설정하면 다른 쪽이 오염되는
실버그이며, 어느 비트 규약을 정본으로 삼을지 설계 결정이 선행돼야 한다.

그 밖에 `breakSetting@lineWrap` 상수 하드코딩, `charPr@shadeColor` 의 `0 → "none"` 특례(검정 음영
소멸), `paraPr@suppressLineNumbers`/`@checked` IR 필드 부재가 남아 있다.

## 처리결과 보고서

`mydocs/report/task_m100_2695_report.md`
