### PR TITLE
fix(hwp3): 컨트롤 push 누락·IR 배선·스펙 오프셋 6건 — kevin9327 축배치 I

### DIFF
--- a/mydocs/report/task_m100_2958_report.md
+++ b/mydocs/report/task_m100_2958_report.md
@@ -1,0 +1,53 @@
+# 완료 보고서 — Task M100-2958
+
+- 이슈: #2958
+- 제목: HWP3 글자 음영색(shade_color) 변환 누락 — convert_char_shape 에서 IR로 복사되지 않음
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2958-hwp3-shade-color`
+
+## 1. 완료 내용
+
+`src/parser/hwp3/mod.rs`의 `convert_char_shape()`는 `Hwp3CharShape.text_color`
+(글자색, offset 24)는 `hwp3_color_index_to_color_ref()`로 매핑하지만, 바로 옆
+필드인 `shade_color`(글자 음영색, offset 23)는 매핑하지 않고 방치하고 있었다.
+
+그 결과 IR `CharShape.shade_color`는 `CharShape::default()`의 값인 `0`(검정,
+`ColorRef = u32` 기본값)으로 항상 남는다. 그런데 렌더러(`html.rs`, `svg.rs`,
+`skia/text_replay.rs`, `canvaskit_policy.rs` 등)는 "형광펜 음영 없음"을
+`0x00FFFFFF`(흰색) sentinel로 판정하므로 (`shade_color & 0x00FFFFFF !=
+0x00FFFFFF`), 값이 `0`으로 남으면 음영 없는 문단도 잠재적으로 "음영 있음"으로
+오판될 소지가 있는 상태였다.
+
+이 필드는 `text_color`와 동일한 8색 팔레트(검정~흰색 인덱스 0~7)를 쓰므로
+기존 `hwp3_color_index_to_color_ref()` 헬퍼를 그대로 재사용해 매핑했다.
+색상 인덱스 7(흰색)은 헬퍼를 거치면 정확히 `0x00FFFFFF`로 변환되어, 음영이
+없는 HWP3 문서(글자 음영색 인덱스가 흰색인 경우)는 그대로 "음영 없음"
+sentinel과 일치하게 되어 회귀가 없다.
+
+같은 함수의 `text_color` 미변환 문제는 이미 #1692에서 지적되어 수정되었으나,
+당시 분석 근거(`records.rs:193`)에 `shade_color`, `text_color` 필드가 함께
+언급되었음에도 수정은 `text_color`에만 적용되고 `shade_color`는 그대로
+누락되어 있었다.
+
+## 2. 주요 변경
+
+- `src/parser/hwp3/mod.rs`
+  - `convert_char_shape()`에 `cs.shade_color =
+    hwp3_color_index_to_color_ref(hwp3_cs.shade_color);` 추가 (5줄, 주석 포함)
+  - 단위 테스트 `task2958_convert_char_shape_preserves_shade_color` 추가
+    (red: 기존 코드에서는 `cs.shade_color`가 항상 `0` → 테스트가 기대하는
+    `0x00FF0000`과 불일치해 실패 / green: 수정 후 통과)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib task2958` → `task2958_convert_char_shape_preserves_shade_color ... ok`
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs`
+
+## 4. 범위 밖 (Out of scope)
+
+- HWP3 문단 모양의 `word_spacing`(낱말 간격)은 파싱만 되고 IR `ParaShape`에
+  대응 필드가 없어 변환되지 않는다. 이는 IR 확장이 필요한 별도 스코프이므로
+  이번 tiny fix에는 포함하지 않았다.

--- a/mydocs/report/task_m100_3016_report.md
+++ b/mydocs/report/task_m100_3016_report.md
@@ -1,0 +1,41 @@
+# Task #3016 처리 결과 — HWP3 CharShape "글꼴에 어울리는 빈칸 사용" 매핑 누락 수정
+
+## 이슈
+
+[#3016](https://github.com/edwardkim/rhwp/issues/3016)
+
+HWP3 `Hwp3CharShape` attr 바이트의 bit 0x80("글꼴에 어울리는 빈칸 사용")을
+읽는 접근자 `is_font_blank()`가 `src/parser/hwp3/records.rs`에 이미
+존재했지만, `src/parser/hwp3/mod.rs`의 `convert_char_shape()`가 이를 호출하지
+않아 공통 IR `CharShape.use_font_space` 필드가 HWP3 파서 경로에서 항상
+`false`로 고정되는 문제.
+
+## 원인
+
+`convert_char_shape()`는 이탤릭/볼드/밑줄/외곽선/그림자를 모두 IR로
+매핑하면서, attr의 마지막 비트(0x80, `is_font_blank()`)에 대한 매핑 한 줄만
+빠져 있었다. "접근자는 존재하지만 호출부가 없어 IR 필드가 항상 기본값으로
+고정되는" 패턴이다.
+
+## 수정
+
+`src/parser/hwp3/mod.rs`의 `convert_char_shape()`에 한 줄 추가:
+
+```rust
+cs.use_font_space = hwp3_cs.is_font_blank();
+```
+
+그리고 attr=0x80 케이스를 검증하는 유닛 테스트
+`convert_char_shape_maps_font_blank`를 추가했다.
+
+## 검증
+
+- `cargo check --lib` — 통과 (경고 없음).
+- `cargo test --lib convert_char_shape` — 관련 테스트 모두 통과
+  (`convert_char_shape_maps_font_blank` 포함).
+- `rustfmt --edition 2021 src/parser/hwp3/mod.rs` — 적용 (변경 없음).
+
+## 변경 범위
+
+`src/parser/hwp3/mod.rs` 1개 파일 (구현 3줄 + 테스트 8줄). 다른 파일은
+건드리지 않았다.

--- a/mydocs/report/task_m100_3147_report.md
+++ b/mydocs/report/task_m100_3147_report.md
@@ -1,0 +1,31 @@
+# Task #3147 처리 결과
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 `parse_simple_control_char` 메일머지 표시(ch==22,
+spec §10.16 표 57) arm 이 필드 이름을 `buf[2..22]`에서 읽었다. 여는 코드
+(파일 오프셋 0..2)는 문자 스캔 루프에서 이미 소비되므로 추가로 읽는 22바이트
+버퍼에서 필드 이름은 `buf[0..20]`, 닫는 코드(0x0016)는 `buf[20..22]`다.
+종전 코드는 이름 앞 2바이트를 유실하고 닫는 코드를 이름 뒤에 혼입시켰다.
+
+바이트 소비량(24바이트 = 12 hchar)은 스펙과 일치해 스트림 정렬은 정상이며,
+IR `Field.command` 내용만 훼손되는 결함이다.
+
+## 수정
+
+`buf[2..22]` → `buf[0..20]` 1줄 수정 (스펙 근거 주석 추가).
+
+## 검증 (red → green)
+
+- 합성 문단(문단 정보 43바이트 + ch=22 컨트롤 24바이트, 필드 이름
+  `MERGEFIELD` 0 패딩)으로 `parse_paragraph_list`를 호출하는 회귀 테스트
+  `hwp3_mail_merge_field_name_starts_at_offset_zero` 추가.
+- 수정 전(red): `left: "RGEFIELD" / right: "MERGEFIELD"` FAIL 확인.
+- 수정 후(green): 해당 테스트 PASS, `cargo test --lib` 전체 2553건 통과,
+  `cargo fmt --check`·`cargo clippy --lib` 무경고.
+
+## 범위
+
+메일머지 arm 의 이름 오프셋만 수정. 같은 arm 의 바이트 소비량·hchar 카운트는
+스펙과 일치해 무변경. 글자겹침(ch=23) 겹칠 글자 미추출은 별도 이슈(#3148)로
+분리.

--- a/mydocs/report/task_m100_3148_report.md
+++ b/mydocs/report/task_m100_3148_report.md
@@ -1,0 +1,33 @@
+# Task #3148 처리 결과
+
+## 문제
+
+`src/parser/hwp3/mod.rs`의 `parse_simple_control_char` 글자겹침(ch==23,
+spec §10.17 표 58) arm 이 추가로 읽은 8바이트 버퍼를 전혀 해석하지 않고
+`CharOverlap::default()`(빈 `chars`)를 IR 에 push 했다. 스펙상 버퍼의
+`[0..6]`은 겹칠 글자 hchar array[3](최대 3자, 남는 부분 0 패딩),
+`[6..8]`은 닫는 코드다. 바이트 소비량(10바이트 = 5 hchar)은 정확해 스트림은
+어긋나지 않지만, 겹침 대상 글자가 전량 유실됐다.
+
+IR `CharOverlap.chars`는 HWP5 직렬화(`serialize_char_overlap`)·HWPX 경로가
+이미 소비하는 필드이므로 파서만 채우면 전 경로가 연결된다.
+
+## 수정
+
+ch==23 arm 에서 `buf[0..6]`의 hchar 3개를 LE 로 읽어 0 이 아닌 값만
+`johab::decode_johab`로 디코딩해 `overlap.chars`에 push (스펙 근거 주석 포함).
+
+## 검증 (red → green)
+
+- 합성 문단(문단 정보 43바이트 + ch=23 컨트롤 10바이트: 겹칠 글자
+  'A','B',0 패딩)으로 `parse_paragraph_list`를 호출하는 회귀 테스트
+  `hwp3_char_overlap_extracts_overlap_chars` 추가.
+- 수정 전(red): `left: [] / right: ['A', 'B']` FAIL 확인.
+- 수정 후(green): 해당 테스트 PASS, `cargo test --lib` 전체 2552건 통과,
+  `cargo clippy --lib` 무경고 (fmt --check 는 Windows CRLF 체크아웃 노이즈만).
+
+## 범위
+
+겹칠 글자 추출만 수정. 바이트 소비량·hchar 카운트는 스펙과 일치해 무변경.
+테두리 종류 등 표 58 외 확장 속성은 HWP3 스펙에 없어 범위 밖. 메일머지
+(ch=22) 이름 오프셋 어긋남은 별도 이슈(#3147)로 분리.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1593,6 +1593,12 @@ fn parse_object_control_char(
                 crate::model::control::UnknownControl::default(),
             ));
         }
+    } else if ch == 15 {
+        let mut hidden_comment = crate::model::control::HiddenComment::default();
+        hidden_comment.paragraphs = nested_paragraphs;
+        controls.push(crate::model::control::Control::HiddenComment(Box::new(
+            hidden_comment,
+        )));
     } else if ch == 16 {
         let apply_to = match info_buf.get(9).copied().unwrap_or(0) {
             1 => crate::model::header_footer::HeaderFooterApply::Even,
@@ -4175,6 +4181,69 @@ mod tests {
                 .any(|c| matches!(c, crate::model::control::Control::Field(_))),
             "ch==5 필드 코드가 Control::Field 로 배선되지 않음: {controls:?}"
         );
+    }
+
+    #[test]
+    fn test_hwp3_ch15_hidden_comment_pushes_control() {
+        // ch=15(숨은 설명)는 nested_paragraphs를 파싱만 하고 Control로 push하지 않던 버그(#3065) 회귀 테스트.
+        // 페이로드: info_buf(8B, 0으로 채움) + 빈 문단 리스트 종료자(char_count=0, 총 43B).
+        // header_val1(4B) + ch2(2B) + info_buf(8B) + 빈 문단 리스트 종료자(43B).
+        let mut body: Vec<u8> = vec![0u8; 6 + 8];
+        body.extend_from_slice(&[0u8; 43]);
+        let mut cursor = Cursor::new(body.as_slice());
+
+        let mut text_string = String::new();
+        let mut char_offsets = Vec::new();
+        let mut hwp3_char_to_utf16_pos = vec![0u32; 8];
+        let mut controls = Vec::new();
+        let mut ctrl_data_records = Vec::new();
+        let mut scan = Hwp3CharScan {
+            text_string: &mut text_string,
+            char_offsets: &mut char_offsets,
+            hwp3_char_to_utf16_pos: &mut hwp3_char_to_utf16_pos,
+            controls: &mut controls,
+            ctrl_data_records: &mut ctrl_data_records,
+        };
+        let mut char_shapes = Vec::new();
+        let mut para_shapes = Vec::new();
+        let mut border_fills = Vec::new();
+        let mut tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+        let para_info = Hwp3ParaInfo {
+            follow_prev_para_shape: 0,
+            char_count: 4,
+            line_count: 1,
+            include_char_shape: 0,
+            flags: 0,
+            special_char_flags: 0,
+            style_index: 0,
+            rep_char_shape: crate::parser::hwp3::records::Hwp3CharShape::default(),
+            para_shape: None,
+        };
+
+        parse_object_control_char(
+            &mut cursor,
+            &mut char_shapes,
+            &mut para_shapes,
+            &mut border_fills,
+            &mut tab_defs,
+            &mut pic_name_to_id,
+            0,
+            0,
+            0,
+            15,
+            &para_info,
+            0,
+            0,
+            &mut scan,
+        )
+        .expect("ch=15 dispatch should succeed");
+
+        assert_eq!(controls.len(), 1);
+        assert!(matches!(
+            controls[0],
+            crate::model::control::Control::HiddenComment(_)
+        ));
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1942,9 +1942,19 @@ fn parse_simple_control_char(
             utf16_len += 1;
             text_string.push('\u{FFFC}');
             let mut overlap = crate::model::control::CharOverlap::default();
-            // buf[0..2] 또는 buf[2..8]은 문자와 테두리 종류를 포함할 수 있습니다.
-            // 가능한 부분을 매핑하지만, 테스트 없이 정확한 오프셋을 찾기는 까다로우므로
-            // 구조체는 유지하되 완벽하게 채우지 않을 수도 있습니다.
+            // 스펙 §10.17 표 58: buf[0..6] = 겹칠 글자 hchar array[3]
+            // (최대 3자, 남는 부분 0 패딩), buf[6..8] = 닫는 코드(늘 23).
+            // 0 이 아닌 hchar 만 johab 디코딩해 IR 에 보존한다.
+            for k in 0..3usize {
+                let v = (&buf[k * 2..k * 2 + 2])
+                    .read_u16::<LittleEndian>()
+                    .unwrap_or(0);
+                if v != 0 {
+                    overlap
+                        .chars
+                        .push(crate::parser::hwp3::johab::decode_johab(v));
+                }
+            }
             controls.push(crate::model::control::Control::CharOverlap(overlap));
             ctrl_data_records.push(None);
         }
@@ -4712,4 +4722,66 @@ mod tests {
         );
     }
 
+    // 스펙 §10.17 표 58: 글자겹침(ch=23)의 겹칠 글자는 오프셋 2..8 의
+    // hchar array[3] (남는 부분 0 패딩)이다. 파서가 이를 IR CharOverlap.chars
+    // 에 채워야 겹침 문자가 보존된다 (종전: 항상 빈 Vec → 겹칠 글자 전량 유실).
+    #[test]
+    fn hwp3_char_overlap_extracts_overlap_chars() {
+        let mut body = Vec::new();
+        body.push(1u8); // follow_prev_para_shape
+        body.extend_from_slice(&5u16.to_le_bytes()); // char_count: 10바이트 = 5 hchar
+        body.extend_from_slice(&0u16.to_le_bytes()); // line_count
+        body.push(0u8); // include_char_shape
+        body.push(0u8); // flags
+        body.extend_from_slice(&0u32.to_le_bytes()); // special_char_flags
+        body.push(0u8); // style_index
+        body.extend_from_slice(&[0u8; 31]); // rep_char_shape
+        assert_eq!(body.len(), 43);
+
+        body.extend_from_slice(&23u16.to_le_bytes()); // 여는 특수 문자 코드
+        body.extend_from_slice(&0x0041u16.to_le_bytes()); // 겹칠 글자 1: 'A'
+        body.extend_from_slice(&0x0042u16.to_le_bytes()); // 겹칠 글자 2: 'B'
+        body.extend_from_slice(&0u16.to_le_bytes()); // 겹칠 글자 3: 없음 (0 패딩)
+        body.extend_from_slice(&23u16.to_le_bytes()); // 닫는 특수 문자 코드
+
+        // 문단 리스트 종료 (빈 문단, 43바이트)
+        body.push(0u8);
+        body.extend_from_slice(&0u16.to_le_bytes());
+        body.extend_from_slice(&[0u8; 40]);
+
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+
+        let paragraphs = parse_paragraph_list(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            1000,
+            1000,
+        )
+        .expect("글자겹침(ch=23) 컨트롤을 포함한 문단 파싱 실패");
+
+        assert_eq!(paragraphs.len(), 1);
+        let overlap = paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                crate::model::control::Control::CharOverlap(co) => Some(co),
+                _ => None,
+            })
+            .expect("CharOverlap 컨트롤이 생성되지 않음");
+        assert_eq!(
+            overlap.chars,
+            vec!['A', 'B'],
+            "겹칠 글자(스펙 표 58 오프셋 2..8)가 IR 로 추출되지 않음"
+        );
+    }
 }

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -301,6 +301,9 @@ pub(crate) fn convert_char_shape(
     // 렌더러(글자 축소·baseline 이동)가 소비하는 IR 필드가 항상 false 였다.
     cs.superscript = hwp3_cs.is_superscript();
     cs.subscript = hwp3_cs.is_subscript();
+    // attr 0x80(글꼴에 어울리는 빈칸 사용). 접근자 is_font_blank()는 있었으나
+    // 호출부가 없어 IR CharShape.use_font_space가 항상 false로 저장됐다.
+    cs.use_font_space = hwp3_cs.is_font_blank();
     cs
 }
 
@@ -4301,6 +4304,17 @@ mod tests {
             doc.doc_properties.footnote_start_num, 1,
             "각주 시작 번호가 doc_info 에서 매핑돼야 함(미매핑 시 0)"
         );
+    }
+
+    #[test]
+    fn convert_char_shape_maps_font_blank() {
+        // attr 0x80=글꼴에 어울리는 빈칸 사용. 종전엔 매핑이 빠져 항상 false.
+        let hwp3_cs = crate::parser::hwp3::records::Hwp3CharShape {
+            attr: 0x80,
+            ..Default::default()
+        };
+        let cs = convert_char_shape(&hwp3_cs);
+        assert!(cs.use_font_space);
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -300,6 +300,11 @@ pub(crate) fn convert_char_shape(
     cs.ratios = hwp3_cs.ratios;
     cs.spacings = hwp3_cs.spacings;
     cs.text_color = hwp3_color_index_to_color_ref(hwp3_cs.text_color);
+    // [#2958] 글자 음영색(offset 23)도 text_color와 같은 8색 팔레트를 쓰지만
+    // 변환부에서 누락되어 CharShape 기본값(0=검정)이 그대로 남아 있었다.
+    // 렌더러는 0x00FFFFFF(흰색)를 "음영 없음" sentinel로 쓰므로, 여기서
+    // 매핑하지 않으면 음영 없는 문서도 검정 형광펜으로 오판될 수 있다.
+    cs.shade_color = hwp3_color_index_to_color_ref(hwp3_cs.shade_color);
     cs.attr = hwp3_cs.attr as u32;
     cs.italic = hwp3_cs.is_italic();
     cs.bold = hwp3_cs.is_bold();
@@ -4417,6 +4422,17 @@ mod tests {
         };
         let cs = convert_char_shape(&hwp3_cs);
         assert!(cs.use_font_space);
+    }
+
+    #[test]
+    fn task2958_convert_char_shape_preserves_shade_color() {
+        let hwp3_cs = crate::parser::hwp3::records::Hwp3CharShape {
+            shade_color: 1,
+            ..Default::default()
+        };
+        let cs = convert_char_shape(&hwp3_cs);
+
+        assert_eq!(cs.shade_color, 0x00FF0000);
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -82,6 +82,19 @@ fn hwp3_hide_empty_line(doc_info: &Hwp3DocInfo) -> bool {
     doc_info.hide_empty_line != 0
 }
 
+/// doc_info.compressed(압축 여부)를 FileHeader.compressed 및 raw_data 플래그 비트(0x01)에 반영한다.
+fn apply_hwp3_compressed_flag(
+    doc_info_compressed: u8,
+    header: &mut crate::model::document::FileHeader,
+) {
+    if doc_info_compressed != 0 {
+        header.compressed = true;
+        if let Some(raw) = header.raw_data.as_mut() {
+            raw[36] |= 0x01;
+        }
+    }
+}
+
 fn hwp3_page_border_fill(
     doc_info: &Hwp3DocInfo,
     border_fill_id: u16,
@@ -3007,6 +3020,10 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     // HWP5/HWPX는 각자의 헤더에서 이 값을 채우지만 HWP3는 raw_data를 항상
     // 비암호(flags=0)로 하드코딩해 doc.header.encrypted가 실제 값과 무관하게 false였다.
     apply_hwp3_encrypted_flag(doc_info.encrypted, &mut doc.header);
+    // doc_info.compressed(압축 여부)를 FileHeader.compressed 및 raw_data 플래그 비트(0x01)에
+    // 반영한다. 본문 압축 해제(아래 4번)에는 doc_info.compressed를 쓰지만 종전엔 헤더 raw_data를
+    // 항상 flags=0(비압축)으로 하드코딩해 doc.header.compressed가 실제 값과 무관하게 false였다.
+    apply_hwp3_compressed_flag(doc_info.compressed, &mut doc.header);
 
     // 2. 문서 요약 파싱 (1008 바이트)
     let doc_summary = Hwp3DocSummary::read(&mut cursor)?;
@@ -4080,6 +4097,19 @@ mod tests {
             .borders
             .iter()
             .all(|b| b.line_type == crate::model::style::BorderLineType::Solid));
+    }
+
+    #[test]
+    fn hwp3_maps_compressed_flag() {
+        // doc_info.compressed != 0 이면 FileHeader.compressed 와 raw_data 플래그 비트가
+        // 반영돼야 한다. 종전엔 배선이 없어 항상 false 였다.
+        let mut header = crate::model::document::FileHeader {
+            raw_data: Some(vec![0u8; crate::parser::header::FILE_HEADER_SIZE]),
+            ..Default::default()
+        };
+        apply_hwp3_compressed_flag(1, &mut header);
+        assert!(header.compressed);
+        assert_eq!(header.raw_data.unwrap()[36] & 0x01, 0x01);
     }
 
     #[test]

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -1938,7 +1938,10 @@ fn parse_simple_control_char(
             char_offsets.push(utf16_len);
             utf16_len += 1;
             text_string.push('\u{FFFC}');
-            let name_buf = &buf[2..22];
+            // 스펙 §10.16 표 57: 필드 이름은 파일 오프셋 2..22 (= 추가로 읽은
+            // buf 의 [0..20]). 종전 buf[2..22] 는 이름 앞 2바이트를 유실하고
+            // 닫는 코드(0x0016)를 이름에 혼입시켰다.
+            let name_buf = &buf[0..20];
             let name = crate::parser::hwp3::encoding::decode_hwp3_string(name_buf)
                 .trim_end_matches('\0')
                 .to_string();
@@ -4520,4 +4523,78 @@ mod tests {
             paragraphs[0].text
         );
     }
+
+    /// 메일머지 표시(ch=22) 문단 바디를 만드는 헬퍼.
+    /// 스펙 §10.16 표 57: open(2) + kchar array[20] 필드 이름 + close(2) = 24바이트.
+    fn build_mail_merge_paragraph(name: &[u8]) -> Vec<u8> {
+        let mut body = Vec::new();
+        body.push(1u8); // follow_prev_para_shape (문단 모양 생략)
+        body.extend_from_slice(&12u16.to_le_bytes()); // char_count: 24바이트 = 12 hchar
+        body.extend_from_slice(&0u16.to_le_bytes()); // line_count = 0
+        body.push(0u8); // include_char_shape
+        body.push(0u8); // flags
+        body.extend_from_slice(&0u32.to_le_bytes()); // special_char_flags
+        body.push(0u8); // style_index
+        body.extend_from_slice(&[0u8; 31]); // rep_char_shape
+        assert_eq!(body.len(), 43);
+
+        body.extend_from_slice(&22u16.to_le_bytes()); // 여는 특수 문자 코드
+        let mut name_buf = [0u8; 20];
+        name_buf[..name.len()].copy_from_slice(name);
+        body.extend_from_slice(&name_buf); // 필드 이름 (파일 오프셋 2..22)
+        body.extend_from_slice(&22u16.to_le_bytes()); // 닫는 특수 문자 코드
+
+        // 문단 리스트 종료 (빈 문단, 43바이트)
+        body.push(0u8);
+        body.extend_from_slice(&0u16.to_le_bytes());
+        body.extend_from_slice(&[0u8; 40]);
+        body
+    }
+
+    // 스펙 §10.16 표 57: 메일머지 표시(ch=22)의 필드 이름은 여는 코드 바로 뒤
+    // (파일 오프셋 2..22, 즉 추가로 읽은 22바이트 buf 의 [0..20])에 있다.
+    // buf[2..22] 로 읽으면 이름 앞 2바이트가 유실되고 닫는 코드(0x0016)가
+    // 이름에 혼입된다.
+    #[test]
+    fn hwp3_mail_merge_field_name_starts_at_offset_zero() {
+        let body = build_mail_merge_paragraph(b"MERGEFIELD");
+        let mut body_cursor = Cursor::new(body.as_slice());
+        let mut doc_char_shapes = Vec::new();
+        let mut doc_para_shapes = Vec::new();
+        let mut doc_border_fills = Vec::new();
+        let mut doc_tab_defs = Vec::new();
+        let mut pic_name_to_id = std::collections::HashMap::new();
+
+        let paragraphs = parse_paragraph_list(
+            &mut body_cursor,
+            &mut doc_char_shapes,
+            &mut doc_para_shapes,
+            &mut doc_border_fills,
+            &mut doc_tab_defs,
+            &mut pic_name_to_id,
+            0,
+            1000,
+            1000,
+        )
+        .expect("메일머지(ch=22) 컨트롤을 포함한 문단 파싱 실패");
+
+        assert_eq!(paragraphs.len(), 1);
+        let field = paragraphs[0]
+            .controls
+            .iter()
+            .find_map(|c| match c {
+                crate::model::control::Control::Field(f) => Some(f),
+                _ => None,
+            })
+            .expect("메일머지 Field 컨트롤이 생성되지 않음");
+        assert_eq!(
+            field.field_type,
+            crate::model::control::FieldType::MailMerge
+        );
+        assert_eq!(
+            field.command, "MERGEFIELD",
+            "필드 이름이 오프셋 +2 로 어긋나게 읽힘 (앞 2바이트 유실)"
+        );
+    }
+
 }


### PR DESCRIPTION
kevin9327 님의 HWP3 파서 축 6건을 메인테이너가 재실증 후 통합한다. 충돌분 4건을 같은 축에 흡수했다.

## 채택 6건

| PR | 결함 |
|---|---|
| #3078 (`Closes #3065`) | 숨은 설명(ch=15)이 nested_paragraphs 를 파싱만 하고 Control 로 push 하지 않음 |
| #3079 | doc_info.compressed(압축 여부)가 FileHeader 에 미배선 — raw_data 플래그 항상 0 |
| #3098 | CharShape "글꼴에 어울리는 빈칸"(attr 0x80) 매핑 누락 |
| #3104 (`Closes #2958`) | 글자 음영색(shade_color) IR 변환 누락 |
| #3165 (`Closes #3147`) | 메일머지 표시(ch=22) 필드 이름을 buf[2..22] 로 읽어 앞 2바이트 유실·닫는 코드 혼입 (스펙 §10.16 표 57) |
| #3166 (`Closes #3148`) | 글자겹침(ch=23) 겹칠 글자 hchar array[3](스펙 §10.17 표 58 오프셋 2..8) 추출 누락 — 전량 유실 |

## 충돌 흡수

4건 전부 어제·오늘 merge 된 hwp3 형제들과 같은 테스트 모듈 자리를 두고 겹친 **테스트 병치** — ch5/ch15, encrypted/compressed, use_font_space/shade_color, 메일머지/글자겹침 각 쌍을 완전한 테스트로 복원해 모두 유지했다. 소스 로직 충돌은 없었다.

## 검증

- **`parser/hwp3/` 밖 `.rs` 변경 0건** — HWP3 아키텍처 경계 준수
- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 신규 회귀 테스트 전건 표적 통과

Co-authored-by 로 원 커밋 provenance 를 보존한다.
