### PR TITLE
docs(orders): 2026-07-22 PDF 축 전면 정리 기록 추가

### DIFF
--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -159,6 +159,83 @@
   `retry-exempt-status-codes` 기본값(400,401,403,404,422)이 4xx를 제외하므로 5xx 계열만
   재시도된다. 순수 추가 15줄, 로직 무변경. [PR #2805](https://github.com/edwardkim/rhwp/pull/2805).
 
+## PDF 축 전면 정리 — 사용자 제안 하나에서 시작
+
+사용자 제안 [#2787](https://github.com/edwardkim/rhwp/issues/2787)("pdf 변환 저장기능")에 답하는
+과정에서 PDF 관련 이슈 전반의 방향을 확정했다.
+
+### #2787 — studio/확장 PDF 는 v1.0.0 미지원 (close)
+
+- 등록자는 첫 이슈·PR 0건인 순수 사용자다. "다른이름으로 저장하기에 pdf로하면 실행 열기가
+  안됩니다" 라는 서술로 studio/확장 사용자임을 확인했다. 저장 형식은 `SaveFormat = 'hml' |
+  'hwp' | 'hwpx'` 뿐이라 `.pdf` 로 이름만 바꾸면 내용은 HWP 그대로다.
+- **답변**: `Ctrl+P`(인쇄) → 대상 "PDF로 저장". 엔진·CLI 는 `export-pdf` 로 이미 정식 지원한다.
+- **확장 1.0.0 로드맵에서 PDF 변환 제외 사유 4가지**를 함께 설명했다 — 폰트 라이선스(웹 표시용
+  배포와 PDF 임베드 재배포는 허용 범위가 다르다), 메모리(네이티브 실측으로도 100MB 초과,
+  브라우저 탭 사망 위험), 품질 절충(텍스트를 path 로 바꾸면 검색·선택 상실), 번들 크기(스토어
+  심사·설치 용량). `Ctrl+P` 경로는 이 넷을 **브라우저에 위임**한다.
+
+### #2283 — krilla 마이그레이션 미진행 (close)
+
+- 경위 조사: krilla 는 기여자 제안이 아니었다. #2269(채번 비결정) 대응으로 작업지시자가
+  **업스트림 기여를 지시**했고, planet6897 님이 이행하려다 typst/svg2pdf 가 2026-07-10
+  아카이브된 것을 확인하면서 **아카이브 공지에 적힌 후계 프로젝트**를 사실 보고한 것이다.
+- **결정: 하지 않는다.** krilla 로 옮기려면 API 학습·결정성 재확보(#2269 를 처음부터)·시각
+  무회귀·메모리 재실측을 전부 치러야 하는데, **그 뒤에도 종착지가 krilla 가 아니다.**
+  저장소에는 이미 Skia 기반 direct PDF 백엔드가 있다(`renderer/pdf.rs:889`,
+  `export-pdf --backend direct`, P37/seo-rii). **중간 기착지에 이주 비용을 치르는 셈**이다.
+- 다만 **Skia direct 도 지금은 SVG 를 대체하지 못한다.** 계약 문서가 gradient·pattern·shadow·
+  multi-line/arrow·connector·unbaked image-adjustment 를 만나면 에러를 내고 SVG 로 유도한다고
+  명시한다. 현행 svg2pdf + 벤더 패치를 유지하고, **위 미지원 op 목록이 비는 시점**을 재판단
+  트리거로 둔다.
+
+### #2856 — svg2pdf 를 rhwp 산하 포크로 이관 (신설)
+
+- `[patch.crates-io]` 가 기여자 개인 포크를 가리켜 **의존성 수명이 개인 계정에 묶여 있다.**
+  업스트림이 아카이브된 상태라 이 포크가 사실상 유일한 공급원이고, 삭제되면 빌드가 불능이 된다.
+- 결정화 커밋은 planet6897 님 작업이므로 **이슈로 사전 통지**하고 출처 명시를 약속했다.
+
+### #2864 + #2268 — 폰트 조달 환경 종속 제거 ([PR #2898](https://github.com/edwardkim/rhwp/pull/2898) `1f582cda46`)
+
+- **작업지시자 지적에서 출발**: `/mnt/c/Windows/Fonts` 는 이 PC 에 한정된 경로이며, 백엔드
+  대량 변환 환경에서는 `--font-path` 나 시스템 기본 경로를 쓰는 것이 정상이다.
+- 조사 결과 **4개 파일에 복제**돼 있었다(`renderer/pdf.rs`·`svg.rs`·`skia/image_conv.rs`·
+  `skia/renderer.rs`). `/mnt/c` 는 WSL2 의 9p 파일시스템이라 간헐 지연이 발생하며, 이것이
+  **#2268 간헐 행(누적 4회 관측)의 직접 원인**이었다.
+- `src/renderer/font_paths.rs` 를 신설해 조달 순서를 단일 정의했다 — 호출자 지정 →
+  `RHWP_FONT_PATH`(신규 환경변수) → 시스템 기본 → `ttfs/opensource`(최후 폴백).
+  코드 58줄 제거 / 22줄 추가.
+- **`ttfs/opensource` 는 유지**한다. `.gitignore` 는 `/ttfs/hwp/`·`/ttfs/windows/` 와 특정 ttf
+  2개만 제외하며, `ttfs/opensource/` 는 **git 이 추적하는 저장소 자산**(NotoSansKR 2종 + OFL)이라
+  모든 체크아웃에서 확보된다. 폰트 미설치 환경에서 한국어가 드롭되는 #2293 회귀를 막는다.
+- **실측이 판단을 바꿨다.** 하드코딩 제거 후 산출 PDF 가 1,024,623 → 650,219 바이트로 줄고
+  임베드 폰트가 Haansoft Batang/Dotum·H2gtrM 에서 Noto 계열로 전부 바뀌었다. 확인하지 않았다면
+  "제거는 안전하다" 고 잘못 보고했을 것이다. 다만
+  `RHWP_FONT_PATH="/mnt/c/Windows/Fonts:ttfs/hwp:ttfs/windows"` 지정 시 **변경 전과 바이트 완전
+  동일**함을 확인해, 기능 손실 없이 명시적 설정으로 옮긴 것임을 입증했다.
+- 종전에는 **환경마다 산출물이 달랐다**(서버·CI 는 이미 `/mnt/c` 가 없어 대체 폰트로 나갔다).
+  이 작업이 그것을 명시적 설정에만 의존하도록 바꾼다. CLI 문서에 "폰트를 지정하지 않으면
+  산출물이 달라진다" 를 명시했다.
+- 회귀 가드 `search_dirs_excludes_environment_specific_paths` 가 재추가를 막는다.
+  red→green: 하드코딩을 되살리면 FAIL, 복원 시 3건 통과.
+
+### #2657 — RFC 전제 변경 안내
+
+postmelee 님의 studio PDF RFC 가 #2283 을 "선행 기반" 으로 참조하고 있어, krilla 미진행과
+studio PDF v1.0.0 제외를 알렸다. 다만 **RFC 전체를 무르는 것이 아님**을 명시했다 — 목표 1(인쇄
+경로 안정화)은 오히려 우선순위가 올라가고, 설계 원칙과 활성화 조건 체크리스트는 그대로 유효하다.
+Stage 2 가 #2268 을 "migration 전 baseline" 으로 배치한 것은 **백엔드와 독립적**이라는 점만
+정정했다. 정리 방식은 작성자 판단에 맡겼다.
+
+### 조사 과정의 사실 정정 3건
+
+- `ttfs` 를 통째로 `.gitignore` 대상이라 보고했으나 **`ttfs/opensource/` 는 추적 자산**이었다.
+  놓쳤다면 #2293 회귀를 일으킬 뻔했다.
+- "fontdb 캐시 없음" 이라 보고했으나 `skia/image_conv.rs` 에는 이미 `OnceLock` 캐시가 있었다.
+- krilla 를 기여자 제안으로 추정할 뻔했으나 조사 결과 아카이브 공지의 후계 프로젝트 보고였다.
+
+세 건 모두 작업지시자의 확인 요구로 잡혔다.
+
 ## 잔여와 다음 단계
 
 - 통합 PR 은 전부 merge 했다 — [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42001ef`,
@@ -183,7 +260,10 @@
 | kevin9327 | 7 | 2 | 3 (리베이스 2 · 테스트 1) |
 | johndoekim | 1 | — | — |
 | postmelee | 1 | — | — |
-| 메인테이너 | — | — | #2804 CI 대기 |
+| 메인테이너 | 2 | — | — |
+
+메인테이너 merge 2건: [#2805](https://github.com/edwardkim/rhwp/pull/2805) `1a48fcda3b`(CI retries) ·
+[#2898](https://github.com/edwardkim/rhwp/pull/2898) `1f582cda46`(폰트 조달 환경 종속 제거)
 
 merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42001ef` ·
 [#2797](https://github.com/edwardkim/rhwp/pull/2797) `f2c02b6669` ·
@@ -191,7 +271,12 @@ merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42
 [#2802](https://github.com/edwardkim/rhwp/pull/2802) `ad4cf05d3f` ·
 [#2803](https://github.com/edwardkim/rhwp/pull/2803) `f85e689752`
 
-연결 이슈 close 9건: #2656 #2660 #2723 #2724 #2740 #2752 #2756 #2759 #2765
+연결 이슈 close 12건: #2656 #2660 #2723 #2724 #2740 #2752 #2756 #2759 #2765 #2804 #2864 #2268
+
+PDF 축 정리로 함께 종결: #2787(사용자 제안 — v1.0.0 미지원 안내) · #2283(krilla 미진행 결정)
+
+**#2268 은 07-14 등록 후 8일 만에 종결**됐다. 원인이 `load_system_fonts()` 자체가 아니라 그 아래
+`/mnt/c/Windows/Fonts` 무조건 스캔이었다는 것을 코드로 특정한 것이 결정적이었다.
 
 ## #2809 — 나눔정렬 마지막 줄과 Canvas 음수 자간 정정
 


### PR DESCRIPTION
사용자 제안 #2787 에서 시작해 PDF 관련 이슈 전반의 방향을 확정한 내역을 오늘할일에 기록한다.

## 추가한 내용

- **#2787 close** — studio/확장 PDF 는 v1.0.0 미지원. `Ctrl+P` 인쇄 경로 안내와 제외 사유 4가지(폰트 라이선스·메모리·검색 상실·번들 크기)
- **#2283 close** — krilla 마이그레이션 미진행 결정. 중간 기착지 논리와 Skia direct 의 현재 제약(미지원 op), 재판단 트리거
- **#2856 신설** — svg2pdf 를 rhwp 산하 포크로 이관. 의존성 수명이 개인 계정에 묶인 문제, 원 기여자 사전 통지
- **#2864 + #2268** — 폰트 조달 환경 종속 제거(PR #2898 `1f582cda46`). 실측이 판단을 바꾼 과정을 남겼다
- **#2657** — RFC 전제 변경 안내. RFC 전체를 무르는 것이 아님을 명시하고 정리는 작성자 판단에 위임
- **조사 과정의 사실 정정 3건** — `ttfs/opensource` 추적 여부, fontdb 캐시 유무, krilla 제안 주체

## 집계 갱신

메인테이너 merge 2건(#2805 CI retries, #2898 폰트 조달) 반영, 연결 이슈 close 9건 → 12건.

## 검증

문서 변경만이라 코드 게이트는 해당 없다. 기존 절(planet6897 3건, kevin9327 11건, #2658, #2667, #2809 등)은 collaborator 작업분이라 그대로 보존했다.