### PR TITLE
docs: PR #2658 최종 검토 기록 보존

### DIFF
--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -92,20 +92,25 @@
 - red→green: `24 | 25` 를 다시 합치니 `task2765_hwp3_toc_mark_does_not_emit_hyphen` FAIL →
   복원 시 통과. hwp3 테스트 21건 green.
 
-## PR #2658 — postmelee 확장 설정 방어 (merge 보류)
+## PR #2658 — postmelee 확장 설정 방어 (merge 완료)
 
 - [#2658](https://github.com/edwardkim/rhwp/pull/2658)은 Chrome/Edge 확장에서 사용자가 끈
   `autoOpen=false`가 업데이트 후 되돌아온다는 제보 대응이다. **원 제보가 재현되지 않았음을 먼저
   밝히고 "Chrome 업데이트가 설정을 초기화한다고 단정하지 않는다"고 범위를 그은 접근**이 좋았다.
   추정으로 고치는 대신 정적 조사와 오류 주입으로 확인된 방어 공백만 제거했다.
-- 다만 [@jangster77](https://github.com/jangster77) 님이 `CHANGES_REQUESTED`를 남긴 상태였고,
+- [@jangster77](https://github.com/jangster77) 님이 남긴 `CHANGES_REQUESTED`에서,
   지적하신 공백을 **코드로 재현했다**. `loadSettingsForAutomaticActions()`의 `syncReadable`은
   `syncResult.ok`, 즉 **storage 호출의 성공**만 판정한다. 개별 키 누락은 조용히
   `DEFAULT_SETTINGS`로 대체되므로, local snapshot이 아직 없는 업데이트 직후에 `autoOpen` 키만
   사라지면 기본값 `true`가 되고 그 값이 snapshot으로 굳는다.
 - 즉 **"읽기는 됐지만 값이 없다"와 "읽기가 안 됐다"가 자동 동작 관점에서는 같은 상태**인데
-  전자만 기본값으로 흘러간다. 재현 절차와 보완 방향(update lifecycle에서 sync 설정 보존 +
-  `SYNC_META_KEY`로 partial sync를 clean-install과 구분)을 코멘트로 공유하고 merge를 보류했다.
+  전자만 기본값으로 흘러가던 공백이 있었다. 기여자는 update lifecycle에서 sync 설정을 보존하고
+  `SYNC_META_KEY`/legacy key를 근거로 partial sync를 clean-install과 구분하도록 보완했다.
+- 최신 head에서 requested-changes 재현 회귀, options 저장 실패, 중복 download event, 확장 배포 계약을
+  재검증했고 GitHub Actions도 통과했다. [#2658](https://github.com/edwardkim/rhwp/pull/2658)은
+  `bb99b8903bb3cec077ff808a6573a87b96739ee9`로 merge됐으며,
+  [#2656](https://github.com/edwardkim/rhwp/issues/2656)은 auto-close 됐다.
+- merge 후 확정된 review 기록과 이 오늘할일은 옵션 2 후속 문서 PR로 보존한다.
 - **검토 절차상 반성** — 코멘트를 확인할 때 `head -10`으로 잘라 postmelee 님 것만 보고
   jangster77 님의 리뷰를 놓친 채 merge 준비를 진행했다. 작업지시자 지적으로 막혔다. 앞으로 PR
   검토는 `gh pr view --json reviews`로 리뷰 상태를 확인하는 것을 첫 단계로 둔다.
@@ -158,8 +163,6 @@
     #2746(`hp:pic` numberingType·groupLevel). 둘 다 실재하는 결함이고 어제 merge 한 #2719 의
     잔여라 정리 가치가 있다.
   - 테스트 보강 — #2762. 작성할 골격을 코드로 제시했다.
-- **다른 기여자 대기 1건** — [#2658](https://github.com/edwardkim/rhwp/pull/2658)(postmelee)은
-  jangster77 님 지적 공백의 보완을 기다린다. 재현 절차와 보완 방향은 코멘트로 공유했다.
 - [PR #2805](https://github.com/edwardkim/rhwp/pull/2805)(#2804 CI retries)는 CI 대기 중이다.
 - 어제분 오늘할일은 [PR #2795](https://github.com/edwardkim/rhwp/pull/2795)(`d668053d6e`)로 반영했다.
 - 존치: [#2550](https://github.com/edwardkim/rhwp/issues/2550) C 안 권고 후 기여자 구현 대기,
@@ -171,7 +174,7 @@
 |---|---:|---:|---|
 | kevin9327 | 7 | 2 | 3 (리베이스 2 · 테스트 1) |
 | johndoekim | 1 | — | — |
-| postmelee | — | — | 1 (보완 대기) |
+| postmelee | 1 | — | — |
 | 메인테이너 | — | — | #2804 CI 대기 |
 
 merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42001ef` ·
@@ -180,4 +183,4 @@ merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42
 [#2802](https://github.com/edwardkim/rhwp/pull/2802) `ad4cf05d3f` ·
 [#2803](https://github.com/edwardkim/rhwp/pull/2803) `f85e689752`
 
-연결 이슈 close 8건: #2660 #2723 #2724 #2740 #2752 #2756 #2759 #2765
+연결 이슈 close 9건: #2656 #2660 #2723 #2724 #2740 #2752 #2756 #2759 #2765

--- a/mydocs/pr/archives/pr_2658_review.md
+++ b/mydocs/pr/archives/pr_2658_review.md
@@ -7,7 +7,9 @@
 | reviewer | [@jangster77](https://github.com/jangster77), [@edwardkim](https://github.com/edwardkim) |
 | 관련 이슈 | [#2656](https://github.com/edwardkim/rhwp/issues/2656) |
 | 범위 | Chrome/Edge 설정 저장·복구, options 초기화·오류 처리, 다운로드 자동 열기 중복·fail-closed 방어 |
-| 처리 경로 | collaborator self-PR head 보강 후 최신 CI와 재검토를 기다리는 경로 |
+| 처리 경로 | 원 PR head 보강 후 재검토·merge 완료, 옵션 2 후속 기록 PR로 최종 상태 보존 |
+| merge 결과 | 2026-07-22, merge commit `bb99b8903bb3cec077ff808a6573a87b96739ee9` |
+| 이슈 결과 | [#2656](https://github.com/edwardkim/rhwp/issues/2656) auto-close 확인 |
 
 ## 검토 결론
 
@@ -27,8 +29,16 @@
   last-known-good snapshot으로 기록하지 않는다.
 
 clean install의 `autoOpen=true` 기본 동작과 유효한 local snapshot 복구는 별도 회귀 테스트로 유지했다.
-따라서 requested-changes의 재현 경로는 로컬 구현 기준으로 해소됐으며, 최신 PR head CI와 reviewer
-재검토를 기다리는 후보로 판단한다.
+따라서 requested-changes의 재현 경로는 로컬 구현 기준으로 해소됐다.
+
+## 최종 처리
+
+보강된 최신 head `31af56fb0df360e98462896446cc29235fc4b97b`에서 reviewer 재검토와 최신 GitHub
+Actions 성공을 확인한 뒤 [#2658](https://github.com/edwardkim/rhwp/pull/2658)을 merge했다. merge commit은
+`bb99b8903bb3cec077ff808a6573a87b96739ee9`이며, `Closes #2656`에 따라
+[#2656](https://github.com/edwardkim/rhwp/issues/2656)이 2026-07-22에 자동 종료된 것도 확인했다.
+
+이 문서는 원 PR에 먼저 포함된 보류 단계 기록을 merge 이후 확정 사실로 보완하는 옵션 2 후속 기록이다.
 
 ## 렌더 영향과 시각 검증
 
@@ -46,18 +56,18 @@ renderer, layout, golden, 샘플은 변경하지 않으므로 visual sweep 대�
 - source/dist `background.js`, `settings-store.js`, `extension-lifecycle.js`, `options.js` byte 비교: 통과
 - 변경 JavaScript `node --check`: 통과
 - `git diff --check`: 통과
+- reviewer 재검증: Chrome/Firefox/shared service worker 113 passed, Chrome options UI 4 passed
+- reviewer 재검증: `wasm-pack build --target web --out-dir pkg` 후 Chrome/Firefox production build 성공,
+  확장 배포 산출물 계약 3 passed
+- 최신 GitHub Actions: CI, CodeQL, Render Diff의 실행된 check 모두 성공
 
-## 작성 시점 참고 상태와 merge 전 조건
+## 보류 단계 기록과 최종 확인
 
-- 보강 작성 기준 원격 head: `7505db1d692d5c7a1525a2301a3d520ce5d5da1b`
-- 작성 시점 참고값: `MERGEABLE` / `BEHIND` / `CHANGES_REQUESTED`
-- 기존 원격 head의 GitHub Actions는 성공했지만, 보강 코드가 포함된 최신 head의 결과가 아니다.
-- 최종 merge 조건:
-  - 최신 `upstream/devel` 동기화 뒤 충돌 없음
-  - 보강 코드가 포함된 최신 PR head 기준 GitHub Actions 통과
-  - requested-changes reviewer 재검토
-  - 이 review 문서와 기존 `mydocs/orders/20260721.md`가 PR diff에 포함됨
-  - 작업지시자 merge 승인
+- 최초 기록의 `CHANGES_REQUESTED`와 `BEHIND`는 보강 전 head를 기준으로 한 과거 참고값이다.
+- 최종 확인 시점에는 보강 코드가 포함된 최신 head의 GitHub Actions가 통과했고, requested-changes
+  reviewer가 `APPROVED`로 재검토를 마쳤다.
+- 이슈 auto-close 봇 코멘트만으로 끝내지 않고, merge commit·로컬 검증·최신 CI 결과를 이 archive 기록과
+  옵션 2 오늘할일 갱신에 함께 남긴다.
 
 requested-changes가 단일 동작 영역으로 수렴하고 실행 순서도 commit, devel sync, 재검증, push,
-재검토 요청으로 고정되어 별도 `pr_2658_review_impl.md`는 작성하지 않는다.
+재검토로 고정되어 별도 `pr_2658_review_impl.md`는 작성하지 않는다.


### PR DESCRIPTION
## 목적

merge 완료된 [#2658](https://github.com/edwardkim/rhwp/pull/2658)의 review 기록과 오늘할일을 옵션 2 후속 문서 PR로 확정합니다.

## 변경

- `mydocs/pr/archives/pr_2658_review.md`에 최신 보강 head 검토, 승인, merge commit `bb99b8903bb3cec077ff808a6573a87b96739ee9`, [#2656](https://github.com/edwardkim/rhwp/issues/2656) auto-close 결과를 기록합니다.
- `mydocs/orders/20260722.md`의 #2658 상태와 기여자/이슈 집계를 merge 완료 기준으로 정정합니다.

## 검증

- `git diff --check` 통과
- 문서 변경만 포함한 fast-pass 대상
- 원 코드 PR 최신 head의 GitHub Actions 성공 및 merge 완료 확인

Closes #2656