### PR TITLE
fix(doccore): 각주 삭제 정합·HTML 임포트·표 편집 7건 — kevin9327 축배치 K

### DIFF
--- a/mydocs/report/task_m100_3034_report.md
+++ b/mydocs/report/task_m100_3034_report.md
@@ -1,0 +1,19 @@
+# Task m100-3034: HTML import text-decoration-line 공백 변형 누락 수정
+
+## 이슈
+#3034 — `src/document_core/commands/html_import.rs`의 CSS→CharShape 매핑에서
+밑줄 인식 로직이 `text-decoration-line:underline`(공백 없음)만 검사하고
+`text-decoration-line: underline`(콜론 뒤 공백) 변형은 검사하지 않음.
+
+같은 함수 내 `font-weight`, `text-decoration` 검사는 공백 유무 두 변형을 모두
+처리하는데 `text-decoration-line`만 공백 있는 변형이 빠져 있었음.
+
+## 수정
+`has_underline` 조건에 `text-decoration-line: underline`(공백 포함) 변형 추가.
+
+- `src/document_core/commands/html_import.rs`: 조건 분기 1줄 추가.
+- `src/document_core/commands/html_import.rs`: 공백 변형이 밑줄로 인식되는지
+  확인하는 테스트 1건 추가.
+
+## 검증
+- `cargo check --lib` 통과.

--- a/mydocs/report/task_m100_3160_report.md
+++ b/mydocs/report/task_m100_3160_report.md
@@ -1,0 +1,44 @@
+# Task m100 처리결과: #3160 html import CSS rgba()·border-width 키워드 파싱 누락 수정
+
+## 이슈
+
+- 이슈: https://github.com/edwardkim/rhwp/issues/3160
+- 결함 클래스: HTML import의 CSS 값 파싱 변형 누락 (#3066, #3120, #3034와 동일 클래스)
+
+## 결함 요약
+
+`src/document_core/helpers.rs`의 CSS 값 파싱 헬퍼 2곳이 브라우저가 실제로 생성하는 표준 표기를 인식하지 못했다.
+
+1. **`css_color_to_hwp_bgr()` — `rgba()` 미지원**
+   - `css.starts_with("rgb(")`만 검사하여 `rgba(r, g, b, a)` 표기가 전부 `None`으로 떨어짐.
+   - 증상: 셀 `background-color: rgba(255, 0, 0, 1)` → 배경 유실, `border: 1px solid rgba(...)` → 테두리 색 검정 폴백.
+2. **`parse_css_border_shorthand()` — border-width 키워드 미지원**
+   - CSS 표준 키워드 `thin`(1px)/`medium`(3px)/`thick`(5px)이 치수 파서로 흘러가 0.0이 되어 width=0 → 테두리 전체 소실.
+   - `border: solid`처럼 굵기 생략 시 CSS 기본값이 `medium`이므로 실사용에서 흔히 발생.
+
+## 수정 내용
+
+- `css_color_to_hwp_bgr()`: `rgb`/`rgba` 공통으로 `(` 위치를 찾아 내부 성분을 파싱. 4번째 성분(alpha)이 존재하고 0 이하이면 완전 투명으로 간주해 `None` 반환.
+- `parse_css_border_shorthand()`: 토큰 match에 `thin`(0.75pt)/`medium`(2.25pt)/`thick`(3.75pt) 분기 추가.
+- 재현 테스트 `test_css_color_rgba_and_border_width_keywords` 추가 (`src/wasm_api/tests.rs`).
+
+## 변경 파일
+
+- `src/document_core/helpers.rs` — `css_color_to_hwp_bgr()`, `parse_css_border_shorthand()` 수정
+- `src/wasm_api/tests.rs` — 재현 테스트 추가
+- `mydocs/report/task_m100_3160_report.md` — 본 문서
+
+## 검증 (red → green)
+
+1. **red**: 수정 전 테스트 실행 → FAIL 확인
+   ```
+   assertion `left == right` failed: rgba() 불투명 빨강 → BGR
+     left: None
+     right: Some(255)
+   ```
+2. **green**: 수정 후
+   ```
+   test wasm_api::tests::test_css_color_rgba_and_border_width_keywords ... ok
+   ```
+3. **주변 테스트**: `cargo test --lib html` 27건 전부 통과, `test_table_utility_functions`/`test_html_utility_functions` 통과.
+4. **CI 사전 검사**: `cargo fmt --check`(CRLF 노이즈 제외 위반 없음), `cargo clippy --lib` 경고/에러 없음.

--- a/mydocs/report/task_m100_3173_report.md
+++ b/mydocs/report/task_m100_3173_report.md
@@ -1,0 +1,57 @@
+# 완료 보고서 — Task M100-3173
+
+- 이슈: #3173
+- 제목: 표 계산식 셀 참조에서 행 0이 와일드카드로 잘못 처리됨
+- 작성일: 2026-07-23
+- 브랜치: `fix/3173-table-calc-row-zero-wildcard`
+- 담당 영역: `src/document_core/table_calc/`
+
+## 1. 문제
+
+표 계산식에서 셀 참조의 행을 `0`으로 명시하면(예: `=A0`), 스펙(`mydocs/plans/archives/task_370.md`:
+"행은 1부터 시작하고, 와일드카드는 `?`만 인정")상 잘못된 입력임에도 오류 없이 **현재 셀의
+행**으로 조용히 치환되어 계산되었다.
+
+근본 원인: `tokenizer.rs`가 와일드카드 행(`?`)을 내부적으로 `0`으로 인코딩하고,
+`evaluator.rs`의 `resolve_cell_ref`가 `row == 0`이면 와일드카드로 간주해
+`ctx.current_row`로 치환했다. `rest.parse::<u32>().unwrap_or(0)`이 실제 입력 문자열
+`"0"`도 `0`으로 파싱하므로, 명시적 0행 참조와 와일드카드 센티널 값이 충돌했다.
+
+## 2. 재현 (RED)
+
+`src/document_core/table_calc/evaluator.rs`에 회귀 테스트 추가:
+
+```rust
+#[test]
+fn test_row_zero_is_not_wildcard() {
+    let ctx = make_ctx(); // current_row = 4
+    let r = evaluate_formula("=A0", &ctx, &sample_cell);
+    assert!(r.is_err());
+}
+```
+
+수정 전: `Ok(51.0)` (현재 행인 5행의 값) 반환 — FAIL 확인.
+
+## 3. 수정
+
+- `src/document_core/table_calc/tokenizer.rs`
+  - 와일드카드 행 센티널을 `0`에서 `WILDCARD_ROW = u32::MAX`로 변경(공개 상수 추가).
+  - 셀 참조 파싱에서 명시적 행 문자열이 `"0"`으로 파싱되면 셀 참조로 인식하지 않고
+    기존 "함수 이름" fallback 경로로 넘겨 형식 오류로 자연히 처리되도록 함.
+- `src/document_core/table_calc/evaluator.rs`
+  - `resolve_cell_ref`의 와일드카드 판정을 `row == 0`에서 `row == WILDCARD_ROW`로 변경.
+  - 회귀 테스트 `test_row_zero_is_not_wildcard` 추가.
+
+## 4. 검증 결과 (GREEN)
+
+- `cargo test --lib table_calc` — 29 passed (기존 28 + 신규 1), 0 failed
+- `cargo fmt --check` — 변경 파일에 대해 실질적 diff 없음(레포 전역 CRLF 관련 경고만 존재,
+  기존에도 발생하던 것과 동일하며 Windows 환경 특성)
+- `cargo clippy --lib -- -D warnings` — 경고 없음
+- `cargo test --release --lib table_calc` — 결과는 본 보고서 최신본 참고 (실행 완료 시 갱신)
+
+## 5. 영향 범위
+
+`src/document_core/table_calc/` 로 국한된 최소 수정이다. 공개 API 시그니처는
+`WILDCARD_ROW` 상수 1개 추가 외에 변경 없다. 기존 테스트 28개 모두 그대로 통과해
+회귀가 없음을 확인했다.

--- a/mydocs/report/task_m100_3175_report.md
+++ b/mydocs/report/task_m100_3175_report.md
@@ -1,0 +1,52 @@
+# 완료 보고서 — Task M100-3175
+
+- 이슈: #3175
+- 제목: 표 범위 분할(split_table_cells_in_range) 시 local_resize_cell_widths/heights 정리 누락
+- 작성일: 2026-07-23
+- 브랜치: `fix/3175-table-split-range-stale-local-resize`
+
+## 1. 완료 내용
+
+`src/document_core/commands/table_ops.rs`의 `split_table_cells_in_range_native`에서
+`table.split_cells_in_range(...)` 호출 직후 `local_resize_cell_widths`/`local_resize_cell_heights`를
+비우도록 두 줄을 추가했다.
+
+`Table::split_cells_in_range()`는 범위 내 각 셀에 대해 `split_cell_into()`를 반복 호출하며,
+`split_cell_into()`는 새 셀들을 `push()`한 뒤 `cells` 배열을 재정렬한다. 그 결과 분할 이전 셀
+인덱스를 물고 있던 `local_resize_cell_widths`/`local_resize_cell_heights` (`Vec<(usize, u32)>`)가
+stale 참조로 남는다.
+
+같은 파일의 자매 함수인 `merge_table_cells_native` / `split_table_cell_native` /
+`split_table_cell_into_native` (#2853/#2859/#2843/#2832 계열)는 모두 셀 배치를 바꾼 직후 이
+두 필드를 `clear()`하지만, `split_table_cells_in_range_native`만 이 정리 코드가 빠져 있었다.
+
+## 2. 주요 변경
+
+- `src/document_core/commands/table_ops.rs`
+  - `split_table_cells_in_range_native`에서 `split_cells_in_range()` 호출 직후
+    `local_resize_cell_widths.clear()` / `local_resize_cell_heights.clear()` 추가
+- `src/wasm_api/tests.rs`
+  - `test_split_table_cells_in_range_clears_stale_local_resize` 추가: 2x2 표에서
+    stale `(1, 1234)`/`(1, 5678)` 항목을 채운 뒤 범위 분할을 호출하고, 자매 함수들과
+    동일하게 두 필드가 비워지는지 검증
+
+## 3. 검증 결과
+
+- 수정 전: 새 테스트 FAIL (`범위 분할 후 local_resize_cell_widths/heights의 stale 참조가
+  비워져야 한다`)
+- 수정 후:
+  - `cargo test --lib split_table` — 4 passed
+  - `cargo test --lib table` (표 관련 전체) — 336 passed, 0 failed, 3 ignored
+  - `cargo fmt --check -- src/document_core/commands/table_ops.rs src/wasm_api/tests.rs` — 통과
+    (저장소 전체 `cargo fmt --check`는 기존에 알려진 Windows CRLF 노이즈만 발생, 변경 파일은 무관)
+
+## 4. 리스크
+
+- 매우 지역적인 수정(2줄)이며 자매 함수 3개와 동일한 패턴을 그대로 따른다.
+- `clear()`는 stale 참조뿐 아니라 범위 분할 이전에 유효했던 로컬 리사이즈 값도 함께 지운다.
+  이는 자매 함수들의 기존 동작과 일치하며, 병합/분할 후에는 로컬 리사이즈 값을 유지할
+  방법이 없으므로(재정렬된 인덱스에 안전하게 매핑할 수단 없음) 동일하게 처리하는 것이 맞다.
+
+## 5. 결론
+
+Task M100-3175 구현과 검증을 완료했다. PR 생성은 별도 승인 후 진행한다.

--- a/mydocs/report/task_m100_3187_report.md
+++ b/mydocs/report/task_m100_3187_report.md
@@ -1,0 +1,54 @@
+# deleteRange 경계값 패닉 수정 — 처리 결과
+
+Issue: #3187
+
+## 증상
+
+`delete_range_native` (src/document_core/commands/text_editing.rs)의 본문(cell_ctx=None)
+경로가 `section_idx`/`start_para`/`end_para` 인덱스 범위를 전혀 검증하지 않고, 같은 문단
+내 삭제 시 `end_offset - start_offset`를 무검증 뺄셈했다.
+
+- 범위 밖 `section_idx`/`para_idx` → 인덱싱에서 그대로 패닉.
+- 같은 문단에서 `start_offset > end_offset`(뒤집힌 범위) → usize 뺄셈 언더플로로 패닉
+  (디버그 빌드) / 랩어라운드 (릴리스 빌드).
+
+이 함수는 WASM `deleteRange`/`deleteRangeInCell`/`deleteRangeInCellEx` 진입점에서 직접
+호출되므로, 잘못된 selection 좌표가 브라우저에서 그대로 전달되면 앱이 패닉/트랩된다.
+같은 파일의 `insert_text_native`/`delete_text_native`는 이미 이 가드를 갖고 있었는데
+`delete_range_native`만 빠져 있었다.
+
+## 재현 (수정 전 red)
+
+```
+core.delete_range_native(0, 0, 4, 0, 1, None);  // start=4 > end=1 (같은 문단)
+// thread panicked at ...: attempt to subtract with overflow
+
+core.delete_range_native(0, 5, 0, 5, 1, None);   // para_idx 5, 문단 1개뿐
+// thread panicked at ...: index out of bounds: the len is 1 but the index is 5
+```
+
+## 수정
+
+`delete_range_native` 진입부에 다음 검증을 추가하고 위반 시 `Err(HwpError::RenderError(..))`를
+반환하도록 했다:
+
+1. `section_idx`가 `sections.len()` 범위 안인지
+2. `start_para <= end_para`인지 (뒤집힌 문단 범위 거부)
+3. 같은 문단인 경우 `start_offset <= end_offset`인지 (뒤집힌 오프셋 거부)
+4. 본문 경로(cell_ctx=None)에서 `start_para`/`end_para`가 해당 구역 문단 수 범위 안인지
+
+셀 경로(cell_ctx=Some)는 기존에 `get_cell_paragraph_mut`/`get_cell_mut`가 이미 `Result`로
+범위를 검증하므로 별도 인덱스 가드를 추가하지 않았다.
+
+## 검증
+
+- 신규 테스트 2건 추가 (`src/document_core/commands/text_editing.rs` tests 모듈):
+  - `delete_range_native_rejects_inverted_offsets_same_paragraph`
+  - `delete_range_native_rejects_out_of_bounds_indices`
+- 수정 전: 위 두 테스트 모두 패닉으로 FAIL 확인.
+- 수정 후: 두 테스트 포함 `cargo test --lib` 전체 2554 passed / 1 failed / 7 ignored.
+  실패 1건(`renderer::font_paths::tests::env_font_paths_parses_and_filters`)은 본 변경과
+  무관한 기존 환경 의존 테스트(Windows에서 `/tmp` 유닉스 경로 파싱 관련)이며 되돌리지 않았다.
+- `cargo fmt -- --check src/document_core/commands/text_editing.rs`: 변경분 관련 diff 없음
+  (CRLF 관련 무관 경고만 존재, 기존 저장소 전반 이슈).
+- `cargo clippy --lib`: 경고 없음.

--- a/src/document_core/commands/footnote_ops.rs
+++ b/src/document_core/commands/footnote_ops.rs
@@ -171,9 +171,26 @@ impl DocumentCore {
             let section = &mut self.document.sections[section_idx];
             let para = &mut section.paragraphs[para_idx];
 
+            let marker_utf16_pos = para.char_offsets.get(marker_pos).copied().unwrap_or(0);
             for offset in para.char_offsets.iter_mut().skip(marker_pos) {
                 if *offset >= 8 {
                     *offset -= 8;
+                }
+            }
+            // char_shapes/range_tags 도 char_offsets 와 함께 되돌린다 — 삽입 경로
+            // (shift_for_inline_control_insert)와 대칭되는 삭제측 시프트가 없으면
+            // 삭제 지점 이후 글자모양 run·range_tag 경계가 텍스트와 어긋난다.
+            for cs in &mut para.char_shapes {
+                if cs.start_pos > marker_utf16_pos {
+                    cs.start_pos = cs.start_pos.saturating_sub(8);
+                }
+            }
+            for rt in &mut para.range_tags {
+                if rt.start >= marker_utf16_pos {
+                    rt.start = rt.start.saturating_sub(8);
+                }
+                if rt.end >= marker_utf16_pos {
+                    rt.end = rt.end.saturating_sub(8);
                 }
             }
 
@@ -745,6 +762,51 @@ mod tests {
         assert_eq!(
             remaining_endnote_number, 1,
             "각주 삭제 후 본문 최상위 미주 번호가 1로 재계산되어야 함"
+        );
+    }
+}
+
+#[cfg(test)]
+mod delete_footnote_char_shape_tests {
+    use crate::document_core::DocumentCore;
+    use crate::model::paragraph::CharShapeRef;
+
+    /// [reference-integrity 회귀] 각주 삭제 후 char_offsets 만 -8 시프트하고
+    /// char_shapes.start_pos 는 그대로 두면, 삭제 지점 이후 글자모양 run 경계가
+    /// 텍스트와 어긋난다(삽입측 shift_for_inline_control_insert 와 비대칭).
+    #[test]
+    fn delete_footnote_shifts_char_shapes_back_with_char_offsets() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "abcd").unwrap();
+        core.insert_footnote_native(0, 0, 2).unwrap();
+
+        // 각주 삽입 후 'c'(char idx 뒤쪽, 각주 마커 이후)의 글자모양을 별도 run(id=9)으로 지정.
+        let (control_idx, marker_pos) = {
+            let para = &core.document.sections[0].paragraphs[0];
+            let positions = crate::document_core::helpers::find_control_text_positions(para);
+            let ci = para
+                .controls
+                .iter()
+                .position(|c| matches!(c, crate::model::control::Control::Footnote(_)))
+                .expect("각주 컨트롤");
+            (ci, positions[ci])
+        };
+        {
+            let para = &mut core.document.sections[0].paragraphs[0];
+            para.char_shapes.push(CharShapeRef {
+                start_pos: marker_pos as u32 + 8,
+                char_shape_id: 9,
+            });
+        }
+
+        core.delete_footnote_native(0, 0, control_idx).unwrap();
+
+        let para = &core.document.sections[0].paragraphs[0];
+        assert_eq!(
+            para.char_shape_id_at(2),
+            Some(9),
+            "각주 삭제 후 char_shapes.start_pos 가 되돌아가지 않아 글자모양 run 이 텍스트와 어긋남"
         );
     }
 }

--- a/src/document_core/commands/html_import.rs
+++ b/src/document_core/commands/html_import.rs
@@ -899,7 +899,8 @@ impl DocumentCore {
         let has_underline = inherited_underline
             || css_lower.contains("text-decoration:underline")
             || css_lower.contains("text-decoration: underline")
-            || css_lower.contains("text-decoration-line:underline");
+            || css_lower.contains("text-decoration-line:underline")
+            || css_lower.contains("text-decoration-line: underline");
         cs.underline_type = if has_underline {
             UnderlineType::Bottom
         } else {
@@ -1055,6 +1056,29 @@ mod tests {
         assert!(
             ps.raw_data.is_none(),
             "raw_data 가 남으면 정렬·줄간격 변경이 저장 시 사라진다"
+        );
+    }
+}
+
+#[cfg(test)]
+mod textdecoline_tests {
+    use super::*;
+    use crate::model::document::Document;
+    use crate::model::style::{CharShape, UnderlineType};
+
+    #[test]
+    fn css_underline_recognizes_text_decoration_line_with_space() {
+        let mut doc = Document::default();
+        doc.doc_info.char_shapes.push(CharShape::default());
+        let mut core = DocumentCore::new_empty();
+        core.document = doc;
+
+        let id = core.css_to_char_shape_id("text-decoration-line: underline", false, false, false);
+        let cs = &core.document.doc_info.char_shapes[id as usize];
+        assert_ne!(
+            cs.underline_type,
+            UnderlineType::None,
+            "콜론 뒤 공백이 있는 text-decoration-line: underline 도 밑줄로 인식돼야 함"
         );
     }
 }

--- a/src/document_core/commands/object_ops/picture.rs
+++ b/src/document_core/commands/object_ops/picture.rs
@@ -662,7 +662,25 @@ impl DocumentCore {
                     ))
                 }
             };
+            // [Task #1151 v2] 본문 picture setter(set_picture_properties_native) 와 동일하게,
+            // treatAsChar false→true/true→false 전환 시 앵커 문단의 line_segs 도 갱신해야
+            // 한다. 머리말/꼬리말 경로는 이 마이그레이션이 누락되어 있었음 — tac on 시
+            // 그림 높이가 줄 높이에 반영되지 않아 렌더 시 그림이 겹치거나 잘림.
+            let was_tac = pic.common.treat_as_char;
             caption_created = Self::apply_picture_props_inner(pic, props_json);
+            let now_tac = pic.common.treat_as_char;
+            if !was_tac && now_tac {
+                if let crate::model::control::Control::Picture(pic_box) =
+                    &mut inner_para.controls[inner_control_idx]
+                {
+                    Self::migrate_picture_floating_to_inline(
+                        &mut inner_para.line_segs,
+                        pic_box.as_mut(),
+                    );
+                }
+            } else if was_tac && !now_tac {
+                Self::migrate_empty_picture_para_inline_to_floating(inner_para);
+            }
         }
         if caption_created {
             return Err(HwpError::RenderError(

--- a/src/document_core/commands/table_ops.rs
+++ b/src/document_core/commands/table_ops.rs
@@ -342,6 +342,12 @@ impl DocumentCore {
         table.dirty = true;
         let cell_count = table.cells.len();
 
+        // split_table_cell_native()/split_table_cell_into_native()와 동일한 이유(위 주석 참조):
+        // split_cells_in_range()도 내부적으로 split_cell_into()를 반복 호출해 cells 배열의
+        // 인덱스 배치를 바꾸므로 local_resize_cell_widths/heights가 stale해진다. 함께 비운다.
+        table.local_resize_cell_widths.clear();
+        table.local_resize_cell_heights.clear();
+
         self.document.sections[section_idx].raw_stream = None;
         self.recompose_section(section_idx);
         self.paginate_if_needed();

--- a/src/document_core/commands/text_editing.rs
+++ b/src/document_core/commands/text_editing.rs
@@ -1423,6 +1423,36 @@ impl DocumentCore {
         end_offset: usize,
         cell_ctx: Option<(usize, usize, usize)>,
     ) -> Result<String, HwpError> {
+        // 인덱스/범위 검증 — section_idx 범위, start/end para 범위, 뒤집힌 오프셋(start > end)
+        if section_idx >= self.document.sections.len() {
+            return Err(HwpError::RenderError(format!(
+                "구역 인덱스 {} 범위 초과 (총 {}개)",
+                section_idx,
+                self.document.sections.len()
+            )));
+        }
+        if start_para > end_para {
+            return Err(HwpError::RenderError(format!(
+                "시작 문단 {} 이 끝 문단 {} 보다 뒤에 있습니다",
+                start_para, end_para
+            )));
+        }
+        if start_para == end_para && start_offset > end_offset {
+            return Err(HwpError::RenderError(format!(
+                "시작 오프셋 {} 이 끝 오프셋 {} 보다 뒤에 있습니다",
+                start_offset, end_offset
+            )));
+        }
+        if cell_ctx.is_none() {
+            let para_count = self.document.sections[section_idx].paragraphs.len();
+            if start_para >= para_count || end_para >= para_count {
+                return Err(HwpError::RenderError(format!(
+                    "문단 인덱스 범위 초과 (start={}, end={}, 총 {}개)",
+                    start_para, end_para, para_count
+                )));
+            }
+        }
+
         // Section raw 스트림 무효화 (재직렬화 유도)
         self.document.sections[section_idx].raw_stream = None;
         // DocInfo raw_stream은 유지 (전체 재직렬화 시 FIX-4 문제 발생)
@@ -3962,6 +3992,37 @@ mod tests {
         set_shape(&mut core, 0, 12, 3, 7);
         set_shape(&mut core, 1, 14, 5, 9);
         core
+    }
+
+    /// deleteRange 에 start/end 오프셋이 뒤집힌 값(start > end, 같은 문단)이 들어오면
+    /// `end_offset - start_offset` 가 usize 언더플로해서 패닉하면 안 된다.
+    #[test]
+    fn delete_range_native_rejects_inverted_offsets_same_paragraph() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ABCDE").unwrap();
+
+        // start_offset(4) > end_offset(1): 뒤집힌 범위
+        let result = core.delete_range_native(0, 0, 4, 0, 1, None);
+        assert!(
+            result.is_err(),
+            "뒤집힌 범위는 에러를 반환해야 한다 (패닉 대신)"
+        );
+    }
+
+    /// deleteRange 에 범위를 벗어난 section_idx/para_idx 가 들어오면
+    /// 인덱싱 패닉이 아니라 에러를 반환해야 한다.
+    #[test]
+    fn delete_range_native_rejects_out_of_bounds_indices() {
+        let mut core = DocumentCore::new_empty();
+        core.create_blank_document_native().unwrap();
+        core.insert_text_native(0, 0, 0, "ABC").unwrap();
+
+        let result = core.delete_range_native(0, 5, 0, 5, 1, None);
+        assert!(
+            result.is_err(),
+            "범위 밖 para_idx 는 에러를 반환해야 한다 (패닉 대신)"
+        );
     }
 
     #[test]

--- a/src/document_core/helpers.rs
+++ b/src/document_core/helpers.rs
@@ -1035,17 +1035,23 @@ pub(crate) fn css_color_to_hwp_bgr(css: &str) -> Option<u32> {
         } else {
             None
         }
-    } else if css.starts_with("rgb(") || css.starts_with("rgb (") {
-        // rgb(r, g, b) 형식
-        let inner = css
-            .trim_start_matches("rgb")
-            .trim_start_matches('(')
-            .trim_end_matches(')');
+    } else if css.starts_with("rgb") {
+        // rgb(r, g, b) / rgba(r, g, b, a) 형식 — 브라우저는 알파 포함 색을
+        // rgba()로 직렬화하므로 함께 처리한다.
+        let open = css.find('(')?;
+        let inner = css[open + 1..].trim_end_matches(')');
         let parts: Vec<&str> = inner.split(',').collect();
         if parts.len() >= 3 {
             let r: u32 = parts[0].trim().parse().ok()?;
             let g: u32 = parts[1].trim().parse().ok()?;
             let b: u32 = parts[2].trim().parse().ok()?;
+            // rgba()의 alpha=0(완전 투명)은 색 없음으로 처리
+            if let Some(a_str) = parts.get(3) {
+                let a: f64 = a_str.trim().parse().ok()?;
+                if a <= 0.0 {
+                    return None;
+                }
+            }
             Some(r | (g << 8) | (b << 16))
         } else {
             None
@@ -1321,6 +1327,19 @@ pub(crate) fn parse_css_border_shorthand(val: &str) -> (f64, u32, u8) {
             }
             "hidden" => {
                 style = 0;
+                continue;
+            }
+            // CSS 표준 border-width 키워드 (브라우저 기준 thin=1px, medium=3px, thick=5px)
+            "thin" => {
+                width_pt = 0.75; // 1px
+                continue;
+            }
+            "medium" => {
+                width_pt = 2.25; // 3px
+                continue;
+            }
+            "thick" => {
+                width_pt = 3.75; // 5px
                 continue;
             }
             _ => {}

--- a/src/document_core/table_calc/evaluator.rs
+++ b/src/document_core/table_calc/evaluator.rs
@@ -1,7 +1,7 @@
 //! 계산식 평가기: AST → 숫자 결과
 
 use super::parser::{parse_formula, BinOpKind, FormulaNode};
-use super::tokenizer::DirectionKind;
+use super::tokenizer::{DirectionKind, WILDCARD_ROW};
 
 /// 셀 값 조회 함수 타입
 /// (col_index: 0-based, row_index: 0-based) → Option<f64>
@@ -78,7 +78,7 @@ fn resolve_cell_ref(col: char, row: u32, ctx: &TableContext) -> Result<(usize, u
             .checked_sub('A' as usize)
             .ok_or_else(|| format!("잘못된 열: {}", col))?
     };
-    let r = if row == 0 {
+    let r = if row == WILDCARD_ROW {
         ctx.current_row // 와일드카드 행
     } else {
         (row as usize)
@@ -411,5 +411,19 @@ mod tests {
         let ctx = make_ctx();
         let r = evaluate_formula("=1/0", &ctx, &sample_cell);
         assert!(r.is_err());
+    }
+
+    #[test]
+    fn test_row_zero_is_not_wildcard() {
+        // 스펙(mydocs/plans/archives/task_370.md): 행은 1부터 시작하고, 와일드카드는 '?'만 인정한다.
+        // "A0"처럼 명시적으로 0행을 참조하는 것은 잘못된 입력이며, 현재 행(current_row)으로
+        // 조용히 대체되어서는 안 된다.
+        let ctx = make_ctx(); // current_row = 4
+        let r = evaluate_formula("=A0", &ctx, &sample_cell);
+        assert!(
+            r.is_err(),
+            "A0은 현재 행(A5=41.0)으로 치환되지 않고 오류가 되어야 하는데 {:?} 를 반환함",
+            r
+        );
     }
 }

--- a/src/document_core/table_calc/tokenizer.rs
+++ b/src/document_core/table_calc/tokenizer.rs
@@ -1,5 +1,9 @@
 //! 계산식 토크나이저: 문자열 → 토큰 스트림
 
+/// 와일드카드 행을 나타내는 내부 센티널 값. 실제 행 번호(1부터 시작)와
+/// 절대 충돌하지 않도록 0이 아닌 u32::MAX를 사용한다.
+pub const WILDCARD_ROW: u32 = u32::MAX;
+
 #[derive(Debug, Clone, PartialEq)]
 pub enum Token {
     /// 숫자 리터럴
@@ -107,14 +111,25 @@ pub fn tokenize(input: &str) -> Vec<Token> {
                 if (first.is_ascii_alphabetic() || first == '?')
                     && (rest.chars().all(|c| c.is_ascii_digit()) || rest == "?")
                 {
+                    // 행은 1부터 시작한다 (mydocs/plans/archives/task_370.md).
+                    // 와일드카드는 `?`만 인정하며, 내부적으로 WILDCARD_ROW로 구분한다.
+                    // 명시적으로 0행("A0")을 쓰는 것은 잘못된 입력이므로 셀 참조로
+                    // 인식하지 않고 아래 함수 이름 처리 경로로 넘긴다 (0이 와일드카드와
+                    // 충돌하여 현재 행으로 조용히 대체되는 것을 방지).
                     let row = if rest == "?" {
-                        0 // 와일드카드 행 (0으로 표시)
+                        Some(WILDCARD_ROW)
                     } else {
-                        rest.parse::<u32>().unwrap_or(0)
+                        match rest.parse::<u32>() {
+                            Ok(0) => None,
+                            Ok(n) => Some(n),
+                            Err(_) => None,
+                        }
                     };
-                    let col_char = if first == '?' { '?' } else { first };
-                    tokens.push(Token::CellRef(col_char, row));
-                    continue;
+                    if let Some(row) = row {
+                        let col_char = if first == '?' { '?' } else { first };
+                        tokens.push(Token::CellRef(col_char, row));
+                        continue;
+                    }
                 }
             }
 

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -5114,6 +5114,46 @@ fn test_table_utility_functions() {
 }
 
 #[test]
+fn test_css_color_rgba_and_border_width_keywords() {
+    // rgba() 색상: 브라우저는 반투명/알파 포함 색을 rgba(r, g, b, a)로 직렬화한다.
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(255, 0, 0, 1)"),
+        Some(0x0000FF),
+        "rgba() 불투명 빨강 → BGR"
+    );
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(0, 128, 255, 0.5)"),
+        Some(0xFF8000),
+        "rgba() 반투명 색도 RGB 성분은 파싱되어야 함"
+    );
+    // 완전 투명(alpha=0)은 색 없음으로 처리
+    assert_eq!(
+        super::css_color_to_hwp_bgr("rgba(255, 0, 0, 0)"),
+        None,
+        "rgba() alpha=0 → 색 없음"
+    );
+
+    // border 축약형의 rgba() 색상
+    let (w, c, s) = super::parse_css_border_shorthand("1px solid rgba(255, 0, 0, 1)");
+    assert!((w - 0.75).abs() < 0.01, "border width 1px -> 0.75pt");
+    assert_eq!(c, 0x0000FF, "border rgba() 색상 빨강 (BGR)");
+    assert_eq!(s, 1, "border style solid");
+
+    // CSS 표준 border-width 키워드: thin(1px)/medium(3px)/thick(5px)
+    // 키워드를 인식하지 못하면 width 0 → 테두리 전체가 소실된다.
+    let (w_thin, _, s_thin) = super::parse_css_border_shorthand("thin solid #000000");
+    assert!((w_thin - 0.75).abs() < 0.01, "thin = 1px = 0.75pt");
+    assert_eq!(s_thin, 1);
+
+    let (w_med, c_med, _) = super::parse_css_border_shorthand("medium solid #ff0000");
+    assert!((w_med - 2.25).abs() < 0.01, "medium = 3px = 2.25pt");
+    assert_eq!(c_med, 0x0000FF);
+
+    let (w_thick, _, _) = super::parse_css_border_shorthand("thick solid #000000");
+    assert!((w_thick - 3.75).abs() < 0.01, "thick = 5px = 3.75pt");
+}
+
+#[test]
 fn test_html_utility_functions() {
     // decode_html_entities
     assert_eq!(super::decode_html_entities("&amp;&lt;&gt;"), "&<>");

--- a/src/wasm_api/tests.rs
+++ b/src/wasm_api/tests.rs
@@ -2564,6 +2564,36 @@ fn test_delete_table_column_and_split_cell_clear_stale_local_resize() {
     }
 }
 
+/// [split_table_cells_in_range stale local-resize] split_table_cell_native/
+/// split_table_cell_into_native와 동일하게 split_table_cells_in_range_native도
+/// Table::split_cells_in_range()가 내부적으로 split_cell_into()를 반복 호출해
+/// cells 배열의 인덱스 배치를 바꾼다. 그런데 이 커맨드만 local_resize_cell_widths/
+/// heights를 비우지 않아 stale 참조가 남는다.
+#[test]
+fn test_split_table_cells_in_range_clears_stale_local_resize() {
+    let mut doc = create_doc_with_table();
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first_mut()
+    {
+        table.local_resize_cell_widths.push((1, 1234));
+        table.local_resize_cell_heights.push((1, 5678));
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+
+    doc.split_table_cells_in_range_native(0, 0, 0, 0, 0, 1, 1, 2, 2, false)
+        .expect("범위 분할");
+
+    if let Some(Control::Table(table)) = doc.document.sections[0].paragraphs[0].controls.first() {
+        assert!(
+            table.local_resize_cell_widths.is_empty() && table.local_resize_cell_heights.is_empty(),
+            "범위 분할 후 local_resize_cell_widths/heights의 stale 참조가 비워져야 한다"
+        );
+    } else {
+        panic!("표 컨트롤을 찾을 수 없음");
+    }
+}
+
 #[test]
 fn test_merge_then_control_layout_has_col_span() {
     let mut doc = create_doc_with_table();

--- a/tests/issue_header_picture_tac_line_seg_migration.rs
+++ b/tests/issue_header_picture_tac_line_seg_migration.rs
@@ -1,0 +1,89 @@
+//! 머리말/꼬리말 그림 treatAsChar 토글 시 앵커 문단 line_segs 미갱신 회귀 가드.
+//!
+//! 본문 그림(set_picture_properties_native)은 [Task #1151 v2] 마이그레이션으로
+//! treatAsChar false→true 시 앵커 line_segs[0].line_height 를 그림 높이로 갱신한다.
+//! 머리말/꼬리말 경로(set_header_footer_picture_properties_native)는 이 마이그레이션이
+//! 누락되어 있었다.
+
+use rhwp::model::control::Control;
+use std::fs;
+use std::path::Path;
+
+fn find_header_picture(hwp: &str) -> Option<(usize, usize, usize, usize, usize)> {
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let path = Path::new(repo_root).join(hwp);
+    let data = fs::read(&path).ok()?;
+    let doc = rhwp::parser::hwp3::parse_hwp3(&data).ok()?;
+    for (si, sec) in doc.sections.iter().enumerate() {
+        for (bi, para) in sec.paragraphs.iter().enumerate() {
+            for (hi, ctrl) in para.controls.iter().enumerate() {
+                if let Control::Header(h) = ctrl {
+                    for (ipi, ipara) in h.paragraphs.iter().enumerate() {
+                        for (ici, ictrl) in ipara.controls.iter().enumerate() {
+                            if matches!(ictrl, Control::Picture(_)) {
+                                return Some((si, bi, hi, ipi, ici));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+    None
+}
+
+#[test]
+fn header_picture_tac_on_updates_anchor_line_height() {
+    use rhwp::document_core::DocumentCore;
+
+    let repo_root = env!("CARGO_MANIFEST_DIR");
+    let p = Path::new(repo_root).join("samples/hwp3-sample11.hwp");
+    let data = fs::read(&p).expect("read");
+    let mut core = DocumentCore::from_bytes(&data).expect("parse");
+
+    let (si, bi, hi, ipi, ici) =
+        find_header_picture("samples/hwp3-sample11.hwp").expect("header picture must exist");
+
+    // 샘플의 초기 tac 상태와 무관하게 false→true 전환을 강제로 재현한다:
+    // 먼저 false 로 만들어 floating 상태로 정규화한 뒤, true 로 토글해 마이그레이션을
+    // 실제로 발동시킨다 (샘플 그림이 이미 tac=true 이면 두 번째 호출이 no-op 이 되어
+    // 마이그레이션 미실행을 놓치는 것을 방지).
+    core.set_header_footer_picture_properties_native(
+        si,
+        bi,
+        hi,
+        ipi,
+        ici,
+        r#"{"treatAsChar":false}"#,
+    )
+    .expect("set_header_footer_picture_properties_native(treatAsChar:false)");
+
+    let pic_height = match &core.document().sections[si].paragraphs[bi].controls[hi] {
+        Control::Header(h) => match &h.paragraphs[ipi].controls[ici] {
+            Control::Picture(p) => p.common.height as i32,
+            _ => panic!("expected picture"),
+        },
+        _ => panic!("expected header"),
+    };
+
+    core.set_header_footer_picture_properties_native(
+        si,
+        bi,
+        hi,
+        ipi,
+        ici,
+        r#"{"treatAsChar":true}"#,
+    )
+    .expect("set_header_footer_picture_properties_native(treatAsChar:true)");
+
+    let line_height = match &core.document().sections[si].paragraphs[bi].controls[hi] {
+        Control::Header(h) => h.paragraphs[ipi].line_segs.first().map(|s| s.line_height),
+        _ => panic!("expected header"),
+    };
+
+    assert_eq!(
+        line_height,
+        Some(pic_height),
+        "머리말 그림 treatAsChar on 후 앵커 문단 line_segs[0].line_height 가 그림 높이({pic_height})로 갱신되어야 함"
+    );
+}


### PR DESCRIPTION
kevin9327 님의 문서 코어 편집 축 7건을 메인테이너가 재실증 후 통합한다. 충돌분 1건을 같은 축에 흡수했다.

## 채택 7건

| PR | 결함 |
|---|---|
| #3075 (`Closes #3073`) | 각주 삭제 시 char_shapes/range_tags 역시프트 누락 — 삭제 지점 이후 글자모양 run 이 텍스트와 어긋남 (삽입측과 비대칭) |
| #3081 (`Closes #3080`) | 머리말/꼬리말 그림 TAC 토글 시 앵커 line_segs 마이그레이션 누락 |
| #3120 (`Closes #3034`) | HTML 임포트 `text-decoration-line: underline`(공백 변형) 밑줄 미인식 |
| #3162 (`Closes #3160`) | HTML 임포트 CSS rgba() 색상·border-width 키워드(thin/medium/thick) 미파싱 |
| #3177 | 표 범위 분할 시 local_resize_cell_widths/heights stale 정리 누락 — #2843/#2853 계열(배치 B)의 마지막 조각 |
| #3179 | 표 계산식 셀 참조에서 행 0 이 와일드카드로 오인식 |
| #3188 (`Closes #3187`) | delete_range_native 뒤집힌 오프셋/범위 밖 인덱스 무검증 패닉 |

## 충돌 흡수

#3075 1건 — 기merge 된 미주 재번호 테스트 모듈과 같은 자리를 두고 겹친 **테스트 모듈 병치**로, 두 모듈을 완전한 형태로 모두 유지했다. 소스 로직 충돌은 없었다.

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 7건 반영을 패치ID + 표적 테스트로 개별 검증

Co-authored-by 로 원 커밋 provenance 를 보존한다.
