### PR TITLE
docs: cli_commands.md의 --backend direct 미구현 서술 정정 (#2893)

### DIFF
--- a/mydocs/manual/cli_commands.md
+++ b/mydocs/manual/cli_commands.md
@@ -96,6 +96,12 @@ HWP/HWPX → PDF (svg2pdf + pdf-writer).
     Windows 폰트 등)가 시스템에 없으면 번들 대체 폰트(Noto Sans/Serif KR)로 떨어져
     글꼴이 바뀐다. 서버·컨테이너에서 대량 변환할 때는 **필요한 폰트를 설치하고
     `--font-path` 또는 `RHWP_FONT_PATH` 로 명시**해야 정본과 같은 결과를 얻는다.
+- `--backend <svg|direct>` — PDF backend(기본값: svg). `svg`는 기존 SVG-derived 경로,
+  `direct`는 `PageLayerTree → PDF` direct/vector 경로. `direct`는 `native-skia` feature로
+  빌드한 native CLI가 필요하며, 해당 feature 없이 빌드된 CLI에서 `--backend direct`를 쓰면
+  종료코드 1과 함께 오류 메시지를 반환한다.
+- `--raster-dpi <DPI>` — `direct` backend fallback raster DPI(기본값: 144). `direct` backend
+  에서만 사용할 수 있다.
 - `--fallback-serif <family>` — PDF serif generic fallback family
 - `--fallback-sans <family>` — PDF sans-serif generic fallback family
 - `--fallback-mono <family>` — PDF monospace generic fallback family
@@ -128,7 +134,8 @@ rhwp export-pdf input.hwp -o out.pdf \
   - Linux: `Noto Serif CJK KR` / `Noto Sans CJK KR` / `Noto Sans Mono CJK KR`
   - macOS: `AppleMyungjo` / `Apple SD Gothic Neo` / `Menlo`
 - 선택한 fallback family 또는 수식 폰트가 fontdb에 없으면 warning을 출력한다.
-- direct/vector `PageLayerTree → PDF` backend는 아직 후속 작업이다.
+- direct/vector `PageLayerTree → PDF` backend는 `--backend direct`로 이미 사용 가능하다
+  (`native-skia` feature 빌드 필요, 위 옵션 설명 참고).
 
 ### `export-text <파일> [옵션]`
 페이지별 텍스트 → TXT. `-o`, `-p`.

--- a/mydocs/report/task_m100_2893_report.md
+++ b/mydocs/report/task_m100_2893_report.md
@@ -1,0 +1,48 @@
+# task m100-2893: cli_commands.md `--backend direct` 서술 오류 수정
+
+## 이슈
+
+edwardkim/rhwp#2893
+
+## 문제
+
+`mydocs/manual/cli_commands.md` 122번째 줄이 `export-pdf`의 direct/vector
+`PageLayerTree → PDF` backend(`--backend direct`)를 "아직 후속 작업"이라고 서술하고
+있었으나, `src/main.rs`와 기존 통합 테스트를 확인한 결과 이 backend는 이미 CLI
+옵션으로 완전히 배선되어 있고 `native-skia` feature 빌드에서 동작이 검증되어 있었다.
+또한 `--backend`, `--raster-dpi` 옵션 자체가 `export-pdf` 옵션 목록에 전혀 나열되어
+있지 않은 문제도 함께 있었다.
+
+## 근거
+
+- `src/main.rs:183,187` — `--help` 출력에 `--backend <svg|direct>`, `--raster-dpi <DPI>`
+  가 이미 존재.
+- `src/main.rs:1347-1368` — `--backend`/`--backend=` 파싱 로직 존재.
+- `src/main.rs:1585-1610` — `PdfBackend::DirectLayer` 분기가
+  `render_pages_pdf_direct_native_with_profile_and_options`로 실제 렌더링 연결(`native-skia`
+  feature 조건부).
+- `src/main.rs:1630-1632` — direct backend 성공 시 `"PDF backend: direct"` 완료 로그.
+- `tests/render_p37_direct_pdf_export.rs` — `#[cfg(... feature = "native-skia")]` 하에서
+  `render_page_pdf_direct_native` 등 3개 API 전체를 호출해 완결된 PDF(`%PDF-` ~
+  `%%EOF`)를 검증.
+- `tests/render_p37_pdf_backend_cli.rs` — CLI 레벨에서 `--backend svg` 기본 동작 동일성과,
+  `native-skia` 없는 빌드에서만 `--backend direct`가 종료코드 1 + 명시적 오류 메시지를
+  반환함을 검증(`direct_backend_reports_missing_native_skia_feature`).
+
+## 변경 사항
+
+`mydocs/manual/cli_commands.md`
+- `export-pdf` 옵션 목록에 `--backend <svg|direct>`, `--raster-dpi <DPI>` 항목을 추가하고,
+  `direct` backend가 `native-skia` feature 빌드를 요구하며 없을 경우 명시적 오류를
+  반환한다는 점을 명시.
+- 122번째 줄의 "아직 후속 작업이다" 서술을 "`--backend direct`로 이미 사용 가능하다
+  (`native-skia` feature 빌드 필요)"로 정정.
+
+## 검증
+
+이번 변경은 마크다운 문서 수정만 포함하는 docs-only 변경이므로 코드 검증은
+코드/테스트 인용을 통한 cross-check로 대체했다(별도 cargo build/test 불필요).
+- `grep -n "backend" src/main.rs` 및 `tests/render_p37_*` 파일 내용을 직접 읽어 문서
+  서술과 실제 구현/테스트가 일치하는지 확인함.
+- `grep -n "backend" mydocs/manual/cli_commands.md`로 수정 후 문서 내 유일한 backend
+  언급이 정정된 내용과 일치함을 확인함.


### PR DESCRIPTION
#2894 가 devel과의 충돌로 일괄 close되어, upstream/devel 기준으로 리베이스 후 새로 오픈합니다. (기존 PR을 GitHub API가 재오픈 거부: force-push된 브랜치는 reopen 불가)

이전: #2894