### PR TITLE
fix: HTML 임포트 시 text-decoration-line: underline(공백) 변형 밑줄 인식 누락 수정

### DIFF
--- a/mydocs/report/task_m100_3034_report.md
+++ b/mydocs/report/task_m100_3034_report.md
@@ -1,0 +1,19 @@
+# Task m100-3034: HTML import text-decoration-line 공백 변형 누락 수정
+
+## 이슈
+#3034 — `src/document_core/commands/html_import.rs`의 CSS→CharShape 매핑에서
+밑줄 인식 로직이 `text-decoration-line:underline`(공백 없음)만 검사하고
+`text-decoration-line: underline`(콜론 뒤 공백) 변형은 검사하지 않음.
+
+같은 함수 내 `font-weight`, `text-decoration` 검사는 공백 유무 두 변형을 모두
+처리하는데 `text-decoration-line`만 공백 있는 변형이 빠져 있었음.
+
+## 수정
+`has_underline` 조건에 `text-decoration-line: underline`(공백 포함) 변형 추가.
+
+- `src/document_core/commands/html_import.rs`: 조건 분기 1줄 추가.
+- `src/document_core/commands/html_import.rs`: 공백 변형이 밑줄로 인식되는지
+  확인하는 테스트 1건 추가.
+
+## 검증
+- `cargo check --lib` 통과.

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -899,7 +899,8 @@ impl DocumentCore {
         let has_underline = inherited_underline
             || css_lower.contains("text-decoration:underline")
             || css_lower.contains("text-decoration: underline")
-            || css_lower.contains("text-decoration-line:underline");
+            || css_lower.contains("text-decoration-line:underline")
+            || css_lower.contains("text-decoration-line: underline");
         cs.underline_type = if has_underline {
             UnderlineType::Bottom
         } else {
@@ -1055,6 +1056,29 @@ mod tests {
         assert!(
             ps.raw_data.is_none(),
             "raw_data 가 남으면 정렬·줄간격 변경이 저장 시 사라진다"
+        );
+    }
+}
+
+#[cfg(test)]
+mod textdecoline_tests {
+    use super::*;
+    use crate::model::document::Document;
+    use crate::model::style::{CharShape, UnderlineType};
+
+    #[test]
+    fn css_underline_recognizes_text_decoration_line_with_space() {
+        let mut doc = Document::default();
+        doc.doc_info.char_shapes.push(CharShape::default());
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+
+        let id = core.css_to_char_shape_id("text-decoration-line: underline", false, false, false);
+        let cs = &core.document.doc_info.char_shapes[id as usize];
+        assert_ne!(
+            cs.underline_type,
+            UnderlineType::None,
+            "콜론 뒤 공백이 있는 text-decoration-line: underline 도 밑줄로 인식돼야 함"
         );
     }
 }


### PR DESCRIPTION
원 PR #3053이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약
- `src/document_core/commands/html_import.rs`의 CSS→CharShape 매핑에서 `text-decoration-line: underline`(콜론 뒤 공백 있는 변형)이 밑줄로 인식되지 않던 버그 수정.
- 같은 함수의 `font-weight`, `text-decoration` 검사는 공백 유무 두 변형을 모두 처리하는데 `text-decoration-line`만 누락돼 있었음.

## 관련 이슈
Closes #3034

## 테스트
- `cargo check --lib` 통과
- 공백 변형이 밑줄로 인식되는지 확인하는 단위 테스트 1건 추가 및 통과