### PR TITLE
[rhwp-studio] 표/셀 속성 다이얼로그 테두리 탭 굵기/색/선종류 select 동기화

### DIFF
--- a/mydocs/report/task_m100_2908_report.md
+++ b/mydocs/report/task_m100_2908_report.md
@@ -1,0 +1,51 @@
+# 완료 보고서 — Task M100-2908
+
+- 이슈: #2908
+- 제목: [rhwp-studio] 표/셀 속성 다이얼로그 테두리 탭: 굵기/색/선종류 select가 문서 값과 동기화되지 않아 방향 버튼 재적용 시 서식 유실
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2908-border-tab-select-sync`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/table-cell-props-dialog.ts`의 표/셀 속성 다이얼로그 "테두리" 탭에서,
+다이얼로그를 열 때 `populateBorderFromTarget()`이 문서의 실제 테두리 값을 `borderEdits`
+배열과 SVG 미리보기에만 반영하고, `굵기`(`borderWidthSelect`)/`색`(`borderColorInput`)/
+`선 종류`(`borderSelectedLineType` + 선 종류 격자 `active` 클래스) 컨트롤은
+`buildBorderTab()`이 만든 하드코딩 기본값(`0.1mm`/`#000000`/실선)에 그대로 머무르는
+결함을 수정했다.
+
+`applyBorderToDirection()`(방향 버튼 클릭 핸들러)은 이 세 컨트롤의 "현재 값"을 그대로
+읽어 `borderEdits`를 덮어쓰고, 그 값이 `onConfirm()`에서 검증 없이
+`wasm.setTableProperties`/`setCellProperties`에 전달된다. 따라서 사용자가 미리보기만
+보고 값을 바꾸지 않은 채 방향 버튼(특히 "모두")을 다시 누르면, 문서에 저장돼 있던
+서식(예: `0.4mm/#FF0000/파선`)이 조용히 `0.1mm/#000000/실선`으로 대체될 수 있었다.
+
+`populateBorderFromTarget()`에서 대표 테두리(왼쪽, `borderEdits[0]`)를 기준으로
+`borderWidthSelect.value`, `borderColorInput.value`, `borderSelectedLineType` 및 선 종류
+격자의 `active` 클래스를 함께 동기화하도록 수정해, 컨트롤이 항상 문서/셀의 현재 테두리
+상태를 정확히 반영하도록 했다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/ui/table-cell-props-dialog.ts`
+  - `populateBorderFromTarget()`: 대표 테두리(왼쪽) 값으로 `borderWidthSelect`,
+    `borderColorInput`, `borderSelectedLineType`, 선 종류 격자 활성 항목을 동기화하는
+    로직 추가.
+- `rhwp-studio/tests/table-cell-props-border-tab-sync.test.ts` (신규)
+  - `populateBorderFromTarget` 본문에 위 3개 컨트롤 동기화 대입문이 존재하는지 정적으로
+    핀하는 소스 가드 테스트 추가.
+
+## 3. 검증 결과
+
+- Red → Green: 수정 전 `table-cell-props-border-tab-sync.test.ts`는
+  `populateBorderFromTarget`에 `this.borderWidthSelect.value = ...` 등 대입문이 없어
+  실패 (assert.match 미스매치), 수정 후 통과.
+- `npm test` (rhwp-studio): 500개 중 499 통과, `cell-flow-boundary.test.ts` 1건만 실패
+  (본 작업과 무관한 기존 baseline 실패로 허용됨).
+- `npx tsc --noEmit` (rhwp-studio): 기존 baseline과 동일하게 `wasm-bridge.ts`,
+  `hwpctl/index.ts`의 `@wasm/rhwp.js` 관련 TS2307 2건만 존재, 신규 타입 오류 없음.
+- `.rs` 파일 변경 없음, `cargo build` 불필요.
+
+## 4. 남은 이슈
+
+없음. TypeScript 전용 변경이며 범위 밖 리팩터링은 하지 않았다.

--- a/rhwp-studio/src/ui/table-cell-props-dialog.ts
+++ b/rhwp-studio/src/ui/table-cell-props-dialog.ts
@@ -1080,6 +1080,20 @@ export class TableCellPropsDialog extends ModalDialog {
         this.borderEdits[i] = { type: b.type, width: b.width, color: b.color };
       }
     }
+    // 굵기/색/선종류 컨트롤을 대표 테두리(왼쪽)로 동기화한다. 이 컨트롤들은
+    // applyBorderToDirection()이 '현재 값'으로 그대로 읽어 wasm.set*Properties에
+    // 전달하므로, 미리보기만 문서 값을 반영하고 컨트롤은 하드코딩 기본값(0.1mm/검정/실선)에
+    // 머무르면 방향 버튼 재적용 시 기존 서식이 조용히 유실된다 (#2908).
+    const rep = this.borderEdits[0];
+    if (rep) {
+      this.borderSelectedLineType = rep.type;
+      this.borderWidthSelect.value = String(rep.width);
+      this.borderColorInput.value = rep.color;
+      this.borderLineTypeGrid.querySelectorAll('.tcp-line-type-item').forEach((el, idx) => {
+        const lineTypeDefs = [0, 1, 2, 3, 4, 5, 6, 8];
+        el.classList.toggle('active', lineTypeDefs[idx] === rep.type);
+      });
+    }
     this.updateBorderPreview();
   }
 

--- a/rhwp-studio/tests/table-cell-props-border-tab-sync.test.ts
+++ b/rhwp-studio/tests/table-cell-props-border-tab-sync.test.ts
@@ -1,0 +1,41 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2908] 표/셀 속성 다이얼로그 "테두리" 탭: 굵기/색/선종류 컨트롤이 문서 값과
+// 동기화되지 않는 결함의 소스 가드.
+//
+// populateBorderFromTarget()은 borderEdits 배열(및 SVG 미리보기)만 문서의 실제 테두리로
+// 갱신하고 borderWidthSelect/borderColorInput/borderSelectedLineType은 buildBorderTab()의
+// 하드코딩 기본값(0.1mm/#000000/실선)에 머무른다. applyBorderToDirection()은 바로 이
+// 컨트롤들의 "현재 값"을 읽어 wasm.set*Properties에 보낼 borderEdits를 덮어쓰므로, 방향
+// 버튼을 다시 누르면 기존 서식이 조용히 유실된다. 회귀 방지를 위해 populateBorderFromTarget
+// 안에서 세 컨트롤이 대표 테두리 값으로 동기화되는지 정적으로 핀한다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const src = readFileSync(join(rootDir, 'src/ui/table-cell-props-dialog.ts'), 'utf8');
+
+test('populateBorderFromTarget 은 굵기/색/선종류 컨트롤을 문서 테두리 값으로 동기화한다(#2908)', () => {
+  const start = src.indexOf('private populateBorderFromTarget');
+  assert.notEqual(start, -1, 'populateBorderFromTarget 메서드를 찾을 수 없음');
+  const end = src.indexOf('\n  }', start);
+  const body = src.slice(start, end);
+
+  assert.match(
+    body,
+    /this\.borderWidthSelect\.value\s*=/,
+    'populateBorderFromTarget 안에서 borderWidthSelect.value 를 문서 값으로 동기화해야 함',
+  );
+  assert.match(
+    body,
+    /this\.borderColorInput\.value\s*=/,
+    'populateBorderFromTarget 안에서 borderColorInput.value 를 문서 값으로 동기화해야 함',
+  );
+  assert.match(
+    body,
+    /this\.borderSelectedLineType\s*=/,
+    'populateBorderFromTarget 안에서 borderSelectedLineType 을 문서 값으로 동기화해야 함',
+  );
+});


### PR DESCRIPTION
## 요약

- 이슈: #2908
- `table-cell-props-dialog.ts`의 테두리 탭에서 `populateBorderFromTarget()`이 `borderEdits`
  배열과 SVG 미리보기만 문서의 실제 테두리 값으로 갱신하고, `굵기`(`borderWidthSelect`)/
  `색`(`borderColorInput`)/`선 종류`(`borderSelectedLineType`) 컨트롤은 `buildBorderTab()`의
  하드코딩 기본값(`0.1mm`/`#000000`/실선)에 머무르는 결함을 수정.
- `applyBorderToDirection()`(방향 버튼 클릭)이 바로 이 컨트롤들의 "현재 값"을 그대로 읽어
  `borderEdits`를 덮어쓰고, 검증 없이 `wasm.setTableProperties`/`setCellProperties`에
  전달되므로, 다이얼로그를 열고 값을 바꾸지 않은 채 방향 버튼("모두" 포함)만 다시 눌러도
  기존 서식이 조용히 유실될 수 있었다.
- `populateBorderFromTarget()`에서 대표 테두리(왼쪽)를 기준으로 세 컨트롤을 동기화하도록
  수정.

## Red → Green

- Red: 신규 소스 가드 테스트 `tests/table-cell-props-border-tab-sync.test.ts`가 수정 전
  코드에서는 `populateBorderFromTarget` 본문에 `this.borderWidthSelect.value = ...` 등
  대입문이 없어 실패.
- Green: 수정 후 통과.

## 검증

- [x] `npm test` (rhwp-studio) — 500개 중 499 통과, `cell-flow-boundary.test.ts` 1건만
      실패(본 변경과 무관한 기존 baseline 실패).
- [x] `npx tsc --noEmit` (rhwp-studio) — baseline과 동일하게 `@wasm/rhwp.js` 관련
      TS2307 2건만 존재, 신규 오류 없음.
- `.rs` 파일 변경 없음, `cargo build` 불필요.

## 범위

`rhwp-studio/src/ui/table-cell-props-dialog.ts`와 신규 테스트 파일, 완료 보고서만
변경했다. 숫자 입력 clamp(#2845/#2847)와는 다른 버그 클래스(select/color 컨트롤이
문서 상태와 동기화되지 않는 문제)이며, 다른 다이얼로그 작업(#2838/#2842, #2845/#2847,
#2851/#2854, #2862/#2865, #2866/#2870, #2878/#2883, #2892/#2899)과 겹치지 않는다.