### PR TITLE
fix(core): 수식 lineMode·개요 수준·secPr autoNumFormat·캡션 문단 왕복 보존 — kevin9327 통합

### DIFF
--- a/mydocs/report/task_m100_2727_report.md
+++ b/mydocs/report/task_m100_2727_report.md
@@ -1,0 +1,298 @@
+# task_m100_2727 처리결과 보고서 — 수식 EQEDIT attribute(lineMode) 왕복 유실
+
+- **이슈**: [#2727](https://github.com/edwardkim/rhwp/issues/2727)
+- **브랜치**: `task/m100-2727-equation-lineMode` (base `devel` @ `49f38446`)
+- **범위**: `src/model/control.rs`, `src/parser/control.rs`, `src/serializer/control.rs`(수식 arm 한정),
+  `src/parser/hwpx/section.rs`, `src/serializer/hwpx/section.rs`, `src/serializer/hwpx/mod.rs`(테스트 픽스처),
+  `tests/issue_2727_equation_line_mode.rs`(신규)
+- **분류**: 결함 수정 (수식 속성 왕복 유실)
+
+## 1. 문제
+
+수식(`eqed`) 컨트롤의 자식 레코드 `HWPTAG_EQEDIT` 선두 UINT32(HWP5 스펙 표 105 attribute)가
+파서에서 버려지고 직렬화기에서 상수 `0` 으로 덮어써졌다.
+
+```rust
+// src/parser/control.rs:866 (정정 전)
+// attr: u32 (4바이트) — bit0: 스크립트 범위
+let _attr = r.read_u32().unwrap_or(0);      // 의미를 주석에 적어두고 버린다
+
+// src/serializer/control.rs:2393 (정정 전)
+// attr: u32
+w.write_u32(0).unwrap();                    // IR 이 없으므로 상수 0
+```
+
+이 UINT32 의 bit 0 은 HWPX `hp:equation@lineMode`(`LINE` / `CHAR`, OWPML 문서 문구
+"수식이 차지하는 범위")와 대응한다. HWPX 쪽도 같은 값이 양방향으로 끊겨 있었다.
+
+- `src/parser/hwpx/section.rs::parse_equation` 의 속성 match 에 `lineMode` arm 없음
+- `src/serializer/hwpx/section.rs::render_equation` 템플릿에 `lineMode` 속성 자체가 없음
+
+결과적으로 수식 범위 설정이 **HWP5→HWP5(편집 후) / HWP5→HWPX / HWPX→HWP5 / HWPX→HWPX 네
+경로 전부**에서 `CHAR`(0)로 초기화됐다.
+
+같은 EQEDIT 레코드 안에서 **스펙에 문서화조차 되어 있지 않은** `unknown: u16` 은 Task #1061 이
+IR 필드로 승격해 원본 그대로 왕복시키고 있었다. 문서화된 필드만 버리는 반대 방향 비대칭이었다.
+
+## 2. 분석
+
+### 2.1 패스스루가 가려주지 않는다
+
+| 층 | 판정 |
+|----|------|
+| `Equation::raw_ctrl_data` | **가리지 않음.** `CTRL_HEADER(eqed)` 의 ctrl_data 만 담는다. attribute 는 자식 레코드 `HWPTAG_EQEDIT` 안이고 EQEDIT 은 raw 필드가 없어 매번 IR 에서 재생성된다. 게다가 `adapt_equation`(`hwpx_to_hwp.rs`)과 `apply_equation_properties`(`object_ops/equation.rs:176`)가 이 필드를 명시적으로 `clear()` 한다. |
+| `Paragraph::ctrl_data_records[i]` | **가리지 않음.** `src/serializer/control.rs:98` 의 수식 arm 이 `ctrl_data_record` 인자를 아예 전달하지 않는다(Picture/Shape/Bookmark arm 은 받는다). 한컴 실측본의 `eqed` 자식은 EQEDIT 하나뿐이라 CTRL_DATA 자체가 없다. |
+| `Section::raw_stream` | **일부만 가린다.** 아무것도 건드리지 않은 HWP5→HWP5 복사에서는 원본 바이트가 그대로 재생돼 손실이 드러나지 않는다(실측 확인, 3.3 참조). 그러나 수식 관련 편집 API 는 모두 `section.raw_stream = None` 을 실행하고(`set_equation_properties_native`·`delete_equation_control_native`·`insert_equation_native`), HWPX 출력 경로는 raw_stream 을 참조하지 않는다. |
+| DocInfo `raw_stream_dirty` | 무관 (EQEDIT 은 BodyText). |
+
+### 2.2 의도된 상수인지 확인
+
+- `git log -S "bit0: 스크립트 범위" -- src/parser/control.rs` → `f0f7f1a4` (최초 커밋) 1건
+- `git log -S "serialize_equation_control" -- src/serializer/control.rs` → `f0f7f1a4` 1건
+
+둘 다 최초 커밋 이후 손대지 않은 코드이며, "0 으로 고정한다"는 계약을 설명하는 주석·정답지 대조
+기록이 없다. `adapt_equation:1204-1208` 의 bit 27(0x08000000) 보강처럼 정답지 근거가 남아 있는
+의도적 상수와는 성격이 다르다(그 코드는 이번 작업에서 손대지 않았다).
+
+### 2.3 근거 자료
+
+- OWPML 스키마 `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2189-2199` — `EquationType/@lineMode`,
+  `default="CHAR"`, enum `LINE|CHAR`, 문서 문구 "수식이 차지하는 범위."
+- `mydocs/tech/webhwp/05_other_controls.md:35-43` — 한컴 웹한글 역분석 기록의 수식 JSON 스키마에
+  `lm: lineMode // 줄 모드 (boolean)`, 임포트 코드 `e.qbn = h.lm ? 1 : 0`(불리언 1비트).
+- rhwp 자신의 파서 주석 `// attr: u32 (4바이트) — bit0: 스크립트 범위`.
+
+### 2.4 말뭉치 전수 조사
+
+`samples/**.hwpx` 중 `<hp:equation>` 포함 파일 전수:
+
+| 항목 | 값 |
+|------|-----|
+| 파일 수 | 19 |
+| `<hp:equation` 요소 총수 | 23,138 |
+| `lineMode` 명시 요소 수 | 23,138 (100%) |
+| 값 `CHAR` / `LINE` | 23,138 / 0 |
+
+한컴은 기본값이어도 예외 없이 이 속성을 기록한다. 말뭉치에 `LINE` 사례가 0건이라는 사실은 그대로
+밝힌다 — 본 결함은 **잠복 손실**이며, 정정해도 기존 23,138개 수식의 출력값은 `CHAR`/`0` 그대로다
+(3.4 회귀 실측).
+
+## 3. 변경
+
+### 3.1 코드
+
+| 파일 | 내용 |
+|------|------|
+| `src/model/control.rs` | `pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;` 신규. `Equation` 에 `pub attr: u32` 신규(UINT32 전체 보존 — bit0 외 비트도 유실시키지 않기 위함). 기본값 0 = OWPML `lineMode` 기본값 `CHAR`. |
+| `src/parser/control.rs:866` | `let _attr = ...` → `equation.attr = r.read_u32().unwrap_or(0);` |
+| `src/serializer/control.rs:2393` | `w.write_u32(0)` → `w.write_u32(eq.attr)` (수식 arm 한정, 3줄) |
+| `src/parser/hwpx/section.rs` | `parse_equation` 에 `b"lineMode"` arm 추가 — `LINE`(대소문자 무시)이면 bit0 set. `Equation` 생성 시 `attr: eq_attr`. |
+| `src/serializer/hwpx/section.rs` | `render_equation` 이 `baseUnit` 과 `font` 사이(한컴 저장본과 동일 자리)에 `lineMode="{LINE\|CHAR}"` 방출. |
+| `src/serializer/hwpx/mod.rs` | 기존 테스트 픽스처의 전량 초기화 리터럴에 `attr: 0,` 1줄 추가(컴파일 보정). |
+
+`hwpx_to_hwp.rs::adapt_equation` 은 변경 없음 — attribute 는 `common` 이 아니라 `Equation` 에 있고,
+그 함수가 지우는 것은 `raw_ctrl_data`(CTRL_HEADER)뿐이라 EQEDIT 재생성 경로에 그대로 실린다.
+
+### 3.2 테스트
+
+- `tests/issue_2727_equation_line_mode.rs` (신규 4건) — 한컴 실제 저장본
+  `samples/수식-문자처럼취급-아님.hwp` 를 입력으로,
+  1. `issue_2727_hwp5_line_mode_survives_roundtrip` — bit0 set 후 HWP5 직렬화→재파싱에서 보존
+  2. `issue_2727_hwpx_line_mode_survives_roundtrip` — HWPX 직렬화→재파싱에서 보존
+  3. `issue_2727_hancom_char_equation_stays_char` — 원본 CHAR 문서는 양 포맷 왕복 후에도 attr 0
+  4. `issue_2727_hancom_hwpx_char_parses_as_zero_bit` — 한컴 원본 HWPX `lineMode="CHAR"` → bit0 clear
+- `src/serializer/hwpx/section.rs::tests::equation_line_mode_reflects_ir` (신규 1건) —
+  `render_equation` 출력에 기본값도 `lineMode="CHAR"` 가 나오고, IR bit0 set 시
+  `baseUnit="1000" lineMode="LINE" font=""` 자리에 방출되는지 단언(선행 `equation_text_flow_reflects_ir` 패턴 정합).
+
+## 4. 검증
+
+### 4.1 red→green (실제 실행 캡처)
+
+정정 4곳(`parser/control.rs`, `serializer/control.rs`, `parser/hwpx/section.rs`,
+`serializer/hwpx/section.rs`)을 원상 복구한 뒤 실행했다(모델 필드는 컴파일을 위해 유지).
+
+**RED — 통합 테스트**
+
+```
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... FAILED
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... FAILED
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+failures:
+
+---- issue_2727_hwp5_line_mode_survives_roundtrip stdout ----
+thread 'issue_2727_hwp5_line_mode_survives_roundtrip' (40324) panicked at tests\issue_2727_equation_line_mode.rs:71:5:
+assertion `left == right` failed: EQEDIT attribute bit0(수식 범위 LINE)이 HWP5 왕복에서 보존돼야 한다. attr=0x00000000
+  left: 0
+ right: 1
+
+---- issue_2727_hwpx_line_mode_survives_roundtrip stdout ----
+thread 'issue_2727_hwpx_line_mode_survives_roundtrip' (36652) panicked at tests\issue_2727_equation_line_mode.rs:89:5:
+assertion `left == right` failed: HWPX lineMode="LINE" 이 왕복에서 보존돼야 한다. attr=0x00000000
+  left: 0
+ right: 1
+
+failures:
+    issue_2727_hwp5_line_mode_survives_roundtrip
+    issue_2727_hwpx_line_mode_survives_roundtrip
+
+test result: FAILED. 2 passed; 2 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.03s
+error: test failed, to rerun pass `--test issue_2727_equation_line_mode`
+```
+
+**RED — 단위 테스트**
+
+```
+running 1 test
+test serializer::hwpx::section::tests::equation_line_mode_reflects_ir ... FAILED
+
+failures:
+
+---- serializer::hwpx::section::tests::equation_line_mode_reflects_ir stdout ----
+thread 'serializer::hwpx::section::tests::equation_line_mode_reflects_ir' (14068) panicked at src\serializer\hwpx\section.rs:2365:9:
+기본값도 lineMode 속성을 방출해야 함(한컴 저장본 정합): <hp:equation id="0" zOrder="0" numberingType="EQUATION" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" instid="0" version="" baseLine="0" textColor="#000000" baseUnit="0" font=""><hp:script></hp:script>...
+
+failures:
+    serializer::hwpx::section::tests::equation_line_mode_reflects_ir
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.01s
+error: test failed, to rerun pass `--lib`
+```
+
+**GREEN — 복구 후 재실행**
+
+```
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.02s
+```
+
+```
+running 1 test
+test serializer::hwpx::section::tests::equation_line_mode_reflects_ir ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out; finished in 0.00s
+```
+
+### 4.2 CLI 실측 — 정정 전
+
+한컴 원본 `samples/수식-문자처럼취급-아님.hwpx` 의 `lineMode="CHAR"` 한 곳만 `LINE` 으로 바꾼
+**조작 입력**(정답지가 아님)을 만들어 측정했다.
+
+```
+=== A) hwpx(LINE) -> export-hwpx ===
+<hp:equation id="1102112140" ... textColor="#000000" baseUnit="1600" font="HancomEQN">
+   → lineMode 속성 소실
+
+=== B) hwpx(LINE) -> convert -> hwp ===   (EQEDIT payload)
+  0000: 00 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+        ^^^^^^^^^^^ 01 00 00 00 이어야 하는데 0
+
+=== 정정 전 CLI: HWP5(attr=1) -> HWPX ===
+lineMode 출현 0회
+```
+
+또한 한컴 원본 `.hwp` 를 그대로 `export-hwpx` 하면 한컴이 쓰는 `lineMode="CHAR"` 가 출력에서
+빠져 있었다.
+
+### 4.3 CLI 실측 — 정정 후
+
+```
+=== A) hwpx(LINE) -> export-hwpx ===
+baseUnit="1600" lineMode="LINE" font="HancomEQN"
+
+=== B) hwpx(LINE) -> convert -> hwp ===
+  0000: 01 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+
+=== C) hwp(attr=1) -> convert -> hwp (HWP5 왕복) ===
+  0000: 01 00 00 00 2B 00 4C 00 41 00 44 00 44 00 45 00
+
+=== D) hwp(attr=1) -> export-hwpx ===
+lineMode="LINE"
+```
+
+정직하게 밝히는 관찰: **손대지 않은 HWP5→HWP5 복사**(`convert a.hwp b.hwp`)는 `Section::raw_stream`
+패스스루가 원본 바이트를 그대로 재생하므로 정정 전에도 attribute 가 살아남는다. 손실이 실현되는 것은
+그 구역이 재직렬화될 때(수식 속성 변경·삽입·삭제 등 편집 API 가 `raw_stream = None` 을 실행한 뒤)이며,
+그 조건을 재현한 것이 4.1 의 RED 통합 테스트다(`set_first_equation_line_mode` 가 실제 편집 API 와
+동일하게 `section.raw_stream = None` 을 수행한다).
+
+### 4.4 회귀 실측 (말뭉치 무변경)
+
+```
+=== 한컴 원본 hwp -> hwpx ===            lineMode="CHAR"
+=== math-001.hwpx -> hwpx (수식 44개) ===  44 lineMode="CHAR"
+=== math-001.hwp EQEDIT attr ===         0000: 00 00 00 00 2A 00 20 00 ...
+```
+
+정정 후 CHAR 문서는 값이 그대로이며, 종전에 빠져 있던 `lineMode="CHAR"` 가 한컴과 같은 자리에
+추가로 방출된다(한컴 정합 방향).
+
+### 4.5 CI 3종
+
+| 검사 | 명령 | 결과 |
+|------|------|------|
+| clippy | `cargo clippy --all-targets -- -D warnings` | **통과** — `Finished dev profile ... in 1m 10s`, 경고 0 |
+| 테스트 | `cargo test --profile release-test --tests` | **통과** — 아래 4.6 |
+| fmt | 변경 `.rs` 전부 `rustfmt --edition 2021` 후 `git diff --name-only` | **통과** — 출력 없음 (커밋 상태 기준) |
+
+`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 파일에 대해 `Incorrect newline style`
+만 출력하고 diff 를 내지 않아 거짓 통과를 만들므로 사용하지 않았다.
+
+### 4.6 `cargo test --profile release-test --tests` 결과
+
+종료 코드 0. 테스트 바이너리 292개 집계:
+
+| 항목 | 수 |
+|------|-----|
+| passed | **3,485** |
+| failed | **0** |
+| ignored | 23 |
+| `FAILED` 문자열 출현 | 0 |
+
+- lib 단위 테스트: `test result: ok. 2465 passed; 0 failed; 7 ignored; 0 measured; 0 filtered out; finished in 9.29s`
+- 신규 통합 테스트:
+
+```
+     Running tests\issue_2727_equation_line_mode.rs
+
+running 4 tests
+test issue_2727_hwp5_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_hwpx_char_parses_as_zero_bit ... ok
+test issue_2727_hwpx_line_mode_survives_roundtrip ... ok
+test issue_2727_hancom_char_equation_stays_char ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+## 5. 미실행 항목
+
+- **한컴 한글 시각 판정 없음.** 이 환경에 한컴 한글이 없어 정정 후 `.hwp`/`.hwpx` 를 한글에서 열어
+  수식 범위가 "줄 단위"로 보이는지 눈으로 확인하지 못했다. 검증은 바이트/XML 레벨과 왕복 IR 동등성에
+  한정된다.
+- **`LINE` 정답지 부재.** 말뭉치에 한컴이 만든 `lineMode="LINE"` 문서가 없어, LINE 값에 대한 검증은
+  조작 입력(4.2)과 IR 왕복 테스트로만 수행했다. `CHAR` 쪽은 한컴 원본 23,138건 기준 무변경을 확인했다.
+
+## 6. 잔여
+
+1. **`affectLSpacing` 전면 유실** — `CommonObjAttr` 에 대응 필드가 없고
+   `serializer/hwpx/section.rs:1913,2030`·`picture.rs:410`·`shape.rs:1004`·`table.rs:146` 이 모두
+   `"0"` 하드코딩이다. `samples/issue1949_giant_cell_nested_tables_perf.hwpx` 의 수식 18개 중 **5개가
+   `affectLSpacing="1"`** 이므로 실사례가 있는 실손실이다. 다만 공용 모델·공용 파서·공용 직렬화기를
+   함께 고쳐야 해서 이번 수식 전용 범위 밖으로 뒀다.
+2. **`allowOverlap` 하드코딩** — `render_equation` 이 `allowOverlap="0"` 고정. `common.allow_overlap`
+   은 이미 IR 필드다(말뭉치 내 수식은 전부 0 이라 잠복).
+3. **`<hp:script>` 자식 순서** — OWPML `EquationType` 은 `sz, pos, outMargin, caption, shapeComment,
+   metaTag, script` 순서를 요구하고 한컴 출력도 `script` 를 마지막에 둔다. rhwp 는 여는 태그 직후에
+   방출한다. 한컴 재적재 영향을 실측하지 못해 이번엔 건드리지 않았다.
+4. **HML 경로** — `src/parser/hml/reader.rs:695-703` 이 `BaseLine|BaseUnit|TextColor|Version|Font`
+   이외의 `EQUATION` 속성을 `UnsupportedEquationSemantics` 경고로 흘려보낸다. HML `LineMode` 매핑은
+   HML 파서·직렬화기 동시 변경이 필요하다.
+5. **수식 캡션** — 한컴 실측본의 `eqed` 자식에 `LIST_HEADER` 가 없어 이번 말뭉치에서는 확인 불가.

--- a/mydocs/report/task_m100_2734_report.md
+++ b/mydocs/report/task_m100_2734_report.md
@@ -1,0 +1,342 @@
+# task_m100_2734 처리결과 보고서 — PARA_SHAPE 말미 4바이트(개요 수준) 복원
+
+- **이슈**: [#2734](https://github.com/edwardkim/rhwp/issues/2734)
+- **브랜치**: `task/m100-2734-docinfo-parashape-outline-level` (base `origin/devel` @ `1658d0bb`)
+- **범위**: `src/parser/doc_info.rs`, `src/serializer/doc_info.rs`, `src/serializer/doc_info/tests.rs`
+- **분류**: 결함 수정 (HWP5 DocInfo 라운드트립 — 필드 미파싱 + 하드코딩 리터럴)
+
+## 1. 문제
+
+`HWPTAG_PARA_SHAPE` 레코드 payload 말미 4바이트(offset 54~57)는 **문단 개요 수준(0~9 = 1수준~10수준)** 이다.
+`attr1` bit 25~27 은 3비트뿐이라 한컴이 6에서 포화시키므로, **8·9·10수준은 이 4바이트에만 존재**한다.
+
+rhwp 는 이 필드를 양쪽에서 다뤘어야 하는데 둘 다 놓쳤다.
+
+1. **파서** (`src/parser/doc_info.rs` `parse_para_shape`) — 4바이트를 아예 읽지 않았다.
+   `para_level` 이 `attr1` 비트에서만 나오므로 8·9·10수준 문단이 전부 **7수준으로 붕괴**했다.
+2. **직렬화기** (`src/serializer/doc_info.rs` `serialize_para_shape`) — `w.write_u32(0)` 리터럴이었다.
+   재직렬화되는 문단 모양마다 개요 수준이 **1수준으로 리셋**되고, `attr1` 이 말하는 수준과
+   tail 이 말하는 수준이 **서로 모순되는 레코드**가 만들어졌다.
+
+이 4바이트를 zero 로 materialize 하는 코드는 #1110 stage26 에서 **"58바이트 길이 계약"만 맞추려고**
+들어간 것이고(`mydocs/working/archives/task_m100_1110_stage1.md:2225-2258`), 값의 정체는 당시 규명되지 않았다.
+이번 작업은 그 값을 규명해 채운 것이며 **길이 계약은 그대로**다(58바이트 불변, 값만 채움).
+
+## 2. 분석
+
+### 2.1 `raw_stream_dirty` 통과 경로 분석 (이 결함이 가려지지 않는 이유)
+
+DocInfo 는 2단 통과 계층을 갖는다.
+
+- **1단 (스트림)** `serializer/doc_info.rs:22-33` — `!raw_stream_dirty && raw_stream.is_some()` 이면
+  원본 스트림을 그대로 반환한다.
+- **2단 (레코드)** `serializer/doc_info.rs:107-113` — dirty 여도 각 ParaShape 은 `raw_data` 가 `Some` 이면
+  원본 바이트를 쓴다.
+
+따라서 `serialize_para_shape()` 가 실제로 도는 조건은 **dirty == true 이면서 그 ParaShape 의
+`raw_data == None`** 이다. 이 결함이 "편집 안 한 문서에선 안 돈다"로 무마되지 않는 이유는,
+**dirty 를 세우는 바로 그 동작이 동시에 `raw_data = None` 인 ParaShape 을 만들기 때문**이다.
+
+`model/document.rs:466-491` `find_or_create_para_shape()` 는 한 함수 안에서
+`ParaShapeMods::apply_to()`(`model/style.rs:918` 에서 `raw_data = None`)로 새 ParaShape 을 만들고,
+push 한 뒤 `raw_stream_dirty = true` 를 세운다. 그리고 편집된 문단이 바로 그 새 id 를 참조한다.
+
+| 조건 | 성립 | 근거 |
+|---|---|---|
+| `raw_stream_dirty = true` | O | `document.rs:489` |
+| 새 ParaShape 의 `raw_data == None` | O | `style.rs:918` |
+| 편집된 문단이 그 ParaShape 참조 | O | `find_or_create_para_shape()` 반환 id |
+
+호출 지점(= 이 경로를 타는 사용자 동작): `formatting.rs:1374,1530,1720,1742`,
+`footnote_ops.rs:391`, `header_footer_ops.rs:843,1037`.
+즉 **정렬·줄간격·여백·들여쓰기·문단수준·탭·문단 테두리** 중 하나만 바꿔도 이 경로다.
+특히 `ParaShapeMods::para_level` 로 **사용자가 개요 수준을 직접 지정**하는 경로에서도
+tail 은 0 으로 나갔다 — 방금 지정한 수준이 한컴이 읽는 필드에 반영되지 않았다.
+
+정직하게 덧붙이면, `find_or_create_para_shape()` 는 동일 ParaShape 이 있으면 **재사용**하고
+그 경우엔 원본 `raw_data` 가 쓰여 손실이 없다. 손실은 **새로 push 되는 경우**에 발생한다.
+
+한편 **읽기 쪽 손실은 dirty 와 무관하게 항상** 발생했다. 소비처는 개요번호 렌더링
+(`renderer/layout.rs:1826`, `renderer/layout/paragraph_layout.rs:6126`), 구조 추출
+(`document_core/queries/structure.rs:82`), HWPX `level` 속성(`serializer/hwpx/header.rs:1075`),
+HML `Level`(`serializer/hml/head.rs:176`) 이다.
+
+### 2.2 필드 정체 규명
+
+`samples/*.hwp` 252개 파일에서 58바이트 `PARA_SHAPE` 11,913건의 tail 과 `attr1` bit25~27 을 대조했다.
+
+| tail | `attr1` 수준 | 건수 | 판정 |
+|---:|---:|---:|---|
+| 0 | 0 | 11,032 | 일치 |
+| 1 | 1 | 97 | 일치 |
+| 2 | 2 | 94 | 일치 |
+| 3 | 3 | 305 | 일치 |
+| 4 | 4 | 84 | 일치 |
+| 5 | 5 | 77 | 일치 |
+| 6 | 6 | 77 | 일치 |
+| 7 | **6** | 46 | attr1 포화 |
+| 8 | **6** | 46 | attr1 포화 |
+| 9 | **6** | 46 | attr1 포화 |
+| 0 | 1~6 | 9 | 단일 파일 예외 |
+
+tail 0~6 구간이 1:1 완전 일치하고, 7·8·9 에서 `attr1` 이 6 으로 포화한다.
+어긋나는 유일한 사례는 `issue2439_zero_offset_coanchored_float_exclusion.hwp`(ver 5.1.0.0) 한 파일의
+9건뿐이며, 나머지 **125개 파일 / 11,904건에서 어긋남 0건**이다.
+
+**교차 검증**: `tail >= 7` 인 ParaShape 을 가진 파일은 46개이고 각 파일에서 정확히 3개(7,8,9)씩 나온다
+(46×3 = 138). 그중 42개 파일이 `HWPTAG_NUMBERING` 에도 확장 수준을 갖는다. 실제 바이트를 뜯으면
+8·9·10수준 문단머리정보 3개 + 시작번호 3개이며, 8수준 번호 형식 문자열이 `5e 00 38 00` = `"^8"` 이다.
+즉 코퍼스의 한컴 문서들이 실제로 8~10수준 개요를 정의하고 있고, 대응 문단모양이 tail 7·8·9 를 갖는다.
+
+## 3. 실측
+
+집계 코드는 `src/serializer/doc_info/tests.rs` 에 임시 테스트로 붙여 실행하고 커밋 전 제거했다
+(커밋에 포함되지 않음). 측정 항목은 (a) tail ↔ attr1 상관, (b) 각 레코드의 `raw_data` 와
+`serialize_X(parse 결과)` 의 바이트 비교다.
+
+### 3.1 수정 전
+
+```
+파일: 성공 252 / 실패 18 (총 270)
+PARA_SHAPE  총 15043  동일 11041  다름 4002   firstdiff={42:112 46:84 54:3806}
+  원본 크기 분포: 42B:112  46B:84  54B:2934  58B:11913
+```
+
+`firstdiff` offset 54 의 3,806건 = 54바이트 레코드 2,934건(tail 신규 부착, 손실 아님)
+**+ 58바이트 레코드 872건(원본 tail 1~9 를 0 으로 덮어씀 = 손실)**.
+
+### 3.2 수정 후
+
+```
+파일: 성공 252 / 실패 18 (총 270)
+PARA_SHAPE  총 15043  동일 11904  다름 3139   firstdiff={42:112 46:84 54:2943}
+```
+
+- **바이트 동일 11,041 → 11,904 (+863)**. 손실 872건 중 863건이 사라졌다.
+- 54바이트 레코드 2,934건의 tail 신규 부착은 #1110 계약 그대로 유지된다.
+
+**남은 9건을 숨기지 않고 밝힌다.**
+
+- 전부 **`issue2439_zero_offset_coanchored_float_exclusion.hwp` 한 파일**(FileHeader ver 5.1.0.0)의
+  ParaShape 9개다. 나머지 125개 파일 11,904건에는 이런 레코드가 없다.
+- 원본이 **`attr1` 수준 = 1,2,3,4,5,6,6,6,6 인데 tail = 0** 인 **자기모순** 레코드다.
+- 수정 후 rhwp 는 tail 에 `attr1` 값을 써서 두 필드를 **정합**시킨다. 값을 지어내는 게 아니라
+  이미 레코드 안에 있는 수준을 다른 필드에도 반영하는 것이다.
+- **IR `para_level` 은 종전과 완전히 동일하다.** 파서가 `max(attr1, tail)` 을 쓰므로 `max(3,0) = 3` 으로
+  기존 값이 유지된다. 이 회귀 없음을 테스트로 고정했다
+  (`para_shape_recovers_outline_level_8_to_10_from_tail` 의 `tail=0/attr1=1~6` 루프).
+- 이 파일 하나만 왜 다른지는 **규명하지 못했다**(다른 파일은 ver 5.1.0.1 / 5.1.1.0). tail 을 채우지
+  않는 구버전 writer 산출물로 **추정**하지만 확인하지 않았으므로 추정이라고 명시한다.
+
+### 3.3 다른 DocInfo 레코드 무영향 확인 (실측)
+
+같은 census 를 수정 전/후로 돌려 전 레코드 종류를 비교했다. **PARA_SHAPE 외 전부 동일**하다.
+
+| 레코드 | 총 | 다름 (수정 전) | 다름 (수정 후) |
+|---|---:|---:|---:|
+| BIN_DATA | 1,627 | 0 | 0 |
+| FACE_NAME | 10,093 | 171 | 171 |
+| BORDER_FILL | 6,237 | 82 | 82 |
+| CHAR_SHAPE | 13,991 | 1,706 | 1,706 |
+| TAB_DEF | 950 | 8 | 8 |
+| NUMBERING | 347 | 203 | 203 |
+| BULLET | 62 | 62 | 62 |
+| STYLE | 6,436 | 101 | 101 |
+| **PARA_SHAPE** | **15,043** | **4,002** | **3,139** |
+
+### 3.4 실측 vs 잠재
+
+- **실측**: 위 모든 수치, tail 값 분포와 상관, 872 → 9 감소, 8수준 번호 형식 바이트 덤프.
+- **잠재(코드 판독)**: "한컴 편집기가 tail 을 authoritative 로 읽어 1수준으로 표시한다"는 부분.
+  한컴 실행 검증은 하지 않았다. 확실한 것은 종전 코드가 **attr1 과 tail 이 모순되는 레코드**를
+  만들었고 한컴 산출물 11,904건은 예외 없이 정합했다는 점, 그리고 8~10수준은 attr1 이 표현할
+  수단 자체가 없어 tail 유실 = 수준 유실이 확정적이라는 점이다.
+- **잠재**: HWPX(.hwpx) → .hwp 변환 산출물을 한컴으로 열어 확인하지 않았다.
+
+## 4. 변경
+
+### 4.1 파서 (`src/parser/doc_info.rs`)
+
+`line_spacing_v2` 다음에 말미 4바이트를 읽고, `para_level` 을 두 출처의 **큰 쪽**으로 정한다.
+
+```rust
+let outline_level_tail = if r.remaining() >= 4 { r.read_u32().unwrap_or(0) } else { 0 };
+...
+let para_level = (((attr1 >> 25) & 0x07) as u8).max(outline_level_tail.min(9) as u8);
+```
+
+`max` 를 쓰는 근거는 실측이다. 두 값이 어긋나는 실측 사례는 (a) tail 7~9 / attr1 6(포화) 138건,
+(b) tail 0 / attr1 1~6 단일 파일 9건뿐이므로, `max` 가 (a)에서 8~10수준을 복원하면서
+(b)에서 종전 동작을 그대로 보존한다. tail 이 없는 42/46/54바이트 레코드는 `remaining() < 4` 라
+`outline_level_tail = 0` → 종전과 동일하다.
+
+### 4.2 직렬화기 (`src/serializer/doc_info.rs`)
+
+```rust
+// bits 25-27
+attr1 |= (ps.para_level.min(6) as u32) << 25;   // 종전: (ps.para_level as u32 & 0x07) << 25
+...
+w.write_u32(ps.para_level.min(9) as u32).unwrap();  // 종전: w.write_u32(0)
+```
+
+`min(6)` 은 한컴 실측 규약이다(개요 8~10수준 문단모양 138건이 모두 attr1 비트 6 + tail 7/8/9).
+종전 `& 0x07` 은 `para_level` 이 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.
+
+### 4.3 건드리지 않은 것
+
+- `ParaShape` 모델 — 필드 추가 없음. `para_level` 이 이미 같은 개념이다.
+- `ParaShapeMods::apply_to` — attr1 비트를 `v & 0x07` 로 쓰지만 직렬화기가 그 비트를 무조건
+  다시 계산하므로 출력에 영향이 없다. 무관 변경 금지 원칙에 따라 손대지 않았다.
+- 58바이트 길이 계약(#1110 stage26), HWPX/HML/렌더러. 렌더러의 `para_level` 소비처는 이미
+  `layout.rs:984`, `paragraph_layout.rs:6139` 에서 `.min(6)` 으로 방어하므로 값이 7~9 로 확장돼도
+  인덱스 초과가 없다.
+
+## 5. 검증
+
+### 5.1 red → green (실제 실행 캡처)
+
+수정 2건(파서 tail 반영, 직렬화기 tail 기록·attr1 포화)을 되돌리고 테스트만 남긴 상태.
+
+```
+running 5 tests
+test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... FAILED
+test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... FAILED
+test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... FAILED
+test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... FAILED
+
+---- serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail stdout ----
+thread '...' panicked at src\serializer\doc_info\tests.rs:283:9:
+assertion `left == right` failed: 말미 4바이트에 개요 수준 1 이 실려야 함
+  left: 0
+ right: 1
+
+---- parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1292:13:
+assertion `left == right` failed: 개요 1 수준 레코드 재직렬화 시 말미 4바이트가 보존돼야 함
+  left: [0, 0, 0, 0]
+ right: [1, 0, 0, 0]
+
+---- parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1310:13:
+assertion `left == right` failed: 개요 수준 8 왕복 보존
+  left: 0
+ right: 8
+
+---- parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail stdout ----
+thread '...' panicked at src\parser\doc_info.rs:1255:13:
+assertion `left == right` failed: tail=7 이면 개요 수준 7 로 복원돼야 함(attr1 은 6 에서 포화)
+  left: 6
+ right: 7
+
+test result: FAILED. 1 passed; 4 failed; 0 ignored; 0 measured; 2470 filtered out; finished in 0.00s
+```
+
+**RED 에서도 통과하는 테스트가 있다 — 어느 것이고 왜인지 밝힌다.**
+
+- `test_serialize_para_shape_roundtrip`(기존 테스트)은 RED 에서도 통과한다. `para_level: 0` 인
+  ParaShape 만 쓰므로 `write_u32(0)` 과 `write_u32(para_level)` 의 출력이 같다.
+  이 테스트의 `assert_eq!(&data[54..58], &[0,0,0,0])` 단언은 수정 후에도 그대로 유효하므로
+  변경하지 않았다.
+- `para_shape_outline_level_roundtrips_0_to_9` 는 **수준 8에서 처음 실패**한다. 수준 0~7 은
+  RED 상태에서도 `attr1` bit25~27(3비트, `& 0x07`)만으로 rhwp 내부 왕복이 성립하기 때문이다.
+  이 테스트가 잡는 것은 3비트를 넘는 8·9수준뿐이다. **한컴이 읽는 tail 값이 사라지는 본체 결함은
+  `serialize_para_shape_writes_outline_level_into_tail`(수준 1에서 즉시 실패)과
+  `para_shape_edit_path_keeps_outline_level_in_tail`(수준 1에서 즉시 실패)이 잡는다.**
+
+수정 복원 후:
+
+```
+running 5 tests
+test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... ok
+test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... ok
+test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... ok
+test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 2470 filtered out; finished in 0.00s
+```
+
+### 5.2 CI 3종
+
+```
+$ cargo clippy --all-targets -- -D warnings
+    Checking rhwp v0.7.19 (C:\Users\swsz9\Downloads\moneyflow\rhwp-wt-c)
+    Finished `dev` profile [unoptimized + debuginfo] target(s) in 1m 43s
+→ 경고 0건
+```
+
+```
+$ git diff --name-only origin/devel...HEAD -- '*.rs'
+src/parser/doc_info.rs
+src/serializer/doc_info.rs
+src/serializer/doc_info/tests.rs
+
+$ for f in $(git diff --name-only origin/devel...HEAD -- '*.rs'); do rustfmt --edition 2021 "$f"; done
+$ git diff --name-only
+[빈 출력]
+```
+
+빈 출력 = 커밋된 3개 파일이 모두 포맷을 준수한다. (커밋 전 1차 적용 시 신규 테스트 1곳의
+줄바꿈 3줄이 조정됐고 그 결과를 커밋에 포함했으므로, 커밋 후 재적용에서는 변화가 없다.)
+`cargo fmt --all -- --check` 는 이 CRLF 체크아웃에서 `Incorrect newline style` 만 찍고
+diff 를 내지 않아 false pass 하므로 **사용하지 않았다.**
+
+```
+$ cargo test --profile release-test --tests
+→ exit 0
+→ 테스트 타깃 292개 전부 ok
+→ 합계 3,494 passed / 0 failed / 23 ignored / 0 measured
+   · lib 단위 테스트(src/lib.rs) 2,468 passed / 0 failed / 7 ignored — 신규 4건 + 기존 1건 포함:
+       test parser::doc_info::tests::para_shape_edit_path_keeps_outline_level_in_tail ... ok
+       test parser::doc_info::tests::para_shape_outline_level_roundtrips_0_to_9 ... ok
+       test parser::doc_info::tests::para_shape_recovers_outline_level_8_to_10_from_tail ... ok
+       test serializer::doc_info::tests::serialize_para_shape_writes_outline_level_into_tail ... ok
+       test serializer::doc_info::tests::test_serialize_para_shape_roundtrip ... ok
+   · 나머지 291개 타깃(tests/ 통합 + bin) 1,026 passed / 0 failed / 16 ignored
+→ 출력 전체에서 `FAILED` / `panicked at` 0건
+```
+
+DocInfo 변경은 파급이 넓어 실파일 왕복·바이트 baseline 게이트를 특히 확인했다. 전부 통과:
+
+```
+tests/hwp5_roundtrip_baseline.rs    ok. 3 passed (baseline_all_samples_roundtrip / large / xfail)
+tests/hwpx_roundtrip_baseline.rs    ok. 4 passed
+tests/visual_roundtrip_baseline.rs  ok. 3 passed
+tests/opengov_corpus_snapshot.rs    ok. 2 passed
+tests/svg_snapshot.rs               ok. 8 passed
+tests/hwp5_strikeout_shape_parity.rs ok. 2 passed
+serializer::cfb_writer::tests::test_serialize_real_hwp_files ... ok
+```
+
+내가 작성하지 않은 테스트 중 실패한 것은 **없다**. 따라서 기존 단언을 수정한 곳도 없다.
+
+### 5.3 코퍼스 재측정
+
+3.2·3.3 참조. PARA_SHAPE 손실 872 → 9(자기모순 레코드 정합화), 다른 레코드 종류 무변화.
+
+## 6. 미실행 항목
+
+- **한컴 편집기 실물 판정 없음.** 수정 후 .hwp 를 한글에서 열어 개요 수준을 눈으로 확인하지 않았다.
+  근거는 전적으로 코퍼스 실측(11,913건 전수 상관)과 코드 경로 분석이다.
+- **HWPX→HWP 변환 산출물 실물 검증 없음.** 이 경로에서도 tail 이 채워지도록 개선되지만
+  변환 결과를 한컴으로 열어보지는 않았다.
+- **8~10수준 렌더링 개선 여부 미검증.** 파서가 이제 7·8·9 를 반환하지만 렌더러/HWPX/HML 이
+  이 값으로 무엇을 다르게 그리는지는 이번 범위에서 측정하지 않았다(소비처가 모두 `.min(6)` 으로
+  클램프하므로 렌더 결과는 종전과 동일할 가능성이 높다). 이 이슈의 성과는 **저장 시 유실 차단**과
+  **IR 정확도 회복**이다.
+
+## 7. 잔여 (범위 밖)
+
+같은 코퍼스 조사에서 함께 관측된 DocInfo 결함들. 이슈 #2734 의 7절에도 기록했다.
+수치는 실측, "영향"은 코드 판독 기반 추정이다.
+
+| 대상 | 관측 | 실측 규모 |
+|---|---|---|
+| `HWPTAG_BULLET` | 실제 레코드는 23/25바이트인데 `serialize_bullet` 은 항상 24바이트. 이미지 글머리 정보가 5바이트(밝기1+명암1+효과1+binID2)인데 파서는 `image_data: [u8;4]` 로 4바이트만 읽어 `check_bullet_char` 가 1바이트 밀린다 | 62/62 불일치. 25바이트 37건 중 13건에서 `U+0020` 대신 `U+2000`, 2건에서 `U+F0A4` 대신 `U+A400` 으로 파싱 |
+| `HWPTAG_NUMBERING` | 8·9·10수준 문단머리정보 + 번호 형식 + 시작번호 3개 미파싱 → 재직렬화 시 60바이트 축소 | 347건 중 200건(57.6%)이 확장 수준 보유 |
+| `HWPTAG_FACE_NAME` | 대체 글꼴 앞 "대체 글꼴 유형" 1바이트를 `font.alt_type & 0x03`(자기 자신의 유형)으로 덮어씀 | 109건 |
+| `HWPTAG_CHAR_SHAPE` | 밑줄 종류 `(attr>>2)&3 == 2` 를 `UnderlineType::None` 으로 접고 0 으로 씀 | 13,991건 중 1,514건 |
+| `HWPTAG_CHAR_SHAPE` | 취소선 비트(18~20)를 `is_real_strike_shape_id` 판정으로 재기록해 원본 비트가 1→0 / 1→2 로 변함 | 1,620건 |
+| `HWPTAG_BORDER_FILL` | fill type 이 비트마스크인데 모델이 단일 enum 이라 `0x03`(단색+이미지)이 이미지 단독으로 붕괴 | 6,237건 중 28건 |
+| `HWPTAG_DOCUMENT_PROPERTIES` | `serialize_document_properties` 가 `raw_data` 있으면 무조건 원본 반환 → 모델 필드 변경 무반영 | 코드 판독만 |

--- a/mydocs/report/task_m100_2736_report.md
+++ b/mydocs/report/task_m100_2736_report.md
@@ -1,0 +1,269 @@
+# task_m100_2736 처리결과 보고서 — 순회 × 컨테이너 전수 조사와 캡션 컨테이너 누락 수정
+
+- **이슈**: [#2736](https://github.com/edwardkim/rhwp/issues/2736)
+- **브랜치**: `task/m100-2736-container-recursion` (base `devel` @ `1658d0bb`)
+- **범위**: `src/document_core/converters/hwpx_to_hwp.rs` 1개 파일 (+ 본 보고서)
+- **분류**: 결함 수정 (순회 누락) + 전수 조사
+
+## 1. 문제
+
+`Document` 는 문단을 14종 컨테이너(본문 / 표 셀 / 중첩 표 셀 / 글상자 / 각주 / 미주 /
+머리말 / 꼬리말 / 바탕쪽 / 표 캡션 / 그림·도형 캡션 / 숨은설명 / 묶음 개체 자식 / 메모)에
+중첩 보관한다. 그런데 문서를 순회하는 함수들은 **각자 독립적으로 어느 컨테이너로 내려갈지
+결정**하며, 완전성을 강제하는 공유 방문자가 저장소에 없다 (`grep -rn "visitor\|Visitor" src/`
+→ 0건).
+
+그래서 "본문·표 셀은 처리하지만 각주 본문은 조용히 건너뛰는" 워크가 만들어지고, 그 컨테이너를
+쓰는 문서에서만 결과가 틀리므로 결함이 오래 산다. 같은 계열의 수정이 이미 5건 머지됐다
+(`632f4258`, `05af4fe7` #2467 / `ea82eb33` #2715 / `761544e7` #2651 / `395ebedc` #2717).
+전부 "다른 워크는 이미 그 컨테이너를 도는데 이 워크만 빠져 있다"는 동일 구조다.
+
+본 작업의 목적은 하나씩 찾는 방식을 끝내고 **행렬을 만드는 것**이었다.
+
+## 2. 행렬 전수 조사
+
+### 2.1 방법
+
+추측이 아니라 순회 관용구 검색으로 후보를 뽑았다.
+
+```
+grep -rn "for para in" src/                      → 126건
+grep -rn "\.paragraphs\.iter()" src/             → 204건
+grep -rn "for cell in\|cells\.iter()" src/       → 194건
+grep -rn "fn .*_recursive\|fn walk_\|fn visit_\|fn collect_" src/ → 98건
+```
+
+이후 스크립트로 `src/document_core` · `serializer` · `renderer` · `model` · `parser` · `paint`
+의 모든 `fn` 본문을 brace 매칭으로 잘라 "표 셀로 내려간다(= 문서 워크)" 마커를 가진 함수
+**269개**를 추출하고, 테스트 헬퍼·`#[cfg(test)]` 내부·호출자가 컨테이너를 이미 지정하는 지역
+루프를 제외해 **컨테이너를 놓치면 사용자 결과가 틀리는 워크 24개**로 좁혔다.
+
+### 2.2 분류별 집계 (우선 범위 `converters/` · `queries/` · `commands/`)
+
+| 분류 | 개수 |
+| --- | --- |
+| 대상 컨테이너를 모두 재귀 (또는 누락이 결과에 영향 없음) | **8** |
+| 의도적 미재귀 (문서화된 범위 한정 / path 해석기 / 파라미터 제어) | **6** |
+| **누락 (재귀해야 하는데 안 함)** | **10** |
+
+24행을 빠짐없이 배분한 결과다 (8 + 6 + 10 = 24). 행렬 전문(24행 × 14열)과 셀별 판정 근거는
+이슈 #2736 §2.2 에 있다. 본 보고서는 중복하지 않고 결론만 옮긴다.
+
+- **재귀함 8** — bin order 수집, `copy_control_native`, `clear_missing_lineseg_placeholders_*`,
+  `materialize_missing_lineseg_paragraphs_*`, `get_cell_paragraph*_by_path`,
+  `renumber_footnotes_in_section`, `collect_header_footer_controls`,
+  `assign_auto_numbers_in_controls`.
+- **의도적 미재귀 6** — `converters/diagnostics.rs:106`(진단 전용),
+  `search_first_body`/`replace_one_native`(doc 주석에 본문 한정 명시),
+  `search_all_text_native(include_cells=false)`(파라미터 제어),
+  `normalize_xml_import_paragraphs`(코드에 TODO 명시), `validate_linesegs`(doc 주석 명시),
+  `resolve_paragraphs`/`resolve_paragraph_by_path`(path 해석기 — 호출자가 컨테이너 지정).
+- **누락 10** — §7.1 잔여표 참조. 그중 `collect_all_fields` 는 위치 모델(`FieldLocation`)
+  한계에서 오는 **설계 제약형 누락**이라 성격이 다르다.
+
+본 PR 의 수정 범위는 **누락 10건 중 adapt 워크 1건 전부 + bin remap·border_fill 워크 2건의
+캡션 축**이다.
+
+**중요 판정 정정** — `collect_bin_order_from_control` 도 그림 캡션을 빠뜨리지만, 뒤이은
+`for id in 1..=bin_count` 폴백(`hwpx_to_hwp.rs:296-298`)이 남은 id 를 전부 order 에 채워
+remap 이 항상 전단사 순열이 되므로 **참조 무결성은 유지되고 순서만 달라진다.** 결함이
+아니라고 판정하고, 형제 워크와의 대칭 유지 목적으로만 수정했다.
+
+## 3. 확정 누락 (수정 대상) — 실측
+
+`adapt` 워크(`adapt_paragraph_with_context` / `adapt_shape_with_context`)가 **그림 캡션과
+도형·묶음·차트·OLE 캡션을 방문하지 않는다.** 같은 워크가 표 캡션은
+`adapt_table_with_context` 에서 `#2443` 근거로 방문한다.
+
+**실측** — 한컴 산출 실파일 `samples/hwpx/aift.hwpx` 를 파싱해 `convert_hwpx_to_hwp_ir()` 를
+돌린 뒤, adapt 방문 표식인 `Paragraph::raw_header_extra.len()`(= `materialize_para_header_tail`
+이 12로 늘림) 분포를 셌다.
+
+```
+para_header_tail_materialized = 6330
+본문     raw_header_extra 길이 분포: {12: 921}   ← 921/921 방문
+표캡션   raw_header_extra 길이 분포: {12: 2}     ←   2/2   방문
+그림캡션 raw_header_extra 길이 분포: {10: 9}     ←   0/9   방문
+```
+
+본문 921/921, 표 캡션 2/2 가 방문되는 동안 **그림 캡션 9/9 전부 미방문**(파서가 넣은 10바이트
+그대로). 코드 확인이 아니라 실파일 계량이다.
+
+**사용자에게 나타나는 잘못된 결과**
+
+1. `adapt_picture_href_ctrl_data` 미실행 → 캡션 안 그림의 하이퍼링크(href)가 HWP 저장 시 유실.
+   `#2467` 이 각주·표 캡션에 대해 고친 것과 같은 증상.
+2. `adapt_table_with_context` 미실행 → 캡션 안 표의 `raw_ctrl_data` 미합성 → 표 개체 공통
+   속성(위치·크기·배치) 유실.
+3. `adapt_equation` 미실행 → 캡션 안 수식 `ctrl_header attr`·글꼴 버전 보정 누락.
+4. `materialize_para_header_tail` 미실행 → 직렬화기(`src/serializer/body_text.rs:406-408`)가
+   `raw_header_extra[6..]` 를 그대로 흘리므로 그림 캡션 문단만 `PARA_HEADER` 22바이트
+   (18+instanceId 4), 본문·표 캡션은 24바이트(+변경추적 2). 한 파일에 형식이 두 종류로 섞인다.
+
+그림 캡션은 희귀 구조가 아니다. `aift.hwpx` 한 파일에만 `<hp:caption>` 이 그림에 11개 붙어
+있고, HWPX 파서는 `#1403` 이래 그림·도형·묶음 캡션을 모두 `Caption` 으로 적재한다
+(`src/parser/hwpx/section.rs:1985,2602,3929,4112`).
+
+같은 캡션 축에서 형제 워크 2건도 그림 캡션을 빠뜨리고 있어 함께 고쳤다.
+
+- `remap_bin_refs_in_control` — `Control::Picture` arm 이 자기 `bin_data_id` 만 리맵하고
+  `pic.caption` 은 안 봄. 표 캡션에 대한 동형 결함이 이미
+  `table_caption_picture_bin_ref_is_remapped` 로 회귀 고정돼 있는데 그림 캡션이 그 미수정 형제.
+- `collect_object_border_fill_refs_from_paragraph` — `Control::Picture` arm 자체가 없음.
+  미수집 시 `normalize_paragraph_char_border_fills` 가드가 실패해 캡션 안 개체 채우기가
+  no-fill 로 정규화된다(`05af4fe7` 와 동일 메커니즘).
+
+## 4. 변경
+
+`src/document_core/converters/hwpx_to_hwp.rs` 한 파일, 캡션 축만. 참조 구현은 같은 저장소의
+`DocumentCore::clear_missing_lineseg_placeholders_in_control`
+(`src/document_core/commands/document.rs:702-751`) — `Table`(셀+캡션)/`Shape`/`Picture`(캡션)/
+`Header`/`Footer`/`Footnote`/`Endnote`/`HiddenComment`/`Field`(memo) 를 모두 처리하는,
+저장소에서 가장 완전한 워크다.
+
+| # | 함수 | 추가한 재귀 |
+| --- | --- | --- |
+| 1 | `adapt_paragraph_with_context` `Control::Picture` arm | `pic.caption.paragraphs` |
+| 2 | `adapt_shape_with_context` | `drawing.caption.paragraphs` — `DrawingObjAttr` 공유로 사각형·타원·선·호·다각형·곡선·글상자·묶음·차트·OLE 일괄 적용 |
+| 3 | `remap_bin_refs_in_control` `Control::Picture` arm | `pic.caption.paragraphs` |
+| 4 | `collect_bin_order_from_control` `Control::Picture` arm | `pic.caption.paragraphs` (대칭 유지 목적, 결과는 순서만) |
+| 5 | `collect_object_border_fill_refs_from_paragraph` | `Control::Picture` arm 신설 → `pic.caption.paragraphs` |
+
+각 추가에 `[#2736]` 접두 한국어 주석으로 **어느 형제 워크가 이미 그 컨테이너를 도는지**를
+명시해 다음 사람이 비대칭을 즉시 볼 수 있게 했다.
+
+`ParagraphContext` 는 캡션에서도 바깥 문맥을 그대로 전달한다(표 캡션 처리와 동일). 캡션 전용
+컨텍스트를 새로 만들면 `materialize_master_page_autonum_placeholder` 의 바탕쪽/머리말 판정이
+흔들리므로 도입하지 않았다.
+
+**추가 테스트 4건** (`hwpx_to_hwp.rs` 테스트 모듈)
+
+- `picture_href_materializes_inside_picture_and_shape_caption` — 그림 캡션·도형 캡션 안 그림 href
+- `picture_caption_picture_bin_ref_is_remapped` — 그림 캡션 안 그림 `bin_data_id` 리맵
+- `border_fill_refs_collected_inside_picture_caption` — 그림 캡션 안 표 `border_fill` 수집
+- `aift_picture_caption_paragraphs_are_adapted` — 실파일 회귀(`samples/hwpx/aift.hwpx` 9문단)
+
+## 5. 검증
+
+### 5.1 red → green (실제 실행, 캡처)
+
+수정 5곳만 되돌리고(테스트는 유지) `cargo test --lib document_core::converters::hwpx_to_hwp` 실행.
+되돌린 상태의 diff 는 테스트 모듈 단일 hunk(`@@ -2257,0 +2258,194 @@ mod tests`)만 남았음을
+`git diff -U0` 로 확인했다.
+
+**RED (실측 출력)**
+
+```
+running 41 tests
+test ...::border_fill_refs_collected_inside_picture_caption ... FAILED
+test ...::picture_href_materializes_inside_picture_and_shape_caption ... FAILED
+test ...::picture_caption_picture_bin_ref_is_remapped ... FAILED
+test ...::aift_picture_caption_paragraphs_are_adapted ... FAILED
+
+---- ...::border_fill_refs_collected_inside_picture_caption stdout ----
+panicked at src\document_core\converters\hwpx_to_hwp.rs:2395:9:
+그림 캡션 안 표의 border_fill 이 수집돼야 함
+
+---- ...::picture_href_materializes_inside_picture_and_shape_caption stdout ----
+panicked at src\document_core\converters\hwpx_to_hwp.rs:2288:9:
+assertion `left == right` failed: 그림 캡션 문단 안 그림의 href 가 물질화돼야 함(캡션 문단 미방문)
+  left: 0
+ right: 1
+
+---- ...::picture_caption_picture_bin_ref_is_remapped stdout ----
+panicked at src\document_core\converters\hwpx_to_hwp.rs:2362:9:
+assertion `left == right` failed: 그림 캡션 안 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)
+  left: 1
+ right: 2
+
+---- ...::aift_picture_caption_paragraphs_are_adapted stdout ----
+panicked at src\document_core\converters\hwpx_to_hwp.rs:2446:9:
+assertion `left == right` failed: 그림 캡션 문단이 adapt 워크의 방문 표식(header tail 12바이트)을 받아야 함
+  left: 0
+ right: 9
+
+test result: FAILED. 37 passed; 4 failed; 0 ignored; 0 measured; 2434 filtered out; finished in 0.70s
+```
+
+RED 상태에서 통과한 신규 테스트는 **없다** — 4건 전부 실패했다.
+
+**GREEN (수정 복원 후, 실측 출력)**
+
+```
+test result: ok. 41 passed; 0 failed; 0 ignored; 0 measured; 2434 filtered out; finished in 0.91s
+```
+
+### 5.2 CI 3종
+
+| 검사 | 결과 |
+| --- | --- |
+| `cargo clippy --all-targets -- -D warnings` | **통과** — `Finished dev profile ... in 58.72s`, 경고 0 |
+| `cargo test --profile release-test --tests` | **통과** — 292 바이너리 / 3,494 passed / 0 failed / 23 ignored (§5.3) |
+| `rustfmt --edition 2021` (변경 `.rs` 파일) | **통과** — 1차 실행에서 신규 테스트 코드 2곳 정정 후 커밋에 포함, 2차 실행 무변경(멱등) |
+
+`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 파일에 대해 `Incorrect newline
+style` 만 찍고 diff 를 내지 않는 **거짓 통과**라 사용하지 않았다.
+
+### 5.3 `--tests` 전체 결과
+
+`cargo test --profile release-test --tests` 종료 코드 **0**.
+
+| 항목 | 수치 |
+| --- | ---: |
+| 테스트 바이너리 | 292 |
+| passed | **3,494** |
+| failed | **0** |
+| ignored | 23 |
+
+`test result:` 라인 292개 전부 `ok`, `FAILED`/`error[` 0건. 그중 lib 타깃 단독 결과는
+`2468 passed; 0 failed; 7 ignored`. 신규 4건 모두 통과:
+
+```
+test ...::border_fill_refs_collected_inside_picture_caption ... ok
+test ...::picture_caption_picture_bin_ref_is_remapped ... ok
+test ...::picture_href_materializes_inside_picture_and_shape_caption ... ok
+test ...::aift_picture_caption_paragraphs_are_adapted ... ok
+```
+
+`cargo test --lib` 은 `tests/` 디렉터리를 통째로 건너뛰므로 판정 근거로 쓰지 않았다.
+
+## 6. 미실행 항목
+
+- **한컴 대조 없음.** 캡션 안 href/표 속성 유실을 한/글에서 열어 확인하지 않았다. 근거는
+  (a) 실파일 방문 계량, (b) 표 캡션·각주에 대한 동형 결함이 `#2467`/`#2443` 에서 이미
+  같은 형태(합성 IR 단위 테스트)로 수용된 선례다.
+- **시각 회귀 없음.** 변경이 HWPX→HWP 저장 경로 한정이고 렌더 트리를 건드리지 않아
+  golden SVG 대조는 돌리지 않았다.
+- **`PARA_HEADER` 22 → 24 의 한컴 정합 미검증.** 본문 921/921·표 캡션 2/2 가 24바이트이므로
+  **동일 문서 내 일관성** 근거로만 정당화한다. "22가 손상"이라고 주장하지 않는다.
+
+## 7. 잔여
+
+### 7.1 이번에 고치지 않은 누락
+
+| # | 누락 | 위치 | 근거 강도 | 미수정 사유 |
+| --- | --- | --- | --- | --- |
+| 1 | `replace_all_native` 가 중첩 표·각주·머리말·캡션 미치환 | `queries/search_query.rs:77` | 코드 확인 | `SearchHit.cell_context` 4-튜플 → 경로형 일반화 필요, `search_all_text_native` 공개 JSON `cellContext` 계약 변경 동반 |
+| 2 | `collect_bookmarks` 글상자 미방문 | `queries/bookmark_query.rs:221` | 코드 확인 | 책갈피 위치 모델(`host_para`)의 글상자 표현 미정 |
+| 3 | `collect_all_fields` 가 각주/머리말/캡션 필드 미수집 | `queries/field_query.rs:50,968` | 코드 확인 | `FieldLocation::NestedEntry` 가 `TableCell`/`TextBox` 만 모델링 |
+| 4 | 누름틀 `field_id` 채번이 각주/머리말 필드 미계수 | `field_query.rs:1193`, `clipboard.rs:200` | **영향 미증명** | "문서 내 고유 ID" 불변식 위반은 확정이나, rhwp 소비자(`get/set_field_value_by_id`)가 `collect_all_fields` 를 쓰고 그 워크도 같은 컨테이너를 안 봐서 충돌한 두 필드가 API 상에서 만나지 않음. 한컴 오동작 미실측 |
+| 5 | `clear_initial_field_texts` 중첩 표·글상자 미방문 | `commands/document.rs:1687` | 코드 확인 | 실파일 재현 미실시 |
+| 6 | `reflow_zero_height_paragraphs` 중첩 표·각주 미방문 | `commands/document.rs:296` | 코드 확인 | 렌더 회귀 위험 — 별도 시각 검증 필요 |
+| 7 | bin remap·border_fill 워크의 숨은설명·메모 축 미방문 | `hwpx_to_hwp.rs:470,732` | **영향 미증명** | 파서가 해당 컨테이너에 그림을 적재하는 경로 미확인 |
+| 8 | `normalize_xml_import_paragraphs` 글상자 미방문 | `commands/document.rs:1670` | 코드에 TODO 명시 | 원 저자가 "정확한 API 미식별" 로 남긴 기지 항목 |
+
+### 7.2 감사하지 않은 영역
+
+- `src/renderer/**`(typeset·layout·pagination) — 순회 함수 100+개, 레이아웃 정합이 별도 축이라 제외.
+  `collect_header_footer_controls` 1건만 표본 포함.
+- `src/serializer/**`, `src/parser/hwpx/**`, `src/parser/hml/**` — 다른 PR 이 점유 중이라 판정만 하고
+  미수정. `assign_auto_numbers_in_controls` 1건만 표본 포함.
+- `src/paint/**`, `src/diagnostics/**` — 결과가 사용자 문서에 반영되지 않아 제외.
+- HWP3 경로(`src/parser/hwp3/`) — 컨테이너를 넓게 도는 것으로 보이나 개별 검증 미실시.
+
+### 7.3 근본 대책 제안
+
+행렬이 보여주듯 이 계열은 개별 수정으로 수렴하지 않는다. `Control` 의 문단 보유 arm 을 한
+곳에서 열거하는 **공유 방문자**(예: `model::visit::for_each_paragraph_container`)를 도입하고
+새 워크가 그것을 쓰게 하면, `Control` 에 컨테이너가 추가될 때 `match` 가 non-exhaustive 로
+깨져 컴파일러가 누락을 잡아준다. 본 작업 범위를 넘어서므로 이슈 #2736 §7.3 에 제안만 남겼다.

--- a/mydocs/report/task_m100_2742_report.md
+++ b/mydocs/report/task_m100_2742_report.md
@@ -1,0 +1,290 @@
+# task_m100_2742 처리결과 보고서 — HWPX secPr 템플릿 고정 속성 전수 조사 + autoNumFormat 수정
+
+- **이슈**: [#2742](https://github.com/edwardkim/rhwp/issues/2742)
+- **브랜치**: `task/m100-2742-secpr-template` (base `origin/devel` @ `1658d0bb`)
+- **범위**: `src/serializer/hwpx/section.rs` (secPr/템플릿 영역 + 테스트 2개), 본 보고서
+- **분류**: 결함 수정 (저장 충실도) + 전수 조사 산출물
+
+## 1. 문제
+
+HWPX 구역 설정 `<hp:secPr>` 은 정적 템플릿 `templates/empty_section0.xml` 을 `replacen`
+으로 부분 치환해 만든다. **치환 앵커가 걸린 속성만 IR 값을 받고, 나머지는 문서가 무엇을
+지정했든 템플릿 상수가 그대로 출력물이 된다.** 단일 버그가 아니라 결함 클래스이므로
+템플릿 secPr 속성 슬롯을 전수 분류한 뒤 실측 손실이 가장 큰 항목을 골라 고쳤다.
+
+## 2. 분석 — secPr 속성 행렬 (103 슬롯)
+
+템플릿의 `<hp:secPr>` 블록에서 속성 슬롯을 기계적으로 추출해(요소 인스턴스 단위,
+`pageBorderFill` 3개·`offset` 3개·note pr 2개를 각각 별개로 셈) **103개**를 얻고,
+`section.rs` 의 치환 앵커 유무와 `src/parser/hwpx/section.rs` 의 IR 수집 유무를 대조했다.
+
+| 분류 | 슬롯 수 |
+|---|---:|
+| **IR 반영** | **76** |
+| **고정(IR 필드 없음)** | **15** |
+| **고정(IR 필드 있는데 미반영 = 결함)** | **12** |
+| 합계 | 103 |
+
+### 2.1 IR 반영 76
+
+`secPr` 5(textDirection·spaceColumns·tabStop·outlineShapeIDRef·masterPageCnt) ·
+`grid` 2 · `startNum` 5 · `visibility` 6 · `pagePr` 4 · `margin` 7 ·
+`footNotePr` 자식 10 · `endNotePr` 자식 10 · `pageBorderFill` ×3 = 15 · `offset` ×3 = 12.
+각각 #1166 / #1388 / #1505 / #1637 / #1984 / #1987 이 도입한 앵커다.
+
+### 2.2 고정(IR 필드 없음) 15 — 직렬화기 단독 수정 불가
+
+| 요소@속성 | 코퍼스 실측 | 판정 |
+|---|---|---|
+| `secPr@memoShapeIDRef` | 값 5종(0/1/2/3/4), 왕복 손실 **14 secPr / 9 파일** | **실측** — 파서·모델 변경 필요, 잔여 |
+| `pageBorderFill@type` ×3 | 위치 기반 합성, 왕복 불일치 1 파일 | 실측(경미) — 잔여 |
+| `secPr@id` / `@tabStopVal` / `@tabStopUnit` / `@textVerticalWidthHead` | 전수 동일값 | 잠재. `tabStopVal`/`tabStopUnit` 은 [Finding 14] `secpr_emits_tab_stop_val_and_unit` 로 이미 의도 고정 |
+| `grid@wonggojiFormat` | 90/90 `0` | 잠재 |
+| `visibility@hideFirstPageNum` / `@showLineNumber` | 90/90 `0` | 잠재. `render_visibility` 주석이 IR 미보존을 이미 명시 |
+| `lineNumberShape@restartType/countBy/distance/startNumber` | **360/360 전부 `0`** | 잠재 (줄 번호 사용 실물 0건) |
+
+### 2.3 결함 12 — 파서는 읽는데 직렬화가 안 씀
+
+| 요소@속성 | 템플릿 고정값 | 대응 IR 필드 |
+|---|---|---|
+| `footNotePr/autoNumFormat@type` | `DIGIT` | `FootnoteShape.number_format` |
+| `…@userChar` | `""` | `.user_char` |
+| `…@prefixChar` | `""` | `.prefix_char` |
+| `…@suffixChar` | `")"` | `.suffix_char` |
+| `…@supscript` | `0` | `.number_code_superscript` |
+| `endNotePr/autoNumFormat` 5속성 | 동일 | `SectionDef.endnote_shape` 의 같은 5필드 |
+| `footNotePr/placement@place` | `EACH_COLUMN` | `.placement` |
+| `endNotePr/placement@place` | `END_OF_DOCUMENT` | `.placement` |
+
+HWPX 파서(`parse_note_pr_children`)뿐 아니라 HWP5 파서도 `HWPTAG_FOOTNOTE_SHAPE` 에서
+같은 5필드를 채우며(`apply_attr_fields_from_raw`), `SectionDef.footnote_shape`/
+`endnote_shape` 는 두 포맷이 공유하는 단일 슬롯이다.
+
+**의도된 고정과의 구분.** `tabStop` IR 0 폴백(주석 + `secpr_keeps_template_tab_stop_when_ir_unset`),
+`tabStopVal`/`tabStopUnit`([Finding 14] 테스트), `textDirection` 조건부 치환은 코드/테스트에
+의도가 남아 있다. 반면 `git log -S "autoNumFormat" -- src/serializer/hwpx/section.rs` 는
+템플릿 도입 커밋 2개와 `autoNum` **컨트롤** 커밋(#1326)뿐으로, secPr `autoNumFormat` 을
+고정으로 두자는 결정 기록이 없다. 파일 머리말도 "IR에 대응 필드가 더 담길 때까지
+점진적으로 동적화 예정"이라는 임시 상태를 명시한다.
+
+## 3. 코퍼스 실측
+
+### 3.1 XML 레벨 — `samples/hwpx/*.hwpx` 60개
+
+`Contents/section*.xml` 에서 `<hp:secPr>` 블록 직접 추출. ZIP 유효 **59 파일 · secPr 90개**
+(`hwpx-01.hwpx` 는 ZIP 아님).
+
+실측 변동이 있는 고정 속성: `secPr@memoShapeIDRef`(9 파일),
+`footNotePr/endNotePr autoNumFormat@supscript`(`0`×80 / `1`×10, 1 파일),
+`pageBorderFill@type`(1 파일). 나머지 고정 속성은 전수 동일값 = **잠재**.
+
+### 3.2 IR 레벨 — 330 파일 · note shape 828개
+
+XML 코퍼스만 보면 `autoNumFormat` 은 거의 잠재로 보인다. 그러나 `SectionDef.footnote_shape`
+는 HWP5 파서도 채우고 `export-hwpx`(HWP5→HWPX 저장)는 1급 기능이므로 IR 레벨로 다시 셌다.
+`rhwp dump-note-shape` 를 `samples/*.hwp` 270 + `samples/hwpx/*.hwpx` 60 =
+**330 파일 전부**에 돌려 **note shape 828개**(각주 414 / 미주 414) 수집, 파싱 실패 0.
+
+```
+endnoteShape   prefixChar  {'\x00': 397, '문': 17}           ← U+BB38
+endnoteShape   suffixChar  {')': 382, '）': 17, '\x00': 15}   ← U+FF09 전각
+endnoteShape   supscript   {False: 413, True: 1}
+footnoteShape  supscript   {False: 413, True: 1}
+footnoteShape/endnoteShape numberFormat {'Digit': 414 / 414}
+footnoteShape/endnoteShape userChar     {'\x00': 414 / 414}
+footnoteShape/endnoteShape placement    {'EachColumn': 414 / 414}
+```
+
+**템플릿 고정 출력값과 다른 note shape = 19개 / 18 파일**
+
+- 미주 `prefixChar='문'` + `suffixChar='）'` — **17 파일**
+  (`3-09월_교육_통합_*`, `3-10월_교육_통합_2022`, `3-11월_실전_통합_*` — 전부 한컴 생산 시험지)
+- 각주·미주 `supscript=true` — **1 파일**
+  (`hwpx/issue2019_floating_form_74312.hwpx`, `version.xml` = `Hancom Office Hangul 9,1,0,2172`)
+
+**실측/잠재 분리** — `prefixChar`·`suffixChar`·`supscript` 3속성은 **실측**,
+`type`·`userChar` 2속성과 `placement@place` 는 현 코퍼스에서 **잠재**(실측 0건)다.
+이번 수정에 `type`/`userChar` 도 포함했지만 실측 효과는 없고 잠재 방어다.
+
+### 3.3 raw_stream 지름길 — HWPX 경로에는 없다
+
+HWP5 경로에는 `src/serializer/body_text.rs` 의 `Section::raw_stream` 조기 반환이 있어
+미편집 저장이 직렬화기에 도달하지 않는다. HWPX 경로에는 대응물이 없다.
+
+- `grep -rn "raw_stream" src/serializer/hwpx/` → **0건**
+- `serialize_hwpx()` 의 `hwpx_aux_entry` 패스스루는 `version.xml`·`Preview/*`·`settings.xml`·
+  `Contents/content.hpf` 에만 적용되고 `Contents/section{N}.xml` 은 **무조건**
+  `section::write_section()` 으로 재조립된다.
+
+아래 4.1 에서 왕복 불일치가 실제로 관측된 것 자체가 그 실증이다(패스스루가 있었다면 0건).
+
+## 4. 왕복 실증
+
+### 4.1 HWPX → HWPX 59 파일 전수 secPr diff (수정 전 → 수정 후)
+
+59 파일 전부 `rhwp export-hwpx` 로 저장한 뒤 원본/저장본의 첫 secPr 속성을 1:1 대조
+(rhwp IR 은 section XML 파트당 secPr 1개만 유지).
+
+| | 수정 전 | 수정 후 |
+|---|---:|---:|
+| 총 불일치 (속성×secPr) | **59** | **57** |
+| 속성 종류 | **22** | **20** |
+| `footNotePr/endNotePr autoNumFormat@supscript` | `'1' → '0'` 각 1건 | **0건** |
+
+남은 57건은 전부 이번 범위 밖 항목이다 — `memoShapeIDRef` 14,
+`tabStopVal`/`tabStopUnit` 추가 26([Finding 14] 의도),
+`autoNumFormat@prefixChar/suffixChar/userChar` 6(**값 변경이 아니라 한컴이 생략한 속성을
+기본값으로 추가**), `noteLine@width` 표기 2, `margin` 4, `pageBorderFill@type` 2,
+`placement@place` 1, `secPr@id` 1, `secPr@tabStop` 1.
+
+#### 이론과 어긋난 관측 2건 — 원인 규명
+
+1. **`margin@left/right/top/bottom` 4건.** `margin` 은 IR 반영 속성인데
+   `issue2019_floating_form_74312.hwpx` 에서 `left 6750 → 7600` 등이 나왔다. 원인은
+   직렬화기가 아니다. 이 파일은 `Contents/section0.xml` **하나에 `<hp:secPr>` 10개**를
+   담고 있고 `parse_secpr_children` 이 같은 `sec_def` 를 순차 덮어쓰므로 IR 에는 **마지막
+   secPr** 값이 남는다. 원본 10번째 secPr 의 `left="7600" right="5800" top="4135"
+   bottom="2935"` 가 저장본과 정확히 일치함을 확인했다. "다중 secPr → 구역 1개" 파서
+   구조 이슈이지 템플릿 고정과 무관하다.
+2. **`secPr@tabStop` `0 → 8000` 1건.** 같은 파일. `replace_secpr_scalars` 가 IR 0 일 때
+   템플릿 상수를 유지하도록 **의도적으로** 작성돼 있고 전용 테스트가 이를 고정한다. 결함 아님.
+
+`supscript '1' → '0'` 은 위 두 예외에 해당하지 않는다. 원본의 secPr 10개가 **전부**
+`supscript="1"` 이라 어느 secPr 이 IR 에 남든 값은 `true` 여야 하고 `dump-note-shape` 도
+`numberCodeSuperscript: true` 를 보고했는데, 저장본만 `0` 이었다 → 템플릿 고정이 유일 원인.
+
+### 4.2 HWP5 → HWPX 실파일 왕복 (수정 전)
+
+```
+$ rhwp export-hwpx "samples/3-09월_교육_통합_2023.hwp" edu2023.hwpx
+$ rhwp dump-note-shape "samples/3-09월_교육_통합_2023.hwp"      # 저장 전
+0 endnoteShape {'numberFormat':'Digit','prefixChar':'문','suffixChar':'）','userChar':'\x00','numberCodeSuperscript':False}
+$ rhwp dump-note-shape edu2023.hwpx                             # 저장 후
+0 endnoteShape {'numberFormat':'Digit','prefixChar':'\x00','suffixChar':')','userChar':'\x00','numberCodeSuperscript':False}
+```
+
+`prefixChar` `문`(U+BB38) → `\x00` 소멸, `suffixChar` `）`(U+FF09) → `)`(U+0029) 변조.
+
+### 4.3 HWP5 → HWPX 실파일 왕복 (수정 후)
+
+```
+$ rhwp dump-note-shape edu2023_fixed.hwpx
+0 endnoteShape {'numberFormat':'Digit','prefixChar':'문','suffixChar':'）','userChar':'\x00','numberCodeSuperscript':False}
+
+# 저장본 Contents/section0.xml 의 secPr
+<hp:autoNumFormat type="DIGIT" userChar="" prefixChar="" suffixChar=")" supscript="0"/>   ← 각주(원본대로 기본값)
+<hp:autoNumFormat type="DIGIT" userChar="" prefixChar="문" suffixChar="）" supscript="0"/> ← 미주(복원)
+```
+
+동일 패턴 파일 17개 전수 재측정: **대상 17 / note shape 5필드 일치 17 / 불일치 0 / 변환 실패 0**
+(수정 전 동일 스크립트: 일치 0 / 불일치 17).
+
+### 4.4 사용자에게 보이는 결과 (과장 없이)
+
+구역 각주/미주 모양은 **새 주석을 삽입할 때의 기본값**이다.
+`document_core/commands/object_ops/note.rs` 가 `shape.prefix_char`/`suffix_char`/번호 모양을
+읽어 새 미주의 `before_decoration_letter`/`after_decoration_letter`/`number_shape` 를 정한다.
+저장본에서 이 값이 리셋되면 이후 삽입되는 미주가 「문1）」이 아니라 「1)」로 매겨지고,
+한/글 [주석 모양] 대화상자도 원본과 다른 값을 보여준다. `number_code_superscript` 는
+`FootnoteShape::encode_attr()` bit 12 라 HWPX→HWP5 재변환 시 `HWPTAG_FOOTNOTE_SHAPE` attr
+까지 오염된다.
+
+**이미 배치된 주석의 마커 렌더는 ctrl 쪽 값**(`Footnote::before_decoration_letter`,
+`renderer/layout/paragraph_layout.rs::note_marker_text_from_control`)**으로 그려지므로 이
+결함만으로 기존 마커 표시가 즉시 바뀌지는 않는다.** 본 건은 구역 기본 주석 모양(secPr)의
+손실이며 ctrl 쪽은 별건이다.
+
+## 5. 변경
+
+`src/serializer/hwpx/section.rs` 한 파일, **+140줄 / -0줄**. secPr/템플릿 영역만 손댔고
+공통 도형(`render_common_shape_xml`)·각주 sublist(`render_note_sublist`) 영역은 무변경.
+
+| 추가 항목 | 내용 |
+|---|---|
+| `note_number_format_str()` | `NumberFormat` → HWPX `type` 토큰 19종. 파서 `number_format_from_name` 의 UPPER_SNAKE 분기 역매핑 (`note_line_type_str`·`note_numbering_str`·`page_num_format_to_str` 와 동형) |
+| `note_deco_char_attr()` | 장식 문자 `char` → 속성값. `< 0x20` 제어문자(`'\0'` 포함, 미지정)면 템플릿 기본값 유지, 아니면 `xml_escape` 후 방출. `render_hp_t_content` 의 `< 0x20` 제외와 동일 정책 — XML 1.0 금지 문자 방출로 저장본이 안 열리는 것을 막는다 |
+| `render_auto_num_format()` | `FootnoteShape` → `<hp:autoNumFormat .../>`. 속성 순서 type→userChar→prefixChar→suffixChar→supscript (템플릿·한컴 실물과 동일) |
+| `TEMPLATE_AUTO_NUM_FORMAT` | 템플릿 앵커 상수 |
+| `replace_footnote_shape()` | 앞머리에 `replace_first_two()` 치환 1회 추가 |
+
+**설계 판단 2가지**
+
+1. **`replacen` 이 아니라 `replace_first_two`.** 템플릿의 각주/미주 `autoNumFormat` 문자열이
+   완전히 같아 연쇄 `replacen` 은 두 번째가 첫 슬롯을 다시 잡는다. 같은 이유로
+   `numbering` 이 이미 쓰던 위치 기반 2회 치환을 재사용했다.
+2. **`'\0'` 은 템플릿 기본값 유지.** `object_ops/note.rs` 가 `suffix_char == '\0'` 을 기본값
+   폴백으로 해석하므로 `'\0'` 은 "없음"이 아니라 "미지정"이다. IR 값이 있을 때만 치환하는
+   `tabStop`/`textDirection` 패턴과 동일하게 두어, 기본 문서의 출력이 템플릿과 바이트
+   동일하도록 보장했다(테스트 `issue2742_auto_num_format_keeps_template_when_ir_unset`).
+
+치환은 콘텐츠 삽입 **이전**에 일어나므로 본문 `<hp:ctrl><hp:autoNum>` 의 `autoNumFormat` 과
+앵커가 충돌하지 않는다.
+
+## 6. 검증
+
+### 6.1 red → green (실제 실행)
+
+**RED** — `replace_footnote_shape` 의 `replace_first_two` 호출만 되돌리고 실행:
+
+```
+running 2 tests
+test serializer::hwpx::section::tests::issue2742_auto_num_format_keeps_template_when_ir_unset ... ok
+test serializer::hwpx::section::tests::issue2742_auto_num_format_reflects_ir ... FAILED
+
+---- serializer::hwpx::section::tests::issue2742_auto_num_format_reflects_ir stdout ----
+thread '...' panicked at src\serializer\hwpx\section.rs:2624:9:
+각주 autoNumFormat 이 IR 값이어야 함: <?xml version="1.0" ... <hp:footNotePr>
+<hp:autoNumFormat type="DIGIT" userChar="" prefixChar="" suffixChar=")" supscript="0"/>
+<hp:noteLine length="0" type="NONE" width="0.1 mm" color="#000000"/> ...
+
+test result: FAILED. 1 passed; 1 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+`issue2742_auto_num_format_keeps_template_when_ir_unset` 은 RED 에서도 **통과한다** —
+이 테스트는 "IR 미설정 시 템플릿과 바이트 동일" 을 고정하는 **회귀 방어용**이므로
+수정 전후 모두 통과하는 것이 정상이다. 결함을 잡는 테스트는
+`issue2742_auto_num_format_reflects_ir` 하나다.
+
+**GREEN** — 수정 복원 후:
+
+```
+running 2 tests
+test serializer::hwpx::section::tests::issue2742_auto_num_format_reflects_ir ... ok
+test serializer::hwpx::section::tests::issue2742_auto_num_format_keeps_template_when_ir_unset ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+### 6.2 CI 3종
+
+| 항목 | 결과 |
+|---|---|
+| `cargo clippy --all-targets -- -D warnings` | **통과** (경고 0) |
+| `cargo test --profile release-test --tests` | **통과** (exit 0, 0 failed) — 통합 바이너리 248 passed. 추가로 `cargo test --lib` 전체 **2466 passed / 0 failed / 7 ignored**, `hwpx_roundtrip_baseline` 4 · `hwpx_roundtrip_integration` 22 · `hwpx_form_roundtrip` 1 · `issue_1172_para_margin_roundtrip` 3 개별 통과 |
+| `rustfmt --edition 2021` (변경 `.rs`) 후 idempotency 확인 | **변경 없음** (포맷 위반 0) |
+
+`cargo fmt --all -- --check` 는 이 Windows 체크아웃에서 CRLF 때문에
+`Incorrect newline style` 만 찍고 diff 를 내지 않는 거짓 통과이므로 사용하지 않았다.
+
+### 6.3 실파일 회귀
+
+- HWPX 왕복 59 파일 전수 secPr diff: 불일치 59 → **57** (autoNumFormat 값 불일치 소멸,
+  다른 속성 증가 0)
+- HWP5→HWPX 17 파일 note shape 5필드: **17/17 일치**
+
+## 7. 미실행 항목
+
+- 한/글 실물 열기 검증(설치 환경 없음). XML 레벨 + IR 재파싱 레벨로 갈음했다.
+- 렌더 이미지 회귀(`render-diff`) 미실행 — 이번 변경은 secPr 속성값만 바꾸고
+  레이아웃 입력(`separator_*`, `note_spacing`)은 건드리지 않는다.
+
+## 8. 잔여
+
+| 항목 | 실측 | 왜 남기나 |
+|---|---|---|
+| `secPr@memoShapeIDRef` | **14 secPr / 9 파일** | 파서 미수집 + `SectionDef` 필드 없음. 파서·모델 변경 필요 |
+| `footNotePr/endNotePr placement@place` | 0건(정규화 1건) | 파서가 `END_OF_SECTION`/`BELOW_TEXT` 를 같은 `BelowText` 로 접어 무손실 역매핑 불가. 컨텍스트별 역매핑 재정의 필요 |
+| `pageBorderFill@type` ×3 | 1 파일 | IR 이 `type` 문자열 미보존(위치로만 저장). 한컴이 `BOTH`×3 을 쓰는 사례 의미 확인 필요 |
+| 한 section 파트에 `<hp:secPr>` 다수 | 1 파일(10개 → 1개, 9개 소실) | "section 파트 1 = 구역 1" 전제를 바꿔야 함. 별도 이슈 |
+| `noteLine@width` `4 mm` → `4.0 mm` | 1 파일 | 굵기 코드 → mm 문자열 포맷 차이. 값 손실은 아니나 한컴 표기와 불일치 |
+| `lineNumberShape` 4속성, `grid@wonggojiFormat`, `visibility@hideFirstPageNum`/`showLineNumber`, `secPr@textVerticalWidthHead`, `secPr@id` | 0건 | 코퍼스 전수 기본값 + IR 필드 없음 — 잠재로 기록만 |

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -384,6 +384,12 @@ fn collect_bin_order_from_control(
     match ctrl {
         Control::Picture(pic) => {
             push_bin_order(pic.image_attr.bin_data_id, bin_count, order, seen);
+            // [#2736] 그림 캡션 문단도 순회한다. 표 캡션(아래 arm)·도형 캡션
+            // (collect_bin_order_from_shape)은 이미 방문하는데 그림 캡션만 빠져 있어,
+            // 같은 캡션 컨테이너인데 소유 개체 종류에 따라 순회 여부가 갈렸다.
+            if let Some(caption) = &pic.caption {
+                collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
+            }
         }
         Control::Shape(shape) => collect_bin_order_from_shape(shape, bin_count, order, seen),
         Control::Table(table) => {
@@ -471,6 +477,13 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
     match ctrl {
         Control::Picture(pic) => {
             pic.image_attr.bin_data_id = remap_bin_ref(pic.image_attr.bin_data_id, remap);
+            // [#2736] 그림 캡션 문단 안의 그림도 리맵해야 한다. 미방문 시 캡션 안 그림의
+            // bin_data_id 가 재정렬 이전 번호로 남아 엉뚱한 이미지로 해석된다 —
+            // 표 캡션에 대한 동형 결함이 이미 table_caption_picture_bin_ref_is_remapped
+            // 로 회귀 고정돼 있고, 그림 캡션이 그 미수정 형제였다.
+            if let Some(caption) = &mut pic.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         Control::Shape(shape) => remap_bin_refs_in_shape(shape, remap),
         Control::Table(table) => {
@@ -737,6 +750,18 @@ fn collect_object_border_fill_refs_from_paragraph(
         match ctrl {
             Control::Table(table) => collect_table_border_fill_refs(table, refs),
             Control::Shape(shape) => collect_object_border_fill_refs_from_shape(shape, refs),
+            // [#2736] 그림 캡션 문단 안 개체 참조도 수집한다. `Control::Picture` arm 자체가
+            // 없어 표 캡션(collect_table_border_fill_refs)·도형 캡션
+            // (collect_object_border_fill_refs_from_shape)과 달리 그림 캡션만 빠져 있었고,
+            // 미수집 시 normalize_paragraph_char_border_fills 가드가 실패해 캡션 안 개체
+            // 채우기가 no-fill 로 정규화된다(#2467 과 동일 메커니즘).
+            Control::Picture(pic) => {
+                if let Some(caption) = &pic.caption {
+                    for p in &caption.paragraphs {
+                        collect_object_border_fill_refs_from_paragraph(p, refs);
+                    }
+                }
+            }
             // 각주/미주/숨은설명 문단 안의 개체도 border_fill 을 참조할 수 있다.
             // 이 참조가 수집되지 않으면 normalize_paragraph_char_border_fills 의
             // 가드가 실패해, 문단 char-border 와 공유된 border_fill 이 no-fill 로
@@ -889,7 +914,16 @@ fn adapt_paragraph_with_context(
                 ParagraphContext::HeaderFooter,
             ),
             Control::Picture(pic) => {
-                adapt_picture_href_ctrl_data(pic, &mut ctrl_data_records[idx], report)
+                adapt_picture_href_ctrl_data(pic, &mut ctrl_data_records[idx], report);
+                // [#2736] 그림 캡션 문단도 보강한다. 표 캡션은 adapt_table_with_context 가
+                // 이미 보강하고, bin order/remap·border_fill 수집 워크는 캡션을 순회하는데
+                // adapt 워크만 그림 캡션을 건너뛰었다. 실측(samples/hwpx/aift.hwpx): 본문
+                // 921/921·표 캡션 2/2 가 방문되는 동안 그림 캡션 9/9 전부 미방문.
+                // 미방문 시 캡션 안 그림 href·표 raw_ctrl_data·수식 보정이 물질화되지 않고
+                // 문단 header tail 도 10바이트로 남아 PARA_HEADER 가 22/24 로 섞인다.
+                if let Some(caption) = &mut pic.caption {
+                    adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
+                }
             }
             Control::Shape(shape) => adapt_shape_with_context(shape, report, context),
             Control::Equation(eq) => adapt_equation(eq, report),
@@ -1237,6 +1271,14 @@ fn adapt_shape_with_context(
         if let Some(text_box) = &mut drawing.text_box {
             materialize_text_box_hwp5_envelope(text_box, report);
             adapt_paragraphs_with_context(&mut text_box.paragraphs, report, context);
+        }
+        // [#2736] 도형 캡션 문단도 보강한다. `DrawingObjAttr` 를 공유하는 사각형·타원·선·호·
+        // 다각형·곡선·글상자·묶음·차트·OLE 이 한 번에 덮인다. 형제 워크
+        // (collect_bin_order_from_shape / remap_bin_refs_in_shape /
+        // collect_object_border_fill_refs_from_shape)는 셋 다 이미 drawing.caption 을
+        // 순회하는데 adapt 워크만 빠져 있었다.
+        if let Some(caption) = &mut drawing.caption {
+            adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
         }
     }
 
@@ -2252,6 +2294,206 @@ mod tests {
                 .unwrap()
                 .len(),
             76
+        );
+    }
+
+    /// [#2736] adapt 워크가 그림 캡션·도형 캡션 문단을 방문하는지.
+    ///
+    /// 표 캡션은 `adapt_table_with_context` 가 이미 보강하고, bin order/remap·
+    /// border_fill 수집 워크도 캡션을 순회하는데 adapt 워크만 그림/도형 캡션을
+    /// 건너뛰어 캡션 안 그림의 href 가 HWP 저장 시 유실됐다.
+    #[test]
+    fn picture_href_materializes_inside_picture_and_shape_caption() {
+        use crate::model::shape::{Caption, RectangleShape, ShapeObject};
+
+        let href_caption = || {
+            let mut inner = Paragraph::default();
+            inner.controls.push(Control::Picture(Box::new(Picture {
+                href: Some("http://www.korea.kr;1;0;0;".to_string()),
+                ..Default::default()
+            })));
+            Caption {
+                paragraphs: vec![inner],
+                ..Default::default()
+            }
+        };
+
+        // 그림 캡션 문단 안의 그림 href
+        let mut ppara = Paragraph::default();
+        ppara.controls.push(Control::Picture(Box::new(Picture {
+            caption: Some(href_caption()),
+            ..Default::default()
+        })));
+
+        let mut preport = AdapterReport::new();
+        adapt_paragraph(&mut ppara, &mut preport);
+        assert_eq!(
+            preport.picture_href_ctrl_data_materialized, 1,
+            "그림 캡션 문단 안 그림의 href 가 물질화돼야 함(캡션 문단 미방문)"
+        );
+        let Control::Picture(pic) = &ppara.controls[0] else {
+            panic!("expected picture control");
+        };
+        let pcap = pic.caption.as_ref().unwrap();
+        assert_eq!(
+            pcap.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+
+        // 도형 캡션 문단 안의 그림 href (DrawingObjAttr 공유 → 묶음·차트·OLE 동시 적용)
+        let mut rect = RectangleShape::default();
+        rect.drawing.caption = Some(href_caption());
+        let mut spara = Paragraph::default();
+        spara
+            .controls
+            .push(Control::Shape(Box::new(ShapeObject::Rectangle(rect))));
+
+        let mut sreport = AdapterReport::new();
+        adapt_paragraph(&mut spara, &mut sreport);
+        assert_eq!(
+            sreport.picture_href_ctrl_data_materialized, 1,
+            "도형 캡션 문단 안 그림의 href 가 물질화돼야 함(캡션 문단 미방문)"
+        );
+        let Control::Shape(shape) = &spara.controls[0] else {
+            panic!("expected shape control");
+        };
+        let scap = shape.drawing().unwrap().caption.as_ref().unwrap();
+        assert_eq!(
+            scap.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+    }
+
+    /// [#2736] 그림 캡션 문단 안 그림의 `bin_data_id` 리맵 — 표 캡션에 대한 동형
+    /// 회귀(`table_caption_picture_bin_ref_is_remapped`)의 미수정 형제였다.
+    #[test]
+    fn picture_caption_picture_bin_ref_is_remapped() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+
+        let mut inner_pic = Picture::default();
+        inner_pic.image_attr.bin_data_id = 1;
+        let mut cap_para = Paragraph::default();
+        cap_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let mut outer = Picture::default();
+        outer.image_attr.bin_data_id = 2;
+        outer.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut ctrl = Control::Picture(Box::new(outer));
+
+        // remap: bin id 1 → 2, 2 → 1
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::Picture(outer) = &ctrl else {
+            panic!("expected picture");
+        };
+        assert_eq!(outer.image_attr.bin_data_id, 1);
+        let caption = outer.caption.as_ref().unwrap();
+        let Control::Picture(inner) = &caption.paragraphs[0].controls[0] else {
+            panic!("expected caption picture");
+        };
+        assert_eq!(
+            inner.image_attr.bin_data_id, 2,
+            "그림 캡션 안 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
+    }
+
+    /// [#2736] 그림 캡션 문단 안 개체의 `border_fill` 참조 수집 —
+    /// `collect_object_border_fill_refs_from_paragraph` 에 `Control::Picture` arm 이
+    /// 아예 없어 표 캡션·도형 캡션과 달리 그림 캡션만 빠져 있었다.
+    #[test]
+    fn border_fill_refs_collected_inside_picture_caption() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+
+        let mut cap_para = Paragraph::default();
+        cap_para.controls.push(Control::Table(Box::new(Table {
+            border_fill_id: 17,
+            ..Default::default()
+        })));
+        let mut pic = Picture::default();
+        pic.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        });
+
+        assert!(
+            collect_object_border_fill_refs(&doc).contains(&17),
+            "그림 캡션 안 표의 border_fill 이 수집돼야 함"
+        );
+    }
+
+    /// [#2736] 실파일 회귀 — 한컴 산출 `aift.hwpx` 의 그림 캡션 문단 9개가 adapt 워크의
+    /// 방문 표식(`materialize_para_header_tail` 의 12바이트 header tail)을 받는지.
+    ///
+    /// 수정 전 실측: 본문 921/921·표 캡션 2/2 는 12바이트, 그림 캡션 9/9 는 파서가 넣은
+    /// 10바이트 그대로 — 직렬화 시 캡션 문단만 PARA_HEADER 22바이트로 갈렸다.
+    #[test]
+    fn aift_picture_caption_paragraphs_are_adapted() {
+        fn count_picture_caption_paragraphs(
+            para: &Paragraph,
+            total: &mut usize,
+            tail12: &mut usize,
+        ) {
+            for ctrl in &para.controls {
+                match ctrl {
+                    Control::Picture(pic) => {
+                        if let Some(caption) = &pic.caption {
+                            for p in &caption.paragraphs {
+                                *total += 1;
+                                if p.raw_header_extra.len() >= 12 {
+                                    *tail12 += 1;
+                                }
+                            }
+                        }
+                    }
+                    Control::Table(table) => {
+                        for cell in &table.cells {
+                            for p in &cell.paragraphs {
+                                count_picture_caption_paragraphs(p, total, tail12);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let data = std::fs::read("samples/hwpx/aift.hwpx").expect("sample exists");
+        let mut core = crate::document_core::DocumentCore::from_bytes(&data).expect("parse hwpx");
+        convert_hwpx_to_hwp_ir(core.document_mut());
+
+        let mut total = 0usize;
+        let mut tail12 = 0usize;
+        for section in &core.document().sections {
+            for para in &section.paragraphs {
+                count_picture_caption_paragraphs(para, &mut total, &mut tail12);
+            }
+        }
+
+        assert_eq!(total, 9, "aift.hwpx 의 그림 캡션 문단 수");
+        assert_eq!(
+            tail12, total,
+            "그림 캡션 문단이 adapt 워크의 방문 표식(header tail 12바이트)을 받아야 함"
         );
     }
 

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -60,11 +60,23 @@ pub enum Control {
     Unknown(UnknownControl),
 }
 
+/// [#2727] `Equation::attr` 의 bit 0 — 수식이 차지하는 범위.
+///
+/// set = 줄 단위 (HWPX `lineMode="LINE"`), clear = 글자 단위 (`lineMode="CHAR"`).
+pub const EQUATION_LINE_MODE_BIT: u32 = 0x0000_0001;
+
 /// 수식 ('eqed' 컨트롤, HWP 스펙 표 105)
 #[derive(Debug, Clone, Default)]
 pub struct Equation {
     /// 개체 공통 속성 (위치, 크기, 배치)
     pub common: CommonObjAttr,
+    /// [#2727] HWPTAG_EQEDIT 속성 (HWP5 spec 표 105 attribute, UINT32).
+    ///
+    /// bit 0 = 수식이 차지하는 범위 (0 = 글자 단위, 1 = 줄 단위) — HWPX
+    /// `hp:equation@lineMode` (`CHAR` / `LINE`) 와 대응한다. 나머지 비트는 의미
+    /// 미상이므로 UINT32 전체를 원본 그대로 보존해 왕복시킨다. 기본값 0 은
+    /// OWPML `lineMode` 기본값 `CHAR` 와 일치한다.
+    pub attr: u32,
     /// 수식 스크립트 ("1 over 2" 등)
     pub script: String,
     /// 글자 크기 (HWPUNIT)

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -863,7 +863,9 @@ fn parse_equation_control(ctrl_data: &[u8], child_records: &[Record]) -> Control
         let mut r = ByteReader::new(data);
 
         // attr: u32 (4바이트) — bit0: 스크립트 범위
-        let _attr = r.read_u32().unwrap_or(0);
+        // [#2727] 종전엔 읽고 버려 저장 시 0 으로 고정됐다. bit0 은 HWPX
+        // `lineMode`(CHAR/LINE) 와 대응하므로 UINT32 전체를 IR 로 보존한다.
+        equation.attr = r.read_u32().unwrap_or(0);
 
         // script: WCHAR 문자열 (길이 접두 UTF-16LE)
         if let Ok(script) = r.read_hwp_string() {

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -738,13 +738,26 @@ fn parse_para_shape(data: &[u8]) -> Result<ParaShape, DocInfoError> {
         0
     };
 
+    // [#2734] 말미 4바이트(payload offset 54~57) = 개요 수준(0~9 = 1수준~10수준).
+    // attr1 bit25~27 은 3비트라 한컴이 6 에서 포화시키므로 8~10수준은 이 필드에만 남는다.
+    // 종전엔 읽지 않아 8·9·10수준 문단이 모두 7수준(para_level=6)으로 붕괴했다.
+    let outline_level_tail = if r.remaining() >= 4 {
+        r.read_u32().unwrap_or(0)
+    } else {
+        0
+    };
+
     let head_type = match (attr1 >> 23) & 0x03 {
         1 => crate::model::style::HeadType::Outline,
         2 => crate::model::style::HeadType::Number,
         3 => crate::model::style::HeadType::Bullet,
         _ => crate::model::style::HeadType::None,
     };
-    let para_level = ((attr1 >> 25) & 0x07) as u8;
+    // [#2734] 두 출처 중 큰 쪽을 취한다. samples 코퍼스 58바이트 레코드 11,913건 전수에서
+    // 두 값이 어긋나는 경우는 (a) tail 7~9 / attr1 6(포화) 138건, (b) tail 0 / attr1 1~6 인
+    // 단일 파일 9건뿐이라, max 가 (a)에서 8~10수준을 복원하면서 (b)의 기존 동작을 보존한다.
+    // tail 이 없는 42/46/54바이트 레코드는 outline_level_tail=0 이라 종전과 동일하다.
+    let para_level = (((attr1 >> 25) & 0x07) as u8).max(outline_level_tail.min(9) as u8);
 
     Ok(ParaShape {
         raw_data: None,
@@ -1204,6 +1217,97 @@ mod tests {
         assert_eq!(ps.line_spacing, 160);
         assert!(matches!(ps.alignment, Alignment::Justify));
         assert!(matches!(ps.line_spacing_type, LineSpacingType::Percent));
+    }
+
+    /// [#2734] PARA_SHAPE 레코드 바이트 생성 헬퍼.
+    ///
+    /// `tail` 이 Some 이면 58바이트(말미 개요 수준 4바이트 포함), None 이면 54바이트.
+    fn make_para_shape_bytes(attr1: u32, tail: Option<u32>) -> Vec<u8> {
+        let mut data = Vec::new();
+        data.extend_from_slice(&attr1.to_le_bytes());
+        for _ in 0..6 {
+            data.extend_from_slice(&0i32.to_le_bytes()); // 여백/들여쓰기/간격/줄간격
+        }
+        for _ in 0..3 {
+            data.extend_from_slice(&0u16.to_le_bytes()); // tab_def/numbering/border_fill id
+        }
+        for _ in 0..4 {
+            data.extend_from_slice(&0i16.to_le_bytes()); // border_spacing
+        }
+        data.extend_from_slice(&0u32.to_le_bytes()); // attr2
+        data.extend_from_slice(&0u32.to_le_bytes()); // attr3
+        data.extend_from_slice(&0u32.to_le_bytes()); // line_spacing_v2
+        if let Some(t) = tail {
+            data.extend_from_slice(&t.to_le_bytes());
+        }
+        data
+    }
+
+    #[test]
+    fn para_shape_recovers_outline_level_8_to_10_from_tail() {
+        // [#2734] attr1 bit25~27 은 3비트라 한컴이 6 에서 포화시키고 실제 개요 수준은
+        // 말미 4바이트에 쓴다. 종전엔 tail 을 읽지 않아 8·9·10수준이 모두 7수준으로 붕괴했다.
+        for (tail, expected) in [(7u32, 7u8), (8, 8), (9, 9)] {
+            let data = make_para_shape_bytes(6u32 << 25, Some(tail));
+            assert_eq!(data.len(), 58);
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(
+                ps.para_level, expected,
+                "tail={tail} 이면 개요 수준 {expected} 로 복원돼야 함(attr1 은 6 에서 포화)"
+            );
+        }
+
+        // 1~7수준 구간은 두 출처가 일치한다 — 값이 그대로여야 한다.
+        for lvl in 0u32..=6 {
+            let data = make_para_shape_bytes(lvl << 25, Some(lvl));
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(ps.para_level, lvl as u8, "tail=attr1={lvl} 인 정합 레코드");
+        }
+
+        // 실측 예외(단일 파일 9건): tail=0 인데 attr1 이 수준을 갖는 형태.
+        // 종전 동작(attr1 값)이 그대로 유지돼야 회귀가 아니다.
+        for lvl in 1u32..=6 {
+            let data = make_para_shape_bytes(lvl << 25, Some(0));
+            let ps = parse_para_shape(&data).unwrap();
+            assert_eq!(ps.para_level, lvl as u8, "tail=0/attr1={lvl} → attr1 유지");
+        }
+
+        // tail 이 없는 54바이트 레코드는 종전과 동일하게 attr1 만 본다.
+        let data = make_para_shape_bytes(3u32 << 25, None);
+        assert_eq!(data.len(), 54);
+        assert_eq!(parse_para_shape(&data).unwrap().para_level, 3);
+    }
+
+    #[test]
+    fn para_shape_edit_path_keeps_outline_level_in_tail() {
+        // [#2734] 실제 손실 경로 재현: 개요 수준이 있는 한컴 레코드를 읽어 raw_data 없이
+        // 다시 직렬화하는 경로(find_or_create_para_shape → ParaShapeMods::apply_to 가
+        // raw_data=None 으로 만든 새 ParaShape)에서 말미 4바이트가 살아남아야 한다.
+        // 종전엔 0 리터럴이라 한컴이 읽는 개요 수준 필드가 매번 1수준으로 리셋됐다.
+        for lvl in 1u32..=6 {
+            let original = make_para_shape_bytes(lvl << 25, Some(lvl));
+            let ps = parse_para_shape(&original).unwrap();
+            let resaved = crate::serializer::doc_info::serialize_para_shape(&ps);
+            assert_eq!(
+                &resaved[54..58],
+                &original[54..58],
+                "개요 {lvl} 수준 레코드 재직렬화 시 말미 4바이트가 보존돼야 함"
+            );
+        }
+    }
+
+    #[test]
+    fn para_shape_outline_level_roundtrips_0_to_9() {
+        // [#2734] 개요 수준 전 범위(1~10수준)가 직렬화→재파싱을 통과해야 한다.
+        // 종전엔 직렬화가 말미 4바이트를 0 리터럴로 써서 모든 수준이 0(1수준)으로 리셋됐다.
+        for lvl in 0u8..=9 {
+            let mut ps = parse_para_shape(&make_para_shape_bytes(0, Some(0))).unwrap();
+            ps.para_level = lvl;
+            let bytes = crate::serializer::doc_info::serialize_para_shape(&ps);
+            assert_eq!(bytes.len(), 58, "58바이트 길이 계약(#1110)은 유지");
+            let back = parse_para_shape(&bytes).unwrap();
+            assert_eq!(back.para_level, lvl, "개요 수준 {lvl} 왕복 보존");
+        }
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -9,6 +9,7 @@ use quick_xml::Reader;
 use crate::model::control::{
     AutoNumber, AutoNumberType, Bookmark, CharOverlap, Control, Equation, Field, FieldType,
     FormObject, FormType, HiddenComment, NewNumber, PageHide, PageNumberPos, Ruby,
+    EQUATION_LINE_MODE_BIT,
 };
 use crate::model::document::{Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
@@ -5319,7 +5320,7 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
 }
 
 /// `<hp:equation>` 요소 (수식)를 파싱한다.
-/// 수식 속성(version, baseLine, textColor, baseUnit, font)과
+/// 수식 속성(version, baseLine, textColor, baseUnit, lineMode, font)과
 /// `<hp:script>` 하위 요소에서 수식 스크립트를 추출하여 `Control::Equation`을 생성한다.
 fn parse_equation(
     e: &quick_xml::events::BytesStart,
@@ -5335,6 +5336,9 @@ fn parse_equation(
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
     let mut font_name = String::new();
+    // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
+    // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
+    let mut eq_attr: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5344,6 +5348,14 @@ fn parse_equation(
             b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(0),
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
+            // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
+            b"lineMode" => {
+                if attr_str(&attr).eq_ignore_ascii_case("LINE") {
+                    eq_attr |= EQUATION_LINE_MODE_BIT;
+                } else {
+                    eq_attr &= !EQUATION_LINE_MODE_BIT;
+                }
+            }
             b"font" => font_name = attr_str(&attr),
             _ => {}
         }
@@ -5423,6 +5435,8 @@ fn parse_equation(
 
     let equation = Equation {
         common,
+        // [#2727] HWPX lineMode → EQEDIT attribute bit0
+        attr: eq_attr,
         script,
         font_size,
         color,

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -2420,7 +2420,9 @@ fn serialize_equation_control(eq: &Equation, level: u16, records: &mut Vec<Recor
     // HWPTAG_EQEDIT 자식 레코드
     let mut w = ByteWriter::new();
     // attr: u32
-    w.write_u32(0).unwrap();
+    // [#2727] 종전 상수 0 하드코딩 → IR 보존값 방출. bit0(수식 범위, HWPX lineMode)
+    // 이 저장마다 CHAR 로 초기화되던 손실 제거.
+    w.write_u32(eq.attr).unwrap();
     // script: HWP string (length-prefixed UTF-16LE)
     w.write_hwp_string(&eq.script).unwrap();
     // font_size: u32

--- a/src/serializer/doc_info.rs
+++ b/src/serializer/doc_info.rs
@@ -657,8 +657,11 @@ pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8> {
         crate::model::style::HeadType::Bullet => 3,
     }) << 23;
     // bits 25-27: para_level
+    // [#2734] 3비트 필드라 6 에서 포화시킨다. 한컴 실측 규약(개요 8~10수준 문단모양 138건이
+    // 모두 attr1 비트 6 + 말미 4바이트 7/8/9)과 동일하다. 종전 `& 0x07` 은 para_level 이
+    // 7 이상일 때 8→0, 9→1 로 엉뚱한 수준을 박는다.
     attr1 &= !(0x07 << 25);
-    attr1 |= (ps.para_level as u32 & 0x07) << 25;
+    attr1 |= (ps.para_level.min(6) as u32) << 25;
     w.write_u32(attr1).unwrap();
     w.write_i32(ps.margin_left).unwrap();
     w.write_i32(ps.margin_right).unwrap();
@@ -684,7 +687,11 @@ pub fn serialize_para_shape(ps: &ParaShape) -> Vec<u8> {
     // 내보낸 정답지들은 PARA_SHAPE를 58바이트로 저장한다. 이 tail이 없으면
     // 한컴 편집기가 일부 masterpage/header 글상자 내부 줄나눔 폭을 다르게
     // 해석해 페이지 번호가 다음 줄로 밀리는 사례가 있다.
-    w.write_u32(0).unwrap();
+    //
+    // [#2734] 이 4바이트의 정체는 개요 수준(0~9 = 1수준~10수준)이다. samples 코퍼스의
+    // 58바이트 레코드 11,913건에서 tail 과 attr1 bit25~27 이 전수 정합하며(포화 138건 제외),
+    // tail != 0 인 872건이 종전 0 리터럴에 덮여 사라졌다. 길이 계약은 그대로 두고 값만 채운다.
+    w.write_u32(ps.para_level.min(9) as u32).unwrap();
     w.into_bytes()
 }
 

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -267,6 +267,34 @@ fn test_serialize_para_shape_roundtrip() {
 }
 
 #[test]
+fn serialize_para_shape_writes_outline_level_into_tail() {
+    // [#2734] 말미 4바이트는 개요 수준(0~9 = 1수준~10수준)이다. 종전엔 0 리터럴이라
+    // 재직렬화되는 모든 문단 모양의 개요 수준이 사라졌다(코퍼스 실측 872건).
+    // attr1 bit25~27 은 3비트라 한컴처럼 6 에서 포화해야 한다.
+    for lvl in 0u8..=9 {
+        let ps = ParaShape {
+            para_level: lvl,
+            ..Default::default()
+        };
+        let data = serialize_para_shape(&ps);
+        assert_eq!(data.len(), 58, "58바이트 길이 계약(#1110) 유지");
+
+        let tail = u32::from_le_bytes([data[54], data[55], data[56], data[57]]);
+        assert_eq!(
+            tail as u8, lvl,
+            "말미 4바이트에 개요 수준 {lvl} 이 실려야 함"
+        );
+
+        let attr1 = u32::from_le_bytes([data[0], data[1], data[2], data[3]]);
+        assert_eq!(
+            (attr1 >> 25) & 0x07,
+            lvl.min(6) as u32,
+            "attr1 bit25~27 은 6 에서 포화(한컴 실측 규약)"
+        );
+    }
+}
+
+#[test]
 fn test_serialize_style_roundtrip() {
     let style = Style {
         raw_data: None,

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -559,6 +559,7 @@ mod tests {
                 horz_align: HorzAlign::Center,
                 ..Default::default()
             },
+            attr: 0,
             script: "x < y & z".to_string(),
             font_size: 1000,
             color: 0x000000FF,

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -23,7 +23,7 @@ use quick_xml::Writer;
 
 use crate::model::control::{
     AutoNumber, AutoNumberType, CharOverlap, Control, Equation, Field, NewNumber, PageHide,
-    PageNumberPos, Ruby,
+    PageNumberPos, Ruby, EQUATION_LINE_MODE_BIT,
 };
 use crate::model::document::{Document, Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
@@ -2096,8 +2096,17 @@ fn render_equation(eq: &Equation) -> String {
     // [#1594] holdAnchorAndSO 는 IR(prevent_page_break)을 보존(종전 "0" 하드코딩 제거).
     let hold = if c.prevent_page_break != 0 { "1" } else { "0" };
 
+    // [#2727] lineMode(수식이 차지하는 범위) 를 EQEDIT attribute bit0 에서 방출한다.
+    // 종전엔 속성 자체를 내보내지 않아 LINE 설정이 왕복마다 CHAR 로 되돌아갔다.
+    // 한컴 저장본과 동일하게 baseUnit 과 font 사이에 위치시킨다.
+    let line_mode = if eq.attr & EQUATION_LINE_MODE_BIT != 0 {
+        "LINE"
+    } else {
+        "CHAR"
+    };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),
@@ -2412,6 +2421,35 @@ mod tests {
         assert!(
             !xml.contains(r#"textFlow="BOTH_SIDES""#),
             "BOTH_SIDES 하드코딩 잔존 금지"
+        );
+    }
+
+    /// [Issue #2727] 수식의 lineMode(수식이 차지하는 범위)가 IR(EQEDIT attribute bit0)에서
+    /// 방출돼야 한다. 종전엔 속성 자체를 내보내지 않아 LINE 설정이 왕복마다 CHAR 로 돌아갔다.
+    /// 한컴 저장본은 값이 기본값(CHAR)이어도 예외 없이 baseUnit 과 font 사이에 기록한다.
+    #[test]
+    fn equation_line_mode_reflects_ir() {
+        use crate::model::control::{Equation, EQUATION_LINE_MODE_BIT};
+
+        let char_xml = render_equation(&Equation::default());
+        assert!(
+            char_xml.contains(r#"lineMode="CHAR""#),
+            "기본값도 lineMode 속성을 방출해야 함(한컴 저장본 정합): {char_xml}"
+        );
+
+        let eq = Equation {
+            attr: EQUATION_LINE_MODE_BIT,
+            font_size: 1000,
+            ..Default::default()
+        };
+        let line_xml = render_equation(&eq);
+        assert!(
+            line_xml.contains(r#"baseUnit="1000" lineMode="LINE" font="""#),
+            "lineMode 는 IR 값으로, 한컴과 같은 baseUnit·font 사이 자리에 와야 함: {line_xml}"
+        );
+        assert!(
+            !line_xml.contains(r#"lineMode="CHAR""#),
+            "CHAR 하드코딩 잔존 금지"
         );
     }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -230,6 +230,73 @@ fn render_note_numbering(shape: &crate::model::footnote::FootnoteShape) -> Strin
     )
 }
 
+/// [#2742] NumberFormat → HWPX `autoNumFormat/@type` 토큰.
+///
+/// 파서 `FootnoteShape::number_format_from_name` 의 UPPER_SNAKE 분기 역매핑이며,
+/// 같은 파일의 `note_line_type_str`·`note_numbering_str` 와 동형이다. 이름이 모델
+/// variant 와 다른 항목(UpperRoman=ROMAN_CAPITAL, HangulDigit=HANGUL_PHONETIC,
+/// HanjaDigit=IDEOGRAPH, HanjaGapEul=DECAGON_CIRCLE, FourSymbol=SYMBOL)은 파서 표기를
+/// 그대로 따른다.
+fn note_number_format_str(format: crate::model::footnote::NumberFormat) -> &'static str {
+    use crate::model::footnote::NumberFormat::*;
+    match format {
+        Digit => "DIGIT",
+        CircledDigit => "CIRCLED_DIGIT",
+        UpperRoman => "ROMAN_CAPITAL",
+        LowerRoman => "ROMAN_SMALL",
+        UpperAlpha => "LATIN_CAPITAL",
+        LowerAlpha => "LATIN_SMALL",
+        CircledUpperAlpha => "CIRCLED_LATIN_CAPITAL",
+        CircledLowerAlpha => "CIRCLED_LATIN_SMALL",
+        HangulSyllable => "HANGUL_SYLLABLE",
+        CircledHangulSyllable => "CIRCLED_HANGUL_SYLLABLE",
+        HangulJamo => "HANGUL_JAMO",
+        CircledHangulJamo => "CIRCLED_HANGUL_JAMO",
+        HangulDigit => "HANGUL_PHONETIC",
+        HanjaDigit => "IDEOGRAPH",
+        CircledHanjaDigit => "CIRCLED_IDEOGRAPH",
+        HanjaGapEul => "DECAGON_CIRCLE",
+        HanjaGapEulHanja => "DECAGON_CIRCLE_HANJA",
+        FourSymbol => "SYMBOL",
+        UserChar => "USER_CHAR",
+    }
+}
+
+/// [#2742] 주석 장식 문자(IR `char`) → HWPX 속성값.
+///
+/// `'\0'` 은 "미지정" 규약이므로(`object_ops/note.rs` 가 `suffix_char == '\0'` 을 기본값
+/// 폴백으로 해석) 템플릿 기본값 `fallback` 을 유지한다. 파싱을 거치지 않은 문서에서
+/// IR 이 0 이면 템플릿 상수를 남기는 `tabStop`/`textDirection` 치환과 같은 패턴이다.
+///
+/// `'\0'` 외의 제어문자(< 0x20)도 같은 폴백으로 보낸다. HWP5 의 장식 문자는 WCHAR 원값이라
+/// 이론상 제어문자가 올 수 있고, 그대로 방출하면 XML 1.0 이 금지하는 문자가 되어 저장본을
+/// 한컴이 열지 못한다. 같은 파일 `render_hp_t_content` 도 `< 0x20` 을 방출 대상에서 뺀다.
+/// (코퍼스 828 note shape 의 장식 문자는 전부 `'\0'` 또는 출력 가능 문자였다.)
+fn note_deco_char_attr(c: char, fallback: &str) -> String {
+    if (c as u32) < 0x20 {
+        fallback.to_string()
+    } else {
+        xml_escape(&c.to_string())
+    }
+}
+
+/// [#2742] FootnoteShape → `<hp:autoNumFormat .../>`.
+/// 속성 순서는 템플릿·한컴 실물과 같이 type → userChar → prefixChar → suffixChar → supscript.
+fn render_auto_num_format(shape: &crate::model::footnote::FootnoteShape) -> String {
+    format!(
+        r#"<hp:autoNumFormat type="{}" userChar="{}" prefixChar="{}" suffixChar="{}" supscript="{}"/>"#,
+        note_number_format_str(shape.number_format),
+        note_deco_char_attr(shape.user_char, ""),
+        note_deco_char_attr(shape.prefix_char, ""),
+        note_deco_char_attr(shape.suffix_char, ")"),
+        u8::from(shape.number_code_superscript),
+    )
+}
+
+/// [#2742] 템플릿의 하드코딩 autoNumFormat — 각주/미주 두 슬롯의 문자열이 동일하다.
+const TEMPLATE_AUTO_NUM_FORMAT: &str =
+    r#"<hp:autoNumFormat type="DIGIT" userChar="" prefixChar="" suffixChar=")" supscript="0"/>"#;
+
 /// `needle` 의 처음 두 출현을 각각 `first`/`second` 로 치환한다. 치환 결과가 needle
 /// 과 같아도 안전하다(연쇄 replacen 은 replacement==needle 일 때 두 번째가 첫 슬롯을
 /// 다시 잡는 버그가 있어 각주/미주 numbering 처럼 fn/en 템플릿 문자열이 동일한 경우
@@ -248,6 +315,19 @@ fn replace_first_two(haystack: &str, needle: &str, first: &str, second: &str) ->
 /// 갈린다(1543000: 각주 overhead 32.83→19.39px → p141 표 1행/3행 → 192/190쪽). 파서는
 /// 값을 FootnoteShape 로 수집하나 직렬화가 템플릿 상수만 방출하던 결함.
 fn replace_footnote_shape(xml: &str, sd: &SectionDef) -> String {
+    // [#2742] 번호 모양·사용자 기호·앞/뒤 장식 문자·위첨자. 파서는 HWPX(autoNumFormat)와
+    // HWP5(FOOTNOTE_SHAPE attr) 양쪽에서 이 5필드를 FootnoteShape 로 읽지만 직렬화가
+    // 템플릿 상수만 방출해, 저장할 때마다 구역 각주/미주 모양이 한컴 기본값으로 리셋됐다.
+    // 새 주석 삽입은 이 모양을 기본값으로 쓰므로(object_ops/note.rs) 저장본에서는 미주가
+    // 「문1）」 대신 「1)」로 매겨진다(실측: 코퍼스 330파일 중 18파일 · note shape 19개).
+    // 각주/미주 템플릿 문자열이 완전히 같아 연쇄 replacen 은 두 번째 슬롯을 못 잡는다 —
+    // numbering 과 같은 사유로 위치 기반 2회 치환을 쓴다.
+    let xml = replace_first_two(
+        xml,
+        TEMPLATE_AUTO_NUM_FORMAT,
+        &render_auto_num_format(&sd.footnote_shape),
+        &render_auto_num_format(&sd.endnote_shape),
+    );
     // 템플릿: 첫 noteLine(length="-1")·noteSpacing(betweenNotes="283") = 각주,
     // 둘째(length="14692344"·betweenNotes="0") = 미주.
     let (fn_line, fn_spacing) = render_note_line_spacing(&sd.footnote_shape);
@@ -2629,6 +2709,71 @@ mod tests {
         assert!(
             !xml.contains(r#"<hp:numbering type="CONTINUOUS" newNum="1"/>"#),
             "템플릿 기본 numbering 잔존 금지"
+        );
+    }
+
+    #[test]
+    fn issue2742_auto_num_format_reflects_ir() {
+        // [#2742] footNotePr/endNotePr 의 autoNumFormat 5속성(type·userChar·prefixChar·
+        // suffixChar·supscript)이 템플릿 상수가 아니라 IR FootnoteShape 값으로 방출돼야
+        // 한다. 미치환 시 구역 각주/미주 모양이 저장마다 한컴 기본값으로 리셋돼, 실측
+        // 코퍼스에서 미주 장식문자 「문…）」(17파일)와 위첨자 설정(1파일)이 사라졌다.
+        // fn/en 템플릿 문자열이 동일하므로 위치 기반 치환이 각 슬롯을 정확히 채우는지도
+        // 함께 검증한다.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, mut section) = make_doc_with_paragraph(para);
+        let fs = &mut section.section_def.footnote_shape;
+        fs.number_format = crate::model::footnote::NumberFormat::CircledDigit;
+        fs.number_code_superscript = true;
+        let es = &mut section.section_def.endnote_shape;
+        es.number_format = crate::model::footnote::NumberFormat::UserChar;
+        es.user_char = '★';
+        es.prefix_char = '문';
+        es.suffix_char = '）'; // U+FF09 전각 — 한컴 실물 표기
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(
+                r#"<hp:autoNumFormat type="CIRCLED_DIGIT" userChar="" prefixChar="" suffixChar=")" supscript="1"/>"#
+            ),
+            "각주 autoNumFormat 이 IR 값이어야 함: {}",
+            &xml[..xml
+                .find("footNotePr")
+                .map(|i| i + 200)
+                .unwrap_or(600)
+                .min(xml.len())]
+        );
+        assert!(
+            xml.contains(
+                r#"<hp:autoNumFormat type="USER_CHAR" userChar="★" prefixChar="문" suffixChar="）" supscript="0"/>"#
+            ),
+            "미주 autoNumFormat 이 IR 값이어야 함(장식문자 보존)"
+        );
+        assert!(
+            !xml.contains(TEMPLATE_AUTO_NUM_FORMAT),
+            "템플릿 기본 autoNumFormat 잔존 금지"
+        );
+    }
+
+    #[test]
+    fn issue2742_auto_num_format_keeps_template_when_ir_unset() {
+        // 파싱을 거치지 않은 기본 SectionDef(number_format=Digit, 장식문자 '\0',
+        // supscript=false)에서는 템플릿과 바이트 동일해야 한다 — '\0' = 미지정 규약.
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        let (doc, section) = make_doc_with_paragraph(para);
+        assert_eq!(
+            section.section_def.endnote_shape.suffix_char, '\0',
+            "전제: 기본 장식문자는 '\\0'"
+        );
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert_eq!(
+            xml.matches(TEMPLATE_AUTO_NUM_FORMAT).count(),
+            2,
+            "IR 미설정 시 각주/미주 모두 템플릿 문자열 유지: {xml:.900}"
         );
     }
 

--- a/tests/issue_2727_equation_line_mode.rs
+++ b/tests/issue_2727_equation_line_mode.rs
@@ -1,0 +1,135 @@
+//! Issue #2727: 수식 EQEDIT attribute(UINT32) 왕복 보존 회귀 가드.
+//!
+//! 정정 전 동작:
+//! - `src/parser/control.rs::parse_equation_control` 이 EQEDIT 선두 UINT32 를
+//!   `let _attr = ...` 로 버렸다.
+//! - `src/serializer/control.rs::serialize_equation_control` 이 같은 자리에 상수 `0` 을 썼다.
+//! - `src/parser/hwpx/section.rs::parse_equation` 이 `lineMode` 를 읽지 않았고,
+//!   `src/serializer/hwpx/section.rs::render_equation` 이 `lineMode` 를 방출하지 않았다.
+//!
+//! 그 결과 수식의 "차지하는 범위"(HWP5 표 105 attribute bit0 = HWPX `lineMode`)가
+//! HWP5→HWP5 / HWP5→HWPX / HWPX→HWP5 / HWPX→HWPX 네 경로 전부에서 CHAR(0) 로 초기화됐다.
+//!
+//! 본 파일은 한컴이 만든 실제 저장본(`samples/수식-문자처럼취급-아님.hwp`)을 입력으로
+//! 삼아 (1) LINE 설정이 왕복에서 살아남는지, (2) 원본 CHAR 문서가 그대로 CHAR 로
+//! 남는지(정답지 무변경)를 동시에 단언한다.
+
+use rhwp::model::control::{Control, Equation, EQUATION_LINE_MODE_BIT};
+use rhwp::model::document::Document;
+use std::fs;
+use std::path::Path;
+
+const HANCOM_EQUATION_HWP: &str = "samples/수식-문자처럼취급-아님.hwp";
+
+fn load_hwp(rel: &str) -> Document {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join(rel);
+    let bytes = fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", rel, e));
+    rhwp::parse_document(&bytes).unwrap_or_else(|e| panic!("parse {}: {:?}", rel, e))
+}
+
+fn first_equation(doc: &Document) -> &Equation {
+    doc.sections
+        .iter()
+        .flat_map(|s| &s.paragraphs)
+        .flat_map(|p| &p.controls)
+        .find_map(|c| match c {
+            Control::Equation(eq) => Some(eq.as_ref()),
+            _ => None,
+        })
+        .expect("문서에 수식 컨트롤이 있어야 한다")
+}
+
+fn set_first_equation_line_mode(doc: &mut Document) {
+    let mut done = false;
+    for section in &mut doc.sections {
+        // 원본 구역 스트림이 남아 있으면 직렬화기가 원본 바이트를 그대로 되돌려주므로
+        // IR 편집이 저장에 반영되지 않는다. 실제 편집 API(set_equation_properties_native 등)
+        // 와 동일하게 패스스루를 무효화한다.
+        section.raw_stream = None;
+        for para in &mut section.paragraphs {
+            for ctrl in &mut para.controls {
+                if let Control::Equation(eq) = ctrl {
+                    eq.attr |= EQUATION_LINE_MODE_BIT;
+                    done = true;
+                }
+            }
+        }
+    }
+    assert!(done, "수식 컨트롤을 찾지 못했다");
+}
+
+/// HWP5 → HWP5: 수식 범위 LINE(attribute bit0)이 저장·재적재 후에도 남아야 한다.
+#[test]
+fn issue_2727_hwp5_line_mode_survives_roundtrip() {
+    let mut doc = load_hwp(HANCOM_EQUATION_HWP);
+    set_first_equation_line_mode(&mut doc);
+
+    let bytes = rhwp::serialize_document(&doc).expect("HWP5 직렬화");
+    let re_doc = rhwp::parse_document(&bytes).expect("HWP5 재파싱");
+
+    let eq = first_equation(&re_doc);
+    assert_eq!(
+        eq.attr & EQUATION_LINE_MODE_BIT,
+        EQUATION_LINE_MODE_BIT,
+        "EQEDIT attribute bit0(수식 범위 LINE)이 HWP5 왕복에서 보존돼야 한다. attr=0x{:08X}",
+        eq.attr
+    );
+}
+
+/// HWP5 → HWPX → IR: `lineMode="LINE"` 로 방출되고 다시 bit0 으로 읽혀야 한다.
+#[test]
+fn issue_2727_hwpx_line_mode_survives_roundtrip() {
+    let mut doc = load_hwp(HANCOM_EQUATION_HWP);
+    set_first_equation_line_mode(&mut doc);
+
+    let bytes = rhwp::serializer::hwpx::serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let re_doc = rhwp::parser::hwpx::parse_hwpx(&bytes).expect("HWPX 재파싱");
+
+    let eq = first_equation(&re_doc);
+    assert_eq!(
+        eq.attr & EQUATION_LINE_MODE_BIT,
+        EQUATION_LINE_MODE_BIT,
+        "HWPX lineMode=\"LINE\" 이 왕복에서 보존돼야 한다. attr=0x{:08X}",
+        eq.attr
+    );
+}
+
+/// 한컴 원본(수식 범위 CHAR)은 정정 후에도 CHAR 그대로여야 한다 — 말뭉치 무변경 보장.
+#[test]
+fn issue_2727_hancom_char_equation_stays_char() {
+    let doc = load_hwp(HANCOM_EQUATION_HWP);
+    assert_eq!(
+        first_equation(&doc).attr,
+        0,
+        "한컴 원본 EQEDIT attribute 는 0(CHAR)이어야 한다"
+    );
+
+    let hwp_bytes = rhwp::serialize_document(&doc).expect("HWP5 직렬화");
+    let hwp_doc = rhwp::parse_document(&hwp_bytes).expect("HWP5 재파싱");
+    assert_eq!(
+        first_equation(&hwp_doc).attr,
+        0,
+        "CHAR 수식은 HWP5 왕복 후에도 attribute 0 이어야 한다"
+    );
+
+    let hwpx_bytes = rhwp::serializer::hwpx::serialize_hwpx(&doc).expect("HWPX 직렬화");
+    let hwpx_doc = rhwp::parser::hwpx::parse_hwpx(&hwpx_bytes).expect("HWPX 재파싱");
+    assert_eq!(
+        first_equation(&hwpx_doc).attr,
+        0,
+        "CHAR 수식은 HWPX 왕복 후에도 attribute 0 이어야 한다"
+    );
+}
+
+/// 한컴 원본 HWPX(`lineMode="CHAR"`)를 그대로 읽으면 bit0 이 서지 않아야 한다.
+#[test]
+fn issue_2727_hancom_hwpx_char_parses_as_zero_bit() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/수식-문자처럼취급-아님.hwpx");
+    let bytes = fs::read(&path).expect("한컴 원본 HWPX 읽기");
+    let doc = rhwp::parser::hwpx::parse_hwpx(&bytes).expect("HWPX 파싱");
+    assert_eq!(
+        first_equation(&doc).attr & EQUATION_LINE_MODE_BIT,
+        0,
+        "lineMode=\"CHAR\" 는 bit0 clear 여야 한다"
+    );
+}


### PR DESCRIPTION
kevin9327 님의 #2744·#2754·#2772·#2749 를 메인테이너가 재실증 후 통합한다.

## 채택
- **#2744** (`Closes #2727`) — 수식 `HWPTAG_EQEDIT` 선두 UINT32(HWP5 표 105 attribute)가 파서에서 버려지고 직렬화기가 상수 0 으로 덮어써, HWPX `lineMode` 가 저장마다 `CHAR` 로 고정됐다.
- **#2754** (`Closes #2734`) — `PARA_SHAPE` 말미 4바이트(개요 수준)를 파싱하지 않고 0 으로 하드코딩해, **문단 서식을 한 번 편집하면 개요 수준이 리셋**되고 8~10 수준은 읽기부터 붕괴했다.
- **#2772** (`Closes #2742`) — secPr 은 정적 템플릿을 `replacen` 으로 부분 치환해 만들어, 앵커가 걸린 속성만 IR 을 받고 나머지는 템플릿 상수로 고정 방출된다. 템플릿 속성 슬롯 **103개를 전수 분류**(IR반영 76 / 고정 15 / 결함 12)한 뒤 실측 손실이 큰 `autoNumFormat` 10슬롯을 고쳤다.
- **#2749** (`Closes #2736`) — HWPX→HWP 변환 워크가 그림·도형 캡션 문단을 방문하지 않아 캡션 안의 href·borderFill 참조가 재매핑되지 않았다.

## 검증
- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- red→green: #2727 1 FAIL / #2734 2 FAIL / #2742 2 FAIL — 복원 시 전부 통과.
  #2736 은 무력화 패치가 컴파일에 실패해 red 를 확보하지 못했다(테스트 부재가 아니라 재현 방식의 한계).

## 함께 정리한 중복
- **#2760** — #2772 와 같은 이슈(#2742)·같은 결함. #2772 가 슬롯 전수 분류를 포함한 상위집합이라 그쪽을 채택했다.

## 분리 처리
- **#2739**(공용 도형 경로 `hp:sz`)·**#2746**(`hp:pic` numberingType/groupLevel)은 이번 merge 로 들어간 #2719·#2728 과 인접 라인 충돌이 나 후속 통합으로 옮긴다. 중복이 아니다.

Co-authored-by 로 원 커밋 provenance 를 보존한다.