### PR TITLE
fix(hwp5/hwpx): 도형 캡션 소실(#2715) + 각주·미주 장식 속성 왕복(#2716) — kevin9327 통합

### DIFF
--- a/mydocs/report/task_m100_2715_report.md
+++ b/mydocs/report/task_m100_2715_report.md
@@ -1,0 +1,195 @@
+# Task #2715 최종 보고서 — 그리기 도형·묶음·차트 캡션 HWP5 직렬화 누락
+
+- 이슈: [#2715](https://github.com/edwardkim/rhwp/issues/2715) / 브랜치: `task/m100-2715-hwp5-drawing-caption` (base `origin/devel` `49f38446`)
+- 관련: #1403(HWPX 캡션 방출), #1387(표 캡션 공유), #1283·#2696(OLE base-only 계약 — 본 작업 범위 밖)
+- 변경 파일: `src/serializer/control.rs`, `src/serializer/control/tests.rs`
+
+## 결론 요약
+
+`serialize_shape_control` 의 **10개 arm 중 캡션(`LIST_HEADER`)을 방출하는 arm 이 하나도 없어**
+그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다. 파서는 전 변종의 캡션을 적재하고
+(`parser/control/shape.rs:205/213/222/230/240`), 같은 파일에서 표(`:492`)·그림(`:998`)은
+`serialize_caption` 을 호출하는데 도형 계열만 비어 있었다.
+
+한컴 저장본 실측에서 `$rec`(사각형)·`$con`(묶음)이 `$pic`(그림)과 **동일한 30B `LIST_HEADER`** 를
+`SHAPE_COMPONENT` 앞에 갖는 것을 확인했으므로 포맷 제약이 아니라 미구현이다. 8개 arm에 방출을
+추가했다.
+
+| 코퍼스 | 도형 캡션 | 표 캡션 | 그림 캡션 |
+|---|---:|---:|---:|
+| `samples/*.hwp` 21개 파일 (수정 전) | **38 → 0** | 597 → 597 | 13 → 13 |
+| `samples/*.hwp` 21개 파일 (수정 후) | **38 → 38** | 597 → 597 | 13 → 13 |
+| `samples/hwpx/aift.hwpx` → HWP5 (수정 전) | **2 → 0** | 2 → 2 | 9 → 9 |
+| `samples/hwpx/aift.hwpx` → HWP5 (수정 후) | **2 → 2** | 2 → 2 | 9 → 9 |
+
+## 1. 문제
+
+파서의 캡션 인식 규칙은 "`SHAPE_COMPONENT` **앞**의 `LIST_HEADER`"다
+(`src/parser/control/shape.rs:134-147`). `SHAPE_COMPONENT` **뒤**의 `LIST_HEADER` 는 글상자로
+별도 처리되므로(`:149-167`) 두 경로는 레코드 위치로 구분된다.
+
+직렬화 쪽 `grep -n "serialize_caption" src/serializer/control.rs` 전수 결과는 3줄뿐이었다 —
+정의(`:666`)와 표(`:492`)·그림(`:998`) 호출 2건. `serialize_shape_control` 안에는 0건.
+
+| arm | 캡션 방출(수정 전) | IR 필드 |
+|---|---|---|
+| `Line` / `Rectangle` / `Ellipse` / `Polygon` / `Arc` / `Curve` | 없음 | `drawing.caption` |
+| `Group` | 없음 | `group.caption` |
+| `Chart` | 없음 | `chart.caption` |
+| `Ole` | 없음 | `ole.caption` (본 작업 범위 밖 — §5) |
+| `Picture(_)` | 해당 없음 | `serialize_picture_control` 위임 |
+
+## 2. 분석
+
+### 2.1 의도적 누락이 아님을 확인
+
+- `git log -S "serialize_caption" -- src/serializer/control.rs` → **`f0f7f1a4`(Initial commit) 1건뿐.**
+  도형 arm 에서 캡션 방출을 제거한 커밋이 없다. "호환성 때문에 뺀" 이력이 아니라 처음부터
+  표·그림에만 구현된 미구현 구간이다. `-S "pic.caption"` / `-S "table.caption"` 도 동일.
+- #1403 계열 커밋(`3baf8724`, `897066c8`, `2a176d09`)은 전부 HWPX 경로만 수정했다.
+  메인테이너 검토 문서 `mydocs/pr/archives/pr_1406_review.md` §3.2 가 오히려
+  **"HWP5 파서는 전 도형 캡션 적재 중"** 을 명시한다 — 적재는 되는데 HWP5 방출만 비어 있는
+  현 상태와 일치.
+- `mydocs/` 전체에서 "HWP5 도형 캡션 미방출" 계약 문서를 찾지 못했다.
+
+### 2.2 한컴 실물 레코드 배치 (결정적 근거)
+
+`samples/3-09월_교육_통합_2023.hwp` (한컴 저장, 캡션 `<보기>`):
+
+```
+tag=71  CTRL_HEADER      lv=1 sz=46  ctrl_id="gso "
+  tag=72  LIST_HEADER      lv=2 sz=30      ← 캡션
+  tag=66  PARA_HEADER      lv=2 sz=24
+    tag=67  PARA_TEXT        lv=3 sz=10
+    tag=68  PARA_CHAR_SHAPE  lv=3 sz=8
+    tag=69  PARA_LINE_SEG    lv=3 sz=36
+  tag=76  SHAPE_COMPONENT  lv=2 sz=239 comp_id="$rec"
+```
+
+`samples/draw-group.hwp` 는 동일 배치로 `comp_id="$con"`(sz=270), `samples/aift.hwp` 는
+`comp_id="$pic"`(sz=196). **세 경우 모두 캡션 `LIST_HEADER` 가 30B 로 동일**하며, 이는 기존
+`serialize_caption`(`control.rs:666-706`)이 방출하는 크기와 정확히 같다
+(`n_para(2)+list_attr(4)+width_ref(2)+attr(4)+width(4)+spacing(2)+max_width(4)+예약(8)=30`).
+해당 함수 주석도 `// 예약 필드 8바이트 (한컴 호환성: 원본 파일은 30바이트 LIST_HEADER)` 로
+이미 이 계약을 명시하고 있었다 — **방출 함수는 준비돼 있고 호출만 없었다.**
+
+### 2.3 `raw_stream` 지름길이 결함을 가리고 있었음
+
+`serialize_section`(`src/serializer/body_text.rs:26-30`)은 원본 섹션 바이트를 그대로 반환한다:
+
+```rust
+if let Some(ref raw) = section.raw_stream {
+    return raw.clone();
+}
+```
+
+따라서 **파싱 직후 무편집 저장은 직렬화기를 타지 않아 손실이 관측되지 않는다.** 최초 계측에서
+`38 → 38` 이 나와 결함이 없어 보였으나, 이는 직렬화기를 우회한 결과였다. 실사용 경로는
+`src/document_core/commands/` 의 편집 명령들이 예외 없이 `raw_stream = None` 을 설정하므로
+(`formatting.rs` 16곳, `header_footer_ops.rs` 9곳, `footnote_ops.rs` 6곳, `clipboard.rs` 4곳 등)
+**문서를 한 글자라도 편집하면 그 섹션의 도형 캡션이 전부 사라진다.** HWPX 입력은 `raw_stream`
+자체가 없어 무조건 손실된다.
+
+§ 결론 요약 표의 수치는 `raw_stream` 을 무효화한 상태(=실사용 경로)의 계측이다.
+
+## 3. 변경
+
+`src/serializer/control.rs`:
+
+1. `serialize_shape_control` 에 `emit_caption` 클로저 신설(`emit_ctrl_data` 옆). 방출 위치·OLE
+   제외 사유·호출 순서 제약을 주석으로 고정.
+2. 8개 arm(`Line`/`Rectangle`/`Ellipse`/`Polygon`/`Arc`/`Curve`/`Group`/`Chart`)에서
+   `emit_caption(...)` 호출. 캡션 필드 해석은 `serializer/hwpx/roundtrip.rs:1322-1335`
+   `shape_caption()` 과 동일 매핑(그리기 6종 → `drawing.caption`, Group/Chart → 각자 필드).
+
+**호출 순서 제약**: `emit_top_level_synthesized_ctrl_data` **뒤**, `SHAPE_COMPONENT` push **앞**.
+`parse_caption`(`parser/control.rs:417-462`)은 `records[0]` 을 LIST_HEADER 로, `records[1..]` 전체를
+캡션 문단으로 넘기므로, 캡션과 `SHAPE_COMPONENT` 사이에 `CTRL_DATA` 가 끼면 문단 파싱이 오염된다.
+
+`src/serializer/control/tests.rs`: 회귀 테스트 4건 + 픽스처 헬퍼 2개 추가.
+
+## 4. 검증
+
+### 4.1 red→green (실제 실행 캡처)
+
+`git stash push -- src/serializer/control.rs` 로 수정만 되돌린 상태 (**RED**):
+
+```
+running 4 tests
+test serializer::control::tests::issue2715_shape_without_caption_emits_no_list_header ... ok
+test serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows ... FAILED
+test serializer::control::tests::issue2715_rectangle_caption_roundtrips ... FAILED
+test serializer::control::tests::issue2715_group_caption_roundtrips ... FAILED
+
+---- serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows stdout ----
+thread '...' (14364) panicked at src\serializer\control\tests.rs:897:5:
+캡션 LIST_HEADER 는 SHAPE_COMPONENT 앞이어야 함 (caption=2, comp=1)
+
+---- serializer::control::tests::issue2715_rectangle_caption_roundtrips stdout ----
+thread '...' (9824) panicked at src\serializer\control\tests.rs:819:10:
+[#2715] 사각형 캡션이 왕복 보존돼야 함
+
+---- serializer::control::tests::issue2715_group_caption_roundtrips stdout ----
+thread '...' (35892) panicked at src\serializer\control\tests.rs:848:14:
+[#2715] 묶음 캡션이 왕복 보존돼야 함
+
+test result: FAILED. 1 passed; 3 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+RED 의 `caption=2, comp=1` 은 발견된 유일한 `LIST_HEADER` 가 `SHAPE_COMPONENT`(idx 1) **뒤**의
+글상자용(idx 2)이었음을 뜻한다 — 캡션이 아예 방출되지 않았다는 직접 증거다.
+
+`git stash pop` 후 (**GREEN**):
+
+```
+running 4 tests
+test serializer::control::tests::issue2715_shape_without_caption_emits_no_list_header ... ok
+test serializer::control::tests::issue2715_group_caption_roundtrips ... ok
+test serializer::control::tests::issue2715_rectangle_caption_roundtrips ... ok
+test serializer::control::tests::issue2715_caption_precedes_shape_component_and_textbox_follows ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+### 4.2 CI 3종
+
+| 명령 | 결과 |
+|---|---|
+| `cargo fmt --all -- --check` | **통과** (`Diff in` 0건 — CRLF 노이즈 `Incorrect newline style` 제외) |
+| `cargo clippy --all-targets -- -D warnings` | **통과** (경고 0, `Finished dev profile`) |
+| `cargo test --profile release-test --tests` | **3484 passed, 0 failed** (`test result: FAILED` 0건, panic 0건) |
+
+### 4.3 회귀 위험 테스트 개별 확인
+
+레코드 시퀀스에 `LIST_HEADER` 를 추가하므로 레코드 인덱스·크기를 고정한 테스트를 사전 조사 후
+개별 확인했다.
+
+| 테스트 | 위험 | 결과 |
+|---|---|---|
+| `issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage` (`shape_component.size == 196` 고정) | OLE 계약 | ok |
+| `issue2696_ole_shape_component_stays_base_only` | OLE 196B base-only | ok |
+| `task903_stage45_*` (`SHAPE_COMPONENT_INDICES = &[21,35,807,808,810,812]` 고정 인덱스) | 인덱스 이동 | ok — 기준 fixture `samples/hwpx/hwpx-h-01.hwpx` 는 도형 캡션 0건이라 이동 없음 |
+| `issue_1403_captions_roundtrip_aift` | HWPX 캡션 | ok |
+| `tests/issue_1251_ole_chart_contents.rs` 전 10건 | OLE 전반 | 전건 ok |
+
+### 4.4 실물 코퍼스 재계측
+
+`raw_stream` 무효화 상태에서 `samples/*.hwp` 270건 전수 재계측 — 도형 캡션 보유 21개 파일
+**38건 전량 보존**(수정 전 0건). 동일 실행에서 표 캡션 597건·그림 캡션 13건도 불변.
+`samples/hwpx/aift.hwpx` → HWP5 변환도 2 → 2 로 보존.
+
+## 5. 미실행·범위 밖
+
+- **OLE 캡션** — `Ole` arm 은 손대지 않았다. #1283/#2696 의 196B base-only 계약 영역이고,
+  캡션 보유 OLE 한컴 실물 샘플을 확보하지 못해 방출 위치를 실측 검증할 수 없다. 별도 이슈 권장.
+- **묶음 자식 도형의 캡션** — `serialize_group_child` 는 `CTRL_HEADER` 없이 `SHAPE_COMPONENT` 만
+  방출하는 경로다. 한컴이 묶음 **자식**에 캡션을 쓰는지 실물 확인하지 못했고, 현 파서도
+  `parse_container_children` 에서 자식 캡션을 적재하지 않으므로 범위 밖.
+- **캡션 내 `atno`(자동 번호) 의미 검증** — `draw-group.hwp` 캡션 문단에 `atno` 컨트롤이 있다.
+  캡션 문단은 `serialize_paragraph_list` 공용 경로를 타므로 레코드는 동승하나, 번호 재계산
+  의미까지는 검증하지 않았다.
+- **시각 검증(렌더 비교)** — 본 변경은 저장 레코드 계약 수정이고 렌더러 경로는 불변이라
+  `visual_baseline_all_samples` 통과로 갈음했다. 별도 SVG 대조는 수행하지 않았다.
+- **`raw_stream` 지름길 자체** — 무편집 저장이 직렬화기를 우회하는 설계는 의도된 것(완전
+  라운드트립)이라 건드리지 않았다. 다만 직렬화기 결함이 무편집 라운드트립 테스트에서 가려지는
+  구조적 사각이므로 별도 관찰 대상으로 남긴다.

--- a/mydocs/report/task_m100_2716_report.md
+++ b/mydocs/report/task_m100_2716_report.md
@@ -1,0 +1,227 @@
+# 최종 결과보고서 — Task M100 #2716
+
+**이슈**: [#2716](https://github.com/edwardkim/rhwp/issues/2716) HWPX 각주/미주 저장 시 `prefixChar`/`suffixChar`/`instId`/`flag` 4개 속성 전량 유실
+**마일스톤**: v1.0.0 (M100)
+**브랜치**: `task/m100-2716-note-hwpx-attrs` (← `origin/devel` @ `49f38446`)
+**범위**: HWPX 각주/미주 컨트롤 속성 왕복 보존 (파서 1개 분기 × 2 + 직렬화기 속성 방출)
+
+---
+
+## 1. 문제
+
+HWPX 직렬화기 `render_note_sublist()` 가 `<hp:footNote>` / `<hp:endNote>` 에 `number` **하나만**
+방출한다. 한컴이 자기 저장본에 항상 쓰는 `prefixChar`(앞 장식) · `suffixChar`(뒤 장식) ·
+`instId`(주석 고유 ID) · `flag`(번호 모양) 4개가 전부 빠진다.
+
+사용자 관점 증상: 미주가 있는 한컴 문서를 rhwp 로 열어 저장하면 본문 미주 마커
+**「문1）」이 「1)」로 퇴화**한다(앞 장식 탈락 + 전각 괄호 → 반각 괄호). 이는
+[#1199](https://github.com/edwardkim/rhwp/issues/1199) 가 파서 쪽에서 고친 바로 그 증상으로,
+저장 경로가 같은 값을 버리므로 **저장 한 번에 #1199 이전 상태로 되돌아간다**.
+
+---
+
+## 2. 분석
+
+### 2-1. 결함 지점과 대조군
+
+| 위치 | 상태 |
+|---|---|
+| `src/serializer/hwpx/section.rs:1961 render_note_sublist` | `number` 스칼라만 인자로 받아 나머지 4개 필드가 **구조적으로 방출 불가** |
+| `src/serializer/hwpx/section.rs:1539 render_header_footer` (같은 파일 형제) | `HeaderFooterFields` 묶음으로 IR 값을 **전부** 방출 |
+| `src/serializer/control.rs:783 serialize_footnote` (HWP5 형제) | `number`+`before`+`after`+`numberShape`+`instanceId` **5개 전부** 기록 |
+| `src/model/footnote.rs:16 Footnote` / `:35 Endnote` | 4개 필드를 이미 보유 |
+| `src/parser/hwpx/section.rs:4563/4612 parse_ctrl_(foot\|end)note` | `flag` 분기 부재 → `number_shape` 가 HWPX 경로에서 항상 0 |
+
+즉 **HWP5 ↔ IR 은 무손실이고 HWPX 만 편도 손실**이다.
+
+### 2-2. 패스스루가 가려주지 않는 이유
+
+`grep -n "raw_stream\|raw_xml\|raw_section_xml" src/serializer/hwpx/*.rs` → 매치 0.
+`Contents/sectionN.xml` 은 100% IR 에서 재조립되므로, 레코드 `raw_data` · `Section::raw_stream`
+(`src/serializer/body_text.rs:26-30`) · DocInfo `raw_stream_dirty` 어느 층도 HWPX 출력 경로에
+관여하지 않는다. 4절 실측이 이를 직접 확인해 준다.
+
+### 2-3. 한컴 실측 계약 확정
+
+`samples/3-09월_교육_통합_2023.hwp`(HWP5) 와 같은 문서의 한컴 HWPX 저장본
+`samples/3-09월_교육_통합_2023.hwpx` 의 각주/미주 46개를 필드 단위로 전수 대조 →
+**일치 46 / 불일치 0**. 이로써 다음이 확정됐다.
+
+- HWPX `flag` == HWP5 `CTRL_FOOTNOTE/CTRL_ENDNOTE` 의 `numberShape`(UInt4)
+- `flag` 존재 ⟺ `number_shape != 0`
+- `prefixChar` 존재 ⟺ `before_decoration_letter != 0`
+- `number` / `suffixChar` / `instId` 는 **항상** 존재 (코퍼스 828/828)
+- 속성 순서: `flag → number → prefixChar → suffixChar → instId`
+
+`suffixChar` 를 0 일 때 생략하면 파서 기본값 `0x0029` `)` 가 들어가 오염된다
+(`src/parser/hwpx/section.rs:4571`). `src/serializer/control.rs:789-792` 가 HWP5 쪽에서
+같은 이유로 이미 고친 문제이므로 **0 이어도 항상 방출**한다.
+
+---
+
+## 3. 변경
+
+| 파일 | 변경 |
+|---|---|
+| `src/serializer/hwpx/section.rs` | `NoteAttrs` 구조체 + `render_note_attrs()` 신설, `render_note_sublist` 시그니처를 묶음 전달로 교체, `render_footnote`/`render_endnote` 가 IR 4개 필드 전달 (+75 / −5) |
+| `src/parser/hwpx/section.rs` | `parse_ctrl_footnote` / `parse_ctrl_endnote` 에 `b"flag" → number_shape` 분기 추가 (+20 / −0) |
+| `src/serializer/hwpx/mod.rs` | 회귀 테스트 `footnote_endnote_decoration_attrs_roundtrip` 추가 (+112 / −0) |
+
+합계 3파일 207 추가 / 5 삭제. 모델 · 렌더러 · HWP5 파서 · HWP5 직렬화기 · HWP3 ·
+`hwpx_to_hwp.rs` 는 **무변경**. `render_note_sublist` 는 각주/미주 전용 영역이라 동시 작업 중인
+`serializer/hwpx/section.rs` 의 shape/table 영역과 겹치지 않는다.
+
+---
+
+## 4. 검증
+
+### 4-1. red → green (실제 실행 · 원문 캡처)
+
+수정 2파일(`src/serializer/hwpx/section.rs`, `src/parser/hwpx/section.rs`)을 `git stash` 로
+되돌리고 테스트만 남긴 상태에서 실행:
+
+```
+$ cargo test --lib footnote_endnote_decoration_attrs_roundtrip
+running 1 test
+test serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip ... FAILED
+
+failures:
+
+---- serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip stdout ----
+
+thread 'serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip' (40568)
+panicked at src\serializer\hwpx\mod.rs:1734:9:
+footNote 속성이 한컴 계약대로 방출되지 않음: <?xml version="1.0" ... >
+  ... <hp:ctrl><hp:footNote number="1"><hp:subList id="" textDirection="HORIZONTAL" ...
+  ... <hp:ctrl><hp:endNote number="2"><hp:subList id="" textDirection="HORIZONTAL" ...
+
+failures:
+    serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.01s
+
+error: test failed, to rerun pass `--lib`
+```
+
+`git stash pop` 으로 수정 복원 후 재실행:
+
+```
+$ cargo test --lib footnote_endnote
+running 4 tests
+test serializer::hwpx::section::tests::footnote_endnote_beneath_text_reflects_ir ... ok
+test serializer::hwpx::section::tests::footnote_endnote_numbering_and_start_reflect_ir ... ok
+test serializer::hwpx::tests::footnote_endnote_roundtrip ... ok
+test serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2468 filtered out; finished in 0.02s
+```
+
+### 4-2. 실파일 왕복 — 361개 note 속성 완전일치
+
+`export-hwpx` 후 한컴 원본과 note 요소 속성 집합을 전수 비교:
+
+| 케이스 | note 수 | 수정 전 | 수정 후 |
+|---|---|---|---|
+| `samples/3-09월_교육_통합_2022.hwpx` → hwpx | 46 | `{number}` 만 (46/46 손실) | **속성 완전일치 True** |
+| `samples/3-09월_교육_통합_2023.hwpx` → hwpx (`flag` 포함) | 46 | `{number}` 만 | **속성 완전일치 True** |
+| `samples/SO-SUEOP.hwpx` → hwpx | 223 | `{number}` 만 | **속성 완전일치 True** |
+| `samples/3-09월_교육_통합_2022.hwp` → hwpx | 46 | `{number}` 만 | **속성 완전일치 True** |
+
+수정 후 출력 예시:
+
+```
+{'flag':'3211264','number':'1','prefixChar':'47928','suffixChar':'65289','instId':'1085611790'}
+```
+
+### 4-3. HWP5 바이트 왕복 — 46/46 페이로드 완전일치
+
+`samples/3-09월_교육_통합_2022.hwp` → HWPX → HWP5(`convert`) 후 `hwp5-inventory` 의
+`CTRL_HEADER('en  ')` 페이로드 비교:
+
+```
+원본 [0]: 20 20 6e 65 01 00 00 00 38 bb 09 ff 00 00 00 00 1d 22 b5 40
+왕복 [0]: 20 20 6e 65 01 00 00 00 38 bb 09 ff 00 00 00 00 1d 22 b5 40
+페이로드 완전일치 46/46
+```
+
+수정 전에는 `... 00 00  29 00  00 00 00 00  00 00 00 00` 이었다
+(`before` 소실, `after` 가 `0x0029` 로 변조, `instance_id` 0 리셋).
+
+### 4-4. 렌더 회귀 — 마커 46개 복원
+
+`export-text` 23쪽 전량 스캔:
+
+```
+원본 HWPX 렌더 "문N）" 마커: 46
+수정 후 재저장본 렌더 "문N）" 마커: 46   (문1）,문2）,문3）,문4）,문5） …)
+```
+
+수정 전 재저장본은 `문N）` 0개 / `N)` 46개였다.
+
+### 4-5. CI 3종
+
+| 항목 | 결과 |
+|---|---|
+| `cargo clippy --all-targets -- -D warnings` | **통과** — 경고 0 (`Finished dev profile in 57.10s`) |
+| `cargo test --profile release-test --tests` | **통과** — exit 0, 테스트 바이너리 291개, **3481 passed / 0 failed / 23 ignored** |
+| 변경 `.rs` 3파일 `rustfmt --edition 2021` 후 `git diff --numstat` | 재포맷 churn 0 (20/0, 112/0, 75/5 — 의도한 hunk 뿐) |
+
+`cargo fmt --all -- --check` 는 CRLF 체크아웃에서 `Incorrect newline style` 만 내고 diff 를
+내지 않는 false pass 이므로 사용하지 않았다.
+
+### 4-6. `cargo test --profile release-test --tests` 상세
+
+lib 유닛 테스트 블록에 신규 테스트가 포함되어 실행됐다.
+
+```
+     Running unittests src\lib.rs (target\release-test\deps\rhwp-9b807afca6f4a468.exe)
+running 2472 tests
+...
+test serializer::hwpx::tests::footnote_endnote_decoration_attrs_roundtrip ... ok
+...
+test result: ok. 2465 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 8.82s
+```
+
+각주/미주가 포함된 HWPX 구조 보존 게이트(`samples/hwpx/` 안 note 13개 — `footnote-01.hwpx` 9,
+`footnote-tbox-01.hwpx` 2, `143E433F503322BD33.hwpx` 1, `aift.hwpx` 1)도 통과했다.
+
+```
+     Running tests\hwpx_roundtrip_baseline.rs
+running 4 tests
+test xfail_entries_still_fail ... ok
+test grade_lists_are_consistent ... ok
+test baseline_large_samples_roundtrip ... ok
+test baseline_all_samples_roundtrip ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 3.29s
+```
+
+전체 집계: `test result:` 블록 291개 합산 **3481 passed / 0 failed / 23 ignored**, `FAILED` 문자열
+등장 0회.
+
+---
+
+## 5. 미실행 항목
+
+- 한컴 오피스 실물 열기 대조는 하지 않았다. 대신 한컴 저장본 원본과의 **속성 전수 일치**(4-2)
+  와 **HWP5 페이로드 바이트 일치**(4-3) 로 대체했다.
+- 시각(SVG/PNG) 픽셀 diff 는 하지 않았다. 마커 문자열 수준(4-4)까지만 확인했다.
+
+---
+
+## 6. 잔여 (범위 밖)
+
+- **공개 OWPML 스키마 불일치**: `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2735
+  NoteType` 은 `instId` 만 선언하고 `number`/`prefixChar`/`suffixChar`/`flag` 는 선언하지 않는다.
+  본 작업은 공개 스키마가 아니라 한컴 실측 계약(828/828, 46/46)을 기준으로 했다. 스키마 문서
+  갱신은 별건.
+- **`flag` 상위 바이트 의미**: 실측값 `0x00310000`, `0x00480000`, `0x00380000`, `0x00200000` 등
+  하위 바이트(번호 모양 코드)는 항상 0 이고 byte 2 만 변한다. 의미 미상 — 본 작업은 raw 왕복
+  보존만 다뤘다. 현행 렌더러는 `number_shape as u8` 만 쓰므로
+  (`src/renderer/layout/paragraph_layout.rs:529`) 이 샘플군 렌더에는 영향이 없다.
+- **각주/미주 `<hp:subList>` 의 `textWidth`/`textHeight`/`hasTextRef`/`hasNumRef`**: 여전히 `"0"`
+  하드코딩이다. 머리말/꼬리말과 달리 `Footnote`/`Endnote` IR 에 대응 필드 자체가 없어 모델 확장이
+  필요하다. 별건.
+- **HWP3 각주 경로**(`src/parser/hwp3/mod.rs:3394`): `after_decoration_letter = ')'`,
+  `number_shape = 0` 고정. HWP3 전용 해석은 `src/parser/hwp3/` 안에 머물러야 한다는 `CLAUDE.md`
+  규칙에 따라 다루지 않았다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4613,6 +4613,17 @@ fn parse_ctrl_footnote(
                     note.after_decoration_letter = v;
                 }
             }
+            // [#2716] flag = HWP5 CTRL_FOOTNOTE numberShape(UInt4). 한컴 HWP5/HWPX 쌍
+            // (3-09월_교육_통합_2023) 각주/미주 46개 전수 대조에서 바이트 단위로 일치했다.
+            // 값이 0 이면 한컴이 속성 자체를 생략하므로 default 0 유지.
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
+                }
+            }
             b"instId" => {
                 if let Ok(v) = std::str::from_utf8(&attr.value)
                     .unwrap_or("")
@@ -4658,6 +4669,15 @@ fn parse_ctrl_endnote(
                     .parse::<u16>()
                 {
                     note.after_decoration_letter = v;
+                }
+            }
+            // [#2716] flag = HWP5 CTRL_ENDNOTE numberShape(UInt4). footNote 와 동일 계약.
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
                 }
             }
             b"instId" => {

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1178,6 +1178,28 @@ fn serialize_shape_control(
         }
     };
 
+    // [#2715] 캡션(SHAPE_COMPONENT 앞, level+1) 방출 헬퍼.
+    //
+    // 파서는 `SHAPE_COMPONENT` **앞**의 LIST_HEADER 를 캡션으로 읽는데
+    // (`parser/control/shape.rs:134-147`), 종전 도형 arm 은 어느 것도 방출하지
+    // 않아 그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다 (표 `:492`·
+    // 그림 `:998` 만 방출 중이었다). 한컴 저장본도 `$rec`(사각형)·`$con`(묶음)에
+    // `$pic`(그림)과 **동일한 30B LIST_HEADER** 를 SHAPE_COMPONENT 앞에 쓴다
+    // (`samples/3-09월_교육_통합_2023.hwp`, `samples/draw-group.hwp` 실측).
+    //
+    // 호출 위치는 반드시 `emit_top_level_synthesized_ctrl_data` **뒤**여야 한다 —
+    // `parse_caption` 은 `records[1..]` 전체를 캡션 문단으로 넘기므로, 캡션과
+    // SHAPE_COMPONENT 사이에 CTRL_DATA 가 끼면 문단 파싱이 오염된다.
+    //
+    // OLE arm 은 제외한다: `#1283` 의 196B base-only 계약 영역이고
+    // (`tests/issue_1251_ole_chart_contents.rs` 가 고정), 캡션 보유 OLE 한컴
+    // 실물 샘플을 확보하지 못해 방출 위치를 실측 검증할 수 없다.
+    let emit_caption = |caption: &Option<Caption>, records: &mut Vec<Record>| {
+        if let Some(caption) = caption {
+            serialize_caption(caption, level + 1, records);
+        }
+    };
+
     match shape {
         ShapeObject::Line(line) => {
             let is_connector = line.connector.is_some();
@@ -1192,6 +1214,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&line.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&line.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1237,6 +1260,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&rect.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&rect.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1266,6 +1290,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&ellipse.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&ellipse.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1308,6 +1333,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&poly.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&poly.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1345,6 +1371,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&arc.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&arc.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1375,6 +1402,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&curve.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&curve.drawing.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,
@@ -1408,6 +1436,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&group.common),
             ));
             emit_top_level_synthesized_ctrl_data(records);
+            emit_caption(&group.caption, records);
             // 그룹 컨테이너: SHAPE_COMPONENT + 자식 수 + 자식 ctrl_id 목록 (한컴 호환)
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
@@ -1440,6 +1469,7 @@ fn serialize_shape_control(
                 &serialize_common_obj_attr(&chart.common),
             ));
             let sc_ctrl_id = chart.drawing.shape_attr.ctrl_id;
+            emit_caption(&chart.caption, records);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,
                 level: level + 1,

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -2,6 +2,7 @@ use super::*;
 use crate::model::document::{Section, SectionDef};
 use crate::model::page::PageDef;
 use crate::model::paragraph::{CharShapeRef, LineSeg, Paragraph};
+use crate::model::shape::{GroupShape, RectangleShape};
 use crate::parser::body_text::parse_body_text_section;
 use crate::serializer::body_text::serialize_section;
 
@@ -729,5 +730,221 @@ fn issue2696_ole_shape_component_stays_base_only() {
         196,
         "[#2696] OLE SHAPE_COMPONENT 는 한컴 실측치와 같은 196B(base-only)여야 한다 \
          — 꼬리를 붙이면 #1283 의 한컴 호환 계약이 깨진다"
+    );
+}
+
+// ============================================================
+// [#2715] 그리기 도형·묶음·차트 캡션 HWP5 직렬화
+// ============================================================
+
+/// 캡션 1개짜리 테스트 픽스처.
+fn caption_fixture(text: &str) -> Caption {
+    Caption {
+        direction: CaptionDirection::Top,
+        vert_align: CaptionVertAlign::Center,
+        width: 4321,
+        spacing: 850,
+        max_width: 30000,
+        include_margin: true,
+        paragraphs: vec![Paragraph {
+            char_count: (text.chars().count() + 1) as u32,
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        }],
+    }
+}
+
+/// 컨트롤 1개를 담은 섹션을 직렬화 → 재파싱한다.
+fn roundtrip_single_control(ctrl: Control) -> Control {
+    let section = Section {
+        paragraphs: vec![Paragraph {
+            char_count: 2,
+            text: String::new(),
+            char_offsets: vec![],
+            controls: vec![ctrl],
+            ..Default::default()
+        }],
+        raw_stream: None,
+        ..Default::default()
+    };
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+    parsed.paragraphs[0]
+        .controls
+        .first()
+        .expect("컨트롤이 왕복돼야 함")
+        .clone()
+}
+
+fn shape_of(ctrl: &Control) -> &ShapeObject {
+    match ctrl {
+        Control::Shape(s) => s.as_ref(),
+        other => panic!("도형 컨트롤이 나와야 함, got {other:?}"),
+    }
+}
+
+/// [#2715] 사각형 도형의 캡션이 HWP5 왕복에서 보존돼야 한다.
+///
+/// 종전에는 `serialize_shape_control` 의 어떤 arm 도 `serialize_caption` 을
+/// 호출하지 않아 `drawing.caption` 이 통째로 사라졌다 — 한컴 저장본
+/// `samples/3-09월_교육_통합_2023.hwp` 는 `$rec` 도형에 그림($pic)과 동일한
+/// 30B LIST_HEADER 캡션을 쓰므로 포맷 제약이 아니라 미구현이었다.
+#[test]
+fn issue2715_rectangle_caption_roundtrips() {
+    let rect = RectangleShape {
+        drawing: DrawingObjAttr {
+            caption: Some(caption_fixture("사각형 캡션")),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let out = roundtrip_single_control(Control::Shape(Box::new(ShapeObject::Rectangle(rect))));
+
+    let ShapeObject::Rectangle(r) = shape_of(&out) else {
+        panic!("사각형이 나와야 함, got {:?}", shape_of(&out));
+    };
+    let cap = r
+        .drawing
+        .caption
+        .as_ref()
+        .expect("[#2715] 사각형 캡션이 왕복 보존돼야 함");
+    assert_eq!(cap.paragraphs[0].text, "사각형 캡션", "캡션 텍스트 보존");
+    assert_eq!(cap.direction, CaptionDirection::Top, "캡션 방향 보존");
+    assert_eq!(
+        cap.vert_align,
+        CaptionVertAlign::Center,
+        "캡션 세로 정렬 보존"
+    );
+    assert_eq!(cap.width, 4321, "캡션 폭 보존");
+    assert_eq!(cap.spacing, 850, "캡션-틀 간격 보존");
+    assert_eq!(cap.max_width, 30000, "캡션 최대 폭 보존");
+    assert!(cap.include_margin, "include_margin 보존");
+}
+
+/// [#2715] 묶음(`$con`) 캡션 왕복 — 한컴 `samples/draw-group.hwp` 실측 대응.
+#[test]
+fn issue2715_group_caption_roundtrips() {
+    let group = GroupShape {
+        caption: Some(caption_fixture("묶음 캡션")),
+        ..Default::default()
+    };
+    let out = roundtrip_single_control(Control::Shape(Box::new(ShapeObject::Group(group))));
+
+    let ShapeObject::Group(g) = shape_of(&out) else {
+        panic!("묶음이 나와야 함, got {:?}", shape_of(&out));
+    };
+    assert_eq!(
+        g.caption
+            .as_ref()
+            .expect("[#2715] 묶음 캡션이 왕복 보존돼야 함")
+            .paragraphs[0]
+            .text,
+        "묶음 캡션"
+    );
+}
+
+/// [#2715] 캡션은 `SHAPE_COMPONENT` **앞**, 글상자 LIST_HEADER 는 **뒤**로
+/// 분리 방출돼야 한다 (파서가 위치로 둘을 구분하므로 순서가 곧 계약이다).
+/// LIST_HEADER 크기 30B 는 한컴 저장본 실측치와 같다.
+#[test]
+fn issue2715_caption_precedes_shape_component_and_textbox_follows() {
+    let rect = RectangleShape {
+        drawing: DrawingObjAttr {
+            caption: Some(caption_fixture("캡션")),
+            text_box: Some(crate::model::shape::TextBox {
+                paragraphs: vec![Paragraph {
+                    char_count: 4,
+                    text: "글상자".to_string(),
+                    char_offsets: vec![0, 1, 2],
+                    char_shapes: vec![CharShapeRef {
+                        start_pos: 0,
+                        char_shape_id: 0,
+                    }],
+                    line_segs: vec![LineSeg {
+                        text_start: 0,
+                        ..Default::default()
+                    }],
+                    ..Default::default()
+                }],
+                ..Default::default()
+            }),
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+    let ctrl = Control::Shape(Box::new(ShapeObject::Rectangle(rect)));
+
+    let mut records: Vec<Record> = Vec::new();
+    serialize_control(&ctrl, 1, None, &mut records);
+
+    let comp_idx = records
+        .iter()
+        .position(|r| r.tag_id == tags::HWPTAG_SHAPE_COMPONENT)
+        .expect("SHAPE_COMPONENT 가 있어야 함");
+    let caption_idx = records
+        .iter()
+        .position(|r| r.tag_id == tags::HWPTAG_LIST_HEADER)
+        .expect("[#2715] 캡션 LIST_HEADER 가 방출돼야 함");
+    assert!(
+        caption_idx < comp_idx,
+        "캡션 LIST_HEADER 는 SHAPE_COMPONENT 앞이어야 함 (caption={caption_idx}, comp={comp_idx})"
+    );
+    assert_eq!(
+        records[caption_idx].level, 2,
+        "캡션 LIST_HEADER 는 level+1 이어야 함"
+    );
+    assert_eq!(
+        records[caption_idx].data.len(),
+        30,
+        "캡션 LIST_HEADER 는 한컴 실측치와 같은 30B 여야 함"
+    );
+
+    let textbox_idx = records
+        .iter()
+        .enumerate()
+        .skip(comp_idx)
+        .find(|(_, r)| r.tag_id == tags::HWPTAG_LIST_HEADER)
+        .map(|(i, _)| i)
+        .expect("글상자 LIST_HEADER 가 방출돼야 함");
+    assert!(
+        textbox_idx > comp_idx,
+        "글상자 LIST_HEADER 는 SHAPE_COMPONENT 뒤여야 함"
+    );
+
+    // 재파싱 시 캡션과 글상자가 각각 제자리에 복원되는지
+    let out = roundtrip_single_control(ctrl);
+    let ShapeObject::Rectangle(r) = shape_of(&out) else {
+        panic!("사각형이 나와야 함");
+    };
+    assert_eq!(
+        r.drawing.caption.as_ref().expect("캡션 보존").paragraphs[0].text,
+        "캡션"
+    );
+    assert_eq!(
+        r.drawing.text_box.as_ref().expect("글상자 보존").paragraphs[0].text,
+        "글상자",
+        "캡션 추가가 글상자 경로를 침범하면 안 됨"
+    );
+}
+
+/// [#2715] 캡션이 없는 도형은 LIST_HEADER 를 방출하지 않아야 한다
+/// (불필요한 레코드 추가로 기존 레코드 시퀀스를 흔들지 않기 위함).
+#[test]
+fn issue2715_shape_without_caption_emits_no_list_header() {
+    let ctrl = Control::Shape(Box::new(ShapeObject::Rectangle(RectangleShape::default())));
+    let mut records: Vec<Record> = Vec::new();
+    serialize_control(&ctrl, 1, None, &mut records);
+    assert!(
+        !records.iter().any(|r| r.tag_id == tags::HWPTAG_LIST_HEADER),
+        "캡션 없는 도형은 LIST_HEADER 를 방출하면 안 됨"
     );
 }

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -1672,6 +1672,118 @@ mod tests {
         );
     }
 
+    /// [#2716] `<hp:footNote>` / `<hp:endNote>` 의 장식 문자·번호 모양·고유 ID 왕복 보존.
+    ///
+    /// 종전 `render_note_sublist` 는 `number` 만 방출해 한컴 저장본이 항상 쓰는
+    /// `suffixChar`/`instId`(828/828), `prefixChar`(598/828), `flag`(27/828) 가 전량
+    /// 유실됐다. 그 결과 미주 마커 「문1）」이 저장 왕복마다 「1)」로 퇴화했다
+    /// (samples/3-09월_교육_통합_2022.hwpx 46/46).
+    ///
+    /// 방출 규칙은 한컴 HWP5/HWPX 쌍(3-09월_교육_통합_2023, note 46개 전수 대조) 실측:
+    /// `flag` 는 number_shape != 0 일 때만, `prefixChar` 는 before != 0 일 때만,
+    /// `number`/`suffixChar`/`instId` 는 항상.
+    #[test]
+    fn footnote_endnote_decoration_attrs_roundtrip() {
+        use crate::model::control::Control;
+        use crate::model::footnote::{Endnote, Footnote};
+        use crate::model::paragraph::Paragraph;
+
+        let mut doc = Document::default();
+        let mut section = crate::model::document::Section::default();
+        let mut para = crate::model::paragraph::Paragraph::default();
+        para.text = "본문".to_string();
+        para.char_offsets = vec![8, 17];
+        para.char_count = 20;
+
+        let mut fn_para = Paragraph::default();
+        fn_para.text = "각주 본문".to_string();
+        para.controls.push(Control::Footnote(Box::new(Footnote {
+            number: 1,
+            paragraphs: vec![fn_para],
+            before_decoration_letter: 47928, // 0xBB38 '문'
+            after_decoration_letter: 65289,  // 0xFF09 '）'
+            number_shape: 3211264,           // 0x00310000
+            instance_id: 1085612573,
+            ..Default::default()
+        })));
+
+        // 접두 없음(0) + 닫는 장식 없음(0): prefixChar/flag 는 생략, suffixChar 는 0 방출.
+        let mut en_para = Paragraph::default();
+        en_para.text = "미주 본문".to_string();
+        para.controls.push(Control::Endnote(Box::new(Endnote {
+            number: 2,
+            paragraphs: vec![en_para],
+            before_decoration_letter: 0,
+            after_decoration_letter: 0,
+            number_shape: 0,
+            instance_id: 7,
+            ..Default::default()
+        })));
+
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let bytes = serialize_hwpx(&doc).expect("serialize notes");
+        let cursor = std::io::Cursor::new(&bytes);
+        let mut archive = zip::ZipArchive::new(cursor).expect("zip");
+        let mut sec0 = archive.by_name("Contents/section0.xml").expect("section0");
+        let mut xml = String::new();
+        std::io::Read::read_to_string(&mut sec0, &mut xml).expect("read");
+        drop(sec0);
+
+        assert!(
+            xml.contains(
+                r#"<hp:footNote flag="3211264" number="1" prefixChar="47928" suffixChar="65289" instId="1085612573">"#
+            ),
+            "footNote 속성이 한컴 계약대로 방출되지 않음: {}",
+            xml
+        );
+        assert!(
+            xml.contains(r#"<hp:endNote number="2" suffixChar="0" instId="7">"#),
+            "endNote 생략 규칙(flag/prefixChar 생략, suffixChar 항상)이 어긋남: {}",
+            xml
+        );
+
+        let parsed = parse_hwpx(&bytes).expect("parse back");
+        let ctrls = &parsed.sections[0].paragraphs[0].controls;
+
+        let fn_ctrl = ctrls
+            .iter()
+            .find_map(|c| match c {
+                Control::Footnote(f) => Some(f),
+                _ => None,
+            })
+            .expect("footnote ctrl");
+        assert_eq!(
+            fn_ctrl.before_decoration_letter, 47928,
+            "footNote prefixChar"
+        );
+        assert_eq!(
+            fn_ctrl.after_decoration_letter, 65289,
+            "footNote suffixChar"
+        );
+        assert_eq!(fn_ctrl.number_shape, 3211264, "footNote flag");
+        assert_eq!(fn_ctrl.instance_id, 1085612573, "footNote instId");
+
+        let en_ctrl = ctrls
+            .iter()
+            .find_map(|c| match c {
+                Control::Endnote(e) => Some(e),
+                _ => None,
+            })
+            .expect("endnote ctrl");
+        assert_eq!(
+            en_ctrl.before_decoration_letter, 0,
+            "endNote prefixChar 없음"
+        );
+        assert_eq!(
+            en_ctrl.after_decoration_letter, 0,
+            "endNote suffixChar 0 이 ')' 로 오염됨"
+        );
+        assert_eq!(en_ctrl.number_shape, 0, "endNote flag 없음");
+        assert_eq!(en_ctrl.instance_id, 7, "endNote instId");
+    }
+
     /// tac-img-02.hwpx 파싱 후 BinData 가 존재하는지, Picture 컨트롤이
     /// section XML 에 반영되는지 확인하는 스모크 테스트.
     /// 실문서는 borderFillIDRef 가 복잡하여 full roundtrip 대신 직렬화 단계만 검증.

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1958,16 +1958,61 @@ fn render_common_shape_xml(
     out
 }
 
+/// [#2716] `<hp:footNote>` / `<hp:endNote>` 의 IR 보존 속성 묶음.
+///
+/// 종전에는 `number` 스칼라 하나만 `render_note_sublist` 로 넘겨 나머지 4개 필드가
+/// 구조적으로 방출 불가였다. 같은 파일의 `render_header_footer` 가 쓰는
+/// `HeaderFooterFields` 와 동일한 묶음 전달 패턴이다.
+struct NoteAttrs {
+    number: u16,
+    /// `before_decoration_letter` — 0 이면 속성 생략(한컴 계약).
+    prefix_char: u16,
+    /// `after_decoration_letter` — 항상 방출.
+    suffix_char: u16,
+    /// HWP5 `numberShape` — 0 이면 속성 생략(한컴 계약).
+    number_shape: u32,
+    /// HWP5 `instanceId` — 항상 방출.
+    inst_id: u32,
+}
+
+/// [#2716] 각주/미주 ctrl 속성 문자열.
+///
+/// 한컴 저장본 실측 계약(samples 16파일 · note 828개, 3-09월_교육_통합_2023 의 HWP5/HWPX
+/// 쌍 46개 필드 단위 전수 대조 일치):
+/// - `number` / `suffixChar` / `instId` 는 항상 존재(828/828)
+/// - `prefixChar` 는 `before_decoration_letter != 0` 일 때만 존재(598/828)
+/// - `flag`(= HWP5 `numberShape`) 는 `number_shape != 0` 일 때만 존재(27/828)
+/// - 속성 순서는 `flag → number → prefixChar → suffixChar → instId`
+///
+/// `suffixChar` 를 생략하면 파서(`parse_ctrl_footnote`)가 기본값 `0x0029` `)` 를 넣어
+/// 닫는 장식이 없는(0) 각주가 오염된다 — HWP5 직렬화기가 `serializer/control.rs` 에서
+/// 같은 이유로 고친 문제이므로 0 이어도 항상 방출한다.
+fn render_note_attrs(attrs: &NoteAttrs) -> String {
+    let mut out = String::new();
+    if attrs.number_shape != 0 {
+        out.push_str(&format!(r#" flag="{}""#, attrs.number_shape));
+    }
+    out.push_str(&format!(r#" number="{}""#, attrs.number));
+    if attrs.prefix_char != 0 {
+        out.push_str(&format!(r#" prefixChar="{}""#, attrs.prefix_char));
+    }
+    out.push_str(&format!(
+        r#" suffixChar="{}" instId="{}""#,
+        attrs.suffix_char, attrs.inst_id
+    ));
+    out
+}
+
 fn render_note_sublist(
     tag: &str,
-    number: u16,
+    attrs: NoteAttrs,
     paragraphs: &[Paragraph],
     ctx: &mut SerializeContext,
 ) -> String {
     let mut out = format!(
-        r#"<hp:ctrl><hp:{tag} number="{num}"><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#,
+        r#"<hp:ctrl><hp:{tag}{attrs}><hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#,
         tag = tag,
-        num = number,
+        attrs = render_note_attrs(&attrs),
     );
     let mut vert_cursor: u32 = 0;
     for p in paragraphs.iter() {
@@ -1985,11 +2030,36 @@ fn render_note_sublist(
 }
 
 fn render_footnote(note: &Footnote, ctx: &mut SerializeContext) -> String {
-    render_note_sublist("footNote", note.number, &note.paragraphs, ctx)
+    // [#2716] IR 이 보존한 장식 문자/번호 모양/고유 ID 를 모두 방출한다. 종전엔 number 만
+    // 써서 저장 왕복마다 앞 장식('문')이 사라지고 뒤 장식이 ')' 로 변조됐다.
+    render_note_sublist(
+        "footNote",
+        NoteAttrs {
+            number: note.number,
+            prefix_char: note.before_decoration_letter,
+            suffix_char: note.after_decoration_letter,
+            number_shape: note.number_shape,
+            inst_id: note.instance_id,
+        },
+        &note.paragraphs,
+        ctx,
+    )
 }
 
 fn render_endnote(note: &Endnote, ctx: &mut SerializeContext) -> String {
-    render_note_sublist("endNote", note.number, &note.paragraphs, ctx)
+    // [#2716] Footnote 와 동일 계약.
+    render_note_sublist(
+        "endNote",
+        NoteAttrs {
+            number: note.number,
+            prefix_char: note.before_decoration_letter,
+            suffix_char: note.after_decoration_letter,
+            number_shape: note.number_shape,
+            inst_id: note.instance_id,
+        },
+        &note.paragraphs,
+        ctx,
+    )
 }
 
 fn render_equation(eq: &Equation) -> String {


### PR DESCRIPTION
kevin9327 님의 #2725·#2728 을 메인테이너가 재실증 후 통합한다.

## 채택
- **#2725** (`Closes #2715`) — `serialize_shape_control` 10개 arm 중 캡션(`LIST_HEADER`) 방출이 하나도 없어 그리기 도형·묶음·차트 캡션이 HWP5 저장에서 전량 소실됐다(21개 샘플 38 → 0). 8개 arm 에 방출 추가. 한컴 저장본에서 `$rec`·`$con` 이 `$pic` 과 동일한 30B `LIST_HEADER` 를 갖는 실측으로 포맷 제약이 아니라 미구현임을 확인했다.
- **#2728** (`Closes #2716`) — HWPX 직렬화기가 `number` 만 방출해 `prefixChar`/`suffixChar`/`instId`/`flag` 가 저장마다 소실됐다. 미주 마커 「문1）」이 「1)」로 퇴화하며, #1199 가 파서에서 고친 증상을 저장 경로가 되돌리는 구조였다.

## 검증
- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- red→green: #2725 캡션 방출 무력화 시 3 FAIL, #2728 4속성 방출 제거 시 1 FAIL — 복원 시 전부 통과

## 함께 정리한 중복
- **#2729** — `connector.rs` 패스스루 무효화는 #2709 통합(`Closes #2698`)에 이미 포함. devel 이 조기 반환 경로까지 잡아 무효화 4곳 + 반대 방향 가드를 더 갖는다.

Co-authored-by 로 원 커밋 provenance 를 보존한다.