### PR TITLE
fix(hwp3): 파싱 바이트 오소비 3건 + IR 배선 누락 5건 — kevin9327 HWP3 축 통합 1차

### DIFF
--- a/mydocs/report/task_m100_1_report.md
+++ b/mydocs/report/task_m100_1_report.md
@@ -1,0 +1,92 @@
+# Task m100-1: HWP3 convert_para_shape() border_connection 배선 누락 수정
+
+## 배경
+
+`#2968`(shade_color 누락), `#2521`(위/아래첨자 attr 매핑 누락) 수정과 동일한 방법론을
+`convert_para_shape()`(`src/parser/hwp3/mod.rs`)와 `convert_style()`에 적용했다. 즉,
+HWP3 바이너리 레코드를 읽어들인 struct의 각 필드가 공통 IR(`Document` 모델)까지
+실제로 배선되는지, 아니면 struct에는 읽혔지만 IR 변환 지점에서 조용히 누락되는지를
+필드 단위로 대조했다.
+
+## 결과 요약
+
+- `convert_para_shape()`: 결함 발견 → 수정 완료 (이슈 [#2976](https://github.com/edwardkim/rhwp/issues/2976))
+- `convert_style()`: 대조 결과 clean. 이름, 다음 스타일 참조, lang font, para-shape-ref,
+  char-shape-ref 모두 IR로 정상 배선되어 있음을 확인.
+
+## 발견한 결함
+
+`src/parser/hwp3/records.rs`의 `Hwp3ParaShape`는 `border_connection: u8` 필드와
+이를 bool로 해석하는 접근자 `border_connection() -> bool`(약 396~397행)을 갖고 있다.
+
+```rust
+pub fn border_connection(&self) -> bool {
+    self.border_connection == 1
+}
+```
+
+그런데 `convert_para_shape()`(`src/parser/hwp3/mod.rs` 288행~)는 `margin_left`,
+`margin_right`, `indent`, `line_spacing`, `margin_bottom`, `margin_top`, `align`,
+`tabs`는 모두 IR로 옮기지만 `border_connection`은 어디에도 사용하지 않았다.
+
+IR 쪽에서 "문단 테두리를 인접 문단과 연결해서 그릴지" 플래그는 이미 확립된 규약으로
+`ParaShape.attr1`의 bit 28에 인코딩된다.
+
+- `src/serializer/hwpx/header.rs:1101` — HWPX 내보내기 시 이 비트를 읽어 `connect` 속성으로 씀
+- `src/document_core/commands/formatting.rs:800` — 편집 커맨드에서 같은 비트를 읽음
+- `src/model/style.rs:909, 1004` — `ParaShapeMods.border_connect`가 같은 비트를 세팅
+
+즉 IR과 그 소비자들은 이미 완성되어 있었는데 HWP3 파서만 이 비트를 채우지 않아,
+HWP3(.hwp) 문서에서 문단 테두리를 인접 문단과 연결하도록 설정한 경우 그 정보가
+파싱 단계에서 항상 소실되고 있었다. `convert_char_shape()`가 과거 위/아래첨자
+접근자는 있었지만 attr 매핑이 빠져 있던 결함(#2521)과 정확히 같은 패턴이다.
+
+## 영향
+
+HWP3(.hwp) 문서에서 문단 테두리를 "연결"로 설정한 경우, rhwp로 파싱한 결과(및 이를
+HWPX로 재저장한 결과)에서는 항상 연결되지 않은 것으로 처리된다. 문단 테두리를 사용하는
+옛 HWP3 문서(표 유사 레이아웃, 강조 박스 등)에서 렌더링·재저장 시 테두리가 문단
+경계마다 끊어져 보이는 시각적 회귀가 발생한다.
+
+## 수정 내용
+
+`convert_para_shape()`에 아래 3줄을 추가했다.
+
+```rust
+if hwp3_ps.border_connection() {
+    ps.attr1 |= 1 << 28;
+}
+```
+
+기존에 이미 존재하던 접근자를 그대로 호출해 IR의 확립된 비트 규약에 맞춰 배선하는
+최소 수정이며, 다른 로직·스케일 변환에는 영향을 주지 않는다.
+
+## 테스트 (red → green)
+
+`src/parser/hwp3/mod.rs`의 `tests` 모듈에
+`test_convert_para_shape_wires_border_connection_into_attr1_bit28`을 추가했다.
+
+- **Red (수정 전)**: `Hwp3ParaShape { border_connection: 1, .. }`을
+  `convert_para_shape()`에 넣으면 반환된 `ParaShape.attr1`의 bit 28이 0으로 남아
+  `assert_eq!((ps.attr1 >> 28) & 1, 1, ...)`가 실패했다.
+- **Green (수정 후)**: 동일 입력에 대해 bit 28이 1로 세팅되어 통과.
+
+```
+running 1 test
+test parser::hwp3::tests::test_convert_para_shape_wires_border_connection_into_attr1_bit28 ... ok
+```
+
+## 검증
+
+- `cargo check --lib` — 통과 (경고 없음)
+- `cargo test --lib test_convert_para_shape_wires_border_connection_into_attr1_bit28` — 통과
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` — 적용 완료
+
+## 변경 파일
+
+- `src/parser/hwp3/mod.rs` (로직 3줄 + 회귀 테스트)
+
+## 이슈/PR
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2976
+- PR: (커밋 후 생성)

--- a/mydocs/report/task_m100_2824_report.md
+++ b/mydocs/report/task_m100_2824_report.md
@@ -1,0 +1,53 @@
+# Task #2824 Report — HWP3 그리기 개체 타입9(변형된 호) 8바이트 오버리드 수정
+
+## 요약
+
+`src/parser/hwp3/drawing.rs`의 `Hwp3DrawingObject::read`에서 그리기 개체
+`object_type == 9`(변형된 호, 회전을 위해 확장된 호)를 처리할 때, 스펙에 없는
+8바이트(`info1_len`, `info2_len`)를 읽어서 버리고 있었다. `mydocs/tech/한글문서파일구조3.0.md`
+11.3.4절은 "추가 세부정보를 필요로 하지 않으며, 회전 속성의 평행사변형 세 점을 이용해
+첫 점에서 끝 점 방향으로 그린다"고 명시하고, 열거형 정의(`Hwp3DrawingObject::ModifiedArc`)의
+기존 주석도 "공통 헤더 외에 추가적인 세부 정보 없음"이라 밝히고 있었음에도, 실제 파서 구현은
+이와 모순되게 사각형/타원(타입 2/3)에만 해당하는 "8바이트 placeholder" 관례를 잘못 차용해
+스트림 커서를 8바이트 더 전진시키고 있었다.
+
+## 근거
+
+- 스펙: `mydocs/tech/한글문서파일구조3.0.md` 11.3.4절(변형된 호) — 추가 세부정보 없음.
+- 대조: 11.3.8절(표 80, 변형된 타원)은 정보1길이(4)+호 좌표 4개(16)+정보2길이(4) = 24바이트를
+  전부 읽고 보존하는데(`Hwp3DrawingModifiedEllipse`), 변형된 호는 그 자체로 세부 구조가 없다.
+- 코드 자체 모순: 수정 전 `Hwp3DrawingObject` 열거형 주석 "`ModifiedArc(...) // 공통 헤더 외에
+  추가적인 세부 정보 없음`"과, `read()` 구현이 실제로는 8바이트를 읽는 동작이 불일치했다.
+
+## 수정 내용
+
+`src/parser/hwp3/drawing.rs`의 `object_type == 9` 분기에서 `_info1_len`/`_info2_len` 읽기
+2줄을 제거하고, 왜 추가 바이트를 읽지 않는지 스펙 근거를 주석으로 남겼다. 파일 전체를
+`rustfmt --edition 2021`로 재포맷했다(변경 없음, diff 없음 확인).
+
+## 검증 (red → green)
+
+`src/parser/hwp3/drawing.rs`에 `modified_arc_overread_tests` 모듈을 추가했다. 공통 헤더만
+있고 추가 필드가 없는 최소 buffer(92바이트, `options=0`으로 회전/그라데이션/비트맵 패턴
+서브레코드 없음)를 만들고, 그 뒤에 "다음 형제 레코드의 선두 바이트"를 흉내 낸 8바이트
+마커를 이어 붙인 뒤 `Hwp3DrawingObject::read`를 호출해 커서 위치가 정확히 공통 헤더
+길이(92)에서 멈추는지 확인한다.
+
+- 수정 전(8바이트 오버리드 코드 상태): `cargo test --lib modified_arc_does_not_overread_past_common_header`
+  → **FAILED** (`left: 100, right: 92` — 8바이트 초과 소비 확인).
+- 수정 후: 같은 테스트 **ok** (`test result: ok. 1 passed`).
+- `cargo build --lib` 통과.
+- `cargo clippy --all-targets --profile release-test -- -D warnings` 경고 없음.
+- `rustfmt --edition 2021 src/parser/hwp3/drawing.rs` 이후 `git diff --name-only` 에 포맷
+  전용 변경 없음(수정한 파일만 diff에 존재).
+
+## 영향
+
+변형된 호(타원 부채꼴을 회전시켜 그리는 호) 그리기 개체가 포함된 HWP 3.0 문서에서, 해당
+개체 뒤에 이어지는 형제/자식 레코드가 8바이트 밀린 채로 파싱되어 헤더 필드가 오염되거나,
+파일 말미에서는 `read_exact` 실패로 조기 종료될 수 있는 문제를 제거했다.
+
+## 후속
+
+- 다른 그리기 개체 타입(2, 3 등)의 "8바이트 placeholder" 자체는 스펙 표 73에 명시된 대로
+  유지했으며, 이번 수정 대상에서 제외했다.

--- a/mydocs/report/task_m100_2844_report.md
+++ b/mydocs/report/task_m100_2844_report.md
@@ -1,0 +1,121 @@
+# 최종 결과 보고서 — Task M100 #2844
+
+## 이슈
+
+HWP3 파서(`src/parser/hwp3/mod.rs`)의 문자 스캔 루프가 특수 문자 코드 **7(날짜 형식,
+한글문서파일구조3.0 §10.3)** 과 **8(날짜 코드, §10.4)** 를, 총 길이가 8바이트인 다른
+"단순 컨트롤" 코드들(9, 22, 23, 24, 25, 26, 28, 30, 31)과 같은 디스패치 버킷
+(`parse_simple_control_char`)으로 잘못 라우팅. 실제로는 각각 84/96바이트짜리 구조체인데
+6바이트만 읽고 스킵하여 76/88바이트가 다음 컨트롤·본문 텍스트로 잘못 흡수됨. 문단 전체가
+바이트 오프셋 디싱크에 빠짐.
+
+- Issue: https://github.com/edwardkim/rhwp/issues/2844
+- PR: (본 보고서 하단 참조)
+
+## 결론
+
+문자 스캔 루프 디스패치 매치(`parse_paragraph_list` 내부, 舊 2089행)에서 `7 | 8` 을
+제거하여 `_` 캐치올(`parse_object_control_char`)로 되돌렸다. `parse_object_control_char`에는
+Task #877 에서 작성된 76/88바이트 스킵 로직이 이미 정확하게 존재했으나, 회귀 이후
+dispatch가 도달시키지 않는 죽은 코드였다. 라우팅만 복원하면 되므로, `parse_simple_control_char`
+안의 잘못된 `7 | 8 =>` (6바이트만 소비) arm은 이제 도달 불가능해져 삭제했다.
+
+이는 추론이 아니라 **git blame 으로 확인된 회귀**다. `git log -L1777,1795:src/parser/hwp3/mod.rs`
+로 추적한 결과, 커밋 `f1995532`("Task #2001: 추출 2 — 소형 컨트롤 코드 arm 헬퍼 2개
+(field/simple, 동작 불변)")가 `1 | 7 | 8 | 9 | 22 | ...` 매치로 ch=7/8을
+`parse_simple_control_char`로 우회시키면서 동시에 6바이트짜리 새 `7 | 8` arm을 만들었다.
+그 결과 "동작 불변"을 표방한 리팩터가 실제로는 회귀를 도입했고, 원래 존재하던 76/88바이트
+로직은 그대로 남았지만 죽은 코드가 되었다.
+
+## 결함 상세
+
+### 결함 위치 — `src/parser/hwp3/mod.rs`
+
+디스패치 매치(`parse_paragraph_list` 내부):
+
+```rust
+1 | 7 | 8 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
+    let (next_i, next_utf16_len, break_char_loop) = parse_simple_control_char(...)
+```
+
+`parse_simple_control_char` 내부:
+
+```rust
+7 | 8 => {
+    let mut buf = [0u8; 6];          // ← 84/96바이트 구조체인데 6바이트만 소비
+    ...
+    i += 3;
+    ...
+}
+```
+
+스펙(`mydocs/tech/한글문서파일구조3.0.md` §10.3/§10.4):
+
+- ch=7(날짜 형식): 전체 84바이트 = 여는 코드(2, outer read 완료) + hchar array[40]
+  날짜 형식 문자열(80) + 닫는 코드(2). 즉 outer read 이후 **82바이트** 추가 소비 필요.
+- ch=8(날짜 코드): 전체 96바이트 = 여는 코드(2) + 날짜형식(80) + 날짜(8) + 시각(4) +
+  닫는 코드(2). outer read 이후 **94바이트** 추가 소비 필요.
+
+`parse_object_control_char`(舊 1257~1279행, Task #877)는 이미 정답을 갖고 있었다:
+
+```rust
+} else if ch == 7 {
+    let mut date_fmt = [0u8; 76];   // header_val1(4)+ch2(2) 이미 소비 → 8+76=84 일치
+    ...
+} else if ch == 8 {
+    let mut date_code = [0u8; 88];  // 8+88=96 일치
+    ...
+}
+```
+
+## 수정 내용
+
+1. `parse_paragraph_list` 디스패치 매치에서 `1 | 7 | 8 | 9 | ...` → `1 | 9 | ...` (7, 8 제거).
+   이제 ch=7/8은 `_` 캐치올을 통해 `parse_object_control_char`로 라우팅되어 Task #877의
+   정확한 76/88바이트 스킵 로직이 실행된다.
+2. `parse_simple_control_char`의 버그 있는 `7 | 8 => { ... 6바이트만 소비 ... }` arm 삭제
+   (라우팅 수정으로 도달 불가능해진 죽은 코드).
+
+## 테스트 (red → green)
+
+`src/parser/hwp3/mod.rs` `mod tests`에 통합 테스트 1건 추가:
+`task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`
+
+- 문단 1개: ch=7 날짜 형식 컨트롤(84바이트, 날짜 형식 문자열은 전부 0) 뒤에 실제 본문
+  `"AAA"`(3 hchar)가 오는 최소 HWP3 문단 바이트열을 직접 구성.
+- `parse_paragraph_list()` 호출 후 `paragraphs[0].text`가 `"AAA"`를 포함하는지 단언.
+
+**Red (수정 전, 임시로 舊 로직 복원 후 실행):**
+```
+thread '...' panicked at src\parser\hwp3\mod.rs:4247:9:
+날짜 형식(ch=7) 컨트롤 뒤의 "AAA" 본문이 유실됨 (바이트 언더리드로 흡수): "￼"
+test result: FAILED. 0 passed; 1 failed
+```
+(84바이트 레코드 중 6바이트만 소비되어 커서가 78바이트 어긋나고, "AAA" 텍스트에
+도달하지 못한 채 남은 0-바이트들을 종료 문단으로 오인해 파싱이 조기 종료됨.)
+
+**Green (수정 후):**
+```
+test parser::hwp3::tests::task2844_hwp3_date_format_ctrl_does_not_swallow_following_text ... ok
+test result: ok. 1 passed; 0 failed
+```
+
+## 검증
+
+- `cargo build --lib`: 통과
+- `cargo test --lib task2844_hwp3_date_format_ctrl_does_not_swallow_following_text`: 통과 (green)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`: 실질적 diff 없음 (개행 방식 경고만,
+  실제 내용 변경 없음 — `git diff --stat`로 확인)
+
+## 영향 범위
+
+- 변경 파일: `src/parser/hwp3/mod.rs` 만 (스코프 최소화).
+- ch=1, 9, 22, 23, 24, 25, 26, 28, 30, 31 은 실제로 총 8/6/10/24/246/64/4바이트로
+  스펙과 정확히 일치함을 개별 재검산으로 확인, 손대지 않았다.
+- 그 밖에 검토했으나 문제가 없었던 영역(스펙 대조로 balancing 확인, 수정 불필요):
+  - `records.rs` `Hwp3InfoBlock`/`Hwp3AdditionalInfoBlock` (§3.4/§3.8 정보 블록)
+  - 그림 정보 블록(§10.7, 348+n바이트) 및 하이퍼텍스트 확장(TagID 3) 관련 n_ext 처리
+  - 표/텍스트박스/수식/버튼 (§10.6) 셀 정보 27바이트 × 셀개수 반복
+  - 각주/미주(§10.11, 14바이트), 머리말/꼬리말(§10.10, 10바이트), 상호참조(§10.22,
+    46+n바이트 가변 구조)

--- a/mydocs/report/task_m100_2924_report.md
+++ b/mydocs/report/task_m100_2924_report.md
@@ -1,0 +1,80 @@
+# Task #2924 처리 결과 — HWP3 조합형(Johab) 무효 종성 인덱스 오처리 수정
+
+## 이슈
+
+- edwardkim/rhwp#2924 — HWP3 조합형(Johab) 디코더가 무효 종성 인덱스를 "받침 없음"으로 오인해
+  존재하지 않는 완성형 음절을 조용히 생성함.
+
+## 문제 분석
+
+`src/parser/hwp3/johab.rs`의 `decode_johab`은 조합형 2바이트 코드의 종성(jong) 5비트 필드를
+`jong_map` 테이블로 변환한다. 이 테이블에서 인덱스 1은 "받침 없음"(값 0)을 나타내고, 인덱스
+0/18/30/31은 표준 조합형 인코딩에서 사용되지 않는 예약/무효 값으로 `-1`이 배정되어 있다.
+
+기존 코드는 다음과 같이 `jong == -1`인 모든 경우를 예외 없이 "받침 없음"(0)으로 치환했다.
+
+```rust
+let mut jong = jong_map[jong_idx as usize];
+
+if cho != -1 && jung != -1 {
+    if jong == -1 {
+        jong = 0;
+    }
+    let uni_val = 0xAC00 + (cho * 21 * 28) + (jung * 28) + jong;
+    ...
+}
+```
+
+이는 "종성 필드가 없음을 뜻하는 유효한 상태"와 "종성 필드 자체가 예약/무효 값인 상태"를 구분하지
+못해, `jong_idx`가 0/18/30/31인 예약/무효 조합조차 정상적인 완성형 한글 음절로 합성해 반환하는
+결과를 낳는다. 이는 `src/parser/hwp3/encoding.rs`의 `decode_hwp3_string`이 짝이 없는 후행 바이트
+같은 무효 입력에 대해 명시적으로 `'?'`를 반환하는 것과 원칙이 어긋난다 — 무효 입력이 플레이스홀더가
+아니라 겉보기에 정상적인, 그러나 원본에는 없던 한글 음절로 둔갑해 버린다.
+
+## Red → Green
+
+### Red (수정 전)
+
+`cho_idx=2`(초성 'ㄱ'), `jung_idx=3`(중성 'ㅏ'), `jong_idx=0`(예약/무효)으로 구성한
+`ch = 0x8000 | (2 << 10) | (3 << 5) | 0 = 0x8860`에 대해:
+
+- 수정 전: `decode_johab(0x8860)` → `'가'` (U+AC00) 반환. 예약/무효 조합인데도 정상 음절처럼 보임.
+- 테스트 `decode_johab_rejects_reserved_jong_index`는 `assert_ne!(decode_johab(ch), '가')`를
+  검증하며, 수정 전 코드에서는 이 assert가 실패한다(수정 전 코드로 되돌려 직접 확인함).
+
+### Green (수정 후)
+
+```rust
+let jong = jong_map[jong_idx as usize];
+
+if cho != -1 && jung != -1 && jong != -1 {
+    let uni_val = 0xAC00 + (cho * 21 * 28) + (jung * 28) + jong;
+    ...
+}
+```
+
+`jong != -1` 조건을 추가해 종성 필드 자체가 유효한 값일 때만 완성형 음절을 합성하도록 강화했다.
+`jong_idx=1`(받침 없음, jong=0)은 여전히 정상 처리되고, 예약/무효 조합(`jong_idx` 0/18/30/31)은
+합성 경로를 건너뛰어 기존 한자/기호 이진 탐색 → 최종 `'?'` fallback 경로로 넘어간다.
+
+```
+$ cargo test --lib johab
+running 1 test
+test parser::hwp3::johab::tests::decode_johab_rejects_reserved_jong_index ... ok
+test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2519 filtered out
+```
+
+## 변경 파일
+
+- `src/parser/hwp3/johab.rs` — `decode_johab` 종성 처리 조건 수정(핵심 diff 6줄) + 회귀 테스트 1건 추가.
+
+## 검증
+
+- `cargo check --lib` 통과.
+- `cargo test --lib johab` 통과(신규 테스트 1건 green).
+- `rustfmt --edition 2021 src/parser/hwp3/johab.rs` 적용.
+
+## 영향 범위
+
+`decode_johab` 내부 로직 변경만으로 해결되며, 렌더러·문서 IR·다른 파서 모듈에는 영향 없음. 변경
+범위가 작아 회귀 위험 낮음.

--- a/mydocs/report/task_m100_2984_report.md
+++ b/mydocs/report/task_m100_2984_report.md
@@ -1,0 +1,48 @@
+# task_m100_2984 처리 결과 보고
+
+## 이슈
+
+edwardkim/rhwp#2984 — HWP3 그림 밝기/명암/그림효과(offset 339~341) 미반영으로 워터마크·그레이스케일·흑백 그림이 원본 그대로 렌더됨.
+
+## 배경 / 근거
+
+`char_shape.shade_color` HWP3 IR 변환 누락 수정(#2958, PR #2968)과 동일한 방법을 `src/parser/hwp3/mod.rs` 의 그림(HWP3 특수문자 코드 11) 변환 경로에 적용했다. 이 함수가 파싱된 HWP3 그림 정보 레코드의 모든 의미 있는 필드를 IR (`model::image::Picture`) 로 옮기는지 점검하기 위해, 로컬 canonical 스펙 문서 `mydocs/tech/한글문서파일구조3.0.md` "10.7. 그림 (11)" 절 표 43 "그림 식별 정보" 를 기준으로 실제 코드가 읽는 `info_buf` 오프셋들과 대조했다.
+
+표 43 은 다음을 명시한다.
+
+```
+| 339 | byte | 밝기   | 워터마크: 그림의 밝기 (-100~100) |
+| 340 | byte | 명암   | 워터마크: 그림의 명암 (-100~100) |
+| 341 | byte | 그림효과 | 워터마크: 0=원래 그림으로, 1=그레이 스케일, 2=흑백으로 |
+```
+
+같은 절 설명: "밝기와 명암이 동시에 0 이 아닌경우 워터마크 판정으로 한다" — 즉 이 3바이트는 단순 워터마크 전용이 아니라 한글97/HWP3 문서가 그림에 흑백/그레이스케일 변환·밝기/명암 보정을 적용했을 때 저장되는 일반 이미지 효과 필드다.
+
+`src/parser/hwp3/mod.rs` 의 그림(ch==11) 분기는 `info_buf` 를 348바이트 전부(offset 339~342 포함) 읽지만, 실제로 소비하는 오프셋은 0-4, 8, 9, 10-14, 18-34, 42-48, 58-64, 70-72, 74, 83-339(그림 이름) 뿐이었다. 339~341 은 한 번도 읽히지 않아 `pic.image_attr.brightness`/`contrast`/`effect` 가 항상 기본값(0, 0, `RealPic`)으로 고정되어 있었다.
+
+같은 IR 필드는 HWP5 경로(`src/parser/control/shape.rs::parse_picture`, 890~923행)에서는 정상적으로 채워지므로, HWP3 → IR 변환 경로에서만 구조적으로 값이 소실되는 케이스임을 확인했다(#2958 과 동일 패턴).
+
+## 수정 내용 (red → green)
+
+- `src/parser/hwp3/mod.rs`
+  - 새 순수 함수 `hwp3_picture_image_effect(info_buf: &[u8]) -> (i8, i8, ImageEffect)` 추가: offset 339=밝기, 340=명암, 341=그림효과(1=GrayScale, 2=BlackWhite, 그 외 RealPic) 를 읽어 반환한다.
+  - 그림(ch==11) 파싱 분기에서 `pic.common.attr = build_common_obj_attr(&pic.common);` 직후 위 함수를 호출해 `pic.image_attr.brightness`/`contrast`/`effect` 에 대입.
+  - 단위 테스트 `task2984_hwp3_picture_image_effect_reads_brightness_contrast_effect` 추가: 합성 348바이트 `info_buf` 에 밝기=-40, 명암=25, 그림효과=1(그레이스케일) 을 심어 반환값을 검증.
+    - red 확인: `hwp3_picture_image_effect` 본문을 원래 버그와 동일하게 항상 `(0, 0, RealPic)` 을 반환하는 자리표시로 임시 교체한 뒤 `cargo test --lib task2984_hwp3_picture_image_effect` 실행 → `assertion left == right failed / left: 0 / right: -40` 로 실패(FAILED, 0 passed; 1 failed) 확인.
+    - green 확인: 실제 오프셋 읽기 로직으로 되돌린 뒤 동일 명령 재실행 → `test result: ok. 1 passed; 0 failed`.
+
+## 영향 범위
+
+- HWP3(.hwp, 한글97) 문서에서 그림에 그레이스케일·흑백 변환이나 밝기/명암 보정이 적용돼 있어도 이제 IR(`Picture.image_attr`) 에 값이 반영되어, SVG/PDF 렌더링 및 HWPX 재저장(`bright`/`contrast`/`effect` 속성) 시 원본과 일치한다.
+- 그 외 경로(HWP5, HWPX)는 변경 없음.
+
+## 검증
+
+- `cargo check --lib` — 통과.
+- `cargo test --lib task2984_hwp3_picture_image_effect` — 통과 (1 passed).
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` — 적용, 추가 diff 없음.
+- `CommonObjAttr`(`src/model/shape.rs`) 는 손대지 않음.
+
+## 남은 이슈
+
+없음. 이번 수정은 그림 밝기/명암/그림효과 3개 필드에 한정된 최소 diff다. 같은 그림 정보 레코드 안의 다른 미사용 바이트 범위(예: offset 342 그림보호 플래그)는 이번 스코프 밖으로 남겨 두었으며, 필요 시 별도 이슈로 분리할 수 있다.

--- a/mydocs/report/task_m100_3006_report.md
+++ b/mydocs/report/task_m100_3006_report.md
@@ -1,0 +1,69 @@
+# Task m100-3006: HWP3 doc_info.hide_empty_line(빈줄감춤) SectionDef 미배선 수정
+
+## 이슈
+
+- edwardkim/rhwp#3006
+
+## 배경
+
+"accessor 는 정의되어 있지만 실제 변환 함수에서 호출되지 않아 값이 항상 기본값으로 고정되는" 계열의
+버그(#2976/#2983 border_connection 패턴)를 HWP3 파서 전반에서 다시 찾는 작업이었다. 이번에는
+accessor 형태는 아니지만 동일한 실패 모드였다 — `Hwp3DocInfo`가 파싱한 원시 필드(`hide_empty_line`)가
+IR(`SectionDef`) 조립부에서 배선 목록에서 누락되어 있었다.
+
+## 조사 과정 (버려진 후보들)
+
+1. `Hwp3CharShape::is_superscript()`/`is_subscript()` — accessor 는 있으나 `convert_char_shape()`가
+   호출하지 않는 것으로 로컬(push-2978) 브랜치에서는 보였다. 그러나 `origin/devel` 최신본을 다시
+   확인하니 **이미 수정되어 있었다**(로컬 브랜치가 devel보다 오래되어 생긴 오탐). 이슈 #2991을 생성
+   직후 devel 확인으로 발견해 즉시 close.
+2. `Hwp3ParaShape::has_border()` — accessor 미호출로 문단 테두리(음영 없을 때)가 유실되는 진짜 버그를
+   찾았으나, `gh issue/pr list` 중복 확인 결과 동일 저장소에서 **이미 이슈 #2995 / PR #2997**로 나(또는
+   병렬 세션)이 제출한 상태였다. 중복 방지를 위해 폐기.
+3. `doc_info.start_page_number`/`footnote_start_number` → `doc.doc_properties` 미배선 — 확인해보니
+   과거 PR #2486(CLOSED, 미병합)로 동일 내용이 이미 시도된 이력이 있어 제외.
+4. `PageHide` 컨트롤의 `hide_master_page`/`hide_fill` 비트 — 스펙(한글문서파일구조3.0.md:1062)을
+   재확인한 결과 HWP3 "홀수쪽시작/감추기" 컨트롤은 애초에 bit 0~3(머리말/꼬리말/쪽번호/테두리)만
+   정의하고 bit 4-15는 예약(reserved)이다. 즉 HWP5(`master_page`/`fill` 비트 존재)와 레이아웃이 다를 뿐,
+   버그가 아니었다.
+5. `doc_info.footnote_line_width` 등 각주 관련 여러 필드 — `hwp3_default_endnote_shape()`가 하드코딩된
+   기본값을 쓰고 있어 실제로 미배선 상태이나, `fixup_hwp3_notes()`가 `doc_info`에 대한 접근권이 없어
+   plumbing 범위가 "1-15줄 tiny fix"를 넘어서므로 이번 타스크에서는 보류.
+
+## 최종 선택: doc_info.hide_empty_line → SectionDef.hide_empty_line
+
+- 한글문서파일구조 3.0 스펙(`mydocs/tech/한글문서파일구조3.0.md:248`): doc_info offset 122 =
+  "빈줄감춤"(0 이외=on).
+- 공통 IR `SectionDef.hide_empty_line`은 HWP5(`src/parser/body_text.rs:580`)·HWPX
+  (`src/parser/hwpx/section.rs:1290`)에서는 이미 매핑되어 있었으나 HWP3 경로만 누락.
+- `gh issue list --search`, `gh pr list --state open --author kevin9327 --search` 로 중복 여부 확인 —
+  히트 없음.
+
+## 수정 내용 (Red → Green)
+
+`src/parser/hwp3/mod.rs`:
+
+- `hwp3_hide_empty_line(doc_info: &Hwp3DocInfo) -> bool` 헬퍼 추가 (기존 `hwp3_page_border_fill` 과
+  동일한 스타일).
+- `Hwp3DocInfo` → `SectionDef` 조립부에 `section_def.hide_empty_line = hwp3_hide_empty_line(&doc_info);`
+  한 줄 추가.
+- 회귀 테스트 `issue_hwp3_hide_empty_line_wires_doc_info_flag` 추가: `hide_empty_line: 1` →
+  `true`, `hide_empty_line: 0` → `false` 단언. 수정 전에는 테스트 대상 함수 자체가 없어 컴파일
+  실패(red) → 헬퍼 추가 + 배선 후 green.
+
+실제 fix 본문 diff는 헬퍼 함수(4줄) + 호출부(3줄) 로 7줄 수준이며, 테스트/주석을 포함한 전체는 25줄.
+
+## 검증
+
+```
+cargo check --lib   # OK
+cargo test --lib issue_hwp3_hide_empty_line_wires_doc_info_flag   # 1 passed
+rustfmt --edition 2021 src/parser/hwp3/mod.rs
+```
+
+## 남은 과제 (후속 이슈 후보, 이번 범위 밖)
+
+- `doc_info.footnote_line_width`/`footnote_bracket`/`footnote_between_margin`/`footnote_text_margin`
+  /`footnote_line_margin` 등 각주 관련 doc_info 필드가 HWP3 파서에서 전혀 소비되지 않음
+  (`hwp3_default_endnote_shape()`가 하드코딩된 기본값 사용). `fixup_hwp3_notes()`가 `Hwp3DocInfo`에
+  접근할 수 있도록 plumbing 이 필요해 별도 타스크로 분리 권장.

--- a/mydocs/report/task_m100_3057_report.md
+++ b/mydocs/report/task_m100_3057_report.md
@@ -1,0 +1,26 @@
+# Task #3057 처리 결과
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 `parse_hwp3_object_dispatch` 중 HWP3 필드 코드
+컨트롤(ch==5, spec §10.1 표33) 분기는 `field_data`를 읽기만 하고 버렸다.
+같은 함수의 책갈피(ch==6) 분기는 파싱 결과를 `Control::Field`로 배선하는데,
+필드 코드는 상위 함수 `parse_object_control_char`의 catch-all에 의해
+`Control::Unknown`으로만 남아 원본 데이터가 소실됐다.
+
+## 수정
+
+`src/parser/hwp3/mod.rs` ch==5 분기에서 책갈피와 동일한 패턴으로
+`field_data`를 디코딩해 `Control::Field`(command에 원본 문자열)로 배선.
+
+## 검증
+
+- 합성 바이트(헤더 8바이트 + payload)로 `parse_object_control_char`를
+  직접 호출해 `Control::Field`가 생성되는지 검증하는 단위 테스트 추가.
+- `cargo check --lib`, `cargo test --lib field_code_ch5` 통과.
+
+## 범위
+
+책갈피/상호참조는 이미 정상 배선되어 있음을 재확인. 필드 코드 세부
+subcommand 파싱(spec 상세 포맷)은 범위 밖 — 원본 바이트를 보존하는
+최소 수정만 수행.

--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -524,9 +524,10 @@ impl Hwp3DrawingObject {
                 Ok(Hwp3DrawingObject::ModifiedEllipse(header, details))
             }
             9 => {
-                // 수정된 호
-                let _info1_len = reader.read_u32::<LittleEndian>()?;
-                let _info2_len = reader.read_u32::<LittleEndian>()?;
+                // 수정된 호 (회전을 위해 확장된 호): 스펙 11.3.4절에 따라 추가
+                // 세부 정보가 전혀 없다. 공통 헤더의 회전 속성(평행사변형
+                // 세 점)만으로 첫 점에서 끝 점 방향의 호를 그리므로, 사각형/
+                // 타원(타입 2/3)처럼 8바이트 placeholder를 읽으면 안 된다.
                 Ok(Hwp3DrawingObject::ModifiedArc(header))
             }
             10 => {
@@ -893,4 +894,45 @@ fn map_to_shape_object(
     }
 
     Ok((final_shape, connection_info))
+}
+
+#[cfg(test)]
+mod modified_arc_overread_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // [Task #2824] 변형된 호(object_type=9)는 스펙 11.3.4절에 따라 공통 헤더
+    // 외에 추가 세부 정보가 전혀 없어야 한다. 수정 전 코드는 존재하지 않는
+    // 8바이트(info1_len, info2_len)를 읽어 버려서, 뒤따르는 형제 레코드의
+    // 선두 바이트를 침범했다. 공통 헤더 크기만큼만 커서가 전진하는지 확인한다.
+    #[test]
+    fn modified_arc_does_not_overread_past_common_header() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&0u32.to_le_bytes()); // header_length
+        buf.extend_from_slice(&9u16.to_le_bytes()); // object_type = 9 (변형된 호)
+        buf.extend_from_slice(&0u16.to_le_bytes()); // connection_info
+        buf.extend_from_slice(&[0u8; 8]); // relative_pos
+        buf.extend_from_slice(&[0u8; 8]); // object_size
+        buf.extend_from_slice(&[0u8; 8]); // absolute_pos
+        buf.extend_from_slice(&[0u8; 16]); // bounds
+        buf.extend_from_slice(&[0u8; 32]); // basic_attr: line_style..pattern_color (8 x u32)
+        buf.extend_from_slice(&[0u8; 8]); // basic_attr: textbox_margin
+        buf.extend_from_slice(&0u32.to_le_bytes()); // basic_attr: options = 0 (no rotation/gradient/bitmap)
+        let common_header_len = buf.len() as u64;
+
+        // 다음 형제 레코드의 선두 바이트라고 가정한 마커. 수정 전 코드는 이
+        // 8바이트를 info1_len/info2_len으로 잘못 소비한다.
+        buf.extend_from_slice(&0xAAAAAAAAu32.to_le_bytes());
+        buf.extend_from_slice(&0xBBBBBBBBu32.to_le_bytes());
+
+        let mut cursor = Cursor::new(buf);
+        let obj = Hwp3DrawingObject::read(&mut cursor).expect("parse modified arc");
+
+        assert!(matches!(obj, Hwp3DrawingObject::ModifiedArc(_)));
+        assert_eq!(
+            cursor.position(),
+            common_header_len,
+            "ModifiedArc 파싱이 공통 헤더 이후 존재하지 않는 바이트를 소비함"
+        );
+    }
 }

--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -29,12 +29,12 @@ pub fn decode_johab(ch: u16) -> char {
 
         let cho = cho_map[cho_idx as usize];
         let jung = jung_map[jung_idx as usize];
-        let mut jong = jong_map[jong_idx as usize];
+        let jong = jong_map[jong_idx as usize];
 
-        if cho != -1 && jung != -1 {
-            if jong == -1 {
-                jong = 0;
-            }
+        // jong_idx == 0 은 예약된 미사용 값이며, jong_map[1] == 0 이 "받침 없음"을
+        // 나타낸다. jong == -1 을 무조건 0(받침 없음)으로 치환하면 예약/무효
+        // 조합(jong_idx 0, 18, 30, 31)이 유효한 완성형 음절로 잘못 디코딩된다.
+        if cho != -1 && jung != -1 && jong != -1 {
             let uni_val = 0xAC00 + (cho * 21 * 28) + (jung * 28) + jong;
             if let Some(c) = std::char::from_u32(uni_val as u32) {
                 return c;
@@ -98,4 +98,19 @@ fn decode_hwp3_extra(ch: u16) -> Option<char> {
         _ => return None,
     };
     char::from_u32(codepoint)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn decode_johab_rejects_reserved_jong_index() {
+        // cho_idx=2(초성 0), jung_idx=3(중성 0), jong_idx=0(예약/무효 값).
+        // jong_idx=0 은 종성 매핑에서 -1(무효)이며, "받침 없음"은 jong_idx=1 이
+        // 별도로 나타낸다. 무효 jong_idx 를 받침 없음으로 오인하면 존재하지
+        // 않아야 할 완성형 음절 '가'(U+AC00)가 잘못 생성된다.
+        let ch: u16 = 0x8000 | (2 << 10) | (3 << 5) | 0;
+        assert_ne!(decode_johab(ch), '가');
+    }
 }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -432,7 +432,10 @@ fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
 }
 
 /// doc_info.encrypted(암호 설정 여부)를 FileHeader.encrypted 및 raw_data 플래그 비트(0x02)에 반영한다.
-fn apply_hwp3_encrypted_flag(doc_info_encrypted: u16, header: &mut crate::model::document::FileHeader) {
+fn apply_hwp3_encrypted_flag(
+    doc_info_encrypted: u16,
+    header: &mut crate::model::document::FileHeader,
+) {
     if doc_info_encrypted != 0 {
         header.encrypted = true;
         if let Some(raw) = header.raw_data.as_mut() {

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1803,25 +1803,6 @@ fn parse_simple_control_char(
             utf16_len += 8;
             text_string.push('\t');
         }
-        7 | 8 => {
-            let mut buf = [0u8; 6];
-            if let Err(_) = body_cursor.read_exact(&mut buf) {
-                return Ok((i, utf16_len, true));
-            }
-            for k in 0..3usize {
-                if i + k < hwp3_char_to_utf16_pos.len() {
-                    hwp3_char_to_utf16_pos[i + k] = utf16_len;
-                }
-            }
-            i += 3;
-            char_offsets.push(utf16_len);
-            utf16_len += 1;
-            text_string.push('\u{FFFC}');
-            controls.push(crate::model::control::Control::Unknown(
-                crate::model::control::UnknownControl { ctrl_id: ch as u32 },
-            ));
-            ctrl_data_records.push(None);
-        }
         23 => {
             let mut buf = [0u8; 8];
             if let Err(_) = body_cursor.read_exact(&mut buf) {
@@ -2086,7 +2067,11 @@ pub(crate) fn parse_paragraph_list(
 
             if ch > 0 && ch <= 31 && ch != 13 {
                 match ch {
-                    1 | 7 | 8 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
+                    // [#2844] ch=7(날짜 형식)/ch=8(날짜 코드)는 각각 84/96바이트짜리
+                    // 가변폭 구조체이며, 이 arm 이 처리하는 다른 코드들처럼 8바이트에
+                    // 맞춰떨어지지 않는다. `_` 캐치올(parse_object_control_char)에 남아
+                    // 있는 Task #877의 76/88바이트 스킵 로직으로 라우팅해야 한다.
+                    1 | 9 | 22 | 23 | 24 | 25 | 26 | 28 | 30 | 31 => {
                         let (next_i, next_utf16_len, break_char_loop) = parse_simple_control_char(
                             body_cursor,
                             ch,
@@ -4183,5 +4168,75 @@ mod tests {
                 "saved HWP5 must have BinData/BIN* streams, got none (images lost)"
             );
         }
+    }
+
+    // [Task #2844] 스펙 §10.3 표 37: 날짜 형식(ch=7) 컨트롤은 식별 헤더 8바이트를
+    // 포함해 전체 84바이트다. 문자 스캔 루프의 디스패치 매치가 ch=7을
+    // parse_simple_control_char(6바이트만 소비)로 잘못 보내면, 그 뒤에 오는 실제
+    // 본문 텍스트("AAA")가 날짜 형식 문자열의 잔여 바이트로 오인되어 사라진다.
+    // 수정 후에는 ch=7이 parse_object_control_char(Task #877의 82바이트 스킵
+    // 로직)로 라우팅되어 "AAA"가 온전히 파싱되어야 한다.
+    #[test]
+    fn task2844_hwp3_date_format_ctrl_does_not_swallow_following_text() {
+        let mut body = Vec::new();
+
+        // 문단 정보 (43바이트: follow_prev_para_shape != 0 이므로 para_shape 생략).
+        body.push(1u8); // follow_prev_para_shape
+        body.extend_from_slice(&7u16.to_le_bytes()); // char_count: ch7(4) + "AAA"(3)
+        body.extend_from_slice(&0u16.to_le_bytes()); // line_count = 0 (LineInfo 생략)
+        body.push(0u8); // include_char_shape = 0
+        body.push(0u8); // flags
+        body.extend_from_slice(&0u32.to_le_bytes()); // special_char_flags
+        body.push(0u8); // style_index
+        body.extend_from_slice(&[0u8; 31]); // rep_char_shape (31바이트)
+        assert_eq!(body.len(), 43, "문단 정보 헤더 길이는 43바이트여야 함");
+
+        // ch=7 컨트롤 레코드 (전체 84바이트): open(2, 외부 char 루프에서 소비) +
+        // header_val1(4) + ch2(2) + 날짜 형식 문자열(76, 전부 0).
+        body.extend_from_slice(&7u16.to_le_bytes()); // 여는 특수 문자 코드
+        body.extend_from_slice(&84u32.to_le_bytes()); // header_val1 (예약 dword)
+        body.extend_from_slice(&7u16.to_le_bytes()); // 닫는 특수 문자 코드
+        body.extend_from_slice(&[0u8; 76]); // 날짜 형식 문자열 (모두 0)
+
+        // 날짜 컨트롤 뒤에 바로 오는 실제 본문: "AAA" (3 hchar).
+        for _ in 0..3 {
+            body.extend_from_slice(&0x0041u16.to_le_bytes()); // 'A'
+        }
+
+        // 문단 리스트 종료를 나타내는 빈 문단 (char_count=0, 총 43바이트).
+        body.push(0u8); // follow_prev_para_shape
+        body.extend_from_slice(&0u16.to_le_bytes()); // char_count = 0
+        body.extend_from_slice(&[0u8; 40]); // Hwp3ParaInfo::read가 요구하는 나머지 40바이트
+
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+
+        let paragraphs = parse_paragraph_list(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            1000,
+            1000,
+        )
+        .expect("날짜 형식(ch=7) 컨트롤을 포함한 문단 파싱 실패");
+
+        assert_eq!(
+            paragraphs.len(),
+            1,
+            "빈 종료 문단을 제외하고 문단이 1개여야 함"
+        );
+        assert!(
+            paragraphs[0].text.contains("AAA"),
+            "날짜 형식(ch=7) 컨트롤 뒤의 \"AAA\" 본문이 유실됨 (바이트 언더리드로 흡수): {:?}",
+            paragraphs[0].text
+        );
     }
 }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -431,6 +431,16 @@ fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
         .max(1)
 }
 
+/// doc_info.encrypted(암호 설정 여부)를 FileHeader.encrypted 및 raw_data 플래그 비트(0x02)에 반영한다.
+fn apply_hwp3_encrypted_flag(doc_info_encrypted: u16, header: &mut crate::model::document::FileHeader) {
+    if doc_info_encrypted != 0 {
+        header.encrypted = true;
+        if let Some(raw) = header.raw_data.as_mut() {
+            raw[36] |= 0x02;
+        }
+    }
+}
+
 fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
@@ -2946,6 +2956,11 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     doc.doc_properties.page_start_num = doc_info.start_page_number;
     doc.doc_properties.footnote_start_num = doc_info.footnote_start_number;
 
+    // doc_info.encrypted(암호 설정 여부)를 FileHeader.encrypted로 배선한다.
+    // HWP5/HWPX는 각자의 헤더에서 이 값을 채우지만 HWP3는 raw_data를 항상
+    // 비암호(flags=0)로 하드코딩해 doc.header.encrypted가 실제 값과 무관하게 false였다.
+    apply_hwp3_encrypted_flag(doc_info.encrypted, &mut doc.header);
+
     // 2. 문서 요약 파싱 (1008 바이트)
     let doc_summary = Hwp3DocSummary::read(&mut cursor)?;
 
@@ -4169,6 +4184,19 @@ mod tests {
         let cs = convert_char_shape(&sub);
         assert!(cs.subscript);
         assert!(!cs.superscript);
+    }
+
+    #[test]
+    fn hwp3_maps_encrypted_flag() {
+        // doc_info.encrypted != 0 이면 FileHeader.encrypted 와 raw_data 플래그 비트가
+        // 반영돼야 한다. 종전엔 배선이 없어 항상 false 였다.
+        let mut header = crate::model::document::FileHeader {
+            raw_data: Some(vec![0u8; crate::parser::header::FILE_HEADER_SIZE]),
+            ..Default::default()
+        };
+        apply_hwp3_encrypted_flag(1, &mut header);
+        assert!(header.encrypted);
+        assert_eq!(header.raw_data.unwrap()[36] & 0x02, 0x02);
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -317,6 +317,13 @@ pub(crate) fn convert_para_shape(
         _ => crate::model::style::Alignment::Justify,
     };
 
+    // [#2976] 문단 테두리 연결(인접 문단끼리 테두리를 이어 그릴지) 플래그.
+    // 접근자 border_connection()은 있었으나 attr1 bit 28(HWPX 직렬화기·편집
+    // 커맨드가 공유하는 규약)로 배선되지 않아 항상 소실되었다.
+    if hwp3_ps.border_connection() {
+        ps.attr1 |= 1 << 28;
+    }
+
     // [Task #741 Stage 6] HWP3 ParaShape tabs[40] → Document IR TabDef 변환.
     // - HWP3 tab struct: tab_type(u8) → leader(u8) → position(u16 LE) — 4 bytes.
     // - default tab pattern (slot N: position=1000*(N+1) hunit, tab_type=0, leader=0) 은 system 기본 탭이므로 제외.
@@ -3912,6 +3919,21 @@ mod tests {
     use super::*;
     use std::fs::File;
     use std::io::Read;
+
+    #[test]
+    fn test_convert_para_shape_wires_border_connection_into_attr1_bit28() {
+        // [#2976] border_connection() 접근자는 있었으나 attr1 bit 28로 배선되지
+        // 않아 항상 소실되던 결함의 회귀 테스트.
+        let mut hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
+        hwp3_ps.border_connection = 1;
+        let mut doc_tab_defs = Vec::new();
+        let ps = convert_para_shape(&hwp3_ps, &mut doc_tab_defs);
+        assert_eq!(
+            (ps.attr1 >> 28) & 1,
+            1,
+            "border_connection이 attr1 bit 28로 배선되어야 함"
+        );
+    }
 
     #[test]
     fn test_alloc_record_buf_overflow_returns_err() {

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -77,6 +77,11 @@ pub(crate) fn check_record_count(count: usize) -> Result<(), io::Error> {
     Ok(())
 }
 
+// HWP3 spec (한글문서파일구조3.0.md:248) doc_info offset 122 "빈줄감춤"(0 이외=on).
+fn hwp3_hide_empty_line(doc_info: &Hwp3DocInfo) -> bool {
+    doc_info.hide_empty_line != 0
+}
+
 fn hwp3_page_border_fill(
     doc_info: &Hwp3DocInfo,
     border_fill_id: u16,
@@ -3236,6 +3241,9 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
         landscape: doc_info.paper_direction != 0,
         ..Default::default()
     };
+    // 파싱만 되고 SectionDef.hide_empty_line 으로 배선되지 않아 페이지 시작부 빈 줄이
+    // 항상 정상 높이로 렌더되던 문제 (#issue).
+    section_def.hide_empty_line = hwp3_hide_empty_line(&doc_info);
 
     // [Task #877 Stage 4] HWP3 doc_info.border_type / border_margin → SectionDef.page_border_fill
     // 변환. HWP3 spec §3.2 (문서 정보) offset 112-121 의 페이지 테두리 정보. type=0 이면 없음,
@@ -4011,6 +4019,23 @@ mod tests {
         assert_eq!(pbf.spacing_bottom, 160);
         assert_eq!(pbf.basis, PageBorderBasis::BodyBased);
         assert_eq!(pbf.ui_basis, PageBorderUiBasis::Page);
+    }
+
+    #[test]
+    fn issue_hwp3_hide_empty_line_wires_doc_info_flag() {
+        // doc_info offset 122 "빈줄감춤" 이 파싱만 되고 SectionDef.hide_empty_line 으로
+        // 배선되지 않던 문제의 회귀 방지.
+        let on = Hwp3DocInfo {
+            hide_empty_line: 1,
+            ..Default::default()
+        };
+        assert!(hwp3_hide_empty_line(&on));
+
+        let off = Hwp3DocInfo {
+            hide_empty_line: 0,
+            ..Default::default()
+        };
+        assert!(!hwp3_hide_empty_line(&off));
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1265,6 +1265,15 @@ fn parse_hwp3_object_dispatch(
             if let Err(_) = body_cursor.read_exact(&mut field_data) {
                 return Ok(Some(true));
             }
+            // [Task #877 후속] field_data 는 파싱만 되고 IR로 배선되지 않아 소실됐다.
+            // 책갈피(ch==6)와 동일하게 원본 바이트를 command 에 실어 Field control로 배선.
+            let mut field = crate::model::control::Field::default();
+            field.field_type = crate::model::control::FieldType::Unknown;
+            field.command = crate::parser::hwp3::encoding::decode_hwp3_string(&field_data)
+                .trim_end_matches('\0')
+                .to_string();
+            controls.push(crate::model::control::Control::Field(field));
+            ctrl_data_records.push(None);
         }
     } else if ch == 6 {
         // [Task #877] 책갈피 (spec §10.2, 표 36): 42 bytes total.
@@ -3996,6 +4005,73 @@ mod tests {
         assert!(check_record_count(HWP3_MAX_RECORD_SIZE + 1).is_err());
         assert!(check_record_count(0xFFFFFFFF).is_err());
         assert!(check_record_count(1024).is_ok());
+    }
+
+    #[test]
+    fn test_hwp3_field_code_ch5_produces_field_control() {
+        // [Task #877 후속] ch==5 필드 코드는 field_data 를 읽고도 IR Field로
+        // 배선되지 않고 소실됐다. 8바이트 헤더(dword len=4 + ch2) + 4바이트
+        // payload 를 합성해 Control::Field 로 배선되는지 검증.
+        let payload = b"ABCD";
+        let mut body = Vec::new();
+        body.extend_from_slice(&(payload.len() as u32).to_le_bytes()); // header_val1
+        body.extend_from_slice(&5u16.to_le_bytes()); // ch2 (close)
+        body.extend_from_slice(payload);
+
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+        let para_info = Hwp3ParaInfo {
+            follow_prev_para_shape: 0,
+            char_count: 10,
+            line_count: 1,
+            include_char_shape: 0,
+            flags: 0,
+            special_char_flags: 0,
+            style_index: 0,
+            rep_char_shape: Default::default(),
+            para_shape: None,
+        };
+        let mut text_string = String::new();
+        let mut char_offsets = Vec::new();
+        let mut hwp3_char_to_utf16_pos = vec![0u32; 10];
+        let mut controls = Vec::new();
+        let mut ctrl_data_records = Vec::new();
+        let mut scan = Hwp3CharScan {
+            text_string: &mut text_string,
+            char_offsets: &mut char_offsets,
+            hwp3_char_to_utf16_pos: &mut hwp3_char_to_utf16_pos,
+            controls: &mut controls,
+            ctrl_data_records: &mut ctrl_data_records,
+        };
+
+        parse_object_control_char(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            0,
+            0,
+            5,
+            &para_info,
+            0,
+            0,
+            &mut scan,
+        )
+        .unwrap();
+
+        assert!(
+            controls
+                .iter()
+                .any(|c| matches!(c, crate::model::control::Control::Field(_))),
+            "ch==5 필드 코드가 Control::Field 로 배선되지 않음: {controls:?}"
+        );
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -192,6 +192,20 @@ fn hwp3_color_index_to_color_ref(color: u8) -> crate::model::ColorRef {
     }
 }
 
+/// [#2984] HWP3 그림 정보 레코드(348바이트) offset 339~341 의 밝기/명암/그림효과를
+/// 읽는다. (`mydocs/tech/한글문서파일구조3.0.md` 10.7절, 표 43 "그림 식별 정보")
+fn hwp3_picture_image_effect(info_buf: &[u8]) -> (i8, i8, crate::model::image::ImageEffect) {
+    if info_buf.len() < 342 {
+        return (0, 0, crate::model::image::ImageEffect::RealPic);
+    }
+    let effect = match info_buf[341] {
+        1 => crate::model::image::ImageEffect::GrayScale,
+        2 => crate::model::image::ImageEffect::BlackWhite,
+        _ => crate::model::image::ImageEffect::RealPic,
+    };
+    (info_buf[339] as i8, info_buf[340] as i8, effect)
+}
+
 const HWP3_TO_IR_PARA_UNIT: i32 = 8;
 
 fn hwp3_para_metric_to_ir(value: i16) -> i32 {
@@ -963,6 +977,13 @@ fn parse_hwp3_object_dispatch(
             pic.common.vertical_offset = (vert_align as i32 * 4) as u32;
         }
         pic.common.attr = build_common_obj_attr(&pic.common);
+
+        // [#2984] 밝기/명암/그림효과 (offset 339~341) 미반영 → 흑백/그레이스케일/
+        // 밝기·명암 보정된 HWP3 그림이 원본 컬러 그대로 렌더링되던 문제 수정.
+        let (brightness, contrast, effect) = hwp3_picture_image_effect(&info_buf);
+        pic.image_attr.brightness = brightness;
+        pic.image_attr.contrast = contrast;
+        pic.image_attr.effect = effect;
 
         let n_ext_from_buf = (&info_buf[0..4]).read_u32::<LittleEndian>().unwrap_or(0);
         let n_ext = n_ext_from_buf;
@@ -4003,6 +4024,19 @@ mod tests {
         assert_eq!(hwp3_color_index_to_color_ref(6), 0x0000FFFF);
         assert_eq!(hwp3_color_index_to_color_ref(7), 0x00FFFFFF);
         assert_eq!(hwp3_color_index_to_color_ref(255), 0x00000000);
+    }
+
+    #[test]
+    fn task2984_hwp3_picture_image_effect_reads_brightness_contrast_effect() {
+        // [#2984] offset 339=밝기, 340=명암, 341=그림효과(1=그레이스케일).
+        let mut info_buf = vec![0u8; 348];
+        info_buf[339] = (-40i8) as u8;
+        info_buf[340] = 25u8;
+        info_buf[341] = 1u8;
+        let (brightness, contrast, effect) = hwp3_picture_image_effect(&info_buf);
+        assert_eq!(brightness, -40);
+        assert_eq!(contrast, 25);
+        assert_eq!(effect, crate::model::image::ImageEffect::GrayScale);
     }
 
     #[test]


### PR DESCRIPTION
kevin9327 님의 HWP3 축 8건을 메인테이너가 재실증 후 통합한다. **`parser/hwp3/` 밖 `.rs` 변경 0건**으로 CLAUDE.md 의 HWP3 아키텍처 경계를 지킨다.

## 채택 — 파싱 바이트 오·과소비 3건

- **#2827** (`Closes #2824`) — 변형된 호(타입9) 파싱이 **스펙에 없는 8바이트를 소비**해 이후 도형이 밀렸다.
- **#2860** (`Closes #2844`) — 날짜 형식(7)·날짜 코드(8) 컨트롤이 6바이트만 소비해 **뒤따르는 본문 텍스트를 삼켰다**. 두 코드를 `parse_simple_control_char` arm 에서 분리했다.
- **#2926** — 조합형 디코더가 무효 종성 인덱스를 **받침 없음으로 오인**해 글자가 달라졌다.

## 채택 — IR 배선 누락 5건

파싱은 되는데 IR 로 넘어가지 않던 계열이다. **읽어놓고 버리는** 유형이라 사용자에게는 설정이 사라진 것으로 보인다.

- **#2983** — `convert_para_shape()` 의 `border_connection` 플래그
- **#2994** (`Closes #2984`) — 그림 밝기/명암/그림효과(offset 339~341)
- **#3010** (`Closes #3006`) — `doc_info.hide_empty_line`(빈줄감춤) → SectionDef
- **#3061** (`Closes #3057`) — 필드 코드(ch=5) `field_data`
- **#3070** — `doc_info.encrypted`(암호 설정 여부) → FileHeader

## 검증

- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- **hwp3 테스트 29건 통과** (devel 21 → 신규 8)
- red→green: 날짜 컨트롤의 `7 | 8` 을 종전 `parse_simple_control_char` arm 으로 되돌리니 `task2844_hwp3_date_format_ctrl_does_not_swallow_following_text` FAIL → 복원 시 29건 통과
- `parser/hwp3/` 밖 `.rs` 변경 0건

**메인테이너 보정 1건** — #3070 cherry-pick 후 `apply_hwp3_encrypted_flag` 시그니처가 100열을 넘어 fmt 위반이 생겨 `cargo fmt` 를 적용했다.

## 이번 배치에서 제외 — 충돌 9건

`2836 2997 3023 3027 3036 3049 3059 3078 3079`

HWP3 축 17건 중 **14건이 같은 `src/parser/hwp3/mod.rs` 를 건드려** 오래된 순서로 적용해도 뒤 건이 밀렸다. 특히 각주 관련 5건(#3023 #3027 #3036 #3049 #3059)이 인접 라인을 수정한다.

이 8건이 merge 되면 devel 기준이 바뀌므로 **충돌이 풀릴 가능성이 있다.** merge 후 재시도한다.

## 처리 맥락

한 기여자의 열린 PR 이 113건까지 쌓여 개별 처리로는 감당이 어려워졌다. `scripts/pr_triage.sh`(#3077)로 축별 분류를 만들고, 충돌 상태 30건을 리베이스 요청과 함께 close 해 잔량을 92건으로 줄인 뒤 축 단위로 처리하는 중이다. HWP3 는 `parser/hwp3/` 경계가 명확해 첫 축으로 골랐다.

Co-authored-by 로 원 커밋 provenance 를 보존한다.
