### PR TITLE
필드 이름 입력 길이 미검증으로 인한 CTRL_DATA 손상 방지 (#2851)

### DIFF
--- a/mydocs/report/task_m100_2851_report.md
+++ b/mydocs/report/task_m100_2851_report.md
@@ -1,0 +1,54 @@
+# task_m100_2851 처리 보고
+
+## 이슈
+
+#2851 — 필드 이름 입력 길이 미검증 → CTRL_DATA 길이 프리픽스 u16 캐스팅 랩어라운드로 저장 파일 손상
+
+## 근본 원인
+
+`rhwp-studio/src/ui/field-edit-dialog.ts`, `field-insert-dialog.ts`의 "필드 이름" 입력에는
+길이 제한이 없었다. 이 값은 `rhwp-studio/src/command/commands/edit.ts`,
+`insert.ts`를 거쳐 검증 없이 `wasm.updateClickHereProps` / `wasm.insertClickHereField`로
+전달되고, 최종적으로 `src/serializer/control.rs:160`의 `(nlen as u16)` 캐스팅으로 CTRL_DATA
+레코드의 길이 프리픽스에 기록된다. `nlen`(UTF-16 코드유닛 수)이 65536 이상이면 이 캐스팅이
+랩어라운드되어, 기록된 길이 프리픽스와 실제로 뒤에 쓰인 바이트 수가 어긋난 손상된 레코드가
+만들어진다.
+
+## 수정 범위 (`.rs` 미수정)
+
+작업 지시에 따라 Rust 직렬화기는 수정하지 않고, 손상 가능한 값이 wasm 호출까지 도달하지
+않도록 프런트엔드 다이얼로그 단계에서 막는다.
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`
+  - `MAX_FIELD_NAME_LEN = 250` 상수 추가(65536보다 충분히 작은 안전한 상한).
+  - `nameInput.maxLength`로 브라우저 레벨 제한.
+  - `onConfirm()`이 길이 초과 시 오류 라벨을 표시하고 `false`를 반환해 다이얼로그를 닫지
+    않도록 변경(기존에는 항상 `void`를 반환해 무조건 닫혔다).
+- `rhwp-studio/src/ui/field-insert-dialog.ts`
+  - 동일한 `MAX_FIELD_NAME_LEN` 가드를 `import`해 재사용, 동일 패턴 적용.
+
+## 테스트
+
+`rhwp-studio/tests/field-name-length-guard.test.ts` 신규 추가(소스 가드 방식):
+
+1. `MAX_FIELD_NAME_LEN`이 u16 랩어라운드 지점(65536)보다 작은지 확인.
+2. `FieldEditDialog.onConfirm`이 이름 길이 초과 시 `return false;` 경로를 갖는지 소스에서 확인.
+3. `FieldInsertDialog`도 동일 가드를 갖는지 확인.
+
+Red → Green:
+
+- 수정 전: `MAX_FIELD_NAME_LEN` 상수와 길이 가드 코드 자체가 없어 세 테스트 모두 실패.
+- 수정 후: 세 테스트 모두 통과.
+
+## 검증 결과
+
+- `npm test`: 502 tests, 501 pass, 1 fail — 실패한 테스트는 사전에 알려진
+  `tests/cell-flow-boundary.test.ts` 뿐이며 이번 변경과 무관하다.
+- `npx tsc --noEmit`: `TS2307` 2건(둘 다 `@wasm/rhwp.js` 모듈 선언 누락, 사전 known-issue) 외
+  신규 오류 없음.
+
+## 변경 파일
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`
+- `rhwp-studio/src/ui/field-insert-dialog.ts`
+- `rhwp-studio/tests/field-name-length-guard.test.ts` (신규)

--- a/rhwp-studio/src/ui/field-edit-dialog.ts
+++ b/rhwp-studio/src/ui/field-edit-dialog.ts
@@ -12,11 +12,23 @@ export interface ClickHereProps {
   editable: boolean;
 }
 
+/**
+ * 필드 이름의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 CTRL_DATA 레코드에 필드 이름 길이를
+ * `nlen as u16`으로 기록한다. 65536자 이상이면 이 캐스팅이 랩어라운드되어 길이
+ * 프리픽스와 실제 기록된 바이트 수가 어긋난 손상된 레코드가 만들어진다(#2851).
+ * `.rs`를 수정하지 않는 범위에서, 손상 가능한 값이 wasm 호출까지 도달하지 않도록
+ * 프런트엔드에서 훨씬 낮은 상한으로 미리 막는다.
+ */
+export const MAX_FIELD_NAME_LEN = 250;
+
 export class FieldEditDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
   private memoInput!: HTMLTextAreaElement;
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
+  private nameErrorLabel!: HTMLDivElement;
 
   /** 적용 콜백 */
   onApply: ((props: ClickHereProps) => void) | null = null;
@@ -93,7 +105,16 @@ export class FieldEditDialog extends ModalDialog {
     this.nameInput = document.createElement('input');
     this.nameInput.type = 'text';
     this.nameInput.className = 'field-edit-input';
+    this.nameInput.maxLength = MAX_FIELD_NAME_LEN;
     panel.appendChild(this.nameInput);
+
+    this.nameErrorLabel = document.createElement('div');
+    this.nameErrorLabel.className = 'field-edit-error';
+    this.nameErrorLabel.style.color = '#c00';
+    this.nameErrorLabel.style.fontSize = '11px';
+    this.nameErrorLabel.style.display = 'none';
+    this.nameErrorLabel.textContent = `필드 이름은 ${MAX_FIELD_NAME_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.nameErrorLabel);
 
     // ── 양식 모드에서 편집 가능(F) ──
     const editableRow = document.createElement('label');
@@ -109,7 +130,14 @@ export class FieldEditDialog extends ModalDialog {
     return body;
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): void | boolean {
+    if (this.nameInput.value.length > MAX_FIELD_NAME_LEN) {
+      this.nameErrorLabel.style.display = '';
+      this.nameInput.focus();
+      return false;
+    }
+    this.nameErrorLabel.style.display = 'none';
+
     if (this.onApply) {
       this.onApply({
         guide: this.guideInput.value,

--- a/rhwp-studio/src/ui/field-insert-dialog.ts
+++ b/rhwp-studio/src/ui/field-insert-dialog.ts
@@ -5,13 +5,14 @@
  * 양식 모드 편집 가능 여부를 입력한다.
  */
 import { ModalDialog } from './dialog';
-import type { ClickHereProps } from './field-edit-dialog';
+import { MAX_FIELD_NAME_LEN, type ClickHereProps } from './field-edit-dialog';
 
 export class FieldInsertDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
   private memoInput!: HTMLTextAreaElement;
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
+  private nameErrorLabel!: HTMLDivElement;
 
   onApply: ((props: ClickHereProps) => void) | null = null;
 
@@ -64,7 +65,16 @@ export class FieldInsertDialog extends ModalDialog {
     this.nameInput = document.createElement('input');
     this.nameInput.type = 'text';
     this.nameInput.className = 'field-edit-input';
+    this.nameInput.maxLength = MAX_FIELD_NAME_LEN;
     panel.appendChild(this.nameInput);
+
+    this.nameErrorLabel = document.createElement('div');
+    this.nameErrorLabel.className = 'field-edit-error';
+    this.nameErrorLabel.style.color = '#c00';
+    this.nameErrorLabel.style.fontSize = '11px';
+    this.nameErrorLabel.style.display = 'none';
+    this.nameErrorLabel.textContent = `필드 이름은 ${MAX_FIELD_NAME_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.nameErrorLabel);
 
     const editableRow = document.createElement('label');
     editableRow.className = 'field-edit-checkbox-row';
@@ -79,7 +89,14 @@ export class FieldInsertDialog extends ModalDialog {
     return body;
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): void | boolean {
+    if (this.nameInput.value.length > MAX_FIELD_NAME_LEN) {
+      this.nameErrorLabel.style.display = '';
+      this.nameInput.focus();
+      return false;
+    }
+    this.nameErrorLabel.style.display = 'none';
+
     this.onApply?.({
       guide: this.guideInput.value,
       memo: this.memoInput.value,

--- a/rhwp-studio/tests/field-name-length-guard.test.ts
+++ b/rhwp-studio/tests/field-name-length-guard.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2851: 필드 이름 입력 길이 미검증 → Rust 직렬화기(src/serializer/control.rs)의
+// `nlen as u16` 캐스팅 랩어라운드로 CTRL_DATA 레코드가 손상될 수 있었다.
+// `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출 전에
+// 이름 길이를 안전한 상한(MAX_FIELD_NAME_LEN)으로 막는지를 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const editSrc = readFileSync(path.join(dir, '../src/ui/field-edit-dialog.ts'), 'utf8');
+const insertSrc = readFileSync(path.join(dir, '../src/ui/field-insert-dialog.ts'), 'utf8');
+
+test('필드 이름 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const m = editSrc.match(/MAX_FIELD_NAME_LEN\s*=\s*(\d+)/);
+  assert.ok(m, 'MAX_FIELD_NAME_LEN 상수를 찾을 수 없음');
+  const limit = Number(m![1]);
+  assert.ok(limit > 0 && limit < 65536, `한도(${limit})가 u16 랩어라운드 지점보다 작아야 함`);
+});
+
+test('FieldEditDialog는 이름 길이 초과 시 onConfirm이 false를 반환해 다이얼로그를 닫지 않는다', () => {
+  assert.match(
+    editSrc,
+    /nameInput\.value\.length > MAX_FIELD_NAME_LEN[\s\S]{0,160}return false;/,
+  );
+});
+
+test('FieldInsertDialog도 동일한 이름 길이 가드를 갖는다', () => {
+  assert.match(
+    insertSrc,
+    /nameInput\.value\.length > MAX_FIELD_NAME_LEN[\s\S]{0,160}return false;/,
+  );
+  assert.match(insertSrc, /MAX_FIELD_NAME_LEN/);
+});


### PR DESCRIPTION
## 요약

#2851 — `FieldEditDialog`/`FieldInsertDialog`의 "필드 이름" 입력에 길이 검증이 없어, 매우 긴
이름이 `wasm.updateClickHereProps`/`wasm.insertClickHereField`로 그대로 전달되면
`src/serializer/control.rs`의 `nlen as u16` 캐스팅이 랩어라운드되어 CTRL_DATA 레코드가
손상될 수 있었다. `.rs`는 수정하지 않고, 손상 가능한 값이 wasm 호출까지 도달하지 않도록
프런트엔드 다이얼로그 단계에서 `MAX_FIELD_NAME_LEN(250)` 가드를 추가했다.

## Red → Green

- 수정 전(red): `rhwp-studio/tests/field-name-length-guard.test.ts`의 세 테스트 모두 실패
  (`MAX_FIELD_NAME_LEN` 상수와 길이 가드 코드가 존재하지 않음).
- 수정 후(green): 동일 테스트 3건 모두 통과.

## 변경 파일

- `rhwp-studio/src/ui/field-edit-dialog.ts` — `MAX_FIELD_NAME_LEN` 상수, `nameInput.maxLength`,
  `onConfirm()`이 초과 시 `false` 반환하도록 변경.
- `rhwp-studio/src/ui/field-insert-dialog.ts` — 동일 가드 재사용.
- `rhwp-studio/tests/field-name-length-guard.test.ts` — 신규 소스 가드 테스트.
- `mydocs/report/task_m100_2851_report.md` — 처리 결과 문서.

## 검증

- `npm test`: 502 tests, 501 pass, 1 fail(`tests/cell-flow-boundary.test.ts`, 사전 known-issue,
  이번 변경과 무관).
- `npx tsc --noEmit`: `TS2307` 2건(`@wasm/rhwp.js` 모듈 선언 누락, 사전 known-issue) 외 신규
  오류 없음.

closes #2851
