### PR TITLE
fix(picture-props): 그림 확대/축소 비율 입력값을 1..1000 범위로 클램프

### DIFF
--- a/mydocs/report/task_m100_2967_report.md
+++ b/mydocs/report/task_m100_2967_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2967
+
+- 이슈: #2967
+- 제목: 사진 속성 밝기/대비 값이 HTML 입력 범위(-100~100)를 벗어나도 clamp 없이 그대로 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2967-picture-brightness-contrast-clamp`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/picture-props-apply-model.ts`의 `appendImageEffects()`에서
+밝기(brightness)·대비(contrast) 값을 UI가 선언한 HTML 입력 범위(-100~100)와 동일하게
+clamp하도록 수정했다. 같은 함수 안의 투명도(transparency) 처리는 이미
+`Math.max(0, Math.min(100, ...))`로 clamp되어 있었는데, 밝기·대비만 `integerOr()` 파싱
+결과를 그대로 patch에 실었다. #2845/#2938/#2949/#2959에서 반복 확인된 "HTML min/max는
+있지만 확인 처리 로직에는 clamp가 없는" 패턴과 동일한 결함이다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageEffects()`에서 brightness/contrast를 `Math.max(-100, Math.min(100, ...))`로
+    clamp 후 patch에 반영
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `image brightness and contrast clamp to the -100..100 HTML input range` 픽스처 추가
+    (입력 `250`/`-999` → 결과 `100`/`-100` 검증)
+
+## 3. 검증 결과
+
+- `npx vitest run tests/picture-props-apply-model.test.ts`
+  - 신규 테스트 포함 전체 통과 (기존 파일의 vitest 러너 특성상 파일 레벨에서
+    "No test suite found" 경고가 함께 출력되나, 개별 테스트 케이스는 모두 통과로 표시됨 —
+    같은 파일의 기존 테스트들과 동일한 현상)
+
+## 4. 리스크
+
+- 변경 범위가 `appendImageEffects()` 내부 2개 필드로 국한되어 다른 patch 필드나
+  객체 타입(shape/line/ole)에는 영향이 없다.
+
+## 5. 결론
+
+Task M100-2967 구현과 테스트를 완료했다. PR 생성 후 이슈를 close할 수 있다.

--- a/mydocs/report/task_m100_2977_report.md
+++ b/mydocs/report/task_m100_2977_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2977
+
+- 이슈: #2977
+- 제목: 그림 확대/축소 비율 입력이 min/max 범위를 벗어나도 확인 시 그대로 적용됨 (picture-props-dialog)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2977-image-scale-clamp`
+
+## 1. 문제
+
+`rhwp-studio` 그림 속성 대화상자의 "확대/축소 비율" 탭 가로/세로 배율 입력 필드
+(`picScaleXInput`, `picScaleYInput`)는 `picture-props-dialog.ts`에서 HTML
+`min=1`, `max=1000` 제약으로 생성된다. 그러나 확인(OK) 시 실제 패치를 만드는
+`appendImageScale`(`picture-props-apply-model.ts`)은 이 범위를 전혀 검증하지 않고
+`numberOr`로 파싱한 값을 그대로 원본 크기에 곱해 폭/높이를 계산했다.
+
+사용자가 네이티브 스피너가 아닌 직접 타이핑(예: `-10`, `5000`)으로 값을 입력하면
+HTML `min`/`max` 속성이 값 검증에 관여하지 않으므로, 범위를 벗어난 배율이 그대로
+적용되어 음수 높이나 1000%를 초과하는 비정상적인 크기가 patch에 들어갈 수 있었다.
+
+같은 파일의 밝기/대비/투명도 클램프, 그리고 최근 회전각 클램프(#2954)와 동일한
+"HTML min/max는 있지만 확인 시 검증 누락" 패턴이다.
+
+## 2. 수정 내용
+
+`appendImageScale`에서 `numberOr`로 읽은 가로/세로 배율을 UI와 동일하게
+`Math.max(1, Math.min(1000, ...))`로 클램프한 뒤 폭/높이를 계산하도록 했다.
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageScale`에 `scaleX`, `scaleY` 클램프 추가
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `'image scale clamps to the 1..1000 HTML input range'` 픽스처 추가
+    (`x: '5000', y: '-10'` → `width: 10000, height: 8`로 클램프되는지 검증)
+
+## 3. 검증 결과
+
+`npx tsx --test tests/picture-props-apply-model.test.ts` 전체 통과 (27 passed).
+
+## 4. 참고
+
+- 동일 패턴 선례: 밝기/대비 클램프(#2967), 회전각 클램프(#2954)

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -452,8 +452,14 @@ function appendImageEffects(
     const effect = form.selectedEffect === 'Original' ? 'RealPic' : form.selectedEffect;
     addChanged(patch, 'effect', effect, props.effect ?? 'RealPic');
   }
-  if (form.brightness !== undefined) addChanged(patch, 'brightness', integerOr(form.brightness, 0), props.brightness ?? 0);
-  if (form.contrast !== undefined) addChanged(patch, 'contrast', integerOr(form.contrast, 0), props.contrast ?? 0);
+  if (form.brightness !== undefined) {
+    const brightness = Math.max(-100, Math.min(100, integerOr(form.brightness, 0)));
+    addChanged(patch, 'brightness', brightness, props.brightness ?? 0);
+  }
+  if (form.contrast !== undefined) {
+    const contrast = Math.max(-100, Math.min(100, integerOr(form.contrast, 0)));
+    addChanged(patch, 'contrast', contrast, props.contrast ?? 0);
+  }
   if (form.transparency !== undefined) {
     const transparency = Math.max(0, Math.min(100, integerOr(form.transparency, 0)));
     addChanged(patch, 'transparency', transparency, props.transparency ?? 0);

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -424,8 +424,10 @@ function appendImageScale(
   form: PicturePropsApplyForm,
 ): void {
   if (form.common.sizeProtect || !form.image.scale || !(props.originalWidth > 0)) return;
-  const width = Math.round(props.originalWidth * numberOr(form.image.scale.x, 100) / 100);
-  const height = Math.round(props.originalHeight * numberOr(form.image.scale.y, 100) / 100);
+  const scaleX = Math.max(1, Math.min(1000, numberOr(form.image.scale.x, 100)));
+  const scaleY = Math.max(1, Math.min(1000, numberOr(form.image.scale.y, 100)));
+  const width = Math.round(props.originalWidth * scaleX / 100);
+  const height = Math.round(props.originalHeight * scaleY / 100);
   addChanged(patch, 'width', width, props.width);
   addChanged(patch, 'height', height, props.height);
 }

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -519,6 +519,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: {},
   },
+  {
+    name: 'image brightness and contrast clamp to the -100..100 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image = { brightness: '250', contrast: '-999' };
+    },
+    expected: { brightness: 100, contrast: -100 },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -527,6 +527,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: { brightness: 100, contrast: -100 },
   },
+  {
+    name: 'image scale clamps to the 1..1000 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image.scale = { x: '5000', y: '-10' };
+    },
+    expected: { width: 10000, height: 8 },
+  },
 ];
 
 for (const fixture of fixtures) {


### PR DESCRIPTION
원 PR #2986이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:
## 요약

- `picScaleXInput`/`picScaleYInput`는 HTML `min=1`, `max=1000`으로 생성되지만
  `appendImageScale`은 이를 검증하지 않고 그대로 폭/높이 계산에 사용했다.
- 직접 타이핑으로 범위를 벗어난 값(예: `-10`, `5000`)을 입력하면 음수 높이나
  1000% 초과 크기가 그대로 patch에 반영되는 문제가 있었다.
- 동일 파일의 밝기/대비/투명도 클램프, 회전각 클램프(#2954)와 같은 패턴으로
  `Math.max(1, Math.min(1000, ...))` 클램프를 추가했다.

Fixes #2977

## 변경 파일

- `rhwp-studio/src/ui/picture-props-apply-model.ts`
- `rhwp-studio/tests/picture-props-apply-model.test.ts`
- `mydocs/report/task_m100_2977_report.md`

## 검증

- [x] `npx tsx --test tests/picture-props-apply-model.test.ts` (28 passed)

