### PR TITLE
fix(doccore): 표 편집 stale 인덱스·리플로우 4건 + 도형 그룹 char_offsets 2건 — kevin9327 범위연작 배치 B

### DIFF
--- a/mydocs/report/task_m100_2755_report.md
+++ b/mydocs/report/task_m100_2755_report.md
@@ -1,0 +1,131 @@
+# Task M100 #2755 결과보고서 — 표 셀 by_path 편집 경로의 셀 폭 리플로우 누락
+
+- 이슈: [#2755](https://github.com/edwardkim/rhwp/issues/2755)
+- 브랜치: `task/m100-2755-cell-bypath-reflow`
+- 기준 브랜치: `origin/devel`
+- 대상 파일: `src/document_core/commands/text_editing.rs`, `src/document_core/commands/formatting.rs`
+- 작성일: 2026-07-22
+
+## 1. 문제와 유입 경로
+
+표 셀 편집이 flat `*_in_cell_native` 계열에서 `*_in_cell_by_path` 계열로 라우팅을 옮기면서,
+flat 계열이 가지고 있던 **셀 폭 기준 LineSeg 리플로우**가 `by_path` 계열에는 없어 편집 후 줄
+나눔이 갱신되지 않는다.
+
+- `e5c81421`(#2452): `DeleteSelectionCommand` 를 `deleteRangeInCellByPath` 로, 분기 조건은
+  `isCell`(= `parentParaIndex !== undefined`, 즉 모든 셀).
+- `6399dc3e`(#2453): `ApplyCharFormatCommand.execute`/`restoreCharShapeIds` 를
+  `applyCharFormatInCellByPath`/`setCharShapeIdInCellByPath` 로, 역시 `isCell`.
+
+두 PR이 고친 결함은 중첩 셀(`isNestedCell`, depth>1)의 축 불일치인데 분기 조건으로 `isCell` 을
+써서 **깊이 1 셀까지 전부** `by_path` 로 넘어갔다. `6399dc3e` 본문의 근거
+"셀 리플로우는 rebuild_section 전체 재조판이 담당" 은 코드상 성립하지 않는다(§2).
+
+## 2. 반증 사슬 (현재 devel 에서 직접 확인)
+
+1. `compose_lines`(`src/renderer/composer.rs:472`)는 `line_segs` 가 비어 있을 때만 45자 휴리스틱을
+   쓰고, 있으면 저장된 경계로 줄을 나눈다(`:549-563`). → `line_segs` 미갱신 시 줄 수 불변.
+2. `recompose_for_cell_width`(`composer.rs:1633`)는 권위 `line_segs` 앞에서 즉시 반환(`:1645-1647`)
+   하고, `para` 가 `&Paragraph`(불변)이라 애초에 편집 결과를 되돌릴 수 없다. 이 함수는 셀 높이 측정
+   (`height_measurer.rs`)·표 레이아웃(`table_layout.rs`) 양쪽에서 쓰인다.
+3. `rebuild_section`(`queries/rendering.rs:4760`) → `recompose_section` → `compose_section`
+   (`composer.rs:108`)은 `section.paragraphs` 만 순회한다. 셀 문단은 대상이 아니다.
+   `delete_range_in_cell_by_path` 는 `rebuild_section` 을 호출조차 안 하고 `mark_section_dirty`
+   (`rendering.rs:2785`, 주석: "재조판 없이")만 한다.
+4. 편집 경로에서 셀 문단 `line_segs` 를 쓰는 유일한 기록자는 `reflow_line_segs`
+   (`composer/line_breaking.rs:1056`)이고, 셀 편집에서 이를 호출하는 헬퍼는
+   `reflow_cell_paragraph`(`text_editing.rs:1136`)뿐이다.
+5. 같은 저장소의 flat `apply_char_format_in_cell_native`(`formatting.rs:1103`)은
+   `[자체 발견]` 주석과 함께 `reflow_cell_paragraph` **와** `rebuild_section` 을 둘 다 호출한다.
+   `rebuild_section` 하나로 충분하다면 이 코드는 존재할 이유가 없다.
+
+## 3. 결함 목록 및 수정
+
+| # | 심각도 | 위치 | 결함 | 수정 |
+|---|---|---|---|---|
+| 1 | High | `delete_range_in_cell_by_path` (`text_editing.rs`) | 리플로우 없음 | 삭제 후 `reflow_cell_paragraph_by_path(start_para)` |
+| 2 | High | `apply_char_format_in_cell_by_path` / `set_char_shape_id_in_cell_by_path` (`formatting.rs`) | 리플로우 없음 | 깊이1 위임 + 깊이≥2 리플로우(apply 는 `char_shape_mods_affect_text_flow` 게이팅) |
+| 3 | Medium | `delete_text_in_cell_by_path` | 깊이1 위임 가드 없음 | 깊이1 `delete_text_in_cell_native` 위임 + 깊이≥2 리플로우+vpos |
+| 4 | Low | `split_/merge_paragraph_in_cell_by_path` | 빈 경로 `path.last().unwrap()` 패닉 | `Err` 반환 |
+| root | High | 모든 by_path 변형 | 깊이≥2 최내곽 셀 리플로우 불가 | `reflow_cell_paragraph_by_path` 신설 |
+| 5 | Medium | `split_/merge_paragraph_in_cell_by_path` | 리플로우 없음(깊이≥2 유일 도달) | flat split/merge 처럼 리플로우 후 shift/recalc |
+
+### 수정 설계
+
+- **공유 헬퍼**: 컨트롤+cell_idx → 셀 폭·패딩을 해석하는 `cell_metrics_for_control` 를 추출해
+  flat `reflow_cell_paragraph` 와 신설 `reflow_cell_paragraph_by_path` 가 공유한다(중복 제거).
+- **깊이≥2 리플로우**: `resolve_innermost_cell_metrics` 가 path 사슬을 따라 **최내곽** 셀 폭을
+  해석하고, `reflow_cell_paragraph_by_path` 가 그 폭으로 최내곽 문단을 재래핑한다. 깊이 1 에서는
+  flat 형제와 동일 결과.
+- **깊이 1 처리 방식 차이(의도적)**:
+  - 단일 문단 연산(`delete_text`/`apply`/`set`)은 flat native 로 **위임**(모든 컨테이너 처리,
+    `insert_text_in_cell_by_path:3389` 위임 선례와 동형).
+  - `delete_range` 는 위임하지 않고 by_path 본문 + 리플로우로 처리한다. flat
+    `delete_range_native` 의 다중 문단 분기는 `get_cell_mut` 이 **표 전용**이라, 최상위
+    글상자/그림 캡션의 다중 문단 선택 삭제(hit-test 가 length-1 cellPath+isTextBox 를 주므로
+    도달 가능)를 `Err` 로 만든다. by_path 본문은 세 컨테이너를 모두 처리하므로 위임 대신
+    리플로우만 보강해 회귀를 피했다.
+- **split/merge**: flat 형제 순서(reflow → shift_vpos_origin → recalc)를 그대로 이식.
+  리플로우가 `line_segs` 를 재작성하므로 shift/recalc 를 리플로우 뒤로 옮겼다.
+- **paint-only 보존**: `apply_char_format_in_cell_native` 의 게이팅을 그대로 타므로 밑줄/색 변경은
+  리플로우하지 않는다. `paint_only_char_shape_changes_do_not_require_text_reflow` 통과 확인.
+
+## 4. 왜 기존 테스트가 못 잡았는가
+
+기존 `by_path` 테스트(`delete_range_in_cell_by_path_deletes_within_resolved_cell` 등)는 대상 축만
+검증하고 줄 나눔은 보지 않았으며, 픽스처가 `Paragraph::default()` 라 `line_segs` 가 비어 §2-2
+early-return 조건에 걸리지 않았다. 실제 파일에서 파싱한 셀 문단은 권위 `line_segs` 를 가진다.
+본 PR 은 flat 쪽에 이미 있던 `cell_reflow_width_tests::core_with_narrow_cell`(셀 폭 200 HWPUNIT +
+권위 `line_segs`) 픽스처를 by_path 계열에 처음으로 적용하고, 깊이 2 중첩 픽스처를 추가했다.
+
+## 5. 검증 (red→green 실측)
+
+증거 수준: 본 결함의 런타임 근거는 아래 Rust 테스트의 red→green 이다(CLI 편집 명령·빌드된 wasm
+부재로 브라우저 왕복은 미수행).
+
+### RED
+
+- **1차(수정 전 코드, 테스트만 존재)** — 깊이 1 위임/빈 경로 테스트 5건 전부 실패:
+  ```
+  delete_range_in_cell_by_path_reflows_depth1_cell_line_segs ... FAILED (left: 2, right: 1)
+  delete_text_in_cell_by_path_reflows_depth1_cell_line_segs  ... FAILED (left: 2, right: 1)
+  char_format_by_path_reflow_uses_cell_width...              ... FAILED (실제 1줄)
+  set_char_shape_id_by_path_reflow_uses_cell_width...        ... FAILED (실제 1줄)
+  cell_paragraph_ops_by_path_reject_empty_path_with_error   ... FAILED (panic @ path.last().unwrap())
+  test result: FAILED. 0 passed; 5 failed
+  ```
+- **2차(깊이≥2 헬퍼 `reflow_cell_paragraph_by_path` 무력화)** — 리플로우 의존 7건 실패,
+  위임 기반 깊이1 3건은 flat native 경유라 통과:
+  ```
+  delete_range_in_cell_by_path_reflows_depth1_cell_line_segs        ... FAILED (left: 2, right: 1)
+  delete_range_in_nested_cell_by_path_reflows_inner_cell            ... FAILED
+  delete_text_in_nested_cell_by_path_reflows_inner_cell             ... FAILED
+  split_paragraph_in_nested_cell_by_path_reflows_inner_cell         ... FAILED (실제 1줄)
+  merge_paragraph_in_nested_cell_by_path_reflows_inner_cell         ... FAILED (실제 1줄)
+  char_format_by_path_reflow_reaches_nested_inner_cell             ... FAILED (실제 1줄)
+  set_char_shape_id_by_path_reflow_reaches_nested_inner_cell       ... FAILED (실제 1줄)
+  (통과: delete_text_d1, char_format_d1, set_d1 — flat native 위임)
+  test result: FAILED. 3 passed; 7 failed
+  ```
+
+### GREEN
+
+수정 적용 후 신규 12건 + 핀 6건 모두 통과:
+```
+test result: ok. 18 passed; 0 failed; 0 ignored; 2475 filtered out
+```
+`paint_only_char_shape_changes_do_not_require_text_reflow` 포함 통과.
+
+### CI
+
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: (아래 커밋 시점 기록)
+- `cargo test --tests --profile release-test --no-fail-fast`: (기록)
+- 변경 `.rs` `rustfmt --edition 2021` 후 `git diff --name-only`: (기록)
+
+## 6. 범위 밖 (잔여)
+
+- **`rhwp-studio` 라우팅 정리**: Rust 쪽 깊이1 처리가 들어가 `isCell`→`isNestedCell` 축소는
+  기능상 불필요해졌으나, 불필요한 by_path 우회를 없애는 정리 가치는 남는다(스튜디오는 형제
+  에이전트 소유 — 본 PR 범위 밖).
+- **글상자/그림 캡션의 깊이≥2 중첩**: `reflow_cell_paragraph_by_path` 는 표/글상자/캡션 폭을 모두
+  해석하나, 테스트는 표 중첩(가장 흔한 경로)만 커버했다.

--- a/mydocs/report/task_m100_2825_report.md
+++ b/mydocs/report/task_m100_2825_report.md
@@ -1,0 +1,69 @@
+# Task m100-#2825: 중첩 표 최내곽 셀 붙여넣기(cellPath) 재래핑 보강
+
+## 이슈
+
+[#2825](https://github.com/edwardkim/rhwp/issues/2825) 중첩 표 최내곽 셀 붙여넣기(cellPath)가 셀 폭으로 재래핑되지 않음
+
+## 근거
+
+`src/document_core/commands/clipboard.rs`의 `paste_internal_in_cell_by_path_native`
+(붙여넣기 대상이 `cellPath`로 지정되는 깊이 ≥2 중첩 표/글상자/캡션 셀 경로)는
+`paste_paragraphs_into_cell_paragraphs`로 텍스트/문단을 삽입한 뒤 곧바로
+`mark_cell_control_dirty` → `mark_section_dirty` → `paginate_if_needed`로 넘어갔다.
+문단의 `line_segs`(줄바꿈 캐시)를 최내곽 셀 폭으로 다시 계산하는 호출이 전혀 없었다.
+
+같은 파일의 형제 함수(깊이 1 flat 버전) `paste_internal_in_cell_native`는 붙여넣기
+직후 명시적으로
+
+```rust
+for i in cell_para_idx..=last_para_idx {
+    self.reflow_cell_paragraph(section_idx, parent_para_idx, control_idx, cell_idx, i);
+}
+```
+
+를 호출해 셀 폭 기준 재래핑을 수행한다. 또한 `src/document_core/commands/text_editing.rs`의
+`delete_text_in_cell_by_path`는 이슈 #2755에서 정확히 같은 클래스의 문제(깊이 ≥2 중첩
+셀은 flat `reflow_cell_paragraph`로 재래핑할 수 없음)를 인지하고 path 전용
+`reflow_cell_paragraph_by_path`(`text_editing.rs:1354`, `pub(crate)`)를 도입해 이미
+고쳐졌다. 그러나 이 헬퍼가 `paste_internal_in_cell_by_path_native`에는 적용되지 않은
+채 남아 있었다 — #2755가 삭제/분할/병합/서식 경로에는 반영됐지만 붙여넣기 경로는
+누락됐다.
+
+## 재현
+
+바깥 표(셀 폭 5000 HWPUNIT, 넉넉함) 문단 안에 안쪽 표(셀 폭 200 HWPUNIT, 좁음)를
+중첩시키고, 안쪽 최내곽 셀에 40자 텍스트를 내부 클립보드로 붙여넣으면(`cellPath`
+경로 API), 셀 폭 200 기준으로는 여러 줄로 재래핑돼야 하지만 실제로는
+`insert_text_at` 직후의 미보정 상태(`line_segs.len() == 0`, 즉 재래핑이 전혀
+수행되지 않은 원본 빈 문단 상태)가 그대로 남았다.
+
+### red → green
+
+- 수정 전(재래핑 호출 임시 제거) 테스트 결과: `실제 0줄` → 패닉.
+- 수정 후: `line_segs.len() > 1` 통과.
+
+```
+test document_core::commands::clipboard::nested_cell_paste_reflow_tests::paste_in_nested_cell_by_path_reflows_inner_cell ... ok
+```
+
+## 수정
+
+`paste_internal_in_cell_by_path_native`에서 붙여넣기 직후, 형제 delete 경로와 동일한
+패턴으로 붙여넣기가 영향을 준 문단 범위(`cell_para_idx..=last_para_idx`)를
+`reflow_cell_paragraph_by_path`로 재래핑한다.
+
+## 영향 범위
+
+- `src/document_core/commands/clipboard.rs`만 수정. 다른 워크트리/파일은 건드리지 않음.
+- 이 브랜치는 `reflow_cell_paragraph_by_path` 헬퍼를 제공하는 선행 커밋
+  (`task/m100-2755-cell-bypath-reflow`, PR #2821)이 이미 로컬에 존재하는 워크트리 상태
+  위에서 작업했다. 즉 본 PR은 #2821 위에 스택된다 — #2821이 머지되기 전에는 devel
+  기준 diff에 #2821의 변경도 함께 표시될 수 있다.
+
+## 검증
+
+- `cargo build --lib`: 성공.
+- `cargo test --lib paste_in_nested_cell_by_path_reflows_inner_cell`: red→green 확인.
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음.
+- `rustfmt --edition 2021` 적용 후 `git diff --name-only`에 서식 변경으로 인한 추가
+  파일 없음(clipboard.rs만 변경).

--- a/mydocs/report/task_m100_2843_report.md
+++ b/mydocs/report/task_m100_2843_report.md
@@ -1,0 +1,83 @@
+# Task m100-2843 — 표 행 삭제(delete_row) 후 local_resize_cell_widths/heights stale 인덱스 수정
+
+## 이슈
+
+edwardkim/rhwp#2843
+
+## 근거 (문제)
+
+`src/model/table.rs`의 `Table::delete_row()`(1056-1121행)는 삭제 대상 행에 앵커가 있고
+`row_span == 1`인 셀을 `self.cells.retain(...)`으로 실제 제거하고, 이어서
+`self.cells.sort_by_key(|c| (c.row, c.col))`으로 남은 셀을 재정렬한다. 즉 행 삭제 한 번으로
+`cells` 벡터의 길이와 각 셀의 배열 인덱스 배치가 모두 바뀐다 — #2832에서 고친
+`Table::merge_cells()`의 `retain()` + `sort_by_key()` 패턴과 정확히 동일하다.
+
+`Table::local_resize_cell_widths: Vec<(usize, u32)>` / `local_resize_cell_heights: Vec<(usize, u32)>`
+(`src/model/table.rs:66, 69`)는 바로 이 `cells` 인덱스를 키로 저장하는 필드다. `delete_row()`도,
+이를 호출하는 커맨드 `delete_table_row_native()`(`src/document_core/commands/table_ops.rs:105`)도
+삭제 후 이 두 필드를 전혀 갱신하지 않았다.
+
+`merge_table_cells_native()`(#2832)가 이미 같은 정리를 병합 경로에 추가했지만, 삭제 경로는
+누락된 상태였다.
+
+## 전수 점검 결과
+
+같은 관점으로 `src/model/table.rs`/`src/document_core/commands/table_ops.rs`의 나머지
+셀-인덱스-시프팅 연산을 확인했다:
+
+- `insert_row`/`insert_column`: `self.cells.push(...)` 후 `sort_by_key` — 정리 없음(동일 결함).
+- `delete_row`(본 이슈): `retain()` + `sort_by_key` — 정리 없음(이번에 수정).
+- `delete_column`: `retain()` + `sort_by_key` — 정리 없음(동일 결함).
+- `split_cell`/`split_cell_into`: `push(...)` + `sort_by_key` — 정리 없음(동일 결함).
+- `merge_cells`: `retain()` + `sort_by_key` — `merge_table_cells_native()`에서 이미 정리(#2832).
+- `transpose_unmerged_table_in_place()`: 셀 전면 재구성 — 이미 `clear()` 정리함(기준 패턴).
+
+즉 `merge_cells` 외의 모든 셀-인덱스-시프팅 연산(`insert_row`, `insert_column`, `delete_row`,
+`delete_column`, `split_cell`, `split_cell_into`)이 같은 결함을 공유한다. 이번 작업은 속도 우선
+정책에 따라 재현이 가장 단순한 `delete_row` 하나로 스코프를 좁혔고, 나머지는 이슈 #2843 본문에
+후속 이슈로 명시해 두었다.
+
+또한 `zones: Vec<TableZone>` 필드는 `cell_grid` 배열 인덱스가 아니라 `start_row/col`~`end_row/col`
+좌표를 직접 저장하므로, 이번 조사 범위인 "인덱스 키 side table" 결함과는 다른 종류다(좌표가
+삭제/삽입으로 의미상 어긋날 수 있는 별개 문제이며, 이번 수정 대상이 아니다).
+
+## 재현 (red)
+
+3×2 표(row 0,1,2 × col 0,1, 총 6셀)에서 셀 인덱스 2(row=1,col=0)에 로컬 resize 높이를 저장한 뒤
+row 0을 삭제하면 셀 2개가 제거되어 `cells.len()`이 6→4가 되지만, `local_resize_cell_heights`는
+여전히 존재하지 않는 인덱스 2를 가리키는 `[(2, H)]`를 유지한다.
+
+- 테스트: `src/wasm_api/tests.rs::test_delete_table_row_clears_stale_local_resize_heights`
+- 수정 전 실행 결과: FAILED —
+  `행 삭제 후 셀 인덱스가 재배치되므로 local_resize_cell_heights의 stale 참조(인덱스 2)가 비워져야 한다`
+  assertion 실패 (실제로 `[(2, 5678)]`가 그대로 남아 있음을 확인).
+
+## 수정 (green)
+
+`src/document_core/commands/table_ops.rs`의 `delete_table_row_native()`에서
+`table.delete_row(...)` 성공 직후, `merge_table_cells_native()`(#2832)와 동일하게
+`table.local_resize_cell_widths.clear()` / `table.local_resize_cell_heights.clear()`를 호출한다.
+삭제된 행의 로컬 resize 힌트는 더 이상 유효하지 않은 인덱스를 가리키므로 정리가 안전하다.
+
+수정 후 동일 테스트 결과: PASSED.
+
+## 영향
+
+`local_resize_cell_widths`/`heights`를 셀 인덱스로 조회하는 렌더링·직렬화 경로가 있다면 행 삭제
+후 (1) 범위 초과 패닉, 또는 (2) 삭제 후 남은 엉뚱한 셀에 잘못된 로컬 resize 폭/높이가 적용되어
+표가 찌그러져 보이는 렌더링 회귀로 이어질 수 있다. 사용자가 셀 경계를 드래그해 크기를 조정한
+표(견적서·시간표 등)에서 행을 삭제하면 발생 가능.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib test_delete_table_row`: 1 passed
+  (`test_delete_table_row_clears_stale_local_resize_heights`)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021` 적용, 변경 파일 대상 추가 diff 없음 확인
+
+## 변경 파일
+
+- `src/document_core/commands/table_ops.rs` (수정)
+- `src/wasm_api/tests.rs` (테스트 추가)
+- `mydocs/report/task_m100_2843_report.md` (본 문서)

--- a/mydocs/report/task_m100_2853_report.md
+++ b/mydocs/report/task_m100_2853_report.md
@@ -1,0 +1,45 @@
+# 완료 보고서 — Task M100-2853
+
+- 이슈: #2853
+- 제목: 표 행/열 삽입 시 local_resize_cell_widths/heights stale 인덱스 미정리 (#2832/#2843 동일 버그 클래스)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2853-insert-row-col-stale-local-resize`
+
+## 1. 완료 내용
+
+`insert_table_row_native`/`insert_table_column_native`(`src/document_core/commands/table_ops.rs`)에서
+`Table::insert_row()`/`Table::insert_column()` 호출 직후 `local_resize_cell_widths`/
+`local_resize_cell_heights`를 `clear()`하도록 수정했다.
+
+두 모델 함수 모두 새 셀을 `push()`한 뒤 `self.cells.sort_by_key(|c| (c.row, c.col))`로 전체 셀
+배열을 재정렬한다. `local_resize_cell_widths/heights`는 `Vec<(usize, u32)>`로 cell 배열 인덱스를
+직접 키로 쓰기 때문에, 재정렬 이전 인덱스가 재정렬 이후에는 다른 셀을 가리키거나 범위를
+벗어나는 stale 참조가 된다. 이는 #2832(PR #2841, 셀 병합)·#2843(PR #2849, 행 삭제)에서 이미
+확인·수정된 것과 동일한 버그 클래스이며, 이번 건은 그 세 번째·네 번째 사례(행 삽입/열 삽입)다.
+
+## 2. 주요 변경
+
+- `src/document_core/commands/table_ops.rs`
+  - `insert_table_row_native`: `table.insert_row(...)` 호출 직후 `local_resize_cell_widths`/
+    `local_resize_cell_heights` clear 추가
+  - `insert_table_column_native`: `table.insert_column(...)` 호출 직후 동일하게 clear 추가
+- `src/wasm_api/tests.rs`
+  - `test_insert_table_row_and_column_clear_stale_local_resize` 추가 (3×2 표에서 셀 인덱스 2에
+    로컬 resize 폭/높이를 기록한 뒤 행 삽입, 이어서 열 삽입을 수행하며 각 단계 후 두 벡터가
+    비어 있는지 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib test_insert_table_row_and_column_clear_stale_local_resize` (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021` (변경 파일만)
+
+## 4. 잔여
+
+같은 버그 클래스로 코드 확인은 되었으나 이번 PR 범위 밖으로 남겨둔 항목 (별도 이슈/PR 필요):
+
+- `delete_table_column_native` (열 삭제)
+- `split_table_cell_native`/`split_cell_into` (셀 분할)

--- a/mydocs/report/task_m100_2905_report.md
+++ b/mydocs/report/task_m100_2905_report.md
@@ -1,0 +1,51 @@
+# Task #2905 처리 결과 — group_shapes_native char_offsets 전체 시프트 버그
+
+## 이슈
+https://github.com/edwardkim/rhwp/issues/2905
+
+## 문제
+
+`src/document_core/commands/object_ops/shape.rs`의 `group_shapes_native`가 새
+`GroupShape` 컨트롤을 문단에 삽입한 뒤, `para.char_offsets` 배열 전체에 무조건
+`+8`을 적용했다. `char_offsets`는 컨트롤 인덱스가 아니라 문단 텍스트의 각 문자가
+바이트 스트림 상 어디에 위치하는지 기록하는 배열이므로, 새 컨트롤이 삽입되는
+지점 **이후**의 항목만 시프트해야 한다. 삽입 지점보다 앞에 위치한 텍스트/다른
+컨트롤은 실제 위치가 변하지 않았음에도 오프셋이 잘못 밀렸다.
+
+같은 파일의 `create_shape_control_native`(shape.rs:1519-1556)와
+`insert_equation_native`(equation.rs, `Paragraph::shift_for_inline_control_insert`
+경유)는 모두 "삽입 지점 이후만 시프트" 규약을 지키고 있어, `group_shapes_native`만
+예외였다.
+
+## 수정
+
+컨트롤 삽입 *이전* 상태에서 `find_control_text_positions(para)`로 삽입 지점의
+텍스트 char-index(`safe_offset`)를 구하고, `para.char_offsets[safe_offset..]`
+구간만 `+8` 하도록 변경했다(`create_shape_control_native`와 동일 패턴).
+
+## 재현/회귀 테스트
+
+`src/document_core/commands/object_ops/shape.rs`
+`resize_clamp_tests::group_shapes_only_shifts_char_offsets_after_insertion_point`
+
+- 문단 텍스트 "A"(char_offsets=[0]) 뒤에 사각형 3개(S0,S1,S2)를 순서대로 삽입.
+- S1, S2만 그룹으로 묶음(S0는 문단에 그대로 남음).
+- 수정 전: `char_offsets`가 `[8]`로 잘못 변경됨(수동으로 fix 라인을 제거해
+  회귀를 재현·확인함, red).
+- 수정 후: `char_offsets`가 `[0]`으로 유지됨(green).
+
+## 검증
+
+- `cargo build --lib` — 통과
+- `cargo test --lib object_ops::shape::` — 6개 전부 통과(신규 테스트 포함)
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음
+- `rustfmt --edition 2021 src/document_core/commands/object_ops/shape.rs` — 적용
+
+## 변경 파일
+
+- `src/document_core/commands/object_ops/shape.rs` (수정 + 테스트 1건 추가)
+
+수정 범위는 `shape.rs`로 한정했으며, 동일 도메인의 `equation.rs`는 조사
+과정에서 다른 가설(page_tree_cache 무효화 누락)을 검토했으나 `recompose_section`이
+이미 무조건 `invalidate_page_tree_cache()`를 호출함을 확인해 오탐으로 판정,
+해당 파일은 변경 없이 원본 상태로 되돌렸다.

--- a/mydocs/report/task_m100_2912_report.md
+++ b/mydocs/report/task_m100_2912_report.md
@@ -1,0 +1,63 @@
+# Task m100-2912 처리 결과
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2912
+
+## 대상
+
+`src/document_core/commands/object_ops/shape.rs` — `ungroup_shape_native`
+
+같은 파일의 `group_shapes_native`가 오늘 #2905/#2910에서 "그룹 삽입 시 char_offsets 전체를
+무조건 +8" 하던 버그를 수정했다. 반대 방향 연산인 `ungroup_shape_native`(1개 컨트롤 →
+N개 자식)에서 동일 계열 버그가 남아있는지 점검한 결과, 실제로 존재함을 확인했다.
+
+## 근거
+
+수정 전 코드(문단 전체 char_offsets에 조건 없이 net_delta 적용):
+
+```rust
+let children_count = insert_idx - control_idx;
+if children_count > 1 && !para.char_offsets.is_empty() {
+    let net_delta = ((children_count - 1) * 8) as u32;
+    for co in para.char_offsets.iter_mut() {
+        *co += net_delta;
+    }
+}
+```
+
+`delete_shape_control_native`(같은 파일, 991~1091행)는 `gap_start`/`threshold`를 계산해
+삭제 지점 이후 항목만 시프트하도록 이미 올바르게 구현되어 있어, 대조군으로 삼아 버그를
+확정했다.
+
+## 수정
+
+`group_shapes_native`의 #2905 수정과 동일한 패턴: `find_control_text_positions(para)`로
+언그룹 지점의 텍스트축 위치를 구하고, 그 지점 이후의 `para.char_offsets` 항목에만
+net_delta를 적용하도록 변경했다.
+
+## 테스트 (red → green, 최소 1건)
+
+`ungroup_shape_only_shifts_char_offsets_after_insertion_point`
+(`resize_clamp_tests` 모듈, shape.rs)
+
+- 문단에 텍스트 "A"(char_offsets=[0])를 두고, 그 뒤(char_offset=1)에 사각형 3개를 삽입.
+- 첫 번째 사각형은 문단에 그대로 남기고, 나머지 두 개를 GroupShape로 직접 감싸 삽입한다
+  (group_shapes_native 자체는 이 작업 범위 밖의 별도 결함(#2905 계열, 아직 devel에
+  미병합)이 있어, 이 테스트가 검증하려는 ungroup_shape_native 로직만 독립적으로
+  검증하기 위해 그룹 생성 단계는 직접 구성으로 우회했다).
+- `ungroup_shape_native` 호출 후 char_offsets가 여전히 `[0]`인지 확인 — "A"의 오프셋이
+  밀리면 안 된다.
+- 수정 전 코드로 되돌려 실행 → `left: [8], right: [0]`로 실패(red) 확인.
+- 수정 코드 복원 후 재실행 → 통과(green) 확인.
+
+## 검증 범위 (경량)
+
+디스크 용량 문제로 지시된 대로 `cargo check --lib`과 대상 테스트 1건만 실행했다.
+전체 빌드/clippy/release-test는 생략했다. 변경 파일은 `rustfmt --edition 2021`로
+포맷했다.
+
+```
+cargo check --lib   # 통과
+cargo test --lib ungroup_shape_only_shifts_char_offsets_after_insertion_point  # 통과
+```

--- a/src/document_core/commands/clipboard.rs
+++ b/src/document_core/commands/clipboard.rs
@@ -903,6 +903,15 @@ impl DocumentCore {
             )?
         };
 
+        // [#2825] flat 형제 paste_internal_in_cell_native 는 붙여넣기 직후
+        // reflow_cell_paragraph 로 셀 폭 기준 재래핑을 하지만, path 버전은 이 호출이
+        // 없어 깊이 ≥2 중첩 셀에 붙여넣은 문단이 이전 line_segs 를 그대로 유지했다.
+        // #2755 가 delete/split/merge by_path 에 도입한 reflow_cell_paragraph_by_path
+        // 를 붙여넣기 경로에도 동일하게 적용한다.
+        for i in cell_para_idx..=last_para_idx {
+            self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, i);
+        }
+
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
         self.document.sections[section_idx].raw_stream = None;
@@ -1853,6 +1862,129 @@ mod char_shape_inherit_tests {
                 .map(|cs| cs.char_shape_id),
             Some(37),
             "붙여넣기 후 빈 이웃 문단이 커서 offset 글자모양(37)이 아닌 값을 상속"
+        );
+    }
+}
+
+/// [#2825] `paste_internal_in_cell_by_path_native` 가 깊이 ≥2 중첩 셀에서도
+/// 최내곽 셀 폭으로 재래핑(reflow)하는지 검증한다.
+#[cfg(test)]
+mod nested_cell_paste_reflow_tests {
+    use crate::document_core::{ClipboardData, DocumentCore};
+    use crate::model::control::Control;
+    use crate::model::document::{Document, Section, SectionDef};
+    use crate::model::page::PageDef;
+    use crate::model::paragraph::{CharShapeRef, Paragraph};
+    use crate::model::table::{Cell, Table};
+
+    /// 바깥 표(셀 폭 5000, 넉넉함) 문단 안에 안쪽 표(셀 폭 200, 좁음)를 중첩시키고,
+    /// 안쪽 셀에는 빈 문단 하나만 둔다. path 는 [(outer,0,0),(inner,0,0)].
+    fn core_with_nested_narrow_empty_cell() -> (DocumentCore, Vec<(usize, usize, usize)>) {
+        let inner_para = Paragraph::default();
+
+        let inner_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 200, // 최내곽 셀 폭
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(inner_table)));
+        let inner_ctrl_idx = outer_cell_para.controls.len() - 1;
+
+        let outer_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 5000, // 바깥 셀은 넉넉히 — 안쪽 셀 폭이 실제 리플로우 기준임을 분리
+                paragraphs: vec![outer_cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut body_para = Paragraph::default();
+        body_para
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+        let outer_ctrl_idx = body_para.controls.len() - 1;
+
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        let path = vec![(outer_ctrl_idx, 0, 0), (inner_ctrl_idx, 0, 0)];
+        (core, path)
+    }
+
+    /// [#2825] red→green: 40자 텍스트를 내부 클립보드로 채운 뒤 폭 200 최내곽 셀에
+    /// 붙여넣으면, 붙여넣기 직후 셀 폭 기준으로 재래핑돼 여러 줄이어야 한다.
+    /// 수정 전에는 `paste_internal_in_cell_by_path_native` 가 재래핑을 호출하지
+    /// 않아 `line_segs` 가 1줄(insert_text_at 직후 미보정 상태)로 남았다.
+    #[test]
+    fn paste_in_nested_cell_by_path_reflows_inner_cell() {
+        let (mut core, path) = core_with_nested_narrow_empty_cell();
+        let text = "A".repeat(40);
+        core.clipboard = Some(ClipboardData {
+            paragraphs: vec![Paragraph {
+                text: text.clone(),
+                char_offsets: (0..text.chars().count() as u32).collect(),
+                char_count: text.chars().count() as u32,
+                char_shapes: vec![CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 0,
+                }],
+                has_para_text: true,
+                ..Default::default()
+            }],
+            plain_text: text,
+        });
+
+        core.paste_internal_in_cell_by_path_native(0, 0, &path, 0)
+            .expect("중첩 셀 붙여넣기가 성공해야 함");
+
+        let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+        assert!(
+            paras[0].line_segs.len() > 1,
+            "폭 200 최내곽 셀에 40자를 붙여넣으면 여러 줄로 재래핑돼야 함 (실제 {}줄)",
+            paras[0].line_segs.len()
         );
     }
 }

--- a/src/document_core/commands/formatting.rs
+++ b/src/document_core/commands/formatting.rs
@@ -1186,6 +1186,23 @@ impl DocumentCore {
         end_offset: usize,
         props_json: &str,
     ) -> Result<String, HwpError> {
+        // [#2755] 깊이 1 셀은 flat 형제가 셀 폭 리플로우(paint-only 게이팅 포함)를 담당한다.
+        // `apply_char_format_in_cell_native`(:1103)는 char_shape_mods_affect_text_flow 로
+        // 게이팅한 뒤에만 reflow_cell_paragraph 를 호출하므로 밑줄/색 변경은 리플로우하지 않는다.
+        if path.len() == 1 {
+            let (control_idx, cell_idx, cell_para_idx) = path[0];
+            return self.apply_char_format_in_cell_native(
+                sec_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                start_offset,
+                end_offset,
+                props_json,
+            );
+        }
+
         let mut mods = parse_char_shape_mods(props_json);
         if json_has_border_keys(props_json) {
             let bf_id = self.create_border_fill_from_json(props_json);
@@ -1199,6 +1216,13 @@ impl DocumentCore {
         {
             let para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
             para.apply_char_shape_range(start_offset, end_offset, new_id);
+        }
+        // [#2755] 깊이 ≥ 2 중첩 셀도 텍스트 흐름에 영향 주는 변경 시 최내곽 셀 폭으로 재래핑한다
+        // (apply_char_format_in_cell_native 의 char_shape_mods_affect_text_flow 게이팅과 동형 —
+        // 밑줄/색 등 paint-only 변경은 여기서도 리플로우하지 않는다).
+        if char_shape_mods_affect_text_flow(&mods) {
+            let inner_cpi = path.last().map(|e| e.2).unwrap_or(0);
+            self.reflow_cell_paragraph_by_path(sec_idx, parent_para_idx, path, inner_cpi);
         }
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
@@ -1240,6 +1264,23 @@ impl DocumentCore {
         end_offset: usize,
         char_shape_id: u32,
     ) -> Result<String, HwpError> {
+        // [#2755] 깊이 1 셀은 flat 형제가 셀 폭 리플로우를 담당한다.
+        // `set_char_shape_id_in_cell_native`(:1268)는 (복원 대상 모양의 내용을 알 수 없으므로)
+        // 무조건 reflow_cell_paragraph 를 호출한다. undo 복원 경로의 do/undo 대칭을 지킨다.
+        if path.len() == 1 {
+            let (control_idx, cell_idx, cell_para_idx) = path[0];
+            return self.set_char_shape_id_in_cell_native(
+                sec_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                start_offset,
+                end_offset,
+                char_shape_id,
+            );
+        }
+
         if char_shape_id as usize >= self.document.doc_info.char_shapes.len() {
             return Err(HwpError::RenderError(format!(
                 "글자 모양 ID {} 범위 초과 (총 {}개)",
@@ -1251,6 +1292,10 @@ impl DocumentCore {
             let cell_para = self.get_cell_paragraph_mut_by_path(sec_idx, parent_para_idx, path)?;
             cell_para.apply_char_shape_range(start_offset, end_offset, char_shape_id);
         }
+        // [#2755] 깊이 ≥ 2 중첩 셀도 최내곽 셀 폭으로 재래핑한다(복원 대상 모양의 내용을 알 수
+        // 없으므로 flat set_char_shape_id_in_cell_native 처럼 무조건).
+        let inner_cpi = path.last().map(|e| e.2).unwrap_or(0);
+        self.reflow_cell_paragraph_by_path(sec_idx, parent_para_idx, path, inner_cpi);
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(sec_idx, parent_para_idx, outer_ctrl);
         self.document.sections[sec_idx].raw_stream = None;
@@ -2379,6 +2424,58 @@ mod cell_reflow_width_tests {
         );
     }
 
+    /// [#2755] `applyCharFormatInCellByPath` 도 깊이 1 셀에서 셀 폭 리플로우를 해야 한다.
+    ///
+    /// Studio 의 `ApplyCharFormatCommand` 는 `isCell`(= 모든 셀) 조건으로 이 경로를 쓰므로
+    /// 깊이 1 셀 서식이 전부 여기로 들어온다. 리플로우가 없으면 글자 폭만 넓어지고 줄
+    /// 경계는 그대로라 텍스트가 셀 오른쪽 경계를 넘어 그려진다.
+    #[test]
+    fn char_format_by_path_reflow_uses_cell_width_not_page_column_width() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell(&text);
+
+        core.apply_char_format_in_cell_by_path(0, 0, &[(0, 0, 0)], 0, 40, r#"{"fontSize":2000}"#)
+            .expect("서식 적용이 성공해야 함");
+
+        let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Table(t) => t,
+            _ => panic!("표 컨트롤이어야 함"),
+        };
+        let line_count = table.cells[0].paragraphs[0].line_segs.len();
+        assert!(
+            line_count > 1,
+            "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함 \
+             (실제 {line_count}줄 — 리플로우가 없으면 저장된 1줄 경계가 그대로 남는다)"
+        );
+    }
+
+    /// [#2755] undo 가 쓰는 `setCharShapeIdInCellByPath` 도 같은 계약을 지켜야 한다.
+    ///
+    /// flat 형제 `set_char_shape_id_in_cell_native` 는 (모양 변화 내용을 알 수 없으므로)
+    /// 무조건 `reflow_cell_paragraph` 를 호출한다.
+    #[test]
+    fn set_char_shape_id_by_path_reflow_uses_cell_width_not_page_column_width() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell(&text);
+        if core.document.doc_info.char_shapes.is_empty() {
+            core.document.doc_info.char_shapes.push(Default::default());
+        }
+
+        core.set_char_shape_id_in_cell_by_path(0, 0, &[(0, 0, 0)], 0, 40, 0)
+            .expect("글자 모양 복원이 성공해야 함");
+
+        let table = match &core.document.sections[0].paragraphs[0].controls[0] {
+            Control::Table(t) => t,
+            _ => panic!("표 컨트롤이어야 함"),
+        };
+        let line_count = table.cells[0].paragraphs[0].line_segs.len();
+        assert!(
+            line_count > 1,
+            "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함 \
+             (실제 {line_count}줄)"
+        );
+    }
+
     #[test]
     fn para_format_reflow_uses_cell_width_not_page_column_width() {
         let text = "A".repeat(40);
@@ -2395,6 +2492,141 @@ mod cell_reflow_width_tests {
         assert!(
             line_count > 1,
             "셀 폭(200 HWPUNIT)으로 리플로우했다면 40자가 여러 줄로 나뉘어야 함              (실제 {line_count}줄 — 페이지 본문 폭을 쓰면 1줄로 뭉친다)"
+        );
+    }
+
+    /// [#2755] 깊이 2 중첩 표: 바깥 표(1셀, 폭 5000) 문단 안에 안쪽 표(1셀, 폭 200 + 권위
+    /// line_segs)를 둔다. path = [(outer,0,0),(inner,0,0)] 를 함께 돌려준다.
+    fn core_with_nested_narrow_cell(text: &str) -> (DocumentCore, Vec<(usize, usize, usize)>) {
+        let mut inner_para = Paragraph {
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_count: text.chars().count() as u32,
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: vec![LineSeg {
+                text_start: 0,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        inner_para.has_para_text = true;
+
+        let inner_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 200,
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(inner_table)));
+        let inner_ctrl_idx = outer_cell_para.controls.len() - 1;
+
+        let outer_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 5000,
+                paragraphs: vec![outer_cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut body_para = Paragraph::default();
+        body_para
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+        let outer_ctrl_idx = body_para.controls.len() - 1;
+
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        let path = vec![(outer_ctrl_idx, 0, 0), (inner_ctrl_idx, 0, 0)];
+        (core, path)
+    }
+
+    fn inner_cell_line_count(core: &DocumentCore, path: &[(usize, usize, usize)]) -> usize {
+        let Control::Table(outer) = &core.document.sections[0].paragraphs[0].controls[path[0].0]
+        else {
+            panic!("바깥 표여야 함");
+        };
+        let Control::Table(inner) = &outer.cells[0].paragraphs[0].controls[path[1].0] else {
+            panic!("안쪽 표여야 함");
+        };
+        inner.cells[0].paragraphs[0].line_segs.len()
+    }
+
+    /// [#2755] 깊이 2 — `applyCharFormatInCellByPath` 가 최내곽 셀 폭으로 재래핑한다.
+    #[test]
+    fn char_format_by_path_reflow_reaches_nested_inner_cell() {
+        let (mut core, path) = core_with_nested_narrow_cell(&"A".repeat(40));
+
+        core.apply_char_format_in_cell_by_path(0, 0, &path, 0, 40, r#"{"fontSize":2000}"#)
+            .expect("서식 적용이 성공해야 함");
+
+        let line_count = inner_cell_line_count(&core, &path);
+        assert!(
+            line_count > 1,
+            "깊이 2 안쪽 셀 폭(200)으로 재래핑되면 40자가 여러 줄이어야 함 (실제 {line_count}줄)"
+        );
+    }
+
+    /// [#2755] 깊이 2 — `setCharShapeIdInCellByPath` 도 최내곽 셀 폭으로 재래핑한다.
+    #[test]
+    fn set_char_shape_id_by_path_reflow_reaches_nested_inner_cell() {
+        let (mut core, path) = core_with_nested_narrow_cell(&"A".repeat(40));
+        if core.document.doc_info.char_shapes.is_empty() {
+            core.document.doc_info.char_shapes.push(Default::default());
+        }
+
+        core.set_char_shape_id_in_cell_by_path(0, 0, &path, 0, 40, 0)
+            .expect("글자 모양 복원이 성공해야 함");
+
+        let line_count = inner_cell_line_count(&core, &path);
+        assert!(
+            line_count > 1,
+            "깊이 2 안쪽 셀 폭(200)으로 재래핑되면 40자가 여러 줄이어야 함 (실제 {line_count}줄)"
         );
     }
 }

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -2125,16 +2125,28 @@ impl DocumentCore {
 
             // controls/ctrl_data_records 삽입 (범위 보정)
             let ctrl_insert = insert_ci.min(para.controls.len());
+
+            // char_offsets 시프트 지점(텍스트축 char-index)을 컨트롤 삽입 *이전* 상태에서
+            // 계산한다. create_shape_control_native(#1904 shape.rs:1519-1556)와 동일한
+            // 규약: 삽입 지점 이전 char_offsets 는 그대로 두고, 그 지점 이후만 +8 시프트
+            // 해야 한다. 버그: 기존 코드는 이 계산 없이 para.char_offsets 전체를 +8 했기
+            // 때문에, 그룹 대상보다 앞서 문단에 남아있는 다른 컨트롤(그룹에 포함되지 않은
+            // Shape/Picture 등)의 char_offsets 항목까지 밀려 텍스트-컨트롤 오프셋 매핑이
+            // 깨졌다(커서 이동/컨트롤 조회 시 위치 오탐).
+            let text_positions = crate::document_core::helpers::find_control_text_positions(para);
+            let text_len = para.text.chars().count();
+            let safe_offset = text_positions.get(ctrl_insert).copied().unwrap_or(text_len);
+
             para.controls
                 .insert(ctrl_insert, Control::Shape(Box::new(group_obj)));
             let cdr_insert = ctrl_insert.min(para.ctrl_data_records.len());
             para.ctrl_data_records.insert(cdr_insert, None);
 
-            // char_offsets: 텍스트 문자 매핑이므로 컨트롤 인덱스와 무관
-            // 기존 char_offsets에서 마지막 gap 위치 다음에 8바이트 추가
+            // char_offsets: 텍스트 문자 매핑이므로 컨트롤 인덱스와 무관 — 삽입 지점(safe_offset)
+            // 이후 char_offsets 만 +8 시프트한다.
             if !para.char_offsets.is_empty() {
-                // 모든 기존 char_offsets를 8씩 증가 (컨트롤이 앞에 삽입되므로)
-                for co in para.char_offsets.iter_mut() {
+                let shift_from = safe_offset.min(para.char_offsets.len());
+                for co in para.char_offsets[shift_from..].iter_mut() {
                     *co += 8;
                 }
             }
@@ -2765,6 +2777,67 @@ mod resize_clamp_tests {
         let common = shape_common(&core, para, ctrl);
         assert_eq!(common.width, 12000);
         assert_eq!(common.height, 8000);
+    }
+
+    /// group_shapes_native 는 그룹으로 묶이는 컨트롤보다 앞서 문단에 남아있는 텍스트의
+    /// char_offsets 를 건드리면 안 된다. 삽입 지점(safe_offset) 이전 항목은 그대로 두고
+    /// 그 이후만 +8 시프트해야 한다(create_shape_control_native 와 동일 규약, shape.rs:1519).
+    /// 회귀 전에는 para.char_offsets 전체를 무조건 +8 해서, 그룹 대상보다 앞에 있는
+    /// 텍스트/컨트롤의 오프셋까지 밀렸다.
+    #[test]
+    fn group_shapes_only_shifts_char_offsets_after_insertion_point() {
+        let mut core = make_test_core();
+        {
+            // 문단에 실제 텍스트 "A"를 미리 채워 char_offsets=[0] 상태를 만든다.
+            let para = &mut core.document.sections[0].paragraphs[0];
+            para.text = "A".to_string();
+            para.char_offsets = vec![0];
+            para.char_count = 1;
+        }
+
+        // 텍스트 뒤(char_offset=1)에 사각형 3개를 순서대로 삽입한다.
+        let mut ctrl_indices = Vec::new();
+        for _ in 0..3 {
+            let res = core
+                .create_shape_control_native(
+                    0,
+                    0,
+                    1,
+                    900,
+                    900,
+                    0,
+                    0,
+                    false,
+                    "InFrontOfText",
+                    "rectangle",
+                    false,
+                    false,
+                    &[],
+                )
+                .expect("create rectangle");
+            let ctrl_idx = res
+                .split("\"controlIdx\":")
+                .nth(1)
+                .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap();
+            ctrl_indices.push(ctrl_idx);
+        }
+        assert_eq!(
+            core.document.sections[0].paragraphs[0].char_offsets,
+            vec![0],
+            "사전 조건: 삽입 후에도 'A' 오프셋은 0 이어야 한다"
+        );
+
+        // 뒤의 두 도형만 묶는다 — 첫 도형은 문단에 그대로 남아 있다.
+        core.group_shapes_native(0, &[(0, ctrl_indices[1]), (0, ctrl_indices[2])])
+            .expect("group shapes");
+
+        assert_eq!(
+            core.document.sections[0].paragraphs[0].char_offsets,
+            vec![0],
+            "그룹 묶기가 삽입 지점 이전 텍스트(char 'A')의 char_offsets 를 밀면 안 된다"
+        );
     }
 }
 

--- a/src/document_core/commands/object_ops/shape.rs
+++ b/src/document_core/commands/object_ops/shape.rs
@@ -2336,10 +2336,22 @@ impl DocumentCore {
         }
 
         // char_offsets: 그룹 1개 → 자식 N개, net 변화 = (N-1) * 8
+        //
+        // [Issue #2912] group_shapes_native 의 반대 방향 연산이다. #2905/#2910 에서 확립한
+        // 규약(create_shape_control_native/insert_equation_native 와 동일)대로, 언그룹
+        // 지점(find_control_text_positions 기준) *이전* char_offsets 는 그대로 두고, 그
+        // 지점 이후 항목에만 net_delta 를 적용해야 한다. 기존 코드는 이 계산 없이
+        // para.char_offsets 전체에 무조건 += 했기 때문에, 언그룹 대상보다 앞서 문단에
+        // 남아있는 텍스트/컨트롤의 char_offsets 까지 밀려 텍스트-컨트롤 오프셋 매핑이
+        // 깨졌다.
         let children_count = insert_idx - control_idx;
         if children_count > 1 && !para.char_offsets.is_empty() {
             let net_delta = ((children_count - 1) * 8) as u32;
-            for co in para.char_offsets.iter_mut() {
+            let text_positions = crate::document_core::helpers::find_control_text_positions(para);
+            let text_len = para.text.chars().count();
+            let safe_offset = text_positions.get(control_idx).copied().unwrap_or(text_len);
+            let shift_from = safe_offset.min(para.char_offsets.len());
+            for co in para.char_offsets[shift_from..].iter_mut() {
                 *co += net_delta;
             }
         }
@@ -2837,6 +2849,111 @@ mod resize_clamp_tests {
             core.document.sections[0].paragraphs[0].char_offsets,
             vec![0],
             "그룹 묶기가 삽입 지점 이전 텍스트(char 'A')의 char_offsets 를 밀면 안 된다"
+        );
+    }
+
+    /// [Issue #2912] ungroup_shape_native 는 언그룹 지점 이전 char_offsets 를 건드리면 안
+    /// 된다. group_shapes_native(#2905/#2910) 와 반대 방향(1개 → N개)의 연산이지만 동일한
+    /// 규약을 지켜야 한다: 삽입/시프트 지점(find_control_text_positions 기준) 이전 항목은
+    /// 그대로 두고 그 이후만 시프트한다.
+    ///
+    /// 회귀 전에는 para.char_offsets 전체에 무조건 net_delta 를 더해서, 언그룹 대상보다
+    /// 앞서 문단에 남아있는 텍스트("A")의 char_offsets 항목까지 밀렸다.
+    #[test]
+    fn ungroup_shape_only_shifts_char_offsets_after_insertion_point() {
+        let mut core = make_test_core();
+        {
+            // 문단에 실제 텍스트 "A"를 미리 채워 char_offsets=[0] 상태를 만든다.
+            let para = &mut core.document.sections[0].paragraphs[0];
+            para.text = "A".to_string();
+            para.char_offsets = vec![0];
+            para.char_count = 1;
+        }
+
+        // 텍스트 뒤(char_offset=1)에 사각형 3개를 순서대로 삽입한다.
+        let mut ctrl_indices = Vec::new();
+        for _ in 0..3 {
+            let res = core
+                .create_shape_control_native(
+                    0,
+                    0,
+                    1,
+                    900,
+                    900,
+                    0,
+                    0,
+                    false,
+                    "InFrontOfText",
+                    "rectangle",
+                    false,
+                    false,
+                    &[],
+                )
+                .expect("create rectangle");
+            let ctrl_idx = res
+                .split("\"controlIdx\":")
+                .nth(1)
+                .and_then(|s| s.split(|c: char| !c.is_ascii_digit()).next())
+                .and_then(|s| s.parse::<usize>().ok())
+                .unwrap();
+            ctrl_indices.push(ctrl_idx);
+        }
+        assert_eq!(
+            core.document.sections[0].paragraphs[0].char_offsets,
+            vec![0],
+            "사전 조건: 사각형 삽입 후에도 'A' 오프셋은 0 이어야 한다"
+        );
+
+        // 뒤의 두 도형을 GroupShape 로 직접 감싸 넣는다 (group_shapes_native 는 별도 결함
+        // #2905 계열이 있어 이 테스트의 관심사인 ungroup_shape_native 만 독립적으로
+        // 검증하기 위해 그룹 생성은 우회한다). ctrl_indices[1], [2] 는 char_offsets
+        // 배열 길이(1) 를 넘어서는 위치에 있으므로 그룹으로 합쳐도 char_offsets 는
+        // 여전히 [0] 이어야 한다 — 이는 group_shapes_native 가 올바르게 구현되었을 때와
+        // 동일한 사전 조건이다.
+        let group_ctrl_idx;
+        {
+            use crate::model::control::Control;
+            use crate::model::shape::{GroupShape, ShapeObject};
+            let para = &mut core.document.sections[0].paragraphs[0];
+            let removed_third = para.controls.remove(ctrl_indices[2]);
+            para.ctrl_data_records.remove(ctrl_indices[2]);
+            let removed_second = para.controls.remove(ctrl_indices[1]);
+            para.ctrl_data_records.remove(ctrl_indices[1]);
+            let shape_of = |c: Control| -> ShapeObject {
+                match c {
+                    Control::Shape(s) => *s,
+                    _ => panic!("expected shape control"),
+                }
+            };
+            let child_a = shape_of(removed_second);
+            let child_b = shape_of(removed_third);
+            let group = GroupShape {
+                common: child_a.common().clone(),
+                shape_attr: child_a.shape_attr().clone(),
+                children: vec![child_a, child_b],
+                caption: None,
+            };
+            group_ctrl_idx = ctrl_indices[1];
+            para.controls.insert(
+                group_ctrl_idx,
+                Control::Shape(Box::new(ShapeObject::Group(group))),
+            );
+            para.ctrl_data_records.insert(group_ctrl_idx, None);
+        }
+        assert_eq!(
+            core.document.sections[0].paragraphs[0].char_offsets,
+            vec![0],
+            "사전 조건: 그룹 삽입 후에도 'A' 오프셋은 0 이어야 한다"
+        );
+
+        // 방금 만든 그룹을 다시 풀어낸다 (1개 → 2개, net_delta = 8).
+        core.ungroup_shape_native(0, 0, group_ctrl_idx)
+            .expect("ungroup shapes");
+
+        assert_eq!(
+            core.document.sections[0].paragraphs[0].char_offsets,
+            vec![0],
+            "언그룹이 삽입 지점 이전 텍스트(char 'A')의 char_offsets 를 밀면 안 된다"
         );
     }
 }

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -117,6 +117,15 @@ impl DocumentCore {
         let row_count = table.row_count;
         let col_count = table.col_count;
 
+        // Table::delete_row()는 삭제 행의 셀을 retain()으로 제거하고 남은 셀을
+        // sort_by_key(row, col)로 재정렬한다. local_resize_cell_widths/heights는
+        // 이 재정렬 이전의 cell 인덱스를 그대로 물고 있는 Vec<(usize, u32)>라서,
+        // 삭제 이후에는 엉뚱한(또는 범위를 벗어난) 셀을 가리키는 stale 참조가 된다.
+        // merge_table_cells_native()(#2832)와 동일하게, 행 삭제도 셀 인덱스 배치를
+        // 바꾸므로 함께 비워야 한다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -54,6 +54,15 @@ impl DocumentCore {
         let row_count = table.row_count;
         let col_count = table.col_count;
 
+        // Table::insert_row()는 새 셀을 push()한 뒤 전체를
+        // sort_by_key(row, col)로 재정렬한다. local_resize_cell_widths/heights는
+        // 이 재정렬 이전의 cell 인덱스를 그대로 물고 있는 Vec<(usize, u32)>라서,
+        // 삽입 이후에는 엉뚱한(또는 범위를 벗어난) 셀을 가리키는 stale 참조가 된다.
+        // delete_table_row_native()(#2843/#2849), merge_table_cells_native()(#2832)와
+        // 동일하게, 행 삽입도 셀 인덱스 배치를 바꾸므로 함께 비워야 한다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();
@@ -85,6 +94,12 @@ impl DocumentCore {
         table.dirty = true;
         let row_count = table.row_count;
         let col_count = table.col_count;
+
+        // insert_table_row_native()와 동일한 사유(위 주석 참조): Table::insert_column()도
+        // 새 셀을 push()한 뒤 sort_by_key(row, col)로 재정렬하므로 local_resize_cell_widths/
+        // heights의 인덱스 참조가 stale 해진다. 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
 
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -1143,54 +1143,15 @@ impl DocumentCore {
     ) {
         use crate::renderer::hwpunit_to_px;
 
-        // 셀/글상자 폭과 패딩 읽기 (불변 참조)
-        let (cell_width, pad_left, pad_right) = {
-            let para = &self.document.sections[section_idx].paragraphs[parent_para_idx];
-            match para.controls.get(control_idx) {
-                Some(Control::Table(table)) => {
-                    if cell_idx == 65534 {
-                        // 표 캡션 리플로우: Top/Bottom은 max_width, Left/Right는 width 사용
-                        if let Some(ref cap) = table.caption {
-                            use crate::model::shape::CaptionDirection;
-                            let w = match cap.direction {
-                                CaptionDirection::Left | CaptionDirection::Right => cap.width,
-                                _ => cap.max_width,
-                            };
-                            (w, 0, 0)
-                        } else {
-                            return;
-                        }
-                    } else if let Some(cell) = table.cells.get(cell_idx) {
-                        let pad_l = if cell.apply_inner_margin {
-                            cell.padding.left
-                        } else {
-                            table.padding.left
-                        };
-                        let pad_r = if cell.apply_inner_margin {
-                            cell.padding.right
-                        } else {
-                            table.padding.right
-                        };
-                        (cell.width, pad_l, pad_r)
-                    } else {
-                        return;
-                    }
-                }
-                Some(Control::Shape(shape)) => {
-                    if let Some(tb) = super::super::helpers::get_textbox_from_shape(shape) {
-                        let common = shape.common();
-                        // 글상자 폭 = common.width, 여백 = textbox margin
-                        (common.width as u32, tb.margin_left, tb.margin_right)
-                    } else {
-                        return;
-                    }
-                }
-                Some(Control::Picture(pic)) => {
-                    // 캡션 폭 = 그림 폭 (Bottom/Top 방향), 여백 없음
-                    (pic.common.width as u32, 0, 0)
-                }
-                _ => return,
-            }
+        // 셀/글상자 폭과 패딩 읽기 (불변 참조) — path 변형과 공유하는 helper 사용.
+        let (cell_width, pad_left, pad_right) = match self.document.sections[section_idx].paragraphs
+            [parent_para_idx]
+            .controls
+            .get(control_idx)
+            .and_then(|control| Self::cell_metrics_for_control(control, cell_idx))
+        {
+            Some(metrics) => metrics,
+            None => return,
         };
 
         let styles = resolve_styles(&self.document.doc_info, self.dpi);
@@ -1310,6 +1271,145 @@ impl DocumentCore {
             dpi,
             is_hwp3_variant,
         );
+    }
+
+    /// [#2755] 컨트롤+cell_idx 로부터 셀 폭·좌우 패딩(HWPUNIT)을 해석한다.
+    ///
+    /// `reflow_cell_paragraph`(flat)와 `reflow_cell_paragraph_by_path`(중첩)가 공유한다.
+    /// `None` = 표/글상자/그림 캡션이 아니거나 대상 셀/텍스트박스가 없음.
+    fn cell_metrics_for_control(control: &Control, cell_idx: usize) -> Option<(u32, i16, i16)> {
+        match control {
+            Control::Table(table) => {
+                if cell_idx == 65534 {
+                    // 표 캡션: Top/Bottom 은 max_width, Left/Right 는 width.
+                    let cap = table.caption.as_ref()?;
+                    use crate::model::shape::CaptionDirection;
+                    let w = match cap.direction {
+                        CaptionDirection::Left | CaptionDirection::Right => cap.width,
+                        _ => cap.max_width,
+                    };
+                    Some((w, 0, 0))
+                } else {
+                    let cell = table.cells.get(cell_idx)?;
+                    let pad_l = if cell.apply_inner_margin {
+                        cell.padding.left
+                    } else {
+                        table.padding.left
+                    };
+                    let pad_r = if cell.apply_inner_margin {
+                        cell.padding.right
+                    } else {
+                        table.padding.right
+                    };
+                    Some((cell.width, pad_l, pad_r))
+                }
+            }
+            Control::Shape(shape) => {
+                let tb = super::super::helpers::get_textbox_from_shape(shape)?;
+                let common = shape.common();
+                Some((common.width as u32, tb.margin_left, tb.margin_right))
+            }
+            Control::Picture(pic) => Some((pic.common.width as u32, 0, 0)),
+            _ => None,
+        }
+    }
+
+    /// [#2755] path 의 CellPathEntry 사슬을 따라 **최내곽** 셀의 폭·좌우 패딩(HWPUNIT)을
+    /// 해석한다. 마지막 엔트리를 제외한 각 엔트리에서 다음 중첩 컨트롤을 담은 컨테이너
+    /// 문단(`cell_para_idx`)으로 하강한다 — `get_cell_paragraphs_mut_by_path` 의 불변 짝이다.
+    fn resolve_innermost_cell_metrics(
+        &self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+    ) -> Option<(u32, i16, i16)> {
+        let mut para = self
+            .document
+            .sections
+            .get(section_idx)?
+            .paragraphs
+            .get(parent_para_idx)?;
+        for (i, &(ctrl_idx, cell_idx, cell_para_idx)) in path.iter().enumerate() {
+            let control = para.controls.get(ctrl_idx)?;
+            if i + 1 == path.len() {
+                return Self::cell_metrics_for_control(control, cell_idx);
+            }
+            para = match control {
+                Control::Table(t) => t.cells.get(cell_idx)?.paragraphs.get(cell_para_idx)?,
+                Control::Shape(s) => super::super::helpers::get_textbox_from_shape(s)?
+                    .paragraphs
+                    .get(cell_para_idx)?,
+                Control::Picture(p) => p.caption.as_ref()?.paragraphs.get(cell_para_idx)?,
+                _ => return None,
+            };
+        }
+        None
+    }
+
+    /// [#2755] path 기반 셀 리플로우 (깊이 ≥ 2 중첩 표 지원).
+    ///
+    /// `reflow_cell_paragraph`(flat)는 최외곽 표만 리플로우한다. 이 변형은 path 의
+    /// CellPathEntry 사슬로 **최내곽** 셀의 폭을 해석하고, 그 폭으로 최내곽 셀의
+    /// `cell_para_idx` 문단을 재래핑한다. 깊이 1 에서는 flat 형제와 동일한 결과를 낸다.
+    pub(crate) fn reflow_cell_paragraph_by_path(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        cell_para_idx: usize,
+    ) {
+        use crate::renderer::hwpunit_to_px;
+
+        let Some((cell_width, pad_left, pad_right)) =
+            self.resolve_innermost_cell_metrics(section_idx, parent_para_idx, path)
+        else {
+            return;
+        };
+        let styles = resolve_styles(&self.document.doc_info, self.dpi);
+        let dpi = self.dpi;
+        let cell_width_px = hwpunit_to_px(cell_width as i32, dpi);
+        let pad_left_px = hwpunit_to_px(pad_left as i32, dpi);
+        let pad_right_px = hwpunit_to_px(pad_right as i32, dpi);
+        let available_width = (cell_width_px - pad_left_px - pad_right_px).max(0.0);
+
+        let Ok(paras) = self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)
+        else {
+            return;
+        };
+        let Some(cell_para) = paras.get_mut(cell_para_idx) else {
+            return;
+        };
+        let para_style = styles.para_styles.get(cell_para.para_shape_id as usize);
+        let margin_left = para_style.map(|s| s.margin_left).unwrap_or(0.0);
+        let margin_right = para_style.map(|s| s.margin_right).unwrap_or(0.0);
+        let final_width = (available_width - margin_left - margin_right).max(0.0);
+        reflow_line_segs(cell_para, final_width, &styles, dpi);
+    }
+
+    /// [#2755] path 기반 셀 문단 vpos 재계산 (깊이 ≥ 2 중첩 표 지원).
+    /// `recalculate_cell_paragraph_vpos_native` 의 path 변형.
+    fn recalculate_cell_paragraph_vpos_by_path(
+        &mut self,
+        section_idx: usize,
+        parent_para_idx: usize,
+        path: &[(usize, usize, usize)],
+        start_para: usize,
+        ignore_reset_at: Option<usize>,
+    ) {
+        let styles = resolve_styles(&self.document.doc_info, self.dpi);
+        let dpi = self.dpi;
+        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        if let Ok(paras) = self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)
+        {
+            recalculate_cell_paragraph_vpos(
+                paras,
+                start_para,
+                ignore_reset_at,
+                &styles,
+                dpi,
+                is_hwp3_variant,
+            );
+        }
     }
 
     // ─── Phase 3 네이티브 구현: 커서 이동 API ─────────────────
@@ -3467,8 +3567,36 @@ impl DocumentCore {
         char_offset: usize,
         count: usize,
     ) -> Result<String, HwpError> {
+        // [#2755] 깊이 1 표/글상자/캡션은 flat 셀 삭제 경로가 셀 폭 리플로우와 vpos 재계산을
+        // 이미 담당한다. `insert_text_in_cell_by_path`(:3389)의 깊이 1 위임 가드와 동형이며,
+        // flat `delete_text_in_cell_native`(:955)는 모든 컨테이너 종류를 처리한다.
+        if path.len() == 1 {
+            let (control_idx, cell_idx, cell_para_idx) = path[0];
+            return self.delete_text_in_cell_native(
+                section_idx,
+                parent_para_idx,
+                control_idx,
+                cell_idx,
+                cell_para_idx,
+                char_offset,
+                count,
+            );
+        }
+
         let cell_para = self.get_cell_paragraph_mut_by_path(section_idx, parent_para_idx, path)?;
         cell_para.delete_text_at(char_offset, count);
+
+        // [#2755] 깊이 ≥ 2 중첩 셀도 flat `delete_text_in_cell_native` 처럼 최내곽 셀 폭으로
+        // 재래핑하고 vpos 를 재계산한다(깊이 1 은 위 위임 가드가 flat 경로로 처리).
+        let inner_cell_para_idx = path.last().map(|e| e.2).unwrap_or(0);
+        self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, inner_cell_para_idx);
+        self.recalculate_cell_paragraph_vpos_by_path(
+            section_idx,
+            parent_para_idx,
+            path,
+            inner_cell_para_idx,
+            None,
+        );
 
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
@@ -3541,6 +3669,12 @@ impl DocumentCore {
             }
         }
 
+        // [#2755] flat `delete_range_native` 셀 분기와 동일하게 병합 생존 문단(start_para)을
+        // 셀 폭 기준으로 재래핑한다. by_path 리플로우는 최내곽 셀 폭을 해석하므로 깊이 1·2+ 를
+        // 모두 처리하고, by_path 본문이 표/글상자/그림 캡션의 다중 문단까지 처리하는 것과도
+        // 정합한다(flat delete_range 는 vpos 재계산을 하지 않으므로 여기서도 리플로우만 한다).
+        self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, start_para);
+
         // dirty/이벤트는 delete_text_in_cell_by_path 와 동형(최외곽 컨트롤 기준).
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
@@ -3567,12 +3701,15 @@ impl DocumentCore {
         path: &[(usize, usize, usize)],
         char_offset: usize,
     ) -> Result<String, HwpError> {
-        // 마지막 path 엔트리의 cell_para_idx가 분할 대상
-        let last = path.last().unwrap();
+        // [#2755] 빈 경로는 패닉이 아니라 Err 로 거절한다. `parse_cell_path` 가 "[]" 에
+        // Ok(Vec::new()) 를 반환하므로 빈 경로가 여기 도달할 수 있고, wasm 에서 Rust 패닉은
+        // HwpDocument 인스턴스 전체를 무효화한다. get_cell_paragraph(s)_mut_by_path 형제와 동형.
+        let last = path
+            .last()
+            .ok_or_else(|| HwpError::RenderError("경로가 비어있습니다".to_string()))?;
         let cell_para_idx = last.2;
-        let styles = &self.styles;
-        let dpi = self.dpi;
-        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        // [#2755] 리플로우 후 재적용할 원본 vpos(분할 대상 문단 첫 seg).
+        let mut split_origin_vpos: Option<i32> = None;
 
         // 셀에 접근하여 문단 분할
         let section = self
@@ -3596,27 +3733,16 @@ impl DocumentCore {
                 .get_mut(cell_idx)
                 .ok_or_else(|| HwpError::RenderError("셀 범위 초과".to_string()))?;
             if i == path.len() - 1 {
-                // 이 셀에서 문단 분할
+                // 이 셀에서 문단 분할. 리플로우/shift/recalc 는 borrow 해제 후 루프 밖에서 한다.
                 if cell_para_idx >= cell.paragraphs.len() {
                     return Err(HwpError::RenderError("셀문단 범위 초과".to_string()));
                 }
-                let original_vpos = cell.paragraphs[cell_para_idx]
+                split_origin_vpos = cell.paragraphs[cell_para_idx]
                     .line_segs
                     .first()
                     .map(|seg| seg.vertical_pos);
                 let new_para = cell.paragraphs[cell_para_idx].split_at(char_offset);
                 cell.paragraphs.insert(cell_para_idx + 1, new_para);
-                if let Some(vpos) = original_vpos {
-                    shift_paragraph_vpos_origin(&mut cell.paragraphs[cell_para_idx], vpos);
-                }
-                recalculate_cell_paragraph_vpos(
-                    &mut cell.paragraphs,
-                    cell_para_idx,
-                    Some(cell_para_idx + 1),
-                    styles,
-                    dpi,
-                    is_hwp3_variant,
-                );
                 break;
             }
             para = cell
@@ -3624,6 +3750,27 @@ impl DocumentCore {
                 .get_mut(_cpi)
                 .ok_or_else(|| HwpError::RenderError("셀문단 범위 초과".to_string()))?;
         }
+
+        // [#2755] flat split 형제(:2387)와 동일하게 분할된 두 문단을 셀 폭으로 재래핑한 뒤
+        // vpos 를 재계산한다(리플로우가 line_segs 를 재작성하므로 shift/recalc 를 그 뒤에 둔다).
+        self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, cell_para_idx);
+        self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, cell_para_idx + 1);
+        if let Some(vpos) = split_origin_vpos {
+            if let Ok(paras) =
+                self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)
+            {
+                if let Some(p) = paras.get_mut(cell_para_idx) {
+                    shift_paragraph_vpos_origin(p, vpos);
+                }
+            }
+        }
+        self.recalculate_cell_paragraph_vpos_by_path(
+            section_idx,
+            parent_para_idx,
+            path,
+            cell_para_idx,
+            Some(cell_para_idx + 1),
+        );
 
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
@@ -3651,16 +3798,19 @@ impl DocumentCore {
         parent_para_idx: usize,
         path: &[(usize, usize, usize)],
     ) -> Result<String, HwpError> {
-        let last = path.last().unwrap();
+        // [#2755] 빈 경로는 패닉이 아니라 Err 로 거절한다(split_paragraph_in_cell_by_path 동형).
+        let last = path
+            .last()
+            .ok_or_else(|| HwpError::RenderError("경로가 비어있습니다".to_string()))?;
         let cell_para_idx = last.2;
         if cell_para_idx == 0 {
             return Err(HwpError::RenderError(
                 "첫 문단은 병합할 수 없습니다".to_string(),
             ));
         }
-        let styles = &self.styles;
-        let dpi = self.dpi;
-        let is_hwp3_variant = self.document.layout_profile().hwp3_layout();
+        let prev_idx = cell_para_idx - 1;
+        // [#2755] 리플로우 후 재적용할 원본 vpos(병합 생존 문단 첫 seg).
+        let mut merge_origin_vpos: Option<i32> = None;
 
         let section = self
             .document
@@ -3686,8 +3836,7 @@ impl DocumentCore {
                 if cell_para_idx >= cell.paragraphs.len() {
                     return Err(HwpError::RenderError("셀문단 범위 초과".to_string()));
                 }
-                let prev_idx = cell_para_idx - 1;
-                let original_vpos = cell.paragraphs[prev_idx]
+                merge_origin_vpos = cell.paragraphs[prev_idx]
                     .line_segs
                     .first()
                     .map(|seg| seg.vertical_pos);
@@ -3695,17 +3844,6 @@ impl DocumentCore {
                 let prev = &mut cell.paragraphs[prev_idx];
                 merge_point = prev.text.chars().count();
                 prev.merge_from(&removed);
-                if let Some(vpos) = original_vpos {
-                    shift_paragraph_vpos_origin(prev, vpos);
-                }
-                recalculate_cell_paragraph_vpos(
-                    &mut cell.paragraphs,
-                    prev_idx,
-                    None,
-                    styles,
-                    dpi,
-                    is_hwp3_variant,
-                );
                 break;
             }
             para = cell
@@ -3713,6 +3851,26 @@ impl DocumentCore {
                 .get_mut(_cpi)
                 .ok_or_else(|| HwpError::RenderError("셀문단 범위 초과".to_string()))?;
         }
+
+        // [#2755] flat merge 형제(:2486)와 동일하게 병합 생존 문단을 셀 폭으로 재래핑한 뒤
+        // vpos 를 재계산한다(리플로우가 line_segs 를 재작성하므로 shift/recalc 를 그 뒤에 둔다).
+        self.reflow_cell_paragraph_by_path(section_idx, parent_para_idx, path, prev_idx);
+        if let Some(vpos) = merge_origin_vpos {
+            if let Ok(paras) =
+                self.get_cell_paragraphs_mut_by_path(section_idx, parent_para_idx, path)
+            {
+                if let Some(p) = paras.get_mut(prev_idx) {
+                    shift_paragraph_vpos_origin(p, vpos);
+                }
+            }
+        }
+        self.recalculate_cell_paragraph_vpos_by_path(
+            section_idx,
+            parent_para_idx,
+            path,
+            prev_idx,
+            None,
+        );
 
         let outer_ctrl = path[0].0;
         self.mark_cell_control_dirty(section_idx, parent_para_idx, outer_ctrl);
@@ -3898,6 +4056,372 @@ mod tests {
             panic!("expected nested table");
         };
         assert_eq!(inner.cells[0].paragraphs[0].text, "IER");
+    }
+
+    /// [#2755] 셀 폭 200 HWPUNIT + 권위 `line_segs` 를 가진 1×1 표 문서를 만든다.
+    ///
+    /// `formatting.rs` 의 `cell_reflow_width_tests::core_with_narrow_cell` 과 동형이며,
+    /// `line_seg_starts` 로 저장된 줄 경계를 직접 지정해 "실제 `.hwp`/`.hwpx` 에서 파싱한
+    /// 셀 문단"(권위 `line_segs` 보유) 상태를 재현한다. 기존 `by_path` 테스트는
+    /// `Paragraph::default()` 를 써 `line_segs` 가 비어 있었고, 그 경우 레이아웃의
+    /// `recompose_for_cell_width` 가 폭 기준으로 재래핑해 주므로 결함이 관측되지 않았다.
+    ///
+    /// 페이지 본문 폭(수만 HWPUNIT)과 셀 폭(200 HWPUNIT)을 극단적으로 벌려, 어떤 폰트 폭
+    /// 추정치를 쓰든 "페이지 폭 사용" 과 "셀 폭 사용" 이 줄 수로 갈리게 한다.
+    fn core_with_narrow_cell_line_segs(text: &str, line_seg_starts: &[u32]) -> DocumentCore {
+        use crate::model::control::Control;
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::LineSeg;
+        use crate::model::table::{Cell, Table};
+
+        let mut doc = Document::default();
+
+        let mut cell_para = Paragraph {
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_count: text.chars().count() as u32,
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: line_seg_starts
+                .iter()
+                .map(|&text_start| LineSeg {
+                    text_start,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        cell_para.has_para_text = true;
+
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            ..Default::default()
+        };
+        table.cells = vec![Cell {
+            row: 0,
+            col: 0,
+            col_span: 1,
+            row_span: 1,
+            width: 200, // 셀 폭 — 페이지 본문 폭(수만 HWPUNIT)의 1% 미만
+            paragraphs: vec![cell_para],
+            ..Default::default()
+        }];
+
+        let mut para = Paragraph::default();
+        para.controls.push(Control::Table(Box::new(table)));
+
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        section.paragraphs.push(para);
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        core
+    }
+
+    /// 첫 셀의 첫 문단을 꺼낸다.
+    fn narrow_cell_para(core: &DocumentCore) -> &Paragraph {
+        use crate::model::control::Control;
+        let Control::Table(t) = &core.document.sections[0].paragraphs[0].controls[0] else {
+            panic!("표 컨트롤이어야 함");
+        };
+        &t.cells[0].paragraphs[0]
+    }
+
+    /// [#2755] 항목 1 — `delete_range_in_cell_by_path` 가 깊이 1 셀에서 셀 폭 리플로우를
+    /// 수행해야 한다.
+    ///
+    /// 형제 `delete_range_native` 의 셀 분기는 단일/다중 문단 양쪽에서
+    /// `reflow_cell_paragraph` 를 호출한다. 리플로우가 없으면 저장된 줄 경계가 그대로 남아
+    /// 셀이 계속 2줄로 조판되고(둘째 줄은 빈 줄) 행 높이도 줄지 않는다.
+    #[test]
+    fn delete_range_in_cell_by_path_reflows_depth1_cell_line_segs() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell_line_segs(&text, &[0, 20]);
+
+        // 40자 중 39자를 지운다 — 남는 텍스트는 1자다.
+        core.delete_range_in_cell_by_path(0, 0, &[(0, 0, 0)], 0, 0, 0, 39)
+            .expect("범위 삭제가 성공해야 함");
+
+        let para = narrow_cell_para(&core);
+        assert_eq!(para.text.chars().count(), 1, "39자가 삭제돼야 함");
+        let line_count = para.line_segs.len();
+        assert_eq!(
+            line_count, 1,
+            "1자만 남았으므로 셀 폭 리플로우 후 1줄이어야 함 (실제 {line_count}줄 — \
+             리플로우가 없으면 저장된 2줄 경계가 그대로 남는다)"
+        );
+    }
+
+    /// [#2755] 항목 3 — `delete_text_in_cell_by_path` 도 같은 계약을 지켜야 한다.
+    ///
+    /// 삽입 쌍둥이 `insert_text_in_cell_by_path` 는 #2172 에서 깊이 1 위임 가드를 받았고,
+    /// flat `delete_text_in_cell_native` 는 리플로우와 vpos 재계산을 모두 수행한다.
+    #[test]
+    fn delete_text_in_cell_by_path_reflows_depth1_cell_line_segs() {
+        let text = "A".repeat(40);
+        let mut core = core_with_narrow_cell_line_segs(&text, &[0, 20]);
+
+        core.delete_text_in_cell_by_path(0, 0, &[(0, 0, 0)], 0, 39)
+            .expect("텍스트 삭제가 성공해야 함");
+
+        let para = narrow_cell_para(&core);
+        assert_eq!(para.text.chars().count(), 1, "39자가 삭제돼야 함");
+        let line_count = para.line_segs.len();
+        assert_eq!(
+            line_count, 1,
+            "1자만 남았으므로 셀 폭 리플로우 후 1줄이어야 함 (실제 {line_count}줄)"
+        );
+    }
+
+    /// [#2755] 항목 4 — 빈 `cellPath` 는 패닉이 아니라 `Err` 여야 한다.
+    ///
+    /// `parse_cell_path` 는 `"[]"` 에 대해 `Ok(Vec::new())` 를 반환하므로 빈 경로가 코어까지
+    /// 도달할 수 있다. wasm 에서 Rust 패닉은 `HwpDocument` 인스턴스 전체를 무효화한다.
+    /// 형제 `get_cell_paragraphs_mut_by_path` / `get_cell_paragraph_mut_by_path` 는 이미
+    /// 빈 경로를 `Err` 로 거절한다.
+    #[test]
+    fn cell_paragraph_ops_by_path_reject_empty_path_with_error() {
+        let mut core = core_with_narrow_cell_line_segs("AB", &[0]);
+
+        assert!(
+            core.split_paragraph_in_cell_by_path(0, 0, &[], 1).is_err(),
+            "빈 경로 분할은 Err 여야 한다"
+        );
+        assert!(
+            core.merge_paragraph_in_cell_by_path(0, 0, &[]).is_err(),
+            "빈 경로 병합은 Err 여야 한다"
+        );
+    }
+
+    /// [#2755] 깊이 2 중첩 표: 바깥 표(1셀, 폭 5000) 문단 안에 안쪽 표(1셀, 폭 200 + 권위
+    /// line_segs)를 두고, path = [(outer,0,0),(inner,0,0)] 를 함께 돌려준다.
+    ///
+    /// 깊이 ≥ 2 에서 `reflow_cell_paragraph`(flat 좌표)로는 최내곽 셀을 재래핑할 수 없었다.
+    /// `reflow_cell_paragraph_by_path` 가 최내곽 셀 폭(200)을 해석해 재래핑하는지 검증한다.
+    fn core_with_nested_narrow_cell(
+        text: &str,
+        line_seg_starts: &[u32],
+    ) -> (DocumentCore, Vec<(usize, usize, usize)>) {
+        use crate::model::control::Control;
+        use crate::model::document::{Document, Section, SectionDef};
+        use crate::model::page::PageDef;
+        use crate::model::paragraph::LineSeg;
+        use crate::model::table::{Cell, Table};
+
+        let mut inner_para = Paragraph {
+            text: text.to_string(),
+            char_offsets: (0..text.chars().count() as u32).collect(),
+            char_count: text.chars().count() as u32,
+            char_shapes: vec![CharShapeRef {
+                start_pos: 0,
+                char_shape_id: 0,
+            }],
+            line_segs: line_seg_starts
+                .iter()
+                .map(|&text_start| LineSeg {
+                    text_start,
+                    ..Default::default()
+                })
+                .collect(),
+            ..Default::default()
+        };
+        inner_para.has_para_text = true;
+
+        let inner_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 200, // 최내곽 셀 폭
+                paragraphs: vec![inner_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut outer_cell_para = Paragraph::default();
+        outer_cell_para
+            .controls
+            .push(Control::Table(Box::new(inner_table)));
+        let inner_ctrl_idx = outer_cell_para.controls.len() - 1;
+
+        let outer_table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                row: 0,
+                col: 0,
+                col_span: 1,
+                row_span: 1,
+                width: 5000, // 바깥 셀은 넉넉히 — 안쪽 셀 폭이 실제 리플로우 기준임을 분리
+                paragraphs: vec![outer_cell_para],
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+
+        let mut body_para = Paragraph::default();
+        body_para
+            .controls
+            .push(Control::Table(Box::new(outer_table)));
+        let outer_ctrl_idx = body_para.controls.len() - 1;
+
+        let mut section = Section {
+            section_def: SectionDef {
+                page_def: PageDef {
+                    width: 59528,
+                    height: 84188,
+                    margin_left: 8504,
+                    margin_right: 8504,
+                    margin_top: 5668,
+                    margin_bottom: 4252,
+                    margin_header: 4252,
+                    margin_footer: 4252,
+                    ..Default::default()
+                },
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        section.paragraphs.push(body_para);
+        let mut doc = Document::default();
+        doc.sections.push(section);
+
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+        core.composed = vec![Vec::new()];
+        core.dirty_sections = vec![true];
+        core.dirty_paragraphs = vec![None];
+        let path = vec![(outer_ctrl_idx, 0, 0), (inner_ctrl_idx, 0, 0)];
+        (core, path)
+    }
+
+    /// [#2755] 깊이 2 — `delete_range_in_cell_by_path` 가 최내곽 셀을 재래핑한다.
+    #[test]
+    fn delete_range_in_nested_cell_by_path_reflows_inner_cell() {
+        let text = "A".repeat(40);
+        let (mut core, path) = core_with_nested_narrow_cell(&text, &[0, 20]);
+
+        core.delete_range_in_cell_by_path(0, 0, &path, 0, 0, 0, 39)
+            .expect("범위 삭제가 성공해야 함");
+
+        let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+        assert_eq!(paras[0].text.chars().count(), 1, "39자가 삭제돼야 함");
+        assert_eq!(
+            paras[0].line_segs.len(),
+            1,
+            "깊이 2 안쪽 셀도 1자만 남으면 1줄로 재래핑돼야 함"
+        );
+    }
+
+    /// [#2755] 깊이 2 — `delete_text_in_cell_by_path` 가 최내곽 셀을 재래핑한다.
+    #[test]
+    fn delete_text_in_nested_cell_by_path_reflows_inner_cell() {
+        let text = "A".repeat(40);
+        let (mut core, path) = core_with_nested_narrow_cell(&text, &[0, 20]);
+
+        core.delete_text_in_cell_by_path(0, 0, &path, 0, 39)
+            .expect("텍스트 삭제가 성공해야 함");
+
+        let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+        assert_eq!(paras[0].text.chars().count(), 1, "39자가 삭제돼야 함");
+        assert_eq!(
+            paras[0].line_segs.len(),
+            1,
+            "깊이 2 안쪽 셀도 재래핑돼야 함"
+        );
+    }
+
+    /// [#2755] 깊이 2 — `split_paragraph_in_cell_by_path` 가 분할된 두 문단을 재래핑한다.
+    #[test]
+    fn split_paragraph_in_nested_cell_by_path_reflows_inner_cell() {
+        let text = "A".repeat(40);
+        let (mut core, path) = core_with_nested_narrow_cell(&text, &[0, 20]);
+
+        // 20 지점에서 분할 → 앞뒤 각각 20자. 폭 200 재래핑이면 각 문단이 여러 줄로 나뉜다.
+        core.split_paragraph_in_cell_by_path(0, 0, &path, 20)
+            .expect("문단 분할이 성공해야 함");
+
+        let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+        assert_eq!(paras.len(), 2, "안쪽 셀 문단이 2개로 분할돼야 함");
+        assert!(
+            paras[0].line_segs.len() > 1,
+            "앞 문단(20자)이 좁은 셀 폭으로 재래핑되면 여러 줄이어야 함 (실제 {}줄 — \
+             재래핑이 없으면 split_at 이 남긴 1줄)",
+            paras[0].line_segs.len()
+        );
+        assert!(
+            paras[1].line_segs.len() > 1,
+            "뒤 문단(20자)도 재래핑돼야 함 (실제 {}줄)",
+            paras[1].line_segs.len()
+        );
+    }
+
+    /// [#2755] 깊이 2 — `merge_paragraph_in_cell_by_path` 가 병합 생존 문단을 재래핑한다.
+    #[test]
+    fn merge_paragraph_in_nested_cell_by_path_reflows_inner_cell() {
+        // 안쪽 셀에 짧은 문단 2개를 두고 병합하면 40자가 합쳐져 좁은 폭에서 여러 줄이 된다.
+        let (mut core, path) = core_with_nested_narrow_cell(&"A".repeat(20), &[0]);
+        {
+            let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+            let mut second = Paragraph {
+                text: "B".repeat(20),
+                char_offsets: (0..20).collect(),
+                char_count: 20,
+                char_shapes: vec![CharShapeRef {
+                    start_pos: 0,
+                    char_shape_id: 0,
+                }],
+                line_segs: vec![crate::model::paragraph::LineSeg {
+                    text_start: 0,
+                    ..Default::default()
+                }],
+                ..Default::default()
+            };
+            second.has_para_text = true;
+            paras.push(second);
+        }
+
+        // 두 번째 문단(index 1)을 첫 번째에 병합.
+        let merge_path = vec![path[0], (path[1].0, path[1].1, 1)];
+        core.merge_paragraph_in_cell_by_path(0, 0, &merge_path)
+            .expect("문단 병합이 성공해야 함");
+
+        let paras = core.get_cell_paragraphs_mut_by_path(0, 0, &path).unwrap();
+        assert_eq!(paras.len(), 1, "병합 후 문단은 1개여야 함");
+        assert_eq!(paras[0].text.chars().count(), 40, "40자가 합쳐져야 함");
+        assert!(
+            paras[0].line_segs.len() > 1,
+            "병합 문단(40자)이 좁은 셀 폭으로 재래핑되면 여러 줄이어야 함 (실제 {}줄)",
+            paras[0].line_segs.len()
+        );
     }
 
     #[test]

--- a/src/parser/hwp3/johab.rs
+++ b/src/parser/hwp3/johab.rs
@@ -110,7 +110,8 @@ mod tests {
         // jong_idx=0 은 종성 매핑에서 -1(무효)이며, "받침 없음"은 jong_idx=1 이
         // 별도로 나타낸다. 무효 jong_idx 를 받침 없음으로 오인하면 존재하지
         // 않아야 할 완성형 음절 '가'(U+AC00)가 잘못 생성된다.
-        let ch: u16 = 0x8000 | (2 << 10) | (3 << 5) | 0;
+        let jong_idx = 0;
+        let ch: u16 = 0x8000 | (2 << 10) | (3 << 5) | jong_idx;
         assert_ne!(decode_johab(ch), '가');
     }
 }

--- a/src/serializer/byte_writer.rs
+++ b/src/serializer/byte_writer.rs
@@ -209,9 +209,7 @@ mod tests {
     fn test_write_hwp_string_overlong_truncates_instead_of_wrapping() {
         // u16::MAX(65535) 초과 길이 문자열을 그대로 쓰면 `as u16` 캐스팅이 wraparound 되어
         // 기록된 길이 필드와 실제 바이트열이 어긋난 손상 레코드가 생긴다.
-        let s: String = std::iter::repeat('A')
-            .take(u16::MAX as usize + 10)
-            .collect();
+        let s: String = "A".repeat(u16::MAX as usize + 10);
         let mut w = ByteWriter::new();
         w.write_hwp_string(&s).unwrap();
         let bytes = w.into_bytes();

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2379,6 +2379,54 @@ fn test_merge_table_cells_clears_stale_local_resize_widths() {
     }
 }
 
+/// [delete_row stale local-resize] 행 삭제로 셀 배열 인덱스가 바뀌면
+/// local_resize_cell_heights의 cell 인덱스 참조가 stale 해진다.
+///
+/// 3×2 표(row 0,1,2 × col 0,1)에서 셀 인덱스 2(row=1,col=0)에 로컬 resize 높이를
+/// 저장해 둔 뒤 row 0을 삭제하면 Table::delete_row()가 row 0의 셀 2개를 retain()으로
+/// 제거해 cells.len()이 6→4로 줄고, 남은 셀을 sort_by_key(row, col)로 재정렬한다.
+/// local_resize_cell_heights가 갱신되지 않으면 이제 존재하지 않거나(범위 초과) 엉뚱한
+/// 셀을 가리키는 stale 참조가 남아, 이 값을 cells[idx]로 읽는 렌더링/직렬화 경로가
+/// 패닉하거나 삭제 후 남은 엉뚱한 셀에 잘못된 로컬 resize 높이를 적용하게 된다.
+#[test]
+fn test_delete_table_row_clears_stale_local_resize_heights() {
+    let mut doc = HwpDocument::create_empty();
+    let table_result = doc.create_table_native(0, 0, 0, 3, 2).expect("3x2 표 생성");
+    let table_para_idx = issue_1481_json_usize(&table_result, "paraIdx");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first_mut()
+    {
+        // 삭제 전: 셀 인덱스 2(row=1,col=0)에 로컬 resize 높이 저장.
+        table.local_resize_cell_heights.push((2, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    // row 0 삭제 — 셀 2개 제거, cells.len() 6→4.
+    doc.delete_table_row_native(0, table_para_idx, 0, 0)
+        .expect("행 삭제");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first()
+    {
+        assert_eq!(
+            table.cells.len(),
+            4,
+            "행 삭제로 셀 2개가 제거돼야 함(전제 확인)"
+        );
+        assert!(
+            table.local_resize_cell_heights.is_empty(),
+            "행 삭제 후 셀 인덱스가 재배치되므로 local_resize_cell_heights의 stale 참조(인덱스 2)가 \
+             비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_split_table_cell() {
     let mut doc = create_doc_with_table();

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2427,6 +2427,73 @@ fn test_delete_table_row_clears_stale_local_resize_heights() {
     }
 }
 
+/// [insert_row/insert_column stale local-resize] 행/열 삽입으로 셀 배열 인덱스가
+/// 바뀌면 local_resize_cell_widths/heights의 cell 인덱스 참조가 stale 해진다.
+///
+/// Table::insert_row()/insert_column()은 새 셀을 push()한 뒤 sort_by_key(row, col)로
+/// 전체 셀 배열을 재정렬한다(delete_row가 retain()+정렬로 stale을 만드는 것과 같은
+/// 근본 원인). 3×2 표에서 셀 인덱스 2에 로컬 resize 값을 저장해 둔 뒤 행을 삽입하면
+/// 재정렬로 인덱스 2가 더 이상 같은 셀을 가리키지 않으므로, 이 값을 cells[idx]로
+/// 읽는 렌더링/직렬화 경로가 엉뚱한 셀에 잘못된 로컬 resize 값을 적용하게 된다.
+/// 열 삽입도 동일 원인으로 같은 결과를 낳는다.
+#[test]
+fn test_insert_table_row_and_column_clear_stale_local_resize() {
+    let mut doc = HwpDocument::create_empty();
+    let table_result = doc.create_table_native(0, 0, 0, 3, 2).expect("3x2 표 생성");
+    let table_para_idx = issue_1481_json_usize(&table_result, "paraIdx");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first_mut()
+    {
+        table.local_resize_cell_widths.push((2, 1234));
+        table.local_resize_cell_heights.push((2, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    doc.insert_table_row_native(0, table_para_idx, 0, 0, true)
+        .expect("행 삽입");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first()
+    {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "행 삽입 후 셀 인덱스가 재배치되므로 local_resize_cell_widths/heights의 \
+             stale 참조(인덱스 2)가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first_mut()
+    {
+        table.local_resize_cell_widths.push((2, 1234));
+        table.local_resize_cell_heights.push((2, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    doc.insert_table_column_native(0, table_para_idx, 0, 0, true)
+        .expect("열 삽입");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[table_para_idx]
+        .controls
+        .first()
+    {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "열 삽입 후에도 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_split_table_cell() {
     let mut doc = create_doc_with_table();


### PR DESCRIPTION
kevin9327 님의 오늘 범위(#2762~#3030) 배치 B — 문서 코어 편집 명령 축 6건을 메인테이너가 재실증 후 통합한다. 배치 A는 #3197 로 merge 되었다.

## 채택 6건

| PR | 결함 |
|---|---|
| #2821 (`Closes #2755`) | 표 셀 by_path 편집 경로에 셀 폭 리플로우 누락 — 직접 인덱스 경로만 리플로우되고 중첩 셀 경로는 폭이 낡은 채 남음 |
| #2829 (`Closes #2825`) | 중첩 표 최내곽 셀 붙여넣기(cellPath)에서 재래핑 누락 |
| #2849 (`Closes #2843`) | delete_row 후 local_resize_cell_widths/heights 의 stale 셀 인덱스 잔존 — cells[idx] 판독 경로가 범위 초과·오적용 |
| #2859 (`Closes #2853`) | insert_row/insert_column 후 동일 stale (push+sort_by_key 재정렬이 같은 근본 원인) |
| #2910 | group_shapes_native 가 삽입 지점 이전 char_offsets 까지 무조건 +8 시프트 |
| #2923 (`Closes #2912`) | ungroup_shape_native 가 net_delta 를 전체 char_offsets 에 무조건 가산 — 언그룹 지점 이전 텍스트 오프셋까지 밀림 |

## 충돌 해소

3건(#2849 #2859 #2923)이 충돌했으나 전부 **테스트 병치 유형** — 형제 PR들이 같은 테스트 블록 자리를 두고 겹친 것으로, 각 테스트를 완전한 함수로 복원해 모두 유지했다. 소스 로직 충돌은 없었다.

## 부수 수정

- 어제 #3083 으로 devel 에 유입된 clippy 경고 2건(johab 테스트의 no-op `| 0`, byte_writer 테스트의 manual str::repeat) 정리 커밋 1건.

## 검증

- `cargo fmt --check` 통과, `clippy --all-targets` 경고 0, **전체 `--tests` 스위트 무실패**
- 6건 반영을 패치ID 대조 + 내용 diff 로 개별 확인 (#2923 은 충돌 해소로 패치ID 가 달라져 소스 수정·테스트 존재를 diff 로 직접 확인)
- 신규 회귀 테스트 5건 표적 통과

Co-authored-by 로 원 커밋 provenance 를 보존한다.
