### PR TITLE
fix(hwpx): hh:bullet checkedChar 속성 파싱/방출 누락 해소

### DIFF
--- a/mydocs/report/task_m100_3028_report.md
+++ b/mydocs/report/task_m100_3028_report.md
@@ -1,0 +1,39 @@
+# 완료 보고서 — Task M100-3028
+
+- 이슈: #3028
+- 제목: hh:bullet checkedChar 속성 파싱/방출 누락
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3025-hwpx-checkedchar-bullet`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/header.rs`의 `parse_bullet_hwpx`가 `hh:bullet` 요소의 `char`,
+`useImage` 속성만 읽고 `checkedChar` 속성을 무시하던 문제를 수정했다. 체크박스
+글머리표(checkbox bullet)의 체크 문자가 항상 IR `check_bullet_char` 기본값
+(`'\0'`)으로 고정되어 실제 문서에 지정된 체크 문자가 소실되고 있었다.
+
+직렬화기(`src/serializer/hwpx/header.rs`의 `write_bullet`)도 대응 수정했다.
+기존에는 `checkedChar` 속성을 방출하지 않고 `paraHead`의 `checkable` 속성을
+항상 `"0"`으로 하드코딩하고 있었다. 같은 계열 버그(#2957, #3005, #3011)와
+동일하게 리터럴 하드코딩이 실제 IR 필드를 반영하지 못한 사례다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs`
+  - `parse_bullet_hwpx`에 `checkedChar` 속성 분기 추가 → `bullet.check_bullet_char`
+  - 회귀 테스트 `test_parse_bullet_hwpx_checked_char` 추가
+- `src/serializer/hwpx/header.rs`
+  - `write_bullet`: `check_bullet_char != '\0'`일 때만 `checkedChar` 속성 방출
+  - `paraHead`의 `checkable` 값을 `has_checked_char` 여부에 따라 동적 설정
+    (`"1"`/`"0"`)
+
+## 3. 검증
+
+- `cargo check --lib` 통과
+- `cargo test --lib checked_char` 통과 (신규 테스트 1건)
+- `cargo test --lib bullet` 통과 (관련 기존 테스트 3건 + 신규 1건, 전부 통과)
+- `rustfmt --edition 2021` 적용 (추가 변경 없음)
+
+## 4. 남은 이슈
+
+없음.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1744,6 +1744,13 @@ fn parse_bullet_hwpx(
                     }
                 }
             }
+            b"checkedChar" => {
+                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                    if let Some(c) = s.chars().next() {
+                        bullet.check_bullet_char = c;
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -2097,6 +2104,27 @@ mod tests {
                 (tags::HWPTAG_TRACKCHANGE, 1, 1032),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_bullet_hwpx_checked_char() {
+        // checkedChar 는 체크 글머리표(checkbox bullet)의 체크 문자다. 종전 파서는
+        // char/useImage 만 읽고 checkedChar 를 무시해 IR.check_bullet_char 가 항상
+        // 기본값('\0')이었다 — 체크박스 글머리표가 라운드트립에서 소실된다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:bullets itemCnt="1">
+      <hh:bullet id="0" char="□" checkedChar="☑" useImage="0">
+        <hh:paraHead level="0" align="LEFT" useInstWidth="0" autoIndent="1" widthAdjust="0" textOffsetType="PERCENT" textOffset="50" numFormat="DIGIT" charPrIDRef="4294967295" checkable="1"/>
+      </hh:bullet>
+    </hh:bullets>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(doc_info.bullets.len(), 1);
+        assert_eq!(doc_info.bullets[0].check_bullet_char, '☑');
     }
 
     #[test]

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -945,11 +945,14 @@ fn write_bullet<W: Write>(
     let id_s = (id + 1).to_string(); // 관찰: 1-based, ParaShape.numbering_id 참조와 정합
     let char_s = b.bullet_char.to_string();
     let use_image = if b.image_bullet > 0 { "1" } else { "0" };
-    start_tag_attrs(
-        w,
-        "hh:bullet",
-        &[("id", &id_s), ("char", &char_s), ("useImage", use_image)],
-    )?;
+    let has_checked_char = b.check_bullet_char != '\0';
+    let checked_char_s = b.check_bullet_char.to_string();
+    let mut attrs: Vec<(&str, &str)> = vec![("id", &id_s), ("char", &char_s)];
+    if has_checked_char {
+        attrs.push(("checkedChar", &checked_char_s));
+    }
+    attrs.push(("useImage", use_image));
+    start_tag_attrs(w, "hh:bullet", &attrs)?;
     // paraHead 뼈대 (파서는 무시하나 OWPML 유효성/한컴 호환 위해 방출).
     empty_tag(
         w,
@@ -964,7 +967,7 @@ fn write_bullet<W: Write>(
             ("textOffset", "50"),
             ("numFormat", "DIGIT"),
             ("charPrIDRef", &u32::MAX.to_string()),
-            ("checkable", "0"),
+            ("checkable", if has_checked_char { "1" } else { "0" }),
         ],
     )?;
     end_tag(w, "hh:bullet")?;


### PR DESCRIPTION
## 요약

- `parse_bullet_hwpx`가 `hh:bullet`의 `char`/`useImage`만 읽고 `checkedChar` 속성을 무시해 체크박스 글머리표의 체크 문자가 항상 IR 기본값(`'\0'`)으로 소실되던 문제 수정
- 직렬화기 `write_bullet`도 `checkedChar`를 조건부로 방출하고 `paraHead`의 `checkable` 하드코딩(`"0"` 고정)을 제거해 왕복 시 정보 소실 방지

Closes #3028. 동일 계열 버그: #2957, #3005, #3011.

## 테스트 계획

- [x] `cargo check --lib`
- [x] `cargo test --lib checked_char`
- [x] `cargo test --lib bullet`
- [x] `rustfmt --edition 2021`