### PR TITLE
fix(hwpx): hp:equation version/baseLine/font 생략 시 OWPML 스키마 기본값으로 복원 (#3149)

### DIFF
--- a/mydocs/report/task_m100_3149_report.md
+++ b/mydocs/report/task_m100_3149_report.md
@@ -1,0 +1,51 @@
+# 완료 보고서 — Task M100-3149
+
+- 이슈: #3149
+- 제목: HWPX hp:equation version/baseLine/font 속성 생략 시 OWPML 스키마 기본값 대신 zero-계열 값으로 복원 — 라운드트립 시 값 변형
+- 작성일: 2026-07-23
+- 브랜치: `fix/task_m100_3149_hwpx_equation_owpml_defaults`
+
+## 1. 완료 내용
+
+HWPX 파서 `parse_equation`(`src/parser/hwpx/section.rs`)의 수식 전용 속성
+로컬 초기값을 OWPML 스키마(ParaList XML schema, `EquationType`) 속성 기본값으로
+교체했다.
+
+| 속성 | 스키마 기본값 | 수정 전 복원값 | 수정 후 |
+|---|---|---|---|
+| `version` | `"Equation Version 60"` | `""` | 스키마 기본값 |
+| `baseLine` | `85` | `0` | 스키마 기본값 |
+| `font` | `"HYhwpEQ"` | `""` | 스키마 기본값 |
+
+직렬화기(`src/serializer/hwpx/section.rs`의 equation 방출부)는 세 속성을 무조건
+방출하므로, 수정 전에는 속성을 생략한 스펙 준수 원본이 라운드트립을 거치면
+`version="" baseLine="0" font=""` 으로 값이 변형됐다. 속성이 명시된 파일의
+동작은 불변이다. `baseLine`의 parse 실패 폴백도 0 → 85 로 기본값과 일치시켰다.
+
+같은 요소의 `textColor`(#000000↔0), `baseUnit`(1000↔1000), `lineMode`(CHAR↔attr
+bit 0 = 0, #2727)는 이미 스펙 기본값과 일치해 변경하지 않았다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/section.rs`
+  - `parse_equation`: `version_info`/`baseline`/`font_name` 초기값을 스키마
+    기본값으로 교체 + 근거 주석
+  - 테스트 `equation_missing_attrs_fall_back_to_owpml_defaults` 추가
+    (속성 생략 수식 파싱 → 세 필드가 스펙 기본값으로 복원되는지 단언)
+
+## 3. 검증 결과 (red → green)
+
+- red (수정 전): `cargo test --lib equation_missing_attrs_fall_back_to_owpml_defaults`
+  → FAILED — `assertion 'left == right' failed: baseLine 생략 시 스펙 기본값 85`
+  (baseline 0, font_name "", version_info "")
+- green (수정 후): 같은 테스트 ok. 1 passed; 0 failed
+- 회귀: `cargo test --lib hwpx` → ok. 496 passed; 0 failed
+- `cargo fmt --check` — Windows CRLF line-ending diff 제외 위반 없음
+- `cargo clippy --lib --tests` — 신규 경고 없음
+
+## 4. 환경 특이사항
+
+- 이 PC 의 Windows SDK `dbghelp.lib`(10.0.26100.0)가 손상(전부 0x00)되어
+  link.exe 가 LNK1123/CVT1107 으로 실패 — 시스템 파일은 건드리지 않고
+  `dbghelp.dll` export 로 재생성한 import lib 를 `RUSTFLAGS=-L` 로 우선
+  탐색시켜 우회했다(검증 전용, 산출물에는 영향 없음).

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5330,12 +5330,14 @@ fn parse_equation(
     let mut shape_attr = ShapeComponentAttr::default();
     let mut has_pos = false;
 
-    // 수식 전용 속성
-    let mut version_info = String::new();
-    let mut baseline: i16 = 0;
+    // 수식 전용 속성 — 초기값은 OWPML(ParaList 스키마 EquationType) 속성 기본값.
+    // 속성이 생략된 파일에서 zero-계열 값으로 복원하면 직렬화기가 세 속성을
+    // 무조건 방출하므로 라운드트립 시 version=""/baseLine="0"/font="" 으로 변형된다.
+    let mut version_info = String::from("Equation Version 60");
+    let mut baseline: i16 = 85;
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
-    let mut font_name = String::new();
+    let mut font_name = String::from("HYhwpEQ");
     // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
     // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
     let mut eq_attr: u32 = 0;
@@ -5345,7 +5347,7 @@ fn parse_equation(
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
             b"version" => version_info = attr_str(&attr),
-            b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(0),
+            b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(85),
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
             // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
@@ -6202,6 +6204,45 @@ mod tests {
         };
         assert!(section_def.hide_empty_line);
         assert_ne!(section_def.flags & 0x0008_0000, 0);
+    }
+
+    #[test]
+    fn equation_missing_attrs_fall_back_to_owpml_defaults() {
+        // OWPML 스키마(ParaList, EquationType)의 속성 기본값:
+        //   version  = "Equation Version 60"
+        //   baseLine = 85
+        //   font     = "HYhwpEQ"
+        // 속성이 생략된 수식을 파싱하면 스펙 기본값으로 복원되어야 한다.
+        // (직렬화기는 세 속성을 무조건 방출하므로, 파서가 0/"" 로 복원하면
+        //  왕복 시 baseLine="0" font="" version="" 으로 값이 변형된다.)
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:equation id="1" zOrder="0" numberingType="EQUATION" textWrap="TOP_AND_BOTTOM" lock="0">
+        <hp:script>1 over 2</hp:script>
+        <hp:sz width="2000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/>
+        <hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/>
+      </hp:equation>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let eq = section.paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Equation(e) => Some(e),
+                _ => None,
+            })
+            .expect("수식 컨트롤");
+        assert_eq!(eq.baseline, 85, "baseLine 생략 시 스펙 기본값 85");
+        assert_eq!(eq.font_name, "HYhwpEQ", "font 생략 시 스펙 기본값 HYhwpEQ");
+        assert_eq!(
+            eq.version_info, "Equation Version 60",
+            "version 생략 시 스펙 기본값"
+        );
     }
 
     #[test]


### PR DESCRIPTION
# 요약

Closes #3149

HWPX 파서 `parse_equation`(`src/parser/hwpx/section.rs`)이 `<hp:equation>`의 `version` / `baseLine` / `font` 속성이 생략된 파일에서 OWPML 스키마(ParaList, `EquationType`) 기본값 대신 `""` / `0` / `""` 으로 복원하던 것을 스키마 기본값(`"Equation Version 60"` / `85` / `"HYhwpEQ"`)으로 교정합니다.

직렬화기는 세 속성을 무조건 방출하므로, 수정 전에는 스펙 기본값에 의존해 속성을 생략한 원본이 라운드트립을 거치면 `version="" baseLine="0" font=""` 으로 값이 변형됐습니다. 속성이 명시된 파일의 동작은 불변입니다.

# 변경 내용

- `src/parser/hwpx/section.rs`
  - `parse_equation` 로컬 초기값 3개를 OWPML 스키마 기본값으로 교체 + 근거 주석
  - `baseLine` parse 실패 폴백도 0 → 85 로 기본값과 일치
  - red→green 테스트 `equation_missing_attrs_fall_back_to_owpml_defaults` 추가
- `mydocs/report/task_m100_3149_report.md` — 처리결과 문서

# 검증 (red → green)

- red (수정 전): `cargo test --lib equation_missing_attrs_fall_back_to_owpml_defaults`
  → FAILED — `assertion 'left == right' failed: baseLine 생략 시 스펙 기본값 85` (baseline 0, font_name "", version_info "")
- green (수정 후): 같은 테스트 ok. 1 passed; 0 failed
- 회귀: `cargo test --lib hwpx` → ok. 496 passed; 0 failed
- `cargo fmt --check` — CRLF line-ending diff 제외 위반 없음
- `cargo clippy --lib --tests` — 신규 경고 없음 (잔여 1건은 기존 `src/parser/hwp3/johab.rs` identity_op)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
