### PR TITLE
fix(hwpx): charPr/paraPr id 속성 무시 — 등장 순서를 인덱스로 오인하던 결함 수정 (#3170)

### DIFF
--- a/mydocs/report/task_3170_report.md
+++ b/mydocs/report/task_3170_report.md
@@ -1,0 +1,74 @@
+# Issue #3170 처리 결과 보고서
+
+## 목표
+
+HWPX `header.xml`의 `<hh:charPr id="N">`/`<hh:paraPr id="N">` 파싱이 `id` 속성을 무시하고 XML 문서
+등장 순서를 그대로 배열 인덱스로 쓰는 결함을 수정한다. 본문 파싱(`section.rs`)과 렌더러/문서
+코어는 `charPrIDRef`/`paraPrIDRef` 값을 그대로 `char_shapes`/`para_shapes` 배열 인덱스로 쓰므로,
+`id` 가 등장 순서와 다르거나 중간이 비어 있으면 스타일 참조가 조용히 뒤바뀐다.
+
+## 원인
+
+- `src/parser/hwpx/header.rs`의 `parse_char_shape`/`parse_para_shape`가 `<hh:charPr>`/`<hh:paraPr>`
+  요소의 `id` 속성을 전혀 읽지 않고, 매 호출마다 `doc_info.char_shapes.push(cs)` /
+  `doc_info.para_shapes.push(ps)` 로 등장 순서에만 의존해 배열에 추가했다.
+- 반면 `src/parser/hwpx/section.rs`는 `<hp:run charPrIDRef="N">` / `<hp:p paraPrIDRef="N">` 의 `N`
+  값을 그대로 `para.char_shape_id`/`para.para_shape_id` 에 저장하고, 렌더러(`style_resolver.rs`,
+  `layout.rs`, `typeset.rs` 등)와 `document_core` 서식 커맨드는 이 값을 `char_shapes[N]` /
+  `para_shapes[N]` 인덱스로 그대로 조회한다.
+- 즉 "XML 등장 순서 == id 값" 이라는 암묵적 가정이 파싱 단계에서 강제되지 않아, id 가 비순차적인
+  (스타일 편집기 재정렬, 스타일 삭제로 인한 gap 등) 문서에서 `charPrIDRef`/`paraPrIDRef` 참조가
+  다른 CharShape/ParaShape 로 오해석되고, 글꼴·크기·정렬·줄간격 등 서식이 조용히 바뀐다.
+
+## 재현 (red)
+
+`src/parser/hwpx/header.rs` 테스트 모듈에 두 개의 red 테스트를 추가해 재현했다.
+
+- `test_char_pr_id_out_of_order_resolves_by_id_not_document_order`
+  — `<hh:charPr id="1" height="2000">` 가 `<hh:charPr id="0" height="1000">` 보다 먼저 등장하는
+  header.xml 조각을 파싱한 뒤, `char_shapes[0]`(= `charPrIDRef="0"` 참조 대상)이 `height=1000`
+  (id="0")이어야 함을 검증. 수정 전에는 `char_shapes[0]`에 첫 번째로 등장한 id="1" 항목이
+  들어가 `height=2000`으로 어긋났다(FAIL 확인).
+- `test_para_pr_id_out_of_order_resolves_by_id_not_document_order`
+  — 동일 구조를 `<hh:paraPr id="N">` + `<hh:align horizontal="...">` 로 재현. 수정 전
+  `para_shapes[0].alignment` 이 `Justify`(default)로 나와 `paraPrIDRef="0"` 참조가 실제로는
+  `id="0"` 항목에 도달하지 못함을 확인(FAIL).
+
+## 수정
+
+`parse_char_shape`/`parse_para_shape`에서 `id` 속성을 읽어, 해당 인덱스에 정확히 배치하도록
+변경했다.
+
+- `id` 속성 값을 파싱해 `Option<usize>` 로 보관.
+- 배열 길이가 `id` 보다 작으면 `Vec::resize_with` 로 기본값(`CharShape::default`/
+  `ParaShape::default`)을 채워 확장한 뒤, `char_shapes[id] = cs` / `para_shapes[id] = ps` 로
+  정확한 위치에 배치.
+- `id` 속성이 없는 비정상 입력만 기존처럼 등장 순서 `push` fallback 유지(하위 호환).
+
+기존 header.rs 단위 테스트 4건은 `<hh:paraPr id="1">`/`id="2"`/`id="3"` 처럼 1부터 시작하는
+샘플을 쓰면서도 결과를 `para_shapes[0]`/`[1]`/`[2]` 로 검증하고 있었다(구 코드의 등장 순서 push를
+암묵 전제한 것). 수정 후 올바른 의미(= id 값이 실제 인덱스)에 맞춰 해당 테스트들의 기대 인덱스를
+`id` 값과 일치하도록 갱신했다:
+
+- `test_parse_hwpx_para_shape_condense_attr_bits`
+- `para_shape_linespacing_between_lines_parses_as_space_only`
+- `test_parse_hwpx_para_shape_break_non_latin_word_bit`
+- `test_parse_hwpx_para_shape_snap_to_grid_bit`
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| red 테스트 2건 (수정 전) | FAIL 확인 |
+| `cargo test --lib parser::hwpx::` | 116 passed, 0 failed |
+| `cargo test --lib` (전체) | 2555 passed, 0 failed, 7 ignored |
+
+전체 회귀 테스트가 모두 통과해 이번 수정이 다른 IR/왕복 계약을 깨지 않음을 확인했다.
+
+## 범위 밖
+
+- `hh:style` 의 `nextStyleIDRef`(다음 스타일 자동 적용)는 편집기 동작(Enter 키 시 다음 문단
+  스타일 전환)이 애초에 구현돼 있지 않아 이번 결함과 별개다. 별도 기능 이슈로 다룰 사안이며
+  이번 PR 범위에 포함하지 않았다.
+- `hh:style` 의 `lockForm` 속성 직렬화 문제(#2839)는 이미 별도로 열린 이슈로, 겹치지 않게
+  건드리지 않았다.

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -565,9 +565,11 @@ fn parse_char_shape(
     doc_info: &mut DocInfo,
 ) -> Result<(), HwpxError> {
     let mut cs = CharShape::default();
+    let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            b"id" => id = Some(parse_u32(&attr) as usize),
             b"height" => cs.base_size = parse_i32(&attr),
             b"textColor" => cs.text_color = parse_color(&attr),
             b"shadeColor" => cs.shade_color = parse_color(&attr),
@@ -818,7 +820,21 @@ fn parse_char_shape(
         }
     }
 
-    doc_info.char_shapes.push(cs);
+    // `id` 속성은 charPrIDRef 가 참조하는 실제 배열 인덱스다. XML 등장 순서를
+    // 그대로 push 하면 id 가 등장 순서와 다르거나(재정렬) 중간이 비어 있을 때
+    // (스타일 삭제 등) charPrIDRef 참조가 엉뚱한 CharShape 로 해석된다.
+    // id 가 없는(비정상) 항목만 등장 순서 fallback 으로 push.
+    match id {
+        Some(idx) => {
+            if doc_info.char_shapes.len() <= idx {
+                doc_info
+                    .char_shapes
+                    .resize_with(idx + 1, CharShape::default);
+            }
+            doc_info.char_shapes[idx] = cs;
+        }
+        None => doc_info.char_shapes.push(cs),
+    }
     Ok(())
 }
 
@@ -832,9 +848,11 @@ fn parse_para_shape(
     let mut ps = ParaShape::default();
     // OWPML ParaShapeType의 snapToGrid 기본값은 true.
     ps.attr1 |= 1 << 8;
+    let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            b"id" => id = Some(parse_u32(&attr) as usize),
             b"tabPrIDRef" => ps.tab_def_id = parse_u16(&attr),
             b"condense" => {
                 let condense = parse_u32(&attr).min(75);
@@ -903,7 +921,19 @@ fn parse_para_shape(
         ps.line_spacing_v2 = ps.line_spacing as u32;
     }
 
-    doc_info.para_shapes.push(ps);
+    // `id` 속성은 paraPrIDRef 가 참조하는 실제 배열 인덱스다. charPr 과 동일한
+    // 이유로 등장 순서 push 대신 id 로 배치한다.
+    match id {
+        Some(idx) => {
+            if doc_info.para_shapes.len() <= idx {
+                doc_info
+                    .para_shapes
+                    .resize_with(idx + 1, ParaShape::default);
+            }
+            doc_info.para_shapes[idx] = ps;
+        }
+        None => doc_info.para_shapes.push(ps),
+    }
     Ok(())
 }
 
@@ -2322,7 +2352,8 @@ mod tests {
 </hh:head>"##;
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
-        let ps = &doc_info.para_shapes[0];
+        // paraPr id="1" 이므로 paraPrIDRef=1 이 참조할 실제 배열 위치는 index 1.
+        let ps = &doc_info.para_shapes[1];
 
         assert_eq!((ps.attr1 >> 9) & 0x7f, 30);
         assert_eq!(ps.attr1 & (1 << 22), 1 << 22);
@@ -2347,8 +2378,9 @@ mod tests {
   </hh:refList>
 </hh:head>"##;
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        // paraPr id="1" → index 1.
         assert_eq!(
-            doc_info.para_shapes[0].line_spacing_type,
+            doc_info.para_shapes[1].line_spacing_type,
             crate::model::style::LineSpacingType::SpaceOnly,
             "type=BETWEEN_LINES 가 SpaceOnly 로 파싱돼야 함(Percent 유실 방지)"
         );
@@ -2374,14 +2406,15 @@ mod tests {
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
 
-        assert_eq!(doc_info.para_shapes[0].attr1 & (1 << 7), 1 << 7);
-        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 7), 0);
+        // paraPr id="1"/"2" → index 1/2 (index 0 은 정의되지 않아 default).
+        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 7), 1 << 7);
+        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 7), 0);
         assert_eq!(
-            doc_info.para_shapes[0].break_latin_word.as_deref(),
+            doc_info.para_shapes[1].break_latin_word.as_deref(),
             Some("KEEP_WORD")
         );
         assert_eq!(
-            doc_info.para_shapes[1].break_latin_word.as_deref(),
+            doc_info.para_shapes[2].break_latin_word.as_deref(),
             Some("HYPHENATION")
         );
     }
@@ -2407,9 +2440,10 @@ mod tests {
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
 
-        assert_eq!(doc_info.para_shapes[0].attr1 & (1 << 8), 1 << 8);
-        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 8), 0);
-        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 8), 1 << 8);
+        // paraPr id="1"/"2"/"3" → index 1/2/3 (index 0 은 정의되지 않아 default).
+        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 8), 1 << 8);
+        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 8), 0);
+        assert_eq!(doc_info.para_shapes[3].attr1 & (1 << 8), 1 << 8);
     }
 
     #[test]
@@ -2987,5 +3021,89 @@ mod tests {
 
         assert_eq!((bf.attr >> 8) & 0x03, 2, "Crooked=2 보존");
         assert_eq!((bf.attr >> 5) & 0x07, 0b010, "backSlash CENTER 보존");
+    }
+
+    /// `<hh:charPr id="N">`/`<hh:paraPr id="N">`의 `id` 속성을 무시하고 XML 등장
+    /// 순서(push 순서)를 그대로 배열 인덱스로 쓰면, id 가 등장 순서와 다르거나
+    /// (역순) 중간이 비어 있을 때 `charPrIDRef`/`paraPrIDRef` 참조가 엉뚱한
+    /// 항목으로 해석된다. 한컴이 내보내는 파일은 보통 id 순으로 정렬돼 있어
+    /// 드러나지 않지만, OWPML 스펙상 id 는 임의 참조값일 뿐 등장 순서를
+    /// 보장하지 않는다 (예: 스타일 편집기로 재정렬되거나 서드파티 생성기가
+    /// 만든 파일).
+    #[test]
+    fn test_char_pr_id_out_of_order_resolves_by_id_not_document_order() {
+        // id="1" 항목이 먼저, id="0" 항목이 나중에 등장 — 등장 순서 그대로
+        // push 하면 char_shapes[0] 에 id="1"의 속성(height=2000)이 들어가
+        // charPrIDRef="0" 참조가 실제로는 id="1" 의 서식을 받게 된다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="2">
+      <hh:charPr id="1" height="2000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        // charPrIDRef="0" 을 참조하는 run 은 id="0"(height=1000) 서식을 받아야 한다.
+        let cs0 = doc_info
+            .char_shapes
+            .get(0)
+            .expect("id=0 charPr 이 존재해야 함");
+        assert_eq!(cs0.base_size, 1000, "charPrIDRef=0 은 id=\"0\" 항목이어야 함");
+
+        let cs1 = doc_info
+            .char_shapes
+            .get(1)
+            .expect("id=1 charPr 이 존재해야 함");
+        assert_eq!(cs1.base_size, 2000, "charPrIDRef=1 은 id=\"1\" 항목이어야 함");
+    }
+
+    /// paraPr 도 charPr 과 동일한 결함을 공유한다: id 속성을 무시하고 등장 순서로
+    /// push 하므로, id 가 비순차적이면 `paraPrIDRef` 가 잘못된 문단 서식을
+    /// 가리킨다.
+    #[test]
+    fn test_para_pr_id_out_of_order_resolves_by_id_not_document_order() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:paraProperties itemCnt="2">
+      <hh:paraPr id="1" tabPrIDRef="0">
+        <hh:align horizontal="RIGHT"/>
+      </hh:paraPr>
+      <hh:paraPr id="0" tabPrIDRef="0">
+        <hh:align horizontal="LEFT"/>
+      </hh:paraPr>
+    </hh:paraProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        let ps0 = doc_info
+            .para_shapes
+            .get(0)
+            .expect("id=0 paraPr 이 존재해야 함");
+        assert_eq!(
+            ps0.alignment,
+            Alignment::Left,
+            "paraPrIDRef=0 은 id=\"0\"(LEFT) 항목이어야 함"
+        );
+
+        let ps1 = doc_info
+            .para_shapes
+            .get(1)
+            .expect("id=1 paraPr 이 존재해야 함");
+        assert_eq!(
+            ps1.alignment,
+            Alignment::Right,
+            "paraPrIDRef=1 은 id=\"1\"(RIGHT) 항목이어야 함"
+        );
     }
 }


### PR DESCRIPTION
## 요약

HWPX `header.xml` 의 `<hh:charPr id="N">`/`<hh:paraPr id="N">` 파싱이 `id` 속성을 무시하고
XML 등장 순서를 그대로 배열 인덱스로 쓰던 결함을 수정한다. 본문 파싱(`section.rs`)과
렌더러/문서 코어는 `charPrIDRef`/`paraPrIDRef` 값을 그대로 `char_shapes`/`para_shapes` 배열
인덱스로 조회하므로, `id` 가 등장 순서와 다르거나(재정렬) 중간이 비어 있으면(삭제로 인한 gap)
스타일 참조가 조용히 뒤바뀌어 글꼴·크기·정렬·줄간격 등 서식이 다른 스타일 것으로 오적용된다.

Closes #3170

## 원인

- `src/parser/hwpx/header.rs`의 `parse_char_shape`/`parse_para_shape`가 `id` 속성을 읽지 않고
  매 호출마다 `char_shapes.push(cs)`/`para_shapes.push(ps)` 로 등장 순서에만 의존해 배열에
  추가했다.
- `section.rs`는 `charPrIDRef`/`paraPrIDRef` 값을 그대로 `char_shape_id`/`para_shape_id` 에
  저장하고, 렌더러(`style_resolver.rs`, `layout.rs`, `typeset.rs` 등)와 `document_core` 서식
  커맨드는 이 값을 배열 인덱스로 직접 조회한다.
- "XML 등장 순서 == id 값" 이라는 가정이 파싱 단계에서 강제되지 않아, 스타일 편집기 재정렬이나
  스타일 삭제로 id 에 gap 이 생긴 문서에서 참조가 뒤바뀐다.

## 재현 (red)

`src/parser/hwpx/header.rs` 에 다음 두 테스트를 추가해 수정 전 FAIL 을 확인했다.

- `test_char_pr_id_out_of_order_resolves_by_id_not_document_order`
- `test_para_pr_id_out_of_order_resolves_by_id_not_document_order`

## 수정

`parse_char_shape`/`parse_para_shape`에서 `id` 속성을 읽어 해당 인덱스에 정확히 배치하도록
변경했다(필요 시 `Vec::resize_with` 로 기본값 확장). `id` 속성이 없는 비정상 입력만 기존처럼
등장 순서 `push` fallback 을 유지한다.

기존 header.rs 단위 테스트 4건은 `id="1"`/`"2"`/`"3"` 처럼 1부터 시작하는 샘플을 쓰면서도
결과를 `para_shapes[0]`/`[1]`/`[2]` 로 검증하고 있었다(구 코드의 등장 순서 push를 암묵
전제한 것). 수정 후 올바른 의미(= id 값이 실제 인덱스)에 맞춰 기대 인덱스를 갱신했다.

## 검증

| 항목 | 결과 |
|---|---|
| red 테스트 2건 (수정 전) | FAIL 확인 |
| `cargo test --lib parser::hwpx::` | 116 passed, 0 failed |
| `cargo test --lib` (전체) | 2555 passed, 0 failed, 7 ignored |

처리 결과 문서: `mydocs/report/task_3170_report.md`

## 범위 밖

- `hh:style` 의 `nextStyleIDRef`(Enter 키 시 다음 문단 스타일 자동 전환)는 편집기 동작 자체가
  구현돼 있지 않은 별개 기능 격차로, 이번 PR 범위 밖이다.
- `hh:style` 의 `lockForm` 속성 직렬화 문제(#2839)는 이미 별도로 열린 이슈로 건드리지 않았다.
