### PR TITLE
글자 모양 다이얼로그 장평/자간 입력에 단축키와 동일한 clamp 적용

### DIFF
--- a/mydocs/report/task_m100_2934_report.md
+++ b/mydocs/report/task_m100_2934_report.md
@@ -1,0 +1,55 @@
+# Task #2934 Report — 글자 모양 다이얼로그 장평/자간 clamp 누락 수정
+
+## 요약
+
+#2925/#2930(툴바 줄 간격 직접입력의 500% 상한 clamp 누락)과 동일한 패턴의 결함을
+`rhwp-studio` 의 다른 UI 컨트롤에서도 찾기 위해, `src/command/commands/format.ts` 의
+단축키 커맨드들과 그 UI 대응물(`toolbar.ts`, 관련 다이얼로그)을 짝지어 훑었다.
+
+| 속성 | 단축키 커맨드 (format.ts → input-handler.ts) | UI 대응물 | 결과 |
+|---|---|---|---|
+| 줄 간격 | `format:line-spacing-increase` → `Math.min(500, ...)` | `toolbar.ts` 줄 간격 드롭다운/버튼 | 이미 #2930 에서 수정됨(대칭) |
+| 글꼴 크기 | `format:font-size-increase/decrease` → `Math.max(100, ...)` | `toolbar.ts` `btnSizeUp/Down` → `Math.max(1, pt-1)` | 대칭 (둘 다 하한만 존재, 값도 동일) |
+| 장평(W) | `format:char-ratio-*` → `adjustCharRatio` → `Math.max(50, Math.min(200, ...))` | `char-shape-dialog.ts` `saveLangFields()` | **비대칭** — clamp 없음 |
+| 자간(P) | `format:char-spacing-*` → `adjustCharSpacing` → `Math.max(-50, Math.min(50, ...))` | `char-shape-dialog.ts` `saveLangFields()` | **비대칭** — clamp 없음 |
+
+장평/자간 입력 필드는 `numberInput(50, 200)`/`numberInput(-50, 50)` 로 `<input type="number">`
+의 `min`/`max` HTML 속성만 설정하는데, 이 속성은 스피너(▲▼) 클릭 시에만 값 범위를 강제하고
+키보드로 직접 범위 밖 숫자를 입력한 뒤 폼 유효성 검사 없이 `.value` 를 읽으면 그대로 통과된다.
+`saveLangFields()` 는 `parseInt(...) || 기본값` 만 수행하고 별도 clamp가 없어, 단축키로는
+만들 수 없는 범위 밖 값(예: 장평 999%, 자간 -999)이 다이얼로그를 통해서는 문서에 기록될 수
+있었다.
+
+## 수정
+
+`src/ui/char-shape-dialog.ts` 의 `saveLangFields()` 에서 `ratio`/`spacing` 파싱 결과를
+`input-handler.ts` 의 `adjustCharRatio`/`adjustCharSpacing` 과 동일한 범위로 clamp 했다
+(장평 50~200, 자간 -50~50). 변경은 2줄, diff 총 4줄이다.
+
+## 검증
+
+새 테스트 `tests/char-shape-dialog-ratio-spacing-clamp.test.ts` 는 소스 가드 방식으로,
+`saveLangFields()` 블록에 clamp 패턴이 존재하는지와 `input-handler.ts` 의 기준 범위
+(50~200, -50~50)가 그대로인지를 함께 확인한다.
+
+- 수정 전: clamp 정규식 미매치로 `FAIL` 확인 (red)
+- 수정 후: `PASS` 확인 (green)
+
+```bash
+cd rhwp-studio
+npx tsx --test tests/char-shape-dialog-ratio-spacing-clamp.test.ts   # PASS
+npm test                                                              # 500 tests, 1 fail
+                                                                       # (cell-flow-boundary.test.ts, 기존에도 실패 — 무관)
+npx tsc --noEmit                                                     # 기존 TS2307 2건만, 신규 0건
+```
+
+## 재현 (수정 전)
+
+1. 문서에서 텍스트 선택 → Alt+L(글자 모양)
+2. 장평(W) 필드에 `999` 입력 후 확인
+3. 문서에 장평 999%가 적용됨 (단축키 Shift+Alt+K로는 최대 200%까지만 증가 가능했던 것과 대비)
+
+## 영향 범위
+
+`char-shape-dialog.ts` 의 `saveLangFields()` 4줄만 수정했으며, 다른 필드(상대 크기/글자 위치)
+는 이번 결함과 무관하여 손대지 않았다.

--- a/rhwp-studio/src/ui/char-shape-dialog.ts
+++ b/rhwp-studio/src/ui/char-shape-dialog.ts
@@ -812,8 +812,10 @@ export class CharShapeDialog {
     if (!this.props) return;
     const arrIdx = this.currentLang === 0 ? -1 : this.currentLang - 1;
 
-    const ratio = parseInt(this.langInputs['cs-ratio'].value) || 100;
-    const spacing = parseInt(this.langInputs['cs-spacing'].value) || 0;
+    // 단축키 커맨드(input-handler.ts adjustCharRatio/adjustCharSpacing)와 동일하게 clamp.
+    // <input type=number>의 min/max 속성은 스피너 클릭에만 강제되고 직접 타이핑에는 적용되지 않는다.
+    const ratio = Math.max(50, Math.min(200, parseInt(this.langInputs['cs-ratio'].value) || 100));
+    const spacing = Math.max(-50, Math.min(50, parseInt(this.langInputs['cs-spacing'].value) || 0));
     const relSize = parseInt(this.langInputs['cs-relative-size'].value) || 100;
     const charOff = parseInt(this.langInputs['cs-char-offset'].value) || 0;
 

--- a/rhwp-studio/tests/char-shape-dialog-ratio-spacing-clamp.test.ts
+++ b/rhwp-studio/tests/char-shape-dialog-ratio-spacing-clamp.test.ts
@@ -1,0 +1,44 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// 글자 모양 다이얼로그(char-shape-dialog.ts)의 장평/자간 입력은 <input type=number>의
+// min/max 속성만으로는 범위를 강제하지 못한다 — 직접 타이핑 후 blur 없이 값을 읽으면
+// 범위 밖 숫자가 그대로 저장된다. 단축키 커맨드(input-handler.ts의 adjustCharRatio/
+// adjustCharSpacing)는 Math.max/Math.min으로 장평 50~200, 자간 -50~50을 코드로 clamp
+// 하므로, 다이얼로그도 saveLangFields()에서 동일하게 clamp 해야 둘의 상한/하한이 어긋나지
+// 않는다. (선례: #2925/#2930 — 툴바 줄 간격 clamp 누락)
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const dialogSrc = readFileSync(join(rootDir, 'src/ui/char-shape-dialog.ts'), 'utf8');
+const inputHandlerSrc = readFileSync(join(rootDir, 'src/engine/input-handler.ts'), 'utf8');
+
+function fnBlock(src: string, name: string): string {
+  const start = src.indexOf(name);
+  assert.notEqual(start, -1, `${name} not found`);
+  const rel = src.slice(start).indexOf('\n  }');
+  assert.notEqual(rel, -1, `${name} 종료 지점 not found`);
+  return src.slice(start, start + rel);
+}
+
+test('char-shape-dialog saveLangFields가 단축키 커맨드와 동일한 장평/자간 범위로 clamp한다', () => {
+  const dialogBlock = fnBlock(dialogSrc, 'private saveLangFields');
+  assert.match(
+    dialogBlock,
+    /Math\.max\(50,\s*Math\.min\(200,\s*parseInt\(this\.langInputs\['cs-ratio'\]\.value\)/,
+    '장평 입력이 50~200으로 clamp되어야 한다 (adjustCharRatio와 동일)'
+  );
+  assert.match(
+    dialogBlock,
+    /Math\.max\(-50,\s*Math\.min\(50,\s*parseInt\(this\.langInputs\['cs-spacing'\]\.value\)/,
+    '자간 입력이 -50~50으로 clamp되어야 한다 (adjustCharSpacing과 동일)'
+  );
+
+  // 단축키 커맨드 쪽 clamp 범위가 바뀌면 이 테스트도 같이 깨지도록 소스에서 직접 확인.
+  const ratioFn = fnBlock(inputHandlerSrc, 'adjustCharRatio(delta: number)');
+  assert.match(ratioFn, /Math\.max\(50,\s*Math\.min\(200,/, 'adjustCharRatio 기준 범위가 50~200이어야 한다');
+  const spacingFn = fnBlock(inputHandlerSrc, 'adjustCharSpacing(delta: number)');
+  assert.match(spacingFn, /Math\.max\(-50,\s*Math\.min\(50,/, 'adjustCharSpacing 기준 범위가 -50~50이어야 한다');
+});


### PR DESCRIPTION
## 요약

#2925/#2930(툴바 줄 간격 직접입력 500% 상한 clamp 누락)과 같은 패턴을 `format.ts`
단축키 커맨드와 대응 UI 컨트롤 전반에서 훑어 찾은 결함이다. `char-shape-dialog.ts`의
장평(W)/자간(P) 입력은 `<input type="number">`의 `min`/`max` 속성에만 의존해 값이
저장되며, 이 속성은 스피너 클릭에만 강제되고 직접 타이핑에는 적용되지 않는다.

- 단축키(`adjustCharRatio`/`adjustCharSpacing`, `input-handler.ts`): `Math.max`/`Math.min`으로
  장평 50~200, 자간 -50~50을 코드로 clamp
- 다이얼로그(`saveLangFields()`, `char-shape-dialog.ts`): clamp 없이 `parseInt` 결과를 그대로 저장

즉 단축키로는 만들 수 없는 범위 밖 장평/자간 값(예: 장평 999%)이 다이얼로그를 통해서는
저장될 수 있었다.

Closes #2934

## Red → Green

`saveLangFields()`에 clamp를 추가하기 전/후로 새 테스트
`tests/char-shape-dialog-ratio-spacing-clamp.test.ts`를 실행해 확인했다.

- 수정 전: clamp 패턴 미검출로 FAIL
- 수정 후: PASS

```bash
cd rhwp-studio
npx tsx --test tests/char-shape-dialog-ratio-spacing-clamp.test.ts   # PASS
npm test        # 500 tests, 1 fail(cell-flow-boundary.test.ts, 기존에도 실패·무관)
npx tsc --noEmit # 기존 TS2307 2건만, 신규 0건
```

## 변경 범위

`src/ui/char-shape-dialog.ts`의 `saveLangFields()` 2줄만 수정(diff 4줄). 다른 필드는
손대지 않았다.

## 상세

`mydocs/report/task_m100_2934_report.md` 참고.
