### PR TITLE
hatchStyle 직렬화 catch-all이 CROSS_DIAGONAL로 잘못 확정되는 문제 수정

### DIFF
--- a/mydocs/report/task_m100_3039_hatch_style_report.md
+++ b/mydocs/report/task_m100_3039_hatch_style_report.md
@@ -1,0 +1,47 @@
+# task-m100-1: hatchStyle 직렬화 catch-all 수정
+
+## 문제
+
+`src/serializer/hwpx/shape.rs`의 `hatch_style_str`은 `parse_hatch_style`
+(파서, `src/parser/hwpx/utils.rs`)의 역매핑이다. 파서 쪽은 `HORIZONTAL`~
+`CROSS_DIAGONAL` 6개 값을 전부 명시적으로 나열하는데, 직렬화 쪽은 마지막
+값(6, `CROSS_DIAGONAL`)만 `_` catch-all에 얹혀 있었다.
+
+```rust
+fn hatch_style_str(pattern_type: i32) -> &'static str {
+    match pattern_type {
+        1 => "HORIZONTAL",
+        2 => "VERTICAL",
+        3 => "BACK_SLASH",
+        4 => "SLASH",
+        5 => "CROSS",
+        _ => "CROSS_DIAGONAL",
+    }
+}
+```
+
+`pattern_type`은 HWP5 binary(`doc_info.rs`)와 HWP3(`drawing.rs`)에서
+원시 정수로 읽혀 IR에 들어오므로, 계약(1~6) 밖의 값(손상 파일, 0, 7 이상)이
+들어와도 이 함수는 조용히 `CROSS_DIAGONAL`을 방출한다. 즉 계약 밖 값을
+정당한 무늬로 둔갑시켜 라운드트립 시 원본과 다른 무늬가 저장될 수 있다.
+같은 파일의 `lineShape` style 매핑(줄 674~676 주석)에서 이미 한 번 겪은
+"catch-all이 유효한 값처럼 보이는" 패턴(#1531)과 동일한 종류다.
+
+## 수정
+
+6을 명시적으로 나열하고, catch-all은 6개 계약 값 중 가장 무난한
+`HORIZONTAL`로 바꿨다(무늬 정보가 없다는 신호를 유지하되 임의의 특정
+무늬로 확정 짓지 않기 위함).
+
+## 테스트
+
+`task_m100_hatch_style_str_covers_all_six` — 1~6 및 계약 밖 값(99)의
+매핑을 검증.
+
+## 검증
+
+이 PC의 Rust 툴체인이 `dbghelp.lib` 손상(`CVT1107`/`LNK1123`)으로 모든
+빌드 스크립트 링크에 실패하는 상태라 `cargo check --lib` 실행이 불가능했다.
+무관한 crate(`proc-macro2`, `paste`, `serde_core` 등)의 빌드 스크립트도
+동일하게 실패하므로 이 변경과 무관한 환경 문제로 판단한다. 변경 자체는
+`match` 분기 추가 및 단위 테스트 추가뿐이라 문법·타입 위험이 낮다.

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -895,7 +895,10 @@ fn hatch_style_str(pattern_type: i32) -> &'static str {
         3 => "BACK_SLASH",
         4 => "SLASH",
         5 => "CROSS",
-        _ => "CROSS_DIAGONAL",
+        6 => "CROSS_DIAGONAL",
+        // 계약(1~6) 밖의 값은 무늬 정보가 없다는 뜻이므로 임의의 무늬로
+        // 둔갑시키지 않고 가장 무난한 HORIZONTAL 로 방출한다.
+        _ => "HORIZONTAL",
     }
 }
 
@@ -1733,5 +1736,19 @@ mod tests {
         assert!(xml.contains(r#"widthRelTo="ABSOLUTE""#), "{xml}");
         assert!(xml.contains(r#"heightRelTo="ABSOLUTE""#), "{xml}");
         assert!(xml.contains(r#"protect="0""#), "{xml}");
+    }
+
+    #[test]
+    fn task_m100_hatch_style_str_covers_all_six() {
+        // 계약(1~6) 값 6개를 모두 명시적으로 매핑하는지 확인한다.
+        // 이전에는 6이 catch-all(_) 분기에 얹혀 있어, 계약 밖의 값(예: 손상된
+        // 원본의 pattern_type=99)도 CROSS_DIAGONAL 로 둔갑했다.
+        assert_eq!(hatch_style_str(1), "HORIZONTAL");
+        assert_eq!(hatch_style_str(2), "VERTICAL");
+        assert_eq!(hatch_style_str(3), "BACK_SLASH");
+        assert_eq!(hatch_style_str(4), "SLASH");
+        assert_eq!(hatch_style_str(5), "CROSS");
+        assert_eq!(hatch_style_str(6), "CROSS_DIAGONAL");
+        assert_eq!(hatch_style_str(99), "HORIZONTAL");
     }
 }


### PR DESCRIPTION
원 PR #3044이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다. (리베이스 중 report 파일명 충돌은 mydocs/report/task_m100_3039_hatch_style_report.md 로 분리해 해결했습니다.)

원본 설명:

## 요약

- `hatch_style_str`(hatchStyle 직렬화 역매핑)이 값 6(CROSS_DIAGONAL)만
  catch-all(`_`)에 의존해, 계약(1~6) 밖의 손상/미지 값도 CROSS_DIAGONAL로
  둔갑시키던 문제를 수정했습니다.
- 6을 명시적으로 나열하고, catch-all은 계약 밖 값을 위해 HORIZONTAL로
  바꿨습니다. 파서 쪽 `parse_hatch_style`(6개 값 전부 명시)과 대칭입니다.

Closes #3039

## 테스트

- `task_m100_hatch_style_str_covers_all_six` 단위 테스트 추가 (1~6, 계약
  밖 값 99 검증)

## 참고

이 환경에서 Rust 툴체인이 `dbghelp.lib` 손상으로 링크 자체가 불가능해
`cargo check --lib`를 실행하지 못했습니다(무관한 crate 빌드 스크립트도
동일 오류). 변경은 `match` 분기 추가와 테스트뿐이라 위험이 낮습니다.
자세한 내용은 `mydocs/report/task_m100_3039_hatch_style_report.md` 참고.