### PR TITLE
표 객체 선택 Ctrl+C/Ctrl+X 가 중첩 표 cellPath 를 native 에 전달하지 않던 문제 수정

### DIFF
--- a/mydocs/report/task_m100_2880_report.md
+++ b/mydocs/report/task_m100_2880_report.md
@@ -1,0 +1,50 @@
+# Task #2880 처리 결과 — 표 객체 선택 Ctrl+C/Ctrl+X cellPath 누락 수정
+
+## 이슈
+
+- GitHub Issue: [#2880](https://github.com/edwardkim/rhwp/issues/2880)
+- 대상 파일(단독 작업 영역): `rhwp-studio/src/engine/input-handler-keyboard.ts`
+
+## 문제
+
+`onKeyDown`의 표 객체 선택 모드(`isInTableObjectSelection`) Ctrl+C/Ctrl+X 핸들러가
+`wasm.copyControl(ref.sec, ref.ppi, ref.ci)` / `wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci)`를
+`cellPathJson` 없이 호출했다. 같은 파일의 그림/글상자 객체 선택 모드 Ctrl+C/Ctrl+X 핸들러(및
+`onCopy`)는 `pictureCellPathJson(ref)`로 계산한 `cellPathJson`을 반드시 함께 넘긴다 — 형제
+핸들러 간 비대칭. `getSelectedTableRef()`가 반환하는 `ref.cellPath`(`CellPathEntry[]`)는 같은
+블록 안에서 중첩 깊이 판정(`ref.cellPath.length > 1`)에는 쓰이고 있었지만 정작 copy/cut
+호출에는 전달되지 않아, 셀 안에 중첩된 표를 복사·잘라내기 하면 native 가 본문 레벨 표로
+오인해 엉뚱한 표를 클립보드에 담거나 조용히 실패했다.
+
+## 수정
+
+- `rhwp-studio/src/engine/input-handler-keyboard.ts` 표 Ctrl+C(867~890행 부근), Ctrl+X(891~919행
+  부근) 블록에서 `pictureCellPathJson(ref)`로 `cellPathJson`을 계산해 `copyControl`/
+  `exportControlHtml` 호출에 전달하도록 수정. 그림 개체 핸들러와 동일한 패턴.
+- `deleteTableControl`은 시그니처상 `cellPathJson`을 받지 않아(별도 이슈 소지) 이번 수정
+  범위에서는 제외 — 기존 가드(`ref.cellPath.length > 1`)로 중첩 표 삭제는 계속 차단됨.
+
+## 테스트
+
+- `rhwp-studio/tests/table-object-copy-cellpath.test.ts` 신규 추가 (source-guard, 최소 1개).
+  - 표 Ctrl+C/Ctrl+X 블록 소스에서 `const cellPathJson = pictureCellPathJson(ref);`,
+    `copyControl(..., cellPathJson)`, `exportControlHtml(..., cellPathJson)` 패턴을 확인.
+  - Red: 수정 전(origin/devel 버전) 소스로 교체해 실행 → 실패 확인
+    (`AssertionError: 표 Ctrl+C 핸들러가 ref.cellPath 를 cellPathJson 으로 계산하지 않음`).
+  - Green: 수정본으로 복원 후 실행 → 통과.
+
+## 검증
+
+```
+cd rhwp-studio
+npm ci          # node_modules 부재 상태였어서 선행 필요
+npm test        # 500 tests, 499 pass, 1 fail (cell-flow-boundary.test.ts — 기존 실패, 허용 범위)
+npx tsc --noEmit  # TS2307 2건(@wasm/rhwp.js, 기존 baseline) — 신규 오류 0건
+```
+
+## 커밋/PR
+
+- 브랜치: `task/m100-2880-table-copy-cellpath` (origin/devel 기준)
+- 변경 파일: `rhwp-studio/src/engine/input-handler-keyboard.ts`,
+  `rhwp-studio/tests/table-object-copy-cellpath.test.ts`,
+  `mydocs/report/task_m100_2880_report.md`

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -870,11 +870,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const ref = this.cursor.getSelectedTableRef();
       if (ref) {
         try {
-          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci);
+          // [Task #2880] 중첩 표(셀 안 표) 선택 시 cellPath 를 native 에 전달하지 않으면
+          // copyControl/exportControlHtml 이 본문 표로 오인해 엉뚱한 표를 복사한다.
+          // 그림 개체 Ctrl+C(위 pictureCellPathJson 사용부) 와 동일하게 cellPathJson 전달.
+          const cellPathJson = pictureCellPathJson(ref);
+          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci, cellPathJson);
           const text = this.wasm.getClipboardText();
           if (text) {
             let html = '';
-            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci) || ''; } catch { /* 무시 */ }
+            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci, cellPathJson) || ''; } catch { /* 무시 */ }
             const markedHtml = prepareRhwpInternalClipboardHtml(this, html, text);
             writeTextHtmlToClipboard(text, markedHtml)
               .catch(() => navigator.clipboard.writeText(text).catch(() => {}));
@@ -891,11 +895,13 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const ref = this.cursor.getSelectedTableRef();
       if (ref && !(ref.cellPath && ref.cellPath.length > 1)) {
         try {
-          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci);
+          // [Task #2880] Ctrl+C 사이드와 동일하게 cellPath 를 copyControl/exportControlHtml 에 전달.
+          const cellPathJson = pictureCellPathJson(ref);
+          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci, cellPathJson);
           const text = this.wasm.getClipboardText();
           if (text) {
             let html = '';
-            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci) || ''; } catch { /* 무시 */ }
+            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci, cellPathJson) || ''; } catch { /* 무시 */ }
             const markedHtml = prepareRhwpInternalClipboardHtml(this, html, text);
             writeTextHtmlToClipboard(text, markedHtml)
               .catch(() => navigator.clipboard.writeText(text).catch(() => {}));

--- a/rhwp-studio/tests/table-object-copy-cellpath.test.ts
+++ b/rhwp-studio/tests/table-object-copy-cellpath.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2880] 표 객체 선택(isInTableObjectSelection) Ctrl+C/Ctrl+X 핸들러가
+// 그림 개체 선택 핸들러(pictureCellPathJson 사용부)와 달리 cellPathJson 을
+// wasm.copyControl/exportControlHtml 에 전달하지 않아, 셀 안 중첩 표를
+// 복사·잘라내기하면 native 가 본문 표로 오인하는 회귀를 막는 source-guard.
+//
+// 이 파일은 무거운 WasmBridge/DOM mock 없이, "표 selection 블록의
+// copyControl(...) 호출이 반드시 cellPathJson 인자를 포함한다"는 사실만
+// 소스 텍스트 수준에서 검증한다 (getSelectedTableRef().cellPath 를 실제로
+// native 호출에 흘려보내는지 확인).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('표 객체 선택 Ctrl+C/Ctrl+X 는 copyControl/exportControlHtml 에 cellPathJson 을 전달한다', () => {
+  const src = source('src/engine/input-handler-keyboard.ts');
+
+  const tableSelectionBlockStart = src.indexOf('this.cursor.isInTableObjectSelection()');
+  assert.notEqual(tableSelectionBlockStart, -1, '표 객체 선택 모드 블록을 찾지 못함');
+
+  const ctrlCStart = src.indexOf("e.key === 'c'", tableSelectionBlockStart);
+  const ctrlXStart = src.indexOf("e.key === 'x'", tableSelectionBlockStart);
+  assert.notEqual(ctrlCStart, -1, '표 Ctrl+C 핸들러를 찾지 못함');
+  assert.notEqual(ctrlXStart, -1, '표 Ctrl+X 핸들러를 찾지 못함');
+
+  const ctrlCBlock = src.slice(ctrlCStart, ctrlXStart);
+  const ctrlVStart = src.indexOf("e.key === 'v'", ctrlXStart);
+  const ctrlXBlock = src.slice(ctrlXStart, ctrlVStart === -1 ? undefined : ctrlVStart);
+
+  for (const [label, block] of [['Ctrl+C', ctrlCBlock], ['Ctrl+X', ctrlXBlock]] as const) {
+    assert.match(
+      block,
+      /const cellPathJson = pictureCellPathJson\(ref\);/,
+      `표 ${label} 핸들러가 ref.cellPath 를 cellPathJson 으로 계산하지 않음 (회귀)`,
+    );
+    assert.match(
+      block,
+      /wasm\.copyControl\(ref\.sec, ref\.ppi, ref\.ci, cellPathJson\)/,
+      `표 ${label} 핸들러의 copyControl 호출에 cellPathJson 인자가 없음 (회귀)`,
+    );
+    assert.match(
+      block,
+      /wasm\.exportControlHtml\(ref\.sec, ref\.ppi, ref\.ci, cellPathJson\)/,
+      `표 ${label} 핸들러의 exportControlHtml 호출에 cellPathJson 인자가 없음 (회귀)`,
+    );
+  }
+});


### PR DESCRIPTION
## 요약

`rhwp-studio/src/engine/input-handler-keyboard.ts`의 표 객체 선택 모드
(`isInTableObjectSelection`) Ctrl+C/Ctrl+X 핸들러가, 같은 파일의 그림/글상자 객체 선택 모드
핸들러와 달리 `cellPathJson`을 `wasm.copyControl`/`wasm.exportControlHtml`에 전달하지 않아
셀 안에 중첩된 표를 복사·잘라내기 하면 native 가 본문 레벨 표로 오인해 엉뚱한 표를 클립보드에
담거나 조용히 실패하는 문제를 수정한다.

Closes #2880

## 근거

- 그림 개체 Ctrl+C/Ctrl+X, `onCopy`는 모두 `pictureCellPathJson(ref)`로 계산한 `cellPathJson`을
  `copyControl`/`exportControlHtml`에 넘긴다.
- 표 객체 Ctrl+C/Ctrl+X는 `this.wasm.copyControl(ref.sec, ref.ppi, ref.ci)` 처럼 `cellPathJson`
  인자를 아예 생략했다 — `getSelectedTableRef()`가 반환하는 `ref.cellPath`는 같은 블록의 중첩
  깊이 판정(`ref.cellPath.length > 1`)에는 쓰이는데 정작 copy/cut 호출에는 전달되지 않았다.
- `wasm.copyControl`/`wasm.exportControlHtml`(`src/core/wasm-bridge.ts`)은 네 번째 인자로
  `cellPathJson = ''`을 받아 native `doc.copyControl(sec, para, cellPathJson, ci)` 로 그대로
  전달한다. 인자를 생략하면 빈 문자열이 전달되어 native 는 "중첩 없음(본문 표)"으로 해석한다.

## 수정

- 표 Ctrl+C/Ctrl+X 핸들러에 `const cellPathJson = pictureCellPathJson(ref);`를 추가하고
  `copyControl`/`exportControlHtml` 호출에 전달 — 그림 핸들러와 동일한 패턴으로 통일.
- `deleteTableControl`은 시그니처상 `cellPathJson`을 받지 않으므로(별도 이슈 소지) 이번 수정
  범위에서는 제외했다. 기존 가드(`ref.cellPath.length > 1`)로 중첩 표 삭제는 계속 차단된다.

## Red → Green

- 신규 source-guard 테스트 `rhwp-studio/tests/table-object-copy-cellpath.test.ts` 추가.
- Red: origin/devel 버전(수정 전) 소스로 교체해 실행 →
  `AssertionError: 표 Ctrl+C 핸들러가 ref.cellPath 를 cellPathJson 으로 계산하지 않음 (회귀)` 로 실패 확인.
- Green: 수정본으로 복원 후 실행 → 통과.

## 검증

```
cd rhwp-studio
npm ci
npm test          # 500 tests, 499 pass, 1 fail (cell-flow-boundary.test.ts — 기존 실패, 이번 변경과 무관)
npx tsc --noEmit  # TS2307 2건(@wasm/rhwp.js) — 기존 baseline, 신규 오류 0건
```

## 처리 결과 문서

`mydocs/report/task_m100_2880_report.md`