### PR TITLE
개체 설명문/수식 스크립트 입력 길이 미검증으로 인한 CTRL_DATA 손상 방지

### DIFF
--- a/mydocs/report/task_m100_2892_report.md
+++ b/mydocs/report/task_m100_2892_report.md
@@ -1,0 +1,61 @@
+# task m100-2892: 개체 설명문/수식 스크립트 입력 길이 가드
+
+## 이슈
+
+- edwardkim/rhwp#2892 — 개체 설명문/수식 스크립트 입력 길이 미검증으로 인한 CTRL_DATA 손상 방지
+  (#2851/#2862/#2866/#2878 형제 필드 재발)
+
+## 근거
+
+`src/serializer/byte_writer.rs:70-76`의 `write_hwp_string()`은 UTF-16 코드 유닛 수를
+`as u16`으로 캐스팅해 길이 프리픽스를 만든다. 검증 없이 65536자 이상 문자열이 들어오면
+캐스팅이 랩어라운드되어 손상된 레코드가 만들어진다. 이 sink에 도달하는 두 입력 경로를
+확인했다.
+
+- `src/serializer/control.rs:1905` — `w.write_hwp_string(&common.description)` ←
+  `picture-props-dialog.ts`의 개체 설명문 서브 대화상자(`showDescriptionPrompt()`)
+- `src/serializer/control.rs:2386` — `w.write_hwp_string(&eq.script)` ←
+  `equation-editor-dialog.ts`의 수식 스크립트 입력(`scriptArea`)
+
+참고: `equation-props-dialog.ts`의 스크립트 필드는 `readOnly = true`인 조회 전용이라
+편집 경로가 아니므로 스코프에서 제외했다.
+
+## 변경 사항
+
+- `rhwp-studio/src/ui/picture-props-dialog.ts`
+  - `MAX_OBJECT_DESCRIPTION_LEN = 4000` 상수 추가
+  - `showDescriptionPrompt()`의 textarea에 `maxLength` 지정, 상한 초과 시 에러 라벨 표시 후
+    저장 거부
+  - `handleOk()` 진입 시 방어적으로 한 번 더 상한 검증(초과 시 서브 대화상자 재표시)
+- `rhwp-studio/src/ui/equation-editor-dialog.ts`
+  - `MAX_EQUATION_SCRIPT_LEN = 8000` 상수 추가
+  - `scriptArea`에 `maxLength` 지정, 에러 라벨 요소 추가
+  - `handleOk()`에서 상한 초과 시 에러 라벨 표시 후 저장 거부; 대화상자 `open()` 시
+    에러 라벨 초기화
+- `rhwp-studio/tests/object-description-equation-script-length-guard.test.ts` (신규)
+  - 두 상수가 65536보다 충분히 작은지 소스 가드로 검증
+  - `handleOk()`가 상한 초과 시 저장을 거부하는 가드 분기를 포함하는지 소스 가드로 검증
+
+`.rs` 파일은 수정하지 않았다.
+
+## 작업 중 발견한 사항 — worktree 브랜치 노후화
+
+작업 시작 시 이 worktree(`rhwp-wt-u`)의 현재 브랜치가 `push-2878`였고, 이는
+`origin/devel`(최신 tip: `95509062` PR #2834 merge)에서 상당히 갈라진 상태였다. 특히
+`picture-props-dialog.ts`는 `origin/devel`에서 `handleOk()`가 `buildPicturePropsPatch()` /
+`captureApplyForm()` / `applyPropertyPatch()`를 사용하는 구조로 리팩터링되어 있었던 반면,
+`push-2878` 브랜치의 파일은 그 이전의 인라인 `updated: Record<string, unknown>` 구조였다.
+
+`git fetch origin devel` 후 `origin/devel`을 베이스로 새 브랜치
+(`task/m100-2883-object-desc-eq-script-len-guard`)를 만들고, 두 파일 중
+`equation-editor-dialog.ts`는 깨끗이 cherry-pick되었지만 `picture-props-dialog.ts`는
+충돌이 발생해 실제 `origin/devel`의 최신 `handleOk()` 구조에 맞춰 다시 작성했다.
+(`git stash`는 사용하지 않았다 — 임시 커밋 + cherry-pick으로 처리했다.)
+
+## 검증
+
+- `npm test` — 501개 중 500 통과, 1 실패(`cell-flow-boundary.test.ts`, 이번 변경과 무관한
+  기존 known-failure). 신규 테스트 2건(`개체 설명문/수식 스크립트 상한은 ...`,
+  `handleOk()가 상한 초과 시 저장을 거부한다`) 모두 통과.
+- `npx tsc --noEmit` — 기존 베이스라인과 동일하게 `@wasm/rhwp.js` 모듈 미발견 TS2307 2건만
+  존재(`wasm-bridge.ts`, `hwpctl/index.ts`), 신규 에러 없음.

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -14,6 +14,19 @@ import { enableDialogDrag } from './dialog-drag';
  * - PicturePropsDialog 패턴 (ModalDialog 미상속, 자체 overlay/DOM/keyboard 관리)
  */
 
+/**
+ * 수식 스크립트(script)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 EQEDIT 컨트롤의 script 문자열을
+ * `write_hwp_string()`(`src/serializer/byte_writer.rs`)로 기록하는데, 이 함수는 UTF-16
+ * 코드 유닛 수를 `as u16`으로 캐스팅해 길이 프리픽스를 만든다. 문자열 길이가 65536
+ * 이상이면 캐스팅이 랩어라운드되어 길이 프리픽스와 실제 기록된 바이트 수가 어긋난
+ * 손상된 레코드가 만들어진다(#2851/#2862/#2866/#2878과 동일 원인). `.rs`를 수정하지 않는
+ * 범위에서, 손상 가능한 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은
+ * 상한으로 미리 막는다.
+ */
+export const MAX_EQUATION_SCRIPT_LEN = 8000;
+
 type InputMode = 'hwp' | 'latex';
 
 interface TemplateEntry { label: string; hwp: string; latex: string }
@@ -203,6 +216,7 @@ export class EquationEditorDialog {
   private dialog!: HTMLDivElement;
   private previewContainer!: HTMLDivElement;
   private scriptArea!: HTMLTextAreaElement;
+  private scriptErrorLabel!: HTMLDivElement;
   private fontSizeInput!: HTMLInputElement;
   private colorInput!: HTMLInputElement;
   private built = false;
@@ -270,6 +284,7 @@ export class EquationEditorDialog {
     }
 
     this.scriptArea.value = this.origProps.script || '';
+    this.scriptErrorLabel.style.display = 'none';
     this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100));
     this.colorInput.value = colorRefToHex(this.origProps.color);
 
@@ -376,6 +391,7 @@ export class EquationEditorDialog {
     this.scriptArea.className = 'eq-script';
     this.scriptArea.rows = 4;
     this.scriptArea.spellcheck = false;
+    this.scriptArea.maxLength = MAX_EQUATION_SCRIPT_LEN;
     this.scriptArea.addEventListener('input', () => { this.schedulePreview(); this.onScriptInput(); });
     this.scriptArea.addEventListener('keydown', (e) => this.onScriptKeydown(e));
 
@@ -385,6 +401,14 @@ export class EquationEditorDialog {
 
     scriptWrap.append(this.scriptArea, this.acDropdown);
     body.appendChild(scriptWrap);
+
+    this.scriptErrorLabel = document.createElement('div');
+    this.scriptErrorLabel.className = 'eq-script-error';
+    this.scriptErrorLabel.style.color = '#c00';
+    this.scriptErrorLabel.style.fontSize = '11px';
+    this.scriptErrorLabel.style.display = 'none';
+    this.scriptErrorLabel.textContent = `수식 스크립트는 ${MAX_EQUATION_SCRIPT_LEN}자를 넘을 수 없습니다.`;
+    body.appendChild(this.scriptErrorLabel);
 
     // 6) 속성 행
     const propsRow = document.createElement('div');
@@ -691,6 +715,11 @@ export class EquationEditorDialog {
     if (!this.origProps) return;
 
     const script = this.scriptArea.value;
+    if (script.length > MAX_EQUATION_SCRIPT_LEN) {
+      this.scriptErrorLabel.style.display = '';
+      return;
+    }
+    this.scriptErrorLabel.style.display = 'none';
     const fontSizePt = parseInt(this.fontSizeInput.value, 10) || 10;
     const fontSizeHwpunit = fontSizePt * 100;
     const color = hexToColorRef(this.colorInput.value);

--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -53,6 +53,19 @@ const OLE_TAB_NAMES = ['기본', '여백/캡션', '선'];
 /** 탭 이름 — 직선용 (채우기/글상자 불필요) */
 const LINE_TAB_NAMES = ['기본', '여백/캡션', '선', '그림자'];
 
+/**
+ * 개체 설명문(description)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 그림/글상자 등 개체의 CommonObjAttr
+ * description 필드를 `write_hwp_string()`(`src/serializer/byte_writer.rs`)로 기록하는데,
+ * 이 함수는 UTF-16 코드 유닛 수를 `as u16`으로 캐스팅해 길이 프리픽스를 만든다. 문자열
+ * 길이가 65536 이상이면 캐스팅이 랩어라운드되어 길이 프리픽스와 실제 기록된 바이트 수가
+ * 어긋난 손상된 레코드가 만들어진다(#2851/#2862/#2866/#2878과 동일 원인). `.rs`를 수정하지
+ * 않는 범위에서, 손상 가능한 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은
+ * 상한으로 미리 막는다.
+ */
+export const MAX_OBJECT_DESCRIPTION_LEN = 4000;
+
 export class PicturePropsDialog {
   private overlay!: HTMLDivElement;
   private dialog!: HTMLDivElement;
@@ -1929,6 +1942,10 @@ export class PicturePropsDialog {
 
   private handleOk(): void {
     if (!this.props) { this.hide(); return; }
+    if (this.descInput.value.length > MAX_OBJECT_DESCRIPTION_LEN) {
+      this.showDescriptionPrompt();
+      return;
+    }
     const updated: Record<string, unknown> = {};
     const sizeProtect = this.sizeFixedCheck.checked;
 
@@ -2701,8 +2718,17 @@ export class PicturePropsDialog {
     leftCol.className = 'cs-left-col';
     const textarea = document.createElement('textarea');
     textarea.className = 'pp-desc-textarea';
+    textarea.maxLength = MAX_OBJECT_DESCRIPTION_LEN;
     textarea.value = this.descInput.value;
     leftCol.appendChild(textarea);
+
+    const errorLabel = document.createElement('div');
+    errorLabel.className = 'pp-desc-error';
+    errorLabel.style.color = '#c00';
+    errorLabel.style.fontSize = '11px';
+    errorLabel.style.display = 'none';
+    errorLabel.textContent = `개체 설명문은 ${MAX_OBJECT_DESCRIPTION_LEN}자를 넘을 수 없습니다.`;
+    leftCol.appendChild(errorLabel);
 
     const rightCol = document.createElement('div');
     rightCol.className = 'cs-right-col';
@@ -2710,6 +2736,10 @@ export class PicturePropsDialog {
     okBtn.className = 'dialog-btn dialog-btn-primary';
     okBtn.textContent = '확인(D)';
     okBtn.addEventListener('click', () => {
+      if (textarea.value.length > MAX_OBJECT_DESCRIPTION_LEN) {
+        errorLabel.style.display = '';
+        return;
+      }
       this.descInput.value = textarea.value;
       overlay.remove();
     });

--- a/rhwp-studio/tests/object-description-equation-script-length-guard.test.ts
+++ b/rhwp-studio/tests/object-description-equation-script-length-guard.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2883 (#2851/#2862/#2866/#2878 형제 필드 재발): 개체 설명문(picture-props-dialog.ts)과
+// 수식 스크립트(equation-editor-dialog.ts) 입력 길이 미검증 → Rust 직렬화기
+// (src/serializer/control.rs)가 각각 CommonObjAttr.description / EQEDIT script를
+// write_hwp_string()(src/serializer/byte_writer.rs)로 기록할 때 UTF-16 코드 유닛 수를
+// `as u16`으로 캐스팅해 65536 이상이면 랩어라운드되어 레코드가 손상될 수 있었다.
+// `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출 전에 각 필드 길이를
+// 안전한 상한(MAX_OBJECT_DESCRIPTION_LEN/MAX_EQUATION_SCRIPT_LEN)으로 막는지를
+// 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const pictureSrc = readFileSync(path.join(dir, '../src/ui/picture-props-dialog.ts'), 'utf8');
+const equationSrc = readFileSync(path.join(dir, '../src/ui/equation-editor-dialog.ts'), 'utf8');
+
+test('개체 설명문/수식 스크립트 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const descMatch = pictureSrc.match(/MAX_OBJECT_DESCRIPTION_LEN\s*=\s*(\d+)/);
+  const scriptMatch = equationSrc.match(/MAX_EQUATION_SCRIPT_LEN\s*=\s*(\d+)/);
+  assert.ok(descMatch, 'MAX_OBJECT_DESCRIPTION_LEN 상수를 찾을 수 없음');
+  assert.ok(scriptMatch, 'MAX_EQUATION_SCRIPT_LEN 상수를 찾을 수 없음');
+
+  const descLimit = Number(descMatch![1]);
+  const scriptLimit = Number(scriptMatch![1]);
+
+  assert.ok(descLimit > 0 && descLimit < 65536, `개체 설명문 상한(${descLimit})이 u16 랩어라운드 지점보다 작아야 함`);
+  assert.ok(scriptLimit > 0 && scriptLimit < 65536, `수식 스크립트 상한(${scriptLimit})이 u16 랩어라운드 지점보다 작아야 함`);
+});
+
+test('handleOk()가 상한 초과 시 저장을 거부한다', () => {
+  assert.match(pictureSrc, /if \(this\.descInput\.value\.length > MAX_OBJECT_DESCRIPTION_LEN\)/);
+  assert.match(equationSrc, /if \(script\.length > MAX_EQUATION_SCRIPT_LEN\)/);
+});


### PR DESCRIPTION
## 요약

- `.rs`의 `write_hwp_string()`(u16 길이 프리픽스, 검증 없음)에 도달하는 개체 설명문 /
  수식 스크립트 입력 경로에 프런트엔드 길이 가드를 추가했다.
- #2851/#2862/#2866/#2878과 동일 원인(u16 캐스팅 랩어라운드)의 형제 필드 재발이다.
- `.rs`는 수정하지 않았다.

## 근거 (Red → Green)

**Red (수정 전)**
- `picture-props-dialog.ts`의 개체 설명문 서브 대화상자(`showDescriptionPrompt()`)
  textarea에 길이 제한이 전혀 없었다.
- `equation-editor-dialog.ts`의 `scriptArea`(수식 스크립트 편집 텍스트 영역)에도 길이
  제한이 전혀 없었다.
- 두 값 모두 `write_hwp_string()`(`src/serializer/byte_writer.rs:70-76`,
  `utf16.len() as u16`)까지 그대로 흘러간다:
  - `src/serializer/control.rs:1905` — `w.write_hwp_string(&common.description)`
  - `src/serializer/control.rs:2386` — `w.write_hwp_string(&eq.script)`
- 65536자 이상 입력 시 u16 캐스팅이 랩어라운드되어 CTRL_DATA/EQEDIT 레코드가 손상된다.

**Green (수정 후)**
- `MAX_OBJECT_DESCRIPTION_LEN = 4000` / `MAX_EQUATION_SCRIPT_LEN = 8000` 상수 추가.
- 각 입력 필드에 `maxLength` 지정 + 상한 초과 시 에러 라벨을 보여주고 저장(`handleOk()`)을
  거부.
- 소스 가드 테스트(`object-description-equation-script-length-guard.test.ts`)로 두 상수가
  65536보다 충분히 작은지, `handleOk()`가 상한 초과 시 저장을 거부하는 가드 분기를
  포함하는지 검증.

## 이슈

Closes edwardkim/rhwp#2892

## 검증

- [x] `npm test` — 신규 테스트 2건 통과, 기존 known-failure(`cell-flow-boundary.test.ts`) 외
      회귀 없음
- [x] `npx tsc --noEmit` — 기존 베이스라인 `@wasm/rhwp.js` TS2307 2건 외 신규 에러 없음
- [x] `.rs` 파일 미수정
