### PR TITLE
문단 모양 대화상자 줄 간격 입력 min/max 미클램프 수정 (#2959)

### DIFF
--- a/mydocs/report/task_m100_2959_report.md
+++ b/mydocs/report/task_m100_2959_report.md
@@ -1,0 +1,50 @@
+# 완료 보고서 — Task M100-2959
+
+- 이슈: #2959
+- 제목: 문단 모양 대화상자 줄 간격 입력이 min/max 범위를 벗어나도 확인 시 그대로 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2959-line-spacing-clamp`
+
+## 1. 배경
+
+`rhwp-studio/src/ui/para-shape-dialog.ts`의 줄 간격 입력란(`lineSpacingInput`)은
+`numberInput(0, 9999, 1)`로 생성되어 HTML `min=0, max=9999` 속성을 갖지만, 값을
+확정해 모델에 반영하는 `collectMods()`에서는 이 범위를 검증하지 않았다. 브라우저
+number input의 `min`/`max`는 스핀 버튼·마우스 휠 조작에만 클램프를 적용하고
+키보드 직접 입력 후 바로 확인을 눌렀을 때는 강제되지 않으므로, 사용자가 예를
+들어 `999999`를 입력하고 확인을 누르면 그 값이 그대로 `mods.lineSpacing`에
+담겨 저장될 수 있었다.
+
+이는 #2845, #2908, #2915, #2928, #2938, #2949 등에서 이미 여러 차례 발견·수정된
+"HTML min/max 속성은 있지만 확인 로직에서 클램프가 빠진" 동일 계보의 버그다.
+
+## 2. 완료 내용
+
+`para-shape-dialog.ts`에 `clampLineSpacing(value)` 헬퍼(0~9999 클램프)를
+추가하고, `collectMods()`의 `Percent`/그 외 두 분기 모두에서 `lineSpacingInput`
+값을 이 헬퍼로 감싸도록 수정했다.
+
+## 3. 주요 변경
+
+- `rhwp-studio/src/ui/para-shape-dialog.ts`
+  - `clampLineSpacing(value: number): number` 헬퍼 함수 추가 (`Math.max(0, Math.min(9999, value))`)
+  - `collectMods()`의 `newLS` 계산 두 분기에 `clampLineSpacing` 적용
+- `rhwp-studio/tests/para-shape-line-spacing-clamp.test.ts` (신규)
+  - `clampLineSpacing` 헬퍼 정의와 `collectMods()` 내 실제 사용을 소스 검사 방식으로 검증
+
+## 4. 검증 결과
+
+통과:
+
+```
+node --test --experimental-strip-types tests/para-shape-line-spacing-clamp.test.ts
+```
+
+- tests 1, pass 1, fail 0
+
+## 5. 참고
+
+같은 대화상자의 `marginLeftInput`/`marginRightInput`/`indentInput`/
+`spacingBeforeInput`/`spacingAfterInput`도 동일한 클램프 누락 패턴을 공유한다.
+diff를 최소화하기 위해 이번 이슈에서는 영향이 가장 큰 줄 간격 필드 하나만
+다뤘으며, 나머지 필드는 별도 이슈로 후속 처리하는 것을 권장한다.

--- a/rhwp-studio/src/ui/para-shape-dialog.ts
+++ b/rhwp-studio/src/ui/para-shape-dialog.ts
@@ -73,6 +73,11 @@ function ptToRaw(pt: number): number {
   return Math.round(pt * HWPUNIT_PER_PT);
 }
 
+/** 줄 간격 입력값을 lineSpacingInput의 min/max(0~9999)로 클램프 */
+function clampLineSpacing(value: number): number {
+  return Math.max(0, Math.min(9999, value));
+}
+
 /** px → raw HWPUNIT (2x) — 비교용 */
 function pxToRaw2x(px: number): number {
   return Math.round(px * 150);  // px * 72/96 * 100 * 2
@@ -780,9 +785,9 @@ export class ParaShapeDialog {
 
     let newLS: number;
     if (newLSType === 'Percent') {
-      newLS = parseInt(this.lineSpacingInput.value) || 160;
+      newLS = clampLineSpacing(parseInt(this.lineSpacingInput.value) || 160);
     } else {
-      newLS = ptToRaw(parseFloat(this.lineSpacingInput.value) || 0);
+      newLS = ptToRaw(clampLineSpacing(parseFloat(this.lineSpacingInput.value) || 0));
     }
     // Percent는 raw 비교, 그 외는 px → HWPUNIT 변환 후 비교
     const origLS = (p.lineSpacingType || 'Percent') === 'Percent'

--- a/rhwp-studio/tests/para-shape-line-spacing-clamp.test.ts
+++ b/rhwp-studio/tests/para-shape-line-spacing-clamp.test.ts
@@ -1,0 +1,29 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('문단 모양 줄 간격 입력값은 collectMods에서 clampLineSpacing으로 min/max(0~9999)에 맞춰진다 (#2959)', () => {
+  const dialog = source('src/ui/para-shape-dialog.ts');
+
+  assert.match(
+    dialog,
+    /function clampLineSpacing\(value: number\): number \{\s*return Math\.max\(0, Math\.min\(9999, value\)\);\s*\}/,
+    'clampLineSpacing 헬퍼가 0~9999 범위로 클램프해야 한다',
+  );
+
+  const collectStart = dialog.indexOf('private collectMods(');
+  const collectEnd = dialog.indexOf('// 문단 간격', collectStart);
+  assert.notEqual(collectStart, -1, 'collectMods 블록을 찾을 수 있어야 한다');
+  const block = dialog.slice(collectStart, collectEnd);
+
+  assert.match(block, /newLS = clampLineSpacing\(parseInt\(this\.lineSpacingInput\.value\) \|\| 160\)/);
+  assert.match(block, /newLS = ptToRaw\(clampLineSpacing\(parseFloat\(this\.lineSpacingInput\.value\) \|\| 0\)\)/);
+});


### PR DESCRIPTION
## 요약
- `para-shape-dialog.ts`의 줄 간격 입력란은 HTML `min=0, max=9999` 속성으로 생성되지만, `collectMods()`에서 값을 확정할 때 이 범위를 검증하지 않는 문제를 수정했습니다.
- `clampLineSpacing` 헬퍼를 추가해 `Percent`/그 외 두 계산 분기 모두에 적용했습니다.
- 동일 계보 버그: #2845, #2908, #2915, #2928, #2938, #2949

## 관련 이슈
Closes #2959

## 변경 파일
- `rhwp-studio/src/ui/para-shape-dialog.ts`
- `rhwp-studio/tests/para-shape-line-spacing-clamp.test.ts` (신규)
- `mydocs/report/task_m100_2959_report.md` (신규)

## 검증
- [x] `node --test --experimental-strip-types tests/para-shape-line-spacing-clamp.test.ts` 통과 (pass 1, fail 0)