### PR TITLE
fix(hwp3): 각주 분리선 여백(footnote_line_margin) IR 배선 + endnote_shape 시그니처 통일 — kevin9327 #3049

### DIFF
--- a/mydocs/report/task_m100_2772_report.md
+++ b/mydocs/report/task_m100_2772_report.md
@@ -1,0 +1,39 @@
+# Task #2772 — HWP3 footnote_line_margin → separator_margin_top 배선
+
+## 이슈
+- edwardkim/rhwp#3046
+
+## 배경
+
+`Hwp3DocInfo`의 `impl` 블록에는 `read()` 외 별도 accessor 메서드가 없어, 필드는 전부 `pub` 필드로
+직접 참조된다. `src/parser/hwp3/mod.rs`에서 각 필드의 실사용 여부를 확인한 결과
+`footnote_line_margin`(오프셋 104, "각주 분리선과 본문 사이의 간격", `한글문서파일구조3.0.md` 10.11절)이
+파싱만 되고 어디에도 배선되지 않은 상태였다.
+
+`footnote_bracket`(#3023), `footnote_line_width`(#3027), `footnote_between_margin`(#3036)는 이미
+별도 PR로 진행 중이라 중복을 피하고 `footnote_line_margin`을 선택했다.
+
+## 원인
+
+HWP3 각주/미주 모양은 `hwp3_default_endnote_shape()`가 만드는데, 이 함수는 `doc_info`를 전혀
+받지 않고 `separator_margin_top`(분리선 위 여백)을 하드코딩된 864로 채우고 있었다.
+
+## 수정
+
+- `hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo)`로 시그니처 변경.
+- `doc_info.footnote_line_margin`이 0이 아니면 `× 4`(HWP3 hunit → HWPUNIT, 기존 margin 필드들과 동일한
+  변환 규칙)해 `separator_margin_top`으로 배선. 0이면 기존 기본값 864 유지(회귀 방지).
+- 호출부 `fixup_hwp3_notes(doc, doc_info)`로 `doc_info`를 관통 전달.
+
+## 검증
+
+- `cargo check --lib` 통과.
+- `cargo test --lib task2772_hwp3_default_endnote_shape` 1개 통과.
+
+## 남은 doc_info 필드
+
+`footnote_bracket`, `footnote_line_width`, `footnote_between_margin`은 각각 오픈 PR(#3023/#3027/#3036)에서
+다루는 중이며, `footnote_text_margin`은 유사 후속 작업 후보로 남아 있다. 나머지 필드
+(cursor_para/cursor_pos, paper_kind, doc_protected, reserved1, link_page_number, link_footnote_number,
+link_print_file, description, encrypted, footnote_reserved, move_frame, sub_revision)는 파서 내부 상태이거나
+IR로 옮길 대응 필드가 없어 미배선이 타당하다.

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -523,7 +523,11 @@ fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote:
         // doc_info offset 110 "각주 옵션": ')' = 번호에 ')' 붙임, 0 = 안 붙임.
         // 파싱만 되고(footnote_bracket) 항상 ')' 로 하드코딩되어 옵션을 끈 문서도
         // ')' 가 표시되던 문제.
-        suffix_char: if doc_info.footnote_bracket != 0 { ')' } else { '\0' },
+        suffix_char: if doc_info.footnote_bracket != 0 {
+            ')'
+        } else {
+            '\0'
+        },
         start_number: 1,
         separator_margin_top,
         note_spacing: 576,

--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -504,9 +504,18 @@ fn apply_hwp3_encrypted_flag(
     }
 }
 
-fn hwp3_default_endnote_shape(bracket: bool) -> crate::model::footnote::FootnoteShape {
+fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote::FootnoteShape {
     use crate::model::footnote::{
         FootnoteNumbering, FootnotePlacement, FootnoteShape, NumberFormat,
+    };
+
+    // [Task #2772] doc_info.footnote_line_margin(오프셋 104, "각주 분리선과 본문
+    // 사이의 간격")을 separator_margin_top 으로 배선한다. 미배선 시 항상
+    // 하드코딩된 864 값이 쓰여 문서가 지정한 간격이 무시됐다.
+    let separator_margin_top = if doc_info.footnote_line_margin != 0 {
+        (doc_info.footnote_line_margin as i16).saturating_mul(4)
+    } else {
+        864
     };
 
     let mut shape = FootnoteShape {
@@ -514,9 +523,9 @@ fn hwp3_default_endnote_shape(bracket: bool) -> crate::model::footnote::Footnote
         // doc_info offset 110 "각주 옵션": ')' = 번호에 ')' 붙임, 0 = 안 붙임.
         // 파싱만 되고(footnote_bracket) 항상 ')' 로 하드코딩되어 옵션을 끈 문서도
         // ')' 가 표시되던 문제.
-        suffix_char: if bracket { ')' } else { '\0' },
+        suffix_char: if doc_info.footnote_bracket != 0 { ')' } else { '\0' },
         start_number: 1,
-        separator_margin_top: 864,
+        separator_margin_top,
         note_spacing: 576,
         separator_line_width: 1,
         separator_color: 0x00000000,
@@ -3416,7 +3425,7 @@ pub fn parse_hwp3(data: &[u8]) -> Result<Document, Hwp3Error> {
     super::populate_link_image_paths(&mut doc);
 
     crate::parser::assign_auto_numbers(&mut doc);
-    fixup_hwp3_notes(&mut doc, doc_info.footnote_bracket != 0);
+    fixup_hwp3_notes(&mut doc, &doc_info);
     fixup_hwp3_outline_fields(&mut doc);
     fixup_hwp3_picture_numbers(&mut doc);
     fixup_hwp3_outline_bullets(&mut doc);
@@ -3432,7 +3441,7 @@ struct Hwp3NoteFixupState {
     has_endnote: bool,
 }
 
-fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, footnote_bracket: bool) {
+fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, doc_info: &Hwp3DocInfo) {
     let para_shapes = doc.doc_info.para_shapes.clone();
     let mut state = Hwp3NoteFixupState {
         footnote_number: doc.doc_properties.footnote_start_num.max(1),
@@ -3448,7 +3457,7 @@ fn fixup_hwp3_notes(doc: &mut crate::model::document::Document, footnote_bracket
 
     if state.has_endnote {
         for section in &mut doc.sections {
-            section.section_def.endnote_shape = hwp3_default_endnote_shape(footnote_bracket);
+            section.section_def.endnote_shape = hwp3_default_endnote_shape(doc_info);
             ensure_hwp3_initial_body_column_def(&mut section.paragraphs);
             let page_def = &section.section_def.page_def;
             let body_width_hu = page_def
@@ -4083,11 +4092,14 @@ mod tests {
     fn issue_hwp3_endnote_suffix_char_wires_footnote_bracket_flag() {
         // doc_info offset 110 "각주 옵션" footnote_bracket 이 파싱만 되고 항상 ')' 로
         // 하드코딩되어, 옵션을 끈(footnote_bracket=0) 문서도 미주 번호에 ')' 가 붙던 문제.
-        let on = hwp3_default_endnote_shape(true);
-        assert_eq!(on.suffix_char, ')');
+        let on = Hwp3DocInfo {
+            footnote_bracket: 1,
+            ..Default::default()
+        };
+        assert_eq!(hwp3_default_endnote_shape(&on).suffix_char, ')');
 
-        let off = hwp3_default_endnote_shape(false);
-        assert_eq!(off.suffix_char, '\0');
+        let off = Hwp3DocInfo::default();
+        assert_eq!(hwp3_default_endnote_shape(&off).suffix_char, '\0');
     }
 
     #[test]
@@ -4329,6 +4341,22 @@ mod tests {
             ..Default::default()
         };
         assert!(!hwp3_hide_empty_line(&off));
+    }
+
+    #[test]
+    fn task2772_hwp3_default_endnote_shape_wires_footnote_line_margin() {
+        // [Task #2772] doc_info.footnote_line_margin 이 separator_margin_top 으로
+        // 배선돼야 한다. 값이 0이면 기존 하드코딩 기본값(864)을 유지한다.
+        let doc_info = Hwp3DocInfo {
+            footnote_line_margin: 50,
+            ..Default::default()
+        };
+        let shape = hwp3_default_endnote_shape(&doc_info);
+        assert_eq!(shape.separator_margin_top, 200);
+
+        let default_doc_info = Hwp3DocInfo::default();
+        let default_shape = hwp3_default_endnote_shape(&default_doc_info);
+        assert_eq!(default_shape.separator_margin_top, 864);
     }
 
     #[test]

--- a/tests/issue_1692.rs
+++ b/tests/issue_1692.rs
@@ -514,7 +514,19 @@ fn issue_1692_so_sueop_hwp3_endnotes_follow_hwpx_numbering_and_width() {
     let hwp3_shape = &hwp3_doc.sections[0].section_def.endnote_shape;
     let hwpx_shape = &hwpx_doc.sections[0].section_def.endnote_shape;
     assert_eq!(hwp3_shape.suffix_char, hwpx_shape.suffix_char);
-    assert_eq!(
+    // [Task #2772 후속] HWP3 doc_info.footnote_line_margin(hunit=1/1800in)이
+    // separator_margin_top(HWPUNIT=1/7200in)으로 배선된 이후, 이 값은 더 이상
+    // 하드코딩된 864가 아니라 SO-SUEOP.hwp 자체에 저장된 실측치(213 hunit → 852)다.
+    // SO-SUEOP.hwpx는 별도로 저장된 aboveLine="864" 값을 갖고 있어 두 샘플이 서로
+    // 다른 시점/도구로 생성된 탓에 비트 단위로 일치하지 않는다(0.12in vs 0.1183in,
+    // 차이 12 HWPUNIT ≈ 0.04mm). 두 포맷이 "같은 문서"의 각주 분리선 여백을 각자의
+    // 정밀도로 보존하는지만 근접값으로 검증한다. 완전 동일 저장을 요구하려면
+    // SO-SUEOP.hwp/.hwpx 샘플 쌍을 동일 여백으로 재생성해야 한다.
+    let separator_margin_top_diff =
+        (hwp3_shape.separator_margin_top as i32 - hwpx_shape.separator_margin_top as i32).abs();
+    assert!(
+        separator_margin_top_diff <= 16,
+        "HWP3/HWPX separator_margin_top must be within HWP3 hunit rounding tolerance: hwp3={} hwpx={}",
         hwp3_shape.separator_margin_top,
         hwpx_shape.separator_margin_top
     );


### PR DESCRIPTION
kevin9327 님의 #3049(각주 분리선 여백 IR 배선)를 메인테이너가 재실증 후 통합한다. 각주 축 3건 중 첫 채택이다.

## 채택 내용 (`Closes #3046`)

`Hwp3DocInfo.footnote_line_margin`(오프셋 104, hunit=1/1800in)이 파싱만 되고 버려져 각주/미주 모양의 `separator_margin_top` 이 항상 864 하드코딩이던 결함 수정 — ×4 로 HWPUNIT(1/7200in) 변환해 배선, 0 이면 기본값 864 유지.

## 시그니처 통일 (충돌 해소)

`hwp3_default_endnote_shape(bracket: bool)` → **`(&Hwp3DocInfo)`** 로 통일하고 bracket(suffix_char)은 내부에서 유도한다. 각주 계열 후속 배선(#3059 등)이 같은 시그니처를 쓰는 기반이 된다 — #3183 에서 시도했던 A안 방향과 일치.

## #1692 계약 판정 (작업지시자 승인)

- **정답지 쪽 범위 계약(`answer_endnote_pages_match_pdf_ranges`)은 그대로 엄격 통과** — 이 배선은 조판을 흔들지 않는다 (#3036 과의 차이).
- 교차 포맷 동일성 테스트 1건만 852 vs 864 로 어긋났는데, SO-SUEOP.hwp(213 hunit 저장)와 .hwpx(aboveLine=864 저장)가 **서로 다른 시점·도구로 저장돼 다른 값을 갖는 것**이 원인이다(차이 12 HWPUNIT ≈ 0.04mm, 시각 판별 불가). 기여자가 단위 근거와 함께 ±16(1 hunit 반올림) 근접 허용으로 완화한 것을 **작업지시자 승인 하에 수용**했다.

## 검증

- #1692 계약 11건 전부 green, `cargo fmt --check` 통과, clippy 0, **전체 `--tests` 스위트 무실패**

Co-authored-by 로 원 커밋 provenance 를 보존한다.
