### PR TITLE
fix(studio): 책갈피 대화상자 재사용 시 sortMode 라디오 초기 상태로 리셋 (#3144)

### DIFF
--- a/mydocs/report/task_m100_3144_report.md
+++ b/mydocs/report/task_m100_3144_report.md
@@ -1,0 +1,28 @@
+# task-m100-3144: 책갈피 대화상자 재사용 시 정렬 상태 불일치 수정
+
+## 이슈
+
+#3144 책갈피 대화상자 재사용 시 정렬 상태 불일치 — 라디오는 '위치'로 초기화되지만
+sortMode는 이전 값 유지
+
+## 원인
+
+`rhwp-studio/src/command/commands/insert.ts`는 `BookmarkDialog`를 모듈 전역
+싱글턴(`bookmarkDialog`)으로 한 번만 생성해 재사용한다. `show()`는 `build()`로
+DOM을 매번 새로 만들어 정렬 라디오가 항상 '위치(P)' 체크 상태로 생성되지만,
+인스턴스 필드 `sortMode`는 리셋되지 않아 이전 세션의 `'name'`이 남는다. 이어지는
+`refreshList()`가 stale `sortMode`로 정렬해 라디오 표시와 목록 정렬이 어긋난다.
+
+#3037(필드 입력 대화상자 재사용 시 이전 값 유지)과 같은 결함 클래스다.
+
+## 수정
+
+`bookmark-dialog.ts`의 `show()`에서 `refreshList()` 호출 전에
+`this.sortMode = 'position'`으로 리셋해 새로 만들어지는 라디오 초기 상태와
+일치시켰다.
+
+## 검증
+
+- `rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts` 신규 테스트 추가
+  (`field-insert-dialog-reset.test.ts`와 동일한 소스 문자열 검사 패턴)
+- 수정 전 red 확인 → 수정 후 `node --test tests/bookmark-dialog-sort-reset.test.ts` 통과

--- a/rhwp-studio/src/ui/bookmark-dialog.ts
+++ b/rhwp-studio/src/ui/bookmark-dialog.ts
@@ -43,6 +43,11 @@ export class BookmarkDialog {
     };
     document.addEventListener('keydown', this.captureHandler, true);
 
+    // 싱글턴으로 재사용되는데 build() 가 라디오를 매번 '위치(P)' 체크 상태로 새로
+    // 만들므로, 이전 세션의 sortMode('name')가 남으면 라디오 표시와 실제 목록
+    // 정렬이 어긋난다 — 라디오 초기 상태와 일치하도록 리셋한다. (#3144)
+    this.sortMode = 'position';
+
     this.refreshList();
     this.suggestName();
     this.nameInput.focus();

--- a/rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts
+++ b/rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 책갈피 대화상자는 commands/insert.ts 에서 모듈 전역 싱글턴으로 재사용된다.
+// show() 는 build() 로 DOM 을 매번 새로 만들기 때문에 정렬 라디오는 항상
+// '위치(P)' 가 선택된 상태로 나타나지만, 인스턴스 필드 sortMode 는 이전 세션
+// 값('name')이 남는다 → 라디오 표시와 실제 목록 정렬이 어긋난다.
+// show() 는 refreshList() 전에 sortMode 를 초기값 'position' 으로 리셋해야 한다.
+test('책갈피 대화상자는 열릴 때마다 sortMode를 라디오 초기 상태(position)로 리셋한다', () => {
+  const dialog = source('src/ui/bookmark-dialog.ts');
+  const showStart = dialog.indexOf('show(): void');
+  assert.notEqual(showStart, -1, 'show() 를 찾을 수 있어야 한다');
+  const hideStart = dialog.indexOf('hide(): void', showStart);
+  const showBody = dialog.slice(showStart, hideStart === -1 ? undefined : hideStart);
+
+  assert.match(
+    showBody,
+    /this\.sortMode\s*=\s*'position'/,
+    'show() 는 refreshList() 전에 sortMode 를 position 으로 리셋해야 한다',
+  );
+
+  const resetIdx = showBody.search(/this\.sortMode\s*=\s*'position'/);
+  const refreshIdx = showBody.indexOf('this.refreshList()');
+  assert.ok(
+    resetIdx !== -1 && refreshIdx !== -1 && resetIdx < refreshIdx,
+    'sortMode 리셋은 refreshList() 호출보다 앞서야 한다',
+  );
+});


### PR DESCRIPTION
Closes #3144

## 결함 요약

책갈피 대화상자 재사용 시 정렬 상태 불일치 — 라디오는 '위치(P)'로 초기화되지만 인스턴스 필드 `sortMode` 는 이전 값('name')이 남아, 라디오 표시와 목록 정렬이 어긋납니다.

`rhwp-studio/src/command/commands/insert.ts` 가 `BookmarkDialog` 를 모듈 전역 싱글턴으로 재사용하는데, `show()` 는 `build()` 로 DOM 을 매번 새로 만들어 라디오는 항상 '위치' 체크 상태로 생성되지만 `sortMode` 필드는 리셋되지 않아 이어지는 `refreshList()` 가 stale 값으로 정렬합니다. #3037(필드 입력 대화상자 재사용 시 이전 값 유지)과 같은 결함 클래스입니다.

## 재현 조건

1. 책갈피 대화상자를 열고 정렬을 '이름'으로 변경 후 닫기
2. 대화상자를 다시 열기 → 라디오는 '위치' 체크인데 목록은 이름순 정렬

## 수정 내용

`rhwp-studio/src/ui/bookmark-dialog.ts` `show()` 에서 `refreshList()` 호출 전에 `this.sortMode = 'position'` 으로 리셋해 새로 생성되는 라디오 초기 상태와 일치시켰습니다.

## red→green 결과

- `rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts` 신규 (`field-insert-dialog-reset.test.ts` 와 동일한 소스 문자열 검사 패턴)
- 수정 전 red 확인(리셋 코드 부재로 FAIL) → 수정 후 PASS

## 검증 명령

```
node --test tests/bookmark-dialog-sort-reset.test.ts   # (rhwp-studio) 통과
```

## 관련 코드

- `rhwp-studio/src/ui/bookmark-dialog.ts` (+5)
- `rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts` (신규)
- `mydocs/report/task_m100_3144_report.md` — 처리결과 문서
- 기준: upstream/devel `49469c1f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
