### PR TITLE
HWPX fieldBegin/fieldEnd fieldid 속성 왕복 손실 수정

### DIFF
--- a/mydocs/report/task_m100_2884_report.md
+++ b/mydocs/report/task_m100_2884_report.md
@@ -1,0 +1,68 @@
+# Task m100-2884: HWPX fieldBegin/fieldEnd `fieldid` 속성 왕복 손실 수정
+
+## 이슈
+
+edwardkim/rhwp#2884
+
+## 문제
+
+`<hp:fieldBegin>` 의 `fieldid` 속성(문서 내 고유 `id` 와 별개인 필드 인스턴스 ID)을
+파서가 `field_id` 계산의 폴백(`id_attr.or(fieldid_attr)`)으로만 사용하고 별도로
+보존하지 않았다. `id` 속성이 거의 항상 존재하므로 `fieldid_attr` 값은 사실상 항상
+버려졌고, 직렬화기(`field_begin_open_tag`, `write_field_begin`, `emit_field_end` →
+`write_field_end`)는 애초에 `fieldid` 속성을 방출하는 코드 경로 자체가 없었다.
+
+기존 테스트 픽스처(`task1556_multipara_field_parse_serialize_parse_roundtrip`)가
+`id="1878228493"` / `fieldid="627272811"` 처럼 두 값이 서로 다른 실물 사례를 이미
+담고 있었는데도, 이 값의 재직렬화 보존은 그동안 한 번도 검증되지 않았다.
+
+#2830 (MEMO subList `textDirection` 하드코딩 수정)과 동일한 패턴 — 파서 미독해 +
+직렬화기 하드코딩/누락 조합 — 이다.
+
+## 수정
+
+1. `src/model/control.rs`: `Field` 구조체에 `instance_id: Option<u32>` 필드 추가.
+   원본 `fieldid` 속성 값을 `field_id` 계산과 무관하게 별도 보존.
+2. `src/parser/hwpx/section.rs`: `parse_field_begin_attrs` 에서
+   `f.instance_id = fieldid_attr;` 로 원본 값을 그대로 저장 (기존 `field_id` 폴백
+   로직은 그대로 유지 — 필드 고유 ID 계약(#1512)에 영향 없음).
+3. `src/serializer/hwpx/field.rs`:
+   - `field_begin_open_tag` — `instance_id` 가 `Some` 이면 `fieldid="{}"` 속성을
+     추가 방출, `None` 이면 기존과 동일하게 생략(자기닫힘 태그 케이스 호환).
+   - `write_field_begin` — 동일한 분기 추가.
+4. `src/serializer/hwpx/section.rs`: `emit_field_end` 가 `write_field_end` 대신
+   `write_field_end_full(w, f.field_id, f.instance_id.unwrap_or(0))` 을 사용하도록
+   변경 — 짝이 되는 `fieldEnd` 에도 `fieldid` 가 있으면 동일하게 반영, 0 이면 속성
+   생략(#1556 이 정의한 기존 규약 재사용).
+5. `Field` 구조체 리터럴을 명시적으로 나열하던 4개 호출부
+   (`src/document_core/queries/field_query.rs` 2곳, `src/parser/control.rs` 1곳)에
+   `instance_id: None,` 추가.
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/field.rs::tests::field_begin_preserves_distinct_fieldid_attr`
+
+- `field_id = 1_878_228_493`, `instance_id = Some(627_272_811)` (실물 fixture 값)인
+  `Field` 로 `write_field_begin` 호출.
+- 수정 전: 출력 XML 에 `fieldid` 속성이 전혀 없어 `assert!(xml.contains(r#"fieldid="627272811""#))` 실패(red).
+- 수정 후: `fieldid="627272811"` 이 방출되어 통과(green).
+
+```
+test serializer::hwpx::field::tests::field_begin_preserves_distinct_fieldid_attr ... ok
+```
+
+## 검증
+
+- `cargo build --lib` — 통과
+- `cargo test --lib field_begin_preserves_distinct_fieldid_attr` — 통과 (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음
+- `rustfmt --edition 2021` — 변경 파일만 적용
+
+## 변경 파일
+
+- `src/model/control.rs`
+- `src/parser/hwpx/section.rs`
+- `src/parser/control.rs`
+- `src/serializer/hwpx/field.rs`
+- `src/serializer/hwpx/section.rs`
+- `src/document_core/queries/field_query.rs`

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1009,6 +1009,7 @@ fn collect_fields_from_paragraph(
                                 properties: if cell.editable_in_form() { 1 } else { 0 },
                                 extra_properties: 0,
                                 ctrl_data_name: Some(fname.clone()),
+                                instance_id: None,
                                 memo_index: 0,
                                 memo_paragraphs: Vec::new(),
                                 raw_parameters_xml: None,
@@ -1260,6 +1261,7 @@ fn insert_click_here_field_in_para(
         extra_properties: 0x09,
         field_id,
         ctrl_id: tags::FIELD_CLICKHERE,
+        instance_id: None,
         ctrl_data_name: if name.is_empty() {
             None
         } else {
@@ -1471,6 +1473,7 @@ mod tests {
             extra_properties: 0,
             field_id: ctrl_id,
             ctrl_id,
+            instance_id: None,
             ctrl_data_name: None,
             memo_index: 0,
             memo_paragraphs: Vec::new(),

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -234,6 +234,10 @@ pub struct Field {
     pub field_id: u32,
     /// 원본 ctrl_id (직렬화용)
     pub ctrl_id: u32,
+    /// HWPX `<hp:fieldBegin fieldid="..">` 원본 값 (동종 필드 간 공유되는 instance id).
+    /// `id`(=field_id, 문서 내 고유)와 별개 값이며 실물 파일에서 서로 다를 수 있다(#1512).
+    /// `None` 이면 fieldid 속성 자체가 없었거나 파서가 값을 못 읽은 경우 — 방출 생략.
+    pub instance_id: Option<u32>,
     /// CTRL_DATA에서 읽은 필드 이름 (누름틀 고치기에서 설정)
     pub ctrl_data_name: Option<String>,
     /// 메모 인덱스 (hwplib: memoIndex)

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -130,6 +130,7 @@ fn parse_field_control(ctrl_id: u32, ctrl_data: &[u8]) -> Control {
         extra_properties,
         field_id,
         ctrl_id,
+        instance_id: None,
         ctrl_data_name: None,
         memo_index,
         memo_paragraphs: Vec::new(),

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4332,6 +4332,10 @@ fn parse_field_begin_attrs(e: &quick_xml::events::BytesStart) -> Field {
     // (예: FORMULA 다수)에서 공유될 수 있어, 이를 우선하면 모든 필드가 동일 ID 로
     // 반환된다(#1512). Memo/비-Memo 모두 고유 `id` 우선으로 통일한다.
     f.field_id = id_attr.or(fieldid_attr).unwrap_or(0);
+    // [#task-m100] `fieldid` 는 위 field_id 계산에 폴백으로만 쓰였고, `id` 가 존재하는
+    // 실물 필드(예: id=1878228493, fieldid=627272811 — 서로 다름)에선 원본 fieldid 값이
+    // 그대로 버려져 직렬화기가 이 속성을 영구히 방출하지 못했다. instance_id 로 별도 보존.
+    f.instance_id = fieldid_attr;
     // [Task #852 Stage 2.5] field_type → ctrl_id 매핑.
     // 정답지 (samples/form-01.hwp) reverse engineering: ClickHere CTRL_HEADER 의 ctrl_id 가
     // "%clk" (FIELD_CLICKHERE). HWPX parser 가 이전엔 ctrl_id 미설정 → serializer 가

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -38,13 +38,25 @@ pub fn field_begin_open_tag(field: &Field) -> String {
     let id_str = field.field_id.to_string();
     let ft = field_type_str(field.field_type);
     let name = xml_escape_attr(field.ctrl_data_name.as_deref().unwrap_or(""));
-    format!(
-        r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}""#,
-        id_str,
-        ft,
-        name,
-        bool01(field.is_editable_in_form()),
-    )
+    // [#task-m100] 원본 `fieldid` 속성 보존 — id 와 별개 값일 수 있어(#1512) 생략하면
+    // 왕복 시 영구 손실된다. 없으면(None) 속성 자체를 생략(#1391 자기닫힘 태그 호환).
+    match field.instance_id {
+        Some(fieldid) => format!(
+            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}" fieldid="{}""#,
+            id_str,
+            ft,
+            name,
+            bool01(field.is_editable_in_form()),
+            fieldid,
+        ),
+        None => format!(
+            r#"<hp:fieldBegin id="{}" type="{}" name="{}" editable="{}""#,
+            id_str,
+            ft,
+            name,
+            bool01(field.is_editable_in_form()),
+        ),
+    }
 }
 
 fn xml_escape_attr(s: &str) -> String {
@@ -60,16 +72,31 @@ fn xml_escape_attr(s: &str) -> String {
 pub fn write_field_begin<W: Write>(w: &mut Writer<W>, field: &Field) -> Result<(), SerializeError> {
     let id_str = field.field_id.to_string();
     let ft = field_type_str(field.field_type);
-    empty_tag(
-        w,
-        "hp:fieldBegin",
-        &[
-            ("id", &id_str),
-            ("type", ft),
-            ("name", field.ctrl_data_name.as_deref().unwrap_or("")),
-            ("editable", bool01(field.is_editable_in_form())),
-        ],
-    )
+    let fieldid_str = field.instance_id.map(|v| v.to_string());
+    let editable_str = bool01(field.is_editable_in_form());
+    match &fieldid_str {
+        Some(fieldid_str) => empty_tag(
+            w,
+            "hp:fieldBegin",
+            &[
+                ("id", &id_str),
+                ("type", ft),
+                ("name", field.ctrl_data_name.as_deref().unwrap_or("")),
+                ("editable", editable_str),
+                ("fieldid", fieldid_str),
+            ],
+        ),
+        None => empty_tag(
+            w,
+            "hp:fieldBegin",
+            &[
+                ("id", &id_str),
+                ("type", ft),
+                ("name", field.ctrl_data_name.as_deref().unwrap_or("")),
+                ("editable", editable_str),
+            ],
+        ),
+    }
 }
 
 /// `<hp:fieldEnd>` — 필드 끝 마커.
@@ -217,6 +244,20 @@ mod tests {
         // [#1595] 올바른 HWPX 값은 CLICK_HERE (언더스코어). 종전 "CLICKHERE" 는
         // 한글이 미인식해 ClickHere placeholder 높이 변동 → 페이지 붕괴(#1589).
         assert!(xml.contains(r#"type="CLICK_HERE""#), "{xml}");
+    }
+
+    #[test]
+    fn field_begin_preserves_distinct_fieldid_attr() {
+        // [#task-m100] 실물 필드는 id(=field_id, 고유)와 fieldid(instance id)가
+        // 서로 다를 수 있다(id=1878228493, fieldid=627272811). 종전엔 fieldid_attr 가
+        // field_id 계산의 폴백으로만 쓰이고 별도 보존되지 않아, 직렬화기가 이 속성을
+        // 영구히 방출하지 못했다(#1512 이후 회귀).
+        let mut f = Field::default();
+        f.field_type = FieldType::ClickHere;
+        f.field_id = 1_878_228_493;
+        f.instance_id = Some(627_272_811);
+        let xml = to_string(|w| write_field_begin(w, &f));
+        assert!(xml.contains(r#"fieldid="627272811""#), "{xml}");
     }
 
     #[test]

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -35,7 +35,7 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
-use super::field::{write_bookmark, write_field_begin, write_field_end, write_field_end_full};
+use super::field::{write_bookmark, write_field_begin, write_field_end_full};
 use super::utils::xml_escape;
 use super::SerializeError;
 use super::{picture, table};
@@ -496,7 +496,10 @@ impl RunSplitter {
 /// `<hp:ctrl><hp:fieldEnd beginIDRef=".."/></hp:ctrl>` 방출 공통 경로.
 fn emit_field_end(out: &mut String, para: &Paragraph, control_idx: usize) {
     if let Some(Control::Field(f)) = para.controls.get(control_idx) {
-        if let Ok(xml) = writer_to_string(|w| write_field_end(w, f.field_id)) {
+        // [#task-m100] fieldEnd 도 원본 fieldid 를 보존(있으면) — fieldBegin 과 동일 규칙.
+        if let Ok(xml) =
+            writer_to_string(|w| write_field_end_full(w, f.field_id, f.instance_id.unwrap_or(0)))
+        {
             out.push_str("<hp:ctrl>");
             out.push_str(&xml);
             out.push_str("</hp:ctrl>");


### PR DESCRIPTION
## 요약

이슈: #2884

`<hp:fieldBegin>` 의 `fieldid` 속성(문서 내 고유 `id` 와 별개인 필드 인스턴스 ID)이
파서→직렬화 왕복 시 영구히 사라지던 문제를 수정했습니다. #2830 과 동일한 패턴 —
파서가 실제 값을 읽고도 `field_id` 계산 폴백으로만 쓰고 버리고, 직렬화기는 애초에
`fieldid` 속성을 방출하는 코드 경로가 없었습니다.

- `Field` 구조체에 `instance_id: Option<u32>` 추가 — 원본 `fieldid` 값 별도 보존.
- 파서(`parse_field_begin_attrs`)가 `fieldid` 속성을 `instance_id` 에 저장.
- 직렬화기(`field_begin_open_tag`, `write_field_begin`, `emit_field_end` →
  `write_field_end_full`)가 `instance_id` 가 있으면 `fieldid` 속성을 재방출.

## 테스트 (red → green)

`src/serializer/hwpx/field.rs::tests::field_begin_preserves_distinct_fieldid_attr`

- `field_id=1878228493`, `instance_id=Some(627272811)` (실물 fixture 값,
  `task1556_multipara_field_parse_serialize_parse_roundtrip` 참고) 인 `Field` 로
  `write_field_begin` 호출.
- 수정 전(red): 출력에 `fieldid` 속성이 없어 실패.
- 수정 후(green): `fieldid="627272811"` 방출 확인, 통과.

## 검증

- `cargo build --lib` 통과
- `cargo test --lib field_begin_preserves_distinct_fieldid_attr` 통과 (1 passed)
- `cargo clippy --all-targets --profile release-test -- -D warnings` 경고 없음
- `rustfmt --edition 2021` 변경 파일만 적용 (실질 변경 없음)

처리 결과 문서: `mydocs/report/task_m100_2884_report.md`
