### PR TITLE
fix(table): 행/열 삽입 후 local_resize_cell_widths/heights stale 인덱스 정리 (#2853)

### DIFF
--- a/mydocs/report/task_m100_2853_report.md
+++ b/mydocs/report/task_m100_2853_report.md
@@ -1,0 +1,45 @@
+# 완료 보고서 — Task M100-2853
+
+- 이슈: #2853
+- 제목: 표 행/열 삽입 시 local_resize_cell_widths/heights stale 인덱스 미정리 (#2832/#2843 동일 버그 클래스)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2853-insert-row-col-stale-local-resize`
+
+## 1. 완료 내용
+
+`insert_table_row_native`/`insert_table_column_native`(`src/document_core/commands/table_ops.rs`)에서
+`Table::insert_row()`/`Table::insert_column()` 호출 직후 `local_resize_cell_widths`/
+`local_resize_cell_heights`를 `clear()`하도록 수정했다.
+
+두 모델 함수 모두 새 셀을 `push()`한 뒤 `self.cells.sort_by_key(|c| (c.row, c.col))`로 전체 셀
+배열을 재정렬한다. `local_resize_cell_widths/heights`는 `Vec<(usize, u32)>`로 cell 배열 인덱스를
+직접 키로 쓰기 때문에, 재정렬 이전 인덱스가 재정렬 이후에는 다른 셀을 가리키거나 범위를
+벗어나는 stale 참조가 된다. 이는 #2832(PR #2841, 셀 병합)·#2843(PR #2849, 행 삭제)에서 이미
+확인·수정된 것과 동일한 버그 클래스이며, 이번 건은 그 세 번째·네 번째 사례(행 삽입/열 삽입)다.
+
+## 2. 주요 변경
+
+- `src/document_core/commands/table_ops.rs`
+  - `insert_table_row_native`: `table.insert_row(...)` 호출 직후 `local_resize_cell_widths`/
+    `local_resize_cell_heights` clear 추가
+  - `insert_table_column_native`: `table.insert_column(...)` 호출 직후 동일하게 clear 추가
+- `src/wasm_api/tests.rs`
+  - `test_insert_table_row_and_column_clear_stale_local_resize` 추가 (3×2 표에서 셀 인덱스 2에
+    로컬 resize 폭/높이를 기록한 뒤 행 삽입, 이어서 열 삽입을 수행하며 각 단계 후 두 벡터가
+    비어 있는지 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib test_insert_table_row_and_column_clear_stale_local_resize` (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021` (변경 파일만)
+
+## 4. 잔여
+
+같은 버그 클래스로 코드 확인은 되었으나 이번 PR 범위 밖으로 남겨둔 항목 (별도 이슈/PR 필요):
+
+- `delete_table_column_native` (열 삭제)
+- `split_table_cell_native`/`split_cell_into` (셀 분할)

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -54,6 +54,15 @@ impl DocumentCore {
         let row_count = table.row_count;
         let col_count = table.col_count;
 
+        // Table::insert_row()는 새 셀을 push()한 뒤 전체를
+        // sort_by_key(row, col)로 재정렬한다. local_resize_cell_widths/heights는
+        // 이 재정렬 이전의 cell 인덱스를 그대로 물고 있는 Vec<(usize, u32)>라서,
+        // 삽입 이후에는 엉뚱한(또는 범위를 벗어난) 셀을 가리키는 stale 참조가 된다.
+        // delete_table_row_native()(#2843/#2849), merge_table_cells_native()(#2832)와
+        // 동일하게, 행 삽입도 셀 인덱스 배치를 바꾸므로 함께 비워야 한다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -85,6 +94,12 @@ impl DocumentCore {
         table.dirty = true;
         let row_count = table.row_count;
         let col_count = table.col_count;
+
+        // insert_table_row_native()와 동일한 사유(위 주석 참조): Table::insert_column()도
+        // 새 셀을 push()한 뒤 sort_by_key(row, col)로 재정렬하므로 local_resize_cell_widths/
+        // heights의 인덱스 참조가 stale 해진다. 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2301,6 +2301,73 @@ fn test_merge_table_cells() {
     }
 }
 
+/// [insert_row/insert_column stale local-resize] 행/열 삽입으로 셀 배열 인덱스가
+/// 바뀌면 local_resize_cell_widths/heights의 cell 인덱스 참조가 stale 해진다.
+///
+/// Table::insert_row()/insert_column()은 새 셀을 push()한 뒤 sort_by_key(row, col)로
+/// 전체 셀 배열을 재정렬한다(delete_row가 retain()+정렬로 stale을 만드는 것과 같은
+/// 근본 원인). 3×2 표에서 셀 인덱스 2에 로컬 resize 값을 저장해 둔 뒤 행을 삽입하면
+/// 재정렬로 인덱스 2가 더 이상 같은 셀을 가리키지 않으므로, 이 값을 cells[idx]로
+/// 읽는 렌더링/직렬화 경로가 엉뚱한 셀에 잘못된 로컬 resize 값을 적용하게 된다.
+/// 열 삽입도 동일 원인으로 같은 결과를 낳는다.
+#[test]
+fn test_insert_table_row_and_column_clear_stale_local_resize() {
+    let mut doc = HwpDocument::create_empty();
+    let table_result = doc.create_table_native(0, 0, 0, 3, 2).expect("3x2 표 생성");
+    let table_para_idx = issue_1481_json_usize(&table_result, "paraIdx");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first_mut()
+    {
+        table.local_resize_cell_widths.push((2, 1234));
+        table.local_resize_cell_heights.push((2, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    doc.insert_table_row_native(0, table_para_idx, 0, 0, true)
+        .expect("행 삽입");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first()
+    {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "행 삽입 후 셀 인덱스가 재배치되므로 local_resize_cell_widths/heights의 \
+             stale 참조(인덱스 2)가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first_mut()
+    {
+        table.local_resize_cell_widths.push((2, 1234));
+        table.local_resize_cell_heights.push((2, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    doc.insert_table_column_native(0, table_para_idx, 0, 0, true)
+        .expect("열 삽입");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first()
+    {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "열 삽입 후에도 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_split_table_cell() {
     let mut doc = create_doc_with_table();


### PR DESCRIPTION
## 요약

#2853 에서 확인한 대로, `Table::insert_row()`/`insert_column()`(`src/model/table.rs`)이 새 셀을
push한 뒤 `self.cells`를 `sort_by_key(|c| (c.row, c.col))`로 재정렬하면서 `local_resize_cell_widths`/
`local_resize_cell_heights`(`Vec<(usize, u32)>`, cell 배열 인덱스로 키잉)의 참조가 stale 해지는
문제를 수정한다. #2832(PR #2841, 셀 병합)·#2843(PR #2849, 행 삭제)와 동일한 버그 클래스의
세 번째·네 번째 사례(행 삽입/열 삽입)다.

## 변경

- `insert_table_row_native`: `table.insert_row(...)` 호출 직후 두 벡터 `clear()`
- `insert_table_column_native`: `table.insert_column(...)` 호출 직후 두 벡터 `clear()`

## Red → Green

`test_insert_table_row_and_column_clear_stale_local_resize` (`src/wasm_api/tests.rs`):

- Red: 수정 전에는 3×2 표에서 셀 인덱스 2에 기록한 `local_resize_cell_widths/heights`가 행/열
  삽입 후에도 비워지지 않아 `assert!(...is_empty())`가 실패한다.
- Green: 수정 후에는 삽입 직후 두 벡터가 `clear()`되어 통과한다.

## 검증

- `cargo build --lib`
- `cargo test --lib test_insert_table_row_and_column_clear_stale_local_resize` — 1 passed
- `cargo clippy --all-targets --profile release-test -- -D warnings` — clean
- `rustfmt --edition 2021` (변경 파일만)

## 잔여

같은 버그 클래스이나 이번 PR 범위 밖 (별도 이슈/PR 필요):

- `delete_table_column_native`
- `split_table_cell_native`/`split_cell_into`

Closes #2853