### PR TITLE
문단 병합 시 컨트롤 없는 tab/개행 텍스트의 control_mask 비트 누락 수정

### DIFF
--- a/mydocs/report/task_m100_3029_report.md
+++ b/mydocs/report/task_m100_3029_report.md
@@ -1,0 +1,46 @@
+# 완료 보고서 — Task M100-3029
+
+- 이슈: #3029
+- 제목: 문단 병합(merge_from) 시 컨트롤 없는 tab/개행 텍스트의 control_mask 비트 누락
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2905b-paragraph-split-merge`
+
+## 1. 완료 내용
+
+`Paragraph::merge_from`이 `control_mask`를 갱신할 때 `other.controls`가 비어 있지 않은
+경우에만 `self.control_mask |= other.control_mask`를 수행하던 것을 수정했다.
+`control_mask`는 `controls` 목록뿐 아니라 텍스트의 tab(`\t`)/개행(`\n`) 존재 여부,
+`field_ranges` 존재 여부에서도 파생되는 비트를 포함하므로, 병합 대상 문단이
+컨트롤 없이 tab/개행만 가진 경우 해당 비트가 누락되고 있었다. `split_at`이 이미
+사용하는 `compute_control_mask_for(text, controls, field_ranges)` 전체 재계산 방식을
+`merge_from`에도 동일하게 적용해 컨트롤 유무와 무관하게 항상 정확한 마스크를
+갱신하도록 했다.
+
+## 2. 주요 변경
+
+- `src/model/paragraph.rs`
+  - `merge_from` 끝부분에서 조건부 `control_mask |= other.control_mask` 대신
+    `self.control_mask = Self::compute_control_mask_for(&self.text, &self.controls, &self.field_ranges)`로
+    전체 재계산 (split_at과 동일 패턴)
+- `src/model/paragraph/tests.rs`
+  - `test_merge_from_text_only_control_mask_bits` 추가: `other.controls`가 비어 있고
+    `other.text`에 tab만 있는 경우에도 병합 후 `control_mask`에 tab 비트(0x9)가
+    반영되는지 검증 (수정 전에는 실패 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib paragraph::tests` (54 passed)
+- `rustfmt --edition 2021` (src/model/paragraph.rs, src/model/paragraph/tests.rs)
+
+수정 전 동일 테스트로 red 상태 재현 확인 (`left: 0, right: 0` 어설션 실패) 후
+수정을 되돌려 green 전환을 확인했다.
+
+## 4. 범위 밖 항목
+
+- 표(table) 셀 병합/분할의 `char_offsets`는 셀이 서로 독립된 텍스트 스트림이라
+  concat 자체가 발생하지 않음을 확인했다 (#2905, #2912 패턴과 일치, 정상).
+- `shape.rs`/`table.rs`/`picture.rs`/`note.rs`의 insert/delete `char_offsets` shift는
+  threshold 기반 shift 패턴을 따르며 이번 조사 범위에서 이상 없음을 확인했다.

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -1038,8 +1038,12 @@ impl Paragraph {
                     .push(other.ctrl_data_records.get(i).cloned().flatten());
             }
             self.controls.extend(other.controls.iter().cloned());
-            self.control_mask |= other.control_mask;
         }
+        // control_mask는 tab/개행 등 텍스트 기반 비트(#1323 이후 확장분)도 포함하므로,
+        // other.controls가 비어 있어도 other.text의 tab/개행이 손실되지 않도록
+        // split_at과 동일하게 병합 후 상태 전체를 재계산한다.
+        self.control_mask =
+            Self::compute_control_mask_for(&self.text, &self.controls, &self.field_ranges);
 
         // 6. char_count 갱신: 텍스트 + 컨트롤(각 8 code unit) + 문단끝(1)
         //    split_at의 ctrl_code_units 계산과 정합. HWPX 직렬화가 char_count에서

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -646,6 +646,36 @@ fn test_merge_from_empty_text_with_control() {
 }
 
 #[test]
+fn test_merge_from_text_only_control_mask_bits() {
+    // other 문단이 controls는 없고 tab/개행만 가진 경우에도 control_mask의
+    // 텍스트 기반 비트(0x9=tab, 0xA=개행)가 병합 결과에 반영돼야 한다.
+    let mut para1 = Paragraph {
+        text: "안녕".to_string(),
+        char_count: 3,
+        char_offsets: vec![0, 1],
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    let tab_para = Paragraph {
+        text: "\t뒤".to_string(),
+        char_count: 3,
+        char_offsets: vec![0, 1],
+        control_mask: 1u32 << 0x0009,
+        has_para_text: true,
+        ..Default::default()
+    };
+
+    para1.merge_from(&tab_para);
+
+    assert_ne!(
+        para1.control_mask & (1u32 << 0x0009),
+        0,
+        "controls가 없는 other의 tab 비트도 control_mask에 반영돼야 한다"
+    );
+}
+
+#[test]
 fn test_merge_from_control_then_right_half() {
     // 셀 paste 3단 흐름 재현: split_at → merge(컨트롤 문단) → merge(right_half)
     let mut para = Paragraph {


### PR DESCRIPTION
## 요약

- 이슈 #3029 수정: `Paragraph::merge_from`이 병합 대상(`other`) 문단에 `controls`가
  하나도 없으면 `control_mask` 갱신 블록 전체를 건너뛰던 문제를 고쳤다.
- `control_mask`는 `controls` 목록뿐 아니라 텍스트의 tab/개행 존재 여부, `field_ranges`
  존재 여부에서도 파생되는 비트를 포함하므로, 컨트롤 없이 tab/개행만 있는 문단을
  병합하면 해당 비트가 누락됐다.
- `split_at`이 이미 쓰는 `compute_control_mask_for(text, controls, field_ranges)`
  전체 재계산 방식을 `merge_from`에도 동일하게 적용했다.

## 변경 파일

- `src/model/paragraph.rs` — `merge_from` 마지막 control_mask 갱신 로직 수정
- `src/model/paragraph/tests.rs` — `test_merge_from_text_only_control_mask_bits` 추가
- `mydocs/report/task_m100_3029_report.md` — 완료 보고서

## 테스트

- `cargo check --lib`
- `cargo test --lib paragraph::tests` (54 passed)
- `rustfmt --edition 2021`
- 수정 전 테스트로 red 상태(비트 누락) 재현 확인 후 되돌려 green 전환 확인

Closes #3029
