### PR TITLE
fix(hml): CHARSHAPE/PARASHAPE 자식 요소를 Id 위치 도형에 귀속 (#3146)

### DIFF
--- a/mydocs/report/task_m100_3146_report.md
+++ b/mydocs/report/task_m100_3146_report.md
@@ -1,0 +1,60 @@
+# task-m100-3146: HML CHARSHAPE/PARASHAPE 자식 요소 last_mut 귀속 결함 수정
+
+## 이슈
+
+#3146 HML 파서에서 CHARSHAPE/PARASHAPE 본체는 `Id` 속성 위치에 배치(set_indexed)되는데,
+자식 요소(FONTID/RATIO/CHARSPACING/RELSIZE/CHAROFFSET, PARAMARGIN/PARABORDER)는
+`last_mut()` 로 "마지막 원소"에 귀속된다. 두 배치 기준이 어긋나 있어:
+
+1. `Id` 가 내림차순(비순차)으로 들어오면 자식 값이 엉뚱한 도형을 덮어쓰고,
+   원래 도형은 기본값(`[0; 7]` 장평 등)으로 방치된다.
+2. #2743 이 도입한 리소스 Id 상한 초과 건너뜀 경로에서는, 건너뛴 도형의 자식이
+   직전 정상 도형을 오염시킨다 — BORDERFILL 에는 있는 "자식 폐기" 처리가
+   CHARSHAPE/PARASHAPE 에는 빠져 있었다.
+
+## 원인 분석
+
+`src/parser/hml/reader.rs`:
+
+- CHARSHAPE/PARASHAPE 시작 태그: `set_indexed(id, ...)` 로 Id 위치에 삽입.
+- 자식 요소(RATIO 등): `char_shapes.last_mut()` / `para_shapes.last_mut()` 로 귀속.
+- `set_indexed` 는 Id 가 현재 길이보다 작으면 기존 슬롯을 교체하므로,
+  Id 내림차순 입력에서 "마지막 원소"와 "방금 삽입한 원소"가 달라진다.
+- 상한 초과 건너뜀 시에도 `last_mut()` 는 직전 정상 도형을 가리켜 오염이 발생한다.
+  (BORDERFILL 은 `current_border_fill: Option<usize>` 로 이미 방어하고 있었다.)
+
+## 수정 내용
+
+BORDERFILL 의 `current_border_fill` 패턴과 동일하게:
+
+- `current_char_shape: Option<usize>` / `current_para_shape: Option<usize>` 필드 추가.
+- CHARSHAPE/PARASHAPE 시작 시 삽입 인덱스를 기록, 상한 초과 건너뜀 시 `None`.
+- 자식 요소는 `last_mut()` 대신 기록된 인덱스로 귀속, `None` 이면 폐기.
+- 요소 종료 시 인덱스 해제.
+
+## red→green 결과
+
+재현 테스트 3건 추가 (`tests/issue_hml_shape_child_attribution.rs`), 수정 전 전부 FAIL 확인:
+
+- `charshape_children_follow_out_of_order_ids` — Id=1,0 순 입력에서 RATIO 교차 오염
+  (수정 전: `Id=1 의 RATIO 는 90 이어야 한다` assert 실패, 실제 `[0; 7]`)
+- `skipped_charshape_children_do_not_pollute_previous_shape` — 상한 초과 건너뜀 도형의
+  RATIO 가 직전 도형 덮어씀 (수정 전: `[100; 7]` 기대, 실제 `[10; 7]`)
+- `parashape_margin_follows_out_of_order_ids` — PARAMARGIN 교차 오염
+  (수정 전: `Id=1 의 PARAMARGIN Left` 700 기대, 실제 0)
+
+수정 후 3건 전부 PASS.
+
+## 검증 명령
+
+```
+cargo test --test issue_hml_shape_child_attribution
+```
+
+3 passed. 기존 HML 파서 테스트 회귀 없음 (`cargo test hml`).
+
+## 관련 코드
+
+- `src/parser/hml/reader.rs` — 귀속 인덱스 추적 (+34/-3)
+- `tests/issue_hml_shape_child_attribution.rs` — 재현 테스트 3건 (신규)
+- 기준 커밋: upstream/devel `49469c1f`

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -195,6 +195,12 @@ struct ReadState<'a> {
     cells: Vec<HmlCell>,
     font_language: Option<usize>,
     current_border_fill: Option<usize>,
+    /// 자식 요소(FONTID/RATIO/...)를 귀속할 CHARSHAPE 의 `Id` 위치.
+    /// `set_indexed` 는 `Id` 위치에 배치하므로 `last_mut` 로는 내림차순·건너뜀
+    /// 입력에서 엉뚱한 도형을 가리킨다 — `current_border_fill` 과 같은 방식.
+    current_char_shape: Option<usize>,
+    /// 자식 요소(PARAMARGIN/PARABORDER)를 귀속할 PARASHAPE 의 `Id` 위치.
+    current_para_shape: Option<usize>,
     head_modeled_children: usize,
     body_modeled_children: usize,
     saw_head: bool,
@@ -218,6 +224,8 @@ impl<'a> ReadState<'a> {
             cells: Vec::new(),
             font_language: None,
             current_border_fill: None,
+            current_char_shape: None,
+            current_para_shape: None,
             head_modeled_children: 0,
             body_modeled_children: 0,
             saw_head: false,
@@ -450,6 +458,8 @@ impl<'a> ReadState<'a> {
         match name {
             "FONTFACE" => self.font_language = None,
             "BORDERFILL" => self.current_border_fill = None,
+            "CHARSHAPE" => self.current_char_shape = None,
+            "PARASHAPE" => self.current_para_shape = None,
             "P" => self.finish_paragraph()?,
             "EQUATION" if self.stack.iter().rev().nth(1).map(String::as_str) == Some("TEXT") => {
                 self.finish_equation()?
@@ -592,7 +602,12 @@ impl<'a> ReadState<'a> {
             self.max_resource_id,
         ) {
             self.warn_resource_id_out_of_range("CHARSHAPE", id);
+            // 건너뛴 CHARSHAPE 의 FONTID/RATIO/... 자식이 다른 도형을 덮어쓰지
+            // 않도록 귀속 대상을 비운다 (BORDERFILL 의 *BORDER 처리와 동일).
+            self.current_char_shape = None;
+            return Ok(());
         }
+        self.current_char_shape = Some(id);
         Ok(())
     }
 
@@ -601,7 +616,10 @@ impl<'a> ReadState<'a> {
         name: &str,
         element: &BytesStart<'_>,
     ) -> Result<(), HmlError> {
-        let Some(shape) = self.source.char_shapes.last_mut() else {
+        let Some(shape) = self
+            .current_char_shape
+            .and_then(|index| self.source.char_shapes.get_mut(index))
+        else {
             return Ok(());
         };
         match name {
@@ -630,12 +648,19 @@ impl<'a> ReadState<'a> {
             self.max_resource_id,
         ) {
             self.warn_resource_id_out_of_range("PARASHAPE", id);
+            // 건너뛴 PARASHAPE 의 PARAMARGIN/PARABORDER 자식도 버린다.
+            self.current_para_shape = None;
+            return Ok(());
         }
+        self.current_para_shape = Some(id);
         Ok(())
     }
 
     fn capture_para_margin(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
-        let Some(shape) = self.source.para_shapes.last_mut() else {
+        let Some(shape) = self
+            .current_para_shape
+            .and_then(|index| self.source.para_shapes.get_mut(index))
+        else {
             return Ok(());
         };
         shape.margin_left = parse_attribute(element, b"Left")?.unwrap_or(0);
@@ -654,7 +679,10 @@ impl<'a> ReadState<'a> {
     }
 
     fn capture_para_border(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
-        if let Some(shape) = self.source.para_shapes.last_mut() {
+        if let Some(shape) = self
+            .current_para_shape
+            .and_then(|index| self.source.para_shapes.get_mut(index))
+        {
             shape.border_fill_id = parse_attribute(element, b"BorderFill")?.unwrap_or(0);
         }
         Ok(())

--- a/tests/issue_hml_shape_child_attribution.rs
+++ b/tests/issue_hml_shape_child_attribution.rs
@@ -1,0 +1,85 @@
+//! HML 리소스 자식 요소 귀속 검증.
+//!
+//! CHARSHAPE/PARASHAPE 는 `Id` 속성 위치에 배치되는데(set_indexed), 자식 요소
+//! (FONTID/RATIO/CHARSPACING/RELSIZE/CHAROFFSET, PARAMARGIN/PARABORDER)는
+//! `last_mut()` 로 귀속된다. Id 가 내림차순이거나 상한 초과로 건너뛴 경우
+//! 자식 값이 엉뚱한 리소스에 덮어써진다.
+
+use rhwp::parser::hml::{parse_hml, parse_hml_with_limits, HmlLimits};
+
+fn wrap_head(mapping_table: &str) -> Vec<u8> {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Version="2.91">
+  <HEAD SecCnt="1"><MAPPINGTABLE>{mapping_table}</MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>x</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL />
+</HWPML>"#
+    )
+    .into_bytes()
+}
+
+/// Id 가 내림차순인 CHARSHAPE 목록: 각 도형의 RATIO 는 자기 CHARSHAPE 에 귀속되어야 한다.
+#[test]
+fn charshape_children_follow_out_of_order_ids() {
+    let xml = wrap_head(
+        r#"<CHARSHAPELIST Count="2">
+             <CHARSHAPE Id="1" Height="1100">
+               <RATIO Hangul="90" Latin="90" Hanja="90" Japanese="90" Other="90" Symbol="90" User="90"/>
+             </CHARSHAPE>
+             <CHARSHAPE Id="0" Height="1000">
+               <RATIO Hangul="50" Latin="50" Hanja="50" Japanese="50" Other="50" Symbol="50" User="50"/>
+             </CHARSHAPE>
+           </CHARSHAPELIST>"#,
+    );
+    let result = parse_hml(&xml).expect("parse should succeed");
+    let shapes = &result.document.doc_info.char_shapes;
+    assert_eq!(shapes[1].ratios, [90; 7], "Id=1 의 RATIO 는 90 이어야 한다");
+    assert_eq!(shapes[0].ratios, [50; 7], "Id=0 의 RATIO 는 50 이어야 한다");
+}
+
+/// 상한 초과로 건너뛴 CHARSHAPE 의 자식이 직전 정상 CHARSHAPE 를 오염시키면 안 된다.
+#[test]
+fn skipped_charshape_children_do_not_pollute_previous_shape() {
+    let xml = wrap_head(
+        r#"<CHARSHAPELIST Count="2">
+             <CHARSHAPE Id="0" Height="1000">
+               <RATIO Hangul="100" Latin="100" Hanja="100" Japanese="100" Other="100" Symbol="100" User="100"/>
+             </CHARSHAPE>
+             <CHARSHAPE Id="9" Height="1000">
+               <RATIO Hangul="10" Latin="10" Hanja="10" Japanese="10" Other="10" Symbol="10" User="10"/>
+             </CHARSHAPE>
+           </CHARSHAPELIST>"#,
+    );
+    let limits = HmlLimits {
+        max_resource_id: 4,
+        ..HmlLimits::default()
+    };
+    let result = parse_hml_with_limits(&xml, &limits).expect("parse should succeed");
+    let shapes = &result.document.doc_info.char_shapes;
+    assert_eq!(
+        shapes[0].ratios, [100; 7],
+        "건너뛴 CHARSHAPE Id=9 의 RATIO 가 Id=0 을 덮어쓰면 안 된다"
+    );
+}
+
+/// Id 가 내림차순인 PARASHAPE: PARAMARGIN 은 자기 PARASHAPE 에 귀속되어야 한다.
+#[test]
+fn parashape_margin_follows_out_of_order_ids() {
+    let xml = wrap_head(
+        r#"<PARASHAPELIST Count="2">
+             <PARASHAPE Id="1" Align="Left">
+               <PARAMARGIN Left="700" Right="700" LineSpacing="150"/>
+             </PARASHAPE>
+             <PARASHAPE Id="0" Align="Justify">
+               <PARAMARGIN Left="300" Right="300" LineSpacing="200"/>
+             </PARASHAPE>
+           </PARASHAPELIST>"#,
+    );
+    let result = parse_hml(&xml).expect("parse should succeed");
+    let shapes = &result.document.doc_info.para_shapes;
+    assert_eq!(shapes[1].margin_left, 700, "Id=1 의 PARAMARGIN Left");
+    assert_eq!(shapes[1].line_spacing, 150, "Id=1 의 LineSpacing");
+    assert_eq!(shapes[0].margin_left, 300, "Id=0 의 PARAMARGIN Left");
+    assert_eq!(shapes[0].line_spacing, 200, "Id=0 의 LineSpacing");
+}


### PR DESCRIPTION
Closes #3146

## 결함 요약

HML 파서에서 CHARSHAPE/PARASHAPE 본체는 `Id` 속성 위치에 배치(`set_indexed`)되는데, 자식 요소(FONTID/RATIO/CHARSPACING/RELSIZE/CHAROFFSET, PARAMARGIN/PARABORDER)는 `last_mut()` 로 "마지막 원소"에 귀속됩니다. 두 배치 기준이 어긋나:

1. `Id` 내림차순 입력에서 자식 값이 엉뚱한 도형을 덮어쓰고, 원래 도형은 기본값(`[0; 7]` 장평 등)으로 방치됩니다.
2. #2743 이 도입한 리소스 Id 상한 초과 건너뜀 경로에서는 건너뛴 도형의 자식이 직전 정상 도형을 오염시킵니다 — BORDERFILL 에는 있는 자식 폐기 처리가 CHARSHAPE/PARASHAPE 에는 빠져 있었습니다.

## 재현 조건

- CHARSHAPELIST/PARASHAPELIST 에서 `Id` 가 비순차(내림차순)로 나열된 HML 문서
- 또는 `HmlLimits::max_resource_id` 초과 Id 도형에 자식 요소가 붙은 문서

## 수정 내용

`current_border_fill` 과 동일한 패턴으로 `current_char_shape` / `current_para_shape` (`Option<usize>`) 귀속 인덱스를 추가:

- 시작 태그에서 `set_indexed` 삽입 위치를 기록, 상한 초과 건너뜀 시 `None`
- 자식 요소는 `last_mut()` 대신 기록된 인덱스로 귀속, `None` 이면 폐기
- 요소 종료 시 인덱스 해제

## red→green 결과

재현 테스트 3건 추가(`tests/issue_hml_shape_child_attribution.rs`), 수정 커밋 원복 시 전부 FAIL:

- `charshape_children_follow_out_of_order_ids` — `Id=1 의 RATIO 는 90 이어야 한다` assert 실패 (실제 `[0; 7]`)
- `skipped_charshape_children_do_not_pollute_previous_shape` — `건너뛴 CHARSHAPE Id=9 의 RATIO 가 Id=0 을 덮어쓰면 안 된다` assert 실패 (`[100; 7]` 기대, 실제 `[10; 7]`)
- `parashape_margin_follows_out_of_order_ids` — `Id=1 의 PARAMARGIN Left` 700 기대, 실제 0

수정 후 3건 전부 PASS.

## 검증 명령

```
cargo test --test issue_hml_shape_child_attribution   # 3 passed
```

기존 HML 파서 테스트 회귀 없음.

## 관련 코드

- `src/parser/hml/reader.rs` (+34/-3) — 귀속 인덱스 추적
- `tests/issue_hml_shape_child_attribution.rs` (신규, 재현 테스트 3건)
- `mydocs/report/task_m100_3146_report.md` — 처리결과 문서
- 기준: upstream/devel `49469c1f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
