### PR TITLE
fix(render): 동일 이미지 겹침-clip 이 plane 다른 페어를 역방향으로 자르는 문제 수정 (closes #2895)

### DIFF
--- a/mydocs/report/task_m100_2895_report.md
+++ b/mydocs/report/task_m100_2895_report.md
@@ -1,0 +1,38 @@
+# Task #M100-2895 처리 결과
+
+## 이슈
+edwardkim/rhwp#2895 — 동일 이미지 겹침-clip 함수가 트리 순서를 z-순서로 오인해 plane 이 다른 이미지 쌍에서 역방향으로 잘림
+
+## 원인
+`PageRenderTree::clip_overlapping_same_bin_images` (`src/renderer/render_tree.rs`, Task #1154 도입)가
+동일 `bin_data_id` 이미지 페어의 clip 방향을 "RenderTree 순회(children 삽입) 순서 = 실제 페인트 순서"라는
+암묵적 가정으로 판단했다. 그러나 `src/paint/replay_order.rs` 가 정의하는 실제 재생 순서는
+`Background → BehindText → Flow → InFrontOfText` 4단계 plane 으로 분리되어 있어, `text_wrap` 이 다른
+두 이미지는 트리 순서와 무관하게 plane 순서로 재생된다. 트리 순서상 먼저 오는 Flow 이미지와 나중에
+오는 BehindText 이미지가 겹치면, 실제로는 BehindText 가 더 아래에 그려짐에도 기존 함수는 Flow 쪽을
+"아래에 깔린 쪽"으로 오판해 역방향으로 clip 했다.
+
+## 수정
+- `src/renderer/render_tree.rs`
+  - `ClipReplayPlane` (BehindText/Flow/InFrontOfText) 타입 추가 — `ImageNode.text_wrap` 으로부터
+    `paint_op_replay_plane_with_layer` 와 동일한 3-way 분류를 적용.
+  - `collect_image_nodes` 가 각 이미지의 plane 을 함께 수집하도록 튜플 확장.
+  - `clip_overlapping_same_bin_images` 의 페어 검출 루프에 `plane_a != plane_b` 가드를 추가해,
+    plane 이 다른 페어는 clip 대상에서 제외(보수적 최소 수정 — 정확한 역방향 clip 계산 대신 미적용).
+
+## 테스트 (red → green)
+`test_clip_skips_cross_plane_pairs` (`src/renderer/render_tree.rs` tests 모듈) 추가.
+
+- Red (가드 임시 비활성화 후 `cargo test`): `assertion left == right failed / left: 50.0 / right: 200.0`
+  — Flow 이미지가 역방향으로 50 까지 clip 됨을 실측.
+- Green (가드 복원 후 `cargo test`): 두 이미지 모두 원래 height(200.0) 유지, 11개 clip 관련 테스트 전부 통과.
+
+## 검증
+- `cargo build --lib`: 성공
+- `cargo test --lib render_tree::tests::test_clip`: 11 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021 src/renderer/render_tree.rs`: 적용 (개행 스타일 외 diff 없음)
+
+## 영향 범위
+`src/renderer/render_tree.rs`, `src/renderer/render_tree.rs` 내 테스트만 변경. 다른 렌더러/직렬화 코드는
+건드리지 않았으며, 기존 clip 로직(같은 plane 내 동일-bin 이미지 겹침)은 그대로 유지된다.

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1241,6 +1241,33 @@ pub struct PageRenderTree {
     inline_shape_positions: std::collections::HashMap<InlineShapeKey, (f64, f64)>,
 }
 
+/// `clip_overlapping_same_bin_images` 전용 대략적 replay plane 분류.
+///
+/// `src/paint/replay_order.rs` (`paint_op_replay_plane_with_layer`,
+/// `cap_master_page_plane`) 가 실제 페인트 backend 에서 적용하는 재생 순서는
+/// Background → BehindText → Flow → InFrontOfText 로, **트리 순서와 무관하게
+/// plane 별로 별도 재생**된다. 즉 트리 순서상 `BehindText` 개체가 `Flow`
+/// 개체보다 뒤에 있어도 실제로는 `BehindText` 가 먼저(더 아래에) 그려진다.
+/// clip 함수는 "트리 순서 = z 순서(먼저 그려짐 = 아래)"를 가정하므로, plane
+/// 이 다른 페어는 이 가정이 성립하지 않아 clip 방향을 잘못 판단할 수 있다
+/// (아래에 깔릴 그림이 아니라 위에 그려질 그림이 잘리는 역방향 clip).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipReplayPlane {
+    BehindText,
+    Flow,
+    InFrontOfText,
+}
+
+impl ClipReplayPlane {
+    fn from_text_wrap(wrap: Option<TextWrap>) -> Self {
+        match wrap {
+            Some(TextWrap::BehindText) => Self::BehindText,
+            Some(TextWrap::InFrontOfText) => Self::InFrontOfText,
+            _ => Self::Flow,
+        }
+    }
+}
+
 impl PageRenderTree {
     /// 새 페이지 렌더 트리 생성
     pub fn new(page_index: u32, width: f64, height: f64) -> Self {
@@ -1352,8 +1379,14 @@ impl PageRenderTree {
     /// 조건 2/3 은 의도적 시각 효과 (test-image, 3-10월_교육_통합 의 대각선
     /// 오프셋 등) 를 보호하기 위한 strict 가드.
     pub fn clip_overlapping_same_bin_images(&mut self) {
-        // Phase 1: 트리 순서대로 ImageNode 의 (id, bbox, bin_id, crop) 수집
-        let mut images: Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)> = Vec::new();
+        // Phase 1: 트리 순서대로 ImageNode 의 (id, bbox, bin_id, crop, plane) 수집
+        let mut images: Vec<(
+            NodeId,
+            BoundingBox,
+            u16,
+            Option<(i32, i32, i32, i32)>,
+            ClipReplayPlane,
+        )> = Vec::new();
         Self::collect_image_nodes(&self.root, &mut images);
 
         if images.len() < 2 {
@@ -1367,10 +1400,19 @@ impl PageRenderTree {
 
         for i in 0..images.len() {
             for j in (i + 1)..images.len() {
-                let (id_a, bbox_a, bin_a, crop_a) = &images[i];
-                let (_id_b, bbox_b, bin_b, _crop_b) = &images[j];
+                let (id_a, bbox_a, bin_a, crop_a, plane_a) = &images[i];
+                let (_id_b, bbox_b, bin_b, _crop_b, plane_b) = &images[j];
                 // 조건 1: 같은 bin_id
                 if bin_a != bin_b {
+                    continue;
+                }
+                // 조건 0 (#paint/replay_order.rs plane 분리 재생 정합):
+                // BehindText/InFrontOfText 는 Flow 와 별도 plane 으로 재생되어
+                // 실제 페인트 순서가 트리 순서와 반대일 수 있다. 서로 다른
+                // plane 페어는 clip 방향을 트리 순서만으로 확정할 수 없으므로
+                // 건너뛴다 (트리 순서가 곧 페인트 순서인 동일 plane 내에서만
+                // 이 함수의 z 가정이 성립한다).
+                if plane_a != plane_b {
                     continue;
                 }
                 // 조건 2/3: x, width 동일 (1px tolerance)
@@ -1418,10 +1460,22 @@ impl PageRenderTree {
 
     fn collect_image_nodes(
         node: &RenderNode,
-        out: &mut Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)>,
+        out: &mut Vec<(
+            NodeId,
+            BoundingBox,
+            u16,
+            Option<(i32, i32, i32, i32)>,
+            ClipReplayPlane,
+        )>,
     ) {
         if let RenderNodeType::Image(img) = &node.node_type {
-            out.push((node.id, node.bbox, img.bin_data_id, img.crop));
+            out.push((
+                node.id,
+                node.bbox,
+                img.bin_data_id,
+                img.crop,
+                ClipReplayPlane::from_text_wrap(img.text_wrap),
+            ));
         }
         for child in &node.children {
             Self::collect_image_nodes(child, out);
@@ -1812,6 +1866,44 @@ mod tests {
         let body = &tree.root.children[0];
         let lower = &body.children[0];
         assert!((image_bbox(lower).height - 219.58).abs() < 0.01);
+    }
+
+    /// Task #M100: BehindText 와 Flow 처럼 서로 다른 재생 plane 에 걸친 페어는
+    /// clip 대상에서 제외해야 한다. `src/paint/replay_order.rs` 의 plane 분리
+    /// 재생 규약상 BehindText 는 트리 순서와 무관하게 Flow 보다 먼저(더 아래)
+    /// 그려지므로, 트리 순서만 보고 clip 방향을 정하면 실제로는 위에 그려질
+    /// Flow 그림이 잘못 잘릴 수 있다.
+    #[test]
+    fn test_clip_skips_cross_plane_pairs() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        // 트리 순서상 먼저 (Flow, y=100~300)
+        let mut flow = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            9,
+            Some((0, 0, 1000, 2000)),
+        );
+        if let RenderNodeType::Image(ref mut img) = flow.node_type {
+            img.text_wrap = Some(TextWrap::Square);
+        }
+        // 트리 순서상 나중 (BehindText, y=150~350) — 실제 재생 순서는 Flow 보다 먼저(더 아래)
+        let mut behind = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(100.0, 150.0, 200.0, 200.0),
+            9,
+            Some((0, 0, 1000, 2000)),
+        );
+        if let RenderNodeType::Image(ref mut img) = behind.node_type {
+            img.text_wrap = Some(TextWrap::BehindText);
+        }
+        tree.root.children.push(flow);
+        tree.root.children.push(behind);
+
+        tree.clip_overlapping_same_bin_images();
+
+        // 두 그림 모두 원래 크기 유지 — plane 이 다르므로 clip 미적용
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 200.0);
     }
 
     /// 단일 이미지만 있는 경우 변경 없음 (no-op).


### PR DESCRIPTION
## 요약

closes #2895

`PageRenderTree::clip_overlapping_same_bin_images` (Task #1154 도입)는 동일 `bin_data_id`
이미지 페어의 clip 방향을 "RenderTree 순회(children) 순서 = 실제 페인트 순서"로 가정했다.
그러나 `src/paint/replay_order.rs` 가 정의하는 실제 재생 순서는
`Background → BehindText → Flow → InFrontOfText` plane 단위로 재편성되므로, `text_wrap`
이 다른 두 이미지가 겹치면 트리 순서만으로 clip 방향을 판단할 수 없다. 트리 순서상 먼저
오는 Flow 이미지가 나중에 오는 BehindText 이미지와 겹칠 때, 실제로는 BehindText 가 더
아래에 그려지는데도 기존 코드는 Flow 쪽을 아래로 오판해 역방향으로 clip 했다.

## 수정

- `src/renderer/render_tree.rs`
  - `ClipReplayPlane` (BehindText/Flow/InFrontOfText) 추가.
  - `collect_image_nodes` 가 각 이미지의 plane 을 함께 수집.
  - `clip_overlapping_same_bin_images` 페어 검출 루프에 `plane_a != plane_b` 가드 추가 —
    plane 이 다른 페어는 clip 미적용(보수적 최소 수정).

## Red → Green

`test_clip_skips_cross_plane_pairs` 추가 (`src/renderer/render_tree.rs`).

- Red (가드 임시 비활성화): `assertion left == right failed / left: 50.0 / right: 200.0`
- Green (가드 적용): 두 이미지 모두 height 200.0 유지, clip 관련 테스트 11개 전부 통과.

## 검증

- `cargo build --lib`: 성공
- `cargo test --lib render_tree::tests::test_clip`: 11 passed
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
- `rustfmt --edition 2021 src/renderer/render_tree.rs`: 적용(개행 스타일 외 diff 없음)

## 처리 결과 문서

`mydocs/report/task_m100_2895_report.md`