### PR TITLE
fix(hml): HML 직렬화 무검증 row_count 방출 — 25배 팽창·4.4초 지연 수정

### DIFF
--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -565,3 +565,70 @@ fn text_wrap_name(value: TextWrap) -> &'static str {
         TextWrap::Square => "Square",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::table::Cell;
+
+    /// row_count 행 중 실제 셀은 cell_rows 행만 덮는 표를 만든다 (행당 1셀, 1열).
+    fn table_with_rows(row_count: u16, cell_rows: u16) -> Table {
+        let mut table = Table {
+            row_count,
+            col_count: 1,
+            ..Default::default()
+        };
+        table.cells = (0..cell_rows)
+            .map(|row| Cell {
+                row,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            })
+            .collect();
+        table
+    }
+
+    fn serialize_table_to_hml(table: &Table) -> String {
+        let mut writer = XmlWriter::default();
+        write_table(&mut writer, table, "/TABLE").expect("table should serialize");
+        String::from_utf8(writer.finish()).expect("HML is UTF-8")
+    }
+
+    // [#2751 회귀] row_count 는 크게, 실셀은 적게: 방출되는 <ROW> 는 실셀 범위로
+    // 제한되어야 한다. 종전에는 무검증 row_count 만큼 빈 <ROW> 9600개가 방출되어
+    // XML 이 25배 팽창하고 저장이 4.4초 지연됐다. 이 결함은 되돌아가도 abort 없이
+    // 조용히 통과하므로 방출 개수 자체를 고정한다.
+    #[test]
+    fn hml_table_row_emission_is_bounded_by_actual_cells() {
+        let table = table_with_rows(10_000, 400);
+
+        let xml = serialize_table_to_hml(&table);
+        let row_count = xml.matches("<ROW").count();
+
+        assert!(
+            row_count <= 400,
+            "실셀 범위를 넘는 <ROW> 가 방출됨: {row_count}"
+        );
+        assert_eq!(row_count, 400, "실셀이 있는 행은 전부 방출되어야 함");
+    }
+
+    // [#2751 회귀] row_count 와 실셀 범위가 일치하는 정상 표는 종전과 동일하게
+    // row_count 만큼 <ROW> 를 방출해야 한다 — 과하게 잘라내지 않는다.
+    #[test]
+    fn normal_table_row_emission_unchanged() {
+        let table = table_with_rows(400, 400);
+
+        let xml = serialize_table_to_hml(&table);
+        assert_eq!(
+            xml.matches("<ROW").count(),
+            400,
+            "정상 표의 <ROW> 방출 개수가 달라짐"
+        );
+
+        // 셀이 하나도 없는 비정상 표도 종전 동작(row_count 만큼 방출)을 유지한다.
+        let empty = table_with_rows(3, 0);
+        assert_eq!(serialize_table_to_hml(&empty).matches("<ROW").count(), 3);
+    }
+}

--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -419,7 +419,16 @@ fn write_table(writer: &mut XmlWriter, table: &Table, path: &str) -> Result<(), 
             table.padding.bottom,
         ),
     );
-    for row in 0..table.row_count {
+    // [#2751] 실셀의 최대 행까지만 <ROW> 방출. 무검증 row_count가 과도하게 크면
+    // 빈 <ROW>가 다수 방출되어 XML이 25배 이상 팽창하고 저장이 4.4초 지연된다.
+    let row_end = table
+        .cells
+        .iter()
+        .map(|c| c.row)
+        .max()
+        .map(|max_row| (max_row.saturating_add(1)).min(table.row_count))
+        .unwrap_or(table.row_count);
+    for row in 0..row_end {
         writer.open("ROW", &[]);
         for (cell_index, cell) in table
             .cells

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -630,6 +630,8 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
         .collect::<Vec<_>>();
     let mut rebuilt = table.clone();
     rebuilt.rebuild_grid();
+    let max_cell_row = table.cells.iter().map(|c| c.row).max().unwrap_or(0);
+    let inflated_rows = table.row_count > max_cell_row.saturating_add(5);
     let omitted = table_attr_has_unrepresentable_bits(table)
         || table.page_break != TablePageBreak::CellBreak
         || !table.repeat_header
@@ -647,6 +649,7 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
         || table.row_sizes != expected_rows
         || table.cell_grid != rebuilt.cell_grid
         || table.common.text_wrap != Default::default()
+        || inflated_rows
         || table
             .cells
             .windows(2)


### PR DESCRIPTION
## 개요

HML 직렬화기(`write_table`)가 `table.row_count`를 검증 없이 그대로 사용하여
의도적으로 크게 설정된 row_count 만큼 `<ROW>`를 방출하는 문제를 수정합니다.

- **문제**: row_count=10000, cells=400행 → 빈 `<ROW>` 9600개 방출 → XML 25배 팽창, 저장 4.4초 지연
- **원인**: `src/serializer/hml/body.rs` write_table이 row_count를 실셀 범위로 제한하지 않음
- **연관**: #2722 잔여 이슈

## 변경 사항

### 1. `src/serializer/hml/body.rs`
- 실셀의 최대 행(`cells.iter().map(|c| c.row).max()`)까지만 `<ROW>` 방출
- `saturating_add`로 overflow 방지
- 셀이 없는 경우 기존 동작 유지

### 2. `src/serializer/hml/preflight.rs`
- row_count가 실셀 범위보다 5행 이상 크면 preflight에서 HML_UNSUPPORTED_IR 차단
- 5행 여유는 의도적인 빈 후행 행 가능성 고려

## 검증
- `cargo fmt` — 통과
- `cargo clippy` — 통과
- 정상 문서: 영향 없음 (row_count와 실셀 범위 일치)