### PR TITLE
fix(document_core): HWPX→HWP 그림 캡션 attr 비트 + BinData remap 잔여 수정

### DIFF
--- a/mydocs/report/task_m100_2767_report.md
+++ b/mydocs/report/task_m100_2767_report.md
@@ -1,0 +1,103 @@
+# #2767 처리 결과 — HWPX→HWP 그림 캡션 attr 비트 + BinData remap 잔여 수정
+
+## 사전 확인 — devel 은 이미 일부를 포함하고 있었다
+
+작업 시작 시 `origin/devel`을 다시 fetch해 확인한 결과, 이슈 본문이 결함 B로
+지목한 것 중 **`Control::Picture`의 캡션 remap과 `Control::Table`의 캡션 remap은
+이미 devel에 존재**했다(주석에 `[#2736]` 태그, `table_caption_picture_bin_ref_is_remapped`·
+`picture_caption_picture_bin_ref_is_remapped` 테스트도 이미 있음). 이슈가 미리
+고지한 병행 PR #2749(같은 파일)는 `gh pr view 2749`로 **CLOSED, mergedAt: null**
+(미머지)임을 확인했으므로, 이 부분은 #2749가 아닌 다른 경로로 이미 devel에
+반영된 것으로 보인다.
+
+실제로 남아 있던 것만 수정 범위로 좁혔다:
+
+- **결함 A** (전부 미해결) — 그림 CTRL_HEADER의 캡션 attr 비트(bit 29)
+- **결함 B 잔여** — `remap_bin_refs_in_control`의 `Control::HiddenComment` arm 부재,
+  `remap_bin_refs_in_shape`의 `ShapeObject::Picture`(그룹 내부 그림) 캡션 미재귀
+  (`ShapeObject::Picture`는 `drawing_mut()`이 항상 `None`이라 공통 caption remap
+  경로를 타지 않음 — 모델상 `DrawingObjAttr`를 갖지 않고 `Picture` 자신의
+  `caption` 필드를 직접 가짐)
+
+## 수정
+
+`src/document_core/converters/hwpx_to_hwp.rs` 한 파일:
+
+1. **결함 A**: `materialize_picture_caption_common_attr()` 신설 — 그림에 캡션이
+   있고 bit29가 아직 꺼져 있으면 **OR**(recompute 아님)한다. 표처럼
+   `pack_common_attr_bits(...)`로 재계산하면 표 전용 비트를 그림에 강제로 얹는
+   회귀가 되므로, HWPX 파서가 이미 채운 `common.attr`에 비트만 얹는다.
+   `adapt_paragraph_with_context`의 `Control::Picture` arm에서 캡션 문단 보강
+   직후 호출. `AdapterReport`에 `picture_caption_common_attr_materialized`
+   카운터 추가 + `changed_anything()` 합산.
+2. **결함 B 잔여**: `remap_bin_refs_in_control`에 `Control::HiddenComment` arm
+   추가(adapt 워크·border-fill 워크는 이미 #2467 근거로 처리 중이던 것과 동형).
+   `remap_bin_refs_in_shape`의 `ShapeObject::Picture` arm에 `pic.caption` 재귀
+   추가(그룹 내부 그림 캡션).
+
+이슈 §A-6에 따라 도형(`$rec`)·OLE·연결선 캡션의 attr 비트는 설정하지 않았다 —
+`serializer/control.rs`가 도형 캡션 레코드 자체를 아직 출력하지 않아 자기모순
+레코드가 되기 때문(별도 후속 과제).
+
+## 테스트 (red → green)
+
+기존 `mod tests`에 4건 추가:
+
+- `picture_caption_common_attr_bit_is_or_ed_in_when_caption_present` — 캡션이 있는
+  그림의 `common.attr`가 `0x042A_2211` → `0x242A_2211`로 OR됨을 단언 + 멱등성 확인
+- `picture_caption_common_attr_bit_untouched_without_caption` — 캡션이 없으면
+  비트를 건드리지 않음(거짓양성 방지)
+- `hidden_comment_picture_bin_ref_is_remapped` — 숨은설명 안 그림의 `bin_data_id`가
+  remap을 반영함
+- `grouped_picture_caption_bin_ref_is_remapped` — 그룹 내부 그림(`ShapeObject::Picture`)
+  캡션 안 그림의 `bin_data_id`가 remap을 반영함
+
+수정 전 코드(4곳의 fix 부분만 되돌린 상태)로 실행한 결과:
+
+```
+failures:
+    document_core::converters::hwpx_to_hwp::tests::grouped_picture_caption_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::hidden_comment_picture_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::picture_caption_common_attr_bit_is_or_ed_in_when_caption_present
+
+test result: FAILED. 42 passed; 3 failed; 0 ignored; 0 measured; 2481 filtered out
+```
+
+(`picture_caption_common_attr_bit_untouched_without_caption`는 대조군이라 수정과
+무관하게 항상 통과 — 의도된 결과.)
+
+수정 적용 후 재실행:
+
+```
+running 45 tests
+...
+test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 2481 filtered out; finished in 2.84s
+```
+
+red → green을 로컬에서 직접 확인했다.
+
+## 검증 (디스크 제약으로 경량 검증만 수행)
+
+- `cargo check --lib` 통과
+- 신설 테스트 4건 포함 `document_core::converters::hwpx_to_hwp::tests` 모듈 전체
+  (45건) `cargo test --lib`로 실행, 전부 통과(red 확인 1회 + green 확인 2회)
+- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
+  로컬 디스크 여유 공간 제약(빌드 중 완전 소진 1회 발생 — `target/debug/incremental`
+  삭제로 복구)으로 스킵
+- `rustfmt --edition 2021` 적용, `git diff --name-only`로 의도한 파일만 변경됨을
+  확인
+- 이슈 §A-5/§B-3이 제안한 실파일 회귀(`samples/hwp3-sample14-hwp5.hwpx` gso attr
+  비교, "OLE storage 재정렬 + 숨은설명/그림캡션" 동시 보유 실파일)는 재확인하지
+  않았다 — 이슈 §B-3이 그런 조합 문서가 샘플에 없다고 명시하고 있어, 단위 테스트가
+  현재 유일하게 재현 가능한 방법이다.
+
+## 범위 밖
+
+- 도형(`$rec`)·OLE·연결선 캡션의 attr 비트 설정(§A-6) — `serializer/control.rs`
+  소관의 별개 상위 결함
+- collect 측(`collect_bin_order_from_control`)의 HiddenComment 미방문(§B-2) —
+  fallback으로 이미 전단사가 보장되어 결함이 아님(이슈 본문 판정)
+
+## 변경 파일
+
+- `src/document_core/converters/hwpx_to_hwp.rs`

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -103,6 +103,11 @@ pub struct AdapterReport {
     pub master_page_autonum_placeholder_removed: u32,
     /// HWPX 바탕쪽 line shape rendering matrix를 HWP5 size ratio contract로 보정한 횟수
     pub master_page_line_rendering_size_ratio_materialized: u32,
+    /// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29,
+    /// 0x2000_0000) 보강 횟수. 표는 이미 `materialize_table_ctrl_header_attr` 로
+    /// 보강되지만 그림은 빠져 있었다(전 코퍼스 실측 80/80 이 개체 종류와 무관하게
+    /// 이 비트를 요구).
+    pub picture_caption_common_attr_materialized: u32,
 }
 
 impl AdapterReport {
@@ -150,7 +155,8 @@ impl AdapterReport {
                 + self.autonum_fwspace_char_shape_offsets_materialized
                 + self.header_footer_fwspace_control_materialized
                 + self.master_page_autonum_placeholder_removed
-                + self.master_page_line_rendering_size_ratio_materialized)
+                + self.master_page_line_rendering_size_ratio_materialized
+                + self.picture_caption_common_attr_materialized)
                 > 0
     }
 }
@@ -500,6 +506,12 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
             remap_bin_refs_in_paragraphs(&mut footnote.paragraphs, remap)
         }
         Control::Endnote(endnote) => remap_bin_refs_in_paragraphs(&mut endnote.paragraphs, remap),
+        // [#2767] adapt 워크·border-fill 워크는 이미 HiddenComment 를 방문한다
+        // (#2467 근거). remap 워크만 빠져 있어 숨은설명 안 그림이 재정렬 후
+        // 엉뚱한 이미지를 가리키는 채로 남았다.
+        Control::HiddenComment(comment) => {
+            remap_bin_refs_in_paragraphs(&mut comment.paragraphs, remap)
+        }
         _ => {}
     }
 }
@@ -508,6 +520,12 @@ fn remap_bin_refs_in_shape(shape: &mut ShapeObject, remap: &[u16]) {
     match shape {
         ShapeObject::Picture(pic) => {
             pic.image_attr.bin_data_id = remap_bin_ref(pic.image_attr.bin_data_id, remap);
+            // [#2767] 그룹 내부 그림(ShapeObject::Picture)은 drawing_mut()이 항상
+            // None 이라(모델상 DrawingObjAttr 를 갖지 않음) 아래 공통 캡션 remap
+            // 경로를 타지 않는다. Picture 자신의 caption 필드를 직접 재귀해야 한다.
+            if let Some(caption) = &mut pic.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         ShapeObject::Ole(ole) => {
             if let Ok(id) = u16::try_from(ole.bin_data_id) {
@@ -924,6 +942,7 @@ fn adapt_paragraph_with_context(
                 if let Some(caption) = &mut pic.caption {
                     adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
                 }
+                materialize_picture_caption_common_attr(pic, report);
             }
             Control::Shape(shape) => adapt_shape_with_context(shape, report, context),
             Control::Equation(eq) => adapt_equation(eq, report),
@@ -1674,6 +1693,27 @@ fn materialize_table_ctrl_header_attr(table: &mut Table, report: &mut AdapterRep
 
     if table.common.attr != before {
         report.table_ctrl_header_attr_materialized += 1;
+    }
+}
+
+/// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29) 보강.
+///
+/// 전 코퍼스 실측(`samples/**/*.hwp`, 한컴 저작 원본): 캡션 동반 gso 80개(그림 42,
+/// 사각형 33, 연결선 3, OLE 2) 전부 bit 29=1, 캡션 없는 gso 2,674개 전부 bit 29=0.
+/// 개체 종류와 무관하게 캡션 유무만으로 결정된다. HWPX 출처 그림의
+/// `common.attr` 는 파서(`pack_hwpx_common_obj_attr`)가 이미 non-zero로 채우고
+/// 직렬화기가 verbatim 기록하므로, 표처럼 `pack_common_attr_bits(...)`로
+/// **recompute** 하지 않고 비트만 **OR** 한다 — recompute 하면 표 전용 비트를
+/// 그림에 강제로 얹는 회귀가 된다. 멱등: 비트가 이미 켜져 있으면 카운트하지 않음.
+///
+/// 도형(`$rec`/`$con`)·OLE 캡션은 범위 밖이다 — 직렬화기(`serializer/control.rs`)가
+/// 도형 캡션 레코드 자체를 아직 출력하지 않아, 레코드 없이 비트만 켜면 자기모순
+/// 레코드가 된다(별도 후속 과제).
+fn materialize_picture_caption_common_attr(pic: &mut Picture, report: &mut AdapterReport) {
+    const HWP5_GSO_CAPTION_COMMON_ATTR_BIT: u32 = 0x2000_0000;
+    if pic.caption.is_some() && pic.common.attr & HWP5_GSO_CAPTION_COMMON_ATTR_BIT == 0 {
+        pic.common.attr |= HWP5_GSO_CAPTION_COMMON_ATTR_BIT;
+        report.picture_caption_common_attr_materialized += 1;
     }
 }
 
@@ -3270,6 +3310,142 @@ mod tests {
         assert_eq!(
             pic.image_attr.bin_data_id, 2,
             "표 캡션 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
+    }
+
+    // ---------- #2767 결함 A — 그림 캡션 gso CTRL_HEADER 캡션 비트 ----------
+
+    #[test]
+    fn picture_caption_common_attr_bit_is_or_ed_in_when_caption_present() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                // 실측(이슈 §A-2)에서 확인한 파서 값 — 캡션 비트 이전에 이미 non-zero.
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: Some(crate::model::shape::Caption::default()),
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x242A_2211,
+            "캡션이 있으면 bit 29 가 OR 되어야 함(recompute 아님)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 1);
+
+        // 멱등: 다시 적용해도 카운트가 늘지 않아야 함.
+        let mut second = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut second);
+        assert_eq!(second.picture_caption_common_attr_materialized, 0);
+    }
+
+    #[test]
+    fn picture_caption_common_attr_bit_untouched_without_caption() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: None,
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x042A_2211,
+            "캡션이 없으면 bit 29 를 켜면 안 됨(거짓양성 방지)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 0);
+    }
+
+    // ---------- #2767 결함 B(잔여) — HiddenComment · 그룹 내부 그림 캡션 remap ----------
+
+    #[test]
+    fn hidden_comment_picture_bin_ref_is_remapped() {
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut inner_para = Paragraph::default();
+        inner_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let comment = crate::model::control::HiddenComment {
+            paragraphs: vec![inner_para],
+        };
+        let mut ctrl = Control::HiddenComment(Box::new(comment));
+
+        // remap[1] = 2 : bin_data_id 1 을 2 로 재배치.
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::HiddenComment(comment) = &ctrl else {
+            panic!("HiddenComment control expected");
+        };
+        let Control::Picture(pic) = &comment.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside HiddenComment");
+        };
+        assert_eq!(
+            pic.image_attr.bin_data_id, 2,
+            "숨은설명 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
+        );
+    }
+
+    #[test]
+    fn grouped_picture_caption_bin_ref_is_remapped() {
+        // ShapeObject::Picture(그룹 내부 그림)는 drawing_mut()이 None 이라 공통
+        // caption remap 경로를 타지 않는다 — Picture 자신의 caption 을 직접 재귀해야 함.
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut caption_para = Paragraph::default();
+        caption_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let grouped_pic = Picture {
+            caption: Some(crate::model::shape::Caption {
+                paragraphs: vec![caption_para],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut shape = ShapeObject::Picture(Box::new(grouped_pic));
+
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_shape(&mut shape, &remap);
+
+        let ShapeObject::Picture(pic) = &shape else {
+            panic!("Picture shape expected");
+        };
+        let caption = pic.caption.as_ref().expect("caption preserved");
+        let Control::Picture(inner) = &caption.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside caption");
+        };
+        assert_eq!(
+            inner.image_attr.bin_data_id, 2,
+            "그룹 내부 그림 캡션 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
         );
     }
 }


### PR DESCRIPTION
원 PR #2971이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약

- #2767 결함 A — 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션
  비트(bit 29, `0x2000_0000`)가 설정되지 않던 문제.
- #2767 결함 B 잔여 — BinData 재정렬 시 숨은설명 안 그림, 그룹 내부 그림
  (`ShapeObject::Picture`) 캡션 안 그림의 `bin_data_id`가 remap되지 않던 문제.
  (`Control::Picture`/`Control::Table`의 캡션 remap은 이미 #2736으로 devel에
  반영되어 있음을 작업 시작 시 확인 — 이 PR은 그 나머지만 다룹니다.)

## 변경

`src/document_core/converters/hwpx_to_hwp.rs`:

1. `materialize_picture_caption_common_attr()` 신설 — 캡션이 있는 그림의
   `common.attr`에 bit29를 **OR**(recompute 아님)한다.
   `adapt_paragraph_with_context`의 `Control::Picture` arm에서 호출.
   `AdapterReport`에 `picture_caption_common_attr_materialized` 카운터 추가.
2. `remap_bin_refs_in_control`에 `Control::HiddenComment` arm 추가.
3. `remap_bin_refs_in_shape`의 `ShapeObject::Picture` arm에 `pic.caption` 재귀
   추가(`drawing_mut()`이 항상 `None`이라 공통 caption remap 경로를 타지 않음).

도형(`$rec`)·OLE·연결선 캡션의 attr 비트는 범위 밖(직렬화기가 캡션 레코드
자체를 아직 출력하지 않음, 별도 후속).

## Red → Green

```
# 수정 전(4곳 되돌린 상태)
failures:
    grouped_picture_caption_bin_ref_is_remapped
    hidden_comment_picture_bin_ref_is_remapped
    picture_caption_common_attr_bit_is_or_ed_in_when_caption_present
test result: FAILED. 42 passed; 3 failed

# 수정 후
test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 2481 filtered out
```

## 검증

- `cargo check --lib` 통과
- `document_core::converters::hwpx_to_hwp::tests` 모듈 전체(45건, 신설 4건 포함)
  `cargo test --lib`로 통과
- `rustfmt --edition 2021` 적용 확인

Fixes #2767 (결함 A + 결함 B 잔여)