### PR TITLE
각주/미주 삽입 시 같은 문단 뒤쪽 표/글상자 각주 오산 수정

### DIFF
--- a/mydocs/report/task_m100_2902_report.md
+++ b/mydocs/report/task_m100_2902_report.md
@@ -1,0 +1,58 @@
+# Task #2902 처리 결과 — 각주/미주 삽입 시 문단 내 표/글상자 위치 미검증 결함 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2902
+
+## 문제
+
+`src/document_core/commands/object_ops/note.rs`의 `insert_footnote_native` /
+`insert_endnote_native`가 신규 각주·미주 번호를 계산할 때, 같은 문단(`is_same`)
+안의 `Control::Table` / `Control::Shape` 분기는 그 컨트롤 자신이 커서(`char_offset`)
+보다 앞인지 뒤인지 확인하지 않고 무조건 안의 각주/미주를 선행으로 카운트했다.
+바로 위 `Control::Footnote`/`Control::Endnote` 단독 분기는 `find_control_text_positions`
+로 실제 위치를 구해 비교하는데, 표/글상자 분기만 이 검사가 빠져 있었다.
+
+영향: 문단 뒷부분에 각주/미주 포함 표·글상자가 있고 그보다 앞에서 새 각주/미주를
+삽입하면 번호가 부풀려진다. 삽입 직후 전체 재넘버링 루프는 본문 참조 마커
+(`Footnote.number`/`Endnote.number`)는 바로잡지만, 각주/미주 내용 문단 맨 앞의
+`AutoNumber` 표시 번호는 생성 시점 값을 그대로 쓰므로 본문 참조 번호와 내용 패널
+표시 번호가 어긋나는 사용자 가시적 결함으로 이어진다.
+
+## 수정
+
+`Control::Table` / `Control::Shape` 가드에 `is_same` 조건일 때 `positions.get(ci) <=
+char_offset` 위치 비교를 추가. `insert_footnote_native`, `insert_endnote_native` 양쪽
+모두 동일하게 적용.
+
+## 테스트 (red → green)
+
+`char_shape_inherit_tests` 모듈에 회귀 테스트 추가:
+`insert_footnote_ignores_table_footnote_positioned_after_cursor_in_same_paragraph`
+
+- 시나리오: 문단 텍스트 "AB" 뒤에 표(셀 안 기존 각주 1개 포함)를 sibling control로
+  배치. 문단 맨 앞(`char_offset=0`, 표보다 앞)에서 신규 각주 삽입.
+- 기대: `footnoteNumber == 1`.
+- 수정 전 코드로 되돌려 확인: `assertion left == right failed ... left: 2, right: 1`
+  (RED 확인 완료).
+- 수정 후: PASS (GREEN).
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib object_ops::note`: 4 passed (신규 테스트 포함)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과
+  (`Box::new(Footnote::default())` → `Box::<Footnote>::default()` clippy 지적 반영)
+- `rustfmt --edition 2021 src/document_core/commands/object_ops/note.rs`: 적용
+
+## 변경 파일
+
+- `src/document_core/commands/object_ops/note.rs`
+
+## 범위
+
+작업 지시에 따라 `src/document_core/commands/object_ops/{picture.rs,note.rs}`만
+검토·수정했다. `picture.rs`는 리뷰 결과 캐시 무효화(`invalidate_page_tree_cache`)
+호출 누락처럼 보이는 지점들을 확인했으나, 모두 `recompose_section`/`paginate_pass`
+내부에서 이미 캐시를 무효화하므로 실질적 결함이 아니었다 (관련 함수:
+`document_core/queries/rendering.rs`의 `recompose_section`, `paginate_pass`).

--- a/src/document_core/commands/object_ops/note.rs
+++ b/src/document_core/commands/object_ops/note.rs
@@ -326,7 +326,23 @@ impl DocumentCore {
                             }
                         }
                         // 표 셀 내 각주
-                        Control::Table(table) if is_before || is_same => {
+                        // [Task #825 후속] is_same(커서와 같은 문단)일 때, 이 Table
+                        // 컨트롤 자체가 커서보다 뒤(char_offset 이후)에 있으면 그
+                        // 안의 각주는 아직 삽입 시점 기준으로 "이전" 각주가 아니다.
+                        // 기존 코드는 위치를 확인하지 않고 무조건 카운트해
+                        // 본문에 텍스트 - 표(각주 포함) - 커서 순서가 아니라
+                        // 커서 - 텍스트 - 표(각주 포함) 순서일 때도 표 각주를
+                        // 선행으로 오산해 신규 각주 번호가 부풀려졌다.
+                        Control::Table(table)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             for cell in &table.cells {
                                 for cp in &cell.paragraphs {
                                     count +=
@@ -337,8 +353,17 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        // 글상자 내 각주
-                        Control::Shape(shape) if is_before || is_same => {
+                        // 글상자 내 각주 (표와 동일한 위치 검사)
+                        Control::Shape(shape)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             if let Some(text_box) =
                                 shape.drawing().and_then(|d| d.text_box.as_ref())
                             {
@@ -640,7 +665,18 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        Control::Table(table) if is_before || is_same => {
+                        // [Task #825 후속] 각주와 동일한 결함 — is_same 일 때 Table 위치가
+                        // char_offset 보다 뒤면 그 안의 미주는 아직 선행이 아니다.
+                        Control::Table(table)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             for cell in &table.cells {
                                 for cp in &cell.paragraphs {
                                     count +=
@@ -651,7 +687,16 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        Control::Shape(shape) if is_before || is_same => {
+                        Control::Shape(shape)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             if let Some(text_box) =
                                 shape.drawing().and_then(|d| d.text_box.as_ref())
                             {
@@ -782,7 +827,7 @@ impl DocumentCore {
 mod char_shape_inherit_tests {
     use crate::document_core::DocumentCore;
     use crate::model::control::Control;
-    use crate::model::paragraph::CharShapeRef;
+    use crate::model::paragraph::{CharShapeRef, Paragraph};
 
     /// 혼합 글자모양 문단: 텍스트 20자, 글자 인덱스 0~9 는 34, 10~ 는 37.
     fn core_with_mixed_shape_paragraph() -> DocumentCore {
@@ -826,6 +871,58 @@ mod char_shape_inherit_tests {
             inner.char_shapes.first().map(|cs| cs.char_shape_id),
             Some(37),
             "각주 내부 문단이 커서 offset 글자모양(37)이 아닌 값을 상속"
+        );
+    }
+
+    /// [Task #825 후속] 같은 문단 안, 커서보다 "뒤"(char_offset 이후)에 있는 표
+    /// 안 각주는 신규 각주 번호 계산에서 선행 각주로 세면 안 된다.
+    ///
+    /// 문단 구성: 텍스트 "AB"(char_offset 0~2) 뒤에 표(각주 1개 포함)를 삽입한다.
+    /// 그 상태에서 문단 맨 앞(char_offset=0), 즉 표보다 앞에 신규 각주를 삽입하면
+    /// 표 각주는 아직 "이전" 각주가 아니므로 신규 각주 번호는 1이어야 한다.
+    /// 버그가 있으면 같은 문단(is_same)이라는 이유만으로 표 각주를 무조건 세어
+    /// 번호가 2로 부풀려진다.
+    #[test]
+    fn insert_footnote_ignores_table_footnote_positioned_after_cursor_in_same_paragraph() {
+        use crate::model::footnote::Footnote;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "AB").unwrap();
+
+        // 표(각주 1개 포함 셀)를 "AB" 텍스트 뒤 sibling control 로 직접 배치한다
+        // (create_table_native 는 문단 끝 삽입 시 별도 문단으로 분리하므로, 같은
+        // 문단 안 텍스트-뒤 컨트롤 배치를 재현하려면 IR 을 직접 구성해야 한다).
+        let mut cell = Cell::default();
+        cell.paragraphs.push(Paragraph::default());
+        cell.paragraphs[0]
+            .controls
+            .push(Control::Footnote(Box::<Footnote>::default()));
+        let mut table = Table::default();
+        table.cells.push(cell);
+
+        let para = &mut core.document.sections[0].paragraphs[0];
+        para.controls.push(Control::Table(Box::new(table)));
+        para.ctrl_data_records.push(None);
+        // "AB"(2) 뒤에 표(8 코드유닛) 갭을 표현하는 char_offsets 항목 추가.
+        para.char_offsets.push(2);
+        para.char_count += 8;
+
+        // 문단 맨 앞(표보다 앞)에 신규 각주 삽입.
+        let result = core
+            .insert_footnote_native(0, 0, 0)
+            .expect("insert footnote before table");
+        let footnote_number: u16 = result
+            .split("\"footnoteNumber\":")
+            .nth(1)
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("missing footnoteNumber in {result}"));
+
+        assert_eq!(
+            footnote_number, 1,
+            "표 안 각주가 커서보다 뒤에 있으므로 신규 각주는 1번이어야 한다: {result}"
         );
     }
 


### PR DESCRIPTION
## 요약

이슈 #2902 — `insert_footnote_native`/`insert_endnote_native`가 신규 각주/미주
번호를 계산할 때, 같은 문단(`is_same`) 안의 `Control::Table`/`Control::Shape`
분기가 컨트롤 자신의 위치(커서보다 앞/뒤)를 확인하지 않고 무조건 안의 각주/미주를
선행으로 카운트하던 결함을 수정합니다. 바로 위 `Control::Footnote`/`Control::Endnote`
단독 분기는 `find_control_text_positions`로 위치를 비교하는데, 표/글상자 분기만
이 검사가 빠져 있었습니다.

## RED → GREEN

`src/document_core/commands/object_ops/note.rs`의 `char_shape_inherit_tests`에
`insert_footnote_ignores_table_footnote_positioned_after_cursor_in_same_paragraph`
추가.

- 시나리오: 문단 텍스트 "AB" 뒤에 표(셀 안 기존 각주 1개 포함)를 sibling control로
  배치. 문단 맨 앞(`char_offset=0`, 표보다 앞)에서 신규 각주 삽입.
- RED (수정 전): `assertion left == right failed ... left: 2, right: 1`
- GREEN (수정 후): PASS

## 검증

- `cargo build --lib`: 성공
- `cargo test --lib object_ops::note`: 4 passed
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과
- `rustfmt --edition 2021`: 적용

## 범위

`src/document_core/commands/object_ops/note.rs`만 수정 (Footnote/Endnote 양쪽에
동일 위치 검사 적용). 처리 결과 문서: `mydocs/report/task_m100_2902_report.md`.