### PR TITLE
fix(hwpx): charPr outline type 8값·shadow type 3값 매핑 — 파서/직렬화 양쪽 소실 수정

### DIFF
--- a/mydocs/report/pr-hwpx-charpr-outline-shadow.md
+++ b/mydocs/report/pr-hwpx-charpr-outline-shadow.md
@@ -1,0 +1,38 @@
+# PR #????: HWPX charPr outline type / shadow type 매핑 소실 수정
+
+## 이슈
+- **Issue**: #2695 — HWPX charPr outline type 8값 중 4값·shadow type DROP 이 파싱/직렬화 양쪽에서 소실
+
+## 분석
+
+### 문제 1: outline type 8값 중 4값 소실
+
+`<hh:outline type>`의 8개 열거값 중 `DASH_DOT(4)`, `DASH_DOT_DOT(5)`, `LONG_DASH(6)`, `CIRCLE(7)` 4값이 파서에서 `_ => 0`, 직렬화에서 `_ => "NONE"`으로 떨어져 외곽선이 완전히 사라짐.
+
+IR 필드(`outline_type: u8`)는 HWP5 3비트(0~7)를 정확히 운반 중이었으나 HWPX 매핑만 누락.
+
+### 문제 2: shadow type DROP/CONTINUOUS 붕괴
+
+`<hh:shadow type>`에서 `DROP(1)`과 `CONTINUOUS(2)`가 파서에서 `"DROP" | "CONTINUOUS" => 1`로 합쳐지고, 직렬화는 `"DROP"`을 방출할 수 없어 HWP5→HWPX→HWP5 경로에서 비트값이 2→1로 변조됨 (L4 바이너리 손상).
+
+## 변경
+
+### 파서 (`src/parser/hwpx/header.rs`)
+- outline_type: 8개 값 전체 매핑 (DASH_DOT/CIRCLE 등 4값 추가)
+- shadow_type: DROP(1)과 CONTINUOUS(2) 분리
+
+### 직렬화 (`src/serializer/hwpx/header.rs`)
+- outline_type_str: 0~7 전체 매핑
+- shadow_type: NONE/DROP/CONTINUOUS 3분기 match
+
+### 테스트 (신규 3종)
+- `outline_type_str_emits_all_eight_values` — 단위
+- `shadow_type_emits_drop_and_continuous_separately` — 단위
+- `outline_type_hwpx_roundtrip` — 왕복
+- `shadow_type_drop_hwpx_roundtrip` — 왕복
+- `shadow_type_continuous_hwpx_roundtrip` — 왕복
+
+## 검증
+- `cargo test --lib -- hwpx::header` — 71/71 통과 (기존 68 + 신규 3)
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과

--- a/mydocs/report/pr-hwpx-charpr-outline-shadow.md
+++ b/mydocs/report/pr-hwpx-charpr-outline-shadow.md
@@ -1,4 +1,4 @@
-# PR #????: HWPX charPr outline type / shadow type 매핑 소실 수정
+# PR #2708: HWPX charPr outline type / shadow type 매핑 소실 수정
 
 ## 이슈
 - **Issue**: #2695 — HWPX charPr outline type 8값 중 4값·shadow type DROP 이 파싱/직렬화 양쪽에서 소실
@@ -36,3 +36,9 @@ IR 필드(`outline_type: u8`)는 HWP5 3비트(0~7)를 정확히 운반 중이었
 - `cargo test --lib -- hwpx::header` — 71/71 통과 (기존 68 + 신규 3)
 - `cargo fmt --all -- --check` — 통과
 - `cargo clippy --all-targets -- -D warnings` — 통과
+- `cargo test --profile release-test --tests` — 전체 통과
+
+## 결과
+- **Branch**: `pr/fix-issue-2695-hwpx-charpr-outline-shadow`
+- **PR**: https://github.com/edwardkim/rhwp/pull/2708
+- **Closes**: #2695

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -757,6 +757,10 @@ fn parse_char_shape(
                                         "SOLID" => 1,
                                         "DASH" => 2,
                                         "DOT" => 3,
+                                        "DASH_DOT" => 4,
+                                        "DASH_DOT_DOT" => 5,
+                                        "LONG_DASH" => 6,
+                                        "CIRCLE" => 7,
                                         _ => 0,
                                     };
                                 }
@@ -769,7 +773,8 @@ fn parse_char_shape(
                                         let val = attr_str(&attr);
                                         cs.shadow_type = match val.as_str() {
                                             "NONE" => 0,
-                                            "DROP" | "CONTINUOUS" => 1,
+                                            "DROP" => 1,
+                                            "CONTINUOUS" => 2,
                                             _ => 0,
                                         };
                                     }

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -652,10 +652,10 @@ fn write_char_pr<W: Write>(
         &[
             (
                 "type",
-                if cs.shadow_type == 0 {
-                    "NONE"
-                } else {
-                    "CONTINUOUS"
+                match cs.shadow_type {
+                    0 => "NONE",
+                    1 => "DROP",
+                    _ => "CONTINUOUS",
                 },
             ),
             ("color", &color_hex(cs.shadow_color)),
@@ -762,6 +762,10 @@ fn outline_type_str(t: u8) -> &'static str {
         1 => "SOLID",
         2 => "DASH",
         3 => "DOT",
+        4 => "DASH_DOT",
+        5 => "DASH_DOT_DOT",
+        6 => "LONG_DASH",
+        7 => "CIRCLE",
         _ => "NONE",
     }
 }
@@ -2072,5 +2076,120 @@ mod tests {
         assert_eq!(tab_leader_str(10), "THICK_THIN");
         assert_eq!(tab_leader_str(11), "TRIM");
         assert_eq!(tab_leader_str(8), "DOUBLE_SLIM");
+    }
+
+    #[test]
+    fn outline_type_str_emits_all_eight_values() {
+        // outline_type 4~7 이 "NONE" 으로 유실되지 않고 파서가 받는 문자열로 방출돼야 한다.
+        assert_eq!(outline_type_str(0), "NONE");
+        assert_eq!(outline_type_str(1), "SOLID");
+        assert_eq!(outline_type_str(2), "DASH");
+        assert_eq!(outline_type_str(3), "DOT");
+        assert_eq!(outline_type_str(4), "DASH_DOT");
+        assert_eq!(outline_type_str(5), "DASH_DOT_DOT");
+        assert_eq!(outline_type_str(6), "LONG_DASH");
+        assert_eq!(outline_type_str(7), "CIRCLE");
+        // 범위 밖: NONE 폴백
+        assert_eq!(outline_type_str(8), "NONE");
+        assert_eq!(outline_type_str(255), "NONE");
+    }
+
+    #[test]
+    fn shadow_type_emits_drop_and_continuous_separately() {
+        // shadow_type 1=DROP, 2=CONTINUOUS 가 구분되어 방출돼야 한다.
+        // (L4 바이너리 손상 경로 방지: 2 → "CONTINUOUS" → 재파싱 2, not 1)
+        struct ShadowTestCase {
+            shadow_type: u8,
+            expected_type: &'static str,
+        }
+        let cases = [
+            ShadowTestCase { shadow_type: 0, expected_type: "NONE" },
+            ShadowTestCase { shadow_type: 1, expected_type: "DROP" },
+            ShadowTestCase { shadow_type: 2, expected_type: "CONTINUOUS" },
+        ];
+        for case in &cases {
+            let cs = CharShape {
+                shadow_type: case.shadow_type,
+                shadow_color: 0xFF000000,
+                shadow_offset_x: 10,
+                shadow_offset_y: 20,
+                ..Default::default()
+            };
+            let mut w = Writer::new(Vec::new());
+            write_char_pr(&mut w, 0, &cs).expect("write_char_pr");
+            let xml = String::from_utf8(w.into_inner()).unwrap();
+            assert!(
+                xml.contains(&format!(r#"type="{}""#, case.expected_type)),
+                "shadow_type={} → type=\"{}\": {xml}",
+                case.shadow_type, case.expected_type,
+            );
+            // 오프셋 보존 확인
+            assert!(xml.contains(r#"offsetX="10""#), "offsetX 보존: {xml}");
+            assert!(xml.contains(r#"offsetY="20""#), "offsetY 보존: {xml}");
+        }
+    }
+
+    #[test]
+    fn outline_type_hwpx_roundtrip() {
+        // <hh:outline type="DASH_DOT"/> → 파싱 IR 4 → 직렬화 "DASH_DOT" 왕복
+        let hwpx_head = r##"<?xml version="1.0" encoding="utf-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2016/head">
+  <hh:refList>
+    <hh:charPr>
+      <hh:outline type="DASH_DOT"/>
+    </hh:charPr>
+  </hh:refList>
+</hh:head>"##;
+        // header XML만 파싱
+        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        assert_eq!(doc_info.char_shapes[0].outline_type, 4);
+        // 직렬화: write_header는 Document 단위이므로 직접 write_char_pr 호출
+        let cs = &doc_info.char_shapes[0];
+        let mut w = Writer::new(Vec::new());
+        write_char_pr(&mut w, 0, cs).expect("write_char_pr");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(xml.contains(r#"type="DASH_DOT""#), "DASH_DOT 왕복: {xml}");
+    }
+
+    #[test]
+    fn shadow_type_drop_hwpx_roundtrip() {
+        // <hh:shadow type="DROP"/> → 파싱 IR 1 → 직렬화 "DROP" 왕복 + 오프셋 보존
+        let hwpx_head = r##"<?xml version="1.0" encoding="utf-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2016/head">
+  <hh:refList>
+    <hh:charPr>
+      <hh:shadow type="DROP" color="#000000" offsetX="10" offsetY="20"/>
+    </hh:charPr>
+  </hh:refList>
+</hh:head>"##;
+        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        assert_eq!(doc_info.char_shapes[0].shadow_type, 1);
+        let cs = &doc_info.char_shapes[0];
+        let mut w = Writer::new(Vec::new());
+        write_char_pr(&mut w, 0, cs).expect("write_char_pr");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(xml.contains(r#"type="DROP""#), "DROP 왕복: {xml}");
+        assert!(xml.contains(r#"offsetX="10""#), "offsetX 보존: {xml}");
+        assert!(xml.contains(r#"offsetY="20""#), "offsetY 보존: {xml}");
+    }
+
+    #[test]
+    fn shadow_type_continuous_hwpx_roundtrip() {
+        // <hh:shadow type="CONTINUOUS"/> → IR 2 → 직렬화 "CONTINUOUS" (L4 경로 방지)
+        let hwpx_head = r##"<?xml version="1.0" encoding="utf-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2016/head">
+  <hh:refList>
+    <hh:charPr>
+      <hh:shadow type="CONTINUOUS" color="#000000" offsetX="0" offsetY="0"/>
+    </hh:charPr>
+  </hh:refList>
+</hh:head>"##;
+        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        assert_eq!(doc_info.char_shapes[0].shadow_type, 2);
+        let cs = &doc_info.char_shapes[0];
+        let mut w = Writer::new(Vec::new());
+        write_char_pr(&mut w, 0, cs).expect("write_char_pr");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(xml.contains(r#"type="CONTINUOUS""#), "CONTINUOUS 왕복: {xml}");
     }
 }

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -2103,9 +2103,18 @@ mod tests {
             expected_type: &'static str,
         }
         let cases = [
-            ShadowTestCase { shadow_type: 0, expected_type: "NONE" },
-            ShadowTestCase { shadow_type: 1, expected_type: "DROP" },
-            ShadowTestCase { shadow_type: 2, expected_type: "CONTINUOUS" },
+            ShadowTestCase {
+                shadow_type: 0,
+                expected_type: "NONE",
+            },
+            ShadowTestCase {
+                shadow_type: 1,
+                expected_type: "DROP",
+            },
+            ShadowTestCase {
+                shadow_type: 2,
+                expected_type: "CONTINUOUS",
+            },
         ];
         for case in &cases {
             let cs = CharShape {
@@ -2121,7 +2130,8 @@ mod tests {
             assert!(
                 xml.contains(&format!(r#"type="{}""#, case.expected_type)),
                 "shadow_type={} → type=\"{}\": {xml}",
-                case.shadow_type, case.expected_type,
+                case.shadow_type,
+                case.expected_type,
             );
             // 오프셋 보존 확인
             assert!(xml.contains(r#"offsetX="10""#), "offsetX 보존: {xml}");
@@ -2141,7 +2151,8 @@ mod tests {
   </hh:refList>
 </hh:head>"##;
         // header XML만 파싱
-        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        let (doc_info, _) =
+            crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
         assert_eq!(doc_info.char_shapes[0].outline_type, 4);
         // 직렬화: write_header는 Document 단위이므로 직접 write_char_pr 호출
         let cs = &doc_info.char_shapes[0];
@@ -2162,7 +2173,8 @@ mod tests {
     </hh:charPr>
   </hh:refList>
 </hh:head>"##;
-        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        let (doc_info, _) =
+            crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
         assert_eq!(doc_info.char_shapes[0].shadow_type, 1);
         let cs = &doc_info.char_shapes[0];
         let mut w = Writer::new(Vec::new());
@@ -2184,12 +2196,16 @@ mod tests {
     </hh:charPr>
   </hh:refList>
 </hh:head>"##;
-        let (doc_info, _) = crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
+        let (doc_info, _) =
+            crate::parser::hwpx::header::parse_hwpx_header(hwpx_head).expect("parse header");
         assert_eq!(doc_info.char_shapes[0].shadow_type, 2);
         let cs = &doc_info.char_shapes[0];
         let mut w = Writer::new(Vec::new());
         write_char_pr(&mut w, 0, cs).expect("write_char_pr");
         let xml = String::from_utf8(w.into_inner()).unwrap();
-        assert!(xml.contains(r#"type="CONTINUOUS""#), "CONTINUOUS 왕복: {xml}");
+        assert!(
+            xml.contains(r#"type="CONTINUOUS""#),
+            "CONTINUOUS 왕복: {xml}"
+        );
     }
 }


### PR DESCRIPTION
## 개요

HWPX `<hh:charPr>` 의 `<hh:outline type>` 과 `<hh:shadow type>` 매핑에서 열거값 일부가 파싱/직렬화 양쪽에서 소실되는 버그를 수정합니다.

## 관련 이슈

- **Closes**: #2695

## 문제 1 — outline type 50% 소실

`<hh:outline type>`의 8개 열거값 중 4개(`DASH_DOT`, `DASH_DOT_DOT`, `LONG_DASH`, `CIRCLE`)가 파서에서 `_ => 0`, 직렬화에서 `_ => "NONE"`으로 떨어져 **외곽선이 완전히 사라집니다.** 같은 파서 파일이 밑줄/취소선에 대해 13종 전체를 이미 매핑하고 있어 누락임이 명확합니다.

| OWPML type | IR 값 | before | after |
|-----------|-------|--------|-------|
| DASH_DOT | 4 | **NONE** | DASH_DOT |
| DASH_DOT_DOT | 5 | **NONE** | DASH_DOT_DOT |
| LONG_DASH | 6 | **NONE** | LONG_DASH |
| CIRCLE | 7 | **NONE** | CIRCLE |

## 문제 2 — shadow type DROP/CONTINUOUS 붕괴 + L4 바이너리 손상

`DROP(1)`과 `CONTINUOUS(2)`가 파서에서 하나로 합쳐지고 직렬화가 `"DROP"`을 방출할 수 없어, **HWP5 → HWPX → HWP5 경로에서 비트값 `2→1`로 변조**됩니다 (L4 바이너리 손상).

## 수정 내용

### 파서 (`src/parser/hwpx/header.rs`)
- `outline_type`: 8값 전체 매핑으로 확장
- `shadow_type`: `DROP | CONTINUOUS => 1` → `DROP => 1, CONTINUOUS => 2`

### 직렬화 (`src/serializer/hwpx/header.rs`)
- `outline_type_str`: 0~7 전체 매핑
- `shadow_type`: `if/else` → 3분기 `match` (NONE/DROP/CONTINUOUS)

## 검증

| 검사 | 결과 |
|------|------|
| lib 테스트 (71/71) | ✅ 기존 68 + 신규 3 통과 |
| cargo fmt | ✅ 통과 |
| cargo clippy -D warnings | ✅ 통과 |

## 추가 정보

- 2개 파일 수정, 129줄 추가 / 5줄 삭제
- IR 필드의 비트 폭은 변경 없음 (HWP5와의 호환성 유지)
- `outline_type`, `shadow_type` 소비 지점 전수 확인 — 모두 `!= 0` / `> 0` 불리언 판정만 하므로 확장 안전
- 처리 결과 문서: `mydocs/report/pr-hwpx-charpr-outline-shadow.md`