### PR TITLE
fix(hwp5/hwpx): 수식 EQEDIT attribute 파싱/직렬화 양쪽 소실 수정

### DIFF
--- a/mydocs/report/pr-equation-eqedit.md
+++ b/mydocs/report/pr-equation-eqedit.md
@@ -1,0 +1,57 @@
+# PR: 수식 EQEDIT attribute 파싱/직렬화 양쪽 소실 수정 (Issue #2727)
+
+## 배경
+
+HWP5 EQEDIT record의 첫 필드(UINT32 attr)는 `lineMode` (bit 0: 0=글자단위/CHAR, 1=줄단위/LINE)를
+포함하지만, 파싱 시 `_attr`로 읽기만 하고 모델에 저장하지 않아 버려졌다. 직렬화 시에도
+`write_u32(0)`으로 고정 출력되어 저장 시 항상 0이 기록되었다.
+
+HWPX 경로에서도 `<hp:equation>`의 `lineMode` 속성이 파싱/직렬화 양쪽에서 누락되어 동일한 유실이
+발생했다.
+
+**4경로 전부 유실**: HWP5 parse, HWP5 serialize, HWPX parse, HWPX serialize
+
+## 변경 사항
+
+### 1. 모델: `eqedit` 필드 추가
+
+**파일**: `src/model/control.rs`
+
+`Equation` struct에 `pub eqedit: u32` 필드 추가 (bit 0 = lineMode)
+
+### 2. HWP5 파서: EQEDIT attr 저장
+
+**파일**: `src/parser/control.rs`
+
+기존 `let _attr = r.read_u32().unwrap_or(0);` → `equation.eqedit = r.read_u32().unwrap_or(0);`
+
+### 3. HWP5 직렬화: EQEDIT attr 출력
+
+**파일**: `src/serializer/control.rs`
+
+기존 `w.write_u32(0).unwrap()` → `w.write_u32(eq.eqedit).unwrap()`
+
+### 4. HWPX 파서: `lineMode` 속성 파싱
+
+**파일**: `src/parser/hwpx/section.rs`
+
+`<hp:equation lineMode="LINE">` → `eqedit |= 0x01`
+`<hp:equation lineMode="CHAR">` → `eqedit = 0x00`
+
+### 5. HWPX 직렬화: `lineMode` 속성 출력
+
+**파일**: `src/serializer/hwpx/section.rs`
+
+EQEDIT attr bit 0에 따라 `lineMode="LINE"` 또는 `lineMode="CHAR"` 속성을 `<hp:equation>`에 추가
+
+### 6. 테스트 픽스처 갱신
+
+**파일**: `src/serializer/hwpx/mod.rs`
+
+`equation_control_roundtrip_preserves_script` 테스트의 Equation 생성자에 `eqedit: 0` 추가
+
+## 영향
+
+- `Default` derive로 `eqedit: 0`이 기본값이므로 신규 생성 수식은 CHAR mode (글자 단위)
+- 기존 HWP5 파일의 EQEDIT attr이 라운드트립에서 보존됨
+- HWPX `<hp:equation>`에 `lineMode` 속성이 항상 출력됨 (기존에는 없었음)

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -77,6 +77,10 @@ pub struct Equation {
     /// HWP5 spec 표 105 에 누락되어 있으나 한컴 실제 저장본에 baseline 과 version_info
     /// 사이에 UINT16 zero 가 위치. Task #1061 발견.
     pub unknown: u16,
+    /// EQEDIT 속성 (UINT32, HWPTAG_EQEDIT 첫 필드).
+    /// bit 0: lineMode (0=글자 단위/CHAR, 1=줄 단위/LINE).
+    /// 종전엔 파싱 후 버려지고 저장 시 0으로 고정되어 lineMode 유실. Issue #2727.
+    pub eqedit: u32,
     /// 버전 정보
     pub version_info: String,
     /// 수식 글꼴명

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -862,8 +862,8 @@ fn parse_equation_control(ctrl_data: &[u8], child_records: &[Record]) -> Control
         let data = &eq_rec.data;
         let mut r = ByteReader::new(data);
 
-        // attr: u32 (4바이트) — bit0: 스크립트 범위
-        let _attr = r.read_u32().unwrap_or(0);
+        // attr: u32 (4바이트) — bit0: lineMode (0=글자단위/CHAR, 1=줄단위/LINE)
+        equation.eqedit = r.read_u32().unwrap_or(0);
 
         // script: WCHAR 문자열 (길이 접두 UTF-16LE)
         if let Ok(script) = r.read_hwp_string() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5302,6 +5302,7 @@ fn parse_equation(
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
     let mut font_name = String::new();
+    let mut eqedit: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5312,6 +5313,12 @@ fn parse_equation(
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
             b"font" => font_name = attr_str(&attr),
+            b"lineMode" => {
+                eqedit = match attr_str(&attr).as_str() {
+                    "LINE" => 0x01,
+                    _ => 0x00,
+                };
+            }
             _ => {}
         }
     }
@@ -5395,6 +5402,7 @@ fn parse_equation(
         color,
         baseline,
         unknown: 0,
+        eqedit,
         font_name,
         version_info,
         raw_ctrl_data: Vec::new(),

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2389,8 +2389,8 @@ fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Recor
 
     // HWPTAG_EQEDIT 자식 레코드
     let mut w = ByteWriter::new();
-    // attr: u32
-    w.write_u32(0).unwrap();
+    // attr: u32 — bit0: lineMode (0=CHAR, 1=LINE)
+    w.write_u32(eq.eqedit).unwrap();
     // script: HWP string (length-prefixed UTF-16LE)
     w.write_hwp_string(&eq.script).unwrap();
     // font_size: u32

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -564,6 +564,7 @@ mod tests {
             color: 0x000000FF,
             baseline: 120,
             unknown: 0,
+            eqedit: 0,
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2026,8 +2026,15 @@ fn render_equation(eq: &Equation) -> String {
     // [#1594] holdAnchorAndSO 는 IR(prevent_page_break)을 보존(종전 "0" 하드코딩 제거).
     let hold = if c.prevent_page_break != 0 { "1" } else { "0" };
 
+    // [#2727] lineMode — EQEDIT attr bit 0 (0=CHAR, 1=LINE)
+    let line_mode = if eq.eqedit & 0x01 != 0 {
+        "LINE"
+    } else {
+        "CHAR"
+    };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}" lineMode="{line_mode}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),


### PR DESCRIPTION
## 개요

HWP5 EQEDIT record의 첫 필드(UINT32 attr)는 `lineMode` (bit 0: 0=글자단위/CHAR,
1=줄단위/LINE)를 포함하지만, 파싱 시 `_attr`로 읽기만 하고 모델에 저장하지 않아
버려졌다. 직렬화 시에도 `write_u32(0)`으로 고정 출력되어 저장 시 항상 0이 기록되었다.

HWPX 경로에서도 `<hp:equation>`의 `lineMode` 속성이 파싱/직렬화 양쪽에서 누락되어
동일한 유실이 발생했다.

**4경로 전부 유실**: HWP5 parse, HWP5 serialize, HWPX parse, HWPX serialize

## 변경 사항

### 모델
- `src/model/control.rs`: `Equation` struct에 `pub eqedit: u32` 필드 추가

### HWP5 경로
- `src/parser/control.rs`: `let _attr` → `equation.eqedit = read_u32()`
- `src/serializer/control.rs`: `write_u32(0)` → `write_u32(eq.eqedit)`

### HWPX 경로
- `src/parser/hwpx/section.rs`: `lineMode` 속성 파싱 (LINE→bit0=1, CHAR→bit0=0)
- `src/serializer/hwpx/section.rs`: `<hp:equation>`에 `lineMode` 속성 출력
- `src/serializer/hwpx/mod.rs`: 테스트 픽스처에 `eqedit: 0` 추가

## 영향
- `Default` derive로 `eqedit: 0`이 기본값 → 신규 생성 수식은 CHAR mode (글자 단위)
- 기존 HWP5 파일의 EQEDIT attr이 라운드트립에서 보존됨
- HWPX `<hp:equation>`에 `lineMode` 속성이 항상 출력됨 (기존에는 없었음)

## 테스트
- `cargo check` 통과
- `cargo clippy --all-targets` 통과
- `cargo test --test issue_1061_equation_serialize` 통과 (7개 회귀 가드)