### PR TITLE
fix(hwpx): hp:pic dropcapstyle(드롭캡) 속성 파싱/방출 누락 해소

### DIFF
--- a/mydocs/report/task_m100_2887_report.md
+++ b/mydocs/report/task_m100_2887_report.md
@@ -1,0 +1,74 @@
+# 완료 보고서 — Task M100-2887
+
+- 이슈: #2887
+- 제목: `hp:pic` `dropcapstyle` 라운드트립 유실 — 파서 미인식으로 저장 시 무조건 None
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2887-pic-dropcapstyle`
+
+## 1. 완료 내용
+
+`<hp:pic>`(그림 개체) 를 감싼 문단의 `dropcapstyle`(드롭캡 표시 방식:
+`None`/`DoubleLine`/`TripleLine`/`Margin`, OWPML Core 스키마 `DropCapStyleType`)
+속성이 파서에서 아예 읽히지 않아, 직렬화기가 항상 `dropcapstyle="None"`을
+하드코딩 방출하던 버그를 고쳤다. `lock`(개체 잠금) 라운드트립 버그
+(#2840 수식, #2855 표)와 동일한 유형("파서 미인식 속성 → 직렬화기 상수
+하드코딩")이며, 이번 PR은 `hp:pic` 1건으로 범위를 좁혔다.
+
+## 2. 근거 (수정 전)
+
+- `src/serializer/hwpx/picture.rs::write_picture()` — `("dropcapstyle", "None")`
+  리터럴 고정 방출.
+- `src/parser/hwpx/section.rs::parse_picture()` — `<hp:pic>` 속성 루프
+  (`id`/`zOrder`/`textWrap`/`textFlow`/`instid`/`href`/`groupLevel`)에
+  `dropcapstyle` 분기 없음.
+- `src/model/shape.rs::CommonObjAttr` — 드롭캡 상태를 보존할 필드 자체가
+  없었음.
+
+## 3. 주요 변경
+
+- `src/model/shape.rs`
+  - `CommonObjAttr`에 `drop_cap_style: DropCapStyle` 필드 추가.
+  - `DropCapStyle` enum 추가 (`None`/`DoubleLine`/`TripleLine`/`Margin`,
+    OWPML `DropCapStyleType` 그대로 매핑).
+- `src/parser/hwpx/section.rs`
+  - `parse_picture()`의 `<hp:pic>` 속성 루프에 `b"dropcapstyle"` 분기 추가
+    — `DoubleLine`/`TripleLine`/`Margin`/그 외(`None`)로 파싱.
+- `src/serializer/hwpx/shape.rs`
+  - `drop_cap_style_str()` 헬퍼 추가 (기존 `numbering_type_str()`과 동형).
+- `src/serializer/hwpx/picture.rs`
+  - `write_picture()`가 하드코딩 `"None"` 대신
+    `super::shape::drop_cap_style_str(pic.common.drop_cap_style)` 방출.
+- `src/document_core/converters/common_obj_attr_writer.rs`
+  - 테스트 헬퍼 `make_sample()`의 `CommonObjAttr` 리터럴 초기화에
+    `drop_cap_style: DropCapStyle::None` 필드 추가 (신규 필드로 인한
+    컴파일 에러 해소, 동작 변경 없음).
+
+## 4. 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::dropcapstyle_round_trips_instead_of_always_none`
+
+- Red (수정 전): `pic.common.drop_cap_style = DropCapStyle::TripleLine`로
+  직렬화해도 출력이 `dropcapstyle="None"`으로 고정돼 실패.
+- Green (수정 후): 출력에 `dropcapstyle="TripleLine"` 포함, 통과.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib dropcapstyle_round_trips_instead_of_always_none`
+  (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021` (변경 파일만)
+
+## 6. 범위 제한 / 후속 과제
+
+`dropcapstyle="None"` 하드코딩은 `hp:rect`/`hp:line`/`hp:tbl`/`hp:equation`
+등 다른 개체 직렬화기에도 동일하게 있으나, 이번 PR은 `hp:pic` 단독으로
+범위를 좁혔다. 나머지 개체 종류로의 확장은 후속 이슈로 남긴다.
+
+또한 `origin/devel` 현재 상태를 `git log -S`·`git grep`으로 확인한 결과
+`CommonObjAttr.locked` 필드는 아직 병합되지 않았고(#2840, #2855 모두
+devel 미반영), `hp:tbl`의 `lock`도 여전히 `bool01(false)` 상수 방출
+중이다. 따라서 `lock` 필드와 충돌 없이 독립적인 `dropcapstyle` 속성을
+선택했다.

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -228,6 +228,7 @@ mod tests {
             description: String::new(),
             raw_extra: Vec::new(),
             numbering_type: crate::model::shape::ObjectNumberingType::None,
+            drop_cap_style: crate::model::shape::DropCapStyle::None,
         }
     }
 

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -90,6 +90,12 @@ pub struct CommonObjAttr {
     /// HWP5 파서는 설정하지 않는다 (기본 None). HWPX 그리기 개체의
     /// `numberingType="PICTURE"` 등을 라운드트립 보존하기 위한 필드.
     pub numbering_type: ObjectNumberingType,
+    /// HWPX `dropcapstyle` (개체를 감싼 단락의 드롭캡 표시 방식) 보존.
+    ///
+    /// 파서가 읽지 않으면 방출측(picture.rs 등)이 항상 `dropcapstyle="None"`으로
+    /// 되돌려, 원본이 `DoubleLine`/`TripleLine`/`Margin` 드롭캡으로 개체를 감싼
+    /// 문단이었더라도 저장 시 드롭캡 스타일이 유실된다.
+    pub drop_cap_style: DropCapStyle,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
 }
@@ -102,6 +108,16 @@ pub enum ObjectNumberingType {
     Picture,
     Table,
     Equation,
+}
+
+/// HWPX 개체 `dropcapstyle` (드롭캡 표시 방식). OWPML Core 스키마 `DropCapStyleType`.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum DropCapStyle {
+    #[default]
+    None,
+    DoubleLine,
+    TripleLine,
+    Margin,
 }
 
 /// 세로 위치 기준

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2251,6 +2251,18 @@ fn parse_picture(
                 }
             }
             b"groupLevel" => shape_attr.group_level = attr_str(&attr).parse().unwrap_or(0),
+            // dropcapstyle (개체를 감싼 문단의 드롭캡 표시 방식) 보존.
+            // 미파싱 상태에서는 picture.rs 방출측이 항상 "None"으로 되돌려,
+            // DoubleLine/TripleLine/Margin 드롭캡 문단에 있던 그림이 저장 시
+            // 드롭캡 스타일을 잃는다.
+            b"dropcapstyle" => {
+                common.drop_cap_style = match attr_str(&attr).as_str() {
+                    "DoubleLine" => crate::model::shape::DropCapStyle::DoubleLine,
+                    "TripleLine" => crate::model::shape::DropCapStyle::TripleLine,
+                    "Margin" => crate::model::shape::DropCapStyle::Margin,
+                    _ => crate::model::shape::DropCapStyle::None,
+                };
+            }
             _ => {}
         }
     }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -70,7 +70,10 @@ pub fn write_picture<W: Write>(
             ("textWrap", tw),
             ("textFlow", tf),
             ("lock", "0"),
-            ("dropcapstyle", "None"),
+            (
+                "dropcapstyle",
+                super::shape::drop_cap_style_str(pic.common.drop_cap_style),
+            ),
             ("href", href),
             ("groupLevel", "0"),
             ("instid", &instid),
@@ -567,6 +570,19 @@ mod tests {
         assert!(
             xml.contains(r#"<hp:curSz width="1366" height="1268"/>"#),
             "curSz 는 shape_attr.current 사용(sz 아님): {xml}"
+        );
+    }
+
+    #[test]
+    fn dropcapstyle_round_trips_instead_of_always_none() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.common.drop_cap_style = crate::model::shape::DropCapStyle::TripleLine;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(r#"dropcapstyle="TripleLine""#),
+            "dropcapstyle 는 원본 값을 보존해야 한다(하드코딩 \"None\" 아님): {xml}"
         );
     }
 

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -1053,6 +1053,18 @@ pub(crate) fn numbering_type_str(n: ObjectNumberingType) -> &'static str {
     }
 }
 
+/// `dropcapstyle` 방출 문자열. OWPML Core 스키마 `DropCapStyleType`
+/// (None/DoubleLine/TripleLine/Margin) 그대로 왕복한다.
+pub(crate) fn drop_cap_style_str(s: crate::model::shape::DropCapStyle) -> &'static str {
+    use crate::model::shape::DropCapStyle;
+    match s {
+        DropCapStyle::None => "None",
+        DropCapStyle::DoubleLine => "DoubleLine",
+        DropCapStyle::TripleLine => "TripleLine",
+        DropCapStyle::Margin => "Margin",
+    }
+}
+
 fn bool01(b: bool) -> &'static str {
     if b {
         "1"


### PR DESCRIPTION
## 요약

이슈 #2887 — `<hp:pic>`(그림 개체)를 감싼 문단의 `dropcapstyle`
(드롭캡 표시 방식: `None`/`DoubleLine`/`TripleLine`/`Margin`)이 파서에서
읽히지 않아, 직렬화기가 항상 `dropcapstyle="None"`을 하드코딩 방출하던
라운드트립 유실 버그를 고쳤다. `lock` 왕복 버그(#2840 수식, #2855 표)와
동일 유형("파서 미인식 속성 → 직렬화기 상수 하드코딩")이며, 이번 PR은
`hp:pic` 단독으로 범위를 좁혔다.

## 변경

- `src/model/shape.rs` — `CommonObjAttr.drop_cap_style: DropCapStyle` 필드 +
  `DropCapStyle` enum(OWPML `DropCapStyleType` 그대로 매핑) 추가.
- `src/parser/hwpx/section.rs` — `parse_picture()` 속성 루프에
  `dropcapstyle` 분기 추가.
- `src/serializer/hwpx/shape.rs` — `drop_cap_style_str()` 헬퍼 추가.
- `src/serializer/hwpx/picture.rs` — `write_picture()` 하드코딩 `"None"`
  제거, 실제 값 방출.
- `src/document_core/converters/common_obj_attr_writer.rs` — 신규 필드로
  인한 테스트 헬퍼 struct 리터럴 컴파일 에러 해소(동작 변경 없음).

## Red → Green

`src/serializer/hwpx/picture.rs::tests::dropcapstyle_round_trips_instead_of_always_none`

- Red: `drop_cap_style = TripleLine` 로 직렬화해도 출력이 항상
  `dropcapstyle="None"` → 실패.
- Green: 출력에 `dropcapstyle="TripleLine"` 포함 → 통과.

## 검증

- `cargo build --lib` 통과
- `cargo test --lib dropcapstyle_round_trips_instead_of_always_none` 통과 (1 passed)
- `cargo clippy --all-targets --profile release-test -- -D warnings` 통과
- `rustfmt --edition 2021` (변경 파일만)

## 범위

`dropcapstyle="None"` 하드코딩은 `hp:rect`/`hp:line`/`hp:tbl`/`hp:equation`
등에도 동일하게 있으나, 이번 PR은 `hp:pic`으로 한정했다. 나머지는 후속
이슈로 남긴다.

Closes #2887
