### PR TITLE
docs(orders): 2026-07-22 #2856 svg2pdf 산하 포크 이관 완료 반영

### DIFF
--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -189,11 +189,40 @@
   명시한다. 현행 svg2pdf + 벤더 패치를 유지하고, **위 미지원 op 목록이 비는 시점**을 재판단
   트리거로 둔다.
 
-### #2856 — svg2pdf 를 rhwp 산하 포크로 이관 (신설)
+### #2856 — svg2pdf 를 rhwp 산하 포크로 이관 ([PR #2979](https://github.com/edwardkim/rhwp/pull/2979) `0ecf686102`)
 
-- `[patch.crates-io]` 가 기여자 개인 포크를 가리켜 **의존성 수명이 개인 계정에 묶여 있다.**
+- `[patch.crates-io]` 가 기여자 개인 포크를 가리켜 **의존성 수명이 개인 계정에 묶여 있었다.**
   업스트림이 아카이브된 상태라 이 포크가 사실상 유일한 공급원이고, 삭제되면 빌드가 불능이 된다.
-- 결정화 커밋은 planet6897 님 작업이므로 **이슈로 사전 통지**하고 출처 명시를 약속했다.
+  `Cargo.lock` 이 rev 를 고정해 브랜치 이동에는 안전했으나 **저장소 소멸은 막지 못한다.**
+- 결정화 커밋은 planet6897 님 작업이므로 **이슈로 사전 통지**했고, 당일 동의를 받아 진행했다
+  ("업스트림이 아카이브된 이상 빌드 의존성이 개인 계정에 묶여 있는 건 저도 정리되어야 할
+  리스크라고 봅니다").
+
+**포크 방식** — 개인 포크를 다시 포크하면 fork of fork 가 되어 원본이 한 단계 가려지므로,
+`typst/svg2pdf` 를 포크한 뒤 `determinism-0.13` 브랜치를 가져오는 방식을 택했다(작업지시자 선택).
+계보가 업스트림으로 직결되어 라이선스·출처 확인이 명확하다.
+
+가져온 브랜치를 검증했고 PR #2281 공급망 감사 기록과 일치했다.
+
+| 항목 | 결과 |
+|---|---|
+| rev | `2caeb0a038f9...` 일치 |
+| authorship | **Jaeook Ryu (planet6897) 보존** |
+| v0.13.0 태그로부터 | 정확히 1커밋 |
+| diff | `util/context.rs`(+13/−4), `util/resources.rs`(+5/−1), 다른 파일 무변경 |
+
+**검증 — 산출물 무변동.** 이관의 성패가 여기 있다고 보고 세 시점에서 확인했다(전환 직후,
+PR 전, devel merge 후). `Cargo.lock` rev 가 `2caeb0a` 그대로 유지되고, `export-pdf` 산출 PDF 가
+**바이트 완전 동일**하며, **2회 연속 실행 바이트 동일**로 #2269 결정성도 살아 있다.
+코드 변경은 0이고 `Cargo.lock` 1줄, `Cargo.toml` 12줄(주석 포함), 문서 2건뿐이다.
+
+**포크 저장소 구성** — `determinism-0.13` 은 패치 커밋만 두고, 안내 문서(`RHWP-FORK.md`)는
+`rhwp-docs` 브랜치로 분리했다. `Cargo.lock` 이 고정한 rev 와 브랜치 HEAD 가 일치해야 나중에
+혼선이 없기 때문이다. 작업 중 문서를 패치 브랜치에 직접 커밋해 HEAD 가 이동한 것을
+`--force-with-lease` 로 정정했다.
+
+`pdf_font_numbering_nondeterminism.md` 의 참조를 산하 포크로 바꾸고, "krilla-svg 마이그레이션 시
+이 패치는 제거한다" 노트를 #2283 결정에 맞춰 수정했다.
 
 ### #2864 + #2268 — 폰트 조달 환경 종속 제거 ([PR #2898](https://github.com/edwardkim/rhwp/pull/2898) `1f582cda46`)
 
@@ -260,10 +289,11 @@ Stage 2 가 #2268 을 "migration 전 baseline" 으로 배치한 것은 **백엔�
 | kevin9327 | 7 | 2 | 3 (리베이스 2 · 테스트 1) |
 | johndoekim | 1 | — | — |
 | postmelee | 1 | — | — |
-| 메인테이너 | 2 | — | — |
+| 메인테이너 | 3 | — | — |
 
-메인테이너 merge 2건: [#2805](https://github.com/edwardkim/rhwp/pull/2805) `1a48fcda3b`(CI retries) ·
-[#2898](https://github.com/edwardkim/rhwp/pull/2898) `1f582cda46`(폰트 조달 환경 종속 제거)
+메인테이너 merge 3건: [#2805](https://github.com/edwardkim/rhwp/pull/2805) `1a48fcda3b`(CI retries) ·
+[#2898](https://github.com/edwardkim/rhwp/pull/2898) `1f582cda46`(폰트 조달 환경 종속 제거) ·
+[#2979](https://github.com/edwardkim/rhwp/pull/2979) `0ecf686102`(svg2pdf 산하 포크 이관)
 
 merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42001ef` ·
 [#2797](https://github.com/edwardkim/rhwp/pull/2797) `f2c02b6669` ·
@@ -273,7 +303,7 @@ merge 된 통합 PR: [#2796](https://github.com/edwardkim/rhwp/pull/2796) `f6d42
 
 연결 이슈 close 12건: #2656 #2660 #2723 #2724 #2740 #2752 #2756 #2759 #2765 #2804 #2864 #2268
 
-PDF 축 정리로 함께 종결: #2787(사용자 제안 — v1.0.0 미지원 안내) · #2283(krilla 미진행 결정)
+PDF 축 정리로 함께 종결: #2787(사용자 제안 — v1.0.0 미지원 안내) · #2283(krilla 미진행 결정) · #2856(산하 포크 이관)
 
 **#2268 은 07-14 등록 후 8일 만에 종결**됐다. 원인이 `load_system_fonts()` 자체가 아니라 그 아래
 `/mnt/c/Windows/Fonts` 무조건 스캔이었다는 것을 코드로 특정한 것이 결정적이었다.


### PR DESCRIPTION
[#2856](https://github.com/edwardkim/rhwp/issues/2856) 처리 결과를 오늘할일에 기록한다.

## 추가한 내용

- **포크 방식 선택 근거** — 개인 포크를 다시 포크하면 fork of fork 가 되어 원본이 가려지므로, `typst/svg2pdf` 를 포크한 뒤 `determinism-0.13` 브랜치를 가져오는 방식을 택했다(작업지시자 선택)
- **검증 4항목** — rev 일치, authorship 보존, v0.13.0 로부터 1커밋, diff 가 PR #2281 공급망 감사 기록과 일치
- **산출물 무변동** — 전환 직후·PR 전·devel merge 후 세 시점에서 바이트 동일 확인. 2회 연속 실행 결정성(#2269)도 유지
- **포크 저장소 구성** — `determinism-0.13` 은 패치 커밋만, 안내 문서는 `rhwp-docs` 로 분리. `Cargo.lock` 고정 rev 와 브랜치 HEAD 가 일치해야 혼선이 없기 때문
- **작업 중 정정 기록** — 문서를 패치 브랜치에 직접 커밋해 HEAD 가 이동한 것을 `--force-with-lease` 로 되돌린 경위

## 집계 갱신

메인테이너 merge 2건 → 3건([#2979](https://github.com/edwardkim/rhwp/pull/2979) `0ecf686102` 추가), 종결 이슈에 #2856 추가.

## 검증

문서 변경만이라 코드 게이트는 해당 없다.