### PR TITLE
fix(hwpx): imgBrush mode 7종이 저장 시 TILE 로 붕괴하던 문제 수정 (#2953)

### DIFF
--- a/mydocs/report/task_m100_2953_report.md
+++ b/mydocs/report/task_m100_2953_report.md
@@ -1,0 +1,42 @@
+# 완료 보고서 — Task M100-2953
+
+- 이슈: #2953
+- 제목: fix(hwpx): 도형/셀 배경 imgBrush mode 12종 중 9종이 저장 시 TILE 로 붕괴
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2953-imgbrush-mode-roundtrip`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/section.rs::parse_shape_fill_brush` 는 `<hc:imgBrush mode="...">`
+속성을 12종 전부 개별 `ImageFillMode` 값으로 정확히 적재하는데(#2563 에서 4종 → 12종
+확장), 역방향인 `src/serializer/hwpx/shape.rs::write_fill_brush` 는 `FitToSize`/
+`Total`/`Center` 3종만 구분하고 나머지 전부(`TileHorzTop`/`TileHorzBottom`/
+`TileVertLeft`/`TileVertRight`/`CenterTop`/`CenterBottom`/`LeftTop`, 7종)를
+`"TILE"` 로 뭉개고 있었다. IR 에는 정확한 배치가 남아 있지만 emit 이 하드코딩돼
+저장 왕복에서 사용자가 지정한 이미지 채우기 배치가 유실되는 문제였다.
+
+`write_fill_brush` 는 도형(`hp:rect`/`hp:line`)뿐 아니라 `header.rs` 의 `borderFill`
+(셀·쪽 배경)도 공유하므로, 영향 범위는 도형 이미지 채우기와 셀/쪽 배경 이미지 채우기
+양쪽 모두다.
+
+## 2. 주요 변경
+
+- `src/serializer/hwpx/shape.rs`
+  - `write_fill_brush` 의 `mode` match 에 파서가 지원하는 나머지 7종
+    (`TileHorzTop`/`TileHorzBottom`/`TileVertLeft`/`TileVertRight`/`CenterTop`/
+    `CenterBottom`/`LeftTop`) arm 을 추가해 파서와 대칭이 되도록 했다.
+  - `task2943_img_brush_mode_roundtrip_not_collapsed_to_tile` 테스트 추가:
+    `ImageFillMode::TileHorzTop` 을 직렬화해 `mode="TILE_HORZ_TOP"` 로 방출되는지 확인.
+
+## 3. 검증 결과
+
+- red → green: 수정 전 임시로 되돌려 테스트가 `mode="TILE"` 로 실패하는 것을 확인한 뒤
+  (`TileHorzTop 이 TILE 로 붕괴함: <hc:fillBrush><hc:imgBrush mode="TILE"/></hc:fillBrush>`),
+  수정을 재적용해 통과함을 확인.
+- `cargo check --lib` 통과
+- `cargo test --lib task2943_img_brush_mode_roundtrip_not_collapsed_to_tile` 통과
+- `rustfmt --edition 2021 src/serializer/hwpx/shape.rs` 적용
+
+## 4. 남은 이슈
+
+없음. `CommonObjAttr` (src/model/shape.rs) 는 건드리지 않았다.

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -836,10 +836,21 @@ pub(crate) fn write_fill_brush<W: Write>(
         }
         FillType::Image => {
             let img = fill.image.clone().unwrap_or_default();
+            // [#2943] parse_shape_fill_brush(section.rs)는 12종 mode 를 모두 개별
+            // ImageFillMode 로 적재하는데, 종전엔 여기서 3종만 구분하고 나머지 7종
+            // (TileHorzTop/Bottom, TileVertLeft/Right, CenterTop/Bottom, LeftTop)이
+            // 전부 "TILE"로 붕괴해 저장 시 실제 배치가 유실됐다.
             let mode = match img.fill_mode {
+                ImageFillMode::TileHorzTop => "TILE_HORZ_TOP",
+                ImageFillMode::TileHorzBottom => "TILE_HORZ_BOTTOM",
+                ImageFillMode::TileVertLeft => "TILE_VERT_LEFT",
+                ImageFillMode::TileVertRight => "TILE_VERT_RIGHT",
                 ImageFillMode::FitToSize => "FIT",
                 ImageFillMode::Total => "TOTAL",
                 ImageFillMode::Center => "CENTER",
+                ImageFillMode::CenterTop => "CENTER_TOP",
+                ImageFillMode::CenterBottom => "CENTER_BOTTOM",
+                ImageFillMode::LeftTop => "TOP_LEFT_ALIGN",
                 _ => "TILE",
             };
             start_tag(w, "hc:fillBrush")?;
@@ -1155,6 +1166,30 @@ mod tests {
         let xml = String::from_utf8(w.into_inner()).unwrap();
         let i = xml.find("style=\"").expect("style attr") + 7;
         xml[i..].split('"').next().unwrap().to_string()
+    }
+
+    /// #2943: imgBrush mode 는 12종 중 3종만 구분하면 나머지 7종
+    /// (TileHorzTop 등)이 저장 시 전부 TILE 로 붕괴한다. 각 모드가 자기 고유의
+    /// mode 문자열로 방출돼야 한다.
+    #[test]
+    fn task2943_img_brush_mode_roundtrip_not_collapsed_to_tile() {
+        use crate::model::style::{Fill, FillType, ImageFill, ImageFillMode};
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        let ctx = SerializeContext::collect_from_document(&Default::default());
+        let fill = Fill {
+            fill_type: FillType::Image,
+            image: Some(ImageFill {
+                fill_mode: ImageFillMode::TileHorzTop,
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        write_fill_brush(&mut w, &fill, &ctx).expect("write_fill_brush");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(
+            xml.contains("mode=\"TILE_HORZ_TOP\""),
+            "TileHorzTop 이 TILE 로 붕괴함: {xml}"
+        );
     }
 
     /// #1531: 선 없음(style code 0) 도형 외곽선이 라운드트립에서 SOLID(사각형 박스)로


### PR DESCRIPTION
closes #2953

## 문제

`src/parser/hwpx/section.rs::parse_shape_fill_brush` 는 `<hc:imgBrush mode="...">` 를
12종 개별 `ImageFillMode` 로 정확히 적재하지만(#2563 에서 4종 → 12종 확장), 역방향인
`src/serializer/hwpx/shape.rs::write_fill_brush` 는 `FitToSize`/`Total`/`Center` 3종만
구분하고 나머지 7종(`TileHorzTop`/`TileHorzBottom`/`TileVertLeft`/`TileVertRight`/
`CenterTop`/`CenterBottom`/`LeftTop`)을 전부 `"TILE"` 로 방출해, 저장 왕복 시 사용자가
지정한 이미지 채우기 배치가 유실됐다. `write_fill_brush` 는 도형뿐 아니라 `header.rs`
의 borderFill(셀/쪽 배경)도 공유하므로 양쪽 다 영향을 받는다.

## 수정

`write_fill_brush` 의 `mode` match 에 파서가 지원하는 나머지 7종 arm 을 추가해
파서 ↔ 직렬화기를 대칭으로 맞췄다.

## Red → Green

`task2943_img_brush_mode_roundtrip_not_collapsed_to_tile` (src/serializer/hwpx/shape.rs):

- 수정 전: `ImageFillMode::TileHorzTop` 을 직렬화하면
  `<hc:imgBrush mode="TILE"/>` 로 나와 테스트 실패
  (`TileHorzTop 이 TILE 로 붕괴함: <hc:fillBrush><hc:imgBrush mode="TILE"/></hc:fillBrush>`)
- 수정 후: `mode="TILE_HORZ_TOP"` 로 정확히 방출되어 통과

## 검증

- `cargo check --lib` 통과
- `cargo test --lib task2943_img_brush_mode_roundtrip_not_collapsed_to_tile` 통과
- `rustfmt --edition 2021 src/serializer/hwpx/shape.rs` 적용

`CommonObjAttr` (src/model/shape.rs) 는 건드리지 않았습니다.