### PR TITLE
fix(renderer): TAC 그림/도형 배치가 테두리 문단에서 margin_left 이중 가산 (#2835)

### DIFF
--- a/mydocs/report/task_m100_2835_report.md
+++ b/mydocs/report/task_m100_2835_report.md
@@ -1,0 +1,93 @@
+# Task #2835 처리 보고서 — TAC 그림/도형 배치 margin_left 이중 가산 수정
+
+## 배경
+
+이슈 #2835: 테두리(border) 있는 문단 안 treat-as-char(TAC) 그림/도형이 같은 문단
+본문 텍스트보다 `para_margin_left` 만큼 더 오른쪽으로 밀려 렌더링되는 결함.
+
+## 근본 원인
+
+`src/renderer/layout.rs` 의 TAC picture/shape 배치 경로(`layout_shape_item`
+계열, `effective_margin_left` 계산부)는 다음 조건에서 `para_margin_left` 를
+"inner padding" 명목으로 한 번 더 가산하고 있었다.
+
+```rust
+let has_visible_stroke = /* border_fill_id 로 실 stroke 판정 */;
+let inner_pad_left =
+    if has_visible_stroke && bs_left_px == 0.0 && bs_right_px == 0.0 {
+        para_margin_left
+    } else {
+        0.0
+    };
+let effective_margin_left = para_margin_left + para_indent + inner_pad_left; // (indent<=0 이면 indent 생략)
+```
+
+그러나 **같은 계산을 하던 `src/renderer/layout/paragraph_layout.rs`(본문 텍스트
+배치 경로)는 커밋 `a30dca73`("Task #544 v2 Stage 2: Phase A 재적용")에서 정확히
+이 `has_visible_stroke`/`bs_left_px`/`bs_right_px`/`inner_pad_left` 분기를
+"이중 inset 부작용"으로 판단해 완전히 제거**했다. 그 커밋 메시지:
+
+> `paragraph_layout.rs`: 1. inner_pad 분기 제거 (line 693~717 → 693~700, -22 LOC)
+> — `has_visible_stroke` / `bs_left_px` / `bs_right_px` / `inner_pad_left`/`right`
+> 변수 모두 제거 — `margin_left = box_margin_left` (단일 룰, 텍스트 inset 한 번만)
+
+`git show a30dca73 -- src/renderer/layout.rs` 결과가 비어있어, 이 수정이
+`layout.rs` 의 TAC picture/shape 경로에는 전혀 반영되지 않았음을 확인했다.
+즉 본문 텍스트는 `margin_left` 만 적용되도록 이미 고쳐졌는데, 같은 문단의
+TAC 그림/도형은 여전히 `margin_left` 를 두 번 적용받는 **형제(sibling)
+코드 경로 간 비대칭**이 남아 있었다.
+
+## 실측 재현
+
+`inner_pad_left` 계산 직후에 디버그 출력을 임시로 추가해
+`samples/exam_kor.hwp` 렌더링을 관찰한 결과, 최소 10개 문단
+(para_index/pi = 46, 50, 54, 56, 60, 63, 66, 70, 108, 111 — 대부분 페이지
+18(1-based)) 에서
+
+```
+inner_pad_left=11.33 para_margin_left=11.33
+```
+
+즉 `para_margin_left`(11.33px = ParaShape margin_left 1704 HU 환산치)가
+매 문단마다 그대로 이중 가산되고 있음을 확인했다. 코드 주석에도 "exam_kor
+p18 pi=50/56 의 [A]/[B] 표시기 옆 그림" 위치 결함으로 이미 알려진 증상이라고
+적혀 있어 이번 조사와 일치한다.
+
+## 수정
+
+- `has_visible_stroke`/`bs_left_px`/`bs_right_px`/`inner_pad_left` 분기를
+  완전히 제거.
+- `paragraph_layout.rs` 와 동일한 "margin_left(+indent) 단일 가산" 규칙을
+  `tac_picture_effective_margin_left(para_margin_left, para_indent)` 라는
+  작은 순수 함수로 추출해, 두 형제 경로가 향후에도 같은 로직을 공유하도록
+  구조화했다 (재발 방지).
+- `border_styles`/`BorderLineType` 조회 등 이제 불필요해진 코드도 함께 제거.
+
+## 검증 (Red → Green)
+
+`tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule`
+(`src/renderer/layout/tests.rs`) 테스트를 추가했다.
+
+- **RED**: 헬퍼 내부에 옛 버그(`inner_pad_left = para_margin_left` 를
+  무조건 추가 가산)를 임시로 재현했을 때 테스트 실패 확인
+  (`22.66 이 아니라 11.33 이어야 함` 단언 실패).
+- **GREEN**: 수정된 헬퍼(단일 가산)로 되돌린 후 테스트 통과 확인.
+
+```
+test renderer::layout::tests::tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule ... ok
+```
+
+- `cargo build --lib`: 통과, 경고 없음.
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과.
+- `rustfmt --edition 2021` 적용 후 `git diff --name-only` 는 의도한 2개
+  파일(`src/renderer/layout.rs`, `src/renderer/layout/tests.rs`)만 남음.
+
+## 변경 파일
+
+- `src/renderer/layout.rs`
+- `src/renderer/layout/tests.rs`
+
+## 참고
+
+- 관련 커밋(선행 수정): `a30dca73` (Task #544 v2 Stage 2)
+- 이슈: https://github.com/edwardkim/rhwp/issues/2835

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1212,6 +1212,22 @@ pub(crate) fn para_has_overlay_shape(para: &Paragraph) -> bool {
 /// 자리차지(TopAndBottom)·tac=true 는 개체가 흐름 공간을 실제로 차지하므로 제외.
 /// Shape/Picture 는 통과·글앞·글뒤만(Square 는 그림 좌우 흘림이 흔해 제외, 회귀 차단).
 /// Table 은 부동 배치가 어울림(Square) 표준이므로 어울림 포함.
+/// [Task #544 v2 정합] TAC picture/shape 배치 경로의 좌측 유효 margin 계산.
+///
+/// `paragraph_layout.rs` (커밋 a30dca73, Task #544 v2 Stage 2) 는 본문 텍스트 경로에서
+/// `has_visible_stroke && border_spacing[0]==[1]==0` 조건에 `box_margin_left` 를 inner
+/// padding 명목으로 한 번 더 가산하던 분기를 이중 inset 부작용으로 판단해 완전히
+/// 제거했다 (`margin_left = box_margin_left` 단일 룰). 본 함수는 TAC picture/shape
+/// 배치 경로가 그 규칙과 동일한 값을 쓰도록 통일한다 — border/stroke 유무는 더 이상
+/// 좌측 margin 계산에 관여하지 않는다.
+pub(crate) fn tac_picture_effective_margin_left(para_margin_left: f64, para_indent: f64) -> f64 {
+    if para_indent > 0.0 {
+        para_margin_left + para_indent
+    } else {
+        para_margin_left
+    }
+}
+
 pub(crate) fn para_is_floating_overlay_anchor(para: &Paragraph) -> bool {
     use crate::model::shape::TextWrap;
     if !para.text.trim().is_empty() || para.controls.is_empty() {
@@ -7586,45 +7602,18 @@ impl LayoutEngine {
                         // Task #347: 첫 줄 effective_margin (hanging indent: indent<0 → first-line은 margin_left만 적용)
                         let para_margin_left = para_style_ref.map(|s| s.margin_left).unwrap_or(0.0);
                         let para_indent = para_style_ref.map(|s| s.indent).unwrap_or(0.0);
-                        // [Task #534] paragraph_layout 의 effective_margin_left 정합:
-                        // visible stroke 보유 + border_spacing[0,1]=0 인 paragraph 는
-                        // box_margin_left 를 inner padding 으로 추가 가산 (paragraph_layout.rs
-                        // line 711-716 와 동일). wrap_host (Square wrap 표 보유) paragraph 는
-                        // paragraph_layout 미호출되어 본 경로만 emit → inner_pad 누락 시
-                        // 위치 결함 (예: exam_kor p18 pi=50/56 의 [A]/[B] 표시기 옆 그림).
-                        let para_border_fill_id_pre =
-                            para_style_ref.map(|s| s.border_fill_id).unwrap_or(0);
-                        let has_visible_stroke = if para_border_fill_id_pre > 0 {
-                            let idx = (para_border_fill_id_pre as usize).saturating_sub(1);
-                            styles
-                                .border_styles
-                                .get(idx)
-                                .map(|bs| {
-                                    bs.borders.iter().any(|b| {
-                                        !matches!(
-                                            b.line_type,
-                                            crate::model::style::BorderLineType::None
-                                        ) && b.width > 0
-                                    })
-                                })
-                                .unwrap_or(false)
-                        } else {
-                            false
-                        };
-                        let bs_left_px = para_style_ref.map(|s| s.border_spacing[0]).unwrap_or(0.0);
-                        let bs_right_px =
-                            para_style_ref.map(|s| s.border_spacing[1]).unwrap_or(0.0);
-                        let inner_pad_left =
-                            if has_visible_stroke && bs_left_px == 0.0 && bs_right_px == 0.0 {
-                                para_margin_left
-                            } else {
-                                0.0
-                            };
-                        let mut effective_margin_left = if para_indent > 0.0 {
-                            para_margin_left + para_indent + inner_pad_left
-                        } else {
-                            para_margin_left + inner_pad_left
-                        };
+                        // [Task #544 v2 정합] paragraph_layout.rs (a30dca73, Task #544 v2 Stage 2)
+                        // 는 has_visible_stroke / bs_left_px / bs_right_px 를 보고
+                        // box_margin_left 를 inner padding 으로 한 번 더 가산하던 분기를
+                        // 이중 inset 부작용으로 판단해 완전히 제거했다 (margin_left =
+                        // box_margin_left 단일 룰, PDF 정합 확인됨). 본 TAC picture/shape
+                        // 경로는 그 수정이 반영되지 않아 테두리 있는 문단(has_visible_stroke)
+                        // + border_spacing[0]=[1]=0 조건에서 그림이 같은 문단의 텍스트보다
+                        // para_margin_left 만큼 더 오른쪽으로 밀리는 결함이 있었다
+                        // (exam_kor.hwp p18/pi=46,50,54,56... 실측 확인 — inner_pad_left=11.33px
+                        // 만큼 이중 가산). paragraph_layout.rs 와 동일하게 가산 없이 통일한다.
+                        let mut effective_margin_left =
+                            tac_picture_effective_margin_left(para_margin_left, para_indent);
                         // [Task #534 v2] LINE_SEG.column_start 는 Square wrap 인라인 표/그림이
                         // 좌측에 floating 시 표 영역 이후 텍스트 시작 위치를 HWP IR 가 인코딩.
                         // layout_shape_item 은 col_area.x 그대로 사용 → picture (TAC) 가 표

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -2220,3 +2220,36 @@ fn page_bg_image_only_on_section_first_page() {
     assert!(!image_rest, "구역 첫 쪽이 아니면 배경 이미지가 없어야 한다");
     assert!(color_rest, "이미지가 억제돼도 색 채우기는 유지되어야 한다");
 }
+
+/// [Task #2835] TAC picture/shape 배치 경로의 좌측 margin 이 paragraph_layout.rs
+/// (Task #544 v2, 커밋 a30dca73) 의 "margin_left 단일 가산" 규칙과 일치해야 한다.
+///
+/// 버그(수정 전): `has_visible_stroke && border_spacing[0]==[1]==0` 인 문단에서
+/// `inner_pad_left = para_margin_left` 를 추가로 더해 TAC 그림이 같은 문단의 본문
+/// 텍스트보다 `para_margin_left` 만큼 더 오른쪽으로 밀렸다 (exam_kor.hwp pi=46 등
+/// 실측 inner_pad_left=11.33px). 본 테스트는 `border_fill_id`/`border_spacing` 유무와
+/// 무관하게 `tac_picture_effective_margin_left` 가 `para_margin_left`(+indent) 만
+/// 반환해야 함을 검증한다.
+#[test]
+fn tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule() {
+    use super::tac_picture_effective_margin_left;
+
+    // 테두리(has_visible_stroke) + border_spacing=0 케이스 (버그 트리거 조건)여도
+    // margin_left 를 한 번만 반영해야 한다. 버그 있던 구현이라면 11.33 + 11.33 = 22.66.
+    let para_margin_left = 11.33;
+    assert!(
+        (tac_picture_effective_margin_left(para_margin_left, 0.0) - para_margin_left).abs() < 1e-9,
+        "border_spacing=0/유테두리 문단에서도 margin_left 를 한 번만 더해야 함 \
+         (이중 가산 버그: 22.66 이 아니라 11.33 이어야 함)"
+    );
+
+    // indent>0 (첫 줄 hanging indent) 이면 margin_left + indent 만 더해야 한다.
+    let para_indent = 13.23;
+    assert!(
+        (tac_picture_effective_margin_left(para_margin_left, para_indent)
+            - (para_margin_left + para_indent))
+            .abs()
+            < 1e-9,
+        "indent>0 이면 margin_left + indent 만 반영해야 함 (inner_pad 이중 가산 없이)"
+    );
+}


### PR DESCRIPTION
## 요약

이슈 #2835 — 테두리(border) 있는 문단 안 treat-as-char(TAC) 그림/도형이 같은
문단 본문 텍스트보다 `para_margin_left` 만큼 더 오른쪽으로 밀려 렌더링되는
결함을 수정합니다.

## 근본 원인

`src/renderer/layout.rs` 의 TAC picture/shape 배치 경로는
`has_visible_stroke && border_spacing[0]==[1]==0` 조건에서 `para_margin_left`
를 "inner padding" 명목으로 한 번 더 가산했습니다.

같은 계산을 하던 `src/renderer/layout/paragraph_layout.rs`(본문 텍스트 배치
경로)는 이미 커밋 `a30dca73`(Task #544 v2 Stage 2)에서 이 분기를 "이중 inset
부작용"으로 판단해 완전히 제거했습니다 (`margin_left = box_margin_left` 단일
룰). `git show a30dca73 -- src/renderer/layout.rs` 가 비어있어 그 수정이
`layout.rs` 의 TAC picture/shape 경로에는 반영되지 않았음을 확인했습니다 —
두 형제 코드 경로 간 비대칭이 남아 있던 것입니다.

실측(`samples/exam_kor.hwp`, 디버그 계측): 최소 10개 문단(pi=46,50,54,56,60,
63,66,70,108,111)에서 `inner_pad_left = para_margin_left = 11.33px` 가 매번
이중 가산되고 있음을 확인했습니다. 기존 코드 주석에도 "exam_kor p18
pi=50/56 의 [A]/[B] 표시기 옆 그림" 위치 결함으로 이미 알려진 증상이라고
적혀 있어 이번 조사와 일치합니다.

## 변경 사항

- `has_visible_stroke`/`bs_left_px`/`bs_right_px`/`inner_pad_left` 분기를
  완전히 제거.
- `paragraph_layout.rs` 와 동일한 "margin_left(+indent) 단일 가산" 규칙을
  `tac_picture_effective_margin_left(para_margin_left, para_indent)` 순수
  함수로 추출해 두 형제 경로가 항상 같은 로직을 공유하도록 구조화 (재발 방지).

## Red → Green

`tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule`
(`src/renderer/layout/tests.rs`) 테스트 추가.

- RED: 헬퍼 내부에 옛 버그(`inner_pad_left = para_margin_left` 무조건 가산)를
  임시 재현 → `22.66 이 아니라 11.33 이어야 함` 단언 실패.
- GREEN: 수정된 단일 가산 로직으로 복원 → 테스트 통과.

```
test renderer::layout::tests::tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule ... ok
```

## 검증

- `cargo build --lib`: 통과, 경고 없음
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과
- `rustfmt --edition 2021`: 적용, `git diff --name-only` 는 의도한 2개 파일만 남음

## 변경 파일

- `src/renderer/layout.rs`
- `src/renderer/layout/tests.rs`
- `mydocs/report/task_m100_2835_report.md`
