### PR TITLE
CI 필수 gate 실패 시 후속 테스트 중단

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -387,13 +387,14 @@ jobs:
             }
 
   # [#2393] 기본 테스트 병렬화 — 테스트 바이너리를 한 번 빌드해 아카이브하고
-  # 8개 샤드가 컴파일 없이 나눠 실행한다. 빌드/테스트/린트가 각각 임계 경로에서
-  # 분리되어 wall-clock 이 단축된다. required check 는 집계 job "Build & Test" 로 불변.
+  # 8개 샤드가 컴파일 없이 나눠 실행한다. [#3064] 필수 gate 실패 뒤 불필요한
+  # 테스트를 시작하지 않도록 lint/frontend/native-skia 성공 뒤 archive를 만든다.
+  # required check 는 집계 job "Build & Test" 로 불변이다.
   build-test-archive:
     name: Build test archive
     runs-on: ubuntu-latest
-    needs: preflight
-    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
+    needs: [preflight, native-skia-tests]
+    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' && needs['native-skia-tests'].result == 'success' }}
     permissions:
       contents: read
     outputs:
@@ -480,7 +481,8 @@ jobs:
     permissions:
       contents: read
     strategy:
-      fail-fast: false
+      # [#3064] 8개 shard는 계속 병렬 실행하되 하나가 실패하면 나머지를 즉시 취소한다.
+      fail-fast: true
       matrix:
         shard: [1, 2, 3, 4, 5, 6, 7, 8]
 
@@ -574,8 +576,23 @@ jobs:
   native-skia-tests:
     name: Native Skia tests
     runs-on: ubuntu-latest
-    needs: preflight
-    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
+    needs: [preflight, lint, frontend-package-gates]
+    # frontend 비대상 job의 skipped는 정상 경로다. 대상 job의 실패/취소와 lint 실패는
+    # native-skia 이후 worker 전체에 전파한다.
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.lint.result == 'success'
+        && (
+          needs['frontend-package-gates'].result == 'success'
+          || (
+            needs.preflight.outputs.frontend_required != 'true'
+            && needs['frontend-package-gates'].result == 'skipped'
+          )
+        )
+      }}
     permissions:
       contents: read
 
@@ -634,8 +651,8 @@ jobs:
   frontend-package-gates:
     name: Frontend package gates
     runs-on: ubuntu-latest
-    needs: preflight
-    if: ${{ always() && needs.preflight.result == 'success' && needs.preflight.outputs.fast_pass != 'true' && needs.preflight.outputs.frontend_required == 'true' }}
+    needs: [preflight, lint]
+    if: ${{ always() && needs.preflight.result == 'success' && needs.lint.result == 'success' && needs.preflight.outputs.fast_pass != 'true' && needs.preflight.outputs.frontend_required == 'true' }}
     permissions:
       contents: read
 
@@ -744,18 +761,18 @@ jobs:
       # [#2393] 샤드 합계 대조 — 8샤드의 `<run> <total>` 을 모아 합계가 전체
       # 테스트 수와 일치하는지 검증한다 (fast-pass 시 샤드 미실행이라 생략).
       - name: Download shard counts
-        if: ${{ needs.preflight.outputs.fast_pass != 'true' }}
+        if: ${{ needs.preflight.outputs.fast_pass != 'true' && needs['test-shard'].result == 'success' }}
         uses: actions/download-artifact@v8
         with:
           pattern: shard-count-*
           merge-multiple: true
 
       - name: Verify shard totals
-        if: ${{ needs.preflight.outputs.fast_pass != 'true' }}
+        if: ${{ needs.preflight.outputs.fast_pass != 'true' && needs['test-shard'].result == 'success' }}
         env:
           EXPECTED_RUNNABLE: ${{ needs['build-test-archive'].outputs.runnable_tests }}
         run: |
-          shards=$(ls shard-count-*.txt 2>/dev/null | wc -l)
+          shards=$(find . -maxdepth 1 -type f -name 'shard-count-*.txt' | wc -l | tr -d ' ')
           if [[ "$shards" != "8" ]]; then
             echo "::error::expected 8 shard count files, found ${shards}"
             exit 1

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -2,7 +2,7 @@
 kind: canonical
 status: active
 canonical: mydocs/manual/pr_review_workflow.md
-last_verified: 2026-07-16
+last_verified: 2026-07-22
 ---
 
 # PR 리뷰 · 통합 워크플로우 매뉴얼
@@ -42,6 +42,24 @@ rhwp 는 v0.2.1 사이클부터 외부 기여자 PR 이 급증했다. 하이퍼-
 ## 2. PR 도착 시 확인 체크리스트
 
 새 PR 이 열리면 다음을 순서대로 확인한다.
+
+### 2.0 대량 PR 유입 사전 분류
+
+한 기여자의 열린 PR이 많아 개별 조회만으로 전체 규모와 통합 그룹을 파악하기 어려우면, 개별 review를
+시작하기 전에 다음 보조 도구로 병합 가능 여부와 변경 축 분포를 먼저 확인한다([#3077](https://github.com/edwardkim/rhwp/pull/3077)).
+
+```bash
+scripts/pr_triage.sh <author>
+scripts/pr_triage.sh <author> --list
+```
+
+- 기본 조회 상한은 500이다. 더 큰 상한이 필요하면 `RHWP_PR_LIMIT`, 다른 저장소를 확인하려면
+  `RHWP_REPO`를 지정한다.
+- 축별 합계와 열린 PR 수가 맞는지 확인한다. `gh pr list`의 기본 limit 30이나 복잡한 `jq`의
+  무매치로 행이 조용히 빠질 수 있으므로, 출력 일부만 보고 전수 처리 완료로 판정하지 않는다.
+- 이 도구는 충돌 목록과 통합 그룹 후보라는 **사실만 수집**한다. merge·close·rebase 요청 판정은
+  각 PR의 이슈, diff, 테스트, 기존 반영 여부를 확인한 뒤 사람이 수행한다.
+- 실제 개별 PR review를 시작할 때는 아래 2.1절에 따라 reviewer assign을 먼저 한다.
 
 ### 2.1 reviewer assign 선행
 

--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -8,6 +8,8 @@
   8개 test shard의 병렬 matrix는 유지하면서 한 shard 실패 시 나머지가 취소되도록 바꿨다.
 - YAML parse, actionlint, 의존성·8-shard 계약, diff-check를 통과했다. PR 최신 head의 GitHub Actions
   전체 성공과 job 실행 순서를 확인한 뒤 merge 및 이슈 후속 처리를 수행한다.
+- 같은 날 merge된 PR #3077의 `scripts/pr_triage.sh`를 실제 검토 절차에서 찾을 수 있도록
+  `pr_review_workflow.md`에 대량 PR 사전 분류 절차와 누락 방지·판정 책임을 추가한다.
 
 ## planet6897 PR #2818·#2819·#2820 체리픽 통합 검토
 

--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -1,5 +1,14 @@
 # 오늘 할일 - 2026년 7월 22일
 
+## #3064 — CI 필수 gate 실패 시 후속 테스트 중단
+
+- PR #3054의 CI run 29927292301에서 frontend gate 실패 뒤에도 Native Skia와 테스트 archive가
+  계속 실행된 원인을 `preflight`만 공유하는 sibling job 구조와 shard의 `fail-fast: false`로 확정했다.
+- 최신 `upstream/devel` 기반 `task/3064-ci-fail-fast`에서 필수 gate를 실패 전파 체인으로 구성하고,
+  8개 test shard의 병렬 matrix는 유지하면서 한 shard 실패 시 나머지가 취소되도록 바꿨다.
+- YAML parse, actionlint, 의존성·8-shard 계약, diff-check를 통과했다. PR 최신 head의 GitHub Actions
+  전체 성공과 job 실행 순서를 확인한 뒤 merge 및 이슈 후속 처리를 수행한다.
+
 ## planet6897 PR #2818·#2819·#2820 체리픽 통합 검토
 
 - 최신 `upstream/devel` `491e56fcc` 위에 `review/planet6897-2818-2820` 브랜치를 만들고 원 기여

--- a/mydocs/plans/task_m100_3064.md
+++ b/mydocs/plans/task_m100_3064.md
@@ -1,0 +1,35 @@
+# 수행계획서 — #3064 CI 필수 gate 실패 전파
+
+- 이슈: [#3064](https://github.com/edwardkim/rhwp/issues/3064)
+- 기준 브랜치: `upstream/devel`
+- 작업 브랜치: `task/3064-ci-fail-fast`
+- 재현 사례: PR #3054 / CI run 29927292301
+
+## 문제
+
+`lint`, `frontend-package-gates`, `native-skia-tests`, `build-test-archive`가 모두
+`preflight`만 의존해 동시에 시작한다. 따라서 한 필수 gate가 실패해도 이미 시작한 다른 고비용
+테스트는 계속 실행된다. `test-shard`도 `strategy.fail-fast: false`라 한 shard가 실패해도 나머지를
+취소하지 않는다.
+
+## 구현 계획
+
+1. 필수 gate를 `preflight → lint → frontend → native-skia → archive → shard` 순서의 실패 전파
+   체인으로 구성한다.
+2. frontend 변경이 없어서 frontend job이 `skipped`인 경우에는 native-skia 이후 체인을 정상 진행한다.
+3. matrix shard의 `fail-fast`를 `true`로 명시해 한 shard 실패 시 나머지를 취소한다.
+4. 최종 `Build & Test` 집계 job은 모든 worker 결과를 보고하는 required check로 유지한다.
+5. `actionlint`, YAML parse, 의존성 계약 검사와 PR CI 전체 성공으로 검증한다.
+
+## 완료 조건
+
+- 필수 gate 실패 시 뒤쪽 worker job이 시작되지 않는다.
+- shard 하나 실패 시 다른 shard가 취소된다.
+- frontend 비대상과 review-only fast-pass 경로가 유지된다.
+- 전체 성공 경로에서 8개 shard 및 최종 집계가 모두 성공한다.
+
+## 범위
+
+- 변경: `.github/workflows/ci.yml`, 작업 계획·보고·오늘할일 문서
+- 제외: 독립 workflow인 CodeQL, Render Diff의 상호 취소
+- 제품 Rust/TypeScript 코드와 테스트 명령 자체는 변경하지 않는다.

--- a/mydocs/plans/task_m100_3064.md
+++ b/mydocs/plans/task_m100_3064.md
@@ -20,6 +20,8 @@
 3. matrix shard의 `fail-fast`를 `true`로 명시해 한 shard 실패 시 나머지를 취소한다.
 4. 최종 `Build & Test` 집계 job은 모든 worker 결과를 보고하는 required check로 유지한다.
 5. `actionlint`, YAML parse, 의존성 계약 검사와 PR CI 전체 성공으로 검증한다.
+6. 같은 날 merge된 PR #3077의 대량 PR 분류 도구를 review workflow에서 찾을 수 있도록 사용 시점,
+   명령, 누락 방지 조건과 판정 책임을 문서화한다.
 
 ## 완료 조건
 
@@ -30,6 +32,6 @@
 
 ## 범위
 
-- 변경: `.github/workflows/ci.yml`, 작업 계획·보고·오늘할일 문서
+- 변경: `.github/workflows/ci.yml`, `mydocs/manual/pr_review_workflow.md`, 작업 계획·보고·오늘할일 문서
 - 제외: 독립 workflow인 CodeQL, Render Diff의 상호 취소
 - 제품 Rust/TypeScript 코드와 테스트 명령 자체는 변경하지 않는다.

--- a/mydocs/pr/archives/pr_3082_review.md
+++ b/mydocs/pr/archives/pr_3082_review.md
@@ -1,0 +1,66 @@
+# PR #3082 검토 기록 — CI 필수 gate 실패 시 후속 테스트 중단
+
+## 메타
+
+| 항목 | 내용 |
+|---|---|
+| PR | [#3082](https://github.com/edwardkim/rhwp/pull/3082) |
+| 작성자 | `jangster77` |
+| base / head | `devel` / `task/3064-ci-fail-fast` |
+| 관련 이슈 | [#3064](https://github.com/edwardkim/rhwp/issues/3064) |
+| 문서 작성 시점 참고값 | full-CI head `b12f0aea4`, mergeable `MERGEABLE`, merge state `CLEAN` |
+
+## 변경 검토
+
+- PR #3054에서 frontend gate 실패 뒤 다른 고비용 worker가 계속 실행된 원인을, 각 worker가
+  `preflight`만 의존하는 sibling 구조와 shard의 `fail-fast: false`로 확인했다.
+- 필수 gate를 `preflight → lint → frontend → native-skia → archive → shard` 순서로 연결했다.
+- frontend 비대상 job의 정상 `skipped`는 native-skia 이후 체인을 허용하고, frontend 실패·취소 및 lint
+  실패는 후속 worker 전체에 전파한다.
+- 기본 테스트 matrix `[1,2,3,4,5,6,7,8]`은 유지하고 `fail-fast: true`만 적용했다. 정상 경로는
+  8-way 병렬이고, 한 shard 실패 시 나머지 실행 중·대기 shard가 취소된다.
+- 최종 `Build & Test` 집계는 항상 실행해 worker 실패 상태를 required check에 표시한다.
+- 추가 요청에 따라 PR #3077의 `scripts/pr_triage.sh`를 `pr_review_workflow.md` 2.0절에서 찾고 사용할 수
+  있도록 실행 명령, 조회 상한, 누락 방지와 사람의 최종 판정 책임을 문서화했다.
+
+## 렌더 영향 판정
+
+CI workflow와 운영 문서만 변경했다. renderer/layout/typeset, 샘플, golden, 기준 PDF를 변경하지 않아
+visual sweep 대상이 아니다.
+
+## 검증
+
+### 로컬 정적 검증
+
+| 항목 | 결과 |
+|---|---|
+| YAML parse | PASS |
+| `actionlint .github/workflows/ci.yml` | PASS |
+| 필수 job `needs` 계약 | PASS |
+| shard matrix 1~8 보존 | PASS |
+| `test-shard.strategy.fail-fast == true` | PASS |
+| `bash -n scripts/pr_triage.sh` | PASS |
+| `git diff --check` | PASS |
+
+제품 코드와 테스트 명령은 바꾸지 않았다. CI workflow 변경은 최신 GitHub Actions 결과로 전체 회귀를
+판정한다.
+
+### GitHub Actions 실측
+
+full-CI head `b12f0aea4` 기준:
+
+- CI run [29932241496](https://github.com/edwardkim/rhwp/actions/runs/29932241496): **success**
+  - preflight, lint, frontend, native-skia, archive가 순서대로 success
+  - archive 완료 직후 shard 1/8~8/8이 모두 동시에 `in_progress`가 되어 8-way 병렬성 확인
+  - 8개 shard 모두 success, 최종 `Build & Test` success
+- CodeQL run [29932240860](https://github.com/edwardkim/rhwp/actions/runs/29932240860): **success**
+- Render Diff run [29932240548](https://github.com/edwardkim/rhwp/actions/runs/29932240548): **success**
+
+이전 head `389fe1988`의 CI run 29930709636은 update branch 뒤 force-cancel했고 최종 상태가
+`completed/cancelled`임을 확인했다.
+
+## 판단
+
+요구한 실패 전파와 shard 병렬 보존이 workflow 계약 및 원격 성공 경로에서 확인됐다. 실제 실패 시
+GitHub Actions matrix 취소는 `strategy.fail-fast: true`의 표준 동작을 사용한다. 최신 PR head의 정형
+fast-pass 결과까지 통과하면 merge 가능으로 판단한다.

--- a/mydocs/report/task_m100_3064_report.md
+++ b/mydocs/report/task_m100_3064_report.md
@@ -1,0 +1,68 @@
+# Task M100 #3064 구현 보고서
+
+## 목표
+
+PR #3054에서 한 필수 CI gate가 실패한 뒤에도 다른 고비용 테스트가 계속 실행된 문제를 해결한다.
+8개 기본 테스트 shard의 정상 병렬성은 유지하고, 실패가 발생한 시점부터 남은 작업만 중단한다.
+
+## 원인
+
+- `lint`, `frontend-package-gates`, `native-skia-tests`, `build-test-archive`가 각각 `preflight`만
+  의존해 sibling job으로 동시에 시작했다.
+- GitHub Actions는 한 sibling job 실패만으로 이미 시작한 다른 sibling job을 자동 취소하지 않는다.
+- `test-shard.strategy.fail-fast`가 명시적으로 `false`여서 shard 실패도 나머지 matrix job에
+  전파되지 않았다.
+
+## 변경
+
+필수 worker의 선행 성공 조건을 다음과 같이 구성했다.
+
+```text
+preflight
+  → lint
+  → frontend-package-gates (frontend 비대상이면 skipped)
+  → native-skia-tests
+  → build-test-archive
+  → test-shard 1/8 ... 8/8 (병렬)
+  → Build & Test 집계
+```
+
+- frontend 비대상인 정상 `skipped`와 frontend 실패·취소를 구분해, 비대상일 때만 native-skia 이후
+  체인이 진행된다.
+- 8개 shard의 matrix 배열과 병렬 실행은 유지하고 `fail-fast: true`로 바꿨다.
+- shard 실패로 count artifact가 완성되지 않은 경우 최종 집계에서 다운로드/합계 검사를 생략하고,
+  worker 결과 검사에서 원래 실패 상태를 보고하도록 했다.
+- 같은 집계 script의 기존 `ls` 카운트를 `find`로 바꿔 `actionlint` SC2012 진단을 제거했다.
+
+## 실패 전파 계약
+
+| 실패 위치 | 실행하지 않는 후속 worker |
+|---|---|
+| lint | frontend, native-skia, archive, shard |
+| frontend | native-skia, archive, shard |
+| native-skia | archive, shard |
+| archive | shard |
+| shard 1개 | 실행 중이거나 대기 중인 나머지 shard 취소 |
+
+최종 `Build & Test`는 테스트 worker가 아니라 required check 집계이므로 항상 실행해 실패 원인을 표시한다.
+CodeQL과 Render Diff는 별도 workflow라 이 의존성 체인의 범위가 아니다.
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| Ruby YAML parse | PASS (`yaml ok`) |
+| `actionlint .github/workflows/ci.yml` | PASS |
+| job `needs` 의존성 계약 검사 | PASS |
+| matrix shard `[1,2,3,4,5,6,7,8]` 보존 | PASS |
+| `test-shard.strategy.fail-fast == true` | PASS |
+| `git diff --check` | PASS |
+
+제품 Rust·TypeScript 코드와 실제 테스트 명령은 변경하지 않았다. CI workflow 변경의 최종 동작과 전체
+회귀는 PR 최신 head의 GitHub Actions에서 확인한다.
+
+## 후속 확인
+
+- 정상 경로에서 8개 shard가 병렬 시작하고 모두 성공하는지 확인
+- 실패 전파는 후속 실패 재현 또는 다음 실제 gate 실패 run에서 job skip/cancel 상태 확인
+- PR CI 전체 성공 뒤 merge하고 #3064를 완료 처리

--- a/mydocs/report/task_m100_3064_report.md
+++ b/mydocs/report/task_m100_3064_report.md
@@ -66,3 +66,9 @@ CodeQL과 Render Diff는 별도 workflow라 이 의존성 체인의 범위가 �
 - 정상 경로에서 8개 shard가 병렬 시작하고 모두 성공하는지 확인
 - 실패 전파는 후속 실패 재현 또는 다음 실제 gate 실패 run에서 job skip/cancel 상태 확인
 - PR CI 전체 성공 뒤 merge하고 #3064를 완료 처리
+
+## PR #3077 도구 참조 보강
+
+작업 중 merge된 `scripts/pr_triage.sh`의 사용처가 정식 절차 문서에 없다는 작업지시자 지적을 반영했다.
+`pr_review_workflow.md` 2.0절에 대량 PR 유입 시의 실행 명령, 조회 상한, 전수 누락 확인, 사실 수집과
+사람의 최종 판정 경계를 추가했다. 개별 review 단계의 reviewer 선행 assign 규칙은 그대로 유지한다.


### PR DESCRIPTION
## 요약

- 필수 CI worker를 `preflight → lint → frontend → native-skia → archive → shard` 실패 전파 체인으로 구성했습니다.
- frontend 비대상 skip과 review-only fast-pass는 유지합니다.
- 8개 default-feature shard의 병렬 matrix는 유지하고, 한 shard 실패 시 나머지를 취소하도록 `fail-fast: true`를 적용했습니다.
- worker 실패 시 shard count artifact 검사를 생략하고 최종 `Build & Test` 집계에서 실제 worker 상태를 보고합니다.

## 배경

PR #3054의 CI run 29927292301에서는 `Frontend package gates`가 실패한 뒤에도 `Native Skia tests`와 `Build test archive`가 계속 실행됐습니다. 각 job이 `preflight`만 의존하고, test shard도 `fail-fast: false`였기 때문입니다.

## 검증

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/ci.yml")'`
- `actionlint .github/workflows/ci.yml`
- 필수 job `needs` 의존성 계약 검사
- shard matrix `[1,2,3,4,5,6,7,8]` 및 `fail-fast == true` 계약 검사
- `git diff --check`

제품 코드와 테스트 명령 자체는 변경하지 않았습니다. 최신 head의 GitHub Actions에서 전체 회귀와 8개 shard 병렬 실행을 확인합니다.

Closes #3064
