### PR TITLE
fix(studio): 수식 편집기 재사용 시 기호 검색어·결과 드롭다운 초기화 (#3145)

### DIFF
--- a/mydocs/report/task_m100_3145_report.md
+++ b/mydocs/report/task_m100_3145_report.md
@@ -1,0 +1,29 @@
+# task-m100-3145: 수식 편집기 재사용 시 기호 검색 상태 리셋 누락 수정
+
+## 이슈
+
+#3145 수식 편집기 대화상자 재사용 시 기호 검색어·결과 드롭다운이 초기화되지
+않고 남음
+
+## 원인
+
+`rhwp-studio/src/command/commands/insert.ts`는 `EquationEditorDialog`를 모듈
+전역 싱글턴(`equationEditorDialog`)으로 생성해 재사용하고, `build()`는 `built`
+플래그로 최초 1회만 실행되어 DOM이 인스턴스에 계속 남는다. `open()`은
+scriptArea/fontSizeInput/colorInput/입력 모드는 문서 값으로 리셋하지만 기호
+검색 입력(`searchInput`)과 결과 드롭다운(`searchResults`)은 건드리지 않고,
+`hide()`도 autocomplete 드롭다운만 닫는다. 그 결과 닫았다 다시 열면 이전
+검색어와 펼쳐진 결과 목록이 그대로 남았다.
+
+#3037(필드 입력 대화상자 재사용 시 이전 값 유지)과 같은 결함 클래스다.
+
+## 수정
+
+`equation-editor-dialog.ts`의 `open()`에서 `searchInput.value`를 비우고
+`searchResults`를 `display: none`으로 닫아 기호 검색 상태를 초기화했다.
+
+## 검증
+
+- `rhwp-studio/tests/equation-editor-search-reset.test.ts` 신규 테스트 추가
+  (`field-insert-dialog-reset.test.ts`와 동일한 소스 문자열 검사 패턴)
+- 수정 전 red 확인 → 수정 후 `node --test tests/equation-editor-search-reset.test.ts` 통과

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -273,6 +273,11 @@ export class EquationEditorDialog {
     this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100));
     this.colorInput.value = colorRefToHex(this.origProps.color);
 
+    // 싱글턴으로 재사용 + build() 는 1회만 실행되므로 이전 세션의 기호 검색어와
+    // 펼쳐진 결과 드롭다운이 남지 않도록 초기화한다. (#3145)
+    this.searchInput.value = '';
+    this.searchResults.style.display = 'none';
+
     // 기존 스크립트에 \ 가 있으면 LaTeX 모드로 시작
     if (this.origProps.script && /\\[a-zA-Z]/.test(this.origProps.script)) {
       this.setMode('latex');

--- a/rhwp-studio/tests/equation-editor-search-reset.test.ts
+++ b/rhwp-studio/tests/equation-editor-search-reset.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 수식 편집기는 commands/insert.ts 에서 모듈 전역 싱글턴으로 재사용되고,
+// build() 는 built 플래그로 최초 1회만 실행되어 DOM 이 인스턴스에 남는다.
+// open() 은 scriptArea/fontSize/color/mode 는 리셋하지만 기호 검색 입력
+// (searchInput)과 검색 결과 드롭다운(searchResults)은 건드리지 않아,
+// 닫았다 다시 열면 이전 검색어와 펼쳐진 결과 목록이 그대로 남는다.
+test('수식 편집기 대화상자는 열릴 때마다 기호 검색 입력과 결과 드롭다운을 초기화한다', () => {
+  const dialog = source('src/ui/equation-editor-dialog.ts');
+  const openStart = dialog.indexOf('open(sec: number');
+  assert.notEqual(openStart, -1, 'open() 을 찾을 수 있어야 한다');
+  const openEnd = dialog.indexOf('hide(): void', openStart);
+  const openBody = dialog.slice(openStart, openEnd === -1 ? undefined : openEnd);
+
+  assert.match(
+    openBody,
+    /this\.searchInput\.value\s*=\s*''/,
+    'open() 은 이전 검색어를 비워야 한다',
+  );
+  assert.match(
+    openBody,
+    /this\.searchResults\.style\.display\s*=\s*'none'/,
+    'open() 은 검색 결과 드롭다운을 닫아야 한다',
+  );
+});


### PR DESCRIPTION
Closes #3145

## 결함 요약

수식 편집기 대화상자 재사용 시 기호 검색어와 결과 드롭다운이 초기화되지 않고 남습니다.

`rhwp-studio/src/command/commands/insert.ts` 가 `EquationEditorDialog` 를 모듈 전역 싱글턴으로 재사용하고 `build()` 는 `built` 플래그로 최초 1회만 실행되어 DOM 이 인스턴스에 계속 남습니다. `open()` 은 scriptArea/fontSizeInput/colorInput/입력 모드는 문서 값으로 리셋하지만 기호 검색 입력(`searchInput`)과 결과 드롭다운(`searchResults`)은 건드리지 않고, `hide()` 도 autocomplete 드롭다운만 닫습니다. #3037 과 같은 결함 클래스입니다.

## 재현 조건

1. 수식 편집기를 열고 기호 검색어 입력(결과 드롭다운 펼쳐짐) 후 닫기
2. 수식 편집기를 다시 열기 → 이전 검색어와 펼쳐진 결과 목록이 그대로 남음

## 수정 내용

`rhwp-studio/src/ui/equation-editor-dialog.ts` `open()` 에서 `searchInput.value` 를 비우고 `searchResults` 를 `display: none` 으로 닫아 기호 검색 상태를 초기화했습니다.

## red→green 결과

- `rhwp-studio/tests/equation-editor-search-reset.test.ts` 신규 (`field-insert-dialog-reset.test.ts` 와 동일한 소스 문자열 검사 패턴)
- 수정 전 red 확인(리셋 코드 부재로 FAIL) → 수정 후 PASS

## 검증 명령

```
node --test tests/equation-editor-search-reset.test.ts   # (rhwp-studio) 통과
```

## 관련 코드

- `rhwp-studio/src/ui/equation-editor-dialog.ts` (+5)
- `rhwp-studio/tests/equation-editor-search-reset.test.ts` (신규)
- `mydocs/report/task_m100_3145_report.md` — 처리결과 문서
- 기준: upstream/devel `49469c1f`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
