### PR TITLE
HWPX 같은 문단 내 짝 fieldEnd(하이퍼링크 등)의 fieldid 속성 라운드트립 소실 수정 (#2909)

### DIFF
--- a/mydocs/report/task_m100_2909_report.md
+++ b/mydocs/report/task_m100_2909_report.md
@@ -1,0 +1,62 @@
+# task_m100_2909 처리 결과 보고
+
+## 이슈
+
+#2909 — HWPX 같은 문단 내 짝(matched) `fieldEnd`(HYPERLINK 등)의 `fieldid` 속성이 직렬화 시
+항상 소실됨
+
+## 원인
+
+`<hp:fieldBegin>`/`<hp:fieldEnd>` 필드가 같은 문단 안에서 짝을 이룰 때, 파서
+(`src/parser/hwpx/section.rs` `parse_paragraph()`)는 `fieldEnd` 자신의 `fieldid` 속성값을
+`parse_field_end_attrs()` 로 이미 읽어오지만, `field_stack.pop()`이 `Some`인(=같은 문단 매칭)
+분기에서는 그 값을 어디에도 저장하지 않고 버렸다. `FieldRange`(`src/model/paragraph.rs`)에는
+애초에 이 값을 담을 필드가 없었다.
+
+직렬화기(`src/serializer/hwpx/section.rs` `emit_field_end()`)는 `write_field_end(w, f.field_id)`
+만 호출해 `beginIDRef` 속성만 쓰고 `fieldid` 는 전혀 방출하지 않았다. 반면 문단 경계를 넘는
+"고아(orphan) fieldEnd" 경로(`emit_orphan_field_end()`)는 `write_field_end_full()` 로 이미
+`fieldid` 까지 보존하고 있어(#1556), 같은 성격의 값을 다루는 두 경로가 비대칭적이었다.
+`<hp:pic lock>`(#2875), `<hp:tbl lock>`(#2855), `hp:equation lock`(#2840) 등에서 반복 확인된
+"파싱은 되지만 직렬화 시 하드코딩/누락"류 결함과 동일 클래스다.
+
+## 수정
+
+1. `src/model/paragraph.rs`: `FieldRange`에 `pub end_field_id: u32` 필드 추가(짝 `fieldEnd`
+   자신의 `fieldid`, 0이면 없음/생략). `split_at`/`merge_from` 등 기존 `FieldRange` 복제 지점
+   에서 값을 그대로 전파하도록 수정.
+2. `src/parser/hwpx/section.rs`: `parse_paragraph()`의 매칭(같은 문단) `field_ranges.push()`에
+   `end_field_id: field_id`(파싱된 `fieldEnd` 자신의 `fieldid`) 반영.
+3. `src/serializer/hwpx/section.rs`: `emit_field_end()` 시그니처를 `control_idx: usize` 대신
+   `fr: &FieldRange` 를 받도록 변경. `fr.end_field_id == 0`이면 종전대로 `write_field_end`,
+   아니면 `write_field_end_full(f.field_id, fr.end_field_id)`로 `fieldid` 를 되돌려 쓰도록 하여
+   고아 경로와 대칭을 맞춤. 8개 호출부(`fr.control_idx` → `fr`)도 함께 수정.
+4. 나머지 파일(`document_core/commands/document.rs`, `document_core/queries/field_query.rs`,
+   `model/paragraph/tests.rs`, `parser/body_text.rs`, `serializer/body_text.rs`,
+   `serializer/hwpx/mod.rs`)은 `FieldRange` 구조체 리터럴 생성부에 신규 필드를 반영하기 위한
+   컴파일 정합성 수정(대부분 `..Default::default()` 또는 기존 `fr.end_field_id` 전파, HWP5
+   경로는 개념이 없어 `0`).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/section.rs::tests::bookmark_hyperlink_matched_field_end_preserves_own_fieldid`
+신규 추가: `fieldBegin id=42`, 짝 `fieldEnd fieldid=100`(서로 다른 값)인 HYPERLINK 필드를
+직렬화해 `<hp:fieldEnd beginIDRef="42" fieldid="100"/>` 가 나오는지 단언.
+
+- Red: `emit_field_end()`를 임시로 종전 로직(`write_field_end(f.field_id)`만 호출)으로 되돌려
+  실행 → 실패 확인(`fieldid` 누락된 XML로 assert 실패, 실제 출력 캡처함).
+- Green: 수정 로직 복원 후 재실행 → 통과.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib`: 2511 passed, 0 failed (전체 lib 유닛 테스트), 관련 테스트
+  `bookmark_hyperlink_matched_field_end_preserves_own_fieldid`: 1 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021`(변경 파일만): 적용, 기능적 diff 없음(CRLF 노이즈 파일은 원상 복구)
+
+## 관련
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2909
+- 전례: #1556(고아 fieldEnd fieldid 보존), #2875(hp:pic lock), #2855(hp:tbl lock),
+  #2840(hp:equation lock)

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1870,11 +1870,13 @@ mod validate_linesegs_tests {
                     start_char_idx: 0,
                     end_char_idx: 6,
                     control_idx: 0,
+                    ..Default::default()
                 },
                 FieldRange {
                     start_char_idx: 0,
                     end_char_idx: 6,
                     control_idx: 0,
+                    ..Default::default()
                 },
             ],
             ..Default::default()

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1280,6 +1280,7 @@ fn insert_click_here_field_in_para(
         start_char_idx: start,
         end_char_idx: start,
         control_idx: insert_idx,
+        ..Default::default()
     };
     let range_idx = para
         .field_ranges
@@ -1491,6 +1492,7 @@ mod tests {
                 start_char_idx: 3,
                 end_char_idx: 5,
                 control_idx: 1,
+                ..Default::default()
             }],
             char_offsets: vec![8, 9, 10, 19, 20],
             ..Default::default()
@@ -1512,6 +1514,7 @@ mod tests {
                 start_char_idx: 0,
                 end_char_idx: 2,
                 control_idx: 0,
+                ..Default::default()
             }],
             char_offsets: vec![8, 9],
             ..Default::default()
@@ -1535,6 +1538,7 @@ mod tests {
                 start_char_idx: 4,
                 end_char_idx: 7,
                 control_idx: 1,
+                ..Default::default()
             }],
             // 원본 offsets (stale after text change, but char_offsets[0] still valid for ctrls_before_text)
             char_offsets: vec![8, 9, 10, 11, 20, 21, 22],

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -274,6 +274,13 @@ pub struct FieldRange {
     pub end_char_idx: usize,
     /// controls[] 배열 내 인덱스 (해당 Field 컨트롤 참조)
     pub control_idx: usize,
+    /// 같은 문단 내 짝을 이루는 `<hp:fieldEnd>` 자신의 `fieldid` 속성값 (0 이면 없음/생략).
+    ///
+    /// `fieldBegin` 의 `id`(문서 내 고유 ID, `Field::field_id` 로 보존)와 달리, `fieldEnd`
+    /// 자신의 `fieldid` 는 별개 값으로 관찰되며(HYPERLINK 등) IR 로 옮기지 않으면 직렬화 시
+    /// 항상 소실된다. 고아(다단락) fieldEnd 는 `OrphanFieldEnd::field_id` 로 이미 보존하므로,
+    /// 같은 문단 내 짝(matched) 경로에도 대칭적으로 보존한다.
+    pub end_field_id: u32,
 }
 
 /// 고아 FIELD_END (0x04) — 짝이 되는 FIELD_BEGIN 이 다른 문단에 있는
@@ -851,6 +858,7 @@ impl Paragraph {
         self.range_tags = kept_range_tags;
 
         // 5-1. field_ranges 분할 (필드 control은 원래 문단에 유지)
+        // retain 은 기존 FieldRange 를 그대로 필터링하므로 end_field_id 등 필드도 보존된다.
         self.field_ranges.retain(|fr| fr.end_char_idx <= split_pos);
 
         // 5-2. controls 분할
@@ -1024,6 +1032,7 @@ impl Paragraph {
                 start_char_idx: fr.start_char_idx + self_text_len,
                 end_char_idx: fr.end_char_idx + self_text_len,
                 control_idx: fr.control_idx + ctrl_offset,
+                end_field_id: fr.end_field_id,
             });
         }
 

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -783,6 +783,7 @@ fn test_merge_from_field_ranges_ctrl_offset() {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         }],
         has_para_text: true,
         ..Default::default()

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -322,6 +322,7 @@ fn parse_para_text(data: &[u8]) -> (String, Vec<u32>, Vec<FieldRange>, Vec<[u16;
                         start_char_idx: start_idx,
                         end_char_idx: char_count,
                         control_idx: field_ctrl_idx,
+                        end_field_id: 0,
                     });
                 }
             } else if is_extended_only_ctrl_char(ch) {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -629,6 +629,7 @@ fn parse_paragraph(
                         start_char_idx,
                         end_char_idx: visible_char_idx,
                         control_idx,
+                        end_field_id: field_id,
                     });
                 } else {
                     // [Task #1556] 짝 fieldBegin 이 다른 문단에 있는 다단락 필드의 종료 마커.

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -1214,6 +1214,7 @@ mod tests {
                 start_char_idx: 0,
                 end_char_idx: 1,
                 control_idx: 0,
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -1260,11 +1261,13 @@ mod tests {
                     start_char_idx: 0,
                     end_char_idx: 2,
                     control_idx: 0,
+                    ..Default::default()
                 },
                 crate::model::paragraph::FieldRange {
                     start_char_idx: 3,
                     end_char_idx: 5,
                     control_idx: 1,
+                    ..Default::default()
                 },
             ],
             ..Default::default()

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -939,6 +939,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 2,
+            ..Default::default()
         }];
         section.paragraphs.push(p);
         doc.sections.push(section);

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -29,7 +29,7 @@ use crate::model::document::{Document, Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
 use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType};
-use crate::model::paragraph::{ColumnBreakType, LineSeg, OrphanFieldEnd, Paragraph};
+use crate::model::paragraph::{ColumnBreakType, FieldRange, LineSeg, OrphanFieldEnd, Paragraph};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, TextWrap, VertAlign, VertRelTo,
 };
@@ -494,9 +494,18 @@ impl RunSplitter {
 }
 
 /// `<hp:ctrl><hp:fieldEnd beginIDRef=".."/></hp:ctrl>` 방출 공통 경로.
-fn emit_field_end(out: &mut String, para: &Paragraph, control_idx: usize) {
-    if let Some(Control::Field(f)) = para.controls.get(control_idx) {
-        if let Ok(xml) = writer_to_string(|w| write_field_end(w, f.field_id)) {
+fn emit_field_end(out: &mut String, para: &Paragraph, fr: &FieldRange) {
+    if let Some(Control::Field(f)) = para.controls.get(fr.control_idx) {
+        // [Task #bookmark-hyperlink] 짝(matched) fieldEnd 자신의 fieldid 는 fieldBegin 의
+        // id(f.field_id, beginIDRef 로 사용)와 별개 값 — 파싱된 fr.end_field_id 를 그대로
+        // 되돌려 써야 한다. 과거엔 write_field_end 로 beginIDRef 만 쓰고 fieldid 는 항상
+        // 누락시켰다(고아 fieldEnd 경로만 write_field_end_full 로 보존, 비대칭).
+        let xml_result = if fr.end_field_id == 0 {
+            writer_to_string(|w| write_field_end(w, f.field_id))
+        } else {
+            writer_to_string(|w| write_field_end_full(w, f.field_id, fr.end_field_id))
+        };
+        if let Ok(xml) = xml_result {
             out.push_str("<hp:ctrl>");
             out.push_str(&xml);
             out.push_str("</hp:ctrl>");
@@ -704,7 +713,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         // fieldBegin(슬롯)만 방출하고 fieldEnd 방출 코드가 없어 same-para 균형 필드가
         // 1/0 으로 깨지며 cc −8 (#1593). #1556 고아 복원과 동형(위치 대신 말미 일괄).
         for fr in &para.field_ranges {
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
         }
         // [Task #1556] 위치 추정 불가 경로에서도 고아 fieldEnd 의 8유닛 슬롯은 복원한다
         // (정확한 위치 대신 말미 일괄 — 최소한 char_count 보존).
@@ -748,7 +757,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         for (i, fr) in para.field_ranges.iter().enumerate() {
             if fr.start_char_idx == fr.end_char_idx && !field_end_emitted[i] {
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -829,7 +838,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     && fr.control_idx == emitted_ctrl_idx
                 {
                     splitter.cut_before(expected_utf16_pos);
-                    emit_field_end(&mut splitter.content, para, fr.control_idx);
+                    emit_field_end(&mut splitter.content, para, fr);
                     expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                     field_end_emitted[i] = true;
                 }
@@ -867,7 +876,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &mut tab_idx,
                 );
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 field_end_emitted[i] = true;
             }
         }
@@ -938,7 +947,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &mut tab_idx,
                 );
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 // [#1407] fieldEnd 는 8유닛 슬롯을 소비한다. expected 를 +8 진행하지
                 // 않으면 다음 idx 에서 텍스트-끝 슬롯(newNum 등)이 이 8유닛 갭을
                 // 가로채 텍스트가 +8 밀린다 (143E 문단 0.14: char_offsets[3] 27→35).
@@ -970,7 +979,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 continue;
             }
             splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }
@@ -1012,7 +1021,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 && fr.control_idx == emitted_ctrl_idx
             {
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -1022,7 +1031,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
     for (i, fr) in para.field_ranges.iter().enumerate() {
         if !field_end_emitted[i] {
             splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }
@@ -2929,6 +2938,35 @@ mod tests {
         );
     }
 
+    /// [bookmark-hyperlink] 같은 문단 내 짝(matched) HYPERLINK fieldBegin/fieldEnd 라운드트립 —
+    /// fieldEnd 자신의 fieldid(=100)가 fieldBegin 의 id(=42, beginIDRef 로 사용)와 다를 때,
+    /// 과거엔 emit_field_end 가 write_field_end(f.field_id) 만 호출해 fieldid 속성을 항상
+    /// 누락시켰다(고아 fieldEnd 경로만 보존해 비대칭). fr.end_field_id 를 IR 에 보존하고
+    /// 되돌려 쓰면 fieldid="100" 이 살아남아야 한다.
+    #[test]
+    fn bookmark_hyperlink_matched_field_end_preserves_own_fieldid() {
+        let mut f = Field::default();
+        f.field_type = FieldType::Hyperlink;
+        f.field_id = 42;
+        let mut para = Paragraph::default();
+        para.text = "링크".to_string();
+        para.char_count = 2 + 8 + 8 + 1; // text(2) + FIELD_BEGIN(8) + FIELD_END(8) + para_end(1)
+        para.controls.push(Control::Field(f));
+        para.field_ranges.push(FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 2,
+            control_idx: 0,
+            end_field_id: 100,
+        });
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"<hp:fieldEnd beginIDRef="42" fieldid="100"/>"#),
+            "matched fieldEnd 는 beginIDRef(=fieldBegin id)와 별개로 자신의 fieldid 를 보존해야 함: {xml}"
+        );
+    }
+
     // ---------- #1289: Bookmark / Field dispatcher 연결 ----------
 
     use crate::model::control::{Bookmark, Control, Field, FieldType};
@@ -2975,6 +3013,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3011,6 +3050,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         });
         let (doc, section) = make_doc_with_paragraph(para);
         let mut ctx = SerializeContext::collect_from_document(&doc);
@@ -3039,6 +3079,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 5,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3081,6 +3122,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3, // == text.len() → 루프 후 처리 경로
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3114,6 +3156,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 0, // 0-length
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3161,6 +3204,7 @@ mod tests {
             start_char_idx: 3,
             end_char_idx: 3, // 0-length mid-text
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3210,6 +3254,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 0,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3263,6 +3308,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3, // "ABC" 래핑
             control_idx: 0,
+            ..Default::default()
         });
 
         let xml = runs_of(&para);
@@ -3419,6 +3465,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3,
             control_idx: 0,
+            ..Default::default()
         });
         para.char_shapes = vec![cs(0, 1), cs(19, 2)];
         let xml = runs_of(&para);


### PR DESCRIPTION
## 요약

같은 문단 안에서 짝(matched)을 이루는 `<hp:fieldBegin>`/`<hp:fieldEnd>` 필드(HYPERLINK 등)를
HWPX 로 라운드트립하면, `fieldEnd` 자신의 `fieldid` 속성이 항상 소실되던 문제를 고칩니다.
문단 경계를 넘는 고아(orphan) fieldEnd 경로(#1556)는 이미 `fieldid` 를 보존하고 있어, 두 경로가
비대칭적으로 동작했습니다.

이슈: #2909

## 원인

- 파서(`src/parser/hwpx/section.rs` `parse_paragraph()`)는 `fieldEnd` 의 `fieldid` 속성을 이미
  읽어오지만(`parse_field_end_attrs()`), 같은 문단 내 매칭 분기(`field_stack.pop()` 이 `Some`)
  에서는 이 값을 어디에도 저장하지 않고 버렸습니다.
- 직렬화기(`src/serializer/hwpx/section.rs` `emit_field_end()`)는 `write_field_end(f.field_id)`
  만 호출해 `beginIDRef` 만 쓰고 `fieldid` 는 방출하지 않았습니다.

## 수정

- `FieldRange`(`src/model/paragraph.rs`)에 `end_field_id: u32` 필드 추가.
- 파서가 매칭 경로에서도 `fieldEnd` 자신의 `fieldid` 를 `end_field_id` 로 보존.
- `emit_field_end()` 가 `end_field_id != 0` 이면 `write_field_end_full()` 로 `fieldid` 를 되돌려
  쓰도록 하여 고아 경로와 대칭을 맞춤.
- 나머지 파일은 `FieldRange` 리터럴 생성부 컴파일 정합성 수정(주로 `..Default::default()`).

## red → green

`src/serializer/hwpx/section.rs::tests::bookmark_hyperlink_matched_field_end_preserves_own_fieldid`:
`fieldBegin id=42`, 짝 `fieldEnd fieldid=100`(서로 다른 값)인 HYPERLINK 필드를 직렬화해
`<hp:fieldEnd beginIDRef="42" fieldid="100"/>` 를 단언. 수정 전에는 `fieldid` 가 누락되어 실패
(직접 되돌려 확인), 수정 후 통과.

## 검증

- `cargo build --lib`: 성공
- `cargo test --lib`: 전체 통과(회귀 없음), 신규 테스트 1 passed
- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
- `rustfmt --edition 2021`(변경 파일만)

상세 처리 기록: `mydocs/report/task_m100_2909_report.md`
