### PR TITLE
fix(hml): 표 셀 안 글상자 문단 귀속 (#2723) + editor README DTO 정정 (#2752) — kevin9327 통합

### DIFF
--- a/mydocs/report/task_m100_2723_report.md
+++ b/mydocs/report/task_m100_2723_report.md
@@ -1,0 +1,290 @@
+# Task M100 #2723 처리결과 보고서 — HML 표 셀 안 글상자 문단 귀속 수정
+
+- 이슈: [#2723](https://github.com/edwardkim/rhwp/issues/2723)
+- 브랜치: `task/m100-2723-hml-nested-textbox`
+- 기준: `origin/devel@49f384463905afd59e59c1b596b70281cb4a8539`
+- 작성일: 2026-07-21
+- 상태: 구현·검증 완료, CI 3종 통과
+
+## 1. 범위
+
+`src/parser/hml/reader.rs` 의 `finish_paragraph` 문단 귀속 규칙 **하나만** 고친다. 같은 파일의
+`set_indexed`·`HmlLimits` 는 별건(#2722)이라 손대지 않았다. 직렬화기·preflight·어댑터·다른 포맷 파서는
+변경 대상이 아니다.
+
+## 2. 문제
+
+HML 리더가 `</P>` 에서 문단을 어느 컨테이너에 넣을지 **컨테이너 종류 우선순위(셀 먼저)** 로 정했다.
+
+```rust
+if let Some(cell) = self.cells.last_mut() {          // 셀이 열려 있으면 무조건 셀
+    cell.paragraphs.push(paragraph);
+} else if let Some(rectangle) = self.rectangles.last_mut() {
+    rectangle.text_box.push(paragraph);
+} else { /* 구역 */ }
+```
+
+`self.cells` 와 `self.rectangles` 는 둘 다 **열린 요소 스택**이라 동시에 비어 있지 않을 수 있다. 그때
+실제 부모는 스택에서 더 안쪽인 쪽인데, 위 코드는 그 순서를 보지 않는다. 그래서
+`CELL > … > RECTANGLE > DRAWINGOBJECT > DRAWTEXT > PARALIST > P` 중첩 — **표 셀 안에 놓인 글상자** —
+에서 글상자 문단이 셀로 흘러들었다.
+
+`adapter.rs:158-160` 이 빈 `text_box` 를 `None` 으로 접으므로 글상자는 텍스트뿐 아니라 **개체 자체가
+IR 에서 사라진다.**
+
+## 3. 분석 — 종류 우선순위 ≠ 최내곽
+
+같은 파일 `reader.rs:855-859` 의 `nearest_object_is_table()` 은 **동일한 문제를 이미 올바르게** 푼다.
+
+```rust
+fn nearest_object_is_table(&self) -> bool {
+    let rectangle = self.stack.iter().rposition(|name| name == "RECTANGLE");
+    let table = self.stack.iter().rposition(|name| name == "TABLE");
+    table.is_some_and(|table_index| rectangle.is_none_or(|rect_index| table_index > rect_index))
+}
+```
+
+사용처 3곳 — `capture_object_size(:809)`, `capture_object_position(:822)`, `capture_shape_object(:861)` —
+가 모두 이 판정을 쓴다. `capture_shape_object` 에는 "종전엔 rectangle 만 처리해 표의 TextWrap 이 HML
+재로드 시 기본값 Square 로 유실됐다"는 주석까지 남아 있다. 컨테이너 선택이 필요한 함수 4개 중
+`finish_paragraph` 만 예외였다.
+
+의도된 설계라는 근거는 다음 확인 범위에서 나오지 않았다.
+
+| 확인 | 결과 |
+|---|---|
+| `git log -S "finish_paragraph" -- src/parser/hml/reader.rs` | 최초 도입 커밋 `40cecb82` 1건뿐, 이후 수정 없음 |
+| `mydocs/` 전체 `finish_paragraph` / `nearest_object_is_table` | 0건 |
+| 종류 우선순위 귀속을 정당화하는 계획·보고서 | 0건 |
+| 동일 규칙을 다루는 열린 이슈·PR | 0건 |
+
+`</P>`(안쪽 글상자 문단) 시점의 스택 — `end()` 가 `finish_element()` 를 호출한 **뒤에** pop 하므로
+닫히는 `P` 도 포함된다.
+
+```
+HWPML BODY SECTION P TEXT TABLE ROW CELL PARALIST P TEXT RECTANGLE DRAWINGOBJECT DRAWTEXT PARALIST P
+                                    ^ rposition=7                               ^ rposition=13
+```
+
+`DRAWTEXT(13) > CELL(7)`. 구분에 필요한 정보는 스택에 이미 완전히 있었고, 쓰이지 않았을 뿐이다.
+
+## 4. 변경
+
+### 4.1 `src/parser/hml/reader.rs` (+22 / −3)
+
+`nearest_object_is_table()` 바로 아래에 대칭 헬퍼를 추가했다.
+
+```rust
+fn nearest_paragraph_owner_is_cell(&self) -> bool {
+    let draw_text = self.stack.iter().rposition(|name| name == "DRAWTEXT");
+    let cell = self.stack.iter().rposition(|name| name == "CELL");
+    cell.is_some_and(|cell_index| draw_text.is_none_or(|text_index| cell_index > text_index))
+}
+```
+
+`finish_paragraph` 은 **글상자가 스택상 더 안쪽일 때만** 글상자를 고르고, 나머지는 종전 순서(셀 → 구역)를
+그대로 둔다.
+
+```rust
+let owner_is_cell = self.nearest_paragraph_owner_is_cell();
+if let Some(rectangle) = self.rectangles.last_mut().filter(|_| !owner_is_cell) {
+    rectangle.text_box.push(paragraph);
+} else if let Some(cell) = self.cells.last_mut() {
+    cell.paragraphs.push(paragraph);
+} else { /* 구역 */ }
+```
+
+비교 대상을 `RECTANGLE` 이 아니라 `DRAWTEXT` 로 둔 이유: 사각형이 문단을 받는 자식은 `DRAWTEXT` 뿐이라
+`SHAPEOBJECT`/`SHAPECOMPONENT`/`LINESHAPE` 등 형제 요소가 열려 있는 동안의 오판 여지를 없앤다.
+
+분기 순서를 뒤집어(사각형 → 셀 → 구역) `!owner_is_cell` 판정이 참이지만 `rectangles` 가 빈 비정상 입력
+(예: `RECTANGLE` 없는 떠 있는 `DRAWTEXT`)에서도 종전과 동일하게 셀로 떨어지게 했다.
+
+동작이 바뀌는 경우는 **`CELL` 과 `DRAWTEXT` 가 동시에 열려 있고 `DRAWTEXT` 가 더 안쪽인 하나뿐**이다.
+
+| 스택 상태 | 종전 | 변경 후 |
+|---|---|---|
+| `CELL` 만 | 셀 | 셀 (동일) |
+| `DRAWTEXT` 만 | 글상자 | 글상자 (동일) |
+| 둘 다 없음 | 구역 | 구역 (동일) |
+| `CELL` 이 더 안쪽 (글상자 안 표) | 셀 | 셀 (동일) |
+| **`DRAWTEXT` 가 더 안쪽 (셀 안 글상자)** | **셀 (결함)** | **글상자 (수정)** |
+
+### 4.2 `tests/hml_parser.rs` (+66)
+
+기존 `nested_table_layout_does_not_overwrite_enclosing_rectangle`(글상자 **안에** 표) 바로 아래에 반대
+방향 픽스처와 테스트 2개를 붙였다.
+
+- `CELL_TEXTBOX_HML` — 셀 문단 1개가 사각형을 담고, 그 사각형 `DRAWTEXT` 안에 `BOXTEXT` 문단 1개.
+- `first_cell_rectangle()` — 셀 문단 수가 1인지 단언하며 셀 안 사각형을 꺼내는 공용 헬퍼.
+- `textbox_inside_table_cell_keeps_its_own_paragraphs` — 파싱 직후 `text_box` 가 `Some` 이고 문단
+  `"BOXTEXT"` 1개.
+- `textbox_inside_table_cell_survives_hml_export_and_reopen` — `export_hml_native()` 산출 XML의
+  `<DRAWTEXT>` 가 1개이고, 되읽은 IR에서도 글상자가 살아 있음.
+
+## 5. 검증
+
+### 5.1 실측 재현 (기준 `origin/devel@49f38446`, 수정 전)
+
+저장소 실제 한컴 파일 `samples/hml/formatting_table.hml` 의 첫 CELL PARALIST 에
+`RECTANGLE/DRAWINGOBJECT/DRAWTEXT/PARALIST/P`(`<CHAR>BOXTEXT</CHAR>`) 하나를 주입해
+`./target/debug/rhwp.exe dump` 를 돌렸다. 이 파일은 구역 직속 사각형(글상자 `"textbox"`)도 함께 갖고 있어
+정상 경로와 결함 경로를 한 실행에서 대조할 수 있다.
+
+구역 직속 사각형 — 정상:
+
+```
+--- 문단 0.0 --- cc=15, text_len=6, controls=1
+  [0]   [사각형] round=0%
+    글상자: list_attr=0x00000000, margins=(283,283,283,283), max_width=6611, paras=1
+      p[0]: ps_id=0, cc=8, text="textbox", ls_count=0, ctrls=0
+```
+
+표 셀 안의 사각형 — 결함:
+
+```
+  [0]   셀[0] r=0,c=0 rs=1,cs=1 h=282 w=41956 pad=(510,510,141,141) valign=Center aim=true hdr=false bf=3 paras=3 text="table|BOXTEXT|"
+  [0]     p[0] ps_id=0 ctrls=0 text_len=5
+  [0]     p[1] ps_id=0 ctrls=0 text_len=7      <- 유입된 "BOXTEXT"
+  [0]     p[2] ps_id=0 ctrls=1 text_len=0      <- 사각형을 담은 문단 (순서 역전)
+  [0]       ctrl[0] 사각형: tac=true, wrap=Square
+```
+
+수정 후 같은 파일:
+
+```
+  [0]   셀[0] r=0,c=0 rs=1,cs=1 h=282 w=41956 pad=(510,510,141,141) valign=Center aim=true hdr=false bf=3 paras=2 text="table|"
+  [0]     p[0] ps_id=0 ctrls=0 text_len=5
+  [0]     p[1] ps_id=0 ctrls=1 text_len=0
+  [0]       ctrl[0] 사각형: tac=true, wrap=Square
+```
+
+`paras=3 → 2`, 셀 텍스트 `"table|BOXTEXT|" → "table|"`.
+
+### 5.2 export → 재열기 왕복 — 실측
+
+`./target/debug/rhwp.exe export-hml <입력> -o <출력>` 을 같은 파일에 대해 수정 전/후로 각각 실행했다.
+
+| | 수정 전 | 수정 후 |
+|---|---|---|
+| 종료 코드 | 0 (거부 없음) | 0 |
+| 출력 `<DRAWTEXT>` 태그 | `['<DRAWTEXT>']` — **1개** | `['<DRAWTEXT>', '<DRAWTEXT>']` — 2개 |
+| 셀 문단 수 | 3 (`table`, `BOXTEXT`, 사각형) | 2 (`table`, 사각형) |
+| `BOXTEXT` 위치 | 셀 문단으로 승격 | `DRAWTEXT/PARALIST/P` 내부 |
+
+수정 전 출력 CELL(요약) — `<DRAWTEXT>` 블록이 통째로 사라졌다.
+
+```xml
+<CELL …><PARALIST>
+  <P …><TEXT CharShape="0"><CHAR>table</CHAR></TEXT></P>
+  <P …><TEXT CharShape="0"><CHAR>BOXTEXT</CHAR></TEXT></P>
+  <P …><TEXT CharShape="0"><RECTANGLE …><DRAWINGOBJECT>
+    <SHAPECOMPONENT …/><LINESHAPE …/>
+  </DRAWINGOBJECT></RECTANGLE></TEXT></P>
+</PARALIST></CELL>
+```
+
+수정 후 출력 CELL(요약) — 원문 구조가 보존된다.
+
+```xml
+<CELL …><PARALIST>
+  <P …><TEXT CharShape="0"><CHAR>table</CHAR></TEXT></P>
+  <P …><TEXT CharShape="0"><RECTANGLE …><DRAWINGOBJECT>
+    <SHAPECOMPONENT …/><LINESHAPE …/>
+    <DRAWTEXT><TEXTMARGIN …/><PARALIST>
+      <P …><TEXT CharShape="0"><CHAR>BOXTEXT</CHAR></TEXT></P>
+    </PARALIST></DRAWTEXT>
+  </DRAWINGOBJECT></RECTANGLE></TEXT></P>
+</PARALIST></CELL>
+```
+
+즉 왕복 파괴는 **코드 확인이 아니라 측정으로 확인**됐고, 수정으로 해소됐다.
+
+### 5.3 red → green (실제 실행 캡처)
+
+수정 코드만 되돌리고(테스트는 그대로) 실행한 결과 — 원문 그대로.
+
+```
+running 3 tests
+test nested_table_layout_does_not_overwrite_enclosing_rectangle ... ok
+test textbox_inside_table_cell_keeps_its_own_paragraphs ... FAILED
+test textbox_inside_table_cell_survives_hml_export_and_reopen ... FAILED
+
+failures:
+
+---- textbox_inside_table_cell_keeps_its_own_paragraphs stdout ----
+
+thread 'textbox_inside_table_cell_keeps_its_own_paragraphs' (39816) panicked at tests\hml_parser.rs:867:5:
+assertion `left == right` failed: 셀 문단은 사각형을 담은 1개뿐이어야 한다
+  left: 2
+ right: 1
+note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
+
+---- textbox_inside_table_cell_survives_hml_export_and_reopen stdout ----
+
+thread 'textbox_inside_table_cell_survives_hml_export_and_reopen' (38400) panicked at tests\hml_parser.rs:901:5:
+assertion `left == right` failed
+  left: 0
+ right: 1
+
+
+failures:
+    textbox_inside_table_cell_keeps_its_own_paragraphs
+    textbox_inside_table_cell_survives_hml_export_and_reopen
+
+test result: FAILED. 1 passed; 2 failed; 0 ignored; 0 measured; 33 filtered out; finished in 0.01s
+```
+
+수정 복구 후 같은 명령 — 원문 그대로.
+
+```
+running 3 tests
+test textbox_inside_table_cell_keeps_its_own_paragraphs ... ok
+test nested_table_layout_does_not_overwrite_enclosing_rectangle ... ok
+test textbox_inside_table_cell_survives_hml_export_and_reopen ... ok
+
+test result: ok. 3 passed; 0 failed; 0 ignored; 0 measured; 33 filtered out; finished in 0.01s
+```
+
+`left: 0 / right: 1` 은 `xml.matches("<DRAWTEXT>").count()` 로, 수정 전 직렬화기가 `<DRAWTEXT>` 를
+**하나도** 쓰지 않았음을 뜻한다.
+
+### 5.4 반대 방향 중첩 비회귀
+
+`nested_table_layout_does_not_overwrite_enclosing_rectangle`(글상자 **안에** 표, `tests/hml_parser.rs`)
+는 **red 실행과 green 실행 양쪽에서 모두 `ok`** 다(위 캡처 1행/2행). 이 방향은 `</CELL>` 이 이미 닫혀
+`cells` 가 비어 있어 종전에도 정상이었고, 이번 변경 후에도 `rposition(CELL) > rposition(DRAWTEXT)` 로
+동일하게 셀이 선택된다. 한 방향을 고치면서 반대 방향을 깨지 않았다.
+
+`tests/hml_parser.rs` 전체도 통과한다 — `test result: ok. 36 passed; 0 failed; 0 ignored`.
+
+### 5.5 CI 3종 (최종 트리 기준, 커밋 내용과 동일)
+
+| 항목 | 명령 | 결과 |
+|---|---|---|
+| clippy | `cargo clippy --all-targets -- -D warnings` | `Finished dev profile … in 55.90s` — 경고 0 |
+| test | `cargo test --profile release-test --tests` | **3482 passed, 0 failed, 23 ignored** (`test result:` 291줄, `FAILED` 0줄) |
+| fmt | 변경 `.rs` 2개에 `rustfmt --edition 2021` 후 재실행 | md5 불변(멱등), 추가 변경 0 |
+
+fmt 는 `cargo fmt --all -- --check` 를 쓰지 않았다. 이 Windows 체크아웃에서는 CRLF 파일에 대해
+`Incorrect newline style` 만 출력하고 diff 를 내지 않아 거짓 통과가 된다.
+
+## 6. 미실행 항목
+
+- **렌더링 픽셀 대조.** IR 과 HML 직렬화 산출물까지만 측정했다. `export-svg`/`export-pdf` 결과를 한컴
+  뷰어 출력과 픽셀 비교하지는 않았다.
+- **한컴에서 저장한 "셀 안 글상자" 원본 파일 확보.** 저장소 실제 한컴 파일(`formatting_table.hml`)에
+  해당 중첩을 주입해 재현했다. 한컴이 직접 저장한 동일 구조 원본으로는 대조하지 못했다.
+- **HWP5/HWPX 경로 회귀.** 변경은 HML 리더 안에서 끝나므로 다른 포맷은 영향을 받지 않지만, 두 포맷의
+  동일 중첩을 별도로 측정하지는 않았다.
+
+## 7. 잔여 (범위 밖)
+
+- **HWPX/HWP5 리더의 동일 패턴 점검.** 다른 포맷 리더가 같은 종류 우선순위 귀속을 쓰는지 미확인.
+- **캡션 등 다른 문단 컨테이너.** 현행 HML 리더가 `CAPTION` 문단을 모델링하지 않아 당장 증상은 없으나,
+  추가될 경우 같은 판정이 필요하다.
+- **`export-hml` preflight 강화.** 이번 수정으로 왕복은 보존되지만, 구조 오귀속을 preflight
+  (`validate_cell` → `validate_paragraph` → `validate_rectangle`)가 잡지 못한다는 사실은 남는다. 차단기
+  추가는 별도 논의가 필요하다.
+- **`dump` 출력의 셀 내부 컨트롤 상세도.** 셀 안 사각형은 한 줄 요약(`ctrl[0] 사각형: …`)만 나와 글상자
+  유무가 보이지 않는다. 이번 결함을 CLI 만으로 알아채기 어려웠던 이유이며, 출력 보강은 별건이다.

--- a/mydocs/report/task_m100_2752_report.md
+++ b/mydocs/report/task_m100_2752_report.md
@@ -1,0 +1,157 @@
+# task m100-2752 — @rhwp/editor README `getHmlSaveState()` 반환 형태 오문서 수정
+
+## 이슈
+
+- **Issue**: [#2752](https://github.com/edwardkim/rhwp/issues/2752) — `npm/editor/README.md`의
+  `editor.getHmlSaveState()` 절이 실재하지 않는 반환 형태 `{ ok, blocker }` 를 문서화
+
+## 분석
+
+`npm/editor/README.md:212`~`219` 이 다음과 같이 적혀 있었다.
+
+```javascript
+const state = await editor.getHmlSaveState();
+// { ok: true } 또는 { ok: false, blocker: '...' }
+```
+
+`ok` / `blocker` 는 이 API 와 관련해 저장소 어디에서도 정의되거나 반환된 적이 없는 키다.
+실제 wire DTO 는 `{ sourceFormat, hmlSavable, blockers[] }` 이며 다음 6곳이 이를 못박는다.
+
+| # | 근거 | 위치 |
+|---|------|------|
+| 1 | canonical Rust DTO `struct HmlSaveState { source_format, hml_savable, blockers }` (serde `camelCase`) | `src/wasm_api.rs:272`~`287` |
+| 2 | `source_format_name()` 이 `"hwpx" \| "hml" \| "hwp"` 만 반환 | `src/wasm_api.rs:317`~`323` |
+| 3 | studio 브리지가 `HmlSaveState { sourceFormat, hmlSavable, blockers }` 로 파싱·반환 | `rhwp-studio/src/core/wasm-bridge.ts:329`~`336`, `rhwp-studio/src/core/hml-save-capability.ts:23`~`27` |
+| 4 | embed 핸들러가 가공 없이 그대로 응답 | `rhwp-studio/src/main.ts:1334`~`1336` |
+| 5 | CI 계약 테스트가 `deepEqual` 로 정확한 DTO 고정 | `scripts/frontend-editor-embed.test.mjs:74`~`81` |
+| 6 | studio e2e 가 `state.sourceFormat === 'hml' && state.hmlSavable && state.blockers.length === 0` 단언 | `rhwp-studio/e2e/hml-equation-embed.test.mjs:264` |
+
+같은 패키지의 `npm/editor/index.d.ts:35`~`46` 도 `HmlSaveState` / `HmlSaveBlocker` 를 정확히 선언하고
+있고, `npm/editor/index.js:202`~`205` 는 studio 응답을 가공 없이 통과시키므로 SDK 계층에 `ok`/`blocker`
+어댑터도 없다.
+
+### 왜 의도된 표기가 아닌가
+
+```
+$ git log -S "{ ok: false, blocker" -- npm/editor/README.md
+a0f839d7 docs(editor): README에 exportHml·getHmlSaveState API 문서 추가 (#2691)
+```
+
+해당 절을 도입한 유일한 커밋이며, 그 이전 README 에는 절 자체가 없었다. 즉 과거 형태의 보존도, 의도적
+축약 표기도 아니다.
+
+### 사용자 영향
+
+README 는 `package.json` 의 `files` 배열에 포함되어 npm 타르볼로 배포되고 npmjs.com 패키지 첫 화면으로
+렌더링된다. README 예제를 그대로 따른 JavaScript 소비자는
+
+- `state.ok` → `undefined` (항상 falsy) → **HML 저장이 가능한 문서에서도 저장 분기에 절대 진입하지 못함**
+- `state.blocker` → `undefined` → 사용자에게 `"...: undefined"` 표시
+
+TypeScript 소비자는 `index.d.ts` 덕분에 컴파일 오류로 걸러진다. 즉 이 결함의 유일한 발현 표면이 문서다.
+
+## 변경
+
+### 1. `npm/editor/README.md` — `### editor.getHmlSaveState()` 절 교체
+
+인접한 올바른 형제 절 `editor.exportHwpVerify()` (`README.md:178`~`194`, 필드가 `index.d.ts` 의
+`HwpVerifyResult` 와 정확히 일치)의 서술 방식을 따랐다.
+
+- 실제 반환 객체를 주석으로 제시 (`sourceFormat`, `hmlSavable`, `blockers[].{code,xmlPath,message,preserved}`)
+- `hmlSavable` 로 분기하고 `blockers` 를 표시하는 사용 예제 추가 — 오류 문자열 파싱을 금지한 SPEC 계약
+  (`docs/changelog/2026-07/13-pr-2219-hml-equation-export-spec/SPEC.md:247`, `:321`)과 일치
+- 반환값 / `HmlSaveBlocker` 필드 표 추가. `sourceFormat` 값 범위는 근거 #2, `preserved` 가 항상 `false`
+  인 점은 `src/wasm_api.rs:305` 및 `index.d.ts:39` 근거
+
+`index.js` / `index.d.ts` / studio / Rust 는 모두 이미 정확하므로 **코드 변경 없음**.
+
+### 2. `npm/editor/tests/hml-save-state-doc.contract.test.mjs` — 신규 계약 테스트
+
+`index.d.ts` 원문을 파싱해 계약을 고정하는 기존 선례
+(`npm/editor/tests/renderer-diagnostics-v1.contract.test.mjs`)를 그대로 따른다.
+
+- `HmlSaveState` / `HmlSaveBlocker` 필드 7개를 `index.d.ts` 에서 추출하고, README 절이 그 7개를 모두
+  **객체 키 형태**(`\bfield\s*:`)로 보이는지 검사
+- 실재하지 않는 `ok:` / `blocker:` 표기가 절에 없는지 검사 (`blockers:` / `blocker.code` 같은 정상 표기는
+  걸리지 않음)
+- 체크아웃에 따라 CRLF 일 수 있으므로 두 파일 모두 LF 로 정규화 후 비교
+
+`npm/editor/package.json` 의 `test` 스크립트가 `tests/*.test.mjs` 를 실행하므로
+`.github/workflows/ci.yml:685` 의 `npm --prefix npm/editor test` 에 자동 포함된다.
+
+## 검증
+
+### RED → GREEN (실제 실행)
+
+테스트를 먼저 추가하고 README 수정 전 상태에서 실행 — **2/2 실패**.
+
+```
+$ node --test tests/hml-save-state-doc.contract.test.mjs
+✖ README getHmlSaveState 절은 HmlSaveState 선언과 같은 필드를 문서화한다 (8.4593ms)
+✖ README getHmlSaveState 절은 실재하지 않는 반환 필드를 문서화하지 않는다 (0.5233ms)
+ℹ tests 2
+ℹ pass 0
+ℹ fail 2
+
+✖ failing tests:
+
+✖ README getHmlSaveState 절은 HmlSaveState 선언과 같은 필드를 문서화한다
+  AssertionError [ERR_ASSERTION]: README 가 반환값 필드 sourceFormat 를 객체 키 형태로 보여야 한다
+    actual: "### editor.getHmlSaveState()\n\n현재 문서의 HML 저장 가능 여부와 blocker를 반환합니다.\n\n
+             ```javascript\nconst state = await editor.getHmlSaveState();\n
+             // { ok: true } 또는 { ok: false, blocker: '...' }\n```\n",
+    expected: /\bsourceFormat\s*:/,
+    operator: 'match',
+
+✖ README getHmlSaveState 절은 실재하지 않는 반환 필드를 문서화하지 않는다
+  AssertionError [ERR_ASSERTION]: getHmlSaveState 는 ok 필드를 반환하지 않는다
+    actual: "### editor.getHmlSaveState()\n\n... // { ok: true } 또는 { ok: false, blocker: '...' }\n```\n",
+    expected: /\bok\s*:/,
+    operator: 'doesNotMatch',
+```
+
+README 수정 후 재실행 — **2/2 통과**.
+
+```
+$ node --test tests/hml-save-state-doc.contract.test.mjs
+✔ README getHmlSaveState 절은 HmlSaveState 선언과 같은 필드를 문서화한다 (6.5352ms)
+✔ README getHmlSaveState 절은 실재하지 않는 반환 필드를 문서화하지 않는다 (0.6775ms)
+ℹ tests 2
+ℹ pass 2
+ℹ fail 0
+```
+
+### CI 게이트
+
+| 명령 | 결과 |
+|------|------|
+| `npm --prefix npm/editor test --if-present` (ci.yml:685) | **21 pass / 0 fail** (기존 19 + 신규 2) |
+| `node --test scripts/frontend-editor-embed.test.mjs` (ci.yml:682) | **2 pass / 0 fail** — 회귀 없음 |
+
+`.rs` 변경이 없으므로 cargo 게이트(clippy / test / rustfmt)는 해당 없음.
+
+### 로컬 환경 한정 실패 (이번 변경과 무관, 사전 존재)
+
+- `scripts/frontend-wasm-bindings.test.mjs` — `pkg/rhwp.d.ts` 부재로 `ENOENT`. `pkg/` 는 wasm-pack
+  빌드 산출물이라 로컬 체크아웃에 없다.
+- `rhwp-chrome/sw/*.test.mjs`, `rhwp-firefox/sw/*.test.mjs` — `SyntaxError: Unexpected token '.'`.
+  `sw/document-url-resolver.js` 등이 `rhwp-shared/sw/` 를 가리키는 **심볼릭 링크**인데 Windows 체크아웃에서
+  링크 대상 경로 문자열(`../../rhwp-shared/sw/...`)을 담은 일반 파일로 복원되어 모듈 파싱이 실패한다.
+  두 경우 모두 이번 diff(`npm/editor/` 2파일) 밖이며 Linux CI 에서는 발생하지 않는다.
+
+## 결과
+
+- **Branch**: `task/m100-2752-editor-readme-hml-save-state`
+- **변경 파일 2개**: `npm/editor/README.md` (수정), `npm/editor/tests/hml-save-state-doc.contract.test.mjs` (신규)
+- **Closes**: #2752
+
+## 범위 밖 (잔여)
+
+- README 절 배치 순서(`exportHml`/`getHmlSaveState` 가 `exportHwpVerify` 뒤)와 `index.js`/`index.d.ts`
+  선언 순서(앞) 불일치 — 사실 오류가 아니므로 제외.
+- `exportHml()` / `getHmlSaveState()` 가 `getRendererDiagnostics()` 와 달리
+  `transport.supports('hml-export')` 를 검사하지 않는 비대칭 — legacy postMessage 폴백에서
+  `_peerCapabilities` 가 비워지므로(`npm/editor/transport.js:231`) 하드 capability 검사는 legacy 경로를
+  깨뜨린다. 의도된 설계로 판단해 제외.
+- `rhwp-shared/security/` 의 `url-validator.js` / `filename-sanitizer.js` / `security-log.js` /
+  `sender-validator.js` 가 현재 어떤 확장에서도 import 되지 않는 상태 — 별도 사안.

--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -211,12 +211,51 @@ URL.revokeObjectURL(url);
 
 ### editor.getHmlSaveState()
 
-현재 문서의 HML 저장 가능 여부와 blocker를 반환합니다.
+현재 문서의 HML 저장 가능 여부와 blocker 목록을 반환합니다.
+저장 가능 여부는 `hmlSavable`로 판정하고, 실패 원인은 `blockers` 배열로 표시하세요.
+`exportHml()`의 오류 문자열을 파싱하지 마세요.
 
 ```javascript
 const state = await editor.getHmlSaveState();
-// { ok: true } 또는 { ok: false, blocker: '...' }
+// {
+//   sourceFormat: 'hwp',
+//   hmlSavable: false,
+//   blockers: [
+//     {
+//       code: 'HML_SOURCE_REQUIRED',
+//       xmlPath: '/HWPML',
+//       message: 'HML source metadata is required',
+//       preserved: false
+//     }
+//   ]
+// }
+
+if (state.hmlSavable) {
+  const bytes = await editor.exportHml();
+  // ... 저장 진행
+} else {
+  for (const item of state.blockers) {
+    console.warn(`HML 저장 불가 [${item.code}] ${item.xmlPath} — ${item.message}`);
+  }
+}
 ```
+
+**반환값:**
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `sourceFormat` | `string` | 현재 문서의 원본 형식 — `'hwp'`, `'hwpx'`, `'hml'` |
+| `hmlSavable` | `boolean` | HML로 저장 가능하면 `true` |
+| `blockers` | `HmlSaveBlocker[]` | 저장을 막는 요소 목록. `hmlSavable`이 `true`이면 빈 배열 |
+
+**`HmlSaveBlocker`:**
+
+| 필드 | 타입 | 설명 |
+|------|------|------|
+| `code` | `string` | blocker 종류 코드 |
+| `xmlPath` | `string` | 해당 요소의 XML 경로 |
+| `message` | `string` | 사람이 읽을 수 있는 사유 |
+| `preserved` | `false` | 항상 `false` — 해당 요소가 HML로 보존되지 않음을 뜻함 |
 
 ### editor.destroy()
 

--- a/npm/editor/tests/hml-save-state-doc.contract.test.mjs
+++ b/npm/editor/tests/hml-save-state-doc.contract.test.mjs
@@ -1,0 +1,61 @@
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+
+/** 체크아웃에 따라 CRLF 일 수 있으므로 개행을 LF 로 정규화한 뒤 비교한다. */
+function readText(relativePath) {
+  return readFileSync(fileURLToPath(new URL(relativePath, import.meta.url)), 'utf8')
+    .replace(/\r\n/g, '\n');
+}
+
+const declarations = readText('../index.d.ts');
+const readme = readText('../README.md');
+
+/** index.d.ts 의 interface 선언에서 필드명 목록을 뽑는다. */
+function interfaceFields(name) {
+  const match = declarations.match(new RegExp(`export interface ${name} \\{([\\s\\S]*?)\\n\\}`));
+  assert.ok(match, `${name} 선언이 index.d.ts 에 존재해야 한다`);
+  return match[1]
+    .split('\n')
+    .map((line) => line.trim().match(/^([A-Za-z][A-Za-z0-9]*)\??:/))
+    .filter((matched) => matched !== null)
+    .map((matched) => matched[1]);
+}
+
+/** README 의 `### <heading>` 절 본문을 다음 heading 직전까지 잘라 반환한다. */
+function readmeSection(heading) {
+  const start = readme.indexOf(`\n### ${heading}\n`);
+  assert.ok(start >= 0, `README 절 "${heading}" 이 존재해야 한다`);
+  const rest = readme.slice(start + 1);
+  const next = rest.search(/\n#+ /);
+  return next < 0 ? rest : rest.slice(0, next);
+}
+
+test('README getHmlSaveState 절은 HmlSaveState 선언과 같은 필드를 문서화한다', () => {
+  const section = readmeSection('editor.getHmlSaveState()');
+  const fields = [
+    ...interfaceFields('HmlSaveState'),
+    ...interfaceFields('HmlSaveBlocker'),
+  ];
+  assert.deepEqual(fields, [
+    'sourceFormat', 'hmlSavable', 'blockers',
+    'code', 'xmlPath', 'message', 'preserved',
+  ]);
+
+  for (const field of fields) {
+    assert.match(
+      section,
+      new RegExp(`\\b${field}\\s*:`),
+      `README 가 반환값 필드 ${field} 를 객체 키 형태로 보여야 한다`,
+    );
+  }
+});
+
+test('README getHmlSaveState 절은 실재하지 않는 반환 필드를 문서화하지 않는다', () => {
+  const section = readmeSection('editor.getHmlSaveState()');
+  // `ok` / `blocker` 는 wire DTO 에 없는 키다. 객체 키 형태(`ok:`, `blocker:`)만 금지하므로
+  // `blockers:` 나 `blocker.code` 같은 정상 표기는 걸리지 않는다.
+  assert.doesNotMatch(section, /\bok\s*:/, 'getHmlSaveState 는 ok 필드를 반환하지 않는다');
+  assert.doesNotMatch(section, /\bblocker\s*:/, 'getHmlSaveState 는 blocker 필드를 반환하지 않는다');
+});

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -929,6 +929,17 @@ impl<'a> ReadState<'a> {
         table.is_some_and(|table_index| rectangle.is_none_or(|rect_index| table_index > rect_index))
     }
 
+    /// [#2723] 닫히는 P 를 셀에 넣을지 글상자에 넣을지 판정한다.
+    /// cells 와 rectangles 는 둘 다 열린 요소 스택이라 동시에 비어 있지 않을 수 있고,
+    /// 그때 실제 부모는 스택에서 더 안쪽인 쪽이다. nearest_object_is_table 과 동일한
+    /// rposition 비교를 쓴다. 사각형이 문단을 받는 자식은 DRAWTEXT 뿐이므로
+    /// RECTANGLE 대신 DRAWTEXT 를 비교해 형제 요소로 인한 오판을 배제한다.
+    fn nearest_paragraph_owner_is_cell(&self) -> bool {
+        let draw_text = self.stack.iter().rposition(|name| name == "DRAWTEXT");
+        let cell = self.stack.iter().rposition(|name| name == "CELL");
+        cell.is_some_and(|cell_index| draw_text.is_none_or(|text_index| cell_index > text_index))
+    }
+
     fn capture_shape_object(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
         let text_wrap = parse_text_wrap(attribute(element, b"TextWrap")?.as_deref());
         // SHAPEOBJECT 는 표에도 방출되므로(write_shape_object) rectangle 뿐 아니라
@@ -1066,10 +1077,15 @@ impl<'a> ReadState<'a> {
             .paragraphs
             .pop()
             .ok_or_else(|| HmlError::InvalidXml("unexpected P end".to_string()))?;
-        if let Some(cell) = self.cells.last_mut() {
-            cell.paragraphs.push(paragraph);
-        } else if let Some(rectangle) = self.rectangles.last_mut() {
+        // [#2723] 종전엔 종류 우선순위(셀 먼저)로 골라, CELL 안 사각형의 DRAWTEXT
+        // 문단이 셀로 흘러들어 글상자는 비고(adapter 가 None 으로 접음) 셀에는 이물
+        // 문단이 남았다. 글상자가 스택상 더 안쪽일 때만 글상자를 고르고, 나머지는
+        // 종전 순서(셀 → 구역)를 그대로 유지한다.
+        let owner_is_cell = self.nearest_paragraph_owner_is_cell();
+        if let Some(rectangle) = self.rectangles.last_mut().filter(|_| !owner_is_cell) {
             rectangle.text_box.push(paragraph);
+        } else if let Some(cell) = self.cells.last_mut() {
+            cell.paragraphs.push(paragraph);
         } else {
             self.source
                 .sections

--- a/tests/hml_parser.rs
+++ b/tests/hml_parser.rs
@@ -845,6 +845,72 @@ fn nested_table_layout_does_not_overwrite_enclosing_rectangle() {
     assert!(!table.common.allow_overlap);
 }
 
+/// [#2723] 셀 안 글상자 중첩(위 테스트의 반대 방향). 종전엔 cells 가 열려 있다는
+/// 이유만으로 DRAWTEXT 문단이 셀로 흘러들어 글상자가 통째로 비었다.
+const CELL_TEXTBOX_HML: &[u8] = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><TABLE RowCount="1" ColCount="1">
+    <SHAPEOBJECT><SIZE Width="4000" Height="1200"/></SHAPEOBJECT>
+    <ROW><CELL ColAddr="0" RowAddr="0" Width="4000" Height="1200"><PARALIST><P><TEXT><RECTANGLE X0="0" X1="1000" X2="1000" X3="0" Y0="0" Y1="0" Y2="500" Y3="500">
+      <SHAPEOBJECT><SIZE Width="1000" Height="500"/></SHAPEOBJECT>
+      <DRAWINGOBJECT><SHAPECOMPONENT XPos="0" YPos="0" OriWidth="1000" OriHeight="500" CurWidth="1000" CurHeight="500"/>
+        <LINESHAPE Width="0" Style="Solid" EndCap="Flat" Alpha="0"/>
+        <DRAWTEXT><TEXTMARGIN Left="0" Right="0" Top="0" Bottom="0"/><PARALIST>
+          <P><TEXT><CHAR>BOXTEXT</CHAR></TEXT></P>
+        </PARALIST></DRAWTEXT>
+      </DRAWINGOBJECT>
+    </RECTANGLE></TEXT></P></PARALIST></CELL></ROW>
+  </TABLE></TEXT></P></SECTION></BODY><TAIL/></HWPML>"#;
+
+fn first_cell_rectangle(document: &rhwp::model::document::Document) -> &RectangleShape {
+    let Control::Table(table) = &document.sections[0].paragraphs[0].controls[0] else {
+        panic!("section paragraph should host the table");
+    };
+    assert_eq!(
+        table.cells[0].paragraphs.len(),
+        1,
+        "셀 문단은 사각형을 담은 1개뿐이어야 한다"
+    );
+    let Control::Shape(shape) = &table.cells[0].paragraphs[0].controls[0] else {
+        panic!("cell paragraph should host the rectangle");
+    };
+    let ShapeObject::Rectangle(rectangle) = shape.as_ref() else {
+        panic!("cell shape should be a rectangle");
+    };
+    rectangle
+}
+
+#[test]
+fn textbox_inside_table_cell_keeps_its_own_paragraphs() {
+    let parsed = parse_hml(CELL_TEXTBOX_HML).expect("textbox inside a cell should parse");
+    let text_box = first_cell_rectangle(&parsed.document)
+        .drawing
+        .text_box
+        .as_ref()
+        .expect("rectangle inside a cell should keep its text box");
+
+    assert_eq!(text_box.paragraphs.len(), 1);
+    assert_eq!(text_box.paragraphs[0].text, "BOXTEXT");
+}
+
+#[test]
+fn textbox_inside_table_cell_survives_hml_export_and_reopen() {
+    let core = DocumentCore::from_bytes(CELL_TEXTBOX_HML).expect("cell textbox should import");
+    let exported = core
+        .export_hml_native()
+        .expect("cell textbox should export");
+    let xml = std::str::from_utf8(&exported).expect("HML is UTF-8");
+    assert_eq!(xml.matches("<DRAWTEXT>").count(), 1);
+
+    let reopened = DocumentCore::from_bytes(&exported).expect("exported HML should reparse");
+    let text_box = first_cell_rectangle(reopened.document())
+        .drawing
+        .text_box
+        .as_ref()
+        .expect("reopened rectangle should keep its text box");
+
+    assert_eq!(text_box.paragraphs.len(), 1);
+    assert_eq!(text_box.paragraphs[0].text, "BOXTEXT");
+}
+
 #[test]
 fn missing_shape_current_size_materializes_from_original_size() {
     let xml = br#"<HWPML Version="2.91"><HEAD/><BODY><SECTION><P><TEXT><RECTANGLE>


### PR DESCRIPTION
kevin9327 님의 #2738·#2761 을 메인테이너가 재실증 후 통합한다.

## 채택

- **#2738** (`Closes #2723`) — HML 리더의 `finish_paragraph()` 가 문단을 넣을 컨테이너를 **종류 우선순위**(셀 먼저)로 골라, 표 셀 안에 놓인 글상자의 문단이 글상자가 아니라 셀로 흘러들었다. `adapter.rs` 가 빈 `text_box` 를 `None` 으로 접으므로 글상자는 텍스트뿐 아니라 **개체째 IR 에서 사라진다**.
  - 수정은 `nearest_paragraph_owner_is_cell()` — 스택에서 `rposition` 으로 `DRAWTEXT` 와 `CELL` 중 **더 안쪽**을 고른다. 종류가 아니라 위치로 판정하므로 중첩 방향이 반대인 경우(글상자 안 표)에도 대칭으로 동작한다.
- **#2761** (`Closes #2752`) — npm editor README 의 `getHmlSaveState()` 반환 형태를 실제 DTO 로 정정. 계약 테스트를 함께 넣어 문서와 구현이 다시 어긋나지 않게 했다.

## 검증

- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- red→green: 컨테이너 선택을 종전 셀 우선으로 되돌리니 `textbox_inside_table_cell_keeps_its_own_paragraphs` 와 `..._survives_hml_export_and_reopen` **2건 전부 FAIL** → 복원 시 통과

## 이번 범위에서 제외

- **#2762**(HML `row_count` 25배 팽창) — 어제 요청한 회귀 테스트가 아직 없어 open 유지. 같은 배치의 #2731·#2758 은 red→green 을 확인하고 merge 했으므로 기준을 일관되게 적용했다. 작성할 테스트 골격은 해당 PR 코멘트에 제시했다.
- **#2739·#2746** — 낡은 base 로 cherry-pick 충돌. 리베이스 절차를 안내하고 재제출을 기다린다.
- **#2773**(=#2754 로 merge 완료) · **#2785**(본문과 실제 변경 불일치, #2717·#2753 을 되돌리는 내용) — close.

Co-authored-by 로 원 커밋 provenance 를 보존한다.
