### PR TITLE
fix(hwpx): 각주/미주 저장 시 prefixChar/suffixChar/instId/flag 속성 유실 수정

### DIFF
--- a/mydocs/report/pr-hwpx-note-attrs.md
+++ b/mydocs/report/pr-hwpx-note-attrs.md
@@ -1,4 +1,4 @@
-# PR #????: HWPX 각주/미주 저장 시 prefixChar/suffixChar/instId/flag 속성 유실 수정 (#2716)
+# PR #2730: HWPX 각주/미주 저장 시 prefixChar/suffixChar/instId/flag 속성 유실 수정 (#2716)
 
 ## 수정
 HWPX 직렬화기 `render_note_sublist`가 number만 방출하고 4개 속성을 버리던 문제 수정.

--- a/mydocs/report/pr-hwpx-note-attrs.md
+++ b/mydocs/report/pr-hwpx-note-attrs.md
@@ -1,0 +1,7 @@
+# PR #????: HWPX 각주/미주 저장 시 prefixChar/suffixChar/instId/flag 속성 유실 수정 (#2716)
+
+## 수정
+HWPX 직렬화기 `render_note_sublist`가 number만 방출하고 4개 속성을 버리던 문제 수정.
+
+- 직렬화: `NoteAttrs` 구조체 도입, 한컴 생략 규칙에 따라 flag/number/prefixChar/suffixChar/instId 방출
+- 파서: `parse_ctrl_footnote`/`parse_ctrl_endnote`에 `flag` → `number_shape` 매핑 추가

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4621,6 +4621,15 @@ fn parse_ctrl_footnote(
                     note.instance_id = v;
                 }
             }
+            // [#2716] flag = HWP5 number_shape (UInt4). 한컴 저장본 3%가 사용.
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
+                }
+            }
             _ => {}
         }
     }
@@ -4666,6 +4675,15 @@ fn parse_ctrl_endnote(
                     .parse::<u32>()
                 {
                     note.instance_id = v;
+                }
+            }
+            // [#2716] flag → number_shape
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
                 }
             }
             _ => {}

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1958,16 +1958,37 @@ fn render_common_shape_xml(
     out
 }
 
+struct NoteAttrs {
+    number: u16,
+    prefix_char: u16,  // 0이면 생략 (before_decoration_letter)
+    suffix_char: u16,  // 항상 방출 (after_decoration_letter)
+    number_shape: u32, // 0이면 flag 생략
+    inst_id: u32,      // 항상 방출 (instance_id)
+}
+
 fn render_note_sublist(
     tag: &str,
-    number: u16,
+    attrs: &NoteAttrs,
     paragraphs: &[Paragraph],
     ctx: &mut SerializeContext,
 ) -> String {
+    // 한컴 저장본 속성 순서: flag, number, prefixChar, suffixChar, instId
+    // 생략 규칙(828개 실측): flag ↔ number_shape != 0, prefixChar ↔ prefix_char != 0
+    let mut note_attrs = String::new();
+    if attrs.number_shape != 0 {
+        note_attrs.push_str(&format!(" flag=\"{}\"", attrs.number_shape));
+    }
+    note_attrs.push_str(&format!(" number=\"{}\"", attrs.number));
+    if attrs.prefix_char != 0 {
+        note_attrs.push_str(&format!(" prefixChar=\"{}\"", attrs.prefix_char));
+    }
+    note_attrs.push_str(&format!(" suffixChar=\"{}\"", attrs.suffix_char));
+    note_attrs.push_str(&format!(" instId=\"{}\"", attrs.inst_id));
+
     let mut out = format!(
-        r#"<hp:ctrl><hp:{tag} number="{num}"><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#,
+        r#"<hp:ctrl><hp:{tag}{attrs}><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#,
         tag = tag,
-        num = number,
+        attrs = note_attrs,
     );
     let mut vert_cursor: u32 = 0;
     for p in paragraphs.iter() {
@@ -1985,11 +2006,33 @@ fn render_note_sublist(
 }
 
 fn render_footnote(note: &Footnote, ctx: &mut SerializeContext) -> String {
-    render_note_sublist("footNote", note.number, &note.paragraphs, ctx)
+    render_note_sublist(
+        "footNote",
+        &NoteAttrs {
+            number: note.number,
+            prefix_char: note.before_decoration_letter,
+            suffix_char: note.after_decoration_letter,
+            number_shape: note.number_shape,
+            inst_id: note.instance_id,
+        },
+        &note.paragraphs,
+        ctx,
+    )
 }
 
 fn render_endnote(note: &Endnote, ctx: &mut SerializeContext) -> String {
-    render_note_sublist("endNote", note.number, &note.paragraphs, ctx)
+    render_note_sublist(
+        "endNote",
+        &NoteAttrs {
+            number: note.number,
+            prefix_char: note.before_decoration_letter,
+            suffix_char: note.after_decoration_letter,
+            number_shape: note.number_shape,
+            inst_id: note.instance_id,
+        },
+        &note.paragraphs,
+        ctx,
+    )
 }
 
 fn render_equation(eq: &Equation) -> String {


### PR DESCRIPTION
## 개요

HWPX 각주/미주 직렬화가 `number`만 방출하고 `prefixChar`/`suffixChar`/`instId`/`flag` 4개 속성을 전량 버리는 문제 수정. #1199가 파서 쪽에서 고친 「문N）」마커가 저장 한 번에 「N)」로 되돌아가는 회귀의 근본 원인.

## 수정

### 직렬화 (`src/serializer/hwpx/section.rs`)
- `NoteAttrs` 구조체 도입 (number/prefix_char/suffix_char/number_shape/inst_id)
- `render_note_sublist`가 NoteAttrs를 받아 한컴 생략 규칙에 따라 방출
  - `flag` ↔ number_shape != 0, `prefixChar` ↔ prefix_char != 0
  - `number`/`suffixChar`/`instId`는 항상 방출

### 파서 (`src/parser/hwpx/section.rs`)
- `parse_ctrl_footnote`/`parse_ctrl_endnote`에 `flag` → `number_shape` 매핑 추가

## 검증
- cargo fmt/clippy 통과