### PR TITLE
사진 속성 밝기/대비 값을 -100~100 범위로 clamp

### DIFF
--- a/mydocs/report/task_m100_2967_report.md
+++ b/mydocs/report/task_m100_2967_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2967
+
+- 이슈: #2967
+- 제목: 사진 속성 밝기/대비 값이 HTML 입력 범위(-100~100)를 벗어나도 clamp 없이 그대로 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2967-picture-brightness-contrast-clamp`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/picture-props-apply-model.ts`의 `appendImageEffects()`에서
+밝기(brightness)·대비(contrast) 값을 UI가 선언한 HTML 입력 범위(-100~100)와 동일하게
+clamp하도록 수정했다. 같은 함수 안의 투명도(transparency) 처리는 이미
+`Math.max(0, Math.min(100, ...))`로 clamp되어 있었는데, 밝기·대비만 `integerOr()` 파싱
+결과를 그대로 patch에 실었다. #2845/#2938/#2949/#2959에서 반복 확인된 "HTML min/max는
+있지만 확인 처리 로직에는 clamp가 없는" 패턴과 동일한 결함이다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageEffects()`에서 brightness/contrast를 `Math.max(-100, Math.min(100, ...))`로
+    clamp 후 patch에 반영
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `image brightness and contrast clamp to the -100..100 HTML input range` 픽스처 추가
+    (입력 `250`/`-999` → 결과 `100`/`-100` 검증)
+
+## 3. 검증 결과
+
+- `npx vitest run tests/picture-props-apply-model.test.ts`
+  - 신규 테스트 포함 전체 통과 (기존 파일의 vitest 러너 특성상 파일 레벨에서
+    "No test suite found" 경고가 함께 출력되나, 개별 테스트 케이스는 모두 통과로 표시됨 —
+    같은 파일의 기존 테스트들과 동일한 현상)
+
+## 4. 리스크
+
+- 변경 범위가 `appendImageEffects()` 내부 2개 필드로 국한되어 다른 patch 필드나
+  객체 타입(shape/line/ole)에는 영향이 없다.
+
+## 5. 결론
+
+Task M100-2967 구현과 테스트를 완료했다. PR 생성 후 이슈를 close할 수 있다.

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -452,8 +452,14 @@ function appendImageEffects(
     const effect = form.selectedEffect === 'Original' ? 'RealPic' : form.selectedEffect;
     addChanged(patch, 'effect', effect, props.effect ?? 'RealPic');
   }
-  if (form.brightness !== undefined) addChanged(patch, 'brightness', integerOr(form.brightness, 0), props.brightness ?? 0);
-  if (form.contrast !== undefined) addChanged(patch, 'contrast', integerOr(form.contrast, 0), props.contrast ?? 0);
+  if (form.brightness !== undefined) {
+    const brightness = Math.max(-100, Math.min(100, integerOr(form.brightness, 0)));
+    addChanged(patch, 'brightness', brightness, props.brightness ?? 0);
+  }
+  if (form.contrast !== undefined) {
+    const contrast = Math.max(-100, Math.min(100, integerOr(form.contrast, 0)));
+    addChanged(patch, 'contrast', contrast, props.contrast ?? 0);
+  }
   if (form.transparency !== undefined) {
     const transparency = Math.max(0, Math.min(100, integerOr(form.transparency, 0)));
     addChanged(patch, 'transparency', transparency, props.transparency ?? 0);

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -519,6 +519,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: {},
   },
+  {
+    name: 'image brightness and contrast clamp to the -100..100 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image = { brightness: '250', contrast: '-999' };
+    },
+    expected: { brightness: 100, contrast: -100 },
+  },
 ];
 
 for (const fixture of fixtures) {


### PR DESCRIPTION
원 PR #2975이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:
## 요약

- `appendImageEffects()`가 투명도(transparency)와 달리 밝기(brightness)·대비(contrast)
  값에는 clamp를 적용하지 않아 HTML 입력이 선언한 -100~100 범위(`numberInput(-100, 100, 1)`)를
  벗어난 값이 그대로 patch로 나갈 수 있었다. 동일한 clamp를 적용했다.
- 회귀 테스트 1건 추가: 입력 `250`/`-999` → clamp 결과 `100`/`-100` 검증.

closes #2967

## 변경 파일

- `rhwp-studio/src/ui/picture-props-apply-model.ts`
- `rhwp-studio/tests/picture-props-apply-model.test.ts`
- `mydocs/report/task_m100_2967_report.md`

## 검증

- `npx vitest run tests/picture-props-apply-model.test.ts` — 신규 테스트 포함 전체 통과
