### PR TITLE
fix(hwpx): hp:equation 의 hp:script CDATA 본문 파싱 누락으로 인한 수식 스크립트 소실 해소

### DIFF
--- a/mydocs/report/task_m100_2916_report.md
+++ b/mydocs/report/task_m100_2916_report.md
@@ -1,0 +1,49 @@
+# 완료 보고서 — Task M100-2916
+
+- 이슈: #2916
+- 제목: hp:equation 의 hp:script 가 CDATA 로 인코딩된 경우 파서가 수식 스크립트를 소실함
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2916-equation-script-cdata-loss`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/section.rs`의 `parse_equation()`이 `<hp:equation>`의 `<hp:script>`
+자식 요소 텍스트를 수집할 때 `Event::Text`와 `Event::GeneralRef`(개체 참조)만
+처리하고 `Event::CData`(`<![CDATA[...]]>`)는 처리하지 않아, 수식 스크립트가 CDATA로
+저장된 HWPX 문서를 열면 `Equation.script`가 통째로 빈 문자열이 되는 문제를 수정했다.
+
+같은 파일의 `header.rs::read_numbering_para_head_text()`가 이미 `Event::Text`와
+`Event::CData`를 동시에 처리하는 패턴을 쓰고 있어, HWPX 문서에서 텍스트 콘텐츠가
+CDATA로 인코딩되는 것이 실제로 관측되는 케이스임을 뒷받침했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/section.rs`
+  - `parse_equation()`의 `<hp:script>` 파싱 루프에 `Event::CData(ref cdata)` 분기
+    추가 — `in_script`일 때 CDATA 본문을 `script`에 그대로 누적(UTF-8 lossy 디코드).
+  - 회귀 가드 단위 테스트
+    `parser::hwpx::section::tests::task_m100_2916_equation_script_cdata_not_lost`
+    추가: `<hp:script><![CDATA[a < b > c]]></hp:script>`를 `parse_equation()`에
+    직접 통과시켜 `eq.script == "a < b > c"`를 검증(수정 전에는 `""`로 실패).
+
+## 3. 검증 결과 (경량 검증 — 디스크 공간 제약으로 `cargo check --lib` 및 대상
+테스트만 실행, 전체 빌드/clippy/release-test는 생략)
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib task_m100_2916_equation_script_cdata_not_lost`
+  (수정 제거 시 `left: "" / right: "a < b > c"`로 실패 → red→green 확인)
+- `rustfmt --edition 2021 src/parser/hwpx/section.rs`
+
+## 4. 스코프 메모
+
+이번 라운드 작업 도메인은 `<hp:equation>`의 `<hp:script>` 자식 요소와 형제 속성
+(`version`/`baseUnit`/`baseLine`/`textColor`)으로 한정했다. `secPr`, 공용 도형
+(common-shape), `lock`/`numberingType`은 다른 진행 중인 작업과 충돌 방지를 위해
+건드리지 않았다.
+
+사전 중복 확인 결과, 열린 PR #2850(`task/m100-2840-equation-lock-roundtrip`)은
+수식 `lock` 속성만 다루고, PR #2899(`task/m100-2883-object-desc-eq-script-len-guard`)는
+`rhwp-studio`의 TypeScript 입력 길이 가드만 다뤄 `.rs` 파일을 건드리지 않는다 —
+둘 다 이번 변경과 겹치지 않는다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5397,6 +5397,14 @@ fn parse_equation(
                     }
                 }
             }
+            Ok(Event::CData(ref cdata)) => {
+                // #2916: 수식 스크립트가 CDATA 로 저장된 경우(비교 연산자 등 XML
+                // 예약 문자를 다량 포함해 엔티티 이스케이프 대신 CDATA 로 감싸는
+                // 케이스), 이 분기가 없으면 script 가 통째로 빈 문자열이 된다.
+                if in_script {
+                    script.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                }
+            }
             Ok(Event::GeneralRef(ref r)) => {
                 if in_script {
                     if let Ok(Some(ch)) = r.resolve_char_ref() {
@@ -7721,6 +7729,35 @@ mod tests {
         let xml = r#"<?xml version="1.0"?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"/>"#;
         let section = parse_hwpx_section(xml).unwrap();
         assert!(section.paragraphs.is_empty());
+    }
+
+    /// #2916: `<hp:equation>`의 `<hp:script>` 본문이 CDATA 섹션으로 인코딩된 경우
+    /// (실제 한글 저장 결과에서 관찰되는 형태 — 수식 스크립트에 `<`, `>` 등이
+    /// 다수 포함되어 개별 엔티티 이스케이프 대신 CDATA 로 감싸짐), 파서가
+    /// Event::CData 를 처리하지 않으면 script 가 빈 문자열로 소실된다.
+    #[test]
+    fn task_m100_2916_equation_script_cdata_not_lost() {
+        let xml = r##"<hp:equation xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+            id="1" version="Equation Version 60" baseLine="0" textColor="#000000" baseUnit="1000" font="HYhwpEQ"><hp:script><![CDATA[a < b > c]]></hp:script></hp:equation>"##;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let ctrl = loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"equation" => {
+                    break parse_equation(e, &mut reader).unwrap();
+                }
+                Event::Eof => panic!("equation not found"),
+                _ => {}
+            }
+            buf.clear();
+        };
+        let Control::Equation(eq) = ctrl else {
+            panic!("expected Equation control");
+        };
+        assert_eq!(
+            eq.script, "a < b > c",
+            "CDATA 로 감싸진 수식 스크립트가 소실되면 안 된다"
+        );
     }
 
     #[test]


### PR DESCRIPTION
원 PR #2927이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약

`<hp:equation>`의 `<hp:script>` 본문이 CDATA 섹션으로 인코딩된 경우
`parse_equation()`이 `Event::CData`를 처리하지 않아 수식 스크립트가 통째로
빈 문자열로 소실되던 문제를 수정했다.

close #2916

## 근거

`src/parser/hwpx/section.rs::parse_equation()`은 `<hp:script>` 텍스트를
`Event::Text`와 `Event::GeneralRef`(개체 참조)로만 수집하고 있었다. 같은 파일의
`header.rs::read_numbering_para_head_text()`는 문단 머리 번호 텍스트에 대해
`Event::Text`와 `Event::CData`를 모두 처리하고 있어, HWPX 문서에서 텍스트
콘텐츠가 CDATA로 인코딩되어 나타나는 것이 실제 관측 케이스임을 뒷받침한다.
수식 스크립트는 `<`/`>` 등 XML 예약 문자를 다량 포함하는 것이 일반적이라 CDATA로
저장되는 경우가 흔하다.

## 변경 사항

- `src/parser/hwpx/section.rs`
  - `parse_equation()`의 `<hp:script>` 파싱 루프에 `Event::CData` 분기 추가
  - 회귀 가드 테스트 `task_m100_2916_equation_script_cdata_not_lost` 추가

## red → green

수정 전: `<hp:script><![CDATA[a < b > c]]></hp:script>`를 파싱하면
`eq.script`가 `""`(빈 문자열)이 되어 테스트 실패
(`left: "" / right: "a < b > c"`).

수정 후: `eq.script == "a < b > c"`로 테스트 통과.

## 검증 (경량)

디스크 공간 제약으로 `cargo check --lib`과 대상 테스트만 실행했다(전체
빌드/clippy/release-test는 생략).

- `cargo check --lib` 통과
- `cargo test --lib task_m100_2916_equation_script_cdata_not_lost` 통과
- `rustfmt --edition 2021 src/parser/hwpx/section.rs` 적용