### PR TITLE
줄 간격 줄이기 단축키(Alt+Shift+A) 5% 하한 clamp 적용

### DIFF
--- a/mydocs/report/task_m100_3009_report.md
+++ b/mydocs/report/task_m100_3009_report.md
@@ -1,0 +1,33 @@
+# task-m100-3009 처리 결과: 줄 간격 줄이기 단축키 하한 clamp 누락 수정
+
+## 이슈
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/3009
+- 배경: 툴바 줄 간격 상한 clamp(PR #2930)를 조사하던 중, 짝을 이루는 감소 방향
+  경로에도 같은 유형의 clamp 누락이 있는지 점검했다.
+
+## 원인
+
+`rhwp-studio/src/command/commands/format.ts`의 `format:line-spacing-increase`
+커맨드(Alt+Shift+Z)는 `Math.min(500, current + 10)`으로 상한을 clamp하는데, 짝인
+`format:line-spacing-decrease`(Alt+Shift+A)는 `current - 10`으로 하한 검사가 전혀
+없었다. 단축키를 연타하면 줄 간격이 0 이하, 심지어 음수까지 내려갈 수 있었다.
+toolbar.ts의 ▼ 버튼은 이미 `Math.max(5, cur - 5)`로 하한을 5로 clamp하고 있어,
+같은 "줄 간격 줄이기" 동작인데 단축키 경로와 버튼 경로의 clamp가 어긋나 있었다.
+
+## 수정 (rhwp-studio/src/command/commands/format.ts, 1줄)
+
+- `newValue = current - 10` → `newValue = Math.max(5, current - 10)`.
+- toolbar.ts ▼ 버튼과 동일한 하한(5%)으로 맞췄다.
+
+## 테스트 (Red → Green)
+
+- 신규 소스-가드 테스트: `rhwp-studio/tests/line-spacing-decrease-clamp.test.ts`
+  - `format.ts` 소스에서 `format:line-spacing-decrease` 블록에
+    `Math.max(5, current - 10)` 패턴이 있는지 정규식으로 확인.
+  - Red: 수정 전 소스에는 해당 패턴이 없어 실패.
+  - Green: 수정 후 통과 (`npx tsx --test tests/line-spacing-decrease-clamp.test.ts`).
+
+## 커밋 / PR
+
+- 브랜치: `task/m100-2965-linespacing-decrease-clamp` (origin/devel 기준)

--- a/rhwp-studio/src/command/commands/format.ts
+++ b/rhwp-studio/src/command/commands/format.ts
@@ -107,7 +107,8 @@ export const formatCommands: CommandDef[] = [
       if (!ih) return;
       const props = ih.getParaProperties();
       const current = props?.lineSpacing ?? 160;
-      const newValue = current - 10;
+      // toolbar.ts ▼ 버튼과 동일하게 5%로 하한 clamp (issue #3009)
+      const newValue = Math.max(5, current - 10);
       ih.setLineSpacing(newValue);
     },
   },

--- a/rhwp-studio/tests/line-spacing-decrease-clamp.test.ts
+++ b/rhwp-studio/tests/line-spacing-decrease-clamp.test.ts
@@ -1,0 +1,25 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// format:line-spacing-decrease(Alt+Shift+A)에 하한 clamp가 없어 연타 시 줄 간격이
+// 0 이하/음수로 내려가는 문제(issue #3009)의 소스 가드. 짝인
+// format:line-spacing-increase 는 이미 Math.min(500, ...)로 상한 clamp가 있었는데
+// decrease 쪽에는 하한이 없었다. toolbar.ts ▼ 버튼의 Math.max(5, cur - 5)와 동일하게
+// 5%로 하한을 맞춘다.
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+const formatSrc = readFileSync(join(rootDir, 'src/command/commands/format.ts'), 'utf8');
+
+test('format:line-spacing-decrease has a lower-bound clamp', () => {
+  const idx = formatSrc.indexOf("id: 'format:line-spacing-decrease'");
+  assert.ok(idx >= 0, 'format:line-spacing-decrease 커맨드를 찾을 수 없음');
+  const block = formatSrc.slice(idx, idx + 500);
+  assert.match(
+    block,
+    /Math\.max\(\s*5\s*,\s*current\s*-\s*10\s*\)/,
+    'decrease 커맨드에 Math.max(5, current - 10) 하한 clamp가 없음',
+  );
+});


### PR DESCRIPTION
## 요약

- `format:line-spacing-increase`(Alt+Shift+Z)는 `Math.min(500, current + 10)`으로 상한을 clamp하는데, 짝인 `format:line-spacing-decrease`(Alt+Shift+A)는 하한 검사가 없어 연타 시 줄 간격이 0 이하/음수로 내려갈 수 있었습니다.
- toolbar.ts ▼ 버튼(`Math.max(5, cur - 5)`)과 동일하게 하한을 5%로 맞췄습니다.
- 이슈: #3009

## 변경

- `rhwp-studio/src/command/commands/format.ts`: `newValue = current - 10` → `newValue = Math.max(5, current - 10)`
- `rhwp-studio/tests/line-spacing-decrease-clamp.test.ts`: 신규 소스-가드 테스트

## 테스트

- `npx tsx --test tests/line-spacing-decrease-clamp.test.ts` — Red(수정 전 실패) → Green(수정 후 통과) 확인