### PR TITLE
[undo] 표 이동 undo가 moveTableOffset 반환값을 버리고 stale ppi/ci를 반환 (#2903)

### DIFF
--- a/mydocs/report/task_m100_2903_report.md
+++ b/mydocs/report/task_m100_2903_report.md
@@ -1,0 +1,102 @@
+# Task #2903 — MoveTableCommand undo가 moveTableOffset 반환값을 버리는 결함 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2903
+
+## 버그 요약
+
+`rhwp-studio/src/engine/command.ts` 의 `MoveTableCommand`(표 이동 Undo/Redo 명령)에서
+`execute()` 와 `undo()` 가 동일한 WASM API(`moveTableOffset`)를 호출하면서도 그 반환값을
+다루는 방식이 비대칭이었다.
+
+- `execute()`: `wasm.moveTableOffset(...)` 의 반환값 `{ ppi, ci }` 를 `this.resultPpi`/
+  `this.resultCi` 에 캡처해 저장하고, 반환하는 `DocumentPosition` 도 이 값을 사용한다 —
+  표는 문단에 걸쳐 있는 anchor 객체라 오프셋 이동으로 귀속 문단(ppi)이 바뀔 수 있고,
+  WASM 이 알려준 값을 신뢰해야 한다는 전제가 이미 코드에 반영돼 있다.
+- `undo()`: 정확히 대칭인 역이동(`-deltaH, -deltaV`)을 호출하지만 그 **반환값을 완전히
+  버리고**, 커맨드 생성 시점에 캡처해 둔 stale `this.ppi`/`this.ci` 를 그대로 반환했다.
+
+표 이동과 문단 구조 변경(삽입/삭제/병합 등으로 문단 인덱스가 shift)이 같은 히스토리
+세션에서 섞이면, undo 후 반환되는 `DocumentPosition` 이 실제로 표가 재배치된 문단이
+아니라 stale 문단을 가리켜 커서/선택 복원이 잘못될 수 있었다.
+
+## 수정
+
+`undo()` 도 `execute()` 와 대칭으로 `wasm.moveTableOffset(...)` 의 반환값을 캡처해
+`this.ppi`/`this.ci` 를 갱신하고, 반환 `DocumentPosition` 도 그 갱신된 값을 사용하도록
+수정했다.
+
+```ts
+undo(wasm: WasmBridge): DocumentPosition {
+  const result = wasm.moveTableOffset(this.sec, this.resultPpi, this.resultCi, -this.deltaH, -this.deltaV);
+  this.ppi = result.ppi;
+  this.ci = result.ci;
+  return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
+}
+```
+
+- 파일: `rhwp-studio/src/engine/command.ts` (`MoveTableCommand.undo`)
+- `.rs` 변경 없음, TypeScript 전용 수정.
+
+## 테스트
+
+신규 파일: `rhwp-studio/tests/undo-move-table-ppi.test.ts`
+
+기존 `undo-delete-char-count.test.ts` 와 동일한 스타일의 소스 가드 테스트로, `command.ts`
+소스에서 `MoveTableCommand.undo()` 블록을 추출해:
+
+1. `undo()` 가 `moveTableOffset` 반환값을 변수(`result`)로 캡처하는지
+2. 그 값으로 `this.ppi`/`this.ci` 를 갱신하는지
+3. 반환 `DocumentPosition` 이 갱신된 `this.ppi` 를 쓰는지
+
+를 검증한다. 회귀 가드로 `execute()` 가 여전히 `resultPpi`/`resultCi` 를 갱신하는지도
+함께 확인한다.
+
+### Red (수정 전)
+
+```
+git stash push -- src/engine/command.ts 후 실행:
+
+✖ MoveTableCommand.undo 는 moveTableOffset 반환값을 캡처해 this.ppi/this.ci 를 갱신한다 (1.4737ms)
+  AssertionError: undo() 가 moveTableOffset 반환값을 변수로 캡처해야 함(execute() 와 대칭)
+tests 2, pass 1, fail 1
+```
+
+### Green (수정 후)
+
+```
+✔ MoveTableCommand.undo 는 moveTableOffset 반환값을 캡처해 this.ppi/this.ci 를 갱신한다 (1.2706ms)
+✔ MoveTableCommand.execute 도 여전히 moveTableOffset 반환값으로 resultPpi/resultCi 를 갱신한다 (회귀 가드) (0.2953ms)
+tests 2, pass 2, fail 0
+```
+
+### 전체 테스트 (`node --test tests/*.test.ts`)
+
+수정 후 전체 실행 결과 — 총 477개 중 476개 통과, `cell-flow-boundary.test.ts` 1건만 실패
+(작업 지침에 따라 이 파일만 실패가 허용됨, 본 변경과 무관한 기존 결함).
+
+```
+ℹ tests 477
+ℹ pass 476
+ℹ fail 1  (cell-flow-boundary.test.ts — 허용된 기존 실패)
+```
+
+### `npx tsc --noEmit`
+
+베이스라인과 동일하게 정확히 2건의 기존 TS2307 오류만 존재(`@wasm/rhwp.js` 모듈 타입
+선언 누락 — WASM 빌드 산출물 미생성으로 인한 환경적 오류, 본 변경 이전부터 존재).
+본 변경으로 추가된 신규 오류 없음.
+
+```
+src/core/wasm-bridge.ts(1,44): error TS2307: Cannot find module '@wasm/rhwp.js' or its corresponding type declarations.
+src/hwpctl/index.ts(417,57): error TS2307: Cannot find module '@wasm/rhwp.js' or its corresponding type declarations.
+```
+
+## 참고: 환경 비고
+
+이 워크트리(`rhwp-wt-cc`)에는 `node_modules` 가 설치돼 있지 않아 `npx tsc` 및 일부
+third-party 의존성을 import 하는 테스트(`canvaskit-resource-key.test.ts` 등)가 실행 전
+단계에서 실패했다. 검증을 위해 `npm install` 을 실행해 로컬 devDependencies 를 설치한
+뒤 위 결과를 얻었다(문서화된 `dev_environment_guide.md` 표준 절차, 프로젝트 코드 변경
+아님).

--- a/rhwp-studio/src/engine/command.ts
+++ b/rhwp-studio/src/engine/command.ts
@@ -1301,7 +1301,14 @@ export class MoveTableCommand implements EditCommand {
   }
 
   undo(wasm: WasmBridge): DocumentPosition {
-    wasm.moveTableOffset(this.sec, this.resultPpi, this.resultCi, -this.deltaH, -this.deltaV);
+    // [Task #2903] execute() 는 moveTableOffset 반환값(result.ppi/ci)을 권위 소스로 삼아
+    // this.resultPpi/resultCi 를 갱신하는데, undo() 는 동일한 반환값을 버리고 생성 시점의
+    // stale this.ppi/this.ci 를 그대로 반환했다. 표 이동과 문단 구조 변경(삽입/삭제/병합)이
+    // 같은 세션에서 섞이면 undo 후 커서가 존재하지 않거나 엉뚱한 문단을 가리킬 수 있다 —
+    // execute() 와 대칭으로 반환값을 캡처해 this.ppi/this.ci 를 갱신한다.
+    const result = wasm.moveTableOffset(this.sec, this.resultPpi, this.resultCi, -this.deltaH, -this.deltaV);
+    this.ppi = result.ppi;
+    this.ci = result.ci;
     return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
   }
 

--- a/rhwp-studio/tests/undo-move-table-ppi.test.ts
+++ b/rhwp-studio/tests/undo-move-table-ppi.test.ts
@@ -1,0 +1,56 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2903] MoveTableCommand.undo() 는 자신이 호출한 moveTableOffset 의 반환값을
+// 버리고 stale 한 this.ppi/this.ci 를 그대로 반환했다. execute() 는 동일한 반환값을
+// this.resultPpi/resultCi 에 캡처하는데 undo() 만 이를 무시해 표 이동과 문단 구조 변경이
+// 섞인 세션에서 undo 후 커서가 잘못된 문단을 가리킬 수 있었다.
+// 소스 가드: undo() 블록이 moveTableOffset 반환값을 변수로 받아 this.ppi/this.ci 를
+// 갱신하는지 확인한다(회귀 시 다시 return 문에서 미갱신 stale 값을 쓰게 되면 실패).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const commandSrc = readFileSync(join(rootDir, 'src/engine/command.ts'), 'utf8');
+
+function classBlock(src: string, name: string): string {
+  const start = src.indexOf(`export class ${name}`);
+  assert.notEqual(start, -1, `${name} 클래스 not found`);
+  const rel = src.slice(start + 1).indexOf('\nexport class ');
+  return rel === -1 ? src.slice(start) : src.slice(start, start + 1 + rel);
+}
+
+function undoBlock(block: string): string {
+  const uIdx = block.indexOf('undo(wasm: WasmBridge): DocumentPosition {');
+  assert.notEqual(uIdx, -1, 'undo 시그니처 not found');
+  const rel = block.slice(uIdx + 1).indexOf('\n  mergeWith');
+  return rel === -1 ? block.slice(uIdx) : block.slice(uIdx, uIdx + 1 + rel);
+}
+
+test('MoveTableCommand.undo 는 moveTableOffset 반환값을 캡처해 this.ppi/this.ci 를 갱신한다', () => {
+  const undo = undoBlock(classBlock(commandSrc, 'MoveTableCommand'));
+
+  // 반환값을 그냥 버리는 옛 형태(대입 없이 호출만)가 재발하지 않았는지 확인.
+  assert.match(undo, /const result = wasm\.moveTableOffset\(/,
+    'undo() 가 moveTableOffset 반환값을 변수로 캡처해야 함(execute() 와 대칭)');
+  assert.match(undo, /this\.ppi = result\.ppi/,
+    'undo() 가 반환값으로 this.ppi 를 갱신해야 함 — 안 그러면 stale 문단 인덱스 반환');
+  assert.match(undo, /this\.ci = result\.ci/,
+    'undo() 가 반환값으로 this.ci 를 갱신해야 함 — 안 그러면 stale 컨트롤 인덱스 반환');
+
+  // 반환 DocumentPosition 이 갱신된 this.ppi 를 쓰는지(재대입 후 stale 값을 참조하면 안 됨).
+  assert.match(undo, /paragraphIndex:\s*this\.ppi/,
+    'undo() 의 반환 DocumentPosition 은 갱신된 this.ppi 를 사용해야 함');
+});
+
+test('MoveTableCommand.execute 도 여전히 moveTableOffset 반환값으로 resultPpi/resultCi 를 갱신한다 (회귀 가드)', () => {
+  const block = classBlock(commandSrc, 'MoveTableCommand');
+  const eIdx = block.indexOf('execute(wasm: WasmBridge): DocumentPosition {');
+  assert.notEqual(eIdx, -1, 'execute 시그니처 not found');
+  const undoStart = block.indexOf('\n  undo(wasm: WasmBridge)');
+  const execBlock = block.slice(eIdx, undoStart === -1 ? undefined : undoStart);
+
+  assert.match(execBlock, /this\.resultPpi = result\.ppi/);
+  assert.match(execBlock, /this\.resultCi = result\.ci/);
+});


### PR DESCRIPTION
## 요약

- `#2903` — `MoveTableCommand.undo()` 가 `wasm.moveTableOffset(...)` 반환값을 버리고 커맨드 생성 시점의 stale `this.ppi`/`this.ci` 를 반환하던 결함 수정.
- `execute()` 는 반환값 `{ppi, ci}` 를 `this.resultPpi`/`this.resultCi` 에 캡처해 신뢰하는데, `undo()` 만 동일한 역이동 호출의 반환값을 무시했다. 표 이동과 문단 구조 변경(삽입/삭제/병합)이 같은 세션에서 섞이면 undo 후 커서/선택이 stale 문단을 가리킬 수 있었다.
- `.rs` 변경 없음 — TypeScript(`rhwp-studio/src/engine/command.ts`) 전용 수정.

## 근거

```ts
// 수정 전
undo(wasm: WasmBridge): DocumentPosition {
  wasm.moveTableOffset(this.sec, this.resultPpi, this.resultCi, -this.deltaH, -this.deltaV);
  return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 }; // stale this.ppi
}
```

```ts
// 수정 후
undo(wasm: WasmBridge): DocumentPosition {
  const result = wasm.moveTableOffset(this.sec, this.resultPpi, this.resultCi, -this.deltaH, -this.deltaV);
  this.ppi = result.ppi;
  this.ci = result.ci;
  return { sectionIndex: this.sec, paragraphIndex: this.ppi, charOffset: 0 };
}
```

## 테스트 — Red → Green

신규 소스 가드 테스트 `rhwp-studio/tests/undo-move-table-ppi.test.ts` (기존 `undo-delete-char-count.test.ts` 와 동일 스타일).

**수정 전 (red)**
```
✖ MoveTableCommand.undo 는 moveTableOffset 반환값을 캡처해 this.ppi/this.ci 를 갱신한다
  AssertionError: undo() 가 moveTableOffset 반환값을 변수로 캡처해야 함(execute() 와 대칭)
tests 2, pass 1, fail 1
```

**수정 후 (green)**
```
✔ MoveTableCommand.undo 는 moveTableOffset 반환값을 캡처해 this.ppi/this.ci 를 갱신한다
✔ MoveTableCommand.execute 도 여전히 moveTableOffset 반환값으로 resultPpi/resultCi 를 갱신한다 (회귀 가드)
tests 2, pass 2, fail 0
```

**전체 테스트** (`node --test tests/*.test.ts`, node_modules 설치 후)
```
tests 477, pass 476, fail 1 (cell-flow-boundary.test.ts — 작업 지침상 허용된 기존 실패, 본 변경과 무관)
```

**`npx tsc --noEmit`** — 베이스라인과 동일하게 기존 TS2307 오류 2건만 존재(`@wasm/rhwp.js` 모듈 타입 선언 누락, WASM 빌드 미생성으로 인한 환경적 오류), 신규 오류 없음.
```
src/core/wasm-bridge.ts(1,44): error TS2307: Cannot find module '@wasm/rhwp.js' ...
src/hwpctl/index.ts(417,57): error TS2307: Cannot find module '@wasm/rhwp.js' ...
```

## 상세 보고서

`mydocs/report/task_m100_2903_report.md`
