### PR TITLE
fix(hwpx): hh:bullet 이미지 글머리표 binaryItemIDRef 파싱 누락 해소

### DIFF
--- a/mydocs/report/task_m100_3033_report.md
+++ b/mydocs/report/task_m100_3033_report.md
@@ -1,0 +1,39 @@
+# 완료 보고서 — Task M100-3033
+
+- 이슈: #3033
+- 제목: [hwpx] hh:bullet 이미지 글머리표가 실제 binaryItemIDRef 를 읽지 않고 항상 ID 1로 고정됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3031-bullet-useimage`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/header.rs`의 `parse_bullet_hwpx()`가 `<hh:bullet>` 자식 요소를
+전부 건너뛰던 것을, `<hh:img binaryItemIDRef="imageN" .../>`만 인식해 숫자 ID를
+추출하도록 수정했다. HWP3 BULLET record(표 44)의 `image_bullet` 필드는
+"0=문자, ID=이미지"로 정의되어 있어, 이미지 글머리표는 실제 참조 ID가 보존되어야
+한다. 기존에는 `useImage="1"` 여부만 보고 상수 `1`을 대입해, 서로 다른 이미지를
+참조하는 여러 글머리표가 전부 같은 BinData ID로 뭉개졌다.
+
+`src/parser/hwpx/section.rs`에 이미 있던 `binaryItemIDRef` → 숫자 ID 추출
+패턴(`val.chars().filter(|c| c.is_ascii_digit())`)을 그대로 재사용했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs`
+  - `parse_bullet_hwpx()` 자식 순회 루프에 `<hh:img>` 매치 분기 추가,
+    `binaryItemIDRef`를 파싱해 `bullet.image_bullet`에 대입
+  - 단위 테스트 `test_parse_bullet_hwpx_image_id_from_binary_item_id_ref` 추가
+    (`binaryItemIDRef="image3"` → `image_bullet == 3` 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib bullet` (관련 4개 테스트 전부 통과, 신규 테스트 포함)
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs`
+
+## 4. 남은 이슈
+
+없음. `image_data`(대비/밝기/효과 4바이트)는 여전히 HWPX에서 채워지지 않으나,
+이는 이번 이슈(binaryItemIDRef 자체 유실)와 별개의 후속 개선 대상이다.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1748,11 +1748,28 @@ fn parse_bullet_hwpx(
         }
     }
 
-    // 자식 <hh:paraHead>, <hh:image> 등 skip
+    // 자식 <hh:paraHead>, <hh:img> 순회. <hh:img binaryItemIDRef="imageN"> 는
+    // 이미지 글머리표의 실제 BinData 참조 ID — useImage="1" 만으로는 어떤 이미지인지
+    // 알 수 없어 누락 시 이미지 글머리표가 항상 ID 1 로 고정된다.
     if !is_empty_event(e) {
         let mut buf = Vec::new();
         loop {
             match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce))
+                    if local_name(ce.name().as_ref()) == b"img" =>
+                {
+                    if let Some(attr) = ce
+                        .attributes()
+                        .flatten()
+                        .find(|a| a.key.as_ref() == b"binaryItemIDRef")
+                    {
+                        let s = String::from_utf8_lossy(&attr.value);
+                        let num: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
+                        if let Ok(id) = num.parse::<i32>() {
+                            bullet.image_bullet = id;
+                        }
+                    }
+                }
                 Ok(Event::End(ref ee)) => {
                     if local_name(ee.name().as_ref()) == b"bullet" {
                         break;
@@ -2096,6 +2113,28 @@ mod tests {
                 (tags::HWPTAG_LAYOUT_COMPATIBILITY, 1, 20),
                 (tags::HWPTAG_TRACKCHANGE, 1, 1032),
             ]
+        );
+    }
+
+    #[test]
+    fn test_parse_bullet_hwpx_image_id_from_binary_item_id_ref() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:bullets itemCnt="1">
+      <hh:bullet id="1" char="0x0" useImage="1">
+        <hh:img binaryItemIDRef="image3" bright="0" contrast="0" effect="REAL_PIC"/>
+      </hh:bullet>
+    </hh:bullets>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(
+            doc_info.bullets[0].image_bullet, 3,
+            "이미지 글머리표는 <hh:img binaryItemIDRef>의 실제 BinData ID(3)로 매핑되어야 함. \
+             useImage=\"1\" 만으로는 어떤 이미지인지 알 수 없어, 이대로 두면 이미지 글머리표가 \
+             항상 ID 1로 고정된다."
         );
     }
 


### PR DESCRIPTION
## 요약

- `<hh:bullet useImage="1">`의 이미지 글머리표가 자식 `<hh:img binaryItemIDRef>`를 읽지 않고 `image_bullet`을 항상 `1`로 고정하던 버그를 고쳤다.
- `binaryItemIDRef="imageN"`에서 숫자 ID를 추출해 `bullet.image_bullet`에 대입하도록 `parse_bullet_hwpx()`를 수정했다 (`src/parser/hwpx/section.rs`의 기존 패턴 재사용).
- #3028/#3030 (`checkedChar` 파싱 누락)과 같은 계열의 문제로, 같은 함수 안에서 자식 요소를 전부 건너뛰던 부분을 보강했다.

## 이슈

closes #3033

## 테스트

- `cargo check --lib`
- `cargo test --lib bullet` (신규 테스트 `test_parse_bullet_hwpx_image_id_from_binary_item_id_ref` 포함 4개 통과)
- `rustfmt --edition 2021 src/parser/hwpx/header.rs`
