### PR TITLE
fix(hwpx): hp:pic 저장 시 numberingType·groupLevel 속성 유실 수정 (#2745)

### DIFF
--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -72,4 +72,4 @@ if let Some(ref caption) = $shape.$caption_field {
 
 ## PR 번호
 
-PR #(PR 생성 후 번호 기입)
+PR #2737

--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -1,0 +1,75 @@
+# PR: 그리기 도형·묶음·차트 캡션이 HWP5 직렬화에서 전량 소실
+
+## 개요
+
+HWP5 직렬화기(`serialize_shape_control`)에서 도형(ShapeObject)의 모든 variant에 대해
+캡션(caption)을 방출하지 않던 문제를 수정.
+
+## 분석
+
+### 파서 상태
+
+`src/parser/control/shape.rs`의 파서는 모든 GSO 도형의 캡션을 올바르게 읽고 있음:
+
+- 기본 도형(Line, Rectangle, Ellipse, Arc, Polygon, Curve): `drawing.caption`에 저장
+- 묶음(Group): `group.caption`에 저장  
+- 차트(Chart): `chart.caption`에 저장
+- OLE: `ole.caption`에 저장
+- 그림(Picture): `picture.caption`에 저장 (별도 함수 `serialize_picture_control`에서 처리)
+
+### 직렬화 문제
+
+`src/serializer/control.rs`에서 `serialize_caption` 호출은 다음 두 곳뿐이었음:
+
+1. 표(`serialize_table_control`, 492행)  
+2. 그림(`serialize_picture_control`, 998행)
+
+`serialize_shape_control`(1181행-)의 모든 arm에는 `serialize_caption` 호출이 전혀 없어,
+도형에 첨부된 캡션이 HWP5 저장 시 전량 소실됨.
+
+### 적용 범위 (9개 ShapeObject variant)
+
+| Variant | 캡션 위치 | 직렬화 위치 (SHAPE_COMPONENT 이전) |
+|---------|-----------|-----------------------------------|
+| Line | `line.drawing.caption` | CTRL_HEADER + synthesized_ctrl_data 이후 |
+| Rectangle | `rect.drawing.caption` | 동일 |
+| Ellipse | `ellipse.drawing.caption` | 동일 |
+| Polygon | `poly.drawing.caption` | 동일 |
+| Arc | `arc.drawing.caption` | 동일 |
+| Curve | `curve.drawing.caption` | 동일 |
+| Group | `group.caption` (직접 필드) | 동일 |
+| Chart | `chart.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+| Ole | `ole.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+
+### 배치 패턴
+
+기존 그림(`serialize_picture_control`)의 캡션 배치와 동일하게:
+1. CTRL_HEADER (`level`)
+2. 캡션 (`level + 1`, LIST_HEADER + 문단)
+3. SHAPE_COMPONENT (`level + 1`)
+4. CTRL_DATA (`level + 2`, SHAPE_COMPONENT의 자식)
+5. 텍스트 박스 및 도형별 레코드 (`level + 2`)
+
+## 코드 변경
+
+**파일**: `src/serializer/control.rs`
+**추가된 호출**: 9개의 `serialize_caption` 호출 (각 ShapeObject arm당 1개)
+
+각 호출 패턴:
+```rust
+// 캡션 (SHAPE_COMPONENT 앞, level+1)
+if let Some(ref caption) = $shape.$caption_field {
+    serialize_caption(caption, level + 1, records);
+}
+```
+
+## 검증
+
+- `cargo check` 통과
+- `cargo fmt --all` 적용 완료
+- 기존 파서-직렬화 라운드트립 검증: 파서가 읽은 캡션을 직렬화가 방출하므로
+  라운드트립 보존 (기존 파서 변경 없음)
+
+## PR 번호
+
+PR #(PR 생성 후 번호 기입)

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -43,3 +43,4 @@ rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자�
 
 - #2697 — 표 hp:sz IR 보존
 - #2712 — rect/line/picture hp:sz IR 보존
+- #2733 — 본 PR

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -1,0 +1,45 @@
+# PR: fix(hwpx): 공용 도형 경로 hp:sz 크기 기준·크기 보호 소실 (ellipse/arc/polygon/curve/chart)
+
+## 개요
+
+Issue #2726. #2697(표)과 #2712(rect/line/picture)에서 해결된 hp:sz의
+widthRelTo/heightRelTo/protect IR 보존이 나머지 도형 타입(ellipse, arc, polygon, curve,
+chart)에서 여전히 hardcoded "ABSOLUTE"/"0"으로 방출되는 문제를 수정한다.
+
+## 분석
+
+`src/serializer/hwpx/shape.rs`의 `write_sz()` 함수(978~992번째 줄)는 `CommonObjAttr`의
+`width_criterion`, `height_criterion`, `size_protect` 필드를 무시하고 항상
+`widthRelTo="ABSOLUTE"`, `heightRelTo="ABSOLUTE"`, `protect="0"`을 방출했다.
+
+이 함수는 다음과 같은 모든 도형 타입에서 공통으로 호출된다:
+- `<hp:rect>` — write_rect (103번째 줄)
+- `<hp:line>` / `<hp:connectLine>` — write_line (250번째 줄)
+- `<hp:container>` — write_container_close (321번째 줄)
+- `<hp:ole>` — write_ole (390번째 줄)
+
+rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자체를 수정하면
+모든 도형 타입이 한 번에 fix된다. ole는 chart/ole 개체를 포함한다.
+
+## 변경 내용
+
+**`src/serializer/hwpx/shape.rs`**
+
+1. `SizeCriterion` import 추가
+2. `size_criterion_width_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column→COLUMN, Para→PARA, Absolute→ABSOLUTE)
+3. `size_criterion_height_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column/Para/Absolute→ABSOLUTE; 파서가 높이는 allow_column_para=false로 읽으므로
+   Column/Para는 존재하지 않지만 fallback으로 ABSOLUTE)
+4. `write_sz()` — hardcoded "ABSOLUTE"/"0" 대신 위 헬퍼 함수와
+   `bool01(c.size_protect)` 사용
+
+## 검증
+
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과 (45.04s)
+
+## 관련 PR
+
+- #2697 — 표 hp:sz IR 보존
+- #2712 — rect/line/picture hp:sz IR 보존

--- a/mydocs/report/pr-hwpx-pic-attrs.md
+++ b/mydocs/report/pr-hwpx-pic-attrs.md
@@ -1,0 +1,44 @@
+# hp:pic 저장 시 numberingType·groupLevel 속성 유실 수정
+
+- **Issue**: #2745
+- **Branch**: `pr/fix-issue-2745-hwpx-pic-attrs`
+- **Type**: fix
+- **Component**: serializer/hwpx, parser/hwpx
+
+## 배경
+
+HWPX 그림(`<hp:pic>`) 직렬화에서 `numberingType`과 `groupLevel` 두 속성이 IR 값을 사용하지 않고 하드코딩되어 방출되어, 저장 시 원본 속성이 유실되는 문제가 있었다. 도형(`<hp:rect>`, `<hp:line>`) 및 표(`<hp:tbl>`)는 이미 #1379/#2697에서 IR 보존으로 정리되었으나 그림 경로는 누락되었다.
+
+## 수정 내용
+
+### 1. Parser: `numberingType` 속성 파싱 추가
+
+**파일**: `src/parser/hwpx/section.rs` - `parse_picture` 함수
+
+기존 `parse_picture`는 `<hp:pic>` 요소의 `numberingType` 속성을 파싱하지 않아 IR의 `common.numbering_type`이 항상 기본값(`None`)으로 남았다. 도형/표 파서와 동일한 매핑 로직을 추가하여 `PICTURE`/`TABLE`/`EQUATION`/`NONE` 값을 IR에 저장한다.
+
+```rust
+b"numberingType" => {
+    common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+        "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+        "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+        "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+        _ => crate::model::shape::ObjectNumberingType::None,
+    };
+}
+```
+
+### 2. Serializer: IR 기반 속성 방출
+
+**파일**: `src/serializer/hwpx/picture.rs` - `write_picture` 함수
+
+- `numberingType`: 하드코딩 `"PICTURE"` → `numbering_type_str(pic.common.numbering_type)` (shape.rs의 기존 헬퍼 함수 사용)
+- `groupLevel`: 하드코딩 `"0"` → `pic.shape_attr.group_level.to_string()` (도형 rect/line 경로와 동일)
+- `numbering_type_str` 함수 import 추가
+
+## 영향
+
+- `groupLevel` 속성: 그룹(`<hp:container>`) 내 그림 개체의 중첩 레벨이 저장 시 보존된다.
+- `numberingType` 속성: 캡션 번호 범주 설정(NONE/PICTURE/TABLE/EQUATION)이 저장 시 보존된다.
+- roundtrip 충실도 향상: 이전에는 저장 후 재파싱 시 두 속성이 항상 기본값으로 되돌아갔다.
+- 신규 문서(Default::default)는 `common.numbering_type=ObjectNumberingType::None`이므로 `numberingType="NONE"`으로 방출되어, 종전 `"PICTURE"` 하드코딩과 차이가 있다. 이는 올바른 동작이다(도형 경로와 일관됨).

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -77,6 +77,10 @@ pub struct Equation {
     /// HWP5 spec 표 105 에 누락되어 있으나 한컴 실제 저장본에 baseline 과 version_info
     /// 사이에 UINT16 zero 가 위치. Task #1061 발견.
     pub unknown: u16,
+    /// EQEDIT 속성 (UINT32, HWPTAG_EQEDIT 첫 필드).
+    /// bit 0: lineMode (0=글자 단위/CHAR, 1=줄 단위/LINE).
+    /// 종전엔 파싱 후 버려지고 저장 시 0으로 고정되어 lineMode 유실. Issue #2727.
+    pub eqedit: u32,
     /// 버전 정보
     pub version_info: String,
     /// 수식 글꼴명

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -862,8 +862,8 @@ fn parse_equation_control(ctrl_data: &[u8], child_records: &[Record]) -> Control
         let data = &eq_rec.data;
         let mut r = ByteReader::new(data);
 
-        // attr: u32 (4바이트) — bit0: 스크립트 범위
-        let _attr = r.read_u32().unwrap_or(0);
+        // attr: u32 (4바이트) — bit0: lineMode (0=글자단위/CHAR, 1=줄단위/LINE)
+        equation.eqedit = r.read_u32().unwrap_or(0);
 
         // script: WCHAR 문자열 (길이 접두 UTF-16LE)
         if let Ok(script) = r.read_hwp_string() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2301,6 +2301,17 @@ fn parse_picture(
                 }
             }
             b"groupLevel" => shape_attr.group_level = attr_str(&attr).parse().unwrap_or(0),
+            // [#2697 동형] numberingType (캡션 번호 범주) 보존 — 도형·표·그림 공통 속성.
+            // 종전 미파싱으로 그림에 번호 범주를 NONE 등으로 변경한 HWPX에서 IR 기본값(None)으로
+            // 떨어져 왕복 시 "PICTURE"로 강제복원되던 결함을 수정한다.
+            b"numberingType" => {
+                common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
             _ => {}
         }
     }
@@ -5302,6 +5313,7 @@ fn parse_equation(
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
     let mut font_name = String::new();
+    let mut eqedit: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5312,6 +5324,12 @@ fn parse_equation(
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
             b"font" => font_name = attr_str(&attr),
+            b"lineMode" => {
+                eqedit = match attr_str(&attr).as_str() {
+                    "LINE" => 0x01,
+                    _ => 0x00,
+                };
+            }
             _ => {}
         }
     }
@@ -5395,6 +5413,7 @@ fn parse_equation(
         color,
         baseline,
         unknown: 0,
+        eqedit,
         font_name,
         version_info,
         raw_ctrl_data: Vec::new(),

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1192,6 +1192,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&line.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = line.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1237,6 +1241,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&rect.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = rect.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1266,6 +1274,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&ellipse.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = ellipse.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1308,6 +1320,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&poly.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = poly.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1345,6 +1361,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&arc.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = arc.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1375,6 +1395,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&curve.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = curve.drawing.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1408,6 +1432,10 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&group.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = group.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             // 그룹 컨테이너: SHAPE_COMPONENT + 자식 수 + 자식 ctrl_id 목록 (한컴 호환)
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
@@ -1439,6 +1467,10 @@ fn serialize_shape_control(
                 level,
                 &serialize_common_obj_attr(&chart.common),
             ));
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = chart.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             let sc_ctrl_id = chart.drawing.shape_attr.ctrl_id;
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
@@ -1461,6 +1493,10 @@ fn serialize_shape_control(
                 level,
                 &serialize_common_obj_attr(&ole.common),
             ));
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = ole.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             let drawing = ole_drawing_with_shape_component_contract(ole, true);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
@@ -2389,8 +2425,8 @@ fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Recor
 
     // HWPTAG_EQEDIT 자식 레코드
     let mut w = ByteWriter::new();
-    // attr: u32
-    w.write_u32(0).unwrap();
+    // attr: u32 — bit0: lineMode (0=CHAR, 1=LINE)
+    w.write_u32(eq.eqedit).unwrap();
     // script: HWP string (length-prefixed UTF-16LE)
     w.write_hwp_string(&eq.script).unwrap();
     // font_size: u32

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -564,6 +564,7 @@ mod tests {
             color: 0x000000FF,
             baseline: 120,
             unknown: 0,
+            eqedit: 0,
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -36,6 +36,7 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
+use super::shape::numbering_type_str;
 use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
@@ -59,6 +60,13 @@ pub fn write_picture<W: Write>(
     let tf = text_flow_str(pic.common.text_flow);
     let instid = pic.instance_id.to_string();
     let href = pic.href.as_deref().unwrap_or("");
+    // [#2697 동형] numberingType 은 IR(common.numbering_type)을 보존한다. 종전 "PICTURE"
+    // 하드코딩은 그림에 번호 범주를 변경한(예: NONE) 문서에서 저장 시 원본 속성이 유실됐다.
+    // 도형·표 계열은 이미 #1379/#2697 에서 IR 보존으로 정리됐다.
+    let numbering_type = numbering_type_str(pic.common.numbering_type);
+    // [#TODO-IR] groupLevel 은 IR(shape_attr.group_level)을 보존한다. 종전 "0" 하드코딩은
+    // 그룹 내 그림 개체의 중첩 레벨이 저장 시 유실됐다(shape.rs rect/line 경로는 이미 보존).
+    let group_level = pic.shape_attr.group_level.to_string();
 
     start_tag_attrs(
         w,
@@ -66,13 +74,13 @@ pub fn write_picture<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "PICTURE"),
+            ("numberingType", &numbering_type),
             ("textWrap", tw),
             ("textFlow", tf),
             ("lock", "0"),
             ("dropcapstyle", "None"),
             ("href", href),
-            ("groupLevel", "0"),
+            ("groupLevel", &group_level),
             ("instid", &instid),
             ("reverse", "0"),
         ],

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2026,8 +2026,15 @@ fn render_equation(eq: &Equation) -> String {
     // [#1594] holdAnchorAndSO 는 IR(prevent_page_break)을 보존(종전 "0" 하드코딩 제거).
     let hold = if c.prevent_page_break != 0 { "1" } else { "0" };
 
+    // [#2727] lineMode — EQEDIT attr bit 0 (0=CHAR, 1=LINE)
+    let line_mode = if eq.eqedit & 0x01 != 0 {
+        "LINE"
+    } else {
+        "CHAR"
+    };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}" lineMode="{line_mode}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -20,8 +20,8 @@ use quick_xml::Writer;
 
 use crate::model::shape::{
     CommonObjAttr, DrawingObjAttr, HorzAlign, HorzRelTo, LineShape, ObjectNumberingType,
-    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, TextBox, TextFlow, TextWrap,
-    VertAlign, VertRelTo,
+    OleDrawingAspect, OleShape, RectangleShape, ShapeComponentAttr, SizeCriterion, TextBox,
+    TextFlow, TextWrap, VertAlign, VertRelTo,
 };
 use crate::model::style::{Fill, FillType, ImageFillMode, ShapeBorderLine, SolidFill};
 use crate::model::ColorRef;
@@ -978,17 +978,44 @@ pub(super) fn write_shape_comment<W: Write>(
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
     let width = c.width.to_string();
     let height = c.height.to_string();
+    // [#2697/#2712] widthRelTo/heightRelTo/protect 는 IR 을 보존한다. 종전
+    // "ABSOLUTE"/"0" 하드코딩은 파서가 이미 읽어 둔 값(width_criterion/height_criterion/
+    // size_protect)을 저장 때 버려, 단/쪽/문단에 맞춘 도형이 절대값으로 바뀌고 크기 보호가
+    // 풀렸다(section.rs:2925/2928).
     empty_tag(
         w,
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_width_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", size_criterion_height_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
+}
+
+/// 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+pub(crate) fn size_criterion_width_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다.
+pub(crate) fn size_criterion_height_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {


### PR DESCRIPTION
## 개요

HWPX 그림(`<hp:pic>`) 저장 시 `numberingType`과 `groupLevel` 두 속성이 IR 값을 사용하지 않고 하드코딩되어 방출되어 저장 시 원본 속성이 유실되는 문제를 수정한다.

## 수정 내용

### Parser (`src/parser/hwpx/section.rs`)
- `parse_picture` 함수에 `numberingType` 속성 파싱 추가
- 기존 도형/표 파서와 동일한 매핑 로직 (PICTURE/TABLE/EQUATION/NONE)

### Serializer (`src/serializer/hwpx/picture.rs`)
- `numberingType`: 하드코딩 PICTURE → IR `common.numbering_type` 사용
- `groupLevel`: 하드코딩 0 → IR `shape_attr.group_level` 사용

### 영향
- 그룹(`<hp:container>`) 내 그림 개체의 중첩 레벨(`groupLevel`)이 보존됨
- 캡션 번호 범주(`numberingType`) 설정이 보존됨
- 도형·표 계열과 일관된 IR 보존 방식 적용 (#1379, #2697)

## 관련 이슈
- Closes #2745
- #2697 (표 numberingType 동형 수정)
- #1379 (도형 속성 IR 보존 정리)