### PR TITLE
fix(parser/wmf/cfb): 악성 입력 무한루프·오버플로 방어 6건 — kevin9327 축배치 J

### DIFF
--- a/mydocs/report/task_m100_3012_report.md
+++ b/mydocs/report/task_m100_3012_report.md
@@ -1,0 +1,40 @@
+# task_m100_3012: 다각형 도형 point count(i32) 음수 부호확장 수정
+
+## 이슈
+#3012 fix(parser): 다각형 도형 point count(i32) 음수 값이 부호확장되어 무한에 가까운 루프를 유발하는 문제
+
+## 원인
+
+`src/parser/control/shape.rs`의 `parse_polygon_shape_data`에서 hwplib 스펙상 부호 있는
+INT32인 다각형 점 개수(count)를 검증 없이 바로 `as usize`로 캐스팅했다. 조작된 값(예: `-1`)이
+들어오면 부호 확장으로 `usize::MAX` 근처의 거대한 값이 되고, 이후 `for _ in 0..cnt` 루프가
+입력이 소진된 뒤에도 `unwrap_or(0)` 기본값으로 계속 실행되어 사실상 종료되지 않는 루프(DoS)가
+된다.
+
+이는 #3004/#3008(`region.rs`의 `scan_count: i16`)과 동일한 버그 클래스(부호 있는 필드를 검증
+없이 usize로 캐스팅)의 i32 사례다.
+
+## 수정
+
+캐스팅 전에 음수 여부를 검사해 음수면 count를 0(빈 다각형)으로 처리하도록 방어했다.
+
+```rust
+let cnt_raw = r.read_i32().unwrap_or(0);
+let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+```
+
+## 테스트
+
+`polygon_point_count_negative_is_treated_as_zero`: count에 `-1`(`0xFFFFFFFF`)을 넣은 최소
+페이로드로 `parse_polygon_shape_data`를 호출해 `poly.points`가 비어 있는지 검증한다(수정 전에는
+사실상 무한 루프에 빠져 테스트가 종료되지 않음).
+
+## 검증
+
+- `cargo check --lib`: 통과
+- `cargo test --lib polygon_point_count_negative_is_treated_as_zero`: 통과 (exit 0)
+- `rustfmt --edition 2021`: 적용, 변경 없음
+
+## 범위
+
+`src/parser/control/shape.rs` 1개 파일, 핵심 수정 2줄 + 테스트 15줄.

--- a/mydocs/report/task_m100_3018_report.md
+++ b/mydocs/report/task_m100_3018_report.md
@@ -1,0 +1,50 @@
+# 완료 보고서 — Task M100-3018
+
+- 이슈: #3018
+- 제목: 선(직선) 개체 파싱 시 방향 보정 플래그가 항상 소실됨 (INT32 대 UINT16 오독)
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-3018-line-flag-u16`
+
+## 1. 완료 내용
+
+`src/parser/control/shape.rs`의 `parse_line_shape_data()`에서 "일반 선"
+(is_connector == false) 분기가 방향 보정 플래그를 `read_i32()`(4바이트)로
+읽던 것을 `read_u16()`(2바이트)로 수정했다.
+
+한글문서파일형식 5.0 revision 1.3 표92("선 개체 속성")는 좌표 4개(4바이트×4)
+뒤에 `UINT16` 속성 필드가 오며 전체 길이가 18바이트라고 명시한다. 기존
+코드는 좌표 16바이트를 읽은 뒤 남은 2바이트뿐인 자리에서 4바이트를
+요구했기 때문에 `ByteReader`가 매번 읽기에 실패해 `unwrap_or(0)`으로
+`started_right_or_bottom` 값이 항상 `false`로 소실되고 있었다.
+
+## 2. 주요 변경
+
+- `src/parser/control/shape.rs`
+  - `parse_line_shape_data()`: `read_i32()` → `read_u16()`, 스펙 근거 주석 추가
+  - `task195_tests` 모듈에 회귀 테스트
+    `line_started_right_or_bottom_parsed_from_18byte_record` 추가
+    (18바이트 레코드에서 플래그(1)가 정확히 읽히는지 검증)
+
+## 3. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib task195_tests::line_started_right_or_bottom_parsed_from_18byte_record`
+  - 1 passed
+- `rustfmt --edition 2021 src/parser/control/shape.rs`
+
+## 4. 리스크
+
+- 순수 직선(HWPTAG_SHAPE_COMPONENT_LINE, is_connector == false) 개체에만
+  영향을 준다. 연결선(connector)과 사각형/타원/호/다각형/곡선 등 다른
+  도형 파서는 이번 조사에서 스펙과 대조해 별도 불일치를 확인하지 못했다.
+- 자체 시리얼라이저(`src/serializer/control.rs`)는 여전히 이 필드를
+  `write_i32`(4바이트)로 기록한다. 이번 수정은 파서(읽기) 쪽만 스펙에
+  맞췄으며, 값 자체는 0/1이라 리틀엔디안 하위 2바이트만 읽어도 왕복
+  일관성은 유지된다(자체 저장 파일 재파싱 시 문제 없음). 시리얼라이저를
+  18바이트 스펙에 맞추는 것은 별도 범위로 남겨둔다.
+
+## 5. 결론
+
+Task M100-3018 구현과 회귀 테스트를 완료했다. PR 생성 후 리뷰를 기다린다.

--- a/mydocs/report/task_m100_3156_report.md
+++ b/mydocs/report/task_m100_3156_report.md
@@ -1,0 +1,40 @@
+# task_m100_3156 처리결과: 곡선 도형 point count(i32) 음수 부호확장 무한루프
+
+## 결함 요약
+
+- 위치: `src/parser/control/shape.rs` `parse_curve_shape_data`
+- 클래스: HWP5 바이너리 파서의 미검증 카운트 → 부호확장으로 인한 무한에 가까운 루프(DoS)
+- 자매 결함: #3012(`parse_polygon_shape_data`, 다각형). #3012는 다각형만 수정하여 곡선 함수는 취약하게 남아 있었음.
+
+## 근본 원인
+
+곡선 도형 데이터의 점 개수 `count`(hwplib 스펙상 INT32, 부호 있음)를 파일에서 읽은 직후 검증 없이 `as usize`로 캐스팅:
+
+```rust
+let cnt = r.read_i32().unwrap_or(0) as usize;
+```
+
+조작된 파일이 `count = -1`(0xFFFFFFFF)을 지정하면 64비트에서 `usize::MAX` 근처의 거대한 값으로 부호확장된다. 이후 `for _ in 0..cnt` 및 `for _ in 0..(cnt - 1)` 루프가 입력 소진 후에도 `read_i32().unwrap_or(0)`으로 계속 0을 반환하며 수십억 회 반복 → 파싱 스레드가 사실상 멈추는 DoS.
+
+## 재현 바이트
+
+곡선 도형 데이터:
+```
+FF FF FF FF   // count = -1 (INT32)
+```
+
+## 수정
+
+캐스팅 전에 음수를 검사하여 음수면 count를 0(빈 곡선)으로 처리. #3012와 동일 패턴.
+
+```rust
+let cnt_raw = r.read_i32().unwrap_or(0);
+let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
+```
+
+## 검증 (red → green)
+
+- red: `curve_point_count_negative_is_treated_as_zero` 테스트가 수정 전에는 60초 이상 종료되지 않음(타임아웃, 무한루프 확인).
+- green: 수정 후 동일 테스트 통과. `cargo test --lib shape::` 42개 전부 통과(회귀 없음), `task195_tests` 5개 통과.
+
+빌드/테스트: `RUSTFLAGS="-C linker=rust-lld" cargo test --lib`

--- a/mydocs/report/task_m100_3159_report.md
+++ b/mydocs/report/task_m100_3159_report.md
@@ -1,0 +1,65 @@
+# Task M100 #3159 구현 보고서
+
+## 목표
+
+WMF 레코드 파서 `RecordSize`의 검증되지 않은 정수 산술 두 곳을 제거해, 적대적/잘린 WMF 바이트에서
+발생하는 패닉(디버그) 및 거대 할당·OOM(릴리스)을 방어한다. 이 경로는 HWP 문서에 임베드된 WMF
+그림을 SVG로 변환할 때 신뢰할 수 없는 입력에 대해 실행된다.
+
+## 원인
+
+`src/wmf/parser/records/mod.rs`의 `RecordSize`:
+
+1. **`byte_count()` 곱셈 오버플로**: `(self.0 * 2) as usize`. `self.0`(WORD 개수)은 u32이며,
+   `self.0 * 2`가 u32 산술로 계산된다. `self.0 >= 0x8000_0000`이면 오버플로 → 디버그 빌드
+   `attempt to multiply with overflow` 패닉.
+
+2. **`remaining_bytes()` 뺄셈 언더플로**: `self.byte_count() - self.1`. 레코드가 자신의 크기를
+   실제 고정 필드보다 작게 선언하면, 레코드 파서가 고정 필드를 읽어 소비 바이트 `self.1`이
+   `byte_count()`를 초과한다. 이때 뺄셈이 usize 언더플로 → 디버그 빌드 패닉, 릴리스 빌드에서는
+   거대한 값이 `consume_remaining_bytes` → `read_variable`의 `Vec::with_capacity`로 전달되어
+   할당 패닉/OOM.
+
+`renderer::svg::convert_wmf_to_svg`는 `WMFConverter::run().ok()`로 호출하는데, `.ok()`는 `Result`
+오류만 삼키고 패닉은 잡지 못하므로 문서 렌더링 전체가 중단된다.
+
+## 재현 경로
+
+`META_LINETO`는 `record_function`(2) + `y`(2) + `x`(2) = 6바이트를 소비한다. 레코드가
+`RecordSize = 2`(byte_count = 4)로 선언되면 소비(6) > 선언(4) → `remaining_bytes()` 언더플로.
+`converter/mod.rs`의 레코드 루프는 `byte_count() == 0`만 걸러내고 최소 헤더 크기는 검증하지 않는다.
+
+## 변경
+
+`src/wmf/parser/records/mod.rs`:
+
+```rust
+pub fn byte_count(&self) -> usize {
+    self.0 as usize * 2               // usize 산술로 승격해 곱셈 오버플로 제거
+}
+
+pub fn remaining_bytes(&self) -> usize {
+    self.byte_count().saturating_sub(self.1)  // 소비 초과 시 0으로 포화
+}
+```
+
+`saturating_sub`으로 소비가 선언 크기를 초과하면 "남은 바이트 없음"으로 안전 처리한다. 이후
+루프는 다음 레코드에서 정렬 불일치로 정상 `ParseError` 후 종료되며 무한 루프는 발생하지 않는다.
+
+## 검증
+
+red → green (디버그 빌드, `RUSTFLAGS="-C linker=rust-lld"`):
+
+| 테스트 | 수정 전 | 수정 후 |
+|---|---|---|
+| `remaining_bytes_does_not_underflow_when_consumed_exceeds_declared_size` | FAIL (`subtract with overflow` @ :107) | PASS |
+| `byte_count_does_not_overflow_on_large_word_size` | FAIL (`multiply with overflow` @ :87) | PASS |
+| 주변 `wmf` 테스트(`negative_scan_count_returns_error_instead_of_panicking` 포함) | PASS | PASS |
+
+`rustfmt --check`(변경 파일 코드 내용): PASS. (저장소 전반의 CRLF newline 경고는 기존 상태이며
+이번 변경과 무관.)
+
+## 관련
+
+동일 방어 클래스의 기존 이슈(#3000 colors_used, #3004 scan_count, #3012·#3156 point count)와
+취지는 같으나 위치가 다른 `RecordSize` 산술 결함이다.

--- a/mydocs/report/task_m100_3174_report.md
+++ b/mydocs/report/task_m100_3174_report.md
@@ -1,0 +1,66 @@
+---
+kind: report
+status: final
+---
+
+# 처리결과: WMF top-down 비트맵 height() 언더플로
+
+Issue: #3174
+
+## 요약
+
+`BitmapInfoHeader::height()`가 Info/V4/V5 헤더에서 부호 있는 32비트 `height`를
+부호 확인 없이 `as usize`로 캐스팅해, top-down DIB(음수 Height, MS-WMF 2.2.2.9)를
+만나면 값이 `usize::MAX` 근방으로 언더플로했다. 같은 파일의 `size()`는 이미
+`height.unsigned_abs()`로 절댓값을 취하고 있어 두 메서드가 서로 다른 규칙을 쓰고
+있었다.
+
+## 근본 원인
+
+`src/wmf/parser/objects/structure/bitmap_info_header/mod.rs`의 `height()`:
+
+```rust
+Self::Info(BitmapInfoHeaderInfo { height, .. })
+| Self::V4(BitmapInfoHeaderV4 { height, .. })
+| Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
+```
+
+`height: i32`가 음수일 때 `as usize` 캐스팅은 2의 보수 재해석으로 거대한 값을
+만든다.
+
+## 영향 경로
+
+- `src/wmf/converter/bitmap.rs::expand_color_palette()` — 행 순회 상한으로
+  이 값을 그대로 사용, top-down DIB 입력 시 즉시 패닉하거나 슬라이스 계산이
+  깨진다.
+- `src/wmf/converter/svg/util.rs` — DIBPatternPT 브러시의 SVG `height` 속성에
+  같은 값을 그대로 써 렌더링이 깨진다.
+
+## 재현 (red)
+
+`bitmap_info_header::mod::tests::height_of_top_down_dib_is_absolute_value`
+추가 후 `cargo test --lib bitmap_info_header` 실행:
+
+```
+left: 18446744073709551606
+right: 10
+```
+
+## 수정 (green)
+
+`height()`도 `size()`처럼 Info/V4/V5 변형에서 `height.unsigned_abs()`를 쓰도록
+통일. 최소 변경, 로직 재구성 없음.
+
+## 검증
+
+```
+cargo test --lib bitmap_info_header  -> 1 passed
+cargo test --lib bitmap              -> 8 passed (회귀 없음, 관련 변환기 테스트 포함)
+cargo test --lib wmf                 -> 2 passed (회귀 없음)
+```
+
+RUSTFLAGS="-C linker=rust-lld" 사용 (dbghelp 링커 오류 회피).
+
+## 변경 파일
+
+- `src/wmf/parser/objects/structure/bitmap_info_header/mod.rs`

--- a/mydocs/report/task_m100_3181_report.md
+++ b/mydocs/report/task_m100_3181_report.md
@@ -1,0 +1,58 @@
+---
+kind: report
+status: done
+last_verified: 2026-07-23
+---
+
+# Task #3181 처리 결과 — CFB LenientCfbReader DIFAT 순환 감지 누락
+
+Issue: #3181
+
+## 문제
+
+`src/parser/cfb_reader.rs` 의 `LenientCfbReader::open` 이 CFB 헤더의 DIFAT 확장 섹터
+체인을 순회할 때 FAT/미니FAT 체인 순회(`read_chain_static`)와 달리 방문 섹터 집합을
+추적하지 않았다. 순회 상한은 파일 헤더에서 그대로 읽은 `difat_sectors_count`
+(`u32`, 공격자 통제 가능, 최대 4,294,967,295)뿐이라, 두 DIFAT 섹터가 서로를
+가리키는 순환을 만들고 `difat_sectors_count` 를 `u32::MAX` 로 설정하면 실제 체인
+길이(2)와 무관하게 최대 42억 회 넘게 동일한 섹터를 반복 순회한다. 패닉은 아니지만
+단일 스레드 WASM 환경(브라우저 탭)에서는 사실상 응답 없음(DoS)이 된다.
+
+## 재현
+
+`src/parser/cfb_reader.rs::tests::lenient_open_terminates_on_cyclic_difat_chain`
+테스트로 재현. 헤더에 서로를 가리키는 DIFAT 섹터 2개를 배치하고
+`difat_sectors_count = u32::MAX` 로 설정한 뒤, `LenientCfbReader::open` 호출을
+별도 스레드에서 실행해 3초 타임아웃 내 반환하는지 확인한다.
+
+- 수정 전: 3초 타임아웃 내 반환하지 못해 테스트 실패(RED, `cargo test` 로 확인).
+- 수정 후: 방문 집합에 의해 즉시(0.06초 이내) 순환을 감지해 종료(GREEN).
+
+## 수정
+
+DIFAT 확장 섹터 순회 루프에 `HashSet<u32>` 방문 집합을 추가했다. 이미 방문한
+섹터 ID 로 돌아오면 즉시 순회를 중단한다. FAT/미니FAT 체인 순회에 이미 있던
+동일한 패턴(`read_chain_static`)을 DIFAT 순회에도 적용한 것이라 별도 개념 도입이
+아니다.
+
+변경 파일: `src/parser/cfb_reader.rs` (DIFAT 확장 섹터 순회 루프, 순회 로직
+약 6줄 추가) + 회귀 테스트 1건 추가.
+
+## 검증
+
+```
+RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::cfb_reader
+# test result: ok. 9 passed; 0 failed
+
+RUSTFLAGS="-C linker=rust-lld" cargo test --lib parser::
+# test result: ok. 427 passed; 0 failed
+```
+
+기존 CFB 관련 테스트(헤더 필드 검증, 손상된 디렉터리 엔트리 name_len 등)와
+전체 `parser` 모듈 테스트 모두 회귀 없이 통과.
+
+## 영향 범위
+
+`LenientCfbReader::open` 은 `parser/mod.rs` 에서 표준 `cfb` 크레이트 파서가
+실패한 뒤 fallback 으로만 호출되므로, 이번 수정은 이미 손상이 확인된 입력
+경로에만 영향을 준다. 정상 CFB 파일의 파싱 결과에는 영향이 없다.

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -394,7 +394,14 @@ impl LenientCfbReader {
         // 추가 DIFAT 섹터 체인
         if difat_sectors_count > 0 && first_difat_sector != Self::END_OF_CHAIN {
             let mut dsid = first_difat_sector;
+            // difat_sectors_count 는 파일 헤더에서 그대로 읽은 값(공격자 통제 가능)이라,
+            // 실제 섹터 체인이 짧은 순환을 이뤄도 최대 u32::MAX 번 순회할 수 있다.
+            // FAT/미니FAT 체인 순회(read_chain_static)처럼 방문 집합으로 순환을 조기 차단한다.
+            let mut visited_difat = std::collections::HashSet::new();
             for _ in 0..difat_sectors_count {
+                if !visited_difat.insert(dsid) {
+                    break;
+                }
                 let off = 512 + dsid as usize * sector_size;
                 if off + sector_size > data.len() {
                     break;
@@ -814,6 +821,48 @@ mod tests {
 
         let r = LenientCfbReader::open(&d);
         assert!(r.is_ok(), "손상된 name_len 에서 패닉 없이 열려야 함");
+    }
+
+    #[test]
+    fn lenient_open_terminates_on_cyclic_difat_chain() {
+        // DIFAT 확장 체인은 header 의 difat_sectors_count(공격자 통제 가능한 4바이트) 만큼
+        // 순회하되, FAT 체인 순회(read_chain_static)와 달리 방문 집합이 없다. 두 DIFAT
+        // 섹터가 서로를 가리키는 순환을 만들고 difat_sectors_count 를 u32::MAX 로 두면,
+        // 실제 체인 길이(2)와 무관하게 최대 40억 회 넘게 순회해 사실상 멈추지 않는다 —
+        // 단일 스레드 WASM 에서는 탭 전체가 응답 없음 상태가 된다.
+        let mut d = minimal_header();
+        d[44..48].copy_from_slice(&0u32.to_le_bytes()); // fat_sectors_count = 0
+        d[68..72].copy_from_slice(&0u32.to_le_bytes()); // first_difat_sector = 섹터 0
+        d[72..76].copy_from_slice(&u32::MAX.to_le_bytes()); // difat_sectors_count: 공격자 제어
+
+        // 헤더(512B) 뒤에 DIFAT 섹터 2개(섹터 0, 섹터 1)를 배치.
+        d.resize(512 + 512 * 2, 0);
+        let entries_per = 512 / 4 - 1; // 127
+        // 모든 FAT-포인터 엔트리는 FREE_SECT 로 채워 fat_sector_ids 가 자라지 않게 한다
+        // (순환 자체와 무관한 메모리 팽창을 피하기 위함).
+        for sector_idx in 0..2usize {
+            let base = 512 + sector_idx * 512;
+            for i in 0..entries_per {
+                let eoff = base + i * 4;
+                d[eoff..eoff + 4].copy_from_slice(&0xFFFF_FFFFu32.to_le_bytes());
+            }
+        }
+        // 섹터 0 의 "다음 DIFAT" 포인터 = 섹터 1
+        let next0 = 512 + entries_per * 4;
+        d[next0..next0 + 4].copy_from_slice(&1u32.to_le_bytes());
+        // 섹터 1 의 "다음 DIFAT" 포인터 = 섹터 0 (순환!)
+        let next1 = 512 + 512 + entries_per * 4;
+        d[next1..next1 + 4].copy_from_slice(&0u32.to_le_bytes());
+
+        let (tx, rx) = std::sync::mpsc::channel();
+        std::thread::spawn(move || {
+            let _ = LenientCfbReader::open(&d);
+            let _ = tx.send(());
+        });
+        assert!(
+            rx.recv_timeout(std::time::Duration::from_secs(3)).is_ok(),
+            "순환 DIFAT 체인에서 방문 집합 없이 difat_sectors_count 만큼 순회해 반환하지 않음"
+        );
     }
 
     #[test]

--- a/src/parser/cfb_reader.rs
+++ b/src/parser/cfb_reader.rs
@@ -838,8 +838,8 @@ mod tests {
         // 헤더(512B) 뒤에 DIFAT 섹터 2개(섹터 0, 섹터 1)를 배치.
         d.resize(512 + 512 * 2, 0);
         let entries_per = 512 / 4 - 1; // 127
-        // 모든 FAT-포인터 엔트리는 FREE_SECT 로 채워 fat_sector_ids 가 자라지 않게 한다
-        // (순환 자체와 무관한 메모리 팽창을 피하기 위함).
+                                       // 모든 FAT-포인터 엔트리는 FREE_SECT 로 채워 fat_sector_ids 가 자라지 않게 한다
+                                       // (순환 자체와 무관한 메모리 팽창을 피하기 위함).
         for sector_idx in 0..2usize {
             let base = 512 + sector_idx * 512;
             for i in 0..entries_per {

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1084,7 +1084,12 @@ fn parse_polygon_shape_data(data: &[u8], poly: &mut PolygonShape) {
 /// hwplib: INT32 count + (INT32 x, INT32 y) × count + BYTE[count-1] segment_types + skip(4)
 fn parse_curve_shape_data(data: &[u8], curve: &mut CurveShape) {
     let mut r = ByteReader::new(data);
-    let cnt = r.read_i32().unwrap_or(0) as usize;
+    // count(INT32)는 파일에서 온 부호 있는 값이다. 음수(예: -1 = 0xFFFFFFFF)를
+    // 검증 없이 `as usize` 로 캐스팅하면 부호 확장으로 usize::MAX 근처의 거대한
+    // 값이 되어 아래 루프가 사실상 종료되지 않는(수십억 회) DoS 를 유발한다.
+    // 캐스팅 전에 음수를 0(빈 곡선)으로 처리한다. (#3012 다각형과 동일 클래스)
+    let cnt_raw = r.read_i32().unwrap_or(0);
+    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
     curve.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1169,6 +1174,29 @@ mod task195_tests {
             poly.points.is_empty(),
             "음수 count는 빈 점 목록으로 처리되어야 함: {}",
             poly.points.len()
+        );
+    }
+
+    #[test]
+    fn curve_point_count_negative_is_treated_as_zero() {
+        // count(INT32)에 음수(-1 = 0xFFFFFFFF)를 넣으면 as usize 부호확장으로
+        // usize::MAX 근처의 거대한 값이 되어 `for _ in 0..cnt` 및
+        // `for _ in 0..(cnt - 1)` 루프가 사실상 종료되지 않는(수십억 회) DoS 를
+        // 유발한다. 음수 count 는 빈 곡선으로 처리되어야 한다. (#3012 다각형과 동일 클래스)
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_le_bytes()); // count (악성)
+
+        let mut curve = CurveShape::default();
+        parse_curve_shape_data(&data, &mut curve);
+        assert!(
+            curve.points.is_empty(),
+            "음수 count는 빈 점 목록으로 처리되어야 함: {}",
+            curve.points.len()
+        );
+        assert!(
+            curve.segment_types.is_empty(),
+            "음수 count는 빈 세그먼트 목록으로 처리되어야 함: {}",
+            curve.segment_types.len()
         );
     }
 

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1011,7 +1011,10 @@ fn parse_line_shape_data(data: &[u8], line: &mut LineShape, is_connector: bool) 
         });
     } else {
         // 일반 선
-        line.started_right_or_bottom = r.read_i32().unwrap_or(0) != 0;
+        // hwp5 스펙 표92: 속성 필드는 UINT16(2바이트). 선 개체 속성 전체 길이가
+        // 18바이트(4+4+4+4+2)로 명시되어 있는데 기존에는 INT32(4바이트)로 읽어
+        // 남은 2바이트로는 항상 실패해 unwrap_or(0)으로 값이 소실되고 있었다.
+        line.started_right_or_bottom = r.read_u16().unwrap_or(0) != 0;
     }
 }
 
@@ -1106,6 +1109,25 @@ fn parse_curve_shape_data(data: &[u8], curve: &mut CurveShape) {
 #[cfg(test)]
 mod task195_tests {
     use super::*;
+
+    #[test]
+    fn line_started_right_or_bottom_parsed_from_18byte_record() {
+        // hwp5 스펙 표92: 선 개체 속성은 4+4+4+4+2=18바이트이며 마지막 필드는
+        // UINT16. 18바이트만 주어져도 플래그(1)가 정확히 읽혀야 한다.
+        let mut data = Vec::new();
+        data.extend_from_slice(&0i32.to_le_bytes()); // start.x
+        data.extend_from_slice(&0i32.to_le_bytes()); // start.y
+        data.extend_from_slice(&0i32.to_le_bytes()); // end.x
+        data.extend_from_slice(&0i32.to_le_bytes()); // end.y
+        data.extend_from_slice(&1u16.to_le_bytes()); // 속성(방향 보정 플래그)
+
+        let mut line = LineShape::default();
+        parse_line_shape_data(&data, &mut line, false);
+        assert!(
+            line.started_right_or_bottom,
+            "18바이트 레코드에서 UINT16 플래그가 true 로 읽혀야 함"
+        );
+    }
 
     #[test]
     fn connector_control_point_count_is_bounded_by_remaining() {

--- a/src/parser/control/shape.rs
+++ b/src/parser/control/shape.rs
@@ -1062,7 +1062,8 @@ fn parse_arc_shape_data(data: &[u8], arc: &mut ArcShape) {
 /// hwplib: INT32 count + (INT32 x, INT32 y) × count + skip(4)
 fn parse_polygon_shape_data(data: &[u8], poly: &mut PolygonShape) {
     let mut r = ByteReader::new(data);
-    let cnt = r.read_i32().unwrap_or(0) as usize;
+    let cnt_raw = r.read_i32().unwrap_or(0);
+    let cnt = if cnt_raw < 0 { 0 } else { cnt_raw as usize };
     poly.points.clear();
     for _ in 0..cnt {
         let x = r.read_i32().unwrap_or(0);
@@ -1130,6 +1131,22 @@ mod task195_tests {
             connector.control_points.is_empty(),
             "남은 바이트가 없으므로 제어점은 비어야 함: {}",
             connector.control_points.len()
+        );
+    }
+
+    #[test]
+    fn polygon_point_count_negative_is_treated_as_zero() {
+        // count(INT32)에 음수(-1 = 0xFFFFFFFF)를 넣으면 as usize 부호확장으로
+        // 사실상 무한 루프에 빠지면 안 되고 빈 다각형으로 처리되어야 한다.
+        let mut data = Vec::new();
+        data.extend_from_slice(&(-1i32).to_le_bytes()); // count (악성)
+
+        let mut poly = PolygonShape::default();
+        parse_polygon_shape_data(&data, &mut poly);
+        assert!(
+            poly.points.is_empty(),
+            "음수 count는 빈 점 목록으로 처리되어야 함: {}",
+            poly.points.len()
         );
     }
 

--- a/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
+++ b/src/wmf/parser/objects/structure/bitmap_info_header/mod.rs
@@ -157,9 +157,12 @@ impl BitmapInfoHeader {
     pub fn height(&self) -> usize {
         match self {
             Self::Core(BitmapInfoHeaderCore { height, .. }) => usize::from(*height),
+            // A negative Height indicates a top-down DIB (MS-WMF 2.2.2.9);
+            // the pixel height is the magnitude, matching `size()`'s use of
+            // `unsigned_abs()` below.
             Self::Info(BitmapInfoHeaderInfo { height, .. })
             | Self::V4(BitmapInfoHeaderV4 { height, .. })
-            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => *height as usize,
+            | Self::V5(BitmapInfoHeaderV5 { height, .. }) => height.unsigned_abs() as usize,
         }
     }
 
@@ -170,5 +173,32 @@ impl BitmapInfoHeader {
             | Self::V4(BitmapInfoHeaderV4 { width, .. })
             | Self::V5(BitmapInfoHeaderV5 { width, .. }) => *width as usize,
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // MS-WMF 2.2.2.9: a negative Height indicates a top-down DIB; the
+    // absolute value is still the pixel height. `height()` must return the
+    // magnitude, matching what `size()` already does via `unsigned_abs()`.
+    #[test]
+    fn height_of_top_down_dib_is_absolute_value() {
+        let header = BitmapInfoHeader::Info(BitmapInfoHeaderInfo {
+            header_size: 40,
+            width: 10,
+            height: -10,
+            planes: 1,
+            bit_count: crate::wmf::parser::BitCount::BI_BITCOUNT_5,
+            compression: crate::wmf::parser::Compression::BI_RGB,
+            image_size: 0,
+            x_pels_per_meter: 0,
+            y_pels_per_meter: 0,
+            color_used: 0,
+            color_important: 0,
+        });
+
+        assert_eq!(header.height(), 10);
     }
 }

--- a/src/wmf/parser/records/mod.rs
+++ b/src/wmf/parser/records/mod.rs
@@ -84,7 +84,7 @@ impl core::fmt::Debug for RecordSize {
 
 impl RecordSize {
     pub fn byte_count(&self) -> usize {
-        (self.0 * 2) as usize
+        self.0 as usize * 2
     }
 
     pub fn word_size(&self) -> usize {
@@ -104,6 +104,41 @@ impl RecordSize {
     }
 
     pub fn remaining_bytes(&self) -> usize {
-        self.byte_count() - self.1
+        self.byte_count().saturating_sub(self.1)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RecordSize;
+
+    /// 악의적 WMF는 RecordSize(WORD 개수)를 실제 고정 필드보다 작게 선언할 수 있다.
+    /// 이때 `remaining_bytes()`의 `byte_count() - self.1`이 usize 언더플로를 일으켜
+    /// 디버그 빌드에서 "attempt to subtract with overflow" 패닉,
+    /// 릴리스 빌드에서 거대한 값이 `read_variable`의 `Vec::with_capacity`로 전달되어
+    /// 할당 패닉/OOM을 유발한다. 수정 후에는 0으로 포화되어 패닉하지 않아야 한다.
+    #[test]
+    fn remaining_bytes_does_not_underflow_when_consumed_exceeds_declared_size() {
+        // word_size = 2 → byte_count = 4 바이트.
+        let mut record_size = RecordSize::from(2u32);
+        // record_function(2) + 고정 필드(4) = 6 바이트 소비 (선언된 4 초과).
+        record_size.consume(6);
+
+        assert_eq!(
+            record_size.remaining_bytes(),
+            0,
+            "consumed가 byte_count를 초과하면 남은 바이트는 0으로 포화되어야 한다"
+        );
+        assert!(!record_size.remaining());
+    }
+
+    /// RecordSize(u32) 값이 매우 크면 `byte_count()`의 `self.0 * 2`가
+    /// u32 산술에서 오버플로되어 디버그 빌드에서 패닉한다.
+    /// 수정 후에는 usize 산술로 계산되어 패닉하지 않아야 한다.
+    #[test]
+    fn byte_count_does_not_overflow_on_large_word_size() {
+        let record_size = RecordSize::from(0x8000_0000u32);
+
+        assert_eq!(record_size.byte_count(), 0x1_0000_0000usize);
     }
 }


### PR DESCRIPTION
kevin9327 님의 파서 견고성 축 6건을 메인테이너가 재실증 후 통합한다. 악성/손상 입력에 대한 무한루프·과대할당·언더플로 방어 계열이다.

## 채택 6건

| PR | 결함 |
|---|---|
| #3093 (`Closes #3012`) | 다각형 point count(i32) 음수 부호확장 → `0..cnt` 무한루프 DoS |
| #3157 (`Closes #3156`) | 곡선 도형 동일 클래스 — points + segment_types 이중 루프 |
| #3102 | 선 개체 방향 보정 플래그를 UINT16 으로 정확히 파싱 (종전 오독) |
| #3163 | WMF RecordSize 산술 미검증 — byte_count 곱셈 오버플로·remaining 언더플로 방어 |
| #3176 (`Closes #3174`) | WMF top-down DIB(음수 height) 부호 언더플로 |
| #3182 (`Closes #3181`) | CFB DIFAT 확장 섹터 체인 순환 감지 누락 — 조작 파일로 무한루프 DoS |

## 충돌 흡수

#3157 1건 — 같은 배치의 #3093(다각형)과 테스트 자리 병치. 두 테스트 모두 유지.

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 신규 방어 테스트 전건 표적 통과

Co-authored-by 로 원 커밋 provenance 를 보존한다.
