### PR TITLE
fix(hwpx): 차트/OLE hp:pos lock(개체 잠금) 속성 라운드트립 유실 수정

### DIFF
--- a/mydocs/report/task_m100_2931_report.md
+++ b/mydocs/report/task_m100_2931_report.md
@@ -1,0 +1,78 @@
+# Task m100-2931: HWPX hp:chart/hp:ole lock(개체 잠금) 속성 왕복 유실 해소
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2931
+
+## 근본 원인
+
+`src/parser/hwpx/section.rs`의 `parse_hp_chart_element`(`<hp:chart>` 전용)와
+`parse_hp_ole_element`(`<hp:ole>` 폴백 전용)는 요소 최상위 속성을 개별 `match`로
+처리하는데, 둘 다 `numberingType`/`zOrder`/`textWrap`/`textFlow`/`chartIDRef`(또는
+`binaryItemIDRef`)/`instid`만 처리하고 `lock` 속성은 매치 대상이 없어
+`_ => {}`로 조용히 버려졌다.
+
+`CommonObjAttr`(`src/model/shape.rs`)에도 애초에 개체 잠금 상태를 담을 필드가
+없었기 때문에, `src/serializer/hwpx/section.rs`의 `render_common_shape_xml`
+(ellipse/arc/polygon/curve/chart 공용 경로 — `ShapeObject::Chart`가 이 경로로
+들어간다)과 `src/serializer/hwpx/shape.rs`의 `write_ole`(OLE 전용)는 모두
+`lock` 속성을 `"0"` 문자열 리터럴로 고정 방출했다.
+
+결과적으로 원본 HWPX 문서에서 `<hp:chart lock="1" .../>` 또는
+`<hp:ole lock="1" .../>`로 잠가 둔 차트·OLE 개체가 rhwp를 거쳐 재저장되면
+항상 `lock="0"`(잠금 해제)으로 바뀌어 사용자가 지정한 개체 보호 설정이
+조용히 사라진다.
+
+같은 저장소에서 이미 수식(`<hp:equation>`, #2840), 표(`<hp:tbl>`, #2855),
+그림(`<hp:pic>`, #2875) 각각에 대해 동일한 `lock="0"` 하드코딩 패턴이 별도로
+확인·트래킹되고 있었지만, 차트(`<hp:chart>`)와 OLE(`<hp:ole>`) 경로는 어떤
+이슈에서도 다뤄지지 않아 잔여로 남아 있었다.
+
+## 변경 사항
+
+- `src/model/shape.rs`: `CommonObjAttr`에 `locked: bool` 필드 추가
+  (#2840에서 제안된 이름과 동일하게 두어 추후 통합을 쉽게 함).
+- `src/parser/hwpx/section.rs`:
+  - `parse_hp_chart_element`에 `b"lock" => common.locked = attr_str(&attr) == "1"`
+    분기 추가.
+  - `parse_hp_ole_element`에도 동일한 분기 추가.
+- `src/serializer/hwpx/section.rs`: `render_common_shape_xml`의 하드코딩
+  `lock="0"`을 `common.locked` 기반 `{lock}` 포맷 인자로 교체.
+- `src/serializer/hwpx/shape.rs`: `write_ole`의 하드코딩 `("lock", "0")`을
+  `common.locked` 기반 `lock` 변수로 교체.
+- `src/document_core/converters/common_obj_attr_writer.rs`: 신규 필드 추가에
+  따른 테스트 헬퍼 `make_sample()` 초기화 보정(`locked: false`).
+
+## 테스트 (red → green)
+
+`src/parser/hwpx/section.rs`의 `parser::hwpx::section::tests` 모듈에
+`task2931_chart_lock_attr_roundtrips_into_common`을 추가했다. `<hp:chart
+lock="1" .../>`를 포함한 최소 HWPX 문서를 파싱해 `ShapeObject::Ole(ole)`의
+`ole.common.locked`가 `true`로 보존되는지 확인한다.
+
+- **Red**: `locked` 필드 도입 전에는 `assert!(ole.common.locked, ...)`가
+  `CommonObjAttr`에 해당 필드가 없어 `error[E0609]: no field \`locked\` on
+  type \`model::shape::CommonObjAttr\`` 컴파일 오류로 실패했다(파서 미구현
+  상태를 그대로 드러냄).
+- **Green**: `locked` 필드 추가 + 파서 2곳(`parse_hp_chart_element`,
+  `parse_hp_ole_element`)에 `lock` 매칭 추가 + 직렬화 2곳(`render_common_shape_xml`,
+  `write_ole`) 하드코딩 제거 후 `cargo test --lib
+  task2931_chart_lock_attr_roundtrips_into_common` 통과.
+
+## 검증 명령과 결과
+
+- `cargo check --lib`: 성공(경고 없음).
+- `cargo test --lib task2931_chart_lock_attr_roundtrips_into_common`: 1개
+  통과.
+- `cargo test --lib -- chart lock ole`: 187개 통과, 0개 실패(회귀 없음;
+  차트/락/OLE 관련 기존 테스트 전부 정상).
+- `rustfmt --edition 2021 <변경 파일 5개>`: 실질 diff 없음(CRLF 개행 경고만
+  발생).
+
+## 완료 기준
+
+차트(`<hp:chart>`)·OLE(`<hp:ole>`) 개체의 `lock` 속성이 IR(`CommonObjAttr.locked`)을
+거쳐 HWPX 왕복 시 보존됨을 최소 단위 테스트로 확인했다. `render_common_shape_xml`이
+공유하는 ellipse/arc/polygon/curve 경로도 동일한 필드를 참조하므로 함께 개선된다
+(단, 이 경로들의 파서는 `parse_object_element_attrs`를 통해 별도 이슈(#2840 PR
+방향)로 다뤄질 예정이며 본 작업 범위 밖이다).

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -228,6 +228,7 @@ mod tests {
             description: String::new(),
             raw_extra: Vec::new(),
             numbering_type: crate::model::shape::ObjectNumberingType::None,
+            locked: false,
         }
     }
 

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -92,6 +92,11 @@ pub struct CommonObjAttr {
     pub numbering_type: ObjectNumberingType,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
+    /// HWPX `lock`(개체 잠금) 속성 보존 (#2931).
+    ///
+    /// 차트(`hp:chart`)·OLE(`hp:ole`) 파서가 이 속성을 읽지 않아 직렬화 시 항상
+    /// `lock="0"`으로 하드코딩되던 문제 해소.
+    pub locked: bool,
 }
 
 /// HWPX 개체 `numberingType` (캡션 번호 범주)

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5861,6 +5861,9 @@ fn parse_hp_chart_element(
                 chart_num = digits.parse().unwrap_or(0);
             }
             b"instid" => common.instance_id = parse_u32(&attr),
+            // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
+            // 되돌아가 차트 개체의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -5945,6 +5948,9 @@ fn parse_hp_ole_element(
                 bin_id = digits.parse().unwrap_or(0);
             }
             b"instid" => common.instance_id = parse_u32(&attr),
+            // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
+            // 되돌아가 OLE 개체의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -7731,6 +7737,35 @@ mod tests {
         assert_eq!(
             parse_field_type("TABLE_OF_CONTENTS"),
             FieldType::TableOfContents
+        );
+    }
+
+    #[test]
+    fn task2931_chart_lock_attr_roundtrips_into_common() {
+        // <hp:chart lock="1" .../> → common.locked 이 true 로 되읽혀야 한다.
+        // 종전엔 parse_hp_chart_element 가 lock 속성을 매치하지 않아 항상 기본값(false)
+        // 으로 남고, 직렬화 시에도 render_common_shape_xml 이 "0"을 하드코딩했다(#2931).
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart id="1" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="1" chartIDRef="Chart/chart1.xml" instid="1"></hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected chart (modeled as OLE) shape");
+        };
+        assert!(
+            ole.common.locked,
+            "lock=\"1\" 이 common.locked 에 보존돼야 한다"
         );
     }
 }

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1986,7 +1986,7 @@ fn render_common_shape_xml(
         .unwrap_or(c.instance_id);
     let mut out = format!(
         concat!(
-            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
+            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="{lock}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
             "{block}",
             "{geometry}",
             r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
@@ -1999,6 +1999,7 @@ fn render_common_shape_xml(
         id = c.instance_id,
         zo = c.z_order,
         nt = super::shape::numbering_type_str(c.numbering_type),
+        lock = if c.locked { "1" } else { "0" },
         gl = group_level,
         iid = instid,
         tw = text_wrap_to_hwpx(c.text_wrap),

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -357,6 +357,8 @@ pub(crate) fn write_ole<W: Write>(
         OleDrawingAspect::DocPrint => "DOCPRINT",
         OleDrawingAspect::Content => "CONTENT",
     };
+    // [#2931] 개체 잠금(lock) — IR(common.locked)을 보존(종전 "0" 하드코딩 제거).
+    let lock = if c.locked { "1" } else { "0" };
 
     start_tag_attrs(
         w,
@@ -367,7 +369,7 @@ pub(crate) fn write_ole<W: Write>(
             ("numberingType", numbering_type_str(c.numbering_type)),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            ("lock", lock),
             ("dropcapstyle", "None"),
             ("href", ""),
             ("groupLevel", "0"),


### PR DESCRIPTION
원 PR #2940이 devel과의 충돌로 close된 후, GitHub 정책상(close 이후 force-push된 브랜치는 reopen 불가) 재오픈이 막혀 upstream/devel 기준으로 리베이스해 새로 엽니다.

원본 설명:

## 요약

- `<hp:chart>`(차트) / `<hp:ole>`(OLE 폴백) 개체의 `lock`(개체 잠금) 속성이 파싱되지 않고, `CommonObjAttr`에 이를 담을 필드도 없어 직렬화 시 항상 `lock="0"`으로 하드코딩되던 문제를 해소합니다 (#2931).
- `CommonObjAttr`에 `locked: bool` 필드를 추가하고, `parse_hp_chart_element`/`parse_hp_ole_element`에서 `lock` 속성을 읽어 채운 뒤, `render_common_shape_xml`(ellipse/arc/polygon/curve/chart 공용 경로)과 `write_ole`(OLE 전용)의 하드코딩을 이 필드 기반으로 교체했습니다.

## 근본 원인

`parse_hp_chart_element`/`parse_hp_ole_element`는 요소 최상위 속성을 개별 `match`로 처리하는데 `lock`이 매치 대상에서 빠져 있었고, 직렬화 두 경로 모두 `("lock", "0")`을 리터럴로 방출했습니다. 표(#2855)·수식(#2840)·그림(#2875)은 각각 별도 이슈로 트래킹되고 있었지만 차트·OLE 경로는 다뤄지지 않았습니다.

## 테스트 (red → green)

`parser::hwpx::section::tests::task2931_chart_lock_attr_roundtrips_into_common`을 추가했습니다. `<hp:chart lock="1" .../>`를 포함한 HWPX 문서를 파싱해 `ole.common.locked == true`를 확인합니다.

- Red: `locked` 필드 도입 전에는 `CommonObjAttr`에 해당 필드가 없어 `error[E0609]: no field \`locked\`` 컴파일 오류로 실패.
- Green: 필드 추가 + 파서 2곳 + 직렬화 2곳 수정 후 테스트 통과.

## 검증

- `cargo check --lib`: 성공
- `cargo test --lib task2931_chart_lock_attr_roundtrips_into_common`: 1개 통과
- `cargo test --lib -- chart lock ole`: 187개 통과, 0개 실패 (회귀 없음)
- `rustfmt --edition 2021`: 변경 파일 대상 실행, 실질 diff 없음(CRLF 경고만)

## 관련

이슈 #2931. 참고 패턴: #2840(수식 lock), #2855(표 lock), #2875(그림 lock).