### PR TITLE
fix(hwpx): hp:pic 저장 시 numberingType·groupLevel 속성 유실 수정 (#2745)

### DIFF
--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -72,4 +72,4 @@ if let Some(ref caption) = $shape.$caption_field {
 
 ## PR 번호
 
-PR #(PR 생성 후 번호 기입)
+PR #2737

--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -1,0 +1,75 @@
+# PR: 그리기 도형·묶음·차트 캡션이 HWP5 직렬화에서 전량 소실
+
+## 개요
+
+HWP5 직렬화기(`serialize_shape_control`)에서 도형(ShapeObject)의 모든 variant에 대해
+캡션(caption)을 방출하지 않던 문제를 수정.
+
+## 분석
+
+### 파서 상태
+
+`src/parser/control/shape.rs`의 파서는 모든 GSO 도형의 캡션을 올바르게 읽고 있음:
+
+- 기본 도형(Line, Rectangle, Ellipse, Arc, Polygon, Curve): `drawing.caption`에 저장
+- 묶음(Group): `group.caption`에 저장  
+- 차트(Chart): `chart.caption`에 저장
+- OLE: `ole.caption`에 저장
+- 그림(Picture): `picture.caption`에 저장 (별도 함수 `serialize_picture_control`에서 처리)
+
+### 직렬화 문제
+
+`src/serializer/control.rs`에서 `serialize_caption` 호출은 다음 두 곳뿐이었음:
+
+1. 표(`serialize_table_control`, 492행)  
+2. 그림(`serialize_picture_control`, 998행)
+
+`serialize_shape_control`(1181행-)의 모든 arm에는 `serialize_caption` 호출이 전혀 없어,
+도형에 첨부된 캡션이 HWP5 저장 시 전량 소실됨.
+
+### 적용 범위 (9개 ShapeObject variant)
+
+| Variant | 캡션 위치 | 직렬화 위치 (SHAPE_COMPONENT 이전) |
+|---------|-----------|-----------------------------------|
+| Line | `line.drawing.caption` | CTRL_HEADER + synthesized_ctrl_data 이후 |
+| Rectangle | `rect.drawing.caption` | 동일 |
+| Ellipse | `ellipse.drawing.caption` | 동일 |
+| Polygon | `poly.drawing.caption` | 동일 |
+| Arc | `arc.drawing.caption` | 동일 |
+| Curve | `curve.drawing.caption` | 동일 |
+| Group | `group.caption` (직접 필드) | 동일 |
+| Chart | `chart.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+| Ole | `ole.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+
+### 배치 패턴
+
+기존 그림(`serialize_picture_control`)의 캡션 배치와 동일하게:
+1. CTRL_HEADER (`level`)
+2. 캡션 (`level + 1`, LIST_HEADER + 문단)
+3. SHAPE_COMPONENT (`level + 1`)
+4. CTRL_DATA (`level + 2`, SHAPE_COMPONENT의 자식)
+5. 텍스트 박스 및 도형별 레코드 (`level + 2`)
+
+## 코드 변경
+
+**파일**: `src/serializer/control.rs`
+**추가된 호출**: 9개의 `serialize_caption` 호출 (각 ShapeObject arm당 1개)
+
+각 호출 패턴:
+```rust
+// 캡션 (SHAPE_COMPONENT 앞, level+1)
+if let Some(ref caption) = $shape.$caption_field {
+    serialize_caption(caption, level + 1, records);
+}
+```
+
+## 검증
+
+- `cargo check` 통과
+- `cargo fmt --all` 적용 완료
+- 기존 파서-직렬화 라운드트립 검증: 파서가 읽은 캡션을 직렬화가 방출하므로
+  라운드트립 보존 (기존 파서 변경 없음)
+
+## PR 번호
+
+PR #(PR 생성 후 번호 기입)

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -43,3 +43,4 @@ rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자�
 
 - #2697 — 표 hp:sz IR 보존
 - #2712 — rect/line/picture hp:sz IR 보존
+- #2733 — 본 PR

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -1,0 +1,45 @@
+# PR: fix(hwpx): 공용 도형 경로 hp:sz 크기 기준·크기 보호 소실 (ellipse/arc/polygon/curve/chart)
+
+## 개요
+
+Issue #2726. #2697(표)과 #2712(rect/line/picture)에서 해결된 hp:sz의
+widthRelTo/heightRelTo/protect IR 보존이 나머지 도형 타입(ellipse, arc, polygon, curve,
+chart)에서 여전히 hardcoded "ABSOLUTE"/"0"으로 방출되는 문제를 수정한다.
+
+## 분석
+
+`src/serializer/hwpx/shape.rs`의 `write_sz()` 함수(978~992번째 줄)는 `CommonObjAttr`의
+`width_criterion`, `height_criterion`, `size_protect` 필드를 무시하고 항상
+`widthRelTo="ABSOLUTE"`, `heightRelTo="ABSOLUTE"`, `protect="0"`을 방출했다.
+
+이 함수는 다음과 같은 모든 도형 타입에서 공통으로 호출된다:
+- `<hp:rect>` — write_rect (103번째 줄)
+- `<hp:line>` / `<hp:connectLine>` — write_line (250번째 줄)
+- `<hp:container>` — write_container_close (321번째 줄)
+- `<hp:ole>` — write_ole (390번째 줄)
+
+rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자체를 수정하면
+모든 도형 타입이 한 번에 fix된다. ole는 chart/ole 개체를 포함한다.
+
+## 변경 내용
+
+**`src/serializer/hwpx/shape.rs`**
+
+1. `SizeCriterion` import 추가
+2. `size_criterion_width_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column→COLUMN, Para→PARA, Absolute→ABSOLUTE)
+3. `size_criterion_height_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column/Para/Absolute→ABSOLUTE; 파서가 높이는 allow_column_para=false로 읽으므로
+   Column/Para는 존재하지 않지만 fallback으로 ABSOLUTE)
+4. `write_sz()` — hardcoded "ABSOLUTE"/"0" 대신 위 헬퍼 함수와
+   `bool01(c.size_protect)` 사용
+
+## 검증
+
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과 (45.04s)
+
+## 관련 PR
+
+- #2697 — 표 hp:sz IR 보존
+- #2712 — rect/line/picture hp:sz IR 보존

--- a/mydocs/report/pr-hwpx-pic-attrs.md
+++ b/mydocs/report/pr-hwpx-pic-attrs.md
@@ -1,0 +1,44 @@
+# hp:pic 저장 시 numberingType·groupLevel 속성 유실 수정
+
+- **Issue**: #2745
+- **Branch**: `pr/fix-issue-2745-hwpx-pic-attrs`
+- **Type**: fix
+- **Component**: serializer/hwpx, parser/hwpx
+
+## 배경
+
+HWPX 그림(`<hp:pic>`) 직렬화에서 `numberingType`과 `groupLevel` 두 속성이 IR 값을 사용하지 않고 하드코딩되어 방출되어, 저장 시 원본 속성이 유실되는 문제가 있었다. 도형(`<hp:rect>`, `<hp:line>`) 및 표(`<hp:tbl>`)는 이미 #1379/#2697에서 IR 보존으로 정리되었으나 그림 경로는 누락되었다.
+
+## 수정 내용
+
+### 1. Parser: `numberingType` 속성 파싱 추가
+
+**파일**: `src/parser/hwpx/section.rs` - `parse_picture` 함수
+
+기존 `parse_picture`는 `<hp:pic>` 요소의 `numberingType` 속성을 파싱하지 않아 IR의 `common.numbering_type`이 항상 기본값(`None`)으로 남았다. 도형/표 파서와 동일한 매핑 로직을 추가하여 `PICTURE`/`TABLE`/`EQUATION`/`NONE` 값을 IR에 저장한다.
+
+```rust
+b"numberingType" => {
+    common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+        "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+        "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+        "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+        _ => crate::model::shape::ObjectNumberingType::None,
+    };
+}
+```
+
+### 2. Serializer: IR 기반 속성 방출
+
+**파일**: `src/serializer/hwpx/picture.rs` - `write_picture` 함수
+
+- `numberingType`: 하드코딩 `"PICTURE"` → `numbering_type_str(pic.common.numbering_type)` (shape.rs의 기존 헬퍼 함수 사용)
+- `groupLevel`: 하드코딩 `"0"` → `pic.shape_attr.group_level.to_string()` (도형 rect/line 경로와 동일)
+- `numbering_type_str` 함수 import 추가
+
+## 영향
+
+- `groupLevel` 속성: 그룹(`<hp:container>`) 내 그림 개체의 중첩 레벨이 저장 시 보존된다.
+- `numberingType` 속성: 캡션 번호 범주 설정(NONE/PICTURE/TABLE/EQUATION)이 저장 시 보존된다.
+- roundtrip 충실도 향상: 이전에는 저장 후 재파싱 시 두 속성이 항상 기본값으로 되돌아갔다.
+- 신규 문서(Default::default)는 `common.numbering_type=ObjectNumberingType::None`이므로 `numberingType="NONE"`으로 방출되어, 종전 `"PICTURE"` 하드코딩과 차이가 있다. 이는 올바른 동작이다(도형 경로와 일관됨).

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2302,6 +2302,17 @@ fn parse_picture(
                 }
             }
             b"groupLevel" => shape_attr.group_level = attr_str(&attr).parse().unwrap_or(0),
+            // [#2697 동형] numberingType (캡션 번호 범주) 보존 — 도형·표·그림 공통 속성.
+            // 종전 미파싱으로 그림에 번호 범주를 NONE 등으로 변경한 HWPX에서 IR 기본값(None)으로
+            // 떨어져 왕복 시 "PICTURE"로 강제복원되던 결함을 수정한다.
+            b"numberingType" => {
+                common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
             _ => {}
         }
     }

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -565,6 +565,7 @@ mod tests {
             color: 0x000000FF,
             baseline: 120,
             unknown: 0,
+            eqedit: 0,
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -37,7 +37,7 @@ use crate::model::shape::{
 
 use super::context::SerializeContext;
 // [#2712] hp:sz 크기 기준 헬퍼는 도형 직렬화기와 공유한다(관례 이중화 방지).
-use super::shape::{height_criterion_str, size_criterion_str};
+use super::shape::{height_criterion_str, numbering_type_str, size_criterion_str};
 use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
@@ -61,6 +61,13 @@ pub fn write_picture<W: Write>(
     let tf = text_flow_str(pic.common.text_flow);
     let instid = pic.instance_id.to_string();
     let href = pic.href.as_deref().unwrap_or("");
+    // [#2697 동형] numberingType 은 IR(common.numbering_type)을 보존한다. 종전 "PICTURE"
+    // 하드코딩은 그림에 번호 범주를 변경한(예: NONE) 문서에서 저장 시 원본 속성이 유실됐다.
+    // 도형·표 계열은 이미 #1379/#2697 에서 IR 보존으로 정리됐다.
+    let numbering_type = numbering_type_str(pic.common.numbering_type);
+    // [#TODO-IR] groupLevel 은 IR(shape_attr.group_level)을 보존한다. 종전 "0" 하드코딩은
+    // 그룹 내 그림 개체의 중첩 레벨이 저장 시 유실됐다(shape.rs rect/line 경로는 이미 보존).
+    let group_level = pic.shape_attr.group_level.to_string();
 
     start_tag_attrs(
         w,
@@ -68,13 +75,13 @@ pub fn write_picture<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "PICTURE"),
+            ("numberingType", &numbering_type),
             ("textWrap", tw),
             ("textFlow", tf),
             ("lock", "0"),
             ("dropcapstyle", "None"),
             ("href", href),
-            ("groupLevel", "0"),
+            ("groupLevel", &group_level),
             ("instid", &instid),
             ("reverse", "0"),
         ],

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -984,7 +984,8 @@ fn write_sz<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Serial
     // 파일 samples/hwpx/143E433F503322BD33.hwpx 의 hp:rect·hp:ole 이 protect="1" 인데
     // 종전 방출은 이를 "0" 으로 되썼다. 이웃 write_pos 는 이미 모든 필드를 통과시키고,
     // 같은 hp:sz 를 다루는 form.rs:183-188 도 3속성 모두 보존한다. 표는 #2697/#2701 에서
-    // 같은 결함을 같은 방식으로 정리했다.
+    // 같은 결함을 같은 방식으로 정리했다. ellipse/arc/polygon/curve/chart 등 write_sz() 를
+    // 공유하는 모든 도형 경로에 동일하게 적용된다(#2745).
     empty_tag(
         w,
         "hp:sz",


### PR DESCRIPTION
이전 PR #2746이 devel 대비 CONFLICTING 상태로 메인테이너에 의해 일괄 close되어, upstream/devel 최신 커밋 기준으로 리베이스 후 재제출합니다. GitHub API가 close된 PR의 강제 푸시된 브랜치 재오픈을 거부하여("branch was force-pushed or recreated") 새 PR로 대체합니다.

리베이스 중 devel에 이미 반영된 관련 수정(#2712 hp:sz 크기 기준/보호, #2727 EQEDIT attr IR 보존, HWP5 캡션 emit_caption 헬퍼)과의 충돌을 해결하면서, 자동 병합 과정에서 발생한 중복 로직(Equation.eqedit 잔존 필드, Chart/Ole 캡션 이중 방출)도 함께 정리했습니다. 최종 diff는 devel 기준 #2745 원 변경 범위(src/parser/hwpx/section.rs numberingType 파싱, src/serializer/hwpx/picture.rs·shape.rs·mod.rs groupLevel/numberingType IR 보존)로 좁혀졌습니다.

관련: #2746