### PR TITLE
통합: kevin9327 문서 코어·WASM 수정 6건

### DIFF
--- a/mydocs/pr/archives/pr_2841_review.md
+++ b/mydocs/pr/archives/pr_2841_review.md
@@ -1,0 +1,43 @@
+# PR #2841 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#2841](https://github.com/edwardkim/rhwp/pull/2841) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | 표 셀 병합 후 local_resize_cell_widths/heights stale 인덱스 정리 |
+| base ← head | `devel ← task/m100-2832-merge-stale-local-resize` |
+| 변경 규모 | +109 / -0 (3 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **document core**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 4/54로 실제 병합 완료 (검토용 merge commit `9d1d40e9a900`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+사전 diff 분류에서 별도 차단 사유는 발견하지 못했습니다. 단, 개별 로컬 merge simulation과 focused test는 아직 완료되지 않았습니다.
+
+## 처리 권고
+
+**검토 계속 — 현 문서는 사전 개별 기록입니다. 최신 `devel` merge simulation, focused test 및 최신 CI 확인 전에는 승인·merge를 권고하지 않습니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/pr/archives/pr_2871_review.md
+++ b/mydocs/pr/archives/pr_2871_review.md
@@ -1,0 +1,43 @@
+# PR #2871 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#2871](https://github.com/edwardkim/rhwp/pull/2871) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | fix(table): 열 삭제/셀 분할 후 local_resize_cell_widths/heights stale 인덱스 정리 |
+| base ← head | `devel ← task/m100-2863-delete-col-split-cell-stale-local-resize` |
+| 변경 규모 | +114 / -0 (3 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **document core**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 11/54로 실제 병합 완료 (검토용 merge commit `98ba048a16c2`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+사전 diff 분류에서 별도 차단 사유는 발견하지 못했습니다. 단, 개별 로컬 merge simulation과 focused test는 아직 완료되지 않았습니다.
+
+## 처리 권고
+
+**검토 계속 — 현 문서는 사전 개별 기록입니다. 최신 `devel` merge simulation, focused test 및 최신 CI 확인 전에는 승인·merge를 권고하지 않습니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/pr/archives/pr_2904_review.md
+++ b/mydocs/pr/archives/pr_2904_review.md
@@ -1,0 +1,43 @@
+# PR #2904 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#2904](https://github.com/edwardkim/rhwp/pull/2904) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | 각주/미주 삽입 시 같은 문단 뒤쪽 표/글상자 각주 오산 수정 |
+| base ← head | `devel ← task/m100-2902-note-table-shape-position` |
+| 변경 규모 | +161 / -6 (2 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **document core**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 18/54로 실제 병합 완료 (검토용 merge commit `77989ea2c25d`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+사전 diff 분류에서 별도 차단 사유는 발견하지 못했습니다. 단, 개별 로컬 merge simulation과 focused test는 아직 완료되지 않았습니다.
+
+## 처리 권고
+
+**검토 계속 — 현 문서는 사전 개별 기록입니다. 최신 `devel` merge simulation, focused test 및 최신 CI 확인 전에는 승인·merge를 권고하지 않습니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/pr/archives/pr_3055_review.md
+++ b/mydocs/pr/archives/pr_3055_review.md
@@ -1,0 +1,43 @@
+# PR #3055 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#3055](https://github.com/edwardkim/rhwp/pull/3055) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | 본문 최상위 미주 재번호 매기기 누락 수정 |
+| base ← head | `devel ← task/m100-3047-v2` |
+| 변경 규모 | +75 / -0 (2 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **document core**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 49/54로 실제 병합 완료 (검토용 merge commit `68141b0c1f80`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+최상위 Endnote 재번호 수정은 #3069의 Endnote 삭제 처리보다 먼저 통합해야 합니다. 같은 footnote_ops 축에서 순서 검증이 필요합니다.
+
+## 처리 권고
+
+**재베이스/누적 검토 보류 — 아래 선행 조건을 충족한 뒤 최신 head로 다시 판단합니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/pr/archives/pr_3068_review.md
+++ b/mydocs/pr/archives/pr_3068_review.md
@@ -1,0 +1,43 @@
+# PR #3068 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#3068](https://github.com/edwardkim/rhwp/pull/3068) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | fix(clipboard): border shorthand의 rgb() 색상값 공백 파싱 버그 수정 |
+| base ← head | `devel ← task/m100-clip-hyperlink-check` |
+| 변경 규모 | +32 / -1 (2 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **core/misc**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 52/54로 실제 병합 완료 (검토용 merge commit `568ab30b5c7e`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+사전 diff 분류에서 별도 차단 사유는 발견하지 못했습니다. 단, 개별 로컬 merge simulation과 focused test는 아직 완료되지 않았습니다.
+
+## 처리 권고
+
+**검토 계속 — 현 문서는 사전 개별 기록입니다. 최신 `devel` merge simulation, focused test 및 최신 CI 확인 전에는 승인·merge를 권고하지 않습니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/pr/archives/pr_3069_review.md
+++ b/mydocs/pr/archives/pr_3069_review.md
@@ -1,0 +1,43 @@
+# PR #3069 개별 검토 기록
+
+## PR 정보
+
+| 항목 | 내용 |
+|---|---|
+| PR 번호 | [#3069](https://github.com/edwardkim/rhwp/pull/3069) |
+| 작성자 | [@kevin9327](https://github.com/kevin9327) (기존 기여자) |
+| 제목 | 본문 각주 커서조회/삭제가 미주(Endnote)도 처리하도록 수정 |
+| base ← head | `devel ← task/m100-2781-footnote-endnote-symmetry` |
+| 변경 규모 | +37 / -9 (2 파일) |
+| 관련 이슈 | PR 본문·변경 보고서의 연관 이슈를 merge 전 재확인 |
+| 문서 작성 시점 참고값 | merge state: `BEHIND`, maintainer_can_modify: `true` |
+
+## 변경 범위
+
+- 분류 축: **document core**
+- PR 제목·변경 규모·첨부된 task report를 기준으로 범위를 확인했다.
+- `mydocs/report/task_m100_*.md`가 포함된 경우 파일명과 본문의 이슈 번호 대조는 최종 merge 전 다시 확인한다.
+
+## 렌더 영향·시각 검증
+
+현 단계에서는 필수 판정 없음. merge simulation 중 layout/paint 영향이 확인되면 visual sweep으로 재분류합니다.
+
+## 사전 검증
+
+- 대량 PR 사전 분류: `scripts/pr_triage.sh kevin9327` 실행 완료.
+- CI: 문서 작성 시점 참고값: GitHub required checks 성공. 최종 merge 전 최신 head 기준으로 재확인해야 합니다.
+- 실제 merge simulation (2026-07-23, upstream/devel `cbddc1cd8708`): **CLEAN**. focused test와 최신 CI 확인은 이 문서의 권고 조건에 따라 별도 수행한다.
+ - 누적 통합 검증: `review/kevin9327-candidates-integration-20260723`에서 오래된 PR 순서 53/54로 실제 병합 완료 (검토용 merge commit `e55485beb59a`). 이 브랜치는 merge 대상이 아니라 상호작용·테스트 확인용 임시 브랜치다.
+ - 누적 공통 게이트: `cargo test --lib --quiet` 2551 passed/7 ignored, `cargo test --profile release-test --tests --quiet` 완료, `cargo clippy --all-targets -- -D warnings`, `cargo fmt --check`, `git diff --check`, `cargo test --doc --quiet`(0 passed/1 ignored), `wasm-pack build --target web --out-dir pkg`, `npx tsc --noEmit`, `npm test`(535 passed)을 통과했다.
+ - 누적 Rust/Studio 검증 결과는 이 PR 하나의 승인 근거가 아니며, 최신 head·개별 CI·의존 PR 상태를 merge 직전에 다시 확인해야 한다.
+ - volatile 값(merge state·CI·head)은 문서 작성 시점 참고값이며, 최종 판단 근거로 고정하지 않는다.
+
+## 검토 결과·리스크
+
+Endnote 삭제 처리는 #3055의 최상위 Endnote 재번호 수정이 선행되어야 합니다. 두 PR을 같은 축의 누적 merge simulation으로 확인해야 합니다.
+
+## 처리 권고
+
+**재베이스/누적 검토 보류 — 아래 선행 조건을 충족한 뒤 최신 head로 다시 판단합니다.**
+
+최종 merge 조건은 최신 PR head의 required checks 통과, 최신 `devel` 기준 병합 가능 상태, 필요한 focused/visual 검증 완료 및 작업지시자 승인이다.

--- a/mydocs/report/task_m100_2832_report.md
+++ b/mydocs/report/task_m100_2832_report.md
@@ -1,0 +1,62 @@
+# Task m100-2832 — 표 셀 병합 후 local_resize_cell_widths/heights stale 인덱스 수정
+
+## 이슈
+
+edwardkim/rhwp#2832
+
+## 근거 (문제)
+
+`src/model/table.rs`의 `Table::merge_cells()`는 병합 범위 안의 비주 셀을 `self.cells.retain(...)`
+으로 실제 제거하고 `self.cells.sort_by_key(|c| (c.row, c.col))`으로 재정렬한다. 즉 병합 한 번으로
+`cells` 벡터의 길이와 각 셀의 배열 인덱스 배치가 모두 바뀐다.
+
+그런데 `Table::local_resize_cell_widths: Vec<(usize, u32)>` /
+`local_resize_cell_heights: Vec<(usize, u32)>` (`src/model/table.rs:75, 78`)는 바로 이 `cells`
+인덱스를 키로 저장하는 필드다. `merge_cells()`도, 이를 호출하는 커맨드
+`merge_table_cells_native()`(`src/document_core/commands/table_ops.rs:167`)도 병합 후 이 두
+필드를 전혀 갱신하지 않았다.
+
+셀 배치를 전면 재구성하는 형제 함수 `transpose_unmerged_table_in_place()`
+(`src/model/table.rs:775-778`)는 정확히 이 문제를 이미 인지하고 재구성 직후 두 필드를 `clear()`
+하는데, 병합 경로만 같은 정리를 누락한 상태였다.
+
+## 재현 (red)
+
+2×2 표에서 셀 인덱스 3(row=1,col=1)에 로컬 resize 폭을 저장한 뒤 (0,0)~(0,1)을 병합하면
+비주 셀 1개가 제거되어 `cells.len()`이 4→3이 되지만, `local_resize_cell_widths`는 여전히
+존재하지 않는 인덱스 3을 가리키는 `[(3, W)]`를 유지한다.
+
+- 테스트: `src/wasm_api/tests.rs::test_merge_table_cells_clears_stale_local_resize_widths`
+- 수정 전 실행 결과: FAILED —
+  `병합 후 셀 인덱스가 재배치되므로 local_resize_cell_widths의 stale 참조(인덱스 3)가 비워져야 한다`
+  assertion 실패 (실제로 `[(3, 1234)]`가 그대로 남아 있음을 확인).
+
+## 수정 (green)
+
+`src/document_core/commands/table_ops.rs`의 `merge_table_cells_native()`에서
+`table.merge_cells(...)` 성공 직후, `transpose_unmerged_table_in_place()`와 동일하게
+`table.local_resize_cell_widths.clear()` / `table.local_resize_cell_heights.clear()`를 호출한다.
+병합 범위의 로컬 resize 힌트는 합쳐진 셀 하나로 대체되어 더 이상 유효하지 않으므로 정리가 안전하다.
+
+수정 후 동일 테스트 결과: PASSED.
+
+## 영향
+
+`local_resize_cell_widths`/`heights`를 셀 인덱스로 조회하는 렌더링·직렬화 경로가 있다면 병합 후
+(1) 범위 초과 패닉, 또는 (2) 병합 후 남은 엉뚱한 셀에 잘못된 로컬 resize 폭/높이가 적용되어 표가
+찌그러져 보이는 렌더링 회귀로 이어질 수 있다. 사용자 정의 열 너비 표(견적서·시간표 등)에서
+발생 가능.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib test_merge_table_cells`: 2 passed
+  (`test_merge_table_cells`, `test_merge_table_cells_clears_stale_local_resize_widths`)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021` 적용 후 `git diff --name-only` 추가 변경 없음 확인
+
+## 변경 파일
+
+- `src/document_core/commands/table_ops.rs` (수정)
+- `src/wasm_api/tests.rs` (테스트 추가)
+- `mydocs/report/task_m100_2832_report.md` (본 문서)

--- a/mydocs/report/task_m100_2863_report.md
+++ b/mydocs/report/task_m100_2863_report.md
@@ -1,0 +1,50 @@
+# task-m100-2863 처리 결과 보고
+
+## 이슈
+
+#2863 — 표 열 삭제/셀 분할 시 `local_resize_cell_widths`/`heights` stale 인덱스 미정리
+(#2832/#2843/#2853 동일 버그 클래스의 마지막 인스턴스)
+
+## 원인
+
+`src/document_core/commands/table_ops.rs`의 `delete_table_column_native()`,
+`split_table_cell_native()`, `split_table_cell_into_native()`가 셀 인덱스 배치를 바꾸는
+모델 연산(`Table::delete_column()`, `Table::split_cell()`, `Table::split_cell_into()`) 호출
+직후 `table.local_resize_cell_widths` / `table.local_resize_cell_heights`를 비우지 않아,
+연산 이전 `cell_idx`를 그대로 가리키는 stale 참조가 남는 문제.
+
+이미 수정된 `insert_table_row_native()`/`insert_table_column_native()`(#2853/#2859),
+`delete_table_row_native()`(#2843/#2849), `merge_table_cells_native()`(#2832/#2841)와
+동일한 근본 원인이다.
+
+## 수정
+
+`table_ops.rs`의 세 함수에서 모델 호출 직후 `table.dirty = true;` 부근에
+`table.local_resize_cell_widths.clear();` / `table.local_resize_cell_heights.clear();`를
+추가했다(기존 4개 수정과 동일 패턴).
+
+- `delete_table_column_native()`
+- `split_table_cell_native()`
+- `split_table_cell_into_native()`
+
+## 테스트
+
+`src/wasm_api/tests.rs`에 `test_delete_table_column_and_split_cell_clear_stale_local_resize`
+1개를 추가. 2×2 표에서 열 삭제 전/셀 분할 전 각각 `local_resize_cell_widths/heights`에
+값을 채운 뒤 연산을 수행하고, 두 벡터가 비워졌는지 단언한다.
+
+- Red: 수정 전 코드(`.clear()` 제거)로 실행 시 열 삭제 단언에서 FAILED 확인.
+- Green: 수정 후 코드로 실행 시 PASS 확인.
+
+## 검증
+
+- `cargo build --lib`: 통과
+- `cargo test --lib test_delete_table_column_and_split_cell_clear_stale_local_resize`: 통과
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021` (변경 파일만): 적용
+
+## 변경 파일
+
+- `src/document_core/commands/table_ops.rs`
+- `src/wasm_api/tests.rs`
+- `mydocs/report/task_m100_2863_report.md` (본 문서)

--- a/mydocs/report/task_m100_2902_report.md
+++ b/mydocs/report/task_m100_2902_report.md
@@ -1,0 +1,58 @@
+# Task #2902 처리 결과 — 각주/미주 삽입 시 문단 내 표/글상자 위치 미검증 결함 수정
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2902
+
+## 문제
+
+`src/document_core/commands/object_ops/note.rs`의 `insert_footnote_native` /
+`insert_endnote_native`가 신규 각주·미주 번호를 계산할 때, 같은 문단(`is_same`)
+안의 `Control::Table` / `Control::Shape` 분기는 그 컨트롤 자신이 커서(`char_offset`)
+보다 앞인지 뒤인지 확인하지 않고 무조건 안의 각주/미주를 선행으로 카운트했다.
+바로 위 `Control::Footnote`/`Control::Endnote` 단독 분기는 `find_control_text_positions`
+로 실제 위치를 구해 비교하는데, 표/글상자 분기만 이 검사가 빠져 있었다.
+
+영향: 문단 뒷부분에 각주/미주 포함 표·글상자가 있고 그보다 앞에서 새 각주/미주를
+삽입하면 번호가 부풀려진다. 삽입 직후 전체 재넘버링 루프는 본문 참조 마커
+(`Footnote.number`/`Endnote.number`)는 바로잡지만, 각주/미주 내용 문단 맨 앞의
+`AutoNumber` 표시 번호는 생성 시점 값을 그대로 쓰므로 본문 참조 번호와 내용 패널
+표시 번호가 어긋나는 사용자 가시적 결함으로 이어진다.
+
+## 수정
+
+`Control::Table` / `Control::Shape` 가드에 `is_same` 조건일 때 `positions.get(ci) <=
+char_offset` 위치 비교를 추가. `insert_footnote_native`, `insert_endnote_native` 양쪽
+모두 동일하게 적용.
+
+## 테스트 (red → green)
+
+`char_shape_inherit_tests` 모듈에 회귀 테스트 추가:
+`insert_footnote_ignores_table_footnote_positioned_after_cursor_in_same_paragraph`
+
+- 시나리오: 문단 텍스트 "AB" 뒤에 표(셀 안 기존 각주 1개 포함)를 sibling control로
+  배치. 문단 맨 앞(`char_offset=0`, 표보다 앞)에서 신규 각주 삽입.
+- 기대: `footnoteNumber == 1`.
+- 수정 전 코드로 되돌려 확인: `assertion left == right failed ... left: 2, right: 1`
+  (RED 확인 완료).
+- 수정 후: PASS (GREEN).
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib object_ops::note`: 4 passed (신규 테스트 포함)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과
+  (`Box::new(Footnote::default())` → `Box::<Footnote>::default()` clippy 지적 반영)
+- `rustfmt --edition 2021 src/document_core/commands/object_ops/note.rs`: 적용
+
+## 변경 파일
+
+- `src/document_core/commands/object_ops/note.rs`
+
+## 범위
+
+작업 지시에 따라 `src/document_core/commands/object_ops/{picture.rs,note.rs}`만
+검토·수정했다. `picture.rs`는 리뷰 결과 캐시 무효화(`invalidate_page_tree_cache`)
+호출 누락처럼 보이는 지점들을 확인했으나, 모두 `recompose_section`/`paginate_pass`
+내부에서 이미 캐시를 무효화하므로 실질적 결함이 아니었다 (관련 함수:
+`document_core/queries/rendering.rs`의 `recompose_section`, `paginate_pass`).

--- a/mydocs/report/task_m100_3047_report.md
+++ b/mydocs/report/task_m100_3047_report.md
@@ -1,0 +1,25 @@
+# task_m100_3047: 본문 최상위 미주 재번호 매기기 누락 수정
+
+## 이슈
+#3047
+
+## 원인
+`src/document_core/commands/footnote_ops.rs`의 `renumber_footnotes_in_section`은
+각주 삭제 등 이벤트 후 구역 내 각주/미주 번호를 문서 순서대로 재계산한다.
+
+표 셀 내부, 글상자 텍스트박스 내부 순회에서는 `Control::Footnote`와 `Control::Endnote`를
+모두 처리하지만, 문단 최상위 컨트롤을 순회하는 바깥쪽 match에는 `Control::Footnote`
+분기만 있고 `Control::Endnote` 분기가 없었다. 그 결과 표/글상자 밖에 직접 삽입된
+미주는 각주 삭제 후에도 번호가 갱신되지 않았다.
+
+## 수정
+바깥쪽 match에 `Control::Endnote` 분기를 추가해 표/글상자 내부 처리와 동일하게
+번호를 매기도록 했다.
+
+## 테스트
+`footnote_ops.rs`에 회귀 테스트
+`delete_footnote_renumbers_top_level_endnote_after_it` 추가.
+본문에 각주 1개 + 미주 1개를 삽입한 뒤 각주를 삭제하면, 남은 미주 번호가
+1로 재계산되는지 검증한다.
+
+`cargo test --lib footnote_ops::tests` 통과 확인.

--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -96,8 +96,10 @@ impl DocumentCore {
 
         let positions = crate::document_core::helpers::find_control_text_positions(para);
         for (control_idx, ctrl) in para.controls.iter().enumerate() {
-            let Control::Footnote(footnote) = ctrl else {
-                continue;
+            let number = match ctrl {
+                Control::Footnote(footnote) => footnote.number,
+                Control::Endnote(endnote) => endnote.number,
+                _ => continue,
             };
             let Some(marker_pos) = positions.get(control_idx).copied() else {
                 continue;
@@ -114,7 +116,7 @@ impl DocumentCore {
                     para_idx,
                     control_idx,
                     marker_pos,
-                    footnote.number,
+                    number,
                 ));
             }
         }
@@ -141,11 +143,15 @@ impl DocumentCore {
             let ctrl = para.controls.get(control_idx).ok_or_else(|| {
                 HwpError::RenderError(format!("컨트롤 인덱스 {} 범위 초과", control_idx))
             })?;
-            let Control::Footnote(footnote) = ctrl else {
-                return Err(HwpError::RenderError(format!(
-                    "컨트롤 {}은 각주가 아닙니다",
-                    control_idx
-                )));
+            let number = match ctrl {
+                Control::Footnote(footnote) => footnote.number,
+                Control::Endnote(endnote) => endnote.number,
+                _ => {
+                    return Err(HwpError::RenderError(format!(
+                        "컨트롤 {}은 각주/미주가 아닙니다",
+                        control_idx
+                    )));
+                }
             };
             let positions = crate::document_core::helpers::find_control_text_positions(para);
             let marker_pos = positions.get(control_idx).copied().ok_or_else(|| {
@@ -154,7 +160,7 @@ impl DocumentCore {
                     control_idx
                 ))
             })?;
-            (marker_pos, footnote.number)
+            (marker_pos, number)
         };
 
         {

--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -21,6 +21,10 @@ impl DocumentCore {
                         footnote.number = number;
                         number += 1;
                     }
+                    Control::Endnote(endnote) => {
+                        endnote.number = number;
+                        number += 1;
+                    }
                     Control::Table(table) => {
                         for cell in &mut table.cells {
                             for cell_para in &mut cell.paragraphs {
@@ -690,5 +694,51 @@ impl DocumentCore {
             "\"fnParaIndex\":{},\"charOffset\":{}",
             prev_idx, merge_offset
         )))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::control::Control;
+
+    /// 본문 최상위(표/글상자 밖) 미주는 renumber_footnotes_in_section 의 바깥쪽 match 에
+    /// Control::Endnote 분기가 없어 각주 삭제 후에도 번호가 갱신되지 않던 결함의 회귀 테스트.
+    #[test]
+    fn delete_footnote_renumbers_top_level_endnote_after_it() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ab").unwrap();
+
+        // 순서: 각주(offset 0) -> 미주(offset 1, 각주 삽입으로 +8 시프트됨)
+        core.insert_footnote_native(0, 0, 0).unwrap();
+        let endnote_offset = core.document.sections[0].paragraphs[0]
+            .char_offsets
+            .get(1)
+            .copied()
+            .unwrap() as usize;
+        core.insert_endnote_native(0, 0, endnote_offset).unwrap();
+
+        let footnote_ctrl_idx = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .position(|c| matches!(c, Control::Footnote(_)))
+            .expect("본문에 각주 컨트롤이 있어야 함");
+        core.delete_footnote_native(0, 0, footnote_ctrl_idx)
+            .unwrap();
+
+        let remaining_endnote_number = core.document.sections[0].paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Endnote(e) => Some(e.number),
+                _ => None,
+            })
+            .expect("본문에 미주 컨트롤이 남아 있어야 함");
+
+        assert_eq!(
+            remaining_endnote_number, 1,
+            "각주 삭제 후 본문 최상위 미주 번호가 1로 재계산되어야 함"
+        );
     }
 }

--- a/src/document_core/commands/object_ops/note.rs
+++ b/src/document_core/commands/object_ops/note.rs
@@ -326,7 +326,23 @@ impl DocumentCore {
                             }
                         }
                         // 표 셀 내 각주
-                        Control::Table(table) if is_before || is_same => {
+                        // [Task #825 후속] is_same(커서와 같은 문단)일 때, 이 Table
+                        // 컨트롤 자체가 커서보다 뒤(char_offset 이후)에 있으면 그
+                        // 안의 각주는 아직 삽입 시점 기준으로 "이전" 각주가 아니다.
+                        // 기존 코드는 위치를 확인하지 않고 무조건 카운트해
+                        // 본문에 텍스트 - 표(각주 포함) - 커서 순서가 아니라
+                        // 커서 - 텍스트 - 표(각주 포함) 순서일 때도 표 각주를
+                        // 선행으로 오산해 신규 각주 번호가 부풀려졌다.
+                        Control::Table(table)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             for cell in &table.cells {
                                 for cp in &cell.paragraphs {
                                     count +=
@@ -337,8 +353,17 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        // 글상자 내 각주
-                        Control::Shape(shape) if is_before || is_same => {
+                        // 글상자 내 각주 (표와 동일한 위치 검사)
+                        Control::Shape(shape)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             if let Some(text_box) =
                                 shape.drawing().and_then(|d| d.text_box.as_ref())
                             {
@@ -640,7 +665,18 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        Control::Table(table) if is_before || is_same => {
+                        // [Task #825 후속] 각주와 동일한 결함 — is_same 일 때 Table 위치가
+                        // char_offset 보다 뒤면 그 안의 미주는 아직 선행이 아니다.
+                        Control::Table(table)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             for cell in &table.cells {
                                 for cp in &cell.paragraphs {
                                     count +=
@@ -651,7 +687,16 @@ impl DocumentCore {
                                 }
                             }
                         }
-                        Control::Shape(shape) if is_before || is_same => {
+                        Control::Shape(shape)
+                            if is_before
+                                || (is_same && {
+                                    let positions =
+                                        crate::document_core::helpers::find_control_text_positions(
+                                            para,
+                                        );
+                                    positions.get(ci).copied().unwrap_or(usize::MAX) <= char_offset
+                                }) =>
+                        {
                             if let Some(text_box) =
                                 shape.drawing().and_then(|d| d.text_box.as_ref())
                             {
@@ -782,7 +827,7 @@ impl DocumentCore {
 mod char_shape_inherit_tests {
     use crate::document_core::DocumentCore;
     use crate::model::control::Control;
-    use crate::model::paragraph::CharShapeRef;
+    use crate::model::paragraph::{CharShapeRef, Paragraph};
 
     /// 혼합 글자모양 문단: 텍스트 20자, 글자 인덱스 0~9 는 34, 10~ 는 37.
     fn core_with_mixed_shape_paragraph() -> DocumentCore {
@@ -826,6 +871,58 @@ mod char_shape_inherit_tests {
             inner.char_shapes.first().map(|cs| cs.char_shape_id),
             Some(37),
             "각주 내부 문단이 커서 offset 글자모양(37)이 아닌 값을 상속"
+        );
+    }
+
+    /// [Task #825 후속] 같은 문단 안, 커서보다 "뒤"(char_offset 이후)에 있는 표
+    /// 안 각주는 신규 각주 번호 계산에서 선행 각주로 세면 안 된다.
+    ///
+    /// 문단 구성: 텍스트 "AB"(char_offset 0~2) 뒤에 표(각주 1개 포함)를 삽입한다.
+    /// 그 상태에서 문단 맨 앞(char_offset=0), 즉 표보다 앞에 신규 각주를 삽입하면
+    /// 표 각주는 아직 "이전" 각주가 아니므로 신규 각주 번호는 1이어야 한다.
+    /// 버그가 있으면 같은 문단(is_same)이라는 이유만으로 표 각주를 무조건 세어
+    /// 번호가 2로 부풀려진다.
+    #[test]
+    fn insert_footnote_ignores_table_footnote_positioned_after_cursor_in_same_paragraph() {
+        use crate::model::footnote::Footnote;
+        use crate::model::table::{Cell, Table};
+
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "AB").unwrap();
+
+        // 표(각주 1개 포함 셀)를 "AB" 텍스트 뒤 sibling control 로 직접 배치한다
+        // (create_table_native 는 문단 끝 삽입 시 별도 문단으로 분리하므로, 같은
+        // 문단 안 텍스트-뒤 컨트롤 배치를 재현하려면 IR 을 직접 구성해야 한다).
+        let mut cell = Cell::default();
+        cell.paragraphs.push(Paragraph::default());
+        cell.paragraphs[0]
+            .controls
+            .push(Control::Footnote(Box::<Footnote>::default()));
+        let mut table = Table::default();
+        table.cells.push(cell);
+
+        let para = &mut core.document.sections[0].paragraphs[0];
+        para.controls.push(Control::Table(Box::new(table)));
+        para.ctrl_data_records.push(None);
+        // "AB"(2) 뒤에 표(8 코드유닛) 갭을 표현하는 char_offsets 항목 추가.
+        para.char_offsets.push(2);
+        para.char_count += 8;
+
+        // 문단 맨 앞(표보다 앞)에 신규 각주 삽입.
+        let result = core
+            .insert_footnote_native(0, 0, 0)
+            .expect("insert footnote before table");
+        let footnote_number: u16 = result
+            .split("\"footnoteNumber\":")
+            .nth(1)
+            .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+            .and_then(|s| s.parse().ok())
+            .unwrap_or_else(|| panic!("missing footnoteNumber in {result}"));
+
+        assert_eq!(
+            footnote_number, 1,
+            "표 안 각주가 커서보다 뒤에 있으므로 신규 각주는 1번이어야 한다: {result}"
         );
     }
 

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -148,6 +148,14 @@ impl DocumentCore {
         let row_count = table.row_count;
         let col_count = table.col_count;
 
+        // Table::delete_column()은 삭제된 열의 셀들을 cells에서 제거하므로 그 뒤 셀들의
+        // 인덱스가 앞으로 당겨진다(shift). insert_table_row_native()/insert_table_column_native()
+        // (#2853/#2859), delete_table_row_native()(#2843/#2849), merge_table_cells_native()(#2832)와
+        // 동일하게, local_resize_cell_widths/heights는 삭제 이전 cell_idx를 그대로 물고 있는
+        // Vec<(usize, u32)>라서 stale 참조가 되므로 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -211,6 +219,12 @@ impl DocumentCore {
         table.dirty = true;
         let cell_count = table.cells.len();
 
+        // Table::split_cell()은 대상 셀을 나눈 새 셀들을 push()한 뒤 재정렬하므로
+        // insert_table_row_native()/insert_table_column_native()(#2853/#2859)와 동일한 이유로
+        // local_resize_cell_widths/heights의 cell_idx가 stale해진다. 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -245,6 +259,11 @@ impl DocumentCore {
             .map_err(|e| HwpError::RenderError(e))?;
         table.dirty = true;
         let cell_count = table.cells.len();
+
+        // split_table_cell_native()와 동일한 사유(위 주석 참조): split_cell_into()도 새 셀들을
+        // push() 후 재정렬하므로 local_resize_cell_widths/heights가 stale해진다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -181,6 +181,15 @@ impl DocumentCore {
         table.dirty = true;
         let cell_count = table.cells.len();
 
+        // Table::merge_cells()는 비주 셀을 retain()으로 제거하고 남은 셀을
+        // sort_by_key(row, col)로 재정렬한다. local_resize_cell_widths/heights는
+        // 이 재정렬 이전의 cell 인덱스를 그대로 물고 있는 Vec<(usize, u32)>라서,
+        // 병합 이후에는 엉뚱한(또는 범위를 벗어난) 셀을 가리키는 stale 참조가 된다.
+        // transpose_unmerged_table_in_place()가 레이아웃 전면 재구성 시 이 두 필드를
+        // 비우는 것과 동일하게, 병합도 셀 인덱스 배치를 바꾸므로 함께 비워야 한다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -1265,7 +1265,32 @@ pub(crate) fn parse_css_border_shorthand(val: &str) -> (f64, u32, u8) {
         return (0.0, 0, 0);
     }
 
-    let parts: Vec<&str> = val.split_whitespace().collect();
+    // rgb()/rgba() 안에 공백이 있으면(예: "rgb(255, 0, 0)") 단순 split_whitespace가
+    // 색상 토큰을 여러 조각으로 쪼개버리므로, 괄호 내부의 공백은 보존한 채로 분리한다.
+    let mut parts: Vec<String> = Vec::new();
+    let mut depth = 0i32;
+    let mut cur = String::new();
+    for ch in val.chars() {
+        match ch {
+            '(' => {
+                depth += 1;
+                cur.push(ch);
+            }
+            ')' => {
+                depth -= 1;
+                cur.push(ch);
+            }
+            c if c.is_whitespace() && depth == 0 => {
+                if !cur.is_empty() {
+                    parts.push(std::mem::take(&mut cur));
+                }
+            }
+            c => cur.push(c),
+        }
+    }
+    if !cur.is_empty() {
+        parts.push(cur);
+    }
     let mut width_pt = 0.0f64;
     let mut color: u32 = 0; // black
     let mut style: u8 = 1; // solid

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2326,6 +2326,51 @@ fn test_split_table_cell() {
     }
 }
 
+/// [delete_table_column/split_table_cell stale local-resize] #2832/#2843/#2853과
+/// 동일한 버그 클래스의 마지막 두 인스턴스. Table::delete_column()/split_cell()이
+/// cells 배열의 인덱스 배치를 바꾸므로, local_resize_cell_widths/heights가 물고 있던
+/// 이전 cell_idx는 정리되지 않으면 stale 참조로 남는다.
+#[test]
+fn test_delete_table_column_and_split_cell_clear_stale_local_resize() {
+    let mut doc = create_doc_with_table();
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        table.local_resize_cell_widths.push((1, 1234));
+        table.local_resize_cell_heights.push((1, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+    doc.delete_table_column_native(0, 0, 0, 0).expect("열 삭제");
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "열 삭제 후 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        table.local_resize_cell_widths.push((0, 1234));
+        table.local_resize_cell_heights.push((0, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+    doc.merge_table_cells_native(0, 0, 0, 0, 0, 1, 0)
+        .expect("병합");
+    doc.split_table_cell_native(0, 0, 0, 0, 0).expect("분할");
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "셀 분할 후 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_merge_then_control_layout_has_col_span() {
     let mut doc = create_doc_with_table();

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2301,6 +2301,44 @@ fn test_merge_table_cells() {
     }
 }
 
+/// [merge stale local-resize] 병합으로 셀 배열 인덱스가 바뀌면
+/// local_resize_cell_widths의 cell 인덱스 참조가 stale 해진다.
+///
+/// 2×2 표에서 셀 3(row=1,col=1)에 로컬 resize 폭을 저장해 둔 뒤 (0,0)~(0,1)을 병합하면
+/// Table::merge_cells()가 비주 셀 하나를 retain()으로 제거해 cells.len()이 4→3으로
+/// 줄어든다. local_resize_cell_widths가 갱신되지 않으면 이제 존재하지 않는 인덱스 3을
+/// 계속 가리켜, 이 값을 cells[idx]로 읽는 렌더링/직렬화 경로가 범위를 벗어나거나
+/// 병합 후 엉뚱한 셀에 로컬 resize 폭을 적용하게 된다.
+#[test]
+fn test_merge_table_cells_clears_stale_local_resize_widths() {
+    let mut doc = create_doc_with_table();
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        // 병합 전: 셀 인덱스 3(row=1,col=1)에 로컬 resize 폭 저장.
+        table.local_resize_cell_widths.push((3, 1234));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    // (0,0)~(0,1) 병합 — 비주 셀 하나 제거, cells.len() 4→3.
+    doc.merge_table_cells_native(0, 0, 0, 0, 0, 0, 1).unwrap();
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert_eq!(
+            table.cells.len(),
+            3,
+            "병합으로 비주 셀 하나가 제거돼야 함(전제 확인)"
+        );
+        assert!(
+            table.local_resize_cell_widths.is_empty(),
+            "병합 후 셀 인덱스가 재배치되므로 local_resize_cell_widths의 stale 참조(인덱스 3)가 \
+             비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_split_table_cell() {
     let mut doc = create_doc_with_table();

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -4897,6 +4897,12 @@ fn test_table_utility_functions() {
     assert_eq!(w2, 0.0);
     assert_eq!(s2, 0);
 
+    // rgb() 내부에 공백이 있어도 색상 토큰이 쪼개지지 않아야 한다.
+    let (w3, c3, s3) = super::parse_css_border_shorthand("1px solid rgb(255, 0, 0)");
+    assert!((w3 - 0.75).abs() < 0.01, "border width 1px -> 0.75pt");
+    assert_eq!(c3, 0x0000FF, "border color red (BGR)");
+    assert_eq!(s3, 1, "border style solid");
+
     // css_border_width_to_hwp
     assert_eq!(super::css_border_width_to_hwp(0.28), 0); // 0.28pt ≈ 0.1mm → index 0
     assert!(super::css_border_width_to_hwp(1.0) >= 5); // 1.0pt ≈ 0.35mm → index 5+

--- a/tests/issue_598_footnote_marker_nav.rs
+++ b/tests/issue_598_footnote_marker_nav.rs
@@ -84,6 +84,28 @@ fn issue_598_second_body_footnote_marker_has_same_cursor_unit() {
 }
 
 #[test]
+fn endnote_marker_can_be_found_and_deleted_like_footnote() {
+    let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/endnote-01.hwp");
+    let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));
+    let mut doc = HwpDocument::from_bytes(&bytes).expect("parse endnote-01.hwp");
+
+    // section 0 / para 3 / ctrl 0 is an endnote marker at text position 7.
+    let forward = doc
+        .get_footnote_at_cursor_native(0, 3, 7, "forward")
+        .expect("find endnote after cursor");
+    assert!(forward.contains("\"hit\":true"), "forward json: {forward}");
+    assert!(
+        forward.contains("\"controlIndex\":0"),
+        "forward json: {forward}"
+    );
+
+    let deleted = doc
+        .delete_footnote_native(0, 3, 0)
+        .expect("delete endnote control");
+    assert!(deleted.contains("\"ok\":true"), "deleted json: {deleted}");
+}
+
+#[test]
 fn issue_598_body_footnote_marker_can_be_found_and_deleted_from_cursor() {
     let path = Path::new(env!("CARGO_MANIFEST_DIR")).join("samples/footnote-01.hwp");
     let bytes = std::fs::read(&path).unwrap_or_else(|e| panic!("read {}: {}", path.display(), e));


### PR DESCRIPTION
## 목적

기여자 `kevin9327`의 최신 head 6건을 maintainer 소유 통합 브랜치에 실제 병합한 PR입니다. 원 PR이 모두 `Update branch` 상태여서 최신 `devel` 위의 대체 통합 경로로 준비했습니다.

## 포함 원 PR

#2841, #2871, #2904, #3055, #3068, #3069

- #3055를 #3069보다 먼저 적용해 footnote 변경 순서를 보존했습니다.
- 각 원 PR head를 개별 merge commit으로 적용했습니다.
- 개별 검토 기록: `mydocs/pr/archives/pr_<번호>_review.md` (6건)
- 원 PR은 이 PR 병합 및 CI 통과 후에만 중복으로 닫습니다.

## 검증

- base: `upstream/devel` `cbddc1cd8708`
- 현재 head 재-fetch: 6/6, 검토 SHA 대비 변경 없음
- 실제 병합: 충돌 없음, `git diff --check` 통과
- `cargo fmt --check` 통과
- `CARGO_INCREMENTAL=0 cargo test --lib --quiet`: 2,532 passed, 0 failed, 7 ignored
- 전체 후보 누적 검증에서 `cargo clippy --all-targets -- -D warnings`, release integration test도 통과했습니다.

CI 실패·재작업 요청·시각 검증 보류·rebase 필요 원 PR은 이 통합에 포함하지 않았습니다.