### PR TITLE
그림 속성 폭/높이 입력 음수 clamp 누락 수정 (#3071)

### DIFF
--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -211,8 +211,8 @@ function appendCommonSize(
 ): void {
   addChanged(patch, 'sizeProtect', form.sizeProtect, props.sizeProtect ?? false);
   if (form.sizeProtect) return;
-  addChanged(patch, 'width', mmToHwp(form.width), props.width);
-  addChanged(patch, 'height', mmToHwp(form.height), props.height);
+  addChanged(patch, 'width', Math.max(0, mmToHwp(form.width)), props.width);
+  addChanged(patch, 'height', Math.max(0, mmToHwp(form.height)), props.height);
 }
 
 function appendCommonPosition(

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -479,6 +479,15 @@ const fixtures: PatchFixture[] = [
     expected: { width: 500, height: 200 },
   },
   {
+    name: 'negative width/height input clamps to 0 instead of applying negative HWPUNIT',
+    objectType: 'image',
+    update(form) {
+      form.common.width = '-50';
+      form.common.height = '-30';
+    },
+    expected: { width: 0, height: 0 },
+  },
+  {
     name: 'image geometry, effects, border, and clamped transparency preserve field policy',
     objectType: 'image',
     update(form) {


### PR DESCRIPTION
## 요약
#3071 — `picture-props-apply-model.ts`의 `appendCommonSize()`가 폭/높이를
`mmToHwp()`로만 변환하고 하한 clamp가 없어, 사용자가 입력창에 음수를 직접
타이핑하면(HTML `min` 속성은 키보드 입력을 강제하지 않음) 음수 HWPUNIT이
그대로 WASM `setPictureProperties`까지 전달되던 문제를 수정했다.
같은 `mmToHwp()`가 쓰이는 horzOffset/vertOffset은 음수가 정상 값이라
그대로 두고, width/height에만 `Math.max(0, ...)`를 적용했다.

## 테스트
- `rhwp-studio/tests/picture-props-apply-model.test.ts`에 음수 입력 시
  0으로 clamp되는 케이스 추가.
- `npx tsx --test tests/picture-props-apply-model.test.ts` — 27/27 통과.

Closes #3071