### PR TITLE
fix(hwp3): doc_info.footnote_text_margin(각주 분리선-본문 간격) IR 배선

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -401,9 +401,18 @@ fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
         .max(1)
 }
 
-fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
+fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
+    };
+
+    // [Task #3054] doc_info.footnote_text_margin(각주 분리선과 각주 본문 사이의
+    // 간격)을 note_spacing 으로 배선한다. 미배선 시 항상 하드코딩된 576 값이
+    // 쓰여 문서가 지정한 간격이 무시됐다.
+    let note_spacing = if doc_info.footnote_text_margin != 0 {
+        (doc_info.footnote_text_margin as i16).saturating_mul(4)
+    } else {
+        576
     };
 
     let mut shape = FootnoteShape {
@@ -411,7 +420,7 @@ fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
         suffix_char: ')',
         start_number: 1,
         separator_margin_top: 864,
-        note_spacing: 576,
+        note_spacing,
         separator_line_width: 1,
         separator_color: 0x00000000,
         numbering: FootnoteNumbering::Continue,
@@ -3243,7 +3252,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     super::populate_link_image_paths(&mut doc);
 
     crate::parser::assign_auto_numbers(&mut doc);
-    fixup_hwp3_notes(&mut doc);
+    fixup_hwp3_notes(&mut doc, &doc_info);
     fixup_hwp3_outline_fields(&mut doc);
     fixup_hwp3_picture_numbers(&mut doc);
     fixup_hwp3_outline_bullets(&mut doc);
@@ -3259,7 +3268,7 @@ struct Hwp3NoteFixupState {
     has_endnote: bool,
 }
 
-fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
+fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, doc_info: &Hwp3DocInfo) {
     let para_shapes = doc.doc_info.para_shapes.clone();
     let mut state = Hwp3NoteFixupState {
         footnote_number: doc.doc_properties.footnote_start_num.max(1),
@@ -3275,7 +3284,7 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
 
     if state.has_endnote {
         for section in &mut doc.sections {
-            section.section_def.endnote_shape = hwp3_default_endnote_shape();
+            section.section_def.endnote_shape = hwp3_default_endnote_shape(doc_info);
             ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
@@ -3890,6 +3899,22 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn task3054_hwp3_default_endnote_shape_wires_footnote_text_margin() {
+        // [Task #3054] doc_info.footnote_text_margin 이 note_spacing 으로
+        // 배선돼야 한다. 값이 0이면 기존 하드코딩 기본값(576)을 유지한다.
+        let doc_info = Hwp3DocInfo {
+            footnote_text_margin: 50,
+            ..Default::default()
+        };
+        let shape = hwp3_default_endnote_shape(&doc_info);
+        assert_eq!(shape.note_spacing, 200);
+
+        let default_doc_info = Hwp3DocInfo::default();
+        let default_shape = hwp3_default_endnote_shape(&default_doc_info);
+        assert_eq!(default_shape.note_spacing, 576);
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {


### PR DESCRIPTION
## 요약

- `hwp3_default_endnote_shape` 가 `doc_info` 를 받지 않아 `note_spacing`(한컴 UI "구분선 아래": 구분선과 첫 주석 내용 사이 간격)이 항상 하드코딩된 576 으로 채워졌다.
- `doc_info.footnote_text_margin`(오프셋 106, 파싱은 되지만 IR로 미배선)을 `note_spacing` 으로 배선해 문서가 지정한 간격을 반영한다.
- 값이 0이면 기존 기본값 576 을 유지한다.

## 테스트

- `task3054_hwp3_default_endnote_shape_wires_footnote_text_margin` 추가
- `cargo check --lib` 통과