### PR TITLE
fix(hwpx): 인라인 autoNum 원문자(CIRCLED_DIGIT) 서식 오탈자로 파싱·직렬화 소실 수정 (#2957)

### DIFF
--- a/mydocs/report/task_m100_2957_report.md
+++ b/mydocs/report/task_m100_2957_report.md
@@ -1,0 +1,51 @@
+# Task #2957 처리 결과 — HWPX 인라인 autoNum 원문자(CIRCLED_DIGIT) 서식 파싱·직렬화 오탈자 수정
+
+## 이슈
+
+- https://github.com/edwardkim/rhwp/issues/2957
+- 인라인 자동번호 컨트롤 `<hp:ctrl><hp:autoNum>...</hp:autoNum></hp:ctrl>`의 자식
+  `<hp:autoNumFormat type="...">`가 원 문자(circled digit, ①②③…) 형식일 때, 파서와
+  직렬화기가 실제 한컴 스펙 표기 `CIRCLED_DIGIT` 대신 잘못된 철자 `CIRCLE_DIGIT`(D 없음)를
+  사용해 왕복 시 값이 소실되는 문제.
+
+## 근거
+
+같은 파일 `src/serializer/hwpx/section.rs`의 각주/미주 모양(`footNotePr`/`endNotePr`)
+`<hp:autoNumFormat type="...">` 방출 경로(`NumberFormat::CircledDigit => "CIRCLED_DIGIT"`,
+약 244줄)는 #2742에서 실측 코퍼스로 검증된 올바른 철자를 쓰고 있다. 반면 인라인 `<hp:autoNum>`
+경로의 `render_autonum()`은 `<hp:pageNum formatType="...">` 전용 매핑 함수
+`page_num_format_to_str()`를 그대로 재사용해서 `1 => "CIRCLE_DIGIT"`(오탈자)를 방출했다.
+`<hp:pageNum formatType>`은 별개 요소이므로 그쪽의 `CIRCLE_DIGIT` 표기 자체는 정상이며
+변경하지 않았다 — `<hp:autoNumFormat type>` 쪽에서만 재사용한 것이 원인이었다.
+
+파서 `src/parser/hwpx/section.rs`의 `parse_ctrl_autonum()`도 동일한 원인으로 `"CIRCLE_DIGIT"
+=> 1`만 인식하고 실제 스펙 표기 `"CIRCLED_DIGIT"`를 만나면 `_ => 0`(DIGIT)으로 떨어뜨려
+원 문자 설정을 소실했다.
+
+## 변경
+
+1. `src/serializer/hwpx/section.rs` `render_autonum()`: `<hp:autoNumFormat type="...">` 방출 시
+   `format == 1`이면 `"CIRCLED_DIGIT"`을 직접 쓰고, 그 외에는 기존
+   `page_num_format_to_str()` 결과를 그대로 사용(다른 형식·`<hp:pageNum>` 쪽은 변경 없음).
+2. `src/parser/hwpx/section.rs` `parse_ctrl_autonum()`: `type` 매치에
+   `"CIRCLE_DIGIT" | "CIRCLED_DIGIT" => 1`로 두 철자 모두 인식하도록 추가(구값 호환 유지).
+   `parse_page_num_attrs()`(pageNum 전용)는 손대지 않았다.
+
+diff 규모: 실질 로직 변경 7줄(파서 3줄 + 직렬화기 4줄) + 테스트 1개.
+
+## 검증 (red → green)
+
+- `cargo check --lib`: 통과.
+- 신규 단위 테스트 `parser::hwpx::section::tests::task2957_autonum_format_circled_digit_parses_as_1`
+  (`src/parser/hwpx/section.rs`): `<hp:autoNumFormat type="CIRCLED_DIGIT" .../>`를 포함한
+  `<hp:autoNum>`을 파싱해 `AutoNumber.format == 1`을 단언.
+  - **Red**: 파서 수정 전(= `"CIRCLE_DIGIT" => 1`만 인식)으로 되돌려 실행하면
+    `assertion left == right failed: left: 0, right: 1`로 실패 확인.
+  - **Green**: 수정 후 `cargo test --lib task2957` → `test result: ok. 1 passed`.
+- `rustfmt --edition 2021`을 두 변경 파일에 적용.
+
+## 범위 밖
+
+이 worktree(`rhwp-wt-s`)에는 이전 세션의 미완료 변경(PR #2927 대응 CData 수정, `hwp3/*`
+관련 파일 등)이 그대로 남아 있다. 이번 작업은 위 2개 파일 + 본 보고서만 커밋하며, 그 외
+사전 존재 변경분은 건드리지 않았다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4614,7 +4614,9 @@ fn parse_ctrl_autonum(
                             b"type" => {
                                 an.format = match attr_str(&attr).as_str() {
                                     "DIGIT" => 0,
-                                    "CIRCLE_DIGIT" => 1,
+                                    // [#2957] 실제 한컴 스펙 표기는 "CIRCLED_DIGIT" (pageNum
+                                    // formatType 의 "CIRCLE_DIGIT" 와 다름). 구값도 겸용 인식.
+                                    "CIRCLE_DIGIT" | "CIRCLED_DIGIT" => 1,
                                     "ROMAN_CAPITAL" => 2,
                                     "ROMAN_SMALL" => 3,
                                     "LATIN_CAPITAL" => 4,
@@ -5939,6 +5941,32 @@ mod tests {
         assert_eq!(section.paragraphs.len(), 1);
         assert_eq!(section.paragraphs[0].text, "Hello World");
         assert_eq!(section.paragraphs[0].para_shape_id, 0);
+    }
+
+    // ---------- #2957: autoNumFormat 원 문자(CIRCLED_DIGIT) 인식 ----------
+
+    #[test]
+    fn task2957_autonum_format_circled_digit_parses_as_1() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0"><hp:ctrl><hp:autoNum num="1" numType="FOOTNOTE"><hp:autoNumFormat type="CIRCLED_DIGIT" userChar="" prefixChar="" suffixChar="" supscript="0"/></hp:autoNum></hp:ctrl><hp:t> </hp:t></hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let an = section.paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::AutoNumber(an) => Some(an),
+                _ => None,
+            })
+            .expect("autoNum 컨트롤이 파싱돼야 함");
+        assert_eq!(
+            an.format, 1,
+            "type=\"CIRCLED_DIGIT\" 는 format=1(circled digit) 로 인식돼야 함(#2957)"
+        );
     }
 
     // ---------- #1382: autoNum 폭 축 일관화 ----------

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1388,7 +1388,13 @@ fn render_autonum(an: &AutoNumber) -> String {
         ),
         num = an.number,
         nt = auto_number_type_to_str(an.number_type),
-        ty = page_num_format_to_str(an.format),
+        // [#2957] <hp:autoNumFormat type> 은 <hp:pageNum formatType> 과 달리 원 문자
+        // 형식을 "CIRCLED_DIGIT"로 표기한다(각주/미주 경로에서 실측 검증됨, #2742).
+        ty = if an.format == 1 {
+            "CIRCLED_DIGIT"
+        } else {
+            page_num_format_to_str(an.format)
+        },
         u = ctrl_char_attr(an.user_symbol),
         p = ctrl_char_attr(an.prefix_char),
         s = ctrl_char_attr(an.suffix_char),


### PR DESCRIPTION
## 요약

인라인 자동번호 컨트롤 `<hp:ctrl><hp:autoNum>...</hp:autoNum></hp:ctrl>`의 자식
`<hp:autoNumFormat type="...">`가 원 문자(circled digit, ①②③…) 형식일 때, 파서와
직렬화기가 실제 한컴 스펙 표기 `CIRCLED_DIGIT` 대신 오탈자 `CIRCLE_DIGIT`(D 없음)을
써서 파싱·저장 양쪽에서 값이 소실되던 문제를 수정합니다 (#2957).

- 같은 파일의 각주/미주 모양(`footNotePr`/`endNotePr`) `<hp:autoNumFormat type="...">`
  방출 경로는 `"CIRCLED_DIGIT"`(#2742 실측 검증)를 정확히 쓰고 있는데, 인라인
  `<hp:autoNum>` 경로만 `<hp:pageNum formatType="...">` 전용 매핑 함수를 그대로 재사용해
  오탈자가 났습니다. `<hp:pageNum formatType>` 쪽의 `CIRCLE_DIGIT` 표기는 정상이므로
  변경하지 않았습니다.

## 변경

- `src/serializer/hwpx/section.rs` `render_autonum()`: format==1(circled digit)이면
  `"CIRCLED_DIGIT"`을 직접 방출.
- `src/parser/hwpx/section.rs` `parse_ctrl_autonum()`: `type` 매치에
  `"CIRCLE_DIGIT" | "CIRCLED_DIGIT" => 1`로 두 철자 모두 인식(구값 호환 유지).

## Red → Green

신규 테스트 `parser::hwpx::section::tests::task2957_autonum_format_circled_digit_parses_as_1`:

- **Red**(수정 전, `"CIRCLE_DIGIT" => 1`만 인식): `assertion left == right failed: left: 0, right: 1`로 실패.
- **Green**(수정 후): `cargo test --lib task2957` → `test result: ok. 1 passed`.

```
cargo check --lib   # 통과
cargo test --lib task2957   # 1 passed
```

## 관련

closes #2957
