### PR TITLE
다중 선택 코너 리사이즈 확정 시 세로 배율 scaleX 재사용 수정

### DIFF
--- a/mydocs/report/task_m100_2823_report.md
+++ b/mydocs/report/task_m100_2823_report.md
@@ -1,0 +1,48 @@
+# 완료 보고서 — Task M100-2823
+
+- 이슈: #2823
+- 제목: 다중 선택 코너 리사이즈 확정 시 세로 배율이 가로 배율로 잘못 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-1-multiselect-corner-resize-scale-mismatch`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/engine/input-handler-picture.ts` 의 `finishPictureResizeDrag`
+다중 선택 리사이즈 확정 분기에서, 코너 핸들(`nw`/`ne`/`sw`/`se`) 드래그를 확정할 때
+세로 배율(`sy`) 계산식이 `scaleY` 가 아니라 `scaleX` 를 재사용하고 있었다.
+
+같은 파일의 라이브 프리뷰 담당 함수 `updatePictureResizeDrag` 는 코너에서
+`sx = scaleX`, `sy = scaleY` 를 독립적으로 적용하는데, `finishPictureResizeDrag`
+만 `sy` 에도 `scaleX` 를 대입해 두 함수가 어긋나 있었다. 그 결과 다중 선택 상태에서
+가로/세로 비율이 다르게 코너를 드래그하면, 드래그 중에는 정상적으로 독립 배율로
+커지다가 마우스를 놓는 순간 세로 크기가 가로 배율로 재계산되어 개체가 순간적으로
+튀는 버그가 발생했다.
+
+`git log -S` 로 확인한 결과 이 비대칭은 회전 리사이즈 개선 커밋(`e8e551e9`)에서
+도입된 이후 지금까지 남아 있었고, 오늘 수정된 #2717/#2720/#2756/#2759/#2766/#2776
+범위와는 겹치지 않는다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/engine/input-handler-picture.ts`
+  - `finishPictureResizeDrag` 다중 선택 코너 분기의 `sy` 계산식을
+    `isCorner ? scaleX : ...` 에서 `isCorner ? scaleY : ...` 로 수정 (1줄).
+- `rhwp-studio/tests/multiselect-corner-resize-scale.test.ts` (신규)
+  - 소스 가드 테스트: `finishPictureResizeDrag` 의 `sy` 계산식이 코너에서
+    `scaleY` 를 사용하는지 정적으로 확인해 재발(scaleX 복붙 실수)을 차단한다.
+
+## 3. 검증 결과
+
+통과:
+
+- `npm test` (500개 중 499 통과, 신규 테스트 포함 전부 통과. 유일한 실패는
+  기존에 알려진 pre-existing 실패 `tests/cell-flow-boundary.test.ts` — 이번
+  변경과 무관)
+- `npx tsc --noEmit` (baseline과 동일하게 `@wasm/rhwp.js` 관련 TS2307 2건만
+  존재, 신규 타입 에러 0건)
+
+## 4. 범위 및 제약
+
+- TypeScript 파일만 수정했다 (`.rs` 파일 변경 없음).
+- 단일 개체 리사이즈(`calcResizedBboxRotated` 경로)와 다중 선택의 코너가 아닌
+  측면(`n`/`s`/`e`/`w`) 리사이즈는 이번 변경의 영향을 받지 않는다.

--- a/rhwp-studio/src/engine/input-handler-picture.ts
+++ b/rhwp-studio/src/engine/input-handler-picture.ts
@@ -886,7 +886,7 @@ export function finishPictureResizeDrag(this: any, e: MouseEvent): void {
         const relX = r.bboxX - origX;
         const relY = r.bboxY - origY;
         const sx = isCorner ? scaleX : (state.dir === 'n' || state.dir === 's' ? 1 : scaleX);
-        const sy = isCorner ? scaleX : (state.dir === 'e' || state.dir === 'w' ? 1 : scaleY);
+        const sy = isCorner ? scaleY : (state.dir === 'e' || state.dir === 'w' ? 1 : scaleY);
         const newPx = newOrigX + relX * sx;
         const newPy = newOrigY + relY * sy;
         const deltaH = Math.round((newPx - r.bboxX) * PX2HWP);

--- a/rhwp-studio/tests/multiselect-corner-resize-scale.test.ts
+++ b/rhwp-studio/tests/multiselect-corner-resize-scale.test.ts
@@ -1,0 +1,22 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Issue #2823] 다중 선택 코너 리사이즈: 드래그 확정(finishPictureResizeDrag)이 라이브 프리뷰
+// (updatePictureResizeDrag)와 동일하게 코너에서 scaleX/scaleY 를 독립적으로 적용해야 한다.
+// 회귀 시 finish 단계에서 sy 에 scaleX 가 재사용되어(복붙 실수) 세로 크기가 가로 배율로
+// 잘못 스냅되며, 라이브 프리뷰와 확정 결과가 어긋난다. 소스 가드로 재발을 막는다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/engine/input-handler-picture.ts'), 'utf8');
+
+test('finishPictureResizeDrag 다중 선택 코너 분기는 sy 에 scaleY 를 사용한다', () => {
+  const start = src.indexOf('export function finishPictureResizeDrag');
+  assert.notEqual(start, -1, 'finishPictureResizeDrag 가 존재해야 함');
+  const idx = src.indexOf("const sy = isCorner ?", start);
+  assert.notEqual(idx, -1, 'sy 계산식을 찾아야 함');
+  const line = src.slice(idx, src.indexOf('\n', idx));
+  assert.match(line, /isCorner \? scaleY/, 'sy 는 코너일 때 scaleY 를 사용해야 함(scaleX 재사용 회귀 방지)');
+});


### PR DESCRIPTION
## 요약

다중 선택 상태에서 코너 핸들(nw/ne/sw/se) 로 리사이즈를 드래그하고 마우스를 놓으면, 세로 크기가 세로 배율(scaleY)이 아니라 가로 배율(scaleX)로 재계산되어 드래그 중 라이브 프리뷰와 확정 결과가 어긋나는 버그를 수정합니다.

`rhwp-studio/src/engine/input-handler-picture.ts` 의 `finishPictureResizeDrag` 다중 선택 코너 분기에서 `sy` 계산식이 `scaleY` 대신 `scaleX` 를 재사용하고 있었습니다 (`updatePictureResizeDrag` 라이브 프리뷰는 이미 `sx=scaleX`, `sy=scaleY` 로 올바르게 독립 계산합니다). `git log -S` 확인 결과 이 비대칭은 `e8e551e9` 커밋에서 도입된 이후 남아 있었습니다.

Fixes #2823

## 변경 사항

- `rhwp-studio/src/engine/input-handler-picture.ts`: `finishPictureResizeDrag` 다중 선택 코너 분기의 `sy` 계산식을 `scaleY` 로 수정 (1줄).
- `rhwp-studio/tests/multiselect-corner-resize-scale.test.ts` (신규): 해당 계산식이 `scaleY` 를 사용하는지 정적으로 확인하는 소스 가드 테스트.
- `mydocs/report/task_m100_2823_report.md` (신규): 완료 보고서.

## 검증

- [x] `npm test` — 500개 중 499 통과 (유일 실패는 기존에 알려진 pre-existing `tests/cell-flow-boundary.test.ts`, 이번 변경과 무관), 신규 테스트 포함 전부 통과
- [x] `npx tsc --noEmit` — baseline과 동일하게 `@wasm/rhwp.js` 관련 TS2307 2건만 존재, 신규 타입 에러 0건

## 범위

TypeScript 파일만 수정했습니다 (`.rs` 파일 변경 없음). 단일 개체 리사이즈 및 다중 선택의 측면(n/s/e/w) 리사이즈는 영향받지 않습니다.