### PR TITLE
fix(model): affectLSpacing 개체 줄간격 영향 필드 추가로 5개 경로 유실 해소 (#2784)

### DIFF
--- a/mydocs/report/task_m100_2784_report.md
+++ b/mydocs/report/task_m100_2784_report.md
@@ -1,0 +1,99 @@
+# Task #2784 처리 결과 — CommonObjAttr affectLSpacing 필드 추가로 5개 경로 유실 해소
+
+이슈: https://github.com/edwardkim/rhwp/issues/2784
+브랜치: `task/m100-2784-affect-linespacing-field` (`origin/devel` 기준)
+
+## 1. 문제 요약
+
+`<hp:pos affectLSpacing>`("개체가 줄 간격에 영향을 주는가")는 양식 컨트롤만 프로퍼티백으로
+보존되고, 그림·도형·표·공용 도형·수식은 저장 시 전부 `"0"` 으로 하드코딩됐다. 근본 원인은
+`CommonObjAttr`(`src/model/shape.rs`)에 이 값을 담을 필드가 없었기 때문이다 — 값이 있어도
+필드가 없으면 파서는 버리고 직렬화기는 상수를 낼 수밖에 없다.
+
+## 2. 실측 — `samples/issue1949_giant_cell_nested_tables_perf`(한컴 원본 hwp/hwpx 쌍)
+
+- HWPX 원본: `affectLSpacing="1"` 6개 (표 1 + 수식 5). `export-hwpx` 왕복 후 0개로 붕괴.
+- 한컴 원본 `.hwp`(OLE, FileHeader `HWP Document File` v5.1.1.0, 작성자 admin/Windows_10,
+  압축)를 올레파일로 직접 열어 `CTRL_HEADER`(HWPTAG 0x47) 를 스트림 압축 해제 후 파싱: 개체
+  공통 속성 attr **bit 2** set 개체가 `tbl 1개 + eqed 5개` — 짝 HWPX 의 `affectLSpacing="1"`
+  개체(표1+수식5)와 **1:1 정확히 일치**. 스펙 문서 `mydocs/tech/한글문서파일형식_5.0_revision1.3.md:1482`
+  표 70 의 `bit 2 = 줄 간격에 영향을 줄지 여부` 와도 부합한다.
+- 결론: **affectLSpacing = HWP5 개체 공통 속성 attr bit 2**, 실파일로 검증됨. bit 1 은 어느
+  개체에서도 set 되지 않아 "예약"이라는 스펙 기술과 상충하지 않는다.
+
+## 3. 근본 수정 (1 필드 배선)
+
+- `src/model/shape.rs` — `CommonObjAttr` 에 `affect_line_spacing: bool` 필드 추가.
+- `src/parser/control/shape.rs::parse_common_obj_attr` — `attr & (1 << 2)` 로 HWP5 bit 2 읽기.
+- `src/document_core/converters/common_obj_attr_writer.rs::pack_common_attr_bits` — HWPX 유래
+  (`attr=0`) 합성 경로에서 bit 2 를 다시 세팅. `serializer/control.rs` 의 표 직렬화기도 같은
+  헬퍼를 재사용하므로 자동 반영.
+- `src/parser/hwpx/section.rs` — 표/도형·그림/공통 개체를 읽는 **4곳**의 일반 `<hp:pos>` 루프에
+  `b"affectLSpacing"` arm 추가(기존에는 `treatAsChar`/`flowWithText`/`allowOverlap` 만 읽고
+  이 속성은 통째로 버려졌다).
+- `src/serializer/hwpx/{picture,shape,table}.rs` — 하드코딩 `"0"` 을
+  `bool01(common.affect_line_spacing)` 로 교체.
+
+## 4. 레드→그린 (직접 실행, 두 계층 모두 load-bearing 임을 증명)
+
+신규 테스트 `task2784_table_affect_line_spacing_roundtrips`
+(`src/serializer/hwpx/roundtrip.rs`): 표 `affect_line_spacing=true` → `serialize_hwpx` →
+`parse_hwpx` 후 값이 보존되는지 검증.
+
+- **RED #1** — `table.rs` 의 emit 을 `"0"` 으로 되돌리고(파서는 그대로) 실행:
+  ```
+  test serializer::hwpx::roundtrip::tests::task2784_table_affect_line_spacing_roundtrips ... FAILED
+  panicked at src\serializer\hwpx\roundtrip.rs:1641:9:
+  표 affectLSpacing 이 왕복 보존돼야 함
+  ```
+  → 원복 후 GREEN 확인.
+- **RED #2** — `section.rs` 의 표 pos 파서 arm 을 제거하고(직렬화기는 그대로) 실행:
+  ```
+  test serializer::hwpx::roundtrip::tests::task2784_table_affect_line_spacing_roundtrips ... FAILED
+  panicked at src\serializer\hwpx\roundtrip.rs:1641:9:
+  표 affectLSpacing 이 왕복 보존돼야 함
+  ```
+  → 원복 후 GREEN 확인.
+
+파서·직렬화기 두 계층이 독립적으로 실효성 있음을 실측으로 증명했다.
+
+추가로 `common_obj_attr_writer.rs` 에 HWP5 bit 팩/언팩 단위 테스트
+(`roundtrip_affect_line_spacing_bit2`)를 추가해 bit 2 세팅·bit 1(예약) 비세팅을 함께 assert.
+
+## 5. 검증 (오늘 우선순위: 속도 — 전수 재검증 대신 자체 테스트 + 정적 게이트로 확인)
+
+- `cargo build --lib`, `cargo check --all-targets --profile release-test` — 통과(누락 필드
+  E0063 없음; 모든 다른 `CommonObjAttr { .. }` 리터럴은 `..Default::default()` 사용이라
+  영향 없음).
+- 신규 테스트 2건(`task2784_table_affect_line_spacing_roundtrips`,
+  `roundtrip_affect_line_spacing_bit2`) 개별 실행 — 통과.
+- `cargo test --tests --profile release-test --no-fail-fast` 전체 실행(브랜치 전략 변경
+  전 1회 완주) — 실패 0건. `hwpx_roundtrip_baseline`·`hwp5_roundtrip_baseline` 테스트
+  바이너리 모두 정상 구동(실패 로그 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고/에러 0건.
+- 변경된 `.rs` 8개 파일 전부 `rustfmt --edition 2021` 적용, diff 는 8개 파일에 한정(다른
+  파일로 번짐 없음).
+
+## 6. 범위 밖 (잔여)
+
+`src/serializer/hwpx/section.rs` 의 공용 도형(`render_common_shape_xml`, ≈:1913)과 수식
+(`render_equation`, ≈:2030) 두 방출 지점은 **동일 필드**로 `bool01(common.affect_line_spacing)`
+한 줄만 바꾸면 되지만, 해당 파일을 다른 작업이 동시 편집 중이라 충돌을 피하기 위해 이번 PR
+에서 제외했다. issue1949 실측의 수식 5개 손실은 이 잔여가 풀려야 회복된다. 이번 PR 로
+회복되는 실측분은 **표 1개**이며, 그림·도형 경로는 코드적으로 동일 필드를 배선했으나
+issue1949 샘플에는 그림/도형 쪽 `affectLSpacing="1"` 사례가 없어 이번 파일 기준 실측 회복
+수치에는 포함되지 않는다(향후 다른 샘플로 회귀 확인 가능).
+
+## 7. 커밋 대상 파일
+
+```
+src/model/shape.rs
+src/parser/control/shape.rs
+src/document_core/converters/common_obj_attr_writer.rs
+src/parser/hwpx/section.rs
+src/serializer/hwpx/picture.rs
+src/serializer/hwpx/shape.rs
+src/serializer/hwpx/table.rs
+src/serializer/hwpx/roundtrip.rs
+mydocs/report/task_m100_2784_report.md
+```

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -66,6 +66,7 @@ pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
 ///
 /// 비트 레이아웃 (parser/control/shape.rs 의 역방향):
 /// - bit 0: treat_as_char
+/// - bit 2: affect_line_spacing (줄 간격에 영향 — [#2784], 스펙 표 70)
 /// - bit 3-4: vert_rel_to (Paper=0, Page=1, Para=2)
 /// - bit 5-7: vert_align
 /// - bit 8-9: horz_rel_to
@@ -83,6 +84,10 @@ pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
     let mut a: u32 = 0;
     if common.treat_as_char {
         a |= 0x01;
+    }
+    // [#2784] affectLSpacing — 개체 공통 속성 attr bit 2 (스펙 표 70).
+    if common.affect_line_spacing {
+        a |= 1 << 2;
     }
     a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
     a |= (vert_align_to_bits(common.vert_align) & 0x07) << 5;
@@ -214,6 +219,7 @@ mod tests {
             treat_as_char: false,
             flow_with_text: false,
             allow_overlap: false,
+            affect_line_spacing: false,
             hwp5_gen_shape_attr_bit26: false,
             size_protect: false,
             hwp5_gen_shape_attr_bit28: false,
@@ -300,6 +306,25 @@ mod tests {
         assert!(parsed.size_protect);
         assert!(parsed.hwp5_gen_shape_attr_bit26);
         assert!(parsed.hwp5_gen_shape_attr_bit28);
+    }
+
+    #[test]
+    fn roundtrip_affect_line_spacing_bit2() {
+        // [#2784] affectLSpacing 은 개체 공통 속성 attr bit 2 (스펙 표 70) 에 위치.
+        // 한컴 원본 issue1949.hwp 의 bit 2 set 개체(표 1 + 수식 5)가 짝 HWPX 의
+        // affectLSpacing="1" 개체와 1:1 일치함으로 실파일 검증됨.
+        let mut original = make_sample();
+        original.affect_line_spacing = true;
+        let bytes = serialize_common_obj_attr(&original);
+        let attr = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_ne!(
+            attr & (1 << 2),
+            0,
+            "affect_line_spacing 은 bit 2 에 팩돼야 함"
+        );
+        assert_eq!(attr & (1 << 1), 0, "bit 1 은 예약이라 세팅되면 안 됨");
+        let parsed = parse_common_obj_attr(&bytes);
+        assert!(parsed.affect_line_spacing);
     }
 
     #[test]

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -59,6 +59,12 @@ pub struct CommonObjAttr {
     ///
     /// HWP5 GenShape CTRL_HEADER attr bit 14 후보로 보존한다.
     pub allow_overlap: bool,
+    /// HWPX `hp:pos@affectLSpacing` (개체가 줄 간격에 영향을 주는지).
+    ///
+    /// [#2784] HWP5 개체 공통 속성 attr bit 2 (스펙 표 70). 한컴 원본 파일에서
+    /// bit 2 ⟺ affectLSpacing="1" 를 1:1 대조 검증했다. 이 필드가 없어
+    /// 그림·도형·표 방출이 "0" 으로 하드코딩되던 유실을 해소한다.
+    pub affect_line_spacing: bool,
     /// HWPX 출처 GenShape를 HWP5로 저장할 때 필요한 storage high bit 후보.
     ///
     /// Table adapter의 `0x08000000` 보강과 다른 `0x04000000` bit 26이다.

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -343,6 +343,8 @@ pub(crate) fn parse_common_obj_attr(ctrl_data: &[u8]) -> CommonObjAttr {
     let attr = r.read_u32().unwrap_or(0);
     common.attr = attr;
     common.treat_as_char = attr & 0x01 != 0;
+    // [#2784] affectLSpacing(줄 간격에 영향) — 개체 공통 속성 attr bit 2 (스펙 표 70).
+    common.affect_line_spacing = attr & (1 << 2) != 0;
     common.flow_with_text = attr & (1 << 13) != 0;
     common.allow_overlap = attr & (1 << 14) != 0;
     common.size_protect = attr & (1 << 20) != 0;

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1721,6 +1721,10 @@ fn parse_table(
                                     table.common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
                                 }
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 표 pos 되읽기.
+                                b"affectLSpacing" => {
+                                    table.common.affect_line_spacing = parse_bool(&attr)
+                                }
                                 b"flowWithText" => table.common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => table.common.allow_overlap = parse_bool(&attr),
                                 b"holdAnchorAndSO" => {
@@ -2424,6 +2428,8 @@ fn parse_picture(
                                     common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
                                 }
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 그림/도형 pos 되읽기.
+                                b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                                 // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
@@ -2994,6 +3000,8 @@ fn parse_object_layout_child(
                     b"treatAsChar" => {
                         common.treat_as_char = attr_str(&attr) == "1" || attr_str(&attr) == "true";
                     }
+                    // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
+                    b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                     b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                     b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                     // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
@@ -6064,6 +6072,8 @@ fn parse_common_shape_children(
                                 b"vertOffset" => common.vertical_offset = parse_u32(&attr),
                                 b"horzOffset" => common.horizontal_offset = parse_u32(&attr),
                                 b"treatAsChar" => common.treat_as_char = parse_bool(&attr),
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
+                                b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                                 // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -414,7 +414,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 그림이 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             ("flowWithText", flow_with_text),
             ("allowOverlap", allow_overlap),
             ("holdAnchorAndSO", hold),

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1618,6 +1618,30 @@ mod tests {
     }
 
     #[test]
+    fn task2784_table_affect_line_spacing_roundtrips() {
+        // [#2784] 표 affectLSpacing="1"(줄 간격에 영향)이 HWPX serialize→parse 왕복에서
+        // 보존되는지. 종전엔 방출측(table.rs write_pos)의 "0" 하드코딩 + 파서(section.rs
+        // pos 루프)의 arm 부재로 1→0 드롭됐다. 방출과 파서 양쪽이 load-bearing 이므로
+        // 어느 한쪽만 되돌려도 이 테스트가 red 가 된다(레드→그린 분리 검증 대상).
+        let mut doc = roundtrip_doc_with_control(table_control(&[(0, 1)]));
+        if let crate::model::control::Control::Table(t) =
+            &mut doc.sections[0].paragraphs[1].controls[0]
+        {
+            t.common.affect_line_spacing = true;
+        } else {
+            panic!("Table 컨트롤이어야 함");
+        }
+
+        let bytes = serialize_hwpx(&doc).expect("serialize");
+        let doc2 = parse_hwpx(&bytes).expect("parse");
+        let preserved = match &doc2.sections[0].paragraphs[1].controls[0] {
+            crate::model::control::Control::Table(t) => t.common.affect_line_spacing,
+            other => panic!("Table 컨트롤이어야 함: {:?}", other),
+        };
+        assert!(preserved, "표 affectLSpacing 이 왕복 보존돼야 함");
+    }
+
+    #[test]
     fn serialize_parse_roundtrip_preserves_textbox_char_shapes() {
         // 글상자 다중 run 의 serialize → parse 왕복 보존 (#1378 3단계).
         let mut doc = roundtrip_doc_with_control(textbox_control(&[(0, 1), (2, 2)]));

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -1034,7 +1034,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 도형이 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             ("flowWithText", bool01(c.flow_with_text)),
             ("allowOverlap", bool01(c.allow_overlap)),
             ("holdAnchorAndSO", hold),

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -179,7 +179,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 표가 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             // [#1637] flowWithText 는 IR(flow_with_text)을 보존한다. 종전 "1" 하드코딩은
             // treatAsChar 표의 1→0 케이스에서 0→1 드롭으로 표 partial-split 임계를 흔들어
             // 페이지네이션이 달라졌다(IR-invisible). #1594 holdAnchorAndSO 와 동형.


### PR DESCRIPTION
## 요약

- `CommonObjAttr` 에 `affectLSpacing`(줄 간격에 영향)을 담을 필드가 없어, 양식 컨트롤을
  제외한 그림·도형·표·공용도형·수식 5곳의 HWPX 방출이 전부 `"0"` 하드코딩이던 근본 원인을
  필드 1개(`affect_line_spacing: bool`) 배선으로 해소했습니다. Closes #2784.
- HWP5 개체 공통 속성 attr **bit 2** 에 대응함을 한컴 원본 `samples/issue1949_giant_cell_nested_tables_perf.hwp`
  (OLE, FileHeader `HWP Document File` v5.1.1.0, admin/Windows_10)를 직접 파싱해 검증했습니다:
  bit 2 set 개체 = `tbl 1개 + eqed 5개`, 짝 HWPX 의 `affectLSpacing="1"` 개체(표1+수식5)와
  1:1 일치. 스펙 `mydocs/tech/한글문서파일형식_5.0_revision1.3.md:1482` 표 70 도 동일하게
  기술합니다.

## 변경 사항

- `src/model/shape.rs` — `CommonObjAttr.affect_line_spacing: bool` 필드 추가.
- `src/parser/control/shape.rs` — HWP5 bit 2 읽기.
- `src/document_core/converters/common_obj_attr_writer.rs` — HWPX 유래 합성 경로에서 bit 2
  팩(HWP5 양방향 보존).
- `src/parser/hwpx/section.rs` — 표/도형·그림/공통 개체를 읽는 4개 일반 `<hp:pos>` 루프에
  `affectLSpacing` arm 추가.
- `src/serializer/hwpx/{picture,shape,table}.rs` — 하드코딩 `"0"` → `bool01(common.affect_line_spacing)`.
- `src/serializer/hwpx/roundtrip.rs` — 표 HWPX serialize→parse 왕복 보존 테스트 추가.

## 레드→그린 (직접 실행)

`task2784_table_affect_line_spacing_roundtrips` 테스트로 파서·직렬화기 두 계층이 각각
load-bearing 임을 실제로 되돌려 확인했습니다(자세한 로그는 `mydocs/report/task_m100_2784_report.md` §4):

- table.rs 방출을 `"0"` 으로 되돌리면(파서는 그대로) → FAILED
- section.rs 의 표 pos 파서 arm 을 제거하면(직렬화기는 그대로) → FAILED
- 둘 다 원복하면 → 통과

## 검증

- `cargo check --all-targets --profile release-test` — 통과(다른 `CommonObjAttr {..}` 리터럴은
  모두 `..Default::default()` 사용이라 무영향).
- 신규 테스트 2건 개별 통과, `cargo test --tests --profile release-test --no-fail-fast` 전체
  1회 완주(실패 0, `hwpx_roundtrip_baseline`/`hwp5_roundtrip_baseline` 포함 정상 구동).
- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고/에러 0.
- 변경 `.rs` 8개 파일 `rustfmt --edition 2021` 적용, diff 는 커밋한 9개 파일에 한정.

## 범위 밖 (잔여)

`src/serializer/hwpx/section.rs` 의 공용 도형(`render_common_shape_xml`)·수식
(`render_equation`) 두 방출 지점은 동일 필드로 한 줄만 바꾸면 되지만, 해당 파일을 다른
작업이 동시 편집 중이라 충돌을 피하기 위해 이번 PR 에서 제외했습니다. issue1949 의 수식
5개 손실 회복은 이 잔여가 풀린 뒤의 후속 과제입니다.

## Done when

- CI 통과, 리뷰 반영 후 devel 병합.
