### PR TITLE
fix(hwpx): 문단번호 paraHead 폴백에서 textOffset/charPrIDRef 하드코딩 수정 (#3192)

### DIFF
--- a/mydocs/report/task_m100_3192_report.md
+++ b/mydocs/report/task_m100_3192_report.md
@@ -1,0 +1,44 @@
+# Task M100 #3192 구현 보고서
+
+Issue: #3192
+
+## 목표
+
+HWP5(.hwp) → HWPX 저장 경로에서 문단 번호(numbering) `paraHead` 폴백 스켈레톤이
+`textOffset`/`charPrIDRef` 를 하드코딩해 원본 값을 유실하는 문제를 수정한다.
+
+## 원인
+
+- `src/serializer/hwpx/header.rs::write_numbering()` 은 원본 HWPX `raw_para_heads` splice가
+  없을 때(HWP5 경유 등) 10개 레벨에 대해 하드코딩 뼈대를 방출한다.
+- 이 폴백이 `("textOffset", "50")`, `("charPrIDRef", &u32::MAX.to_string())` 를 무조건
+  써서, `NumberingHead.text_distance`/`char_shape_id` 값(HWP5 DocInfo 파서가 표 43 규격
+  12바이트 레코드에서 실제로 채운 값, `src/parser/doc_info.rs`)을 전혀 참조하지 않았다.
+- 같은 파일의 대응 함수 `write_bullet()` 은 이미 `b.text_distance`/`b.char_shape_id` 를
+  값으로 채워 방출하고 있어(989~993번째 줄 부근), numbering 쪽만 비대칭적으로
+  하드코딩되어 있었다.
+- `numFormat="DIGIT"` 하드코딩은 별도 이슈(#2947/#3097)에서 이미 수정되었다 —
+  이번 수정은 그 외 나머지 속성(textOffset, charPrIDRef)에 한정한다.
+
+## 변경
+
+- `write_numbering()` 폴백 스켈레톤에서 `textOffset` 을 `h.text_distance`, `charPrIDRef` 를
+  `h.char_shape_id` 값으로 방출하도록 수정. `numFormat="DIGIT"` 하드코딩은 이번 이슈 범위
+  밖이라 손대지 않았다.
+
+## 검증
+
+1. Red: `write_numbering_skeleton_preserves_text_distance_and_char_shape_id` 테스트를
+   먼저 작성 — `NumberingHead.text_distance = 130`, `char_shape_id = 7` 을 넣고 직렬화한
+   결과에 `textOffset="130"`, `charPrIDRef="7"` 이 있는지 확인. 수정 전 코드에서 FAIL
+   확인(실제 출력은 `textOffset="50"`, `charPrIDRef="4294967295"`).
+2. 최소 수정 적용 후 같은 테스트 PASS.
+3. 기존 `write_numbering_falls_back_to_skeleton_when_no_raw`,
+   `write_numbering_splices_raw_para_heads_verbatim` 등 주변 테스트 회귀 없음.
+4. `RUSTFLAGS="-C linker=rust-lld" cargo test --lib` 전체 스윕: 2554 passed, 0 failed,
+   7 ignored.
+
+## 참고
+
+- 이 PC 환경은 Norton TLS 검사로 인한 dbghelp 링커 오류가 있어
+  `RUSTFLAGS="-C linker=rust-lld"` 로 우회했다(기존 알려진 이슈, 코드와 무관).

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -910,6 +910,8 @@ fn write_numbering<W: Write>(
         let level_s = (level + 1).to_string();
         let start_s = start.to_string();
         let wa = h.width_adjust.to_string();
+        let text_offset_s = h.text_distance.to_string();
+        let char_pr_id_ref_s = h.char_shape_id.to_string();
         empty_tag(
             w,
             "hh:paraHead",
@@ -921,9 +923,9 @@ fn write_numbering<W: Write>(
                 ("autoIndent", "1"),
                 ("widthAdjust", &wa),
                 ("textOffsetType", "PERCENT"),
-                ("textOffset", "50"),
+                ("textOffset", &text_offset_s),
                 ("numFormat", "DIGIT"),
-                ("charPrIDRef", &u32::MAX.to_string()),
+                ("charPrIDRef", &char_pr_id_ref_s),
                 ("checkable", "0"),
             ],
         )?;
@@ -2203,6 +2205,30 @@ mod tests {
 
         assert_eq!(xml.matches("<hh:paraHead").count(), 10);
         assert!(xml.starts_with(r#"<hh:numbering id="1" start="0">"#));
+    }
+
+    #[test]
+    fn write_numbering_skeleton_preserves_text_distance_and_char_shape_id() {
+        // HWP5 경로(raw_para_heads 없음)에서 NumberingHead.text_distance /
+        // char_shape_id 는 DocInfo 파서가 실제 값으로 채워 넣는 필드인데,
+        // 폴백 스켈레톤이 textOffset="50" / charPrIDRef=u32::MAX 로 하드코딩해
+        // 유실시키면 안 된다 (write_bullet 의 대응 필드 처리와 대칭이어야 함).
+        let mut n = Numbering::default();
+        n.heads[0].text_distance = 130;
+        n.heads[0].char_shape_id = 7;
+
+        let mut writer = Writer::new(Vec::new());
+        write_numbering(&mut writer, 0, &n).unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(r#"textOffset="130""#),
+            "text_distance 유실: {xml}"
+        );
+        assert!(
+            xml.contains(r#"charPrIDRef="7""#),
+            "char_shape_id 유실: {xml}"
+        );
     }
 
     #[test]


### PR DESCRIPTION
## 결함

HWP5→HWPX 저장 시 `write_numbering()`의 `raw_para_heads` 없는 폴백 스켈레톤이 `textOffset`/`charPrIDRef`를 각각 `50`/`u32::MAX`로 하드코딩해 `NumberingHead.text_distance`/`char_shape_id` 값이 유실됩니다. 대응 함수 `write_bullet()`은 이미 동일 필드를 정상 값으로 채우고 있어 비대칭이었습니다.

## 수정

두 속성을 실제 필드 참조로 변경.

## red→green

`write_numbering_skeleton_preserves_text_distance_and_char_shape_id` — 수정 전 FAIL, 수정 후 PASS. `cargo test --lib` 2554 passed, clippy clean.

Closes #3192