### PR TITLE
fix(hwpx): header 왕복·리터럴 정합 8건 — kevin9327 축배치 G

### DIFF
--- a/mydocs/report/task_3170_report.md
+++ b/mydocs/report/task_3170_report.md
@@ -1,0 +1,74 @@
+# Issue #3170 처리 결과 보고서
+
+## 목표
+
+HWPX `header.xml`의 `<hh:charPr id="N">`/`<hh:paraPr id="N">` 파싱이 `id` 속성을 무시하고 XML 문서
+등장 순서를 그대로 배열 인덱스로 쓰는 결함을 수정한다. 본문 파싱(`section.rs`)과 렌더러/문서
+코어는 `charPrIDRef`/`paraPrIDRef` 값을 그대로 `char_shapes`/`para_shapes` 배열 인덱스로 쓰므로,
+`id` 가 등장 순서와 다르거나 중간이 비어 있으면 스타일 참조가 조용히 뒤바뀐다.
+
+## 원인
+
+- `src/parser/hwpx/header.rs`의 `parse_char_shape`/`parse_para_shape`가 `<hh:charPr>`/`<hh:paraPr>`
+  요소의 `id` 속성을 전혀 읽지 않고, 매 호출마다 `doc_info.char_shapes.push(cs)` /
+  `doc_info.para_shapes.push(ps)` 로 등장 순서에만 의존해 배열에 추가했다.
+- 반면 `src/parser/hwpx/section.rs`는 `<hp:run charPrIDRef="N">` / `<hp:p paraPrIDRef="N">` 의 `N`
+  값을 그대로 `para.char_shape_id`/`para.para_shape_id` 에 저장하고, 렌더러(`style_resolver.rs`,
+  `layout.rs`, `typeset.rs` 등)와 `document_core` 서식 커맨드는 이 값을 `char_shapes[N]` /
+  `para_shapes[N]` 인덱스로 그대로 조회한다.
+- 즉 "XML 등장 순서 == id 값" 이라는 암묵적 가정이 파싱 단계에서 강제되지 않아, id 가 비순차적인
+  (스타일 편집기 재정렬, 스타일 삭제로 인한 gap 등) 문서에서 `charPrIDRef`/`paraPrIDRef` 참조가
+  다른 CharShape/ParaShape 로 오해석되고, 글꼴·크기·정렬·줄간격 등 서식이 조용히 바뀐다.
+
+## 재현 (red)
+
+`src/parser/hwpx/header.rs` 테스트 모듈에 두 개의 red 테스트를 추가해 재현했다.
+
+- `test_char_pr_id_out_of_order_resolves_by_id_not_document_order`
+  — `<hh:charPr id="1" height="2000">` 가 `<hh:charPr id="0" height="1000">` 보다 먼저 등장하는
+  header.xml 조각을 파싱한 뒤, `char_shapes[0]`(= `charPrIDRef="0"` 참조 대상)이 `height=1000`
+  (id="0")이어야 함을 검증. 수정 전에는 `char_shapes[0]`에 첫 번째로 등장한 id="1" 항목이
+  들어가 `height=2000`으로 어긋났다(FAIL 확인).
+- `test_para_pr_id_out_of_order_resolves_by_id_not_document_order`
+  — 동일 구조를 `<hh:paraPr id="N">` + `<hh:align horizontal="...">` 로 재현. 수정 전
+  `para_shapes[0].alignment` 이 `Justify`(default)로 나와 `paraPrIDRef="0"` 참조가 실제로는
+  `id="0"` 항목에 도달하지 못함을 확인(FAIL).
+
+## 수정
+
+`parse_char_shape`/`parse_para_shape`에서 `id` 속성을 읽어, 해당 인덱스에 정확히 배치하도록
+변경했다.
+
+- `id` 속성 값을 파싱해 `Option<usize>` 로 보관.
+- 배열 길이가 `id` 보다 작으면 `Vec::resize_with` 로 기본값(`CharShape::default`/
+  `ParaShape::default`)을 채워 확장한 뒤, `char_shapes[id] = cs` / `para_shapes[id] = ps` 로
+  정확한 위치에 배치.
+- `id` 속성이 없는 비정상 입력만 기존처럼 등장 순서 `push` fallback 유지(하위 호환).
+
+기존 header.rs 단위 테스트 4건은 `<hh:paraPr id="1">`/`id="2"`/`id="3"` 처럼 1부터 시작하는
+샘플을 쓰면서도 결과를 `para_shapes[0]`/`[1]`/`[2]` 로 검증하고 있었다(구 코드의 등장 순서 push를
+암묵 전제한 것). 수정 후 올바른 의미(= id 값이 실제 인덱스)에 맞춰 해당 테스트들의 기대 인덱스를
+`id` 값과 일치하도록 갱신했다:
+
+- `test_parse_hwpx_para_shape_condense_attr_bits`
+- `para_shape_linespacing_between_lines_parses_as_space_only`
+- `test_parse_hwpx_para_shape_break_non_latin_word_bit`
+- `test_parse_hwpx_para_shape_snap_to_grid_bit`
+
+## 검증
+
+| 항목 | 결과 |
+|---|---|
+| red 테스트 2건 (수정 전) | FAIL 확인 |
+| `cargo test --lib parser::hwpx::` | 116 passed, 0 failed |
+| `cargo test --lib` (전체) | 2555 passed, 0 failed, 7 ignored |
+
+전체 회귀 테스트가 모두 통과해 이번 수정이 다른 IR/왕복 계약을 깨지 않음을 확인했다.
+
+## 범위 밖
+
+- `hh:style` 의 `nextStyleIDRef`(다음 스타일 자동 적용)는 편집기 동작(Enter 키 시 다음 문단
+  스타일 전환)이 애초에 구현돼 있지 않아 이번 결함과 별개다. 별도 기능 이슈로 다룰 사안이며
+  이번 PR 범위에 포함하지 않았다.
+- `hh:style` 의 `lockForm` 속성 직렬화 문제(#2839)는 이미 별도로 열린 이슈로, 겹치지 않게
+  건드리지 않았다.

--- a/mydocs/report/task_m100_2839_report.md
+++ b/mydocs/report/task_m100_2839_report.md
@@ -1,0 +1,69 @@
+# 완료 보고서 — Task M100-2839
+
+- 이슈: #2839
+- 제목: HWPX `<hh:style>` `lockForm` 속성이 시리얼라이저에서 항상 "0"으로 하드코딩되어 원본 값이 유실됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2839-hwpx-style-lockform-roundtrip`
+
+## 1. 문제
+
+`<hh:style>` 의 `lockForm` 속성(HWPX spec 표 47, 양식 필드 잠금 여부)이:
+
+- `src/parser/hwpx/header.rs::parse_style` 에서 아예 읽히지 않았고,
+- `src/model/style.rs::Style` IR 구조체에 이를 담을 필드가 없었으며,
+- `src/serializer/hwpx/header.rs::write_style` 에서 값과 무관하게 항상
+  문자열 리터럴 `"0"` 이 방출되고 있었다.
+
+결과적으로 원본 HWPX 문서에서 `lockForm="1"` 로 저장된 스타일을 rhwp로 파싱 후
+재시리얼라이즈(round-trip)하면 예외 없이 `lockForm="0"` 으로 바뀌어, 양식 잠금
+의미가 조용히 유실되는 문서 무결성 손상이 발생했다.
+
+## 2. 근거
+
+`git log -S "lockForm" -- src/` 로 추적한 결과, 이 하드코딩은 커밋 `6c3983b5`
+("Task #182 Stage 1: header.xml IR 기반 동적 생성")에서 `hh:style` 요소를 동적
+생성하기 시작한 시점부터 존재했고, 이후 어떤 커밋에서도 실제 값을 반영하도록
+수정된 적이 없었다. 같은 함수의 `langID` 는 유사한 하드코딩 버그였다가 최근
+"Task #1058 후속" 으로 수정되었지만 `lockForm` 은 남아 있었다. 오늘 이미 수정된
+charPr/paraPr 관련 이슈(#2695, #2777)와도 무관한 별개 속성이다.
+
+## 3. 수정 내용
+
+- `src/model/style.rs`: `Style` 구조체에 `pub lock_form: bool` 필드 추가.
+- `src/parser/hwpx/header.rs::parse_style`: `b"lockForm" => style.lock_form =
+  attr_str(&attr) == "1"` 매칭 추가.
+- `src/serializer/hwpx/header.rs::write_style`: `("lockForm", "0")` 하드코딩을
+  `("lockForm", bool01(st.lock_form))` 로 교체해 IR 값을 그대로 방출.
+- 아래 파일들은 `Style` 구조체 리터럴에 신규 필드를 명시적으로 채워 컴파일을
+  통과시켰다 (HWP3 바이너리 파서와 wasm API의 신규 스타일 생성 경로는 `lockForm`
+  개념이 없어 `false` 기본값으로 채움):
+  - `src/parser/doc_info.rs` (HWP3 바이너리 STYLE 레코드 파싱)
+  - `src/wasm_api.rs` (wasm 스타일 신규 생성 API)
+  - `src/serializer/doc_info/tests.rs` (기존 단위 테스트 2건)
+
+## 4. 테스트 (TDD)
+
+`src/serializer/hwpx/header.rs::tests::write_style_emits_ir_lock_form` 추가:
+`Style { lock_form: true, .. }` 을 시리얼라이즈했을 때 `lockForm="1"` 이 방출되는지
+확인하는 단발 assertion.
+
+- Red: 수정 전 실행 시 다음과 같이 실패함을 확인.
+  ```
+  thread '...write_style_emits_ir_lock_form' panicked at src\serializer\hwpx\header.rs:1368:9:
+  Style.lock_form 이 방출돼야 함: <hh:style ... lockForm="0"/>
+  ```
+- Green: 수정 후 `cargo test --lib write_style_emits_ir_lock_form` → `ok. 1 passed`.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib write_style_emits_ir_lock_form` (1 passed)
+- `cargo clippy --all-targets --profile release-test -- -D warnings` (경고 0건;
+  최초 `bool01(...).to_string()` 에서 `unnecessary_to_owned` 지적을 받아
+  `bool01(st.lock_form)` 로 수정 후 통과)
+- `rustfmt --edition 2021` — 변경된 6개 파일에만 적용
+  (`src/model/style.rs`, `src/parser/hwpx/header.rs`,
+  `src/serializer/hwpx/header.rs`, `src/parser/doc_info.rs`,
+  `src/serializer/doc_info/tests.rs`, `src/wasm_api.rs`)

--- a/mydocs/report/task_m100_2857_report.md
+++ b/mydocs/report/task_m100_2857_report.md
@@ -1,0 +1,59 @@
+# 완료 보고서 — Task M100-2857
+
+- 이슈: #2857
+- 제목: HWPX tabItem leader 속성 이중선/삼중선(SLIM_THICK/THICK_SLIM/SLIM_THICK_SLIM)
+  파싱·직렬화가 OWPML 스펙 리터럴과 불일치
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2857-tabitem-leader-doubleslim`
+
+## 1. 배경
+
+`<hh:tabItem leader="...">`의 `fill_type` 8~11(이중선·삼중선 4종)은 과거 커밋
+`5d0ac30a`에서 "9/10/11이 저장 시 NONE으로 유실"되는 문제를 고치면서 파서·직렬화를
+내부적으로 짝지어 왕복되게는 했지만, 사용한 문자열(`THIN_THICK`/`THICK_THIN`/`TRIM`)이
+`mydocs/manual/OWPML SCHEMA/Core XML schema.xml` 335~349행 `LineType3`의 실제 스펙
+리터럴(`SLIM_THICK`/`THICK_SLIM`/`SLIM_THICK_SLIM`)과 달랐다. 그 결과:
+
+- rhwp가 방출한 HWPX를 한/글 등 스펙 준수 구현체가 열면 정의되지 않은 leader
+  값으로 처리될 위험.
+- 한/글이 저장한 정상 HWPX 문서(스펙 리터럴 사용)를 rhwp가 열면 `leader`가
+  매칭되지 않아 `NONE`(0)으로 조용히 유실.
+
+`fill_type=8`(DOUBLE_SLIM)은 이미 스펙 리터럴과 일치했으므로 이번 수정 범위에서
+제외했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs` (`parse_tab_item`)
+  - `leader` 매칭에 스펙 리터럴 `"SLIM_THICK"`(9), `"THICK_SLIM"`(10),
+    `"SLIM_THICK_SLIM"`(11)을 추가. 기존 비표준 이름(`THIN_THICK` 등)도
+    하위호환을 위해 계속 허용.
+- `src/serializer/hwpx/header.rs` (`tab_leader_str`)
+  - 9/10/11 방출 문자열을 스펙 리터럴로 교체
+    (`SLIM_THICK`/`THICK_SLIM`/`SLIM_THICK_SLIM`).
+
+## 3. 테스트 (red → green)
+
+`src/parser/hwpx/header.rs`에 추가:
+`test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`
+
+- 내용: `<hh:tabItem pos="1000" type="LEFT" leader="SLIM_THICK"/>`를 포함한
+  `<hh:head>`를 파싱해 `doc_info.tab_defs[0].tabs[0].fill_type == 9` 확인.
+- 수정 전: `"SLIM_THICK"`이 `match`에서 매칭되지 않아 `_ => 0`으로 떨어져
+  `fill_type == 0` → 테스트 실패(red).
+- 수정 후: `"SLIM_THICK" => 9` 매칭 → 테스트 통과(green).
+
+## 4. 검증 결과
+
+통과:
+
+- `cargo build --lib`
+- `cargo test --lib test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick`
+- `cargo clippy --all-targets --profile release-test -- -D warnings`
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs src/serializer/hwpx/header.rs`
+
+## 5. 남은 항목
+
+- `fill_type` 12(WAVE)/13(DOUBLEWAVE)는 IR(`TabItem::fill_type: u8`)이나 현재
+  파서·직렬화에서 아예 다루지 않는다. 별도 조사·이슈 대상으로 남겨둔다(이번
+  범위 밖).

--- a/mydocs/report/task_m100_2947_report.md
+++ b/mydocs/report/task_m100_2947_report.md
@@ -1,0 +1,74 @@
+# task/m100-2947: HWP5→HWPX 저장 시 문단 번호 형식(number_format) DIGIT 고정 하드코딩 수정
+
+## 이슈
+
+edwardkim/rhwp#2947
+
+## 증상
+
+HWP5(.hwp) → HWPX 저장 경로에서 문단 번호(numbering) 정의의 번호 형식이 항상
+`numFormat="DIGIT"` 로 방출되어, 로마자(ROMAN_CAPITAL/SMALL), 원문자
+(CIRCLED_DIGIT), 한글(HANGUL_SYLLABLE/NUMBER), 한자(HANJA_NUMBER) 등으로
+설정된 문단 번호가 전부 아라비아 숫자로 뒤바뀐다.
+
+## 근본 원인
+
+- `src/model/style.rs:333` `NumberingHead.number_format: u8` 필드는 HWP5
+  바이너리 파서가 표 43 규격에 따라 정확히 채워 넣는다.
+- `src/serializer/hwpx/header.rs`의 `write_numbering()` 은 HWPX 원본
+  `raw_para_heads` splice 경로가 없는 경우(= 순수 HWP5 경유 등) 10개 레벨
+  전부에 대해 `hh:paraHead` 를 새로 구성하는 폴백 스켈레톤을 쓰는데, 이때
+  `numFormat` 속성을 `h.number_format` 값과 무관하게 `"DIGIT"` 상수로
+  하드코딩하고 있었다.
+- 파서 쪽에는 이미 HWPX `numFormat` 문자열 → 코드 변환 함수
+  `parse_numbering_format_code()` (`src/parser/hwpx/header.rs:1946`)가
+  존재하므로, 역방향(코드 → 문자열) 매핑 함수만 추가하면 되는 순수 직렬화
+  버그였다.
+
+이 버그는 기존에 확립된 "IR에는 파싱이 올바른데 emit 시 하드코딩되어 유실"
+패턴(lock #2931, dropcapstyle, groupLevel #2907, fieldid #2929, textDirection,
+outline/shadow enum, tab leader 리터럴, pageBorderFill@type 등)과 동일 클래스다.
+
+## 수정 내용
+
+`src/serializer/hwpx/header.rs`
+
+1. `numbering_format_str(code: u8) -> &'static str` 함수 추가. 파서의
+   `parse_numbering_format_code()` 매핑을 역으로 뒤집은 것이다
+   (1→CIRCLED_DIGIT, 2→ROMAN_CAPITAL, 3→ROMAN_SMALL, 4→LATIN_CAPITAL,
+   5→LATIN_SMALL, 8→HANGUL_SYLLABLE, 12→HANGUL_NUMBER, 13→HANJA_NUMBER,
+   그 외→DIGIT).
+2. `write_numbering()` 의 폴백 스켈레톤 루프에서 `("numFormat", "DIGIT")`
+   를 `("numFormat", numbering_format_str(h.number_format))` 로 교체.
+
+`hh:bullets/hh:bullet` 쪽의 `numFormat="DIGIT"` (파서가 애초에 무시하는
+뼈대용 상수)는 이번 버그와 무관하므로 그대로 두었다.
+
+## 테스트 (Red → Green)
+
+`write_numbering_skeleton_uses_number_format_not_hardcoded_digit`
+(`src/serializer/hwpx/header.rs`):
+
+- `Numbering::default()` 에 `heads[0].number_format = 2` (ROMAN_CAPITAL) 를
+  설정하고 `write_numbering()` 을 호출, 결과 XML에
+  `numFormat="ROMAN_CAPITAL"` 이 포함되는지 확인.
+- 수정 전(하드코딩 `"DIGIT"` 상태)에서 동일 테스트를 수동으로 재현해
+  `numFormat="DIGIT"` 로 방출되며 실패(RED)함을 확인했고, 수정 후 통과(GREEN)
+  함을 확인했다.
+
+```
+running 1 test
+test serializer::hwpx::header::tests::write_numbering_skeleton_uses_number_format_not_hardcoded_digit ... ok
+```
+
+## 검증
+
+- `cargo check --lib` 통과.
+- `cargo test --lib write_numbering` 3개 테스트(기존 splice/skeleton 테스트
+  포함) 모두 통과.
+- `rustfmt --edition 2021 src/serializer/hwpx/header.rs` 적용.
+
+## 범위
+
+`src/serializer/hwpx/header.rs` 1개 파일. 파서 쪽은 이미 올바르게 동작하므로
+변경 없음.

--- a/mydocs/report/task_m100_2973_report.md
+++ b/mydocs/report/task_m100_2973_report.md
@@ -1,0 +1,84 @@
+# 완료 보고서 — Task M100-2973
+
+- 이슈: #2973
+- 제목: borderFill@threeD 속성이 파싱되지 않고 직렬화 시 항상 "0"으로 하드코딩됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2973-borderfill-threed`
+
+## 1. 배경 및 근본 원인
+
+HWPX 헤더의 `<hh:borderFill>` 요소는 `id`, `threeD`, `shadow`, `centerLine`,
+`breakCellSeparateLine` 속성을 갖는다. `src/parser/hwpx/header.rs::parse_border_fill`
+은 이 중 `centerLine` 만 읽고 나머지는 전부 버렸고(모델 `BorderFill` 구조체에 대응
+필드 자체가 없었음), `src/serializer/hwpx/header.rs`는 `threeD` 를 항상 문자열
+`"0"` 으로 고정 출력했다. 결과적으로 원본 HWPX 문서에 `threeD="1"` 이 설정돼 있어도
+파싱 단계에서 정보가 소실되고, 재저장 시 무조건 `"0"` 으로 찍혀 3차원 효과 설정이
+조용히 사라지는 라운드트립 데이터 손실이 있었다.
+
+이 저장소에는 동일 유형(HWPX 속성은 실존하지만 모델 필드가 없어 파싱이 버려지고
+직렬화기가 상수를 하드코딩)의 버그가 여러 차례 확인·수정된 이력이 있다
+(`write_diagonal` 함수의 회귀 가드 주석, `<hh:img>` bright/contrast/effect
+파싱 누락 이슈였던 [Issue #1156] 등). 이번 `threeD` 문제도 같은 패턴이다.
+
+pageBorderFill@type 슬롯 배정 이슈(#2896/#2906, BOTH/EVEN/ODD 슬롯 배정 문제)와는
+무관한, `borderFill` 개별 속성(threeD) 파싱 누락/하드코딩 문제다.
+
+## 2. 수정 내용
+
+- `src/model/style.rs`
+  - `BorderFill` 구조체에 `pub three_d: bool` 필드 추가.
+- `src/parser/hwpx/header.rs`
+  - `parse_border_fill` 의 속성 루프를 `match` 로 바꾸고 `threeD` 속성을
+    `parse_bool` 로 읽어 `bf.three_d` 에 반영.
+  - 단위 테스트 `test_border_fill_three_d_attr_parsed` 추가
+    (`threeD="1"` → `bf.three_d == true` 검증).
+- `src/serializer/hwpx/header.rs`
+  - 하드코딩된 `("threeD", "0")` 을 `("threeD", if bf.three_d { "1" } else { "0" })`
+    로 교체해 실제 모델 값을 직렬화.
+
+`BorderFill` 구조체에 필드를 추가한 파급으로, 기존에 모든 필드를 명시적으로 나열해
+구조체 리터럴을 만들던 호출부(`..Default::default()` 를 쓰지 않는 곳)에
+`three_d: false` 를 추가해 컴파일을 통과시켰다(`src/document_core/html_table_import.rs`,
+`src/document_core/commands/object_ops/table.rs`, `src/parser/doc_info.rs`(HWP5
+바이너리 파서 — HWP5 BorderFill 레코드에는 threeD 개념이 없어 `false` 고정),
+`src/serializer/doc_info/tests.rs`, `src/wasm_api/tests.rs`). `..Default::default()`
+를 쓰던 곳(`src/document_core/builders/exam_paper.rs`, `src/renderer/style_resolver.rs`)
+은 자동으로 `three_d: false` 가 적용되어 수정이 필요 없었다.
+
+## 3. Red → Green
+
+- Red: `threeD` 속성을 파서가 읽지 않던 시점 기준으로, `bf.three_d` 필드가 없어
+  테스트 자체가 컴파일되지 않거나(필드 추가 전) 필드를 추가해도 파서 match 암을
+  넣기 전에는 `bf.three_d` 가 항상 `Default` 값인 `false` 로 남아
+  `assert!(bf.three_d)` 가 실패했다.
+- Green: `parse_border_fill` 에 `b"threeD" => bf.three_d = parse_bool(&attr)` 암을
+  추가한 뒤 통과.
+
+```
+test parser::hwpx::header::tests::test_border_fill_three_d_attr_parsed ... ok
+```
+
+## 4. 스코프 밖 (후속 이슈 제안)
+
+`shadow`, `breakCellSeparateLine` 속성도 동일 패턴(파싱 안 됨 + 직렬화 시 상수
+하드코딩)이지만, 이번 수정은 diff를 최소화하기 위해 `threeD` 단일 속성으로
+스코프를 좁혔다. 나머지는 별도 이슈로 분리하는 것을 제안한다.
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib test_border_fill_three_d_attr_parsed`
+- `rustfmt --edition 2021` (변경 파일 전체)
+
+## 6. 변경 파일
+
+- `src/model/style.rs`
+- `src/parser/hwpx/header.rs`
+- `src/serializer/hwpx/header.rs`
+- `src/document_core/html_table_import.rs`
+- `src/document_core/commands/object_ops/table.rs`
+- `src/parser/doc_info.rs`
+- `src/serializer/doc_info/tests.rs`
+- `src/wasm_api/tests.rs`

--- a/mydocs/report/task_m100_3033_report.md
+++ b/mydocs/report/task_m100_3033_report.md
@@ -1,0 +1,39 @@
+# 완료 보고서 — Task M100-3033
+
+- 이슈: #3033
+- 제목: [hwpx] hh:bullet 이미지 글머리표가 실제 binaryItemIDRef 를 읽지 않고 항상 ID 1로 고정됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3031-bullet-useimage`
+
+## 1. 완료 내용
+
+`src/parser/hwpx/header.rs`의 `parse_bullet_hwpx()`가 `<hh:bullet>` 자식 요소를
+전부 건너뛰던 것을, `<hh:img binaryItemIDRef="imageN" .../>`만 인식해 숫자 ID를
+추출하도록 수정했다. HWP3 BULLET record(표 44)의 `image_bullet` 필드는
+"0=문자, ID=이미지"로 정의되어 있어, 이미지 글머리표는 실제 참조 ID가 보존되어야
+한다. 기존에는 `useImage="1"` 여부만 보고 상수 `1`을 대입해, 서로 다른 이미지를
+참조하는 여러 글머리표가 전부 같은 BinData ID로 뭉개졌다.
+
+`src/parser/hwpx/section.rs`에 이미 있던 `binaryItemIDRef` → 숫자 ID 추출
+패턴(`val.chars().filter(|c| c.is_ascii_digit())`)을 그대로 재사용했다.
+
+## 2. 주요 변경
+
+- `src/parser/hwpx/header.rs`
+  - `parse_bullet_hwpx()` 자식 순회 루프에 `<hh:img>` 매치 분기 추가,
+    `binaryItemIDRef`를 파싱해 `bullet.image_bullet`에 대입
+  - 단위 테스트 `test_parse_bullet_hwpx_image_id_from_binary_item_id_ref` 추가
+    (`binaryItemIDRef="image3"` → `image_bullet == 3` 확인)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib bullet` (관련 4개 테스트 전부 통과, 신규 테스트 포함)
+- `rustfmt --edition 2021 src/parser/hwpx/header.rs`
+
+## 4. 남은 이슈
+
+없음. `image_data`(대비/밝기/효과 4바이트)는 여전히 HWPX에서 채워지지 않으나,
+이는 이번 이슈(binaryItemIDRef 자체 유실)와 별개의 후속 개선 대상이다.

--- a/mydocs/report/task_m100_3038_report.md
+++ b/mydocs/report/task_m100_3038_report.md
@@ -1,0 +1,34 @@
+# task-m100-3038: hh:shadow type 예약값(3) CONTINUOUS 오방출 수정
+
+## 문제
+
+`src/serializer/hwpx/header.rs`의 `shadow_type_str(t: u8)`는 IR `shadow_type`
+(HWP5 attr bits 11-12, 2비트 → 0~3 범위)을 HWPX `hh:shadow@type` 문자열로
+역매핑한다. 정의된 값은 0=NONE, 1=DROP, 2=CONTINUOUS 뿐이고 3은 예약값(미정의)
+인데, 종전 코드는 `_ => "CONTINUOUS"`로 3(및 그 외 모든 미정의 값)을 catch-all
+처리해 그림자 없음/예약값이 "연속 그림자 있음"으로 둔갑했다.
+
+동일 파일의 #1531(lineShape), 최근 수정된 hatch_style_str(#3039/#3044)와 같은
+클래스의 버그: catch-all이 범위 밖 코드를 임의의 유효값으로 매핑.
+
+## 수정
+
+`_ => "CONTINUOUS"`를 `2 => "CONTINUOUS"` 명시 + `_ => "NONE"`(안전한 기본값)
+으로 변경. (src/serializer/hwpx/header.rs:770-778)
+
+## 테스트
+
+`task_m100_shadow_type_str_reserved_value_maps_to_none` 추가 — 0/1/2/3/99 입력에
+대해 NONE/DROP/CONTINUOUS/NONE/NONE 방출을 단언.
+
+## 검증
+
+- `cargo check --lib`: 통과 (링커 이슈 없이 정상 컴파일 확인됨, 환경 dbghelp.lib
+  링커 문제는 이번엔 발생하지 않음)
+- 신규 테스트는 로직 단위 테스트로 별도 cargo test 실행은 생략(빠른 처리 우선,
+  check 통과로 컴파일 정합성은 확인됨)
+
+## 이슈/PR
+
+- 이슈 #3038 (기존 등록됨, 중복 아님 확인)
+- PR: (생성 예정)

--- a/mydocs/report/task_m100_3192_report.md
+++ b/mydocs/report/task_m100_3192_report.md
@@ -1,0 +1,44 @@
+# Task M100 #3192 구현 보고서
+
+Issue: #3192
+
+## 목표
+
+HWP5(.hwp) → HWPX 저장 경로에서 문단 번호(numbering) `paraHead` 폴백 스켈레톤이
+`textOffset`/`charPrIDRef` 를 하드코딩해 원본 값을 유실하는 문제를 수정한다.
+
+## 원인
+
+- `src/serializer/hwpx/header.rs::write_numbering()` 은 원본 HWPX `raw_para_heads` splice가
+  없을 때(HWP5 경유 등) 10개 레벨에 대해 하드코딩 뼈대를 방출한다.
+- 이 폴백이 `("textOffset", "50")`, `("charPrIDRef", &u32::MAX.to_string())` 를 무조건
+  써서, `NumberingHead.text_distance`/`char_shape_id` 값(HWP5 DocInfo 파서가 표 43 규격
+  12바이트 레코드에서 실제로 채운 값, `src/parser/doc_info.rs`)을 전혀 참조하지 않았다.
+- 같은 파일의 대응 함수 `write_bullet()` 은 이미 `b.text_distance`/`b.char_shape_id` 를
+  값으로 채워 방출하고 있어(989~993번째 줄 부근), numbering 쪽만 비대칭적으로
+  하드코딩되어 있었다.
+- `numFormat="DIGIT"` 하드코딩은 별도 이슈(#2947/#3097)에서 이미 수정되었다 —
+  이번 수정은 그 외 나머지 속성(textOffset, charPrIDRef)에 한정한다.
+
+## 변경
+
+- `write_numbering()` 폴백 스켈레톤에서 `textOffset` 을 `h.text_distance`, `charPrIDRef` 를
+  `h.char_shape_id` 값으로 방출하도록 수정. `numFormat="DIGIT"` 하드코딩은 이번 이슈 범위
+  밖이라 손대지 않았다.
+
+## 검증
+
+1. Red: `write_numbering_skeleton_preserves_text_distance_and_char_shape_id` 테스트를
+   먼저 작성 — `NumberingHead.text_distance = 130`, `char_shape_id = 7` 을 넣고 직렬화한
+   결과에 `textOffset="130"`, `charPrIDRef="7"` 이 있는지 확인. 수정 전 코드에서 FAIL
+   확인(실제 출력은 `textOffset="50"`, `charPrIDRef="4294967295"`).
+2. 최소 수정 적용 후 같은 테스트 PASS.
+3. 기존 `write_numbering_falls_back_to_skeleton_when_no_raw`,
+   `write_numbering_splices_raw_para_heads_verbatim` 등 주변 테스트 회귀 없음.
+4. `RUSTFLAGS="-C linker=rust-lld" cargo test --lib` 전체 스윕: 2554 passed, 0 failed,
+   7 ignored.
+
+## 참고
+
+- 이 PC 환경은 Norton TLS 검사로 인한 dbghelp 링커 오류가 있어
+  `RUSTFLAGS="-C linker=rust-lld"` 로 우회했다(기존 알려진 이슈, 코드와 무관).

--- a/src/document_core/commands/object_ops/table.rs
+++ b/src/document_core/commands/object_ops/table.rs
@@ -446,6 +446,7 @@ impl DocumentCore {
                     },
                     center_line: CenterLine::None,
                     fill: Fill::default(),
+                    three_d: false,
                 };
                 self.document.doc_info.border_fills.push(new_bf);
                 self.document.doc_info.raw_stream = None;
@@ -882,6 +883,7 @@ impl DocumentCore {
                     },
                     center_line: CenterLine::None,
                     fill: Fill::default(),
+                    three_d: false,
                 };
                 self.document.doc_info.border_fills.push(new_bf);
                 self.document.doc_info.raw_stream = None;

--- a/src/document_core/html_table_import.rs
+++ b/src/document_core/html_table_import.rs
@@ -756,6 +756,7 @@ impl DocumentCore {
             diagonal: DiagonalLine::default(),
             center_line: CenterLine::None,
             fill,
+            three_d: false,
         };
 
         // 기존 BorderFill에서 동일한 항목 검색
@@ -816,6 +817,7 @@ impl DocumentCore {
                 diagonal: DiagonalLine::default(),
                 center_line: CenterLine::None,
                 fill: Fill::default(),
+                three_d: false,
             });
         bf.raw_data = None;
 

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -448,6 +448,10 @@ pub struct Style {
     pub para_shape_id: u16,
     /// 글자 모양 ID 참조
     pub char_shape_id: u16,
+    /// [Task #2839] 양식(폼) 필드 잠금 여부 (HWPX `lockForm`).
+    /// 파서가 값을 읽지 않고 시리얼라이저가 "0" 을 하드코딩해 원본이 항상
+    /// 잠금 해제 상태로 바뀌던 결함 수정.
+    pub lock_form: bool,
 }
 
 /// 테두리/배경 (HWPTAG_BORDER_FILL)

--- a/src/model/style.rs
+++ b/src/model/style.rs
@@ -469,6 +469,8 @@ pub struct BorderFill {
     pub center_line: CenterLine,
     /// 채우기 정보
     pub fill: Fill,
+    /// 3차원 효과 (HWPX borderFill@threeD)
+    pub three_d: bool,
 }
 
 /// 중심선 방향 (HWPX borderFill@centerLine)

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -367,6 +367,7 @@ fn parse_border_fill(data: &[u8]) -> Result<BorderFill, DocInfoError> {
         diagonal,
         center_line: CenterLine::from_hwp_attr(attr),
         fill,
+        three_d: false,
     })
 }
 

--- a/src/parser/doc_info.rs
+++ b/src/parser/doc_info.rs
@@ -903,6 +903,7 @@ fn parse_style(data: &[u8]) -> Result<Style, DocInfoError> {
         lang_id,
         para_shape_id,
         char_shape_id,
+        lock_form: false,
     })
 }
 

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1329,6 +1329,10 @@ fn parse_style(e: &quick_xml::events::BytesStart, doc_info: &mut DocInfo) {
                     }
                 }
             }
+            // [Task #2839] HWPX `lockForm` → Style.lock_form.
+            // 종전엔 이 속성을 아예 읽지 않아 시리얼라이저가 항상 "0" 을
+            // 하드코딩했고, 원본 lockForm="1"(양식 잠금) 이 왕복마다 유실됐다.
+            b"lockForm" => style.lock_form = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -3192,15 +3192,21 @@ mod tests {
         // charPrIDRef="0" 을 참조하는 run 은 id="0"(height=1000) 서식을 받아야 한다.
         let cs0 = doc_info
             .char_shapes
-            .get(0)
+            .first()
             .expect("id=0 charPr 이 존재해야 함");
-        assert_eq!(cs0.base_size, 1000, "charPrIDRef=0 은 id=\"0\" 항목이어야 함");
+        assert_eq!(
+            cs0.base_size, 1000,
+            "charPrIDRef=0 은 id=\"0\" 항목이어야 함"
+        );
 
         let cs1 = doc_info
             .char_shapes
             .get(1)
             .expect("id=1 charPr 이 존재해야 함");
-        assert_eq!(cs1.base_size, 2000, "charPrIDRef=1 은 id=\"1\" 항목이어야 함");
+        assert_eq!(
+            cs1.base_size, 2000,
+            "charPrIDRef=1 은 id=\"1\" 항목이어야 함"
+        );
     }
 
     /// paraPr 도 charPr 과 동일한 결함을 공유한다: id 속성을 무시하고 등장 순서로
@@ -3226,7 +3232,7 @@ mod tests {
 
         let ps0 = doc_info
             .para_shapes
-            .get(0)
+            .first()
             .expect("id=0 paraPr 이 존재해야 함");
         assert_eq!(
             ps0.alignment,

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -565,9 +565,11 @@ fn parse_char_shape(
     doc_info: &mut DocInfo,
 ) -> Result<(), HwpxError> {
     let mut cs = CharShape::default();
+    let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            b"id" => id = Some(parse_u32(&attr) as usize),
             b"height" => cs.base_size = parse_i32(&attr),
             b"textColor" => cs.text_color = parse_color(&attr),
             b"shadeColor" => cs.shade_color = parse_color(&attr),
@@ -818,7 +820,21 @@ fn parse_char_shape(
         }
     }
 
-    doc_info.char_shapes.push(cs);
+    // `id` 속성은 charPrIDRef 가 참조하는 실제 배열 인덱스다. XML 등장 순서를
+    // 그대로 push 하면 id 가 등장 순서와 다르거나(재정렬) 중간이 비어 있을 때
+    // (스타일 삭제 등) charPrIDRef 참조가 엉뚱한 CharShape 로 해석된다.
+    // id 가 없는(비정상) 항목만 등장 순서 fallback 으로 push.
+    match id {
+        Some(idx) => {
+            if doc_info.char_shapes.len() <= idx {
+                doc_info
+                    .char_shapes
+                    .resize_with(idx + 1, CharShape::default);
+            }
+            doc_info.char_shapes[idx] = cs;
+        }
+        None => doc_info.char_shapes.push(cs),
+    }
     Ok(())
 }
 
@@ -832,9 +848,11 @@ fn parse_para_shape(
     let mut ps = ParaShape::default();
     // OWPML ParaShapeType의 snapToGrid 기본값은 true.
     ps.attr1 |= 1 << 8;
+    let mut id: Option<usize> = None;
 
     for attr in e.attributes().flatten() {
         match attr.key.as_ref() {
+            b"id" => id = Some(parse_u32(&attr) as usize),
             b"tabPrIDRef" => ps.tab_def_id = parse_u16(&attr),
             b"condense" => {
                 let condense = parse_u32(&attr).min(75);
@@ -903,7 +921,19 @@ fn parse_para_shape(
         ps.line_spacing_v2 = ps.line_spacing as u32;
     }
 
-    doc_info.para_shapes.push(ps);
+    // `id` 속성은 paraPrIDRef 가 참조하는 실제 배열 인덱스다. charPr 과 동일한
+    // 이유로 등장 순서 push 대신 id 로 배치한다.
+    match id {
+        Some(idx) => {
+            if doc_info.para_shapes.len() <= idx {
+                doc_info
+                    .para_shapes
+                    .resize_with(idx + 1, ParaShape::default);
+            }
+            doc_info.para_shapes[idx] = ps;
+        }
+        None => doc_info.para_shapes.push(ps),
+    }
     Ok(())
 }
 
@@ -2453,7 +2483,8 @@ mod tests {
 </hh:head>"##;
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
-        let ps = &doc_info.para_shapes[0];
+        // paraPr id="1" 이므로 paraPrIDRef=1 이 참조할 실제 배열 위치는 index 1.
+        let ps = &doc_info.para_shapes[1];
 
         assert_eq!((ps.attr1 >> 9) & 0x7f, 30);
         assert_eq!(ps.attr1 & (1 << 22), 1 << 22);
@@ -2478,8 +2509,9 @@ mod tests {
   </hh:refList>
 </hh:head>"##;
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        // paraPr id="1" → index 1.
         assert_eq!(
-            doc_info.para_shapes[0].line_spacing_type,
+            doc_info.para_shapes[1].line_spacing_type,
             crate::model::style::LineSpacingType::SpaceOnly,
             "type=BETWEEN_LINES 가 SpaceOnly 로 파싱돼야 함(Percent 유실 방지)"
         );
@@ -2505,14 +2537,15 @@ mod tests {
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
 
-        assert_eq!(doc_info.para_shapes[0].attr1 & (1 << 7), 1 << 7);
-        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 7), 0);
+        // paraPr id="1"/"2" → index 1/2 (index 0 은 정의되지 않아 default).
+        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 7), 1 << 7);
+        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 7), 0);
         assert_eq!(
-            doc_info.para_shapes[0].break_latin_word.as_deref(),
+            doc_info.para_shapes[1].break_latin_word.as_deref(),
             Some("KEEP_WORD")
         );
         assert_eq!(
-            doc_info.para_shapes[1].break_latin_word.as_deref(),
+            doc_info.para_shapes[2].break_latin_word.as_deref(),
             Some("HYPHENATION")
         );
     }
@@ -2538,9 +2571,10 @@ mod tests {
 
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
 
-        assert_eq!(doc_info.para_shapes[0].attr1 & (1 << 8), 1 << 8);
-        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 8), 0);
-        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 8), 1 << 8);
+        // paraPr id="1"/"2"/"3" → index 1/2/3 (index 0 은 정의되지 않아 default).
+        assert_eq!(doc_info.para_shapes[1].attr1 & (1 << 8), 1 << 8);
+        assert_eq!(doc_info.para_shapes[2].attr1 & (1 << 8), 0);
+        assert_eq!(doc_info.para_shapes[3].attr1 & (1 << 8), 1 << 8);
     }
 
     #[test]
@@ -3125,5 +3159,89 @@ mod tests {
 
         assert_eq!((bf.attr >> 8) & 0x03, 2, "Crooked=2 보존");
         assert_eq!((bf.attr >> 5) & 0x07, 0b010, "backSlash CENTER 보존");
+    }
+
+    /// `<hh:charPr id="N">`/`<hh:paraPr id="N">`의 `id` 속성을 무시하고 XML 등장
+    /// 순서(push 순서)를 그대로 배열 인덱스로 쓰면, id 가 등장 순서와 다르거나
+    /// (역순) 중간이 비어 있을 때 `charPrIDRef`/`paraPrIDRef` 참조가 엉뚱한
+    /// 항목으로 해석된다. 한컴이 내보내는 파일은 보통 id 순으로 정렬돼 있어
+    /// 드러나지 않지만, OWPML 스펙상 id 는 임의 참조값일 뿐 등장 순서를
+    /// 보장하지 않는다 (예: 스타일 편집기로 재정렬되거나 서드파티 생성기가
+    /// 만든 파일).
+    #[test]
+    fn test_char_pr_id_out_of_order_resolves_by_id_not_document_order() {
+        // id="1" 항목이 먼저, id="0" 항목이 나중에 등장 — 등장 순서 그대로
+        // push 하면 char_shapes[0] 에 id="1"의 속성(height=2000)이 들어가
+        // charPrIDRef="0" 참조가 실제로는 id="1" 의 서식을 받게 된다.
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:charProperties itemCnt="2">
+      <hh:charPr id="1" height="2000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+      <hh:charPr id="0" height="1000" textColor="#000000" shadeColor="none" useFontSpace="0" useKerning="0" symMark="NONE">
+        <hh:fontRef hangul="0" latin="0" hanja="0" japanese="0" other="0" symbol="0" user="0"/>
+      </hh:charPr>
+    </hh:charProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        // charPrIDRef="0" 을 참조하는 run 은 id="0"(height=1000) 서식을 받아야 한다.
+        let cs0 = doc_info
+            .char_shapes
+            .get(0)
+            .expect("id=0 charPr 이 존재해야 함");
+        assert_eq!(cs0.base_size, 1000, "charPrIDRef=0 은 id=\"0\" 항목이어야 함");
+
+        let cs1 = doc_info
+            .char_shapes
+            .get(1)
+            .expect("id=1 charPr 이 존재해야 함");
+        assert_eq!(cs1.base_size, 2000, "charPrIDRef=1 은 id=\"1\" 항목이어야 함");
+    }
+
+    /// paraPr 도 charPr 과 동일한 결함을 공유한다: id 속성을 무시하고 등장 순서로
+    /// push 하므로, id 가 비순차적이면 `paraPrIDRef` 가 잘못된 문단 서식을
+    /// 가리킨다.
+    #[test]
+    fn test_para_pr_id_out_of_order_resolves_by_id_not_document_order() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:paraProperties itemCnt="2">
+      <hh:paraPr id="1" tabPrIDRef="0">
+        <hh:align horizontal="RIGHT"/>
+      </hh:paraPr>
+      <hh:paraPr id="0" tabPrIDRef="0">
+        <hh:align horizontal="LEFT"/>
+      </hh:paraPr>
+    </hh:paraProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+
+        let ps0 = doc_info
+            .para_shapes
+            .get(0)
+            .expect("id=0 paraPr 이 존재해야 함");
+        assert_eq!(
+            ps0.alignment,
+            Alignment::Left,
+            "paraPrIDRef=0 은 id=\"0\"(LEFT) 항목이어야 함"
+        );
+
+        let ps1 = doc_info
+            .para_shapes
+            .get(1)
+            .expect("id=1 paraPr 이 존재해야 함");
+        assert_eq!(
+            ps1.alignment,
+            Alignment::Right,
+            "paraPrIDRef=1 은 id=\"1\"(RIGHT) 항목이어야 함"
+        );
     }
 }

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1791,10 +1791,12 @@ fn parse_bullet_hwpx(
     }
 
     // 자식 <hh:paraHead>(align/useInstWidth/widthAdjust/textOffset/charPrIDRef 등),
-    // <hh:image> 를 순회. widthAdjust/textOffset/charPrIDRef 는 Bullet 필드로 흡수하고,
+    // <hh:img> 를 순회. widthAdjust/textOffset/charPrIDRef 는 Bullet 필드로 흡수하고,
     // 7수준 모델로 표현 못하는 나머지 속성(align/useInstWidth/autoIndent/checkable 등)은
     // numbering.raw_para_heads(#2695 계열)와 같은 방식으로 원본 구간을 통째로 보존해
     // 직렬화 시 splice 한다(무손실 라운드트립).
+    // <hh:img binaryItemIDRef="imageN"> 는 이미지 글머리표의 실제 BinData 참조 ID —
+    // useImage="1" 만으로는 어떤 이미지인지 알 수 없어 누락 시 항상 ID 1 로 고정된다.
     if !is_empty_event(e) {
         let inner_start = reader.buffer_position() as usize;
         let mut inner_end = inner_start;
@@ -1802,6 +1804,21 @@ fn parse_bullet_hwpx(
         loop {
             let pos_before = reader.buffer_position() as usize;
             match reader.read_event_into(&mut buf) {
+                Ok(Event::Start(ref ce)) | Ok(Event::Empty(ref ce))
+                    if local_name(ce.name().as_ref()) == b"img" =>
+                {
+                    if let Some(attr) = ce
+                        .attributes()
+                        .flatten()
+                        .find(|a| a.key.as_ref() == b"binaryItemIDRef")
+                    {
+                        let s = String::from_utf8_lossy(&attr.value);
+                        let num: String = s.chars().filter(|c| c.is_ascii_digit()).collect();
+                        if let Ok(id) = num.parse::<i32>() {
+                            bullet.image_bullet = id;
+                        }
+                    }
+                }
                 Ok(Event::Empty(ref ce)) => {
                     if local_name(ce.name().as_ref()) == b"paraHead" {
                         apply_bullet_para_head_attrs(&mut bullet, ce);
@@ -2229,6 +2246,28 @@ mod tests {
         let (doc_info, _) = parse_hwpx_header(xml).unwrap();
         assert_eq!(doc_info.bullets.len(), 1);
         assert_eq!(doc_info.bullets[0].check_bullet_char, '☑');
+    }
+
+    #[test]
+    fn test_parse_bullet_hwpx_image_id_from_binary_item_id_ref() {
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:bullets itemCnt="1">
+      <hh:bullet id="1" char="0x0" useImage="1">
+        <hh:img binaryItemIDRef="image3" bright="0" contrast="0" effect="REAL_PIC"/>
+      </hh:bullet>
+    </hh:bullets>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(
+            doc_info.bullets[0].image_bullet, 3,
+            "이미지 글머리표는 <hh:img binaryItemIDRef>의 실제 BinData ID(3)로 매핑되어야 함. \
+             useImage=\"1\" 만으로는 어떤 이미지인지 알 수 없어, 이대로 두면 이미지 글머리표가 \
+             항상 ID 1로 고정된다."
+        );
     }
 
     #[test]

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1348,13 +1348,26 @@ fn parse_border_fill(
 ) -> Result<(), HwpxError> {
     let mut bf = BorderFill::default();
     for attr in e.attributes().flatten() {
-        if attr.key.as_ref() == b"centerLine" {
-            bf.center_line = parse_center_line(&attr);
-            if bf.center_line == CenterLine::None {
-                bf.attr &= !(1 << 13);
-            } else {
-                bf.attr |= 1 << 13;
+        match attr.key.as_ref() {
+            b"centerLine" => {
+                bf.center_line = parse_center_line(&attr);
+                if bf.center_line == CenterLine::None {
+                    bf.attr &= !(1 << 13);
+                } else {
+                    bf.attr |= 1 << 13;
+                }
             }
+            // [#2973] 필드와 함께 attr bit0(표 24 3D 효과)도 동기화한다 — 방출측
+            // (#2965)이 attr 비트에서 읽으므로, centerLine(bit13)과 같은 패턴.
+            b"threeD" => {
+                bf.three_d = parse_bool(&attr);
+                if bf.three_d {
+                    bf.attr |= 1;
+                } else {
+                    bf.attr &= !1;
+                }
+            }
+            _ => {}
         }
     }
 
@@ -3021,6 +3034,13 @@ mod tests {
             .into_iter()
             .next()
             .expect("borderFill 파싱 실패")
+    }
+
+    #[test]
+    fn test_border_fill_three_d_attr_parsed() {
+        // threeD="1" 은 파서가 읽어 모델에 보존해야 한다(직렬화 시 하드코딩 "0" 방지).
+        let bf = parse_single_border_fill(r#"<hh:borderFill id="9" threeD="1"></hh:borderFill>"#);
+        assert!(bf.three_d, "threeD=\"1\" 이 bf.three_d 로 파싱되어야 함");
     }
 
     #[test]

--- a/src/parser/hwpx/header.rs
+++ b/src/parser/hwpx/header.rs
@@ -1647,9 +1647,12 @@ fn parse_tab_item(ce: &quick_xml::events::BytesStart) -> TabItem {
                     // 방출측 tab_leader_str 은 fill_type 8 을 "DOUBLE_SLIM" 으로 낸다
                     // (border 명명과 동일). 안 받으면 이중실선 탭 리더가 왕복 시 NONE(0)으로 유실.
                     "DOUBLE_LINE" | "DOUBLE_SLIM" => 8, // 이중실선
-                    "THIN_THICK" => 9,                  // 얇고 굵은 이중선
-                    "THICK_THIN" => 10,                 // 굵고 얇은 이중선
-                    "TRIM" => 11,                       // 얇고 굵고 얇은 삼중선
+                    // OWPML LineType3 스펙 리터럴은 SLIM_THICK/THICK_SLIM/SLIM_THICK_SLIM
+                    // (Core XML schema.xml 335~349행). THIN_THICK/THICK_THIN/TRIM 은
+                    // rhwp 내부에서만 쓰던 비표준 이름이라 스펙 준수 문서(#2857)를 못 읽었다.
+                    "THIN_THICK" | "SLIM_THICK" => 9, // 얇고 굵은 이중선
+                    "THICK_THIN" | "THICK_SLIM" => 10, // 굵고 얇은 이중선
+                    "TRIM" | "SLIM_THICK_SLIM" => 11, // 얇고 굵고 얇은 삼중선
                     _ => 0,
                 };
             }
@@ -2268,6 +2271,26 @@ mod tests {
              useImage=\"1\" 만으로는 어떤 이미지인지 알 수 없어, 이대로 두면 이미지 글머리표가 \
              항상 ID 1로 고정된다."
         );
+    }
+
+    #[test]
+    fn test_parse_tab_item_leader_accepts_owpml_spec_literal_slim_thick() {
+        // OWPML LineType3 스펙 리터럴(Core XML schema.xml 335행)은 "SLIM_THICK"이다.
+        // rhwp 내부 전용 이름 "THIN_THICK"만 받으면 한/글이 저장한 정상 문서의
+        // 탭 리더가 NONE(0)으로 유실된다 (#2857).
+        let xml = r##"<?xml version="1.0" encoding="UTF-8"?>
+<hh:head xmlns:hh="http://www.hancom.co.kr/hwpml/2011/head">
+  <hh:refList>
+    <hh:tabProperties itemCnt="1">
+      <hh:tabPr id="0" autoTabLeft="0" autoTabRight="0">
+        <hh:tabItem pos="1000" type="LEFT" leader="SLIM_THICK"/>
+      </hh:tabPr>
+    </hh:tabProperties>
+  </hh:refList>
+</hh:head>"##;
+
+        let (doc_info, _) = parse_hwpx_header(xml).unwrap();
+        assert_eq!(doc_info.tab_defs[0].tabs[0].fill_type, 9);
     }
 
     #[test]

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -305,6 +305,7 @@ fn test_serialize_style_roundtrip() {
         lang_id: 1042,
         para_shape_id: 1,
         char_shape_id: 2,
+        lock_form: false,
     };
 
     let data = serialize_style(&style);
@@ -641,6 +642,7 @@ fn test_serialize_doc_info_roundtrip() {
         lang_id: 1042,
         para_shape_id: 0,
         char_shape_id: 0,
+        lock_form: false,
     });
 
     // 직렬화 → 역직렬화

--- a/src/serializer/doc_info/tests.rs
+++ b/src/serializer/doc_info/tests.rs
@@ -383,6 +383,7 @@ fn test_serialize_border_fill_solid() {
             image: None,
             alpha: 0,
         },
+        three_d: false,
     };
 
     let data = serialize_border_fill(&bf);
@@ -423,6 +424,7 @@ fn test_serialize_border_fill_preserves_solid_and_image_alpha() {
             image: None,
             alpha: 180,
         },
+        three_d: false,
     };
     let data = serialize_border_fill(&bf);
     let mut r = crate::parser::byte_reader::ByteReader::new(&data[FILL_OFFSET..]);
@@ -458,6 +460,7 @@ fn test_serialize_border_fill_cross_centerline_uses_hwp5_center_bits() {
         diagonal: DiagonalLine::default(),
         center_line: CenterLine::Cross,
         fill: Fill::default(),
+        three_d: false,
     };
 
     let data = serialize_border_fill(&bf);
@@ -511,6 +514,7 @@ fn test_serialize_border_fill_image_fill_mode_uses_hwp5_values() {
                 }),
                 alpha: 0,
             },
+            three_d: false,
         };
 
         let data = serialize_border_fill(&bf);

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -865,11 +865,14 @@ fn tab_leader_str(f: u8) -> &'static str {
         6 => "LONG_DASH",
         7 => "CIRCLE",
         8 => "DOUBLE_SLIM",
-        // 종전엔 9/10/11 이 _ => "NONE" 으로 떨어져 이중/삼중선 탭 리더가 저장 시 유실됐다.
-        // 파서(parse_tab_item)는 이 문자열들을 각각 9/10/11 로 받으므로 왕복 보존된다.
-        9 => "THIN_THICK",
-        10 => "THICK_THIN",
-        11 => "TRIM",
+        // OWPML LineType3 스펙 리터럴(Core XML schema.xml 335~349행)로 방출한다.
+        // 종전엔 THIN_THICK/THICK_THIN/TRIM 이라는 비표준 이름을 썼는데, rhwp
+        // 자기 자신은 다시 읽을 수 있어도(파서가 두 이름을 모두 허용) 한/글 등
+        // 스펙을 따르는 다른 구현체에는 정의되지 않은 값이라 상호운용에 문제가
+        // 있었다(#2857). 파서는 하위호환을 위해 옛 이름도 계속 받는다.
+        9 => "SLIM_THICK",
+        10 => "THICK_SLIM",
+        11 => "SLIM_THICK_SLIM",
         _ => "NONE",
     }
 }

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -934,6 +934,8 @@ fn write_numbering<W: Write>(
         // [#2947] h.number_format 을 무시하고 "DIGIT" 로 고정 방출하면 HWP5 경유
         // 저장 시 로마자/한글/원문자 등 문단 번호 형식이 전부 아라비아 숫자로 뒤바뀐다.
         let num_format = numbering_format_str(h.number_format);
+        let text_offset_s = h.text_distance.to_string();
+        let char_pr_id_ref_s = h.char_shape_id.to_string();
         empty_tag(
             w,
             "hh:paraHead",
@@ -945,9 +947,9 @@ fn write_numbering<W: Write>(
                 ("autoIndent", "1"),
                 ("widthAdjust", &wa),
                 ("textOffsetType", "PERCENT"),
-                ("textOffset", "50"),
+                ("textOffset", &text_offset_s),
                 ("numFormat", num_format),
-                ("charPrIDRef", &u32::MAX.to_string()),
+                ("charPrIDRef", &char_pr_id_ref_s),
                 ("checkable", "0"),
             ],
         )?;
@@ -2275,6 +2277,30 @@ mod tests {
         assert!(
             xml.contains(r#"numFormat="ROMAN_CAPITAL""#),
             "level 1 paraHead 는 number_format=2 를 ROMAN_CAPITAL 로 방출해야 한다: {xml}"
+        );
+    }
+
+    #[test]
+    fn write_numbering_skeleton_preserves_text_distance_and_char_shape_id() {
+        // HWP5 경로(raw_para_heads 없음)에서 NumberingHead.text_distance /
+        // char_shape_id 는 DocInfo 파서가 실제 값으로 채워 넣는 필드인데,
+        // 폴백 스켈레톤이 textOffset="50" / charPrIDRef=u32::MAX 로 하드코딩해
+        // 유실시키면 안 된다 (write_bullet 의 대응 필드 처리와 대칭이어야 함).
+        let mut n = Numbering::default();
+        n.heads[0].text_distance = 130;
+        n.heads[0].char_shape_id = 7;
+
+        let mut writer = Writer::new(Vec::new());
+        write_numbering(&mut writer, 0, &n).unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(r#"textOffset="130""#),
+            "text_distance 유실: {xml}"
+        );
+        assert!(
+            xml.contains(r#"charPrIDRef="7""#),
+            "char_shape_id 유실: {xml}"
         );
     }
 

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -1329,7 +1329,7 @@ fn write_style<W: Write>(w: &mut Writer<W>, id: u16, st: &Style) -> Result<(), S
             // 파서가 Style.lang_id 로 읽는 값을 그대로 되돌린다. 종전 "1042"
             // 하드코딩은 비한국어 langID(예: 1033)를 왕복마다 1042 로 바꿨다.
             ("langID", &st.lang_id.to_string()),
-            ("lockForm", "0"),
+            ("lockForm", bool01(st.lock_form)),
         ],
     )
 }
@@ -1387,6 +1387,23 @@ mod tests {
         assert!(
             xml.contains(r#"langID="1033""#),
             "Style.lang_id 가 방출돼야 함: {xml}"
+        );
+    }
+
+    #[test]
+    fn write_style_emits_ir_lock_form() {
+        // [Task #2839] 파서가 읽은 Style.lock_form 이 그대로 방출돼야 한다.
+        // 종전엔 "0" 하드코딩으로 lockForm="1" 스타일이 왕복마다 잠금 해제로 뭉개졌다.
+        let st = Style {
+            lock_form: true,
+            ..Default::default()
+        };
+        let mut w: Writer<Vec<u8>> = Writer::new(Vec::new());
+        write_style(&mut w, 0, &st).expect("write_style");
+        let xml = String::from_utf8(w.into_inner()).unwrap();
+        assert!(
+            xml.contains(r#"lockForm="1""#),
+            "Style.lock_form 이 방출돼야 함: {xml}"
         );
     }
 

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -785,12 +785,15 @@ fn outline_type_str(t: u8) -> &'static str {
 }
 
 // [#2695] 그림자 3종. IR shadow_type 은 HWP5 attr bits 11-12(2비트).
-// 1=비연속(DROP), 2=연속(CONTINUOUS).
+// 1=비연속(DROP), 2=연속(CONTINUOUS). 3은 예약값(미정의).
+// [#3038] 종전엔 예약값 3이 `_ => "CONTINUOUS"`로 떨어져 그림자 없음이 그림자
+// 있음으로 둔갑했다. 계약(0~2) 밖의 값은 안전한 기본값(NONE)으로 방출한다.
 fn shadow_type_str(t: u8) -> &'static str {
     match t {
         0 => "NONE",
         1 => "DROP",
-        _ => "CONTINUOUS",
+        2 => "CONTINUOUS",
+        _ => "NONE",
     }
 }
 
@@ -1408,6 +1411,17 @@ mod tests {
             xml.contains(r#"lockForm="1""#),
             "Style.lock_form 이 방출돼야 함: {xml}"
         );
+    }
+
+    #[test]
+    fn task_m100_shadow_type_str_reserved_value_maps_to_none() {
+        // [#3038] 계약(0~2) 밖의 예약값(3)은 CONTINUOUS 로 둔갑하지 않고
+        // 안전한 기본값 NONE 으로 방출돼야 한다.
+        assert_eq!(shadow_type_str(0), "NONE");
+        assert_eq!(shadow_type_str(1), "DROP");
+        assert_eq!(shadow_type_str(2), "CONTINUOUS");
+        assert_eq!(shadow_type_str(3), "NONE");
+        assert_eq!(shadow_type_str(99), "NONE");
     }
 
     #[test]

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -408,6 +408,21 @@ fn write_diag_line<W: Write>(
     )
 }
 
+// [#2947] parser 측 parse_numbering_format_code() (표 43) 의 역매핑.
+fn numbering_format_str(code: u8) -> &'static str {
+    match code {
+        1 => "CIRCLED_DIGIT",
+        2 => "ROMAN_CAPITAL",
+        3 => "ROMAN_SMALL",
+        4 => "LATIN_CAPITAL",
+        5 => "LATIN_SMALL",
+        8 => "HANGUL_SYLLABLE",
+        12 => "HANGUL_NUMBER",
+        13 => "HANJA_NUMBER",
+        _ => "DIGIT",
+    }
+}
+
 fn diagonal_shape_type(code: u8) -> &'static str {
     match code & 0x07 {
         0 => "NONE",
@@ -910,6 +925,9 @@ fn write_numbering<W: Write>(
         let level_s = (level + 1).to_string();
         let start_s = start.to_string();
         let wa = h.width_adjust.to_string();
+        // [#2947] h.number_format 을 무시하고 "DIGIT" 로 고정 방출하면 HWP5 경유
+        // 저장 시 로마자/한글/원문자 등 문단 번호 형식이 전부 아라비아 숫자로 뒤바뀐다.
+        let num_format = numbering_format_str(h.number_format);
         empty_tag(
             w,
             "hh:paraHead",
@@ -922,7 +940,7 @@ fn write_numbering<W: Write>(
                 ("widthAdjust", &wa),
                 ("textOffsetType", "PERCENT"),
                 ("textOffset", "50"),
-                ("numFormat", "DIGIT"),
+                ("numFormat", num_format),
                 ("charPrIDRef", &u32::MAX.to_string()),
                 ("checkable", "0"),
             ],
@@ -2207,6 +2225,23 @@ mod tests {
 
         assert_eq!(xml.matches("<hh:paraHead").count(), 10);
         assert!(xml.starts_with(r#"<hh:numbering id="1" start="0">"#));
+    }
+
+    #[test]
+    fn write_numbering_skeleton_uses_number_format_not_hardcoded_digit() {
+        // [#2947] HWP5 경유(raw_para_heads 없음) 시 h.number_format(예: ROMAN_CAPITAL=2)
+        // 을 무시하고 "DIGIT" 로 고정 방출하면 로마자/한글 문단 번호가 유실된다.
+        let mut n = Numbering::default();
+        n.heads[0].number_format = 2; // ROMAN_CAPITAL
+
+        let mut writer = Writer::new(Vec::new());
+        write_numbering(&mut writer, 0, &n).unwrap();
+        let xml = String::from_utf8(writer.into_inner()).unwrap();
+
+        assert!(
+            xml.contains(r#"numFormat="ROMAN_CAPITAL""#),
+            "level 1 paraHead 는 number_format=2 를 ROMAN_CAPITAL 로 방출해야 한다: {xml}"
+        );
     }
 
     #[test]

--- a/src/serializer/hwpx/header.rs
+++ b/src/serializer/hwpx/header.rs
@@ -2266,10 +2266,12 @@ mod tests {
 
     #[test]
     fn tab_leader_str_emits_double_and_triple_line_types() {
-        // fill_type 9/10/11 이 "NONE" 으로 유실되지 않고 파서가 받는 문자열로 방출돼야 한다.
-        assert_eq!(tab_leader_str(9), "THIN_THICK");
-        assert_eq!(tab_leader_str(10), "THICK_THIN");
-        assert_eq!(tab_leader_str(11), "TRIM");
+        // fill_type 9/10/11 이 "NONE" 으로 유실되지 않고 OWPML LineType3 스펙 리터럴
+        // (Core XML schema.xml 335~349행)로 방출돼야 한다 (#2857). 파서는 옛 이름
+        // (THIN_THICK/THICK_THIN/TRIM)도 하위호환으로 계속 받는다.
+        assert_eq!(tab_leader_str(9), "SLIM_THICK");
+        assert_eq!(tab_leader_str(10), "THICK_SLIM");
+        assert_eq!(tab_leader_str(11), "SLIM_THICK_SLIM");
         assert_eq!(tab_leader_str(8), "DOUBLE_SLIM");
     }
 }

--- a/src/wasm_api.rs
+++ b/src/wasm_api.rs
@@ -5897,6 +5897,7 @@ impl HwpDocument {
             lang_id: 1042, // 한국어 default (HWP5 spec 표 47)
             para_shape_id,
             char_shape_id,
+            lock_form: false,
         };
         self.core.document.doc_info.styles.push(new_style);
         self.core.document.doc_info.raw_stream_dirty = true;

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -14813,6 +14813,7 @@ fn test_save_table_1x1() {
         },
         center_line: CenterLine::None,
         fill: Fill::default(),
+        three_d: false,
     };
     doc.document.doc_info.border_fills.push(new_bf);
     let table_bf_id = doc.document.doc_info.border_fills.len() as u16; // 1-based ID
@@ -16758,6 +16759,7 @@ fn test_save_pic_in_table() {
         },
         center_line: CenterLine::None,
         fill: Fill::default(),
+        three_d: false,
     };
     doc.document.doc_info.border_fills.push(new_bf);
     let table_bf_id = doc.document.doc_info.border_fills.len() as u16;

--- a/tests/fixtures/ir_field_sweep_baseline.tsv
+++ b/tests/fixtures/ir_field_sweep_baseline.tsv
@@ -297,7 +297,6 @@ hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].c
 hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	985
 hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].cells[].list_header_width_ref	16
 hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].controls[].children[][].drawing.text_box.raw_list_header_extra.len	7
-hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].controls[][].caption	2
 hwp5rb	issue2559/1341000_research_report_footnotes.hwp	sections[].paragraphs[].controls[][].drawing.text_box.raw_list_header_extra.len	3
 hwp5rb	issue2808_report_physical_ladder.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	22
 hwp5rb	issue_1133.hwp	sections[].paragraphs[].controls[].cells[].list_header_width_ref	15
@@ -415,8 +414,6 @@ hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[].caption.paragrap
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].raw_header_extra[]	60
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[].paragraphs[].raw_header_extra[]	2
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[].text_box.paragraphs[].raw_header_extra[]	1
-hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[][].common.attr	1
-hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].controls[][].common.hwp5_gen_shape_attr_bit28	1
 hwpx	143E433F503322BD33.hwpx	sections[].paragraphs[].raw_header_extra[]	22
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_x	1
 hwpx	2024년 1분기 해외직접투자 보도자료 ff.hwpx	sections[].paragraphs[].controls[].cells[].paragraphs[].controls[].shape_attr.offset_y	1


### PR DESCRIPTION
kevin9327 님의 hwpx-header 축 8건을 메인테이너가 재실증 후 통합한다. 충돌분 5건을 같은 축에 흡수했다.

## 채택 8건

| PR | 결함 |
|---|---|
| #3040 (`Closes #3033`) | hh:bullet 이미지 글머리표 binaryItemIDRef 미파싱 — 이미지 글머리표가 항상 ID 1 로 고정 |
| #3088 (`Closes #2857`) | 탭 리더 이중/삼중선이 OWPML 스펙 리터럴(SLIM_THICK 계열) 대신 내부 이름만 인식 — 정상 문서의 탭 리더 NONE 유실 |
| #3097 (`Closes #2947`) | HWP5→HWPX 문단 번호 numFormat "DIGIT" 고정 — 로마자/한글 번호 형식 유실 |
| #3107 (`Closes #2973`) | hh:borderFill@threeD 파싱 누락·직렬화 하드코딩 |
| #3113 (`Closes #2839`) | hh:style lockForm 왕복 소실 |
| #3116 (`Closes #3038`) | hh:shadow type 예약값(3)이 CONTINUOUS 로 오방출 |
| #3172 (`Closes #3170`) | charPr/paraPr id 속성 무시 — 등장 순서를 인덱스로 오인, 재정렬/간극 문서에서 참조 오해석 |
| #3194 | HWP5 경유 paraHead textOffset/charPrIDRef 하드코딩 — #3097 과 상호보완 형제 |

## 제외 1건과 판정 정정

- **#3185(memoProperties) 제외** — IR 필드 스윕 전수(799샘플)에서 표 셀 문단 raw_header_extra 발산 +2 회귀 5건의 단독 원인으로 이분 탐색 확정. 재작업 요청 코멘트 게시.
- **#3172 는 처음 회귀 원인으로 오판해 제외했다가 이분 탐색 완료 후 무혐의로 확인, 복귀·정정 코멘트 게시.** 오판 원인은 "해당 커밋 이전"과 비교하고 "해당 커밋만 제외"를 검증하지 않은 것.

## 충돌 흡수와 판단

- **#3107 실질 병합**: 파서는 bf.three_d 필드만 채우고 방출측(#2965)은 attr bit0 에서 읽는 간극을 발견 — centerLine(bit13)과 같은 패턴으로 파서가 필드+비트를 동시 동기화하도록 결합했다.
- **#3194 상호보완 결합**: #3097 이 numFormat 을, #3194 가 textOffset/charPrIDRef 를 각각 동적화하며 서로가 고친 걸 하드코딩 — 셋 모두 동적으로 결합.
- 그 외 3건(#3040 #3088 #3116)은 테스트/파스루프 병치.

## 부수

- IR 필드 스윕 baseline 갱신 — 이 배치의 왕복 수정들이 만든 순개선 3건 반영(회귀 0).
- #3172 테스트의 clippy get(0)→first() 정리.

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**, IR 스윕 green
- 8건 반영을 패치ID + 표적 테스트로 개별 검증

Co-authored-by 로 원 커밋 provenance 를 보존한다.
