### PR TITLE
fix(parser): 곡선 도형 point count(i32) 음수 부호확장 무한루프 방지 (#3156)

### DIFF
--- a/mydocs/report/task_m100_3156_report.md
+++ b/mydocs/report/task_m100_3156_report.md
@@ -1,0 +1,40 @@
+# task_m100_3156 처리결과: 곡선 도형 point count(i32) 음수 부호확장 무한루프
+
+## 결함 요약
+
+- 위치: `src/parser/control/shape.rs` `parse_curve_shape_data`
+- 클래스: HWP5 바이너리 파서의 미검증 카운트 → 부호확장으로 인한 무한에 가까운 루프(DoS)
+- 자매 결함: #3012(`parse_polygon_shape_data`, 다각형). #3012는 다각형만 수정하여 곡선 함수는 취약하게 남아 있었음.
+
+## 근본 원인
+
+곡선 도형 데이터의 점 개수 `count`(hwplib 스펙상 INT32, 부호 있음)를 파일에서 읽은 직후 검증 없이 `as usize`로 캐스팅:
+
+```rust
+let cnt = r.read_i32().unwrap_or(0) as usize;
+```
+
+조작된 파일이 `count = -1`(0xFFFFFFFF)을 지정하면 64비트에서 `usize::MAX` 근처의 거대한 값으로 부호확장된다. 이후 `for _ in 0..cnt` 및 `for _ in 0..(cnt - 1)` 루프가 입력 소진 후에도 `read_i32().unwrap_or(0)`으로 계속 0을 반환하며 수십억 회 반복 → 파싱 스레드가 사실상 멈추는 DoS.
+
+## 재현 바이트
+
+곡선 도형 데이터:
+```
+FF FF FF FF   // count = -1 (INT32)
+```
+
+## 수정
+
+캐스팅 전에 음수를 검사하여 음수면 count를 0(빈 곡선)으로 처리. #3012와 동일 패턴.
+
+```rust
+let cnt_raw = r.read_i32().unwrap_or(0);
+let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+```
+
+## 검증 (red → green)
+
+- red: `curve_point_count_negative_is_treated_as_zero` 테스트가 수정 전에는 60초 이상 종료되지 않음(타임아웃, 무한루프 확인).
+- green: 수정 후 동일 테스트 통과. `cargo test --lib shape::` 42개 전부 통과(회귀 없음), `task195_tests` 5개 통과.
+
+빌드/테스트: `RUSTFLAGS="-C linker=rust-lld" cargo test --lib`

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1078,7 +1078,12 @@ fn parse_polygon_shape_data(data: &[u8], poly: &mut PolygonShape) {
 /// hwplib: INT32 count + (INT32 x, INT32 y) × count + BYTE[count-1] segment_types + skip(4)
 fn parse_curve_shape_data(data: &[u8], curve: &mut CurveShape) {
     let mut r = ByteReader::new(data);
-    let cnt = r.read_i32().unwrap_or(0) as usize;
+    // count(INT32)는 파일에서 온 부호 있는 값이다. 음수(예: -1 = 0xFFFFFFFF)를
+    // 검증 없이 `as usize` 로 캐스팅하면 부호 확장으로 usize::MAX 근처의 거대한
+    // 값이 되어 아래 루프가 사실상 종료되지 않는(수십억 회) DoS 를 유발한다.
+    // 캐스팅 전에 음수를 0(빈 곡선)으로 처리한다. (#3012 다각형과 동일 클래스)
+    let cnt_raw = r.read_i32().unwrap_or(0);
+    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
     curve.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1128,6 +1133,29 @@ mod task195_tests {
             connector.control_points.is_empty(),
             "남은 바이트가 없으므로 제어점은 비어야 함: {}",
             connector.control_points.len()
+        );
+    }
+
+    #[test]
+    fn curve_point_count_negative_is_treated_as_zero() {
+        // count(INT32)에 음수(-1 = 0xFFFFFFFF)를 넣으면 as usize 부호확장으로
+        // usize::MAX 근처의 거대한 값이 되어 `for _ in 0..cnt` 및
+        // `for _ in 0..(cnt - 1)` 루프가 사실상 종료되지 않는(수십억 회) DoS 를
+        // 유발한다. 음수 count 는 빈 곡선으로 처리되어야 한다. (#3012 다각형과 동일 클래스)
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_le_bytes()); // count (악성)
+
+        let mut curve = CurveShape::default();
+        parse_curve_shape_data(&data, &mut curve);
+        assert!(
+            curve.points.is_empty(),
+            "음수 count는 빈 점 목록으로 처리되어야 함: {}",
+            curve.points.len()
+        );
+        assert!(
+            curve.segment_types.is_empty(),
+            "음수 count는 빈 세그먼트 목록으로 처리되어야 함: {}",
+            curve.segment_types.len()
         );
     }
 


### PR DESCRIPTION
## 개요

`src/parser/control/shape.rs`의 `parse_curve_shape_data`에서 곡선 도형 점 개수(count)를 검증 없이 `as usize`로 캐스팅하여, 조작된 파일이 음수 count를 주면 부호확장으로 무한에 가까운 루프에 빠지는 DoS를 수정합니다.

이는 #3012(다각형 `parse_polygon_shape_data`)와 **동일 클래스의 자매 함수** 결함입니다. #3012는 다각형만 수정하므로 곡선 함수는 그대로 취약했습니다.

Closes #3156

## 근본 원인

```rust
let cnt = r.read_i32().unwrap_or(0) as usize;
```

`count`(hwplib 스펙상 INT32)가 `-1`(0xFFFFFFFF)이면 64비트에서 `usize::MAX` 근처로 부호확장되어 `for _ in 0..cnt` 및 `for _ in 0..(cnt - 1)` 루프가 사실상 종료되지 않습니다.

## 재현 바이트

곡선 도형 데이터:
```
FF FF FF FF   // count = -1 (INT32)
```

## 수정

캐스팅 전 음수를 0(빈 곡선)으로 처리 — #3012와 동일 패턴.

```rust
let cnt_raw = r.read_i32().unwrap_or(0);
let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
```

## 검증 (red → green)

- **red**: 추가한 `curve_point_count_negative_is_treated_as_zero` 테스트가 수정 전에는 60초 이상 종료되지 않음(무한루프 확인, 타임아웃).
- **green**: 수정 후 통과. `cargo test --lib shape::` 42개 전부 통과(회귀 없음), `task195_tests` 5개 통과. `cargo clippy --lib` 경고 없음.
