### PR TITLE
fix(hwpx): 공용 도형 경로 hp:sz 크기 기준·크기 보호 소실 (ellipse/arc/polygon/curve/chart)

### DIFF
--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -43,3 +43,4 @@ rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자�
 
 - #2697 — 표 hp:sz IR 보존
 - #2712 — rect/line/picture hp:sz IR 보존
+- #2733 — 본 PR

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -1,0 +1,45 @@
+# PR: fix(hwpx): 공용 도형 경로 hp:sz 크기 기준·크기 보호 소실 (ellipse/arc/polygon/curve/chart)
+
+## 개요
+
+Issue #2726. #2697(표)과 #2712(rect/line/picture)에서 해결된 hp:sz의
+widthRelTo/heightRelTo/protect IR 보존이 나머지 도형 타입(ellipse, arc, polygon, curve,
+chart)에서 여전히 hardcoded "ABSOLUTE"/"0"으로 방출되는 문제를 수정한다.
+
+## 분석
+
+`src/serializer/hwpx/shape.rs`의 `write_sz()` 함수(978~992번째 줄)는 `CommonObjAttr`의
+`width_criterion`, `height_criterion`, `size_protect` 필드를 무시하고 항상
+`widthRelTo="ABSOLUTE"`, `heightRelTo="ABSOLUTE"`, `protect="0"`을 방출했다.
+
+이 함수는 다음과 같은 모든 도형 타입에서 공통으로 호출된다:
+- `<hp:rect>` — write_rect (103번째 줄)
+- `<hp:line>` / `<hp:connectLine>` — write_line (250번째 줄)
+- `<hp:container>` — write_container_close (321번째 줄)
+- `<hp:ole>` — write_ole (390번째 줄)
+
+rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자체를 수정하면
+모든 도형 타입이 한 번에 fix된다. ole는 chart/ole 개체를 포함한다.
+
+## 변경 내용
+
+**`src/serializer/hwpx/shape.rs`**
+
+1. `SizeCriterion` import 추가
+2. `size_criterion_width_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column→COLUMN, Para→PARA, Absolute→ABSOLUTE)
+3. `size_criterion_height_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column/Para/Absolute→ABSOLUTE; 파서가 높이는 allow_column_para=false로 읽으므로
+   Column/Para는 존재하지 않지만 fallback으로 ABSOLUTE)
+4. `write_sz()` — hardcoded "ABSOLUTE"/"0" 대신 위 헬퍼 함수와
+   `bool01(c.size_protect)` 사용
+
+## 검증
+
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과 (45.04s)
+
+## 관련 PR
+
+- #2697 — 표 hp:sz IR 보존
+- #2712 — rect/line/picture hp:sz IR 보존

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -20,8 +20,8 @@ use quick_xml::Writer;
 
 use crate::model::shape::{
     CommonObjAttr, DrawingObjAttr, HorzAlign, HorzRelTo, LineShape, ObjectNumberingType,
-    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, TextBox, TextFlow, TextWrap,
-    VertAlign, VertRelTo,
+    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, SizeCriterion, TextBox,
+    TextFlow, TextWrap, VertAlign, VertRelTo,
 };
 use crate::model::style::{Fill, FillType, ImageFillMode, ShapeBorderLine, SolidFill};
 use crate::model::ColorRef;
@@ -978,17 +978,44 @@ pub(super) fn write_shape_comment<W: Write>(
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
     let width = c.width.to_string();
     let height = c.height.to_string();
+    // [#2697/#2712] widthRelTo/heightRelTo/protect 는 IR 을 보존한다. 종전
+    // "ABSOLUTE"/"0" 하드코딩은 파서가 이미 읽어 둔 값(width_criterion/height_criterion/
+    // size_protect)을 저장 때 버려, 단/쪽/문단에 맞춘 도형이 절대값으로 바뀌고 크기 보호가
+    // 풀렸다(section.rs:2925/2928).
     empty_tag(
         w,
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_width_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", size_criterion_height_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
+}
+
+/// 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+pub(crate) fn size_criterion_width_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다.
+pub(crate) fn size_criterion_height_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {


### PR DESCRIPTION
## 개요

Issue #2726. #2697(표)과 #2712(rect/line/picture)에서 해결된 hp:sz의
widthRelTo/heightRelTo/protect IR 보존이 나머지 도형 타입(ellipse, arc, polygon,
curve, chart)에서 여전히 hardcoded "ABSOLUTE"/"0"으로 방출되는 문제를 수정한다.

## 분석

`src/serializer/hwpx/shape.rs`의 `write_sz()` 함수는 `CommonObjAttr`의
`width_criterion`, `height_criterion`, `size_protect` 필드를 무시하고 항상
`widthRelTo="ABSOLUTE"`, `heightRelTo="ABSOLUTE"`, `protect="0"`을 방출했다.

이 함수는 다음과 같은 모든 도형 타입에서 공통으로 호출된다:
- `<hp:rect>` — write_rect
- `<hp:line>` / `<hp:connectLine>` — write_line
- `<hp:container>` — write_container_close
- `<hp:ole>` — write_ole (chart 포함)

따라서 write_sz() 자체를 수정하면 모든 도형 타입이 한 번에 fix된다.

## 변경 내용

**`src/serializer/hwpx/shape.rs`**

1. `SizeCriterion` import 추가
2. `size_criterion_width_str()` — `pub(crate)` 헬퍼 함수
3. `size_criterion_height_str()` — `pub(crate)` 헬퍼 함수
4. `write_sz()` — hardcoded "ABSOLUTE"/"0" 대신 위 헬퍼 함수와 `bool01(c.size_protect)` 사용

## 검증

- `cargo fmt --all -- --check` — 통과
- `cargo clippy --all-targets -- -D warnings` — 통과

## 관련 Issue / PR

- #2697 — 표 hp:sz IR 보존
- #2712 — rect/line/picture hp:sz IR 보존
- #2726 — 본 이슈