### PR TITLE
fix(#2878): 누름틀 안내문/메모 입력 길이 미검증으로 인한 CTRL_DATA 손상 방지

### DIFF
--- a/mydocs/report/task_m100_2878_report.md
+++ b/mydocs/report/task_m100_2878_report.md
@@ -1,0 +1,55 @@
+# Task #m100-2878 처리 결과 보고
+
+## 이슈
+
+#2878 — 누름틀(ClickHere) 안내문(guide)/메모(memo) 입력 길이 미검증 → CTRL_DATA(command) `u16` 캐스팅
+랩어라운드로 저장 파일 손상. #2851(필드 이름)/#2862(책갈피 이름)/#2866(스타일 이름)와 동일 근본 원인의
+형제 필드 재발 인스턴스.
+
+## 스윕 경과
+
+`rhwp-studio/src/ui/*.ts`, `rhwp-studio/src/engine/*.ts` 전수 조사(`<input>`/`<textarea>`/`prompt()` →
+`wasm.*` 경로) 결과, 남은 후보 다수는 SAFE로 확인됨(폰트셋 이름·검색/바꾸기·히스토리 라벨 등은 wasm/직렬화기에
+도달하지 않거나 u32/텍스트 경로를 씀). 다음 두 후보는 같은 `write_hwp_string`(`src/serializer/byte_writer.rs:70-76`,
+`utf16.len() as u16`) 싱크로 향하는 **잠재 취약 소견**으로 확인했으나, 이번 작업 스코프에서는 제외하고 별도 이슈로
+분리할 것을 권고함:
+
+- 개체 설명문(`rhwp-studio/src/ui/picture-props-dialog.ts` `descInput`) → `src/serializer/control.rs:1905`
+- 수식 스크립트(`rhwp-studio/src/ui/equation-editor-dialog.ts`, `equation-props-dialog.ts` `scriptArea`) → `src/serializer/control.rs:2386`
+
+guide/memo는 즉시 조치 가능한 명확한 인스턴스로 판단해 이번 작업에서 수정함.
+
+## 근본 원인
+
+`rhwp-studio/src/ui/field-edit-dialog.ts`/`field-insert-dialog.ts`의 `guideInput`/`memoInput`이 길이
+제한 없이 `wasm.updateClickHereProps`/`wasm.insertClickHereField`로 전달되고, `src/serializer/control.rs`의
+누름틀 CTRL_DATA 직렬화가 guide/memo를 포함한 `f.command` 전체 UTF-16 길이를 `cmd_len as u16`으로 기록한다.
+합산 길이가 65536 코드 유닛 이상이면 랩어라운드되어 손상된 레코드가 생성된다. `name` 필드는 #2851에서
+`MAX_FIELD_NAME_LEN(250)` 가드가 추가되었으나 `guide`/`memo`는 미가드 상태였다.
+
+## 수정 (TypeScript만, `.rs` 미변경)
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`: `MAX_FIELD_GUIDE_LEN(250)`, `MAX_FIELD_MEMO_LEN(1000)` 상수
+  추가. `guideInput`/`memoInput`에 `maxLength` 속성과 에러 라벨을 추가하고, `onConfirm()`에서 길이 검증 실패
+  시 `false`를 반환해 다이얼로그가 닫히지 않도록(적용을 막도록) 변경.
+- `rhwp-studio/src/ui/field-insert-dialog.ts`: 동일 상수를 `field-edit-dialog.ts`에서 import해 동일 가드
+  적용.
+
+## 검증(적색→녹색)
+
+- 적색: 수정 전 `guideInput`/`memoInput`에 `maxLength`/길이 검증이 전혀 없었음(코드 확인).
+- 신규 소스 가드 테스트: `rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts`
+  — `MAX_FIELD_GUIDE_LEN`/`MAX_FIELD_MEMO_LEN` 상수가 존재하고 합산 한도가 u16 랩어라운드 지점(65536)보다
+  충분히 작은지 검증. 수정 후 통과.
+- `cd rhwp-studio && npm test`: 500개 중 499 통과, 1건(`tests/cell-flow-boundary.test.ts`) 실패 — 이 실패는
+  wasm 빌드 산출물 부재로 인한 기존(베이스라인) 실패이며 `field-edit-dialog.ts`/`field-insert-dialog.ts`를
+  참조하지 않음(grep 확인, 무관 확인).
+- `npx tsc --noEmit`: `@wasm/rhwp.js` 모듈을 찾을 수 없다는 기존(베이스라인) 오류만 있음(wasm 빌드 산출물
+  부재), 이번 변경으로 인한 신규 타입 오류 없음.
+
+## 변경 파일
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`
+- `rhwp-studio/src/ui/field-insert-dialog.ts`
+- `rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts` (신규)
+- `mydocs/report/task_m100_2878_report.md` (본 보고서)

--- a/rhwp-studio/src/ui/field-edit-dialog.ts
+++ b/rhwp-studio/src/ui/field-edit-dialog.ts
@@ -12,11 +12,28 @@ export interface ClickHereProps {
   editable: boolean;
 }
 
+/**
+ * 안내문(guide)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 누름틀 CTRL_DATA 레코드에 안내문과
+ * 메모를 포함한 command 문자열 전체 길이를 `cmd_len as u16`으로 기록한다. 두 필드의
+ * 합산 UTF-16 코드 유닛 수가 65536 이상이면 이 캐스팅이 랩어라운드되어 길이
+ * 프리픽스와 실제 기록된 바이트 수가 어긋난 손상된 레코드가 만들어진다(#2851과
+ * 동일 원인, guide/memo 형제 필드 재발). `.rs`를 수정하지 않는 범위에서, 손상 가능한
+ * 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은 상한으로 미리 막는다.
+ */
+export const MAX_FIELD_GUIDE_LEN = 250;
+
+/** 메모(memo)의 안전한 상한 길이(문자 수). 근거는 {@link MAX_FIELD_GUIDE_LEN} 참고. */
+export const MAX_FIELD_MEMO_LEN = 1000;
+
 export class FieldEditDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
   private memoInput!: HTMLTextAreaElement;
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
+  private guideErrorLabel!: HTMLDivElement;
+  private memoErrorLabel!: HTMLDivElement;
 
   /** 적용 콜백 */
   onApply: ((props: ClickHereProps) => void) | null = null;
@@ -71,7 +88,16 @@ export class FieldEditDialog extends ModalDialog {
     this.guideInput = document.createElement('input');
     this.guideInput.type = 'text';
     this.guideInput.className = 'field-edit-input';
+    this.guideInput.maxLength = MAX_FIELD_GUIDE_LEN;
     panel.appendChild(this.guideInput);
+
+    this.guideErrorLabel = document.createElement('div');
+    this.guideErrorLabel.className = 'field-edit-error';
+    this.guideErrorLabel.style.color = '#c00';
+    this.guideErrorLabel.style.fontSize = '11px';
+    this.guideErrorLabel.style.display = 'none';
+    this.guideErrorLabel.textContent = `안내문은 ${MAX_FIELD_GUIDE_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.guideErrorLabel);
 
     // ── 메모 내용(M) ──
     const memoLabel = document.createElement('label');
@@ -82,7 +108,16 @@ export class FieldEditDialog extends ModalDialog {
     this.memoInput = document.createElement('textarea');
     this.memoInput.className = 'field-edit-textarea';
     this.memoInput.rows = 4;
+    this.memoInput.maxLength = MAX_FIELD_MEMO_LEN;
     panel.appendChild(this.memoInput);
+
+    this.memoErrorLabel = document.createElement('div');
+    this.memoErrorLabel.className = 'field-edit-error';
+    this.memoErrorLabel.style.color = '#c00';
+    this.memoErrorLabel.style.fontSize = '11px';
+    this.memoErrorLabel.style.display = 'none';
+    this.memoErrorLabel.textContent = `메모 내용은 ${MAX_FIELD_MEMO_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.memoErrorLabel);
 
     // ── 필드 이름(N) ──
     const nameLabel = document.createElement('label');
@@ -109,7 +144,24 @@ export class FieldEditDialog extends ModalDialog {
     return body;
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): void | boolean {
+    let valid = true;
+    if (this.guideInput.value.length > MAX_FIELD_GUIDE_LEN) {
+      this.guideErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.guideErrorLabel.style.display = 'none';
+    }
+    if (this.memoInput.value.length > MAX_FIELD_MEMO_LEN) {
+      this.memoErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.memoErrorLabel.style.display = 'none';
+    }
+    if (!valid) {
+      return false;
+    }
+
     if (this.onApply) {
       this.onApply({
         guide: this.guideInput.value,

--- a/rhwp-studio/src/ui/field-insert-dialog.ts
+++ b/rhwp-studio/src/ui/field-insert-dialog.ts
@@ -5,13 +5,19 @@
  * 양식 모드 편집 가능 여부를 입력한다.
  */
 import { ModalDialog } from './dialog';
-import type { ClickHereProps } from './field-edit-dialog';
+import {
+  MAX_FIELD_GUIDE_LEN,
+  MAX_FIELD_MEMO_LEN,
+  type ClickHereProps,
+} from './field-edit-dialog';
 
 export class FieldInsertDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
   private memoInput!: HTMLTextAreaElement;
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
+  private guideErrorLabel!: HTMLDivElement;
+  private memoErrorLabel!: HTMLDivElement;
 
   onApply: ((props: ClickHereProps) => void) | null = null;
 
@@ -44,7 +50,16 @@ export class FieldInsertDialog extends ModalDialog {
     this.guideInput.type = 'text';
     this.guideInput.className = 'field-edit-input';
     this.guideInput.value = '입력하세요';
+    this.guideInput.maxLength = MAX_FIELD_GUIDE_LEN;
     panel.appendChild(this.guideInput);
+
+    this.guideErrorLabel = document.createElement('div');
+    this.guideErrorLabel.className = 'field-edit-error';
+    this.guideErrorLabel.style.color = '#c00';
+    this.guideErrorLabel.style.fontSize = '11px';
+    this.guideErrorLabel.style.display = 'none';
+    this.guideErrorLabel.textContent = `안내문은 ${MAX_FIELD_GUIDE_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.guideErrorLabel);
 
     const memoLabel = document.createElement('label');
     memoLabel.className = 'field-edit-label';
@@ -54,7 +69,16 @@ export class FieldInsertDialog extends ModalDialog {
     this.memoInput = document.createElement('textarea');
     this.memoInput.className = 'field-edit-textarea';
     this.memoInput.rows = 4;
+    this.memoInput.maxLength = MAX_FIELD_MEMO_LEN;
     panel.appendChild(this.memoInput);
+
+    this.memoErrorLabel = document.createElement('div');
+    this.memoErrorLabel.className = 'field-edit-error';
+    this.memoErrorLabel.style.color = '#c00';
+    this.memoErrorLabel.style.fontSize = '11px';
+    this.memoErrorLabel.style.display = 'none';
+    this.memoErrorLabel.textContent = `메모 내용은 ${MAX_FIELD_MEMO_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.memoErrorLabel);
 
     const nameLabel = document.createElement('label');
     nameLabel.className = 'field-edit-label';
@@ -79,7 +103,24 @@ export class FieldInsertDialog extends ModalDialog {
     return body;
   }
 
-  protected onConfirm(): void {
+  protected onConfirm(): void | boolean {
+    let valid = true;
+    if (this.guideInput.value.length > MAX_FIELD_GUIDE_LEN) {
+      this.guideErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.guideErrorLabel.style.display = 'none';
+    }
+    if (this.memoInput.value.length > MAX_FIELD_MEMO_LEN) {
+      this.memoErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.memoErrorLabel.style.display = 'none';
+    }
+    if (!valid) {
+      return false;
+    }
+
     this.onApply?.({
       guide: this.guideInput.value,
       memo: this.memoInput.value,

--- a/rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts
+++ b/rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2878 (#2851 형제 필드 재발): 누름틀(ClickHere) 안내문(guide)/메모(memo) 입력 길이
+// 미검증 → Rust 직렬화기(src/serializer/control.rs)가 guide/memo를 포함한 command
+// 문자열 전체 길이를 `cmd_len as u16`으로 기록할 때 랩어라운드되어 CTRL_DATA 레코드가
+// 손상될 수 있었다. `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출
+// 전에 guide/memo 길이를 안전한 상한(MAX_FIELD_GUIDE_LEN/MAX_FIELD_MEMO_LEN)으로
+// 막는지를 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, '../src/ui/field-edit-dialog.ts'), 'utf8');
+
+test('누름틀 안내문/메모 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const guideMatch = src.match(/MAX_FIELD_GUIDE_LEN\s*=\s*(\d+)/);
+  const memoMatch = src.match(/MAX_FIELD_MEMO_LEN\s*=\s*(\d+)/);
+  assert.ok(guideMatch, 'MAX_FIELD_GUIDE_LEN 상수를 찾을 수 없음');
+  assert.ok(memoMatch, 'MAX_FIELD_MEMO_LEN 상수를 찾을 수 없음');
+
+  const guideLimit = Number(guideMatch![1]);
+  const memoLimit = Number(memoMatch![1]);
+
+  assert.ok(
+    guideLimit > 0 && memoLimit > 0 && guideLimit + memoLimit < 65536,
+    `합산 한도(${guideLimit + memoLimit})가 u16 랩어라운드 지점보다 작아야 함`,
+  );
+});


### PR DESCRIPTION
## 요약

#2878에서 확인된, 누름틀(ClickHere) 필드의 안내문(guide)/메모(memo) 입력이 길이 제한 없이
`wasm.updateClickHereProps`/`wasm.insertClickHereField`로 전달되어 CTRL_DATA 레코드 손상을
유발할 수 있는 문제를 수정합니다. #2851(필드 이름)/#2862(책갈피 이름)/#2866(스타일 이름)와
동일한 근본 원인(u16 길이 프리픽스 캐스팅 랩어라운드)의 형제 필드 재발 인스턴스입니다.

## 근본 원인

`src/serializer/control.rs`의 누름틀 CTRL_DATA 직렬화는 guide/memo를 포함한 `f.command`
전체 UTF-16 길이를 `cmd_len as u16`으로 기록합니다:

```rust
let cmd_utf16: Vec<u16> = f.command.encode_utf16().collect();
let cmd_len = cmd_utf16.len();
...
data.extend_from_slice(&(cmd_len as u16).to_le_bytes());
```

`guide`/`memo` 합산 UTF-16 코드 유닛 수가 65536 이상이면 이 캐스팅이 랩어라운드되어 길이
프리픽스와 실제 기록된 바이트 수가 어긋난 손상된 레코드가 만들어집니다. `name` 필드는 #2851에서
가드되었으나 `guide`/`memo`는 미가드 상태였습니다.

## 수정 (TypeScript만, `.rs` 미변경)

- `rhwp-studio/src/ui/field-edit-dialog.ts`: `MAX_FIELD_GUIDE_LEN(250)`, `MAX_FIELD_MEMO_LEN(1000)`
  가드 추가, `onConfirm()`에서 검증 실패 시 적용 차단.
- `rhwp-studio/src/ui/field-insert-dialog.ts`: 동일 가드 적용.

## 적색 → 녹색

- 적색: 수정 전 `guideInput`/`memoInput`에 `maxLength`/길이 검증이 전혀 없었음.
- 신규 소스 가드 테스트 `rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts`:
  `MAX_FIELD_GUIDE_LEN`/`MAX_FIELD_MEMO_LEN` 상수 존재 및 합산 한도가 u16 랩어라운드 지점(65536)보다
  작은지 검증. 수정 후 통과.

## 검증

- `cd rhwp-studio && npm test`: 500개 중 499 통과. 실패 1건(`tests/cell-flow-boundary.test.ts`)은
  wasm 빌드 산출물 부재로 인한 기존 베이스라인 실패이며 이번 변경 파일과 무관함(확인 완료).
- `npx tsc --noEmit`: `@wasm/rhwp.js` 모듈 부재(기존 베이스라인, wasm 미빌드)만 있고, 이번 변경으로 인한
  신규 타입 오류 없음.

## 스윕 비고

이번 작업은 `rhwp-studio/src/ui`, `rhwp-studio/src/engine` 전수 스윕의 일부로 수행되었습니다. 개체
설명문(`picture-props-dialog.ts`)과 수식 스크립트(`equation-editor-dialog.ts`/`equation-props-dialog.ts`)도
동일한 `write_hwp_string`(`src/serializer/byte_writer.rs:70-76`) u16 캐스팅 싱크로 향하고 있어 잠재
취약 소견이 있으나, 스코프 판단을 위해 이번 PR에서는 제외하고 별도 이슈로 분리했습니다.

세부 처리 결과는 `mydocs/report/task_m100_2878_report.md` 참고.