### PR TITLE
fix(parser/hwp3): 글자겹침(ch=23) 겹칠 글자 hchar array[3] 추출 누락 수정

### DIFF
--- a/mydocs/report/task_m100_3148_report.md
+++ b/mydocs/report/task_m100_3148_report.md
@@ -1,0 +1,33 @@
+# Task #3148 처리 결과
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 `parse_simple_control_char` 글자겹침(ch==23,
+spec §10.17 표 58) arm 이 추가로 읽은 8바이트 버퍼를 전혀 해석하지 않고
+`CharOverlap::default()`(빈 `chars`)를 IR 에 push 했다. 스펙상 버퍼의
+`[0..6]`은 겹칠 글자 hchar array[3](최대 3자, 남는 부분 0 패딩),
+`[6..8]`은 닫는 코드다. 바이트 소비량(10바이트 = 5 hchar)은 정확해 스트림은
+어긋나지 않지만, 겹침 대상 글자가 전량 유실됐다.
+
+IR `CharOverlap.chars`는 HWP5 직렬화(`serialize_char_overlap`)·HWPX 경로가
+이미 소비하는 필드이므로 파서만 채우면 전 경로가 연결된다.
+
+## 수정
+
+ch==23 arm 에서 `buf[0..6]`의 hchar 3개를 LE 로 읽어 0 이 아닌 값만
+`johab::decode_johab`로 디코딩해 `overlap.chars`에 push (스펙 근거 주석 포함).
+
+## 검증 (red → green)
+
+- 합성 문단(문단 정보 43바이트 + ch=23 컨트롤 10바이트: 겹칠 글자
+  'A','B',0 패딩)으로 `parse_paragraph_list`를 호출하는 회귀 테스트
+  `hwp3_char_overlap_extracts_overlap_chars` 추가.
+- 수정 전(red): `left: [] / right: ['A', 'B']` FAIL 확인.
+- 수정 후(green): 해당 테스트 PASS, `cargo test --lib` 전체 2552건 통과,
+  `cargo clippy --lib` 무경고 (fmt --check 는 Windows CRLF 체크아웃 노이즈만).
+
+## 범위
+
+겹칠 글자 추출만 수정. 바이트 소비량·hchar 카운트는 스펙과 일치해 무변경.
+테두리 종류 등 표 58 외 확장 속성은 HWP3 스펙에 없어 범위 밖. 메일머지
+(ch=22) 이름 오프셋 어긋남은 별도 이슈(#3147)로 분리.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1873,9 +1873,19 @@ fn parse_simple_control_char(
             utf16_len += 1;
             text_string.push('\u{FFFC}');
             let mut overlap = crate::model::control::CharOverlap::default();
-            // buf[0..2] 또는 buf[2..8]은 문자와 테두리 종류를 포함할 수 있습니다.
-            // 가능한 부분을 매핑하지만, 테스트 없이 정확한 오프셋을 찾기는 까다로우므로
-            // 구조체는 유지하되 완벽하게 채우지 않을 수도 있습니다.
+            // 스펙 §10.17 표 58: buf[0..6] = 겹칠 글자 hchar array[3]
+            // (최대 3자, 남는 부분 0 패딩), buf[6..8] = 닫는 코드(늘 23).
+            // 0 이 아닌 hchar 만 johab 디코딩해 IR 에 보존한다.
+            for k in 0..3usize {
+                let v = (&buf[k * 2..k * 2 + 2])
+                    .read_u16::<LittleEndian>()
+                    .unwrap_or(0);
+                if v != 0 {
+                    overlap
+                        .chars
+                        .push(crate::parser::hwp3::johab::decode_johab(v));
+                }
+            }
             controls.push(crate::model::control::Control::CharOverlap(overlap));
             ctrl_data_records.push(None);
         }
@@ -4425,6 +4435,69 @@ mod tests {
             paragraphs[0].text.contains("AAA"),
             "날짜 형식(ch=7) 컨트롤 뒤의 \"AAA\" 본문이 유실됨 (바이트 언더리드로 흡수): {:?}",
             paragraphs[0].text
+        );
+    }
+
+    // 스펙 §10.17 표 58: 글자겹침(ch=23)의 겹칠 글자는 오프셋 2..8 의
+    // hchar array[3] (남는 부분 0 패딩)이다. 파서가 이를 IR CharOverlap.chars
+    // 에 채워야 겹침 문자가 보존된다 (종전: 항상 빈 Vec → 겹칠 글자 전량 유실).
+    #[test]
+    fn hwp3_char_overlap_extracts_overlap_chars() {
+        let mut body = Vec::new();
+        body.push(1u8); // follow_prev_para_shape
+        body.extend_from_slice(&5u16.to_le_bytes()); // char_count: 10바이트 = 5 hchar
+        body.extend_from_slice(&0u16.to_le_bytes()); // line_count
+        body.push(0u8); // include_char_shape
+        body.push(0u8); // flags
+        body.extend_from_slice(&0u32.to_le_bytes()); // special_char_flags
+        body.push(0u8); // style_index
+        body.extend_from_slice(&[0u8; 31]); // rep_char_shape
+        assert_eq!(body.len(), 43);
+
+        body.extend_from_slice(&23u16.to_le_bytes()); // 여는 특수 문자 코드
+        body.extend_from_slice(&0x0041u16.to_le_bytes()); // 겹칠 글자 1: 'A'
+        body.extend_from_slice(&0x0042u16.to_le_bytes()); // 겹칠 글자 2: 'B'
+        body.extend_from_slice(&0u16.to_le_bytes()); // 겹칠 글자 3: 없음 (0 패딩)
+        body.extend_from_slice(&23u16.to_le_bytes()); // 닫는 특수 문자 코드
+
+        // 문단 리스트 종료 (빈 문단, 43바이트)
+        body.push(0u8);
+        body.extend_from_slice(&0u16.to_le_bytes());
+        body.extend_from_slice(&[0u8; 40]);
+
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+
+        let paragraphs = parse_paragraph_list(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            1000,
+            1000,
+        )
+        .expect("글자겹침(ch=23) 컨트롤을 포함한 문단 파싱 실패");
+
+        assert_eq!(paragraphs.len(), 1);
+        let overlap = paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                crate::model::control::Control::CharOverlap(co) => Some(co),
+                _ => None,
+            })
+            .expect("CharOverlap 컨트롤이 생성되지 않음");
+        assert_eq!(
+            overlap.chars,
+            vec!['A', 'B'],
+            "겹칠 글자(스펙 표 58 오프셋 2..8)가 IR 로 추출되지 않음"
         );
     }
 }


### PR DESCRIPTION
## 요약

HWP3 파서 글자겹침(ch=23, 스펙 §10.17 표 58)의 겹칠 글자 hchar array[3](오프셋 2..8)를 추출해 IR `CharOverlap.chars`에 보존합니다.

종전 코드는 추가로 읽은 8바이트 버퍼를 해석하지 않고 `CharOverlap::default()`(빈 `chars`)를 push 해, 겹침 대상 글자가 전량 유실됐습니다. 바이트 소비량(10바이트=5 hchar)은 스펙과 일치해 스트림 정렬은 정상이며 내용만 유실되는 결함입니다. `CharOverlap.chars`는 HWP5 직렬화(`serialize_char_overlap`)·HWPX 경로가 이미 소비하는 필드라 파서만 채우면 전 경로가 연결됩니다.

## 변경 내용

- `src/parser/hwp3/mod.rs`: ch==23 arm 에서 `buf[0..6]`의 hchar 3개를 LE 로 읽어 0 이 아닌 값만 `johab::decode_johab`로 디코딩해 `overlap.chars`에 push (스펙 근거 주석 포함).
- 회귀 테스트 `hwp3_char_overlap_extracts_overlap_chars` 추가 (합성 문단: 문단 정보 43바이트 + ch=23 컨트롤 10바이트: 'A','B',0 패딩).
- 처리결과 문서 `mydocs/report/task_m100_3148_report.md` 추가.

## 검증 (red → green)

- 수정 전(red): `assertion failed — left: [] / right: ['A', 'B']` FAIL 확인.
- 수정 후(green): 해당 테스트 PASS, `cargo test --lib` 전체 2552건 통과, `cargo clippy --lib` 무경고 (fmt --check 는 Windows CRLF 체크아웃 노이즈만).

Closes #3148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
