### PR TITLE
task: kevin9327 신규 코어 6건 통합 (선택영역 중첩셀·HWPX 열거/속성·Picture 직렬화·커넥터·캡션)

### DIFF
--- a/mydocs/report/task_m100_2651_report.md
+++ b/mydocs/report/task_m100_2651_report.md
@@ -1,0 +1,101 @@
+# task_m100_2651 처리결과 보고서 — 선택 영역 사각형의 중첩 표 셀 오매칭
+
+- **이슈**: [#2651](https://github.com/edwardkim/rhwp/issues/2651)
+- **브랜치**: `task/m100-2651-selection-rects-nested-cell` (base `devel`)
+- **범위**: `src/document_core/queries/cursor_nav.rs`
+- **분류**: 결함 수정 (중첩 표에서 잘못된 셀 선택)
+
+## 1. 문제
+
+`get_selection_rects_native`(선택 영역 사각형 계산)의 셀 매칭이 `cell_context.path` 의
+**첫 항목만** 비교했다.
+
+```rust
+let matches_cell = tr.cell_context.as_ref().map_or(false, |ctx| {
+    ctx.path.first().map_or(false, |entry| {
+        ctx.parent_para_index == ppi
+            && entry.control_index == ci
+            && entry.cell_index == cei
+            && entry.cell_para_index == cpi
+    })
+});
+```
+
+중첩 표 **내부** 셀의 TextRun 은 `path = [바깥 셀, 안쪽 셀]` 이고, 그 `path[0]` 이
+**중첩 표를 품은 바깥 셀과 정확히 같다.** 따라서 바깥 셀을 질의해도 내부 run 들이 전부
+매칭된다. `cpi` 비교 역시 바깥 셀의 문단 슬롯과 비교하는 것이라 형제 내부 셀들을
+구분하지 못한다.
+
+이는 이미 수정된 `cursor_rect.rs` 의 동일 클래스 버그(`path[0]`-only 매칭)와 같은
+근본 원인이다. 같은 파일의 `cell_context_matches` 헬퍼가 `ctx.path.len() == path.len()`
+를 계약으로 명시하고 있어, 설계 모호성이 아니라 계약 위반이다.
+
+### 영향
+
+`getSelectionRectsInCell`/`getSelectionRectsInCellEx` 로 중첩 표 안에서 드래그 선택을
+시작·종료하면, 트리 순회 순서상 먼저 나온 아무 중첩 셀의 사각형이 선택되어 **엉뚱한 셀
+위에 선택 영역이 그려진다.**
+
+## 2. 분석 — 최소 안전 수정을 택한 이유
+
+`get_selection_rects_native` 의 `cell_ctx` 파라미터 자체가 평면 3-튜플
+`Option<(usize, usize, usize)>` 이라 **애초에 중첩 셀 경로 전체를 표현할 수 없다**
+(이미 고친 `cursor_rect.rs` 의 리졸버들이 `Vec<CellPathEntry>` 전체를 받는 것과 대조적).
+
+따라서 이번 수정은 API 를 넓히지 않고 `path.len() == 1` 가드만 추가한다. 효과:
+
+- **틀린 셀을 잘못 고르는 것**(현재 결함) → 막힘
+- **중첩 셀을 정확히 겨냥하는 것**(기존에도 불가) → 여전히 "못 찾음" 으로 안전하게 떨어짐
+
+중첩 셀을 실제로 겨냥하려면 `cell_ctx` 를 `Vec<CellPathEntry>` 로 넓히고 wasm 진입점
+(`getSelectionRectsInCell`/`Ex`)까지 바꿔야 하므로, 범위를 섞지 않기 위해 분리했다.
+
+## 3. 변경
+
+매칭 술어를 `flat_cell_ctx_matches` 헬퍼로 추출하고 `ctx.path.len() == 1` 가드를 추가했다.
+헬퍼로 뺀 이유는 **단위 테스트 가능성** — 원래 위치가 메서드 내부의 중첩 함수라 직접
+호출할 수 없었다.
+
+## 4. 검증
+
+### 신규 테스트 (`flat_cell_ctx_matches_tests`, 3건)
+
+1. `matches_direct_single_level_cell` — 단일 depth 셀은 정상 매칭
+2. `rejects_nested_cell_sharing_the_same_outer_path_entry` — **핵심**: `path[0]` 이
+   질의와 동일한 중첩 셀 run 을 거부
+3. `rejects_mismatched_outer_indices` — 인덱스 불일치 거부
+
+### red→green 실증
+
+가드(`ctx.path.len() == 1 &&`)를 제거하고 실행:
+```
+rejects_nested_cell_sharing_the_same_outer_path_entry ... FAILED
+  assertion failed: !flat_cell_ctx_matches(&ctx, 0, 1, 2, 3)
+test result: FAILED. 2 passed; 1 failed
+```
+가드 복원 후:
+```
+test result: ok. 3 passed; 0 failed
+```
+**중첩 셀 테스트만 정확히 실패**했고 나머지 2건은 통과 — 가드가 의도한 지점만 잡는다는
+증거다.
+
+### 회귀
+
+```
+cargo test --lib document_core::  →  257 passed / 0 failed / 2 ignored
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`)은 저장소
+  규약상 작업지시자 별도 승인 사항이라 실행하지 않았다.
+- 렌더 트리를 구성한 **행위 수준 E2E** 는 넣지 않았다. 이 매처는 메서드 내부 중첩
+  함수라 직접 호출이 불가능했고, 그래서 술어를 헬퍼로 추출해 **결함의 핵심 판정
+  로직을 직접 단위 테스트**하는 방식을 택했다. 렌더 트리 하네스 구축은 범위를 넘는다고
+  판단했다.
+
+## 5. 잔여
+
+`cell_ctx` 를 `Vec<CellPathEntry>` 로 확장해 중첩 셀을 정확히 겨냥하는 작업은 wasm
+진입점 변경을 수반하므로 별도 이슈로 분리한다.

--- a/mydocs/report/task_m100_2695_report.md
+++ b/mydocs/report/task_m100_2695_report.md
@@ -1,0 +1,203 @@
+# task_m100_2695 처리결과 보고서 — HWPX charPr outline/shadow 열거값 절단 수정
+
+- **이슈**: [#2695](https://github.com/edwardkim/rhwp/issues/2695)
+- **브랜치**: `task/m100-2695-hwpx-charpr-outline-shadow` (base `devel` @ `2cd4d78b`)
+- **범위**: `src/parser/hwpx/header.rs`, `src/serializer/hwpx/header.rs`
+- **분류**: 결함 수정 (열거값 매핑 누락 — 파싱·직렬화 양측)
+
+## 1. 문제
+
+`<hh:charPr>` 자식 두 개가 **파싱측과 직렬화측 양쪽에서 동시에** 열거값을 잘라먹었다.
+
+| 요소 | 스펙 값 수 | 파서가 구분한 수 | 직렬화가 방출 가능한 수 |
+|---|---|---|---|
+| `<hh:outline type>` | 8 | 4 | 4 |
+| `<hh:shadow type>` | 3 | 2 | 2 |
+
+- **outline**: 파서 `_ => 0`(`parser/hwpx/header.rs:751-764`), 직렬화 `_ => "NONE"`
+  (`outline_type_str`, `serializer/hwpx/header.rs:759-767`). 값 4~7
+  (`DASH_DOT`/`DASH_DOT_DOT`/`LONG_DASH`/`CIRCLE`)이 `NONE` 으로 떨어져 **외곽선이 다른 선으로
+  열화되는 게 아니라 아예 소멸**했다.
+- **shadow**: 파서가 `"DROP" | "CONTINUOUS" => 1` 로 두 종류를 한 슬롯에 합치고
+  (`parser/hwpx/header.rs:765-782`), 직렬화는 `if shadow_type == 0 {"NONE"} else {"CONTINUOUS"}`
+  (`serializer/hwpx/header.rs:649-665`)라 **`"DROP"` 문자열이 코드 어디에도 없었다** — 방출 불가능.
+
+두 필드 모두 IR 은 이미 충분한 값 범위를 담고 있었다. `CharShape.outline_type`(`model/style.rs:124`)은
+HWP5 `attr` bits 8-10 **3비트**를 그대로 받고(`parser/doc_info.rs:592`의 `(attr >> 8) & 0x07`,
+재패킹 `serializer/doc_info.rs:470-472`), `CharShape.shadow_type`(`model/style.rs:126`)은
+bits 11-12 **2비트**를 받는다(`parser/doc_info.rs:593`의 `(attr >> 11) & 0x03`, 재패킹 `:473-475`).
+즉 손실 지점은 오직 HWPX 매핑 테이블이었다.
+
+## 2. 분석
+
+### 2.1 누락임을 보이는 자기모순
+
+**같은 파서 파일**이 40여 줄 위에서 밑줄(`header.rs:695-710`)·취소선(`:727-742`)에 대해 선 종류
+13종(0~12) 전체를 이미 매핑한다. 직렬화측 `line_shape_str`(`serializer/hwpx/header.rs:742-757`)도
+0~12 를 전부 되돌린다. 즉 `DASH_DOT`/`DASH_DOT_DOT`/`LONG_DASH`/`CIRCLE` 네 문자열은 저장소가
+**이미 알고 이미 처리하던 값**이고, outline 매핑에서만 빠져 있었다. 한 파일 안에서 같은 선 종류
+계열을 한쪽은 13개, 다른 쪽은 4개로 다루는 것은 설계가 아니라 불일치다.
+
+같은 파일의 기존 테스트 `tab_leader_str_emits_double_and_triple_line_types` 가 이미 동일 유형
+(`fill_type 9/10/11` 이 `"NONE"` 으로 유실)을 결함으로 인정하고 고친 전례다.
+
+### 2.2 손실 경로 4종
+
+| # | 입력 | 경로 | 산출 | 피해 |
+|---|---|---|---|---|
+| L1 | HWPX `outline type="DASH_DOT"` | 파싱 → IR `0` → 직렬화 | `type="NONE"` | 외곽선 소멸 (파싱측 유실) |
+| L2 | HWP5 attr bits 8-10 = `0b101` | `doc_info` → IR `5` → HWPX 직렬화 | `type="NONE"` | 외곽선 소멸 (직렬화측 유실) |
+| L3 | HWPX `shadow type="DROP" offsetX/Y` | 파싱 → IR `1` → 직렬화 | `type="CONTINUOUS"` + 오프셋 잔존 | 종류 변조, 오프셋이 해석 주체를 잃음 |
+| L4 | HWP5 attr bits 11-12 = `0b10` | `doc_info` → IR `2` → HWPX `CONTINUOUS` → **재파싱** → IR `1` → `doc_info` | bits = `0b01` | **바이너리 손상** (HWPX 경유만으로 2→1) |
+
+L1 은 직렬화만, L2 는 파서만 고쳐서는 해결되지 않는다. 양측을 함께 고쳐야 하는 근거다.
+
+### 2.3 마스킹 없음 확인
+
+원문 보존(raw splice) 경로가 이 결함을 가리는지 확인했고 **해당 없음**으로 판정했다.
+
+- `hwpx_head_tail` splice(파서 `:218-224` → 직렬화 `:92-103`)는 `</hh:refList>` **이후** 꼬리
+  구간만 보존한다. `charPr` 은 `refList` **안**이라 범위 밖이다.
+- `write_char_pr`(`serializer/hwpx/header.rs:574`)에 원문 재사용 단축 경로가 없다.
+- `raw_para_heads` 보존(`:885-891`)은 numbering 의 `paraHead` 전용이다.
+
+### 2.4 하위 호환 확인 (범위 확대의 안전성)
+
+`outline_type`/`shadow_type` 의 **모든 소비 지점이 `!= 0` / `> 0` 불리언 판정 또는 단순 복사**임을
+전수 확인했다. `outline_type <= 3` 이나 `shadow_type <= 1` 을 전제하는 코드는 없다.
+
+`canvaskit_policy.rs:1834,1837` · `html.rs:352` · `web_canvas.rs:2189,2893,2901` · `svg.rs:2823` ·
+`skia/text_replay.rs:531,539` · `paint/text_v2.rs:758-759` — 전부 비영 판정.
+`paint/paint_op.rs:1551-1552` 는 `== 0` 빈 스타일 판정. `style_resolver.rs:379-380`,
+`layout/text_measurement.rs:1446-1447` 은 단순 복사. `parser/hwp3/mod.rs:279-280` 은 HWP3 불리언을
+`0`/`1` 로만 쓰므로 영향 없다.
+
+## 3. 변경
+
+매핑 테이블 4곳만 수정했다(파일 2개).
+
+1. **파서 outline**(`parser/hwpx/header.rs`) — `DASH_DOT=4`, `DASH_DOT_DOT=5`, `LONG_DASH=6`,
+   `CIRCLE=7` 4개 arm 추가. 문자열은 같은 파일 `underline_shape` 테이블이 쓰는 이름 그대로다
+   (outline 은 `NONE` 이 0번을 차지하므로 선 종류 인덱스보다 1 크다).
+2. **직렬화 `outline_type_str`** — (1)의 정확한 역함수로 `4..=7` 확장.
+3. **파서 shadow** — `"DROP" | "CONTINUOUS" => 1` 을 `"DROP" => 1, "CONTINUOUS" => 2` 로 분리.
+4. **직렬화 shadow** — `write_char_pr` 인라인 `if`/`else` 를 신설 `shadow_type_str(t)` 3분기
+   `match` 로 교체. 인접한 `outline_type_str`/`line_shape_str` 과 동일한 헬퍼 형태를 따랐다.
+
+주석은 저장소 관례대로 한국어 `[#2695]` 접두어로 달고, 각 값이 HWP5 어느 비트에 대응하는지를 남겼다.
+
+## 4. 검증
+
+### 신규 테스트 (`serializer/hwpx/header.rs` 기존 `#[cfg(test)]` 모듈)
+
+파싱과 직렬화를 한 테스트에서 함께 고정하는 왕복 형태다(헬퍼 `parse_single_char_pr` /
+`write_single_char_pr` 신설).
+
+- `char_pr_outline_type_roundtrips_all_eight_values` — 8값 전부에 대해 `type=X` → IR 기대값 →
+  재직렬화 `type=X` 를 단언.
+- `char_pr_shadow_drop_survives_roundtrip_with_offsets` — `DROP` + `offsetX=10`/`offsetY=-7` →
+  IR `1` → 재직렬화 `type="DROP"` 및 오프셋 보존.
+- `char_pr_shadow_continuous_is_ir_two_not_one` — `CONTINUOUS` → IR `2` → 재직렬화
+  `type="CONTINUOUS"` (L4 바이너리 손상 경로 고정).
+
+### red→green 실증 (수정 4곳을 각각 되돌려 4회 수행)
+
+각 수정을 **하나씩만** 되돌려 테스트가 실제로 실패하는지 확인하고 복원했다. 아래는 실제 캡처
+출력이다.
+
+**RED 1 — 파서 outline arm 4~7 제거**
+
+```
+test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (3412) panicked at src\serializer\hwpx\header.rs:1984:13:
+assertion `left == right` failed: outline type=DASH_DOT 은 IR 4 로 파싱돼야 함
+  left: 0
+ right: 4
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 2 — 직렬화 `outline_type_str` arm 4~7 제거** (IR 은 4를 들고 있는데 `NONE` 이 방출되는
+소멸 현상이 출력에 그대로 찍힌다)
+
+```
+test serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_outline_type_roundtrips_all_eight_values' (33564) panicked at src\serializer\hwpx\header.rs:1986:13:
+outline_type=4 은 type="DASH_DOT" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="NONE" color="#000000" offsetX="0" offsetY="0"/></hh:charPr>
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 3 — 파서 shadow 를 `"DROP" | "CONTINUOUS" => 1` 로 되돌림** (L4 의 값 붕괴 2→1 이 그대로 재현)
+
+```
+test serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_shadow_continuous_is_ir_two_not_one' (9720) panicked at src\serializer\hwpx\header.rs:2026:9:
+assertion `left == right` failed: CONTINUOUS 는 IR 2(연속)
+  left: 1
+ right: 2
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**RED 4 — 직렬화 shadow 를 `if`/`else` 로 되돌림** (L3 의 "종류는 변조되고 오프셋만 남는" 증상이
+출력에 그대로 찍힌다: `type="CONTINUOUS" ... offsetX="10" offsetY="-7"`)
+
+```
+test serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets ... FAILED
+
+thread 'serializer::hwpx::header::tests::char_pr_shadow_drop_survives_roundtrip_with_offsets' (33392) panicked at src\serializer\hwpx\header.rs:2011:9:
+shadow_type=1 은 type="DROP" 으로 방출돼야 함: <hh:charPr id="0" height="1000" ... /><hh:outline type="NONE"/><hh:shadow type="CONTINUOUS" color="#C0C0C0" offsetX="10" offsetY="-7"/></hh:charPr>
+
+test result: FAILED. 9 passed; 1 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+**GREEN — 4곳 모두 복원**
+
+```
+test result: ok. 10 passed; 0 failed; 0 ignored; 0 measured; 2445 filtered out
+```
+
+### 회귀
+
+```
+cargo test --lib hwpx    →  474 passed / 0 failed / 0 ignored
+cargo test --lib header  →  130 passed / 0 failed / 1 ignored
+cargo test --lib (전체)  → 2448 passed / 0 failed / 7 ignored
+```
+
+값 범위를 넓히는 변경이라 렌더러까지 영향이 갈 수 있어 전체 lib 테스트도 돌렸고, 실패는 없다.
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
+  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라 실행하지 않았다.
+- **실제 한/글 시각 검증**: 외곽선 4종·비연속 그림자를 지정한 실문서를 한/글에서 열어 확인하는
+  절차는 수행하지 않았다. 검증은 파싱·직렬화 왕복의 값 보존 수준에서 이뤄졌다. 다만 §2.4 에서
+  모든 렌더러 소비 지점이 비영 판정만 한다는 점을 확인했으므로, 이 변경이 렌더링 동작을 바꾸는
+  경로는 없다(렌더러는 종전에도 지금도 "외곽선 있음/없음"만 구분한다). 즉 이번 수정의 효과는
+  **저장 파일의 값 보존**에 한정되며, 종류별 렌더링 차등화는 별개 과제다.
+- **HWP5 왕복 통합 테스트**(L4 경로를 `.hwp` 바이트 수준에서 끝까지 검증)는 추가하지 않았다.
+  `serializer/doc_info.rs:473-475` 가 `shadow_type` 을 `& 0x03` 으로 그대로 재패킹함을 코드로
+  확인했고, 붕괴 지점이 HWPX 매핑임을 `char_pr_shadow_continuous_is_ir_two_not_one` 으로 직접
+  고정했다. 포맷 간 완전 왕복 하네스는 이 범위를 넘는다고 판단했다.
+
+## 5. 잔여 (범위 밖)
+
+조사 중 같은 두 파일에서 확인했으나 이번 범위에 넣지 않은 항목. 이슈 #2695 §7 에 상세를 남겼다.
+
+- **`breakSetting@lineWrap`** 이 `"BREAK"` 상수 하드코딩. 파서는 이 속성을 읽지도 않는다. IR
+  귀속처는 `ParaShape.attr2` bits 0-1 (`ParaShapeMods::single_line`, `model/style.rs:974-976`).
+  파서·직렬화·IR 세 곳을 함께 이어야 하는 별개 작업.
+- **`<hh:autoSpacing>`** 이 `"0"/"0"` 하드코딩. **이것은 단순 매핑 문제가 아니라 `attr2` bit 5 의
+  규약 충돌 때문에 의도적으로 보류했다.** `model/style.rs:977-982` 계열은 bit 4 =
+  `auto_space_kr_en`, bit 5 = `auto_space_kr_num` 으로 쓰고, HWPX 파서(`header.rs:1023-1028`)·
+  직렬화(`serializer/hwpx/header.rs:1048`)·렌더러(`style_resolver.rs:883`) 계열은 bit 5 =
+  `widowOrphan` 으로 쓴다. 한쪽을 설정하면 다른 쪽이 오염되는 실버그이며, **어느 비트 규약을
+  정본으로 삼을지에 대한 설계 결정이 선행**돼야 해서 이번 수정에 포함하지 않았다.
+- **`charPr@shadeColor` 의 `0 → "none"` 특례**(`serializer/hwpx/header.rs:581-585`) — 검정
+  음영(`#000000`)과 음영 없음이 구분되지 않아 검정 음영이 소멸한다. 센티넬 값 설계 사안이라 분리.
+- **`paraPr@suppressLineNumbers` / `@checked`** — 대응 IR 필드가 아예 없어 모델 확장이 선행돼야 한다.

--- a/mydocs/report/task_m100_2696_report.md
+++ b/mydocs/report/task_m100_2696_report.md
@@ -1,9 +1,50 @@
-# task_m100_2696 처리결과 보고서 — HWP5 도형 직렬화 비대칭 2건 (OLE SHAPE_COMPONENT / 최상위 Picture)
+# task_m100_2696 처리결과 보고서 — HWP5 도형 직렬화 (최상위 Picture 무출력)
 
 - **이슈**: [#2696](https://github.com/edwardkim/rhwp/issues/2696)
 - **브랜치**: `task/m100-2696-hwp5-shape-serializer-symmetry` (base `devel` @ `2cd4d78b`)
 - **범위**: `src/serializer/control.rs`, `src/serializer/control/tests.rs`
-- **분류**: 결함 수정 (직렬화 누락 2건 — 형제 arm 비대칭)
+- **분류**: 결함 수정 1건 + 오판 정정 1건
+
+## 0. 정정 고지 — OLE 건은 결함이 아니었다 (철회)
+
+이 보고서는 처음에 결함 2건을 주장했다. **그중 OLE 건은 오판이었고 철회한다.**
+
+최초 주장은 "Chart 형제 arm 은 `serialize_drawing_shape_component` 로 `DrawingObjAttr`
+전체를 기록하는데 OLE arm 만 base-only 이므로 비대칭 결함"이었다. 그러나 CI 검증
+(`cargo test --profile release-test --tests`)에서 기존 통합 테스트
+`issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage` 가 깨졌다:
+
+```
+assertion `left == right` failed
+  left: 239
+ right: 196
+```
+
+**한컴 저장본을 직접 실측해 판정했다.** `samples/143E433F503322BD33.hwp` 의 레코드 덤프:
+
+```
+[ 14]  SHAPE_COMPONENT  sz=252     ← 도형 (테두리/채우기/그림자 꼬리 있음)
+[ 27]  SHAPE_COMPONENT  sz=252     ← 도형
+[ 49]  SHAPE_COMPONENT  sz=196     ← 그림 (뒤에 SC_PICTURE)
+[225]  SHAPE_COMPONENT  sz=196     ← OLE (데이터 선두 65 6c 6f 24 = "$ole")
+```
+
+**한컴 자신이 OLE 의 `SHAPE_COMPONENT` 를 196B(base-only)로 쓴다.** 즉 base-only 는
+누락이 아니라 한컴의 실제 OLE 포맷이며, `#1283`("Fix HWPX OLE chart save contract")이
+한컴 편집기 파일 읽기 오류를 잡으면서 확정한 계약이다.
+
+파서가 `parse_shape_component_full` 로 꼬리를 읽을 수 있는 것은 **관대함이지 직렬화
+의무가 아니었다.** 형제 arm 비대칭이라는 관찰은 사실이었지만, 그 비대칭에는 근거가
+있었고 내가 그 근거를 확인하지 않고 결함으로 단정했다.
+
+조치:
+- OLE arm 2곳(최상위/그룹 자식)을 `devel` 동작으로 되돌리고, **왜** base-only 인지
+  주석으로 근거를 남겼다.
+- 잘못된 전제로 쓴 테스트 `issue2696_ole_shape_component_keeps_border_fill_shadow` 를
+  제거하고, 반대로 **196B 계약을 고정하는** `issue2696_ole_shape_component_stays_base_only`
+  를 추가했다. 같은 오판이 반복되지 않게 하기 위해서다.
+
+아래 본문의 OLE 관련 서술은 이 정정에 따라 무효다. Picture 건(2절)만 유효하다.
 
 ## 1. 문제
 

--- a/mydocs/report/task_m100_2696_report.md
+++ b/mydocs/report/task_m100_2696_report.md
@@ -1,0 +1,242 @@
+# task_m100_2696 처리결과 보고서 — HWP5 도형 직렬화 비대칭 2건 (OLE SHAPE_COMPONENT / 최상위 Picture)
+
+- **이슈**: [#2696](https://github.com/edwardkim/rhwp/issues/2696)
+- **브랜치**: `task/m100-2696-hwp5-shape-serializer-symmetry` (base `devel` @ `2cd4d78b`)
+- **범위**: `src/serializer/control.rs`, `src/serializer/control/tests.rs`
+- **분류**: 결함 수정 (직렬화 누락 2건 — 형제 arm 비대칭)
+
+## 1. 문제
+
+### 1-1. 전제 — raw 패스스루가 가려주지 않는다
+
+`src/serializer/body_text.rs:313-320` 은 컨트롤별로 `ctrl_data_records`(= `HWPTAG_CTRL_DATA`)
+**하나만** 원본 바이트로 되살린다. 도형의 `CTRL_HEADER` / `HWPTAG_SHAPE_COMPONENT` / 도형별
+기하 레코드는 저장할 때마다 IR 로부터 매번 새로 합성되고, `serialize_shape_control` 에는
+원본 레코드 폴백이 없다. `OleShape::raw_tag_data` 는 `HWPTAG_SHAPE_COMPONENT_OLE` 태그
+레코드만 보호하며 그 앞의 `HWPTAG_SHAPE_COMPONENT` 는 보호 대상이 아니다.
+
+따라서 아래 두 결함은 HWPX→HWP5 변환 같은 특수 경로가 아니라 **HWP5 파일을 열어 저장하는
+가장 흔한 경로에서 무조건 발동**한다.
+
+### 1-2. 결함 (1) — OLE `SHAPE_COMPONENT` 이 base-only 로 기록됨
+
+파서는 모든 gso 도형의 `HWPTAG_SHAPE_COMPONENT` 를 `parse_shape_component_full` 로 완전
+파싱해 `border_line` / `fill` / `shadow_*` / `inst_id` / `shadow_alpha` 를 `drawing` 에
+채우고(`parser/control/shape.rs:76-88`), OLE 분기에서 `ole.drawing = drawing;`
+(`shape.rs:324`)으로 그대로 보존한다. **IR 에는 값이 정확히 살아 있다.**
+
+그런데 직렬화기는 최상위(`control.rs:1463`)와 그룹 자식(`:1760`) 양쪽에서 base-only
+`serialize_shape_component(tags::SHAPE_OLE_ID, &drawing.shape_attr, …)` 을 호출했다. 이
+함수는 `write_shape_component_base` 한 줄이 전부이며 주석에도 *"ShapeComponentAttr만 —
+Picture, Group용"* 이라고 적혀 있다. 값을 손에 쥔 채(`ole_drawing_with_shape_component_contract`
+가 이미 `ole.drawing` 전체를 clone 해서 돌려준다) `.shape_attr` 만 꺼내 쓰고 나머지를 버렸다.
+
+재파싱 시에는 `parse_shape_component_full` 의 길이 가드가 전부 실패한다 —
+`remaining() >= 13`(테두리, `shape.rs:574`), `>= 4`(채우기, `:582`), `>= 16`(그림자, `:590`),
+`>= 4`(inst_id, `:602`), `>= 1`(shadow_alpha, `:610`). 에러 하나 없이 조용히 기본값이 된다.
+
+유실 바이트: 테두리 13 + 채우기 8(None)~16(Solid) + 그림자 16 + inst/예약/alpha 6
+= **43~51바이트 / 저장 1회당**.
+
+**비대칭 증거**: 구조적으로 동일한 Chart arm 은 최상위(`:1441`)·그룹 자식(`:1740`) 모두
+`serialize_drawing_shape_component` 를 쓴다. Line/Rectangle/Ellipse/Arc/Polygon/Curve 도
+마찬가지다. `DrawingObjAttr` 를 가진 도형 중 **OLE 두 곳만** base-only 를 호출했다.
+
+### 1-3. 결함 (2) — 최상위 `ShapeObject::Picture` 무출력 + `char_count` 어긋남
+
+`control.rs:1426-1428` 은 레코드를 하나도 push 하지 않았다:
+
+```rust
+ShapeObject::Picture(_pic) => {
+    // 그룹 내 그림: 그룹 직렬화 시 자식으로 처리됨 (단독 Picture는 Control::Picture로 직렬화)
+}
+```
+
+주석의 전제("그룹 자식으로만 등장한다")가 거짓이다. `ungroup_shape_native`
+(`document_core/commands/object_ops/shape.rs`)는 그림 자식을 **최상위 컨트롤로** 삽입한다 —
+`:2297` 에 `ShapeObject::Picture(p) => &mut p.shape_attr` 가 명시적으로 있고, `:2317-2318`
+에서 `para.controls.insert(insert_idx, Control::Shape(Box::new(child)))`, `:2319` 에서
+`ctrl_data_records.insert(insert_idx, None)` 를 수행한다. 직렬화 이전에 이를
+`Control::Picture` 로 정규화하는 코드는 저장소 어디에도 없다.
+
+**단순 유실이 아니라 문서 손상인 이유**: 바로 이어지는 `:2320-2321` 이
+`para.char_count += 8; para.control_mask |= 0x0000_0800;` 로 확장 컨트롤 문자 8 wchar 를
+확보한다. 저장 시 `CTRL_HEADER` 가 0개 방출되면 `HWPTAG_PARA_TEXT` 의 컨트롤 문자와
+`HWPTAG_CTRL_HEADER` 레코드의 1:1 결합이 한 칸씩 밀린다. 그림이 사라지는 데 그치지 않고
+**같은 문단의 이후 컨트롤이 전부 잘못된 문자 위치에 결합**되며, 파싱 단계에서 에러가 나지
+않는다.
+
+## 2. 변경
+
+두 건 모두 "이미 올바른 형제 코드를 그대로 따라간다" 성격이다. 새 직렬화 로직을 쓰지 않았다.
+
+**(1) OLE — Chart arm 과 동일하게 (`control.rs` 2곳)**
+
+```rust
+// 최상위
+data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, true),
+// 그룹 자식
+data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, false),
+```
+
+`drawing` 은 두 지점 모두 `ole_drawing_with_shape_component_contract(...)` 반환값으로 이미
+준비돼 있었다. `ctrl_id` 기본값·`is_two_ctrl_id` 처리는 두 함수가 공유하는
+`write_shape_component_base` 안에 있으므로 **base 부분 출력은 바이트 단위로 동일**하고
+뒤에 43~51바이트가 덧붙을 뿐이다.
+
+**(2) Picture — 검증된 함수에 위임 (`control.rs` 1곳)**
+
+```rust
+ShapeObject::Picture(pic) => {
+    serialize_picture_control(pic, level, ctrl_data_record, records);
+}
+```
+
+`serialize_picture_control`(`control.rs:983-1026`)은 `Control::Picture` 가 이미 쓰고 있는
+함수로, gso `CTRL_HEADER` → 캡션 → `SHAPE_COMPONENT`(`SHAPE_PICTURE_ID`) → `CTRL_DATA` →
+`SHAPE_COMPONENT_PICTURE` 를 방출한다. 4개 인자(`pic`, `level`, `ctrl_data_record`,
+`records`)가 `serialize_shape_control` 스코프에서 그대로 사용 가능해 어댑터가 필요 없었다
+(호출 전 시그니처 대조 확인함).
+
+세 지점 모두 `[#2696]` 주석을 달았다.
+
+## 3. 검증
+
+### 신규 테스트 (`src/serializer/control/tests.rs`, 3건)
+
+기존 serialize→reparse 하네스(`test_roundtrip_group_picture_child`)를 그대로 따랐다.
+
+| 테스트 | 검증 내용 |
+|---|---|
+| `issue2696_ole_shape_component_keeps_border_fill_shadow` | 테두리(color/width/attr/outline) + 단색 채우기(bg/pattern/type) + 그림자(type/color/offset×2) + `inst_id` + `shadow_alpha` **11개 필드**가 왕복 보존 |
+| `issue2696_top_level_shape_picture_is_serialized` | 최상위 `Control::Shape(ShapeObject::Picture)` 가 컨트롤 1개로 왕복, `bin_data_id == 7` |
+| `issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header` | `HWPTAG_CTRL_HEADER` 가 **정확히 1개** + `SHAPE_COMPONENT_PICTURE` 동반 방출 (char_count 짝 고정) |
+
+세 번째 테스트를 별도로 둔 이유: 그림 유실보다 **컨트롤 문자/레코드 짝 어긋남**이 더
+위험한 손상 벡터이므로 개수 자체를 회귀 방지선으로 고정했다.
+
+### red→green 실증 (실제 실행·캡처)
+
+**결함 (1) — OLE 수정 2곳을 원래대로 되돌린 상태**
+
+```
+running 1 test
+test serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow ... FAILED
+
+failures:
+
+---- serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow stdout ----
+
+thread 'serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow' (9960) panicked at src\serializer\control\tests.rs:686:5:
+assertion `left == right` failed: 테두리 색이 보존돼야 함
+  left: 0
+ right: 1193046
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+failures:
+    serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2454 filtered out; finished in 0.00s
+```
+
+복원 후:
+
+```
+running 1 test
+test serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2454 filtered out; finished in 0.00s
+```
+
+**결함 (2) — Picture arm 을 무출력으로 되돌린 상태**
+
+```
+running 2 tests
+test serializer::control::tests::issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header ... FAILED
+test serializer::control::tests::issue2696_top_level_shape_picture_is_serialized ... FAILED
+
+failures:
+
+---- serializer::control::tests::issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header stdout ----
+
+thread 'serializer::control::tests::issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header' (11684) panicked at src\serializer\control\tests.rs:789:5:
+assertion `left == right` failed: 최상위 그림 1개는 CTRL_HEADER 를 정확히 1개 방출해야 함 (char_count += 8 과 1:1)
+  left: 0
+ right: 1
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+---- serializer::control::tests::issue2696_top_level_shape_picture_is_serialized stdout ----
+
+thread 'serializer::control::tests::issue2696_top_level_shape_picture_is_serialized' (22220) panicked at src\serializer\control\tests.rs:749:5:
+assertion `left == right` failed: 최상위 ShapeObject::Picture 가 컨트롤 1개로 왕복돼야 함
+  left: 0
+ right: 1
+
+failures:
+    serializer::control::tests::issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header
+    serializer::control::tests::issue2696_top_level_shape_picture_is_serialized
+
+test result: FAILED. 0 passed; 2 failed; 0 ignored; 0 measured; 2453 filtered out; finished in 0.01s
+```
+
+`left: 0` — 컨트롤 0개, CTRL_HEADER 0개. 이슈에서 예측한 값과 정확히 일치한다.
+
+복원 후 (3건 전체):
+
+```
+running 3 tests
+test serializer::control::tests::issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header ... ok
+test serializer::control::tests::issue2696_top_level_shape_picture_is_serialized ... ok
+test serializer::control::tests::issue2696_ole_shape_component_keeps_border_fill_shadow ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.01s
+```
+
+### 회귀
+
+```
+cargo test --lib serializer::control  →  16 passed / 0 failed
+cargo test --lib shape                → 161 passed / 0 failed
+cargo test --lib serializer::         → 408 passed / 0 failed   (실제 HWP 파일 왕복
+                                                                 test_serialize_real_hwp_files 포함)
+cargo test --lib ole                  →  28 passed / 0 failed
+cargo test --lib picture              → 111 passed / 0 failed
+```
+
+OLE 변경이 실제 파일의 바이트 출력을 바꾸므로 `serializer::` 전체와 실 파일 왕복 테스트까지
+확인했다.
+
+## 4. 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
+  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라 실행하지
+  않았다.
+- **실제 OLE 포함 HWP 파일을 이용한 시각/E2E 검증**은 하지 않았다. 저장소 샘플에 border/
+  fill/shadow 가 비영인 OLE 개체가 있는 파일을 특정하지 못해, 대신 필드 단위 왕복 단언으로
+  검증했다. `serializer::` 전체(408건, 실 파일 왕복 포함) 무회귀는 확인했다.
+- **그룹 해제→저장→재열기 시나리오의 앱 레벨 재현**은 하지 않았다. 도달 경로는 코드로
+  확인했고(`ungroup_shape_native` 의 삽입·char_count 증가 지점), 손상 벡터는
+  CTRL_HEADER 개수 단언으로 고정했다.
+
+## 5. 잔여 (별도 후속 과제)
+
+**(a) 도형 캡션이 HWP5 직렬화에서 방출되지 않음**
+
+파서는 모든 gso 도형의 캡션을 읽지만(`parser/control/shape.rs:136-147`, `:205`/`:213`/
+`:222`/`:230`/`:240`), `serialize_shape_control` 의 **어느 arm 도 `serialize_caption` 을
+호출하지 않는다**. HWP5 의 호출처는 표(`control.rs:492`)와 그림(`:997-999`) 둘뿐이며 HWPX
+라이터는 이미 방출하고 있어(`serializer/hwpx/shape.rs:107`, `:254`, `:393`) 포맷 간
+비대칭이기도 하다.
+
+→ 본 수정 (2) 로 **그림의 캡션은 부수적으로 해결**된다(`serialize_picture_control` 이 캡션을
+방출하므로). 나머지 도형(Line/Rect/Ellipse/Arc/Polygon/Curve/Group/Chart/Ole)의 일반
+케이스는 범위를 넘어 손대지 않았다.
+
+**(b) HWP5 출신 그림의 IR 편집이 raw 로 덮임**
+
+`serialize_picture_data`(`control.rs:1068-1070`)는 `pic.raw_picture_extra` 가 비어 있지
+않으면 이를 그대로 재생하고 투명도 1바이트만 패치한다
+(`picture_raw_extra_with_transparency`, `:1093-1116`). 따라서 파서가 `raw_picture_extra` 를
+채운 HWP5 출신 그림에서는 `pic.border_opacity`(`parser/control/shape.rs:929-931`),
+`pic.instance_id`(`:932-939`), `pic.img_dim`(`:950-956`) 에 대한 IR 편집이 저장 시 무시된다.
+HWPX 출신(빈 `raw_picture_extra`)은 정상 반영되므로 이 역시 출처 의존 비대칭이다.

--- a/mydocs/report/task_m100_2697_report.md
+++ b/mydocs/report/task_m100_2697_report.md
@@ -1,0 +1,241 @@
+# task_m100_2697 처리결과 보고서 — `<hp:tbl>` 크기·번호 범주 속성 라운드트립
+
+- **이슈**: [#2697](https://github.com/edwardkim/rhwp/issues/2697)
+- **브랜치**: `task/m100-2697-hwpx-table-attr-roundtrip` (base `devel` @ `2cd4d78b`)
+- **범위**: `src/parser/hwpx/section.rs`, `src/serializer/hwpx/table.rs`
+- **분류**: 결함 수정 (직렬화 하드코딩 + 파서 arm 누락)
+
+## 1. 문제
+
+`<hp:tbl>` 직렬화기가 표 크기·번호 범주 관련 속성 3종 4개를 IR 대신 리터럴로 방출한다.
+
+> 1·2절의 `file:line` 인용은 모두 **수정 전** 기준(base `2cd4d78b`)이다. 3절 이후는 수정 후 기준.
+
+| # | 속성 | 종전 방출 | 파서 | IR 필드 |
+|---|------|-----------|------|---------|
+| 1 | `hp:sz@widthRelTo` | `"ABSOLUTE"` | 읽음 (`section.rs:1689`) | `Table.common.width_criterion` |
+| 1 | `hp:sz@heightRelTo` | `"ABSOLUTE"` | 읽음 (`section.rs:1693`) | `Table.common.height_criterion` |
+| 2 | `hp:sz@protect` | `"0"` | **arm 부재** | `Table.common.size_protect` |
+| 3 | `hp:tbl@numberingType` | `"TABLE"` | **arm 부재** | `Table.common.numbering_type` |
+
+사용자 관점 증상:
+
+- 단/쪽/문단에 맞춘 표가 저장 한 번에 절대값으로 바뀌어, 이후 단·여백·용지를 바꿔도
+  따라오지 않는다(레이아웃 회귀가 저장 시점이 아니라 다음 편집 때 드러난다).
+- "표 크기 보호"가 왕복에서 풀린다.
+- 표에 그림 번호 캡션(`numberingType="PICTURE"`)을 붙인 문서에서 캡션 자동 번호가
+  저장할 때마다 재배치된다.
+
+## 2. 분석
+
+### 2-1. IR-불가시 문제가 아님
+
+세 값 모두 IR 안에서 이미 소비된다. 따라서 "IR 에 없어서 못 낸다"가 아니라
+**HWPX 로 되쓸 때만 끊긴다**.
+
+- `width_criterion`/`height_criterion` → `pack_hwpx_common_obj_attr`
+  (`section.rs:1918-1928`) 가 attr bit 15-17 / 18-19 로 패킹하고, HWP5 저장 경로도
+  동일하게 패킹한다(`document_core/converters/common_obj_attr_writer.rs:100-101`).
+  기존 테스트 `section.rs` `assert_eq!(table.common.attr, 0x082a_2211)` 가 이 비트를
+  이미 고정하고 있다.
+- `size_protect` → HWP5 파서는 `parser/control/shape.rs:348` 에서 attr bit 20 을 정상
+  파싱한다. 그런데 HWPX 로 저장하면 `protect="0"` 로 나가고, 다시 HWP5 로 저장할 때
+  bit 20 은 IR 에서 재유도되므로(`common_obj_attr_writer.rs:97`)
+  **HWP → HWPX → HWP 왕복에서 "표 크기 보호"가 영구 소실**된다.
+- `numbering_type` → 필드 주석 자체가 `#1379` 의 라운드트립 보존 목적이라고 밝히고 있다
+  (`model/shape.rs:88-92`).
+
+### 2-2. 대칭성 — 설계 결정이 아니라 누락
+
+같은 `hp:sz` 요소를 다루는 코드끼리 비교하면 표만 빠져 있다.
+
+파서: 도형/그림 공통(`section.rs:2901/2904/2907`), 사각형 계열(`:5967`),
+양식 개체(`:5582/5586/5590`)는 `widthRelTo`/`heightRelTo`/`protect` 를 모두 읽는다.
+표(`:1689/1693`)만 `protect` arm 이 없다.
+
+직렬화: **`serializer/hwpx/form.rs:178-188` 이 결정적 반례** — 완전히 같은 `hp:sz`
+요소를 세 속성 모두 보존값으로 방출한다. 즉 "HWPX `hp:sz` 는 ABSOLUTE 고정" 같은 설계
+결정은 이 저장소에 존재하지 않는다.
+
+`numberingType`: 도형 파서(`section.rs:2855-2861`, `[Task #1379]` 주석), 차트(`:5764`),
+사각형(`:5839`) 이 읽고, 도형 직렬화기 4곳(`shape.rs:70,172,291,367`)이
+`numbering_type_str()` 로 방출한다. 표만 계약 밖이다.
+
+같은 파일 내부에서도 `write_pos` 는 `holdAnchorAndSO`(#1594), `flowWithText`(#1637),
+`allowOverlap` 순으로 이미 "리터럴 → IR" 정리가 끝났는데, 바로 위 `write_sz` 만 손이
+닿지 않았다.
+
+### 2-3. 정확한 역함수 제약 (heightRelTo)
+
+`heightRelTo` 는 파서에서 `parse_size_criterion(_, allow_column_para = false)` 로 읽힌다
+(`section.rs:1693`). 파서 치역이 `{Paper, Page, Absolute}` 3값뿐이므로, 방출측도 같은
+3값만 내야 왕복이 정확한 역이 된다. height 에 너비용 5값 매핑을 그대로 쓰면
+`Column`/`Para` 가 담긴 IR 이 `heightRelTo="COLUMN"` 을 방출하고, 재파싱 시 `Absolute` 로
+접혀 **왕복이 비가역**이 된다. HWP5 측 `height_criterion_to_bits`
+(`common_obj_attr_writer.rs:160-167`, `_ => 2`) 도 동일하게 접으므로, 제안 매핑은 기존
+규약과 일치한다.
+
+## 3. 변경
+
+### `src/serializer/hwpx/table.rs`
+
+- `numberingType` → `numbering_type_str(table.common.numbering_type)`
+  (`shape.rs:1047` 의 기존 공용 헬퍼 재사용, 새 매핑 도입 없음).
+- `size_criterion_str(SizeCriterion) -> &'static str` 신설 — 너비용 5값 전체 매핑,
+  `parse_size_criterion(_, true)` 의 정확한 역.
+- `height_criterion_str(SizeCriterion) -> &'static str` 신설 — `Column`/`Para` 를
+  `"ABSOLUTE"` 로 접는 3값 매핑(2-3 제약).
+- `write_sz` 가 `c.width_criterion` / `c.height_criterion` / `c.size_protect` 를 사용.
+
+### `src/parser/hwpx/section.rs`
+
+- `parse_table` 의 `b"sz"` arm 에 `b"protect" => table.common.size_protect = parse_bool(&attr)`
+  추가 (형제 파서 `:2907` 과 동일 코드).
+- `parse_table` 루트 속성 루프에 `numberingType` arm 추가 (도형 파서 `:2855-2861` 과 동형).
+  속성 부재 시 기본값은 `ObjectNumberingType::Table` — 표의 자연 기본값이자 종전 방출
+  리터럴과 같으므로 기존 문서의 동작이 바뀌지 않는다.
+- `materialize_hwpx_table_attrs` 의 `HWPX_TABLE_NUMBERING_BIT` 무조건 OR 을
+  `numbering_type == Table` 조건부로 변경. 종전 동작은 `numberingType="PICTURE"` 표에서
+  IR 모순(`numbering_type = Picture` ↔ attr 은 TABLE 번호)을 만든다. 차트 파서
+  (`:5800-5801`)가 PICTURE 를 별도 비트로 분기하는 것과 같은 취지다.
+
+기능 변경은 위 6개뿐이며, 리팩터링·포맷 변경은 하지 않았다.
+
+## 4. 검증
+
+### 4-1. 신규 테스트 (`src/serializer/hwpx/table.rs` 기존 `#[cfg(test)] mod tests`)
+
+| 테스트 | 내용 |
+|--------|------|
+| `task2697_sz_criteria_and_protect_emitted_from_ir` | IR `Column`/`Paper`/`true` → `widthRelTo="COLUMN"`, `heightRelTo="PAPER"`, `protect="1"` |
+| `task2697_sz_defaults_unchanged` | 기본 IR 은 종전 출력(`ABSOLUTE`/`ABSOLUTE`/`0`)과 동일 — 무변화 보장 |
+| `task2697_numbering_type_emitted_from_ir` | IR `Picture` → `numberingType="PICTURE"`, `Table` → `"TABLE"` |
+| `task2697_tbl_attrs_survive_xml_ir_xml_roundtrip` | XML → IR → XML 전 구간. IR 4값 단언 + attr 번호 비트 단언 + 재방출 4속성 단언 |
+| `task2697_height_criterion_str_is_exact_inverse_of_parser` | height 가 `COLUMN`/`PARA` 를 절대 내지 않음을 고정 (`page_break_str_is_exact_inverse_of_parser` 와 동형) |
+
+### 4-2. red→green 실증 (3건 각각 개별 되돌림 후 실제 실행)
+
+#### 결함 1 — `widthRelTo`/`heightRelTo` 되돌림 (`table.rs` `write_sz` 를 `"ABSOLUTE"` 리터럴로)
+
+```
+running 5 tests
+test serializer::hwpx::table::tests::task2697_height_criterion_str_is_exact_inverse_of_parser ... ok
+test serializer::hwpx::table::tests::task2697_sz_defaults_unchanged ... ok
+test serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir ... ok
+test serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir ... FAILED
+test serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip ... FAILED
+
+---- serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir' (19452) panicked at src\serializer\hwpx\table.rs:1212:9:
+widthRelTo 가 IR(Column)로 방출돼야 함(현재 ABSOLUTE 하드코딩): <hp:tbl id="0" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" pageBreak="NONE" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="0" widthRelTo="ABSOLUTE" height="0" heightRelTo="ABSOLUTE" protect="1"/><hp:pos treatAsChar="0" affectLSpacing="0" flowWithText="0" allowOverlap="0" holdAnchorAndSO=
+
+---- serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip' (18064) panicked at src\serializer\hwpx\table.rs:1334:13:
+widthRelTo="COLUMN" 유실: <hp:tbl id="0" zOrder="0" numberingType="PICTURE" ... <hp:sz width="42520" widthRelTo="ABSOLUTE" height="10000" heightRelTo="ABSOLUTE" protect="1"/> ...
+
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.01s
+```
+
+#### 결함 2 — `protect` 되돌림 (파서 arm 제거 + `table.rs` `("protect", "0")`)
+
+```
+running 5 tests
+test serializer::hwpx::table::tests::task2697_height_criterion_str_is_exact_inverse_of_parser ... ok
+test serializer::hwpx::table::tests::task2697_sz_defaults_unchanged ... ok
+test serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir ... ok
+test serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir ... FAILED
+test serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip ... FAILED
+
+---- serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir' (33528) panicked at src\serializer\hwpx\table.rs:1222:9:
+protect 가 IR(size_protect=true)로 방출돼야 함(현재 0 하드코딩): <hp:tbl id="0" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" pageBreak="NONE" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="0" widthRelTo="COLUMN" height="0" heightRelTo="PAPER" protect="0"/><hp:pos treatAsChar="0" affectLSpacing="0" flowWithText="0" allowOverlap="0" holdAnchorAndSO="0" v
+
+---- serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip' (32656) panicked at src\serializer\hwpx\table.rs:1309:9:
+protect=1 이 IR(size_protect)에 남아야 함(파서 arm 누락)
+
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.00s
+```
+
+#### 결함 3 — `numberingType` 되돌림 (파서 arm + attr 비트 게이트 + `table.rs` `"TABLE"` 리터럴)
+
+```
+running 5 tests
+test serializer::hwpx::table::tests::task2697_height_criterion_str_is_exact_inverse_of_parser ... ok
+test serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir ... ok
+test serializer::hwpx::table::tests::task2697_sz_defaults_unchanged ... ok
+test serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir ... FAILED
+test serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip ... FAILED
+
+---- serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir' (12460) panicked at src\serializer\hwpx\table.rs:1250:9:
+numberingType 이 IR(Picture)로 방출돼야 함(현재 TABLE 하드코딩): <hp:tbl id="0" zOrder="0" numberingType="TABLE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" pageBreak="NONE" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="0" widthRelTo="ABSOLUTE" height="0" heightRelTo="ABSOLUTE" protect="0"/><hp:pos treatAsChar="0" affectLSpacing="0" flowWithText="0" allowOverlap="0" holdAnchorAndSO
+
+---- serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip stdout ----
+
+thread 'serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip' (13608) panicked at src\serializer\hwpx\table.rs:1313:9:
+assertion `left == right` failed: numberingType=PICTURE 가 IR 에 남아야 함(파서 arm 누락)
+  left: Table
+ right: Picture
+
+test result: FAILED. 3 passed; 2 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.00s
+```
+
+#### 복원 후 (GREEN)
+
+```
+running 5 tests
+test serializer::hwpx::table::tests::task2697_height_criterion_str_is_exact_inverse_of_parser ... ok
+test serializer::hwpx::table::tests::task2697_sz_defaults_unchanged ... ok
+test serializer::hwpx::table::tests::task2697_sz_criteria_and_protect_emitted_from_ir ... ok
+test serializer::hwpx::table::tests::task2697_tbl_attrs_survive_xml_ir_xml_roundtrip ... ok
+test serializer::hwpx::table::tests::task2697_numbering_type_emitted_from_ir ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.01s
+```
+
+### 4-3. 회귀
+
+```
+cargo test --lib hwpx   →  476 passed / 0 failed / 0 ignored  (1981 filtered out)
+cargo test --lib table  →  330 passed / 0 failed / 3 ignored  (2124 filtered out)
+cargo test --lib        → 2450 passed / 0 failed / 7 ignored  (0 filtered out, 186.86s)
+```
+
+기존 `test_parse_hwpx_table_materializes_hwp_common_attrs`
+(`assert_eq!(table.common.attr, 0x082a_2211)`) 가 그대로 통과한다 — `numberingType="TABLE"`
+표에서 `HWPX_TABLE_NUMBERING_BIT` 가 유지됨을 기존 테스트가 직접 보증한다.
+
+### 4-4. 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
+  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라
+  실행하지 않았다.
+- **한컴 오피스 실물 대조**: `widthRelTo="COLUMN"` 표를 한글에서 열어 "단에 맞춤"으로
+  표시되는지의 시각 검증은 수행하지 않았다. 파서 치역·HWP5 attr 비트 매핑·형제 개체
+  구현이 모두 일치함을 코드로 대조 확인하는 데 그쳤다.
+- **통합 테스트(`tests/`) 추가 없음**: 결함이 파서/직렬화기 단위에 한정되고 기존 표
+  테스트 하네스(`serializer/hwpx/table.rs`)로 XML→IR→XML 전 구간을 덮을 수 있어
+  단위 테스트로 마무리했다.
+
+## 5. 잔여 (범위 밖)
+
+1. **`hp:cellzone` 확장형 미인식** — `parse_table` 이 `cellzone` 을 `Event::Empty` arm
+   에서만 처리한다. `<hp:cellzone ...></hp:cellzone>` 처럼 펼쳐 쓴 형태는 `Event::Start`
+   arm(`tr`/`tc`/`caption` 만 처리)에 걸리지 않아 셀 영역 테두리/배경이 유실된다.
+   직렬화기는 항상 self-closing 으로 내므로 rhwp 자신이 만든 파일에서는 드러나지 않고,
+   다른 생성기가 만든 HWPX 에서만 발생한다.
+2. **IR 필드가 없는 하드코딩 속성** — `hp:tbl@lock`, `hp:tbl@dropcapstyle`,
+   `hp:pos@affectLSpacing`. 담을 IR 필드가 없어 모델 확장이 선행돼야 한다.
+3. **도형/그림 `write_sz` 의 동일 결함** — `shape.rs:986-988`, `picture.rs:390-392` 도
+   `widthRelTo`/`heightRelTo` 를 `"ABSOLUTE"` 로 하드코딩한다. 파서는 읽으므로 표와 똑같은
+   손실이 있다. 변경 범위를 표 경로로 좁히기 위해 분리했다.
+4. **HWPX→HWP5 어댑터의 무조건 번호 비트** —
+   `document_core/converters/hwpx_to_hwp.rs:1619-1631` 이 `HWPX_TABLE_NUMBERING_BIT` 를
+   무조건 OR 한다. 파서 쪽은 본 수정으로 정리됐지만 HWP5 저장 경로는 여전히 TABLE 로
+   강제한다. 어댑터는 본 수정의 대상 파일 밖이라 분리했다.

--- a/mydocs/report/task_m100_2698_report.md
+++ b/mydocs/report/task_m100_2698_report.md
@@ -1,0 +1,152 @@
+# task_m100_2698 처리결과 보고서 — 커넥터 뮤테이터의 구역 패스스루 무효화 누락
+
+- **이슈**: [#2698](https://github.com/edwardkim/rhwp/issues/2698)
+- **브랜치**: `task/m100-2698-connector-raw-stream-invalidation` (base `devel`)
+- **범위**: `src/document_core/commands/object_ops/connector.rs`
+- **분류**: 계약 위반 수정 (패스스루 무효화 누락)
+
+## 1. 문제
+
+`connector.rs`(347줄, 공개 뮤테이터 3개)에 패스스루 무효화가 **0건**이었다.
+`raw_stream` / `raw_data` 문자열이 파일 전체에 한 번도 등장하지 않았다.
+
+`serialize_section`(`src/serializer/body_text.rs:26-30`)은 `Section::raw_stream` 이
+`Some` 이면 구역 전체를 원본 바이트 그대로 반환한다. 따라서 IR 을 고친 뮤테이터가
+그 층을 무효화하지 않으면 편집이 저장 결과에서 사라진다.
+
+### object_ops 무효화 밀도 (`grep -c 'raw_stream'`)
+
+| 모듈 | 등장 | 판정 |
+|---|---:|---|
+| `picture.rs` | 11 | 정상 |
+| `shape.rs` | 8 | 정상 |
+| `table.rs` | 7 | 정상 |
+| `equation.rs` | 3 | 정상 |
+| `note.rs` | 3 | 정상 |
+| `common.rs` | 2 | 정상 |
+| **`connector.rs`** | **0** | **누락** |
+| `mod.rs` | 0 | 해당 없음 (`pub fn` 0개, 모듈 선언 전용) |
+
+뮤테이션을 수행하는 모듈 중 0건인 것은 `connector.rs` 가 유일하다. `#1904`
+도메인 분할 때 이 모듈만 누락된 것으로 보인다.
+
+## 2. 분석 — 현재 관측 가능한 유실은 없다 (정직 고지)
+
+주장을 과장하지 않기 위해 세 함수의 **모든** 호출 지점을 전수 조사했다.
+
+| # | 호출 지점 | 선행 무효화 | 현재 |
+|---|---|---|---|
+| 1 | `wasm_api.rs:3567` | `create_shape_control_native` → `shape.rs:1492` | 안전 |
+| 2 | `wasm_api.rs:3576` | 동일 블록 | 안전 |
+| 3 | `common.rs:328` | 바로 위 `common.rs:325` | 안전 |
+| 4 | `wasm_api.rs:3748` (wasm 공개 진입점) | **없음** | 호출자 위임 |
+| 5 | `input-handler-picture.ts:1061`, `input-handler-table.ts:1324` | 직전 `setObjectProperties` | 안전 |
+
+**결론: 현재 studio UI 경로에서는 선행 뮤테이션이 우연히 무효화를 대신해 주고 있어
+사용자에게 관측되는 유실이 없다.** 이 사실을 숨기지 않는다.
+
+### 그럼에도 고친 이유
+
+1. **저장소가 선언한 계약과 구현이 어긋나 있다.** `mutation-method-registry.ts` 는
+   자신을 "문서 변경 WasmBridge 메서드의 단일 권위 목록"으로, `MUTATING_METHODS` 를
+   "문서 IR(**직렬화 결과**)을 바꾸는 메서드 전수"로 정의하고 `:44` 에
+   `'updateConnectorsInSection'` 을 등재해 두었다. 그러나 Rust 구현은 `raw_stream` 이
+   `Some` 인 한 직렬화 결과를 바꾸지 않는다.
+2. **안전성이 지역적이지 않고 호출자 순서에 의존한다.** 새 호출자 추가나 순서 변경으로
+   깨지며, 깨져도 컴파일 에러·테스트 실패·런타임 경고가 전혀 없다.
+3. **공개 wasm API 다.** 제3자 임베더는 "호출 전 다른 뮤테이션 필요"라는 암묵 조건을 알 수 없다.
+4. **비용이 사실상 0이다** (3줄, 이미 `None` 이면 무연산).
+
+## 3. 변경
+
+무효화를 뮤테이션 지점에 두되, **실제로 IR 을 바꾼 경우에만** 수행하도록 조건부로 걸었다.
+인덱스가 빗나가 아무것도 바꾸지 않은 경로에서 불필요하게 완전 라운드트립을 깨뜨리지 않기
+위해서다.
+
+- `update_connector_subject_ids` — `mutated` 플래그, SubjectID 4개 대입 시에만 무효화
+- `recalculate_connector_routing` — **갈래가 3개**이므로 각각 처리
+  - 꺾인 연결선: `conn.control_points = pts` 후 `routed = true`
+  - 곡선 연결선: `conn.control_points = vec![...]` 후 `routed = true`
+  - 직선 연결선: `control_points.clear()` 후 **조기 반환**하므로 그 자리에서 직접 무효화
+- `update_connectors_in_section` — bbox/로컬좌표 갱신 루프에 `geometry_updated` 플래그.
+  3단계 제어점 재계산은 `recalculate_connector_routing` 이 자체 무효화하므로, 여기서는
+  좌표만 바뀌고 라우팅 대상이 없는 경우를 덮는다.
+
+### 구현 중 발견한 자체 결함
+
+최초 구현은 `recalculate_connector_routing` 의 **꺾인 갈래에만** 무효화를 걸었다.
+곡선 갈래와 직선(clear 후 조기 반환) 갈래는 `control_points` 를 실제로 바꾸면서도
+무효화를 타지 않는 구멍이 남아 있었다. 갈래별 테스트를 추가하는 과정에서 발견해
+두 갈래를 모두 막았다.
+
+## 4. 검증
+
+### 신규 테스트 (`connector_passthrough_invalidation_tests`, 4건)
+
+1. `update_connector_subject_ids_invalidates_section_passthrough`
+2. `recalculate_connector_routing_invalidates_section_passthrough`
+3. `every_routing_branch_invalidates_section_passthrough` — StrokeBoth / ArcBoth /
+   StraightNoArrow 세 갈래 전부
+4. `no_op_call_keeps_passthrough_intact` — 조건부 설계 고정 (반대 방향)
+
+픽스처는 빈 문서에 커넥터를 심고 `raw_stream = Some(...)` 로 "방금 로드한 원본"을
+모사한다. 빈 문서 첫 문단은 이미 SectionDef/ColumnDef 컨트롤을 갖고 있어
+`control_idx` 를 하드코딩하지 않고 삽입 시점의 실제 인덱스를 돌려준다.
+
+### red→green 실증
+
+**(1) 무효화 2개소를 무력화** (`if mutated && false`, `if routed && false`):
+```
+recalculate_connector_routing_invalidates_section_passthrough ... FAILED
+update_connector_subject_ids_invalidates_section_passthrough ... FAILED
+panicked at connector.rs:421:9:
+[#2698] SubjectID 를 바꿨으면 구역 패스스루가 무효화되어야 한다 — 그렇지 않으면
+저장 시 원본 바이트가 그대로 나가 편집이 사라진다
+panicked at connector.rs:435:9:
+[#2698] 제어점을 재구성했으면 구역 패스스루가 무효화되어야 한다
+test result: FAILED. 1 passed; 2 failed
+```
+`no_op_call_keeps_passthrough_intact` 는 통과 — 테스트가 무차별이 아니라 계약 위반
+지점만 잡는다는 증거다.
+
+**(2) 곡선 갈래의 `routed = true` 만 제거**:
+```
+every_routing_branch_invalidates_section_passthrough ... FAILED
+panicked at connector.rs:461:13:
+[#2698] ArcBoth 갈래에서 구역 패스스루가 무효화되지 않았다
+test result: FAILED. 3 passed; 1 failed
+```
+세 갈래 중 **ArcBoth 만 정확히 지목**했다.
+
+**(3) 전부 복원**:
+```
+test result: ok. 4 passed; 0 failed
+```
+
+### 회귀
+
+```
+cargo test --lib document_core::  →  259 passed / 0 failed / 2 ignored
+cargo test --lib serializer::     →  405 passed / 0 failed
+```
+
+### 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`)은 저장소
+  규약(`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인
+  사항이라 실행하지 않았다.
+- 실제 커넥터가 연결된 문서를 저장→재열기하는 **바이트 수준 왕복 검증**은 하지 않았다.
+  이 수정의 계약은 "뮤테이션 후 `raw_stream` 이 `None` 이어야 한다"는 것이고, 그 이후의
+  재직렬화 정확성은 기존 직렬화 테스트(405건)가 담당한다고 판단했다.
+- `update_connectors_in_section` 의 무효화는 단위 테스트로 고정하지 못했다.
+  `conn_points` 맵이 채워지려면 inst_id 를 가진 비-Line 도형과 그것을 참조하는 커넥터가
+  함께 필요해 픽스처 비용이 커서다. 대신 그 함수가 위임하는
+  `recalculate_connector_routing` 쪽을 갈래별로 고정했다. **확인하지 않은 것을 확인한
+  것처럼 적지 않기 위해 밝혀 둔다.**
+
+## 5. 잔여
+
+- `mutation-method-registry.ts` 의 저작 시점 가드를 "Rust 뮤테이터가 무효화하는가"까지
+  검사하도록 확장하는 정적 분석 과제.
+- 다른 모듈의 무효화 누락 여부는 밀도 조사로 0건이 아님만 확인했을 뿐, 뮤테이터 단위
+  전수 검증은 하지 않았다.

--- a/mydocs/report/task_m100_2699_report.md
+++ b/mydocs/report/task_m100_2699_report.md
@@ -1,0 +1,221 @@
+# task_m100_2699 처리결과 보고서 — Bottom 캡션 예약의 음수 line_spacing 미클램프
+
+- **이슈**: [#2699](https://github.com/edwardkim/rhwp/issues/2699)
+- **브랜치**: `task/m100-2699-caption-reserve-negative-linespacing` (base `devel` @ `2cd4d78b`)
+- **범위**: `src/renderer/pagination/engine.rs`, `src/renderer/pagination/tests.rs`
+- **분류**: 결함 수정 (페이지네이션 과소 예약 → 본문 하단 넘침)
+
+## 1. 문제
+
+`split_table_rows()` 가 Bottom 캡션 예약분을 계산할 때 호스트 문단의 `line_spacing` 을
+**클램프 없이** 더했다 (`engine.rs:2449-2453`).
+
+```rust
+let host_line_spacing_for_caption = para
+    .line_segs
+    .first()
+    .map(|seg| crate::renderer::hwpunit_to_px(seg.line_spacing, self.dpi))
+    .unwrap_or(0.0);
+```
+
+`line_spacing` 은 `i32`(`src/model/paragraph.rs:152`)이고, `hwpunit_to_px`
+(`src/renderer/mod.rs:918`)는 부호를 그대로 보존한다. 이 저장소에서 **음수 `line_spacing`
+은 고정값 줄간격 TAC 표 마커로 실제 사용되는 값**(Task #9)이므로 음수가 정상 경로로 들어온다.
+
+### 실패 사슬
+
+1. `:2470-2474` — `caption_overhead = caption_base_overhead + host_line_spacing_for_caption`.
+   음수 ls 가 예약분을 **차감**한다.
+2. `:2683` — `total_with_caption = partial_height + caption_overhead` 가 `|ls|` px 만큼 작아진다.
+3. `:2689` — 참이어야 할 `total_with_caption > avail` 이 거짓이 된다.
+4. `:2690` — `end_row = end_row.saturating_sub(1)` 이 **발동하지 않는다.**
+
+결과: 마지막 표 행 + Bottom 캡션이 N 페이지에 남아 본문 하단선 아래 / 꼬리말 영역을 침범해
+그려진다. 과소 예약이므로 **넘침 방향**의 오류다.
+
+## 2. 분석
+
+### 음수 ls 가 실제 값이라는 근거
+
+- `engine.rs:977-988` — **결함 지점과 동일한 `para.line_segs.first()`** 를 읽어
+  `seg.line_spacing < 0` 이면 고정값 줄간격 TAC 표로 분기한다. 같은 seg 를 한쪽은 마커로
+  해석하고 다른 쪽은 예약량에 그대로 더하는 비대칭이었다.
+- `layout.rs:5272-5286` — 렌더러도 `line_segs.first()` 의 음수 ls 로 같은 판별을 한다.
+- `layout.rs:7154-7160` — 렌더러는 `ls > 0` 일 때만 `y_offset` 을 더하고, 음수는 별도 분기로
+  처리한다. 즉 실제 조판에서 음수 ls 는 캡션 앞 간격을 **0** 으로 만들지 음수로 만들지 않는다.
+  페이지네이션이 음수를 그대로 빼던 것은 렌더러 동작과 불일치였다.
+
+### `engine.rs` 의 `line_spacing` 참조 전수 조사
+
+| 줄 | 클램프 | 용도 분류 | 판정 |
+|---|---|---|---|
+| `532` | `.filter(> 0)` | 예약/트레일링 | OK |
+| `557` | 없음 | advance 합 (`text_height + ls`) | OK |
+| `589` | `.filter(> 0)` | 예약/트레일링 | OK |
+| `642` | `.filter(> 0)` | 트레일링 차감 | OK |
+| `712` | 없음 | advance 합 (`vpos + lh + ls`) | OK |
+| `921` | `if > 0` | 예약/트레일링 | OK |
+| `958` | 없음 | advance 합 (`lh + ls`) | OK |
+| `1134` | 없음 | advance 합 (`vpos + lh + ls`) | OK |
+| `1266` | 없음 | 트레일링 차감 | 자체 정합 — 5항(잔여) |
+| `1941` | `.filter(> 0)` | 호스트 ls 예약 | OK |
+| `1947` | `.filter(> 0)` | 호스트 ls 예약 | OK |
+| `2017` | `if > 0` | 트레일링 제외 | OK |
+| `2238` | 없음 | advance 합 (`th + ls`) | OK |
+| **`2452`** | **없음** | **캡션 예약 항** | **결함 (수정 대상)** |
+
+- 클램프됨 7건 / 클램프 없음 7건.
+- 클램프 없는 7건 중 **5건은 advance 합산**이며, 렌더러 자신의 advance 공식
+  (`layout.rs:727`)과 동형이므로 음수 포함 합산이 의도된 동작이다.
+- **예약/트레일링 용도이면서 클램프가 없는 것은 `1266` 과 `2452` 둘뿐**이고,
+  그중 **과소 예약(넘침 방향)을 만드는 것은 `2452` 하나뿐**이다.
+
+인접 모듈 `src/renderer/height_cursor.rs` 는 일관되게 클램프한다
+(`:284`/`:323`/`:332`/`:421` `.max(0)`, `:316`/`:829`/`:1188` `> 0` 가드,
+`:639` 는 의도적 `< 0` 검사). 규약 위반 없음.
+
+### 오차 크기
+
+96 DPI 에서 `hwpunit_to_px(x) = x / 75`, 즉 1 px = 75 HWPUNIT. Task #9 의 음수 ls 는
+`ls = (실제 문단 advance) - (표 높이로 부풀려진 lh)` 이므로, 행 2000 HU 짜리 3행 표 기준
+`ls ≈ 1200 - 6000 = -4800 HU = -64 px` 이고 같은 표의 행 하나는 26.7 px 다.
+→ 오차가 **표 행 약 2.4개 분량**으로, 행 넘김 판정을 뒤집기에 충분하다.
+
+## 3. 변경
+
+`engine.rs:2449-2453` 한 지점에 형제 코드와 동일한 필터를 추가했다.
+
+```rust
+// [#2699] 음수 line_spacing(고정값 줄간격 TAC 표 마커, Task #9)은 캡션 예약에서 제외.
+// 클램프하지 않으면 :2471의 caption_overhead가 |ls|만큼 작아져 과소 예약이 되고,
+// 아래 "Bottom 캡션 공간 확보" 판정이 발동하지 않아 마지막 행+캡션이 본문 하단을 넘는다.
+// 렌더러도 음수 ls에서는 y_offset을 더하지 않는다(layout.rs:7154). 형제: :1941/:1947
+let host_line_spacing_for_caption = para
+    .line_segs
+    .first()
+    .filter(|seg| seg.line_spacing > 0)
+    .map(|seg| crate::renderer::hwpunit_to_px(seg.line_spacing, self.dpi))
+    .unwrap_or(0.0);
+```
+
+`.filter(|seg| seg.line_spacing > 0)` 을 택한 이유: 같은 파일에서 의미가 가장 가까운 형제가
+`:1941`/`:1947` 의 `host_line_spacing` 이다. 이름·용도(호스트 문단 ls 를 표 아래 공간으로
+예약)가 같고 `Option` 체인 형태
+(`.filter(> 0)` → `.map(hwpunit_to_px)` → `.unwrap_or(0.0)`)까지 일치한다.
+`seg.line_spacing.max(0)`(`layout.rs:5250`/`:5261` 방식)도 수치 결과는 같지만 그 지점들은
+`.filter()` 가 없는 형태라, 가장 가까운 형제의 형태를 따랐다.
+
+## 4. 검증
+
+### 신규 테스트
+
+`bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699`
+(`src/renderer/pagination/tests.rs`) — **완전한 end-to-end 페이지네이션 재현**이다.
+헬퍼 추출 없이 `paginate()` 를 그대로 구동한다.
+
+구성 근거: 피트 판단에 쓰이는 `effective_height` 는 캡션을 제외하므로
+(`engine.rs:1861-1874`) 캡션 예약은 **연속(continuation) 페이지**에서 판정된다.
+따라서 2페이지에 걸치는 표로 시나리오를 구성했다.
+
+- 본문 영역 ≈ 876.8 px (a4_page_def, 96 DPI — 실측 확인)
+- 표 20행 × 6000 HU(= 80 px) = 1600 px → 분할됨
+  - 1페이지: 행 0..10 = 800 px (11행이면 880 px 로 초과)
+  - 2페이지: 남은 행 10..20 = 800 px → 행만으로는 들어감 (여유 76.8 px)
+- Bottom 캡션 10275 HU = 137 px → 800 + 137 = 937 px > 876.8 px (60 px 초과)
+  → 마지막 행(19)을 3페이지로 넘겨야 한다
+- 호스트 `line_spacing = -9000 HU`(= -120 px): 클램프가 없으면 예약이 137-120 = 17 px 로 줄어
+  800 + 17 = 817 px ≤ 876.8 px (60 px 여유) 가 되어 행 넘김이 사라진다
+
+양쪽 분기 모두 약 60 px 마진을 두어 부동소수점·기하 오차에 둔감하도록 설계했다.
+
+### red→green 실증 (실제 실행 출력)
+
+**RED** — `.filter(|seg| seg.line_spacing > 0)` 한 줄을 제거하고 실행:
+
+```
+running 1 test
+test renderer::pagination::tests::bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699 ... FAILED
+
+failures:
+
+---- renderer::pagination::tests::bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699 stdout ----
+
+thread 'renderer::pagination::tests::bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699' (20348) panicked at src\renderer\pagination\tests.rs:1404:5:
+assertion `left == right` failed: 캡션 예약으로 3개 파트(0..10, 10..19, 19..20)여야 함, partials=[(0, 10), (10, 20)] pages=2
+  left: 2
+ right: 3
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+
+failures:
+    renderer::pagination::tests::bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.00s
+```
+
+`partials=[(0, 10), (10, 20)]` 는 예측한 증상 그대로다 — 행 10..20 전체와 캡션이 2페이지에
+남아 본문 하단을 넘는다.
+
+**GREEN** — 필터 복원 후 실행:
+
+```
+running 1 test
+test renderer::pagination::tests::bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699 ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2452 filtered out; finished in 0.00s
+```
+
+### 회귀
+
+```
+cargo test --lib pagination  →  19 passed / 0 failed / 3 ignored   (기준선 18 + 신규 1)
+cargo test --lib renderer::  →  906 passed / 0 failed / 4 ignored
+```
+
+## 5. 미실행 항목 (투명 고지)
+
+- **PR CI 전체 검증**(`cargo test --verbose`, `cargo clippy -- -D warnings`): 저장소 규약
+  (`mydocs/manual/codex/docs_and_git_workflow.md`)상 작업지시자 별도 승인 사항이라 실행하지
+  않았다.
+- **실제 HWP/HWPX 문서를 이용한 시각 검증**은 수행하지 않았다. 재현은 합성 문서 모델을
+  구성한 페이지네이션 단위 테스트로 했다. 다만 이는 헬퍼 추출이 아닌 `paginate()` 전체를
+  구동하는 end-to-end 경로이며, 분할 결과(`PartialTable` 행 범위)를 직접 단언한다.
+
+## 6. 잔여 — 의도적으로 고치지 않은 것
+
+**`engine.rs:1262-1283` 의 FullParagraph 적합성 검사(`:1266`)는 이번에 클램프하지 않았다.**
+
+```rust
+// 문단 적합성 검사: trailing line_spacing 제외
+let trailing_ls = para
+    .line_segs
+    .last()
+    .map(|seg| crate::renderer::hwpunit_to_px(seg.line_spacing, self.dpi))
+    .unwrap_or(0.0);
+```
+
+표면적으로 `2452` 와 같은 문제로 보이고, 40여 줄 앞의 거의 동일한 형제 `:639-645` 는
+`.filter(|seg| seg.line_spacing > 0)` 과 `.max(0.0)` 을 둘 다 갖고 있어 불일치처럼 읽힌다.
+그러나 `:1266` 은 **자체적으로 정합**이다.
+
+차감 대상인 `para_height` 는 `src/renderer/height_measurer.rs:737-742` 의
+`lines_total = Σ(lh_i + ls_i)` 에서 나오고, 이때 `line_spacings` 는 같은 파일 `:713-714`
+에서 **클램프 없이** 만들어진다. 즉 `para_height` 는 이미 음수 ls 를 접어 넣은 값이므로,
+`para_height - trailing_ls` 를 **같은 부호 규약으로** 빼야 "트레일링 제외 높이"가 정확히
+복원된다. `trailing_ls` 만 0 으로 클램프하면 `para_height` 속 음수는 남고 차감만 사라져
+**오히려 계산이 어긋난다.**
+
+이 지점의 불일치는 `engine.rs` 내부가 아니라 **렌더러와의 불일치**다. `layout.rs:727` 은
+advance 를 `hwpunit_to_px(lh + ls, dpi).max(0.0)` 로 바닥을 0 에 고정하는데
+`height_measurer` 의 합산에는 그 `.max(0.0)` 이 없다. 그 결과 페이지네이션은 **과대 예약**을
+하게 되고 실패 모드는 조기 개행 / 짧은 페이지다. **넘침은 발생하지 않는다** — `2452` 와
+정반대의 안전한 방향이다.
+
+따라서:
+
+- `:1266` 에 무턱대고 클램프를 넣으면 자체 정합성이 깨져 현재보다 나빠질 수 있다.
+- 올바른 수정은 `height_measurer` 의 합산에 렌더러와 같은 per-line `.max(0.0)` 을 넣는
+  것이지만, 모든 문단 높이에 영향을 주는 광범위한 변경이라 이 이슈의 범위를 벗어난다.
+- 해당 지점에 근거를 남기는 주석 추가를 권고하며, 별도 이슈로 다루는 편이 안전하다.
+
+이번 변경은 `engine.rs:2449-2453` **한 지점만** 수정한다.

--- a/src/document_core/commands/object_ops/connector.rs
+++ b/src/document_core/commands/object_ops/connector.rs
@@ -21,6 +21,7 @@ impl DocumentCore {
         end_subject_id: u32,
         end_subject_index: u32,
     ) {
+        let mut mutated = false;
         if let Some(section) = self.document.sections.get_mut(section_idx) {
             if let Some(para) = section.paragraphs.get_mut(para_idx) {
                 if let Some(Control::Shape(ref mut shape)) = para.controls.get_mut(control_idx) {
@@ -30,9 +31,18 @@ impl DocumentCore {
                             conn.start_subject_index = start_subject_index;
                             conn.end_subject_id = end_subject_id;
                             conn.end_subject_index = end_subject_index;
+                            mutated = true;
                         }
                     }
                 }
+            }
+            // [#2698] IR을 실제로 바꾼 경우에만 구역 패스스루를 무효화한다.
+            // 무효화하지 않으면 serialize_section 이 원본 raw_stream 을 그대로
+            // 반환해(body_text.rs:26-30) 이 편집이 저장 결과에서 사라진다.
+            // 인덱스가 빗나가 아무것도 바꾸지 않은 경로에서는 라운드트립을
+            // 깨뜨리지 않기 위해 조건부로 둔다.
+            if mutated {
+                section.raw_stream = None;
             }
         }
     }
@@ -48,6 +58,7 @@ impl DocumentCore {
     ) {
         use crate::model::shape::ConnectorControlPoint;
 
+        let mut routed = false;
         let section = match self.document.sections.get_mut(section_idx) {
             Some(s) => s,
             None => return,
@@ -84,6 +95,9 @@ impl DocumentCore {
         // 직선 연결선: 제어점 불필요
         if !conn.link_type.is_stroke() && !conn.link_type.is_arc() {
             conn.control_points.clear();
+            // [#2698] 이 조기 반환 경로도 제어점 목록을 비우는 실제 IR 변경이므로
+            // 아래 공통 무효화를 타지 못하는 만큼 여기서 직접 무효화한다.
+            section.raw_stream = None;
             return;
         }
 
@@ -136,6 +150,7 @@ impl DocumentCore {
                     point_type: 26,
                 }, // 끝 앵커
             ];
+            routed = true;
         } else {
             // ─── 꺽인 연결선: 직각 꺾임점 ───
             let mut pts = Vec::new();
@@ -207,6 +222,11 @@ impl DocumentCore {
                 point_type: 26,
             });
             conn.control_points = pts;
+            routed = true;
+        }
+        // [#2698] 제어점을 실제로 재구성한 경우에만 구역 패스스루를 무효화한다.
+        if routed {
+            section.raw_stream = None;
         }
     }
     /// 구역 내 모든 연결선을 스캔하여 연결된 도형의 현재 위치에 맞게 갱신한다.
@@ -256,6 +276,7 @@ impl DocumentCore {
         }
 
         // 2) 커넥터 찾기 및 좌표 갱신
+        let mut geometry_updated = false;
         let section = match self.document.sections.get_mut(section_idx) {
             Some(s) => s,
             None => return,
@@ -311,7 +332,14 @@ impl DocumentCore {
                 line.drawing.shape_attr.rotation_center.x = new_w as i32 / 2;
                 line.drawing.shape_attr.rotation_center.y = new_h as i32 / 2;
                 line.drawing.shape_attr.raw_rendering = Vec::new();
+                geometry_updated = true;
             }
+        }
+        // [#2698] bbox/로컬좌표를 실제로 갱신한 경우에만 구역 패스스루를 무효화한다.
+        // (3) 단계의 제어점 재계산은 recalculate_connector_routing 이 자체적으로
+        // 무효화하므로, 여기서는 좌표만 바뀌고 라우팅 대상이 없는 경우를 덮는다.
+        if geometry_updated {
+            section.raw_stream = None;
         }
 
         // 3) 제어점 재계산 (인덱스 수집 후 별도 루프 — borrow checker 대응)
@@ -343,5 +371,113 @@ impl DocumentCore {
         for (pi, ci, si, ei) in routing_targets {
             self.recalculate_connector_routing(section_idx, pi, ci, si, ei);
         }
+    }
+}
+
+/// [#2698] 커넥터 뮤테이터의 구역 패스스루 무효화 계약.
+///
+/// `serialize_section` 은 `Section::raw_stream` 이 `Some` 이면 구역 전체를 원본
+/// 그대로 반환한다(`serializer/body_text.rs:26-30`). 따라서 IR 을 고친 뮤테이터가
+/// 그 층을 무효화하지 않으면 편집이 저장 결과에서 사라진다. 이 모듈의 다른
+/// 형제(`picture.rs`/`shape.rs`/`table.rs` 등)는 전부 뮤테이션 지점에서
+/// 무효화하지만 `connector.rs` 만 누락되어 있었다.
+#[cfg(test)]
+mod connector_passthrough_invalidation_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+    use crate::model::shape::{ConnectorData, LineShape, LinkLineType, ShapeObject};
+
+    /// 방금 로드한 원본 문서를 모사한다 — 커넥터 1개가 있고, 구역 패스스루가
+    /// 아직 살아 있어 저장 시 원본 바이트가 그대로 반환될 상태.
+    ///
+    /// 반환값의 `usize` 는 삽입한 커넥터의 `control_idx` 다. 빈 문서의 첫 문단은
+    /// 이미 SectionDef/ColumnDef 컨트롤을 갖고 있어 0 이 아니므로, 하드코딩하지
+    /// 않고 실제 인덱스를 돌려준다.
+    fn core_with_live_passthrough() -> (DocumentCore, usize) {
+        core_with_connector_of(LinkLineType::StrokeBoth)
+    }
+
+    fn core_with_connector_of(link_type: LinkLineType) -> (DocumentCore, usize) {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+
+        let line = LineShape {
+            connector: Some(ConnectorData {
+                link_type,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let controls = &mut core.document.sections[0].paragraphs[0].controls;
+        let ctrl_idx = controls.len();
+        controls.push(Control::Shape(Box::new(ShapeObject::Line(line))));
+
+        core.document.sections[0].raw_stream = Some(vec![0xAB; 16]);
+        (core, ctrl_idx)
+    }
+
+    #[test]
+    fn update_connector_subject_ids_invalidates_section_passthrough() {
+        let (mut core, ctrl_idx) = core_with_live_passthrough();
+        assert!(
+            core.document.sections[0].raw_stream.is_some(),
+            "전제 성립 확인: 뮤테이션 전에는 패스스루가 살아 있어야 한다"
+        );
+
+        core.update_connector_subject_ids(0, 0, ctrl_idx, 3, 1, 4, 2);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "[#2698] SubjectID 를 바꿨으면 구역 패스스루가 무효화되어야 한다 — \
+             그렇지 않으면 저장 시 원본 바이트가 그대로 나가 편집이 사라진다"
+        );
+    }
+
+    #[test]
+    fn recalculate_connector_routing_invalidates_section_passthrough() {
+        let (mut core, ctrl_idx) = core_with_live_passthrough();
+        assert!(core.document.sections[0].raw_stream.is_some());
+
+        core.recalculate_connector_routing(0, 0, ctrl_idx, 1, 3);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_none(),
+            "[#2698] 제어점을 재구성했으면 구역 패스스루가 무효화되어야 한다"
+        );
+    }
+
+    /// `recalculate_connector_routing` 은 링크 타입에 따라 세 갈래로 갈라지고,
+    /// 세 갈래 모두 `control_points` 를 바꾼다(꺾인=재구성, 곡선=재구성,
+    /// 직선=clear 후 조기 반환). 한 갈래만 무효화하면 나머지 둘에서 편집이
+    /// 조용히 사라지므로 갈래별로 계약을 고정한다.
+    #[test]
+    fn every_routing_branch_invalidates_section_passthrough() {
+        for link_type in [
+            LinkLineType::StrokeBoth,      // 꺾인 — 공통 경로
+            LinkLineType::ArcBoth,         // 곡선 — 별도 분기
+            LinkLineType::StraightNoArrow, // 직선 — clear 후 조기 반환
+        ] {
+            let (mut core, ctrl_idx) = core_with_connector_of(link_type);
+            core.recalculate_connector_routing(0, 0, ctrl_idx, 1, 3);
+            assert!(
+                core.document.sections[0].raw_stream.is_none(),
+                "[#2698] {link_type:?} 갈래에서 구역 패스스루가 무효화되지 않았다"
+            );
+        }
+    }
+
+    /// 무효화를 무조건 하지 않고 조건부로 둔 설계를 고정한다. 인덱스가 빗나가
+    /// 아무것도 바꾸지 않은 호출은 완전 라운드트립을 깨뜨리지 않아야 한다.
+    #[test]
+    fn no_op_call_keeps_passthrough_intact() {
+        let (mut core, _) = core_with_live_passthrough();
+
+        core.update_connector_subject_ids(0, 0, 99, 3, 1, 4, 2);
+        core.recalculate_connector_routing(0, 0, 99, 1, 3);
+
+        assert!(
+            core.document.sections[0].raw_stream.is_some(),
+            "[#2698] IR 을 바꾸지 않은 호출은 패스스루를 유지해야 한다"
+        );
     }
 }

--- a/src/document_core/queries/cursor_nav.rs
+++ b/src/document_core/queries/cursor_nav.rs
@@ -1895,10 +1895,10 @@ impl DocumentCore {
                 best: &mut Option<(u8, CursorHit)>,
             ) {
                 if let RenderNodeType::TextRun(ref tr) = node.node_type {
-                    let matches_cell =
-                        tr.cell_context.as_ref().is_some_and(|ctx| {
-                            flat_cell_ctx_matches(ctx, ppi, ci, cei, cpi)
-                        });
+                    let matches_cell = tr
+                        .cell_context
+                        .as_ref()
+                        .is_some_and(|ctx| flat_cell_ctx_matches(ctx, ppi, ci, cei, cpi));
                     if matches_cell {
                         let cs = tr.char_start.unwrap_or(0);
                         let cc = tr.text.chars().count();

--- a/src/document_core/queries/cursor_nav.rs
+++ b/src/document_core/queries/cursor_nav.rs
@@ -1895,14 +1895,10 @@ impl DocumentCore {
                 best: &mut Option<(u8, CursorHit)>,
             ) {
                 if let RenderNodeType::TextRun(ref tr) = node.node_type {
-                    let matches_cell = tr.cell_context.as_ref().map_or(false, |ctx| {
-                        ctx.path.first().map_or(false, |entry| {
-                            ctx.parent_para_index == ppi
-                                && entry.control_index == ci
-                                && entry.cell_index == cei
-                                && entry.cell_para_index == cpi
-                        })
-                    });
+                    let matches_cell =
+                        tr.cell_context.as_ref().is_some_and(|ctx| {
+                            flat_cell_ctx_matches(ctx, ppi, ci, cei, cpi)
+                        });
                     if matches_cell {
                         let cs = tr.char_start.unwrap_or(0);
                         let cc = tr.text.chars().count();
@@ -2226,6 +2222,73 @@ impl DocumentCore {
         }
 
         Ok(format!("[{}]", rects.join(",")))
+    }
+}
+
+/// [#2651] `get_selection_rects_native` 의 셀 매칭 술어. `cell_ctx` 는 평면
+/// 3-튜플(parent_para_idx, control_idx, cell_idx)이라 애초에 중첩 셀을 정확히
+/// 지정할 수 없다 — `path.len() == 1` 가드 없이 `path[0]` 만 비교하면, 중첩
+/// 표 내부(depth>=2) run 이 그 중첩 표를 품은 바깥 셀과 동일한 `path[0]` 을
+/// 가져 잘못 매칭된다(같은 클래스의 이미 고친 `cursor_rect.rs` 버그와 동형).
+fn flat_cell_ctx_matches(
+    ctx: &crate::renderer::layout::CellContext,
+    ppi: usize,
+    ci: usize,
+    cei: usize,
+    cpi: usize,
+) -> bool {
+    ctx.path.len() == 1
+        && ctx.path.first().is_some_and(|entry| {
+            ctx.parent_para_index == ppi
+                && entry.control_index == ci
+                && entry.cell_index == cei
+                && entry.cell_para_index == cpi
+        })
+}
+
+#[cfg(test)]
+mod flat_cell_ctx_matches_tests {
+    use super::flat_cell_ctx_matches;
+    use crate::renderer::layout::{CellContext, CellPathEntry};
+
+    fn entry(control_index: usize, cell_index: usize, cell_para_index: usize) -> CellPathEntry {
+        CellPathEntry {
+            control_index,
+            cell_index,
+            cell_para_index,
+            text_direction: 0,
+        }
+    }
+
+    #[test]
+    fn matches_direct_single_level_cell() {
+        let ctx = CellContext {
+            parent_para_index: 0,
+            path: vec![entry(1, 2, 3)],
+        };
+        assert!(flat_cell_ctx_matches(&ctx, 0, 1, 2, 3));
+    }
+
+    #[test]
+    fn rejects_nested_cell_sharing_the_same_outer_path_entry() {
+        // 중첩 표 내부 run: path = [바깥 셀(1,2,3), 안쪽 셀(0,0,0)].
+        // path[0] 은 바깥 셀 질의(0,1,2,3)와 정확히 같지만, 이 run 은 실제로
+        // 안쪽 셀에 속하므로 매칭돼선 안 된다 — 종전엔 path.len() 가드가
+        // 없어 여기서 잘못 true 를 반환했다(#2651).
+        let ctx = CellContext {
+            parent_para_index: 0,
+            path: vec![entry(1, 2, 3), entry(0, 0, 0)],
+        };
+        assert!(!flat_cell_ctx_matches(&ctx, 0, 1, 2, 3));
+    }
+
+    #[test]
+    fn rejects_mismatched_outer_indices() {
+        let ctx = CellContext {
+            parent_para_index: 0,
+            path: vec![entry(1, 2, 3)],
+        };
+        assert!(!flat_cell_ctx_matches(&ctx, 0, 9, 9, 9));
     }
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -752,11 +752,18 @@ fn parse_char_shape(
                             for attr in ce.attributes().flatten() {
                                 if attr.key.as_ref() == b"type" {
                                     let val = attr_str(&attr);
+                                    // [#2695] 외곽선 8종 (표 27 선 종류 앞 7개 + NONE).
+                                    // HWP5 attr bits 8-10 (3비트) 과 1:1 대응하므로
+                                    // 4~7 을 버리면 외곽선이 NONE 으로 소멸한다.
                                     cs.outline_type = match val.as_str() {
                                         "NONE" => 0,
                                         "SOLID" => 1,
                                         "DASH" => 2,
                                         "DOT" => 3,
+                                        "DASH_DOT" => 4,
+                                        "DASH_DOT_DOT" => 5,
+                                        "LONG_DASH" => 6,
+                                        "CIRCLE" => 7,
                                         _ => 0,
                                     };
                                 }
@@ -767,9 +774,13 @@ fn parse_char_shape(
                                 match attr.key.as_ref() {
                                     b"type" => {
                                         let val = attr_str(&attr);
+                                        // [#2695] HWP5 attr bits 11-12: 1=비연속(DROP,
+                                        // offsetX/Y 사용), 2=연속(CONTINUOUS). 둘을 1 로
+                                        // 합치면 HWP5 왕복에서 2 가 1 로 손상된다.
                                         cs.shadow_type = match val.as_str() {
                                             "NONE" => 0,
-                                            "DROP" | "CONTINUOUS" => 1,
+                                            "DROP" => 1,
+                                            "CONTINUOUS" => 2,
                                             _ => 0,
                                         };
                                     }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1592,6 +1592,8 @@ fn parse_table(
 ) -> Result<Table, HwpxError> {
     let mut table = Table::default();
     let mut table_record_flags = 0u32;
+    // [#2697] numberingType 부재 시 표의 자연 기본값은 TABLE (종전 방출 리터럴과 동일).
+    table.common.numbering_type = crate::model::shape::ObjectNumberingType::Table;
 
     // 표 기본 속성
     for attr in e.attributes().flatten() {
@@ -1641,6 +1643,16 @@ fn parse_table(
                     "RIGHT_ONLY" => crate::model::shape::TextFlow::RightOnly,
                     "LARGEST_ONLY" => crate::model::shape::TextFlow::LargestOnly,
                     _ => crate::model::shape::TextFlow::BothSides,
+                };
+            }
+            // [#2697] 표만 numberingType arm 이 없어 캡션 번호 범주가 파싱 단계에서
+            // 유실됐다. 도형 파서(같은 파일 2855)와 동형. 방출측은 종전 "TABLE" 하드코딩.
+            b"numberingType" => {
+                table.common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
                 };
             }
             _ => {}
@@ -1694,6 +1706,10 @@ fn parse_table(
                                     table.common.height_criterion =
                                         parse_size_criterion(&attr_str(&attr), false);
                                 }
+                                // [#2697] 표만 protect arm 이 없어 "표 크기 보호"가 파싱
+                                // 단계에서 유실됐다. 도형(2907)·사각형(5967)·양식(5590)
+                                // 파서는 모두 같은 hp:sz@protect 를 읽는다.
+                                b"protect" => table.common.size_protect = parse_bool(&attr),
                                 _ => {}
                             }
                         }
@@ -1854,7 +1870,14 @@ fn parse_size_criterion(value: &str, allow_column_para: bool) -> SizeCriterion {
 fn materialize_hwpx_table_attrs(table: &mut Table, table_record_flags: u32) {
     const HWPX_TABLE_NUMBERING_BIT: u32 = 0x0800_0000;
 
-    table.common.attr = pack_hwpx_common_obj_attr(&table.common) | HWPX_TABLE_NUMBERING_BIT;
+    // [#2697] "표 번호" 비트는 numberingType 이 실제로 TABLE 일 때만 세운다. 종전 무조건 OR
+    // 은 numberingType="PICTURE" 표에서 IR 모순(numbering_type=Picture ↔ attr=TABLE)을 만든다.
+    // 차트 파서(5800)가 PICTURE 를 별도 비트로 분기하는 것과 같은 취지.
+    let mut attr = pack_hwpx_common_obj_attr(&table.common);
+    if table.common.numbering_type == crate::model::shape::ObjectNumberingType::Table {
+        attr |= HWPX_TABLE_NUMBERING_BIT;
+    }
+    table.common.attr = attr;
     // HWPX keeps semantic placement in hp:pos, while legacy layout code still reads
     // table.attr bit0 for some inline-table decisions. Only mirror the minimum
     // renderer compatibility bit here; the HWP5 storage attr is packed later by

--- a/src/renderer/pagination/engine.rs
+++ b/src/renderer/pagination/engine.rs
@@ -2446,9 +2446,14 @@ impl Paginator {
         };
 
         // 캡션 높이 계산
+        // [#2699] 음수 line_spacing(고정값 줄간격 TAC 표 마커, Task #9)은 캡션 예약에서 제외.
+        // 클램프하지 않으면 :2471의 caption_overhead가 |ls|만큼 작아져 과소 예약이 되고,
+        // 아래 "Bottom 캡션 공간 확보" 판정이 발동하지 않아 마지막 행+캡션이 본문 하단을 넘는다.
+        // 렌더러도 음수 ls에서는 y_offset을 더하지 않는다(layout.rs:7154). 형제: :1941/:1947
         let host_line_spacing_for_caption = para
             .line_segs
             .first()
+            .filter(|seg| seg.line_spacing > 0)
             .map(|seg| crate::renderer::hwpunit_to_px(seg.line_spacing, self.dpi))
             .unwrap_or(0.0);
         let caption_base_overhead = {

--- a/src/renderer/pagination/tests.rs
+++ b/src/renderer/pagination/tests.rs
@@ -1296,3 +1296,127 @@ fn test_table_height_within_body_area() {
         }
     }
 }
+
+/// [#2699] Bottom 캡션 예약이 호스트 문단의 음수 line_spacing 때문에 과소 계산되면
+/// 마지막 표 행 + 캡션이 다음 페이지로 넘어가지 않고 본문 하단을 넘어 그려진다.
+///
+/// 음수 line_spacing 은 고정값 줄간격 TAC 표 마커(Task #9)로 실제 사용되는 값이며
+/// (`engine.rs:977`, `layout.rs:5276`), 캡션 예약 계산은 같은 `line_segs.first()` 를 읽는다.
+/// 클램프가 없으면 `caption_overhead` 가 |ls| 만큼 작아져
+/// `end_row = end_row.saturating_sub(1)` 이 발동하지 않는다.
+#[test]
+fn bottom_caption_reserve_ignores_negative_host_line_spacing_issue2699() {
+    use crate::model::control::Control;
+    use crate::model::shape::{Caption, CaptionDirection};
+    use crate::model::table::{Cell, Table};
+
+    let paginator = Paginator::with_default_dpi();
+    let styles = ResolvedStyleSet::default();
+
+    // 본문 영역 ≈ 876.8px (a4_page_def 기준, 96 DPI).
+    // 표 본체 높이는 피트 판단에서 캡션을 제외하므로(engine.rs:1861-1874) 캡션 예약은
+    // 연속(continuation) 페이지에서 판정된다. 따라서 2페이지에 걸치는 표로 구성한다.
+    //
+    // 표: 20행 x 6000HU(=80px) = 1600px → 분할됨
+    //   1페이지: 행 0..10 = 800px (11행이면 880px > 876.8px 이므로 10행)
+    //   2페이지: 남은 행 10..20 = 800px → 행만으로는 들어감 (여유 76.8px)
+    // 캡션: 10275HU(=137px) → 800 + 137 = 937px > 876.8px (60px 초과)
+    //   → 마지막 행(19)을 3페이지로 넘기고 캡션도 함께 이동해야 한다.
+    // 호스트 ls = -9000HU(=-120px): 클램프가 없으면 캡션 예약이 137-120=17px 로 줄어
+    //   800 + 17 = 817px <= 876.8px (60px 여유) 가 되어 행 넘김이 발동하지 않고,
+    //   행 19 + 캡션이 2페이지 본문 하단을 넘어 그려진다.
+    let mut cells = Vec::new();
+    for r in 0..20u16 {
+        for c in 0..2u16 {
+            cells.push(Cell {
+                row: r,
+                col: c,
+                row_span: 1,
+                col_span: 1,
+                height: 6000,
+                width: 5000,
+                ..Default::default()
+            });
+        }
+    }
+
+    let caption_para = Paragraph {
+        line_segs: vec![LineSeg {
+            line_height: 10275,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+
+    let mut table_para = Paragraph {
+        // 고정값 줄간격 TAC 표 마커와 동일한 형태의 음수 line_spacing
+        line_segs: vec![LineSeg {
+            line_height: 1000,
+            line_spacing: -9000,
+            ..Default::default()
+        }],
+        ..Default::default()
+    };
+    table_para.controls.push(Control::Table(Box::new(Table {
+        row_count: 20,
+        col_count: 2,
+        cells,
+        caption: Some(Caption {
+            direction: CaptionDirection::Bottom,
+            paragraphs: vec![caption_para],
+            ..Default::default()
+        }),
+        ..Default::default()
+    })));
+
+    let paras = vec![table_para];
+    let composed: Vec<ComposedParagraph> = Vec::new();
+    let (result, _measured) = paginator.paginate(
+        &paras,
+        &composed,
+        &styles,
+        &a4_page_def(),
+        &ColumnDef::default(),
+        0,
+    );
+
+    let mut partials: Vec<(usize, usize)> = Vec::new();
+    for page in &result.pages {
+        for col in &page.column_contents {
+            for item in &col.items {
+                if let PageItem::PartialTable {
+                    start_row, end_row, ..
+                } = item
+                {
+                    partials.push((*start_row, *end_row));
+                }
+            }
+        }
+    }
+
+    assert!(
+        !partials.is_empty(),
+        "표가 분할되어 PartialTable이 존재해야 함, pages={}",
+        result.pages.len()
+    );
+    // 연속 페이지에서 남은 행(10..20)이 모두 들어가더라도 Bottom 캡션 예약분 때문에
+    // 마지막 행은 다음 페이지로 넘어가야 한다. 음수 ls가 예약분을 깎으면 이 분할이 사라진다.
+    assert_eq!(
+        partials.len(),
+        3,
+        "캡션 예약으로 3개 파트(0..10, 10..19, 19..20)여야 함, partials={:?} pages={}",
+        partials,
+        result.pages.len()
+    );
+    assert_eq!(
+        partials[1].1, 19,
+        "연속 페이지 파트는 캡션 예약분 때문에 마지막 행(19)을 넘겨 end_row=19여야 함, partials={:?}",
+        partials
+    );
+    assert_eq!(
+        partials.last().unwrap().1,
+        20,
+        "마지막 파트 end_row은 전체 행 수(20)여야 함, partials={:?}",
+        partials
+    );
+}

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1466,11 +1466,12 @@ fn serialize_shape_control(
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
                 size: 0,
-                // [#2696] base-only 직렬화는 테두리/채우기/그림자/inst_id/shadow_alpha 를
-                // 버려 재파싱 시 전부 기본값이 됐다 (parse_shape_component_full 의
-                // remaining() 가드가 조용히 실패). Chart 등 형제 arm 과 동일하게
-                // DrawingObjAttr 전체를 기록한다.
-                data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, true),
+                // [#2696] OLE 의 SHAPE_COMPONENT 는 의도적으로 base-only 다.
+                // 한컴 저장본(samples/143E433F503322BD33.hwp)의 `$ole` SHAPE_COMPONENT
+                // 실측 크기가 196B(base) 이고, 테두리/채우기/그림자 꼬리를 붙인
+                // 252B 는 같은 파일의 도형 레코드 쪽이다. #1283 이 한컴 읽기 오류를
+                // 잡으며 확정한 계약이므로 Chart arm 과 달리 확장하지 않는다.
+                data: serialize_shape_component(tags::SHAPE_OLE_ID, &drawing.shape_attr, true),
             });
             emit_ctrl_data(records);
             serialize_text_box_if_present(&drawing, level + 2, records);
@@ -1767,8 +1768,8 @@ fn serialize_group_child(
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: comp_level,
                 size: 0,
-                // [#2696] 최상위 OLE arm 과 동일 — 그룹 자식도 DrawingObjAttr 전체를 기록.
-                data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, false),
+                // [#2696] 최상위 OLE arm 과 동일하게 base-only 를 유지한다(#1283 계약).
+                data: serialize_shape_component(tags::SHAPE_OLE_ID, &drawing.shape_attr, false),
             });
             serialize_text_box_if_present(&drawing, type_level, records);
             records.push(Record {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1423,8 +1423,14 @@ fn serialize_shape_control(
                 serialize_group_child(child, child_comp_level, child_type_level, records);
             }
         }
-        ShapeObject::Picture(_pic) => {
-            // 그룹 내 그림: 그룹 직렬화 시 자식으로 처리됨 (단독 Picture는 Control::Picture로 직렬화)
+        ShapeObject::Picture(pic) => {
+            // [#2696] 그룹 해제(object_ops/shape.rs 의 ungroup_shape_native)는 그림
+            // 자식을 최상위 Control::Shape(ShapeObject::Picture) 로 삽입하면서
+            // char_count += 8 을 함께 적용한다. 종전에는 이 arm 이 아무
+            // 레코드도 방출하지 않아 그림이 사라질 뿐 아니라 PARA_TEXT 의 확장 컨트롤
+            // 문자와 CTRL_HEADER 개수가 어긋나 이후 컨트롤이 잘못된 위치에 결합됐다.
+            // Control::Picture 가 쓰는 검증된 경로에 그대로 위임한다.
+            serialize_picture_control(pic, level, ctrl_data_record, records);
         }
         ShapeObject::Chart(chart) => {
             // Task #195 단계 2: raw_chart_data를 그대로 보존하여 라운드트립 유지
@@ -1460,7 +1466,11 @@ fn serialize_shape_control(
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
                 size: 0,
-                data: serialize_shape_component(tags::SHAPE_OLE_ID, &drawing.shape_attr, true),
+                // [#2696] base-only 직렬화는 테두리/채우기/그림자/inst_id/shadow_alpha 를
+                // 버려 재파싱 시 전부 기본값이 됐다 (parse_shape_component_full 의
+                // remaining() 가드가 조용히 실패). Chart 등 형제 arm 과 동일하게
+                // DrawingObjAttr 전체를 기록한다.
+                data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, true),
             });
             emit_ctrl_data(records);
             serialize_text_box_if_present(&drawing, level + 2, records);
@@ -1757,7 +1767,8 @@ fn serialize_group_child(
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: comp_level,
                 size: 0,
-                data: serialize_shape_component(tags::SHAPE_OLE_ID, &drawing.shape_attr, false),
+                // [#2696] 최상위 OLE arm 과 동일 — 그룹 자식도 DrawingObjAttr 전체를 기록.
+                data: serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &drawing, false),
             });
             serialize_text_box_if_present(&drawing, type_level, records);
             records.push(Record {

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -604,3 +604,196 @@ fn test_cell_field_name_extra_roundtrip() {
     assert_eq!(extra.len(), 13);
     assert_eq!(crate::parser::control::parse_cell_field_name(&extra), None);
 }
+
+/// [#2696] OLE 의 SHAPE_COMPONENT 가 DrawingObjAttr 전체를 기록하는지.
+///
+/// 종전에는 base-only `serialize_shape_component` 를 호출해 테두리(13B) + 채우기 +
+/// 그림자(16B) + inst_id/shadow_alpha(6B) 가 빠졌고, 재파싱 시
+/// `parse_shape_component_full` 의 `remaining()` 가드가 전부 실패해 조용히 기본값이 됐다.
+#[test]
+fn issue2696_ole_shape_component_keeps_border_fill_shadow() {
+    use crate::model::style::SolidFill;
+
+    let drawing = DrawingObjAttr {
+        shape_attr: ShapeComponentAttr {
+            original_width: 7200,
+            original_height: 7200,
+            current_width: 7200,
+            current_height: 7200,
+            ..Default::default()
+        },
+        border_line: ShapeBorderLine {
+            color: 0x123456,
+            width: 300,
+            attr: 0x5,
+            outline_style: 1,
+        },
+        fill: Fill {
+            fill_type: FillType::Solid,
+            solid: Some(SolidFill {
+                background_color: 0x00FF00,
+                pattern_color: 0x0000FF,
+                pattern_type: -1,
+            }),
+            ..Default::default()
+        },
+        shadow_type: 2,
+        shadow_color: 0x808080,
+        shadow_offset_x: 141,
+        shadow_offset_y: 282,
+        inst_id: 0x0000_ABCD,
+        shadow_alpha: 0x80,
+        ..Default::default()
+    };
+
+    let ole = OleShape {
+        common: CommonObjAttr {
+            width: 7200,
+            height: 7200,
+            ..Default::default()
+        },
+        drawing,
+        extent_x: 7200,
+        extent_y: 7200,
+        bin_data_id: 1,
+        ..Default::default()
+    };
+
+    let para = Paragraph {
+        char_count: 2,
+        text: "".to_string(),
+        char_offsets: vec![],
+        controls: vec![Control::Shape(Box::new(ShapeObject::Ole(Box::new(ole))))],
+        ..Default::default()
+    };
+    let section = Section {
+        paragraphs: vec![para],
+        raw_stream: None,
+        ..Default::default()
+    };
+
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+
+    let Control::Shape(shape) = &parsed.paragraphs[0].controls[0] else {
+        panic!("Shape 컨트롤이 나와야 함");
+    };
+    let ShapeObject::Ole(reparsed) = shape.as_ref() else {
+        panic!("Ole 도형이 나와야 함, got {:?}", shape);
+    };
+    let d = &reparsed.drawing;
+
+    assert_eq!(d.border_line.color, 0x123456, "테두리 색이 보존돼야 함");
+    assert_eq!(d.border_line.width, 300, "테두리 굵기가 보존돼야 함");
+    assert_eq!(d.border_line.attr, 0x5, "테두리 속성 워드가 보존돼야 함");
+    assert_eq!(d.border_line.outline_style, 1, "아웃라인 스타일이 보존돼야 함");
+
+    assert_eq!(d.fill.fill_type, FillType::Solid, "단색 채우기가 보존돼야 함");
+    let solid = d.fill.solid.expect("단색 채우기 본문이 있어야 함");
+    assert_eq!(solid.background_color, 0x00FF00, "채우기 배경색이 보존돼야 함");
+    assert_eq!(solid.pattern_color, 0x0000FF, "채우기 무늬색이 보존돼야 함");
+    assert_eq!(solid.pattern_type, -1, "채우기 무늬 종류가 보존돼야 함");
+
+    assert_eq!(d.shadow_type, 2, "그림자 종류가 보존돼야 함");
+    assert_eq!(d.shadow_color, 0x808080, "그림자 색이 보존돼야 함");
+    assert_eq!(d.shadow_offset_x, 141, "그림자 가로 오프셋이 보존돼야 함");
+    assert_eq!(d.shadow_offset_y, 282, "그림자 세로 오프셋이 보존돼야 함");
+
+    assert_eq!(d.inst_id, 0x0000_ABCD, "inst_id 가 보존돼야 함");
+    assert_eq!(d.shadow_alpha, 0x80, "그림자 투명도가 보존돼야 함");
+}
+
+/// [#2696] 최상위 `ShapeObject::Picture` 가 실제로 직렬화되는지.
+///
+/// 그룹 해제(`ungroup_shape_native`)는 그림 자식을 최상위
+/// `Control::Shape(ShapeObject::Picture)` 로 삽입한다. 종전에는 이 arm 이 아무 레코드도
+/// 방출하지 않아 그림이 통째로 사라졌다.
+#[test]
+fn issue2696_top_level_shape_picture_is_serialized() {
+    let pic = Picture {
+        common: CommonObjAttr {
+            width: 5000,
+            height: 3000,
+            ..Default::default()
+        },
+        shape_attr: ShapeComponentAttr {
+            original_width: 5000,
+            original_height: 3000,
+            current_width: 5000,
+            current_height: 3000,
+            ..Default::default()
+        },
+        image_attr: crate::model::image::ImageAttr {
+            bin_data_id: 7,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let para = Paragraph {
+        char_count: 2,
+        text: "".to_string(),
+        char_offsets: vec![],
+        controls: vec![Control::Shape(Box::new(ShapeObject::Picture(Box::new(pic))))],
+        ..Default::default()
+    };
+    let section = Section {
+        paragraphs: vec![para],
+        raw_stream: None,
+        ..Default::default()
+    };
+
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+
+    assert_eq!(
+        parsed.paragraphs[0].controls.len(),
+        1,
+        "최상위 ShapeObject::Picture 가 컨트롤 1개로 왕복돼야 함"
+    );
+    let bin_data_id = match &parsed.paragraphs[0].controls[0] {
+        Control::Picture(p) => p.image_attr.bin_data_id,
+        Control::Shape(s) => match s.as_ref() {
+            ShapeObject::Picture(p) => p.image_attr.bin_data_id,
+            other => panic!("그림 도형이 나와야 함, got {:?}", other),
+        },
+        _ => panic!("그림 컨트롤이 나와야 함"),
+    };
+    assert_eq!(bin_data_id, 7, "bin_data_id 가 왕복 보존돼야 함");
+}
+
+/// [#2696] 최상위 `ShapeObject::Picture` 가 CTRL_HEADER 를 정확히 1개 방출하는지.
+///
+/// 그룹 해제는 그림 1개당 `char_count += 8`(확장 컨트롤 문자)을 함께 적용한다
+/// (`document_core/commands/object_ops/shape.rs:2317-2321`). CTRL_HEADER 가 0개면
+/// PARA_TEXT 의 컨트롤 문자와 레코드 개수가 어긋나 **이후 컨트롤이 잘못된 문자 위치에
+/// 결합**된다. 그림 유실보다 이 짝 어긋남이 더 위험하므로 개수를 별도로 고정한다.
+#[test]
+fn issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header() {
+    let pic = Picture {
+        image_attr: crate::model::image::ImageAttr {
+            bin_data_id: 7,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ctrl = Control::Shape(Box::new(ShapeObject::Picture(Box::new(pic))));
+
+    let mut records: Vec<Record> = Vec::new();
+    serialize_control(&ctrl, 1, None, &mut records);
+
+    let ctrl_headers = records
+        .iter()
+        .filter(|r| r.tag_id == tags::HWPTAG_CTRL_HEADER)
+        .count();
+    assert_eq!(
+        ctrl_headers, 1,
+        "최상위 그림 1개는 CTRL_HEADER 를 정확히 1개 방출해야 함 (char_count += 8 과 1:1)"
+    );
+    assert!(
+        records
+            .iter()
+            .any(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT_PICTURE),
+        "SHAPE_COMPONENT_PICTURE 레코드가 함께 방출돼야 함"
+    );
+}

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -605,104 +605,6 @@ fn test_cell_field_name_extra_roundtrip() {
     assert_eq!(crate::parser::control::parse_cell_field_name(&extra), None);
 }
 
-/// [#2696] OLE 의 SHAPE_COMPONENT 가 DrawingObjAttr 전체를 기록하는지.
-///
-/// 종전에는 base-only `serialize_shape_component` 를 호출해 테두리(13B) + 채우기 +
-/// 그림자(16B) + inst_id/shadow_alpha(6B) 가 빠졌고, 재파싱 시
-/// `parse_shape_component_full` 의 `remaining()` 가드가 전부 실패해 조용히 기본값이 됐다.
-#[test]
-fn issue2696_ole_shape_component_keeps_border_fill_shadow() {
-    use crate::model::style::SolidFill;
-
-    let drawing = DrawingObjAttr {
-        shape_attr: ShapeComponentAttr {
-            original_width: 7200,
-            original_height: 7200,
-            current_width: 7200,
-            current_height: 7200,
-            ..Default::default()
-        },
-        border_line: ShapeBorderLine {
-            color: 0x123456,
-            width: 300,
-            attr: 0x5,
-            outline_style: 1,
-        },
-        fill: Fill {
-            fill_type: FillType::Solid,
-            solid: Some(SolidFill {
-                background_color: 0x00FF00,
-                pattern_color: 0x0000FF,
-                pattern_type: -1,
-            }),
-            ..Default::default()
-        },
-        shadow_type: 2,
-        shadow_color: 0x808080,
-        shadow_offset_x: 141,
-        shadow_offset_y: 282,
-        inst_id: 0x0000_ABCD,
-        shadow_alpha: 0x80,
-        ..Default::default()
-    };
-
-    let ole = OleShape {
-        common: CommonObjAttr {
-            width: 7200,
-            height: 7200,
-            ..Default::default()
-        },
-        drawing,
-        extent_x: 7200,
-        extent_y: 7200,
-        bin_data_id: 1,
-        ..Default::default()
-    };
-
-    let para = Paragraph {
-        char_count: 2,
-        text: "".to_string(),
-        char_offsets: vec![],
-        controls: vec![Control::Shape(Box::new(ShapeObject::Ole(Box::new(ole))))],
-        ..Default::default()
-    };
-    let section = Section {
-        paragraphs: vec![para],
-        raw_stream: None,
-        ..Default::default()
-    };
-
-    let bytes = serialize_section(&section);
-    let parsed = parse_body_text_section(&bytes).unwrap();
-
-    let Control::Shape(shape) = &parsed.paragraphs[0].controls[0] else {
-        panic!("Shape 컨트롤이 나와야 함");
-    };
-    let ShapeObject::Ole(reparsed) = shape.as_ref() else {
-        panic!("Ole 도형이 나와야 함, got {:?}", shape);
-    };
-    let d = &reparsed.drawing;
-
-    assert_eq!(d.border_line.color, 0x123456, "테두리 색이 보존돼야 함");
-    assert_eq!(d.border_line.width, 300, "테두리 굵기가 보존돼야 함");
-    assert_eq!(d.border_line.attr, 0x5, "테두리 속성 워드가 보존돼야 함");
-    assert_eq!(d.border_line.outline_style, 1, "아웃라인 스타일이 보존돼야 함");
-
-    assert_eq!(d.fill.fill_type, FillType::Solid, "단색 채우기가 보존돼야 함");
-    let solid = d.fill.solid.expect("단색 채우기 본문이 있어야 함");
-    assert_eq!(solid.background_color, 0x00FF00, "채우기 배경색이 보존돼야 함");
-    assert_eq!(solid.pattern_color, 0x0000FF, "채우기 무늬색이 보존돼야 함");
-    assert_eq!(solid.pattern_type, -1, "채우기 무늬 종류가 보존돼야 함");
-
-    assert_eq!(d.shadow_type, 2, "그림자 종류가 보존돼야 함");
-    assert_eq!(d.shadow_color, 0x808080, "그림자 색이 보존돼야 함");
-    assert_eq!(d.shadow_offset_x, 141, "그림자 가로 오프셋이 보존돼야 함");
-    assert_eq!(d.shadow_offset_y, 282, "그림자 세로 오프셋이 보존돼야 함");
-
-    assert_eq!(d.inst_id, 0x0000_ABCD, "inst_id 가 보존돼야 함");
-    assert_eq!(d.shadow_alpha, 0x80, "그림자 투명도가 보존돼야 함");
-}
-
 /// [#2696] 최상위 `ShapeObject::Picture` 가 실제로 직렬화되는지.
 ///
 /// 그룹 해제(`ungroup_shape_native`)는 그림 자식을 최상위
@@ -734,7 +636,9 @@ fn issue2696_top_level_shape_picture_is_serialized() {
         char_count: 2,
         text: "".to_string(),
         char_offsets: vec![],
-        controls: vec![Control::Shape(Box::new(ShapeObject::Picture(Box::new(pic))))],
+        controls: vec![Control::Shape(Box::new(ShapeObject::Picture(Box::new(
+            pic,
+        ))))],
         ..Default::default()
     };
     let section = Section {
@@ -795,5 +699,35 @@ fn issue2696_top_level_shape_picture_emits_exactly_one_ctrl_header() {
             .iter()
             .any(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT_PICTURE),
         "SHAPE_COMPONENT_PICTURE 레코드가 함께 방출돼야 함"
+    );
+}
+
+/// [#2696] OLE 의 `SHAPE_COMPONENT` 는 **의도적으로** base-only 다.
+///
+/// 최초 조사에서 "Chart 형제 arm 은 `serialize_drawing_shape_component` 로
+/// DrawingObjAttr 전체를 기록하는데 OLE 만 base-only 이므로 비대칭 결함" 이라고
+/// 판단했으나, 한컴 저장본 `samples/143E433F503322BD33.hwp` 를 실측한 결과
+/// `$ole` ctrl id 를 가진 `SHAPE_COMPONENT` 는 **196B(base-only)** 였다. 같은
+/// 파일에서 테두리/채우기/그림자 꼬리를 가진 252B 레코드는 도형 쪽이다.
+/// 즉 base-only 가 한컴의 실제 OLE 포맷이며, `#1283` 이 한컴 읽기 오류를
+/// 잡으면서 확정한 계약이다(`tests/issue_1251_ole_chart_contents.rs` 가
+/// `shape_component.size == 196` 으로 고정).
+///
+/// 파서가 `parse_shape_component_full` 로 꼬리를 읽을 수 있는 것은 관대함이지
+/// 직렬화 의무가 아니다. 같은 오판이 반복되지 않도록 계약을 여기에 못박는다.
+#[test]
+fn issue2696_ole_shape_component_stays_base_only() {
+    let base = serialize_shape_component(tags::SHAPE_OLE_ID, &ShapeComponentAttr::default(), true);
+    let full =
+        serialize_drawing_shape_component(tags::SHAPE_OLE_ID, &DrawingObjAttr::default(), true);
+    assert!(
+        full.len() > base.len(),
+        "전제 확인: 전체 직렬화가 base 보다 길어야 이 계약이 의미를 가짐"
+    );
+    assert_eq!(
+        base.len(),
+        196,
+        "[#2696] OLE SHAPE_COMPONENT 는 한컴 실측치와 같은 196B(base-only)여야 한다 \
+         — 꼬리를 붙이면 #1283 의 한컴 호환 계약이 깨진다"
     );
 }

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -650,14 +650,7 @@ fn write_char_pr<W: Write>(
         w,
         "hh:shadow",
         &[
-            (
-                "type",
-                if cs.shadow_type == 0 {
-                    "NONE"
-                } else {
-                    "CONTINUOUS"
-                },
-            ),
+            ("type", shadow_type_str(cs.shadow_type)),
             ("color", &color_hex(cs.shadow_color)),
             ("offsetX", &cs.shadow_offset_x.to_string()),
             ("offsetY", &cs.shadow_offset_y.to_string()),
@@ -756,13 +749,29 @@ fn line_shape_str(s: u8) -> &'static str {
     }
 }
 
+// [#2695] 외곽선 8종. IR outline_type 은 HWP5 attr bits 8-10(3비트)을 그대로 담으므로
+// 0~7 전부를 방출해야 한다. 4~7 을 NONE 으로 떨구면 외곽선이 소멸한다.
 fn outline_type_str(t: u8) -> &'static str {
     match t {
         0 => "NONE",
         1 => "SOLID",
         2 => "DASH",
         3 => "DOT",
+        4 => "DASH_DOT",
+        5 => "DASH_DOT_DOT",
+        6 => "LONG_DASH",
+        7 => "CIRCLE",
         _ => "NONE",
+    }
+}
+
+// [#2695] 그림자 3종. IR shadow_type 은 HWP5 attr bits 11-12(2비트).
+// 1=비연속(DROP), 2=연속(CONTINUOUS).
+fn shadow_type_str(t: u8) -> &'static str {
+    match t {
+        0 => "NONE",
+        1 => "DROP",
+        _ => "CONTINUOUS",
     }
 }
 
@@ -1926,6 +1935,100 @@ mod tests {
         assert!(
             xml.contains(r#"<hh:shadow type="NONE""#),
             "shadow NONE 항상 출력: {xml}"
+        );
+    }
+
+    /// [#2695] charPr 자식 하나를 담은 최소 hh:head 를 파싱해 CharShape 를 얻는다.
+    fn parse_single_char_pr(child: &str) -> CharShape {
+        let xml = format!(
+            r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="1">
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+        {child}
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##
+        );
+        let (doc_info, _) =
+            crate::parser::hwpx::header::parse_hwpx_header(&xml).expect("parse hh:head");
+        doc_info.char_shapes[0].clone()
+    }
+
+    /// [#2695] CharShape 를 charPr 로 직렬화한 XML 문자열.
+    fn write_single_char_pr(cs: &CharShape) -> String {
+        let mut writer = Writer::new(Vec::new());
+        write_char_pr(&mut writer, 0, cs).expect("write charPr");
+        String::from_utf8(writer.into_inner()).unwrap()
+    }
+
+    #[test]
+    fn char_pr_outline_type_roundtrips_all_eight_values() {
+        // [#2695] 외곽선은 HWP5 attr bits 8-10(3비트) = 8종이다. 종전엔 파서가
+        // NONE/SOLID/DASH/DOT 4종만 알고 나머지를 `_ => 0` 으로, 직렬화가
+        // `_ => "NONE"` 으로 떨궈 4~7 지정 시 외곽선이 통째로 사라졌다.
+        for (name, expected) in [
+            ("NONE", 0u8),
+            ("SOLID", 1),
+            ("DASH", 2),
+            ("DOT", 3),
+            ("DASH_DOT", 4),
+            ("DASH_DOT_DOT", 5),
+            ("LONG_DASH", 6),
+            ("CIRCLE", 7),
+        ] {
+            let cs = parse_single_char_pr(&format!(r#"<hh:outline type="{name}"/>"#));
+            assert_eq!(
+                cs.outline_type, expected,
+                "outline type={name} 은 IR {expected} 로 파싱돼야 함"
+            );
+
+            let xml = write_single_char_pr(&cs);
+            assert!(
+                xml.contains(&format!(r#"<hh:outline type="{name}"/>"#)),
+                "outline_type={expected} 은 type=\"{name}\" 으로 방출돼야 함: {xml}"
+            );
+        }
+    }
+
+    #[test]
+    fn char_pr_shadow_drop_survives_roundtrip_with_offsets() {
+        // [#2695] 비연속(DROP)은 offsetX/offsetY 로 본체와 떨어뜨려 그리는 종류다.
+        // 종전엔 파서가 DROP|CONTINUOUS 를 모두 1 로 합치고 직렬화가 0 이외를
+        // 무조건 CONTINUOUS 로 써서 DROP 이 방출 불가능했고, 보존된 오프셋도
+        // 해석 주체를 잃었다.
+        let cs = parse_single_char_pr(
+            r##"<hh:shadow type="DROP" color="#C0C0C0" offsetX="10" offsetY="-7"/>"##,
+        );
+        assert_eq!(cs.shadow_type, 1, "DROP 은 IR 1(비연속)");
+        assert_eq!(cs.shadow_offset_x, 10);
+        assert_eq!(cs.shadow_offset_y, -7);
+
+        let xml = write_single_char_pr(&cs);
+        assert!(
+            xml.contains(r#"<hh:shadow type="DROP""#),
+            "shadow_type=1 은 type=\"DROP\" 으로 방출돼야 함: {xml}"
+        );
+        assert!(
+            xml.contains(r#"offsetX="10" offsetY="-7""#),
+            "오프셋도 함께 보존돼야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn char_pr_shadow_continuous_is_ir_two_not_one() {
+        // [#2695] 연속은 HWP5 attr bits 11-12 = 2 다. 종전 파서는 1 로 읽어
+        // HWPX 를 경유한 .hwp 재저장 시 비트값이 2→1 로 손상됐다.
+        let cs = parse_single_char_pr(r##"<hh:shadow type="CONTINUOUS" color="#808080"/>"##);
+        assert_eq!(cs.shadow_type, 2, "CONTINUOUS 는 IR 2(연속)");
+
+        let xml = write_single_char_pr(&cs);
+        assert!(
+            xml.contains(r#"<hh:shadow type="CONTINUOUS""#),
+            "shadow_type=2 는 type=\"CONTINUOUS\" 로 방출돼야 함: {xml}"
         );
     }
 

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -29,12 +29,13 @@ use std::io::Write;
 use quick_xml::Writer;
 
 use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, TextFlow, TextWrap, VertAlign, VertRelTo,
+    CommonObjAttr, HorzAlign, HorzRelTo, SizeCriterion, TextFlow, TextWrap, VertAlign, VertRelTo,
 };
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
 
 use super::context::SerializeContext;
 use super::section::{render_hp_p_open, render_paragraph_parts};
+use super::shape::numbering_type_str;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
 
@@ -73,7 +74,11 @@ pub fn write_table<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "TABLE"),
+            // [#2697] numberingType 은 IR(common.numbering_type)을 보존한다. 종전 "TABLE"
+            // 하드코딩은 표에 그림 번호 캡션을 붙인 문서(numberingType="PICTURE")에서
+            // 저장 시 번호 범주를 되돌려 문서 전체 캡션 번호를 재배치시켰다. 도형 계열은
+            // 이미 #1379 에서 IR 보존으로 정리됐다(shape.rs:70,172,291,367).
+            ("numberingType", numbering_type_str(table.common.numbering_type)),
             ("textWrap", text_wrap),
             ("textFlow", text_flow),
             ("lock", lock),
@@ -118,17 +123,45 @@ pub fn write_table<W: Write>(
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
     let width = c.width.to_string();
     let height = c.height.to_string();
+    // [#2697] widthRelTo/heightRelTo/protect 는 IR 을 보존한다. 종전 "ABSOLUTE"/"0"
+    // 하드코딩은 파서가 이미 읽어 둔 값(section.rs:1689/1693)을 저장 때 버려, 단/쪽/문단에
+    // 맞춘 표가 절대값으로 바뀌고 크기 보호가 풀렸다. 이웃 write_pos 는 이미 모든 필드를
+    // enum 헬퍼로 통과시킨다. 같은 hp:sz 를 다루는 form.rs:178-188 도 3속성 모두 보존한다.
     empty_tag(
         w,
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", height_criterion_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
+}
+
+/// 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+fn size_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로(section.rs:1693)
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다. HWP5 측 `height_criterion_to_bits` 도 동일하게 접는다
+/// (`common_obj_attr_writer.rs:160`).
+fn height_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
@@ -1163,6 +1196,161 @@ mod tests {
         assert_eq!(table_page_break_str(TablePageBreak::None), "NONE");
         assert_eq!(table_page_break_str(TablePageBreak::CellBreak), "TABLE");
         assert_eq!(table_page_break_str(TablePageBreak::RowBreak), "CELL");
+    }
+
+    // ---------- #2697: hp:tbl 크기·번호 범주 속성 라운드트립 ----------
+
+    #[test]
+    fn task2697_sz_criteria_and_protect_emitted_from_ir() {
+        // [#2697] hp:sz 의 widthRelTo/heightRelTo/protect 는 IR 을 보존해야 한다.
+        // 종전 "ABSOLUTE"/"ABSOLUTE"/"0" 하드코딩은 파서가 이미 읽어 둔 값을 버렸다. RED.
+        let mut t = empty_table(1, 1);
+        t.common.width_criterion = SizeCriterion::Column;
+        t.common.height_criterion = SizeCriterion::Paper;
+        t.common.size_protect = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="COLUMN""#),
+            "widthRelTo 가 IR(Column)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"heightRelTo="PAPER""#),
+            "heightRelTo 가 IR(Paper)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"protect="1""#),
+            "protect 가 IR(size_protect=true)로 방출돼야 함(현재 0 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_sz_defaults_unchanged() {
+        // 기본 IR(Absolute/Absolute/false)은 종전 출력과 동일해야 한다(무변화 보장).
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="ABSOLUTE""#)
+                && xml.contains(r#"heightRelTo="ABSOLUTE""#)
+                && xml.contains(r#"protect="0""#),
+            "기본값 출력이 바뀌면 안 됨: {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_numbering_type_emitted_from_ir() {
+        // [#2697] numberingType 은 IR 을 보존해야 한다. 종전 "TABLE" 리터럴. RED.
+        use crate::model::shape::ObjectNumberingType;
+        let mut t = empty_table(1, 1);
+        t.common.numbering_type = ObjectNumberingType::Picture;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"numberingType="PICTURE""#),
+            "numberingType 이 IR(Picture)로 방출돼야 함(현재 TABLE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        // 기본값(Table)은 종전 출력과 동일.
+        let mut t2 = empty_table(1, 1);
+        t2.common.numbering_type = ObjectNumberingType::Table;
+        assert!(serialize(&t2).contains(r#"numberingType="TABLE""#));
+    }
+
+    #[test]
+    fn task2697_tbl_attrs_survive_xml_ir_xml_roundtrip() {
+        // XML → IR → XML 전 구간. 파서 arm 부재(protect/numberingType)와 방출 하드코딩이
+        // 모두 걸리는 통합 케이스.
+        use crate::model::shape::ObjectNumberingType;
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl numberingType="PICTURE" textWrap="TOP_AND_BOTTOM" pageBreak="CELL"
+            repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0"
+            noAdjust="0">
+      <hp:sz width="42520" widthRelTo="COLUMN" height="10000" heightRelTo="PAPER" protect="1"/>
+      <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0"
+              vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT"
+              vertOffset="0" horzOffset="0"/>
+      <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0">
+          <hp:cellAddr colAddr="0" rowAddr="0"/>
+          <hp:cellSpan colSpan="1" rowSpan="1"/>
+          <hp:cellSz width="42520" height="10000"/>
+        </hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(src).expect("파싱");
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(t) => t.as_ref().clone(),
+            other => panic!("표가 아님: {other:?}"),
+        };
+
+        // IR 단계 — 파서가 4속성을 모두 읽어야 한다.
+        assert_eq!(
+            table.common.width_criterion,
+            SizeCriterion::Column,
+            "widthRelTo=COLUMN 이 IR 에 남아야 함"
+        );
+        assert_eq!(
+            table.common.height_criterion,
+            SizeCriterion::Paper,
+            "heightRelTo=PAPER 가 IR 에 남아야 함"
+        );
+        assert!(
+            table.common.size_protect,
+            "protect=1 이 IR(size_protect)에 남아야 함(파서 arm 누락)"
+        );
+        assert_eq!(
+            table.common.numbering_type,
+            ObjectNumberingType::Picture,
+            "numberingType=PICTURE 가 IR 에 남아야 함(파서 arm 누락)"
+        );
+        // numberingType 이 TABLE 이 아니므로 "표 번호" attr 비트는 서지 않는다.
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "PICTURE 번호 표에 TABLE 번호 비트가 서면 IR 모순: {:#010x}",
+            table.common.attr
+        );
+
+        // 방출 단계 — 4속성이 그대로 되살아나야 한다.
+        let xml = serialize(&table);
+        for expected in [
+            r#"numberingType="PICTURE""#,
+            r#"widthRelTo="COLUMN""#,
+            r#"heightRelTo="PAPER""#,
+            r#"protect="1""#,
+        ] {
+            assert!(xml.contains(expected), "{expected} 유실: {xml}");
+        }
+    }
+
+    #[test]
+    fn task2697_height_criterion_str_is_exact_inverse_of_parser() {
+        // 파서는 높이를 parse_size_criterion(_, allow_column_para=false) 로 읽으므로
+        // (section.rs:1693) 치역이 {Paper, Page, Absolute} 3값뿐이다. 방출이 COLUMN/PARA 를
+        // 내면 재파싱 시 Absolute 로 접혀 왕복이 비가역이 된다. 너비만 5값 전체를 낸다.
+        assert_eq!(height_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(height_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(height_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Column), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Para), "ABSOLUTE");
+
+        assert_eq!(size_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(size_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(size_criterion_str(SizeCriterion::Column), "COLUMN");
+        assert_eq!(size_criterion_str(SizeCriterion::Para), "PARA");
+        assert_eq!(size_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
     }
 
     #[test]

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -78,7 +78,10 @@ pub fn write_table<W: Write>(
             // 하드코딩은 표에 그림 번호 캡션을 붙인 문서(numberingType="PICTURE")에서
             // 저장 시 번호 범주를 되돌려 문서 전체 캡션 번호를 재배치시켰다. 도형 계열은
             // 이미 #1379 에서 IR 보존으로 정리됐다(shape.rs:70,172,291,367).
-            ("numberingType", numbering_type_str(table.common.numbering_type)),
+            (
+                "numberingType",
+                numbering_type_str(table.common.numbering_type),
+            ),
             ("textWrap", text_wrap),
             ("textFlow", text_flow),
             ("lock", lock),


### PR DESCRIPTION
## 통합 목적

kevin9327 님의 신규 코어 계열 6건을 최신 `devel` 위에 각 PR 의 **전 커밋을 순서대로** cherry-pick(-x) 통합합니다(provenance 보존).

## 반영 (원 PR → 이슈)

- #2685 → #2651: `get_selection_rects_native` 의 path[0]-only 셀 매칭 — 중첩 표 내부 run 이 바깥 셀로 오매칭되던 결함. `flat_cell_ctx_matches` 로 `path.len()==1` 가드 추가
- #2700 → #2695: HWPX charPr outline 8값·shadow DROP 열거 절단
- #2701 → #2697: 표 `hp:tbl` 크기·번호 범주 속성 4개 라운드트립 보존
- #2703 → #2696: 최상위 `ShapeObject::Picture` 미직렬화로 문단 char_count 어긋남
- #2704 → #2698: 커넥터 뮤테이터가 구역 passthrough 를 무효화하지 않음
- #2705 → #2699: Bottom 캡션 예약에서 음수 line_spacing 클램프

## 메인테이너 정정 사항 (#2651)

어제 이슈 정리 중 #2651 을 "#2547 과 중복"으로 판단해 close 했으나, **오판이었습니다**. #2547 은 `cursor_rect.rs`, 본 건(#2685)은 `cursor_nav.rs` 의 `get_selection_rects_native` 로 **같은 결함 클래스의 서로 다른 파일**입니다. #2651 은 미해결 상태였고, 이 통합으로 실제 해결됩니다.

## 검증

- `cargo test --profile release-test --tests --no-fail-fast` 전건 통과
- `cargo clippy --all-targets -- -D warnings` / `cargo fmt --all -- --check` 클린
- `hwp5_roundtrip_baseline` 3/3 · `hwpx_roundtrip_baseline` 4/4 무회귀
- 충돌 0 (전 커밋 순서 적용 방식으로 이식)

## 운영

head CI 성공 + 작업지시자 merge 승인 후, merge SHA 를 근거로 각 원 PR·연결 이슈에 결과를 남기고 close 한다.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
