### PR TITLE
fix(hwpx): 수식 lock(개체 잠금) 속성 파싱 누락 해소 (#2840)

### DIFF
--- a/mydocs/report/task_m100_2840_report.md
+++ b/mydocs/report/task_m100_2840_report.md
@@ -1,0 +1,43 @@
+# Task m100-2840: 수식 lock(개체 잠금) 속성 왕복 유실 해소
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2840
+
+## 근본 원인
+
+`src/parser/hwpx/section.rs`의 `parse_object_element_attrs`(모든 그리기 개체 공통 속성
+파서)는 `id`, `zOrder`, `textWrap`, `textFlow`, `instid`, `groupLevel`, `ratio`,
+`numberingType`, `isReverseHV`만 처리하고 `lock` 속성은 매치 대상이 없어 `_ => {}`로
+버려졌다. `CommonObjAttr`(`src/model/shape.rs`)에도 잠금 상태를 담을 필드가 없어,
+`src/serializer/hwpx/section.rs`의 `render_equation`은 항상 `lock="0"`을 문자열
+리터럴로 방출했다. 결과적으로 원본 HWPX 문서의 수식 개체가 `lock="1"`(개체 보호)이어도
+rhwp를 거쳐 재저장하면 항상 잠금 해제 상태로 바뀐다.
+
+## 변경 사항
+
+- `src/model/shape.rs`: `CommonObjAttr`에 `locked: bool` 필드 추가.
+- `src/parser/hwpx/section.rs`: `parse_object_element_attrs`에서 `b"lock"` 속성을
+  읽어 `common.locked`에 반영.
+- `src/serializer/hwpx/section.rs`: `render_equation`의 하드코딩 `lock="0"`을
+  `common.locked` 기반 방출로 교체.
+- `src/document_core/converters/common_obj_attr_writer.rs`: 신규 필드 추가에 따른
+  테스트 헬퍼 `make_sample()` 초기화 보정(`locked: false`).
+
+다른 개체 타입(그림·표·도형)도 동일한 `("lock", "0")` 하드코딩 패턴을 공유하지만, 이번
+작업은 충돌 회피를 위해 실제 사용처가 있는 `<hp:equation>` 경로로 범위를 한정했다.
+나머지 경로는 잔여로 남긴다.
+
+## 검증
+
+- `cargo build --lib`: 성공.
+- `cargo test --lib equation_lock_reflects_ir`: red(수정 전 컴파일 불가/구현 전
+  `lock="0"` 고정) → green(수정 후 `lock="1"` 방출 확인) 전환.
+- `cargo test --lib equation`: 166개 전부 통과(기존 수식 관련 테스트 회귀 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음.
+- `rustfmt --edition 2021`: 변경 파일 대상 실행, 포맷 diff 없음(CRLF 경고만 발생,
+  실질 변경 없음).
+
+## 완료 기준
+
+수식 `lock` 속성이 IR을 거쳐 왕복 시 보존됨을 최소 단위 테스트로 확인.

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -227,6 +227,7 @@ mod tests {
             height_criterion: SizeCriterion::Absolute,
             description: String::new(),
             raw_extra: Vec::new(),
+            locked: false,
             numbering_type: crate::model::shape::ObjectNumberingType::None,
         }
     }

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -92,6 +92,11 @@ pub struct CommonObjAttr {
     pub numbering_type: ObjectNumberingType,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
+    /// HWPX `lock`(개체 잠금) 속성 보존 (#2840).
+    ///
+    /// 파서가 이 속성을 읽지 않아 `<hp:equation>` 직렬화 시 항상 `lock="0"`으로
+    /// 하드코딩되던 문제 해소. 우선 수식(`render_equation`) 경로에만 배선한다.
+    pub locked: bool,
 }
 
 /// HWPX 개체 `numberingType` (캡션 번호 범주)

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2900,6 +2900,9 @@ fn parse_object_element_attrs(
             // 선/연결선의 방향 뒤집기(isReverseHV). serializer 는 방출하나 파서가
             // 되읽지 않아 HWPX 원본 선의 방향 반전이 왕복 시 유실됐다.
             b"isReverseHV" => ids.is_reverse_hv = attr_str(&attr) == "1",
+            // [#2840] 개체 잠금(lock) — 종전 미파싱으로 <hp:equation> 직렬화 시
+            // 항상 "0"으로 되돌아가 원본의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2185,8 +2185,11 @@ fn render_equation(eq: &Equation) -> String {
         "CHAR"
     };
 
+    // [#2840] 개체 잠금(lock) — 종전 하드코딩 "0" 제거, IR(common.locked) 값을 방출.
+    let lock = if c.locked { "1" } else { "0" };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="{lock}" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),
@@ -2530,6 +2533,21 @@ mod tests {
         assert!(
             !line_xml.contains(r#"lineMode="CHAR""#),
             "CHAR 하드코딩 잔존 금지"
+        );
+    }
+
+    /// [Issue #2840] 수식의 lock(개체 잠금)이 IR(common.locked)에서 방출돼야 한다.
+    /// 종전엔 파서가 lock 속성을 읽지 않아 하드코딩 "0"으로 왕복마다 잠금이 풀렸다.
+    #[test]
+    fn equation_lock_reflects_ir() {
+        use crate::model::control::Equation;
+
+        let mut eq = Equation::default();
+        eq.common.locked = true;
+        let xml = render_equation(&eq);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "locked=true 면 lock=\"1\" 을 방출해야 함(하드코딩 \"0\" 잔존 금지): {xml}"
         );
     }
 


### PR DESCRIPTION
원 PR #2850이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

closes #2840

원본 설명:

Closes #2840

## 요약

HWPX `<hp:equation>`의 `lock`(개체 잠금) 속성이 파서에서 전혀 읽히지 않고, 직렬화 시
`render_equation`이 항상 `lock="0"`을 하드코딩하고 있었습니다. 원본 문서에서 수식이
`lock="1"`(한컴 UI의 개체 보호)로 저장돼 있어도 rhwp를 거쳐 재저장하면 항상 잠금이
풀립니다.

## 근거

- `src/parser/hwpx/section.rs`의 `parse_object_element_attrs`(모든 그리기 개체 공통
  속성 파서)는 `id`/`zOrder`/`textWrap`/`textFlow`/`instid`/`groupLevel`/`ratio`/
  `numberingType`/`isReverseHV`는 처리하지만 `lock`은 매치 대상이 없어 `_ => {}`로
  버려집니다.
- `CommonObjAttr`(`src/model/shape.rs`)에도 잠금 상태를 담을 필드가 없어
  `render_equation`은 원본 값을 참조할 수단이 없이 `lock="0"`을 문자열로 방출합니다.

## Red → Green

- Red: `equation_lock_reflects_ir` 테스트 작성 시점엔 `common.locked` 필드 자체가
  없어 컴파일 불가(및 수정 전 로직 기준으로는 `lock="0"` 고정).
- Green: `CommonObjAttr.locked` 필드 추가 + 파서 `b"lock"` 처리 + `render_equation`의
  `lock="{lock}"` 배선 후, `locked=true` 인 IR을 직렬화하면 `lock="1"`이 방출됨을
  확인.

다른 개체 타입(그림·표·도형)도 동일한 `("lock", "0")` 하드코딩을 공유하지만, 동시
편집 충돌을 피하기 위해 이번 PR은 실사용 경로인 `<hp:equation>`로 범위를 한정했습니다.

## 검증

- `cargo build --lib`
- `cargo test --lib equation` (166 passed)
- `cargo clippy --all-targets --profile release-test -- -D warnings` (경고 없음)
- `rustfmt --edition 2021` (변경 파일 대상, diff 없음)

## 참고

이 fork(`kevin9327/rhwp`)의 `devel`이 `origin/devel`보다 다수 커밋 뒤처져 있어(OAuth
`workflow` scope 제약으로 fork 동기화 푸시가 막힘), 실제 검증은 `origin/devel` 기반
로컬 브랜치에서 수행했습니다. PR 헤드 브랜치는 fork `devel`(공통 조상 커밋)에
해당 커밋 1개만 cherry-pick하여 푸시했으며, `git diff origin/devel...HEAD`로 순
diff가 의도한 범위(파서/직렬화/모델/테스트헬퍼/보고서 문서)로 한정됨을 확인했습니다.