### PR TITLE
docs(orders): 07-23 기록의 merge 방식 서술 정정

### DIFF
--- a/mydocs/orders/20260723.md
+++ b/mydocs/orders/20260723.md
@@ -15,8 +15,13 @@
 
 - 전 배치 공통 절차: devel 에서 브랜치 → 오래된 순 `cherry-pick -x`(provenance 보존) →
   건별 BEFORE/AFTER 커밋 해시로 반영 검증 → 게이트(fmt / clippy / 전체 `--tests`
-  release-test) → 승인 → squash merge(`Co-authored-by: kevin9327`) → 원 PR 크레딧
-  코멘트+close → 연결 이슈 close 확인 → devel 동기화.
+  release-test) → 승인 → merge → 원 PR 크레딧 코멘트+close → 연결 이슈 close 확인 →
+  devel 동기화.
+- **merge 방식 정정(07-24)**: A·B 는 메인테이너가 squash merge(`Co-authored-by:
+  kevin9327`) 했으나, C·D·E 는 CI green 직후 jangster77 님이 merge commit 방식으로
+  처리해 kevin9327 원 커밋이 authorship 그대로 devel 에 들어갔다. 내용은 검증본과
+  동일하며 provenance 는 오히려 커밋 단위로 보존됐다. 당초 이 문서가 "squash" 로
+  일괄 서술했던 것을 바로잡는다.
 - 연결 이슈 21건 종결: #2751 #2755 #2784 #2825 #2831 #2835 #2843 #2853 #2875
   #2878 #2880 #2887 #2895 #2912 #2941 #2946 #2995 #3000 #3011 #3022 #3028.
 


### PR DESCRIPTION
어제 오늘할일 문서가 배치 5건 전부를 squash merge 로 서술했으나, 실제로는 C(#3199)·D(#3200)·E(#3201)를 jangster77 님이 merge commit 방식으로 처리했다. 사실대로 정정한다. 문서만 변경.