### PR TITLE
fix(serializer/hwpx): hp:caption vertAlign 이 IR 값을 반영하도록 수정

### DIFF
--- a/mydocs/report/task_m100_3035_report.md
+++ b/mydocs/report/task_m100_3035_report.md
@@ -1,0 +1,37 @@
+# task-m100-3035: hp:caption vertAlign 고정값 방출 수정
+
+## 이슈
+#3035 — `write_caption`(`src/serializer/hwpx/table.rs`)이 `hp:subList`의
+`vertAlign` 속성을 IR 값(`caption.vert_align`)과 무관하게 항상 `"TOP"`으로
+고정 방출.
+
+## 근거
+- `Caption` IR(`src/model/shape.rs:651`)에 `vert_align: CaptionVertAlign`
+  필드가 존재.
+- `document_core/commands/table_ops.rs:2312`에 사용자가 `captionVertAlign`
+  (Top/Center/Bottom)을 실제로 편집하는 경로가 존재 — 즉 진짜로 값이
+  바뀔 수 있는 필드.
+- 기존 모듈 주석은 "캡션 subList 속성은 파서가 적재하지 않으며 …
+  vertAlign=TOP … 실물 고정값 방출"이라 되어 있었으나, 이는 HWPX
+  샘플 17건이 모두 TOP이었다는 관찰일 뿐 IR 자체가 항상 TOP이라는
+  뜻은 아니었음(HWP3→IR 변환·편집 커맨드로는 Center/Bottom도 생성됨).
+
+## 수정
+`write_caption`에서 `caption.vert_align`을 `TOP`/`CENTER`/`BOTTOM`으로
+매핑해 `vertAlign` 속성에 방출하도록 변경. `lineWrap`/`textDirection`은
+여전히 고정값(파서 미적재, 근거 유효)으로 유지.
+
+## 테스트
+`task3035_caption_vert_align_reflects_ir` 추가 — `vert_align = Bottom`
+설정 시 `vertAlign="BOTTOM"`이 방출되는지 확인.
+
+## 검증
+- 코드 리뷰: 기존 `side` 매핑 패턴과 동일한 구조로 `vert_align` 매핑 추가,
+  diff 범위 최소(약 10줄 실질 변경 + 테스트 1개).
+- **`cargo check --lib` 미실행**: 로컬 환경에서 시스템 `dbghelp.lib`
+  손상(`CVT1107`/`LNK1123`)으로 모든 빌드 스크립트 링크가 실패하는
+  환경 문제 발생(코드 변경과 무관, 사전 존재하는 로컬 툴체인 손상).
+  CI에서 정상 검증 필요.
+
+## 결과
+PR 생성됨 (base: devel, head: kevin9327:task/m100-3035-caption-vertalign).

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -332,21 +332,27 @@ fn write_sub_list_paragraphs<W: Write>(
 /// `<hp:caption>` 직렬화 (#1387) — 자식 순서상 outMargin 과 inMargin 사이 (모듈 doc).
 ///
 /// 속성 순서는 한컴 실물(ta-pic-001-r) 기준: side, fullSz, width, gap, lastWidth.
-/// 캡션 subList 속성은 파서가 적재하지 않으며 samples/hwpx 전수 17건 동일
-/// (vertAlign=TOP lineWrap=BREAK textDirection=HORIZONTAL — 1단계 측정) — 실물 고정값 방출.
+/// 캡션 subList 의 lineWrap/textDirection 은 파서가 적재하지 않으며 samples/hwpx 전수
+/// 17건 동일(lineWrap=BREAK textDirection=HORIZONTAL — 1단계 측정) — 실물 고정값 방출.
+/// vertAlign 은 IR(`caption.vert_align`, table_ops.rs 편집 경로 존재)을 실제로 반영한다(#3035).
 /// 그림/도형/묶음 캡션(#1403)도 동일 경로를 공유한다 (pub(super)).
 pub(super) fn write_caption<W: Write>(
     w: &mut Writer<W>,
     caption: &crate::model::shape::Caption,
     ctx: &mut SerializeContext,
 ) -> Result<(), SerializeError> {
-    use crate::model::shape::CaptionDirection;
+    use crate::model::shape::{CaptionDirection, CaptionVertAlign};
 
     let side = match caption.direction {
         CaptionDirection::Left => "LEFT",
         CaptionDirection::Right => "RIGHT",
         CaptionDirection::Top => "TOP",
         CaptionDirection::Bottom => "BOTTOM",
+    };
+    let vert_align = match caption.vert_align {
+        CaptionVertAlign::Top => "TOP",
+        CaptionVertAlign::Center => "CENTER",
+        CaptionVertAlign::Bottom => "BOTTOM",
     };
     let full_sz = bool01(caption.include_margin);
     let width = caption.width.to_string();
@@ -370,7 +376,7 @@ pub(super) fn write_caption<W: Write>(
             ("id", ""),
             ("textDirection", "HORIZONTAL"),
             ("lineWrap", "BREAK"),
-            ("vertAlign", "TOP"),
+            ("vertAlign", vert_align),
             ("linkListIDRef", "0"),
             ("linkListNextIDRef", "0"),
             ("textWidth", "0"),
@@ -619,6 +625,22 @@ mod tests {
         let cp = xml.find("<hp:caption").unwrap();
         let im = xml.find("<hp:inMargin").unwrap();
         assert!(om < cp && cp < im, "caption 은 outMargin 과 inMargin 사이");
+    }
+
+    #[test]
+    fn task3035_caption_vert_align_reflects_ir() {
+        // vertAlign 이 caption.vert_align IR 값을 실제로 반영해야 함(고정 TOP 방출 금지).
+        use crate::model::shape::CaptionVertAlign;
+        let mut t = empty_table(1, 1);
+        let mut c = caption_with_text("c");
+        c.vert_align = CaptionVertAlign::Bottom;
+        t.caption = Some(c);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"vertAlign="BOTTOM""#),
+            "vertAlign 이 IR 값(BOTTOM)으로 방출되어야 함: {}",
+            xml
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약
- `write_caption`(`src/serializer/hwpx/table.rs`)이 `hp:subList`의 `vertAlign` 속성을 IR(`caption.vert_align`)과 무관하게 항상 `"TOP"`으로 고정 방출하던 버그 수정.
- `caption.vert_align`은 `document_core/commands/table_ops.rs`에서 실제로 편집 가능한 필드이며(Top/Center/Bottom), 이를 무시하고 고정값을 방출하면 캡션 세로 정렬을 Center/Bottom으로 편집한 문서를 HWPX로 저장할 때 값이 유실됨.
- `lineWrap`/`textDirection`은 파서가 적재하지 않는 필드로 근거가 유효해 고정값 유지.

관련 이슈: #3035

## 테스트
- `task3035_caption_vert_align_reflects_ir` 추가: `vert_align = Bottom` 설정 시 `vertAlign="BOTTOM"` 방출 확인.

## 검증
로컬 환경의 시스템 `dbghelp.lib` 손상(`CVT1107`/`LNK1123`, 코드 변경과 무관한 사전 존재 문제)으로 `cargo check --lib` 실행이 불가능했습니다. 변경은 기존 `side` 매핑과 동일한 패턴으로 diff 범위가 작습니다(실질 변경 약 10줄 + 테스트 1개). CI에서 검증 부탁드립니다.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>