### PR TITLE
fix(hwp5): PARA_SHAPE 말미 4바이트(개요 수준) 미파싱·0 하드코딩 — 문단 서식 편집 한 번에 개요 수준 리셋, 8~10수준은 읽기부터 붕괴 (#2734)

### DIFF
--- a/mydocs/report/task_m100_2734_report.md
+++ b/mydocs/report/task_m100_2734_report.md
@@ -1,0 +1,342 @@
+# task_m100_2734 처리결과 보고서 — PARA_SHAPE 말미 4바이트(개요 수준) 복원
+
+- **이슈**: [#2734](https://github.com/edwardkim/rhwp/issues/2734)
+- **브랜치**: `task/m100-2734-docinfo-parashape-outline-level` (base `origin/devel` @ `1658d0bb`)
+- **범위**: `src/parser/doc_info.rs`, `src/serializer/doc_info.rs`, `src/serializer/doc_info/tests.rs`
+- **분류**: 결함 수정 (HWP5 DocInfo 라운드트립 — 필드 미파싱 + 하드코딩 리터럴)
+
+## 1. 문제
+
+`HWPTAG_PARA_SHAPE` 레코드 payload 말미 4바이트(offset 54~57)는 **문단 개요 수준(0~9 = 1수준~10수준)** 이다.
+`attr1` bit 25~27 은 3비트뿐이라 한컴이 6에서 포화시키므로, **8·9·10수준은 이 4바이트에만 존재**한다.
+
+rhwp 는 이 필드를 양쪽에서 다뤘어야 하는데 둘 다 놓쳤다.
+
+1. **파서** (`src/parser/doc_info.rs` `parse_para_shape`) — 4바이트를 아예 읽지 않았다.
+   `para_level` 이 `attr1` 비트에서만 나오므로 8·9·10수준 문단이 전부 **7수준으로 붕괴**했다.
+2. **직렬화기** (`src/serializer/doc_info.rs` `serialize_para_shape`) — `w.write_u32(0)` 리터럴이었다.
+   재직렬화되는 문단 모양마다 개요 수준이 **1수준으로 리셋**되고, `attr1` 이 말하는 수준과
+   tail 이 말하는 수준이 **서로 모순되는 레코드**가 만들어졌다.
+
+이 4바이트를 zero 로 materialize 하는 코드는 #1110 stage26 에서 **"58바이트 길이 계약"만 맞추려고**
+들어간 것이고(`mydocs/working/archives/task_m100_1110_stage1.md:2225-2258`), 값의 정체는 당시 규명되지 않았다.
+이번 작업은 그 값을 규명해 채운 것이며 **길이 계약은 그대로**다(58바이트 불변, 값만 채움).
+
+## 2. 분석
+
+### 2.1 `raw_stream_dirty` 통과 경로 분석 (이 결함이 가려지지 않는 이유)
+
+DocInfo 는 2단 통과 계층을 갖는다.
+
+- **1단 (스트림)** `serializer/doc_info.rs:22-33` — `!raw_stream_dirty && raw_stream.is_some()` 이면
+  원본 스트림을 그대로 반환한다.
+- **2단 (레코드)** `serializer/doc_info.rs:107-113` — dirty 여도 각 ParaShape 은 `raw_data` 가 `Some` 이면
+  원본 바이트를 쓴다.
+
+따라서 `serialize_para_shape()` 가 실제로 도는 조건은 **dirty == true 이면서 그 ParaShape 의
+`raw_data == None`** 이다. 이 결함이 "편집 안 한 문서에선 안 돈다"로 무마되지 않는 이유는,
+**dirty 를 세우는 바로 그 동작이 동시에 `raw_data = None` 인 ParaShape 을 만들기 때문**이다.
+
+`model/document.rs:466-491` `find_or_create_para_shape()` 는 한 함수 안에서
+`ParaShapeMods::apply_to()`(`model/style.rs:918` 에서 `raw_data = None`)로 새 ParaShape 을 만들고,
+push 한 뒤 `raw_stream_dirty = true` 를 세운다. 그리고 편집된 문단이 바로 그 새 id 를 참조한다.
+
+| 조건 | 성립 | 근거 |
+|---|---|---|
+| `raw_stream_dirty = true` | O | `document.rs:489` |
+| 새 ParaShape 의 `raw_data == None` | O | `style.rs:918` |
+| 편집된 문단이 그 ParaShape 참조 | O | `find_or_create_para_shape()` 반환 id |
+
+호출 지점(= 이 경로를 타는 사용자 동작): `formatting.rs:1374,1530,1720,1742`,
+`footnote_ops.rs:391`, `header_footer_ops.rs:843,1037`.
+즉 **정렬·줄간격·여백·들여쓰기·문단수준·탭·문단 테두리** 중 하나만 바꿔도 이 경로다.
+특히 `ParaShapeMods::para_level` 로 **사용자가 개요 수준을 직접 지정**하는 경로에서도
+tail 은 0 으로 나갔다 — 방금 지정한 수준이 한컴이 읽는 필드에 반영되지 않았다.
+
+정직하게 덧붙이면, `find_or_create_para_shape()` 는 동일 ParaShape 이 있으면 **재사용**하고
+그 경우엔 원본 `raw_data` 가 쓰여 손실이 없다. 손실은 **새로 push 되는 경우**에 발생한다.
+
+한편 **읽기 쪽 손실은 dirty 와 무관하게 항상** 발생했다. 소비처는 개요번호 렌더링
+(`renderer/layout.rs:1826`, `renderer/layout/paragraph_layout.rs:6126`), 구조 추출
+(`document_core/queries/structure.rs:82`), HWPX `level` 속성(`serializer/hwpx/header.rs:1075`),
+HML `Level`(`serializer/hml/head.rs:176`) 이다.
+
+### 2.2 필드 정체 규명
+
+`samples/*.hwp` 252개 파일에서 58바이트 `PARA_SHAPE` 11,913건의 tail 과 `attr1` bit25~27 을 대조했다.
+
+| tail | `attr1` 수준 | 건수 | 판정 |
+|---:|---:|---:|---|
+| 0 | 0 | 11,032 | 일치 |
+| 1 | 1 | 97 | 일치 |
+| 2 | 2 | 94 | 일치 |
+| 3 | 3 | 305 | 일치 |
+| 4 | 4 | 84 | 일치 |
+| 5 | 5 | 77 | 일치 |
+| 6 | 6 | 77 | 일치 |
+| 7 | **6** | 46 | attr1 포화 |
+| 8 | **6** | 46 | attr1 포화 |
+| 9 | **6** | 46 | attr1 포화 |
+| 0 | 1~6 | 9 | 단일 파일 예외 |
+
+tail 0~6 구간이 1:1 완전 일치하고, 7·8·9 에서 `attr1` 이 6 으로 포화한다.
+어긋나는 유일한 사례는 `issue2439_zero_offset_coanchored_float_exclusion.hwp`(ver 5.1.0.0) 한 파일의
+9건뿐이며, 나머지 **125개 파일 / 11,904건에서 어긋남 0건**이다.
+
+**교차 검증**: `tail >= 7` 인 ParaShape 을 가진 파일은 46개이고 각 파일에서 정확히 3개(7,8,9)씩 나온다
+(46×3 = 138). 그중 42개 파일이 `HWPTAG_NUMBERING` 에도 확장 수준을 갖는다. 실제 바이트를 뜯으면
+8·9·10수준 문단머리정보 3개 + 시작번호 3개이며, 8수준 번호 형식 문자열이 `5e 00 38 00` = `"^8"` 이다.
+즉 코퍼스의 한컴 문서들이 실제로 8~10수준 개요를 정의하고 있고, 대응 문단모양이 tail 7·8·9 를 갖는다.
+
+## 3. 실측
+
+집계 코드는 `src/serializer/doc_info/tests.rs` 에 임시 테스트로 붙여 실행하고 커밋 전 제거했다
+(커밋에 포함되지 않음). 측정 항목은 (a) tail ↔ attr1 상관, (b) 각 레코드의 `raw_data` 와
+`serialize_X(parse 결과)` 의 바이트 비교다.
+
+### 3.1 수정 전
+
+```
+파일: 성공 252 / 실패 18 (총 270)
+PARA_SHAPE  총 15043  동일 11041  다름 4002   firstdiff={42:112 46:84 54:3806}
+  원본 크기 분포: 42B:112  46B:84  54B:2934  58B:11913
+```
+
+`firstdiff` offset 54 의 3,806건 = 54바이트 레코드 2,934건(tail 신규 부착, 손실 아님)
+**+ 58바이트 레코드 872건(원본 tail 1~9 를 0 으로 덮어씀 = 손실)**.
+
+### 3.2 수정 후
+
+```
+파일: 성공 252 / 실패 18 (총 270)
+PARA_SHAPE  총 15043  동일 11904  다름 3139   firstdiff={42:112 46:84 54:2943}
+```
+
+- **바이트 동일 11,041 → 11,904 (+863)**. 손실 872건 중 863건이 사라졌다.
+- 54바이트 레코드 2,934건의 tail 신규 부착은 #1110 계약 그대로 유지된다.
+
+**남은 9건을 숨기지 않고 밝힌다.**
+
+- 전부 **`issue2439_zero_offset_coanchored_float_exclusion.hwp` 한 파일**(FileHeader ver 5.1.0.0)의
+  ParaShape 9개다. 나머지 125개 파일 11,904건에는 이런 레코드가 없다.
+- 원본이 **`attr1` 수준 = 1,2,3,4,5,6,6,6,6 인데 tail = 0** 인 **자기모순** 레코드다.
+- 수정 후 rhwp 는 tail 에 `attr1` 값을 써서 두 필드를 **정합**시킨다. 값을 지어내는 게 아니라
+  이미 레코드 안에 있는 수준을 다른 필드에도 반영하는 것이다.
+- **IR `para_level` 은 종전과 완전히 동일하다.** 파서가 `max(attr1, tail)` 을 쓰므로 `max(3,0) = 3` 으로
+  기존 값이 유지된다. 이 회귀 없음을 테스트로 고정했다
+  (`para_shape_recovers_outline_level_8_to_10_from_tail` 의 `tail=0/attr1=1~6` 루프).
+- 이 파일 하나만 왜 다른지는 **규명하지 못했다**(다른 파일은 ver 5.1.0.1 / 5.1.1.0). tail 을 채우지
+  않는 구버전 writer 산출물로 **추정**하지만 확인하지 않았으므로 추정이라고 명시한다.
+
+### 3.3 다른 DocInfo 레코드 무영향 확인 (실측)
+
+같은 census 를 수정 전/후로 돌려 전 레코드 종류를 비교했다. **PARA_SHAPE 외 전부 동일**하다.
+
+| 레코드 | 총 | 다름 (수정 전) | 다름 (수정 후) |
+|---|---:|---:|---:|
+| BIN_DATA | 1,627 | 0 | 0 |
+| FACE_NAME | 10,093 | 171 | 171 |
+| BORDER_FILL | 6,237 | 82 | 82 |
+| CHAR_SHAPE | 13,991 | 1,706 | 1,706 |
+| TAB_DEF | 950 | 8 | 8 |
+| NUMBERING | 347 | 203 | 203 |
+| BULLET | 62 | 62 | 62 |
+| STYLE | 6,436 | 101 | 101 |
+| **PARA_SHAPE** | **15,043** | **4,002** | **3,139** |
+
+### 3.4 실측 vs 잠재
+
+- **실측**: 위 모든 수치, tail 값 분포와 상관, 872 → 9 감소, 8수준 번호 형식 바이트 덤프.
+- **잠재(코드 판독)**: "한컴 편집기가 tail 을 authoritative 로 읽어 1수준으로 표시한다"는 부분.
+  한컴 실행 검증은 하지 않았다. 확실한 것은 종전 코드가 **attr1 과 tail 이 모순되는 레코드**를
+  만들었고 한컴 산출물 11,904건은 예외 없이 정합했다는 점, 그리고 8~10수준은 attr1 이 표현할
+  수단 자체가 없어 tail 유실 = 수준 유실이 확정적이라는 점이다.
+- **잠재**: HWPX(.hwpx) → .hwp 변환 산출물을 한컴으로 열어 확인하지 않았다.
+
+## 4. 변경
+
+### 4.1 파서 (`src/parser/doc_info.rs`)
+
+`line_spacing_v2` 다음에 말미 4바이트를 읽고, `para_level` 을 두 출처의 **큰 쪽**으로 정한다.
+
+```rust
+let outline_level_tail = if r.remaining() >= 4 { r.read_u32().unwrap_or(0) } else { 0 };
+...
+let para_level = (((attr1 >> 25) & 0x07) as u8).max(outline_level_tail.min(9) as u8);
+```
+
+`max` 를 쓰는 근거는 실측이다. 두 값이 어긋나는 실측 사례는 (a) tail 7~9 / attr1 6(포화) 138건,
+(b) tail 0 / attr1 1~6 단일 파일 9건뿐이므로, `max` 가 (a)에서 8~10수준을 복원하면서
+(b)에서 종전 동작을 그대로 보존한다. tail 이 없는 42/46/54바이트 레코드는 `remaining() < 4` 라
+`outline_level_tail = 0` → 종전과 동일하다.
+
+### 4.2 직렬화기 (`src/serializer/doc_info.rs`)
+
+```rust
+// bits 25-27
+attr1 |= (ps.para_level.min(6) as u32) << 25;   // 종전: (ps.para_level as u32 & 0x07) << 25
+...
+w.write_u32(ps.para_level.min(9) as u32).unwrap();  // 종전: w.write_u32(0)
+```
+
+`min(6)` 은 한컴 실측 규약이다(개요 8~10수준 문단모양 138건이 모두 attr1 비트 6 + tail 7/8/9).
+종전 `& 0x07` 은 `para_level` 이 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.
+
+### 4.3 건드리지 않은 것
+
+- `ParaShape` 모델 — 필드 추가 없음. `para_level` 이 이미 같은 개념이다.
+- `ParaShapeMods::apply_to` — attr1 비트를 `v & 0x07` 로 쓰지만 직렬화기가 그 비트를 무조건
+  다시 계산하므로 출력에 영향이 없다. 무관 변경 금지 원칙에 따라 손대지 않았다.
+- 58바이트 길이 계약(#1110 stage26), HWPX/HML/렌더러. 렌더러의 `para_level` 소비처는 이미
+  `layout.rs:984`, `paragraph_layout.rs:6139` 에서 `.min(6)` 으로 방어하므로 값이 7~9 로 확장돼도
+  인덱스 초과가 없다.
+
+## 5. 검증
+
+### 5.1 red → green (실제 실행 캡처)
+
+수정 2건(파서 tail 반영, 직렬화기 tail 기록·attr1 포화)을 되돌리고 테스트만 남긴 상태.
+
+```
+running 5 tests
+test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... FAILED
+test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... FAILED
+test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... FAILED
+test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... FAILED
+
+---- serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail stdout ----
+thread '...' panicked at src\serializer\doc_info\tests.rs:283:9:
+assertion `left == right` failed: 말미 4바이트에 개요 수준 1 이 실려야 함
+  left: 0
+ right: 1
+
+---- parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1292:13:
+assertion `left == right` failed: 개요 1 수준 레코드 재직렬화 시 말미 4바이트가 보존돼야 함
+  left: [0, 0, 0, 0]
+ right: [1, 0, 0, 0]
+
+---- parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1310:13:
+assertion `left == right` failed: 개요 수준 8 왕복 보존
+  left: 0
+ right: 8
+
+---- parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1255:13:
+assertion `left == right` failed: tail=7 이면 개요 수준 7 로 복원돼야 함(attr1 은 6 에서 포화)
+  left: 6
+ right: 7
+
+test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 2470 filtered out; finished in 0.00s
+```
+
+**RED 에서도 통과하는 테스트가 있다 — 어느 것이고 왜인지 밝힌다.**
+
+- `test_serialize_para_shape_roundtrip`(기존 테스트)은 RED 에서도 통과한다. `para_level: 0` 인
+  ParaShape 만 쓰므로 `write_u32(0)` 과 `write_u32(para_level)` 의 출력이 같다.
+  이 테스트의 `assert_eq!(&data[54..58], &[0,0,0,0])` 단언은 수정 후에도 그대로 유효하므로
+  변경하지 않았다.
+- `para_shape_outline_level_roundtrips_0_to_9` 는 **수준 8에서 처음 실패**한다. 수준 0~7 은
+  RED 상태에서도 `attr1` bit25~27(3비트, `& 0x07`)만으로 rhwp 내부 왕복이 성립하기 때문이다.
+  이 테스트가 잡는 것은 3비트를 넘는 8·9수준뿐이다. **한컴이 읽는 tail 값이 사라지는 본체 결함은
+  `serialize_para_shape_writes_outline_level_into_tail`(수준 1에서 즉시 실패)과
+  `para_shape_edit_path_keeps_outline_level_in_tail`(수준 1에서 즉시 실패)이 잡는다.**
+
+수정 복원 후:
+
+```
+running 5 tests
+test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... ok
+test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... ok
+test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... ok
+test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2470 filtered out; finished in 0.00s
+```
+
+### 5.2 CI 3종
+
+```
+$ cargo clippy --all-targets -- -D warnings
+    Checking rhwp v0.7.19 (C:\Users\swsz9\Downloads\moneyflow\rhwp-wt-c)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s
+→ 경고 0건
+```
+
+```
+$ git diff --name-only origin/devel...HEAD -- '*.rs'
+src/parser/doc_info.rs
+src/serializer/doc_info.rs
+src/serializer/doc_info/tests.rs
+
+$ for f in $(git diff --name-only origin/devel...HEAD -- '*.rs'); do rustfmt --edition 2021 "$f"; done
+$ git diff --name-only
+[빈 출력]
+```
+
+빈 출력 = 커밋된 3개 파일이 모두 포맷을 준수한다. (커밋 전 1차 적용 시 신규 테스트 1곳의
+줄바꿈 3줄이 조정됐고 그 결과를 커밋에 포함했으므로, 커밋 후 재적용에서는 변화가 없다.)
+`cargo fmt --all -- --check` 는 이 CRLF 체크아웃에서 `Incorrect newline style` 만 찍고
+diff 를 내지 않아 false pass 하므로 **사용하지 않았다.**
+
+```
+$ cargo test --profile release-test --tests
+→ exit 0
+→ 테스트 타깃 292개 전부 ok
+→ 합계 3,494 passed / 0 failed / 23 ignored / 0 measured
+   · lib 단위 테스트(src/lib.rs) 2,468 passed / 0 failed / 7 ignored — 신규 4건 + 기존 1건 포함:
+       test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... ok
+       test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... ok
+       test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... ok
+       test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... ok
+       test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+   · 나머지 291개 타깃(tests/ 통합 + bin) 1,026 passed / 0 failed / 16 ignored
+→ 출력 전체에서 `FAILED` / `panicked at` 0건
+```
+
+DocInfo 변경은 파급이 넓어 실파일 왕복·바이트 baseline 게이트를 특히 확인했다. 전부 통과:
+
+```
+tests/hwp5_roundtrip_baseline.rs    ok. 3 passed (baseline_all_samples_roundtrip / large / xfail)
+tests/hwpx_roundtrip_baseline.rs    ok. 4 passed
+tests/visual_roundtrip_baseline.rs  ok. 3 passed
+tests/opengov_corpus_snapshot.rs    ok. 2 passed
+tests/svg_snapshot.rs               ok. 8 passed
+tests/hwp5_strikeout_shape_parity.rs ok. 2 passed
+serializer::cfb_writer::tests::test_serialize_real_hwp_files ... ok
+```
+
+내가 작성하지 않은 테스트 중 실패한 것은 **없다**. 따라서 기존 단언을 수정한 곳도 없다.
+
+### 5.3 코퍼스 재측정
+
+3.2·3.3 참조. PARA_SHAPE 손실 872 → 9(자기모순 레코드 정합화), 다른 레코드 종류 무변화.
+
+## 6. 미실행 항목
+
+- **한컴 편집기 실물 판정 없음.** 수정 후 .hwp 를 한글에서 열어 개요 수준을 눈으로 확인하지 않았다.
+  근거는 전적으로 코퍼스 실측(11,913건 전수 상관)과 코드 경로 분석이다.
+- **HWPX→HWP 변환 산출물 실물 검증 없음.** 이 경로에서도 tail 이 채워지도록 개선되지만
+  변환 결과를 한컴으로 열어보지는 않았다.
+- **8~10수준 렌더링 개선 여부 미검증.** 파서가 이제 7·8·9 를 반환하지만 렌더러/HWPX/HML 이
+  이 값으로 무엇을 다르게 그리는지는 이번 범위에서 측정하지 않았다(소비처가 모두 `.min(6)` 으로
+  클램프하므로 렌더 결과는 종전과 동일할 가능성이 높다). 이 이슈의 성과는 **저장 시 유실 차단**과
+  **IR 정확도 회복**이다.
+
+## 7. 잔여 (범위 밖)
+
+같은 코퍼스 조사에서 함께 관측된 DocInfo 결함들. 이슈 #2734 의 7절에도 기록했다.
+수치는 실측, "영향"은 코드 판독 기반 추정이다.
+
+| 대상 | 관측 | 실측 규모 |
+|---|---|---|
+| `HWPTAG_BULLET` | 실제 레코드는 23/25바이트인데 `serialize_bullet` 은 항상 24바이트. 이미지 글머리 정보가 5바이트(밝기1+명암1+효과1+binID2)인데 파서는 `image_data: [u8;4]` 로 4바이트만 읽어 `check_bullet_char` 가 1바이트 밀린다 | 62/62 불일치. 25바이트 37건 중 13건에서 `U+0020` 대신 `U+2000`, 2건에서 `U+F0A4` 대신 `U+A400` 으로 파싱 |
+| `HWPTAG_NUMBERING` | 8·9·10수준 문단머리정보 + 번호 형식 + 시작번호 3개 미파싱 → 재직렬화 시 60바이트 축소 | 347건 중 200건(57.6%)이 확장 수준 보유 |
+| `HWPTAG_FACE_NAME` | 대체 글꼴 앞 "대체 글꼴 유형" 1바이트를 `font.alt_type & 0x03`(자기 자신의 유형)으로 덮어씀 | 109건 |
+| `HWPTAG_CHAR_SHAPE` | 밑줄 종류 `(attr>>2)&3 == 2` 를 `UnderlineType::None` 으로 접고 0 으로 씀 | 13,991건 중 1,514건 |
+| `HWPTAG_CHAR_SHAPE` | 취소선 비트(18~20)를 `is_real_strike_shape_id` 판정으로 재기록해 원본 비트가 1→0 / 1→2 로 변함 | 1,620건 |
+| `HWPTAG_BORDER_FILL` | fill type 이 비트마스크인데 모델이 단일 enum 이라 `0x03`(단색+이미지)이 이미지 단독으로 붕괴 | 6,237건 중 28건 |
+| `HWPTAG_DOCUMENT_PROPERTIES` | `serialize_document_properties` 가 `raw_data` 있으면 무조건 원본 반환 → 모델 필드 변경 무반영 | 코드 판독만 |

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -738,13 +738,26 @@ fn parse_para_shape(data: &[u8]) -> Result<ParaShape, DocInfoError> {
         0
     };
 
+    // [#2734] 말미 4바이트(payload offset 54~57) = 개요 수준(0~9 = 1수준~10수준).
+    // attr1 bit25~27 은 3비트라 한컴이 6 에서 포화시키므로 8~10수준은 이 필드에만 남는다.
+    // 종전엔 읽지 않아 8·9·10수준 문단이 모두 7수준(para_level=6)으로 붕괴했다.
+    let outline_level_tail = if r.remaining() >= 4 {
+        r.read_u32().unwrap_or(0)
+    } else {
+        0
+    };
+
     let head_type = match (attr1 >> 23) & 0x03 {
         1 => crate::model::style::HeadType::Outline,
         2 => crate::model::style::HeadType::Number,
         3 => crate::model::style::HeadType::Bullet,
         _ => crate::model::style::HeadType::None,
     };
-    let para_level = ((attr1 >> 25) & 0x07) as u8;
+    // [#2734] 두 출처 중 큰 쪽을 취한다. samples 코퍼스 58바이트 레코드 11,913건 전수에서
+    // 두 값이 어긋나는 경우는 (a) tail 7~9 / attr1 6(포화) 138건, (b) tail 0 / attr1 1~6 인
+    // 단일 파일 9건뿐이라, max 가 (a)에서 8~10수준을 복원하면서 (b)의 기존 동작을 보존한다.
+    // tail 이 없는 42/46/54바이트 레코드는 outline_level_tail=0 이라 종전과 동일하다.
+    let para_level = (((attr1 >> 25) & 0x07) as u8).max(outline_level_tail.min(9) as u8);
 
     Ok(ParaShape {
         raw_data: None,
@@ -1204,6 +1217,97 @@ mod tests {
         assert_eq!(ps.line_spacing, 160);
         assert!(matches!(ps.alignment, Alignment::Justify));
         assert!(matches!(ps.line_spacing_type, LineSpacingType::Percent));
+    }
+
+    /// [#2734] PARA_SHAPE 레코드 바이트 생성 헬퍼.
+    ///
+    /// `tail` 이 Some 이면 58바이트(말미 개요 수준 4바이트 포함), None 이면 54바이트.
+    fn make_para_shape_bytes(attr1: u32, tail: Option<u32>) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&attr1.to_le_bytes());
+        for _ in 0..6 {
+            data.extend_from_slice(&0i32.to_le_bytes()); // 여백/들여쓰기/간격/줄간격
+        }
+        for _ in 0..3 {
+            data.extend_from_slice(&0u16.to_le_bytes()); // tab_def/numbering/border_fill id
+        }
+        for _ in 0..4 {
+            data.extend_from_slice(&0i16.to_le_bytes()); // border_spacing
+        }
+        data.extend_from_slice(&0u32.to_le_bytes()); // attr2
+        data.extend_from_slice(&0u32.to_le_bytes()); // attr3
+        data.extend_from_slice(&0u32.to_le_bytes()); // line_spacing_v2
+        if let Some(t) = tail {
+            data.extend_from_slice(&t.to_le_bytes());
+        }
+        data
+    }
+
+    #[test]
+    fn para_shape_recovers_outline_level_8_to_10_from_tail() {
+        // [#2734] attr1 bit25~27 은 3비트라 한컴이 6 에서 포화시키고 실제 개요 수준은
+        // 말미 4바이트에 쓴다. 종전엔 tail 을 읽지 않아 8·9·10수준이 모두 7수준으로 붕괴했다.
+        for (tail, expected) in [(7u32, 7u8), (8, 8), (9, 9)] {
+            let data = make_para_shape_bytes(6u32 << 25, Some(tail));
+            assert_eq!(data.len(), 58);
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(
+                ps.para_level, expected,
+                "tail={tail} 이면 개요 수준 {expected} 로 복원돼야 함(attr1 은 6 에서 포화)"
+            );
+        }
+
+        // 1~7수준 구간은 두 출처가 일치한다 — 값이 그대로여야 한다.
+        for lvl in 0u32..=6 {
+            let data = make_para_shape_bytes(lvl << 25, Some(lvl));
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(ps.para_level, lvl as u8, "tail=attr1={lvl} 인 정합 레코드");
+        }
+
+        // 실측 예외(단일 파일 9건): tail=0 인데 attr1 이 수준을 갖는 형태.
+        // 종전 동작(attr1 값)이 그대로 유지돼야 회귀가 아니다.
+        for lvl in 1u32..=6 {
+            let data = make_para_shape_bytes(lvl << 25, Some(0));
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(ps.para_level, lvl as u8, "tail=0/attr1={lvl} → attr1 유지");
+        }
+
+        // tail 이 없는 54바이트 레코드는 종전과 동일하게 attr1 만 본다.
+        let data = make_para_shape_bytes(3u32 << 25, None);
+        assert_eq!(data.len(), 54);
+        assert_eq!(parse_para_shape(&data).unwrap().para_level, 3);
+    }
+
+    #[test]
+    fn para_shape_edit_path_keeps_outline_level_in_tail() {
+        // [#2734] 실제 손실 경로 재현: 개요 수준이 있는 한컴 레코드를 읽어 raw_data 없이
+        // 다시 직렬화하는 경로(find_or_create_para_shape → ParaShapeMods::apply_to 가
+        // raw_data=None 으로 만든 새 ParaShape)에서 말미 4바이트가 살아남아야 한다.
+        // 종전엔 0 리터럴이라 한컴이 읽는 개요 수준 필드가 매번 1수준으로 리셋됐다.
+        for lvl in 1u32..=6 {
+            let original = make_para_shape_bytes(lvl << 25, Some(lvl));
+            let ps = parse_para_shape(&original).unwrap();
+            let resaved = crate::serializer::doc_info::serialize_para_shape(&ps);
+            assert_eq!(
+                &resaved[54..58],
+                &original[54..58],
+                "개요 {lvl} 수준 레코드 재직렬화 시 말미 4바이트가 보존돼야 함"
+            );
+        }
+    }
+
+    #[test]
+    fn para_shape_outline_level_roundtrips_0_to_9() {
+        // [#2734] 개요 수준 전 범위(1~10수준)가 직렬화→재파싱을 통과해야 한다.
+        // 종전엔 직렬화가 말미 4바이트를 0 리터럴로 써서 모든 수준이 0(1수준)으로 리셋됐다.
+        for lvl in 0u8..=9 {
+            let mut ps = parse_para_shape(&make_para_shape_bytes(0, Some(0))).unwrap();
+            ps.para_level = lvl;
+            let bytes = crate::serializer::doc_info::serialize_para_shape(&ps);
+            assert_eq!(bytes.len(), 58, "58바이트 길이 계약(#1110)은 유지");
+            let back = parse_para_shape(&bytes).unwrap();
+            assert_eq!(back.para_level, lvl, "개요 수준 {lvl} 왕복 보존");
+        }
     }
 
     #[test]

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -657,8 +657,11 @@ pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8> {
         crate::model::style::HeadType::Bullet => 3,
     }) << 23;
     // bits 25-27: para_level
+    // [#2734] 3비트 필드라 6 에서 포화시킨다. 한컴 실측 규약(개요 8~10수준 문단모양 138건이
+    // 모두 attr1 비트 6 + 말미 4바이트 7/8/9)과 동일하다. 종전 `& 0x07` 은 para_level 이
+    // 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.
     attr1 &= !(0x07 << 25);
-    attr1 |= (ps.para_level as u32 & 0x07) << 25;
+    attr1 |= (ps.para_level.min(6) as u32) << 25;
     w.write_u32(attr1).unwrap();
     w.write_i32(ps.margin_left).unwrap();
     w.write_i32(ps.margin_right).unwrap();
@@ -684,7 +687,11 @@ pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8> {
     // 내보낸 정답지들은 PARA_SHAPE를 58바이트로 저장한다. 이 tail이 없으면
     // 한컴 편집기가 일부 masterpage/header 글상자 내부 줄나눔 폭을 다르게
     // 해석해 페이지 번호가 다음 줄로 밀리는 사례가 있다.
-    w.write_u32(0).unwrap();
+    //
+    // [#2734] 이 4바이트의 정체는 개요 수준(0~9 = 1수준~10수준)이다. samples 코퍼스의
+    // 58바이트 레코드 11,913건에서 tail 과 attr1 bit25~27 이 전수 정합하며(포화 138건 제외),
+    // tail != 0 인 872건이 종전 0 리터럴에 덮여 사라졌다. 길이 계약은 그대로 두고 값만 채운다.
+    w.write_u32(ps.para_level.min(9) as u32).unwrap();
     w.into_bytes()
 }
 

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -267,6 +267,34 @@ fn test_serialize_para_shape_roundtrip() {
 }
 
 #[test]
+fn serialize_para_shape_writes_outline_level_into_tail() {
+    // [#2734] 말미 4바이트는 개요 수준(0~9 = 1수준~10수준)이다. 종전엔 0 리터럴이라
+    // 재직렬화되는 모든 문단 모양의 개요 수준이 사라졌다(코퍼스 실측 872건).
+    // attr1 bit25~27 은 3비트라 한컴처럼 6 에서 포화해야 한다.
+    for lvl in 0u8..=9 {
+        let ps = ParaShape {
+            para_level: lvl,
+            ..Default::default()
+        };
+        let data = serialize_para_shape(&ps);
+        assert_eq!(data.len(), 58, "58바이트 길이 계약(#1110) 유지");
+
+        let tail = u32::from_le_bytes([data[54], data[55], data[56], data[57]]);
+        assert_eq!(
+            tail as u8, lvl,
+            "말미 4바이트에 개요 수준 {lvl} 이 실려야 함"
+        );
+
+        let attr1 = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        assert_eq!(
+            (attr1 >> 25) & 0x07,
+            lvl.min(6) as u32,
+            "attr1 bit25~27 은 6 에서 포화(한컴 실측 규약)"
+        );
+    }
+}
+
+#[test]
 fn test_serialize_style_roundtrip() {
     let style = Style {
         raw_data: None,


### PR DESCRIPTION
이슈 #2734 수정.

## 무엇이 문제였나

`HWPTAG_PARA_SHAPE` payload 말미 4바이트(offset 54~57)는 **문단 개요 수준(0~9 = 1수준~10수준)** 이다.
`attr1` bit25~27 은 3비트라 한컴이 6에서 포화시키므로 **8·9·10수준은 이 4바이트에만 존재**한다.

- **파서** `parse_para_shape()` — 이 4바이트를 아예 읽지 않아 8·9·10수준 문단이 전부 7수준으로 붕괴.
- **직렬화기** `serialize_para_shape()` — `w.write_u32(0)` 리터럴이라 재직렬화되는 문단 모양마다
  개요 수준이 1수준으로 리셋되고, `attr1` 과 tail 이 **서로 모순되는 레코드**가 만들어졌다.

말미 4바이트를 zero 로 채우는 코드는 #1110 stage26 에서 **58바이트 길이 계약만 맞추려고** 들어간 것이고
값의 정체는 당시 규명되지 않았다(`mydocs/working/archives/task_m100_1110_stage1.md:2225-2258`).
이 PR 은 그 값을 규명해 채운다. **길이 계약은 불변**(58바이트, 값만 채움).

## 이 4바이트가 "개요 수준"이라는 근거

값이 무엇인지 모른 채 채우면 #1110 때와 똑같은 실수가 되므로, 정체를 두 갈래로 입증했다.

**근거 1 — `attr1` 수준 비트와의 전수 대조 + 포화 현상.**
`samples/*.hwp` 252개 파일의 58바이트 `PARA_SHAPE` 11,913건에서 tail 과 `attr1` bit25~27 을 대조했다.

| tail | `attr1` 수준 | 건수 | 판정 |
|---:|---:|---:|---|
| 0~6 | 동일 | 11,766 | 1:1 완전 일치 |
| 7 | **6** | 46 | attr1 포화 |
| 8 | **6** | 46 | attr1 포화 |
| 9 | **6** | 46 | attr1 포화 |
| 0 | 1~6 | 9 | 단일 파일 예외(아래 별도 설명) |

tail 0~6 구간이 문서화된 `attr1` 문단 수준 필드와 **1:1 로 완전히 일치**한다. 그리고 결정적으로,
tail 이 7·8·9 일 때 `attr1` 이 예외 없이 **6 에서 멈춘다**. 3비트 필드는 0~7 을 담을 수 있는데도
7 을 쓰지 않고 6 에 포화시킨다는 것은, 한컴이 그 필드를 "표현 가능한 최대치"로 clamp 하고
**실제 수준은 tail 에만 기록**한다는 뜻이다. 즉 8~10수준의 유일한 운반 수단이 tail 이다.

**근거 2 — `HWPTAG_NUMBERING` 확장 수준과의 교차 검증(독립 증거).**
`tail >= 7` 인 ParaShape 을 가진 파일은 46개이고, 각 파일에서 **정확히 3개**(tail 7, 8, 9 각 1개)씩
나온다(46×3 = 138 = 위 표의 46+46+46). 개요 스타일 세트의 8·9·10수준 3종이다.
그 46개 중 **42개**가 `HWPTAG_NUMBERING` 에도 7수준 너머의 확장 구간을 갖는다. 잔여 바이트를 뜯으면:

```
2026_oss_rst.hwp 의 NUMBERING 잔여 58바이트:
2c 01 00 00 | 00 00 | 32 00 | ff ff ff ff | 02 00 | 5e 00 38 00   ← 8수준: attr, 보정, 거리50, csid, fmtlen=2, "^8"
4c 01 00 00 | 00 00 | 32 00 | ff ff ff ff | 00 00                 ← 9수준
6c 00 00 00 | 00 00 | 32 00 | ff ff ff ff | 00 00                 ← 10수준
01 00 00 00 01 00 00 00 01 00 00 00                               ← 8·9·10수준 시작번호
```

`5e 00 38 00` = `U+005E U+0038` = **`"^8"`**, 8수준 번호 형식 문자열이다.
즉 코퍼스의 한컴 문서들이 실제로 8~10수준 개요를 **정의**하고 있고, 그 문서들의 문단모양이
tail 7·8·9 를 갖는다. 두 레코드 종류에서 독립적으로 같은 결론이 나오므로 우연이 아니다.

**아직 확인하지 않은 것**: 한컴 편집기를 띄워 "이 값을 바꾸면 화면의 개요 수준이 바뀐다"를 직접
보지는 않았다. 위 근거는 코퍼스 실측 + 코드 판독이다. 다만 8~10수준은 `attr1` 이 표현할 수단
자체가 없으므로 **tail 유실 = 수준 유실**은 확정적이다.

## `raw_stream_dirty` 가 가려주지 않는 이유

DocInfo 는 2단 통과(스트림 `raw_stream_dirty`, 레코드 `raw_data`)를 갖는다.
`serialize_para_shape()` 는 dirty 이면서 `raw_data == None` 일 때만 돈다 — 그런데
**dirty 를 세우는 바로 그 동작이 동시에 `raw_data = None` 인 ParaShape 을 만든다.**

`Document::find_or_create_para_shape()`(`model/document.rs:466-491`)은 한 함수 안에서
`ParaShapeMods::apply_to()`(`model/style.rs:918` 에서 `raw_data = None`)로 새 ParaShape 을 만들고,
push 한 뒤 `raw_stream_dirty = true` 를 세우며, 편집된 문단이 바로 그 id 를 참조한다.
호출 지점은 `formatting.rs:1374,1530,1720,1742`, `footnote_ops.rs:391`,
`header_footer_ops.rs:843,1037` — **정렬·줄간격·여백·들여쓰기·문단수준·탭·문단 테두리** 중
하나만 바꿔도 이 경로다. 사용자가 **개요 수준을 직접 지정**하는 경로에서도 tail 은 0 으로 나갔다.

정직하게 덧붙이면, `find_or_create_para_shape()` 는 동일 ParaShape 이 있으면 재사용하고 그 경우엔
원본 `raw_data` 가 쓰여 손실이 없다. 손실은 **새로 push 되는 경우**에 발생한다.
읽기 쪽 손실(8~10수준 붕괴)은 dirty 와 무관하게 항상 발생했다.

## 수정 효과 (실측)

재직렬화 바이트 비교 — 같은 census 를 수정 전/후로 돌렸다.

| | 총 | 바이트 동일 | 다름 |
|---|---:|---:|---:|
| 수정 전 | 15,043 | 11,041 | 4,002 |
| 수정 후 | 15,043 | **11,904** | 3,139 |

수정 전 diff 4,002건의 내역: 42바이트 레코드 112건 + 46바이트 84건 + 54바이트 2,934건
(모두 구버전 레코드에 확장/ tail 을 새로 붙이는 것, 손실 아님) **+ 58바이트 872건(tail 1~9 를 0 으로 덮음 = 손실)**.
이 **872건 중 863건이 사라졌다.**

### 남은 9건을 그대로 밝힌다

수정 후에도 58바이트 레코드 9건은 원본과 바이트가 다르다. 숨기지 않고 정확히 적는다.

- 전부 **`issue2439_zero_offset_coanchored_float_exclusion.hwp` 한 파일**(FileHeader ver 5.1.0.0)의
  ParaShape 9개다. 나머지 125개 파일 11,904건에는 이런 레코드가 없다.
- 이 9건은 원본이 **`attr1` 수준 = 1,2,3,4,5,6,6,6,6 인데 tail = 0** 인 **자기모순** 레코드다.
- 수정 후 rhwp 는 tail 에 `attr1` 값을 써서 두 필드를 **정합**시킨다. 값을 지어내는 게 아니라
  이미 레코드 안에 있는 수준을 다른 필드에도 반영하는 것이다.
- **IR `para_level` 은 종전과 완전히 동일하다.** 파서가 `max(attr1, tail)` 을 쓰므로 `max(3, 0) = 3` 으로
  기존 값이 그대로 유지된다. 이 회귀 없음을 테스트로 고정했다
  (`para_shape_recovers_outline_level_8_to_10_from_tail` 의 `tail=0/attr1=1~6` 루프).
- 이 파일 하나만 왜 다른지는 규명하지 못했다(다른 파일은 ver 5.1.0.1 / 5.1.1.0). tail 을 채우지 않는
  구버전 writer 산출물로 추정하지만 **추정이라고 명시한다.**

다른 DocInfo 레코드는 diff 건수가 수정 전후 **완전히 동일**하다 — BIN_DATA 0, FACE_NAME 171,
BORDER_FILL 82, CHAR_SHAPE 1,706, TAB_DEF 8, NUMBERING 203, BULLET 62, STYLE 101.

## 변경

`src/parser/doc_info.rs`

```rust
let outline_level_tail = if r.remaining() >= 4 { r.read_u32().unwrap_or(0) } else { 0 };
let para_level = (((attr1 >> 25) & 0x07) as u8).max(outline_level_tail.min(9) as u8);
```

`max` 는 실측 근거다. 어긋나는 사례가 (a) tail 7~9 / attr1 6(포화) 138건, (b) tail 0 / attr1 1~6
9건뿐이라, `max` 가 (a)에서 8~10수준을 복원하면서 (b)의 기존 동작을 보존한다.
tail 이 없는 42/46/54바이트 레코드는 `remaining() < 4` 라 종전과 동일하다.

`src/serializer/doc_info.rs`

```rust
attr1 |= (ps.para_level.min(6) as u32) << 25;        // 종전: (ps.para_level as u32 & 0x07) << 25
w.write_u32(ps.para_level.min(9) as u32).unwrap();   // 종전: w.write_u32(0)
```

`min(6)` 은 한컴 실측 규약(8~10수준 문단모양 138건이 모두 attr1 비트 6 + tail 7/8/9)이다.
종전 `& 0x07` 은 `para_level` 이 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.

모델 필드 추가 없음. `ParaShapeMods::apply_to` 는 직렬화기가 attr1 비트를 무조건 다시 계산하므로
손대지 않았다(무관 변경 금지). 렌더러 소비처는 이미 `layout.rs:984`, `paragraph_layout.rs:6139` 에서
`.min(6)` 으로 방어하므로 값이 7~9 로 확장돼도 인덱스 초과가 없다.

## red → green (실제 실행 캡처)

수정 2건을 되돌리고 테스트만 남긴 상태:

```
running 5 tests
test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... FAILED
test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... FAILED
test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... FAILED
test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... FAILED

---- serialize_para_shape_writes_outline_level_into_tail ----
assertion `left == right` failed: 말미 4바이트에 개요 수준 1 이 실려야 함
  left: 0
 right: 1

---- para_shape_edit_path_keeps_outline_level_in_tail ----
assertion `left == right` failed: 개요 1 수준 레코드 재직렬화 시 말미 4바이트가 보존돼야 함
  left: [0, 0, 0, 0]
 right: [1, 0, 0, 0]

---- para_shape_outline_level_roundtrips_0_to_9 ----
assertion `left == right` failed: 개요 수준 8 왕복 보존
  left: 0
 right: 8

---- para_shape_recovers_outline_level_8_to_10_from_tail ----
assertion `left == right` failed: tail=7 이면 개요 수준 7 로 복원돼야 함(attr1 은 6 에서 포화)
  left: 6
 right: 7

test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 2470 filtered out
```

**RED 에서도 통과하는 것이 있어 밝힌다.**

- `test_serialize_para_shape_roundtrip`(기존)은 `para_level: 0` 만 쓰므로 RED 에서도 통과한다.
  그 테스트의 `assert_eq!(&data[54..58], &[0,0,0,0])` 은 수정 후에도 유효해 **변경하지 않았다.**
- `para_shape_outline_level_roundtrips_0_to_9` 는 **수준 8에서 처음 실패**한다. 수준 0~7 은 RED 에서도
  `attr1` 3비트만으로 rhwp 내부 왕복이 성립하기 때문이다. 이 테스트가 잡는 건 3비트를 넘는 8·9수준뿐이고,
  **한컴이 읽는 tail 이 사라지는 본체 결함은 나머지 두 테스트가 수준 1에서 즉시 잡는다.**

수정 복원 후: `test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2470 filtered out`

## CI 3종

```
$ cargo clippy --all-targets -- -D warnings
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s
→ 경고 0건

$ for f in $(git diff --name-only origin/devel...HEAD -- '*.rs'); do rustfmt --edition 2021 "$f"; done
$ git diff --name-only
→ 빈 출력 (변경 3개 파일 모두 포맷 준수, 재포맷 결과는 커밋에 포함)

$ cargo test --profile release-test --tests
→ exit 0, 테스트 타깃 292개 전부 ok
→ 합계 3,494 passed / 0 failed / 23 ignored / 0 measured
   · lib 단위 테스트(src/lib.rs) 2,468 passed / 0 failed / 7 ignored — 신규 4건 + 기존 1건 포함:
       test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... ok
       test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... ok
       test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... ok
       test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... ok
       test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
   · 나머지 291개 타깃(tests/ 통합 + bin) 1,026 passed / 0 failed / 16 ignored
→ 출력 전체에서 `FAILED` / `panicked at` 0건
```

DocInfo 변경은 파급이 넓어 실파일 왕복·바이트 baseline 게이트를 특히 확인했다. 전부 통과:

```
tests/hwp5_roundtrip_baseline.rs     ok. 3 passed  (baseline_all_samples_roundtrip / large / xfail)
tests/hwpx_roundtrip_baseline.rs     ok. 4 passed
tests/visual_roundtrip_baseline.rs   ok. 3 passed
tests/opengov_corpus_snapshot.rs     ok. 2 passed
tests/svg_snapshot.rs                ok. 8 passed
tests/hwp5_strikeout_shape_parity.rs ok. 2 passed
serializer::cfb_writer::tests::test_serialize_real_hwp_files ... ok
```

**내가 작성하지 않은 테스트 중 실패한 것은 없다. 따라서 기존 단언을 수정한 곳도 없다.**

처리 결과 문서: `mydocs/report/task_m100_2734_report.md`

## 미실행 항목

- 한컴 편집기 실물 판정 없음(위 "아직 확인하지 않은 것" 참조).
- HWPX→HWP 변환 산출물을 한컴으로 열어 확인하지 않았다.
- 8~10수준의 렌더링 변화는 측정하지 않았다. 소비처가 모두 `.min(6)` 으로 클램프하므로 렌더 결과는
  종전과 같을 가능성이 높다. 이 PR 의 성과는 **저장 시 유실 차단**과 **IR 정확도 회복**이다.

## 잔여 (이 PR 범위 밖)

같은 코퍼스 조사에서 함께 관측된 DocInfo 결함들 — 이슈 #2734 의 7절과 보고서 7절에 실측치와 함께 기록했다.
`HWPTAG_BULLET` 24 vs 실제 23/25바이트(62/62 불일치), `HWPTAG_NUMBERING` 8~10수준 미파싱(347건 중 200건),
`HWPTAG_FACE_NAME` 대체 글꼴 유형 바이트 덮어쓰기(109건), `HWPTAG_CHAR_SHAPE` 밑줄 종류 값 2 붕괴(1,514건)
및 취소선 비트 재기록(1,620건), `HWPTAG_BORDER_FILL` fill type `0x03` 붕괴(28건).
