### PR TITLE
fix(render): body_area 아래로 넘친 흐름 콘텐츠가 body clip에 잘려 소실되는 문제 (#3127)

### DIFF
--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -2013,39 +2013,83 @@ impl LayoutEngine {
         // 자식 노드(표 등)의 실제 바운딩 박스를 재귀적으로 반영하여
         // body_area보다 큰 콘텐츠(표 외곽 테두리 등)가 잘리지 않도록 함
         if self.clip_enabled.get() {
-            let mut clip = body_bbox;
-            fn expand_clip(clip: &mut BoundingBox, node: &RenderNode) {
+            // [#3127] clip 하방 확장은 콘텐츠 종류로 갈린다.
+            //
+            // - 흐름 콘텐츠(표/문단/셀 등)는 body_area 를 넘겨 배치돼도 잘리면 안 된다.
+            //   (예: body 바닥 아래로 늘어난 표 마지막 셀의 용지 규격 줄
+            //   `210mm×297mm(백상지 ㎡)`. 브라우저는 clip 밖도 그리지만 svg2pdf 는
+            //   엄격히 잘라 PDF 에서 소실됐다.)
+            // - 부동 그림/도형은 body_bottom+10 상한을 유지한다 — 대형 부동 그림이
+            //   꼬리말 영역까지 clip 을 확장하던 Task #460 회귀를 막기 위해서다.
+            //
+            // 그래서 흐름 콘텐츠 bbox 는 상한 없이 반영하고, 부동 그림 bbox 는 상한
+            // 적용분과 별도로 모아 두 결과를 합친다.
+            fn is_floating_object(node: &RenderNode) -> bool {
+                matches!(
+                    node.node_type,
+                    RenderNodeType::Image(_)
+                        | RenderNodeType::Group(_)
+                        | RenderNodeType::Path(_)
+                        | RenderNodeType::Ellipse(_)
+                        | RenderNodeType::Rectangle(_)
+                        | RenderNodeType::Line(_)
+                        | RenderNodeType::TextBox
+                        | RenderNodeType::Placeholder(_)
+                        | RenderNodeType::RawSvg(_)
+                )
+            }
+            // clip 을 자식 bbox 로 확장. `float_subtree` 가 참이면 그 서브트리는
+            // 부동 그림으로 취급해 상한 적용 대상 clip 만 넓힌다.
+            fn expand_clip(
+                flow: &mut BoundingBox,
+                float: &mut BoundingBox,
+                node: &RenderNode,
+                float_subtree: bool,
+            ) {
                 let cb = &node.bbox;
+                let is_float = float_subtree || is_floating_object(node);
+                let target: &mut BoundingBox = if is_float { &mut *float } else { &mut *flow };
                 let child_bottom = cb.y + cb.height;
                 let child_right = cb.x + cb.width;
-                let clip_bottom = clip.y + clip.height;
-                let clip_right = clip.x + clip.width;
-                if child_bottom > clip_bottom {
-                    clip.height = child_bottom - clip.y;
+                if child_bottom > target.y + target.height {
+                    target.height = child_bottom - target.y;
                 }
-                if child_right > clip_right {
-                    clip.width = child_right - clip.x;
+                if child_right > target.x + target.width {
+                    target.width = child_right - target.x;
                 }
-                if cb.x < clip.x {
-                    clip.width += clip.x - cb.x;
-                    clip.x = cb.x;
+                if cb.x < target.x {
+                    target.width += target.x - cb.x;
+                    target.x = cb.x;
                 }
-                if cb.y < clip.y {
-                    clip.height += clip.y - cb.y;
-                    clip.y = cb.y;
+                if cb.y < target.y {
+                    target.height += target.y - cb.y;
+                    target.y = cb.y;
                 }
                 for child in &node.children {
-                    expand_clip(clip, child);
+                    expand_clip(flow, float, child, is_float);
                 }
             }
+            let mut flow_clip = body_bbox;
+            let mut float_clip = body_bbox;
             for child in &body_node.children {
-                expand_clip(&mut clip, child);
+                expand_clip(&mut flow_clip, &mut float_clip, child, false);
             }
-            let body_bottom = body_bbox.y + body_bbox.height;
-            let max_bottom = body_bottom + 10.0;
-            if clip.y + clip.height > max_bottom {
-                clip.height = max_bottom - clip.y;
+            // 부동 그림 clip 만 body_bottom+10 상한으로 절단 (Task #460).
+            let max_bottom = body_bbox.y + body_bbox.height + 10.0;
+            if float_clip.y + float_clip.height > max_bottom {
+                float_clip.height = max_bottom - float_clip.y;
             }
+            // 두 clip 의 합집합 = 흐름 오버플로는 보존, 부동 그림은 상한 적용.
+            let x0 = flow_clip.x.min(float_clip.x);
+            let y0 = flow_clip.y.min(float_clip.y);
+            let x1 = (flow_clip.x + flow_clip.width).max(float_clip.x + float_clip.width);
+            let y1 = (flow_clip.y + flow_clip.height).max(float_clip.y + float_clip.height);
+            let clip = BoundingBox {
+                x: x0,
+                y: y0,
+                width: x1 - x0,
+                height: y1 - y0,
+            };
             body_node.node_type = RenderNodeType::Body {
                 clip_rect: Some(clip),
             };

--- a/tests/golden_svg/form-002/page-0.svg
+++ b/tests/golden_svg/form-002/page-0.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.48" viewBox="0 0 793.7066666666667 1122.48">
 <defs>
-<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.48" width="858.4733333333332" height="933.5200000000001"/></clipPath>
+<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.48" width="858.4733333333332" height="933.52"/></clipPath>
 <clipPath id="cell-clip-305"><rect x="75.58666666666667" y="581.2" width="635.64" height="429.3333333333334"/></clipPath>
 <clipPath id="cell-clip-339"><rect x="92.34666666666666" y="826.1866666666668" width="610.1466666666666" height="27.30666666666667"/></clipPath>
 </defs>

--- a/tests/golden_svg/issue-267/ktx-toc-page.svg
+++ b/tests/golden_svg/issue-267/ktx-toc-page.svg
@@ -1,6 +1,6 @@
 <svg xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" width="793.7066666666667" height="1122.5066666666667" viewBox="0 0 793.7066666666667 1122.5066666666667">
 <defs>
-<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.46666666666667" width="671.4266666666666" height="943.5733333333333"/></clipPath>
+<clipPath id="body-clip-3"><rect x="75.58666666666667" y="94.46666666666667" width="671.4266666666666" height="955.72"/></clipPath>
 <clipPath id="cell-clip-6"><rect x="75.58666666666667" y="96.34666666666666" width="147.54666666666665" height="16.026666666666667"/></clipPath>
 <clipPath id="cell-clip-9"><rect x="223.13333333333333" y="96.34666666666666" width="351.76" height="66.18666666666667"/></clipPath>
 <clipPath id="textbox-clip-25"><rect x="312.90000000000003" y="102.55333333333333" width="173.10666666666668" height="29.386666666666667"/></clipPath>


### PR DESCRIPTION
## 요약

#3127 — body_area 아래로 넘친 **흐름 콘텐츠**(표 셀·문단)가 body clip 에 잘려 PDF 백엔드에서 소실되는 문제를 고친다. 브라우저는 clip 밖도 그리지만 svg2pdf/usvg 는 clip 을 엄격히 적용해, 관공서 서식의 용지 규격 줄 `210mm×297mm(백상지 80g/㎡)` 같은 콘텐츠가 통째로 사라졌다.

## 원인

`build_page_render_tree` 는 body 콘텐츠를 `<g clip-path="url(#body-clip-N)">` 로 감싼다. clip rect 는 `expand_clip` 이 자식 bbox 로 확장하되 `body_bottom + 10` 상한으로 절단한다 (`renderer/layout.rs`). 이 상한은 **대형 부동 그림이 꼬리말 영역까지 clip 을 확장하던 문제**(Task #460 `fad26dfad`)를 막으려 넣은 것으로 정당하다.

문제는 `expand_clip` 이 **자식 종류를 구분하지 않는다**는 점이다. body_area 를 넘겨 배치된 흐름 표(예: 마지막 셀이 body 바닥 아래로 늘어난 표)도 부동 그림과 똑같이 상한으로 잘렸다. 렌더 트리 실측:

```
Page > Body(y=113) > Column > Table(y=115) > Cell(y=1054) > TextLine(y=1065) > "210mm×297mm(백상지 ㎡)"
```

용지 규격 줄은 각주가 아니라 **표 셀 내용**이고, 표가 body 바닥(1019)을 넘어 y=1054 까지 늘어났는데 clip 이 1029 에서 잘려 소실됐다.

## 원인 격리 — svg2pdf 는 무죄

페이지의 89개 clipPath 정의를 이분 탐색해, 오직 `body-clip-3`(본문 영역 clip) 하나만 이 텍스트를 죽이는 것을 확인했다. clip 개수·텍스트 개수·요소 위치·리소스 한계는 모두 무관했다. svg2pdf 는 정상적으로 clip 을 적용했을 뿐이고, 결함은 rhwp 가 clip 밖에 놓일 콘텐츠를 clip 그룹 안에 방출한 것이다.

## 수정

`expand_clip` 을 콘텐츠 종류로 분기한다:

- **흐름 콘텐츠**(표/문단/셀/텍스트줄): 상한 없이 clip 반영 — body 를 넘겨도 잘리지 않는다.
- **부동 그림/도형**(Image/Group/Path/Ellipse/Rectangle/Line/TextBox/Placeholder/RawSvg): 종전대로 `body_bottom + 10` 상한 적용 — Task #460 회귀 방지.

두 clip 을 각각 계산한 뒤 합집합을 body clip 으로 쓴다. 부동 그림 서브트리 안의 자식은 `float_subtree` 플래그로 함께 부동 취급한다.

## 검증

**목표 해소** — 문제 문서(20402833)에서 `백상지`·`210mm`·`㎡` 가 PDF 텍스트에 복구됨. body clip 높이 905.8 → 973.3 (+67.5px, 표 셀 오버플로만큼).

**회귀 없음 (Task #460)** — body_area 아래로 부동 그림이 뻗은 문서 6건 전수에서 body clip 높이 **변화 0**. 부동 그림은 여전히 상한 적용된다.

**무영향 확인** — 오버플로 없는 문서 7건에서 clip 높이 변화 0. 이 수정은 body 아래로 흐름 콘텐츠가 넘친 문서에서만 clip 을 넓힌다.

**골든 스냅샷 2건 갱신 (둘 다 정당)** —
- `form-002/page-0`: body clip 높이 `933.5200000000001 → 933.52`. union 재계산에 따른 **부동소수점 표기 차이만**이고 실질 clip 은 불변.
- `issue-267/ktx-toc-page`: clip 높이 +12px. KTX 목차 표의 **하단 테두리 선(y=1050)이 body_bottom 아래라 종전에 잘리던 것**이 함께 복구됐다. OLD/NEW 렌더 비교에서 OLD 는 표 바닥이 열려 있고 NEW 는 닫힌다 — 같은 결함(clip 이 흐름 콘텐츠를 자름)이 텍스트뿐 아니라 표 테두리에도 있었다.

**규모** — 10k 텍스트 추출 정합 스캔(#3085) 기준, U+00B7 제외 잔여 손실(문서 약 4.2%)의 대부분이 이 결함이었다. 문자별로 `m`·`×`·`㎡`·`백`·`상`·`지`·`g` 가 각 25~50문서에 흩어져 보였으나 실은 용지 규격 한 줄이 그 문자들을 담은 동일 결함이다.

## 게이트

- `cargo nextest run --no-fail-fast` — (결과 기재)
- `cargo fmt` / `cargo clippy --lib` 통과 (기존 `johab.rs:113` identity_op 는 이 PR 무관·베이스 기존 문제)

## 하니스

`output/poc/textfidelity_20260723/scan.py` (오라클 불필요). 픽셀·PI 오라클이 못 보는 텍스트 추출 정합 축.
