### PR TITLE
fix(#2973): hh:borderFill@threeD 파싱 누락 및 직렬화 하드코딩 수정

### DIFF
--- a/mydocs/report/task_m100_2973_report.md
+++ b/mydocs/report/task_m100_2973_report.md
@@ -1,0 +1,84 @@
+# 완료 보고서 — Task M100-2973
+
+- 이슈: #2973
+- 제목: borderFill@threeD 속성이 파싱되지 않고 직렬화 시 항상 "0"으로 하드코딩됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2973-borderfill-threed`
+
+## 1. 배경 및 근본 원인
+
+HWPX 헤더의 `<hh:borderFill>` 요소는 `id`, `threeD`, `shadow`, `centerLine`,
+`breakCellSeparateLine` 속성을 갖는다. `src/parser/hwpx/header.rs::parse_border_fill`
+은 이 중 `centerLine` 만 읽고 나머지는 전부 버렸고(모델 `BorderFill` 구조체에 대응
+필드 자체가 없었음), `src/serializer/hwpx/header.rs`는 `threeD` 를 항상 문자열
+`"0"` 으로 고정 출력했다. 결과적으로 원본 HWPX 문서에 `threeD="1"` 이 설정돼 있어도
+파싱 단계에서 정보가 소실되고, 재저장 시 무조건 `"0"` 으로 찍혀 3차원 효과 설정이
+조용히 사라지는 라운드트립 데이터 손실이 있었다.
+
+이 저장소에는 동일 유형(HWPX 속성은 실존하지만 모델 필드가 없어 파싱이 버려지고
+직렬화기가 상수를 하드코딩)의 버그가 여러 차례 확인·수정된 이력이 있다
+(`write_diagonal` 함수의 회귀 가드 주석, `<hh:img>` bright/contrast/effect
+파싱 누락 이슈였던 [Issue #1156] 등). 이번 `threeD` 문제도 같은 패턴이다.
+
+pageBorderFill@type 슬롯 배정 이슈(#2896/#2906, BOTH/EVEN/ODD 슬롯 배정 문제)와는
+무관한, `borderFill` 개별 속성(threeD) 파싱 누락/하드코딩 문제다.
+
+## 2. 수정 내용
+
+- `src/model/style.rs`
+  - `BorderFill` 구조체에 `pub three_d: bool` 필드 추가.
+- `src/parser/hwpx/header.rs`
+  - `parse_border_fill` 의 속성 루프를 `match` 로 바꾸고 `threeD` 속성을
+    `parse_bool` 로 읽어 `bf.three_d` 에 반영.
+  - 단위 테스트 `test_border_fill_three_d_attr_parsed` 추가
+    (`threeD="1"` → `bf.three_d == true` 검증).
+- `src/serializer/hwpx/header.rs`
+  - 하드코딩된 `("threeD", "0")` 을 `("threeD", if bf.three_d { "1" } else { "0" })`
+    로 교체해 실제 모델 값을 직렬화.
+
+`BorderFill` 구조체에 필드를 추가한 파급으로, 기존에 모든 필드를 명시적으로 나열해
+구조체 리터럴을 만들던 호출부(`..Default::default()` 를 쓰지 않는 곳)에
+`three_d: false` 를 추가해 컴파일을 통과시켰다(`src/document_core/html_table_import.rs`,
+`src/document_core/commands/object_ops/table.rs`, `src/parser/doc_info.rs`(HWP5
+바이너리 파서 — HWP5 BorderFill 레코드에는 threeD 개념이 없어 `false` 고정),
+`src/serializer/doc_info/tests.rs`, `src/wasm_api/tests.rs`). `..Default::default()`
+를 쓰던 곳(`src/document_core/builders/exam_paper.rs`, `src/renderer/style_resolver.rs`)
+은 자동으로 `three_d: false` 가 적용되어 수정이 필요 없었다.
+
+## 3. Red → Green
+
+- Red: `threeD` 속성을 파서가 읽지 않던 시점 기준으로, `bf.three_d` 필드가 없어
+  테스트 자체가 컴파일되지 않거나(필드 추가 전) 필드를 추가해도 파서 match 암을
+  넣기 전에는 `bf.three_d` 가 항상 `Default` 값인 `false` 로 남아
+  `assert!(bf.three_d)` 가 실패했다.
+- Green: `parse_border_fill` 에 `b"threeD" => bf.three_d = parse_bool(&attr)` 암을
+  추가한 뒤 통과.
+
+```
+test parser::hwpx::header::tests::test_border_fill_three_d_attr_parsed ... ok
+```
+
+## 4. 스코프 밖 (후속 이슈 제안)
+
+`shadow`, `breakCellSeparateLine` 속성도 동일 패턴(파싱 안 됨 + 직렬화 시 상수
+하드코딩)이지만, 이번 수정은 diff를 최소화하기 위해 `threeD` 단일 속성으로
+스코프를 좁혔다. 나머지는 별도 이슈로 분리하는 것을 제안한다.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib test_border_fill_three_d_attr_parsed`
+- `rustfmt --edition 2021` (변경 파일 전체)
+
+## 6. 변경 파일
+
+- `src/model/style.rs`
+- `src/parser/hwpx/header.rs`
+- `src/serializer/hwpx/header.rs`
+- `src/document_core/html_table_import.rs`
+- `src/document_core/commands/object_ops/table.rs`
+- `src/parser/doc_info.rs`
+- `src/serializer/doc_info/tests.rs`
+- `src/wasm_api/tests.rs`

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -446,6 +446,7 @@ impl DocumentCore {
                     },
                     center_line: CenterLine::None,
                     fill: Fill::default(),
+                    three_d: false,
                 };
                 self.document.doc_info.border_fills.push(new_bf);
                 self.document.doc_info.raw_stream = None;
@@ -882,6 +883,7 @@ impl DocumentCore {
                     },
                     center_line: CenterLine::None,
                     fill: Fill::default(),
+                    three_d: false,
                 };
                 self.document.doc_info.border_fills.push(new_bf);
                 self.document.doc_info.raw_stream = None;

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -756,6 +756,7 @@ impl DocumentCore {
             diagonal: DiagonalLine::default(),
             center_line: CenterLine::None,
             fill,
+            three_d: false,
         };
 
         // 기존 BorderFill에서 동일한 항목 검색
@@ -816,6 +817,7 @@ impl DocumentCore {
                 diagonal: DiagonalLine::default(),
                 center_line: CenterLine::None,
                 fill: Fill::default(),
+                three_d: false,
             });
         bf.raw_data = None;
 

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -461,6 +461,8 @@ pub struct BorderFill {
     pub center_line: CenterLine,
     /// 채우기 정보
     pub fill: Fill,
+    /// 3차원 효과 (HWPX borderFill@threeD)
+    pub three_d: bool,
 }
 
 /// 중심선 방향 (HWPX borderFill@centerLine)

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -367,6 +367,7 @@ fn parse_border_fill(data: &[u8]) -> Result<BorderFill, DocInfoError> {
         diagonal,
         center_line: CenterLine::from_hwp_attr(attr),
         fill,
+        three_d: false,
     })
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1344,13 +1344,17 @@ fn parse_border_fill(
 ) -> Result<(), HwpxError> {
     let mut bf = BorderFill::default();
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"centerLine" {
-            bf.center_line = parse_center_line(&attr);
-            if bf.center_line == CenterLine::None {
-                bf.attr &= !(1 << 13);
-            } else {
-                bf.attr |= 1 << 13;
+        match attr.key.as_ref() {
+            b"centerLine" => {
+                bf.center_line = parse_center_line(&attr);
+                if bf.center_line == CenterLine::None {
+                    bf.attr &= !(1 << 13);
+                } else {
+                    bf.attr |= 1 << 13;
+                }
             }
+            b"threeD" => bf.three_d = parse_bool(&attr),
+            _ => {}
         }
     }
 
@@ -2811,6 +2815,13 @@ mod tests {
             .into_iter()
             .next()
             .expect("borderFill 파싱 실패")
+    }
+
+    #[test]
+    fn test_border_fill_three_d_attr_parsed() {
+        // threeD="1" 은 파서가 읽어 모델에 보존해야 한다(직렬화 시 하드코딩 "0" 방지).
+        let bf = parse_single_border_fill(r#"<hh:borderFill id="9" threeD="1"></hh:borderFill>"#);
+        assert!(bf.three_d, "threeD=\"1\" 이 bf.three_d 로 파싱되어야 함");
     }
 
     #[test]

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -382,6 +382,7 @@ fn test_serialize_border_fill_solid() {
             image: None,
             alpha: 0,
         },
+        three_d: false,
     };
 
     let data = serialize_border_fill(&bf);
@@ -422,6 +423,7 @@ fn test_serialize_border_fill_preserves_solid_and_image_alpha() {
             image: None,
             alpha: 180,
         },
+        three_d: false,
     };
     let data = serialize_border_fill(&bf);
     let mut r = crate::parser::byte_reader::ByteReader::new(&data[FILL_OFFSET..]);
@@ -457,6 +459,7 @@ fn test_serialize_border_fill_cross_centerline_uses_hwp5_center_bits() {
         diagonal: DiagonalLine::default(),
         center_line: CenterLine::Cross,
         fill: Fill::default(),
+        three_d: false,
     };
 
     let data = serialize_border_fill(&bf);
@@ -510,6 +513,7 @@ fn test_serialize_border_fill_image_fill_mode_uses_hwp5_values() {
                 }),
                 alpha: 0,
             },
+            three_d: false,
         };
 
         let data = serialize_border_fill(&bf);

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -346,7 +346,7 @@ fn write_border_fill<W: Write>(
         "hh:borderFill",
         &[
             ("id", &(id + 1).to_string()), // HWPX 관찰: id는 1-based
-            ("threeD", "0"),
+            ("threeD", if bf.three_d { "1" } else { "0" }),
             ("shadow", "0"),
             ("centerLine", center_line_type(bf)),
             ("breakCellSeparateLine", "0"),

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -14609,6 +14609,7 @@ fn test_save_table_1x1() {
         },
         center_line: CenterLine::None,
         fill: Fill::default(),
+        three_d: false,
     };
     doc.document.doc_info.border_fills.push(new_bf);
     let table_bf_id = doc.document.doc_info.border_fills.len() as u16; // 1-based ID
@@ -16552,6 +16553,7 @@ fn test_save_pic_in_table() {
         },
         center_line: CenterLine::None,
         fill: Fill::default(),
+        three_d: false,
     };
     doc.document.doc_info.border_fills.push(new_bf);
     let table_bf_id = doc.document.doc_info.border_fills.len() as u16;


### PR DESCRIPTION
원 PR #2982이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:
## 요약

이슈: #2973

`<hh:borderFill>` 의 `threeD` 속성이 파서에서 전혀 읽히지 않고, 직렬화기는
항상 `threeD="0"` 으로 하드코딩되어 있어 원본 문서의 3차원 효과 설정이
라운드트립 시 소실되는 문제를 수정합니다.

## 변경 내용

- `src/model/style.rs`: `BorderFill.three_d: bool` 필드 추가
- `src/parser/hwpx/header.rs`: `threeD` 속성 파싱(`parse_bool`) + 단위 테스트 추가
- `src/serializer/hwpx/header.rs`: 하드코딩된 `"0"` 대신 `bf.three_d` 직렬화
- 나머지 파일: 신규 필드 추가로 인한 구조체 리터럴 보정(`three_d: false`)

## Red → Green

Red: `parse_border_fill` 이 `threeD` 속성을 읽지 않던 상태에서는
`bf.three_d` 가 항상 `Default` 값 `false` 로 남아 아래 테스트가 실패.

Green: `b"threeD" => bf.three_d = parse_bool(&attr)` 암 추가 후 통과.

```
test parser::hwpx::header::tests::test_border_fill_three_d_attr_parsed ... ok
```

## 검증

- `cargo check --lib` 통과
- `cargo test --lib test_border_fill_three_d_attr_parsed` 통과
- `rustfmt --edition 2021` 적용

## 스코프 밖

`shadow`, `breakCellSeparateLine` 도 동일 패턴이지만 diff 최소화를 위해
`threeD` 단일 속성으로 스코프를 좁혔습니다. 후속 이슈로 분리를 제안합니다.

