### PR TITLE
fix(table): 열 삭제/셀 분할 후 local_resize_cell_widths/heights stale 인덱스 정리

### DIFF
--- a/mydocs/report/task_m100_2863_report.md
+++ b/mydocs/report/task_m100_2863_report.md
@@ -1,0 +1,50 @@
+# task-m100-2863 처리 결과 보고
+
+## 이슈
+
+#2863 — 표 열 삭제/셀 분할 시 `local_resize_cell_widths`/`heights` stale 인덱스 미정리
+(#2832/#2843/#2853 동일 버그 클래스의 마지막 인스턴스)
+
+## 원인
+
+`src/document_core/commands/table_ops.rs`의 `delete_table_column_native()`,
+`split_table_cell_native()`, `split_table_cell_into_native()`가 셀 인덱스 배치를 바꾸는
+모델 연산(`Table::delete_column()`, `Table::split_cell()`, `Table::split_cell_into()`) 호출
+직후 `table.local_resize_cell_widths` / `table.local_resize_cell_heights`를 비우지 않아,
+연산 이전 `cell_idx`를 그대로 가리키는 stale 참조가 남는 문제.
+
+이미 수정된 `insert_table_row_native()`/`insert_table_column_native()`(#2853/#2859),
+`delete_table_row_native()`(#2843/#2849), `merge_table_cells_native()`(#2832/#2841)와
+동일한 근본 원인이다.
+
+## 수정
+
+`table_ops.rs`의 세 함수에서 모델 호출 직후 `table.dirty = true;` 부근에
+`table.local_resize_cell_widths.clear();` / `table.local_resize_cell_heights.clear();`를
+추가했다(기존 4개 수정과 동일 패턴).
+
+- `delete_table_column_native()`
+- `split_table_cell_native()`
+- `split_table_cell_into_native()`
+
+## 테스트
+
+`src/wasm_api/tests.rs`에 `test_delete_table_column_and_split_cell_clear_stale_local_resize`
+1개를 추가. 2×2 표에서 열 삭제 전/셀 분할 전 각각 `local_resize_cell_widths/heights`에
+값을 채운 뒤 연산을 수행하고, 두 벡터가 비워졌는지 단언한다.
+
+- Red: 수정 전 코드(`.clear()` 제거)로 실행 시 열 삭제 단언에서 FAILED 확인.
+- Green: 수정 후 코드로 실행 시 PASS 확인.
+
+## 검증
+
+- `cargo build --lib`: 통과
+- `cargo test --lib test_delete_table_column_and_split_cell_clear_stale_local_resize`: 통과
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021` (변경 파일만): 적용
+
+## 변경 파일
+
+- `src/document_core/commands/table_ops.rs`
+- `src/wasm_api/tests.rs`
+- `mydocs/report/task_m100_2863_report.md` (본 문서)

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -148,6 +148,14 @@ impl DocumentCore {
         let row_count = table.row_count;
         let col_count = table.col_count;
 
+        // Table::delete_column()은 삭제된 열의 셀들을 cells에서 제거하므로 그 뒤 셀들의
+        // 인덱스가 앞으로 당겨진다(shift). insert_table_row_native()/insert_table_column_native()
+        // (#2853/#2859), delete_table_row_native()(#2843/#2849), merge_table_cells_native()(#2832)와
+        // 동일하게, local_resize_cell_widths/heights는 삭제 이전 cell_idx를 그대로 물고 있는
+        // Vec<(usize, u32)>라서 stale 참조가 되므로 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -211,6 +219,12 @@ impl DocumentCore {
         table.dirty = true;
         let cell_count = table.cells.len();
 
+        // Table::split_cell()은 대상 셀을 나눈 새 셀들을 push()한 뒤 재정렬하므로
+        // insert_table_row_native()/insert_table_column_native()(#2853/#2859)와 동일한 이유로
+        // local_resize_cell_widths/heights의 cell_idx가 stale해진다. 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -245,6 +259,11 @@ impl DocumentCore {
             .map_err(|e| HwpError::RenderError(e))?;
         table.dirty = true;
         let cell_count = table.cells.len();
+
+        // split_table_cell_native()와 동일한 사유(위 주석 참조): split_cell_into()도 새 셀들을
+        // push() 후 재정렬하므로 local_resize_cell_widths/heights가 stale해진다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2326,6 +2326,51 @@ fn test_split_table_cell() {
     }
 }
 
+/// [delete_table_column/split_table_cell stale local-resize] #2832/#2843/#2853과
+/// 동일한 버그 클래스의 마지막 두 인스턴스. Table::delete_column()/split_cell()이
+/// cells 배열의 인덱스 배치를 바꾸므로, local_resize_cell_widths/heights가 물고 있던
+/// 이전 cell_idx는 정리되지 않으면 stale 참조로 남는다.
+#[test]
+fn test_delete_table_column_and_split_cell_clear_stale_local_resize() {
+    let mut doc = create_doc_with_table();
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        table.local_resize_cell_widths.push((1, 1234));
+        table.local_resize_cell_heights.push((1, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+    doc.delete_table_column_native(0, 0, 0, 0).expect("열 삭제");
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "열 삭제 후 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        table.local_resize_cell_widths.push((0, 1234));
+        table.local_resize_cell_heights.push((0, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+    doc.merge_table_cells_native(0, 0, 0, 0, 0, 1, 0)
+        .expect("병합");
+    doc.split_table_cell_native(0, 0, 0, 0, 0).expect("분할");
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "셀 분할 후 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_merge_then_control_layout_has_col_span() {
     let mut doc = create_doc_with_table();


### PR DESCRIPTION
## 요약

#2863 — `delete_table_column_native()` / `split_table_cell_native()` / `split_table_cell_into_native()`가
셀 인덱스 배치를 바꾸는 모델 연산(`delete_column`/`split_cell`/`split_cell_into`) 호출 후
`local_resize_cell_widths`/`heights`를 비우지 않아 stale `cell_idx` 참조가 남는 문제를 수정합니다.

#2832(PR #2841)/#2843(PR #2849)/#2853(PR #2859)와 동일한 버그 클래스의 마지막 두 인스턴스이며,
이번 PR로 `table_ops.rs` 내 셀 인덱스 재배치 연산 전체가 커버리지를 갖추어 이 버그 클래스가 종결됩니다.

## 수정

세 함수에서 모델 호출 직후 `table.local_resize_cell_widths.clear();` /
`table.local_resize_cell_heights.clear();`를 추가했습니다(기존 4개 수정과 동일 패턴).

## Red → Green

`src/wasm_api/tests.rs::test_delete_table_column_and_split_cell_clear_stale_local_resize`

- Red: `.clear()` 제거 상태로 실행 시 열 삭제 후 단언에서 FAILED.
- Green: 수정 후 실행 시 PASS.

## 검증

- `cargo build --lib`: 통과
- `cargo test --lib test_delete_table_column_and_split_cell_clear_stale_local_resize`: 통과
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
- `rustfmt --edition 2021` (변경 파일만)

Closes #2863
