### PR TITLE
fix(studio): 툴바 줄 간격 직접입력/증가버튼에 500% 상한 clamp 적용

### DIFF
--- a/mydocs/report/task_m100_2925_report.md
+++ b/mydocs/report/task_m100_2925_report.md
@@ -1,0 +1,52 @@
+# task-m100-2925 처리 결과: 툴바 줄 간격 500% 상한 clamp 누락 수정
+
+## 이슈
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2925
+- 배경: 직전 작업(#2917/#2920)에서 `rhwp-studio/src/ui/toolbar.ts`의 글자 크기 입력에
+  char-shape-dialog.ts와 동일한 1~4096pt clamp를 적용했다. 그 후속으로 toolbar.ts의 다른
+  숫자 입력 경로(줌 배율, 들여쓰기 증감 버튼, 줄 간격 퀵셀렉트 등)를 훑어 같은 유형의
+  clamp 누락이 더 있는지 점검했다.
+
+## 원인
+
+`setupLineSpacingDropdown()` 안에 줄 간격 값을 바꾸는 경로가 세 가지 있다.
+
+1. 셀렉트 `change` 이벤트 (프리셋 값만 선택 가능 — 범위 밖 값 없음, 안전)
+2. 더블클릭 → 직접 입력(텍스트 input) → Enter/blur로 commit
+3. ▲/▼ 증감 버튼 (5%씩 증감)
+
+같은 "줄 간격 늘리기" 동작이 단축키(Alt+Shift+Z)로 실행되는 경로인
+`rhwp-studio/src/command/commands/format.ts`의 `format:line-spacing-increase` 커맨드는
+
+```ts
+const newValue = Math.min(500, current + 10);
+```
+
+로 500%를 상한으로 clamp한다. 그런데 toolbar.ts의 직접 입력 commit(구 189행 부근)과
+▲ 버튼(구 209~210행 부근)에는 이 상한 검사가 전혀 없어, 더블클릭 입력으로 `9999` 같은
+값을 넣거나 ▲ 버튼을 연타하면 500%를 훨씬 초과하는 줄 간격이 그대로 적용됐다.
+▼ 버튼은 `Math.max(5, cur - 5)`로 하한만 존재해 대칭성도 어긋나 있었다.
+
+## 수정 (rhwp-studio/src/ui/toolbar.ts, +/-diff 약 6줄)
+
+- 직접 입력 commit: `parseInt` 결과를 `Math.min(500, num)`으로 clamp한 뒤 `ensureLsOption` /
+  `lsSelect.value` / dispatch에 사용하도록 변경.
+- ▲ 버튼(`btnLsUp`): `next = cur + 5` → `next = Math.min(500, cur + 5)`.
+
+커맨드 레이어(`format:line-spacing-increase`)의 기존 500% 상한과 동일한 값으로 맞췄다.
+
+## 테스트 (Red → Green)
+
+- 신규 소스-가드 테스트: `rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts`
+  - `toolbar.ts` 소스에서 `Math.min(500, num)`, `Math.min(500, cur + 5)` 패턴 존재를 정규식으로 확인.
+  - Red: 수정 전 소스에는 해당 패턴이 없어 실패.
+  - Green: 수정 후 통과.
+- `npm test`: 500개 중 499 pass, 1 fail(`tests/cell-flow-boundary.test.ts` — 기존에도 실패하던
+  무관 테스트, 베이스라인과 동일).
+- `npx tsc --noEmit`: `@wasm/rhwp.js` 관련 TS2307 2건만 남음(기존 베이스라인과 동일, 신규 에러 없음).
+
+## 커밋 / PR
+
+- 브랜치: `task/m100-2925-linespacing-clamp` (origin/devel 기준)
+- 커밋: `fix(studio): 툴바 줄 간격 직접입력/증가버튼에 500% 상한 clamp 적용`

--- a/rhwp-studio/src/ui/toolbar.ts
+++ b/rhwp-studio/src/ui/toolbar.ts
@@ -187,10 +187,12 @@ export class Toolbar {
 
       const commit = () => {
         const num = parseInt(input.value, 10);
+        // format:line-spacing-increase 커맨드(format.ts)와 동일하게 500%로 상한 clamp
         if (num > 0) {
-          this.ensureLsOption(num);
-          this.lsSelect.value = String(num);
-          this.dispatcher.dispatch('format:line-spacing', { value: num });
+          const clamped = Math.min(500, num);
+          this.ensureLsOption(clamped);
+          this.lsSelect.value = String(clamped);
+          this.dispatcher.dispatch('format:line-spacing', { value: clamped });
         }
         input.remove();
         this.lsSelect.style.display = '';
@@ -207,7 +209,7 @@ export class Toolbar {
     this.btnLsUp.addEventListener('mousedown', (e) => {
       e.preventDefault();
       const cur = Number(this.lsSelect.value) || 160;
-      const next = cur + 5;
+      const next = Math.min(500, cur + 5);
       this.ensureLsOption(next);
       this.lsSelect.value = String(next);
       this.dispatcher.dispatch('format:line-spacing', { value: next });

--- a/rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts
+++ b/rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts
@@ -1,0 +1,10 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+
+const toolbar = readFileSync(new URL('../src/ui/toolbar.ts', import.meta.url), 'utf8');
+
+test('툴바 줄 간격 직접입력/증가버튼은 format:line-spacing-increase 커맨드와 동일하게 500%로 clamp한다', () => {
+  assert.match(toolbar, /const clamped = Math\.min\(500, num\);/);
+  assert.match(toolbar, /const next = Math\.min\(500, cur \+ 5\);/);
+});


### PR DESCRIPTION
Fixes #2925

## 요약

format:line-spacing-increase 커맨드(단축키 Alt+Shift+Z, format.ts)는 `Math.min(500, current + 10)`으로 줄 간격을 500%로 clamp하지만, 툴바(toolbar.ts)의 더블클릭 직접입력 commit과 ▲ 증감 버튼에는 이 상한이 없어 9999% 같은 값이 그대로 적용되던 문제를 수정했습니다. (직전 작업 #2917/#2920의 글자 크기 clamp 누락과 동일한 유형의 버그를 toolbar.ts 내 다른 숫자 입력 경로에서 발견)

## 변경

- `rhwp-studio/src/ui/toolbar.ts`: 직접 입력 commit과 ▲ 버튼에 `Math.min(500, ...)` clamp 추가.

## 테스트 (Red → Green)

- 신규: `rhwp-studio/tests/toolbar-line-spacing-clamp.test.ts` — 소스에 500% clamp 패턴이 있는지 검사 (수정 전 실패 → 수정 후 통과)
- `npm test`: 500 중 499 pass, 1 fail(`tests/cell-flow-boundary.test.ts`, 기존에도 실패하던 무관 테스트)
- `npx tsc --noEmit`: `@wasm/rhwp.js` TS2307 2건만 남음(베이스라인과 동일, 신규 에러 없음)

## 처리 결과 문서

`mydocs/report/task_m100_2925_report.md`