### PR TITLE
fix(studio): 중첩 셀 축 오용 데이터 손실(#2756) + 드래그·클릭 히스토리 라우팅(#2759) — kevin9327 통합

### DIFF
--- a/mydocs/report/task_m100_2756_report.md
+++ b/mydocs/report/task_m100_2756_report.md
@@ -1,0 +1,98 @@
+# task m100-2756 — 중첩 표 셀 flat 좌표 축 오용 수정 (studio)
+
+- **이슈**: [#2756](https://github.com/edwardkim/rhwp/issues/2756)
+- **브랜치**: `task/m100-2756-nested-cell-axis` (base: `origin/devel`)
+- **분류**: 결함 수정 (중첩 셀 좌표 축 혼용 — outer/inner). 결함 2건, 뿌리 1개.
+- **Rust 파일 변경 없음** — 전부 `rhwp-studio/` TypeScript.
+
+## 1. 문제
+
+`DocumentPosition` 은 flat 필드(`controlIndex`/`cellIndex`/`cellParaIndex`)와 `cellPath` 배열을 동시에 들고 다닌다. hit-test 는 flat 필드를 `cellPath[0]`, 즉 **최외곽** 셀에서 채운다(`src/document_core/queries/cursor_rect.rs:2462-2491` 의 `let outer = &ctx.path[0];`; `ctx.path[0]` 참조는 이 파일에만 18곳). 따라서 중첩 표(depth ≥ 2)에서 flat 필드는 **바깥 셀의 축**이고, 안쪽 셀 값은 `cellPath[last]` 다.
+
+이 축 전환은 `command.ts` 의 커맨드 계층에서는 `cellParaIndexOf()` 헬퍼로 이미 정리됐으나, 호출부 두 곳이 누락됐다.
+
+- **결함 1 (HIGH, 데이터 손실)** — `cursor.ts:186` `CursorState.comparePositions` 가 flat `cellIndex`/`cellParaIndex` 를 맨몸으로 비교. 중첩 셀에서 선택 양끝이 뒤바뀐다. 소비자 `DeleteSelectionCommand`(`command.ts:555`)는 `cellParaIndexOf`(안쪽 축)로 start/end 를 읽으므로 `startPara > endPara` → `savedTexts=[]`, Rust `delete_range_in_cell_by_path`(`text_editing.rs:3497`)는 `start_para != end_para` 분기를 타 **선택 범위의 여집합**을 삭제. `multiPara=true` + 빈 `savedTexts` 라 `undo` 는 아무것도 복원하지 못한다(영구 손실).
+  - **입력 방식 의존**: 좌/우 화살표 선택은 `cursor.ts:435` `updateCellParaInPath` 가 flat 을 안쪽 값으로 덮어써 우연히 정상. 마우스 클릭·드래그 / Shift+상하 화살표만 발현.
+- **결함 2 (MEDIUM)** — `input-handler.ts:1822` `getCharPropertiesAtCursor()` 가 `getCellCharPropertiesAt`(flat) 로 **바깥 셀** 서식을 조회. `applyToggleFormat`(`:1789`)이 이 값에서 `!current[prop]` 로 토글 **방향**을 정하고(실제 적용 `ApplyCharFormatCommand` 는 이미 `...ByPath`), `emitCursorFormatState`(`:2028`)의 툴바 표시도 이 조회를 쓴다. 소비자 8곳 전부 오답.
+
+## 2. 검증 근거 (소스·이력)
+
+- `git log -S "comparePositions" -- rhwp-studio/src/engine/cursor.ts` → `f0f7f1a4 Initial commit` 만. 중첩 셀 축으로 한 번도 개정된 적 없음.
+- `grep -rn "comparePositions|getSelectionOrdered" rhwp-studio/tests/` → **0건**. 정렬 로직 테스트 부재.
+- 기존 두 가드(`delete-selection-nested-cell.test.ts`, `apply-charformat-nested-cell.test.ts`)는 `classBlock`으로 **`command.ts` 커맨드 본문만** 검사 → 결함 2(입력 핸들러)와 start/end 생산자(결함 1)는 시야 밖.
+
+## 3. 변경
+
+| 파일 | 변경 |
+|---|---|
+| `src/engine/command.ts` | `cellAxisPath(pos)` 헬퍼 신설·export (축 유도 단일 정의 공유; `cellParaIndexOf` 와 동일 규약의 경로 전체 버전). `CellPathEntry` 타입 import 추가. |
+| `src/engine/cursor.ts` | `comparePositions` 의 셀-내부 분기를 `cellAxisPath` 기반 깊이별 비교로 교체. `command.ts` 에서 `cellAxisPath` import. |
+| `src/engine/input-handler.ts` | `getCharPropertiesAtCursor` 에 `cellPath` 유무 분기 추가 — 있으면 `getCellCharPropertiesAtByPath`(안쪽 축), 없으면 기존 flat 폴백. |
+
+**동작 변화 범위 (수학적 등가 확인)**: `cellPath` 가 없는 두 위치(레거시 flat/`applyNavResult` 산출물)를 비교할 때 `cellAxisPath` 는 flat 필드로 1-depth 경로를 합성하므로, 새 비교 순서(parentParaIndex → controlIndex → cellIndex → cellParaIndex → charOffset)가 **기존 로직과 완전히 동치**다. depth 1 은 `cellPath[0]=최내곽=flat` 이라 무변화. **depth ≥ 2 에서만** 안쪽 축으로 판정이 바뀐다. 결함 2 도 `cellPath` 부재 시 flat 폴백이라 depth 1/레거시 무변화.
+
+축 유도를 인라인 복제하지 않고 헬퍼를 공유한 이유는 `tests/undo-nested-cell-merge-offset.test.ts:44`("인덱스 축 유도가 여러 곳에 복제되면 한쪽만 고쳐지는 회귀가 재발한다")와 선행 PR #2720 의 방침을 따른 것.
+
+## 4. 검증
+
+### 4-1. 신규 테스트
+
+- `tests/selection-ordering-nested-cell.test.ts` — **행위 테스트**. `cursor.ts` 는 `constructor(private wasm)` parameter property 때문에 Node strip-only 로더로 직접 import 불가 → `process.execPath` 자식 프로세스를 `--experimental-transform-types` 로 띄우고 `module.registerHooks` 로 `@/` 별칭·확장자 없는 상대 import 를 매핑(선행 PR #2720 기법). 실제 `CursorState.comparePositions` 호출 + `moveToHit`/`setAnchor`/`getSelectionOrdered` 실경로로 정렬 결과를 검증. 8건.
+- `tests/char-properties-cursor-nested-cell.test.ts` — **소스 가드**. `getCharPropertiesAtCursor` 메서드 본문을 추출해 `getCellCharPropertiesAtByPath` 사용·`cellPath` 분기·폴백 순서를 핀. 결함 2 는 조회 결과를 그대로 반환할 뿐 분기 로직이 없어(경로 유무만 판단) "어느 API 를 호출하는가"로 충분. 2건.
+
+행위 red→green 은 결함 1 쪽에서 실경로로 확보했고, 결함 2 는 정적 가드를 선택했다(이유: 위 참조).
+
+### 4-2. red→green 실증 (실제 캡처)
+
+**결함 1** — `cursor.ts` `comparePositions` 를 devel 원본(flat 비교)으로 되돌린 상태:
+
+```
+✖ 중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다 (데이터 손실 방지)
+  AssertionError: flat cellParaIndex(바깥=0) 로 비교하면 두 문단이 같아 보여 charOffset(5>0)으로 낙하, 양끝이 뒤바뀐다
+  1 !== -1
+✖ 서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다
+  AssertionError: flat cellIndex 는 둘 다 바깥 셀(0)이라 같다 — 안쪽 cellPath[last].cellIndex(2<4)로 정렬해야 한다
+  1 !== -1
+✔ depth 1 (비중첩) 셀 정렬은 불변이다 (회귀 대조군)
+✔ 본문 정렬은 불변이다 (회귀 대조군)
+✔ 본문↔셀 혼합 정렬은 불변이다 (회귀 대조군)
+✔ comparePositions 는 반대칭·반사적이다
+ℹ pass 4 / fail 2
+```
+
+RED 에서 **대조군 4건이 통과**한 것이 핵심 — 실패가 중첩 셀 축 혼용 때문임을 격리한다(depth 1·본문·본문↔셀 혼합 무변화 증명).
+
+**결함 2** — `getCharPropertiesAtCursor` 를 devel 원본(flat 전용)으로 되돌린 상태:
+
+```
+✖ getCharPropertiesAtCursor 는 cellPath 가 있으면 ...ByPath 로 최내곽 셀을 조회한다
+  AssertionError: 중첩 셀 서식 조회는 getCellCharPropertiesAtByPath(안쪽 축)를 써야 한다
+✖ getCharPropertiesAtCursor 의 flat 조회는 cellPath 부재 폴백으로만 남는다
+  AssertionError: ByPath 분기가 있어야 한다
+ℹ pass 0 / fail 2
+```
+
+두 수정 복원 후 신규 10건 전부 GREEN.
+
+### 4-3. CI 게이트 (기준선 대조)
+
+| | clean `devel` 기준선 | 수정 후 |
+|---|---|---|
+| `npm test` | tests 465 / pass 464 / **fail 1** | tests 473 / pass 472 / **fail 1** |
+| `npx tsc --noEmit` | error 2 (둘 다 `TS2307 @wasm/rhwp.js`) | error 2 (**baseline 과 byte-identical**) |
+
+- 신규 통과 +8(행위 6 + 가드 2 = 8건), 총계 465→473. 신규 8건 전부 통과. 유일한 실패 `tests/cell-flow-boundary.test.ts` 는 **기준선에도 있던 선재 실패**(`spawnSync(node_modules/.bin/tsc)` 가 Windows 에서 `status=null`)로 본 변경과 무관, 손대지 않음.
+- `tsc` 2건은 로컬 WASM 빌드 산출물 부재로 나는 **선재** 오류. `diff baseline after` → **완전 동일**(신규 타입 오류 0).
+- `npm run lint` 는 `package.json` 에 없음(스크립트 부재). Rust 무변경으로 Rust CI 3종 대상 밖.
+
+### 4-4. 미실행 항목 (투명 고지)
+
+- 브라우저 왕복 시각 검증(중첩 표 문서에서 손 확인) 미수행 — 로컬에 빌드된 `rhwp_bg.wasm` 이 없어 studio 를 띄울 수 없음. 그래서 결함 1 은 실경로 행위 테스트로 런타임 증명을 대신했다.
+- `npm run build`(`tsc && vite build`) — WASM 바인딩(`@wasm/rhwp.js`) 요구로 로컬 실행 불가. 해당 바인딩 무변경.
+
+## 5. 잔여 (범위 밖)
+
+1. `applyNavResult`(`cursor.ts:396-407`)가 컨테이너 내부 위치 재구성 시 `cellPath` 를 싣지 않아 수직 이동 산출물이 중첩 경로를 유실. 이번 수정은 폴백으로 일관성만 확보. 별건.
+2. flat 필드 자체의 폐기(`cellPath` 상위 집합) — Rust 직렬화(`cursor_rect.rs` 18곳)와 다수 호출부 연동으로 범위 밖.
+3. 셀 내 다중 문단 삭제 undo 의 구조적 한계(`command.ts:603-613` 자체 주석) — 이번 건은 `savedTexts` 가 비는 문제만 제거.
+4. Rust `cursor_rect.rs` 의 flat 채움 규칙 — 무수정. TS 소비자가 축을 올바로 고르는 것으로 충분.

--- a/mydocs/report/task_m100_2759_report.md
+++ b/mydocs/report/task_m100_2759_report.md
@@ -1,0 +1,105 @@
+# Task #2759 처리 결과 보고서 — 드래그·클릭 문서 뮤테이션 3건 히스토리 라우팅
+
+- 일자: 2026-07-21
+- 이슈: [#2759](https://github.com/edwardkim/rhwp/issues/2759)
+- 브랜치: `task/m100-2759-drag-undo-routing` (base `origin/devel` = `bd442b2a`)
+- 범위: `rhwp-studio/` TypeScript 만. `.rs` 무수정.
+
+## 1. 무엇을 고쳤나
+
+`mutation-method-registry.ts:1-19` 가 명명한 재발 계급(#2027/#2037/#2053/#2077 — 미기록 뮤테이션의
+①undo 불가 ②redo 미무효화 ③스냅샷 undo 동반 파괴)에 속하는 **엔진 층 진입점 3곳**을 라우팅했다.
+
+| # | 진입점 | 종전 | 수정 |
+|---|---|---|---|
+| 1 | 회전 핸들 드래그 종료 `finishPictureRotateDrag` | 상태만 정리, 미기록 | `computeRotationRecord` 로 각 변화 판정 → `executeOperation({kind:'record', ResizeObjectCommand([{rotationAngle before/after}])})` |
+| 2 | 직선 끝점 드래그 종료 (onMouseUp 인라인) | 상태만 정리, 미기록 | `finishLineEndpointDrag` 신설: 드래그 시작 시 원래 끝점 캡처 → `computeLineEndpointRecord` 판정 → `executeOperation({kind:'record', MoveLineEndpointCommand})` |
+| 3 | 클릭 시 z순서 변경 `bringShapeToFront` | `this.wasm.changeShapeZOrder` 직접 호출 | 메뉴 정렬(insert.ts:427)과 동형 `executeOperation({kind:'snapshot', operationType:'changeZOrder'})` |
+
+세 수정 모두 기존 라우팅된 형제(리사이즈/이동 드래그, 메뉴 회전/정렬)와 동형 패턴을 그대로 미러했다.
+새 커맨드는 `MoveLineEndpointCommand`(전/후 글로벌 끝점 좌표) 하나뿐이고, 회전은 기존
+`ResizeObjectCommand` 의 임의 속성 가방(`{rotationAngle}`)을 재사용해 새 클래스가 없다.
+
+## 2. 변경 파일
+
+| 파일 | 내용 |
+|---|---|
+| `src/engine/object-drag-record.ts` (신규) | 순수 결정 함수 `computeRotationRecord`, `computeLineEndpointRecord`(변화 없으면 null). picture-resize.ts 패턴 |
+| `src/engine/command.ts` | `MoveLineEndpointCommand` 추가(execute=after 재적용, undo=before 복원). `LineEndpoints` 타입 import |
+| `src/engine/input-handler-picture.ts` | `finishPictureRotateDrag` 에 record 기록 + `computeRotationRecord` import |
+| `src/engine/input-handler-mouse.ts` | 끝점 드래그 시작 시 `orig` 캡처, `finishLineEndpointDrag` 신설, onMouseUp 위임, `bringShapeToFront` snapshot 라우팅 |
+| `src/engine/input-handler.ts` | `lineEndpointState.orig` 필드, `finishLineEndpointDrag` 위임 메서드 |
+| `tests/object-drag-record.test.ts` (신규) | 순수 함수 단위 테스트 8건 |
+| `tests/undo-drag-command-behaviour.test.ts` (+`tests/support/*.mjs`, 신규) | 커맨드 클래스 execute/undo 행위 테스트(자식 프로세스 로드) |
+| `tests/undo-drag-click-routing.test.ts` (신규) | 3 진입점 라우팅 소스 가드 4건 |
+
+## 3. 검증
+
+### 3-1. 행위 테스트 vs 소스 가드 (무엇을 택했나)
+
+두 층 모두 사용했다.
+
+- **행위(순수 모듈)**: `object-drag-record.ts` 를 외부 import 없는 순수 함수로 분리해 기본 test 러너로
+  직접 검증(picture-resize.ts ↔ picture-resize.test.ts 선례). 기록 결정 로직의 진짜 red→green.
+- **행위(커맨드 클래스)**: 이 저장소는 `cursor.ts:85` TS 파라미터 프로퍼티 때문에 기본(strip-only)
+  러너로 엔진 클래스를 import 못 한다. PR #2720 방식(`--experimental-transform-types` +
+  `module.registerHooks` 별칭)을 자식 프로세스로 spawn 해 `command.ts` 를 실제 로드하고 mock
+  WasmBridge 로 `MoveLineEndpointCommand`·`ResizeObjectCommand(회전)` 의 execute/undo 를 검증했다.
+  **로컬(Node 24.17)에서 실제 green** 이며, 구버전 Node(플래그/registerHooks 미지원)에서는 skip 해
+  CI 를 깨지 않는다.
+- **소스 가드**: 배선(어느 종료 핸들러가 executeOperation 을 호출하는가)은 `undo-menu-object-ops`
+  모델의 정적 가드로 핀했다 — 이것이 라우팅 red→green 의 주 구동체.
+
+### 3-2. red→green (각 수정 개별 되돌림, 실제 출력)
+
+`git stash` 는 워크트리 간 공유되어 위험하므로 사용하지 않고, 각 수정을 Edit 로 개별 되돌려 실행했다.
+
+- **RED 1 (회전 되돌림)**: `undo-drag-click-routing` 4건 중 1건만 실패, 나머지 12건(순수+행위 포함) GREEN.
+  ```
+  AssertionError: origAngle→finalAngle 기록 결정을 순수 함수로 위임
+    expected: /computeRotationRecord\(/
+  ```
+- **RED 2 (끝점 onMouseUp 위임 되돌림)**: `onMouseUp ... finishLineEndpointDrag 로 위임` 1건만 실패.
+  ```
+  AssertionError: onMouseUp 은 상태 인라인 초기화가 아니라 finishLineEndpointDrag 로 위임해야 함(기록 경로 확보)
+  ```
+- **RED 3 (z순서 되돌림)**: `bringShapeToFront ... snapshot` 1건만 실패.
+  ```
+  AssertionError: this.wasm.changeShapeZOrder 직접 호출 금지 — executeOperation 경유여야 함
+  ```
+
+**RED 에서도 통과하는 것**: 순수 함수 테스트(`object-drag-record`)와 커맨드 행위 테스트
+(`undo-drag-command-behaviour`)는 배선이 아니라 메커니즘을 보므로 각 RED 에서도 GREEN. 라우팅 gap 은
+소스 가드가 잡는다는 설계 의도 그대로다.
+
+### 3-3. CI 게이트
+
+- `npx tsc --noEmit`: **2 errors**, 모두 사전 존재(`@wasm/rhwp.js` 모듈 미해석 — WASM 산출물 미빌드,
+  환경 요인). 수정 전 baseline 과 diff **완전 동일 = 신규 타입 오류 0**.
+- `npm test`: **478 tests / 477 pass / 1 fail**. 유일 실패는 `cell-flow-boundary.test.ts`(깨끗한 devel
+  에서도 실패하는 기존 실패, 본 작업 무관). baseline 465→478(+13 신규), skipped 0(행위 테스트 실제 실행).
+  - (참고) 머신 고부하 시 1회 다른 기존 테스트가 타임아웃으로 함께 실패한 적 있으나, 부하 완화 후
+    재실행 시 `cell-flow-boundary` 단일 실패로 재현. 신규 테스트는 격리 실행에서 13/13 GREEN.
+
+### 3-4. 뮤테이션 표면 원장
+
+세 수정 모두 스캔 대상 파일의 `wasm.*` 뮤테이터 텍스트 수를 늘리지 않는다(호출을 콜백 안으로 이동
+또는 유지, 신규 `moveLineEndpoint` 호출은 스캔 비대상 `command.ts` 에만). `mutation-routing-guard` 원장
+테스트 GREEN — BASELINE 갱신 불필요.
+
+## 4. 범위 밖 (잔여)
+
+- **`lineEndpointState.ref` 의 cellPath/headerFooter 미포함**: 형제 상태와 달리 경로축이 없다. 선택
+  진입부도 직선에 cellPath 를 안 넘기고 `moveLineEndpoint` 에 경로 인자가 없어, 셀 내 직선 끝점 드래그가
+  도달 가능한지 미확인. 본문 직선의 undo 누락은 이와 무관하게 성립하므로 본 PR 에서 확장하지 않음.
+- **선택만으로 z순서가 바뀌는 설계**: 한컴은 선택 시 재정렬하지 않는다. 유지 여부는 메인테이너 판단
+  요청(이슈 4절). 유지 시 최소한 기록은 되어야 하며(본 PR 이 그 부분 처리), no-op 재클릭이 히스토리에
+  쌓이는 부작용은 사전 판별이 TS 만으로 불가(변경 플래그/ z순서 setter 부재 = Rust 변경 필요)라 별건.
+- **머리말/꼬리말 개체의 `ResizeObjectCommand` 경로**: `setProps` 에 headerFooter 분기 부재는 기존
+  리사이즈 드래그도 동일한 선행 한계라 확장하지 않음.
+
+## 5. 주의 기록 (환경)
+
+작업 중 `git stash` 가 **워크트리 간 공유 스택**임을 확인(다른 워크트리의 #2751 `body.rs` 변경이
+워킹트리에 누출됨). 해당 `body.rs` 는 본 작업과 무관하며 스테이징하지 않았다. 커밋은 파일 명시
+스테이징으로만 수행(`git add -A` 미사용).

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,6 +1,7 @@
 import type { WasmBridge } from '@/core/wasm-bridge';
 import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
+import type { LineEndpoints as LineEndpointsLike } from './object-drag-record';
 
 /** 편집 명령 공통 인터페이스 */
 export interface EditCommand {
@@ -1588,6 +1589,43 @@ export class ResizeObjectCommand implements EditCommand {
     }
     const first = this.targets[0];
     return { sectionIndex: first?.sec ?? 0, paragraphIndex: first?.ppi ?? 0, charOffset: 0 };
+  }
+
+  mergeWith(): null { return null; }
+}
+
+/**
+ * [Task #2759] 직선/연결선 끝점 드래그를 Undo/Redo 스택에 기록하기 위한 명령.
+ *
+ * ResizeObjectCommand 와 동일하게 드래그 중 WASM 에 이미 반영된 변경을 kind:'record' 로
+ * 사후 기록한다(execute 는 redo 경로에서만 재적용). before/after 는 글로벌 끝점 좌표
+ * (HWPUNIT)이며 moveLineEndpoint 는 절대 좌표 setter 라 역연산이 자명하다.
+ */
+export class MoveLineEndpointCommand implements EditCommand {
+  readonly type = 'moveLineEndpoint';
+  readonly timestamp: number;
+
+  constructor(
+    private sec: number,
+    private ppi: number,
+    private ci: number,
+    private before: LineEndpointsLike,
+    private after: LineEndpointsLike,
+    timestamp?: number,
+  ) {
+    this.timestamp = timestamp ?? Date.now();
+  }
+
+  execute(wasm: WasmBridge): DocumentPosition {
+    wasm.moveLineEndpoint(this.sec, this.ppi, this.ci,
+      this.after.sx, this.after.sy, this.after.ex, this.after.ey);
+    return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
+  }
+
+  undo(wasm: WasmBridge): DocumentPosition {
+    wasm.moveLineEndpoint(this.sec, this.ppi, this.ci,
+      this.before.sx, this.before.sy, this.before.ex, this.before.ey);
+    return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
   }
 
   mergeWith(): null { return null; }

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1,5 +1,5 @@
 import type { WasmBridge } from '@/core/wasm-bridge';
-import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike } from '@/core/types';
+import type { DocumentPosition, CharProperties, ParaProperties, CellPathLike, CellPathEntry } from '@/core/types';
 import { MAX_PAGE_LOCAL_TEXT_EDIT_CHARS } from './input-edit-invalidation';
 
 /** 편집 명령 공통 인터페이스 */
@@ -206,6 +206,26 @@ function cellPathJsonForPara(pos: DocumentPosition, cellParaIndex: number): stri
 export function cellParaIndexOf(pos: DocumentPosition): number {
   const path = pos.cellPath;
   return (path?.length ?? 0) > 0 ? path![path!.length - 1].cellParaIndex : pos.cellParaIndex!;
+}
+
+/**
+ * [#2756] 비교용 셀 경로 — `cellParaIndexOf` 와 같은 축 규약의 경로 전체 버전.
+ *
+ * `cellParaIndexOf` 가 최내곽 **문단 인덱스** 하나를 주는 것과 달리, 이쪽은 셀 **정체성**을
+ * 깊이별로 비교해야 하는 곳(선택 영역 정렬)에 쓴다. 두 함수는 같은 규약을 공유한다 —
+ * `cellParaIndexOf(pos) === cellAxisPath(pos)[last].cellParaIndex`.
+ *
+ * `cellPath` 가 없는 위치(레거시 flat 좌표, `applyNavResult` 산출물)는 flat 필드로 1-depth
+ * 경로를 합성한다. hit-test 가 flat 을 `cellPath[0]`(최외곽)에서 채우므로, depth 1 에서는
+ * 합성 경로가 실제 경로와 완전히 같아 **동작 변화가 없다**.
+ */
+export function cellAxisPath(pos: DocumentPosition): CellPathEntry[] {
+  if ((pos.cellPath?.length ?? 0) > 0) return pos.cellPath!;
+  return [{
+    controlIndex: pos.controlIndex ?? 0,
+    cellIndex: pos.cellIndex ?? 0,
+    cellParaIndex: pos.cellParaIndex ?? 0,
+  }];
 }
 
 /** 셀 문단 구조 편집 뒤 flat/path 커서 위치를 같은 문단으로 맞춘다. */

--- a/rhwp-studio/src/engine/cursor.ts
+++ b/rhwp-studio/src/engine/cursor.ts
@@ -1,5 +1,7 @@
 import type { DocumentPosition, CursorRect, LineInfo, CellPathEntry, NavContextEntry, CellBbox } from '@/core/types';
 import type { WasmBridge } from '@/core/wasm-bridge';
+// [#2756] 셀 좌표 축 헬퍼는 command.ts 와 단일 정의를 공유한다(축 유도 복제 금지).
+import { cellAxisPath } from './command';
 
 type CellSelectionReason = 'manual' | 'protected';
 
@@ -189,17 +191,34 @@ export class CursorState {
     const bInCell = b.parentParaIndex !== undefined;
 
     if (aInCell && bInCell) {
-      // 둘 다 셀 내부 — 같은 셀인지 확인
-      if (a.parentParaIndex !== b.parentParaIndex ||
-          a.controlIndex !== b.controlIndex ||
-          a.cellIndex !== b.cellIndex) {
-        // 다른 셀이면 셀 인덱스로 비교
-        if (a.parentParaIndex !== b.parentParaIndex) return a.parentParaIndex! < b.parentParaIndex! ? -1 : 1;
-        if (a.controlIndex !== b.controlIndex) return a.controlIndex! < b.controlIndex! ? -1 : 1;
-        return a.cellIndex! < b.cellIndex! ? -1 : 1;
+      // [#2756] 둘 다 셀 내부 — **최내곽 축**으로 비교한다.
+      //
+      // flat controlIndex/cellIndex/cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서
+      // 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`). 중첩 표에서 이 셋을 그대로 쓰면
+      // 안쪽 셀의 서로 다른 문단이 **같은 위치**로 보여 charOffset 으로 낙하하고, 그 결과
+      // 선택 양끝이 뒤바뀐다. 소비자 DeleteSelectionCommand 는 cellParaIndexOf(=안쪽 축)로
+      // start/end 를 읽으므로 startPara > endPara 가 되어 savedTexts 가 비고, Rust
+      // delete_range_in_cell_by_path 는 start_para != end_para 분기를 타 **선택 범위의
+      // 여집합**을 지운다. undo 는 복원할 텍스트가 없어 무효가 된다.
+      if (a.parentParaIndex !== b.parentParaIndex) return a.parentParaIndex! < b.parentParaIndex! ? -1 : 1;
+
+      // 셀 경로를 깊이 순으로 비교 — 바깥에서 안쪽으로 진입 순서가 곧 문서 순서다.
+      // 각 깊이의 cellParaIndex 는 (중간 깊이) 어느 문단에서 다음 표로 내려갔는지 /
+      // (최내곽) 커서가 어느 문단에 있는지를 뜻하므로 두 경우 모두 올바른 정렬 키다.
+      const pathA = cellAxisPath(a);
+      const pathB = cellAxisPath(b);
+      const common = Math.min(pathA.length, pathB.length);
+      for (let d = 0; d < common; d++) {
+        const ea = pathA[d];
+        const eb = pathB[d];
+        if (ea.controlIndex !== eb.controlIndex) return ea.controlIndex < eb.controlIndex ? -1 : 1;
+        if (ea.cellIndex !== eb.cellIndex) return ea.cellIndex < eb.cellIndex ? -1 : 1;
+        if (ea.cellParaIndex !== eb.cellParaIndex) return ea.cellParaIndex < eb.cellParaIndex ? -1 : 1;
       }
-      // 같은 셀 내부: cellParaIndex → charOffset 비교
-      if (a.cellParaIndex !== b.cellParaIndex) return a.cellParaIndex! < b.cellParaIndex! ? -1 : 1;
+      // 공통 구간이 같으면 얕은 쪽(바깥 셀 본문)이 그 문단에서 표로 내려가기 전이므로 앞선다.
+      if (pathA.length !== pathB.length) return pathA.length < pathB.length ? -1 : 1;
+
+      // 같은 최내곽 셀·같은 문단: 마지막 루프 반복이 곧 cellParaIndexOf 비교였다.
       if (a.charOffset !== b.charOffset) return a.charOffset < b.charOffset ? -1 : 1;
       return 0;
     }

--- a/rhwp-studio/src/engine/input-handler-mouse.ts
+++ b/rhwp-studio/src/engine/input-handler-mouse.ts
@@ -3,6 +3,8 @@
 
 import type { ContextMenuItem } from '@/ui/context-menu';
 import * as _connector from './input-handler-connector';
+import { MoveLineEndpointCommand } from './command';
+import { computeLineEndpointRecord } from './object-drag-record';
 
 function protectedCellKey(hit: any): string | null {
   if (!hit || hit.isTextBox) return null;
@@ -563,11 +565,21 @@ export function onClick(this: any, e: MouseEvent): void {
                 const pw = this.virtualScroll.getPageWidth(picBbox.pageIndex);
                 const pl = this.virtualScroll.getPageLeftResolved(picBbox.pageIndex, sc.clientWidth);
                 this.isLineEndpointDragging = true;
+                // [Task #2759] 드래그 시작 시 원래 끝점(글로벌 HWPUNIT)을 캡처해 종료 시
+                // Undo 기록의 before 로 쓴다. (x1,y1)=시작점, (x2,y2)=끝점 — 드래그 중
+                // 좌표 계산(PX2HWP=75)과 동일. cellPath 는 담지 않는다(잔여: 셀 내 직선 미대응).
+                const PX2HWP_LINE = 75;
                 this.lineEndpointState = {
                   ref: { sec: ref.sec, ppi: ref.ppi, ci: ref.ci, type: ref.type },
                   endpoint: dir === 'sw' ? 'start' : 'end',
                   pageIndex: picBbox.pageIndex,
                   pageLeft: pl, pageOffset: po, zoom,
+                  orig: {
+                    sx: Math.round((picBbox.x1 ?? 0) * PX2HWP_LINE),
+                    sy: Math.round((picBbox.y1 ?? 0) * PX2HWP_LINE),
+                    ex: Math.round((picBbox.x2 ?? 0) * PX2HWP_LINE),
+                    ey: Math.round((picBbox.y2 ?? 0) * PX2HWP_LINE),
+                  },
                 };
                 this.container.style.cursor = 'crosshair';
                 document.addEventListener('mouseup', this.onMouseUpBound, { once: true });
@@ -1886,10 +1898,7 @@ export function onMouseUp(this: any, _e: MouseEvent): void {
 
   // 직선 끝점 드래그 종료
   if (this.isLineEndpointDragging) {
-    this.isLineEndpointDragging = false;
-    this.lineEndpointState = null;
-    this.container.style.cursor = '';
-    if (this.dragRafId) { cancelAnimationFrame(this.dragRafId); this.dragRafId = 0; }
+    this.finishLineEndpointDrag();
     return;
   }
 
@@ -1950,10 +1959,59 @@ export function onMouseUp(this: any, _e: MouseEvent): void {
 function bringShapeToFront(this: any, picHit: any): void {
   if (picHit.type === 'shape' || picHit.type === 'line' || picHit.type === 'group' || picHit.type === 'ole') {
     try {
-      this.wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+      // [Task #2759] 선택 시 z순서 변경도 문서 뮤테이션 — 메뉴 정렬(insert.ts:427 등)의
+      // recordObjectMutation 과 동형으로 snapshot 기록해 undo 가능·redo 무효화·스냅샷 undo
+      // 동반 파괴를 막는다. UI 후처리(선택 진입·재렌더)는 호출부가 기존대로 수행한다.
+      const pos = this.getCursorPosition();
+      this.executeOperation({
+        kind: 'snapshot',
+        operationType: 'changeZOrder',
+        operation: (wasm: any) => {
+          wasm.changeShapeZOrder(picHit.sec, picHit.ppi, picHit.ci, 'front');
+          return pos;
+        },
+      });
       this.eventBus.emit('document-changed');
     } catch { /* ignore */ }
   }
+}
+
+/**
+ * [Task #2759] 직선 끝점 드래그 종료 — 드래그 중 이미 문서에 반영된 끝점 이동을 Undo
+ * 히스토리에 기록한다. 다른 드래그 종료(finishPictureMoveDrag/finishPictureResizeDrag)와
+ * 동형으로 kind:'record' 를 쓴다(after 는 종료 시점 문서에서 읽어 실제 반영값과 정합).
+ */
+export function finishLineEndpointDrag(this: any): void {
+  const st = this.lineEndpointState;
+  if (st && st.orig) {
+    try {
+      const PX2HWP = 75;
+      const bbox = this.findPictureBbox(st.ref);
+      if (bbox) {
+        const after = {
+          sx: Math.round((bbox.x1 ?? 0) * PX2HWP),
+          sy: Math.round((bbox.y1 ?? 0) * PX2HWP),
+          ex: Math.round((bbox.x2 ?? 0) * PX2HWP),
+          ey: Math.round((bbox.y2 ?? 0) * PX2HWP),
+        };
+        const record = computeLineEndpointRecord(st.orig, after);
+        if (record) {
+          this.executeOperation({
+            kind: 'record',
+            command: new MoveLineEndpointCommand(
+              st.ref.sec, st.ref.ppi, st.ref.ci, record.before, record.after,
+            ),
+          });
+        }
+      }
+    } catch (err) {
+      console.warn('[InputHandler] 직선 끝점 이동 기록 실패:', err);
+    }
+  }
+  this.isLineEndpointDragging = false;
+  this.lineEndpointState = null;
+  this.container.style.cursor = '';
+  if (this.dragRafId) { cancelAnimationFrame(this.dragRafId); this.dragRafId = 0; }
 }
 
 function getRotatedCursor(dir: string, angleDeg: number): string {

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -4,6 +4,7 @@
 import { MovePictureCommand, MoveShapeCommand, ResizeObjectCommand } from './command';
 import type { ObjectResizeTarget } from './command';
 import { computeArrowResize, MIN_SIZE_HWP, type ArrowKey } from './picture-resize';
+import { computeRotationRecord } from './object-drag-record';
 import type { CellPathLike } from '@/core/types';
 import { showToast } from '@/ui/toast';
 
@@ -1135,8 +1136,31 @@ export function updatePictureRotateDrag(this: any, e: MouseEvent): void {
   }
 }
 
-/** 회전 드래그 종료: 핸들을 최종 회전 위치로 스냅 */
+/** 회전 드래그 종료: 최종 회전각을 Undo 히스토리에 기록하고 핸들을 최종 위치로 스냅 */
 export function finishPictureRotateDrag(this: any, _e: MouseEvent): void {
+  // [Task #2759] 드래그 중 setObjectProperties({rotationAngle})가 문서에 이미 반영됐으나
+  // 미기록이면 undo 불가·redo 미무효화·스냅샷 undo 동반 파괴. finishPictureResizeDrag 와
+  // 동형으로 kind:'record' 로 사후 기록한다(origAngle 은 드래그 시작 시 캡처됨).
+  const state = this.pictureRotateState;
+  if (state) {
+    try {
+      const props = getObjectProperties.call(this, state.ref);
+      const finalAngle = Math.round((props?.rotationAngle as number) ?? state.origAngle);
+      const record = computeRotationRecord(state.origAngle, finalAngle);
+      if (record) {
+        this.executeOperation({
+          kind: 'record',
+          command: new ResizeObjectCommand([{
+            sec: state.ref.sec, ppi: state.ref.ppi, ci: state.ref.ci,
+            type: state.ref.type, cellPath: state.ref.cellPath,
+            before: record.before, after: record.after,
+          }]),
+        });
+      }
+    } catch (err) {
+      console.warn('[InputHandler] 개체 회전 기록 실패:', err);
+    }
+  }
   this.isPictureRotateDragging = false;
   this.pictureRotateState = null;
   this.container.style.cursor = '';

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -432,6 +432,8 @@ export class InputHandler {
     pageLeft: number;
     pageOffset: number;
     zoom: number;
+    // [Task #2759] 드래그 시작 시 캡처한 원래 끝점(글로벌 HWPUNIT) — 종료 시 Undo 기록의 before.
+    orig: { sx: number; sy: number; ex: number; ey: number };
   } | null = null;
 
   // 양식 개체 오버레이
@@ -1329,6 +1331,11 @@ export class InputHandler {
   /** 마우스 버튼 놓기: 드래그 선택 종료 */
   private onMouseUp(_e: MouseEvent): void {
     _mouse.onMouseUp.call(this, _e);
+  }
+
+  /** [Task #2759] 직선 끝점 드래그 종료 — 끝점 이동을 Undo 히스토리에 기록 */
+  private finishLineEndpointDrag(): void {
+    _mouse.finishLineEndpointDrag.call(this);
   }
 
   /** 마우스 이벤트에서 hitTest 결과를 반환한다 */

--- a/rhwp-studio/src/engine/input-handler.ts
+++ b/rhwp-studio/src/engine/input-handler.ts
@@ -1824,6 +1824,16 @@ export class InputHandler {
     // offset이 0이면 해당 위치, 아니면 offset-1 위치의 서식 반환 (커서 앞 글자 기준)
     const queryOffset = pos.charOffset > 0 ? pos.charOffset - 1 : 0;
     if (pos.parentParaIndex !== undefined) {
+      // [#2756] 중첩 표는 최내곽 셀 대상 ...ByPath 로 조회한다. flat controlIndex/cellIndex/
+      // cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서 채우므로 그대로 넘기면 **바깥
+      // 셀**의 서식을 읽는다. applyToggleFormat 이 이 값에서 !current[prop] 로 토글 방향을
+      // 정하므로(그리고 실제 적용 ApplyCharFormatCommand 는 이미 ...ByPath 로 안쪽 셀에
+      // 적용) 방향이 어긋나 Ctrl+B/I 가 거꾸로 동작하고 툴바 표시도 오답이 된다.
+      if ((pos.cellPath?.length ?? 0) > 0) {
+        return this.wasm.getCellCharPropertiesAtByPath(
+          pos.sectionIndex, pos.parentParaIndex, JSON.stringify(pos.cellPath), queryOffset,
+        );
+      }
       return this.wasm.getCellCharPropertiesAt(
         pos.sectionIndex, pos.parentParaIndex, pos.controlIndex!,
         pos.cellIndex!, pos.cellParaIndex!, queryOffset,

--- a/rhwp-studio/src/engine/object-drag-record.ts
+++ b/rhwp-studio/src/engine/object-drag-record.ts
@@ -1,0 +1,71 @@
+/**
+ * 개체 드래그 종료 시 "히스토리에 기록할 before/after" 결정 로직 (#2759) — 순수 함수 모듈.
+ *
+ * 회전 핸들 드래그(input-handler-picture.ts:finishPictureRotateDrag)와 직선 끝점
+ * 드래그(input-handler-mouse.ts:finishLineEndpointDrag)가 사용한다. 두 종료 핸들러는
+ * 드래그 중 이미 문서에 반영된 변경을 executeOperation({kind:'record'})로 기록해야
+ * undo/redo 계약(#2027/#2037/#2053/#2077 재발 계급)을 지킨다.
+ *
+ * picture-resize.ts / navigation-keymap.ts 와 동일하게 외부 import 없이 유지해
+ * node:test 단위 테스트(tests/object-drag-record.test.ts) 대상으로 둔다. "변화가 없으면
+ * null" 계약으로 무의미한 Undo 항목·redo 스택 무효화를 막는 책임이 이 모듈에 있다.
+ */
+
+/** 회전각 변경 기록. before/after 는 setObjectProperties 에 그대로 전달되는 속성 가방. */
+export interface RotationRecord {
+  before: { rotationAngle: number };
+  after: { rotationAngle: number };
+}
+
+/**
+ * 드래그 시작 각도(origAngle)와 종료 시 문서에 실제 반영된 각도(finalAngle)를 비교해
+ * 기록 대상 before/after 를 돌려준다. 두 각이 같거나(=드래그 없음) 입력이 비정상이면 null.
+ * 각도는 호출부에서 이미 정규화·라운딩된 값이 들어온다(그대로 보존).
+ */
+export function computeRotationRecord(
+  origAngle: number,
+  finalAngle: number,
+): RotationRecord | null {
+  if (!Number.isFinite(origAngle) || !Number.isFinite(finalAngle)) return null;
+  if (origAngle === finalAngle) return null;
+  return {
+    before: { rotationAngle: origAngle },
+    after: { rotationAngle: finalAngle },
+  };
+}
+
+/** 직선 끝점 좌표(글로벌 HWPUNIT). moveLineEndpoint(sec,ppi,ci, sx,sy,ex,ey) 인자와 1:1. */
+export interface LineEndpoints {
+  sx: number;
+  sy: number;
+  ex: number;
+  ey: number;
+}
+
+/** 직선 끝점 드래그 기록. before/after 는 MoveLineEndpointCommand 가 그대로 사용. */
+export interface LineEndpointRecord {
+  before: LineEndpoints;
+  after: LineEndpoints;
+}
+
+function endpointsEqual(a: LineEndpoints, b: LineEndpoints): boolean {
+  return a.sx === b.sx && a.sy === b.sy && a.ex === b.ex && a.ey === b.ey;
+}
+
+function endpointsFinite(p: LineEndpoints): boolean {
+  return Number.isFinite(p.sx) && Number.isFinite(p.sy) &&
+    Number.isFinite(p.ex) && Number.isFinite(p.ey);
+}
+
+/**
+ * 드래그 시작 시 캡처한 끝점(before)과 종료 시 문서에서 읽은 끝점(after)을 비교해 기록
+ * 대상을 돌려준다. 좌표가 동일하거나(=클릭만 하고 안 움직임) 비정상이면 null.
+ */
+export function computeLineEndpointRecord(
+  before: LineEndpoints,
+  after: LineEndpoints,
+): LineEndpointRecord | null {
+  if (!endpointsFinite(before) || !endpointsFinite(after)) return null;
+  if (endpointsEqual(before, after)) return null;
+  return { before: { ...before }, after: { ...after } };
+}

--- a/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
+++ b/rhwp-studio/tests/char-properties-cursor-nested-cell.test.ts
@@ -1,0 +1,67 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [#2756] getCharPropertiesAtCursor() 의 중첩 셀 좌표 축 가드.
+//
+// flat controlIndex/cellIndex/cellParaIndex 는 hit-test 가 cellPath[0](최외곽)에서 채운다.
+// 중첩 표 셀에서 이를 그대로 getCellCharPropertiesAt(flat)에 넘기면 **바깥 셀**의 글자 서식을
+// 읽는다. applyToggleFormat 이 이 값에서 !current[prop] 로 토글 **방향**을 정하므로(그리고
+// 실제 적용 ApplyCharFormatCommand 는 이미 ...ByPath 로 안쪽 셀에 적용) 방향이 어긋나
+// Ctrl+B/I 가 거꾸로 동작하고, emitCursorFormatState 의 툴바 표시도 오답이 된다.
+//
+// 형제 선례: ApplyCharFormatCommand 는 이미 getCellCharPropertiesAtByPath 로 교정됐고
+// tests/apply-charformat-nested-cell.test.ts 가 그 커맨드를 핀한다. 그러나 그 테스트는
+// command.ts 의 커맨드 블록만 보므로 input-handler.ts 의 이 조회는 시야 밖이었다.
+//
+// 정적 가드인 이유: getCharPropertiesAtCursor 는 wasm 응답을 그대로 돌려줄 뿐 분기 로직이
+// 없어(경로 유무만 판단), 동작 증명은 "어느 API 를 호출하는가"로 충분하다. 행위 red→green 은
+// comparePositions 쪽(selection-ordering-nested-cell.test.ts)에서 실경로로 확보한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+
+/** `NAME(` 시그니처부터 매칭 중괄호가 닫힐 때까지 메서드 본문을 추출. */
+function methodBody(name: string): string {
+  const sig = new RegExp(`\\b${name}\\s*\\([^)]*\\)\\s*:[^\\{]*\\{`);
+  const m = sig.exec(src);
+  assert.ok(m, `${name} 메서드 not found`);
+  const open = src.indexOf('{', m.index + m[0].length - 1);
+  let depth = 0;
+  for (let i = open; i < src.length; i++) {
+    if (src[i] === '{') depth++;
+    else if (src[i] === '}') {
+      depth--;
+      if (depth === 0) return src.slice(open, i + 1);
+    }
+  }
+  throw new Error(`${name} 본문의 닫는 괄호를 찾지 못함`);
+}
+
+test('getCharPropertiesAtCursor 는 cellPath 가 있으면 ...ByPath 로 최내곽 셀을 조회한다', () => {
+  const body = methodBody('getCharPropertiesAtCursor');
+  assert.match(
+    body,
+    /getCellCharPropertiesAtByPath\s*\(/,
+    '중첩 셀 서식 조회는 getCellCharPropertiesAtByPath(안쪽 축)를 써야 한다',
+  );
+  assert.match(
+    body,
+    /pos\.cellPath\?\.length/,
+    'cellPath 유무로 경로/flat 을 분기해야 한다',
+  );
+});
+
+test('getCharPropertiesAtCursor 의 flat 조회는 cellPath 부재 폴백으로만 남는다', () => {
+  const body = methodBody('getCharPropertiesAtCursor');
+  // flat 호출 자체는 depth 1/레거시 폴백으로 유지되지만, ByPath 분기보다 뒤에 와야 한다.
+  const byPathIdx = body.indexOf('getCellCharPropertiesAtByPath');
+  const flatIdx = body.indexOf('getCellCharPropertiesAt(');
+  assert.ok(byPathIdx !== -1, 'ByPath 분기가 있어야 한다');
+  assert.ok(
+    flatIdx === -1 || byPathIdx < flatIdx,
+    'flat getCellCharPropertiesAt 은 ByPath 분기 뒤(폴백)에 와야 한다 — 중첩 셀이 flat 으로 새면 안 된다',
+  );
+});

--- a/rhwp-studio/tests/object-drag-record.test.ts
+++ b/rhwp-studio/tests/object-drag-record.test.ts
@@ -1,0 +1,62 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  computeRotationRecord,
+  computeLineEndpointRecord,
+  type LineEndpoints,
+} from '../src/engine/object-drag-record.ts';
+
+// [Task #2759] 개체 드래그 종료 시 "기록할 before/after 결정" 순수 로직 단위 테스트.
+// 회전 핸들 드래그·직선 끝점 드래그가 undo 가능하려면 이 결정이 정확해야 한다
+// (변화 없으면 null → 무의미한 Undo 항목·redo 스택 무효화 방지).
+
+test('computeRotationRecord 는 각이 바뀌면 origAngle→finalAngle before/after 를 준다', () => {
+  const r = computeRotationRecord(0, 45);
+  assert.ok(r);
+  assert.deepEqual(r.before, { rotationAngle: 0 });
+  assert.deepEqual(r.after, { rotationAngle: 45 });
+});
+
+test('computeRotationRecord 는 각이 같으면 null (드래그 없음 = 미기록)', () => {
+  assert.equal(computeRotationRecord(90, 90), null);
+  assert.equal(computeRotationRecord(0, 0), null);
+});
+
+test('computeRotationRecord 는 음수각·정규화된 값을 그대로 보존한다', () => {
+  const r = computeRotationRecord(30, -15);
+  assert.ok(r);
+  assert.deepEqual(r.before, { rotationAngle: 30 });
+  assert.deepEqual(r.after, { rotationAngle: -15 });
+});
+
+test('computeRotationRecord 는 비정상 입력(NaN/Infinity)에 null 을 준다', () => {
+  assert.equal(computeRotationRecord(Number.NaN, 45), null);
+  assert.equal(computeRotationRecord(0, Number.POSITIVE_INFINITY), null);
+});
+
+const A: LineEndpoints = { sx: 1000, sy: 2000, ex: 3000, ey: 4000 };
+
+test('computeLineEndpointRecord 는 끝점이 바뀌면 before/after 를 복사해 준다', () => {
+  const after: LineEndpoints = { sx: 1500, sy: 2000, ex: 3000, ey: 4000 };
+  const r = computeLineEndpointRecord(A, after);
+  assert.ok(r);
+  assert.deepEqual(r.before, A);
+  assert.deepEqual(r.after, after);
+  // 방어적 복사 — 원본 변형이 기록에 새지 않아야 한다.
+  assert.notEqual(r.before, A);
+});
+
+test('computeLineEndpointRecord 는 좌표가 동일하면 null (클릭만 = 미기록)', () => {
+  assert.equal(computeLineEndpointRecord(A, { ...A }), null);
+});
+
+test('computeLineEndpointRecord 는 어느 한 좌표만 달라도 기록 대상이다', () => {
+  assert.ok(computeLineEndpointRecord(A, { ...A, ey: 4001 }));
+  assert.ok(computeLineEndpointRecord(A, { ...A, sx: 999 }));
+});
+
+test('computeLineEndpointRecord 는 비정상 좌표(NaN)에 null 을 준다', () => {
+  assert.equal(computeLineEndpointRecord(A, { ...A, sx: Number.NaN }), null);
+  assert.equal(computeLineEndpointRecord({ ...A, ey: Number.NaN }, A), null);
+});

--- a/rhwp-studio/tests/selection-ordering-nested-cell.test.ts
+++ b/rhwp-studio/tests/selection-ordering-nested-cell.test.ts
@@ -1,0 +1,211 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { fileURLToPath, pathToFileURL } from 'node:url';
+
+// [#2756] 중첩 표 안쪽 셀 선택 영역 정렬의 "축 정합" 행위 가드.
+//
+// hit-test 는 flat 필드(controlIndex/cellIndex/cellParaIndex)를 cellPath[0], 즉 **최외곽**
+// 엔트리에서 채운다(cursor_rect.rs 의 `outer = &ctx.path[0]`). 따라서 중첩 셀에서
+// pos.cellParaIndex 는 바깥 셀의 문단 인덱스이고, 안쪽 셀 값은 cellPath[last].cellParaIndex 다
+// (command.ts 의 cellParaIndexOf 주석 / tests/undo-nested-cell-merge-offset.test.ts).
+//
+// CursorState.comparePositions 가 flat cellIndex/cellParaIndex 를 맨몸으로 비교하면
+//   A. 안쪽 셀의 서로 다른 문단(바깥 문단은 동일) → 문단 비교가 통과돼 charOffset 으로 낙하,
+//      선택 양끝이 뒤바뀐다. 소비자 DeleteSelectionCommand 는 cellParaIndexOf(안쪽 축)로
+//      start/end 를 읽으므로 startPara > endPara → savedTexts 가 비고, Rust
+//      delete_range_in_cell_by_path 는 선택 범위의 **여집합**을 지운다. undo 는 무효.
+//   B. 안쪽 셀이 서로 다름(바깥 셀 식별자는 동일) → flat cellIndex 가 같아 정렬이 붕괴.
+// 두 방향 모두 어긋난다.
+//
+// 검증 방식: 소스 복제 없이 실제 cursor.ts 를 로드해 comparePositions/getSelectionOrdered 를
+// 직접 호출한다. CursorState 는 constructor(private wasm) parameter property 때문에 Node 의
+// strip-only 로더로는 직접 import 가 불가하므로(`TypeScript parameter property is not supported
+// in strip-only mode`), process.execPath 자식 프로세스를 --experimental-transform-types 로
+// 띄우고 module.registerHooks 로 `@/` 별칭과 확장자 없는 상대 import 를 매핑한다.
+// node_modules/.bin 실행 파일에 의존하지 않아 플랫폼 무관하게 동작한다.
+
+const studioRoot = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
+const workDir = mkdtempSync(path.join(tmpdir(), 'rhwp-sel-order-'));
+
+const driverPath = path.join(workDir, 'driver.mjs');
+writeFileSync(driverPath, `
+import { registerHooks } from 'node:module';
+import { pathToFileURL } from 'node:url';
+
+const srcRoot = ${JSON.stringify(pathToFileURL(path.join(studioRoot, 'src') + path.sep).href)};
+
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) return nextResolve(srcRoot + specifier.slice(2) + '.ts', context);
+    // 스튜디오 소스의 확장자 없는 상대 import (번들러 관례) 보정.
+    if (/^\\.{1,2}\\//.test(specifier) && !/\\.[a-z]+$/.test(specifier)) {
+      return nextResolve(specifier + '.ts', context);
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { CursorState } = await import(srcRoot + 'engine/cursor.ts');
+
+const R = { pageIndex: 0, x: 0, y: 0, height: 10 };
+
+// 안쪽 셀(cellIndex 2)의 문단 para, 오프셋 off. 바깥 표 cellIndex 0 의 문단 outerPara 에 중첩.
+// flat 필드는 hit-test 규약대로 **바깥** 엔트리(cellPath[0]) 값으로 채운다.
+function innerPos(outerPara, innerCell, innerPara, off) {
+  return {
+    sectionIndex: 0, paragraphIndex: innerPara, charOffset: off,
+    parentParaIndex: 3, controlIndex: 0, cellIndex: 0, cellParaIndex: outerPara,
+    cellPath: [
+      { controlIndex: 0, cellIndex: 0, cellParaIndex: outerPara },
+      { controlIndex: 0, cellIndex: innerCell, cellParaIndex: innerPara },
+    ],
+    cursorRect: R,
+  };
+}
+
+// depth 1 (비중첩) 셀 위치 — flat 과 cellPath[0] 이 곧 최내곽으로 일치.
+function flatCellPos(cellPara, off) {
+  return {
+    sectionIndex: 0, paragraphIndex: cellPara, charOffset: off,
+    parentParaIndex: 3, controlIndex: 0, cellIndex: 2, cellParaIndex: cellPara,
+    cellPath: [{ controlIndex: 0, cellIndex: 2, cellParaIndex: cellPara }],
+    cursorRect: R,
+  };
+}
+
+function bodyPos(para, off) {
+  return { sectionIndex: 0, paragraphIndex: para, charOffset: off, cursorRect: R };
+}
+
+const cmp = (a, b) => CursorState.comparePositions(a, b);
+const sign = (n) => (n < 0 ? -1 : n > 0 ? 1 : 0);
+
+// getSelectionOrdered 실경로 — moveToHit(cursorRect 有 → updateRect 미호출) + setAnchor.
+function orderedInner(anchor, focus) {
+  const cs = new CursorState({});
+  cs.moveToHit(anchor);
+  cs.setAnchor();
+  cs.moveToHit(focus);
+  const sel = cs.getSelectionOrdered();
+  const innerPara = (p) => p.cellPath[p.cellPath.length - 1].cellParaIndex;
+  const innerCell = (p) => p.cellPath[p.cellPath.length - 1].cellIndex;
+  return {
+    startInnerPara: innerPara(sel.start), endInnerPara: innerPara(sel.end),
+    startInnerCell: innerCell(sel.start), endInnerCell: innerCell(sel.end),
+    startOff: sel.start.charOffset, endOff: sel.end.charOffset,
+  };
+}
+
+const result = {};
+
+// A. 같은 안쪽 셀, 안쪽 문단 0 끝(off 5) → 문단 1 시작(off 0). 바깥 문단은 둘 다 0.
+//    올바르면 cmp<0 (anchor<focus), 뒤바뀌면 cmp>0.
+const aAnchor = innerPos(0, 2, 0, 5);
+const aFocus  = innerPos(0, 2, 1, 0);
+result.sameCellCmp = sign(cmp(aAnchor, aFocus));
+result.sameCellOrdered = orderedInner(aAnchor, aFocus);
+
+// B. 서로 다른 안쪽 셀(2 vs 4), 바깥 셀 식별자는 동일. 올바르면 cellIndex 2<4 로 cmp<0.
+const bAnchor = innerPos(0, 2, 1, 3);
+const bFocus  = innerPos(0, 4, 0, 0);
+result.diffInnerCellCmp = sign(cmp(bAnchor, bFocus));
+
+// C. depth 1 회귀 대조군 — 문단 0 off5 vs 문단 1 off0. 현행 동작 불변(cmp<0).
+result.depth1Cmp = sign(cmp(flatCellPos(0, 5), flatCellPos(1, 0)));
+
+// D. 본문 회귀 대조군 — 문단 2 off0 vs 문단 1 off9. cmp>0 (2>1).
+result.bodyCmp = sign(cmp(bodyPos(2, 0), bodyPos(1, 9)));
+
+// E. 본문↔셀 혼합 회귀 대조군 — 본문 문단 3 vs 같은 문단의 셀(parentPara 3). 셀이 뒤 → cmp<0.
+result.bodyVsCellCmp = sign(cmp(bodyPos(3, 0), innerPos(0, 2, 0, 0)));
+
+// F. 반사성/대칭성 — cmp(a,b) === -cmp(b,a), cmp(a,a)===0.
+result.antisymmetry = sign(cmp(aAnchor, aFocus)) === -sign(cmp(aFocus, aAnchor));
+result.reflexivity = sign(cmp(aAnchor, { ...aAnchor })) === 0;
+
+process.stdout.write('###' + JSON.stringify(result) + '###');
+`);
+
+const run = spawnSync(
+  process.execPath,
+  ['--experimental-transform-types', '--no-warnings', driverPath],
+  { cwd: studioRoot, encoding: 'utf8' },
+);
+
+rmSync(workDir, { recursive: true, force: true });
+
+assert.equal(
+  run.status,
+  0,
+  `comparePositions 행위 드라이버 실행 실패:\n${run.stdout}\n${run.stderr}`,
+);
+
+const captured = /###([\s\S]*)###/.exec(run.stdout);
+assert.ok(captured, `드라이버 출력에서 결과 JSON 을 찾지 못함:\n${run.stdout}\n${run.stderr}`);
+const observed = JSON.parse(captured[1]) as {
+  sameCellCmp: number;
+  sameCellOrdered: {
+    startInnerPara: number; endInnerPara: number;
+    startInnerCell: number; endInnerCell: number;
+    startOff: number; endOff: number;
+  };
+  diffInnerCellCmp: number;
+  depth1Cmp: number;
+  bodyCmp: number;
+  bodyVsCellCmp: number;
+  antisymmetry: boolean;
+  reflexivity: boolean;
+};
+
+test('중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다 (데이터 손실 방지)', () => {
+  assert.equal(
+    observed.sameCellCmp,
+    -1,
+    'flat cellParaIndex(바깥=0) 로 비교하면 두 문단이 같아 보여 charOffset(5>0)으로 낙하, 양끝이 뒤바뀐다',
+  );
+  // 정렬 결과의 안쪽 축이 start <= end 여야 한다 (DeleteSelectionCommand 가 읽는 축).
+  assert.ok(
+    observed.sameCellOrdered.startInnerPara <= observed.sameCellOrdered.endInnerPara,
+    `정렬된 start 의 안쪽 문단(${observed.sameCellOrdered.startInnerPara})이 end(${observed.sameCellOrdered.endInnerPara})보다 뒤면 ` +
+    'startPara>endPara 로 savedTexts 가 비고 삭제가 여집합을 지운다',
+  );
+  assert.deepEqual(
+    { p: observed.sameCellOrdered.startInnerPara, off: observed.sameCellOrdered.startOff },
+    { p: 0, off: 5 },
+    'start 는 문단 0 끝(anchor)이어야 한다',
+  );
+  assert.deepEqual(
+    { p: observed.sameCellOrdered.endInnerPara, off: observed.sameCellOrdered.endOff },
+    { p: 1, off: 0 },
+    'end 는 문단 1 시작(focus)이어야 한다',
+  );
+});
+
+test('서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다', () => {
+  assert.equal(
+    observed.diffInnerCellCmp,
+    -1,
+    'flat cellIndex 는 둘 다 바깥 셀(0)이라 같다 — 안쪽 cellPath[last].cellIndex(2<4)로 정렬해야 한다',
+  );
+});
+
+test('depth 1 (비중첩) 셀 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.depth1Cmp, -1, 'depth 1 은 cellPath[0]=최내곽=flat 이라 종전대로 문단 0<1');
+});
+
+test('본문 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.bodyCmp, 1, '본문 문단 2>1');
+});
+
+test('본문↔셀 혼합 정렬은 불변이다 (회귀 대조군)', () => {
+  assert.equal(observed.bodyVsCellCmp, -1, '같은 문단에서 셀은 본문보다 뒤로 간주');
+});
+
+test('comparePositions 는 반대칭·반사적이다', () => {
+  assert.ok(observed.antisymmetry, 'cmp(a,b) === -cmp(b,a)');
+  assert.ok(observed.reflexivity, 'cmp(a,a) === 0');
+});

--- a/rhwp-studio/tests/support/drag-command-behaviour.runner.mjs
+++ b/rhwp-studio/tests/support/drag-command-behaviour.runner.mjs
@@ -1,0 +1,64 @@
+// [Task #2759] 행위 러너 — command.ts 의 커맨드 클래스를 실제 로드해 execute/undo 를
+// mock WasmBridge 로 검증한다. cursor.ts:85 의 TS 파라미터 프로퍼티 때문에 기본 test
+// 러너(strip-only)는 엔진 클래스를 import 하지 못하므로, 이 러너를 부모 테스트가
+// --experimental-transform-types 로 spawn 한다(별도 PR #2720 방식). 실패 시 비정상 종료.
+import { registerHooks } from 'node:module';
+import { pathToFileURL, fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+import assert from 'node:assert/strict';
+
+const srcDir = join(dirname(fileURLToPath(import.meta.url)), '..', '..', 'src');
+
+// @/ 별칭 + 확장자 없는 상대 import 를 .ts 로 해석(tsconfig paths 재현).
+registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('@/')) {
+      const abs = join(srcDir, specifier.slice(2));
+      const withTs = abs.endsWith('.ts') ? abs : abs + '.ts';
+      return { url: pathToFileURL(withTs).href, shortCircuit: true };
+    }
+    if ((specifier.startsWith('./') || specifier.startsWith('../')) && !/\.[cm]?[tj]s$/.test(specifier)) {
+      const parent = context.parentURL ? dirname(fileURLToPath(context.parentURL)) : srcDir;
+      return { url: pathToFileURL(join(parent, specifier + '.ts')).href, shortCircuit: true };
+    }
+    return nextResolve(specifier, context);
+  },
+});
+
+const { MoveLineEndpointCommand, ResizeObjectCommand } =
+  await import(pathToFileURL(join(srcDir, 'engine', 'command.ts')).href);
+
+// ── MoveLineEndpointCommand: 끝점 이동 undo/redo ────────────────────────────
+{
+  let last = null;
+  const wasm = { moveLineEndpoint: (...a) => { last = a; } };
+  const before = { sx: 100, sy: 200, ex: 300, ey: 400 };
+  const after = { sx: 150, sy: 200, ex: 300, ey: 999 };
+  const cmd = new MoveLineEndpointCommand(2, 3, 4, before, after);
+
+  cmd.execute(wasm); // redo 경로: after 재적용
+  assert.deepEqual(last, [2, 3, 4, 150, 200, 300, 999], 'execute 는 after 끝점을 적용해야 함');
+
+  cmd.undo(wasm); // before 복원
+  assert.deepEqual(last, [2, 3, 4, 100, 200, 300, 400], 'undo 는 before 끝점을 복원해야 함');
+  assert.equal(cmd.type, 'moveLineEndpoint');
+  assert.equal(cmd.mergeWith(), null, '병합 없음(각 드래그는 독립 기록)');
+}
+
+// ── ResizeObjectCommand: 회전각 before/after(임의 속성 가방) ─────────────────
+{
+  const applied = [];
+  const wasm = { setShapeProperties: (s, p, c, props) => applied.push(props) };
+  const cmd = new ResizeObjectCommand([{
+    sec: 0, ppi: 1, ci: 2, type: 'shape',
+    before: { rotationAngle: 0 }, after: { rotationAngle: 45 },
+  }]);
+
+  cmd.execute(wasm); // 회전 드래그 종료 후 redo
+  assert.deepEqual(applied.at(-1), { rotationAngle: 45 }, 'execute 는 after 회전각을 적용');
+
+  cmd.undo(wasm);
+  assert.deepEqual(applied.at(-1), { rotationAngle: 0 }, 'undo 는 원래 회전각으로 복원');
+}
+
+console.log('DRAG_COMMAND_BEHAVIOUR_OK');

--- a/rhwp-studio/tests/undo-drag-click-routing.test.ts
+++ b/rhwp-studio/tests/undo-drag-click-routing.test.ts
@@ -1,0 +1,63 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2759] 드래그·클릭 문서 뮤테이션의 히스토리 라우팅 소스 가드.
+//
+// 회전 핸들 드래그·직선 끝점 드래그·클릭 z순서 변경이 executeOperation 를 경유해 undo 에
+// 기록되는지 정적으로 핀한다. 뮤테이션 표면 원장(mutation-routing-guard)은 '표면 증가'만
+// 잡고 '라우팅 누락'은 못 잡으므로(라우팅해도 wasm.X( 텍스트는 그대로 남음), 그리고
+// undo-menu-object-ops 는 command/commands/insert.ts 만 보므로, 엔진 층 진입점은 이 가드가
+// 담당한다. 행위 증명은 tests/undo-drag-command-behaviour.test.ts(커맨드 execute/undo)와
+// tests/object-drag-record.test.ts(기록 결정 순수 로직)에 있다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const pictureSrc = readFileSync(join(rootDir, 'src/engine/input-handler-picture.ts'), 'utf8');
+const mouseSrc = readFileSync(join(rootDir, 'src/engine/input-handler-mouse.ts'), 'utf8');
+
+/** name 으로 시작하는 함수 본문을 다음 최상위 'export function'/'function ' 전까지 잘라온다. */
+function fnBody(src: string, header: string): string {
+  const start = src.indexOf(header);
+  assert.notEqual(start, -1, `${header} 를 찾지 못함`);
+  const after = src.slice(start + header.length);
+  const next = after.search(/\n(export )?function /);
+  return after.slice(0, next === -1 ? 2000 : next);
+}
+
+// ── 결함 1: 회전 핸들 드래그 ───────────────────────────────────────────────
+test('finishPictureRotateDrag 는 회전각 변경을 executeOperation record 로 기록한다', () => {
+  const body = fnBody(pictureSrc, 'export function finishPictureRotateDrag');
+  assert.match(body, /computeRotationRecord\(/, 'origAngle→finalAngle 기록 결정을 순수 함수로 위임');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유(히스토리 기록)');
+  assert.match(body, /kind:\s*'record'/, "kind:'record' 로 드래그 사후 기록");
+  assert.match(body, /new ResizeObjectCommand\(/, 'rotationAngle before/after 를 ResizeObjectCommand 로');
+});
+
+// ── 결함 2: 직선 끝점 드래그 ───────────────────────────────────────────────
+test('finishLineEndpointDrag 는 끝점 이동을 executeOperation record 로 기록한다', () => {
+  const body = fnBody(mouseSrc, 'export function finishLineEndpointDrag');
+  assert.match(body, /computeLineEndpointRecord\(/, 'before/after 끝점 기록 결정을 순수 함수로 위임');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유');
+  assert.match(body, /kind:\s*'record'/, "kind:'record' 로 드래그 사후 기록");
+  assert.match(body, /new MoveLineEndpointCommand\(/, '끝점 좌표 역연산 커맨드로 기록');
+});
+
+test('onMouseUp 은 직선 끝점 종료를 finishLineEndpointDrag 로 위임한다(인라인 정리 금지)', () => {
+  const body = fnBody(mouseSrc, 'export function onMouseUp');
+  assert.match(body, /if \(this\.isLineEndpointDragging\)\s*{\s*this\.finishLineEndpointDrag\(\);/,
+    'onMouseUp 은 상태 인라인 초기화가 아니라 finishLineEndpointDrag 로 위임해야 함(기록 경로 확보)');
+});
+
+// ── 결함 3: 클릭 z순서 변경 ────────────────────────────────────────────────
+test('bringShapeToFront 는 z순서 변경을 executeOperation snapshot 으로 기록한다', () => {
+  const body = fnBody(mouseSrc, 'function bringShapeToFront');
+  // 미라우팅 회귀: this.wasm.changeShapeZOrder( 직접 호출이 남으면 히스토리 우회.
+  assert.doesNotMatch(body, /this\.wasm\.changeShapeZOrder\s*\(/,
+    'this.wasm.changeShapeZOrder 직접 호출 금지 — executeOperation 경유여야 함');
+  assert.match(body, /executeOperation\(/, 'executeOperation 경유');
+  assert.match(body, /kind:\s*'snapshot'/, "kind:'snapshot' 로 기록(메뉴 정렬 경로와 동형)");
+  assert.match(body, /operationType:\s*'changeZOrder'/, 'changeZOrder 로 분류');
+  assert.match(body, /wasm\.changeShapeZOrder\s*\(/, '뮤테이션 자체는 operation 콜백에 존재');
+});

--- a/rhwp-studio/tests/undo-drag-command-behaviour.test.ts
+++ b/rhwp-studio/tests/undo-drag-command-behaviour.test.ts
@@ -1,0 +1,40 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { spawnSync } from 'node:child_process';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import * as nodeModule from 'node:module';
+
+// [Task #2759] command.ts 커맨드 클래스의 execute/undo 행위 테스트.
+//
+// 이 저장소는 cursor.ts:85 의 TS 파라미터 프로퍼티 때문에 기본 test 러너(strip-only)로
+// 엔진 클래스를 import 하지 못한다(tests/undo-menu-object-ops.test.ts 헤더 참고). 그래서
+// --experimental-transform-types 를 켠 자식 프로세스로 러너를 spawn 해 실제 클래스를 로드하고
+// mock WasmBridge 로 MoveLineEndpointCommand·ResizeObjectCommand(회전) 을 검증한다.
+//
+// 자식이 요구하는 기능(Transform Types 플래그 + module.registerHooks)이 없는 구버전 Node
+// 에서는 skip 한다(부모는 strip-only 로 동작하므로 CI 를 깨지 않는다). 지원 런타임에서는
+// 진짜 행위 red→green 게이트로 동작한다.
+
+const here = dirname(fileURLToPath(import.meta.url));
+const runner = join(here, 'support', 'drag-command-behaviour.runner.mjs');
+
+function transformTypesSupported(): boolean {
+  return process.allowedNodeEnvironmentFlags.has('--experimental-transform-types')
+    && typeof (nodeModule as { registerHooks?: unknown }).registerHooks === 'function';
+}
+
+test('커맨드 클래스 execute/undo 행위 (자식 프로세스 로드)', (t) => {
+  if (!transformTypesSupported()) {
+    t.skip('현재 Node 가 --experimental-transform-types / registerHooks 미지원 — 행위 테스트 skip');
+    return;
+  }
+  const res = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', runner],
+    { encoding: 'utf8' },
+  );
+  assert.equal(res.status, 0,
+    `러너가 비정상 종료했습니다.\n--- stdout ---\n${res.stdout}\n--- stderr ---\n${res.stderr}`);
+  assert.match(res.stdout, /DRAG_COMMAND_BEHAVIOUR_OK/, '행위 검증 성공 마커가 있어야 함');
+});


### PR DESCRIPTION
kevin9327 님의 #2766·#2776 을 메인테이너가 재실증 후 통합한다. **`.rs` 무수정, `rhwp-studio/` TypeScript 만.**

## 채택

### #2766 (`Closes #2756`) — 중첩 표 셀 flat 좌표 축 오용

`DocumentPosition` 의 flat 필드(`controlIndex`/`cellIndex`/`cellParaIndex`)는 hit-test 가 `cellPath[0]`, 즉 **최외곽** 셀에서 채운다. 안쪽 셀 값은 `cellPath[last]` 다. 이 축 전환은 `command.ts` 커맨드 계층에서 `cellParaIndexOf()` 로 이미 정리됐으나 **호출부 두 곳이 누락**돼 있었다.

증상이 가볍지 않다 — 선택 정렬이 뒤바뀌어 **삭제 시 데이터가 손실**되고 undo 가 무효화되며, Ctrl+B/I 토글 방향도 어긋난다.

헬퍼를 복제하지 않고 `command.ts` 의 `cellAxisPath` 를 import 해 **단일 정의를 공유**한 판단이 좋다("축 유도 복제 금지"). 어제 merge 한 #2720(`handleBackspace` 축 정합)의 잔여 호출부이며, 뿌리가 같아 하나로 묶은 것도 맞다.

### #2776 (`Closes #2759`) — 드래그·클릭 문서 뮤테이션 3건 히스토리 라우팅

`mutation-method-registry.ts` 가 이미 명명해 둔 **재발 계급**(#2027/#2037/#2053/#2077)의 신규 3건이다. 문서를 바꾸면서 히스토리를 우회하는 진입점은 ①undo 불가 ②redo 미무효화 ③스냅샷 undo 동반 파괴를 일으킨다. 기존 라우팅된 형제와 동형으로 `executeOperation` 에 태웠다.

## 검증

- `.rs` 변경 0건, `tsc --noEmit` 오류 0
- studio 테스트 **494 pass / 0 fail** (devel 473 → 신규 21건 추가)
- red→green: 최내곽 축 비교를 종전 flat 필드 비교로 되돌리니 "중첩 안쪽 셀의 문단 0 끝 → 문단 1 시작 선택이 뒤바뀌지 않는다(데이터 손실 방지)" 와 "서로 다른 안쪽 셀은 경로의 안쪽 cellIndex 로 정렬한다" **2건 FAIL** → 복원 시 494 pass

Co-authored-by 로 원 커밋 provenance 를 보존한다.
