### PR TITLE
fix(hwpx): hp:edit passwordChar 속성이 스키마 기본값(*) 대신 빈 문자열로 하드코딩됨 수정 (#2989)

### DIFF
--- a/mydocs/report/task_m100_2989_report.md
+++ b/mydocs/report/task_m100_2989_report.md
@@ -1,0 +1,78 @@
+# Task #2989 Report — hp:edit passwordChar 스키마 기본값 하드코딩 수정
+
+## 요약
+
+이슈 #2989 에서 지적한 대로, `src/serializer/hwpx/form.rs` 의 `write_form()` 이
+`<hp:edit>`(양식 개체 편집 상자)를 직렬화할 때 `passwordChar` 속성의 폴백 기본값을
+빈 문자열(`""`)로 하드코딩하고 있었다. OWPML 공식 스키마
+(`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml:2632`, `EditType.passwordChar`)는
+`default="*"` 를 명시하므로, 원본 문서에 `passwordChar` 속성이 없던 `<hp:edit>` 컨트롤을
+저장할 때 마스킹 문자 `*` 대신 빈 문자열이 방출되어 저장 후 재로딩 시 마스킹 문자가
+소실되는 결과를 낳고 있었다.
+
+같은 `EditType` 의 다른 모든 속성(`multiLine`/`scrollBars`/`tabKeyBehavior`/`numOnly`/
+`readOnly`/`alignText`)은 이미 스키마 default 값을 정확히 폴백으로 쓰고 있어, `passwordChar`
+하나만 어긋난 실수로 판단했다.
+
+## 원인
+
+- 파서(`src/parser/hwpx/section.rs:5573-5576`): `<hp:edit passwordChar="...">` 속성이
+  XML 에 실제로 존재할 때만 `FormObject.properties["PasswordChar"]` 를 채운다. 속성이
+  없으면 이 키 자체가 생기지 않는다(스펙상 정상 — 생략 시 스키마 기본값 적용을 기대).
+- 직렬화기(`src/serializer/hwpx/form.rs:112`, 수정 전):
+  ```rust
+  attrs.push(("passwordChar", prop(form, "PasswordChar", "")));
+  ```
+  `properties` 에 키가 없을 때(신규 생성 폼, 또는 속성이 생략된 원본) `""` 로 폴백해
+  스키마 기본값 `"*"` 와 어긋난 값을 명시적으로 출력했다.
+
+## 수정
+
+`src/serializer/hwpx/form.rs:112` 한 줄만 변경했다.
+
+```rust
+// 변경 전
+attrs.push(("passwordChar", prop(form, "PasswordChar", "")));
+// 변경 후
+attrs.push(("passwordChar", prop(form, "PasswordChar", "*")));
+```
+
+`passwordChar` 속성이 원본에 명시적으로 있던 경우는 `properties` 에 값이 이미 채워져
+있으므로 이번 수정과 무관하게 그대로 보존된다(라운드트립 영향 없음). 영향을 받는 대상은
+(1) 원본에 `passwordChar` 속성이 없던 `<hp:edit>` 컨트롤, (2) rhwp API 로 새로 생성한
+`FormObject::Edit` 뿐이다.
+
+## 검증 (red → green)
+
+`src/serializer/hwpx/form.rs` 의 `tests` 모듈에 회귀 테스트를 추가했다.
+
+```rust
+#[test]
+fn task3001_edit_password_char_defaults_to_asterisk() {
+    let form = FormObject {
+        form_type: FormType::Edit,
+        name: "Edit".to_string(),
+        enabled: true,
+        ..Default::default()
+    };
+    let xml = to_string(|w| write_form(w, &form));
+    assert!(xml.contains(r#"passwordChar="*""#), "{xml}");
+}
+```
+
+- 수정 전(red): `properties` 가 비어 있으므로 `prop(form, "PasswordChar", "")` 폴백이
+  적용되어 `passwordChar=""` 가 출력되고, 위 단언이 실패한다.
+- 수정 후(green): 폴백이 `"*"` 로 바뀌어 단언이 통과한다.
+
+```bash
+cargo test --lib task3001_edit_password_char_defaults_to_asterisk
+# running 1 test
+# test serializer::hwpx::form::tests::task3001_edit_password_char_defaults_to_asterisk ... ok
+cargo check --lib
+# Finished `dev` profile [unoptimized + debuginfo] target(s)
+```
+
+## 범위
+
+`src/serializer/hwpx/form.rs` 1개 파일만 수정(로직 1줄 + 테스트 12줄). 다른 파일은
+건드리지 않았다.

--- a/src/serializer/hwpx/form.rs
+++ b/src/serializer/hwpx/form.rs
@@ -109,7 +109,10 @@ pub fn write_form<W: Write>(w: &mut Writer<W>, form: &FormObject) -> Result<(), 
         }
         FormType::Edit => {
             attrs.push(("multiLine", prop(form, "MultiLine", "0")));
-            attrs.push(("passwordChar", prop(form, "PasswordChar", "")));
+            // [#3001] OWPML 스키마 EditType.passwordChar 의 기본값은 "*"(빈 문자열
+            // 아님, ParaList schema.xml:2632). 원본에 속성이 없던(=파서가 properties
+            // 에 못 채운) 신규/누락 케이스에서 ""로 떨어지면 마스킹 문자가 사라진다.
+            attrs.push(("passwordChar", prop(form, "PasswordChar", "*")));
             attrs.push(("maxLength", prop(form, "MaxLength", "2147483647")));
             attrs.push(("scrollBars", prop(form, "ScrollBars", "NONE")));
             attrs.push((
@@ -296,6 +299,21 @@ mod tests {
         let xml = to_string(|w| write_form(w, &form));
         assert!(xml.starts_with("<hp:edit"), "{xml}");
         assert!(xml.contains("<hp:text>입력값</hp:text>"), "{xml}");
+    }
+
+    #[test]
+    fn task3001_edit_password_char_defaults_to_asterisk() {
+        // [#3001] properties 에 "PasswordChar" 가 없으면(원본 XML 에 속성 자체가
+        // 없던 경우) OWPML 스키마 기본값 "*" 로 떨어져야 한다(schema.xml:2632).
+        // 종전엔 "" 로 떨어져 마스킹 문자가 소실됐다.
+        let form = FormObject {
+            form_type: FormType::Edit,
+            name: "Edit".to_string(),
+            enabled: true,
+            ..Default::default()
+        };
+        let xml = to_string(|w| write_form(w, &form));
+        assert!(xml.contains(r#"passwordChar="*""#), "{xml}");
     }
 
     #[test]


### PR DESCRIPTION
## 요약

이슈 #2989 — `src/serializer/hwpx/form.rs` 의 `write_form()` 이 `<hp:edit>` 컨트롤을
직렬화할 때 `passwordChar` 속성 폴백 기본값을 빈 문자열(`""`)로 하드코딩하고 있었다.
OWPML 공식 스키마(`ParaList XML schema.xml:2632`, `EditType.passwordChar`)는
`default="*"` 를 명시하므로, 원본 문서에 이 속성이 없던 편집 상자를 저장하면 마스킹
문자가 소실되는 결과를 낳는다.

같은 `EditType` 의 다른 모든 속성(`multiLine`/`scrollBars`/`tabKeyBehavior`/`numOnly`/
`readOnly`/`alignText`)은 이미 스키마 default 값을 정확히 폴백으로 쓰고 있어,
`passwordChar` 하나만 어긋난 실수로 판단했다.

## 수정

`src/serializer/hwpx/form.rs:112` 한 줄.

```rust
// 변경 전
attrs.push(("passwordChar", prop(form, "PasswordChar", "")));
// 변경 후
attrs.push(("passwordChar", prop(form, "PasswordChar", "*")));
```

`passwordChar` 속성이 원본에 명시적으로 있던 문서는 `properties` 에 값이 이미 채워져
있으므로 이번 수정과 무관하게 그대로 보존된다(라운드트립 영향 없음). 영향을 받는
대상은 원본에 이 속성이 없던 `<hp:edit>` 컨트롤이거나 rhwp API 로 새로 생성한
`FormObject::Edit` 뿐이다.

## red → green 검증

```rust
#[test]
fn task3001_edit_password_char_defaults_to_asterisk() {
    let form = FormObject {
        form_type: FormType::Edit,
        name: "Edit".to_string(),
        enabled: true,
        ..Default::default()
    };
    let xml = to_string(|w| write_form(w, &form));
    assert!(xml.contains(r#"passwordChar="*""#), "{xml}");
}
```

- 수정 전(red): `properties` 가 비어 있어 `prop(form, "PasswordChar", "")` 폴백이
  적용되어 `passwordChar=""` 가 출력, 단언 실패.
- 수정 후(green): 폴백이 `"*"` 로 바뀌어 단언 통과.

```
cargo test --lib task3001_edit_password_char_defaults_to_asterisk
running 1 test
test serializer::hwpx::form::tests::task3001_edit_password_char_defaults_to_asterisk ... ok

cargo check --lib
Finished `dev` profile [unoptimized + debuginfo] target(s)
```

## 범위

`src/serializer/hwpx/form.rs` 1개 파일만 수정(로직 1줄 + 테스트 12줄). 상세 보고서는
`mydocs/report/task_m100_2989_report.md`.