### PR TITLE
fix(parser): 무검증 할당 2건 — 표 그리드 68GB·HML 리소스 Id 선형 비례 (#2722, #2743)

### DIFF
--- a/mydocs/report/task_m100_2722_report.md
+++ b/mydocs/report/task_m100_2722_report.md
@@ -1,0 +1,266 @@
+# task_m100_2722 처리결과 보고서 — 표 그리드 재구축 무한 할당 차단
+
+- **이슈**: [#2722](https://github.com/edwardkim/rhwp/issues/2722)
+- **브랜치**: `task/m100-2722-parser-robustness` (base `origin/devel` @ `49f38446`)
+- **범위**: `src/model/table.rs`, `tests/issue_2722_table_grid_alloc.rs`
+- **분류**: 결함 수정 (malformed 입력에 대한 파서 robustness — 무검증 할당)
+
+## 1. 문제
+
+`Table::rebuild_grid()` (`src/model/table.rs:513-516`, 수정 전) 이 파일에서 그대로 온
+`row_count`/`col_count` 를 검증 없이 곱해 그리드를 예약했다.
+
+```rust
+pub fn rebuild_grid(&mut self) {
+    let rc = self.row_count as usize;
+    let cc = self.col_count as usize;
+    self.cell_grid = vec![None; rc * cc];   // 상한 없음
+    for (idx, cell) in self.cells.iter().enumerate() {
+        ...
+                if gi < self.cell_grid.len() {   // 쓰기에는 가드가 이미 있었다
+```
+
+두 필드 모두 `u16` 이므로 최대 곱은 `65535 × 65535 = 4,294,836,225` 칸이고,
+원소 `Option<usize>` 가 x86_64 에서 16바이트이므로 **68,717,379,600 바이트(약 64 GiB)**
+예약을 시도한다. `Vec` 은 할당 실패를 `Err` 로 돌려주지 않고 `handle_alloc_error` →
+`abort()` 로 프로세스를 죽인다. `catch_unwind` 로도 잡히지 않는다.
+
+`rebuild_grid()` 는 HWPX·HWP5·HML·HWP3 네 파서가 전부 지나는 **단일 chokepoint** 다.
+
+| 포맷 | 값 출처 | `rebuild_grid()` 호출 | 파일이 직접 지정? |
+|---|---|---|---|
+| HWPX | `src/parser/hwpx/section.rs:1601-1602` (`rowCnt`/`colCnt` XML 속성) | `section.rs:1840` | 예 |
+| HWP5 | `src/parser/control.rs:262-263` (`HWPTAG_TABLE` `read_u16()`) | `control.rs:244` | 예 |
+| HML | `src/parser/hml/reader.rs:786-787` (`RowCount`/`ColCount`) | `hml/adapter.rs:262` | 예 |
+| HWP3 | `src/parser/hwp3/mod.rs:680-688` (셀 좌표 집합에서 **유도**) | `hwp3/mod.rs:818` | 아니오 |
+
+`if gi < self.cell_grid.len()` 가드가 **루프 안쪽에는 이미 있었다**는 점이 이 결함의
+성격을 보여준다 — 인덱스는 의심했으나 그보다 먼저 실행되는 할당 크기는 검증 대상에서
+빠져 있었다.
+
+## 2. 분석
+
+### 2.1 상위 경계가 막지 못하는 이유
+
+- `row_count`/`col_count` 는 셀 데이터와 독립된 스칼라다. HWPX 는 4~5바이트 XML 속성,
+  HWP5 는 `HWPTAG_TABLE` 안의 2바이트 필드 2개다. `record.rs` 의 레코드 크기 검사를
+  완벽히 통과한다 — **입력 크기와 할당 크기 사이에 비례관계가 전혀 없다**.
+- `HmlLimits` (`src/parser/hml/reader.rs:39-54`) 는 XML 바이트·깊이·속성 수·텍스트
+  길이만 본다. 아래 250바이트 입력은 어떤 상한에도 걸리지 않는다.
+- ZIP 폭탄 방어와도 무관하다. 2.3 재현은 압축률을 건드리지 않은 정상 ZIP 이다.
+- `cells` 가 비어 있어도 무관하다. 그리드 크기는 선언된 행·열 수에만 의존한다.
+
+### 2.2 같은 클래스를 이미 막고 있는 대조 지점
+
+저장소는 "파일에서 온 count/size 를 할당 인자로 쓰기 전 상한" 정책을 이미 구현하고 있다.
+표 그리드만 누락이었다.
+
+| 지점 | 방식 | 주석이 밝힌 종전 규모 |
+|---|---|---|
+| `src/parser/record.rs:59-73` | `checked_add` + 경계 검사 | wasm32 랩어라운드 → 4GB |
+| `src/parser/doc_info.rs:652-658` | `.min(r.remaining() / 8)` | ~34GB |
+| `src/parser/control/shape.rs:980-985` | `.min(r.remaining() / 10)` | ~51GB |
+| `src/parser/hwp3/mod.rs:60-78` | `check_record_count()` (#877, 256 MiB) | 3.69GB |
+
+표 그리드의 **68GB** 는 이 중 최대이며, 유일하게 네 포맷 공통 경로다.
+
+### 2.3 wasm32 관점
+
+wasm32 는 `usize` 가 32비트다.
+
+- `rc * cc = 4,294,836,225` 는 `u32::MAX = 4,294,967,295` 보다 **131,070 작다**. 곱셈
+  자체는 아슬아슬하게 랩어라운드하지 않는다(만약 두 필드가 `u32` 였다면 `record.rs:59-73`
+  과 동일한 랩어라운드 형태가 됐을 것이다).
+- 그러나 `Layout::array::<Option<usize>>(4_294_836_225)` 는 `× 8 = 34,358,689,800` 으로
+  32비트 `usize` 를 넘겨 `capacity overflow` **패닉**이 된다. wasm 에서 패닉은
+  `unreachable` 트랩이므로 **모듈 인스턴스 전체가 사용 불능**이 된다.
+
+## 3. 변경
+
+`src/model/table.rs` 한 파일, 3개 변경.
+
+1. **상한 상수 신설** (`table.rs:7-14`)
+   ```rust
+   pub const MAX_TABLE_GRID_CELLS: usize = 4_000_000;
+   ```
+   실측 근거는 4.4 참조 (정상 문서 최댓값의 75.8배).
+
+2. **`rebuild_grid()` 에 가드** (`table.rs:531-545`)
+   ```rust
+   let requested = rc.saturating_mul(cc);
+   let grid_len = if requested > MAX_TABLE_GRID_CELLS {
+       self.addressed_grid_len(cc).min(MAX_TABLE_GRID_CELLS).min(requested)
+   } else {
+       requested
+   };
+   self.cell_grid = vec![None; grid_len];
+   ```
+   `requested <= MAX_TABLE_GRID_CELLS` 이면 `grid_len == rc * cc` 로 **종전 식과 동일**.
+   분기 자체가 실행되지 않는다.
+
+3. **`addressed_grid_len()` 신설** (`table.rs:558-578`)
+   셀이 실제로 가리키는 마지막 그리드 인덱스 + 1 을 `saturating_*` 로만 계산한다.
+   셀 0개면 0. 상한만 걸 경우 표 하나당 최대 64 MiB 를 여전히 허용해 "빈 표를 여러 개"
+   변형이 남는데, 이 축소를 먼저 적용하면 그 여지가 사라진다.
+
+### 3.1 설계 선택 근거
+
+- **`row_count`/`col_count` 는 건드리지 않는다.** 모델 필드를 변형하면 직렬화·라운드트립
+  계약에 영향이 갈 수 있다. 길이만 줄이고 `col_count`(stride)는 그대로 두므로
+  `cell_index_at()`/`cell_at()` 은 범위 안 셀을 정확히 그대로 조회하고, 범위 밖은
+  `Vec::get()` 이 `None` 을 준다 — 루프 안쪽 기존 가드와 동일한 의미다.
+- **검토 후 채택하지 않은 안**: (a) `row_count`/`col_count` 를 셀이 쓰는 범위로 낮추기 —
+  단일 셀이 `row_span=65535, col_span=65535` 를 선언하면 축소 목표가 다시 65535×65535 가
+  되어 결국 하드 상한이 어차피 필요하다. (b) `rebuild_grid()` 를 `Result` 로 변경 —
+  호출처가 4개 파서 + 편집 명령 다수라 전면 수정이 필요하고, 손상된 표 하나로 문서 전체
+  파싱을 실패시키는 것은 기존 `unwrap_or(0)` graceful 파싱 방침과 어긋난다.
+
+## 4. 검증
+
+빌드 환경: `cargo test --profile release-test` (릴리스 최적화, `overflow-checks` 없음).
+
+### 4.1 신규 테스트 — `tests/issue_2722_table_grid_alloc.rs` (4개)
+
+| 테스트 | 내용 |
+|---|---|
+| `rebuild_grid_bounds_hostile_row_col_count` | 셀 0개 65535×65535 → 그리드 0칸, `row_count`/`col_count` 는 65535 그대로 |
+| `rebuild_grid_bounds_hostile_counts_with_one_cell` | (0,0) 셀 1개 65535×65535 → 그리드 1칸, 앵커 인덱스 보존 |
+| `hml_table_with_hostile_counts_parses_without_abort` | 250바이트 HML(`RowCount="65535" ColCount="65535"`) → `Ok`, 그리드 상한 이하 |
+| `normal_table_grid_size_is_unchanged` | 정상 3×4 표 → 그리드 정확히 12칸, 12칸 전부 조회 성공 |
+
+### 4.2 red→green 실증 (실제 실행 · 캡처 원문)
+
+**RED** — `rebuild_grid()` 의 가드를 종전 `self.cell_grid = vec![None; rc * cc];` 로
+되돌리고 동일 테스트 실행:
+
+```
+running 4 tests
+memory allocation of 68717379600 bytes failed
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+test normal_table_grid_size_is_unchanged ... error: test failed, to rerun pass `--test issue_2722_table_grid_alloc`
+
+Caused by:
+  process didn't exit successfully: `C:\Users\swsz9\Downloads\moneyflow\rhwp-wt-g\target\release-test\deps\issue_2722_table_grid_alloc-4b9540f9bd1bc640.exe` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
+note: test exited abnormally; to see the full output pass --no-capture to the harness.
+```
+
+**이것은 일반적인 테스트 실패가 아니다.** `0xC0000409` 는 Windows 에서 Rust `abort()` 가
+보고되는 코드이며, 정상 표만 검사하는 `normal_table_grid_size_is_unchanged` 조차 진행 중
+함께 죽었다 — 바이너리 전체가 사망한다.
+
+**GREEN** — 가드를 복원하고 동일 명령 재실행:
+
+```
+running 4 tests
+test rebuild_grid_bounds_hostile_row_col_count ... ok
+test normal_table_grid_size_is_unchanged ... ok
+test rebuild_grid_bounds_hostile_counts_with_one_cell ... ok
+test hml_table_with_hostile_counts_parses_without_abort ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+### 4.3 추가 실측 — 실제 한컴 HWPX (커밋하지 않은 임시 재현)
+
+`samples/3-09월_교육_통합_2022.hwpx` (4,113,254 바이트) 의 `Contents/section0.xml` 에서
+**첫 번째 `<hp:tbl>` 태그의 속성 2개만** 바꾸고 ZIP 재패킹:
+
+```
+before: <hp:tbl id="1587285471" ... repeatHeader="1" rowCnt="2"     colCnt="4"     ...
+after : <hp:tbl id="1587285471" ... repeatHeader="1" rowCnt="65535" colCnt="65535" ...
+```
+
+수정 전 `rhwp::parser::parse_document()`:
+
+```
+hwpx bytes = 4113254
+memory allocation of 68717379600 bytes failed
+...
+  process didn't exit successfully: `...\wtg_repro_tblgrid-91198fa859c6fda8.exe --nocapture --exact repro_hwpx_patched` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
+```
+
+수정 후 동일 파일:
+
+```
+hwpx bytes = 4113254
+hwpx parse ok = true
+test repro_hwpx_patched ... ok
+```
+
+이 재현 파일은 스크래치 경로에 의존하므로 회귀 가드로 커밋하지 않았다. 커밋된 가드는
+경로 의존이 없는 4.1 의 4개다.
+
+### 4.4 상한값 실측 근거
+
+`samples/` 전수 조사(중첩 표 포함, 이번 작업 중 직접 실행):
+
+```
+SURVEY files_parsed=343 tables=5353
+SURVEY max_cells=52770 max_row_count=5277 max_col_count=10 file=issue2063_huge_cellbreak_table.hwp
+```
+
+- 실제 문서 5,353개 표 중 `row_count × col_count` 최댓값 **52,770** (5,277행 × 10열).
+  파일명부터 `huge_cellbreak_table` 인 극단 케이스다.
+- 상한 `4,000,000` 은 실측 최댓값의 **75.8배**. 정상 문서는 상한 분기에 닿지 않으므로
+  **동작이 비트 단위로 불변**이다.
+- 최악의 경우 예약량은 `4,000,000 × 16B = 64 MiB` (wasm32 는 8B → 32 MiB).
+
+### 4.5 CI 3종 (실측 결과)
+
+| 검사 | 명령 | 결과 |
+|---|---|---|
+| clippy | `cargo clippy --all-targets -- -D warnings` | **exit 0** (`Finished dev profile`) |
+| 테스트 | `cargo test --profile release-test --tests` | **exit 0** — 테스트 타깃 292개 전부 `ok`, `FAILED` 0개, 합계 **3,484 passed / 0 failed / 23 ignored** |
+| fmt | 변경 파일에 `rustfmt --edition 2021` 적용 후 재적용 시 md5 불변 확인 | **IDEMPOTENT** (두 파일 모두 해시 동일) |
+
+테스트 타깃별 주요 결과:
+
+```
+unittests src\lib.rs          ok. 2464 passed; 0 failed; 7 ignored
+issue_2722_table_grid_alloc   ok. 4 passed; 0 failed; 0 ignored     ← 신규
+hwp5_roundtrip_baseline       ok. 3 passed; 0 failed; 0 ignored
+hwpx_roundtrip_baseline       ok. 4 passed; 0 failed; 0 ignored
+hwpx_roundtrip_integration    ok. 22 passed; 0 failed; 0 ignored
+hwpx_form_roundtrip           ok. 1 passed; 0 failed; 0 ignored
+hml_parser                    ok. 34 passed; 0 failed; 0 ignored
+hml_serializer                ok. 30 passed; 0 failed; 0 ignored
+visual_roundtrip_baseline     ok. 3 passed; 0 failed; 0 ignored
+```
+
+fmt 는 지시대로 `cargo fmt --all -- --check` 를 쓰지 않았다 — 이 Windows 체크아웃에서는
+CRLF 파일에 대해 `Incorrect newline style` 만 출력하고 diff 를 내지 않아 **거짓 통과**가
+된다. 대신 write 모드 `rustfmt` 를 적용한 뒤 재적용해도 md5 가 변하지 않음을 확인했다
+(`src/model/table.rs` = `de5a2111...`, `tests/issue_2722_table_grid_alloc.rs` = `a9fdc62c...`).
+
+### 4.6 정상 파일 불변 확인
+
+- 4.4 실측대로 정상 문서 최대치(52,770)는 상한(4,000,000)의 1/75.8 이므로 새 분기가
+  **실행되지 않는다**. `grid_len == rc * cc` 로 종전 식과 동일하다.
+- `tests/` 의 실파일 라운드트립 가드가 **전부 통과**했다 — `hwp5_roundtrip_baseline` 3,
+  `hwpx_roundtrip_baseline` 4, `hwpx_roundtrip_integration` 22, `hwpx_form_roundtrip` 1,
+  `hml_serializer` 30, `hml_parser` 34, `visual_roundtrip_baseline` 3 (모두 0 failed).
+  즉 정상 파일의 파싱→직렬화 왕복 바이트와 시각 baseline 이 종전과 동일하다.
+- `row_count`/`col_count` 를 변형하지 않으므로 직렬화 입력은 파싱 결과 그대로다.
+
+## 5. 미실행 항목 (투명 고지)
+
+- **HWP5 (`.hwp`) 는 코드 확인만 했고 실측하지 않았다.** `src/parser/control.rs:262-263`
+  이 `HWPTAG_TABLE` 에서 `read_u16()` 두 개를 그대로 대입하고 `:244` 에서
+  `rebuild_grid()` 를 호출하므로 경로는 HWPX·HML 과 동일하지만, CFB + deflate 스트림을
+  편집할 도구가 없어 악성 바이트를 실제로 만들지 못했다. **HWP5 에서 재현했다고 주장하지
+  않는다.**
+- HWP3 는 `row_count`/`col_count` 가 셀 좌표 집합에서 유도되므로 파일이 임의값을 직접
+  지정할 수 없다 — 재현 시도 대상에서 제외했다.
+- wasm32 실기 실행은 하지 않았다. 2.3 의 wasm32 서술은 `usize` 폭과 `Layout::array` 의
+  산술로부터 도출한 것이며, 관측이 아니다.
+
+## 6. 잔여 (범위 밖)
+
+이슈 #2722 의 7장과 동일. 각각 별도 이슈감이며 이번 PR 에서 건드리지 않았다.
+
+| # | 지점 | 내용 | 이번에 손대지 않는 이유 |
+|---|---|---|---|
+| 1 | `src/serializer/hml/body.rs:422`, `src/serializer/hwpx/table.rs:104` | `for row in 0..table.row_count` 중첩 루프 — 손상된 표가 파싱을 통과하면 저장 시 약 43억 회 반복 → 사실상 hang | 저장 경로 결함으로 원인이 다르다. 본 수정은 abort 제거(문서를 열 수 있게 하는 것)에 한정 |
+| 2 | `src/model/table.rs` 채우기 루프 `cell.row..(cell.row + cell.row_span)` | `u16` 덧셈 오버플로. `release-test` 는 `overflow-checks` 가 꺼져 wrap 하고 `if gi < len` 가드가 막지만 debug 빌드에서는 패닉 | `release-test` 에서 관측 불가라 red→green 으로 증명할 수 없다 |
+| 3 | `src/parser/hml/reader.rs:1504` `set_indexed()` | HML `Id` 속성이 `Vec::resize_with` 크기를 직접 지정 | 별도 결함 클래스(인덱스 상한 부재). 별도 이슈로 분리 |
+| 4 | HWP5 실측 | 5장 참조 | CFB+deflate 편집 도구 부재 |

--- a/mydocs/report/task_m100_2743_report.md
+++ b/mydocs/report/task_m100_2743_report.md
@@ -1,0 +1,281 @@
+# task_m100_2743 처리결과 보고서 — HML 리소스 Id 할당 상한
+
+- **이슈**: [#2743](https://github.com/edwardkim/rhwp/issues/2743)
+- **브랜치**: `task/m100-2743-hml-resource-id-limit` (base `origin/devel` @ `1658d0bb`)
+- **범위**: `src/parser/hml/reader.rs`, `tests/issue_2743_hml_resource_id_limit.rs`
+- **분류**: 결함 수정 (malformed 입력에 대한 파서 robustness — 무검증 할당)
+
+## 1. 문제
+
+HML 리더의 `set_indexed()` 가 파일에서 온 `Id` 를 검증 없이 `resize_with(index + 1, ..)`
+에 넘겨, 리소스 테이블 예약 크기가 `Id` 값에 선형 비례했다.
+
+```rust
+fn set_indexed<T: Default>(values: &mut Vec<T>, index: usize, value: T) {
+    if values.len() <= index {
+        values.resize_with(index + 1, T::default);   // index 는 파일에서 온 값
+    }
+    values[index] = value;
+}
+```
+
+여섯 개 호출부가 전부 `parse_attribute::<usize>(element, b"Id")?` 결과를 그대로 넘긴다:
+`FONT`, `BORDERFILL`, `CHARSHAPE`, `PARASHAPE`, `TABDEF`, `STYLE`.
+
+### 1.1 #2722 와 다른 점 — **조용한 구간**이 따로 있다
+
+| 입력 | 결과 | 종료 코드 |
+|---|---|---|
+| 382바이트, `CHARSHAPE Id="1000000"` | 힙 최대 **120,009,531 바이트** 예약 | **0 — 오류·경고 없음** |
+| 385바이트, `CHARSHAPE Id="2000000000"` | `memory allocation of 240000000120 bytes failed` → abort | `0xC0000409` |
+
+전자는 `parse_hml` 이 `Ok` 를 반환한다. 호출자가 정상 문서와 구별할 방법이 없었다.
+이 결함의 본질은 abort 가 아니라 **이 조용함**이다.
+
+### 1.2 같은 함수 안의 대조
+
+`capture_border_fill` 은 같은 `Id` 속성에 대해 **너무 작은** 값(`Id=0`)은 하드 `Err` 로
+거부하면서, `Id=2000000000` 은 그대로 통과시켜 240 GB 를 요구했다. 경계 검사가 한 방향만
+있었다.
+
+### 1.3 상한 기구는 이미 있었다
+
+`HmlLimits` 는 `max_xml_bytes`/`max_depth`/`max_attributes`/`max_text_node_bytes` 네 개를
+갖고 있으나 전부 **입력 크기** 상한이고 **인덱스(할당 크기) 상한이 없었다**. 재현 입력은
+382바이트 / 깊이 6 / 속성 2개로 네 상한 전부의 한참 아래다.
+
+## 2. 변경
+
+`src/parser/hml/reader.rs` 한 파일 (92 insertions, 9 deletions).
+
+1. **`HmlLimits::max_resource_id` 신설** (`:58`, 기본값 `65_535` at `:68`) — 새 기구를
+   만들지 않고 이미 있는 상한 구조체에 필드 하나를 더했다.
+2. **`set_indexed` 가 상한을 받아 `bool` 반환** (`:1583`) — 초과 시 **아무것도 할당하지
+   않고** `false`. 상한 이하에서는 종전 코드와 동일하다.
+3. **`ReadState.max_resource_id`** (`:203`) — `ReadState::new(xml, limits.max_resource_id)`
+   (`:207`, `:1336`) 로 한 번만 복사. `capture_*` 시그니처를 건드리지 않아 디스패치 체인
+   (`start`/`empty`/`capture_start`)은 그대로다.
+4. **`warn_resource_id_out_of_range()`** (`:232`) — 건너뛴 리소스를 기존
+   `HmlWarning::invalid_reference`(`HmlWarningCode::InvalidReference`)로 보고. 새 경고
+   코드를 추가하지 않았다.
+5. **여섯 호출부**(`:509` FONT, `:525` BORDERFILL, `:592` CHARSHAPE, `:630` PARASHAPE,
+   `:669` TABDEF, `:688` STYLE)가 반환값을 확인해 실패 시 경고를 남긴다.
+   `BORDERFILL` 은 추가로 `current_border_fill = None` 으로 되돌려, 뒤따르는
+   `*BORDER` 자식이 존재하지 않는 테이블 항목을 가리키지 않게 했다.
+
+`HmlLimits` 는 공개 타입이라 필드 추가가 **외부에서 구조체 리터럴로 전 필드를 나열하는
+코드**에는 breaking 이다. 저장소 안의 구성 지점(`tests/hml_parser.rs:870`,
+`src/serializer/hml/raw_fragment.rs:8`)은 전부 `HmlLimits::default()` /
+`..HmlLimits::default()` 를 써서 영향이 없음을 확인했다. `#[non_exhaustive]` 부착은 별도
+API 결정이라 이번 범위에 넣지 않았다.
+
+### 2.1 하드 `Err` 가 아니라 skip + 경고로 한 이유
+
+1. **오늘 열리는 파일이 내일 안 열리면 안 된다.** `Id="1000000"` 파일은 현재 `Ok` 로
+   열린다(느리고 뚱뚱할 뿐). 하드 `Err` 는 회귀다.
+2. **리더의 확립된 방침과 일치한다.** `HmlWarning::invalid_reference` 의 문구가 이미
+   "잘못된 HML 리소스 참조를 기본값으로 대체했습니다" 다.
+3. **조용함이 결함의 본질이므로 경고가 수정의 절반이다.** 지금까지는 아무 신호가 없었다.
+4. **한 리소스를 건너뛰어도 다른 `Id` 위치가 밀리지 않는다.** `set_indexed` 는 절대
+   인덱스에 배치하므로 나머지 테이블은 온전하고, 남은 참조는 기존 조회 경로가 기본값으로
+   떨어뜨린다(`capture_border_line` 은 이미 `.get_mut()` 사용).
+
+`capture_border_fill` 의 `Id=0` 하드 `Err` 는 그대로 뒀다 — 1-based 규약 위반(의미론
+오류)이라 성격이 다르고, 바꾸면 기존 동작 회귀 위험이 있다.
+
+### 2.2 상한값 `65_535` 근거 — 그리고 흔한 오해의 정정
+
+**(a) 실측 코퍼스 조사** (이번 작업 중 직접 실행, `samples/` 345개 파일):
+
+```
+SURVEY files=345 (hml=2)
+SURVEY max char_shapes=28193 (hwp3-sample10.hwp)
+SURVEY max para_shapes=3378 (hwp3-sample16.hwp)
+SURVEY max styles=208 (loading-fail-01.hwp)
+SURVEY max border_fills=2705 (hwp3-sample16.hwp)
+SURVEY max tab_defs=25 font_faces_per_lang=165
+HML aligns.hml           cs=5 ps=12 st=14 bf=2 td=3
+HML formatting_table.hml cs=7 ps=17 st=18 bf=3 td=3
+```
+
+관측 최댓값 **28,193** 대비 상한은 **2.32배**. 리소스 테이블 길이는 포맷 독립적인 DocInfo
+자원이므로(같은 문서를 HML 로 내보내면 `CHARSHAPE Id="28192"` 가 나온다) HML 샘플이 2개뿐
+이어도 이 조사가 `Id` 범위의 근거가 된다. HML 샘플 자체 최댓값은 18 로 상한의 1/3,641.
+
+**(b) 참조 폭 — "65,535 초과는 어차피 참조 불가"는 부분적으로만 참이다.**
+
+| 참조 필드 | 타입 | 65,535 초과 도달 |
+|---|---|---|
+| `Paragraph.para_shape_id` (`src/model/paragraph.rs:13`) | `u16` | 불가 |
+| `Paragraph.style_id` (`:15`) | `u8` | 불가 |
+| `Style.para_shape_id` (`src/model/style.rs:444`) | `u16` | 불가 |
+| `Style.char_shape_id` (`src/model/style.rs:446`) | `u16` | 불가 |
+| **`CharShapeRef.char_shape_id`** (`src/model/paragraph.rs:131`) | **`u32`** | **가능** |
+
+문단의 글자모양 런 테이블은 `u32` 로 참조하므로 **char_shapes 에 대해서는 표현 한계가
+아니라 (a) 실측 기반 정책 상한**이다. 그렇기 때문에 더더욱 하드 `Err` 가 아니라 경고를
+남기는 skip 이어야 한다. (제안받은 근거를 그대로 쓰지 않고 확인 후 정정했다.)
+
+**(c) 최악 예약량** (원소 크기는 `std::mem::size_of` 실측):
+
+| 테이블 | 원소 | 65,536칸 |
+|---|---|---|
+| `font_faces[lang]` | `Font` 200 B | 13.1 MB |
+| `border_fills` | `BorderFill` 160 B | 10.5 MB |
+| `char_shapes` | `CharShape` 120 B | 7.9 MB |
+| `para_shapes` | `ParaShape` 112 B | 7.3 MB |
+| `styles` | `Style` 80 B | 5.2 MB |
+| `tab_defs` | `TabDef` 56 B | 3.7 MB |
+
+## 3. 검증
+
+빌드: `cargo test --profile release-test` (릴리스 최적화).
+
+### 3.1 재현 측정 방법
+
+할당량은 테스트 바이너리에 **추적용 `#[global_allocator]`** 를 끼워 측정했다 — 샘플링
+RSS 가 아니라 결정론적 누계다. (PowerShell `PeakWorkingSet64` 는 이 환경에서 빈 값을
+돌려줘 사용하지 않았다.) 측정용 probe 는 커밋하지 않았다.
+
+| 입력 | 수정 전 힙 최대 | 수정 후 힙 최대 |
+|---|---|---|
+| `Id="0"` (376 B, 기준선) | 20,172 B | 20,246 B |
+| `Id="1000000"` (382 B) | **120,009,531 B (114.5 MB)** | **20,532 B** |
+| `Id="2000000000"` (385 B) | abort (240,000,000,120 B 요구) | 정상 파싱 |
+
+- 파일이 **6바이트** 늘었을 뿐인데 수정 전에는 힙이 **+119,989,359 바이트(+114.4 MB)**
+  늘었다. 입력 대비 **314,161배**, 기준선 대비 **5,949배**.
+- 수정 후에는 기준선과 사실상 동일(20,532 vs 20,246)해져 **5,845배** 줄었다.
+- 할당 지점 확정: `240,000,000,120 / 120(= size_of::<CharShape>()) = 2,000,000,001 = Id + 1`
+  — `resize_with(index + 1, ..)` 와 정확히 일치.
+
+### 3.2 red→green 실증 (실제 실행 · 캡처 원문)
+
+**RED 방법**: `max_resource_id` 기본값을 `usize::MAX` 로 되돌려 가드를 무력화했다
+(코드 경로는 유지하고 효과만 종전과 동일하게 만든 것). abort 케이스가 바이너리를 죽이므로
+2회로 나눠 실행했다.
+
+**RED 1차 — abort 하지 않는 테스트들**
+
+```
+running 3 tests
+test hml_resource_id_beyond_limit_is_skipped_with_warning ... FAILED
+test hml_resource_id_boundary_accepts_limit_and_rejects_above ... FAILED
+test hml_resource_ids_within_limit_are_unchanged ... ok
+
+---- hml_resource_id_beyond_limit_is_skipped_with_warning stdout ----
+thread 'hml_resource_id_beyond_limit_is_skipped_with_warning' (25692) panicked at tests\issue_2743_hml_resource_id_limit.rs:47:5:
+상한 초과 CHARSHAPE 는 테이블을 늘리지 않아야 함 (실제 1000001칸)
+
+---- hml_resource_id_boundary_accepts_limit_and_rejects_above stdout ----
+thread 'hml_resource_id_boundary_accepts_limit_and_rejects_above' (2464) panicked at tests\issue_2743_hml_resource_id_limit.rs:122:5:
+Id=65536 는 건너뛰어야 함
+
+test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 2 filtered out; finished in 0.09s
+```
+
+**RED 2차 — abort 케이스 단독**
+
+```
+running 1 test
+memory allocation of 240000000120 bytes failed
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+error: test failed, to rerun pass `--test issue_2743_hml_resource_id_limit`
+
+Caused by:
+  process didn't exit successfully: `...\issue_2743_hml_resource_id_limit-49304a36aa4d5693.exe --exact hml_resource_id_far_beyond_limit_does_not_abort` (exit code: 0xc0000409, STATUS_STACK_BUFFER_OVERRUN)
+note: test exited abnormally; to see the full output pass --no-capture to the harness.
+```
+
+**RED 3차 — 여섯 종류 동시 단독**
+
+```
+---- hml_all_six_resource_kinds_are_bounded stdout ----
+thread 'hml_all_six_resource_kinds_are_bounded' (37736) panicked at tests\issue_2743_hml_resource_id_limit.rs:97:9:
+char_shapes 가 상한 초과 Id 로 늘어남 (9000001칸)
+
+test result: FAILED. 0 passed; 1 failed; 0 ignored; 0 measured; 4 filtered out; finished in 1.93s
+```
+
+이 케이스는 abort 하지 **않았다** — 즉 **797바이트 HML 이 여섯 테이블 합계
+6,552,000,568 바이트(6.10 GiB)를 아무 오류 없이 예약하고 통과**했다. 조용한 구간이
+GB 규모까지 확장된다는 직접 증거다.
+
+**GREEN — 가드 복원 후 전체 재실행**
+
+```
+running 5 tests
+test hml_resource_id_far_beyond_limit_does_not_abort ... ok
+test hml_all_six_resource_kinds_are_bounded ... ok
+test hml_resource_id_beyond_limit_is_skipped_with_warning ... ok
+test hml_resource_ids_within_limit_are_unchanged ... ok
+test hml_resource_id_boundary_accepts_limit_and_rejects_above ... ok
+
+test result: ok. 5 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.00s
+```
+
+### 3.3 red→green 회계 (통과/실패를 테스트별로 명시)
+
+| 테스트 | RED | GREEN |
+|---|---|---|
+| `hml_resource_id_beyond_limit_is_skipped_with_warning` | FAILED — "실제 1000001칸" | ok |
+| `hml_resource_id_boundary_accepts_limit_and_rejects_above` | FAILED — "Id=65536 는 건너뛰어야 함" | ok |
+| `hml_all_six_resource_kinds_are_bounded` | FAILED — "9000001칸" (6.10 GiB 를 오류 없이 예약) | ok |
+| `hml_resource_id_far_beyond_limit_does_not_abort` | **프로세스 abort** (`0xC0000409`) | ok |
+| `hml_resource_ids_within_limit_are_unchanged` | **ok — 수정 전에도 통과** | ok |
+
+마지막 항목은 red 가 되지 않는 것이 **정상**이다. 정상 범위 `Id`(0~2)의 동작이 수정 전후
+완전히 같음을 고정하는 동작 불변 가드이므로, 양쪽에서 통과해야 의미가 있다.
+
+조용한 구간을 잡기 위해 가드는 "죽지 않음"이 아니라 **결과 테이블 길이와 경고 개수**를
+단언한다. 그렇게 하지 않으면 수정 전에도 통과해 red 가 성립하지 않는다.
+
+### 3.4 CI 3종 (실측 결과)
+
+| 검사 | 명령 | 결과 |
+|---|---|---|
+| clippy | `cargo clippy --all-targets -- -D warnings` | **exit 0** |
+| 테스트 | `cargo test --profile release-test --tests` | **exit 0** — 테스트 타깃 293개 전부 `ok`, `FAILED` 0개, 합계 **3,495 passed / 0 failed / 23 ignored** |
+| fmt | 변경 2개 파일에 write 모드 `rustfmt --edition 2021` 적용 후 재적용 시 md5 불변 | **IDEMPOTENT** |
+
+테스트 타깃별 주요 결과 (정상 파일 불변 확인):
+
+```
+unittests src\lib.rs              ok. 2464 passed; 0 failed; 7 ignored
+issue_2743_hml_resource_id_limit  ok. 5 passed; 0 failed; 0 ignored     ← 신규
+hml_parser                        ok. 34 passed; 0 failed; 0 ignored
+hml_serializer                    ok. 30 passed; 0 failed; 0 ignored
+hwp5_roundtrip_baseline           ok. 3 passed; 0 failed; 0 ignored
+hwpx_roundtrip_baseline           ok. 4 passed; 0 failed; 0 ignored
+hwpx_roundtrip_integration        ok. 22 passed; 0 failed; 0 ignored
+visual_roundtrip_baseline         ok. 3 passed; 0 failed; 0 ignored
+```
+
+특히 `hml_parser` 34개·`hml_serializer` 30개가 전부 통과했다 — 기존 HML 경고 개수를
+단언하는 `assert_eq!(result.warnings.len(), 6)` (`tests/hml_parser.rs:642`) 포함이라,
+정상 입력에 새 경고가 끼어들지 않음이 확인된다.
+
+fmt 는 지시대로 `cargo fmt --all -- --check` 를 쓰지 않았다 — 이 Windows 체크아웃에서는
+CRLF 파일에 대해 `Incorrect newline style` 만 출력하고 diff 를 내지 않아 거짓 통과가 된다.
+`src/parser/hml/reader.rs` 는 하위 모듈 선언이 없어 rustfmt 가 다른 파일로 내려가지
+않음을 사전에 확인했다(#2722 때 `mod tests` 로 내려간 사례 재발 방지).
+
+## 4. 미실행 항목 (투명 고지)
+
+- **wasm32 실기 실행은 하지 않았다.** 이슈의 wasm32 서술(`Layout::array` 가 32비트
+  `usize` 초과 → capacity overflow → 트랩)은 `usize` 폭과 원소 크기 산술에서 도출한
+  것이며 관측이 아니다.
+- **PeakWorkingSet(RSS) 는 측정하지 못했다.** 이 환경의 PowerShell 이 빈 값을 돌려줘,
+  대신 추적 `#[global_allocator]` 의 결정론적 누계를 썼다. 보고한 수치는 RSS 가 아니라
+  힙 할당 최대치다.
+- `set_indexed` 가 HML 리더 전용임은 `grep -rn "set_indexed" src/` 로 확인했다
+  (다른 포맷 경로에는 이 결함이 없다).
+
+## 5. 잔여 (범위 밖)
+
+| # | 항목 | 이번에 다루지 않는 이유 |
+|---|---|---|
+| 1 | `capture_border_fill` 의 `Id=0` 하드 `Err` | 기존 동작. 2.1 참조 — 성격이 다르고 바꾸면 회귀 위험 |
+| 2 | `<CHARSHAPELIST Count="N">` 선언 개수와 실제 항목 수의 교차 검증 | 정합성 기능이지 할당 상한이 아니다 |
+| 3 | HWP5/HWPX 의 동일 리소스 테이블 | `set_indexed` 를 쓰지 않는다. 레코드 크기 검사로 이미 유계 |
+| 4 | `HmlLimits` 를 CLI/공개 API 에서 조정하는 표면 | 기본값만으로 결함이 닫힌다 |

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -4,6 +4,15 @@ use super::paragraph::Paragraph;
 use super::shape::{common_obj_offsets, Caption};
 use super::*;
 
+/// [#2722] `Table::rebuild_grid()` 가 예약할 수 있는 최대 그리드 칸 수.
+///
+/// 실측 근거: `samples/` 전수 조사(파일 343개, 중첩 포함 표 5,353개)에서
+/// `row_count × col_count` 최댓값은 52,770 (5,277행 × 10열,
+/// `issue2063_huge_cellbreak_table.hwp`) 이었다. 이 상한은 그 75.8배이므로
+/// 정상 문서는 상한 분기에 닿지 않는다. 최악의 경우 예약량은
+/// 4,000,000 × 16B = 64 MiB (wasm32 는 8B → 32 MiB) 로 abort 없이 처리된다.
+pub const MAX_TABLE_GRID_CELLS: usize = 4_000_000;
+
 pub const CELL_FLAG_HAS_MARGIN: u16 = 0x0001;
 pub const CELL_FLAG_PROTECT: u16 = 0x0002;
 pub const CELL_FLAG_HEADER: u16 = 0x0004;
@@ -510,10 +519,30 @@ impl Table {
 
     /// 2D 그리드 인덱스를 재구축한다.
     /// 구조 변경(파싱, 행/열 추가/삭제, 병합/분할) 후 호출해야 한다.
+    ///
+    /// [#2722] `row_count`/`col_count` 는 파일에서 그대로 온 `u16` 이다(HWPX `rowCnt`/
+    /// `colCnt`, HWP5 `HWPTAG_TABLE`, HML `RowCount`/`ColCount`). 종전엔 상한 없이
+    /// `vec![None; rc * cc]` 를 예약해, 65535×65535 = 4,294,836,225 칸 ×
+    /// `Option<usize>` 16바이트 = 68,717,379,600 바이트 예약을 시도하고 실패 시
+    /// `handle_alloc_error` → abort 로 프로세스가 죽었다(250바이트 HML 로 재현).
+    /// wasm32 에서는 `Layout::array` 가 32비트 `usize` 를 넘겨 capacity overflow
+    /// 패닉 → 모듈 트랩이 된다. 정상 파일은 실측상 최대 52,770 칸이라 아래
+    /// 분기가 아예 실행되지 않으므로 동작 불변이다.
     pub fn rebuild_grid(&mut self) {
         let rc = self.row_count as usize;
         let cc = self.col_count as usize;
-        self.cell_grid = vec![None; rc * cc];
+        let requested = rc.saturating_mul(cc);
+        let grid_len = if requested > MAX_TABLE_GRID_CELLS {
+            // 손상된 행/열 수. 실제 셀이 가리키는 마지막 칸 + 1 까지만 예약한다.
+            // 아래 채우기 루프에 이미 `gi < self.cell_grid.len()` 가드가 있어
+            // 범위를 넘는 칸은 원래도 무시됐다.
+            self.addressed_grid_len(cc)
+                .min(MAX_TABLE_GRID_CELLS)
+                .min(requested)
+        } else {
+            requested
+        };
+        self.cell_grid = vec![None; grid_len];
         for (idx, cell) in self.cells.iter().enumerate() {
             for r in cell.row..(cell.row + cell.row_span) {
                 for c in cell.col..(cell.col + cell.col_span) {
@@ -524,6 +553,28 @@ impl Table {
                 }
             }
         }
+    }
+
+    /// [#2722] 셀이 실제로 가리키는 마지막 그리드 인덱스 + 1.
+    /// 손상된 `row_count`/`col_count` 로 그리드가 상한을 넘을 때만 쓰인다.
+    /// 셀이 없으면 0 — 셀 0개짜리 악성 표는 그리드도 0칸이면 충분하다.
+    fn addressed_grid_len(&self, cc: usize) -> usize {
+        self.cells
+            .iter()
+            .map(|cell| {
+                let last_row = (cell.row as usize)
+                    .saturating_add(cell.row_span as usize)
+                    .saturating_sub(1);
+                let last_col = (cell.col as usize)
+                    .saturating_add(cell.col_span as usize)
+                    .saturating_sub(1);
+                last_row
+                    .saturating_mul(cc)
+                    .saturating_add(last_col)
+                    .saturating_add(1)
+            })
+            .max()
+            .unwrap_or(0)
     }
 
     /// O(1) 셀 인덱스 조회. rebuild_grid() 호출 후 사용해야 한다.

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -41,6 +41,21 @@ pub struct HmlLimits {
     pub max_depth: usize,
     pub max_attributes: usize,
     pub max_text_node_bytes: usize,
+    /// [#2743] 리소스 테이블(`FONT`/`BORDERFILL`/`CHARSHAPE`/`PARASHAPE`/`TABDEF`/
+    /// `STYLE`)의 `Id` 상한.
+    ///
+    /// 다른 필드는 전부 *입력 크기* 상한이지만 이것만 *할당 크기* 상한이다. `Id` 는
+    /// 문자 몇 개인데 `set_indexed` 의 `resize_with(id + 1, ..)` 는 그 값에 선형
+    /// 비례해 예약하므로, 상한이 없으면 382바이트 파일이 오류 없이 120 MB 를 쓰고
+    /// 385바이트 파일이 240 GB 를 요구하다 abort 한다.
+    ///
+    /// 기본값 65,535 근거: `samples/` 345개 파일 실측에서 리소스 테이블 최대 길이는
+    /// 28,193(char_shapes) 이라 2.32배 여유이며, `Paragraph.para_shape_id`(u16)·
+    /// `Style.para_shape_id`/`char_shape_id`(u16)·`Paragraph.style_id`(u8) 참조는
+    /// 애초에 이 범위를 넘길 수 없다. 다만 `CharShapeRef.char_shape_id` 는 u32 라
+    /// char_shapes 에 대해서는 표현 한계가 아닌 정책 상한이며, 그래서 초과분은
+    /// 하드 오류가 아니라 경고를 남기고 건너뛴다.
+    pub max_resource_id: usize,
 }
 
 impl Default for HmlLimits {
@@ -50,6 +65,7 @@ impl Default for HmlLimits {
             max_depth: 256,
             max_attributes: 256,
             max_text_node_bytes: 8 * 1024 * 1024,
+            max_resource_id: 65_535,
         }
     }
 }
@@ -183,10 +199,12 @@ struct ReadState<'a> {
     body_modeled_children: usize,
     saw_head: bool,
     saw_body: bool,
+    /// [#2743] `HmlLimits::max_resource_id` 사본 — 리소스 `Id` 상한.
+    max_resource_id: usize,
 }
 
 impl<'a> ReadState<'a> {
-    fn new(xml: &'a str) -> Self {
+    fn new(xml: &'a str, max_resource_id: usize) -> Self {
         Self {
             xml,
             stack: Vec::new(),
@@ -204,7 +222,19 @@ impl<'a> ReadState<'a> {
             body_modeled_children: 0,
             saw_head: false,
             saw_body: false,
+            max_resource_id,
         }
+    }
+
+    /// [#2743] 상한을 넘겨 건너뛴 리소스를 경고로 남긴다.
+    /// 기존 `InvalidReference` 경고 코드를 그대로 쓴다 — 잘못된 참조를 기본값으로
+    /// 대체하고 계속 진행하는 이 리더의 확립된 방침과 같은 처리다.
+    fn warn_resource_id_out_of_range(&mut self, element: &str, id: usize) {
+        let max = self.max_resource_id;
+        self.source.warnings.push(HmlWarning::invalid_reference(
+            format!("/{}", self.stack.join("/")),
+            format!("{element} Id={id} (상한 {max} 초과, 건너뜀)"),
+        ));
     }
 
     fn start(
@@ -472,7 +502,14 @@ impl<'a> ReadState<'a> {
             },
             ..Default::default()
         };
-        set_indexed(&mut self.source.font_faces[language], id, font);
+        if !set_indexed(
+            &mut self.source.font_faces[language],
+            id,
+            font,
+            self.max_resource_id,
+        ) {
+            self.warn_resource_id_out_of_range("FONT", id);
+        }
         Ok(())
     }
 
@@ -481,7 +518,18 @@ impl<'a> ReadState<'a> {
         if id == 0 {
             return Err(HmlError::InvalidReference("BORDERFILL Id=0".to_string()));
         }
-        set_indexed(&mut self.source.border_fills, id - 1, BorderFill::default());
+        if !set_indexed(
+            &mut self.source.border_fills,
+            id - 1,
+            BorderFill::default(),
+            self.max_resource_id,
+        ) {
+            self.warn_resource_id_out_of_range("BORDERFILL", id);
+            // 이 BORDERFILL 은 테이블에 없으므로 뒤따르는 *BORDER 자식도 버린다.
+            // (`capture_border_line` 은 `current_border_fill` 이 None 이면 무시한다)
+            self.current_border_fill = None;
+            return Ok(());
+        }
         self.current_border_fill = Some(id - 1);
         Ok(())
     }
@@ -537,7 +585,14 @@ impl<'a> ReadState<'a> {
             shade_color: parse_attribute(element, b"ShadeColor")?.unwrap_or(0),
             ..Default::default()
         };
-        set_indexed(&mut self.source.char_shapes, id, shape);
+        if !set_indexed(
+            &mut self.source.char_shapes,
+            id,
+            shape,
+            self.max_resource_id,
+        ) {
+            self.warn_resource_id_out_of_range("CHARSHAPE", id);
+        }
         Ok(())
     }
 
@@ -568,7 +623,14 @@ impl<'a> ReadState<'a> {
             para_level: parse_attribute(element, b"Level")?.unwrap_or(0),
             ..Default::default()
         };
-        set_indexed(&mut self.source.para_shapes, id, shape);
+        if !set_indexed(
+            &mut self.source.para_shapes,
+            id,
+            shape,
+            self.max_resource_id,
+        ) {
+            self.warn_resource_id_out_of_range("PARASHAPE", id);
+        }
         Ok(())
     }
 
@@ -600,7 +662,14 @@ impl<'a> ReadState<'a> {
 
     fn capture_tab_def(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
         let id = parse_attribute::<usize>(element, b"Id")?.unwrap_or(0);
-        set_indexed(&mut self.source.tab_defs, id, TabDef::default());
+        if !set_indexed(
+            &mut self.source.tab_defs,
+            id,
+            TabDef::default(),
+            self.max_resource_id,
+        ) {
+            self.warn_resource_id_out_of_range("TABDEF", id);
+        }
         Ok(())
     }
 
@@ -616,7 +685,9 @@ impl<'a> ReadState<'a> {
             char_shape_id: parse_attribute(element, b"CharShape")?.unwrap_or(0),
             ..Default::default()
         };
-        set_indexed(&mut self.source.styles, id, style);
+        if !set_indexed(&mut self.source.styles, id, style, self.max_resource_id) {
+            self.warn_resource_id_out_of_range("STYLE", id);
+        }
         Ok(())
     }
 
@@ -1262,7 +1333,7 @@ pub(crate) fn has_hwpml_root(xml: &str) -> bool {
 
 pub(crate) fn read_hml(xml: &str, limits: &HmlLimits) -> Result<HmlSource, HmlError> {
     let mut reader = Reader::from_str(xml);
-    let mut state = ReadState::new(xml);
+    let mut state = ReadState::new(xml, limits.max_resource_id);
     // 이전 이벤트가 소비를 마친 지점 = 다음 시작 태그의 첫 바이트 오프셋.
     // 보존 캡슐이 원문을 바이트 그대로 잘라내는 데 사용한다.
     let mut prev_pos: u64 = 0;
@@ -1501,9 +1572,21 @@ fn parse_text_wrap(value: Option<&str>) -> TextWrap {
     }
 }
 
-fn set_indexed<T: Default>(values: &mut Vec<T>, index: usize, value: T) {
+/// 리소스 테이블의 `index` 칸에 값을 배치한다. 필요한 만큼 테이블을 늘린다.
+///
+/// [#2743] `index` 는 HML `Id` 속성에서 그대로 온 값이라 상한이 필요하다. 종전엔
+/// `resize_with(index + 1, ..)` 에 검증이 없어 `Id="1000000"` 이면 오류 없이
+/// 120 MB 를(측정값: 힙 최대 120,009,531 바이트) 조용히 예약하고, `Id="2000000000"`
+/// 이면 240,000,000,120 바이트를 요구하다 `handle_alloc_error` → abort 로 프로세스가
+/// 죽었다. 상한을 넘으면 **아무것도 할당하지 않고** `false` 를 반환한다 — 호출부는
+/// 경고를 남기고 그 리소스만 건너뛴다(정상 파일은 상한에 닿지 않아 동작 불변).
+fn set_indexed<T: Default>(values: &mut Vec<T>, index: usize, value: T, max_index: usize) -> bool {
+    if index > max_index {
+        return false;
+    }
     if values.len() <= index {
         values.resize_with(index + 1, T::default);
     }
     values[index] = value;
+    true
 }

--- a/tests/issue_2722_table_grid_alloc.rs
+++ b/tests/issue_2722_table_grid_alloc.rs
@@ -15,12 +15,23 @@ use rhwp::model::control::Control;
 use rhwp::model::table::{Cell, Table, MAX_TABLE_GRID_CELLS};
 use rhwp::parser::hml::parse_hml;
 
-/// (1) 모델 직접 호출 — 셀이 하나도 없는 65535×65535 표.
+/// (1) 모델 직접 호출 — 셀이 하나도 없는 상한 초과 표.
+///
+/// [메인테이너 보정] 종전에는 `65535 × 65535` 를 썼다. 가드가 살아 있으면 실셀 범위까지만
+/// 예약하므로 안전하지만, **가드가 회귀로 사라지면 `Option<usize>` 16B × 42.9억 = 68.7GB**
+/// 를 요구해 테스트가 실패하는 대신 러너가 스왑에 빠지거나 OOM 으로 죽는다. CI 에서 회귀를
+/// 진단 가능한 형태로 잡아야 하므로, 상한(`MAX_TABLE_GRID_CELLS` = 4,000,000)을 넘기되
+/// 회귀 시에도 감당 가능한 크기(2100 × 2100 = 4.41M 칸 ≈ 70MB)로 낮춘다. 상한 초과 여부를
+/// 검사한다는 목적은 그대로다.
 #[test]
 fn rebuild_grid_bounds_hostile_row_col_count() {
     let mut table = Table::default();
-    table.row_count = 65535;
-    table.col_count = 65535;
+    table.row_count = 2100;
+    table.col_count = 2100;
+    assert!(
+        (table.row_count as usize) * (table.col_count as usize) > MAX_TABLE_GRID_CELLS,
+        "재현 입력이 상한을 넘어야 의미가 있다"
+    );
     table.rebuild_grid();
 
     assert!(
@@ -35,16 +46,18 @@ fn rebuild_grid_bounds_hostile_row_col_count() {
         "셀 0개 표는 그리드도 0칸이어야 함"
     );
     // 모델 필드는 건드리지 않는다 (직렬화·라운드트립 계약 보존).
-    assert_eq!(table.row_count, 65535);
-    assert_eq!(table.col_count, 65535);
+    assert_eq!(table.row_count, 2100);
+    assert_eq!(table.col_count, 2100);
 }
 
-/// (1') 셀이 하나 있는 65535×65535 표 — 실제 셀이 가리키는 범위까지만 예약.
+/// (1') 셀이 하나 있는 상한 초과 표 — 실제 셀이 가리키는 범위까지만 예약.
+///
+/// [메인테이너 보정] (1) 과 같은 이유로 `65535 × 65535` 에서 낮췄다.
 #[test]
 fn rebuild_grid_bounds_hostile_counts_with_one_cell() {
     let mut table = Table::default();
-    table.row_count = 65535;
-    table.col_count = 65535;
+    table.row_count = 2100;
+    table.col_count = 2100;
     table.cells = vec![Cell {
         row: 0,
         col: 0,
@@ -66,10 +79,13 @@ fn rebuild_grid_bounds_hostile_counts_with_one_cell() {
     );
 }
 
-/// (2) HML 파싱 경로 — 250바이트짜리 악성 입력이 abort 없이 파싱돼야 한다.
+/// (2) HML 파싱 경로 — 작은 악성 입력이 abort 없이 파싱돼야 한다.
+///
+/// [메인테이너 보정] (1) 과 같은 이유로 `65535` 에서 낮췄다. 파일이 선언한 카운트를 그대로
+/// 믿고 곱하면 안 된다는 계약은 상한(4,000,000)을 넘기기만 하면 검증된다.
 #[test]
 fn hml_table_with_hostile_counts_parses_without_abort() {
-    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="65535" ColCount="65535">
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="2100" ColCount="2100">
 <ROW><CELL ColAddr="0" RowAddr="0"><PARALIST><P><TEXT><CHAR>x</CHAR></TEXT></P></PARALIST></CELL></ROW>
 </TABLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
 
@@ -89,8 +105,8 @@ fn hml_table_with_hostile_counts_parses_without_abort() {
         table.cell_grid.len()
     );
     // 파일이 선언한 행/열 수는 그대로 보존한다.
-    assert_eq!(table.row_count, 65535);
-    assert_eq!(table.col_count, 65535);
+    assert_eq!(table.row_count, 2100);
+    assert_eq!(table.col_count, 2100);
 }
 
 /// (3) 정상 표는 그리드 크기가 종전 식(`rc * cc`)과 완전히 동일해야 한다.

--- a/tests/issue_2722_table_grid_alloc.rs
+++ b/tests/issue_2722_table_grid_alloc.rs
@@ -1,0 +1,124 @@
+//! Issue #2722 회귀 가드 — 표 그리드 재구축의 무한 할당 방지.
+//!
+//! `Table::rebuild_grid()` 이 파일에서 온 `row_count`/`col_count` 를 검증 없이
+//! 곱해 `vec![None; rc * cc]` 를 예약하면, 65535×65535 = 4,294,836,225 칸 ×
+//! `Option<usize>` 16바이트 = 68,717,379,600 바이트 예약이 되어 할당 실패 시
+//! `handle_alloc_error` → abort 로 프로세스가 죽는다(테스트 실패가 아니라
+//! 바이너리 전체 사망). wasm32 에서는 `Layout::array` 가 32비트 `usize` 를
+//! 넘겨 capacity overflow 패닉 → 모듈 트랩이 된다.
+//!
+//! 아래 가드는 (1) 모델 직접 호출, (2) HML 파싱 경로 두 곳에서 abort 없이
+//! 유계 그리드로 끝나는지, 그리고 (3) 정상 표에서는 그리드 크기가 종전과
+//! 완전히 동일한지를 고정한다.
+
+use rhwp::model::control::Control;
+use rhwp::model::table::{Cell, Table, MAX_TABLE_GRID_CELLS};
+use rhwp::parser::hml::parse_hml;
+
+/// (1) 모델 직접 호출 — 셀이 하나도 없는 65535×65535 표.
+#[test]
+fn rebuild_grid_bounds_hostile_row_col_count() {
+    let mut table = Table::default();
+    table.row_count = 65535;
+    table.col_count = 65535;
+    table.rebuild_grid();
+
+    assert!(
+        table.cell_grid.len() <= MAX_TABLE_GRID_CELLS,
+        "그리드가 상한을 넘음: {}",
+        table.cell_grid.len()
+    );
+    // 셀이 없으므로 예약할 칸도 없다.
+    assert_eq!(
+        table.cell_grid.len(),
+        0,
+        "셀 0개 표는 그리드도 0칸이어야 함"
+    );
+    // 모델 필드는 건드리지 않는다 (직렬화·라운드트립 계약 보존).
+    assert_eq!(table.row_count, 65535);
+    assert_eq!(table.col_count, 65535);
+}
+
+/// (1') 셀이 하나 있는 65535×65535 표 — 실제 셀이 가리키는 범위까지만 예약.
+#[test]
+fn rebuild_grid_bounds_hostile_counts_with_one_cell() {
+    let mut table = Table::default();
+    table.row_count = 65535;
+    table.col_count = 65535;
+    table.cells = vec![Cell {
+        row: 0,
+        col: 0,
+        row_span: 1,
+        col_span: 1,
+        ..Default::default()
+    }];
+    table.rebuild_grid();
+
+    assert_eq!(
+        table.cell_grid.len(),
+        1,
+        "(0,0) 셀 하나만 있으면 그리드 1칸이면 충분"
+    );
+    assert_eq!(
+        table.cell_grid[0],
+        Some(0),
+        "앵커 셀 인덱스는 유지되어야 함"
+    );
+}
+
+/// (2) HML 파싱 경로 — 250바이트짜리 악성 입력이 abort 없이 파싱돼야 한다.
+#[test]
+fn hml_table_with_hostile_counts_parses_without_abort() {
+    let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="65535" ColCount="65535">
+<ROW><CELL ColAddr="0" RowAddr="0"><PARALIST><P><TEXT><CHAR>x</CHAR></TEXT></P></PARALIST></CELL></ROW>
+</TABLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+
+    let parsed = parse_hml(xml).expect("악성 표 카운트도 graceful 하게 파싱되어야 함");
+    let table = parsed.document.sections[0].paragraphs[0]
+        .controls
+        .iter()
+        .find_map(|c| match c {
+            Control::Table(t) => Some(t.as_ref()),
+            _ => None,
+        })
+        .expect("표 컨트롤이 있어야 함");
+
+    assert!(
+        table.cell_grid.len() <= MAX_TABLE_GRID_CELLS,
+        "그리드가 상한을 넘음: {}",
+        table.cell_grid.len()
+    );
+    // 파일이 선언한 행/열 수는 그대로 보존한다.
+    assert_eq!(table.row_count, 65535);
+    assert_eq!(table.col_count, 65535);
+}
+
+/// (3) 정상 표는 그리드 크기가 종전 식(`rc * cc`)과 완전히 동일해야 한다.
+#[test]
+fn normal_table_grid_size_is_unchanged() {
+    let mut table = Table::default();
+    table.row_count = 3;
+    table.col_count = 4;
+    table.cells = (0..3)
+        .flat_map(|r| {
+            (0..4).map(move |c| Cell {
+                row: r,
+                col: c,
+                row_span: 1,
+                col_span: 1,
+                ..Default::default()
+            })
+        })
+        .collect();
+    table.rebuild_grid();
+
+    assert_eq!(table.cell_grid.len(), 3 * 4, "정상 표 그리드 크기 불변");
+    for r in 0..3u16 {
+        for c in 0..4u16 {
+            assert!(
+                table.cell_index_at(r, c).is_some(),
+                "({r},{c}) 셀 조회가 유지되어야 함"
+            );
+        }
+    }
+}

--- a/tests/issue_2743_hml_resource_id_limit.rs
+++ b/tests/issue_2743_hml_resource_id_limit.rs
@@ -55,13 +55,22 @@ fn hml_resource_id_beyond_limit_is_skipped_with_warning() {
     );
 }
 
-/// abort 구간 — 수정 전에는 테스트 실패가 아니라 프로세스가 죽는다.
+/// abort 구간 — 상한을 크게 넘는 Id 도 테이블을 늘리지 않아야 한다.
+///
+/// [메인테이너 보정] 종전에는 Id `2000000000` 을 썼다. 가드가 살아 있으면 안전하지만,
+/// **가드가 회귀로 사라지면 `CharShape` 120B × 20억 = 240GB** 를 요구해 테스트가 실패하는
+/// 대신 러너가 죽는다. 원저자도 "수정 전에는 테스트 실패가 아니라 프로세스가 죽는다" 고
+/// 주석에 적어 두었는데, 그것이 바로 CI 에서 허용될 수 없는 성질이다.
+///
+/// 상한(65,535)을 크게 넘는다는 성질은 Id `2_000_000` 으로도 동일하게 검증되며, 회귀 시
+/// 요구량은 240MB 로 진단 가능한 범위에 머문다. 경계 자체는 아래
+/// `hml_resource_id_boundary_accepts_limit_and_rejects_above` 가 65535/65536 으로 고정한다.
 #[test]
 fn hml_resource_id_far_beyond_limit_does_not_abort() {
-    let bytes = hml_with_charshape_id("2000000000");
-    assert_eq!(bytes.len(), 385, "재현 입력 크기 고정");
+    let bytes = hml_with_charshape_id("2000000");
+    assert_eq!(bytes.len(), 382, "재현 입력 크기 고정");
 
-    let parsed = parse_hml(&bytes).expect("240GB 를 요구하지 말고 정상 파싱되어야 함");
+    let parsed = parse_hml(&bytes).expect("거대 테이블을 요구하지 말고 정상 파싱되어야 함");
     assert!(parsed.document.doc_info.char_shapes.len() < 1_000);
     assert_eq!(invalid_reference_warnings(&parsed), 1);
 }

--- a/tests/issue_2743_hml_resource_id_limit.rs
+++ b/tests/issue_2743_hml_resource_id_limit.rs
@@ -1,0 +1,168 @@
+//! Issue #2743 회귀 가드 — HML 리소스 `Id` 가 할당 크기가 되는 것을 상한으로 막는다.
+//!
+//! `set_indexed()` 가 `resize_with(Id + 1, ..)` 를 검증 없이 호출해, 파일에서 온
+//! `Id` 값에 선형 비례하는 예약이 일어났다. 이 결함은 두 구간을 가진다.
+//!
+//! - **조용한 구간**: `Id="1000000"` → 힙 최대 120,009,531 바이트를 쓰고도
+//!   `parse_hml` 이 `Ok` 를 반환한다. 오류도 경고도 없어 호출자가 알 수 없다.
+//!   따라서 아래 가드는 "죽지 않음"이 아니라 **결과 테이블 길이와 경고**를 단언한다
+//!   (그렇게 해야 수정 전에 red 가 된다).
+//! - **abort 구간**: `Id="2000000000"` → 240,000,000,120 바이트 요구 →
+//!   `handle_alloc_error` → abort. 테스트 실패가 아니라 바이너리 전체가 죽는다.
+
+use rhwp::parser::hml::{parse_hml, HmlWarningCode};
+
+/// 상한(기본 65,535)을 훨씬 넘는 `Id` 하나만 든 최소 HML.
+fn hml_with_charshape_id(id: &str) -> Vec<u8> {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Style="embed" SubVersion="9.0.1.0" Version="2.9">
+  <HEAD SecCnt="1"><MAPPINGTABLE><CHARSHAPELIST Count="1"><CHARSHAPE Id="{id}" Height="1000"/></CHARSHAPELIST></MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>A</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL />
+</HWPML>
+"#
+    )
+    .into_bytes()
+}
+
+fn invalid_reference_warnings(result: &rhwp::parser::hml::HmlParseResult) -> usize {
+    result
+        .warnings
+        .iter()
+        .filter(|w| w.code == HmlWarningCode::InvalidReference)
+        .count()
+}
+
+/// 조용한 구간 — 수정 전에는 `Ok` 이면서 테이블이 1,000,001칸이 된다.
+/// 길이와 경고를 단언해야 red 가 성립한다.
+#[test]
+fn hml_resource_id_beyond_limit_is_skipped_with_warning() {
+    let bytes = hml_with_charshape_id("1000000");
+    assert_eq!(bytes.len(), 382, "재현 입력 크기 고정");
+
+    let parsed = parse_hml(&bytes).expect("상한 초과 Id 여도 문서는 열려야 함");
+    let len = parsed.document.doc_info.char_shapes.len();
+
+    assert!(
+        len < 1_000,
+        "상한 초과 CHARSHAPE 는 테이블을 늘리지 않아야 함 (실제 {len}칸)"
+    );
+    assert_eq!(
+        invalid_reference_warnings(&parsed),
+        1,
+        "건너뛴 리소스는 경고로 보고되어야 함 (조용히 사라지면 안 됨)"
+    );
+}
+
+/// abort 구간 — 수정 전에는 테스트 실패가 아니라 프로세스가 죽는다.
+#[test]
+fn hml_resource_id_far_beyond_limit_does_not_abort() {
+    let bytes = hml_with_charshape_id("2000000000");
+    assert_eq!(bytes.len(), 385, "재현 입력 크기 고정");
+
+    let parsed = parse_hml(&bytes).expect("240GB 를 요구하지 말고 정상 파싱되어야 함");
+    assert!(parsed.document.doc_info.char_shapes.len() < 1_000);
+    assert_eq!(invalid_reference_warnings(&parsed), 1);
+}
+
+/// 여섯 개 호출부(FONT/BORDERFILL/CHARSHAPE/PARASHAPE/TABDEF/STYLE) 전부 유계여야 한다.
+#[test]
+fn hml_all_six_resource_kinds_are_bounded() {
+    let xml = br#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Style="embed" SubVersion="9.0.1.0" Version="2.9">
+  <HEAD SecCnt="1"><MAPPINGTABLE>
+    <FACENAMELIST><FONTFACE Count="1" Lang="Hangul"><FONT Id="9000000" Name="X" Type="ttf"/></FONTFACE></FACENAMELIST>
+    <BORDERFILLLIST Count="1"><BORDERFILL Id="9000000"/></BORDERFILLLIST>
+    <CHARSHAPELIST Count="1"><CHARSHAPE Id="9000000" Height="1000"/></CHARSHAPELIST>
+    <TABDEFLIST Count="1"><TABDEF Id="9000000"/></TABDEFLIST>
+    <PARASHAPELIST Count="1"><PARASHAPE Id="9000000" Align="Left"/></PARASHAPELIST>
+    <STYLELIST Count="1"><STYLE Id="9000000" Name="s"/></STYLELIST>
+  </MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>A</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL />
+</HWPML>
+"#;
+
+    let parsed = parse_hml(xml).expect("여섯 종류 전부 상한 초과여도 문서는 열려야 함");
+    let d = &parsed.document.doc_info;
+
+    for (name, len) in [
+        ("char_shapes", d.char_shapes.len()),
+        ("para_shapes", d.para_shapes.len()),
+        ("styles", d.styles.len()),
+        ("border_fills", d.border_fills.len()),
+        ("tab_defs", d.tab_defs.len()),
+    ] {
+        assert!(len < 1_000, "{name} 가 상한 초과 Id 로 늘어남 ({len}칸)");
+    }
+    for faces in &d.font_faces {
+        assert!(
+            faces.len() < 1_000,
+            "font_faces 가 늘어남 ({}칸)",
+            faces.len()
+        );
+    }
+
+    assert_eq!(
+        invalid_reference_warnings(&parsed),
+        6,
+        "여섯 호출부가 각각 경고를 남겨야 함"
+    );
+}
+
+/// 경계값 — 상한 이하는 종전대로 수용, 상한 초과만 건너뛴다.
+#[test]
+fn hml_resource_id_boundary_accepts_limit_and_rejects_above() {
+    let accepted = parse_hml(&hml_with_charshape_id("65535")).expect("상한값은 수용되어야 함");
+    assert_eq!(
+        accepted.document.doc_info.char_shapes.len(),
+        65_536,
+        "Id=65535 는 종전대로 65,536칸을 만들어야 함"
+    );
+    assert_eq!(invalid_reference_warnings(&accepted), 0, "경고가 없어야 함");
+
+    let rejected = parse_hml(&hml_with_charshape_id("65536")).expect("상한 초과도 열려야 함");
+    assert!(
+        rejected.document.doc_info.char_shapes.len() < 1_000,
+        "Id=65536 는 건너뛰어야 함"
+    );
+    assert_eq!(invalid_reference_warnings(&rejected), 1);
+}
+
+/// 정상 범위 Id 는 동작이 완전히 불변이어야 한다 (수정 전후 모두 통과하는 가드).
+#[test]
+fn hml_resource_ids_within_limit_are_unchanged() {
+    let xml = r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Style="embed" SubVersion="9.0.1.0" Version="2.9">
+  <HEAD SecCnt="1"><MAPPINGTABLE>
+    <FACENAMELIST><FONTFACE Count="2" Lang="Hangul"><FONT Id="0" Name="굴림" Type="ttf"/><FONT Id="1" Name="바탕" Type="ttf"/></FONTFACE></FACENAMELIST>
+    <BORDERFILLLIST Count="2"><BORDERFILL Id="1"/><BORDERFILL Id="2"/></BORDERFILLLIST>
+    <CHARSHAPELIST Count="3"><CHARSHAPE Id="0" Height="1000"/><CHARSHAPE Id="1" Height="1100"/><CHARSHAPE Id="2" Height="1200"/></CHARSHAPELIST>
+    <TABDEFLIST Count="2"><TABDEF Id="0"/><TABDEF Id="1"/></TABDEFLIST>
+    <PARASHAPELIST Count="2"><PARASHAPE Id="0" Align="Left"/><PARASHAPE Id="1" Align="Center"/></PARASHAPELIST>
+    <STYLELIST Count="2"><STYLE Id="0" Name="바탕글"/><STYLE Id="1" Name="본문"/></STYLELIST>
+  </MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>가</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL />
+</HWPML>
+"#
+    .as_bytes();
+
+    let parsed = parse_hml(xml).expect("정상 HML 은 그대로 파싱되어야 함");
+    let d = &parsed.document.doc_info;
+
+    assert_eq!(d.char_shapes.len(), 3);
+    assert_eq!(d.para_shapes.len(), 2);
+    assert_eq!(d.styles.len(), 2);
+    assert_eq!(d.border_fills.len(), 2);
+    assert_eq!(d.tab_defs.len(), 2);
+    assert_eq!(d.font_faces[0].len(), 2);
+    assert_eq!(d.char_shapes[1].base_size, 1100, "값도 그대로여야 함");
+    assert_eq!(d.char_shapes[2].base_size, 1200);
+    assert_eq!(
+        invalid_reference_warnings(&parsed),
+        0,
+        "정상 파일에는 경고가 없어야 함"
+    );
+}


### PR DESCRIPTION
kevin9327 님의 #2731·#2758 을 메인테이너가 재실증 후 통합한다.

## 채택
- **#2731** (`Closes #2722`) — `Table::rebuild_grid()` 가 파일에서 온 `row_count`/`col_count` 를 검증 없이 곱해 `vec![None; rc * cc]` 를 예약했다. 두 필드가 `u16` 이라 최대 `65535 × 65535 = 4,294,836,225` 칸이고 `Option<usize>` 가 16B 이므로 **68.7GB** 예약을 시도해 프로세스가 abort 한다. 실셀이 가리키는 범위와 상한(`MAX_TABLE_GRID_CELLS` = 4,000,000)으로 막았다.
- **#2758** (`Closes #2743`) — `set_indexed()` 가 파일에서 온 `Id` 를 `resize_with(index + 1, ..)` 에 그대로 넘겨, 리소스 테이블 예약 크기가 `Id` 값에 선형 비례했다. 여섯 개 호출부(`FONT`/`BORDERFILL`/`CHARSHAPE`/`PARASHAPE`/`TABDEF`/`STYLE`) 전부를 유계로 만들고, 건너뛴 리소스를 조용히 버리지 않고 `invalid_reference` 경고로 보고한다. 상한 65,535 는 `Id` 가 `u16` 치역이라는 포맷 근거가 있다.

## 메인테이너 보정 — 회귀 시 CI 러너를 죽이는 극단값 (`112c4999`)

두 테스트가 가드 검증을 목적으로 하면서 **그 가드에 의존해야만 살아남는** 구조였다. 가드가 있으면 실셀 범위까지만 예약해 안전하지만, 회귀로 가드가 사라지면 테스트가 빨간불로 알려주는 대신 러너가 스왑에 빠지거나 OOM 으로 죽는다. 원저자도 "수정 전에는 테스트 실패가 아니라 프로세스가 죽는다" 고 주석에 적어 두었는데, 그것이 CI 에서 허용될 수 없는 성질이다.

`size_of` 실측:

| 테스트 | 회귀 시 요구량 | 보정 후 |
|---|---|---|
| `issue_2743` Id=2,000,000,000 | `CharShape` 120B × 20억 = **240GB** | Id 2,000,000 → ~240MB |
| `issue_2722` 65535×65535 (×2 케이스) | `Option<usize>` 16B × 42.9억 = **68.7GB** | 2100×2100 → ~70MB |

상한 초과 여부를 검사한다는 목적은 값을 낮춰도 그대로 달성된다. 경계 정확도는 `hml_resource_id_boundary_accepts_limit_and_rejects_above` 가 65535/65536 으로 고정하므로 잃지 않는다.

## 검증
- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- red→green: 가드 제거 시 #2722 **3건 전부**, #2743 **4건 전부** FAIL → 복원 시 9건 통과
- 보정 **후** red 를 재확인해 검증력 손실이 없음을 확인했다

## 이번 범위에서 제외
- **#2762**(HML `row_count` 25배 팽창) — 수정 자체는 타당하나 회귀 테스트가 없어 보강 요청 후 open 유지. 이 축은 abort 가 아니라 성능 저하라 되돌아가도 CI 가 잡지 못한다.
- #2762 브랜치에 얹혀 있던 **#2760 커밋**도 함께 제외했다. #2772 와 같은 `render_auto_num_format` 을 정의해 중복 정의로 빌드가 깨진다.

Co-authored-by 로 원 커밋 provenance 를 보존한다.