### PR TITLE
fix(hwp3): 문단 테두리(has_border) 플래그가 음영 없을 때 소실되던 결함 수정

### DIFF
--- a/mydocs/report/task_m100_2995_report.md
+++ b/mydocs/report/task_m100_2995_report.md
@@ -1,0 +1,70 @@
+# Task m100-2995: HWP3 문단 테두리(has_border) 플래그 소실 수정
+
+## 배경
+
+`#2976`(`convert_para_shape()`의 `border_connection` 배선 누락, PR #2983)과 동일한 방법론을
+`Hwp3ParaShape`(`src/parser/hwp3/records.rs`)에 다시 적용했다. 즉 HWP3 바이너리 레코드를 읽어들인
+struct의 각 접근자가 공통 IR(`Document` 모델)까지 실제로 배선되는지, 아니면 struct에는 읽혔지만
+변환 지점에서 조용히 누락되는지를 필드 단위로 대조했다.
+
+`grep -rn "\.has_border()\|\.border_connection()" src/`로 확인한 결과 `border_connection()`은
+#2983에서 다루는 중이었고, `has_border()`(`src/parser/hwp3/records.rs` 392~394행)는 저장소 전체
+어디서도 호출되지 않고 있었다.
+
+## 발견한 결함
+
+`Hwp3ParaShape.border: u8`는 문단 테두리 on/off 플래그이고 `has_border()`가 이를 bool로 해석하는
+접근자다. 이 값을 소비할 수 있는 유일한 지점은 `src/parser/hwp3/mod.rs`의 `parse_paragraph_list()`
+안에서 `shade_ratio`(문단 음영) 값만 검사해 `BorderFill`을 만들고 `ps.border_fill_id`에 배선하는
+인라인 코드였는데, 이 블록이 `shade_ratio > 0`만 조건으로 삼고 `has_border()`는 전혀 참조하지
+않았다. 결과적으로 음영 없이 테두리만 켜진 문단(`border == 1`, `shade_ratio == 0`)은
+`border_fill_id`가 끝까지 0으로 남아 테두리 정보가 항상 소실됐다.
+
+이슈 [#2995](https://github.com/edwardkim/rhwp/issues/2995)로 등록했다.
+
+## 영향
+
+HWP3(.hwp) 문서에서 문단에 음영 없이 테두리만 지정한 경우(강조 박스, 예시/정답 구획 등 옛 한글
+문서에서 흔한 패턴), rhwp 파싱 결과 및 이를 HWPX로 재저장한 결과에서 해당 테두리가 항상 사라진다.
+
+## 수정 내용
+
+`src/parser/hwp3/mod.rs`에 순수 함수 `hwp3_para_shape_border_fill()`을 추가해 기존 shade 전용
+인라인 로직을 이 함수로 옮기고, `shade_ratio > 0 || has_border()` 조건으로 확장했다.
+`has_border()`가 true면 `BorderFill.borders`의 4방향(좌/우/상/하)을 `BorderLineType::Solid`로
+설정한다. HWP3 `Hwp3ParaShape`에는 선 굵기·색상 필드가 없어(`border: u8` 단일 on/off 플래그) 두께·
+색은 `BorderLine`의 기본값을 그대로 사용했다. `parse_paragraph_list()`의 호출부는 아래처럼
+단순화됐다.
+
+```rust
+if let Some(bf) = hwp3_para_shape_border_fill(hwp3_ps) {
+    doc_border_fills.push(bf);
+    ps.border_fill_id = doc_border_fills.len() as u16; // 1-based (렌더러 규칙)
+}
+```
+
+기존에 이미 존재하던 `has_border()` 접근자를 호출해 이미 확립된 `border_fill_id` 배선 경로에
+맞춰 넣는 최소 수정이며, `convert_char_shape()`(#2521)·`convert_para_shape()`(#2976)와 같은
+"접근자는 있지만 호출되지 않음" 패턴이다.
+
+## 테스트 (red → green)
+
+`src/parser/hwp3/mod.rs`의 `tests` 모듈에
+`test_hwp3_para_shape_border_fill_wires_has_border_flag`를 추가했다.
+
+- **Red (수정 전)**: `Hwp3ParaShape { border: 1, shade_ratio: 0, .. }`을
+  `hwp3_para_shape_border_fill()`에 넣으면 (수정 전 로직 기준으로는) `None`이 반환되어
+  `.expect("border_fill 이 생성되어야 함")`가 패닉했다.
+- **Green (수정 후)**: 동일 입력에 대해 `Some(BorderFill)`이 반환되고, 4방향 테두리선의
+  `line_type`이 모두 `BorderLineType::Solid`로 세팅되어 통과한다.
+
+```
+cargo test --lib hwp3_para_shape_border_fill
+running 1 test
+test parser::hwp3::tests::test_hwp3_para_shape_border_fill_wires_has_border_flag ... ok
+```
+
+## 검증
+
+- `cargo check --lib` 통과.
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` 적용.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -361,6 +361,34 @@ pub(crate) fn convert_para_shape(
     ps
 }
 
+// [#2986] HWP3 ParaShape.border(has_border()) 플래그가 shade_ratio 처럼 border_fill_id로
+// 배선되지 않아, 문단 테두리가 켜져 있어도(음영 없이) 항상 소실되던 결함 수정.
+fn hwp3_para_shape_border_fill(
+    hwp3_ps: &crate::parser::hwp3::records::Hwp3ParaShape,
+) -> Option<crate::model::style::BorderFill> {
+    if hwp3_ps.shade_ratio == 0 && !hwp3_ps.has_border() {
+        return None;
+    }
+    let mut bf = crate::model::style::BorderFill::default();
+    if hwp3_ps.shade_ratio > 0 {
+        let ratio = hwp3_ps.shade_ratio.min(100) as u32;
+        let gray = (255 * (100 - ratio) / 100) as u8;
+        let color = u32::from_le_bytes([gray, gray, gray, 0]);
+        bf.fill.fill_type = crate::model::style::FillType::Solid;
+        bf.fill.solid = Some(crate::model::style::SolidFill {
+            background_color: color,
+            pattern_color: 0,
+            pattern_type: 0,
+        });
+    }
+    if hwp3_ps.has_border() {
+        for b in bf.borders.iter_mut() {
+            b.line_type = crate::model::style::BorderLineType::Solid;
+        }
+    }
+    Some(bf)
+}
+
 fn hwp3_para_line_box(
     para_shape: Option<&crate::model::style::ParaShape>,
     column_width_hu: i32,
@@ -1991,17 +2019,7 @@ pub(crate) fn parse_paragraph_list(
         if para_info.follow_prev_para_shape == 0 {
             if let Some(ref hwp3_ps) = para_info.para_shape {
                 let mut ps = convert_para_shape(hwp3_ps, doc_tab_defs);
-                if hwp3_ps.shade_ratio > 0 {
-                    let ratio = hwp3_ps.shade_ratio.min(100) as u32;
-                    let gray = (255 * (100 - ratio) / 100) as u8;
-                    let color = u32::from_le_bytes([gray, gray, gray, 0]);
-                    let mut bf = crate::model::style::BorderFill::default();
-                    bf.fill.fill_type = crate::model::style::FillType::Solid;
-                    bf.fill.solid = Some(crate::model::style::SolidFill {
-                        background_color: color,
-                        pattern_color: 0,
-                        pattern_type: 0,
-                    });
+                if let Some(bf) = hwp3_para_shape_border_fill(hwp3_ps) {
                     doc_border_fills.push(bf);
                     ps.border_fill_id = doc_border_fills.len() as u16; // 1-based (렌더러 규칙)
                 }
@@ -3890,6 +3908,19 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn test_hwp3_para_shape_border_fill_wires_has_border_flag() {
+        // [#2986] border=1, shade_ratio=0 인 경우에도 border_fill 이 생성되고
+        // 4방향 테두리선이 Solid 로 설정되어야 한다 (기존에는 None 이 반환되어 소실됨).
+        let mut hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
+        hwp3_ps.border = 1;
+        let bf = hwp3_para_shape_border_fill(&hwp3_ps).expect("border_fill 이 생성되어야 함");
+        assert!(bf
+            .borders
+            .iter()
+            .all(|b| b.line_type == crate::model::style::BorderLineType::Solid));
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {


### PR DESCRIPTION
## 요약

- `Hwp3ParaShape.has_border()` 접근자가 정의만 되어 있고 어디서도 호출되지 않아, HWP3 문단에
  음영 없이 테두리만 켠 경우(`border == 1`, `shade_ratio == 0`) `border_fill_id`가 끝까지 0으로
  남아 테두리 정보가 항상 소실되는 결함을 수정했다.
- `parse_paragraph_list()`의 shade 전용 인라인 `BorderFill` 생성 로직을
  `hwp3_para_shape_border_fill()`로 추출하고, `shade_ratio > 0 || has_border()` 조건으로 확장해
  `has_border()`가 true면 4방향 테두리선을 `BorderLineType::Solid`로 설정한다.
- `#2976`(`convert_para_shape()`의 `border_connection` 배선 누락, PR #2983)과 동일한 방법론으로
  발견했다. 이슈 [#2995](https://github.com/edwardkim/rhwp/issues/2995).

## 테스트 (red → green)

`src/parser/hwp3/mod.rs`에 `test_hwp3_para_shape_border_fill_wires_has_border_flag` 추가.

- Red: `Hwp3ParaShape { border: 1, shade_ratio: 0, .. }`을 (수정 전) 인라인 로직에 대응하는
  함수에 넣으면 `None`이 반환되어 `.expect(...)`가 패닉.
- Green: 동일 입력에서 `Some(BorderFill)`이 반환되고 4방향 테두리선이 모두
  `BorderLineType::Solid`로 세팅됨을 확인.

```
cargo test --lib hwp3_para_shape_border_fill
test parser::hwp3::tests::test_hwp3_para_shape_border_fill_wires_has_border_flag ... ok
```

## 검증

- `cargo check --lib` 통과
- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` 적용
