### PR TITLE
fix(rhwp-studio): 쪽 테두리 다이얼로그 lineWidthSelect 옵션을 16개로 확장

### DIFF
--- a/mydocs/report/task_m100_2946_report.md
+++ b/mydocs/report/task_m100_2946_report.md
@@ -1,0 +1,42 @@
+# task/m100-2946 처리 결과 보고
+
+## 관련 이슈
+
+- https://github.com/edwardkim/rhwp/issues/2946
+
+## 문제 요약
+
+`rhwp-studio/src/ui/page-border-dialog.ts`의 쪽 테두리/배경 다이얼로그에서 굵기(`lineWidthSelect`)
+`<select>`가 옵션 9개(코드 0~8, 0.1mm~0.6mm)만 제공했습니다. 형제 다이얼로그인
+`endnote-shape-dialog.ts`는 동일한 목적의 select에서 코드 0~15(0.1mm~5mm), 총 16개 옵션을
+제공하며, 이것이 HWPX/HWP5 테두리 굵기 값의 실제 범위와 일치하는 참조 구현입니다.
+
+`populate()`가 문서에서 읽은 굵기 코드값을 `this.lineWidthSelect.value = String(firstBorder.width || 0)`로
+할당하는데, 값이 9 이상이면 대응하는 `<option>`이 없어 할당이 무시되고 브라우저 기본 동작에 따라
+select는 첫 번째 옵션(코드 0, 0.1mm)을 가리키게 됩니다. 이어서 `onConfirm()` → `currentBorder()`가
+select의 현재 값을 그대로 읽어 저장하므로, 사용자가 굵기 필드를 전혀 조작하지 않고 다이얼로그를
+열었다가 그대로 확인만 눌러도 0.7mm~5mm 범위의 원본 테두리 굵기가 조용히 0.1mm로 손실됩니다.
+
+## 수정 내용
+
+`buildLineWidthSelect()`의 옵션 라벨 배열에 코드 9~15에 해당하는 `0.7mm`, `1mm`, `1.5mm`, `2mm`,
+`3mm`, `4mm`, `5mm`를 추가해 총 16개 옵션으로 확장했습니다. 라벨 텍스트는
+`endnote-shape-dialog.ts`의 `LINE_WIDTH_OPTIONS` 라벨 형식과 동일하게 맞췄습니다.
+
+- 변경 파일: `rhwp-studio/src/ui/page-border-dialog.ts` (1개 파일, 옵션 배열 확장 4줄 순증)
+
+## 검증
+
+- 별도 빌드 없이 TS 코드 리뷰로 검증: `buildLineWidthSelect()`가 생성하는 옵션의 `value`가
+  이제 `"0"`~`"15"`까지 연속적으로 존재함을 확인했습니다.
+- `populate()`의 `this.lineWidthSelect.value = String(firstBorder.width || 0)` 할당이 굵기 코드
+  0~15 전 범위에서 대응하는 `<option>`을 찾도록 옵션 목록과 코드값이 1:1로 일치함을 확인했습니다.
+- `onConfirm()` → `currentBorder()`가 `parseInt(this.lineWidthSelect.value, 10)`으로 굵기를 다시
+  읽어 저장하는 경로도 동일한 옵션 목록을 사용하므로 왕복(round-trip) 시 굵기 손실이 없음을
+  코드상으로 확인했습니다.
+- 이 다이얼로그의 옵션 목록을 검증하는 기존 테스트 하네스가 없어 별도 테스트는 추가하지
+  않았습니다.
+
+## 남은 이슈
+
+없음. 단일 파일의 옵션 목록 확장만으로 해결되며 IR/파서 변경은 필요하지 않습니다.

--- a/rhwp-studio/src/ui/page-border-dialog.ts
+++ b/rhwp-studio/src/ui/page-border-dialog.ts
@@ -423,7 +423,10 @@ export class PageBorderDialog extends ModalDialog {
   private buildLineWidthSelect(): HTMLSelectElement {
     this.lineWidthSelect = document.createElement('select');
     this.lineWidthSelect.className = 'dialog-select';
-    ['0.1mm', '0.12mm', '0.15mm', '0.2mm', '0.25mm', '0.3mm', '0.4mm', '0.5mm', '0.6mm'].forEach((text, idx) => {
+    [
+      '0.1mm', '0.12mm', '0.15mm', '0.2mm', '0.25mm', '0.3mm', '0.4mm', '0.5mm', '0.6mm',
+      '0.7mm', '1mm', '1.5mm', '2mm', '3mm', '4mm', '5mm',
+    ].forEach((text, idx) => {
       const option = document.createElement('option');
       option.value = String(idx);
       option.textContent = text;


### PR DESCRIPTION
## 요약

- `page-border-dialog.ts`의 굵기(`lineWidthSelect`) 옵션이 9개(코드 0~8, 0.1mm~0.6mm)뿐이라
  문서의 실제 굵기 코드값이 9 이상(0.7mm~5mm)이면 select 매칭 실패로 다이얼로그를 열었다가
  그대로 확인만 눌러도 굵기가 조용히 0.1mm로 손실되는 문제를 수정합니다.
- 형제 다이얼로그 `endnote-shape-dialog.ts`의 참조 구현(코드 0~15, 16개 옵션)에 맞춰
  옵션을 확장했습니다.

관련 이슈: #2946

## 테스트 계획

- [x] 코드 리뷰로 옵션 `value` 0~15가 굵기 코드 전 범위와 1:1 매칭됨을 확인
- [x] `populate()` / `onConfirm()`(`currentBorder()`) 왕복 경로에서 굵기 손실이 없음을 코드상 확인