### PR TITLE
fix(hml): into_table() row_sizes 계산 이차시간 수정

### DIFF
--- a/mydocs/report/task_m100_2833_report.md
+++ b/mydocs/report/task_m100_2833_report.md
@@ -1,0 +1,78 @@
+# #2833 처리 결과 — HML 파서 into_table() row_sizes 계산 이차시간 수정
+
+## 문제
+
+`src/parser/hml/adapter.rs`의 `into_table()`이 `row_sizes`를 계산할 때
+`table.row_count`(파일 `RowCount` 속성을 검증 없이 받은 `u16`)만큼 바깥 루프를 돌며
+매 행마다 `cells` 전체를 선형 스캔했다(`O(row_count × cells.len())`). `RowCount`만
+크게 부풀리고 `CELL`은 정상 개수인 입력이 **파싱 자체**를 느리게 만든다 — #2751이
+지적한 export 경로(`serializer/hml/body.rs`)와는 별개로, import 경로에 남은 동형
+잔여 결함이다.
+
+## 수정
+
+`src/parser/hml/adapter.rs`의 `into_table()` 한 곳:
+
+```rust
+let mut row_sizes = vec![0i16; source.row_count as usize];
+for cell in &cells {
+    if let Some(slot) = row_sizes.get_mut(cell.row as usize) {
+        *slot = slot.saturating_add(1);
+    }
+}
+```
+
+`cells`를 한 번만 순회해 행별 카운트를 누적하는 방식으로 교체 —
+`O(row_count + cells.len())`. `cell.row >= row_count`인 셀은 종전 코드에서도
+`0..row_count` 범위 밖이라 어떤 행에도 카운트되지 않았으므로, `get_mut`이 `None`을
+반환하는 경우 그대로 무시해 동일한 동작을 유지한다. 정상 문서(`cell.row <
+row_count`)에서는 결과가 원본과 값 단위로 동일하다.
+
+## 테스트 (red → green)
+
+`tests/issue_2833_hml_adapter_row_sizes.rs` 신설. 이슈 실측(`RowCount=60000`,
+`CELL=3000`)을 재현하는 최소 HML을 구성해 `parse_hml()`을 호출하고:
+
+1. 파싱 소요시간이 500ms 미만임을 단언(느슨한 회귀 상한)
+2. `row_sizes` 값 자체가 정확함을 단언 — `row_sizes.len() == 60000`,
+   `row_sizes[0] == 3000`(모든 셀이 row=0), 나머지 행은 전부 0.
+
+수정 전 코드(`(0..source.row_count).map(|row| cells.iter().filter(...))`)로
+되돌려 실행한 결과:
+
+```
+thread 'inflated_row_count_does_not_slow_down_parsing' panicked:
+row_sizes 계산이 O(row_count × cells.len()) 로 되돌아가면 이 상한을 넘음 (실제 1.5931682s)
+```
+
+수정 적용 후 재실행:
+
+```
+running 1 test
+test inflated_row_count_does_not_slow_down_parsing ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
+```
+
+1.59초 → 0.2초(테스트 전체, 파싱 자체는 그중 일부)로 확인, red → green을 로컬에서
+직접 확인했다.
+
+## 검증 (디스크 제약으로 경량 검증만 수행)
+
+- `cargo check --lib` 통과
+- 위 테스트 1건 `cargo test --test issue_2833_hml_adapter_row_sizes`로 개별 실행
+  통과(red 확인 1회 + green 확인 2회)
+- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
+  디스크 여유 공간(~19GB, 거의 100% 사용) 제약으로 스킵
+- `rustfmt --edition 2021` 적용, `git diff --name-only`로 의도한 파일(`adapter.rs`,
+  신규 테스트 파일)만 변경됨을 확인
+
+## 범위 밖
+
+이슈 본문에서 언급된 동형 루프(`model/table.rs::rebuild_row_sizes` 등)는 이 이슈의
+범위(`adapter.rs::into_table()` 한 곳)에 포함되지 않아 손대지 않았다.
+
+## 변경 파일
+
+- `src/parser/hml/adapter.rs`
+- `tests/issue_2833_hml_adapter_row_sizes.rs` (신규)

--- a/src/parser/hml/adapter.rs
+++ b/src/parser/hml/adapter.rs
@@ -236,9 +236,19 @@ fn into_table(source: HmlTable) -> Result<Control, HmlError> {
             ..Default::default()
         });
     }
-    let row_sizes = (0..source.row_count)
-        .map(|row| cells.iter().filter(|cell| cell.row == row).count() as i16)
-        .collect();
+    // [#2833] row_count 는 <TABLE RowCount="..."> 를 검증 없이 받은 u16 이다.
+    // 종전 코드는 row_count 만큼 순회하며 매 행마다 cells 전체를 다시 스캔해
+    // O(row_count × cells.len()) 이었다 — RowCount 만 부풀린 입력이 파싱 자체를
+    // 느리게 만들었다(#2751 은 export 경로, 이건 import 경로의 동형 잔여).
+    // cells 를 한 번만 순회해 행별로 누적하면 O(row_count + cells.len()).
+    // cell.row >= row_count 인 셀은 종전에도 어떤 행에도 카운트되지 않았으므로
+    // (0..row_count 범위 밖) get_mut 이 None 인 경우 그대로 무시해 동일하게 맞춘다.
+    let mut row_sizes = vec![0i16; source.row_count as usize];
+    for cell in &cells {
+        if let Some(slot) = row_sizes.get_mut(cell.row as usize) {
+            *slot = slot.saturating_add(1);
+        }
+    }
     let attr = u32::from(source.common.treat_as_char);
     let mut table = Table {
         attr,

--- a/tests/issue_2833_hml_adapter_row_sizes.rs
+++ b/tests/issue_2833_hml_adapter_row_sizes.rs
@@ -1,0 +1,63 @@
+//! Issue #2833 회귀 가드 — HML 파서 `into_table()` 의 `row_sizes` 계산이
+//! `O(row_count × cells.len())` 이던 문제(#2751 의 import 경로 잔여).
+//! `RowCount` 만 크게 부풀리고 `CELL` 은 정상 개수인 입력(뷰어가 여는 "멀쩡한"
+//! 문서)이 파싱 자체를 느리게 만들지 않아야 한다.
+
+use rhwp::parser::hml::parse_hml;
+use std::time::Instant;
+
+/// `RowCount` 를 크게, `CELL` 은 `cell_count`개(모두 `RowAddr="0"`)로 구성한
+/// 최소 HML 표 문서.
+fn hml_with_inflated_row_count(row_count: u32, cell_count: usize) -> Vec<u8> {
+    let mut cells = String::new();
+    for _ in 0..cell_count {
+        cells.push_str(
+            r#"<CELL BorderFill="1" ColAddr="0" ColSpan="1" Dirty="false" Editable="false" HasMargin="false" Header="false" Height="100" Protect="false" RowAddr="0" RowSpan="1" Width="1000"><CELLMARGIN Bottom="0" Left="0" Right="0" Top="0"/><PARALIST LineWrap="Break" LinkListID="0" LinkListIDNext="0" TextDirection="0" VertAlign="Center"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>x</CHAR></TEXT></P></PARALIST></CELL>"#,
+        );
+    }
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Style="embed" SubVersion="9.0.1.0" Version="2.9">
+  <HEAD SecCnt="1"><MAPPINGTABLE><BORDERFILLLIST Count="1"><BORDERFILL BackSlash="0" BreakCellSeparateLine="0" CenterLine="0" CounterBackSlash="0" CounterSlash="0" CrookedSlash="0" Id="1" Shadow="false" Slash="0" ThreeD="false"><LEFTBORDER Type="None" Width="0.1mm"/><RIGHTBORDER Type="None" Width="0.1mm"/><TOPBORDER Type="None" Width="0.1mm"/><BOTTOMBORDER Type="None" Width="0.1mm"/><DIAGONAL Type="Solid" Width="0.1mm"/></BORDERFILL></BORDERFILLLIST><CHARSHAPELIST Count="1"><CHARSHAPE BorderFillId="1" Height="1000" Id="0" ShadeColor="4294967295" SymMark="0" TextColor="0" UseFontSpace="false" UseKerning="false"/></CHARSHAPELIST><PARASHAPELIST Count="1"><PARASHAPE Align="Left" AutoSpaceEAsianEng="false" AutoSpaceEAsianNum="false" BreakLatinWord="KeepWord" BreakNonLatinWord="false" Condense="0" FontLineHeight="false" HeadingType="None" Id="0" KeepLines="false" KeepWithNext="false" Level="0" LineWrap="Break" PageBreakBefore="false" SnapToGrid="true" TabDef="0" VerAlign="Baseline" WidowOrphan="false"><PARAMARGIN Indent="0" Left="0" LineSpacing="160" LineSpacingType="Percent" Next="0" Prev="0" Right="0"/><PARABORDER BorderFill="1" Connect="false" IgnoreMargin="false"/></PARASHAPE></PARASHAPELIST><STYLELIST Count="1"><STYLE CharShape="0" EngName="Normal" Id="0" LangId="1042" LockForm="0" Name="바탕글" NextStyle="0" ParaShape="0" Type="Para"/></STYLELIST></MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>a</CHAR><TABLE BorderFill="1" CellSpacing="0" ColCount="1" PageBreak="Cell" RepeatHeader="true" RowCount="{row_count}"><SHAPEOBJECT InstId="1" Lock="false" NumberingType="Table" TextFlow="BothSides" ZOrder="0"><SIZE Height="100" HeightRelTo="Absolute" Protect="false" Width="1000" WidthRelTo="Absolute"/><POSITION AffectLSpacing="false" AllowOverlap="false" FlowWithText="true" HoldAnchorAndSO="false" HorzAlign="Left" HorzOffset="0" HorzRelTo="Para" TreatAsChar="true" VertAlign="Top" VertOffset="0" VertRelTo="Para"/><OUTSIDEMARGIN Bottom="0" Left="0" Right="0" Top="0"/></SHAPEOBJECT><INSIDEMARGIN Bottom="0" Left="0" Right="0" Top="0"/><ROW>{cells}</ROW></TABLE><CHAR>b</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL/>
+</HWPML>
+"#
+    )
+    .into_bytes()
+}
+
+#[test]
+fn inflated_row_count_does_not_slow_down_parsing() {
+    // 실측(이슈 본문): RowCount=60000, CELL=3000 이 수정 전 코드에서 O(row_count ×
+    // cells.len()) = 1.8억 회 비교를 강제해 120~180ms/call 대였다. 수정 후에는
+    // O(row_count + cells.len()) 이라 같은 입력이 훨씬 빨라야 한다. 느슨한 상한
+    // (수 초)으로 회귀만 잡는다 — CI 환경 편차를 고려해 타이트하게 걸지 않는다.
+    let bytes = hml_with_inflated_row_count(60_000, 3_000);
+
+    let started = Instant::now();
+    let parsed = parse_hml(&bytes).expect("RowCount 부풀림이 있어도 파싱은 성공해야 함");
+    let elapsed = started.elapsed();
+
+    assert!(
+        elapsed.as_millis() < 500,
+        "row_sizes 계산이 O(row_count × cells.len()) 로 되돌아가면 이 상한을 넘음 (실제 {elapsed:?})"
+    );
+
+    // row_sizes 값 자체도 정확해야 한다: row=0 에 cells.len() 개, 나머지는 0.
+    use rhwp::model::control::Control;
+    let table = parsed
+        .document
+        .sections
+        .iter()
+        .flat_map(|s| &s.paragraphs)
+        .flat_map(|p| &p.controls)
+        .find_map(|c| match c {
+            Control::Table(t) => Some(t.as_ref()),
+            _ => None,
+        })
+        .expect("표 컨트롤이 있어야 함");
+    assert_eq!(table.row_sizes.len(), 60_000);
+    assert_eq!(table.row_sizes[0], 3_000);
+    assert!(table.row_sizes[1..].iter().all(|&n| n == 0));
+}


### PR DESCRIPTION
## 요약

- #2833: `src/parser/hml/adapter.rs`의 `into_table()`이 `row_sizes`를 계산할 때
  `row_count`(파일 `RowCount` 속성을 검증 없이 받은 `u16`)만큼 순회하며 매 행마다
  `cells` 전체를 다시 스캔했다 — `O(row_count × cells.len())`.
- `RowCount`만 부풀리고 `CELL`은 정상 개수인 입력이 **파싱 자체**를 느리게 만든다.
  #2751(export 경로, `serializer/hml/body.rs`)과 동형이지만 import 경로에 남은
  별개 잔여 결함이다.
- 이슈 실측: `RowCount=60000`, `CELL=3000`(1행에 배치) 구성에서 수정 전 약
  120~180ms/call, `row_count`를 실 셀 범위로 낮추면 1ms 미만 — 비용이
  `row_count × cells.len()`에 비례함을 보여준다.

## 변경

`src/parser/hml/adapter.rs`의 `into_table()` 한 곳:

```rust
let mut row_sizes = vec![0i16; source.row_count as usize];
for cell in &cells {
    if let Some(slot) = row_sizes.get_mut(cell.row as usize) {
        *slot = slot.saturating_add(1);
    }
}
```

`cells`를 한 번만 순회해 행별로 누적 → `O(row_count + cells.len())`.
`cell.row >= row_count`인 셀은 종전에도 카운트되지 않았으므로(`0..row_count` 범위
밖) `get_mut`이 `None`인 경우 그대로 무시해 동일한 동작을 유지. 정상 문서에서는
결과가 원본과 값 단위로 동일하다.

## Red → Green

```
# 수정 전
thread 'inflated_row_count_does_not_slow_down_parsing' panicked:
row_sizes 계산이 O(row_count × cells.len()) 로 되돌아가면 이 상한을 넘음 (실제 1.5931682s)

# 수정 후
running 1 test
test inflated_row_count_does_not_slow_down_parsing ... ok

test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out; finished in 0.20s
```

`tests/issue_2833_hml_adapter_row_sizes.rs`에 파싱 소요시간 상한 + `row_sizes`
값 정확성(길이/각 행 카운트) 단언을 함께 추가했다.

## 검증 (디스크 공간 제약으로 경량 검증만 수행)

- `cargo check --lib` 통과
- 위 테스트 1건 `cargo test --test issue_2833_hml_adapter_row_sizes`로 개별 실행 통과
- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
  로컬 디스크 여유 공간(~19GB) 제약으로 스킵
- `rustfmt --edition 2021` 적용, 변경 파일 목록이 의도한 파일로만 유지됨을 확인

## 범위 밖

이슈 본문에서 언급된 동형 루프(`model/table.rs::rebuild_row_sizes` 등)는 이 이슈
범위(`adapter.rs::into_table()` 한 곳)에 포함되지 않아 손대지 않았다.

## 관련 문서

- `mydocs/report/task_m100_2833_report.md`

Fixes #2833