### PR TITLE
fix: hwpx 왕복·변환·hml·직렬화·CLI 소형 10건 — kevin9327 축배치 L

### DIFF
--- a/mydocs/report/task_m100_2767_report.md
+++ b/mydocs/report/task_m100_2767_report.md
@@ -1,0 +1,103 @@
+# #2767 처리 결과 — HWPX→HWP 그림 캡션 attr 비트 + BinData remap 잔여 수정
+
+## 사전 확인 — devel 은 이미 일부를 포함하고 있었다
+
+작업 시작 시 `origin/devel`을 다시 fetch해 확인한 결과, 이슈 본문이 결함 B로
+지목한 것 중 **`Control::Picture`의 캡션 remap과 `Control::Table`의 캡션 remap은
+이미 devel에 존재**했다(주석에 `[#2736]` 태그, `table_caption_picture_bin_ref_is_remapped`·
+`picture_caption_picture_bin_ref_is_remapped` 테스트도 이미 있음). 이슈가 미리
+고지한 병행 PR #2749(같은 파일)는 `gh pr view 2749`로 **CLOSED, mergedAt: null**
+(미머지)임을 확인했으므로, 이 부분은 #2749가 아닌 다른 경로로 이미 devel에
+반영된 것으로 보인다.
+
+실제로 남아 있던 것만 수정 범위로 좁혔다:
+
+- **결함 A** (전부 미해결) — 그림 CTRL_HEADER의 캡션 attr 비트(bit 29)
+- **결함 B 잔여** — `remap_bin_refs_in_control`의 `Control::HiddenComment` arm 부재,
+  `remap_bin_refs_in_shape`의 `ShapeObject::Picture`(그룹 내부 그림) 캡션 미재귀
+  (`ShapeObject::Picture`는 `drawing_mut()`이 항상 `None`이라 공통 caption remap
+  경로를 타지 않음 — 모델상 `DrawingObjAttr`를 갖지 않고 `Picture` 자신의
+  `caption` 필드를 직접 가짐)
+
+## 수정
+
+`src/document_core/converters/hwpx_to_hwp.rs` 한 파일:
+
+1. **결함 A**: `materialize_picture_caption_common_attr()` 신설 — 그림에 캡션이
+   있고 bit29가 아직 꺼져 있으면 **OR**(recompute 아님)한다. 표처럼
+   `pack_common_attr_bits(...)`로 재계산하면 표 전용 비트를 그림에 강제로 얹는
+   회귀가 되므로, HWPX 파서가 이미 채운 `common.attr`에 비트만 얹는다.
+   `adapt_paragraph_with_context`의 `Control::Picture` arm에서 캡션 문단 보강
+   직후 호출. `AdapterReport`에 `picture_caption_common_attr_materialized`
+   카운터 추가 + `changed_anything()` 합산.
+2. **결함 B 잔여**: `remap_bin_refs_in_control`에 `Control::HiddenComment` arm
+   추가(adapt 워크·border-fill 워크는 이미 #2467 근거로 처리 중이던 것과 동형).
+   `remap_bin_refs_in_shape`의 `ShapeObject::Picture` arm에 `pic.caption` 재귀
+   추가(그룹 내부 그림 캡션).
+
+이슈 §A-6에 따라 도형(`$rec`)·OLE·연결선 캡션의 attr 비트는 설정하지 않았다 —
+`serializer/control.rs`가 도형 캡션 레코드 자체를 아직 출력하지 않아 자기모순
+레코드가 되기 때문(별도 후속 과제).
+
+## 테스트 (red → green)
+
+기존 `mod tests`에 4건 추가:
+
+- `picture_caption_common_attr_bit_is_or_ed_in_when_caption_present` — 캡션이 있는
+  그림의 `common.attr`가 `0x042A_2211` → `0x242A_2211`로 OR됨을 단언 + 멱등성 확인
+- `picture_caption_common_attr_bit_untouched_without_caption` — 캡션이 없으면
+  비트를 건드리지 않음(거짓양성 방지)
+- `hidden_comment_picture_bin_ref_is_remapped` — 숨은설명 안 그림의 `bin_data_id`가
+  remap을 반영함
+- `grouped_picture_caption_bin_ref_is_remapped` — 그룹 내부 그림(`ShapeObject::Picture`)
+  캡션 안 그림의 `bin_data_id`가 remap을 반영함
+
+수정 전 코드(4곳의 fix 부분만 되돌린 상태)로 실행한 결과:
+
+```
+failures:
+    document_core::converters::hwpx_to_hwp::tests::grouped_picture_caption_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::hidden_comment_picture_bin_ref_is_remapped
+    document_core::converters::hwpx_to_hwp::tests::picture_caption_common_attr_bit_is_or_ed_in_when_caption_present
+
+test result: FAILED. 42 passed; 3 failed; 0 ignored; 0 measured; 2481 filtered out
+```
+
+(`picture_caption_common_attr_bit_untouched_without_caption`는 대조군이라 수정과
+무관하게 항상 통과 — 의도된 결과.)
+
+수정 적용 후 재실행:
+
+```
+running 45 tests
+...
+test result: ok. 45 passed; 0 failed; 0 ignored; 0 measured; 2481 filtered out; finished in 2.84s
+```
+
+red → green을 로컬에서 직접 확인했다.
+
+## 검증 (디스크 제약으로 경량 검증만 수행)
+
+- `cargo check --lib` 통과
+- 신설 테스트 4건 포함 `document_core::converters::hwpx_to_hwp::tests` 모듈 전체
+  (45건) `cargo test --lib`로 실행, 전부 통과(red 확인 1회 + green 확인 2회)
+- 전체 `cargo test`, `cargo build --lib`, `cargo clippy --profile release-test`는
+  로컬 디스크 여유 공간 제약(빌드 중 완전 소진 1회 발생 — `target/debug/incremental`
+  삭제로 복구)으로 스킵
+- `rustfmt --edition 2021` 적용, `git diff --name-only`로 의도한 파일만 변경됨을
+  확인
+- 이슈 §A-5/§B-3이 제안한 실파일 회귀(`samples/hwp3-sample14-hwp5.hwpx` gso attr
+  비교, "OLE storage 재정렬 + 숨은설명/그림캡션" 동시 보유 실파일)는 재확인하지
+  않았다 — 이슈 §B-3이 그런 조합 문서가 샘플에 없다고 명시하고 있어, 단위 테스트가
+  현재 유일하게 재현 가능한 방법이다.
+
+## 범위 밖
+
+- 도형(`$rec`)·OLE·연결선 캡션의 attr 비트 설정(§A-6) — `serializer/control.rs`
+  소관의 별개 상위 결함
+- collect 측(`collect_bin_order_from_control`)의 HiddenComment 미방문(§B-2) —
+  fallback으로 이미 전단사가 보장되어 결함이 아님(이슈 본문 판정)
+
+## 변경 파일
+
+- `src/document_core/converters/hwpx_to_hwp.rs`

--- a/mydocs/report/task_m100_2948_report.md
+++ b/mydocs/report/task_m100_2948_report.md
@@ -1,0 +1,69 @@
+# 완료 보고서 — Task M100-2948
+
+- 이슈: #2948
+- 제목: HWPX `<hp:tc dirty>` 셀 속성이 항상 0으로 하드코딩되어 라운드트립 소실
+- 작성일: 2026-07-22
+- 브랜치: `task/m100-2948-tc-dirty`
+
+## 0. 작업 재개 메모 (디스크 공간 이슈)
+
+이번 세션 시작 시 디스크 공간이 임계 수준으로 부족한 상태였다. 사용자가 여유 공간을
+54GB+ 확보하고 `target/*/incremental` 및 오래된 `deps` 산출물을 정리한 뒤 작업을
+재개했다. 정리 후 `cargo check --lib` 은 링커 오류 없이 정상 동작했다 — 이번 작업에서
+`LNK1123`/`CVT1107`/`dbghelp.lib` 류의 Windows SDK 링커 손상은 재현되지 않았다.
+
+## 1. 완료 내용
+
+HWPX 표 셀(`<hp:tc>`)의 `dirty` 속성(편집기 캐시 무효화 표시 플래그)이 파서에서
+아예 읽히지 않고, 직렬화기에서는 값과 무관하게 항상 `dirty="0"` 으로 하드코딩되어
+방출되던 문제를 수정했다. "parsed but hardcoded" 계열(lock, reverse, dropCapStyle,
+groupLevel, numberingType, fieldid 등)에 속하는 반복 패턴이다.
+
+## 2. 주요 변경
+
+- `src/model/table.rs`
+  - `Cell` 구조체에 `pub dirty_flag: bool` 필드 추가.
+  - 템플릿 기반 신규 셀 생성 경로(`Cell::from_template` 계열)는 `dirty_flag: false` 로
+    초기화 — dirty는 편집기 캐시 상태이므로 템플릿에서 상속하지 않음.
+- `src/parser/hwpx/section.rs`
+  - `parse_table_cell` 에 `b"dirty" => cell.dirty_flag = parse_bool(&attr),` 추가.
+- `src/serializer/hwpx/table.rs`
+  - `write_cell` 에서 하드코딩된 `("dirty", "0")` 을 `("dirty", dirty)`
+    (`dirty = bool01(cell.dirty_flag)`) 로 교체.
+- `src/diagnostics/ir_field_sweep.rs`
+  - `sweep_cell` 의 `Cell` 전수 구조 분해(`..` 없이 모든 필드 나열)에 새 필드
+    `dirty_flag` 를 추가하고 `f!(dirty_flag);` 비교 호출을 추가. (devel 최신본과 병합
+    과정에서 이 파일이 새 필드를 인식하지 못해 컴파일이 깨졌던 부분을 별도 커밋으로 수정.)
+
+## 3. red→green 테스트
+
+`src/serializer/hwpx/table.rs::tests`
+
+- `tc_dirty_flag_preserved_when_set` — `dirty_flag=true` 인 셀이 `dirty="1"` 로
+  직렬화되는지 확인 (수정 전에는 항상 `dirty="0"` 하드코딩이라 실패).
+- `tc_dirty_flag_zero_when_unset` — 기본값(false)에서는 기존 동작대로 `dirty="0"`
+  유지 확인.
+
+## 4. 검증 결과
+
+통과:
+
+- `cargo check --lib`
+- `cargo test --lib tc_dirty_flag` — 2 passed
+- `rustfmt --edition 2021` (변경 4개 파일: `src/model/table.rs`,
+  `src/parser/hwpx/section.rs`, `src/serializer/hwpx/table.rs`,
+  `src/diagnostics/ir_field_sweep.rs`) — 포맷 위반 없음
+
+## 5. 특이사항
+
+- `origin/devel` 에 브랜치를 새로 딴 뒤 기존 커밋을 cherry-pick 하는 과정에서
+  `src/serializer/hwpx/table.rs` 테스트 삽입 지점에서 다른 병렬 작업(`allowOverlap`
+  보존 테스트, PR 이력상 이미 devel에 병합됨)과 충돌이 발생했다. 두 테스트 블록을
+  모두 보존하는 방식으로 수동 해결했다.
+- 동일하게 devel 최신본에서 `src/diagnostics/ir_field_sweep.rs::sweep_cell` 이
+  `Cell` 을 `..` 없이 전수 구조 분해하는 방어적 패턴을 쓰고 있어, 새 필드 추가만으로
+  컴파일이 깨졌다. 해당 파일에 `dirty_flag` 를 반영하는 후속 커밋으로 수정했다.
+
+## 6. 결론
+
+Task M100-2948 구현과 검증을 완료했다. PR 생성 대기 상태다.

--- a/mydocs/report/task_m100_3143_report.md
+++ b/mydocs/report/task_m100_3143_report.md
@@ -1,0 +1,49 @@
+# task-m100-3143: 글자겹침(tcps) 직렬화 미검증 캐스팅 방어
+
+## 이슈
+
+#3143 HWP5 글자겹침(CTRL_TCPS) 직렬화기의 미검증 캐스팅 2건:
+
+1. **비BMP 문자 절단** — `ch as u16` 캐스팅으로 하위 16비트만 기록.
+   파서(`parse_char_overlap`)는 서로게이트 쌍을 디코딩하므로 왕복이 깨진다.
+2. **u8 카운트 wraparound** — charshape ID 카운트를 `len() as u8` 로 기록.
+   HWPX `<hp:compose>` 는 `<hp:charPr>` 자식 수 제한이 없어 256개 이상 입력 시
+   카운트 필드(256→0)와 실제 기록 데이터가 어긋난 손상 레코드가 만들어진다.
+
+## 원인 분석
+
+`src/serializer/control.rs` `serialize_char_overlap`:
+
+- chars 를 `ch as u16` 으로 단순 캐스팅 → U+10000 이상에서 절단.
+- 카운트 필드(u16/u8)에 상한 검사 없음 → wraparound 시 카운트-데이터 불일치.
+
+## 수정 내용
+
+- chars 를 `encode_utf16()` 으로 서로게이트 쌍 포함 인코딩 (파서와 대칭).
+- 카운트 필드(u16/u8)를 타입 한계로 상한 절단하고, 기록 배열도 함께 절단해
+  카운트와 실제 기록 데이터가 항상 일치하도록 방어 (손상 레코드 방지).
+
+## red→green 결과
+
+회귀 테스트 2건 추가 (`src/serializer/control/tests.rs`), 수정 전 FAIL 확인:
+
+- `char_overlap_non_bmp_char_roundtrip` — U+1D400(𝐀) 왕복 시
+  (수정 전: `비BMP 문자가 왕복 보존되어야 함` assert 실패 — 하위 16비트 문자로 변형)
+- `char_overlap_256_char_shape_ids_no_wraparound` — ID 256개 입력 시
+  (수정 전: `카운트 필드(0)와 실제 기록된 ID 바이트(1024)가 어긋남 — u8 wraparound`)
+
+수정 후 2건 전부 PASS.
+
+## 검증 명령
+
+```
+cargo test char_overlap
+```
+
+전량 PASS. `cargo fmt --check` 통과(후속 style 커밋 `5527c211` 로 정렬).
+
+## 관련 코드
+
+- `src/serializer/control.rs` — encode_utf16 인코딩·카운트 상한 절단 (+32/-4)
+- `src/serializer/control/tests.rs` — 회귀 테스트 2건 (+59)
+- 기준 커밋: upstream/devel `6f34e9b2`

--- a/mydocs/report/task_m100_3146_report.md
+++ b/mydocs/report/task_m100_3146_report.md
@@ -1,0 +1,60 @@
+# task-m100-3146: HML CHARSHAPE/PARASHAPE 자식 요소 last_mut 귀속 결함 수정
+
+## 이슈
+
+#3146 HML 파서에서 CHARSHAPE/PARASHAPE 본체는 `Id` 속성 위치에 배치(set_indexed)되는데,
+자식 요소(FONTID/RATIO/CHARSPACING/RELSIZE/CHAROFFSET, PARAMARGIN/PARABORDER)는
+`last_mut()` 로 "마지막 원소"에 귀속된다. 두 배치 기준이 어긋나 있어:
+
+1. `Id` 가 내림차순(비순차)으로 들어오면 자식 값이 엉뚱한 도형을 덮어쓰고,
+   원래 도형은 기본값(`[0; 7]` 장평 등)으로 방치된다.
+2. #2743 이 도입한 리소스 Id 상한 초과 건너뜀 경로에서는, 건너뛴 도형의 자식이
+   직전 정상 도형을 오염시킨다 — BORDERFILL 에는 있는 "자식 폐기" 처리가
+   CHARSHAPE/PARASHAPE 에는 빠져 있었다.
+
+## 원인 분석
+
+`src/parser/hml/reader.rs`:
+
+- CHARSHAPE/PARASHAPE 시작 태그: `set_indexed(id, ...)` 로 Id 위치에 삽입.
+- 자식 요소(RATIO 등): `char_shapes.last_mut()` / `para_shapes.last_mut()` 로 귀속.
+- `set_indexed` 는 Id 가 현재 길이보다 작으면 기존 슬롯을 교체하므로,
+  Id 내림차순 입력에서 "마지막 원소"와 "방금 삽입한 원소"가 달라진다.
+- 상한 초과 건너뜀 시에도 `last_mut()` 는 직전 정상 도형을 가리켜 오염이 발생한다.
+  (BORDERFILL 은 `current_border_fill: Option<usize>` 로 이미 방어하고 있었다.)
+
+## 수정 내용
+
+BORDERFILL 의 `current_border_fill` 패턴과 동일하게:
+
+- `current_char_shape: Option<usize>` / `current_para_shape: Option<usize>` 필드 추가.
+- CHARSHAPE/PARASHAPE 시작 시 삽입 인덱스를 기록, 상한 초과 건너뜀 시 `None`.
+- 자식 요소는 `last_mut()` 대신 기록된 인덱스로 귀속, `None` 이면 폐기.
+- 요소 종료 시 인덱스 해제.
+
+## red→green 결과
+
+재현 테스트 3건 추가 (`tests/issue_hml_shape_child_attribution.rs`), 수정 전 전부 FAIL 확인:
+
+- `charshape_children_follow_out_of_order_ids` — Id=1,0 순 입력에서 RATIO 교차 오염
+  (수정 전: `Id=1 의 RATIO 는 90 이어야 한다` assert 실패, 실제 `[0; 7]`)
+- `skipped_charshape_children_do_not_pollute_previous_shape` — 상한 초과 건너뜀 도형의
+  RATIO 가 직전 도형 덮어씀 (수정 전: `[100; 7]` 기대, 실제 `[10; 7]`)
+- `parashape_margin_follows_out_of_order_ids` — PARAMARGIN 교차 오염
+  (수정 전: `Id=1 의 PARAMARGIN Left` 700 기대, 실제 0)
+
+수정 후 3건 전부 PASS.
+
+## 검증 명령
+
+```
+cargo test --test issue_hml_shape_child_attribution
+```
+
+3 passed. 기존 HML 파서 테스트 회귀 없음 (`cargo test hml`).
+
+## 관련 코드
+
+- `src/parser/hml/reader.rs` — 귀속 인덱스 추적 (+34/-3)
+- `tests/issue_hml_shape_child_attribution.rs` — 재현 테스트 3건 (신규)
+- 기준 커밋: upstream/devel `49469c1f`

--- a/mydocs/report/task_m100_3161_report.md
+++ b/mydocs/report/task_m100_3161_report.md
@@ -1,0 +1,44 @@
+# 완료 보고서 — Task M100-3161
+
+- 이슈: #3161
+- 제목: HWPX→HWP5 변환: 표 CTRL_HEADER "표 번호" 비트(0x0800_0000)가 numberingType 과 무관하게 무조건 설정
+- 작성일: 2026-07-23
+- 브랜치: `fix/3161-table-numbering-bit-gate`
+
+## 1. 문제
+
+HWPX→HWP5 변환 어댑터 `materialize_table_ctrl_header_attr()`
+(`src/document_core/converters/hwpx_to_hwp.rs`)가 표 CTRL_HEADER attr 를 재합성할 때
+"표 번호" 범주 비트(`0x0800_0000`, bit 27)를 numberingType 과 무관하게 무조건 OR 했다.
+
+HWPX 파서는 #2697 에서 `materialize_hwpx_table_attrs`(`src/parser/hwpx/section.rs`)에
+`numbering_type == Table` 게이트를 걸어 IR 모순(`numbering_type=Picture ↔ attr=TABLE`)을
+제거했으나, HWP5 저장 경로의 변환 계층이 파서가 계산한 `common.attr` 를 무조건-OR 값으로
+덮어써 같은 모순을 저장 시점에 재도입했다. 결과적으로 `numberingType="PICTURE"`
+(그림 번호 캡션 표)·`"NONE"`(번호 제외 표)이 HWP5 저장 시 "표 번호" 범주로 바뀐다.
+
+## 2. 수정
+
+- `materialize_table_ctrl_header_attr()`: 파서(#2697)와 동일하게
+  `table.common.numbering_type == ObjectNumberingType::Table` 일 때만
+  `HWPX_TABLE_NUMBERING_BIT` 를 OR.
+- 기존 어댑터 테스트 픽스처 2건(`table_axis_materializes_hancom_record_contract`,
+  `captioned_table_materializes_hancom_caption_common_attr_bit`)에 실제 파서 기본값인
+  `numbering_type: Table` 을 명시 — 기대 상수(`0x082a_2311`/`0x282a_2311`) 유지.
+
+## 3. red → green
+
+`src/document_core/converters/hwpx_to_hwp.rs` tests 추가:
+
+| 테스트 | 수정 전 | 수정 후 |
+|---|---|---|
+| `picture_numbering_table_keeps_category_on_hwp_save` | FAIL (attr `0x080a2000`) | PASS |
+| `none_numbering_table_keeps_category_on_hwp_save` | FAIL | PASS |
+| `table_numbering_table_still_sets_numbering_bit` (회귀 가드) | PASS | PASS |
+
+## 4. 검증 결과
+
+- `cargo test --lib` — 2554 passed / 0 failed
+- `cargo test --test hwpx_to_hwp_adapter --test hwpx_roundtrip_baseline --test hwp5_roundtrip_baseline` — 전부 통과 (3 / 4 / 50 passed)
+- `cargo fmt --check` — CRLF newline-style 경고 외 잔여 없음
+- `cargo clippy --all-targets` — 신규 경고 없음 (기존 2건은 johab.rs/byte_writer.rs 무관 항목)

--- a/mydocs/report/task_m100_3169_report.md
+++ b/mydocs/report/task_m100_3169_report.md
@@ -1,0 +1,92 @@
+---
+kind: report
+status: final
+task: m100-3169
+issue: 3169
+---
+
+# Task #3169 처리 결과 — 진단 명령 6종 종료 코드 계약 확장
+
+## 1. 요약
+
+`#2707`(PR #2711)은 `export-*`/`convert`/`export-hwpx` 계열만 고쳤고, 자체 보고서
+§6.1(`mydocs/report/task_m100_2707_report.md:243-252`)에서 같은 결함이
+`info`, `dump`, `dump-note-shape`, `dump-endnote-lines`, `dump-pages`,
+`diag`, `build-from-ingest`, `dump-records`, `ir-diff`, `test-*`, `gen-*`,
+`rhwp::diagnostics::*::run` 계열에 남아 있다고 명시했다.
+
+이번 작업은 그중 사용자가 직접 호출하는 6개 명령 — `info`, `dump-note-shape`,
+`dump-endnote-lines`, `dump-pages`, `dump-records`, `build-from-ingest` — 에
+`#2707` 관례(`EXIT_OK`/`EXIT_RUNTIME`/`EXIT_USAGE`)를 그대로 확장했다.
+
+## 2. 재현 (수정 전)
+
+```
+$ ./target/debug/rhwp info nonexistent.hwp
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ... (os error 2)
+$ echo $?
+0
+```
+
+`dump-note-shape`, `dump-endnote-lines`, `dump-pages`, `dump-records`,
+`build-from-ingest` 모두 동일 — 인자 없음/파일 읽기 실패/파싱 실패/범위 초과
+경로 전부 종료 코드 0.
+
+`dump-pages` 는 `#2551` 로 인자 검증 로직(파싱 실패·범위 초과 감지)은 이미
+형제 명령과 정합되어 있었으나, 오류 감지 후 종료 코드 전파만 빠져 있었다 —
+`return;` 은 있었지만 이 함수가 `main` 의 `match` 에서 `exit_with(...)` 로
+감싸이지 않아 항상 프로세스 종료 코드 0으로 끝났다.
+
+## 3. 수정
+
+`src/main.rs`:
+
+- `show_info`, `dump_note_shape`, `dump_endnote_lines`, `dump_pages`,
+  `dump_raw_records`, `build_from_ingest` 시그니처를 `fn(&[String])` →
+  `fn(&[String]) -> i32` 로 변경.
+- 각 함수의 치명 경로(인자 없음/누락 → `EXIT_USAGE`, 파일 읽기·파싱·직렬화·저장
+  실패 → `EXIT_RUNTIME`, 페이지/섹션/문단/컨트롤 인덱스 범위 초과 →
+  `EXIT_USAGE`)에서 `return;` 대신 해당 상수를 반환하도록 수정.
+  성공 경로 끝에 `EXIT_OK` 추가.
+- `main()` 의 디스패치에서 이 6개 명령을 `exit_with(...)` 로 감쌈.
+
+3/4(`--verify`/`--verify-pages`)는 건드리지 않았다 — 해당 없음(이 6개 명령에는
+그 옵션이 없음).
+
+## 4. 검증
+
+```
+cargo build --bin rhwp
+cargo test --test cli_exit_codes                        # 기존 회귀, 통과
+cargo test --test cli_exit_codes_diagnostic_commands     # 신규 회귀
+cargo test --test dump_pages_cli                         # #2551 회귀, 통과
+cargo fmt --check -- src/main.rs tests/cli_exit_codes_diagnostic_commands.rs
+cargo clippy --bin rhwp --tests
+```
+
+신규 테스트 `tests/cli_exit_codes_diagnostic_commands.rs` (5개, 전부 통과):
+
+- `missing_arguments_report_usage_error` — 인자 없음 → 2
+- `unreadable_input_reports_runtime_failure` — 존재하지 않는 입력 → 1
+- `dump_pages_out_of_range_reports_usage_error` — 페이지 범위 초과 → 2
+- `build_from_ingest_missing_output_reports_usage_error` — `-o` 누락 → 2
+- `successful_diagnostic_commands_return_zero` — 성공 경로는 여전히 0
+  (회귀 방지; `dump-records` 는 HWP5 CFB 샘플 `samples/2010-01-06.hwp` 사용 —
+  HWP3 샘플은 CFB 컨테이너가 아니라 이 명령이 지원하지 않음)
+
+수정 후 실측:
+
+```
+$ ./target/release/rhwp info nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - ...
+1
+$ ./target/release/rhwp info samples/2010-01-06.hwp >/dev/null; echo $?
+0
+```
+
+## 5. 범위 밖 (잔여)
+
+`dump`(`dump_controls`, ~1200줄), `diag`(`diag_document`, ~530줄), `ir-diff`,
+`test-*`, `gen-*`, `rhwp::diagnostics::*::run` 계열은 함수 규모가 커
+별도 이슈로 남긴다 — `#2707` 도 동일한 이유(진단·개발 보조 명령, PR 위험 최소화)로
+같은 판단을 내렸다.

--- a/mydocs/report/task_m100_3178_report.md
+++ b/mydocs/report/task_m100_3178_report.md
@@ -1,0 +1,101 @@
+---
+kind: report
+status: done
+last_verified: 2026-07-23
+---
+
+# task_m100_3178_report
+
+Issue: #3178
+
+## 요약
+
+`#2707`(PR #2711)·`#3169`(PR #3171)이 명시적으로 범위 밖에 남긴 `dump`(dump_controls)·
+`diag`(diag_document) 두 명령에도 동일 클래스의 종료 코드 미전파 버그가 있음을 실측으로
+확인하고, 동일 계약(EXIT_OK/EXIT_RUNTIME/EXIT_USAGE)으로 최소 수정했다.
+
+## 재현 (수정 전)
+
+```
+$ rhwp dump nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ...
+0
+
+$ rhwp diag nonexistent.hwp; echo $?
+오류: 파일을 읽을 수 없습니다 - nonexistent.hwp: ...
+0
+
+$ rhwp dump; echo $?      # 인자 없음
+0
+
+$ rhwp diag; echo $?      # 인자 없음
+0
+```
+
+## 원인
+
+`dump_controls`(src/main.rs, ~1200줄)·`diag_document`(~530줄) 모두 `fn(&[String])`
+(반환값 없음) 시그니처였고, 세 오류 경로(인자 없음/파일 읽기 실패/파싱 실패) 각각
+`eprintln!` 후 `return;`으로 끝났다. `main()` 디스패치도 `exit_with(...)`로 감싸지
+않고 직접 호출했다.
+
+몸통 크기와 무관하게 오류 반환 지점은 각 함수당 3곳뿐이라 계약 적용 자체는 국소적이었다.
+
+## 수정
+
+- `dump_controls`, `diag_document`: `fn(&[String])` → `fn(&[String]) -> i32`.
+  - 인자 없음 → `EXIT_USAGE`
+  - 파일 읽기 실패 / 문서 파싱 실패 → `EXIT_RUNTIME`
+  - 정상 종료 → `EXIT_OK`
+- `main()` 디스패치의 `"dump"`·`"diag"` 분기를 `exit_with(...)`로 감쌈.
+- `tests/cli_exit_codes_dump_diag.rs` 신규 — 인자 없음/읽기 실패/파싱 실패/성공 경로 4개 테스트.
+
+## 검증
+
+```
+RUSTFLAGS="-C linker=rust-lld" cargo build --bin rhwp
+RUSTFLAGS="-C linker=rust-lld" cargo test --test cli_exit_codes_dump_diag   # 신규 4개, 통과
+RUSTFLAGS="-C linker=rust-lld" cargo test --test cli_exit_codes             # 기존 10개 회귀, 통과
+cargo fmt --check -- src/main.rs tests/cli_exit_codes_dump_diag.rs         # 변경 파일 포맷 이슈 없음
+                                                                             # (기존 examples/ 의 CRLF 경고는
+                                                                             #  본 변경과 무관한 사전 존재 이슈)
+RUSTFLAGS="-C linker=rust-lld" cargo clippy --bin rhwp --tests             # 신규 경고 없음
+                                                                             # (johab.rs/byte_writer.rs 사전 존재
+                                                                             #  경고 2건은 본 변경과 무관)
+```
+
+수정 전/후 실측:
+
+```
+$ rhwp dump nonexistent.hwp; echo $?
+...
+1   → (수정 전 0)
+
+$ rhwp diag nonexistent.hwp; echo $?
+...
+1   → (수정 전 0)
+
+$ rhwp dump; echo $?
+...
+2   → (수정 전 0)
+
+$ rhwp diag; echo $?
+...
+2   → (수정 전 0)
+```
+
+성공 경로 회귀 확인 (samples/hwp3-sample.hwp):
+
+```
+$ rhwp dump samples/hwp3-sample.hwp; echo $?
+0
+$ rhwp diag samples/hwp3-sample.hwp; echo $?
+0
+```
+
+## 범위
+
+이번 수정은 `dump`·`diag` 두 명령만 다룬다. `ir-diff`/`test-*`/`gen-*` 계열과
+`rhwp::diagnostics::*::run` 계열도 동일 클래스 버그가 있음을 확인했으나(실측:
+모두 실패 시 exit 0), 함수 개수와 각각의 사용법/오류 경로가 많아 이번 범위에서는
+제외했다. 후속 이슈로 분리 권장.

--- a/mydocs/report/task_m100_3186_report.md
+++ b/mydocs/report/task_m100_3186_report.md
@@ -1,0 +1,64 @@
+---
+kind: report
+status: active
+last_verified: 2026-07-23
+---
+
+# 처리 결과 — 파이 차트 범례 공간 미예약 (Issue: #3186)
+
+## 증상
+
+원형(파이) 차트는 카테고리 기반 범례를 사용하므로 시리즈 이름(`c:tx`)이 비어 있어도
+`render_chart_svg`의 파이 분기가 `render_legend`/`render_legend_right`를 무조건
+호출해 범례가 항상 그려진다. 그런데 범례를 위한 레이아웃 공간(`legend_h`/`legend_w`)은
+`legend_visible = chart.series.iter().any(|s| !s.name.is_empty())`, 즉 시리즈 이름
+존재 여부로만 계산되고 있었다.
+
+결과: 시리즈 이름이 없는 파이 차트는 범례는 그려지는데 플롯 영역이 그 공간을 빼지
+않고 계산되어 파이가 부당하게 커지고 범례와 겹친다.
+
+## 재현 (red)
+
+`src/ooxml_chart/renderer.rs`에 테스트
+`test_pie_legend_reserves_space_regardless_of_series_name` 추가. 카테고리 3개,
+값 3개, 시리즈 이름만 다른(`"판매"` vs `""`) 두 파이 차트를 400x300으로 렌더링해
+파이 반지름(SVG path의 `A r,r`)을 비교:
+
+- 이름 있음: r = 111.6 (범례 공간 22px 예약)
+- 이름 없음: r = 121.5 (범례 공간 미예약 — 버그)
+
+두 경우 모두 `hwp-chart-legend`가 렌더 결과에 포함되므로(카테고리 기반) 반지름은
+같아야 정상. 수정 전 FAIL 확인.
+
+## 원인
+
+`render_chart_svg`(`src/ooxml_chart/renderer.rs`)의 `legend_visible` 계산이 모든
+차트 종류에 대해 "시리즈 이름 존재 여부"만 사용했다. 그러나 파이 차트의 범례는
+`legend_items()`에서 카테고리 라벨을 사용하며(`chart.categories`), 시리즈 이름과
+무관하게 항상 렌더링 분기를 탄다(파이 전용 분기는 `legend_visible`을 참조하지 않고
+무조건 `render_legend`/`render_legend_right`를 호출).
+
+## 수정
+
+`legend_visible` 계산에 파이 차트 종류를 추가로 포함:
+
+```rust
+let legend_visible =
+    chart.chart_type == OoxmlChartType::Pie || chart.series.iter().any(|s| !s.name.is_empty());
+```
+
+`render_chart_svg` 진입 시 `chart.series.is_empty()`면 이미 fallback으로 반환되므로
+파이 차트는 항상 `series`가 1개 이상 존재 — 위 변경은 안전하다.
+
+## 검증
+
+- 신규 테스트 green 확인.
+- `cargo test --lib ooxml_chart` 138개 전부 pass (기존 회귀 없음).
+- `cargo fmt --check`: 대상 파일 diff 없음(CRLF 관련 노이즈만, 기존에도 존재).
+- `cargo clippy --lib -- -D warnings`: 경고 없음.
+- `cargo test --release --lib`: 실행 완료 확인(별도 로그).
+
+## 영향 범위
+
+`src/ooxml_chart/renderer.rs` 한 줄 조건 추가 + 테스트 1건. 파이 차트가 아닌
+경우(막대/선/분산형/stock/콤보) 동작 변화 없음.

--- a/mydocs/report/task_m100_3191_report.md
+++ b/mydocs/report/task_m100_3191_report.md
@@ -1,0 +1,43 @@
+---
+kind: report
+status: active
+last_verified: 2026-07-23
+---
+
+# #3191 처리 결과 — 숨은설명 안 그림 BinData 순서 수집/remap 누락
+
+## 문제
+
+`src/document_core/converters/hwpx_to_hwp.rs` 의 `collect_bin_order_from_control()` 과
+`remap_bin_refs_in_control()` 은 각주(Footnote)·미주(Endnote)·머리말(Header)·꼬리말(Footer)·표(Table,
+캡션 포함) 안의 그림은 모두 순회하지만 숨은설명(`Control::HiddenComment`) 안의 그림만 두 함수 모두에서 빠져
+있었다. 같은 파일의 `collect_object_border_fill_refs_from_paragraph()` 는 이미 `Control::HiddenComment`
+를 처리하고 있어(#2467/05af4fe7) 컨테이너 순회 목록이 함수마다 어긋나 있었다.
+
+## 영향
+
+OLE Storage 를 포함한 HWPX 문서에서 `materialize_hwp5_bin_data_order()` 가 BinData 순서를 재배치할 때,
+숨은설명 안 그림의 `bin_data_id` 는 remap 되지 않고 옛 순번을 그대로 가리켜 재배치 후 다른 그림을 참조하거나
+존재하지 않는 BinData 를 참조하게 된다.
+
+## 재현 (red)
+
+`table_caption_picture_bin_ref_is_remapped` 와 동형의 테스트를 숨은설명 컨테이너로 작성:
+
+- `hidden_comment_picture_bin_ref_is_remapped`: `remap_bin_refs_in_control()` 호출 후 숨은설명 안 그림의
+  `bin_data_id` 가 remap 되지 않음을 확인 (FAIL: left=1, right=2 기대).
+- `hidden_comment_picture_is_collected_into_bin_order`: `collect_bin_order_from_control()` 호출 후 순서
+  목록에 숨은설명 안 그림의 `bin_data_id` 가 없음을 확인 (FAIL: left=[], right=[2] 기대).
+
+## 수정
+
+`collect_bin_order_from_control()` 과 `remap_bin_refs_in_control()` 의 match 문에 다른 컨테이너와 동일한
+패턴으로 `Control::HiddenComment(comment) => ...comment.paragraphs...` 분기를 추가했다.
+
+## 검증
+
+```
+cargo test --lib document_core::converters::hwpx_to_hwp
+```
+
+수정 전 신규 테스트 2건 FAIL 확인 → 최소 수정 적용 → 43 tests passed (기존 41건 + 신규 2건), 0 failed.

--- a/mydocs/report/task_m100_3195_report.md
+++ b/mydocs/report/task_m100_3195_report.md
@@ -1,0 +1,77 @@
+# 완료 보고서 — Task M100-3195
+
+- 이슈: #3195
+- 제목: [HWP5 저장] SectionDef page_num_type(홀/짝 쪽번호 시작)이 flags에 미반영되어 저장 시 유실
+- 작성일: 2026-07-23
+- 브랜치: `fix/3195-section-def-page-num-type-flags-sync`
+
+## 1. 문제
+
+HWPX 파서(`src/parser/hwpx/section.rs::parse_start_num`)는 `<hp:startNum
+pageStartsOn="ODD|EVEN">` 을 읽어 `SectionDef.page_num_type` 필드만 세팅하고
+`flags` 비트 20-21은 건드리지 않는다. 반면 HWP5는 `page_num_type`을 별도
+필드로 갖지 않고 `flags` 비트 20-21로만 표현하며, HWP5 직렬화기
+(`src/serializer/control.rs::serialize_section_def`)는 `sd.flags`를 그대로만
+기록한다.
+
+두 방향(HWPX 파서: 필드만 갱신, HWP5 직렬화기: flags만 사용) 사이의 비대칭
+때문에, HWPX 출처 문서를 HWP5로 저장하면 홀/짝 쪽번호 시작 설정이 소리 없이
+유실된다(재로드 시 항상 0=이어서로 읽힘).
+
+## 2. 재현 (red)
+
+`src/serializer/control/tests.rs` 에 다음 라운드트립 테스트를 추가해
+`flags: 0, page_num_type: 1` 인 `SectionDef` 를 HWP5 직렬화 → 재파싱하면
+`page_num_type` 이 1 → 0 으로 붕괴함을 확인했다.
+
+```
+test serializer::control::tests::test_roundtrip_section_def_page_num_type_without_flags_sync ... FAILED
+  left: 0
+ right: 1
+```
+
+## 3. 수정
+
+`serialize_section_def` 에서 `flags` 를 쓰기 직전 `page_num_type` 값으로
+bit 20-21 을 재구성한다(HWP5 표현의 유일한 소스인 flags 필드에 최종 반영):
+
+```rust
+let flags = (sd.flags & !0x0030_0000) | (((sd.page_num_type as u32) & 0x03) << 20);
+w.write_u32(flags).unwrap();
+```
+
+동일 패턴이 이미 편집 경로인
+`document_core/queries/rendering.rs::apply_section_def_json` 에 존재해,
+직렬화 경로에도 동일 계약을 맞췄다.
+
+## 4. 주요 변경
+
+- `src/serializer/control.rs`
+  - `serialize_section_def`: flags 기록 직전 page_num_type→bit 20-21 재구성
+- `src/serializer/control/tests.rs`
+  - `test_roundtrip_section_def_page_num_type_without_flags_sync` 추가 (red→green)
+
+## 5. 검증 결과
+
+통과:
+
+- `cargo fmt --check` (수정 파일 기준, 기존 CRLF 노이즈 제외)
+- `RUSTFLAGS="-C linker=rust-lld" cargo clippy --lib -- -D warnings`
+- `RUSTFLAGS="-C linker=rust-lld" cargo test --lib serializer::control`
+  - 21 passed (신규 테스트 포함)
+- `RUSTFLAGS="-C linker=rust-lld" cargo test --lib`
+  - 2553 passed, 1 failed(무관), 7 ignored
+  - 실패 1건(`renderer::font_paths::tests::env_font_paths_parses_and_filters`)은
+    본 변경과 무관한 기존 Windows 환경 이슈(`/tmp` 경로 파싱)로, worktree
+    생성 직후 clean devel 기준으로도 동일하게 재현되어 pre-existing으로 판단.
+
+## 6. 리스크
+
+- flags 비트 20-21 외 다른 비트에는 영향 없음(마스크 `0x0030_0000`으로 해당
+  비트만 재구성).
+- HWP5 원본에서 파싱된 문서는 `page_num_type` 이 이미 `flags`에서 파생된
+  값이므로 이 변경으로 동작이 바뀌지 않는다(round-trip 항등).
+
+## 7. 결론
+
+Task M100-3195 구현과 검증을 완료했다. PR 생성 후 이슈를 close할 수 있다.

--- a/src/diagnostics/ir_field_sweep.rs
+++ b/src/diagnostics/ir_field_sweep.rs
@@ -868,6 +868,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut Vec<FieldDivergence>) {
         is_header,
         raw_list_extra,
         field_name,
+        dirty_flag,
     } = a;
 
     macro_rules! f {
@@ -890,6 +891,7 @@ fn sweep_cell(base: &str, a: &Cell, b: &Cell, out: &mut Vec<FieldDivergence>) {
     f!(is_header);
     f!(raw_list_extra);
     f!(field_name);
+    f!(dirty_flag);
 
     sweep_paragraphs(
         &format!("{base}.paragraphs"),

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -103,6 +103,11 @@ pub struct AdapterReport {
     pub master_page_autonum_placeholder_removed: u32,
     /// HWPX 바탕쪽 line shape rendering matrix를 HWP5 size ratio contract로 보정한 횟수
     pub master_page_line_rendering_size_ratio_materialized: u32,
+    /// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29,
+    /// 0x2000_0000) 보강 횟수. 표는 이미 `materialize_table_ctrl_header_attr` 로
+    /// 보강되지만 그림은 빠져 있었다(전 코퍼스 실측 80/80 이 개체 종류와 무관하게
+    /// 이 비트를 요구).
+    pub picture_caption_common_attr_materialized: u32,
 }
 
 impl AdapterReport {
@@ -150,7 +155,8 @@ impl AdapterReport {
                 + self.autonum_fwspace_char_shape_offsets_materialized
                 + self.header_footer_fwspace_control_materialized
                 + self.master_page_autonum_placeholder_removed
-                + self.master_page_line_rendering_size_ratio_materialized)
+                + self.master_page_line_rendering_size_ratio_materialized
+                + self.picture_caption_common_attr_materialized)
                 > 0
     }
 }
@@ -500,6 +506,12 @@ fn remap_bin_refs_in_control(ctrl: &mut Control, remap: &[u16]) {
             remap_bin_refs_in_paragraphs(&mut footnote.paragraphs, remap)
         }
         Control::Endnote(endnote) => remap_bin_refs_in_paragraphs(&mut endnote.paragraphs, remap),
+        // [#2767] adapt 워크·border-fill 워크는 이미 HiddenComment 를 방문한다
+        // (#2467 근거). remap 워크만 빠져 있어 숨은설명 안 그림이 재정렬 후
+        // 엉뚱한 이미지를 가리키는 채로 남았다.
+        Control::HiddenComment(comment) => {
+            remap_bin_refs_in_paragraphs(&mut comment.paragraphs, remap)
+        }
         _ => {}
     }
 }
@@ -508,6 +520,12 @@ fn remap_bin_refs_in_shape(shape: &mut ShapeObject, remap: &[u16]) {
     match shape {
         ShapeObject::Picture(pic) => {
             pic.image_attr.bin_data_id = remap_bin_ref(pic.image_attr.bin_data_id, remap);
+            // [#2767] 그룹 내부 그림(ShapeObject::Picture)은 drawing_mut()이 항상
+            // None 이라(모델상 DrawingObjAttr 를 갖지 않음) 아래 공통 캡션 remap
+            // 경로를 타지 않는다. Picture 자신의 caption 필드를 직접 재귀해야 한다.
+            if let Some(caption) = &mut pic.caption {
+                remap_bin_refs_in_paragraphs(&mut caption.paragraphs, remap);
+            }
         }
         ShapeObject::Ole(ole) => {
             if let Ok(id) = u16::try_from(ole.bin_data_id) {
@@ -924,6 +942,7 @@ fn adapt_paragraph_with_context(
                 if let Some(caption) = &mut pic.caption {
                     adapt_paragraphs_with_context(&mut caption.paragraphs, report, context);
                 }
+                materialize_picture_caption_common_attr(pic, report);
             }
             Control::Shape(shape) => adapt_shape_with_context(shape, report, context),
             Control::Equation(eq) => adapt_equation(eq, report),
@@ -1674,6 +1693,27 @@ fn materialize_table_ctrl_header_attr(table: &mut Table, report: &mut AdapterRep
 
     if table.common.attr != before {
         report.table_ctrl_header_attr_materialized += 1;
+    }
+}
+
+/// [#2767] 캡션이 있는 그림(gso `$pic`) CTRL_HEADER 의 한컴 캡션 비트(bit 29) 보강.
+///
+/// 전 코퍼스 실측(`samples/**/*.hwp`, 한컴 저작 원본): 캡션 동반 gso 80개(그림 42,
+/// 사각형 33, 연결선 3, OLE 2) 전부 bit 29=1, 캡션 없는 gso 2,674개 전부 bit 29=0.
+/// 개체 종류와 무관하게 캡션 유무만으로 결정된다. HWPX 출처 그림의
+/// `common.attr` 는 파서(`pack_hwpx_common_obj_attr`)가 이미 non-zero로 채우고
+/// 직렬화기가 verbatim 기록하므로, 표처럼 `pack_common_attr_bits(...)`로
+/// **recompute** 하지 않고 비트만 **OR** 한다 — recompute 하면 표 전용 비트를
+/// 그림에 강제로 얹는 회귀가 된다. 멱등: 비트가 이미 켜져 있으면 카운트하지 않음.
+///
+/// 도형(`$rec`/`$con`)·OLE 캡션은 범위 밖이다 — 직렬화기(`serializer/control.rs`)가
+/// 도형 캡션 레코드 자체를 아직 출력하지 않아, 레코드 없이 비트만 켜면 자기모순
+/// 레코드가 된다(별도 후속 과제).
+fn materialize_picture_caption_common_attr(pic: &mut Picture, report: &mut AdapterReport) {
+    const HWP5_GSO_CAPTION_COMMON_ATTR_BIT: u32 = 0x2000_0000;
+    if pic.caption.is_some() && pic.common.attr & HWP5_GSO_CAPTION_COMMON_ATTR_BIT == 0 {
+        pic.common.attr |= HWP5_GSO_CAPTION_COMMON_ATTR_BIT;
+        report.picture_caption_common_attr_materialized += 1;
     }
 }
 
@@ -3270,6 +3310,142 @@ mod tests {
         assert_eq!(
             pic.image_attr.bin_data_id, 2,
             "표 캡션 그림의 bin_data_id 가 remap 되지 않음(캡션 문단 미방문)"
+        );
+    }
+
+    // ---------- #2767 결함 A — 그림 캡션 gso CTRL_HEADER 캡션 비트 ----------
+
+    #[test]
+    fn picture_caption_common_attr_bit_is_or_ed_in_when_caption_present() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                // 실측(이슈 §A-2)에서 확인한 파서 값 — 캡션 비트 이전에 이미 non-zero.
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: Some(crate::model::shape::Caption::default()),
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x242A_2211,
+            "캡션이 있으면 bit 29 가 OR 되어야 함(recompute 아님)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 1);
+
+        // 멱등: 다시 적용해도 카운트가 늘지 않아야 함.
+        let mut second = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut second);
+        assert_eq!(second.picture_caption_common_attr_materialized, 0);
+    }
+
+    #[test]
+    fn picture_caption_common_attr_bit_untouched_without_caption() {
+        let mut para = Paragraph::default();
+        let pic = Picture {
+            common: crate::model::shape::CommonObjAttr {
+                attr: 0x042A_2211,
+                ..Default::default()
+            },
+            caption: None,
+            ..Default::default()
+        };
+        para.controls.push(Control::Picture(Box::new(pic)));
+
+        let mut report = AdapterReport::new();
+        adapt_paragraph(&mut para, &mut report);
+
+        let Control::Picture(pic) = &para.controls[0] else {
+            panic!("Picture control expected");
+        };
+        assert_eq!(
+            pic.common.attr, 0x042A_2211,
+            "캡션이 없으면 bit 29 를 켜면 안 됨(거짓양성 방지)"
+        );
+        assert_eq!(report.picture_caption_common_attr_materialized, 0);
+    }
+
+    // ---------- #2767 결함 B(잔여) — HiddenComment · 그룹 내부 그림 캡션 remap ----------
+
+    #[test]
+    fn hidden_comment_picture_bin_ref_is_remapped() {
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut inner_para = Paragraph::default();
+        inner_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let comment = crate::model::control::HiddenComment {
+            paragraphs: vec![inner_para],
+        };
+        let mut ctrl = Control::HiddenComment(Box::new(comment));
+
+        // remap[1] = 2 : bin_data_id 1 을 2 로 재배치.
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_control(&mut ctrl, &remap);
+
+        let Control::HiddenComment(comment) = &ctrl else {
+            panic!("HiddenComment control expected");
+        };
+        let Control::Picture(pic) = &comment.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside HiddenComment");
+        };
+        assert_eq!(
+            pic.image_attr.bin_data_id, 2,
+            "숨은설명 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
+        );
+    }
+
+    #[test]
+    fn grouped_picture_caption_bin_ref_is_remapped() {
+        // ShapeObject::Picture(그룹 내부 그림)는 drawing_mut()이 None 이라 공통
+        // caption remap 경로를 타지 않는다 — Picture 자신의 caption 을 직접 재귀해야 함.
+        let inner_pic = Picture {
+            image_attr: crate::model::image::ImageAttr {
+                bin_data_id: 1,
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let mut caption_para = Paragraph::default();
+        caption_para
+            .controls
+            .push(Control::Picture(Box::new(inner_pic)));
+        let grouped_pic = Picture {
+            caption: Some(crate::model::shape::Caption {
+                paragraphs: vec![caption_para],
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let mut shape = ShapeObject::Picture(Box::new(grouped_pic));
+
+        let remap = vec![0u16, 2, 1];
+        remap_bin_refs_in_shape(&mut shape, &remap);
+
+        let ShapeObject::Picture(pic) = &shape else {
+            panic!("Picture shape expected");
+        };
+        let caption = pic.caption.as_ref().expect("caption preserved");
+        let Control::Picture(inner) = &caption.paragraphs[0].controls[0] else {
+            panic!("Picture control expected inside caption");
+        };
+        assert_eq!(
+            inner.image_attr.bin_data_id, 2,
+            "그룹 내부 그림 캡션 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
         );
     }
 }

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -1683,9 +1683,14 @@ fn materialize_table_ctrl_header_attr(table: &mut Table, report: &mut AdapterRep
     const HWP5_TABLE_CAPTION_COMMON_ATTR_BIT: u32 = 0x2000_0000;
 
     let before = table.common.attr;
-    let mut attr = pack_common_attr_bits(&table.common)
-        | HWPX_TABLE_FLOW_WITH_TEXT_BIT
-        | HWPX_TABLE_NUMBERING_BIT;
+    let mut attr = pack_common_attr_bits(&table.common) | HWPX_TABLE_FLOW_WITH_TEXT_BIT;
+    // [#2697] 파서(materialize_hwpx_table_attrs)와 동일 게이트: "표 번호" 비트는
+    // numberingType 이 실제로 TABLE 일 때만 세운다. 종전 무조건 OR 은 numberingType=
+    // "PICTURE"/"NONE" 표를 HWP5 저장 시 표 번호 범주로 되돌려, 파서가 #2697 에서
+    // 제거한 IR 모순(numbering_type=Picture ↔ attr=TABLE)을 변환 계층이 재도입했다.
+    if table.common.numbering_type == crate::model::shape::ObjectNumberingType::Table {
+        attr |= HWPX_TABLE_NUMBERING_BIT;
+    }
     if table.caption.is_some() {
         attr |= HWP5_TABLE_CAPTION_COMMON_ATTR_BIT;
     }
@@ -1943,6 +1948,8 @@ mod tests {
                 width: 47697,
                 height: 3525,
                 z_order: 26,
+                // HWPX 파서는 표 기본 numberingType 을 TABLE 로 채운다 (section.rs).
+                numbering_type: crate::model::shape::ObjectNumberingType::Table,
                 ..Default::default()
             },
             outer_margin_left: 283,
@@ -2054,6 +2061,8 @@ mod tests {
                 width: 47152,
                 height: 14976,
                 z_order: 6,
+                // HWPX 파서는 표 기본 numberingType 을 TABLE 로 채운다 (section.rs).
+                numbering_type: crate::model::shape::ObjectNumberingType::Table,
                 ..Default::default()
             },
             outer_margin_left: 141,
@@ -2082,6 +2091,106 @@ mod tests {
                     .unwrap(),
             ),
             0x282a_2311
+        );
+    }
+
+    #[test]
+    fn picture_numbering_table_keeps_category_on_hwp_save() {
+        // [#2697] HWPX 파서는 numberingType="PICTURE" 표에 TABLE 번호 비트(0x0800_0000)를
+        // 세우지 않는다. HWP5 저장 어댑터도 같은 게이트를 따라야 한다 — 종전 무조건 OR 은
+        // 그림 번호 캡션 표를 표 번호 범주로 되돌려 파서가 만든 IR 계약과 모순됐다.
+        use crate::model::shape::ObjectNumberingType;
+
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        table.common.numbering_type = ObjectNumberingType::Picture;
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "PICTURE 번호 표에 TABLE 번호 비트가 서면 IR 모순: {:#010x}",
+            table.common.attr
+        );
+        let flags = u32::from_le_bytes(
+            table.raw_ctrl_data[common_obj_offsets::FLAGS]
+                .try_into()
+                .unwrap(),
+        );
+        assert_eq!(
+            flags & 0x0800_0000,
+            0,
+            "raw_ctrl_data 에도 TABLE 번호 비트가 없어야 함: {flags:#010x}"
+        );
+    }
+
+    #[test]
+    fn none_numbering_table_keeps_category_on_hwp_save() {
+        // numberingType="NONE"(번호 매김 제외) 표도 저장 시 표 번호 범주로 승격되면 안 된다.
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        // Table::default() 의 common.numbering_type 은 None.
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0,
+            "NONE 번호 표에 TABLE 번호 비트가 서면 안 됨: {:#010x}",
+            table.common.attr
+        );
+    }
+
+    #[test]
+    fn table_numbering_table_still_sets_numbering_bit() {
+        // 회귀 가드: 기본 표(numberingType="TABLE")는 종전대로 표 번호 비트를 유지한다.
+        use crate::model::shape::ObjectNumberingType;
+
+        let mut table = Table {
+            row_count: 1,
+            col_count: 1,
+            cells: vec![Cell {
+                col: 0,
+                row: 0,
+                col_span: 1,
+                row_span: 1,
+                ..Default::default()
+            }],
+            ..Default::default()
+        };
+        table.common.numbering_type = ObjectNumberingType::Table;
+
+        let mut report = AdapterReport::new();
+        adapt_table(&mut table, &mut report);
+
+        assert_eq!(
+            table.common.attr & 0x0800_0000,
+            0x0800_0000,
+            "TABLE 번호 표는 표 번호 비트를 유지해야 함: {:#010x}",
+            table.common.attr
         );
     }
 

--- a/src/document_core/converters/hwpx_to_hwp.rs
+++ b/src/document_core/converters/hwpx_to_hwp.rs
@@ -418,6 +418,9 @@ fn collect_bin_order_from_control(
         Control::Endnote(endnote) => {
             collect_bin_order_from_paragraphs(&endnote.paragraphs, bin_count, order, seen);
         }
+        Control::HiddenComment(comment) => {
+            collect_bin_order_from_paragraphs(&comment.paragraphs, bin_count, order, seen);
+        }
         _ => {}
     }
 }
@@ -3555,6 +3558,31 @@ mod tests {
         assert_eq!(
             inner.image_attr.bin_data_id, 2,
             "그룹 내부 그림 캡션 안 그림의 bin_data_id 도 재정렬 remap 을 반영해야 함"
+        );
+    }
+
+    #[test]
+    fn hidden_comment_picture_is_collected_into_bin_order() {
+        use crate::model::control::HiddenComment;
+        use crate::model::image::Picture;
+        use std::collections::BTreeSet;
+
+        let mut pic = Picture::default();
+        pic.image_attr.bin_data_id = 2;
+        let mut comment_para = Paragraph::default();
+        comment_para.controls.push(Control::Picture(Box::new(pic)));
+        let ctrl = Control::HiddenComment(Box::new(HiddenComment {
+            paragraphs: vec![comment_para],
+        }));
+
+        let mut order = Vec::new();
+        let mut seen = BTreeSet::new();
+        collect_bin_order_from_control(&ctrl, 2, &mut order, &mut seen);
+
+        assert_eq!(
+            order,
+            vec![2],
+            "숨은설명 안 그림의 bin_data_id 가 순서 수집에서 누락됨(숨은설명 문단 미방문)"
         );
     }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -42,11 +42,11 @@ fn main() {
         Some("export-hml") => export_hml(&args[2..]),
         Some("export-doclang") => exit_with(export_doclang(&args[2..])),
         Some("info") => show_info(&args[2..]),
-        Some("dump") => dump_controls(&args[2..]),
+        Some("dump") => exit_with(dump_controls(&args[2..])),
         Some("dump-note-shape") => dump_note_shape(&args[2..]),
         Some("dump-endnote-lines") => dump_endnote_lines(&args[2..]),
         Some("dump-pages") => dump_pages(&args[2..]),
-        Some("diag") => diag_document(&args[2..]),
+        Some("diag") => exit_with(diag_document(&args[2..])),
         Some("convert") => exit_with(convert_hwp(&args[2..])),
         Some("build-from-ingest") => build_from_ingest(&args[2..]),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
@@ -3013,13 +3013,13 @@ fn brief_text(text: &str, max_chars: usize) -> String {
     out
 }
 
-fn dump_controls(args: &[String]) {
+fn dump_controls(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: 문서 파일 경로를 지정해주세요.");
         eprintln!(
             "사용법: rhwp dump <파일.hwp|파일.hwpx|파일.hml> [--section <번호>] [--para <번호>]"
         );
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -3055,7 +3055,7 @@ fn dump_controls(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -3063,7 +3063,7 @@ fn dump_controls(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 문서 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4236,13 +4236,15 @@ fn dump_controls(args: &[String]) {
             .map(|s| s.paragraphs.len())
             .sum::<usize>()
     );
+
+    EXIT_OK
 }
 
-fn diag_document(args: &[String]) {
+fn diag_document(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: HWP 파일 경로를 지정해주세요.");
         eprintln!("사용법: rhwp diag <파일.hwp>");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -4250,7 +4252,7 @@ fn diag_document(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4258,7 +4260,7 @@ fn diag_document(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4358,6 +4360,8 @@ fn diag_document(args: &[String]) {
             }
         }
     }
+
+    EXIT_OK
 }
 
 #[derive(Debug, Default, Clone, Copy)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,14 +41,14 @@ fn main() {
         Some("export-hwpx") => exit_with(export_hwpx(&args[2..])),
         Some("export-hml") => export_hml(&args[2..]),
         Some("export-doclang") => exit_with(export_doclang(&args[2..])),
-        Some("info") => show_info(&args[2..]),
+        Some("info") => exit_with(show_info(&args[2..])),
         Some("dump") => exit_with(dump_controls(&args[2..])),
-        Some("dump-note-shape") => dump_note_shape(&args[2..]),
-        Some("dump-endnote-lines") => dump_endnote_lines(&args[2..]),
-        Some("dump-pages") => dump_pages(&args[2..]),
+        Some("dump-note-shape") => exit_with(dump_note_shape(&args[2..])),
+        Some("dump-endnote-lines") => exit_with(dump_endnote_lines(&args[2..])),
+        Some("dump-pages") => exit_with(dump_pages(&args[2..])),
         Some("diag") => exit_with(diag_document(&args[2..])),
         Some("convert") => exit_with(convert_hwp(&args[2..])),
-        Some("build-from-ingest") => build_from_ingest(&args[2..]),
+        Some("build-from-ingest") => exit_with(build_from_ingest(&args[2..])),
         Some("hwp5-inventory") => rhwp::diagnostics::hwp5_inventory::run(&args[2..]),
         Some("hwp5-inventory-diff") => rhwp::diagnostics::hwp5_inventory_diff::run(&args[2..]),
         Some("hwp5-contract-analyze") => rhwp::diagnostics::hwp5_contract_analyze::run(&args[2..]),
@@ -68,7 +68,7 @@ fn main() {
         Some("hwp5-cell-header-probe") => {
             rhwp::diagnostics::hwp5_cell_header_probe::run(&args[2..])
         }
-        Some("dump-records") => dump_raw_records(&args[2..]),
+        Some("dump-records") => exit_with(dump_raw_records(&args[2..])),
         Some("test-shape") => test_shape_roundtrip(&args[2..]),
         Some("test-caption") => test_caption(&args[2..]),
         Some("gen-table") => gen_table(&args[2..]),
@@ -2096,10 +2096,10 @@ fn export_markdown(args: &[String]) -> i32 {
     }
 }
 
-fn show_info(args: &[String]) {
+fn show_info(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("오류: 문서 파일 경로를 지정해주세요.");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2109,7 +2109,7 @@ fn show_info(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2121,7 +2121,7 @@ fn show_info(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 문서 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2412,6 +2412,7 @@ fn show_info(args: &[String]) {
             }
         }
     }
+    EXIT_OK
 }
 
 /// HWPUNIT(u32)을 mm로 변환
@@ -2424,10 +2425,10 @@ fn hu_to_mm_i(hu: i32) -> f64 {
     hu as f64 * 25.4 / 7200.0
 }
 
-fn dump_note_shape(args: &[String]) {
+fn dump_note_shape(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-note-shape <파일.hwp|파일.hwpx>");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2435,7 +2436,7 @@ fn dump_note_shape(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2443,7 +2444,7 @@ fn dump_note_shape(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2466,8 +2467,14 @@ fn dump_note_shape(args: &[String]) {
         "sections": sections,
     });
     match serde_json::to_string_pretty(&value) {
-        Ok(text) => println!("{}", text),
-        Err(e) => eprintln!("오류: JSON 생성 실패 - {}", e),
+        Ok(text) => {
+            println!("{}", text);
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("오류: JSON 생성 실패 - {}", e);
+            EXIT_RUNTIME
+        }
     }
 }
 
@@ -2512,10 +2519,10 @@ fn rounded_mm(hu: i32) -> f64 {
     (hu_to_mm_i(hu) * 1000.0).round() / 1000.0
 }
 
-fn dump_pages(args: &[String]) {
+fn dump_pages(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-pages <파일.hwp> [-p <페이지번호>]");
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2534,13 +2541,13 @@ fn dump_pages(args: &[String]) {
                         Ok(n) => target_page = Some(n),
                         Err(_) => {
                             eprintln!("오류: 페이지 번호가 올바르지 않습니다: {}", args[i + 1]);
-                            return;
+                            return EXIT_USAGE;
                         }
                     }
                     i += 2;
                 } else {
                     eprintln!("오류: {} 뒤에 페이지 번호가 필요합니다.", args[i]);
-                    return;
+                    return EXIT_USAGE;
                 }
             }
             "--respect-vpos-reset" => {
@@ -2549,7 +2556,7 @@ fn dump_pages(args: &[String]) {
             }
             _ => {
                 eprintln!("알 수 없는 옵션: {}", args[i]);
-                return;
+                return EXIT_USAGE;
             }
         }
     }
@@ -2558,7 +2565,7 @@ fn dump_pages(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2566,7 +2573,7 @@ fn dump_pages(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2585,20 +2592,21 @@ fn dump_pages(args: &[String]) {
                 "오류: 페이지 번호가 범위를 벗어났습니다 (0~{})",
                 page_count.saturating_sub(1)
             );
-            return;
+            return EXIT_USAGE;
         }
     }
 
     println!("문서 로드: {} ({}페이지)", file_path, page_count);
     print!("{}", doc.dump_page_items(target_page));
+    EXIT_OK
 }
 
-fn dump_endnote_lines(args: &[String]) {
+fn dump_endnote_lines(args: &[String]) -> i32 {
     if args.len() < 4 {
         eprintln!(
             "사용법: rhwp dump-endnote-lines <파일.hwp> <section> <para> <control> [note-para]"
         );
-        return;
+        return EXIT_USAGE;
     }
 
     let file_path = &args[0];
@@ -2606,21 +2614,21 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: section 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let para_idx = match args[2].parse::<usize>() {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: para 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let control_idx = match args[3].parse::<usize>() {
         Ok(v) => v,
         Err(e) => {
             eprintln!("오류: control 인덱스 파싱 실패 - {}", e);
-            return;
+            return EXIT_USAGE;
         }
     };
     let target_note_para = if args.len() >= 5 {
@@ -2628,7 +2636,7 @@ fn dump_endnote_lines(args: &[String]) {
             Ok(v) => Some(v),
             Err(e) => {
                 eprintln!("오류: note-para 인덱스 파싱 실패 - {}", e);
-                return;
+                return EXIT_USAGE;
             }
         }
     } else {
@@ -2639,7 +2647,7 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: 파일을 읽을 수 없습니다 - {}: {}", file_path, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -2647,22 +2655,22 @@ fn dump_endnote_lines(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: HWP 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
     let document = doc.document();
     let Some(section) = document.sections.get(section_idx) else {
         eprintln!("오류: section {} 범위 초과", section_idx);
-        return;
+        return EXIT_USAGE;
     };
     let Some(source_para) = section.paragraphs.get(para_idx) else {
         eprintln!("오류: para {} 범위 초과", para_idx);
-        return;
+        return EXIT_USAGE;
     };
     let Some(ctrl) = source_para.controls.get(control_idx) else {
         eprintln!("오류: control {} 범위 초과", control_idx);
-        return;
+        return EXIT_USAGE;
     };
 
     let rhwp::model::control::Control::Endnote(endnote) = ctrl else {
@@ -2673,7 +2681,7 @@ fn dump_endnote_lines(args: &[String]) {
             control_idx,
             control_kind(ctrl)
         );
-        return;
+        return EXIT_USAGE;
     };
 
     println!(
@@ -2701,6 +2709,7 @@ fn dump_endnote_lines(args: &[String]) {
         );
         dump_paragraph_line_trace(para);
     }
+    EXIT_OK
 }
 
 fn dump_paragraph_line_trace(para: &rhwp::model::paragraph::Paragraph) {
@@ -4899,10 +4908,10 @@ fn export_hml(args: &[String]) {
 ///
 /// Claude Code Skill (`rhwp-exam-ingest`)이 생성한 JSON 중간 표현을 HWPX로 변환한다.
 /// Task #660 (Neumann 본 작업 1단계).
-fn build_from_ingest(args: &[String]) {
+fn build_from_ingest(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp build-from-ingest <ingest.json> [--media-dir <dir>] -o <out.hwpx>");
-        return;
+        return EXIT_USAGE;
     }
 
     let mut input_path: Option<&str> = None;
@@ -4915,7 +4924,7 @@ fn build_from_ingest(args: &[String]) {
             "-o" | "--output" => {
                 if i + 1 >= args.len() {
                     eprintln!("오류: -o 옵션에 값이 필요합니다");
-                    return;
+                    return EXIT_USAGE;
                 }
                 output_path = Some(&args[i + 1]);
                 i += 2;
@@ -4923,7 +4932,7 @@ fn build_from_ingest(args: &[String]) {
             "--media-dir" => {
                 if i + 1 >= args.len() {
                     eprintln!("오류: --media-dir 옵션에 값이 필요합니다");
-                    return;
+                    return EXIT_USAGE;
                 }
                 media_dir = Some(&args[i + 1]);
                 i += 2;
@@ -4943,14 +4952,14 @@ fn build_from_ingest(args: &[String]) {
         Some(p) => p,
         None => {
             eprintln!("오류: 입력 ingest JSON 경로가 누락되었습니다");
-            return;
+            return EXIT_USAGE;
         }
     };
     let output = match output_path {
         Some(p) => p,
         None => {
             eprintln!("오류: -o <출력 경로> 가 누락되었습니다");
-            return;
+            return EXIT_USAGE;
         }
     };
 
@@ -4958,7 +4967,7 @@ fn build_from_ingest(args: &[String]) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("오류: 입력 파일 읽기 실패 - {}: {}", input, e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4966,7 +4975,7 @@ fn build_from_ingest(args: &[String]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: ingest JSON 파싱 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
@@ -4986,35 +4995,41 @@ fn build_from_ingest(args: &[String]) {
         Ok(b) => b,
         Err(e) => {
             eprintln!("오류: HWPX 직렬화 실패 - {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
 
     match fs::write(output, &hwpx_bytes) {
-        Ok(_) => println!(
-            "저장 완료: {} ({}바이트, 문제 {}개, 문단 {}개)",
-            output,
-            hwpx_bytes.len(),
-            ingest.questions.len(),
-            doc.sections
-                .iter()
-                .map(|s| s.paragraphs.len())
-                .sum::<usize>()
-        ),
-        Err(e) => eprintln!("오류: 파일 저장 실패 - {}: {}", output, e),
+        Ok(_) => {
+            println!(
+                "저장 완료: {} ({}바이트, 문제 {}개, 문단 {}개)",
+                output,
+                hwpx_bytes.len(),
+                ingest.questions.len(),
+                doc.sections
+                    .iter()
+                    .map(|s| s.paragraphs.len())
+                    .sum::<usize>()
+            );
+            EXIT_OK
+        }
+        Err(e) => {
+            eprintln!("오류: 파일 저장 실패 - {}: {}", output, e);
+            EXIT_RUNTIME
+        }
     }
 }
 
-fn dump_raw_records(args: &[String]) {
+fn dump_raw_records(args: &[String]) -> i32 {
     if args.is_empty() {
         eprintln!("사용법: rhwp dump-records <파일.hwp>");
-        return;
+        return EXIT_USAGE;
     }
     let data = match fs::read(&args[0]) {
         Ok(d) => d,
         Err(e) => {
             eprintln!("오류: {}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     use rhwp::parser::cfb_reader::CfbReader;
@@ -5023,7 +5038,7 @@ fn dump_raw_records(args: &[String]) {
         Ok(c) => c,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     // FileHeader에서 압축 여부 확인
@@ -5033,14 +5048,14 @@ fn dump_raw_records(args: &[String]) {
         Ok(s) => s,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     let records = match Record::read_all(&section) {
         Ok(r) => r,
         Err(e) => {
             eprintln!("오류: {:?}", e);
-            return;
+            return EXIT_RUNTIME;
         }
     };
     let tag_name = |id: u16| -> &str {
@@ -5093,6 +5108,7 @@ fn dump_raw_records(args: &[String]) {
             }
         }
     }
+    EXIT_OK
 }
 
 fn test_shape_roundtrip(args: &[String]) {

--- a/src/model/table.rs
+++ b/src/model/table.rs
@@ -143,6 +143,9 @@ pub struct Cell {
     /// 셀 필드 이름 (한컴 셀 속성 → 필드 → 필드 이름)
     /// raw_list_extra의 offset 14-15(name_len) + offset 16~(UTF-16LE)에서 추출
     pub field_name: Option<String>,
+    /// HWPX `<hp:tc dirty>` 속성 (편집기 캐시 무효화 표시, 라운드트립 보존용).
+    /// HWP5 바이너리에는 대응 비트가 없어 list_header_width_ref 재사용 대상에서 제외한다.
+    pub dirty_flag: bool,
 }
 
 /// 표 셀 행/열 바꿈 복사 데이터.
@@ -346,6 +349,7 @@ impl Cell {
             is_header: template.is_header,
             raw_list_extra: template.raw_list_extra.clone(),
             field_name: None,
+            dirty_flag: false,
             paragraphs: vec![para],
         }
     }

--- a/src/ooxml_chart/renderer.rs
+++ b/src/ooxml_chart/renderer.rs
@@ -206,7 +206,10 @@ pub fn render_chart_svg(chart: &OoxmlChart, x: f64, y: f64, w: f64, h: f64) -> S
 
     // 영역 분할
     let title_h = if effective_title.is_some() { 22.0 } else { 4.0 };
-    let legend_visible = chart.series.iter().any(|s| !s.name.is_empty());
+    // 파이는 카테고리 기반 범례라 시리즈 이름과 무관하게 항상 그려진다(파이 분기가
+    // render_legend/render_legend_right를 무조건 호출) — 공간 예약도 그에 맞춰야 함.
+    let legend_visible =
+        chart.chart_type == OoxmlChartType::Pie || chart.series.iter().any(|s| !s.name.is_empty());
     // C1c #1882 갭③: legendPos=r(한컴 코퍼스 전 샘플)은 우측 세로 스택 — 하단 슬롯
     // 대신 우측 폭(legend_w)을 확보. 그 외 위치는 현행 하단 가로 유지.
     // `w * 0.30 >= 50.0` 가드: 폭이 좁으면(<167px) 하단 폴백 — 아래 clamp의
@@ -2257,6 +2260,53 @@ mod tests {
         let chart = OoxmlChart::default();
         let svg = render_chart_svg(&chart, 0.0, 0.0, 100.0, 100.0);
         assert!(svg.contains("fallback"));
+    }
+
+    #[test]
+    fn test_pie_legend_reserves_space_regardless_of_series_name() {
+        // 파이 범례는 카테고리 기반이라 시리즈 이름과 무관하게 항상 그려진다
+        // (render_chart_svg 파이 분기는 legend_h/legend_w 계산과 무관하게
+        // render_legend를 무조건 호출). 그런데 legend_h/legend_w는
+        // `legend_visible`(= 시리즈 이름 존재 여부)로만 계산되므로, 시리즈
+        // 이름이 없으면 범례가 그려지는데도 plot_h가 legend 공간을 빼지 않고
+        // 계산되어(버그) 파이 반지름이 이름 있는 경우보다 부당하게 커진다.
+        fn pie(name: &str) -> OoxmlChart {
+            OoxmlChart {
+                chart_type: OoxmlChartType::Pie,
+                series: vec![OoxmlSeries {
+                    name: name.to_string(),
+                    values: vec![1.0, 2.0, 3.0],
+                    series_type: OoxmlChartType::Pie,
+                    ..Default::default()
+                }],
+                categories: vec!["가".into(), "나".into(), "다".into()],
+                ..Default::default()
+            }
+        }
+        fn pie_radius(svg: &str) -> f64 {
+            // path의 `A{r},{r}` 반지름 값을 첫 슬라이스에서 추출
+            let a_pos = svg.find(" A").expect("파이 path 없음");
+            let rest = &svg[a_pos + 2..];
+            let comma = rest.find(',').unwrap();
+            rest[..comma].parse::<f64>().unwrap()
+        }
+
+        let named_svg = render_chart_svg(&pie("판매"), 0.0, 0.0, 400.0, 300.0);
+        let unnamed_svg = render_chart_svg(&pie(""), 0.0, 0.0, 400.0, 300.0);
+
+        // 두 경우 모두 범례가 그려진다 (카테고리 기반이므로 시리즈 이름 무관)
+        assert!(named_svg.contains("hwp-chart-legend"));
+        assert!(unnamed_svg.contains("hwp-chart-legend"));
+
+        let named_r = pie_radius(&named_svg);
+        let unnamed_r = pie_radius(&unnamed_svg);
+        // 범례가 동일하게 그려지므로 예약 공간도 동일해야 하고, 따라서 두
+        // 반지름이 같아야 한다. 버그 상태에서는 unnamed_r > named_r (범례
+        // 공간이 예약되지 않아 파이가 legend와 겹치도록 더 크게 그려짐).
+        assert_eq!(
+            named_r, unnamed_r,
+            "시리즈 이름 유무와 무관하게 파이 범례 공간이 동일하게 예약되어야 함 (named={named_r}, unnamed={unnamed_r})"
+        );
     }
 
     #[test]

--- a/src/parser/hml/reader.rs
+++ b/src/parser/hml/reader.rs
@@ -195,6 +195,12 @@ struct ReadState<'a> {
     cells: Vec<HmlCell>,
     font_language: Option<usize>,
     current_border_fill: Option<usize>,
+    /// 자식 요소(FONTID/RATIO/...)를 귀속할 CHARSHAPE 의 `Id` 위치.
+    /// `set_indexed` 는 `Id` 위치에 배치하므로 `last_mut` 로는 내림차순·건너뜀
+    /// 입력에서 엉뚱한 도형을 가리킨다 — `current_border_fill` 과 같은 방식.
+    current_char_shape: Option<usize>,
+    /// 자식 요소(PARAMARGIN/PARABORDER)를 귀속할 PARASHAPE 의 `Id` 위치.
+    current_para_shape: Option<usize>,
     head_modeled_children: usize,
     body_modeled_children: usize,
     saw_head: bool,
@@ -218,6 +224,8 @@ impl<'a> ReadState<'a> {
             cells: Vec::new(),
             font_language: None,
             current_border_fill: None,
+            current_char_shape: None,
+            current_para_shape: None,
             head_modeled_children: 0,
             body_modeled_children: 0,
             saw_head: false,
@@ -450,6 +458,8 @@ impl<'a> ReadState<'a> {
         match name {
             "FONTFACE" => self.font_language = None,
             "BORDERFILL" => self.current_border_fill = None,
+            "CHARSHAPE" => self.current_char_shape = None,
+            "PARASHAPE" => self.current_para_shape = None,
             "P" => self.finish_paragraph()?,
             "EQUATION" if self.stack.iter().rev().nth(1).map(String::as_str) == Some("TEXT") => {
                 self.finish_equation()?
@@ -592,7 +602,12 @@ impl<'a> ReadState<'a> {
             self.max_resource_id,
         ) {
             self.warn_resource_id_out_of_range("CHARSHAPE", id);
+            // 건너뛴 CHARSHAPE 의 FONTID/RATIO/... 자식이 다른 도형을 덮어쓰지
+            // 않도록 귀속 대상을 비운다 (BORDERFILL 의 *BORDER 처리와 동일).
+            self.current_char_shape = None;
+            return Ok(());
         }
+        self.current_char_shape = Some(id);
         Ok(())
     }
 
@@ -601,7 +616,10 @@ impl<'a> ReadState<'a> {
         name: &str,
         element: &BytesStart<'_>,
     ) -> Result<(), HmlError> {
-        let Some(shape) = self.source.char_shapes.last_mut() else {
+        let Some(shape) = self
+            .current_char_shape
+            .and_then(|index| self.source.char_shapes.get_mut(index))
+        else {
             return Ok(());
         };
         match name {
@@ -630,12 +648,19 @@ impl<'a> ReadState<'a> {
             self.max_resource_id,
         ) {
             self.warn_resource_id_out_of_range("PARASHAPE", id);
+            // 건너뛴 PARASHAPE 의 PARAMARGIN/PARABORDER 자식도 버린다.
+            self.current_para_shape = None;
+            return Ok(());
         }
+        self.current_para_shape = Some(id);
         Ok(())
     }
 
     fn capture_para_margin(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
-        let Some(shape) = self.source.para_shapes.last_mut() else {
+        let Some(shape) = self
+            .current_para_shape
+            .and_then(|index| self.source.para_shapes.get_mut(index))
+        else {
             return Ok(());
         };
         shape.margin_left = parse_attribute(element, b"Left")?.unwrap_or(0);
@@ -654,7 +679,10 @@ impl<'a> ReadState<'a> {
     }
 
     fn capture_para_border(&mut self, element: &BytesStart<'_>) -> Result<(), HmlError> {
-        if let Some(shape) = self.source.para_shapes.last_mut() {
+        if let Some(shape) = self
+            .current_para_shape
+            .and_then(|index| self.source.para_shapes.get_mut(index))
+        {
             shape.border_fill_id = parse_attribute(element, b"BorderFill")?.unwrap_or(0);
         }
         Ok(())

--- a/src/parser/hwpx/section.rs
+++ b/src/parser/hwpx/section.rs
@@ -2100,6 +2100,7 @@ fn parse_table_cell(
             b"hasMargin" => cell.set_apply_inner_margin(parse_bool(&attr)),
             b"protect" => cell.set_cell_protect(parse_bool(&attr)),
             b"editable" => cell.set_editable_in_form(parse_bool(&attr)),
+            b"dirty" => cell.dirty_flag = parse_bool(&attr),
             // 셀 필드 이름 (누름틀 셀 필드, #493). 직렬화기는 무명 셀도 name=""로
             // 항상 방출하므로 빈 값은 None — HWP5 파서(parse_cell_field_name)와
             // 동일 의미. 누락 시 HWPX 로드에서 getFieldList가 셀 필드를 반환하지 못하고

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -233,7 +233,12 @@ fn make_ctrl_record(ctrl_id: u32, level: u16, ctrl_data: &[u8]) -> Record {
 
 fn serialize_section_def(sd: &SectionDef, level: u16, records: &mut Vec<Record>) {
     let mut w = ByteWriter::new();
-    w.write_u32(sd.flags).unwrap();
+    // HWPX 파서(parse_start_num, pageStartsOn)는 page_num_type 필드만 세팅하고
+    // flags bit 20-21은 동기화하지 않는다. HWP5는 page_num_type을 별도 필드로
+    // 갖지 않고 flags bit 20-21로만 표현하므로, 여기서 반영하지 않으면 HWPX
+    // 출처 문서를 HWP5로 저장할 때 홀/짝 쪽번호 시작 설정이 유실된다.
+    let flags = (sd.flags & !0x0030_0000) | (((sd.page_num_type as u32) & 0x03) << 20);
+    w.write_u32(flags).unwrap();
     w.write_i16(sd.column_spacing).unwrap();
     w.write_i16(sd.line_grid).unwrap();
     w.write_i16(sd.char_grid).unwrap();

--- a/src/serializer/control.rs
+++ b/src/serializer/control.rs
@@ -960,17 +960,41 @@ fn serialize_bookmark_ctrl_data(bm: &Bookmark) -> Option<Vec<u8>> {
 }
 
 /// 글자 겹침 직렬화 (HWP 스펙 표 152)
+///
+/// [#3143] 미검증 `as` 캐스팅 방어:
+/// - 겹칠 글자는 `encode_utf16()` 으로 서로게이트 쌍을 포함해 인코딩하고,
+///   카운트는 파서(parse_char_overlap)와 대칭인 UTF-16 코드유닛 수로 기록한다.
+///   (기존 `ch as u16` 은 비BMP 문자를 하위 16비트로 절단했다.)
+/// - 카운트 필드(u16/u8)는 타입 한계로 상한을 두고 기록 배열도 함께 절단해
+///   카운트와 실제 데이터가 항상 일치하도록 보장한다.
 fn serialize_char_overlap(co: &CharOverlap) -> Vec<u8> {
     let mut w = ByteWriter::new();
-    w.write_u16(co.chars.len() as u16).unwrap();
+
+    // 겹칠 글자: WCHAR(UTF-16LE) 배열, 서로게이트 쌍 포함
+    let mut utf16: Vec<u16> = Vec::with_capacity(co.chars.len());
+    let mut buf = [0u16; 2];
     for &ch in &co.chars {
-        w.write_u16(ch as u16).unwrap();
+        utf16.extend_from_slice(ch.encode_utf16(&mut buf));
     }
+    // u16 카운트 필드 wraparound 방지 (스펙상 최대 9글자라 실사용에선 도달하지 않음)
+    utf16.truncate(u16::MAX as usize);
+    // 절단 끝이 홀로 남은 상위 서로게이트면 함께 제거
+    if matches!(utf16.last(), Some(&last) if (0xD800..=0xDBFF).contains(&last)) {
+        utf16.pop();
+    }
+    w.write_u16(utf16.len() as u16).unwrap();
+    for unit in utf16 {
+        w.write_u16(unit).unwrap();
+    }
+
     w.write_u8(co.border_type).unwrap();
     w.write_i8(co.inner_char_size).unwrap();
     w.write_u8(co.expansion).unwrap();
-    w.write_u8(co.char_shape_ids.len() as u8).unwrap();
-    for &id in &co.char_shape_ids {
+
+    // charshape 카운트: u8 wraparound 방지 — 카운트와 기록 개수를 함께 상한 절단
+    let n_ids = co.char_shape_ids.len().min(u8::MAX as usize);
+    w.write_u8(n_ids as u8).unwrap();
+    for &id in &co.char_shape_ids[..n_ids] {
         w.write_u32(id).unwrap();
     }
     w.into_bytes()

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -58,6 +58,58 @@ fn test_roundtrip_section_def() {
     assert_eq!(parsed.section_def.page_def.height, 84188);
 }
 
+/// [#new] page_num_type 필드만 설정되고 flags 비트(20-21)는 미동기화된
+/// SectionDef를 HWP5로 직렬화 → 재파싱했을 때 page_num_type이 보존되어야 한다.
+///
+/// HWPX 파서(src/parser/hwpx/section.rs::parse_start_num)는 pageStartsOn 속성을
+/// 읽어 page_num_type만 설정하고 flags는 건드리지 않는다. HWP5 직렬화기
+/// (src/serializer/control.rs::serialize_section_def)는 sd.flags를 그대로만
+/// 기록하므로, HWPX 출처 문서를 HWP5로 저장하면 홀/짝 시작 쪽번호 설정이
+/// 유실된다.
+#[test]
+fn test_roundtrip_section_def_page_num_type_without_flags_sync() {
+    let sd = SectionDef {
+        flags: 0,         // HWPX 파서가 남긴 상태: page_num_type만 세팅, flags는 미동기화
+        page_num_type: 1, // 홀수 시작 (ODD)
+        page_def: PageDef {
+            width: 59528,
+            height: 84188,
+            ..Default::default()
+        },
+        ..Default::default()
+    };
+
+    let para = Paragraph {
+        char_count: 3,
+        text: "A".to_string(),
+        char_offsets: vec![8],
+        char_shapes: vec![CharShapeRef {
+            start_pos: 0,
+            char_shape_id: 0,
+        }],
+        line_segs: vec![LineSeg {
+            text_start: 0,
+            ..Default::default()
+        }],
+        controls: vec![Control::SectionDef(Box::new(sd))],
+        ..Default::default()
+    };
+
+    let section = Section {
+        paragraphs: vec![para],
+        raw_stream: None,
+        ..Default::default()
+    };
+
+    let bytes = serialize_section(&section);
+    let parsed = parse_body_text_section(&bytes).unwrap();
+
+    assert_eq!(
+        parsed.section_def.page_num_type, 1,
+        "HWP5 라운드트립 후 page_num_type(홀/짝 쪽번호 시작)이 유실됨"
+    );
+}
+
 /// ColumnDef 라운드트립
 #[test]
 fn test_roundtrip_column_def() {

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -967,7 +967,11 @@ fn char_overlap_non_bmp_char_roundtrip() {
     let Control::CharOverlap(r) = parsed else {
         panic!("CharOverlap 이 아님");
     };
-    assert_eq!(r.chars, vec!['\u{1D400}'], "비BMP 문자가 왕복 보존되어야 함");
+    assert_eq!(
+        r.chars,
+        vec!['\u{1D400}'],
+        "비BMP 문자가 왕복 보존되어야 함"
+    );
     assert_eq!(r.char_shape_ids, vec![3]);
 }
 

--- a/src/serializer/control/tests.rs
+++ b/src/serializer/control/tests.rs
@@ -948,3 +948,62 @@ fn issue2715_shape_without_caption_emits_no_list_header() {
         "캡션 없는 도형은 LIST_HEADER 를 방출하면 안 됨"
     );
 }
+
+/// [#3143] 글자겹침(tcps) 라운드트립: 비BMP 문자(서로게이트 쌍)가 보존되어야 한다.
+///
+/// 파서(parse_char_overlap)는 WCHAR 배열에서 서로게이트 쌍을 디코딩하지만,
+/// 직렬화기는 `ch as u16` 절단 캐스팅으로 하위 16비트만 기록해 왕복이 깨진다.
+#[test]
+fn char_overlap_non_bmp_char_roundtrip() {
+    let co = CharOverlap {
+        chars: vec!['\u{1D400}'], // 𝐀 (MATHEMATICAL BOLD CAPITAL A)
+        border_type: 1,
+        inner_char_size: 100,
+        expansion: 0,
+        char_shape_ids: vec![3],
+    };
+    let data = serialize_char_overlap(&co);
+    let parsed = crate::parser::control::parse_control(tags::CTRL_TCPS, &data, &[]);
+    let Control::CharOverlap(r) = parsed else {
+        panic!("CharOverlap 이 아님");
+    };
+    assert_eq!(r.chars, vec!['\u{1D400}'], "비BMP 문자가 왕복 보존되어야 함");
+    assert_eq!(r.char_shape_ids, vec![3]);
+}
+
+/// [#3143] 글자겹침(tcps) charshape 카운트 필드: u8 랩어라운드로 레코드가 손상되면 안 된다.
+///
+/// HWPX `<hp:compose>` 는 `<hp:charPr>` 자식 수에 제한이 없어 256개 이상이 들어올 수 있고,
+/// 직렬화기의 `len() as u8` 캐스팅이 wraparound 되면 카운트 필드(256→0)와 실제 기록된
+/// ID 개수가 어긋난 손상 레코드가 만들어진다.
+#[test]
+fn char_overlap_256_char_shape_ids_no_wraparound() {
+    let co = CharOverlap {
+        chars: vec!['가'],
+        border_type: 0,
+        inner_char_size: 100,
+        expansion: 0,
+        char_shape_ids: (0u32..256).collect(),
+    };
+    let data = serialize_char_overlap(&co);
+    // 카운트 바이트: chars 카운트(2) + WCHAR(2×1) + 테두리(1) + 크기(1) + 펼침(1) = offset 7
+    let cnt = data[7];
+    // 기록된 ID 바이트 수와 카운트 필드가 일치해야 한다 (손상 레코드 금지)
+    let id_bytes = data.len() - 8;
+    assert_eq!(
+        cnt as usize * 4,
+        id_bytes,
+        "카운트 필드({})와 실제 기록된 ID 바이트({})가 어긋남 — u8 wraparound",
+        cnt,
+        id_bytes
+    );
+    // 왕복 시 charshape ID 가 전량 소실되면 안 된다
+    let parsed = crate::parser::control::parse_control(tags::CTRL_TCPS, &data, &[]);
+    let Control::CharOverlap(r) = parsed else {
+        panic!("CharOverlap 이 아님");
+    };
+    assert!(
+        !r.char_shape_ids.is_empty(),
+        "u8 카운트 wraparound 로 charshape ID 전량 소실"
+    );
+}

--- a/src/serializer/hwpx/table.rs
+++ b/src/serializer/hwpx/table.rs
@@ -278,6 +278,7 @@ fn write_cell<W: Write>(
     let has_margin = bool01(cell.apply_inner_margin);
     let protect = bool01(cell.cell_protect());
     let editable = bool01(cell.editable_in_form());
+    let dirty = bool01(cell.dirty_flag);
     let border_ref = cell.border_fill_id.to_string();
 
     start_tag_attrs(
@@ -289,7 +290,7 @@ fn write_cell<W: Write>(
             ("hasMargin", has_margin),
             ("protect", protect),
             ("editable", editable),
-            ("dirty", "0"),
+            ("dirty", dirty),
             ("borderFillIDRef", &border_ref),
         ],
     )?;
@@ -704,6 +705,34 @@ mod tests {
         let xml = serialize(&t);
         assert!(
             xml.contains(r#"allowOverlap="0""#),
+            "기본 0: {}",
+            &xml[..xml.len().min(300)]
+        );
+    }
+
+    // ---------- tc dirty 속성 라운드트립 ----------
+
+    #[test]
+    fn tc_dirty_flag_preserved_when_set() {
+        // <hp:tc dirty> 는 파싱은 되지만 직렬화 시 "0"으로 하드코딩되어 있었다.
+        // dirty_flag=true 인 셀은 dirty="1" 로 방출돼야 한다. RED(수정 전에는 실패).
+        let mut t = empty_table(1, 1);
+        t.cells[0].dirty_flag = true;
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"dirty="1""#),
+            "dirty_flag=true 인 셀은 dirty=\"1\" 로 방출돼야 한다: {}",
+            &xml[..xml.len().min(500)]
+        );
+    }
+
+    #[test]
+    fn tc_dirty_flag_zero_when_unset() {
+        // dirty_flag=false(기본) 이면 기존 동작대로 dirty="0" 유지.
+        let t = empty_table(1, 1);
+        let xml = serialize(&t);
+        assert!(
+            xml.contains(r#"dirty="0""#),
             "기본 0: {}",
             &xml[..xml.len().min(300)]
         );

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -1,0 +1,123 @@
+//! [#2707 후속] `info`/`dump-note-shape`/`dump-endnote-lines`/`dump-pages`/
+//! `dump-records`/`build-from-ingest` 도 export 계열과 동일한 종료 코드 계약을 따라야 한다.
+//!
+//! #2707 은 export-* / convert / export-hwpx 만 고쳤고, 같은 클래스(치명 실패에도
+//! 종료 코드 0)가 이 진단·조립 명령들에 남아 있다고 명시적으로 §6.1 에 기록했다
+//! (`mydocs/report/task_m100_2707_report.md`). 이 테스트는 그 잔여를 봉인한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+/// HWP5(CFB) 샘플 — `dump-records` 는 HWP3 CFB 아닌 입력을 지원하지 않는다.
+const HWP5_SAMPLE: &str = "samples/2010-01-06.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn hwp5_sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(HWP5_SAMPLE)
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "{}",
+        describe(args, &output)
+    );
+    output
+}
+
+/// 인자 없이 호출 → 사용법 오류(2).
+#[test]
+fn missing_arguments_report_usage_error() {
+    for cmd in ["info", "dump-note-shape", "dump-pages", "dump-records"] {
+        assert_code(&[cmd], 2);
+    }
+    // dump-endnote-lines 는 인자 4개 미만이면 사용법 오류.
+    assert_code(&["dump-endnote-lines", "x.hwp"], 2);
+    assert_code(&["build-from-ingest"], 2);
+}
+
+/// 존재하지 않는 입력 파일 → 런타임 실패(1). #2707 이전에는 전부 0이었다.
+#[test]
+fn unreadable_input_reports_runtime_failure() {
+    assert_code(&["info", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-note-shape", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-pages", "does-not-exist.hwp"], 1);
+    assert_code(&["dump-records", "does-not-exist.hwp"], 1);
+    assert_code(
+        &["dump-endnote-lines", "does-not-exist.hwp", "0", "0", "0"],
+        1,
+    );
+    assert_code(
+        &["build-from-ingest", "does-not-exist.json", "-o", "out.hwpx"],
+        1,
+    );
+}
+
+/// dump-pages 페이지 범위 초과 → 사용법 오류(2) (형제 명령과 정합, #2551 후속 확인).
+#[test]
+fn dump_pages_out_of_range_reports_usage_error() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("valid utf8 path");
+    assert_code(&["dump-pages", sample, "-p", "999999"], 2);
+}
+
+/// build-from-ingest 출력 경로 누락 → 사용법 오류(2).
+#[test]
+fn build_from_ingest_missing_output_reports_usage_error() {
+    assert_code(
+        &[
+            "build-from-ingest",
+            "tools/rhwp-ingest/schema/sample_minimal.json",
+        ],
+        2,
+    );
+}
+
+/// 성공 경로는 여전히 0이어야 한다 (회귀 방지).
+#[test]
+fn successful_diagnostic_commands_return_zero() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("valid utf8 path");
+    for cmd in ["info", "dump-note-shape", "dump-pages"] {
+        let output = run(&[cmd, sample]);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{}",
+            describe(&[cmd, sample], &output)
+        );
+    }
+
+    let hwp5_sample = hwp5_sample_path();
+    let hwp5_sample = hwp5_sample.to_str().expect("valid utf8 path");
+    let output = run(&["dump-records", hwp5_sample]);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "{}",
+        describe(&["dump-records", hwp5_sample], &output)
+    );
+}

--- a/tests/cli_exit_codes_dump_diag.rs
+++ b/tests/cli_exit_codes_dump_diag.rs
@@ -1,0 +1,91 @@
+//! [#3172] `dump`/`diag` CLI 종료 코드 계약 회귀 테스트.
+//!
+//! `#2707`(PR #2711)·`#3169`(PR #3171)이 각각 export-*/convert/export-hwpx 와
+//! info/dump-note-shape/dump-endnote-lines/dump-pages/dump-records/build-from-ingest 에
+//! 적용한 계약(0 성공 / 1 런타임 실패 / 2 사용법 오류)을, 두 PR이 명시적으로 범위 밖에
+//! 남겨둔 `dump`(dump_controls)·`diag`(diag_document) 에도 동일하게 확장한다.
+#![cfg(not(target_arch = "wasm32"))]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Output};
+
+const SAMPLE: &str = "samples/hwp3-sample.hwp";
+
+fn sample_path() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(SAMPLE)
+}
+
+fn unique_temp_path(label: &str) -> PathBuf {
+    let nonce = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system clock")
+        .as_nanos();
+    std::env::temp_dir().join(format!(
+        "rhwp-exit-codes-dump-diag-{label}-{}-{nonce}",
+        std::process::id()
+    ))
+}
+
+fn run(args: &[&str]) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+        .args(args)
+        .output()
+        .expect("rhwp 실행 실패")
+}
+
+fn describe(args: &[&str], output: &Output) -> String {
+    format!(
+        "명령: rhwp {}\nstdout:\n{}\nstderr:\n{}",
+        args.join(" "),
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    )
+}
+
+fn assert_code(args: &[&str], expected: i32) -> Output {
+    let output = run(args);
+    assert_eq!(
+        output.status.code(),
+        Some(expected),
+        "종료 코드 {expected} 를 기대했다\n{}",
+        describe(args, &output)
+    );
+    output
+}
+
+#[test]
+fn missing_arguments_report_usage_error() {
+    for command in ["dump", "diag"] {
+        assert_code(&[command], 2);
+    }
+}
+
+#[test]
+fn unreadable_input_reports_runtime_failure() {
+    let missing = unique_temp_path("missing.hwp");
+    let missing = missing.to_str().expect("utf-8 경로").to_string();
+
+    assert_code(&["dump", &missing], 1);
+    assert_code(&["diag", &missing], 1);
+}
+
+#[test]
+fn unparseable_input_reports_runtime_failure() {
+    let bogus = unique_temp_path("bogus-not-hwp");
+    std::fs::write(&bogus, b"not a real hwp document").expect("파싱 실패 유도용 파일 생성");
+    let bogus = bogus.to_str().expect("utf-8 경로").to_string();
+
+    assert_code(&["dump", &bogus], 1);
+    assert_code(&["diag", &bogus], 1);
+
+    let _ = std::fs::remove_file(&bogus);
+}
+
+#[test]
+fn successful_run_returns_zero() {
+    let sample = sample_path();
+    let sample = sample.to_str().expect("utf-8 경로");
+
+    assert_code(&["dump", sample], 0);
+    assert_code(&["diag", sample], 0);
+}

--- a/tests/issue_hml_shape_child_attribution.rs
+++ b/tests/issue_hml_shape_child_attribution.rs
@@ -1,0 +1,85 @@
+//! HML 리소스 자식 요소 귀속 검증.
+//!
+//! CHARSHAPE/PARASHAPE 는 `Id` 속성 위치에 배치되는데(set_indexed), 자식 요소
+//! (FONTID/RATIO/CHARSPACING/RELSIZE/CHAROFFSET, PARAMARGIN/PARABORDER)는
+//! `last_mut()` 로 귀속된다. Id 가 내림차순이거나 상한 초과로 건너뛴 경우
+//! 자식 값이 엉뚱한 리소스에 덮어써진다.
+
+use rhwp::parser::hml::{parse_hml, parse_hml_with_limits, HmlLimits};
+
+fn wrap_head(mapping_table: &str) -> Vec<u8> {
+    format!(
+        r#"<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<HWPML Version="2.91">
+  <HEAD SecCnt="1"><MAPPINGTABLE>{mapping_table}</MAPPINGTABLE></HEAD>
+  <BODY><SECTION Id="0"><P ParaShape="0" Style="0"><TEXT CharShape="0"><CHAR>x</CHAR></TEXT></P></SECTION></BODY>
+  <TAIL />
+</HWPML>"#
+    )
+    .into_bytes()
+}
+
+/// Id 가 내림차순인 CHARSHAPE 목록: 각 도형의 RATIO 는 자기 CHARSHAPE 에 귀속되어야 한다.
+#[test]
+fn charshape_children_follow_out_of_order_ids() {
+    let xml = wrap_head(
+        r#"<CHARSHAPELIST Count="2">
+             <CHARSHAPE Id="1" Height="1100">
+               <RATIO Hangul="90" Latin="90" Hanja="90" Japanese="90" Other="90" Symbol="90" User="90"/>
+             </CHARSHAPE>
+             <CHARSHAPE Id="0" Height="1000">
+               <RATIO Hangul="50" Latin="50" Hanja="50" Japanese="50" Other="50" Symbol="50" User="50"/>
+             </CHARSHAPE>
+           </CHARSHAPELIST>"#,
+    );
+    let result = parse_hml(&xml).expect("parse should succeed");
+    let shapes = &result.document.doc_info.char_shapes;
+    assert_eq!(shapes[1].ratios, [90; 7], "Id=1 의 RATIO 는 90 이어야 한다");
+    assert_eq!(shapes[0].ratios, [50; 7], "Id=0 의 RATIO 는 50 이어야 한다");
+}
+
+/// 상한 초과로 건너뛴 CHARSHAPE 의 자식이 직전 정상 CHARSHAPE 를 오염시키면 안 된다.
+#[test]
+fn skipped_charshape_children_do_not_pollute_previous_shape() {
+    let xml = wrap_head(
+        r#"<CHARSHAPELIST Count="2">
+             <CHARSHAPE Id="0" Height="1000">
+               <RATIO Hangul="100" Latin="100" Hanja="100" Japanese="100" Other="100" Symbol="100" User="100"/>
+             </CHARSHAPE>
+             <CHARSHAPE Id="9" Height="1000">
+               <RATIO Hangul="10" Latin="10" Hanja="10" Japanese="10" Other="10" Symbol="10" User="10"/>
+             </CHARSHAPE>
+           </CHARSHAPELIST>"#,
+    );
+    let limits = HmlLimits {
+        max_resource_id: 4,
+        ..HmlLimits::default()
+    };
+    let result = parse_hml_with_limits(&xml, &limits).expect("parse should succeed");
+    let shapes = &result.document.doc_info.char_shapes;
+    assert_eq!(
+        shapes[0].ratios, [100; 7],
+        "건너뛴 CHARSHAPE Id=9 의 RATIO 가 Id=0 을 덮어쓰면 안 된다"
+    );
+}
+
+/// Id 가 내림차순인 PARASHAPE: PARAMARGIN 은 자기 PARASHAPE 에 귀속되어야 한다.
+#[test]
+fn parashape_margin_follows_out_of_order_ids() {
+    let xml = wrap_head(
+        r#"<PARASHAPELIST Count="2">
+             <PARASHAPE Id="1" Align="Left">
+               <PARAMARGIN Left="700" Right="700" LineSpacing="150"/>
+             </PARASHAPE>
+             <PARASHAPE Id="0" Align="Justify">
+               <PARAMARGIN Left="300" Right="300" LineSpacing="200"/>
+             </PARASHAPE>
+           </PARASHAPELIST>"#,
+    );
+    let result = parse_hml(&xml).expect("parse should succeed");
+    let shapes = &result.document.doc_info.para_shapes;
+    assert_eq!(shapes[1].margin_left, 700, "Id=1 의 PARAMARGIN Left");
+    assert_eq!(shapes[1].line_spacing, 150, "Id=1 의 LineSpacing");
+    assert_eq!(shapes[0].margin_left, 300, "Id=0 의 PARAMARGIN Left");
+    assert_eq!(shapes[0].line_spacing, 200, "Id=0 의 LineSpacing");
+}


### PR DESCRIPTION
kevin9327 님의 소형 잔여 10건(hwpx 왕복·hwpx2hwp 변환·hml·hwp5 직렬화·CLI·차트)을 메인테이너가 재실증 후 통합한다. 충돌분 2건을 흡수했다.

## 채택 10건

| PR | 결함 |
|---|---|
| #3115 (`Closes #2948`) | HWPX `<hp:tc dirty>` 셀 속성 라운드트립 소실 |
| #3119 (`Closes #2767`) | HWPX→HWP 그림 캡션 attr 비트(bit 29) + BinData remap 잔여(숨은설명·그룹 캡션) |
| #3150 (`Closes #3146`) | HML CHARSHAPE/PARASHAPE 자식 요소가 등장 순서 도형에 오귀속 — Id 위치 귀속으로 정정 |
| #3151 (`Closes #3143`) | 글자겹침(tcps) 직렬화의 미검증 캐스팅 — 비BMP 절단·u8 카운트 wraparound |
| #3164 (`Closes #3161`) | 표 CTRL_HEADER "표 번호" 비트 무조건 설정 → numberingType=TABLE 일 때만 |
| #3171 (`Closes #3169`) | CLI 진단 명령 6종 실패 시 종료 코드 미반환 |
| #3180 (`Closes #3178`) | CLI dump/diag 오류 시 종료 코드 0 반환 |
| #3190 | 파이 차트 시리즈 이름 부재 시 범례 공간 미예약 |
| #3193 (`Closes #3191`) | 숨은설명 안 그림이 BinData 순서 수집에서 누락 |
| #3196 | SectionDef page_num_type 이 flags 비트 20-21 에 미동기화되어 저장 시 유실 |

## 충돌 흡수와 판단

- **#3171/#3180 상호보완 결합**: 두 형제가 서로 다른 명령군에 exit_with 를 배선 — doclang(export-doclang) 포함 전 명령으로 통일.
- **#3193 중복 정리**: remap 절반이 같은 배치의 #3119 와 겹침 — 중복 테스트/코드는 걷어내고 고유분(collect 워크의 HiddenComment 방문 + 테스트)만 편입.

## 검증

- `cargo fmt --check` 통과, clippy 경고 0, **전체 `--tests` 스위트 무실패**
- 신규 테스트 표적 통과 (collect/remap·CLI 종료 코드·tcps 방어 등)

Co-authored-by 로 원 커밋 provenance 를 보존한다.
