### PR TITLE
fix(hwpx): 공용 도형 hp:sz 크기 기준·크기 보호 라운드트립 보존 (#2726)

### DIFF
--- a/mydocs/report/task_m100_2726_report.md
+++ b/mydocs/report/task_m100_2726_report.md
@@ -1,0 +1,346 @@
+# [#2726] HWPX 공용 도형 경로 `hp:sz` — 크기 기준·크기 보호 라운드트립 보존
+
+## 이슈 / 브랜치 / 범위
+
+| 항목 | 값 |
+|---|---|
+| 이슈 | [#2726](https://github.com/edwardkim/rhwp/issues/2726) |
+| 브랜치 | `task/m100-2726-hwpx-common-shape-sz` (분기점 `origin/devel` = `49f38446`) |
+| 변경 파일 | `src/serializer/hwpx/section.rs`, `src/parser/hwpx/section.rs` |
+| 범위 밖 | `render_equation`(수식 서브시스템 별도 작업 중), `serializer/hwpx/{table,shape,picture}.rs`(#2697·#2712 소관) |
+
+`#2697`/`#2701`(표, devel 병합 `8b77bb15`·`14e4b806`)과 `#2712`/`#2719`
+(rect/line/container/picture, 열림)가 고친 것과 **같은 결함 클래스의 잔여**다.
+`#2719` 가 본문에 명시적으로 잔여로 남긴 두 지점이 본 작업 대상이다.
+
+---
+
+## 1. 문제
+
+### 1-1. 직렬화 — `src/serializer/hwpx/section.rs:1912` (`render_common_shape_xml`)
+
+```rust
+r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
+```
+
+- `widthRelTo` / `heightRelTo` — IR `CommonObjAttr::width_criterion` / `height_criterion`
+  이 있는데도 `"ABSOLUTE"` 리터럴로 고정.
+- `protect` — IR `size_protect` 가 있는데 **속성이 아예 방출되지 않음**.
+
+이 경로를 타는 태그는 `:1776`–`:1805` 디스패치 기준 **ellipse / arc / polygon / curve /
+chart** 5종이다.
+
+### 1-2. 파싱 — `src/parser/hwpx/section.rs:5985` (`parse_common_shape_children`)
+
+`hp:sz` arm 이 `width` / `height` / `protect` 만 읽고 `widthRelTo` / `heightRelTo` arm 이
+없다. 호출자는 `:5822`(chart) · `:5906`(ole) 두 곳이므로 **차트·OLE 의 크기 기준이
+파싱 단계에서 소실**된다.
+
+---
+
+## 2. 분석
+
+### 2-1. 과잉 주장 배제 — 파서는 4개 태그에 대해 이미 무결하다
+
+`ellipse` / `arc` / `polygon` / `curve` 는 `parse_common_shape_children` 을 **타지 않는다**.
+이들은 `parse_shape_object`(`:3698`) → `parse_object_layout_child`(`:2901`, `hp:sz` arm
+`:2909`)로 파싱되며, 그 arm 은 `widthRelTo`(`:2925`) · `heightRelTo`(`:2928`) ·
+`protect`(`:2930`)를 **이미 정상적으로 읽고 있다**.
+
+따라서 이 4개 태그에 대해서는 **파서는 손실원이 아니고 직렬화기만 손실원**이다.
+"공용 자식 파서가 안 읽어서 4개 태그의 왕복이 막혀 있다"는 서술은 사실이 아니므로
+이슈·본 보고서 어디에도 그렇게 적지 않았다.
+
+파서 arm 5개 대조:
+
+| arm | 위치 | 담당 | `widthRelTo` | `heightRelTo` | `protect` |
+|---|---|---|---|---|---|
+| 표 | `:1692` | `hp:tbl` | O | O | O (#2697) |
+| 그림 | `:2331` | `hp:pic` | O (#2712) | O (#2712) | O (#2712) |
+| 도형 공용 | `:2909` | rect/ellipse/arc/polygon/curve/line | O | O | O |
+| 양식 | `:5599` | `hp:checkBtn` 등 | O | O | O |
+| **공용 자식** | **`:5985`** | **chart / ole** | **X** | **X** | O |
+
+차트만 파싱·직렬화 **양쪽**이 막혀 있어 두 수정이 각각 독립적으로 필요하다.
+
+### 2-2. HWP5 경로가 실재함을 코드로 확인
+
+`src/parser/control/shape.rs:339 parse_common_obj_attr`(호출 `:30`)는 **모든 HWP5 도형**에
+대해 공용으로 3값을 적재한다.
+
+- `:348` `size_protect = attr & (1 << 20) != 0`
+- `:380` `width_criterion = (attr >> 15) & 0x07` → Paper/Page/Column/Para/Absolute
+- `:388` `height_criterion = (attr >> 18) & 0x03` → Paper/Page/Absolute
+
+기록측도 `document_core/converters/common_obj_attr_writer.rs:150 width_criterion_to_bits` /
+`:160 height_criterion_to_bits` 로 완비돼 있다. 끊긴 고리는 HWPX 직렬화기 한 곳뿐이었다.
+
+---
+
+## 3. 코퍼스 실측
+
+`samples/hwpx` 의 실제 한글 산출 `.hwpx` **60개**를 열어 모든 `section*.xml` 의 `hp:sz` 를
+**부모 태그와 함께** 전수 집계했다(zip + 태그 스택 파싱). 총 **1583개**로,
+`#2719` 가 보고한 수치와 정확히 일치해 방법론이 교차 검증된다.
+
+```
+샘플 파일 수: 60          hp:sz 총 개수: 1583
+부모태그          sz수  protect속성  protect="1"  파일수
+tbl               684        684         13        47
+rect              314        314          1        21
+checkBtn          182        182          0         3
+pic               177        177          0        33
+polygon           150        150          0         8   <- 본 작업
+equation           60         60          0         2   <- 범위 밖(잔여)
+container           7          7          0         6
+btn                 2          2          0         2
+comboBox            2          2          0         2
+radioBtn            2          2          0         2
+edit                2          2          0         2
+ole                 1          1          1         1   <- 파싱측만 본 작업
+widthRelTo  전역 분포: {'ABSOLUTE': 1583}
+heightRelTo 전역 분포: {'ABSOLUTE': 1583}
+```
+
+### 3-1. 실측 — `hp:polygon` 150개의 구조 이탈
+
+- **`hp:sz` 1583개 전부(1583/1583, 100%)가 `protect` 속성을 갖는다.** 한글은 이 속성을
+  예외 없이 쓴다. 전수이므로 표본 편향이 아니다.
+- `render_common_shape_xml` 은 `protect` 를 방출하지 않았다. 따라서 8개 실제 한글 파일의
+  `hp:polygon` **150개**가 HWPX→HWPX 저장에서 이 속성을 **잃었다**.
+- 값이 `0` 이라 *의미* 손실은 아니다. 그러나 한컴 원본 대비 **XML 구조 이탈**이며,
+  한컴 자신의 1583/1583 불변식을 깨는 것이다. 이 부분은 지금 재현 가능한 실측이다.
+
+### 3-2. 잠재 — 값 손실은 이 코퍼스로 증명되지 않는다
+
+| 태그 | 코퍼스 인스턴스 | `protect="1"` | 비-ABSOLUTE 범주 | 판정 |
+|---|---|---|---|---|
+| `hp:polygon` | 150 (8파일) | 0 | 0 | **실측 구조 이탈** |
+| `hp:ellipse` | **0** | — | — | 잠재 |
+| `hp:arc` | **0** | — | — | 잠재 |
+| `hp:curve` | **0** | — | — | 잠재 |
+| `hp:chart` | **0** | — | — | 잠재 |
+| `hp:ole` | 1 | 1 | 0 | 파싱측만 해당 |
+
+- `protect="1"` 은 본 경로 담당 태그에 코퍼스 인스턴스가 **0개**다. 전체 15개는
+  `hp:tbl`(13, #2697) · `hp:rect`(1) · `hp:ole`(1, #2712)로 모두 선행 PR 소관이다.
+- `widthRelTo` / `heightRelTo` 는 **1583개 전부 `ABSOLUTE`** 다. 비-ABSOLUTE 표본이 없다.
+- 즉 **값 손실 절반은 잠복(latent)** 이며 HWP5 입력 경로(2-2) 또는 문서 코어 편집
+  경로로만 도달한다. `#2719` 가 같은 상황을 밝힌 것과 동일하게 적는다.
+  **추론을 측정으로 제시하지 않았다.**
+
+`hwpx-01.hwpx` 1개는 zip 이 아니어서 집계에서 제외됐다(스크립트가 경고 출력). 위 60은
+실제로 열린 파일 수다.
+
+---
+
+## 4. 변경
+
+### 4-1. `src/serializer/hwpx/section.rs`
+
+1. `hp:sz` 포맷 리터럴을 IR 통과로 교체하고 `protect` 를 추가.
+   ```rust
+   r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
+   ```
+   인자: `wrt = size_criterion_str(c.width_criterion)`,
+   `hrt = height_criterion_str(c.height_criterion)`,
+   `prot = if c.size_protect { "1" } else { "0" }`.
+2. `size_criterion_str`(5값) · `height_criterion_str`(3값 접기) 헬퍼 추가.
+3. `use crate::model::shape::…` 에 `SizeCriterion` 추가.
+
+**높이 정확-역 제약을 유지했다.** 파서가 높이를
+`parse_size_criterion(_, allow_column_para = false)`(`parser/hwpx/section.rs:1860`)로 읽어
+치역이 `{Paper, Page, Absolute}` 3값뿐이므로, `height_criterion_str` 는 `Column`/`Para` 를
+`ABSOLUTE` 로 접는다. 접지 않으면 되읽기에서 `Absolute` 로 접혀 왕복이 비-멱등이 된다.
+HWP5 측 `height_criterion_to_bits` 도 동일하게 접으므로 세 표현이 일관된다.
+이 성질은 5값 전수 대조 테스트로 못 박았다.
+
+### 4-2. `src/parser/hwpx/section.rs`
+
+`parse_common_shape_children` 의 `hp:sz` arm 에 두 arm 추가 — 같은 파일 `:2925`/`:2928`
+(도형 공용) 및 `:1702`/`:1706`(표)과 **동형**이며 새 관례를 만들지 않았다.
+
+```rust
+b"widthRelTo"  => { common.width_criterion  = parse_size_criterion(&attr_str(&attr), true); }
+b"heightRelTo" => { common.height_criterion = parse_size_criterion(&attr_str(&attr), false); }
+```
+
+영향 범위는 chart(`:5822`) · ole(`:5906`). 코퍼스의 해당 `hp:sz`(chart 0개, ole 1개)가
+전부 `ABSOLUTE` 이므로 **기존 표본에는 무변화**다. OLE `#1283` 계약 테스트 무회귀는
+6장에서 확인했다.
+
+### 4-3. 헬퍼 재사용 방침
+
+`devel` 기준 `size_criterion_str` / `height_criterion_str` 는
+`serializer/hwpx/table.rs:147`/`:162` 에 **private(`fn`)** 로만 존재해 `section.rs` 에서
+도달할 수 없다. `#2712` 가 `shape.rs` 에 추가한 `pub(super)` 사본은 아직 `devel` 에 없다.
+따라서 `section.rs` 에 **동일 의미** 사본을 두고 doc 주석에 복제 사유를 명시했으며,
+공용 위치 1벌 통합은 잔여로 신고한다(8장). **두 번째 관례를 만들지 않았다.**
+
+---
+
+## 5. 신규 테스트 6종
+
+| # | 테스트 | 위치 | 확인 |
+|---|---|---|---|
+| 1 | `issue2726_common_shape_sz_preserves_criteria_and_protect` | 직렬화 | 5개 태그 전부 `COLUMN`/`PAGE`/`protect="1"` 보존 |
+| 2 | `issue2726_common_shape_sz_always_emits_protect_attribute` | 직렬화 | `size_protect=false` 여도 `protect="0"` **속성 방출** (3-1 대응) |
+| 3 | `issue2726_height_criterion_never_emits_column_or_para` | 직렬화 | 높이 5값 전수 → `COLUMN`/`PARA` 절대 미방출 (정확-역 고정) |
+| 4 | `issue2726_width_criterion_emits_all_five_values` | 직렬화 | 너비 5값 전수 대조 |
+| 5 | `issue2726_parse_chart_preserves_size_criteria` | 파싱 | 차트 `widthRelTo="COLUMN"`/`heightRelTo="PAGE"` → IR 적재 |
+| 6 | `issue2726_parse_chart_height_folds_column_and_para_to_absolute` | 파싱 | 높이 `COLUMN`/`PARA` → `Absolute` 접힘, 너비는 원문 보존 |
+
+---
+
+## 6. 검증
+
+### 6-1. RED → GREEN (실제 실행, 캡처)
+
+두 수정은 서로 독립이므로 **각각 따로 되돌려** 개별로 load-bearing 임을 증명했다.
+
+#### RED 1 — 직렬화 수정만 되돌림 (파서 수정은 유지)
+
+`cargo test --lib issue2726`
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... FAILED
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... FAILED
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... FAILED
+
+---- issue2726_common_shape_sz_preserves_criteria_and_protect stdout ----
+panicked at src\serializer\hwpx\section.rs:2437:13:
+ellipse: 너비 기준 COLUMN 이 보존되어야 함: <hp:ellipse …><hp:sz width="4000" height="3000"
+widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+---- issue2726_common_shape_sz_always_emits_protect_attribute stdout ----
+panicked at src\serializer\hwpx\section.rs:2469:9:
+size_protect=false 여도 protect="0" 속성이 방출되어야 함: <hp:polygon …><hp:sz width="0"
+height="0" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+---- issue2726_height_criterion_never_emits_column_or_para stdout ----
+panicked at src\serializer\hwpx\section.rs:2506:13:
+Paper → heightRelTo="PAPER" 이어야 함: <hp:polygon …><hp:sz width="0" height="0"
+widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+test result: FAILED. 3 passed; 3 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+**RED 1 에서도 통과한 테스트 3개 (공시)**
+
+| 테스트 | 통과 사유 |
+|---|---|
+| `issue2726_width_criterion_emits_all_five_values` | 헬퍼 `size_criterion_str` 를 직접 호출할 뿐 포맷 리터럴을 타지 않는다 |
+| `issue2726_parse_chart_preserves_size_criteria` | 파서 테스트 — 직렬화 수정과 무관 |
+| `issue2726_parse_chart_height_folds_column_and_para_to_absolute` | 파서 테스트 — 직렬화 수정과 무관 |
+
+#### RED 2 — 파서 수정만 되돌림 (직렬화 수정은 유지)
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... FAILED
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... FAILED
+
+---- issue2726_parse_chart_height_folds_column_and_para_to_absolute stdout ----
+panicked at src\parser\hwpx\section.rs:7575:13:
+assertion `left == right` failed: 너비는 COLUMN 를 그대로 보존해야 한다
+  left: Absolute
+ right: Column
+
+---- issue2726_parse_chart_preserves_size_criteria stdout ----
+panicked at src\parser\hwpx\section.rs:7527:9:
+assertion `left == right` failed: widthRelTo="COLUMN" 이 IR 에 적재되어야 한다
+  left: Absolute
+ right: Column
+
+test result: FAILED. 4 passed; 2 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+**RED 2 에서도 통과한 테스트 4개 (공시)** — 직렬화 테스트 3개 + 헬퍼 테스트 1개.
+전부 파서 경로를 타지 않으므로 파서 수정과 독립이다. 이는 두 수정이 서로 다른
+결함을 덮고 있음을 보이는 증거이기도 하다.
+
+#### GREEN — 두 수정 모두 복원 후
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... ok
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... ok
+
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+### 6-2. CI 3종 — 전부 통과
+
+| 검사 | 명령 | 결과 |
+|---|---|---|
+| fmt | 변경 `.rs` 2개에 `rustfmt --edition 2021` 후 `git diff --name-only` | 1차 실행에서 정형화 적용됨 → 2차 실행 md5 불변(고정점 도달) |
+| clippy | `cargo clippy --all-targets -- -D warnings` | **exit 0**, 경고 0건 |
+| test | `cargo test --profile release-test --tests` | **exit 0** — 291개 테스트 바이너리, **3486 passed / 0 failed / 23 ignored** |
+
+`cargo fmt --all -- --check` 는 **쓰지 않았다.** 이 Windows 체크아웃에서는 CRLF 파일에
+대해 `Incorrect newline style` 만 출력하고 diff 를 내지 않아 **거짓 통과**한다.
+
+### 6-3. 민감 테스트 무회귀 확인
+
+파서 변경이 OLE 파싱 경로(`:5906`)를 건드리므로 `#1283` 계약 회귀를 개별 확인했다.
+
+```
+test ole_chart_contents_probe_is_stable ... ok
+test ole_chart_contents_parse_result_is_stable ... ok
+test ole_chart_contents_exposes_renderer_neutral_ir ... ok
+test ole_chart_contents_renders_rust_svg_fragment ... ok
+test ole_chart_contents_renders_standalone_rust_svg ... ok
+test issue_1251_svg_uses_legacy_ole_chart_renderer ... ok
+test issue_1283_hwpx_internal_ole_is_loaded_even_when_isembeded_zero ... ok
+test issue_1283_hwpx_svg_uses_legacy_ole_chart_renderer ... ok
+test issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage ... ok
+
+test issue_1436_picture_properties_round_trip_size_protect ... ok
+test issue_1436_shape_properties_round_trip_size_protect ... ok
+test parser::hwpx::section::tests::test_parse_rect_preserves_size_protect ... ok
+```
+
+시각 회귀도 무변화 — `visual_baseline_all_samples`, `visual_xfail_entries_still_fail`,
+`svg_snapshot`(8종) 전부 통과.
+
+---
+
+## 7. 미실행 항목
+
+- **한글(HWP) 실물 대조 없음.** 수정 결과를 한글에서 열어 "단에 맞춤"이 유지되는지
+  육안 확인하지 않았다. 검증은 IR ↔ XML 계약 수준(단위 테스트)과 기존 회귀 스위트
+  무변화까지다.
+- **비-ABSOLUTE 크기 기준의 실물 코퍼스 확보 실패.** 3-2 에 적은 대로 표본이 없어
+  값 손실은 합성 IR/XML 로만 검증했다. 실물 표본을 만들려면 한글에서 타원/다각형에
+  "단에 맞춤"을 지정해 저장해야 하는데 이번 작업에서는 하지 않았다.
+- **HWP5→HWPX→HWP5 왕복 실측 없음.** 2-2 는 코드 경로 확인이며, 실제 바이트 왕복
+  비교는 수행하지 않았다.
+
+---
+
+## 8. 잔여
+
+1. **`render_equation`** — `serializer/hwpx/section.rs:2030` 의 `hp:sz` 도
+   `widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"` 하드코딩 + `protect` 미방출로
+   **완전히 동일한 결함**이다. 코퍼스 실측 `hp:equation` **60개(2파일, `protect` 60/60
+   존재)** 로 3-1 과 같은 구조 이탈이 있다. 수식 서브시스템이 별도 작업 중이라
+   본 작업에서 건드리지 않았다.
+2. **헬퍼 3중화** — 본 수정 후 `size_criterion_str`/`height_criterion_str` 가
+   `table.rs`(private) · `shape.rs`(#2712, `pub(super)`) · `section.rs`(본 PR) 3벌이 된다.
+   `serializer/hwpx/mod.rs` 등 공용 위치로 1벌 통합이 필요하다. `#2712` 병합 전에는
+   `devel` 에서 도달 가능한 사본이 없어 지금 통합할 수 없다.
+3. **OLE 직렬화측** — `serializer/hwpx/shape.rs write_ole` 는 `#2712` 소관.
+   본 PR 은 OLE 의 **파싱측**만 건드렸다.
+4. **`hp:container` 등 나머지** — `#2712` 소관.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5987,6 +5987,19 @@ fn parse_common_shape_children(
                             match attr.key.as_ref() {
                                 b"width" => common.width = parse_u32(&attr),
                                 b"height" => common.height = parse_u32(&attr),
+                                // [#2726] 공용 자식 파서(차트·OLE)만 크기 기준 arm 이 없어
+                                // 파싱 단계에서 유실됐다. 도형 공용 파서(같은 파일 2925/2928)·
+                                // 표(1702/1706)·그림(#2712)과 동형이며, 높이는 동일하게
+                                // allow_column_para=false 로 읽어 치역을 {Paper, Page,
+                                // Absolute} 로 제한한다.
+                                b"widthRelTo" => {
+                                    common.width_criterion =
+                                        parse_size_criterion(&attr_str(&attr), true);
+                                }
+                                b"heightRelTo" => {
+                                    common.height_criterion =
+                                        parse_size_criterion(&attr_str(&attr), false);
+                                }
                                 b"protect" => common.size_protect = parse_bool(&attr),
                                 _ => {}
                             }
@@ -7496,6 +7509,93 @@ mod tests {
             rect.common.text_flow,
             crate::model::shape::TextFlow::RightOnly
         );
+    }
+
+    /// [#2726] 공용 자식 파서(`parse_common_shape_children`)는 차트·OLE 를 담당하는데
+    /// `widthRelTo`/`heightRelTo` arm 이 없어 크기 기준이 **파싱 단계에서** 유실됐다.
+    /// 표(1702/1706)·도형(2925/2928)·그림(#2712) 파서와 동형으로 보강한다.
+    #[test]
+    fn issue2726_parse_chart_preserves_size_criteria() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart chartIDRef="Chart/chart1.xml" id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="4000" height="3000" widthRelTo="COLUMN" heightRelTo="PAGE" protect="1"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE(chart) shape");
+        };
+        assert_eq!(
+            ole.common.width_criterion,
+            SizeCriterion::Column,
+            "widthRelTo=\"COLUMN\" 이 IR 에 적재되어야 한다"
+        );
+        assert_eq!(
+            ole.common.height_criterion,
+            SizeCriterion::Page,
+            "heightRelTo=\"PAGE\" 가 IR 에 적재되어야 한다"
+        );
+        assert!(ole.common.size_protect, "protect=\"1\" 은 종전에도 읽혔다");
+    }
+
+    /// [#2726] 높이 기준은 `allow_column_para=false` 로 읽어 치역이
+    /// `{Paper, Page, Absolute}` 3값이어야 한다. `COLUMN`/`PARA` 가 들어와도 `Absolute`
+    /// 로 접혀야 직렬화기 `height_criterion_str` 와 정확한 역 관계가 유지된다.
+    #[test]
+    fn issue2726_parse_chart_height_folds_column_and_para_to_absolute() {
+        for raw in ["COLUMN", "PARA"] {
+            let xml = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart chartIDRef="Chart/chart1.xml" id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="4000" height="3000" widthRelTo="{raw}" heightRelTo="{raw}" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#
+            );
+
+            let section = parse_hwpx_section(&xml).unwrap();
+            let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+                panic!("expected shape control");
+            };
+            let ShapeObject::Ole(ole) = shape.as_ref() else {
+                panic!("expected OLE(chart) shape");
+            };
+            // 너비는 5값 전부 허용 → 원문 그대로.
+            let expected_width = if raw == "COLUMN" {
+                SizeCriterion::Column
+            } else {
+                SizeCriterion::Para
+            };
+            assert_eq!(
+                ole.common.width_criterion, expected_width,
+                "너비는 {raw} 를 그대로 보존해야 한다"
+            );
+            // 높이는 3값으로 접힘.
+            assert_eq!(
+                ole.common.height_criterion,
+                SizeCriterion::Absolute,
+                "높이 {raw} 는 Absolute 로 접혀야 한다"
+            );
+        }
     }
 
     #[test]

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -31,7 +31,7 @@ use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType};
 use crate::model::paragraph::{ColumnBreakType, LineSeg, OrphanFieldEnd, Paragraph};
 use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, TextWrap, VertAlign, VertRelTo,
+    CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, SizeCriterion, TextWrap, VertAlign, VertRelTo,
 };
 
 use super::context::SerializeContext;
@@ -1909,7 +1909,7 @@ fn render_common_shape_xml(
             r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
             "{block}",
             "{geometry}",
-            r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
+            r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
             r#"<hp:pos treatAsChar="{tac}" affectLSpacing="0" flowWithText="{fwt}" allowOverlap="{ao}" holdAnchorAndSO="{hold}" vertRelTo="{vr}" vertAlign="{va}" horzRelTo="{hr}" horzAlign="{ha}" vertOffset="{vo}" horzOffset="{ho}"/>"#,
             r#"<hp:outMargin left="{ml}" right="{mr}" top="{mt}" bottom="{mb}"/>"#,
         ),
@@ -1928,6 +1928,12 @@ fn render_common_shape_xml(
         hold = if c.prevent_page_break != 0 { "1" } else { "0" },
         w = c.width,
         h = c.height,
+        // [#2726] 종전 widthRelTo/heightRelTo 는 "ABSOLUTE" 리터럴, protect 는 아예
+        // 미방출이었다. 파서(parse_object_layout_child:2909)가 이미 3값을 IR 에 적재하므로
+        // 저장에서만 버려지는 순손실이었다. #2697(표)·#2712(rect/line/container/pic) 와 동형.
+        wrt = size_criterion_str(c.width_criterion),
+        hrt = height_criterion_str(c.height_criterion),
+        prot = if c.size_protect { "1" } else { "0" },
         vr = vert_rel_to_hwpx(c.vert_rel_to),
         va = vert_align_to_hwpx(c.vert_align),
         hr = horz_rel_to_hwpx(c.horz_rel_to),
@@ -1956,6 +1962,33 @@ fn render_common_shape_xml(
     }
     out.push_str(&format!("</hp:{tag}>"));
     out
+}
+
+/// [#2726] 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+///
+/// `table.rs:147` 이 `#2697` 로 정립한 관례와 **동일 의미**다. 해당 사본이 private 이라
+/// 이 모듈에서 도달할 수 없어 부득이 복제했다. 공용 위치 1벌 통합은 잔여다(이슈 7장).
+fn size_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// [#2726] 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로(`parser/hwpx/section.rs:1860`)
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다 — `COLUMN`/`PARA` 를 내면 되읽기에서 `Absolute` 로 접혀 비-멱등이 된다.
+/// HWP5 측 `height_criterion_to_bits`(`common_obj_attr_writer.rs:160`)도 동일하게 접는다.
+fn height_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn render_note_sublist(
@@ -2384,6 +2417,125 @@ mod tests {
             !xml_empty.contains("<hp:drawText"),
             "빈 글상자는 drawText 를 방출하지 않아야 함"
         );
+    }
+
+    /// [#2726] 공용 도형 경로(ellipse/arc/polygon/curve/chart)의 `hp:sz` 가 IR 의
+    /// 크기 기준·크기 보호를 보존해야 한다. 종전엔 `widthRelTo`/`heightRelTo` 가
+    /// `"ABSOLUTE"` 리터럴이고 `protect` 는 아예 미방출이었다.
+    #[test]
+    fn issue2726_common_shape_sz_preserves_criteria_and_protect() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let c = CommonObjAttr {
+            width: 4000,
+            height: 3000,
+            width_criterion: SizeCriterion::Column,
+            height_criterion: SizeCriterion::Page,
+            size_protect: true,
+            ..Default::default()
+        };
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        for tag in ["ellipse", "arc", "polygon", "curve", "chart"] {
+            let xml = render_common_shape_xml(tag, &c, &None, Some(&drawing), &[], "", &mut ctx);
+            assert!(
+                xml.contains(r#"widthRelTo="COLUMN""#),
+                "{tag}: 너비 기준 COLUMN 이 보존되어야 함: {xml}"
+            );
+            assert!(
+                xml.contains(r#"heightRelTo="PAGE""#),
+                "{tag}: 높이 기준 PAGE 가 보존되어야 함: {xml}"
+            );
+            assert!(
+                xml.contains(r#"protect="1""#),
+                "{tag}: 크기 보호가 보존되어야 함: {xml}"
+            );
+        }
+    }
+
+    /// [#2726] `protect` 는 값이 0 이어도 **속성 자체가** 방출되어야 한다.
+    /// `samples/hwpx` 실제 한글 파일 60개의 `hp:sz` 1583개가 **전부** `protect` 를 갖는다
+    /// (1583/1583). 종전 미방출은 그중 `hp:polygon` 150개(8파일)에서 한컴 원본 대비
+    /// 구조 이탈을 만들었다.
+    #[test]
+    fn issue2726_common_shape_sz_always_emits_protect_attribute() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let c = CommonObjAttr {
+            size_protect: false,
+            ..Default::default()
+        };
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        let xml = render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+        assert!(
+            xml.contains(r#"protect="0""#),
+            "size_protect=false 여도 protect=\"0\" 속성이 방출되어야 함: {xml}"
+        );
+    }
+
+    /// [#2726] `heightRelTo` 는 파서(`parse_size_criterion(_, allow_column_para=false)`)의
+    /// **정확한 역**이어야 한다. 파서 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이므로
+    /// 방출도 절대 `COLUMN`/`PARA` 를 내면 안 된다 — 내면 되읽기에서 `Absolute` 로 접혀
+    /// 왕복이 비-멱등이 된다. 5값 전수 대조로 못 박는다.
+    #[test]
+    fn issue2726_height_criterion_never_emits_column_or_para() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let cases = [
+            (SizeCriterion::Paper, "PAPER"),
+            (SizeCriterion::Page, "PAGE"),
+            (SizeCriterion::Column, "ABSOLUTE"),
+            (SizeCriterion::Para, "ABSOLUTE"),
+            (SizeCriterion::Absolute, "ABSOLUTE"),
+        ];
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        for (criterion, expected) in cases {
+            assert_eq!(
+                height_criterion_str(criterion),
+                expected,
+                "높이 기준 {criterion:?} 는 {expected} 로 방출되어야 함"
+            );
+
+            let c = CommonObjAttr {
+                height_criterion: criterion,
+                ..Default::default()
+            };
+            let xml =
+                render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+            assert!(
+                xml.contains(&format!(r#"heightRelTo="{expected}""#)),
+                "{criterion:?} → heightRelTo=\"{expected}\" 이어야 함: {xml}"
+            );
+            assert!(
+                !xml.contains(r#"heightRelTo="COLUMN""#) && !xml.contains(r#"heightRelTo="PARA""#),
+                "heightRelTo 는 COLUMN/PARA 를 방출하면 안 됨: {xml}"
+            );
+        }
+    }
+
+    /// [#2726] `widthRelTo` 는 5값 전부를 그대로 방출한다 — 파서
+    /// `parse_size_criterion(_, allow_column_para=true)` 의 정확한 역.
+    #[test]
+    fn issue2726_width_criterion_emits_all_five_values() {
+        let cases = [
+            (SizeCriterion::Paper, "PAPER"),
+            (SizeCriterion::Page, "PAGE"),
+            (SizeCriterion::Column, "COLUMN"),
+            (SizeCriterion::Para, "PARA"),
+            (SizeCriterion::Absolute, "ABSOLUTE"),
+        ];
+        for (criterion, expected) in cases {
+            assert_eq!(
+                size_criterion_str(criterion),
+                expected,
+                "너비 기준 {criterion:?} 는 {expected} 로 방출되어야 함"
+            );
+        }
     }
 
     /// [Task #1627] empty-text(객체-only) 문단에서 bookmark 는 문단 시작으로 끌려가지 않고


### PR DESCRIPTION
## 요약

Fixes #2726

HWPX `hp:sz` 의 `widthRelTo`/`heightRelTo` 가 공용 도형 직렬화 경로
`render_common_shape_xml`(`src/serializer/hwpx/section.rs:1912`)에서 `"ABSOLUTE"` 리터럴로
박혀 있고, `protect` 는 **아예 방출되지 않았다**. 파서가 이미 읽어 둔
IR(`CommonObjAttr::width_criterion` / `height_criterion` / `size_protect`)이 저장 때 버려진다.
이 경로는 **ellipse / arc / polygon / curve / chart** 5개 태그를 담당한다.

추가로 공용 자식 파서 `parse_common_shape_children`(`src/parser/hwpx/section.rs:5985`,
chart·ole 담당)이 `widthRelTo`/`heightRelTo` 를 읽지 않아 **차트는 파싱·직렬화 양쪽**이
막혀 있었다.

`#2697`/#2701(표, `devel` 병합 완료 `8b77bb15`·`14e4b806`)과 `#2712`/#2719
(rect/line/container/pic)가 고친 결함 클래스의 잔여이며, **#2719 가 본문에 명시적으로
잔여로 남긴 두 지점**이다.

---

## 코퍼스 실측 — 실측과 잠재를 구분해서 보고합니다

`samples/hwpx` 의 실제 한글 산출 파일 **60개**에서 `hp:sz` **1583개를 전수 조사**했다.
`#2719` 가 보고한 수치와 정확히 일치하므로 방법론이 교차 검증된다.

```
부모태그    sz수  protect속성  protect="1"  파일수
tbl          684      684         13        47
rect         314      314          1        21
checkBtn     182      182          0         3
pic          177      177          0        33
polygon      150      150          0         8   <- 본 PR
equation      60       60          0         2   <- 범위 밖(잔여)
container      7        7          0         6
ole            1        1          1         1   <- 파싱측만 본 PR
widthRelTo  전역 분포: {'ABSOLUTE': 1583}
heightRelTo 전역 분포: {'ABSOLUTE': 1583}
```

### 실측된 손실 — `hp:polygon` 150개

`hp:sz` **1583개 전부(1583/1583, 100%)가 `protect` 속성을 갖는다.** 한글은 이 속성을
예외 없이 쓴다. 그런데 본 경로는 `protect` 를 방출하지 않았으므로 **8개 실제 한글
파일의 `hp:polygon` 150개**가 HWPX→HWPX 저장에서 이 속성을 잃었다. 값이 `0` 이라
*의미* 손실은 아니지만 한컴 원본 대비 **XML 구조 이탈**이며 한컴 자신의 불변식을
깨는 것이다. 지금 재현 가능한 실측이다.

### 잠재 손실 — 이 코퍼스로는 증명되지 않는다

- `protect="1"` 은 본 경로 담당 태그(ellipse/arc/polygon/curve/chart)에 **코퍼스
  인스턴스가 0개**다. 전체 15개는 `tbl` 13 · `rect` 1 · `ole` 1 로 모두 선행 PR 소관.
- `widthRelTo`/`heightRelTo` 는 **1583개 전부 `ABSOLUTE`** — 비-ABSOLUTE 표본이 없다.

따라서 값 손실 절반은 **잠복(latent)** 이며, HWP5 입력 경로나 문서 코어 편집 경로로만
도달한다. HWP5 경로가 실재함은 코드로 확인했다 —
`src/parser/control/shape.rs:339 parse_common_obj_attr`(호출 `:30`)가 **모든 HWP5 도형**에
대해 `size_protect`(bit 20) · `width_criterion`(bit 15-17) · `height_criterion`(bit 18-19)
를 적재하고, 기록측 `common_obj_attr_writer.rs:150`/`:160` 도 완비돼 있다.
끊긴 고리는 HWPX 직렬화기 한 곳뿐이었다. **추론을 측정으로 제시하지 않습니다.**

---

## 과잉 주장 배제 — 파서는 4개 태그에 대해 이미 무결합니다

`ellipse`/`arc`/`polygon`/`curve` 는 `parse_common_shape_children` 을 **타지 않는다**.
`parse_shape_object`(`:3698`) → `parse_object_layout_child`(`:2901`, `hp:sz` arm `:2909`)로
파싱되며 그 arm 은 `widthRelTo`(`:2925`) · `heightRelTo`(`:2928`) · `protect`(`:2930`)를
**이미 정상적으로 읽고 있다**. 이 4개 태그는 **파서가 무결하고 직렬화기만 손실원**이다.

공용 자식 파서의 누락은 **chart(`:5822`) · ole(`:5906`)** 에만 영향한다. 차트만 양쪽이
막혀 있어 두 수정이 각각 독립적으로 필요하다.

---

## 변경

### `src/serializer/hwpx/section.rs`
- `hp:sz` 포맷 리터럴을 IR 통과로 교체하고 `protect` 추가.
- `size_criterion_str`(5값) · `height_criterion_str`(3값 접기) 헬퍼 추가.
- `use` 에 `SizeCriterion` 추가.

**헬퍼 복제 사유(의도적, 잔여 신고 포함).** `devel` 기준 두 헬퍼는
`serializer/hwpx/table.rs:147`/`:162` 에 **private(`fn`)** 로만 있어 `section.rs` 에서
도달 불가하고, #2719 가 `shape.rs` 에 넣은 `pub(super)` 사본은 아직 `devel` 에 없다.
**동일 의미**로 복제하고 doc 주석에 사유를 명시했으며, 공용 위치 1벌 통합을 잔여로
신고한다. 두 번째 관례를 만들지 않았다.

### `src/parser/hwpx/section.rs`
- `parse_common_shape_children` 의 `hp:sz` arm 에 `widthRelTo`/`heightRelTo` 추가.
  같은 파일 `:2925`/`:2928`(도형)·`:1702`/`:1706`(표)과 동형.
- 코퍼스의 해당 `hp:sz`(chart 0개, ole 1개)가 전부 `ABSOLUTE` 라 **기존 표본 무변화**.

### `heightRelTo` 정확-역 제약 유지
파서가 높이를 `parse_size_criterion(_, allow_column_para=false)`(`:1860`)로 읽어 치역이
`{Paper, Page, Absolute}` 3값뿐이므로 `height_criterion_str` 는 `Column`/`Para` 를
`ABSOLUTE` 로 접는다. 접지 않으면 되읽기에서 접혀 왕복이 비-멱등이 된다.
HWP5 측 `height_criterion_to_bits` 도 동일하게 접는다. **5값 전수 대조 테스트로 고정**했다.

---

## 검증

### RED → GREEN (실제 실행, 출력 캡처)

두 수정은 독립이므로 **각각 따로 되돌려** 개별 load-bearing 을 증명했다.

**RED 1 — 직렬화 수정만 되돌림**: `3 passed; 3 failed`
```
panicked at src\serializer\hwpx\section.rs:2437:13:
ellipse: 너비 기준 COLUMN 이 보존되어야 함: …<hp:sz width="4000" height="3000"
widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…

panicked at src\serializer\hwpx\section.rs:2469:9:
size_protect=false 여도 protect="0" 속성이 방출되어야 함: …<hp:sz width="0" height="0"
widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…

panicked at src\serializer\hwpx\section.rs:2506:13:
Paper → heightRelTo="PAPER" 이어야 함: …widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
```
**RED 1 에서도 통과한 3개 (공시)** — `issue2726_width_criterion_emits_all_five_values`
(헬퍼 직접 호출이라 포맷 리터럴을 타지 않음), 파서 테스트 2개(직렬화와 무관).

**RED 2 — 파서 수정만 되돌림**: `4 passed; 2 failed`
```
panicked at src\parser\hwpx\section.rs:7527:9:
assertion `left == right` failed: widthRelTo="COLUMN" 이 IR 에 적재되어야 한다
  left: Absolute
 right: Column

panicked at src\parser\hwpx\section.rs:7575:13:
assertion `left == right` failed: 너비는 COLUMN 를 그대로 보존해야 한다
  left: Absolute
 right: Column
```
**RED 2 에서도 통과한 4개 (공시)** — 직렬화 테스트 3개 + 헬퍼 테스트 1개. 전부 파서
경로를 타지 않는다. 두 수정이 서로 다른 결함을 덮고 있음의 증거이기도 하다.

**GREEN** — 두 수정 복원 후 `6 passed; 0 failed`.

### 신규 테스트 6종
| 테스트 | 확인 |
|---|---|
| `issue2726_common_shape_sz_preserves_criteria_and_protect` | 5개 태그 전부 `COLUMN`/`PAGE`/`protect="1"` 보존 |
| `issue2726_common_shape_sz_always_emits_protect_attribute` | `false` 여도 `protect="0"` **속성 방출**(150건 구조 이탈 대응) |
| `issue2726_height_criterion_never_emits_column_or_para` | 높이 5값 전수 → `COLUMN`/`PARA` 절대 미방출 |
| `issue2726_width_criterion_emits_all_five_values` | 너비 5값 전수 대조 |
| `issue2726_parse_chart_preserves_size_criteria` | 차트 `COLUMN`/`PAGE` → IR 적재 |
| `issue2726_parse_chart_height_folds_column_and_para_to_absolute` | 높이 접힘 + 너비 보존 |

### CI 3종 — 전부 통과
| 검사 | 결과 |
|---|---|
| 변경 `.rs` 2개 `rustfmt --edition 2021` → `git diff --name-only` | **빈 출력(clean)**, 2차 실행 md5 불변 |
| `cargo clippy --all-targets -- -D warnings` | **exit 0**, 경고 0건 |
| `cargo test --profile release-test --tests` | **exit 0** — 291 바이너리, **3486 passed / 0 failed / 23 ignored** |

`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 파일에 대해
`Incorrect newline style` 만 내고 diff 를 내지 않아 거짓 통과하므로 쓰지 않았다.

### 민감 테스트 무회귀 개별 확인
파서 변경이 OLE 파싱 경로를 건드리므로 `#1283` 계약을 개별 확인했다 —
`issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage`,
`issue_1283_hwpx_internal_ole_is_loaded_even_when_isembeded_zero`,
`issue_1283_hwpx_svg_uses_legacy_ole_chart_renderer`, `ole_chart_contents_*` 5개,
`issue_1251_svg_uses_legacy_ole_chart_renderer` — **9개 전부 통과**.
`issue_1436_*_round_trip_size_protect` 2개와 `test_parse_rect_preserves_size_protect` 도 통과.
시각 회귀(`visual_baseline_all_samples`, `visual_xfail_entries_still_fail`,
`svg_snapshot` 8종) 무변화.

---

## 미실행 항목

- **한글 실물 대조 없음.** 검증은 IR ↔ XML 계약 수준(단위 테스트)과 기존 회귀 스위트
  무변화까지다.
- **비-ABSOLUTE 크기 기준의 실물 표본 확보 실패.** 값 손실은 합성 IR/XML 로만 검증했다.
- **HWP5→HWPX→HWP5 바이트 왕복 실측 없음.** 해당 절은 코드 경로 확인이다.

## 잔여

1. **`render_equation`**(`serializer/hwpx/section.rs:2030`) — **완전히 동일한 결함**
   (`ABSOLUTE` 하드코딩 + `protect` 미방출). 코퍼스 `hp:equation` **60개(2파일,
   `protect` 60/60 존재)** 로 같은 구조 이탈이 있다. 수식 서브시스템이 별도 작업 중이라
   본 PR 에서 건드리지 않았다.
2. **헬퍼 3중화** — 본 PR 후 `table.rs`(private) · `shape.rs`(#2719, `pub(super)`) ·
   `section.rs`(본 PR) 3벌. 공용 위치 1벌 통합 필요. #2719 병합 전에는 `devel` 에서
   도달 가능한 사본이 없어 지금 통합 불가.
3. **OLE 직렬화측**(`shape.rs write_ole`) — #2719 소관. 본 PR 은 OLE 의 **파싱측**만 건드림.
4. **`hp:container` 등 나머지** — #2719 소관.

처리 결과 문서: `mydocs/report/task_m100_2726_report.md`
