### PR TITLE
책갈피 이름 길이 미검증으로 인한 CTRL_DATA 손상 방지 (#2862)

### DIFF
--- a/mydocs/report/task_m100_2862_report.md
+++ b/mydocs/report/task_m100_2862_report.md
@@ -1,0 +1,43 @@
+# Task m100-2862 처리 결과
+
+## 이슈
+
+#2862 — 책갈피 이름 입력 길이 미검증 → CTRL_DATA 길이 프리픽스 u16 캐스팅 랩어라운드로 저장 파일
+손상 (#2851/#2854 재발).
+
+## 원인
+
+`BookmarkDialog`(`rhwp-studio/src/ui/bookmark-dialog.ts`)의 이름 입력("넣기" `nameInput`,
+"이름 바꾸기" `prompt()`)에 길이 제한이 없어, 매우 긴 이름이 `wasm.addBookmark`/
+`wasm.renameBookmark`로 그대로 전달되면 `src/serializer/control.rs`의
+`serialize_bookmark_ctrl_data`에서 `utf16.len() as u16` 캐스팅이 랩어라운드되어 CTRL_DATA
+레코드가 손상될 수 있었다. `.rs`는 수정하지 않고, 손상 가능한 값이 wasm 호출까지 도달하지
+않도록 프런트엔드 다이얼로그 단계에서 `MAX_BOOKMARK_NAME_LEN(250)` 가드를 추가했다.
+
+## Red → Green
+
+- 수정 전(red): `rhwp-studio/tests/bookmark-name-length-guard.test.ts`가 `MAX_BOOKMARK_NAME_LEN`
+  상수 부재로 실패.
+- 수정 후(green): 동일 테스트 통과.
+
+## 변경 파일
+
+- `rhwp-studio/src/ui/bookmark-dialog.ts` — `MAX_BOOKMARK_NAME_LEN` 상수, `nameInput.maxLength`,
+  `doAdd()`의 길이 초과 검사, `doRename()`의 `prompt()` 반환값 길이 초과 검사(`alert`로 안내 후
+  중단).
+- `rhwp-studio/tests/bookmark-name-length-guard.test.ts` — 신규 소스 가드 테스트.
+- `mydocs/report/task_m100_2862_report.md` — 본 보고서.
+
+## 검증
+
+- `cd rhwp-studio && npm test` — 500 테스트 중 499 통과, 1 실패(`cell-flow-boundary.test.ts`,
+  기존에도 실패하던 무관 테스트로 확인됨). 신규 테스트는 통과.
+- `cd rhwp-studio && npx tsc --noEmit` — `error TS2307` 2건(`@wasm/rhwp.js` 모듈 부재)만 존재,
+  기존 베이스라인과 동일. 신규 에러 없음.
+
+## 스코프 밖 관찰 (후속 이슈 후보)
+
+같은 근본 원인(`write_hwp_string`의 `utf16.len() as u16`, `src/serializer/byte_writer.rs:70-77`)
+이 `serialize_style`(`src/serializer/doc_info.rs:665-670`)의 스타일 이름 직렬화에도 존재하며,
+`rhwp-studio/src/ui/style-edit-dialog.ts`의 `nameInput`/`enNameInput`에도 길이 제한이 없다.
+이번 작업 범위에는 포함하지 않았으며, 별도 이슈로 후속 처리가 필요하다.

--- a/rhwp-studio/src/ui/bookmark-dialog.ts
+++ b/rhwp-studio/src/ui/bookmark-dialog.ts
@@ -9,6 +9,12 @@ import { enableDialogDrag } from './dialog-drag';
 
 type SortMode = 'name' | 'position';
 
+// [Task #2862] 책갈피 이름은 HWP5 CTRL_DATA 레코드에서 u16 길이 프리픽스로 직렬화된다
+// (`src/serializer/control.rs`의 `serialize_bookmark_ctrl_data`, `utf16.len() as u16`).
+// UTF-16 코드 유닛 65536개 이상이면 길이 프리픽스가 랩어라운드되어 저장 파일이 손상되므로
+// (#2851/#2854와 동일한 원인), 프런트엔드에서 여유를 둔 상한으로 미리 차단한다.
+export const MAX_BOOKMARK_NAME_LEN = 250;
+
 export class BookmarkDialog {
   private services: CommandServices;
   private _open = false;
@@ -93,6 +99,7 @@ export class BookmarkDialog {
     this.nameInput = document.createElement('input');
     this.nameInput.type = 'text';
     this.nameInput.className = 'bm-name-input';
+    this.nameInput.maxLength = MAX_BOOKMARK_NAME_LEN;
     this.nameInput.addEventListener('keydown', (e) => {
       if (e.key === 'Enter') { e.preventDefault(); this.doAdd(); }
     });
@@ -274,6 +281,11 @@ export class BookmarkDialog {
       this.statusLabel.style.color = '#c00';
       return;
     }
+    if (name.length > MAX_BOOKMARK_NAME_LEN) {
+      this.statusLabel.textContent = `책갈피 이름은 ${MAX_BOOKMARK_NAME_LEN}자를 넘을 수 없습니다.`;
+      this.statusLabel.style.color = '#c00';
+      return;
+    }
 
     const ih = this.services.getInputHandler();
     if (!ih) return;
@@ -350,6 +362,10 @@ export class BookmarkDialog {
     const bm = this.bookmarks[this.selectedIdx];
     const newName = prompt('새 책갈피 이름:', bm.name);
     if (!newName || newName.trim() === '' || newName === bm.name) return;
+    if (newName.trim().length > MAX_BOOKMARK_NAME_LEN) {
+      alert(`책갈피 이름은 ${MAX_BOOKMARK_NAME_LEN}자를 넘을 수 없습니다.`);
+      return;
+    }
 
     const ih = this.services.getInputHandler();
     if (!ih) return;

--- a/rhwp-studio/tests/bookmark-name-length-guard.test.ts
+++ b/rhwp-studio/tests/bookmark-name-length-guard.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2862 (#2851/#2854 재발 사례): 책갈피 이름 입력 길이 미검증 → Rust 직렬화기
+// (src/serializer/control.rs의 serialize_bookmark_ctrl_data)의
+// `utf16.len() as u16` 캐스팅 랩어라운드로 CTRL_DATA 레코드가 손상될 수 있었다.
+// `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출 전에 이름 길이를
+// 안전한 상한(MAX_BOOKMARK_NAME_LEN)으로 막는지를 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, '../src/ui/bookmark-dialog.ts'), 'utf8');
+
+test('책갈피 이름 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const m = src.match(/MAX_BOOKMARK_NAME_LEN\s*=\s*(\d+)/);
+  assert.ok(m, 'MAX_BOOKMARK_NAME_LEN 상수를 찾을 수 없음');
+  const limit = Number(m![1]);
+  assert.ok(limit > 0 && limit < 65536, `한도(${limit})가 u16 랩어라운드 지점보다 작아야 함`);
+});


### PR DESCRIPTION
closes #2862

## 요약

#2851/#2854(필드 이름 입력 길이 미검증 → CTRL_DATA u16 랩어라운드)와 동일한 근본 원인이
책갈피 이름 경로에도 존재했다. `BookmarkDialog`의 "넣기" `nameInput`과 "이름 바꾸기"
`prompt()` 모두 길이 제한 없이 `wasm.addBookmark`/`wasm.renameBookmark`로 전달되며, 결국
`src/serializer/control.rs`의 `serialize_bookmark_ctrl_data`가 `utf16.len() as u16`으로
CTRL_DATA 길이 프리픽스를 기록한다. 이름이 UTF-16 65536 코드 유닛 이상이면 이 캐스팅이
랩어라운드되어 저장 파일이 조용히 손상된다.

`.rs`는 수정하지 않고, #2854와 동일한 패턴으로 프런트엔드 다이얼로그 단계에서
`MAX_BOOKMARK_NAME_LEN(250)` 가드를 추가했다.

## Red → Green

- Red: `rhwp-studio/tests/bookmark-name-length-guard.test.ts`가 `MAX_BOOKMARK_NAME_LEN` 상수
  부재로 실패.
- Green: 상수 추가 후 통과.

## 변경 파일

- `rhwp-studio/src/ui/bookmark-dialog.ts`
- `rhwp-studio/tests/bookmark-name-length-guard.test.ts`
- `mydocs/report/task_m100_2862_report.md`

## 검증

- `npm test` — 500 테스트 중 499 통과, 1 실패는 기존에도 무관하게 실패하던
  `cell-flow-boundary.test.ts` (본 변경과 무관).
- `npx tsc --noEmit` — 기존 베이스라인과 동일한 `TS2307` 2건(`@wasm/rhwp.js` 모듈 부재)만
  존재, 신규 에러 없음.

## 스코프 밖 관찰

같은 원인(`write_hwp_string`의 `utf16.len() as u16`)이 `serialize_style`의 스타일 이름
직렬화에도 존재하고 `style-edit-dialog.ts`에도 길이 가드가 없음을 확인했다. 이번 PR
범위에는 포함하지 않았으며 별도 이슈로 후속 처리할 예정이다.
