### PR TITLE
fix(hml): 표 TextWrap 이 기본값이 아니면 저장이 항상 차단되던 문제 수정

### DIFF
--- a/mydocs/report/task_m100_2890_report.md
+++ b/mydocs/report/task_m100_2890_report.md
@@ -1,0 +1,74 @@
+# task/m100-2890: HML 표(TABLE) TextWrap preflight 부당 차단 수정
+
+## 문제
+
+HML 표(TABLE) 컨트롤의 `TextWrap` 속성 값이 기본값(`Square`)이 아니면, `src/serializer/hml/preflight.rs`의
+`validate_table`이 `table.common.text_wrap != Default::default()`를 이유로 항상
+`HML_UNSUPPORTED_IR` 블로커를 추가해 저장을 차단했다. 하지만 이 값은 파서(`reader.rs`)와
+writer(`body.rs`) 양쪽 모두 이미 정상적으로 지원하고 있어서, 저장을 막을 이유가 없는 불필요한
+차단이었다.
+
+## 근거
+
+- `src/serializer/hml/body.rs:412` (`write_table`) → `write_shape_object(writer, &table.common, "Table")` 호출.
+  `write_shape_object`(`body.rs:341-358`)는 컨트롤 종류와 무관하게 `("TextWrap", text_wrap_name(common.text_wrap).into())`를
+  항상 실제 값으로 방출한다. 즉 표에 대해서도 TextWrap 직렬화는 이미 구현되어 있다.
+- `src/parser/hml/reader.rs:943-955` (`capture_shape_object`) → `nearest_object_is_table()`로 분기해
+  표면 `table.common.text_wrap`, 사각형이면 `rectangle.text_wrap`을 채운다. 이 로직은 커밋
+  `ec226dad`(`fix(hml): 표의 TextWrap 이 HML 되읽기에서 유실`)에서 "표에도 SHAPEOBJECT 의 TextWrap 이
+  방출되는데 reader 는 rectangle 만 처리해서 유실된다"는 회귀를 고치며 추가되었다. 즉 되읽기는 이미
+  정상 동작한다.
+- `src/parser/hml/adapter.rs:221-264` (`into_table`)는 `common: source.common`으로 reader 가 채운
+  `text_wrap` 을 손실 없이 `Document`의 `Table.common`에 그대로 전달한다.
+- 그런데 `src/serializer/hml/preflight.rs`의 `validate_table`만 옛 가정(표의 TextWrap 은 항상
+  기본값)을 그대로 유지한 채 저장을 차단하고 있었다. reader/writer 능력과 preflight 검사가 서로
+  어긋난 전형적인 capability mismatch. (이슈 #2890 에 상세 근거 기록)
+
+## 수정 내용
+
+`src/serializer/hml/preflight.rs`의 `validate_table`에서 다음 한 줄을 제거했다.
+
+```rust
+|| table.common.text_wrap != Default::default()
+```
+
+writer 가 이미 실제 값을 그대로 직렬화하므로, preflight 에서 이를 "미지원"으로 취급할 필요가 없다.
+`reader.rs`는 전혀 건드리지 않았다(작업 범위 제한 준수).
+
+## red → green 테스트
+
+`tests/hml_serializer.rs`에 `table_with_non_default_text_wrap_round_trips_through_hml_save` 테스트를
+추가했다.
+
+- **Red (수정 전)**: `samples/hml/formatting_table.hml`의 표 `SHAPEOBJECT` 태그에
+  `TextWrap="TopAndBottom"`을 주입해 파싱한 뒤(파싱은 정상, `table.common.text_wrap`이 올바르게
+  `TopAndBottom`으로 확인됨) 수정 없이 곧바로 `serialize_hml`로 저장을 시도하면 다음과 같이 항상
+  실패했다.
+  ```
+  Err(UnsupportedIr { blockers: [HmlSaveBlocker {
+      code: "HML_UNSUPPORTED_IR",
+      xml_path: "/HWPML/BODY/SECTION[0]/P[1]/CONTROL[0]/TABLE",
+      message: "table fields cannot round-trip through HML",
+  }] })
+  ```
+  (임시 프로브 테스트로 이 실패를 실제로 실행해 확인함 — 수정 전 `preflight.rs` 상태에서
+  `cargo test`를 돌려 위 오류 메시지를 그대로 재현했다.)
+- **Green (수정 후)**: 동일한 문서를 저장하면 성공하고, 저장된 바이트를 다시 파싱했을 때도
+  `table.common.text_wrap == TextWrap::TopAndBottom`이 왕복 보존됨을 확인한다.
+  실제 실행 결과: `test table_with_non_default_text_wrap_round_trips_through_hml_save ... ok`.
+
+## 검증 결과
+
+- `cargo build --lib`: 성공 (`Finished dev profile ... target(s) in 1m 44s`).
+- 대상 테스트 `cargo test --test hml_serializer table_with_non_default_text_wrap_round_trips_through_hml_save`:
+  통과 (`test result: ok. 1 passed; 0 failed`).
+- `rustfmt --edition 2021`: 변경 파일(`src/serializer/hml/preflight.rs`, `tests/hml_serializer.rs`)에만 적용, 정상 완료.
+- **`cargo clippy --all-targets --profile release-test -- -D warnings`: 미실행.** 작업 중 디스크 여유 공간이
+  20GB(1.9TB 중 99% 사용)까지 떨어져, 코디네이터 지시에 따라 release-test 프로파일 전체 링크가 필요한
+  clippy 단계를 이번 커밋에서는 건너뛰었다. 메인테이너 CI 에서 clippy 검사가 수행될 것으로 예상하고
+  넘어갔으며, 이 사실을 숨기지 않고 명시적으로 기록한다. 변경 범위가 조건식 한 줄 삭제 + 테스트 추가로
+  매우 작아 clippy 위반 가능성은 낮다고 판단했지만, 로컬로 직접 확인하지는 못했다.
+- 전체 테스트 스위트(`cargo test` 전체)도 디스크/시간 제약으로 실행하지 않았다. 변경이
+  `validate_table`의 조건 하나를 완화하는 것뿐이고, 관련 기존 회귀 테스트(`table_text_wrap_is_read_back_from_hml`,
+  `stale_offsets_after_unequal_direct_text_mutation_block_export` 등 인접 테스트)의 로직과 충돌하지 않음을
+  코드 리뷰로 확인했으나, 전체 스위트 실행으로 재확인하지는 못했다.

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -646,7 +646,6 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
         || !table.raw_table_record_extra.is_empty()
         || table.row_sizes != expected_rows
         || table.cell_grid != rebuilt.cell_grid
-        || table.common.text_wrap != Default::default()
         || table
             .cells
             .windows(2)

--- a/tests/hml_serializer.rs
+++ b/tests/hml_serializer.rs
@@ -1371,3 +1371,64 @@ fn raw_fragment_depth_boundary_matches_secure_reparse() {
     assert_eq!(blockers[0].code, "HML_INVALID_RAW_FRAGMENT");
     assert_eq!(blockers[0].xml_path, "/HWPML/HEAD/X");
 }
+
+#[test]
+fn table_with_non_default_text_wrap_round_trips_through_hml_save() {
+    // 표 SHAPEOBJECT 의 TextWrap 이 기본값(Square)이 아니면 reader 는 이미
+    // table.common.text_wrap 으로 정상적으로 되읽고(#2743 유실 수정, ec226dad),
+    // writer(write_shape_object)도 표에 대해 TextWrap 을 그대로 방출하지만,
+    // preflight 의 validate_table 이 "table.common.text_wrap != Default" 를
+    // 무조건 HML_UNSUPPORTED_IR 로 차단해 저장이 항상 실패했다. 이 값은 이미
+    // 두 방향 모두 지원되므로 preflight 차단은 불필요하다(#2890).
+    let fixture = include_str!("../samples/hml/formatting_table.hml");
+    let injected = fixture.replacen(
+        r#"NumberingType="Table" TextFlow="BothSides" ZOrder="1""#,
+        r#"NumberingType="Table" TextFlow="BothSides" TextWrap="TopAndBottom" ZOrder="1""#,
+        1,
+    );
+    assert_ne!(
+        injected, fixture,
+        "fixture 의 표 SHAPEOBJECT 태그를 찾지 못함"
+    );
+
+    let parsed = parse_document_with_metadata(injected.as_bytes())
+        .expect("TextWrap 이 주입된 표 HML 은 파싱되어야 함");
+    let metadata = parsed.hml_metadata.as_ref().expect("HML metadata");
+
+    let table = parsed
+        .document
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+        .flat_map(|paragraph| paragraph.controls.iter())
+        .find_map(|control| match control {
+            Control::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("표가 있어야 함");
+    assert_eq!(
+        table.common.text_wrap,
+        rhwp::model::shape::TextWrap::TopAndBottom,
+        "표 TextWrap 이 파싱 단계에서 유실됨"
+    );
+
+    let bytes = serialize_hml(&parsed.document, metadata)
+        .expect("표의 비-기본값 TextWrap 저장이 preflight 에 의해 부당하게 차단됨");
+    let reparsed = DocumentCore::from_bytes(&bytes).expect("저장된 HML 은 다시 파싱되어야 함");
+    let reparsed_table = reparsed
+        .document()
+        .sections
+        .iter()
+        .flat_map(|section| section.paragraphs.iter())
+        .flat_map(|paragraph| paragraph.controls.iter())
+        .find_map(|control| match control {
+            Control::Table(table) => Some(table),
+            _ => None,
+        })
+        .expect("재파싱된 문서에도 표가 있어야 함");
+    assert_eq!(
+        reparsed_table.common.text_wrap,
+        rhwp::model::shape::TextWrap::TopAndBottom,
+        "왕복 저장 후 표 TextWrap 값이 보존되지 않음"
+    );
+}


### PR DESCRIPTION
## 문제

이슈 #2890 . HML 표(TABLE) 컨트롤의 `TextWrap`이 기본값(`Square`)이 아니면 `src/serializer/hml/preflight.rs`의 `validate_table`이 `table.common.text_wrap != Default::default()`를 이유로 항상 `HML_UNSUPPORTED_IR` 블로커를 추가해 저장을 차단하고 있었다.

## 근거

- writer(`src/serializer/hml/body.rs` `write_shape_object`, 341-358행)는 표에 대해서도 `TextWrap`을 실제 값 그대로 이미 직렬화한다.
- reader(`src/parser/hml/reader.rs` `capture_shape_object`, 943-955행)는 커밋 `ec226dad`에서 "표의 TextWrap이 HML 되읽기에서 유실"되던 회귀를 고치며, 표/사각형을 구분해 `table.common.text_wrap`을 정상적으로 채우도록 이미 고쳐져 있다.
- `src/parser/hml/adapter.rs`의 `into_table`은 `common: source.common`으로 이 값을 손실 없이 `Document` IR까지 전달한다.
- 그런데 `preflight.rs`의 `validate_table`만 옛 가정(표의 TextWrap은 항상 기본값)을 그대로 유지해 저장을 차단하고 있었다 — reader/writer 능력과 preflight 검사가 어긋난 capability mismatch.

## 수정

`validate_table`에서 `|| table.common.text_wrap != Default::default()` 한 줄을 제거했다. `reader.rs`는 건드리지 않았다.

## red → green 테스트

`tests/hml_serializer.rs`에 `table_with_non_default_text_wrap_round_trips_through_hml_save`를 추가했다.

- **Red**: 수정 전 `preflight.rs`로 실행하면, `samples/hml/formatting_table.hml`의 표에 `TextWrap="TopAndBottom"`을 주입해 파싱(파싱 자체는 성공, `table.common.text_wrap`도 정상 확인)한 뒤 그대로 저장을 시도하면 다음 오류로 항상 실패했다:
  ```
  Err(UnsupportedIr { blockers: [HmlSaveBlocker {
      code: "HML_UNSUPPORTED_IR",
      xml_path: "/HWPML/BODY/SECTION[0]/P[1]/CONTROL[0]/TABLE",
      message: "table fields cannot round-trip through HML",
  }] })
  ```
  (수정 전 코드로 실제 실행해 위 오류를 재현 확인함.)
- **Green**: 수정 후 동일 문서 저장이 성공하고, 저장된 바이트를 재파싱해도 `table.common.text_wrap == TextWrap::TopAndBottom`이 왕복 보존됨을 확인한다. 실행 결과: `test table_with_non_default_text_wrap_round_trips_through_hml_save ... ok`.

## 검증

- `cargo build --lib`: 성공
- 대상 테스트: 통과 (`1 passed; 0 failed`)
- `rustfmt --edition 2021`: 변경 파일에 적용 완료
- **`cargo clippy --all-targets --profile release-test -- -D warnings`: 이번 PR 에서는 미실행.** 작업 중 로컬 디스크 여유 공간이 20GB(1.9TB 중 99% 사용)까지 떨어져 release-test 프로파일 전체 링크가 필요한 clippy 단계를 건너뛰었다. 변경 범위가 조건식 한 줄 삭제 + 테스트 추가로 작아 위반 가능성은 낮다고 보지만, 로컬로 직접 확인하지 못했다는 점과 전체 테스트 스위트(`cargo test` 전체)도 실행하지 못했다는 점을 명시한다. 메인테이너 CI 에서의 clippy/전체 테스트 확인을 부탁드린다.

자세한 내용은 `mydocs/report/task_m100_2890_report.md` 참고.