### PR TITLE
fix(hwp3): doc_info.footnote_between_margin(각주 사이 간격) 미주 모양 raw_unknown 배선

### DIFF
--- a/mydocs/report/task_m100_3032_report.md
+++ b/mydocs/report/task_m100_3032_report.md
@@ -1,0 +1,39 @@
+# Task m100-3032 처리 결과
+
+## 이슈
+
+edwardkim/rhwp#3032 — `doc_info.footnote_between_margin`(각주 사이 간격) 미주 모양
+`raw_unknown` 미배선
+
+## 원인
+
+HWP3 `doc_info` 오프셋 108 "각주와 각주 사이의 간격"(`footnote_between_margin`)이
+`Hwp3DocInfo::read`에서 파싱만 되고, `src/parser/hwp3/mod.rs`의
+`hwp3_default_endnote_shape()`는 `FootnoteShape.raw_unknown`("주석 사이" 값)을 항상
+기본값 0으로 남겼다. `#3006`(hide_empty_line) · `#3021`(footnote_bracket) ·
+`#3017`(footnote_line_width→separator_length)와 같은 클래스의 "파싱만 되고 IR에
+배선되지 않은 필드" 누락이다.
+
+## 수정
+
+- `hwp3_default_endnote_shape()`가 `between_margin: u16` 인자를 받아
+  `raw_unknown` 필드에 배선하도록 변경.
+- `fixup_hwp3_notes()`가 `footnote_between_margin: u16` 인자를 받아 호출부
+  (`parse_hwp3`)에서 `doc_info.footnote_between_margin`을 전달.
+
+파일: `src/parser/hwp3/mod.rs` (16 lines changed).
+
+## 검증
+
+- 신규 단위 테스트 `issue_hwp3_endnote_raw_unknown_wires_footnote_between_margin`
+  추가: `hwp3_default_endnote_shape(720).raw_unknown == 720` 확인 (수정 전 실패,
+  수정 후 통과).
+- `cargo check --lib` 통과.
+- `cargo test --lib issue_hwp3_endnote_raw_unknown_wires_footnote_between_margin`
+  통과.
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` 적용 완료.
+
+## 범위
+
+`src/parser/hwp3/` 내부로 국한. 렌더러·문서 코어에 HWP3 전용 분기를 추가하지
+않았다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -401,7 +401,7 @@ fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
         .max(1)
 }
 
-fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
+fn hwp3_default_endnote_shape(between_margin: u16) -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
     };
@@ -416,6 +416,9 @@ fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
         separator_color: 0x00000000,
         numbering: FootnoteNumbering::Continue,
         placement: FootnotePlacement::EachColumn,
+        // doc_info offset 108 "각주와 각주 사이의 간격"이 파싱만 되고(footnote_between_margin)
+        // raw_unknown("주석 사이" 값)에 배선되지 않아 항상 0으로 렌더되던 문제.
+        raw_unknown: between_margin,
         ..Default::default()
     };
     shape.attr = shape.encode_attr();
@@ -3243,7 +3246,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     super::populate_link_image_paths(&mut doc);
 
     crate::parser::assign_auto_numbers(&mut doc);
-    fixup_hwp3_notes(&mut doc);
+    fixup_hwp3_notes(&mut doc, doc_info.footnote_between_margin);
     fixup_hwp3_outline_fields(&mut doc);
     fixup_hwp3_picture_numbers(&mut doc);
     fixup_hwp3_outline_bullets(&mut doc);
@@ -3259,7 +3262,7 @@ struct Hwp3NoteFixupState {
     has_endnote: bool,
 }
 
-fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
+fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, footnote_between_margin: u16) {
     let para_shapes = doc.doc_info.para_shapes.clone();
     let mut state = Hwp3NoteFixupState {
         footnote_number: doc.doc_properties.footnote_start_num.max(1),
@@ -3275,7 +3278,7 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
 
     if state.has_endnote {
         for section in &mut doc.sections {
-            section.section_def.endnote_shape = hwp3_default_endnote_shape();
+            section.section_def.endnote_shape = hwp3_default_endnote_shape(footnote_between_margin);
             ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
@@ -3890,6 +3893,15 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn issue_hwp3_endnote_raw_unknown_wires_footnote_between_margin() {
+        // doc_info offset 108 "각주와 각주 사이의 간격"(footnote_between_margin)이 파싱만
+        // 되고 endnote_shape.raw_unknown("주석 사이" 값)에 배선되지 않아 항상 0으로
+        // 렌더되던 문제.
+        let shape = hwp3_default_endnote_shape(720);
+        assert_eq!(shape.raw_unknown, 720);
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {


### PR DESCRIPTION
## 요약

- HWP3 `doc_info` 오프셋 108 "각주와 각주 사이의 간격"(`footnote_between_margin`)이
  파싱만 되고 `hwp3_default_endnote_shape()`에서 `FootnoteShape.raw_unknown`
  ("주석 사이" 값)으로 배선되지 않아 항상 0으로 렌더되던 문제를 고쳤습니다.
- `#3006`(hide_empty_line) · `#3021`(footnote_bracket) ·
  `#3017`(footnote_line_width→separator_length)와 같은 클래스의 "파싱만 되고 IR에
  배선되지 않은 필드" 누락을 계속 점검하다가 발견했습니다.

Closes #3032

## 변경

- `hwp3_default_endnote_shape()`가 `between_margin: u16` 인자를 받아
  `raw_unknown`에 배선.
- `fixup_hwp3_notes()` → `parse_hwp3()` 경로로 `doc_info.footnote_between_margin`
  전달.

## 테스트

- [x] `cargo check --lib`
- [x] `cargo test --lib issue_hwp3_endnote_raw_unknown_wires_footnote_between_margin`
- [x] `rustfmt --edition 2021 src/parser/hwp3/mod.rs`