### PR TITLE
fix(hwpx): hp:pic reverse(좌우 반전) 속성 파싱·저장 유실 수정

### DIFF
--- a/mydocs/report/task_m100_2861_report.md
+++ b/mydocs/report/task_m100_2861_report.md
@@ -1,0 +1,50 @@
+# Task #2861 처리 결과
+
+## 개요
+
+HWPX `<hp:pic reverse="...">` (그림 좌우 반전) 속성이 파서에서 아예 읽히지 않고, 직렬화기는
+IR 과 무관하게 항상 `reverse="0"` 을 방출하던 결함을 수정했다. `lock`(#2840)·`lockForm`(#2839)·
+`affectLSpacing`(#2784)·`widthRelTo`/`protect`(#2712) 와 동일한 유형("파싱 누락 + 직렬화
+하드코딩")이다.
+
+## 근거
+
+- `mydocs/plans/archives/task_43_feature_def.md:177` — 한컴 Automation `InsertPicture` 옵션
+  목록에 `reverse` 명시.
+- `mydocs/report/archives/task_m100_182_report.md:164` — `<hp:pic>` 방출 속성 표에 `reverse`
+  가 요소 속성 중 하나로 명시돼 있으나 코드 구현은 되지 않았음.
+
+## 수정 내용
+
+- `src/model/image.rs`: `Picture` 에 `reverse: bool` 필드 추가.
+- `src/parser/hwpx/section.rs`: `<hp:pic>` 속성 파싱 루프에 `b"reverse"` 매칭 추가, `pic.reverse`
+  에 반영.
+- `src/serializer/hwpx/picture.rs`: `("reverse", "0")` 하드코딩을 `pic.reverse` 기반 `bool01()`
+  출력으로 교체.
+- `src/wasm_api/tests.rs`: `Picture` 구조체 리터럴 2곳에 `reverse: ref_pic.reverse` 필드 추가
+  (신규 필드로 인한 컴파일 오류 수정, 로직 변경 없음).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::issue2861_pic_reverse_is_preserved_on_serialize` 추가.
+
+- 수정 전: `Picture` 에 `reverse` 필드가 없어 컴파일 불가(혹은 필드 추가만 하고 직렬화기 미수정
+  시 `reverse="0"` 하드코딩으로 실패).
+- 수정 후: `pic.reverse = true` 설정 후 직렬화한 XML 에 `reverse="1"` 포함 확인 — 통과.
+
+```
+cargo test --lib issue2861_pic_reverse
+running 1 test
+test serializer::hwpx::picture::tests::issue2861_pic_reverse_is_preserved_on_serialize ... ok
+```
+
+## 검증
+
+- `cargo build --lib` — 성공
+- `cargo test --lib issue2861_pic_reverse` — 통과
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음
+- `rustfmt --edition 2021` — 변경 파일 4개만 적용
+
+## 관련
+
+- Closes #2861

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -47,6 +47,10 @@ pub struct Picture {
     /// imgClip extent 와 독립(전수 측정: 불일치 24/170) — 원본 이미지 픽셀 크기를
     /// verbatim 보존한다. (dimwidth, dimheight). HWPX 파서만 적재.
     pub img_dim: (u32, u32),
+    /// HWPX `<hp:pic reverse="...">` 값 — 그림 좌우 반전(한컴 Automation
+    /// `InsertPicture`의 `reverse` 옵션과 동일 개념). 파서가 읽지 않고 직렬화기가
+    /// 항상 "0"을 방출해 `reverse="1"`로 저장된 그림이 왕복 시 반전이 풀린다.
+    pub reverse: bool,
 }
 
 /// 자르기 정보

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2218,6 +2218,7 @@ fn parse_picture(
     let mut href: Option<String> = None;
     let mut picture_instance_id = 0;
     let mut effects = PictureEffects::default();
+    let mut reverse = false;
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
@@ -2251,6 +2252,9 @@ fn parse_picture(
                 }
             }
             b"groupLevel" => shape_attr.group_level = attr_str(&attr).parse().unwrap_or(0),
+            // [#2861] 좌우 반전(한컴 Automation InsertPicture 의 reverse 옵션과 동일 개념).
+            // 종전 미매칭으로 조용히 버려져 직렬화 시 항상 reverse="0" 하드코딩되던 유실.
+            b"reverse" => reverse = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -2541,6 +2545,7 @@ fn parse_picture(
     pic.effects = effects;
     pic.caption = caption;
     pic.img_dim = img_dim;
+    pic.reverse = reverse;
 
     Ok(Control::Picture(Box::new(pic)))
 }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -59,6 +59,9 @@ pub fn write_picture<W: Write>(
     let tf = text_flow_str(pic.common.text_flow);
     let instid = pic.instance_id.to_string();
     let href = pic.href.as_deref().unwrap_or("");
+    // [#2861] 좌우 반전 — 종전 하드코딩 "0" 은 reverse="1" 로 저장된 그림의 반전 정보를
+    // 왕복 시 소실시켰다.
+    let reverse = bool01(pic.reverse);
 
     start_tag_attrs(
         w,
@@ -74,7 +77,7 @@ pub fn write_picture<W: Write>(
             ("href", href),
             ("groupLevel", "0"),
             ("instid", &instid),
-            ("reverse", "0"),
+            ("reverse", reverse),
         ],
     )?;
 
@@ -615,6 +618,21 @@ mod tests {
         assert!(
             xml.contains(r#"alpha="255""#),
             "그림 투명도 100%는 한컴 HWPX alpha byte 255로 저장되어야 한다: {xml}"
+        );
+    }
+
+    // [#2861] reverse="1" 이 IR 에 있어도 종전에는 하드코딩 "0" 으로 방출됐다.
+    #[test]
+    fn issue2861_pic_reverse_is_preserved_on_serialize() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+
+        pic.reverse = true;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(r#"reverse="1""#),
+            "hp:pic reverse=1 이 저장 시 보존돼야 한다: {xml}"
         );
     }
 

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -15349,6 +15349,7 @@ fn test_save_picture() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        reverse: ref_pic.reverse,
     };
 
     // 5. 문단 구성 (참조 파일: 단일 문단에 SectionDef + ColumnDef + Picture)
@@ -16540,6 +16541,7 @@ fn test_save_pic_in_table() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        reverse: ref_pic.reverse,
     };
 
     // 6. 셀 내부 문단 구성 (cc=9: gso(8)+CR(1), mask=0x00000800)


### PR DESCRIPTION
## 개요

HWPX `<hp:pic reverse="...">` (좌우 반전) 속성이 파서에서 아예 읽히지 않고, 직렬화기는 IR 과
무관하게 항상 `reverse="0"` 을 방출한다. `reverse="1"` 로 저장된 그림을 왕복 저장하면 반전이
풀린다.

## 재현 (red → green)

`src/serializer/hwpx/picture.rs::tests::issue2861_pic_reverse_is_preserved_on_serialize`

- 수정 전: `Picture` 에 `reverse` 필드가 없어 직렬화기가 항상 `reverse="0"` 을 방출 → 실패
- 수정 후: `pic.reverse = true` 설정 후 직렬화한 XML 에 `reverse="1"` 포함 → 통과

```
test serializer::hwpx::picture::tests::issue2861_pic_reverse_is_preserved_on_serialize ... ok
```

## 수정 내용

- `src/model/image.rs`: `Picture` 에 `reverse: bool` 필드 추가
- `src/parser/hwpx/section.rs`: `<hp:pic>` 속성 파싱 루프에 `reverse` 매칭 추가
- `src/serializer/hwpx/picture.rs`: `("reverse", "0")` 하드코딩을 `pic.reverse` 기반 출력으로 교체
- `src/wasm_api/tests.rs`: 신규 필드로 인한 `Picture` 리터럴 2곳 보정 (로직 변경 없음)

## 검증

- `cargo build --lib`
- `cargo test --lib issue2861_pic_reverse`
- `cargo clippy --all-targets --profile release-test -- -D warnings`
- `rustfmt --edition 2021` (변경 파일만)

## 관련

Closes #2861