### PR TITLE
fix(parser): HWPX 표 row_sizes를 셀 높이 대신 셀 수로 채움

### DIFF
--- a/mydocs/report/task_m100_2901_report.md
+++ b/mydocs/report/task_m100_2901_report.md
@@ -1,0 +1,33 @@
+# Task m100-2901: HWPX 표 row_sizes 계약 위반 수정
+
+- 이슈: #3060
+- 브랜치: `task/m100-2901-table-cnt-attrs`
+
+## 문제
+
+`src/parser/hwpx/section.rs`의 `parse_table`이 `Table::row_sizes`를 "행별 최대 셀 높이"로
+채우고 있었다. 그러나 이 필드의 실제 계약은 "행별 셀 수"(HWP5 스펙 `UINT16[NRows]`)이며,
+다음 모든 생산자가 이 계약을 따른다.
+
+- `src/parser/control.rs:274` (HWP5 네이티브 파서, 스펙 주석 명시)
+- `src/model/table.rs::rebuild_row_sizes()`
+- `src/document_core/html_table_import.rs:538`
+- `src/document_core/commands/object_ops/table.rs` (신규 표 생성)
+- `src/document_core/converters/hwpx_to_hwp.rs::materialize_table_record_row_sizes`
+  (HWPX→HWP 저장 직전, "행별 셀 수"로 강제 재계산 — 이 안전망 때문에 HWP 변환 경로는
+  증상이 가려져 있었다)
+
+HWPX 파서만 유일하게 "높이"를 채워, 순수 HWPX IR을 그대로 소비하는 경로
+(예: 렌더러의 cellzone 폴백 계산)에서 필드 의미가 어긋난다.
+
+## 수정
+
+`parse_table` 말미의 row_sizes 계산을 "행별 셀 수" 카운트로 통일했다 (다른 생산자와
+동일한 `(0..row_count).map(|r| cells.iter().filter(|c| c.row == r).count())` 패턴).
+
+## 검증
+
+- `cargo check --lib`: 통과
+- 신규 테스트 `test_parse_table_row_sizes_is_cell_count_not_height` (2행×2열, 행별 높이를
+  다르게 주어 카운트(2,2)와 높이가 혼동되지 않음을 확인): 통과
+- `cargo test --lib table` (332개 표 관련 테스트, hwpx_to_hwp 어댑터 회귀 포함): 전부 통과

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1633,7 +1633,6 @@ fn parse_table(
     // 표 내용 파싱 (행/셀)
     let mut buf = Vec::new();
     let mut current_row: u16 = 0;
-    let mut row_sizes: Vec<HwpUnit16> = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -1806,18 +1805,12 @@ fn parse_table(
     table.common.margin.top = table.outer_margin_top;
     table.common.margin.bottom = table.outer_margin_bottom;
 
-    // row_sizes 설정 (행별 셀 높이의 최대값)
-    for r in 0..table.row_count {
-        let max_h = table
-            .cells
-            .iter()
-            .filter(|c| c.row == r && c.row_span == 1)
-            .map(|c| c.height as i16)
-            .max()
-            .unwrap_or(0);
-        row_sizes.push(max_h);
-    }
-    table.row_sizes = row_sizes;
+    // row_sizes 설정 (행별 셀 수, HWP 스펙 UINT16[NRows] 계약과 동일 — 높이가 아니다).
+    // model::table::Table::rebuild_row_sizes, parser::control(HWP5), html_table_import,
+    // document_core::commands::object_ops::table 이 모두 이 필드를 "행별 셀 개수"로 채운다.
+    table.row_sizes = (0..table.row_count)
+        .map(|r| table.cells.iter().filter(|c| c.row == r).count() as i16)
+        .collect();
 
     materialize_hwpx_table_attrs(&mut table, table_record_flags);
     table.rebuild_grid();
@@ -6587,6 +6580,39 @@ mod tests {
         assert!(table.cells[0].apply_inner_margin);
         assert_eq!(table.cells[0].padding.left, 141);
         assert_eq!(table.cells[0].padding.top, 113);
+    }
+
+    #[test]
+    fn test_parse_table_row_sizes_is_cell_count_not_height() {
+        // [#row_sizes 계약] HWP 스펙 UINT16[NRows]("행별 셀 수")과 동일해야 한다.
+        // model::table::Table::rebuild_row_sizes, parser::control(HWP5),
+        // html_table_import 모두 이 필드를 "행별 셀 개수"로 채우므로 HWPX 파서만
+        // 높이를 채우면 계약이 깨진다. 2행 2열에서 각 셀 높이를 다르게 주어
+        // 카운트(2)와 높이(예: 500/3000)를 구분한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl rowCnt="2" colCnt="2" cellSpacing="0" borderFillIDRef="0">
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="1" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc>
+      </hp:tr>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="1"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="3000"/></hp:tc>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="1" rowAddr="1"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="3000"/></hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(table) => table,
+            other => panic!("expected table, got {:?}", other),
+        };
+        assert_eq!(table.row_sizes, vec![2, 2]);
     }
 
     #[test]


### PR DESCRIPTION
## 문제

이슈: #3060

`src/parser/hwpx/section.rs`의 `parse_table`이 `Table::row_sizes`를 "행별 최대 셀 높이"로
채우고 있었다. 이 필드의 실제 계약은 "행별 셀 수"(HWP5 스펙 `UINT16[NRows]`, `src/parser/control.rs:274`
주석에 명시)이며, `model::table::Table::rebuild_row_sizes`, `html_table_import`,
`document_core::commands::object_ops::table`(신규 표 생성) 등 다른 모든 생산자가 이 계약을
따른다. `document_core::converters::hwpx_to_hwp::materialize_table_record_row_sizes`가
HWPX→HWP 저장 직전에 "행별 셀 수"로 강제 재계산하기 때문에 이 안전망 덕분에 HWP 변환
경로에서는 증상이 가려져 있었지만, 순수 HWPX IR을 그대로 소비하는 경로(예: 렌더러의
cellzone 폴백 계산)에서는 필드 의미가 어긋난다.

## 수정

`parse_table` 말미의 row_sizes 계산을 다른 생산자와 동일한 "행별 셀 수" 카운트로 통일.

## 검증

- `cargo check --lib`: 통과
- 신규 테스트 `test_parse_table_row_sizes_is_cell_count_not_height` (2행×2열, 행별 높이를
  다르게 주어 카운트와 높이가 혼동되지 않음을 확인): 통과
- `cargo test --lib table` (332개 표 관련 테스트, hwpx_to_hwp 어댑터 회귀 포함): 전부 통과

자세한 내용: `mydocs/report/task_m100_2901_report.md`