### PR TITLE
fix(hwpx): borderFill threeD/shadow 속성이 저장 시 0으로 고정되던 문제 수정 (#2965)

### DIFF
--- a/mydocs/report/task_m100_2965_report.md
+++ b/mydocs/report/task_m100_2965_report.md
@@ -1,0 +1,74 @@
+# Task m100-2965: HWPX borderFill threeD/shadow 라운드트립 소실 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2965
+
+## 근거
+
+HWP5 바이너리 BORDER_FILL 레코드(스펙 표 23/24)는 속성 UINT16 을 그대로
+`BorderFill.attr` 필드에 보존한다(`src/parser/doc_info.rs:318`
+`parse_border_fill`). 표 24 에 따르면:
+
+- bit 0: 3D 효과 유무
+- bit 1: 그림자 효과 유무
+- bit 2~13: slash/backSlash 대각선 모양·꺾은선·회전·중심선
+
+그런데 `src/serializer/hwpx/header.rs` 의 `write_border_fill` (수정 전)은
+`<hh:borderFill>` 의 `threeD`/`shadow` 두 속성을 `attr` 비트를 읽지 않고 항상
+상수 `"0"` 으로 방출했다.
+
+```rust
+// 수정 전
+&[
+    ("id", &(id + 1).to_string()),
+    ("threeD", "0"),
+    ("shadow", "0"),
+    ("centerLine", center_line_type(bf)),
+    ("breakCellSeparateLine", "0"),
+]
+```
+
+같은 함수 안에서 대각선(bit 2~13)은 `attr` 에서 정확히 역매핑되고 있어
+threeD/shadow(bit 0/1) 만 예외적으로 하드코딩되어 있었다. HWP5→HWPX 저장
+경로에서 3D 테두리 또는 그림자 효과가 걸린 borderFill 을 저장하면 항상
+`threeD="0" shadow="0"` 으로 덮어써져 효과가 소실된다.
+
+동일 클래스 결함이 최근 numbering(`numFormat`, #2947), bullet paraHead(#2828),
+style langID/lockForm(#2839) 에서 반복 발견·수정된 "파서는 실값을 필드에
+보존하지만 직렬화기가 상수로 되돌린다" 패턴과 같다.
+
+## 재현 (수정 전, red)
+
+```rust
+let mut bf = BorderFill::default();
+bf.attr = 0b11; // bit0(3D)=1, bit1(shadow)=1
+// write_border_fill 재방출 시:
+// 수정 전: threeD="0" shadow="0" (attr 값 무시, 유실)
+```
+
+## 수정 내용
+
+`src/serializer/hwpx/header.rs` `write_border_fill` — `effective_border_fill_attr(bf)`
+로 얻은 유효 attr 값에서 bit0/bit1 을 읽어 `threeD`/`shadow` 속성을 방출하도록
+변경. 기존 `bool01()` 헬퍼(같은 파일 내 이미 존재)를 재사용해 "1"/"0" 문자열로
+변환.
+
+## 검증 (green)
+
+새 테스트 `write_border_fill_preserves_three_d_and_shadow_bits`
+(`src/serializer/hwpx/header.rs`)가 `attr=0b11` 일 때 `threeD="1"`/`shadow="1"`
+이 방출되는지 확인한다.
+
+```
+test serializer::hwpx::header::tests::write_border_fill_preserves_three_d_and_shadow_bits ... ok
+
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2522 filtered out; finished in 0.00s
+```
+
+`cargo check --lib` 통과. `rustfmt --edition 2021` 적용 완료.
+
+## 잔여 범위
+
+`breakCellSeparateLine` 은 스펙 표 24 범위 밖 별도 필드로, 이번 수정에서는
+다루지 않는다(별도 조사 필요 시 후속 이슈로 분리).

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -339,6 +339,10 @@ fn write_border_fill<W: Write>(
     ctx: &SerializeContext,
 ) -> Result<(), SerializeError> {
     let attr = effective_border_fill_attr(bf);
+    // [#2965] 표 24 bit0=3D 효과, bit1=그림자 효과 — 파서가 attr 에 보존하는
+    // 실값을 read_border_fill 이 되돌리지 않고 상수로 방출하던 결함 수정.
+    let three_d = bool01(attr & 1 != 0);
+    let shadow = bool01(attr & (1 << 1) != 0);
 
     // 속성 순서 (BorderFillType.cpp:64-68): id, threeD, shadow, centerLine, breakCellSeparateLine
     start_tag_attrs(
@@ -346,8 +350,8 @@ fn write_border_fill<W: Write>(
         "hh:borderFill",
         &[
             ("id", &(id + 1).to_string()), // HWPX 관찰: id는 1-based
-            ("threeD", "0"),
-            ("shadow", "0"),
+            ("threeD", three_d),
+            ("shadow", shadow),
             ("centerLine", center_line_type(bf)),
             ("breakCellSeparateLine", "0"),
         ],
@@ -1638,6 +1642,29 @@ mod tests {
         assert!(
             xml.contains(r#"<hh:backSlash type="CENTER_BELOW" Crooked="0" isCounter="0"/>"#),
             "backSlash 방향 비트가 CENTER_BELOW로 보존되어야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn write_border_fill_preserves_three_d_and_shadow_bits() {
+        // [#2965] bf.attr bit0=3D, bit1=그림자. 종전엔 threeD/shadow 가 항상
+        // "0" 으로 하드코딩되어 파서가 보존한 값이 왕복에서 소실됐다.
+        let mut bf = BorderFill::default();
+        bf.attr = 0b11; // bit0(3D)=1, bit1(shadow)=1
+
+        let mut writer = Writer::new(Vec::new());
+        write_border_fill(
+            &mut writer,
+            0,
+            &bf,
+            &SerializeContext::collect_from_document(&Default::default()),
+        )
+        .expect("write borderFill");
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(r#"threeD="1""#) && xml.contains(r#"shadow="1""#),
+            "attr bit0/bit1 이 threeD/shadow 로 방출돼야 함: {xml}"
         );
     }
 


### PR DESCRIPTION
## 요약

- `BorderFill.attr` bit0(3D 효과)/bit1(그림자 효과)(스펙 표 24)는 파서가 실값을
  보존하지만, `src/serializer/hwpx/header.rs`의 `write_border_fill`이
  `threeD`/`shadow`를 항상 `"0"`으로 하드코딩해 왕복 시 소실됐다.
- 같은 함수 안 대각선(bit 2~13)은 이미 `attr`에서 정확히 역매핑되고 있어
  threeD/shadow만 예외적으로 남아있던 결함.
- Fixes #2965

## Red → Green

수정 전: `bf.attr = 0b11`(3D+그림자 on)로 `write_border_fill` 호출 시
`threeD="0" shadow="0"`이 방출됨(파서가 읽은 값 무시).

수정 후: `attr` bit0/bit1을 읽어 `threeD`/`shadow`를 방출.

```
test serializer::hwpx::header::tests::write_border_fill_preserves_three_d_and_shadow_bits ... ok
```

## 검증

- `cargo check --lib` 통과
- `rustfmt --edition 2021` 적용
- 신규 테스트 1건 추가, green 확인

## 문서

`mydocs/report/task_m100_2965_report.md`