### PR TITLE
fix(hwpx): hp:pic reverse(좌우 반전) 속성 파싱 누락 및 직렬화 하드코딩 해소 (#2861)

### DIFF
--- a/mydocs/report/task_m100_2861_report.md
+++ b/mydocs/report/task_m100_2861_report.md
@@ -1,0 +1,59 @@
+# Task m100-2861: HWPX `hp:pic@reverse`(좌우 반전) 파싱 누락 + 직렬화 하드코딩 수정
+
+## 배경
+
+이슈 #2861. `<hp:pic reverse="...">` 는 그림의 좌우 반전 여부를 나타내지만, 파서는 이 속성을
+전혀 읽지 않았고(`_ => {}` 로 조용히 폐기) `Picture` IR 에도 값을 담을 필드가 없었다. 시리얼라이저는
+IR 값과 무관하게 항상 리터럴 `"0"` 을 방출했다. 결과적으로 `reverse="1"` 로 저장된(좌우 반전
+삽입된) 그림을 rhwp 로 열었다가 그대로 저장하면 반전이 풀려 원본과 다르게 렌더링됐다.
+
+`lock`(#2840), `lockForm`(#2839), `affectLSpacing`(#2784) 등과 동일한 "파싱 누락 + 직렬화
+하드코딩" 결함 유형이다.
+
+## 조사
+
+- `mydocs/plans/archives/task_43_feature_def.md:177` — `InsertPicture` 옵션 목록에 `reverse` 명시.
+- `mydocs/report/archives/task_m100_182_report.md:164` — `<hp:pic>` 방출 속성 표에 `reverse` 포함.
+- `src/parser/hwpx/section.rs` `parse_picture()` 의 `<hp:pic>` 속성 매칭 루프가 `reverse` 를
+  다루지 않음을 코드로 확인.
+- `src/serializer/hwpx/picture.rs` `write_picture()` 의 `start_tag_attrs` 호출이
+  `("reverse", "0")` 로 리터럴 고정돼 있음을 코드로 확인.
+- 바탕쪽(masterPage) `type`/`pageDuplicate`/`pageNumber`/`pageFront`/`hasTextRef`/`hasNumRef`/
+  `textDirection` 은 모두 기존 코드와 테스트에서 정상 왕복함을 `src/parser/hwpx/section.rs`,
+  `src/serializer/hwpx/master_page.rs` 를 직접 읽어 확인했다(추가 결함 없음). 이번 수정은 별도
+  요소인 `hp:pic@reverse` 를 대상으로 한다.
+
+## 수정
+
+- `src/model/image.rs`: `Picture` 에 `reverse: bool` 필드 추가.
+- `src/parser/hwpx/section.rs`: `parse_picture()` 가 `hp:pic@reverse` 속성을 읽어
+  `pic.reverse` 에 반영(`"0"` 이외 값은 `true`).
+- `src/serializer/hwpx/picture.rs`: `write_picture()` 가 `pic.reverse` 값을 `"1"`/`"0"` 으로
+  방출(종전 하드코딩 `"0"` 제거).
+- `src/wasm_api/tests.rs`: `Picture` 리터럴 초기화 2곳에 `reverse: ref_pic.reverse,` 필드 추가
+  (컴파일 유지, 참조 파일 값 그대로 전달).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::task2861_reverse_true_round_trips`
+
+- 수정 전: `pic.reverse` 필드 자체가 없어 컴파일 불가(구조적 red) — 필드 추가와 동시에
+  시리얼라이저가 `"0"` 하드코딩이면 `assert!(xml.contains(r#"reverse="1""#))` 가 실패.
+- 수정 후: `write_picture` 가 `pic.reverse` 를 반영해 `reverse="1"` 방출 → 통과.
+
+```
+cargo test --lib task2861_reverse_true_round_trips
+test serializer::hwpx::picture::tests::task2861_reverse_true_round_trips ... ok
+```
+
+## 검증
+
+- `cargo build --lib` — 통과
+- `cargo test --lib task2861_reverse_true_round_trips` — 통과
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음
+- `rustfmt --edition 2021` (변경 파일만: `src/model/image.rs`, `src/parser/hwpx/section.rs`,
+  `src/serializer/hwpx/picture.rs`, `src/wasm_api/tests.rs`)
+
+## 범위
+
+변경 파일 4개, 이슈 #2861 범위로 한정. 다른 리팩터링 없음.

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -47,6 +47,11 @@ pub struct Picture {
     /// imgClip extent 와 독립(전수 측정: 불일치 24/170) — 원본 이미지 픽셀 크기를
     /// verbatim 보존한다. (dimwidth, dimheight). HWPX 파서만 적재.
     pub img_dim: (u32, u32),
+    /// HWPX `<hp:pic reverse="...">` 좌우 반전 여부 (#2861).
+    ///
+    /// 종전엔 파서가 이 속성을 읽지 않고 시리얼라이저가 항상 "0"을 방출해
+    /// 좌우 반전 삽입된 그림의 반전 상태가 왕복 시 소실됐다.
+    pub reverse: bool,
 }
 
 /// 자르기 정보

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2218,11 +2218,13 @@ fn parse_picture(
     let mut href: Option<String> = None;
     let mut picture_instance_id = 0;
     let mut effects = PictureEffects::default();
+    let mut reverse = false; // #2861: hp:pic@reverse (좌우 반전)
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
             b"id" => common.instance_id = parse_u32(&attr),
+            b"reverse" => reverse = attr_str(&attr) != "0",
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
                 common.text_wrap = match attr_str(&attr).as_str() {
@@ -2541,6 +2543,7 @@ fn parse_picture(
     pic.effects = effects;
     pic.caption = caption;
     pic.img_dim = img_dim;
+    pic.reverse = reverse;
 
     Ok(Control::Picture(Box::new(pic)))
 }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -59,6 +59,9 @@ pub fn write_picture<W: Write>(
     let tf = text_flow_str(pic.common.text_flow);
     let instid = pic.instance_id.to_string();
     let href = pic.href.as_deref().unwrap_or("");
+    // #2861: 파싱된 IR 값을 그대로 왕복시킨다. 종전엔 리터럴 "0" 하드코딩이라
+    // reverse="1"(좌우 반전) 그림이 저장 시 반전 해제됐다.
+    let reverse = if pic.reverse { "1" } else { "0" };
 
     start_tag_attrs(
         w,
@@ -74,7 +77,7 @@ pub fn write_picture<W: Write>(
             ("href", href),
             ("groupLevel", "0"),
             ("instid", &instid),
-            ("reverse", "0"),
+            ("reverse", reverse),
         ],
     )?;
 
@@ -671,6 +674,18 @@ mod tests {
         let pic = make_picture(1); // description 빈 문자열
         let xml = serialize(&pic, &mut ctx);
         assert!(!xml.contains("<hp:shapeComment"), "빈 설명은 미방출: {xml}");
+    }
+
+    #[test]
+    fn task2861_reverse_true_round_trips() {
+        // #2861: hp:pic@reverse(좌우 반전)가 serializer 하드코딩("0")으로 항상 소실됐다.
+        // reverse=true 그림을 직렬화하면 XML 에 reverse="1" 이 방출돼야 한다.
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.reverse = true;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(xml.contains(r#"reverse="1""#), "reverse=1 방출: {xml}");
     }
 
     #[test]

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -15349,6 +15349,7 @@ fn test_save_picture() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        reverse: ref_pic.reverse,
     };
 
     // 5. 문단 구성 (참조 파일: 단일 문단에 SectionDef + ColumnDef + Picture)
@@ -16540,6 +16541,7 @@ fn test_save_pic_in_table() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        reverse: ref_pic.reverse,
     };
 
     // 6. 셀 내부 문단 구성 (cc=9: gso(8)+CR(1), mask=0x00000800)


### PR DESCRIPTION
## 요약

`<hp:pic reverse="...">`(그림 좌우 반전) 속성이 파서에서 아예 읽히지 않고, 시리얼라이저는
IR 값과 무관하게 항상 `reverse="0"` 을 방출했다. `reverse="1"` 로 저장된(좌우 반전 삽입된) 그림을
rhwp 로 열었다가 그대로 저장하면 반전이 풀렸다. Fixes #2861.

## 근거

- `mydocs/plans/archives/task_43_feature_def.md:177` — `InsertPicture` 옵션 목록에 `reverse` 명시.
- `mydocs/report/archives/task_m100_182_report.md:164` — `<hp:pic>` 방출 속성 표에 `reverse` 명시.
- `src/parser/hwpx/section.rs` `parse_picture()` 의 `<hp:pic>` 속성 매칭 루프가 `reverse` 를
  다루지 않고 `_ => {}` 로 폐기.
- `src/serializer/hwpx/picture.rs` `write_picture()` 가 `("reverse", "0")` 로 리터럴 고정.

`lock`(#2840), `lockForm`(#2839) 과 동일한 "파싱 누락 + 직렬화 하드코딩" 결함 유형.

## 수정

- `src/model/image.rs`: `Picture` 에 `reverse: bool` 필드 추가.
- `src/parser/hwpx/section.rs`: `hp:pic@reverse` 파싱 추가.
- `src/serializer/hwpx/picture.rs`: `pic.reverse` 값을 그대로 방출(하드코딩 제거).
- `src/wasm_api/tests.rs`: 신규 필드로 인한 구조체 리터럴 2곳 보정.

## 테스트 (red → green)

`src/serializer/hwpx/picture.rs::tests::task2861_reverse_true_round_trips` —
`pic.reverse = true` 로 직렬화 시 `reverse="1"` 방출을 단언. 필드 추가 전에는 컴파일 자체가
안 되고, 시리얼라이저가 하드코딩이면 assert 실패(red) → 수정 후 통과(green).

```
cargo test --lib task2861_reverse_true_round_trips
test serializer::hwpx::picture::tests::task2861_reverse_true_round_trips ... ok
```

## 검증

- `cargo build --lib` 통과
- `cargo test --lib task2861_reverse_true_round_trips` 통과
- `cargo clippy --all-targets --profile release-test -- -D warnings` 경고 없음
- `rustfmt --edition 2021` (변경 파일만)

## 범위

파일 5개, 이슈 #2861 범위로 한정. 무관한 리팩터링 없음.