### PR TITLE
fix(hwp5): 글자겹침(tcps) 직렬화 비BMP 절단·u8 카운트 wraparound 방어 (#3143)

### DIFF
--- a/mydocs/report/task_m100_3143_report.md
+++ b/mydocs/report/task_m100_3143_report.md
@@ -1,0 +1,49 @@
+# task-m100-3143: 글자겹침(tcps) 직렬화 미검증 캐스팅 방어
+
+## 이슈
+
+#3143 HWP5 글자겹침(CTRL_TCPS) 직렬화기의 미검증 캐스팅 2건:
+
+1. **비BMP 문자 절단** — `ch as u16` 캐스팅으로 하위 16비트만 기록.
+   파서(`parse_char_overlap`)는 서로게이트 쌍을 디코딩하므로 왕복이 깨진다.
+2. **u8 카운트 wraparound** — charshape ID 카운트를 `len() as u8` 로 기록.
+   HWPX `<hp:compose>` 는 `<hp:charPr>` 자식 수 제한이 없어 256개 이상 입력 시
+   카운트 필드(256→0)와 실제 기록 데이터가 어긋난 손상 레코드가 만들어진다.
+
+## 원인 분석
+
+`src/serializer/control.rs` `serialize_char_overlap`:
+
+- chars 를 `ch as u16` 으로 단순 캐스팅 → U+10000 이상에서 절단.
+- 카운트 필드(u16/u8)에 상한 검사 없음 → wraparound 시 카운트-데이터 불일치.
+
+## 수정 내용
+
+- chars 를 `encode_utf16()` 으로 서로게이트 쌍 포함 인코딩 (파서와 대칭).
+- 카운트 필드(u16/u8)를 타입 한계로 상한 절단하고, 기록 배열도 함께 절단해
+  카운트와 실제 기록 데이터가 항상 일치하도록 방어 (손상 레코드 방지).
+
+## red→green 결과
+
+회귀 테스트 2건 추가 (`src/serializer/control/tests.rs`), 수정 전 FAIL 확인:
+
+- `char_overlap_non_bmp_char_roundtrip` — U+1D400(𝐀) 왕복 시
+  (수정 전: `비BMP 문자가 왕복 보존되어야 함` assert 실패 — 하위 16비트 문자로 변형)
+- `char_overlap_256_char_shape_ids_no_wraparound` — ID 256개 입력 시
+  (수정 전: `카운트 필드(0)와 실제 기록된 ID 바이트(1024)가 어긋남 — u8 wraparound`)
+
+수정 후 2건 전부 PASS.
+
+## 검증 명령
+
+```
+cargo test char_overlap
+```
+
+전량 PASS. `cargo fmt --check` 통과(후속 style 커밋 `5527c211` 로 정렬).
+
+## 관련 코드
+
+- `src/serializer/control.rs` — encode_utf16 인코딩·카운트 상한 절단 (+32/-4)
+- `src/serializer/control/tests.rs` — 회귀 테스트 2건 (+59)
+- 기준 커밋: upstream/devel `6f34e9b2`

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -960,17 +960,41 @@ fn serialize_bookmark_ctrl_data(bm: &Bookmark) -> Option<Vec<u8>> {
 }
 
 /// 글자 겹침 직렬화 (HWP 스펙 표 152)
+///
+/// [#3143] 미검증 `as` 캐스팅 방어:
+/// - 겹칠 글자는 `encode_utf16()` 으로 서로게이트 쌍을 포함해 인코딩하고,
+///   카운트는 파서(parse_char_overlap)와 대칭인 UTF-16 코드유닛 수로 기록한다.
+///   (기존 `ch as u16` 은 비BMP 문자를 하위 16비트로 절단했다.)
+/// - 카운트 필드(u16/u8)는 타입 한계로 상한을 두고 기록 배열도 함께 절단해
+///   카운트와 실제 데이터가 항상 일치하도록 보장한다.
 fn serialize_char_overlap(co: &CharOverlap) -> Vec<u8> {
     let mut w = ByteWriter::new();
-    w.write_u16(co.chars.len() as u16).unwrap();
+
+    // 겹칠 글자: WCHAR(UTF-16LE) 배열, 서로게이트 쌍 포함
+    let mut utf16: Vec<u16> = Vec::with_capacity(co.chars.len());
+    let mut buf = [0u16; 2];
     for &ch in &co.chars {
-        w.write_u16(ch as u16).unwrap();
+        utf16.extend_from_slice(ch.encode_utf16(&mut buf));
     }
+    // u16 카운트 필드 wraparound 방지 (스펙상 최대 9글자라 실사용에선 도달하지 않음)
+    utf16.truncate(u16::MAX as usize);
+    // 절단 끝이 홀로 남은 상위 서로게이트면 함께 제거
+    if matches!(utf16.last(), Some(&last) if (0xD800..=0xDBFF).contains(&last)) {
+        utf16.pop();
+    }
+    w.write_u16(utf16.len() as u16).unwrap();
+    for unit in utf16 {
+        w.write_u16(unit).unwrap();
+    }
+
     w.write_u8(co.border_type).unwrap();
     w.write_i8(co.inner_char_size).unwrap();
     w.write_u8(co.expansion).unwrap();
-    w.write_u8(co.char_shape_ids.len() as u8).unwrap();
-    for &id in &co.char_shape_ids {
+
+    // charshape 카운트: u8 wraparound 방지 — 카운트와 기록 개수를 함께 상한 절단
+    let n_ids = co.char_shape_ids.len().min(u8::MAX as usize);
+    w.write_u8(n_ids as u8).unwrap();
+    for &id in &co.char_shape_ids[..n_ids] {
         w.write_u32(id).unwrap();
     }
     w.into_bytes()

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -967,7 +967,11 @@ fn char_overlap_non_bmp_char_roundtrip() {
     let Control::CharOverlap(r) = parsed else {
         panic!("CharOverlap 이 아님");
     };
-    assert_eq!(r.chars, vec!['\u{1D400}'], "비BMP 문자가 왕복 보존되어야 함");
+    assert_eq!(
+        r.chars,
+        vec!['\u{1D400}'],
+        "비BMP 문자가 왕복 보존되어야 함"
+    );
     assert_eq!(r.char_shape_ids, vec![3]);
 }
 

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -948,3 +948,62 @@ fn issue2715_shape_without_caption_emits_no_list_header() {
         "캡션 없는 도형은 LIST_HEADER 를 방출하면 안 됨"
     );
 }
+
+/// [#3143] 글자겹침(tcps) 라운드트립: 비BMP 문자(서로게이트 쌍)가 보존되어야 한다.
+///
+/// 파서(parse_char_overlap)는 WCHAR 배열에서 서로게이트 쌍을 디코딩하지만,
+/// 직렬화기는 `ch as u16` 절단 캐스팅으로 하위 16비트만 기록해 왕복이 깨진다.
+#[test]
+fn char_overlap_non_bmp_char_roundtrip() {
+    let co = CharOverlap {
+        chars: vec!['\u{1D400}'], // 𝐀 (MATHEMATICAL BOLD CAPITAL A)
+        border_type: 1,
+        inner_char_size: 100,
+        expansion: 0,
+        char_shape_ids: vec![3],
+    };
+    let data = serialize_char_overlap(&co);
+    let parsed = crate::parser::control::parse_control(tags::CTRL_TCPS, &data, &[]);
+    let Control::CharOverlap(r) = parsed else {
+        panic!("CharOverlap 이 아님");
+    };
+    assert_eq!(r.chars, vec!['\u{1D400}'], "비BMP 문자가 왕복 보존되어야 함");
+    assert_eq!(r.char_shape_ids, vec![3]);
+}
+
+/// [#3143] 글자겹침(tcps) charshape 카운트 필드: u8 랩어라운드로 레코드가 손상되면 안 된다.
+///
+/// HWPX `<hp:compose>` 는 `<hp:charPr>` 자식 수에 제한이 없어 256개 이상이 들어올 수 있고,
+/// 직렬화기의 `len() as u8` 캐스팅이 wraparound 되면 카운트 필드(256→0)와 실제 기록된
+/// ID 개수가 어긋난 손상 레코드가 만들어진다.
+#[test]
+fn char_overlap_256_char_shape_ids_no_wraparound() {
+    let co = CharOverlap {
+        chars: vec!['가'],
+        border_type: 0,
+        inner_char_size: 100,
+        expansion: 0,
+        char_shape_ids: (0u32..256).collect(),
+    };
+    let data = serialize_char_overlap(&co);
+    // 카운트 바이트: chars 카운트(2) + WCHAR(2×1) + 테두리(1) + 크기(1) + 펼침(1) = offset 7
+    let cnt = data[7];
+    // 기록된 ID 바이트 수와 카운트 필드가 일치해야 한다 (손상 레코드 금지)
+    let id_bytes = data.len() - 8;
+    assert_eq!(
+        cnt as usize * 4,
+        id_bytes,
+        "카운트 필드({})와 실제 기록된 ID 바이트({})가 어긋남 — u8 wraparound",
+        cnt,
+        id_bytes
+    );
+    // 왕복 시 charshape ID 가 전량 소실되면 안 된다
+    let parsed = crate::parser::control::parse_control(tags::CTRL_TCPS, &data, &[]);
+    let Control::CharOverlap(r) = parsed else {
+        panic!("CharOverlap 이 아님");
+    };
+    assert!(
+        !r.char_shape_ids.is_empty(),
+        "u8 카운트 wraparound 로 charshape ID 전량 소실"
+    );
+}


### PR DESCRIPTION
Closes #3143

## 결함 요약

HWP5 글자겹침(CTRL_TCPS) 직렬화기 `serialize_char_overlap` 의 미검증 캐스팅 2건:

1. **비BMP 문자 절단** — `ch as u16` 캐스팅으로 하위 16비트만 기록. 파서(`parse_char_overlap`)는 서로게이트 쌍을 디코딩하므로 왕복이 깨집니다.
2. **u8 카운트 wraparound** — charshape ID 카운트를 `len() as u8` 로 기록. HWPX `<hp:compose>` 는 `<hp:charPr>` 자식 수 제한이 없어 256개 이상 입력 시 카운트 필드(256→0)와 실제 기록 데이터가 어긋난 손상 레코드가 생성됩니다.

## 재현 조건

- U+10000 이상(비BMP) 문자가 포함된 글자겹침을 HWP5 로 직렬화
- charshape ID 256개 이상인 `<hp:compose>` 를 HWP5 로 직렬화

## 수정 내용

- chars 를 `encode_utf16()` 으로 서로게이트 쌍 포함 인코딩 (파서와 대칭)
- 카운트 필드(u16/u8)를 타입 한계로 상한 절단하고 기록 배열도 함께 절단해 카운트-데이터 불일치 손상 레코드 방지

## red→green 결과

회귀 테스트 2건 추가(`src/serializer/control/tests.rs`), 수정 커밋 원복 시 FAIL:

- `char_overlap_non_bmp_char_roundtrip` — `비BMP 문자가 왕복 보존되어야 함` assert 실패 (U+1D400 이 하위 16비트 문자로 변형)
- `char_overlap_256_char_shape_ids_no_wraparound` — `카운트 필드(0)와 실제 기록된 ID 바이트(1024)가 어긋남 — u8 wraparound` assert 실패

수정 후 2건 전부 PASS.

## 검증 명령

```
cargo test char_overlap   # 전량 PASS
cargo fmt --check          # 통과 (style 커밋 5527c211 로 정렬)
```

## 관련 코드

- `src/serializer/control.rs` (+32/-4) — encode_utf16 인코딩·카운트 상한 절단
- `src/serializer/control/tests.rs` (+59) — 회귀 테스트 2건
- `mydocs/report/task_m100_3143_report.md` — 처리결과 문서
- 기준: upstream/devel `6f34e9b2`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
