### PR TITLE
feat(studio): 호스트 저장 완료 통지 API notifySaved (#2660) — johndoekim 통합

### DIFF
--- a/mydocs/plans/task_m100_2660.md
+++ b/mydocs/plans/task_m100_2660.md
@@ -1,0 +1,142 @@
+# 수행계획서 — 호스트 저장 완료 통지 API notifySaved (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660` (`local/devel` = `upstream/devel` a803f079 기준)
+- **작성일**: 2026-07-21
+- **관련**: #1448, PR #1450 (자동 백업/복구), 후속 별도 이슈 #2661 (hwpctl SaveAs)
+
+## 1. 목표
+
+외부 호스트 앱이 rhwp-studio에서 문서 바이트를 내보내 자체 저장한 뒤, 저장 완료를
+스튜디오에 통지할 공개 API를 제공한다. 이로써 사용자가 저장했다고 느꼈음에도
+dirty 상태와 IndexedDB 백업 draft가 남아 다음 실행 시 "문서 복구" 다이얼로그가
+뜨는 문제를 해소한다.
+
+대상 통합 토폴로지 두 가지를 모두 지원한다.
+
+1. **팝업**: 호스트가 스튜디오를 `window.open`으로 띄우고, 스튜디오 창 안 코드가
+   `window.opener.postMessage(직렬화 결과)` 후 `window.close()` 하는 방식.
+2. **iframe**: `@rhwp/editor` SDK 또는 embed RPC로 `exportHwp` 등을 호출해 바이트를
+   받아 호스트 서버에 업로드하는 방식.
+
+## 2. 배경과 원인
+
+#1448(PR #1450)로 미저장 문서 자동 백업/복구가 추가되면서 표면화됐다.
+
+- 내부 저장(파일 메뉴)은 `markClean('save'|'save-as')` →
+  `document-dirty-changed(dirty=false)` → `AutosaveManager.discardCurrentDraft()` →
+  IndexedDB(`rhwpStudioAutosave`) draft 삭제 사슬로 정리된다
+  (`rhwp-studio/src/command/commands/file.ts` `completeHandleSave` L171-180,
+  폴백 경로 L224·L275).
+- 반면 호스트 내보내기 경로는 직렬화 바이트만 가져가고 **저장 완료를 알릴 수단이
+  없다**. embed RPC 핸들러(`rhwp-studio/src/main.ts` L1322-1337)는 바이트만 반환하고,
+  프로토콜(`rpc-router.ts`)에 저장 통지 메서드 자체가 없다. 팝업 커스텀 코드도
+  `documentState`에 접근할 공개 통로가 없다.
+- 결과: dirty=true 유지 → draft 미삭제 → 다음 실행 시 복구 다이얼로그 (최대 12개 누적).
+
+#1448 자체의 버그가 아니라(재오픈 불필요) "호스트 통합 경로에 저장 완료 통지 수단
+부재"라는 API 공백이다.
+
+추가 발견 2건도 본 타스크에서 다룬다.
+
+- **close 잘림 위험**: 이벤트 경로의 draft 삭제는 fire-and-forget
+  (`autosave-manager.ts` L99 `void this.discardCurrentDraft(...)`)이라, 팝업이
+  통지 직후 `window.close()` 하면 IndexedDB 삭제가 잘릴 수 있다. 공개 API는 삭제
+  완료를 await해야 한다.
+- **flush↔discard 경합**: `flushNow()` 진행 중(`saving=true`) discard가 끼어들면
+  진행 중이던 `saveDraft`가 나중에 완료되며 draft가 부활할 수 있다(기존 내부 저장에도
+  잠재하는 경합). 제너레이션 카운터로 방어한다.
+
+## 3. 설계 결정
+
+| 항목 | 결정 |
+|------|------|
+| 코어 | `completeHostSave(fileName?)`: `markClean('host-save')` + `await autosaveManager.discardCurrentDraft('host-save')` (main.ts 싱글톤 접근 지점) |
+| 표면 A (팝업/포크) | `window.rhwpStudio = { notifySaved }` 프로덕션 포함 항상 노출 (기존 `__documentState` 등은 DEV 전용 유지) |
+| 표면 B (iframe) | embed RPC `notifySaved(fileName?)` + capability `'notify-saved-v1'` + `@rhwp/editor` SDK 메서드(capability 게이팅) |
+| 저장 시점 계약 | 팝업: 핸드오프 즉시 통지 후 close (이후 영속화 책임은 바이트를 보유한 호스트). iframe: 업로드 성공 확인 후 통지 |
+| export 자동 markClean | 하지 않음 — iframe 흐름에서 업로드 실패 시 백업 보존 필요 |
+| 반환값 | `{ ok: true, wasDirty: boolean }` (멱등 호출 관찰 가능) |
+| race 정책 | 내부 저장과 동일하게 무조건 markClean. flush↔discard 경합만 제너레이션 카운터로 방어 |
+| 프로토콜 버전 | `EMBED_PROTOCOL_VERSION = 1` 유지 — 순수 additive. 구버전 스튜디오는 `Unknown method` RPC_ERROR로 안전 실패, capability로 감지 |
+| hwpctl `SaveAs()` | 범위 제외 — `HwpCtrl`은 `wasmDoc`만 주입받아 배선에 별도 설계 필요. #2661로 분리 |
+
+## 4. 수정 범위
+
+| 포함 | 제외 |
+|---|---|
+| `main.ts` 코어 함수 + `window.rhwpStudio` 노출 + embed 핸들러 | export 핸들러의 자동 markClean |
+| `embed/protocol.ts` capability, `embed/rpc-router.ts` 메서드 | `embed/runtime.ts`, `EMBED_PROTOCOL_VERSION` 변경 |
+| `recovery/autosave-manager.ts` 경합 방어(제너레이션 카운터) | `autosave-store.ts`, `document-dirty-state.ts` |
+| `npm/editor` SDK (transport/index/index.d.ts) + README 저장 계약 | hwpctl (`SaveAs()` → #2661) |
+| 단위·계약·E2E 테스트 | Rust/WASM 전체 |
+
+## 5. 단계
+
+### Stage 1 — 코어 + window 공개 API
+
+- `completeHostSave(fileName?)` 구현: `wasDirty` 캡처 → (선택) `wasm.fileName` 갱신 →
+  `markClean('host-save')` → `await discardCurrentDraft('host-save')` → 결과 반환.
+- `window.rhwpStudio.notifySaved` 노출 (프로덕션 포함).
+- `AutosaveManager` 제너레이션 카운터: `discardCurrentDraft`가 카운터를 증가시키고,
+  `flushNow`는 `saveDraft` 완료 후 카운터 변경을 감지하면 방금 저장한 draft를 재삭제.
+- 단위 테스트: 경합 시나리오(mock store로 flush 중 discard) 포함.
+- 검증: `cd rhwp-studio && npm test`, `npx tsc --noEmit`.
+
+### Stage 2 — embed RPC
+
+- `protocol.ts` `EMBED_CAPABILITIES`에 `'notify-saved-v1'` 추가.
+- `rpc-router.ts` `EmbedRpcHandlers.notifySaved(fileName?)` + `case 'notifySaved'`
+  (fileName은 비어있지 않은 문자열만 통과, 아니면 `undefined`).
+- `main.ts` 핸들러 블록에 `notifySaved` 배선 (`await initPromise` 포함).
+- v1 MessagePort·legacy 경로 모두 `routeEmbedRequest` 공유로 자동 지원 확인.
+- `tests/embed-protocol.test.ts` 갱신: capability deepEqual, 핸들러 목(신규
+  `suppressDialogs` 파라미터 포함 현행 시그니처 기준), 라우팅 assert.
+- 검증: `npm test`.
+
+### Stage 3 — @rhwp/editor SDK
+
+- `transport.js` 클라이언트 CAPABILITIES에 `'notify-saved-v1'`.
+- `index.js` `notifySaved(fileName?)` — capability 게이팅(기존
+  `getRendererDiagnostics` 패턴), 미지원 스튜디오 연결 시 명시적 throw.
+- `index.d.ts` 시그니처 + JSDoc(호출 시점 계약 명기).
+- SDK 계약 테스트: capability 광고 시 요청/응답, 미광고 시 throw.
+- 검증: `npm test` + `cd ../npm/editor && npm test`.
+
+### Stage 4 — E2E
+
+- 신규 `e2e/embed-save-ack.test.mjs`
+  (기존 `embed-transport.test.mjs` + `autosave-recovery.test.mjs` 패턴 조합,
+  DEV 노출 `__documentState`/`__autosaveManager` 활용):
+  - TC-1: loadFile → dirty + draft 생성 → export → `notifySaved()` → dirty 해제·draft
+    삭제 확인 → 재생성 시 복구 다이얼로그 미표시.
+  - TC-2 (음성): `notifySaved` 생략 → 재생성 시 "문서 복구" 표시.
+  - TC-3: `rhwp-connected` capabilities에 `'notify-saved-v1'` 포함.
+  - TC-4 (window API): 페이지에서 직접 markDirty → flushNow →
+    `window.rhwpStudio.notifySaved()` → 리로드 → 다이얼로그 미표시.
+- 기존 회귀: `npm run e2e:embed`, `node e2e/autosave-recovery.test.mjs --mode=headless`.
+
+### Stage 5 — 문서화 + 최종 회귀
+
+- `npm/editor/README.md`(호스트 정본 문서) 저장 계약 절:
+  - iframe: export → 업로드 **성공 시에만** `notifySaved()` (실패 시 미호출 — 백업 보존).
+  - 팝업: 핸드오프 즉시 `await notifySaved()` 후 close. `postMessage`의
+    targetOrigin은 반드시 명시적 오리진 사용 권고(문서 내용 유출 방지).
+- 전체 회귀(`npm test` / `npm run build` / Stage 4 E2E) + 최종 결과보고서.
+
+## 6. 위험과 완화
+
+- **팝업 close에 IndexedDB 삭제 잘림**: 공개 API가 삭제 완료를 await — 호스트는
+  `await notifySaved()` 후 close 하도록 계약 문서화.
+- **draft 부활 경합**: Stage 1 제너레이션 카운터 + 경합 단위 테스트.
+- **통지 전 사용자 추가 편집 유실 가능성**: 내부 저장(export→비동기 쓰기→markClean)과
+  동일한 의미론으로 수용. 편집이 이어지면 즉시 markDirty로 복귀하므로 위험 창은
+  통지 직후 즉시 종료되는 경우로 한정. 호스트 계약(내보내기 중 편집 차단 또는 즉시
+  통지)으로 완화.
+- **구버전/미지원 스튜디오**: capability 미광고 시 SDK가 명시적 throw, 직접 RPC는
+  `Unknown method` 안전 실패. 프로토콜 버전 범프 없음.
+- **기존 저장/복구 회귀**: 기존 경로는 무수정(재사용만). 기존 단위·E2E 전건 회귀 실행.
+
+## 7. 승인
+
+수행계획서 승인 대기.

--- a/mydocs/plans/task_m100_2660_impl.md
+++ b/mydocs/plans/task_m100_2660_impl.md
@@ -1,0 +1,242 @@
+# 구현계획서 — 호스트 저장 완료 통지 API notifySaved (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660` (`upstream/devel` a803f079 기준)
+- **수행계획서**: [`task_m100_2660.md`](task_m100_2660.md)
+- **작성일**: 2026-07-21
+
+## 1. 구현 계약
+
+호스트가 내보내기 바이트의 영속화(또는 핸드오프)를 마친 뒤 `notifySaved(fileName?)`를
+호출하면, 스튜디오는 ① dirty를 해제하고(`markClean('host-save')`) ② 자동 백업 draft의
+IndexedDB **삭제 완료까지 기다린 뒤** `{ ok: true, wasDirty }`를 반환한다. 응답이
+도착한 시점에는 팝업을 닫아도 안전하다.
+
+- `exportHwp`/`exportHwpx`/`exportHml`은 무수정 — 자동 markClean 하지 않는다.
+- 프로토콜 버전 1 유지. capability `'notify-saved-v1'`로 feature-detect.
+- 문서 미로드/이미 clean 상태 호출은 관대한 no-op(`wasDirty: false`) — 멱등.
+- autosave `flushNow` 진행 중 discard가 끼어들어도 draft가 부활하지 않는다
+  (제너레이션 카운터).
+
+## 2. 예상 코드 변경
+
+### `rhwp-studio/src/recovery/autosave-manager.ts`
+
+`AutosaveManager`에 discard 제너레이션 카운터 추가:
+
+```ts
+private discardGeneration = 0;
+
+async discardCurrentDraft(reason = 'discard'): Promise<void> {
+  this.discardGeneration += 1;
+  // ...기존 로직 유지...
+}
+
+async flushNow(reason = 'manual'): Promise<void> {
+  // ...
+  const generationAtStart = this.discardGeneration;   // saveDraft 직전 캡처
+  await this.store.saveDraft({ ... });
+  if (this.discardGeneration !== generationAtStart) {
+    await this.deleteDraft(current.draftId, 'discarded-during-save');
+    return;                                            // lastSavedAt·saved status 생략
+  }
+  // ...기존 로직...
+}
+```
+
+`saving` 중 discard → `pendingReason=null`이므로 finally의 재스케줄은 기존 동작대로
+발생하지 않는다. 그 외 로직 무변경.
+
+### `rhwp-studio/src/main.ts`
+
+1. 싱글톤 선언부(L58-67) 아래에 코어 함수:
+
+```ts
+async function completeHostSave(fileName?: string): Promise<{ ok: true; wasDirty: boolean }> {
+  const wasDirty = documentState.isDirty();
+  if (fileName) wasm.fileName = fileName;
+  documentState.markClean('host-save');                    // 기존 이벤트 체인 재사용
+  await autosaveManager.discardCurrentDraft('host-save');  // 삭제 완료 보장 (멱등)
+  return { ok: true, wasDirty };
+}
+```
+
+2. DEV 전용 노출 블록(L74-81)과 별개로 **무조건 노출**:
+
+```ts
+(window as any).rhwpStudio = {
+  notifySaved: (fileName?: string) => completeHostSave(fileName),
+};
+```
+
+3. embed 핸들러 블록(L1281-)에 추가:
+
+```ts
+async notifySaved(fileName) {
+  await initPromise;
+  return completeHostSave(fileName);
+},
+```
+
+### `rhwp-studio/src/embed/protocol.ts`
+
+`EMBED_CAPABILITIES`에 `'notify-saved-v1'` 추가 (4번째 항목). 그 외 무변경.
+
+### `rhwp-studio/src/embed/rpc-router.ts`
+
+```ts
+export interface EmbedNotifySavedResult { ok: true; wasDirty: boolean }
+
+export interface EmbedRpcHandlers {
+  // ...기존 10개...
+  notifySaved(fileName?: string): Promise<EmbedNotifySavedResult>;
+}
+
+// routeEmbedRequest switch:
+case 'notifySaved': return handlers.notifySaved(
+  typeof params.fileName === 'string' && params.fileName.length > 0
+    ? params.fileName
+    : undefined,
+);
+```
+
+v1 MessagePort 경로와 legacy 경로 모두 `routeEmbedRequest`를 공유하므로
+`runtime.ts` 무수정.
+
+### `npm/editor/transport.js`
+
+`CAPABILITIES`(L2-6)에 `'notify-saved-v1'` 추가. `LONG_RUNNING_METHODS`에는 넣지
+않음(기본 10초 타임아웃 충분 — draft 삭제는 밀리초 단위).
+
+### `npm/editor/index.js` — `RhwpEditor`
+
+`getRendererDiagnostics`(L164-176)와 동일한 capability 게이팅 패턴:
+
+```js
+async notifySaved(fileName) {
+  if (!this._transport.supports('notify-saved-v1')) {
+    throw new Error('notifySaved is not supported by this Studio');
+  }
+  const params = typeof fileName === 'string' && fileName.length > 0 ? { fileName } : {};
+  return this._request('notifySaved', params);
+}
+```
+
+legacy 폴백 모드에서는 `_peerCapabilities`가 비어 throw — `getRendererDiagnostics`와
+동일한 기존 한계로 README에 명기.
+
+### `npm/editor/index.d.ts`
+
+```ts
+/**
+ * 내보내기 바이트의 영속화(업로드/핸드오프) 완료를 스튜디오에 통지합니다.
+ * dirty 해제 + 자동복구 draft 삭제 완료 후 resolve — resolve 이후 창을 닫아도 안전.
+ * 업로드 실패 시에는 호출하지 마세요(백업 draft 보존).
+ */
+notifySaved(fileName?: string): Promise<{ ok: true; wasDirty: boolean }>;
+```
+
+### 무변경 파일
+
+`document-dirty-state.ts`, `autosave-store.ts`, `embed/runtime.ts`,
+`hwpctl/index.ts`(→ #2661), `command/commands/file.ts`, Rust/WASM 전체.
+
+## 3. 테스트 계획
+
+### 단위 — `rhwp-studio/tests/`
+
+`embed-protocol.test.ts`:
+- capability deepEqual(L33-37)에 `'notify-saved-v1'` 추가.
+- `EmbedRpcHandlers` 리터럴 목 2곳(L51-65, L106-117)에
+  `notifySaved: async () => ({ ok: true, wasDirty: true })` 추가
+  (인터페이스 확장으로 TS가 누락을 강제 검출).
+- 신규 assert:
+  - `routeEmbedRequest('notifySaved', {}, handlers)` → 핸들러 호출,
+    `fileName === undefined`.
+  - `{ fileName: 'a.hwp' }` → `'a.hwp'` 전달.
+  - `{ fileName: 123 }`, `{ fileName: '' }` → `undefined` 정규화.
+
+신규 `autosave-discard-race.test.ts` (또는 기존 autosave 테스트 파일에 추가):
+- mock store의 `saveDraft`를 지연 Promise로 만들어, `flushNow` 진행 중
+  `discardCurrentDraft` 호출 → `saveDraft` resolve 후 draft가 재삭제되는지 검증.
+- discard 없는 정상 flush는 삭제가 일어나지 않는지(회귀) 검증.
+
+### SDK 계약 — `npm/editor/tests/`
+
+기존 `renderer-diagnostics-v1.contract.test.mjs` 패턴으로 신규
+`notify-saved-v1.contract.test.mjs`:
+- `rhwp-connected`가 `'notify-saved-v1'` 광고 시: `editor.notifySaved('b.hwp')`가
+  `{ method: 'notifySaved', params: { fileName: 'b.hwp' } }` 요청을 보내고 결과 반환.
+- 인자 생략 시 `params: {}`.
+- 미광고 시: 명시적 throw.
+- `transport.test.mjs`의 클라이언트 CAPABILITIES assert 갱신.
+
+### E2E — 신규 `rhwp-studio/e2e/embed-save-ack.test.mjs`
+
+기존 `embed-transport.test.mjs`(SDK iframe 생성) + `autosave-recovery.test.mjs`
+(IndexedDB/다이얼로그 헬퍼) 패턴 조합. DEV 전역(`__documentState`,
+`__autosaveManager`) 활용.
+
+- **TC-1 (positive)**: loadFile → iframe 내부 `markDirty` + `flushNow` → draft 존재
+  확인 → `editor.exportHwp()` → `editor.notifySaved()` → `isDirty() === false` +
+  draft 삭제 확인 → editor 재생성 → 복구 다이얼로그 미표시.
+- **TC-2 (negative)**: 동일 절차에서 notifySaved 생략 → 재생성 시
+  `.modal-overlay .dialog-wrap`에 "문서 복구" 표시.
+- **TC-3 (capability)**: `rhwp-connected` capabilities에 `'notify-saved-v1'` 포함.
+- **TC-4 (window API)**: 스튜디오 페이지 직접 접속 → markDirty → flushNow →
+  `window.rhwpStudio.notifySaved()` → 리로드 → 다이얼로그 미표시.
+
+## 4. 단계별 작업
+
+### Stage 1 — 코어 + window API + 경합 방어
+
+- `autosave-manager.ts` 제너레이션 카운터, `main.ts` `completeHostSave` +
+  `window.rhwpStudio` 노출.
+- 경합 단위 테스트 신규 작성 (red→green).
+- 검증: `cd rhwp-studio && npm test`, `npx tsc --noEmit`.
+
+### Stage 2 — embed RPC
+
+- `protocol.ts` capability, `rpc-router.ts` 인터페이스·라우팅, `main.ts` 핸들러.
+- `embed-protocol.test.ts` 갱신 + 신규 assert.
+- 검증: `npm test`.
+
+### Stage 3 — @rhwp/editor SDK
+
+- `transport.js`, `index.js`, `index.d.ts` + 신규 계약 테스트.
+- 검증: `npm test`(SDK 테스트 포함), `cd ../npm/editor && npm test`.
+
+### Stage 4 — E2E
+
+- `e2e/embed-save-ack.test.mjs` TC-1~4 작성.
+- 검증: `npx vite --host 0.0.0.0 --port 7700 &` →
+  `node e2e/embed-save-ack.test.mjs --mode=headless`,
+  기존 회귀 `npm run e2e:embed`,
+  `node e2e/autosave-recovery.test.mjs --mode=headless`.
+
+### Stage 5 — 문서화 + 최종 회귀
+
+- `npm/editor/README.md` 저장 계약 절:
+  - iframe: export → 업로드 **성공 시에만** `notifySaved()` (실패 시 미호출 —
+    백업 draft 보존).
+  - 팝업: 핸드오프 즉시 `await editor.notifySaved()` 후 `window.close()`.
+  - `postMessage` targetOrigin 명시적 오리진 사용 권고.
+  - legacy 폴백 모드 한계(capability 미광고 → throw) 명기.
+- 최종 회귀: `npm test 2>&1 | tee "$TMPDIR/task2660_full_test.log"`,
+  `npm run build`, Stage 4 E2E 3종 재실행.
+- 최종 결과보고서 `mydocs/report/task_m100_2660_report.md`.
+
+## 5. 리스크·주의
+
+- **`window.rhwpStudio` 이름 충돌**: 신규 전역이므로 충돌 없음. 확장 여지를 위해
+  객체 리터럴로 노출(추후 메서드 추가 가능).
+- **embed-protocol.test.ts의 소스 정규식 테스트**(L14-24): main.ts 수정 시 기존
+  `getRendererDiagnostics` 정규식 매치가 깨지지 않도록 핸들러 블록 내 상대 순서 유지.
+- **flushNow 조기 return**: 제너레이션 감지 시 `saved` status 콜백을 생략하므로
+  상태 표시줄 autosave 표시 회귀 여부를 단위 테스트에서 확인.
+- **E2E 타이밍**: TC-1/2의 draft 확인은 iframe 컨텍스트의 IndexedDB에서 수행
+  (autosave-recovery.test.mjs 헬퍼 재사용).
+
+## 6. 승인
+
+구현계획서 승인 대기.

--- a/mydocs/report/task_m100_2660_report.md
+++ b/mydocs/report/task_m100_2660_report.md
@@ -1,0 +1,112 @@
+# 최종 결과보고서 — 호스트 저장 완료 통지 API notifySaved (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660` (`upstream/devel` a803f079 기준)
+- **수행계획서**: [`../plans/task_m100_2660.md`](../plans/task_m100_2660.md)
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+- **관련**: #1448 (PR #1450, 자동 백업/복구), 후속 이슈 #2661 (hwpctl SaveAs)
+
+## 1. 문제와 해법 요약
+
+외부 호스트가 rhwp-studio에서 내보내기(직렬화 바이트 취득)로 문서를 저장하는
+통합(팝업 opener postMessage / iframe embed RPC)에서는 **저장 완료를 스튜디오에
+알릴 수단이 없어**, 사용자가 저장했다고 느꼈음에도 dirty 상태와 자동복구
+draft(IndexedDB, #1448)가 남아 다음 실행 시 "문서 복구" 다이얼로그가 떴다.
+
+**해법**: 코어 함수 하나(`completeHostSave`)를 두 표면으로 노출하는 저장 완료
+통지 API를 추가했다.
+
+- 코어: `markClean('host-save')` → 기존 정리 사슬 재사용 + **draft 삭제 완료를
+  await** (팝업 `window.close()`에 IndexedDB 삭제가 잘리지 않는 계약).
+- 표면 A: `window.rhwpStudio.notifySaved(fileName?)` — 팝업/포크 통합용, 프로덕션
+  상시 노출.
+- 표면 B: embed RPC `notifySaved` + `'notify-saved-v1'` capability +
+  `@rhwp/editor` SDK `editor.notifySaved(fileName?)` (capability 게이팅).
+- `exportHwp` 등 내보내기 자체는 무수정 — 업로드 실패 시 백업 보존을 위해
+  자동 markClean을 하지 않는 설계를 유지.
+- 부수 강화: autosave flush 진행 중 discard 시 draft가 부활하는 경합을
+  제너레이션 카운터로 방어.
+
+## 2. 변경 파일
+
+| 영역 | 파일 | 내용 |
+|---|---|---|
+| 코어 | `rhwp-studio/src/main.ts` | `completeHostSave` + `window.rhwpStudio` + embed 핸들러 |
+| 코어 | `rhwp-studio/src/recovery/autosave-manager.ts` | `discardGeneration` 경합 방어 |
+| RPC | `rhwp-studio/src/embed/protocol.ts` | `'notify-saved-v1'` capability (버전 1 유지) |
+| RPC | `rhwp-studio/src/embed/rpc-router.ts` | `notifySaved` 인터페이스·라우팅 (fileName 정규화) |
+| SDK | `npm/editor/transport.js`, `index.js`, `index.d.ts` | 클라이언트 capability + `notifySaved` + 선언 |
+| 문서 | `npm/editor/README.md` | API 절 + **저장 계약** 절 (iframe/팝업/targetOrigin) |
+| 테스트 | `rhwp-studio/tests/{autosave-manager,embed-protocol}.test.ts` | 경합·계약·라우팅 (TDD red→green) |
+| 테스트 | `npm/editor/tests/{notify-saved-v1.contract,transport}.test.mjs` | SDK 계약 |
+| E2E | `rhwp-studio/e2e/embed-save-ack.test.mjs` (신규) | TC-1~4, 17 assertion |
+| E2E 인프라 | `rhwp-studio/e2e/{helpers,embed-transport.test}.mjs` | Windows 휴대성 (보고서 경로, /@fs URL) |
+
+Rust/WASM, `document-dirty-state.ts`, `autosave-store.ts`, `embed/runtime.ts`,
+`hwpctl/index.ts` 무수정.
+
+## 3. 커밋 이력 (local/task2660)
+
+| 커밋 | 내용 |
+|---|---|
+| 339d88a3 | 수행계획서 + 오늘할일 |
+| 29c61139 | 구현계획서 (5단계) |
+| 06212e7c | Stage 1 — 코어 + window API + 경합 방어 |
+| ef57d635 | Stage 2 — embed RPC + capability |
+| e91a7c7a | Stage 3 — SDK notifySaved |
+| c058305e | Stage 4 — E2E 4케이스 + e2e Windows 휴대성 |
+| (본 커밋) | Stage 5 — README 저장 계약 + 최종 회귀 + 최종보고서 |
+
+## 4. 검증 총괄
+
+전 단계 TDD(red→green): 신규 단위·계약 테스트는 모두 실패를 먼저 확인한 뒤
+구현했다.
+
+| 검증 | 결과 |
+|---|---|
+| 단위+SDK `npm test` | **458/459** (잔여 1건 `cell-flow-boundary`는 Windows spawnSync 기존 환경 이슈 — HEAD 동일 재현) |
+| `npx tsc --noEmit` | **0 오류** (Docker WASM pkg 재생성 후) |
+| `npm run build` | **성공** |
+| 신규 E2E (embed-save-ack) | **17/17 PASS** — 통지→다이얼로그 없음 / 미통지→표시(원 증상 재현) / capability / window API |
+| 회귀 `e2e:embed` | 11/12 — 1 FAIL은 **베이스 src 치환 재실행으로 기존 환경 이슈 실증** |
+| 회귀 `autosave-recovery` | 18 PASS / 4 FAIL — 동일 방법으로 베이스와 실패 집합 완전 일치 실증 |
+
+기존 환경 실패(단위 1, e2e 5)는 모두 베이스 커밋에서 동일 재현 — 본 타스크와
+무관하며, merge 전 CI(Linux)에서 최종 확인을 권고한다.
+
+## 5. 호스트 적용 안내 (통합 앱 후속 1줄)
+
+팝업 통합 호스트의 내보내기 핸들러에 통지 한 줄을 추가하면 된다:
+
+```js
+const bytes = await editor.exportHwp();
+const base64 = uint8ArrayToBase64(bytes);
+window.opener?.postMessage(
+  { action: 'documentExported', content: base64, format: 'hwp' },
+  HOST_ORIGIN, // 보안 권고: '*' 대신 명시적 오리진
+);
+await editor.notifySaved(); // ← 추가: dirty 해제 + 복구 draft 삭제 완료 대기
+window.close();
+```
+
+## 6. 범위 외 기록 (후속 후보)
+
+- #2661: hwpctl `SaveAs()` dirty 미정리 (등록 완료, 우선순위 낮음).
+- `beginDocument({discardPreviousDraft})` 경로의 draft 부활 경합 —
+  `discardCurrentDraft` 세대 카운터의 보호 범위 밖 (발생 조건 좁음, Stage 1
+  보고서에 기록).
+- e2e `cell-flow-boundary` 단위 테스트와 일부 e2e의 Windows 네이티브 실행 한계
+  (spawnSync `.bin/tsc`, 렌더러 선택 진단, 복구 다이얼로그 타이밍) — CI Linux
+  기준으로는 영향 없음.
+
+## 7. 완료 조건 대비 (#2660 수용 기준)
+
+- [x] 팝업 흐름: 통지 후 재실행 시 복구 다이얼로그 없음 (E2E TC-1/TC-4)
+- [x] iframe 흐름: 통지 시 dirty 해제+draft 삭제, 미호출 시 draft 보존 (E2E TC-1/TC-2)
+- [x] `'notify-saved-v1'` capability 광고 (E2E TC-3, 단위)
+- [x] flush↔discard 경합 시 draft 미부활 (단위, red→green)
+- [x] 기존 내부 저장/복구 회귀 없음 (단위 458/459 + E2E 회귀, 잔여 실패는 베이스 동일)
+- [x] README 저장 계약 문서화
+
+merge(local/devel) 및 이슈 클로즈는 작업지시자 승인 후 진행한다.

--- a/mydocs/report/task_m100_2660_report.md
+++ b/mydocs/report/task_m100_2660_report.md
@@ -109,4 +109,18 @@ window.close();
 - [x] 기존 내부 저장/복구 회귀 없음 (단위 458/459 + E2E 회귀, 잔여 실패는 베이스 동일)
 - [x] README 저장 계약 문서화
 
-merge(local/devel) 및 이슈 클로즈는 작업지시자 승인 후 진행한다.
+## 8. 통합 절차 (정정: 컨트리뷰터 PR 워크플로우)
+
+당초 메인테이너용 local/devel merge로 기재했으나, 본 저장소에서 우리는
+fork(johndoekim) 기반 컨트리뷰터이므로 CONTRIBUTING.md의 Fork & PR 워크플로우를
+따른다 (작업지시자 지적 반영).
+
+- PR 전 체크리스트 수행: `cargo clippy -- -D warnings` 통과,
+  `cargo test --profile release-test --tests --no-fail-fast` **3,447 passed / 0 failed**
+  (`$TMPDIR/task2660_cargo_full_test.log`). `cargo fmt --check`는 로컬
+  `core.autocrlf=true`(CRLF) 체크아웃으로 전 파일 판정 불가 — 본 PR은 .rs 0건
+  변경이므로 CI 판정에 위임.
+- fork 브랜치 `feature/2660-notify-saved` push 후 PR 생성:
+  **[edwardkim/rhwp#2667](https://github.com/edwardkim/rhwp/pull/2667)** (base: devel,
+  `Closes #2660` 포함 — 메인테이너 merge 시 이슈 자동 클로즈).
+- 이후 절차: CI(빌드+테스트+Clippy) 통과 확인 → 메인테이너 리뷰 대응.

--- a/mydocs/working/task_m100_2660_stage1.md
+++ b/mydocs/working/task_m100_2660_stage1.md
@@ -1,0 +1,62 @@
+# Stage 1 완료보고서 — 코어 + window API + 경합 방어 (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660`
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+
+## 1. 구현 내용
+
+TDD(red→green)로 진행했다. 테스트를 먼저 작성해 실패를 확인한 뒤 구현했다.
+
+### `src/recovery/autosave-manager.ts` — flush↔discard 경합 방어
+
+- `discardGeneration` 카운터 추가. `discardCurrentDraft()` 진입 시 증가.
+- `flushNow()`는 `store.saveDraft()` 직전 세대를 캡처하고, 저장 완료 후 세대가
+  변했으면 방금 저장으로 부활한 draft를 `deleteDraft(..., 'discarded-during-save')`로
+  재삭제하고 `lastSavedAt`/`saved` 상태 콜백을 생략한다.
+
+### `src/main.ts` — 코어 + window 공개 API
+
+- `completeHostSave(fileName?)`: `wasDirty` 캡처 → (선택) `wasm.fileName` 갱신 →
+  `markClean('host-save')` → **`await autosaveManager.discardCurrentDraft('host-save')`**
+  → `{ ok: true, wasDirty }` 반환. 삭제 완료를 await하므로 resolve 이후 팝업
+  `window.close()`에 IndexedDB 삭제가 잘리지 않는다.
+- `window.rhwpStudio = { notifySaved }` — DEV 전용 `__*` 노출과 달리 프로덕션 포함
+  항상 노출 (SDK 없이 스튜디오 페이지 안에서 통합하는 팝업/포크 호스트용).
+
+## 2. 테스트 (RED → GREEN)
+
+| 테스트 | RED (구현 전) | GREEN (구현 후) |
+|---|---|---|
+| `tests/autosave-manager.test.ts` "저장 진행 중 discard가 끼어들면 저장 완료로 부활한 draft를 재삭제한다" | 실패 — ops가 `['delete','save']`로 끝나 draft 부활 잔존 | 통과 — `['delete','save','delete']` |
+| `tests/autosave-manager.test.ts` "discard 없는 정상 flush에서는 draft를 삭제하지 않는다" (회귀 가드) | 통과(기존 동작 확인용) | 통과 |
+| `tests/embed-protocol.test.ts` "main.ts는 호스트 저장 완료 API completeHostSave를 window.rhwpStudio로 노출한다 (#2660)" | 실패 — API 부재 | 통과 |
+
+## 3. 검증 결과
+
+Node v24.16.0 (`node --test *.ts` 타입 스트리핑 요구사항), 로그
+`$TMPDIR/task2660_stage1_test.log`.
+
+- `npm test`: **455개 중 453 통과, 실패 2**
+  - 실패 2건(`cell-flow-boundary.test.ts`, `canvaskit-resource-key.test.ts`)은
+    **본 변경과 무관한 기존 로컬 환경 이슈** — `git stash`로 원복한 HEAD에서도 동일
+    실패 재현 확인. 원인: Windows에서 `spawnSync('node_modules/.bin/tsc')` 실행 불가
+    (`compilation.status === null`). CI(Linux)에서는 통과하는 테스트.
+- `npx tsc --noEmit`: 오류 7줄 — **HEAD와 diff 완전 동일(IDENTICAL)**, 본 변경 파일
+  관련 0건. 원인: 로컬 `pkg/` WASM 타입 구본 + `@noble/hashes` 로컬 미설치.
+- 커밋 대상 파일: `src/recovery/autosave-manager.ts`, `src/main.ts`,
+  `tests/autosave-manager.test.ts`, `tests/embed-protocol.test.ts`.
+
+## 4. 관찰 사항 (범위 외 기록)
+
+- `beginDocument({ discardPreviousDraft: true })` 경로에도 유사한 부활 경합이
+  잠재한다(진행 중 flush가 이전 draftId를 재저장). 이 경로는 `discardCurrentDraft`를
+  거치지 않아 이번 세대 카운터의 보호를 받지 않는다. 발생 조건이 문서 교체 순간으로
+  좁고 본 타스크 범위(호스트 저장 통지) 밖이므로 기록만 남긴다. 필요 시 후속 이슈로
+  분리 권고.
+
+## 5. 다음 단계
+
+Stage 2 — embed RPC (`protocol.ts` capability, `rpc-router.ts` 인터페이스·라우팅,
+`main.ts` 핸들러, `embed-protocol.test.ts` 갱신). 승인 후 진행.

--- a/mydocs/working/task_m100_2660_stage2.md
+++ b/mydocs/working/task_m100_2660_stage2.md
@@ -1,0 +1,53 @@
+# Stage 2 완료보고서 — embed RPC notifySaved (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660`
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+
+## 1. 구현 내용
+
+TDD(red→green). RED에서 3개 테스트가 의도한 이유(capability 부재 / `Unknown method:
+notifySaved` / main.ts 핸들러 부재)로 실패함을 확인한 뒤 구현했다.
+
+### `src/embed/protocol.ts`
+
+- `EMBED_CAPABILITIES`에 `'notify-saved-v1'` 추가 (4번째 항목).
+- `EMBED_PROTOCOL_VERSION = 1` 유지 — 순수 additive 확장.
+
+### `src/embed/rpc-router.ts`
+
+- `EmbedNotifySavedResult { ok: true; wasDirty: boolean }` 타입 추가.
+- `EmbedRpcHandlers.notifySaved(fileName?: string)` 추가.
+- `case 'notifySaved'`: fileName은 **비어있지 않은 문자열만** 통과, 그 외
+  (비문자열/빈 문자열/누락)는 `undefined`로 정규화.
+- v1 MessagePort·legacy 경로 모두 `routeEmbedRequest` 공유 — `runtime.ts` 무수정.
+
+### `src/main.ts`
+
+- 임베드 핸들러 블록에 `notifySaved(fileName)` 배선 — `await initPromise` 후
+  Stage 1의 `completeHostSave(fileName)` 호출 (코어 단일화).
+
+## 2. 테스트 (RED → GREEN)
+
+| 테스트 (`tests/embed-protocol.test.ts`) | RED | GREEN |
+|---|---|---|
+| capability deepEqual에 `'notify-saved-v1'` 추가 | 실패 (protocol 미반영) | 통과 |
+| "embed router는 notifySaved fileName을 정규화해 핸들러로 전달한다 (#2660)" — 4케이스(생략/'a.hwp'/123/'') | 실패 (`Unknown method`) | 통과 |
+| #2660 소스 계약 테스트에 embed 핸들러 정규식 추가 (`async notifySaved(fileName)` → `completeHostSave(fileName)`) | 실패 (핸들러 부재) | 통과 |
+
+`EmbedRpcHandlers` 완전 타입 리터럴 목 3곳(라우터/런타임/suppressDialogs 테스트)에
+`notifySaved` 목을 추가해 인터페이스 확장 누락이 타입으로 강제 검출되게 했다.
+
+## 3. 검증 결과
+
+- `npm test`: **456개 중 454 통과, 실패 2** — Stage 1 보고서와 동일한 기존 로컬 환경
+  이슈 2건(`cell-flow-boundary`, `canvaskit-resource-key`; Windows spawnSync 문제,
+  HEAD에서도 동일 재현 확인됨). 로그 `$TMPDIR/task2660_s2_green.log`.
+- `npx tsc --noEmit`: 변경 전 베이스라인과 **diff 완전 동일(IDENTICAL)** — 신규 타입
+  오류 0건.
+
+## 4. 다음 단계
+
+Stage 3 — `@rhwp/editor` SDK (`transport.js` CAPABILITIES, `index.js`
+`notifySaved()` capability 게이팅, `index.d.ts`, 계약 테스트). 승인 후 진행.

--- a/mydocs/working/task_m100_2660_stage3.md
+++ b/mydocs/working/task_m100_2660_stage3.md
@@ -1,0 +1,71 @@
+# Stage 3 완료보고서 — @rhwp/editor SDK notifySaved (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660`
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+
+## 1. 구현 내용
+
+TDD(red→green). RED에서 4개 테스트가 의도한 이유로 실패함을 확인한 뒤 구현했다.
+
+### `npm/editor/transport.js`
+
+- 클라이언트 `CAPABILITIES`에 `'notify-saved-v1'` 추가.
+- `LONG_RUNNING_METHODS`에는 미포함 — 기본 10초 타임아웃(draft 삭제는 밀리초 단위).
+
+### `npm/editor/index.js` — `RhwpEditor.notifySaved(fileName?)`
+
+- `getRendererDiagnostics`와 동일한 capability 게이팅: 스튜디오가
+  `notify-saved-v1`을 광고하지 않으면(구버전 또는 legacy 폴백 연결) **요청을 보내지
+  않고** `notifySaved is not supported by this Studio`로 명시적 실패.
+- fileName은 비어있지 않은 문자열일 때만 `{ fileName }` 파라미터로 전달.
+- JSDoc에 저장 계약 명기: resolve 이후 창을 닫아도 안전 / 업로드 실패 시 호출 금지.
+
+### `npm/editor/index.d.ts`
+
+- `RhwpEditor`에 `notifySaved(fileName?: string): Promise<{ ok: true; wasDirty: boolean }>`
+  선언 + 저장 계약 JSDoc 추가.
+
+## 2. 테스트 (RED → GREEN)
+
+신규 `npm/editor/tests/notify-saved-v1.contract.test.mjs`
+(기존 `renderer-diagnostics-v1.contract.test.mjs` + transport 테스트 MessageChannel
+하네스 패턴 조합):
+
+| 테스트 | RED | GREEN |
+|---|---|---|
+| capability 광고 시 `notifySaved('b.hwp')`/`notifySaved()`가 `{method:'notifySaved', params:{fileName}/{}}` 요청 후 결과 반환 | 실패 (메서드 부재) | 통과 |
+| 미광고 시 요청 0건 + 명시적 throw | 실패 | 통과 |
+| `index.d.ts` notifySaved 선언 계약 | 실패 | 통과 |
+| `transport.test.mjs` 클라이언트 CAPABILITIES assert에 `'notify-saved-v1'` 추가 | 실패 | 통과 |
+
+작성 과정 메모: 최초 RED 실행에서 assert 실패 시 `transport.destroy()`가 건너뛰어져
+열린 MessagePort가 이벤트 루프를 잡아 `node --test`가 행 걸리는 문제를 발견,
+계약 테스트를 try/finally(destroy + 서버 포트 close) 구조로 작성했다.
+
+## 3. 검증 결과
+
+- `cd npm/editor && node --test tests/*.test.mjs`: **21/21 통과**.
+- `cd rhwp-studio && npm test`(SDK 테스트 포함 실행): **459개 중 457 통과, 실패 2** —
+  Stage 1·2와 동일한 기존 로컬 환경 이슈(`cell-flow-boundary`,
+  `canvaskit-resource-key`; Windows spawnSync, HEAD 동일 재현 확인됨).
+  로그 `$TMPDIR/task2660_s3_green.log`.
+- TypeScript 소스 무변경(SDK는 JS + d.ts) — tsc 재검증은 Stage 2와 동일 상태.
+
+## 4. 호스트 사용 예 (팝업 흐름)
+
+```js
+const bytes = await editor.exportHwp();
+const base64 = uint8ArrayToBase64(bytes);
+window.opener?.postMessage(
+  { action: 'documentExported', content: base64, format: 'hwp' },
+  HOST_ORIGIN, // '*' 대신 명시적 오리진 권장
+);
+await editor.notifySaved(); // dirty 해제 + draft 삭제 완료 대기
+window.close();
+```
+
+## 5. 다음 단계
+
+Stage 4 — E2E (`e2e/embed-save-ack.test.mjs` TC-1~4 + 기존 회귀). 승인 후 진행.

--- a/mydocs/working/task_m100_2660_stage4.md
+++ b/mydocs/working/task_m100_2660_stage4.md
@@ -1,0 +1,51 @@
+# Stage 4 완료보고서 — E2E 검증 (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660`
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+
+## 1. 신규 E2E — `e2e/embed-save-ack.test.mjs` (17 assertion 전건 PASS)
+
+실행: Vite dev(7700) + headless Chrome(Windows 로컬), Node v24.16.0.
+로그 `$TMPDIR/task2660_s4_e2e.log`, 보고서 `output/e2e/embed-save-ack-report.html`.
+
+| TC | 내용 | 결과 |
+|---|---|---|
+| TC-3 | `rhwp-connected` capabilities에 `notify-saved-v1` 광고 | PASS |
+| TC-1 | SDK loadFile→dirty+flush→draft 존재→`exportHwp`(15,360B)→**export만으로 dirty·draft 유지**→`notifySaved('footnote-01-저장본.hwp')`→`{ok, wasDirty:true}`+dirty 해제+fileName 반영+draft 0건→스튜디오 재생성 시 복구 다이얼로그 **없음** | PASS (10 assertion) |
+| TC-2 | 동일 절차에서 notifySaved 생략(팝업 강제 종료 동일 조건)→재생성 시 "문서 복구" 다이얼로그 **표시** | PASS (2 assertion) |
+| TC-4 | 직접 페이지에서 `window.rhwpStudio.notifySaved()`→`{ok, wasDirty:true}`+dirty 해제+draft 0건→리로드 시 다이얼로그 없음 | PASS (5 assertion) |
+
+핵심 검증: **positive(통지→다이얼로그 없음)와 negative(미통지→다이얼로그 표시)가
+쌍으로 성립** — #2660이 보고한 증상과 수정 효과를 모두 재현·확인.
+
+## 2. 기존 E2E 회귀
+
+| 테스트 | 태스크 브랜치 | 베이스(a803f079) src 치환 재실행 | 판정 |
+|---|---|---|---|
+| `npm run e2e:embed` (embed-transport) | 11 PASS / 1 FAIL | **동일 1 FAIL** ("additive selection diagnostics가 실제 auto 요청을 보존한다") | 기존 로컬 환경 이슈 — 렌더러 선택 영역, 본 diff 미접촉 |
+| `autosave-recovery.test.mjs` | 18 PASS / 4 FAIL | **동일 4 FAIL** (복구본 dirty 유지 2건, draft 삭제 2건) | 기존 로컬 환경 이슈 — 베이스와 결과 완전 동일 |
+
+두 회귀 모두 작업트리 src를 베이스 커밋으로 치환해 재실행하는 방법으로
+**본 타스크 커밋과의 인과를 분리**했다 (실패 집합이 베이스와 완전히 일치).
+CI(Linux)에서는 통과하는 테스트들이며, 최종 판정은 Stage 5 이후 CI에서 재확인한다.
+
+## 3. 환경 정비 (부수 수정·기록)
+
+- **`e2e/helpers.mjs` 1줄 수정**: `getReportFilename()`이 '/'로만 split하여 Windows
+  `process.argv[1]`(역슬래시 경로)에서 보고서 생성이 ENOENT로 죽는 버그 →
+  `split(/[\\/]/)`로 휴대성 수정 (Linux 동작 불변).
+- **`e2e/embed-transport.test.mjs` `/@fs` URL 정규화**: Windows 절대 경로(`D:\...`)가
+  `/@fsD:/...`로 붙어 모듈 로드가 실패 → 슬래시 정규화 (신규 테스트에도 동일 적용).
+  이 수정이 없으면 Windows 네이티브에서 embed E2E 자체가 실행 불가.
+- 로컬 `node_modules` 불완전(`pixelmatch`, `@noble/hashes` 등 누락)으로
+  `npm install --no-audit` 수행 — **package-lock.json 무변경**(추가 설치만).
+  실행 중 Vite가 네이티브 바이너리를 잠가 `npm ci`는 EPERM으로 불가했음을 기록.
+- 첫 E2E 실행 시 Vite가 신규 의존성 최적화로 full-reload를 보내 1회 실패
+  ("Execution context was destroyed") — 재실행으로 해소 (1회성).
+
+## 4. 다음 단계
+
+Stage 5 — `npm/editor/README.md` 저장 계약 문서화 + 최종 회귀 + 최종 결과보고서.
+승인 후 진행.

--- a/mydocs/working/task_m100_2660_stage5.md
+++ b/mydocs/working/task_m100_2660_stage5.md
@@ -1,0 +1,46 @@
+# Stage 5 완료보고서 — 문서화 + 최종 회귀 (M100 #2660)
+
+- **이슈**: [edwardkim/rhwp#2660](https://github.com/edwardkim/rhwp/issues/2660)
+- **브랜치**: `local/task2660`
+- **구현계획서**: [`../plans/task_m100_2660_impl.md`](../plans/task_m100_2660_impl.md)
+- **작성일**: 2026-07-21
+
+## 1. 문서화 — `npm/editor/README.md` (호스트 정본 문서)
+
+- `### editor.notifySaved(fileName?)` API 절 추가 — 반환값, fileName 의미,
+  capability 게이팅(미광고 시 요청 없이 예외) 명기.
+- `## 저장 계약 — 내보내기와 저장 완료 통지` 절 추가:
+  - `exportHwp/Hwpx/Hml`은 문서를 "저장됨"으로 표시하지 않음 — 통지 전까지
+    자동복구 draft 보존, 통지 없이 종료 시 "문서 복구" 안내가 뜨는 동작 설명.
+  - **iframe 계약**: 업로드 **성공 시에만** `notifySaved()` (실패 시 미호출 →
+    draft 보존으로 재시도/복구 가능).
+  - **팝업 계약**: 핸드오프 즉시 `await editor.notifySaved()` 후 `window.close()`
+    — resolve가 draft 삭제 완료를 보장. `postMessage` targetOrigin은 `'*'` 대신
+    명시적 오리진 사용 권고(문서 유출 방지).
+  - SDK 없는 포크/주입 통합용 `window.rhwpStudio.notifySaved(fileName?)` 안내.
+
+## 2. 최종 회귀 결과
+
+로컬 WASM `pkg/` 구본을 Docker WASM 빌드(`docker compose run --rm wasm`,
+7m 56s)로 재생성한 뒤 수행했다.
+
+| 검증 | 결과 | 로그 |
+|---|---|---|
+| `npm test` (단위 459 + SDK 21 포함) | **458/459 통과** — 잔여 1건은 `cell-flow-boundary`(Windows에서 `spawnSync('node_modules/.bin/tsc')` 실행 불가, HEAD 동일 재현 확인된 기존 환경 이슈; CI Linux 통과) | `$TMPDIR/task2660_full_test.log` |
+| `npx tsc --noEmit` | **오류 0건** (WASM pkg 재생성으로 기존 3건도 해소) | `$TMPDIR/task2660_s5_tsc.log` |
+| `npm run build` (tsc && vite build) | **성공** (PWA precache 포함) | `$TMPDIR/task2660_s5_build.log` |
+| `e2e/embed-save-ack.test.mjs` | **17/17 PASS** (새 WASM 반영 재실행) | `$TMPDIR/task2660_s5_e2e1.log` |
+| `npm run e2e:embed` | 11/12 — 1 FAIL은 Stage 4에서 베이스 src 치환으로 기존 환경 이슈 실증 | `$TMPDIR/task2660_s5_e2e2.log` |
+| `autosave-recovery.test.mjs` | 18 PASS / 4 FAIL — 동일하게 베이스와 실패 집합 일치 실증 (새 WASM에서도 동일 → 환경 요인 재확인) | `$TMPDIR/task2660_s5_e2e3.log` |
+
+## 3. 비고
+
+- 로컬 검증 환경: Windows 11 + Node v24.16.0 + headless Chrome. e2e 인프라의
+  Windows 휴대성 2건은 Stage 4에서 수정 완료.
+- 기존 환경 실패(단위 1건, e2e 5건)는 모두 베이스 커밋에서 동일 재현되어 본
+  타스크와 무관 — merge 전 CI(Linux)에서 최종 확인 권고.
+
+## 4. 다음 단계
+
+최종 결과보고서(`report/task_m100_2660_report.md`) 승인 → 이후 절차(local/devel
+merge, 이슈 클로즈)는 작업지시자 승인에 따름.

--- a/npm/editor/README.md
+++ b/npm/editor/README.md
@@ -256,6 +256,25 @@ if (state.hmlSavable) {
 | `xmlPath` | `string` | 해당 요소의 XML 경로 |
 | `message` | `string` | 사람이 읽을 수 있는 사유 |
 | `preserved` | `false` | 항상 `false` — 해당 요소가 HML로 보존되지 않음을 뜻함 |
+### editor.notifySaved(fileName?)
+
+내보내기 바이트의 영속화(서버 업로드 또는 호스트 핸드오프) 완료를 스튜디오에
+통지합니다 (#2660). 통지 시 스튜디오는 미저장(dirty) 상태를 해제하고 자동복구
+draft(IndexedDB)를 삭제합니다. **draft 삭제가 완료된 뒤 resolve**되므로, resolve
+이후 창을 닫아도 안전합니다.
+
+```javascript
+const bytes = await editor.exportHwp();
+await uploadToServer(bytes);        // 호스트 저장
+await editor.notifySaved();         // 저장 완료 통지 — dirty 해제 + 복구 draft 삭제
+```
+
+- `fileName` (선택): 호스트가 저장에 사용한 파일 이름. 전달하면 스튜디오의 현재
+  파일 이름이 갱신됩니다.
+- 반환: `{ ok: true, wasDirty: boolean }` — `wasDirty`는 통지 시점에 미저장
+  변경이 있었는지 여부(멱등 호출 관찰용).
+- 스튜디오가 `notify-saved-v1` capability를 광고하지 않으면(구버전 스튜디오 또는
+  legacy 폴백 연결) 요청을 보내지 않고 예외를 던집니다.
 
 ### editor.destroy()
 
@@ -264,6 +283,43 @@ if (state.hmlSavable) {
 ```javascript
 editor.destroy();
 ```
+
+## 저장 계약 — 내보내기와 저장 완료 통지
+
+`exportHwp()`/`exportHwpx()`/`exportHml()`은 직렬화 바이트만 반환하며 **문서를
+"저장됨"으로 표시하지 않습니다.** 호스트 저장(업로드)이 실패할 수 있으므로,
+스튜디오는 호스트가 `notifySaved()`로 확정하기 전까지 자동복구 draft를
+보존합니다. 통지 없이 종료하면 다음 실행 시 "문서 복구" 안내가 표시됩니다.
+
+**iframe 임베드 (업로드 확정 후 통지):**
+
+```javascript
+const bytes = await editor.exportHwp();
+try {
+  await uploadToServer(bytes);
+  await editor.notifySaved();       // 업로드 "성공 시에만" 호출
+} catch (error) {
+  // 통지하지 않음 — 복구 draft가 보존되어 재시도/복구 가능
+}
+```
+
+**팝업 통합 (핸드오프 즉시 통지 후 닫기):**
+
+스튜디오를 `window.open`으로 띄우고 `window.opener.postMessage`로 바이트를
+넘기는 통합에서는, 핸드오프 시점에 통지하고 닫습니다. 바이트를 수신한 호스트가
+이후 영속화(재시도 포함)를 책임집니다.
+
+```javascript
+window.opener?.postMessage(
+  { action: 'documentExported', content: base64, format: 'hwp' },
+  HOST_ORIGIN,                       // '*' 대신 반드시 명시적 오리진 사용 (문서 유출 방지)
+);
+await editor.notifySaved();          // draft 삭제 완료까지 대기
+window.close();
+```
+
+SDK 없이 스튜디오 페이지 안에서 직접 통합(포크/주입)하는 경우에는 같은 동작의
+`window.rhwpStudio.notifySaved(fileName?)`를 사용할 수 있습니다.
 
 ## 디버깅 도구 — rhwpDev
 

--- a/npm/editor/index.d.ts
+++ b/npm/editor/index.d.ts
@@ -171,6 +171,13 @@ export declare class RhwpEditor {
   getHmlSaveState(): Promise<HmlSaveState>;
   /** HWP 직렬화 + 자기 재로드 검증 메타데이터 (#178) */
   exportHwpVerify(): Promise<HwpVerifyResult>;
+  /**
+   * 내보내기 바이트의 영속화(업로드/핸드오프) 완료를 스튜디오에 통지합니다 (#2660).
+   * dirty 해제 + 자동복구 draft 삭제 완료 후 resolve — resolve 이후 창을 닫아도 안전.
+   * 업로드 실패 시에는 호출하지 마세요(백업 draft 보존).
+   * 스튜디오가 notify-saved-v1 capability를 광고하지 않으면 요청 없이 실패합니다.
+   */
+  notifySaved(fileName?: string): Promise<{ ok: true; wasDirty: boolean }>;
   /** iframe 엘리먼트를 반환합니다 */
   readonly element: HTMLIFrameElement;
   /** 에디터를 제거합니다 */

--- a/npm/editor/index.js
+++ b/npm/editor/index.js
@@ -216,6 +216,27 @@ export class RhwpEditor {
   }
 
   /**
+   * 내보내기 바이트의 영속화(업로드/핸드오프) 완료를 스튜디오에 통지합니다.
+   *
+   * dirty 상태를 해제하고 자동복구 draft의 IndexedDB 삭제 "완료"까지 기다린 뒤
+   * resolve합니다 — resolve 이후 창을 닫아도 안전합니다. 업로드 실패 시에는
+   * 호출하지 마세요(백업 draft가 보존되어야 합니다).
+   *
+   * 스튜디오가 `notify-saved-v1` capability를 광고하지 않으면(구버전 또는
+   * legacy 폴백 연결) 요청을 보내지 않고 명시적으로 실패합니다.
+   *
+   * @param fileName - 호스트가 저장에 사용한 파일 이름 (선택)
+   * @returns {Promise<{ ok: true, wasDirty: boolean }>}
+   */
+  async notifySaved(fileName) {
+    if (!this._transport.supports('notify-saved-v1')) {
+      throw new Error('notifySaved is not supported by this Studio');
+    }
+    const params = typeof fileName === 'string' && fileName.length > 0 ? { fileName } : {};
+    return this._request('notifySaved', params);
+  }
+
+  /**
    * iframe 엘리먼트를 반환합니다.
    */
   get element() {

--- a/npm/editor/tests/notify-saved-v1.contract.test.mjs
+++ b/npm/editor/tests/notify-saved-v1.contract.test.mjs
@@ -1,0 +1,93 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+
+import { EditorTransport } from '../transport.js';
+import { RhwpEditor } from '../index.js';
+
+function createStudio(capabilities, result) {
+  const requests = [];
+  let server;
+  const contentWindow = {
+    postMessage(message, _targetOrigin, ports) {
+      server = ports[0];
+      server.onmessage = ({ data }) => {
+        requests.push(data);
+        server.postMessage({
+          type: 'rhwp-response', version: 1, sessionId: data.sessionId,
+          id: data.id, result,
+        });
+      };
+      server.start();
+      server.postMessage({
+        type: 'rhwp-connected', version: 1, sessionId: message.sessionId,
+        capabilities,
+      });
+    },
+  };
+  return { contentWindow, requests, closeServer: () => server?.close() };
+}
+
+async function connectEditor(contentWindow) {
+  const transport = new EditorTransport(
+    { contentWindow },
+    'https://studio.example/app',
+    {
+      window: { addEventListener() {}, removeEventListener() {} },
+      requestTimeoutMs: 100,
+      handshakeTimeoutMs: 100,
+    },
+  );
+  await transport.connect();
+  return { transport, editor: new RhwpEditor({}, transport) };
+}
+
+test('notify-saved-v1 광고 시 notifySaved는 fileName을 전달하고 결과를 반환한다', async () => {
+  const { contentWindow, requests, closeServer } = createStudio(
+    ['transferable-array-buffer', 'notify-saved-v1'],
+    { ok: true, wasDirty: true },
+  );
+  const { transport, editor } = await connectEditor(contentWindow);
+
+  try {
+    assert.deepEqual(await editor.notifySaved('b.hwp'), { ok: true, wasDirty: true });
+    assert.deepEqual(await editor.notifySaved(), { ok: true, wasDirty: true });
+
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].method, 'notifySaved');
+    assert.deepEqual(requests[0].params, { fileName: 'b.hwp' });
+    assert.equal(requests[1].method, 'notifySaved');
+    assert.deepEqual(requests[1].params, {});
+  } finally {
+    transport.destroy();
+    closeServer();
+  }
+});
+
+test('notify-saved-v1 미광고 시 notifySaved는 요청 없이 명시적으로 실패한다', async () => {
+  const { contentWindow, requests, closeServer } = createStudio(
+    ['transferable-array-buffer'],
+    { ok: true, wasDirty: true },
+  );
+  const { transport, editor } = await connectEditor(contentWindow);
+
+  try {
+    await assert.rejects(async () => editor.notifySaved(), /notifySaved is not supported/);
+    assert.equal(requests.length, 0);
+  } finally {
+    transport.destroy();
+    closeServer();
+  }
+});
+
+test('index.d.ts는 notifySaved 선언과 저장 계약 JSDoc을 포함한다', () => {
+  const declarations = readFileSync(
+    fileURLToPath(new URL('../index.d.ts', import.meta.url)),
+    'utf8',
+  );
+  assert.match(
+    declarations,
+    /notifySaved\(fileName\?: string\): Promise<\{ ok: true; wasDirty: boolean \}>/,
+  );
+});

--- a/npm/editor/tests/transport.test.mjs
+++ b/npm/editor/tests/transport.test.mjs
@@ -14,6 +14,7 @@ test('EditorTransport는 exact origin의 v1 port로 binary를 caller detach 없�
         'transferable-array-buffer',
         'hml-export',
         'renderer-diagnostics-v1',
+        'notify-saved-v1',
       ]);
       const server = ports[0];
       server.onmessage = ({ data }) => {

--- a/npm/editor/transport.js
+++ b/npm/editor/transport.js
@@ -3,6 +3,7 @@ const CAPABILITIES = [
   'transferable-array-buffer',
   'hml-export',
   'renderer-diagnostics-v1',
+  'notify-saved-v1',
 ];
 const LONG_RUNNING_METHODS = new Set([
   'loadFile', 'exportHwp', 'exportHwpVerify', 'exportHwpx', 'exportHml',

--- a/rhwp-studio/e2e/embed-save-ack.test.mjs
+++ b/rhwp-studio/e2e/embed-save-ack.test.mjs
@@ -1,0 +1,207 @@
+/**
+ * Task #2660 — 호스트 저장 완료 통지 (notifySaved) E2E
+ *
+ * TC-1: SDK export → notifySaved → dirty 해제 + draft 삭제, 재시작 시 복구 다이얼로그 없음
+ * TC-2: notifySaved 생략 → 재시작 시 복구 다이얼로그 표시 (음성 대조)
+ * TC-3: rhwp-connected가 notify-saved-v1 capability를 광고
+ * TC-4: window.rhwpStudio.notifySaved (팝업/포크 통합 표면)
+ *
+ * 실행:
+ *   CHROME_PATH="..." VITE_URL=http://localhost:7700 \
+ *   node e2e/embed-save-ack.test.mjs --mode=headless
+ */
+import { resolve } from 'path';
+
+import { runTest, assert, setTestCase } from './helpers.mjs';
+
+// Windows 절대 경로(D:\...)도 Vite /@fs URL로 변환되도록 정규화한다
+const EDITOR_MODULE_PATH = resolve(import.meta.dirname, '../../npm/editor/index.js').replace(/\\/g, '/');
+const EDITOR_MODULE_URL = EDITOR_MODULE_PATH.startsWith('/')
+  ? `/@fs${EDITOR_MODULE_PATH}`
+  : `/@fs/${EDITOR_MODULE_PATH}`;
+const VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
+const SAMPLE_URL = '/samples/footnote-01.hwp';
+
+runTest('Task #2660 호스트 저장 완료 통지 (notifySaved)', async ({ page }) => {
+  page.on('dialog', (dialog) => dialog.accept().catch(() => {}));
+
+  setTestCase('Part A: SDK iframe — TC-1/2/3');
+  await page.goto(`${VITE_URL}/@vite/client`, { waitUntil: 'domcontentloaded' });
+  const partA = await page.evaluate(async ({ editorModuleUrl, sampleUrl }) => {
+    const { createEditor } = await import(editorModuleUrl);
+    const host = document.createElement('div');
+    host.style.cssText = 'width: 100vw; height: 100vh';
+    document.body.appendChild(host);
+
+    const clearDb = () => new Promise((resolveClear) => {
+      const req = indexedDB.deleteDatabase('rhwpStudioAutosave');
+      req.onsuccess = req.onerror = req.onblocked = () => resolveClear();
+    });
+    const listDraftIds = async () => {
+      const req = indexedDB.open('rhwpStudioAutosave', 1);
+      const db = await new Promise((resolveDb, rejectDb) => {
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('drafts')) {
+            req.result.createObjectStore('drafts', { keyPath: 'id' });
+          }
+        };
+        req.onerror = () => rejectDb(req.error);
+        req.onsuccess = () => resolveDb(req.result);
+      });
+      const ids = await new Promise((resolveIds, rejectIds) => {
+        const tx = db.transaction('drafts', 'readonly');
+        const keysReq = tx.objectStore('drafts').getAllKeys();
+        keysReq.onsuccess = () => resolveIds(keysReq.result);
+        keysReq.onerror = () => rejectIds(keysReq.error);
+      });
+      db.close();
+      return ids;
+    };
+    const waitRecoveryDialog = async (iframeEl, timeoutMs) => {
+      const deadline = Date.now() + timeoutMs;
+      while (Date.now() < deadline) {
+        const dialog = iframeEl.contentDocument?.querySelector('.modal-overlay .dialog-wrap');
+        if (dialog && (dialog.textContent || '').includes('문서 복구')) return true;
+        await new Promise((delay) => setTimeout(delay, 200));
+      }
+      return false;
+    };
+    const newEditor = () => createEditor(host, {
+      studioUrl: `${location.origin}/`,
+      handshakeTimeoutMs: 10_000,
+    });
+
+    await clearDb();
+
+    // TC-3: capability 광고
+    const editor1 = await newEditor();
+    const capabilityAdvertised = editor1._transport.supports('notify-saved-v1');
+
+    // TC-1: export → notifySaved → dirty 해제 + draft 삭제 + fileName 갱신
+    const sampleBuffer = await fetch(sampleUrl).then((response) => response.arrayBuffer());
+    await editor1.loadFile(sampleBuffer, 'footnote-01.hwp', { suppressDialogs: true });
+    const win1 = editor1.element.contentWindow;
+    win1.__documentState.markDirty('e2e-embed-save');
+    await win1.__autosaveManager.flushNow('e2e-embed-save');
+    const draftsAfterFlush = (await listDraftIds()).length;
+    const bytes = await editor1.exportHwp();
+    const dirtyAfterExport = win1.__documentState.isDirty();
+    const draftsAfterExport = (await listDraftIds()).length;
+    const ack = await editor1.notifySaved('footnote-01-저장본.hwp');
+    const dirtyAfterAck = win1.__documentState.isDirty();
+    const fileNameAfterAck = win1.__wasm.fileName;
+    const draftsAfterAck = (await listDraftIds()).length;
+    editor1.destroy();
+
+    // TC-1 재시작: 통지 후에는 복구 다이얼로그가 뜨지 않는다
+    const editor2 = await newEditor();
+    const dialogAfterAck = await waitRecoveryDialog(editor2.element, 2_500);
+
+    // TC-2: notifySaved 생략 → 재시작 시 복구 다이얼로그 표시
+    await editor2.loadFile(sampleBuffer, 'footnote-01.hwp', { suppressDialogs: true });
+    const win2 = editor2.element.contentWindow;
+    win2.__documentState.markDirty('e2e-no-ack');
+    await win2.__autosaveManager.flushNow('e2e-no-ack');
+    const draftsBeforeClose = (await listDraftIds()).length;
+    editor2.destroy(); // 통지 없이 종료 — 팝업 강제 종료와 동일 조건
+
+    const editor3 = await newEditor();
+    const dialogWithoutAck = await waitRecoveryDialog(editor3.element, 10_000);
+    editor3.destroy();
+    await clearDb();
+    host.remove();
+
+    return {
+      capabilityAdvertised,
+      draftsAfterFlush,
+      exportLength: bytes.byteLength,
+      dirtyAfterExport,
+      draftsAfterExport,
+      ack,
+      dirtyAfterAck,
+      fileNameAfterAck,
+      draftsAfterAck,
+      dialogAfterAck,
+      draftsBeforeClose,
+      dialogWithoutAck,
+    };
+  }, { editorModuleUrl: EDITOR_MODULE_URL, sampleUrl: SAMPLE_URL });
+
+  console.log(`  Part A result: ${JSON.stringify(partA)}`);
+  assert(partA.capabilityAdvertised === true, 'TC-3: rhwp-connected가 notify-saved-v1을 광고한다');
+  assert(partA.draftsAfterFlush >= 1, 'TC-1: dirty + flush 후 복구 draft 존재');
+  assert(partA.exportLength > 0, 'TC-1: exportHwp bytes 취득');
+  assert(partA.dirtyAfterExport === true, 'TC-1: export만으로는 dirty 유지 (자동 markClean 없음)');
+  assert(partA.draftsAfterExport >= 1, 'TC-1: export만으로는 draft 보존 (업로드 실패 대비)');
+  assert(partA.ack?.ok === true && partA.ack?.wasDirty === true,
+    'TC-1: notifySaved 응답 { ok: true, wasDirty: true }');
+  assert(partA.dirtyAfterAck === false, 'TC-1: notifySaved 후 dirty 해제');
+  assert(partA.fileNameAfterAck === 'footnote-01-저장본.hwp', 'TC-1: fileName 파라미터 반영');
+  assert(partA.draftsAfterAck === 0, 'TC-1: notifySaved 후 draft 삭제 완료');
+  assert(partA.dialogAfterAck === false, 'TC-1: 통지 후 재시작 시 복구 다이얼로그 없음');
+  assert(partA.draftsBeforeClose >= 1, 'TC-2: 통지 없이 종료 직전 draft 존재');
+  assert(partA.dialogWithoutAck === true, 'TC-2: 통지 생략 시 재시작에서 복구 다이얼로그 표시');
+
+  setTestCase('TC-4: window.rhwpStudio.notifySaved (팝업/포크 표면)');
+  await page.goto(
+    `${VITE_URL}/?url=${encodeURIComponent(SAMPLE_URL)}&filename=footnote-01.hwp`,
+    { waitUntil: 'domcontentloaded', timeout: 30000 },
+  );
+  await page.waitForFunction(
+    () => !!window.__wasm && !!window.__canvasView && !!window.rhwpStudio,
+    { timeout: 60000 },
+  );
+  await page.evaluate(() => new Promise((delay) => setTimeout(delay, 500)));
+
+  const partB = await page.evaluate(async () => {
+    const listDraftIds = async () => {
+      const req = indexedDB.open('rhwpStudioAutosave', 1);
+      const db = await new Promise((resolveDb, rejectDb) => {
+        req.onupgradeneeded = () => {
+          if (!req.result.objectStoreNames.contains('drafts')) {
+            req.result.createObjectStore('drafts', { keyPath: 'id' });
+          }
+        };
+        req.onerror = () => rejectDb(req.error);
+        req.onsuccess = () => resolveDb(req.result);
+      });
+      const ids = await new Promise((resolveIds, rejectIds) => {
+        const tx = db.transaction('drafts', 'readonly');
+        const keysReq = tx.objectStore('drafts').getAllKeys();
+        keysReq.onsuccess = () => resolveIds(keysReq.result);
+        keysReq.onerror = () => rejectIds(keysReq.error);
+      });
+      db.close();
+      return ids;
+    };
+
+    window.__documentState.markDirty('e2e-window-api');
+    await window.__autosaveManager.flushNow('e2e-window-api');
+    const draftsAfterFlush = (await listDraftIds()).length;
+    const ack = await window.rhwpStudio.notifySaved();
+    const dirtyAfterAck = window.__documentState.isDirty();
+    const draftsAfterAck = (await listDraftIds()).length;
+    return { draftsAfterFlush, ack, dirtyAfterAck, draftsAfterAck };
+  });
+
+  console.log(`  TC-4 result: ${JSON.stringify(partB)}`);
+  assert(partB.draftsAfterFlush >= 1, 'TC-4: dirty + flush 후 복구 draft 존재');
+  assert(partB.ack?.ok === true && partB.ack?.wasDirty === true,
+    'TC-4: window.rhwpStudio.notifySaved 응답 { ok: true, wasDirty: true }');
+  assert(partB.dirtyAfterAck === false, 'TC-4: notifySaved 후 dirty 해제');
+  assert(partB.draftsAfterAck === 0, 'TC-4: notifySaved 후 draft 삭제 완료');
+
+  // TC-4 재시작: 통지 후에는 복구 다이얼로그가 뜨지 않는다
+  await page.goto(`${VITE_URL}/`, { waitUntil: 'domcontentloaded', timeout: 30000 });
+  await page.waitForFunction(() => !!window.__wasm, { timeout: 60000 });
+  const dialogAfterWindowAck = await page.evaluate(async () => {
+    const deadline = Date.now() + 2_500;
+    while (Date.now() < deadline) {
+      const dialog = document.querySelector('.modal-overlay .dialog-wrap');
+      if (dialog && (dialog.textContent || '').includes('문서 복구')) return true;
+      await new Promise((delay) => setTimeout(delay, 200));
+    }
+    return false;
+  });
+  assert(dialogAfterWindowAck === false, 'TC-4: 통지 후 재시작 시 복구 다이얼로그 없음');
+}, { skipLoadApp: true });

--- a/rhwp-studio/e2e/embed-transport.test.mjs
+++ b/rhwp-studio/e2e/embed-transport.test.mjs
@@ -2,7 +2,11 @@ import { resolve } from 'path';
 
 import { runTest, assert } from './helpers.mjs';
 
-const EDITOR_MODULE_URL = `/@fs${resolve(import.meta.dirname, '../../npm/editor/index.js')}`;
+// Windows 절대 경로(D:\...)도 Vite /@fs URL로 변환되도록 정규화한다
+const EDITOR_MODULE_PATH = resolve(import.meta.dirname, '../../npm/editor/index.js').replace(/\\/g, '/');
+const EDITOR_MODULE_URL = EDITOR_MODULE_PATH.startsWith('/')
+  ? `/@fs${EDITOR_MODULE_PATH}`
+  : `/@fs/${EDITOR_MODULE_PATH}`;
 const VITE_URL = process.env.VITE_URL || 'http://localhost:7700';
 
 runTest('Issue #2186 @rhwp/editor MessageChannel v1 iframe transport', async ({ page }) => {

--- a/rhwp-studio/e2e/helpers.mjs
+++ b/rhwp-studio/e2e/helpers.mjs
@@ -796,7 +796,7 @@ export function assert(condition, message) {
  */
 function getReportFilename() {
   const scriptPath = process.argv[1] || 'unknown';
-  const basename = scriptPath.split('/').pop().replace(/\.test\.mjs$/, '');
+  const basename = scriptPath.split(/[\\/]/).pop().replace(/\.test\.mjs$/, '');
   return `${basename}-report.html`;
 }
 

--- a/rhwp-studio/src/embed/protocol.ts
+++ b/rhwp-studio/src/embed/protocol.ts
@@ -3,6 +3,7 @@ export const EMBED_CAPABILITIES = [
   'transferable-array-buffer',
   'hml-export',
   'renderer-diagnostics-v1',
+  'notify-saved-v1',
 ] as const;
 
 export interface EmbedConnectAttempt {

--- a/rhwp-studio/src/embed/rpc-router.ts
+++ b/rhwp-studio/src/embed/rpc-router.ts
@@ -7,6 +7,11 @@ import type {
   RenderBackendRequest,
 } from '../view/render-backend.ts';
 
+export interface EmbedNotifySavedResult {
+  ok: true;
+  wasDirty: boolean;
+}
+
 export interface EmbedRpcHandlers {
   ready(): Promise<boolean>;
   loadFile(
@@ -23,6 +28,7 @@ export interface EmbedRpcHandlers {
   exportHml(): Promise<Uint8Array>;
   getHmlSaveState(): Promise<HmlSaveState>;
   exportHwpVerify(): Promise<unknown>;
+  notifySaved(fileName?: string): Promise<EmbedNotifySavedResult>;
 }
 
 export interface EmbedRendererDiagnosticsV1 {
@@ -86,6 +92,11 @@ export async function routeEmbedRequest(
     case 'exportHml': return handlers.exportHml();
     case 'getHmlSaveState': return handlers.getHmlSaveState();
     case 'exportHwpVerify': return handlers.exportHwpVerify();
+    case 'notifySaved': return handlers.notifySaved(
+      typeof params.fileName === 'string' && params.fileName.length > 0
+        ? params.fileName
+        : undefined,
+    );
     default: throw new Error(`Unknown method: ${method}`);
   }
 }

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -70,6 +70,27 @@ initThemeSync((effective, mode) => {
   eventBus.emit('command-state-changed');
 });
 
+/**
+ * 호스트 저장 완료 통지 (#2660).
+ *
+ * 호스트가 내보내기 바이트의 영속화(업로드/핸드오프)를 마친 뒤 호출한다.
+ * draft 삭제 "완료"까지 await하므로, resolve 이후 팝업을 닫아도 IndexedDB
+ * 삭제가 잘리지 않는다. export 시점에는 호출하지 않는다(실패 시 백업 보존).
+ */
+async function completeHostSave(fileName?: string): Promise<{ ok: true; wasDirty: boolean }> {
+  const wasDirty = documentState.isDirty();
+  if (fileName) wasm.fileName = fileName;
+  documentState.markClean('host-save');
+  await autosaveManager.discardCurrentDraft('host-save');
+  return { ok: true, wasDirty };
+}
+
+// 호스트 통합용 공개 API — 팝업/포크 등 SDK 없이 스튜디오 페이지 안에서 통합하는
+// 호스트를 위해 프로덕션 빌드에도 항상 노출한다 (iframe 호스트는 embed RPC 사용).
+(window as any).rhwpStudio = {
+  notifySaved: (fileName?: string) => completeHostSave(fileName),
+};
+
 // E2E 테스트용 전역 노출 (개발 모드 전용)
 if (import.meta.env.DEV) {
   (window as any).__wasm = wasm;

--- a/rhwp-studio/src/main.ts
+++ b/rhwp-studio/src/main.ts
@@ -1360,5 +1360,9 @@ installEmbedRuntime({
       await initPromise;
       return JSON.parse(wasm.exportHwpVerify());
     },
+    async notifySaved(fileName) {
+      await initPromise;
+      return completeHostSave(fileName);
+    },
   },
 });

--- a/rhwp-studio/src/recovery/autosave-manager.ts
+++ b/rhwp-studio/src/recovery/autosave-manager.ts
@@ -69,6 +69,8 @@ export class AutosaveManager {
   private lastSavedAt = 0;
   private saving = false;
   private pendingReason: string | null = null;
+  /** discard 세대 — 진행 중이던 saveDraft가 discard 이후 완료되며 draft를 부활시키는 경합 감지용 */
+  private discardGeneration = 0;
   private scheduleSettings: AutosaveScheduleSettings;
 
   constructor(options: AutosaveManagerOptions) {
@@ -186,6 +188,7 @@ export class AutosaveManager {
     try {
       const bytes = this.exportBytes();
       const savedAt = this.now();
+      const generationAtStart = this.discardGeneration;
       await this.store.saveDraft({
         id: current.draftId,
         fileName: current.fileName,
@@ -195,6 +198,11 @@ export class AutosaveManager {
         data: new Uint8Array(bytes),
         dirtyReason: reason,
       });
+      if (this.discardGeneration !== generationAtStart) {
+        // 저장 진행 중 discard가 끼어듦 — 방금 저장으로 부활한 draft를 재삭제한다
+        await this.deleteDraft(current.draftId, 'discarded-during-save');
+        return;
+      }
       this.lastSavedAt = savedAt;
       this.logger.debug?.(`[autosave] draft saved: ${current.fileName} (${bytes.byteLength} bytes)`);
       this.onStatus?.({ state: 'saved', reason, byteLength: bytes.byteLength });
@@ -212,6 +220,7 @@ export class AutosaveManager {
   }
 
   async discardCurrentDraft(reason = 'discard'): Promise<void> {
+    this.discardGeneration += 1;
     this.cancelTimers();
     this.pendingReason = null;
     this.lastSavedAt = 0;

--- a/rhwp-studio/tests/autosave-manager.test.ts
+++ b/rhwp-studio/tests/autosave-manager.test.ts
@@ -184,6 +184,62 @@ test('AutosaveManager는 저장 상태 콜백을 보낸다', async () => {
   assert.deepEqual(states, ['saving', 'saved']);
 });
 
+test('AutosaveManager는 저장 진행 중 discard가 끼어들면 저장 완료로 부활한 draft를 재삭제한다', async () => {
+  const ops: string[] = [];
+  let signalSaveEntered: () => void = () => {};
+  const saveEntered = new Promise<void>((resolve) => {
+    signalSaveEntered = resolve;
+  });
+  let resolveSave: () => void = () => {};
+  const store: AutosaveStoreLike = {
+    async saveDraft(draft) {
+      signalSaveEntered();
+      await new Promise<void>((resolve) => {
+        resolveSave = resolve;
+      });
+      ops.push(`save:${draft.id}`);
+    },
+    async deleteDraft(id) {
+      ops.push(`delete:${id}`);
+    },
+  };
+  const manager = new AutosaveManager({
+    exportBytes: () => new Uint8Array([1]),
+    schedule: { recoveryEnabled: false, idleEnabled: false },
+    idFactory: () => 'draft-race',
+    store,
+    logger: { debug() {}, warn() {} },
+  });
+
+  await manager.beginDocument({ fileName: 'race.hwp', sourceFormat: 'hwp' });
+  const flushPromise = manager.flushNow('typing');
+  await saveEntered; // 저장이 IndexedDB put 대기 중인 시점
+  const discardPromise = manager.discardCurrentDraft('host-save');
+  await discardPromise;
+  resolveSave(); // put 완료 — draft 부활 시점
+  await flushPromise;
+
+  // discard 후 완료된 저장은 draft를 부활시키므로 반드시 재삭제되어야 한다
+  assert.deepEqual(ops, ['delete:draft-race', 'save:draft-race', 'delete:draft-race']);
+});
+
+test('AutosaveManager는 discard 없는 정상 flush에서는 draft를 삭제하지 않는다', async () => {
+  const { store, saved, deleted } = createStore();
+  const manager = new AutosaveManager({
+    exportBytes: () => new Uint8Array([6]),
+    schedule: { recoveryEnabled: false, idleEnabled: false },
+    idFactory: () => 'draft-plain',
+    store,
+    logger: { debug() {}, warn() {} },
+  });
+
+  await manager.beginDocument({ fileName: 'plain.hwp', sourceFormat: 'hwp' });
+  await manager.flushNow('typing');
+
+  assert.equal(saved.length, 1);
+  assert.deepEqual(deleted, []);
+});
+
 test('AutosaveManager는 대기 중인 저장이 없으면 설정 변경만으로 draft를 저장하지 않는다', async () => {
   const { store, saved } = createStore();
   const manager = new AutosaveManager({

--- a/rhwp-studio/tests/embed-protocol.test.ts
+++ b/rhwp-studio/tests/embed-protocol.test.ts
@@ -32,6 +32,8 @@ test('main.ts는 호스트 저장 완료 API completeHostSave를 window.rhwpStud
   );
   // window 공개 API: DEV 전용이 아닌 무조건 노출
   assert.match(source, /\.rhwpStudio = \{\s*\n?\s*notifySaved:/);
+  // embed RPC 핸들러도 동일 코어를 사용한다
+  assert.match(source, /async notifySaved\(fileName\)[\s\S]*?completeHostSave\(fileName\)/);
 });
 
 test('embed protocol은 capability를 포함한 v1 connect와 session-bound request만 허용한다', () => {
@@ -45,6 +47,7 @@ test('embed protocol은 capability를 포함한 v1 connect와 session-bound requ
     'transferable-array-buffer',
     'hml-export',
     'renderer-diagnostics-v1',
+    'notify-saved-v1',
   ]);
 
   assert.equal(isRequestEnvelope({
@@ -73,6 +76,7 @@ test('embed router는 binary load와 unknown method를 공개 동작으로 처�
     exportHml: async () => new Uint8Array([3]),
     getHmlSaveState: async () => ({ sourceFormat: 'hml', hmlSavable: true, blockers: [] }),
     exportHwpVerify: async () => ({ recovered: true }),
+    notifySaved: async () => ({ ok: true as const, wasDirty: true }),
   };
 
   assert.deepEqual(
@@ -125,6 +129,7 @@ test('embed runtime은 parent의 exact origin에서 v1 port session을 설치한
     exportHml: async () => new Uint8Array([3]),
     getHmlSaveState: async () => ({ sourceFormat: 'hml', hmlSavable: true, blockers: [] }),
     exportHwpVerify: async () => ({ recovered: true }),
+    notifySaved: async () => ({ ok: true as const, wasDirty: true }),
   };
   const cleanup = installEmbedRuntime({
     hostWindow: hostWindow as unknown as Window,
@@ -794,6 +799,7 @@ test('embed router는 suppressDialogs 파라미터를 핸들러로 전달한다 
     exportHml: async () => new Uint8Array(),
     getHmlSaveState: async () => ({ sourceFormat: 'hml', hmlSavable: true, blockers: [] }),
     exportHwpVerify: async () => ({}),
+    notifySaved: async () => ({ ok: true as const, wasDirty: false }),
   };
 
   await routeEmbedRequest('loadFile', { data: new Uint8Array([1]) }, handlers);
@@ -807,4 +813,25 @@ test('embed router는 suppressDialogs 파라미터를 핸들러로 전달한다 
     { skipUnsavedGuard: false, suppressDialogs: false },
     { skipUnsavedGuard: true, suppressDialogs: true },
   ]);
+});
+
+test('embed router는 notifySaved fileName을 정규화해 핸들러로 전달한다 (#2660)', async () => {
+  const received: Array<string | undefined> = [];
+  const handlers = {
+    notifySaved: async (fileName?: string) => {
+      received.push(fileName);
+      return { ok: true as const, wasDirty: true };
+    },
+  } as EmbedRpcHandlers;
+
+  assert.deepEqual(
+    await routeEmbedRequest('notifySaved', {}, handlers),
+    { ok: true, wasDirty: true },
+  );
+  await routeEmbedRequest('notifySaved', { fileName: 'a.hwp' }, handlers);
+  // 비문자열/빈 문자열 fileName은 undefined로 정규화한다
+  await routeEmbedRequest('notifySaved', { fileName: 123 }, handlers);
+  await routeEmbedRequest('notifySaved', { fileName: '' }, handlers);
+
+  assert.deepEqual(received, [undefined, 'a.hwp', undefined, undefined]);
 });

--- a/rhwp-studio/tests/embed-protocol.test.ts
+++ b/rhwp-studio/tests/embed-protocol.test.ts
@@ -23,6 +23,17 @@ test('renderer diagnostics v1 keeps auto intent in the additive selection field'
   );
 });
 
+test('main.ts는 호스트 저장 완료 API completeHostSave를 window.rhwpStudio로 노출한다 (#2660)', () => {
+  const source = readFileSync(new URL('../src/main.ts', import.meta.url), 'utf8');
+  // 코어: markClean('host-save') 후 draft 삭제 "완료"까지 await — 팝업 close 안전 계약
+  assert.match(
+    source,
+    /async function completeHostSave\(fileName\?: string\)[\s\S]*?markClean\('host-save'\)[\s\S]*?await autosaveManager\.discardCurrentDraft\('host-save'\)[\s\S]*?wasDirty/,
+  );
+  // window 공개 API: DEV 전용이 아닌 무조건 노출
+  assert.match(source, /\.rhwpStudio = \{\s*\n?\s*notifySaved:/);
+});
+
 test('embed protocol은 capability를 포함한 v1 connect와 session-bound request만 허용한다', () => {
   assert.equal(isConnectMessage({
     type: 'rhwp-connect', version: 1, sessionId: 's-1', capabilities: EMBED_CAPABILITIES,

--- a/scripts/frontend-editor-embed.test.mjs
+++ b/scripts/frontend-editor-embed.test.mjs
@@ -22,6 +22,7 @@ test('@rhwp/editor public API uses exact-origin MessageChannel v1 binary transpo
       'transferable-array-buffer',
       'hml-export',
       'renderer-diagnostics-v1',
+      'notify-saved-v1',
     ]);
     assert.equal(transfer.length, 1);
     sessionId = message.sessionId;
@@ -42,6 +43,7 @@ test('@rhwp/editor public API uses exact-origin MessageChannel v1 binary transpo
         'transferable-array-buffer',
         'hml-export',
         'renderer-diagnostics-v1',
+        'notify-saved-v1',
       ],
     });
   });
@@ -81,6 +83,10 @@ test('@rhwp/editor public API uses exact-origin MessageChannel v1 binary transpo
   });
   assert.deepEqual(await editor.exportHwpVerify(), verifyResult());
 
+  assert.deepEqual(await editor.notifySaved('sample-saved.hwp'), { ok: true, wasDirty: true });
+  const notifyRequest = requests.find((request) => request.method === 'notifySaved');
+  assert.deepEqual(notifyRequest.params, { fileName: 'sample-saved.hwp' });
+
   editor.destroy();
   assert.equal(harness.iframe.removed, true);
 });
@@ -108,6 +114,10 @@ test('@rhwp/editor keeps the bounded legacy request/response fallback', async (t
   assert.equal(await editor.pageCount(), 3);
   await assert.rejects(
     () => editor.getRendererDiagnostics(0),
+    /not supported by this Studio/,
+  );
+  await assert.rejects(
+    () => editor.notifySaved(),
     /not supported by this Studio/,
   );
 
@@ -216,6 +226,7 @@ function responseFor(message, legacy = false) {
       }],
     };
     case 'exportHwpVerify': return verifyResult();
+    case 'notifySaved': return { ok: true, wasDirty: true };
     default: throw new Error(`Unexpected method: ${message.method}`);
   }
 }


### PR DESCRIPTION
johndoekim 님의 #2667 을 메인테이너가 재실증 후 통합한다. **`.rs` 무수정.**

## 채택

**#2667** (`Closes #2660`) — 호스트 저장 완료 통지 API `notifySaved`

호스트가 `exportHwp()` 로 받은 바이트를 서버에 저장해도 스튜디오는 그 사실을 알 수 없어, 미저장(dirty) 상태가 유지되고 자동복구 draft 가 남는다. 다음 접속 때 "복구할 문서가 있습니다" 가 잘못 뜨는 원인이다.

```ts
notifySaved(fileName?: string): Promise<{ ok: true; wasDirty: boolean }>
```

- **draft 삭제가 끝난 뒤 resolve** 한다. "resolve 이후 창을 닫아도 안전" 이 계약에 명시돼 있어 호스트가 저장 직후 창을 닫는 흐름에서도 draft 가 남지 않는다.
- **capability 게이팅** — 구버전 스튜디오나 legacy 폴백 연결이 `notify-saved-v1` 을 광고하지 않으면 요청을 보내지 않고 예외를 던진다. 조용한 실패를 만들지 않았다.
- `wasDirty` 를 돌려주어 멱등 호출을 관찰할 수 있다.

**핵심은 autosave 경합 방어다.** `saveDraft` 진행 중 `discard` 가 끼어들면 저장이 완료되면서 draft 가 부활한다. 이를 **세대 카운터**(`discardGeneration`)로 감지해 재삭제하고, 정상 flush 에서는 삭제하지 않는 반대 방향까지 테스트로 고정했다.

## 검증

- `tsc --noEmit` 오류 0, **studio 503 pass**(devel 494 → 신규 9건), npm/editor 계약 24 pass, embed dist 계약 2 pass
- red→green: 경합 감지(`this.discardGeneration !== generationAtStart`)를 무력화하니 "저장 진행 중 discard 가 끼어들면 저장 완료로 부활한 draft 를 재삭제한다" 가 정확히 FAIL → 복원 시 503 pass
- 하이퍼-워터폴 문서 규칙 준수(수행계획서 → 구현계획서 → stage1~5 → 최종보고서)

## 충돌 해소 2건

원 PR 의 base 가 현재 `devel` 보다 115 커밋 뒤처져 두 곳에서 충돌했다. 둘 다 문서이며 코드 충돌은 없었다.

- `mydocs/orders/20260721.md` — 어제 merge 한 오늘할일과 겹쳐 HEAD 를 유지했다.
- `npm/editor/README.md` — 오늘 merge 한 #2761 의 `getHmlSaveState` 문서와 겹쳤다. 서로 다른 API 라 **양쪽을 모두 보존**했다(`getHmlSaveState` 212행, `notifySaved` 259행).

Co-authored-by 로 원 커밋 provenance 를 보존한다.
