### PR TITLE
fix(hwpx): 바탕쪽 hp:subList textDirection 왕복 시 세로쓰기 유실 (#2846)

### DIFF
--- a/mydocs/report/task_m100_2846_report.md
+++ b/mydocs/report/task_m100_2846_report.md
@@ -1,0 +1,88 @@
+# 최종 결과 보고서 — Task M100 #2846
+
+## 이슈
+
+HWPX 바탕쪽(masterPage)의 `hp:subList@textDirection`(세로쓰기 여부)을 파서가 읽지 않고,
+직렬화기가 `"HORIZONTAL"`로 고정 출력하여, 세로쓰기 바탕쪽이 왕복 저장 시 가로쓰기로 바뀜.
+
+- Issue: https://github.com/edwardkim/rhwp/issues/2846
+- PR: (본 보고서 하단 참조)
+
+## 결론
+
+`MasterPage` IR에 `text_direction: u8` 필드(0=HORIZONTAL, 1=VERTICAL — 표 셀
+`cell.text_direction`과 동일 규약)를 추가하고, 파서(`parse_master_page_sub_list`)가
+`textDirection` 속성을 읽어 반영하도록, 직렬화기(`render_master_page_xml`)가 그 값을
+방출하도록 수정했다. HWP5 바이너리 경로는 이 개념이 없어 항상 0(HORIZONTAL)으로 채운다.
+
+## 결함 상세
+
+### 결함 위치 1 — `src/parser/hwpx/section.rs` `parse_master_page_sub_list` (수정 전)
+
+```rust
+fn parse_master_page_sub_list(e: &quick_xml::events::BytesStart, master_page: &mut MasterPage) {
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"textWidth" => master_page.text_width = parse_u32(&attr),
+            b"textHeight" => master_page.text_height = parse_u32(&attr),
+            b"hasTextRef" => master_page.text_ref = parse_u8(&attr),
+            b"hasNumRef" => master_page.num_ref = parse_u8(&attr),
+            _ => {}   // ← textDirection 이 여기로 떨어져 폐기됨
+        }
+    }
+}
+```
+
+### 결함 위치 2 — `src/serializer/hwpx/master_page.rs` `render_master_page_xml` (수정 전)
+
+```rust
+r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" ...>"#,
+```
+
+`textDirection="HORIZONTAL"`이 리터럴로 고정되어, IR에 값이 있어도(수정 전엔 아예 없음)
+반영할 자리가 없었다.
+
+### 스키마 근거
+
+`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml`의 `hp:ParaListType`(masterPage의
+`hp:subList`가 이를 따름)은 `textDirection` 속성을 `HORIZONTAL`/`VERTICAL`/`VERTICALALL`
+열거값으로 정의한다. 즉 존재하는 정식 스키마 속성이 파서·직렬화기 양쪽에서 누락돼 있었다.
+
+### 이미 같은 클래스로 고쳐진 선례
+
+표 셀 `textDirection`(파서 `subList`/`cellPr` 처리 주석: "세로쓰기 셀... 종전엔 vertAlign
+만 읽어 세로쓰기가 왕복 시 유실됐다")과 secPr 레벨 `text_direction`
+(`src/serializer/hwpx/section.rs` 100번 줄 부근)에서 동일 클래스 버그가 이미 수정됐다.
+바탕쪽의 `subList`는 이 두 지점에서 누락된 세 번째 자리였다. `pageFront`(커밋 `1c4510fa`)와
+같은 계열의 "바탕쪽 속성 왕복 유실" 버그.
+
+## 수정 내역
+
+| 파일 | 수정 |
+| --- | --- |
+| `src/model/header_footer.rs` | `MasterPage`에 `text_direction: u8` 필드 추가. |
+| `src/parser/hwpx/section.rs` | `parse_master_page_sub_list`가 `textDirection` 속성을 읽어 필드에 반영. |
+| `src/serializer/hwpx/master_page.rs` | `render_master_page_xml`이 `text_direction`에 따라 `HORIZONTAL`/`VERTICAL` 방출. 회귀 테스트 1개(`master_page_text_direction_round_trips`) 추가. |
+| `src/parser/body_text.rs` | HWP5 바이너리 `MasterPage` 생성 시 `text_direction: 0`(개념 없음) 명시. |
+
+## 검증 결과
+
+### red→green
+
+- **RED** (수정 전 상태로 확인): 파서가 `textDirection` 무시, 직렬화기가 `"HORIZONTAL"` 고정
+  — `text_direction` 필드 자체가 없어 컴파일 단계에서 결함이 드러남(필드 부재 확인).
+- **GREEN** (수정 후): `master_page_text_direction_round_trips` — `text_direction: 1`로
+  직렬화 → XML에 `textDirection="VERTICAL"` 포함 확인 → 재파싱 → `text_direction == 1`
+  보존 확인. `... ok`.
+
+### 빌드/전체 테스트
+
+1. `cargo build --lib` — 통과.
+2. `cargo test --lib master_page` — 25 passed, 0 failed (기존 바탕쪽 테스트 전부 회귀 없음).
+3. `cargo clippy --all-targets --profile release-test -- -D warnings` — 클린.
+4. `rustfmt --edition 2021` (변경 파일만) — 추가 diff 없음.
+
+## 후속 (범위 밖)
+
+- `VERTICALALL`(세로 영문 세움) 구분은 스키마상 별도 열거값이나, 표 셀 쪽 기존 구현도
+  VERTICAL/HORIZONTAL 이진 규약만 쓰고 있어 이번 수정도 동일 규약을 따름(기존 패턴과 일관).

--- a/src/model/header_footer.rs
+++ b/src/model/header_footer.rs
@@ -89,6 +89,11 @@ pub struct MasterPage {
     pub text_ref: u8,
     /// 번호 참조 비트맵
     pub num_ref: u8,
+    /// HWPX masterPage/hp:subList@textDirection. 0=HORIZONTAL, 1=VERTICAL.
+    ///
+    /// 세로쓰기 바탕쪽(예: 세로 제본 문서)의 subList가 VERTICAL로 저장되는데,
+    /// serializer 가 이를 읽지 않고 HORIZONTAL 로 고정 출력하면 왕복 시 세로쓰기가 유실된다.
+    pub text_direction: u8,
     /// HWPX masterPage@pageNumber.
     ///
     /// HWPX에서 이 값은 바탕쪽 내부 PAGE 필드의 치환 가능 여부를 판단하는 힌트로 쓰인다.

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -723,6 +723,7 @@ fn parse_master_pages_from_raw(raw_records: &[RawRecord]) -> Vec<MasterPage> {
             overlap,
             replace_base: false,
             ext_flags,
+            text_direction: 0, // HWP5 바이너리 바탕쪽엔 textDirection 개념 없음
             paragraphs,
             text_width,
             text_height,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -242,6 +242,12 @@ fn parse_master_page_sub_list(e: &quick_xml::events::BytesStart, master_page: &m
             b"textHeight" => master_page.text_height = parse_u32(&attr),
             b"hasTextRef" => master_page.text_ref = parse_u8(&attr),
             b"hasNumRef" => master_page.num_ref = parse_u8(&attr),
+            // 세로쓰기 바탕쪽(hp:subList@textDirection). serializer 는 항상
+            // HORIZONTAL 로 고정 출력하지만 종전엔 파서가 미독 →
+            // textDirection="VERTICAL" 바탕쪽이 왕복 시 가로쓰기로 바뀌었다.
+            b"textDirection" => {
+                master_page.text_direction = if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+            }
             _ => {}
         }
     }

--- a/src/serializer/hwpx/master_page.rs
+++ b/src/serializer/hwpx/master_page.rs
@@ -69,7 +69,7 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
         concat!(
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>"#,
             r#"<masterPage {xmlns} id="{id}" type="{ty}" pageNumber="{pn}" pageDuplicate="{pd}" pageFront="0">"#,
-            r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" hasTextRef="{tr}" hasNumRef="{nr}">"#,
+            r#"<hp:subList id="" textDirection="{td}" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" hasTextRef="{tr}" hasNumRef="{nr}">"#,
             "{body}",
             r#"</hp:subList></masterPage>"#,
         ),
@@ -78,6 +78,11 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
         ty = master_page_type_str(mp),
         pn = mp.hwpx_page_number.unwrap_or(0),
         pd = page_duplicate_str(mp),
+        td = if mp.text_direction == 1 {
+            "VERTICAL"
+        } else {
+            "HORIZONTAL"
+        },
         tw = mp.text_width,
         th = mp.text_height,
         tr = mp.text_ref,
@@ -92,4 +97,35 @@ pub fn render_master_page_refs(ids: &[String]) -> String {
     ids.iter()
         .map(|id| format!(r#"<hp:masterPage idRef="{id}"/>"#))
         .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::document::Document;
+
+    #[test]
+    fn master_page_text_direction_round_trips() {
+        // 세로쓰기 바탕쪽(hp:subList@textDirection="VERTICAL")이 render→parse 왕복에서
+        // 보존돼야 한다. 종전엔 serializer 가 textDirection="HORIZONTAL" 고정, 파서 미독으로
+        // 세로쓰기가 유실됐다.
+        let mp = MasterPage {
+            text_direction: 1,
+            ..Default::default()
+        };
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = render_master_page_xml(&mp, "0", &mut ctx);
+        assert!(
+            xml.contains(r#"textDirection="VERTICAL""#),
+            "textDirection=VERTICAL 방출: {xml}"
+        );
+
+        let parsed =
+            crate::parser::hwpx::section::parse_hwpx_master_page(&xml).expect("master page parse");
+        assert_eq!(
+            parsed.text_direction, 1,
+            "text_direction 이 왕복에서 보존돼야 함"
+        );
+    }
 }


### PR DESCRIPTION
## 요약

closes #2846

HWPX 바탕쪽(masterPage)의 `hp:subList@textDirection`(세로쓰기 여부)을 파서가 읽지 않고,
직렬화기가 `"HORIZONTAL"`로 고정 출력하여, 세로쓰기 바탕쪽이 왕복 저장 시 가로쓰기로 바뀌는
결함을 수정했습니다.

- `src/model/header_footer.rs`: `MasterPage`에 `text_direction: u8` 필드 추가 (0=HORIZONTAL, 1=VERTICAL — 표 셀 `cell.text_direction`과 동일 규약)
- `src/parser/hwpx/section.rs`: `parse_master_page_sub_list`가 `textDirection` 속성을 읽어 반영
- `src/serializer/hwpx/master_page.rs`: `render_master_page_xml`이 `text_direction`에 따라 `HORIZONTAL`/`VERTICAL` 방출 + 회귀 테스트 1개
- `src/parser/body_text.rs`: HWP5 바이너리 경로는 이 개념이 없어 `text_direction: 0`으로 명시

## red → green

- **RED**: 수정 전에는 `MasterPage`에 `text_direction` 필드 자체가 없어 세로쓰기 여부를 담을
  자리가 없었고, 직렬화기는 `textDirection="HORIZONTAL"`을 리터럴로 방출했습니다.
- **GREEN**: `master_page_text_direction_round_trips` 테스트 — `text_direction: 1`로 직렬화 →
  `textDirection="VERTICAL"` 방출 확인 → 재파싱 → `text_direction == 1` 보존 확인.

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib master_page` (25 passed, 0 failed, 기존 바탕쪽 테스트 회귀 없음)
- [x] `cargo clippy --all-targets --profile release-test -- -D warnings` (클린)
- [x] `rustfmt --edition 2021` (변경 파일만, 추가 diff 없음)

자세한 근거(코드 인용)와 조사 내역은 이슈 #2846 및 `mydocs/report/task_m100_2846_report.md` 참고.