### PR TITLE
fix(hwp3): 각주 옵션·분리선 길이 IR 배선 2건 — kevin9327 HWP3 축 통합 2차

### DIFF
--- a/mydocs/report/task_m100_3017_report.md
+++ b/mydocs/report/task_m100_3017_report.md
@@ -1,0 +1,51 @@
+# task_m100_3017: HWP3 각주 분리선 길이(footnote_line_width) 미매핑 수정
+
+## 이슈
+
+edwardkim/rhwp#3017
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 HWP3 문서 정보 파서가 각주 옵션 필드
+`footnote_line_width`(HWP3 스펙 §3.2, offset 111: 각주 분리선 길이 종류.
+0=5cm, 1=본문 폭의 1/3, 2=단 너비, 3=없음)를 `Hwp3DocInfo`로 파싱만 하고,
+IR(`SectionDef.footnote_shape.separator_length`)로 전혀 전달하지 않았다.
+결과적으로 HWP3 문서의 실제 설정값과 무관하게 각주 분리선 길이가 항상
+기본값 0(선 없음)으로 렌더링되는 버그였다.
+
+## 원인
+
+`section_def.page_def` 구성 직후, 섹션 정의(SectionDef)를 만드는 지점에서
+`doc_info.footnote_line_width`를 읽어 쓰는 코드가 없었다. 필드 자체는
+`records.rs`의 `Hwp3DocInfo`에 정의되고 바이트 스트림에서 정상적으로
+읽히지만(`records.rs:90`), 이후 어디에서도 참조되지 않았다.
+
+## 수정
+
+- `hwp3_footnote_separator_length(footnote_line_width: u8, column_width_hu: i32) -> i32`
+  순수 함수를 추가해 스펙 4종 값을 HWPUNIT 길이로 변환.
+  - 0 → 5cm(≈14160 HWPUNIT, 1mm≈283.2 HWPUNIT)
+  - 1 → 본문 폭(`column_width_hu`)의 1/3
+  - 2 → 본문 폭 그대로(단 너비)
+  - 3 이상 → 0(없음)
+- `section_def.footnote_shape.separator_length` / `separator_line_type` /
+  `separator_line_width`를 이 값으로 채우도록 `section_def.page_def` 구성
+  직후에 3줄 추가.
+- 단위 테스트 `hwp3_maps_footnote_separator_length`로 0/1/2/3 네 케이스
+  매핑을 직접 검증.
+
+## 검증
+
+- `cargo check --lib`: 통과.
+- `cargo test --lib hwp3_maps_footnote_separator_length`: 통과(1 passed).
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`: 적용.
+
+## 범위
+
+- 변경 파일: `src/parser/hwp3/mod.rs` (순수 함수 + 3줄 배선 + 단위 테스트).
+- 렌더러, 레이아웃, 공통 IR 등 다른 계층에는 손대지 않음(HWP3 전용 해석은
+  `src/parser/hwp3/` 안에서 종료).
+- 후속 과제: 각주 분리선의 `separator_line_type`/`separator_line_width`
+  자체를 결정하는 HWP3 스펙 필드가 별도로 없어 관례값(실선/굵기 1)을
+  사용했다. 실제 문서 대량 검증으로 값이 다르면 후속 조정이 필요할 수
+  있다.

--- a/mydocs/report/task_m100_3021_report.md
+++ b/mydocs/report/task_m100_3021_report.md
@@ -1,0 +1,50 @@
+# 완료 보고서 — Task M100-3021
+
+- 이슈: #3021
+- 제목: HWP3 doc_info.footnote_bracket(각주 옵션) 파싱만 되고 미주 모양에 배선되지 않음
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3021-hwp3-footnote-bracket`
+
+## 1. 완료 내용
+
+#3006 (`Hwp3DocInfo.hide_empty_line` 배선 누락) 처리 시 사용한 방법 — doc_info 인접
+플래그를 `impl Hwp3DocInfo`와 `SectionDef` 조립부(`src/parser/hwp3/mod.rs`)에서
+전수 대조 — 를 이어서 적용해 offset 110 `footnote_bracket`(각주 옵션)에서 동일한 유형의
+문제를 찾았다.
+
+`Hwp3DocInfo::read`(`src/parser/hwp3/records.rs`)는 스펙(`mydocs/tech/한글문서파일구조3.0.md:244`,
+`110 | echar | ')' = 각주 번호에 ')'를 붙임, 0=안 붙임 | 각주 옵션`)대로 `footnote_bracket: u8`을
+정확히 파싱하지만, `hwp3_default_endnote_shape()`은 공통 IR `FootnoteShape.suffix_char`을
+항상 `')'`로 하드코딩해 이 값을 사용하지 않았다. HWP5(`src/parser/doc_info.rs`)와
+HWPX(`src/parser/hwpx/section.rs:901,908`)는 각각 원본 값으로 `suffix_char`을 채우므로
+HWP3만 이 옵션을 무시하는 genuine gap이었다. 사용자가 한/글에서 "각주 번호 뒤 ')' 안 붙임"으로
+설정한 HWP3 문서도 미주 번호 뒤에 항상 ')' 가 렌더링되는 시각 차이가 있었다.
+
+## 2. 주요 변경
+
+- `src/parser/hwp3/mod.rs`
+  - `hwp3_default_endnote_shape()` → `hwp3_default_endnote_shape(bracket: bool)`:
+    `suffix_char`을 `bracket`에 따라 `')'` 또는 `'\0'`(안 붙임)으로 결정
+  - `fixup_hwp3_notes()`에 `footnote_bracket: bool` 매개변수 추가, 호출부에
+    `doc_info.footnote_bracket != 0` 전달
+  - 단위 테스트 `issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag` 추가
+    (bracket=true → `')'`, bracket=false → `'\0'` 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib hwp3::` (14 passed, 신규 테스트 포함)
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`
+
+## 4. 범위 밖 후속 과제
+
+- `hwp3_default_endnote_shape`의 `start_number: 1` 도 `doc_info.footnote_start_number`를
+  직접 반영하지 않고 하드코딩되어 있다(실제 번호 매기기 시작값은
+  `doc.doc_properties.footnote_start_num` 경유로 별도 적용되어 렌더 결과에는 영향 없음).
+  `FootnoteShape.start_number`는 메타데이터 필드라 별도 검증이 필요해 이번 타스크
+  범위에서는 제외했다.
+- 각주(footnote, `SectionDef.footnote_shape`) 자체는 HWP3 파서에서 전혀 조립되지 않아
+  항상 `Default`값이다. 이는 offset 하나짜리 배선 누락보다 훨씬 큰 범위의 기능 격차라
+  별도 타스크로 분리해야 한다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -4037,7 +4037,6 @@ mod tests {
         assert_eq!(hwp3_footnote_separator_length(1, 9000), 3000); // 본문 폭의 1/3
         assert_eq!(hwp3_footnote_separator_length(2, 9000), 9000); // 단 너비
         assert_eq!(hwp3_footnote_separator_length(3, 9000), 0); // 없음
-
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -444,14 +444,17 @@ fn apply_hwp3_encrypted_flag(
     }
 }
 
-fn hwp3_default_endnote_shape() -> crate::model::footnote::FootnoteShape {
+fn hwp3_default_endnote_shape(bracket: bool) -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
     };
 
     let mut shape = FootnoteShape {
         number_format: NumberFormat::Digit,
-        suffix_char: ')',
+        // doc_info offset 110 "각주 옵션": ')' = 번호에 ')' 붙임, 0 = 안 붙임.
+        // 파싱만 되고(footnote_bracket) 항상 ')' 로 하드코딩되어 옵션을 끈 문서도
+        // ')' 가 표시되던 문제.
+        suffix_char: if bracket { ')' } else { '\0' },
         start_number: 1,
         separator_margin_top: 864,
         note_spacing: 576,
@@ -3328,7 +3331,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     super::populate_link_image_paths(&mut doc);
 
     crate::parser::assign_auto_numbers(&mut doc);
-    fixup_hwp3_notes(&mut doc);
+    fixup_hwp3_notes(&mut doc, doc_info.footnote_bracket != 0);
     fixup_hwp3_outline_fields(&mut doc);
     fixup_hwp3_picture_numbers(&mut doc);
     fixup_hwp3_outline_bullets(&mut doc);
@@ -3344,7 +3347,7 @@ struct Hwp3NoteFixupState {
     has_endnote: bool,
 }
 
-fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
+fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, footnote_bracket: bool) {
     let para_shapes = doc.doc_info.para_shapes.clone();
     let mut state = Hwp3NoteFixupState {
         footnote_number: doc.doc_properties.footnote_start_num.max(1),
@@ -3360,7 +3363,7 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document) {
 
     if state.has_endnote {
         for section in &mut doc.sections {
-            section.section_def.endnote_shape = hwp3_default_endnote_shape();
+            section.section_def.endnote_shape = hwp3_default_endnote_shape(footnote_bracket);
             ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
@@ -3989,6 +3992,18 @@ mod tests {
             1,
             "border_connection이 attr1 bit 28로 배선되어야 함"
         );
+    }
+
+    #[test]
+    fn issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag() {
+        // doc_info offset 110 "각주 옵션" footnote_bracket 이 파싱만 되고 항상 ')' 로
+        // 하드코딩되어, 옵션을 끈(footnote_bracket=0) 문서도 미주 번호에 ')' 가 붙던 문제.
+        let on = hwp3_default_endnote_shape(true);
+        assert_eq!(on.suffix_char, ')');
+
+        let off = hwp3_default_endnote_shape(false);
+        assert_eq!(off.suffix_char, '\0');
+
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -421,6 +421,17 @@ fn hwp3_para_flow_spacing(para_shape: Option<&crate::model::style::ParaShape>) -
     )
 }
 
+/// HWP3 스펙 offset 111 각주 분리선 길이 종류(0=5cm, 1=본문 폭의 1/3, 2=단 너비,
+/// 3 이상=없음)를 HWPUNIT 길이로 변환한다.
+fn hwp3_footnote_separator_length(footnote_line_width: u8, column_width_hu: i32) -> i32 {
+    match footnote_line_width {
+        0 => 14160, // 5cm ≈ 283.2 HWPUNIT/mm * 50mm
+        1 => column_width_hu / 3,
+        2 => column_width_hu,
+        _ => 0,
+    }
+}
+
 fn hwp3_note_column_width_hu(column_width_hu: i32) -> i32 {
     // HWP3 미주는 HWPX 기준 출력처럼 본문 영역 안에서 2단으로 흘린다.
     // 한글 97 계열의 기본 미주 단 간격은 5mm에 해당하는 1416 HWPUNIT로 본다.
@@ -3275,6 +3286,18 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     // 항상 정상 높이로 렌더되던 문제 (#issue).
     section_def.hide_empty_line = hwp3_hide_empty_line(&doc_info);
 
+    // HWP3 스펙(한글문서파일구조3.0.md:245) offset 111 각주 분리선 길이 종류.
+    // 기존 코드는 doc_info.footnote_line_width 를 파싱만 하고 버려 항상
+    // separator_length=0(선 없음)으로 렌더링했다.
+    section_def.footnote_shape.separator_length =
+        hwp3_footnote_separator_length(doc_info.footnote_line_width, column_width_hu);
+    section_def.footnote_shape.separator_line_type = if doc_info.footnote_line_width == 3 {
+        0
+    } else {
+        1
+    };
+    section_def.footnote_shape.separator_line_width = 1;
+
     // [Task #877 Stage 4] HWP3 doc_info.border_type / border_margin → SectionDef.page_border_fill
     // 변환. HWP3 spec §3.2 (문서 정보) offset 112-121 의 페이지 테두리 정보. type=0 이면 없음,
     // 그 외 = 실선 등. 한컴 viewer 의 PDF 출력에 페이지 외곽선 박스 표시 (sample16 표지/목차/
@@ -4003,6 +4026,17 @@ mod tests {
 
         let off = hwp3_default_endnote_shape(false);
         assert_eq!(off.suffix_char, '\0');
+    }
+
+    #[test]
+    fn hwp3_maps_footnote_separator_length() {
+        // doc_info.footnote_line_width(스펙 offset 111, 각주 분리선 길이 종류)를
+        // 파싱만 하고 버리던 기존 버그: section_def.footnote_shape.separator_length 가
+        // 값과 무관하게 항상 0(선 없음)으로 남았다.
+        assert_eq!(hwp3_footnote_separator_length(0, 9999), 14160); // 5cm 고정
+        assert_eq!(hwp3_footnote_separator_length(1, 9000), 3000); // 본문 폭의 1/3
+        assert_eq!(hwp3_footnote_separator_length(2, 9000), 9000); // 단 너비
+        assert_eq!(hwp3_footnote_separator_length(3, 9000), 0); // 없음
 
     }
 


### PR DESCRIPTION
kevin9327 님의 HWP3 각주 2건을 메인테이너가 재실증 후 통합한다. 어제 1차 배치(#3083)에서 **충돌로 미적용**됐던 건을 수동 해소해 흡수했다. **`parser/hwp3/` 밖 `.rs` 변경 0건.**

## 채택

- **#3023** (`Closes #3021`) — `doc_info.footnote_bracket`(각주 옵션, offset 110)이 파싱만 되고 미주 모양 `suffix_char` 가 **항상 `')'` 로 하드코딩**됐다. 옵션을 끈 문서(`footnote_bracket=0`)도 미주 번호에 `)` 가 붙었다. `hwp3_default_endnote_shape(bracket: bool)` 로 배선한다.
- **#3027** — 각주 분리선 길이(`footnote_line_width`, offset 111)가 파싱 후 미사용이라 `section_def.footnote_shape.separator_length` 가 값과 무관하게 항상 0(선 없음)으로 남았다. `hwp3_footnote_separator_length()` 로 배선한다.

## 충돌 해소 방식

두 PR 이 어제 merge 된 각주 코드와 겹친 부분은 **함수 시그니처 변경 + 테스트 병치**뿐이었다. cherry-pick 3-way 가 인접한 별개 변경(devel 의 `apply_hwp3_encrypted_flag`·`border_connection` 테스트)을 겹쳐 본 것이지 실제 라인 다툼이 아니라, 양쪽을 모두 살려 해소했다.

## 검증

- 전체 스위트 green, `cargo fmt --check` 통과, `clippy --all-targets` 오류 0
- **hwp3 테스트 31건 통과** (#3083 반영 후 29 → 31)
- red→green: `hwp3_default_endnote_shape` 에서 `bracket` 을 무시하고 `')'` 로 되돌리니 `issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag` FAIL → 복원 시 통과
- `parser/hwp3/` 밖 `.rs` 변경 0건

## 이번 배치에서 제외 — 코드 충돌 7건

`#3036 #3049 #3059 #2997 #2836 #3078 #3079` 는 devel 의 hwp3 수정과 실제로 겹쳐 각각 수동 해소가 필요하다. 별도 배치로 처리한다.

## 처리 맥락

`scripts/pr_triage.sh`(#3077) 로 축별 분류 후 HWP3 축을 처리 중이다. 1차(#3083) 8건 + 이번 2건으로 HWP3 축 17건 중 10건이 정리됐다.

Co-authored-by 로 원 커밋 provenance 를 보존한다.
