### PR TITLE
fix(parser): CFB DIFAT 확장 섹터 체인 순환 감지 누락으로 인한 DoS 방지 (#3181)

### DIFF
--- a/mydocs/report/task_m100_3181_report.md
+++ b/mydocs/report/task_m100_3181_report.md
@@ -1,0 +1,58 @@
+---
+kind: report
+status: done
+last_verified: 2026-07-23
+---
+
+# Task #3181 처리 결과 — CFB LenientCfbReader DIFAT 순환 감지 누락
+
+Issue: #3181
+
+## 문제
+
+`src/parser/cfb_reader.rs` 의 `LenientCfbReader::open` 이 CFB 헤더의 DIFAT 확장 섹터
+체인을 순회할 때 FAT/미니FAT 체인 순회(`read_chain_static`)와 달리 방문 섹터 집합을
+추적하지 않았다. 순회 상한은 파일 헤더에서 그대로 읽은 `difat_sectors_count`
+(`u32`, 공격자 통제 가능, 최대 4,294,967,295)뿐이라, 두 DIFAT 섹터가 서로를
+가리키는 순환을 만들고 `difat_sectors_count` 를 `u32::MAX` 로 설정하면 실제 체인
+길이(2)와 무관하게 최대 42억 회 넘게 동일한 섹터를 반복 순회한다. 패닉은 아니지만
+단일 스레드 WASM 환경(브라우저 탭)에서는 사실상 응답 없음(DoS)이 된다.
+
+## 재현
+
+`src/parser/cfb_reader.rs::tests::lenient_open_terminates_on_cyclic_difat_chain`
+테스트로 재현. 헤더에 서로를 가리키는 DIFAT 섹터 2개를 배치하고
+`difat_sectors_count = u32::MAX` 로 설정한 뒤, `LenientCfbReader::open` 호출을
+별도 스레드에서 실행해 3초 타임아웃 내 반환하는지 확인한다.
+
+- 수정 전: 3초 타임아웃 내 반환하지 못해 테스트 실패(RED, `cargo test` 로 확인).
+- 수정 후: 방문 집합에 의해 즉시(0.06초 이내) 순환을 감지해 종료(GREEN).
+
+## 수정
+
+DIFAT 확장 섹터 순회 루프에 `HashSet<u32>` 방문 집합을 추가했다. 이미 방문한
+섹터 ID 로 돌아오면 즉시 순회를 중단한다. FAT/미니FAT 체인 순회에 이미 있던
+동일한 패턴(`read_chain_static`)을 DIFAT 순회에도 적용한 것이라 별도 개념 도입이
+아니다.
+
+변경 파일: `src/parser/cfb_reader.rs` (DIFAT 확장 섹터 순회 루프, 순회 로직
+약 6줄 추가) + 회귀 테스트 1건 추가.
+
+## 검증
+
+```
+RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::cfb_reader
+# test result: ok. 9 passed; 0 failed
+
+RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::
+# test result: ok. 427 passed; 0 failed
+```
+
+기존 CFB 관련 테스트(헤더 필드 검증, 손상된 디렉터리 엔트리 name_len 등)와
+전체 `parser` 모듈 테스트 모두 회귀 없이 통과.
+
+## 영향 범위
+
+`LenientCfbReader::open` 은 `parser/mod.rs` 에서 표준 `cfb` 크레이트 파서가
+실패한 뒤 fallback 으로만 호출되므로, 이번 수정은 이미 손상이 확인된 입력
+경로에만 영향을 준다. 정상 CFB 파일의 파싱 결과에는 영향이 없다.

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -394,7 +394,14 @@ impl LenientCfbReader {
         // 추가 DIFAT 섹터 체인
         if difat_sectors_count > 0 && first_difat_sector != Self::END_OF_CHAIN {
             let mut dsid = first_difat_sector;
+            // difat_sectors_count 는 파일 헤더에서 그대로 읽은 값(공격자 통제 가능)이라,
+            // 실제 섹터 체인이 짧은 순환을 이뤄도 최대 u32::MAX 번 순회할 수 있다.
+            // FAT/미니FAT 체인 순회(read_chain_static)처럼 방문 집합으로 순환을 조기 차단한다.
+            let mut visited_difat = std::collections::HashSet::new();
             for _ in 0..difat_sectors_count {
+                if !visited_difat.insert(dsid) {
+                    break;
+                }
                 let off = 512 + dsid as usize * sector_size;
                 if off + sector_size > data.len() {
                     break;
@@ -814,6 +821,48 @@ mod tests {
 
         let r = LenientCfbReader::open(&d);
         assert!(r.is_ok(), "손상된 name_len 에서 패닉 없이 열려야 함");
+    }
+
+    #[test]
+    fn lenient_open_terminates_on_cyclic_difat_chain() {
+        // DIFAT 확장 체인은 header 의 difat_sectors_count(공격자 통제 가능한 4바이트) 만큼
+        // 순회하되, FAT 체인 순회(read_chain_static)와 달리 방문 집합이 없다. 두 DIFAT
+        // 섹터가 서로를 가리키는 순환을 만들고 difat_sectors_count 를 u32::MAX 로 두면,
+        // 실제 체인 길이(2)와 무관하게 최대 40억 회 넘게 순회해 사실상 멈추지 않는다 —
+        // 단일 스레드 WASM 에서는 탭 전체가 응답 없음 상태가 된다.
+        let mut d = minimal_header();
+        d[44..48].copy_from_slice(&0u32.to_le_bytes()); // fat_sectors_count = 0
+        d[68..72].copy_from_slice(&0u32.to_le_bytes()); // first_difat_sector = 섹터 0
+        d[72..76].copy_from_slice(&u32::MAX.to_le_bytes()); // difat_sectors_count: 공격자 제어
+
+        // 헤더(512B) 뒤에 DIFAT 섹터 2개(섹터 0, 섹터 1)를 배치.
+        d.resize(512 + 512 * 2, 0);
+        let entries_per = 512 / 4 - 1; // 127
+        // 모든 FAT-포인터 엔트리는 FREE_SECT 로 채워 fat_sector_ids 가 자라지 않게 한다
+        // (순환 자체와 무관한 메모리 팽창을 피하기 위함).
+        for sector_idx in 0..2usize {
+            let base = 512 + sector_idx * 512;
+            for i in 0..entries_per {
+                let eoff = base + i * 4;
+                d[eoff..eoff + 4].copy_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+            }
+        }
+        // 섹터 0 의 "다음 DIFAT" 포인터 = 섹터 1
+        let next0 = 512 + entries_per * 4;
+        d[next0..next0 + 4].copy_from_slice(&1u32.to_le_bytes());
+        // 섹터 1 의 "다음 DIFAT" 포인터 = 섹터 0 (순환!)
+        let next1 = 512 + 512 + entries_per * 4;
+        d[next1..next1 + 4].copy_from_slice(&0u32.to_le_bytes());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = LenientCfbReader::open(&d);
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(3)).is_ok(),
+            "순환 DIFAT 체인에서 방문 집합 없이 difat_sectors_count 만큼 순회해 반환하지 않음"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

`LenientCfbReader::open` 의 DIFAT 확장 섹터 순회에 방문 집합을 추가해, 순환하는
DIFAT 체인에서 공격자 통제 가능한 `difat_sectors_count`(최대 `u32::MAX`)로 인해
사실상 응답 없음(DoS) 상태가 되던 문제를 고쳤습니다.

## 배경

FAT/미니FAT 체인 순회(`read_chain_static`)는 이미 방문 집합으로 순환을 방지하지만,
같은 함수 안의 DIFAT 확장 섹터 순회에는 그 보호가 없었습니다. 두 DIFAT 섹터가
서로를 가리키도록 손상된 파일을 만들고 헤더의 `difat_sectors_count` 를
`u32::MAX` 로 설정하면, 실제 체인 길이(2)와 무관하게 최대 42억 회 넘게 동일한
섹터를 반복 순회합니다. 패닉은 아니지만 단일 스레드 WASM(브라우저 탭)에서는
사실상 DoS 입니다.

## 변경 사항

- `src/parser/cfb_reader.rs`: DIFAT 확장 섹터 순회 루프에 `HashSet<u32>` 방문
  집합 추가. 이미 방문한 섹터로 돌아오면 즉시 중단.
- 재현 테스트 `lenient_open_terminates_on_cyclic_difat_chain` 추가: 순환 DIFAT
  체인 + `difat_sectors_count = u32::MAX` 입력을 별도 스레드에서 열고 3초 내
  반환하는지 확인.

## 검증

```
RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::cfb_reader
# 9 passed; 0 failed (수정 전 신규 테스트는 RED 로 재현 확인)

RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::
# 427 passed; 0 failed
```

Closes #3181
