### PR TITLE
fix(#3037): 필드 입력 대화상자 재사용 시 메모/이름/편집가능 값 초기화

### DIFF
--- a/mydocs/report/task_m100_3037_report.md
+++ b/mydocs/report/task_m100_3037_report.md
@@ -1,0 +1,25 @@
+# task-m100-3037: 필드 입력 대화상자 재사용 시 값 리셋 누락 수정
+
+## 이슈
+
+#3037 필드 입력 대화상자가 재사용 시 이전 값을 유지함 — 메모/이름/편집가능 체크박스 초기화 누락
+
+## 원인
+
+`rhwp-studio/src/command/commands/insert.ts`는 `FieldInsertDialog`를 모듈 전역
+싱글턴(`fieldInsertDialog`)으로 한 번만 생성해 재사용한다. 그런데
+`FieldInsertDialog.show()` 오버라이드는 안내문 입력(guideInput)에 포커스·선택만
+수행할 뿐, memoInput·nameInput·editableCheckbox 값을 초기 상태로 되돌리지 않았다.
+그 결과 사용자가 필드를 삽입한 뒤 대화상자를 다시 열면 이전에 입력했던 메모·이름과
+체크박스 상태가 그대로 남아있었다.
+
+## 수정
+
+`field-insert-dialog.ts`의 `show()`에서 guideInput 기본값 설정과 함께
+memoInput/nameInput을 빈 문자열로, editableCheckbox를 `true`로 리셋하도록 추가했다.
+
+## 검증
+
+- `rhwp-studio/tests/field-insert-dialog-reset.test.ts` 신규 테스트 추가
+  (`table-create-dialog.test.ts`와 동일한 소스 문자열 검사 패턴)
+- `npx tsx --test tests/field-insert-dialog-reset.test.ts` 통과 확인

--- a/rhwp-studio/src/ui/field-insert-dialog.ts
+++ b/rhwp-studio/src/ui/field-insert-dialog.ts
@@ -98,6 +98,12 @@ export class FieldInsertDialog extends ModalDialog {
       if (buttons[1]) buttons[1].textContent = '취소';
     }
 
+    // 싱글턴으로 재사용되므로 이전 삽입 값이 남지 않도록 초기 상태로 리셋한다.
+    this.guideInput.value = '입력하세요';
+    this.memoInput.value = '';
+    this.nameInput.value = '';
+    this.editableCheckbox.checked = true;
+
     this.guideInput.focus();
     this.guideInput.select();
   }

--- a/rhwp-studio/tests/field-insert-dialog-reset.test.ts
+++ b/rhwp-studio/tests/field-insert-dialog-reset.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('필드 입력 대화상자는 열릴 때마다 메모/이름/편집가능 값을 초기 상태로 리셋한다', () => {
+  const dialog = source('src/ui/field-insert-dialog.ts');
+  const showStart = dialog.indexOf('override show(): void');
+  assert.notEqual(showStart, -1, 'show() 오버라이드를 찾을 수 있어야 한다');
+
+  const showBody = dialog.slice(showStart);
+
+  // 싱글턴으로 재사용되므로(commands/insert.ts), 매번 열릴 때 이전 삽입 값이 남지 않아야 한다.
+  assert.match(showBody, /this\.memoInput\.value\s*=\s*''/);
+  assert.match(showBody, /this\.nameInput\.value\s*=\s*''/);
+  assert.match(showBody, /this\.editableCheckbox\.checked\s*=\s*true/);
+});


### PR DESCRIPTION
## 요약
- 필드 입력 대화상자(FieldInsertDialog)는 싱글턴으로 재사용되는데, `show()`가 안내문(guideInput)만 초기화하고 메모/이름/편집가능 체크박스는 리셋하지 않아 이전 값이 남아있던 문제를 수정
- `show()`에서 memoInput/nameInput을 빈 문자열로, editableCheckbox를 기본값(true)으로 리셋

## 관련 이슈
Closes #3037

## 테스트
- `rhwp-studio/tests/field-insert-dialog-reset.test.ts` 신규 추가, `npx tsx --test` 통과 확인