### PR TITLE
fix(hwpx): bullet paraHead 원본 splice로 align/useInstWidth/widthAdjust 라운드트립 소실 해소

### DIFF
--- a/mydocs/report/task_m100_2828_report.md
+++ b/mydocs/report/task_m100_2828_report.md
@@ -1,0 +1,98 @@
+# Task m100-2828: HWPX bullet paraHead 라운드트립 소실 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2828
+
+## 근거
+
+`src/parser/hwpx/header.rs` 의 `parse_bullet_hwpx` (수정 전)는 `<hh:bullet>` 의
+`char`/`useImage` 두 속성만 읽고, 자식 `<hh:paraHead>` (align/useInstWidth/
+autoIndent/widthAdjust/textOffsetType/textOffset/numFormat/charPrIDRef/checkable
+9개 속성 보유, HWP5 BULLET record 표 44 문단 머리 정보 12바이트에 대응)를 통째로
+skip 했다. 그 결과 `src/serializer/hwpx/header.rs` 의 `write_bullet` (수정 전)은
+원본 값과 무관하게
+
+```rust
+("align", "LEFT"),
+("useInstWidth", "0"),
+("autoIndent", "1"),
+("widthAdjust", &b.width_adjust.to_string()), // 파서가 안 채우므로 항상 "0"
+("textOffsetType", "PERCENT"),
+("textOffset", "50"),                          // 하드코딩
+("numFormat", "DIGIT"),
+("charPrIDRef", &u32::MAX.to_string()),         // 하드코딩
+("checkable", "0"),
+```
+
+를 방출했다. 동일 클래스 결함이 `numbering`(`<hh:numbering>`/`<hh:paraHead>`)에서는
+이미 커밋 `3f564107`로 `raw_para_heads` 원본 구간 splice 방식으로 해소됐으나,
+`bullet` 에는 이 패턴이 적용돼 있지 않았다.
+
+`Bullet` 모델의 `attr`/`width_adjust`/`text_distance`/`char_shape_id` 필드는
+HWP5 바이너리 `parse_bullet`(`src/parser/doc_info.rs:825`)이 파싱하는 12바이트
+문단 머리 정보와 동일 의미이지만, HWPX 경로는 이 필드들을 전혀 채우지 않았다.
+
+## 재현 (수정 전, red)
+
+```rust
+let xml = r##"<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList><hh:bullets itemCnt="1">
+    <hh:bullet id="1" char="❏" useImage="0">
+      <hh:paraHead level="0" align="CENTER" useInstWidth="1" autoIndent="0"
+        widthAdjust="120" textOffsetType="PERCENT" textOffset="30"
+        numFormat="DIGIT" charPrIDRef="9" checkable="1"/>
+    </hh:bullet>
+  </hh:bullets></hh:refList>
+</hh:head>"##;
+let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+// 수정 전: bullets[0].width_adjust == 0, char_shape_id == 0 (유실)
+// write_bullet 재방출 시 align="CENTER"/useInstWidth="1" 등이 "LEFT"/"0" 으로 덮어써짐
+```
+
+## 수정 내용
+
+`numbering.raw_para_heads` 와 동일 패턴으로 `Bullet` 에
+`raw_para_head: Option<String>` 필드를 추가:
+
+1. `src/model/style.rs` — `Bullet::raw_para_head` 필드 추가.
+2. `src/parser/hwpx/header.rs` — `parse_bullet_hwpx` 가 `xml: &str` 를 추가로 받아
+   `<hh:paraHead>` 여는/닫는 태그 사이 원본 구간을 byte-exact 로 캡처해
+   `bullet.raw_para_head` 에 저장. 동시에 `apply_bullet_para_head_attrs` 로
+   `widthAdjust`/`textOffset`/`charPrIDRef` 를 `Bullet::width_adjust`/
+   `text_distance`/`char_shape_id` 필드로도 흡수(HWP5 경로 폴백용).
+3. `src/serializer/hwpx/header.rs` — `write_bullet` 이 `raw_para_head` 가 있으면
+   원본 그대로 splice, 없으면(HWP5→HWPX 경로 등) 필드값(`width_adjust`/
+   `text_distance`/`char_shape_id`)으로 채운 뼈대로 폴백.
+4. `src/parser/doc_info.rs`, `src/serializer/doc_info/tests.rs` — 새 필드 추가로 인한
+   `Bullet` 구조체 리터럴 2곳에 `raw_para_head: None` 보강(HWP5 바이너리 경로는
+   HWPX paraHead 원본이 없으므로 `None`이 올바름).
+
+## 검증 (green)
+
+새 테스트 `bullet_para_head_align_useinstwidth_survive_roundtrip_via_raw_splice`
+(`src/parser/hwpx/header.rs`)가 위 재현 XML로:
+
+- `bullet.raw_para_head` 가 원본 `<hh:paraHead .../>` 구간과 byte-exact 일치
+- `width_adjust == 120`, `text_distance == 30`, `char_shape_id == 9`
+
+를 확인한다.
+
+```
+test parser::hwpx::header::tests::bullet_para_head_align_useinstwidth_survive_roundtrip_via_raw_splice ... ok
+test serializer::doc_info::tests::test_serialize_bullet_layout_and_roundtrip ... ok
+test renderer::pua_oldhangul::tests::test_no_collision_with_pua_bullet_range ... ok
+test renderer::layout::tests::test_square_bullet_with_space_preserves_layout ... ok
+
+test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2486 filtered out
+```
+
+`cargo build --lib` 통과, `cargo clippy --all-targets --profile release-test -- -D warnings`
+경고 0건, `rustfmt --edition 2021 --check` 통과.
+
+## 잔여 범위
+
+`checkable`/`align`/`useInstWidth`/`autoIndent`/`textOffsetType` 는 `Bullet` 의
+7수준 전용 필드로는 표현하지 않고 `raw_para_head` 원본 splice로만 보존한다
+(numbering 과 동일한 설계 선택). 여러 `<hh:paraHead>`/`<hh:img>` 자식을 동시에 갖는
+케이스도 splice 구간에 전부 포함되므로 별도 처리 불필요.

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -354,6 +354,10 @@ pub struct Bullet {
     pub image_data: [u8; 4],
     /// 체크 글머리표 문자
     pub check_bullet_char: char,
+    /// HWPX `<hh:bullet>` 자식 `<hh:paraHead>`(+`<hh:img>`) 원본 구간 (무손실 splice 용).
+    /// align/useInstWidth/autoIndent/textOffsetType/checkable 등 7수준 필드로 표현
+    /// 못하는 HWPX 전용 속성 보존. [#2790]
+    pub raw_para_head: Option<String>,
 }
 
 /// 텍스트 정렬 방식

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -854,6 +854,7 @@ fn parse_bullet(data: &[u8]) -> Result<Bullet, DocInfoError> {
         image_bullet,
         image_data,
         check_bullet_char,
+        raw_para_head: None,
     })
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -159,7 +159,7 @@ pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxErro
                     // paragraph 에 자동 부여. HWPX `<hh:bullet id="N" char="❏" useImage="0">`
                     // 4개 → HWP BULLET record 4개. 누락 시 일반 문단 시작 글머리표 부작용.
                     b"bullet" => {
-                        let bullet = parse_bullet_hwpx(e, &mut reader)?;
+                        let bullet = parse_bullet_hwpx(e, &mut reader, xml)?;
                         doc_info.bullets.push(bullet);
                     }
                     _ => {}
@@ -1725,6 +1725,7 @@ fn parse_tab_def(
 fn parse_bullet_hwpx(
     e: &quick_xml::events::BytesStart,
     reader: &mut Reader<&[u8]>,
+    xml: &str,
 ) -> Result<Bullet, HwpxError> {
     let mut bullet = Bullet::default();
 
@@ -1748,25 +1749,63 @@ fn parse_bullet_hwpx(
         }
     }
 
-    // 자식 <hh:paraHead>, <hh:image> 등 skip
+    // 자식 <hh:paraHead>(align/useInstWidth/widthAdjust/textOffset/charPrIDRef 등),
+    // <hh:image> 를 순회. widthAdjust/textOffset/charPrIDRef 는 Bullet 필드로 흡수하고,
+    // 7수준 모델로 표현 못하는 나머지 속성(align/useInstWidth/autoIndent/checkable 등)은
+    // numbering.raw_para_heads(#2695 계열)와 같은 방식으로 원본 구간을 통째로 보존해
+    // 직렬화 시 splice 한다(무손실 라운드트립).
     if !is_empty_event(e) {
+        let inner_start = reader.buffer_position() as usize;
+        let mut inner_end = inner_start;
         let mut buf = Vec::new();
         loop {
+            let pos_before = reader.buffer_position() as usize;
             match reader.read_event_into(&mut buf) {
+                Ok(Event::Empty(ref ce)) => {
+                    if local_name(ce.name().as_ref()) == b"paraHead" {
+                        apply_bullet_para_head_attrs(&mut bullet, ce);
+                    }
+                }
+                Ok(Event::Start(ref ce)) => {
+                    if local_name(ce.name().as_ref()) == b"paraHead" {
+                        apply_bullet_para_head_attrs(&mut bullet, ce);
+                    }
+                }
                 Ok(Event::End(ref ee)) => {
                     if local_name(ee.name().as_ref()) == b"bullet" {
+                        inner_end = pos_before;
                         break;
                     }
                 }
-                Ok(Event::Eof) => break,
+                Ok(Event::Eof) => {
+                    inner_end = pos_before;
+                    break;
+                }
                 Err(e) => return Err(HwpxError::XmlError(format!("bullet: {}", e))),
                 _ => {}
             }
             buf.clear();
         }
+
+        if inner_end >= inner_start && inner_end <= xml.len() {
+            bullet.raw_para_head = Some(xml[inner_start..inner_end].to_string());
+        }
     }
 
     Ok(bullet)
+}
+
+/// `<hh:bullet>` 자식 `<hh:paraHead>` 의 widthAdjust/textOffset/charPrIDRef 를
+/// Bullet 필드(HWP5 BULLET record 의 문단 머리 정보 12바이트와 동일 의미)로 흡수한다.
+fn apply_bullet_para_head_attrs(bullet: &mut Bullet, e: &quick_xml::events::BytesStart) {
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"charPrIDRef" => bullet.char_shape_id = parse_u32(&attr),
+            b"widthAdjust" => bullet.width_adjust = parse_i16(&attr),
+            b"textOffset" => bullet.text_distance = parse_i16(&attr),
+            _ => {}
+        }
+    }
 }
 
 fn parse_numbering(
@@ -2167,6 +2206,26 @@ mod tests {
             doc_info.numberings[0].raw_para_heads.as_deref(),
             Some(inner)
         );
+    }
+
+    #[test]
+    fn bullet_para_head_align_useinstwidth_survive_roundtrip_via_raw_splice() {
+        // [#2790] 종전 parse_bullet_hwpx 는 char/useImage 만 읽고 <hh:paraHead> 를
+        // 통째로 skip 했다. 그 결과 align="CENTER"/useInstWidth="1" 처럼 기본값과
+        // 다른 원본 값이 직렬화 시 항상 "LEFT"/"0" 로 하드코딩돼 소실됐다.
+        // raw_para_head splice 로 원본 구간이 byte-exact 보존되는지 확인한다.
+        let inner = r##"<hh:paraHead level="0" align="CENTER" useInstWidth="1" autoIndent="0" widthAdjust="120" textOffsetType="PERCENT" textOffset="30" numFormat="DIGIT" charPrIDRef="9" checkable="1"/>"##;
+        let xml = format!(
+            r##"<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head"><hh:refList><hh:bullets itemCnt="1"><hh:bullet id="1" char="❏" useImage="0">{inner}</hh:bullet></hh:bullets></hh:refList></hh:head>"##
+        );
+
+        let (doc_info, _) = parse_hwpx_header(&xml).unwrap();
+        let bullet = &doc_info.bullets[0];
+
+        assert_eq!(bullet.raw_para_head.as_deref(), Some(inner));
+        assert_eq!(bullet.width_adjust, 120);
+        assert_eq!(bullet.text_distance, 30);
+        assert_eq!(bullet.char_shape_id, 9);
     }
 
     #[test]

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -623,6 +623,7 @@ fn test_serialize_bullet_layout_and_roundtrip() {
         image_bullet: 0,
         image_data: [0; 4],
         check_bullet_char: '\0',
+        raw_para_head: None,
     };
 
     // 레이아웃: 문단 머리 정보 12바이트 후 offset 12 에 bullet_char

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -950,23 +950,33 @@ fn write_bullet<W: Write>(
         "hh:bullet",
         &[("id", &id_s), ("char", &char_s), ("useImage", use_image)],
     )?;
-    // paraHead 뼈대 (파서는 무시하나 OWPML 유효성/한컴 호환 위해 방출).
-    empty_tag(
-        w,
-        "hh:paraHead",
-        &[
-            ("level", "0"),
-            ("align", "LEFT"),
-            ("useInstWidth", "0"),
-            ("autoIndent", "1"),
-            ("widthAdjust", &b.width_adjust.to_string()),
-            ("textOffsetType", "PERCENT"),
-            ("textOffset", "50"),
-            ("numFormat", "DIGIT"),
-            ("charPrIDRef", &u32::MAX.to_string()),
-            ("checkable", "0"),
-        ],
-    )?;
+    // 원본 HWPX paraHead 구간이 있으면(=이 파일에서 파싱된 bullet) 그대로 splice 해
+    // align/useInstWidth/autoIndent/textOffsetType/checkable 등 Bullet 필드로 표현
+    // 못하는 속성까지 무손실 복원(numbering.raw_para_heads 와 동일 패턴, #2790).
+    // 없으면(HWP5 경로 등) widthAdjust/textOffset/charPrIDRef 만 필드값으로 채운
+    // 뼈대로 폴백.
+    if let Some(raw) = &b.raw_para_head {
+        w.get_mut()
+            .write_all(raw.as_bytes())
+            .map_err(|e| SerializeError::XmlError(format!("bullet paraHead splice: {e}")))?;
+    } else {
+        empty_tag(
+            w,
+            "hh:paraHead",
+            &[
+                ("level", "0"),
+                ("align", "LEFT"),
+                ("useInstWidth", "0"),
+                ("autoIndent", "1"),
+                ("widthAdjust", &b.width_adjust.to_string()),
+                ("textOffsetType", "PERCENT"),
+                ("textOffset", &b.text_distance.to_string()),
+                ("numFormat", "DIGIT"),
+                ("charPrIDRef", &b.char_shape_id.to_string()),
+                ("checkable", "0"),
+            ],
+        )?;
+    }
     end_tag(w, "hh:bullet")?;
     Ok(())
 }


### PR DESCRIPTION
## 요약

이슈 #2828

`<hh:bullet>` 의 자식 `<hh:paraHead>` (align/useInstWidth/autoIndent/widthAdjust/
textOffsetType/textOffset/numFormat/charPrIDRef/checkable)를 `parse_bullet_hwpx`
가 통째로 skip 하고 `write_bullet` 이 항상 `"LEFT"`/`"0"`/`u32::MAX` 등으로
하드코딩 재방출하던 문제를, `numbering.raw_para_heads` 와 동일한 원본 구간
byte-exact splice 패턴으로 해소했습니다.

## 근거 (code-cited)

- 파서: `src/parser/hwpx/header.rs` `parse_bullet_hwpx` (수정 전) — `char`/
  `useImage` 만 읽고 `<hh:paraHead>` 전체를 skip.
- 직렬화: `src/serializer/hwpx/header.rs` `write_bullet` (수정 전) — `align`/
  `useInstWidth`/`autoIndent`/`textOffsetType`/`textOffset`/`charPrIDRef`/
  `checkable` 이 전부 상수.
- 동일 클래스 결함이 `numbering`(`<hh:numbering>`/`<hh:paraHead>`)에서는 이미
  커밋 `3f564107`로 해소됐으나 `bullet` 에는 미적용.

## Red → Green

Red (수정 전, 코멘트에 재현 XML 포함): `bullets[0].width_adjust == 0`,
`char_shape_id == 0` 로 유실, 재직렬화 시 `align="CENTER"`/`useInstWidth="1"`
등 원본 값이 `"LEFT"`/`"0"` 으로 항상 덮어써짐.

Green: 신규 테스트
`bullet_para_head_align_useinstwidth_survive_roundtrip_via_raw_splice`
(`src/parser/hwpx/header.rs`)가 다음을 확인합니다.

```
test parser::hwpx::header::tests::bullet_para_head_align_useinstwidth_survive_roundtrip_via_raw_splice ... ok
test serializer::doc_info::tests::test_serialize_bullet_layout_and_roundtrip ... ok
test renderer::pua_oldhangul::tests::test_no_collision_with_pua_bullet_range ... ok
test renderer::layout::tests::test_square_bullet_with_space_preserves_layout ... ok

test result: ok. 4 passed; 0 failed; 0 ignored; 0 measured; 2513 filtered out
```

## 변경 파일

- `src/model/style.rs` — `Bullet::raw_para_head: Option<String>` 필드 추가
- `src/parser/hwpx/header.rs` — `parse_bullet_hwpx` 가 `xml: &str` 를 받아
  `<hh:paraHead>` 원본 구간을 byte-exact 캡처, `widthAdjust`/`textOffset`/
  `charPrIDRef` 는 `Bullet` 필드로도 흡수(HWP5 폴백용)
- `src/serializer/hwpx/header.rs` — `write_bullet` 이 `raw_para_head` 있으면
  splice, 없으면 필드값 기반 뼈대로 폴백
- `src/parser/doc_info.rs`, `src/serializer/doc_info/tests.rs` — 신규 필드로 인한
  `Bullet` 구조체 리터럴 2곳에 `raw_para_head: None` 보강

## 검증

- `cargo build --lib` 통과
- `cargo test --lib bullet` 4건 통과 (신규 1건 포함)
- `cargo clippy --all-targets --profile release-test -- -D warnings` 경고 0건
- `rustfmt --edition 2021 --check` 통과

## 문서

`mydocs/report/task_m100_2828_report.md`