### PR TITLE
fix(#2872): TableOfContents 필드 type 값 라운드트립 정합화

### DIFF
--- a/mydocs/report/task_m100_2872_report.md
+++ b/mydocs/report/task_m100_2872_report.md
@@ -1,0 +1,57 @@
+# Task #2872 처리 결과 — TableOfContents 필드 type 값 라운드트립 소실 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2872
+
+HWPX `<hp:fieldBegin type="...">`를 파싱할 때 `parse_field_type()`
+(`src/parser/hwpx/section.rs:4400`)은 `"TABLE_OF_CONTENTS"` / `"TABLEOFCONTENTS"`를
+`FieldType::TableOfContents`로 인식하지만, 직렬화기 `field_type_str()`
+(`src/serializer/hwpx/field.rs`)은 이를 `"TOC"`로 emit해왔다. `"TOC"`는 파서의 어느 분기와도
+매치되지 않아 `_ => FieldType::Unknown`으로 떨어진다. 즉 HWPX 저장→재로드 1회 왕복만으로
+목차 필드 타입이 소실된다.
+
+같은 파일 안에 `ClickHere`(#1595), `DocDate`/`UserInfo`/`Summary`(OWPML 스키마 표기 정합화)에
+대해 동일 계열 버그가 이미 수정된 이력이 있었고, `TableOfContents` 분기만 그 정리에서 누락되어
+있었다.
+
+## 원인
+
+`src/serializer/hwpx/field.rs`의 `field_type_str()`:
+
+```rust
+TableOfContents => "TOC",
+```
+
+파서가 인식하는 값과 불일치.
+
+## 수정
+
+```rust
+TableOfContents => "TABLE_OF_CONTENTS",
+```
+
+파서가 실제로 받아들이는 두 표기(`TABLE_OF_CONTENTS`/`TABLEOFCONTENTS`) 중 하나로 emit하도록
+정합화.
+
+## 테스트 (red → green)
+
+- 기존 `field_type_str_covers_main_variants` 테스트가 버그 값(`"TOC"`)을 그대로 검증하고
+  있어 이를 올바른 기대값(`"TABLE_OF_CONTENTS"`)으로 교체.
+- 신규 테스트 `field_type_str_toc_round_trips_through_hwpx_parser` 추가:
+  수정 전 코드에서는 `field_type_str(FieldType::TableOfContents)`가 `"TOC"`를 반환해
+  실패(red), 수정 후에는 `"TABLE_OF_CONTENTS"`를 반환해 통과(green).
+
+## 검증
+
+- `cargo build --lib` — 통과
+- `cargo test --lib field_type_str` — 3개 테스트 통과
+  (`field_type_str_covers_main_variants`, `field_type_str_matches_owpml_schema`,
+  `field_type_str_toc_round_trips_through_hwpx_parser`)
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음
+- `rustfmt --edition 2021 src/serializer/hwpx/field.rs` — 적용
+
+## 변경 파일
+
+- `src/serializer/hwpx/field.rs` (수정)
+- `mydocs/report/task_m100_2872_report.md` (신규, 본 문서)

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -183,7 +183,7 @@ fn field_type_str(t: FieldType) -> &'static str {
         Hyperlink => "HYPERLINK",
         Memo => "MEMO",
         PrivateInfoSecurity => "PRIVATE_INFO",
-        TableOfContents => "TOC",
+        TableOfContents => "TABLE_OF_CONTENTS",
     }
 }
 
@@ -252,6 +252,21 @@ mod tests {
         assert_eq!(field_type_str(FieldType::Hyperlink), "HYPERLINK");
         assert_eq!(field_type_str(FieldType::Bookmark), "BOOKMARK");
         assert_eq!(field_type_str(FieldType::Date), "DATE");
-        assert_eq!(field_type_str(FieldType::TableOfContents), "TOC");
+        assert_eq!(
+            field_type_str(FieldType::TableOfContents),
+            "TABLE_OF_CONTENTS"
+        );
+    }
+
+    #[test]
+    fn field_type_str_toc_round_trips_through_hwpx_parser() {
+        // [#2845] 종전 "TOC" 방출은 parse_field_type()이 인식하지 못해(매칭 분기 없음)
+        // 재파싱 시 FieldType::Unknown 으로 떨어졌다(TOC 필드 정체성 소실). 파서가
+        // 실제로 받아들이는 "TABLE_OF_CONTENTS"/"TABLEOFCONTENTS" 중 하나와 일치해야
+        // HWPX 저장→재로드 라운드트립에서 TOC 필드가 살아남는다.
+        assert_eq!(
+            field_type_str(FieldType::TableOfContents),
+            "TABLE_OF_CONTENTS"
+        );
     }
 }


### PR DESCRIPTION
## 요약

- `src/serializer/hwpx/field.rs`의 `field_type_str()`에서 `FieldType::TableOfContents`가
  `"TOC"`를 emit했으나, 파서 `parse_field_type()`(`src/parser/hwpx/section.rs:4400`)은
  `"TABLE_OF_CONTENTS"`/`"TABLEOFCONTENTS"`만 인식한다. `"TOC"`는 어느 분기와도 매치되지
  않아 `FieldType::Unknown`으로 떨어져, HWPX 저장→재로드 1회 왕복만으로 목차 필드 정체성이
  소실되는 버그였다.
- 같은 파일에서 `ClickHere`(#1595)와 `DocDate`/`UserInfo`/`Summary`(OWPML 스키마 표기 정합화)에
  대해 이미 동일 계열 버그가 수정된 이력이 있었고, `TableOfContents` 분기만 누락되어 있었다.
- `TableOfContents => "TABLE_OF_CONTENTS"`로 수정.

이슈: #2872

## Red → Green

- 기존 `field_type_str_covers_main_variants` 테스트가 버그 값(`"TOC"`)을 검증하고 있어
  올바른 기대값(`"TABLE_OF_CONTENTS"`)으로 교체.
- 신규 테스트 `field_type_str_toc_round_trips_through_hwpx_parser` 추가.
  - 수정 전: `field_type_str(FieldType::TableOfContents)` == `"TOC"` → 어서션 실패 (red)
  - 수정 후: `field_type_str(FieldType::TableOfContents)` == `"TABLE_OF_CONTENTS"` → 통과 (green)

## Test plan

- [x] `cargo build --lib`
- [x] `cargo test --lib field_type_str` (3 passed)
- [x] `cargo clippy --all-targets --profile release-test -- -D warnings` (경고 없음)
- [x] `rustfmt --edition 2021 src/serializer/hwpx/field.rs`