### PR TITLE
chore(#2677): 한양 4종 preflight identity 아티팩트 실측 재보존 (COM)

### DIFF
--- a/tools/task2430/EVIDENCE.md
+++ b/tools/task2430/EVIDENCE.md
@@ -29,17 +29,17 @@
 휴먼명조:   readback=('휴먼명조',   FontType=2) OK
 ```
 
-> **커밋 아티팩트 상태(정정)**: 위 5행 블록은 *콘솔 로그*이며 커밋된
-> `tools/task2430/measured/preflight_report.tsv` 파일 내용 자체가 아니다.
-> 최초 커밋 시점의 `preflight_report.tsv` 는 per-face 프로세스 분할 실행에서
-> **매 실행이 파일을 덮어써 마지막 face(휴먼명조) 1행만** 잔존했다. 따라서
-> **저장소에 identity 아티팩트로 독립 보존된 것은 휴먼명조 1종**이고, 한양
-> 4종의 FontType=2 readback 은 현재 이 문서 산문으로만 남아 있다. 이 갭을
-> 없애기 위해 `hy_ascii_ladder.py` preflight 를 requested_face 기준 **누적
-> 병합**으로 개선했으므로(#2510 리뷰 후속 커밋), 저자가 동일 COM 환경에서
-> 5종 per-face 를 재실행하면 5행 `preflight_report.tsv` 가 커밋 아티팩트로
-> 보존된다. `--verify` 재현성(아래 §4)은 커밋 TSV↔배열 일치만 보증하며 HFT
-> vs fallback identity 는 이 preflight 아티팩트로만 입증되는 점에 유의한다.
+> **커밋 아티팩트 상태(재보존 완료, 2026-07-21, #2677)**: 위 5행 블록은
+> *콘솔 로그*이며, 이제 커밋된 `tools/task2430/measured/preflight_report.tsv`
+> 파일에도 **5종 identity 행이 모두 보존**된다(한양신명조·중고딕·견명조·견고딕
+> = FontType=2, 휴먼명조 = FontType=2). 최초 커밋 시점에는 per-face 프로세스
+> 분할 실행에서 매 실행이 파일을 덮어써 마지막 face(휴먼명조) 1행만 잔존했으나,
+> `hy_ascii_ladder.py` preflight 를 requested_face 기준 **누적 병합**으로
+> 개선(#2510 리뷰 후속 커밋 #2675)한 뒤 동일 Windows + 한컴(한글 2022) COM
+> 환경에서 5종 per-face 를 재실행해 5행 아티팩트를 재보존했다(재실행 시
+> `ladder_<face>.tsv` 5종은 커밋본과 byte-exact 일치 확인 — 측정 결정성).
+> `--verify` 재현성(아래 §4)은 커밋 TSV↔배열 일치만 보증하며 HFT vs fallback
+> identity 는 이 preflight 아티팩트로만 입증되는 점에 유의한다.
 
 PDF 단 이중 확인: 각 face 프로브 PDF 의 임베드 폰트가 한양 4종=**Type3**(HFT
 렌더 경로), 휴먼명조=**Type0 `INPILL+휴먼명조`**(cp949 복원) — 시스템 TTF

--- a/tools/task2430/measured/preflight_report.tsv
+++ b/tools/task2430/measured/preflight_report.tsv
@@ -1,2 +1,6 @@
 requested_face	readback_face	readback_fonttype	verdict
+한양견고딕	한양견고딕	2	OK
+한양견명조	한양견명조	2	OK
+한양신명조	한양신명조	2	OK
+한양중고딕	한양중고딕	2	OK
 휴먼명조	휴먼명조	2	OK


### PR DESCRIPTION
## 요약

#2677 대응 — merged PR #2510 검토 후속 중 **한양 4종 preflight identity 아티팩트 실측 재보존**(Windows + 한컴 COM 필요분).

## 배경

커밋된 `tools/task2430/measured/preflight_report.tsv` 가 per-face 프로세스 분할 실행에서 매 실행마다 덮어써져 **휴먼명조 1행만** 잔존했다. #2675 가 harness preflight 를 `requested_face` 기준 누적 병합으로 개선했으므로, 동일 COM 환경에서 5종 per-face 를 재실행해 5행 아티팩트를 재보존한다.

## 수행 (Windows + 한컴 한글 2022 COM)

```
for f in 한양신명조 한양중고딕 한양견명조 한양견고딕 휴먼명조; do
  python tools/task2430/hy_ascii_ladder.py --fonts "$f" --out-dir <tmp>
done
```

preflight readback 결과 — **5종 모두 FontType=2 (실존 HFT, fallback 아님)**:

| requested_face | readback_face | FontType | verdict |
|---|---|---|---|
| 한양견고딕 | 한양견고딕 | 2 | OK |
| 한양견명조 | 한양견명조 | 2 | OK |
| 한양신명조 | 한양신명조 | 2 | OK |
| 한양중고딕 | 한양중고딕 | 2 | OK |
| 휴먼명조 | 휴먼명조 | 2 | OK |

## 검증

- 재실행한 `ladder_<face>.tsv` 5종은 커밋본과 **byte-exact 일치**(측정 결정성 확인) → golden ladder 불변, `preflight_report.tsv` 만 1→5행 갱신.
- `python tools/task2430/gen_metrics.py --ladder-dir tools/task2430/measured --verify` → **5/5 face 95/95 exact match OK**.
- 저작권 글꼴 파일 미첨부.

## 변경

- `tools/task2430/measured/preflight_report.tsv`: 1행(휴먼명조) → 5행(한양 4종 + 휴먼명조).
- `tools/task2430/EVIDENCE.md` §2: 재보존 완료 상태로 정정.
