### PR TITLE
fix(studio): 누름틀 길이 가드·중첩 표 cellPath·다이얼로그 동기화 4건 — kevin9327 범위연작 배치 C

### DIFF
--- a/mydocs/report/task_m100_2878_report.md
+++ b/mydocs/report/task_m100_2878_report.md
@@ -1,0 +1,55 @@
+# Task #m100-2878 처리 결과 보고
+
+## 이슈
+
+#2878 — 누름틀(ClickHere) 안내문(guide)/메모(memo) 입력 길이 미검증 → CTRL_DATA(command) `u16` 캐스팅
+랩어라운드로 저장 파일 손상. #2851(필드 이름)/#2862(책갈피 이름)/#2866(스타일 이름)와 동일 근본 원인의
+형제 필드 재발 인스턴스.
+
+## 스윕 경과
+
+`rhwp-studio/src/ui/*.ts`, `rhwp-studio/src/engine/*.ts` 전수 조사(`<input>`/`<textarea>`/`prompt()` →
+`wasm.*` 경로) 결과, 남은 후보 다수는 SAFE로 확인됨(폰트셋 이름·검색/바꾸기·히스토리 라벨 등은 wasm/직렬화기에
+도달하지 않거나 u32/텍스트 경로를 씀). 다음 두 후보는 같은 `write_hwp_string`(`src/serializer/byte_writer.rs:70-76`,
+`utf16.len() as u16`) 싱크로 향하는 **잠재 취약 소견**으로 확인했으나, 이번 작업 스코프에서는 제외하고 별도 이슈로
+분리할 것을 권고함:
+
+- 개체 설명문(`rhwp-studio/src/ui/picture-props-dialog.ts` `descInput`) → `src/serializer/control.rs:1905`
+- 수식 스크립트(`rhwp-studio/src/ui/equation-editor-dialog.ts`, `equation-props-dialog.ts` `scriptArea`) → `src/serializer/control.rs:2386`
+
+guide/memo는 즉시 조치 가능한 명확한 인스턴스로 판단해 이번 작업에서 수정함.
+
+## 근본 원인
+
+`rhwp-studio/src/ui/field-edit-dialog.ts`/`field-insert-dialog.ts`의 `guideInput`/`memoInput`이 길이
+제한 없이 `wasm.updateClickHereProps`/`wasm.insertClickHereField`로 전달되고, `src/serializer/control.rs`의
+누름틀 CTRL_DATA 직렬화가 guide/memo를 포함한 `f.command` 전체 UTF-16 길이를 `cmd_len as u16`으로 기록한다.
+합산 길이가 65536 코드 유닛 이상이면 랩어라운드되어 손상된 레코드가 생성된다. `name` 필드는 #2851에서
+`MAX_FIELD_NAME_LEN(250)` 가드가 추가되었으나 `guide`/`memo`는 미가드 상태였다.
+
+## 수정 (TypeScript만, `.rs` 미변경)
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`: `MAX_FIELD_GUIDE_LEN(250)`, `MAX_FIELD_MEMO_LEN(1000)` 상수
+  추가. `guideInput`/`memoInput`에 `maxLength` 속성과 에러 라벨을 추가하고, `onConfirm()`에서 길이 검증 실패
+  시 `false`를 반환해 다이얼로그가 닫히지 않도록(적용을 막도록) 변경.
+- `rhwp-studio/src/ui/field-insert-dialog.ts`: 동일 상수를 `field-edit-dialog.ts`에서 import해 동일 가드
+  적용.
+
+## 검증(적색→녹색)
+
+- 적색: 수정 전 `guideInput`/`memoInput`에 `maxLength`/길이 검증이 전혀 없었음(코드 확인).
+- 신규 소스 가드 테스트: `rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts`
+  — `MAX_FIELD_GUIDE_LEN`/`MAX_FIELD_MEMO_LEN` 상수가 존재하고 합산 한도가 u16 랩어라운드 지점(65536)보다
+  충분히 작은지 검증. 수정 후 통과.
+- `cd rhwp-studio && npm test`: 500개 중 499 통과, 1건(`tests/cell-flow-boundary.test.ts`) 실패 — 이 실패는
+  wasm 빌드 산출물 부재로 인한 기존(베이스라인) 실패이며 `field-edit-dialog.ts`/`field-insert-dialog.ts`를
+  참조하지 않음(grep 확인, 무관 확인).
+- `npx tsc --noEmit`: `@wasm/rhwp.js` 모듈을 찾을 수 없다는 기존(베이스라인) 오류만 있음(wasm 빌드 산출물
+  부재), 이번 변경으로 인한 신규 타입 오류 없음.
+
+## 변경 파일
+
+- `rhwp-studio/src/ui/field-edit-dialog.ts`
+- `rhwp-studio/src/ui/field-insert-dialog.ts`
+- `rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts` (신규)
+- `mydocs/report/task_m100_2878_report.md` (본 보고서)

--- a/mydocs/report/task_m100_2880_report.md
+++ b/mydocs/report/task_m100_2880_report.md
@@ -1,0 +1,50 @@
+# Task #2880 처리 결과 — 표 객체 선택 Ctrl+C/Ctrl+X cellPath 누락 수정
+
+## 이슈
+
+- GitHub Issue: [#2880](https://github.com/edwardkim/rhwp/issues/2880)
+- 대상 파일(단독 작업 영역): `rhwp-studio/src/engine/input-handler-keyboard.ts`
+
+## 문제
+
+`onKeyDown`의 표 객체 선택 모드(`isInTableObjectSelection`) Ctrl+C/Ctrl+X 핸들러가
+`wasm.copyControl(ref.sec, ref.ppi, ref.ci)` / `wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci)`를
+`cellPathJson` 없이 호출했다. 같은 파일의 그림/글상자 객체 선택 모드 Ctrl+C/Ctrl+X 핸들러(및
+`onCopy`)는 `pictureCellPathJson(ref)`로 계산한 `cellPathJson`을 반드시 함께 넘긴다 — 형제
+핸들러 간 비대칭. `getSelectedTableRef()`가 반환하는 `ref.cellPath`(`CellPathEntry[]`)는 같은
+블록 안에서 중첩 깊이 판정(`ref.cellPath.length > 1`)에는 쓰이고 있었지만 정작 copy/cut
+호출에는 전달되지 않아, 셀 안에 중첩된 표를 복사·잘라내기 하면 native 가 본문 레벨 표로
+오인해 엉뚱한 표를 클립보드에 담거나 조용히 실패했다.
+
+## 수정
+
+- `rhwp-studio/src/engine/input-handler-keyboard.ts` 표 Ctrl+C(867~890행 부근), Ctrl+X(891~919행
+  부근) 블록에서 `pictureCellPathJson(ref)`로 `cellPathJson`을 계산해 `copyControl`/
+  `exportControlHtml` 호출에 전달하도록 수정. 그림 개체 핸들러와 동일한 패턴.
+- `deleteTableControl`은 시그니처상 `cellPathJson`을 받지 않아(별도 이슈 소지) 이번 수정
+  범위에서는 제외 — 기존 가드(`ref.cellPath.length > 1`)로 중첩 표 삭제는 계속 차단됨.
+
+## 테스트
+
+- `rhwp-studio/tests/table-object-copy-cellpath.test.ts` 신규 추가 (source-guard, 최소 1개).
+  - 표 Ctrl+C/Ctrl+X 블록 소스에서 `const cellPathJson = pictureCellPathJson(ref);`,
+    `copyControl(..., cellPathJson)`, `exportControlHtml(..., cellPathJson)` 패턴을 확인.
+  - Red: 수정 전(origin/devel 버전) 소스로 교체해 실행 → 실패 확인
+    (`AssertionError: 표 Ctrl+C 핸들러가 ref.cellPath 를 cellPathJson 으로 계산하지 않음`).
+  - Green: 수정본으로 복원 후 실행 → 통과.
+
+## 검증
+
+```
+cd rhwp-studio
+npm ci          # node_modules 부재 상태였어서 선행 필요
+npm test        # 500 tests, 499 pass, 1 fail (cell-flow-boundary.test.ts — 기존 실패, 허용 범위)
+npx tsc --noEmit  # TS2307 2건(@wasm/rhwp.js, 기존 baseline) — 신규 오류 0건
+```
+
+## 커밋/PR
+
+- 브랜치: `task/m100-2880-table-copy-cellpath` (origin/devel 기준)
+- 변경 파일: `rhwp-studio/src/engine/input-handler-keyboard.ts`,
+  `rhwp-studio/tests/table-object-copy-cellpath.test.ts`,
+  `mydocs/report/task_m100_2880_report.md`

--- a/mydocs/report/task_m100_2941_report.md
+++ b/mydocs/report/task_m100_2941_report.md
@@ -1,0 +1,68 @@
+# 완료 보고서 — Task M100-2941
+
+- 이슈: #2941
+- 제목: [rhwp-studio] 표/셀 속성 다이얼로그 배경 탭 무늬색·무늬모양 populate 동기화 결함
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2938b-bg-pattern-sync`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/table-cell-props-dialog.ts`의 `populateBgFromTarget()`에서 배경 무늬색
+(`bgPatternColorPicker`)과 무늬모양(`bgPatternTypeSelect`)이 모델 값이 없을 때 이전에 열려
+있던 다른 셀/표의 값을 그대로 유지하던 populate 동기화 결함을 수정했다.
+
+## 2. 원인
+
+```ts
+if (props.patternColor) this.bgPatternColorPicker.value = props.patternColor;
+if (props.patternType != null) this.bgPatternTypeSelect.value = String(props.patternType);
+```
+
+두 줄 모두 값이 있을 때만 UI를 갱신하는 조건부 대입이었다. `fillColor`는 매번 무조건
+갱신되는 반면, `patternColor`/`patternType`이 없는 셀(단색 채우기만 있고 무늬는 없는 셀)을
+열면 두 컨트롤은 직전에 열었던 다른 셀·표의 값을 그대로 유지했다. 이는 이미 수정된
+표/셀 속성 다이얼로그 테두리 탭 select 동기화 결함(#2908 → PR #2913), 문단모양 다이얼로그
+테두리 탭 select 동기화 결함(#2915 → PR #2921), 문자모양 다이얼로그 외곽선/그림자 토글
+populate 동기화 결함(#2928 → PR #2933)과 동일한 클래스의 버그다.
+
+`onConfirm()`은 `bgColorRadio.checked`일 때 `bgPatternTypeSelect.value`를 그대로 읽어
+`newCellProps.patternType`에 저장하므로(1376번째 줄 부근), 사용자가 아무 것도 건드리지
+않고 확인만 눌러도 스테일 무늬 값이 모델에 잘못 저장될 수 있었다. 미리보기
+(`updateBgPreview()`)도 같은 스테일 값을 사용해 잘못된 무늬를 보여줬다.
+
+## 3. 주요 변경
+
+- `rhwp-studio/src/ui/table-cell-props-dialog.ts`
+  - `populateBgFromTarget()`에서 무늬색/무늬모양 대입을 조건부(`if`)에서 널 병합
+    연산자(`??`) 기반 무조건 대입으로 변경. 모델에 값이 없으면 각각 `'#000000'`,
+    `'0'`(없음)으로 명시적 리셋한다.
+
+```diff
+-      this.bgColorRadio.checked = true;
+-      this.bgColorPicker.value = props.fillColor;
+-      if (props.patternColor) this.bgPatternColorPicker.value = props.patternColor;
+-      if (props.patternType != null) this.bgPatternTypeSelect.value = String(props.patternType);
++      this.bgColorRadio.checked = true;
++      this.bgColorPicker.value = props.fillColor;
++      this.bgPatternColorPicker.value = props.patternColor ?? '#000000';
++      this.bgPatternTypeSelect.value = props.patternType != null ? String(props.patternType) : '0';
+```
+
+diff 4줄 변경.
+
+## 4. 검증 결과
+
+TS 전용 변경이며 로직이 단순(대입 조건 제거)하므로 별도 빌드 없이 수동 코드 리뷰로 검증했다.
+
+- `props.patternColor`가 `undefined`인 경로: 이전에는 대입을 건너뛰어 스테일 값 유지 →
+  수정 후 `'#000000'`으로 명시적 리셋됨을 코드상 확인.
+- `props.patternType`이 `null`/`undefined`인 경로: 이전에는 대입을 건너뛰어 스테일 값 유지 →
+  수정 후 `'0'`(없음)으로 명시적 리셋됨을 코드상 확인.
+- 값이 정상적으로 있는 경로(`patternColor`/`patternType` 둘 다 존재)는 이전과 동일하게
+  모델 값을 그대로 대입하므로 회귀 없음을 확인.
+- 같은 파일의 다른 필드(`cellFieldNameInput.value = cp.fieldName ?? ''`, 1263번째 줄)가
+  이미 동일한 `??` 패턴을 사용하고 있어 코드베이스 관례와 일치함을 확인.
+
+## 5. 남은 이슈
+
+없음. 이번 수정 범위 밖에서 발견된 별도 결함은 없다.

--- a/mydocs/report/task_m100_2946_report.md
+++ b/mydocs/report/task_m100_2946_report.md
@@ -1,0 +1,42 @@
+# task/m100-2946 처리 결과 보고
+
+## 관련 이슈
+
+- https://github.com/edwardkim/rhwp/issues/2946
+
+## 문제 요약
+
+`rhwp-studio/src/ui/page-border-dialog.ts`의 쪽 테두리/배경 다이얼로그에서 굵기(`lineWidthSelect`)
+`<select>`가 옵션 9개(코드 0~8, 0.1mm~0.6mm)만 제공했습니다. 형제 다이얼로그인
+`endnote-shape-dialog.ts`는 동일한 목적의 select에서 코드 0~15(0.1mm~5mm), 총 16개 옵션을
+제공하며, 이것이 HWPX/HWP5 테두리 굵기 값의 실제 범위와 일치하는 참조 구현입니다.
+
+`populate()`가 문서에서 읽은 굵기 코드값을 `this.lineWidthSelect.value = String(firstBorder.width || 0)`로
+할당하는데, 값이 9 이상이면 대응하는 `<option>`이 없어 할당이 무시되고 브라우저 기본 동작에 따라
+select는 첫 번째 옵션(코드 0, 0.1mm)을 가리키게 됩니다. 이어서 `onConfirm()` → `currentBorder()`가
+select의 현재 값을 그대로 읽어 저장하므로, 사용자가 굵기 필드를 전혀 조작하지 않고 다이얼로그를
+열었다가 그대로 확인만 눌러도 0.7mm~5mm 범위의 원본 테두리 굵기가 조용히 0.1mm로 손실됩니다.
+
+## 수정 내용
+
+`buildLineWidthSelect()`의 옵션 라벨 배열에 코드 9~15에 해당하는 `0.7mm`, `1mm`, `1.5mm`, `2mm`,
+`3mm`, `4mm`, `5mm`를 추가해 총 16개 옵션으로 확장했습니다. 라벨 텍스트는
+`endnote-shape-dialog.ts`의 `LINE_WIDTH_OPTIONS` 라벨 형식과 동일하게 맞췄습니다.
+
+- 변경 파일: `rhwp-studio/src/ui/page-border-dialog.ts` (1개 파일, 옵션 배열 확장 4줄 순증)
+
+## 검증
+
+- 별도 빌드 없이 TS 코드 리뷰로 검증: `buildLineWidthSelect()`가 생성하는 옵션의 `value`가
+  이제 `"0"`~`"15"`까지 연속적으로 존재함을 확인했습니다.
+- `populate()`의 `this.lineWidthSelect.value = String(firstBorder.width || 0)` 할당이 굵기 코드
+  0~15 전 범위에서 대응하는 `<option>`을 찾도록 옵션 목록과 코드값이 1:1로 일치함을 확인했습니다.
+- `onConfirm()` → `currentBorder()`가 `parseInt(this.lineWidthSelect.value, 10)`으로 굵기를 다시
+  읽어 저장하는 경로도 동일한 옵션 목록을 사용하므로 왕복(round-trip) 시 굵기 손실이 없음을
+  코드상으로 확인했습니다.
+- 이 다이얼로그의 옵션 목록을 검증하는 기존 테스트 하네스가 없어 별도 테스트는 추가하지
+  않았습니다.
+
+## 남은 이슈
+
+없음. 단일 파일의 옵션 목록 확장만으로 해결되며 IR/파서 변경은 필요하지 않습니다.

--- a/rhwp-studio/src/engine/input-handler-keyboard.ts
+++ b/rhwp-studio/src/engine/input-handler-keyboard.ts
@@ -870,11 +870,15 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const ref = this.cursor.getSelectedTableRef();
       if (ref) {
         try {
-          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci);
+          // [Task #2880] 중첩 표(셀 안 표) 선택 시 cellPath 를 native 에 전달하지 않으면
+          // copyControl/exportControlHtml 이 본문 표로 오인해 엉뚱한 표를 복사한다.
+          // 그림 개체 Ctrl+C(위 pictureCellPathJson 사용부) 와 동일하게 cellPathJson 전달.
+          const cellPathJson = pictureCellPathJson(ref);
+          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci, cellPathJson);
           const text = this.wasm.getClipboardText();
           if (text) {
             let html = '';
-            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci) || ''; } catch { /* 무시 */ }
+            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci, cellPathJson) || ''; } catch { /* 무시 */ }
             const markedHtml = prepareRhwpInternalClipboardHtml(this, html, text);
             writeTextHtmlToClipboard(text, markedHtml)
               .catch(() => navigator.clipboard.writeText(text).catch(() => {}));
@@ -891,11 +895,13 @@ export function onKeyDown(this: any, e: KeyboardEvent): void {
       const ref = this.cursor.getSelectedTableRef();
       if (ref && !(ref.cellPath && ref.cellPath.length > 1)) {
         try {
-          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci);
+          // [Task #2880] Ctrl+C 사이드와 동일하게 cellPath 를 copyControl/exportControlHtml 에 전달.
+          const cellPathJson = pictureCellPathJson(ref);
+          this.wasm.copyControl(ref.sec, ref.ppi, ref.ci, cellPathJson);
           const text = this.wasm.getClipboardText();
           if (text) {
             let html = '';
-            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci) || ''; } catch { /* 무시 */ }
+            try { html = this.wasm.exportControlHtml(ref.sec, ref.ppi, ref.ci, cellPathJson) || ''; } catch { /* 무시 */ }
             const markedHtml = prepareRhwpInternalClipboardHtml(this, html, text);
             writeTextHtmlToClipboard(text, markedHtml)
               .catch(() => navigator.clipboard.writeText(text).catch(() => {}));

--- a/rhwp-studio/src/ui/field-edit-dialog.ts
+++ b/rhwp-studio/src/ui/field-edit-dialog.ts
@@ -23,12 +23,29 @@ export interface ClickHereProps {
  */
 export const MAX_FIELD_NAME_LEN = 250;
 
+/**
+ * 안내문(guide)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 누름틀 CTRL_DATA 레코드에 안내문과
+ * 메모를 포함한 command 문자열 전체 길이를 `cmd_len as u16`으로 기록한다. 두 필드의
+ * 합산 UTF-16 코드 유닛 수가 65536 이상이면 이 캐스팅이 랩어라운드되어 길이
+ * 프리픽스와 실제 기록된 바이트 수가 어긋난 손상된 레코드가 만들어진다(#2851과
+ * 동일 원인, guide/memo 형제 필드 재발). `.rs`를 수정하지 않는 범위에서, 손상 가능한
+ * 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은 상한으로 미리 막는다.
+ */
+export const MAX_FIELD_GUIDE_LEN = 250;
+
+/** 메모(memo)의 안전한 상한 길이(문자 수). 근거는 {@link MAX_FIELD_GUIDE_LEN} 참고. */
+export const MAX_FIELD_MEMO_LEN = 1000;
+
 export class FieldEditDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
   private memoInput!: HTMLTextAreaElement;
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
   private nameErrorLabel!: HTMLDivElement;
+  private guideErrorLabel!: HTMLDivElement;
+  private memoErrorLabel!: HTMLDivElement;
 
   /** 적용 콜백 */
   onApply: ((props: ClickHereProps) => void) | null = null;
@@ -83,7 +100,16 @@ export class FieldEditDialog extends ModalDialog {
     this.guideInput = document.createElement('input');
     this.guideInput.type = 'text';
     this.guideInput.className = 'field-edit-input';
+    this.guideInput.maxLength = MAX_FIELD_GUIDE_LEN;
     panel.appendChild(this.guideInput);
+
+    this.guideErrorLabel = document.createElement('div');
+    this.guideErrorLabel.className = 'field-edit-error';
+    this.guideErrorLabel.style.color = '#c00';
+    this.guideErrorLabel.style.fontSize = '11px';
+    this.guideErrorLabel.style.display = 'none';
+    this.guideErrorLabel.textContent = `안내문은 ${MAX_FIELD_GUIDE_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.guideErrorLabel);
 
     // ── 메모 내용(M) ──
     const memoLabel = document.createElement('label');
@@ -94,7 +120,16 @@ export class FieldEditDialog extends ModalDialog {
     this.memoInput = document.createElement('textarea');
     this.memoInput.className = 'field-edit-textarea';
     this.memoInput.rows = 4;
+    this.memoInput.maxLength = MAX_FIELD_MEMO_LEN;
     panel.appendChild(this.memoInput);
+
+    this.memoErrorLabel = document.createElement('div');
+    this.memoErrorLabel.className = 'field-edit-error';
+    this.memoErrorLabel.style.color = '#c00';
+    this.memoErrorLabel.style.fontSize = '11px';
+    this.memoErrorLabel.style.display = 'none';
+    this.memoErrorLabel.textContent = `메모 내용은 ${MAX_FIELD_MEMO_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.memoErrorLabel);
 
     // ── 필드 이름(N) ──
     const nameLabel = document.createElement('label');
@@ -137,6 +172,23 @@ export class FieldEditDialog extends ModalDialog {
       return false;
     }
     this.nameErrorLabel.style.display = 'none';
+
+    let valid = true;
+    if (this.guideInput.value.length > MAX_FIELD_GUIDE_LEN) {
+      this.guideErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.guideErrorLabel.style.display = 'none';
+    }
+    if (this.memoInput.value.length > MAX_FIELD_MEMO_LEN) {
+      this.memoErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.memoErrorLabel.style.display = 'none';
+    }
+    if (!valid) {
+      return false;
+    }
 
     if (this.onApply) {
       this.onApply({

--- a/rhwp-studio/src/ui/field-insert-dialog.ts
+++ b/rhwp-studio/src/ui/field-insert-dialog.ts
@@ -5,7 +5,12 @@
  * 양식 모드 편집 가능 여부를 입력한다.
  */
 import { ModalDialog } from './dialog';
-import { MAX_FIELD_NAME_LEN, type ClickHereProps } from './field-edit-dialog';
+import {
+  MAX_FIELD_GUIDE_LEN,
+  MAX_FIELD_MEMO_LEN,
+  MAX_FIELD_NAME_LEN,
+  type ClickHereProps,
+} from './field-edit-dialog';
 
 export class FieldInsertDialog extends ModalDialog {
   private guideInput!: HTMLInputElement;
@@ -13,6 +18,8 @@ export class FieldInsertDialog extends ModalDialog {
   private nameInput!: HTMLInputElement;
   private editableCheckbox!: HTMLInputElement;
   private nameErrorLabel!: HTMLDivElement;
+  private guideErrorLabel!: HTMLDivElement;
+  private memoErrorLabel!: HTMLDivElement;
 
   onApply: ((props: ClickHereProps) => void) | null = null;
 
@@ -45,7 +52,16 @@ export class FieldInsertDialog extends ModalDialog {
     this.guideInput.type = 'text';
     this.guideInput.className = 'field-edit-input';
     this.guideInput.value = '입력하세요';
+    this.guideInput.maxLength = MAX_FIELD_GUIDE_LEN;
     panel.appendChild(this.guideInput);
+
+    this.guideErrorLabel = document.createElement('div');
+    this.guideErrorLabel.className = 'field-edit-error';
+    this.guideErrorLabel.style.color = '#c00';
+    this.guideErrorLabel.style.fontSize = '11px';
+    this.guideErrorLabel.style.display = 'none';
+    this.guideErrorLabel.textContent = `안내문은 ${MAX_FIELD_GUIDE_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.guideErrorLabel);
 
     const memoLabel = document.createElement('label');
     memoLabel.className = 'field-edit-label';
@@ -55,7 +71,16 @@ export class FieldInsertDialog extends ModalDialog {
     this.memoInput = document.createElement('textarea');
     this.memoInput.className = 'field-edit-textarea';
     this.memoInput.rows = 4;
+    this.memoInput.maxLength = MAX_FIELD_MEMO_LEN;
     panel.appendChild(this.memoInput);
+
+    this.memoErrorLabel = document.createElement('div');
+    this.memoErrorLabel.className = 'field-edit-error';
+    this.memoErrorLabel.style.color = '#c00';
+    this.memoErrorLabel.style.fontSize = '11px';
+    this.memoErrorLabel.style.display = 'none';
+    this.memoErrorLabel.textContent = `메모 내용은 ${MAX_FIELD_MEMO_LEN}자를 넘을 수 없습니다.`;
+    panel.appendChild(this.memoErrorLabel);
 
     const nameLabel = document.createElement('label');
     nameLabel.className = 'field-edit-label';
@@ -96,6 +121,23 @@ export class FieldInsertDialog extends ModalDialog {
       return false;
     }
     this.nameErrorLabel.style.display = 'none';
+
+    let valid = true;
+    if (this.guideInput.value.length > MAX_FIELD_GUIDE_LEN) {
+      this.guideErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.guideErrorLabel.style.display = 'none';
+    }
+    if (this.memoInput.value.length > MAX_FIELD_MEMO_LEN) {
+      this.memoErrorLabel.style.display = '';
+      valid = false;
+    } else {
+      this.memoErrorLabel.style.display = 'none';
+    }
+    if (!valid) {
+      return false;
+    }
 
     this.onApply?.({
       guide: this.guideInput.value,

--- a/rhwp-studio/src/ui/page-border-dialog.ts
+++ b/rhwp-studio/src/ui/page-border-dialog.ts
@@ -423,7 +423,10 @@ export class PageBorderDialog extends ModalDialog {
   private buildLineWidthSelect(): HTMLSelectElement {
     this.lineWidthSelect = document.createElement('select');
     this.lineWidthSelect.className = 'dialog-select';
-    ['0.1mm', '0.12mm', '0.15mm', '0.2mm', '0.25mm', '0.3mm', '0.4mm', '0.5mm', '0.6mm'].forEach((text, idx) => {
+    [
+      '0.1mm', '0.12mm', '0.15mm', '0.2mm', '0.25mm', '0.3mm', '0.4mm', '0.5mm', '0.6mm',
+      '0.7mm', '1mm', '1.5mm', '2mm', '3mm', '4mm', '5mm',
+    ].forEach((text, idx) => {
       const option = document.createElement('option');
       option.value = String(idx);
       option.textContent = text;

--- a/rhwp-studio/src/ui/table-cell-props-dialog.ts
+++ b/rhwp-studio/src/ui/table-cell-props-dialog.ts
@@ -1221,8 +1221,8 @@ export class TableCellPropsDialog extends ModalDialog {
     if (props.fillType === 'solid' && props.fillColor) {
       this.bgColorRadio.checked = true;
       this.bgColorPicker.value = props.fillColor;
-      if (props.patternColor) this.bgPatternColorPicker.value = props.patternColor;
-      if (props.patternType != null) this.bgPatternTypeSelect.value = String(props.patternType);
+      this.bgPatternColorPicker.value = props.patternColor ?? '#000000';
+      this.bgPatternTypeSelect.value = props.patternType != null ? String(props.patternType) : '0';
     } else {
       this.bgNoneRadio.checked = true;
     }

--- a/rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts
+++ b/rhwp-studio/tests/clickhere-guide-memo-length-guard.test.ts
@@ -1,0 +1,30 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2878 (#2851 형제 필드 재발): 누름틀(ClickHere) 안내문(guide)/메모(memo) 입력 길이
+// 미검증 → Rust 직렬화기(src/serializer/control.rs)가 guide/memo를 포함한 command
+// 문자열 전체 길이를 `cmd_len as u16`으로 기록할 때 랩어라운드되어 CTRL_DATA 레코드가
+// 손상될 수 있었다. `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출
+// 전에 guide/memo 길이를 안전한 상한(MAX_FIELD_GUIDE_LEN/MAX_FIELD_MEMO_LEN)으로
+// 막는지를 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(path.join(dir, '../src/ui/field-edit-dialog.ts'), 'utf8');
+
+test('누름틀 안내문/메모 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const guideMatch = src.match(/MAX_FIELD_GUIDE_LEN\s*=\s*(\d+)/);
+  const memoMatch = src.match(/MAX_FIELD_MEMO_LEN\s*=\s*(\d+)/);
+  assert.ok(guideMatch, 'MAX_FIELD_GUIDE_LEN 상수를 찾을 수 없음');
+  assert.ok(memoMatch, 'MAX_FIELD_MEMO_LEN 상수를 찾을 수 없음');
+
+  const guideLimit = Number(guideMatch![1]);
+  const memoLimit = Number(memoMatch![1]);
+
+  assert.ok(
+    guideLimit > 0 && memoLimit > 0 && guideLimit + memoLimit < 65536,
+    `합산 한도(${guideLimit + memoLimit})가 u16 랩어라운드 지점보다 작아야 함`,
+  );
+});

--- a/rhwp-studio/tests/table-object-copy-cellpath.test.ts
+++ b/rhwp-studio/tests/table-object-copy-cellpath.test.ts
@@ -1,0 +1,55 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// [Task #2880] 표 객체 선택(isInTableObjectSelection) Ctrl+C/Ctrl+X 핸들러가
+// 그림 개체 선택 핸들러(pictureCellPathJson 사용부)와 달리 cellPathJson 을
+// wasm.copyControl/exportControlHtml 에 전달하지 않아, 셀 안 중첩 표를
+// 복사·잘라내기하면 native 가 본문 표로 오인하는 회귀를 막는 source-guard.
+//
+// 이 파일은 무거운 WasmBridge/DOM mock 없이, "표 selection 블록의
+// copyControl(...) 호출이 반드시 cellPathJson 인자를 포함한다"는 사실만
+// 소스 텍스트 수준에서 검증한다 (getSelectedTableRef().cellPath 를 실제로
+// native 호출에 흘려보내는지 확인).
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+test('표 객체 선택 Ctrl+C/Ctrl+X 는 copyControl/exportControlHtml 에 cellPathJson 을 전달한다', () => {
+  const src = source('src/engine/input-handler-keyboard.ts');
+
+  const tableSelectionBlockStart = src.indexOf('this.cursor.isInTableObjectSelection()');
+  assert.notEqual(tableSelectionBlockStart, -1, '표 객체 선택 모드 블록을 찾지 못함');
+
+  const ctrlCStart = src.indexOf("e.key === 'c'", tableSelectionBlockStart);
+  const ctrlXStart = src.indexOf("e.key === 'x'", tableSelectionBlockStart);
+  assert.notEqual(ctrlCStart, -1, '표 Ctrl+C 핸들러를 찾지 못함');
+  assert.notEqual(ctrlXStart, -1, '표 Ctrl+X 핸들러를 찾지 못함');
+
+  const ctrlCBlock = src.slice(ctrlCStart, ctrlXStart);
+  const ctrlVStart = src.indexOf("e.key === 'v'", ctrlXStart);
+  const ctrlXBlock = src.slice(ctrlXStart, ctrlVStart === -1 ? undefined : ctrlVStart);
+
+  for (const [label, block] of [['Ctrl+C', ctrlCBlock], ['Ctrl+X', ctrlXBlock]] as const) {
+    assert.match(
+      block,
+      /const cellPathJson = pictureCellPathJson\(ref\);/,
+      `표 ${label} 핸들러가 ref.cellPath 를 cellPathJson 으로 계산하지 않음 (회귀)`,
+    );
+    assert.match(
+      block,
+      /wasm\.copyControl\(ref\.sec, ref\.ppi, ref\.ci, cellPathJson\)/,
+      `표 ${label} 핸들러의 copyControl 호출에 cellPathJson 인자가 없음 (회귀)`,
+    );
+    assert.match(
+      block,
+      /wasm\.exportControlHtml\(ref\.sec, ref\.ppi, ref\.ci, cellPathJson\)/,
+      `표 ${label} 핸들러의 exportControlHtml 호출에 cellPathJson 인자가 없음 (회귀)`,
+    );
+  }
+});


### PR DESCRIPTION
kevin9327 님의 오늘 범위(#2762~#3030) 배치 C — rhwp-studio UI 축 4건을 메인테이너가 재실증 후 통합한다. 배치 A(#3197)·B(#3198)는 merge 완료.

## 채택 4건

| PR | 결함 |
|---|---|
| #2883 (`Closes #2878`) | 누름틀 안내문/메모 길이 미검증 — 합산 UTF-16 길이 65536 이상이면 CTRL_DATA `cmd_len as u16` 랩어라운드로 손상 레코드 생성 |
| #2889 (`Closes #2880`) | 표 객체 선택 Ctrl+C/Ctrl+X 가 중첩 표 cellPath 를 native 에 전달하지 않음 |
| #2944 (`Closes #2941`) | 표/셀 속성 다이얼로그 배경 탭의 무늬색·무늬모양 populate 미동기화 |
| #2950 (`Closes #2946`) | 쪽 테두리 다이얼로그 lineWidthSelect 옵션이 실제 지원 굵기 16개보다 적음 |

## 충돌 해소

#2883 은 devel 의 필드 이름 길이 가드(#2851 계열)와 형제 필드 병치 — field-edit/insert 두 다이얼로그에서 이름/안내문/메모 세 가드를 모두 유지했다. 이름 가드의 기존 동작(위반 시 focus 후 즉시 반환)은 그대로 두고 안내문/메모 가드를 후행시켰다.

## 검증

- `npm ci` 선행 후 `tsc --noEmit` 오류 0
- 테스트 537건 전부 통과, 신규 테스트 2파일(길이 가드·cellPath) 표적 재확인

Co-authored-by 로 원 커밋 provenance 를 보존한다.
