### PR TITLE
fix(studio): 문단 번호 대화상자 시작 번호를 1~999로 clamp

### DIFF
--- a/mydocs/report/task_m100_2838_report.md
+++ b/mydocs/report/task_m100_2838_report.md
@@ -1,0 +1,77 @@
+# Task m100-2838: numbering-dialog 시작 번호 clamp 누락 수정
+
+## 관련 이슈
+
+edwardkim/rhwp #2838
+
+## 버그
+
+`rhwp-studio/src/ui/numbering-dialog.ts`의 문단 번호 대화상자 "시작 번호" `<input type="number">`는
+`min="1"` `max="999"` HTML 속성을 갖고 있었지만(364~365행), 이 다이얼로그는 `<form>` submit 흐름 없이
+`input` 이벤트만으로 상태를 갱신하므로 브라우저가 min/max를 강제하지 않았다.
+
+기존 핸들러:
+
+```ts
+startInput.addEventListener('input', () => {
+  this.startNumber = parseInt(startInput.value) || 1;
+  this.updatePreview();
+});
+```
+
+`|| 1`은 `NaN`(빈 문자열 등)만 걸러내며, `0`/`-5`/`100000` 같은 유효한 정수는 그대로
+`this.startNumber`에 반영되고, `onConfirm()`에서 `JSON.stringify({ ..., startNumber: this.startNumber })`로
+`wasm.createNumbering()` 호출에 그대로 실려 Rust WASM 엔진까지 전달된다.
+
+## 원인
+
+입력 검증이 HTML 속성 선언에만 의존했고, 실제 상태를 갱신하는 JS 핸들러에는 범위 clamp 로직이
+없었다. `formatNumber()`(93~120행)는 이미 여러 포맷 코드에서 `num >= 1 && num <= N` 가드를
+반복적으로 두고 있어, 코드베이스가 "1 이상의 유효 범위"를 전제하고 있음을 보여준다 — 그런데
+정작 값의 유일한 입력 지점에는 동일한 가드가 없었다.
+
+## 수정
+
+`rhwp-studio/src/ui/numbering-dialog.ts`의 `input` 핸들러에서 `parseInt` 결과를
+`Math.min(999, Math.max(1, parsed))`로 clamp한 뒤 `this.startNumber`에 대입하도록 변경.
+
+```ts
+startInput.addEventListener('input', () => {
+  const parsed = parseInt(startInput.value) || 1;
+  this.startNumber = Math.min(999, Math.max(1, parsed));
+  this.updatePreview();
+});
+```
+
+## 테스트
+
+`rhwp-studio/tests/numbering-dialog-start-clamp.test.ts` 신규 추가 — 소스 가드 테스트로,
+`startInput` input 핸들러 본문에 `Math.min(999, Math.max(1, ...))` clamp 패턴이 존재하는지
+정규식으로 확인한다.
+
+### Red (수정 전, `git stash`로 원본 재현)
+
+```
+✖ numbering-dialog.ts 시작 번호 input 핸들러는 1~999로 clamp한다 (3.9077ms)
+AssertionError: startNumber 대입 전에 Math.min(999, Math.max(1, ...)) clamp가 있어야 함
+```
+
+### Green (수정 후)
+
+```
+npm test
+ℹ tests 500
+ℹ pass 499
+ℹ fail 1   (cell-flow-boundary.test.ts — 기존에 알려진 사전 실패, 이번 변경과 무관)
+```
+
+새로 추가한 `numbering-dialog-start-clamp.test.ts`는 통과.
+
+## tsc 베이스라인 확인
+
+```
+npx tsc --noEmit
+```
+
+기존과 동일하게 TS2307 에러 2건만 존재 (`@wasm/rhwp.js` 모듈 미해결, WASM 빌드 산출물 부재로 인한
+사전 존재 에러). 이번 변경으로 새로 발생한 에러 없음.

--- a/rhwp-studio/src/ui/numbering-dialog.ts
+++ b/rhwp-studio/src/ui/numbering-dialog.ts
@@ -366,7 +366,10 @@ export class NumberingDialog extends ModalDialog {
     startInput.style.width = '60px';
     startInput.disabled = this.restartMode !== 2;
     startInput.addEventListener('input', () => {
-      this.startNumber = parseInt(startInput.value) || 1;
+      const parsed = parseInt(startInput.value) || 1;
+      // WASM createNumbering으로 넘어가기 전에 min/max(1~999) 범위로 clamp한다.
+      // (input의 min/max HTML 속성은 이 다이얼로그에 <form> submit 흐름이 없어 강제되지 않음)
+      this.startNumber = Math.min(999, Math.max(1, parsed));
       this.updatePreview();
     });
     startSection.appendChild(startLabel);

--- a/rhwp-studio/tests/numbering-dialog-start-clamp.test.ts
+++ b/rhwp-studio/tests/numbering-dialog-start-clamp.test.ts
@@ -1,0 +1,27 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Issue #2838] numbering-dialog.ts '시작 번호' input(min=1,max=999)이 값 변경 시
+// 범위를 clamp하지 않고 WASM createNumbering으로 그대로 전달되던 검증 누락 버그의 회귀 가드.
+//
+// 이 다이얼로그는 <form> submit 흐름이 없어 HTML min/max 속성이 강제되지 않으므로,
+// input 이벤트 핸들러 자체가 1~999 범위로 clamp해야 한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/ui/numbering-dialog.ts'), 'utf8');
+
+test('numbering-dialog.ts 시작 번호 input 핸들러는 1~999로 clamp한다', () => {
+  const handlerMatch = src.match(
+    /startInput\.addEventListener\('input', \(\) => \{([\s\S]*?)\}\);/,
+  );
+  assert.ok(handlerMatch, 'startInput input 핸들러를 찾을 수 없음');
+  const body = handlerMatch![1];
+  assert.match(
+    body,
+    /Math\.min\(\s*999\s*,\s*Math\.max\(\s*1\s*,/,
+    'startNumber 대입 전에 Math.min(999, Math.max(1, ...)) clamp가 있어야 함',
+  );
+});


### PR DESCRIPTION
## 요약

- `numbering-dialog.ts`의 "시작 번호" input이 `min="1"`/`max="999"` HTML 속성만 있고 `<form>` submit 흐름이 없어 실제로는 범위가 강제되지 않던 문제를 수정합니다.
- `input` 이벤트 핸들러가 `parseInt` 결과를 그대로 `startNumber`에 대입해, 0/음수/999 초과 값이 검증 없이 `wasm.createNumbering()` JSON 페이로드에 실려 WASM 엔진까지 전달될 수 있었습니다.
- `Math.min(999, Math.max(1, parsed))`로 clamp하도록 수정했습니다.

관련 이슈: #2838

## 테스트

`rhwp-studio/tests/numbering-dialog-start-clamp.test.ts` 신규 추가 (소스 가드 테스트).

### Red (수정 전)

```
✖ numbering-dialog.ts 시작 번호 input 핸들러는 1~999로 clamp한다
AssertionError: startNumber 대입 전에 Math.min(999, Math.max(1, ...)) clamp가 있어야 함
```

### Green (수정 후)

```
npm test
ℹ tests 500
ℹ pass 499
ℹ fail 1   (cell-flow-boundary.test.ts — 기존 사전 실패, 이번 변경과 무관 확인)
```

### tsc 베이스라인

```
npx tsc --noEmit
```
기존과 동일하게 `@wasm/rhwp.js` 모듈 관련 TS2307 에러 2건만 존재, 새 에러 없음.

상세 내용은 `mydocs/report/task_m100_2838_report.md` 참고.
