### PR TITLE
fix(clipboard): border shorthand의 rgb() 색상값 공백 파싱 버그 수정

### DIFF
--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -1265,7 +1265,32 @@ pub(crate) fn parse_css_border_shorthand(val: &str) -> (f64, u32, u8) {
         return (0.0, 0, 0);
     }
 
-    let parts: Vec<&str> = val.split_whitespace().collect();
+    // rgb()/rgba() 안에 공백이 있으면(예: "rgb(255, 0, 0)") 단순 split_whitespace가
+    // 색상 토큰을 여러 조각으로 쪼개버리므로, 괄호 내부의 공백은 보존한 채로 분리한다.
+    let mut parts: Vec<String> = Vec::new();
+    let mut depth = 0i32;
+    let mut cur = String::new();
+    for ch in val.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                cur.push(ch);
+            }
+            ')' => {
+                depth -= 1;
+                cur.push(ch);
+            }
+            c if c.is_whitespace() && depth == 0 => {
+                if !cur.is_empty() {
+                    parts.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        parts.push(cur);
+    }
     let mut width_pt = 0.0f64;
     let mut color: u32 = 0; // black
     let mut style: u8 = 1; // solid

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -4897,6 +4897,12 @@ fn test_table_utility_functions() {
     assert_eq!(w2, 0.0);
     assert_eq!(s2, 0);
 
+    // rgb() 내부에 공백이 있어도 색상 토큰이 쪼개지지 않아야 한다.
+    let (w3, c3, s3) = super::parse_css_border_shorthand("1px solid rgb(255, 0, 0)");
+    assert!((w3 - 0.75).abs() < 0.01, "border width 1px -> 0.75pt");
+    assert_eq!(c3, 0x0000FF, "border color red (BGR)");
+    assert_eq!(s3, 1, "border style solid");
+
     // css_border_width_to_hwp
     assert_eq!(super::css_border_width_to_hwp(0.28), 0); // 0.28pt ≈ 0.1mm → index 0
     assert!(super::css_border_width_to_hwp(1.0) >= 5); // 1.0pt ≈ 0.35mm → index 5+


### PR DESCRIPTION
## 요약
- `parse_css_border_shorthand`(src/document_core/helpers.rs, html_table_import.rs에서 표 셀 border 파싱에 사용)가 shorthand 값을 `split_whitespace()`로만 토큰화하여, `border: 1px solid rgb(255, 0, 0)`처럼 rgb()/rgba() 함수 내부에 공백이 있으면 색상 토큰이 여러 조각으로 쪼개져 색상 매칭이 실패하고 기본값(검정)으로 떨어지던 문제를 수정.
- 괄호 depth를 추적해 괄호 내부 공백은 보존한 채로 토큰을 분리하도록 교체.

Closes #3066

## 테스트
- `parse_css_border_shorthand("1px solid rgb(255, 0, 0)")`에 대한 유닛 테스트를 `src/wasm_api/tests.rs`에 추가 (color/width/style 검증).

## 알려진 제약
로컬 환경의 MSVC 링커(`link.exe`)가 `dbghelp.lib` 손상으로 native 빌드/테스트 실행이 불가능한 상태라(본 변경과 무관한 환경 이슈), 로컬에서 테스트를 직접 실행해 통과를 확인하지 못했습니다. 코드 변경은 수동으로 로직을 추적 검증했고, CI에서 테스트 실행 결과를 확인해 주시면 감사하겠습니다.