### PR TITLE
fix(document_core): html import CSS rgba() 색상·border-width 키워드(thin/medium/thick) 파싱 누락 수정 (#3160)

### DIFF
--- a/mydocs/report/task_m100_3160_report.md
+++ b/mydocs/report/task_m100_3160_report.md
@@ -1,0 +1,44 @@
+# Task m100 처리결과: #3160 html import CSS rgba()·border-width 키워드 파싱 누락 수정
+
+## 이슈
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/3160
+- 결함 클래스: HTML import의 CSS 값 파싱 변형 누락 (#3066, #3120, #3034와 동일 클래스)
+
+## 결함 요약
+
+`src/document_core/helpers.rs`의 CSS 값 파싱 헬퍼 2곳이 브라우저가 실제로 생성하는 표준 표기를 인식하지 못했다.
+
+1. **`css_color_to_hwp_bgr()` — `rgba()` 미지원**
+   - `css.starts_with("rgb(")`만 검사하여 `rgba(r, g, b, a)` 표기가 전부 `None`으로 떨어짐.
+   - 증상: 셀 `background-color: rgba(255, 0, 0, 1)` → 배경 유실, `border: 1px solid rgba(...)` → 테두리 색 검정 폴백.
+2. **`parse_css_border_shorthand()` — border-width 키워드 미지원**
+   - CSS 표준 키워드 `thin`(1px)/`medium`(3px)/`thick`(5px)이 치수 파서로 흘러가 0.0이 되어 width=0 → 테두리 전체 소실.
+   - `border: solid`처럼 굵기 생략 시 CSS 기본값이 `medium`이므로 실사용에서 흔히 발생.
+
+## 수정 내용
+
+- `css_color_to_hwp_bgr()`: `rgb`/`rgba` 공통으로 `(` 위치를 찾아 내부 성분을 파싱. 4번째 성분(alpha)이 존재하고 0 이하이면 완전 투명으로 간주해 `None` 반환.
+- `parse_css_border_shorthand()`: 토큰 match에 `thin`(0.75pt)/`medium`(2.25pt)/`thick`(3.75pt) 분기 추가.
+- 재현 테스트 `test_css_color_rgba_and_border_width_keywords` 추가 (`src/wasm_api/tests.rs`).
+
+## 변경 파일
+
+- `src/document_core/helpers.rs` — `css_color_to_hwp_bgr()`, `parse_css_border_shorthand()` 수정
+- `src/wasm_api/tests.rs` — 재현 테스트 추가
+- `mydocs/report/task_m100_3160_report.md` — 본 문서
+
+## 검증 (red → green)
+
+1. **red**: 수정 전 테스트 실행 → FAIL 확인
+   ```
+   assertion `left == right` failed: rgba() 불투명 빨강 → BGR
+     left: None
+     right: Some(255)
+   ```
+2. **green**: 수정 후
+   ```
+   test wasm_api::tests::test_css_color_rgba_and_border_width_keywords ... ok
+   ```
+3. **주변 테스트**: `cargo test --lib html` 27건 전부 통과, `test_table_utility_functions`/`test_html_utility_functions` 통과.
+4. **CI 사전 검사**: `cargo fmt --check`(CRLF 노이즈 제외 위반 없음), `cargo clippy --lib` 경고/에러 없음.

--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -1035,17 +1035,23 @@ pub(crate) fn css_color_to_hwp_bgr(css: &str) -> Option<u32> {
         } else {
             None
         }
-    } else if css.starts_with("rgb(") || css.starts_with("rgb (") {
-        // rgb(r, g, b) 형식
-        let inner = css
-            .trim_start_matches("rgb")
-            .trim_start_matches('(')
-            .trim_end_matches(')');
+    } else if css.starts_with("rgb") {
+        // rgb(r, g, b) / rgba(r, g, b, a) 형식 — 브라우저는 알파 포함 색을
+        // rgba()로 직렬화하므로 함께 처리한다.
+        let open = css.find('(')?;
+        let inner = css[open + 1..].trim_end_matches(')');
         let parts: Vec<&str> = inner.split(',').collect();
         if parts.len() >= 3 {
             let r: u32 = parts[0].trim().parse().ok()?;
             let g: u32 = parts[1].trim().parse().ok()?;
             let b: u32 = parts[2].trim().parse().ok()?;
+            // rgba()의 alpha=0(완전 투명)은 색 없음으로 처리
+            if let Some(a_str) = parts.get(3) {
+                let a: f64 = a_str.trim().parse().ok()?;
+                if a <= 0.0 {
+                    return None;
+                }
+            }
             Some(r | (g << 8) | (b << 16))
         } else {
             None
@@ -1321,6 +1327,19 @@ pub(crate) fn parse_css_border_shorthand(val: &str) -> (f64, u32, u8) {
             }
             "hidden" => {
                 style = 0;
+                continue;
+            }
+            // CSS 표준 border-width 키워드 (브라우저 기준 thin=1px, medium=3px, thick=5px)
+            "thin" => {
+                width_pt = 0.75; // 1px
+                continue;
+            }
+            "medium" => {
+                width_pt = 2.25; // 3px
+                continue;
+            }
+            "thick" => {
+                width_pt = 3.75; // 5px
                 continue;
             }
             _ => {}

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -4999,6 +4999,46 @@ fn test_table_utility_functions() {
 }
 
 #[test]
+fn test_css_color_rgba_and_border_width_keywords() {
+    // rgba() 색상: 브라우저는 반투명/알파 포함 색을 rgba(r, g, b, a)로 직렬화한다.
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(255, 0, 0, 1)"),
+        Some(0x0000FF),
+        "rgba() 불투명 빨강 → BGR"
+    );
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(0, 128, 255, 0.5)"),
+        Some(0xFF8000),
+        "rgba() 반투명 색도 RGB 성분은 파싱되어야 함"
+    );
+    // 완전 투명(alpha=0)은 색 없음으로 처리
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(255, 0, 0, 0)"),
+        None,
+        "rgba() alpha=0 → 색 없음"
+    );
+
+    // border 축약형의 rgba() 색상
+    let (w, c, s) = super::parse_css_border_shorthand("1px solid rgba(255, 0, 0, 1)");
+    assert!((w - 0.75).abs() < 0.01, "border width 1px -> 0.75pt");
+    assert_eq!(c, 0x0000FF, "border rgba() 색상 빨강 (BGR)");
+    assert_eq!(s, 1, "border style solid");
+
+    // CSS 표준 border-width 키워드: thin(1px)/medium(3px)/thick(5px)
+    // 키워드를 인식하지 못하면 width 0 → 테두리 전체가 소실된다.
+    let (w_thin, _, s_thin) = super::parse_css_border_shorthand("thin solid #000000");
+    assert!((w_thin - 0.75).abs() < 0.01, "thin = 1px = 0.75pt");
+    assert_eq!(s_thin, 1);
+
+    let (w_med, c_med, _) = super::parse_css_border_shorthand("medium solid #ff0000");
+    assert!((w_med - 2.25).abs() < 0.01, "medium = 3px = 2.25pt");
+    assert_eq!(c_med, 0x0000FF);
+
+    let (w_thick, _, _) = super::parse_css_border_shorthand("thick solid #000000");
+    assert!((w_thick - 3.75).abs() < 0.01, "thick = 5px = 3.75pt");
+}
+
+#[test]
 fn test_html_utility_functions() {
     // decode_html_entities
     assert_eq!(super::decode_html_entities("&amp;&lt;&gt;"), "&<>");


### PR DESCRIPTION
Closes #3160

## 요약

HTML 붙여넣기/표 import의 CSS 값 파싱 헬퍼(`src/document_core/helpers.rs`)가 브라우저가 실제로 생성하는 두 가지 표준 표기를 인식하지 못하던 문제를 수정한다. #3066(rgb() 공백), #3120/#3034(text-decoration-line 공백 변형)와 같은 "CSS 값 파싱 변형 누락" 클래스.

## 수정 내용

1. **`css_color_to_hwp_bgr()` — `rgba()` 지원**
   - 기존: `starts_with("rgb(")`만 검사 → `rgba(255, 0, 0, 1)` 전부 파싱 실패 (배경색 유실, 테두리 색 검정 폴백)
   - 수정: `rgb`/`rgba` 공통으로 `(` 위치를 찾아 내부 성분 파싱. alpha 성분이 0 이하(완전 투명)이면 색 없음(`None`) 처리.
2. **`parse_css_border_shorthand()` — border-width 키워드 지원**
   - 기존: CSS 표준 키워드 `thin`/`medium`/`thick`이 치수 파서로 흘러가 0.0 → width=0 → 테두리 전체 소실
   - 수정: 토큰 match에 `thin`(0.75pt=1px)/`medium`(2.25pt=3px)/`thick`(3.75pt=5px) 분기 추가.

## 검증 (red → green)

- **red**: 재현 테스트 `test_css_color_rgba_and_border_width_keywords` 추가 후 수정 전 실행 → FAIL
  ```
  assertion `left == right` failed: rgba() 불투명 빨강 → BGR
    left: None
    right: Some(255)
  ```
- **green**: 수정 후 통과
  ```
  test wasm_api::tests::test_css_color_rgba_and_border_width_keywords ... ok
  ```
- 주변 테스트: `cargo test --lib html` 27건 전부 통과, `test_table_utility_functions`/`test_html_utility_functions` 통과
- `cargo fmt --check`(CRLF 노이즈 제외 위반 없음) / `cargo clippy --lib` 경고·에러 없음

## 변경 파일

- `src/document_core/helpers.rs`
- `src/wasm_api/tests.rs`
- `mydocs/report/task_m100_3160_report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
