### PR TITLE
문자표 최근 사용 문자 선택 시 엉뚱한 셀 하이라이트 수정

### DIFF
--- a/mydocs/report/task_m100_2857_report.md
+++ b/mydocs/report/task_m100_2857_report.md
@@ -1,0 +1,25 @@
+# task_m100_2857: 문자표 최근 사용 문자 하이라이트 버그 수정
+
+## 이슈
+#3052 — [문자표] 최근 사용 문자 선택 시 엉뚱한 그리드 셀이 하이라이트됨
+
+## 원인
+`rhwp-studio/src/ui/symbols-dialog.ts`의 `selectChar()`는 그리드 하이라이트 인덱스를
+`codePoint - this.currentBlock.start`로 계산한다. [최근 사용한 문자] 목록에서 문자를
+클릭하면 그 문자가 **현재 화면에 표시된 블록**에 속하지 않을 수 있는데도 동일한 계산을
+그대로 적용해, charGrid의 관계없는 셀(또는 우연히 범위 안에 들어간 엉뚱한 문자)에
+`selected` 클래스를 붙였다.
+
+## 수정
+- `isCodePointInBlock(codePoint, block)` 헬퍼를 추가하고 export.
+- `selectChar()`에서 이 헬퍼로 문자가 현재 블록에 속할 때만 그리드 하이라이트를 적용하도록
+  가드.
+
+## 검증
+- 신규 단위 테스트 `rhwp-studio/tests/symbols-dialog.test.ts` 추가:
+  현재 블록 내부 코드포인트는 true, 다른 블록(한글 음절) 코드포인트는 false를 확인.
+- `npx tsx --test tests/symbols-dialog.test.ts` 통과.
+
+## 영향 범위
+UI 표시(하이라이트)만 변경, 문자 선택/삽입 로직(`selectedChar`, `codeLabel`, `previewCell`)은
+변경 없음 — 최소 diff.

--- a/rhwp-studio/src/ui/symbols-dialog.ts
+++ b/rhwp-studio/src/ui/symbols-dialog.ts
@@ -60,6 +60,11 @@ const COLS = 16;
 const RECENT_KEY = 'rhwp-symbols-recent';
 const MAX_RECENT = 32;
 
+/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
+export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
+  return codePoint >= block.start && codePoint <= block.end;
+}
+
 export class SymbolsDialog {
   private services: CommandServices;
   private _open = false;
@@ -285,11 +290,13 @@ export class SymbolsDialog {
     this.codeLabel.textContent = codePoint.toString(16).toUpperCase().padStart(4, '0');
     this.previewCell.textContent = ch;
 
-    // 그리드 하이라이트
+    // 그리드 하이라이트 (최근 사용 문자가 현재 블록에 없으면 하이라이트하지 않음)
     this.charGrid.querySelectorAll('.sym-cell.selected').forEach(el => el.classList.remove('selected'));
-    const idx = codePoint - this.currentBlock.start;
-    const cells = this.charGrid.querySelectorAll('.sym-cell');
-    cells[idx]?.classList.add('selected');
+    if (isCodePointInBlock(codePoint, this.currentBlock)) {
+      const idx = codePoint - this.currentBlock.start;
+      const cells = this.charGrid.querySelectorAll('.sym-cell');
+      cells[idx]?.classList.add('selected');
+    }
   }
 
   // ── 삽입 ──

--- a/rhwp-studio/src/ui/symbols-dialog.ts
+++ b/rhwp-studio/src/ui/symbols-dialog.ts
@@ -6,14 +6,11 @@
 import type { CommandServices } from '@/command/types';
 import { InsertTextCommand } from '@/engine/command';
 import { enableDialogDrag } from './dialog-drag';
+import { isCodePointInBlock, type UnicodeBlock } from './unicode-block.ts';
+
+export { isCodePointInBlock } from './unicode-block.ts';
 
 // ── 유니코드 블록 정의 ──
-
-interface UnicodeBlock {
-  name: string;
-  start: number;
-  end: number;
-}
 
 const UNICODE_BLOCKS: UnicodeBlock[] = [
   { name: '기본 라틴 문자', start: 0x0020, end: 0x007F },
@@ -59,11 +56,6 @@ const UNICODE_BLOCKS: UnicodeBlock[] = [
 const COLS = 16;
 const RECENT_KEY = 'rhwp-symbols-recent';
 const MAX_RECENT = 32;
-
-/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
-export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
-  return codePoint >= block.start && codePoint <= block.end;
-}
 
 export class SymbolsDialog {
   private services: CommandServices;

--- a/rhwp-studio/src/ui/unicode-block.ts
+++ b/rhwp-studio/src/ui/unicode-block.ts
@@ -1,0 +1,19 @@
+/**
+ * 유니코드 블록 판정 헬퍼
+ *
+ * symbols-dialog.ts 에서 분리한 순수 함수 모듈. `@/engine/command` 등 런타임
+ * 의존성이 없어 node 네이티브 테스트 러너로 직접 import 해도 안전하다
+ * (symbols-dialog.ts 는 InsertTextCommand 를 가져오며, 해당 모듈은 node의
+ * TypeScript strip-only 모드가 지원하지 않는 parameter property 문법을 쓴다).
+ */
+
+export interface UnicodeBlock {
+  name: string;
+  start: number;
+  end: number;
+}
+
+/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
+export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
+  return codePoint >= block.start && codePoint <= block.end;
+}

--- a/rhwp-studio/tests/symbols-dialog.test.ts
+++ b/rhwp-studio/tests/symbols-dialog.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isCodePointInBlock } from '../src/ui/symbols-dialog.ts';
+
+// [문자표] 최근 사용 문자는 현재 표시된 블록과 다른 블록에 속할 수 있다.
+// selectChar()가 codePoint - block.start 로 그리드 인덱스를 계산하므로,
+// 문자가 현재 블록에 속하지 않으면 엉뚱한 셀을 하이라이트하게 되는 버그가 있었다.
+test('현재 블록에 속하지 않는 코드포인트는 false', () => {
+  const block = { name: '기본 라틴 문자', start: 0x0020, end: 0x007F };
+  assert.equal(isCodePointInBlock(0x0041, block), true); // 'A' — 블록 내부
+  assert.equal(isCodePointInBlock(0xAC00, block), false); // '가' — 다른 블록(한글 음절)
+});

--- a/rhwp-studio/tests/symbols-dialog.test.ts
+++ b/rhwp-studio/tests/symbols-dialog.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isCodePointInBlock } from '../src/ui/symbols-dialog.ts';
+import { isCodePointInBlock } from '../src/ui/unicode-block.ts';
 
 // [문자표] 최근 사용 문자는 현재 표시된 블록과 다른 블록에 속할 수 있다.
 // selectChar()가 codePoint - block.start 로 그리드 인덱스를 계산하므로,


### PR DESCRIPTION
## 요약
- 이슈 #3052 해결
- symbols-dialog.ts의 selectChar()는 그리드 하이라이트 인덱스를 codePoint - currentBlock.start 로 계산한다. [최근 사용한 문자] 클릭 시 그 문자가 현재 화면에 표시된 블록에 속하지 않을 수 있는데도 동일 계산을 적용해 관계없는 셀에 selected 클래스를 붙이는 버그가 있었다.
- isCodePointInBlock() 가드를 추가해 문자가 현재 블록에 속할 때만 하이라이트하도록 수정.

## 테스트 계획
- [x] 신규 단위 테스트 rhwp-studio/tests/symbols-dialog.test.ts 추가 및 통과 확인 (`npx tsx --test tests/symbols-dialog.test.ts`)

## 관련 문서
- mydocs/report/task_m100_2857_report.md