### PR TITLE
fix(cli): 진단 명령 6종 실패 시 종료 코드 반환 (#3169)

### DIFF
--- a/mydocs/report/task_m100_3169_report.md
+++ b/mydocs/report/task_m100_3169_report.md
@@ -1,0 +1,92 @@
+---
+kind: report
+status: final
+task: m100-3169
+issue: 3169
+---
+
+# Task #3169 처리 결과 — 진단 명령 6종 종료 코드 계약 확장
+
+## 1. 요약
+
+`#2707`(PR #2711)은 `export-*`/`convert`/`export-hwpx` 계열만 고쳤고, 자체 보고서
+§6.1(`mydocs/report/task_m100_2707_report.md:243-252`)에서 같은 결함이
+`info`, `dump`, `dump-note-shape`, `dump-endnote-lines`, `dump-pages`,
+`diag`, `build-from-ingest`, `dump-records`, `ir-diff`, `test-*`, `gen-*`,
+`rhwp::diagnostics::*::run` 계열에 남아 있다고 명시했다.
+
+이번 작업은 그중 사용자가 직접 호출하는 6개 명령 — `info`, `dump-note-shape`,
+`dump-endnote-lines`, `dump-pages`, `dump-records`, `build-from-ingest` — 에
+`#2707` 관례(`EXIT_OK`/`EXIT_RUNTIME`/`EXIT_USAGE`)를 그대로 확장했다.
+
+## 2. 재현 (수정 전)
+
+```
+$ ./target/debug/rhwp info nonexistent.hwp
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ... (os error 2)
+$ echo $?
+0
+```
+
+`dump-note-shape`, `dump-endnote-lines`, `dump-pages`, `dump-records`,
+`build-from-ingest` 모두 동일 — 인자 없음/파일 읽기 실패/파싱 실패/범위 초과
+경로 전부 종료 코드 0.
+
+`dump-pages` 는 `#2551` 로 인자 검증 로직(파싱 실패·범위 초과 감지)은 이미
+형제 명령과 정합되어 있었으나, 오류 감지 후 종료 코드 전파만 빠져 있었다 —
+`return;` 은 있었지만 이 함수가 `main` 의 `match` 에서 `exit_with(...)` 로
+감싸이지 않아 항상 프로세스 종료 코드 0으로 끝났다.
+
+## 3. 수정
+
+`src/main.rs`:
+
+- `show_info`, `dump_note_shape`, `dump_endnote_lines`, `dump_pages`,
+  `dump_raw_records`, `build_from_ingest` 시그니처를 `fn(&[String])` →
+  `fn(&[String]) -> i32` 로 변경.
+- 각 함수의 치명 경로(인자 없음/누락 → `EXIT_USAGE`, 파일 읽기·파싱·직렬화·저장
+  실패 → `EXIT_RUNTIME`, 페이지/섹션/문단/컨트롤 인덱스 범위 초과 →
+  `EXIT_USAGE`)에서 `return;` 대신 해당 상수를 반환하도록 수정.
+  성공 경로 끝에 `EXIT_OK` 추가.
+- `main()` 의 디스패치에서 이 6개 명령을 `exit_with(...)` 로 감쌈.
+
+3/4(`--verify`/`--verify-pages`)는 건드리지 않았다 — 해당 없음(이 6개 명령에는
+그 옵션이 없음).
+
+## 4. 검증
+
+```
+cargo build --bin rhwp
+cargo test --test cli_exit_codes                        # 기존 회귀, 통과
+cargo test --test cli_exit_codes_diagnostic_commands     # 신규 회귀
+cargo test --test dump_pages_cli                         # #2551 회귀, 통과
+cargo fmt --check -- src/main.rs tests/cli_exit_codes_diagnostic_commands.rs
+cargo clippy --bin rhwp --tests
+```
+
+신규 테스트 `tests/cli_exit_codes_diagnostic_commands.rs` (5개, 전부 통과):
+
+- `missing_arguments_report_usage_error` — 인자 없음 → 2
+- `unreadable_input_reports_runtime_failure` — 존재하지 않는 입력 → 1
+- `dump_pages_out_of_range_reports_usage_error` — 페이지 범위 초과 → 2
+- `build_from_ingest_missing_output_reports_usage_error` — `-o` 누락 → 2
+- `successful_diagnostic_commands_return_zero` — 성공 경로는 여전히 0
+  (회귀 방지; `dump-records` 는 HWP5 CFB 샘플 `samples/2010-01-06.hwp` 사용 —
+  HWP3 샘플은 CFB 컨테이너가 아니라 이 명령이 지원하지 않음)
+
+수정 후 실측:
+
+```
+$ ./target/release/rhwp info nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - ...
+1
+$ ./target/release/rhwp info samples/2010-01-06.hwp >/dev/null; echo $?
+0
+```
+
+## 5. 범위 밖 (잔여)
+
+`dump`(`dump_controls`, ~1200줄), `diag`(`diag_document`, ~530줄), `ir-diff`,
+`test-*`, `gen-*`, `rhwp::diagnostics::*::run` 계열은 함수 규모가 커
+별도 이슈로 남긴다 — `#2707` 도 동일한 이유(진단·개발 보조 명령, PR 위험 최소화)로
+같은 판단을 내렸다.

--- a/src/main.rs
+++ b/src/main.rs
@@ -40,14 +40,14 @@ fn main() {
         Some("export-markdown") => exit_with(export_markdown(&args[2..])),
         Some("export-hwpx") => exit_with(export_hwpx(&args[2..])),
         Some("export-hml") => export_hml(&args[2..]),
-        Some("info") => show_info(&args[2..]),
+        Some("info") => exit_with(show_info(&args[2..])),
         Some("dump") => dump_controls(&args[2..]),
-        Some("dump-note-shape") => dump_note_shape(&args[2..]),
-        Some("dump-endnote-lines") => dump_endnote_lines(&args[2..]),
-        Some("dump-pages") => dump_pages(&args[2..]),
+        Some("dump-note-shape") => exit_with(dump_note_shape(&args[2..])),
+        Some("dump-endnote-lines") => exit_with(dump_endnote_lines(&args[2..])),
+        Some("dump-pages") => exit_with(dump_pages(&args[2..])),
         Some("diag") => diag_document(&args[2..]),
         Some("convert") => exit_with(convert_hwp(&args[2..])),
-        Some("build-from-ingest") => build_from_ingest(&args[2..]),
+        Some("build-from-ingest") => exit_with(build_from_ingest(&args[2..])),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
         Some("hwp5-inventory-diff") => rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]),
         Some("hwp5-contract-analyze") => rhwp::diagnostics::hwp5_contract_analyze::run(&args[2..]),
@@ -67,7 +67,7 @@ fn main() {
         Some("hwp5-cell-header-probe") => {
             rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..])
         }
-        Some("dump-records") => dump_raw_records(&args[2..]),
+        Some("dump-records") => exit_with(dump_raw_records(&args[2..])),
         Some("test-shape") => test_shape_roundtrip(&args[2..]),
         Some("test-caption") => test_caption(&args[2..]),
         Some("gen-table") => gen_table(&args[2..]),
@@ -2088,10 +2088,10 @@ fn export_markdown(args: &[String]) -> i32 {
     }
 }
 
-fn show_info(args: &[String]) {
+fn show_info(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: 문서 파일 경로를 지정해주세요.");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2101,7 +2101,7 @@ fn show_info(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2113,7 +2113,7 @@ fn show_info(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 문서 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2404,6 +2404,7 @@ fn show_info(args: &[String]) {
             }
         }
     }
+    EXIT_OK
 }
 
 /// HWPUNIT(u32)을 mm로 변환
@@ -2416,10 +2417,10 @@ fn hu_to_mm_i(hu: i32) -> f64 {
     hu as f64 * 25.4 / 7200.0
 }
 
-fn dump_note_shape(args: &[String]) {
+fn dump_note_shape(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-note-shape <파일.hwp|파일.hwpx>");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2427,7 +2428,7 @@ fn dump_note_shape(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2435,7 +2436,7 @@ fn dump_note_shape(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2458,8 +2459,14 @@ fn dump_note_shape(args: &[String]) {
         "sections": sections,
     });
     match serde_json::to_string_pretty(&value) {
-        Ok(text) => println!("{}", text),
-        Err(e) => eprintln!("오류: JSON 생성 실패 - {}", e),
+        Ok(text) => {
+            println!("{}", text);
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("오류: JSON 생성 실패 - {}", e);
+            EXIT_RUNTIME
+        }
     }
 }
 
@@ -2504,10 +2511,10 @@ fn rounded_mm(hu: i32) -> f64 {
     (hu_to_mm_i(hu) * 1000.0).round() / 1000.0
 }
 
-fn dump_pages(args: &[String]) {
+fn dump_pages(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-pages <파일.hwp> [-p <페이지번호>]");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2526,13 +2533,13 @@ fn dump_pages(args: &[String]) {
                         Ok(n) => target_page = Some(n),
                         Err(_) => {
                             eprintln!("오류: 페이지 번호가 올바르지 않습니다: {}", args[i + 1]);
-                            return;
+                            return EXIT_USAGE;
                         }
                     }
                     i += 2;
                 } else {
                     eprintln!("오류: {} 뒤에 페이지 번호가 필요합니다.", args[i]);
-                    return;
+                    return EXIT_USAGE;
                 }
             }
             "--respect-vpos-reset" => {
@@ -2541,7 +2548,7 @@ fn dump_pages(args: &[String]) {
             }
             _ => {
                 eprintln!("알 수 없는 옵션: {}", args[i]);
-                return;
+                return EXIT_USAGE;
             }
         }
     }
@@ -2550,7 +2557,7 @@ fn dump_pages(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2558,7 +2565,7 @@ fn dump_pages(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2577,20 +2584,21 @@ fn dump_pages(args: &[String]) {
                 "오류: 페이지 번호가 범위를 벗어났습니다 (0~{})",
                 page_count.saturating_sub(1)
             );
-            return;
+            return EXIT_USAGE;
         }
     }
 
     println!("문서 로드: {} ({}페이지)", file_path, page_count);
     print!("{}", doc.dump_page_items(target_page));
+    EXIT_OK
 }
 
-fn dump_endnote_lines(args: &[String]) {
+fn dump_endnote_lines(args: &[String]) -> i32 {
     if args.len() < 4 {
         eprintln!(
             "사용법: rhwp dump-endnote-lines <파일.hwp> <section> <para> <control> [note-para]"
         );
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2598,21 +2606,21 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: section 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let para_idx = match args[2].parse::<usize>() {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: para 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let control_idx = match args[3].parse::<usize>() {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: control 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let target_note_para = if args.len() >= 5 {
@@ -2620,7 +2628,7 @@ fn dump_endnote_lines(args: &[String]) {
             Ok(v) => Some(v),
             Err(e) => {
                 eprintln!("오류: note-para 인덱스 파싱 실패 - {}", e);
-                return;
+                return EXIT_USAGE;
             }
         }
     } else {
@@ -2631,7 +2639,7 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2639,22 +2647,22 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
     let document = doc.document();
     let Some(section) = document.sections.get(section_idx) else {
         eprintln!("오류: section {} 범위 초과", section_idx);
-        return;
+        return EXIT_USAGE;
     };
     let Some(source_para) = section.paragraphs.get(para_idx) else {
         eprintln!("오류: para {} 범위 초과", para_idx);
-        return;
+        return EXIT_USAGE;
     };
     let Some(ctrl) = source_para.controls.get(control_idx) else {
         eprintln!("오류: control {} 범위 초과", control_idx);
-        return;
+        return EXIT_USAGE;
     };
 
     let rhwp::model::control::Control::Endnote(endnote) = ctrl else {
@@ -2665,7 +2673,7 @@ fn dump_endnote_lines(args: &[String]) {
             control_idx,
             control_kind(ctrl)
         );
-        return;
+        return EXIT_USAGE;
     };
 
     println!(
@@ -2693,6 +2701,7 @@ fn dump_endnote_lines(args: &[String]) {
         );
         dump_paragraph_line_trace(para);
     }
+    EXIT_OK
 }
 
 fn dump_paragraph_line_trace(para: &rhwp::model::paragraph::Paragraph) {
@@ -4762,10 +4771,10 @@ fn export_hml(args: &[String]) {
 ///
 /// Claude Code Skill (`rhwp-exam-ingest`)이 생성한 JSON 중간 표현을 HWPX로 변환한다.
 /// Task #660 (Neumann 본 작업 1단계).
-fn build_from_ingest(args: &[String]) {
+fn build_from_ingest(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp build-from-ingest <ingest.json> [--media-dir <dir>] -o <out.hwpx>");
-        return;
+        return EXIT_USAGE;
     }
 
     let mut input_path: Option<&str> = None;
@@ -4778,7 +4787,7 @@ fn build_from_ingest(args: &[String]) {
             "-o" | "--output" => {
                 if i + 1 >= args.len() {
                     eprintln!("오류: -o 옵션에 값이 필요합니다");
-                    return;
+                    return EXIT_USAGE;
                 }
                 output_path = Some(&args[i + 1]);
                 i += 2;
@@ -4786,7 +4795,7 @@ fn build_from_ingest(args: &[String]) {
             "--media-dir" => {
                 if i + 1 >= args.len() {
                     eprintln!("오류: --media-dir 옵션에 값이 필요합니다");
-                    return;
+                    return EXIT_USAGE;
                 }
                 media_dir = Some(&args[i + 1]);
                 i += 2;
@@ -4806,14 +4815,14 @@ fn build_from_ingest(args: &[String]) {
         Some(p) => p,
         None => {
             eprintln!("오류: 입력 ingest JSON 경로가 누락되었습니다");
-            return;
+            return EXIT_USAGE;
         }
     };
     let output = match output_path {
         Some(p) => p,
         None => {
             eprintln!("오류: -o <출력 경로> 가 누락되었습니다");
-            return;
+            return EXIT_USAGE;
         }
     };
 
@@ -4821,7 +4830,7 @@ fn build_from_ingest(args: &[String]) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("오류: 입력 파일 읽기 실패 - {}: {}", input, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4829,7 +4838,7 @@ fn build_from_ingest(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: ingest JSON 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4849,35 +4858,41 @@ fn build_from_ingest(args: &[String]) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("오류: HWPX 직렬화 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
     match fs::write(output, &hwpx_bytes) {
-        Ok(_) => println!(
-            "저장 완료: {} ({}바이트, 문제 {}개, 문단 {}개)",
-            output,
-            hwpx_bytes.len(),
-            ingest.questions.len(),
-            doc.sections
-                .iter()
-                .map(|s| s.paragraphs.len())
-                .sum::<usize>()
-        ),
-        Err(e) => eprintln!("오류: 파일 저장 실패 - {}: {}", output, e),
+        Ok(_) => {
+            println!(
+                "저장 완료: {} ({}바이트, 문제 {}개, 문단 {}개)",
+                output,
+                hwpx_bytes.len(),
+                ingest.questions.len(),
+                doc.sections
+                    .iter()
+                    .map(|s| s.paragraphs.len())
+                    .sum::<usize>()
+            );
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("오류: 파일 저장 실패 - {}: {}", output, e);
+            EXIT_RUNTIME
+        }
     }
 }
 
-fn dump_raw_records(args: &[String]) {
+fn dump_raw_records(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-records <파일.hwp>");
-        return;
+        return EXIT_USAGE;
     }
     let data = match fs::read(&args[0]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     use rhwp::parser::cfb_reader::CfbReader;
@@ -4886,7 +4901,7 @@ fn dump_raw_records(args: &[String]) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     // FileHeader에서 압축 여부 확인
@@ -4896,14 +4911,14 @@ fn dump_raw_records(args: &[String]) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     let records = match Record::read_all(&section) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     let tag_name = |id: u16| -> &str {
@@ -4956,6 +4971,7 @@ fn dump_raw_records(args: &[String]) {
             }
         }
     }
+    EXIT_OK
 }
 
 fn test_shape_roundtrip(args: &[String]) {

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -1,0 +1,123 @@
+//! [#2707 후속] `info`/`dump-note-shape`/`dump-endnote-lines`/`dump-pages`/
+//! `dump-records`/`build-from-ingest` 도 export 계열과 동일한 종료 코드 계약을 따라야 한다.
+//!
+//! #2707 은 export-* / convert / export-hwpx 만 고쳤고, 같은 클래스(치명 실패에도
+//! 종료 코드 0)가 이 진단·조립 명령들에 남아 있다고 명시적으로 §6.1 에 기록했다
+//! (`mydocs/report/task_m100_2707_report.md`). 이 테스트는 그 잔여를 봉인한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+/// HWP5(CFB) 샘플 — `dump-records` 는 HWP3 CFB 아닌 입력을 지원하지 않는다.
+const HWP5_SAMPLE: &str = "samples/2010-01-06.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn hwp5_sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(HWP5_SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "{}",
+        describe(args, &output)
+    );
+    output
+}
+
+/// 인자 없이 호출 → 사용법 오류(2).
+#[test]
+fn missing_arguments_report_usage_error() {
+    for cmd in ["info", "dump-note-shape", "dump-pages", "dump-records"] {
+        assert_code(&[cmd], 2);
+    }
+    // dump-endnote-lines 는 인자 4개 미만이면 사용법 오류.
+    assert_code(&["dump-endnote-lines", "x.hwp"], 2);
+    assert_code(&["build-from-ingest"], 2);
+}
+
+/// 존재하지 않는 입력 파일 → 런타임 실패(1). #2707 이전에는 전부 0이었다.
+#[test]
+fn unreadable_input_reports_runtime_failure() {
+    assert_code(&["info", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-note-shape", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-pages", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-records", "does-not-exist.hwp"], 1);
+    assert_code(
+        &["dump-endnote-lines", "does-not-exist.hwp", "0", "0", "0"],
+        1,
+    );
+    assert_code(
+        &["build-from-ingest", "does-not-exist.json", "-o", "out.hwpx"],
+        1,
+    );
+}
+
+/// dump-pages 페이지 범위 초과 → 사용법 오류(2) (형제 명령과 정합, #2551 후속 확인).
+#[test]
+fn dump_pages_out_of_range_reports_usage_error() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("valid utf8 path");
+    assert_code(&["dump-pages", sample, "-p", "999999"], 2);
+}
+
+/// build-from-ingest 출력 경로 누락 → 사용법 오류(2).
+#[test]
+fn build_from_ingest_missing_output_reports_usage_error() {
+    assert_code(
+        &[
+            "build-from-ingest",
+            "tools/rhwp-ingest/schema/sample_minimal.json",
+        ],
+        2,
+    );
+}
+
+/// 성공 경로는 여전히 0이어야 한다 (회귀 방지).
+#[test]
+fn successful_diagnostic_commands_return_zero() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("valid utf8 path");
+    for cmd in ["info", "dump-note-shape", "dump-pages"] {
+        let output = run(&[cmd, sample]);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}",
+            describe(&[cmd, sample], &output)
+        );
+    }
+
+    let hwp5_sample = hwp5_sample_path();
+    let hwp5_sample = hwp5_sample.to_str().expect("valid utf8 path");
+    let output = run(&["dump-records", hwp5_sample]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&["dump-records", hwp5_sample], &output)
+    );
+}


### PR DESCRIPTION
## 요약

- `#2707`(PR #2711)이 export-*/convert/export-hwpx 만 고치고 §6.1 에서 잔여로
  명시한 진단 명령 6종에 동일한 종료 코드 계약을 확장합니다.
- 대상: `info`, `dump-note-shape`, `dump-endnote-lines`, `dump-pages`,
  `dump-records`, `build-from-ingest`.

## 변경

- `src/main.rs`: 위 6개 함수를 `fn(&[String])` → `fn(&[String]) -> i32` 로 변경.
  치명 경로는 `EXIT_USAGE`(인자 없음/누락, 범위 초과) 또는 `EXIT_RUNTIME`
  (읽기·파싱·직렬화·저장 실패)을 반환하고, 성공 시 `EXIT_OK`.
  `main()` 디스패치에서 `exit_with(...)` 로 감쌈.
- `tests/cli_exit_codes_diagnostic_commands.rs` 신규 — 인자 없음/읽기 실패/범위
  초과/성공 경로 5개 테스트.
- `mydocs/report/task_m100_3169_report.md` 신규 — 처리 결과 문서.

## 검증

```
cargo build --bin rhwp
cargo test --test cli_exit_codes                      # 기존 회귀, 통과
cargo test --test cli_exit_codes_diagnostic_commands   # 신규 5개, 통과
cargo test --test dump_pages_cli                       # #2551 회귀, 통과
cargo fmt --check -- src/main.rs tests/cli_exit_codes_diagnostic_commands.rs
cargo clippy --bin rhwp --tests                        # 관련 경고 없음
```

수정 전/후 실측:

```
$ rhwp info nonexistent.hwp; echo $?
오류: 파일을 읽을 수 없습니다 - ...
0   → 1 (수정 후)
```

## 범위 밖

`dump`(dump_controls), `diag`, `ir-diff`, `test-*`, `gen-*`,
`rhwp::diagnostics::*::run` 계열은 함수 규모가 커 이번 범위에서 제외했습니다
(이슈 본문에 명시).

Closes #3169
