### PR TITLE
fix(parser/hwp3): ch==15(숨은설명) HiddenComment 배선 추가

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1526,6 +1526,12 @@ fn parse_object_control_char(
             footnote.paragraphs = nested_paragraphs;
             controls.push(crate::model::control::Control::Footnote(Box::new(footnote)));
         }
+    } else if ch == 15 {
+        let mut hidden_comment = crate::model::control::HiddenComment::default();
+        hidden_comment.paragraphs = nested_paragraphs;
+        controls.push(crate::model::control::Control::HiddenComment(Box::new(
+            hidden_comment,
+        )));
     } else if ch == 29 {
         let mut field = crate::model::control::Field::default();
         field.field_type = crate::model::control::FieldType::CrossRef;


### PR DESCRIPTION
## 요약

- \`parse_object_control_char\`에서 ch==15(숨은설명)가 명시적 분기 없이 최종 \`else\` 캐치올로
  빠져 \`Control::Unknown\`이 push되고, 이 과정에서 \`nested_paragraphs\`(숨은설명 본문 문단)가
  버려지는 문제를 수정했습니다.
- ch==16(머리말/꼬리말), ch==17(각주/미주)과 동일한 패턴으로 \`Control::HiddenComment\` 배선을
  추가했습니다. IR에는 이미 \`Control::HiddenComment\` / \`HiddenComment{ paragraphs }\`가 존재하며
  HWP5 경로는 이미 이를 사용하고 있어 신규 필드 추가 없이 배선만 보완했습니다.

Closes #3072

## 검증

- \`cargo check --lib\` 통과
- 실 재현 HWP3 숨은설명 샘플 파일이 저장소에 없어 라운드트립 회귀 테스트는 추가하지 못했습니다.
  코드 경로는 ch==16/17과 동일 패턴이며 정적으로 확인했습니다.