### PR TITLE
fix(hwpx): 쪽번호(pageNum) 원문자(CIRCLED_DIGIT) formatType 오탈자 수정 (#3005)

### DIFF
--- a/mydocs/report/task_m100_3005_report.md
+++ b/mydocs/report/task_m100_3005_report.md
@@ -1,0 +1,62 @@
+# task_m100_3005 처리 결과 보고
+
+## 이슈
+
+[#3005 HWPX 쪽번호(pageNum) 원문자(CIRCLED_DIGIT) formatType이 CIRCLE_DIGIT 오탈자로
+파싱·직렬화되어 소실](https://github.com/edwardkim/rhwp/issues/3005)
+
+## 배경
+
+같은 클래스의 오탈자 버그가 이슈 #2957(PR #2964, 처리 시점 기준 아직 미병합)에서
+`<hp:autoNumFormat type="...">`에 대해 이미 지적됐다. 그런데 #2957의 이슈 본문은
+"`<hp:pageNum formatType="...">`는 별개 요소·속성이므로 그쪽의 `CIRCLE_DIGIT` 표기는
+그대로 유지해야 한다"고 명시적으로 결론지었다. 이번 작업은 그 결론을 스키마와 직접
+대조해 검증하는 것이 목표였다.
+
+`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml` 193~194행에서 `<hp:pageNum>`의
+`formatType` 속성은 `type="hc:NumberType1"`로 선언돼 있다. `mydocs/manual/OWPML SCHEMA/Core
+XML schema.xml`을 보면 `NumberType1`(5~83행)과 `NumberType2`(84행~)가 각각 정의돼
+있는데, 두 enum 모두 원문자 값을 `CIRCLED_DIGIT`(12행·91행)로 동일하게 표기한다.
+즉 `pageNum`이 `autoNumFormat`과 별개 속성이라는 #2957의 전제는 맞지만, 값 자체는
+동일한 스펙 표기(`CIRCLED_DIGIT`)를 따라야 한다는 점에서 "그대로 유지" 판단은
+스키마 미대조 상태의 오판이었다 — `page_num_format_to_str()`/`parse_page_num_attrs()`가
+쓰던 `CIRCLE_DIGIT` 자체가 별도의 동일 클래스 오탈자였다.
+
+## 근본 원인
+
+- `src/serializer/hwpx/section.rs`의 `page_num_format_to_str()`에서
+  `1 => "CIRCLE_DIGIT"`로 방출.
+- `src/parser/hwpx/section.rs`의 `parse_page_num_attrs()`에서 `formatType` 매치에
+  `"CIRCLE_DIGIT" => 1`만 있고 스펙 문자열 `"CIRCLED_DIGIT"`는 인식하지 못해
+  `_ => 0`(DIGIT)으로 떨어짐.
+
+## 변경 내용
+
+- `src/serializer/hwpx/section.rs`: `page_num_format_to_str()`의 `1 => "CIRCLE_DIGIT"`를
+  `1 => "CIRCLED_DIGIT"`로 수정(스펙 철자).
+- `src/parser/hwpx/section.rs`: `parse_page_num_attrs()`의 `formatType` 매치에
+  `"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1`로 두 표기 모두 인식하도록 추가(과거 오탈자로
+  저장된 한컴 실물 파일과의 하위 호환 유지).
+- `src/serializer/hwpx/section.rs`: 단위 테스트
+  `page_num_circled_digit_format_reflects_spec_spelling` 추가 — `PageNumberPos.format = 1`
+  (원문자)일 때 `render_page_num()`이 `formatType="CIRCLED_DIGIT"`를 방출하고
+  `formatType="CIRCLE_DIGIT"`는 방출하지 않음을 검증.
+
+## 검증 (red → green)
+
+수정 전 `page_num_format_to_str()`를 `"CIRCLE_DIGIT"`로 되돌린 상태에서
+`cargo test --lib page_num_circled_digit_format_reflects_spec_spelling`을 실행하면
+`formatType="CIRCLE_DIGIT"` 출력에 대해 `CIRCLED_DIGIT` 단언이 실패함을 확인(red).
+수정을 되돌린 뒤(green) 동일 테스트가 통과함을 재확인했다.
+
+```
+test serializer::hwpx::section::tests::page_num_circled_digit_format_reflects_spec_spelling ... ok
+```
+
+`cargo check --lib`도 통과했다.
+
+## 범위 밖
+
+이슈 #2957/PR #2964가 다루는 `<hp:autoNumFormat type="...">`(인라인 자동번호) 경로는
+이번 작업에서 건드리지 않았다. `<hp:pageNum formatType="...">`만 별도 이슈(#3005)로
+분리해 수정했다.

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4362,7 +4362,9 @@ fn parse_page_num_attrs(e: &quick_xml::events::BytesStart) -> PageNumberPos {
             b"formatType" => {
                 pn.format = match attr_str(&attr).as_str() {
                     "DIGIT" => 0,
-                    "CIRCLE_DIGIT" => 1,
+                    // [#XXXX] 스펙 표기는 "CIRCLED_DIGIT"(NumberType1). 과거 오탈자
+                    // "CIRCLE_DIGIT"로 저장된 한컴 실물 파일과의 호환을 위해 둘 다 인식한다.
+                    "CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
                     "ROMAN_CAPITAL" => 2,
                     "ROMAN_SMALL" => 3,
                     "LATIN_CAPITAL" => 4,

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1740,7 +1740,9 @@ fn page_num_pos_to_str(pos: u8) -> &'static str {
 fn page_num_format_to_str(fmt: u8) -> &'static str {
     match fmt {
         0 => "DIGIT",
-        1 => "CIRCLE_DIGIT",
+        // [#XXXX] OWPML Core 스키마 NumberType1(<hp:pageNum formatType>)의 실제 값은
+        // "CIRCLED_DIGIT"이다 (Core XML schema.xml 12행). "CIRCLE_DIGIT"은 오탈자.
+        1 => "CIRCLED_DIGIT",
         2 => "ROMAN_CAPITAL",
         3 => "ROMAN_SMALL",
         4 => "LATIN_CAPITAL",
@@ -2484,6 +2486,25 @@ fn render_page_border_fill(ty: &str, pbf: &crate::model::page::PageBorderFill) -
 mod tests {
     use super::*;
     use crate::model::paragraph::{CharShapeRef, Paragraph};
+
+    /// [#XXXX] `<hp:pageNum formatType="...">`의 원문자(circled digit) 값은 OWPML Core
+    /// 스키마 NumberType1 표기인 "CIRCLED_DIGIT"이어야 한다. 종전엔 "CIRCLE_DIGIT"(D 없음)
+    /// 오탈자로 방출돼 한컴이 값을 인식하지 못했다.
+    #[test]
+    fn page_num_circled_digit_format_reflects_spec_spelling() {
+        use crate::model::control::PageNumberPos;
+        let mut pn = PageNumberPos::default();
+        pn.format = 1; // circled digit
+        let xml = render_page_num(&pn);
+        assert!(
+            xml.contains(r#"formatType="CIRCLED_DIGIT""#),
+            "pageNum formatType 이 스펙 철자(CIRCLED_DIGIT)여야 함: {xml}"
+        );
+        assert!(
+            !xml.contains(r#"formatType="CIRCLE_DIGIT""#),
+            "CIRCLE_DIGIT 오탈자 잔존 금지: {xml}"
+        );
+    }
 
     #[test]
     fn equation_text_flow_reflects_ir() {


### PR DESCRIPTION
원 PR #3007이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:
## 요약

이슈 #3005: `<hp:pageNum formatType="...">`의 원문자(circled digit) 값이 OWPML 스펙
(NumberType1) 표기인 `CIRCLED_DIGIT` 대신 `CIRCLE_DIGIT`(D 없음) 오탈자로 파싱·직렬화되어
한컴 왕복 시 서식이 소실되던 문제를 수정합니다.

- `mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml` 193~194행: `<hp:pageNum>`의
  `formatType` 속성은 `hc:NumberType1`을 참조.
- `mydocs/manual/OWPML SCHEMA/Core XML schema.xml` 5~16행: `NumberType1`의 원문자 값은
  `<xs:enumeration value="CIRCLED_DIGIT">`.

이슈 #2957(PR #2964)이 같은 클래스의 오탈자를 `<hp:autoNumFormat>` 쪽에서 다루며
"`<hp:pageNum>` 쪽 `CIRCLE_DIGIT` 표기는 그대로 유지해야 한다"고 판단했는데, 이는
스키마 미대조 상태의 가정이었습니다. 실제로는 `pageNum`도 `CIRCLED_DIGIT`을 써야 합니다.

## 변경

- `src/serializer/hwpx/section.rs`: `page_num_format_to_str()`의 `1 => "CIRCLE_DIGIT"`를
  `1 => "CIRCLED_DIGIT"`로 수정.
- `src/parser/hwpx/section.rs`: `parse_page_num_attrs()`의 `formatType` 매치를
  `"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1`로 확장(과거 오탈자로 저장된 한컴 실물 파일과의
  하위 호환 유지).
- `src/serializer/hwpx/section.rs`: 단위 테스트
  `page_num_circled_digit_format_reflects_spec_spelling` 추가.

## 검증 (red → green)

수정 전(`page_num_format_to_str()`가 `"CIRCLE_DIGIT"`를 방출하던 상태)에
`cargo test --lib page_num_circled_digit_format_reflects_spec_spelling`을 실행하면 실패:

```
thread '...page_num_circled_digit_format_reflects_spec_spelling' panicked at src\serializer\hwpx\section.rs:2499:9:
pageNum formatType 이 스펙 철자(CIRCLED_DIGIT)여야 함: <hp:ctrl><hp:pageNum pos="NONE" formatType="CIRCLE_DIGIT" sideChar="-"/></hp:ctrl>
```

수정 후 동일 테스트 통과:

```
test serializer::hwpx::section::tests::page_num_circled_digit_format_reflects_spec_spelling ... ok
```

`cargo check --lib`도 통과했습니다.

## 범위

이슈 #2957/PR #2964가 다루는 `<hp:autoNumFormat type="...">`(인라인 자동번호) 경로는
이번 PR에서 건드리지 않았습니다. `<hp:pageNum formatType="...">`만 별도로 수정했습니다.

