### PR TITLE
본문 최상위 미주 재번호 매기기 누락 수정

### DIFF
--- a/mydocs/report/task_m100_3047_report.md
+++ b/mydocs/report/task_m100_3047_report.md
@@ -1,0 +1,25 @@
+# task_m100_3047: 본문 최상위 미주 재번호 매기기 누락 수정
+
+## 이슈
+#3047
+
+## 원인
+`src/document_core/commands/footnote_ops.rs`의 `renumber_footnotes_in_section`은
+각주 삭제 등 이벤트 후 구역 내 각주/미주 번호를 문서 순서대로 재계산한다.
+
+표 셀 내부, 글상자 텍스트박스 내부 순회에서는 `Control::Footnote`와 `Control::Endnote`를
+모두 처리하지만, 문단 최상위 컨트롤을 순회하는 바깥쪽 match에는 `Control::Footnote`
+분기만 있고 `Control::Endnote` 분기가 없었다. 그 결과 표/글상자 밖에 직접 삽입된
+미주는 각주 삭제 후에도 번호가 갱신되지 않았다.
+
+## 수정
+바깥쪽 match에 `Control::Endnote` 분기를 추가해 표/글상자 내부 처리와 동일하게
+번호를 매기도록 했다.
+
+## 테스트
+`footnote_ops.rs`에 회귀 테스트
+`delete_footnote_renumbers_top_level_endnote_after_it` 추가.
+본문에 각주 1개 + 미주 1개를 삽입한 뒤 각주를 삭제하면, 남은 미주 번호가
+1로 재계산되는지 검증한다.
+
+`cargo test --lib footnote_ops::tests` 통과 확인.

--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -21,6 +21,10 @@ impl DocumentCore {
                         footnote.number = number;
                         number += 1;
                     }
+                    Control::Endnote(endnote) => {
+                        endnote.number = number;
+                        number += 1;
+                    }
                     Control::Table(table) => {
                         for cell in &mut table.cells {
                             for cell_para in &mut cell.paragraphs {
@@ -690,5 +694,51 @@ impl DocumentCore {
             "\"fnParaIndex\":{},\"charOffset\":{}",
             prev_idx, merge_offset
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+
+    /// 본문 최상위(표/글상자 밖) 미주는 renumber_footnotes_in_section 의 바깥쪽 match 에
+    /// Control::Endnote 분기가 없어 각주 삭제 후에도 번호가 갱신되지 않던 결함의 회귀 테스트.
+    #[test]
+    fn delete_footnote_renumbers_top_level_endnote_after_it() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ab").unwrap();
+
+        // 순서: 각주(offset 0) -> 미주(offset 1, 각주 삽입으로 +8 시프트됨)
+        core.insert_footnote_native(0, 0, 0).unwrap();
+        let endnote_offset = core.document.sections[0].paragraphs[0]
+            .char_offsets
+            .get(1)
+            .copied()
+            .unwrap() as usize;
+        core.insert_endnote_native(0, 0, endnote_offset).unwrap();
+
+        let footnote_ctrl_idx = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .position(|c| matches!(c, Control::Footnote(_)))
+            .expect("본문에 각주 컨트롤이 있어야 함");
+        core.delete_footnote_native(0, 0, footnote_ctrl_idx)
+            .unwrap();
+
+        let remaining_endnote_number = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Endnote(e) => Some(e.number),
+                _ => None,
+            })
+            .expect("본문에 미주 컨트롤이 남아 있어야 함");
+
+        assert_eq!(
+            remaining_endnote_number, 1,
+            "각주 삭제 후 본문 최상위 미주 번호가 1로 재계산되어야 함"
+        );
     }
 }


### PR DESCRIPTION
## 요약
- \`renumber_footnotes_in_section\`의 문단 최상위 컨트롤 순회 match에 \`Control::Endnote\` 분기가 없어, 표/글상자 밖에 직접 삽입된 미주는 각주 삭제 후에도 번호가 갱신되지 않던 결함 수정
- 표 셀/글상자 내부 순회와 동일하게 최상위에도 \`Control::Endnote\` 처리 추가

## 관련 이슈
Closes #3047

## 테스트
- \`cargo test --lib footnote_ops::tests\` (신규 회귀 테스트 \`delete_footnote_renumbers_top_level_endnote_after_it\` 통과)