### PR TITLE
fix(hwpx): 개체 lock 배선 통일·fieldEnd fieldid 보존 등 5건 — kevin9327 축배치 H

### DIFF
--- a/mydocs/report/task_m100_2840_report.md
+++ b/mydocs/report/task_m100_2840_report.md
@@ -1,0 +1,43 @@
+# Task m100-2840: 수식 lock(개체 잠금) 속성 왕복 유실 해소
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2840
+
+## 근본 원인
+
+`src/parser/hwpx/section.rs`의 `parse_object_element_attrs`(모든 그리기 개체 공통 속성
+파서)는 `id`, `zOrder`, `textWrap`, `textFlow`, `instid`, `groupLevel`, `ratio`,
+`numberingType`, `isReverseHV`만 처리하고 `lock` 속성은 매치 대상이 없어 `_ => {}`로
+버려졌다. `CommonObjAttr`(`src/model/shape.rs`)에도 잠금 상태를 담을 필드가 없어,
+`src/serializer/hwpx/section.rs`의 `render_equation`은 항상 `lock="0"`을 문자열
+리터럴로 방출했다. 결과적으로 원본 HWPX 문서의 수식 개체가 `lock="1"`(개체 보호)이어도
+rhwp를 거쳐 재저장하면 항상 잠금 해제 상태로 바뀐다.
+
+## 변경 사항
+
+- `src/model/shape.rs`: `CommonObjAttr`에 `locked: bool` 필드 추가.
+- `src/parser/hwpx/section.rs`: `parse_object_element_attrs`에서 `b"lock"` 속성을
+  읽어 `common.locked`에 반영.
+- `src/serializer/hwpx/section.rs`: `render_equation`의 하드코딩 `lock="0"`을
+  `common.locked` 기반 방출로 교체.
+- `src/document_core/converters/common_obj_attr_writer.rs`: 신규 필드 추가에 따른
+  테스트 헬퍼 `make_sample()` 초기화 보정(`locked: false`).
+
+다른 개체 타입(그림·표·도형)도 동일한 `("lock", "0")` 하드코딩 패턴을 공유하지만, 이번
+작업은 충돌 회피를 위해 실제 사용처가 있는 `<hp:equation>` 경로로 범위를 한정했다.
+나머지 경로는 잔여로 남긴다.
+
+## 검증
+
+- `cargo build --lib`: 성공.
+- `cargo test --lib equation_lock_reflects_ir`: red(수정 전 컴파일 불가/구현 전
+  `lock="0"` 고정) → green(수정 후 `lock="1"` 방출 확인) 전환.
+- `cargo test --lib equation`: 166개 전부 통과(기존 수식 관련 테스트 회귀 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음.
+- `rustfmt --edition 2021`: 변경 파일 대상 실행, 포맷 diff 없음(CRLF 경고만 발생,
+  실질 변경 없음).
+
+## 완료 기준
+
+수식 `lock` 속성이 IR을 거쳐 왕복 시 보존됨을 최소 단위 테스트로 확인.

--- a/mydocs/report/task_m100_2840_report.md
+++ b/mydocs/report/task_m100_2840_report.md
@@ -20,13 +20,20 @@ rhwp를 거쳐 재저장하면 항상 잠금 해제 상태로 바뀐다.
 - `src/parser/hwpx/section.rs`: `parse_object_element_attrs`에서 `b"lock"` 속성을
   읽어 `common.locked`에 반영.
 - `src/serializer/hwpx/section.rs`: `render_equation`의 하드코딩 `lock="0"`을
-  `common.locked` 기반 방출로 교체.
+  `common.locked` 기반 방출로 교체. legacy 공용 도형 경로(`hp:{tag}` 포맷 문자열)도 동일
+  교체.
+- `src/serializer/hwpx/shape.rs`: `write_rect`/선(line·connectLine)/`hp:container`/
+  `hp:ole`의 `("lock", "0")` 하드코딩을 `common.locked` 방출로 교체.
+- `src/serializer/hwpx/picture.rs`, `src/serializer/hwpx/table.rs`: 동일 교체.
 - `src/document_core/converters/common_obj_attr_writer.rs`: 신규 필드 추가에 따른
   테스트 헬퍼 `make_sample()` 초기화 보정(`locked: false`).
 
-다른 개체 타입(그림·표·도형)도 동일한 `("lock", "0")` 하드코딩 패턴을 공유하지만, 이번
-작업은 충돌 회피를 위해 실제 사용처가 있는 `<hp:equation>` 경로로 범위를 한정했다.
-나머지 경로는 잔여로 남긴다.
+처음에는 `<hp:equation>` 경로로 범위를 한정했으나, 파서(`parse_object_element_attrs`)가
+모든 개체 공통으로 `lock`을 읽기 시작하면서 직렬화기가 여전히 `"0"` 하드코딩인 개체
+(rect 등)에서 IR 왕복 발산(`common.locked : 1건`)이 새로 생겨
+`ir_field_sweep_does_not_regress`가 CI에서 실패했다(샘플 `143E433F503322BD33.hwpx`의
+`lock="1"` rect). 따라서 파서와 대칭이 되도록 HWPX 개체 직렬화기 전체에 `lock` 방출을
+배선했다.
 
 ## 검증
 

--- a/mydocs/report/task_m100_2855_report.md
+++ b/mydocs/report/task_m100_2855_report.md
@@ -1,0 +1,56 @@
+# task/m100-2855 처리 결과 — 표(hp:tbl) lock 파싱/방출 누락 수정
+
+## 이슈
+
+#2855 — `<hp:tbl>` 의 `lock`(개체 잠금) 속성이 파서(`parse_table`)에 arm 자체가 없어
+버려지고, 방출측(`src/serializer/hwpx/table.rs:62`)도 `bool01(false)` 리터럴을 그대로
+방출해 IR을 전혀 참조하지 않았다. 결과적으로 잠긴 표를 왕복하면 잠금 상태가 소리 없이
+풀린다.
+
+`<hp:rect>`/`<hp:line>`/`<hp:pic>`/`<hp:container>` 는 `parse_object_element_attrs`
+(공유 함수, `src/parser/hwpx/section.rs:2858`)를 통해 `lock`을 정상 파싱하지만, 표는
+별도 파서(`parse_table`)를 쓰기 때문에 예외였다.
+
+## 근거
+
+- `src/parser/hwpx/section.rs:1600-1661` (`parse_table` 속성 매치) — `lock` arm 부재,
+  `_ => {}` 로 조용히 버려짐.
+- `src/serializer/hwpx/table.rs:62`(수정 전) — `let lock = bool01(false);` 리터럴.
+- 대조: `<hp:equation>` 경로는 IR(`common.locked`)을 참조하도록 되어 있어(§#2840 계열
+  패턴), 표만 그 패턴을 따르지 않음을 확인.
+
+이번 작업 시점에 `CommonObjAttr.locked` 필드 자체가 `origin/devel`에 아직 없어(별도
+진행 중인 수식 lock 브랜치에만 존재, 미병합), 표 수정을 위해 필드도 함께 추가했다.
+
+## 재현 (RED)
+
+`src/serializer/hwpx/table.rs` 에 `task2855_tbl_lock_survives_xml_ir_xml_roundtrip`
+테스트 추가. `lock="1"` 을 가진 `<hp:tbl>` XML을 파싱 → `table.common.locked` 확인
+→ 재직렬화 → `lock="1"` 이 방출되는지 확인. 필드 추가 전에는
+`no field 'locked' on type CommonObjAttr` 컴파일 에러로 RED, 필드 추가 후에는
+파싱 단계에서 `false`(기본값)로 남아 어서션 실패로 RED를 재현했다.
+
+## 수정
+
+1. `src/model/shape.rs` — `CommonObjAttr` 에 `pub locked: bool` 필드 추가.
+2. `src/parser/hwpx/section.rs` (`parse_table`) — `b"lock" => table.common.locked =
+   attr_str(&attr) == "1",` arm 추가.
+3. `src/serializer/hwpx/table.rs:62` — `bool01(false)` → `bool01(table.common.locked)`.
+4. `src/document_core/converters/common_obj_attr_writer.rs` — 테스트 헬퍼
+   `make_sample()` 에 신규 필드 `locked: false` 추가 (컴파일 오류 해소, 기존 동작
+   변경 없음).
+
+## 검증 (GREEN)
+
+- `cargo build --lib` — 성공.
+- `cargo test --lib task2855_tbl_lock_survives_xml_ir_xml_roundtrip` — 1 passed.
+- `cargo test --lib table::` — 기존 125개 표 관련 테스트 전부 통과(회귀 없음).
+- `cargo clippy --all-targets --profile release-test -- -D warnings` — 경고 없음.
+- `rustfmt --edition 2021` 변경 파일 4개 적용 — 포맷 외 diff 변화 없음.
+
+## 영향 범위
+
+`src/model/shape.rs`, `src/parser/hwpx/section.rs`, `src/serializer/hwpx/table.rs`,
+`src/document_core/converters/common_obj_attr_writer.rs`. 표(`<hp:tbl>`) 경로에 한정된
+수정이며 다른 개체 유형(`rect`/`line`/`pic`/`container`)의 `lock` 처리는 이미 정상
+동작함을 별도로 확인했으므로 손대지 않았다.

--- a/mydocs/report/task_m100_2909_report.md
+++ b/mydocs/report/task_m100_2909_report.md
@@ -1,0 +1,62 @@
+# task_m100_2909 처리 결과 보고
+
+## 이슈
+
+#2909 — HWPX 같은 문단 내 짝(matched) `fieldEnd`(HYPERLINK 등)의 `fieldid` 속성이 직렬화 시
+항상 소실됨
+
+## 원인
+
+`<hp:fieldBegin>`/`<hp:fieldEnd>` 필드가 같은 문단 안에서 짝을 이룰 때, 파서
+(`src/parser/hwpx/section.rs` `parse_paragraph()`)는 `fieldEnd` 자신의 `fieldid` 속성값을
+`parse_field_end_attrs()` 로 이미 읽어오지만, `field_stack.pop()`이 `Some`인(=같은 문단 매칭)
+분기에서는 그 값을 어디에도 저장하지 않고 버렸다. `FieldRange`(`src/model/paragraph.rs`)에는
+애초에 이 값을 담을 필드가 없었다.
+
+직렬화기(`src/serializer/hwpx/section.rs` `emit_field_end()`)는 `write_field_end(w, f.field_id)`
+만 호출해 `beginIDRef` 속성만 쓰고 `fieldid` 는 전혀 방출하지 않았다. 반면 문단 경계를 넘는
+"고아(orphan) fieldEnd" 경로(`emit_orphan_field_end()`)는 `write_field_end_full()` 로 이미
+`fieldid` 까지 보존하고 있어(#1556), 같은 성격의 값을 다루는 두 경로가 비대칭적이었다.
+`<hp:pic lock>`(#2875), `<hp:tbl lock>`(#2855), `hp:equation lock`(#2840) 등에서 반복 확인된
+"파싱은 되지만 직렬화 시 하드코딩/누락"류 결함과 동일 클래스다.
+
+## 수정
+
+1. `src/model/paragraph.rs`: `FieldRange`에 `pub end_field_id: u32` 필드 추가(짝 `fieldEnd`
+   자신의 `fieldid`, 0이면 없음/생략). `split_at`/`merge_from` 등 기존 `FieldRange` 복제 지점
+   에서 값을 그대로 전파하도록 수정.
+2. `src/parser/hwpx/section.rs`: `parse_paragraph()`의 매칭(같은 문단) `field_ranges.push()`에
+   `end_field_id: field_id`(파싱된 `fieldEnd` 자신의 `fieldid`) 반영.
+3. `src/serializer/hwpx/section.rs`: `emit_field_end()` 시그니처를 `control_idx: usize` 대신
+   `fr: &FieldRange` 를 받도록 변경. `fr.end_field_id == 0`이면 종전대로 `write_field_end`,
+   아니면 `write_field_end_full(f.field_id, fr.end_field_id)`로 `fieldid` 를 되돌려 쓰도록 하여
+   고아 경로와 대칭을 맞춤. 8개 호출부(`fr.control_idx` → `fr`)도 함께 수정.
+4. 나머지 파일(`document_core/commands/document.rs`, `document_core/queries/field_query.rs`,
+   `model/paragraph/tests.rs`, `parser/body_text.rs`, `serializer/body_text.rs`,
+   `serializer/hwpx/mod.rs`)은 `FieldRange` 구조체 리터럴 생성부에 신규 필드를 반영하기 위한
+   컴파일 정합성 수정(대부분 `..Default::default()` 또는 기존 `fr.end_field_id` 전파, HWP5
+   경로는 개념이 없어 `0`).
+
+## 테스트 (red → green)
+
+`src/serializer/hwpx/section.rs::tests::bookmark_hyperlink_matched_field_end_preserves_own_fieldid`
+신규 추가: `fieldBegin id=42`, 짝 `fieldEnd fieldid=100`(서로 다른 값)인 HYPERLINK 필드를
+직렬화해 `<hp:fieldEnd beginIDRef="42" fieldid="100"/>` 가 나오는지 단언.
+
+- Red: `emit_field_end()`를 임시로 종전 로직(`write_field_end(f.field_id)`만 호출)으로 되돌려
+  실행 → 실패 확인(`fieldid` 누락된 XML로 assert 실패, 실제 출력 캡처함).
+- Green: 수정 로직 복원 후 재실행 → 통과.
+
+## 검증
+
+- `cargo build --lib`: 성공
+- `cargo test --lib`: 2511 passed, 0 failed (전체 lib 유닛 테스트), 관련 테스트
+  `bookmark_hyperlink_matched_field_end_preserves_own_fieldid`: 1 passed
+- `cargo clippy --all-targets --profile release-test -- -D warnings`: 경고 없음
+- `rustfmt --edition 2021`(변경 파일만): 적용, 기능적 diff 없음(CRLF 노이즈 파일은 원상 복구)
+
+## 관련
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/2909
+- 전례: #1556(고아 fieldEnd fieldid 보존), #2875(hp:pic lock), #2855(hp:tbl lock),
+  #2840(hp:equation lock)

--- a/mydocs/report/task_m100_2931_report.md
+++ b/mydocs/report/task_m100_2931_report.md
@@ -1,0 +1,78 @@
+# Task m100-2931: HWPX hp:chart/hp:ole lock(개체 잠금) 속성 왕복 유실 해소
+
+## 이슈
+
+https://github.com/edwardkim/rhwp/issues/2931
+
+## 근본 원인
+
+`src/parser/hwpx/section.rs`의 `parse_hp_chart_element`(`<hp:chart>` 전용)와
+`parse_hp_ole_element`(`<hp:ole>` 폴백 전용)는 요소 최상위 속성을 개별 `match`로
+처리하는데, 둘 다 `numberingType`/`zOrder`/`textWrap`/`textFlow`/`chartIDRef`(또는
+`binaryItemIDRef`)/`instid`만 처리하고 `lock` 속성은 매치 대상이 없어
+`_ => {}`로 조용히 버려졌다.
+
+`CommonObjAttr`(`src/model/shape.rs`)에도 애초에 개체 잠금 상태를 담을 필드가
+없었기 때문에, `src/serializer/hwpx/section.rs`의 `render_common_shape_xml`
+(ellipse/arc/polygon/curve/chart 공용 경로 — `ShapeObject::Chart`가 이 경로로
+들어간다)과 `src/serializer/hwpx/shape.rs`의 `write_ole`(OLE 전용)는 모두
+`lock` 속성을 `"0"` 문자열 리터럴로 고정 방출했다.
+
+결과적으로 원본 HWPX 문서에서 `<hp:chart lock="1" .../>` 또는
+`<hp:ole lock="1" .../>`로 잠가 둔 차트·OLE 개체가 rhwp를 거쳐 재저장되면
+항상 `lock="0"`(잠금 해제)으로 바뀌어 사용자가 지정한 개체 보호 설정이
+조용히 사라진다.
+
+같은 저장소에서 이미 수식(`<hp:equation>`, #2840), 표(`<hp:tbl>`, #2855),
+그림(`<hp:pic>`, #2875) 각각에 대해 동일한 `lock="0"` 하드코딩 패턴이 별도로
+확인·트래킹되고 있었지만, 차트(`<hp:chart>`)와 OLE(`<hp:ole>`) 경로는 어떤
+이슈에서도 다뤄지지 않아 잔여로 남아 있었다.
+
+## 변경 사항
+
+- `src/model/shape.rs`: `CommonObjAttr`에 `locked: bool` 필드 추가
+  (#2840에서 제안된 이름과 동일하게 두어 추후 통합을 쉽게 함).
+- `src/parser/hwpx/section.rs`:
+  - `parse_hp_chart_element`에 `b"lock" => common.locked = attr_str(&attr) == "1"`
+    분기 추가.
+  - `parse_hp_ole_element`에도 동일한 분기 추가.
+- `src/serializer/hwpx/section.rs`: `render_common_shape_xml`의 하드코딩
+  `lock="0"`을 `common.locked` 기반 `{lock}` 포맷 인자로 교체.
+- `src/serializer/hwpx/shape.rs`: `write_ole`의 하드코딩 `("lock", "0")`을
+  `common.locked` 기반 `lock` 변수로 교체.
+- `src/document_core/converters/common_obj_attr_writer.rs`: 신규 필드 추가에
+  따른 테스트 헬퍼 `make_sample()` 초기화 보정(`locked: false`).
+
+## 테스트 (red → green)
+
+`src/parser/hwpx/section.rs`의 `parser::hwpx::section::tests` 모듈에
+`task2931_chart_lock_attr_roundtrips_into_common`을 추가했다. `<hp:chart
+lock="1" .../>`를 포함한 최소 HWPX 문서를 파싱해 `ShapeObject::Ole(ole)`의
+`ole.common.locked`가 `true`로 보존되는지 확인한다.
+
+- **Red**: `locked` 필드 도입 전에는 `assert!(ole.common.locked, ...)`가
+  `CommonObjAttr`에 해당 필드가 없어 `error[E0609]: no field \`locked\` on
+  type \`model::shape::CommonObjAttr\`` 컴파일 오류로 실패했다(파서 미구현
+  상태를 그대로 드러냄).
+- **Green**: `locked` 필드 추가 + 파서 2곳(`parse_hp_chart_element`,
+  `parse_hp_ole_element`)에 `lock` 매칭 추가 + 직렬화 2곳(`render_common_shape_xml`,
+  `write_ole`) 하드코딩 제거 후 `cargo test --lib
+  task2931_chart_lock_attr_roundtrips_into_common` 통과.
+
+## 검증 명령과 결과
+
+- `cargo check --lib`: 성공(경고 없음).
+- `cargo test --lib task2931_chart_lock_attr_roundtrips_into_common`: 1개
+  통과.
+- `cargo test --lib -- chart lock ole`: 187개 통과, 0개 실패(회귀 없음;
+  차트/락/OLE 관련 기존 테스트 전부 정상).
+- `rustfmt --edition 2021 <변경 파일 5개>`: 실질 diff 없음(CRLF 개행 경고만
+  발생).
+
+## 완료 기준
+
+차트(`<hp:chart>`)·OLE(`<hp:ole>`) 개체의 `lock` 속성이 IR(`CommonObjAttr.locked`)을
+거쳐 HWPX 왕복 시 보존됨을 최소 단위 테스트로 확인했다. `render_common_shape_xml`이
+공유하는 ellipse/arc/polygon/curve 경로도 동일한 필드를 참조하므로 함께 개선된다
+(단, 이 경로들의 파서는 `parse_object_element_attrs`를 통해 별도 이슈(#2840 PR
+방향)로 다뤄질 예정이며 본 작업 범위 밖이다).

--- a/mydocs/report/task_m100_3039_hatch_style_report.md
+++ b/mydocs/report/task_m100_3039_hatch_style_report.md
@@ -1,0 +1,47 @@
+# task-m100-1: hatchStyle 직렬화 catch-all 수정
+
+## 문제
+
+`src/serializer/hwpx/shape.rs`의 `hatch_style_str`은 `parse_hatch_style`
+(파서, `src/parser/hwpx/utils.rs`)의 역매핑이다. 파서 쪽은 `HORIZONTAL`~
+`CROSS_DIAGONAL` 6개 값을 전부 명시적으로 나열하는데, 직렬화 쪽은 마지막
+값(6, `CROSS_DIAGONAL`)만 `_` catch-all에 얹혀 있었다.
+
+```rust
+fn hatch_style_str(pattern_type: i32) -> &'static str {
+    match pattern_type {
+        1 => "HORIZONTAL",
+        2 => "VERTICAL",
+        3 => "BACK_SLASH",
+        4 => "SLASH",
+        5 => "CROSS",
+        _ => "CROSS_DIAGONAL",
+    }
+}
+```
+
+`pattern_type`은 HWP5 binary(`doc_info.rs`)와 HWP3(`drawing.rs`)에서
+원시 정수로 읽혀 IR에 들어오므로, 계약(1~6) 밖의 값(손상 파일, 0, 7 이상)이
+들어와도 이 함수는 조용히 `CROSS_DIAGONAL`을 방출한다. 즉 계약 밖 값을
+정당한 무늬로 둔갑시켜 라운드트립 시 원본과 다른 무늬가 저장될 수 있다.
+같은 파일의 `lineShape` style 매핑(줄 674~676 주석)에서 이미 한 번 겪은
+"catch-all이 유효한 값처럼 보이는" 패턴(#1531)과 동일한 종류다.
+
+## 수정
+
+6을 명시적으로 나열하고, catch-all은 6개 계약 값 중 가장 무난한
+`HORIZONTAL`로 바꿨다(무늬 정보가 없다는 신호를 유지하되 임의의 특정
+무늬로 확정 짓지 않기 위함).
+
+## 테스트
+
+`task_m100_hatch_style_str_covers_all_six` — 1~6 및 계약 밖 값(99)의
+매핑을 검증.
+
+## 검증
+
+이 PC의 Rust 툴체인이 `dbghelp.lib` 손상(`CVT1107`/`LNK1123`)으로 모든
+빌드 스크립트 링크에 실패하는 상태라 `cargo check --lib` 실행이 불가능했다.
+무관한 crate(`proc-macro2`, `paste`, `serde_core` 등)의 빌드 스크립트도
+동일하게 실패하므로 이 변경과 무관한 환경 문제로 판단한다. 변경 자체는
+`match` 분기 추가 및 단위 테스트 추가뿐이라 문법·타입 위험이 낮다.

--- a/src/doclang/adapter/inline.rs
+++ b/src/doclang/adapter/inline.rs
@@ -744,6 +744,7 @@ mod tests {
             start_char_idx: 4,
             end_char_idx: 8,
             control_idx: 0,
+            end_field_id: 0,
         }];
 
         let di = DocInfo::default();
@@ -777,6 +778,7 @@ mod tests {
             start_char_idx: 2,
             end_char_idx: 6,
             control_idx: 0,
+            end_field_id: 0,
         }];
 
         let di = DocInfo::default();

--- a/src/document_core/commands/document.rs
+++ b/src/document_core/commands/document.rs
@@ -1871,11 +1871,13 @@ mod validate_linesegs_tests {
                     start_char_idx: 0,
                     end_char_idx: 6,
                     control_idx: 0,
+                    ..Default::default()
                 },
                 FieldRange {
                     start_char_idx: 0,
                     end_char_idx: 6,
                     control_idx: 0,
+                    ..Default::default()
                 },
             ],
             ..Default::default()

--- a/src/document_core/converters/common_obj_attr_writer.rs
+++ b/src/document_core/converters/common_obj_attr_writer.rs
@@ -233,6 +233,7 @@ mod tests {
             height_criterion: SizeCriterion::Absolute,
             description: String::new(),
             raw_extra: Vec::new(),
+            locked: false,
             numbering_type: crate::model::shape::ObjectNumberingType::None,
             drop_cap_style: crate::model::shape::DropCapStyle::None,
         }

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1296,6 +1296,7 @@ fn insert_click_here_field_in_para(
         start_char_idx: start,
         end_char_idx: start,
         control_idx: insert_idx,
+        ..Default::default()
     };
     let range_idx = para
         .field_ranges
@@ -1594,6 +1595,7 @@ mod tests {
                 start_char_idx: 3,
                 end_char_idx: 5,
                 control_idx: 1,
+                ..Default::default()
             }],
             char_offsets: vec![8, 9, 10, 19, 20],
             ..Default::default()
@@ -1615,6 +1617,7 @@ mod tests {
                 start_char_idx: 0,
                 end_char_idx: 2,
                 control_idx: 0,
+                ..Default::default()
             }],
             char_offsets: vec![8, 9],
             ..Default::default()
@@ -1638,6 +1641,7 @@ mod tests {
                 start_char_idx: 4,
                 end_char_idx: 7,
                 control_idx: 1,
+                ..Default::default()
             }],
             // 원본 offsets (stale after text change, but char_offsets[0] still valid for ctrls_before_text)
             char_offsets: vec![8, 9, 10, 11, 20, 21, 22],

--- a/src/document_core/queries/field_query.rs
+++ b/src/document_core/queries/field_query.rs
@@ -1509,6 +1509,7 @@ mod tests {
                 start_char_idx: 3,
                 end_char_idx: 5,
                 control_idx: 1,
+                ..Default::default()
             }],
             char_count: 21,
             char_offsets: vec![8, 9, 10, 19, 20],

--- a/src/model/paragraph.rs
+++ b/src/model/paragraph.rs
@@ -274,6 +274,13 @@ pub struct FieldRange {
     pub end_char_idx: usize,
     /// controls[] 배열 내 인덱스 (해당 Field 컨트롤 참조)
     pub control_idx: usize,
+    /// 같은 문단 내 짝을 이루는 `<hp:fieldEnd>` 자신의 `fieldid` 속성값 (0 이면 없음/생략).
+    ///
+    /// `fieldBegin` 의 `id`(문서 내 고유 ID, `Field::field_id` 로 보존)와 달리, `fieldEnd`
+    /// 자신의 `fieldid` 는 별개 값으로 관찰되며(HYPERLINK 등) IR 로 옮기지 않으면 직렬화 시
+    /// 항상 소실된다. 고아(다단락) fieldEnd 는 `OrphanFieldEnd::field_id` 로 이미 보존하므로,
+    /// 같은 문단 내 짝(matched) 경로에도 대칭적으로 보존한다.
+    pub end_field_id: u32,
 }
 
 /// 고아 FIELD_END (0x04) — 짝이 되는 FIELD_BEGIN 이 다른 문단에 있는
@@ -909,6 +916,7 @@ impl Paragraph {
                     start_char_idx: fr.start_char_idx - split_pos,
                     end_char_idx: fr.end_char_idx - split_pos,
                     control_idx: fr.control_idx,
+                    end_field_id: fr.end_field_id,
                 });
             } else if fr.end_char_idx <= split_pos {
                 // 완전히 원래 문단 쪽
@@ -919,6 +927,7 @@ impl Paragraph {
                     start_char_idx: fr.start_char_idx,
                     end_char_idx: split_pos,
                     control_idx: fr.control_idx,
+                    end_field_id: fr.end_field_id,
                 });
             }
         }
@@ -1112,6 +1121,7 @@ impl Paragraph {
                 start_char_idx: fr.start_char_idx + self_text_len,
                 end_char_idx: fr.end_char_idx + self_text_len,
                 control_idx: fr.control_idx + ctrl_offset,
+                end_field_id: fr.end_field_id,
             });
         }
 

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -882,6 +882,7 @@ fn test_undo_split_moves_merged_clickhere_field_to_restored_paragraph() {
             start_char_idx: 0,
             end_char_idx: 2,
             control_idx: 0,
+            ..Default::default()
         }],
         has_para_text: true,
         ..Default::default()
@@ -923,6 +924,7 @@ fn test_split_moves_field_with_range_without_consuming_visible_offset() {
             start_char_idx: 2,
             end_char_idx: 4,
             control_idx: 0,
+            ..Default::default()
         }],
         has_para_text: true,
         ..Default::default()

--- a/src/model/paragraph/tests.rs
+++ b/src/model/paragraph/tests.rs
@@ -813,6 +813,7 @@ fn test_merge_from_field_ranges_ctrl_offset() {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         }],
         has_para_text: true,
         ..Default::default()

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -104,10 +104,10 @@ pub struct CommonObjAttr {
     pub drop_cap_style: DropCapStyle,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
-    /// HWPX `lock`(개체 잠금) 속성 보존 (#2840).
+    /// HWPX `lock`(개체 잠금) 속성 보존 (#2840, #2855, #2931).
     ///
-    /// 파서가 이 속성을 읽지 않아 `<hp:equation>` 직렬화 시 항상 `lock="0"`으로
-    /// 하드코딩되던 문제 해소. 우선 수식(`render_equation`) 경로에만 배선한다.
+    /// 파서가 이 속성을 읽지 않아 직렬화 시 항상 `lock="0"`으로 하드코딩되던 문제
+    /// 해소 — 수식·공용 도형·표·차트/OLE 경로에 배선한다.
     pub locked: bool,
 }
 

--- a/src/model/shape.rs
+++ b/src/model/shape.rs
@@ -104,6 +104,11 @@ pub struct CommonObjAttr {
     pub drop_cap_style: DropCapStyle,
     /// 파싱된 필드 이후 추가 바이트 (라운드트립 보존용)
     pub raw_extra: Vec<u8>,
+    /// HWPX `lock`(개체 잠금) 속성 보존 (#2840).
+    ///
+    /// 파서가 이 속성을 읽지 않아 `<hp:equation>` 직렬화 시 항상 `lock="0"`으로
+    /// 하드코딩되던 문제 해소. 우선 수식(`render_equation`) 경로에만 배선한다.
+    pub locked: bool,
 }
 
 /// HWPX 개체 `numberingType` (캡션 번호 범주)

--- a/src/parser/body_text.rs
+++ b/src/parser/body_text.rs
@@ -322,6 +322,7 @@ fn parse_para_text(data: &[u8]) -> (String, Vec<u32>, Vec<FieldRange>, Vec<[u16;
                         start_char_idx: start_idx,
                         end_char_idx: char_count,
                         control_idx: field_ctrl_idx,
+                        end_field_id: 0,
                     });
                 }
             } else if is_extended_only_ctrl_char(ch) {

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -1702,6 +1702,9 @@ fn parse_table(
                     _ => crate::model::shape::ObjectNumberingType::None,
                 };
             }
+            // [#2855] 표만 lock arm 이 없어 개체 잠금이 파싱 단계에서 유실됐다. 도형/그림
+            // 계열이 공유하는 parse_object_element_attrs(같은 파일 2905행, #2840)와 동형.
+            b"lock" => table.common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -6018,6 +6018,9 @@ fn parse_hp_chart_element(
                 chart_num = digits.parse().unwrap_or(0);
             }
             b"instid" => common.instance_id = parse_u32(&attr),
+            // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
+            // 되돌아가 차트 개체의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -6112,6 +6115,9 @@ fn parse_hp_ole_element(
                 bin_id = digits.parse().unwrap_or(0);
             }
             b"instid" => common.instance_id = parse_u32(&attr),
+            // [#2931] 개체 잠금(lock) — 종전 미파싱으로 직렬화 시 항상 "0"으로
+            // 되돌아가 OLE 개체의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }
@@ -8291,6 +8297,35 @@ mod tests {
             co.chars,
             vec!['a', '<', 'b'],
             "composeText CDATA 가 소실되면 안 됨"
+        );
+    }
+
+    #[test]
+    fn task2931_chart_lock_attr_roundtrips_into_common() {
+        // <hp:chart lock="1" .../> → common.locked 이 true 로 되읽혀야 한다.
+        // 종전엔 parse_hp_chart_element 가 lock 속성을 매치하지 않아 항상 기본값(false)
+        // 으로 남고, 직렬화 시에도 render_common_shape_xml 이 "0"을 하드코딩했다(#2931).
+        let xml = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p id="0" paraPrIDRef="0" styleIDRef="0">
+    <hp:run charPrIDRef="0">
+      <hp:chart id="1" zOrder="0" numberingType="NONE" textWrap="SQUARE" textFlow="BOTH_SIDES" lock="1" chartIDRef="Chart/chart1.xml" instid="1"></hp:chart>
+      <hp:t/>
+    </hp:run>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(xml).unwrap();
+        let Control::Shape(shape) = &section.paragraphs[0].controls[0] else {
+            panic!("expected shape control");
+        };
+        let ShapeObject::Ole(ole) = shape.as_ref() else {
+            panic!("expected chart (modeled as OLE) shape");
+        };
+        assert!(
+            ole.common.locked,
+            "lock=\"1\" 이 common.locked 에 보존돼야 한다"
         );
     }
 }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2977,6 +2977,9 @@ fn parse_object_element_attrs(
             // 선/연결선의 방향 뒤집기(isReverseHV). serializer 는 방출하나 파서가
             // 되읽지 않아 HWPX 원본 선의 방향 반전이 왕복 시 유실됐다.
             b"isReverseHV" => ids.is_reverse_hv = attr_str(&attr) == "1",
+            // [#2840] 개체 잠금(lock) — 종전 미파싱으로 <hp:equation> 직렬화 시
+            // 항상 "0"으로 되돌아가 원본의 잠금 상태가 유실됐다.
+            b"lock" => common.locked = attr_str(&attr) == "1",
             _ => {}
         }
     }

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -639,6 +639,7 @@ fn parse_paragraph(
                         start_char_idx,
                         end_char_idx: visible_char_idx,
                         control_idx,
+                        end_field_id: field_id,
                     });
                 } else {
                     // [Task #1556] 짝 fieldBegin 이 다른 문단에 있는 다단락 필드의 종료 마커.

--- a/src/serializer/body_text.rs
+++ b/src/serializer/body_text.rs
@@ -1246,6 +1246,7 @@ mod tests {
                 start_char_idx: 0,
                 end_char_idx: 1,
                 control_idx: 0,
+                ..Default::default()
             }],
             ..Default::default()
         };
@@ -1292,11 +1293,13 @@ mod tests {
                     start_char_idx: 0,
                     end_char_idx: 2,
                     control_idx: 0,
+                    ..Default::default()
                 },
                 crate::model::paragraph::FieldRange {
                     start_char_idx: 3,
                     end_char_idx: 5,
                     control_idx: 1,
+                    ..Default::default()
                 },
             ],
             ..Default::default()

--- a/src/serializer/hwpx/mod.rs
+++ b/src/serializer/hwpx/mod.rs
@@ -941,6 +941,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 2,
+            ..Default::default()
         }];
         section.paragraphs.push(p);
         doc.sections.push(section);

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -3822,6 +3822,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            end_field_id: 0,
         });
 
         let (doc, section) = make_doc_with_paragraph(para);

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -29,7 +29,7 @@ use crate::model::document::{Document, Section, SectionDef};
 use crate::model::footnote::{Endnote, Footnote};
 use crate::model::header_footer::{Footer, Header, HeaderFooterApply};
 use crate::model::page::{ColumnDef, ColumnDirection, ColumnType};
-use crate::model::paragraph::{ColumnBreakType, LineSeg, OrphanFieldEnd, Paragraph};
+use crate::model::paragraph::{ColumnBreakType, FieldRange, LineSeg, OrphanFieldEnd, Paragraph};
 use crate::model::shape::{
     CommonObjAttr, HorzAlign, HorzRelTo, ShapeObject, SizeCriterion, TextWrap, VertAlign, VertRelTo,
 };
@@ -708,12 +708,18 @@ impl RunSplitter {
 }
 
 /// `<hp:ctrl><hp:fieldEnd beginIDRef=".."/></hp:ctrl>` 방출 공통 경로.
-fn emit_field_end(out: &mut String, para: &Paragraph, control_idx: usize) {
-    if let Some(Control::Field(f)) = para.controls.get(control_idx) {
-        // [#task-m100] fieldEnd 도 원본 fieldid 를 보존(있으면) — fieldBegin 과 동일 규칙.
-        if let Ok(xml) =
-            writer_to_string(|w| write_field_end_full(w, f.field_id, f.instance_id.unwrap_or(0)))
-        {
+fn emit_field_end(out: &mut String, para: &Paragraph, fr: &FieldRange) {
+    if let Some(Control::Field(f)) = para.controls.get(fr.control_idx) {
+        // [Task #bookmark-hyperlink] 짝(matched) fieldEnd 자신의 fieldid 는 fieldBegin 의
+        // id(f.field_id, beginIDRef 로 사용)와 별개 값 — 파싱된 fr.end_field_id 를 그대로
+        // 되돌려 써야 한다. 과거엔 write_field_end 로 beginIDRef 만 쓰고 fieldid 는 항상
+        // 누락시켰다(고아 fieldEnd 경로만 write_field_end_full 로 보존, 비대칭).
+        let xml_result = if fr.end_field_id == 0 {
+            writer_to_string(|w| write_field_end(w, f.field_id))
+        } else {
+            writer_to_string(|w| write_field_end_full(w, f.field_id, fr.end_field_id))
+        };
+        if let Ok(xml) = xml_result {
             out.push_str("<hp:ctrl>");
             out.push_str(&xml);
             out.push_str("</hp:ctrl>");
@@ -921,7 +927,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         // fieldBegin(슬롯)만 방출하고 fieldEnd 방출 코드가 없어 same-para 균형 필드가
         // 1/0 으로 깨지며 cc −8 (#1593). #1556 고아 복원과 동형(위치 대신 말미 일괄).
         for fr in &para.field_ranges {
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
         }
         // [Task #1556] 위치 추정 불가 경로에서도 고아 fieldEnd 의 8유닛 슬롯은 복원한다
         // (정확한 위치 대신 말미 일괄 — 최소한 char_count 보존).
@@ -965,7 +971,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
         for (i, fr) in para.field_ranges.iter().enumerate() {
             if fr.start_char_idx == fr.end_char_idx && !field_end_emitted[i] {
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -1046,7 +1052,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     && fr.control_idx == emitted_ctrl_idx
                 {
                     splitter.cut_before(expected_utf16_pos);
-                    emit_field_end(&mut splitter.content, para, fr.control_idx);
+                    emit_field_end(&mut splitter.content, para, fr);
                     expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                     field_end_emitted[i] = true;
                 }
@@ -1084,7 +1090,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &mut tab_idx,
                 );
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 field_end_emitted[i] = true;
             }
         }
@@ -1155,7 +1161,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                     &mut tab_idx,
                 );
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 // [#1407] fieldEnd 는 8유닛 슬롯을 소비한다. expected 를 +8 진행하지
                 // 않으면 다음 idx 에서 텍스트-끝 슬롯(newNum 등)이 이 8유닛 갭을
                 // 가로채 텍스트가 +8 밀린다 (143E 문단 0.14: char_offsets[3] 27→35).
@@ -1187,7 +1193,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 continue;
             }
             splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }
@@ -1229,7 +1235,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
                 && fr.control_idx == emitted_ctrl_idx
             {
                 splitter.cut_before(expected_utf16_pos);
-                emit_field_end(&mut splitter.content, para, fr.control_idx);
+                emit_field_end(&mut splitter.content, para, fr);
                 expected_utf16_pos = expected_utf16_pos.saturating_add(8);
                 field_end_emitted[i] = true;
             }
@@ -1239,7 +1245,7 @@ fn render_runs(para: &Paragraph, ctx: &mut SerializeContext) -> String {
     for (i, fr) in para.field_ranges.iter().enumerate() {
         if !field_end_emitted[i] {
             splitter.cut_before(expected_utf16_pos);
-            emit_field_end(&mut splitter.content, para, fr.control_idx);
+            emit_field_end(&mut splitter.content, para, fr);
             expected_utf16_pos = expected_utf16_pos.saturating_add(8);
             field_end_emitted[i] = true;
         }
@@ -3698,6 +3704,35 @@ mod tests {
         );
     }
 
+    /// [bookmark-hyperlink] 같은 문단 내 짝(matched) HYPERLINK fieldBegin/fieldEnd 라운드트립 —
+    /// fieldEnd 자신의 fieldid(=100)가 fieldBegin 의 id(=42, beginIDRef 로 사용)와 다를 때,
+    /// 과거엔 emit_field_end 가 write_field_end(f.field_id) 만 호출해 fieldid 속성을 항상
+    /// 누락시켰다(고아 fieldEnd 경로만 보존해 비대칭). fr.end_field_id 를 IR 에 보존하고
+    /// 되돌려 쓰면 fieldid="100" 이 살아남아야 한다.
+    #[test]
+    fn bookmark_hyperlink_matched_field_end_preserves_own_fieldid() {
+        let mut f = Field::default();
+        f.field_type = FieldType::Hyperlink;
+        f.field_id = 42;
+        let mut para = Paragraph::default();
+        para.text = "링크".to_string();
+        para.char_count = 2 + 8 + 8 + 1; // text(2) + FIELD_BEGIN(8) + FIELD_END(8) + para_end(1)
+        para.controls.push(Control::Field(f));
+        para.field_ranges.push(FieldRange {
+            start_char_idx: 0,
+            end_char_idx: 2,
+            control_idx: 0,
+            end_field_id: 100,
+        });
+        let (doc, section) = make_doc_with_paragraph(para);
+        let mut ctx = SerializeContext::collect_from_document(&doc);
+        let xml = String::from_utf8(write_section(&section, &doc, 0, &mut ctx).unwrap()).unwrap();
+        assert!(
+            xml.contains(r#"<hp:fieldEnd beginIDRef="42" fieldid="100"/>"#),
+            "matched fieldEnd 는 beginIDRef(=fieldBegin id)와 별개로 자신의 fieldid 를 보존해야 함: {xml}"
+        );
+    }
+
     // ---------- #1289: Bookmark / Field dispatcher 연결 ----------
 
     use crate::model::control::{Bookmark, Control, Field, FieldType};
@@ -3744,6 +3779,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3813,6 +3849,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 1,
             control_idx: 0,
+            ..Default::default()
         });
         let (doc, section) = make_doc_with_paragraph(para);
         let mut ctx = SerializeContext::collect_from_document(&doc);
@@ -3841,6 +3878,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 5,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3883,6 +3921,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3, // == text.len() → 루프 후 처리 경로
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3916,6 +3955,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 0, // 0-length
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -3963,6 +4003,7 @@ mod tests {
             start_char_idx: 3,
             end_char_idx: 3, // 0-length mid-text
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -4012,6 +4053,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 0,
             control_idx: 0,
+            ..Default::default()
         });
 
         let (doc, section) = make_doc_with_paragraph(para);
@@ -4065,6 +4107,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3, // "ABC" 래핑
             control_idx: 0,
+            ..Default::default()
         });
 
         let xml = runs_of(&para);
@@ -4221,6 +4264,7 @@ mod tests {
             start_char_idx: 0,
             end_char_idx: 3,
             control_idx: 0,
+            ..Default::default()
         });
         para.char_shapes = vec![cs(0, 1), cs(19, 2)];
         let xml = runs_of(&para);

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2235,8 +2235,11 @@ fn render_equation(eq: &Equation) -> String {
         "CHAR"
     };
 
+    // [#2840] 개체 잠금(lock) — 종전 하드코딩 "0" 제거, IR(common.locked) 값을 방출.
+    let lock = if c.locked { "1" } else { "0" };
+
     format!(
-        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="0" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
+        r#"<hp:equation id="{id}" zOrder="{z_order}" numberingType="EQUATION" textWrap="{}" textFlow="{}" lock="{lock}" dropcapstyle="None" instid="{id}" version="{version}" baseLine="{baseline}" textColor="{text_color}" baseUnit="{base_unit}" lineMode="{line_mode}" font="{font}"><hp:script>{script}</hp:script><hp:sz width="{width}" widthRelTo="ABSOLUTE" height="{height}" heightRelTo="ABSOLUTE"/><hp:pos treatAsChar="{treat}" affectLSpacing="0" flowWithText="{flow_with_text}" allowOverlap="0" holdAnchorAndSO="{hold}" vertRelTo="{}" horzRelTo="{}" vertAlign="{}" horzAlign="{}" vertOffset="{vert_offset}" horzOffset="{horz_offset}"/><hp:outMargin left="{margin_left}" right="{margin_right}" top="{margin_top}" bottom="{margin_bottom}"/>{shape_comment}</hp:equation>"#,
         text_wrap_to_hwpx(c.text_wrap),
         text_flow_to_hwpx(c.text_flow),
         vert_rel_to_hwpx(c.vert_rel_to),
@@ -2600,6 +2603,21 @@ mod tests {
         assert!(
             !line_xml.contains(r#"lineMode="CHAR""#),
             "CHAR 하드코딩 잔존 금지"
+        );
+    }
+
+    /// [Issue #2840] 수식의 lock(개체 잠금)이 IR(common.locked)에서 방출돼야 한다.
+    /// 종전엔 파서가 lock 속성을 읽지 않아 하드코딩 "0"으로 왕복마다 잠금이 풀렸다.
+    #[test]
+    fn equation_lock_reflects_ir() {
+        use crate::model::control::Equation;
+
+        let mut eq = Equation::default();
+        eq.common.locked = true;
+        let xml = render_equation(&eq);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "locked=true 면 lock=\"1\" 을 방출해야 함(하드코딩 \"0\" 잔존 금지): {xml}"
         );
     }
 

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2003,7 +2003,7 @@ fn render_common_shape_xml(
         .unwrap_or(c.instance_id);
     let mut out = format!(
         concat!(
-            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="0" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
+            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="{lk}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
             "{block}",
             "{geometry}",
             r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
@@ -2019,6 +2019,8 @@ fn render_common_shape_xml(
         gl = group_level,
         iid = instid,
         tw = text_wrap_to_hwpx(c.text_wrap),
+        // [#2840] lock(개체 잠금) — IR 보존 값 방출 (종전 "0" 하드코딩).
+        lk = if c.locked { "1" } else { "0" },
         tac = if c.treat_as_char { "1" } else { "0" },
         fwt = if c.flow_with_text { "1" } else { "0" },
         ao = if c.allow_overlap { "1" } else { "0" },

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -2009,7 +2009,7 @@ fn render_common_shape_xml(
         .unwrap_or(c.instance_id);
     let mut out = format!(
         concat!(
-            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="{lk}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
+            r#"<hp:{tag} id="{id}" zOrder="{zo}" numberingType="{nt}" textWrap="{tw}" textFlow="BOTH_SIDES" lock="{lock}" dropcapstyle="None" href="" groupLevel="{gl}" instid="{iid}">"#,
             "{block}",
             "{geometry}",
             r#"<hp:sz width="{w}" height="{h}" widthRelTo="{wrt}" heightRelTo="{hrt}" protect="{prot}"/>"#,
@@ -2022,11 +2022,11 @@ fn render_common_shape_xml(
         id = c.instance_id,
         zo = c.z_order,
         nt = super::shape::numbering_type_str(c.numbering_type),
+        // [#2840] lock(개체 잠금) — IR 보존 값 방출 (종전 "0" 하드코딩).
+        lock = if c.locked { "1" } else { "0" },
         gl = group_level,
         iid = instid,
         tw = text_wrap_to_hwpx(c.text_wrap),
-        // [#2840] lock(개체 잠금) — IR 보존 값 방출 (종전 "0" 하드코딩).
-        lk = if c.locked { "1" } else { "0" },
         tac = if c.treat_as_char { "1" } else { "0" },
         fwt = if c.flow_with_text { "1" } else { "0" },
         ao = if c.allow_overlap { "1" } else { "0" },

--- a/src/serializer/hwpx/section.rs
+++ b/src/serializer/hwpx/section.rs
@@ -35,7 +35,7 @@ use crate::model::shape::{
 };
 
 use super::context::SerializeContext;
-use super::field::{write_bookmark, write_field_begin, write_field_end_full};
+use super::field::{write_bookmark, write_field_begin, write_field_end, write_field_end_full};
 use super::utils::xml_escape;
 use super::SerializeError;
 use super::{picture, table};

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -70,7 +70,8 @@ pub fn write_rect<W: Write>(
             ("numberingType", numbering_type_str(c.numbering_type)),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            // [#2840] lock(개체 잠금) — 파서가 읽기 시작했으므로 IR 값을 방출한다.
+            ("lock", bool01(c.locked)),
             ("dropcapstyle", "None"),
             ("href", ""),
             ("groupLevel", &group_level),
@@ -172,7 +173,8 @@ pub fn write_line<W: Write>(
         ("numberingType", numbering_type_str(c.numbering_type)),
         ("textWrap", text_wrap_str(c.text_wrap)),
         ("textFlow", text_flow_str(c.text_flow)),
-        ("lock", "0"),
+        // [#2840] lock(개체 잠금) — IR 보존 값 방출.
+        ("lock", bool01(c.locked)),
         ("dropcapstyle", "None"),
         ("href", ""),
         ("groupLevel", &group_level),
@@ -291,7 +293,8 @@ pub fn write_container_open<W: Write>(
             ("numberingType", numbering_type_str(common.numbering_type)),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            // [#2840] lock(개체 잠금) — IR 보존 값 방출.
+            ("lock", bool01(common.locked)),
             ("dropcapstyle", "None"),
             ("href", ""),
             ("groupLevel", "0"),
@@ -367,7 +370,8 @@ pub(crate) fn write_ole<W: Write>(
             ("numberingType", numbering_type_str(c.numbering_type)),
             ("textWrap", tw),
             ("textFlow", tf),
-            ("lock", "0"),
+            // [#2840] lock(개체 잠금) — IR 보존 값 방출.
+            ("lock", bool01(c.locked)),
             ("dropcapstyle", "None"),
             ("href", ""),
             ("groupLevel", "0"),

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -930,7 +930,10 @@ fn hatch_style_str(pattern_type: i32) -> &'static str {
         3 => "BACK_SLASH",
         4 => "SLASH",
         5 => "CROSS",
-        _ => "CROSS_DIAGONAL",
+        6 => "CROSS_DIAGONAL",
+        // 계약(1~6) 밖의 값은 무늬 정보가 없다는 뜻이므로 임의의 무늬로
+        // 둔갑시키지 않고 가장 무난한 HORIZONTAL 로 방출한다.
+        _ => "HORIZONTAL",
     }
 }
 
@@ -1837,5 +1840,19 @@ mod tests {
         assert!(xml.contains(r#"widthRelTo="ABSOLUTE""#), "{xml}");
         assert!(xml.contains(r#"heightRelTo="ABSOLUTE""#), "{xml}");
         assert!(xml.contains(r#"protect="0""#), "{xml}");
+    }
+
+    #[test]
+    fn task_m100_hatch_style_str_covers_all_six() {
+        // 계약(1~6) 값 6개를 모두 명시적으로 매핑하는지 확인한다.
+        // 이전에는 6이 catch-all(_) 분기에 얹혀 있어, 계약 밖의 값(예: 손상된
+        // 원본의 pattern_type=99)도 CROSS_DIAGONAL 로 둔갑했다.
+        assert_eq!(hatch_style_str(1), "HORIZONTAL");
+        assert_eq!(hatch_style_str(2), "VERTICAL");
+        assert_eq!(hatch_style_str(3), "BACK_SLASH");
+        assert_eq!(hatch_style_str(4), "SLASH");
+        assert_eq!(hatch_style_str(5), "CROSS");
+        assert_eq!(hatch_style_str(6), "CROSS_DIAGONAL");
+        assert_eq!(hatch_style_str(99), "HORIZONTAL");
     }
 }

--- a/src/serializer/hwpx/shape.rs
+++ b/src/serializer/hwpx/shape.rs
@@ -360,6 +360,8 @@ pub(crate) fn write_ole<W: Write>(
         OleDrawingAspect::DocPrint => "DOCPRINT",
         OleDrawingAspect::Content => "CONTENT",
     };
+    // [#2931] 개체 잠금(lock) — IR(common.locked)을 보존(종전 "0" 하드코딩 제거).
+    let lock = if c.locked { "1" } else { "0" };
 
     start_tag_attrs(
         w,

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -59,7 +59,8 @@ pub fn write_table<W: Write>(
     let z_order = table.common.z_order.to_string();
     let text_wrap = text_wrap_str(table.common.text_wrap);
     let text_flow = text_flow_str(table.common.text_flow);
-    let lock = bool01(false);
+    // [#2840] lock(개체 잠금) — IR 보존 값 방출 (종전 false 하드코딩).
+    let lock = bool01(table.common.locked);
     let page_break = table_page_break_str(table.page_break);
     let repeat_header = bool01(table.repeat_header);
     let row_cnt = table.row_count.to_string();

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -1364,6 +1364,53 @@ mod tests {
     }
 
     #[test]
+    fn task2855_tbl_lock_survives_xml_ir_xml_roundtrip() {
+        // [#2855] <hp:tbl> 의 lock(개체 잠금)이 parse_table 에 arm 이 없어 파싱 단계에서
+        // 버려지고, 방출측(이 파일 62행)도 bool01(false) 로 하드코딩되어 있어 왕복 시
+        // 원본 lock="1" 이 소리 없이 lock="0" 으로 풀린다. RED.
+        use crate::parser::hwpx::section::parse_hwpx_section;
+
+        let src = r#"<?xml version="1.0" encoding="UTF-8"?>
+<hs:sec xmlns:hp="http://www.hancom.co.kr/hwpml/2011/paragraph"
+        xmlns:hs="http://www.hancom.co.kr/hwpml/2011/section">
+  <hp:p paraPrIDRef="0" styleIDRef="0">
+    <hp:tbl lock="1" rowCnt="1" colCnt="1" cellSpacing="0" borderFillIDRef="0">
+      <hp:sz width="1000" widthRelTo="ABSOLUTE" height="1000" heightRelTo="ABSOLUTE"/>
+      <hp:pos treatAsChar="0" flowWithText="1" allowOverlap="0"
+              vertRelTo="PARA" horzRelTo="COLUMN" vertAlign="TOP" horzAlign="LEFT"
+              vertOffset="0" horzOffset="0"/>
+      <hp:outMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:inMargin left="0" right="0" top="0" bottom="0"/>
+      <hp:tr>
+        <hp:tc borderFillIDRef="0">
+          <hp:cellAddr colAddr="0" rowAddr="0"/>
+          <hp:cellSpan colSpan="1" rowSpan="1"/>
+          <hp:cellSz width="1000" height="1000"/>
+        </hp:tc>
+      </hp:tr>
+    </hp:tbl>
+  </hp:p>
+</hs:sec>"#;
+
+        let section = parse_hwpx_section(src).expect("파싱");
+        let table = match &section.paragraphs[0].controls[0] {
+            crate::model::control::Control::Table(t) => t.as_ref().clone(),
+            other => panic!("표가 아님: {other:?}"),
+        };
+
+        assert!(
+            table.common.locked,
+            "lock=\"1\" 이 IR(common.locked)에 남아야 함(parse_table 에 lock arm 누락)"
+        );
+        let xml = serialize(&table);
+        assert!(
+            xml.contains(r#"lock="1""#),
+            "lock 이 IR 에서 방출돼야 함(현재 bool01(false) 하드코딩): {}",
+            &xml[..xml.len().min(400)]
+        );
+    }
+
+    #[test]
     fn task2697_height_criterion_str_is_exact_inverse_of_parser() {
         // 파서는 높이를 parse_size_criterion(_, allow_column_para=false) 로 읽으므로
         // (section.rs:1693) 치역이 {Paper, Page, Absolute} 3값뿐이다. 방출이 COLUMN/PARA 를


### PR DESCRIPTION
kevin9327 님의 hwpx lock 연작·shape 축 5건을 메인테이너가 재실증 후 통합한다. 충돌분 4건을 같은 축에 흡수했다.

## 채택 5건

| PR | 결함 |
|---|---|
| #3111 (`Closes #2840`) | 수식 lock(개체 잠금) 미파싱 + lock 방출을 전 개체 직렬화기로 확장 |
| #3114 | hatchStyle 직렬화 catch-all 이 CROSS_DIAGONAL 로 오확정 |
| #3118 (`Closes #2909`) | HWPX 같은 문단 내 짝(matched) fieldEnd 의 fieldid 속성 왕복 소실 |
| #3121 (`Closes #2855`) | 표(hp:tbl) lock 파싱/방출 누락 |
| #3122 (`Closes #2931`) | 차트/OLE lock 속성 저장 시 0 하드코딩 |

## 충돌 흡수와 판단

- **lock 삼중 중복 정리**: 세 PR(#3111 #3121 #3122)이 같은 `common.locked` 배선을 각자 구현 — #3111 을 기축으로 삼고 #3121/#3122 는 고유분(hp:tbl·hp:chart/ole 파서 arm, 왕복 테스트)만 남겼다. hp:pic 은 기merge 된 #2881(`pic.lock`)을 유지해 이중 구현을 피했다.
- **#3118 실질 병합**: devel 의 instance_id 근사 방출 대신 이 PR 의 `FieldRange.end_field_id` 정밀 보존을 채택 — 짝 fieldEnd 자신의 fieldid 는 fieldBegin id 와 별개 값이라는 분석이 더 정확하다.
- **후속 보강 2커밋**: write_field_end import 보정, FieldRange 확장에 못 따라온 doclang·serializer 테스트 리터럴 3곳 `end_field_id: 0` 보강 (doclang 은 이 PR 제출 이후 devel 에 유입된 모듈).

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 5건 반영을 표적 테스트(chart lock 왕복·compose CDATA 등)로 개별 확인

Co-authored-by 로 원 커밋 provenance 를 보존한다.
