### PR TITLE
ci: 검증 워크플로 self-hosted 러너 전환 + timeout — #3284

### DIFF
--- a/.github/actions/install-wasm-pack/action.yml
+++ b/.github/actions/install-wasm-pack/action.yml
@@ -16,5 +16,11 @@ runs:
         TARBALL="wasm-pack-v${WASM_PACK_VERSION}-x86_64-unknown-linux-musl"
         URL="https://github.com/rustwasm/wasm-pack/releases/download/v${WASM_PACK_VERSION}/${TARBALL}.tar.gz"
         curl -sSfL "$URL" | tar -xzf - -C /tmp
-        sudo mv "/tmp/${TARBALL}/wasm-pack" /usr/local/bin/wasm-pack
-        wasm-pack --version
+        # [#3284] sudo 없이 사용자 경로(~/.cargo/bin)에 배치 — self-hosted 러너의
+        # 제한된 sudo(apt 한정)와 호스티드 러너 양쪽에서 동일하게 동작한다.
+        # dtolnay/rust-toolchain 이 이미 PATH 에 넣지만 self-hosted 안전을 위해 명시 추가.
+        install_dir="${HOME}/.cargo/bin"
+        mkdir -p "$install_dir"
+        mv "/tmp/${TARBALL}/wasm-pack" "$install_dir/wasm-pack"
+        echo "$install_dir" >> "$GITHUB_PATH"
+        "$install_dir/wasm-pack" --version

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -457,7 +457,11 @@ jobs:
         with:
           toolchain: 1.93.1
 
+      # [#3289] 20개 러너가 /home/app 의 ~/.cargo/bin 을 공유하므로 동시 설치 시
+      # mv 레이스로 실패한다 (shard 8개 동시 시작 실측). self-hosted 는 호스트에
+      # 1회 설치된 cargo-nextest 를 그대로 쓰고, hosted 러너에서만 설치한다.
       - name: Install cargo-nextest
+        if: runner.environment == 'github-hosted'
         uses: taiki-e/install-action@v2
         with:
           tool: nextest
@@ -562,7 +566,9 @@ jobs:
         with:
           toolchain: 1.93.1
 
+      # [#3289] 공유 ~/.cargo/bin 동시 설치 레이스 방지 — build-test-archive 주석 참조.
       - name: Install cargo-nextest
+        if: runner.environment == 'github-hosted'
         uses: taiki-e/install-action@v2
         with:
           tool: nextest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,8 @@ concurrency:
 jobs:
   preflight:
     name: CI preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -410,7 +411,8 @@ jobs:
   # required check 는 집계 job "Build & Test" 로 불변이다.
   build-test-archive:
     name: Build test archive
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
     needs: [preflight, lint, frontend-package-gates]
     if: >-
       ${{
@@ -509,7 +511,8 @@ jobs:
 
   test-shard:
     name: Default-feature tests (shard ${{ matrix.shard }}/8)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
     needs: [preflight, native-skia-tests, build-test-archive]
     # [#3266] archive와 Native Skia를 병렬화하되, 두 필수 worker가 모두 성공한
     # 뒤에만 기본 테스트를 실행한다. 따라서 Native 실패 시 archive가 완료돼도 shard는 skip된다.
@@ -585,7 +588,8 @@ jobs:
 
   lint:
     name: Lint (fmt, clippy, WASM check)
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 20
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
     permissions:
@@ -618,7 +622,8 @@ jobs:
 
   native-skia-tests:
     name: Native Skia tests
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
     needs: [preflight, lint, frontend-package-gates]
     # frontend 비대상 job의 skipped는 정상 경로다. 대상 job의 실패/취소와 lint 실패는
     # native-skia 이후 worker 전체에 전파한다.
@@ -690,7 +695,8 @@ jobs:
 
   frontend-package-gates:
     name: Frontend package gates
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 20
     # [#3268] Frontend는 Lint의 산출물을 읽지 않고 독립 runner에서 별도 target/cache를 쓴다.
     # preflight의 fast-pass·영향 판정만 기다려 Lint와 병렬 시작한다. Lint 실패 시 Frontend가
     # 끝날 수는 있지만 Native/archive는 아래 두 worker의 성공을 모두 계속 요구한다.
@@ -788,7 +794,8 @@ jobs:
 
   build-and-test:
     name: Build & Test
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 45
     needs:
       - preflight
       - build-test-archive
@@ -905,7 +912,8 @@ jobs:
 
   wasm-build:
     name: WASM Build
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 30
     permissions:
       contents: read
     if: github.event_name == 'workflow_dispatch' || startsWith(github.ref, 'refs/tags/v')

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -440,6 +440,9 @@ jobs:
       # [Task #1109 / #1192 C] ubuntu-latest runner 의 미사용 사전 설치 toolchain 제거하여
       # 테스트 빌드 시 디스크 한도 초과를 줄인다.
       - name: Free disk space (remove unused pre-installed toolchains)
+        # [#3284] GitHub-hosted 이미지 전용 사전설치물 제거 — self-hosted 러너에는
+        # 해당 디렉터리가 없고 sudo(apt 한정)로 rm 이 불가하므로 skip 한다.
+        if: runner.environment == 'github-hosted'
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
@@ -652,6 +655,9 @@ jobs:
       # [#1192] 캐시 정상 작동 확인 후 "크고 빠른" 항목(android/dotnet)만 남기고 축소.
       # 느린 docker prune --all / apt clean / ghc / CodeQL 정리는 제거. df -h 로 여유 확인.
       - name: Free disk space (remove unused pre-installed toolchains)
+        # [#3284] GitHub-hosted 이미지 전용 사전설치물 제거 — self-hosted 러너에는
+        # 해당 디렉터리가 없고 sudo(apt 한정)로 rm 이 불가하므로 skip 한다.
+        if: runner.environment == 'github-hosted'
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet
@@ -924,6 +930,9 @@ jobs:
       # [Task #1109 / #1192 C] wasm-build job 도 build-and-test 와 동일 축소 패턴.
       # "크고 빠른" 항목(android/dotnet)만 제거. df -h 로 여유 확인.
       - name: Free disk space (remove unused pre-installed toolchains)
+        # [#3284] GitHub-hosted 이미지 전용 사전설치물 제거 — self-hosted 러너에는
+        # 해당 디렉터리가 없고 sudo(apt 한정)로 rm 이 불가하므로 skip 한다.
+        if: runner.environment == 'github-hosted'
         run: |
           sudo rm -rf /usr/local/lib/android
           sudo rm -rf /usr/share/dotnet

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -413,6 +413,10 @@ jobs:
     name: Build test archive
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
+    # [#3289] 러너 .env 의 CARGO_BUILD_JOBS=3 은 20개 러너 동시 빌드 폭주 대비
+    # 보수값이다. critical path 빌드 잡만 상향해 70코어 호스트를 활용한다.
+    env:
+      CARGO_BUILD_JOBS: 12
     needs: [preflight, lint, frontend-package-gates]
     if: >-
       ${{
@@ -485,6 +489,20 @@ jobs:
             --cargo-profile "${{ steps.profile.outputs.cargo_profile }}" \
             --archive-file tests.tar.zst
 
+      # [#3289] 20개 러너가 한 호스트를 공유하므로 아카이브를 호스트 캐시 디렉터리에
+      # 복사해 두면 8개 shard 의 동시 다운로드(1GB×8, 회선 공유로 ~6분 대기)를
+      # 로컬 hardlink/copy 로 대체할 수 있다. 업로드 아티팩트는 fallback 으로 유지한다.
+      # tmp+mv 원자적 쓰기로 부분 파일 노출을 막고, 하루 지난 run 캐시는 정리한다.
+      - name: Publish archive to host cache
+        if: runner.environment != 'github-hosted'
+        run: |
+          cache_dir="$HOME/artifact-cache/${GITHUB_RUN_ID}"
+          find "$HOME/artifact-cache" -mindepth 1 -maxdepth 1 -type d -mmin +1440 -exec rm -rf {} + 2>/dev/null || true
+          mkdir -p "$cache_dir"
+          cp tests.tar.zst "$cache_dir/tests.tar.zst.tmp"
+          mv "$cache_dir/tests.tar.zst.tmp" "$cache_dir/tests.tar.zst"
+          ls -la --block-size=M "$cache_dir"
+
       # [#2393] 샤드 합계 대조의 기대치 — 비-ignored(runnable) 테스트 수.
       # nextest Summary 의 skipped 는 파티션 제외분과 #[ignore] 를 합산하므로
       # run 합계의 기준은 total 이 아니라 runnable 이다 (3차 PR CI 실측: 23 ignored).
@@ -549,7 +567,25 @@ jobs:
         with:
           tool: nextest
 
+      # [#3289] 같은 호스트의 build-test-archive 잡이 남긴 호스트 캐시를 우선 사용해
+      # 8개 shard 동시 다운로드 병목(~6분)을 제거한다. hardlink 는 동일 파일시스템
+      # (/home/app)에서 즉시 완료되고, 실패 시 copy → 그마저 없으면 아티팩트 다운로드.
+      - name: Fetch test archive from host cache
+        id: host_cache
+        if: runner.environment != 'github-hosted'
+        run: |
+          src="$HOME/artifact-cache/${GITHUB_RUN_ID}/tests.tar.zst"
+          if [[ -f "$src" ]]; then
+            ln -f "$src" tests.tar.zst 2>/dev/null || cp "$src" tests.tar.zst
+            hit=true
+          else
+            hit=false
+          fi
+          echo "hit=$hit" >> "$GITHUB_OUTPUT"
+          echo "host cache hit=$hit"
+
       - name: Download test archive
+        if: steps.host_cache.outputs.hit != 'true'
         uses: actions/download-artifact@v8
         with:
           name: test-archive-${{ github.run_id }}
@@ -593,6 +629,9 @@ jobs:
     name: Lint (fmt, clippy, WASM check)
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 20
+    # [#3289] critical path 빌드 잡 한정 CARGO_BUILD_JOBS 상향 (build-test-archive 주석 참조)
+    env:
+      CARGO_BUILD_JOBS: 12
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
     permissions:
@@ -627,6 +666,9 @@ jobs:
     name: Native Skia tests
     runs-on: [self-hosted, Linux, X64]
     timeout-minutes: 30
+    # [#3289] critical path 빌드 잡 한정 CARGO_BUILD_JOBS 상향 (build-test-archive 주석 참조)
+    env:
+      CARGO_BUILD_JOBS: 12
     needs: [preflight, lint, frontend-package-gates]
     # frontend 비대상 job의 skipped는 정상 경로다. 대상 job의 실패/취소와 lint 실패는
     # native-skia 이후 worker 전체에 전파한다.

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -45,7 +45,8 @@ concurrency:
 jobs:
   preflight:
     name: CodeQL preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
     permissions:
       contents: read
       checks: read
@@ -247,7 +248,8 @@ jobs:
 
   analyze:
     name: Analyze (${{ matrix.language }})
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 45
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
     permissions:

--- a/.github/workflows/full-renderer-sweep.yml
+++ b/.github/workflows/full-renderer-sweep.yml
@@ -18,7 +18,8 @@ env:
 jobs:
   full-renderer-sweep:
     name: Full Renderer Sweep
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 60
     permissions:
       contents: read
 

--- a/.github/workflows/render-diff.yml
+++ b/.github/workflows/render-diff.yml
@@ -61,7 +61,8 @@ concurrency:
 jobs:
   preflight:
     name: Render Diff preflight
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 10
     permissions:
       actions: read
       contents: read
@@ -299,7 +300,8 @@ jobs:
 
   canvas-visual-diff:
     name: Canvas visual diff
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, Linux, X64]
+    timeout-minutes: 45
     needs: preflight
     if: ${{ always() && needs.preflight.outputs.fast_pass != 'true' }}
     permissions:

--- a/mydocs/report/task_m100_3284_report.md
+++ b/mydocs/report/task_m100_3284_report.md
@@ -1,0 +1,57 @@
+# Task #3284 — CI 검증 워크플로 self-hosted 러너 전환 (최종 보고서)
+
+`Closes #3284`.
+
+## 배경
+
+GitHub 호스티드 큐 적체로 CI 병목. 사내 self-hosted 러너 `runner-lxc`(192.168.2.13,
+Proxmox LXC) 구성·검증 후 검증 워크플로를 전환했다.
+
+## 러너 사양·검증 (SSH 실측)
+
+- Xeon E5-2697 v4 **56 논리코어** / **100 GiB RAM** / 185 GB 여유 / Ubuntu 24.10 / podman 5.0.3
+- 설치: build-essential·pkg-config·libssl-dev·unzip + Native Skia(libfontconfig1-dev·
+  libfreetype-dev·fonts-dejavu-core). app 계정 apt NOPASSWD sudo.
+- 실증: rustup 자체 설치(rustc 1.93.1 정합), rhwp clean 빌드 **1m28s**(로컬 WSL2 2m12s보다
+  빠름), 최대 RSS 2.77 GB, 외부망(static.rust-lang.org·github.com 200) 도달.
+- 라벨: `self-hosted, Linux, X64, podman`.
+
+## 변경 (검증 워크플로 4개, 13 job)
+
+`runs-on: ubuntu-latest` → `runs-on: [self-hosted, Linux, X64]` + `timeout-minutes` 명시.
+
+| 파일 | job(timeout분) |
+|---|---|
+| `ci.yml` | preflight(10)·lint(20)·frontend-package-gates(20)·build-test-archive(30)·native-skia-tests(30)·test-shard(30)·build-and-test(45)·wasm-build(30) |
+| `codeql.yml` | preflight(10)·analyze(45) |
+| `render-diff.yml` | preflight(10)·canvas-visual-diff(45) |
+| `full-renderer-sweep.yml` | full-renderer-sweep(60) |
+
+`podman` 라벨은 요구하지 않는다(호스트 직접 실행). timeout 은 로컬 실측 대비 2~3배 여유로,
+러너 hang 을 실패로 드러내는 상한이지 성능 목표가 아니다.
+
+## 제외 (무수정)
+
+- `deploy-pages.yml`·`npm-publish.yml`·`close-issues-on-devel-push.yml`.
+- `release-binary.yml` — matrix.runner(ubuntu-latest)가 macos-14/windows-latest 와 같은
+  매트릭스라 건드리면 크로스플랫폼 릴리스가 깨진다. 릴리스 게시 job 도 호스티드 유지.
+
+## 방침·제약 (작업지시자 결정)
+
+- **단일 러너**(멀티 러너는 후속) / **폴백 미구현**(needs 그래프 무변경).
+- 인지된 제약: 러너 1 인스턴스 = job 직렬. test-shard 8 은 순차 실행되어 호스티드 병렬보다
+  벽시계는 느릴 수 있다. timeout 으로 무한 대기(24h 큐잉)는 방지하나 폴백은 없어 러너 장애
+  시 CI 전면 중단 — 발생 시 대응. 멀티 러너·폴백은 실측 후 별도 이슈 후보.
+
+## 검증
+
+- actionlint 1.7.12: 4파일 오류·경고 **0**.
+- YAML 파싱(python yaml.safe_load) 4파일 정합, runs-on 배열·timeout-minutes 값 확인.
+- diff 정확성: 대상 4파일만 변경, release-binary/deploy/npm/close 무변경.
+- 실 검증: 이 전환 PR 의 CI 가 self-hosted 러너에서 실제로 도는 것으로 확인(PR 브랜치
+  워크플로가 즉시 적용됨).
+
+## 후속 후보
+
+- 멀티 러너(단일 LXC 다중 인스턴스 + `CARGO_BUILD_JOBS` 제한) — 8-shard 병렬성 회복.
+- self-hosted 우선·hosted 폴백(preflight API 감지) — 단일점 장애 대응.

--- a/mydocs/report/task_m100_3289_report.md
+++ b/mydocs/report/task_m100_3289_report.md
@@ -1,0 +1,78 @@
+# Task #3289 — self-hosted 러너 20 인스턴스화 + 병렬성 회복 (최종 보고서)
+
+`Closes #3289`. #3284(단일 러너 전환)의 후속으로, 러너 1개 직렬화 제약을 20 인스턴스로
+풀고 CI 벽시계를 호스티드 이하로 회복했다.
+
+## 구성 결과
+
+- `runner-lxc-01`~`20` (app@192.168.2.13, LXC 70코어 확장분) 등록·systemd 서비스화, 전부 online.
+- 기존 단일 `runner-lxc`는 GitHub 등록 해제·서비스 제거 완료 — 플릿은 01~20 만 남는다.
+- 러너 인스턴스별 디렉터리(`~/actions-runner-NN`)는 분리, **홈(`/home/app`)은 공유**:
+  `~/.cargo`·`~/.rustup`·nvm node 는 호스트에 1벌만 존재한다.
+
+## 시간 실측 (PR #3286 브랜치, 클린 전주 기준)
+
+| 단계 | 호스티드(devel 실측) | 1차 (22m38s) | 최종 (9m55s) |
+|---|---|---|---|
+| Lint | 1m34s | 3m21s | 2m25s |
+| Build test archive | 7m47s | 10m56s | **4m38s** |
+| 8-shard 단계 | 2m38s | 7m41s (다운로드 ~6m) | **1m58s** (캐시 8/8 hit) |
+| **전체** | 12m22s~13m51s | 22m38s | **9m55s** |
+
+- 8-shard 는 8개 러너에 1:1 동시 배정(동일 초 시작) — #3284 의 직렬화 제약 해소 실측.
+- run 30144809772: CI·Render Diff·CodeQL 전부 success.
+
+## 결함 4종 — 전부 "공유 홈 + 러너별 경로" 구조에서 나온 것
+
+1. **`.path` 2줄 → node 미발견**: 러너는 `.path` 를 PATH 문자열 하나로 읽는다. 2줄이면
+   첫 콜론 토큰이 `"...bin\n/usr/local/sbin"` 으로 깨져 **첫 줄에만 있는 항목만** 죽는다
+   (시스템 경로는 뒤 토큰으로 생존 → git 은 되고 node 만 안 되는 증상). 한 줄(콜론 결합)로
+   수정. **`.path` 는 반드시 한 줄**.
+2. **cargo-nextest 동시 설치 레이스**: 8-shard 가 동시에 taiki-e/install-action 으로 공유
+   `~/.cargo/bin` 에 설치하다 mv 충돌. → 설치 스텝을 `runner.environment == 'github-hosted'`
+   로 게이트, self-hosted 는 호스트 상주 설치본 사용.
+3. **rustup 재설치 레이스**: `.path` 에 `~/.cargo/bin` 이 없어 rust-toolchain 액션의
+   `command -v rustup` 이 매번 실패 → **매 잡마다 rustup 인스톨러 재실행**. 단일 러너에선
+   무해했으나 동시 8잡이 공유 rustup 바이너리를 교체하다 127. → `.path` 에
+   `/home/app/.cargo/bin` 추가로 인스톨러 경로 자체 제거.
+4. **`env!("CARGO_BIN_EXE_rhwp")` 빌더 경로 고착**: 컴파일타임 절대경로가 아카이브 빌더
+   러너의 `_work` 를 가리켜, 다른 러너의 shard 에서 NotFound. 호스티드가 green 이었던 건
+   전 VM 경로 동일이라는 우연. 1차 run 의 green 도 빌더 러너 `_work` 가 같은 호스트에
+   남아 있던 시한부 운(다음 checkout 의 `git clean -ffdx` 가 지우면 레이스). →
+   **런타임 `CARGO_BIN_EXE_rhwp`(nextest 가 shard 로컬 추출 경로로 재매핑) 우선 + 컴파일타임
+   폴백** 헬퍼 `rhwp_bin()` 으로 12파일 25곳 교체. 로컬 프로브로 런타임 주입 검증,
+   release-test 4003/4003 통과.
+
+## 성능 최적화 2종
+
+- **아카이브 호스트 캐시 공유**: 1GB 아카이브를 8-shard 가 한 호스트 회선으로 동시
+  다운로드하며 ~6분 대기하던 것을, build 잡이 `$HOME/artifact-cache/$RUN_ID/` 에 원자적
+  (tmp+mv) 복사 → shard 는 hardlink 우선·artifact 다운로드 폴백. 24h 지난 캐시는 build
+  잡이 정리. 업로드 아티팩트는 폴백·provenance 로 유지.
+- **critical path 만 `CARGO_BUILD_JOBS` 상향**: 러너 `.env` 는 3(20러너 동시 폭주 대비
+  보수값) 유지, lint·native-skia·build-test-archive 잡만 워크플로 `env:` 로 12 오버라이드.
+  70코어에 3잡×3코어=9코어만 쓰던 낭비 해소 (archive 빌드 9m11s→3m27s).
+
+## 멀티러너 거버넌스 (운영 규칙)
+
+- **공유 홈 원칙**: 잡 단위 툴 설치 액션 금지(레이스). 툴은 호스트에 1회 설치가 정본.
+  현재 상주: rustup/cargo(1.93.1), cargo-nextest 0.9.140, node v24.18.0(nvm).
+- **Rust 툴체인 버전 범프 절차**: CI 의 toolchain 값을 올리기 전에 호스트에서
+  `rustup toolchain install <ver>` 선행 — 동시 잡의 자동 설치 레이스 방지.
+- **러너 설정 파일**: `.path` 는 한 줄 콜론 결합(nvm bin + 시스템 + `/home/app/.cargo/bin`),
+  `.env` 는 `LANG` + `CARGO_BUILD_JOBS=3`. 변경 후 `systemctl restart
+  actions.runner.edwardkim-rhwp.runner-lxc-NN.service` 필요(20개 일괄).
+- **CLI 테스트 규약**: 새 CLI 통합 테스트는 `env!("CARGO_BIN_EXE_rhwp")` 직접 사용 금지,
+  각 파일의 `rhwp_bin()` 패턴(런타임 env 우선)을 따른다.
+- **무해 경고**: 취소된 잡이 `_work` 를 어중간하게 남기면 다음 checkout 이
+  "Unable to clean → repository will be recreated" 로 자가 복구한다(재클론 ~30s). 조치 불요.
+- **네트워크**: 20 러너가 회선 1개 공유 — 대용량 아티팩트를 다수 잡이 동시 소비하는 설계는
+  호스트 캐시 공유를 먼저 검토한다.
+
+## 후속 후보
+
+- **CodeQL·Render Diff 호스티드 재배치**(CI만 self-hosted 유지) — 호스트 동시 부하 분산
+  목적. 두 워크플로 모두 `runner.environment` 분기로 이식성 확보 상태라 `runs-on` 만
+  되돌리면 된다. 작업지시자 결정: 후속 이슈로 분리(2026-07-25).
+- self-hosted 우선·hosted 폴백(러너 플릿 전면 장애 대응) — #3284 보고서에서 이월.
+- `_work`·`artifact-cache` 디스크 누적 관측(20 인스턴스 × target/). 현재 여유 185GB.

--- a/mydocs/working/task_m100_3284_stage1.md
+++ b/mydocs/working/task_m100_3284_stage1.md
@@ -1,0 +1,62 @@
+# Task #3284 Stage 1 — CI 검증 워크플로 self-hosted 전환 (수행계획서)
+
+## 배경
+
+GitHub 호스티드 큐 적체로 CI 병목. self-hosted 러너 `runner-lxc`(192.168.2.13,
+56코어/100GB, 라벨 `self-hosted, Linux, X64, podman`) 구성·검증 완료(clean 빌드 1m28s).
+"오늘은 CI 쪽 모두를 외부 러너로 전환" 지시에 따라, **검증 워크플로 전체**를 옮긴다.
+
+## 대상 확정 (push/pull_request 검증 워크플로)
+
+| 워크플로 | job 수 | runs-on 위치(행) |
+|---|---|---|
+| `ci.yml` | 8 | 56, 413, 512, 588, 621, 693, 791, 908 |
+| `codeql.yml` | 2 | 48, 250 |
+| `render-diff.yml` | 2 | 64, 302 |
+| `full-renderer-sweep.yml` | 1 | 21 |
+
+→ 총 **13 job**, 전부 `runs-on: ubuntu-latest` → `runs-on: [self-hosted, Linux, X64]`.
+
+## 제외 (배포/퍼블리시 — 호스티드 유지)
+
+- `deploy-pages.yml`(2) — GitHub Pages 배포
+- `npm-publish.yml`(4) — 레지스트리 퍼블리시
+- `release-binary.yml` — Linux 1 + **macos-14×2 + windows-latest×1 매트릭스**(크로스 플랫폼,
+  self-hosted 불가)
+- `close-issues-on-devel-push.yml`(1) — 경량 API job(전환 이득 없음)
+
+제외 근거: 배포·릴리스는 시크릿·플랫폼 매트릭스가 걸려 있어 단일 Linux self-hosted로
+못 옮기거나 옮기면 안 된다. 검증(CI)만 전환해도 병목의 대부분을 해소한다.
+
+## 전환 방식
+
+1. 13개 `runs-on: ubuntu-latest` → `runs-on: [self-hosted, Linux, X64]` 치환.
+   - 라벨 배열 매칭 — 셋 모두 만족하는 러너에 배정. `podman` 라벨은 요구하지 않는다
+     (컨테이너 실행이 아니라 호스트 직접 실행이므로).
+2. **안정성 가드**: 러너가 단일 대수라 다운 시 job 이 무한 대기한다. 각 job 에
+   `timeout-minutes` 를 명시(현재 전무) — 빌드/테스트 job 은 30~45, 경량 job 은 15.
+   러너 장애 시 무한 대기 대신 타임아웃 실패로 드러나게 한다.
+3. 도구 설치 스텝 무수정 — dtolnay/rust-toolchain(rustup 자체 설치)·setup-node·
+   `sudo apt-get`(NOPASSWD 준비됨) 모두 러너에서 동작 실증됨.
+
+## 리스크 및 대응
+
+- **단일 러너 장애 → 전 CI 정지**: 검증 워크플로 전부를 한 러너에 몰면 그 러너가 죽을 때
+  PR 검증이 전면 중단된다. timeout-minutes 로 무한 대기는 막지만, 근본 대응은 러너 증설
+  또는 "self-hosted 우선, 실패 시 호스티드 폴백" 구성이다. → **초기엔 timeout 가드만 두고,
+  1주 관측 후 폴백/증설을 별도 이슈로 판단**(오늘 범위는 전환까지).
+- **동시성**: 13 job 이 단일 러너에 몰리면 직렬화된다. 러너의 job 동시 실행 수
+  (runner 설정 `--runnergroup`/병렬)를 확인해야 하나, 56코어라 여러 job 병렬 수용 가능.
+  → 관측 대상, 오늘은 전환 후 실측.
+- **캐시**: Swatinem/rust-cache 는 self-hosted 에서 로컬 디스크에 남아 오히려 빠르다
+  (185G 여유). 부작용 없음.
+
+## 검증 (전환 후)
+
+- 워크플로 YAML lint(actionlint) + 파싱.
+- 전환 커밋을 PR 로 올려 **실제로 self-hosted 러너에서 도는지** + 시간 단축 확인.
+- 8-shard 병렬이 OOM 없이 도는지 실측(100GB 여유라 낙관).
+
+## 다음 단계
+
+승인 시 Stage 2(구현계획서) — 파일별 정확한 치환 목록 + timeout 값 확정 후 구현.

--- a/mydocs/working/task_m100_3284_stage2.md
+++ b/mydocs/working/task_m100_3284_stage2.md
@@ -65,3 +65,21 @@
 - 본문: 범위(13 job + timeout, 배포/릴리스 제외), 인지된 제약(단일 러너 직렬·폴백 없음 —
   발생 시 대응), 러너 사양 실증, 멀티 러너·폴백은 후속 이슈 후보로 명시.
 - assignee=edwardkim / milestone=v1.0.0.
+
+## 정정 (구현 후 — CI 실패 대응)
+
+첫 CI 실행에서 두 스텝이 self-hosted 러너의 제한된 sudo(apt 한정)로 실패했다. 조사
+(GitHub 공식 문서)로 양쪽 호환 패턴을 확정해 정정한다:
+
+1. **`install-wasm-pack` 액션** (`sudo mv → /usr/local/bin` 실패):
+   → `~/.cargo/bin` 에 sudo 없이 배치 + `$GITHUB_PATH` 추가. 호스티드·self-hosted 양쪽
+   동일 동작(sudo 의존 제거가 가장 견고 — 분기 불필요). **이 액션은 deploy-pages·
+   npm-publish(호스티드 유지 대상)도 쓰지만, sudo 제거는 그쪽에도 안전한 무해 개선.**
+
+2. **ci.yml 디스크 정리 3곳** (`sudo rm android/dotnet` — 호스티드 이미지 전용):
+   → `if: runner.environment == 'github-hosted'` 로 감싸 self-hosted 에서 skip.
+   호스티드 동작 100% 보존(되돌려도 회귀 없음). `runner.environment` 는 공식 컨텍스트
+   (값 github-hosted/self-hosted), 러너 에이전트가 노출.
+
+원칙: **sudo/시스템경로 의존은 제거(설치 스텝), 호스티드 이미지 구조 전용 스텝은
+조건 분기로 skip(작업지시자 권고).** 두 기법의 역할 분리가 portable 패턴.

--- a/mydocs/working/task_m100_3284_stage2.md
+++ b/mydocs/working/task_m100_3284_stage2.md
@@ -1,0 +1,67 @@
+# Task #3284 Stage 2 — 구현계획서 (갱신)
+
+## 방침 확정 (작업지시자 결정 반영)
+
+- **단일 러너로 구성** — 멀티 러너(안 1/2)는 후속으로 남긴다.
+- **fallback 미구현** — preflight 감지·runner-fallback-action 도입 안 함. needs 그래프
+  무변경.
+- **timeout-minutes 는 넣는다** — 단일 러너 다운 시 24시간 큐잉을 짧은 타임아웃으로 대체.
+- 이번 구현 = **runs-on 13곳 전환 + 대상 job 에 timeout-minutes 명시**.
+
+## 인지된 제약 (구현엔 반영 안 하되 기록)
+
+- 러너 인스턴스 1개 = job 직렬. test-shard 8 은 순차 실행되어 호스티드 병렬보다 벽시계는
+  느릴 수 있다. 이번엔 감수하고, 실측 후 멀티 러너를 별도 이슈로 판단.
+- 단일 러너 장애 시 CI 전면 중단 — timeout 으로 무한 대기만 방지, 폴백은 없음. 발생 시 대응.
+
+## 치환 1 — runs-on (13 job)
+
+전부 `runs-on: ubuntu-latest` → `runs-on: [self-hosted, Linux, X64]`.
+
+| 파일 | job |
+|---|---|
+| `ci.yml` | preflight, lint, test-shard, build-and-test, native-skia-tests, frontend-package-gates, build-test-archive, wasm-build (8개, 파일 내 전역) |
+| `codeql.yml` | preflight, analyze (2) |
+| `render-diff.yml` | preflight, canvas-visual-diff (2) |
+| `full-renderer-sweep.yml` | full-renderer-sweep (1) |
+
+## 치환 2 — timeout-minutes (job 성격별)
+
+각 job 의 `runs-on` 바로 아래 줄에 추가. 값은 job 성격 + 단일 러너 직렬 여유를 감안:
+
+| job | timeout | 근거 |
+|---|---|---|
+| preflight (ci/codeql/render-diff) | 10 | 경량 감지 job(API·diff 판정) |
+| lint | 20 | fmt+clippy+wasm check |
+| frontend-package-gates | 20 | tsc + npm test |
+| build-test-archive | 30 | 빌드 + 아티팩트 |
+| native-skia-tests | 30 | skia 빌드+테스트 |
+| test-shard | 30 | shard 1개(직렬이라 넉넉히) |
+| build-and-test | 45 | 전체 빌드+테스트 |
+| wasm-build | 30 | wasm 빌드 |
+| codeql analyze | 45 | 정적분석 무거움 |
+| render-diff canvas-visual-diff | 45 | 렌더 diff |
+| full-renderer-sweep | 60 | 전수 sweep |
+
+(값은 로컬 실측 대비 2~3배 여유. 러너 hang 을 실패로 드러내는 상한이지 성능 목표 아님.)
+
+## 제외 (무수정)
+
+- `deploy-pages.yml` / `npm-publish.yml` / `close-issues-on-devel-push.yml`.
+- `release-binary.yml` — matrix.runner(ubuntu-latest)는 macos-14/windows 와 같은 매트릭스,
+  139행 릴리스 게시 job 도 호스티드 유지. **건드리지 않는다.**
+
+## 검증
+
+1. **actionlint** — 전 워크플로 문법·스키마(runs-on 배열·timeout-minutes 정합).
+2. **YAML 파싱** — python yaml.safe_load 로 4개 파일 로드 가능.
+3. **diff 정확성** — 대상 4파일만 변경, release-binary/deploy/npm/close 무변경 확인.
+4. **실 검증** — 이 전환 PR 의 CI 가 self-hosted 러너에서 실제로 도는 것으로 확인
+   (PR 브랜치 워크플로가 즉시 적용됨).
+
+## PR
+
+- 브랜치 `task/3284-ci-self-hosted`, `Closes #3284`.
+- 본문: 범위(13 job + timeout, 배포/릴리스 제외), 인지된 제약(단일 러너 직렬·폴백 없음 —
+  발생 시 대응), 러너 사양 실증, 멀티 러너·폴백은 후속 이슈 후보로 명시.
+- assignee=edwardkim / milestone=v1.0.0.

--- a/mydocs/working/task_m100_3289_stage1.md
+++ b/mydocs/working/task_m100_3289_stage1.md
@@ -1,0 +1,62 @@
+# Task #3289 Stage 1 — self-hosted 러너 20 인스턴스화 (수행계획서)
+
+## 배경
+
+#3284(#3286) 단일 러너 전환이 직렬 처리로 호스티드보다 느려짐(실측 ~13분 vs 24분+).
+GitHub Free 동시 상한 20 job 에 맞춰 **20 러너**로 병렬성 회복. LXC 단일 노드에 러너
+인스턴스 20개 등록, 공통 라벨 유지(워크플로 runs-on 무변경).
+
+## 서비스 방식 확정 (작업지시자 결정)
+
+**방식 A — systemd system 서비스**(현 러너 1개와 동일 방식). svc.sh install/start 로
+20개 서비스 등록. 부팅 자동 시작, 일관성.
+
+## 선행 조건 (작업지시자 직접 — 제가 SSH 로 불가)
+
+1. **LXC 코어 56 → 70 확장** (Proxmox). 호스트 72 중 시스템 2 남김. 진행 예정.
+2. **svc.sh install 용 sudo 확대**. 방식 A 는 각 러너의 systemd system 서비스
+   등록에 sudo(systemctl, cp to /etc/systemd/system)가 필요한데, 현재 app 계정
+   NOPASSWD 는 apt 한정이다. 두 안 중 택1:
+   - (a) app 계정에 svc.sh install 이 쓰는 명령(systemctl, /etc/systemd/system 쓰기)
+     NOPASSWD 확대 → 제가 20개 등록·서비스화 자동화.
+   - (b) 러너 등록(config.sh)은 sudo 불필요하니 제가 20개 등록까지 하고,
+     **svc install/start(sudo 부분)만 작업지시자가 스크립트 실행**.
+   → 계획서 승인 시 (a)/(b) 확정.
+
+## 구성 절차 (선행 완료 후)
+
+1. **디렉터리 배치**: `~/actions-runner-01` ~ `~/actions-runner-20` (또는 현 러너를
+   01 로 재편). 각 디렉터리에 러너 바이너리 복사(또는 tar 재전개).
+2. **등록**: 각 인스턴스 `./config.sh --url https://github.com/edwardkim/rhwp
+   --token <REG_TOKEN> --name runner-lxc-NN --labels self-hosted,Linux,X64
+   --unattended --replace`. 등록 토큰은 `gh api -X POST
+   .../actions/runners/registration-token` 로 발급(만료 짧음 — 인스턴스별 재발급).
+3. **CARGO_BUILD_JOBS 주입**: 각 러너 `.env` 에 `CARGO_BUILD_JOBS=4` (코어 경쟁 억제,
+   20 × 4 = 80 요청 vs 70코어 — 약간 오버서브스크립션이나 job 이 늘 다 병렬은 아님).
+4. **서비스화**: 각 인스턴스 `sudo ./svc.sh install && sudo ./svc.sh start`
+   (방식 A). 서비스명은 인스턴스별 고유(runner-lxc-NN).
+5. **공유 자원**: 툴체인(rustup·node·chromium libs·apt)은 LXC 공유라 재설치 불필요.
+   단, 20 러너가 같은 `~/.cargo`/`~/.rustup` 을 공유하면 빌드 캐시 경합 가능 →
+   러너별 `CARGO_TARGET_DIR`/작업 디렉터리 분리는 actions-runner 가 `_work` 를
+   인스턴스별로 갖도록 이미 격리됨(확인 필요).
+
+## 리스크
+
+- **오버서브스크립션**: 20러너 × CARGO_BUILD_JOBS=4 = 80 > 70코어. 모든 러너가 동시에
+  빌드 피크를 치면 경쟁. 그러나 실제로는 job 이 빌드/테스트/대기 단계가 섞여 평균
+  부하는 낮다. `CARGO_BUILD_JOBS=3`(60) 으로 보수적 시작도 가능 → 관측 후 조정.
+- **디스크**: 20 러너 각 `_work` + target 캐시. 185GB 여유이나 20 × 수 GB 누적 감시.
+- **~/.cargo 공유 레지스트리 락**: 여러 cargo 가 동시에 레지스트리 갱신 시 락 대기.
+  보통 문제없으나 관측 대상.
+
+## 검증
+
+- 20 러너 online 확인(`gh api .../actions/runners`).
+- 한 PR CI 의 8-shard + 독립 job 이 **동시 실행**(여러 러너 busy) 되는지 실측.
+- 전체 CI 시간이 호스티드(~13분) 이하로 회복되는지 측정.
+- load average(70코어 기준), 러너별 RSS, 디스크 관측.
+
+## 다음 단계
+
+승인 + 선행 2조건(LXC 70, sudo 방식 a/b) 확정 후 Stage 2(구현계획서) — 등록 자동화
+스크립트, CARGO_BUILD_JOBS 값 확정, 서비스 템플릿.

--- a/mydocs/working/task_m100_3289_stage2.md
+++ b/mydocs/working/task_m100_3289_stage2.md
@@ -1,0 +1,74 @@
+# Task #3289 Stage 2 — 구현계획서
+
+방식 A + sudo (a) 확정. 선행: LXC 70코어 확장 + NOPASSWD 확대(작업지시자).
+
+## 선행: NOPASSWD 확대 목록 (작업지시자 — LXC 작업 시 함께)
+
+svc.sh 는 내부에서 `systemctl`(daemon-reload/enable/start/stop/status) + `/etc/systemd/
+system/<svc>` 쓰기를 한다. `sudo ./svc.sh install|start` 로 실행하므로, 최소 권한은:
+
+```
+# /etc/sudoers.d/app-runner
+app ALL=(ALL) NOPASSWD: /usr/bin/systemctl, /home/app/actions-runner-*/svc.sh
+```
+
+(기존 apt NOPASSWD 는 유지. systemctl 전역 허용이 넓다면, svc.sh 래퍼만 허용하는
+방식으로 좁힐 수 있으나 svc.sh 가 여러 디렉터리에 복제되므로 와일드카드 필요.)
+
+## 구현 절차 (제가 SSH 자동화)
+
+### 1. 깨끗한 러너 바이너리 확보 (6.1GB 복제 대신)
+현 `~/actions-runner` 는 `_work` 빌드 캐시 포함 6.1GB. 복제하면 낭비 + 오염.
+→ GitHub 러너 릴리스 tar 를 1회 받아 `~/runner-pkg/` 에 전개, 이걸 20개로 배포.
+   (현 러너 버전과 동일 버전 tar. 버전은 `~/actions-runner/bin/Runner.Listener
+   --version` 으로 확인.)
+
+### 2. 20 인스턴스 배치
+- 현 러너(`runner-lxc`)는 **그대로 두거나 runner-lxc-01 로 재편**. 재편 시 기존
+  서비스 stop/uninstall 후 재등록(라벨·이름 정합). → **신규 20개를 01~20 으로 새로
+  만들고 기존 단일 러너는 제거**하는 편이 깔끔(이름 충돌 회피).
+- `~/actions-runner-01` … `~/actions-runner-20`, 각 디렉터리에 pkg 전개.
+
+### 3. 등록 (per-instance token)
+```bash
+for i in $(seq -w 1 20); do
+  TOKEN=$(gh api -X POST repos/edwardkim/rhwp/actions/runners/registration-token -q .token)  # 인스턴스별 재발급
+  cd ~/actions-runner-$i
+  ./config.sh --url https://github.com/edwardkim/rhwp --token "$TOKEN" \
+    --name runner-lxc-$i --labels self-hosted,Linux,X64 --unattended --replace
+  # CARGO_BUILD_JOBS 주입
+  echo "CARGO_BUILD_JOBS=4" >> .env
+  # node PATH (기존 러너의 .path 와 동일하게)
+  cp ~/actions-runner/.path .path 2>/dev/null || true
+  sudo ./svc.sh install app && sudo ./svc.sh start
+done
+```
+(토큰은 발급 API 를 SSH 세션이 아니라 로컬에서 호출해 넘기거나, 러너에 gh 설치.
+ → 로컬에서 토큰 20개 발급해 배열로 전달하는 방식이 안전.)
+
+### 4. CARGO_BUILD_JOBS
+- 초기값 **3** 으로 보수적 시작(20×3=60 < 70코어). 관측 후 4 로 상향 판단.
+  (오버서브스크립션 리스크 최소화 — 계획서 리스크 항목 반영.)
+
+### 5. 기존 단일 러너 처리
+- `runner-lxc`(현재 #3286 실행 중) — **진행 중 job 완료 후** stop → svc uninstall →
+  config remove(GitHub 등록 해제) → 20개 신규로 대체. (실행 중 제거 금지.)
+
+## 디스크 관리
+
+- 러너 pkg ~200MB × 20 + 각 `_work` 빌드 캐시. 초기엔 여유(185GB)이나 20 러너가
+  각자 target/ 을 쌓으면 누적. → `~/.cargo` 는 공유(레지스트리 1벌), `_work` 만
+  인스턴스별. 주기적 `_work` 정리 또는 `rust-cache` 로 관리. 관측 대상.
+
+## 검증
+
+1. 20 러너 online: `gh api repos/edwardkim/rhwp/actions/runners --jq '.total_count'` = 20.
+2. 한 PR CI 재트리거 → 8-shard + 독립 job 이 **여러 러너에 동시 배정**(busy 다수) 실측.
+3. 전체 CI 시간 호스티드(~13분) 이하 회복 측정.
+4. load average(70코어), 러너별 RSS, 디스크 관측. 코어 경쟁 시 CARGO_BUILD_JOBS 하향.
+
+## PR
+
+- 이 작업은 **러너 인프라 구성(SSH)** 이라 저장소 코드 변경이 없다. #3286(전환 워크플로)
+  이 이미 self-hosted 를 참조하므로, 20 러너 구성 후 #3286 재검증 → green 이면 merge.
+- working/report 문서만 저장소에 남긴다(인프라 작업 기록). `Closes #3289`.

--- a/tests/cli_exit_codes.rs
+++ b/tests/cli_exit_codes.rs
@@ -39,7 +39,7 @@ fn unique_temp_path(label: &str) -> PathBuf {
 }
 
 fn run(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .args(args)
         .output()
         .expect("rhwp 실행 실패")
@@ -238,4 +238,10 @@ fn export_png_without_native_skia_reports_usage_error() {
         "왜 못 쓰는지 알려야 한다\n{}",
         describe(&args, &output)
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/cli_exit_codes_diagnostic_commands.rs
+++ b/tests/cli_exit_codes_diagnostic_commands.rs
@@ -22,7 +22,7 @@ fn hwp5_sample_path() -> PathBuf {
 }
 
 fn run(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .args(args)
         .output()
         .expect("rhwp 실행 실패")
@@ -120,4 +120,10 @@ fn successful_diagnostic_commands_return_zero() {
         "{}",
         describe(&["dump-records", hwp5_sample], &output)
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/cli_exit_codes_dump_diag.rs
+++ b/tests/cli_exit_codes_dump_diag.rs
@@ -27,7 +27,7 @@ fn unique_temp_path(label: &str) -> PathBuf {
 }
 
 fn run(args: &[&str]) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .args(args)
         .output()
         .expect("rhwp 실행 실패")
@@ -88,4 +88,10 @@ fn successful_run_returns_zero() {
 
     assert_code(&["dump", sample], 0);
     assert_code(&["diag", sample], 0);
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/doclang_export.rs
+++ b/tests/doclang_export.rs
@@ -32,7 +32,7 @@ fn unique_temp_path(label: &str) -> PathBuf {
 }
 
 fn run_export_doclang(input: &Path, output: &Path) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .arg("export-doclang")
         .arg(input)
         .arg("-o")
@@ -170,4 +170,10 @@ fn export_doclang_never_overwrites_a_hard_link_to_its_input() {
         std::fs::read(&input).expect("read unchanged input"),
         original
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/dump_pages_cli.rs
+++ b/tests/dump_pages_cli.rs
@@ -3,7 +3,7 @@
 use std::process::Command;
 
 fn run(args: &[&str]) -> std::process::Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .args(args)
         .output()
         .expect("rhwp 실행 실패")
@@ -51,4 +51,10 @@ fn missing_page_value_names_the_option_used() {
         String::from_utf8_lossy(&output.stderr).contains("-p 뒤에 페이지 번호가 필요합니다."),
         "실제 사용한 옵션 이름을 오류에 보여야 한다"
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/hml_cli.rs
+++ b/tests/hml_cli.rs
@@ -19,7 +19,7 @@ fn unique_temp_dir(label: &str) -> std::path::PathBuf {
 }
 
 fn run_export_hml(input: &Path, output: &Path, output_flag: &str) -> Output {
-    Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    Command::new(rhwp_bin())
         .arg("export-hml")
         .arg(input)
         .arg(output_flag)
@@ -75,7 +75,7 @@ fn document_core_preserves_real_hml_page_breaks() {
 
 #[test]
 fn info_reports_hml_contract_fields() {
-    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let output = Command::new(rhwp_bin())
         .arg("info")
         .arg(fixture_path())
         .output()
@@ -132,7 +132,7 @@ fn info_reports_hml_contract_fields() {
 
 #[test]
 fn help_lists_hml_for_supported_document_commands() {
-    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let output = Command::new(rhwp_bin())
         .arg("--help")
         .output()
         .expect("run rhwp --help");
@@ -188,7 +188,7 @@ fn export_hml_flags_preserve_edit_reparse_and_raw_fragment() {
 
 #[test]
 fn export_hml_refusals_are_nonzero_structured_and_write_nothing() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let non_hml_output = unique_temp_dir("cli_non_hml").with_extension("hml");
     let non_hml = Command::new(exe)
         .arg("export-hml")
@@ -268,7 +268,7 @@ fn export_hml_never_overwrites_a_hard_link_to_its_input() {
 fn export_hml_rejects_an_option_token_as_the_output_value() {
     let sandbox = unique_temp_dir("cli_output_option");
     std::fs::create_dir_all(&sandbox).expect("create isolated working directory");
-    let command = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let command = Command::new(rhwp_bin())
         .current_dir(&sandbox)
         .arg("export-hml")
         .arg(fixture_path())
@@ -330,10 +330,10 @@ fn export_hml_accepts_a_near_name_max_output_basename() {
 
 #[test]
 fn dump_svg_and_pdf_commands_accept_hml() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let fixture = fixture_path();
 
-    let dump = Command::new(exe)
+    let dump = Command::new(&exe)
         .arg("dump")
         .arg(&fixture)
         .output()
@@ -345,7 +345,7 @@ fn dump_svg_and_pdf_commands_accept_hml() {
     );
 
     let svg_dir = unique_temp_dir("svg");
-    let svg = Command::new(exe)
+    let svg = Command::new(&exe)
         .arg("export-svg")
         .arg(&fixture)
         .args(["--output", svg_dir.to_str().expect("UTF-8 temp path")])
@@ -360,7 +360,7 @@ fn dump_svg_and_pdf_commands_accept_hml() {
     assert!(svg_count > 0, "HML export-svg produced no SVG pages");
 
     let pdf_path = unique_temp_dir("pdf").with_extension("pdf");
-    let pdf = Command::new(exe)
+    let pdf = Command::new(&exe)
         .arg("export-pdf")
         .arg(&fixture)
         .args(["--output", pdf_path.to_str().expect("UTF-8 temp path")])
@@ -369,4 +369,10 @@ fn dump_svg_and_pdf_commands_accept_hml() {
     assert!(pdf.status.success(), "PDF command failed");
     let pdf_bytes = std::fs::read(&pdf_path).expect("PDF output");
     assert!(pdf_bytes.starts_with(b"%PDF-"), "invalid PDF output");
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/ir_diff_summary_mode.rs
+++ b/tests/ir_diff_summary_mode.rs
@@ -7,7 +7,7 @@ use std::process::Command;
 
 #[test]
 fn summary_mode_categorizes_diffs() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let output = Command::new(exe)
         .args([
             "ir-diff",
@@ -63,7 +63,7 @@ fn summary_mode_categorizes_diffs() {
 
 #[test]
 fn max_lines_truncates() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let output = Command::new(exe)
         .args([
             "ir-diff",
@@ -92,7 +92,7 @@ fn max_lines_truncates() {
 #[test]
 fn no_flags_preserves_full_output() {
     // 회귀 가드: --summary / --max-lines 없으면 기존 출력 형식 보존
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let output = Command::new(exe)
         .args(["ir-diff", "samples/hwpx/aift.hwpx", "samples/aift.hwp"])
         .output()
@@ -116,4 +116,10 @@ fn no_flags_preserves_full_output() {
         !stdout.contains("이하 생략"),
         "기본 모드에서는 truncation 출력이 없어야 함"
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/issue_1638_convert_verify_gate.rs
+++ b/tests/issue_1638_convert_verify_gate.rs
@@ -24,7 +24,7 @@ fn temp_output(name: &str, ext: &str) -> PathBuf {
 
 #[test]
 fn export_hwpx_verify_and_verify_pages_pass() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let out = temp_output("export", "hwpx");
 
     let output = Command::new(exe)
@@ -55,7 +55,7 @@ fn export_hwpx_verify_and_verify_pages_pass() {
 
 #[test]
 fn convert_verify_and_verify_pages_pass_for_hwp_source() {
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let out = temp_output("convert", "hwp");
 
     let output = Command::new(exe)
@@ -82,4 +82,10 @@ fn convert_verify_and_verify_pages_pass_for_hwp_source() {
     assert!(stdout.contains("검증 통과(--verify): IR 차이 없음"));
 
     let _ = fs::remove_file(out);
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/issue_1914.rs
+++ b/tests/issue_1914.rs
@@ -60,11 +60,11 @@ fn issue_1914_roundtrip_gates_classify_masqueraded_files_as_format_skip() {
     // HWP3 실체 → .hwp 확장자 (hwp5 게이트 범위 밖 — #1892 도구 축)
     let hwp3_as_hwp = repo_root.join("samples/issue1892_hwp3_drawing_group_roundtrip.hwp");
 
-    let exe = env!("CARGO_BIN_EXE_rhwp");
+    let exe = rhwp_bin();
     let out_dir = tmp.join("out");
 
     let run = |args: &[&str]| -> (String, bool) {
-        let output = Command::new(exe).args(args).output().expect("run rhwp");
+        let output = Command::new(&exe).args(args).output().expect("run rhwp");
         let text = format!(
             "{}{}",
             String::from_utf8_lossy(&output.stdout),
@@ -96,4 +96,10 @@ fn issue_1914_roundtrip_gates_classify_masqueraded_files_as_format_skip() {
         "hwp5-roundtrip HWP3 실체: FORMAT_SKIP+실체 안내여야 함 (종전 오도성 IR_DIFF, #1892): {text}"
     );
     assert!(ok, "FORMAT_SKIP 은 하드 실패가 아님 (exit 0): {text}");
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/issue_2225_missing_picture_placeholder.rs
+++ b/tests/issue_2225_missing_picture_placeholder.rs
@@ -71,7 +71,7 @@ fn issue_2225_export_png_defaults_to_print_equivalent_skia_profile() {
     let default_dir = output_root.join("default");
     let screen_dir = output_root.join("screen");
 
-    let default_output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let default_output = Command::new(rhwp_bin())
         .arg("export-png")
         .arg(&sample_path)
         .args(["--page", "0", "--output"])
@@ -85,7 +85,7 @@ fn issue_2225_export_png_defaults_to_print_equivalent_skia_profile() {
         String::from_utf8_lossy(&default_output.stderr)
     );
 
-    let screen_output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let screen_output = Command::new(rhwp_bin())
         .arg("export-png")
         .arg(&sample_path)
         .args(["--page", "0", "--output"])
@@ -136,4 +136,10 @@ fn issue_2225_export_png_defaults_to_print_equivalent_skia_profile() {
         screen_ink > 1_000,
         "explicit screen profile did not emit the missingPicture editor visual: {screen_ink}"
     );
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/render_p37_direct_pdf_export.rs
+++ b/tests/render_p37_direct_pdf_export.rs
@@ -87,7 +87,7 @@ fn document_core_direct_pdf_preserves_selection_errors() {
 #[test]
 fn export_pdf_cli_selects_direct_backend_explicitly() {
     let output_path = unique_pdf_path();
-    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let output = Command::new(rhwp_bin())
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "direct"])
@@ -111,7 +111,7 @@ fn export_pdf_cli_selects_direct_backend_explicitly() {
     assert_complete_pdf(&pdf);
 
     let explicit_print_path = unique_pdf_path();
-    let explicit_print = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let explicit_print = Command::new(rhwp_bin())
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "direct", "--profile", "print"])
@@ -129,7 +129,7 @@ fn export_pdf_cli_selects_direct_backend_explicitly() {
 #[test]
 fn export_pdf_cli_rejects_backend_specific_option_mismatches() {
     let direct_output_path = unique_pdf_path();
-    let direct_with_svg_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let direct_with_svg_option = Command::new(rhwp_bin())
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "direct", "--fallback-serif", "serif"])
@@ -143,7 +143,7 @@ fn export_pdf_cli_rejects_backend_specific_option_mismatches() {
     assert!(!direct_output_path.exists());
 
     let compatibility_output_path = unique_pdf_path();
-    let svg_with_direct_option = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let svg_with_direct_option = Command::new(rhwp_bin())
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "svg", "--raster-dpi", "96"])
@@ -155,4 +155,10 @@ fn export_pdf_cli_rejects_backend_specific_option_mismatches() {
     assert!(String::from_utf8_lossy(&svg_with_direct_option.stderr)
         .contains("direct PDF backend에서만"));
     assert!(!compatibility_output_path.exists());
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }

--- a/tests/render_p37_pdf_backend_cli.rs
+++ b/tests/render_p37_pdf_backend_cli.rs
@@ -19,7 +19,7 @@ fn unique_pdf_path(label: &str) -> PathBuf {
 }
 
 fn run_compatibility_export(output_path: &Path, explicit_backend: bool) -> std::process::Output {
-    let mut command = Command::new(env!("CARGO_BIN_EXE_rhwp"));
+    let mut command = Command::new(rhwp_bin());
     command.arg("export-pdf").arg(sample_path());
     if explicit_backend {
         command.args(["--backend", "svg"]);
@@ -49,7 +49,7 @@ fn explicit_svg_backend_preserves_default_pdf_bytes_and_stdout() {
 #[test]
 fn direct_backend_reports_missing_native_skia_feature() {
     let output_path = unique_pdf_path("missing-feature");
-    let output = Command::new(env!("CARGO_BIN_EXE_rhwp"))
+    let output = Command::new(rhwp_bin())
         .arg("export-pdf")
         .arg(sample_path())
         .args(["--backend", "direct", "--output"])
@@ -61,4 +61,10 @@ fn direct_backend_reports_missing_native_skia_feature() {
     assert!(String::from_utf8_lossy(&output.stderr)
         .contains("direct PDF backend requires a build with the native-skia feature"));
     assert!(!output_path.exists());
+}
+
+/// [#3289] 아카이브 실행 시 컴파일타임 경로는 빌드 러너 전용이므로,
+/// nextest가 런타임에 재매핑해 주입하는 CARGO_BIN_EXE_rhwp를 우선한다.
+fn rhwp_bin() -> String {
+    std::env::var("CARGO_BIN_EXE_rhwp").unwrap_or_else(|_| env!("CARGO_BIN_EXE_rhwp").to_string())
 }


### PR DESCRIPTION
GitHub 호스티드 큐 적체로 CI 병목. 사내 self-hosted 러너 `runner-lxc`(192.168.2.13, Proxmox LXC)를 구성·검증하고 **검증 워크플로 13 job** 을 전환한다.

## 러너 사양 (SSH 실측)

Xeon E5-2697 v4 **56코어** / **100 GiB RAM** / 185 GB 여유 / Ubuntu 24.10. 빌드 툴체인·Native Skia 의존성 설치, app 계정 apt NOPASSWD sudo. **rhwp clean 빌드 1m28s** 성공(로컬 WSL2 2m12s보다 빠름), rustc 1.93.1 정합, 외부망 도달. 라벨 `self-hosted, Linux, X64, podman`.

## 변경 (4파일, runs-on + timeout-minutes)

`runs-on: ubuntu-latest` → `[self-hosted, Linux, X64]`:

| 파일 | job (timeout분) |
|---|---|
| ci.yml | preflight(10)·lint(20)·frontend-package-gates(20)·build-test-archive(30)·native-skia-tests(30)·test-shard(30)·build-and-test(45)·wasm-build(30) |
| codeql.yml | preflight(10)·analyze(45) |
| render-diff.yml | preflight(10)·canvas-visual-diff(45) |
| full-renderer-sweep.yml | full-renderer-sweep(60) |

`podman` 라벨 미요구(호스트 직접 실행). timeout 은 러너 hang 을 실패로 드러내는 상한.

## 제외 (무수정)

deploy-pages·npm-publish·close-issues, 그리고 **release-binary**(matrix.runner 가 macos-14/windows 와 같은 매트릭스 — 크로스플랫폼 릴리스 보호).

## 방침·제약 (작업지시자 결정)

- **단일 러너 / 폴백 미구현**(needs 그래프 무변경).
- 인지된 제약: 러너 1 인스턴스 = job 직렬 → test-shard 8 순차 실행, 호스티드 병렬보다 벽시계는 느릴 수 있음. timeout 으로 24h 큐잉은 방지하나 폴백 없어 러너 장애 시 CI 중단 — 발생 시 대응. 멀티 러너·폴백은 실측 후 별도 이슈 후보.

## 검증

- actionlint 1.7.12 오류·경고 0, YAML 파싱 정합, diff 대상 4파일 한정(제외 대상 무변경).
- **실 검증: 이 PR 의 CI 가 곧 self-hosted 러너에서 도는지로 확인된다**(PR 브랜치 워크플로 즉시 적용).

Closes #3284.
