### PR TITLE
fix(hwp3/wmf): 책갈피 32바이트 언더리드·has_border 소실·DIB 과대 할당 — kevin9327 범위연작 배치 E

### DIFF
--- a/mydocs/report/task_m100_2831_report.md
+++ b/mydocs/report/task_m100_2831_report.md
@@ -1,0 +1,62 @@
+# 완료 보고서 — Task M100-2831
+
+- 이슈: #2831
+- 제목: HWP3 하이퍼텍스트 정보의 책갈피 필드가 16바이트 언더리드되어 후속 그리기 개체 파싱이 어긋남
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2831-hypertext-bookmark-underread`
+
+## 1. 배경
+
+직전 태스크(#2824, 변형된 호 오버리드)와 같은 스크루티니를 `Hwp3DrawingObject::read`의
+나머지 `object_type` 분기(Line/Rectangle/Ellipse/Arc/Polygon/TextBox/Curve/
+ModifiedEllipse/ExtendedCurve/ClosedPolygon)와 `src/parser/hwp3/**`의 형제 레코드
+리더에도 적용해, 각 분기의 바이트 소비량이 스펙 인용과 정확히 일치하는지 재검증했다.
+
+## 2. 검증 결과
+
+- `Hwp3DrawingObject::read`의 object_type 0~11 각 분기: `mydocs/tech/한글문서파일구조3.0.md`
+  §11.3.1~11.3.10(공통 헤더, 선/호/다각형/글상자/곡선/변형된 타원/확장·닫힌 다각형 세부 정보)과
+  바이트 단위로 대조한 결과 전부 일치했다. 특히 공통 헤더의 기본 속성(44바이트)/회전
+  속성(32바이트)/그라데이션 속성(28바이트)/비트맵 패턴 속성(278바이트)도 표 69~72와
+  정확히 일치함을 확인했다.
+- 그 과정에서 `Hwp3DrawingObjectHypertextInfo::read`(drawing.rs:49-76)의
+  `jump_bookmark` 필드가 **16바이트만 읽는** 것을 발견했다. 코드 주석조차
+  "16 hchar(32바이트)로 명시되어 있으나 오프셋 계산상 16바이트로 처리함"이라고
+  스스로 모순을 인정하고 있었다.
+- 스펙 §8.3 "하이퍼텍스트(HyperLink) 정보" 표 21은 이 구조체와 동일한 필드 구성을
+  절대 오프셋과 함께 별도로 명시한다: 책갈피 필드는 오프셋 264→296 사이(32바이트)이며,
+  전체 길이 공식 `617 = 256(파일이름) + 32(책갈피) + 325(매크로) + 1(종류) + 3(예약)`도
+  32바이트를 요구한다. 16바이트로는 601바이트가 되어 공식과 16바이트 어긋난다.
+- `parse_drawing_object_tree`(drawing.rs:581-587)는 `frame_header.header_length > 24`일
+  때 이 구조체를 `seek` 없이 순차 `read_exact`로 읽으므로, 16바이트 언더리드는 하이퍼링크가
+  걸린 그리기 개체를 포함한 HWP3 문서에서 이후 모든 형제/자식 그리기 개체 레코드의 파싱을
+  통째로 밀어버린다(#2824와 동일한 버그 클래스).
+
+## 3. 수정 내용
+
+- `src/parser/hwp3/drawing.rs`
+  - `jump_bookmark_buf`를 `[0u8; 16]` → `[0u8; 32]`로 수정
+  - 구조체 필드 주석과 read 함수 내 주석을 스펙 §8.3 표 21의 절대 오프셋·전체 길이
+    공식 근거로 갱신
+  - 회귀 테스트 `hypertext_bookmark_underread_tests::hypertext_info_consumes_full_32_byte_bookmark`
+    추가: 하이퍼텍스트 정보 뒤에 마커 바이트를 두고, 32바이트 소비 후 정확히 마커
+    위치에 커서가 도달하는지 확인. 수정 전 코드로 되돌려 실행하면
+    `left: 605, right: 621`로 16바이트 차이가 나며 실패하는 것을 확인했다(red).
+    수정 후에는 통과한다(green).
+
+## 4. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib hypertext_bookmark_underread_tests`
+  (수정 전 코드로 되돌려 재실행 시 실패 확인 → red→green 검증 완료)
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021 src/parser/hwp3/drawing.rs` (변경된 파일만 대상, 이후
+  `git diff --name-only` 결과 해당 파일만 존재)
+
+## 5. 그 외 분기에 대한 결론
+
+Line(1), Rectangle(2), Ellipse(3), Arc(4), Polygon(5), TextBox(6), Curve(7),
+ModifiedEllipse(8), ExtendedCurve(10), ClosedPolygon(11) 분기와 공통 헤더 하위
+속성 리더는 모두 스펙과 바이트 단위로 일치하여 추가 수정이 필요하지 않았다.

--- a/mydocs/report/task_m100_2995_report.md
+++ b/mydocs/report/task_m100_2995_report.md
@@ -1,0 +1,70 @@
+# Task m100-2995: HWP3 문단 테두리(has_border) 플래그 소실 수정
+
+## 배경
+
+`#2976`(`convert_para_shape()`의 `border_connection` 배선 누락, PR #2983)과 동일한 방법론을
+`Hwp3ParaShape`(`src/parser/hwp3/records.rs`)에 다시 적용했다. 즉 HWP3 바이너리 레코드를 읽어들인
+struct의 각 접근자가 공통 IR(`Document` 모델)까지 실제로 배선되는지, 아니면 struct에는 읽혔지만
+변환 지점에서 조용히 누락되는지를 필드 단위로 대조했다.
+
+`grep -rn "\.has_border()\|\.border_connection()" src/`로 확인한 결과 `border_connection()`은
+#2983에서 다루는 중이었고, `has_border()`(`src/parser/hwp3/records.rs` 392~394행)는 저장소 전체
+어디서도 호출되지 않고 있었다.
+
+## 발견한 결함
+
+`Hwp3ParaShape.border: u8`는 문단 테두리 on/off 플래그이고 `has_border()`가 이를 bool로 해석하는
+접근자다. 이 값을 소비할 수 있는 유일한 지점은 `src/parser/hwp3/mod.rs`의 `parse_paragraph_list()`
+안에서 `shade_ratio`(문단 음영) 값만 검사해 `BorderFill`을 만들고 `ps.border_fill_id`에 배선하는
+인라인 코드였는데, 이 블록이 `shade_ratio > 0`만 조건으로 삼고 `has_border()`는 전혀 참조하지
+않았다. 결과적으로 음영 없이 테두리만 켜진 문단(`border == 1`, `shade_ratio == 0`)은
+`border_fill_id`가 끝까지 0으로 남아 테두리 정보가 항상 소실됐다.
+
+이슈 [#2995](https://github.com/edwardkim/rhwp/issues/2995)로 등록했다.
+
+## 영향
+
+HWP3(.hwp) 문서에서 문단에 음영 없이 테두리만 지정한 경우(강조 박스, 예시/정답 구획 등 옛 한글
+문서에서 흔한 패턴), rhwp 파싱 결과 및 이를 HWPX로 재저장한 결과에서 해당 테두리가 항상 사라진다.
+
+## 수정 내용
+
+`src/parser/hwp3/mod.rs`에 순수 함수 `hwp3_para_shape_border_fill()`을 추가해 기존 shade 전용
+인라인 로직을 이 함수로 옮기고, `shade_ratio > 0 || has_border()` 조건으로 확장했다.
+`has_border()`가 true면 `BorderFill.borders`의 4방향(좌/우/상/하)을 `BorderLineType::Solid`로
+설정한다. HWP3 `Hwp3ParaShape`에는 선 굵기·색상 필드가 없어(`border: u8` 단일 on/off 플래그) 두께·
+색은 `BorderLine`의 기본값을 그대로 사용했다. `parse_paragraph_list()`의 호출부는 아래처럼
+단순화됐다.
+
+```rust
+if let Some(bf) = hwp3_para_shape_border_fill(hwp3_ps) {
+    doc_border_fills.push(bf);
+    ps.border_fill_id = doc_border_fills.len() as u16; // 1-based (렌더러 규칙)
+}
+```
+
+기존에 이미 존재하던 `has_border()` 접근자를 호출해 이미 확립된 `border_fill_id` 배선 경로에
+맞춰 넣는 최소 수정이며, `convert_char_shape()`(#2521)·`convert_para_shape()`(#2976)와 같은
+"접근자는 있지만 호출되지 않음" 패턴이다.
+
+## 테스트 (red → green)
+
+`src/parser/hwp3/mod.rs`의 `tests` 모듈에
+`test_hwp3_para_shape_border_fill_wires_has_border_flag`를 추가했다.
+
+- **Red (수정 전)**: `Hwp3ParaShape { border: 1, shade_ratio: 0, .. }`을
+  `hwp3_para_shape_border_fill()`에 넣으면 (수정 전 로직 기준으로는) `None`이 반환되어
+  `.expect("border_fill 이 생성되어야 함")`가 패닉했다.
+- **Green (수정 후)**: 동일 입력에 대해 `Some(BorderFill)`이 반환되고, 4방향 테두리선의
+  `line_type`이 모두 `BorderLineType::Solid`로 세팅되어 통과한다.
+
+```
+cargo test --lib hwp3_para_shape_border_fill
+running 1 test
+test parser::hwp3::tests::test_hwp3_para_shape_border_fill_wires_has_border_flag ... ok
+```
+
+## 검증
+
+- `cargo check --lib` 통과.
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` 적용.

--- a/src/parser/hwp3/drawing.rs
+++ b/src/parser/hwp3/drawing.rs
@@ -40,7 +40,7 @@ impl Hwp3DrawingObjectFrameHeader {
 pub struct Hwp3DrawingObjectHypertextInfo {
     pub length: u32,
     pub jump_file_name: String, // 256 kchar
-    pub jump_bookmark: String,  // 16 hchar (보통 32 바이트지만 문서에 따라 16 바이트로 처리)
+    pub jump_bookmark: String,  // 16 hchar = 32 바이트 (스펙 8.3절 표 21, 오프셋 264→296)
     pub macro_data: Vec<u8>,    // 325 바이트
     pub kind: u8,
     pub reserved: [u8; 3],
@@ -53,7 +53,11 @@ impl Hwp3DrawingObjectHypertextInfo {
         reader.read_exact(&mut jump_file_name_buf)?;
         let jump_file_name = decode_hwp3_string(&jump_file_name_buf);
 
-        let mut jump_bookmark_buf = [0u8; 16]; // 문서에는 16 hchar(32바이트)로 명시되어 있으나, 오프셋 계산상 16바이트로 처리함
+        // [Task #2831] 스펙 8.3절 표 21은 "건너뛸 책갈피"를 hchar array[16]로 명시하며
+        // (hchar=2바이트), 표의 절대 오프셋(264→296)과 전체 길이 공식(617 =
+        // 256+32+325+1+3)이 모두 32바이트를 요구한다. 16바이트만 읽으면 이후
+        // 그리기 개체 레코드 전체가 16바이트씩 밀려 파싱된다.
+        let mut jump_bookmark_buf = [0u8; 32];
         reader.read_exact(&mut jump_bookmark_buf)?;
         let jump_bookmark = decode_hwp3_string(&jump_bookmark_buf);
 
@@ -933,6 +937,42 @@ mod modified_arc_overread_tests {
             cursor.position(),
             common_header_len,
             "ModifiedArc 파싱이 공통 헤더 이후 존재하지 않는 바이트를 소비함"
+        );
+    }
+}
+
+#[cfg(test)]
+mod hypertext_bookmark_underread_tests {
+    use super::*;
+    use std::io::Cursor;
+
+    // [Task #2831] 스펙 8.3절 표 21에 따라 "건너뛸 책갈피"는 hchar array[16] = 32바이트다.
+    // 수정 전 코드는 16바이트만 읽어, 뒤따르는 필드(매크로/종류/예약)의 선두를
+    // 책갈피의 나머지 절반으로 오인하고 읽어버렸다. 32바이트 전체를 소비한 뒤
+    // 정확히 마커 위치에 도달하는지 확인한다.
+    #[test]
+    fn hypertext_info_consumes_full_32_byte_bookmark() {
+        let mut buf = Vec::new();
+        buf.extend_from_slice(&621u32.to_le_bytes()); // length
+        buf.extend_from_slice(&[0u8; 256]); // jump_file_name
+        buf.extend_from_slice(&[0u8; 32]); // jump_bookmark (32바이트 전체)
+        buf.extend_from_slice(&[0u8; 325]); // macro_data
+        buf.push(0u8); // kind
+        buf.extend_from_slice(&[0u8; 3]); // reserved
+        let hypertext_len = buf.len() as u64;
+
+        // 다음 필드라고 가정한 마커. 수정 전 코드는 이 마커의 앞부분을
+        // 책갈피 뒷부분으로 잘못 소비한다.
+        buf.extend_from_slice(&0xCCCCCCCCu32.to_le_bytes());
+
+        let mut cursor = Cursor::new(buf);
+        let _info =
+            Hwp3DrawingObjectHypertextInfo::read(&mut cursor).expect("parse hypertext info");
+
+        assert_eq!(
+            cursor.position(),
+            hypertext_len,
+            "하이퍼텍스트 정보 파싱이 책갈피 필드를 32바이트로 소비하지 않음"
         );
     }
 }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -391,6 +391,34 @@ pub(crate) fn convert_para_shape(
     ps
 }
 
+// [#2986] HWP3 ParaShape.border(has_border()) 플래그가 shade_ratio 처럼 border_fill_id로
+// 배선되지 않아, 문단 테두리가 켜져 있어도(음영 없이) 항상 소실되던 결함 수정.
+fn hwp3_para_shape_border_fill(
+    hwp3_ps: &crate::parser::hwp3::records::Hwp3ParaShape,
+) -> Option<crate::model::style::BorderFill> {
+    if hwp3_ps.shade_ratio == 0 && !hwp3_ps.has_border() {
+        return None;
+    }
+    let mut bf = crate::model::style::BorderFill::default();
+    if hwp3_ps.shade_ratio > 0 {
+        let ratio = hwp3_ps.shade_ratio.min(100) as u32;
+        let gray = (255 * (100 - ratio) / 100) as u8;
+        let color = u32::from_le_bytes([gray, gray, gray, 0]);
+        bf.fill.fill_type = crate::model::style::FillType::Solid;
+        bf.fill.solid = Some(crate::model::style::SolidFill {
+            background_color: color,
+            pattern_color: 0,
+            pattern_type: 0,
+        });
+    }
+    if hwp3_ps.has_border() {
+        for b in bf.borders.iter_mut() {
+            b.line_type = crate::model::style::BorderLineType::Solid;
+        }
+    }
+    Some(bf)
+}
+
 fn hwp3_para_line_box(
     para_shape: Option<&crate::model::style::ParaShape>,
     column_width_hu: i32,
@@ -2070,17 +2098,7 @@ pub(crate) fn parse_paragraph_list(
         if para_info.follow_prev_para_shape == 0 {
             if let Some(ref hwp3_ps) = para_info.para_shape {
                 let mut ps = convert_para_shape(hwp3_ps, doc_tab_defs);
-                if hwp3_ps.shade_ratio > 0 {
-                    let ratio = hwp3_ps.shade_ratio.min(100) as u32;
-                    let gray = (255 * (100 - ratio) / 100) as u8;
-                    let color = u32::from_le_bytes([gray, gray, gray, 0]);
-                    let mut bf = crate::model::style::BorderFill::default();
-                    bf.fill.fill_type = crate::model::style::FillType::Solid;
-                    bf.fill.solid = Some(crate::model::style::SolidFill {
-                        background_color: color,
-                        pattern_color: 0,
-                        pattern_type: 0,
-                    });
+                if let Some(bf) = hwp3_para_shape_border_fill(hwp3_ps) {
                     doc_border_fills.push(bf);
                     ps.border_fill_id = doc_border_fills.len() as u16; // 1-based (렌더러 규칙)
                 }
@@ -4037,6 +4055,19 @@ mod tests {
         assert_eq!(hwp3_footnote_separator_length(1, 9000), 3000); // 본문 폭의 1/3
         assert_eq!(hwp3_footnote_separator_length(2, 9000), 9000); // 단 너비
         assert_eq!(hwp3_footnote_separator_length(3, 9000), 0); // 없음
+    }
+
+    #[test]
+    fn test_hwp3_para_shape_border_fill_wires_has_border_flag() {
+        // [#2986] border=1, shade_ratio=0 인 경우에도 border_fill 이 생성되고
+        // 4방향 테두리선이 Solid 로 설정되어야 한다 (기존에는 None 이 반환되어 소실됨).
+        let mut hwp3_ps = crate::parser::hwp3::records::Hwp3ParaShape::default();
+        hwp3_ps.border = 1;
+        let bf = hwp3_para_shape_border_fill(&hwp3_ps).expect("border_fill 이 생성되어야 함");
+        assert!(bf
+            .borders
+            .iter()
+            .all(|b| b.line_type == crate::model::style::BorderLineType::Solid));
     }
 
     #[test]

--- a/src/wmf/parser/objects/structure/device_independent_bitmap.rs
+++ b/src/wmf/parser/objects/structure/device_independent_bitmap.rs
@@ -197,6 +197,12 @@ impl Colors {
         colors_length: usize,
         core: bool,
     ) -> Result<(Self, usize), crate::wmf::parser::ParseError> {
+        // colors_length는 BITMAPINFOHEADER의 colors_used(검증되지 않은 u32)에서
+        // 온다. 색상표가 존재하는 비트 심도(<=8bpp)에서 사양상 최대 항목 수는
+        // 2^8=256이므로 이를 상한으로 둔다. 상한이 없으면 Vec::with_capacity가
+        // 거대한 값을 그대로 예약해 OOM abort로 이어진다 (doc_info.rs tab_count,
+        // emf parse_points16 #2992와 동일한 클래스).
+        let colors_length = colors_length.min(256);
         let mut consumed_bytes: usize = 0;
 
         match color_usage {
@@ -275,5 +281,27 @@ impl core::fmt::Debug for BitmapBuffer {
             )
             .field("a_data", &format!("[u8; {}]", self.a_data.len()))
             .finish()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// colors_length가 BITMAPINFOHEADER의 검증되지 않은 colors_used(u32)에서
+    /// 그대로 오는 경우, 거대한 값(u32::MAX)을 넘겨도 Vec::with_capacity가
+    /// 그 값을 그대로 예약하지 않고(256 상한) 데이터 부족으로 정상적으로
+    /// 에러를 반환해야 한다 (OOM abort 없이 graceful degradation).
+    #[test]
+    fn parse_from_color_usage_bounds_huge_colors_length() {
+        let mut data: &[u8] = &[0u8; 4]; // RGBQuad 1개 분량도 안 되는 소량 데이터
+        let result = Colors::parse_from_color_usage(
+            &mut data,
+            crate::wmf::parser::ColorUsage::DIB_RGB_COLORS,
+            u32::MAX as usize,
+            false,
+        );
+
+        assert!(result.is_err());
     }
 }


### PR DESCRIPTION
kevin9327 님의 오늘 범위(#2762~#3030) 배치 E — HWP3 파서 2건 + WMF 1건을 메인테이너가 재실증 후 통합한다.

## 채택 3건

| PR | 결함 |
|---|---|
| #2836 (`Closes #2831`) | HWP3 하이퍼텍스트 정보의 "건너뛸 책갈피" 필드를 16바이트만 읽음 — 스펙 8.3절 표 21 은 hchar array[16] = 32바이트. 뒤따르는 매크로/종류/예약 필드 선두를 오소비 |
| #2997 (`Closes #2995`) | 문단 테두리 has_border 가 음영 없을 때(border=1, shade_ratio=0) border_fill 이 None 으로 반환되어 소실 |
| #3002 (`Closes #3000`) | WMF DIB 색상표 colors_used(u32) 미검증 값이 `Vec::with_capacity` 에 상한 없이 전달 — 조작 파일로 과대 할당 유발 가능 |

## 충돌 해소

#2836 · #2997 은 어제 merge 된 hwp3 통합(#3083)의 테스트 모듈과 같은 자리를 두고 겹친 병치 — 양쪽 테스트를 완전한 형태로 모두 유지했다. HWP3 전용 해석은 `src/parser/hwp3/` 안에서 종결되며 렌더러·문서 코어에 HWP3 분기를 추가하지 않는다.

## 검증

- `cargo fmt --check` 통과, 전체 `--tests` 스위트 무실패
- 신규 테스트 7건(32바이트 소비·has_border 배선·colors_used 상한 등) 표적 통과

Co-authored-by 로 원 커밋 provenance 를 보존한다.
