### PR TITLE
HWP3 날짜 형식(7)/날짜 코드(8) 컨트롤 바이트 언더리드 회귀 수정

### DIFF
--- a/mydocs/report/task_m100_2844_report.md
+++ b/mydocs/report/task_m100_2844_report.md
@@ -1,0 +1,121 @@
+# 최종 결과 보고서 — Task M100 #2844
+
+## 이슈
+
+HWP3 파서(`src/parser/hwp3/mod.rs`)의 문자 스캔 루프가 특수 문자 코드 **7(날짜 형식,
+한글문서파일구조3.0 §10.3)** 과 **8(날짜 코드, §10.4)** 를, 총 길이가 8바이트인 다른
+"단순 컨트롤" 코드들(9, 22, 23, 24, 25, 26, 28, 30, 31)과 같은 디스패치 버킷
+(`parse_simple_control_char`)으로 잘못 라우팅. 실제로는 각각 84/96바이트짜리 구조체인데
+6바이트만 읽고 스킵하여 76/88바이트가 다음 컨트롤·본문 텍스트로 잘못 흡수됨. 문단 전체가
+바이트 오프셋 디싱크에 빠짐.
+
+- Issue: https://github.com/edwardkim/rhwp/issues/2844
+- PR: (본 보고서 하단 참조)
+
+## 결론
+
+문자 스캔 루프 디스패치 매치(`parse_paragraph_list` 내부, 舊 2089행)에서 `7 | 8` 을
+제거하여 `_` 캐치올(`parse_object_control_char`)로 되돌렸다. `parse_object_control_char`에는
+Task #877 에서 작성된 76/88바이트 스킵 로직이 이미 정확하게 존재했으나, 회귀 이후
+dispatch가 도달시키지 않는 죽은 코드였다. 라우팅만 복원하면 되므로, `parse_simple_control_char`
+안의 잘못된 `7 | 8 =>` (6바이트만 소비) arm은 이제 도달 불가능해져 삭제했다.
+
+이는 추론이 아니라 **git blame 으로 확인된 회귀**다. `git log -L1777,1795:src/parser/hwp3/mod.rs`
+로 추적한 결과, 커밋 `f1995532`("Task #2001: 추출 2 — 소형 컨트롤 코드 arm 헬퍼 2개
+(field/simple, 동작 불변)")가 `1 | 7 | 8 | 9 | 22 | ...` 매치로 ch=7/8을
+`parse_simple_control_char`로 우회시키면서 동시에 6바이트짜리 새 `7 | 8` arm을 만들었다.
+그 결과 "동작 불변"을 표방한 리팩터가 실제로는 회귀를 도입했고, 원래 존재하던 76/88바이트
+로직은 그대로 남았지만 죽은 코드가 되었다.
+
+## 결함 상세
+
+### 결함 위치 — `src/parser/hwp3/mod.rs`
+
+디스패치 매치(`parse_paragraph_list` 내부):
+
+```rust
+1 | 7 | 8 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
+    let (next_i, next_utf16_len, break_char_loop) = parse_simple_control_char(...)
+```
+
+`parse_simple_control_char` 내부:
+
+```rust
+7 | 8 => {
+    let mut buf = [0u8; 6];          // ← 84/96바이트 구조체인데 6바이트만 소비
+    ...
+    i += 3;
+    ...
+}
+```
+
+스펙(`mydocs/tech/한글문서파일구조3.0.md` §10.3/§10.4):
+
+- ch=7(날짜 형식): 전체 84바이트 = 여는 코드(2, outer read 완료) + hchar array[40]
+  날짜 형식 문자열(80) + 닫는 코드(2). 즉 outer read 이후 **82바이트** 추가 소비 필요.
+- ch=8(날짜 코드): 전체 96바이트 = 여는 코드(2) + 날짜형식(80) + 날짜(8) + 시각(4) +
+  닫는 코드(2). outer read 이후 **94바이트** 추가 소비 필요.
+
+`parse_object_control_char`(舊 1257~1279행, Task #877)는 이미 정답을 갖고 있었다:
+
+```rust
+} else if ch == 7 {
+    let mut date_fmt = [0u8; 76];   // header_val1(4)+ch2(2) 이미 소비 → 8+76=84 일치
+    ...
+} else if ch == 8 {
+    let mut date_code = [0u8; 88];  // 8+88=96 일치
+    ...
+}
+```
+
+## 수정 내용
+
+1. `parse_paragraph_list` 디스패치 매치에서 `1 | 7 | 8 | 9 | ...` → `1 | 9 | ...` (7, 8 제거).
+   이제 ch=7/8은 `_` 캐치올을 통해 `parse_object_control_char`로 라우팅되어 Task #877의
+   정확한 76/88바이트 스킵 로직이 실행된다.
+2. `parse_simple_control_char`의 버그 있는 `7 | 8 => { ... 6바이트만 소비 ... }` arm 삭제
+   (라우팅 수정으로 도달 불가능해진 죽은 코드).
+
+## 테스트 (red → green)
+
+`src/parser/hwp3/mod.rs` `mod tests`에 통합 테스트 1건 추가:
+`task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`
+
+- 문단 1개: ch=7 날짜 형식 컨트롤(84바이트, 날짜 형식 문자열은 전부 0) 뒤에 실제 본문
+  `"AAA"`(3 hchar)가 오는 최소 HWP3 문단 바이트열을 직접 구성.
+- `parse_paragraph_list()` 호출 후 `paragraphs[0].text`가 `"AAA"`를 포함하는지 단언.
+
+**Red (수정 전, 임시로 舊 로직 복원 후 실행):**
+```
+thread '...' panicked at src\parser\hwp3\mod.rs:4247:9:
+날짜 형식(ch=7) 컨트롤 뒤의 "AAA" 본문이 유실됨 (바이트 언더리드로 흡수): "￼"
+test result: FAILED. 0 passed; 1 failed
+```
+(84바이트 레코드 중 6바이트만 소비되어 커서가 78바이트 어긋나고, "AAA" 텍스트에
+도달하지 못한 채 남은 0-바이트들을 종료 문단으로 오인해 파싱이 조기 종료됨.)
+
+**Green (수정 후):**
+```
+test parser::hwp3::tests::task2844_hwp3_date_format_ctrl_does_not_swallow_following_text ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+## 검증
+
+- `cargo build --lib`: 통과
+- `cargo test --lib task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`: 통과 (green)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`: 실질적 diff 없음 (개행 방식 경고만,
+  실제 내용 변경 없음 — `git diff --stat`로 확인)
+
+## 영향 범위
+
+- 변경 파일: `src/parser/hwp3/mod.rs` 만 (스코프 최소화).
+- ch=1, 9, 22, 23, 24, 25, 26, 28, 30, 31 은 실제로 총 8/6/10/24/246/64/4바이트로
+  스펙과 정확히 일치함을 개별 재검산으로 확인, 손대지 않았다.
+- 그 밖에 검토했으나 문제가 없었던 영역(스펙 대조로 balancing 확인, 수정 불필요):
+  - `records.rs` `Hwp3InfoBlock`/`Hwp3AdditionalInfoBlock` (§3.4/§3.8 정보 블록)
+  - 그림 정보 블록(§10.7, 348+n바이트) 및 하이퍼텍스트 확장(TagID 3) 관련 n_ext 처리
+  - 표/텍스트박스/수식/버튼 (§10.6) 셀 정보 27바이트 × 셀개수 반복
+  - 각주/미주(§10.11, 14바이트), 머리말/꼬리말(§10.10, 10바이트), 상호참조(§10.22,
+    46+n바이트 가변 구조)

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1774,25 +1774,6 @@ fn parse_simple_control_char(
             utf16_len += 8;
             text_string.push('\t');
         }
-        7 | 8 => {
-            let mut buf = [0u8; 6];
-            if let Err(_) = body_cursor.read_exact(&mut buf) {
-                return Ok((i, utf16_len, true));
-            }
-            for k in 0..3usize {
-                if i + k < hwp3_char_to_utf16_pos.len() {
-                    hwp3_char_to_utf16_pos[i + k] = utf16_len;
-                }
-            }
-            i += 3;
-            char_offsets.push(utf16_len);
-            utf16_len += 1;
-            text_string.push('\u{FFFC}');
-            controls.push(crate::model::control::Control::Unknown(
-                crate::model::control::UnknownControl { ctrl_id: ch as u32 },
-            ));
-            ctrl_data_records.push(None);
-        }
         23 => {
             let mut buf = [0u8; 8];
             if let Err(_) = body_cursor.read_exact(&mut buf) {
@@ -2057,7 +2038,11 @@ pub(crate) fn parse_paragraph_list(
 
             if ch > 0 && ch <= 31 && ch != 13 {
                 match ch {
-                    1 | 7 | 8 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
+                    // [#2844] ch=7(날짜 형식)/ch=8(날짜 코드)는 각각 84/96바이트짜리
+                    // 가변폭 구조체이며, 이 arm 이 처리하는 다른 코드들처럼 8바이트에
+                    // 맞춰떨어지지 않는다. `_` 캐치올(parse_object_control_char)에 남아
+                    // 있는 Task #877의 76/88바이트 스킵 로직으로 라우팅해야 한다.
+                    1 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
                         let (next_i, next_utf16_len, break_char_loop) = parse_simple_control_char(
                             body_cursor,
                             ch,
@@ -4069,5 +4054,75 @@ mod tests {
                 "saved HWP5 must have BinData/BIN* streams, got none (images lost)"
             );
         }
+    }
+
+    // [Task #2844] 스펙 §10.3 표 37: 날짜 형식(ch=7) 컨트롤은 식별 헤더 8바이트를
+    // 포함해 전체 84바이트다. 문자 스캔 루프의 디스패치 매치가 ch=7을
+    // parse_simple_control_char(6바이트만 소비)로 잘못 보내면, 그 뒤에 오는 실제
+    // 본문 텍스트("AAA")가 날짜 형식 문자열의 잔여 바이트로 오인되어 사라진다.
+    // 수정 후에는 ch=7이 parse_object_control_char(Task #877의 82바이트 스킵
+    // 로직)로 라우팅되어 "AAA"가 온전히 파싱되어야 한다.
+    #[test]
+    fn task2844_hwp3_date_format_ctrl_does_not_swallow_following_text() {
+        let mut body = Vec::new();
+
+        // 문단 정보 (43바이트: follow_prev_para_shape != 0 이므로 para_shape 생략).
+        body.push(1u8); // follow_prev_para_shape
+        body.extend_from_slice(&7u16.to_le_bytes()); // char_count: ch7(4) + "AAA"(3)
+        body.extend_from_slice(&0u16.to_le_bytes()); // line_count = 0 (LineInfo 생략)
+        body.push(0u8); // include_char_shape = 0
+        body.push(0u8); // flags
+        body.extend_from_slice(&0u32.to_le_bytes()); // special_char_flags
+        body.push(0u8); // style_index
+        body.extend_from_slice(&[0u8; 31]); // rep_char_shape (31바이트)
+        assert_eq!(body.len(), 43, "문단 정보 헤더 길이는 43바이트여야 함");
+
+        // ch=7 컨트롤 레코드 (전체 84바이트): open(2, 외부 char 루프에서 소비) +
+        // header_val1(4) + ch2(2) + 날짜 형식 문자열(76, 전부 0).
+        body.extend_from_slice(&7u16.to_le_bytes()); // 여는 특수 문자 코드
+        body.extend_from_slice(&84u32.to_le_bytes()); // header_val1 (예약 dword)
+        body.extend_from_slice(&7u16.to_le_bytes()); // 닫는 특수 문자 코드
+        body.extend_from_slice(&[0u8; 76]); // 날짜 형식 문자열 (모두 0)
+
+        // 날짜 컨트롤 뒤에 바로 오는 실제 본문: "AAA" (3 hchar).
+        for _ in 0..3 {
+            body.extend_from_slice(&0x0041u16.to_le_bytes()); // 'A'
+        }
+
+        // 문단 리스트 종료를 나타내는 빈 문단 (char_count=0, 총 43바이트).
+        body.push(0u8); // follow_prev_para_shape
+        body.extend_from_slice(&0u16.to_le_bytes()); // char_count = 0
+        body.extend_from_slice(&[0u8; 40]); // Hwp3ParaInfo::read가 요구하는 나머지 40바이트
+
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+
+        let paragraphs = parse_paragraph_list(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            1000,
+            1000,
+        )
+        .expect("날짜 형식(ch=7) 컨트롤을 포함한 문단 파싱 실패");
+
+        assert_eq!(
+            paragraphs.len(),
+            1,
+            "빈 종료 문단을 제외하고 문단이 1개여야 함"
+        );
+        assert!(
+            paragraphs[0].text.contains("AAA"),
+            "날짜 형식(ch=7) 컨트롤 뒤의 \"AAA\" 본문이 유실됨 (바이트 언더리드로 흡수): {:?}",
+            paragraphs[0].text
+        );
     }
 }


### PR DESCRIPTION
## 요약

- `src/parser/hwp3/mod.rs`의 문자 스캔 디스패치가 특수 문자 코드 7(날짜 형식)·8(날짜 코드)을
  총 8바이트짜리 "단순 컨트롤" 버킷(`parse_simple_control_char`)으로 잘못 라우팅하고 있었습니다.
  스펙(§10.3/§10.4)상 이 두 코드는 각각 84/96바이트 구조체인데, 6바이트만 읽고 넘어가면서
  76/88바이트가 다음 컨트롤·본문 텍스트로 잘못 흡수되어 바이트 오프셋 디싱크가 발생했습니다.
- Task #877에서 작성된 정확한 82/94바이트 스킵 로직이 `parse_object_control_char`에 이미
  존재했지만, Task #2001 리팩터(`f1995532`)가 디스패치 라우팅을 바꾸면서 도달 불가능한
  죽은 코드가 되어 있었습니다.
- Fixes #2844

## 변경 사항

1. `parse_paragraph_list` 디스패치 매치에서 `7`, `8`을 제거 → `_` 캐치올을 통해
   `parse_object_control_char`(Task #877의 정확한 82/94바이트 스킵 로직)로 라우팅.
2. `parse_simple_control_char`의 잘못된 `7 | 8 => { ... 6바이트만 소비 ... }` arm 삭제
   (라우팅 수정 후 도달 불가능해진 죽은 코드).

## 테스트 (red → green)

`task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`: ch=7 날짜 형식 컨트롤(84바이트)
뒤에 실제 본문 `"AAA"`가 오는 최소 HWP3 문단 바이트열을 구성해 `parse_paragraph_list()`로 파싱.

- **Red** (수정 전 로직으로 재현): `"AAA"`가 유실되어 파싱된 문단 텍스트가 컨트롤 마커
  하나(`"\u{FFFC}"`)만 남고 패닉.
  ```
  날짜 형식(ch=7) 컨트롤 뒤의 "AAA" 본문이 유실됨 (바이트 언더리드로 흡수): "￼"
  test result: FAILED. 0 passed; 1 failed
  ```
- **Green** (수정 후): 통과.
  ```
  test parser::hwp3::tests::task2844_hwp3_date_format_ctrl_does_not_swallow_following_text ... ok
  ```

## 검증

- `cargo build --lib`: 통과
- `cargo test --lib task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`: 통과
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`: 실질적 diff 없음

## 참고

상세 분석/근거(스펙 표 대조, `git blame`으로 확인한 회귀 커밋 등)는
`mydocs/report/task_m100_2844_report.md` 및 이슈 #2844 본문을 참고해주세요.
