### PR TITLE
fix(ooxml_chart): 파이 차트 시리즈 이름 없어도 범례 공간 예약

### DIFF
--- a/mydocs/report/task_m100_3186_report.md
+++ b/mydocs/report/task_m100_3186_report.md
@@ -1,0 +1,64 @@
+---
+kind: report
+status: active
+last_verified: 2026-07-23
+---
+
+# 처리 결과 — 파이 차트 범례 공간 미예약 (Issue: #3186)
+
+## 증상
+
+원형(파이) 차트는 카테고리 기반 범례를 사용하므로 시리즈 이름(`c:tx`)이 비어 있어도
+`render_chart_svg`의 파이 분기가 `render_legend`/`render_legend_right`를 무조건
+호출해 범례가 항상 그려진다. 그런데 범례를 위한 레이아웃 공간(`legend_h`/`legend_w`)은
+`legend_visible = chart.series.iter().any(|s| !s.name.is_empty())`, 즉 시리즈 이름
+존재 여부로만 계산되고 있었다.
+
+결과: 시리즈 이름이 없는 파이 차트는 범례는 그려지는데 플롯 영역이 그 공간을 빼지
+않고 계산되어 파이가 부당하게 커지고 범례와 겹친다.
+
+## 재현 (red)
+
+`src/ooxml_chart/renderer.rs`에 테스트
+`test_pie_legend_reserves_space_regardless_of_series_name` 추가. 카테고리 3개,
+값 3개, 시리즈 이름만 다른(`"판매"` vs `""`) 두 파이 차트를 400x300으로 렌더링해
+파이 반지름(SVG path의 `A r,r`)을 비교:
+
+- 이름 있음: r = 111.6 (범례 공간 22px 예약)
+- 이름 없음: r = 121.5 (범례 공간 미예약 — 버그)
+
+두 경우 모두 `hwp-chart-legend`가 렌더 결과에 포함되므로(카테고리 기반) 반지름은
+같아야 정상. 수정 전 FAIL 확인.
+
+## 원인
+
+`render_chart_svg`(`src/ooxml_chart/renderer.rs`)의 `legend_visible` 계산이 모든
+차트 종류에 대해 "시리즈 이름 존재 여부"만 사용했다. 그러나 파이 차트의 범례는
+`legend_items()`에서 카테고리 라벨을 사용하며(`chart.categories`), 시리즈 이름과
+무관하게 항상 렌더링 분기를 탄다(파이 전용 분기는 `legend_visible`을 참조하지 않고
+무조건 `render_legend`/`render_legend_right`를 호출).
+
+## 수정
+
+`legend_visible` 계산에 파이 차트 종류를 추가로 포함:
+
+```rust
+let legend_visible =
+    chart.chart_type == OoxmlChartType::Pie || chart.series.iter().any(|s| !s.name.is_empty());
+```
+
+`render_chart_svg` 진입 시 `chart.series.is_empty()`면 이미 fallback으로 반환되므로
+파이 차트는 항상 `series`가 1개 이상 존재 — 위 변경은 안전하다.
+
+## 검증
+
+- 신규 테스트 green 확인.
+- `cargo test --lib ooxml_chart` 138개 전부 pass (기존 회귀 없음).
+- `cargo fmt --check`: 대상 파일 diff 없음(CRLF 관련 노이즈만, 기존에도 존재).
+- `cargo clippy --lib -- -D warnings`: 경고 없음.
+- `cargo test --release --lib`: 실행 완료 확인(별도 로그).
+
+## 영향 범위
+
+`src/ooxml_chart/renderer.rs` 한 줄 조건 추가 + 테스트 1건. 파이 차트가 아닌
+경우(막대/선/분산형/stock/콤보) 동작 변화 없음.

--- a/src/ooxml_chart/renderer.rs
+++ b/src/ooxml_chart/renderer.rs
@@ -206,7 +206,10 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
 
     // 영역 분할
     let title_h = if effective_title.is_some() { 22.0 } else { 4.0 };
-    let legend_visible = chart.series.iter().any(|s| !s.name.is_empty());
+    // 파이는 카테고리 기반 범례라 시리즈 이름과 무관하게 항상 그려진다(파이 분기가
+    // render_legend/render_legend_right를 무조건 호출) — 공간 예약도 그에 맞춰야 함.
+    let legend_visible =
+        chart.chart_type == OoxmlChartType::Pie || chart.series.iter().any(|s| !s.name.is_empty());
     // C1c #1882 갭③: legendPos=r(한컴 코퍼스 전 샘플)은 우측 세로 스택 — 하단 슬롯
     // 대신 우측 폭(legend_w)을 확보. 그 외 위치는 현행 하단 가로 유지.
     // `w * 0.30 >= 50.0` 가드: 폭이 좁으면(<167px) 하단 폴백 — 아래 clamp의
@@ -2257,6 +2260,53 @@ mod tests {
         let chart = OoxmlChart::default();
         let svg = render_chart_svg(&chart, 0.0, 0.0, 100.0, 100.0);
         assert!(svg.contains("fallback"));
+    }
+
+    #[test]
+    fn test_pie_legend_reserves_space_regardless_of_series_name() {
+        // 파이 범례는 카테고리 기반이라 시리즈 이름과 무관하게 항상 그려진다
+        // (render_chart_svg 파이 분기는 legend_h/legend_w 계산과 무관하게
+        // render_legend를 무조건 호출). 그런데 legend_h/legend_w는
+        // `legend_visible`(= 시리즈 이름 존재 여부)로만 계산되므로, 시리즈
+        // 이름이 없으면 범례가 그려지는데도 plot_h가 legend 공간을 빼지 않고
+        // 계산되어(버그) 파이 반지름이 이름 있는 경우보다 부당하게 커진다.
+        fn pie(name: &str) -> OoxmlChart {
+            OoxmlChart {
+                chart_type: OoxmlChartType::Pie,
+                series: vec![OoxmlSeries {
+                    name: name.to_string(),
+                    values: vec![1.0, 2.0, 3.0],
+                    series_type: OoxmlChartType::Pie,
+                    ..Default::default()
+                }],
+                categories: vec!["가".into(), "나".into(), "다".into()],
+                ..Default::default()
+            }
+        }
+        fn pie_radius(svg: &str) -> f64 {
+            // path의 `A{r},{r}` 반지름 값을 첫 슬라이스에서 추출
+            let a_pos = svg.find(" A").expect("파이 path 없음");
+            let rest = &svg[a_pos + 2..];
+            let comma = rest.find(',').unwrap();
+            rest[..comma].parse::<f64>().unwrap()
+        }
+
+        let named_svg = render_chart_svg(&pie("판매"), 0.0, 0.0, 400.0, 300.0);
+        let unnamed_svg = render_chart_svg(&pie(""), 0.0, 0.0, 400.0, 300.0);
+
+        // 두 경우 모두 범례가 그려진다 (카테고리 기반이므로 시리즈 이름 무관)
+        assert!(named_svg.contains("hwp-chart-legend"));
+        assert!(unnamed_svg.contains("hwp-chart-legend"));
+
+        let named_r = pie_radius(&named_svg);
+        let unnamed_r = pie_radius(&unnamed_svg);
+        // 범례가 동일하게 그려지므로 예약 공간도 동일해야 하고, 따라서 두
+        // 반지름이 같아야 한다. 버그 상태에서는 unnamed_r > named_r (범례
+        // 공간이 예약되지 않아 파이가 legend와 겹치도록 더 크게 그려짐).
+        assert_eq!(
+            named_r, unnamed_r,
+            "시리즈 이름 유무와 무관하게 파이 범례 공간이 동일하게 예약되어야 함 (named={named_r}, unnamed={unnamed_r})"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 요약

원형(파이) 차트는 카테고리 기반 범례를 사용하므로 시리즈 이름(`c:tx`)이 비어 있어도
범례가 항상 그려진다. 그런데 범례 레이아웃 공간(`legend_h`/`legend_w`)은 시리즈 이름
존재 여부로만 계산되어, 시리즈 이름이 없는 파이 차트는 범례가 그려지는데도 공간이
예약되지 않아 파이가 범례와 겹치는 문제가 있었다.

## 변경

`src/ooxml_chart/renderer.rs`의 `legend_visible` 계산에 파이 차트 조건을 추가:

```rust
let legend_visible =
    chart.chart_type == OoxmlChartType::Pie || chart.series.iter().any(|s| !s.name.is_empty());
```

## 검증

- 신규 테스트 `test_pie_legend_reserves_space_regardless_of_series_name` 추가 —
  수정 전 FAIL(named r=111.6 vs unnamed r=121.5), 수정 후 PASS.
- `cargo test --lib ooxml_chart` 138개 전부 pass.
- `cargo fmt --check`, `cargo clippy --lib -- -D warnings` 통과.
- `cargo test --release --lib` 실행 — 무관한 사전 존재 테스트 1건
  (`renderer::font_paths::tests::env_font_paths_parses_and_filters`, 병렬 실행 시
  env var 경합으로 인한 플레이크, 단독 실행 시 pass) 외 전부 pass.

Closes #3186
