### PR TITLE
스타일 이름/영문 이름 입력 길이 미검증으로 인한 STYLE 레코드 손상 방지 (#2866)

### DIFF
--- a/mydocs/report/task_m100_2866_report.md
+++ b/mydocs/report/task_m100_2866_report.md
@@ -1,0 +1,44 @@
+# Task #2866 처리 결과 — 스타일 이름/영문 이름 입력 길이 미검증 (#2851/#2862 재발)
+
+## 문제
+
+`rhwp-studio/src/ui/style-edit-dialog.ts`의 `nameInput`(스타일 이름)과 `enNameInput`(영문 이름)에
+길이 제한이 없어, `wasm.createStyle()` / `wasm.updateStyle()`을 거쳐 `serialize_style()`
+(`src/serializer/doc_info.rs:665-670`) → `write_hwp_string()`
+(`src/serializer/byte_writer.rs:70-77`)에서 `utf16.len() as u16` 캐스팅이 랩어라운드되어
+STYLE 레코드가 손상될 수 있었다. #2851(필드 이름, PR #2854)과 #2862(책갈피 이름, PR #2865)와
+동일한 원인의 세 번째 재발 경로.
+
+## 재현 (수정 전)
+
+1. 스타일 추가/편집 대화상자를 연다.
+2. 스타일 이름 또는 영문 이름 입력란에 UTF-16 코드 유닛 65536개 이상인 문자열을 넣는다
+   (예: 자동화 스크립트나 클립보드 붙여넣기).
+3. 저장하면 `write_hwp_string`의 `utf16.len() as u16`이 0으로 랩어라운드되어 길이 프리픽스가
+   깨지고, 실제 문자 데이터는 그대로 남아 STYLE 레코드 이후 DocInfo 파싱이 오프셋 밀림으로
+   손상된다.
+
+## 수정 (red → green)
+
+- `rhwp-studio/src/ui/style-edit-dialog.ts`
+  - `MAX_STYLE_NAME_LEN = 250` 상수 추가(#2865의 `MAX_BOOKMARK_NAME_LEN` 패턴 준용).
+  - `nameInput`/`enNameInput`에 `maxLength = MAX_STYLE_NAME_LEN` 설정.
+  - `onConfirm()`에 길이 초과 시 알림 후 반환하는 방어 검증 추가(붙여넣기 등으로 `maxLength`를
+    우회한 값이 들어와도 저장 직전에 차단).
+- `rhwp-studio/tests/style-name-length-guard.test.ts` (신규)
+  - `MAX_STYLE_NAME_LEN`이 u16 랩어라운드 지점(65536)보다 작은지 검증하는 소스 가드 테스트
+    (수정 전에는 상수 자체가 없으므로 red, 수정 후 green).
+
+`.rs` 파일은 수정하지 않았다(범위: TypeScript 프런트엔드 가드만).
+
+## 검증
+
+- `npm test` (`rhwp-studio`): 500 테스트 중 499 통과, 실패 1건은 기존에 알려진
+  `tests/cell-flow-boundary.test.ts` 뿐(무관한 사전 실패).
+- `npx tsc --noEmit` (`rhwp-studio`): 사전 존재하는 TS2307 오류 2건(`@wasm/rhwp.js` 모듈 누락)만
+  남고 신규 오류 없음.
+
+## 관련
+
+- 이슈 #2866
+- 선행 사례: #2851 → PR #2854, #2862 → PR #2865

--- a/rhwp-studio/src/ui/style-edit-dialog.ts
+++ b/rhwp-studio/src/ui/style-edit-dialog.ts
@@ -27,6 +27,14 @@ import { ModalDialog } from './dialog';
 import { CharShapeDialog } from './char-shape-dialog';
 import { ParaShapeDialog } from './para-shape-dialog';
 
+// [Task #2866] 스타일 이름/영문 이름은 HWP5 DocInfo STYLE 레코드에서 u16 길이
+// 프리픽스로 직렬화된다(`src/serializer/doc_info.rs`의 `serialize_style` →
+// `src/serializer/byte_writer.rs`의 `write_hwp_string`, `utf16.len() as u16`).
+// UTF-16 코드 유닛 65536개 이상이면 길이 프리픽스가 랩어라운드되어 저장 파일이
+// 손상되므로(#2851/#2862와 동일한 원인), 프런트엔드에서 여유를 둔 상한으로
+// 미리 차단한다.
+export const MAX_STYLE_NAME_LEN = 250;
+
 interface StyleInfo {
   id: number;
   name: string;
@@ -86,6 +94,7 @@ export class StyleEditDialog extends ModalDialog {
     nameLabel.textContent = '스타일 이름(N):';
     this.nameInput = document.createElement('input');
     this.nameInput.className = 'se-field-input';
+    this.nameInput.maxLength = MAX_STYLE_NAME_LEN;
     this.nameInput.value = this.styleInfo.name;
     nameGroup.appendChild(nameLabel);
     nameGroup.appendChild(this.nameInput);
@@ -97,6 +106,7 @@ export class StyleEditDialog extends ModalDialog {
     enLabel.textContent = '영문 이름(E):';
     this.enNameInput = document.createElement('input');
     this.enNameInput.className = 'se-field-input';
+    this.enNameInput.maxLength = MAX_STYLE_NAME_LEN;
     this.enNameInput.value = this.styleInfo.englishName;
     enGroup.appendChild(enLabel);
     enGroup.appendChild(this.enNameInput);
@@ -276,6 +286,10 @@ export class StyleEditDialog extends ModalDialog {
 
     if (!name) {
       alert('스타일 이름을 입력하세요.');
+      return;
+    }
+    if (name.length > MAX_STYLE_NAME_LEN || englishName.length > MAX_STYLE_NAME_LEN) {
+      alert(`스타일 이름/영문 이름은 ${MAX_STYLE_NAME_LEN}자를 넘을 수 없습니다.`);
       return;
     }
 

--- a/rhwp-studio/tests/style-name-length-guard.test.ts
+++ b/rhwp-studio/tests/style-name-length-guard.test.ts
@@ -1,0 +1,21 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2866 (#2851/#2862 재발 사례): 스타일 이름/영문 이름 입력 길이 미검증 → Rust 직렬화기
+// (src/serializer/doc_info.rs의 serialize_style → src/serializer/byte_writer.rs의
+// write_hwp_string)의 `utf16.len() as u16` 캐스팅 랩어라운드로 STYLE 레코드가 손상될 수
+// 있었다. `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출 전에 이름 길이를
+// 안전한 상한(MAX_STYLE_NAME_LEN)으로 막는지를 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, '../src/ui/style-edit-dialog.ts'), 'utf8');
+
+test('스타일 이름 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const m = src.match(/MAX_STYLE_NAME_LEN\s*=\s*(\d+)/);
+  assert.ok(m, 'MAX_STYLE_NAME_LEN 상수를 찾을 수 없음');
+  const limit = Number(m![1]);
+  assert.ok(limit > 0 && limit < 65536, `한도(${limit})가 u16 랩어라운드 지점보다 작아야 함`);
+});


### PR DESCRIPTION
## 요약

#2866의 수정. #2851(PR #2854)·#2862(PR #2865)와 동일한 `utf16.len() as u16` 캐스팅
랩어라운드 클래스가 스타일 편집 대화상자(`style-edit-dialog.ts`)의 스타일 이름/영문 이름
입력 경로에도 존재했다.

## Red → Green

- **Red**: 수정 전에는 `MAX_STYLE_NAME_LEN` 상수가 없어 `style-name-length-guard.test.ts`가
  실패한다. `nameInput`/`enNameInput`에 길이 제한이 없어 65536 UTF-16 코드 유닛 이상의
  이름을 저장하면 `src/serializer/doc_info.rs`의 `serialize_style()` → `byte_writer.rs`의
  `write_hwp_string()`에서 `utf16.len() as u16`이 랩어라운드되어 STYLE 레코드가 손상된다.
- **Green**: `MAX_STYLE_NAME_LEN = 250` 가드를 추가하고 두 입력 필드에 `maxLength`를
  설정, `onConfirm()`에도 방어 검증을 추가. 신규 테스트 통과.

## 변경 파일

- `rhwp-studio/src/ui/style-edit-dialog.ts`
- `rhwp-studio/tests/style-name-length-guard.test.ts` (신규)
- `mydocs/report/task_m100_2866_report.md` (신규)

`.rs` 파일은 변경하지 않았다.

## 검증

- `npm test` (rhwp-studio): 500 중 499 통과, 실패 1건은 기존 알려진
  `tests/cell-flow-boundary.test.ts` 뿐(무관).
- `npx tsc --noEmit` (rhwp-studio): 기존 TS2307 오류 2건(`@wasm/rhwp.js`)만 남고 신규 오류 없음.

Closes #2866
