### PR TITLE
본문 각주 커서조회/삭제가 미주(Endnote)도 처리하도록 수정

### DIFF
--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -96,8 +96,10 @@ impl DocumentCore {
 
         let positions = crate::document_core::helpers::find_control_text_positions(para);
         for (control_idx, ctrl) in para.controls.iter().enumerate() {
-            let Control::Footnote(footnote) = ctrl else {
-                continue;
+            let number = match ctrl {
+                Control::Footnote(footnote) => footnote.number,
+                Control::Endnote(endnote) => endnote.number,
+                _ => continue,
             };
             let Some(marker_pos) = positions.get(control_idx).copied() else {
                 continue;
@@ -114,7 +116,7 @@ impl DocumentCore {
                     para_idx,
                     control_idx,
                     marker_pos,
-                    footnote.number,
+                    number,
                 ));
             }
         }
@@ -141,11 +143,15 @@ impl DocumentCore {
             let ctrl = para.controls.get(control_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("컨트롤 인덱스 {} 범위 초과", control_idx))
             })?;
-            let Control::Footnote(footnote) = ctrl else {
-                return Err(HwpError::RenderError(format!(
-                    "컨트롤 {}은 각주가 아닙니다",
-                    control_idx
-                )));
+            let number = match ctrl {
+                Control::Footnote(footnote) => footnote.number,
+                Control::Endnote(endnote) => endnote.number,
+                _ => {
+                    return Err(HwpError::RenderError(format!(
+                        "컨트롤 {}은 각주/미주가 아닙니다",
+                        control_idx
+                    )));
+                }
             };
             let positions = crate::document_core::helpers::find_control_text_positions(para);
             let marker_pos = positions.get(control_idx).copied().ok_or_else(|| {
@@ -154,7 +160,7 @@ impl DocumentCore {
                     control_idx
                 ))
             })?;
-            (marker_pos, footnote.number)
+            (marker_pos, number)
         };
 
         {

--- a/tests/issue_598_footnote_marker_nav.rs
+++ b/tests/issue_598_footnote_marker_nav.rs
@@ -84,6 +84,28 @@ fn issue_598_second_body_footnote_marker_has_same_cursor_unit() {
 }
 
 #[test]
+fn endnote_marker_can_be_found_and_deleted_like_footnote() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/endnote-01.hwp");
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse endnote-01.hwp");
+
+    // section 0 / para 3 / ctrl 0 is an endnote marker at text position 7.
+    let forward = doc
+        .get_footnote_at_cursor_native(0, 3, 7, "forward")
+        .expect("find endnote after cursor");
+    assert!(forward.contains("\"hit\":true"), "forward json: {forward}");
+    assert!(
+        forward.contains("\"controlIndex\":0"),
+        "forward json: {forward}"
+    );
+
+    let deleted = doc
+        .delete_footnote_native(0, 3, 0)
+        .expect("delete endnote control");
+    assert!(deleted.contains("\"ok\":true"), "deleted json: {deleted}");
+}
+
+#[test]
 fn issue_598_body_footnote_marker_can_be_found_and_deleted_from_cursor() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/footnote-01.hwp");
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));


### PR DESCRIPTION
## 요약
- `get_footnote_at_cursor_native`, `delete_footnote_native`가 `Control::Footnote`만 매칭하고 `Control::Endnote`를 빠뜨리던 비대칭 수정 (#3047/#3055와 같은 패턴).
- 같은 파일의 다른 함수들은 이미 Footnote/Endnote를 모두 처리하고 있어 이 두 함수만 예외였음.

Closes #3067

## 테스트
- `samples/endnote-01.hwp`로 미주 마커 커서조회 + 삭제 신규 테스트 추가 (`endnote_marker_can_be_found_and_deleted_like_footnote`)
- `cargo test --test issue_598_footnote_marker_nav` 통과
- `cargo check --lib` 통과