### PR TITLE
fix(hwpx): hp:dutmal 의 mainText/subText CDATA 본문 파싱 누락으로 인한 덧말 소실 해소

### DIFF
--- a/mydocs/report/task_m100_2951_report.md
+++ b/mydocs/report/task_m100_2951_report.md
@@ -1,0 +1,71 @@
+# Task #2951 최종 결과보고서
+
+## 이슈 요약
+
+**원 보고 제목**: hp:dutmal 의 mainText/subText 가 CDATA 로 인코딩된 경우 파서가 덧말(Ruby) 텍스트를 소실함 #2951
+
+**증상**: `<hp:dutmal>`(덧말/Ruby) 하위 `<hp:mainText>`(기준 텍스트) / `<hp:subText>`(덧말 텍스트)가
+`<![CDATA[...]]>`로 인코딩된 경우, 파서가 이를 인식하지 못해 빈 문자열로 소실됨.
+
+## 원인
+
+`src/parser/hwpx/section.rs`의 `read_dutmal_text` 함수가 quick-xml 이벤트 중
+`Event::Text`, `Event::GeneralRef`만 매치하고 `Event::CData`를 처리하는 분기가 없었음.
+CDATA 섹션은 `_ => {}` 폴백에 걸려 텍스트가 그대로 버려짐.
+
+#2916(`hp:equation`의 `hp:script`, PR #2927)와 #2935(`hp:parameters`의
+`stringParam(Command)`, PR #2943)에서 동일한 클래스의 결함이 이미 확인·수정된 바 있음.
+이번 건은 세 번째 발생 지점인 `hp:dutmal`(덧말)에서 재현됨.
+
+## 수정 내용
+
+**파일**: `src/parser/hwpx/section.rs` (`read_dutmal_text`)
+
+기존 `Event::Text` / `Event::GeneralRef` 분기 사이에 `Event::CData` 분기를 추가하여,
+CDATA 내용을 `String::from_utf8_lossy`로 디코딩해 `text`에 이어붙이도록 함
+(기존 header.rs `read_numbering_para_head_text`, section.rs `parse_field_parameters`의
+CDATA 처리와 동일한 패턴).
+
+```diff
+             Ok(Event::GeneralRef(ref r)) => {
+                 text.push_str(&decode_xml_general_ref(r));
+             }
++            // [CDATA] dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우 처리하지
++            // 않으면 덧말 텍스트가 소실된다. #2916/#2935의 hp:script/stringParam CDATA
++            // 누락과 동일한 패턴.
++            Ok(Event::CData(ref cdata)) => {
++                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
++            }
+             Ok(Event::End(ref ee)) => {
+```
+
+## 검증 결과
+
+### 테스트 (red → green)
+
+`dutmal_maintext_subtext_preserve_cdata` 단위 테스트 추가:
+`mainText`에 `a<b`, `subText`에 `c>d`를 CDATA로 감싼 `<hp:dutmal>`을 파싱해
+`Control::Ruby`의 `main_text`/`ruby_text`가 원문 그대로 보존되는지 확인.
+
+- **수정 전 (red)**: `assertion left == right failed: mainText CDATA 가 소실되면 안 됨` — `left: "", right: "a<b"`
+- **수정 후 (green)**: `test parser::hwpx::section::tests::dutmal_maintext_subtext_preserve_cdata ... ok`
+
+### 빌드
+
+- `cargo check --lib`: 통과 (경고 없음)
+
+## 영향 범위
+
+**영향 받음**: `<hp:dutmal>`의 `mainText`/`subText`가 CDATA로 인코딩된 HWPX 문서 (덧말에
+`<`, `>`, `&` 등을 포함하는 경우 한/글이 CDATA로 저장할 수 있음).
+
+**영향 없음**: CDATA를 쓰지 않는 일반 텍스트 덧말, 다른 컨트롤/요소의 파싱 경로.
+
+## 산출물
+
+- `mydocs/report/task_m100_2951_report.md` (본 문서)
+- 소스: `src/parser/hwpx/section.rs` (`read_dutmal_text` 6줄 추가 + 테스트 1개 24줄 추가)
+
+## 이슈 종료 조건
+
+작업지시자 승인 후 `gh issue close 2951` 실행.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5153,6 +5153,12 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
             }
+            // [CDATA] dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우 처리하지
+            // 않으면 덧말 텍스트가 소실된다. #2916/#2935의 hp:script/stringParam CDATA
+            // 누락과 동일한 패턴.
+            Ok(Event::CData(ref cdata)) => {
+                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+            }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
                 if local_name(eename.as_ref()) == end_tag {
@@ -6657,6 +6663,75 @@ mod tests {
         assert_eq!(table.common.attr, 0x082a_2211);
         assert_eq!(table.attr, 0x01);
         assert_eq!(table.raw_table_record_attr, 0x0400_000e);
+    }
+
+    #[test]
+    fn table_textwrap_tight_and_through_survive_roundtrip() {
+        // 표 textWrap="TIGHT"/"THROUGH" 가 파서 arm 누락으로 SQUARE 로 유실되던 결함.
+        // 방출측 text_wrap_str 은 이 두 값을 내므로 왕복 보존돼야 한다.
+        for (s, expect) in [("TIGHT", TextWrap::Tight), ("THROUGH", TextWrap::Through)] {
+            let xml = format!(
+                r#"<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"><hp:p paraPrIDRef="0" styleIDRef="0"><hp:tbl numberingType="TABLE" textWrap="{s}" pageBreak="CELL" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="1000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0" vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:tr><hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="1000"/></hp:tc></hp:tr></hp:tbl></hp:p></hs:sec>"#
+            );
+            let section = parse_hwpx_section(&xml).unwrap();
+            let table = match &section.paragraphs[0].controls[0] {
+                crate::model::control::Control::Table(t) => t,
+                other => panic!("expected table, got {other:?}"),
+            };
+            assert_eq!(
+                table.common.text_wrap, expect,
+                "textWrap={s} 가 {expect:?} 로 파싱돼야 함(SQUARE 유실 방지)"
+            );
+        }
+    }
+
+    #[test]
+    fn picture_pattern_8_8_effect_is_preserved() {
+        // 방출측이 내는 PATTERN_8_8 효과가 기본값 RealPic 으로 되돌아가지 않아야 한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:pic id="1" zOrder="0" textWrap="SQUARE" textFlow="BOTH_SIDES">
+        <hp:img binaryItemIDRef="image1" effect="PATTERN_8_8"/>
+      </hp:pic>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Picture(picture) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 그림이어야 함");
+        };
+        assert_eq!(
+            picture.image_attr.effect,
+            crate::model::image::ImageEffect::Pattern8x8,
+            "PATTERN_8_8 그림 효과가 RealPic 으로 유실되면 안 됨"
+        );
+    }
+
+    #[test]
+    fn dutmal_maintext_subtext_preserve_cdata() {
+        // hp:dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우
+        // (예: 비교연산자 `<`/`>` 포함) 파서 arm 누락으로 소실되던 결함.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:dutmal posType="TOP" align="CENTER" szRatio="50" option="0" styleIDRef="0">
+        <hp:mainText><![CDATA[a<b]]></hp:mainText>
+        <hp:subText><![CDATA[c>d]]></hp:subText>
+      </hp:dutmal>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Ruby(ruby) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 Ruby(덧말)여야 함");
+        };
+        assert_eq!(ruby.main_text, "a<b", "mainText CDATA 가 소실되면 안 됨");
+        assert_eq!(ruby.ruby_text, "c>d", "subText CDATA 가 소실되면 안 됨");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

`<hp:dutmal>`(덧말/Ruby)의 `<hp:mainText>`/`<hp:subText>`가 CDATA로 인코딩된 경우
파서가 이를 소실하던 결함을 수정합니다. (closes #2951)

`read_dutmal_text`(`src/parser/hwpx/section.rs`)가 `Event::Text`/`Event::GeneralRef`만
처리하고 `Event::CData` 분기가 없어 CDATA 섹션이 그대로 버려졌습니다.
#2916(`hp:script`, PR #2927)/#2935(`stringParam`, PR #2943)와 동일한 클래스의 결함이
`hp:dutmal`에서도 재현된 것입니다.

## 수정

기존 `Event::GeneralRef` 분기 다음에 `Event::CData` 분기를 추가해 CDATA 내용을
`String::from_utf8_lossy`로 디코딩하여 이어붙이도록 했습니다. (6줄)

## 테스트 (red → green)

`dutmal_maintext_subtext_preserve_cdata` 추가: `mainText`에 `a<b`, `subText`에 `c>d`를
CDATA로 감싼 `<hp:dutmal>`을 파싱해 `Control::Ruby`의 `main_text`/`ruby_text`가 보존되는지 확인.

- 수정 전(red): `assertion left == right failed` — `left: "", right: "a<b"`
- 수정 후(green): `test ... dutmal_maintext_subtext_preserve_cdata ... ok`

`cargo check --lib` 통과.

## 문서

`mydocs/report/task_m100_2951_report.md` 에 상세 결과보고서 작성.