### PR TITLE
ci: #3233 문서-only Update merge fast-pass 재사용 보완

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -117,6 +117,11 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
+            function isCurrentBaseReviewMerge(commit, baseSha) {
+              const parents = commit.parents || [];
+              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -178,12 +183,23 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  if ((commit.parents || []).length !== 1) {
-                    setResult(false, `${reviewOnlyLabel(files)}-merge-commit:${sha}`);
-                    return;
+                  const parents = commit.parents || [];
+                  if (parents.length === 1) {
+                    trailingReviewOnlyCommits += 1;
+                    continue;
                   }
-                  trailingReviewOnlyCommits += 1;
-                  continue;
+                  // #3233: a docs-only Update branch merge can be the already-verified
+                  // candidate after one or more trailing review-record commits. It must
+                  // be exactly a merge of the current PR base; all other merge shapes
+                  // retain the conservative full-CI fallback.
+                  if (trailingReviewOnlyCommits > 0
+                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
+                    candidateSha = sha;
+                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    break;
+                  }
+                  setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
+                  return;
                 }
 
                 candidateSha = sha;

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -112,6 +112,11 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
+            function isCurrentBaseReviewMerge(commit, baseSha) {
+              const parents = commit.parents || [];
+              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -173,12 +178,23 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  if ((commit.parents || []).length !== 1) {
-                    setResult(false, `${reviewOnlyLabel(files)}-merge-commit:${sha}`);
-                    return;
+                  const parents = commit.parents || [];
+                  if (parents.length === 1) {
+                    trailingReviewOnlyCommits += 1;
+                    continue;
                   }
-                  trailingReviewOnlyCommits += 1;
-                  continue;
+                  // #3233: a docs-only Update branch merge can be the already-verified
+                  // candidate after one or more trailing review-record commits. It must
+                  // be exactly a merge of the current PR base; all other merge shapes
+                  // retain the conservative full-CodeQL fallback.
+                  if (trailingReviewOnlyCommits > 0
+                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
+                    candidateSha = sha;
+                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    break;
+                  }
+                  setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
+                  return;
                 }
 
                 candidateSha = sha;

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -122,6 +122,11 @@ jobs:
               return hasReferenceArtifact ? 'review-reference-only' : 'mydocs-only';
             }
 
+            function isCurrentBaseReviewMerge(commit, baseSha) {
+              const parents = commit.parents || [];
+              return parents.length === 2 && parents.some((parent) => parent.sha === baseSha);
+            }
+
             function latestRun(runs) {
               return runs
                 .slice()
@@ -183,12 +188,23 @@ jobs:
 
                 const reviewOnly = files.every((file) => isAllowedReviewPath(file));
                 if (reviewOnly) {
-                  if ((commit.parents || []).length !== 1) {
-                    setResult(false, `${reviewOnlyLabel(files)}-merge-commit:${sha}`);
-                    return;
+                  const parents = commit.parents || [];
+                  if (parents.length === 1) {
+                    trailingReviewOnlyCommits += 1;
+                    continue;
                   }
-                  trailingReviewOnlyCommits += 1;
-                  continue;
+                  // #3233: a docs-only Update branch merge can be the already-verified
+                  // candidate after one or more trailing review-record commits. It must
+                  // be exactly a merge of the current PR base; all other merge shapes
+                  // retain the conservative full-render fallback.
+                  if (trailingReviewOnlyCommits > 0
+                    && isCurrentBaseReviewMerge(commit, pr.base.sha)) {
+                    candidateSha = sha;
+                    core.info(`using current-base ${reviewOnlyLabel(files)} merge as candidate SHA ${candidateSha}`);
+                    break;
+                  }
+                  setResult(false, `${reviewOnlyLabel(files)}-merge-not-reusable:${sha}`);
+                  return;
                 }
 
                 candidateSha = sha;

--- a/mydocs/manual/pr_review_workflow.md
+++ b/mydocs/manual/pr_review_workflow.md
@@ -1234,9 +1234,14 @@ PR 커밋 전에 archive 경로로 이동한다. archive 이동만을 위한 별
   - 신규 추가(`added`) 상태의 `samples/**/*.png`
   - 신규 추가(`added`) 상태의 `pdf/**/*.pdf`
 - 기존 `samples/**` 또는 `pdf/**` 파일을 수정, 삭제, rename 한 경우 fast-pass 대상이 아니다.
-- 해당 후속 커밋들은 single-parent commit 이다.
-- 후속 문서 커밋을 제외한 직전 코드 검증 대상 SHA 에 기존 GitHub Actions check-run 이 존재한다.
-- 직전 코드 검증 대상 SHA 의 relevant check 가 `success`, `skipped`, `neutral` 중 하나다.
+- 해당 후속 문서 커밋들은 single-parent commit 이다. 단, 그 바로 앞 candidate SHA 는 문서-only
+  Update branch merge일 수 있다. 이 예외는 다음을 모두 만족할 때만 허용한다.
+  - merge parent 수가 정확히 2개이고 현재 PR `base.sha`를 parent로 포함한다.
+  - merge diff도 허용된 review-only 경로만 포함한다.
+  - 적어도 하나의 trailing single-parent 후속 문서 커밋이 그 merge 뒤에 있다.
+- 후속 문서 커밋을 제외한 직전 검증 대상 SHA(코드 commit 또는 위 문서-only Update branch merge)에 기존
+  GitHub Actions check-run 이 존재한다.
+- 직전 검증 대상 SHA 의 relevant check 가 `success`, `skipped`, `neutral` 중 하나다.
 
 fast-pass 는 merge 조건을 약화하는 예외가 아니다. 이전 코드 검증 결과를 재사용하는 좁은 최적화일 뿐이다.
 다음 변경이 포함되면 반드시 최신 PR head 기준 heavy CI 를 다시 기다린다.
@@ -1244,7 +1249,8 @@ fast-pass 는 merge 조건을 약화하는 예외가 아니다. 이전 코드 �
 - 코드, 테스트, CI workflow 파일(`.github/workflows/**`) 변경
 - 기존 샘플, baseline, golden, 렌더링 fixture 변경
 - `mydocs/**` 밖의 파일 변경 또는 신규 기준 샘플/PDF 추가가 아닌 실행/검증 입력 파일 변경
-- check-run 조회 실패, missing check, failed check, merge commit 형태의 문서 후속 커밋
+- check-run 조회 실패, missing check, failed check, 현재 base를 parent로 포함하지 않는 merge commit 형태의
+  문서 후속 커밋
 
 fast-pass 가 적용되면 PR UI 에서 heavy job 이 `skipped` 로 보일 수 있다. 이때도 collaborator 는 GitHub Actions
 결과가 merge 가능 상태인지 확인하고, branch protection 이 요구하는 check 가 pending/failing 이면 merge 하지

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -129,7 +129,7 @@ devel 판과 PR 적용판을 각각 native-skia 로 빌드해 SO-SUEOP.hwp 42·4
 
 - [#3233](https://github.com/edwardkim/rhwp/issues/3233)의 재현 사례(#3123 문서 보강 후 full CI 재실행)를 바탕으로, [#3235](https://github.com/edwardkim/rhwp/pull/3235)에 CI·CodeQL·Render Diff preflight의 재사용 guard를 보완했다.
 - trailing 문서 커밋 직전의 candidate가 현재 base를 부모로 포함하는 정확히 2-parent 문서-only Update branch merge일 때만 기존 check를 재사용한다. merge diff, trailing 문서 커밋, parent/base 조건이 하나라도 맞지 않으면 full CI로 fallback한다.
-- workflow 변경이 포함된 최초 head에서는 full CI를 의도적으로 실행해 Build & Test 8 shards, Lint, Native Skia, Frontend, CodeQL, Canvas visual diff를 모두 통과했다. 이후 이 오늘할일과 archive review만 후속 문서 커밋으로 push해 heavy CI skip을 실제 검증한다.
+- workflow 변경이 포함된 최초 head에서는 full CI를 의도적으로 실행해 Build & Test 8 shards, Lint, Native Skia, Frontend, CodeQL, Canvas visual diff를 모두 통과했다. 이후 이 오늘할일과 archive review만 후속 문서 커밋으로 push했고, preflight·Build & Test 집계 성공과 heavy job 전부 skipped, `CLEAN` 상태를 실제로 확인했다.
 
 ## 오후 추가분 — 각주 축 2건 채택 (#3049 #3059)
 

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -125,6 +125,12 @@ devel 판과 PR 적용판을 각각 native-skia 로 빌드해 SO-SUEOP.hwp 42·4
 이틀 누적으로 kevin9327 연작 83건이 merge 됐고, 남은 열린 PR 은 각주 3건과 재작업
 1건 수준으로 줄었다. 유입 속도를 처리 속도가 따라잡았다.
 
+## #3233/#3235 — 문서-only Update branch merge fast-pass 보완
+
+- [#3233](https://github.com/edwardkim/rhwp/issues/3233)의 재현 사례(#3123 문서 보강 후 full CI 재실행)를 바탕으로, [#3235](https://github.com/edwardkim/rhwp/pull/3235)에 CI·CodeQL·Render Diff preflight의 재사용 guard를 보완했다.
+- trailing 문서 커밋 직전의 candidate가 현재 base를 부모로 포함하는 정확히 2-parent 문서-only Update branch merge일 때만 기존 check를 재사용한다. merge diff, trailing 문서 커밋, parent/base 조건이 하나라도 맞지 않으면 full CI로 fallback한다.
+- workflow 변경이 포함된 최초 head에서는 full CI를 의도적으로 실행해 Build & Test 8 shards, Lint, Native Skia, Frontend, CodeQL, Canvas visual diff를 모두 통과했다. 이후 이 오늘할일과 archive review만 후속 문서 커밋으로 push해 heavy CI skip을 실제 검증한다.
+
 ## 오후 추가분 — 각주 축 2건 채택 (#3049 #3059)
 
 - **#3049**([#3225](https://github.com/edwardkim/rhwp/pull/3225) `988aee4f84`) —

--- a/mydocs/plans/task_m100_3233.md
+++ b/mydocs/plans/task_m100_3233.md
@@ -1,0 +1,35 @@
+# 수행계획서 — #3233 문서-only Update branch merge fast-pass 재사용 보완
+
+- 이슈: #3233
+- 브랜치: `devel` (메인테이너 보정 작업)
+- 기준: `upstream/devel` `0f0d92e`
+- 관련 재현: PR #3123의 `f8eebc4` (문서-only Update branch merge) 뒤 `a4a3826` (오늘할일·archive review) push
+
+## 문제
+
+후속 기록은 `mydocs/**`만 바꿨지만, 세 fast-pass 탐지기가 문서-only merge commit을 만나면 부모 수가 1이
+아니라는 이유만으로 즉시 full CI로 fallback했다. 그 merge commit 자체에는 현재 PR base와 일치하는
+green CI 결과가 있으므로, 안전한 검증 후보로 사용할 수 있다.
+
+## 범위
+
+1. CI, CodeQL, Render Diff의 중복 review-only 탐지기에 같은 candidate 승격 조건을 추가한다.
+2. 오늘할일·review 문서만 올린 뒤의 문서-only Update branch merge는 현재 base를 정확히 부모로 포함하고
+   해당 SHA의 기존 검증이 green일 때만 candidate로 사용한다.
+3. 허용 경로 밖 변경, base 불일치, 2-parent가 아닌 merge, API 오류, check 누락·실패는 현재처럼 full CI로
+   fallback한다.
+4. `pr_review_workflow.md` 9.3.1절을 실제 예외 조건과 검증 방법으로 갱신한다.
+
+## 검증
+
+- `actionlint`와 Ruby YAML parse, `git diff --check`를 실행한다.
+- #3123의 실제 commit/Actions 메타데이터로 candidate 조건을 재현해 세 workflow가 같은 결론을 내는지
+  정적으로 확인한다.
+- 구현 PR의 full CI 성공 후, 문서-only 후속 커밋을 push해 CI·CodeQL·Render Diff heavy job이 `skipped`인지
+  GitHub Actions에서 확인한다.
+
+## 범위 제외
+
+- branch protection required check 이름·정책 변경
+- 코드·기존 샘플·golden·baseline 변경
+- #2431 cache lifecycle의 A, B, D 단계

--- a/mydocs/plans/task_m100_3233_impl.md
+++ b/mydocs/plans/task_m100_3233_impl.md
@@ -1,0 +1,26 @@
+# 구현계획서 — #3233 review-only merge candidate 검증
+
+## 판정 규칙
+
+PR commit을 최신순으로 읽어 trailing single-parent review-only 커밋을 센다. 그 뒤에 다음 merge commit이
+나오면 코드 candidate로 승격한다.
+
+| 조건 | 결과 |
+| --- | --- |
+| trailing review-only 커밋이 1개 이상 | 계속 확인 |
+| merge parent가 정확히 2개이고 현재 `pr.base.sha`를 포함 | candidate SHA로 사용 |
+| merge diff가 `mydocs/**` 또는 허용된 신규 검증 자료만 포함 | 계속 확인 |
+| candidate의 기존 required 검증이 green | fast-pass |
+| 위 조건 하나라도 불만족 | full CI fallback |
+
+`Build & Test`, CodeQL 3개 분석, Canvas visual diff의 기존 identity 검증은 유지한다. 따라서 문서-only
+merge라는 형태만 예외로 인정하며, 다른 PR·base·repo에서 생성된 성공 run을 재사용하지 않는다.
+
+## 파일
+
+- `.github/workflows/ci.yml`
+- `.github/workflows/codeql.yml`
+- `.github/workflows/render-diff.yml`
+- `mydocs/manual/pr_review_workflow.md`
+
+세 workflow의 JavaScript는 같은 분기와 실패 이유를 사용해 drift를 방지한다.

--- a/mydocs/pr/archives/pr_3123_review.md
+++ b/mydocs/pr/archives/pr_3123_review.md
@@ -33,5 +33,5 @@
 
 ## 최종 권고
 
-- 최신 head CI가 성공했으므로 수용 권고. 추가 코드 보정은 필요하지 않으며, merge는 작업지시자 별도 승인 후 수행한다.
+- 최신 head CI가 성공해 수용했고, squash merge `0f0d92e687b1a0006e4d33c3892f883fb718f810`로 `devel`에 반영했다. 추가 코드 보정은 필요하지 않다.
 - merge 뒤에는 devel writer save와 후속 PR warm restore를 관측하고, #2431은 A, B, D 및 legacy cache 정리 범위를 계속 추적한다.

--- a/mydocs/pr/archives/pr_3235_review.md
+++ b/mydocs/pr/archives/pr_3235_review.md
@@ -24,8 +24,9 @@
 ## 후속 fast-pass 검증
 
 - 이 문서와 오늘할일 기록만을 뒤따르는 single-parent 문서 커밋으로 push한다. 변경 경로는 `mydocs/orders/20260724.md`와 이 archive review 파일뿐이다.
-- push 후 preflight 성공, heavy job의 `skipped` 표시, PR의 merge 가능 상태를 확인한다. 기대와 달리 full CI가 재실행되거나 preflight가 실패하면 원인을 기록하고 merge하지 않는다.
+- 문서 head `82844486b`에서 CI·CodeQL·Render Diff preflight가 모두 성공했고 Build & Test 집계도 성공했다. Lint, Native Skia tests, Frontend package gates, Build test archive, 8개 default-feature shard, CodeQL 분석, Canvas visual diff는 모두 `skipped`였다.
+- 이 head는 `CLEAN`·`MERGEABLE` 상태가 됐다. 기대와 달리 full CI가 재실행되거나 preflight가 실패하지 않아, #3123에서 확인한 base 일치 문서-only Update branch merge 재사용 경로가 실제로 동작함을 확인했다.
 
 ## 최종 권고
 
-- 문서 전용 후속 push의 실제 결과 확인이 남아 있다. 그 결과가 fast-pass 조건과 merge 가능 상태를 모두 만족하면 #3235를 merge 후보로 권고한다.
+- fast-pass 조건과 merge 가능 상태를 모두 충족했다. 최종 문서 보완 head도 같은 문서-only 경로로 확인한 뒤 #3235를 merge 후보로 권고한다.

--- a/mydocs/pr/archives/pr_3235_review.md
+++ b/mydocs/pr/archives/pr_3235_review.md
@@ -1,0 +1,31 @@
+# PR #3235 검토 — 문서-only Update branch merge fast-pass 재사용
+
+| 항목 | 내용 |
+| --- | --- |
+| PR | [#3235](https://github.com/edwardkim/rhwp/pull/3235) |
+| 관련 이슈 | [#3233](https://github.com/edwardkim/rhwp/issues/3233) |
+| base / 최초 검증 head | `devel` `0f0d92e687b1a0006e4d33c3892f883fb718f810` / `2a41243a034cd58701c4058d865adc7286b3383d` |
+| 최초 변경 규모 | 7 files, +135 -20 |
+| 검토 경로 | maintainer 후속 기록 fast-pass 검증 PR |
+
+## 배경과 변경 범위
+
+- #3123에서 `Update branch`가 만든 문서-only merge 뒤에 오늘할일·검토 기록만 추가했을 때, 기존 preflight가 merge commit을 일괄 거절해 전체 CI를 다시 실행한 사례를 #3233으로 기록했다.
+- CI, CodeQL, Render Diff의 review-only 탐색은 trailing single-parent 문서 커밋을 건너뛰되, 그 직전 candidate가 **현재 PR base를 부모로 갖는 정확히 2-parent 문서-only Update branch merge**일 때만 기존 검증 결과를 재사용한다.
+- merge diff가 허용된 review 경로만 바꾸는지, trailing 문서 커밋이 실제로 하나 이상 있는지까지 확인한다. 어느 하나라도 불일치하면 기존처럼 full CI로 안전하게 되돌린다.
+- `pr_review_workflow.md` 9.3.2절에 같은 guard와 fallback 조건을 명시했다. 코드·테스트·workflow 변경, base 불일치, 3개 이상 parent merge, 허용 경로 밖 변경은 fast-pass 대상이 아니다.
+
+## 검증 근거
+
+- `actionlint`로 CI·CodeQL workflow를, Ruby YAML 파서로 세 workflow를 확인했다. Render Diff의 actionlint SC2086은 변경하지 않은 기존 shell 구문 경고다.
+- 실제 #3123 SHA를 사용한 Node 회귀 검사로, `a4a3826` 문서 커밋과 `f8eebc4`의 2-parent/base 일치 merge가 수용되고, base 불일치·trailing 문서 커밋 부재·3-parent merge는 거절되는 것을 확인했다.
+- 최초 code/workflow head `2a41243a`에서는 fast-pass를 적용하지 않고 전체 GitHub Actions를 수행했다. Build & Test(아카이브 및 8 shards), Lint, Native Skia tests, Frontend package gates, CodeQL 3개 분석, Canvas visual diff가 모두 성공했고 WASM Build는 조건에 따라 skipped였다.
+
+## 후속 fast-pass 검증
+
+- 이 문서와 오늘할일 기록만을 뒤따르는 single-parent 문서 커밋으로 push한다. 변경 경로는 `mydocs/orders/20260724.md`와 이 archive review 파일뿐이다.
+- push 후 preflight 성공, heavy job의 `skipped` 표시, PR의 merge 가능 상태를 확인한다. 기대와 달리 full CI가 재실행되거나 preflight가 실패하면 원인을 기록하고 merge하지 않는다.
+
+## 최종 권고
+
+- 문서 전용 후속 push의 실제 결과 확인이 남아 있다. 그 결과가 fast-pass 조건과 merge 가능 상태를 모두 만족하면 #3235를 merge 후보로 권고한다.


### PR DESCRIPTION
## 배경

문서-only Update branch merge 뒤에 review/오늘할일만 push한 PR #3123에서, 기존 탐지기가 2-parent merge를 즉시 거절해 heavy CI가 다시 실행됐습니다.

## 변경

- CI, CodeQL, Render Diff의 review-only 탐지기가 trailing single-parent 문서 기록 뒤의 문서-only Update branch merge를 candidate SHA로 재사용합니다.
- candidate는 정확히 2-parent이고 현재 `base.sha`를 parent로 포함해야 하며, 기존 green check·Render Diff identity 검증을 그대로 통과해야 합니다.
- base 불일치, 3-parent merge, check 누락·실패, 허용 경로 밖 변경은 계속 full CI fallback입니다.
- PR review 워크플로 매뉴얼에 예외 조건과 검증 절차를 반영했습니다.

## 검증

- `actionlint` (CI·CodeQL) 통과
- Ruby YAML parse 통과
- #3123 실제 `a4a3826 → f8eebc4` 구조를 이용한 candidate guard 재현 통과
- `f8eebc4`의 Build & Test·CodeQL·Canvas Render Diff identity green 확인
- Render Diff actionlint의 SC2086은 변경 범위 밖 기존 경고입니다.

Refs #3233