### PR TITLE
chore(deps): svg2pdf 결정화 패치 공급원을 rhwp 산하 포크로 이관 (#2856)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1238,7 +1238,7 @@ dependencies = [
 [[package]]
 name = "svg2pdf"
 version = "0.13.0"
-source = "git+https://github.com/planet6897/svg2pdf?branch=determinism-0.13#2caeb0a038f9128b79833d803b94c2667565c4da"
+source = "git+https://github.com/edwardkim/svg2pdf?branch=determinism-0.13#2caeb0a038f9128b79833d803b94c2667565c4da"
 dependencies = [
  "fontdb",
  "image",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -166,6 +166,14 @@ codegen-units = 16
 # #2269 PDF 채번 비결정 근본 정정 — svg2pdf 0.13 의 HashMap 반복(폰트 객체 방출·
 # 리소스 딕셔너리 순서)을 결정화한 벤더 패치. 업스트림(typst/svg2pdf)이 2026-07
 # 아카이브되어 기여 불가, 포크 브랜치로 대체 (Cargo.lock 이 정확한 rev 를 고정).
-# krilla-svg 마이그레이션 시 이 패치는 제거한다.
+#
+# [#2856] 공급원을 rhwp 산하 포크로 이관했다. 종전에는 기여자 개인 포크를 가리켜
+# 의존성 수명이 개인 계정에 묶여 있었고, 업스트림이 아카이브된 상태에서 그 포크가
+# 사실상 유일한 공급원이라 삭제 시 빌드가 불능이 된다. 결정화 커밋의 authorship 은
+# 그대로 보존된다(원 작성자 planet6897, 이관 동의 완료).
+#
+# [#2283] krilla-svg 마이그레이션은 하지 않기로 결정했다. 장기 방향은 Skia direct
+# 백엔드 단일화이며, 그 미지원 op 목록(gradient·pattern·shadow·connector 등)이
+# 비는 시점에 재판단한다. 그때까지 이 패치를 유지·관리한다.
 [patch.crates-io]
-svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism-0.13" }
+svg2pdf = { git = "https://github.com/edwardkim/svg2pdf", branch = "determinism-0.13" }

--- a/mydocs/plans/task_m100_2856.md
+++ b/mydocs/plans/task_m100_2856.md
@@ -1,0 +1,111 @@
+# 타스크 수행계획서 — #2856 svg2pdf 결정화 패치를 rhwp 산하 포크로 이관
+
+- 이슈: [#2856](https://github.com/edwardkim/rhwp/issues/2856)
+- 브랜치: `task/2856-svg2pdf-fork`
+- base: `devel` @ `491e56fc`
+- 담당: edwardkim (원 기여자 planet6897 동의 완료, 2026-07-22 11:12)
+
+## 1. 배경
+
+`export-pdf` 는 svg2pdf 를 쓰는데 **업스트림 `typst/svg2pdf` 는 아카이브**됐다(실측
+`archived=true`). PDF 채번 결정화(#2269)를 위한 벤더 패치를 PR #2281 로 채택했고, 현재 참조는
+기여자 개인 포크다.
+
+```toml
+[patch.crates-io]
+svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism-0.13" }
+```
+
+```
+# Cargo.lock:1241
+source = "git+https://github.com/planet6897/svg2pdf?branch=determinism-0.13#2caeb0a038f9128b79833d803b94c2667565c4da"
+```
+
+#2283 에서 krilla 마이그레이션을 하지 않기로 결정하면서 이 패치는 당분간 계속 쓰인다.
+
+## 2. 문제
+
+**의존성 수명이 개인 계정에 묶여 있다.** 업스트림이 살아 있다면 포크는 임시 우회로지만,
+아카이브된 지금은 이 포크가 사실상 유일한 공급원이다. 삭제되거나 접근이 막히면 **빌드가
+불능**이 된다. `Cargo.lock` 이 rev `2caeb0a` 를 고정해 브랜치 이동에는 안전하나, **저장소 자체가
+사라지는 경우는 막지 못한다.**
+
+## 3. 사전 조사 (완료)
+
+| 항목 | 실측 |
+|---|---|
+| 업스트림 `typst/svg2pdf` | `archived=true` — 기여 불가 확정 |
+| `planet6897/svg2pdf` | fork, `determinism-0.13 @ 2caeb0a038f9...` 존재 |
+| `edwardkim/svg2pdf` | **아직 없음** — 생성 필요 |
+| 패치 내용 | v0.13.0 태그 + 단일 커밋. `util/context.rs`(+13/−4), `util/resources.rs`(+5/−1) — 외과적 정렬 2건뿐 (PR #2281 공급망 감사) |
+| 기준 무결성 | fork 의 v0.13.0 태그 소스 == crates.io 0.13.0 배포본 (직접 대조 확인) |
+
+## 4. 작업 단계
+
+### 1단계 — 산하 포크 생성 ⚠️ 승인 필요
+
+`edwardkim/svg2pdf` 를 만든다. **GitHub 저장소 생성은 외부에 드러나고 되돌리기 번거로우므로
+작업지시자 승인 후에만 실행한다.**
+
+방식은 두 가지가 있다.
+
+- **(가) `planet6897/svg2pdf` 를 포크** — 커밋 이력과 authorship 이 자동 보존되고 GitHub 가
+  포크 관계를 표시한다. 다만 fork of fork 가 되어 원본이 `typst/svg2pdf` 임이 한 단계 가려진다.
+- **(나) `typst/svg2pdf` 를 포크한 뒤 `determinism-0.13` 을 가져오기** — 계보가 업스트림으로
+  직결되어 명확하다. 아카이브된 저장소도 포크는 가능하다.
+
+**(나)를 권고**한다. 계보가 원본으로 직결되는 편이 라이선스·출처 확인에 유리하고, planet6897
+님의 커밋은 브랜치를 가져오면 authorship 이 그대로 보존된다.
+
+### 2단계 — 참조 전환
+
+- `Cargo.toml` 의 `[patch.crates-io]` 를 `https://github.com/edwardkim/svg2pdf` 로 변경
+- `cargo update -p svg2pdf` 로 `Cargo.lock` 재생성 — **rev 는 `2caeb0a` 그대로여야 한다**
+  (같은 커밋을 가리키므로 해시가 바뀌면 내용이 달라진 것)
+
+### 3단계 — 결정성·동등성 검증
+
+이 작업의 성패는 **산출물이 한 바이트도 달라지지 않는 것**이다.
+
+- 전환 전후 `export-pdf` 산출 PDF **바이트 동일** 확인 (동일 폰트 조건에서)
+- 2회 연속 실행 바이트 동일 (#2269 결정성 유지)
+- 전체 스위트 + fmt + clippy
+
+### 4단계 — 포크 저장소 문서화
+
+`edwardkim/svg2pdf` README 에 다음을 남긴다.
+
+- 원 저작: `typst/svg2pdf` (아카이브됨), 라이선스 그대로 승계
+- 패치 내용: PDF 바이트 재현성을 위한 정렬 2건, 원 작성자 [@planet6897](https://github.com/planet6897)
+- rhwp 에서 쓰는 이유와 `[patch.crates-io]` 참조 위치
+- 유지관리 방침: 업스트림이 죽었으므로 필요한 수정은 이 포크에서 직접 반영
+
+### 5단계 — 저장소 문서 갱신
+
+- `mydocs/troubleshootings/pdf_font_numbering_nondeterminism.md` — 참조 위치 갱신
+  ("krilla-svg 마이그레이션 시 이 패치는 제거한다" 노트는 #2283 결정에 맞춰 수정)
+- `mydocs/pr/archives/pr_2281_review.md` 의 "산하 미러 또는 krilla-svg 마이그레이션이 정착지"
+  기록에 결말을 덧붙일지 판단
+
+## 5. 위험과 대응
+
+| 위험 | 대응 |
+|---|---|
+| 전환 후 산출 PDF 가 달라짐 | 3단계 바이트 동일 검증이 게이트. 다르면 전환 중단 |
+| `Cargo.lock` rev 가 바뀜 | 같은 커밋을 가리키므로 바뀌면 안 된다. 바뀌면 원인 규명 후 진행 |
+| planet6897 님 포크가 먼저 사라짐 | 포크 생성이 곧 대비책이다. 이 작업 자체가 그 위험을 없앤다 |
+| authorship 소실 | GitHub 포크·브랜치 가져오기는 커밋 이력을 보존한다. README 에도 명시 |
+
+## 6. 범위 밖
+
+- **패치 내용 수정** — 이관만 하고 코드는 건드리지 않는다
+- **krilla 마이그레이션** — #2283 에서 미진행 결정
+- **`typst/pdf-writer` 직접 사용 검토** — 작업지시자가 #2856 코멘트에서 언급한 향후 축.
+  IR 에서 직접 PDF 를 쓰는 방향이라 이 작업과 별개다
+
+## 7. 승인 요청
+
+**1단계(저장소 생성)에 승인이 필요합니다.** 특히 다음 두 가지를 확인해 주십시오.
+
+- 포크 방식 — (가) planet6897 포크 vs **(나) typst 원본 포크 후 브랜치 가져오기(권고)**
+- 저장소 이름 — `edwardkim/svg2pdf` 로 할지, `rhwp-svg2pdf` 처럼 용도를 드러낼지

--- a/mydocs/troubleshootings/pdf_font_numbering_nondeterminism.md
+++ b/mydocs/troubleshootings/pdf_font_numbering_nondeterminism.md
@@ -68,7 +68,9 @@ python tools/pdf_normalize_compare.py --emit x.pdf > x.norm   # 게이트용 정
 
 ### 패치 브랜치
 
-**planet6897/svg2pdf `determinism-0.13`** (커밋 2caeb0a, v0.13.0 태그 기반 2지점 수정):
+**edwardkim/svg2pdf `determinism-0.13`** (커밋 2caeb0a, v0.13.0 태그 기반 2지점 수정):
+원 작성자는 [@planet6897](https://github.com/planet6897) 이며, 공급원을 rhwp 산하로
+이관했다(#2856, 본인 동의). authorship 은 그대로 보존된다.
 
 | 지점 | 수정 | 결정화 대상 |
 |---|---|---|
@@ -86,7 +88,7 @@ python tools/pdf_normalize_compare.py --emit x.pdf > x.norm   # 게이트용 정
 
 ```toml
 [patch.crates-io]
-svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism-0.13" }
+svg2pdf = { git = "https://github.com/edwardkim/svg2pdf", branch = "determinism-0.13" }
 ```
 
 ### 검증 (upstream/devel 640d04f7 + 패치)
@@ -98,4 +100,6 @@ svg2pdf = { git = "https://github.com/planet6897/svg2pdf", branch = "determinism
 ### 유지보수 노트
 
 - `pdf_normalize_compare.py` 게이트는 이중 안전망으로 유지한다.
-- **krilla-svg 마이그레이션 시 이 패치는 제거**한다 (svg2pdf 계열 EOL — 장기 축은 별도 이슈).
+- **krilla-svg 마이그레이션은 하지 않기로 결정**했다(#2283). 장기 방향은 Skia direct 백엔드
+  단일화이며, 그 미지원 op 목록(gradient·pattern·shadow·connector 등)이 비는 시점에
+  재판단한다. 그때까지 이 패치를 rhwp 산하 포크에서 유지·관리한다(#2856).


### PR DESCRIPTION
`Closes #2856`

## 배경

업스트림 `typst/svg2pdf` 가 **2026-07-10 아카이브**된 상태에서 `[patch.crates-io]` 가 기여자 개인 포크를 가리켜, **의존성 수명이 개인 계정에 묶여** 있었다. 그 포크가 사실상 유일한 공급원이라 삭제되거나 접근이 막히면 빌드가 불능이 된다. `Cargo.lock` 이 rev 를 고정해 브랜치 이동에는 안전했으나 **저장소 소멸은 막지 못한다**.

#2283 에서 krilla 마이그레이션을 하지 않기로 결정하면서 이 패치는 당분간 계속 쓰인다.

## 이관 내용

`edwardkim/svg2pdf` 를 **`typst/svg2pdf` 포크**로 만들고 `determinism-0.13` 브랜치를 가져왔다. 계보가 업스트림으로 직결되어 라이선스·출처 확인에 유리하다(작업지시자 선택).

가져온 브랜치를 검증했다.

| 항목 | 결과 |
|---|---|
| rev | `2caeb0a038f9...` 일치 |
| authorship | **Jaeook Ryu (planet6897) 보존** |
| v0.13.0 태그로부터 | 정확히 1커밋 |
| diff | `util/context.rs`(+13/−4), `util/resources.rs`(+5/−1) — 다른 파일·의존성·빌드 스크립트 무변경 |

PR #2281 공급망 감사 기록과 일치한다. 원 작성자 [@planet6897](https://github.com/planet6897) 님의 이관 동의를 #2856 에서 받았다.

## 검증 — 산출물 무변동

이 작업의 성패는 **한 바이트도 달라지지 않는 것**이다.

- `Cargo.lock` rev 가 `2caeb0a` **그대로 유지**된다(같은 커밋이므로 내용 동일)
- 전환 전후 `export-pdf` 산출 PDF **바이트 완전 동일** (동일 폰트 조건)
- **2회 연속 실행 바이트 동일** — #2269 결정성 유지
- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0

코드 변경은 0이며 `Cargo.lock` 1줄, `Cargo.toml` 12줄(주석 포함), 문서 2건뿐이다.

## 포크 저장소 구성

| 브랜치 | 내용 |
|---|---|
| `determinism-0.13` | `2caeb0a` — **순수 패치 커밋만** |
| `rhwp-docs` | `RHWP-FORK.md` — 포크 이유, 패치 내용, 원 작성자, 결정화 배경, 참조 위치, 기준 무결성, 라이선스 승계 |
| `main` | 업스트림 원본 |

문서를 패치 브랜치에서 분리해 `Cargo.lock` 고정 rev 와 브랜치 HEAD 가 일치하도록 두었다.

## 문서 갱신

`mydocs/troubleshootings/pdf_font_numbering_nondeterminism.md`

- 참조를 산하 포크로 변경, 원 작성자와 이관 경위 명시
- "krilla-svg 마이그레이션 시 이 패치는 제거한다" 노트를 **#2283 결정에 맞춰 수정** — 마이그레이션은 하지 않으며 장기 방향은 Skia direct 단일화이고, 그 미지원 op 목록이 비는 시점에 재판단한다

## 범위 밖

- 패치 내용 수정 — 이관만 하고 코드는 건드리지 않았다
- `typst/pdf-writer` 직접 사용 검토 — #2856 코멘트에서 언급된 향후 축, 별개 작업
