### PR TITLE
fix(hwp5): 최상위 ShapeObject::Picture HWP5 직렬화 무출력 버그 수정

### DIFF
--- a/mydocs/report/pr-hwp5-picture-serialize.md
+++ b/mydocs/report/pr-hwp5-picture-serialize.md
@@ -1,0 +1,31 @@
+# PR #????: 최상위 ShapeObject::Picture HWP5 직렬화 무출력 버그 수정
+
+## 이슈
+- **Issue**: #2696 — 최상위 ShapeObject::Picture 무출력으로 그림 유실 + char_count 어긋남
+
+## 분석
+
+`src/serializer/control.rs`의 `serialize_shape_control` 함수에서 `ShapeObject::Picture` arm이 레코드를 하나도 방출하지 않는다. 주석에는 "그룹 내 그림: 그룹 직렬화 시 자식으로 처리됨 (단독 Picture는 Control::Picture로 직렬화)"라고 되어 있으나, `ungroup_shape_native`(그룹 해제)가 `Control::Shape(ShapeObject::Picture(..))`를 최상위 컨트롤로 생성하므로 이 전제는 거짓이다.
+
+### 영향
+
+그룹 해제 후 저장 시:
+- Picture의 CTRL_HEADER가 방출되지 않아 그림 소실
+- `char_count += 8`로 확보된 확장 컨트롤 문자와 CTRL_HEADER 개수가 불일치하여 이후 컨트롤 위치가 어긋남 (문서 손상)
+
+## 변경
+
+`serialize_picture_control` 함수(그림 전용 직렬화, 이미 검증됨)에 위임:
+
+```rust
+// before
+ShapeObject::Picture(_pic) => {}
+// after
+ShapeObject::Picture(pic) => {
+    serialize_picture_control(pic, level, ctrl_data_record, records);
+}
+```
+
+## 검증
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과

--- a/mydocs/report/pr-hwp5-picture-serialize.md
+++ b/mydocs/report/pr-hwp5-picture-serialize.md
@@ -1,4 +1,4 @@
-# PR #????: 최상위 ShapeObject::Picture HWP5 직렬화 무출력 버그 수정
+# PR #2713: 최상위 ShapeObject::Picture HWP5 직렬화 무출력 버그 수정
 
 ## 이슈
 - **Issue**: #2696 — 최상위 ShapeObject::Picture 무출력으로 그림 유실 + char_count 어긋남

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1423,8 +1423,8 @@ fn serialize_shape_control(
                 serialize_group_child(child, child_comp_level, child_type_level, records);
             }
         }
-        ShapeObject::Picture(_pic) => {
-            // 그룹 내 그림: 그룹 직렬화 시 자식으로 처리됨 (단독 Picture는 Control::Picture로 직렬화)
+        ShapeObject::Picture(pic) => {
+            serialize_picture_control(pic, level, ctrl_data_record, records);
         }
         ShapeObject::Chart(chart) => {
             // Task #195 단계 2: raw_chart_data를 그대로 보존하여 라운드트립 유지


### PR DESCRIPTION
## 개요

HWP5 직렬화기에서 `ShapeObject::Picture` arm이 레코드를 전혀 방출하지 않아 그룹 해제 후 저장 시 그림이 소실되고 char_count 불일치로 문서가 손상되는 버그를 수정합니다.

## 관련 이슈

- **Closes**: #2696

## 문제

`src/serializer/control.rs`의 `serialize_shape_control`에서 `ShapeObject::Picture` arm이 비어 있습니다. 주석은 "단독 Picture는 Control::Picture로 직렬화"라고 가정하지만, `ungroup_shape_native`(그룹 해제)가 `Control::Shape(ShapeObject::Picture(..))`를 최상위 컨트롤로 생성하므로 이 가정은 거짓입니다.

결과:
1. Picture의 CTRL_HEADER가 방출되지 않아 **그림 소실**
2. `char_count += 8`로 확보된 확장 컨트롤 문자와 CTRL_HEADER 개수가 불일치하여 **후속 컨트롤 위치 어긋남 (문서 손상)**

## 수정

```rust
// before
ShapeObject::Picture(_pic) => {}
// after
ShapeObject::Picture(pic) => {
    serialize_picture_control(pic, level, ctrl_data_record, records);
}
```

이미 검증된 `serialize_picture_control`(`Control::Picture`용 직렬화 함수)에 위임합니다.

## 검증

| 검사 | 결과 |
|------|------|
| cargo fmt | ✅ 통과 |
| cargo clippy -D warnings | ✅ 통과 |
| cargo test --profile release-test --tests | ✅ 통과 |

## 추가 정보

- 1개 파일, 2줄 변경
- 새 직렬화 로직 없음 — 기존 검증된 함수 재사용
- 처리 결과 문서: `mydocs/report/pr-hwp5-picture-serialize.md`