### PR TITLE
fix(hwp5): 그리기 도형·묶음·차트 캡션이 저장 시 전량 소실 — serialize_shape_control 전 arm이 LIST_HEADER 미방출 (#2715)

### DIFF
--- a/mydocs/report/task_m100_2715_report.md
+++ b/mydocs/report/task_m100_2715_report.md
@@ -1,0 +1,195 @@
+# Task #2715 최종 보고서 — 그리기 도형·묶음·차트 캡션 HWP5 직렬화 누락
+
+- 이슈: [#2715](https://github.com/edwardkim/rhwp/issues/2715) / 브랜치: `task/m100-2715-hwp5-drawing-caption` (base `origin/devel` `49f38446`)
+- 관련: #1403(HWPX 캡션 방출), #1387(표 캡션 공유), #1283·#2696(OLE base-only 계약 — 본 작업 범위 밖)
+- 변경 파일: `src/serializer/control.rs`, `src/serializer/control/tests.rs`
+
+## 결론 요약
+
+`serialize_shape_control` 의 **10개 arm 중 캡션(`LIST_HEADER`)을 방출하는 arm 이 하나도 없어**
+그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다. 파서는 전 변종의 캡션을 적재하고
+(`parser/control/shape.rs:205/213/222/230/240`), 같은 파일에서 표(`:492`)·그림(`:998`)은
+`serialize_caption` 을 호출하는데 도형 계열만 비어 있었다.
+
+한컴 저장본 실측에서 `$rec`(사각형)·`$con`(묶음)이 `$pic`(그림)과 **동일한 30B `LIST_HEADER`** 를
+`SHAPE_COMPONENT` 앞에 갖는 것을 확인했으므로 포맷 제약이 아니라 미구현이다. 8개 arm에 방출을
+추가했다.
+
+| 코퍼스 | 도형 캡션 | 표 캡션 | 그림 캡션 |
+|---|---:|---:|---:|
+| `samples/*.hwp` 21개 파일 (수정 전) | **38 → 0** | 597 → 597 | 13 → 13 |
+| `samples/*.hwp` 21개 파일 (수정 후) | **38 → 38** | 597 → 597 | 13 → 13 |
+| `samples/hwpx/aift.hwpx` → HWP5 (수정 전) | **2 → 0** | 2 → 2 | 9 → 9 |
+| `samples/hwpx/aift.hwpx` → HWP5 (수정 후) | **2 → 2** | 2 → 2 | 9 → 9 |
+
+## 1. 문제
+
+파서의 캡션 인식 규칙은 "`SHAPE_COMPONENT` **앞**의 `LIST_HEADER`"다
+(`src/parser/control/shape.rs:134-147`). `SHAPE_COMPONENT` **뒤**의 `LIST_HEADER` 는 글상자로
+별도 처리되므로(`:149-167`) 두 경로는 레코드 위치로 구분된다.
+
+직렬화 쪽 `grep -n "serialize_caption" src/serializer/control.rs` 전수 결과는 3줄뿐이었다 —
+정의(`:666`)와 표(`:492`)·그림(`:998`) 호출 2건. `serialize_shape_control` 안에는 0건.
+
+| arm | 캡션 방출(수정 전) | IR 필드 |
+|---|---|---|
+| `Line` / `Rectangle` / `Ellipse` / `Polygon` / `Arc` / `Curve` | 없음 | `drawing.caption` |
+| `Group` | 없음 | `group.caption` |
+| `Chart` | 없음 | `chart.caption` |
+| `Ole` | 없음 | `ole.caption` (본 작업 범위 밖 — §5) |
+| `Picture(_)` | 해당 없음 | `serialize_picture_control` 위임 |
+
+## 2. 분석
+
+### 2.1 의도적 누락이 아님을 확인
+
+- `git log -S "serialize_caption" -- src/serializer/control.rs` → **`f0f7f1a4`(Initial commit) 1건뿐.**
+  도형 arm 에서 캡션 방출을 제거한 커밋이 없다. "호환성 때문에 뺀" 이력이 아니라 처음부터
+  표·그림에만 구현된 미구현 구간이다. `-S "pic.caption"` / `-S "table.caption"` 도 동일.
+- #1403 계열 커밋(`3baf8724`, `897066c8`, `2a176d09`)은 전부 HWPX 경로만 수정했다.
+  메인테이너 검토 문서 `mydocs/pr/archives/pr_1406_review.md` §3.2 가 오히려
+  **"HWP5 파서는 전 도형 캡션 적재 중"** 을 명시한다 — 적재는 되는데 HWP5 방출만 비어 있는
+  현 상태와 일치.
+- `mydocs/` 전체에서 "HWP5 도형 캡션 미방출" 계약 문서를 찾지 못했다.
+
+### 2.2 한컴 실물 레코드 배치 (결정적 근거)
+
+`samples/3-09월_교육_통합_2023.hwp` (한컴 저장, 캡션 `<보기>`):
+
+```
+tag=71  CTRL_HEADER      lv=1 sz=46  ctrl_id="gso "
+  tag=72  LIST_HEADER      lv=2 sz=30      ← 캡션
+  tag=66  PARA_HEADER      lv=2 sz=24
+    tag=67  PARA_TEXT        lv=3 sz=10
+    tag=68  PARA_CHAR_SHAPE  lv=3 sz=8
+    tag=69  PARA_LINE_SEG    lv=3 sz=36
+  tag=76  SHAPE_COMPONENT  lv=2 sz=239 comp_id="$rec"
+```
+
+`samples/draw-group.hwp` 는 동일 배치로 `comp_id="$con"`(sz=270), `samples/aift.hwp` 는
+`comp_id="$pic"`(sz=196). **세 경우 모두 캡션 `LIST_HEADER` 가 30B 로 동일**하며, 이는 기존
+`serialize_caption`(`control.rs:666-706`)이 방출하는 크기와 정확히 같다
+(`n_para(2)+list_attr(4)+width_ref(2)+attr(4)+width(4)+spacing(2)+max_width(4)+예약(8)=30`).
+해당 함수 주석도 `// 예약 필드 8바이트 (한컴 호환성: 원본 파일은 30바이트 LIST_HEADER)` 로
+이미 이 계약을 명시하고 있었다 — **방출 함수는 준비돼 있고 호출만 없었다.**
+
+### 2.3 `raw_stream` 지름길이 결함을 가리고 있었음
+
+`serialize_section`(`src/serializer/body_text.rs:26-30`)은 원본 섹션 바이트를 그대로 반환한다:
+
+```rust
+if let Some(ref raw) = section.raw_stream {
+    return raw.clone();
+}
+```
+
+따라서 **파싱 직후 무편집 저장은 직렬화기를 타지 않아 손실이 관측되지 않는다.** 최초 계측에서
+`38 → 38` 이 나와 결함이 없어 보였으나, 이는 직렬화기를 우회한 결과였다. 실사용 경로는
+`src/document_core/commands/` 의 편집 명령들이 예외 없이 `raw_stream = None` 을 설정하므로
+(`formatting.rs` 16곳, `header_footer_ops.rs` 9곳, `footnote_ops.rs` 6곳, `clipboard.rs` 4곳 등)
+**문서를 한 글자라도 편집하면 그 섹션의 도형 캡션이 전부 사라진다.** HWPX 입력은 `raw_stream`
+자체가 없어 무조건 손실된다.
+
+§ 결론 요약 표의 수치는 `raw_stream` 을 무효화한 상태(=실사용 경로)의 계측이다.
+
+## 3. 변경
+
+`src/serializer/control.rs`:
+
+1. `serialize_shape_control` 에 `emit_caption` 클로저 신설(`emit_ctrl_data` 옆). 방출 위치·OLE
+   제외 사유·호출 순서 제약을 주석으로 고정.
+2. 8개 arm(`Line`/`Rectangle`/`Ellipse`/`Polygon`/`Arc`/`Curve`/`Group`/`Chart`)에서
+   `emit_caption(...)` 호출. 캡션 필드 해석은 `serializer/hwpx/roundtrip.rs:1322-1335`
+   `shape_caption()` 과 동일 매핑(그리기 6종 → `drawing.caption`, Group/Chart → 각자 필드).
+
+**호출 순서 제약**: `emit_top_level_synthesized_ctrl_data` **뒤**, `SHAPE_COMPONENT` push **앞**.
+`parse_caption`(`parser/control.rs:417-462`)은 `records[0]` 을 LIST_HEADER 로, `records[1..]` 전체를
+캡션 문단으로 넘기므로, 캡션과 `SHAPE_COMPONENT` 사이에 `CTRL_DATA` 가 끼면 문단 파싱이 오염된다.
+
+`src/serializer/control/tests.rs`: 회귀 테스트 4건 + 픽스처 헬퍼 2개 추가.
+
+## 4. 검증
+
+### 4.1 red→green (실제 실행 캡처)
+
+`git stash push -- src/serializer/control.rs` 로 수정만 되돌린 상태 (**RED**):
+
+```
+running 4 tests
+test serializer::control::tests::issue2715_shape_without_caption_emits_no_list_header ... ok
+test serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows ... FAILED
+test serializer::control::tests::issue2715_rectangle_caption_roundtrips ... FAILED
+test serializer::control::tests::issue2715_group_caption_roundtrips ... FAILED
+
+---- serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows stdout ----
+thread '...' (14364) panicked at src\serializer\control\tests.rs:897:5:
+캡션 LIST_HEADER 는 SHAPE_COMPONENT 앞이어야 함 (caption=2, comp=1)
+
+---- serializer::control::tests::issue2715_rectangle_caption_roundtrips stdout ----
+thread '...' (9824) panicked at src\serializer\control\tests.rs:819:10:
+[#2715] 사각형 캡션이 왕복 보존돼야 함
+
+---- serializer::control::tests::issue2715_group_caption_roundtrips stdout ----
+thread '...' (35892) panicked at src\serializer\control\tests.rs:848:14:
+[#2715] 묶음 캡션이 왕복 보존돼야 함
+
+test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+RED 의 `caption=2, comp=1` 은 발견된 유일한 `LIST_HEADER` 가 `SHAPE_COMPONENT`(idx 1) **뒤**의
+글상자용(idx 2)이었음을 뜻한다 — 캡션이 아예 방출되지 않았다는 직접 증거다.
+
+`git stash pop` 후 (**GREEN**):
+
+```
+running 4 tests
+test serializer::control::tests::issue2715_shape_without_caption_emits_no_list_header ... ok
+test serializer::control::tests::issue2715_group_caption_roundtrips ... ok
+test serializer::control::tests::issue2715_rectangle_caption_roundtrips ... ok
+test serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+### 4.2 CI 3종
+
+| 명령 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | **통과** (`Diff in` 0건 — CRLF 노이즈 `Incorrect newline style` 제외) |
+| `cargo clippy --all-targets -- -D warnings` | **통과** (경고 0, `Finished dev profile`) |
+| `cargo test --profile release-test --tests` | **3484 passed, 0 failed** (`test result: FAILED` 0건, panic 0건) |
+
+### 4.3 회귀 위험 테스트 개별 확인
+
+레코드 시퀀스에 `LIST_HEADER` 를 추가하므로 레코드 인덱스·크기를 고정한 테스트를 사전 조사 후
+개별 확인했다.
+
+| 테스트 | 위험 | 결과 |
+|---|---|---|
+| `issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage` (`shape_component.size == 196` 고정) | OLE 계약 | ok |
+| `issue2696_ole_shape_component_stays_base_only` | OLE 196B base-only | ok |
+| `task903_stage45_*` (`SHAPE_COMPONENT_INDICES = &[21,35,807,808,810,812]` 고정 인덱스) | 인덱스 이동 | ok — 기준 fixture `samples/hwpx/hwpx-h-01.hwpx` 는 도형 캡션 0건이라 이동 없음 |
+| `issue_1403_captions_roundtrip_aift` | HWPX 캡션 | ok |
+| `tests/issue_1251_ole_chart_contents.rs` 전 10건 | OLE 전반 | 전건 ok |
+
+### 4.4 실물 코퍼스 재계측
+
+`raw_stream` 무효화 상태에서 `samples/*.hwp` 270건 전수 재계측 — 도형 캡션 보유 21개 파일
+**38건 전량 보존**(수정 전 0건). 동일 실행에서 표 캡션 597건·그림 캡션 13건도 불변.
+`samples/hwpx/aift.hwpx` → HWP5 변환도 2 → 2 로 보존.
+
+## 5. 미실행·범위 밖
+
+- **OLE 캡션** — `Ole` arm 은 손대지 않았다. #1283/#2696 의 196B base-only 계약 영역이고,
+  캡션 보유 OLE 한컴 실물 샘플을 확보하지 못해 방출 위치를 실측 검증할 수 없다. 별도 이슈 권장.
+- **묶음 자식 도형의 캡션** — `serialize_group_child` 는 `CTRL_HEADER` 없이 `SHAPE_COMPONENT` 만
+  방출하는 경로다. 한컴이 묶음 **자식**에 캡션을 쓰는지 실물 확인하지 못했고, 현 파서도
+  `parse_container_children` 에서 자식 캡션을 적재하지 않으므로 범위 밖.
+- **캡션 내 `atno`(자동 번호) 의미 검증** — `draw-group.hwp` 캡션 문단에 `atno` 컨트롤이 있다.
+  캡션 문단은 `serialize_paragraph_list` 공용 경로를 타므로 레코드는 동승하나, 번호 재계산
+  의미까지는 검증하지 않았다.
+- **시각 검증(렌더 비교)** — 본 변경은 저장 레코드 계약 수정이고 렌더러 경로는 불변이라
+  `visual_baseline_all_samples` 통과로 갈음했다. 별도 SVG 대조는 수행하지 않았다.
+- **`raw_stream` 지름길 자체** — 무편집 저장이 직렬화기를 우회하는 설계는 의도된 것(완전
+  라운드트립)이라 건드리지 않았다. 다만 직렬화기 결함이 무편집 라운드트립 테스트에서 가려지는
+  구조적 사각이므로 별도 관찰 대상으로 남긴다.

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1178,6 +1178,28 @@ fn serialize_shape_control(
         }
     };
 
+    // [#2715] 캡션(SHAPE_COMPONENT 앞, level+1) 방출 헬퍼.
+    //
+    // 파서는 `SHAPE_COMPONENT` **앞**의 LIST_HEADER 를 캡션으로 읽는데
+    // (`parser/control/shape.rs:134-147`), 종전 도형 arm 은 어느 것도 방출하지
+    // 않아 그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다 (표 `:492`·
+    // 그림 `:998` 만 방출 중이었다). 한컴 저장본도 `$rec`(사각형)·`$con`(묶음)에
+    // `$pic`(그림)과 **동일한 30B LIST_HEADER** 를 SHAPE_COMPONENT 앞에 쓴다
+    // (`samples/3-09월_교육_통합_2023.hwp`, `samples/draw-group.hwp` 실측).
+    //
+    // 호출 위치는 반드시 `emit_top_level_synthesized_ctrl_data` **뒤**여야 한다 —
+    // `parse_caption` 은 `records[1..]` 전체를 캡션 문단으로 넘기므로, 캡션과
+    // SHAPE_COMPONENT 사이에 CTRL_DATA 가 끼면 문단 파싱이 오염된다.
+    //
+    // OLE arm 은 제외한다: `#1283` 의 196B base-only 계약 영역이고
+    // (`tests/issue_1251_ole_chart_contents.rs` 가 고정), 캡션 보유 OLE 한컴
+    // 실물 샘플을 확보하지 못해 방출 위치를 실측 검증할 수 없다.
+    let emit_caption = |caption: &Option<Caption>, records: &mut Vec<Record>| {
+        if let Some(caption) = caption {
+            serialize_caption(caption, level + 1, records);
+        }
+    };
+
     match shape {
         ShapeObject::Line(line) => {
             let is_connector = line.connector.is_some();
@@ -1192,6 +1214,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&line.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&line.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1237,6 +1260,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&rect.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&rect.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1266,6 +1290,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&ellipse.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&ellipse.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1308,6 +1333,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&poly.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&poly.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1345,6 +1371,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&arc.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&arc.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1375,6 +1402,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&curve.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&curve.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1408,6 +1436,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&group.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&group.caption, records);
             // 그룹 컨테이너: SHAPE_COMPONENT + 자식 수 + 자식 ctrl_id 목록 (한컴 호환)
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
@@ -1440,6 +1469,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&chart.common),
             ));
             let sc_ctrl_id = chart.drawing.shape_attr.ctrl_id;
+            emit_caption(&chart.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::model::document::{Section, SectionDef};
 use crate::model::page::PageDef;
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::shape::{GroupShape, RectangleShape};
 use crate::parser::body_text::parse_body_text_section;
 use crate::serializer::body_text::serialize_section;
 
@@ -729,5 +730,221 @@ fn issue2696_ole_shape_component_stays_base_only() {
         196,
         "[#2696] OLE SHAPE_COMPONENT 는 한컴 실측치와 같은 196B(base-only)여야 한다 \
          — 꼬리를 붙이면 #1283 의 한컴 호환 계약이 깨진다"
+    );
+}
+
+// ============================================================
+// [#2715] 그리기 도형·묶음·차트 캡션 HWP5 직렬화
+// ============================================================
+
+/// 캡션 1개짜리 테스트 픽스처.
+fn caption_fixture(text: &str) -> Caption {
+    Caption {
+        direction: CaptionDirection::Top,
+        vert_align: CaptionVertAlign::Center,
+        width: 4321,
+        spacing: 850,
+        max_width: 30000,
+        include_margin: true,
+        paragraphs: vec![Paragraph {
+            char_count: (text.chars().count() + 1) as u32,
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// 컨트롤 1개를 담은 섹션을 직렬화 → 재파싱한다.
+fn roundtrip_single_control(ctrl: Control) -> Control {
+    let section = Section {
+        paragraphs: vec![Paragraph {
+            char_count: 2,
+            text: String::new(),
+            char_offsets: vec![],
+            controls: vec![ctrl],
+            ..Default::default()
+        }],
+        raw_stream: None,
+        ..Default::default()
+    };
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+    parsed.paragraphs[0]
+        .controls
+        .first()
+        .expect("컨트롤이 왕복돼야 함")
+        .clone()
+}
+
+fn shape_of(ctrl: &Control) -> &ShapeObject {
+    match ctrl {
+        Control::Shape(s) => s.as_ref(),
+        other => panic!("도형 컨트롤이 나와야 함, got {other:?}"),
+    }
+}
+
+/// [#2715] 사각형 도형의 캡션이 HWP5 왕복에서 보존돼야 한다.
+///
+/// 종전에는 `serialize_shape_control` 의 어떤 arm 도 `serialize_caption` 을
+/// 호출하지 않아 `drawing.caption` 이 통째로 사라졌다 — 한컴 저장본
+/// `samples/3-09월_교육_통합_2023.hwp` 는 `$rec` 도형에 그림($pic)과 동일한
+/// 30B LIST_HEADER 캡션을 쓰므로 포맷 제약이 아니라 미구현이었다.
+#[test]
+fn issue2715_rectangle_caption_roundtrips() {
+    let rect = RectangleShape {
+        drawing: DrawingObjAttr {
+            caption: Some(caption_fixture("사각형 캡션")),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let out = roundtrip_single_control(Control::Shape(Box::new(ShapeObject::Rectangle(rect))));
+
+    let ShapeObject::Rectangle(r) = shape_of(&out) else {
+        panic!("사각형이 나와야 함, got {:?}", shape_of(&out));
+    };
+    let cap = r
+        .drawing
+        .caption
+        .as_ref()
+        .expect("[#2715] 사각형 캡션이 왕복 보존돼야 함");
+    assert_eq!(cap.paragraphs[0].text, "사각형 캡션", "캡션 텍스트 보존");
+    assert_eq!(cap.direction, CaptionDirection::Top, "캡션 방향 보존");
+    assert_eq!(
+        cap.vert_align,
+        CaptionVertAlign::Center,
+        "캡션 세로 정렬 보존"
+    );
+    assert_eq!(cap.width, 4321, "캡션 폭 보존");
+    assert_eq!(cap.spacing, 850, "캡션-틀 간격 보존");
+    assert_eq!(cap.max_width, 30000, "캡션 최대 폭 보존");
+    assert!(cap.include_margin, "include_margin 보존");
+}
+
+/// [#2715] 묶음(`$con`) 캡션 왕복 — 한컴 `samples/draw-group.hwp` 실측 대응.
+#[test]
+fn issue2715_group_caption_roundtrips() {
+    let group = GroupShape {
+        caption: Some(caption_fixture("묶음 캡션")),
+        ..Default::default()
+    };
+    let out = roundtrip_single_control(Control::Shape(Box::new(ShapeObject::Group(group))));
+
+    let ShapeObject::Group(g) = shape_of(&out) else {
+        panic!("묶음이 나와야 함, got {:?}", shape_of(&out));
+    };
+    assert_eq!(
+        g.caption
+            .as_ref()
+            .expect("[#2715] 묶음 캡션이 왕복 보존돼야 함")
+            .paragraphs[0]
+            .text,
+        "묶음 캡션"
+    );
+}
+
+/// [#2715] 캡션은 `SHAPE_COMPONENT` **앞**, 글상자 LIST_HEADER 는 **뒤**로
+/// 분리 방출돼야 한다 (파서가 위치로 둘을 구분하므로 순서가 곧 계약이다).
+/// LIST_HEADER 크기 30B 는 한컴 저장본 실측치와 같다.
+#[test]
+fn issue2715_caption_precedes_shape_component_and_textbox_follows() {
+    let rect = RectangleShape {
+        drawing: DrawingObjAttr {
+            caption: Some(caption_fixture("캡션")),
+            text_box: Some(crate::model::shape::TextBox {
+                paragraphs: vec![Paragraph {
+                    char_count: 4,
+                    text: "글상자".to_string(),
+                    char_offsets: vec![0, 1, 2],
+                    char_shapes: vec![CharShapeRef {
+                        start_pos: 0,
+                        char_shape_id: 0,
+                    }],
+                    line_segs: vec![LineSeg {
+                        text_start: 0,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ctrl = Control::Shape(Box::new(ShapeObject::Rectangle(rect)));
+
+    let mut records: Vec<Record> = Vec::new();
+    serialize_control(&ctrl, 1, None, &mut records);
+
+    let comp_idx = records
+        .iter()
+        .position(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT)
+        .expect("SHAPE_COMPONENT 가 있어야 함");
+    let caption_idx = records
+        .iter()
+        .position(|r| r.tag_id == tags::HWPTAG_LIST_HEADER)
+        .expect("[#2715] 캡션 LIST_HEADER 가 방출돼야 함");
+    assert!(
+        caption_idx < comp_idx,
+        "캡션 LIST_HEADER 는 SHAPE_COMPONENT 앞이어야 함 (caption={caption_idx}, comp={comp_idx})"
+    );
+    assert_eq!(
+        records[caption_idx].level, 2,
+        "캡션 LIST_HEADER 는 level+1 이어야 함"
+    );
+    assert_eq!(
+        records[caption_idx].data.len(),
+        30,
+        "캡션 LIST_HEADER 는 한컴 실측치와 같은 30B 여야 함"
+    );
+
+    let textbox_idx = records
+        .iter()
+        .enumerate()
+        .skip(comp_idx)
+        .find(|(_, r)| r.tag_id == tags::HWPTAG_LIST_HEADER)
+        .map(|(i, _)| i)
+        .expect("글상자 LIST_HEADER 가 방출돼야 함");
+    assert!(
+        textbox_idx > comp_idx,
+        "글상자 LIST_HEADER 는 SHAPE_COMPONENT 뒤여야 함"
+    );
+
+    // 재파싱 시 캡션과 글상자가 각각 제자리에 복원되는지
+    let out = roundtrip_single_control(ctrl);
+    let ShapeObject::Rectangle(r) = shape_of(&out) else {
+        panic!("사각형이 나와야 함");
+    };
+    assert_eq!(
+        r.drawing.caption.as_ref().expect("캡션 보존").paragraphs[0].text,
+        "캡션"
+    );
+    assert_eq!(
+        r.drawing.text_box.as_ref().expect("글상자 보존").paragraphs[0].text,
+        "글상자",
+        "캡션 추가가 글상자 경로를 침범하면 안 됨"
+    );
+}
+
+/// [#2715] 캡션이 없는 도형은 LIST_HEADER 를 방출하지 않아야 한다
+/// (불필요한 레코드 추가로 기존 레코드 시퀀스를 흔들지 않기 위함).
+#[test]
+fn issue2715_shape_without_caption_emits_no_list_header() {
+    let ctrl = Control::Shape(Box::new(ShapeObject::Rectangle(RectangleShape::default())));
+    let mut records: Vec<Record> = Vec::new();
+    serialize_control(&ctrl, 1, None, &mut records);
+    assert!(
+        !records.iter().any(|r| r.tag_id == tags::HWPTAG_LIST_HEADER),
+        "캡션 없는 도형은 LIST_HEADER 를 방출하면 안 됨"
     );
 }


### PR DESCRIPTION
closes #2715

## 요약

`serialize_shape_control`(`src/serializer/control.rs`)의 **10개 arm 중 캡션(`LIST_HEADER`)을 방출하는 arm 이 하나도 없어** 그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다. 파서는 전 변종의 캡션을 적재하고(`parser/control/shape.rs:205/213/222/230/240`), 같은 파일에서 표(`:492`)·그림(`:998`)은 `serialize_caption` 을 호출하는데 도형 계열만 비어 있었다.

한컴 저장본 실측에서 `$rec`(사각형)·`$con`(묶음)이 `$pic`(그림)과 **동일한 30B `LIST_HEADER`** 를 `SHAPE_COMPONENT` 앞에 갖는 것을 확인했으므로 포맷 제약이 아니라 미구현이다. 8개 arm에 방출을 추가했다.

| 코퍼스 | 도형 캡션 | 표 캡션 | 그림 캡션 |
|---|---:|---:|---:|
| `samples/*.hwp` 21개 파일 (수정 전) | **38 → 0** | 597 → 597 | 13 → 13 |
| `samples/*.hwp` 21개 파일 (수정 후) | **38 → 38** | 597 → 597 | 13 → 13 |
| `aift.hwpx` → HWP5 (수정 전) | **2 → 0** | 2 → 2 | 9 → 9 |
| `aift.hwpx` → HWP5 (수정 후) | **2 → 2** | 2 → 2 | 9 → 9 |

## 실물 근거

`samples/3-09월_교육_통합_2023.hwp` (한컴 저장, 캡션 `<보기>`):

```
tag=71  CTRL_HEADER      lv=1 sz=46  ctrl_id="gso "
  tag=72  LIST_HEADER      lv=2 sz=30      ← 캡션
  tag=66  PARA_HEADER      lv=2 sz=24
    tag=67  PARA_TEXT        lv=3 sz=10
    tag=68  PARA_CHAR_SHAPE  lv=3 sz=8
    tag=69  PARA_LINE_SEG    lv=3 sz=36
  tag=76  SHAPE_COMPONENT  lv=2 sz=239 comp_id="$rec"
```

`samples/draw-group.hwp` 는 동일 배치로 `comp_id="$con"`(sz=270), `samples/aift.hwp` 는 `comp_id="$pic"`(sz=196). 세 경우 모두 캡션 `LIST_HEADER` 가 **30B 로 동일**하고, 이는 기존 `serialize_caption`(`control.rs:666-706`)이 방출하는 크기와 정확히 같다. 해당 함수 주석도 이미 `// 예약 필드 8바이트 (한컴 호환성: 원본 파일은 30바이트 LIST_HEADER)` 로 이 계약을 명시하고 있었다 — **방출 함수는 준비돼 있고 호출만 없었다.**

## 의도적 누락이 아님

- `git log -S "serialize_caption" -- src/serializer/control.rs` → **Initial commit 1건뿐.** 도형 arm 에서 캡션 방출을 제거한 커밋이 없다.
- #1403 계열 커밋은 전부 HWPX 경로만 수정했고, 당시 검토 문서 `mydocs/pr/archives/pr_1406_review.md` §3.2 는 오히려 **"HWP5 파서는 전 도형 캡션 적재 중"** 을 명시한다.

## `raw_stream` 지름길 주의

`serialize_section`(`src/serializer/body_text.rs:26-30`)이 원본 섹션 바이트를 그대로 반환하므로 **파싱 직후 무편집 저장은 직렬화기를 타지 않아 손실이 관측되지 않는다.** 최초 계측에서 `38 → 38` 이 나와 결함이 없어 보였으나 직렬화기를 우회한 결과였다.

실사용 경로는 `src/document_core/commands/` 의 편집 명령들이 예외 없이 `raw_stream = None` 을 설정하므로(`formatting.rs` 16곳, `header_footer_ops.rs` 9곳, `footnote_ops.rs` 6곳, `clipboard.rs` 4곳 등) **문서를 한 글자라도 편집하면 그 섹션의 도형 캡션이 전부 사라진다.** HWPX 입력은 `raw_stream` 자체가 없어 무조건 손실된다. 위 표의 수치는 `raw_stream` 무효화 상태(=실사용 경로) 계측이다.

## 변경

1. `serialize_shape_control` 에 `emit_caption` 클로저 신설(`emit_ctrl_data` 옆). 방출 위치·OLE 제외 사유·호출 순서 제약을 주석으로 고정.
2. 8개 arm(`Line`/`Rectangle`/`Ellipse`/`Polygon`/`Arc`/`Curve`/`Group`/`Chart`)에서 호출. 캡션 필드 해석은 `serializer/hwpx/roundtrip.rs:1322-1335` `shape_caption()` 과 동일 매핑.

**호출 순서 제약**: `emit_top_level_synthesized_ctrl_data` **뒤**, `SHAPE_COMPONENT` push **앞**. `parse_caption`(`parser/control.rs:417-462`)이 `records[1..]` 전체를 캡션 문단으로 넘기므로 캡션과 `SHAPE_COMPONENT` 사이에 `CTRL_DATA` 가 끼면 문단 파싱이 오염된다.

**`Ole` arm 은 제외했다** — #1283/#2696 의 196B base-only 계약 영역이고, 캡션 보유 OLE 한컴 실물 샘플을 확보하지 못해 방출 위치를 실측 검증할 수 없다. 별도 이슈로 남긴다.

## 검증

### red→green

수정만 되돌린 상태(**RED**):

```
test issue2715_shape_without_caption_emits_no_list_header ... ok
test issue2715_caption_precedes_shape_component_and_textbox_follows ... FAILED
test issue2715_rectangle_caption_roundtrips ... FAILED
test issue2715_group_caption_roundtrips ... FAILED

panicked at src\serializer\control\tests.rs:897:5:
캡션 LIST_HEADER 는 SHAPE_COMPONENT 앞이어야 함 (caption=2, comp=1)
panicked at src\serializer\control\tests.rs:819:10:
[#2715] 사각형 캡션이 왕복 보존돼야 함
panicked at src\serializer\control\tests.rs:848:14:
[#2715] 묶음 캡션이 왕복 보존돼야 함

test result: FAILED. 1 passed; 3 failed
```

RED 의 `caption=2, comp=1` 은 발견된 유일한 `LIST_HEADER` 가 `SHAPE_COMPONENT`(idx 1) **뒤**의 글상자용(idx 2)이었음을 뜻한다 — 캡션이 아예 방출되지 않았다는 직접 증거다.

수정 복원 후(**GREEN**): `test result: ok. 4 passed; 0 failed`

### CI 3종

| 명령 | 결과 |
|---|---|
| `cargo fmt --all -- --check` | 통과 (`Diff in` 0건) |
| `cargo clippy --all-targets -- -D warnings` | 통과 (경고 0) |
| `cargo test --profile release-test --tests` | **3484 passed, 0 failed** |

### 회귀 위험 테스트 개별 확인

레코드 시퀀스에 `LIST_HEADER` 를 추가하므로 인덱스·크기 고정 테스트를 사전 조사 후 개별 확인했다.

| 테스트 | 위험 | 결과 |
|---|---|---|
| `issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage` (`shape_component.size == 196`) | OLE 계약 | ok |
| `issue2696_ole_shape_component_stays_base_only` | OLE base-only | ok |
| `task903_stage45_*` (고정 인덱스 `[21,35,807,808,810,812]`) | 인덱스 이동 | ok — 기준 fixture `hwpx-h-01.hwpx` 는 도형 캡션 0건이라 이동 없음 |
| `issue_1403_captions_roundtrip_aift` | HWPX 캡션 | ok |
| `tests/issue_1251_ole_chart_contents.rs` 전 10건 | OLE 전반 | 전건 ok |

### 신규 테스트 4건 (`src/serializer/control/tests.rs`)

- `issue2715_rectangle_caption_roundtrips` — 캡션 텍스트·방향·세로정렬·폭·간격·최대폭·include_margin 전 필드 왕복
- `issue2715_group_caption_roundtrips` — 묶음(`$con`) 캡션 왕복
- `issue2715_caption_precedes_shape_component_and_textbox_follows` — 캡션은 `SHAPE_COMPONENT` 앞·글상자는 뒤, `level+1`, 30B 고정 + 둘 다 재파싱 복원
- `issue2715_shape_without_caption_emits_no_list_header` — 캡션 없는 도형은 레코드 미추가

## 범위 밖 (잔여)

- **OLE 캡션** — 위 사유로 제외. 별도 이슈 권장.
- **묶음 자식 도형의 캡션** — `serialize_group_child` 는 `CTRL_HEADER` 없이 `SHAPE_COMPONENT` 만 방출하는 경로다. 한컴이 묶음 자식에 캡션을 쓰는지 실물 확인하지 못했고, 현 파서도 `parse_container_children` 에서 자식 캡션을 적재하지 않는다.
- **캡션 내 `atno`(자동 번호) 의미 검증** — 레코드는 공용 `serialize_paragraph_list` 로 동승하나 번호 재계산 의미까지는 검증하지 않았다.
- **`raw_stream` 지름길 자체** — 의도된 설계(완전 라운드트립)라 건드리지 않았다. 다만 직렬화기 결함이 무편집 라운드트립 테스트에서 가려지는 구조적 사각이므로 관찰 대상으로 남긴다.

처리 결과 문서: `mydocs/report/task_m100_2715_report.md`
