### PR TITLE
fix(hwp3): 각주 분리선-본문 간격(footnote_text_margin) IR 배선 — kevin9327 #3059

### DIFF
--- a/src/parser/hwp3/mod.rs
+++ b/src/parser/hwp3/mod.rs
@@ -518,6 +518,15 @@ fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote:
         864
     };
 
+    // [Task #3054] doc_info.footnote_text_margin(각주 분리선과 각주 본문 사이의
+    // 간격)을 note_spacing 으로 배선한다. 미배선 시 항상 하드코딩된 576 값이
+    // 쓰여 문서가 지정한 간격이 무시됐다.
+    let note_spacing = if doc_info.footnote_text_margin != 0 {
+        (doc_info.footnote_text_margin as i16).saturating_mul(4)
+    } else {
+        576
+    };
+
     let mut shape = FootnoteShape {
         number_format: NumberFormat::Digit,
         // doc_info offset 110 "각주 옵션": ')' = 번호에 ')' 붙임, 0 = 안 붙임.
@@ -530,7 +539,7 @@ fn hwp3_default_endnote_shape(doc_info: &Hwp3DocInfo) -> crate::model::footnote:
         },
         start_number: 1,
         separator_margin_top,
-        note_spacing: 576,
+        note_spacing,
         separator_line_width: 1,
         separator_color: 0x00000000,
         numbering: FootnoteNumbering::Continue,
@@ -4141,6 +4150,22 @@ mod tests {
         apply_hwp3_compressed_flag(1, &mut header);
         assert!(header.compressed);
         assert_eq!(header.raw_data.unwrap()[36] & 0x01, 0x01);
+    }
+
+    #[test]
+    fn task3054_hwp3_default_endnote_shape_wires_footnote_text_margin() {
+        // [Task #3054] doc_info.footnote_text_margin 이 note_spacing 으로
+        // 배선돼야 한다. 값이 0이면 기존 하드코딩 기본값(576)을 유지한다.
+        let doc_info = Hwp3DocInfo {
+            footnote_text_margin: 50,
+            ..Default::default()
+        };
+        let shape = hwp3_default_endnote_shape(&doc_info);
+        assert_eq!(shape.note_spacing, 200);
+
+        let default_doc_info = Hwp3DocInfo::default();
+        let default_shape = hwp3_default_endnote_shape(&default_doc_info);
+        assert_eq!(default_shape.note_spacing, 576);
     }
 
     #[test]

--- a/tests/issue_1692.rs
+++ b/tests/issue_1692.rs
@@ -530,7 +530,16 @@ fn issue_1692_so_sueop_hwp3_endnotes_follow_hwpx_numbering_and_width() {
         hwp3_shape.separator_margin_top,
         hwpx_shape.separator_margin_top
     );
-    assert_eq!(hwp3_shape.note_spacing, hwpx_shape.note_spacing);
+    // [Task #3054 후속] note_spacing 도 같은 이유로 근접값 검증 — SO-SUEOP.hwp 는
+    // footnote_text_margin=142 hunit(→568 HWPUNIT), .hwpx 는 belowLine=576 을
+    // 저장하고 있다(차이 8 HWPUNIT ≈ 0.03mm, 샘플 쌍의 저장 시점 차이).
+    let note_spacing_diff = (hwp3_shape.note_spacing as i32 - hwpx_shape.note_spacing as i32).abs();
+    assert!(
+        note_spacing_diff <= 16,
+        "HWP3/HWPX note_spacing must be within HWP3 hunit rounding tolerance: hwp3={} hwpx={}",
+        hwp3_shape.note_spacing,
+        hwpx_shape.note_spacing
+    );
     assert_eq!(
         hwp3_shape.separator_line_width,
         hwpx_shape.separator_line_width


### PR DESCRIPTION
kevin9327 님의 #3059(각주 분리선-본문 간격 IR 배선)를 메인테이너가 재실증 후 통합한다. #3049(#3225) 로 통일된 `&Hwp3DocInfo` 시그니처 위에 얹는 각주 축 두 번째 채택이다.

## 채택 내용 (`Closes #3054`)

`Hwp3DocInfo.footnote_text_margin`(오프셋 106, hunit)이 파싱만 되고 버려져 `note_spacing`(한컴 UI "구분선 아래")이 항상 576 하드코딩이던 결함 수정 — ×4 HWPUNIT 변환 배선, 0 이면 기본값 576 유지.

## #1692 계약 판정 (작업지시자 승인)

- **정답지 쪽 범위 계약은 그대로 엄격 통과** — 조판을 흔들지 않는다.
- 교차 포맷 동일성 1건만 568 vs 576 (SO-SUEOP.hwp 는 142 hunit, .hwpx 는 belowLine=576 저장 — 샘플 쌍의 저장 시점 차이, 8 HWPUNIT ≈ 0.03mm). #3049 에서 승인된 것과 동일 근거로 note_spacing 비교에도 ±16(1 hunit) 근접 허용을 적용했다(사유 주석 포함).

## 검증

- #1692 계약 11건 green, `cargo fmt --check` 통과, clippy 0, **전체 `--tests` 스위트 무실패**(#3049 위 검증 완료 후 merge 된 devel 에 재적용)

Co-authored-by 로 원 커밋 provenance 를 보존한다.
