### PR TITLE
ci: #3266 Native Skia와 테스트 archive 병렬화

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,14 +403,28 @@ jobs:
             }
 
   # [#2393] 기본 테스트 병렬화 — 테스트 바이너리를 한 번 빌드해 아카이브하고
-  # 8개 샤드가 컴파일 없이 나눠 실행한다. [#3064] 필수 gate 실패 뒤 불필요한
-  # 테스트를 시작하지 않도록 lint/frontend/native-skia 성공 뒤 archive를 만든다.
+  # 8개 샤드가 컴파일 없이 나눠 실행한다. [#3266] Native Skia와 archive는 같은
+  # lint/frontend gate 뒤 병렬로 시작한다. Native 실패 시 archive가 끝날 수는 있어도
+  # shard는 두 job 성공 뒤에만 시작하므로 #3064의 테스트 실행 차단은 유지된다.
   # required check 는 집계 job "Build & Test" 로 불변이다.
   build-test-archive:
     name: Build test archive
     runs-on: ubuntu-latest
-    needs: [preflight, native-skia-tests]
-    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' && needs['native-skia-tests'].result == 'success' }}
+    needs: [preflight, lint, frontend-package-gates]
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs.lint.result == 'success'
+        && (
+          needs['frontend-package-gates'].result == 'success'
+          || (
+            needs.preflight.outputs.frontend_required != 'true'
+            && needs['frontend-package-gates'].result == 'skipped'
+          )
+        )
+      }}
     permissions:
       contents: read
     outputs:
@@ -486,14 +500,26 @@ jobs:
         with:
           name: test-archive-${{ github.run_id }}
           path: tests.tar.zst
+          # tests.tar.zst 는 cargo-nextest가 이미 압축한 파일이다. ZIP 재압축 CPU를
+          # 쓰지 않아 Native Skia와 겹치는 archive 준비 시간을 더 줄인다. (#3266)
+          compression-level: 0
           retention-days: 1
           if-no-files-found: error
 
   test-shard:
     name: Default-feature tests (shard ${{ matrix.shard }}/8)
     runs-on: ubuntu-latest
-    needs: [preflight, build-test-archive]
-    if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' && needs['build-test-archive'].result == 'success' }}
+    needs: [preflight, native-skia-tests, build-test-archive]
+    # [#3266] archive와 Native Skia를 병렬화하되, 두 필수 worker가 모두 성공한
+    # 뒤에만 기본 테스트를 실행한다. 따라서 Native 실패 시 archive가 완료돼도 shard는 skip된다.
+    if: >-
+      ${{
+        always()
+        && needs.preflight.result == 'success'
+        && needs.preflight.outputs.fast_pass != 'true'
+        && needs['native-skia-tests'].result == 'success'
+        && needs['build-test-archive'].result == 'success'
+      }}
     permissions:
       contents: read
     strategy:

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -242,3 +242,17 @@ devel 판과 PR 적용판을 각각 native-skia 로 빌드해 SO-SUEOP.hwp 42·4
 - 다음 단계: 원본 저장소 `devel` 대상 PR을 생성하고 최신 head CI를 확인한다. #3257은 PR merge로
   close 후보이며, #3259는 macOS Finder 실제 드롭→다른 문서→최근 A 재열기 수동 확인 후 close 여부를
   결정한다.
+
+## #3266 — Native Skia·테스트 archive 병렬화 PR 준비
+
+- 이슈 [#3266](https://github.com/edwardkim/rhwp/issues/3266)의 성공 경로를
+  `lint/frontend → (Native Skia || Build test archive) → default-feature shard`로 바꿨다.
+  Native Skia가 실패하면 archive가 이미 실행 중일 수 있으나 shard는 두 worker가 모두 성공할 때만
+  시작하도록 보장한다.
+- `tests.tar.zst` upload의 ZIP 재압축을 `compression-level: 0`으로 꺼서, 이미 압축된 archive에
+  불필요한 CPU 시간을 쓰지 않게 했다. artifact 이름·retention·8개 shard·`Build & Test` 집계는 유지한다.
+- 로컬 검증: `actionlint .github/workflows/ci.yml`, Ruby YAML parse, DAG 계약 검사,
+  `git diff --check` 통과. 최종 PR CI에서 Native·archive 병렬 시작, shard dual-success 차단,
+  artifact/shard 시간과 전체 wall-clock을 기준 run과 비교한다.
+- 작업 브랜치: `task/3266-ci-parallel-archive`, 대상: `devel`. PR 번호 확정 후 archive review 문서에
+  메타와 최종 CI 측정값을 기록한다.

--- a/mydocs/orders/20260724.md
+++ b/mydocs/orders/20260724.md
@@ -252,7 +252,7 @@ devel 판과 PR 적용판을 각각 native-skia 로 빌드해 SO-SUEOP.hwp 42·4
 - `tests.tar.zst` upload의 ZIP 재압축을 `compression-level: 0`으로 꺼서, 이미 압축된 archive에
   불필요한 CPU 시간을 쓰지 않게 했다. artifact 이름·retention·8개 shard·`Build & Test` 집계는 유지한다.
 - 로컬 검증: `actionlint .github/workflows/ci.yml`, Ruby YAML parse, DAG 계약 검사,
-  `git diff --check` 통과. 최종 PR CI에서 Native·archive 병렬 시작, shard dual-success 차단,
-  artifact/shard 시간과 전체 wall-clock을 기준 run과 비교한다.
+  `git diff --check` 통과. 이 PR CI에서는 Native·archive 병렬 시작과 shard dual-success 차단만
+  확인하고, artifact/shard 시간과 전체 wall-clock의 전후 비교는 merge 뒤 다음 PR에서 수행한다.
 - 작업 브랜치: `task/3266-ci-parallel-archive`, 대상: `devel`. PR 번호 확정 후 archive review 문서에
   메타와 최종 CI 측정값을 기록한다.

--- a/mydocs/plans/task_m100_3266.md
+++ b/mydocs/plans/task_m100_3266.md
@@ -55,8 +55,9 @@ Native Skia가 실패하면 archive job은 이미 실행 중일 수 있으나, `
    - archive 실패: shard는 시작하지 않는다.
    - frontend 비대상 skip: backend의 Native Skia·archive·shard 체인은 정상 진행한다.
    - fast-pass: archive와 shard는 기존처럼 실행하지 않는다.
-3. PR CI 완료 뒤 Native, archive, shard별 다운로드·nextest 시간, 전체 wall-clock을 #3265 run 및
-   #3266 기준 run과 비교해 완료 보고서와 PR 본문에 남긴다.
+3. 이 workflow 변경 PR에서는 Native·archive·shard의 gate 결과만 확인한다. 시간 단축 수치는
+   merge 뒤 **다음 PR**에서 Native, archive, shard별 다운로드·nextest 시간과 전체 wall-clock을
+   #3265 run 및 #3266 기준 run과 비교해 #3266에 남긴다.
 
 ## 6. 완료 기준
 
@@ -64,5 +65,6 @@ Native Skia가 실패하면 archive job은 이미 실행 중일 수 있으나, `
 - Native Skia 실패 시 default-feature shard가 시작하지 않는다.
 - `Build & Test` 집계, shard 합계 검증, artifact 이름과 retention, fast-pass와 frontend skip의
   기존 계약이 유지된다.
-- 구현·검증·보고서를 task 브랜치에 커밋하고, 작업지시자 승인 후에만 PR을 생성한다.
+- 구현·검증·보고서를 task 브랜치에 커밋하고, 작업지시자 승인 후에만 PR을 생성한다. 이 PR의 CI가
+  gate 계약을 통과한 뒤 merge하고, 시간 단축 완료 판정은 다음 PR의 실측까지 #3266에서 보류한다.
   `mydocs/orders/20260724.md`는 PR 생성 승인이 난 직전의 최종 PR 준비 단계에서만 생성·갱신한다.

--- a/mydocs/plans/task_m100_3266.md
+++ b/mydocs/plans/task_m100_3266.md
@@ -1,0 +1,68 @@
+# 수행계획서 — CI Native Skia·테스트 아카이브 병렬화와 shard tail 측정 (M100 #3266)
+
+- **이슈**: [edwardkim/rhwp#3266](https://github.com/edwardkim/rhwp/issues/3266)
+- **브랜치**: `task/3266-ci-parallel-archive` (`upstream/devel@16c39f31e` 기준)
+- **작성일**: 2026-07-24
+
+## 1. 목표
+
+PR CI의 성공 경로에서 `Native Skia tests`와 `Build test archive`가 같은 선행 gate 뒤에
+병렬로 시작되게 한다. 기본 테스트 shard는 두 job이 모두 성공한 뒤에만 실행하여, #3064에서
+정한 필수 gate 실패 전파와 `Build & Test` required check 표면을 보존한다.
+
+## 2. 재현 근거
+
+| run | Native Skia | Build test archive | shard tail | 전체 |
+| --- | ---: | ---: | ---: | ---: |
+| [30081855067](https://github.com/edwardkim/rhwp/actions/runs/30081855067) | 7분 27초 | 7분 56초 | 약 7분 36초 | 26분 48초 |
+| [#3265 update-branch run 30094656772](https://github.com/edwardkim/rhwp/actions/runs/30094656772) | 4분 8초 | 7분 56초 | 3분 4초 | 후속 측정 기준 |
+
+현재 `build-test-archive`는 `native-skia-tests`를 `needs`로 가져 Native Skia가 끝난 뒤에만
+시작한다. #3265 run에서도 이 직렬 경로가 재현됐다.
+
+shard 번호 자체는 고정 병목이 아니다. #3265에서 약 1GB archive 다운로드는 shard 6의 13.3초부터
+shard 4의 90.7초까지, nextest 실행은 shard 1의 8.732초부터 shard 3의 50.191초까지 변동했다.
+따라서 이번 변경은 먼저 직렬된 두 큰 job을 겹치고, shard 수·분배 방식은 전후 측정 뒤 별도 판단한다.
+
+## 3. 범위와 안전 조건
+
+| 포함 | 제외 |
+| --- | --- |
+| archive와 Native Skia의 공통 선행 gate 및 조건을 정렬해 병렬 시작 | 테스트를 생략·축소하거나 coverage를 변경하는 작업 |
+| shard가 archive·Native Skia 모두 `success`일 때만 시작하도록 의존성 강화 | 4-shard 또는 timing-aware partition을 근거 없이 즉시 도입 |
+| 이미 `.zst`인 archive의 Actions 재압축을 끄고 측정 항목을 기록 | cache writer 정책·artifact 전송 구조의 대규모 재설계 |
+| actionlint와 workflow 구조 검토, 실제 PR CI 전후 시간 비교 | required check 이름·branch protection 정책 변경 |
+
+Native Skia가 실패하면 archive job은 이미 실행 중일 수 있으나, `test-shard`는 절대로 시작하지 않는다.
+이는 #3064의 테스트 실행 차단을 유지하면서 성공 경로의 wall-clock을 줄이는 의도된 trade-off다.
+
+## 4. 구현 설계
+
+1. `build-test-archive`의 `needs`를 `preflight`, `lint`, `frontend-package-gates`로 바꾸고,
+   `native-skia-tests`와 같은 fast-pass·frontend skip 허용 조건을 사용한다.
+2. `test-shard`의 `needs`에 `native-skia-tests`를 추가한다. 조건식에서 preflight 성공, archive 성공,
+   Native Skia 성공을 모두 요구한다.
+3. `Upload test archive`에 `compression-level: 0`을 지정한다. 입력이 이미 `tests.tar.zst`이므로
+   ZIP 재압축 CPU만 피하고 artifact 내용·이름·retention은 바꾸지 않는다.
+4. 기존 job 설명 주석을 새 DAG와 trade-off에 맞게 갱신한다.
+
+## 5. 검증 계획
+
+1. `actionlint`로 workflow 문법과 GitHub Actions expression을 검사한다.
+2. 변경 전후 job graph를 대조한다.
+   - lint/frontend 실패: Native Skia·archive·shard 모두 시작하지 않는다.
+   - Native Skia 실패: archive는 진행 중일 수 있어도 shard는 시작하지 않는다.
+   - archive 실패: shard는 시작하지 않는다.
+   - frontend 비대상 skip: backend의 Native Skia·archive·shard 체인은 정상 진행한다.
+   - fast-pass: archive와 shard는 기존처럼 실행하지 않는다.
+3. PR CI 완료 뒤 Native, archive, shard별 다운로드·nextest 시간, 전체 wall-clock을 #3265 run 및
+   #3266 기준 run과 비교해 완료 보고서와 PR 본문에 남긴다.
+
+## 6. 완료 기준
+
+- 성공 경로에서 Native Skia와 archive가 공통 gate 뒤 병렬 시작한다.
+- Native Skia 실패 시 default-feature shard가 시작하지 않는다.
+- `Build & Test` 집계, shard 합계 검증, artifact 이름과 retention, fast-pass와 frontend skip의
+  기존 계약이 유지된다.
+- 구현·검증·보고서를 task 브랜치에 커밋하고, 작업지시자 승인 후에만 PR을 생성한다.
+  `mydocs/orders/20260724.md`는 PR 생성 승인이 난 직전의 최종 PR 준비 단계에서만 생성·갱신한다.

--- a/mydocs/pr/archives/pr_3267_review.md
+++ b/mydocs/pr/archives/pr_3267_review.md
@@ -22,8 +22,8 @@ writer 충돌은 없다. PR run은 두 cache 모두 restore-only다.
 
 기준 run [30081855067](https://github.com/edwardkim/rhwp/actions/runs/30081855067)에서는 Native Skia
 7분 27초 뒤 archive 7분 56초가 시작해 전체 26분 48초가 걸렸다. 이 변경은 성공 경로에서 두 구간을
-겹쳐 약 4–8분의 critical path 단축을 목표로 한다. 실제 절감값은 최신 PR CI의 job 시작·완료 시각으로
-판정한다.
+겹쳐 약 4–8분의 critical path 단축을 목표로 한다. 작업지시자 지시에 따라 실제 절감값은 이 PR이
+merge된 뒤 **다음 PR**에서의 job 시작·완료 시각으로 판정한다.
 
 ### 실패 전파 보존
 
@@ -50,7 +50,7 @@ writer 충돌은 없다. PR run은 두 cache 모두 restore-only다.
 
 Rust·TypeScript 제품 코드와 실행할 테스트 명령은 바꾸지 않았다. 따라서 로컬 cargo 전체 회귀를 중복 실행하지
 않고, 최신 PR CI에서 Native Skia, test archive, 8개 default-feature shard, `Build & Test`, CodeQL,
-Render Diff의 실제 동작과 시간을 최종 확인한다.
+Render Diff의 gate 동작을 최종 확인한다. 시간 단축 측정은 merge 뒤 다음 PR에서 수행한다.
 
 ## 범위 외와 리스크
 
@@ -63,4 +63,5 @@ Render Diff의 실제 동작과 시간을 최종 확인한다.
 ## 최종 권고
 
 최신 PR head의 GitHub Actions가 통과하고, Native Skia와 archive의 병렬 시작 및 shard dual-success
-차단 계약을 확인한 뒤 작업지시자 승인으로 ready 전환·merge를 판단한다.
+차단 계약을 확인한 뒤 작업지시자 승인으로 ready 전환·merge를 판단한다. #3266의 시간 단축 완료 판정은
+다음 PR의 실측까지 보류한다.

--- a/mydocs/pr/archives/pr_3267_review.md
+++ b/mydocs/pr/archives/pr_3267_review.md
@@ -1,0 +1,66 @@
+# PR #3267 검토 기록 — #3266 Native Skia·테스트 archive 병렬화
+
+## 메타
+
+| 항목 | 값 |
+|---|---|
+| PR | [#3267](https://github.com/edwardkim/rhwp/pull/3267) |
+| 작성자 | `jangster77` (repository collaborator) |
+| base | `devel` |
+| 관련 이슈 | [#3266](https://github.com/edwardkim/rhwp/issues/3266) |
+| 범위 | GitHub Actions CI job DAG, test archive upload 설정, 계획·검증 기록 |
+| 문서 작성 시점 참고 | Draft PR. mergeable·CI·head SHA는 merge 전에 최신 상태를 다시 확인한다. |
+
+## 변경과 판단
+
+### 성공 경로 단축
+
+`Build test archive`의 선행 조건을 `Native Skia tests`에서 분리했다. 두 job은 이제 같은
+`preflight → lint → frontend-package-gates` 성공 뒤 별도 GitHub-hosted runner에서 병렬로 시작한다.
+각 job의 workspace·Cargo target·`rust-cache` shared key는 각각 분리되어 있으므로 파일 lock이나 PR cache
+writer 충돌은 없다. PR run은 두 cache 모두 restore-only다.
+
+기준 run [30081855067](https://github.com/edwardkim/rhwp/actions/runs/30081855067)에서는 Native Skia
+7분 27초 뒤 archive 7분 56초가 시작해 전체 26분 48초가 걸렸다. 이 변경은 성공 경로에서 두 구간을
+겹쳐 약 4–8분의 critical path 단축을 목표로 한다. 실제 절감값은 최신 PR CI의 job 시작·완료 시각으로
+판정한다.
+
+### 실패 전파 보존
+
+`test-shard`는 `native-skia-tests`와 `build-test-archive`를 모두 `needs`로 가지고, 두 결과가
+`success`일 때만 실행한다. 따라서 Native Skia가 실패하면 archive가 이미 실행 중이거나 완료돼도
+8개 default-feature shard는 시작하지 않는다. lint 실패, frontend 대상 gate 실패, archive 실패도
+기존처럼 shard를 막는다. frontend 비대상 job의 정상 `skipped`와 fast-pass 경로는 두 병렬 worker에
+동일하게 적용한다.
+
+### artifact upload
+
+`tests.tar.zst`는 cargo-nextest가 이미 Zstandard 압축한 파일이므로 `upload-artifact`에
+`compression-level: 0`을 지정했다. ZIP wrapper의 재압축 CPU를 제거하지만 artifact 내용, 이름,
+1일 retention, 다운로드 방식 및 shard 수는 바꾸지 않는다.
+
+## 사전 검증
+
+| 검증 | 결과 |
+|---|---|
+| `actionlint .github/workflows/ci.yml` | PASS |
+| Ruby `YAML.load_file('.github/workflows/ci.yml')` | PASS (`yaml ok`) |
+| DAG 계약 검사 | PASS — archive/native 공통 gate, shard dual-success, 8개 matrix, aggregate 의존성, `compression-level: 0` |
+| `git diff --check` | PASS |
+
+Rust·TypeScript 제품 코드와 실행할 테스트 명령은 바꾸지 않았다. 따라서 로컬 cargo 전체 회귀를 중복 실행하지
+않고, 최신 PR CI에서 Native Skia, test archive, 8개 default-feature shard, `Build & Test`, CodeQL,
+Render Diff의 실제 동작과 시간을 최종 확인한다.
+
+## 범위 외와 리스크
+
+- artifact를 8개 shard에 전송하는 구조는 유지한다. #3265에서 느린 shard 번호가 매번 달랐으므로,
+  4-shard 또는 timing-aware 분할은 이번 PR에 추정으로 섞지 않고 #3266의 후속 측정으로 결정한다.
+- Native Skia 실패 시 archive runner 시간이 일부 낭비될 수 있다. 이는 성공 경로를 줄이는 대신이며,
+  shard 실행 차단과 `Build & Test` 실패 보고는 유지된다.
+- renderer·WASM 출력·샘플·golden은 바꾸지 않아 visual sweep 대상이 아니다.
+
+## 최종 권고
+
+최신 PR head의 GitHub Actions가 통과하고, Native Skia와 archive의 병렬 시작 및 shard dual-success
+차단 계약을 확인한 뒤 작업지시자 승인으로 ready 전환·merge를 판단한다.

--- a/mydocs/working/task_m100_3266_stage1.md
+++ b/mydocs/working/task_m100_3266_stage1.md
@@ -1,0 +1,56 @@
+# 단계 완료보고서 — #3266 Stage 1 CI archive·Native Skia 병렬화
+
+## 결과
+
+`Build test archive`를 `Native Skia tests`의 후속 job에서 분리해 같은
+`preflight → lint → frontend-package-gates` 성공 뒤에 병렬로 시작하게 했다.
+기본 테스트 shard는 archive와 Native Skia가 모두 성공해야 실행한다.
+
+```text
+preflight → lint → frontend-package-gates
+                    ├─ Native Skia tests ─┐
+                    └─ Build test archive ┴→ Default-feature shards (8) → Build & Test
+```
+
+Native Skia 실패 시 archive가 진행 중이거나 완료될 수 있는 것은 의도된 trade-off다. 그러나
+shard는 `needs['native-skia-tests'].result == 'success'`와
+`needs['build-test-archive'].result == 'success'`를 함께 요구하므로 시작하지 않는다.
+
+## 변경 범위
+
+| 파일 | 변경 |
+| --- | --- |
+| `.github/workflows/ci.yml` | archive의 공통 gate 의존성·조건, shard의 dual-success 의존성·조건, 이미 압축된 `tests.tar.zst`의 `compression-level: 0` |
+| `mydocs/plans/task_m100_3266.md` | 원인, 안전 조건, 구현과 검증 계획 |
+| 본 문서 | 구현 결과와 검증 근거 |
+
+변경하지 않은 항목:
+
+- `Build & Test` required check와 worker 결과 집계
+- shard 8개 matrix, `hash:i/8` 분할, shard 합계 검증
+- artifact 이름, 1일 retention, 다운로드·실행 명령
+- fast-pass와 frontend 비대상(`skipped`) 경로
+- Rust·TypeScript 제품 코드 및 테스트 자체
+
+`compression-level: 0`은 이미 Zstandard로 압축된 파일을 upload-artifact ZIP wrapper가 다시 압축하지
+않게 한다. artifact의 내용·전송 대상 수는 바꾸지 않으며, 다음 PR CI에서 upload 시간과 전체 경로에
+미치는 효과를 측정한다.
+
+## 검증
+
+| 검증 | 결과 |
+| --- | --- |
+| `actionlint .github/workflows/ci.yml` | PASS |
+| Ruby `YAML.load_file('.github/workflows/ci.yml')` | PASS (`yaml ok`) |
+| `git diff --check` | PASS |
+| workflow DAG 계약 Ruby 검사 | PASS — archive/native 공통 조건, shard dual-success, 8개 matrix, `compression-level: 0`, aggregate dependency 확인 |
+
+제품 테스트 명령은 변경하지 않았으므로 이 단계에서 cargo 전체 회귀는 실행하지 않았다. 최종 검증은
+작업지시자 승인 후 생성할 PR의 GitHub Actions에서 Native Skia·archive 병렬 시작, 8개 shard,
+`Build & Test`, CodeQL, Render Diff를 모두 확인하고 기준 run과 시간을 비교한다.
+
+## 후속 측정 기준
+
+- 기준: run [30081855067](https://github.com/edwardkim/rhwp/actions/runs/30081855067), 전체 26분 48초
+- 최근 기준: [#3265 update-branch run 30094656772](https://github.com/edwardkim/rhwp/actions/runs/30094656772), Native Skia 4분 8초, archive 7분 56초, 최장 shard 3분 4초
+- PR CI 후 기록할 값: Native·archive 시작/종료 시각, artifact upload/download, shard별 nextest, 전체 wall-clock

--- a/mydocs/working/task_m100_3266_stage1.md
+++ b/mydocs/working/task_m100_3266_stage1.md
@@ -45,12 +45,12 @@ shard는 `needs['native-skia-tests'].result == 'success'`와
 | `git diff --check` | PASS |
 | workflow DAG 계약 Ruby 검사 | PASS — archive/native 공통 조건, shard dual-success, 8개 matrix, `compression-level: 0`, aggregate dependency 확인 |
 
-제품 테스트 명령은 변경하지 않았으므로 이 단계에서 cargo 전체 회귀는 실행하지 않았다. 최종 검증은
-작업지시자 승인 후 생성할 PR의 GitHub Actions에서 Native Skia·archive 병렬 시작, 8개 shard,
-`Build & Test`, CodeQL, Render Diff를 모두 확인하고 기준 run과 시간을 비교한다.
+제품 테스트 명령은 변경하지 않았으므로 이 단계에서 cargo 전체 회귀는 실행하지 않았다. 이 PR의
+GitHub Actions에서는 Native Skia·archive 병렬 시작, 8개 shard, `Build & Test`, CodeQL, Render Diff의
+gate 계약만 확인한다. 시간 단축의 전후 비교는 이 변경 merge 뒤 **다음 PR**에서 수행한다.
 
 ## 후속 측정 기준
 
 - 기준: run [30081855067](https://github.com/edwardkim/rhwp/actions/runs/30081855067), 전체 26분 48초
 - 최근 기준: [#3265 update-branch run 30094656772](https://github.com/edwardkim/rhwp/actions/runs/30094656772), Native Skia 4분 8초, archive 7분 56초, 최장 shard 3분 4초
-- PR CI 후 기록할 값: Native·archive 시작/종료 시각, artifact upload/download, shard별 nextest, 전체 wall-clock
+- 다음 PR에서 기록할 값: Native·archive 시작/종료 시각, artifact upload/download, shard별 nextest, 전체 wall-clock


### PR DESCRIPTION
## 요약

- Native Skia와 default-feature test archive를 lint/frontend 성공 뒤 병렬로 준비합니다.
- default-feature shard는 archive와 Native Skia가 모두 성공할 때만 시작해 #3064의 실패 차단을 유지합니다.
- 이미 Zstandard로 압축된 `tests.tar.zst`의 ZIP 재압축을 끕니다.

## 검증

- `actionlint .github/workflows/ci.yml`
- Ruby YAML parse
- DAG 계약 검사: 공통 선행 gate, Native·archive dual-success shard gate, 8개 shard, `Build & Test` 집계 유지
- `git diff --check`

## CI 확인과 후속 측정

이 PR에서는 변경한 DAG의 gate 동작과 전체 check 통과만 확인합니다. 시간 단축의 전후 비교는 이 변경 merge 뒤 다음 PR에서 Native·archive 시작 시각, artifact upload/download, shard별 nextest, 전체 wall-clock을 기준 run과 비교해 #3266에 기록합니다.

관련 이슈: #3266
