### PR TITLE
fix(hwpx): 문단 번호 모양(numFormat) CIRCLE_DIGIT 오탈자 호환 누락 수정 (#3011)

### DIFF
--- a/mydocs/report/task_m100_3011_report.md
+++ b/mydocs/report/task_m100_3011_report.md
@@ -1,0 +1,36 @@
+# Task m100-3011: 문단 번호 모양(numFormat) CIRCLE_DIGIT 오탈자 호환 누락 수정
+
+## 이슈
+
+- https://github.com/edwardkim/rhwp/issues/3011
+- 관련 선행 이슈: #2957/#2964(`autoNumFormat`), #3005/#3007(`pageNum formatType`) — 동일한
+  `hc:NumberType1` 스키마를 참조하는 3개 지점 중 앞선 2곳에서 발견된 패턴.
+
+## 원인
+
+`hc:NumberType1`(OWPML `Core XML schema.xml` 5행)은 `autoNumFormat`, `pageNum formatType`,
+`hh:paraHead numFormat` 세 곳에서 참조되는 공유 enum이다. 앞의 두 지점(`src/parser/hwpx/section.rs`)은
+스펙 철자 `CIRCLED_DIGIT`과 한컴 실물 파일의 오탈자 `CIRCLE_DIGIT`(D 없음)를 모두 인식하도록
+처리되어 있었으나, 세 번째 지점인 `src/parser/hwpx/header.rs`의 `parse_numbering_format_code`
+(문단 번호 모양 파싱)에는 이 호환 별칭이 누락되어 있었다. 그 결과 `numFormat="CIRCLE_DIGIT"`로
+저장된 문서를 읽으면 원문자(circled digit) 서식이 `DIGIT`(0)으로 유실된다.
+
+## 수정
+
+`src/parser/hwpx/header.rs`의 `parse_numbering_format_code` 매치암을 확장:
+
+```rust
+"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
+```
+
+## 테스트
+
+- 추가: `test_parse_hwpx_numbering_para_head_accepts_circle_digit_typo_for_hancom_compat`
+  (수정 전 실패 → 수정 후 통과 확인)
+- `cargo check --lib` 통과
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs` 적용
+
+## 범위
+
+`hc:NumberType1` 참조 3개 지점(`autoNumFormat`, `pageNum formatType`, `paraHead numFormat`) 모두
+`CIRCLE_DIGIT` 호환 별칭 처리가 일치하게 되어, 이 클래스의 버그는 닫힌 것으로 판단한다.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1916,7 +1916,9 @@ fn apply_numbering_para_head(
 fn parse_numbering_format_code(value: &str) -> u8 {
     match value {
         "DIGIT" | "ARABIC" => 0,
-        "CIRCLED_DIGIT" => 1,
+        // "CIRCLED_DIGIT"이 스펙 철자(NumberType1)이나, "CIRCLE_DIGIT"(D 없음)로 저장된
+        // 한컴 실물 파일과의 호환을 위해 둘 다 인식한다 (section.rs autoNumFormat/pageNum과 동일 처리).
+        "CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
         "ROMAN_CAPITAL" | "ROMAN_UPPER" | "ROMAN" => 2,
         "ROMAN_SMALL" | "ROMAN_LOWER" => 3,
         "LATIN_CAPITAL" | "LATIN_UPPER" | "ALPHA_CAPITAL" => 4,
@@ -2149,6 +2151,28 @@ mod tests {
         assert_eq!(numbering.level_formats[0], "^1");
         assert_eq!(numbering.heads[0].number_format, 1);
         assert_eq!((numbering.heads[0].attr >> 5) & 0x0f, 1);
+    }
+
+    #[test]
+    fn test_parse_hwpx_numbering_para_head_accepts_circle_digit_typo_for_hancom_compat() {
+        // section.rs의 autoNumFormat/pageNum formatType과 마찬가지로, 문단 번호 모양
+        // numFormat도 한컴 실물 파일의 오탈자 "CIRCLE_DIGIT"(D 없음)를 스펙 철자
+        // "CIRCLED_DIGIT"과 동일하게 인식해야 한다 (#3011).
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:numberings itemCnt="1">
+      <hh:numbering id="1" start="1">
+        <hh:paraHead start="1" level="1" numFormat="CIRCLE_DIGIT" text="^1"/>
+      </hh:numbering>
+    </hh:numberings>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        let numbering = &doc_info.numberings[0];
+
+        assert_eq!(numbering.heads[0].number_format, 1);
     }
 
     #[test]


### PR DESCRIPTION
## 요약

closes #3011

`hc:NumberType1`(OWPML `Core XML schema.xml`)은 `autoNumFormat`(#2957/#2964), `pageNum formatType`(#3005/#3007), `hh:paraHead numFormat` 세 지점에서 참조되는 공유 enum입니다. 앞의 두 지점은 스펙 철자 `CIRCLED_DIGIT`과 한컴 실물 파일의 오탈자 `CIRCLE_DIGIT`(D 없음)를 모두 인식하도록 처리되어 있었으나, 세 번째 지점(`src/parser/hwpx/header.rs`의 `parse_numbering_format_code`)에는 이 호환 별칭이 빠져 있어 `numFormat="CIRCLE_DIGIT"`로 저장된 문서를 읽으면 원문자 서식이 `DIGIT`(0)으로 유실되었습니다.

## 변경

- `src/parser/hwpx/header.rs`: `parse_numbering_format_code` 매치암을 `"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,`로 확장
- 회귀 테스트 추가: `test_parse_hwpx_numbering_para_head_accepts_circle_digit_typo_for_hancom_compat`
- `mydocs/report/task_m100_3011_report.md` 처리 결과 문서 추가

## 검증

- [x] `cargo check --lib` 통과
- [x] 신규 테스트 수정 전 실패 → 수정 후 통과 확인
- [x] `rustfmt --edition 2021 src/parser/hwpx/header.rs`