### PR TITLE
fix(wmf): top-down DIB height() 부호 언더플로 수정 (#3174)

### DIFF
--- a/mydocs/report/task_m100_3174_report.md
+++ b/mydocs/report/task_m100_3174_report.md
@@ -1,0 +1,66 @@
+---
+kind: report
+status: final
+---
+
+# 처리결과: WMF top-down 비트맵 height() 언더플로
+
+Issue: #3174
+
+## 요약
+
+`BitmapInfoHeader::height()`가 Info/V4/V5 헤더에서 부호 있는 32비트 `height`를
+부호 확인 없이 `as usize`로 캐스팅해, top-down DIB(음수 Height, MS-WMF 2.2.2.9)를
+만나면 값이 `usize::MAX` 근방으로 언더플로했다. 같은 파일의 `size()`는 이미
+`height.unsigned_abs()`로 절댓값을 취하고 있어 두 메서드가 서로 다른 규칙을 쓰고
+있었다.
+
+## 근본 원인
+
+`src/wmf/parser/objects/structure/bitmap_info_header/mod.rs`의 `height()`:
+
+```rust
+Self::Info(BitmapInfoHeaderInfo { height, .. })
+| Self::V4(BitmapInfoHeaderV4 { height, .. })
+| Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
+```
+
+`height: i32`가 음수일 때 `as usize` 캐스팅은 2의 보수 재해석으로 거대한 값을
+만든다.
+
+## 영향 경로
+
+- `src/wmf/converter/bitmap.rs::expand_color_palette()` — 행 순회 상한으로
+  이 값을 그대로 사용, top-down DIB 입력 시 즉시 패닉하거나 슬라이스 계산이
+  깨진다.
+- `src/wmf/converter/svg/util.rs` — DIBPatternPT 브러시의 SVG `height` 속성에
+  같은 값을 그대로 써 렌더링이 깨진다.
+
+## 재현 (red)
+
+`bitmap_info_header::mod::tests::height_of_top_down_dib_is_absolute_value`
+추가 후 `cargo test --lib bitmap_info_header` 실행:
+
+```
+left: 18446744073709551606
+right: 10
+```
+
+## 수정 (green)
+
+`height()`도 `size()`처럼 Info/V4/V5 변형에서 `height.unsigned_abs()`를 쓰도록
+통일. 최소 변경, 로직 재구성 없음.
+
+## 검증
+
+```
+cargo test --lib bitmap_info_header  -> 1 passed
+cargo test --lib bitmap              -> 8 passed (회귀 없음, 관련 변환기 테스트 포함)
+cargo test --lib wmf                 -> 2 passed (회귀 없음)
+```
+
+RUSTFLAGS="-C linker=rust-lld" 사용 (dbghelp 링커 오류 회피).
+
+## 변경 파일
+
+- `src/wmf/parser/objects/structure/bitmap_info_header/mod.rs`

--- a/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
+++ b/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
@@ -157,9 +157,12 @@ impl BitmapInfoHeader {
     pub fn height(&self) -> usize {
         match self {
             Self::Core(BitmapInfoHeaderCore { height, .. }) => usize::from(*height),
+            // A negative Height indicates a top-down DIB (MS-WMF 2.2.2.9);
+            // the pixel height is the magnitude, matching `size()`'s use of
+            // `unsigned_abs()` below.
             Self::Info(BitmapInfoHeaderInfo { height, .. })
             | Self::V4(BitmapInfoHeaderV4 { height, .. })
-            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
+            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => height.unsigned_abs() as usize,
         }
     }
 
@@ -170,5 +173,32 @@ impl BitmapInfoHeader {
             | Self::V4(BitmapInfoHeaderV4 { width, .. })
             | Self::V5(BitmapInfoHeaderV5 { width, .. }) => *width as usize,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // MS-WMF 2.2.2.9: a negative Height indicates a top-down DIB; the
+    // absolute value is still the pixel height. `height()` must return the
+    // magnitude, matching what `size()` already does via `unsigned_abs()`.
+    #[test]
+    fn height_of_top_down_dib_is_absolute_value() {
+        let header = BitmapInfoHeader::Info(BitmapInfoHeaderInfo {
+            header_size: 40,
+            width: 10,
+            height: -10,
+            planes: 1,
+            bit_count: crate::wmf::parser::BitCount::BI_BITCOUNT_5,
+            compression: crate::wmf::parser::Compression::BI_RGB,
+            image_size: 0,
+            x_pels_per_meter: 0,
+            y_pels_per_meter: 0,
+            color_used: 0,
+            color_important: 0,
+        });
+
+        assert_eq!(header.height(), 10);
     }
 }


### PR DESCRIPTION
## 결함

MS-WMF 2.2.2.9 규격상 BitmapInfoHeader의 `height`가 음수면 top-down DIB를 뜻하는데, `height()`가 부호 확인 없이 `as usize`로 캐스팅해 `usize::MAX` 근방으로 언더플로합니다. 같은 파일의 `size()`는 이미 `height.unsigned_abs()`를 써서 두 메서드 규칙이 불일치했습니다.

영향 경로: `src/wmf/converter/bitmap.rs::expand_color_palette()`(팔레트 확장 행 순회 상한 파괴), `src/wmf/converter/svg/util.rs`(해치 브러시 SVG height 속성 파괴).

## 수정

`height()`도 `size()`와 동일하게 `height.unsigned_abs()` 사용.

## red→green

신규 테스트 `height_of_top_down_dib_is_absolute_value` — 수정 전 `18446744073709551606` 반환(FAIL) → 수정 후 `10`(PASS). `cargo test --lib bitmap_info_header/bitmap/wmf` 전부 통과, 회귀 없음.

Closes #3174