### PR TITLE
fix(cli): dump/diag 명령 오류 시 종료 코드 0 반환 수정 (#3178)

### DIFF
--- a/mydocs/report/task_m100_3178_report.md
+++ b/mydocs/report/task_m100_3178_report.md
@@ -1,0 +1,101 @@
+---
+kind: report
+status: done
+last_verified: 2026-07-23
+---
+
+# task_m100_3178_report
+
+Issue: #3178
+
+## 요약
+
+`#2707`(PR #2711)·`#3169`(PR #3171)이 명시적으로 범위 밖에 남긴 `dump`(dump_controls)·
+`diag`(diag_document) 두 명령에도 동일 클래스의 종료 코드 미전파 버그가 있음을 실측으로
+확인하고, 동일 계약(EXIT_OK/EXIT_RUNTIME/EXIT_USAGE)으로 최소 수정했다.
+
+## 재현 (수정 전)
+
+```
+$ rhwp dump nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ...
+0
+
+$ rhwp diag nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ...
+0
+
+$ rhwp dump; echo $?      # 인자 없음
+0
+
+$ rhwp diag; echo $?      # 인자 없음
+0
+```
+
+## 원인
+
+`dump_controls`(src/main.rs, ~1200줄)·`diag_document`(~530줄) 모두 `fn(&[String])`
+(반환값 없음) 시그니처였고, 세 오류 경로(인자 없음/파일 읽기 실패/파싱 실패) 각각
+`eprintln!` 후 `return;`으로 끝났다. `main()` 디스패치도 `exit_with(...)`로 감싸지
+않고 직접 호출했다.
+
+몸통 크기와 무관하게 오류 반환 지점은 각 함수당 3곳뿐이라 계약 적용 자체는 국소적이었다.
+
+## 수정
+
+- `dump_controls`, `diag_document`: `fn(&[String])` → `fn(&[String]) -> i32`.
+  - 인자 없음 → `EXIT_USAGE`
+  - 파일 읽기 실패 / 문서 파싱 실패 → `EXIT_RUNTIME`
+  - 정상 종료 → `EXIT_OK`
+- `main()` 디스패치의 `"dump"`·`"diag"` 분기를 `exit_with(...)`로 감쌈.
+- `tests/cli_exit_codes_dump_diag.rs` 신규 — 인자 없음/읽기 실패/파싱 실패/성공 경로 4개 테스트.
+
+## 검증
+
+```
+RUSTFLAGS="-C linker=rust-lld" cargo build --bin rhwp
+RUSTFLAGS="-C linker=rust-lld" cargo test --test cli_exit_codes_dump_diag   # 신규 4개, 통과
+RUSTFLAGS="-C linker=rust-lld" cargo test --test cli_exit_codes             # 기존 10개 회귀, 통과
+cargo fmt --check -- src/main.rs tests/cli_exit_codes_dump_diag.rs         # 변경 파일 포맷 이슈 없음
+                                                                             # (기존 examples/ 의 CRLF 경고는
+                                                                             #  본 변경과 무관한 사전 존재 이슈)
+RUSTFLAGS="-C linker=rust-lld" cargo clippy --bin rhwp --tests             # 신규 경고 없음
+                                                                             # (johab.rs/byte_writer.rs 사전 존재
+                                                                             #  경고 2건은 본 변경과 무관)
+```
+
+수정 전/후 실측:
+
+```
+$ rhwp dump nonexistent.hwp; echo $?
+...
+1   → (수정 전 0)
+
+$ rhwp diag nonexistent.hwp; echo $?
+...
+1   → (수정 전 0)
+
+$ rhwp dump; echo $?
+...
+2   → (수정 전 0)
+
+$ rhwp diag; echo $?
+...
+2   → (수정 전 0)
+```
+
+성공 경로 회귀 확인 (samples/hwp3-sample.hwp):
+
+```
+$ rhwp dump samples/hwp3-sample.hwp; echo $?
+0
+$ rhwp diag samples/hwp3-sample.hwp; echo $?
+0
+```
+
+## 범위
+
+이번 수정은 `dump`·`diag` 두 명령만 다룬다. `ir-diff`/`test-*`/`gen-*` 계열과
+`rhwp::diagnostics::*::run` 계열도 동일 클래스 버그가 있음을 확인했으나(실측:
+모두 실패 시 exit 0), 함수 개수와 각각의 사용법/오류 경로가 많아 이번 범위에서는
+제외했다. 후속 이슈로 분리 권장.

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,11 +41,11 @@ fn main() {
         Some("export-hwpx") => exit_with(export_hwpx(&args[2..])),
         Some("export-hml") => export_hml(&args[2..]),
         Some("info") => show_info(&args[2..]),
-        Some("dump") => dump_controls(&args[2..]),
+        Some("dump") => exit_with(dump_controls(&args[2..])),
         Some("dump-note-shape") => dump_note_shape(&args[2..]),
         Some("dump-endnote-lines") => dump_endnote_lines(&args[2..]),
         Some("dump-pages") => dump_pages(&args[2..]),
-        Some("diag") => diag_document(&args[2..]),
+        Some("diag") => exit_with(diag_document(&args[2..])),
         Some("convert") => exit_with(convert_hwp(&args[2..])),
         Some("build-from-ingest") => build_from_ingest(&args[2..]),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
@@ -3005,13 +3005,13 @@ fn brief_text(text: &str, max_chars: usize) -> String {
     out
 }
 
-fn dump_controls(args: &[String]) {
+fn dump_controls(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: 문서 파일 경로를 지정해주세요.");
         eprintln!(
             "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
         );
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -3047,7 +3047,7 @@ fn dump_controls(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -3055,7 +3055,7 @@ fn dump_controls(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 문서 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4228,13 +4228,15 @@ fn dump_controls(args: &[String]) {
             .map(|s| s.paragraphs.len())
             .sum::<usize>()
     );
+
+    EXIT_OK
 }
 
-fn diag_document(args: &[String]) {
+fn diag_document(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: HWP 파일 경로를 지정해주세요.");
         eprintln!("사용법: rhwp diag <파일.hwp>");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -4242,7 +4244,7 @@ fn diag_document(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4250,7 +4252,7 @@ fn diag_document(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4350,6 +4352,8 @@ fn diag_document(args: &[String]) {
             }
         }
     }
+
+    EXIT_OK
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/tests/cli_exit_codes_dump_diag.rs
+++ b/tests/cli_exit_codes_dump_diag.rs
@@ -1,0 +1,91 @@
+//! [#3172] `dump`/`diag` CLI 종료 코드 계약 회귀 테스트.
+//!
+//! `#2707`(PR #2711)·`#3169`(PR #3171)이 각각 export-*/convert/export-hwpx 와
+//! info/dump-note-shape/dump-endnote-lines/dump-pages/dump-records/build-from-ingest 에
+//! 적용한 계약(0 성공 / 1 런타임 실패 / 2 사용법 오류)을, 두 PR이 명시적으로 범위 밖에
+//! 남겨둔 `dump`(dump_controls)·`diag`(diag_document) 에도 동일하게 확장한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-exit-codes-dump-diag-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "종료 코드 {expected} 를 기대했다\n{}",
+        describe(args, &output)
+    );
+    output
+}
+
+#[test]
+fn missing_arguments_report_usage_error() {
+    for command in ["dump", "diag"] {
+        assert_code(&[command], 2);
+    }
+}
+
+#[test]
+fn unreadable_input_reports_runtime_failure() {
+    let missing = unique_temp_path("missing.hwp");
+    let missing = missing.to_str().expect("utf-8 경로").to_string();
+
+    assert_code(&["dump", &missing], 1);
+    assert_code(&["diag", &missing], 1);
+}
+
+#[test]
+fn unparseable_input_reports_runtime_failure() {
+    let bogus = unique_temp_path("bogus-not-hwp");
+    std::fs::write(&bogus, b"not a real hwp document").expect("파싱 실패 유도용 파일 생성");
+    let bogus = bogus.to_str().expect("utf-8 경로").to_string();
+
+    assert_code(&["dump", &bogus], 1);
+    assert_code(&["diag", &bogus], 1);
+
+    let _ = std::fs::remove_file(&bogus);
+}
+
+#[test]
+fn successful_run_returns_zero() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("utf-8 경로");
+
+    assert_code(&["dump", sample], 0);
+    assert_code(&["diag", sample], 0);
+}


### PR DESCRIPTION
## 결함

#2707/#3169 와 동일 클래스 — `dump`(dump_controls), `diag`(diag_document) 명령이 stderr에 오류를 찍고도 exit 0을 반환합니다.

재현(수정 전):
```
rhwp dump nonexistent.hwp; echo $?   → 0
rhwp diag nonexistent.hwp; echo $?   → 0
rhwp dump; echo $?                   → 0 (인자 없음)
```

## 수정

기존 #2707/#3169 컨벤션(EXIT_USAGE/EXIT_RUNTIME/EXIT_OK, exit_with)에 맞춰 `dump_controls`/`diag_document`를 `fn(&[String]) -> i32`로 전환, 오류 지점 3곳(인자없음/읽기실패/파싱실패)에 값 반환 추가.

## red→green

신규 테스트 `tests/cli_exit_codes_dump_diag.rs` 4건 — 수정 전 exit 0(FAIL) → 수정 후 usage=2/runtime=1/success=0(PASS). 기존 `cli_exit_codes.rs` 10건 회귀 없음.

## 범위 밖

`ir-diff`/`test-*`/`gen-*` 계열도 같은 증상이 있으나, #2707과 동일하게 이번엔 검증 쉬운 2개 명령만 최소 수정 범위로 잡았습니다.

Closes #3178