### PR TITLE
fix(document_core): HWPX→HWP 그림 캡션 attr 비트 + BinData remap 잔여 수정

### DIFF
--- a/mydocs/report/task_m100_2767_report.md
+++ b/mydocs/report/task_m100_2767_report.md
@@ -1,0 +1,103 @@
+# #2767 처리 결과 — HWPX→HWP 그림 캡션 attr 비트 + BinData remap 잔여 수정
+
+## 사전 확인 — devel 은 이미 일부를 포함하고 있었다
+
+작업 시작 시 `origin/devel`을 다시 fetch해 확인한 결과, 이슈 본문이 결함 B로
+지목한 것 중 **`Control::Picture`의 캡션 remap과 `Control::Table`의 캡션 remap은
+이미 devel에 존재**했다(주석에 `[#2736]` 태그, `table_caption_picture_bin_ref_is_remapped`·
+`picture_caption_picture_bin_ref_is_remapped` 테스트도 이미 있음). 이슈가 미리
+고지한 병행 PR #2749(같은 파일)는 `gh pr view 2749`로 **CLOSED, mergedAt: null**
+(미머지)임을 확인했으므로, 이 부분은 #2749가 아닌 다른 경로로 이미 devel에
+반영된 것으로 보인다.
+
+실제로 남아 있던 것만 수정 범위로 좁혔다:
+
+- **결함 A** (전부 미해결) — 그림 CTRL_HEADER의 캡션 attr 비트(bit 29)
+- **결함 B 잔여** — `remap_bin_refs_in_control`의 `Control::HiddenComment` arm 부재,
+  `remap_bin_refs_in_shape`의 `ShapeObject::Picture`(그룹 내부 그림) 캡션 미재귀
+  (`ShapeObject::Picture`는 `drawing_mut()`이 항상 `None`이라 공통 caption remap
+  경로를 타지 않음 — 모델상 `DrawingObjAttr`를 갖지 않고 `Picture` 자신의
+  `caption` 필드를 직접 가짐)
+
+## 수정
+
+`src/document_core/converters/hwpx_to_hwp.rs` 한 파일:
+
+1. **결함 A**: `materialize_picture_caption_common_attr()` 신설 — 그림에 캡션이
+   있고 bit29가 아직 꺼져 있으면 **OR**(recompute 아님)한다. 표처럼
+   `pack_common_attr_bits(...)`로 재계산하면 표 전용 비트를 그림에 강제로 얹는
+   회귀가 되므로, HWPX 파서가 이미 채운 `common.attr`에 비트만 얹는다.
+   `adapt_paragraph_with_context`의 `Control::Picture` arm에서 캡션 문단 보강
+   직후 호출. `AdapterReport`에 `picture_caption_common_attr_materialized`
+   카운터 추가 + `changed_anything()` 합산.
+2. **결함 B 잔여**: `remap_bin_refs_in_control`에 `Control::HiddenComment` arm
+   추가(adapt 워크·border-fill 워크는 이미 #2467 근거로 처리 중이던 것과 동형).
+   `remap_bin_refs_in_shape`의 `ShapeObject::Picture` arm에 `pic.caption` 재귀
+   추가(그룹 내부 그림 캡션).
+
+이슈 §A-6에 따라 도형(`$rec`)·OLE·연결선 캡션의 attr 비트는 설정하지 않았다 —
+`serializer/control.rs`가 도형 캡션 레코드 자체를 아직 출력하지 않아 자기모순
+레코드가 되기 때문(별도 후속 과제).
+
+## 테스트 (red → green)
+
+기존 `mod tests`에 4건 추가:
+
+- `picture_caption_common_attr_bit_is_or_ed_in_when_caption_present` — 캡션이 있는
+  그림의 `common.attr`가 `0x042A_2211` → `0x242A_2211`로 OR됨을 단언 + 멱등성 확인
+- `picture_caption_common_attr_bit_untouched_without_caption` — 캡션이 없으면
+  비트를 건드리지 않음(거짓양성 방지)
+- `hidden_comment_picture_bin_ref_is_remapped` — 숨은설명 안 그림의 `bin_data_id`가
+  remap을 반영함
+- `grouped_picture_caption_bin_ref_is_remapped` — 그룹 내부 그림(`ShapeObject::Picture`)
+  캡션 안 그림의 `bin_data_id`가 remap을 반영함
+
+수정 전 코드(4곳의 fix 부분만 되돌린 상태)로 실행한 결과:
+
+```
+failures:
+    document_core::converters::hwpx_to_hwp::tests::grouped_picture_caption_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::hidden_comment_picture_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::picture_caption_common_attr_bit_is_or_ed_in_when_caption_present
+
+test result: FAILED. 42 passed; 3 failed; 0 ignored; 0 measured; 2481 filtered out
+```
+
+(`picture_caption_common_attr_bit_untouched_without_caption`는 대조군이라 수정과
+무관하게 항상 통과 — 의도된 결과.)
+
+수정 적용 후 재실행:
+
+```
+running 45 tests
+...
+test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 2481 filtered out; finished in 2.84s
+```
+
+red → green을 로컬에서 직접 확인했다.
+
+## 검증 (디스크 제약으로 경량 검증만 수행)
+
+- `cargo check --lib` 통과
+- 신설 테스트 4건 포함 `document_core::converters::hwpx_to_hwp::tests` 모듈 전체
+  (45건) `cargo test --lib`로 실행, 전부 통과(red 확인 1회 + green 확인 2회)
+- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
+  로컬 디스크 여유 공간 제약(빌드 중 완전 소진 1회 발생 — `target/debug/incremental`
+  삭제로 복구)으로 스킵
+- `rustfmt --edition 2021` 적용, `git diff --name-only`로 의도한 파일만 변경됨을
+  확인
+- 이슈 §A-5/§B-3이 제안한 실파일 회귀(`samples/hwp3-sample14-hwp5.hwpx` gso attr
+  비교, "OLE storage 재정렬 + 숨은설명/그림캡션" 동시 보유 실파일)는 재확인하지
+  않았다 — 이슈 §B-3이 그런 조합 문서가 샘플에 없다고 명시하고 있어, 단위 테스트가
+  현재 유일하게 재현 가능한 방법이다.
+
+## 범위 밖
+
+- 도형(`$rec`)·OLE·연결선 캡션의 attr 비트 설정(§A-6) — `serializer/control.rs`
+  소관의 별개 상위 결함
+- collect 측(`collect_bin_order_from_control`)의 HiddenComment 미방문(§B-2) —
+  fallback으로 이미 전단사가 보장되어 결함이 아님(이슈 본문 판정)
+
+## 변경 파일
+
+- `src/document_core/converters/hwpx_to_hwp.rs`

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -103,6 +103,11 @@ pub struct AdapterReport {
     pub master_page_autonum_placeholder_removed: u32,
     /// HWPX 바탕쪽 line shape rendering matrix를 HWP5 size ratio contract로 보정한 횟수
     pub master_page_line_rendering_size_ratio_materialized: u32,
+    /// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29,
+    /// 0x2000_0000) 보강 횟수. 표는 이미 `materialize_table_ctrl_header_attr` 로
+    /// 보강되지만 그림은 빠져 있었다(전 코퍼스 실측 80/80 이 개체 종류와 무관하게
+    /// 이 비트를 요구).
+    pub picture_caption_common_attr_materialized: u32,
 }
 
 impl AdapterReport {
@@ -150,7 +155,8 @@ impl AdapterReport {
                 + self.autonum_fwspace_char_shape_offsets_materialized
                 + self.header_footer_fwspace_control_materialized
                 + self.master_page_autonum_placeholder_removed
-                + self.master_page_line_rendering_size_ratio_materialized)
+                + self.master_page_line_rendering_size_ratio_materialized
+                + self.picture_caption_common_attr_materialized)
                 > 0
     }
 }
@@ -384,11 +390,20 @@ fn collect_bin_order_from_control(
     match ctrl {
         Control::Picture(pic) => {
             push_bin_order(pic.image_attr.bin_data_id, bin_count, order, seen);
+            // [#2736] 그림 캡션 문단도 순회한다. 표 캡션(아래 arm)·도형 캡션
+            // (collect_bin_order_from_shape)은 이미 방문하는데 그림 캡션만 빠져 있어,
+            // 같은 캡션 컨테이너인데 소유 개체 종류에 따라 순회 여부가 갈렸다.
+            if let Some(caption) = &pic.caption {
+                collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
+            }
         }
         Control::Shape(shape) => collect_bin_order_from_shape(shape, bin_count, order, seen),
         Control::Table(table) => {
             for cell in &table.cells {
                 collect_bin_order_from_paragraphs(&cell.paragraphs, bin_count, order, seen);
+            }
+            if let Some(caption) = &table.caption {
+                collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
             }
         }
         Control::Header(header) => {
@@ -437,6 +452,9 @@ fn collect_bin_order_from_shape(
         if let Some(text_box) = &drawing.text_box {
             collect_bin_order_from_paragraphs(&text_box.paragraphs, bin_count, order, seen);
         }
+        if let Some(caption) = &drawing.caption {
+            collect_bin_order_from_paragraphs(&caption.paragraphs, bin_count, order, seen);
+        }
     }
 }
 
@@ -465,11 +483,21 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
     match ctrl {
         Control::Picture(pic) => {
             pic.image_attr.bin_data_id = remap_bin_ref(pic.image_attr.bin_data_id, remap);
+            // [#2736] 그림 캡션 문단 안의 그림도 리맵해야 한다. 미방문 시 캡션 안 그림의
+            // bin_data_id 가 재정렬 이전 번호로 남아 엉뚱한 이미지로 해석된다 —
+            // 표 캡션에 대한 동형 결함이 이미 table_caption_picture_bin_ref_is_remapped
+            // 로 회귀 고정돼 있고, 그림 캡션이 그 미수정 형제였다.
+            if let Some(caption) = &mut pic.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         Control::Shape(shape) => remap_bin_refs_in_shape(shape, remap),
         Control::Table(table) => {
             for cell in &mut table.cells {
                 remap_bin_refs_in_paragraphs(&mut cell.paragraphs, remap);
+            }
+            if let Some(caption) = &mut table.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
             }
         }
         Control::Header(header) => remap_bin_refs_in_paragraphs(&mut header.paragraphs, remap),
@@ -478,6 +506,12 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
             remap_bin_refs_in_paragraphs(&mut footnote.paragraphs, remap)
         }
         Control::Endnote(endnote) => remap_bin_refs_in_paragraphs(&mut endnote.paragraphs, remap),
+        // [#2767] adapt 워크·border-fill 워크는 이미 HiddenComment 를 방문한다
+        // (#2467 근거). remap 워크만 빠져 있어 숨은설명 안 그림이 재정렬 후
+        // 엉뚱한 이미지를 가리키는 채로 남았다.
+        Control::HiddenComment(comment) => {
+            remap_bin_refs_in_paragraphs(&mut comment.paragraphs, remap)
+        }
         _ => {}
     }
 }
@@ -486,6 +520,12 @@ fn remap_bin_refs_in_shape(shape: &mut ShapeObject, remap: &[u16]) {
     match shape {
         ShapeObject::Picture(pic) => {
             pic.image_attr.bin_data_id = remap_bin_ref(pic.image_attr.bin_data_id, remap);
+            // [#2767] 그룹 내부 그림(ShapeObject::Picture)은 drawing_mut()이 항상
+            // None 이라(모델상 DrawingObjAttr 를 갖지 않음) 아래 공통 캡션 remap
+            // 경로를 타지 않는다. Picture 자신의 caption 필드를 직접 재귀해야 한다.
+            if let Some(caption) = &mut pic.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         ShapeObject::Ole(ole) => {
             if let Ok(id) = u16::try_from(ole.bin_data_id) {
@@ -504,6 +544,9 @@ fn remap_bin_refs_in_shape(shape: &mut ShapeObject, remap: &[u16]) {
         remap_bin_ref_in_fill(&mut drawing.fill, remap);
         if let Some(text_box) = &mut drawing.text_box {
             remap_bin_refs_in_paragraphs(&mut text_box.paragraphs, remap);
+        }
+        if let Some(caption) = &mut drawing.caption {
+            remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
         }
     }
 }
@@ -705,6 +748,14 @@ fn collect_object_border_fill_refs(doc: &Document) -> std::collections::HashSet<
         for para in &section.paragraphs {
             collect_object_border_fill_refs_from_paragraph(para, &mut refs);
         }
+        // 바탕쪽(master page) 문단 안 개체 참조도 수집한다. bin 워크
+        // (materialize_hwp5_bin_data_order, remap_bin_refs_in_doc)와 adapt 워크가
+        // 이미 바탕쪽을 순회하는데 이 collect 워크만 빠져 있었다.
+        for master_page in &section.section_def.master_pages {
+            for para in &master_page.paragraphs {
+                collect_object_border_fill_refs_from_paragraph(para, &mut refs);
+            }
+        }
     }
     refs
 }
@@ -717,6 +768,48 @@ fn collect_object_border_fill_refs_from_paragraph(
         match ctrl {
             Control::Table(table) => collect_table_border_fill_refs(table, refs),
             Control::Shape(shape) => collect_object_border_fill_refs_from_shape(shape, refs),
+            // [#2736] 그림 캡션 문단 안 개체 참조도 수집한다. `Control::Picture` arm 자체가
+            // 없어 표 캡션(collect_table_border_fill_refs)·도형 캡션
+            // (collect_object_border_fill_refs_from_shape)과 달리 그림 캡션만 빠져 있었고,
+            // 미수집 시 normalize_paragraph_char_border_fills 가드가 실패해 캡션 안 개체
+            // 채우기가 no-fill 로 정규화된다(#2467 과 동일 메커니즘).
+            Control::Picture(pic) => {
+                if let Some(caption) = &pic.caption {
+                    for p in &caption.paragraphs {
+                        collect_object_border_fill_refs_from_paragraph(p, refs);
+                    }
+                }
+            }
+            // 각주/미주/숨은설명 문단 안의 개체도 border_fill 을 참조할 수 있다.
+            // 이 참조가 수집되지 않으면 normalize_paragraph_char_border_fills 의
+            // 가드가 실패해, 문단 char-border 와 공유된 border_fill 이 no-fill 로
+            // 정규화되어 컨테이너 안 개체의 채우기가 유실된다(#2467 adapt 워크와 동형).
+            Control::Footnote(footnote) => {
+                for p in &footnote.paragraphs {
+                    collect_object_border_fill_refs_from_paragraph(p, refs);
+                }
+            }
+            Control::Endnote(endnote) => {
+                for p in &endnote.paragraphs {
+                    collect_object_border_fill_refs_from_paragraph(p, refs);
+                }
+            }
+            Control::HiddenComment(comment) => {
+                for p in &comment.paragraphs {
+                    collect_object_border_fill_refs_from_paragraph(p, refs);
+                }
+            }
+            // 머리말/꼬리말 문단 안 개체도 다른 워크(bin order/remap, adapt)와 동일하게 순회.
+            Control::Header(header) => {
+                for p in &header.paragraphs {
+                    collect_object_border_fill_refs_from_paragraph(p, refs);
+                }
+            }
+            Control::Footer(footer) => {
+                for p in &footer.paragraphs {
+                    collect_object_border_fill_refs_from_paragraph(p, refs);
+                }
+            }
             _ => {}
         }
     }
@@ -729,6 +822,13 @@ fn collect_object_border_fill_refs_from_shape(
     if let Some(drawing) = shape.drawing() {
         if let Some(text_box) = &drawing.text_box {
             for para in &text_box.paragraphs {
+                collect_object_border_fill_refs_from_paragraph(para, refs);
+            }
+        }
+        // 도형 캡션 문단 안 개체 참조도 수집(bin order/remap 워크와 동형).
+        // #2483 은 표 캡션을 다뤘고, 이 도형 drawing.caption 은 별개 경로다.
+        if let Some(caption) = &drawing.caption {
+            for para in &caption.paragraphs {
                 collect_object_border_fill_refs_from_paragraph(para, refs);
             }
         }
@@ -755,6 +855,12 @@ fn collect_table_border_fill_refs(table: &Table, refs: &mut std::collections::Ha
             refs.insert(cell.border_fill_id);
         }
         for para in &cell.paragraphs {
+            collect_object_border_fill_refs_from_paragraph(para, refs);
+        }
+    }
+    // 표 캡션 문단 안의 개체 참조도 수집(#2467 과 동일 근거).
+    if let Some(caption) = &table.caption {
+        for para in &caption.paragraphs {
             collect_object_border_fill_refs_from_paragraph(para, refs);
         }
     }
@@ -826,10 +932,33 @@ fn adapt_paragraph_with_context(
                 ParagraphContext::HeaderFooter,
             ),
             Control::Picture(pic) => {
-                adapt_picture_href_ctrl_data(pic, &mut ctrl_data_records[idx], report)
+                adapt_picture_href_ctrl_data(pic, &mut ctrl_data_records[idx], report);
+                // [#2736] 그림 캡션 문단도 보강한다. 표 캡션은 adapt_table_with_context 가
+                // 이미 보강하고, bin order/remap·border_fill 수집 워크는 캡션을 순회하는데
+                // adapt 워크만 그림 캡션을 건너뛰었다. 실측(samples/hwpx/aift.hwpx): 본문
+                // 921/921·표 캡션 2/2 가 방문되는 동안 그림 캡션 9/9 전부 미방문.
+                // 미방문 시 캡션 안 그림 href·표 raw_ctrl_data·수식 보정이 물질화되지 않고
+                // 문단 header tail 도 10바이트로 남아 PARA_HEADER 가 22/24 로 섞인다.
+                if let Some(caption) = &mut pic.caption {
+                    adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
+                }
+                materialize_picture_caption_common_attr(pic, report);
             }
             Control::Shape(shape) => adapt_shape_with_context(shape, report, context),
             Control::Equation(eq) => adapt_equation(eq, report),
+            // 각주/미주/숨은설명 문단도 body 문단과 동일하게 보강해야 한다.
+            // bin 참조 수집·리맵 워크(collect_bin_order/remap_bin_refs)는 이미 이들을
+            // 재귀하므로 adapt 워크만 빠져 있으면, 이 안의 그림 href·표 ctrl_data 등이
+            // 물질화되지 않고 HWPX→HWP 변환 시 유실된다.
+            Control::Footnote(footnote) => {
+                adapt_paragraphs_with_context(&mut footnote.paragraphs, report, context)
+            }
+            Control::Endnote(endnote) => {
+                adapt_paragraphs_with_context(&mut endnote.paragraphs, report, context)
+            }
+            Control::HiddenComment(comment) => {
+                adapt_paragraphs_with_context(&mut comment.paragraphs, report, context)
+            }
             _ => {}
         }
     }
@@ -1162,6 +1291,14 @@ fn adapt_shape_with_context(
             materialize_text_box_hwp5_envelope(text_box, report);
             adapt_paragraphs_with_context(&mut text_box.paragraphs, report, context);
         }
+        // [#2736] 도형 캡션 문단도 보강한다. `DrawingObjAttr` 를 공유하는 사각형·타원·선·호·
+        // 다각형·곡선·글상자·묶음·차트·OLE 이 한 번에 덮인다. 형제 워크
+        // (collect_bin_order_from_shape / remap_bin_refs_in_shape /
+        // collect_object_border_fill_refs_from_shape)는 셋 다 이미 drawing.caption 을
+        // 순회하는데 adapt 워크만 빠져 있었다.
+        if let Some(caption) = &mut drawing.caption {
+            adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
+        }
     }
 
     if let ShapeObject::Group(group) = shape {
@@ -1415,6 +1552,12 @@ fn adapt_table_with_context(
             adapt_paragraph_with_context(cpara, report, context);
         }
     }
+
+    // 표 캡션 문단도 보강한다(#2443 에서 캡션이 bin 리맵 대상임이 확인됨).
+    // 누락 시 캡션 안의 그림 href·중첩 표 ctrl_data 등이 물질화되지 않는다.
+    if let Some(caption) = &mut table.caption {
+        adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
+    }
 }
 
 fn table_requires_cell_width_ref_contract(table: &Table) -> bool {
@@ -1553,6 +1696,27 @@ fn materialize_table_ctrl_header_attr(table: &mut Table, report: &mut AdapterRep
     }
 }
 
+/// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29) 보강.
+///
+/// 전 코퍼스 실측(`samples/**/*.hwp`, 한컴 저작 원본): 캡션 동반 gso 80개(그림 42,
+/// 사각형 33, 연결선 3, OLE 2) 전부 bit 29=1, 캡션 없는 gso 2,674개 전부 bit 29=0.
+/// 개체 종류와 무관하게 캡션 유무만으로 결정된다. HWPX 출처 그림의
+/// `common.attr` 는 파서(`pack_hwpx_common_obj_attr`)가 이미 non-zero로 채우고
+/// 직렬화기가 verbatim 기록하므로, 표처럼 `pack_common_attr_bits(...)`로
+/// **recompute** 하지 않고 비트만 **OR** 한다 — recompute 하면 표 전용 비트를
+/// 그림에 강제로 얹는 회귀가 된다. 멱등: 비트가 이미 켜져 있으면 카운트하지 않음.
+///
+/// 도형(`$rec`/`$con`)·OLE 캡션은 범위 밖이다 — 직렬화기(`serializer/control.rs`)가
+/// 도형 캡션 레코드 자체를 아직 출력하지 않아, 레코드 없이 비트만 켜면 자기모순
+/// 레코드가 된다(별도 후속 과제).
+fn materialize_picture_caption_common_attr(pic: &mut Picture, report: &mut AdapterReport) {
+    const HWP5_GSO_CAPTION_COMMON_ATTR_BIT: u32 = 0x2000_0000;
+    if pic.caption.is_some() && pic.common.attr & HWP5_GSO_CAPTION_COMMON_ATTR_BIT == 0 {
+        pic.common.attr |= HWP5_GSO_CAPTION_COMMON_ATTR_BIT;
+        report.picture_caption_common_attr_materialized += 1;
+    }
+}
+
 /// 셀 `apply_inner_margin` → LIST_HEADER width_ref bit 0 합성 (Stage 3, 보수적).
 ///
 /// ## 배경
@@ -1612,6 +1776,116 @@ pub fn convert_if_hwpx_source(doc: &mut Document, source_format: FileFormat) -> 
 mod tests {
     use super::*;
     use crate::model::paragraph::CharShapeRef;
+
+    #[test]
+    fn border_fill_refs_collected_inside_footnote_and_caption() {
+        use crate::model::footnote::Footnote;
+        use crate::model::shape::Caption;
+
+        // 각주 문단 안 표의 border_fill 이 수집돼야 한다(종전엔 각주 미재귀로 누락).
+        let mut fn_para = Paragraph::default();
+        fn_para.controls.push(Control::Table(Box::new(Table {
+            border_fill_id: 7,
+            ..Default::default()
+        })));
+        let mut footnote = Footnote::default();
+        footnote.paragraphs.push(fn_para);
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Footnote(Box::new(footnote)));
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        });
+        let refs = collect_object_border_fill_refs(&doc);
+        assert!(refs.contains(&7), "각주 안 표의 border_fill 이 수집돼야 함");
+
+        // 표 캡션 문단 안 표의 border_fill 도 수집돼야 한다.
+        let mut cap_para = Paragraph::default();
+        cap_para.controls.push(Control::Table(Box::new(Table {
+            border_fill_id: 9,
+            ..Default::default()
+        })));
+        let mut caption = Caption::default();
+        caption.paragraphs.push(cap_para);
+        let mut tpara = Paragraph::default();
+        tpara.controls.push(Control::Table(Box::new(Table {
+            border_fill_id: 1,
+            caption: Some(caption),
+            ..Default::default()
+        })));
+        let mut doc2 = Document::default();
+        doc2.sections.push(Section {
+            paragraphs: vec![tpara],
+            ..Default::default()
+        });
+        let refs2 = collect_object_border_fill_refs(&doc2);
+        assert!(
+            refs2.contains(&9),
+            "표 캡션 안 표의 border_fill 이 수집돼야 함"
+        );
+    }
+
+    #[test]
+    fn border_fill_refs_collected_inside_header_masterpage_and_shape_caption() {
+        use crate::model::header_footer::{Header, MasterPage};
+        use crate::model::shape::{Caption, RectangleShape, ShapeObject};
+
+        let table_para = |bf: u16| {
+            let mut p = Paragraph::default();
+            p.controls.push(Control::Table(Box::new(Table {
+                border_fill_id: bf,
+                ..Default::default()
+            })));
+            p
+        };
+
+        // 머리말 안 표
+        let mut header = Header::default();
+        header.paragraphs.push(table_para(11));
+        let mut hpara = Paragraph::default();
+        hpara.controls.push(Control::Header(Box::new(header)));
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![hpara],
+            ..Default::default()
+        });
+        assert!(
+            collect_object_border_fill_refs(&doc).contains(&11),
+            "머리말 안 표의 border_fill 이 수집돼야 함"
+        );
+
+        // 바탕쪽(master page) 안 표
+        let mut mp = MasterPage::default();
+        mp.paragraphs.push(table_para(13));
+        let mut sec = Section::default();
+        sec.section_def.master_pages.push(mp);
+        let mut doc2 = Document::default();
+        doc2.sections.push(sec);
+        assert!(
+            collect_object_border_fill_refs(&doc2).contains(&13),
+            "바탕쪽 안 표의 border_fill 이 수집돼야 함"
+        );
+
+        // 도형 캡션 안 표
+        let mut caption = Caption::default();
+        caption.paragraphs.push(table_para(15));
+        let mut rect = RectangleShape::default();
+        rect.drawing.caption = Some(caption);
+        let mut spara = Paragraph::default();
+        spara
+            .controls
+            .push(Control::Shape(Box::new(ShapeObject::Rectangle(rect))));
+        let mut doc3 = Document::default();
+        doc3.sections.push(Section {
+            paragraphs: vec![spara],
+            ..Default::default()
+        });
+        assert!(
+            collect_object_border_fill_refs(&doc3).contains(&15),
+            "도형 캡션 안 표의 border_fill 이 수집돼야 함"
+        );
+    }
 
     #[test]
     fn empty_doc_normalizes_file_header_once() {
@@ -2000,6 +2274,267 @@ mod tests {
         let mut second = AdapterReport::new();
         adapt_paragraph(&mut para, &mut second);
         assert_eq!(second.picture_href_ctrl_data_materialized, 0);
+    }
+
+    #[test]
+    fn picture_href_materializes_inside_footnote_and_caption() {
+        use crate::model::footnote::Footnote;
+        use crate::model::shape::Caption;
+
+        // 각주 문단 안의 그림 href 가 물질화되어야 한다(종전엔 adapt 워크가
+        // 각주를 재귀하지 않아 유실).
+        let mut fn_inner = Paragraph::default();
+        fn_inner.controls.push(Control::Picture(Box::new(Picture {
+            href: Some("http://www.korea.kr;1;0;0;".to_string()),
+            ..Default::default()
+        })));
+        let mut footnote = Footnote::default();
+        footnote.paragraphs.push(fn_inner);
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Footnote(Box::new(footnote)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+        assert_eq!(report.picture_href_ctrl_data_materialized, 1);
+        let Control::Footnote(fnote) = &para.controls[0] else {
+            panic!("expected footnote control");
+        };
+        assert_eq!(
+            fnote.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+
+        // 표 캡션 문단 안의 그림 href 도 물질화되어야 한다.
+        let mut cap_inner = Paragraph::default();
+        cap_inner.controls.push(Control::Picture(Box::new(Picture {
+            href: Some("http://www.korea.kr;1;0;0;".to_string()),
+            ..Default::default()
+        })));
+        let mut caption = Caption::default();
+        caption.paragraphs.push(cap_inner);
+        let mut tpara = Paragraph::default();
+        tpara.controls.push(Control::Table(Box::new(Table {
+            caption: Some(caption),
+            ..Default::default()
+        })));
+
+        let mut treport = AdapterReport::new();
+        adapt_paragraph(&mut tpara, &mut treport);
+        assert_eq!(treport.picture_href_ctrl_data_materialized, 1);
+        let Control::Table(tbl) = &tpara.controls[0] else {
+            panic!("expected table control");
+        };
+        let cap = tbl.caption.as_ref().unwrap();
+        assert_eq!(
+            cap.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+    }
+
+    /// [#2736] adapt 워크가 그림 캡션·도형 캡션 문단을 방문하는지.
+    ///
+    /// 표 캡션은 `adapt_table_with_context` 가 이미 보강하고, bin order/remap·
+    /// border_fill 수집 워크도 캡션을 순회하는데 adapt 워크만 그림/도형 캡션을
+    /// 건너뛰어 캡션 안 그림의 href 가 HWP 저장 시 유실됐다.
+    #[test]
+    fn picture_href_materializes_inside_picture_and_shape_caption() {
+        use crate::model::shape::{Caption, RectangleShape, ShapeObject};
+
+        let href_caption = || {
+            let mut inner = Paragraph::default();
+            inner.controls.push(Control::Picture(Box::new(Picture {
+                href: Some("http://www.korea.kr;1;0;0;".to_string()),
+                ..Default::default()
+            })));
+            Caption {
+                paragraphs: vec![inner],
+                ..Default::default()
+            }
+        };
+
+        // 그림 캡션 문단 안의 그림 href
+        let mut ppara = Paragraph::default();
+        ppara.controls.push(Control::Picture(Box::new(Picture {
+            caption: Some(href_caption()),
+            ..Default::default()
+        })));
+
+        let mut preport = AdapterReport::new();
+        adapt_paragraph(&mut ppara, &mut preport);
+        assert_eq!(
+            preport.picture_href_ctrl_data_materialized, 1,
+            "그림 캡션 문단 안 그림의 href 가 물질화돼야 함(캡션 문단 미방문)"
+        );
+        let Control::Picture(pic) = &ppara.controls[0] else {
+            panic!("expected picture control");
+        };
+        let pcap = pic.caption.as_ref().unwrap();
+        assert_eq!(
+            pcap.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+
+        // 도형 캡션 문단 안의 그림 href (DrawingObjAttr 공유 → 묶음·차트·OLE 동시 적용)
+        let mut rect = RectangleShape::default();
+        rect.drawing.caption = Some(href_caption());
+        let mut spara = Paragraph::default();
+        spara
+            .controls
+            .push(Control::Shape(Box::new(ShapeObject::Rectangle(rect))));
+
+        let mut sreport = AdapterReport::new();
+        adapt_paragraph(&mut spara, &mut sreport);
+        assert_eq!(
+            sreport.picture_href_ctrl_data_materialized, 1,
+            "도형 캡션 문단 안 그림의 href 가 물질화돼야 함(캡션 문단 미방문)"
+        );
+        let Control::Shape(shape) = &spara.controls[0] else {
+            panic!("expected shape control");
+        };
+        let scap = shape.drawing().unwrap().caption.as_ref().unwrap();
+        assert_eq!(
+            scap.paragraphs[0].ctrl_data_records[0]
+                .as_ref()
+                .unwrap()
+                .len(),
+            76
+        );
+    }
+
+    /// [#2736] 그림 캡션 문단 안 그림의 `bin_data_id` 리맵 — 표 캡션에 대한 동형
+    /// 회귀(`table_caption_picture_bin_ref_is_remapped`)의 미수정 형제였다.
+    #[test]
+    fn picture_caption_picture_bin_ref_is_remapped() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+
+        let mut inner_pic = Picture::default();
+        inner_pic.image_attr.bin_data_id = 1;
+        let mut cap_para = Paragraph::default();
+        cap_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let mut outer = Picture::default();
+        outer.image_attr.bin_data_id = 2;
+        outer.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut ctrl = Control::Picture(Box::new(outer));
+
+        // remap: bin id 1 → 2, 2 → 1
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::Picture(outer) = &ctrl else {
+            panic!("expected picture");
+        };
+        assert_eq!(outer.image_attr.bin_data_id, 1);
+        let caption = outer.caption.as_ref().unwrap();
+        let Control::Picture(inner) = &caption.paragraphs[0].controls[0] else {
+            panic!("expected caption picture");
+        };
+        assert_eq!(
+            inner.image_attr.bin_data_id, 2,
+            "그림 캡션 안 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
+    }
+
+    /// [#2736] 그림 캡션 문단 안 개체의 `border_fill` 참조 수집 —
+    /// `collect_object_border_fill_refs_from_paragraph` 에 `Control::Picture` arm 이
+    /// 아예 없어 표 캡션·도형 캡션과 달리 그림 캡션만 빠져 있었다.
+    #[test]
+    fn border_fill_refs_collected_inside_picture_caption() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+
+        let mut cap_para = Paragraph::default();
+        cap_para.controls.push(Control::Table(Box::new(Table {
+            border_fill_id: 17,
+            ..Default::default()
+        })));
+        let mut pic = Picture::default();
+        pic.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut doc = Document::default();
+        doc.sections.push(Section {
+            paragraphs: vec![para],
+            ..Default::default()
+        });
+
+        assert!(
+            collect_object_border_fill_refs(&doc).contains(&17),
+            "그림 캡션 안 표의 border_fill 이 수집돼야 함"
+        );
+    }
+
+    /// [#2736] 실파일 회귀 — 한컴 산출 `aift.hwpx` 의 그림 캡션 문단 9개가 adapt 워크의
+    /// 방문 표식(`materialize_para_header_tail` 의 12바이트 header tail)을 받는지.
+    ///
+    /// 수정 전 실측: 본문 921/921·표 캡션 2/2 는 12바이트, 그림 캡션 9/9 는 파서가 넣은
+    /// 10바이트 그대로 — 직렬화 시 캡션 문단만 PARA_HEADER 22바이트로 갈렸다.
+    #[test]
+    fn aift_picture_caption_paragraphs_are_adapted() {
+        fn count_picture_caption_paragraphs(
+            para: &Paragraph,
+            total: &mut usize,
+            tail12: &mut usize,
+        ) {
+            for ctrl in &para.controls {
+                match ctrl {
+                    Control::Picture(pic) => {
+                        if let Some(caption) = &pic.caption {
+                            for p in &caption.paragraphs {
+                                *total += 1;
+                                if p.raw_header_extra.len() >= 12 {
+                                    *tail12 += 1;
+                                }
+                            }
+                        }
+                    }
+                    Control::Table(table) => {
+                        for cell in &table.cells {
+                            for p in &cell.paragraphs {
+                                count_picture_caption_paragraphs(p, total, tail12);
+                            }
+                        }
+                    }
+                    _ => {}
+                }
+            }
+        }
+
+        let data = std::fs::read("samples/hwpx/aift.hwpx").expect("sample exists");
+        let mut core = crate::document_core::DocumentCore::from_bytes(&data).expect("parse hwpx");
+        convert_hwpx_to_hwp_ir(core.document_mut());
+
+        let mut total = 0usize;
+        let mut tail12 = 0usize;
+        for section in &core.document().sections {
+            for para in &section.paragraphs {
+                count_picture_caption_paragraphs(para, &mut total, &mut tail12);
+            }
+        }
+
+        assert_eq!(total, 9, "aift.hwpx 의 그림 캡션 문단 수");
+        assert_eq!(
+            tail12, total,
+            "그림 캡션 문단이 adapt 워크의 방문 표식(header tail 12바이트)을 받아야 함"
+        );
     }
 
     #[test]
@@ -2740,5 +3275,177 @@ mod tests {
         );
         assert_eq!(para.char_shapes[1].start_pos, 9);
         assert_eq!(para.char_shapes[2].start_pos, 16);
+    }
+
+    /// [bin remap 회귀] HWPX→HWP 변환의 BinData 재정렬 시 표 캡션 문단 안의 그림
+    /// bin_data_id 가 remap 되지 않아 캡션 그림이 엉뚱한 이미지로 해석되던 결함.
+    #[test]
+    fn table_caption_picture_bin_ref_is_remapped() {
+        use crate::model::image::Picture;
+        use crate::model::shape::Caption;
+        use crate::model::table::Table;
+
+        let mut pic = Picture::default();
+        pic.image_attr.bin_data_id = 1;
+        let mut cap_para = Paragraph::default();
+        cap_para.controls.push(Control::Picture(Box::new(pic)));
+        let mut table = Table::default();
+        table.caption = Some(Caption {
+            paragraphs: vec![cap_para],
+            ..Default::default()
+        });
+        let mut ctrl = Control::Table(Box::new(table));
+
+        // remap: bin id 1 → 2
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::Table(table) = &ctrl else {
+            panic!("expected table");
+        };
+        let caption = table.caption.as_ref().unwrap();
+        let Control::Picture(pic) = &caption.paragraphs[0].controls[0] else {
+            panic!("expected caption picture");
+        };
+        assert_eq!(
+            pic.image_attr.bin_data_id, 2,
+            "표 캡션 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
+    }
+
+    // ---------- #2767 결함 A — 그림 캡션 gso CTRL_HEADER 캡션 비트 ----------
+
+    #[test]
+    fn picture_caption_common_attr_bit_is_or_ed_in_when_caption_present() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                // 실측(이슈 §A-2)에서 확인한 파서 값 — 캡션 비트 이전에 이미 non-zero.
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: Some(crate::model::shape::Caption::default()),
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x242A_2211,
+            "캡션이 있으면 bit 29 가 OR 되어야 함(recompute 아님)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 1);
+
+        // 멱등: 다시 적용해도 카운트가 늘지 않아야 함.
+        let mut second = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut second);
+        assert_eq!(second.picture_caption_common_attr_materialized, 0);
+    }
+
+    #[test]
+    fn picture_caption_common_attr_bit_untouched_without_caption() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: None,
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x042A_2211,
+            "캡션이 없으면 bit 29 를 켜면 안 됨(거짓양성 방지)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 0);
+    }
+
+    // ---------- #2767 결함 B(잔여) — HiddenComment · 그룹 내부 그림 캡션 remap ----------
+
+    #[test]
+    fn hidden_comment_picture_bin_ref_is_remapped() {
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut inner_para = Paragraph::default();
+        inner_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let comment = crate::model::control::HiddenComment {
+            paragraphs: vec![inner_para],
+        };
+        let mut ctrl = Control::HiddenComment(Box::new(comment));
+
+        // remap[1] = 2 : bin_data_id 1 을 2 로 재배치.
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::HiddenComment(comment) = &ctrl else {
+            panic!("HiddenComment control expected");
+        };
+        let Control::Picture(pic) = &comment.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside HiddenComment");
+        };
+        assert_eq!(
+            pic.image_attr.bin_data_id, 2,
+            "숨은설명 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
+        );
+    }
+
+    #[test]
+    fn grouped_picture_caption_bin_ref_is_remapped() {
+        // ShapeObject::Picture(그룹 내부 그림)는 drawing_mut()이 None 이라 공통
+        // caption remap 경로를 타지 않는다 — Picture 자신의 caption 을 직접 재귀해야 함.
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut caption_para = Paragraph::default();
+        caption_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let grouped_pic = Picture {
+            caption: Some(crate::model::shape::Caption {
+                paragraphs: vec![caption_para],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut shape = ShapeObject::Picture(Box::new(grouped_pic));
+
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_shape(&mut shape, &remap);
+
+        let ShapeObject::Picture(pic) = &shape else {
+            panic!("Picture shape expected");
+        };
+        let caption = pic.caption.as_ref().expect("caption preserved");
+        let Control::Picture(inner) = &caption.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside caption");
+        };
+        assert_eq!(
+            inner.image_attr.bin_data_id, 2,
+            "그룹 내부 그림 캡션 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
+        );
     }
 }


### PR DESCRIPTION
## 주의 — diff 표시 크기 안내

제 fork(kevin9327/rhwp)의 devel 브랜치가 upstream devel 대비 약 600커밋 정도
뒤처져 있어(로컬 확인: `git rev-list --count fork/devel..origin/devel` = 597),
`src/document_core/converters/hwpx_to_hwp.rs`가 그 사이 upstream에서 크게
바뀐 상태입니다(특히 #2736의 캡션 순회 보강). 그 결과 이 PR의 GitHub diff가
해당 파일에서 실제 변경보다 훨씬 크게(700줄+) 표시될 수 있습니다.

**실제로 이 PR이 추가하는 변경은 아래 "변경" 절에 적은 지점 4곳뿐입니다** —
나머지는 fork가 아직 갖지 못한 upstream 기존 코드가 diff에 함께 실려 보이는
것이며, 이 PR이 그 코드를 새로 작성한 것이 아닙니다. 로컬에서
`git diff origin/devel fe88ebaf -- src/document_core/converters/hwpx_to_hwp.rs`
(제 실제 커밋 대 devel 직접 비교)로는 229줄로 확인됩니다.

## 요약

- #2767 결함 A — 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션
  비트(bit 29, `0x2000_0000`)가 설정되지 않던 문제.
- #2767 결함 B 잔여 — BinData 재정렬 시 숨은설명 안 그림, 그룹 내부 그림
  (`ShapeObject::Picture`) 캡션 안 그림의 `bin_data_id`가 remap되지 않던 문제.
  (`Control::Picture`/`Control::Table`의 캡션 remap은 이미 #2736으로 devel에
  반영되어 있음을 작업 시작 시 확인 — 이 PR은 그 나머지만 다룹니다.)

## 변경

`src/document_core/converters/hwpx_to_hwp.rs`:

1. `materialize_picture_caption_common_attr()` 신설 — 캡션이 있는 그림의
   `common.attr`에 bit29를 **OR**(recompute 아님)한다.
   `adapt_paragraph_with_context`의 `Control::Picture` arm에서 호출.
   `AdapterReport`에 `picture_caption_common_attr_materialized` 카운터 추가.
2. `remap_bin_refs_in_control`에 `Control::HiddenComment` arm 추가.
3. `remap_bin_refs_in_shape`의 `ShapeObject::Picture` arm에 `pic.caption` 재귀
   추가(`drawing_mut()`이 항상 `None`이라 공통 caption remap 경로를 타지 않음).

도형(`$rec`)·OLE·연결선 캡션의 attr 비트는 범위 밖(직렬화기가 캡션 레코드
자체를 아직 출력하지 않음, 별도 후속).

## Red → Green

```
# 수정 전(4곳 되돌린 상태)
failures:
    grouped_picture_caption_bin_ref_is_remapped
    hidden_comment_picture_bin_ref_is_remapped
    picture_caption_common_attr_bit_is_or_ed_in_when_caption_present
test result: FAILED. 42 passed; 3 failed

# 수정 후
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 2481 filtered out
```

## 검증 (디스크 공간 제약으로 경량 검증만 수행)

- `cargo check --lib` 통과
- `document_core::converters::hwpx_to_hwp::tests` 모듈 전체(45건, 신설 4건 포함)
  `cargo test --lib`로 통과
- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
  로컬 디스크 여유 공간 제약으로 스킵
- `rustfmt --edition 2021` 적용 확인

## 관련 문서

- `mydocs/report/task_m100_2767_report.md`

Fixes #2767 (결함 A + 결함 B 잔여)