### PR TITLE
fix(hwpx): 도형·그림 hp:sz widthRelTo/heightRelTo/protect 하드코딩 제거

### DIFF
--- a/mydocs/report/pr-hwpx-shape-sz-attrs.md
+++ b/mydocs/report/pr-hwpx-shape-sz-attrs.md
@@ -1,0 +1,6 @@
+# PR #????: 도형·그림 hp:sz widthRelTo/heightRelTo/protect 하드코딩 제거 (#2712)
+
+이슈 #2697 잔여 — 도형(shape.rs)과 그림(picture.rs)의 write_sz가 widthRelTo/heightRelTo/protect를 리터럴("ABSOLUTE"/"0")로 방출하던 것을 IR 값에서 유도하도록 수정. size_criterion_width_str/height_str 헬퍼를 shape.rs에 pub(crate)로 추가하고 picture.rs에서 재사용.
+
+## 검증
+- hwpx 테스트 471/471 통과

--- a/mydocs/report/pr-hwpx-shape-sz-attrs.md
+++ b/mydocs/report/pr-hwpx-shape-sz-attrs.md
@@ -1,4 +1,4 @@
-# PR #????: 도형·그림 hp:sz widthRelTo/heightRelTo/protect 하드코딩 제거 (#2712)
+# PR #2721: 도형·그림 hp:sz widthRelTo/heightRelTo/protect 하드코딩 제거 (#2712)
 
 이슈 #2697 잔여 — 도형(shape.rs)과 그림(picture.rs)의 write_sz가 widthRelTo/heightRelTo/protect를 리터럴("ABSOLUTE"/"0")로 방출하던 것을 IR 값에서 유도하도록 수정. size_criterion_width_str/height_str 헬퍼를 shape.rs에 pub(crate)로 추가하고 picture.rs에서 재사용.
 

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -36,6 +36,7 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
+use super::shape::{size_criterion_height_str, size_criterion_width_str};
 use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
@@ -387,10 +388,10 @@ fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Serial
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_width_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", size_criterion_height_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
 }

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -20,8 +20,8 @@ use quick_xml::Writer;
 
 use crate::model::shape::{
     CommonObjAttr, DrawingObjAttr, HorzAlign, HorzRelTo, LineShape, ObjectNumberingType,
-    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, TextBox, TextFlow, TextWrap,
-    VertAlign, VertRelTo,
+    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, SizeCriterion, TextBox,
+    TextFlow, TextWrap, VertAlign, VertRelTo,
 };
 use crate::model::style::{Fill, FillType, ImageFillMode, ShapeBorderLine, SolidFill};
 use crate::model::ColorRef;
@@ -983,10 +983,10 @@ fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Serial
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_width_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", size_criterion_height_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
 }
@@ -1041,6 +1041,26 @@ pub(crate) fn color_to_hex(c: ColorRef) -> String {
         format!("#{:02X}{:02X}{:02X}", r, g, b)
     } else {
         format!("#{:02X}{:02X}{:02X}{:02X}", a, r, g, b)
+    }
+}
+
+pub(crate) fn size_criterion_width_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// heightRelTo 전용: 파서가 Column/Para를 Absolute로 접으므로
+/// 방출측도 이 둘은 Absolute로 내야 정확한 역함수가 성립한다.
+pub(crate) fn size_criterion_height_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        _ => "ABSOLUTE",
     }
 }
 


### PR DESCRIPTION
## 개요

#2697 잔여 — 도형·그림의 hp:sz 속성 3종(widthRelTo/heightRelTo/protect)이 IR 값 대신 리터럴로 방출되는 문제 수정.

## 수정 내용

- `shape.rs::write_sz`: `"ABSOLUTE"`/`"0"` → `size_criterion_width_str`/`size_criterion_height_str`/`bool01(c.size_protect)`
- `picture.rs::write_sz`: 동일
- `shape.rs`에 `size_criterion_width_str`/`size_criterion_height_str` 헬퍼 추가 (picture.rs에서 재사용)

## 검증
- hwpx 테스트 471/471 통과