### PR TITLE
fix(renderer): 테두리 문단 TAC margin 이중 가산 + plane 무시 역방향 clip — kevin9327 범위연작 배치 D

### DIFF
--- a/mydocs/report/task_m100_2835_report.md
+++ b/mydocs/report/task_m100_2835_report.md
@@ -1,0 +1,93 @@
+# Task #2835 처리 보고서 — TAC 그림/도형 배치 margin_left 이중 가산 수정
+
+## 배경
+
+이슈 #2835: 테두리(border) 있는 문단 안 treat-as-char(TAC) 그림/도형이 같은 문단
+본문 텍스트보다 `para_margin_left` 만큼 더 오른쪽으로 밀려 렌더링되는 결함.
+
+## 근본 원인
+
+`src/renderer/layout.rs` 의 TAC picture/shape 배치 경로(`layout_shape_item`
+계열, `effective_margin_left` 계산부)는 다음 조건에서 `para_margin_left` 를
+"inner padding" 명목으로 한 번 더 가산하고 있었다.
+
+```rust
+let has_visible_stroke = /* border_fill_id 로 실 stroke 판정 */;
+let inner_pad_left =
+    if has_visible_stroke && bs_left_px == 0.0 && bs_right_px == 0.0 {
+        para_margin_left
+    } else {
+        0.0
+    };
+let effective_margin_left = para_margin_left + para_indent + inner_pad_left; // (indent<=0 이면 indent 생략)
+```
+
+그러나 **같은 계산을 하던 `src/renderer/layout/paragraph_layout.rs`(본문 텍스트
+배치 경로)는 커밋 `a30dca73`("Task #544 v2 Stage 2: Phase A 재적용")에서 정확히
+이 `has_visible_stroke`/`bs_left_px`/`bs_right_px`/`inner_pad_left` 분기를
+"이중 inset 부작용"으로 판단해 완전히 제거**했다. 그 커밋 메시지:
+
+> `paragraph_layout.rs`: 1. inner_pad 분기 제거 (line 693~717 → 693~700, -22 LOC)
+> — `has_visible_stroke` / `bs_left_px` / `bs_right_px` / `inner_pad_left`/`right`
+> 변수 모두 제거 — `margin_left = box_margin_left` (단일 룰, 텍스트 inset 한 번만)
+
+`git show a30dca73 -- src/renderer/layout.rs` 결과가 비어있어, 이 수정이
+`layout.rs` 의 TAC picture/shape 경로에는 전혀 반영되지 않았음을 확인했다.
+즉 본문 텍스트는 `margin_left` 만 적용되도록 이미 고쳐졌는데, 같은 문단의
+TAC 그림/도형은 여전히 `margin_left` 를 두 번 적용받는 **형제(sibling)
+코드 경로 간 비대칭**이 남아 있었다.
+
+## 실측 재현
+
+`inner_pad_left` 계산 직후에 디버그 출력을 임시로 추가해
+`samples/exam_kor.hwp` 렌더링을 관찰한 결과, 최소 10개 문단
+(para_index/pi = 46, 50, 54, 56, 60, 63, 66, 70, 108, 111 — 대부분 페이지
+18(1-based)) 에서
+
+```
+inner_pad_left=11.33 para_margin_left=11.33
+```
+
+즉 `para_margin_left`(11.33px = ParaShape margin_left 1704 HU 환산치)가
+매 문단마다 그대로 이중 가산되고 있음을 확인했다. 코드 주석에도 "exam_kor
+p18 pi=50/56 의 [A]/[B] 표시기 옆 그림" 위치 결함으로 이미 알려진 증상이라고
+적혀 있어 이번 조사와 일치한다.
+
+## 수정
+
+- `has_visible_stroke`/`bs_left_px`/`bs_right_px`/`inner_pad_left` 분기를
+  완전히 제거.
+- `paragraph_layout.rs` 와 동일한 "margin_left(+indent) 단일 가산" 규칙을
+  `tac_picture_effective_margin_left(para_margin_left, para_indent)` 라는
+  작은 순수 함수로 추출해, 두 형제 경로가 향후에도 같은 로직을 공유하도록
+  구조화했다 (재발 방지).
+- `border_styles`/`BorderLineType` 조회 등 이제 불필요해진 코드도 함께 제거.
+
+## 검증 (Red → Green)
+
+`tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule`
+(`src/renderer/layout/tests.rs`) 테스트를 추가했다.
+
+- **RED**: 헬퍼 내부에 옛 버그(`inner_pad_left = para_margin_left` 를
+  무조건 추가 가산)를 임시로 재현했을 때 테스트 실패 확인
+  (`22.66 이 아니라 11.33 이어야 함` 단언 실패).
+- **GREEN**: 수정된 헬퍼(단일 가산)로 되돌린 후 테스트 통과 확인.
+
+```
+test renderer::layout::tests::tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule ... ok
+```
+
+- `cargo build --lib`: 통과, 경고 없음.
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 통과.
+- `rustfmt --edition 2021` 적용 후 `git diff --name-only` 는 의도한 2개
+  파일(`src/renderer/layout.rs`, `src/renderer/layout/tests.rs`)만 남음.
+
+## 변경 파일
+
+- `src/renderer/layout.rs`
+- `src/renderer/layout/tests.rs`
+
+## 참고
+
+- 관련 커밋(선행 수정): `a30dca73` (Task #544 v2 Stage 2)
+- 이슈: https://github.com/edwardkim/rhwp/issues/2835

--- a/mydocs/report/task_m100_2895_report.md
+++ b/mydocs/report/task_m100_2895_report.md
@@ -1,0 +1,38 @@
+# Task #M100-2895 처리 결과
+
+## 이슈
+edwardkim/rhwp#2895 — 동일 이미지 겹침-clip 함수가 트리 순서를 z-순서로 오인해 plane 이 다른 이미지 쌍에서 역방향으로 잘림
+
+## 원인
+`PageRenderTree::clip_overlapping_same_bin_images` (`src/renderer/render_tree.rs`, Task #1154 도입)가
+동일 `bin_data_id` 이미지 페어의 clip 방향을 "RenderTree 순회(children 삽입) 순서 = 실제 페인트 순서"라는
+암묵적 가정으로 판단했다. 그러나 `src/paint/replay_order.rs` 가 정의하는 실제 재생 순서는
+`Background → BehindText → Flow → InFrontOfText` 4단계 plane 으로 분리되어 있어, `text_wrap` 이 다른
+두 이미지는 트리 순서와 무관하게 plane 순서로 재생된다. 트리 순서상 먼저 오는 Flow 이미지와 나중에
+오는 BehindText 이미지가 겹치면, 실제로는 BehindText 가 더 아래에 그려짐에도 기존 함수는 Flow 쪽을
+"아래에 깔린 쪽"으로 오판해 역방향으로 clip 했다.
+
+## 수정
+- `src/renderer/render_tree.rs`
+  - `ClipReplayPlane` (BehindText/Flow/InFrontOfText) 타입 추가 — `ImageNode.text_wrap` 으로부터
+    `paint_op_replay_plane_with_layer` 와 동일한 3-way 분류를 적용.
+  - `collect_image_nodes` 가 각 이미지의 plane 을 함께 수집하도록 튜플 확장.
+  - `clip_overlapping_same_bin_images` 의 페어 검출 루프에 `plane_a != plane_b` 가드를 추가해,
+    plane 이 다른 페어는 clip 대상에서 제외(보수적 최소 수정 — 정확한 역방향 clip 계산 대신 미적용).
+
+## 테스트 (red → green)
+`test_clip_skips_cross_plane_pairs` (`src/renderer/render_tree.rs` tests 모듈) 추가.
+
+- Red (가드 임시 비활성화 후 `cargo test`): `assertion left == right failed / left: 50.0 / right: 200.0`
+  — Flow 이미지가 역방향으로 50 까지 clip 됨을 실측.
+- Green (가드 복원 후 `cargo test`): 두 이미지 모두 원래 height(200.0) 유지, 11개 clip 관련 테스트 전부 통과.
+
+## 검증
+- `cargo build --lib`: 성공
+- `cargo test --lib render_tree::tests::test_clip`: 11 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021 src/renderer/render_tree.rs`: 적용 (개행 스타일 외 diff 없음)
+
+## 영향 범위
+`src/renderer/render_tree.rs`, `src/renderer/render_tree.rs` 내 테스트만 변경. 다른 렌더러/직렬화 코드는
+건드리지 않았으며, 기존 clip 로직(같은 plane 내 동일-bin 이미지 겹침)은 그대로 유지된다.

--- a/src/renderer/layout.rs
+++ b/src/renderer/layout.rs
@@ -1251,6 +1251,22 @@ pub(crate) fn para_has_overlay_shape(para: &Paragraph) -> bool {
 /// 자리차지(TopAndBottom)·tac=true 는 개체가 흐름 공간을 실제로 차지하므로 제외.
 /// Shape/Picture 는 통과·글앞·글뒤만(Square 는 그림 좌우 흘림이 흔해 제외, 회귀 차단).
 /// Table 은 부동 배치가 어울림(Square) 표준이므로 어울림 포함.
+/// [Task #544 v2 정합] TAC picture/shape 배치 경로의 좌측 유효 margin 계산.
+///
+/// `paragraph_layout.rs` (커밋 a30dca73, Task #544 v2 Stage 2) 는 본문 텍스트 경로에서
+/// `has_visible_stroke && border_spacing[0]==[1]==0` 조건에 `box_margin_left` 를 inner
+/// padding 명목으로 한 번 더 가산하던 분기를 이중 inset 부작용으로 판단해 완전히
+/// 제거했다 (`margin_left = box_margin_left` 단일 룰). 본 함수는 TAC picture/shape
+/// 배치 경로가 그 규칙과 동일한 값을 쓰도록 통일한다 — border/stroke 유무는 더 이상
+/// 좌측 margin 계산에 관여하지 않는다.
+pub(crate) fn tac_picture_effective_margin_left(para_margin_left: f64, para_indent: f64) -> f64 {
+    if para_indent > 0.0 {
+        para_margin_left + para_indent
+    } else {
+        para_margin_left
+    }
+}
+
 pub(crate) fn para_is_floating_overlay_anchor(para: &Paragraph) -> bool {
     use crate::model::shape::TextWrap;
     if !para.text.trim().is_empty() || para.controls.is_empty() {
@@ -7756,45 +7772,18 @@ impl LayoutEngine {
                         // Task #347: 첫 줄 effective_margin (hanging indent: indent<0 → first-line은 margin_left만 적용)
                         let para_margin_left = para_style_ref.map(|s| s.margin_left).unwrap_or(0.0);
                         let para_indent = para_style_ref.map(|s| s.indent).unwrap_or(0.0);
-                        // [Task #534] paragraph_layout 의 effective_margin_left 정합:
-                        // visible stroke 보유 + border_spacing[0,1]=0 인 paragraph 는
-                        // box_margin_left 를 inner padding 으로 추가 가산 (paragraph_layout.rs
-                        // line 711-716 와 동일). wrap_host (Square wrap 표 보유) paragraph 는
-                        // paragraph_layout 미호출되어 본 경로만 emit → inner_pad 누락 시
-                        // 위치 결함 (예: exam_kor p18 pi=50/56 의 [A]/[B] 표시기 옆 그림).
-                        let para_border_fill_id_pre =
-                            para_style_ref.map(|s| s.border_fill_id).unwrap_or(0);
-                        let has_visible_stroke = if para_border_fill_id_pre > 0 {
-                            let idx = (para_border_fill_id_pre as usize).saturating_sub(1);
-                            styles
-                                .border_styles
-                                .get(idx)
-                                .map(|bs| {
-                                    bs.borders.iter().any(|b| {
-                                        !matches!(
-                                            b.line_type,
-                                            crate::model::style::BorderLineType::None
-                                        ) && b.width > 0
-                                    })
-                                })
-                                .unwrap_or(false)
-                        } else {
-                            false
-                        };
-                        let bs_left_px = para_style_ref.map(|s| s.border_spacing[0]).unwrap_or(0.0);
-                        let bs_right_px =
-                            para_style_ref.map(|s| s.border_spacing[1]).unwrap_or(0.0);
-                        let inner_pad_left =
-                            if has_visible_stroke && bs_left_px == 0.0 && bs_right_px == 0.0 {
-                                para_margin_left
-                            } else {
-                                0.0
-                            };
-                        let mut effective_margin_left = if para_indent > 0.0 {
-                            para_margin_left + para_indent + inner_pad_left
-                        } else {
-                            para_margin_left + inner_pad_left
-                        };
+                        // [Task #544 v2 정합] paragraph_layout.rs (a30dca73, Task #544 v2 Stage 2)
+                        // 는 has_visible_stroke / bs_left_px / bs_right_px 를 보고
+                        // box_margin_left 를 inner padding 으로 한 번 더 가산하던 분기를
+                        // 이중 inset 부작용으로 판단해 완전히 제거했다 (margin_left =
+                        // box_margin_left 단일 룰, PDF 정합 확인됨). 본 TAC picture/shape
+                        // 경로는 그 수정이 반영되지 않아 테두리 있는 문단(has_visible_stroke)
+                        // + border_spacing[0]=[1]=0 조건에서 그림이 같은 문단의 텍스트보다
+                        // para_margin_left 만큼 더 오른쪽으로 밀리는 결함이 있었다
+                        // (exam_kor.hwp p18/pi=46,50,54,56... 실측 확인 — inner_pad_left=11.33px
+                        // 만큼 이중 가산). paragraph_layout.rs 와 동일하게 가산 없이 통일한다.
+                        let mut effective_margin_left =
+                            tac_picture_effective_margin_left(para_margin_left, para_indent);
                         // [Task #534 v2] LINE_SEG.column_start 는 Square wrap 인라인 표/그림이
                         // 좌측에 floating 시 표 영역 이후 텍스트 시작 위치를 HWP IR 가 인코딩.
                         // layout_shape_item 은 col_area.x 그대로 사용 → picture (TAC) 가 표

--- a/src/renderer/layout/tests.rs
+++ b/src/renderer/layout/tests.rs
@@ -2349,3 +2349,36 @@ fn page_bg_image_only_on_section_first_page() {
     assert!(!image_rest, "구역 첫 쪽이 아니면 배경 이미지가 없어야 한다");
     assert!(color_rest, "이미지가 억제돼도 색 채우기는 유지되어야 한다");
 }
+
+/// [Task #2835] TAC picture/shape 배치 경로의 좌측 margin 이 paragraph_layout.rs
+/// (Task #544 v2, 커밋 a30dca73) 의 "margin_left 단일 가산" 규칙과 일치해야 한다.
+///
+/// 버그(수정 전): `has_visible_stroke && border_spacing[0]==[1]==0` 인 문단에서
+/// `inner_pad_left = para_margin_left` 를 추가로 더해 TAC 그림이 같은 문단의 본문
+/// 텍스트보다 `para_margin_left` 만큼 더 오른쪽으로 밀렸다 (exam_kor.hwp pi=46 등
+/// 실측 inner_pad_left=11.33px). 본 테스트는 `border_fill_id`/`border_spacing` 유무와
+/// 무관하게 `tac_picture_effective_margin_left` 가 `para_margin_left`(+indent) 만
+/// 반환해야 함을 검증한다.
+#[test]
+fn tac_picture_effective_margin_left_matches_paragraph_layout_single_margin_rule() {
+    use super::tac_picture_effective_margin_left;
+
+    // 테두리(has_visible_stroke) + border_spacing=0 케이스 (버그 트리거 조건)여도
+    // margin_left 를 한 번만 반영해야 한다. 버그 있던 구현이라면 11.33 + 11.33 = 22.66.
+    let para_margin_left = 11.33;
+    assert!(
+        (tac_picture_effective_margin_left(para_margin_left, 0.0) - para_margin_left).abs() < 1e-9,
+        "border_spacing=0/유테두리 문단에서도 margin_left 를 한 번만 더해야 함 \
+         (이중 가산 버그: 22.66 이 아니라 11.33 이어야 함)"
+    );
+
+    // indent>0 (첫 줄 hanging indent) 이면 margin_left + indent 만 더해야 한다.
+    let para_indent = 13.23;
+    assert!(
+        (tac_picture_effective_margin_left(para_margin_left, para_indent)
+            - (para_margin_left + para_indent))
+            .abs()
+            < 1e-9,
+        "indent>0 이면 margin_left + indent 만 반영해야 함 (inner_pad 이중 가산 없이)"
+    );
+}

--- a/src/renderer/render_tree.rs
+++ b/src/renderer/render_tree.rs
@@ -1241,6 +1241,33 @@ pub struct PageRenderTree {
     inline_shape_positions: std::collections::HashMap<InlineShapeKey, (f64, f64)>,
 }
 
+/// `clip_overlapping_same_bin_images` 전용 대략적 replay plane 분류.
+///
+/// `src/paint/replay_order.rs` (`paint_op_replay_plane_with_layer`,
+/// `cap_master_page_plane`) 가 실제 페인트 backend 에서 적용하는 재생 순서는
+/// Background → BehindText → Flow → InFrontOfText 로, **트리 순서와 무관하게
+/// plane 별로 별도 재생**된다. 즉 트리 순서상 `BehindText` 개체가 `Flow`
+/// 개체보다 뒤에 있어도 실제로는 `BehindText` 가 먼저(더 아래에) 그려진다.
+/// clip 함수는 "트리 순서 = z 순서(먼저 그려짐 = 아래)"를 가정하므로, plane
+/// 이 다른 페어는 이 가정이 성립하지 않아 clip 방향을 잘못 판단할 수 있다
+/// (아래에 깔릴 그림이 아니라 위에 그려질 그림이 잘리는 역방향 clip).
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ClipReplayPlane {
+    BehindText,
+    Flow,
+    InFrontOfText,
+}
+
+impl ClipReplayPlane {
+    fn from_text_wrap(wrap: Option<TextWrap>) -> Self {
+        match wrap {
+            Some(TextWrap::BehindText) => Self::BehindText,
+            Some(TextWrap::InFrontOfText) => Self::InFrontOfText,
+            _ => Self::Flow,
+        }
+    }
+}
+
 impl PageRenderTree {
     /// 새 페이지 렌더 트리 생성
     pub fn new(page_index: u32, width: f64, height: f64) -> Self {
@@ -1352,8 +1379,14 @@ impl PageRenderTree {
     /// 조건 2/3 은 의도적 시각 효과 (test-image, 3-10월_교육_통합 의 대각선
     /// 오프셋 등) 를 보호하기 위한 strict 가드.
     pub fn clip_overlapping_same_bin_images(&mut self) {
-        // Phase 1: 트리 순서대로 ImageNode 의 (id, bbox, bin_id, crop) 수집
-        let mut images: Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)> = Vec::new();
+        // Phase 1: 트리 순서대로 ImageNode 의 (id, bbox, bin_id, crop, plane) 수집
+        let mut images: Vec<(
+            NodeId,
+            BoundingBox,
+            u16,
+            Option<(i32, i32, i32, i32)>,
+            ClipReplayPlane,
+        )> = Vec::new();
         Self::collect_image_nodes(&self.root, &mut images);
 
         if images.len() < 2 {
@@ -1367,10 +1400,19 @@ impl PageRenderTree {
 
         for i in 0..images.len() {
             for j in (i + 1)..images.len() {
-                let (id_a, bbox_a, bin_a, crop_a) = &images[i];
-                let (_id_b, bbox_b, bin_b, _crop_b) = &images[j];
+                let (id_a, bbox_a, bin_a, crop_a, plane_a) = &images[i];
+                let (_id_b, bbox_b, bin_b, _crop_b, plane_b) = &images[j];
                 // 조건 1: 같은 bin_id
                 if bin_a != bin_b {
+                    continue;
+                }
+                // 조건 0 (#paint/replay_order.rs plane 분리 재생 정합):
+                // BehindText/InFrontOfText 는 Flow 와 별도 plane 으로 재생되어
+                // 실제 페인트 순서가 트리 순서와 반대일 수 있다. 서로 다른
+                // plane 페어는 clip 방향을 트리 순서만으로 확정할 수 없으므로
+                // 건너뛴다 (트리 순서가 곧 페인트 순서인 동일 plane 내에서만
+                // 이 함수의 z 가정이 성립한다).
+                if plane_a != plane_b {
                     continue;
                 }
                 // 조건 2/3: x, width 동일 (1px tolerance)
@@ -1418,10 +1460,22 @@ impl PageRenderTree {
 
     fn collect_image_nodes(
         node: &RenderNode,
-        out: &mut Vec<(NodeId, BoundingBox, u16, Option<(i32, i32, i32, i32)>)>,
+        out: &mut Vec<(
+            NodeId,
+            BoundingBox,
+            u16,
+            Option<(i32, i32, i32, i32)>,
+            ClipReplayPlane,
+        )>,
     ) {
         if let RenderNodeType::Image(img) = &node.node_type {
-            out.push((node.id, node.bbox, img.bin_data_id, img.crop));
+            out.push((
+                node.id,
+                node.bbox,
+                img.bin_data_id,
+                img.crop,
+                ClipReplayPlane::from_text_wrap(img.text_wrap),
+            ));
         }
         for child in &node.children {
             Self::collect_image_nodes(child, out);
@@ -1812,6 +1866,44 @@ mod tests {
         let body = &tree.root.children[0];
         let lower = &body.children[0];
         assert!((image_bbox(lower).height - 219.58).abs() < 0.01);
+    }
+
+    /// Task #M100: BehindText 와 Flow 처럼 서로 다른 재생 plane 에 걸친 페어는
+    /// clip 대상에서 제외해야 한다. `src/paint/replay_order.rs` 의 plane 분리
+    /// 재생 규약상 BehindText 는 트리 순서와 무관하게 Flow 보다 먼저(더 아래)
+    /// 그려지므로, 트리 순서만 보고 clip 방향을 정하면 실제로는 위에 그려질
+    /// Flow 그림이 잘못 잘릴 수 있다.
+    #[test]
+    fn test_clip_skips_cross_plane_pairs() {
+        let mut tree = PageRenderTree::new(0, 1122.5, 1587.4);
+        // 트리 순서상 먼저 (Flow, y=100~300)
+        let mut flow = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(100.0, 100.0, 200.0, 200.0),
+            9,
+            Some((0, 0, 1000, 2000)),
+        );
+        if let RenderNodeType::Image(ref mut img) = flow.node_type {
+            img.text_wrap = Some(TextWrap::Square);
+        }
+        // 트리 순서상 나중 (BehindText, y=150~350) — 실제 재생 순서는 Flow 보다 먼저(더 아래)
+        let mut behind = make_image_node(
+            tree.next_id(),
+            BoundingBox::new(100.0, 150.0, 200.0, 200.0),
+            9,
+            Some((0, 0, 1000, 2000)),
+        );
+        if let RenderNodeType::Image(ref mut img) = behind.node_type {
+            img.text_wrap = Some(TextWrap::BehindText);
+        }
+        tree.root.children.push(flow);
+        tree.root.children.push(behind);
+
+        tree.clip_overlapping_same_bin_images();
+
+        // 두 그림 모두 원래 크기 유지 — plane 이 다르므로 clip 미적용
+        assert_eq!(image_bbox(&tree.root.children[0]).height, 200.0);
+        assert_eq!(image_bbox(&tree.root.children[1]).height, 200.0);
     }
 
     /// 단일 이미지만 있는 경우 변경 없음 (no-op).


### PR DESCRIPTION
kevin9327 님의 오늘 범위(#2762~#3030) 배치 D — 렌더러 축 2건을 메인테이너가 재실증 후 통합한다.

## 채택 2건

| PR | 결함 |
|---|---|
| #2848 (`Closes #2835`) | 테두리 문단 안 TAC 그림/도형 배치가 `para_margin_left` 를 이중 가산해 본문 텍스트보다 우측으로 밀림. 본문 텍스트 경로(paragraph_layout.rs)는 a30dca73 에서 이미 "이중 inset 부작용"으로 제거된 분기가 layout.rs 의 TAC 경로에만 잔존한 것 |
| #2900 (`Closes #2895`) | 동일 bin_data_id 이미지 겹침-clip 이 replay plane(Background→BehindText→Flow→InFrontOfText) 재편성을 무시하고 트리 순회 순서로 상하를 판정해, plane 이 다른 페어를 역방향으로 자름 |

## 시각 영향

전체 스위트 무실패에 **기존 golden SVG 변화 없음** — 두 수정이 건드는 경로는 현행 golden 샘플에 나타나지 않아 기존 렌더링 회귀는 없다. #2848 은 본문 텍스트 경로의 기수정 판단을 TAC 경로에 일치시키는 선례 기반 정정이며, 두 PR 모두 레이아웃/단위 테스트를 동반한다.

## 검증

- `cargo fmt --check` 통과, 전체 `--tests` 스위트 무실패
- 반영을 커밋 해시로 개별 검증

Co-authored-by 로 원 커밋 provenance 를 보존한다.
