### PR TITLE
fix(hwpx2hwp): 표 CTRL_HEADER "표 번호" 비트를 numberingType=TABLE 일 때만 설정 (#3161)

### DIFF
--- a/mydocs/report/task_m100_3161_report.md
+++ b/mydocs/report/task_m100_3161_report.md
@@ -1,0 +1,44 @@
+# 완료 보고서 — Task M100-3161
+
+- 이슈: #3161
+- 제목: HWPX→HWP5 변환: 표 CTRL_HEADER "표 번호" 비트(0x0800_0000)가 numberingType 과 무관하게 무조건 설정
+- 작성일: 2026-07-23
+- 브랜치: `fix/3161-table-numbering-bit-gate`
+
+## 1. 문제
+
+HWPX→HWP5 변환 어댑터 `materialize_table_ctrl_header_attr()`
+(`src/document_core/converters/hwpx_to_hwp.rs`)가 표 CTRL_HEADER attr 를 재합성할 때
+"표 번호" 범주 비트(`0x0800_0000`, bit 27)를 numberingType 과 무관하게 무조건 OR 했다.
+
+HWPX 파서는 #2697 에서 `materialize_hwpx_table_attrs`(`src/parser/hwpx/section.rs`)에
+`numbering_type == Table` 게이트를 걸어 IR 모순(`numbering_type=Picture ↔ attr=TABLE`)을
+제거했으나, HWP5 저장 경로의 변환 계층이 파서가 계산한 `common.attr` 를 무조건-OR 값으로
+덮어써 같은 모순을 저장 시점에 재도입했다. 결과적으로 `numberingType="PICTURE"`
+(그림 번호 캡션 표)·`"NONE"`(번호 제외 표)이 HWP5 저장 시 "표 번호" 범주로 바뀐다.
+
+## 2. 수정
+
+- `materialize_table_ctrl_header_attr()`: 파서(#2697)와 동일하게
+  `table.common.numbering_type == ObjectNumberingType::Table` 일 때만
+  `HWPX_TABLE_NUMBERING_BIT` 를 OR.
+- 기존 어댑터 테스트 픽스처 2건(`table_axis_materializes_hancom_record_contract`,
+  `captioned_table_materializes_hancom_caption_common_attr_bit`)에 실제 파서 기본값인
+  `numbering_type: Table` 을 명시 — 기대 상수(`0x082a_2311`/`0x282a_2311`) 유지.
+
+## 3. red → green
+
+`src/document_core/converters/hwpx_to_hwp.rs` tests 추가:
+
+| 테스트 | 수정 전 | 수정 후 |
+|---|---|---|
+| `picture_numbering_table_keeps_category_on_hwp_save` | FAIL (attr `0x080a2000`) | PASS |
+| `none_numbering_table_keeps_category_on_hwp_save` | FAIL | PASS |
+| `table_numbering_table_still_sets_numbering_bit` (회귀 가드) | PASS | PASS |
+
+## 4. 검증 결과
+
+- `cargo test --lib` — 2554 passed / 0 failed
+- `cargo test --test hwpx_to_hwp_adapter --test hwpx_roundtrip_baseline --test hwp5_roundtrip_baseline` — 전부 통과 (3 / 4 / 50 passed)
+- `cargo fmt --check` — CRLF newline-style 경고 외 잔여 없음
+- `cargo clippy --all-targets` — 신규 경고 없음 (기존 2건은 johab.rs/byte_writer.rs 무관 항목)

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1664,9 +1664,14 @@ fn materialize_table_ctrl_header_attr(table: &mut Table, report: &mut AdapterRep
     const HWP5_TABLE_CAPTION_COMMON_ATTR_BIT: u32 = 0x2000_0000;
 
     let before = table.common.attr;
-    let mut attr = pack_common_attr_bits(&table.common)
-        | HWPX_TABLE_FLOW_WITH_TEXT_BIT
-        | HWPX_TABLE_NUMBERING_BIT;
+    let mut attr = pack_common_attr_bits(&table.common) | HWPX_TABLE_FLOW_WITH_TEXT_BIT;
+    // [#2697] 파서(materialize_hwpx_table_attrs)와 동일 게이트: "표 번호" 비트는
+    // numberingType 이 실제로 TABLE 일 때만 세운다. 종전 무조건 OR 은 numberingType=
+    // "PICTURE"/"NONE" 표를 HWP5 저장 시 표 번호 범주로 되돌려, 파서가 #2697 에서
+    // 제거한 IR 모순(numbering_type=Picture ↔ attr=TABLE)을 변환 계층이 재도입했다.
+    if table.common.numbering_type == crate::model::shape::ObjectNumberingType::Table {
+        attr |= HWPX_TABLE_NUMBERING_BIT;
+    }
     if table.caption.is_some() {
         attr |= HWP5_TABLE_CAPTION_COMMON_ATTR_BIT;
     }
@@ -1903,6 +1908,8 @@ mod tests {
                 width: 47697,
                 height: 3525,
                 z_order: 26,
+                // HWPX 파서는 표 기본 numberingType 을 TABLE 로 채운다 (section.rs).
+                numbering_type: crate::model::shape::ObjectNumberingType::Table,
                 ..Default::default()
             },
             outer_margin_left: 283,
@@ -2014,6 +2021,8 @@ mod tests {
                 width: 47152,
                 height: 14976,
                 z_order: 6,
+                // HWPX 파서는 표 기본 numberingType 을 TABLE 로 채운다 (section.rs).
+                numbering_type: crate::model::shape::ObjectNumberingType::Table,
                 ..Default::default()
             },
             outer_margin_left: 141,
@@ -2042,6 +2051,106 @@ mod tests {
                     .unwrap(),
             ),
             0x282a_2311
+        );
+    }
+
+    #[test]
+    fn picture_numbering_table_keeps_category_on_hwp_save() {
+        // [#2697] HWPX 파서는 numberingType="PICTURE" 표에 TABLE 번호 비트(0x0800_0000)를
+        // 세우지 않는다. HWP5 저장 어댑터도 같은 게이트를 따라야 한다 — 종전 무조건 OR 은
+        // 그림 번호 캡션 표를 표 번호 범주로 되돌려 파서가 만든 IR 계약과 모순됐다.
+        use crate::model::shape::ObjectNumberingType;
+
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        table.common.numbering_type = ObjectNumberingType::Picture;
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "PICTURE 번호 표에 TABLE 번호 비트가 서면 IR 모순: {:#010x}",
+            table.common.attr
+        );
+        let flags = u32::from_le_bytes(
+            table.raw_ctrl_data[common_obj_offsets::FLAGS]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(
+            flags & 0x0800_0000,
+            0,
+            "raw_ctrl_data 에도 TABLE 번호 비트가 없어야 함: {flags:#010x}"
+        );
+    }
+
+    #[test]
+    fn none_numbering_table_keeps_category_on_hwp_save() {
+        // numberingType="NONE"(번호 매김 제외) 표도 저장 시 표 번호 범주로 승격되면 안 된다.
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        // Table::default() 의 common.numbering_type 은 None.
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "NONE 번호 표에 TABLE 번호 비트가 서면 안 됨: {:#010x}",
+            table.common.attr
+        );
+    }
+
+    #[test]
+    fn table_numbering_table_still_sets_numbering_bit() {
+        // 회귀 가드: 기본 표(numberingType="TABLE")는 종전대로 표 번호 비트를 유지한다.
+        use crate::model::shape::ObjectNumberingType;
+
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        table.common.numbering_type = ObjectNumberingType::Table;
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0x0800_0000,
+            "TABLE 번호 표는 표 번호 비트를 유지해야 함: {:#010x}",
+            table.common.attr
         );
     }
 


### PR DESCRIPTION
Closes #3161

## 문제

HWPX→HWP5 변환 어댑터 `materialize_table_ctrl_header_attr()`(`src/document_core/converters/hwpx_to_hwp.rs`)가 표 CTRL_HEADER attr 재합성 시 "표 번호" 범주 비트(`0x0800_0000`, bit 27)를 numberingType 과 무관하게 무조건 OR 했다.

HWPX 파서는 #2697 에서 `numbering_type == Table` 일 때만 이 비트를 세우도록 고쳐졌으나(`materialize_hwpx_table_attrs`), HWP5 저장 경로의 변환 계층이 파서가 계산한 attr 를 무조건-OR 값으로 덮어써 IR 모순(`numbering_type=Picture ↔ attr=TABLE`)을 저장 시점에 재도입했다. 그 결과 `numberingType="PICTURE"`(그림 번호 캡션 표)·`"NONE"`(번호 제외 표)이 HWP5 저장 시 "표 번호" 범주로 바뀐다.

## 수정

- `materialize_table_ctrl_header_attr()`: 파서(#2697)와 동일하게 `table.common.numbering_type == ObjectNumberingType::Table` 일 때만 `HWPX_TABLE_NUMBERING_BIT` OR.
- 기존 어댑터 테스트 픽스처 2건(`table_axis_materializes_hancom_record_contract`, `captioned_table_materializes_hancom_caption_common_attr_bit`)에 실제 파서 기본값인 `numbering_type: Table` 을 명시 — 기대 상수(`0x082a_2311`/`0x282a_2311`)는 그대로 유지.

## red → green

추가 테스트 (`src/document_core/converters/hwpx_to_hwp.rs`):

| 테스트 | 수정 전 | 수정 후 |
|---|---|---|
| `picture_numbering_table_keeps_category_on_hwp_save` | FAIL (attr `0x080a2000`, bit 27 강제) | PASS |
| `none_numbering_table_keeps_category_on_hwp_save` | FAIL | PASS |
| `table_numbering_table_still_sets_numbering_bit` (회귀 가드) | PASS | PASS |

## 검증

- `cargo test --lib` 전체 통과
- `cargo test --test hwpx_to_hwp_adapter --test hwpx_roundtrip_baseline --test hwp5_roundtrip_baseline` 통과
- `cargo fmt --check` (CRLF newline-style 경고 제외 잔여 없음), `cargo clippy --all-targets` 신규 경고 없음
