### PR TITLE
머리말/꼬리말 그림 tac 토글 시 앵커 line_segs 마이그레이션 누락 수정

### DIFF
--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -662,7 +662,25 @@ impl DocumentCore {
                     ))
                 }
             };
+            // [Task #1151 v2] 본문 picture setter(set_picture_properties_native) 와 동일하게,
+            // treatAsChar false→true/true→false 전환 시 앵커 문단의 line_segs 도 갱신해야
+            // 한다. 머리말/꼬리말 경로는 이 마이그레이션이 누락되어 있었음 — tac on 시
+            // 그림 높이가 줄 높이에 반영되지 않아 렌더 시 그림이 겹치거나 잘림.
+            let was_tac = pic.common.treat_as_char;
             caption_created = Self::apply_picture_props_inner(pic, props_json);
+            let now_tac = pic.common.treat_as_char;
+            if !was_tac && now_tac {
+                if let crate::model::control::Control::Picture(pic_box) =
+                    &mut inner_para.controls[inner_control_idx]
+                {
+                    Self::migrate_picture_floating_to_inline(
+                        &mut inner_para.line_segs,
+                        pic_box.as_mut(),
+                    );
+                }
+            } else if was_tac && !now_tac {
+                Self::migrate_empty_picture_para_inline_to_floating(inner_para);
+            }
         }
         if caption_created {
             return Err(HwpError::RenderError(

--- a/tests/issue_header_picture_tac_line_seg_migration.rs
+++ b/tests/issue_header_picture_tac_line_seg_migration.rs
@@ -1,0 +1,89 @@
+//! 머리말/꼬리말 그림 treatAsChar 토글 시 앵커 문단 line_segs 미갱신 회귀 가드.
+//!
+//! 본문 그림(set_picture_properties_native)은 [Task #1151 v2] 마이그레이션으로
+//! treatAsChar false→true 시 앵커 line_segs[0].line_height 를 그림 높이로 갱신한다.
+//! 머리말/꼬리말 경로(set_header_footer_picture_properties_native)는 이 마이그레이션이
+//! 누락되어 있었다.
+
+use rhwp::model::control::Control;
+use std::fs;
+use std::path::Path;
+
+fn find_header_picture(hwp: &str) -> Option<(usize, usize, usize, usize, usize)> {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join(hwp);
+    let data = fs::read(&path).ok()?;
+    let doc = rhwp::parser::hwp3::parse_hwp3(&data).ok()?;
+    for (si, sec) in doc.sections.iter().enumerate() {
+        for (bi, para) in sec.paragraphs.iter().enumerate() {
+            for (hi, ctrl) in para.controls.iter().enumerate() {
+                if let Control::Header(h) = ctrl {
+                    for (ipi, ipara) in h.paragraphs.iter().enumerate() {
+                        for (ici, ictrl) in ipara.controls.iter().enumerate() {
+                            if matches!(ictrl, Control::Picture(_)) {
+                                return Some((si, bi, hi, ipi, ici));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn header_picture_tac_on_updates_anchor_line_height() {
+    use rhwp::document_core::DocumentCore;
+
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let p = Path::new(repo_root).join("samples/hwp3-sample11.hwp");
+    let data = fs::read(&p).expect("read");
+    let mut core = DocumentCore::from_bytes(&data).expect("parse");
+
+    let (si, bi, hi, ipi, ici) =
+        find_header_picture("samples/hwp3-sample11.hwp").expect("header picture must exist");
+
+    // 샘플의 초기 tac 상태와 무관하게 false→true 전환을 강제로 재현한다:
+    // 먼저 false 로 만들어 floating 상태로 정규화한 뒤, true 로 토글해 마이그레이션을
+    // 실제로 발동시킨다 (샘플 그림이 이미 tac=true 이면 두 번째 호출이 no-op 이 되어
+    // 마이그레이션 미실행을 놓치는 것을 방지).
+    core.set_header_footer_picture_properties_native(
+        si,
+        bi,
+        hi,
+        ipi,
+        ici,
+        r#"{"treatAsChar":false}"#,
+    )
+    .expect("set_header_footer_picture_properties_native(treatAsChar:false)");
+
+    let pic_height = match &core.document().sections[si].paragraphs[bi].controls[hi] {
+        Control::Header(h) => match &h.paragraphs[ipi].controls[ici] {
+            Control::Picture(p) => p.common.height as i32,
+            _ => panic!("expected picture"),
+        },
+        _ => panic!("expected header"),
+    };
+
+    core.set_header_footer_picture_properties_native(
+        si,
+        bi,
+        hi,
+        ipi,
+        ici,
+        r#"{"treatAsChar":true}"#,
+    )
+    .expect("set_header_footer_picture_properties_native(treatAsChar:true)");
+
+    let line_height = match &core.document().sections[si].paragraphs[bi].controls[hi] {
+        Control::Header(h) => h.paragraphs[ipi].line_segs.first().map(|s| s.line_height),
+        _ => panic!("expected header"),
+    };
+
+    assert_eq!(
+        line_height,
+        Some(pic_height),
+        "머리말 그림 treatAsChar on 후 앵커 문단 line_segs[0].line_height 가 그림 높이({pic_height})로 갱신되어야 함"
+    );
+}


### PR DESCRIPTION
## 요약

- 본문 그림 setter(`set_picture_properties_native`)는 treatAsChar false→true/true→false
  전환 시 앵커 문단의 `line_segs` 를 그림 높이에 맞춰 마이그레이션한다.
- 머리말/꼬리말 경로(`set_header_footer_picture_properties_native`,
  `src/document_core/commands/object_ops/picture.rs`)는 이 마이그레이션 호출이 누락되어
  있어, tac on 전환 후 그림 높이가 줄 높이에 반영되지 않아 렌더 시 그림이 겹치거나
  잘릴 수 있었다.
- 본문 경로와 동일하게 `migrate_picture_floating_to_inline` /
  `migrate_empty_picture_para_inline_to_floating` 호출 분기를 추가했다.

Issue: #3080

## 테스트

- `tests/issue_header_picture_tac_line_seg_migration.rs` 신규 회귀 테스트 추가
  (`samples/hwp3-sample11.hwp` 머리말 그림으로 false→true 토글 후
  `line_segs[0].line_height` 가 그림 높이로 갱신됨을 검증)
- `cargo check --lib`, `cargo test --test issue_header_picture_tac_line_seg_migration` 통과