### PR TITLE
fix(render): 폰트 조달의 환경 종속 경로 제거 — 4개 파일 하드코딩 통합 (#2864, #2268)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -87,6 +87,15 @@ HWP/HWPX → PDF (svg2pdf + pdf-writer).
 - `-o <파일>`, `--output <파일>` — 출력 PDF 파일(기본 `output/<입력명>.pdf`)
 - `-p <번호>`, `--page <번호>` — 0-based 단일 페이지 선택. 생략하면 전체 문서를 다중 페이지 PDF로 내보낸다.
 - `--font-path <경로>` — PDF 변환 fontdb에 추가할 폰트 탐색 경로(여러 번 지정 가능)
+  - 환경변수 `RHWP_FONT_PATH` 로도 지정할 수 있다(#2864). 복수 경로는 OS 관례
+    구분자로 나눈다(유닉스 `:`, Windows `;`). 백엔드에서 대량 변환할 때 호출마다
+    `--font-path` 를 붙이는 대신 한 번만 설정하면 된다.
+  - 조달 순서: `--font-path` → `RHWP_FONT_PATH` → 시스템 설치 폰트 →
+    저장소 번들 `ttfs/opensource`(최후 폴백, 한국어 드롭 방지).
+  - **폰트를 지정하지 않으면 산출물이 달라진다.** 문서가 쓰는 폰트(한컴 바탕/돋움,
+    Windows 폰트 등)가 시스템에 없으면 번들 대체 폰트(Noto Sans/Serif KR)로 떨어져
+    글꼴이 바뀐다. 서버·컨테이너에서 대량 변환할 때는 **필요한 폰트를 설치하고
+    `--font-path` 또는 `RHWP_FONT_PATH` 로 명시**해야 정본과 같은 결과를 얻는다.
 - `--fallback-serif <family>` — PDF serif generic fallback family
 - `--fallback-sans <family>` — PDF sans-serif generic fallback family
 - `--fallback-mono <family>` — PDF monospace generic fallback family

--- a/mydocs/plans/task_m100_2864.md
+++ b/mydocs/plans/task_m100_2864.md
@@ -1,0 +1,114 @@
+# 타스크 수행계획서 — #2864 폰트 조달 환경 종속 경로 제거
+
+- 이슈: [#2864](https://github.com/edwardkim/rhwp/issues/2864)
+- 브랜치: `task/2864-font-path-hardcoding`
+- base: `devel` @ `58991a76`
+- 담당: edwardkim
+
+## 1. 문제
+
+렌더러 4곳이 폰트 조달 경로를 각자 하드코딩하고 있고, 그중 일부가 **특정 개발 환경에만
+존재하는 경로**다. 서버·컨테이너에서 CLI 로 대량 변환할 때 아무 값도 주지 못하면서 경로
+검사만 발생시키고, WSL2 개발 환경에서는 `/mnt/c`(9p 파일시스템) 지연으로
+[#2268](https://github.com/edwardkim/rhwp/issues/2268) 간헐 행(누적 4회 관측)을 일으킨다.
+
+### 현황 — 4개 파일
+
+| 파일 | 하드코딩 |
+|---|---|
+| `src/renderer/pdf.rs:527,532` | `ttfs`, `ttfs/windows`, `ttfs/hwp`, `/mnt/c/Windows/Fonts` |
+| `src/renderer/svg.rs:3513,3533,3537` | `ttfs/hwp`, `ttfs/windows`, `ttfs`, `/mnt/c/...`, `ttfs/opensource` |
+| `src/renderer/skia/image_conv.rs:415,420` | `ttfs`, `ttfs/windows`, `ttfs/hwp`, `/mnt/c/...` |
+| `src/renderer/skia/renderer.rs:315` | `ttfs/hwp`, `ttfs/windows`, `ttfs` |
+
+## 2. 사전 조사 결과 (구현 전 확정)
+
+### `ttfs/opensource/` 는 저장소 자산이다 — 유지
+
+`.gitignore` 는 일부만 제외한다(`/ttfs/hwp/`, `/ttfs/windows/`, `hamchob-r.ttf`,
+`hamchod-r.ttf`). **`ttfs/opensource/` 는 git 이 추적**하며 NotoSansKR 2종과 OFL 라이선스가
+들어 있다.
+
+`skia/image_conv.rs` 의 "저장소 체크아웃에는 `ttfs/opensource/NotoSansKR` 이 항상 있어
+한국어 폴백이 보장된다" 는 주석은 **사실**이다. 제거하면 폰트 미설치 환경(CI headless·
+컨테이너)에서 한국어가 드롭되는 [#2293](https://github.com/edwardkim/rhwp/issues/2293)
+회귀가 재발한다.
+
+**작업지시자 결정**: `ttfs/opensource/` 는 모든 경우에 접근 경로로 확보할 수 있으므로 유지한다.
+
+### #2293 회귀 방어의 실체
+
+#2293 의 근인은 두 가지였고 **경로 로딩은 부수적**이었다.
+
+1. `ttfs/` 미로딩
+2. **generic 폴백을 존재 확인 없이 하드 고정** ← 실제로 텍스트를 드롭시킨 원인
+   (실험 증명: 실존 폰트로 바꾸니 축 라벨 잉크 0 → 451)
+
+현재 `first_existing_family()` 로 폴백을 존재 확인 후 체인 결정하는 방어가 살아 있다.
+**이 방어와 `ttfs/opensource/` 유지로 회귀 위험은 없다.**
+
+## 3. 조치 범위
+
+| 경로 | 조치 | 근거 |
+|---|---|---|
+| `ttfs/opensource/` | **유지** | 저장소 자산, 한국어 폴백 보장 |
+| `ttfs/hwp/`, `ttfs/windows/` | **제거** | `.gitignore` 로컬 전용(저작권 폰트) |
+| `ttfs` (루트) | **제거** | 위 둘의 상위, 저장소에는 `FONTS.md` 와 `opensource/` 뿐 |
+| `/mnt/c/Windows/Fonts` | **제거** | WSL2 개발 PC 전용, #2268 원인 |
+| OS 시스템 경로 (`/usr/share/fonts` 등) | **유지** | `svg.rs` 의 정당한 OS별 분기 |
+
+제거된 경로의 폰트가 필요하면 `--font-path` 또는 신규 `RHWP_FONT_PATH` 로 지정한다.
+
+## 4. 작업 단계
+
+### 1단계 — 폰트 조달 경로 결정을 한 곳으로 통합
+
+`src/renderer/font_paths.rs`(신규)에 조달 순서를 단일 정의한다.
+
+```
+1. 호출자 지정      — options.font_paths / extra_paths (최우선)
+2. RHWP_FONT_PATH   — 환경변수, OS 관례 구분자(`:` / Windows `;`)
+3. 시스템 기본      — load_system_fonts() 또는 OS별 경로
+4. ttfs/opensource  — 최후 폴백 (저장소 자산)
+```
+
+4개 파일이 이 함수를 호출하도록 바꾼다. `svg.rs` 의 OS별 분기는 이 함수로 옮긴다.
+
+### 2단계 — `RHWP_FONT_PATH` 지원
+
+- 복수 경로를 OS 관례 구분자로 분리
+- 존재하지 않는 경로는 경고 후 건너뛴다(현행 `--font-path` 와 동일 동작)
+- CLI 문서(`mydocs/manual/cli_commands.md`)에 반영
+
+### 3단계 — 하드코딩 제거
+
+3절 표대로 4개 파일에서 제거한다. `ttfs/opensource` 는 1단계 함수의 최후 폴백으로만 남는다.
+
+### 4단계 — 검증
+
+- 폰트를 `--font-path` 로 공급했을 때 산출 PDF·SVG **바이트 동일** 확인(제거 전후 대조)
+- `RHWP_FONT_PATH` 지정/미지정 동작 테스트
+- **`ttfs/opensource` 만 있는 상태에서 한국어 렌더 확인** — #2293 회귀 가드
+- 전체 스위트 + roundtrip baseline + native-skia 대상 테스트
+
+## 5. 검증 계획 상세
+
+red→green 재현이 가능한 지점을 명시한다.
+
+- `RHWP_FONT_PATH` 를 무시하도록 되돌리면 신규 테스트가 FAIL 해야 한다
+- `ttfs/opensource` 폴백을 제거하면 한국어 렌더 가드가 FAIL 해야 한다
+
+## 6. 범위 밖
+
+- **fontdb 캐시 도입** — `skia/image_conv.rs` 는 이미 `OnceLock` 캐시가 있으나 `pdf.rs` 는
+  없다. 캐시는 #2264(fontdb 메모리 축)와 연계해 별도 처리한다. 1단계 통합이 그 준비가 된다.
+- **#2268 close 판단** — 이 작업으로 원인이 제거되지만, 간헐 재현이라 일정 기간 관찰 후
+  작업지시자가 판단한다.
+- 백엔드 선택(#2283 krilla 미진행 결정)과 무관하다.
+
+## 7. 승인 요청
+
+위 4단계로 진행해도 될지 확인 부탁드립니다. 특히 다음 두 가지에 의견 주시면 반영하겠습니다.
+
+- `RHWP_FONT_PATH` 라는 이름과 OS 관례 구분자 사용
+- 1단계에서 `svg.rs` 의 OS별 시스템 경로 분기를 공통 함수로 옮기는 범위

--- a/src/renderer/font_paths.rs
+++ b/src/renderer/font_paths.rs
@@ -1,0 +1,199 @@
+//! [#2864] 폰트 조달 경로를 한 곳에서 결정한다.
+//!
+//! 종전에는 `renderer/pdf.rs`·`renderer/svg.rs`·`renderer/skia/image_conv.rs`·
+//! `renderer/skia/renderer.rs` 네 곳이 각자 탐색 경로를 하드코딩했고, 그중
+//! `ttfs/hwp`·`ttfs/windows`(로컬 전용 저작권 폰트, `.gitignore`)와
+//! `/mnt/c/Windows/Fonts`(WSL2 개발 PC 전용)는 **특정 환경에만 존재**했다.
+//!
+//! 서버·컨테이너에서 CLI 로 대량 변환할 때 이 경로들은 아무 값도 주지 못하면서
+//! 경로 검사만 발생시키고, WSL2 에서는 `/mnt/c` 가 9p 파일시스템이라 간헐적
+//! 극단 지연으로 `export-pdf` 가 통째로 멎었다(#2268, 누적 4회 관측).
+//!
+//! 폰트는 호출자가 `--font-path`(`options.font_paths`) 또는 `RHWP_FONT_PATH`
+//! 로 지정하거나 시스템에 설치해 쓴다. 이 모듈은 그 순서만 정의한다.
+//!
+//! # 조달 순서
+//!
+//! 1. **호출자 지정** — `--font-path` / `options.font_paths` (최우선)
+//! 2. **`RHWP_FONT_PATH`** — 환경변수. 백엔드 대량 변환에서 호출마다 인자를
+//!    붙이는 대신 한 번만 설정한다. 복수 경로는 OS 관례 구분자로 나눈다
+//!    (유닉스 `:`, Windows `;`).
+//! 3. **시스템 기본** — OS별 표준 폰트 디렉터리
+//! 4. **`ttfs/opensource`** — 최후 폴백. `.gitignore` 대상이 아닌 **저장소 자산**
+//!    (NotoSansKR 2종 + OFL)이라 모든 체크아웃에서 확보된다. 폰트 미설치 환경
+//!    (CI headless·컨테이너)에서 한국어가 드롭되는 것을 막는다(#2293).
+
+use std::path::{Path, PathBuf};
+
+/// 폰트 탐색 경로 환경변수. 복수 경로는 OS 관례 구분자로 나눈다.
+pub const FONT_PATH_ENV: &str = "RHWP_FONT_PATH";
+
+/// 저장소 번들 오픈소스 폰트 — 최후 폴백(#2293 한국어 드롭 방지).
+pub const BUNDLED_OPENSOURCE_DIR: &str = "ttfs/opensource";
+
+/// `RHWP_FONT_PATH` 를 읽어 경로 목록으로 나눈다.
+///
+/// 미설정이면 빈 벡터를 돌려준다. 존재하지 않는 경로도 그대로 담아 호출부가
+/// 기존 `--font-path` 와 동일하게 경고·건너뛰기를 하도록 맡긴다.
+pub fn env_font_paths() -> Vec<PathBuf> {
+    let Ok(raw) = std::env::var(FONT_PATH_ENV) else {
+        return Vec::new();
+    };
+    // `split` 은 빈 조각도 내므로(예: 연속 구분자, 양끝 구분자) 걸러낸다.
+    raw.split(PATH_SEPARATOR)
+        .map(str::trim)
+        .filter(|s| !s.is_empty())
+        .map(PathBuf::from)
+        .collect()
+}
+
+#[cfg(target_os = "windows")]
+const PATH_SEPARATOR: char = ';';
+
+#[cfg(not(target_os = "windows"))]
+const PATH_SEPARATOR: char = ':';
+
+/// OS별 시스템 폰트 디렉터리.
+///
+/// `usvg::fontdb::Database::load_system_fonts()` 를 쓰는 경로에서는 필요 없고,
+/// 파일을 직접 훑는 경로(`svg.rs::find_font_file`, `skia` typeface 로딩)에서 쓴다.
+pub fn system_font_dirs() -> Vec<PathBuf> {
+    #[cfg(target_os = "macos")]
+    {
+        vec![
+            PathBuf::from("/Library/Fonts"),
+            PathBuf::from("/System/Library/Fonts"),
+            PathBuf::from("/System/Library/Fonts/Supplemental"),
+        ]
+    }
+    #[cfg(target_os = "linux")]
+    {
+        vec![
+            PathBuf::from("/usr/share/fonts"),
+            PathBuf::from("/usr/local/share/fonts"),
+        ]
+    }
+    #[cfg(target_os = "windows")]
+    {
+        vec![PathBuf::from("C:\\Windows\\Fonts")]
+    }
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        Vec::new()
+    }
+}
+
+/// 파일을 직접 훑는 경로용 탐색 디렉터리 전체를 조달 순서대로 돌려준다.
+///
+/// `extra` 는 호출자 지정 경로(`--font-path` 등)이며 최우선이다.
+pub fn search_dirs(extra: &[PathBuf]) -> Vec<PathBuf> {
+    let mut dirs: Vec<PathBuf> = extra.to_vec();
+    dirs.extend(env_font_paths());
+    dirs.extend(system_font_dirs());
+    // 최후 폴백 — 저장소 자산이라 항상 존재한다(#2293).
+    dirs.push(PathBuf::from(BUNDLED_OPENSOURCE_DIR));
+    dirs
+}
+
+/// `fontdb` 에 조달 순서대로 폰트를 적재한다.
+///
+/// 시스템 폰트는 `load_system_fonts()` 가 담당하므로 여기서는 호출자 지정 →
+/// 환경변수 → 번들 순으로 디렉터리만 추가한다. 존재하지 않는 경로는 건너뛰되,
+/// `extra`(사용자가 명시한 경로)만 경고한다 — 환경변수·번들은 없을 수 있다.
+pub fn load_into_fontdb(fontdb: &mut usvg::fontdb::Database, extra: &[PathBuf]) {
+    for dir in extra {
+        if dir.exists() {
+            fontdb.load_fonts_dir(dir);
+        } else {
+            eprintln!(
+                "WARN: font path '{}' not found. 해당 경로의 폰트는 로드하지 않습니다.",
+                dir.display()
+            );
+        }
+    }
+    for dir in env_font_paths() {
+        if dir.exists() {
+            fontdb.load_fonts_dir(&dir);
+        } else {
+            eprintln!(
+                "WARN: {FONT_PATH_ENV} entry '{}' not found. 해당 경로의 폰트는 로드하지 않습니다.",
+                dir.display()
+            );
+        }
+    }
+    let bundled = Path::new(BUNDLED_OPENSOURCE_DIR);
+    if bundled.exists() {
+        fontdb.load_fonts_dir(bundled);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// 환경변수는 프로세스 전역이라 테스트가 병렬로 돌면 서로를 덮는다.
+    /// 이 모듈의 env 의존 테스트는 하나로 묶어 순서를 고정한다.
+    #[test]
+    fn env_font_paths_parses_and_filters() {
+        // 미설정
+        std::env::remove_var(FONT_PATH_ENV);
+        assert!(env_font_paths().is_empty(), "미설정이면 빈 목록이어야 한다");
+
+        // 단일 경로
+        std::env::set_var(FONT_PATH_ENV, "/tmp/fonts-a");
+        assert_eq!(env_font_paths(), vec![PathBuf::from("/tmp/fonts-a")]);
+
+        // 복수 경로 + 빈 조각(연속·양끝 구분자) 제거
+        let joined = format!(
+            "{sep}/tmp/fonts-a{sep}{sep}/tmp/fonts-b{sep}",
+            sep = PATH_SEPARATOR
+        );
+        std::env::set_var(FONT_PATH_ENV, joined);
+        assert_eq!(
+            env_font_paths(),
+            vec![PathBuf::from("/tmp/fonts-a"), PathBuf::from("/tmp/fonts-b")],
+            "빈 조각은 걸러내고 순서는 보존해야 한다"
+        );
+
+        std::env::remove_var(FONT_PATH_ENV);
+    }
+
+    #[test]
+    fn search_dirs_orders_caller_first_and_bundled_last() {
+        std::env::remove_var(FONT_PATH_ENV);
+        let extra = vec![PathBuf::from("/tmp/caller")];
+        let dirs = search_dirs(&extra);
+
+        assert_eq!(
+            dirs.first(),
+            Some(&PathBuf::from("/tmp/caller")),
+            "호출자 지정 경로가 최우선이어야 한다"
+        );
+        assert_eq!(
+            dirs.last(),
+            Some(&PathBuf::from(BUNDLED_OPENSOURCE_DIR)),
+            "번들 오픈소스 폰트가 최후 폴백이어야 한다"
+        );
+    }
+
+    /// [#2864] 환경 종속 경로가 조달 목록에 다시 들어오지 않도록 고정한다.
+    /// 이 가드가 없으면 편의를 위해 재추가되어 #2268 간헐 행이 재발할 수 있다.
+    #[test]
+    fn search_dirs_excludes_environment_specific_paths() {
+        std::env::remove_var(FONT_PATH_ENV);
+        let dirs = search_dirs(&[]);
+        let joined: Vec<String> = dirs.iter().map(|p| p.display().to_string()).collect();
+
+        for banned in [
+            "/mnt/c/Windows/Fonts", // WSL2 개발 PC 전용 — #2268 간헐 행 원인
+            "ttfs/hwp",             // .gitignore 로컬 전용(저작권 폰트)
+            "ttfs/windows",
+        ] {
+            assert!(
+                !joined.iter().any(|d| d == banned),
+                "환경 종속 경로가 조달 목록에 있다: {banned}\n\
+                 폰트가 필요하면 --font-path 또는 {FONT_PATH_ENV} 로 지정한다."
+            );
+        }
+    }
+}

--- a/src/renderer/mod.rs
+++ b/src/renderer/mod.rs
@@ -15,6 +15,8 @@ pub mod equation;
 pub(crate) mod equation_tac_flow;
 pub mod float_placement;
 pub mod font_metrics_data;
+#[cfg(not(target_arch = "wasm32"))]
+pub mod font_paths;
 pub(crate) mod form_caption;
 pub mod height_cursor;
 pub mod height_measurer;

--- a/src/renderer/pdf.rs
+++ b/src/renderer/pdf.rs
@@ -514,24 +514,10 @@ fn default_mono_family() -> &'static str {
 fn create_fontdb(options: &PdfExportOptions) -> usvg::fontdb::Database {
     let mut fontdb = usvg::fontdb::Database::new();
     fontdb.load_system_fonts();
-    for dir in &options.font_paths {
-        if dir.exists() {
-            fontdb.load_fonts_dir(dir);
-        } else {
-            eprintln!(
-                "WARN: PDF font path '{}' not found. 해당 경로의 폰트는 로드하지 않습니다.",
-                dir.display()
-            );
-        }
-    }
-    for dir in &["ttfs", "ttfs/windows", "ttfs/hwp"] {
-        if std::path::Path::new(dir).exists() {
-            fontdb.load_fonts_dir(dir);
-        }
-    }
-    if std::path::Path::new("/mnt/c/Windows/Fonts").exists() {
-        fontdb.load_fonts_dir("/mnt/c/Windows/Fonts");
-    }
+    // [#2864] 조달 순서는 renderer::font_paths 가 단일 정의한다.
+    // 종전의 ttfs/hwp·ttfs/windows(로컬 전용)와 /mnt/c/Windows/Fonts(WSL2 전용)는
+    // 제거했다 — 서버·컨테이너에서 무의미하고 /mnt/c 는 #2268 간헐 행의 원인이었다.
+    crate::renderer::font_paths::load_into_fontdb(&mut fontdb, &options.font_paths);
     fontdb.set_serif_family(options.fallback_serif.as_str());
     fontdb.set_sans_serif_family(options.fallback_sans.as_str());
     fontdb.set_monospace_family(options.fallback_mono.as_str());

--- a/src/renderer/skia/image_conv.rs
+++ b/src/renderer/skia/image_conv.rs
@@ -412,14 +412,9 @@ fn svg_fontdb() -> Arc<usvg::fontdb::Database> {
             // resvg 가 조각의 텍스트를 통째로 드롭했다.
             let mut fontdb = usvg::fontdb::Database::new();
             fontdb.load_system_fonts();
-            for dir in &["ttfs", "ttfs/windows", "ttfs/hwp"] {
-                if std::path::Path::new(dir).exists() {
-                    fontdb.load_fonts_dir(dir);
-                }
-            }
-            if std::path::Path::new("/mnt/c/Windows/Fonts").exists() {
-                fontdb.load_fonts_dir("/mnt/c/Windows/Fonts");
-            }
+            // [#2864] 조달 순서는 renderer::font_paths 가 단일 정의한다.
+            // ttfs/opensource 번들이 최후 폴백으로 남아 한국어 드롭을 막는다(#2293).
+            crate::renderer::font_paths::load_into_fontdb(&mut fontdb, &[]);
 
             // generic 폴백은 실존하는 첫 후보로 (매칭 실패 = 텍스트 드롭 방지).
             let sans = first_existing_family(

--- a/src/renderer/skia/renderer.rs
+++ b/src/renderer/skia/renderer.rs
@@ -311,10 +311,8 @@ impl SkiaLayerRenderer {
     /// 사용자 지정 폰트 디렉토리 (ttfs 등) 의 폰트를 로드하여 Skia 가 직접 사용 가능하게 한다.
     /// SVG 의 `--font-path` 와 동일한 패턴.
     pub fn with_font_paths(mut self, font_paths: &[std::path::PathBuf]) -> Self {
-        let mut search_dirs: Vec<std::path::PathBuf> = font_paths.to_vec();
-        for dir in &["ttfs/hwp", "ttfs/windows", "ttfs"] {
-            search_dirs.push(std::path::PathBuf::from(dir));
-        }
+        // [#2864] 조달 순서는 renderer::font_paths 가 단일 정의한다.
+        let search_dirs = crate::renderer::font_paths::search_dirs(font_paths);
         for dir in &search_dirs {
             if !dir.exists() {
                 continue;

--- a/src/renderer/svg.rs
+++ b/src/renderer/svg.rs
@@ -3508,34 +3508,12 @@ fn find_font_file(
         files
     };
 
-    // 탐색 경로 (우선순위 순)
-    let mut search_dirs: Vec<std::path::PathBuf> = extra_paths.to_vec();
-    for dir in &["ttfs/hwp", "ttfs/windows", "ttfs"] {
-        search_dirs.push(Path::new(dir).to_path_buf());
-    }
-    // 시스템 폰트 경로
-    #[cfg(target_os = "macos")]
-    {
-        search_dirs.push(Path::new("/Library/Fonts").to_path_buf());
-        search_dirs.push(Path::new("/System/Library/Fonts").to_path_buf());
-        search_dirs.push(Path::new("/System/Library/Fonts/Supplemental").to_path_buf());
-    }
-    #[cfg(target_os = "linux")]
-    {
-        search_dirs.push(Path::new("/usr/share/fonts").to_path_buf());
-        search_dirs.push(Path::new("/usr/local/share/fonts").to_path_buf());
-    }
-    #[cfg(target_os = "windows")]
-    {
-        search_dirs.push(Path::new("C:\\Windows\\Fonts").to_path_buf());
-    }
-    // WSL Windows 폰트
-    if Path::new("/mnt/c/Windows/Fonts").exists() {
-        search_dirs.push(Path::new("/mnt/c/Windows/Fonts").to_path_buf());
-    }
-    // Task #1224: 오픈소스 번들 대체 폰트 경로 — **최후 탐색**(실제 저작권/시스템 폰트가
-    // 항상 우선). 고딕 계열의 Noto Sans KR ExtraLight 대체가 여기서만 매칭된다.
-    search_dirs.push(Path::new("ttfs/opensource").to_path_buf());
+    // [#2864] 탐색 경로(우선순위 순)는 renderer::font_paths 가 단일 정의한다.
+    // 호출자 지정 → RHWP_FONT_PATH → OS 시스템 경로 → ttfs/opensource(최후 폴백).
+    // 종전의 ttfs/hwp·ttfs/windows(로컬 전용)와 /mnt/c/Windows/Fonts(WSL2 전용)는
+    // 제거했다. Task #1224 의 고딕 대체(Noto Sans KR ExtraLight)는 최후 탐색인
+    // ttfs/opensource 에서 그대로 매칭된다.
+    let search_dirs = crate::renderer::font_paths::search_dirs(extra_paths);
 
     for dir in &search_dirs {
         if !dir.exists() {


### PR DESCRIPTION
`Closes #2864`
`Closes #2268`

## 문제

렌더러 4곳이 각자 폰트 탐색 경로를 하드코딩했고, 그중 두 종류는 **특정 환경에만 존재**했다.

- `ttfs/hwp`, `ttfs/windows` — 로컬 전용 저작권 폰트(`.gitignore`)
- `/mnt/c/Windows/Fonts` — WSL2 개발 PC 전용

서버·컨테이너에서 CLI 로 대량 변환할 때 이 경로들은 아무 값도 주지 못하면서 경로 검사만 발생시키고, WSL2 에서는 `/mnt/c` 가 9p 파일시스템이라 간헐적 극단 지연으로 `export-pdf` 가 통째로 멎었다(**#2268**, 누적 4회 관측 — 5분 이상 무응답 후 재시도 시 정상).

| 파일 | 하드코딩 |
|---|---|
| `renderer/pdf.rs` | `ttfs`, `ttfs/windows`, `ttfs/hwp`, `/mnt/c/Windows/Fonts` |
| `renderer/svg.rs` | 위 + OS별 시스템 경로 + `ttfs/opensource` |
| `renderer/skia/image_conv.rs` | `ttfs`, `ttfs/windows`, `ttfs/hwp`, `/mnt/c/...` |
| `renderer/skia/renderer.rs` | `ttfs/hwp`, `ttfs/windows`, `ttfs` |

## 변경

`src/renderer/font_paths.rs` 를 신설해 조달 순서를 단일 정의하고, 4개 파일이 이를 호출한다.

1. **호출자 지정** — `--font-path` / `options.font_paths`
2. **`RHWP_FONT_PATH`** — 신규 환경변수(유닉스 `:`, Windows `;`). 백엔드 대량 변환에서 호출마다 인자를 붙이는 대신 한 번만 설정한다
3. **시스템 기본** — OS별 표준 경로
4. **`ttfs/opensource`** — 최후 폴백

`svg.rs` 의 OS별 시스템 경로 분기도 함께 옮겼다. **코드 58줄 제거 / 22줄 추가.**

### `ttfs/opensource` 는 유지한다

`.gitignore` 는 `/ttfs/hwp/`, `/ttfs/windows/` 와 특정 ttf 2개만 제외한다. **`ttfs/opensource/` 는 git 이 추적하는 저장소 자산**(NotoSansKR 2종 + OFL)이라 모든 체크아웃에서 확보되며, 폰트 미설치 환경(CI headless·컨테이너)에서 한국어가 드롭되는 것을 막는다(#2293).

#2293 의 실제 근인은 "generic 폴백을 존재 확인 없이 하드 고정" 이었고(실험 증명: 실존 폰트로 바꾸니 축 라벨 잉크 0 → 451), 경로 로딩은 부수적이었다. `first_existing_family()` 방어는 그대로 유지된다.

## 실측 — 기능 손실 없음

`samples/basic/treatise sample.hwp` 로 확인했다.

| 조건 | 산출 크기 | 임베드 폰트 |
|---|---:|---|
| 변경 전 | 1,024,623 | Haansoft Batang/Dotum, H2gtrM, TimesNewRoman |
| 변경 후 (폰트 미지정) | 650,219 | NotoSerifKR, NotoSansKR, DejaVu |
| 변경 후 + `RHWP_FONT_PATH` | **1,024,623 (바이트 완전 동일)** | **변경 전과 동일** |

```bash
RHWP_FONT_PATH="/mnt/c/Windows/Fonts:ttfs/hwp:ttfs/windows" \
  rhwp export-pdf "samples/basic/treatise sample.hwp" -o out.pdf
# → 변경 전 산출물과 cmp 결과 동일
```

폰트 미지정 시의 차이는 **이 PC 에만 `/mnt/c` 가 있어 생기던 것**이며, 서버·CI 는 이미 후자와 같은 출력이었다. 즉 종전에는 **환경마다 산출물이 달랐고**, 이 PR 이 그것을 명시적 설정에만 의존하도록 바꾼다.

## 회귀 가드

`search_dirs_excludes_environment_specific_paths` 가 `/mnt/c/Windows/Fonts`·`ttfs/hwp`·`ttfs/windows` 의 재추가를 막는다. 편의를 위해 되돌리면 #2268 이 재발하므로 코드로 고정했다.

## 검증

- `cargo fmt --check` 통과, `clippy --all-targets` 오류 0, 전체 스위트 실패 없음
- `font_paths` 테스트 3건 통과
- **red→green**: 하드코딩을 되살리면 가드가 FAIL(`환경 종속 경로가 조달 목록에 있다: /mnt/c/Windows/Fonts`) → 복원 시 3건 통과
- `RHWP_FONT_PATH` 지정 시 변경 전과 바이트 동일 확인

## 문서

`mydocs/manual/cli_commands.md` 에 조달 순서와 함께 **"폰트를 지정하지 않으면 산출물이 달라진다"** 를 명시했다. 서버·컨테이너에서 정본과 같은 결과를 얻으려면 폰트를 설치하고 경로를 명시해야 한다는 안내다.

## #2268 종결

간헐 행의 원인(`/mnt/c` 9p 스캔)이 제거되어 함께 close 한다. 재발 시 재개한다.
