### PR TITLE
HWP3 각주 분리선 길이(footnote_line_width) 파싱 후 미사용 수정

### DIFF
--- a/mydocs/report/task_m100_3017_report.md
+++ b/mydocs/report/task_m100_3017_report.md
@@ -1,0 +1,51 @@
+# task_m100_3017: HWP3 각주 분리선 길이(footnote_line_width) 미매핑 수정
+
+## 이슈
+
+edwardkim/rhwp#3017
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 HWP3 문서 정보 파서가 각주 옵션 필드
+`footnote_line_width`(HWP3 스펙 §3.2, offset 111: 각주 분리선 길이 종류.
+0=5cm, 1=본문 폭의 1/3, 2=단 너비, 3=없음)를 `Hwp3DocInfo`로 파싱만 하고,
+IR(`SectionDef.footnote_shape.separator_length`)로 전혀 전달하지 않았다.
+결과적으로 HWP3 문서의 실제 설정값과 무관하게 각주 분리선 길이가 항상
+기본값 0(선 없음)으로 렌더링되는 버그였다.
+
+## 원인
+
+`section_def.page_def` 구성 직후, 섹션 정의(SectionDef)를 만드는 지점에서
+`doc_info.footnote_line_width`를 읽어 쓰는 코드가 없었다. 필드 자체는
+`records.rs`의 `Hwp3DocInfo`에 정의되고 바이트 스트림에서 정상적으로
+읽히지만(`records.rs:90`), 이후 어디에서도 참조되지 않았다.
+
+## 수정
+
+- `hwp3_footnote_separator_length(footnote_line_width: u8, column_width_hu: i32) -> i32`
+  순수 함수를 추가해 스펙 4종 값을 HWPUNIT 길이로 변환.
+  - 0 → 5cm(≈14160 HWPUNIT, 1mm≈283.2 HWPUNIT)
+  - 1 → 본문 폭(`column_width_hu`)의 1/3
+  - 2 → 본문 폭 그대로(단 너비)
+  - 3 이상 → 0(없음)
+- `section_def.footnote_shape.separator_length` / `separator_line_type` /
+  `separator_line_width`를 이 값으로 채우도록 `section_def.page_def` 구성
+  직후에 3줄 추가.
+- 단위 테스트 `hwp3_maps_footnote_separator_length`로 0/1/2/3 네 케이스
+  매핑을 직접 검증.
+
+## 검증
+
+- `cargo check --lib`: 통과.
+- `cargo test --lib hwp3_maps_footnote_separator_length`: 통과(1 passed).
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`: 적용.
+
+## 범위
+
+- 변경 파일: `src/parser/hwp3/mod.rs` (순수 함수 + 3줄 배선 + 단위 테스트).
+- 렌더러, 레이아웃, 공통 IR 등 다른 계층에는 손대지 않음(HWP3 전용 해석은
+  `src/parser/hwp3/` 안에서 종료).
+- 후속 과제: 각주 분리선의 `separator_line_type`/`separator_line_width`
+  자체를 결정하는 HWP3 스펙 필드가 별도로 없어 관례값(실선/굵기 1)을
+  사용했다. 실제 문서 대량 검증으로 값이 다르면 후속 조정이 필요할 수
+  있다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -391,6 +391,17 @@ fn hwp3_para_flow_spacing(para_shape: Option<&crate::model::style::ParaShape>) -
     )
 }
 
+/// HWP3 스펙 offset 111 각주 분리선 길이 종류(0=5cm, 1=본문 폭의 1/3, 2=단 너비,
+/// 3 이상=없음)를 HWPUNIT 길이로 변환한다.
+fn hwp3_footnote_separator_length(footnote_line_width: u8, column_width_hu: i32) -> i32 {
+    match footnote_line_width {
+        0 => 14160, // 5cm ≈ 283.2 HWPUNIT/mm * 50mm
+        1 => column_width_hu / 3,
+        2 => column_width_hu,
+        _ => 0,
+    }
+}
+
 fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
     // HWP3 미주는 HWPX 기준 출력처럼 본문 영역 안에서 2단으로 흘린다.
     // 한글 97 계열의 기본 미주 단 간격은 5mm에 해당하는 1416 HWPUNIT로 본다.
@@ -3187,6 +3198,18 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
         ..Default::default()
     };
 
+    // HWP3 스펙(한글문서파일구조3.0.md:245) offset 111 각주 분리선 길이 종류.
+    // 기존 코드는 doc_info.footnote_line_width 를 파싱만 하고 버려 항상
+    // separator_length=0(선 없음)으로 렌더링했다.
+    section_def.footnote_shape.separator_length =
+        hwp3_footnote_separator_length(doc_info.footnote_line_width, column_width_hu);
+    section_def.footnote_shape.separator_line_type = if doc_info.footnote_line_width == 3 {
+        0
+    } else {
+        1
+    };
+    section_def.footnote_shape.separator_line_width = 1;
+
     // [Task #877 Stage 4] HWP3 doc_info.border_type / border_margin → SectionDef.page_border_fill
     // 변환. HWP3 spec §3.2 (문서 정보) offset 112-121 의 페이지 테두리 정보. type=0 이면 없음,
     // 그 외 = 실선 등. 한컴 viewer 의 PDF 출력에 페이지 외곽선 박스 표시 (sample16 표지/목차/
@@ -3890,6 +3913,17 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn hwp3_maps_footnote_separator_length() {
+        // doc_info.footnote_line_width(스펙 offset 111, 각주 분리선 길이 종류)를
+        // 파싱만 하고 버리던 기존 버그: section_def.footnote_shape.separator_length 가
+        // 값과 무관하게 항상 0(선 없음)으로 남았다.
+        assert_eq!(hwp3_footnote_separator_length(0, 9999), 14160); // 5cm 고정
+        assert_eq!(hwp3_footnote_separator_length(1, 9000), 3000); // 본문 폭의 1/3
+        assert_eq!(hwp3_footnote_separator_length(2, 9000), 9000); // 단 너비
+        assert_eq!(hwp3_footnote_separator_length(3, 9000), 0); // 없음
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {


### PR DESCRIPTION
## 요약

- HWP3 doc_info.footnote_line_width(스펙 offset 111, 각주 분리선 길이 종류:
  0=5cm/1=본문 폭의 1/3/2=단 너비/3=없음)를 파싱만 하고 IR로 매핑하지 않던
  버그를 고쳤습니다. 실제 문서 설정과 무관하게 각주 분리선 길이가 항상
  0(선 없음)으로 렌더링되던 문제입니다.
- 순수 함수 `hwp3_footnote_separator_length`로 4종 값을 HWPUNIT 길이로
  변환해 `section_def.footnote_shape.separator_length` 등에 배선했습니다.

## 이슈

Closes edwardkim/rhwp#3017

## 테스트

- [x] `cargo check --lib`
- [x] `cargo test --lib hwp3_maps_footnote_separator_length`
- [x] `rustfmt --edition 2021 src/parser/hwp3/mod.rs`

## 보고서

`mydocs/report/task_m100_3017_report.md`