### PR TITLE
fix(parser): 다각형 도형 point count(i32) 음수 부호확장으로 인한 무한루프 방지 (#3012)

### DIFF
--- a/mydocs/report/task_m100_3012_report.md
+++ b/mydocs/report/task_m100_3012_report.md
@@ -1,0 +1,40 @@
+# task_m100_3012: 다각형 도형 point count(i32) 음수 부호확장 수정
+
+## 이슈
+#3012 fix(parser): 다각형 도형 point count(i32) 음수 값이 부호확장되어 무한에 가까운 루프를 유발하는 문제
+
+## 원인
+
+`src/parser/control/shape.rs`의 `parse_polygon_shape_data`에서 hwplib 스펙상 부호 있는
+INT32인 다각형 점 개수(count)를 검증 없이 바로 `as usize`로 캐스팅했다. 조작된 값(예: `-1`)이
+들어오면 부호 확장으로 `usize::MAX` 근처의 거대한 값이 되고, 이후 `for _ in 0..cnt` 루프가
+입력이 소진된 뒤에도 `unwrap_or(0)` 기본값으로 계속 실행되어 사실상 종료되지 않는 루프(DoS)가
+된다.
+
+이는 #3004/#3008(`region.rs`의 `scan_count: i16`)과 동일한 버그 클래스(부호 있는 필드를 검증
+없이 usize로 캐스팅)의 i32 사례다.
+
+## 수정
+
+캐스팅 전에 음수 여부를 검사해 음수면 count를 0(빈 다각형)으로 처리하도록 방어했다.
+
+```rust
+let cnt_raw = r.read_i32().unwrap_or(0);
+let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+```
+
+## 테스트
+
+`polygon_point_count_negative_is_treated_as_zero`: count에 `-1`(`0xFFFFFFFF`)을 넣은 최소
+페이로드로 `parse_polygon_shape_data`를 호출해 `poly.points`가 비어 있는지 검증한다(수정 전에는
+사실상 무한 루프에 빠져 테스트가 종료되지 않음).
+
+## 검증
+
+- `cargo check --lib`: 통과
+- `cargo test --lib polygon_point_count_negative_is_treated_as_zero`: 통과 (exit 0)
+- `rustfmt --edition 2021`: 적용, 변경 없음
+
+## 범위
+
+`src/parser/control/shape.rs` 1개 파일, 핵심 수정 2줄 + 테스트 15줄.

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1060,7 +1060,8 @@ fn parse_arc_shape_data(data: &[u8], arc: &mut ArcShape) {
 /// hwplib: INT32 count + (INT32 x, INT32 y) × count + skip(4)
 fn parse_polygon_shape_data(data: &[u8], poly: &mut PolygonShape) {
     let mut r = ByteReader::new(data);
-    let cnt = r.read_i32().unwrap_or(0) as usize;
+    let cnt_raw = r.read_i32().unwrap_or(0);
+    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
     poly.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1128,6 +1129,22 @@ mod task195_tests {
             connector.control_points.is_empty(),
             "남은 바이트가 없으므로 제어점은 비어야 함: {}",
             connector.control_points.len()
+        );
+    }
+
+    #[test]
+    fn polygon_point_count_negative_is_treated_as_zero() {
+        // count(INT32)에 음수(-1 = 0xFFFFFFFF)를 넣으면 as usize 부호확장으로
+        // 사실상 무한 루프에 빠지면 안 되고 빈 다각형으로 처리되어야 한다.
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_le_bytes()); // count (악성)
+
+        let mut poly = PolygonShape::default();
+        parse_polygon_shape_data(&data, &mut poly);
+        assert!(
+            poly.points.is_empty(),
+            "음수 count는 빈 점 목록으로 처리되어야 함: {}",
+            poly.points.len()
         );
     }
 


### PR DESCRIPTION
원 PR #3020이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약

- `src/parser/control/shape.rs`의 `parse_polygon_shape_data`에서 다각형 점 개수(count, INT32)를
  검증 없이 `as usize`로 캐스팅하던 문제를 수정했습니다.
- 조작된 count가 음수(예: `-1`)일 경우 부호 확장으로 `usize::MAX` 근처 값이 되어, 이후
  `for _ in 0..cnt` 루프가 입력 소진 후에도 `unwrap_or(0)` 기본값으로 계속 실행되며 사실상
  종료되지 않는 루프(DoS)가 발생했습니다.
- 캐스팅 전 음수 여부를 검사해 음수면 count를 0(빈 다각형)으로 처리하도록 방어했습니다.
- #3004/#3008(`region.rs`의 `scan_count: i16`)과 동일한 버그 클래스(부호 있는 필드를 검증 없이
  usize로 캐스팅)의 i32 사례입니다.

Closes #3012

## 테스트 플랜

- [x] `polygon_point_count_negative_is_treated_as_zero` 추가: count=-1 페이로드로
      `parse_polygon_shape_data` 호출 후 `poly.points`가 비어있음을 검증
- [x] `cargo check --lib` 통과
- [x] `cargo test --lib polygon_point_count_negative_is_treated_as_zero` 통과
- [x] `rustfmt --edition 2021` 적용(변경 없음)