### PR TITLE
HWPX tc dirty 셀 속성 라운드트립 소실 수정

### DIFF
--- a/mydocs/report/task_m100_2948_report.md
+++ b/mydocs/report/task_m100_2948_report.md
@@ -1,0 +1,69 @@
+# 완료 보고서 — Task M100-2948
+
+- 이슈: #2948
+- 제목: HWPX `<hp:tc dirty>` 셀 속성이 항상 0으로 하드코딩되어 라운드트립 소실
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2948-tc-dirty`
+
+## 0. 작업 재개 메모 (디스크 공간 이슈)
+
+이번 세션 시작 시 디스크 공간이 임계 수준으로 부족한 상태였다. 사용자가 여유 공간을
+54GB+ 확보하고 `target/*/incremental` 및 오래된 `deps` 산출물을 정리한 뒤 작업을
+재개했다. 정리 후 `cargo check --lib` 은 링커 오류 없이 정상 동작했다 — 이번 작업에서
+`LNK1123`/`CVT1107`/`dbghelp.lib` 류의 Windows SDK 링커 손상은 재현되지 않았다.
+
+## 1. 완료 내용
+
+HWPX 표 셀(`<hp:tc>`)의 `dirty` 속성(편집기 캐시 무효화 표시 플래그)이 파서에서
+아예 읽히지 않고, 직렬화기에서는 값과 무관하게 항상 `dirty="0"` 으로 하드코딩되어
+방출되던 문제를 수정했다. "parsed but hardcoded" 계열(lock, reverse, dropCapStyle,
+groupLevel, numberingType, fieldid 등)에 속하는 반복 패턴이다.
+
+## 2. 주요 변경
+
+- `src/model/table.rs`
+  - `Cell` 구조체에 `pub dirty_flag: bool` 필드 추가.
+  - 템플릿 기반 신규 셀 생성 경로(`Cell::from_template` 계열)는 `dirty_flag: false` 로
+    초기화 — dirty는 편집기 캐시 상태이므로 템플릿에서 상속하지 않음.
+- `src/parser/hwpx/section.rs`
+  - `parse_table_cell` 에 `b"dirty" => cell.dirty_flag = parse_bool(&attr),` 추가.
+- `src/serializer/hwpx/table.rs`
+  - `write_cell` 에서 하드코딩된 `("dirty", "0")` 을 `("dirty", dirty)`
+    (`dirty = bool01(cell.dirty_flag)`) 로 교체.
+- `src/diagnostics/ir_field_sweep.rs`
+  - `sweep_cell` 의 `Cell` 전수 구조 분해(`..` 없이 모든 필드 나열)에 새 필드
+    `dirty_flag` 를 추가하고 `f!(dirty_flag);` 비교 호출을 추가. (devel 최신본과 병합
+    과정에서 이 파일이 새 필드를 인식하지 못해 컴파일이 깨졌던 부분을 별도 커밋으로 수정.)
+
+## 3. red→green 테스트
+
+`src/serializer/hwpx/table.rs::tests`
+
+- `tc_dirty_flag_preserved_when_set` — `dirty_flag=true` 인 셀이 `dirty="1"` 로
+  직렬화되는지 확인 (수정 전에는 항상 `dirty="0"` 하드코딩이라 실패).
+- `tc_dirty_flag_zero_when_unset` — 기본값(false)에서는 기존 동작대로 `dirty="0"`
+  유지 확인.
+
+## 4. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib tc_dirty_flag` — 2 passed
+- `rustfmt --edition 2021` (변경 4개 파일: `src/model/table.rs`,
+  `src/parser/hwpx/section.rs`, `src/serializer/hwpx/table.rs`,
+  `src/diagnostics/ir_field_sweep.rs`) — 포맷 위반 없음
+
+## 5. 특이사항
+
+- `origin/devel` 에 브랜치를 새로 딴 뒤 기존 커밋을 cherry-pick 하는 과정에서
+  `src/serializer/hwpx/table.rs` 테스트 삽입 지점에서 다른 병렬 작업(`allowOverlap`
+  보존 테스트, PR 이력상 이미 devel에 병합됨)과 충돌이 발생했다. 두 테스트 블록을
+  모두 보존하는 방식으로 수동 해결했다.
+- 동일하게 devel 최신본에서 `src/diagnostics/ir_field_sweep.rs::sweep_cell` 이
+  `Cell` 을 `..` 없이 전수 구조 분해하는 방어적 패턴을 쓰고 있어, 새 필드 추가만으로
+  컴파일이 깨졌다. 해당 파일에 `dirty_flag` 를 반영하는 후속 커밋으로 수정했다.
+
+## 6. 결론
+
+Task M100-2948 구현과 검증을 완료했다. PR 생성 대기 상태다.

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -1,0 +1,1267 @@
+//! [#2740] IR 필드 전수 스윕 — `Debug` 표현 기반 왕복 불변식 비교기.
+//!
+//! ## 왜 비교기를 하나 더 만드는가
+//!
+//! `serializer::hwpx::roundtrip::diff_documents` 는 이미 성숙한 왕복 비교기이고
+//! `tests/hwp5_roundtrip_baseline.rs`·`tests/hwpx_roundtrip_baseline.rs` 가 코퍼스
+//! 전수 게이트를 XFAIL 래칫과 함께 이미 돌리고 있다. **코퍼스 스윕 자체는 이미 있다.**
+//!
+//! 없는 것은 *비교 대상의 망라성*이다. `diff_documents` 는 사건 대응으로 누적된
+//! 수작업 화이트리스트(22종 variant, #1378~#1403)라서 다음이 통째로 비교되지 않는다.
+//!
+//! - `CharShape`/`ParaShape`/`BorderFill`/`Numbering`/`Bullet`/`Style`/`Font` 의 **내용**
+//!   (개수만 비교하고 필드는 하나도 보지 않는다)
+//! - `Paragraph.text`·`para_shape_id`·`style_id`
+//! - 표/셀의 속성 전부 (`attr`·`row_count`·`cell_spacing`·`padding`·`zones`·셀 병합/여백/
+//!   테두리 등) — 셀은 문단 재귀를 위해 순회만 하고 속성은 보지 않는다
+//! - `CommonObjAttr` 의 배치 모델 대부분 (`width_criterion`·`vert_rel_to`·`text_wrap`·
+//!   `z_order`·오프셋 등)
+//! - 그림 외 도형의 크기·기하
+//! - `footnote_shape`/`endnote_shape`/`page_border_fill`
+//!
+//! 최근 반복 수정된 1속성 왕복 소실(`hp:tbl` widthRelTo/protect/numberingType,
+//! `charPr` outline/shadow, 그림·도형 `hp:sz`)이 정확히 이 사각지대에 있다. 즉
+//! **게이트가 통과하는데도 같은 부류의 결함이 계속 나오는 이유는 게이트가 그 필드를
+//! 볼 수 없기 때문**이다. 사람이 눈으로 찾는 한 이 부류는 계속 재발한다.
+//!
+//! ## 설계 — 손으로 나열하지 않는 비교
+//!
+//! 비교 단위를 손으로 적는 대신 각 IR 노드의 `Debug` 파생 표현을 문자열로 얻어
+//! 구조적으로 재귀 분해한다. `Debug` 파생은 구조체의 **모든 필드**를 출력하므로
+//! IR 에 필드를 추가하면 별도 조치 없이 비교 대상에 편입된다(무유지보수).
+//!
+//! 척추(순회 경로)는 명시적이되, 큰 노드는 **철저 구조 분해**(`let Paragraph { .. } = p`
+//! 를 `..` 없이)로 잡아 필드가 추가되면 **컴파일이 깨지도록** 했다. 즉 사각지대가
+//! 조용히 생기지 않는다:
+//!
+//! - `Paragraph`·`Table`·`Cell` — 철저 구조 분해 (복제 비용 회피 + 컴파일 타임 관문)
+//! - 그 밖의 모든 잎 노드 — `Debug` 전수 비교 (런타임 망라)
+//!
+//! ## 비용 통제
+//!
+//! `Debug` 문자열화는 [`DEBUG_CAP`] 바이트에서 잘린다([`CappedWriter`] 가 `Err` 를
+//! 돌려 파생 `Debug` 를 조기 중단시킨다). 초과분은 비교되지 않으며 이는 명시된 한계다
+//! (문단 텍스트/`char_offsets` 가 큰 문단에서 발생 가능).
+//!
+//! ## 범위 밖 (의도)
+//!
+//! `raw_stream`·`bin_data_content`·`extra_streams`·`hwpx_aux_entries` 는 원본 바이트
+//! 보존 버퍼라 왕복 후 달라지는 것이 **정상**이다(재직렬화 결과이므로). 바이트 보존은
+//! `hwp5_roundtrip_batch` 의 C2 BinData 지문이 이미 담당한다.
+
+use std::fmt::{Debug, Write as _};
+
+use crate::model::control::Control;
+use crate::model::document::{DocInfo, Document, SectionDef};
+use crate::model::paragraph::Paragraph;
+use crate::model::shape::ShapeObject;
+use crate::model::table::{Cell, Table};
+
+/// `Debug` 문자열화 상한(바이트). 초과 시 그 노드는 앞부분만 비교된다.
+const DEBUG_CAP: usize = 96 * 1024;
+
+/// 구조 재귀 최대 깊이 — 병적인 중첩에서 폭주 방지.
+const MAX_DEPTH: usize = 14;
+
+/// 발산 보고 시 값 문자열 절단 길이.
+const VALUE_CAP: usize = 160;
+
+/// 문서 1건당 수집 상한 — 심하게 깨진 문서에서 메모리 폭주 방지.
+pub const MAX_DIVERGENCES: usize = 2000;
+
+/// 왕복 전후 IR 의 단일 필드 발산.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct FieldDivergence {
+    /// 인덱스를 포함한 정확 경로 (`sections[0].paragraphs[3].controls[1].common.z_order`).
+    pub path: String,
+    /// 원본 IR 값 (절단됨).
+    pub left: String,
+    /// 재파싱 IR 값 (절단됨).
+    pub right: String,
+}
+
+impl FieldDivergence {
+    /// 인덱스를 지운 정규화 경로 — baseline 키.
+    ///
+    /// `sections[0].paragraphs[37].controls[1].common.z_order`
+    /// → `sections[].paragraphs[].controls[].common.z_order`
+    ///
+    /// 샘플마다 인덱스는 다르지만 **결함의 종류**는 경로 모양으로 식별되므로,
+    /// baseline 을 인덱스가 아니라 이 모양으로 고정해야 문서가 조금 바뀌어도
+    /// 래칫이 오작동하지 않는다.
+    pub fn normalized_path(&self) -> String {
+        let mut out = String::with_capacity(self.path.len());
+        let mut in_index = false;
+        for ch in self.path.chars() {
+            match ch {
+                '[' => {
+                    in_index = true;
+                    out.push('[');
+                }
+                ']' => {
+                    in_index = false;
+                    out.push(']');
+                }
+                _ if in_index => {}
+                _ => out.push(ch),
+            }
+        }
+        out
+    }
+}
+
+impl std::fmt::Display for FieldDivergence {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{}: {} → {}", self.path, self.left, self.right)
+    }
+}
+
+/// 상한을 넘으면 `Err` 를 돌려 파생 `Debug` 의 문자열화를 조기 중단시키는 writer.
+///
+/// 파생 `Debug` 구현은 `write!` 결과에 `?` 를 걸므로 첫 `Err` 에서 즉시 반환된다.
+/// 덕분에 거대한 `Vec<u8>`·긴 텍스트를 만나도 비용이 `cap` 으로 묶인다.
+struct CappedWriter {
+    buf: String,
+    cap: usize,
+    overflow: bool,
+}
+
+impl std::fmt::Write for CappedWriter {
+    fn write_str(&mut self, s: &str) -> std::fmt::Result {
+        if self.buf.len() + s.len() > self.cap {
+            self.overflow = true;
+            return Err(std::fmt::Error);
+        }
+        self.buf.push_str(s);
+        Ok(())
+    }
+}
+
+/// `Debug` 표현을 [`DEBUG_CAP`] 이내로 문자열화. 두 번째 값은 절단 여부.
+fn debug_capped<T: Debug + ?Sized>(v: &T) -> (String, bool) {
+    let mut w = CappedWriter {
+        buf: String::new(),
+        cap: DEBUG_CAP,
+        overflow: false,
+    };
+    // 결과 무시 — 절단은 overflow 로 전달된다.
+    let _ = write!(w, "{v:?}");
+    (w.buf, w.overflow)
+}
+
+/// 최상위(중첩·문자열 리터럴 밖) 구분자 기준으로 `body` 를 콤마 분리.
+/// 괄호 짝이 맞지 않으면 `None`.
+fn split_top_level(body: &str) -> Option<Vec<&str>> {
+    let mut parts = Vec::new();
+    let mut depth = 0i32;
+    let mut start = 0usize;
+    let mut quote: Option<u8> = None;
+    let b = body.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i];
+        if let Some(q) = quote {
+            if c == b'\\' {
+                // 이스케이프 다음 바이트는 항상 ASCII (Rust Debug 출력 규약).
+                i += 2;
+                continue;
+            }
+            if c == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' | b'\'' => quote = Some(c),
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => {
+                depth -= 1;
+                if depth < 0 {
+                    return None;
+                }
+            }
+            b',' if depth == 0 => {
+                parts.push(&body[start..i]);
+                start = i + 1;
+            }
+            _ => {}
+        }
+        i += 1;
+    }
+    if depth != 0 || quote.is_some() {
+        return None;
+    }
+    parts.push(&body[start..]);
+    Some(parts)
+}
+
+/// `name: value` 를 최상위 첫 `:` 에서 분리.
+fn split_field(part: &str) -> Option<(&str, &str)> {
+    let mut depth = 0i32;
+    let mut quote: Option<u8> = None;
+    let b = part.as_bytes();
+    let mut i = 0usize;
+    while i < b.len() {
+        let c = b[i];
+        if let Some(q) = quote {
+            if c == b'\\' {
+                i += 2;
+                continue;
+            }
+            if c == q {
+                quote = None;
+            }
+            i += 1;
+            continue;
+        }
+        match c {
+            b'"' | b'\'' => quote = Some(c),
+            b'{' | b'[' | b'(' => depth += 1,
+            b'}' | b']' | b')' => depth -= 1,
+            b':' if depth == 0 => return Some((&part[..i], &part[i + 1..])),
+            _ => {}
+        }
+        i += 1;
+    }
+    None
+}
+
+/// `Debug` 문자열 한 개를 (헤드 이름, 자식 목록) 으로 분해.
+///
+/// - `Name { a: 1, b: 2 }` → `("Name", [("a","1"), ("b","2")])`
+/// - `[x, y]` → `("", [("0","x"), ("1","y")])`
+/// - `Name(x, y)` → `("Name", [("0","x"), ("1","y")])`
+///
+/// 스칼라·문자열 리터럴·유닛 variant 는 분해 불가(`None`) — 잎으로 취급된다.
+fn split_debug(s: &str) -> Option<(&str, Vec<(&str, &str)>)> {
+    let s = s.trim();
+    if s.len() < 2 || s.starts_with('"') {
+        return None;
+    }
+    let open_idx = s.find(['{', '[', '('])?;
+    let open = s.as_bytes()[open_idx];
+    let close = match open {
+        b'{' => '}',
+        b'[' => ']',
+        _ => ')',
+    };
+    if !s.ends_with(close) {
+        return None;
+    }
+    let head = s[..open_idx].trim();
+    let body = &s[open_idx + 1..s.len() - 1];
+    let parts = split_top_level(body)?;
+    let named = open == b'{';
+    let mut out = Vec::with_capacity(parts.len());
+    for (i, part) in parts.iter().enumerate() {
+        let part = part.trim();
+        if part.is_empty() {
+            // `Name {}` / `[]` 의 빈 본문
+            continue;
+        }
+        if named {
+            let (k, v) = split_field(part)?;
+            out.push((k.trim(), v.trim()));
+        } else {
+            // 인덱스 키는 경로 조립에서 `[i]` 로 쓰이므로 정적 문자열이 필요 없다.
+            let key = INDEX_KEYS.get(i).copied().unwrap_or("n");
+            out.push((key, part));
+        }
+    }
+    Some((head, out))
+}
+
+/// 시퀀스 자식 키 — `split_debug` 가 인덱스를 문자열로 만들지 않도록 미리 준비.
+/// 범위를 넘으면 `"n"` 으로 축약되며, 경로에는 실제 인덱스가 따로 붙는다.
+const INDEX_KEYS: &[&str] = &[
+    "0", "1", "2", "3", "4", "5", "6", "7", "8", "9", "10", "11", "12", "13", "14", "15", "16",
+    "17", "18", "19", "20", "21", "22", "23", "24", "25", "26", "27", "28", "29", "30", "31",
+];
+
+/// 양쪽이 모두 `Some(..)` 이면 안쪽을 벗겨 경로를 투명하게 유지한다.
+fn unwrap_some<'a>(a: &'a str, b: &'a str) -> (&'a str, &'a str) {
+    let peel = |s: &'a str| -> Option<&'a str> {
+        let s = s.trim();
+        if s.starts_with("Some(") && s.ends_with(')') {
+            Some(s["Some(".len()..s.len() - 1].trim())
+        } else {
+            None
+        }
+    };
+    match (peel(a), peel(b)) {
+        (Some(x), Some(y)) => (x, y),
+        _ => (a, b),
+    }
+}
+
+fn truncate(s: &str) -> String {
+    if s.chars().count() <= VALUE_CAP {
+        return s.to_string();
+    }
+    let cut: String = s.chars().take(VALUE_CAP).collect();
+    format!("{cut}…")
+}
+
+fn push_leaf(path: &str, a: &str, b: &str, out: &mut Vec<FieldDivergence>) {
+    if out.len() >= MAX_DIVERGENCES {
+        return;
+    }
+    out.push(FieldDivergence {
+        path: path.to_string(),
+        left: truncate(a),
+        right: truncate(b),
+    });
+}
+
+/// 두 `Debug` 문자열을 구조적으로 비교해 발산 잎을 수집한다.
+fn compare_node(path: &str, a: &str, b: &str, depth: usize, out: &mut Vec<FieldDivergence>) {
+    if a == b || out.len() >= MAX_DIVERGENCES {
+        return;
+    }
+    if depth >= MAX_DEPTH {
+        push_leaf(path, a, b, out);
+        return;
+    }
+    let (a, b) = unwrap_some(a, b);
+    if a == b {
+        return;
+    }
+    let (Some((head_a, kids_a)), Some((head_b, kids_b))) = (split_debug(a), split_debug(b)) else {
+        push_leaf(path, a, b, out);
+        return;
+    };
+    if head_a != head_b {
+        // 다른 enum variant / 다른 타입 — 잎으로 보고한다.
+        push_leaf(path, a, b, out);
+        return;
+    }
+    if kids_a.len() != kids_b.len() {
+        // 길이 불일치는 그 자체로 보고하고(기존 비교기의 zip 사각지대), 공통 구간만 계속 본다.
+        push_leaf(
+            &format!("{path}.len"),
+            &kids_a.len().to_string(),
+            &kids_b.len().to_string(),
+            out,
+        );
+    }
+    for (idx, ((ka, va), (kb, vb))) in kids_a.iter().zip(kids_b.iter()).enumerate() {
+        if ka != kb {
+            push_leaf(path, a, b, out);
+            return;
+        }
+        let child = if ka.as_bytes().first().is_some_and(|c| c.is_ascii_digit()) {
+            format!("{path}[{idx}]")
+        } else {
+            format!("{path}.{ka}")
+        };
+        compare_node(&child, va, vb, depth + 1, out);
+    }
+}
+
+/// 값 2개를 `Debug` 로 문자열화해 구조 비교한다.
+fn cmp_debug<T: Debug + ?Sized>(path: &str, a: &T, b: &T, out: &mut Vec<FieldDivergence>) {
+    if out.len() >= MAX_DIVERGENCES {
+        return;
+    }
+    let (sa, _) = debug_capped(a);
+    let (sb, _) = debug_capped(b);
+    compare_node(path, &sa, &sb, 0, out);
+}
+
+/// 개수 비교 — 시퀀스는 개수를 먼저 보고해야 zip 이 뒤를 가리지 않는다.
+fn cmp_count(path: &str, a: usize, b: usize, out: &mut Vec<FieldDivergence>) {
+    if a != b {
+        push_leaf(&format!("{path}.len"), &a.to_string(), &b.to_string(), out);
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 척추 — 순회 경로
+// ---------------------------------------------------------------------------
+
+/// 왕복 전후 두 `Document` 의 IR 필드를 전수 비교한다.
+pub fn sweep_documents(a: &Document, b: &Document) -> Vec<FieldDivergence> {
+    let mut out = Vec::new();
+    sweep_doc_info(&a.doc_info, &b.doc_info, &mut out);
+    cmp_count("sections", a.sections.len(), b.sections.len(), &mut out);
+    for (i, (sa, sb)) in a.sections.iter().zip(b.sections.iter()).enumerate() {
+        if out.len() >= MAX_DIVERGENCES {
+            break;
+        }
+        let base = format!("sections[{i}]");
+        sweep_section_def(&base, &sa.section_def, &sb.section_def, &mut out);
+        sweep_paragraphs(
+            &format!("{base}.paragraphs"),
+            &sa.paragraphs,
+            &sb.paragraphs,
+            &mut out,
+        );
+    }
+    out
+}
+
+fn sweep_doc_info(a: &DocInfo, b: &DocInfo, out: &mut Vec<FieldDivergence>) {
+    macro_rules! table {
+        ($f:ident) => {{
+            let base = concat!("doc_info.", stringify!($f));
+            cmp_count(base, a.$f.len(), b.$f.len(), out);
+            for (i, (x, y)) in a.$f.iter().zip(b.$f.iter()).enumerate() {
+                cmp_debug(&format!("{base}[{i}]"), x, y, out);
+            }
+        }};
+    }
+    table!(char_shapes);
+    table!(para_shapes);
+    table!(border_fills);
+    table!(tab_defs);
+    table!(numberings);
+    table!(bullets);
+    table!(styles);
+    table!(bin_data_list);
+
+    // font_faces 는 언어별 2차원 목록.
+    cmp_count(
+        "doc_info.font_faces",
+        a.font_faces.len(),
+        b.font_faces.len(),
+        out,
+    );
+    for (i, (xs, ys)) in a.font_faces.iter().zip(b.font_faces.iter()).enumerate() {
+        let base = format!("doc_info.font_faces[{i}]");
+        cmp_count(&base, xs.len(), ys.len(), out);
+        for (j, (x, y)) in xs.iter().zip(ys.iter()).enumerate() {
+            cmp_debug(&format!("{base}[{j}]"), x, y, out);
+        }
+    }
+
+    cmp_debug(
+        "doc_info.bullet_count",
+        &a.bullet_count,
+        &b.bullet_count,
+        out,
+    );
+    cmp_debug(
+        "doc_info.memo_shape_count",
+        &a.memo_shape_count,
+        &b.memo_shape_count,
+        out,
+    );
+    cmp_debug(
+        "doc_info.hwpml_version",
+        &a.hwpml_version,
+        &b.hwpml_version,
+        out,
+    );
+    // extra_records 는 미모델링 레코드의 원본 바이트 — 개수만 본다.
+    cmp_count(
+        "doc_info.extra_records",
+        a.extra_records.len(),
+        b.extra_records.len(),
+        out,
+    );
+}
+
+fn sweep_section_def(base: &str, a: &SectionDef, b: &SectionDef, out: &mut Vec<FieldDivergence>) {
+    // 원본 보존 버퍼/렌더 파생물은 개수만 (내용 비교는 왕복 의미가 없다).
+    cmp_count(
+        &format!("{base}.section_def.extra_child_records"),
+        a.extra_child_records.len(),
+        b.extra_child_records.len(),
+        out,
+    );
+    cmp_count(
+        &format!("{base}.section_def.master_pages"),
+        a.master_pages.len(),
+        b.master_pages.len(),
+        out,
+    );
+    let mut sa = a.clone();
+    let mut sb = b.clone();
+    sa.extra_child_records.clear();
+    sa.master_pages.clear();
+    sb.extra_child_records.clear();
+    sb.master_pages.clear();
+    cmp_debug(&format!("{base}.section_def"), &sa, &sb, out);
+}
+
+fn sweep_paragraphs(base: &str, a: &[Paragraph], b: &[Paragraph], out: &mut Vec<FieldDivergence>) {
+    cmp_count(base, a.len(), b.len(), out);
+    for (i, (pa, pb)) in a.iter().zip(b.iter()).enumerate() {
+        if out.len() >= MAX_DIVERGENCES {
+            return;
+        }
+        sweep_paragraph(&format!("{base}[{i}]"), pa, pb, out);
+    }
+}
+
+/// 문단 1건 — `..` 없는 철저 구조 분해로 필드 누락을 컴파일 타임에 막는다.
+/// (`Paragraph` 에 필드를 추가하면 여기서 컴파일이 깨진다.)
+fn sweep_paragraph(base: &str, a: &Paragraph, b: &Paragraph, out: &mut Vec<FieldDivergence>) {
+    let Paragraph {
+        char_count,
+        control_mask,
+        para_shape_id,
+        style_id,
+        column_type,
+        raw_break_type,
+        text,
+        char_offsets,
+        char_shapes,
+        line_segs,
+        range_tags,
+        field_ranges,
+        orphan_field_ends,
+        controls,
+        ctrl_data_records,
+        char_count_msb,
+        raw_header_extra,
+        has_para_text,
+        tab_extended,
+        numbering_restart,
+    } = a;
+
+    macro_rules! f {
+        ($n:ident) => {
+            cmp_debug(&format!("{base}.{}", stringify!($n)), $n, &b.$n, out)
+        };
+    }
+    f!(char_count);
+    f!(control_mask);
+    f!(para_shape_id);
+    f!(style_id);
+    f!(column_type);
+    f!(raw_break_type);
+    f!(text);
+    f!(char_offsets);
+    f!(char_shapes);
+    f!(line_segs);
+    f!(range_tags);
+    f!(field_ranges);
+    f!(orphan_field_ends);
+    f!(ctrl_data_records);
+    f!(char_count_msb);
+    f!(raw_header_extra);
+    f!(has_para_text);
+    f!(tab_extended);
+    f!(numbering_restart);
+
+    sweep_controls(&format!("{base}.controls"), controls, &b.controls, out);
+}
+
+fn sweep_controls(base: &str, a: &[Control], b: &[Control], out: &mut Vec<FieldDivergence>) {
+    cmp_count(base, a.len(), b.len(), out);
+    for (i, (ca, cb)) in a.iter().zip(b.iter()).enumerate() {
+        if out.len() >= MAX_DIVERGENCES {
+            return;
+        }
+        sweep_control(&format!("{base}[{i}]"), ca, cb, out);
+    }
+}
+
+/// 컨트롤 1건 — 속성은 전수 비교하고, 하위 문단은 따로 재귀한다.
+///
+/// 표는 셀 문단까지 복제하면 비용이 커지므로 철저 구조 분해로 처리하고,
+/// 나머지는 하위 문단만 비워낸 사본을 `Debug` 로 전수 비교한다.
+fn sweep_control(base: &str, a: &Control, b: &Control, out: &mut Vec<FieldDivergence>) {
+    use Control::*;
+    match (a, b) {
+        (Table(ta), Table(tb)) => sweep_table(base, ta, tb, out),
+        (Header(ha), Header(hb)) => {
+            let (mut x, mut y) = (ha.clone(), hb.clone());
+            x.paragraphs.clear();
+            y.paragraphs.clear();
+            cmp_debug(base, &x, &y, out);
+            sweep_paragraphs(
+                &format!("{base}.paragraphs"),
+                &ha.paragraphs,
+                &hb.paragraphs,
+                out,
+            );
+        }
+        (Footer(ha), Footer(hb)) => {
+            let (mut x, mut y) = (ha.clone(), hb.clone());
+            x.paragraphs.clear();
+            y.paragraphs.clear();
+            cmp_debug(base, &x, &y, out);
+            sweep_paragraphs(
+                &format!("{base}.paragraphs"),
+                &ha.paragraphs,
+                &hb.paragraphs,
+                out,
+            );
+        }
+        (Footnote(fa), Footnote(fb)) => {
+            let (mut x, mut y) = (fa.clone(), fb.clone());
+            x.paragraphs.clear();
+            y.paragraphs.clear();
+            cmp_debug(base, &x, &y, out);
+            sweep_paragraphs(
+                &format!("{base}.paragraphs"),
+                &fa.paragraphs,
+                &fb.paragraphs,
+                out,
+            );
+        }
+        (Endnote(fa), Endnote(fb)) => {
+            let (mut x, mut y) = (fa.clone(), fb.clone());
+            x.paragraphs.clear();
+            y.paragraphs.clear();
+            cmp_debug(base, &x, &y, out);
+            sweep_paragraphs(
+                &format!("{base}.paragraphs"),
+                &fa.paragraphs,
+                &fb.paragraphs,
+                out,
+            );
+        }
+        (Field(fa), Field(fb)) => {
+            let (mut x, mut y) = (fa.clone(), fb.clone());
+            x.memo_paragraphs.clear();
+            y.memo_paragraphs.clear();
+            cmp_debug(base, &x, &y, out);
+            sweep_paragraphs(
+                &format!("{base}.memo_paragraphs"),
+                &fa.memo_paragraphs,
+                &fb.memo_paragraphs,
+                out,
+            );
+        }
+        (Picture(pa), Picture(pb)) => {
+            let (mut x, mut y) = (pa.clone(), pb.clone());
+            if let Some(c) = x.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+            if let Some(c) = y.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+            cmp_debug(base, &x, &y, out);
+            sweep_caption_paragraphs(base, &pa.caption, &pb.caption, out);
+        }
+        (Shape(sa), Shape(sb)) => sweep_shape(base, sa, sb, out),
+        (Form(fa), Form(fb)) => sweep_form(base, fa, fb, out),
+        (HiddenComment(ha), HiddenComment(hb)) => sweep_paragraphs(
+            &format!("{base}.paragraphs"),
+            &ha.paragraphs,
+            &hb.paragraphs,
+            out,
+        ),
+        // 하위 문단이 없는 컨트롤 — 통째로 전수 비교.
+        (SectionDef(x), SectionDef(y)) => sweep_section_def(base, x, y, out),
+        (ColumnDef(x), ColumnDef(y)) => cmp_debug(base, x, y, out),
+        (AutoNumber(x), AutoNumber(y)) => cmp_debug(base, x, y, out),
+        (NewNumber(x), NewNumber(y)) => cmp_debug(base, x, y, out),
+        (PageNumberPos(x), PageNumberPos(y)) => cmp_debug(base, x, y, out),
+        (Bookmark(x), Bookmark(y)) => cmp_debug(base, x, y, out),
+        (Hyperlink(x), Hyperlink(y)) => cmp_debug(base, x, y, out),
+        (Ruby(x), Ruby(y)) => cmp_debug(base, x, y, out),
+        (CharOverlap(x), CharOverlap(y)) => cmp_debug(base, x, y, out),
+        (PageHide(x), PageHide(y)) => cmp_debug(base, x, y, out),
+        (Equation(x), Equation(y)) => cmp_debug(base, x, y, out),
+        (Unknown(x), Unknown(y)) => cmp_debug(base, x, y, out),
+        // 컨트롤 종류 자체가 달라진 경우 — 왕복 소실 중 가장 큰 종류.
+        _ => push_leaf(base, control_kind(a), control_kind(b), out),
+    }
+}
+
+/// 컨트롤 종류 이름 — 종류 자체가 뒤바뀐 발산을 읽기 쉽게 보고한다.
+fn control_kind(c: &Control) -> &'static str {
+    use Control::*;
+    match c {
+        SectionDef(_) => "SectionDef",
+        ColumnDef(_) => "ColumnDef",
+        Table(_) => "Table",
+        Shape(_) => "Shape",
+        Picture(_) => "Picture",
+        Header(_) => "Header",
+        Footer(_) => "Footer",
+        Footnote(_) => "Footnote",
+        Endnote(_) => "Endnote",
+        AutoNumber(_) => "AutoNumber",
+        NewNumber(_) => "NewNumber",
+        PageNumberPos(_) => "PageNumberPos",
+        Bookmark(_) => "Bookmark",
+        Hyperlink(_) => "Hyperlink",
+        Ruby(_) => "Ruby",
+        CharOverlap(_) => "CharOverlap",
+        PageHide(_) => "PageHide",
+        HiddenComment(_) => "HiddenComment",
+        Equation(_) => "Equation",
+        Field(_) => "Field",
+        Form(_) => "Form",
+        Unknown(_) => "Unknown",
+    }
+}
+
+/// 양식 개체 — `properties` 만 `HashMap` 이라 `Debug` 순서가 비결정적이다.
+/// 그대로 비교하면 실행마다 결과가 달라지는 위양성이 나오므로 정렬해서 비교한다.
+/// (`..` 없는 철저 구조 분해로 필드 추가를 컴파일 타임에 잡는다.)
+fn sweep_form(
+    base: &str,
+    a: &crate::model::control::FormObject,
+    b: &crate::model::control::FormObject,
+    out: &mut Vec<FieldDivergence>,
+) {
+    let crate::model::control::FormObject {
+        form_type,
+        name,
+        caption,
+        text,
+        width,
+        height,
+        fore_color,
+        back_color,
+        value,
+        enabled,
+        properties,
+    } = a;
+
+    macro_rules! f {
+        ($n:ident) => {
+            cmp_debug(&format!("{base}.{}", stringify!($n)), $n, &b.$n, out)
+        };
+    }
+    f!(form_type);
+    f!(name);
+    f!(caption);
+    f!(text);
+    f!(width);
+    f!(height);
+    f!(fore_color);
+    f!(back_color);
+    f!(value);
+    f!(enabled);
+
+    let sorted = |m: &std::collections::HashMap<String, String>| {
+        m.iter()
+            .map(|(k, v)| (k.clone(), v.clone()))
+            .collect::<std::collections::BTreeMap<_, _>>()
+    };
+    cmp_debug(
+        &format!("{base}.properties"),
+        &sorted(properties),
+        &sorted(&b.properties),
+        out,
+    );
+}
+
+fn sweep_caption_paragraphs(
+    base: &str,
+    a: &Option<crate::model::shape::Caption>,
+    b: &Option<crate::model::shape::Caption>,
+    out: &mut Vec<FieldDivergence>,
+) {
+    if let (Some(x), Some(y)) = (a, b) {
+        sweep_paragraphs(
+            &format!("{base}.caption.paragraphs"),
+            &x.paragraphs,
+            &y.paragraphs,
+            out,
+        );
+    }
+}
+
+/// 표 — `..` 없는 철저 구조 분해. 필드가 추가되면 컴파일이 깨진다.
+fn sweep_table(base: &str, a: &Table, b: &Table, out: &mut Vec<FieldDivergence>) {
+    let Table {
+        attr,
+        row_count,
+        col_count,
+        cell_spacing,
+        padding,
+        row_sizes,
+        border_fill_id,
+        zones,
+        cells,
+        cell_grid,
+        page_break,
+        repeat_header,
+        caption,
+        common,
+        outer_margin_left,
+        outer_margin_right,
+        outer_margin_top,
+        outer_margin_bottom,
+        raw_ctrl_data,
+        raw_table_record_attr,
+        raw_table_record_extra,
+        dirty,
+        local_resize_rows,
+        local_resize_cols,
+        local_resize_cell_widths,
+        local_resize_cell_heights,
+    } = a;
+
+    macro_rules! f {
+        ($n:ident) => {
+            cmp_debug(&format!("{base}.{}", stringify!($n)), $n, &b.$n, out)
+        };
+    }
+    f!(attr);
+    f!(row_count);
+    f!(col_count);
+    f!(cell_spacing);
+    f!(padding);
+    f!(row_sizes);
+    f!(border_fill_id);
+    f!(zones);
+    f!(cell_grid);
+    f!(page_break);
+    f!(repeat_header);
+    f!(common);
+    f!(outer_margin_left);
+    f!(outer_margin_right);
+    f!(outer_margin_top);
+    f!(outer_margin_bottom);
+    f!(raw_ctrl_data);
+    f!(raw_table_record_attr);
+    f!(raw_table_record_extra);
+    f!(dirty);
+    f!(local_resize_rows);
+    f!(local_resize_cols);
+    f!(local_resize_cell_widths);
+    f!(local_resize_cell_heights);
+
+    // 캡션: 속성은 문단을 뺀 사본으로, 문단은 재귀로.
+    {
+        let strip = |c: &Option<crate::model::shape::Caption>| {
+            c.clone().map(|mut v| {
+                v.paragraphs.clear();
+                v
+            })
+        };
+        cmp_debug(
+            &format!("{base}.caption"),
+            &strip(caption),
+            &strip(&b.caption),
+            out,
+        );
+        sweep_caption_paragraphs(base, caption, &b.caption, out);
+    }
+
+    let cells_path = format!("{base}.cells");
+    cmp_count(&cells_path, cells.len(), b.cells.len(), out);
+    for (i, (ca, cb)) in cells.iter().zip(b.cells.iter()).enumerate() {
+        if out.len() >= MAX_DIVERGENCES {
+            return;
+        }
+        sweep_cell(&format!("{cells_path}[{i}]"), ca, cb, out);
+    }
+}
+
+/// 셀 — `..` 없는 철저 구조 분해.
+fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut Vec<FieldDivergence>) {
+    let Cell {
+        col,
+        row,
+        col_span,
+        row_span,
+        width,
+        height,
+        padding,
+        border_fill_id,
+        paragraphs,
+        list_header_width_ref,
+        text_direction,
+        vertical_align,
+        apply_inner_margin,
+        is_header,
+        raw_list_extra,
+        field_name,
+        dirty_flag,
+    } = a;
+
+    macro_rules! f {
+        ($n:ident) => {
+            cmp_debug(&format!("{base}.{}", stringify!($n)), $n, &b.$n, out)
+        };
+    }
+    f!(col);
+    f!(row);
+    f!(col_span);
+    f!(row_span);
+    f!(width);
+    f!(height);
+    f!(padding);
+    f!(border_fill_id);
+    f!(list_header_width_ref);
+    f!(text_direction);
+    f!(vertical_align);
+    f!(apply_inner_margin);
+    f!(is_header);
+    f!(raw_list_extra);
+    f!(field_name);
+    f!(dirty_flag);
+
+    sweep_paragraphs(
+        &format!("{base}.paragraphs"),
+        paragraphs,
+        &b.paragraphs,
+        out,
+    );
+}
+
+/// 도형 — 하위 문단(글상자·캡션)을 비운 사본으로 속성 전수 비교 후 문단 재귀.
+fn sweep_shape(base: &str, a: &ShapeObject, b: &ShapeObject, out: &mut Vec<FieldDivergence>) {
+    let mut x = a.clone();
+    let mut y = b.clone();
+    strip_shape(&mut x);
+    strip_shape(&mut y);
+    cmp_debug(base, &x, &y, out);
+
+    // 글상자 문단
+    if let (Some(ta), Some(tb)) = (shape_text_box(a), shape_text_box(b)) {
+        sweep_paragraphs(
+            &format!("{base}.text_box.paragraphs"),
+            &ta.paragraphs,
+            &tb.paragraphs,
+            out,
+        );
+    }
+    // 캡션 문단
+    sweep_caption_paragraphs(base, shape_caption(a), shape_caption(b), out);
+    // 묶음 자식
+    if let (ShapeObject::Group(ga), ShapeObject::Group(gb)) = (a, b) {
+        let path = format!("{base}.children");
+        cmp_count(&path, ga.children.len(), gb.children.len(), out);
+        for (i, (ca, cb)) in ga.children.iter().zip(gb.children.iter()).enumerate() {
+            if out.len() >= MAX_DIVERGENCES {
+                return;
+            }
+            sweep_shape(&format!("{path}[{i}]"), ca, cb, out);
+        }
+    }
+}
+
+/// 도형에서 하위 문단·자식을 비운다(속성 전수 비교용 사본 준비).
+fn strip_shape(s: &mut ShapeObject) {
+    use ShapeObject::*;
+    macro_rules! drawing {
+        ($x:expr) => {{
+            if let Some(tb) = $x.drawing.text_box.as_mut() {
+                tb.paragraphs.clear();
+            }
+            if let Some(c) = $x.drawing.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+        }};
+    }
+    match s {
+        Line(x) => drawing!(x),
+        Rectangle(x) => drawing!(x),
+        Ellipse(x) => drawing!(x),
+        Arc(x) => drawing!(x),
+        Polygon(x) => drawing!(x),
+        Curve(x) => drawing!(x),
+        Chart(x) => {
+            drawing!(x);
+            if let Some(c) = x.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+        }
+        Ole(x) => {
+            drawing!(x);
+            if let Some(c) = x.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+        }
+        Group(x) => {
+            if let Some(c) = x.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+            // 자식은 따로 재귀 비교하므로 사본에서는 비운다.
+            x.children.clear();
+        }
+        Picture(x) => {
+            if let Some(c) = x.caption.as_mut() {
+                c.paragraphs.clear();
+            }
+        }
+    }
+}
+
+fn shape_text_box(s: &ShapeObject) -> Option<&crate::model::shape::TextBox> {
+    use ShapeObject::*;
+    match s {
+        Line(x) => x.drawing.text_box.as_ref(),
+        Rectangle(x) => x.drawing.text_box.as_ref(),
+        Ellipse(x) => x.drawing.text_box.as_ref(),
+        Arc(x) => x.drawing.text_box.as_ref(),
+        Polygon(x) => x.drawing.text_box.as_ref(),
+        Curve(x) => x.drawing.text_box.as_ref(),
+        Chart(x) => x.drawing.text_box.as_ref(),
+        Ole(x) => x.drawing.text_box.as_ref(),
+        Group(_) | Picture(_) => None,
+    }
+}
+
+fn shape_caption(s: &ShapeObject) -> &Option<crate::model::shape::Caption> {
+    use ShapeObject::*;
+    match s {
+        Line(x) => &x.drawing.caption,
+        Rectangle(x) => &x.drawing.caption,
+        Ellipse(x) => &x.drawing.caption,
+        Arc(x) => &x.drawing.caption,
+        Polygon(x) => &x.drawing.caption,
+        Curve(x) => &x.drawing.caption,
+        Chart(x) => &x.caption,
+        Ole(x) => &x.caption,
+        Group(x) => &x.caption,
+        Picture(x) => &x.caption,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// 왕복 실행 진입점
+// ---------------------------------------------------------------------------
+
+/// HWP5 왕복(`parse → serialize → reparse`) 후 IR 필드 전수 스윕.
+pub fn sweep_hwp5_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+    use crate::parser::parse_document;
+    use crate::serializer::serialize_document;
+    let doc1 = parse_document(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
+    let out = serialize_document(&doc1).map_err(|e| format!("직렬화 실패: {e}"))?;
+    let doc2 = parse_document(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
+    Ok(sweep_documents(&doc1, &doc2))
+}
+
+/// HWP5 **레코드 재생성** 경로 왕복 후 IR 필드 전수 스윕.
+///
+/// [`sweep_hwp5_roundtrip`] 은 실제로 직렬화기를 거의 검사하지 못한다.
+/// `serializer/body_text.rs:28`·`serializer/doc_info.rs:25` 가 `raw_stream` 이
+/// 있으면 **원본 바이트를 그대로 되돌려주기** 때문이다. 즉 편집하지 않은 문서의
+/// HWP5 왕복은 바이트 재생(replay)이고, IR 이 같은 것은 당연하다.
+///
+/// 제품에서 문서를 한 글자라도 고치면 `document_core/commands/*` 가
+/// `section.raw_stream = None` / `doc_info.raw_stream_dirty = true` 로 무효화하고
+/// **레코드를 다시 만드는 경로**로 저장한다. 반복돼 온 1속성 소실은 전부 이 경로에서
+/// 난다. 이 함수는 그 무효화를 그대로 재현해 진짜 저장 경로를 측정한다.
+pub fn sweep_hwp5_rebuild_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+    use crate::parser::parse_document;
+    use crate::serializer::serialize_document;
+    let doc1 = parse_document(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
+
+    // 편집이 일어난 문서와 동일한 무효화 (document_core/commands 관례).
+    let mut edited = doc1.clone();
+    edited.doc_info.raw_stream_dirty = true;
+    for s in &mut edited.sections {
+        s.raw_stream = None;
+    }
+
+    let out = serialize_document(&edited).map_err(|e| format!("직렬화 실패: {e}"))?;
+    let doc2 = parse_document(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
+    Ok(sweep_documents(&doc1, &doc2))
+}
+
+/// HWPX 왕복(`parse → serialize → reparse`) 후 IR 필드 전수 스윕.
+pub fn sweep_hwpx_roundtrip(bytes: &[u8]) -> Result<Vec<FieldDivergence>, String> {
+    use crate::parser::hwpx::parse_hwpx;
+    use crate::serializer::hwpx::serialize_hwpx;
+    let doc1 = parse_hwpx(bytes).map_err(|e| format!("파싱 실패: {e}"))?;
+    let out = serialize_hwpx(&doc1).map_err(|e| format!("직렬화 실패: {e}"))?;
+    let doc2 = parse_hwpx(&out).map_err(|e| format!("재파싱 실패: {e}"))?;
+    Ok(sweep_documents(&doc1, &doc2))
+}
+
+/// 발산 목록을 정규화 경로별 건수로 집계 (baseline 키 단위).
+pub fn tally(divs: &[FieldDivergence]) -> std::collections::BTreeMap<String, usize> {
+    let mut map = std::collections::BTreeMap::new();
+    for d in divs {
+        *map.entry(d.normalized_path()).or_insert(0) += 1;
+    }
+    map
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn split_debug_struct() {
+        let (head, kids) = split_debug("CharShape { bold: true, size: 1000 }").unwrap();
+        assert_eq!(head, "CharShape");
+        assert_eq!(kids, vec![("bold", "true"), ("size", "1000")]);
+    }
+
+    #[test]
+    fn split_debug_seq() {
+        let (head, kids) = split_debug("[1, 2, 3]").unwrap();
+        assert_eq!(head, "");
+        assert_eq!(kids, vec![("0", "1"), ("1", "2"), ("2", "3")]);
+    }
+
+    #[test]
+    fn split_debug_nested_commas_are_not_split() {
+        let (_, kids) = split_debug("T { a: [1, 2], b: S { c: 3 } }").unwrap();
+        assert_eq!(kids, vec![("a", "[1, 2]"), ("b", "S { c: 3 }")]);
+    }
+
+    #[test]
+    fn split_debug_string_with_comma_and_braces() {
+        let (_, kids) = split_debug(r#"T { name: "a, b { c", n: 1 }"#).unwrap();
+        assert_eq!(kids, vec![("name", r#""a, b { c""#), ("n", "1")]);
+    }
+
+    #[test]
+    fn split_debug_rejects_scalar() {
+        assert!(split_debug("42").is_none());
+        assert!(split_debug("true").is_none());
+        assert!(split_debug(r#""hello""#).is_none());
+        assert!(split_debug("None").is_none());
+    }
+
+    #[test]
+    fn compare_node_reports_leaf_path() {
+        let mut out = Vec::new();
+        compare_node(
+            "t",
+            "T { a: 1, b: S { c: 2 } }",
+            "T { a: 1, b: S { c: 9 } }",
+            0,
+            &mut out,
+        );
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "t.b.c");
+        assert_eq!(out[0].left, "2");
+        assert_eq!(out[0].right, "9");
+    }
+
+    #[test]
+    fn compare_node_reports_seq_length_and_common_prefix() {
+        let mut out = Vec::new();
+        compare_node("v", "[1, 2, 3]", "[1, 9]", 0, &mut out);
+        // 길이 발산 1건 + 인덱스 1 값 발산 1건
+        let paths: Vec<&str> = out.iter().map(|d| d.path.as_str()).collect();
+        assert!(paths.contains(&"v.len"), "길이 발산 누락: {paths:?}");
+        assert!(paths.contains(&"v[1]"), "값 발산 누락: {paths:?}");
+    }
+
+    #[test]
+    fn compare_node_unwraps_matching_some() {
+        let mut out = Vec::new();
+        compare_node("c", "Some(S { x: 1 })", "Some(S { x: 2 })", 0, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "c.x", "Some 은 경로에 투명해야 함");
+    }
+
+    #[test]
+    fn compare_node_some_vs_none_is_leaf() {
+        let mut out = Vec::new();
+        compare_node("c", "Some(S { x: 1 })", "None", 0, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "c");
+        assert_eq!(out[0].right, "None");
+    }
+
+    #[test]
+    fn compare_node_different_variant_is_leaf() {
+        let mut out = Vec::new();
+        compare_node("s", "Line { a: 1 }", "Rectangle { a: 1 }", 0, &mut out);
+        assert_eq!(out.len(), 1);
+        assert_eq!(out[0].path, "s");
+    }
+
+    #[test]
+    fn identical_values_produce_nothing() {
+        let mut out = Vec::new();
+        compare_node("x", "T { a: 1 }", "T { a: 1 }", 0, &mut out);
+        assert!(out.is_empty());
+    }
+
+    #[test]
+    fn normalized_path_strips_indices() {
+        let d = FieldDivergence {
+            path: "sections[0].paragraphs[37].controls[1].common.z_order".to_string(),
+            left: "1".into(),
+            right: "2".into(),
+        };
+        assert_eq!(
+            d.normalized_path(),
+            "sections[].paragraphs[].controls[].common.z_order"
+        );
+    }
+
+    #[test]
+    fn capped_writer_truncates_large_debug() {
+        let big: Vec<u32> = (0..200_000).collect();
+        let (s, overflow) = debug_capped(&big);
+        assert!(overflow, "상한 초과가 감지되어야 함");
+        assert!(s.len() <= DEBUG_CAP, "상한을 넘겨 문자열화하면 안 됨");
+    }
+
+    #[test]
+    fn debug_capped_small_value_is_complete() {
+        let (s, overflow) = debug_capped(&(1u8, 2u8));
+        assert!(!overflow);
+        assert_eq!(s, "(1, 2)");
+    }
+
+    #[test]
+    fn tally_groups_by_normalized_path() {
+        let divs = vec![
+            FieldDivergence {
+                path: "sections[0].paragraphs[1].text".into(),
+                left: "a".into(),
+                right: "b".into(),
+            },
+            FieldDivergence {
+                path: "sections[0].paragraphs[9].text".into(),
+                left: "a".into(),
+                right: "b".into(),
+            },
+        ];
+        let t = tally(&divs);
+        assert_eq!(t.get("sections[].paragraphs[].text"), Some(&2));
+    }
+
+    /// 실제 IR 타입 위에서 동작하는지 — 표 속성 1개만 바꾸면 그 경로만 나와야 한다.
+    #[test]
+    fn sweep_detects_single_table_attribute_change() {
+        use crate::model::control::Control;
+        use crate::model::document::{Document, Section};
+        use crate::model::paragraph::Paragraph;
+        use crate::model::table::Table;
+
+        let mut tbl = Table::default();
+        tbl.row_count = 2;
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Table(Box::new(tbl)));
+        let mut doc_a = Document::default();
+        doc_a.sections.push(Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        });
+
+        let mut doc_b = doc_a.clone();
+        if let Control::Table(t) = &mut doc_b.sections[0].paragraphs[0].controls[0] {
+            t.row_count = 3;
+        }
+
+        let divs = sweep_documents(&doc_a, &doc_b);
+        assert_eq!(divs.len(), 1, "예상 밖 발산: {divs:?}");
+        assert_eq!(
+            divs[0].path,
+            "sections[0].paragraphs[0].controls[0].row_count"
+        );
+        assert_eq!(divs[0].left, "2");
+        assert_eq!(divs[0].right, "3");
+    }
+
+    /// 동일 문서는 발산 0 — 위양성 방지 기본 보증.
+    #[test]
+    fn sweep_identical_documents_is_empty() {
+        use crate::model::document::{Document, Section};
+        use crate::model::paragraph::Paragraph;
+
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![Paragraph {
+                text: "가나다".to_string(),
+                ..Default::default()
+            }],
+            ..Default::default()
+        });
+        let copy = doc.clone();
+        assert!(sweep_documents(&doc, &copy).is_empty());
+    }
+}

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -4,6 +4,15 @@ use super::paragraph::Paragraph;
 use super::shape::{common_obj_offsets, Caption};
 use super::*;
 
+/// [#2722] `Table::rebuild_grid()` 가 예약할 수 있는 최대 그리드 칸 수.
+///
+/// 실측 근거: `samples/` 전수 조사(파일 343개, 중첩 포함 표 5,353개)에서
+/// `row_count × col_count` 최댓값은 52,770 (5,277행 × 10열,
+/// `issue2063_huge_cellbreak_table.hwp`) 이었다. 이 상한은 그 75.8배이므로
+/// 정상 문서는 상한 분기에 닿지 않는다. 최악의 경우 예약량은
+/// 4,000,000 × 16B = 64 MiB (wasm32 는 8B → 32 MiB) 로 abort 없이 처리된다.
+pub const MAX_TABLE_GRID_CELLS: usize = 4_000_000;
+
 pub const CELL_FLAG_HAS_MARGIN: u16 = 0x0001;
 pub const CELL_FLAG_PROTECT: u16 = 0x0002;
 pub const CELL_FLAG_HEADER: u16 = 0x0004;
@@ -134,6 +143,9 @@ pub struct Cell {
     /// 셀 필드 이름 (한컴 셀 속성 → 필드 → 필드 이름)
     /// raw_list_extra의 offset 14-15(name_len) + offset 16~(UTF-16LE)에서 추출
     pub field_name: Option<String>,
+    /// HWPX `<hp:tc dirty>` 속성 (편집기 캐시 무효화 표시, 라운드트립 보존용).
+    /// HWP5 바이너리에는 대응 비트가 없어 list_header_width_ref 재사용 대상에서 제외한다.
+    pub dirty_flag: bool,
 }
 
 /// 표 셀 행/열 바꿈 복사 데이터.
@@ -337,6 +349,7 @@ impl Cell {
             is_header: template.is_header,
             raw_list_extra: template.raw_list_extra.clone(),
             field_name: None,
+            dirty_flag: false,
             paragraphs: vec![para],
         }
     }
@@ -372,16 +385,15 @@ impl Table {
         (0..h).collect()
     }
 
-    /// 저장/복구 후 Studio 런타임 힌트가 사라진 행 단위 가로 resize를 보수적으로 추론한다.
-    ///
-    /// 한컴 HWP5에는 `local_resize_rows` 같은 rhwp 내부 힌트를 저장할 곳이 없다. 따라서
-    /// 같은 셀 배치 패턴을 공유하는 행들 중 다수의 폭 벡터와 다른 소수 행만 행 단위
-    /// resize 결과로 간주한다. 병합 패턴이 유일한 행은 원본 문서 구조일 가능성이 높아
-    /// 추론 대상에서 제외한다.
-    pub fn inferred_local_resize_rows(&self) -> Vec<u16> {
+    fn inferred_width_row_roles(
+        &self,
+    ) -> (
+        std::collections::BTreeSet<u16>,
+        std::collections::BTreeSet<u16>,
+    ) {
         let col_count = self.col_count as usize;
         if col_count == 0 || self.row_count == 0 {
-            return Vec::new();
+            return Default::default();
         }
 
         let explicit_rows = self
@@ -429,7 +441,8 @@ impl Table {
             grouped_rows.entry(pattern).or_default().push((row, widths));
         }
 
-        let mut inferred = std::collections::BTreeSet::new();
+        let mut base_grid_outliers = std::collections::BTreeSet::new();
+        let mut inferred_local_resize = std::collections::BTreeSet::new();
         for rows in grouped_rows.values() {
             if rows.len() < 2 {
                 continue;
@@ -458,22 +471,82 @@ impl Table {
                 continue;
             }
 
+            // Studio의 행 단위 가로 resize는 행 전체 표시 폭을 유지한다. 저장된
+            // 독립 행은 기준 폭 합과 같거나, 셀 간격을 흡수한 common.width와 같은
+            // 폭 합을 가질 수 있다. 반대로 일부 HWP5 셀의 퇴화 폭(예: 1 HU)은
+            // 어느 쪽에도 맞지 않으므로 로컬 resize로 오인하면 안 된다.
+            let dominant_total = dominant_widths
+                .iter()
+                .map(|width| u64::from(*width))
+                .sum::<u64>();
+            // 셀별 HWPUNIT 정수 반올림이 누적될 수 있어 셀당 1 HU를 허용한다.
+            let total_tolerance = dominant_widths.len().max(1) as u64;
+
             for (row, widths) in rows {
+                let row_total = widths.iter().map(|width| u64::from(*width)).sum::<u64>();
+                let matches_base_total = row_total.abs_diff(dominant_total) <= total_tolerance;
+                let matches_common_width = self.common.width > 0
+                    && row_total.abs_diff(u64::from(self.common.width)) <= total_tolerance;
                 if widths != dominant_widths {
-                    inferred.insert(*row);
+                    // Every unique minority vector is excluded from base-column extraction.
+                    // Otherwise a single oversized/corrupt cell can widen the entire table even
+                    // when it is not safe to reproduce as an independent row grid.
+                    base_grid_outliers.insert(*row);
+                    if matches_base_total || matches_common_width {
+                        inferred_local_resize.insert(*row);
+                    }
                 }
             }
         }
 
-        inferred.into_iter().collect()
+        (base_grid_outliers, inferred_local_resize)
+    }
+
+    /// Minority row-width vectors that must not participate in the table's base column grid.
+    ///
+    /// This set is intentionally wider than [`Self::inferred_local_resize_rows`]: a malformed
+    /// row with a non-preserved total is rendered on the dominant base grid, but still must not
+    /// enlarge that base grid.
+    pub fn base_grid_outlier_rows(&self) -> Vec<u16> {
+        self.inferred_width_row_roles().0.into_iter().collect()
+    }
+
+    /// 저장/복구 후 Studio 런타임 힌트가 사라진 행 단위 가로 resize를 보수적으로 추론한다.
+    ///
+    /// 한컴 HWP5에는 `local_resize_rows` 같은 rhwp 내부 힌트를 저장할 곳이 없다. 따라서
+    /// 같은 셀 배치 패턴을 공유하는 행들 중 다수의 폭 벡터와 다른 소수 행만 행 단위
+    /// resize 결과로 간주한다. 병합 패턴이 유일한 행은 원본 문서 구조일 가능성이 높아
+    /// 추론 대상에서 제외한다. 표시 폭 합이 보존된 행만 독립 grid로 재현한다.
+    pub fn inferred_local_resize_rows(&self) -> Vec<u16> {
+        self.inferred_width_row_roles().1.into_iter().collect()
     }
 
     /// 2D 그리드 인덱스를 재구축한다.
     /// 구조 변경(파싱, 행/열 추가/삭제, 병합/분할) 후 호출해야 한다.
+    ///
+    /// [#2722] `row_count`/`col_count` 는 파일에서 그대로 온 `u16` 이다(HWPX `rowCnt`/
+    /// `colCnt`, HWP5 `HWPTAG_TABLE`, HML `RowCount`/`ColCount`). 종전엔 상한 없이
+    /// `vec![None; rc * cc]` 를 예약해, 65535×65535 = 4,294,836,225 칸 ×
+    /// `Option<usize>` 16바이트 = 68,717,379,600 바이트 예약을 시도하고 실패 시
+    /// `handle_alloc_error` → abort 로 프로세스가 죽었다(250바이트 HML 로 재현).
+    /// wasm32 에서는 `Layout::array` 가 32비트 `usize` 를 넘겨 capacity overflow
+    /// 패닉 → 모듈 트랩이 된다. 정상 파일은 실측상 최대 52,770 칸이라 아래
+    /// 분기가 아예 실행되지 않으므로 동작 불변이다.
     pub fn rebuild_grid(&mut self) {
         let rc = self.row_count as usize;
         let cc = self.col_count as usize;
-        self.cell_grid = vec![None; rc * cc];
+        let requested = rc.saturating_mul(cc);
+        let grid_len = if requested > MAX_TABLE_GRID_CELLS {
+            // 손상된 행/열 수. 실제 셀이 가리키는 마지막 칸 + 1 까지만 예약한다.
+            // 아래 채우기 루프에 이미 `gi < self.cell_grid.len()` 가드가 있어
+            // 범위를 넘는 칸은 원래도 무시됐다.
+            self.addressed_grid_len(cc)
+                .min(MAX_TABLE_GRID_CELLS)
+                .min(requested)
+        } else {
+            requested
+        };
+        self.cell_grid = vec![None; grid_len];
         for (idx, cell) in self.cells.iter().enumerate() {
             for r in cell.row..(cell.row + cell.row_span) {
                 for c in cell.col..(cell.col + cell.col_span) {
@@ -484,6 +557,28 @@ impl Table {
                 }
             }
         }
+    }
+
+    /// [#2722] 셀이 실제로 가리키는 마지막 그리드 인덱스 + 1.
+    /// 손상된 `row_count`/`col_count` 로 그리드가 상한을 넘을 때만 쓰인다.
+    /// 셀이 없으면 0 — 셀 0개짜리 악성 표는 그리드도 0칸이면 충분하다.
+    fn addressed_grid_len(&self, cc: usize) -> usize {
+        self.cells
+            .iter()
+            .map(|cell| {
+                let last_row = (cell.row as usize)
+                    .saturating_add(cell.row_span as usize)
+                    .saturating_sub(1);
+                let last_col = (cell.col as usize)
+                    .saturating_add(cell.col_span as usize)
+                    .saturating_sub(1);
+                last_row
+                    .saturating_mul(cc)
+                    .saturating_add(last_col)
+                    .saturating_add(1)
+            })
+            .max()
+            .unwrap_or(0)
     }
 
     /// O(1) 셀 인덱스 조회. rebuild_grid() 호출 후 사용해야 한다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -9,6 +9,7 @@ use quick_xml::Reader;
 use crate::model::control::{
     AutoNumber, AutoNumberType, Bookmark, CharOverlap, Control, Equation, Field, FieldType,
     FormObject, FormType, HiddenComment, NewNumber, PageHide, PageNumberPos, Ruby,
+    EQUATION_LINE_MODE_BIT,
 };
 use crate::model::document::{Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
@@ -218,6 +219,9 @@ fn parse_master_page_start(e: &quick_xml::events::BytesStart, master_page: &mut 
                 master_page.overlap = duplicate;
             }
             b"pageNumber" => master_page.hwpx_page_number = Some(parse_u16(&attr)),
+            // 표지(첫 쪽) 전용 바탕쪽. serializer 는 방출하나 종전엔 미독 →
+            // pageFront="1" 바탕쪽이 왕복 시 "0" 으로 적용 범위가 바뀌었다.
+            b"pageFront" => master_page.page_front = attr_str(&attr) != "0",
             _ => {}
         }
     }
@@ -1237,6 +1241,15 @@ fn parse_start_num(e: &quick_xml::events::BytesStart, sec_def: &mut SectionDef) 
             b"pic" => sec_def.picture_num = parse_u16(&attr),
             b"tbl" => sec_def.table_num = parse_u16(&attr),
             b"equation" => sec_def.equation_num = parse_u16(&attr),
+            // 쪽 번호 시작 종류(0=이어서/1=홀수/2=짝수, flags bit20-21). 종전엔
+            // 미독이라 HWPX 왕복 시 홀/짝 시작이 유실됐다(serializer 는 BOTH 고정).
+            b"pageStartsOn" => {
+                sec_def.page_num_type = match attr_str(&attr).as_str() {
+                    "ODD" => 1,
+                    "EVEN" => 2,
+                    _ => 0,
+                };
+            }
             _ => {}
         }
     }
@@ -1580,6 +1593,8 @@ fn parse_table(
 ) -> Result<Table, HwpxError> {
     let mut table = Table::default();
     let mut table_record_flags = 0u32;
+    // [#2697] numberingType 부재 시 표의 자연 기본값은 TABLE (종전 방출 리터럴과 동일).
+    table.common.numbering_type = crate::model::shape::ObjectNumberingType::Table;
 
     // 표 기본 속성
     for attr in e.attributes().flatten() {
@@ -1612,6 +1627,11 @@ fn parse_table(
             }
             b"textWrap" => {
                 table.common.text_wrap = match attr_str(&attr).as_str() {
+                    // 표 textWrap 파서만 TIGHT/THROUGH arm 이 빠져 있어, 방출측
+                    // (text_wrap_str)이 내는 이 두 값이 SQUARE 로 유실됐다. 도형/그림/차트
+                    // 파서(같은 파일 2228/2795/5681)는 이미 처리하므로 표만 맞춘다.
+                    "TIGHT" => crate::model::shape::TextWrap::Tight,
+                    "THROUGH" => crate::model::shape::TextWrap::Through,
                     "TOP_AND_BOTTOM" => crate::model::shape::TextWrap::TopAndBottom,
                     "BEHIND_TEXT" => crate::model::shape::TextWrap::BehindText,
                     "IN_FRONT_OF_TEXT" => crate::model::shape::TextWrap::InFrontOfText,
@@ -1624,6 +1644,16 @@ fn parse_table(
                     "RIGHT_ONLY" => crate::model::shape::TextFlow::RightOnly,
                     "LARGEST_ONLY" => crate::model::shape::TextFlow::LargestOnly,
                     _ => crate::model::shape::TextFlow::BothSides,
+                };
+            }
+            // [#2697] 표만 numberingType arm 이 없어 캡션 번호 범주가 파싱 단계에서
+            // 유실됐다. 도형 파서(같은 파일 2855)와 동형. 방출측은 종전 "TABLE" 하드코딩.
+            b"numberingType" => {
+                table.common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
                 };
             }
             _ => {}
@@ -1677,6 +1707,10 @@ fn parse_table(
                                     table.common.height_criterion =
                                         parse_size_criterion(&attr_str(&attr), false);
                                 }
+                                // [#2697] 표만 protect arm 이 없어 "표 크기 보호"가 파싱
+                                // 단계에서 유실됐다. 도형(2907)·사각형(5967)·양식(5590)
+                                // 파서는 모두 같은 hp:sz@protect 를 읽는다.
+                                b"protect" => table.common.size_protect = parse_bool(&attr),
                                 _ => {}
                             }
                         }
@@ -1837,7 +1871,14 @@ fn parse_size_criterion(value: &str, allow_column_para: bool) -> SizeCriterion {
 fn materialize_hwpx_table_attrs(table: &mut Table, table_record_flags: u32) {
     const HWPX_TABLE_NUMBERING_BIT: u32 = 0x0800_0000;
 
-    table.common.attr = pack_hwpx_common_obj_attr(&table.common) | HWPX_TABLE_NUMBERING_BIT;
+    // [#2697] "표 번호" 비트는 numberingType 이 실제로 TABLE 일 때만 세운다. 종전 무조건 OR
+    // 은 numberingType="PICTURE" 표에서 IR 모순(numbering_type=Picture ↔ attr=TABLE)을 만든다.
+    // 차트 파서(5800)가 PICTURE 를 별도 비트로 분기하는 것과 같은 취지.
+    let mut attr = pack_hwpx_common_obj_attr(&table.common);
+    if table.common.numbering_type == crate::model::shape::ObjectNumberingType::Table {
+        attr |= HWPX_TABLE_NUMBERING_BIT;
+    }
+    table.common.attr = attr;
     // HWPX keeps semantic placement in hp:pos, while legacy layout code still reads
     // table.attr bit0 for some inline-table decisions. Only mirror the minimum
     // renderer compatibility bit here; the HWP5 storage attr is packed later by
@@ -2013,6 +2054,7 @@ fn parse_table_cell(
             b"hasMargin" => cell.set_apply_inner_margin(parse_bool(&attr)),
             b"protect" => cell.set_cell_protect(parse_bool(&attr)),
             b"editable" => cell.set_editable_in_form(parse_bool(&attr)),
+            b"dirty" => cell.dirty_flag = parse_bool(&attr),
             // 셀 필드 이름 (누름틀 셀 필드, #493). 직렬화기는 무명 셀도 name=""로
             // 항상 방출하므로 빈 값은 None — HWP5 파서(parse_cell_field_name)와
             // 동일 의미. 누락 시 HWPX 로드에서 getFieldList가 셀 필드를 반환하지 못하고
@@ -2094,14 +2136,24 @@ fn parse_table_cell(
                         }
                     }
                     b"subList" => {
-                        // subList: vertAlign 속성 파싱
+                        // subList: vertAlign + textDirection 속성 파싱
                         for attr in ce.attributes().flatten() {
-                            if attr.key.as_ref() == b"vertAlign" {
-                                cell.vertical_align = match attr_str(&attr).as_str() {
-                                    "CENTER" => VerticalAlign::Center,
-                                    "BOTTOM" => VerticalAlign::Bottom,
-                                    _ => VerticalAlign::Top,
-                                };
+                            match attr.key.as_ref() {
+                                b"vertAlign" => {
+                                    cell.vertical_align = match attr_str(&attr).as_str() {
+                                        "CENTER" => VerticalAlign::Center,
+                                        "BOTTOM" => VerticalAlign::Bottom,
+                                        _ => VerticalAlign::Top,
+                                    };
+                                }
+                                // 세로쓰기 셀(textDirection). serializer 는 셀 <hp:subList>
+                                // 에 방출하지만 종전엔 vertAlign 만 읽어 세로쓰기가 왕복 시
+                                // 유실됐다(cellPr 경로는 serializer 가 방출하지 않음).
+                                b"textDirection" => {
+                                    cell.text_direction =
+                                        if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+                                }
+                                _ => {}
                             }
                         }
                     }
@@ -2294,6 +2346,19 @@ fn parse_picture(
                                         common.height = v;
                                     }
                                 }
+                                // [#2712] 그림만 크기 기준·크기 보호 arm 이 없어 파싱 단계에서
+                                // 유실됐다. 도형 파서(같은 파일 2901-2907)와 동형이며, 높이는
+                                // 도형과 마찬가지로 allow_column_para=false 로 읽어 치역을
+                                // {Paper, Page, Absolute} 로 제한한다.
+                                b"widthRelTo" => {
+                                    common.width_criterion =
+                                        parse_size_criterion(&attr_str(&attr), true);
+                                }
+                                b"heightRelTo" => {
+                                    common.height_criterion =
+                                        parse_size_criterion(&attr_str(&attr), false);
+                                }
+                                b"protect" => common.size_protect = parse_bool(&attr),
                                 _ => {}
                             }
                         }
@@ -2363,6 +2428,13 @@ fn parse_picture(
                                 }
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
+                                // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
+                                // 종전엔 표 파서만 되읽어, 그림/도형/차트/OLE 는 prevent_page_break
+                                // 이 0 으로 유실됐다(표 파서와 동형으로 보강).
+                                b"holdAnchorAndSO" => {
+                                    common.prevent_page_break =
+                                        if parse_bool(&attr) { 1 } else { 0 };
+                                }
                                 b"vertRelTo" => {
                                     common.vert_rel_to = match attr_str(&attr).as_str() {
                                         "PAPER" => VertRelTo::Paper,
@@ -2464,6 +2536,9 @@ fn parse_picture(
                                         "REAL_PIC" => ImageEffect::RealPic,
                                         "GRAY_SCALE" => ImageEffect::GrayScale,
                                         "BLACK_WHITE" => ImageEffect::BlackWhite,
+                                        // 방출측 image_effect_str 은 Pattern8x8 을 이 문자열로
+                                        // 낸다. 안 받으면 무늬(패턴) 효과가 왕복 시 RealPic 유실.
+                                        "PATTERN_8_8" => ImageEffect::Pattern8x8,
                                         _ => ImageEffect::RealPic,
                                     };
                                 }
@@ -2707,6 +2782,7 @@ enum ShapeStorageKind {
 struct ObjectElementIds {
     instid: u32,
     round_rate: u8,
+    is_reverse_hv: bool,
 }
 
 /// HWPX 일부 샘플은 `<hp:curSz width="0" height="0">`를 기록하면서 실제 크기는
@@ -2822,6 +2898,9 @@ fn parse_object_element_attrs(
                     _ => crate::model::shape::ObjectNumberingType::None,
                 };
             }
+            // 선/연결선의 방향 뒤집기(isReverseHV). serializer 는 방출하나 파서가
+            // 되읽지 않아 HWPX 원본 선의 방향 반전이 왕복 시 유실됐다.
+            b"isReverseHV" => ids.is_reverse_hv = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -2919,6 +2998,11 @@ fn parse_object_layout_child(
                     }
                     b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                     b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
+                    // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
+                    // 종전엔 표 파서만 되읽어 개체 배치에선 prevent_page_break 이 유실됐다.
+                    b"holdAnchorAndSO" => {
+                        common.prevent_page_break = if parse_bool(&attr) { 1 } else { 0 };
+                    }
                     b"vertRelTo" => {
                         common.vert_rel_to = match attr_str(&attr).as_str() {
                             "PAPER" => VertRelTo::Paper,
@@ -3410,13 +3494,23 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         let mut img = ImageFill::default();
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
+                                // [#2563] 헤더(borderFill) 파서와 동일한 12종 매핑.
+                                // 종전엔 4종만 받아 TOTAL 등 8종이 TILE 로 붕괴했다.
                                 b"mode" => {
                                     img.fill_mode = match attr_str(&attr).as_str() {
                                         "TILE" | "TILE_ALL" => ImageFillMode::TileAll,
+                                        "TILE_HORZ_TOP" => ImageFillMode::TileHorzTop,
+                                        "TILE_HORZ_BOTTOM" => ImageFillMode::TileHorzBottom,
+                                        "TILE_VERT_LEFT" => ImageFillMode::TileVertLeft,
+                                        "TILE_VERT_RIGHT" => ImageFillMode::TileVertRight,
+                                        "CENTER" => ImageFillMode::Center,
+                                        "CENTER_TOP" => ImageFillMode::CenterTop,
+                                        "CENTER_BOTTOM" => ImageFillMode::CenterBottom,
                                         "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                             ImageFillMode::FitToSize
                                         }
-                                        "CENTER" => ImageFillMode::Center,
+                                        "TOTAL" => ImageFillMode::Total,
+                                        "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                         _ => ImageFillMode::TileAll,
                                     };
                                 }
@@ -3424,6 +3518,35 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                             }
                         }
                         fill.image = Some(img);
+                    }
+                    // [#2563] <hc:imgBrush> 의 <hc:img> 자식. 종전엔 이 arm 이 없어
+                    // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌고,
+                    // bin_data_id 가 0 이라 직렬화가 <hc:img> 를 아예 못 내
+                    // 이미지로 채운 도형이 왕복 후 빈 도형이 됐다.
+                    // 헤더(borderFill) 파서 header.rs 의 b"img" arm 과 동형.
+                    b"img" | b"image" => {
+                        if let Some(ref mut img_fill) = fill.image {
+                            for attr in ce.attributes().flatten() {
+                                match attr.key.as_ref() {
+                                    b"binaryItemIDRef" => {
+                                        let val = attr_str(&attr);
+                                        let num: String =
+                                            val.chars().filter(|c| c.is_ascii_digit()).collect();
+                                        img_fill.bin_data_id = num.parse().unwrap_or(0);
+                                    }
+                                    b"bright" => img_fill.brightness = parse_i8(&attr),
+                                    b"contrast" => img_fill.contrast = parse_i8(&attr),
+                                    b"effect" => {
+                                        img_fill.effect = match attr_str(&attr).as_str() {
+                                            "GRAY_SCALE" => 1,
+                                            "BLACK_WHITE" => 2,
+                                            _ => 0, // REAL_PIC
+                                        };
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -3853,6 +3976,7 @@ fn parse_shape_object(
                 x: x_coords[1],
                 y: y_coords[1],
             },
+            started_right_or_bottom: object_ids.is_reverse_hv,
             ..Default::default()
         }),
         b"connectLine" => ShapeObject::Line(LineShape {
@@ -3875,7 +3999,7 @@ fn parse_shape_object(
                 control_points: connect_control_points,
                 raw_trailing: Vec::new(),
             }),
-            ..Default::default()
+            started_right_or_bottom: object_ids.is_reverse_hv,
         }),
         b"arc" => ShapeObject::Arc(ArcShape {
             common,
@@ -4392,12 +4516,14 @@ fn parse_field_type(s: &str) -> FieldType {
         "CROSSREF" => FieldType::CrossRef,
         "FORMULA" => FieldType::Formula,
         "CLICK_HERE" | "CLICKHERE" => FieldType::ClickHere,
-        "SUMMARY" => FieldType::Summary,
+        "SUMMARY" | "SUMMERY" => FieldType::Summary,
         "USER_INFO" | "USERINFO" => FieldType::UserInfo,
         "HYPERLINK" => FieldType::Hyperlink,
         "MEMO" => FieldType::Memo,
         "PRIVATE_INFO" | "PRIVATEINFO" => FieldType::PrivateInfoSecurity,
-        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" => FieldType::TableOfContents,
+        // 직렬화기(serializer/hwpx/field.rs)는 TableOfContents 를 "TOC" 로 방출하므로
+        // 파서도 이를 받아야 hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        "TABLE_OF_CONTENTS" | "TABLEOFCONTENTS" | "TOC" => FieldType::TableOfContents,
         _ => FieldType::Unknown,
     }
 }
@@ -4502,6 +4628,17 @@ fn parse_ctrl_footnote(
                     note.after_decoration_letter = v;
                 }
             }
+            // [#2716] flag = HWP5 CTRL_FOOTNOTE numberShape(UInt4). 한컴 HWP5/HWPX 쌍
+            // (3-09월_교육_통합_2023) 각주/미주 46개 전수 대조에서 바이트 단위로 일치했다.
+            // 값이 0 이면 한컴이 속성 자체를 생략하므로 default 0 유지.
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
+                }
+            }
             b"instId" => {
                 if let Ok(v) = std::str::from_utf8(&attr.value)
                     .unwrap_or("")
@@ -4547,6 +4684,15 @@ fn parse_ctrl_endnote(
                     .parse::<u16>()
                 {
                     note.after_decoration_letter = v;
+                }
+            }
+            // [#2716] flag = HWP5 CTRL_ENDNOTE numberShape(UInt4). footNote 와 동일 계약.
+            b"flag" => {
+                if let Ok(v) = std::str::from_utf8(&attr.value)
+                    .unwrap_or("")
+                    .parse::<u32>()
+                {
+                    note.number_shape = v;
                 }
             }
             b"instId" => {
@@ -4741,7 +4887,6 @@ fn parse_field_parameters(
     raw.push('>');
 
     // 현재 열린 파라미터 요소 태그(닫을 때 사용).
-    let mut open_param: Option<String> = None;
     loop {
         match reader.read_event_into(&mut buf) {
             Ok(Event::Start(ref ce)) => {
@@ -4758,7 +4903,6 @@ fn parse_field_parameters(
                     raw.push('"');
                 }
                 raw.push('>');
-                open_param = Some(tag);
                 if local == b"stringParam" {
                     for attr in ce.attributes().flatten() {
                         if attr.key.as_ref() == b"name" && attr_str(&attr) == "Command" {
@@ -4820,11 +4964,13 @@ fn parse_field_parameters(
                     raw.push_str("</hp:parameters>");
                     break;
                 }
-                if let Some(tag) = open_param.take() {
-                    raw.push_str("</");
-                    raw.push_str(&tag);
-                    raw.push('>');
-                }
+                // 임의 깊이 중첩(listParam 안의 stringParam 등)에서도 균형 잡힌 XML 을
+                // 재조립하도록, 단일 open_param 추적 대신 End 이벤트 자신의 정규화 이름으로 닫는다.
+                // 종전엔 open_param 이 마지막 Start 로 덮여, 바깥 태그의 닫는 태그가 누락됐다.
+                let qn = String::from_utf8_lossy(eename.as_ref());
+                raw.push_str("</");
+                raw.push_str(&qn);
+                raw.push('>');
                 if local == b"stringParam" {
                     in_command = false;
                 } else if local == b"integerParam" {
@@ -5175,7 +5321,7 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
 }
 
 /// `<hp:equation>` 요소 (수식)를 파싱한다.
-/// 수식 속성(version, baseLine, textColor, baseUnit, font)과
+/// 수식 속성(version, baseLine, textColor, baseUnit, lineMode, font)과
 /// `<hp:script>` 하위 요소에서 수식 스크립트를 추출하여 `Control::Equation`을 생성한다.
 fn parse_equation(
     e: &quick_xml::events::BytesStart,
@@ -5191,6 +5337,9 @@ fn parse_equation(
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
     let mut font_name = String::new();
+    // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
+    // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
+    let mut eq_attr: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5200,6 +5349,14 @@ fn parse_equation(
             b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(0),
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
+            // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
+            b"lineMode" => {
+                if attr_str(&attr).eq_ignore_ascii_case("LINE") {
+                    eq_attr |= EQUATION_LINE_MODE_BIT;
+                } else {
+                    eq_attr &= !EQUATION_LINE_MODE_BIT;
+                }
+            }
             b"font" => font_name = attr_str(&attr),
             _ => {}
         }
@@ -5279,6 +5436,8 @@ fn parse_equation(
 
     let equation = Equation {
         common,
+        // [#2727] HWPX lineMode → EQEDIT attribute bit0
+        attr: eq_attr,
         script,
         font_size,
         color,
@@ -5707,7 +5866,8 @@ fn parse_hp_chart_element(
         }
     }
 
-    parse_common_shape_children(reader, &mut common, b"chart")?;
+    let mut extent: Option<(i32, i32)> = None;
+    parse_common_shape_children(reader, &mut common, b"chart", &mut extent)?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -5720,8 +5880,10 @@ fn parse_hp_chart_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.bin_data_id = 60000u32 + chart_num as u32;
-    ole.extent_x = 7200;
-    ole.extent_y = 7200;
+    // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
+    let (ext_x, ext_y) = extent.unwrap_or((7200, 7200));
+    ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
+    ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
@@ -5735,15 +5897,28 @@ fn parse_hp_ole_element(
 ) -> Result<Option<Control>, HwpxError> {
     use crate::model::shape::OleShape;
 
+    use crate::model::shape::OleDrawingAspect;
+
     let mut common = CommonObjAttr::default();
     common.hwp5_gen_shape_attr_bit26 = true;
     let mut bin_id: u32 = 0;
     let mut numbering_type_picture = false;
+    let mut draw_aspect = OleDrawingAspect::default();
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
             b"numberingType" => {
                 numbering_type_picture = attr_str(&attr).eq_ignore_ascii_case("PICTURE");
+            }
+            // 표시 방식(아이콘/썸네일/인쇄용/내용). serializer 는 방출하나 종전엔
+            // 파서가 읽지 않아 ICON 등이 왕복 시 CONTENT 로 바뀌었다.
+            b"drawAspect" => {
+                draw_aspect = match attr_str(&attr).as_str() {
+                    "ICON" => OleDrawingAspect::Icon,
+                    "THUMBNAIL" => OleDrawingAspect::Thumbnail,
+                    "DOCPRINT" => OleDrawingAspect::DocPrint,
+                    _ => OleDrawingAspect::Content,
+                };
             }
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
@@ -5775,7 +5950,8 @@ fn parse_hp_ole_element(
         }
     }
 
-    parse_common_shape_children(reader, &mut common, b"ole")?;
+    let mut extent: Option<(i32, i32)> = None;
+    parse_common_shape_children(reader, &mut common, b"ole", &mut extent)?;
     if numbering_type_picture {
         common.hwp5_gen_shape_attr_bit28 = true;
     }
@@ -5784,8 +5960,11 @@ fn parse_hp_ole_element(
     let mut ole = OleShape::default();
     ole.common = common;
     ole.bin_data_id = bin_id;
-    ole.extent_x = 7200;
-    ole.extent_y = 7200;
+    ole.drawing_aspect = draw_aspect;
+    // <hc:extent> 가 있으면 원본 개체 크기를 보존한다(없으면 종전 기본값 7200).
+    let (ext_x, ext_y) = extent.unwrap_or((7200, 7200));
+    ole.extent_x = if ext_x > 0 { ext_x } else { 7200 };
+    ole.extent_y = if ext_y > 0 { ext_y } else { 7200 };
     apply_hwpx_ole_shape_component_contract(&mut ole);
     Ok(Some(Control::Shape(Box::new(ShapeObject::Ole(Box::new(
         ole,
@@ -5828,6 +6007,9 @@ fn parse_common_shape_children(
     reader: &mut Reader<&[u8]>,
     common: &mut CommonObjAttr,
     end_tag: &[u8],
+    // OLE 전용 `<hc:extent>`(원본 개체 크기) 수집용. 호출자(ole/chart)만 사용한다.
+    // 종전엔 이 자식을 무시하고 호출자가 7200 을 하드코딩해 개체 크기가 유실됐다.
+    extent_out: &mut Option<(i32, i32)>,
 ) -> Result<(), HwpxError> {
     let mut buf = Vec::new();
     loop {
@@ -5836,6 +6018,18 @@ fn parse_common_shape_children(
                 let cname = ce.name();
                 let local = local_name(cname.as_ref());
                 match local {
+                    b"extent" => {
+                        let mut x = 0i32;
+                        let mut y = 0i32;
+                        for attr in ce.attributes().flatten() {
+                            match attr.key.as_ref() {
+                                b"x" => x = parse_i32(&attr),
+                                b"y" => y = parse_i32(&attr),
+                                _ => {}
+                            }
+                        }
+                        *extent_out = Some((x, y));
+                    }
                     b"sz" => {
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
@@ -5887,6 +6081,13 @@ fn parse_common_shape_children(
                                 b"treatAsChar" => common.treat_as_char = parse_bool(&attr),
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
+                                // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
+                                // 종전엔 표 파서만 되읽어, 그림/도형/차트/OLE 는 prevent_page_break
+                                // 이 0 으로 유실됐다(표 파서와 동형으로 보강).
+                                b"holdAnchorAndSO" => {
+                                    common.prevent_page_break =
+                                        if parse_bool(&attr) { 1 } else { 0 };
+                                }
                                 _ => {}
                             }
                         }
@@ -6660,6 +6861,51 @@ mod tests {
     }
 
     #[test]
+    fn table_textwrap_tight_and_through_survive_roundtrip() {
+        // 표 textWrap="TIGHT"/"THROUGH" 가 파서 arm 누락으로 SQUARE 로 유실되던 결함.
+        // 방출측 text_wrap_str 은 이 두 값을 내므로 왕복 보존돼야 한다.
+        for (s, expect) in [("TIGHT", TextWrap::Tight), ("THROUGH", TextWrap::Through)] {
+            let xml = format!(
+                r#"<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"><hp:p paraPrIDRef="0" styleIDRef="0"><hp:tbl numberingType="TABLE" textWrap="{s}" pageBreak="CELL" repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0" noAdjust="0"><hp:sz width="1000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0" vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/><hp:outMargin left="0" right="0" top="0" bottom="0"/><hp:inMargin left="0" right="0" top="0" bottom="0"/><hp:tr><hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="1000"/></hp:tc></hp:tr></hp:tbl></hp:p></hs:sec>"#
+            );
+            let section = parse_hwpx_section(&xml).unwrap();
+            let table = match &section.paragraphs[0].controls[0] {
+                crate::model::control::Control::Table(t) => t,
+                other => panic!("expected table, got {other:?}"),
+            };
+            assert_eq!(
+                table.common.text_wrap, expect,
+                "textWrap={s} 가 {expect:?} 로 파싱돼야 함(SQUARE 유실 방지)"
+            );
+        }
+    }
+
+    #[test]
+    fn picture_pattern_8_8_effect_is_preserved() {
+        // 방출측이 내는 PATTERN_8_8 효과가 기본값 RealPic 으로 되돌아가지 않아야 한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:pic id="1" zOrder="0" textWrap="SQUARE" textFlow="BOTH_SIDES">
+        <hp:img binaryItemIDRef="image1" effect="PATTERN_8_8"/>
+      </hp:pic>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Picture(picture) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 그림이어야 함");
+        };
+        assert_eq!(
+            picture.image_attr.effect,
+            crate::model::image::ImageEffect::Pattern8x8,
+            "PATTERN_8_8 그림 효과가 RealPic 으로 유실되면 안 됨"
+        );
+    }
+
+    #[test]
     fn test_parse_hwpx_masterpage_line_materializes_shape_common_attr() {
         let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
 <masterPage xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
@@ -6855,6 +7101,37 @@ mod tests {
 
         assert_eq!(field.command, "MEMO/65535/2/1650281184/31247371/user/\\;;");
         assert_eq!(field.memo_index, 2);
+    }
+
+    #[test]
+    fn parse_field_parameters_reassembles_nested_params_balanced() {
+        // 중첩 파라미터(listParam 안의 stringParam). 종전엔 open_param 이 마지막 Start 로
+        // 덮여 바깥 </hp:listParam> 닫는 태그가 누락돼 raw_parameters_xml 이 불균형이었다.
+        let xml = r#"<hp:parameters xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph" cnt="1" name=""><hp:listParam cnt="1" name="L"><hp:stringParam name="A">x</hp:stringParam></hp:listParam></hp:parameters>"#;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut field = Field::default();
+
+        loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"parameters" => {
+                    let start = e.to_owned();
+                    parse_field_parameters(&start, &mut reader, &mut field).unwrap();
+                    break;
+                }
+                Event::Eof => panic!("parameters not found"),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        let raw = field.raw_parameters_xml.expect("raw_parameters_xml");
+        assert!(raw.contains("</hp:stringParam>"), "inner close: {raw}");
+        assert!(
+            raw.contains("</hp:listParam>"),
+            "바깥 </hp:listParam> 누락(중첩 불균형): {raw}"
+        );
+        assert!(raw.ends_with("</hp:parameters>"), "params close: {raw}");
     }
 
     #[test]
@@ -7244,7 +7521,7 @@ mod tests {
           </hp:subList>
         </hp:drawText>
         <hp:sz width="2600" height="2600" protect="1"/>
-        <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="1" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="1" holdAnchorAndSO="1" vertRelTo="PARA" horzRelTo="PARA"/>
       </hp:rect>
       <hp:t/>
     </hp:run>
@@ -7261,9 +7538,132 @@ mod tests {
         assert!(rect.common.size_protect);
         assert!(rect.common.flow_with_text);
         assert!(rect.common.allow_overlap);
+        // holdAnchorAndSO="1" → prevent_page_break 이 비표 개체에서도 되읽혀야 한다.
+        assert_eq!(rect.common.prevent_page_break, 1);
         assert_eq!(
             rect.common.text_flow,
             crate::model::shape::TextFlow::RightOnly
+        );
+    }
+
+    #[test]
+    fn test_parse_line_preserves_is_reverse_hv() {
+        // <hp:line isReverseHV="1"> → LineShape.started_right_or_bottom.
+        // 종전엔 파서가 isReverseHV 를 읽지 않아 방향 반전이 유실됐다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:line id="1" zOrder="0" textWrap="SQUARE" textFlow="BOTH_SIDES" isReverseHV="1">
+        <hp:sz width="1000" height="0" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hp:pt0 x="0" y="0"/>
+        <hp:pt1 x="1000" y="0"/>
+      </hp:line>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Line(line) = shape.as_ref() else {
+            panic!("expected line shape");
+        };
+        assert!(
+            line.started_right_or_bottom,
+            "isReverseHV=\"1\" 이 started_right_or_bottom 로 되읽혀야 함"
+        );
+    }
+
+    #[test]
+    fn test_parse_ole_preserves_extent_and_draw_aspect() {
+        // <hc:extent> 원본 개체 크기와 drawAspect(표시 방식)가 IR 로 되읽혀야 한다.
+        // 종전엔 extent 를 7200 으로 하드코딩하고 drawAspect 를 읽지 않아,
+        // 모든 OLE 이 7200x7200 / CONTENT 로 왕복에서 뭉개졌다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" drawAspect="ICON" binaryItemIDRef="ole1">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hc:extent x="12345" y="6789"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape");
+        };
+        assert_eq!(ole.extent_x, 12345, "hc:extent x 가 보존돼야 함");
+        assert_eq!(ole.extent_y, 6789, "hc:extent y 가 보존돼야 함");
+        assert_eq!(
+            ole.drawing_aspect,
+            crate::model::shape::OleDrawingAspect::Icon,
+            "drawAspect=ICON 이 보존돼야 함"
+        );
+    }
+
+    #[test]
+    fn test_shape_img_brush_preserves_image_ref_and_mode() {
+        // [#2563] 도형 <hc:imgBrush> 의 <hc:img> 자식과 12종 mode 매핑.
+        // 종전엔 mode 4종만 받아 TOTAL 이 TILE 로 붕괴했고, <hc:img> arm 이 없어
+        // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌다. bin_data_id 가
+        // 0 이면 직렬화가 <hc:img> 를 못 내므로 이미지 도형이 빈 도형이 된다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:rect id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hc:fillBrush>
+          <hc:imgBrush mode="TOTAL">
+            <hc:img binaryItemIDRef="image3" bright="10" contrast="-5" effect="GRAY_SCALE"/>
+          </hc:imgBrush>
+        </hc:fillBrush>
+      </hp:rect>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Rectangle(rect) = shape.as_ref() else {
+            panic!("expected rectangle shape");
+        };
+        let img = rect
+            .drawing
+            .fill
+            .image
+            .as_ref()
+            .expect("imgBrush 는 ImageFill 을 남겨야 함");
+
+        assert_eq!(img.bin_data_id, 3, "binaryItemIDRef 가 보존돼야 함");
+        assert_eq!(img.brightness, 10, "bright 가 보존돼야 함");
+        assert_eq!(img.contrast, -5, "contrast 가 보존돼야 함");
+        assert_eq!(img.effect, 1, "effect=GRAY_SCALE 가 보존돼야 함");
+        assert_eq!(
+            img.fill_mode,
+            crate::model::style::ImageFillMode::Total,
+            "mode=TOTAL 이 TILE 로 붕괴하면 안 됨"
         );
     }
 
@@ -7322,5 +7722,16 @@ mod tests {
         let xml = r#"<?xml version="1.0"?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"/>"#;
         let section = parse_hwpx_section(xml).unwrap();
         assert!(section.paragraphs.is_empty());
+    }
+
+    #[test]
+    fn parse_field_type_accepts_toc() {
+        // 직렬화기(hwpx/field.rs)가 방출하는 "TOC" 가 TableOfContents 로 파싱돼야
+        // hwpx 왕복에서 차례 필드 타입이 Unknown 으로 유실되지 않는다.
+        assert_eq!(parse_field_type("TOC"), FieldType::TableOfContents);
+        assert_eq!(
+            parse_field_type("TABLE_OF_CONTENTS"),
+            FieldType::TableOfContents
+        );
     }
 }

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -29,12 +29,13 @@ use std::io::Write;
 use quick_xml::Writer;
 
 use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, TextFlow, TextWrap, VertAlign, VertRelTo,
+    CommonObjAttr, HorzAlign, HorzRelTo, SizeCriterion, TextFlow, TextWrap, VertAlign, VertRelTo,
 };
 use crate::model::table::{Cell, Table, TablePageBreak, VerticalAlign};
 
 use super::context::SerializeContext;
 use super::section::{render_hp_p_open, render_paragraph_parts};
+use super::shape::numbering_type_str;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
 
@@ -73,7 +74,14 @@ pub fn write_table<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "TABLE"),
+            // [#2697] numberingType 은 IR(common.numbering_type)을 보존한다. 종전 "TABLE"
+            // 하드코딩은 표에 그림 번호 캡션을 붙인 문서(numberingType="PICTURE")에서
+            // 저장 시 번호 범주를 되돌려 문서 전체 캡션 번호를 재배치시켰다. 도형 계열은
+            // 이미 #1379 에서 IR 보존으로 정리됐다(shape.rs:70,172,291,367).
+            (
+                "numberingType",
+                numbering_type_str(table.common.numbering_type),
+            ),
             ("textWrap", text_wrap),
             ("textFlow", text_flow),
             ("lock", lock),
@@ -118,17 +126,45 @@ pub fn write_table<W: Write>(
 fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
     let width = c.width.to_string();
     let height = c.height.to_string();
+    // [#2697] widthRelTo/heightRelTo/protect 는 IR 을 보존한다. 종전 "ABSOLUTE"/"0"
+    // 하드코딩은 파서가 이미 읽어 둔 값(section.rs:1689/1693)을 저장 때 버려, 단/쪽/문단에
+    // 맞춘 표가 절대값으로 바뀌고 크기 보호가 풀렸다. 이웃 write_pos 는 이미 모든 필드를
+    // enum 헬퍼로 통과시킨다. 같은 hp:sz 를 다루는 form.rs:178-188 도 3속성 모두 보존한다.
     empty_tag(
         w,
         "hp:sz",
         &[
             ("width", &width),
-            ("widthRelTo", "ABSOLUTE"),
+            ("widthRelTo", size_criterion_str(c.width_criterion)),
             ("height", &height),
-            ("heightRelTo", "ABSOLUTE"),
-            ("protect", "0"),
+            ("heightRelTo", height_criterion_str(c.height_criterion)),
+            ("protect", bool01(c.size_protect)),
         ],
     )
+}
+
+/// 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+fn size_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로(section.rs:1693)
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다. HWP5 측 `height_criterion_to_bits` 도 동일하게 접는다
+/// (`common_obj_attr_writer.rs:160`).
+fn height_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), SerializeError> {
@@ -148,7 +184,11 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
             // treatAsChar 표의 1→0 케이스에서 0→1 드롭으로 표 partial-split 임계를 흔들어
             // 페이지네이션이 달라졌다(IR-invisible). #1594 holdAnchorAndSO 와 동형.
             ("flowWithText", bool01(c.flow_with_text)),
-            ("allowOverlap", "0"),
+            // allowOverlap 는 IR(allow_overlap)을 보존한다. 이웃 flowWithText(#1637)·
+            // holdAnchorAndSO(#1594)는 이미 IR 보존으로 고쳐졌는데 그 사이 allowOverlap 만
+            // "0" 하드코딩으로 남아, "개체 겹침 허용"이 켜진 플로팅 표가 저장 시 1→0 으로
+            // 드롭됐다(IR-invisible). shape.rs·picture.rs 의 write_pos 와 동형으로 방출.
+            ("allowOverlap", bool01(c.allow_overlap)),
             ("holdAnchorAndSO", hold),
             ("vertRelTo", vert_rel_to_str(c.vert_rel_to)),
             ("horzRelTo", horz_rel_to_str(c.horz_rel_to)),
@@ -235,6 +275,7 @@ fn write_cell<W: Write>(
     let has_margin = bool01(cell.apply_inner_margin);
     let protect = bool01(cell.cell_protect());
     let editable = bool01(cell.editable_in_form());
+    let dirty = bool01(cell.dirty_flag);
     let border_ref = cell.border_fill_id.to_string();
 
     start_tag_attrs(
@@ -246,7 +287,7 @@ fn write_cell<W: Write>(
             ("hasMargin", has_margin),
             ("protect", protect),
             ("editable", editable),
-            ("dirty", "0"),
+            ("dirty", dirty),
             ("borderFillIDRef", &border_ref),
         ],
     )?;
@@ -541,6 +582,54 @@ mod tests {
         t
     }
 
+    #[test]
+    fn cell_text_direction_survives_hwpx_roundtrip() {
+        use crate::model::control::Control;
+        // 세로쓰기 셀(text_direction=1)이 HWPX 왕복에서 보존돼야 한다. serializer 는
+        // 셀 <hp:subList> 에 textDirection 을 방출하지만, 종전엔 파서가 subList 에서
+        // vertAlign 만 읽어 세로쓰기가 유실됐다. (유효한 DocInfo 를 위해 표 샘플 사용.)
+        let find_first_table = |doc: &Document| -> usize {
+            doc.sections
+                .iter()
+                .flat_map(|s| &s.paragraphs)
+                .flat_map(|p| &p.controls)
+                .filter(|c| matches!(c, Control::Table(_)))
+                .count()
+        };
+
+        let bytes0 = std::fs::read("samples/hwpx/basic-table-01.hwpx").expect("샘플 읽기");
+        let mut doc = crate::parser::hwpx::parse_hwpx(&bytes0).expect("샘플 파싱");
+        assert!(find_first_table(&doc) >= 1, "샘플에 표가 있어야 함");
+
+        // 첫 표의 첫 셀을 세로쓰기로 설정
+        for section in &mut doc.sections {
+            for para in &mut section.paragraphs {
+                for control in &mut para.controls {
+                    if let Control::Table(table) = control {
+                        table.cells[0].text_direction = 1;
+                    }
+                }
+            }
+        }
+
+        let bytes = crate::serializer::hwpx::serialize_hwpx(&doc).expect("직렬화");
+        let doc2 = crate::parser::hwpx::parse_hwpx(&bytes).expect("재파싱");
+        let table2 = doc2
+            .sections
+            .iter()
+            .flat_map(|s| &s.paragraphs)
+            .flat_map(|p| &p.controls)
+            .find_map(|c| match c {
+                Control::Table(t) => Some(t),
+                _ => None,
+            })
+            .expect("표");
+        assert_eq!(
+            table2.cells[0].text_direction, 1,
+            "세로쓰기 셀 방향(textDirection)이 HWPX 왕복에서 보존돼야 함"
+        );
+    }
+
     fn serialize(table: &Table) -> String {
         let doc = Document::default();
         let mut ctx = SerializeContext::collect_from_document(&doc);
@@ -579,6 +668,62 @@ mod tests {
         let xml = serialize(&t);
         assert!(
             xml.contains(r#"holdAnchorAndSO="0""#),
+            "기본 0: {}",
+            &xml[..xml.len().min(300)]
+        );
+    }
+
+    // ---------- allowOverlap 보존 ----------
+
+    #[test]
+    fn allow_overlap_preserved() {
+        // allowOverlap 는 IR(common.allow_overlap)을 보존해야 한다. 종전 "0" 하드코딩은
+        // 개체 겹침 허용이 켜진 플로팅 표에서 1→0 드롭으로 저장 시 설정을 유실시켰다. RED.
+        let mut t = empty_table(1, 1);
+        t.common.allow_overlap = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"allowOverlap="1""#),
+            "allowOverlap 가 IR 값(1)으로 방출돼야 한다(종전 0 하드코딩): {}",
+            &xml[..xml.len().min(500)]
+        );
+    }
+
+    #[test]
+    fn allow_overlap_zero_when_unset() {
+        // allow_overlap=false 이면 allowOverlap="0" (기존 동작 보존).
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"allowOverlap="0""#),
+            "기본 0: {}",
+            &xml[..xml.len().min(300)]
+        );
+    }
+
+    // ---------- tc dirty 속성 라운드트립 ----------
+
+    #[test]
+    fn tc_dirty_flag_preserved_when_set() {
+        // <hp:tc dirty> 는 파싱은 되지만 직렬화 시 "0"으로 하드코딩되어 있었다.
+        // dirty_flag=true 인 셀은 dirty="1" 로 방출돼야 한다. RED(수정 전에는 실패).
+        let mut t = empty_table(1, 1);
+        t.cells[0].dirty_flag = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"dirty="1""#),
+            "dirty_flag=true 인 셀은 dirty=\"1\" 로 방출돼야 한다: {}",
+            &xml[..xml.len().min(500)]
+        );
+    }
+
+    #[test]
+    fn tc_dirty_flag_zero_when_unset() {
+        // dirty_flag=false(기본) 이면 기존 동작대로 dirty="0" 유지.
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"dirty="0""#),
             "기본 0: {}",
             &xml[..xml.len().min(300)]
         );
@@ -1083,6 +1228,161 @@ mod tests {
         assert_eq!(table_page_break_str(TablePageBreak::None), "NONE");
         assert_eq!(table_page_break_str(TablePageBreak::CellBreak), "TABLE");
         assert_eq!(table_page_break_str(TablePageBreak::RowBreak), "CELL");
+    }
+
+    // ---------- #2697: hp:tbl 크기·번호 범주 속성 라운드트립 ----------
+
+    #[test]
+    fn task2697_sz_criteria_and_protect_emitted_from_ir() {
+        // [#2697] hp:sz 의 widthRelTo/heightRelTo/protect 는 IR 을 보존해야 한다.
+        // 종전 "ABSOLUTE"/"ABSOLUTE"/"0" 하드코딩은 파서가 이미 읽어 둔 값을 버렸다. RED.
+        let mut t = empty_table(1, 1);
+        t.common.width_criterion = SizeCriterion::Column;
+        t.common.height_criterion = SizeCriterion::Paper;
+        t.common.size_protect = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="COLUMN""#),
+            "widthRelTo 가 IR(Column)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"heightRelTo="PAPER""#),
+            "heightRelTo 가 IR(Paper)로 방출돼야 함(현재 ABSOLUTE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        assert!(
+            xml.contains(r#"protect="1""#),
+            "protect 가 IR(size_protect=true)로 방출돼야 함(현재 0 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_sz_defaults_unchanged() {
+        // 기본 IR(Absolute/Absolute/false)은 종전 출력과 동일해야 한다(무변화 보장).
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"widthRelTo="ABSOLUTE""#)
+                && xml.contains(r#"heightRelTo="ABSOLUTE""#)
+                && xml.contains(r#"protect="0""#),
+            "기본값 출력이 바뀌면 안 됨: {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
+    fn task2697_numbering_type_emitted_from_ir() {
+        // [#2697] numberingType 은 IR 을 보존해야 한다. 종전 "TABLE" 리터럴. RED.
+        use crate::model::shape::ObjectNumberingType;
+        let mut t = empty_table(1, 1);
+        t.common.numbering_type = ObjectNumberingType::Picture;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"numberingType="PICTURE""#),
+            "numberingType 이 IR(Picture)로 방출돼야 함(현재 TABLE 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+        // 기본값(Table)은 종전 출력과 동일.
+        let mut t2 = empty_table(1, 1);
+        t2.common.numbering_type = ObjectNumberingType::Table;
+        assert!(serialize(&t2).contains(r#"numberingType="TABLE""#));
+    }
+
+    #[test]
+    fn task2697_tbl_attrs_survive_xml_ir_xml_roundtrip() {
+        // XML → IR → XML 전 구간. 파서 arm 부재(protect/numberingType)와 방출 하드코딩이
+        // 모두 걸리는 통합 케이스.
+        use crate::model::shape::ObjectNumberingType;
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl numberingType="PICTURE" textWrap="TOP_AND_BOTTOM" pageBreak="CELL"
+            repeatHeader="0" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0"
+            noAdjust="0">
+      <hp:sz width="42520" widthRelTo="COLUMN" height="10000" heightRelTo="PAPER" protect="1"/>
+      <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0"
+              vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT"
+              vertOffset="0" horzOffset="0"/>
+      <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0">
+          <hp:cellAddr colAddr="0" rowAddr="0"/>
+          <hp:cellSpan colSpan="1" rowSpan="1"/>
+          <hp:cellSz width="42520" height="10000"/>
+        </hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(src).expect("파싱");
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(t) => t.as_ref().clone(),
+            other => panic!("표가 아님: {other:?}"),
+        };
+
+        // IR 단계 — 파서가 4속성을 모두 읽어야 한다.
+        assert_eq!(
+            table.common.width_criterion,
+            SizeCriterion::Column,
+            "widthRelTo=COLUMN 이 IR 에 남아야 함"
+        );
+        assert_eq!(
+            table.common.height_criterion,
+            SizeCriterion::Paper,
+            "heightRelTo=PAPER 가 IR 에 남아야 함"
+        );
+        assert!(
+            table.common.size_protect,
+            "protect=1 이 IR(size_protect)에 남아야 함(파서 arm 누락)"
+        );
+        assert_eq!(
+            table.common.numbering_type,
+            ObjectNumberingType::Picture,
+            "numberingType=PICTURE 가 IR 에 남아야 함(파서 arm 누락)"
+        );
+        // numberingType 이 TABLE 이 아니므로 "표 번호" attr 비트는 서지 않는다.
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "PICTURE 번호 표에 TABLE 번호 비트가 서면 IR 모순: {:#010x}",
+            table.common.attr
+        );
+
+        // 방출 단계 — 4속성이 그대로 되살아나야 한다.
+        let xml = serialize(&table);
+        for expected in [
+            r#"numberingType="PICTURE""#,
+            r#"widthRelTo="COLUMN""#,
+            r#"heightRelTo="PAPER""#,
+            r#"protect="1""#,
+        ] {
+            assert!(xml.contains(expected), "{expected} 유실: {xml}");
+        }
+    }
+
+    #[test]
+    fn task2697_height_criterion_str_is_exact_inverse_of_parser() {
+        // 파서는 높이를 parse_size_criterion(_, allow_column_para=false) 로 읽으므로
+        // (section.rs:1693) 치역이 {Paper, Page, Absolute} 3값뿐이다. 방출이 COLUMN/PARA 를
+        // 내면 재파싱 시 Absolute 로 접혀 왕복이 비가역이 된다. 너비만 5값 전체를 낸다.
+        assert_eq!(height_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(height_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(height_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Column), "ABSOLUTE");
+        assert_eq!(height_criterion_str(SizeCriterion::Para), "ABSOLUTE");
+
+        assert_eq!(size_criterion_str(SizeCriterion::Paper), "PAPER");
+        assert_eq!(size_criterion_str(SizeCriterion::Page), "PAGE");
+        assert_eq!(size_criterion_str(SizeCriterion::Column), "COLUMN");
+        assert_eq!(size_criterion_str(SizeCriterion::Para), "PARA");
+        assert_eq!(size_criterion_str(SizeCriterion::Absolute), "ABSOLUTE");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

이슈 #2948 — HWPX 표 셀(`<hp:tc>`)의 `dirty` 속성이 파서에서 읽히지 않고, 직렬화기는
값과 무관하게 항상 `dirty="0"` 을 하드코딩해 방출하던 문제를 수정했습니다. lock,
reverse, dropCapStyle, groupLevel, numberingType, fieldid 등과 같은 "parsed but
hardcoded" 계열 반복 패턴입니다.

## 변경

- `src/model/table.rs` — `Cell` 에 `pub dirty_flag: bool` 추가 (템플릿 기반 신규 셀
  생성 경로는 `false` 로 초기화).
- `src/parser/hwpx/section.rs` — `parse_table_cell` 에
  `b"dirty" => cell.dirty_flag = parse_bool(&attr),` 추가.
- `src/serializer/hwpx/table.rs` — 하드코딩된 `("dirty", "0")` 을
  `("dirty", dirty)` (`dirty = bool01(cell.dirty_flag)`) 로 교체.
- `src/diagnostics/ir_field_sweep.rs` — `sweep_cell` 의 `Cell` 전수 구조 분해에 새
  필드 `dirty_flag` 반영 (새 필드 추가로 인한 컴파일 브레이크 방지).

## red→green 테스트

`src/serializer/hwpx/table.rs::tests`
- `tc_dirty_flag_preserved_when_set` — `dirty_flag=true` 인 셀이 `dirty="1"` 로
  직렬화되는지 확인 (수정 전에는 항상 `dirty="0"` 하드코딩이라 실패).
- `tc_dirty_flag_zero_when_unset` — 기본값(false)에서는 `dirty="0"` 유지 확인.

## 검증

- `cargo check --lib` 통과
- `cargo test --lib tc_dirty_flag` — 2 passed
- `rustfmt --edition 2021` — 변경 파일 전부 포맷 위반 없음

## 참고

포크(kevin9327/rhwp)가 devel 대비 다소 뒤처져 있어(`708ab239` 기준), 이 브랜치를
`fork/devel` 위에서 작업했습니다. `src/diagnostics/ir_field_sweep.rs` 는 fork 기준
시점에 존재하지 않던 파일이라 병합 시 add/add 형태로 나타날 수 있습니다 — 병합 시
현재 devel의 `ir_field_sweep.rs` 최신본을 기준으로 `dirty_flag` 필드만 추가하면
됩니다(diff 자체는 2줄).

상세 작업 보고서: `mydocs/report/task_m100_2948_report.md`