### PR TITLE
task: kevin9327 신규 studio/hwpctl·확장·문서 6건 통합

### DIFF
--- a/mydocs/report/pr-editor-readme-hml.md
+++ b/mydocs/report/pr-editor-readme-hml.md
@@ -1,0 +1,20 @@
+# PR #????: @rhwp/editor README에 exportHml·getHmlSaveState 문서 추가
+
+## 이슈
+- **Issue**: #2691 — README에 exportHml·getHmlSaveState API 문서 누락
+
+## 분석
+
+`npm/editor/index.js`에는 `exportHml()`과 `getHmlSaveState()`가 구현되어 있지만 `npm/editor/README.md`의 API 문서에는 누락되어 있었다. SDK 사용자가 해당 API의 존재를 인지할 수 없었다.
+
+## 변경
+
+`README.md`의 API 섹션에 `exportHwpVerify()` 다음에 두 메서드 추가:
+
+1. `exportHml()` — HML(XML) 내보내기 예제 코드 포함
+2. `getHmlSaveState()` — HML 저장 가능 여부 반환
+
+## 결과
+- **Branch**: `pr/fix-issue-2691-editor-readme-hml`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2691

--- a/mydocs/report/pr-editor-readme-hml.md
+++ b/mydocs/report/pr-editor-readme-hml.md
@@ -16,5 +16,5 @@
 
 ## 결과
 - **Branch**: `pr/fix-issue-2691-editor-readme-hml`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2692
 - **Closes**: #2691

--- a/mydocs/report/pr-ext-hml-regex.md
+++ b/mydocs/report/pr-ext-hml-regex.md
@@ -29,5 +29,5 @@ const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
 ## 결과
 - **Branch**: `pr/fix-issue-2689-ext-hml-regex`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2690
 - **Closes**: #2689

--- a/mydocs/report/pr-ext-hml-regex.md
+++ b/mydocs/report/pr-ext-hml-regex.md
@@ -1,0 +1,33 @@
+# PR #????: 확장 프로그램 dev-tools-inject.js HML 링크 감지 정규식 보완
+
+## 이슈
+- **Issue**: #2689 — dev-tools-inject.js HML 링크 감지 정규식에 .hml 누락
+
+## 분석
+
+`rhwpDev.inspect()`는 페이지의 `<a>` 링크 중 HWP 문서 링크를 감지하여 `data-hwp="true"` 속성 누락을 검사한다. 감지 정규식에서 `.hml` 확장자가 누락되어 HML 문서 링크를 HWP 문서로 인식하지 못했다.
+
+`content-script.js`는 올바르게 `.hml`을 포함하고 있으나 `dev-tools-inject.js`에만 누락되어 있었다.
+
+## 변경
+
+Chrome 및 Firefox의 `dev-tools-inject.js`에서 정규식 보완:
+
+```javascript
+// before
+const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+// after
+const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
+```
+
+## 검증
+
+- `.hwp` 링크: 기존과 동일하게 감지
+- `.hwpx` 링크: 기존과 동일하게 감지
+- `.hml` 링크: 신규 감지
+- `.hwp?query=1`: 쿼리 파라미터 처리 기존과 동일
+
+## 결과
+- **Branch**: `pr/fix-issue-2689-ext-hml-regex`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2689

--- a/mydocs/report/pr-hwpctl-open-cursor.md
+++ b/mydocs/report/pr-hwpctl-open-cursor.md
@@ -1,0 +1,13 @@
+# PR #????: hwpctl Open() 커서 위치 초기화
+
+## 이슈
+- **Issue**: #2693 — Open()이 커서 위치를 초기화하지 않음
+
+## 분석
+`Clear()`는 `createBlankDocument()` 후 커서를 (0,0,0)으로 초기화하지만, `Open()`은 `wasmDoc` 교체만 하고 cursor 필드를 초기화하지 않아 이전 문서의 커서 위치가 잔류하는 불일치가 있었다.
+
+## 변경
+`Open()` 성공 경로에 `cursorSection = cursorPara = cursorPos = 0` 추가 (Clear와 동일).
+
+## 결과
+- **Branch**: `pr/fix-issue-2693-hwpctl-open-cursor`

--- a/mydocs/report/pr-hwpctl-open-cursor.md
+++ b/mydocs/report/pr-hwpctl-open-cursor.md
@@ -11,3 +11,5 @@
 
 ## 결과
 - **Branch**: `pr/fix-issue-2693-hwpctl-open-cursor`
+- **PR**: https://github.com/edwardkim/rhwp/pull/2694
+- **Closes**: #2693

--- a/mydocs/report/pr-hwpctl-saveas-markclean.md
+++ b/mydocs/report/pr-hwpctl-saveas-markclean.md
@@ -96,5 +96,5 @@ const ctrl = await createHwpCtrl({
 
 ## 결과
 - **Branch**: `pr/fix-issue-2661-hwpctl-markclean`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2683
 - **Closes**: #2661

--- a/mydocs/report/pr-hwpctl-saveas-markclean.md
+++ b/mydocs/report/pr-hwpctl-saveas-markclean.md
@@ -1,0 +1,100 @@
+# PR #????: hwpctl SaveAs 성공 시 dirty 상태 정리 — onSave 콜백 추가
+
+## 이슈
+- **Issue**: #2661 — rhwp-studio: hwpctl SaveAs()가 dirty 상태를 정리하지 않음
+
+## 분석
+
+`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl.SaveAs()`는 blob 다운로드 방식 내보내기를 수행한 후 `documentState.markClean()`을 호출하지 않는다. 이로 인해 SaveAs 성공 후에도 편집 창의 dirty 상태와 자동 백업 draft가 정리되지 않는다.
+
+### 문제의 원인
+
+`HwpCtrl`은 `wasmDoc`만 주입받는 독립 객체로 설계되어 있다. 내부 저장 경로(`file.ts`)는 `services.documentState.markClean('save-as')`를 호출하지만, HwpCtrl은 `documentState`나 `eventBus`에 접근할 방법이 없다.
+
+이슈 본문에서 언급된 대로, 생성자 시그니처를 변경하거나 콜백을 주입하는 방식이 필요하다.
+
+### 해결 방안
+
+세 가지 접근법을 고려했다:
+
+1. **`documentState` 직접 주입**: HwpCtrl이 `DocumentDirtyState`를 직접 알게 하는 방법. 그러나 HwpCtrl의 독립성과 테스트 용이성이 손상됨.
+2. **커스텀 이벤트 발생**: SaveAs 성공 시 DOM 커스텀 이벤트를 발생시키는 방법. 그러나 전역 이벤트는 디버깅이 어렵고 타입 안전성이 낮음.
+3. **✅ 선택적 콜백 주입 (채택)**: 생성자에 선택적 `onSave: SaveCallback` 파라미터를 추가. HwpCtrl의 독립성을 유지하면서 호출자가 후처리를 원하는 대로 구성 가능.
+
+### 선택한 방식의 장점
+
+- **하위 호환성**: `onSave`는 선택적(optional) 파라미터로, 기존 `new HwpCtrl(wasmDoc)` 호출은 전혀 영향 없음
+- **단일 책임**: HwpCtrl은 저장 자체만 담당하고, dirty 상태 관리는 호출자에게 위임
+- **테스트 용이성**: 콜백 모킹이 간단함
+
+## 변경
+
+```typescript
+// before
+export class HwpCtrl {
+  wasmDoc: any;
+  constructor(wasmDoc: any) {
+    this.wasmDoc = wasmDoc;
+  }
+  SaveAs(filename: string): boolean {
+    // ... blob 생성 및 다운로드 ...
+    return true;
+  }
+}
+
+// after
+export type SaveCallback = () => void;
+
+export class HwpCtrl {
+  wasmDoc: any;
+  private onSave: SaveCallback | undefined;
+
+  constructor(wasmDoc: any, onSave?: SaveCallback) {
+    this.wasmDoc = wasmDoc;
+    this.onSave = onSave;  // 선택적 콜백 저장
+  }
+
+  SaveAs(filename: string): boolean {
+    // ... blob 생성 및 다운로드 ...
+    this.onSave?.();  // 저장 성공 시 콜백 호출
+    return true;
+  }
+}
+```
+
+`createHwpCtrl` 팩토리 함수도 확장:
+
+```typescript
+export async function createHwpCtrl(options: {
+  wasmUrl?: string;
+  wasmModule?: any;
+  onSave?: SaveCallback;  // 신규
+}): Promise<HwpCtrl> {
+  // ...
+  return new HwpCtrl(wasmDoc, options.onSave);
+}
+```
+
+## 사용 예
+
+호출자(embed runtime 등)에서 `onSave`로 `documentState.markClean()`을 연결:
+
+```typescript
+const ctrl = await createHwpCtrl({
+  wasmUrl: '/pkg/rhwp_bg.wasm',
+  onSave: () => documentState.markClean('hwpctl-save-as'),
+});
+```
+
+## 검증
+
+- `onSave` 미지정 시 기존 동작 완전히 동일 (`this.onSave`가 `undefined`이므로 `?.()`는 무시)
+- 기존 `new HwpCtrl(wasmDoc)` 생성자 호출 전혀 영향 없음
+- TypeScript 타입 체크 통과 (기존 오류만 존재)
+- 콜백 등록 시 SaveAs 성공 후 정확히 한 번 호출됨
+- SaveAs 예외 발생 시 콜백 호출되지 않음 (catch 블록보다 위에 위치)
+
+## 결과
+- **Branch**: `pr/fix-issue-2661-hwpctl-markclean`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2661

--- a/mydocs/report/pr-hwpctl-trycatch.md
+++ b/mydocs/report/pr-hwpctl-trycatch.md
@@ -1,0 +1,69 @@
+# PR #????: hwpctl PageCount·Clear WASM 호출 예외 처리 추가
+
+## 이슈
+- **Issue**: #2684 — PageCount·Clear WASM 호출에 try-catch 누락
+
+## 분석
+
+`rhwp-studio/src/hwpctl/index.ts`의 `HwpCtrl` 클래스는 대부분의 WASM 호출 메서드(`Open`, `SaveAs`, `InsertText`, `SetCellText`, `GetCellText`, `EvaluateFormula`, `GetFieldList`, `MoveToField`, `PutFieldText`, `GetFieldText`, `MovePos`)가 try-catch로 예외를 처리하고 `console.error`로 기록한다.
+
+그러나 다음 두 메서드는 try-catch 없이 WASM을 직접 호출한다:
+
+```typescript
+// Clear — 예외 발생 시 호출자까지 전파 + 커서 위치만 초기화되는 불일치
+Clear(): void {
+  this.wasmDoc.createBlankDocument();
+  this.cursorSection = 0;
+  this.cursorPara = 0;
+  this.cursorPos = 0;
+}
+
+// PageCount — WASM 패닉이 스튜디오 전체로 전파 가능
+PageCount(): number {
+  return this.wasmDoc.pageCount();
+}
+```
+
+### 영향
+
+- `PageCount()` WASM 패닉 → 스튜디오 전체 비정상 종료
+- `Clear()` 실패 후 커서 위치 초기화 → 문서 상태 불일치
+
+## 변경
+
+두 메서드에 try-catch를 추가하고 실패 시 안전한 기본값을 반환:
+
+```typescript
+// after
+Clear(): void {
+  try {
+    this.wasmDoc.createBlankDocument();
+    this.cursorSection = 0;
+    this.cursorPara = 0;
+    this.cursorPos = 0;
+  } catch (e) {
+    console.error('[hwpctl] Clear 실패:', e);
+  }
+}
+
+PageCount(): number {
+  try {
+    return this.wasmDoc.pageCount();
+  } catch (e) {
+    console.error('[hwpctl] PageCount 실패:', e);
+    return 0;
+  }
+}
+```
+
+## 검증
+
+- 정상 경로: 기존 동작과 완전히 동일
+- 예외 경로: `console.error` 출력 후 안전한 기본값(0 또는 void) 반환
+- `PageCount()` 실패 시 `0` 반환 — 호출자는 페이지 없음으로 처리
+- TypeScript 타입 체크 통과 (기존 `@wasm/rhwp.js` 미생성 오류 외 신규 오류 없음)
+
+## 결과
+- **Branch**: `pr/fix-issue-2684-hwpctl-trycatch`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2684

--- a/mydocs/report/pr-hwpctl-trycatch.md
+++ b/mydocs/report/pr-hwpctl-trycatch.md
@@ -65,5 +65,5 @@ PageCount(): number {
 
 ## 결과
 - **Branch**: `pr/fix-issue-2684-hwpctl-trycatch`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2686
 - **Closes**: #2684

--- a/mydocs/report/pr-recovery-deadcode.md
+++ b/mydocs/report/pr-recovery-deadcode.md
@@ -1,0 +1,51 @@
+# PR #????: recoveryFileName 데드코드 제거
+
+## 이슈
+- **Issue**: #2687 — recoveryFileName 데드코드 제거
+
+## 분석
+
+`rhwp-studio/src/recovery/recovery-format.ts`의 `recoveryFileName()`에 불필요한 조건 분기가 존재한다.
+
+### 문제
+
+```typescript
+export function recoveryFileName(fileName: string, sourceFormat = 'hwp'): string {
+  const base = baseNameWithoutKnownExtension(fileName);
+  if (sourceFormat.toLowerCase() === 'hwpx') return `${base} 복구본.hwp`;
+  return `${base} 복구본.hwp`;  // hwpx 분기와 동일
+}
+```
+
+두 분기가 완전히 동일한 값을 반환한다 (`복구본.hwp`). 주석에서도 "autosave draft는 exportHwp() 결과"라고 명시하고 있어, sourceFormat과 무관하게 항상 .hwp 확장자를 사용하는 것이 의도된 동작이다.
+
+### 영향
+
+- 호출처에서 `sourceFormat`을 넘기지만 실제로 사용되지 않음
+- 불필요한 조건문으로 인한 코드 복잡도 증가
+
+## 변경
+
+1. `sourceFormat` 파라미터 제거
+2. 단일 `return`으로 통일
+3. 호출처(`main.ts:restoreAutosaveDraft`)에서 두 번째 인자 제거
+4. 테스트(`recovery-ui.test.ts`)에서 불필요한 두 번째 인자 제거
+
+```typescript
+// after
+export function recoveryFileName(fileName: string): string {
+  const base = baseNameWithoutKnownExtension(fileName);
+  return `${base} 복구본.hwp`;
+}
+```
+
+## 검증
+
+- `node --test tests/recovery-ui.test.ts` — 전과 동일하게 5/5 통과
+- `recoveryFileName` 시그니처 변경에 따른 타입 오류 없음 (기존 호출처 모두 수정 완료)
+- 함수 동작이 변경되지 않으므로 회귀 없음
+
+## 결과
+- **Branch**: `pr/fix-issue-2687-recovery-deadcode`
+- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **Closes**: #2687

--- a/mydocs/report/pr-recovery-deadcode.md
+++ b/mydocs/report/pr-recovery-deadcode.md
@@ -47,5 +47,5 @@ export function recoveryFileName(fileName: string): string {
 
 ## 결과
 - **Branch**: `pr/fix-issue-2687-recovery-deadcode`
-- **PR**: https://github.com/edwardkim/rhwp/pull/???? (생성 후 업데이트)
+- **PR**: https://github.com/edwardkim/rhwp/pull/2688
 - **Closes**: #2687

--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -193,6 +193,31 @@ if (!verify.recovered || verify.pageCountBefore !== verify.pageCountAfter) {
 }
 ```
 
+### editor.exportHml()
+
+현재 편집 중인 문서를 HML(XML) 바이너리로 내보냅니다.
+
+```javascript
+const bytes = await editor.exportHml();
+const blob = new Blob([bytes], { type: 'application/xml' });
+
+const url = URL.createObjectURL(blob);
+const a = document.createElement('a');
+a.href = url;
+a.download = 'document.hml';
+a.click();
+URL.revokeObjectURL(url);
+```
+
+### editor.getHmlSaveState()
+
+현재 문서의 HML 저장 가능 여부와 blocker를 반환합니다.
+
+```javascript
+const state = await editor.getHmlSaveState();
+// { ok: true } 또는 { ok: false, blocker: '...' }
+```
+
 ### editor.destroy()
 
 에디터를 제거합니다.

--- a/rhwp-chrome/dev-tools-inject.js
+++ b/rhwp-chrome/dev-tools-inject.js
@@ -15,7 +15,7 @@
       for (const a of links) {
         const href = a.href || '';
         const isMarked = a.getAttribute('data-hwp') === 'true';
-        const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+        const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
         if (!isMarked && !isExt) continue;
 

--- a/rhwp-firefox/dev-tools-inject.js
+++ b/rhwp-firefox/dev-tools-inject.js
@@ -16,7 +16,7 @@
       for (const a of links) {
         const href = a.href || '';
         const isMarked = a.getAttribute('data-hwp') === 'true';
-        const isExt = /\.(hwp|hwpx)(\?.*)?$/i.test(href);
+        const isExt = /\.(hwp|hwpx|hml)(\?.*)?$/i.test(href);
 
         if (!isMarked && !isExt) continue;
 

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -20,6 +20,8 @@ import './actions/page';
 export { ParameterSet } from './parameter-set';
 export { Action } from './action';
 
+export type SaveCallback = () => void;
+
 export class HwpCtrl {
   /** rhwp WASM 문서 객체 */
   private wasmDoc: any;
@@ -29,9 +31,12 @@ export class HwpCtrl {
   private cursorPos = 0;
   /** 이벤트 리스너 */
   private listeners: Map<number, Function[]> = new Map();
+  /** 저장 성공 시 dirty 상태 정리 등 후처리 콜백 */
+  private onSave: SaveCallback | undefined;
 
-  constructor(wasmDoc: any) {
+  constructor(wasmDoc: any, onSave?: SaveCallback) {
     this.wasmDoc = wasmDoc;
+    this.onSave = onSave;
   }
 
   /** 내부: WASM 문서 객체 접근 */
@@ -109,6 +114,7 @@ export class HwpCtrl {
       a.download = filename;
       a.click();
       URL.revokeObjectURL(url);
+      this.onSave?.();
       return true;
     } catch (e) {
       console.error('[hwpctl] SaveAs 실패:', e);
@@ -387,6 +393,7 @@ export class HwpCtrl {
 export async function createHwpCtrl(options: {
   wasmUrl?: string;
   wasmModule?: any;
+  onSave?: SaveCallback;
 }): Promise<HwpCtrl> {
   let wasmDoc: any;
 
@@ -400,5 +407,5 @@ export async function createHwpCtrl(options: {
     wasmDoc = HwpDocument.createEmpty();
   }
 
-  return new HwpCtrl(wasmDoc);
+  return new HwpCtrl(wasmDoc, options.onSave);
 }

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -67,10 +67,14 @@ export class HwpCtrl {
 
   /** 빈 문서 생성 */
   Clear(): void {
-    this.wasmDoc.createBlankDocument();
-    this.cursorSection = 0;
-    this.cursorPara = 0;
-    this.cursorPos = 0;
+    try {
+      this.wasmDoc.createBlankDocument();
+      this.cursorSection = 0;
+      this.cursorPara = 0;
+      this.cursorPos = 0;
+    } catch (e) {
+      console.error('[hwpctl] Clear 실패:', e);
+    }
   }
 
   /** 원본 파일 형식에 맞게 HWP, HWPX 또는 HML로 내보내기 */
@@ -188,7 +192,12 @@ export class HwpCtrl {
 
   /** 페이지 수 */
   PageCount(): number {
-    return this.wasmDoc.pageCount();
+    try {
+      return this.wasmDoc.pageCount();
+    } catch (e) {
+      console.error('[hwpctl] PageCount 실패:', e);
+      return 0;
+    }
   }
 
   // ── 표 셀 텍스트 API ──

--- a/rhwp-studio/src/hwpctl/index.ts
+++ b/rhwp-studio/src/hwpctl/index.ts
@@ -56,6 +56,9 @@ export class HwpCtrl {
     try {
       const bytes = data instanceof ArrayBuffer ? new Uint8Array(data) : data;
       this.wasmDoc = new (this.wasmDoc.constructor)(bytes);
+      this.cursorSection = 0;
+      this.cursorPara = 0;
+      this.cursorPos = 0;
       callback?.(true);
       return true;
     } catch (e) {

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -1082,7 +1082,7 @@ async function offerAutosaveRecoveryIfIdle(): Promise<void> {
 }
 
 async function restoreAutosaveDraft(draft: AutosaveDraft): Promise<void> {
-  const fileName = recoveryFileName(draft.fileName, draft.sourceFormat);
+  const fileName = recoveryFileName(draft.fileName);
   await loadBytes(new Uint8Array(draft.data), fileName, null, performance.now(), { skipRecent: true });
   await deleteAutosaveDraft(draft.id);
   documentState.markDirty('autosave-recovered');

--- a/rhwp-studio/src/recovery/recovery-format.ts
+++ b/rhwp-studio/src/recovery/recovery-format.ts
@@ -12,10 +12,9 @@ function baseNameWithoutKnownExtension(fileName: string): string {
   return trimmed;
 }
 
-export function recoveryFileName(fileName: string, sourceFormat = 'hwp'): string {
+export function recoveryFileName(fileName: string): string {
   const base = baseNameWithoutKnownExtension(fileName);
-  // autosave draft는 exportHwp() 결과이므로 HWPX 출처도 복구본은 HWP로 연다.
-  if (sourceFormat.toLowerCase() === 'hwpx') return `${base} 복구본.hwp`;
+  // autosave draft는 exportHwp() 결과이므로 모든 출처의 복구본은 HWP로 생성한다.
   return `${base} 복구본.hwp`;
 }
 

--- a/rhwp-studio/tests/recovery-ui.test.ts
+++ b/rhwp-studio/tests/recovery-ui.test.ts
@@ -11,7 +11,7 @@ import {
 test('recoveryFileName은 원본을 덮어쓰지 않는 복구본 이름을 만든다', () => {
   assert.equal(recoveryFileName('sample.hwp'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hwpx'), 'sample 복구본.hwp');
-  assert.equal(recoveryFileName('sample.hwpx', 'hwpx'), 'sample 복구본.hwp');
+  assert.equal(recoveryFileName('sample.hwpx'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('sample.hml'), 'sample 복구본.hwp');
   assert.equal(recoveryFileName('새 문서.hwp'), '새 문서 복구본.hwp');
   assert.equal(recoveryFileName('memo'), 'memo 복구본.hwp');


### PR DESCRIPTION
## 통합

kevin9327 님의 studio/hwpctl·확장·문서 계열 6건을 각 PR 전 커밋 순서대로 cherry-pick(-x) 통합.

- #2683: hwpctl SaveAs 성공 시 dirty 정리 onSave 콜백
- #2686: hwpctl PageCount·Clear WASM 호출 try-catch
- #2688: recovery `recoveryFileName` 데드코드 제거
- #2694: hwpctl Open() 커서 위치 초기화 — Clear() 와 일관성
- #2690: 확장 dev-tools-inject HML 링크 감지 정규식에 .hml
- #2692: npm/editor README 에 exportHml·getHmlSaveState API 문서

## 검증

- studio: `npx tsc --noEmit` clean, `npm test` 466/466
- 확장 JS: chrome/firefox dev-tools-inject `node --check` 통과
- 마크다운 링크 검사 green
- 충돌 0

## 운영

head CI 성공 + merge 승인 후 원 PR·연결 이슈 크레딧·close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
