### PR TITLE
HWPX hh:style lockForm round-trip 복원

### DIFF
--- a/mydocs/report/task_m100_2839_report.md
+++ b/mydocs/report/task_m100_2839_report.md
@@ -1,0 +1,69 @@
+# 완료 보고서 — Task M100-2839
+
+- 이슈: #2839
+- 제목: HWPX `<hh:style>` `lockForm` 속성이 시리얼라이저에서 항상 "0"으로 하드코딩되어 원본 값이 유실됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2839-hwpx-style-lockform-roundtrip`
+
+## 1. 문제
+
+`<hh:style>` 의 `lockForm` 속성(HWPX spec 표 47, 양식 필드 잠금 여부)이:
+
+- `src/parser/hwpx/header.rs::parse_style` 에서 아예 읽히지 않았고,
+- `src/model/style.rs::Style` IR 구조체에 이를 담을 필드가 없었으며,
+- `src/serializer/hwpx/header.rs::write_style` 에서 값과 무관하게 항상
+  문자열 리터럴 `"0"` 이 방출되고 있었다.
+
+결과적으로 원본 HWPX 문서에서 `lockForm="1"` 로 저장된 스타일을 rhwp로 파싱 후
+재시리얼라이즈(round-trip)하면 예외 없이 `lockForm="0"` 으로 바뀌어, 양식 잠금
+의미가 조용히 유실되는 문서 무결성 손상이 발생했다.
+
+## 2. 근거
+
+`git log -S "lockForm" -- src/` 로 추적한 결과, 이 하드코딩은 커밋 `6c3983b5`
+("Task #182 Stage 1: header.xml IR 기반 동적 생성")에서 `hh:style` 요소를 동적
+생성하기 시작한 시점부터 존재했고, 이후 어떤 커밋에서도 실제 값을 반영하도록
+수정된 적이 없었다. 같은 함수의 `langID` 는 유사한 하드코딩 버그였다가 최근
+"Task #1058 후속" 으로 수정되었지만 `lockForm` 은 남아 있었다. 오늘 이미 수정된
+charPr/paraPr 관련 이슈(#2695, #2777)와도 무관한 별개 속성이다.
+
+## 3. 수정 내용
+
+- `src/model/style.rs`: `Style` 구조체에 `pub lock_form: bool` 필드 추가.
+- `src/parser/hwpx/header.rs::parse_style`: `b"lockForm" => style.lock_form =
+  attr_str(&attr) == "1"` 매칭 추가.
+- `src/serializer/hwpx/header.rs::write_style`: `("lockForm", "0")` 하드코딩을
+  `("lockForm", bool01(st.lock_form))` 로 교체해 IR 값을 그대로 방출.
+- 아래 파일들은 `Style` 구조체 리터럴에 신규 필드를 명시적으로 채워 컴파일을
+  통과시켰다 (HWP3 바이너리 파서와 wasm API의 신규 스타일 생성 경로는 `lockForm`
+  개념이 없어 `false` 기본값으로 채움):
+  - `src/parser/doc_info.rs` (HWP3 바이너리 STYLE 레코드 파싱)
+  - `src/wasm_api.rs` (wasm 스타일 신규 생성 API)
+  - `src/serializer/doc_info/tests.rs` (기존 단위 테스트 2건)
+
+## 4. 테스트 (TDD)
+
+`src/serializer/hwpx/header.rs::tests::write_style_emits_ir_lock_form` 추가:
+`Style { lock_form: true, .. }` 을 시리얼라이즈했을 때 `lockForm="1"` 이 방출되는지
+확인하는 단발 assertion.
+
+- Red: 수정 전 실행 시 다음과 같이 실패함을 확인.
+  ```
+  thread '...write_style_emits_ir_lock_form' panicked at src\serializer\hwpx\header.rs:1368:9:
+  Style.lock_form 이 방출돼야 함: <hh:style ... lockForm="0"/>
+  ```
+- Green: 수정 후 `cargo test --lib write_style_emits_ir_lock_form` → `ok. 1 passed`.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib write_style_emits_ir_lock_form` (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings` (경고 0건;
+  최초 `bool01(...).to_string()` 에서 `unnecessary_to_owned` 지적을 받아
+  `bool01(st.lock_form)` 로 수정 후 통과)
+- `rustfmt --edition 2021` — 변경된 6개 파일에만 적용
+  (`src/model/style.rs`, `src/parser/hwpx/header.rs`,
+  `src/serializer/hwpx/header.rs`, `src/parser/doc_info.rs`,
+  `src/serializer/doc_info/tests.rs`, `src/wasm_api.rs`)

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -444,6 +444,10 @@ pub struct Style {
     pub para_shape_id: u16,
     /// 글자 모양 ID 참조
     pub char_shape_id: u16,
+    /// [Task #2839] 양식(폼) 필드 잠금 여부 (HWPX `lockForm`).
+    /// 파서가 값을 읽지 않고 시리얼라이저가 "0" 을 하드코딩해 원본이 항상
+    /// 잠금 해제 상태로 바뀌던 결함 수정.
+    pub lock_form: bool,
 }
 
 /// 테두리/배경 (HWPTAG_BORDER_FILL)

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -902,6 +902,7 @@ fn parse_style(data: &[u8]) -> Result<Style, DocInfoError> {
         lang_id,
         para_shape_id,
         char_shape_id,
+        lock_form: false,
     })
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1329,6 +1329,10 @@ fn parse_style(e: &quick_xml::events::BytesStart, doc_info: &mut DocInfo) {
                     }
                 }
             }
+            // [Task #2839] HWPX `lockForm` → Style.lock_form.
+            // 종전엔 이 속성을 아예 읽지 않아 시리얼라이저가 항상 "0" 을
+            // 하드코딩했고, 원본 lockForm="1"(양식 잠금) 이 왕복마다 유실됐다.
+            b"lockForm" => style.lock_form = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -305,6 +305,7 @@ fn test_serialize_style_roundtrip() {
         lang_id: 1042,
         para_shape_id: 1,
         char_shape_id: 2,
+        lock_form: false,
     };
 
     let data = serialize_style(&style);
@@ -641,6 +642,7 @@ fn test_serialize_doc_info_roundtrip() {
         lang_id: 1042,
         para_shape_id: 0,
         char_shape_id: 0,
+        lock_form: false,
     });
 
     // 직렬화 → 역직렬화

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -1293,7 +1293,7 @@ fn write_style<W: Write>(w: &mut Writer<W>, id: u16, st: &Style) -> Result<(), S
             // 파서가 Style.lang_id 로 읽는 값을 그대로 되돌린다. 종전 "1042"
             // 하드코딩은 비한국어 langID(예: 1033)를 왕복마다 1042 로 바꿨다.
             ("langID", &st.lang_id.to_string()),
-            ("lockForm", "0"),
+            ("lockForm", bool01(st.lock_form)),
         ],
     )
 }
@@ -1351,6 +1351,23 @@ mod tests {
         assert!(
             xml.contains(r#"langID="1033""#),
             "Style.lang_id 가 방출돼야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn write_style_emits_ir_lock_form() {
+        // [Task #2839] 파서가 읽은 Style.lock_form 이 그대로 방출돼야 한다.
+        // 종전엔 "0" 하드코딩으로 lockForm="1" 스타일이 왕복마다 잠금 해제로 뭉개졌다.
+        let st = Style {
+            lock_form: true,
+            ..Default::default()
+        };
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_style(&mut w, 0, &st).expect("write_style");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(
+            xml.contains(r#"lockForm="1""#),
+            "Style.lock_form 이 방출돼야 함: {xml}"
         );
     }
 

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -5897,6 +5897,7 @@ impl HwpDocument {
             lang_id: 1042, // 한국어 default (HWP5 spec 표 47)
             para_shape_id,
             char_shape_id,
+            lock_form: false,
         };
         self.core.document.doc_info.styles.push(new_style);
         self.core.document.doc_info.raw_stream_dirty = true;


### PR DESCRIPTION
원 PR #2852이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

closes #2839

원본 설명:

## 요약

- `<hh:style>` 의 `lockForm` 속성이 파서에는 대응 IR 필드가 없고 시리얼라이저에서는
  항상 `"0"` 으로 하드코딩되어, 원본에서 `lockForm="1"`(양식 잠금) 이던 스타일이
  round-trip 저장 시마다 잠금 해제 상태로 조용히 바뀌는 결함을 수정합니다.
- `Style` IR(`src/model/style.rs`)에 `lock_form: bool` 필드를 추가하고, 파서
  (`src/parser/hwpx/header.rs`)에서 `lockForm` 속성을 읽어 채우며, 시리얼라이저
  (`src/serializer/hwpx/header.rs`)에서 하드코딩 대신 이 값을 그대로 방출하도록
  수정했습니다.
- 신규 필드 추가에 따라 `Style` 구조체 리터럴을 사용하는 다른 경로
  (`src/parser/doc_info.rs` 의 HWP3 바이너리 STYLE 파서, `src/wasm_api.rs` 의 wasm
  스타일 생성 API, `src/serializer/doc_info/tests.rs` 의 기존 테스트 2건)도 함께
  갱신했습니다. 이 경로들은 `lockForm` 개념이 없어 `false` 기본값으로 채웠습니다.

관련 이슈: closes #2839

## Red → Green 근거

`src/serializer/hwpx/header.rs::tests::write_style_emits_ir_lock_form` 를 먼저 추가해
결함을 증명했습니다.

- Red (수정 전): `Style { lock_form: true, .. }` 을 시리얼라이즈하면 `lockForm="0"` 이
  방출되어 아래와 같이 실패했습니다.
  ```
  thread '...write_style_emits_ir_lock_form' panicked at src\serializer\hwpx\header.rs:1368:9:
  Style.lock_form 이 방출돼야 함: <hh:style ... lockForm="0"/>
  ```
- Green (수정 후): `cargo test --lib write_style_emits_ir_lock_form` → `test result: ok. 1 passed`.

## 검증

- `cargo build --lib` — 통과
- `cargo test --lib write_style_emits` — `write_style_emits_ir_lang_id`,
  `write_style_emits_ir_lock_form` 2건 모두 통과
- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 0건
- `rustfmt --edition 2021` — 변경된 파일에만 적용 (`src/model/style.rs`,
  `src/parser/hwpx/header.rs`, `src/serializer/hwpx/header.rs`,
  `src/parser/doc_info.rs`, `src/serializer/doc_info/tests.rs`, `src/wasm_api.rs`)

## 참고

- 개발 편의를 위해 `origin/devel` 기준 커밋을 fork `devel` 위로 cherry-pick 하는
  과정에서 `src/serializer/hwpx/header.rs` 의 최근 `langID` 하드코딩 수정
  (`write_style_emits_ir_lang_id` 테스트 포함)과 충돌이 있어 두 수정을 함께
  병합했습니다. 이 PR에는 `langID` 관련 로직 변경은 없으며, 병합 편의상 함께
  포함된 것입니다.

리포트: `mydocs/report/task_m100_2839_report.md`
