### PR TITLE
fix(hwpx): 탭 리더 이중/삼중선 OWPML 스펙 리터럴 불일치 수정 (#2857)

### DIFF
--- a/mydocs/report/task_m100_2857_report.md
+++ b/mydocs/report/task_m100_2857_report.md
@@ -1,0 +1,59 @@
+# 완료 보고서 — Task M100-2857
+
+- 이슈: #2857
+- 제목: HWPX tabItem leader 속성 이중선/삼중선(SLIM_THICK/THICK_SLIM/SLIM_THICK_SLIM)
+  파싱·직렬화가 OWPML 스펙 리터럴과 불일치
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2857-tabitem-leader-doubleslim`
+
+## 1. 배경
+
+`<hh:tabItem leader="...">`의 `fill_type` 8~11(이중선·삼중선 4종)은 과거 커밋
+`5d0ac30a`에서 "9/10/11이 저장 시 NONE으로 유실"되는 문제를 고치면서 파서·직렬화를
+내부적으로 짝지어 왕복되게는 했지만, 사용한 문자열(`THIN_THICK`/`THICK_THIN`/`TRIM`)이
+`mydocs/manual/OWPML SCHEMA/Core XML schema.xml` 335~349행 `LineType3`의 실제 스펙
+리터럴(`SLIM_THICK`/`THICK_SLIM`/`SLIM_THICK_SLIM`)과 달랐다. 그 결과:
+
+- rhwp가 방출한 HWPX를 한/글 등 스펙 준수 구현체가 열면 정의되지 않은 leader
+  값으로 처리될 위험.
+- 한/글이 저장한 정상 HWPX 문서(스펙 리터럴 사용)를 rhwp가 열면 `leader`가
+  매칭되지 않아 `NONE`(0)으로 조용히 유실.
+
+`fill_type=8`(DOUBLE_SLIM)은 이미 스펙 리터럴과 일치했으므로 이번 수정 범위에서
+제외했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs` (`parse_tab_item`)
+  - `leader` 매칭에 스펙 리터럴 `"SLIM_THICK"`(9), `"THICK_SLIM"`(10),
+    `"SLIM_THICK_SLIM"`(11)을 추가. 기존 비표준 이름(`THIN_THICK` 등)도
+    하위호환을 위해 계속 허용.
+- `src/serializer/hwpx/header.rs` (`tab_leader_str`)
+  - 9/10/11 방출 문자열을 스펙 리터럴로 교체
+    (`SLIM_THICK`/`THICK_SLIM`/`SLIM_THICK_SLIM`).
+
+## 3. 테스트 (red → green)
+
+`src/parser/hwpx/header.rs`에 추가:
+`test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`
+
+- 내용: `<hh:tabItem pos="1000" type="LEFT" leader="SLIM_THICK"/>`를 포함한
+  `<hh:head>`를 파싱해 `doc_info.tab_defs[0].tabs[0].fill_type == 9` 확인.
+- 수정 전: `"SLIM_THICK"`이 `match`에서 매칭되지 않아 `_ => 0`으로 떨어져
+  `fill_type == 0` → 테스트 실패(red).
+- 수정 후: `"SLIM_THICK" => 9` 매칭 → 테스트 통과(green).
+
+## 4. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs src/serializer/hwpx/header.rs`
+
+## 5. 남은 항목
+
+- `fill_type` 12(WAVE)/13(DOUBLEWAVE)는 IR(`TabItem::fill_type: u8`)이나 현재
+  파서·직렬화에서 아예 다루지 않는다. 별도 조사·이슈 대상으로 남겨둔다(이번
+  범위 밖).

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1643,9 +1643,12 @@ fn parse_tab_item(ce: &quick_xml::events::BytesStart) -> TabItem {
                     // 방출측 tab_leader_str 은 fill_type 8 을 "DOUBLE_SLIM" 으로 낸다
                     // (border 명명과 동일). 안 받으면 이중실선 탭 리더가 왕복 시 NONE(0)으로 유실.
                     "DOUBLE_LINE" | "DOUBLE_SLIM" => 8, // 이중실선
-                    "THIN_THICK" => 9,                  // 얇고 굵은 이중선
-                    "THICK_THIN" => 10,                 // 굵고 얇은 이중선
-                    "TRIM" => 11,                       // 얇고 굵고 얇은 삼중선
+                    // OWPML LineType3 스펙 리터럴은 SLIM_THICK/THICK_SLIM/SLIM_THICK_SLIM
+                    // (Core XML schema.xml 335~349행). THIN_THICK/THICK_THIN/TRIM 은
+                    // rhwp 내부에서만 쓰던 비표준 이름이라 스펙 준수 문서(#2857)를 못 읽었다.
+                    "THIN_THICK" | "SLIM_THICK" => 9, // 얇고 굵은 이중선
+                    "THICK_THIN" | "THICK_SLIM" => 10, // 굵고 얇은 이중선
+                    "TRIM" | "SLIM_THICK_SLIM" => 11, // 얇고 굵고 얇은 삼중선
                     _ => 0,
                 };
             }
@@ -2134,6 +2137,26 @@ mod tests {
                 (tags::HWPTAG_TRACKCHANGE, 1, 1032),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick() {
+        // OWPML LineType3 스펙 리터럴(Core XML schema.xml 335행)은 "SLIM_THICK"이다.
+        // rhwp 내부 전용 이름 "THIN_THICK"만 받으면 한/글이 저장한 정상 문서의
+        // 탭 리더가 NONE(0)으로 유실된다 (#2857).
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:tabProperties itemCnt="1">
+      <hh:tabPr id="0" autoTabLeft="0" autoTabRight="0">
+        <hh:tabItem pos="1000" type="LEFT" leader="SLIM_THICK"/>
+      </hh:tabPr>
+    </hh:tabProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(doc_info.tab_defs[0].tabs[0].fill_type, 9);
     }
 
     #[test]

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -846,11 +846,14 @@ fn tab_leader_str(f: u8) -> &'static str {
         6 => "LONG_DASH",
         7 => "CIRCLE",
         8 => "DOUBLE_SLIM",
-        // 종전엔 9/10/11 이 _ => "NONE" 으로 떨어져 이중/삼중선 탭 리더가 저장 시 유실됐다.
-        // 파서(parse_tab_item)는 이 문자열들을 각각 9/10/11 로 받으므로 왕복 보존된다.
-        9 => "THIN_THICK",
-        10 => "THICK_THIN",
-        11 => "TRIM",
+        // OWPML LineType3 스펙 리터럴(Core XML schema.xml 335~349행)로 방출한다.
+        // 종전엔 THIN_THICK/THICK_THIN/TRIM 이라는 비표준 이름을 썼는데, rhwp
+        // 자기 자신은 다시 읽을 수 있어도(파서가 두 이름을 모두 허용) 한/글 등
+        // 스펙을 따르는 다른 구현체에는 정의되지 않은 값이라 상호운용에 문제가
+        // 있었다(#2857). 파서는 하위호환을 위해 옛 이름도 계속 받는다.
+        9 => "SLIM_THICK",
+        10 => "THICK_SLIM",
+        11 => "SLIM_THICK_SLIM",
         _ => "NONE",
     }
 }


### PR DESCRIPTION
원 PR #2868이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약

closes #2857

`<hh:tabItem leader="...">` 이중선/삼중선 3종(`fill_type` 9/10/11)의 파싱·직렬화가
OWPML `LineType3` 스펙 리터럴(`SLIM_THICK`/`THICK_SLIM`/`SLIM_THICK_SLIM`,
`mydocs/manual/OWPML SCHEMA/Core XML schema.xml` 335~349행)과 다른 비표준 이름
(`THIN_THICK`/`THICK_THIN`/`TRIM`)을 쓰고 있어, 한/글이 저장한 정상 HWPX 문서의
해당 탭 리더가 rhwp에서 열람 시 `NONE`으로 유실되고, rhwp가 방출한 문서도 다른
구현체와 상호운용에 문제가 있었습니다.

## 근거

- `mydocs/manual/OWPML SCHEMA/Core XML schema.xml` 335~349행 `LineType3` 정의.
- `src/parser/hwpx/header.rs` `parse_tab_item`: `leader` 매칭에 비표준 이름만 존재.
- `src/serializer/hwpx/header.rs` `tab_leader_str`: 9/10/11 방출 문자열이 비표준.
- 자세한 근거는 이슈 #2857 본문·후속 코멘트 참고.

## Red → Green

`src/parser/hwpx/header.rs`에 추가한
`test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`:

- `<hh:tabItem pos="1000" type="LEFT" leader="SLIM_THICK"/>`를 파싱해
  `fill_type == 9`를 확인.
- 수정 전: `"SLIM_THICK"`이 매칭되지 않고 `_ => 0`으로 떨어져 `fill_type == 0` → red.
- 수정 후: `"SLIM_THICK" => 9` → green.

## 변경 사항

- `src/parser/hwpx/header.rs`: `leader` 파싱에 스펙 리터럴 3종 추가(기존 비표준
  이름도 하위호환으로 계속 허용).
- `src/serializer/hwpx/header.rs`: `tab_leader_str` 9/10/11 방출을 스펙 리터럴로 교체.
- `mydocs/report/task_m100_2857_report.md`: 완료 보고서.

## 검증

- `cargo build --lib`
- `cargo test --lib test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`
- `cargo clippy --all-targets --profile release-test -- -D warnings`
- `rustfmt --edition 2021 src/parser/hwpx/header.rs src/serializer/hwpx/header.rs`

## 참고

`autoTabLeft`/`autoTabRight`, `tab_type`, `leader` 0~8은 이미 정상 왕복됨을
확인했습니다(이슈 본문 참고). `fill_type` 12(WAVE)/13(DOUBLEWAVE)는 IR에서 아예
다루지 않아 이번 범위 밖으로 남겨두었습니다.