### PR TITLE
fix(document_core): 커넥터 뮤테이터가 구역 패스스루를 무효화하지 않음 (#2698)

### DIFF
--- a/mydocs/report/task_m100_2698_report.md
+++ b/mydocs/report/task_m100_2698_report.md
@@ -1,0 +1,152 @@
+# task_m100_2698 처리결과 보고서 — 커넥터 뮤테이터의 구역 패스스루 무효화 누락
+
+- **이슈**: [#2698](https://github.com/edwardkim/rhwp/issues/2698)
+- **브랜치**: `task/m100-2698-connector-raw-stream-invalidation` (base `devel`)
+- **범위**: `src/document_core/commands/object_ops/connector.rs`
+- **분류**: 계약 위반 수정 (패스스루 무효화 누락)
+
+## 1. 문제
+
+`connector.rs`(347줄, 공개 뮤테이터 3개)에 패스스루 무효화가 **0건**이었다.
+`raw_stream` / `raw_data` 문자열이 파일 전체에 한 번도 등장하지 않았다.
+
+`serialize_section`(`src/serializer/body_text.rs:26-30`)은 `Section::raw_stream` 이
+`Some` 이면 구역 전체를 원본 바이트 그대로 반환한다. 따라서 IR 을 고친 뮤테이터가
+그 층을 무효화하지 않으면 편집이 저장 결과에서 사라진다.
+
+### object_ops 무효화 밀도 (`grep -c 'raw_stream'`)
+
+| 모듈 | 등장 | 판정 |
+|---|---:|---|
+| `picture.rs` | 11 | 정상 |
+| `shape.rs` | 8 | 정상 |
+| `table.rs` | 7 | 정상 |
+| `equation.rs` | 3 | 정상 |
+| `note.rs` | 3 | 정상 |
+| `common.rs` | 2 | 정상 |
+| **`connector.rs`** | **0** | **누락** |
+| `mod.rs` | 0 | 해당 없음 (`pub fn` 0개, 모듈 선언 전용) |
+
+뮤테이션을 수행하는 모듈 중 0건인 것은 `connector.rs` 가 유일하다. `#1904`
+도메인 분할 때 이 모듈만 누락된 것으로 보인다.
+
+## 2. 분석 — 현재 관측 가능한 유실은 없다 (정직 고지)
+
+주장을 과장하지 않기 위해 세 함수의 **모든** 호출 지점을 전수 조사했다.
+
+| # | 호출 지점 | 선행 무효화 | 현재 |
+|---|---|---|---|
+| 1 | `wasm_api.rs:3567` | `create_shape_control_native` → `shape.rs:1492` | 안전 |
+| 2 | `wasm_api.rs:3576` | 동일 블록 | 안전 |
+| 3 | `common.rs:328` | 바로 위 `common.rs:325` | 안전 |
+| 4 | `wasm_api.rs:3748` (wasm 공개 진입점) | **없음** | 호출자 위임 |
+| 5 | `input-handler-picture.ts:1061`, `input-handler-table.ts:1324` | 직전 `setObjectProperties` | 안전 |
+
+**결론: 현재 studio UI 경로에서는 선행 뮤테이션이 우연히 무효화를 대신해 주고 있어
+사용자에게 관측되는 유실이 없다.** 이 사실을 숨기지 않는다.
+
+### 그럼에도 고친 이유
+
+1. **저장소가 선언한 계약과 구현이 어긋나 있다.** `mutation-method-registry.ts` 는
+   자신을 "문서 변경 WasmBridge 메서드의 단일 권위 목록"으로, `MUTATING_METHODS` 를
+   "문서 IR(**직렬화 결과**)을 바꾸는 메서드 전수"로 정의하고 `:44` 에
+   `'updateConnectorsInSection'` 을 등재해 두었다. 그러나 Rust 구현은 `raw_stream` 이
+   `Some` 인 한 직렬화 결과를 바꾸지 않는다.
+2. **안전성이 지역적이지 않고 호출자 순서에 의존한다.** 새 호출자 추가나 순서 변경으로
+   깨지며, 깨져도 컴파일 에러·테스트 실패·런타임 경고가 전혀 없다.
+3. **공개 wasm API 다.** 제3자 임베더는 "호출 전 다른 뮤테이션 필요"라는 암묵 조건을 알 수 없다.
+4. **비용이 사실상 0이다** (3줄, 이미 `None` 이면 무연산).
+
+## 3. 변경
+
+무효화를 뮤테이션 지점에 두되, **실제로 IR 을 바꾼 경우에만** 수행하도록 조건부로 걸었다.
+인덱스가 빗나가 아무것도 바꾸지 않은 경로에서 불필요하게 완전 라운드트립을 깨뜨리지 않기
+위해서다.
+
+- `update_connector_subject_ids` — `mutated` 플래그, SubjectID 4개 대입 시에만 무효화
+- `recalculate_connector_routing` — **갈래가 3개**이므로 각각 처리
+  - 꺾인 연결선: `conn.control_points = pts` 후 `routed = true`
+  - 곡선 연결선: `conn.control_points = vec![...]` 후 `routed = true`
+  - 직선 연결선: `control_points.clear()` 후 **조기 반환**하므로 그 자리에서 직접 무효화
+- `update_connectors_in_section` — bbox/로컬좌표 갱신 루프에 `geometry_updated` 플래그.
+  3단계 제어점 재계산은 `recalculate_connector_routing` 이 자체 무효화하므로, 여기서는
+  좌표만 바뀌고 라우팅 대상이 없는 경우를 덮는다.
+
+### 구현 중 발견한 자체 결함
+
+최초 구현은 `recalculate_connector_routing` 의 **꺾인 갈래에만** 무효화를 걸었다.
+곡선 갈래와 직선(clear 후 조기 반환) 갈래는 `control_points` 를 실제로 바꾸면서도
+무효화를 타지 않는 구멍이 남아 있었다. 갈래별 테스트를 추가하는 과정에서 발견해
+두 갈래를 모두 막았다.
+
+## 4. 검증
+
+### 신규 테스트 (`connector_passthrough_invalidation_tests`, 4건)
+
+1. `update_connector_subject_ids_invalidates_section_passthrough`
+2. `recalculate_connector_routing_invalidates_section_passthrough`
+3. `every_routing_branch_invalidates_section_passthrough` — StrokeBoth / ArcBoth /
+   StraightNoArrow 세 갈래 전부
+4. `no_op_call_keeps_passthrough_intact` — 조건부 설계 고정 (반대 방향)
+
+픽스처는 빈 문서에 커넥터를 심고 `raw_stream = Some(...)` 로 "방금 로드한 원본"을
+모사한다. 빈 문서 첫 문단은 이미 SectionDef/ColumnDef 컨트롤을 갖고 있어
+`control_idx` 를 하드코딩하지 않고 삽입 시점의 실제 인덱스를 돌려준다.
+
+### red→green 실증
+
+**(1) 무효화 2개소를 무력화** (`if mutated && false`, `if routed && false`):
+```
+recalculate_connector_routing_invalidates_section_passthrough ... FAILED
+update_connector_subject_ids_invalidates_section_passthrough ... FAILED
+panicked at connector.rs:421:9:
+[#2698] SubjectID 를 바꿨으면 구역 패스스루가 무효화되어야 한다 — 그렇지 않으면
+저장 시 원본 바이트가 그대로 나가 편집이 사라진다
+panicked at connector.rs:435:9:
+[#2698] 제어점을 재구성했으면 구역 패스스루가 무효화되어야 한다
+test result: FAILED. 1 passed; 2 failed
+```
+`no_op_call_keeps_passthrough_intact` 는 통과 — 테스트가 무차별이 아니라 계약 위반
+지점만 잡는다는 증거다.
+
+**(2) 곡선 갈래의 `routed = true` 만 제거**:
+```
+every_routing_branch_invalidates_section_passthrough ... FAILED
+panicked at connector.rs:461:13:
+[#2698] ArcBoth 갈래에서 구역 패스스루가 무효화되지 않았다
+test result: FAILED. 3 passed; 1 failed
+```
+세 갈래 중 **ArcBoth 만 정확히 지목**했다.
+
+**(3) 전부 복원**:
+```
+test result: ok. 4 passed; 0 failed
+```
+
+### 회귀
+
+```
+cargo test --lib document_core::  →  259 passed / 0 failed / 2 ignored
+cargo test --lib serializer::     →  405 passed / 0 failed
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`)은 저장소
+  규약(`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인
+  사항이라 실행하지 않았다.
+- 실제 커넥터가 연결된 문서를 저장→재열기하는 **바이트 수준 왕복 검증**은 하지 않았다.
+  이 수정의 계약은 "뮤테이션 후 `raw_stream` 이 `None` 이어야 한다"는 것이고, 그 이후의
+  재직렬화 정확성은 기존 직렬화 테스트(405건)가 담당한다고 판단했다.
+- `update_connectors_in_section` 의 무효화는 단위 테스트로 고정하지 못했다.
+  `conn_points` 맵이 채워지려면 inst_id 를 가진 비-Line 도형과 그것을 참조하는 커넥터가
+  함께 필요해 픽스처 비용이 커서다. 대신 그 함수가 위임하는
+  `recalculate_connector_routing` 쪽을 갈래별로 고정했다. **확인하지 않은 것을 확인한
+  것처럼 적지 않기 위해 밝혀 둔다.**
+
+## 5. 잔여
+
+- `mutation-method-registry.ts` 의 저작 시점 가드를 "Rust 뮤테이터가 무효화하는가"까지
+  검사하도록 확장하는 정적 분석 과제.
+- 다른 모듈의 무효화 누락 여부는 밀도 조사로 0건이 아님만 확인했을 뿐, 뮤테이터 단위
+  전수 검증은 하지 않았다.

--- a/src/document_core/commands/object_ops/connector.rs
+++ b/src/document_core/commands/object_ops/connector.rs
@@ -21,6 +21,7 @@ impl DocumentCore {
         end_subject_id: u32,
         end_subject_index: u32,
     ) {
+        let mut mutated = false;
         if let Some(section) = self.document.sections.get_mut(section_idx) {
             if let Some(para) = section.paragraphs.get_mut(para_idx) {
                 if let Some(Control::Shape(ref mut shape)) = para.controls.get_mut(control_idx) {
@@ -30,9 +31,18 @@ impl DocumentCore {
                             conn.start_subject_index = start_subject_index;
                             conn.end_subject_id = end_subject_id;
                             conn.end_subject_index = end_subject_index;
+                            mutated = true;
                         }
                     }
                 }
+            }
+            // [#2698] IR을 실제로 바꾼 경우에만 구역 패스스루를 무효화한다.
+            // 무효화하지 않으면 serialize_section 이 원본 raw_stream 을 그대로
+            // 반환해(body_text.rs:26-30) 이 편집이 저장 결과에서 사라진다.
+            // 인덱스가 빗나가 아무것도 바꾸지 않은 경로에서는 라운드트립을
+            // 깨뜨리지 않기 위해 조건부로 둔다.
+            if mutated {
+                section.raw_stream = None;
             }
         }
     }
@@ -48,6 +58,7 @@ impl DocumentCore {
     ) {
         use crate::model::shape::ConnectorControlPoint;
 
+        let mut routed = false;
         let section = match self.document.sections.get_mut(section_idx) {
             Some(s) => s,
             None => return,
@@ -84,6 +95,9 @@ impl DocumentCore {
         // 직선 연결선: 제어점 불필요
         if !conn.link_type.is_stroke() && !conn.link_type.is_arc() {
             conn.control_points.clear();
+            // [#2698] 이 조기 반환 경로도 제어점 목록을 비우는 실제 IR 변경이므로
+            // 아래 공통 무효화를 타지 못하는 만큼 여기서 직접 무효화한다.
+            section.raw_stream = None;
             return;
         }
 
@@ -136,6 +150,7 @@ impl DocumentCore {
                     point_type: 26,
                 }, // 끝 앵커
             ];
+            routed = true;
         } else {
             // ─── 꺽인 연결선: 직각 꺾임점 ───
             let mut pts = Vec::new();
@@ -207,6 +222,11 @@ impl DocumentCore {
                 point_type: 26,
             });
             conn.control_points = pts;
+            routed = true;
+        }
+        // [#2698] 제어점을 실제로 재구성한 경우에만 구역 패스스루를 무효화한다.
+        if routed {
+            section.raw_stream = None;
         }
     }
     /// 구역 내 모든 연결선을 스캔하여 연결된 도형의 현재 위치에 맞게 갱신한다.
@@ -256,6 +276,7 @@ impl DocumentCore {
         }
 
         // 2) 커넥터 찾기 및 좌표 갱신
+        let mut geometry_updated = false;
         let section = match self.document.sections.get_mut(section_idx) {
             Some(s) => s,
             None => return,
@@ -311,7 +332,14 @@ impl DocumentCore {
                 line.drawing.shape_attr.rotation_center.x = new_w as i32 / 2;
                 line.drawing.shape_attr.rotation_center.y = new_h as i32 / 2;
                 line.drawing.shape_attr.raw_rendering = Vec::new();
+                geometry_updated = true;
             }
+        }
+        // [#2698] bbox/로컬좌표를 실제로 갱신한 경우에만 구역 패스스루를 무효화한다.
+        // (3) 단계의 제어점 재계산은 recalculate_connector_routing 이 자체적으로
+        // 무효화하므로, 여기서는 좌표만 바뀌고 라우팅 대상이 없는 경우를 덮는다.
+        if geometry_updated {
+            section.raw_stream = None;
         }
 
         // 3) 제어점 재계산 (인덱스 수집 후 별도 루프 — borrow checker 대응)
@@ -343,5 +371,113 @@ impl DocumentCore {
         for (pi, ci, si, ei) in routing_targets {
             self.recalculate_connector_routing(section_idx, pi, ci, si, ei);
         }
+    }
+}
+
+/// [#2698] 커넥터 뮤테이터의 구역 패스스루 무효화 계약.
+///
+/// `serialize_section` 은 `Section::raw_stream` 이 `Some` 이면 구역 전체를 원본
+/// 그대로 반환한다(`serializer/body_text.rs:26-30`). 따라서 IR 을 고친 뮤테이터가
+/// 그 층을 무효화하지 않으면 편집이 저장 결과에서 사라진다. 이 모듈의 다른
+/// 형제(`picture.rs`/`shape.rs`/`table.rs` 등)는 전부 뮤테이션 지점에서
+/// 무효화하지만 `connector.rs` 만 누락되어 있었다.
+#[cfg(test)]
+mod connector_passthrough_invalidation_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::shape::{ConnectorData, LineShape, LinkLineType, ShapeObject};
+
+    /// 방금 로드한 원본 문서를 모사한다 — 커넥터 1개가 있고, 구역 패스스루가
+    /// 아직 살아 있어 저장 시 원본 바이트가 그대로 반환될 상태.
+    ///
+    /// 반환값의 `usize` 는 삽입한 커넥터의 `control_idx` 다. 빈 문서의 첫 문단은
+    /// 이미 SectionDef/ColumnDef 컨트롤을 갖고 있어 0 이 아니므로, 하드코딩하지
+    /// 않고 실제 인덱스를 돌려준다.
+    fn core_with_live_passthrough() -> (DocumentCore, usize) {
+        core_with_connector_of(LinkLineType::StrokeBoth)
+    }
+
+    fn core_with_connector_of(link_type: LinkLineType) -> (DocumentCore, usize) {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let line = LineShape {
+            connector: Some(ConnectorData {
+                link_type,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let controls = &mut core.document.sections[0].paragraphs[0].controls;
+        let ctrl_idx = controls.len();
+        controls.push(Control::Shape(Box::new(ShapeObject::Line(line))));
+
+        core.document.sections[0].raw_stream = Some(vec![0xAB; 16]);
+        (core, ctrl_idx)
+    }
+
+    #[test]
+    fn update_connector_subject_ids_invalidates_section_passthrough() {
+        let (mut core, ctrl_idx) = core_with_live_passthrough();
+        assert!(
+            core.document.sections[0].raw_stream.is_some(),
+            "전제 성립 확인: 뮤테이션 전에는 패스스루가 살아 있어야 한다"
+        );
+
+        core.update_connector_subject_ids(0, 0, ctrl_idx, 3, 1, 4, 2);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "[#2698] SubjectID 를 바꿨으면 구역 패스스루가 무효화되어야 한다 — \
+             그렇지 않으면 저장 시 원본 바이트가 그대로 나가 편집이 사라진다"
+        );
+    }
+
+    #[test]
+    fn recalculate_connector_routing_invalidates_section_passthrough() {
+        let (mut core, ctrl_idx) = core_with_live_passthrough();
+        assert!(core.document.sections[0].raw_stream.is_some());
+
+        core.recalculate_connector_routing(0, 0, ctrl_idx, 1, 3);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "[#2698] 제어점을 재구성했으면 구역 패스스루가 무효화되어야 한다"
+        );
+    }
+
+    /// `recalculate_connector_routing` 은 링크 타입에 따라 세 갈래로 갈라지고,
+    /// 세 갈래 모두 `control_points` 를 바꾼다(꺾인=재구성, 곡선=재구성,
+    /// 직선=clear 후 조기 반환). 한 갈래만 무효화하면 나머지 둘에서 편집이
+    /// 조용히 사라지므로 갈래별로 계약을 고정한다.
+    #[test]
+    fn every_routing_branch_invalidates_section_passthrough() {
+        for link_type in [
+            LinkLineType::StrokeBoth,      // 꺾인 — 공통 경로
+            LinkLineType::ArcBoth,         // 곡선 — 별도 분기
+            LinkLineType::StraightNoArrow, // 직선 — clear 후 조기 반환
+        ] {
+            let (mut core, ctrl_idx) = core_with_connector_of(link_type);
+            core.recalculate_connector_routing(0, 0, ctrl_idx, 1, 3);
+            assert!(
+                core.document.sections[0].raw_stream.is_none(),
+                "[#2698] {link_type:?} 갈래에서 구역 패스스루가 무효화되지 않았다"
+            );
+        }
+    }
+
+    /// 무효화를 무조건 하지 않고 조건부로 둔 설계를 고정한다. 인덱스가 빗나가
+    /// 아무것도 바꾸지 않은 호출은 완전 라운드트립을 깨뜨리지 않아야 한다.
+    #[test]
+    fn no_op_call_keeps_passthrough_intact() {
+        let (mut core, _) = core_with_live_passthrough();
+
+        core.update_connector_subject_ids(0, 0, 99, 3, 1, 4, 2);
+        core.recalculate_connector_routing(0, 0, 99, 1, 3);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_some(),
+            "[#2698] IR 을 바꾸지 않은 호출은 패스스루를 유지해야 한다"
+        );
     }
 }


### PR DESCRIPTION
이슈 [#2698](https://github.com/edwardkim/rhwp/issues/2698) 처리.
처리결과 문서: `mydocs/report/task_m100_2698_report.md`

## 문제

`src/document_core/commands/object_ops/connector.rs`(347줄, 공개 뮤테이터 3개)에 패스스루 무효화가 **0건**이었습니다.

`serialize_section` 은 `raw_stream` 이 `Some` 이면 구역을 원본 바이트 그대로 반환합니다(`serializer/body_text.rs:26-30`). 무효화하지 않은 IR 편집은 저장 시 사라집니다.

### object_ops 무효화 밀도 (`grep -c 'raw_stream'`)

| 모듈 | 등장 | 판정 |
|---|---:|---|
| `picture.rs` | 11 | 정상 |
| `shape.rs` | 8 | 정상 |
| `table.rs` | 7 | 정상 |
| `equation.rs` | 3 | 정상 |
| `note.rs` | 3 | 정상 |
| `common.rs` | 2 | 정상 |
| **`connector.rs`** | **0** | **누락** |
| `mod.rs` | 0 | 해당 없음 (`pub fn` 0개) |

뮤테이션을 수행하는 모듈 중 0건은 `connector.rs` 가 유일합니다. `#1904` 도메인 분할 때 이 모듈만 누락된 것으로 보입니다.

## 먼저 정직하게 — 현재 관측되는 유실은 없습니다

호출 지점 **5개를 전수 조사**했습니다.

| # | 호출 지점 | 선행 무효화 | 현재 |
|---|---|---|---|
| 1 | `wasm_api.rs:3567` | `create_shape_control_native` → `shape.rs:1492` | 안전 |
| 2 | `wasm_api.rs:3576` | 동일 블록 | 안전 |
| 3 | `common.rs:328` | 바로 위 `common.rs:325` | 안전 |
| 4 | `wasm_api.rs:3748` (wasm 공개 진입점) | **없음** | 호출자 위임 |
| 5 | `input-handler-picture.ts:1061`, `input-handler-table.ts:1324` | 직전 `setObjectProperties` | 안전 |

**현재 studio UI 경로에서는 선행 뮤테이션이 우연히 무효화를 대신해 주고 있습니다.** 숨기지 않고 먼저 밝힙니다. 이 PR 의 성격은 "관측된 데이터 유실 수정"이 아니라 **계약 위반 해소**입니다.

### 그럼에도 고치는 이유

1. **저장소가 선언한 계약과 구현이 어긋나 있습니다.** `rhwp-studio/src/core/mutation-method-registry.ts` 는 자신을 "문서 변경 WasmBridge 메서드의 **단일 권위 목록**", `MUTATING_METHODS` 를 "문서 IR(**직렬화 결과**)을 바꾸는 메서드 전수"로 정의하고 `:44` 에 `'updateConnectorsInSection'` 을 등재해 두었습니다. 그러나 구현은 `raw_stream` 이 `Some` 인 한 직렬화 결과를 바꾸지 않습니다.
2. **안전성이 지역적이지 않고 호출자 순서에 의존합니다.** 새 호출자 추가·순서 변경으로 깨지며, 깨져도 컴파일 에러·테스트 실패·런타임 경고가 **전혀 없습니다**. 저장 후 재열기 때 연결선이 옛 위치에 있는 것으로만 드러납니다.
3. **공개 wasm API 입니다.** 제3자 임베더는 "호출 전 다른 뮤테이션이 필요하다"는 암묵 조건을 알 수 없습니다.
4. **비용이 사실상 0입니다** — 이미 `None` 이면 무연산.

## 변경

무효화를 뮤테이션 지점에 두되 **실제로 IR 을 바꾼 경우에만** 수행하도록 조건부로 걸었습니다. 인덱스가 빗나가 아무것도 바꾸지 않은 호출이 완전 라운드트립을 깨뜨리지 않게 하기 위해서입니다.

`recalculate_connector_routing` 은 **갈래가 3개**(꺾인=재구성 / 곡선=재구성 / 직선=`clear()` 후 조기 반환)이고 셋 다 `control_points` 를 바꾸므로 전부 처리했습니다.

> 최초 구현은 꺾인 갈래만 막아 두었습니다. 갈래별 테스트를 추가하다가 곡선·직선 갈래에 구멍이 남은 것을 발견해 보완했습니다.

## 검증

**신규 테스트 4건** — 뮤테이터별 계약 2건, 라우팅 3갈래 전수 1건, 조건부 설계 고정(반대 방향) 1건.

**red→green 실증 (1)** — 무효화 2개소 무력화:
```
recalculate_connector_routing_invalidates_section_passthrough ... FAILED
update_connector_subject_ids_invalidates_section_passthrough ... FAILED
panicked at connector.rs:421:9:
[#2698] SubjectID 를 바꿨으면 구역 패스스루가 무효화되어야 한다 — 그렇지 않으면
저장 시 원본 바이트가 그대로 나가 편집이 사라진다
test result: FAILED. 1 passed; 2 failed
```
`no_op_call_keeps_passthrough_intact` 는 통과 — 테스트가 무차별이 아님을 증명합니다.

**red→green 실증 (2)** — 곡선 갈래의 `routed = true` 만 제거:
```
panicked at connector.rs:461:13:
[#2698] ArcBoth 갈래에서 구역 패스스루가 무효화되지 않았다
test result: FAILED. 3 passed; 1 failed
```
세 갈래 중 **ArcBoth 만 정확히 지목**했습니다.

**복원 후**: `ok. 4 passed; 0 failed`

**회귀**: `document_core::` **259 passed / 0 failed**, `serializer::` **405 passed / 0 failed**

### 미실행 (투명 고지)

- PR CI 전체 검증(`cargo test --verbose`, `cargo clippy -- -D warnings`)은 저장소 규약상 작업지시자 별도 승인 사항이라 실행하지 않았습니다.
- 저장→재열기 **바이트 수준 왕복 검증**은 하지 않았습니다. 이 수정의 계약은 "뮤테이션 후 `raw_stream` 이 `None`"이고 이후 재직렬화 정확성은 기존 405건이 담당한다고 판단했습니다.
- `update_connectors_in_section` 의 무효화는 단위 테스트로 고정하지 못했습니다. `conn_points` 맵을 채우려면 inst_id 를 가진 비-Line 도형과 그것을 참조하는 커넥터가 함께 필요해 픽스처 비용이 큽니다. 대신 그 함수가 위임하는 `recalculate_connector_routing` 을 갈래별로 고정했습니다. **확인하지 않은 것을 확인한 것처럼 적지 않기 위해 밝혀 둡니다.**
