### PR TITLE
[수식] EQEDIT attribute(HWPX lineMode)가 저장마다 CHAR 로 고정되던 유실 수정 (#2727)

### DIFF
--- a/mydocs/report/task_m100_2727_report.md
+++ b/mydocs/report/task_m100_2727_report.md
@@ -1,0 +1,298 @@
+# task_m100_2727 처리결과 보고서 — 수식 EQEDIT attribute(lineMode) 왕복 유실
+
+- **이슈**: [#2727](https://github.com/edwardkim/rhwp/issues/2727)
+- **브랜치**: `task/m100-2727-equation-lineMode` (base `devel` @ `49f38446`)
+- **범위**: `src/model/control.rs`, `src/parser/control.rs`, `src/serializer/control.rs`(수식 arm 한정),
+  `src/parser/hwpx/section.rs`, `src/serializer/hwpx/section.rs`, `src/serializer/hwpx/mod.rs`(테스트 픽스처),
+  `tests/issue_2727_equation_line_mode.rs`(신규)
+- **분류**: 결함 수정 (수식 속성 왕복 유실)
+
+## 1. 문제
+
+수식(`eqed`) 컨트롤의 자식 레코드 `HWPTAG_EQEDIT` 선두 UINT32(HWP5 스펙 표 105 attribute)가
+파서에서 버려지고 직렬화기에서 상수 `0` 으로 덮어써졌다.
+
+```rust
+// src/parser/control.rs:866 (정정 전)
+// attr: u32 (4바이트) — bit0: 스크립트 범위
+let _attr = r.read_u32().unwrap_or(0);      // 의미를 주석에 적어두고 버린다
+
+// src/serializer/control.rs:2393 (정정 전)
+// attr: u32
+w.write_u32(0).unwrap();                    // IR 이 없으므로 상수 0
+```
+
+이 UINT32 의 bit 0 은 HWPX `hp:equation@lineMode`(`LINE` / `CHAR`, OWPML 문서 문구
+"수식이 차지하는 범위")와 대응한다. HWPX 쪽도 같은 값이 양방향으로 끊겨 있었다.
+
+- `src/parser/hwpx/section.rs::parse_equation` 의 속성 match 에 `lineMode` arm 없음
+- `src/serializer/hwpx/section.rs::render_equation` 템플릿에 `lineMode` 속성 자체가 없음
+
+결과적으로 수식 범위 설정이 **HWP5→HWP5(편집 후) / HWP5→HWPX / HWPX→HWP5 / HWPX→HWPX 네
+경로 전부**에서 `CHAR`(0)로 초기화됐다.
+
+같은 EQEDIT 레코드 안에서 **스펙에 문서화조차 되어 있지 않은** `unknown: u16` 은 Task #1061 이
+IR 필드로 승격해 원본 그대로 왕복시키고 있었다. 문서화된 필드만 버리는 반대 방향 비대칭이었다.
+
+## 2. 분석
+
+### 2.1 패스스루가 가려주지 않는다
+
+| 층 | 판정 |
+|----|------|
+| `Equation::raw_ctrl_data` | **가리지 않음.** `CTRL_HEADER(eqed)` 의 ctrl_data 만 담는다. attribute 는 자식 레코드 `HWPTAG_EQEDIT` 안이고 EQEDIT 은 raw 필드가 없어 매번 IR 에서 재생성된다. 게다가 `adapt_equation`(`hwpx_to_hwp.rs`)과 `apply_equation_properties`(`object_ops/equation.rs:176`)가 이 필드를 명시적으로 `clear()` 한다. |
+| `Paragraph::ctrl_data_records[i]` | **가리지 않음.** `src/serializer/control.rs:98` 의 수식 arm 이 `ctrl_data_record` 인자를 아예 전달하지 않는다(Picture/Shape/Bookmark arm 은 받는다). 한컴 실측본의 `eqed` 자식은 EQEDIT 하나뿐이라 CTRL_DATA 자체가 없다. |
+| `Section::raw_stream` | **일부만 가린다.** 아무것도 건드리지 않은 HWP5→HWP5 복사에서는 원본 바이트가 그대로 재생돼 손실이 드러나지 않는다(실측 확인, 3.3 참조). 그러나 수식 관련 편집 API 는 모두 `section.raw_stream = None` 을 실행하고(`set_equation_properties_native`·`delete_equation_control_native`·`insert_equation_native`), HWPX 출력 경로는 raw_stream 을 참조하지 않는다. |
+| DocInfo `raw_stream_dirty` | 무관 (EQEDIT 은 BodyText). |
+
+### 2.2 의도된 상수인지 확인
+
+- `git log -S "bit0: 스크립트 범위" -- src/parser/control.rs` → `f0f7f1a4` (최초 커밋) 1건
+- `git log -S "serialize_equation_control" -- src/serializer/control.rs` → `f0f7f1a4` 1건
+
+둘 다 최초 커밋 이후 손대지 않은 코드이며, "0 으로 고정한다"는 계약을 설명하는 주석·정답지 대조
+기록이 없다. `adapt_equation:1204-1208` 의 bit 27(0x08000000) 보강처럼 정답지 근거가 남아 있는
+의도적 상수와는 성격이 다르다(그 코드는 이번 작업에서 손대지 않았다).
+
+### 2.3 근거 자료
+
+- OWPML 스키마 `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2189-2199` — `EquationType/@lineMode`,
+  `default="CHAR"`, enum `LINE|CHAR`, 문서 문구 "수식이 차지하는 범위."
+- `mydocs/tech/webhwp/05_other_controls.md:35-43` — 한컴 웹한글 역분석 기록의 수식 JSON 스키마에
+  `lm: lineMode // 줄 모드 (boolean)`, 임포트 코드 `e.qbn = h.lm ? 1 : 0`(불리언 1비트).
+- rhwp 자신의 파서 주석 `// attr: u32 (4바이트) — bit0: 스크립트 범위`.
+
+### 2.4 말뭉치 전수 조사
+
+`samples/**.hwpx` 중 `<hp:equation>` 포함 파일 전수:
+
+| 항목 | 값 |
+|------|-----|
+| 파일 수 | 19 |
+| `<hp:equation` 요소 총수 | 23,138 |
+| `lineMode` 명시 요소 수 | 23,138 (100%) |
+| 값 `CHAR` / `LINE` | 23,138 / 0 |
+
+한컴은 기본값이어도 예외 없이 이 속성을 기록한다. 말뭉치에 `LINE` 사례가 0건이라는 사실은 그대로
+밝힌다 — 본 결함은 **잠복 손실**이며, 정정해도 기존 23,138개 수식의 출력값은 `CHAR`/`0` 그대로다
+(3.4 회귀 실측).
+
+## 3. 변경
+
+### 3.1 코드
+
+| 파일 | 내용 |
+|------|------|
+| `src/model/control.rs` | `pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;` 신규. `Equation` 에 `pub attr: u32` 신규(UINT32 전체 보존 — bit0 외 비트도 유실시키지 않기 위함). 기본값 0 = OWPML `lineMode` 기본값 `CHAR`. |
+| `src/parser/control.rs:866` | `let _attr = ...` → `equation.attr = r.read_u32().unwrap_or(0);` |
+| `src/serializer/control.rs:2393` | `w.write_u32(0)` → `w.write_u32(eq.attr)` (수식 arm 한정, 3줄) |
+| `src/parser/hwpx/section.rs` | `parse_equation` 에 `b"lineMode"` arm 추가 — `LINE`(대소문자 무시)이면 bit0 set. `Equation` 생성 시 `attr: eq_attr`. |
+| `src/serializer/hwpx/section.rs` | `render_equation` 이 `baseUnit` 과 `font` 사이(한컴 저장본과 동일 자리)에 `lineMode="{LINE\|CHAR}"` 방출. |
+| `src/serializer/hwpx/mod.rs` | 기존 테스트 픽스처의 전량 초기화 리터럴에 `attr: 0,` 1줄 추가(컴파일 보정). |
+
+`hwpx_to_hwp.rs::adapt_equation` 은 변경 없음 — attribute 는 `common` 이 아니라 `Equation` 에 있고,
+그 함수가 지우는 것은 `raw_ctrl_data`(CTRL_HEADER)뿐이라 EQEDIT 재생성 경로에 그대로 실린다.
+
+### 3.2 테스트
+
+- `tests/issue_2727_equation_line_mode.rs` (신규 4건) — 한컴 실제 저장본
+  `samples/수식-문자처럼취급-아님.hwp` 를 입력으로,
+  1. `issue_2727_hwp5_line_mode_survives_roundtrip` — bit0 set 후 HWP5 직렬화→재파싱에서 보존
+  2. `issue_2727_hwpx_line_mode_survives_roundtrip` — HWPX 직렬화→재파싱에서 보존
+  3. `issue_2727_hancom_char_equation_stays_char` — 원본 CHAR 문서는 양 포맷 왕복 후에도 attr 0
+  4. `issue_2727_hancom_hwpx_char_parses_as_zero_bit` — 한컴 원본 HWPX `lineMode="CHAR"` → bit0 clear
+- `src/serializer/hwpx/section.rs::tests::equation_line_mode_reflects_ir` (신규 1건) —
+  `render_equation` 출력에 기본값도 `lineMode="CHAR"` 가 나오고, IR bit0 set 시
+  `baseUnit="1000" lineMode="LINE" font=""` 자리에 방출되는지 단언(선행 `equation_text_flow_reflects_ir` 패턴 정합).
+
+## 4. 검증
+
+### 4.1 red→green (실제 실행 캡처)
+
+정정 4곳(`parser/control.rs`, `serializer/control.rs`, `parser/hwpx/section.rs`,
+`serializer/hwpx/section.rs`)을 원상 복구한 뒤 실행했다(모델 필드는 컴파일을 위해 유지).
+
+**RED — 통합 테스트**
+
+```
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... FAILED
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... FAILED
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+failures:
+
+---- issue_2727_hwp5_line_mode_survives_roundtrip stdout ----
+thread 'issue_2727_hwp5_line_mode_survives_roundtrip' (40324) panicked at tests\issue_2727_equation_line_mode.rs:71:5:
+assertion `left == right` failed: EQEDIT attribute bit0(수식 범위 LINE)이 HWP5 왕복에서 보존돼야 한다. attr=0x00000000
+  left: 0
+ right: 1
+
+---- issue_2727_hwpx_line_mode_survives_roundtrip stdout ----
+thread 'issue_2727_hwpx_line_mode_survives_roundtrip' (36652) panicked at tests\issue_2727_equation_line_mode.rs:89:5:
+assertion `left == right` failed: HWPX lineMode="LINE" 이 왕복에서 보존돼야 한다. attr=0x00000000
+  left: 0
+ right: 1
+
+failures:
+    issue_2727_hwp5_line_mode_survives_roundtrip
+    issue_2727_hwpx_line_mode_survives_roundtrip
+
+test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+error: test failed, to rerun pass `--test issue_2727_equation_line_mode`
+```
+
+**RED — 단위 테스트**
+
+```
+running 1 test
+test serializer::hwpx::section::tests::equation_line_mode_reflects_ir ... FAILED
+
+failures:
+
+---- serializer::hwpx::section::tests::equation_line_mode_reflects_ir stdout ----
+thread 'serializer::hwpx::section::tests::equation_line_mode_reflects_ir' (14068) panicked at src\serializer\hwpx\section.rs:2365:9:
+기본값도 lineMode 속성을 방출해야 함(한컴 저장본 정합): <hp:equation id="0" zOrder="0" numberingType="EQUATION" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" instid="0" version="" baseLine="0" textColor="#000000" baseUnit="0" font=""><hp:script></hp:script>...
+
+failures:
+    serializer::hwpx::section::tests::equation_line_mode_reflects_ir
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.01s
+error: test failed, to rerun pass `--lib`
+```
+
+**GREEN — 복구 후 재실행**
+
+```
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+```
+
+```
+running 1 test
+test serializer::hwpx::section::tests::equation_line_mode_reflects_ir ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.00s
+```
+
+### 4.2 CLI 실측 — 정정 전
+
+한컴 원본 `samples/수식-문자처럼취급-아님.hwpx` 의 `lineMode="CHAR"` 한 곳만 `LINE` 으로 바꾼
+**조작 입력**(정답지가 아님)을 만들어 측정했다.
+
+```
+=== A) hwpx(LINE) -> export-hwpx ===
+<hp:equation id="1102112140" ... textColor="#000000" baseUnit="1600" font="HancomEQN">
+   → lineMode 속성 소실
+
+=== B) hwpx(LINE) -> convert -> hwp ===   (EQEDIT payload)
+  0000: 00 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+        ^^^^^^^^^^^ 01 00 00 00 이어야 하는데 0
+
+=== 정정 전 CLI: HWP5(attr=1) -> HWPX ===
+lineMode 출현 0회
+```
+
+또한 한컴 원본 `.hwp` 를 그대로 `export-hwpx` 하면 한컴이 쓰는 `lineMode="CHAR"` 가 출력에서
+빠져 있었다.
+
+### 4.3 CLI 실측 — 정정 후
+
+```
+=== A) hwpx(LINE) -> export-hwpx ===
+baseUnit="1600" lineMode="LINE" font="HancomEQN"
+
+=== B) hwpx(LINE) -> convert -> hwp ===
+  0000: 01 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+
+=== C) hwp(attr=1) -> convert -> hwp (HWP5 왕복) ===
+  0000: 01 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+
+=== D) hwp(attr=1) -> export-hwpx ===
+lineMode="LINE"
+```
+
+정직하게 밝히는 관찰: **손대지 않은 HWP5→HWP5 복사**(`convert a.hwp b.hwp`)는 `Section::raw_stream`
+패스스루가 원본 바이트를 그대로 재생하므로 정정 전에도 attribute 가 살아남는다. 손실이 실현되는 것은
+그 구역이 재직렬화될 때(수식 속성 변경·삽입·삭제 등 편집 API 가 `raw_stream = None` 을 실행한 뒤)이며,
+그 조건을 재현한 것이 4.1 의 RED 통합 테스트다(`set_first_equation_line_mode` 가 실제 편집 API 와
+동일하게 `section.raw_stream = None` 을 수행한다).
+
+### 4.4 회귀 실측 (말뭉치 무변경)
+
+```
+=== 한컴 원본 hwp -> hwpx ===            lineMode="CHAR"
+=== math-001.hwpx -> hwpx (수식 44개) ===  44 lineMode="CHAR"
+=== math-001.hwp EQEDIT attr ===         0000: 00 00 00 00 2A 00 20 00 ...
+```
+
+정정 후 CHAR 문서는 값이 그대로이며, 종전에 빠져 있던 `lineMode="CHAR"` 가 한컴과 같은 자리에
+추가로 방출된다(한컴 정합 방향).
+
+### 4.5 CI 3종
+
+| 검사 | 명령 | 결과 |
+|------|------|------|
+| clippy | `cargo clippy --all-targets -- -D warnings` | **통과** — `Finished dev profile ... in 1m 10s`, 경고 0 |
+| 테스트 | `cargo test --profile release-test --tests` | **통과** — 아래 4.6 |
+| fmt | 변경 `.rs` 전부 `rustfmt --edition 2021` 후 `git diff --name-only` | **통과** — 출력 없음 (커밋 상태 기준) |
+
+`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 파일에 대해 `Incorrect newline style`
+만 출력하고 diff 를 내지 않아 거짓 통과를 만들므로 사용하지 않았다.
+
+### 4.6 `cargo test --profile release-test --tests` 결과
+
+종료 코드 0. 테스트 바이너리 292개 집계:
+
+| 항목 | 수 |
+|------|-----|
+| passed | **3,485** |
+| failed | **0** |
+| ignored | 23 |
+| `FAILED` 문자열 출현 | 0 |
+
+- lib 단위 테스트: `test result: ok. 2465 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 9.29s`
+- 신규 통합 테스트:
+
+```
+     Running tests\issue_2727_equation_line_mode.rs
+
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## 5. 미실행 항목
+
+- **한컴 한글 시각 판정 없음.** 이 환경에 한컴 한글이 없어 정정 후 `.hwp`/`.hwpx` 를 한글에서 열어
+  수식 범위가 "줄 단위"로 보이는지 눈으로 확인하지 못했다. 검증은 바이트/XML 레벨과 왕복 IR 동등성에
+  한정된다.
+- **`LINE` 정답지 부재.** 말뭉치에 한컴이 만든 `lineMode="LINE"` 문서가 없어, LINE 값에 대한 검증은
+  조작 입력(4.2)과 IR 왕복 테스트로만 수행했다. `CHAR` 쪽은 한컴 원본 23,138건 기준 무변경을 확인했다.
+
+## 6. 잔여
+
+1. **`affectLSpacing` 전면 유실** — `CommonObjAttr` 에 대응 필드가 없고
+   `serializer/hwpx/section.rs:1913,2030`·`picture.rs:410`·`shape.rs:1004`·`table.rs:146` 이 모두
+   `"0"` 하드코딩이다. `samples/issue1949_giant_cell_nested_tables_perf.hwpx` 의 수식 18개 중 **5개가
+   `affectLSpacing="1"`** 이므로 실사례가 있는 실손실이다. 다만 공용 모델·공용 파서·공용 직렬화기를
+   함께 고쳐야 해서 이번 수식 전용 범위 밖으로 뒀다.
+2. **`allowOverlap` 하드코딩** — `render_equation` 이 `allowOverlap="0"` 고정. `common.allow_overlap`
+   은 이미 IR 필드다(말뭉치 내 수식은 전부 0 이라 잠복).
+3. **`<hp:script>` 자식 순서** — OWPML `EquationType` 은 `sz, pos, outMargin, caption, shapeComment,
+   metaTag, script` 순서를 요구하고 한컴 출력도 `script` 를 마지막에 둔다. rhwp 는 여는 태그 직후에
+   방출한다. 한컴 재적재 영향을 실측하지 못해 이번엔 건드리지 않았다.
+4. **HML 경로** — `src/parser/hml/reader.rs:695-703` 이 `BaseLine|BaseUnit|TextColor|Version|Font`
+   이외의 `EQUATION` 속성을 `UnsupportedEquationSemantics` 경고로 흘려보낸다. HML `LineMode` 매핑은
+   HML 파서·직렬화기 동시 변경이 필요하다.
+5. **수식 캡션** — 한컴 실측본의 `eqed` 자식에 `LIST_HEADER` 가 없어 이번 말뭉치에서는 확인 불가.

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -60,11 +60,23 @@ pub enum Control {
     Unknown(UnknownControl),
 }
 
+/// [#2727] `Equation::attr` 의 bit 0 — 수식이 차지하는 범위.
+///
+/// set = 줄 단위 (HWPX `lineMode="LINE"`), clear = 글자 단위 (`lineMode="CHAR"`).
+pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;
+
 /// 수식 ('eqed' 컨트롤, HWP 스펙 표 105)
 #[derive(Debug, Clone, Default)]
 pub struct Equation {
     /// 개체 공통 속성 (위치, 크기, 배치)
     pub common: CommonObjAttr,
+    /// [#2727] HWPTAG_EQEDIT 속성 (HWP5 spec 표 105 attribute, UINT32).
+    ///
+    /// bit 0 = 수식이 차지하는 범위 (0 = 글자 단위, 1 = 줄 단위) — HWPX
+    /// `hp:equation@lineMode` (`CHAR` / `LINE`) 와 대응한다. 나머지 비트는 의미
+    /// 미상이므로 UINT32 전체를 원본 그대로 보존해 왕복시킨다. 기본값 0 은
+    /// OWPML `lineMode` 기본값 `CHAR` 와 일치한다.
+    pub attr: u32,
     /// 수식 스크립트 ("1 over 2" 등)
     pub script: String,
     /// 글자 크기 (HWPUNIT)

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -863,7 +863,9 @@ fn parse_equation_control(ctrl_data: &[u8], child_records: &[Record]) -> Control
         let mut r = ByteReader::new(data);
 
         // attr: u32 (4바이트) — bit0: 스크립트 범위
-        let _attr = r.read_u32().unwrap_or(0);
+        // [#2727] 종전엔 읽고 버려 저장 시 0 으로 고정됐다. bit0 은 HWPX
+        // `lineMode`(CHAR/LINE) 와 대응하므로 UINT32 전체를 IR 로 보존한다.
+        equation.attr = r.read_u32().unwrap_or(0);
 
         // script: WCHAR 문자열 (길이 접두 UTF-16LE)
         if let Ok(script) = r.read_hwp_string() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -9,6 +9,7 @@ use quick_xml::Reader;
 use crate::model::control::{
     AutoNumber, AutoNumberType, Bookmark, CharOverlap, Control, Equation, Field, FieldType,
     FormObject, FormType, HiddenComment, NewNumber, PageHide, PageNumberPos, Ruby,
+    EQUATION_LINE_MODE_BIT,
 };
 use crate::model::document::{Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
@@ -5286,7 +5287,7 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
 }
 
 /// `<hp:equation>` 요소 (수식)를 파싱한다.
-/// 수식 속성(version, baseLine, textColor, baseUnit, font)과
+/// 수식 속성(version, baseLine, textColor, baseUnit, lineMode, font)과
 /// `<hp:script>` 하위 요소에서 수식 스크립트를 추출하여 `Control::Equation`을 생성한다.
 fn parse_equation(
     e: &quick_xml::events::BytesStart,
@@ -5302,6 +5303,9 @@ fn parse_equation(
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
     let mut font_name = String::new();
+    // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
+    // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
+    let mut eq_attr: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5311,6 +5315,14 @@ fn parse_equation(
             b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(0),
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
+            // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
+            b"lineMode" => {
+                if attr_str(&attr).eq_ignore_ascii_case("LINE") {
+                    eq_attr |= EQUATION_LINE_MODE_BIT;
+                } else {
+                    eq_attr &= !EQUATION_LINE_MODE_BIT;
+                }
+            }
             b"font" => font_name = attr_str(&attr),
             _ => {}
         }
@@ -5390,6 +5402,8 @@ fn parse_equation(
 
     let equation = Equation {
         common,
+        // [#2727] HWPX lineMode → EQEDIT attribute bit0
+        attr: eq_attr,
         script,
         font_size,
         color,

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2390,7 +2390,9 @@ fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Recor
     // HWPTAG_EQEDIT 자식 레코드
     let mut w = ByteWriter::new();
     // attr: u32
-    w.write_u32(0).unwrap();
+    // [#2727] 종전 상수 0 하드코딩 → IR 보존값 방출. bit0(수식 범위, HWPX lineMode)
+    // 이 저장마다 CHAR 로 초기화되던 손실 제거.
+    w.write_u32(eq.attr).unwrap();
     // script: HWP string (length-prefixed UTF-16LE)
     w.write_hwp_string(&eq.script).unwrap();
     // font_size: u32

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -559,6 +559,7 @@ mod tests {
                 horz_align: HorzAlign::Center,
                 ..Default::default()
             },
+            attr: 0,
             script: "x < y & z".to_string(),
             font_size: 1000,
             color: 0x000000FF,

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -23,7 +23,7 @@ use quick_xml::Writer;
 
 use crate::model::control::{
     AutoNumber, AutoNumberType, CharOverlap, Control, Equation, Field, NewNumber, PageHide,
-    PageNumberPos, Ruby,
+    PageNumberPos, Ruby, EQUATION_LINE_MODE_BIT,
 };
 use crate::model::document::{Document, Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
@@ -2026,8 +2026,17 @@ fn render_equation(eq: &Equation) -> String {
     // [#1594] holdAnchorAndSO 는 IR(prevent_page_break)을 보존(종전 "0" 하드코딩 제거).
     let hold = if c.prevent_page_break != 0 { "1" } else { "0" };
 
+    // [#2727] lineMode(수식이 차지하는 범위) 를 EQEDIT attribute bit0 에서 방출한다.
+    // 종전엔 속성 자체를 내보내지 않아 LINE 설정이 왕복마다 CHAR 로 되돌아갔다.
+    // 한컴 저장본과 동일하게 baseUnit 과 font 사이에 위치시킨다.
+    let line_mode = if eq.attr & EQUATION_LINE_MODE_BIT != 0 {
+        "LINE"
+    } else {
+        "CHAR"
+    };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),
@@ -2342,6 +2351,35 @@ mod tests {
         assert!(
             !xml.contains(r#"textFlow="BOTH_SIDES""#),
             "BOTH_SIDES 하드코딩 잔존 금지"
+        );
+    }
+
+    /// [Issue #2727] 수식의 lineMode(수식이 차지하는 범위)가 IR(EQEDIT attribute bit0)에서
+    /// 방출돼야 한다. 종전엔 속성 자체를 내보내지 않아 LINE 설정이 왕복마다 CHAR 로 돌아갔다.
+    /// 한컴 저장본은 값이 기본값(CHAR)이어도 예외 없이 baseUnit 과 font 사이에 기록한다.
+    #[test]
+    fn equation_line_mode_reflects_ir() {
+        use crate::model::control::{Equation, EQUATION_LINE_MODE_BIT};
+
+        let char_xml = render_equation(&Equation::default());
+        assert!(
+            char_xml.contains(r#"lineMode="CHAR""#),
+            "기본값도 lineMode 속성을 방출해야 함(한컴 저장본 정합): {char_xml}"
+        );
+
+        let eq = Equation {
+            attr: EQUATION_LINE_MODE_BIT,
+            font_size: 1000,
+            ..Default::default()
+        };
+        let line_xml = render_equation(&eq);
+        assert!(
+            line_xml.contains(r#"baseUnit="1000" lineMode="LINE" font="""#),
+            "lineMode 는 IR 값으로, 한컴과 같은 baseUnit·font 사이 자리에 와야 함: {line_xml}"
+        );
+        assert!(
+            !line_xml.contains(r#"lineMode="CHAR""#),
+            "CHAR 하드코딩 잔존 금지"
         );
     }
 

--- a/tests/issue_2727_equation_line_mode.rs
+++ b/tests/issue_2727_equation_line_mode.rs
@@ -1,0 +1,135 @@
+//! Issue #2727: 수식 EQEDIT attribute(UINT32) 왕복 보존 회귀 가드.
+//!
+//! 정정 전 동작:
+//! - `src/parser/control.rs::parse_equation_control` 이 EQEDIT 선두 UINT32 를
+//!   `let _attr = ...` 로 버렸다.
+//! - `src/serializer/control.rs::serialize_equation_control` 이 같은 자리에 상수 `0` 을 썼다.
+//! - `src/parser/hwpx/section.rs::parse_equation` 이 `lineMode` 를 읽지 않았고,
+//!   `src/serializer/hwpx/section.rs::render_equation` 이 `lineMode` 를 방출하지 않았다.
+//!
+//! 그 결과 수식의 "차지하는 범위"(HWP5 표 105 attribute bit0 = HWPX `lineMode`)가
+//! HWP5→HWP5 / HWP5→HWPX / HWPX→HWP5 / HWPX→HWPX 네 경로 전부에서 CHAR(0) 로 초기화됐다.
+//!
+//! 본 파일은 한컴이 만든 실제 저장본(`samples/수식-문자처럼취급-아님.hwp`)을 입력으로
+//! 삼아 (1) LINE 설정이 왕복에서 살아남는지, (2) 원본 CHAR 문서가 그대로 CHAR 로
+//! 남는지(정답지 무변경)를 동시에 단언한다.
+
+use rhwp::model::control::{Control, Equation, EQUATION_LINE_MODE_BIT};
+use rhwp::model::document::Document;
+use std::fs;
+use std::path::Path;
+
+const HANCOM_EQUATION_HWP: &str = "samples/수식-문자처럼취급-아님.hwp";
+
+fn load_hwp(rel: &str) -> Document {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    rhwp::parse_document(&bytes).unwrap_or_else(|e| panic!("parse {}: {:?}", rel, e))
+}
+
+fn first_equation(doc: &Document) -> &Equation {
+    doc.sections
+        .iter()
+        .flat_map(|s| &s.paragraphs)
+        .flat_map(|p| &p.controls)
+        .find_map(|c| match c {
+            Control::Equation(eq) => Some(eq.as_ref()),
+            _ => None,
+        })
+        .expect("문서에 수식 컨트롤이 있어야 한다")
+}
+
+fn set_first_equation_line_mode(doc: &mut Document) {
+    let mut done = false;
+    for section in &mut doc.sections {
+        // 원본 구역 스트림이 남아 있으면 직렬화기가 원본 바이트를 그대로 되돌려주므로
+        // IR 편집이 저장에 반영되지 않는다. 실제 편집 API(set_equation_properties_native 등)
+        // 와 동일하게 패스스루를 무효화한다.
+        section.raw_stream = None;
+        for para in &mut section.paragraphs {
+            for ctrl in &mut para.controls {
+                if let Control::Equation(eq) = ctrl {
+                    eq.attr |= EQUATION_LINE_MODE_BIT;
+                    done = true;
+                }
+            }
+        }
+    }
+    assert!(done, "수식 컨트롤을 찾지 못했다");
+}
+
+/// HWP5 → HWP5: 수식 범위 LINE(attribute bit0)이 저장·재적재 후에도 남아야 한다.
+#[test]
+fn issue_2727_hwp5_line_mode_survives_roundtrip() {
+    let mut doc = load_hwp(HANCOM_EQUATION_HWP);
+    set_first_equation_line_mode(&mut doc);
+
+    let bytes = rhwp::serialize_document(&doc).expect("HWP5 직렬화");
+    let re_doc = rhwp::parse_document(&bytes).expect("HWP5 재파싱");
+
+    let eq = first_equation(&re_doc);
+    assert_eq!(
+        eq.attr & EQUATION_LINE_MODE_BIT,
+        EQUATION_LINE_MODE_BIT,
+        "EQEDIT attribute bit0(수식 범위 LINE)이 HWP5 왕복에서 보존돼야 한다. attr=0x{:08X}",
+        eq.attr
+    );
+}
+
+/// HWP5 → HWPX → IR: `lineMode="LINE"` 로 방출되고 다시 bit0 으로 읽혀야 한다.
+#[test]
+fn issue_2727_hwpx_line_mode_survives_roundtrip() {
+    let mut doc = load_hwp(HANCOM_EQUATION_HWP);
+    set_first_equation_line_mode(&mut doc);
+
+    let bytes = rhwp::serializer::hwpx::serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let re_doc = rhwp::parser::hwpx::parse_hwpx(&bytes).expect("HWPX 재파싱");
+
+    let eq = first_equation(&re_doc);
+    assert_eq!(
+        eq.attr & EQUATION_LINE_MODE_BIT,
+        EQUATION_LINE_MODE_BIT,
+        "HWPX lineMode=\"LINE\" 이 왕복에서 보존돼야 한다. attr=0x{:08X}",
+        eq.attr
+    );
+}
+
+/// 한컴 원본(수식 범위 CHAR)은 정정 후에도 CHAR 그대로여야 한다 — 말뭉치 무변경 보장.
+#[test]
+fn issue_2727_hancom_char_equation_stays_char() {
+    let doc = load_hwp(HANCOM_EQUATION_HWP);
+    assert_eq!(
+        first_equation(&doc).attr,
+        0,
+        "한컴 원본 EQEDIT attribute 는 0(CHAR)이어야 한다"
+    );
+
+    let hwp_bytes = rhwp::serialize_document(&doc).expect("HWP5 직렬화");
+    let hwp_doc = rhwp::parse_document(&hwp_bytes).expect("HWP5 재파싱");
+    assert_eq!(
+        first_equation(&hwp_doc).attr,
+        0,
+        "CHAR 수식은 HWP5 왕복 후에도 attribute 0 이어야 한다"
+    );
+
+    let hwpx_bytes = rhwp::serializer::hwpx::serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let hwpx_doc = rhwp::parser::hwpx::parse_hwpx(&hwpx_bytes).expect("HWPX 재파싱");
+    assert_eq!(
+        first_equation(&hwpx_doc).attr,
+        0,
+        "CHAR 수식은 HWPX 왕복 후에도 attribute 0 이어야 한다"
+    );
+}
+
+/// 한컴 원본 HWPX(`lineMode="CHAR"`)를 그대로 읽으면 bit0 이 서지 않아야 한다.
+#[test]
+fn issue_2727_hancom_hwpx_char_parses_as_zero_bit() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/수식-문자처럼취급-아님.hwpx");
+    let bytes = fs::read(&path).expect("한컴 원본 HWPX 읽기");
+    let doc = rhwp::parser::hwpx::parse_hwpx(&bytes).expect("HWPX 파싱");
+    assert_eq!(
+        first_equation(&doc).attr & EQUATION_LINE_MODE_BIT,
+        0,
+        "lineMode=\"CHAR\" 는 bit0 clear 여야 한다"
+    );
+}


### PR DESCRIPTION
이슈 #2727 처리.

## 무엇이 문제였나

수식(`eqed`)의 자식 레코드 `HWPTAG_EQEDIT` 선두 UINT32(HWP5 표 105 attribute)가 파서에서 버려지고
직렬화기에서 상수 `0` 으로 덮어써졌다.

```rust
// src/parser/control.rs:866 (정정 전)
// attr: u32 (4바이트) — bit0: 스크립트 범위
let _attr = r.read_u32().unwrap_or(0);      // 의미를 주석에 적어두고 버린다

// src/serializer/control.rs:2393 (정정 전)
w.write_u32(0).unwrap();                    // IR 이 없으므로 상수 0
```

이 bit 0 은 HWPX `hp:equation@lineMode`(`LINE`/`CHAR`, OWPML 문구 "수식이 차지하는 범위")와 대응한다.
HWPX 쪽도 양방향으로 끊겨 있었다 — `parse_equation` 에 `lineMode` arm 이 없고, `render_equation`
템플릿에는 속성 자체가 없다.

결과: 수식 범위 설정이 **HWP5→HWP5(편집 후) / HWP5→HWPX / HWPX→HWP5 / HWPX→HWPX 네 경로 전부**에서
`CHAR`(0)로 초기화됐다. 같은 레코드에서 스펙에 문서화조차 없는 `unknown: u16` 은 #1061 이 IR 로 승격해
원본 그대로 왕복시키고 있는데, 문서화된 필드만 버리는 반대 방향 비대칭이었다.

## 패스스루 확인

- `Equation::raw_ctrl_data` — CTRL_HEADER ctrl_data 전용. attribute 는 자식 레코드 EQEDIT 안이며
  EQEDIT 은 raw 필드가 없어 매번 IR 에서 재생성된다. `adapt_equation`·`apply_equation_properties` 는
  이 필드를 오히려 `clear()` 한다.
- `Paragraph::ctrl_data_records[i]` — `src/serializer/control.rs:98` 의 수식 arm 이 이 인자를 아예
  전달하지 않는다. 한컴 실측본의 `eqed` 자식은 EQEDIT 하나뿐이라 CTRL_DATA 자체가 없다.
- `Section::raw_stream` — **일부만 가린다.** 손대지 않은 HWP5→HWP5 복사는 원본 바이트가 재생돼 손실이
  드러나지 않는다(실측 확인). 그러나 `set_equation_properties_native`·`delete_equation_control_native`·
  `insert_equation_native` 가 모두 `raw_stream = None` 을 실행하고, HWPX 출력 경로는 raw_stream 을
  참조하지 않는다.

## 의도된 상수가 아님

`git log -S "bit0: 스크립트 범위" -- src/parser/control.rs`, `git log -S "serialize_equation_control"
-- src/serializer/control.rs` 모두 최초 커밋 `f0f7f1a4` 1건. 계약 설명 주석·정답지 대조 기록이 없다.
`adapt_equation` 의 bit 27 보강처럼 근거가 남아 있는 의도적 상수와는 성격이 다르며, 그 코드는 손대지
않았다.

## 변경

| 파일 | 내용 |
|------|------|
| `src/model/control.rs` | `EQUATION_LINE_MODE_BIT` 상수 + `Equation::attr: u32` 신규(bit0 만이 아니라 UINT32 전체 보존). 기본값 0 = OWPML `lineMode` 기본값 `CHAR`. |
| `src/parser/control.rs` | `let _attr = ...` → `equation.attr = ...` |
| `src/serializer/control.rs` | 수식 arm 한정 3줄 — `w.write_u32(0)` → `w.write_u32(eq.attr)` |
| `src/parser/hwpx/section.rs` | `parse_equation` 에 `lineMode` arm(대소문자 무시) |
| `src/serializer/hwpx/section.rs` | `render_equation` 이 한컴과 같은 자리(`baseUnit`↔`font`)에 `lineMode` 방출 + 단위 테스트 |
| `src/serializer/hwpx/mod.rs` | 기존 테스트 픽스처 전량 초기화 리터럴에 `attr: 0,` 1줄(컴파일 보정) |
| `tests/issue_2727_equation_line_mode.rs` | 신규 통합 테스트 4건 |

`hwpx_to_hwp.rs::adapt_equation` 은 변경 없음(attribute 는 `common` 이 아니라 `Equation` 에 있고,
그 함수가 지우는 것은 `raw_ctrl_data` 뿐이라 EQEDIT 재생성 경로에 그대로 실린다).

### bit0 ↔ lineMode 매핑 근거와 안전성

- rhwp 파서의 기존 주석 `// attr: u32 (4바이트) — bit0: 스크립트 범위`
- OWPML `EquationType/@lineMode` 문서 문구 "수식이 차지하는 범위", `default="CHAR"`, enum `LINE|CHAR`
- `mydocs/tech/webhwp/05_other_controls.md:35-43` — 한컴 웹한글 수식 JSON 의 `lm: lineMode`(boolean),
  임포트 코드 `e.qbn = h.lm ? 1 : 0`

설령 이 비트 대응이 틀렸다 해도 HWP5↔HWP5 는 UINT32 전체를 원본 그대로 왕복시키므로 충실도가
떨어지지 않는다. HWPX 쪽은 한컴이 100% 기록하는 속성을 rhwp 도 기록하게 되는 변화이며, 말뭉치
23,138건의 값은 그대로다.

## 검증

### red→green (실제 실행 캡처)

정정 4곳을 원상 복구한 뒤 실행.

**RED**

```
running 4 tests
test issue_2727_hwp5_line_mode_survives_roundtrip ... FAILED
test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
test issue_2727_hwpx_line_mode_survives_roundtrip ... FAILED
test issue_2727_hancom_char_equation_stays_char ... ok

---- issue_2727_hwp5_line_mode_survives_roundtrip stdout ----
assertion `left == right` failed: EQEDIT attribute bit0(수식 범위 LINE)이 HWP5 왕복에서 보존돼야 한다. attr=0x00000000
  left: 0
 right: 1

---- issue_2727_hwpx_line_mode_survives_roundtrip stdout ----
assertion `left == right` failed: HWPX lineMode="LINE" 이 왕복에서 보존돼야 한다. attr=0x00000000
  left: 0
 right: 1

test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
```

```
test serializer::hwpx::section::tests::equation_line_mode_reflects_ir ... FAILED
기본값도 lineMode 속성을 방출해야 함(한컴 저장본 정합): <hp:equation ... baseUnit="0" font="">...
test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.01s
```

**GREEN**

```
test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.00s
```

### CLI 실측

한컴 원본 `samples/수식-문자처럼취급-아님.hwpx` 의 `lineMode="CHAR"` 한 곳만 `LINE` 으로 바꾼
**조작 입력**(정답지 아님) 기준.

| 경로 | 정정 전 | 정정 후 |
|------|---------|---------|
| hwpx(LINE) → `export-hwpx` | `lineMode` 속성 소실 | `baseUnit="1600" lineMode="LINE" font="HancomEQN"` |
| hwpx(LINE) → `convert` → hwp | EQEDIT `00 00 00 00` | `01 00 00 00` |
| hwp(attr=1) → `convert` → hwp | — | `01 00 00 00` 유지 |
| hwp(attr=1) → `export-hwpx` | `lineMode` 출현 0회 | `lineMode="LINE"` |

한컴 원본 `.hwp` 를 그대로 `export-hwpx` 했을 때도 정정 전에는 한컴이 쓰는 `lineMode="CHAR"` 가
출력에서 빠져 있었다.

### 회귀 (말뭉치 무변경)

`samples/**.hwpx` 중 수식 포함 19 파일, `<hp:equation>` **23,138개 전부** `lineMode` 명시 · 값 전부
`CHAR`. 정정 후에도 값은 그대로이며, 종전에 빠져 있던 `lineMode="CHAR"` 가 한컴과 같은 자리에 추가로
방출된다.

```
한컴 원본 hwp -> hwpx            : lineMode="CHAR"
math-001.hwpx -> hwpx (수식 44개) : 44 lineMode="CHAR"
math-001.hwp EQEDIT attr         : 0000: 00 00 00 00 2A 00 20 00 ...
```

### CI 3종

| 검사 | 명령 | 결과 |
|------|------|------|
| clippy | `cargo clippy --all-targets -- -D warnings` | 통과 — 경고 0 (`Finished dev profile ... in 1m 10s`) |
| 테스트 | `cargo test --profile release-test --tests` | 통과 — 종료 코드 0, 테스트 바이너리 292개, **3,485 passed / 0 failed / 23 ignored** (lib 단위 `2465 passed; 0 failed; 7 ignored`) |
| fmt | 변경 `.rs` 전부 `rustfmt --edition 2021` 후 `git diff --name-only` | 통과 — 출력 없음 |

`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 파일에 `Incorrect newline style` 만
출력하고 diff 를 내지 않아 거짓 통과를 만들므로 쓰지 않았다.

## 밝혀두는 한계

- 이 환경에 한컴 한글이 없어 **시각 판정을 하지 못했다.** 검증은 바이트/XML 레벨과 왕복 IR 동등성에
  한정된다.
- 말뭉치에 한컴이 만든 `lineMode="LINE"` 문서가 없다. LINE 값 검증은 위 조작 입력과 IR 왕복 테스트로만
  수행했고, `CHAR` 쪽은 한컴 원본 23,138건 무변경을 확인했다.

## 범위 밖 (잔여)

1. `affectLSpacing` 이 수식·그림·도형·표 전부 `"0"` 하드코딩이고 `CommonObjAttr` 에 대응 필드가 없다.
   `samples/issue1949_giant_cell_nested_tables_perf.hwpx` 의 수식 18개 중 5개가 `affectLSpacing="1"`
   이라 실사례가 있는 실손실이지만, 공용 모델·파서·직렬화기를 함께 고쳐야 해 분리한다.
2. `render_equation` 의 `allowOverlap="0"` 하드코딩(`common.allow_overlap` 은 이미 IR 필드).
3. `<hp:script>` 자식 순서 — OWPML `EquationType` 과 한컴 출력은 `script` 를 마지막에 두는데 rhwp 는
   여는 태그 직후에 방출한다. 한컴 재적재 영향을 실측하지 못해 이번엔 건드리지 않았다.
4. HML `LineMode` 매핑(`src/parser/hml/reader.rs` 가 현재 `UnsupportedEquationSemantics` 경고 처리).

처리결과 보고서: `mydocs/report/task_m100_2727_report.md`

Closes #2727
