### PR TITLE
fix(parser/hwp3): 메일머지 필드 이름 오프셋 어긋남(#3147)·글자겹침 겹칠 글자 미배선(#3148) 수정

### DIFF
--- a/mydocs/report/task_m100_3147_report.md
+++ b/mydocs/report/task_m100_3147_report.md
@@ -1,0 +1,38 @@
+# Task m100 #3147 처리결과 — HWP3 메일머지 표시(ch=22) 필드 이름 오프셋 +2 어긋남 수정
+
+## 대상 이슈
+
+- #3147 — HWP3 메일머지 표시(ch=22) 필드 이름이 오프셋 +2로 어긋나게 읽혀 앞 2바이트 유실
+
+## 원인 분석
+
+`src/parser/hwp3/mod.rs` `parse_simple_control_char`의 `22 =>` arm이 필드 이름을
+`buf[2..22]`에서 읽었다. 스펙(한글문서파일구조 3.0 §10.16 표 57) 기준 필드 이름은
+파일 오프셋 2..22(kchar array[20])인데, 여는 특수 문자 코드(오프셋 0..2)는 문자
+스캔 루프에서 이미 소비되므로 이어 읽는 22바이트 버퍼에서 이름은 `buf[0..20]`,
+닫는 코드는 `buf[20..22]`다. 종전 코드는:
+
+- 필드 이름 앞 2바이트 유실 (`MERGEFIELD` → `RGEFIELD`)
+- 이름이 정확히 20바이트인 경우 닫는 코드 0x0016이 이름 뒤에 혼입
+
+바이트 소비량(24바이트 = 12 hchar)은 스펙과 일치해 스트림 자체는 어긋나지 않는다.
+
+## 수정 내용
+
+- `src/parser/hwp3/mod.rs` — `let name_buf = &buf[2..22];` → `&buf[0..20]` (스펙 근거 주석 포함)
+
+## red → green
+
+재현 테스트 `parser::hwp3::tests::hwp3_mail_merge_field_name_starts_at_offset_zero`
+(합성 22바이트 body: 이름 `MERGEFIELD` + 0 패딩 + 닫는 코드 0x0016):
+
+- 수정 전 FAIL: `left: "RGEFIELD" / right: "MERGEFIELD"`
+- 수정 후 PASS. 바이트 소비량(22) 불변 검증 포함.
+
+## 검증
+
+- `cargo test --profile release-test --lib -- --test-threads=1`: 2553 passed / 0 failed
+  (병렬 실행 시 `renderer::font_paths::tests::env_font_paths_parses_and_filters` 1건이
+  간헐 실패하나, 단독·단일 스레드 실행 모두 통과하는 기존 env-var 경합으로 본 수정과 무관)
+- `cargo clippy --profile release-test --lib`: 경고 없음
+- `rustfmt` (변경 파일) 적용

--- a/mydocs/report/task_m100_3148_report.md
+++ b/mydocs/report/task_m100_3148_report.md
@@ -1,0 +1,40 @@
+# Task m100 #3148 처리결과 — HWP3 글자겹침(ch=23) 겹칠 글자 array[3] 파싱 배선
+
+## 대상 이슈
+
+- #3148 — HWP3 글자겹침(ch=23)의 겹칠 글자(hchar array[3])가 파싱되지 않아 `CharOverlap.chars`가 항상 빈 Vec
+
+## 원인 분석
+
+`src/parser/hwp3/mod.rs` `parse_simple_control_char`의 `23 =>` arm이 8바이트 버퍼를
+읽기만 하고 내용을 전혀 사용하지 않은 채 `CharOverlap::default()`(빈 `chars`)를
+IR에 push했다. 스펙(한글문서파일구조 3.0 §10.17 표 58) 기준 글자겹침 10바이트 중
+오프셋 2..8이 겹칠 글자 hchar array[3](남는 부분 0 채움)이며, 여는 코드 소비 후
+읽는 8바이트 버퍼에서 `buf[0..6]`이 겹칠 글자, `buf[6..8]`이 닫는 코드다.
+
+IR `CharOverlap.chars`는 HWP5 직렬화·HWPX 경로가 이미 소비하므로 파서 배선만으로
+전 경로가 연결된다.
+
+## 수정 내용
+
+- `src/parser/hwp3/mod.rs` — `buf[0..6]`에서 hchar 3개를 LE로 읽어 0이 아닌 값만
+  `johab::decode_johab`로 디코딩해 `overlap.chars`에 push (스펙 근거 주석 포함)
+
+## red → green
+
+재현 테스트 `parser::hwp3::tests::hwp3_char_overlap_extracts_overlap_chars`
+(합성 8바이트 body: 'A', 'B', 0 + 닫는 코드 0x0017):
+
+- 수정 전 FAIL: `left: [] / right: ['A', 'B']`
+- 수정 후 PASS. 바이트 소비량(8) 불변 검증 포함.
+
+## 검증
+
+- `cargo test --profile release-test --lib -- --test-threads=1`: 2553 passed / 0 failed
+- `cargo clippy --profile release-test --lib`: 경고 없음
+- `rustfmt` (변경 파일) 적용
+
+## 비고
+
+#3147과 동일 함수(`parse_simple_control_char`) 인접 arm 수정이므로 메인테이너
+지시(같은 파일 축은 한 PR로)에 따라 #3147과 한 PR로 묶어 제출.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1873,9 +1873,17 @@ fn parse_simple_control_char(
             utf16_len += 1;
             text_string.push('\u{FFFC}');
             let mut overlap = crate::model::control::CharOverlap::default();
-            // buf[0..2] 또는 buf[2..8]은 문자와 테두리 종류를 포함할 수 있습니다.
-            // 가능한 부분을 매핑하지만, 테스트 없이 정확한 오프셋을 찾기는 까다로우므로
-            // 구조체는 유지하되 완벽하게 채우지 않을 수도 있습니다.
+            // [#3148] 스펙 §10.17 표 58: 오프셋 2..8 = 겹칠 글자 hchar array[3]
+            // (남는 부분 0 채움). 여는 코드는 스캔 루프에서 소비됐으므로 이
+            // 8바이트 버퍼에서 buf[0..6]이 겹칠 글자, buf[6..8]이 닫는 코드다.
+            for k in 0..3usize {
+                let hch = u16::from_le_bytes([buf[k * 2], buf[k * 2 + 1]]);
+                if hch != 0 {
+                    overlap
+                        .chars
+                        .push(crate::parser::hwp3::johab::decode_johab(hch));
+                }
+            }
             controls.push(crate::model::control::Control::CharOverlap(overlap));
             ctrl_data_records.push(None);
         }
@@ -1893,7 +1901,11 @@ fn parse_simple_control_char(
             char_offsets.push(utf16_len);
             utf16_len += 1;
             text_string.push('\u{FFFC}');
-            let name_buf = &buf[2..22];
+            // [#3147] 스펙 §10.16 표 57: 필드 이름은 파일 오프셋 2..22 (kchar
+            // array[20]). 여는 코드(오프셋 0..2)는 스캔 루프에서 이미 소비됐으므로
+            // 이 22바이트 버퍼에서 이름은 buf[0..20], 닫는 코드는 buf[20..22]다.
+            // (종전 buf[2..22] 는 앞 2바이트 유실 + 닫는 코드 혼입)
+            let name_buf = &buf[0..20];
             let name = crate::parser::hwp3::encoding::decode_hwp3_string(name_buf)
                 .trim_end_matches('\0')
                 .to_string();
@@ -4089,6 +4101,92 @@ mod tests {
                 .iter()
                 .any(|c| matches!(c, crate::model::control::Control::Field(_))),
             "ch==5 필드 코드가 Control::Field 로 배선되지 않음: {controls:?}"
+        );
+    }
+
+    /// ch=22/23 테스트 공용: `parse_simple_control_char` 를 합성 body 로 구동한다.
+    /// 반환: (controls, 소비 후 커서 위치)
+    fn run_simple_control_char(
+        body: Vec<u8>,
+        ch: u16,
+    ) -> (Vec<crate::model::control::Control>, u64) {
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut text_string = String::new();
+        let mut char_offsets = Vec::new();
+        let mut hwp3_char_to_utf16_pos = vec![0u32; 16];
+        let mut controls = Vec::new();
+        let mut ctrl_data_records = Vec::new();
+        let mut scan = Hwp3CharScan {
+            text_string: &mut text_string,
+            char_offsets: &mut char_offsets,
+            hwp3_char_to_utf16_pos: &mut hwp3_char_to_utf16_pos,
+            controls: &mut controls,
+            ctrl_data_records: &mut ctrl_data_records,
+        };
+        parse_simple_control_char(&mut body_cursor, ch, 0, 0, &mut scan).unwrap();
+        let pos = body_cursor.position();
+        (controls, pos)
+    }
+
+    #[test]
+    fn hwp3_mail_merge_field_name_starts_at_offset_zero() {
+        // [#3147] 스펙 §10.16 표 57: 필드 이름은 파일 오프셋 2..22.
+        // 여는 코드(오프셋 0..2)는 스캔 루프에서 이미 소비되므로, 이어 읽는
+        // 22바이트 버퍼에서 이름은 buf[0..20], 닫는 코드는 buf[20..22]다.
+        // 종전 buf[2..22] 사용 시 앞 2바이트('ME')가 유실된다.
+        let mut body = Vec::new();
+        let name = b"MERGEFIELD";
+        body.extend_from_slice(name); // 이름 (아스키)
+        body.resize(20, 0); // 20바이트까지 0 패딩
+        body.extend_from_slice(&22u16.to_le_bytes()); // 닫는 특수 문자 코드
+        assert_eq!(body.len(), 22);
+
+        let (controls, pos) = run_simple_control_char(body, 22);
+        assert_eq!(pos, 22, "ch=22 는 추가 22바이트를 소비해야 함");
+        let field = controls
+            .iter()
+            .find_map(|c| match c {
+                crate::model::control::Control::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("ch==22 는 Control::Field 를 push 해야 함");
+        assert_eq!(
+            field.field_type,
+            crate::model::control::FieldType::MailMerge
+        );
+        assert_eq!(
+            field.command, "MERGEFIELD",
+            "필드 이름은 buf[0..20]에서 읽어야 함 (buf[2..22] 사용 시 앞 2글자 유실)"
+        );
+    }
+
+    #[test]
+    fn hwp3_char_overlap_extracts_overlap_chars() {
+        // [#3148] 스펙 §10.17 표 58: 글자겹침(10바이트) 오프셋 2..8 =
+        // 겹칠 글자 hchar array[3] (남는 부분 0 채움).
+        // 여는 코드 소비 후 읽는 8바이트 버퍼에서 buf[0..6]이 겹칠 글자,
+        // buf[6..8]이 닫는 코드다. 종전에는 buf 를 전혀 사용하지 않아
+        // CharOverlap.chars 가 항상 빈 Vec 이었다.
+        let mut body = Vec::new();
+        body.extend_from_slice(&(b'A' as u16).to_le_bytes()); // 겹칠 글자 1
+        body.extend_from_slice(&(b'B' as u16).to_le_bytes()); // 겹칠 글자 2
+        body.extend_from_slice(&0u16.to_le_bytes()); // 미사용(0 채움)
+        body.extend_from_slice(&23u16.to_le_bytes()); // 닫는 특수 문자 코드
+        assert_eq!(body.len(), 8);
+
+        let (controls, pos) = run_simple_control_char(body, 23);
+        assert_eq!(pos, 8, "ch=23 은 추가 8바이트를 소비해야 함");
+        let overlap = controls
+            .iter()
+            .find_map(|c| match c {
+                crate::model::control::Control::CharOverlap(o) => Some(o),
+                _ => None,
+            })
+            .expect("ch==23 은 Control::CharOverlap 을 push 해야 함");
+        assert_eq!(
+            overlap.chars,
+            vec!['A', 'B'],
+            "겹칠 글자 hchar array[3] (buf[0..6]) 가 chars 로 배선되어야 함"
         );
     }
 


### PR DESCRIPTION
## 요약

HWP3 파서 `parse_simple_control_char`의 인접한 두 arm 결함을 함께 수정합니다
(같은 파일·같은 함수 축이므로 한 PR로 묶음).

- **#3147 (ch=22 메일머지 표시)** — 필드 이름을 `buf[2..22]`에서 읽어 앞 2바이트가
  유실되고, 이름이 20바이트를 꽉 채우면 닫는 코드 0x0016이 혼입되던 문제.
  스펙(한글문서파일구조 3.0 §10.16 표 57) 기준: 여는 코드는 스캔 루프에서 이미
  소비되므로 이어 읽는 22바이트 버퍼에서 이름은 `buf[0..20]`.
- **#3148 (ch=23 글자겹침)** — 8바이트 버퍼를 읽고도 내용을 사용하지 않아
  `CharOverlap.chars`가 항상 빈 Vec이던 문제. 스펙(§10.17 표 58) 기준
  `buf[0..6]`의 hchar array[3]을 LE로 읽어 0이 아닌 값만 `decode_johab`로
  디코딩해 `chars`에 배선. HWP5/HWPX 직렬화 경로는 이미 이 필드를 소비하므로
  파서 배선만으로 전 경로가 연결됩니다.

두 수정 모두 바이트 소비량(각 24바이트=12 hchar, 10바이트=5 hchar)은 종전과
동일해 스트림 정렬에는 영향이 없습니다.

## red → green

| 테스트 | 수정 전 | 수정 후 |
| --- | --- | --- |
| `hwp3_mail_merge_field_name_starts_at_offset_zero` | FAIL — `left: "RGEFIELD" / right: "MERGEFIELD"` | PASS |
| `hwp3_char_overlap_extracts_overlap_chars` | FAIL — `left: [] / right: ['A', 'B']` | PASS |

두 테스트 모두 바이트 소비량 불변(커서 위치 22/8) 검증을 포함합니다.

## 검증

- `cargo test --profile release-test --lib -- --test-threads=1`: **2553 passed / 0 failed**
  (병렬 실행 시 `env_font_paths_parses_and_filters` 1건이 간헐 실패하나 단독·단일
  스레드 모두 통과하는 기존 env-var 경합으로 본 수정과 무관)
- `cargo clippy --profile release-test --lib`: 경고 없음
- `rustfmt` 변경 파일 적용

## 처리결과 문서

- `mydocs/report/task_m100_3147_report.md`
- `mydocs/report/task_m100_3148_report.md`

Closes #3147
Closes #3148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
