### PR TITLE
fix(studio): 드래그·클릭 문서 뮤테이션 3건 히스토리 라우팅 (#2759)

### DIFF
--- a/mydocs/report/task_m100_2759_report.md
+++ b/mydocs/report/task_m100_2759_report.md
@@ -1,0 +1,105 @@
+# Task #2759 처리 결과 보고서 — 드래그·클릭 문서 뮤테이션 3건 히스토리 라우팅
+
+- 일자: 2026-07-21
+- 이슈: [#2759](https://github.com/edwardkim/rhwp/issues/2759)
+- 브랜치: `task/m100-2759-drag-undo-routing` (base `origin/devel` = `bd442b2a`)
+- 범위: `rhwp-studio/` TypeScript 만. `.rs` 무수정.
+
+## 1. 무엇을 고쳤나
+
+`mutation-method-registry.ts:1-19` 가 명명한 재발 계급(#2027/#2037/#2053/#2077 — 미기록 뮤테이션의
+①undo 불가 ②redo 미무효화 ③스냅샷 undo 동반 파괴)에 속하는 **엔진 층 진입점 3곳**을 라우팅했다.
+
+| # | 진입점 | 종전 | 수정 |
+|---|---|---|---|
+| 1 | 회전 핸들 드래그 종료 `finishPictureRotateDrag` | 상태만 정리, 미기록 | `computeRotationRecord` 로 각 변화 판정 → `executeOperation({kind:'record', ResizeObjectCommand([{rotationAngle before/after}])})` |
+| 2 | 직선 끝점 드래그 종료 (onMouseUp 인라인) | 상태만 정리, 미기록 | `finishLineEndpointDrag` 신설: 드래그 시작 시 원래 끝점 캡처 → `computeLineEndpointRecord` 판정 → `executeOperation({kind:'record', MoveLineEndpointCommand})` |
+| 3 | 클릭 시 z순서 변경 `bringShapeToFront` | `this.wasm.changeShapeZOrder` 직접 호출 | 메뉴 정렬(insert.ts:427)과 동형 `executeOperation({kind:'snapshot', operationType:'changeZOrder'})` |
+
+세 수정 모두 기존 라우팅된 형제(리사이즈/이동 드래그, 메뉴 회전/정렬)와 동형 패턴을 그대로 미러했다.
+새 커맨드는 `MoveLineEndpointCommand`(전/후 글로벌 끝점 좌표) 하나뿐이고, 회전은 기존
+`ResizeObjectCommand` 의 임의 속성 가방(`{rotationAngle}`)을 재사용해 새 클래스가 없다.
+
+## 2. 변경 파일
+
+| 파일 | 내용 |
+|---|---|
+| `src/engine/object-drag-record.ts` (신규) | 순수 결정 함수 `computeRotationRecord`, `computeLineEndpointRecord`(변화 없으면 null). picture-resize.ts 패턴 |
+| `src/engine/command.ts` | `MoveLineEndpointCommand` 추가(execute=after 재적용, undo=before 복원). `LineEndpoints` 타입 import |
+| `src/engine/input-handler-picture.ts` | `finishPictureRotateDrag` 에 record 기록 + `computeRotationRecord` import |
+| `src/engine/input-handler-mouse.ts` | 끝점 드래그 시작 시 `orig` 캡처, `finishLineEndpointDrag` 신설, onMouseUp 위임, `bringShapeToFront` snapshot 라우팅 |
+| `src/engine/input-handler.ts` | `lineEndpointState.orig` 필드, `finishLineEndpointDrag` 위임 메서드 |
+| `tests/object-drag-record.test.ts` (신규) | 순수 함수 단위 테스트 8건 |
+| `tests/undo-drag-command-behaviour.test.ts` (+`tests/support/*.mjs`, 신규) | 커맨드 클래스 execute/undo 행위 테스트(자식 프로세스 로드) |
+| `tests/undo-drag-click-routing.test.ts` (신규) | 3 진입점 라우팅 소스 가드 4건 |
+
+## 3. 검증
+
+### 3-1. 행위 테스트 vs 소스 가드 (무엇을 택했나)
+
+두 층 모두 사용했다.
+
+- **행위(순수 모듈)**: `object-drag-record.ts` 를 외부 import 없는 순수 함수로 분리해 기본 test 러너로
+  직접 검증(picture-resize.ts ↔ picture-resize.test.ts 선례). 기록 결정 로직의 진짜 red→green.
+- **행위(커맨드 클래스)**: 이 저장소는 `cursor.ts:85` TS 파라미터 프로퍼티 때문에 기본(strip-only)
+  러너로 엔진 클래스를 import 못 한다. PR #2720 방식(`--experimental-transform-types` +
+  `module.registerHooks` 별칭)을 자식 프로세스로 spawn 해 `command.ts` 를 실제 로드하고 mock
+  WasmBridge 로 `MoveLineEndpointCommand`·`ResizeObjectCommand(회전)` 의 execute/undo 를 검증했다.
+  **로컬(Node 24.17)에서 실제 green** 이며, 구버전 Node(플래그/registerHooks 미지원)에서는 skip 해
+  CI 를 깨지 않는다.
+- **소스 가드**: 배선(어느 종료 핸들러가 executeOperation 을 호출하는가)은 `undo-menu-object-ops`
+  모델의 정적 가드로 핀했다 — 이것이 라우팅 red→green 의 주 구동체.
+
+### 3-2. red→green (각 수정 개별 되돌림, 실제 출력)
+
+`git stash` 는 워크트리 간 공유되어 위험하므로 사용하지 않고, 각 수정을 Edit 로 개별 되돌려 실행했다.
+
+- **RED 1 (회전 되돌림)**: `undo-drag-click-routing` 4건 중 1건만 실패, 나머지 12건(순수+행위 포함) GREEN.
+  ```
+  AssertionError: origAngle→finalAngle 기록 결정을 순수 함수로 위임
+    expected: /computeRotationRecord\(/
+  ```
+- **RED 2 (끝점 onMouseUp 위임 되돌림)**: `onMouseUp ... finishLineEndpointDrag 로 위임` 1건만 실패.
+  ```
+  AssertionError: onMouseUp 은 상태 인라인 초기화가 아니라 finishLineEndpointDrag 로 위임해야 함(기록 경로 확보)
+  ```
+- **RED 3 (z순서 되돌림)**: `bringShapeToFront ... snapshot` 1건만 실패.
+  ```
+  AssertionError: this.wasm.changeShapeZOrder 직접 호출 금지 — executeOperation 경유여야 함
+  ```
+
+**RED 에서도 통과하는 것**: 순수 함수 테스트(`object-drag-record`)와 커맨드 행위 테스트
+(`undo-drag-command-behaviour`)는 배선이 아니라 메커니즘을 보므로 각 RED 에서도 GREEN. 라우팅 gap 은
+소스 가드가 잡는다는 설계 의도 그대로다.
+
+### 3-3. CI 게이트
+
+- `npx tsc --noEmit`: **2 errors**, 모두 사전 존재(`@wasm/rhwp.js` 모듈 미해석 — WASM 산출물 미빌드,
+  환경 요인). 수정 전 baseline 과 diff **완전 동일 = 신규 타입 오류 0**.
+- `npm test`: **478 tests / 477 pass / 1 fail**. 유일 실패는 `cell-flow-boundary.test.ts`(깨끗한 devel
+  에서도 실패하는 기존 실패, 본 작업 무관). baseline 465→478(+13 신규), skipped 0(행위 테스트 실제 실행).
+  - (참고) 머신 고부하 시 1회 다른 기존 테스트가 타임아웃으로 함께 실패한 적 있으나, 부하 완화 후
+    재실행 시 `cell-flow-boundary` 단일 실패로 재현. 신규 테스트는 격리 실행에서 13/13 GREEN.
+
+### 3-4. 뮤테이션 표면 원장
+
+세 수정 모두 스캔 대상 파일의 `wasm.*` 뮤테이터 텍스트 수를 늘리지 않는다(호출을 콜백 안으로 이동
+또는 유지, 신규 `moveLineEndpoint` 호출은 스캔 비대상 `command.ts` 에만). `mutation-routing-guard` 원장
+테스트 GREEN — BASELINE 갱신 불필요.
+
+## 4. 범위 밖 (잔여)
+
+- **`lineEndpointState.ref` 의 cellPath/headerFooter 미포함**: 형제 상태와 달리 경로축이 없다. 선택
+  진입부도 직선에 cellPath 를 안 넘기고 `moveLineEndpoint` 에 경로 인자가 없어, 셀 내 직선 끝점 드래그가
+  도달 가능한지 미확인. 본문 직선의 undo 누락은 이와 무관하게 성립하므로 본 PR 에서 확장하지 않음.
+- **선택만으로 z순서가 바뀌는 설계**: 한컴은 선택 시 재정렬하지 않는다. 유지 여부는 메인테이너 판단
+  요청(이슈 4절). 유지 시 최소한 기록은 되어야 하며(본 PR 이 그 부분 처리), no-op 재클릭이 히스토리에
+  쌓이는 부작용은 사전 판별이 TS 만으로 불가(변경 플래그/ z순서 setter 부재 = Rust 변경 필요)라 별건.
+- **머리말/꼬리말 개체의 `ResizeObjectCommand` 경로**: `setProps` 에 headerFooter 분기 부재는 기존
+  리사이즈 드래그도 동일한 선행 한계라 확장하지 않음.
+
+## 5. 주의 기록 (환경)
+
+작업 중 `git stash` 가 **워크트리 간 공유 스택**임을 확인(다른 워크트리의 #2751 `body.rs` 변경이
+워킹트리에 누출됨). 해당 `body.rs` 는 본 작업과 무관하며 스테이징하지 않았다. 커밋은 파일 명시
+스테이징으로만 수행(`git add -A` 미사용).

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,6 +1,7 @@
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
+import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
 
 /** 편집 명령 공통 인터페이스 */
 export interface EditCommand {
@@ -1564,6 +1565,43 @@ export class ResizeObjectCommand implements EditCommand {
     }
     const first = this.targets[0];
     return { sectionIndex: first?.sec ?? 0, paragraphIndex: first?.ppi ?? 0, charOffset: 0 };
+  }
+
+  mergeWith(): null { return null; }
+}
+
+/**
+ * [Task #2759] 직선/연결선 끝점 드래그를 Undo/Redo 스택에 기록하기 위한 명령.
+ *
+ * ResizeObjectCommand 와 동일하게 드래그 중 WASM 에 이미 반영된 변경을 kind:'record' 로
+ * 사후 기록한다(execute 는 redo 경로에서만 재적용). before/after 는 글로벌 끝점 좌표
+ * (HWPUNIT)이며 moveLineEndpoint 는 절대 좌표 setter 라 역연산이 자명하다.
+ */
+export class MoveLineEndpointCommand implements EditCommand {
+  readonly type = 'moveLineEndpoint';
+  readonly timestamp: number;
+
+  constructor(
+    private sec: number,
+    private ppi: number,
+    private ci: number,
+    private before: LineEndpointsLike,
+    private after: LineEndpointsLike,
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.moveLineEndpoint(this.sec, this.ppi, this.ci,
+      this.after.sx, this.after.sy, this.after.ex, this.after.ey);
+    return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.moveLineEndpoint(this.sec, this.ppi, this.ci,
+      this.before.sx, this.before.sy, this.before.ex, this.before.ey);
+    return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
   }
 
   mergeWith(): null { return null; }

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -3,6 +3,8 @@
 
 import type { ContextMenuItem } from '@/ui/context-menu';
 import * as _connector from './input-handler-connector';
+import { MoveLineEndpointCommand } from './command';
+import { computeLineEndpointRecord } from './object-drag-record';
 
 function protectedCellKey(hit: any): string | null {
   if (!hit || hit.isTextBox) return null;
@@ -563,11 +565,21 @@ export function onClick(this: any, e: MouseEvent): void {
                 const pw = this.virtualScroll.getPageWidth(picBbox.pageIndex);
                 const pl = this.virtualScroll.getPageLeftResolved(picBbox.pageIndex, sc.clientWidth);
                 this.isLineEndpointDragging = true;
+                // [Task #2759] 드래그 시작 시 원래 끝점(글로벌 HWPUNIT)을 캡처해 종료 시
+                // Undo 기록의 before 로 쓴다. (x1,y1)=시작점, (x2,y2)=끝점 — 드래그 중
+                // 좌표 계산(PX2HWP=75)과 동일. cellPath 는 담지 않는다(잔여: 셀 내 직선 미대응).
+                const PX2HWP_LINE = 75;
                 this.lineEndpointState = {
                   ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
                   endpoint: dir === 'sw' ? 'start' : 'end',
                   pageIndex: picBbox.pageIndex,
                   pageLeft: pl, pageOffset: po, zoom,
+                  orig: {
+                    sx: Math.round((picBbox.x1 ?? 0) * PX2HWP_LINE),
+                    sy: Math.round((picBbox.y1 ?? 0) * PX2HWP_LINE),
+                    ex: Math.round((picBbox.x2 ?? 0) * PX2HWP_LINE),
+                    ey: Math.round((picBbox.y2 ?? 0) * PX2HWP_LINE),
+                  },
                 };
                 this.container.style.cursor = 'crosshair';
                 document.addEventListener('mouseup', this.onMouseUpBound, { once: true });
@@ -1886,10 +1898,7 @@ export function onMouseUp(this: any, _e: MouseEvent): void {
 
   // 직선 끝점 드래그 종료
   if (this.isLineEndpointDragging) {
-    this.isLineEndpointDragging = false;
-    this.lineEndpointState = null;
-    this.container.style.cursor = '';
-    if (this.dragRafId) { cancelAnimationFrame(this.dragRafId); this.dragRafId = 0; }
+    this.finishLineEndpointDrag();
     return;
   }
 
@@ -1950,10 +1959,59 @@ export function onMouseUp(this: any, _e: MouseEvent): void {
 function bringShapeToFront(this: any, picHit: any): void {
   if (picHit.type === 'shape' || picHit.type === 'line' || picHit.type === 'group' || picHit.type === 'ole') {
     try {
-      this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+      // [Task #2759] 선택 시 z순서 변경도 문서 뮤테이션 — 메뉴 정렬(insert.ts:427 등)의
+      // recordObjectMutation 과 동형으로 snapshot 기록해 undo 가능·redo 무효화·스냅샷 undo
+      // 동반 파괴를 막는다. UI 후처리(선택 진입·재렌더)는 호출부가 기존대로 수행한다.
+      const pos = this.getCursorPosition();
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'changeZOrder',
+        operation: (wasm: any) => {
+          wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+          return pos;
+        },
+      });
       this.eventBus.emit('document-changed');
     } catch { /* ignore */ }
   }
+}
+
+/**
+ * [Task #2759] 직선 끝점 드래그 종료 — 드래그 중 이미 문서에 반영된 끝점 이동을 Undo
+ * 히스토리에 기록한다. 다른 드래그 종료(finishPictureMoveDrag/finishPictureResizeDrag)와
+ * 동형으로 kind:'record' 를 쓴다(after 는 종료 시점 문서에서 읽어 실제 반영값과 정합).
+ */
+export function finishLineEndpointDrag(this: any): void {
+  const st = this.lineEndpointState;
+  if (st && st.orig) {
+    try {
+      const PX2HWP = 75;
+      const bbox = this.findPictureBbox(st.ref);
+      if (bbox) {
+        const after = {
+          sx: Math.round((bbox.x1 ?? 0) * PX2HWP),
+          sy: Math.round((bbox.y1 ?? 0) * PX2HWP),
+          ex: Math.round((bbox.x2 ?? 0) * PX2HWP),
+          ey: Math.round((bbox.y2 ?? 0) * PX2HWP),
+        };
+        const record = computeLineEndpointRecord(st.orig, after);
+        if (record) {
+          this.executeOperation({
+            kind: 'record',
+            command: new MoveLineEndpointCommand(
+              st.ref.sec, st.ref.ppi, st.ref.ci, record.before, record.after,
+            ),
+          });
+        }
+      }
+    } catch (err) {
+      console.warn('[InputHandler] 직선 끝점 이동 기록 실패:', err);
+    }
+  }
+  this.isLineEndpointDragging = false;
+  this.lineEndpointState = null;
+  this.container.style.cursor = '';
+  if (this.dragRafId) { cancelAnimationFrame(this.dragRafId); this.dragRafId = 0; }
 }
 
 function getRotatedCursor(dir: string, angleDeg: number): string {

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -4,6 +4,7 @@
 import { MovePictureCommand, MoveShapeCommand, ResizeObjectCommand } from './command';
 import type { ObjectResizeTarget } from './command';
 import { computeArrowResize, MIN_SIZE_HWP, type ArrowKey } from './picture-resize';
+import { computeRotationRecord } from './object-drag-record';
 import type { CellPathLike } from '@/core/types';
 import { showToast } from '@/ui/toast';
 
@@ -1135,8 +1136,31 @@ export function updatePictureRotateDrag(this: any, e: MouseEvent): void {
   }
 }
 
-/** 회전 드래그 종료: 핸들을 최종 회전 위치로 스냅 */
+/** 회전 드래그 종료: 최종 회전각을 Undo 히스토리에 기록하고 핸들을 최종 위치로 스냅 */
 export function finishPictureRotateDrag(this: any, _e: MouseEvent): void {
+  // [Task #2759] 드래그 중 setObjectProperties({rotationAngle})가 문서에 이미 반영됐으나
+  // 미기록이면 undo 불가·redo 미무효화·스냅샷 undo 동반 파괴. finishPictureResizeDrag 와
+  // 동형으로 kind:'record' 로 사후 기록한다(origAngle 은 드래그 시작 시 캡처됨).
+  const state = this.pictureRotateState;
+  if (state) {
+    try {
+      const props = getObjectProperties.call(this, state.ref);
+      const finalAngle = Math.round((props?.rotationAngle as number) ?? state.origAngle);
+      const record = computeRotationRecord(state.origAngle, finalAngle);
+      if (record) {
+        this.executeOperation({
+          kind: 'record',
+          command: new ResizeObjectCommand([{
+            sec: state.ref.sec, ppi: state.ref.ppi, ci: state.ref.ci,
+            type: state.ref.type, cellPath: state.ref.cellPath,
+            before: record.before, after: record.after,
+          }]),
+        });
+      }
+    } catch (err) {
+      console.warn('[InputHandler] 개체 회전 기록 실패:', err);
+    }
+  }
   this.isPictureRotateDragging = false;
   this.pictureRotateState = null;
   this.container.style.cursor = '';

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -432,6 +432,8 @@ export class InputHandler {
     pageLeft: number;
     pageOffset: number;
     zoom: number;
+    // [Task #2759] 드래그 시작 시 캡처한 원래 끝점(글로벌 HWPUNIT) — 종료 시 Undo 기록의 before.
+    orig: { sx: number; sy: number; ex: number; ey: number };
   } | null = null;
 
   // 양식 개체 오버레이
@@ -1329,6 +1331,11 @@ export class InputHandler {
   /** 마우스 버튼 놓기: 드래그 선택 종료 */
   private onMouseUp(_e: MouseEvent): void {
     _mouse.onMouseUp.call(this, _e);
+  }
+
+  /** [Task #2759] 직선 끝점 드래그 종료 — 끝점 이동을 Undo 히스토리에 기록 */
+  private finishLineEndpointDrag(): void {
+    _mouse.finishLineEndpointDrag.call(this);
   }
 
   /** 마우스 이벤트에서 hitTest 결과를 반환한다 */

--- a/rhwp-studio/src/engine/object-drag-record.ts
+++ b/rhwp-studio/src/engine/object-drag-record.ts
@@ -1,0 +1,71 @@
+/**
+ * 개체 드래그 종료 시 "히스토리에 기록할 before/after" 결정 로직 (#2759) — 순수 함수 모듈.
+ *
+ * 회전 핸들 드래그(input-handler-picture.ts:finishPictureRotateDrag)와 직선 끝점
+ * 드래그(input-handler-mouse.ts:finishLineEndpointDrag)가 사용한다. 두 종료 핸들러는
+ * 드래그 중 이미 문서에 반영된 변경을 executeOperation({kind:'record'})로 기록해야
+ * undo/redo 계약(#2027/#2037/#2053/#2077 재발 계급)을 지킨다.
+ *
+ * picture-resize.ts / navigation-keymap.ts 와 동일하게 외부 import 없이 유지해
+ * node:test 단위 테스트(tests/object-drag-record.test.ts) 대상으로 둔다. "변화가 없으면
+ * null" 계약으로 무의미한 Undo 항목·redo 스택 무효화를 막는 책임이 이 모듈에 있다.
+ */
+
+/** 회전각 변경 기록. before/after 는 setObjectProperties 에 그대로 전달되는 속성 가방. */
+export interface RotationRecord {
+  before: { rotationAngle: number };
+  after: { rotationAngle: number };
+}
+
+/**
+ * 드래그 시작 각도(origAngle)와 종료 시 문서에 실제 반영된 각도(finalAngle)를 비교해
+ * 기록 대상 before/after 를 돌려준다. 두 각이 같거나(=드래그 없음) 입력이 비정상이면 null.
+ * 각도는 호출부에서 이미 정규화·라운딩된 값이 들어온다(그대로 보존).
+ */
+export function computeRotationRecord(
+  origAngle: number,
+  finalAngle: number,
+): RotationRecord | null {
+  if (!Number.isFinite(origAngle) || !Number.isFinite(finalAngle)) return null;
+  if (origAngle === finalAngle) return null;
+  return {
+    before: { rotationAngle: origAngle },
+    after: { rotationAngle: finalAngle },
+  };
+}
+
+/** 직선 끝점 좌표(글로벌 HWPUNIT). moveLineEndpoint(sec,ppi,ci, sx,sy,ex,ey) 인자와 1:1. */
+export interface LineEndpoints {
+  sx: number;
+  sy: number;
+  ex: number;
+  ey: number;
+}
+
+/** 직선 끝점 드래그 기록. before/after 는 MoveLineEndpointCommand 가 그대로 사용. */
+export interface LineEndpointRecord {
+  before: LineEndpoints;
+  after: LineEndpoints;
+}
+
+function endpointsEqual(a: LineEndpoints, b: LineEndpoints): boolean {
+  return a.sx === b.sx && a.sy === b.sy && a.ex === b.ex && a.ey === b.ey;
+}
+
+function endpointsFinite(p: LineEndpoints): boolean {
+  return Number.isFinite(p.sx) && Number.isFinite(p.sy) &&
+    Number.isFinite(p.ex) && Number.isFinite(p.ey);
+}
+
+/**
+ * 드래그 시작 시 캡처한 끝점(before)과 종료 시 문서에서 읽은 끝점(after)을 비교해 기록
+ * 대상을 돌려준다. 좌표가 동일하거나(=클릭만 하고 안 움직임) 비정상이면 null.
+ */
+export function computeLineEndpointRecord(
+  before: LineEndpoints,
+  after: LineEndpoints,
+): LineEndpointRecord | null {
+  if (!endpointsFinite(before) || !endpointsFinite(after)) return null;
+  if (endpointsEqual(before, after)) return null;
+  return { before: { ...before }, after: { ...after } };
+}

--- a/rhwp-studio/tests/object-drag-record.test.ts
+++ b/rhwp-studio/tests/object-drag-record.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeRotationRecord,
+  computeLineEndpointRecord,
+  type LineEndpoints,
+} from '../src/engine/object-drag-record.ts';
+
+// [Task #2759] 개체 드래그 종료 시 "기록할 before/after 결정" 순수 로직 단위 테스트.
+// 회전 핸들 드래그·직선 끝점 드래그가 undo 가능하려면 이 결정이 정확해야 한다
+// (변화 없으면 null → 무의미한 Undo 항목·redo 스택 무효화 방지).
+
+test('computeRotationRecord 는 각이 바뀌면 origAngle→finalAngle before/after 를 준다', () => {
+  const r = computeRotationRecord(0, 45);
+  assert.ok(r);
+  assert.deepEqual(r.before, { rotationAngle: 0 });
+  assert.deepEqual(r.after, { rotationAngle: 45 });
+});
+
+test('computeRotationRecord 는 각이 같으면 null (드래그 없음 = 미기록)', () => {
+  assert.equal(computeRotationRecord(90, 90), null);
+  assert.equal(computeRotationRecord(0, 0), null);
+});
+
+test('computeRotationRecord 는 음수각·정규화된 값을 그대로 보존한다', () => {
+  const r = computeRotationRecord(30, -15);
+  assert.ok(r);
+  assert.deepEqual(r.before, { rotationAngle: 30 });
+  assert.deepEqual(r.after, { rotationAngle: -15 });
+});
+
+test('computeRotationRecord 는 비정상 입력(NaN/Infinity)에 null 을 준다', () => {
+  assert.equal(computeRotationRecord(Number.NaN, 45), null);
+  assert.equal(computeRotationRecord(0, Number.POSITIVE_INFINITY), null);
+});
+
+const A: LineEndpoints = { sx: 1000, sy: 2000, ex: 3000, ey: 4000 };
+
+test('computeLineEndpointRecord 는 끝점이 바뀌면 before/after 를 복사해 준다', () => {
+  const after: LineEndpoints = { sx: 1500, sy: 2000, ex: 3000, ey: 4000 };
+  const r = computeLineEndpointRecord(A, after);
+  assert.ok(r);
+  assert.deepEqual(r.before, A);
+  assert.deepEqual(r.after, after);
+  // 방어적 복사 — 원본 변형이 기록에 새지 않아야 한다.
+  assert.notEqual(r.before, A);
+});
+
+test('computeLineEndpointRecord 는 좌표가 동일하면 null (클릭만 = 미기록)', () => {
+  assert.equal(computeLineEndpointRecord(A, { ...A }), null);
+});
+
+test('computeLineEndpointRecord 는 어느 한 좌표만 달라도 기록 대상이다', () => {
+  assert.ok(computeLineEndpointRecord(A, { ...A, ey: 4001 }));
+  assert.ok(computeLineEndpointRecord(A, { ...A, sx: 999 }));
+});
+
+test('computeLineEndpointRecord 는 비정상 좌표(NaN)에 null 을 준다', () => {
+  assert.equal(computeLineEndpointRecord(A, { ...A, sx: Number.NaN }), null);
+  assert.equal(computeLineEndpointRecord({ ...A, ey: Number.NaN }, A), null);
+});

--- a/rhwp-studio/tests/support/drag-command-behaviour.runner.mjs
+++ b/rhwp-studio/tests/support/drag-command-behaviour.runner.mjs
@@ -1,0 +1,64 @@
+// [Task #2759] 행위 러너 — command.ts 의 커맨드 클래스를 실제 로드해 execute/undo 를
+// mock WasmBridge 로 검증한다. cursor.ts:85 의 TS 파라미터 프로퍼티 때문에 기본 test
+// 러너(strip-only)는 엔진 클래스를 import 하지 못하므로, 이 러너를 부모 테스트가
+// --experimental-transform-types 로 spawn 한다(별도 PR #2720 방식). 실패 시 비정상 종료.
+import { registerHooks } from 'node:module';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import assert from 'node:assert/strict';
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src');
+
+// @/ 별칭 + 확장자 없는 상대 import 를 .ts 로 해석(tsconfig paths 재현).
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) {
+      const abs = join(srcDir, specifier.slice(2));
+      const withTs = abs.endsWith('.ts') ? abs : abs + '.ts';
+      return { url: pathToFileURL(withTs).href, shortCircuit: true };
+    }
+    if ((specifier.startsWith('./') || specifier.startsWith('../')) && !/\.[cm]?[tj]s$/.test(specifier)) {
+      const parent = context.parentURL ? dirname(fileURLToPath(context.parentURL)) : srcDir;
+      return { url: pathToFileURL(join(parent, specifier + '.ts')).href, shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { MoveLineEndpointCommand, ResizeObjectCommand } =
+  await import(pathToFileURL(join(srcDir, 'engine', 'command.ts')).href);
+
+// ── MoveLineEndpointCommand: 끝점 이동 undo/redo ────────────────────────────
+{
+  let last = null;
+  const wasm = { moveLineEndpoint: (...a) => { last = a; } };
+  const before = { sx: 100, sy: 200, ex: 300, ey: 400 };
+  const after = { sx: 150, sy: 200, ex: 300, ey: 999 };
+  const cmd = new MoveLineEndpointCommand(2, 3, 4, before, after);
+
+  cmd.execute(wasm); // redo 경로: after 재적용
+  assert.deepEqual(last, [2, 3, 4, 150, 200, 300, 999], 'execute 는 after 끝점을 적용해야 함');
+
+  cmd.undo(wasm); // before 복원
+  assert.deepEqual(last, [2, 3, 4, 100, 200, 300, 400], 'undo 는 before 끝점을 복원해야 함');
+  assert.equal(cmd.type, 'moveLineEndpoint');
+  assert.equal(cmd.mergeWith(), null, '병합 없음(각 드래그는 독립 기록)');
+}
+
+// ── ResizeObjectCommand: 회전각 before/after(임의 속성 가방) ─────────────────
+{
+  const applied = [];
+  const wasm = { setShapeProperties: (s, p, c, props) => applied.push(props) };
+  const cmd = new ResizeObjectCommand([{
+    sec: 0, ppi: 1, ci: 2, type: 'shape',
+    before: { rotationAngle: 0 }, after: { rotationAngle: 45 },
+  }]);
+
+  cmd.execute(wasm); // 회전 드래그 종료 후 redo
+  assert.deepEqual(applied.at(-1), { rotationAngle: 45 }, 'execute 는 after 회전각을 적용');
+
+  cmd.undo(wasm);
+  assert.deepEqual(applied.at(-1), { rotationAngle: 0 }, 'undo 는 원래 회전각으로 복원');
+}
+
+console.log('DRAG_COMMAND_BEHAVIOUR_OK');

--- a/rhwp-studio/tests/undo-drag-click-routing.test.ts
+++ b/rhwp-studio/tests/undo-drag-click-routing.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2759] 드래그·클릭 문서 뮤테이션의 히스토리 라우팅 소스 가드.
+//
+// 회전 핸들 드래그·직선 끝점 드래그·클릭 z순서 변경이 executeOperation 를 경유해 undo 에
+// 기록되는지 정적으로 핀한다. 뮤테이션 표면 원장(mutation-routing-guard)은 '표면 증가'만
+// 잡고 '라우팅 누락'은 못 잡으므로(라우팅해도 wasm.X( 텍스트는 그대로 남음), 그리고
+// undo-menu-object-ops 는 command/commands/insert.ts 만 보므로, 엔진 층 진입점은 이 가드가
+// 담당한다. 행위 증명은 tests/undo-drag-command-behaviour.test.ts(커맨드 execute/undo)와
+// tests/object-drag-record.test.ts(기록 결정 순수 로직)에 있다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pictureSrc = readFileSync(join(rootDir, 'src/engine/input-handler-picture.ts'), 'utf8');
+const mouseSrc = readFileSync(join(rootDir, 'src/engine/input-handler-mouse.ts'), 'utf8');
+
+/** name 으로 시작하는 함수 본문을 다음 최상위 'export function'/'function ' 전까지 잘라온다. */
+function fnBody(src: string, header: string): string {
+  const start = src.indexOf(header);
+  assert.notEqual(start, -1, `${header} 를 찾지 못함`);
+  const after = src.slice(start + header.length);
+  const next = after.search(/\n(export )?function /);
+  return after.slice(0, next === -1 ? 2000 : next);
+}
+
+// ── 결함 1: 회전 핸들 드래그 ───────────────────────────────────────────────
+test('finishPictureRotateDrag 는 회전각 변경을 executeOperation record 로 기록한다', () => {
+  const body = fnBody(pictureSrc, 'export function finishPictureRotateDrag');
+  assert.match(body, /computeRotationRecord\(/, 'origAngle→finalAngle 기록 결정을 순수 함수로 위임');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유(히스토리 기록)');
+  assert.match(body, /kind:\s*'record'/, "kind:'record' 로 드래그 사후 기록");
+  assert.match(body, /new ResizeObjectCommand\(/, 'rotationAngle before/after 를 ResizeObjectCommand 로');
+});
+
+// ── 결함 2: 직선 끝점 드래그 ───────────────────────────────────────────────
+test('finishLineEndpointDrag 는 끝점 이동을 executeOperation record 로 기록한다', () => {
+  const body = fnBody(mouseSrc, 'export function finishLineEndpointDrag');
+  assert.match(body, /computeLineEndpointRecord\(/, 'before/after 끝점 기록 결정을 순수 함수로 위임');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유');
+  assert.match(body, /kind:\s*'record'/, "kind:'record' 로 드래그 사후 기록");
+  assert.match(body, /new MoveLineEndpointCommand\(/, '끝점 좌표 역연산 커맨드로 기록');
+});
+
+test('onMouseUp 은 직선 끝점 종료를 finishLineEndpointDrag 로 위임한다(인라인 정리 금지)', () => {
+  const body = fnBody(mouseSrc, 'export function onMouseUp');
+  assert.match(body, /if \(this\.isLineEndpointDragging\)\s*{\s*this\.finishLineEndpointDrag\(\);/,
+    'onMouseUp 은 상태 인라인 초기화가 아니라 finishLineEndpointDrag 로 위임해야 함(기록 경로 확보)');
+});
+
+// ── 결함 3: 클릭 z순서 변경 ────────────────────────────────────────────────
+test('bringShapeToFront 는 z순서 변경을 executeOperation snapshot 으로 기록한다', () => {
+  const body = fnBody(mouseSrc, 'function bringShapeToFront');
+  // 미라우팅 회귀: this.wasm.changeShapeZOrder( 직접 호출이 남으면 히스토리 우회.
+  assert.doesNotMatch(body, /this\.wasm\.changeShapeZOrder\s*\(/,
+    'this.wasm.changeShapeZOrder 직접 호출 금지 — executeOperation 경유여야 함');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유');
+  assert.match(body, /kind:\s*'snapshot'/, "kind:'snapshot' 로 기록(메뉴 정렬 경로와 동형)");
+  assert.match(body, /operationType:\s*'changeZOrder'/, 'changeZOrder 로 분류');
+  assert.match(body, /wasm\.changeShapeZOrder\s*\(/, '뮤테이션 자체는 operation 콜백에 존재');
+});

--- a/rhwp-studio/tests/undo-drag-command-behaviour.test.ts
+++ b/rhwp-studio/tests/undo-drag-command-behaviour.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as nodeModule from 'node:module';
+
+// [Task #2759] command.ts 커맨드 클래스의 execute/undo 행위 테스트.
+//
+// 이 저장소는 cursor.ts:85 의 TS 파라미터 프로퍼티 때문에 기본 test 러너(strip-only)로
+// 엔진 클래스를 import 하지 못한다(tests/undo-menu-object-ops.test.ts 헤더 참고). 그래서
+// --experimental-transform-types 를 켠 자식 프로세스로 러너를 spawn 해 실제 클래스를 로드하고
+// mock WasmBridge 로 MoveLineEndpointCommand·ResizeObjectCommand(회전) 을 검증한다.
+//
+// 자식이 요구하는 기능(Transform Types 플래그 + module.registerHooks)이 없는 구버전 Node
+// 에서는 skip 한다(부모는 strip-only 로 동작하므로 CI 를 깨지 않는다). 지원 런타임에서는
+// 진짜 행위 red→green 게이트로 동작한다.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runner = join(here, 'support', 'drag-command-behaviour.runner.mjs');
+
+function transformTypesSupported(): boolean {
+  return process.allowedNodeEnvironmentFlags.has('--experimental-transform-types')
+    && typeof (nodeModule as { registerHooks?: unknown }).registerHooks === 'function';
+}
+
+test('커맨드 클래스 execute/undo 행위 (자식 프로세스 로드)', (t) => {
+  if (!transformTypesSupported()) {
+    t.skip('현재 Node 가 --experimental-transform-types / registerHooks 미지원 — 행위 테스트 skip');
+    return;
+  }
+  const res = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', runner],
+    { encoding: 'utf8' },
+  );
+  assert.equal(res.status, 0,
+    `러너가 비정상 종료했습니다.\n--- stdout ---\n${res.stdout}\n--- stderr ---\n${res.stderr}`);
+  assert.match(res.stdout, /DRAG_COMMAND_BEHAVIOUR_OK/, '행위 검증 성공 마커가 있어야 함');
+});


### PR DESCRIPTION
## 요약

이슈 #2759 의 결함 3건을 한 계급·한 패턴으로 수정한다. `rhwp-studio` 엔진 층에서 **문서를 바꾸지만
히스토리를 우회하던 드래그·클릭 진입점 3곳**을 기존 라우팅된 형제와 동형으로 `executeOperation` 에
태운다. `.rs` 무수정, `rhwp-studio/` TypeScript 만.

계급: `mutation-method-registry.ts:1-19` 가 명명한 재발 계급(#2027/#2037/#2053/#2077) — 미기록
뮤테이션의 ①undo 불가 ②redo 미무효화 ③스냅샷 undo 동반 파괴.

## 수정

| # | 진입점 | 종전 | 수정 | 형제 |
|---|---|---|---|---|
| 1 | `finishPictureRotateDrag` (input-handler-picture.ts) | 상태만 정리, 미기록 | `computeRotationRecord` 판정 → `kind:'record'` + `ResizeObjectCommand([{rotationAngle}])` | `finishPictureResizeDrag`(동일 파일) |
| 2 | 직선 끝점 드래그 종료 (onMouseUp, input-handler-mouse.ts) | 상태만 정리, 미기록 | `finishLineEndpointDrag` 신설 → `kind:'record'` + `MoveLineEndpointCommand`(신규) | `finishPictureMoveDrag`(동일 onMouseUp) |
| 3 | `bringShapeToFront` (input-handler-mouse.ts) | `this.wasm.changeShapeZOrder` 직접 | 메뉴 정렬과 동형 `kind:'snapshot'`(`operationType:'changeZOrder'`) | `insert.ts:427` `recordObjectMutation` |

- 새 커맨드는 `MoveLineEndpointCommand`(전/후 글로벌 끝점 좌표) 하나뿐. 회전은 기존
  `ResizeObjectCommand` 의 임의 속성 가방(`{rotationAngle}`)을 재사용해 새 클래스 없음.
- 결함 2 는 드래그 시작(`input-handler-mouse.ts` 끝점 핸들 진입)에서 원래 끝점을 `lineEndpointState.orig`
  로 캡처해 종료 시 `before` 로 쓴다.
- 기록 결정은 순수 모듈 `object-drag-record.ts`(`computeRotationRecord`/`computeLineEndpointRecord`,
  변화 없으면 `null` → 무의미한 Undo 항목·redo 무효화 방지). `picture-resize.ts` 패턴.

## 왜 기존 가드가 못 잡았나

- **뮤테이션 표면 원장**(`mutation-routing-guard`)은 `wasm.X(` 텍스트 수만 세는 '표면 증가'
  트립와이어라 '라우팅 누락'은 못 잡는다(테스트 헤더가 명시). `input-handler-mouse.ts:3` 원장 항목의
  내역이 바로 이 결함 2·3 을 포함하고 있었다.
- **개체 조작 라우팅 가드**(`undo-menu-object-ops`)는 `command/commands/insert.ts` 한 파일만 읽어 엔진
  층 진입점은 사정거리 밖.
- `git log -S "finishPictureRotateDrag"` / `-S "isLineEndpointDragging"` 는 `f0f7f1a4 Initial commit`
  단 하나 — 이후 라우팅 정비(#2327/#2343) 스코프에 든 적이 없다. #2343(`9ffbad18`)은 같은 계급을
  서술하면서도 `--stat` 이 `insert.ts`+테스트만 건드려 클릭 진입점을 남겼다.

## 검증

- `npx tsc --noEmit`: 신규 오류 **0**. 사전 존재 2건(`@wasm/rhwp.js` 미해석 — WASM 산출물 미빌드,
  환경 요인)은 수정 전 baseline 과 완전 동일.
- `npm test`: **478 / 477 pass / 1 fail**. 유일 실패 `cell-flow-boundary.test.ts` 는 깨끗한 devel 에서도
  실패하는 기존 실패(본 작업 무관). skipped 0.
- **행위 테스트**: `object-drag-record.test.ts`(순수 결정 함수 8건) + `undo-drag-command-behaviour.test.ts`
  (`--experimental-transform-types` + `module.registerHooks` 로 자식 프로세스에서 `command.ts` 실제 로드,
  mock WasmBridge 로 `MoveLineEndpointCommand`·`ResizeObjectCommand(회전)` execute/undo 검증 — 로컬 실제
  green, 구버전 Node 는 skip 하여 CI 불파괴).
- **소스 가드**: `undo-drag-click-routing.test.ts`(3 진입점 라우팅 4건). 각 수정 개별 되돌림 red→green
  실증(순수·행위 테스트는 RED 에서도 GREEN — 배선 gap 은 소스 가드가 담당).
- **뮤테이션 표면 원장 불변**(호출 콜백 이동/유지, 신규 `moveLineEndpoint` 는 스캔 비대상 `command.ts`).

## 범위 밖 (잔여)

- `lineEndpointState.ref` 의 `cellPath`/`headerFooter` 미포함 — 셀 내 직선 끝점 드래그 도달성 미확인.
  본문 직선 undo 누락은 이와 무관하게 성립하므로 확장하지 않음.
- **선택만으로 z순서가 바뀌는 것이 옳은가**(한컴은 선택 시 재정렬 안 함) — 메인테이너 판단 요청.
  유지 시 최소한 기록은 필요(본 PR). no-op 재클릭이 히스토리에 쌓이는 부작용의 사전 판별은 TS 만으로
  불가(변경 플래그/z순서 setter 부재 = Rust 변경)라 별건.
- 머리말/꼬리말 개체의 `ResizeObjectCommand` 경로 headerFooter 분기 부재는 기존 리사이즈 드래그도
  가진 선행 한계라 확장하지 않음.

Closes #2759

🤖 Generated with [Claude Code](https://claude.com/claude-code)
