### PR TITLE
fix(#2830): HWPX MEMO 필드 subList textDirection 왕복 손실 수정

### DIFF
--- a/mydocs/report/task_m100_2830_report.md
+++ b/mydocs/report/task_m100_2830_report.md
@@ -1,0 +1,61 @@
+# Task #2830 Report — HWPX MEMO 필드 subList textDirection 왕복 손실 수정
+
+## 이슈
+
+[#2830](https://github.com/edwardkim/rhwp/issues/2830) HWPX MEMO 필드 subList
+textDirection 왕복 시 세로쓰기→가로쓰기 강제 전환.
+
+## 근본 원인
+
+- `src/parser/hwpx/section.rs` `parse_ctrl_field_begin` 의 MEMO subList 분기가
+  `<hp:subList>` 시작 태그 속성을 전혀 읽지 않고 바로 `parse_sublist_paragraphs` 로
+  문단만 추출 — `textDirection` 소실.
+- `src/serializer/hwpx/section.rs` 의 `SUB_LIST_OPEN` 이 `textDirection="HORIZONTAL"`
+  로 고정된 문자열 상수라 원본 값을 반영할 여지가 애초에 없었음.
+- header/footer/글상자 subList 경로는 이미 `parse_sublist_paragraphs_with_layout` +
+  `parse_hwpx_sublist_layout_attrs` 인프라로 `vertAlign` 등을 캡처하지만, 이는 HWP5
+  LIST_HEADER 변환용 별도 구조체(`HwpxSubListLayout`)이며 HWPX→HWPX 직렬화 경로와는
+  무관 — MEMO subList 만 두 경로 모두에서 완전히 누락된 상태였다.
+
+## 수정
+
+1. `src/model/control.rs`: `Field` 에 `memo_text_direction: Option<String>` 필드 추가
+   (기본값 `None` = "HORIZONTAL").
+2. `src/parser/hwpx/section.rs`: MEMO subList 시작 태그에서 `textDirection` 속성을
+   읽어 `"HORIZONTAL"` 이 아니면 `f.memo_text_direction` 에 저장.
+3. `src/serializer/hwpx/section.rs`: `SUB_LIST_OPEN` 상수를 `render_sub_list_open(text_direction: Option<&str>)`
+   함수로 교체, `f.memo_text_direction` 값을 반영(없으면 기존 "HORIZONTAL" 기본값
+   유지 — 회귀 없음).
+4. `Field` 리터럴을 사용하는 3곳(`src/document_core/queries/field_query.rs` 2곳,
+   `src/parser/control.rs` 1곳, 테스트 헬퍼 1곳)에 새 필드 초기화 추가.
+
+## 테스트 (레드→그린)
+
+신규 유닛 테스트 `serializer::hwpx::section::tests::memo_vertical_text_direction_roundtrips`
+(`src/serializer/hwpx/section.rs`):
+
+- MEMO 필드에 `memo_text_direction = Some("VERTICAL")` 설정 후 `write_section` 결과에
+  `<hp:subList id="" textDirection="VERTICAL" ...>` 포함 여부 확인.
+- **레드**: 수정 전(`render_sub_list_open(None)` 강제) → 결과 XML 에
+  `textDirection="HORIZONTAL"` 만 존재, assert 실패 확인.
+- **그린**: 수정 후 → 통과.
+
+## 검증
+
+```
+cargo build --lib                                              # 통과
+cargo test --lib memo_vertical_text_direction_roundtrips        # 통과 (레드→그린 확인)
+cargo test --lib                                                 # 2492 passed; 0 failed; 7 ignored
+cargo clippy --all-targets --profile release-test -- -D warnings # 경고 없음
+rustfmt --edition 2021 <변경 파일 5개>                            # git diff --name-only 는 편집한
+                                                                  # 5개 파일만 표시(포맷팅만의
+                                                                  # 추가 diff 없음)
+```
+
+## 영향 범위
+
+- MEMO 필드 subList 의 `textDirection` 만 다룸. 나머지 subList 속성
+  (`vertAlign`/`linkListIDRef`/`textWidth`/`textHeight`/`hasTextRef`/`hasNumRef`)은
+  렌더 영향이 낮아(이슈 #1893 판례와 동일 계열로 추정) 이번 스코프에서 제외했다.
+  `fieldid`/`dirty` 속성 소실은 #1893 조사에서 렌더 무해로 이미 판별된 별개 사안이라
+  이번 수정 대상에서 제외했다.

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1011,6 +1011,7 @@ fn collect_fields_from_paragraph(
                                 ctrl_data_name: Some(fname.clone()),
                                 memo_index: 0,
                                 memo_paragraphs: Vec::new(),
+                                memo_text_direction: None,
                                 raw_parameters_xml: None,
                             },
                             location: loc,
@@ -1267,6 +1268,7 @@ fn insert_click_here_field_in_para(
         },
         memo_index: 0,
         memo_paragraphs: Vec::new(),
+        memo_text_direction: None,
         raw_parameters_xml: None,
     };
 
@@ -1474,6 +1476,7 @@ mod tests {
             ctrl_data_name: None,
             memo_index: 0,
             memo_paragraphs: Vec::new(),
+            memo_text_direction: None,
             raw_parameters_xml: None,
         })
     }

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -240,6 +240,10 @@ pub struct Field {
     pub memo_index: u32,
     /// 메모 본문 문단 리스트 (`fieldBegin type="MEMO"` 내부 subList)
     pub memo_paragraphs: Vec<Paragraph>,
+    /// 메모 본문 subList 의 `textDirection` 속성 (예: "VERTICAL"). 세로쓰기 메모가
+    /// 왕복 시 가로쓰기로 뒤집히지 않도록 원본 값을 보존한다.
+    /// `None` 이면 기본값 "HORIZONTAL" 방출.
+    pub memo_text_direction: Option<String>,
     /// HWPX `<hp:parameters>` 요소 원문 verbatim (#1391).
     ///
     /// 전 fieldBegin 타입(MEMO/HYPERLINK/FORMULA/BOOKMARK 등)이 parameters 를

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -133,6 +133,7 @@ fn parse_field_control(ctrl_id: u32, ctrl_data: &[u8]) -> Control {
         ctrl_data_name: None,
         memo_index,
         memo_paragraphs: Vec::new(),
+        memo_text_direction: None,
         raw_parameters_xml: None,
     })
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4680,6 +4680,14 @@ fn parse_ctrl_field_begin(
                 if local == b"parameters" {
                     parse_field_parameters(ce, reader, &mut f)?;
                 } else if local == b"subList" && f.field_type == FieldType::Memo {
+                    for attr in ce.attributes().flatten() {
+                        if attr.key.as_ref() == b"textDirection" {
+                            let dir = attr_str(&attr);
+                            if dir != "HORIZONTAL" {
+                                f.memo_text_direction = Some(dir);
+                            }
+                        }
+                    }
                     f.memo_paragraphs = parse_sublist_paragraphs(reader, b"subList")?;
                 } else {
                     let tag = local.to_vec();

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -43,7 +43,13 @@ use super::{picture, table};
 const EMPTY_SECTION_XML: &str = include_str!("templates/empty_section0.xml");
 
 /// MEMO subList 여는 태그 (#1391) — 실물(aift) 고정 속성.
-const SUB_LIST_OPEN: &str = r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#;
+/// `textDirection` 만 원본값 보존(가변); 나머지는 실측 고정 속성.
+fn render_sub_list_open(text_direction: Option<&str>) -> String {
+    format!(
+        r#"<hp:subList id="" textDirection="{}" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="0" textHeight="0" hasTextRef="0" hasNumRef="0">"#,
+        text_direction.unwrap_or("HORIZONTAL"),
+    )
+}
 const LINESEG_SLOT_OPEN: &str = "<hp:linesegarray>";
 const LINESEG_SLOT_CLOSE: &str = "</hp:linesegarray>";
 const PARA_CLOSE: &str = "</hp:p></hs:sec>";
@@ -1177,7 +1183,7 @@ fn render_control_slot(out: &mut String, control: &Control, ctx: &mut SerializeC
                     out.push_str(params);
                 }
                 if has_memo {
-                    out.push_str(SUB_LIST_OPEN);
+                    out.push_str(&render_sub_list_open(f.memo_text_direction.as_deref()));
                     let mut vert_cursor: u32 = 0;
                     for para in &f.memo_paragraphs {
                         ctx.para_shape_ids.reference(para.para_shape_id);
@@ -2994,6 +3000,39 @@ mod tests {
         let pp = xml.find("<hp:parameters").unwrap();
         let sl = xml.find("<hp:subList").unwrap();
         assert!(pp < sl, "parameters 가 subList 보다 먼저");
+    }
+
+    #[test]
+    fn memo_vertical_text_direction_roundtrips() {
+        // [#task-m100] 세로쓰기 MEMO subList 는 파싱 시 textDirection="VERTICAL" 을
+        // 보존해야 하며, 재직렬화 시 하드코딩된 "HORIZONTAL" 로 뒤집히면 안 된다.
+        let mut f = Field::default();
+        f.field_type = FieldType::Memo;
+        f.field_id = 9;
+        f.memo_text_direction = Some("VERTICAL".to_string());
+        let mut memo_para = Paragraph::default();
+        memo_para.text = "메모".to_string();
+        f.memo_paragraphs.push(memo_para);
+
+        let mut para = Paragraph::default();
+        para.text = "x".to_string();
+        para.char_count = 18;
+        para.char_offsets = vec![8];
+        para.controls.push(Control::Field(f));
+        para.field_ranges.push(FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 1,
+            control_idx: 0,
+        });
+
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+
+        assert!(
+            xml.contains(r#"<hp:subList id="" textDirection="VERTICAL""#),
+            "세로쓰기 메모 subList 의 textDirection 보존: {xml}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

이슈 #2830. HWPX `<hp:fieldBegin type="MEMO">` 내부 `<hp:subList>`(메모 본문)의
`textDirection` 속성을 파서가 전혀 읽지 않고, 직렬화기가 항상
`textDirection="HORIZONTAL"` 을 하드코딩 방출했다. 세로쓰기(`VERTICAL`)로 작성된
메모가 hwpx→hwpx 재저장 시 가로쓰기로 강제 전환되는 정보 손실이 있었다.

## 근본 원인

- `src/parser/hwpx/section.rs` `parse_ctrl_field_begin` 의 MEMO subList 분기가
  `<hp:subList>` 시작 태그 속성을 읽지 않고 바로 문단만 추출.
- `src/serializer/hwpx/section.rs` 의 `SUB_LIST_OPEN` 이
  `textDirection="HORIZONTAL"` 고정 문자열 상수로, 원본 값을 반영할 여지가 없었음.

## 수정

1. `src/model/control.rs`: `Field` 에 `memo_text_direction: Option<String>` 추가.
2. `src/parser/hwpx/section.rs`: MEMO subList 의 `textDirection` 이 기본값이 아니면
   캡처.
3. `src/serializer/hwpx/section.rs`: `SUB_LIST_OPEN` 상수를
   `render_sub_list_open(text_direction: Option<&str>)` 함수로 교체, 캡처한 값을
   반영(없으면 기존 "HORIZONTAL" 기본값 유지 — 회귀 없음).
4. `Field` 리터럴 사용처 3곳에 신규 필드 초기화 추가.

## 레드 → 그린

`serializer::hwpx::section::tests::memo_vertical_text_direction_roundtrips`
(`src/serializer/hwpx/section.rs`):
- 수정 전: `render_sub_list_open(None)` 강제 시 결과 XML 에 `textDirection="HORIZONTAL"`
  만 존재 → assert 실패(레드) 확인.
- 수정 후: `textDirection="VERTICAL"` 보존 → 통과(그린).

## 검증

```
cargo build --lib                                              # 통과
cargo test --lib memo_vertical_text_direction_roundtrips        # 통과
cargo test --lib                                                 # 2492 passed; 0 failed; 7 ignored
cargo clippy --all-targets --profile release-test -- -D warnings # 경고 없음
```

`rustfmt --edition 2021` 적용 후 `git diff --name-only` 는 편집한 5개 소스 파일만
표시(포맷팅만의 추가 diff 없음).

## 스코프

MEMO subList 의 `textDirection` 만 다룸. `vertAlign`/`linkListIDRef` 등 나머지
subList 속성과 `fieldid`/`dirty` 속성 소실(#1893 조사에서 렌더 무해 판별됨)은
이번 수정 대상에서 제외했다.

Closes #2830