### PR TITLE
편집 용지·표/셀 속성 대화상자 숫자 입력 min clamp 누락 수정

### DIFF
--- a/mydocs/report/task_m100_2845_report.md
+++ b/mydocs/report/task_m100_2845_report.md
@@ -1,0 +1,48 @@
+# task_m100_2845 처리 보고
+
+## 이슈
+edwardkim/rhwp#2845 — 편집 용지·표/셀 속성 대화상자 숫자 입력: HTML min 속성이 있어도 JS clamp
+누락으로 음수가 WASM까지 전달됨.
+
+## 배경
+직전에 처리한 #2838(문단 번호 대화상자 시작 번호 clamp 누락)과 동일 패턴을 다른 대화상자에도
+찾아보라는 지시에 따라 `table-property-dialog.ts`(존재하지 않음 → 실질적으로 대응하는
+`table-cell-props-dialog.ts`), `bullet-dialog.ts`(존재하지 않음), `style-dialog.ts`,
+`page-setup-dialog.ts` 를 검사했다.
+
+## 조사 결과
+- `style-dialog.ts`: `type="number"` 입력 없음(해당 없음).
+- `table-create-dialog.ts`: 행/열 입력은 `Math.max(1, Math.min(256, ...))`로 이미 clamp됨(정상).
+- `table-row-column-dialog.ts`: `countInput`은 `min`/`max` HTML 속성 + `input` 이벤트에서
+  `clampInsertCount()`로 실제 clamp까지 수행(정상 — 대조군).
+- **`page-setup-dialog.ts`**: `numberInput()` 헬퍼가 `min='0'`만 설정하고 `max` 없음. `onConfirm()`이
+  `widthInput`/`heightInput`/`marginInputs[...]`의 `.value`를 검증 없이 `parseFloat` 후
+  `wasm.setPageDef()`로 전달 — **버그 확인**.
+- **`table-cell-props-dialog.ts`**: 동일한 `numberInput()` 헬퍼가 그대로 복제되어 있고, 셀 폭/높이/
+  안쪽여백, 표 안쪽여백/바깥여백/세로·가로 오프셋/캡션 폭/간격 등 최소 14개 필드가 검증 없이
+  `wasm.setCellProperties()` / `wasm.setTableProperties()`로 전달 — **버그 확인**.
+- 회전각/기울이기 입력(`rotInput`/`skewH`/`skewV`)은 `disabled=true`라 사용자 입력 경로가 없어
+  제외.
+
+## 수정
+두 파일의 `numberInput()` 헬퍼에 공통으로 `change` 리스너를 추가해, 생성된 `<input>`의
+`min`/`max` 속성값을 기준으로 `.value`를 실제로 clamp한다(빈 문자열은 통과시켜 기존
+`parseFloat(...) || 0` fallback과 충돌하지 않게 함). 헬퍼 하나만 고쳐서 두 대화상자가 쓰는
+모든 숫자 필드가 함께 방어된다.
+
+- `rhwp-studio/src/ui/page-setup-dialog.ts`
+- `rhwp-studio/src/ui/table-cell-props-dialog.ts`
+
+## 테스트
+`rhwp-studio/tests/dialog-numberinput-min-clamp.test.ts` 추가(소스 가드): 두 파일의
+`numberInput()` 함수 본문에 `change` 리스너 + `Math.min(max, Math.max(min, v))` clamp가
+있는지 정규식으로 검사.
+
+- 수정 전(가드): 테스트 실패(리스너 없음) — 로컬에서 red 확인 후 fix 적용.
+- 수정 후: `npm test` → 501 tests, 500 pass, 1 fail(`tests/cell-flow-boundary.test.ts`,
+  기존에도 실패하던 것으로 이번 변경과 무관 — baseline).
+- `npx tsc --noEmit` → 기존 baseline TS2307 2건(`@wasm/rhwp.js` 모듈 없음)만 남고 신규 에러 없음.
+
+## 커밋/PR
+- 브랜치: `task/m100-2845-dialog-number-min-clamp` (origin/devel 기준)
+- PR: edwardkim/rhwp 로 devel 대상 생성 예정.

--- a/rhwp-studio/src/ui/page-setup-dialog.ts
+++ b/rhwp-studio/src/ui/page-setup-dialog.ts
@@ -344,6 +344,18 @@ export class PageSetupDialog extends ModalDialog {
     inp.className = 'dialog-input';
     inp.step = '0.1';
     inp.min = '0';
+    // HTML min 속성은 .value 를 자동으로 clamp 하지 않는다(브라우저는 checkValidity()에서만
+    // 검사) — 음수·비정상 값이 그대로 parseFloat 되어 wasm.setPageDef 로 전달되는 것을 막는다.
+    // (#2838 번호매기기 시작 번호 clamp 누락과 동일 패턴)
+    inp.addEventListener('change', () => {
+      if (inp.value === '') return;
+      const min = inp.min !== '' ? parseFloat(inp.min) : -Infinity;
+      const max = inp.max !== '' ? parseFloat(inp.max) : Infinity;
+      const v = parseFloat(inp.value);
+      if (!Number.isFinite(v)) return;
+      const clamped = Math.min(max, Math.max(min, v));
+      if (clamped !== v) inp.value = String(clamped);
+    });
     return inp;
   }
 

--- a/rhwp-studio/src/ui/table-cell-props-dialog.ts
+++ b/rhwp-studio/src/ui/table-cell-props-dialog.ts
@@ -1525,6 +1525,18 @@ export class TableCellPropsDialog extends ModalDialog {
     inp.className = 'dialog-input';
     inp.step = '0.1';
     inp.min = '0';
+    // HTML min 속성은 .value 를 자동으로 clamp 하지 않는다(브라우저는 checkValidity()에서만
+    // 검사) — 음수·비정상 값이 그대로 parseFloat 되어 wasm.setCellProperties/setTableProperties
+    // 로 전달되는 것을 막는다. (#2838 번호매기기 시작 번호 clamp 누락과 동일 패턴)
+    inp.addEventListener('change', () => {
+      if (inp.value === '') return;
+      const min = inp.min !== '' ? parseFloat(inp.min) : -Infinity;
+      const max = inp.max !== '' ? parseFloat(inp.max) : Infinity;
+      const v = parseFloat(inp.value);
+      if (!Number.isFinite(v)) return;
+      const clamped = Math.min(max, Math.max(min, v));
+      if (clamped !== v) inp.value = String(clamped);
+    });
     return inp;
   }
 

--- a/rhwp-studio/tests/dialog-numberinput-min-clamp.test.ts
+++ b/rhwp-studio/tests/dialog-numberinput-min-clamp.test.ts
@@ -1,0 +1,49 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Issue #2845] page-setup-dialog.ts / table-cell-props-dialog.ts 의 공유 numberInput()
+// 헬퍼가 <input type="number" min="0"> 을 만들지만, HTML min 속성은 .value 를 자동
+// clamp하지 않는다(브라우저는 checkValidity() 호출 시에만 검사). onConfirm() 이
+// input.value 를 그대로 parseFloat 하여 wasm.setPageDef / setCellProperties /
+// setTableProperties 로 넘기므로, 직접 타이핑한 음수 값이 검증 없이 WASM까지 전달되던
+// 버그의 회귀 가드. numberInput() 자체가 change 시 min/max로 clamp해야 한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function readNumberInputBody(relPath: string): string {
+  const src = readFileSync(join(rootDir, relPath), 'utf8');
+  const match = src.match(/private numberInput\(\): HTMLInputElement \{([\s\S]*?)\n  \}/);
+  assert.ok(match, `${relPath}: numberInput() 정의를 찾을 수 없음`);
+  return match![1];
+}
+
+test('page-setup-dialog.ts numberInput()은 change 시 min/max로 값을 clamp한다', () => {
+  const body = readNumberInputBody('src/ui/page-setup-dialog.ts');
+  assert.match(
+    body,
+    /addEventListener\('change'/,
+    'numberInput()에 change 리스너가 있어야 함',
+  );
+  assert.match(
+    body,
+    /Math\.min\(max, Math\.max\(min, v\)\)/,
+    'change 리스너가 min/max로 값을 clamp해야 함',
+  );
+});
+
+test('table-cell-props-dialog.ts numberInput()은 change 시 min/max로 값을 clamp한다', () => {
+  const body = readNumberInputBody('src/ui/table-cell-props-dialog.ts');
+  assert.match(
+    body,
+    /addEventListener\('change'/,
+    'numberInput()에 change 리스너가 있어야 함',
+  );
+  assert.match(
+    body,
+    /Math\.min\(max, Math\.max\(min, v\)\)/,
+    'change 리스너가 min/max로 값을 clamp해야 함',
+  );
+});


### PR DESCRIPTION
## 요약
- #2845: `page-setup-dialog.ts` / `table-cell-props-dialog.ts`가 공유하는 `numberInput()` 헬퍼가
  `<input type="number" min="0">`을 만들지만 `.value`를 JS 단에서 clamp하지 않아, 직접 타이핑한
  음수가 검증 없이 `wasm.setPageDef` / `setCellProperties` / `setTableProperties`로 전달되던 문제
  (#2838과 동일 패턴)를 수정.
- `numberInput()`에 `change` 리스너를 추가해 `min`/`max` 속성 기준으로 실제 clamp 수행.

## 근거
이슈 #2845에 코드 인용과 재현 절차 기재.

## Red → Green
- 수정 전(`origin/devel` 기준): `numberInput()` 본문에 `change` 리스너 없음 확인
  (`git show origin/devel:rhwp-studio/src/ui/page-setup-dialog.ts` 정규식 검사 → false).
- 수정 후: 신규 소스 가드 테스트 `rhwp-studio/tests/dialog-numberinput-min-clamp.test.ts` pass.

## 테스트 계획
- [x] `cd rhwp-studio && npm test` → 501 tests, 500 pass, 1 fail(`tests/cell-flow-boundary.test.ts` —
      기존에도 실패하던 baseline, 이번 변경과 무관)
- [x] `npx tsc --noEmit` → 기존 baseline TS2307 2건(`@wasm/rhwp.js`)만 남고 신규 에러 없음
