### PR TITLE
fix(hwpx): refList의 memoProperties(메모 모양 정의) 왕복 소실 수정 (#3184)

### DIFF
--- a/mydocs/report/task_m100_3184_report.md
+++ b/mydocs/report/task_m100_3184_report.md
@@ -1,0 +1,88 @@
+---
+kind: report
+status: done
+---
+
+# 처리 결과: refList memoProperties hwpx→hwpx 라운드트립 소실
+
+Issue: #3184
+
+## 문제
+
+HWPX 헤더 `<hh:refList>`의 마지막 자식인 `<hh:memoProperties>`(메모 모양 정의:
+테두리 두께/색상/채우기색/타입)가 hwpx→hwpx 라운드트립(parse 후 재직렬화)에서
+통째로 사라진다.
+
+## 근거 (실물 샘플)
+
+`samples/hwpx/aift.hwpx`의 `Contents/header.xml` `refList` 마지막 자식:
+
+```xml
+<hh:memoProperties itemCnt="1">
+  <hh:memoPr id="1" width="15591" lineWidth="3" lineType="SOLID"
+    lineColor="#A9A9A9" fillColor="#CBFF99" activeColor="#FDBCDD" memoType="NOMAL"/>
+</hh:memoProperties>
+```
+
+## 원인
+
+`src/parser/hwpx/header.rs::parse_memo_shape()`는 `<hh:memoPr>`을 읽어
+`DocInfo.extra_records`에 `HWPTAG_MEMO_SHAPE` 바이너리 레코드로만 쌓는다. 이
+레코드는 `src/serializer/doc_info.rs`(HWP5 DocInfo 스트림 직렬화, hwpx→hwp5
+변환 전용)에서만 소비된다. HWPX 재직렬화 경로인
+`src/serializer/hwpx/header.rs::write_header()`는 `extra_records`를 전혀
+참조하지 않고, `fontfaces`~`styles`까지만 `refList` 자식을 재구성해 방출한 뒤
+바로 `</hh:refList>`를 닫는다 — `memoProperties`를 방출하는 코드 자체가
+없었다.
+
+## 3중 중복확인
+
+- upstream log: `git log --oneline -- src/serializer/hwpx/header.rs`에
+  memoProperties 관련 커밋 없음.
+- gh 이슈 검색: `memoProperties`/`memoShape` 검색 결과 기존 이슈 없음(관련
+  이슈 #2779는 `secPr memoShapeIDRef` 참조 보존이고, #2978은 `parse_memo_shape`
+  내부 lineType enum 매핑 오류로 별개 지점).
+- git grep: `write_header.rs` 전체에 `memoProperties`/`memoPr` 토큰이 전무함을
+  확인.
+
+## 재현 (red)
+
+`src/serializer/hwpx/header.rs`에 테스트 추가 후, 직렬화기 splice 로직을
+임시로 비활성화(`if false { ... }`)하고 확인:
+
+```
+test serializer::hwpx::header::tests::write_header_preserves_memo_properties_roundtrip ... FAILED
+재직렬화된 header.xml에 memoProperties가 있어야 함
+```
+
+## 수정
+
+`hwpx_head_tail`(refList 뒤 compatibleDocument/docOption/trackchageConfig
+splice)과 동일한 verbatim splice 패턴 적용:
+
+1. `src/model/document.rs`: `DocInfo.memo_properties_xml: Option<String>` 필드
+   추가.
+2. `src/parser/hwpx/header.rs`: `extract_memo_properties()` 추가 — 헤더 원문에서
+   `<hh:memoProperties>...</hh:memoProperties>`(또는 자기닫힘) 블록을 그대로
+   추출해 저장. `parse_hwpx_header()`에서 `hwpx_head_tail`과 나란히 호출.
+3. `src/serializer/hwpx/header.rs`: `write_styles()` 이후, `</hh:refList>` 닫기
+   전에 `doc.doc_info.memo_properties_xml`이 있으면 그대로 splice.
+
+기존 `parse_memo_shape()`/`extra_records`(hwpx→hwp5 변환용)는 그대로 유지.
+
+## 검증 (green)
+
+```
+test serializer::hwpx::header::tests::write_header_preserves_memo_properties_roundtrip ... ok
+```
+
+`cargo test --lib`: 전체 2553개 통과, 실패 1건은 이번 변경과 무관한
+`renderer::font_paths::tests::env_font_paths_parses_and_filters`
+(환경변수/tmp 경로 의존, 손대지 않은 `font_paths.rs`에서 발생 — 사전 존재하는
+환경 이슈로 판단).
+
+## 파일
+
+- `src/model/document.rs`
+- `src/parser/hwpx/header.rs`
+- `src/serializer/hwpx/header.rs`

--- a/mydocs/report/task_m100_3184_report.md
+++ b/mydocs/report/task_m100_3184_report.md
@@ -86,3 +86,77 @@ test serializer::hwpx::header::tests::write_header_preserves_memo_properties_rou
 - `src/model/document.rs`
 - `src/parser/hwpx/header.rs`
 - `src/serializer/hwpx/header.rs`
+
+## 후속: PR #3185 메인테이너 지적 — IR 필드 스윕 발산 +2건 (2026-07-24)
+
+### 증상
+
+메인테이너가 `ir_field_sweep_does_not_regress`(799샘플)에서 이 PR 단독으로
+5개 파일의 `sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]`
+발산이 +2씩 늘었다고 지적(이분탐색으로 원인 커밋 확정, 예: aift.hwpx
+1477→1479). "memoProperties 방출이 refList 구조를 바꾸며 표 셀 문단
+raw_header_extra 왕복에 부수효과를 낸 것 같다"는 가설을 남김.
+
+### 조사 (실측)
+
+1. `cargo test --test ir_field_sweep_baseline ir_field_sweep_does_not_regress`
+   로 재현: 동일 5개 파일에서 +2 확인.
+2. 이 커밋(8b11e2218)만 되돌린 worktree(upstream devel 기준)와 적용본을 각각
+   빌드해 `sweep_hwpx_roundtrip(aift.hwpx)` 를 직접 호출·비교.
+3. 지적된 경로(`sections[2].paragraphs[134].controls[0].cells[57].paragraphs[0]`)
+   의 `raw_header_extra` 실제 바이트를 두 빌드에서 직접 추출: **완전히
+   동일**(원본 `[0,0,0,0,0,0,0,0,0,0]` vs 재파싱 `[0,0,0,0,0,0,54,3,0,0]`,
+   두 빌드 모두 동일값). 즉 이 특정 문단의 직렬화 결과 자체는 이 PR로
+   **전혀 바뀌지 않았다.**
+4. 그런데 되돌린 빌드에서 `sweep_documents()`를 직접 호출하면 이 경로가
+   발산 목록에 **아예 없다**. 원인 추적 결과
+   `src/diagnostics/ir_field_sweep.rs:70`의 `MAX_DIVERGENCES: usize = 2000`
+   전역 캡 확인. `sweep_documents()`는 `sweep_doc_info()` → `sections`
+   순으로 같은 `out: Vec<FieldDivergence>`에 계속 적재하며, 캡에 도달하면
+   이후 모든 재귀 호출이 즉시 `break`한다(388~391행 등 각 재귀 지점마다
+   동일 체크).
+5. aift.hwpx는 이미 발산 총량이 캡(2000)에 근접/도달한 파일이다. 확인 결과:
+   - 되돌린 빌드(버그 있는 상태): `doc_info` 레벨 발산 2건
+     (`memo_shape_count: 1→0`, `extra_records.len: 6→5` — 바로 #3184
+     버그 그 자체).
+   - 이 PR 적용본: `doc_info` 레벨 발산 **0건**(정확히 수정됨).
+   - 두 빌드 모두 `sweep_documents()` 총 발산 = **2000**(캡 도달).
+   `sweep_doc_info()`가 섹션보다 먼저 실행되므로, doc_info 레벨 발산 2건이
+   사라지면 캡 도달 시점이 딱 2건만큼 뒤로 밀려, 이미 존재했지만 캡에
+   가려 기록되지 못했던 표 셀 `raw_header_extra` 발산(한컴 원본이 `id="0"`
+   /`0x80000000` 같은 sentinel을 쓰고 우리 직렬화기는 항상 순차 id를
+   새로 매기는, **이 PR과 무관한 기존 현상**)이 2건 더 드러난 것이다.
+
+### 결론
+
+**실제 직렬화 회귀가 아니다.** 표 셀 문단의 `raw_header_extra`(instanceId)는
+이 PR 전후로 바이트 단위까지 동일하며, 이 PR이 고치는 `doc_info.memo_shape_count`
+/`extra_records.len` 회귀 수정이 스윕 도구의 `MAX_DIVERGENCES=2000` 전역
+캡 안에서 "예산"을 2건 절약해, 원래부터 있었던(그러나 캡에 가려 안 보이던)
+표 셀 id 불일치 backlog 2건을 더 드러낸 것뿐이다. `baseline.tsv` 재생성
+결과(`RHWP_IR_SWEEP_DUMP=... cargo test --profile release-test --test
+ir_field_sweep_baseline`)에서도 이 5개 파일 모두 **`doc_info.memo_shape_count`
+/`doc_info.extra_records.len` 행이 사라지고(수정 확인) 그 대가로 같은
+5개 파일의 `raw_header_extra[]` 카운트가 +2**로 정확히 대응됨을 확인했다
+— 우연이 아니라 캡 메커니즘의 직접적 산술 결과.
+
+### 조치
+
+- 소스 코드 변경 없음(고칠 실제 결함이 없음).
+- `tests/fixtures/ir_field_sweep_baseline.tsv` 재생성(래칫 절차 그대로
+  따름) → 5개 파일의 `raw_header_extra[]` 행 +2 갱신 + 9개 파일의
+  `doc_info.memo_shape_count`/`doc_info.extra_records.len` 행 제거(진짜
+  개선, #3184 수정이 aift.hwpx 외 8개 파일에서도 추가로 효과가 있었음을
+  확인).
+- 리베이스로 인해 hwp5rb 레인 일부(`chars[]`) 발산도 함께 줄었는데, 이는
+  이 PR과 무관하게 upstream devel에 먼저 반영된 개선분이 재생성 시점에
+  자연 반영된 것.
+- `cargo test --test ir_field_sweep_baseline`(799샘플) green,
+  `write_header_preserves_memo_properties_roundtrip` 여전히 PASS 확인.
+
+### 참고: MAX_DIVERGENCES 캡의 한계 (별도 이슈 후보, 이번 PR 범위 밖)
+
+캡이 낮은 파일에서는 "실제로는 무해한" doc_info 레벨 수정이 하위 트리의
+드러나는 발산 개수를 흔들 수 있다는 뜻이라, 향후 유사한 헷갈림을 줄이려면
+캡을 (a) 최상위에서만 걸거나 (b) 레인/경로별로 독립적으로 적용하는 개선을
+고려할 만하다. 이번 PR 범위에서는 손대지 않음.

--- a/src/model/document.rs
+++ b/src/model/document.rs
@@ -178,6 +178,12 @@ pub struct DocInfo {
     pub bullet_count: u32,
     /// MemoShape 개수 (ID_MAPPINGS에 포함, 현재 파싱 미지원이지만 보존 필요)
     pub memo_shape_count: u32,
+    /// HWPX 헤더 `<hh:refList>` 안의 `<hh:memoProperties>...</hh:memoProperties>`
+    /// (또는 자기닫힘) 블록을 원본 그대로 보존한다. `extra_records`의
+    /// HWPTAG_MEMO_SHAPE 바이너리는 hwpx→hwp5 변환 전용이라 hwpx→hwpx
+    /// 라운드트립 시 refList에 재방출되지 않아, memoPr(메모 테두리/색상 모양)이
+    /// 통째로 소실되는 문제를 splice 보존으로 막는다. 원본에 없으면 None.
+    pub memo_properties_xml: Option<String>,
     /// DISTRIBUTE_DOC_DATA 레코드 제거 플래그 (serializer에서 raw_stream surgical remove 수행)
     pub distribute_doc_data_removed: bool,
     /// raw_stream이 model 변경과 동기화되지 않음 (serializer에서 재생성 필요)

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -208,8 +208,29 @@ pub fn parse_hwpx_header(xml: &str) -> Result<(DocInfo, DocProperties), HwpxErro
     // compatibleDocument/docOption/trackchageConfig 등은 본문과 무관한 전역
     // 설정이라 헤더 재생성 시 splice 로 무손실 복원한다.
     doc_info.hwpx_head_tail = extract_head_tail(xml);
+    doc_info.memo_properties_xml = extract_memo_properties(xml);
 
     Ok((doc_info, doc_props))
+}
+
+/// HWPX 헤더 원문에서 `<hh:memoProperties>...</hh:memoProperties>`
+/// (또는 자기닫힘 `<hh:memoProperties .../>`) 블록을 그대로 추출한다.
+/// `parse_memo_shape`가 만드는 HWPTAG_MEMO_SHAPE 바이너리는 hwpx→hwp5
+/// 변환용 `extra_records`에만 쌓이고 HWPX 재직렬화 시 사용되지 않으므로,
+/// hwpx→hwpx 라운드트립에서 memoPr(메모 모양 정의)이 통째로 사라지는 것을
+/// 막기 위해 원문을 verbatim 보존한다.
+fn extract_memo_properties(xml: &str) -> Option<String> {
+    const OPEN: &str = "<hh:memoProperties";
+    let start = xml.find(OPEN)?;
+    let tail = &xml[start..];
+    let first_close = tail.find('>')?;
+    if tail.as_bytes()[first_close - 1] == b'/' {
+        // 자기닫힘: <hh:memoProperties itemCnt="0"/>
+        return Some(tail[..=first_close].to_string());
+    }
+    const CLOSE: &str = "</hh:memoProperties>";
+    let end = tail.find(CLOSE)? + CLOSE.len();
+    Some(tail[..end].to_string())
 }
 
 /// HWPX 헤더 문자열에서 `</hh:refList>` 닫는 태그와 `</hh:head>` 사이 구간을

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -85,6 +85,15 @@ pub fn write_header(doc: &Document, ctx: &SerializeContext) -> Result<Vec<u8>, S
     write_bullets(&mut w, &doc.doc_info)?;
     write_para_properties(&mut w, &doc.doc_info, ctx)?;
     write_styles(&mut w, &doc.doc_info, ctx)?;
+    // memoProperties(메모 모양 정의: 테두리/색상)는 refList 마지막 자식으로,
+    // parse_memo_shape가 만드는 extra_records(HWPTAG_MEMO_SHAPE, hwpx→hwp5
+    // 변환 전용)는 여기서 쓰이지 않는다. 원본 verbatim splice로 hwpx→hwpx
+    // 라운드트립 시 memoPr 소실을 막는다(#3xxx).
+    if let Some(memo_properties) = &doc.doc_info.memo_properties_xml {
+        w.get_mut()
+            .write_all(memo_properties.as_bytes())
+            .map_err(|e| SerializeError::XmlError(format!("memoProperties splice: {e}")))?;
+    }
     end_tag(&mut w, "hh:refList")?;
 
     // 문서 설정 tail: 원본 HWPX 가 있으면 그대로 splice(compatibleDocument/
@@ -1475,6 +1484,34 @@ mod tests {
         assert!(
             !xml.contains(r#"version="1.2""#),
             "하드코딩 1.2 가 남아있으면 안 됨"
+        );
+    }
+
+    #[test]
+    fn write_header_preserves_memo_properties_roundtrip() {
+        // aift.hwpx 실물 헤더에는 refList 마지막 자식으로
+        // <hh:memoProperties itemCnt="1"><hh:memoPr .../></hh:memoProperties>
+        // 가 있다. parse_memo_shape()가 만드는 extra_records(HWPTAG_MEMO_SHAPE)는
+        // hwpx→hwp5 변환 전용이라 write_header가 참조하지 않으므로, splice
+        // 보존이 없으면 hwpx→hwpx 라운드트립에서 memoPr(메모 모양: 테두리/색상)이
+        // 통째로 사라진다.
+        let bytes = include_bytes!("../../../samples/hwpx/aift.hwpx");
+        let doc = parse_hwpx(bytes).expect("parse aift.hwpx");
+        assert!(
+            doc.doc_info.memo_properties_xml.is_some(),
+            "파서가 memoProperties 원문을 보존해야 함"
+        );
+        let ctx = SerializeContext::collect_from_document(&doc);
+        let header_xml =
+            String::from_utf8(write_header(&doc, &ctx).expect("write header")).unwrap();
+        assert!(
+            header_xml.contains("<hh:memoProperties"),
+            "재직렬화된 header.xml에 memoProperties가 있어야 함: {header_xml}"
+        );
+        assert!(
+            header_xml.contains(r#"lineType="SOLID""#)
+                && header_xml.contains(r##"fillColor="#CBFF99""##),
+            "memoPr 원본 속성(lineType/fillColor 등)이 그대로 보존돼야 함: {header_xml}"
         );
     }
 

--- a/tests/fixtures/ir_field_sweep_baseline.tsv
+++ b/tests/fixtures/ir_field_sweep_baseline.tsv
@@ -119,7 +119,6 @@ hwp5rb	basic/issue1994_behindtext_table_20200830.hwp	sections[].paragraphs[].con
 hwp5rb	basic/issue2007_nested_cell_pagination_42065.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	4
 hwp5rb	basic/issue2007_nested_cell_pagination_42065.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	2
 hwp5rb	basic/issue2007_nested_cell_pagination_42065.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	39
-hwp5rb	basic/issue2007_nested_cell_pagination_42065.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	7
 hwp5rb	basic/request.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	9
 hwp5rb	basic/treatise sample.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	5
 hwp5rb	biz_plan.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	6
@@ -257,7 +256,6 @@ hwp5rb	hwpx/hancom-hwp/hy-002.hwp	sections[].paragraphs[].controls[].cells[].lis
 hwp5rb	hwpx/hancom-hwp/issue_157.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	21
 hwp5rb	hwpx/hancom-hwp/issue_241.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	28
 hwp5rb	hwpx/hancom-hwp/mel-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	282
-hwp5rb	hwpx/hancom-hwp/mel-001.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	6
 hwp5rb	hwpx/hancom-hwp/tb-org-02.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	54
 hwp5rb	hwpx_sample2.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	382
 hwp5rb	hwpx_sample2.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	166
@@ -267,7 +265,6 @@ hwp5rb	issue-986-receipt.hwp	sections[].paragraphs[].controls[].cells[].list_hea
 hwp5rb	issue1510_coanchored_float_tables.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	9
 hwp5rb	issue1510_coanchored_float_tables.hwp	sections[].paragraphs[].controls[].cells[].raw_list_extra.len	9
 hwp5rb	issue1842_cell_tac_group_lineheight.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	37
-hwp5rb	issue1842_cell_tac_group_lineheight.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	2
 hwp5rb	issue1921/59043_regulatory_analysis.hwp	sections[].paragraphs[].char_count	9
 hwp5rb	issue1921/59043_regulatory_analysis.hwp	sections[].paragraphs[].control_mask	9
 hwp5rb	issue1921/59043_regulatory_analysis.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	216
@@ -302,15 +299,12 @@ hwp5rb	issue2808_report_physical_ladder.hwp	sections[].paragraphs[].controls[].c
 hwp5rb	issue_1133.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	15
 hwp5rb	issues/2809/jubo_20260104.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	174
 hwp5rb	k-water-rfp-2024.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	457
-hwp5rb	k-water-rfp-2024.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	3
 hwp5rb	k-water-rfp.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	457
-hwp5rb	k-water-rfp.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	3
 hwp5rb	kps-ai.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1151
 hwp5rb	kps-ai.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	135
 hwp5rb	landscape-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	33
 hwp5rb	loading-fail-01.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	32
 hwp5rb	mel-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	137
-hwp5rb	mel-001.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	6
 hwp5rb	multi-table-001.hwp	sections[].paragraphs[].char_count	1
 hwp5rb	multi-table-001.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	multi-table-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	69
@@ -348,7 +342,6 @@ hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].char_count	1
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	36
 hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	11
-hwp5rb	table-vpos-01.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	6
 hwp5rb	table_scattered_header_rowbreak.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2000
 hwp5rb	tac-case-001.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	4
 hwp5rb	tac-img-02.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	1871
@@ -396,7 +389,6 @@ hwp5rb	task2430/1382000_domestic_violence_survey.hwp	sections[].paragraphs[].cha
 hwp5rb	task2430/1382000_domestic_violence_survey.hwp	sections[].paragraphs[].control_mask	1
 hwp5rb	task2430/1382000_domestic_violence_survey.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	220
 hwp5rb	task2430/1382000_domestic_violence_survey.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	1
-hwp5rb	task2430/1382000_domestic_violence_survey.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].chars[]	2
 hwp5rb	tb-img-03.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	4
 hwp5rb	text-align-2.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2
 hwp5rb	text-align.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	2
@@ -423,15 +415,11 @@ hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraph
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1869
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].raw_header_extra[]	129
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	doc_info.extra_records.len	1
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	doc_info.memo_shape_count	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1878
+hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1880
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].raw_header_extra[]	118
-hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	doc_info.extra_records.len	1
-hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	doc_info.memo_shape_count	1
-hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1855
+hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1857
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_y	2
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
@@ -440,24 +428,18 @@ hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	sections[].paragraphs[].raw_header_extra[]	135
 hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1868
 hwpx	2025년 2분기 해외직접투자 (최종).hwpx	sections[].paragraphs[].raw_header_extra[]	132
-hwpx	2026_oss_rst.hwpx	doc_info.extra_records.len	1
-hwpx	2026_oss_rst.hwpx	doc_info.memo_shape_count	1
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	16
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	221
 hwpx	2026_oss_rst.hwpx	sections[].paragraphs[].raw_header_extra[]	19
-hwpx	[2027] 온새미로 1 본교재.hwpx	doc_info.extra_records.len	1
-hwpx	[2027] 온새미로 1 본교재.hwpx	doc_info.memo_shape_count	1
-hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	357
+hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	359
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	18
 hwpx	[2027] 온새미로 1 본교재.hwpx	sections[].paragraphs[].raw_header_extra[]	1621
-hwpx	aift.hwpx	doc_info.extra_records.len	1
-hwpx	aift.hwpx	doc_info.memo_shape_count	1
 hwpx	aift.hwpx	sections[].paragraphs[].controls[]	4
 hwpx	aift.hwpx	sections[].paragraphs[].controls[].caption.paragraphs[].raw_header_extra[]	2
 hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	149
-hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1477
+hwpx	aift.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1479
 hwpx	aift.hwpx	sections[].paragraphs[].raw_header_extra[]	366
 hwpx	basic-table-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	11
 hwpx	basic-table-01.hwpx	sections[].paragraphs[].raw_header_extra[]	5
@@ -567,8 +549,6 @@ hwpx	form-01.hwpx	sections[].paragraphs[].raw_header_extra[]	12
 hwpx	form-02.hwpx	sections[].paragraphs[].controls[].properties	1
 hwpx	form-02.hwpx	sections[].paragraphs[].controls[].properties.len	1
 hwpx	form-02.hwpx	sections[].paragraphs[].raw_header_extra[]	12
-hwpx	hcar-001.hwpx	doc_info.extra_records.len	1
-hwpx	hcar-001.hwpx	doc_info.memo_shape_count	1
 hwpx	hcar-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	76
 hwpx	hcar-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	409
 hwpx	hcar-001.hwpx	sections[].paragraphs[].raw_header_extra[]	20
@@ -582,9 +562,7 @@ hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_
 hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].raw_header_extra[]	134
 hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1868
 hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].raw_header_extra[]	132
-hwpx	hwpx-h-03.hwpx	doc_info.extra_records.len	1
-hwpx	hwpx-h-03.hwpx	doc_info.memo_shape_count	1
-hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1855
+hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1857
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_x	2
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].controls[].shape_attr.offset_y	2
 hwpx	hwpx-h-03.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
@@ -595,8 +573,6 @@ hwpx	hy-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_hea
 hwpx	hy-001.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
 hwpx	hy-001.hwpx	sections[].paragraphs[].controls[][].drawing.shape_attr.offset_y	1
 hwpx	hy-001.hwpx	sections[].paragraphs[].raw_header_extra[]	59
-hwpx	hy-002.hwpx	doc_info.extra_records.len	1
-hwpx	hy-002.hwpx	doc_info.memo_shape_count	1
 hwpx	hy-002.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	114
 hwpx	hy-002.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	2
 hwpx	hy-002.hwpx	sections[].paragraphs[].controls[][].drawing.shape_attr.offset_y	1
@@ -655,8 +631,6 @@ hwpx	local-font-nanumsquare-bold.hwpx	sections[].paragraphs[].raw_header_extra[]
 hwpx	math-001.hwpx	sections[].paragraphs[].raw_header_extra[]	29
 hwpx	mel-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1975
 hwpx	mel-001.hwpx	sections[].paragraphs[].raw_header_extra[]	25
-hwpx	pagenation-001.hwpx	doc_info.extra_records.len	1
-hwpx	pagenation-001.hwpx	doc_info.memo_shape_count	1
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
 hwpx	pagenation-001.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	215


### PR DESCRIPTION
## 결함

HWPX 헤더 `<hh:refList>`의 마지막 자식인 `<hh:memoProperties>`(메모 모양 정의: 테두리 두께/색상/채우기색/타입)가 parse 후 다시 HWPX로 직렬화(hwpx→hwpx 왕복)할 때 통째로 사라집니다. `parse_memo_shape()`(src/parser/hwpx/header.rs)가 이를 `HWPTAG_MEMO_SHAPE` 바이너리 레코드로만 변환해 `DocInfo.extra_records`에 넣는데, 이건 HWP5 직렬화기만 소비하고 `write_header()`(src/serializer/hwpx/header.rs)는 `extra_records`를 전혀 참조하지 않은 채 styles 뒤에서 `</hh:refList>`를 닫아버립니다.

실물 샘플 `samples/hwpx/aift.hwpx`로 재현 확인.

## 수정

`DocInfo.memo_properties_xml: Option<String>` 필드 추가(hwpx_head_tail과 동일한 verbatim splice 패턴). 파서가 원본 `<hh:memoProperties>...</hh:memoProperties>` 블록을 그대로 추출해 저장하고, 직렬화기가 refList를 닫기 전에 그대로 재방출합니다.

## red→green

신규 테스트(serializer/hwpx/header.rs) — 수정 비활성화 시 FAIL 확인, 수정 후 PASS. `cargo test --lib` 2553 passed(기존 무관 실패 1건 제외).

Closes #3184