### PR TITLE
[studio] 중첩 표 셀 flat 좌표 축 오용 — 선택 정렬 뒤바뀜(삭제 데이터 손실·undo 무효) 및 Ctrl+B/I 토글 방향 오류 (#2756)

### DIFF
--- a/mydocs/report/task_m100_2756_report.md
+++ b/mydocs/report/task_m100_2756_report.md
@@ -1,0 +1,98 @@
+# task m100-2756 — 중첩 표 셀 flat 좌표 축 오용 수정 (studio)
+
+- **이슈**: [#2756](https://github.com/edwardkim/rhwp/issues/2756)
+- **브랜치**: `task/m100-2756-nested-cell-axis` (base: `origin/devel`)
+- **분류**: 결함 수정 (중첩 셀 좌표 축 혼용 — outer/inner). 결함 2건, 뿌리 1개.
+- **Rust 파일 변경 없음** — 전부 `rhwp-studio/` TypeScript.
+
+## 1. 문제
+
+`DocumentPosition` 은 flat 필드(`controlIndex`/`cellIndex`/`cellParaIndex`)와 `cellPath` 배열을 동시에 들고 다닌다. hit-test 는 flat 필드를 `cellPath[0]`, 즉 **최외곽** 셀에서 채운다(`src/document_core/queries/cursor_rect.rs:2462-2491` 의 `let outer = &ctx.path[0];`; `ctx.path[0]` 참조는 이 파일에만 18곳). 따라서 중첩 표(depth ≥ 2)에서 flat 필드는 **바깥 셀의 축**이고, 안쪽 셀 값은 `cellPath[last]` 다.
+
+이 축 전환은 `command.ts` 의 커맨드 계층에서는 `cellParaIndexOf()` 헬퍼로 이미 정리됐으나, 호출부 두 곳이 누락됐다.
+
+- **결함 1 (HIGH, 데이터 손실)** — `cursor.ts:186` `CursorState.comparePositions` 가 flat `cellIndex`/`cellParaIndex` 를 맨몸으로 비교. 중첩 셀에서 선택 양끝이 뒤바뀐다. 소비자 `DeleteSelectionCommand`(`command.ts:555`)는 `cellParaIndexOf`(안쪽 축)로 start/end 를 읽으므로 `startPara > endPara` → `savedTexts=[]`, Rust `delete_range_in_cell_by_path`(`text_editing.rs:3497`)는 `start_para != end_para` 분기를 타 **선택 범위의 여집합**을 삭제. `multiPara=true` + 빈 `savedTexts` 라 `undo` 는 아무것도 복원하지 못한다(영구 손실).
+  - **입력 방식 의존**: 좌/우 화살표 선택은 `cursor.ts:435` `updateCellParaInPath` 가 flat 을 안쪽 값으로 덮어써 우연히 정상. 마우스 클릭·드래그 / Shift+상하 화살표만 발현.
+- **결함 2 (MEDIUM)** — `input-handler.ts:1822` `getCharPropertiesAtCursor()` 가 `getCellCharPropertiesAt`(flat) 로 **바깥 셀** 서식을 조회. `applyToggleFormat`(`:1789`)이 이 값에서 `!current[prop]` 로 토글 **방향**을 정하고(실제 적용 `ApplyCharFormatCommand` 는 이미 `...ByPath`), `emitCursorFormatState`(`:2028`)의 툴바 표시도 이 조회를 쓴다. 소비자 8곳 전부 오답.
+
+## 2. 검증 근거 (소스·이력)
+
+- `git log -S "comparePositions" -- rhwp-studio/src/engine/cursor.ts` → `f0f7f1a4 Initial commit` 만. 중첩 셀 축으로 한 번도 개정된 적 없음.
+- `grep -rn "comparePositions|getSelectionOrdered" rhwp-studio/tests/` → **0건**. 정렬 로직 테스트 부재.
+- 기존 두 가드(`delete-selection-nested-cell.test.ts`, `apply-charformat-nested-cell.test.ts`)는 `classBlock`으로 **`command.ts` 커맨드 본문만** 검사 → 결함 2(입력 핸들러)와 start/end 생산자(결함 1)는 시야 밖.
+
+## 3. 변경
+
+| 파일 | 변경 |
+|---|---|
+| `src/engine/command.ts` | `cellAxisPath(pos)` 헬퍼 신설·export (축 유도 단일 정의 공유; `cellParaIndexOf` 와 동일 규약의 경로 전체 버전). `CellPathEntry` 타입 import 추가. |
+| `src/engine/cursor.ts` | `comparePositions` 의 셀-내부 분기를 `cellAxisPath` 기반 깊이별 비교로 교체. `command.ts` 에서 `cellAxisPath` import. |
+| `src/engine/input-handler.ts` | `getCharPropertiesAtCursor` 에 `cellPath` 유무 분기 추가 — 있으면 `getCellCharPropertiesAtByPath`(안쪽 축), 없으면 기존 flat 폴백. |
+
+**동작 변화 범위 (수학적 등가 확인)**: `cellPath` 가 없는 두 위치(레거시 flat/`applyNavResult` 산출물)를 비교할 때 `cellAxisPath` 는 flat 필드로 1-depth 경로를 합성하므로, 새 비교 순서(parentParaIndex → controlIndex → cellIndex → cellParaIndex → charOffset)가 **기존 로직과 완전히 동치**다. depth 1 은 `cellPath[0]=최내곽=flat` 이라 무변화. **depth ≥ 2 에서만** 안쪽 축으로 판정이 바뀐다. 결함 2 도 `cellPath` 부재 시 flat 폴백이라 depth 1/레거시 무변화.
+
+축 유도를 인라인 복제하지 않고 헬퍼를 공유한 이유는 `tests/undo-nested-cell-merge-offset.test.ts:44`("인덱스 축 유도가 여러 곳에 복제되면 한쪽만 고쳐지는 회귀가 재발한다")와 선행 PR #2720 의 방침을 따른 것.
+
+## 4. 검증
+
+### 4-1. 신규 테스트
+
+- `tests/selection-ordering-nested-cell.test.ts` — **행위 테스트**. `cursor.ts` 는 `constructor(private wasm)` parameter property 때문에 Node strip-only 로더로 직접 import 불가 → `process.execPath` 자식 프로세스를 `--experimental-transform-types` 로 띄우고 `module.registerHooks` 로 `@/` 별칭·확장자 없는 상대 import 를 매핑(선행 PR #2720 기법). 실제 `CursorState.comparePositions` 호출 + `moveToHit`/`setAnchor`/`getSelectionOrdered` 실경로로 정렬 결과를 검증. 8건.
+- `tests/char-properties-cursor-nested-cell.test.ts` — **소스 가드**. `getCharPropertiesAtCursor` 메서드 본문을 추출해 `getCellCharPropertiesAtByPath` 사용·`cellPath` 분기·폴백 순서를 핀. 결함 2 는 조회 결과를 그대로 반환할 뿐 분기 로직이 없어(경로 유무만 판단) "어느 API 를 호출하는가"로 충분. 2건.
+
+행위 red→green 은 결함 1 쪽에서 실경로로 확보했고, 결함 2 는 정적 가드를 선택했다(이유: 위 참조).
+
+### 4-2. red→green 실증 (실제 캡처)
+
+**결함 1** — `cursor.ts` `comparePositions` 를 devel 원본(flat 비교)으로 되돌린 상태:
+
+```
+✖ 중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다 (데이터 손실 방지)
+  AssertionError: flat cellParaIndex(바깥=0) 로 비교하면 두 문단이 같아 보여 charOffset(5>0)으로 낙하, 양끝이 뒤바뀐다
+  1 !== -1
+✖ 서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다
+  AssertionError: flat cellIndex 는 둘 다 바깥 셀(0)이라 같다 — 안쪽 cellPath[last].cellIndex(2<4)로 정렬해야 한다
+  1 !== -1
+✔ depth 1 (비중첩) 셀 정렬은 불변이다 (회귀 대조군)
+✔ 본문 정렬은 불변이다 (회귀 대조군)
+✔ 본문↔셀 혼합 정렬은 불변이다 (회귀 대조군)
+✔ comparePositions 는 반대칭·반사적이다
+ℹ pass 4 / fail 2
+```
+
+RED 에서 **대조군 4건이 통과**한 것이 핵심 — 실패가 중첩 셀 축 혼용 때문임을 격리한다(depth 1·본문·본문↔셀 혼합 무변화 증명).
+
+**결함 2** — `getCharPropertiesAtCursor` 를 devel 원본(flat 전용)으로 되돌린 상태:
+
+```
+✖ getCharPropertiesAtCursor 는 cellPath 가 있으면 ...ByPath 로 최내곽 셀을 조회한다
+  AssertionError: 중첩 셀 서식 조회는 getCellCharPropertiesAtByPath(안쪽 축)를 써야 한다
+✖ getCharPropertiesAtCursor 의 flat 조회는 cellPath 부재 폴백으로만 남는다
+  AssertionError: ByPath 분기가 있어야 한다
+ℹ pass 0 / fail 2
+```
+
+두 수정 복원 후 신규 10건 전부 GREEN.
+
+### 4-3. CI 게이트 (기준선 대조)
+
+| | clean `devel` 기준선 | 수정 후 |
+|---|---|---|
+| `npm test` | tests 465 / pass 464 / **fail 1** | tests 473 / pass 472 / **fail 1** |
+| `npx tsc --noEmit` | error 2 (둘 다 `TS2307 @wasm/rhwp.js`) | error 2 (**baseline 과 byte-identical**) |
+
+- 신규 통과 +8(행위 6 + 가드 2 = 8건), 총계 465→473. 신규 8건 전부 통과. 유일한 실패 `tests/cell-flow-boundary.test.ts` 는 **기준선에도 있던 선재 실패**(`spawnSync(node_modules/.bin/tsc)` 가 Windows 에서 `status=null`)로 본 변경과 무관, 손대지 않음.
+- `tsc` 2건은 로컬 WASM 빌드 산출물 부재로 나는 **선재** 오류. `diff baseline after` → **완전 동일**(신규 타입 오류 0).
+- `npm run lint` 는 `package.json` 에 없음(스크립트 부재). Rust 무변경으로 Rust CI 3종 대상 밖.
+
+### 4-4. 미실행 항목 (투명 고지)
+
+- 브라우저 왕복 시각 검증(중첩 표 문서에서 손 확인) 미수행 — 로컬에 빌드된 `rhwp_bg.wasm` 이 없어 studio 를 띄울 수 없음. 그래서 결함 1 은 실경로 행위 테스트로 런타임 증명을 대신했다.
+- `npm run build`(`tsc && vite build`) — WASM 바인딩(`@wasm/rhwp.js`) 요구로 로컬 실행 불가. 해당 바인딩 무변경.
+
+## 5. 잔여 (범위 밖)
+
+1. `applyNavResult`(`cursor.ts:396-407`)가 컨테이너 내부 위치 재구성 시 `cellPath` 를 싣지 않아 수직 이동 산출물이 중첩 경로를 유실. 이번 수정은 폴백으로 일관성만 확보. 별건.
+2. flat 필드 자체의 폐기(`cellPath` 상위 집합) — Rust 직렬화(`cursor_rect.rs` 18곳)와 다수 호출부 연동으로 범위 밖.
+3. 셀 내 다중 문단 삭제 undo 의 구조적 한계(`command.ts:603-613` 자체 주석) — 이번 건은 `savedTexts` 가 비는 문제만 제거.
+4. Rust `cursor_rect.rs` 의 flat 채움 규칙 — 무수정. TS 소비자가 축을 올바로 고르는 것으로 충분.

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,5 +1,5 @@
 import type { WasmBridge } from '@/core/wasm-bridge';
-import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike } from '@/core/types';
+import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 
 /** 편집 명령 공통 인터페이스 */
@@ -202,6 +202,26 @@ function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): stri
 function cellParaIndexOf(pos: DocumentPosition): number {
   const path = pos.cellPath;
   return (path?.length ?? 0) > 0 ? path![path!.length - 1].cellParaIndex : pos.cellParaIndex!;
+}
+
+/**
+ * [#2756] 비교용 셀 경로 — `cellParaIndexOf` 와 같은 축 규약의 경로 전체 버전.
+ *
+ * `cellParaIndexOf` 가 최내곽 **문단 인덱스** 하나를 주는 것과 달리, 이쪽은 셀 **정체성**을
+ * 깊이별로 비교해야 하는 곳(선택 영역 정렬)에 쓴다. 두 함수는 같은 규약을 공유한다 —
+ * `cellParaIndexOf(pos) === cellAxisPath(pos)[last].cellParaIndex`.
+ *
+ * `cellPath` 가 없는 위치(레거시 flat 좌표, `applyNavResult` 산출물)는 flat 필드로 1-depth
+ * 경로를 합성한다. hit-test 가 flat 을 `cellPath[0]`(최외곽)에서 채우므로, depth 1 에서는
+ * 합성 경로가 실제 경로와 완전히 같아 **동작 변화가 없다**.
+ */
+export function cellAxisPath(pos: DocumentPosition): CellPathEntry[] {
+  if ((pos.cellPath?.length ?? 0) > 0) return pos.cellPath!;
+  return [{
+    controlIndex: pos.controlIndex ?? 0,
+    cellIndex: pos.cellIndex ?? 0,
+    cellParaIndex: pos.cellParaIndex ?? 0,
+  }];
 }
 
 /** 셀 문단 구조 편집 뒤 flat/path 커서 위치를 같은 문단으로 맞춘다. */

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1,5 +1,7 @@
 import type { DocumentPosition, CursorRect, LineInfo, CellPathEntry, NavContextEntry, CellBbox } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
+// [#2756] 셀 좌표 축 헬퍼는 command.ts 와 단일 정의를 공유한다(축 유도 복제 금지).
+import { cellAxisPath } from './command';
 
 type CellSelectionReason = 'manual' | 'protected';
 
@@ -189,17 +191,34 @@ export class CursorState {
     const bInCell = b.parentParaIndex !== undefined;
 
     if (aInCell && bInCell) {
-      // 둘 다 셀 내부 — 같은 셀인지 확인
-      if (a.parentParaIndex !== b.parentParaIndex ||
-          a.controlIndex !== b.controlIndex ||
-          a.cellIndex !== b.cellIndex) {
-        // 다른 셀이면 셀 인덱스로 비교
-        if (a.parentParaIndex !== b.parentParaIndex) return a.parentParaIndex! < b.parentParaIndex! ? -1 : 1;
-        if (a.controlIndex !== b.controlIndex) return a.controlIndex! < b.controlIndex! ? -1 : 1;
-        return a.cellIndex! < b.cellIndex! ? -1 : 1;
+      // [#2756] 둘 다 셀 내부 — **최내곽 축**으로 비교한다.
+      //
+      // flat controlIndex/cellIndex/cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서
+      // 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`). 중첩 표에서 이 셋을 그대로 쓰면
+      // 안쪽 셀의 서로 다른 문단이 **같은 위치**로 보여 charOffset 으로 낙하하고, 그 결과
+      // 선택 양끝이 뒤바뀐다. 소비자 DeleteSelectionCommand 는 cellParaIndexOf(=안쪽 축)로
+      // start/end 를 읽으므로 startPara > endPara 가 되어 savedTexts 가 비고, Rust
+      // delete_range_in_cell_by_path 는 start_para != end_para 분기를 타 **선택 범위의
+      // 여집합**을 지운다. undo 는 복원할 텍스트가 없어 무효가 된다.
+      if (a.parentParaIndex !== b.parentParaIndex) return a.parentParaIndex! < b.parentParaIndex! ? -1 : 1;
+
+      // 셀 경로를 깊이 순으로 비교 — 바깥에서 안쪽으로 진입 순서가 곧 문서 순서다.
+      // 각 깊이의 cellParaIndex 는 (중간 깊이) 어느 문단에서 다음 표로 내려갔는지 /
+      // (최내곽) 커서가 어느 문단에 있는지를 뜻하므로 두 경우 모두 올바른 정렬 키다.
+      const pathA = cellAxisPath(a);
+      const pathB = cellAxisPath(b);
+      const common = Math.min(pathA.length, pathB.length);
+      for (let d = 0; d < common; d++) {
+        const ea = pathA[d];
+        const eb = pathB[d];
+        if (ea.controlIndex !== eb.controlIndex) return ea.controlIndex < eb.controlIndex ? -1 : 1;
+        if (ea.cellIndex !== eb.cellIndex) return ea.cellIndex < eb.cellIndex ? -1 : 1;
+        if (ea.cellParaIndex !== eb.cellParaIndex) return ea.cellParaIndex < eb.cellParaIndex ? -1 : 1;
       }
-      // 같은 셀 내부: cellParaIndex → charOffset 비교
-      if (a.cellParaIndex !== b.cellParaIndex) return a.cellParaIndex! < b.cellParaIndex! ? -1 : 1;
+      // 공통 구간이 같으면 얕은 쪽(바깥 셀 본문)이 그 문단에서 표로 내려가기 전이므로 앞선다.
+      if (pathA.length !== pathB.length) return pathA.length < pathB.length ? -1 : 1;
+
+      // 같은 최내곽 셀·같은 문단: 마지막 루프 반복이 곧 cellParaIndexOf 비교였다.
       if (a.charOffset !== b.charOffset) return a.charOffset < b.charOffset ? -1 : 1;
       return 0;
     }

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1824,6 +1824,16 @@ export class InputHandler {
     // offset이 0이면 해당 위치, 아니면 offset-1 위치의 서식 반환 (커서 앞 글자 기준)
     const queryOffset = pos.charOffset > 0 ? pos.charOffset - 1 : 0;
     if (pos.parentParaIndex !== undefined) {
+      // [#2756] 중첩 표는 최내곽 셀 대상 ...ByPath 로 조회한다. flat controlIndex/cellIndex/
+      // cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서 채우므로 그대로 넘기면 **바깥
+      // 셀**의 서식을 읽는다. applyToggleFormat 이 이 값에서 !current[prop] 로 토글 방향을
+      // 정하므로(그리고 실제 적용 ApplyCharFormatCommand 는 이미 ...ByPath 로 안쪽 셀에
+      // 적용) 방향이 어긋나 Ctrl+B/I 가 거꾸로 동작하고 툴바 표시도 오답이 된다.
+      if ((pos.cellPath?.length ?? 0) > 0) {
+        return this.wasm.getCellCharPropertiesAtByPath(
+          pos.sectionIndex, pos.parentParaIndex, JSON.stringify(pos.cellPath), queryOffset,
+        );
+      }
       return this.wasm.getCellCharPropertiesAt(
         pos.sectionIndex, pos.parentParaIndex, pos.controlIndex!,
         pos.cellIndex!, pos.cellParaIndex!, queryOffset,

--- a/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
+++ b/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#2756] getCharPropertiesAtCursor() 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex/cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다.
+// 중첩 표 셀에서 이를 그대로 getCellCharPropertiesAt(flat)에 넘기면 **바깥 셀**의 글자 서식을
+// 읽는다. applyToggleFormat 이 이 값에서 !current[prop] 로 토글 **방향**을 정하므로(그리고
+// 실제 적용 ApplyCharFormatCommand 는 이미 ...ByPath 로 안쪽 셀에 적용) 방향이 어긋나
+// Ctrl+B/I 가 거꾸로 동작하고, emitCursorFormatState 의 툴바 표시도 오답이 된다.
+//
+// 형제 선례: ApplyCharFormatCommand 는 이미 getCellCharPropertiesAtByPath 로 교정됐고
+// tests/apply-charformat-nested-cell.test.ts 가 그 커맨드를 핀한다. 그러나 그 테스트는
+// command.ts 의 커맨드 블록만 보므로 input-handler.ts 의 이 조회는 시야 밖이었다.
+//
+// 정적 가드인 이유: getCharPropertiesAtCursor 는 wasm 응답을 그대로 돌려줄 뿐 분기 로직이
+// 없어(경로 유무만 판단), 동작 증명은 "어느 API 를 호출하는가"로 충분하다. 행위 red→green 은
+// comparePositions 쪽(selection-ordering-nested-cell.test.ts)에서 실경로로 확보한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+
+/** `NAME(` 시그니처부터 매칭 중괄호가 닫힐 때까지 메서드 본문을 추출. */
+function methodBody(name: string): string {
+  const sig = new RegExp(`\\b${name}\\s*\\([^)]*\\)\\s*:[^\\{]*\\{`);
+  const m = sig.exec(src);
+  assert.ok(m, `${name} 메서드 not found`);
+  const open = src.indexOf('{', m.index + m[0].length - 1);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  throw new Error(`${name} 본문의 닫는 괄호를 찾지 못함`);
+}
+
+test('getCharPropertiesAtCursor 는 cellPath 가 있으면 ...ByPath 로 최내곽 셀을 조회한다', () => {
+  const body = methodBody('getCharPropertiesAtCursor');
+  assert.match(
+    body,
+    /getCellCharPropertiesAtByPath\s*\(/,
+    '중첩 셀 서식 조회는 getCellCharPropertiesAtByPath(안쪽 축)를 써야 한다',
+  );
+  assert.match(
+    body,
+    /pos\.cellPath\?\.length/,
+    'cellPath 유무로 경로/flat 을 분기해야 한다',
+  );
+});
+
+test('getCharPropertiesAtCursor 의 flat 조회는 cellPath 부재 폴백으로만 남는다', () => {
+  const body = methodBody('getCharPropertiesAtCursor');
+  // flat 호출 자체는 depth 1/레거시 폴백으로 유지되지만, ByPath 분기보다 뒤에 와야 한다.
+  const byPathIdx = body.indexOf('getCellCharPropertiesAtByPath');
+  const flatIdx = body.indexOf('getCellCharPropertiesAt(');
+  assert.ok(byPathIdx !== -1, 'ByPath 분기가 있어야 한다');
+  assert.ok(
+    flatIdx === -1 || byPathIdx < flatIdx,
+    'flat getCellCharPropertiesAt 은 ByPath 분기 뒤(폴백)에 와야 한다 — 중첩 셀이 flat 으로 새면 안 된다',
+  );
+});

--- a/rhwp-studio/tests/selection-ordering-nested-cell.test.ts
+++ b/rhwp-studio/tests/selection-ordering-nested-cell.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// [#2756] 중첩 표 안쪽 셀 선택 영역 정렬의 "축 정합" 행위 가드.
+//
+// hit-test 는 flat 필드(controlIndex/cellIndex/cellParaIndex)를 cellPath[0], 즉 **최외곽**
+// 엔트리에서 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`). 따라서 중첩 셀에서
+// pos.cellParaIndex 는 바깥 셀의 문단 인덱스이고, 안쪽 셀 값은 cellPath[last].cellParaIndex 다
+// (command.ts 의 cellParaIndexOf 주석 / tests/undo-nested-cell-merge-offset.test.ts).
+//
+// CursorState.comparePositions 가 flat cellIndex/cellParaIndex 를 맨몸으로 비교하면
+//   A. 안쪽 셀의 서로 다른 문단(바깥 문단은 동일) → 문단 비교가 통과돼 charOffset 으로 낙하,
+//      선택 양끝이 뒤바뀐다. 소비자 DeleteSelectionCommand 는 cellParaIndexOf(안쪽 축)로
+//      start/end 를 읽으므로 startPara > endPara → savedTexts 가 비고, Rust
+//      delete_range_in_cell_by_path 는 선택 범위의 **여집합**을 지운다. undo 는 무효.
+//   B. 안쪽 셀이 서로 다름(바깥 셀 식별자는 동일) → flat cellIndex 가 같아 정렬이 붕괴.
+// 두 방향 모두 어긋난다.
+//
+// 검증 방식: 소스 복제 없이 실제 cursor.ts 를 로드해 comparePositions/getSelectionOrdered 를
+// 직접 호출한다. CursorState 는 constructor(private wasm) parameter property 때문에 Node 의
+// strip-only 로더로는 직접 import 가 불가하므로(`TypeScript parameter property is not supported
+// in strip-only mode`), process.execPath 자식 프로세스를 --experimental-transform-types 로
+// 띄우고 module.registerHooks 로 `@/` 별칭과 확장자 없는 상대 import 를 매핑한다.
+// node_modules/.bin 실행 파일에 의존하지 않아 플랫폼 무관하게 동작한다.
+
+const studioRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const workDir = mkdtempSync(path.join(tmpdir(), 'rhwp-sel-order-'));
+
+const driverPath = path.join(workDir, 'driver.mjs');
+writeFileSync(driverPath, `
+import { registerHooks } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const srcRoot = ${JSON.stringify(pathToFileURL(path.join(studioRoot, 'src') + path.sep).href)};
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) return nextResolve(srcRoot + specifier.slice(2) + '.ts', context);
+    // 스튜디오 소스의 확장자 없는 상대 import (번들러 관례) 보정.
+    if (/^\\.{1,2}\\//.test(specifier) && !/\\.[a-z]+$/.test(specifier)) {
+      return nextResolve(specifier + '.ts', context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { CursorState } = await import(srcRoot + 'engine/cursor.ts');
+
+const R = { pageIndex: 0, x: 0, y: 0, height: 10 };
+
+// 안쪽 셀(cellIndex 2)의 문단 para, 오프셋 off. 바깥 표 cellIndex 0 의 문단 outerPara 에 중첩.
+// flat 필드는 hit-test 규약대로 **바깥** 엔트리(cellPath[0]) 값으로 채운다.
+function innerPos(outerPara, innerCell, innerPara, off) {
+  return {
+    sectionIndex: 0, paragraphIndex: innerPara, charOffset: off,
+    parentParaIndex: 3, controlIndex: 0, cellIndex: 0, cellParaIndex: outerPara,
+    cellPath: [
+      { controlIndex: 0, cellIndex: 0, cellParaIndex: outerPara },
+      { controlIndex: 0, cellIndex: innerCell, cellParaIndex: innerPara },
+    ],
+    cursorRect: R,
+  };
+}
+
+// depth 1 (비중첩) 셀 위치 — flat 과 cellPath[0] 이 곧 최내곽으로 일치.
+function flatCellPos(cellPara, off) {
+  return {
+    sectionIndex: 0, paragraphIndex: cellPara, charOffset: off,
+    parentParaIndex: 3, controlIndex: 0, cellIndex: 2, cellParaIndex: cellPara,
+    cellPath: [{ controlIndex: 0, cellIndex: 2, cellParaIndex: cellPara }],
+    cursorRect: R,
+  };
+}
+
+function bodyPos(para, off) {
+  return { sectionIndex: 0, paragraphIndex: para, charOffset: off, cursorRect: R };
+}
+
+const cmp = (a, b) => CursorState.comparePositions(a, b);
+const sign = (n) => (n < 0 ? -1 : n > 0 ? 1 : 0);
+
+// getSelectionOrdered 실경로 — moveToHit(cursorRect 有 → updateRect 미호출) + setAnchor.
+function orderedInner(anchor, focus) {
+  const cs = new CursorState({});
+  cs.moveToHit(anchor);
+  cs.setAnchor();
+  cs.moveToHit(focus);
+  const sel = cs.getSelectionOrdered();
+  const innerPara = (p) => p.cellPath[p.cellPath.length - 1].cellParaIndex;
+  const innerCell = (p) => p.cellPath[p.cellPath.length - 1].cellIndex;
+  return {
+    startInnerPara: innerPara(sel.start), endInnerPara: innerPara(sel.end),
+    startInnerCell: innerCell(sel.start), endInnerCell: innerCell(sel.end),
+    startOff: sel.start.charOffset, endOff: sel.end.charOffset,
+  };
+}
+
+const result = {};
+
+// A. 같은 안쪽 셀, 안쪽 문단 0 끝(off 5) → 문단 1 시작(off 0). 바깥 문단은 둘 다 0.
+//    올바르면 cmp<0 (anchor<focus), 뒤바뀌면 cmp>0.
+const aAnchor = innerPos(0, 2, 0, 5);
+const aFocus  = innerPos(0, 2, 1, 0);
+result.sameCellCmp = sign(cmp(aAnchor, aFocus));
+result.sameCellOrdered = orderedInner(aAnchor, aFocus);
+
+// B. 서로 다른 안쪽 셀(2 vs 4), 바깥 셀 식별자는 동일. 올바르면 cellIndex 2<4 로 cmp<0.
+const bAnchor = innerPos(0, 2, 1, 3);
+const bFocus  = innerPos(0, 4, 0, 0);
+result.diffInnerCellCmp = sign(cmp(bAnchor, bFocus));
+
+// C. depth 1 회귀 대조군 — 문단 0 off5 vs 문단 1 off0. 현행 동작 불변(cmp<0).
+result.depth1Cmp = sign(cmp(flatCellPos(0, 5), flatCellPos(1, 0)));
+
+// D. 본문 회귀 대조군 — 문단 2 off0 vs 문단 1 off9. cmp>0 (2>1).
+result.bodyCmp = sign(cmp(bodyPos(2, 0), bodyPos(1, 9)));
+
+// E. 본문↔셀 혼합 회귀 대조군 — 본문 문단 3 vs 같은 문단의 셀(parentPara 3). 셀이 뒤 → cmp<0.
+result.bodyVsCellCmp = sign(cmp(bodyPos(3, 0), innerPos(0, 2, 0, 0)));
+
+// F. 반사성/대칭성 — cmp(a,b) === -cmp(b,a), cmp(a,a)===0.
+result.antisymmetry = sign(cmp(aAnchor, aFocus)) === -sign(cmp(aFocus, aAnchor));
+result.reflexivity = sign(cmp(aAnchor, { ...aAnchor })) === 0;
+
+process.stdout.write('###' + JSON.stringify(result) + '###');
+`);
+
+const run = spawnSync(
+  process.execPath,
+  ['--experimental-transform-types', '--no-warnings', driverPath],
+  { cwd: studioRoot, encoding: 'utf8' },
+);
+
+rmSync(workDir, { recursive: true, force: true });
+
+assert.equal(
+  run.status,
+  0,
+  `comparePositions 행위 드라이버 실행 실패:\n${run.stdout}\n${run.stderr}`,
+);
+
+const captured = /###([\s\S]*)###/.exec(run.stdout);
+assert.ok(captured, `드라이버 출력에서 결과 JSON 을 찾지 못함:\n${run.stdout}\n${run.stderr}`);
+const observed = JSON.parse(captured[1]) as {
+  sameCellCmp: number;
+  sameCellOrdered: {
+    startInnerPara: number; endInnerPara: number;
+    startInnerCell: number; endInnerCell: number;
+    startOff: number; endOff: number;
+  };
+  diffInnerCellCmp: number;
+  depth1Cmp: number;
+  bodyCmp: number;
+  bodyVsCellCmp: number;
+  antisymmetry: boolean;
+  reflexivity: boolean;
+};
+
+test('중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다 (데이터 손실 방지)', () => {
+  assert.equal(
+    observed.sameCellCmp,
+    -1,
+    'flat cellParaIndex(바깥=0) 로 비교하면 두 문단이 같아 보여 charOffset(5>0)으로 낙하, 양끝이 뒤바뀐다',
+  );
+  // 정렬 결과의 안쪽 축이 start <= end 여야 한다 (DeleteSelectionCommand 가 읽는 축).
+  assert.ok(
+    observed.sameCellOrdered.startInnerPara <= observed.sameCellOrdered.endInnerPara,
+    `정렬된 start 의 안쪽 문단(${observed.sameCellOrdered.startInnerPara})이 end(${observed.sameCellOrdered.endInnerPara})보다 뒤면 ` +
+    'startPara>endPara 로 savedTexts 가 비고 삭제가 여집합을 지운다',
+  );
+  assert.deepEqual(
+    { p: observed.sameCellOrdered.startInnerPara, off: observed.sameCellOrdered.startOff },
+    { p: 0, off: 5 },
+    'start 는 문단 0 끝(anchor)이어야 한다',
+  );
+  assert.deepEqual(
+    { p: observed.sameCellOrdered.endInnerPara, off: observed.sameCellOrdered.endOff },
+    { p: 1, off: 0 },
+    'end 는 문단 1 시작(focus)이어야 한다',
+  );
+});
+
+test('서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다', () => {
+  assert.equal(
+    observed.diffInnerCellCmp,
+    -1,
+    'flat cellIndex 는 둘 다 바깥 셀(0)이라 같다 — 안쪽 cellPath[last].cellIndex(2<4)로 정렬해야 한다',
+  );
+});
+
+test('depth 1 (비중첩) 셀 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.depth1Cmp, -1, 'depth 1 은 cellPath[0]=최내곽=flat 이라 종전대로 문단 0<1');
+});
+
+test('본문 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.bodyCmp, 1, '본문 문단 2>1');
+});
+
+test('본문↔셀 혼합 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.bodyVsCellCmp, -1, '같은 문단에서 셀은 본문보다 뒤로 간주');
+});
+
+test('comparePositions 는 반대칭·반사적이다', () => {
+  assert.ok(observed.antisymmetry, 'cmp(a,b) === -cmp(b,a)');
+  assert.ok(observed.reflexivity, 'cmp(a,a) === 0');
+});


### PR DESCRIPTION
## 요약

이슈 #2756 수정. 중첩 표(depth ≥ 2)에서 `DocumentPosition` 의 flat 필드(`controlIndex`/`cellIndex`/`cellParaIndex`)는 hit-test 가 `cellPath[0]`, 즉 **최외곽** 셀에서 채운다(`src/document_core/queries/cursor_rect.rs:2462-2491` 의 `let outer = &ctx.path[0];`). 안쪽 셀 값은 `cellPath[last]` 다. 이 축 전환은 `command.ts` 커맨드 계층에서 `cellParaIndexOf()` 로 이미 정리됐으나 **호출부 두 곳이 누락**됐다. 뿌리가 같아 하나의 PR 로 묶는다.

`.rs` 변경 없음 — 전부 `rhwp-studio/` TypeScript.

## 결함 1 (HIGH, 데이터 손실) — 중첩 셀 선택이 바깥 축으로 정렬됨

`cursor.ts:186` `CursorState.comparePositions` 가 flat `cellIndex`/`cellParaIndex` 를 맨몸으로 비교한다. 중첩 안쪽 셀에서 **문단 0 끝 → 문단 1 시작**을 선택하면(마우스/드래그/Shift+상하), 바깥 문단 인덱스가 둘 다 같아 `charOffset(5 > 0)` 으로 낙하 → **양끝이 뒤바뀐다**.

소비자 `DeleteSelectionCommand`(`command.ts:555`)는 `cellParaIndexOf`(안쪽 축)로 start/end 를 읽으므로 `startPara(1) > endPara(0)` → 루프가 안 돌아 `savedTexts=[]`. Rust `delete_range_in_cell_by_path`(`text_editing.rs:3497`)는 `start_para != end_para` 분기를 타 **선택 범위의 여집합**(두 문단 본문 전체)을 삭제한다. `multiPara=true` + 빈 `savedTexts` 라 `undo` 는 아무것도 복원하지 못한다 — **Ctrl+Z 로도 영구 손실**.

**입력 방식 의존(리포트가 재현 불가로 닫히기 쉬운 지점)**: 좌/우 화살표 선택은 `cursor.ts:435` `updateCellParaInPath` 가 flat 을 안쪽 값으로 덮어써 우연히 정상 동작한다. 마우스 클릭·드래그, Shift+상/하 화살표에서만 발현.

**수정**: `command.ts` 에 `cellAxisPath(pos)` 헬퍼를 두고(축 유도 단일 정의 — `undo-nested-cell-merge-offset.test.ts:44` 의 복제 금지 방침, 선행 PR #2720 접근), `comparePositions` 를 `cellPath` 깊이별 비교로 교체. `cellPath` 부재 위치는 flat 로 1-depth 경로를 합성하므로 **기존 비교 로직과 동치**(depth 1 도 `cellPath[0]=최내곽=flat` 이라 무변화). **depth ≥ 2 에서만** 판정이 안쪽 축으로 바뀐다.

## 결함 2 (MEDIUM) — Ctrl+B/I 가 바깥 셀 서식을 읽음

`input-handler.ts:1822` `getCharPropertiesAtCursor()` 가 `getCellCharPropertiesAt`(flat) 로 **바깥 셀** 서식을 조회한다. `applyToggleFormat`(`:1789`)이 이 값에서 `!current[prop]` 로 토글 **방향**을 정하고(실제 적용 `ApplyCharFormatCommand` 는 이미 `...ByPath` 로 안쪽 셀에 적용), `emitCursorFormatState`(`:2028`)의 툴바 표시도 이 조회를 쓴다. 안쪽 셀 텍스트가 진하기 없음인데 바깥 셀 같은 인덱스 문단이 진하기면 `Ctrl+B` 가 `!true=false` 를 계산 → 선택이 그대로 남는다(두 번 눌러야 함). 소비자 8곳 전부 오답.

**수정**: `cellPath` 가 있으면 `getCellCharPropertiesAtByPath`(브리지에 이미 노출됨 `wasm-bridge.ts:1845`)로 분기, 없으면 기존 flat 폴백 유지.

## 왜 기존 테스트가 못 잡았는가

- `grep -rn "comparePositions|getSelectionOrdered" rhwp-studio/tests/` → **0건**. 정렬 로직 테스트 부재.
- `git log -S "comparePositions" -- rhwp-studio/src/engine/cursor.ts` → `f0f7f1a4 Initial commit` 만. 중첩 셀 축으로 한 번도 개정 안 됨.
- 기존 두 가드(`delete-selection-nested-cell.test.ts`, `apply-charformat-nested-cell.test.ts`)는 `classBlock` 으로 **`command.ts` 커맨드 본문만** 검사 → start/end 생산자(결함 1)와 입력 핸들러(결함 2)는 시야 밖.

> 근본 원인 분석은 **소스 판독·git 이력**이며 런타임 계측이 아니다(로컬에 빌드된 `rhwp_bg.wasm` 부재로 앱 구동 불가). 런타임 증명은 아래 행위 테스트로 대신한다.

## 검증

**신규 테스트**
- `tests/selection-ordering-nested-cell.test.ts` — **행위 테스트**(정적 문자열 검사 아님). `cursor.ts` 는 `constructor(private wasm)` parameter property 때문에 Node strip-only 로더로 직접 import 불가 → `process.execPath` 자식을 `--experimental-transform-types` + `module.registerHooks`(`@/` 별칭·확장자 보정)로 띄워 실제 `CursorState.comparePositions` 및 `moveToHit`/`setAnchor`/`getSelectionOrdered` 실경로를 검증. 6건.
- `tests/char-properties-cursor-nested-cell.test.ts` — 소스 가드(결함 2 는 조회 결과를 그대로 반환할 뿐 분기 로직 없음 → API 선택으로 충분). 2건.

**red→green (실측)** — 각 수정을 개별 되돌려 캡처:

결함 1 (comparePositions 원복):
```
✖ 중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다 (데이터 손실 방지)  1 !== -1
✖ 서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다  1 !== -1
✔ depth 1 (비중첩) 셀 정렬은 불변이다 (회귀 대조군)
✔ 본문 정렬은 불변이다 (회귀 대조군)
✔ 본문↔셀 혼합 정렬은 불변이다 (회귀 대조군)
✔ comparePositions 는 반대칭·반사적이다
pass 4 / fail 2
```
RED 에서 **대조군 4건이 통과**해 실패가 중첩 셀 축 혼용 때문임을 격리한다(depth 1·본문·혼합 무변화 증명).

결함 2 (getCharPropertiesAtCursor 원복): 가드 2건 모두 실패("ByPath 분기가 있어야 한다"). 복원 후 신규 8건 전부 GREEN.

**CI 게이트 (기준선 대조)**

| | clean `devel` | 수정 후 |
|---|---|---|
| `npm test` | tests 465 / pass 464 / fail 1 | tests 473 / pass 472 / fail 1 |
| `npx tsc --noEmit` | error 2 (`TS2307 @wasm/rhwp.js`) | error 2 (**baseline 과 byte-identical**) |

유일한 실패 `tests/cell-flow-boundary.test.ts` 는 **기준선에도 있던 선재 실패**(Windows `spawnSync` `status=null`)로 본 변경과 무관. `tsc` 2건은 로컬 WASM 산출물 부재로 나는 선재 오류이며 `diff` 결과 완전 동일(신규 타입 오류 0).

## 범위 밖 (잔여)

1. `applyNavResult`(`cursor.ts:396`)의 `cellPath` 유실(수직 이동) — 이번 수정은 폴백으로 일관성만 확보. 별건.
2. flat 필드 폐기 — Rust 직렬화(`cursor_rect.rs` 18곳) 연동으로 범위 밖.
3. 셀 내 다중 문단 삭제 undo 의 구조적 한계(`command.ts:603` 자체 주석) — 이번 건은 `savedTexts` 가 비는 문제만 제거.
4. `cursor_rect.rs` flat 채움 규칙 — 무수정(TS 소비자가 축을 올바로 고르는 것으로 충분).

처리결과 문서: `mydocs/report/task_m100_2756_report.md`.
