### PR TITLE
fix(hwpx): 표 hp:tbl 속성 3종 하드코딩 제거 — widthRelTo/heightRelTo/protect/numberingType

### DIFF
--- a/mydocs/report/pr-hwpx-table-attrs.md
+++ b/mydocs/report/pr-hwpx-table-attrs.md
@@ -1,4 +1,4 @@
-# PR #????: hwpx 표 hp:tbl 속성 3종 하드코딩 제거 — widthRelTo/heightRelTo/protect/numberingType
+# PR #2718: hwpx 표 hp:tbl 속성 3종 하드코딩 제거 — widthRelTo/heightRelTo/protect/numberingType
 
 ## 이슈
 - **Issue**: #2697 — 표 `<hp:tbl>` 속성 3종이 하드코딩으로 라운드트립 유실

--- a/mydocs/report/pr-hwpx-table-attrs.md
+++ b/mydocs/report/pr-hwpx-table-attrs.md
@@ -1,0 +1,30 @@
+# PR #????: hwpx 표 hp:tbl 속성 3종 하드코딩 제거 — widthRelTo/heightRelTo/protect/numberingType
+
+## 이슈
+- **Issue**: #2697 — 표 `<hp:tbl>` 속성 3종이 하드코딩으로 라운드트립 유실
+
+## 분석
+
+표 HWPX 직렬화기에서 4개 속성이 IR 대신 리터럴로 방출되어 라운드트립 소실 발생:
+
+| 속성 | 문제 | 수정 |
+|------|------|------|
+| `hp:sz@widthRelTo` | `"ABSOLUTE"` 하드코딩 | `size_criterion_width_str()`로 IR 방출 |
+| `hp:sz@heightRelTo` | `"ABSOLUTE"` 하드코딩 | `size_criterion_height_str()`로 IR 방출 (Column/Para→Absolute) |
+| `hp:sz@protect` | `"0"` 하드코딩 + 파서 arm 부재 | `bool01(size_protect)` + 파서 추가 |
+| `hp:tbl@numberingType` | `"TABLE"` 하드코딩 + 파서 arm 부재 | `numbering_type_str()` + 파서 추가 |
+
+## 변경
+
+### 파서 (`src/parser/hwpx/section.rs`)
+- `numberingType` 속성 파싱 추가
+- `hp:sz protect` 속성 파싱 추가
+- `materialize_hwpx_table_attrs` numbering bit 조건부 설정으로 수정
+
+### 직렬화 (`src/serializer/hwpx/table.rs`)
+- `size_criterion_width_str`/`height_str` 헬퍼 추가
+- `write_sz`에서 IR 값 방출
+- `numbering_type` IR 값 방출
+
+## 검증
+- `cargo test --lib -- hwpx::table` — 43/43 통과

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1643,6 +1643,14 @@ fn parse_table(
                     _ => crate::model::shape::TextFlow::BothSides,
                 };
             }
+            b"numberingType" => {
+                table.common.numbering_type = match attr_str(&attr).as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
             _ => {}
         }
     }
@@ -1693,6 +1701,9 @@ fn parse_table(
                                 b"heightRelTo" => {
                                     table.common.height_criterion =
                                         parse_size_criterion(&attr_str(&attr), false);
+                                }
+                                b"protect" => {
+                                    table.common.size_protect = attr_str(&attr) == "1";
                                 }
                                 _ => {}
                             }
@@ -1854,7 +1865,15 @@ fn parse_size_criterion(value: &str, allow_column_para: bool) -> SizeCriterion {
 fn materialize_hwpx_table_attrs(table: &mut Table, table_record_flags: u32) {
     const HWPX_TABLE_NUMBERING_BIT: u32 = 0x0800_0000;
 
-    table.common.attr = pack_hwpx_common_obj_attr(&table.common) | HWPX_TABLE_NUMBERING_BIT;
+    // numberingType이 Table일 때만 번호 비트를 설정한다 (#2697).
+    // 이전에는 무조건 OR하여 numbering_type과 attr 내부의 비트가 불일치했다.
+    let numbering_bit =
+        if table.common.numbering_type == crate::model::shape::ObjectNumberingType::Table {
+            HWPX_TABLE_NUMBERING_BIT
+        } else {
+            0
+        };
+    table.common.attr = pack_hwpx_common_obj_attr(&table.common) | numbering_bit;
     // HWPX keeps semantic placement in hp:pos, while legacy layout code still reads
     // table.attr bit0 for some inline-table decisions. Only mirror the minimum
     // renderer compatibility bit here; the HWP5 storage attr is packed later by

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -29,7 +29,8 @@ use std::io::Write;
 use quick_xml::Writer;
 
 use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, TextFlow, TextWrap, VertAlign, VertRelTo,
+    CommonObjAttr, HorzAlign, HorzRelTo, ObjectNumberingType, SizeCriterion, TextFlow, TextWrap,
+    VertAlign, VertRelTo,
 };
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
 
@@ -66,6 +67,7 @@ pub fn write_table<W: Write>(
     let cell_spacing = table.cell_spacing.to_string();
     let border_fill_id_ref = table.border_fill_id.to_string();
     let no_adjust = bool01((table.attr | table.raw_table_record_attr) & 0x08 != 0);
+    let numbering_type = numbering_type_str(table.common.numbering_type);
 
     start_tag_attrs(
         w,
@@ -73,7 +75,7 @@ pub fn write_table<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "TABLE"),
+            ("numberingType", numbering_type),
             ("textWrap", text_wrap),
             ("textFlow", text_flow),
             ("lock", lock),
@@ -118,15 +120,21 @@ pub fn write_table<W: Write>(
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
     let width = c.width.to_string();
     let height = c.height.to_string();
+    let width_rel_to = size_criterion_width_str(c.width_criterion);
+    // heightRelTo는 파서가 Column/Para를 Absolute로 접으므로(parse_size_criterion
+    // with allow_column_para=false), 방출측도 Paper/Page/Absolute 3값만 내야
+    // 정확한 역함수가 된다. Column/Para IR(HWP5 경로 유입)은 Absolute로 접는다.
+    let height_rel_to = size_criterion_height_str(c.height_criterion);
+    let protect = bool01(c.size_protect);
     empty_tag(
         w,
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", width_rel_to),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", height_rel_to),
+            ("protect", protect),
         ],
     )
 }
@@ -420,6 +428,35 @@ fn write_cell_margin<W: Write>(w: &mut Writer<W>, cell: &Cell) -> Result<(), Ser
 }
 
 // ---------- enum 변환 헬퍼 ----------
+
+fn size_criterion_width_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// heightRelTo 전용: 파서가 Column/Para를 Absolute로 접으므로
+/// 방출측도 이 둘은 Absolute로 내야 정확한 역함수가 성립한다.
+fn size_criterion_height_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        _ => "ABSOLUTE",
+    }
+}
+
+fn numbering_type_str(n: ObjectNumberingType) -> &'static str {
+    match n {
+        ObjectNumberingType::Picture => "PICTURE",
+        ObjectNumberingType::Table => "TABLE",
+        ObjectNumberingType::Equation => "EQUATION",
+        ObjectNumberingType::None => "NONE",
+    }
+}
 
 fn bool01(b: bool) -> &'static str {
     if b {


### PR DESCRIPTION
## 개요

HWPX 표 직렬화기에서 4개 속성이 IR 대신 리터럴로 방출되어 라운드트립이 소실되는 문제를 수정합니다.

## 관련 이슈

- **Closes**: #2697

## 수정 내용

### 파서 (`src/parser/hwpx/section.rs`)
- `hp:tbl` 루트 속성에 `numberingType` 파싱 추가
- `hp:sz`에 `protect` 파싱 추가 (형제 파서 3곳과 일관성)
- `materialize_hwpx_table_attrs`의 무조건 numbering 비트 OR을 `numbering_type == Table`일 때로 조건부 변경

### 직렬화 (`src/serializer/hwpx/table.rs`)
- `size_criterion_width_str`/`size_criterion_height_str` 헬퍼 추가
- `write_sz`: `widthRelTo`/`heightRelTo`/`protect`를 IR 값에서 방출
- `numberingType`: `numbering_type_str()`으로 IR 값에서 방출

## 검증

| 검사 | 결과 |
|------|------|
| hwpx::table 테스트 | ✅ 43/43 통과 |
| cargo fmt | ✅ 통과 |
| cargo clippy -D warnings | ✅ 통과 |
| cargo test --profile release-test --tests | ✅ 전체 통과 |