### PR TITLE
fix(ui): 그림 자르기/여백 입력값 음수 클램프 추가

### DIFF
--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -437,10 +437,10 @@ function appendImageBox(
   current: readonly [number, number, number, number],
 ): void {
   if (!values) return;
-  addChanged(patch, keys[0], mmToHwp(values.left), current[0]);
-  addChanged(patch, keys[1], mmToHwp(values.top), current[1]);
-  addChanged(patch, keys[2], mmToHwp(values.right), current[2]);
-  addChanged(patch, keys[3], mmToHwp(values.bottom), current[3]);
+  addChanged(patch, keys[0], Math.max(0, mmToHwp(values.left)), current[0]);
+  addChanged(patch, keys[1], Math.max(0, mmToHwp(values.top)), current[1]);
+  addChanged(patch, keys[2], Math.max(0, mmToHwp(values.right)), current[2]);
+  addChanged(patch, keys[3], Math.max(0, mmToHwp(values.bottom)), current[3]);
 }
 
 function appendImageEffects(

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -519,6 +519,36 @@ const fixtures: PatchFixture[] = [
     },
     expected: {},
   },
+  {
+    name: 'negative crop and padding inputs clamp to zero',
+    objectType: 'image',
+    props: pictureProps({
+      cropLeft: 100,
+      cropTop: 100,
+      cropRight: 100,
+      cropBottom: 100,
+      paddingLeft: 100,
+      paddingTop: 100,
+      paddingRight: 100,
+      paddingBottom: 100,
+    }),
+    update(form) {
+      form.image = {
+        crop: { left: '-1', top: '-2', right: '-3', bottom: '-4' },
+        padding: { left: '-4', top: '-3', right: '-2', bottom: '-1' },
+      };
+    },
+    expected: {
+      cropLeft: 0,
+      cropTop: 0,
+      cropRight: 0,
+      cropBottom: 0,
+      paddingLeft: 0,
+      paddingTop: 0,
+      paddingRight: 0,
+      paddingBottom: 0,
+    },
+  },
 ];
 
 for (const fixture of fixtures) {


### PR DESCRIPTION
## 요약
- `appendImageBox()`가 mm 입력을 hwp 단위로 변환할 때 음수를 그대로 patch에 반영하던 문제 수정
- `Math.max(0, ...)`로 클램프하여 자르기(crop)/여백(padding) 값이 음수가 되지 않도록 함
- outerMargin 동기 스피너와 동일한 하한 정책을 자르기/여백에도 적용

Fixes #3056

## 재현 및 검증 (red → green)
- 수정 전: 자르기/여백 입력에 음수(`-1` ~ `-4`)를 입력하면 patch에 음수 값이 그대로 반영됨 (테스트 실패, red)
- 수정 후: `Math.max(0, mmToHwp(...))` 클램프 적용으로 모든 음수 입력이 `0`으로 정규화됨을 확인 (테스트 통과, green)
- `rhwp-studio/tests/picture-props-apply-model.test.ts`에 `negative crop and padding inputs clamp to zero` 케이스 추가하여 회귀 방지

## 변경 파일
- `rhwp-studio/src/ui/picture-props-apply-model.ts`
- `rhwp-studio/tests/picture-props-apply-model.test.ts`