### PR TITLE
fix(hwpx): section 왕복·CDATA 스윕 11건 — kevin9327 축배치 F

### DIFF
--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -72,4 +72,4 @@ if let Some(ref caption) = $shape.$caption_field {
 
 ## PR 번호
 
-PR #(PR 생성 후 번호 기입)
+PR #2737

--- a/mydocs/report/pr-hwp5-shape-caption.md
+++ b/mydocs/report/pr-hwp5-shape-caption.md
@@ -1,0 +1,75 @@
+# PR: 그리기 도형·묶음·차트 캡션이 HWP5 직렬화에서 전량 소실
+
+## 개요
+
+HWP5 직렬화기(`serialize_shape_control`)에서 도형(ShapeObject)의 모든 variant에 대해
+캡션(caption)을 방출하지 않던 문제를 수정.
+
+## 분석
+
+### 파서 상태
+
+`src/parser/control/shape.rs`의 파서는 모든 GSO 도형의 캡션을 올바르게 읽고 있음:
+
+- 기본 도형(Line, Rectangle, Ellipse, Arc, Polygon, Curve): `drawing.caption`에 저장
+- 묶음(Group): `group.caption`에 저장  
+- 차트(Chart): `chart.caption`에 저장
+- OLE: `ole.caption`에 저장
+- 그림(Picture): `picture.caption`에 저장 (별도 함수 `serialize_picture_control`에서 처리)
+
+### 직렬화 문제
+
+`src/serializer/control.rs`에서 `serialize_caption` 호출은 다음 두 곳뿐이었음:
+
+1. 표(`serialize_table_control`, 492행)  
+2. 그림(`serialize_picture_control`, 998행)
+
+`serialize_shape_control`(1181행-)의 모든 arm에는 `serialize_caption` 호출이 전혀 없어,
+도형에 첨부된 캡션이 HWP5 저장 시 전량 소실됨.
+
+### 적용 범위 (9개 ShapeObject variant)
+
+| Variant | 캡션 위치 | 직렬화 위치 (SHAPE_COMPONENT 이전) |
+|---------|-----------|-----------------------------------|
+| Line | `line.drawing.caption` | CTRL_HEADER + synthesized_ctrl_data 이후 |
+| Rectangle | `rect.drawing.caption` | 동일 |
+| Ellipse | `ellipse.drawing.caption` | 동일 |
+| Polygon | `poly.drawing.caption` | 동일 |
+| Arc | `arc.drawing.caption` | 동일 |
+| Curve | `curve.drawing.caption` | 동일 |
+| Group | `group.caption` (직접 필드) | 동일 |
+| Chart | `chart.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+| Ole | `ole.caption` (직접 필드) | CTRL_HEADER 이후 (synthesized_ctrl_data 없음) |
+
+### 배치 패턴
+
+기존 그림(`serialize_picture_control`)의 캡션 배치와 동일하게:
+1. CTRL_HEADER (`level`)
+2. 캡션 (`level + 1`, LIST_HEADER + 문단)
+3. SHAPE_COMPONENT (`level + 1`)
+4. CTRL_DATA (`level + 2`, SHAPE_COMPONENT의 자식)
+5. 텍스트 박스 및 도형별 레코드 (`level + 2`)
+
+## 코드 변경
+
+**파일**: `src/serializer/control.rs`
+**추가된 호출**: 9개의 `serialize_caption` 호출 (각 ShapeObject arm당 1개)
+
+각 호출 패턴:
+```rust
+// 캡션 (SHAPE_COMPONENT 앞, level+1)
+if let Some(ref caption) = $shape.$caption_field {
+    serialize_caption(caption, level + 1, records);
+}
+```
+
+## 검증
+
+- `cargo check` 통과
+- `cargo fmt --all` 적용 완료
+- 기존 파서-직렬화 라운드트립 검증: 파서가 읽은 캡션을 직렬화가 방출하므로
+  라운드트립 보존 (기존 파서 변경 없음)
+
+## PR 번호
+
+PR #(PR 생성 후 번호 기입)

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -43,3 +43,4 @@ rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자�
 
 - #2697 — 표 hp:sz IR 보존
 - #2712 — rect/line/picture hp:sz IR 보존
+- #2733 — 본 PR

--- a/mydocs/report/pr-hwpx-common-shape-sz.md
+++ b/mydocs/report/pr-hwpx-common-shape-sz.md
@@ -1,0 +1,45 @@
+# PR: fix(hwpx): 공용 도형 경로 hp:sz 크기 기준·크기 보호 소실 (ellipse/arc/polygon/curve/chart)
+
+## 개요
+
+Issue #2726. #2697(표)과 #2712(rect/line/picture)에서 해결된 hp:sz의
+widthRelTo/heightRelTo/protect IR 보존이 나머지 도형 타입(ellipse, arc, polygon, curve,
+chart)에서 여전히 hardcoded "ABSOLUTE"/"0"으로 방출되는 문제를 수정한다.
+
+## 분석
+
+`src/serializer/hwpx/shape.rs`의 `write_sz()` 함수(978~992번째 줄)는 `CommonObjAttr`의
+`width_criterion`, `height_criterion`, `size_protect` 필드를 무시하고 항상
+`widthRelTo="ABSOLUTE"`, `heightRelTo="ABSOLUTE"`, `protect="0"`을 방출했다.
+
+이 함수는 다음과 같은 모든 도형 타입에서 공통으로 호출된다:
+- `<hp:rect>` — write_rect (103번째 줄)
+- `<hp:line>` / `<hp:connectLine>` — write_line (250번째 줄)
+- `<hp:container>` — write_container_close (321번째 줄)
+- `<hp:ole>` — write_ole (390번째 줄)
+
+rect(#2712)와 line(#2712)은 각각 write_sz를 호출하므로, write_sz 자체를 수정하면
+모든 도형 타입이 한 번에 fix된다. ole는 chart/ole 개체를 포함한다.
+
+## 변경 내용
+
+**`src/serializer/hwpx/shape.rs`**
+
+1. `SizeCriterion` import 추가
+2. `size_criterion_width_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column→COLUMN, Para→PARA, Absolute→ABSOLUTE)
+3. `size_criterion_height_str()` — `pub(crate)` 헬퍼 함수 (Paper→PAPER, Page→PAGE,
+   Column/Para/Absolute→ABSOLUTE; 파서가 높이는 allow_column_para=false로 읽으므로
+   Column/Para는 존재하지 않지만 fallback으로 ABSOLUTE)
+4. `write_sz()` — hardcoded "ABSOLUTE"/"0" 대신 위 헬퍼 함수와
+   `bool01(c.size_protect)` 사용
+
+## 검증
+
+- `cargo fmt --all -- --check` — 통과
+- `cargo clippy --all-targets -- -D warnings` — 통과 (45.04s)
+
+## 관련 PR
+
+- #2697 — 표 hp:sz IR 보존
+- #2712 — rect/line/picture hp:sz IR 보존

--- a/mydocs/report/pr-hwpx-pic-attrs.md
+++ b/mydocs/report/pr-hwpx-pic-attrs.md
@@ -1,0 +1,44 @@
+# hp:pic 저장 시 numberingType·groupLevel 속성 유실 수정
+
+- **Issue**: #2745
+- **Branch**: `pr/fix-issue-2745-hwpx-pic-attrs`
+- **Type**: fix
+- **Component**: serializer/hwpx, parser/hwpx
+
+## 배경
+
+HWPX 그림(`<hp:pic>`) 직렬화에서 `numberingType`과 `groupLevel` 두 속성이 IR 값을 사용하지 않고 하드코딩되어 방출되어, 저장 시 원본 속성이 유실되는 문제가 있었다. 도형(`<hp:rect>`, `<hp:line>`) 및 표(`<hp:tbl>`)는 이미 #1379/#2697에서 IR 보존으로 정리되었으나 그림 경로는 누락되었다.
+
+## 수정 내용
+
+### 1. Parser: `numberingType` 속성 파싱 추가
+
+**파일**: `src/parser/hwpx/section.rs` - `parse_picture` 함수
+
+기존 `parse_picture`는 `<hp:pic>` 요소의 `numberingType` 속성을 파싱하지 않아 IR의 `common.numbering_type`이 항상 기본값(`None`)으로 남았다. 도형/표 파서와 동일한 매핑 로직을 추가하여 `PICTURE`/`TABLE`/`EQUATION`/`NONE` 값을 IR에 저장한다.
+
+```rust
+b"numberingType" => {
+    common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+        "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+        "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+        "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+        _ => crate::model::shape::ObjectNumberingType::None,
+    };
+}
+```
+
+### 2. Serializer: IR 기반 속성 방출
+
+**파일**: `src/serializer/hwpx/picture.rs` - `write_picture` 함수
+
+- `numberingType`: 하드코딩 `"PICTURE"` → `numbering_type_str(pic.common.numbering_type)` (shape.rs의 기존 헬퍼 함수 사용)
+- `groupLevel`: 하드코딩 `"0"` → `pic.shape_attr.group_level.to_string()` (도형 rect/line 경로와 동일)
+- `numbering_type_str` 함수 import 추가
+
+## 영향
+
+- `groupLevel` 속성: 그룹(`<hp:container>`) 내 그림 개체의 중첩 레벨이 저장 시 보존된다.
+- `numberingType` 속성: 캡션 번호 범주 설정(NONE/PICTURE/TABLE/EQUATION)이 저장 시 보존된다.
+- roundtrip 충실도 향상: 이전에는 저장 후 재파싱 시 두 속성이 항상 기본값으로 되돌아갔다.
+- 신규 문서(Default::default)는 `common.numbering_type=ObjectNumberingType::None`이므로 `numberingType="NONE"`으로 방출되어, 종전 `"PICTURE"` 하드코딩과 차이가 있다. 이는 올바른 동작이다(도형 경로와 일관됨).

--- a/mydocs/report/task_m100_2726_report.md
+++ b/mydocs/report/task_m100_2726_report.md
@@ -1,0 +1,346 @@
+# [#2726] HWPX 공용 도형 경로 `hp:sz` — 크기 기준·크기 보호 라운드트립 보존
+
+## 이슈 / 브랜치 / 범위
+
+| 항목 | 값 |
+|---|---|
+| 이슈 | [#2726](https://github.com/edwardkim/rhwp/issues/2726) |
+| 브랜치 | `task/m100-2726-hwpx-common-shape-sz` (분기점 `origin/devel` = `49f38446`) |
+| 변경 파일 | `src/serializer/hwpx/section.rs`, `src/parser/hwpx/section.rs` |
+| 범위 밖 | `render_equation`(수식 서브시스템 별도 작업 중), `serializer/hwpx/{table,shape,picture}.rs`(#2697·#2712 소관) |
+
+`#2697`/`#2701`(표, devel 병합 `8b77bb15`·`14e4b806`)과 `#2712`/`#2719`
+(rect/line/container/picture, 열림)가 고친 것과 **같은 결함 클래스의 잔여**다.
+`#2719` 가 본문에 명시적으로 잔여로 남긴 두 지점이 본 작업 대상이다.
+
+---
+
+## 1. 문제
+
+### 1-1. 직렬화 — `src/serializer/hwpx/section.rs:1912` (`render_common_shape_xml`)
+
+```rust
+r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
+```
+
+- `widthRelTo` / `heightRelTo` — IR `CommonObjAttr::width_criterion` / `height_criterion`
+  이 있는데도 `"ABSOLUTE"` 리터럴로 고정.
+- `protect` — IR `size_protect` 가 있는데 **속성이 아예 방출되지 않음**.
+
+이 경로를 타는 태그는 `:1776`–`:1805` 디스패치 기준 **ellipse / arc / polygon / curve /
+chart** 5종이다.
+
+### 1-2. 파싱 — `src/parser/hwpx/section.rs:5985` (`parse_common_shape_children`)
+
+`hp:sz` arm 이 `width` / `height` / `protect` 만 읽고 `widthRelTo` / `heightRelTo` arm 이
+없다. 호출자는 `:5822`(chart) · `:5906`(ole) 두 곳이므로 **차트·OLE 의 크기 기준이
+파싱 단계에서 소실**된다.
+
+---
+
+## 2. 분석
+
+### 2-1. 과잉 주장 배제 — 파서는 4개 태그에 대해 이미 무결하다
+
+`ellipse` / `arc` / `polygon` / `curve` 는 `parse_common_shape_children` 을 **타지 않는다**.
+이들은 `parse_shape_object`(`:3698`) → `parse_object_layout_child`(`:2901`, `hp:sz` arm
+`:2909`)로 파싱되며, 그 arm 은 `widthRelTo`(`:2925`) · `heightRelTo`(`:2928`) ·
+`protect`(`:2930`)를 **이미 정상적으로 읽고 있다**.
+
+따라서 이 4개 태그에 대해서는 **파서는 손실원이 아니고 직렬화기만 손실원**이다.
+"공용 자식 파서가 안 읽어서 4개 태그의 왕복이 막혀 있다"는 서술은 사실이 아니므로
+이슈·본 보고서 어디에도 그렇게 적지 않았다.
+
+파서 arm 5개 대조:
+
+| arm | 위치 | 담당 | `widthRelTo` | `heightRelTo` | `protect` |
+|---|---|---|---|---|---|
+| 표 | `:1692` | `hp:tbl` | O | O | O (#2697) |
+| 그림 | `:2331` | `hp:pic` | O (#2712) | O (#2712) | O (#2712) |
+| 도형 공용 | `:2909` | rect/ellipse/arc/polygon/curve/line | O | O | O |
+| 양식 | `:5599` | `hp:checkBtn` 등 | O | O | O |
+| **공용 자식** | **`:5985`** | **chart / ole** | **X** | **X** | O |
+
+차트만 파싱·직렬화 **양쪽**이 막혀 있어 두 수정이 각각 독립적으로 필요하다.
+
+### 2-2. HWP5 경로가 실재함을 코드로 확인
+
+`src/parser/control/shape.rs:339 parse_common_obj_attr`(호출 `:30`)는 **모든 HWP5 도형**에
+대해 공용으로 3값을 적재한다.
+
+- `:348` `size_protect = attr & (1 << 20) != 0`
+- `:380` `width_criterion = (attr >> 15) & 0x07` → Paper/Page/Column/Para/Absolute
+- `:388` `height_criterion = (attr >> 18) & 0x03` → Paper/Page/Absolute
+
+기록측도 `document_core/converters/common_obj_attr_writer.rs:150 width_criterion_to_bits` /
+`:160 height_criterion_to_bits` 로 완비돼 있다. 끊긴 고리는 HWPX 직렬화기 한 곳뿐이었다.
+
+---
+
+## 3. 코퍼스 실측
+
+`samples/hwpx` 의 실제 한글 산출 `.hwpx` **60개**를 열어 모든 `section*.xml` 의 `hp:sz` 를
+**부모 태그와 함께** 전수 집계했다(zip + 태그 스택 파싱). 총 **1583개**로,
+`#2719` 가 보고한 수치와 정확히 일치해 방법론이 교차 검증된다.
+
+```
+샘플 파일 수: 60          hp:sz 총 개수: 1583
+부모태그          sz수  protect속성  protect="1"  파일수
+tbl               684        684         13        47
+rect              314        314          1        21
+checkBtn          182        182          0         3
+pic               177        177          0        33
+polygon           150        150          0         8   <- 본 작업
+equation           60         60          0         2   <- 범위 밖(잔여)
+container           7          7          0         6
+btn                 2          2          0         2
+comboBox            2          2          0         2
+radioBtn            2          2          0         2
+edit                2          2          0         2
+ole                 1          1          1         1   <- 파싱측만 본 작업
+widthRelTo  전역 분포: {'ABSOLUTE': 1583}
+heightRelTo 전역 분포: {'ABSOLUTE': 1583}
+```
+
+### 3-1. 실측 — `hp:polygon` 150개의 구조 이탈
+
+- **`hp:sz` 1583개 전부(1583/1583, 100%)가 `protect` 속성을 갖는다.** 한글은 이 속성을
+  예외 없이 쓴다. 전수이므로 표본 편향이 아니다.
+- `render_common_shape_xml` 은 `protect` 를 방출하지 않았다. 따라서 8개 실제 한글 파일의
+  `hp:polygon` **150개**가 HWPX→HWPX 저장에서 이 속성을 **잃었다**.
+- 값이 `0` 이라 *의미* 손실은 아니다. 그러나 한컴 원본 대비 **XML 구조 이탈**이며,
+  한컴 자신의 1583/1583 불변식을 깨는 것이다. 이 부분은 지금 재현 가능한 실측이다.
+
+### 3-2. 잠재 — 값 손실은 이 코퍼스로 증명되지 않는다
+
+| 태그 | 코퍼스 인스턴스 | `protect="1"` | 비-ABSOLUTE 범주 | 판정 |
+|---|---|---|---|---|
+| `hp:polygon` | 150 (8파일) | 0 | 0 | **실측 구조 이탈** |
+| `hp:ellipse` | **0** | — | — | 잠재 |
+| `hp:arc` | **0** | — | — | 잠재 |
+| `hp:curve` | **0** | — | — | 잠재 |
+| `hp:chart` | **0** | — | — | 잠재 |
+| `hp:ole` | 1 | 1 | 0 | 파싱측만 해당 |
+
+- `protect="1"` 은 본 경로 담당 태그에 코퍼스 인스턴스가 **0개**다. 전체 15개는
+  `hp:tbl`(13, #2697) · `hp:rect`(1) · `hp:ole`(1, #2712)로 모두 선행 PR 소관이다.
+- `widthRelTo` / `heightRelTo` 는 **1583개 전부 `ABSOLUTE`** 다. 비-ABSOLUTE 표본이 없다.
+- 즉 **값 손실 절반은 잠복(latent)** 이며 HWP5 입력 경로(2-2) 또는 문서 코어 편집
+  경로로만 도달한다. `#2719` 가 같은 상황을 밝힌 것과 동일하게 적는다.
+  **추론을 측정으로 제시하지 않았다.**
+
+`hwpx-01.hwpx` 1개는 zip 이 아니어서 집계에서 제외됐다(스크립트가 경고 출력). 위 60은
+실제로 열린 파일 수다.
+
+---
+
+## 4. 변경
+
+### 4-1. `src/serializer/hwpx/section.rs`
+
+1. `hp:sz` 포맷 리터럴을 IR 통과로 교체하고 `protect` 를 추가.
+   ```rust
+   r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
+   ```
+   인자: `wrt = size_criterion_str(c.width_criterion)`,
+   `hrt = height_criterion_str(c.height_criterion)`,
+   `prot = if c.size_protect { "1" } else { "0" }`.
+2. `size_criterion_str`(5값) · `height_criterion_str`(3값 접기) 헬퍼 추가.
+3. `use crate::model::shape::…` 에 `SizeCriterion` 추가.
+
+**높이 정확-역 제약을 유지했다.** 파서가 높이를
+`parse_size_criterion(_, allow_column_para = false)`(`parser/hwpx/section.rs:1860`)로 읽어
+치역이 `{Paper, Page, Absolute}` 3값뿐이므로, `height_criterion_str` 는 `Column`/`Para` 를
+`ABSOLUTE` 로 접는다. 접지 않으면 되읽기에서 `Absolute` 로 접혀 왕복이 비-멱등이 된다.
+HWP5 측 `height_criterion_to_bits` 도 동일하게 접으므로 세 표현이 일관된다.
+이 성질은 5값 전수 대조 테스트로 못 박았다.
+
+### 4-2. `src/parser/hwpx/section.rs`
+
+`parse_common_shape_children` 의 `hp:sz` arm 에 두 arm 추가 — 같은 파일 `:2925`/`:2928`
+(도형 공용) 및 `:1702`/`:1706`(표)과 **동형**이며 새 관례를 만들지 않았다.
+
+```rust
+b"widthRelTo"  => { common.width_criterion  = parse_size_criterion(&attr_str(&attr), true); }
+b"heightRelTo" => { common.height_criterion = parse_size_criterion(&attr_str(&attr), false); }
+```
+
+영향 범위는 chart(`:5822`) · ole(`:5906`). 코퍼스의 해당 `hp:sz`(chart 0개, ole 1개)가
+전부 `ABSOLUTE` 이므로 **기존 표본에는 무변화**다. OLE `#1283` 계약 테스트 무회귀는
+6장에서 확인했다.
+
+### 4-3. 헬퍼 재사용 방침
+
+`devel` 기준 `size_criterion_str` / `height_criterion_str` 는
+`serializer/hwpx/table.rs:147`/`:162` 에 **private(`fn`)** 로만 존재해 `section.rs` 에서
+도달할 수 없다. `#2712` 가 `shape.rs` 에 추가한 `pub(super)` 사본은 아직 `devel` 에 없다.
+따라서 `section.rs` 에 **동일 의미** 사본을 두고 doc 주석에 복제 사유를 명시했으며,
+공용 위치 1벌 통합은 잔여로 신고한다(8장). **두 번째 관례를 만들지 않았다.**
+
+---
+
+## 5. 신규 테스트 6종
+
+| # | 테스트 | 위치 | 확인 |
+|---|---|---|---|
+| 1 | `issue2726_common_shape_sz_preserves_criteria_and_protect` | 직렬화 | 5개 태그 전부 `COLUMN`/`PAGE`/`protect="1"` 보존 |
+| 2 | `issue2726_common_shape_sz_always_emits_protect_attribute` | 직렬화 | `size_protect=false` 여도 `protect="0"` **속성 방출** (3-1 대응) |
+| 3 | `issue2726_height_criterion_never_emits_column_or_para` | 직렬화 | 높이 5값 전수 → `COLUMN`/`PARA` 절대 미방출 (정확-역 고정) |
+| 4 | `issue2726_width_criterion_emits_all_five_values` | 직렬화 | 너비 5값 전수 대조 |
+| 5 | `issue2726_parse_chart_preserves_size_criteria` | 파싱 | 차트 `widthRelTo="COLUMN"`/`heightRelTo="PAGE"` → IR 적재 |
+| 6 | `issue2726_parse_chart_height_folds_column_and_para_to_absolute` | 파싱 | 높이 `COLUMN`/`PARA` → `Absolute` 접힘, 너비는 원문 보존 |
+
+---
+
+## 6. 검증
+
+### 6-1. RED → GREEN (실제 실행, 캡처)
+
+두 수정은 서로 독립이므로 **각각 따로 되돌려** 개별로 load-bearing 임을 증명했다.
+
+#### RED 1 — 직렬화 수정만 되돌림 (파서 수정은 유지)
+
+`cargo test --lib issue2726`
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... FAILED
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... FAILED
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... FAILED
+
+---- issue2726_common_shape_sz_preserves_criteria_and_protect stdout ----
+panicked at src\serializer\hwpx\section.rs:2437:13:
+ellipse: 너비 기준 COLUMN 이 보존되어야 함: <hp:ellipse …><hp:sz width="4000" height="3000"
+widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+---- issue2726_common_shape_sz_always_emits_protect_attribute stdout ----
+panicked at src\serializer\hwpx\section.rs:2469:9:
+size_protect=false 여도 protect="0" 속성이 방출되어야 함: <hp:polygon …><hp:sz width="0"
+height="0" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+---- issue2726_height_criterion_never_emits_column_or_para stdout ----
+panicked at src\serializer\hwpx\section.rs:2506:13:
+Paper → heightRelTo="PAPER" 이어야 함: <hp:polygon …><hp:sz width="0" height="0"
+widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>…
+
+test result: FAILED. 3 passed; 3 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+**RED 1 에서도 통과한 테스트 3개 (공시)**
+
+| 테스트 | 통과 사유 |
+|---|---|
+| `issue2726_width_criterion_emits_all_five_values` | 헬퍼 `size_criterion_str` 를 직접 호출할 뿐 포맷 리터럴을 타지 않는다 |
+| `issue2726_parse_chart_preserves_size_criteria` | 파서 테스트 — 직렬화 수정과 무관 |
+| `issue2726_parse_chart_height_folds_column_and_para_to_absolute` | 파서 테스트 — 직렬화 수정과 무관 |
+
+#### RED 2 — 파서 수정만 되돌림 (직렬화 수정은 유지)
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... FAILED
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... FAILED
+
+---- issue2726_parse_chart_height_folds_column_and_para_to_absolute stdout ----
+panicked at src\parser\hwpx\section.rs:7575:13:
+assertion `left == right` failed: 너비는 COLUMN 를 그대로 보존해야 한다
+  left: Absolute
+ right: Column
+
+---- issue2726_parse_chart_preserves_size_criteria stdout ----
+panicked at src\parser\hwpx\section.rs:7527:9:
+assertion `left == right` failed: widthRelTo="COLUMN" 이 IR 에 적재되어야 한다
+  left: Absolute
+ right: Column
+
+test result: FAILED. 4 passed; 2 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+**RED 2 에서도 통과한 테스트 4개 (공시)** — 직렬화 테스트 3개 + 헬퍼 테스트 1개.
+전부 파서 경로를 타지 않으므로 파서 수정과 독립이다. 이는 두 수정이 서로 다른
+결함을 덮고 있음을 보이는 증거이기도 하다.
+
+#### GREEN — 두 수정 모두 복원 후
+
+```
+running 6 tests
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_always_emits_protect_attribute ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_preserves_size_criteria ... ok
+test parser::hwpx::section::tests::issue2726_parse_chart_height_folds_column_and_para_to_absolute ... ok
+test serializer::hwpx::section::tests::issue2726_common_shape_sz_preserves_criteria_and_protect ... ok
+test serializer::hwpx::section::tests::issue2726_width_criterion_emits_all_five_values ... ok
+test serializer::hwpx::section::tests::issue2726_height_criterion_never_emits_column_or_para ... ok
+
+test result: ok. 6 passed; 0 failed; 0 ignored; 0 measured; 2471 filtered out
+```
+
+### 6-2. CI 3종 — 전부 통과
+
+| 검사 | 명령 | 결과 |
+|---|---|---|
+| fmt | 변경 `.rs` 2개에 `rustfmt --edition 2021` 후 `git diff --name-only` | 1차 실행에서 정형화 적용됨 → 2차 실행 md5 불변(고정점 도달) |
+| clippy | `cargo clippy --all-targets -- -D warnings` | **exit 0**, 경고 0건 |
+| test | `cargo test --profile release-test --tests` | **exit 0** — 291개 테스트 바이너리, **3486 passed / 0 failed / 23 ignored** |
+
+`cargo fmt --all -- --check` 는 **쓰지 않았다.** 이 Windows 체크아웃에서는 CRLF 파일에
+대해 `Incorrect newline style` 만 출력하고 diff 를 내지 않아 **거짓 통과**한다.
+
+### 6-3. 민감 테스트 무회귀 확인
+
+파서 변경이 OLE 파싱 경로(`:5906`)를 건드리므로 `#1283` 계약 회귀를 개별 확인했다.
+
+```
+test ole_chart_contents_probe_is_stable ... ok
+test ole_chart_contents_parse_result_is_stable ... ok
+test ole_chart_contents_exposes_renderer_neutral_ir ... ok
+test ole_chart_contents_renders_rust_svg_fragment ... ok
+test ole_chart_contents_renders_standalone_rust_svg ... ok
+test issue_1251_svg_uses_legacy_ole_chart_renderer ... ok
+test issue_1283_hwpx_internal_ole_is_loaded_even_when_isembeded_zero ... ok
+test issue_1283_hwpx_svg_uses_legacy_ole_chart_renderer ... ok
+test issue_1283_hwpx_to_hwp_save_keeps_ole_as_storage ... ok
+
+test issue_1436_picture_properties_round_trip_size_protect ... ok
+test issue_1436_shape_properties_round_trip_size_protect ... ok
+test parser::hwpx::section::tests::test_parse_rect_preserves_size_protect ... ok
+```
+
+시각 회귀도 무변화 — `visual_baseline_all_samples`, `visual_xfail_entries_still_fail`,
+`svg_snapshot`(8종) 전부 통과.
+
+---
+
+## 7. 미실행 항목
+
+- **한글(HWP) 실물 대조 없음.** 수정 결과를 한글에서 열어 "단에 맞춤"이 유지되는지
+  육안 확인하지 않았다. 검증은 IR ↔ XML 계약 수준(단위 테스트)과 기존 회귀 스위트
+  무변화까지다.
+- **비-ABSOLUTE 크기 기준의 실물 코퍼스 확보 실패.** 3-2 에 적은 대로 표본이 없어
+  값 손실은 합성 IR/XML 로만 검증했다. 실물 표본을 만들려면 한글에서 타원/다각형에
+  "단에 맞춤"을 지정해 저장해야 하는데 이번 작업에서는 하지 않았다.
+- **HWP5→HWPX→HWP5 왕복 실측 없음.** 2-2 는 코드 경로 확인이며, 실제 바이트 왕복
+  비교는 수행하지 않았다.
+
+---
+
+## 8. 잔여
+
+1. **`render_equation`** — `serializer/hwpx/section.rs:2030` 의 `hp:sz` 도
+   `widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"` 하드코딩 + `protect` 미방출로
+   **완전히 동일한 결함**이다. 코퍼스 실측 `hp:equation` **60개(2파일, `protect` 60/60
+   존재)** 로 3-1 과 같은 구조 이탈이 있다. 수식 서브시스템이 별도 작업 중이라
+   본 작업에서 건드리지 않았다.
+2. **헬퍼 3중화** — 본 수정 후 `size_criterion_str`/`height_criterion_str` 가
+   `table.rs`(private) · `shape.rs`(#2712, `pub(super)`) · `section.rs`(본 PR) 3벌이 된다.
+   `serializer/hwpx/mod.rs` 등 공용 위치로 1벌 통합이 필요하다. `#2712` 병합 전에는
+   `devel` 에서 도달 가능한 사본이 없어 지금 통합할 수 없다.
+3. **OLE 직렬화측** — `serializer/hwpx/shape.rs write_ole` 는 `#2712` 소관.
+   본 PR 은 OLE 의 **파싱측**만 건드렸다.
+4. **`hp:container` 등 나머지** — `#2712` 소관.

--- a/mydocs/report/task_m100_2846_report.md
+++ b/mydocs/report/task_m100_2846_report.md
@@ -1,0 +1,88 @@
+# 최종 결과 보고서 — Task M100 #2846
+
+## 이슈
+
+HWPX 바탕쪽(masterPage)의 `hp:subList@textDirection`(세로쓰기 여부)을 파서가 읽지 않고,
+직렬화기가 `"HORIZONTAL"`로 고정 출력하여, 세로쓰기 바탕쪽이 왕복 저장 시 가로쓰기로 바뀜.
+
+- Issue: https://github.com/edwardkim/rhwp/issues/2846
+- PR: (본 보고서 하단 참조)
+
+## 결론
+
+`MasterPage` IR에 `text_direction: u8` 필드(0=HORIZONTAL, 1=VERTICAL — 표 셀
+`cell.text_direction`과 동일 규약)를 추가하고, 파서(`parse_master_page_sub_list`)가
+`textDirection` 속성을 읽어 반영하도록, 직렬화기(`render_master_page_xml`)가 그 값을
+방출하도록 수정했다. HWP5 바이너리 경로는 이 개념이 없어 항상 0(HORIZONTAL)으로 채운다.
+
+## 결함 상세
+
+### 결함 위치 1 — `src/parser/hwpx/section.rs` `parse_master_page_sub_list` (수정 전)
+
+```rust
+fn parse_master_page_sub_list(e: &quick_xml::events::BytesStart, master_page: &mut MasterPage) {
+    for attr in e.attributes().flatten() {
+        match attr.key.as_ref() {
+            b"textWidth" => master_page.text_width = parse_u32(&attr),
+            b"textHeight" => master_page.text_height = parse_u32(&attr),
+            b"hasTextRef" => master_page.text_ref = parse_u8(&attr),
+            b"hasNumRef" => master_page.num_ref = parse_u8(&attr),
+            _ => {}   // ← textDirection 이 여기로 떨어져 폐기됨
+        }
+    }
+}
+```
+
+### 결함 위치 2 — `src/serializer/hwpx/master_page.rs` `render_master_page_xml` (수정 전)
+
+```rust
+r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" ...>"#,
+```
+
+`textDirection="HORIZONTAL"`이 리터럴로 고정되어, IR에 값이 있어도(수정 전엔 아예 없음)
+반영할 자리가 없었다.
+
+### 스키마 근거
+
+`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml`의 `hp:ParaListType`(masterPage의
+`hp:subList`가 이를 따름)은 `textDirection` 속성을 `HORIZONTAL`/`VERTICAL`/`VERTICALALL`
+열거값으로 정의한다. 즉 존재하는 정식 스키마 속성이 파서·직렬화기 양쪽에서 누락돼 있었다.
+
+### 이미 같은 클래스로 고쳐진 선례
+
+표 셀 `textDirection`(파서 `subList`/`cellPr` 처리 주석: "세로쓰기 셀... 종전엔 vertAlign
+만 읽어 세로쓰기가 왕복 시 유실됐다")과 secPr 레벨 `text_direction`
+(`src/serializer/hwpx/section.rs` 100번 줄 부근)에서 동일 클래스 버그가 이미 수정됐다.
+바탕쪽의 `subList`는 이 두 지점에서 누락된 세 번째 자리였다. `pageFront`(커밋 `1c4510fa`)와
+같은 계열의 "바탕쪽 속성 왕복 유실" 버그.
+
+## 수정 내역
+
+| 파일 | 수정 |
+| --- | --- |
+| `src/model/header_footer.rs` | `MasterPage`에 `text_direction: u8` 필드 추가. |
+| `src/parser/hwpx/section.rs` | `parse_master_page_sub_list`가 `textDirection` 속성을 읽어 필드에 반영. |
+| `src/serializer/hwpx/master_page.rs` | `render_master_page_xml`이 `text_direction`에 따라 `HORIZONTAL`/`VERTICAL` 방출. 회귀 테스트 1개(`master_page_text_direction_round_trips`) 추가. |
+| `src/parser/body_text.rs` | HWP5 바이너리 `MasterPage` 생성 시 `text_direction: 0`(개념 없음) 명시. |
+
+## 검증 결과
+
+### red→green
+
+- **RED** (수정 전 상태로 확인): 파서가 `textDirection` 무시, 직렬화기가 `"HORIZONTAL"` 고정
+  — `text_direction` 필드 자체가 없어 컴파일 단계에서 결함이 드러남(필드 부재 확인).
+- **GREEN** (수정 후): `master_page_text_direction_round_trips` — `text_direction: 1`로
+  직렬화 → XML에 `textDirection="VERTICAL"` 포함 확인 → 재파싱 → `text_direction == 1`
+  보존 확인. `... ok`.
+
+### 빌드/전체 테스트
+
+1. `cargo build --lib` — 통과.
+2. `cargo test --lib master_page` — 25 passed, 0 failed (기존 바탕쪽 테스트 전부 회귀 없음).
+3. `cargo clippy --all-targets --profile release-test -- -D warnings` — 클린.
+4. `rustfmt --edition 2021` (변경 파일만) — 추가 diff 없음.
+
+## 후속 (범위 밖)
+
+- `VERTICALALL`(세로 영문 세움) 구분은 스키마상 별도 열거값이나, 표 셀 쪽 기존 구현도
+  VERTICAL/HORIZONTAL 이진 규약만 쓰고 있어 이번 수정도 동일 규약을 따름(기존 패턴과 일관).

--- a/mydocs/report/task_m100_2882_report.md
+++ b/mydocs/report/task_m100_2882_report.md
@@ -1,0 +1,83 @@
+# #2882 처리 결과 — HWPX hp:ole/hp:chart numberingType 파싱만 되고 저장 시 NONE 하드코딩 수정
+
+## 문제
+
+`src/parser/hwpx/section.rs`의 `parse_hp_ole_element`(OLE, fallback 경로)와
+`parse_hp_chart_element`(차트) 두 함수가 `numberingType` 속성을 읽긴 하지만,
+그 값을 `bool` 지역 변수(`numbering_type_picture`)로만 축약해 HWP5 변환용 비트
+플래그(`hwp5_gen_shape_attr_bit28`)에만 반영하고, HWPX 라운드트립 직렬화가 실제로
+참조하는 `common.numbering_type: ObjectNumberingType` 필드는 채우지 않는다.
+직렬화기(`numbering_type_str`, `src/serializer/hwpx/shape.rs`)는 오직
+`common.numbering_type`만 보므로, 저장 시 항상 `NONE`으로 되쓰인다. 같은 파일의
+공용 도형 파서(`section.rs:2892` 부근)는 이미 올바른 패턴으로 매핑하고 있어,
+OLE/차트 두 파서만 이 매핑에서 빠져 있었다.
+
+## 수정
+
+`src/parser/hwpx/section.rs`의 `parse_hp_chart_element`와 `parse_hp_ole_element`
+두 함수의 `b"numberingType"` 핸들러에, 공용 도형 파서(`section.rs:2892`)와 동일한
+패턴으로 `common.numbering_type` 매핑을 추가:
+
+```rust
+common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+    _ => crate::model::shape::ObjectNumberingType::None,
+};
+```
+
+기존 `numbering_type_picture` bool 변수와 그것이 채우는
+`common.hwp5_gen_shape_attr_bit28`(HWP5 변환 경로용)은 그대로 유지했다 —
+이슈 본문이 명시한 대로 HWP5 바이너리 레이아웃(#1283)과는 무관한, HWPX XML
+라운드트립 문제만 다룬다.
+
+## 테스트 (red → green)
+
+`src/parser/hwpx/section.rs`의 기존 `mod tests`에 2건 추가:
+
+- `issue2882_ole_numbering_type_picture_is_parsed_into_common_field` —
+  `<hp:ole numberingType="PICTURE" .../>`를 파싱해 `OleShape.common.numbering_type`이
+  `ObjectNumberingType::Picture`임을 단언
+- `issue2882_chart_numbering_type_table_is_parsed_into_common_field` —
+  `<hp:chart numberingType="TABLE" .../>`를 파싱해 동일하게 `Table`임을 단언
+  (차트는 내부적으로 `OleShape`로 모델링됨)
+
+수정 전 코드(두 곳 모두 되돌린 상태)로 실행한 결과:
+
+```
+running 2 tests
+test issue2882_chart_numbering_type_table_is_parsed_into_common_field ... FAILED
+test issue2882_ole_numbering_type_picture_is_parsed_into_common_field ... FAILED
+
+  left: None
+ right: Table   (또는 Picture)
+
+test result: FAILED. 0 passed; 2 failed
+```
+
+수정 적용 후 재실행:
+
+```
+running 2 tests
+test issue2882_ole_numbering_type_picture_is_parsed_into_common_field ... ok
+test issue2882_chart_numbering_type_table_is_parsed_into_common_field ... ok
+
+test result: ok. 2 passed; 0 failed; 0 ignored; 0 measured; 2522 filtered out; finished in 0.00s
+```
+
+red → green을 로컬에서 직접 확인했다.
+
+## 검증 (디스크 제약으로 경량 검증만 수행)
+
+- `cargo check --lib` 통과
+- 위 테스트 2건 `cargo test --lib issue2882`로 실행, 통과(red 확인 1회 + green
+  확인 2회)
+- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
+  로컬 디스크 여유 공간 제약으로 스킵
+- `rustfmt --edition 2021 src/parser/hwpx/section.rs` 적용, `git diff --name-only`로
+  의도한 파일만 변경됨을 확인
+
+## 변경 파일
+
+- `src/parser/hwpx/section.rs`

--- a/mydocs/report/task_m100_2901_report.md
+++ b/mydocs/report/task_m100_2901_report.md
@@ -1,0 +1,33 @@
+# Task m100-2901: HWPX 표 row_sizes 계약 위반 수정
+
+- 이슈: #3060
+- 브랜치: `task/m100-2901-table-cnt-attrs`
+
+## 문제
+
+`src/parser/hwpx/section.rs`의 `parse_table`이 `Table::row_sizes`를 "행별 최대 셀 높이"로
+채우고 있었다. 그러나 이 필드의 실제 계약은 "행별 셀 수"(HWP5 스펙 `UINT16[NRows]`)이며,
+다음 모든 생산자가 이 계약을 따른다.
+
+- `src/parser/control.rs:274` (HWP5 네이티브 파서, 스펙 주석 명시)
+- `src/model/table.rs::rebuild_row_sizes()`
+- `src/document_core/html_table_import.rs:538`
+- `src/document_core/commands/object_ops/table.rs` (신규 표 생성)
+- `src/document_core/converters/hwpx_to_hwp.rs::materialize_table_record_row_sizes`
+  (HWPX→HWP 저장 직전, "행별 셀 수"로 강제 재계산 — 이 안전망 때문에 HWP 변환 경로는
+  증상이 가려져 있었다)
+
+HWPX 파서만 유일하게 "높이"를 채워, 순수 HWPX IR을 그대로 소비하는 경로
+(예: 렌더러의 cellzone 폴백 계산)에서 필드 의미가 어긋난다.
+
+## 수정
+
+`parse_table` 말미의 row_sizes 계산을 "행별 셀 수" 카운트로 통일했다 (다른 생산자와
+동일한 `(0..row_count).map(|r| cells.iter().filter(|c| c.row == r).count())` 패턴).
+
+## 검증
+
+- `cargo check --lib`: 통과
+- 신규 테스트 `test_parse_table_row_sizes_is_cell_count_not_height` (2행×2열, 행별 높이를
+  다르게 주어 카운트(2,2)와 높이가 혼동되지 않음을 확인): 통과
+- `cargo test --lib table` (332개 표 관련 테스트, hwpx_to_hwp 어댑터 회귀 포함): 전부 통과

--- a/mydocs/report/task_m100_2916_report.md
+++ b/mydocs/report/task_m100_2916_report.md
@@ -1,0 +1,49 @@
+# 완료 보고서 — Task M100-2916
+
+- 이슈: #2916
+- 제목: hp:equation 의 hp:script 가 CDATA 로 인코딩된 경우 파서가 수식 스크립트를 소실함
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2916-equation-script-cdata-loss`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/section.rs`의 `parse_equation()`이 `<hp:equation>`의 `<hp:script>`
+자식 요소 텍스트를 수집할 때 `Event::Text`와 `Event::GeneralRef`(개체 참조)만
+처리하고 `Event::CData`(`<![CDATA[...]]>`)는 처리하지 않아, 수식 스크립트가 CDATA로
+저장된 HWPX 문서를 열면 `Equation.script`가 통째로 빈 문자열이 되는 문제를 수정했다.
+
+같은 파일의 `header.rs::read_numbering_para_head_text()`가 이미 `Event::Text`와
+`Event::CData`를 동시에 처리하는 패턴을 쓰고 있어, HWPX 문서에서 텍스트 콘텐츠가
+CDATA로 인코딩되는 것이 실제로 관측되는 케이스임을 뒷받침했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/section.rs`
+  - `parse_equation()`의 `<hp:script>` 파싱 루프에 `Event::CData(ref cdata)` 분기
+    추가 — `in_script`일 때 CDATA 본문을 `script`에 그대로 누적(UTF-8 lossy 디코드).
+  - 회귀 가드 단위 테스트
+    `parser::hwpx::section::tests::task_m100_2916_equation_script_cdata_not_lost`
+    추가: `<hp:script><![CDATA[a < b > c]]></hp:script>`를 `parse_equation()`에
+    직접 통과시켜 `eq.script == "a < b > c"`를 검증(수정 전에는 `""`로 실패).
+
+## 3. 검증 결과 (경량 검증 — 디스크 공간 제약으로 `cargo check --lib` 및 대상
+테스트만 실행, 전체 빌드/clippy/release-test는 생략)
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib task_m100_2916_equation_script_cdata_not_lost`
+  (수정 제거 시 `left: "" / right: "a < b > c"`로 실패 → red→green 확인)
+- `rustfmt --edition 2021 src/parser/hwpx/section.rs`
+
+## 4. 스코프 메모
+
+이번 라운드 작업 도메인은 `<hp:equation>`의 `<hp:script>` 자식 요소와 형제 속성
+(`version`/`baseUnit`/`baseLine`/`textColor`)으로 한정했다. `secPr`, 공용 도형
+(common-shape), `lock`/`numberingType`은 다른 진행 중인 작업과 충돌 방지를 위해
+건드리지 않았다.
+
+사전 중복 확인 결과, 열린 PR #2850(`task/m100-2840-equation-lock-roundtrip`)은
+수식 `lock` 속성만 다루고, PR #2899(`task/m100-2883-object-desc-eq-script-len-guard`)는
+`rhwp-studio`의 TypeScript 입력 길이 가드만 다뤄 `.rs` 파일을 건드리지 않는다 —
+둘 다 이번 변경과 겹치지 않는다.

--- a/mydocs/report/task_m100_2935_report.md
+++ b/mydocs/report/task_m100_2935_report.md
@@ -1,0 +1,64 @@
+---
+kind: report
+status: done
+task: m100-2935
+issue: 2935
+---
+
+# task-m100-2935: hp:parameters의 stringParam(Command) CDATA 소실 수정 보고서
+
+## 이슈
+
+edwardkim/rhwp#2935 — `hp:parameters` 하위 `hp:stringParam name="Command"`가 CDATA로
+인코딩된 경우 파서가 필드 명령 문자열(하이퍼링크 대상, 필드 명령 등)을 소실하는 문제.
+
+이미 병합된 #2916 / PR #2927(`hp:equation`의 `hp:script` CDATA 누락)과 동일한 근본 원인
+패턴이다.
+
+## 근본 원인
+
+`src/parser/hwpx/section.rs`의 `parse_field_parameters()`는 `hp:parameters`의 자식
+요소 텍스트를 읽어 `Field::command`를 채우는 이벤트 루프에서 `Event::Text`와
+`Event::GeneralRef`만 처리하고 `Event::CData`를 처리하지 않았다. quick-xml은
+`<![CDATA[...]]>` 블록을 `Event::Text`가 아니라 별도의 `Event::CData` 이벤트로
+방출하므로, 이 분기가 없으면 CDATA로 감싸진 콘텐츠(예: 쿼리스트링에 `&`가 포함된
+하이퍼링크 URL, 비교 연산자 `<`/`>`를 포함한 필드 명령)가 조용히 사라진다.
+
+## 수정
+
+`Event::GeneralRef` 분기 뒤에 `Event::CData` 분기를 추가하여, CDATA 콘텐츠를
+UTF-8로 디코드한 뒤 verbatim 재조립 버퍼(`raw`)에 이스케이프하여 추가하고,
+`in_command`일 때는 기존 `Event::Text` 분기와 동일하게 `field.command`에도
+반영하도록 했다. `header.rs::read_numbering_para_head_text()`와 #2927에서 수정된
+`hp:script` 파서의 기존 패턴을 그대로 따랐다.
+
+diff 규모: `src/parser/hwpx/section.rs` 순수 수정부 약 9줄 + 회귀 테스트 1개
+(총 +35줄, 삭제 없음).
+
+## 검증 (Red → Green)
+
+1. **Red**: `Event::CData` 분기를 임시로 제거한 상태에서
+   `test_parse_field_parameters_preserves_cdata_command`를 실행 →
+   `field.command`가 빈 문자열(`""`)로 나와 실패 확인.
+   ```
+   left: ""
+   right: "HYPERLINK \"https://example.com/?a=1&b=2\""
+   ```
+2. **Green**: `Event::CData` 분기를 복원한 뒤 동일 테스트 재실행 → 통과.
+   ```
+   test parser::hwpx::section::tests::test_parse_field_parameters_preserves_cdata_command ... ok
+   ```
+3. 기존 인접 테스트(`test_parse_memo_field_parameters_preserves_number_as_memo_index`,
+   `parse_field_parameters_reassembles_nested_params_balanced`)도 회귀 없이 통과.
+4. `cargo check --lib` 통과.
+
+## 참고
+
+- 작업 중 `C:` 드라이브 여유 공간이 0이 되어 Edit 도구가 `ENOSPC`로 실패하는 일이
+  있었다. `rhwp-wt-s` 워크트리에서 `cargo clean`으로 target 디렉터리(약 7.4GiB)를
+  정리해 여유 공간을 11GB로 확보한 뒤 작업을 재개했다. 이 워크트리에 국한된 조치이며
+  다른 워크트리나 공용 자원은 건드리지 않았다.
+- 브랜치 전환 시 동일 워크트리에 남아 있던 `src/parser/hwp3/*` 8개 파일의 미커밋
+  변경(본 작업과 무관, 사용자가 만든 것으로 추정)은 건드리지 않고 그대로 두었다.
+  `git stash`는 지시에 따라 사용하지 않았고, 대신 본 작업분만 `git diff` 패치로
+  분리 저장한 뒤 `origin/devel` 기준 새 브랜치에 `git apply`로 재적용했다.

--- a/mydocs/report/task_m100_2951_report.md
+++ b/mydocs/report/task_m100_2951_report.md
@@ -1,0 +1,71 @@
+# Task #2951 최종 결과보고서
+
+## 이슈 요약
+
+**원 보고 제목**: hp:dutmal 의 mainText/subText 가 CDATA 로 인코딩된 경우 파서가 덧말(Ruby) 텍스트를 소실함 #2951
+
+**증상**: `<hp:dutmal>`(덧말/Ruby) 하위 `<hp:mainText>`(기준 텍스트) / `<hp:subText>`(덧말 텍스트)가
+`<![CDATA[...]]>`로 인코딩된 경우, 파서가 이를 인식하지 못해 빈 문자열로 소실됨.
+
+## 원인
+
+`src/parser/hwpx/section.rs`의 `read_dutmal_text` 함수가 quick-xml 이벤트 중
+`Event::Text`, `Event::GeneralRef`만 매치하고 `Event::CData`를 처리하는 분기가 없었음.
+CDATA 섹션은 `_ => {}` 폴백에 걸려 텍스트가 그대로 버려짐.
+
+#2916(`hp:equation`의 `hp:script`, PR #2927)와 #2935(`hp:parameters`의
+`stringParam(Command)`, PR #2943)에서 동일한 클래스의 결함이 이미 확인·수정된 바 있음.
+이번 건은 세 번째 발생 지점인 `hp:dutmal`(덧말)에서 재현됨.
+
+## 수정 내용
+
+**파일**: `src/parser/hwpx/section.rs` (`read_dutmal_text`)
+
+기존 `Event::Text` / `Event::GeneralRef` 분기 사이에 `Event::CData` 분기를 추가하여,
+CDATA 내용을 `String::from_utf8_lossy`로 디코딩해 `text`에 이어붙이도록 함
+(기존 header.rs `read_numbering_para_head_text`, section.rs `parse_field_parameters`의
+CDATA 처리와 동일한 패턴).
+
+```diff
+             Ok(Event::GeneralRef(ref r)) => {
+                 text.push_str(&decode_xml_general_ref(r));
+             }
++            // [CDATA] dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우 처리하지
++            // 않으면 덧말 텍스트가 소실된다. #2916/#2935의 hp:script/stringParam CDATA
++            // 누락과 동일한 패턴.
++            Ok(Event::CData(ref cdata)) => {
++                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
++            }
+             Ok(Event::End(ref ee)) => {
+```
+
+## 검증 결과
+
+### 테스트 (red → green)
+
+`dutmal_maintext_subtext_preserve_cdata` 단위 테스트 추가:
+`mainText`에 `a<b`, `subText`에 `c>d`를 CDATA로 감싼 `<hp:dutmal>`을 파싱해
+`Control::Ruby`의 `main_text`/`ruby_text`가 원문 그대로 보존되는지 확인.
+
+- **수정 전 (red)**: `assertion left == right failed: mainText CDATA 가 소실되면 안 됨` — `left: "", right: "a<b"`
+- **수정 후 (green)**: `test parser::hwpx::section::tests::dutmal_maintext_subtext_preserve_cdata ... ok`
+
+### 빌드
+
+- `cargo check --lib`: 통과 (경고 없음)
+
+## 영향 범위
+
+**영향 받음**: `<hp:dutmal>`의 `mainText`/`subText`가 CDATA로 인코딩된 HWPX 문서 (덧말에
+`<`, `>`, `&` 등을 포함하는 경우 한/글이 CDATA로 저장할 수 있음).
+
+**영향 없음**: CDATA를 쓰지 않는 일반 텍스트 덧말, 다른 컨트롤/요소의 파싱 경로.
+
+## 산출물
+
+- `mydocs/report/task_m100_2951_report.md` (본 문서)
+- 소스: `src/parser/hwpx/section.rs` (`read_dutmal_text` 6줄 추가 + 테스트 1개 24줄 추가)
+
+## 이슈 종료 조건
+
+작업지시자 승인 후 `gh issue close 2951` 실행.

--- a/mydocs/report/task_m100_2974_report.md
+++ b/mydocs/report/task_m100_2974_report.md
@@ -1,0 +1,68 @@
+# 완료 보고서 — Task M100-2974
+
+- 이슈: #2974
+- 제목: hp:composeText(글자겹치기) 본문이 CDATA로 인코딩된 경우 파서가 겹침 텍스트를 소실함
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2974-compose-cdata-loss`
+
+## 1. 문제 요약
+
+`src/parser/hwpx/section.rs`의 `read_compose_text`(글자겹치기 `hp:compose`의
+`composeText` 본문을 읽는 헬퍼)가 `Event::Text`와 `Event::GeneralRef`만 처리하고
+`Event::CData`를 처리하지 않았다. `quick_xml` 리더는 `<![CDATA[...]]>` 섹션을
+`Event::Text`가 아닌 별도의 `Event::CData` 이벤트로 전달하므로, `<composeText>`
+본문이 CDATA로 인코딩된 경우(겹침 문자에 `<`, `>`, `&` 등 XML 특수문자가 포함되어
+저장기가 CDATA로 이스케이프한 경우) 겹침 텍스트가 빈 문자열로 소실되던 결함이다.
+
+이는 이 코드베이스에서 이미 세 차례 발견·수정된 것과 동일한 결함 클래스다.
+
+- #2916 — `hp:script` 본문 CDATA 파싱 누락
+- #2935 — `stringParam` 본문 CDATA 파싱 누락
+- #2951 — `hp:dutmal`의 `mainText`/`subText` CDATA 파싱 누락 (PR #2966)
+
+`read_compose_text`는 위 세 지점과 동일한 "텍스트 본문을 직접 읽는 소형 리더 루프"
+패턴이며, CDATA 분기만 아직 누락되어 있었다.
+
+## 2. 재현 (수정 전, red)
+
+```rust
+let xml = r#"...
+<hp:compose circleType="CHAR" charSz="100" composeType="OVERLAP">
+  <composeText><![CDATA[a<b]]></composeText>
+</hp:compose>..."#;
+let section = parse_hwpx_section(xml).unwrap();
+// Control::CharOverlap(co).chars 가 빈 Vec — "a<b" 세 글자가 전부 소실됨
+```
+
+수정 전에는 `co.chars`가 빈 벡터가 되어 테스트가 실패했다(red).
+
+## 3. 수정 내용
+
+`read_compose_text`의 `match` 문에 `Event::CData` 분기를 추가해
+`String::from_utf8_lossy`로 디코딩한 뒤 누적하도록 했다. #2916/#2935/#2951과
+완전히 동일한 패턴을 그대로 적용했다.
+
+- `src/parser/hwpx/section.rs`
+  - `read_compose_text`에 `Ok(Event::CData(ref cdata))` 분기 6줄 추가
+  - 회귀 테스트 `compose_text_preserve_cdata` 추가 (CDATA로 인코딩된 `a<b`가
+    `['a', '<', 'b']`로 정확히 파싱되는지 검증)
+
+## 4. 검증 결과 (수정 후, green)
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib compose_text_preserve_cdata`
+  - 1 passed
+- `rustfmt --edition 2021 src/parser/hwpx/section.rs`
+
+## 5. 리스크
+
+- 변경 범위가 `read_compose_text` 내부 CDATA 분기 추가로 한정되어 있어 기존
+  Text/GeneralRef 경로에는 영향이 없다.
+- 동일 클래스의 CDATA 누락 지점이 코드베이스 다른 곳에 더 있을 수 있으나, 본
+  이슈의 범위는 `composeText`로 한정한다.
+
+## 6. 결론
+
+Task M100-2974 구현과 검증을 완료했다. 이슈를 close할 수 있다.

--- a/mydocs/report/task_m100_3005_report.md
+++ b/mydocs/report/task_m100_3005_report.md
@@ -1,0 +1,62 @@
+# task_m100_3005 처리 결과 보고
+
+## 이슈
+
+[#3005 HWPX 쪽번호(pageNum) 원문자(CIRCLED_DIGIT) formatType이 CIRCLE_DIGIT 오탈자로
+파싱·직렬화되어 소실](https://github.com/edwardkim/rhwp/issues/3005)
+
+## 배경
+
+같은 클래스의 오탈자 버그가 이슈 #2957(PR #2964, 처리 시점 기준 아직 미병합)에서
+`<hp:autoNumFormat type="...">`에 대해 이미 지적됐다. 그런데 #2957의 이슈 본문은
+"`<hp:pageNum formatType="...">`는 별개 요소·속성이므로 그쪽의 `CIRCLE_DIGIT` 표기는
+그대로 유지해야 한다"고 명시적으로 결론지었다. 이번 작업은 그 결론을 스키마와 직접
+대조해 검증하는 것이 목표였다.
+
+`mydocs/manual/OWPML SCHEMA/ParaList XML schema.xml` 193~194행에서 `<hp:pageNum>`의
+`formatType` 속성은 `type="hc:NumberType1"`로 선언돼 있다. `mydocs/manual/OWPML SCHEMA/Core
+XML schema.xml`을 보면 `NumberType1`(5~83행)과 `NumberType2`(84행~)가 각각 정의돼
+있는데, 두 enum 모두 원문자 값을 `CIRCLED_DIGIT`(12행·91행)로 동일하게 표기한다.
+즉 `pageNum`이 `autoNumFormat`과 별개 속성이라는 #2957의 전제는 맞지만, 값 자체는
+동일한 스펙 표기(`CIRCLED_DIGIT`)를 따라야 한다는 점에서 "그대로 유지" 판단은
+스키마 미대조 상태의 오판이었다 — `page_num_format_to_str()`/`parse_page_num_attrs()`가
+쓰던 `CIRCLE_DIGIT` 자체가 별도의 동일 클래스 오탈자였다.
+
+## 근본 원인
+
+- `src/serializer/hwpx/section.rs`의 `page_num_format_to_str()`에서
+  `1 => "CIRCLE_DIGIT"`로 방출.
+- `src/parser/hwpx/section.rs`의 `parse_page_num_attrs()`에서 `formatType` 매치에
+  `"CIRCLE_DIGIT" => 1`만 있고 스펙 문자열 `"CIRCLED_DIGIT"`는 인식하지 못해
+  `_ => 0`(DIGIT)으로 떨어짐.
+
+## 변경 내용
+
+- `src/serializer/hwpx/section.rs`: `page_num_format_to_str()`의 `1 => "CIRCLE_DIGIT"`를
+  `1 => "CIRCLED_DIGIT"`로 수정(스펙 철자).
+- `src/parser/hwpx/section.rs`: `parse_page_num_attrs()`의 `formatType` 매치에
+  `"CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1`로 두 표기 모두 인식하도록 추가(과거 오탈자로
+  저장된 한컴 실물 파일과의 하위 호환 유지).
+- `src/serializer/hwpx/section.rs`: 단위 테스트
+  `page_num_circled_digit_format_reflects_spec_spelling` 추가 — `PageNumberPos.format = 1`
+  (원문자)일 때 `render_page_num()`이 `formatType="CIRCLED_DIGIT"`를 방출하고
+  `formatType="CIRCLE_DIGIT"`는 방출하지 않음을 검증.
+
+## 검증 (red → green)
+
+수정 전 `page_num_format_to_str()`를 `"CIRCLE_DIGIT"`로 되돌린 상태에서
+`cargo test --lib page_num_circled_digit_format_reflects_spec_spelling`을 실행하면
+`formatType="CIRCLE_DIGIT"` 출력에 대해 `CIRCLED_DIGIT` 단언이 실패함을 확인(red).
+수정을 되돌린 뒤(green) 동일 테스트가 통과함을 재확인했다.
+
+```
+test serializer::hwpx::section::tests::page_num_circled_digit_format_reflects_spec_spelling ... ok
+```
+
+`cargo check --lib`도 통과했다.
+
+## 범위 밖
+
+이슈 #2957/PR #2964가 다루는 `<hp:autoNumFormat type="...">`(인라인 자동번호) 경로는
+이번 작업에서 건드리지 않았다. `<hp:pageNum formatType="...">`만 별도 이슈(#3005)로
+분리해 수정했다.

--- a/mydocs/report/task_m100_3149_report.md
+++ b/mydocs/report/task_m100_3149_report.md
@@ -1,0 +1,51 @@
+# 완료 보고서 — Task M100-3149
+
+- 이슈: #3149
+- 제목: HWPX hp:equation version/baseLine/font 속성 생략 시 OWPML 스키마 기본값 대신 zero-계열 값으로 복원 — 라운드트립 시 값 변형
+- 작성일: 2026-07-23
+- 브랜치: `fix/task_m100_3149_hwpx_equation_owpml_defaults`
+
+## 1. 완료 내용
+
+HWPX 파서 `parse_equation`(`src/parser/hwpx/section.rs`)의 수식 전용 속성
+로컬 초기값을 OWPML 스키마(ParaList XML schema, `EquationType`) 속성 기본값으로
+교체했다.
+
+| 속성 | 스키마 기본값 | 수정 전 복원값 | 수정 후 |
+|---|---|---|---|
+| `version` | `"Equation Version 60"` | `""` | 스키마 기본값 |
+| `baseLine` | `85` | `0` | 스키마 기본값 |
+| `font` | `"HYhwpEQ"` | `""` | 스키마 기본값 |
+
+직렬화기(`src/serializer/hwpx/section.rs`의 equation 방출부)는 세 속성을 무조건
+방출하므로, 수정 전에는 속성을 생략한 스펙 준수 원본이 라운드트립을 거치면
+`version="" baseLine="0" font=""` 으로 값이 변형됐다. 속성이 명시된 파일의
+동작은 불변이다. `baseLine`의 parse 실패 폴백도 0 → 85 로 기본값과 일치시켰다.
+
+같은 요소의 `textColor`(#000000↔0), `baseUnit`(1000↔1000), `lineMode`(CHAR↔attr
+bit 0 = 0, #2727)는 이미 스펙 기본값과 일치해 변경하지 않았다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/section.rs`
+  - `parse_equation`: `version_info`/`baseline`/`font_name` 초기값을 스키마
+    기본값으로 교체 + 근거 주석
+  - 테스트 `equation_missing_attrs_fall_back_to_owpml_defaults` 추가
+    (속성 생략 수식 파싱 → 세 필드가 스펙 기본값으로 복원되는지 단언)
+
+## 3. 검증 결과 (red → green)
+
+- red (수정 전): `cargo test --lib equation_missing_attrs_fall_back_to_owpml_defaults`
+  → FAILED — `assertion 'left == right' failed: baseLine 생략 시 스펙 기본값 85`
+  (baseline 0, font_name "", version_info "")
+- green (수정 후): 같은 테스트 ok. 1 passed; 0 failed
+- 회귀: `cargo test --lib hwpx` → ok. 496 passed; 0 failed
+- `cargo fmt --check` — Windows CRLF line-ending diff 제외 위반 없음
+- `cargo clippy --lib --tests` — 신규 경고 없음
+
+## 4. 환경 특이사항
+
+- 이 PC 의 Windows SDK `dbghelp.lib`(10.0.26100.0)가 손상(전부 0x00)되어
+  link.exe 가 LNK1123/CVT1107 으로 실패 — 시스템 파일은 건드리지 않고
+  `dbghelp.dll` export 로 재생성한 import lib 를 `RUSTFLAGS=-L` 로 우선
+  탐색시켜 우회했다(검증 전용, 산출물에는 영향 없음).

--- a/src/model/control.rs
+++ b/src/model/control.rs
@@ -89,6 +89,10 @@ pub struct Equation {
     /// HWP5 spec 표 105 에 누락되어 있으나 한컴 실제 저장본에 baseline 과 version_info
     /// 사이에 UINT16 zero 가 위치. Task #1061 발견.
     pub unknown: u16,
+    /// EQEDIT 속성 (UINT32, HWPTAG_EQEDIT 첫 필드).
+    /// bit 0: lineMode (0=글자 단위/CHAR, 1=줄 단위/LINE).
+    /// 종전엔 파싱 후 버려지고 저장 시 0으로 고정되어 lineMode 유실. Issue #2727.
+    pub eqedit: u32,
     /// 버전 정보
     pub version_info: String,
     /// 수식 글꼴명

--- a/src/model/header_footer.rs
+++ b/src/model/header_footer.rs
@@ -92,6 +92,11 @@ pub struct MasterPage {
     pub text_ref: u8,
     /// 번호 참조 비트맵
     pub num_ref: u8,
+    /// HWPX masterPage/hp:subList@textDirection. 0=HORIZONTAL, 1=VERTICAL.
+    ///
+    /// 세로쓰기 바탕쪽(예: 세로 제본 문서)의 subList가 VERTICAL로 저장되는데,
+    /// serializer 가 이를 읽지 않고 HORIZONTAL 로 고정 출력하면 왕복 시 세로쓰기가 유실된다.
+    pub text_direction: u8,
     /// HWPX masterPage@pageNumber.
     ///
     /// HWPX에서 이 값은 바탕쪽 내부 PAGE 필드의 치환 가능 여부를 판단하는 힌트로 쓰인다.

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -724,6 +724,7 @@ fn parse_master_pages_from_raw(raw_records: &[RawRecord]) -> Vec<MasterPage> {
             replace_base: false,
             ext_flags,
             page_front: false, // HWP5 바이너리 바탕쪽엔 pageFront 개념 없음
+            text_direction: 0, // HWP5 바이너리 바탕쪽엔 textDirection 개념 없음
             paragraphs,
             text_width,
             text_height,

--- a/src/parser/control.rs
+++ b/src/parser/control.rs
@@ -864,10 +864,11 @@ fn parse_equation_control(ctrl_data: &[u8], child_records: &[Record]) -> Control
         let data = &eq_rec.data;
         let mut r = ByteReader::new(data);
 
-        // attr: u32 (4바이트) — bit0: 스크립트 범위
-        // [#2727] 종전엔 읽고 버려 저장 시 0 으로 고정됐다. bit0 은 HWPX
-        // `lineMode`(CHAR/LINE) 와 대응하므로 UINT32 전체를 IR 로 보존한다.
-        equation.attr = r.read_u32().unwrap_or(0);
+        // attr: u32 (4바이트) — bit0: lineMode (0=글자단위/CHAR, 1=줄단위/LINE)
+        // `attr`/`eqedit` 두 필드가 동일한 값을 보관하므로 함께 채운다.
+        let raw_attr = r.read_u32().unwrap_or(0);
+        equation.attr = raw_attr;
+        equation.eqedit = raw_attr;
 
         // script: WCHAR 문자열 (길이 접두 UTF-16LE)
         if let Ok(script) = r.read_hwp_string() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -246,6 +246,12 @@ fn parse_master_page_sub_list(e: &quick_xml::events::BytesStart, master_page: &m
             b"textHeight" => master_page.text_height = parse_u32(&attr),
             b"hasTextRef" => master_page.text_ref = parse_u8(&attr),
             b"hasNumRef" => master_page.num_ref = parse_u8(&attr),
+            // 세로쓰기 바탕쪽(hp:subList@textDirection). serializer 는 항상
+            // HORIZONTAL 로 고정 출력하지만 종전엔 파서가 미독 →
+            // textDirection="VERTICAL" 바탕쪽이 왕복 시 가로쓰기로 바뀌었다.
+            b"textDirection" => {
+                master_page.text_direction = if attr_str(&attr) == "VERTICAL" { 1 } else { 0 };
+            }
             _ => {}
         }
     }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5435,12 +5435,14 @@ fn parse_equation(
     let mut shape_attr = ShapeComponentAttr::default();
     let mut has_pos = false;
 
-    // 수식 전용 속성
-    let mut version_info = String::new();
-    let mut baseline: i16 = 0;
+    // 수식 전용 속성 — 초기값은 OWPML(ParaList 스키마 EquationType) 속성 기본값.
+    // 속성이 생략된 파일에서 zero-계열 값으로 복원하면 직렬화기가 세 속성을
+    // 무조건 방출하므로 라운드트립 시 version=""/baseLine="0"/font="" 으로 변형된다.
+    let mut version_info = String::from("Equation Version 60");
+    let mut baseline: i16 = 85;
     let mut color: u32 = 0;
     let mut font_size: u32 = 1000;
-    let mut font_name = String::new();
+    let mut font_name = String::from("HYhwpEQ");
     // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
     // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
     let mut eq_attr: u32 = 0;
@@ -5450,7 +5452,7 @@ fn parse_equation(
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
             b"version" => version_info = attr_str(&attr),
-            b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(0),
+            b"baseLine" => baseline = attr_str(&attr).parse().unwrap_or(85),
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
             // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
@@ -6385,6 +6387,45 @@ mod tests {
         };
         assert!(section_def.hide_empty_line);
         assert_ne!(section_def.flags & 0x0008_0000, 0);
+    }
+
+    #[test]
+    fn equation_missing_attrs_fall_back_to_owpml_defaults() {
+        // OWPML 스키마(ParaList, EquationType)의 속성 기본값:
+        //   version  = "Equation Version 60"
+        //   baseLine = 85
+        //   font     = "HYhwpEQ"
+        // 속성이 생략된 수식을 파싱하면 스펙 기본값으로 복원되어야 한다.
+        // (직렬화기는 세 속성을 무조건 방출하므로, 파서가 0/"" 로 복원하면
+        //  왕복 시 baseLine="0" font="" version="" 으로 값이 변형된다.)
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:equation id="1" zOrder="0" numberingType="EQUATION" textWrap="TOP_AND_BOTTOM" lock="0">
+        <hp:script>1 over 2</hp:script>
+        <hp:sz width="2000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/>
+        <hp:pos treatAsChar="1" affectLSpacing="0" flowWithText="1" allowOverlap="0" holdAnchorAndSO="0" vertRelTo="PARA" horzRelTo="PARA" vertAlign="TOP" horzAlign="LEFT" vertOffset="0" horzOffset="0"/>
+      </hp:equation>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let eq = section.paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                Control::Equation(e) => Some(e),
+                _ => None,
+            })
+            .expect("수식 컨트롤");
+        assert_eq!(eq.baseline, 85, "baseLine 생략 시 스펙 기본값 85");
+        assert_eq!(eq.font_name, "HYhwpEQ", "font 생략 시 스펙 기본값 HYhwpEQ");
+        assert_eq!(
+            eq.version_info, "Equation Version 60",
+            "version 생략 시 스펙 기본값"
+        );
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5945,8 +5945,18 @@ fn parse_hp_chart_element(
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            // [#2882] common.numbering_type(ObjectNumberingType) 도 함께 채운다.
+            // 직렬화기(numbering_type_str, serializer/hwpx/shape.rs)가 참조하는
+            // 필드는 이것뿐이라, bool 지역 변수만으로는 저장 시 항상 NONE 으로
+            // 되쓰인다(공용 도형 파서 section.rs:2892 와 동일 패턴으로 맞춤).
             b"numberingType" => {
                 numbering_type_picture = attr_str(&attr).eq_ignore_ascii_case("PICTURE");
+                common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
             }
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
@@ -6020,8 +6030,28 @@ fn parse_hp_ole_element(
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            // [#2882] common.numbering_type(ObjectNumberingType) 도 함께 채운다.
+            // 직렬화기(numbering_type_str, serializer/hwpx/shape.rs)가 참조하는
+            // 필드는 이것뿐이라, bool 지역 변수만으로는 저장 시 항상 NONE 으로
+            // 되쓰인다(공용 도형 파서 section.rs:2892 와 동일 패턴으로 맞춤).
             b"numberingType" => {
                 numbering_type_picture = attr_str(&attr).eq_ignore_ascii_case("PICTURE");
+                common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
+            // 표시 방식(아이콘/썸네일/인쇄용/내용). serializer 는 방출하나 종전엔
+            // 파서가 읽지 않아 ICON 등이 왕복 시 CONTENT 로 바뀌었다.
+            b"drawAspect" => {
+                draw_aspect = match attr_str(&attr).as_str() {
+                    "ICON" => OleDrawingAspect::Icon,
+                    "THUMBNAIL" => OleDrawingAspect::Thumbnail,
+                    "DOCPRINT" => OleDrawingAspect::DocPrint,
+                    _ => OleDrawingAspect::Content,
+                };
             }
             // 표시 방식(아이콘/썸네일/인쇄용/내용). serializer 는 방출하나 종전엔
             // 파서가 읽지 않아 ICON 등이 왕복 시 CONTENT 로 바뀌었다.
@@ -7924,6 +7954,70 @@ mod tests {
         assert!(
             line.started_right_or_bottom,
             "isReverseHV=\"1\" 이 started_right_or_bottom 로 되읽혀야 함"
+        );
+    }
+
+    // ---------- #2882: hp:ole/hp:chart numberingType 라운드트립 ----------
+
+    #[test]
+    fn issue2882_ole_numbering_type_picture_is_parsed_into_common_field() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:ole id="1" zOrder="0" numberingType="PICTURE" binaryItemIDRef="ole1">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:ole>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape");
+        };
+        assert_eq!(
+            ole.common.numbering_type,
+            crate::model::shape::ObjectNumberingType::Picture,
+            "numberingType=\"PICTURE\" 가 common.numbering_type 에 매핑돼야 함(직렬화기가 참조하는 필드)"
+        );
+    }
+
+    #[test]
+    fn issue2882_chart_numbering_type_table_is_parsed_into_common_field() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"
+        xmlns:hc="http://www.hancom.co.kr/hwpml/2011/core">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart id="1" zOrder="0" numberingType="TABLE" chartIDRef="Chart/chart1.xml">
+        <hp:sz width="2600" height="2600"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected ole shape (chart is modeled as OleShape)");
+        };
+        assert_eq!(
+            ole.common.numbering_type,
+            crate::model::shape::ObjectNumberingType::Table,
+            "numberingType=\"TABLE\" 가 common.numbering_type 에 매핑돼야 함(직렬화기가 참조하는 필드)"
         );
     }
 

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5288,6 +5288,11 @@ fn read_compose_text(reader: &mut Reader<&[u8]>) -> Result<String, HwpxError> {
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
             }
+            // [CDATA] composeText(글자겹치기) 본문이 CDATA로 인코딩된 경우 처리하지
+            // 않으면 겹침 텍스트가 소실된다. #2916/#2935/#2951의 CDATA 누락과 동일한 패턴.
+            Ok(Event::CData(ref cdata)) => {
+                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+            }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
                 if local_name(eename.as_ref()) == b"composeText" {
@@ -8104,6 +8109,32 @@ mod tests {
         assert_eq!(
             parse_field_type("TABLE_OF_CONTENTS"),
             FieldType::TableOfContents
+        );
+    }
+
+    #[test]
+    fn compose_text_preserve_cdata() {
+        // hp:compose(글자겹치기)의 composeText가 CDATA로 인코딩된 경우
+        // (예: 비교연산자 `<`/`>` 포함) read_compose_text의 arm 누락으로 소실되던 결함(#2974).
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:compose circleType="CHAR" charSz="100" composeType="OVERLAP">
+        <composeText><![CDATA[a<b]]></composeText>
+      </hp:compose>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::CharOverlap(co) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 CharOverlap(글자겹치기)이어야 함");
+        };
+        assert_eq!(
+            co.chars,
+            vec!['a', '<', 'b'],
+            "composeText CDATA 가 소실되면 안 됨"
         );
     }
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6053,16 +6053,6 @@ fn parse_hp_ole_element(
                     _ => OleDrawingAspect::Content,
                 };
             }
-            // 표시 방식(아이콘/썸네일/인쇄용/내용). serializer 는 방출하나 종전엔
-            // 파서가 읽지 않아 ICON 등이 왕복 시 CONTENT 로 바뀌었다.
-            b"drawAspect" => {
-                draw_aspect = match attr_str(&attr).as_str() {
-                    "ICON" => OleDrawingAspect::Icon,
-                    "THUMBNAIL" => OleDrawingAspect::Thumbnail,
-                    "DOCPRINT" => OleDrawingAspect::DocPrint,
-                    _ => OleDrawingAspect::Content,
-                };
-            }
             b"zOrder" => common.z_order = parse_i32(&attr),
             b"textWrap" => {
                 common.text_wrap = match attr_str(&attr).as_str() {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1702,7 +1702,6 @@ fn parse_table(
     // 표 내용 파싱 (행/셀)
     let mut buf = Vec::new();
     let mut current_row: u16 = 0;
-    let mut row_sizes: Vec<HwpUnit16> = Vec::new();
 
     loop {
         match reader.read_event_into(&mut buf) {
@@ -1883,18 +1882,12 @@ fn parse_table(
     table.common.margin.top = table.outer_margin_top;
     table.common.margin.bottom = table.outer_margin_bottom;
 
-    // row_sizes 설정 (행별 셀 높이의 최대값)
-    for r in 0..table.row_count {
-        let max_h = table
-            .cells
-            .iter()
-            .filter(|c| c.row == r && c.row_span == 1)
-            .map(|c| c.height as i16)
-            .max()
-            .unwrap_or(0);
-        row_sizes.push(max_h);
-    }
-    table.row_sizes = row_sizes;
+    // row_sizes 설정 (행별 셀 수, HWP 스펙 UINT16[NRows] 계약과 동일 — 높이가 아니다).
+    // model::table::Table::rebuild_row_sizes, parser::control(HWP5), html_table_import,
+    // document_core::commands::object_ops::table 이 모두 이 필드를 "행별 셀 개수"로 채운다.
+    table.row_sizes = (0..table.row_count)
+        .map(|r| table.cells.iter().filter(|c| c.row == r).count() as i16)
+        .collect();
 
     materialize_hwpx_table_attrs(&mut table, table_record_flags);
     table.rebuild_grid();
@@ -6932,6 +6925,39 @@ mod tests {
         assert!(table.cells[0].apply_inner_margin);
         assert_eq!(table.cells[0].padding.left, 141);
         assert_eq!(table.cells[0].padding.top, 113);
+    }
+
+    #[test]
+    fn test_parse_table_row_sizes_is_cell_count_not_height() {
+        // [#row_sizes 계약] HWP 스펙 UINT16[NRows]("행별 셀 수")과 동일해야 한다.
+        // model::table::Table::rebuild_row_sizes, parser::control(HWP5),
+        // html_table_import 모두 이 필드를 "행별 셀 개수"로 채우므로 HWPX 파서만
+        // 높이를 채우면 계약이 깨진다. 2행 2열에서 각 셀 높이를 다르게 주어
+        // 카운트(2)와 높이(예: 500/3000)를 구분한다.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl rowCnt="2" colCnt="2" cellSpacing="0" borderFillIDRef="0">
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="1" rowAddr="0"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="500"/></hp:tc>
+      </hp:tr>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="0" rowAddr="1"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="3000"/></hp:tc>
+        <hp:tc borderFillIDRef="0"><hp:cellAddr colAddr="1" rowAddr="1"/><hp:cellSpan colSpan="1" rowSpan="1"/><hp:cellSz width="1000" height="3000"/></hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(table) => table,
+            other => panic!("expected table, got {:?}", other),
+        };
+        assert_eq!(table.row_sizes, vec![2, 2]);
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5032,6 +5032,16 @@ fn parse_field_parameters(
                     field.command.push_str(&decoded);
                 }
             }
+            // [CDATA] stringParam(Command)이 CDATA로 인코딩된 경우(예: 하이퍼링크 URL의
+            // 쿼리스트링 `&`, 수식 필드의 비교연산자 `<`/`>`) 처리하지 않으면 필드 명령
+            // 문자열이 소실된다. #2916/#2927의 hp:script CDATA 누락과 동일한 패턴.
+            Ok(Event::CData(ref cdata)) => {
+                let decoded = String::from_utf8_lossy(cdata.as_ref()).into_owned();
+                raw.push_str(&escape_xml_text(&decoded));
+                if in_command {
+                    field.command.push_str(&decoded);
+                }
+            }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
                 let local = local_name(eename.as_ref());
@@ -7315,6 +7325,31 @@ mod tests {
             "바깥 </hp:listParam> 누락(중첩 불균형): {raw}"
         );
         assert!(raw.ends_with("</hp:parameters>"), "params close: {raw}");
+    }
+
+    #[test]
+    fn test_parse_field_parameters_preserves_cdata_command() {
+        let xml = r#"<hp:parameters xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph">
+  <hp:stringParam name="Command"><![CDATA[HYPERLINK "https://example.com/?a=1&b=2"]]></hp:stringParam>
+</hp:parameters>"#;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let mut field = Field::default();
+
+        loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"parameters" => {
+                    let start = e.to_owned();
+                    parse_field_parameters(&start, &mut reader, &mut field).unwrap();
+                    break;
+                }
+                Event::Eof => panic!("parameters not found"),
+                _ => {}
+            }
+            buf.clear();
+        }
+
+        assert_eq!(field.command, "HYPERLINK \"https://example.com/?a=1&b=2\"");
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2364,6 +2364,17 @@ fn parse_picture(
                     _ => crate::model::shape::DropCapStyle::None,
                 };
             }
+            // [#2697 동형] numberingType (캡션 번호 범주) 보존 — 도형·표·그림 공통 속성.
+            // 종전 미파싱으로 그림에 번호 범주를 NONE 등으로 변경한 HWPX에서 IR 기본값(None)으로
+            // 떨어져 왕복 시 "PICTURE"로 강제복원되던 결함을 수정한다.
+            b"numberingType" => {
+                common.numbering_type = match attr_str(&attr).to_ascii_uppercase().as_str() {
+                    "PICTURE" => crate::model::shape::ObjectNumberingType::Picture,
+                    "TABLE" => crate::model::shape::ObjectNumberingType::Table,
+                    "EQUATION" => crate::model::shape::ObjectNumberingType::Equation,
+                    _ => crate::model::shape::ObjectNumberingType::None,
+                };
+            }
             _ => {}
         }
     }
@@ -5445,7 +5456,9 @@ fn parse_equation(
     let mut font_name = String::from("HYhwpEQ");
     // [#2727] lineMode(수식이 차지하는 범위) → EQEDIT attribute bit0.
     // OWPML 기본값은 CHAR 이므로 속성이 없으면 0(글자 단위)으로 둔다.
+    // `attr`/`eqedit` 두 필드가 동일한 값을 보관하므로 함께 채운다.
     let mut eq_attr: u32 = 0;
+    let mut eqedit: u32 = 0;
 
     // 공통 개체 속성 + 수식 속성 파싱
     parse_object_element_attrs(e, &mut common, &mut shape_attr);
@@ -5456,12 +5469,14 @@ fn parse_equation(
             b"textColor" => color = parse_color(&attr),
             b"baseUnit" => font_size = parse_u32(&attr),
             // [#2727] LINE 이면 bit0 set. 종전엔 미파싱으로 왕복 시 CHAR 로 고정됐다.
+            // `attr`/`eqedit` 두 필드가 동일한 값을 보관하므로 함께 채운다.
             b"lineMode" => {
                 if attr_str(&attr).eq_ignore_ascii_case("LINE") {
                     eq_attr |= EQUATION_LINE_MODE_BIT;
                 } else {
                     eq_attr &= !EQUATION_LINE_MODE_BIT;
                 }
+                eqedit = eq_attr;
             }
             b"font" => font_name = attr_str(&attr),
             _ => {}
@@ -5557,6 +5572,7 @@ fn parse_equation(
         color,
         baseline,
         unknown: 0,
+        eqedit,
         font_name,
         version_info,
         raw_ctrl_data: Vec::new(),

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5384,6 +5384,12 @@ fn read_dutmal_text(reader: &mut Reader<&[u8]>, end_tag: &[u8]) -> Result<String
             Ok(Event::GeneralRef(ref r)) => {
                 text.push_str(&decode_xml_general_ref(r));
             }
+            // [CDATA] dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우 처리하지
+            // 않으면 덧말 텍스트가 소실된다. #2916/#2935의 hp:script/stringParam CDATA
+            // 누락과 동일한 패턴.
+            Ok(Event::CData(ref cdata)) => {
+                text.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+            }
             Ok(Event::End(ref ee)) => {
                 let eename = ee.name();
                 if local_name(eename.as_ref()) == end_tag {
@@ -7096,6 +7102,30 @@ mod tests {
             crate::model::image::ImageEffect::Pattern8x8,
             "PATTERN_8_8 그림 효과가 RealPic 으로 유실되면 안 됨"
         );
+    }
+
+    #[test]
+    fn dutmal_maintext_subtext_preserve_cdata() {
+        // hp:dutmal(덧말)의 mainText/subText가 CDATA로 인코딩된 경우
+        // (예: 비교연산자 `<`/`>` 포함) 파서 arm 누락으로 소실되던 결함.
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:dutmal posType="TOP" align="CENTER" szRatio="50" option="0" styleIDRef="0">
+        <hp:mainText><![CDATA[a<b]]></hp:mainText>
+        <hp:subText><![CDATA[c>d]]></hp:subText>
+      </hp:dutmal>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Ruby(ruby) = &section.paragraphs[0].controls[0] else {
+            panic!("첫 컨트롤은 Ruby(덧말)여야 함");
+        };
+        assert_eq!(ruby.main_text, "a<b", "mainText CDATA 가 소실되면 안 됨");
+        assert_eq!(ruby.ruby_text, "c>d", "subText CDATA 가 소실되면 안 됨");
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -4424,7 +4424,9 @@ fn parse_page_num_attrs(e: &quick_xml::events::BytesStart) -> PageNumberPos {
             b"formatType" => {
                 pn.format = match attr_str(&attr).as_str() {
                     "DIGIT" => 0,
-                    "CIRCLE_DIGIT" => 1,
+                    // [#XXXX] 스펙 표기는 "CIRCLED_DIGIT"(NumberType1). 과거 오탈자
+                    // "CIRCLE_DIGIT"로 저장된 한컴 실물 파일과의 호환을 위해 둘 다 인식한다.
+                    "CIRCLED_DIGIT" | "CIRCLE_DIGIT" => 1,
                     "ROMAN_CAPITAL" => 2,
                     "ROMAN_SMALL" => 3,
                     "LATIN_CAPITAL" => 4,

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -5489,6 +5489,14 @@ fn parse_equation(
                     }
                 }
             }
+            Ok(Event::CData(ref cdata)) => {
+                // #2916: 수식 스크립트가 CDATA 로 저장된 경우(비교 연산자 등 XML
+                // 예약 문자를 다량 포함해 엔티티 이스케이프 대신 CDATA 로 감싸는
+                // 케이스), 이 분기가 없으면 script 가 통째로 빈 문자열이 된다.
+                if in_script {
+                    script.push_str(&String::from_utf8_lossy(cdata.as_ref()));
+                }
+            }
             Ok(Event::GeneralRef(ref r)) => {
                 if in_script {
                     if let Ok(Some(ch)) = r.resolve_char_ref() {
@@ -8057,6 +8065,35 @@ mod tests {
         let xml = r#"<?xml version="1.0"?><hs:sec xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section"/>"#;
         let section = parse_hwpx_section(xml).unwrap();
         assert!(section.paragraphs.is_empty());
+    }
+
+    /// #2916: `<hp:equation>`의 `<hp:script>` 본문이 CDATA 섹션으로 인코딩된 경우
+    /// (실제 한글 저장 결과에서 관찰되는 형태 — 수식 스크립트에 `<`, `>` 등이
+    /// 다수 포함되어 개별 엔티티 이스케이프 대신 CDATA 로 감싸짐), 파서가
+    /// Event::CData 를 처리하지 않으면 script 가 빈 문자열로 소실된다.
+    #[test]
+    fn task_m100_2916_equation_script_cdata_not_lost() {
+        let xml = r##"<hp:equation xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+            id="1" version="Equation Version 60" baseLine="0" textColor="#000000" baseUnit="1000" font="HYhwpEQ"><hp:script><![CDATA[a < b > c]]></hp:script></hp:equation>"##;
+        let mut reader = Reader::from_str(xml);
+        let mut buf = Vec::new();
+        let ctrl = loop {
+            match reader.read_event_into(&mut buf).unwrap() {
+                Event::Start(ref e) if local_name(e.name().as_ref()) == b"equation" => {
+                    break parse_equation(e, &mut reader).unwrap();
+                }
+                Event::Eof => panic!("equation not found"),
+                _ => {}
+            }
+            buf.clear();
+        };
+        let Control::Equation(eq) = ctrl else {
+            panic!("expected Equation control");
+        };
+        assert_eq!(
+            eq.script, "a < b > c",
+            "CDATA 로 감싸진 수식 스크립트가 소실되면 안 된다"
+        );
     }
 
     #[test]

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6119,6 +6119,19 @@ fn parse_common_shape_children(
                             match attr.key.as_ref() {
                                 b"width" => common.width = parse_u32(&attr),
                                 b"height" => common.height = parse_u32(&attr),
+                                // [#2726] 공용 자식 파서(차트·OLE)만 크기 기준 arm 이 없어
+                                // 파싱 단계에서 유실됐다. 도형 공용 파서(같은 파일 2925/2928)·
+                                // 표(1702/1706)·그림(#2712)과 동형이며, 높이는 동일하게
+                                // allow_column_para=false 로 읽어 치역을 {Paper, Page,
+                                // Absolute} 로 제한한다.
+                                b"widthRelTo" => {
+                                    common.width_criterion =
+                                        parse_size_criterion(&attr_str(&attr), true);
+                                }
+                                b"heightRelTo" => {
+                                    common.height_criterion =
+                                        parse_size_criterion(&attr_str(&attr), false);
+                                }
                                 b"protect" => common.size_protect = parse_bool(&attr),
                                 _ => {}
                             }
@@ -7714,6 +7727,93 @@ mod tests {
             rect.common.text_flow,
             crate::model::shape::TextFlow::RightOnly
         );
+    }
+
+    /// [#2726] 공용 자식 파서(`parse_common_shape_children`)는 차트·OLE 를 담당하는데
+    /// `widthRelTo`/`heightRelTo` arm 이 없어 크기 기준이 **파싱 단계에서** 유실됐다.
+    /// 표(1702/1706)·도형(2925/2928)·그림(#2712) 파서와 동형으로 보강한다.
+    #[test]
+    fn issue2726_parse_chart_preserves_size_criteria() {
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart chartIDRef="Chart/chart1.xml" id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="4000" height="3000" widthRelTo="COLUMN" heightRelTo="PAGE" protect="1"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected OLE(chart) shape");
+        };
+        assert_eq!(
+            ole.common.width_criterion,
+            SizeCriterion::Column,
+            "widthRelTo=\"COLUMN\" 이 IR 에 적재되어야 한다"
+        );
+        assert_eq!(
+            ole.common.height_criterion,
+            SizeCriterion::Page,
+            "heightRelTo=\"PAGE\" 가 IR 에 적재되어야 한다"
+        );
+        assert!(ole.common.size_protect, "protect=\"1\" 은 종전에도 읽혔다");
+    }
+
+    /// [#2726] 높이 기준은 `allow_column_para=false` 로 읽어 치역이
+    /// `{Paper, Page, Absolute}` 3값이어야 한다. `COLUMN`/`PARA` 가 들어와도 `Absolute`
+    /// 로 접혀야 직렬화기 `height_criterion_str` 와 정확한 역 관계가 유지된다.
+    #[test]
+    fn issue2726_parse_chart_height_folds_column_and_para_to_absolute() {
+        for raw in ["COLUMN", "PARA"] {
+            let xml = format!(
+                r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart chartIDRef="Chart/chart1.xml" id="1" zOrder="0" textWrap="SQUARE">
+        <hp:sz width="4000" height="3000" widthRelTo="{raw}" heightRelTo="{raw}" protect="0"/>
+        <hp:pos treatAsChar="0" vertRelTo="PARA" horzRelTo="PARA"/>
+      </hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#
+            );
+
+            let section = parse_hwpx_section(&xml).unwrap();
+            let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+                panic!("expected shape control");
+            };
+            let ShapeObject::Ole(ole) = shape.as_ref() else {
+                panic!("expected OLE(chart) shape");
+            };
+            // 너비는 5값 전부 허용 → 원문 그대로.
+            let expected_width = if raw == "COLUMN" {
+                SizeCriterion::Column
+            } else {
+                SizeCriterion::Para
+            };
+            assert_eq!(
+                ole.common.width_criterion, expected_width,
+                "너비는 {raw} 를 그대로 보존해야 한다"
+            );
+            // 높이는 3값으로 접힘.
+            assert_eq!(
+                ole.common.height_criterion,
+                SizeCriterion::Absolute,
+                "높이 {raw} 는 Absolute 로 접혀야 한다"
+            );
+        }
     }
 
     #[test]

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -1468,6 +1468,10 @@ fn serialize_shape_control(
                 level,
                 &serialize_common_obj_attr(&chart.common),
             ));
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = chart.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             let sc_ctrl_id = chart.drawing.shape_attr.ctrl_id;
             emit_caption(&chart.caption, records);
             records.push(Record {
@@ -1491,6 +1495,10 @@ fn serialize_shape_control(
                 level,
                 &serialize_common_obj_attr(&ole.common),
             ));
+            // 캡션 (SHAPE_COMPONENT 앞, level+1)
+            if let Some(ref caption) = ole.caption {
+                serialize_caption(caption, level + 1, records);
+            }
             let drawing = ole_drawing_with_shape_component_contract(ole, true);
             records.push(Record {
                 tag_id: tags::HWPTAG_SHAPE_COMPONENT,

--- a/src/serializer/hwpx/master_page.rs
+++ b/src/serializer/hwpx/master_page.rs
@@ -69,7 +69,7 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
         concat!(
             r#"<?xml version="1.0" encoding="UTF-8" standalone="yes" ?>"#,
             r#"<masterPage {xmlns} id="{id}" type="{ty}" pageNumber="{pn}" pageDuplicate="{pd}" pageFront="{pf}">"#,
-            r#"<hp:subList id="" textDirection="HORIZONTAL" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" hasTextRef="{tr}" hasNumRef="{nr}">"#,
+            r#"<hp:subList id="" textDirection="{td}" lineWrap="BREAK" vertAlign="TOP" linkListIDRef="0" linkListNextIDRef="0" textWidth="{tw}" textHeight="{th}" hasTextRef="{tr}" hasNumRef="{nr}">"#,
             "{body}",
             r#"</hp:subList></masterPage>"#,
         ),
@@ -79,6 +79,11 @@ pub fn render_master_page_xml(mp: &MasterPage, id: &str, ctx: &mut SerializeCont
         pn = mp.hwpx_page_number.unwrap_or(0),
         pd = page_duplicate_str(mp),
         pf = mp.page_front as u8,
+        td = if mp.text_direction == 1 {
+            "VERTICAL"
+        } else {
+            "HORIZONTAL"
+        },
         tw = mp.text_width,
         th = mp.text_height,
         tr = mp.text_ref,
@@ -116,5 +121,30 @@ mod tests {
         let parsed =
             crate::parser::hwpx::section::parse_hwpx_master_page(&xml).expect("master page parse");
         assert!(parsed.page_front, "pageFront 이 왕복에서 보존돼야 함");
+    }
+
+    #[test]
+    fn master_page_text_direction_round_trips() {
+        // 세로쓰기 바탕쪽(hp:subList@textDirection="VERTICAL")이 render→parse 왕복에서
+        // 보존돼야 한다. 종전엔 serializer 가 textDirection="HORIZONTAL" 고정, 파서 미독으로
+        // 세로쓰기가 유실됐다.
+        let mp = MasterPage {
+            text_direction: 1,
+            ..Default::default()
+        };
+        let doc = Document::default();
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = render_master_page_xml(&mp, "0", &mut ctx);
+        assert!(
+            xml.contains(r#"textDirection="VERTICAL""#),
+            "textDirection=VERTICAL 방출: {xml}"
+        );
+
+        let parsed =
+            crate::parser::hwpx::section::parse_hwpx_master_page(&xml).expect("master page parse");
+        assert_eq!(
+            parsed.text_direction, 1,
+            "text_direction 이 왕복에서 보존돼야 함"
+        );
     }
 }

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -565,6 +565,7 @@ mod tests {
             color: 0x000000FF,
             baseline: 120,
             unknown: 0,
+            eqedit: 0,
             font_name: "HYhwpEQ".to_string(),
             version_info: "Equation Version 60".to_string(),
             raw_ctrl_data: Vec::new(),

--- a/src/serializer/hwpx/picture.rs
+++ b/src/serializer/hwpx/picture.rs
@@ -37,7 +37,7 @@ use crate::model::shape::{
 
 use super::context::SerializeContext;
 // [#2712] hp:sz 크기 기준 헬퍼는 도형 직렬화기와 공유한다(관례 이중화 방지).
-use super::shape::{height_criterion_str, size_criterion_str};
+use super::shape::{height_criterion_str, numbering_type_str, size_criterion_str};
 use super::table::write_caption;
 use super::utils::{empty_tag, end_tag, start_tag, start_tag_attrs};
 use super::SerializeError;
@@ -67,6 +67,13 @@ pub fn write_picture<W: Write>(
     // [#2875] 개체 잠금 — 종전 하드코딩 "0" 은 lock="1" 로 저장된 그림의 잠금 정보를
     // 왕복 시 소실시켰다 (#2861 reverse, #2855 hp:tbl lock 과 동일 패턴).
     let lock = bool01(pic.lock);
+    // [#2697 동형] numberingType 은 IR(common.numbering_type)을 보존한다. 종전 "PICTURE"
+    // 하드코딩은 그림에 번호 범주를 변경한(예: NONE) 문서에서 저장 시 원본 속성이 유실됐다.
+    // 도형·표 계열은 이미 #1379/#2697 에서 IR 보존으로 정리됐다.
+    let numbering_type = numbering_type_str(pic.common.numbering_type);
+    // [#TODO-IR] groupLevel 은 IR(shape_attr.group_level)을 보존한다. 종전 "0" 하드코딩은
+    // 그룹 내 그림 개체의 중첩 레벨이 저장 시 유실됐다(shape.rs rect/line 경로는 이미 보존).
+    let group_level = pic.shape_attr.group_level.to_string();
 
     start_tag_attrs(
         w,
@@ -74,7 +81,7 @@ pub fn write_picture<W: Write>(
         &[
             ("id", &id_str),
             ("zOrder", &z_order),
-            ("numberingType", "PICTURE"),
+            ("numberingType", &numbering_type),
             ("textWrap", tw),
             ("textFlow", tf),
             ("lock", lock),
@@ -83,7 +90,7 @@ pub fn write_picture<W: Write>(
                 super::shape::drop_cap_style_str(pic.common.drop_cap_style),
             ),
             ("href", href),
-            ("groupLevel", "0"),
+            ("groupLevel", &group_level),
             ("instid", &instid),
             ("reverse", reverse),
         ],

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -31,7 +31,7 @@ use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType};
 use crate::model::paragraph::{ColumnBreakType, LineSeg, OrphanFieldEnd, Paragraph};
 use crate::model::shape::{
-    CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, TextWrap, VertAlign, VertRelTo,
+    CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, SizeCriterion, TextWrap, VertAlign, VertRelTo,
 };
 
 use super::context::SerializeContext;
@@ -2004,7 +2004,7 @@ fn render_common_shape_xml(
             r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
             "{block}",
             "{geometry}",
-            r#"<hp:sz width="{w}" height="{h}" widthRelTo="ABSOLUTE" heightRelTo="ABSOLUTE"/>"#,
+            r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
             r#"<hp:pos treatAsChar="{tac}" affectLSpacing="0" flowWithText="{fwt}" allowOverlap="{ao}" holdAnchorAndSO="{hold}" vertRelTo="{vr}" vertAlign="{va}" horzRelTo="{hr}" horzAlign="{ha}" vertOffset="{vo}" horzOffset="{ho}"/>"#,
             r#"<hp:outMargin left="{ml}" right="{mr}" top="{mt}" bottom="{mb}"/>"#,
         ),
@@ -2023,6 +2023,12 @@ fn render_common_shape_xml(
         hold = if c.prevent_page_break != 0 { "1" } else { "0" },
         w = c.width,
         h = c.height,
+        // [#2726] 종전 widthRelTo/heightRelTo 는 "ABSOLUTE" 리터럴, protect 는 아예
+        // 미방출이었다. 파서(parse_object_layout_child:2909)가 이미 3값을 IR 에 적재하므로
+        // 저장에서만 버려지는 순손실이었다. #2697(표)·#2712(rect/line/container/pic) 와 동형.
+        wrt = size_criterion_str(c.width_criterion),
+        hrt = height_criterion_str(c.height_criterion),
+        prot = if c.size_protect { "1" } else { "0" },
         vr = vert_rel_to_hwpx(c.vert_rel_to),
         va = vert_align_to_hwpx(c.vert_align),
         hr = horz_rel_to_hwpx(c.horz_rel_to),
@@ -2096,6 +2102,33 @@ fn render_note_attrs(attrs: &NoteAttrs) -> String {
         attrs.suffix_char, attrs.inst_id
     ));
     out
+}
+
+/// [#2726] 너비 기준 → HWPX `widthRelTo`. 파서 `parse_size_criterion(_, true)` 의 정확한 역.
+///
+/// `table.rs:147` 이 `#2697` 로 정립한 관례와 **동일 의미**다. 해당 사본이 private 이라
+/// 이 모듈에서 도달할 수 없어 부득이 복제했다. 공용 위치 1벌 통합은 잔여다(이슈 7장).
+fn size_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column => "COLUMN",
+        SizeCriterion::Para => "PARA",
+        SizeCriterion::Absolute => "ABSOLUTE",
+    }
+}
+
+/// [#2726] 높이 기준 → HWPX `heightRelTo`. 파서는 높이를
+/// `parse_size_criterion(_, allow_column_para = false)` 로 읽으므로(`parser/hwpx/section.rs:1860`)
+/// 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이다. 방출도 같은 3값으로 접어야 왕복이 정확한
+/// 역이 된다 — `COLUMN`/`PARA` 를 내면 되읽기에서 `Absolute` 로 접혀 비-멱등이 된다.
+/// HWP5 측 `height_criterion_to_bits`(`common_obj_attr_writer.rs:160`)도 동일하게 접는다.
+fn height_criterion_str(c: SizeCriterion) -> &'static str {
+    match c {
+        SizeCriterion::Paper => "PAPER",
+        SizeCriterion::Page => "PAGE",
+        SizeCriterion::Column | SizeCriterion::Para | SizeCriterion::Absolute => "ABSOLUTE",
+    }
 }
 
 fn render_note_sublist(
@@ -2588,6 +2621,125 @@ mod tests {
             !xml_empty.contains("<hp:drawText"),
             "빈 글상자는 drawText 를 방출하지 않아야 함"
         );
+    }
+
+    /// [#2726] 공용 도형 경로(ellipse/arc/polygon/curve/chart)의 `hp:sz` 가 IR 의
+    /// 크기 기준·크기 보호를 보존해야 한다. 종전엔 `widthRelTo`/`heightRelTo` 가
+    /// `"ABSOLUTE"` 리터럴이고 `protect` 는 아예 미방출이었다.
+    #[test]
+    fn issue2726_common_shape_sz_preserves_criteria_and_protect() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let c = CommonObjAttr {
+            width: 4000,
+            height: 3000,
+            width_criterion: SizeCriterion::Column,
+            height_criterion: SizeCriterion::Page,
+            size_protect: true,
+            ..Default::default()
+        };
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        for tag in ["ellipse", "arc", "polygon", "curve", "chart"] {
+            let xml = render_common_shape_xml(tag, &c, &None, Some(&drawing), &[], "", &mut ctx);
+            assert!(
+                xml.contains(r#"widthRelTo="COLUMN""#),
+                "{tag}: 너비 기준 COLUMN 이 보존되어야 함: {xml}"
+            );
+            assert!(
+                xml.contains(r#"heightRelTo="PAGE""#),
+                "{tag}: 높이 기준 PAGE 가 보존되어야 함: {xml}"
+            );
+            assert!(
+                xml.contains(r#"protect="1""#),
+                "{tag}: 크기 보호가 보존되어야 함: {xml}"
+            );
+        }
+    }
+
+    /// [#2726] `protect` 는 값이 0 이어도 **속성 자체가** 방출되어야 한다.
+    /// `samples/hwpx` 실제 한글 파일 60개의 `hp:sz` 1583개가 **전부** `protect` 를 갖는다
+    /// (1583/1583). 종전 미방출은 그중 `hp:polygon` 150개(8파일)에서 한컴 원본 대비
+    /// 구조 이탈을 만들었다.
+    #[test]
+    fn issue2726_common_shape_sz_always_emits_protect_attribute() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let c = CommonObjAttr {
+            size_protect: false,
+            ..Default::default()
+        };
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        let xml = render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+        assert!(
+            xml.contains(r#"protect="0""#),
+            "size_protect=false 여도 protect=\"0\" 속성이 방출되어야 함: {xml}"
+        );
+    }
+
+    /// [#2726] `heightRelTo` 는 파서(`parse_size_criterion(_, allow_column_para=false)`)의
+    /// **정확한 역**이어야 한다. 파서 치역이 `{PAPER, PAGE, ABSOLUTE}` 3값뿐이므로
+    /// 방출도 절대 `COLUMN`/`PARA` 를 내면 안 된다 — 내면 되읽기에서 `Absolute` 로 접혀
+    /// 왕복이 비-멱등이 된다. 5값 전수 대조로 못 박는다.
+    #[test]
+    fn issue2726_height_criterion_never_emits_column_or_para() {
+        use crate::model::shape::{CommonObjAttr, DrawingObjAttr};
+
+        let cases = [
+            (SizeCriterion::Paper, "PAPER"),
+            (SizeCriterion::Page, "PAGE"),
+            (SizeCriterion::Column, "ABSOLUTE"),
+            (SizeCriterion::Para, "ABSOLUTE"),
+            (SizeCriterion::Absolute, "ABSOLUTE"),
+        ];
+        let drawing = DrawingObjAttr::default();
+        let mut ctx = SerializeContext::default();
+
+        for (criterion, expected) in cases {
+            assert_eq!(
+                height_criterion_str(criterion),
+                expected,
+                "높이 기준 {criterion:?} 는 {expected} 로 방출되어야 함"
+            );
+
+            let c = CommonObjAttr {
+                height_criterion: criterion,
+                ..Default::default()
+            };
+            let xml =
+                render_common_shape_xml("polygon", &c, &None, Some(&drawing), &[], "", &mut ctx);
+            assert!(
+                xml.contains(&format!(r#"heightRelTo="{expected}""#)),
+                "{criterion:?} → heightRelTo=\"{expected}\" 이어야 함: {xml}"
+            );
+            assert!(
+                !xml.contains(r#"heightRelTo="COLUMN""#) && !xml.contains(r#"heightRelTo="PARA""#),
+                "heightRelTo 는 COLUMN/PARA 를 방출하면 안 됨: {xml}"
+            );
+        }
+    }
+
+    /// [#2726] `widthRelTo` 는 5값 전부를 그대로 방출한다 — 파서
+    /// `parse_size_criterion(_, allow_column_para=true)` 의 정확한 역.
+    #[test]
+    fn issue2726_width_criterion_emits_all_five_values() {
+        let cases = [
+            (SizeCriterion::Paper, "PAPER"),
+            (SizeCriterion::Page, "PAGE"),
+            (SizeCriterion::Column, "COLUMN"),
+            (SizeCriterion::Para, "PARA"),
+            (SizeCriterion::Absolute, "ABSOLUTE"),
+        ];
+        for (criterion, expected) in cases {
+            assert_eq!(
+                size_criterion_str(criterion),
+                expected,
+                "너비 기준 {criterion:?} 는 {expected} 로 방출되어야 함"
+            );
+        }
     }
 
     /// [Task #1627] empty-text(객체-only) 문단에서 bookmark 는 문단 시작으로 끌려가지 않고

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -1755,7 +1755,9 @@ fn page_num_pos_to_str(pos: u8) -> &'static str {
 fn page_num_format_to_str(fmt: u8) -> &'static str {
     match fmt {
         0 => "DIGIT",
-        1 => "CIRCLE_DIGIT",
+        // [#XXXX] OWPML Core 스키마 NumberType1(<hp:pageNum formatType>)의 실제 값은
+        // "CIRCLED_DIGIT"이다 (Core XML schema.xml 12행). "CIRCLE_DIGIT"은 오탈자.
+        1 => "CIRCLED_DIGIT",
         2 => "ROMAN_CAPITAL",
         3 => "ROMAN_SMALL",
         4 => "LATIN_CAPITAL",
@@ -2533,6 +2535,25 @@ fn render_page_border_fill(ty: &str, pbf: &crate::model::page::PageBorderFill) -
 mod tests {
     use super::*;
     use crate::model::paragraph::{CharShapeRef, Paragraph};
+
+    /// [#XXXX] `<hp:pageNum formatType="...">`의 원문자(circled digit) 값은 OWPML Core
+    /// 스키마 NumberType1 표기인 "CIRCLED_DIGIT"이어야 한다. 종전엔 "CIRCLE_DIGIT"(D 없음)
+    /// 오탈자로 방출돼 한컴이 값을 인식하지 못했다.
+    #[test]
+    fn page_num_circled_digit_format_reflects_spec_spelling() {
+        use crate::model::control::PageNumberPos;
+        let mut pn = PageNumberPos::default();
+        pn.format = 1; // circled digit
+        let xml = render_page_num(&pn);
+        assert!(
+            xml.contains(r#"formatType="CIRCLED_DIGIT""#),
+            "pageNum formatType 이 스펙 철자(CIRCLED_DIGIT)여야 함: {xml}"
+        );
+        assert!(
+            !xml.contains(r#"formatType="CIRCLE_DIGIT""#),
+            "CIRCLE_DIGIT 오탈자 잔존 금지: {xml}"
+        );
+    }
 
     #[test]
     fn equation_text_flow_reflects_ir() {

--- a/tests/fixtures/ir_field_sweep_baseline.tsv
+++ b/tests/fixtures/ir_field_sweep_baseline.tsv
@@ -420,20 +420,17 @@ hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[][].common.hwp5_ge
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].raw_header_extra[]	22
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1862
-hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].children[][].shape_attr.group_level	3
-hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].raw_header_extra[]	133
+hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1864
+hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].raw_header_extra[]	134
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1866
-hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].children[][].shape_attr.group_level	3
+hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1869
 hwpx	2024년 2분기 해외직접투자 보도자료ff.hwpx	sections[].paragraphs[].raw_header_extra[]	129
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	doc_info.extra_records.len	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	doc_info.memo_shape_count	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1875
-hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].children[][].shape_attr.group_level	3
+hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1878
 hwpx	2024년 연간 해외직접투자 보도자료 _ ff.hwpx	sections[].paragraphs[].raw_header_extra[]	118
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	doc_info.extra_records.len	1
 hwpx	2025년 1분기 해외직접투자 보도자료f.hwpx	doc_info.memo_shape_count	1
@@ -584,9 +581,8 @@ hwpx	hwpx-centered-cell-vpos-after-tac-shape.hwpx	sections[].paragraphs[].contro
 hwpx	hwpx-centered-cell-vpos-after-tac-shape.hwpx	sections[].paragraphs[].raw_header_extra[]	15
 hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1
-hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1862
-hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].children[][].shape_attr.group_level	3
-hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].raw_header_extra[]	133
+hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1864
+hwpx	hwpx-h-01.hwpx	sections[].paragraphs[].raw_header_extra[]	134
 hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	1868
 hwpx	hwpx-h-02.hwpx	sections[].paragraphs[].raw_header_extra[]	132
 hwpx	hwpx-h-03.hwpx	doc_info.extra_records.len	1

--- a/tests/hwpx_to_hwp_adapter.rs
+++ b/tests/hwpx_to_hwp_adapter.rs
@@ -352,7 +352,9 @@ fn task888_basic_table_materializes_hancom_table_attrs() {
         table.raw_table_record_attr, 0x0400_0006,
         "HWPX table record attr는 pageBreak/repeatHeader/noAdjust와 안쪽 여백 활성 계약 필드로 재구성한다"
     );
-    assert_eq!(report.table_record_row_sizes_materialized, 1);
+    // [#3062] row_sizes 는 이제 HWPX 파서가 셀 수로 직접 채우므로 어댑터
+    // materialize 는 no-op 이다 (attr 계열과 동일한 "파서가 이미 한다" 계약).
+    assert_eq!(report.table_record_row_sizes_materialized, 0);
     assert_eq!(table.row_sizes, vec![4, 4, 4]);
     assert!(table.raw_ctrl_data.len() >= 4);
     assert_eq!(
@@ -408,7 +410,8 @@ fn task888_expense_report_materializes_tac_table_ctrl_attrs() {
         report.table_ctrl_header_attr_materialized, 0,
         "HWPX 파서가 TAC table CTRL_HEADER attr를 이미 materialize한다"
     );
-    assert_eq!(report.table_record_row_sizes_materialized, 2);
+    // [#3062] row_sizes 는 파서가 직접 채우므로 어댑터 materialize 는 0 이다.
+    assert_eq!(report.table_record_row_sizes_materialized, 0);
 }
 
 #[test]


### PR DESCRIPTION
kevin9327 님의 hwpx-section 축 11건을 메인테이너가 재실증 후 통합한다. 오늘 방침대로 충돌분(#3101)을 같은 축에 흡수했다.

## 채택 11건

| PR | 결함 |
|---|---|
| #3062 (`Closes #3057`) | 표 row_sizes 를 셀 높이 대신 셀 수로 채움 — 파서 직채움 |
| #3087 (`Closes #2726`) | 공용 도형 경로(ellipse/arc/polygon/curve/chart) hp:sz 크기 기준·크기 보호 왕복 소실 |
| #3092 | hp:parameters 의 stringParam(Command) CDATA 본문 미파싱 |
| #3099 | hp:dutmal mainText/subText CDATA 본문 미파싱 — 덧말 텍스트 소실 |
| #3101 (`Closes #2745`) | hp:pic 저장 시 numberingType·groupLevel 속성 유실 |
| #3103 | hp:equation 의 hp:script CDATA 본문 미파싱 — 수식 스크립트 소실 |
| #3106 | hp:composeText CDATA 본문 미파싱 — 글자겹치기 텍스트 소실 |
| #3109 | hp:ole/hp:chart numberingType 저장 시 NONE 하드코딩 |
| #3110 | hh:shadow type 예약값(3)이 저장 시 CONTINUOUS 로 오방출 |
| #3117 (`Closes #2846`) | 바탕쪽 hp:subList textDirection 왕복 시 세로쓰기 유실 |
| #3155 (`Closes #3149`) | hp:equation version/baseLine/font 생략 시 OWPML 스키마 기본값 복원 |

## 충돌 흡수와 판단

- **#3101 스택 브랜치 선별**: 브랜치 8커밋 중 타 PR 잔재 5커밋은 패치ID 로 기반영 확인 후 제외. "리베이스 잔재 롤백" 커밋도 제외 — 기여자 브랜치 안에서만 존재하던 중복(스택 커밋 + upstream 기merge 공존)을 지우는 브랜치 로컬 청소라, devel 에 적용하면 정상 코드를 삭제한다. 실질 수정 + baseline 갱신 2커밋만 채택했고 IR 필드 스윕 게이트 green 으로 검증했다.
- **속성 병치**: #3101 의 numberingType/groupLevel 이 배치 A(#2881 lock, #2888 dropcapstyle)가 선점한 hp:pic 속성 블록과 충돌 — 합집합으로 병치.
- **어댑터 테스트 기대치 갱신**: #3062 가 row_sizes 채움을 파서로 옮긴 의도된 결과로 hwpx_to_hwp_adapter 의 materialize 계수가 0 이 됨. 해당 테스트 파일의 기존 계약("파서가 이미 하면 계수 0")에 맞춰 2건 갱신.

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 11건 반영을 패치ID + 내용 diff 로 개별 검증, 최신 devel(#3158 포함) rebase 후 표적 재확인

Co-authored-by 로 원 커밋 provenance 를 보존한다.
