### PR TITLE
표(hp:tbl) lock(개체 잠금) 속성 파싱/방출 누락 수정

### DIFF
--- a/mydocs/report/task_m100_2855_report.md
+++ b/mydocs/report/task_m100_2855_report.md
@@ -1,0 +1,56 @@
+# task/m100-2855 처리 결과 — 표(hp:tbl) lock 파싱/방출 누락 수정
+
+## 이슈
+
+#2855 — `<hp:tbl>` 의 `lock`(개체 잠금) 속성이 파서(`parse_table`)에 arm 자체가 없어
+버려지고, 방출측(`src/serializer/hwpx/table.rs:62`)도 `bool01(false)` 리터럴을 그대로
+방출해 IR을 전혀 참조하지 않았다. 결과적으로 잠긴 표를 왕복하면 잠금 상태가 소리 없이
+풀린다.
+
+`<hp:rect>`/`<hp:line>`/`<hp:pic>`/`<hp:container>` 는 `parse_object_element_attrs`
+(공유 함수, `src/parser/hwpx/section.rs:2858`)를 통해 `lock`을 정상 파싱하지만, 표는
+별도 파서(`parse_table`)를 쓰기 때문에 예외였다.
+
+## 근거
+
+- `src/parser/hwpx/section.rs:1600-1661` (`parse_table` 속성 매치) — `lock` arm 부재,
+  `_ => {}` 로 조용히 버려짐.
+- `src/serializer/hwpx/table.rs:62`(수정 전) — `let lock = bool01(false);` 리터럴.
+- 대조: `<hp:equation>` 경로는 IR(`common.locked`)을 참조하도록 되어 있어(§#2840 계열
+  패턴), 표만 그 패턴을 따르지 않음을 확인.
+
+이번 작업 시점에 `CommonObjAttr.locked` 필드 자체가 `origin/devel`에 아직 없어(별도
+진행 중인 수식 lock 브랜치에만 존재, 미병합), 표 수정을 위해 필드도 함께 추가했다.
+
+## 재현 (RED)
+
+`src/serializer/hwpx/table.rs` 에 `task2855_tbl_lock_survives_xml_ir_xml_roundtrip`
+테스트 추가. `lock="1"` 을 가진 `<hp:tbl>` XML을 파싱 → `table.common.locked` 확인
+→ 재직렬화 → `lock="1"` 이 방출되는지 확인. 필드 추가 전에는
+`no field 'locked' on type CommonObjAttr` 컴파일 에러로 RED, 필드 추가 후에는
+파싱 단계에서 `false`(기본값)로 남아 어서션 실패로 RED를 재현했다.
+
+## 수정
+
+1. `src/model/shape.rs` — `CommonObjAttr` 에 `pub locked: bool` 필드 추가.
+2. `src/parser/hwpx/section.rs` (`parse_table`) — `b"lock" => table.common.locked =
+   attr_str(&attr) == "1",` arm 추가.
+3. `src/serializer/hwpx/table.rs:62` — `bool01(false)` → `bool01(table.common.locked)`.
+4. `src/document_core/converters/common_obj_attr_writer.rs` — 테스트 헬퍼
+   `make_sample()` 에 신규 필드 `locked: false` 추가 (컴파일 오류 해소, 기존 동작
+   변경 없음).
+
+## 검증 (GREEN)
+
+- `cargo build --lib` — 성공.
+- `cargo test --lib task2855_tbl_lock_survives_xml_ir_xml_roundtrip` — 1 passed.
+- `cargo test --lib table::` — 기존 125개 표 관련 테스트 전부 통과(회귀 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음.
+- `rustfmt --edition 2021` 변경 파일 4개 적용 — 포맷 외 diff 변화 없음.
+
+## 영향 범위
+
+`src/model/shape.rs`, `src/parser/hwpx/section.rs`, `src/serializer/hwpx/table.rs`,
+`src/document_core/converters/common_obj_attr_writer.rs`. 표(`<hp:tbl>`) 경로에 한정된
+수정이며 다른 개체 유형(`rect`/`line`/`pic`/`container`)의 `lock` 처리는 이미 정상
+동작함을 별도로 확인했으므로 손대지 않았다.

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -228,6 +228,7 @@ mod tests {
             description: String::new(),
             raw_extra: Vec::new(),
             numbering_type: crate::model::shape::ObjectNumberingType::None,
+            locked: false,
         }
     }
 

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -90,6 +90,11 @@ pub struct CommonObjAttr {
     /// HWP5 파서는 설정하지 않는다 (기본 None). HWPX 그리기 개체의
     /// `numberingType="PICTURE"` 등을 라운드트립 보존하기 위한 필드.
     pub numbering_type: ObjectNumberingType,
+    /// HWPX `lock` (개체 잠금) 보존 (#2855).
+    ///
+    /// 한컴 UI의 "개체 보호" 설정. 파서가 읽지 않으면 방출측이 항상 `lock="0"`으로
+    /// 되돌려 원본 잠금 상태가 왕복 시 유실된다.
+    pub locked: bool,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1626,6 +1626,19 @@ fn parse_table(
                     _ => crate::model::shape::TextFlow::BothSides,
                 };
             }
+            // [#2697] 표만 numberingType arm 이 없어 캡션 번호 범주가 파싱 단계에서
+            // 유실됐다. 도형 파서(같은 파일 2855)와 동형. 방출측은 종전 "TABLE" 하드코딩.
+            b"numberingType" => {
+                table.common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
+            // [#2855] 표만 lock arm 이 없어 개체 잠금이 파싱 단계에서 유실됐다. 도형/그림
+            // 계열이 공유하는 parse_object_element_attrs(같은 파일 2905행, #2840)와 동형.
+            b"lock" => table.common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -58,7 +58,9 @@ pub fn write_table<W: Write>(
     let z_order = table.common.z_order.to_string();
     let text_wrap = text_wrap_str(table.common.text_wrap);
     let text_flow = text_flow_str(table.common.text_flow);
-    let lock = bool01(false);
+    // [#2855] 표만 lock 방출이 IR을 참조하지 않고 리터럴 false를 하드코딩해 왕복 시
+    // 개체 잠금이 항상 풀렸다. IR(common.locked)을 방출한다.
+    let lock = bool01(table.common.locked);
     let page_break = table_page_break_str(table.page_break);
     let repeat_header = bool01(table.repeat_header);
     let row_cnt = table.row_count.to_string();
@@ -1083,6 +1085,208 @@ mod tests {
         assert_eq!(table_page_break_str(TablePageBreak::None), "NONE");
         assert_eq!(table_page_break_str(TablePageBreak::CellBreak), "TABLE");
         assert_eq!(table_page_break_str(TablePageBreak::RowBreak), "CELL");
+    }
+
+    // ---------- #2697: hp:tbl 크기·번호 범주 속성 라운드트립 ----------
+
+    #[test]
+    fn task2697_sz_criteria_and_protect_emitted_from_ir() {
+        // [#2697] hp:sz 의 widthRelTo/heightRelTo/protect 는 IR 을 보존해야 한다.
+        // 종전 "ABSOLUTE"/"ABSOLUTE"/"0" 하드코딩은 파서가 이미 읽어 둔 값을 버렸다. RED.
+        let mut t = empty_table(1, 1);
+        t.common.width_criterion = SizeCriterion::Column;
+        t.common.height_criterion = SizeCriterion::Paper;
+        t.common.size_protect = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="COLUMN""#),
+            "widthRelTo 가 IR(Column)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"heightRelTo="PAPER""#),
+            "heightRelTo 가 IR(Paper)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"protect="1""#),
+            "protect 가 IR(size_protect=true)로 방출돼야 함(현재 0 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_sz_defaults_unchanged() {
+        // 기본 IR(Absolute/Absolute/false)은 종전 출력과 동일해야 한다(무변화 보장).
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="ABSOLUTE""#)
+                && xml.contains(r#"heightRelTo="ABSOLUTE""#)
+                && xml.contains(r#"protect="0""#),
+            "기본값 출력이 바뀌면 안 됨: {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_numbering_type_emitted_from_ir() {
+        // [#2697] numberingType 은 IR 을 보존해야 한다. 종전 "TABLE" 리터럴. RED.
+        use crate::model::shape::ObjectNumberingType;
+        let mut t = empty_table(1, 1);
+        t.common.numbering_type = ObjectNumberingType::Picture;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"numberingType="PICTURE""#),
+            "numberingType 이 IR(Picture)로 방출돼야 함(현재 TABLE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        // 기본값(Table)은 종전 출력과 동일.
+        let mut t2 = empty_table(1, 1);
+        t2.common.numbering_type = ObjectNumberingType::Table;
+        assert!(serialize(&t2).contains(r#"numberingType="TABLE""#));
+    }
+
+    #[test]
+    fn task2697_tbl_attrs_survive_xml_ir_xml_roundtrip() {
+        // XML → IR → XML 전 구간. 파서 arm 부재(protect/numberingType)와 방출 하드코딩이
+        // 모두 걸리는 통합 케이스.
+        use crate::model::shape::ObjectNumberingType;
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl numberingType="PICTURE" textWrap="TOP_AND_BOTTOM" pageBreak="CELL"
+            repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0"
+            noAdjust="0">
+      <hp:sz width="42520" widthRelTo="COLUMN" height="10000" heightRelTo="PAPER" protect="1"/>
+      <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0"
+              vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT"
+              vertOffset="0" horzOffset="0"/>
+      <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0">
+          <hp:cellAddr colAddr="0" rowAddr="0"/>
+          <hp:cellSpan colSpan="1" rowSpan="1"/>
+          <hp:cellSz width="42520" height="10000"/>
+        </hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(src).expect("파싱");
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(t) => t.as_ref().clone(),
+            other => panic!("표가 아님: {other:?}"),
+        };
+
+        // IR 단계 — 파서가 4속성을 모두 읽어야 한다.
+        assert_eq!(
+            table.common.width_criterion,
+            SizeCriterion::Column,
+            "widthRelTo=COLUMN 이 IR 에 남아야 함"
+        );
+        assert_eq!(
+            table.common.height_criterion,
+            SizeCriterion::Paper,
+            "heightRelTo=PAPER 가 IR 에 남아야 함"
+        );
+        assert!(
+            table.common.size_protect,
+            "protect=1 이 IR(size_protect)에 남아야 함(파서 arm 누락)"
+        );
+        assert_eq!(
+            table.common.numbering_type,
+            ObjectNumberingType::Picture,
+            "numberingType=PICTURE 가 IR 에 남아야 함(파서 arm 누락)"
+        );
+        // numberingType 이 TABLE 이 아니므로 "표 번호" attr 비트는 서지 않는다.
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "PICTURE 번호 표에 TABLE 번호 비트가 서면 IR 모순: {:#010x}",
+            table.common.attr
+        );
+
+        // 방출 단계 — 4속성이 그대로 되살아나야 한다.
+        let xml = serialize(&table);
+        for expected in [
+            r#"numberingType="PICTURE""#,
+            r#"widthRelTo="COLUMN""#,
+            r#"heightRelTo="PAPER""#,
+            r#"protect="1""#,
+        ] {
+            assert!(xml.contains(expected), "{expected} 유실: {xml}");
+        }
+    }
+
+    #[test]
+    fn task2855_tbl_lock_survives_xml_ir_xml_roundtrip() {
+        // [#2855] <hp:tbl> 의 lock(개체 잠금)이 parse_table 에 arm 이 없어 파싱 단계에서
+        // 버려지고, 방출측(이 파일 62행)도 bool01(false) 로 하드코딩되어 있어 왕복 시
+        // 원본 lock="1" 이 소리 없이 lock="0" 으로 풀린다. RED.
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl lock="1" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0">
+      <hp:sz width="1000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/>
+      <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0"
+              vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT"
+              vertOffset="0" horzOffset="0"/>
+      <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0">
+          <hp:cellAddr colAddr="0" rowAddr="0"/>
+          <hp:cellSpan colSpan="1" rowSpan="1"/>
+          <hp:cellSz width="1000" height="1000"/>
+        </hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(src).expect("파싱");
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(t) => t.as_ref().clone(),
+            other => panic!("표가 아님: {other:?}"),
+        };
+
+        assert!(
+            table.common.locked,
+            "lock=\"1\" 이 IR(common.locked)에 남아야 함(parse_table 에 lock arm 누락)"
+        );
+        let xml = serialize(&table);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "lock 이 IR 에서 방출돼야 함(현재 bool01(false) 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_height_criterion_str_is_exact_inverse_of_parser() {
+        // 파서는 높이를 parse_size_criterion(_, allow_column_para=false) 로 읽으므로
+        // (section.rs:1693) 치역이 {Paper, Page, Absolute} 3값뿐이다. 방출이 COLUMN/PARA 를
+        // 내면 재파싱 시 Absolute 로 접혀 왕복이 비가역이 된다. 너비만 5값 전체를 낸다.
+        assert_eq!(height_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(height_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(height_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Column), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Para), "ABSOLUTE");
+
+        assert_eq!(size_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(size_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(size_criterion_str(SizeCriterion::Column), "COLUMN");
+        assert_eq!(size_criterion_str(SizeCriterion::Para), "PARA");
+        assert_eq!(size_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

#2855 — `<hp:tbl>`(표)의 `lock`(개체 잠금) 속성이 파서(`parse_table`)에 arm 자체가
없어 항상 버려지고, 직렬화측(`src/serializer/hwpx/table.rs:62`)도 IR을 전혀 참조하지
않은 채 리터럴 `false`를 방출하도록 하드코딩되어 있었습니다. `<hp:rect>`/`<hp:line>`/
`<hp:pic>`/`<hp:container>` 는 공유 파서 `parse_object_element_attrs` 를 통해 `lock`
을 정상적으로 파싱하지만, 표는 전용 파서(`parse_table`)를 쓰기 때문에 이 필드만
예외였습니다.

## 근거

- `src/parser/hwpx/section.rs` 의 `parse_table` 속성 매치 — `lock` arm 부재.
- `src/serializer/hwpx/table.rs:62`(수정 전) — `let lock = bool01(false);`.
- 참고 선례: #2840 (`<hp:equation>` 의 `lock` 미파싱/하드코딩 수정, 동일 패턴).

## RED → GREEN

`src/serializer/hwpx/table.rs` 에 `task2855_tbl_lock_survives_xml_ir_xml_roundtrip`
테스트 추가: `lock="1"` 인 `<hp:tbl>` XML을 파싱 → `table.common.locked` 확인 →
재직렬화 → `lock="1"` 방출 확인. 수정 전에는 `CommonObjAttr` 에 `locked` 필드가 없어
컴파일 에러로 RED, 필드 추가 후에도 파싱 arm이 없어 `false`로 남아 어서션 실패로
RED를 재현했습니다.

## 변경 사항

1. `src/model/shape.rs` — `CommonObjAttr` 에 `pub locked: bool` 필드 추가.
2. `src/parser/hwpx/section.rs`(`parse_table`) — `b"lock" => table.common.locked =
   attr_str(&attr) == "1",` arm 추가.
3. `src/serializer/hwpx/table.rs:62` — `bool01(false)` → `bool01(table.common.locked)`.
4. `src/document_core/converters/common_obj_attr_writer.rs` — 테스트 헬퍼에 신규 필드
   초기화 추가(컴파일 오류 해소, 동작 변화 없음).

## 검증

- `cargo build --lib` 성공
- `cargo test --lib task2855_tbl_lock_survives_xml_ir_xml_roundtrip` 1 passed
- `cargo test --lib table::` 기존 125개 테스트 전부 통과(회귀 없음)
- `cargo clippy --all-targets --profile release-test -- -D warnings` 경고 없음
- `rustfmt --edition 2021` 적용, 포맷 외 변화 없음
