### PR TITLE
fix(hwpx): hp:pic lock(개체 잠금) 속성 파싱·저장 유실 수정 (#2875)

### DIFF
--- a/mydocs/report/task_m100_2875_report.md
+++ b/mydocs/report/task_m100_2875_report.md
@@ -1,0 +1,48 @@
+# task_m100_2875 처리 결과 보고
+
+## 이슈
+
+#2875 — `hp:pic lock`(개체 잠금) 속성이 파싱되지 않고 직렬화 시 항상 0으로 하드코딩됨
+
+## 원인
+
+`<hp:pic>`(그림 개체)의 `lock` 속성은 파서(`src/parser/hwpx/section.rs` `parse_picture()`)의 속성
+매치 리스트에 없어 조용히 버려졌고, 직렬화기(`src/serializer/hwpx/picture.rs` `write_picture()`)는
+`("lock", "0")`을 항상 하드코딩 방출했다. `Picture` IR(`src/model/image.rs`)에도 값을 보관할 필드가
+없었다. `<hp:tbl>`(#2855/#2867), `hp:equation`(#2840/#2850)에서 이미 확인·수정된 것과 동일한 패턴이
+`<hp:pic>`에서만 남아 있었다.
+
+## 조사 범위 — 겸사 확인한 형제 속성
+
+- `<hp:pic reverse>`(좌우 반전): #2861/#2869 로 이미 수정됨(별도 이슈).
+- `groupLevel`/`numberingType`: 이슈 #2745(PR #2746)에서 이미 다룸 — 본 작업에서 손대지 않음.
+- `flip`(좌우/상하 반전)·`rotationInfo`(회전각): `hp:flip`/`hp:rotationInfo` 자식 요소로 이미 완전히
+  파싱·직렬화되어 왕복 보존됨을 코드로 확인(`parse_shape_flip`/`parse_shape_rotation_info`,
+  `write_flip`/`write_rotation_info`) — 갭 없음.
+
+## 수정
+
+1. `src/model/image.rs`: `Picture` 구조체에 `pub lock: bool` 필드 추가.
+2. `src/parser/hwpx/section.rs`: `parse_picture()`에 `b"lock" => lock = attr_str(&attr) == "1"` 매치
+   추가, 파싱 종료 시 `pic.lock = lock` 반영.
+3. `src/serializer/hwpx/picture.rs`: `write_picture()`에서 `("lock", "0")` 하드코딩을
+   `("lock", bool01(pic.lock))`로 교체.
+4. `src/wasm_api/tests.rs`: `Picture` 구조체 리터럴 2곳에 신규 필드 `lock: false` 추가(컴파일 정합성).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::issue2875_pic_lock_is_preserved_on_serialize` 신규 추가:
+`pic.lock = true` 설정 후 직렬화 결과에 `lock="1"`이 포함되는지 단언. 수정 전에는 하드코딩 `"0"`
+때문에 실패(red), 수정 후 통과(green)를 코드 리뷰로 확인.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib issue2875_pic_lock_is_preserved_on_serialize`: 1 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021`(변경 파일만): 적용, 기능적 diff 없음
+
+## 관련
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2875
+- 전례: #2861/#2869(hp:pic reverse), #2855/#2867(hp:tbl lock), #2840/#2850(hp:equation lock)

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -47,6 +47,9 @@ pub struct Picture {
     /// imgClip extent 와 독립(전수 측정: 불일치 24/170) — 원본 이미지 픽셀 크기를
     /// verbatim 보존한다. (dimwidth, dimheight). HWPX 파서만 적재.
     pub img_dim: (u32, u32),
+    /// HWPX `<hp:pic lock="...">` 값 — 개체 잠금(보호) 여부. 파서가 읽지 않고
+    /// 직렬화기가 항상 "0"을 방출해 lock="1"로 저장된 그림이 왕복 시 잠금 해제됐다.
+    pub lock: bool,
 }
 
 /// 자르기 정보

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2218,6 +2218,7 @@ fn parse_picture(
     let mut href: Option<String> = None;
     let mut picture_instance_id = 0;
     let mut effects = PictureEffects::default();
+    let mut lock = false;
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
@@ -2251,6 +2252,9 @@ fn parse_picture(
                 }
             }
             b"groupLevel" => shape_attr.group_level = attr_str(&attr).parse().unwrap_or(0),
+            // [#2875] 개체 잠금(보호). 종전 미매칭으로 조용히 버려져 직렬화 시 항상
+            // lock="0" 하드코딩되던 유실 — #2861(reverse), #2855(hp:tbl lock)과 동일 패턴.
+            b"lock" => lock = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -2541,6 +2545,7 @@ fn parse_picture(
     pic.effects = effects;
     pic.caption = caption;
     pic.img_dim = img_dim;
+    pic.lock = lock;
 
     Ok(Control::Picture(Box::new(pic)))
 }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -59,6 +59,9 @@ pub fn write_picture<W: Write>(
     let tf = text_flow_str(pic.common.text_flow);
     let instid = pic.instance_id.to_string();
     let href = pic.href.as_deref().unwrap_or("");
+    // [#2875] 개체 잠금 — 종전 하드코딩 "0" 은 lock="1" 로 저장된 그림의 잠금 정보를
+    // 왕복 시 소실시켰다 (#2861 reverse, #2855 hp:tbl lock 과 동일 패턴).
+    let lock = bool01(pic.lock);
 
     start_tag_attrs(
         w,
@@ -69,7 +72,7 @@ pub fn write_picture<W: Write>(
             ("numberingType", "PICTURE"),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            ("lock", lock),
             ("dropcapstyle", "None"),
             ("href", href),
             ("groupLevel", "0"),
@@ -554,6 +557,20 @@ mod tests {
         let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
         write_picture(&mut w, pic, ctx).expect("write_picture");
         String::from_utf8(w.into_inner()).unwrap()
+    }
+
+    // [#2875] hp:pic lock="1" 이 IR 에 있어도 종전에는 하드코딩 "0" 으로 방출됐다.
+    #[test]
+    fn issue2875_pic_lock_is_preserved_on_serialize() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.lock = true;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "hp:pic lock=1 이 저장 시 보존돼야 한다: {xml}"
+        );
     }
 
     #[test]

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -15349,6 +15349,7 @@ fn test_save_picture() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        lock: false,
     };
 
     // 5. 문단 구성 (참조 파일: 단일 문단에 SectionDef + ColumnDef + Picture)
@@ -16540,6 +16541,7 @@ fn test_save_pic_in_table() {
         effects: ref_pic.effects.clone(),
         caption: None,
         img_dim: (0, 0),
+        lock: false,
     };
 
     // 6. 셀 내부 문단 구성 (cc=9: gso(8)+CR(1), mask=0x00000800)


### PR DESCRIPTION
## 요약

hp:pic 의 lock(개체 잠금) 속성이 파서에서 읽히지 않고 IR 에도 필드가 없어, 직렬화기가
항상 lock="0" 을 하드코딩 방출했다. #2861(reverse), #2855(hp:tbl lock)과 동일 패턴.

## Red → Green

`src/serializer/hwpx/picture.rs::tests::issue2875_pic_lock_is_preserved_on_serialize`:
`pic.lock = true` 설정 후 직렬화 결과에 `lock="1"` 포함을 단언. 수정 전 하드코딩 `"0"` 때문에
실패(red) → `Picture.lock` 필드/파서/직렬화기 반영 후 통과(green).

## 검증

- `cargo build --lib`: 성공
- `cargo test --lib issue2875_pic_lock_is_preserved_on_serialize`: 1 passed
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
- `rustfmt --edition 2021`(변경 파일만)

Closes #2875
