### PR TITLE
HWP3 각주 옵션(footnote_bracket) 플래그를 미주 모양 suffix_char로 배선

### DIFF
--- a/mydocs/report/task_m100_3021_report.md
+++ b/mydocs/report/task_m100_3021_report.md
@@ -1,0 +1,50 @@
+# 완료 보고서 — Task M100-3021
+
+- 이슈: #3021
+- 제목: HWP3 doc_info.footnote_bracket(각주 옵션) 파싱만 되고 미주 모양에 배선되지 않음
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3021-hwp3-footnote-bracket`
+
+## 1. 완료 내용
+
+#3006 (`Hwp3DocInfo.hide_empty_line` 배선 누락) 처리 시 사용한 방법 — doc_info 인접
+플래그를 `impl Hwp3DocInfo`와 `SectionDef` 조립부(`src/parser/hwp3/mod.rs`)에서
+전수 대조 — 를 이어서 적용해 offset 110 `footnote_bracket`(각주 옵션)에서 동일한 유형의
+문제를 찾았다.
+
+`Hwp3DocInfo::read`(`src/parser/hwp3/records.rs`)는 스펙(`mydocs/tech/한글문서파일구조3.0.md:244`,
+`110 | echar | ')' = 각주 번호에 ')'를 붙임, 0=안 붙임 | 각주 옵션`)대로 `footnote_bracket: u8`을
+정확히 파싱하지만, `hwp3_default_endnote_shape()`은 공통 IR `FootnoteShape.suffix_char`을
+항상 `')'`로 하드코딩해 이 값을 사용하지 않았다. HWP5(`src/parser/doc_info.rs`)와
+HWPX(`src/parser/hwpx/section.rs:901,908`)는 각각 원본 값으로 `suffix_char`을 채우므로
+HWP3만 이 옵션을 무시하는 genuine gap이었다. 사용자가 한/글에서 "각주 번호 뒤 ')' 안 붙임"으로
+설정한 HWP3 문서도 미주 번호 뒤에 항상 ')' 가 렌더링되는 시각 차이가 있었다.
+
+## 2. 주요 변경
+
+- `src/parser/hwp3/mod.rs`
+  - `hwp3_default_endnote_shape()` → `hwp3_default_endnote_shape(bracket: bool)`:
+    `suffix_char`을 `bracket`에 따라 `')'` 또는 `'\0'`(안 붙임)으로 결정
+  - `fixup_hwp3_notes()`에 `footnote_bracket: bool` 매개변수 추가, 호출부에
+    `doc_info.footnote_bracket != 0` 전달
+  - 단위 테스트 `issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag` 추가
+    (bracket=true → `')'`, bracket=false → `'\0'` 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib hwp3::` (14 passed, 신규 테스트 포함)
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`
+
+## 4. 범위 밖 후속 과제
+
+- `hwp3_default_endnote_shape`의 `start_number: 1` 도 `doc_info.footnote_start_number`를
+  직접 반영하지 않고 하드코딩되어 있다(실제 번호 매기기 시작값은
+  `doc.doc_properties.footnote_start_num` 경유로 별도 적용되어 렌더 결과에는 영향 없음).
+  `FootnoteShape.start_number`는 메타데이터 필드라 별도 검증이 필요해 이번 타스크
+  범위에서는 제외했다.
+- 각주(footnote, `SectionDef.footnote_shape`) 자체는 HWP3 파서에서 전혀 조립되지 않아
+  항상 `Default`값이다. 이는 offset 하나짜리 배선 누락보다 훨씬 큰 범위의 기능 격차라
+  별도 타스크로 분리해야 한다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -401,14 +401,17 @@ fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
         .max(1)
 }
 
-fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
+fn hwp3_default_endnote_shape(bracket: bool) -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
     };
 
     let mut shape = FootnoteShape {
         number_format: NumberFormat::Digit,
-        suffix_char: ')',
+        // doc_info offset 110 "각주 옵션": ')' = 번호에 ')' 붙임, 0 = 안 붙임.
+        // 파싱만 되고(footnote_bracket) 항상 ')' 로 하드코딩되어 옵션을 끈 문서도
+        // ')' 가 표시되던 문제.
+        suffix_char: if bracket { ')' } else { '\0' },
         start_number: 1,
         separator_margin_top: 864,
         note_spacing: 576,
@@ -3243,7 +3246,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     super::populate_link_image_paths(&mut doc);
 
     crate::parser::assign_auto_numbers(&mut doc);
-    fixup_hwp3_notes(&mut doc);
+    fixup_hwp3_notes(&mut doc, doc_info.footnote_bracket != 0);
     fixup_hwp3_outline_fields(&mut doc);
     fixup_hwp3_picture_numbers(&mut doc);
     fixup_hwp3_outline_bullets(&mut doc);
@@ -3259,7 +3262,7 @@ struct Hwp3NoteFixupState {
     has_endnote: bool,
 }
 
-fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
+fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, footnote_bracket: bool) {
     let para_shapes = doc.doc_info.para_shapes.clone();
     let mut state = Hwp3NoteFixupState {
         footnote_number: doc.doc_properties.footnote_start_num.max(1),
@@ -3275,7 +3278,7 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
 
     if state.has_endnote {
         for section in &mut doc.sections {
-            section.section_def.endnote_shape = hwp3_default_endnote_shape();
+            section.section_def.endnote_shape = hwp3_default_endnote_shape(footnote_bracket);
             ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
@@ -3890,6 +3893,17 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag() {
+        // doc_info offset 110 "각주 옵션" footnote_bracket 이 파싱만 되고 항상 ')' 로
+        // 하드코딩되어, 옵션을 끈(footnote_bracket=0) 문서도 미주 번호에 ')' 가 붙던 문제.
+        let on = hwp3_default_endnote_shape(true);
+        assert_eq!(on.suffix_char, ')');
+
+        let off = hwp3_default_endnote_shape(false);
+        assert_eq!(off.suffix_char, '\0');
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {


### PR DESCRIPTION
## 요약

- #3021 처리: HWP3 `doc_info.footnote_bracket`(offset 110, 각주 옵션)이 파싱만 되고
  공통 IR `FootnoteShape.suffix_char`로 배선되지 않아, 번호 뒤 ')' 를 끈 문서도
  미주 번호 뒤에 항상 ')' 가 렌더되던 문제를 고쳤습니다.
- #3006 (`hide_empty_line` 배선 누락)과 같은 패턴의 doc_info 인접 플래그 점검에서 발견.

## 변경

- `src/parser/hwp3/mod.rs`
  - `hwp3_default_endnote_shape(bracket: bool)`: `suffix_char`을 `bracket` 값에 따라
    `')'` 또는 `'\0'`으로 결정
  - `fixup_hwp3_notes()`에 `footnote_bracket: bool` 매개변수 추가, 호출부에서
    `doc_info.footnote_bracket != 0` 전달
  - 단위 테스트 `issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag` 추가
- `mydocs/report/task_m100_3021_report.md`: 처리 결과 문서

## Test plan

- [x] `cargo check --lib`
- [x] `cargo test --lib hwp3::` 통과 (신규 테스트 포함)
- [x] `rustfmt --edition 2021 src/parser/hwp3/mod.rs`