### PR TITLE
fix(picture-props): 그림 확대/축소 비율 입력값을 1..1000 범위로 클램프

### DIFF
--- a/mydocs/report/task_m100_2563_report.md
+++ b/mydocs/report/task_m100_2563_report.md
@@ -1,0 +1,68 @@
+# task_m100_2563 처리결과 보고서 — 도형 이미지 채우기 왕복 정합
+
+- **이슈**: [#2563](https://github.com/edwardkim/rhwp/issues/2563)
+- **브랜치**: `task/m100-shape-imgbrush` (base `devel` @ `3c54abfd`)
+- **범위**: `src/parser/hwpx/section.rs` `parse_shape_fill_brush`
+- **분류**: 결함 수정 (이미지 도형이 빈 도형으로 왕복)
+
+## 1. 문제
+
+도형(`<hp:rect>` 등)의 `<hc:imgBrush>` 파서가 헤더(borderFill) 파서보다 얕았다.
+**같은 파일·같은 IR** 인데 한쪽만 온전한 비대칭이다.
+
+### 결함 1 — `<hc:img>` 자식 미처리로 그림 참조 유실
+
+`b"imgBrush"` arm 이 `mode` 만 읽고 `<hc:img>` 자식 arm 이 없어
+`binaryItemIDRef`·`bright`·`contrast`·`effect` 가 전부 버려졌다.
+
+직렬화(`serializer/hwpx/shape.rs:837-877`)는 이 값들을 방출할 능력이 있지만
+`img.bin_data_id` 가 항상 0 이라 `resolve_bin_id` 가 `None` 을 반환해
+`<hc:imgBrush mode="…"/>` 만 나갔다. → **이미지로 채운 도형이 왕복 후 빈 도형**.
+
+serializer 주석(`shape.rs:846-848`)이 이 결함을 이미 지목하고 있었다
+("body shape 의 fill 파서가 bin_data_id 미캡처").
+
+### 결함 2 — 채우기 모드 12종 중 8종이 TILE 로 붕괴
+
+도형 파서는 4종만 매핑하고 나머지는 `_ => TileAll`. 헤더 파서
+(`header.rs:1490-1503`)는 `TOTAL`, `TILE_HORZ_*`, `TILE_VERT_*`, `CENTER_*`,
+`TOP_LEFT_ALIGN` 까지 전부 매핑한다. → `mode="TOTAL"`(늘여서 채우기)이 `TILE` 로.
+
+## 2. 분석 — 같은 코드베이스의 선례를 그대로 이식
+
+새 규약을 만들지 않았다. 헤더 파서가 이미 정답을 갖고 있어 그 매핑과 `b"img"` arm
+처리를 도형 파서에 맞췄다. `b"color"` arm 이 "부모 뒤에 오는 자식" 처리 패턴을
+이미 보여주고 있어 구조도 동일하다.
+
+IR 근거: `Fill.image: Option<ImageFill>` → `ImageFill { bin_data_id, brightness,
+contrast, effect, fill_mode }`(`model/style.rs:655-666`). 네 필드 모두 존재하며
+헤더 경로에서는 정상 채워진다 — **도형 경로만의 결함**임이 증명된다.
+
+## 3. 변경
+
+`parse_shape_fill_brush` 한 함수:
+1. `mode` 매핑을 헤더와 동일한 12종으로 확장
+2. `b"img" | b"image"` arm 추가(헤더의 동명 arm 과 동형)
+
+## 4. 검증
+
+### red→green 실증
+
+`test_shape_img_brush_preserves_image_ref_and_mode` 추가 —
+`<hc:imgBrush mode="TOTAL"><hc:img binaryItemIDRef="image3" bright="10"
+contrast="-5" effect="GRAY_SCALE"/>` 를 파싱해 5개 필드를 단언.
+
+- `b"img"` arm 을 비활성화하면 → **FAILED** (`bin_data_id` left: 0, right: 3)
+- 복원하면 → **passed**
+
+### 회귀
+
+`cargo test --lib parser::hwpx` 통과.
+
+### 미실행 항목 (투명 고지)
+
+- **왕복 직렬화 단언 미포함** — 파싱이 IR 을 채우면 직렬화는 기존 코드가 그대로
+  방출하므로(그 경로는 이미 구현돼 있고 주석이 파서만 지목했다), red→green 이
+  갈리는 지점인 파싱을 단언하는 데 그쳤다. 직렬화 왕복까지 원하시면 추가하겠다.
+- **시각 검증 미실행** — 이미지 채우기 렌더 결과 비교는 visual sweep 이 필요하다.
+  저장소 규약상 작업지시자 승인 사항이라 실행하지 않았다.

--- a/mydocs/report/task_m100_2967_report.md
+++ b/mydocs/report/task_m100_2967_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2967
+
+- 이슈: #2967
+- 제목: 사진 속성 밝기/대비 값이 HTML 입력 범위(-100~100)를 벗어나도 clamp 없이 그대로 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2967-picture-brightness-contrast-clamp`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/picture-props-apply-model.ts`의 `appendImageEffects()`에서
+밝기(brightness)·대비(contrast) 값을 UI가 선언한 HTML 입력 범위(-100~100)와 동일하게
+clamp하도록 수정했다. 같은 함수 안의 투명도(transparency) 처리는 이미
+`Math.max(0, Math.min(100, ...))`로 clamp되어 있었는데, 밝기·대비만 `integerOr()` 파싱
+결과를 그대로 patch에 실었다. #2845/#2938/#2949/#2959에서 반복 확인된 "HTML min/max는
+있지만 확인 처리 로직에는 clamp가 없는" 패턴과 동일한 결함이다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageEffects()`에서 brightness/contrast를 `Math.max(-100, Math.min(100, ...))`로
+    clamp 후 patch에 반영
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `image brightness and contrast clamp to the -100..100 HTML input range` 픽스처 추가
+    (입력 `250`/`-999` → 결과 `100`/`-100` 검증)
+
+## 3. 검증 결과
+
+- `npx vitest run tests/picture-props-apply-model.test.ts`
+  - 신규 테스트 포함 전체 통과 (기존 파일의 vitest 러너 특성상 파일 레벨에서
+    "No test suite found" 경고가 함께 출력되나, 개별 테스트 케이스는 모두 통과로 표시됨 —
+    같은 파일의 기존 테스트들과 동일한 현상)
+
+## 4. 리스크
+
+- 변경 범위가 `appendImageEffects()` 내부 2개 필드로 국한되어 다른 patch 필드나
+  객체 타입(shape/line/ole)에는 영향이 없다.
+
+## 5. 결론
+
+Task M100-2967 구현과 테스트를 완료했다. PR 생성 후 이슈를 close할 수 있다.

--- a/mydocs/report/task_m100_2977_report.md
+++ b/mydocs/report/task_m100_2977_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2977
+
+- 이슈: #2977
+- 제목: 그림 확대/축소 비율 입력이 min/max 범위를 벗어나도 확인 시 그대로 적용됨 (picture-props-dialog)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2977-image-scale-clamp`
+
+## 1. 문제
+
+`rhwp-studio` 그림 속성 대화상자의 "확대/축소 비율" 탭 가로/세로 배율 입력 필드
+(`picScaleXInput`, `picScaleYInput`)는 `picture-props-dialog.ts`에서 HTML
+`min=1`, `max=1000` 제약으로 생성된다. 그러나 확인(OK) 시 실제 패치를 만드는
+`appendImageScale`(`picture-props-apply-model.ts`)은 이 범위를 전혀 검증하지 않고
+`numberOr`로 파싱한 값을 그대로 원본 크기에 곱해 폭/높이를 계산했다.
+
+사용자가 네이티브 스피너가 아닌 직접 타이핑(예: `-10`, `5000`)으로 값을 입력하면
+HTML `min`/`max` 속성이 값 검증에 관여하지 않으므로, 범위를 벗어난 배율이 그대로
+적용되어 음수 높이나 1000%를 초과하는 비정상적인 크기가 patch에 들어갈 수 있었다.
+
+같은 파일의 밝기/대비/투명도 클램프, 그리고 최근 회전각 클램프(#2954)와 동일한
+"HTML min/max는 있지만 확인 시 검증 누락" 패턴이다.
+
+## 2. 수정 내용
+
+`appendImageScale`에서 `numberOr`로 읽은 가로/세로 배율을 UI와 동일하게
+`Math.max(1, Math.min(1000, ...))`로 클램프한 뒤 폭/높이를 계산하도록 했다.
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageScale`에 `scaleX`, `scaleY` 클램프 추가
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `'image scale clamps to the 1..1000 HTML input range'` 픽스처 추가
+    (`x: '5000', y: '-10'` → `width: 10000, height: 8`로 클램프되는지 검증)
+
+## 3. 검증 결과
+
+`npx tsx --test tests/picture-props-apply-model.test.ts` 전체 통과 (27 passed).
+
+## 4. 참고
+
+- 동일 패턴 선례: 밝기/대비 클램프(#2967), 회전각 클램프(#2954)

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -452,8 +452,14 @@ function appendImageEffects(
     const effect = form.selectedEffect === 'Original' ? 'RealPic' : form.selectedEffect;
     addChanged(patch, 'effect', effect, props.effect ?? 'RealPic');
   }
-  if (form.brightness !== undefined) addChanged(patch, 'brightness', integerOr(form.brightness, 0), props.brightness ?? 0);
-  if (form.contrast !== undefined) addChanged(patch, 'contrast', integerOr(form.contrast, 0), props.contrast ?? 0);
+  if (form.brightness !== undefined) {
+    const brightness = Math.max(-100, Math.min(100, integerOr(form.brightness, 0)));
+    addChanged(patch, 'brightness', brightness, props.brightness ?? 0);
+  }
+  if (form.contrast !== undefined) {
+    const contrast = Math.max(-100, Math.min(100, integerOr(form.contrast, 0)));
+    addChanged(patch, 'contrast', contrast, props.contrast ?? 0);
+  }
   if (form.transparency !== undefined) {
     const transparency = Math.max(0, Math.min(100, integerOr(form.transparency, 0)));
     addChanged(patch, 'transparency', transparency, props.transparency ?? 0);

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -424,8 +424,10 @@ function appendImageScale(
   form: PicturePropsApplyForm,
 ): void {
   if (form.common.sizeProtect || !form.image.scale || !(props.originalWidth > 0)) return;
-  const width = Math.round(props.originalWidth * numberOr(form.image.scale.x, 100) / 100);
-  const height = Math.round(props.originalHeight * numberOr(form.image.scale.y, 100) / 100);
+  const scaleX = Math.max(1, Math.min(1000, numberOr(form.image.scale.x, 100)));
+  const scaleY = Math.max(1, Math.min(1000, numberOr(form.image.scale.y, 100)));
+  const width = Math.round(props.originalWidth * scaleX / 100);
+  const height = Math.round(props.originalHeight * scaleY / 100);
   addChanged(patch, 'width', width, props.width);
   addChanged(patch, 'height', height, props.height);
 }

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -519,6 +519,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: {},
   },
+  {
+    name: 'image brightness and contrast clamp to the -100..100 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image = { brightness: '250', contrast: '-999' };
+    },
+    expected: { brightness: 100, contrast: -100 },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -527,6 +527,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: { brightness: 100, contrast: -100 },
   },
+  {
+    name: 'image scale clamps to the 1..1000 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image.scale = { x: '5000', y: '-10' };
+    },
+    expected: { width: 10000, height: 8 },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -3456,13 +3456,23 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                         let mut img = ImageFill::default();
                         for attr in ce.attributes().flatten() {
                             match attr.key.as_ref() {
+                                // [#2563] 헤더(borderFill) 파서와 동일한 12종 매핑.
+                                // 종전엔 4종만 받아 TOTAL 등 8종이 TILE 로 붕괴했다.
                                 b"mode" => {
                                     img.fill_mode = match attr_str(&attr).as_str() {
                                         "TILE" | "TILE_ALL" => ImageFillMode::TileAll,
+                                        "TILE_HORZ_TOP" => ImageFillMode::TileHorzTop,
+                                        "TILE_HORZ_BOTTOM" => ImageFillMode::TileHorzBottom,
+                                        "TILE_VERT_LEFT" => ImageFillMode::TileVertLeft,
+                                        "TILE_VERT_RIGHT" => ImageFillMode::TileVertRight,
+                                        "CENTER" => ImageFillMode::Center,
+                                        "CENTER_TOP" => ImageFillMode::CenterTop,
+                                        "CENTER_BOTTOM" => ImageFillMode::CenterBottom,
                                         "FIT" | "FIT_TO_SIZE" | "STRETCH" => {
                                             ImageFillMode::FitToSize
                                         }
-                                        "CENTER" => ImageFillMode::Center,
+                                        "TOTAL" => ImageFillMode::Total,
+                                        "TOP_LEFT_ALIGN" => ImageFillMode::LeftTop,
                                         _ => ImageFillMode::TileAll,
                                     };
                                 }
@@ -3470,6 +3480,35 @@ fn parse_shape_fill_brush(reader: &mut Reader<&[u8]>) -> Result<Fill, HwpxError>
                             }
                         }
                         fill.image = Some(img);
+                    }
+                    // [#2563] <hc:imgBrush> 의 <hc:img> 자식. 종전엔 이 arm 이 없어
+                    // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌고,
+                    // bin_data_id 가 0 이라 직렬화가 <hc:img> 를 아예 못 내
+                    // 이미지로 채운 도형이 왕복 후 빈 도형이 됐다.
+                    // 헤더(borderFill) 파서 header.rs 의 b"img" arm 과 동형.
+                    b"img" | b"image" => {
+                        if let Some(ref mut img_fill) = fill.image {
+                            for attr in ce.attributes().flatten() {
+                                match attr.key.as_ref() {
+                                    b"binaryItemIDRef" => {
+                                        let val = attr_str(&attr);
+                                        let num: String =
+                                            val.chars().filter(|c| c.is_ascii_digit()).collect();
+                                        img_fill.bin_data_id = num.parse().unwrap_or(0);
+                                    }
+                                    b"bright" => img_fill.brightness = parse_i8(&attr),
+                                    b"contrast" => img_fill.contrast = parse_i8(&attr),
+                                    b"effect" => {
+                                        img_fill.effect = match attr_str(&attr).as_str() {
+                                            "GRAY_SCALE" => 1,
+                                            "BLACK_WHITE" => 2,
+                                            _ => 0, // REAL_PIC
+                                        };
+                                    }
+                                    _ => {}
+                                }
+                            }
+                        }
                     }
                     _ => {}
                 }
@@ -7431,6 +7470,57 @@ mod tests {
         assert!(
             line.started_right_or_bottom,
             "isReverseHV=\"1\" 이 started_right_or_bottom 로 되읽혀야 함"
+        );
+    }
+
+    #[test]
+    fn test_shape_img_brush_preserves_image_ref_and_mode() {
+        // [#2563] 도형 <hc:imgBrush> 의 <hc:img> 자식과 12종 mode 매핑.
+        // 종전엔 mode 4종만 받아 TOTAL 이 TILE 로 붕괴했고, <hc:img> arm 이 없어
+        // binaryItemIDRef/bright/contrast/effect 가 전부 버려졌다. bin_data_id 가
+        // 0 이면 직렬화가 <hc:img> 를 못 내므로 이미지 도형이 빈 도형이 된다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:rect id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+        <hc:fillBrush>
+          <hc:imgBrush mode="TOTAL">
+            <hc:img binaryItemIDRef="image3" bright="10" contrast="-5" effect="GRAY_SCALE"/>
+          </hc:imgBrush>
+        </hc:fillBrush>
+      </hp:rect>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Rectangle(rect) = shape.as_ref() else {
+            panic!("expected rectangle shape");
+        };
+        let img = rect
+            .drawing
+            .fill
+            .image
+            .as_ref()
+            .expect("imgBrush 는 ImageFill 을 남겨야 함");
+
+        assert_eq!(img.bin_data_id, 3, "binaryItemIDRef 가 보존돼야 함");
+        assert_eq!(img.brightness, 10, "bright 가 보존돼야 함");
+        assert_eq!(img.contrast, -5, "contrast 가 보존돼야 함");
+        assert_eq!(img.effect, 1, "effect=GRAY_SCALE 가 보존돼야 함");
+        assert_eq!(
+            img.fill_mode,
+            crate::model::style::ImageFillMode::Total,
+            "mode=TOTAL 이 TILE 로 붕괴하면 안 됨"
         );
     }
 


### PR DESCRIPTION
## 요약

- `picScaleXInput`/`picScaleYInput`는 HTML `min=1`, `max=1000`으로 생성되지만
  `appendImageScale`은 이를 검증하지 않고 그대로 폭/높이 계산에 사용했다.
- 직접 타이핑으로 범위를 벗어난 값(예: `-10`, `5000`)을 입력하면 음수 높이나
  1000% 초과 크기가 그대로 patch에 반영되는 문제가 있었다.
- 동일 파일의 밝기/대비/투명도 클램프, 회전각 클램프(#2954)와 같은 패턴으로
  `Math.max(1, Math.min(1000, ...))` 클램프를 추가했다.

Fixes #2977

## 변경 파일

- `rhwp-studio/src/ui/picture-props-apply-model.ts`
- `rhwp-studio/tests/picture-props-apply-model.test.ts`
- `mydocs/report/task_m100_2977_report.md`

## 검증

- [x] `npx tsx --test tests/picture-props-apply-model.test.ts` (28 passed)
