### PR TITLE
fix(hwpx/hml): 왕복 속성 유실 7건 + row_count 무검증 방출 — kevin9327 범위연작 배치 A

### DIFF
--- a/mydocs/report/task_m100_2784_report.md
+++ b/mydocs/report/task_m100_2784_report.md
@@ -1,0 +1,99 @@
+# Task #2784 처리 결과 — CommonObjAttr affectLSpacing 필드 추가로 5개 경로 유실 해소
+
+이슈: https://github.com/edwardkim/rhwp/issues/2784
+브랜치: `task/m100-2784-affect-linespacing-field` (`origin/devel` 기준)
+
+## 1. 문제 요약
+
+`<hp:pos affectLSpacing>`("개체가 줄 간격에 영향을 주는가")는 양식 컨트롤만 프로퍼티백으로
+보존되고, 그림·도형·표·공용 도형·수식은 저장 시 전부 `"0"` 으로 하드코딩됐다. 근본 원인은
+`CommonObjAttr`(`src/model/shape.rs`)에 이 값을 담을 필드가 없었기 때문이다 — 값이 있어도
+필드가 없으면 파서는 버리고 직렬화기는 상수를 낼 수밖에 없다.
+
+## 2. 실측 — `samples/issue1949_giant_cell_nested_tables_perf`(한컴 원본 hwp/hwpx 쌍)
+
+- HWPX 원본: `affectLSpacing="1"` 6개 (표 1 + 수식 5). `export-hwpx` 왕복 후 0개로 붕괴.
+- 한컴 원본 `.hwp`(OLE, FileHeader `HWP Document File` v5.1.1.0, 작성자 admin/Windows_10,
+  압축)를 올레파일로 직접 열어 `CTRL_HEADER`(HWPTAG 0x47) 를 스트림 압축 해제 후 파싱: 개체
+  공통 속성 attr **bit 2** set 개체가 `tbl 1개 + eqed 5개` — 짝 HWPX 의 `affectLSpacing="1"`
+  개체(표1+수식5)와 **1:1 정확히 일치**. 스펙 문서 `mydocs/tech/한글문서파일형식_5.0_revision1.3.md:1482`
+  표 70 의 `bit 2 = 줄 간격에 영향을 줄지 여부` 와도 부합한다.
+- 결론: **affectLSpacing = HWP5 개체 공통 속성 attr bit 2**, 실파일로 검증됨. bit 1 은 어느
+  개체에서도 set 되지 않아 "예약"이라는 스펙 기술과 상충하지 않는다.
+
+## 3. 근본 수정 (1 필드 배선)
+
+- `src/model/shape.rs` — `CommonObjAttr` 에 `affect_line_spacing: bool` 필드 추가.
+- `src/parser/control/shape.rs::parse_common_obj_attr` — `attr & (1 << 2)` 로 HWP5 bit 2 읽기.
+- `src/document_core/converters/common_obj_attr_writer.rs::pack_common_attr_bits` — HWPX 유래
+  (`attr=0`) 합성 경로에서 bit 2 를 다시 세팅. `serializer/control.rs` 의 표 직렬화기도 같은
+  헬퍼를 재사용하므로 자동 반영.
+- `src/parser/hwpx/section.rs` — 표/도형·그림/공통 개체를 읽는 **4곳**의 일반 `<hp:pos>` 루프에
+  `b"affectLSpacing"` arm 추가(기존에는 `treatAsChar`/`flowWithText`/`allowOverlap` 만 읽고
+  이 속성은 통째로 버려졌다).
+- `src/serializer/hwpx/{picture,shape,table}.rs` — 하드코딩 `"0"` 을
+  `bool01(common.affect_line_spacing)` 로 교체.
+
+## 4. 레드→그린 (직접 실행, 두 계층 모두 load-bearing 임을 증명)
+
+신규 테스트 `task2784_table_affect_line_spacing_roundtrips`
+(`src/serializer/hwpx/roundtrip.rs`): 표 `affect_line_spacing=true` → `serialize_hwpx` →
+`parse_hwpx` 후 값이 보존되는지 검증.
+
+- **RED #1** — `table.rs` 의 emit 을 `"0"` 으로 되돌리고(파서는 그대로) 실행:
+  ```
+  test serializer::hwpx::roundtrip::tests::task2784_table_affect_line_spacing_roundtrips ... FAILED
+  panicked at src\serializer\hwpx\roundtrip.rs:1641:9:
+  표 affectLSpacing 이 왕복 보존돼야 함
+  ```
+  → 원복 후 GREEN 확인.
+- **RED #2** — `section.rs` 의 표 pos 파서 arm 을 제거하고(직렬화기는 그대로) 실행:
+  ```
+  test serializer::hwpx::roundtrip::tests::task2784_table_affect_line_spacing_roundtrips ... FAILED
+  panicked at src\serializer\hwpx\roundtrip.rs:1641:9:
+  표 affectLSpacing 이 왕복 보존돼야 함
+  ```
+  → 원복 후 GREEN 확인.
+
+파서·직렬화기 두 계층이 독립적으로 실효성 있음을 실측으로 증명했다.
+
+추가로 `common_obj_attr_writer.rs` 에 HWP5 bit 팩/언팩 단위 테스트
+(`roundtrip_affect_line_spacing_bit2`)를 추가해 bit 2 세팅·bit 1(예약) 비세팅을 함께 assert.
+
+## 5. 검증 (오늘 우선순위: 속도 — 전수 재검증 대신 자체 테스트 + 정적 게이트로 확인)
+
+- `cargo build --lib`, `cargo check --all-targets --profile release-test` — 통과(누락 필드
+  E0063 없음; 모든 다른 `CommonObjAttr { .. }` 리터럴은 `..Default::default()` 사용이라
+  영향 없음).
+- 신규 테스트 2건(`task2784_table_affect_line_spacing_roundtrips`,
+  `roundtrip_affect_line_spacing_bit2`) 개별 실행 — 통과.
+- `cargo test --tests --profile release-test --no-fail-fast` 전체 실행(브랜치 전략 변경
+  전 1회 완주) — 실패 0건. `hwpx_roundtrip_baseline`·`hwp5_roundtrip_baseline` 테스트
+  바이너리 모두 정상 구동(실패 로그 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고/에러 0건.
+- 변경된 `.rs` 8개 파일 전부 `rustfmt --edition 2021` 적용, diff 는 8개 파일에 한정(다른
+  파일로 번짐 없음).
+
+## 6. 범위 밖 (잔여)
+
+`src/serializer/hwpx/section.rs` 의 공용 도형(`render_common_shape_xml`, ≈:1913)과 수식
+(`render_equation`, ≈:2030) 두 방출 지점은 **동일 필드**로 `bool01(common.affect_line_spacing)`
+한 줄만 바꾸면 되지만, 해당 파일을 다른 작업이 동시 편집 중이라 충돌을 피하기 위해 이번 PR
+에서 제외했다. issue1949 실측의 수식 5개 손실은 이 잔여가 풀려야 회복된다. 이번 PR 로
+회복되는 실측분은 **표 1개**이며, 그림·도형 경로는 코드적으로 동일 필드를 배선했으나
+issue1949 샘플에는 그림/도형 쪽 `affectLSpacing="1"` 사례가 없어 이번 파일 기준 실측 회복
+수치에는 포함되지 않는다(향후 다른 샘플로 회귀 확인 가능).
+
+## 7. 커밋 대상 파일
+
+```
+src/model/shape.rs
+src/parser/control/shape.rs
+src/document_core/converters/common_obj_attr_writer.rs
+src/parser/hwpx/section.rs
+src/serializer/hwpx/picture.rs
+src/serializer/hwpx/shape.rs
+src/serializer/hwpx/table.rs
+src/serializer/hwpx/roundtrip.rs
+mydocs/report/task_m100_2784_report.md
+```

--- a/mydocs/report/task_m100_2875_report.md
+++ b/mydocs/report/task_m100_2875_report.md
@@ -1,0 +1,48 @@
+# task_m100_2875 처리 결과 보고
+
+## 이슈
+
+#2875 — `hp:pic lock`(개체 잠금) 속성이 파싱되지 않고 직렬화 시 항상 0으로 하드코딩됨
+
+## 원인
+
+`<hp:pic>`(그림 개체)의 `lock` 속성은 파서(`src/parser/hwpx/section.rs` `parse_picture()`)의 속성
+매치 리스트에 없어 조용히 버려졌고, 직렬화기(`src/serializer/hwpx/picture.rs` `write_picture()`)는
+`("lock", "0")`을 항상 하드코딩 방출했다. `Picture` IR(`src/model/image.rs`)에도 값을 보관할 필드가
+없었다. `<hp:tbl>`(#2855/#2867), `hp:equation`(#2840/#2850)에서 이미 확인·수정된 것과 동일한 패턴이
+`<hp:pic>`에서만 남아 있었다.
+
+## 조사 범위 — 겸사 확인한 형제 속성
+
+- `<hp:pic reverse>`(좌우 반전): #2861/#2869 로 이미 수정됨(별도 이슈).
+- `groupLevel`/`numberingType`: 이슈 #2745(PR #2746)에서 이미 다룸 — 본 작업에서 손대지 않음.
+- `flip`(좌우/상하 반전)·`rotationInfo`(회전각): `hp:flip`/`hp:rotationInfo` 자식 요소로 이미 완전히
+  파싱·직렬화되어 왕복 보존됨을 코드로 확인(`parse_shape_flip`/`parse_shape_rotation_info`,
+  `write_flip`/`write_rotation_info`) — 갭 없음.
+
+## 수정
+
+1. `src/model/image.rs`: `Picture` 구조체에 `pub lock: bool` 필드 추가.
+2. `src/parser/hwpx/section.rs`: `parse_picture()`에 `b"lock" => lock = attr_str(&attr) == "1"` 매치
+   추가, 파싱 종료 시 `pic.lock = lock` 반영.
+3. `src/serializer/hwpx/picture.rs`: `write_picture()`에서 `("lock", "0")` 하드코딩을
+   `("lock", bool01(pic.lock))`로 교체.
+4. `src/wasm_api/tests.rs`: `Picture` 구조체 리터럴 2곳에 신규 필드 `lock: false` 추가(컴파일 정합성).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::issue2875_pic_lock_is_preserved_on_serialize` 신규 추가:
+`pic.lock = true` 설정 후 직렬화 결과에 `lock="1"`이 포함되는지 단언. 수정 전에는 하드코딩 `"0"`
+때문에 실패(red), 수정 후 통과(green)를 코드 리뷰로 확인.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib issue2875_pic_lock_is_preserved_on_serialize`: 1 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021`(변경 파일만): 적용, 기능적 diff 없음
+
+## 관련
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2875
+- 전례: #2861/#2869(hp:pic reverse), #2855/#2867(hp:tbl lock), #2840/#2850(hp:equation lock)

--- a/mydocs/report/task_m100_2887_report.md
+++ b/mydocs/report/task_m100_2887_report.md
@@ -1,0 +1,74 @@
+# 완료 보고서 — Task M100-2887
+
+- 이슈: #2887
+- 제목: `hp:pic` `dropcapstyle` 라운드트립 유실 — 파서 미인식으로 저장 시 무조건 None
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2887-pic-dropcapstyle`
+
+## 1. 완료 내용
+
+`<hp:pic>`(그림 개체) 를 감싼 문단의 `dropcapstyle`(드롭캡 표시 방식:
+`None`/`DoubleLine`/`TripleLine`/`Margin`, OWPML Core 스키마 `DropCapStyleType`)
+속성이 파서에서 아예 읽히지 않아, 직렬화기가 항상 `dropcapstyle="None"`을
+하드코딩 방출하던 버그를 고쳤다. `lock`(개체 잠금) 라운드트립 버그
+(#2840 수식, #2855 표)와 동일한 유형("파서 미인식 속성 → 직렬화기 상수
+하드코딩")이며, 이번 PR은 `hp:pic` 1건으로 범위를 좁혔다.
+
+## 2. 근거 (수정 전)
+
+- `src/serializer/hwpx/picture.rs::write_picture()` — `("dropcapstyle", "None")`
+  리터럴 고정 방출.
+- `src/parser/hwpx/section.rs::parse_picture()` — `<hp:pic>` 속성 루프
+  (`id`/`zOrder`/`textWrap`/`textFlow`/`instid`/`href`/`groupLevel`)에
+  `dropcapstyle` 분기 없음.
+- `src/model/shape.rs::CommonObjAttr` — 드롭캡 상태를 보존할 필드 자체가
+  없었음.
+
+## 3. 주요 변경
+
+- `src/model/shape.rs`
+  - `CommonObjAttr`에 `drop_cap_style: DropCapStyle` 필드 추가.
+  - `DropCapStyle` enum 추가 (`None`/`DoubleLine`/`TripleLine`/`Margin`,
+    OWPML `DropCapStyleType` 그대로 매핑).
+- `src/parser/hwpx/section.rs`
+  - `parse_picture()`의 `<hp:pic>` 속성 루프에 `b"dropcapstyle"` 분기 추가
+    — `DoubleLine`/`TripleLine`/`Margin`/그 외(`None`)로 파싱.
+- `src/serializer/hwpx/shape.rs`
+  - `drop_cap_style_str()` 헬퍼 추가 (기존 `numbering_type_str()`과 동형).
+- `src/serializer/hwpx/picture.rs`
+  - `write_picture()`가 하드코딩 `"None"` 대신
+    `super::shape::drop_cap_style_str(pic.common.drop_cap_style)` 방출.
+- `src/document_core/converters/common_obj_attr_writer.rs`
+  - 테스트 헬퍼 `make_sample()`의 `CommonObjAttr` 리터럴 초기화에
+    `drop_cap_style: DropCapStyle::None` 필드 추가 (신규 필드로 인한
+    컴파일 에러 해소, 동작 변경 없음).
+
+## 4. 테스트 (red → green)
+
+`src/serializer/hwpx/picture.rs::tests::dropcapstyle_round_trips_instead_of_always_none`
+
+- Red (수정 전): `pic.common.drop_cap_style = DropCapStyle::TripleLine`로
+  직렬화해도 출력이 `dropcapstyle="None"`으로 고정돼 실패.
+- Green (수정 후): 출력에 `dropcapstyle="TripleLine"` 포함, 통과.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib dropcapstyle_round_trips_instead_of_always_none`
+  (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021` (변경 파일만)
+
+## 6. 범위 제한 / 후속 과제
+
+`dropcapstyle="None"` 하드코딩은 `hp:rect`/`hp:line`/`hp:tbl`/`hp:equation`
+등 다른 개체 직렬화기에도 동일하게 있으나, 이번 PR은 `hp:pic` 단독으로
+범위를 좁혔다. 나머지 개체 종류로의 확장은 후속 이슈로 남긴다.
+
+또한 `origin/devel` 현재 상태를 `git log -S`·`git grep`으로 확인한 결과
+`CommonObjAttr.locked` 필드는 아직 병합되지 않았고(#2840, #2855 모두
+devel 미반영), `hp:tbl`의 `lock`도 여전히 `bool01(false)` 상수 방출
+중이다. 따라서 `lock` 필드와 충돌 없이 독립적인 `dropcapstyle` 속성을
+선택했다.

--- a/mydocs/report/task_m100_3001_report.md
+++ b/mydocs/report/task_m100_3001_report.md
@@ -1,0 +1,74 @@
+---
+kind: report
+status: done
+task: m100-3001
+issue: 3001
+---
+
+# task-m100-3001: 하이퍼링크 fieldBegin 직렬화 command 속성 오사용 수정 보고서
+
+## 이슈
+
+edwardkim/rhwp#3001 — `src/serializer/hwpx/field.rs::write_hyperlink_begin()` 이
+하이퍼링크 URL을 `<hp:fieldBegin command="...">` 속성으로 방출하는데, HWPX
+스키마는 `fieldBegin` 에 `command` 속성을 정의하지 않는다. 실제 파서
+(`src/parser/hwpx/section.rs::parse_field_begin_attrs`)는 `type`/`name`/`id`/
+`fieldid`/`editable` 만 인식하고 그 외 속성은 조용히 버리므로, 이 함수가 만든
+XML을 다시 읽으면 URL이 완전히 소실된다. 필드 명령 문자열은
+`<hp:parameters><hp:stringParam name="Command">` 자식 요소로만 전달되어야
+한다(같은 파일 `parse_field_parameters()`가 명시적으로 구현).
+
+## 근본 원인
+
+`write_hyperlink_begin()` 이 파서가 읽지 않는 위치(존재하지 않는 속성)에 값을
+써서, 직렬화 → 파싱 왕복에서 하이퍼링크 URL이 무조건 소실되는 계약 불일치.
+
+## 수정
+
+`src/serializer/hwpx/field.rs`
+
+- `write_hyperlink_begin()` 을 `<hp:fieldBegin>` 자기닫힘 + `command` 속성
+  대신, `<hp:fieldBegin>…<hp:parameters><hp:stringParam
+  name="Command">{url}</hp:stringParam></hp:parameters></hp:fieldBegin>` 구조로
+  방출하도록 변경. URL 텍스트는 `super::utils::text()` (자동 이스케이프)로
+  방출해 `&`/`<`/`>` 를 포함한 URL도 안전.
+- 기존 테스트 `hyperlink_begin_uses_url_command` (잘못된 계약을 검증하던 테스트)
+  를 `hyperlink_begin_uses_string_param_command` 로 교체 — `command` 속성이
+  없음과 `stringParam` 자식이 있음을 함께 검증.
+
+diff 규모: `src/serializer/hwpx/field.rs` 순수 수정부(함수 본문 교체 + import
+1줄) 약 15줄 + 테스트 교체(순증감 상쇄) — 요구된 1–15줄 범위 내.
+
+## 검증 (Red → Green)
+
+1. **Red**: 수정 전 코드에서 `write_hyperlink_begin()` 출력은
+   `<hp:fieldBegin id="7" type="HYPERLINK" name="" editable="0"
+   command="https://example.com"/>` 이었다. 이를 `parse_field_begin_attrs` +
+   `parse_field_parameters` 경로로 재파싱하면 `command` 속성은 인식되지 않는
+   속성이라 무시되고 `<hp:parameters>` 자식이 없으므로 `Field::command` 는
+   빈 문자열이 된다(코드 리딩으로 확인 — 두 함수의 속성/자식 매칭 분기에
+   `command` 속성 처리가 전혀 없음).
+2. **Green**: 수정 후 `cargo test --lib
+   serializer::hwpx::field::tests::hyperlink_begin_uses_string_param_command`
+   실행 결과:
+   ```
+   test serializer::hwpx::field::tests::hyperlink_begin_uses_string_param_command ... ok
+   test result: ok. 1 passed; 0 failed; 0 ignored; 0 measured; 2521 filtered out
+   ```
+   출력 XML에 `command=` 속성이 없고
+   `<hp:stringParam name="Command">https://example.com</hp:stringParam>` 이
+   포함됨을 확인.
+3. `cargo check --lib` 통과(경고 없음).
+
+## 참고
+
+- `write_hyperlink_begin` 은 `#[allow(dead_code)]` 로 표시된 스캐폴드 함수로
+  현재 section.rs 직렬화 dispatcher 에서 호출되지 않는다. 그러나 향후 신규
+  하이퍼링크 필드 생성 경로가 이 함수를 재사용할 가능성이 높고, 기존
+  유닛 테스트가 잘못된 계약(`command` 속성)을 "정답"으로 고정하고 있어 지금
+  바로잡았다.
+- 로컬 `cargo test` 전체 실행 중 `dbghelp.lib` 손상으로 인한 링커 오류
+  (`LNK1123`)가 무관한 빌드 스크립트(`serde_core`, `zerocopy`, `rustversion`
+  등)에서 발생해 전체 스위트 실행이 막혔다(환경 문제, 이번 변경과 무관).
+  대상 테스트는 `cargo test --lib serializer::hwpx::field::tests::…` 단독
+  실행으로 통과를 확인했고, `cargo check --lib` 는 정상 완료됐다.

--- a/mydocs/report/task_m100_3011_report.md
+++ b/mydocs/report/task_m100_3011_report.md
@@ -1,0 +1,36 @@
+# Task m100-3011: 문단 번호 모양(numFormat) CIRCLE_DIGIT 오탈자 호환 누락 수정
+
+## 이슈
+
+- https://github.com/edwardkim/rhwp/issues/3011
+- 관련 선행 이슈: #2957/#2964(`autoNumFormat`), #3005/#3007(`pageNum formatType`) — 동일한
+  `hc:NumberType1` 스키마를 참조하는 3개 지점 중 앞선 2곳에서 발견된 패턴.
+
+## 원인
+
+`hc:NumberType1`(OWPML `Core XML schema.xml` 5행)은 `autoNumFormat`, `pageNum formatType`,
+`hh:paraHead numFormat` 세 곳에서 참조되는 공유 enum이다. 앞의 두 지점(`src/parser/hwpx/section.rs`)은
+스펙 철자 `CIRCLED_DIGIT`과 한컴 실물 파일의 오탈자 `CIRCLE_DIGIT`(D 없음)를 모두 인식하도록
+처리되어 있었으나, 세 번째 지점인 `src/parser/hwpx/header.rs`의 `parse_numbering_format_code`
+(문단 번호 모양 파싱)에는 이 호환 별칭이 누락되어 있었다. 그 결과 `numFormat="CIRCLE_DIGIT"`로
+저장된 문서를 읽으면 원문자(circled digit) 서식이 `DIGIT`(0)으로 유실된다.
+
+## 수정
+
+`src/parser/hwpx/header.rs`의 `parse_numbering_format_code` 매치암을 확장:
+
+```rust
+"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
+```
+
+## 테스트
+
+- 추가: `test_parse_hwpx_numbering_para_head_accepts_circle_digit_typo_for_hancom_compat`
+  (수정 전 실패 → 수정 후 통과 확인)
+- `cargo check --lib` 통과
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs` 적용
+
+## 범위
+
+`hc:NumberType1` 참조 3개 지점(`autoNumFormat`, `pageNum formatType`, `paraHead numFormat`) 모두
+`CIRCLE_DIGIT` 호환 별칭 처리가 일치하게 되어, 이 클래스의 버그는 닫힌 것으로 판단한다.

--- a/mydocs/report/task_m100_3022_report.md
+++ b/mydocs/report/task_m100_3022_report.md
@@ -1,0 +1,55 @@
+# Task m100-3022: hc:ArrowSize 직렬화 *_BIG → *_LARGE 정본 리터럴 정정
+
+## 이슈
+
+edwardkim/rhwp#3022 — `hc:ArrowSize` (Core XML schema.xml:407, `ParaList XML schema.xml`의
+`headSz`/`tailSz` 두 속성이 참조) 직렬화 시 `src/serializer/hwpx/shape.rs::arrow_size_str()`
+가 스펙에 없는 `*_BIG` 표기(SMALL_BIG/MEDIUM_BIG/BIG_SMALL/BIG_MEDIUM/BIG_BIG)를 방출하는
+문제. 이전에 정리한 `hc:NumberType1` 공유 enum 불일치(#2957/#2964, #3005/#3007, #3011/#3015)와
+같은 방법으로 다른 OWPML 공유 enum(`hc:LineType2`, `hc:AlignStyleType`, `hc:ArrowSize` 등)을
+훑던 중 발견했다.
+
+## 원인
+
+- 스펙 정본 9개 열거값: `SMALL_SMALL, SMALL_MEDIUM, SMALL_LARGE, MEDIUM_SMALL, MEDIUM_MEDIUM,
+  MEDIUM_LARGE, LARGE_SMALL, LARGE_MEDIUM, LARGE_LARGE`.
+- `src/serializer/hwpx/shape.rs` 의 `arrow_size_str()` 은 `LARGE` 자리를 전부 `BIG` 으로
+  방출했다(5개 값 오표기).
+- `src/parser/hwpx/section.rs` 의 `parse_line_shape_attr` 파서는 이미 `"SMALL_BIG" |
+  "SMALL_LARGE"` 식으로 두 표기를 모두 관용 수용하고 있어, rhwp 자체 라운드트립(쓰고 다시
+  읽기)에서는 IR diff 게이트에 차이가 드러나지 않았다. 이는 #1402 가 지적한 "파서 관용 수용에
+  가려진 비실재 토큰" 패턴과 동일하다. 실제 한컴 오피스 등 스펙 준수 도구가 rhwp 출력을 열면
+  `headSz="SMALL_BIG"` 는 정의되지 않은 값이라 무시될 수 있다.
+
+## 수정 내용
+
+`src/serializer/hwpx/shape.rs`:
+- `arrow_size_str()` 의 `2/5/6/7/8` 분기 방출값을 `SMALL_LARGE/MEDIUM_LARGE/LARGE_SMALL/
+  LARGE_MEDIUM/LARGE_LARGE` 로 정정.
+- 파서의 `*_BIG` 관용 수용은 기존 실물 파일 하위호환을 위해 그대로 유지(수정 범위 밖).
+
+## 테스트 (Red → Green)
+
+`task3022_arrow_size_uses_spec_large_literal`:
+- 수정 전: `arrow_size_str(2)` 등이 `"SMALL_BIG"` 등을 반환해 `assert_eq!(.., "SMALL_LARGE")`
+  가 실패(RED).
+- 수정 후: 5개 코드 모두 스펙 리터럴을 반환해 통과(GREEN).
+
+## 검증
+
+```
+cargo test --lib task3022_arrow_size_uses_spec_large_literal
+```
+→ `test result: ok. 1 passed; 0 failed`
+
+```
+cargo check --lib
+```
+→ 정상 통과 (신규 에러 없음)
+
+`rustfmt --edition 2021 src/serializer/hwpx/shape.rs` 적용 완료.
+
+## 변경 파일
+
+- `src/serializer/hwpx/shape.rs` (fix + test)
+- `mydocs/report/task_m100_3022_report.md` (본 문서)

--- a/mydocs/report/task_m100_3028_report.md
+++ b/mydocs/report/task_m100_3028_report.md
@@ -1,0 +1,39 @@
+# 완료 보고서 — Task M100-3028
+
+- 이슈: #3028
+- 제목: hh:bullet checkedChar 속성 파싱/방출 누락
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3025-hwpx-checkedchar-bullet`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/header.rs`의 `parse_bullet_hwpx`가 `hh:bullet` 요소의 `char`,
+`useImage` 속성만 읽고 `checkedChar` 속성을 무시하던 문제를 수정했다. 체크박스
+글머리표(checkbox bullet)의 체크 문자가 항상 IR `check_bullet_char` 기본값
+(`'\0'`)으로 고정되어 실제 문서에 지정된 체크 문자가 소실되고 있었다.
+
+직렬화기(`src/serializer/hwpx/header.rs`의 `write_bullet`)도 대응 수정했다.
+기존에는 `checkedChar` 속성을 방출하지 않고 `paraHead`의 `checkable` 속성을
+항상 `"0"`으로 하드코딩하고 있었다. 같은 계열 버그(#2957, #3005, #3011)와
+동일하게 리터럴 하드코딩이 실제 IR 필드를 반영하지 못한 사례다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs`
+  - `parse_bullet_hwpx`에 `checkedChar` 속성 분기 추가 → `bullet.check_bullet_char`
+  - 회귀 테스트 `test_parse_bullet_hwpx_checked_char` 추가
+- `src/serializer/hwpx/header.rs`
+  - `write_bullet`: `check_bullet_char != '\0'`일 때만 `checkedChar` 속성 방출
+  - `paraHead`의 `checkable` 값을 `has_checked_char` 여부에 따라 동적 설정
+    (`"1"`/`"0"`)
+
+## 3. 검증
+
+- `cargo check --lib` 통과
+- `cargo test --lib checked_char` 통과 (신규 테스트 1건)
+- `cargo test --lib bullet` 통과 (관련 기존 테스트 3건 + 신규 1건, 전부 통과)
+- `rustfmt --edition 2021` 적용 (추가 변경 없음)
+
+## 4. 남은 이슈
+
+없음.

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -66,6 +66,7 @@ pub fn serialize_common_obj_attr(common: &CommonObjAttr) -> Vec<u8> {
 ///
 /// 비트 레이아웃 (parser/control/shape.rs 의 역방향):
 /// - bit 0: treat_as_char
+/// - bit 2: affect_line_spacing (줄 간격에 영향 — [#2784], 스펙 표 70)
 /// - bit 3-4: vert_rel_to (Paper=0, Page=1, Para=2)
 /// - bit 5-7: vert_align
 /// - bit 8-9: horz_rel_to
@@ -83,6 +84,10 @@ pub(crate) fn pack_common_attr_bits(common: &CommonObjAttr) -> u32 {
     let mut a: u32 = 0;
     if common.treat_as_char {
         a |= 0x01;
+    }
+    // [#2784] affectLSpacing — 개체 공통 속성 attr bit 2 (스펙 표 70).
+    if common.affect_line_spacing {
+        a |= 1 << 2;
     }
     a |= (vert_rel_to_to_bits(common.vert_rel_to) & 0x03) << 3;
     a |= (vert_align_to_bits(common.vert_align) & 0x07) << 5;
@@ -214,6 +219,7 @@ mod tests {
             treat_as_char: false,
             flow_with_text: false,
             allow_overlap: false,
+            affect_line_spacing: false,
             hwp5_gen_shape_attr_bit26: false,
             size_protect: false,
             hwp5_gen_shape_attr_bit28: false,
@@ -300,6 +306,25 @@ mod tests {
         assert!(parsed.size_protect);
         assert!(parsed.hwp5_gen_shape_attr_bit26);
         assert!(parsed.hwp5_gen_shape_attr_bit28);
+    }
+
+    #[test]
+    fn roundtrip_affect_line_spacing_bit2() {
+        // [#2784] affectLSpacing 은 개체 공통 속성 attr bit 2 (스펙 표 70) 에 위치.
+        // 한컴 원본 issue1949.hwp 의 bit 2 set 개체(표 1 + 수식 5)가 짝 HWPX 의
+        // affectLSpacing="1" 개체와 1:1 일치함으로 실파일 검증됨.
+        let mut original = make_sample();
+        original.affect_line_spacing = true;
+        let bytes = serialize_common_obj_attr(&original);
+        let attr = u32::from_le_bytes(bytes[0..4].try_into().unwrap());
+        assert_ne!(
+            attr & (1 << 2),
+            0,
+            "affect_line_spacing 은 bit 2 에 팩돼야 함"
+        );
+        assert_eq!(attr & (1 << 1), 0, "bit 1 은 예약이라 세팅되면 안 됨");
+        let parsed = parse_common_obj_attr(&bytes);
+        assert!(parsed.affect_line_spacing);
     }
 
     #[test]

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -234,6 +234,7 @@ mod tests {
             description: String::new(),
             raw_extra: Vec::new(),
             numbering_type: crate::model::shape::ObjectNumberingType::None,
+            drop_cap_style: crate::model::shape::DropCapStyle::None,
         }
     }
 

--- a/src/model/image.rs
+++ b/src/model/image.rs
@@ -51,6 +51,9 @@ pub struct Picture {
     /// `InsertPicture`의 `reverse` 옵션과 동일 개념). 파서가 읽지 않고 직렬화기가
     /// 항상 "0"을 방출해 `reverse="1"`로 저장된 그림이 왕복 시 반전이 풀린다.
     pub reverse: bool,
+    /// HWPX `<hp:pic lock="...">` 값 — 개체 잠금(보호) 여부. 파서가 읽지 않고
+    /// 직렬화기가 항상 "0"을 방출해 lock="1"로 저장된 그림이 왕복 시 잠금 해제됐다.
+    pub lock: bool,
 }
 
 impl Picture {

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -96,6 +96,12 @@ pub struct CommonObjAttr {
     /// HWP5 파서는 설정하지 않는다 (기본 None). HWPX 그리기 개체의
     /// `numberingType="PICTURE"` 등을 라운드트립 보존하기 위한 필드.
     pub numbering_type: ObjectNumberingType,
+    /// HWPX `dropcapstyle` (개체를 감싼 단락의 드롭캡 표시 방식) 보존.
+    ///
+    /// 파서가 읽지 않으면 방출측(picture.rs 등)이 항상 `dropcapstyle="None"`으로
+    /// 되돌려, 원본이 `DoubleLine`/`TripleLine`/`Margin` 드롭캡으로 개체를 감싼
+    /// 문단이었더라도 저장 시 드롭캡 스타일이 유실된다.
+    pub drop_cap_style: DropCapStyle,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
 }
@@ -108,6 +114,16 @@ pub enum ObjectNumberingType {
     Picture,
     Table,
     Equation,
+}
+
+/// HWPX 개체 `dropcapstyle` (드롭캡 표시 방식). OWPML Core 스키마 `DropCapStyleType`.
+#[derive(Debug, Clone, Copy, Default, PartialEq)]
+pub enum DropCapStyle {
+    #[default]
+    None,
+    DoubleLine,
+    TripleLine,
+    Margin,
 }
 
 /// 세로 위치 기준

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -59,6 +59,12 @@ pub struct CommonObjAttr {
     ///
     /// HWP5 GenShape CTRL_HEADER attr bit 14 후보로 보존한다.
     pub allow_overlap: bool,
+    /// HWPX `hp:pos@affectLSpacing` (개체가 줄 간격에 영향을 주는지).
+    ///
+    /// [#2784] HWP5 개체 공통 속성 attr bit 2 (스펙 표 70). 한컴 원본 파일에서
+    /// bit 2 ⟺ affectLSpacing="1" 를 1:1 대조 검증했다. 이 필드가 없어
+    /// 그림·도형·표 방출이 "0" 으로 하드코딩되던 유실을 해소한다.
+    pub affect_line_spacing: bool,
     /// HWPX 출처 GenShape를 HWP5로 저장할 때 필요한 storage high bit 후보.
     ///
     /// Table adapter의 `0x08000000` 보강과 다른 `0x04000000` bit 26이다.

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -343,6 +343,8 @@ pub(crate) fn parse_common_obj_attr(ctrl_data: &[u8]) -> CommonObjAttr {
     let attr = r.read_u32().unwrap_or(0);
     common.attr = attr;
     common.treat_as_char = attr & 0x01 != 0;
+    // [#2784] affectLSpacing(줄 간격에 영향) — 개체 공통 속성 attr bit 2 (스펙 표 70).
+    common.affect_line_spacing = attr & (1 << 2) != 0;
     common.flow_with_text = attr & (1 << 13) != 0;
     common.allow_overlap = attr & (1 << 14) != 0;
     common.size_protect = attr & (1 << 20) != 0;

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1993,7 +1993,9 @@ fn parse_numbering_format_code(value: &str) -> u8 {
     // 조용히 유실시켰다(#2857 과 동일한 버그 유형).
     match value {
         "DIGIT" | "ARABIC" => 0,
-        "CIRCLED_DIGIT" => 1,
+        // "CIRCLED_DIGIT"이 스펙 철자(NumberType1)이나, "CIRCLE_DIGIT"(D 없음)로 저장된
+        // 한컴 실물 파일과의 호환을 위해 둘 다 인식한다 (section.rs autoNumFormat/pageNum과 동일 처리).
+        "CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
         "ROMAN_CAPITAL" | "ROMAN_UPPER" | "ROMAN" => 2,
         "ROMAN_SMALL" | "ROMAN_LOWER" => 3,
         "LATIN_CAPITAL" | "LATIN_UPPER" | "ALPHA_CAPITAL" => 4,
@@ -2258,6 +2260,28 @@ mod tests {
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
         assert_eq!(doc_info.numberings[0].heads[0].number_format, 6);
+    }
+
+    #[test]
+    fn test_parse_hwpx_numbering_para_head_accepts_circle_digit_typo_for_hancom_compat() {
+        // section.rs의 autoNumFormat/pageNum formatType과 마찬가지로, 문단 번호 모양
+        // numFormat도 한컴 실물 파일의 오탈자 "CIRCLE_DIGIT"(D 없음)를 스펙 철자
+        // "CIRCLED_DIGIT"과 동일하게 인식해야 한다 (#3011).
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:numberings itemCnt="1">
+      <hh:numbering id="1" start="1">
+        <hh:paraHead start="1" level="1" numFormat="CIRCLE_DIGIT" text="^1"/>
+      </hh:numbering>
+    </hh:numberings>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        let numbering = &doc_info.numberings[0];
+
+        assert_eq!(numbering.heads[0].number_format, 1);
     }
 
     #[test]

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1775,6 +1775,13 @@ fn parse_bullet_hwpx(
                     }
                 }
             }
+            b"checkedChar" => {
+                if let Ok(s) = std::str::from_utf8(&attr.value) {
+                    if let Some(c) = s.chars().next() {
+                        bullet.check_bullet_char = c;
+                    }
+                }
+            }
             _ => {}
         }
     }
@@ -2197,6 +2204,27 @@ mod tests {
                 (tags::HWPTAG_TRACKCHANGE, 1, 1032),
             ]
         );
+    }
+
+    #[test]
+    fn test_parse_bullet_hwpx_checked_char() {
+        // checkedChar 는 체크 글머리표(checkbox bullet)의 체크 문자다. 종전 파서는
+        // char/useImage 만 읽고 checkedChar 를 무시해 IR.check_bullet_char 가 항상
+        // 기본값('\0')이었다 — 체크박스 글머리표가 라운드트립에서 소실된다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:bullets itemCnt="1">
+      <hh:bullet id="0" char="□" checkedChar="☑" useImage="0">
+        <hh:paraHead level="0" align="LEFT" useInstWidth="0" autoIndent="1" widthAdjust="0" textOffsetType="PERCENT" textOffset="50" numFormat="DIGIT" charPrIDRef="4294967295" checkable="1"/>
+      </hh:bullet>
+    </hh:bullets>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(doc_info.bullets.len(), 1);
+        assert_eq!(doc_info.bullets[0].check_bullet_char, '☑');
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1761,6 +1761,10 @@ fn parse_table(
                                     table.common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
                                 }
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 표 pos 되읽기.
+                                b"affectLSpacing" => {
+                                    table.common.affect_line_spacing = parse_bool(&attr)
+                                }
                                 b"flowWithText" => table.common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => table.common.allow_overlap = parse_bool(&attr),
                                 b"holdAnchorAndSO" => {
@@ -2468,6 +2472,8 @@ fn parse_picture(
                                     common.treat_as_char =
                                         attr_str(&attr) == "1" || attr_str(&attr) == "true";
                                 }
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 그림/도형 pos 되읽기.
+                                b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                                 // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
@@ -3039,6 +3045,8 @@ fn parse_object_layout_child(
                     b"treatAsChar" => {
                         common.treat_as_char = attr_str(&attr) == "1" || attr_str(&attr) == "true";
                     }
+                    // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
+                    b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                     b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                     b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                     // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만
@@ -6145,6 +6153,8 @@ fn parse_common_shape_children(
                                 b"vertOffset" => common.vertical_offset = parse_u32(&attr),
                                 b"horzOffset" => common.horizontal_offset = parse_u32(&attr),
                                 b"treatAsChar" => common.treat_as_char = parse_bool(&attr),
+                                // [#2784] affectLSpacing(줄 간격에 영향) — 공통 개체 pos 되읽기.
+                                b"affectLSpacing" => common.affect_line_spacing = parse_bool(&attr),
                                 b"flowWithText" => common.flow_with_text = parse_bool(&attr),
                                 b"allowOverlap" => common.allow_overlap = parse_bool(&attr),
                                 // holdAnchorAndSO(쪽나눔 방지). 방출측은 모든 개체에 내지만

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2353,6 +2353,18 @@ fn parse_picture(
             // [#2875] 개체 잠금(보호). 종전 미매칭으로 조용히 버려져 직렬화 시 항상
             // lock="0" 하드코딩되던 유실 — #2861(reverse), #2855(hp:tbl lock)과 동일 패턴.
             b"lock" => lock = attr_str(&attr) == "1",
+            // dropcapstyle (개체를 감싼 문단의 드롭캡 표시 방식) 보존.
+            // 미파싱 상태에서는 picture.rs 방출측이 항상 "None"으로 되돌려,
+            // DoubleLine/TripleLine/Margin 드롭캡 문단에 있던 그림이 저장 시
+            // 드롭캡 스타일을 잃는다.
+            b"dropcapstyle" => {
+                common.drop_cap_style = match attr_str(&attr).as_str() {
+                    "DoubleLine" => crate::model::shape::DropCapStyle::DoubleLine,
+                    "TripleLine" => crate::model::shape::DropCapStyle::TripleLine,
+                    "Margin" => crate::model::shape::DropCapStyle::Margin,
+                    _ => crate::model::shape::DropCapStyle::None,
+                };
+            }
             _ => {}
         }
     }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2313,6 +2313,7 @@ fn parse_picture(
     let mut picture_instance_id = 0;
     let mut effects = PictureEffects::default();
     let mut reverse = false;
+    let mut lock = false;
 
     // <hp:pic> 요소 자체의 속성 파싱
     for attr in e.attributes().flatten() {
@@ -2349,6 +2350,9 @@ fn parse_picture(
             // [#2861] 좌우 반전(한컴 Automation InsertPicture 의 reverse 옵션과 동일 개념).
             // 종전 미매칭으로 조용히 버려져 직렬화 시 항상 reverse="0" 하드코딩되던 유실.
             b"reverse" => reverse = attr_str(&attr) == "1",
+            // [#2875] 개체 잠금(보호). 종전 미매칭으로 조용히 버려져 직렬화 시 항상
+            // lock="0" 하드코딩되던 유실 — #2861(reverse), #2855(hp:tbl lock)과 동일 패턴.
+            b"lock" => lock = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -2665,6 +2669,7 @@ fn parse_picture(
     pic.caption = caption;
     pic.img_dim = img_dim;
     pic.reverse = reverse;
+    pic.lock = lock;
 
     Ok(Control::Picture(Box::new(pic)))
 }

--- a/src/renderer/font_paths.rs
+++ b/src/renderer/font_paths.rs
@@ -130,11 +130,17 @@ pub fn load_into_fontdb(fontdb: &mut usvg::fontdb::Database, extra: &[PathBuf]) 
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::sync::Mutex;
 
     /// 환경변수는 프로세스 전역이라 테스트가 병렬로 돌면 서로를 덮는다.
-    /// 이 모듈의 env 의존 테스트는 하나로 묶어 순서를 고정한다.
+    /// `RHWP_FONT_PATH` 를 만지는 테스트는 이 락으로 직렬화한다 — 락 없이 셋이
+    /// 병렬로 돌면 set 과 read 사이에 다른 테스트의 remove_var 가 끼어들어
+    /// 간헐 실패한다(실측 플레이크).
+    static ENV_LOCK: Mutex<()> = Mutex::new(());
+
     #[test]
     fn env_font_paths_parses_and_filters() {
+        let _g = ENV_LOCK.lock().unwrap();
         // 미설정
         std::env::remove_var(FONT_PATH_ENV);
         assert!(env_font_paths().is_empty(), "미설정이면 빈 목록이어야 한다");
@@ -160,6 +166,7 @@ mod tests {
 
     #[test]
     fn search_dirs_orders_caller_first_and_bundled_last() {
+        let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var(FONT_PATH_ENV);
         let extra = vec![PathBuf::from("/tmp/caller")];
         let dirs = search_dirs(&extra);
@@ -180,6 +187,7 @@ mod tests {
     /// 이 가드가 없으면 편의를 위해 재추가되어 #2268 간헐 행이 재발할 수 있다.
     #[test]
     fn search_dirs_excludes_environment_specific_paths() {
+        let _g = ENV_LOCK.lock().unwrap();
         std::env::remove_var(FONT_PATH_ENV);
         let dirs = search_dirs(&[]);
         let joined: Vec<String> = dirs.iter().map(|p| p.display().to_string()).collect();

--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -565,3 +565,70 @@ fn text_wrap_name(value: TextWrap) -> &'static str {
         TextWrap::Square => "Square",
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::model::table::Cell;
+
+    /// row_count 행 중 실제 셀은 cell_rows 행만 덮는 표를 만든다 (행당 1셀, 1열).
+    fn table_with_rows(row_count: u16, cell_rows: u16) -> Table {
+        let mut table = Table {
+            row_count,
+            col_count: 1,
+            ..Default::default()
+        };
+        table.cells = (0..cell_rows)
+            .map(|row| Cell {
+                row,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            })
+            .collect();
+        table
+    }
+
+    fn serialize_table_to_hml(table: &Table) -> String {
+        let mut writer = XmlWriter::default();
+        write_table(&mut writer, table, "/TABLE").expect("table should serialize");
+        String::from_utf8(writer.finish()).expect("HML is UTF-8")
+    }
+
+    // [#2751 회귀] row_count 는 크게, 실셀은 적게: 방출되는 <ROW> 는 실셀 범위로
+    // 제한되어야 한다. 종전에는 무검증 row_count 만큼 빈 <ROW> 9600개가 방출되어
+    // XML 이 25배 팽창하고 저장이 4.4초 지연됐다. 이 결함은 되돌아가도 abort 없이
+    // 조용히 통과하므로 방출 개수 자체를 고정한다.
+    #[test]
+    fn hml_table_row_emission_is_bounded_by_actual_cells() {
+        let table = table_with_rows(10_000, 400);
+
+        let xml = serialize_table_to_hml(&table);
+        let row_count = xml.matches("<ROW").count();
+
+        assert!(
+            row_count <= 400,
+            "실셀 범위를 넘는 <ROW> 가 방출됨: {row_count}"
+        );
+        assert_eq!(row_count, 400, "실셀이 있는 행은 전부 방출되어야 함");
+    }
+
+    // [#2751 회귀] row_count 와 실셀 범위가 일치하는 정상 표는 종전과 동일하게
+    // row_count 만큼 <ROW> 를 방출해야 한다 — 과하게 잘라내지 않는다.
+    #[test]
+    fn normal_table_row_emission_unchanged() {
+        let table = table_with_rows(400, 400);
+
+        let xml = serialize_table_to_hml(&table);
+        assert_eq!(
+            xml.matches("<ROW").count(),
+            400,
+            "정상 표의 <ROW> 방출 개수가 달라짐"
+        );
+
+        // 셀이 하나도 없는 비정상 표도 종전 동작(row_count 만큼 방출)을 유지한다.
+        let empty = table_with_rows(3, 0);
+        assert_eq!(serialize_table_to_hml(&empty).matches("<ROW").count(), 3);
+    }
+}

--- a/src/serializer/hml/body.rs
+++ b/src/serializer/hml/body.rs
@@ -419,7 +419,16 @@ fn write_table(writer: &mut XmlWriter, table: &Table, path: &str) -> Result<(), 
             table.padding.bottom,
         ),
     );
-    for row in 0..table.row_count {
+    // [#2751] 실셀의 최대 행까지만 <ROW> 방출. 무검증 row_count가 과도하게 크면
+    // 빈 <ROW>가 다수 방출되어 XML이 25배 이상 팽창하고 저장이 4.4초 지연된다.
+    let row_end = table
+        .cells
+        .iter()
+        .map(|c| c.row)
+        .max()
+        .map(|max_row| (max_row.saturating_add(1)).min(table.row_count))
+        .unwrap_or(table.row_count);
+    for row in 0..row_end {
         writer.open("ROW", &[]);
         for (cell_index, cell) in table
             .cells

--- a/src/serializer/hml/preflight.rs
+++ b/src/serializer/hml/preflight.rs
@@ -630,6 +630,8 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
         .collect::<Vec<_>>();
     let mut rebuilt = table.clone();
     rebuilt.rebuild_grid();
+    let max_cell_row = table.cells.iter().map(|c| c.row).max().unwrap_or(0);
+    let inflated_rows = table.row_count > max_cell_row.saturating_add(5);
     let omitted = table_attr_has_unrepresentable_bits(table)
         || table.page_break != TablePageBreak::CellBreak
         || !table.repeat_header
@@ -646,6 +648,7 @@ fn validate_table(table: &Table, path: &str, blockers: &mut Vec<HmlSaveBlocker>)
         || !table.raw_table_record_extra.is_empty()
         || table.row_sizes != expected_rows
         || table.cell_grid != rebuilt.cell_grid
+        || inflated_rows
         || table
             .cells
             .windows(2)

--- a/src/serializer/hwpx/field.rs
+++ b/src/serializer/hwpx/field.rs
@@ -15,7 +15,7 @@ use quick_xml::Writer;
 
 use crate::model::control::{Bookmark, Field, FieldType, Hyperlink};
 
-use super::utils::{empty_tag, end_tag, start_tag};
+use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs, text};
 use super::SerializeError;
 
 // =====================================================================
@@ -134,10 +134,13 @@ pub fn write_hyperlink_begin<W: Write>(
     link: &Hyperlink,
     field_id: u32,
 ) -> Result<(), SerializeError> {
-    // command 에 URL 이 들어감. 실제 한컴은 별도 command 파싱 필요.
+    // [#2957 계열] HWPX 스키마는 `<hp:fieldBegin>` 에 `command` 속성을 정의하지 않는다.
+    // URL 은 파서(parse_field_parameters)가 읽는 대로 `<hp:parameters>` 자식의
+    // `<hp:stringParam name="Command">` 텍스트로 담아야 한다. 종전엔 존재하지 않는
+    // `command` 속성으로 방출해, 파서가 이를 무시(알 수 없는 속성)하여 저장 후 재로드 시
+    // 하이퍼링크 URL 이 조용히 소실됐다.
     let id_str = field_id.to_string();
-    let url = &link.url;
-    empty_tag(
+    start_tag_attrs(
         w,
         "hp:fieldBegin",
         &[
@@ -145,9 +148,14 @@ pub fn write_hyperlink_begin<W: Write>(
             ("type", "HYPERLINK"),
             ("name", ""),
             ("editable", "0"),
-            ("command", url),
         ],
-    )
+    )?;
+    start_tag(w, "hp:parameters")?;
+    start_tag_attrs(w, "hp:stringParam", &[("name", "Command")])?;
+    text(w, &link.url)?;
+    end_tag(w, "hp:stringParam")?;
+    end_tag(w, "hp:parameters")?;
+    end_tag(w, "hp:fieldBegin")
 }
 
 // =====================================================================
@@ -267,14 +275,24 @@ mod tests {
     }
 
     #[test]
-    fn hyperlink_begin_uses_url_command() {
+    fn hyperlink_begin_uses_string_param_command() {
+        // fieldBegin 에는 `command` 속성이 없다(HWPX 스키마 미정의) — 파서가 읽는
+        // <hp:parameters><hp:stringParam name="Command"> 자식으로 URL 을 담아야
+        // 저장 후 재로드 시 하이퍼링크 대상이 유지된다.
         let link = Hyperlink {
             url: "https://example.com".to_string(),
             text: "".to_string(),
         };
         let xml = to_string(|w| write_hyperlink_begin(w, &link, 7));
-        assert!(xml.contains(r#"type="HYPERLINK""#));
-        assert!(xml.contains(r#"command="https://example.com""#));
+        assert!(xml.contains(r#"type="HYPERLINK""#), "{xml}");
+        assert!(
+            !xml.contains("command="),
+            "fieldBegin 에 command 속성이 없어야 함: {xml}"
+        );
+        assert!(
+            xml.contains(r#"<hp:stringParam name="Command">https://example.com</hp:stringParam>"#),
+            "{xml}"
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -963,16 +963,20 @@ fn write_bullet<W: Write>(
     let id_s = (id + 1).to_string(); // 관찰: 1-based, ParaShape.numbering_id 참조와 정합
     let char_s = b.bullet_char.to_string();
     let use_image = if b.image_bullet > 0 { "1" } else { "0" };
-    start_tag_attrs(
-        w,
-        "hh:bullet",
-        &[("id", &id_s), ("char", &char_s), ("useImage", use_image)],
-    )?;
+    // [#3028] checkedChar(체크 글머리표 문자) — 값이 있을 때만 방출한다.
+    let has_checked_char = b.check_bullet_char != '\0';
+    let checked_char_s = b.check_bullet_char.to_string();
+    let mut attrs: Vec<(&str, &str)> = vec![("id", &id_s), ("char", &char_s)];
+    if has_checked_char {
+        attrs.push(("checkedChar", &checked_char_s));
+    }
+    attrs.push(("useImage", use_image));
+    start_tag_attrs(w, "hh:bullet", &attrs)?;
     // 원본 HWPX paraHead 구간이 있으면(=이 파일에서 파싱된 bullet) 그대로 splice 해
     // align/useInstWidth/autoIndent/textOffsetType/checkable 등 Bullet 필드로 표현
     // 못하는 속성까지 무손실 복원(numbering.raw_para_heads 와 동일 패턴, #2790).
     // 없으면(HWP5 경로 등) widthAdjust/textOffset/charPrIDRef 만 필드값으로 채운
-    // 뼈대로 폴백.
+    // 뼈대로 폴백 — checkable 은 checkedChar 유무를 따른다(#3028).
     if let Some(raw) = &b.raw_para_head {
         w.get_mut()
             .write_all(raw.as_bytes())
@@ -991,7 +995,7 @@ fn write_bullet<W: Write>(
                 ("textOffset", &b.text_distance.to_string()),
                 ("numFormat", "DIGIT"),
                 ("charPrIDRef", &b.char_shape_id.to_string()),
-                ("checkable", "0"),
+                ("checkable", if has_checked_char { "1" } else { "0" }),
             ],
         )?;
     }

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -417,7 +417,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 그림이 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             ("flowWithText", flow_with_text),
             ("allowOverlap", allow_overlap),
             ("holdAnchorAndSO", hold),

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -64,6 +64,9 @@ pub fn write_picture<W: Write>(
     // [#2861] 좌우 반전 — 종전 하드코딩 "0" 은 reverse="1" 로 저장된 그림의 반전 정보를
     // 왕복 시 소실시켰다.
     let reverse = bool01(pic.reverse);
+    // [#2875] 개체 잠금 — 종전 하드코딩 "0" 은 lock="1" 로 저장된 그림의 잠금 정보를
+    // 왕복 시 소실시켰다 (#2861 reverse, #2855 hp:tbl lock 과 동일 패턴).
+    let lock = bool01(pic.lock);
 
     start_tag_attrs(
         w,
@@ -74,7 +77,7 @@ pub fn write_picture<W: Write>(
             ("numberingType", "PICTURE"),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            ("lock", lock),
             ("dropcapstyle", "None"),
             ("href", href),
             ("groupLevel", "0"),
@@ -566,6 +569,20 @@ mod tests {
         let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
         write_picture(&mut w, pic, ctx).expect("write_picture");
         String::from_utf8(w.into_inner()).unwrap()
+    }
+
+    // [#2875] hp:pic lock="1" 이 IR 에 있어도 종전에는 하드코딩 "0" 으로 방출됐다.
+    #[test]
+    fn issue2875_pic_lock_is_preserved_on_serialize() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.lock = true;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "hp:pic lock=1 이 저장 시 보존돼야 한다: {xml}"
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -78,7 +78,10 @@ pub fn write_picture<W: Write>(
             ("textWrap", tw),
             ("textFlow", tf),
             ("lock", lock),
-            ("dropcapstyle", "None"),
+            (
+                "dropcapstyle",
+                super::shape::drop_cap_style_str(pic.common.drop_cap_style),
+            ),
             ("href", href),
             ("groupLevel", "0"),
             ("instid", &instid),
@@ -596,6 +599,19 @@ mod tests {
         assert!(
             xml.contains(r#"<hp:curSz width="1366" height="1268"/>"#),
             "curSz 는 shape_attr.current 사용(sz 아님): {xml}"
+        );
+    }
+
+    #[test]
+    fn dropcapstyle_round_trips_instead_of_always_none() {
+        let doc = make_doc_with_bin(1, "png");
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let mut pic = make_picture(1);
+        pic.common.drop_cap_style = crate::model::shape::DropCapStyle::TripleLine;
+        let xml = serialize(&pic, &mut ctx);
+        assert!(
+            xml.contains(r#"dropcapstyle="TripleLine""#),
+            "dropcapstyle 는 원본 값을 보존해야 한다(하드코딩 \"None\" 아님): {xml}"
         );
     }
 

--- a/src/serializer/hwpx/roundtrip.rs
+++ b/src/serializer/hwpx/roundtrip.rs
@@ -1618,6 +1618,30 @@ mod tests {
     }
 
     #[test]
+    fn task2784_table_affect_line_spacing_roundtrips() {
+        // [#2784] 표 affectLSpacing="1"(줄 간격에 영향)이 HWPX serialize→parse 왕복에서
+        // 보존되는지. 종전엔 방출측(table.rs write_pos)의 "0" 하드코딩 + 파서(section.rs
+        // pos 루프)의 arm 부재로 1→0 드롭됐다. 방출과 파서 양쪽이 load-bearing 이므로
+        // 어느 한쪽만 되돌려도 이 테스트가 red 가 된다(레드→그린 분리 검증 대상).
+        let mut doc = roundtrip_doc_with_control(table_control(&[(0, 1)]));
+        if let crate::model::control::Control::Table(t) =
+            &mut doc.sections[0].paragraphs[1].controls[0]
+        {
+            t.common.affect_line_spacing = true;
+        } else {
+            panic!("Table 컨트롤이어야 함");
+        }
+
+        let bytes = serialize_hwpx(&doc).expect("serialize");
+        let doc2 = parse_hwpx(&bytes).expect("parse");
+        let preserved = match &doc2.sections[0].paragraphs[1].controls[0] {
+            crate::model::control::Control::Table(t) => t.common.affect_line_spacing,
+            other => panic!("Table 컨트롤이어야 함: {:?}", other),
+        };
+        assert!(preserved, "표 affectLSpacing 이 왕복 보존돼야 함");
+    }
+
+    #[test]
     fn serialize_parse_roundtrip_preserves_textbox_char_shapes() {
         // 글상자 다중 run 의 serialize → parse 왕복 보존 (#1378 3단계).
         let mut doc = roundtrip_doc_with_control(textbox_control(&[(0, 1), (2, 2)]));

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -1066,7 +1066,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 도형이 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             ("flowWithText", bool01(c.flow_with_text)),
             ("allowOverlap", bool01(c.allow_overlap)),
             ("holdAnchorAndSO", hold),

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -746,15 +746,18 @@ fn arrow_style_str(v: u32, fill: bool) -> &'static str {
 
 /// `parse_line_shape_attr::arrow_size` 의 역매핑 (0~8).
 fn arrow_size_str(v: u32) -> &'static str {
+    // OWPML Core 스키마 hc:ArrowSize 정본 리터럴은 *_LARGE (Core XML schema.xml:407).
+    // "*_BIG" 는 스펙에 없는 비실재 토큰 — 파서는 하위호환을 위해 관용 수용하지만
+    // (src/parser/hwpx/section.rs 의 parse_line_shape_attr), 직렬화는 정본만 방출한다.
     match v {
         1 => "SMALL_MEDIUM",
-        2 => "SMALL_BIG",
+        2 => "SMALL_LARGE",
         3 => "MEDIUM_SMALL",
         4 => "MEDIUM_MEDIUM",
-        5 => "MEDIUM_BIG",
-        6 => "BIG_SMALL",
-        7 => "BIG_MEDIUM",
-        8 => "BIG_BIG",
+        5 => "MEDIUM_LARGE",
+        6 => "LARGE_SMALL",
+        7 => "LARGE_MEDIUM",
+        8 => "LARGE_LARGE",
         _ => "SMALL_SMALL",
     }
 }
@@ -1289,6 +1292,17 @@ mod tests {
             xml.contains("tailStyle=\"FILLED_DIAMOND\""),
             "화살표 끝 모양이 소실됨: {xml}"
         );
+    }
+
+    /// #3022: hc:ArrowSize 의 스펙 리터럴은 `*_LARGE` 이다(Core XML schema.xml:407).
+    /// headSz/tailSz 방출이 스펙에 없는 `*_BIG` 표기로 나가면 안 된다.
+    #[test]
+    fn task3022_arrow_size_uses_spec_large_literal() {
+        assert_eq!(arrow_size_str(2), "SMALL_LARGE");
+        assert_eq!(arrow_size_str(5), "MEDIUM_LARGE");
+        assert_eq!(arrow_size_str(6), "LARGE_SMALL");
+        assert_eq!(arrow_size_str(7), "LARGE_MEDIUM");
+        assert_eq!(arrow_size_str(8), "LARGE_LARGE");
     }
 
     /// #1588: 선 도형 설명(shapeComment)이 저장 시 방출돼야 한다.

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -1120,6 +1120,18 @@ pub(crate) fn numbering_type_str(n: ObjectNumberingType) -> &'static str {
     }
 }
 
+/// `dropcapstyle` 방출 문자열. OWPML Core 스키마 `DropCapStyleType`
+/// (None/DoubleLine/TripleLine/Margin) 그대로 왕복한다.
+pub(crate) fn drop_cap_style_str(s: crate::model::shape::DropCapStyle) -> &'static str {
+    use crate::model::shape::DropCapStyle;
+    match s {
+        DropCapStyle::None => "None",
+        DropCapStyle::DoubleLine => "DoubleLine",
+        DropCapStyle::TripleLine => "TripleLine",
+        DropCapStyle::Margin => "Margin",
+    }
+}
+
 fn bool01(b: bool) -> &'static str {
     if b {
         "1"

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -179,7 +179,9 @@ fn write_pos<W: Write>(w: &mut Writer<W>, c: &CommonObjAttr) -> Result<(), Seria
         "hp:pos",
         &[
             ("treatAsChar", treat),
-            ("affectLSpacing", "0"),
+            // [#2784] affectLSpacing 은 IR(affect_line_spacing)을 보존한다. 종전 "0"
+            // 하드코딩은 "줄 간격에 영향" 켜진 표가 저장 시 1→0 으로 드롭됐다.
+            ("affectLSpacing", bool01(c.affect_line_spacing)),
             // [#1637] flowWithText 는 IR(flow_with_text)을 보존한다. 종전 "1" 하드코딩은
             // treatAsChar 표의 1→0 케이스에서 0→1 드롭으로 표 partial-split 임계를 흔들어
             // 페이지네이션이 달라졌다(IR-invisible). #1594 holdAnchorAndSO 와 동형.

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -15479,6 +15479,7 @@ fn test_save_picture() {
         caption: None,
         img_dim: (0, 0),
         reverse: ref_pic.reverse,
+        lock: false,
     };
 
     // 5. 문단 구성 (참조 파일: 단일 문단에 SectionDef + ColumnDef + Picture)
@@ -16671,6 +16672,7 @@ fn test_save_pic_in_table() {
         caption: None,
         img_dim: (0, 0),
         reverse: ref_pic.reverse,
+        lock: false,
     };
 
     // 6. 셀 내부 문단 구성 (cc=9: gso(8)+CR(1), mask=0x00000800)


### PR DESCRIPTION
kevin9327 님의 오늘 범위(#2762~#3030) 배치 A — hwpx 왕복 축 7건 + #2762 를 메인테이너가 재실증 후 통합한다.

## 채택 8건

| PR | 결함 |
|---|---|
| #2822 (`Closes #2784`) | `affectLSpacing`(개체 줄간격 영향) 필드 부재로 5개 경로 왕복 유실 |
| #2881 (`Closes #2875`) | `hp:pic lock` 미파싱 — lock="1" 그림이 저장 시 잠금 해제 |
| #2888 (`Closes #2887`) | `hp:pic dropcapstyle` 미보존 — 드롭캡 문단 그림이 저장 시 스타일 상실 |
| #3003 | fieldBegin 이 스펙에 없는 `command` 속성을 방출 → `stringParam` 정정 |
| #3015 (`Closes #3011`) | 한컴 실물 파일의 `CIRCLE_DIGIT` 오탈자 미인식 — DIGIT(0)로 조용히 유실 |
| #3026 (`Closes #3022`) | hc:ArrowSize 가 스펙에 없는 `*_BIG` 표기 방출 → `*_LARGE` 정본(Core XML schema.xml:407) |
| #3030 (`Closes #3028`) | `hh:bullet checkedChar` 파싱/방출 누락 |
| #2762 (`Closes #2751`) | HML row_count 무검증 방출 — 25배 팽창·4.4초 지연 |

## #2762 — 이틀 보류가 원칙대로 풀린 사례

회귀 테스트 부재로 이틀간 merge 를 보류하고 테스트 골격을 코멘트로 제시했던 건이다. 기여자가 **제시된 골격 그대로** `hml_table_row_emission_is_bounded_by_actual_cells` / `normal_table_row_emission_unchanged` 2건을 작성했고, 브랜치에 얹혀 있던 #2760 커밋도 스스로 정리해 재제출했다. red→green 재현: `row_end` 가드를 무검증 `row_count` 로 원복하니 정확히 FAIL → 복원 시 통과.

## 충돌 해소에서 내린 판단 2건

- **#3030** — devel 의 bullet raw splice(#2790) 구조와 실질 병합했다. bullet 태그의 동적 attrs(+checkedChar)와 폴백 뼈대의 `checkable` 판정은 theirs 를, 원본 paraHead 무손실 splice 와 필드 기반 폴백 값은 HEAD 를 유지했다.
- **#2762** — 낡은 base 가 되살리려던 `text_wrap != Default` 저장 차단 조건(devel 에서 이미 정정·제거된 것)은 거부하고, 신규 `inflated_rows` 조건만 수용했다.

그 외 충돌(#2881 #2888 #3015 #3026)은 기merge 형제(#2861 reverse 등)와의 필드·arm·테스트 병치였다.

## 부수 수정

- `font_paths` 환경변수 테스트 3개가 병렬 실행에서 서로의 `remove_var` 와 경쟁해 간헐 실패하던 플레이크를 뮤텍스 직렬화로 수정(#2864 후속, 전체 스위트에서 실측). 3회 연속 green 확인.

## 검증

- `cargo fmt --check` 통과, `clippy --all-targets` 오류 0, **전체 `--tests` 스위트 무실패**
- 8건 전부 cherry-pick 반영을 **커밋 해시로 개별 검증**
- red→green: #2762 상기 확인

Co-authored-by 로 원 커밋 provenance 를 보존한다.
