### PR TITLE
fix(studio): 입력 클램프·대화상자 리셋·문자표 하이라이트 6건 — kevin9327 축배치 M

### DIFF
--- a/mydocs/report/task_m100_2892_report.md
+++ b/mydocs/report/task_m100_2892_report.md
@@ -1,0 +1,61 @@
+# task m100-2892: 개체 설명문/수식 스크립트 입력 길이 가드
+
+## 이슈
+
+- edwardkim/rhwp#2892 — 개체 설명문/수식 스크립트 입력 길이 미검증으로 인한 CTRL_DATA 손상 방지
+  (#2851/#2862/#2866/#2878 형제 필드 재발)
+
+## 근거
+
+`src/serializer/byte_writer.rs:70-76`의 `write_hwp_string()`은 UTF-16 코드 유닛 수를
+`as u16`으로 캐스팅해 길이 프리픽스를 만든다. 검증 없이 65536자 이상 문자열이 들어오면
+캐스팅이 랩어라운드되어 손상된 레코드가 만들어진다. 이 sink에 도달하는 두 입력 경로를
+확인했다.
+
+- `src/serializer/control.rs:1905` — `w.write_hwp_string(&common.description)` ←
+  `picture-props-dialog.ts`의 개체 설명문 서브 대화상자(`showDescriptionPrompt()`)
+- `src/serializer/control.rs:2386` — `w.write_hwp_string(&eq.script)` ←
+  `equation-editor-dialog.ts`의 수식 스크립트 입력(`scriptArea`)
+
+참고: `equation-props-dialog.ts`의 스크립트 필드는 `readOnly = true`인 조회 전용이라
+편집 경로가 아니므로 스코프에서 제외했다.
+
+## 변경 사항
+
+- `rhwp-studio/src/ui/picture-props-dialog.ts`
+  - `MAX_OBJECT_DESCRIPTION_LEN = 4000` 상수 추가
+  - `showDescriptionPrompt()`의 textarea에 `maxLength` 지정, 상한 초과 시 에러 라벨 표시 후
+    저장 거부
+  - `handleOk()` 진입 시 방어적으로 한 번 더 상한 검증(초과 시 서브 대화상자 재표시)
+- `rhwp-studio/src/ui/equation-editor-dialog.ts`
+  - `MAX_EQUATION_SCRIPT_LEN = 8000` 상수 추가
+  - `scriptArea`에 `maxLength` 지정, 에러 라벨 요소 추가
+  - `handleOk()`에서 상한 초과 시 에러 라벨 표시 후 저장 거부; 대화상자 `open()` 시
+    에러 라벨 초기화
+- `rhwp-studio/tests/object-description-equation-script-length-guard.test.ts` (신규)
+  - 두 상수가 65536보다 충분히 작은지 소스 가드로 검증
+  - `handleOk()`가 상한 초과 시 저장을 거부하는 가드 분기를 포함하는지 소스 가드로 검증
+
+`.rs` 파일은 수정하지 않았다.
+
+## 작업 중 발견한 사항 — worktree 브랜치 노후화
+
+작업 시작 시 이 worktree(`rhwp-wt-u`)의 현재 브랜치가 `push-2878`였고, 이는
+`origin/devel`(최신 tip: `95509062` PR #2834 merge)에서 상당히 갈라진 상태였다. 특히
+`picture-props-dialog.ts`는 `origin/devel`에서 `handleOk()`가 `buildPicturePropsPatch()` /
+`captureApplyForm()` / `applyPropertyPatch()`를 사용하는 구조로 리팩터링되어 있었던 반면,
+`push-2878` 브랜치의 파일은 그 이전의 인라인 `updated: Record<string, unknown>` 구조였다.
+
+`git fetch origin devel` 후 `origin/devel`을 베이스로 새 브랜치
+(`task/m100-2883-object-desc-eq-script-len-guard`)를 만들고, 두 파일 중
+`equation-editor-dialog.ts`는 깨끗이 cherry-pick되었지만 `picture-props-dialog.ts`는
+충돌이 발생해 실제 `origin/devel`의 최신 `handleOk()` 구조에 맞춰 다시 작성했다.
+(`git stash`는 사용하지 않았다 — 임시 커밋 + cherry-pick으로 처리했다.)
+
+## 검증
+
+- `npm test` — 501개 중 500 통과, 1 실패(`cell-flow-boundary.test.ts`, 이번 변경과 무관한
+  기존 known-failure). 신규 테스트 2건(`개체 설명문/수식 스크립트 상한은 ...`,
+  `handleOk()가 상한 초과 시 저장을 거부한다`) 모두 통과.
+- `npx tsc --noEmit` — 기존 베이스라인과 동일하게 `@wasm/rhwp.js` 모듈 미발견 TS2307 2건만
+  존재(`wasm-bridge.ts`, `hwpctl/index.ts`), 신규 에러 없음.

--- a/mydocs/report/task_m100_2967_report.md
+++ b/mydocs/report/task_m100_2967_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2967
+
+- 이슈: #2967
+- 제목: 사진 속성 밝기/대비 값이 HTML 입력 범위(-100~100)를 벗어나도 clamp 없이 그대로 적용됨
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2967-picture-brightness-contrast-clamp`
+
+## 1. 완료 내용
+
+`rhwp-studio/src/ui/picture-props-apply-model.ts`의 `appendImageEffects()`에서
+밝기(brightness)·대비(contrast) 값을 UI가 선언한 HTML 입력 범위(-100~100)와 동일하게
+clamp하도록 수정했다. 같은 함수 안의 투명도(transparency) 처리는 이미
+`Math.max(0, Math.min(100, ...))`로 clamp되어 있었는데, 밝기·대비만 `integerOr()` 파싱
+결과를 그대로 patch에 실었다. #2845/#2938/#2949/#2959에서 반복 확인된 "HTML min/max는
+있지만 확인 처리 로직에는 clamp가 없는" 패턴과 동일한 결함이다.
+
+## 2. 주요 변경
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageEffects()`에서 brightness/contrast를 `Math.max(-100, Math.min(100, ...))`로
+    clamp 후 patch에 반영
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `image brightness and contrast clamp to the -100..100 HTML input range` 픽스처 추가
+    (입력 `250`/`-999` → 결과 `100`/`-100` 검증)
+
+## 3. 검증 결과
+
+- `npx vitest run tests/picture-props-apply-model.test.ts`
+  - 신규 테스트 포함 전체 통과 (기존 파일의 vitest 러너 특성상 파일 레벨에서
+    "No test suite found" 경고가 함께 출력되나, 개별 테스트 케이스는 모두 통과로 표시됨 —
+    같은 파일의 기존 테스트들과 동일한 현상)
+
+## 4. 리스크
+
+- 변경 범위가 `appendImageEffects()` 내부 2개 필드로 국한되어 다른 patch 필드나
+  객체 타입(shape/line/ole)에는 영향이 없다.
+
+## 5. 결론
+
+Task M100-2967 구현과 테스트를 완료했다. PR 생성 후 이슈를 close할 수 있다.

--- a/mydocs/report/task_m100_2977_report.md
+++ b/mydocs/report/task_m100_2977_report.md
@@ -1,0 +1,40 @@
+# 완료 보고서 — Task M100-2977
+
+- 이슈: #2977
+- 제목: 그림 확대/축소 비율 입력이 min/max 범위를 벗어나도 확인 시 그대로 적용됨 (picture-props-dialog)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2977-image-scale-clamp`
+
+## 1. 문제
+
+`rhwp-studio` 그림 속성 대화상자의 "확대/축소 비율" 탭 가로/세로 배율 입력 필드
+(`picScaleXInput`, `picScaleYInput`)는 `picture-props-dialog.ts`에서 HTML
+`min=1`, `max=1000` 제약으로 생성된다. 그러나 확인(OK) 시 실제 패치를 만드는
+`appendImageScale`(`picture-props-apply-model.ts`)은 이 범위를 전혀 검증하지 않고
+`numberOr`로 파싱한 값을 그대로 원본 크기에 곱해 폭/높이를 계산했다.
+
+사용자가 네이티브 스피너가 아닌 직접 타이핑(예: `-10`, `5000`)으로 값을 입력하면
+HTML `min`/`max` 속성이 값 검증에 관여하지 않으므로, 범위를 벗어난 배율이 그대로
+적용되어 음수 높이나 1000%를 초과하는 비정상적인 크기가 patch에 들어갈 수 있었다.
+
+같은 파일의 밝기/대비/투명도 클램프, 그리고 최근 회전각 클램프(#2954)와 동일한
+"HTML min/max는 있지만 확인 시 검증 누락" 패턴이다.
+
+## 2. 수정 내용
+
+`appendImageScale`에서 `numberOr`로 읽은 가로/세로 배율을 UI와 동일하게
+`Math.max(1, Math.min(1000, ...))`로 클램프한 뒤 폭/높이를 계산하도록 했다.
+
+- `rhwp-studio/src/ui/picture-props-apply-model.ts`
+  - `appendImageScale`에 `scaleX`, `scaleY` 클램프 추가
+- `rhwp-studio/tests/picture-props-apply-model.test.ts`
+  - `'image scale clamps to the 1..1000 HTML input range'` 픽스처 추가
+    (`x: '5000', y: '-10'` → `width: 10000, height: 8`로 클램프되는지 검증)
+
+## 3. 검증 결과
+
+`npx tsx --test tests/picture-props-apply-model.test.ts` 전체 통과 (27 passed).
+
+## 4. 참고
+
+- 동일 패턴 선례: 밝기/대비 클램프(#2967), 회전각 클램프(#2954)

--- a/mydocs/report/task_m100_3144_report.md
+++ b/mydocs/report/task_m100_3144_report.md
@@ -1,0 +1,28 @@
+# task-m100-3144: 책갈피 대화상자 재사용 시 정렬 상태 불일치 수정
+
+## 이슈
+
+#3144 책갈피 대화상자 재사용 시 정렬 상태 불일치 — 라디오는 '위치'로 초기화되지만
+sortMode는 이전 값 유지
+
+## 원인
+
+`rhwp-studio/src/command/commands/insert.ts`는 `BookmarkDialog`를 모듈 전역
+싱글턴(`bookmarkDialog`)으로 한 번만 생성해 재사용한다. `show()`는 `build()`로
+DOM을 매번 새로 만들어 정렬 라디오가 항상 '위치(P)' 체크 상태로 생성되지만,
+인스턴스 필드 `sortMode`는 리셋되지 않아 이전 세션의 `'name'`이 남는다. 이어지는
+`refreshList()`가 stale `sortMode`로 정렬해 라디오 표시와 목록 정렬이 어긋난다.
+
+#3037(필드 입력 대화상자 재사용 시 이전 값 유지)과 같은 결함 클래스다.
+
+## 수정
+
+`bookmark-dialog.ts`의 `show()`에서 `refreshList()` 호출 전에
+`this.sortMode = 'position'`으로 리셋해 새로 만들어지는 라디오 초기 상태와
+일치시켰다.
+
+## 검증
+
+- `rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts` 신규 테스트 추가
+  (`field-insert-dialog-reset.test.ts`와 동일한 소스 문자열 검사 패턴)
+- 수정 전 red 확인 → 수정 후 `node --test tests/bookmark-dialog-sort-reset.test.ts` 통과

--- a/mydocs/report/task_m100_3145_report.md
+++ b/mydocs/report/task_m100_3145_report.md
@@ -1,0 +1,29 @@
+# task-m100-3145: 수식 편집기 재사용 시 기호 검색 상태 리셋 누락 수정
+
+## 이슈
+
+#3145 수식 편집기 대화상자 재사용 시 기호 검색어·결과 드롭다운이 초기화되지
+않고 남음
+
+## 원인
+
+`rhwp-studio/src/command/commands/insert.ts`는 `EquationEditorDialog`를 모듈
+전역 싱글턴(`equationEditorDialog`)으로 생성해 재사용하고, `build()`는 `built`
+플래그로 최초 1회만 실행되어 DOM이 인스턴스에 계속 남는다. `open()`은
+scriptArea/fontSizeInput/colorInput/입력 모드는 문서 값으로 리셋하지만 기호
+검색 입력(`searchInput`)과 결과 드롭다운(`searchResults`)은 건드리지 않고,
+`hide()`도 autocomplete 드롭다운만 닫는다. 그 결과 닫았다 다시 열면 이전
+검색어와 펼쳐진 결과 목록이 그대로 남았다.
+
+#3037(필드 입력 대화상자 재사용 시 이전 값 유지)과 같은 결함 클래스다.
+
+## 수정
+
+`equation-editor-dialog.ts`의 `open()`에서 `searchInput.value`를 비우고
+`searchResults`를 `display: none`으로 닫아 기호 검색 상태를 초기화했다.
+
+## 검증
+
+- `rhwp-studio/tests/equation-editor-search-reset.test.ts` 신규 테스트 추가
+  (`field-insert-dialog-reset.test.ts`와 동일한 소스 문자열 검사 패턴)
+- 수정 전 red 확인 → 수정 후 `node --test tests/equation-editor-search-reset.test.ts` 통과

--- a/rhwp-studio/src/ui/bookmark-dialog.ts
+++ b/rhwp-studio/src/ui/bookmark-dialog.ts
@@ -49,6 +49,11 @@ export class BookmarkDialog {
     };
     document.addEventListener('keydown', this.captureHandler, true);
 
+    // 싱글턴으로 재사용되는데 build() 가 라디오를 매번 '위치(P)' 체크 상태로 새로
+    // 만들므로, 이전 세션의 sortMode('name')가 남으면 라디오 표시와 실제 목록
+    // 정렬이 어긋난다 — 라디오 초기 상태와 일치하도록 리셋한다. (#3144)
+    this.sortMode = 'position';
+
     this.refreshList();
     this.suggestName();
     this.nameInput.focus();

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -14,6 +14,19 @@ import { enableDialogDrag } from './dialog-drag';
  * - PicturePropsDialog 패턴 (ModalDialog 미상속, 자체 overlay/DOM/keyboard 관리)
  */
 
+/**
+ * 수식 스크립트(script)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 EQEDIT 컨트롤의 script 문자열을
+ * `write_hwp_string()`(`src/serializer/byte_writer.rs`)로 기록하는데, 이 함수는 UTF-16
+ * 코드 유닛 수를 `as u16`으로 캐스팅해 길이 프리픽스를 만든다. 문자열 길이가 65536
+ * 이상이면 캐스팅이 랩어라운드되어 길이 프리픽스와 실제 기록된 바이트 수가 어긋난
+ * 손상된 레코드가 만들어진다(#2851/#2862/#2866/#2878과 동일 원인). `.rs`를 수정하지 않는
+ * 범위에서, 손상 가능한 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은
+ * 상한으로 미리 막는다.
+ */
+export const MAX_EQUATION_SCRIPT_LEN = 8000;
+
 type InputMode = 'hwp' | 'latex';
 
 interface TemplateEntry { label: string; hwp: string; latex: string }
@@ -203,6 +216,7 @@ export class EquationEditorDialog {
   private dialog!: HTMLDivElement;
   private previewContainer!: HTMLDivElement;
   private scriptArea!: HTMLTextAreaElement;
+  private scriptErrorLabel!: HTMLDivElement;
   private fontSizeInput!: HTMLInputElement;
   private colorInput!: HTMLInputElement;
   private built = false;
@@ -270,6 +284,7 @@ export class EquationEditorDialog {
     }
 
     this.scriptArea.value = this.origProps.script || '';
+    this.scriptErrorLabel.style.display = 'none';
     this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100));
     this.colorInput.value = colorRefToHex(this.origProps.color);
 
@@ -376,6 +391,7 @@ export class EquationEditorDialog {
     this.scriptArea.className = 'eq-script';
     this.scriptArea.rows = 4;
     this.scriptArea.spellcheck = false;
+    this.scriptArea.maxLength = MAX_EQUATION_SCRIPT_LEN;
     this.scriptArea.addEventListener('input', () => { this.schedulePreview(); this.onScriptInput(); });
     this.scriptArea.addEventListener('keydown', (e) => this.onScriptKeydown(e));
 
@@ -385,6 +401,14 @@ export class EquationEditorDialog {
 
     scriptWrap.append(this.scriptArea, this.acDropdown);
     body.appendChild(scriptWrap);
+
+    this.scriptErrorLabel = document.createElement('div');
+    this.scriptErrorLabel.className = 'eq-script-error';
+    this.scriptErrorLabel.style.color = '#c00';
+    this.scriptErrorLabel.style.fontSize = '11px';
+    this.scriptErrorLabel.style.display = 'none';
+    this.scriptErrorLabel.textContent = `수식 스크립트는 ${MAX_EQUATION_SCRIPT_LEN}자를 넘을 수 없습니다.`;
+    body.appendChild(this.scriptErrorLabel);
 
     // 6) 속성 행
     const propsRow = document.createElement('div');
@@ -691,6 +715,11 @@ export class EquationEditorDialog {
     if (!this.origProps) return;
 
     const script = this.scriptArea.value;
+    if (script.length > MAX_EQUATION_SCRIPT_LEN) {
+      this.scriptErrorLabel.style.display = '';
+      return;
+    }
+    this.scriptErrorLabel.style.display = 'none';
     const fontSizePt = parseInt(this.fontSizeInput.value, 10) || 10;
     const fontSizeHwpunit = fontSizePt * 100;
     const color = hexToColorRef(this.colorInput.value);

--- a/rhwp-studio/src/ui/equation-editor-dialog.ts
+++ b/rhwp-studio/src/ui/equation-editor-dialog.ts
@@ -288,6 +288,11 @@ export class EquationEditorDialog {
     this.fontSizeInput.value = String(Math.round(this.origProps.fontSize / 100));
     this.colorInput.value = colorRefToHex(this.origProps.color);
 
+    // 싱글턴으로 재사용 + build() 는 1회만 실행되므로 이전 세션의 기호 검색어와
+    // 펼쳐진 결과 드롭다운이 남지 않도록 초기화한다. (#3145)
+    this.searchInput.value = '';
+    this.searchResults.style.display = 'none';
+
     // 기존 스크립트에 \ 가 있으면 LaTeX 모드로 시작
     if (this.origProps.script && /\\[a-zA-Z]/.test(this.origProps.script)) {
       this.setMode('latex');

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -452,8 +452,14 @@ function appendImageEffects(
     const effect = form.selectedEffect === 'Original' ? 'RealPic' : form.selectedEffect;
     addChanged(patch, 'effect', effect, props.effect ?? 'RealPic');
   }
-  if (form.brightness !== undefined) addChanged(patch, 'brightness', integerOr(form.brightness, 0), props.brightness ?? 0);
-  if (form.contrast !== undefined) addChanged(patch, 'contrast', integerOr(form.contrast, 0), props.contrast ?? 0);
+  if (form.brightness !== undefined) {
+    const brightness = Math.max(-100, Math.min(100, integerOr(form.brightness, 0)));
+    addChanged(patch, 'brightness', brightness, props.brightness ?? 0);
+  }
+  if (form.contrast !== undefined) {
+    const contrast = Math.max(-100, Math.min(100, integerOr(form.contrast, 0)));
+    addChanged(patch, 'contrast', contrast, props.contrast ?? 0);
+  }
   if (form.transparency !== undefined) {
     const transparency = Math.max(0, Math.min(100, integerOr(form.transparency, 0)));
     addChanged(patch, 'transparency', transparency, props.transparency ?? 0);

--- a/rhwp-studio/src/ui/picture-props-apply-model.ts
+++ b/rhwp-studio/src/ui/picture-props-apply-model.ts
@@ -424,8 +424,10 @@ function appendImageScale(
   form: PicturePropsApplyForm,
 ): void {
   if (form.common.sizeProtect || !form.image.scale || !(props.originalWidth > 0)) return;
-  const width = Math.round(props.originalWidth * numberOr(form.image.scale.x, 100) / 100);
-  const height = Math.round(props.originalHeight * numberOr(form.image.scale.y, 100) / 100);
+  const scaleX = Math.max(1, Math.min(1000, numberOr(form.image.scale.x, 100)));
+  const scaleY = Math.max(1, Math.min(1000, numberOr(form.image.scale.y, 100)));
+  const width = Math.round(props.originalWidth * scaleX / 100);
+  const height = Math.round(props.originalHeight * scaleY / 100);
   addChanged(patch, 'width', width, props.width);
   addChanged(patch, 'height', height, props.height);
 }

--- a/rhwp-studio/src/ui/picture-props-dialog.ts
+++ b/rhwp-studio/src/ui/picture-props-dialog.ts
@@ -48,6 +48,19 @@ const OLE_TAB_NAMES = ['기본', '여백/캡션', '선'];
 /** 탭 이름 — 직선용 (채우기/글상자 불필요) */
 const LINE_TAB_NAMES = ['기본', '여백/캡션', '선', '그림자'];
 
+/**
+ * 개체 설명문(description)의 안전한 상한 길이(문자 수).
+ *
+ * Rust 직렬화기(`src/serializer/control.rs`)는 그림/글상자 등 개체의 CommonObjAttr
+ * description 필드를 `write_hwp_string()`(`src/serializer/byte_writer.rs`)로 기록하는데,
+ * 이 함수는 UTF-16 코드 유닛 수를 `as u16`으로 캐스팅해 길이 프리픽스를 만든다. 문자열
+ * 길이가 65536 이상이면 캐스팅이 랩어라운드되어 길이 프리픽스와 실제 기록된 바이트 수가
+ * 어긋난 손상된 레코드가 만들어진다(#2851/#2862/#2866/#2878과 동일 원인). `.rs`를 수정하지
+ * 않는 범위에서, 손상 가능한 값이 wasm 호출까지 도달하지 않도록 프런트엔드에서 훨씬 낮은
+ * 상한으로 미리 막는다.
+ */
+export const MAX_OBJECT_DESCRIPTION_LEN = 4000;
+
 export class PicturePropsDialog {
   private overlay!: HTMLDivElement;
   private dialog!: HTMLDivElement;
@@ -2096,6 +2109,10 @@ export class PicturePropsDialog {
 
   private handleOk(): void {
     if (!this.props) { this.hide(); return; }
+    if (this.descInput.value.length > MAX_OBJECT_DESCRIPTION_LEN) {
+      this.showDescriptionPrompt();
+      return;
+    }
     const patch = buildPicturePropsPatch(
       this.objectType,
       this.props,
@@ -2488,8 +2505,17 @@ export class PicturePropsDialog {
     leftCol.className = 'cs-left-col';
     const textarea = document.createElement('textarea');
     textarea.className = 'pp-desc-textarea';
+    textarea.maxLength = MAX_OBJECT_DESCRIPTION_LEN;
     textarea.value = this.descInput.value;
     leftCol.appendChild(textarea);
+
+    const errorLabel = document.createElement('div');
+    errorLabel.className = 'pp-desc-error';
+    errorLabel.style.color = '#c00';
+    errorLabel.style.fontSize = '11px';
+    errorLabel.style.display = 'none';
+    errorLabel.textContent = `개체 설명문은 ${MAX_OBJECT_DESCRIPTION_LEN}자를 넘을 수 없습니다.`;
+    leftCol.appendChild(errorLabel);
 
     const rightCol = document.createElement('div');
     rightCol.className = 'cs-right-col';
@@ -2497,6 +2523,10 @@ export class PicturePropsDialog {
     okBtn.className = 'dialog-btn dialog-btn-primary';
     okBtn.textContent = '확인(D)';
     okBtn.addEventListener('click', () => {
+      if (textarea.value.length > MAX_OBJECT_DESCRIPTION_LEN) {
+        errorLabel.style.display = '';
+        return;
+      }
       this.descInput.value = textarea.value;
       overlay.remove();
     });

--- a/rhwp-studio/src/ui/symbols-dialog.ts
+++ b/rhwp-studio/src/ui/symbols-dialog.ts
@@ -60,6 +60,11 @@ const COLS = 16;
 const RECENT_KEY = 'rhwp-symbols-recent';
 const MAX_RECENT = 32;
 
+/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
+export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
+  return codePoint >= block.start && codePoint <= block.end;
+}
+
 export class SymbolsDialog {
   private services: CommandServices;
   private _open = false;
@@ -285,11 +290,13 @@ export class SymbolsDialog {
     this.codeLabel.textContent = codePoint.toString(16).toUpperCase().padStart(4, '0');
     this.previewCell.textContent = ch;
 
-    // 그리드 하이라이트
+    // 그리드 하이라이트 (최근 사용 문자가 현재 블록에 없으면 하이라이트하지 않음)
     this.charGrid.querySelectorAll('.sym-cell.selected').forEach(el => el.classList.remove('selected'));
-    const idx = codePoint - this.currentBlock.start;
-    const cells = this.charGrid.querySelectorAll('.sym-cell');
-    cells[idx]?.classList.add('selected');
+    if (isCodePointInBlock(codePoint, this.currentBlock)) {
+      const idx = codePoint - this.currentBlock.start;
+      const cells = this.charGrid.querySelectorAll('.sym-cell');
+      cells[idx]?.classList.add('selected');
+    }
   }
 
   // ── 삽입 ──

--- a/rhwp-studio/src/ui/symbols-dialog.ts
+++ b/rhwp-studio/src/ui/symbols-dialog.ts
@@ -6,14 +6,11 @@
 import type { CommandServices } from '@/command/types';
 import { InsertTextCommand } from '@/engine/command';
 import { enableDialogDrag } from './dialog-drag';
+import { isCodePointInBlock, type UnicodeBlock } from './unicode-block.ts';
+
+export { isCodePointInBlock } from './unicode-block.ts';
 
 // ── 유니코드 블록 정의 ──
-
-interface UnicodeBlock {
-  name: string;
-  start: number;
-  end: number;
-}
 
 const UNICODE_BLOCKS: UnicodeBlock[] = [
   { name: '기본 라틴 문자', start: 0x0020, end: 0x007F },
@@ -59,11 +56,6 @@ const UNICODE_BLOCKS: UnicodeBlock[] = [
 const COLS = 16;
 const RECENT_KEY = 'rhwp-symbols-recent';
 const MAX_RECENT = 32;
-
-/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
-export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
-  return codePoint >= block.start && codePoint <= block.end;
-}
 
 export class SymbolsDialog {
   private services: CommandServices;

--- a/rhwp-studio/src/ui/unicode-block.ts
+++ b/rhwp-studio/src/ui/unicode-block.ts
@@ -1,0 +1,19 @@
+/**
+ * 유니코드 블록 판정 헬퍼
+ *
+ * symbols-dialog.ts 에서 분리한 순수 함수 모듈. `@/engine/command` 등 런타임
+ * 의존성이 없어 node 네이티브 테스트 러너로 직접 import 해도 안전하다
+ * (symbols-dialog.ts 는 InsertTextCommand 를 가져오며, 해당 모듈은 node의
+ * TypeScript strip-only 모드가 지원하지 않는 parameter property 문법을 쓴다).
+ */
+
+export interface UnicodeBlock {
+  name: string;
+  start: number;
+  end: number;
+}
+
+/** 문자가 해당 유니코드 블록에 속하는지 판정(최근 사용 문자는 다른 블록일 수 있음). */
+export function isCodePointInBlock(codePoint: number, block: UnicodeBlock): boolean {
+  return codePoint >= block.start && codePoint <= block.end;
+}

--- a/rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts
+++ b/rhwp-studio/tests/bookmark-dialog-sort-reset.test.ts
@@ -1,0 +1,37 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 책갈피 대화상자는 commands/insert.ts 에서 모듈 전역 싱글턴으로 재사용된다.
+// show() 는 build() 로 DOM 을 매번 새로 만들기 때문에 정렬 라디오는 항상
+// '위치(P)' 가 선택된 상태로 나타나지만, 인스턴스 필드 sortMode 는 이전 세션
+// 값('name')이 남는다 → 라디오 표시와 실제 목록 정렬이 어긋난다.
+// show() 는 refreshList() 전에 sortMode 를 초기값 'position' 으로 리셋해야 한다.
+test('책갈피 대화상자는 열릴 때마다 sortMode를 라디오 초기 상태(position)로 리셋한다', () => {
+  const dialog = source('src/ui/bookmark-dialog.ts');
+  const showStart = dialog.indexOf('show(): void');
+  assert.notEqual(showStart, -1, 'show() 를 찾을 수 있어야 한다');
+  const hideStart = dialog.indexOf('hide(): void', showStart);
+  const showBody = dialog.slice(showStart, hideStart === -1 ? undefined : hideStart);
+
+  assert.match(
+    showBody,
+    /this\.sortMode\s*=\s*'position'/,
+    'show() 는 refreshList() 전에 sortMode 를 position 으로 리셋해야 한다',
+  );
+
+  const resetIdx = showBody.search(/this\.sortMode\s*=\s*'position'/);
+  const refreshIdx = showBody.indexOf('this.refreshList()');
+  assert.ok(
+    resetIdx !== -1 && refreshIdx !== -1 && resetIdx < refreshIdx,
+    'sortMode 리셋은 refreshList() 호출보다 앞서야 한다',
+  );
+});

--- a/rhwp-studio/tests/equation-editor-search-reset.test.ts
+++ b/rhwp-studio/tests/equation-editor-search-reset.test.ts
@@ -1,0 +1,35 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const rootDir = dirname(dirname(fileURLToPath(import.meta.url)));
+
+function source(path: string): string {
+  return readFileSync(join(rootDir, path), 'utf8');
+}
+
+// 수식 편집기는 commands/insert.ts 에서 모듈 전역 싱글턴으로 재사용되고,
+// build() 는 built 플래그로 최초 1회만 실행되어 DOM 이 인스턴스에 남는다.
+// open() 은 scriptArea/fontSize/color/mode 는 리셋하지만 기호 검색 입력
+// (searchInput)과 검색 결과 드롭다운(searchResults)은 건드리지 않아,
+// 닫았다 다시 열면 이전 검색어와 펼쳐진 결과 목록이 그대로 남는다.
+test('수식 편집기 대화상자는 열릴 때마다 기호 검색 입력과 결과 드롭다운을 초기화한다', () => {
+  const dialog = source('src/ui/equation-editor-dialog.ts');
+  const openStart = dialog.indexOf('open(sec: number');
+  assert.notEqual(openStart, -1, 'open() 을 찾을 수 있어야 한다');
+  const openEnd = dialog.indexOf('hide(): void', openStart);
+  const openBody = dialog.slice(openStart, openEnd === -1 ? undefined : openEnd);
+
+  assert.match(
+    openBody,
+    /this\.searchInput\.value\s*=\s*''/,
+    'open() 은 이전 검색어를 비워야 한다',
+  );
+  assert.match(
+    openBody,
+    /this\.searchResults\.style\.display\s*=\s*'none'/,
+    'open() 은 검색 결과 드롭다운을 닫아야 한다',
+  );
+});

--- a/rhwp-studio/tests/object-description-equation-script-length-guard.test.ts
+++ b/rhwp-studio/tests/object-description-equation-script-length-guard.test.ts
@@ -1,0 +1,36 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import path from 'node:path';
+
+// #2883 (#2851/#2862/#2866/#2878 형제 필드 재발): 개체 설명문(picture-props-dialog.ts)과
+// 수식 스크립트(equation-editor-dialog.ts) 입력 길이 미검증 → Rust 직렬화기
+// (src/serializer/control.rs)가 각각 CommonObjAttr.description / EQEDIT script를
+// write_hwp_string()(src/serializer/byte_writer.rs)로 기록할 때 UTF-16 코드 유닛 수를
+// `as u16`으로 캐스팅해 65536 이상이면 랩어라운드되어 레코드가 손상될 수 있었다.
+// `.rs`를 수정하지 않는 범위에서, 프런트엔드 다이얼로그가 wasm 호출 전에 각 필드 길이를
+// 안전한 상한(MAX_OBJECT_DESCRIPTION_LEN/MAX_EQUATION_SCRIPT_LEN)으로 막는지를
+// 소스 가드로 검증한다.
+
+const dir = path.dirname(fileURLToPath(import.meta.url));
+const pictureSrc = readFileSync(path.join(dir, '../src/ui/picture-props-dialog.ts'), 'utf8');
+const equationSrc = readFileSync(path.join(dir, '../src/ui/equation-editor-dialog.ts'), 'utf8');
+
+test('개체 설명문/수식 스크립트 상한은 u16 캐스팅이 랩어라운드되는 65536보다 충분히 작다', () => {
+  const descMatch = pictureSrc.match(/MAX_OBJECT_DESCRIPTION_LEN\s*=\s*(\d+)/);
+  const scriptMatch = equationSrc.match(/MAX_EQUATION_SCRIPT_LEN\s*=\s*(\d+)/);
+  assert.ok(descMatch, 'MAX_OBJECT_DESCRIPTION_LEN 상수를 찾을 수 없음');
+  assert.ok(scriptMatch, 'MAX_EQUATION_SCRIPT_LEN 상수를 찾을 수 없음');
+
+  const descLimit = Number(descMatch![1]);
+  const scriptLimit = Number(scriptMatch![1]);
+
+  assert.ok(descLimit > 0 && descLimit < 65536, `개체 설명문 상한(${descLimit})이 u16 랩어라운드 지점보다 작아야 함`);
+  assert.ok(scriptLimit > 0 && scriptLimit < 65536, `수식 스크립트 상한(${scriptLimit})이 u16 랩어라운드 지점보다 작아야 함`);
+});
+
+test('handleOk()가 상한 초과 시 저장을 거부한다', () => {
+  assert.match(pictureSrc, /if \(this\.descInput\.value\.length > MAX_OBJECT_DESCRIPTION_LEN\)/);
+  assert.match(equationSrc, /if \(script\.length > MAX_EQUATION_SCRIPT_LEN\)/);
+});

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -558,6 +558,14 @@ const fixtures: PatchFixture[] = [
       paddingBottom: 0,
     },
   },
+  {
+    name: 'image brightness and contrast clamp to the -100..100 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image = { brightness: '250', contrast: '-999' };
+    },
+    expected: { brightness: 100, contrast: -100 },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/rhwp-studio/tests/picture-props-apply-model.test.ts
+++ b/rhwp-studio/tests/picture-props-apply-model.test.ts
@@ -566,6 +566,14 @@ const fixtures: PatchFixture[] = [
     },
     expected: { brightness: 100, contrast: -100 },
   },
+  {
+    name: 'image scale clamps to the 1..1000 HTML input range',
+    objectType: 'image',
+    update(form) {
+      form.image.scale = { x: '5000', y: '-10' };
+    },
+    expected: { width: 10000, height: 8 },
+  },
 ];
 
 for (const fixture of fixtures) {

--- a/rhwp-studio/tests/symbols-dialog.test.ts
+++ b/rhwp-studio/tests/symbols-dialog.test.ts
@@ -1,0 +1,13 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { isCodePointInBlock } from '../src/ui/symbols-dialog.ts';
+
+// [문자표] 최근 사용 문자는 현재 표시된 블록과 다른 블록에 속할 수 있다.
+// selectChar()가 codePoint - block.start 로 그리드 인덱스를 계산하므로,
+// 문자가 현재 블록에 속하지 않으면 엉뚱한 셀을 하이라이트하게 되는 버그가 있었다.
+test('현재 블록에 속하지 않는 코드포인트는 false', () => {
+  const block = { name: '기본 라틴 문자', start: 0x0020, end: 0x007F };
+  assert.equal(isCodePointInBlock(0x0041, block), true); // 'A' — 블록 내부
+  assert.equal(isCodePointInBlock(0xAC00, block), false); // '가' — 다른 블록(한글 음절)
+});

--- a/rhwp-studio/tests/symbols-dialog.test.ts
+++ b/rhwp-studio/tests/symbols-dialog.test.ts
@@ -1,7 +1,7 @@
 import test from 'node:test';
 import assert from 'node:assert/strict';
 
-import { isCodePointInBlock } from '../src/ui/symbols-dialog.ts';
+import { isCodePointInBlock } from '../src/ui/unicode-block.ts';
 
 // [문자표] 최근 사용 문자는 현재 표시된 블록과 다른 블록에 속할 수 있다.
 // selectChar()가 codePoint - block.start 로 그리드 인덱스를 계산하므로,


### PR DESCRIPTION
kevin9327 님의 rhwp-studio UI 축 6건을 메인테이너가 재실증 후 통합한다. 충돌분 2건을 같은 축에 흡수했다.

## 채택 6건

| PR | 결함 |
|---|---|
| #3054 (`Closes #3051`) | 문자표 최근 사용 문자가 다른 유니코드 블록일 때 엉뚱한 셀 하이라이트 |
| #3095 (`Closes #2892`) | 개체 설명문/수식 스크립트 입력 길이 미검증 — CTRL_DATA cmd_len u16 랩어라운드 손상 (#2883 누름틀 가드와 같은 계열) |
| #3105 (`Closes #2967`) | 사진 밝기/대비 입력값 -100~100 클램프 부재 |
| #3108 (`Closes #2977`) | 그림 확대/축소 비율 입력값 1..1000 클램프 부재 |
| #3152 (`Closes #3144`) | 책갈피 대화상자 재사용 시 sortMode 라디오 미리셋 |
| #3153 (`Closes #3145`) | 수식 편집기 재사용 시 기호 검색어·결과 드롭다운 미초기화 |

## 충돌 흡수

#3105/#3108 은 1분 간격 제출된 형제로 같은 apply-model 테스트 파일을 수정 — #3108 브랜치에 스택된 #3105 사본 커밋을 걷어내고 실질 커밋만 편입했으며, 테스트 케이스 배열은 병치로 모두 유지했다.

## 검증

- `npm ci` 선행 후 `tsc --noEmit` 오류 0
- **studio 테스트 544건 전부 통과** (신규 가드·리셋 테스트 포함)

Co-authored-by 로 원 커밋 provenance 를 보존한다.
