### PR TITLE
docs: #2428 종료 검증 및 수동 close 근거

### DIFF
--- a/mydocs/orders/20260722.md
+++ b/mydocs/orders/20260722.md
@@ -360,3 +360,9 @@ PDF 축 정리로 함께 종결: #2787(사용자 제안 — v1.0.0 미지원 안
 - PR 검토는 `mydocs/pr/archives/pr_2834_review.md`, 상세 결과는
   `mydocs/report/task_m100_2809_report.md`에 기록한다. push/PR 생성은 작업지시자
   승인 후 진행한다.
+
+## M100 — #2428 각주 hit-test fast-reject 종료 검증
+
+| Issue | 타스크 | 상태 | 비고 |
+|---|---|---|---|
+| #2428 | 거대 표 본문 클릭 성능 개선 종료 검증·문서화 | 완료 (12:43) | 7/23 최신 devel +46커밋 재검증, HWP/HWPX 각 12회 native 각주 hit 0회, 실제 각주 진입·복귀 PASS, 문서 PR merge 후 수동 close |

--- a/mydocs/plans/task_m100_2428.md
+++ b/mydocs/plans/task_m100_2428.md
@@ -1,0 +1,70 @@
+# 수행 계획서 — Task M100 #2428 종료 검증
+
+## 1. 작업 개요
+
+- 이슈: [#2428](https://github.com/edwardkim/rhwp/issues/2428)
+- 제목: 거대 표 페이지의 본문 클릭마다 `hitTestFootnote`가 약 250ms 소요
+- 작업 성격: 이미 통합된 성능 개선의 종료 검증과 운영 상태 정리
+- 작업 브랜치: `issue-2428-closure-verification-pr`
+- 최초 검증 기준: `upstream/devel@12f8a820c82e34cbc61042df4b613532b8459a37`
+- PR 전 재검증 기준: `upstream/devel@29b5547e256a3d6a1f8c94c9434c14a351b5543a`
+- 작성일: 2026-07-22
+- 상태: 작업지시자 승인 후 종료 검증 완료, 문서 PR 준비
+
+구현은 통합 PR [#2521](https://github.com/edwardkim/rhwp/pull/2521)로 이미 `devel`에
+들어갔다. 이 작업에서는 코드를 다시 수정하지 않고, 이슈의 완료 조건을 현재 production WASM과
+실제 pointer 경로에서 재검증한 뒤 수동 종료에 필요한 근거를 남긴다.
+
+최초 종료 검증 뒤 `devel`이 46커밋 전진했으므로 PR 직전에 다시 rebase한다. 해당 구간의
+#2428 fast-reject 코드·회귀 테스트·4개 픽스처 변경 유무를 먼저 확인하고, renderer/footnote
+간접 변경이 있으면 production build와 실제 pointer 검증까지 반복한다.
+
+## 2. 확인할 가설
+
+1. 각주가 없는 115쪽 거대 표의 UI 114쪽 본문 클릭은 page metadata에서 빠르게 음성 판정되어
+   네이티브 `hitTestFootnote`를 호출하지 않는다.
+2. 캐럿은 셀 문단 2499의 offset 77/78에 정확히 들어가며 표 객체 선택이나 각주 모드 진입이
+   발생하지 않는다.
+3. 실제 각주가 있는 HWP/HWPX에서는 본문 각주 마커와 각주 영역 클릭이 계속 각주 편집 모드로
+   진입하고, 본문 클릭으로 정상 복귀한다.
+4. focused Rust 회귀와 Studio production build가 현재 `devel`에서 통과한다.
+5. 구현 통합이 끝났는데도 이슈가 열린 이유를 GitHub 통합·종료 이력으로 설명할 수 있다.
+
+## 3. 검증 매트릭스
+
+| 축 | HWP | HWPX | 판정 기준 |
+| --- | --- | --- | --- |
+| 거대 표 본문 반복 클릭 | 12회 | 12회 | offset 77/78 교대, native 각주 hit 0회 |
+| 전체 클릭 처리 시간 | p50/p95 | p50/p95 | 기존 HWP baseline과 비교, 현재 절대값 기록 |
+| 각주 없는 page metadata | UI 114쪽 | UI 114쪽 | `pageHasFootnoteFootholds=false` |
+| 본문 각주 마커 | `footnote-01` | `footnote-01` | 각주 모드 진입 |
+| 각주 영역 | `footnote-01` | `footnote-01` | 각주 모드 유지 |
+| 본문 복귀 | `footnote-01` | `footnote-01` | 각주 모드 해제 |
+
+결정적 native 계약은 기존 `tests/issue_2428_footnote_fast_reject.rs`로 확인한다. 브라우저 probe는
+실제 `mousedown` 처리기를 통과시키되 일회성 측정 도구와 원시 JSON은 `/private/tmp`에만 둔다.
+
+## 4. 문서화와 종료 순서
+
+1. `mydocs/working/task_m100_2428_stage1.md`에 환경, 픽스처 해시, 명령, 원시 요약값을 기록한다.
+2. `mydocs/report/task_m100_2428_report.md`에 완료 조건 판정과 이슈 미종료 이유를 정리한다.
+3. 문서 PR은 `devel` 대상으로 만들고 `Related: #2428`로 연결한다.
+4. 문서 PR merge 후 이슈에 구현 merge, 종료 검증 PR, 측정 결과를 남기고 수동으로 close한다.
+
+저장소 기본 브랜치는 `main`이고 실제 통합 대상은 `devel`이므로 closing keyword에 의존하지 않는다.
+또한 검증 문서가 merge되기 전에 이슈를 먼저 닫지 않는다.
+
+## 5. 완료 조건
+
+- HWP/HWPX 거대 표 반복 클릭의 정확성, 호출 생략, p50/p95가 기록된다.
+- 실제 각주 마커·영역·본문 복귀가 두 포맷 모두 통과한다.
+- focused Rust test, production WASM build, Studio production build가 통과한다.
+- 구현 커밋과 회귀 커밋이 현재 `upstream/devel`에 포함된 사실을 확인한다.
+- 이슈가 열린 채 남은 이유와 문서 PR merge 후 수동 close 절차를 명시한다.
+
+## 6. 범위 제외
+
+- #2428 구현의 재설계 또는 추가 최적화
+- #2400의 표 경계·캐럿 기하와 #2424의 pagination continuation 변경
+- 전체 Rust test/clippy 재실행과 시각 fidelity sweep
+- 문서 PR merge 전 이슈 close

--- a/mydocs/pr/archives/pr_3124_review.md
+++ b/mydocs/pr/archives/pr_3124_review.md
@@ -1,0 +1,89 @@
+# PR #3124 검토 기록 — #2428 종료 검증 및 수동 close 근거
+
+## 1. 메타
+
+| 항목 | 값 |
+| --- | --- |
+| PR | [#3124](https://github.com/edwardkim/rhwp/pull/3124) |
+| 작성자 | `postmelee` |
+| base | `devel` |
+| head | `postmelee:issue-2428-closure-verification-pr` |
+| 관련 이슈 | [#2428](https://github.com/edwardkim/rhwp/issues/2428) |
+| 성격 | collaborator self-merge 후보, 문서-only 종료 검증 |
+| 기준 | `upstream/devel@29b5547e256a3d6a1f8c94c9434c14a351b5543a` |
+| 작성일 | 2026-07-23 |
+
+`draft`, `mergeable`, head SHA와 CI 상태는 변동값이다. 최종 merge 조건은 PR 최신 head의
+GitHub Actions 통과와 작업지시자 승인이다.
+
+## 2. 목적과 범위
+
+#2428의 구현은 원 기여 PR #2471이 아니라 누적 통합 PR #2521을 통해 이미 `devel`에 들어갔다.
+저장소 기본 브랜치는 `main`이고 실제 통합 대상은 `devel`이라 자동 close 대신 수동 상태 정리가
+필요했지만, 구현 포함 여부 재검증과 이슈 close 후속이 누락됐다.
+
+이 PR은 코드를 다시 수정하지 않고 다음 운영 근거만 반영한다.
+
+- 종료 검증 계획서
+- 환경·픽스처 해시·실제 pointer 계측을 담은 working 기록
+- 완료 조건 판정, 미종료 이유와 이슈 코멘트 초안을 담은 최종 보고서
+- 2026-07-22 오늘할일 기록
+- 이 collaborator self-merge 검토 기록
+
+## 3. 최신 devel 정렬
+
+최초 검증 기준 `12f8a820` 뒤 `devel`이 46커밋 전진해 PR 생성 전에
+`29b5547e`로 rebase했다.
+
+- #2428 fast-reject가 있는 `cursor_rect.rs`, `wasm_api.rs`, `wasm-bridge.ts`,
+  `input-handler-mouse.ts`에는 변경이 없었다.
+- `tests/issue_2428_footnote_fast_reject.rs`와 HWP/HWPX 거대 표·각주 픽스처 4개도
+  변경되지 않았다.
+- renderer/layout 통합, per-page 각주 조사, svg2pdf 공급원 이관의 간접 영향 가능성을
+  고려해 production build와 실제 pointer 검증을 전부 재실행했다.
+- #2428은 PR 준비 시점에도 OPEN, 코멘트 0건이고 중복 종료 검증 PR은 없었다.
+
+## 4. 종료 검증
+
+로컬 검증:
+
+```text
+env CARGO_TARGET_DIR=/Users/melee/Documents/projects/forks/rhwp/target \
+  CARGO_BUILD_JOBS=1 cargo test --test issue_2428_footnote_fast_reject -- --nocapture
+env CARGO_BUILD_JOBS=1 wasm-pack build --target web --out-dir pkg
+npm --prefix rhwp-studio run build
+git diff --check
+```
+
+결과:
+
+- focused Rust: 1 passed, 0 failed
+- production WASM build: PASS
+- Studio `tsc` + Vite/PWA: 169 modules, PASS
+- HWP/HWPX UI 114쪽 실제 pointer 클릭: 포맷별 12회
+  - native `hitTestFootnote`: 두 포맷 모두 0/12회
+  - 캐럿: 24/24회 cell paragraph 2499, offset 77/78, page 113
+  - 표 객체 선택·각주 오진입: 0회
+  - HWP handler: p50 258.1→2.8ms, p95 268.6→9.225ms
+- 실제 각주 HWP/HWPX:
+  - 본문 marker 진입, 각주 영역 유지, 본문 복귀 모두 PASS
+
+## 5. 영향과 리스크
+
+최종 diff는 `mydocs/**` 문서만 추가·수정한다. 소스, 테스트, workflow, sample,
+golden/baseline과 렌더 산출물을 바꾸지 않으므로 visual sweep 대상이 아니다.
+
+거대 표 마지막 상태 갱신에서 기존 `getCursorRectInCell` 오류가 `hitTest` cursor rect로
+fallback되는 경고가 포맷별 1회 있었지만 최종 캐럿 rect와 offset은 정확했다. 이는
+`hitTestFootnote` fast-reject 회귀가 아니며 #2428 merge blocker로 보지 않는다.
+
+## 6. merge 권고와 후속
+
+문서-only fast-pass PR로 merge를 권고한다. 최종 조건은 다음과 같다.
+
+1. 이 review 문서를 포함한 최신 PR head 기준 preflight와 required check가 성공한다.
+2. PR이 `MERGEABLE`이고 branch protection의 pending/failing check가 없다.
+3. 작업지시자의 merge 승인을 확인한다.
+
+merge 후에는 merge SHA와 이 PR의 검증 근거를 #2428에 남긴 뒤 수동 close한다. 별도 후속
+문서 PR은 만들지 않는다. 현재 #2428 범위에서 알려진 잔여 구현 과제는 없다.

--- a/mydocs/report/task_m100_2428_report.md
+++ b/mydocs/report/task_m100_2428_report.md
@@ -1,0 +1,101 @@
+# Task M100 #2428 최종 보고서 — 각주 hit-test fast-reject 종료 검증
+
+## 결론
+
+[#2428](https://github.com/edwardkim/rhwp/issues/2428)은 현재 유효한 미구현 작업이 아니다.
+요구한 최적화는 [#2521](https://github.com/edwardkim/rhwp/pull/2521)을 통해 `devel`에 통합됐고,
+2026-07-23 최신 `upstream/devel@29b5547e`의 HWP/HWPX production WASM 실제 클릭 경로에서
+종료 조건을 모두 만족했다.
+
+문서 PR이 merge된 뒤 검증 결과를 이슈에 남기고 수동 close한다. 추가 구현 이슈로 존치할 근거는
+없다.
+
+## 반영된 구현
+
+- 구현: `0564f976c4c5d513aa52270d0408267e14bba682`
+  - page-local pagination metadata의 `footnotes` 유무를 O(1)로 확인한다.
+  - 각주가 없는 page에서는 Studio가 native `hitTestFootnote`를 호출하지 않는다.
+- 회귀: `2c785d9bb3f65116e6fda81b4b12f89ede3e8e01`
+  - 각주가 있는 첫 page, 없는 마지막 page, 범위 밖 page의 native/WASM 계약을 고정한다.
+- 통합: PR #2521, merge commit `625e23a3d59ebe1002ef96a6d52a99c54e4b0f73`
+
+## 종료 검증 요약
+
+| 완료 조건 | 결과 | 판정 |
+| --- | --- | --- |
+| HWP/HWPX UI 114쪽 일반 본문 fast-reject | 포맷별 12회, native `hitTestFootnote` 0회 | PASS |
+| 전체 클릭 지연 감소 | HWP p50 258.1→2.8ms, p95 268.6→9.225ms | PASS |
+| 캐럿 정확성 | 24/24회 cell paragraph 2499, offset 77/78, page 113 | PASS |
+| 표/각주 오진입 방지 | 24/24회 표 선택 false, 각주 모드 false | PASS |
+| 실제 각주 마커와 영역 | HWP/HWPX 모두 진입·유지·본문 복귀 | PASS |
+| native 회귀 | focused Rust test 1 passed | PASS |
+| production 산출물 | WASM build와 Studio build 통과 | PASS |
+
+상세 환경, 픽스처 해시, 좌표와 하위 호출 계측은
+`mydocs/working/task_m100_2428_stage1.md`에 보존한다.
+
+최초 검증 뒤 `devel`이 46커밋 전진해 PR 직전에 다시 rebase했다. #2428 코드·회귀·픽스처에는
+직접 변경이 없었지만 render/layout과 각주 조사 변경의 간접 영향을 고려해 focused test,
+production build, HWP/HWPX pointer matrix를 전부 재실행했다.
+
+## 이슈가 닫히지 않은 이유
+
+이슈가 열린 상태인 것은 구현 미완료가 아니라 통합 후 상태 정리 누락이다.
+
+1. 원 기여 PR #2471은 `Issue: #2428`로 참조만 했고 closing keyword를 사용하지 않았다.
+2. 원 PR은 직접 merge되지 않고 2026-07-20에 closed/unmerged 처리됐다.
+3. 실제 코드는 누적 통합 PR #2521로 cherry-pick되어 `devel`에 merge됐다.
+4. 저장소 기본 브랜치는 `main`이다. GitHub의 closing keyword 자동 종료는 기본 브랜치를 대상으로
+   하므로 `devel` 통합에서는 자동 close에 의존할 수 없다.
+5. #2521 merge 뒤 원 PR 정리는 수행됐지만 #2428의 구현 포함 여부 재검증과 수동 close가 후속으로
+   실행되지 않았다.
+
+따라서 #2428의 OPEN 상태는 기술적 잔여 작업을 의미하지 않는다. 원 PR의 비직접 통합과
+`devel` 중심 운영에서 필요한 수동 종료 단계가 빠진 운영상 공백이다.
+
+참고: [GitHub의 이슈-PR 연결 및 자동 종료 규칙](https://docs.github.com/en/issues/tracking-your-work-with-issues/using-issues/linking-a-pull-request-to-an-issue)
+
+## 종료 순서
+
+1. 이 보고서와 working 기록을 담은 문서 PR을 `devel`에 merge한다.
+2. #2428에 구현 merge와 종료 검증 결과, 문서 PR 링크를 코멘트한다.
+3. 코멘트 게시 후 이슈를 `completed`로 수동 close한다.
+
+문서 PR 본문에는 `Related: #2428`을 사용한다. `Closes #2428`로 검증 문서 merge와 동시에
+닫힌 것처럼 표현하지 않으며, merge된 증적 링크를 확보한 뒤 별도 상태 전환한다.
+
+## 이슈 코멘트 초안
+
+```markdown
+종료 검증을 완료했습니다.
+
+- 구현은 누적 통합 PR #2521을 통해 `devel`에 반영됐습니다.
+  - 구현: `0564f976c4c5d513aa52270d0408267e14bba682`
+  - 회귀: `2c785d9bb3f65116e6fda81b4b12f89ede3e8e01`
+- production WASM에서 거대 표 HWP/HWPX를 각각 12회 실제 클릭했습니다.
+  - native `hitTestFootnote`: 두 포맷 모두 0/12회
+  - HWP 전체 handler: p50 258.1→2.8ms, p95 268.6→9.225ms
+  - 24/24회 셀 문단 2499의 offset 77/78로 정확히 진입, 표 선택·각주 오진입 없음
+- 실제 각주 HWP/HWPX에서 본문 marker 진입, 각주 영역 유지, 본문 복귀를 확인했습니다.
+- focused Rust test, production WASM build, Studio production build가 통과했습니다.
+- 최초 검증 뒤 46커밋 전진한 최신 `devel@29b5547e`로 rebase하고 같은 matrix를 재실행했습니다.
+- 종료 검증 문서: PR #<검증-문서-PR>
+
+이슈가 열린 채 남은 이유는 구현 미완료가 아닙니다. 원 PR #2471이 직접 merge되지 않고
+#2521에 흡수됐고, 저장소 기본 브랜치가 `main`인 반면 통합은 `devel`로 이뤄져 자동 종료 대신
+수동 상태 정리가 필요했으나 그 후속이 누락됐습니다.
+
+완료 조건을 모두 만족하므로 이 코멘트와 함께 이슈를 닫습니다.
+```
+
+## 잔여 위험
+
+- 이 측정은 한 macOS/arm64 headless Chrome 환경의 12회 표본이며 일반 성능 SLA를 정의하지 않는다.
+- 이슈 본문에는 HWPX 변경 전 독립 baseline이 없어 HWPX 감소율은 산출하지 않았다. 다만 현재
+  HWPX의 native 호출 생략, 절대 지연, 캐럿 정확성과 실제 각주 회귀를 직접 검증했으므로 종료를
+  막지 않는다.
+- 거대 표 마지막 상태 갱신에서 기존 `getCursorRectInCell` 오류가 `hitTest` cursor rect로
+  fallback되는 경고가 포맷별 1회 있었지만 최종 캐럿 rect와 offset은 모두 정확했다. 이는
+  `hitTestFootnote` 경로의 회귀가 아니며, 정리 시 #2400 계열의 별도 진단 대상으로 본다.
+- 이후 `pageHasFootnoteFootholds` metadata와 render tree가 불일치하는 새 픽스처가 발견되면 새
+  재현 이슈로 추적한다. 현재 #2428 범위에서 알려진 잔여 결함은 없다.

--- a/mydocs/working/task_m100_2428_stage1.md
+++ b/mydocs/working/task_m100_2428_stage1.md
@@ -1,0 +1,164 @@
+# Task M100 #2428 Stage 1 — 종료 검증 기록
+
+## 1. 결론
+
+2026-07-23 현재 `upstream/devel@29b5547e`에서 #2428의 완료 조건을 다시 검증했고 모두
+통과했다. 각주가 없는 115쪽 거대 표의 UI 114쪽에서 HWP/HWPX 각각 12회 실제 pointer 클릭을
+수행한 결과 네이티브 `hitTestFootnote` 호출은 두 포맷 모두 0회였다. 캐럿은 매번 셀 문단
+2499의 기대 offset 77/78로 이동했고 표 객체 선택이나 각주 모드 오진입은 없었다.
+
+실제 각주 문서에서는 두 포맷 모두 본문 각주 마커 클릭과 각주 영역 클릭으로 각주 편집 모드에
+들어갔으며, 본문 클릭으로 다시 빠져나왔다. 따라서 fast-reject가 실제 각주 동작을 차단하지 않는다.
+
+## 2. 통합 상태
+
+| 항목 | 확인값 |
+| --- | --- |
+| 원 기여 PR | [#2471](https://github.com/edwardkim/rhwp/pull/2471), closed/unmerged |
+| 누적 통합 PR | [#2521](https://github.com/edwardkim/rhwp/pull/2521), merged 2026-07-20 |
+| 통합 merge commit | `625e23a3d59ebe1002ef96a6d52a99c54e4b0f73` |
+| #2428 구현 commit | `0564f976c4c5d513aa52270d0408267e14bba682` |
+| focused 회귀 commit | `2c785d9bb3f65116e6fda81b4b12f89ede3e8e01` |
+| 최초 종료 검증 기준 | `12f8a820c82e34cbc61042df4b613532b8459a37` |
+| PR 전 재검증 기준 | `29b5547e256a3d6a1f8c94c9434c14a351b5543a` |
+
+`git branch -r --contains 0564f976...`로 `upstream/devel` 포함을 확인했다. 구현 commit은
+기여자의 원 commit `58ae9c2e...`를 collaborator가 cherry-pick한 것으로 저자 정보와 원 commit
+참조를 보존한다.
+
+## 3. 환경과 재현 입력
+
+최신 `devel` 재검증 시각은 2026-07-23 12:08 KST 전후다.
+
+| 항목 | 값 |
+| --- | --- |
+| OS / 아키텍처 | macOS 26.5.2 (25F84), arm64 |
+| Rust / Cargo | 1.93.1 / 1.93.1 |
+| wasm-pack | 0.15.0 |
+| Node.js / npm | 24.15.0 / 11.12.1 |
+| Chrome | 150.0.7871.130, headless new |
+| viewport | 1600×1000, DPR 1 |
+| browser reported memory / concurrency | 16 GiB / 12 |
+
+| 픽스처 | SHA-256 |
+| --- | --- |
+| `samples/issue1949_giant_cell_nested_tables_perf.hwp` | `ef10261cd29325116028e4f4f3e6be1a72c675eb771bddfd8484e7fe5aa94b4e` |
+| `samples/issue1949_giant_cell_nested_tables_perf.hwpx` | `fc6e5f156de470dfbb14aab392389491720ee7fb1bf6f03fe9a018e93b420c65` |
+| `samples/footnote-01.hwp` | `5bbc8a8fd23415aad59dd91d1eb261050946d9c64635933fcd49609ec2cc94e5` |
+| `samples/hwpx/footnote-01.hwpx` | `2b59b7248af275a5fa6e108f95997ceacbec9f3bb4fc9b1a30502373a8f672cb` |
+| 최초 기준 production `pkg/rhwp_bg.wasm` | `6a467a115af0170481d96aeac5b58d59627877b1210627540ca127689991fdb2` |
+| 최신 기준 production `pkg/rhwp_bg.wasm` | `625a270400ffeaa1e3f2e1ae5d6f792525879ad67be3ca8321941fc23811ade9` |
+
+## 4. 빌드와 focused 회귀
+
+다음 검증이 통과했다.
+
+```text
+env CARGO_BUILD_JOBS=1 wasm-pack build --target web --out-dir pkg
+npm --prefix rhwp-studio run build
+env CARGO_TARGET_DIR=/Users/melee/Documents/projects/forks/rhwp/target \
+  CARGO_BUILD_JOBS=1 cargo test --test issue_2428_footnote_fast_reject -- --nocapture
+```
+
+- production WASM build: 통과
+- Studio `tsc` + Vite/PWA production build: 169 modules, 통과
+- `issue_2428_footnote_fast_reject_matches_page_metadata`: 1 passed, 0 failed, 0.02s
+
+최신 `devel`의 svg2pdf 공급원 이관도 반영해 새 의존성을 받은 뒤 같은 production build를
+완료했다. `pkg/rhwp_bg.wasm` 해시가 달라진 것은 이 46커밋 누적분을 포함한 새 산출물이기
+때문이며, 아래 브라우저 검증은 새 해시를 대상으로 했다.
+
+기본 병렬 WASM build는 같은 로컬 머신의 동시 작업으로 메모리 압박을 받아 exit 137이 발생했다.
+소스를 바꾸지 않고 job 수만 1로 제한한 clean worktree production build는 통과했다. 이는 코드
+실패가 아니라 로컬 자원 조건이며, 최종 판정은 성공한 단일 job production 산출물로 수행했다.
+
+## 5. 거대 표 실제 클릭 계측
+
+### 5.1 방법
+
+production WASM과 Studio build를 로드한 깨끗한 Chrome profile에서 실제 `page.mouse.click()`으로
+`mousedown` 처리기를 통과시켰다. UI 114쪽(`pageIndex=113`) 마지막 줄의 hit range를 현재
+`hitTest`로 찾고 다음 두 점을 교대했다.
+
+| 기대 offset | page point | hit x range | 기대 cursor rect |
+| ---: | --- | --- | --- |
+| 77 | `(124.25, 1057.3)` | 탐색 범위 내 `90.0..158.5` | page 113, `(150.8, 1049.3, h=16)` |
+| 78 | `(165.0, 1057.3)` | `159.0..171.0` | page 113, `(166.8, 1049.3, h=16)` |
+
+각 클릭에서 전체 handler와 `pageHasFootnoteFootholds`, `hitTestFootnote`, 본문 각주 마커 hit,
+주 body hit, `moveToHit`, cursor path lookup을 계측했다. 브라우저 client 좌표의 정수 양자화가
+글자 경계를 넘지 않도록 range 중앙을 사용했다.
+
+### 5.2 결과
+
+| 포맷 | page 수 | load | 전체 handler 첫 클릭 | p50 | p95 | native `hitTestFootnote` |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| HWP | 115 | 1024.6ms | 13.9ms | 2.8ms | 9.225ms | 0/12 |
+| HWPX | 115 | 1051.0ms | 4.1ms | 3.25ms | 5.16ms | 0/12 |
+
+HWP의 이슈 baseline과 같은 지표를 비교하면 다음과 같다.
+
+| HWP 지표 | 2026-07-19 baseline | 2026-07-23 재검증 | 감소 |
+| --- | ---: | ---: | ---: |
+| 전체 `mousedown` p50 | 258.1ms | 2.8ms | 98.9% |
+| 전체 `mousedown` p95 | 268.6ms | 9.225ms | 96.6% |
+| `hitTestFootnote` 호출 | 12/12 | 0/12 | 100% 생략 |
+
+HWPX는 이슈 본문에 독립된 변경 전 baseline이 없으므로 HWP baseline을 전용해 감소율을 만들지
+않았다. 현재 절대값과 호출 생략, 정확성만 별도로 판정했다.
+
+하위 경로 요약은 다음과 같다.
+
+| 포맷 | page metadata | 본문 각주 마커 hit | 주 body `hitTest` | `moveToHit` | cursor path lookup |
+| --- | --- | --- | --- | --- | --- |
+| HWP | 12회, p50 0ms | 12회, p50 0.1ms | 24회, p50 0.8ms | 12회, p50 0ms | 0회 |
+| HWPX | 12회, p50 0ms | 12회, p50 0.1ms | 24회, p50 0.9ms | 12회, p50 0ms | 0회 |
+
+두 포맷의 24회 클릭 모두 다음 단언을 만족했다.
+
+- `pageHasFootnoteFootholds(pageIndex=113) == false`
+- cursor cell paragraph = 2499, char offset = 기대 77/78
+- cursor rect page = 113
+- `tableObjectSelected == false`
+- `cursor.isInFootnote() == false`
+
+비차단 관찰로, 두 거대 문서의 마지막 상태 갱신에서 `getCursorRectInCell` 경로 오류 뒤
+`hitTest`의 `cursorRect`를 쓰는 기존 fallback 경고가 각각 1회 집계됐다. 최초 검증과 최신
+재검증에서 동일했고 최종 rect는 위 기대값과 일치했다. `hitTestFootnote` fast-reject나 캐럿
+정확성 실패는 아니므로 #2428 종료를 막지 않으며, fallback 경로 자체를 정리할 경우 #2400 계열의
+별도 진단 범위로 다룬다.
+
+## 6. 실제 각주 회귀
+
+각주 샘플 첫 페이지는 `pageHasFootnoteFootholds=true`였다. render tree에서 찾은 본문 marker와
+`FootnoteArea` 내부를 실제 pointer로 클릭하고 상태를 확인했다.
+
+| 포맷 | 본문 marker hit | marker 클릭 후 | 각주 영역 클릭 후 | 본문 클릭 후 | 판정 |
+| --- | --- | --- | --- | --- | --- |
+| HWP | footnote 1, source index 0 | 각주 모드 진입 | 각주 모드 유지 | 각주 모드 해제 | PASS |
+| HWPX | footnote 1, source index 0 | 각주 모드 진입 | 각주 모드 유지 | 각주 모드 해제 | PASS |
+
+두 포맷 모두 각주 cursor rect가 page 0의 `(92.7, 1000.8, h=12)`로 확인됐다. marker click과
+각주 영역 click이 기존 `hitTestFootnote`/`hitTestInFootnote` 경로를 계속 사용하므로 fast-reject의
+양성 페이지 동작도 보존됐다.
+
+## 7. PR 전 최신 devel 추가 검토
+
+최초 검증 기준 `12f8a820` 뒤 `devel`이 46커밋 전진한 것을 확인하고
+`29b5547e`로 rebase했다.
+
+- `cursor_rect.rs`, `wasm_api.rs`, `wasm-bridge.ts`, `input-handler-mouse.ts`,
+  `issue_2428_footnote_fast_reject.rs`와 4개 검증 픽스처에는 변경이 없었다.
+- 다만 render/layout 통합 `88730063f`, per-page 각주 조사 `530c41cce`, svg2pdf 공급원 이관
+  `0ecf68610`이 포함되어 간접 영향 가능성을 배제하지 않았다.
+- focused Rust test, production WASM, Studio production build와 HWP/HWPX pointer matrix를
+  새 기준에서 모두 다시 실행했다.
+- 이슈 #2428은 여전히 OPEN이고 코멘트 0건, assignee 0명이며, 새 종료 검증 PR은 없었다.
+
+따라서 46커밋 누적분은 #2428 구현 계약을 변경하지 않았고 실제 동작도 회귀하지 않았다.
+
+## 8. 판정
+
+#2428의 성능, 캐럿 정확성, 실제 각주 동작, HWP/HWPX, focused 회귀 조건을 모두 만족한다.
+추가 코드 변경은 필요하지 않다. 종료 검증 문서 PR을 `devel`에 merge한 뒤 그 PR과 이 기록을
+이슈에 연결하고 수동 close하는 것이 적절하다.


### PR DESCRIPTION
## 요약

- 이미 `devel`에 통합된 #2428 `hitTestFootnote` fast-reject의 종료 조건을 최신 production WASM에서 재검증했습니다.
- HWP/HWPX 성능·캐럿 정확성·실제 각주 진입/복귀 근거와 이슈가 열린 채 남은 운영상 이유를 문서화했습니다.
- 문서 PR merge 후 #2428에 검증 결과를 남기고 수동 close하는 순서를 고정했습니다.

## 최신 devel 재검토

최초 검증 뒤 `devel`이 46커밋 전진해 `upstream/devel@29b5547e`로 rebase했습니다.

- #2428 fast-reject 코드, focused 회귀 테스트와 4개 검증 픽스처에는 직접 변경이 없었습니다.
- renderer/layout 통합과 각주 조사 변경의 간접 영향을 고려해 focused test, production WASM/Studio build와 실제 pointer matrix를 전부 재실행했습니다.
- #2428은 여전히 OPEN, 코멘트 0건이며 중복 종료 검증 PR은 없습니다.

## 검증

- `cargo test --test issue_2428_footnote_fast_reject -- --nocapture`
  - 1 passed, 0 failed
- `CARGO_BUILD_JOBS=1 wasm-pack build --target web --out-dir pkg`
- `npm --prefix rhwp-studio run build`
  - 169 modules
- 거대 표 HWP/HWPX UI 114쪽 실제 pointer 클릭 각 12회
  - native `hitTestFootnote`: 두 포맷 모두 0/12회
  - 캐럿: 24/24회 cell paragraph 2499, offset 77/78, page 113
  - 표 객체 선택·각주 오진입: 0회
  - HWP handler: p50 258.1→2.8ms, p95 268.6→9.225ms
- 실제 각주 HWP/HWPX
  - 본문 marker 진입, 각주 영역 유지, 본문 복귀 모두 PASS

## 이슈가 열린 이유

원 기여 PR #2471 은 직접 merge되지 않고 누적 통합 PR #2521 에 흡수됐습니다. 저장소 기본 브랜치는 `main`이고 실제 통합 대상은 `devel`이라 자동 close 대신 수동 상태 정리가 필요했지만, #2521 merge 뒤 그 후속이 누락됐습니다.

따라서 OPEN 상태는 구현 미완료를 의미하지 않습니다. 이 PR에는 `Closes`를 사용하지 않고, 문서 merge를 확인한 뒤 #2428 에 결과를 게시하고 수동 close합니다.

## 변경 범위

- 종료 검증 계획서
- 상세 working 기록
- 최종 보고서와 이슈 코멘트 초안
- 2026-07-22 오늘할일 기록

Related: #2428
